### PR TITLE
lsc: replace 'interface{}' with 'any' in embedder and tool components and fix goimports

### DIFF
--- a/core/knowledge/embedder/embedder.go
+++ b/core/knowledge/embedder/embedder.go
@@ -49,7 +49,7 @@ type Embedder interface {
 	// - A slice of float64 values representing the embedding
 	// - Usage information as a map (may be nil if not supported)
 	// - An error for system-level failures
-	GetEmbeddingWithUsage(ctx context.Context, text string) ([]float64, map[string]interface{}, error)
+	GetEmbeddingWithUsage(ctx context.Context, text string) ([]float64, map[string]any, error)
 
 	// GetDimensions returns the dimensionality of the embeddings produced by this embedder.
 	// Returns 0 if dimensions are not known or configurable.

--- a/core/knowledge/embedder/openai/openai.go
+++ b/core/knowledge/embedder/openai/openai.go
@@ -200,7 +200,7 @@ func (e *Embedder) GetEmbedding(ctx context.Context, text string) ([]float64, er
 
 // GetEmbeddingWithUsage implements the embedder.Embedder interface.
 // It generates an embedding vector for the given text and returns usage information.
-func (e *Embedder) GetEmbeddingWithUsage(ctx context.Context, text string) ([]float64, map[string]interface{}, error) {
+func (e *Embedder) GetEmbeddingWithUsage(ctx context.Context, text string) ([]float64, map[string]any, error) {
 	if text == "" {
 		return nil, nil, fmt.Errorf("text cannot be empty")
 	}
@@ -245,7 +245,7 @@ func (e *Embedder) GetEmbeddingWithUsage(ctx context.Context, text string) ([]fl
 	}
 
 	// Extract usage information.
-	usage := make(map[string]interface{})
+	usage := make(map[string]any)
 	if response.Usage.PromptTokens > 0 || response.Usage.TotalTokens > 0 {
 		usage["prompt_tokens"] = response.Usage.PromptTokens
 		usage["total_tokens"] = response.Usage.TotalTokens

--- a/core/tool/callbacks_test.go
+++ b/core/tool/callbacks_test.go
@@ -378,7 +378,7 @@ func TestToolCallbacks_Integration(t *testing.T) {
 
 		// Modify args for certain tools.
 		if toolName == "modify-args" {
-			var args map[string]interface{}
+			var args map[string]any
 			if err := json.Unmarshal(jsonArgs, &args); err != nil {
 				return nil, err
 			}

--- a/core/tool/mcp/tool.go
+++ b/core/tool/mcp/tool.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"trpc.group/trpc-go/trpc-agent-go/core/tool"
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	mcp "trpc.group/trpc-go/trpc-mcp-go"
@@ -36,20 +37,20 @@ func (t *mcpTool) Call(ctx context.Context, jsonArgs []byte) (any, error) {
 	log.Debug("Calling MCP tool", "name", t.mcpToolRef.Name)
 
 	// Parse raw arguments.
-	var rawArguments map[string]interface{}
+	var rawArguments map[string]any
 	if len(jsonArgs) > 0 {
 		if err := json.Unmarshal(jsonArgs, &rawArguments); err != nil {
 			return nil, fmt.Errorf("failed to parse tool arguments: %w", err)
 		}
 	} else {
-		rawArguments = make(map[string]interface{})
+		rawArguments = make(map[string]any)
 	}
 
 	return t.callOnce(ctx, rawArguments)
 }
 
 // callOnce performs a single call to the MCP tool.
-func (t *mcpTool) callOnce(ctx context.Context, arguments map[string]interface{}) (any, error) {
+func (t *mcpTool) callOnce(ctx context.Context, arguments map[string]any) (any, error) {
 	content, err := t.sessionManager.callTool(ctx, t.mcpToolRef.Name, arguments)
 	if err != nil {
 		return nil, err

--- a/core/tool/mcp/toolset.go
+++ b/core/tool/mcp/toolset.go
@@ -290,7 +290,7 @@ func (m *mcpSessionManager) listTools(ctx context.Context) ([]mcp.Tool, error) {
 }
 
 // callTool executes a tool call on the MCP server.
-func (m *mcpSessionManager) callTool(ctx context.Context, name string, arguments map[string]interface{}) ([]mcp.Content, error) {
+func (m *mcpSessionManager) callTool(ctx context.Context, name string, arguments map[string]any) ([]mcp.Content, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 

--- a/core/tool/mcp/utils.go
+++ b/core/tool/mcp/utils.go
@@ -7,7 +7,7 @@ import (
 )
 
 // convertMCPSchemaToSchema converts MCP's JSON schema to our Schema format.
-func convertMCPSchemaToSchema(mcpSchema interface{}) *tool.Schema {
+func convertMCPSchemaToSchema(mcpSchema any) *tool.Schema {
 	schemaBytes, err := json.Marshal(mcpSchema)
 	if err != nil {
 		return &tool.Schema{
@@ -15,7 +15,7 @@ func convertMCPSchemaToSchema(mcpSchema interface{}) *tool.Schema {
 		}
 	}
 
-	var schemaMap map[string]interface{}
+	var schemaMap map[string]any
 	if err := json.Unmarshal(schemaBytes, &schemaMap); err != nil {
 		return &tool.Schema{
 			Type: "object",
@@ -29,10 +29,10 @@ func convertMCPSchemaToSchema(mcpSchema interface{}) *tool.Schema {
 	if descVal, ok := schemaMap["description"].(string); ok {
 		schema.Description = descVal
 	}
-	if propsVal, ok := schemaMap["properties"].(map[string]interface{}); ok {
+	if propsVal, ok := schemaMap["properties"].(map[string]any); ok {
 		schema.Properties = convertProperties(propsVal)
 	}
-	if reqVal, ok := schemaMap["required"].([]interface{}); ok {
+	if reqVal, ok := schemaMap["required"].([]any); ok {
 		required := make([]string, len(reqVal))
 		for i, req := range reqVal {
 			if reqStr, ok := req.(string); ok {
@@ -46,14 +46,14 @@ func convertMCPSchemaToSchema(mcpSchema interface{}) *tool.Schema {
 }
 
 // convertProperties converts property definitions from map[string]interface{} to map[string]*Schema.
-func convertProperties(props map[string]interface{}) map[string]*tool.Schema {
+func convertProperties(props map[string]any) map[string]*tool.Schema {
 	if props == nil {
 		return nil
 	}
 
 	result := make(map[string]*tool.Schema)
 	for name, prop := range props {
-		if propMap, ok := prop.(map[string]interface{}); ok {
+		if propMap, ok := prop.(map[string]any); ok {
 			propSchema := &tool.Schema{}
 			if typeVal, ok := propMap["type"].(string); ok {
 				propSchema.Type = typeVal

--- a/examples/mcp_tool/streamalbe_server/main.go
+++ b/examples/mcp_tool/streamalbe_server/main.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+
 	mcp "trpc.group/trpc-go/trpc-mcp-go"
 )
 

--- a/internal/tool/tool_test.go
+++ b/internal/tool/tool_test.go
@@ -11,7 +11,7 @@ import (
 func TestGenerateJSONSchema_PrimitiveTypes(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    interface{}
+		input    any
 		expected *tool.Schema
 	}{
 		{

--- a/log/log.go
+++ b/log/log.go
@@ -86,79 +86,79 @@ var encoderConfig = zapcore.EncoderConfig{
 // Logger is the underlying logging work for trpc-a2a-go.
 type Logger interface {
 	// Debug logs to DEBUG log. Arguments are handled in the manner of fmt.Print.
-	Debug(args ...interface{})
+	Debug(args ...any)
 	// Debugf logs to DEBUG log. Arguments are handled in the manner of fmt.Printf.
-	Debugf(format string, args ...interface{})
+	Debugf(format string, args ...any)
 	// Info logs to INFO log. Arguments are handled in the manner of fmt.Print.
-	Info(args ...interface{})
+	Info(args ...any)
 	// Infof logs to INFO log. Arguments are handled in the manner of fmt.Printf.
-	Infof(format string, args ...interface{})
+	Infof(format string, args ...any)
 	// Warn logs to WARNING log. Arguments are handled in the manner of fmt.Print.
-	Warn(args ...interface{})
+	Warn(args ...any)
 	// Warnf logs to WARNING log. Arguments are handled in the manner of fmt.Printf.
-	Warnf(format string, args ...interface{})
+	Warnf(format string, args ...any)
 	// Error logs to ERROR log. Arguments are handled in the manner of fmt.Print.
-	Error(args ...interface{})
+	Error(args ...any)
 	// Errorf logs to ERROR log. Arguments are handled in the manner of fmt.Printf.
-	Errorf(format string, args ...interface{})
+	Errorf(format string, args ...any)
 	// Fatal logs to ERROR log. Arguments are handled in the manner of fmt.Print.
-	Fatal(args ...interface{})
+	Fatal(args ...any)
 	// Fatalf logs to ERROR log. Arguments are handled in the manner of fmt.Printf.
-	Fatalf(format string, args ...interface{})
+	Fatalf(format string, args ...any)
 }
 
 // Debug logs to DEBUG log. Arguments are handled in the manner of fmt.Print.
-func Debug(args ...interface{}) {
+func Debug(args ...any) {
 	Default.Debug(args...)
 }
 
 // Debugf logs to DEBUG log. Arguments are handled in the manner of fmt.Printf.
-func Debugf(format string, args ...interface{}) {
+func Debugf(format string, args ...any) {
 	Default.Debugf(format, args...)
 }
 
 // Info logs to INFO log. Arguments are handled in the manner of fmt.Print.
-func Info(args ...interface{}) {
+func Info(args ...any) {
 	Default.Info(args...)
 }
 
 // Infof logs to INFO log. Arguments are handled in the manner of fmt.Printf.
-func Infof(format string, args ...interface{}) {
+func Infof(format string, args ...any) {
 	Default.Infof(format, args...)
 }
 
 // Warn logs to WARNING log. Arguments are handled in the manner of fmt.Print.
-func Warn(args ...interface{}) {
+func Warn(args ...any) {
 	Default.Warn(args...)
 }
 
 // Warnf logs to WARNING log. Arguments are handled in the manner of fmt.Printf.
-func Warnf(format string, args ...interface{}) {
+func Warnf(format string, args ...any) {
 	Default.Warnf(format, args...)
 }
 
 // Error logs to ERROR log. Arguments are handled in the manner of fmt.Print.
-func Error(args ...interface{}) {
+func Error(args ...any) {
 	Default.Error(args...)
 }
 
 // Errorf logs to ERROR log. Arguments are handled in the manner of fmt.Printf.
-func Errorf(format string, args ...interface{}) {
+func Errorf(format string, args ...any) {
 	Default.Errorf(format, args...)
 }
 
 // Fatal logs to ERROR log. Arguments are handled in the manner of fmt.Print.
-func Fatal(args ...interface{}) {
+func Fatal(args ...any) {
 	Default.Fatal(args...)
 }
 
 // Fatalf logs to ERROR log. Arguments are handled in the manner of fmt.Printf.
-func Fatalf(format string, args ...interface{}) {
+func Fatalf(format string, args ...any) {
 	Default.Fatalf(format, args...)
 }
 
 // Tracef logs a message at the trace level with formatting.
-func Tracef(format string, args ...interface{}) {
+func Tracef(format string, args ...any) {
 	// Trace is more detailed than debug, so we'll log it at debug level
 	// until we have proper trace level support in the underlying logger
 	Default.Debugf("[TRACE] "+format, args...)

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -22,13 +22,13 @@ func TestLog(t *testing.T) {
 
 type noopLogger struct{}
 
-func (*noopLogger) Debug(args ...interface{})                 {}
-func (*noopLogger) Debugf(format string, args ...interface{}) {}
-func (*noopLogger) Info(args ...interface{})                  {}
-func (*noopLogger) Infof(format string, args ...interface{})  {}
-func (*noopLogger) Warn(args ...interface{})                  {}
-func (*noopLogger) Warnf(format string, args ...interface{})  {}
-func (*noopLogger) Error(args ...interface{})                 {}
-func (*noopLogger) Errorf(format string, args ...interface{}) {}
-func (*noopLogger) Fatal(args ...interface{})                 {}
-func (*noopLogger) Fatalf(format string, args ...interface{}) {}
+func (*noopLogger) Debug(args ...any)                 {}
+func (*noopLogger) Debugf(format string, args ...any) {}
+func (*noopLogger) Info(args ...any)                  {}
+func (*noopLogger) Infof(format string, args ...any)  {}
+func (*noopLogger) Warn(args ...any)                  {}
+func (*noopLogger) Warnf(format string, args ...any)  {}
+func (*noopLogger) Error(args ...any)                 {}
+func (*noopLogger) Errorf(format string, args ...any) {}
+func (*noopLogger) Fatal(args ...any)                 {}
+func (*noopLogger) Fatalf(format string, args ...any) {}

--- a/orchestration/session/state.go
+++ b/orchestration/session/state.go
@@ -32,7 +32,7 @@ func (s *State) Set(key string, value []byte) {
 
 // Get gets the value of a key in the state.
 // Will return the delta value if it exists, otherwise the value.
-func (s *State) Get(key string) (interface{}, bool) {
+func (s *State) Get(key string) (any, bool) {
 	v, ok := s.Delta[key]
 	if ok {
 		return v, true

--- a/tool/duckduckgo/internal/client/client.go
+++ b/tool/duckduckgo/internal/client/client.go
@@ -46,7 +46,7 @@ func (fs *FlexibleString) UnmarshalJSON(data []byte) error {
 	}
 
 	// If both fail, try to unmarshal as any type and convert to string.
-	var v interface{}
+	var v any
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}


### PR DESCRIPTION
- Updated the Embedder interface and its OpenAI implementation to use 'any' instead of 'interface{}' for better type safety.
- Modified various tool components, including MCP and DuckDuckGo, to replace 'interface{}' with 'any' in function signatures and variable declarations.
- Adjusted logging functions to accept 'any' as argument types for consistency across the logging interface.
- Enhanced state management by changing the return type of the Get method to 'any' for improved flexibility.