### PR TITLE
Increase test coverage above 80%

### DIFF
--- a/orchestration/session/session_test.go
+++ b/orchestration/session/session_test.go
@@ -1,0 +1,382 @@
+package session
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"trpc.group/trpc-go/trpc-agent-go/core/event"
+)
+
+func TestWithEventNum(t *testing.T) {
+	tests := []struct {
+		name     string
+		num      int
+		expected int
+	}{
+		{
+			name:     "positive number",
+			num:      10,
+			expected: 10,
+		},
+		{
+			name:     "zero",
+			num:      0,
+			expected: 0,
+		},
+		{
+			name:     "negative number",
+			num:      -5,
+			expected: -5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			option := WithEventNum(tt.num)
+			opts := &Options{}
+			option(opts)
+			assert.Equal(t, tt.expected, opts.EventNum)
+		})
+	}
+}
+
+func TestWithEventTime(t *testing.T) {
+	tests := []struct {
+		name     string
+		time     time.Time
+		expected time.Time
+	}{
+		{
+			name:     "current time",
+			time:     time.Now(),
+			expected: time.Now(),
+		},
+		{
+			name:     "zero time",
+			time:     time.Time{},
+			expected: time.Time{},
+		},
+		{
+			name:     "past time",
+			time:     time.Now().Add(-1 * time.Hour),
+			expected: time.Now().Add(-1 * time.Hour),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			option := WithEventTime(tt.time)
+			opts := &Options{}
+			option(opts)
+			assert.Equal(t, tt.expected, opts.EventTime)
+		})
+	}
+}
+
+func TestKey_CheckSessionKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     Key
+		wantErr error
+	}{
+		{
+			name: "valid session key",
+			key: Key{
+				AppName:   "testapp",
+				UserID:    "user123",
+				SessionID: "session456",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "missing app name",
+			key: Key{
+				UserID:    "user123",
+				SessionID: "session456",
+			},
+			wantErr: ErrAppNameRequired,
+		},
+		{
+			name: "missing user id",
+			key: Key{
+				AppName:   "testapp",
+				SessionID: "session456",
+			},
+			wantErr: ErrUserIDRequired,
+		},
+		{
+			name: "missing session id",
+			key: Key{
+				AppName: "testapp",
+				UserID:  "user123",
+			},
+			wantErr: ErrSessionIDRequired,
+		},
+		{
+			name: "empty app name",
+			key: Key{
+				AppName:   "",
+				UserID:    "user123",
+				SessionID: "session456",
+			},
+			wantErr: ErrAppNameRequired,
+		},
+		{
+			name: "empty user id",
+			key: Key{
+				AppName:   "testapp",
+				UserID:    "",
+				SessionID: "session456",
+			},
+			wantErr: ErrUserIDRequired,
+		},
+		{
+			name: "empty session id",
+			key: Key{
+				AppName:   "testapp",
+				UserID:    "user123",
+				SessionID: "",
+			},
+			wantErr: ErrSessionIDRequired,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.key.CheckSessionKey()
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestKey_CheckUserKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     Key
+		wantErr error
+	}{
+		{
+			name: "valid user key",
+			key: Key{
+				AppName: "testapp",
+				UserID:  "user123",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "missing app name",
+			key: Key{
+				UserID: "user123",
+			},
+			wantErr: ErrAppNameRequired,
+		},
+		{
+			name: "missing user id",
+			key: Key{
+				AppName: "testapp",
+			},
+			wantErr: ErrUserIDRequired,
+		},
+		{
+			name: "empty app name",
+			key: Key{
+				AppName: "",
+				UserID:  "user123",
+			},
+			wantErr: ErrAppNameRequired,
+		},
+		{
+			name: "empty user id",
+			key: Key{
+				AppName: "testapp",
+				UserID:  "",
+			},
+			wantErr: ErrUserIDRequired,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.key.CheckUserKey()
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestUserKey_CheckUserKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     UserKey
+		wantErr error
+	}{
+		{
+			name: "valid user key",
+			key: UserKey{
+				AppName: "testapp",
+				UserID:  "user123",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "missing app name",
+			key: UserKey{
+				UserID: "user123",
+			},
+			wantErr: ErrAppNameRequired,
+		},
+		{
+			name: "missing user id",
+			key: UserKey{
+				AppName: "testapp",
+			},
+			wantErr: ErrUserIDRequired,
+		},
+		{
+			name: "empty app name",
+			key: UserKey{
+				AppName: "",
+				UserID:  "user123",
+			},
+			wantErr: ErrAppNameRequired,
+		},
+		{
+			name: "empty user id",
+			key: UserKey{
+				AppName: "testapp",
+				UserID:  "",
+			},
+			wantErr: ErrUserIDRequired,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.key.CheckUserKey()
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestSession_Struct(t *testing.T) {
+	// Test that Session struct can be created and fields are accessible
+	session := &Session{
+		ID:        "test-session",
+		AppName:   "testapp",
+		UserID:    "user123",
+		State:     StateMap{"key1": []byte("value1")},
+		Events:    []event.Event{},
+		UpdatedAt: time.Now(),
+		CreatedAt: time.Now(),
+	}
+
+	assert.Equal(t, "test-session", session.ID)
+	assert.Equal(t, "testapp", session.AppName)
+	assert.Equal(t, "user123", session.UserID)
+	assert.Equal(t, []byte("value1"), session.State["key1"])
+	assert.Equal(t, 0, len(session.Events))
+	assert.False(t, session.UpdatedAt.IsZero())
+	assert.False(t, session.CreatedAt.IsZero())
+}
+
+func TestStateMap_Operations(t *testing.T) {
+	// Test StateMap operations
+	stateMap := StateMap{
+		"key1": []byte("value1"),
+		"key2": []byte("value2"),
+	}
+
+	// Test get
+	value, exists := stateMap["key1"]
+	assert.True(t, exists)
+	assert.Equal(t, []byte("value1"), value)
+
+	// Test set
+	stateMap["key3"] = []byte("value3")
+	assert.Equal(t, []byte("value3"), stateMap["key3"])
+
+	// Test delete
+	delete(stateMap, "key2")
+	_, exists = stateMap["key2"]
+	assert.False(t, exists)
+
+	// Test length
+	assert.Equal(t, 2, len(stateMap))
+}
+
+func TestOptions_Struct(t *testing.T) {
+	// Test that Options struct can be created and fields are accessible
+	opts := &Options{
+		EventNum:  10,
+		EventTime: time.Now(),
+	}
+
+	assert.Equal(t, 10, opts.EventNum)
+	assert.False(t, opts.EventTime.IsZero())
+}
+
+func TestService_Interface(t *testing.T) {
+	// Test that Service interface is properly defined
+	// This is a compile-time test to ensure the interface is complete
+	var _ Service = (*MockService)(nil)
+}
+
+// MockService is a mock implementation of Service interface for testing
+type MockService struct{}
+
+func (m *MockService) CreateSession(ctx context.Context, key Key, state StateMap, options ...Option) (*Session, error) {
+	return nil, nil
+}
+
+func (m *MockService) GetSession(ctx context.Context, key Key, options ...Option) (*Session, error) {
+	return nil, nil
+}
+
+func (m *MockService) ListSessions(ctx context.Context, userKey UserKey, options ...Option) ([]*Session, error) {
+	return nil, nil
+}
+
+func (m *MockService) DeleteSession(ctx context.Context, key Key, options ...Option) error {
+	return nil
+}
+
+func (m *MockService) UpdateAppState(ctx context.Context, appName string, state StateMap) error {
+	return nil
+}
+
+func (m *MockService) DeleteAppState(ctx context.Context, appName string, key string) error {
+	return nil
+}
+
+func (m *MockService) ListAppStates(ctx context.Context, appName string) (StateMap, error) {
+	return nil, nil
+}
+
+func (m *MockService) UpdateUserState(ctx context.Context, userKey UserKey, state StateMap) error {
+	return nil
+}
+
+func (m *MockService) ListUserStates(ctx context.Context, userKey UserKey) (StateMap, error) {
+	return nil, nil
+}
+
+func (m *MockService) DeleteUserState(ctx context.Context, userKey UserKey, key string) error {
+	return nil
+}
+
+func (m *MockService) AppendEvent(ctx context.Context, session *Session, event *event.Event, options ...Option) error {
+	return nil
+}

--- a/orchestration/session/state_test.go
+++ b/orchestration/session/state_test.go
@@ -1,0 +1,157 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewState(t *testing.T) {
+	state := NewState()
+
+	assert.NotNil(t, state)
+	assert.NotNil(t, state.Value)
+	assert.NotNil(t, state.Delta)
+	assert.Equal(t, 0, len(state.Value))
+	assert.Equal(t, 0, len(state.Delta))
+}
+
+func TestState_Set(t *testing.T) {
+	state := NewState()
+
+	// Test setting a new key
+	state.Set("key1", []byte("value1"))
+	assert.Equal(t, []byte("value1"), state.Value["key1"])
+	assert.Equal(t, []byte("value1"), state.Delta["key1"])
+
+	// Test updating an existing key
+	state.Set("key1", []byte("updated_value"))
+	assert.Equal(t, []byte("updated_value"), state.Value["key1"])
+	assert.Equal(t, []byte("updated_value"), state.Delta["key1"])
+
+	// Test setting multiple keys
+	state.Set("key2", []byte("value2"))
+	state.Set("key3", []byte("value3"))
+
+	assert.Equal(t, []byte("value2"), state.Value["key2"])
+	assert.Equal(t, []byte("value2"), state.Delta["key2"])
+	assert.Equal(t, []byte("value3"), state.Value["key3"])
+	assert.Equal(t, []byte("value3"), state.Delta["key3"])
+
+	// Test setting empty value
+	state.Set("empty_key", []byte{})
+	assert.Equal(t, []byte{}, state.Value["empty_key"])
+	assert.Equal(t, []byte{}, state.Delta["empty_key"])
+}
+
+func TestState_Get(t *testing.T) {
+	state := NewState()
+
+	// Test getting non-existent key
+	value, exists := state.Get("non_existent")
+	assert.False(t, exists)
+	assert.Nil(t, value)
+
+	// Test getting key that exists in Delta but not in Value
+	state.Delta["delta_only"] = []byte("delta_value")
+	value, exists = state.Get("delta_only")
+	assert.True(t, exists)
+	assert.Equal(t, []byte("delta_value"), value)
+
+	// Test getting key that exists in Value but not in Delta
+	state.Value["value_only"] = []byte("value_only_data")
+	value, exists = state.Get("value_only")
+	assert.True(t, exists)
+	assert.Equal(t, []byte("value_only_data"), value)
+
+	// Test getting key that exists in both Delta and Value (Delta should take precedence)
+	state.Value["both"] = []byte("value_data")
+	state.Delta["both"] = []byte("delta_data")
+	value, exists = state.Get("both")
+	assert.True(t, exists)
+	assert.Equal(t, []byte("delta_data"), value) // Delta should take precedence
+
+	// Test getting empty value
+	state.Set("empty_key", []byte{})
+	value, exists = state.Get("empty_key")
+	assert.True(t, exists)
+	assert.Equal(t, []byte{}, value)
+}
+
+func TestState_Integration(t *testing.T) {
+	state := NewState()
+
+	// Test the complete workflow: Set -> Get
+	state.Set("integration_key", []byte("integration_value"))
+	value, exists := state.Get("integration_key")
+	assert.True(t, exists)
+	assert.Equal(t, []byte("integration_value"), value)
+
+	// Test updating and getting
+	state.Set("integration_key", []byte("updated_integration_value"))
+	value, exists = state.Get("integration_key")
+	assert.True(t, exists)
+	assert.Equal(t, []byte("updated_integration_value"), value)
+
+	// Test multiple operations
+	keys := []string{"key1", "key2", "key3"}
+	values := [][]byte{[]byte("value1"), []byte("value2"), []byte("value3")}
+
+	for i, key := range keys {
+		state.Set(key, values[i])
+	}
+
+	for i, key := range keys {
+		value, exists := state.Get(key)
+		assert.True(t, exists)
+		assert.Equal(t, values[i], value)
+	}
+}
+
+func TestState_EmptyValues(t *testing.T) {
+	state := NewState()
+
+	// Test setting and getting empty byte slice
+	state.Set("empty_bytes", []byte{})
+	value, exists := state.Get("empty_bytes")
+	assert.True(t, exists)
+	assert.Equal(t, []byte{}, value)
+
+	// Test setting and getting nil value
+	state.Set("nil_value", nil)
+	value, exists = state.Get("nil_value")
+	assert.True(t, exists)
+	assert.Nil(t, value)
+}
+
+func TestState_ConcurrentAccess(t *testing.T) {
+	state := NewState()
+
+	// Test that Value and Delta are separate maps
+	state.Value["value_key"] = []byte("value_data")
+	state.Delta["delta_key"] = []byte("delta_data")
+
+	// Value should not contain delta_key
+	_, exists := state.Value["delta_key"]
+	assert.False(t, exists)
+
+	// Delta should not contain value_key
+	_, exists = state.Delta["value_key"]
+	assert.False(t, exists)
+
+	// But Get should find both
+	value, exists := state.Get("value_key")
+	assert.True(t, exists)
+	assert.Equal(t, []byte("value_data"), value)
+
+	value, exists = state.Get("delta_key")
+	assert.True(t, exists)
+	assert.Equal(t, []byte("delta_data"), value)
+}
+
+func TestStateConstants(t *testing.T) {
+	// Test that constants are properly defined
+	assert.Equal(t, "app:", StateAppPrefix)
+	assert.Equal(t, "user:", StateUserPrefix)
+	assert.Equal(t, "temp:", StateTempPrefix)
+}


### PR DESCRIPTION
Add comprehensive unit tests for `session.go` and `state.go` to increase package test coverage.