### PR TITLE
{agent, model, flow}:  add StopError type to allow stop agent by user

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -28,6 +28,9 @@ type Info struct {
 	Description string
 }
 
+// ErrorTypeStopAgentError is the error type used to indicate that an agent should stop execution.
+const ErrorTypeStopAgentError = "stop_agent_error"
+
 // StopError represents an error that signals the agent execution should be stopped.
 // When this error type is returned, it indicates the agent should stop processing.
 type StopError struct {

--- a/examples/multi_tools/main.go
+++ b/examples/multi_tools/main.go
@@ -111,9 +111,9 @@ func (c *multiToolChat) setup(_ context.Context) error {
 		// 2. time_tool: Get current time, date, timezone information, etc.
 		// 3. text_tool: Process text, including case conversion, length statistics, string operations, etc.
 		// 4. file_tool: Basic file operations such as reading, writing, listing directories, etc.
-		//5. duckduckgo_search: Search web information, suitable for finding factual, encyclopedia-type information
+		// 5. duckduckgo_search: Search web information, suitable for finding factual, encyclopedia-type information
 
-		//Please select the appropriate tool based on user needs and provide helpful assistance.`),
+		// Please select the appropriate tool based on user needs and provide helpful assistance.`),
 		llmagent.WithGenerationConfig(genConfig),
 		llmagent.WithChannelBufferSize(100),
 		llmagent.WithTools(tools),
@@ -212,7 +212,7 @@ func (c *multiToolChat) processStreamingResponse(eventChan <-chan *event.Event) 
 	for event := range eventChan {
 		// Handle errors
 		if event.Error != nil {
-			if event.Error.Type == model.ErrorTypeStopAgentError {
+			if event.Error.Type == agent.ErrorTypeStopAgentError {
 				// Handle stop agent error
 				fmt.Printf("\n🛑 Agent stopped: %s\n", event.Error.Message)
 				log.Fatal("Agent execution stopped due to error: ", event.Error.Message)

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -105,7 +105,7 @@ func (f *Flow) Run(ctx context.Context, invocation *agent.Invocation) (<-chan *e
 					errorEvent = event.NewErrorEvent(
 						invocation.InvocationID,
 						invocation.AgentName,
-						model.ErrorTypeStopAgentError,
+						agent.ErrorTypeStopAgentError,
 						err.Error(),
 					)
 					log.Errorf("Flow step stopped for agent %s: %v", invocation.AgentName, err)

--- a/model/response.go
+++ b/model/response.go
@@ -21,8 +21,6 @@ const (
 	ErrorTypeStreamError = "stream_error"
 	ErrorTypeAPIError    = "api_error"
 	ErrorTypeFlowError   = "flow_error"
-
-	ErrorTypeStopAgentError = "stop_agent_error"
 )
 
 // Object type constants for Response.Object field.


### PR DESCRIPTION
这 4 个函数返回的 StopError 可以让用户选择终止 agent

- RunBeforeTool
- ToolCall
- RunAfterTool
- RunAfterModelCallbacks