### PR TITLE
internal/tool: update JSON schema generation to remove null type for pointers

### DIFF
--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -73,9 +73,9 @@ func GenerateJSONSchema(t reflect.Type) *tool.Schema {
 		}
 
 	case reflect.Ptr:
-		elemSchema := GenerateFieldSchema(t.Elem())
-		elemSchema.Type = elemSchema.Type + ",null"
-		return elemSchema
+		// For function tool parameters, we typically use value types
+		// So we can just return the element type schema.
+		return GenerateFieldSchema(t.Elem())
 
 	default:
 		return GenerateFieldSchema(t)
@@ -108,10 +108,9 @@ func GenerateFieldSchema(t reflect.Type) *tool.Schema {
 			AdditionalProperties: GenerateFieldSchema(t.Elem()),
 		}
 	case reflect.Ptr:
-		elemSchema := GenerateFieldSchema(t.Elem())
-		// Pointers are nullable
-		elemSchema.Type = elemSchema.Type + ",null"
-		return elemSchema
+		// For function tool parameters, we typically use value types
+		// So we can just return the element type schema
+		return GenerateFieldSchema(t.Elem())
 	case reflect.Struct:
 		nestedSchema := &tool.Schema{
 			Type:       "object",

--- a/internal/tool/tool_test.go
+++ b/internal/tool/tool_test.go
@@ -97,8 +97,8 @@ func TestGenerateJSONSchema_ComplexTypes(t *testing.T) {
 		var input *string
 		result := itool.GenerateJSONSchema(reflect.TypeOf(input))
 
-		if result.Type != "string,null" {
-			t.Errorf("expected string,null type, got %s", result.Type)
+		if result.Type != "string" {
+			t.Errorf("expected string type, got %s", result.Type)
 		}
 	})
 }
@@ -131,8 +131,8 @@ func TestGenerateJSONSchema_StructTypes(t *testing.T) {
 			t.Errorf("expected age property of type integer")
 		}
 
-		if result.Properties["optional"] == nil || result.Properties["optional"].Type != "string,null" {
-			t.Errorf("expected optional property of type string,null")
+		if result.Properties["optional"] == nil || result.Properties["optional"].Type != "string" {
+			t.Errorf("expected optional property of type string")
 		}
 
 		// Check required fields
@@ -192,5 +192,37 @@ func TestGenerateJSONSchema_Nested(t *testing.T) {
 
 	if result.Properties["tags"].Items == nil || result.Properties["tags"].Items.Type != "string" {
 		t.Errorf("expected tags items to be of type string")
+	}
+}
+
+func TestGenerateJSONSchema_PointerTypeFix(t *testing.T) {
+	// Test that pointer types now generate standard schema format
+	// instead of the problematic "object,null" format
+
+	type TestRequest struct {
+		Name string `json:"name"`
+		Age  int    `json:"age"`
+	}
+
+	var input *TestRequest
+	result := itool.GenerateJSONSchema(reflect.TypeOf(input))
+
+	// Should generate "object" instead of "object,null"
+	if result.Type != "object" {
+		t.Errorf("expected object type for pointer to struct, got %s", result.Type)
+	}
+
+	// Should have properties
+	if result.Properties == nil {
+		t.Errorf("expected properties for struct schema")
+	}
+
+	// Check that properties are correctly generated
+	if result.Properties["name"] == nil || result.Properties["name"].Type != "string" {
+		t.Errorf("expected name property of type string")
+	}
+
+	if result.Properties["age"] == nil || result.Properties["age"].Type != "integer" {
+		t.Errorf("expected age property of type integer")
 	}
 }


### PR DESCRIPTION
- Modified the JSON schema generation logic to return only the element type for pointer types, removing the nullable type.
- Updated tests to reflect the expected type changes for string and optional properties.