### PR TITLE
examples/callbacks: add Tool Timer example for performance monitoring

### DIFF
--- a/examples/callbacks/README.md
+++ b/examples/callbacks/README.md
@@ -12,7 +12,7 @@ This example demonstrates how to use the `Runner` orchestration component in a m
 - **Tool Integration**: Built-in calculator and time tools
 - **Callback Mechanism**: Pluggable model, tool, and agent callbacks for extensibility and debugging
 - **Command Line Interface**: Configurable via command-line flags
-- **Performance Monitoring**: See [Timer Example](./timer/README.md) for comprehensive timing measurements
+- **Performance Monitoring**: See [Timer Example](./timer/README.md) for comprehensive timing measurements with OpenTelemetry integration
 
 ---
 
@@ -351,7 +351,7 @@ go run main.go -streaming=false
 
 - [runner/README.md](../runner/README.md) (basic multi-turn chat and tool calling)
 - This directory's `main.go` (full callback registration and usage)
-- [Timer Example](./timer/README.md) (comprehensive timing measurements for agent, model, and tool execution)
+- [Timer Example](./timer/README.md) (comprehensive timing measurements with OpenTelemetry integration for agent, model, and tool execution)
 
 ---
 

--- a/examples/callbacks/timer/README.md
+++ b/examples/callbacks/timer/README.md
@@ -1,14 +1,15 @@
-# Tool Timer Example
+# Tool Timer with Telemetry Example
 
-This example demonstrates how to use **ToolCallbacks**, **AgentCallbacks**, and **ModelCallbacks** to measure execution time for different components in the agent system.
+This example demonstrates how to use **ToolCallbacks**, **AgentCallbacks**, and **ModelCallbacks** to measure execution time for different components in the agent system and report the data to **OpenTelemetry** for monitoring and observability.
 
 ## Overview
 
-The timer example shows how to implement comprehensive timing measurements across three key components:
+The timer example shows how to implement comprehensive timing measurements across three key components with telemetry integration:
 
 - **Agent Timing**: Measures the total time for agent execution
 - **Model Timing**: Measures the time for LLM model inference
 - **Tool Timing**: Measures the time for individual tool execution
+- **Telemetry Integration**: Reports metrics and traces to OpenTelemetry Collector
 
 ## Key Features
 
@@ -16,6 +17,26 @@ The timer example shows how to implement comprehensive timing measurements acros
 - **Real-time Output**: See timing information as components execute
 - **Interactive Chat**: Test timing with different calculation scenarios
 - **Clean Output**: Clear timing indicators with emoji for easy identification
+- **OpenTelemetry Integration**: Automatic reporting to Jaeger (traces) and Prometheus (metrics)
+- **Observability**: View traces in Jaeger UI and metrics in Prometheus
+
+## Architecture
+
+```
+Timer Example + OpenTelemetry Integration
+┌─────────────────┐    ┌─────────────────────┐    ┌─────────────┐
+│   Timer App     │───▶│  OTEL Collector     │───▶│   Jaeger    │
+│   (main.go)     │    │  (localhost:4317)   │    │ (localhost: │
+│                 │    │                     │    │   16686)    │
+└─────────────────┘    └─────────────────────┘    └─────────────┘
+                              │
+                              ▼
+                       ┌─────────────┐
+                       │ Prometheus  │
+                       │ (localhost: │
+                       │    9090)    │
+                       └─────────────┘
+```
 
 ## Timing Output Example
 
@@ -37,6 +58,32 @@ The timer example shows how to implement comprehensive timing measurements acros
    Result: {add 10 20 30}
 ```
 
+## Telemetry Data
+
+The example automatically reports the following telemetry data:
+
+### Metrics (Prometheus)
+
+- `agent_duration_seconds` - Histogram of agent execution times
+- `model_duration_seconds` - Histogram of model inference times
+- `tool_duration_seconds` - Histogram of tool execution times
+- `agent_executions_total` - Counter of agent executions
+- `model_inferences_total` - Counter of model inferences
+- `tool_executions_total` - Counter of tool executions
+
+### Traces (Jaeger)
+
+- `agent_execution` - Trace spans for agent execution
+- `model_inference` - Trace spans for model inference
+- `tool_execution` - Trace spans for tool execution
+
+Each trace includes attributes like:
+
+- Component name (agent.name, tool.name)
+- Duration in seconds
+- Status (success/error)
+- Additional context (invocation ID, arguments, etc.)
+
 ## Implementation Details
 
 ### Timer Storage Strategy
@@ -49,12 +96,19 @@ type toolTimerExample struct {
     agentStartTimes map[string]time.Time
     modelStartTimes map[string]time.Time
     currentModelKey string
+    // Telemetry metrics
+    agentDurationHistogram   metric.Float64Histogram
+    toolDurationHistogram    metric.Float64Histogram
+    modelDurationHistogram   metric.Float64Histogram
+    agentCounter            metric.Int64Counter
+    toolCounter             metric.Int64Counter
+    modelCounter            metric.Int64Counter
 }
 ```
 
 ### Callback Registration
 
-The example registers callbacks for all three levels:
+The example registers callbacks for all three levels with telemetry integration:
 
 ```go
 // Tool callbacks
@@ -73,26 +127,121 @@ modelCallbacks.RegisterBeforeModel(e.createBeforeModelCallback())
 modelCallbacks.RegisterAfterModel(e.createAfterModelCallback())
 ```
 
+### Telemetry Integration
+
+Each callback creates OpenTelemetry spans and records metrics:
+
+```go
+// Create trace span
+ctx, span := atrace.Tracer.Start(ctx, "agent_execution",
+    trace.WithAttributes(
+        attribute.String("agent.name", invocation.AgentName),
+        attribute.String("invocation.id", invocation.InvocationID),
+    ),
+)
+
+// Record metrics
+e.agentDurationHistogram.Record(ctx, durationSeconds,
+    metric.WithAttributes(
+        attribute.String("agent.name", invocation.AgentName),
+    ),
+)
+```
+
 ## Running the Example
 
-1. **Set up your API key:**
+### Prerequisites
 
+1. **Install Docker Compose V2** for running the telemetry infrastructure
+2. **Set up your API key:**
    ```bash
    export OPENAI_API_KEY="your-api-key"
    ```
 
-2. **Run the example:**
+### Start Telemetry Infrastructure
+
+1. **Start the telemetry stack:**
+
+   ```bash
+   docker compose up -d
+   ```
+
+2. **Verify services are running:**
+   - OpenTelemetry Collector: `localhost:4317`
+   - Jaeger UI: http://localhost:16686
+   - Prometheus: http://localhost:9090
+
+### Run the Timer Example
+
+1. **Run the example:**
 
    ```bash
    go run main.go
    ```
 
-3. **Test different scenarios:**
+2. **Test different scenarios:**
    - `calculate 123 * 321` - Test fast calculator
    - `calculate 10 + 20` - Test basic arithmetic
    - `/history` - Show conversation history
    - `/new` - Start a new session
    - `/exit` - End the conversation
+
+### View Telemetry Data
+
+1. **View traces in Jaeger:**
+
+   - Open http://localhost:16686
+   - Search for service "telemetry"
+   - View trace spans for agent, model, and tool execution
+
+2. **View metrics in Prometheus:**
+   - Open http://localhost:9090
+   - In the query input field, search for metrics like:
+     - `agent_duration_seconds` - Agent execution duration histogram
+     - `model_duration_seconds` - Model inference duration histogram
+     - `tool_duration_seconds` - Tool execution duration histogram
+     - `agent_executions_total` - Total agent executions counter
+     - `model_inferences_total` - Total model inferences counter
+     - `tool_executions_total` - Total tool executions counter
+   - Click "Execute" to see the results
+   - Switch to "Graph" tab to visualize the metrics over time
+
+### Prometheus Query Examples
+
+Here are some useful PromQL queries you can try:
+
+**Duration Histograms:**
+
+```
+# Agent execution duration (95th percentile)
+histogram_quantile(0.95, agent_duration_seconds_bucket)
+
+# Model inference duration (average)
+rate(model_duration_seconds_sum[5m]) / rate(model_duration_seconds_count[5m])
+
+# Tool execution duration (max)
+max(tool_duration_seconds)
+```
+
+**Execution Counters:**
+
+```
+# Total agent executions
+agent_executions_total
+
+# Rate of model inferences per minute
+rate(model_inferences_total[1m])
+
+# Tool executions by tool name
+tool_executions_total
+```
+
+**Error Rates:**
+
+```
+# Agent error rate
+rate(agent_executions_total{status="error"}[5m]) / rate(agent_executions_total[5m])
+```
 
 ## Available Tools
 
@@ -101,11 +250,12 @@ modelCallbacks.RegisterAfterModel(e.createAfterModelCallback())
 
 ## Performance Insights
 
-From the timing output, you can observe:
+From the timing output and telemetry data, you can observe:
 
 - **Model Inference**: Usually the slowest component (4-6 seconds)
 - **Tool Execution**: Very fast for local calculations (20-50 microseconds)
 - **Agent Overhead**: Minimal additional time beyond model + tool execution
+- **Telemetry Overhead**: Minimal impact on performance
 
 ## Use Cases
 
@@ -113,21 +263,64 @@ From the timing output, you can observe:
 - **Debugging**: Understand where time is spent in complex workflows
 - **Optimization**: Measure the impact of different model configurations
 - **Development**: Verify that tools and models are performing as expected
+- **Production Monitoring**: Use telemetry data for alerting and dashboards
+- **Distributed Tracing**: Track requests across multiple services
 
 ## Customization
 
-To add timing to your own agent system:
+To add timing and telemetry to your own agent system:
 
 1. **Copy the timer structure** from this example
 2. **Register callbacks** in your agent setup
 3. **Customize timing logic** as needed for your use case
 4. **Add additional metrics** like memory usage, API calls, etc.
+5. **Configure telemetry endpoints** for your environment
+6. **Set up monitoring dashboards** using the telemetry data
+
+## Troubleshooting
+
+### No metrics found in Prometheus?
+
+1. **Check if metrics are being sent:**
+
+   - Look for "No data queried yet" message
+   - Try running the timer example multiple times to generate more data
+   - Check the OpenTelemetry Collector logs: `sudo docker compose logs otel-collector`
+
+2. **Check metric names:**
+
+   - The metrics are prefixed with `trpcgoagent_` (from the collector config)
+   - Try searching for: `trpcgoagent_agent_duration_seconds`
+   - Or use the metric browser in Prometheus UI
+
+3. **Check time range:**
+   - Make sure the time range includes when you ran the example
+   - Try "Last 1 hour" or "Last 6 hours"
+
+### No traces found in Jaeger?
+
+1. **Check service name:**
+
+   - Look for service "telemetry" (not "timer-example")
+   - The service name comes from the OpenTelemetry SDK configuration
+
+2. **Check time range:**
+   - Make sure the time range includes when you ran the example
+
+## Shutting Down
+
+To shut down the telemetry infrastructure:
+
+```bash
+docker compose down
+```
 
 ## Related Examples
 
 - [Multi-turn Chat with Callbacks](../main.go) - Comprehensive callback examples
+- [Telemetry Example](../../telemetry/) - Basic OpenTelemetry integration
 - [Runner Examples](../../runner/) - Basic agent and tool usage
 
 ---
 
-This example demonstrates how to implement comprehensive timing measurements in a production-ready agent system.
+This example demonstrates how to implement comprehensive timing measurements with production-ready observability using OpenTelemetry.

--- a/examples/callbacks/timer/docker-compose.yaml
+++ b/examples/callbacks/timer/docker-compose.yaml
@@ -1,0 +1,20 @@
+services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.128.0
+    command: ["--config=/etc/otel-collector.yaml"]
+    volumes:
+      - ./otel-collector.yaml:/etc/otel-collector.yaml
+    ports:
+      - 4317:4317
+
+  prometheus:
+    image: prom/prometheus:v3.4.1
+    volumes:
+      - ./prometheus.yaml:/etc/prometheus/prometheus.yml
+    ports:
+      - 9090:9090
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.60
+    ports:
+      - 16686:16686 

--- a/examples/callbacks/timer/otel-collector.yaml
+++ b/examples/callbacks/timer/otel-collector.yaml
@@ -1,0 +1,33 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+processors:
+
+extensions:
+  health_check: {}
+
+exporters:
+  otlp:
+    endpoint: jaeger:4317
+    tls:
+      insecure: true
+  prometheus:
+    endpoint: 0.0.0.0:9090
+    namespace: trpcgoagent
+  debug:
+
+service:
+  extensions: [health_check]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: []
+      exporters: [otlp, debug]
+
+    metrics:
+      receivers: [otlp]
+      processors: []
+      exporters: [prometheus, debug]

--- a/examples/callbacks/timer/prometheus.yaml
+++ b/examples/callbacks/timer/prometheus.yaml
@@ -1,0 +1,5 @@
+scrape_configs:
+  - job_name: "otel-collector"
+    scrape_interval: 5s
+    static_configs:
+      - targets: ["otel-collector:9090"]


### PR DESCRIPTION
- Introduced a new example demonstrating the use of ToolCallbacks, AgentCallbacks, and ModelCallbacks to measure execution time across different components.
- Updated README files to include details about the new Timer Example and its features, including multi-level timing and interactive chat capabilities.
- Implemented comprehensive timing measurements for agent, model, and tool execution, providing real-time output for performance insights.