### PR TITLE
knowledge/tool: update KnowledgeSearchTool to return nil while error occurs

### DIFF
--- a/knowledge/tool/searchtool_test.go
+++ b/knowledge/tool/searchtool_test.go
@@ -38,7 +38,7 @@ func (s stubKnowledge) Search(ctx context.Context, req *knowledge.SearchRequest)
 
 func marshalArgs(t *testing.T, query string) []byte {
 	t.Helper()
-	bts, err := json.Marshal(KnowledgeSearchRequest{Query: query})
+	bts, err := json.Marshal(&KnowledgeSearchRequest{Query: query})
 	require.NoError(t, err)
 	return bts
 }
@@ -47,28 +47,25 @@ func TestKnowledgeSearchTool(t *testing.T) {
 	t.Run("empty query", func(t *testing.T) {
 		kb := stubKnowledge{}
 		searchTool := NewKnowledgeSearchTool(kb)
-		res, _ := searchTool.(ctool.CallableTool).Call(context.Background(), marshalArgs(t, ""))
-		rsp := res.(KnowledgeSearchResponse)
-		require.False(t, rsp.Success)
-		require.Contains(t, rsp.Message, "Query cannot be empty")
+		_, err := searchTool.(ctool.CallableTool).Call(context.Background(), marshalArgs(t, ""))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "query cannot be empty")
 	})
 
 	t.Run("search error", func(t *testing.T) {
 		kb := stubKnowledge{err: errors.New("boom")}
 		searchTool := NewKnowledgeSearchTool(kb)
-		res, _ := searchTool.(ctool.CallableTool).Call(context.Background(), marshalArgs(t, "hello"))
-		rsp := res.(KnowledgeSearchResponse)
-		require.False(t, rsp.Success)
-		require.Contains(t, rsp.Message, "Search failed")
+		_, err := searchTool.(ctool.CallableTool).Call(context.Background(), marshalArgs(t, "hello"))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "search failed")
 	})
 
 	t.Run("no result", func(t *testing.T) {
 		kb := stubKnowledge{}
 		searchTool := NewKnowledgeSearchTool(kb)
-		res, _ := searchTool.(ctool.CallableTool).Call(context.Background(), marshalArgs(t, "hello"))
-		rsp := res.(KnowledgeSearchResponse)
-		require.True(t, rsp.Success)
-		require.Contains(t, rsp.Message, "No relevant information")
+		_, err := searchTool.(ctool.CallableTool).Call(context.Background(), marshalArgs(t, "hello"))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no relevant information found")
 	})
 
 	t.Run("success", func(t *testing.T) {
@@ -76,10 +73,10 @@ func TestKnowledgeSearchTool(t *testing.T) {
 		searchTool := NewKnowledgeSearchTool(kb)
 		res, err := searchTool.(ctool.CallableTool).Call(context.Background(), marshalArgs(t, "hello"))
 		require.NoError(t, err)
-		rsp := res.(KnowledgeSearchResponse)
-		require.True(t, rsp.Success)
+		rsp := res.(*KnowledgeSearchResponse)
 		require.Equal(t, "foo", rsp.Text)
 		require.Equal(t, 0.9, rsp.Score)
+		require.Contains(t, rsp.Message, "Found relevant content")
 	})
 
 	// Verify Declaration metadata is populated.


### PR DESCRIPTION
- Modified the search function to return errors for invalid queries and search failures, improving error handling.
- Updated tests to reflect the new error-based response structure, ensuring proper validation and messaging for empty queries and search results.
- Adjusted the KnowledgeSearchResponse structure to remove the Success field, focusing on error handling instead.