### PR TITLE
model: add support for reasoning_content field

### DIFF
--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -24,6 +24,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"os"
+	"strconv"
 	"time"
 
 	openai "github.com/openai/openai-go"
@@ -808,6 +809,12 @@ func (m *Model) shouldSuppressChunk(chunk openai.ChatCompletionChunk) bool {
 	if delta.Content != "" {
 		return false
 	}
+
+	// think model reasoning content
+	if !delta.JSON.ExtraFields["reasoning_content"].Valid() {
+		return false
+	}
+
 	// If this chunk is a tool_calls delta, suppress emission. We'll only expose
 	// tool calls in the final aggregated response to avoid noisy blank chunks.
 	if delta.JSON.ToolCalls.Valid() {
@@ -842,9 +849,16 @@ func (m *Model) createPartialResponse(chunk openai.ChatCompletionChunk) *model.R
 		if response.Choices == nil {
 			response.Choices = make([]model.Choice, 1)
 		}
+
+		reasoningContent, err := strconv.Unquote(chunk.Choices[0].Delta.JSON.ExtraFields["reasoning_content"].Raw())
+		if err != nil {
+			reasoningContent = ""
+		}
+
 		response.Choices[0].Delta = model.Message{
-			Role:    model.RoleAssistant,
-			Content: chunk.Choices[0].Delta.Content,
+			Role:             model.RoleAssistant,
+			Content:          chunk.Choices[0].Delta.Content,
+			ReasoningContent: reasoningContent,
 		}
 
 		// Handle finish reason - FinishReason is a plain string.

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -1618,3 +1618,82 @@ func TestModel_GenerateContent_StreamingBatchProcessing(t *testing.T) {
 		})
 	}
 }
+
+func TestModel_GenerateContent_WithReasoningContent(t *testing.T) {
+	// Create a mock server that returns streaming responses with reasoning_content
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/chat/completions") {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+
+		// Send response chunks with reasoning_content
+		chunks := []string{
+			`data: {"id":"test","object":"chat.completion.chunk","created":1699200000,"model":"deepseek-chat","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"First part of reasoning"},"finish_reason":null}]}`,
+			`data: {"id":"test","object":"chat.completion.chunk","created":1699200000,"model":"deepseek-chat","choices":[{"index":0,"delta":{"reasoning_content":" second part of reasoning"},"finish_reason":null}]}`,
+			`data: {"id":"test","object":"chat.completion.chunk","created":1699200000,"model":"deepseek-chat","choices":[{"index":0,"delta":{"reasoning_content":" final part of reasoning"},"finish_reason":"stop"}]}`,
+		}
+
+		for _, chunk := range chunks {
+			fmt.Fprintf(w, "%s\n\n", chunk)
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+	}))
+	defer server.Close()
+
+	// Create model instance
+	m := New("deepseek-chat", WithBaseURL(server.URL), WithAPIKey("test-key"))
+
+	// Create request
+	req := &model.Request{
+		Messages:         []model.Message{{Role: model.RoleUser, Content: "Test with reasoning content"}},
+		GenerationConfig: model.GenerationConfig{Stream: true},
+	}
+
+	// Send request
+	ctx := context.Background()
+	responseChan, err := m.GenerateContent(ctx, req)
+	if err != nil {
+		t.Fatalf("GenerateContent failed: %v", err)
+	}
+
+	// Collect responses
+	var responses []*model.Response
+	for response := range responseChan {
+		responses = append(responses, response)
+		if response.Error != nil {
+			t.Fatalf("Response error: %v", response.Error)
+		}
+	}
+
+	// Verify responses contain reasoning_content
+	if len(responses) < 3 {
+		t.Fatalf("Expected at least 3 responses, got %d", len(responses))
+	}
+
+	// Check the first response chunk
+	if len(responses) > 0 && len(responses[0].Choices) > 0 {
+		if responses[0].Choices[0].Delta.ReasoningContent != "First part of reasoning" {
+			t.Errorf("Expected reasoning_content 'First part of reasoning', got '%s'", responses[0].Choices[0].Delta.ReasoningContent)
+		}
+	}
+
+	// Check if any responses contain reasoning_content
+	foundReasoningContent := false
+	for _, response := range responses {
+		if len(response.Choices) > 0 && response.Choices[0].Delta.ReasoningContent != "" {
+			foundReasoningContent = true
+			break
+		}
+	}
+
+	if !foundReasoningContent {
+		t.Error("Expected to find responses with reasoning_content, but none were found")
+	}
+}

--- a/model/request.go
+++ b/model/request.go
@@ -69,6 +69,9 @@ type Message struct {
 	ToolName string `json:"tool_name,omitempty"`
 	// ToolCalls is the optional tool calls for the message.
 	ToolCalls []ToolCall `json:"tool_calls,omitempty"`
+	// ReasoningContent is hunyuan or deepseek think content
+	// - https://api-docs.deepseek.com/api/create-chat-completion#responses
+	ReasoningContent string `json:"reasoning_content,omitempty"`
 }
 
 // AddFilePath adds a file path to the message.

--- a/model/request_test.go
+++ b/model/request_test.go
@@ -275,6 +275,26 @@ func TestContentPartWithFile(t *testing.T) {
 	}
 }
 
+func TestMessage_WithReasoningContent(t *testing.T) {
+	// Test message with ReasoningContent field
+	msg := Message{
+		Role:             RoleAssistant,
+		Content:          "This is the main content",
+		ReasoningContent: "This is the reasoning content",
+	}
+
+	// Verify field values
+	if msg.Role != RoleAssistant {
+		t.Errorf("Message.Role = %v, want %v", msg.Role, RoleAssistant)
+	}
+	if msg.Content != "This is the main content" {
+		t.Errorf("Message.Content = %v, want %v", msg.Content, "This is the main content")
+	}
+	if msg.ReasoningContent != "This is the reasoning content" {
+		t.Errorf("Message.ReasoningContent = %v, want %v", msg.ReasoningContent, "This is the reasoning content")
+	}
+}
+
 // Helper functions for test data
 func intPtr(i int) *int {
 	return &i


### PR DESCRIPTION
Add ReasoningContent field to Message struct and handle it in openai package for streaming responses.

RELEASE NOTES: Added support for reasoning_content field in model messages.