### PR TITLE
trpc-agent-go: upgrade codecov version to v5

### DIFF
--- a/.github/workflows/prc.yml
+++ b/.github/workflows/prc.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Test
       run: go test -v -coverprofile=coverage.out ./...
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       with:
         files: coverage.out
         flags: unittests


### PR DESCRIPTION
v3 is no longer maintained and it has a problem: pushing a new commit on an existing PR will not update the coverage comment.
Upgrade codecov version to v5 to fix this problem.