### PR TITLE
examples/memory: refactor memory service for clarity

### DIFF
--- a/examples/memory/README.md
+++ b/examples/memory/README.md
@@ -256,7 +256,17 @@ if err != nil {
 You can override default tool implementations with custom ones:
 
 ```go
-// Custom clear tool with enhanced logging
+import (
+    "context"
+    "fmt"
+
+    "trpc.group/trpc-go/trpc-agent-go/memory"
+    toolmemory "trpc.group/trpc-go/trpc-agent-go/memory/tool"
+    "trpc.group/trpc-go/trpc-agent-go/tool"
+    "trpc.group/trpc-go/trpc-agent-go/tool/function"
+)
+
+// Custom clear tool with enhanced logging.
 func customClearMemoryTool(memoryService memory.Service) tool.Tool {
     clearFunc := func(ctx context.Context, _ struct{}) (toolmemory.ClearMemoryResponse, error) {
         fmt.Println("🧹 [Custom Clear Tool] Clearing memories with extra sparkle... ✨")

--- a/examples/memory/README.md
+++ b/examples/memory/README.md
@@ -240,6 +240,17 @@ memoryService := memoryinmemory.NewMemoryService(
 )
 ```
 
+```go
+// Redis service: enable delete tool.
+memoryService, err := memoryredis.NewService(
+    memoryredis.WithRedisClientURL("redis://localhost:6379"),
+    memoryredis.WithToolEnabled(memory.DeleteToolName, true),
+)
+if err != nil {
+    // Handle error appropriately.
+}
+```
+
 ### Custom Tool Implementation
 
 You can override default tool implementations with custom ones:
@@ -267,6 +278,17 @@ func customClearMemoryTool(memoryService memory.Service) tool.Tool {
 memoryService := memoryinmemory.NewMemoryService(
     memoryinmemory.WithCustomTool(memory.ClearToolName, customClearMemoryTool),
 )
+```
+
+```go
+// Or register the custom tool for Redis service.
+memoryService, err := memoryredis.NewService(
+    memoryredis.WithRedisClientURL("redis://localhost:6379"),
+    memoryredis.WithCustomTool(memory.ClearToolName, customClearMemoryTool),
+)
+if err != nil {
+    // Handle error appropriately.
+}
 ```
 
 ### Tool Creator Pattern


### PR DESCRIPTION
- Removed unused imports and cleaned up memory service initialization logic.
- Enhanced the README with examples for enabling tools in Redis service.
- Improved formatting in output messages for clarity.

close https://github.com/trpc-group/trpc-agent-go/issues/186