### PR TITLE
{memory, examples}: introduce custom instruction builder for memory services

### DIFF
--- a/agent/llmagent/extras_test.go
+++ b/agent/llmagent/extras_test.go
@@ -343,6 +343,10 @@ func (m *mockMemoryService) EnabledTools() []string {
 	return nil
 }
 
+func (m *mockMemoryService) BuildInstruction(enabledTools []string, defaultPrompt string) (string, bool) {
+	return "", false
+}
+
 func TestLLMAgent_WithEnableParallelTools_Option(t *testing.T) {
 	// Test that WithEnableParallelTools option sets the correct value
 	tests := []struct {

--- a/examples/memory/README.md
+++ b/examples/memory/README.md
@@ -240,6 +240,27 @@ memoryService := memoryinmemory.NewMemoryService(
 )
 ```
 
+### Custom Memory Instruction Prompt
+
+You can provide a custom memory instruction prompt builder at service creation. The framework generates a default English instruction based on enabled tools; your builder can wrap or replace that default:
+
+```go
+memoryService := memoryinmemory.NewMemoryService(
+    memoryinmemory.WithInstructionBuilder(func(enabledTools []string, defaultPrompt string) string {
+        header := "[Memory Instruction] Follow these guidelines to manage user memories.\n\n"
+        // Example A: wrap the default content
+        return header + defaultPrompt
+        // Example B: replace with your own content
+        // return fmt.Sprintf("[Memory Instruction] Tools available: %s\n...", strings.Join(enabledTools, ", "))
+    }),
+)
+```
+
+Notes:
+
+- Enabled tools: the set of memory tools currently active for your service. By default, `memory_add`, `memory_update`, `memory_search`, and `memory_load` are enabled; `memory_delete` and `memory_clear` are disabled. Control them with `WithToolEnabled(...)`. The builder’s `enabledTools` argument reflects this list.
+- The default prompt already includes tool-specific guidance; your builder receives it via `defaultPrompt`.
+
 ```go
 // Redis service: enable delete tool.
 memoryService, err := memoryredis.NewService(

--- a/examples/memory/main.go
+++ b/examples/memory/main.go
@@ -116,7 +116,14 @@ func (c *memoryChat) setup(_ context.Context) error {
 			return fmt.Errorf("failed to create redis memory service: %w", err)
 		}
 	default: // inmemory
-		memoryService = memoryinmemory.NewMemoryService()
+		memoryService = memoryinmemory.NewMemoryService(
+			// Provide a custom instruction builder for memory service.
+			// The framework generates a default memory instruction based on enabled tools.
+			// You can wrap or replace that default with your own guidance here.
+			memoryinmemory.WithInstructionBuilder(func(enabledTools []string, defaultPrompt string) string {
+				return "[Memory Instruction] Follow these guidelines to manage user memories.\n\n" + defaultPrompt
+			}),
+		)
 	}
 
 	// Setup identifiers first.

--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -72,8 +72,8 @@ func GenerateInstruction(memoryService memory.Service) string {
 	// Get enabled memory tools from the service.
 	enabledTools := getEnabledMemoryTools(memoryService)
 
-	// Generate dynamic instruction based on enabled tools.
-	instruction := `You have access to memory tools to provide personalized assistance. 
+	// Generate default dynamic instruction based on enabled tools.
+	defaultInstruction := `You have access to memory tools to provide personalized assistance. 
 
 IMPORTANT: When users share personal information about themselves (name, preferences, experiences, etc.), 
 ALWAYS use memory_add to remember this information. 
@@ -91,29 +91,29 @@ Examples of when to use memory_add:
 		case memory.AddToolName:
 			// Already covered in the main instruction.
 		case memory.SearchToolName:
-			instruction += `
+			defaultInstruction += `
 
 When users ask about themselves or their preferences, use memory_search to find relevant information.`
 		case memory.LoadToolName:
-			instruction += `
+			defaultInstruction += `
 
 When users ask 'tell me about myself' or similar, use memory_load to get an overview.`
 		case memory.UpdateToolName:
-			instruction += `
+			defaultInstruction += `
 
 When users want to update existing information, use memory_update with the memory_id.`
 		case memory.DeleteToolName:
-			instruction += `
+			defaultInstruction += `
 
 When users want to remove specific memories, use memory_delete with the memory_id.`
 		case memory.ClearToolName:
-			instruction += `
+			defaultInstruction += `
 
 When users want to clear all their memories, use memory_clear to remove all stored information.`
 		}
 	}
 
-	instruction += `
+	defaultInstruction += `
 
 Available memory tools: ` + strings.Join(enabledTools, ", ") + `.
 
@@ -121,5 +121,14 @@ Be helpful, conversational, and proactive about remembering user information.
 Always strive to create memories that capture the essence of what the user shares, 
 making future interactions more personalized and contextually relevant.`
 
-	return instruction
+	// If the service provides a custom instruction builder, use it.
+	if memoryService != nil {
+		if builtInstruction, ok := memoryService.BuildInstruction(
+			enabledTools, defaultInstruction,
+		); ok && builtInstruction != "" {
+			return builtInstruction
+		}
+	}
+
+	return defaultInstruction
 }

--- a/memory/inmemory/in_memory_memory_service.go
+++ b/memory/inmemory/in_memory_memory_service.go
@@ -55,6 +55,8 @@ type serviceOpts struct {
 	toolCreators map[string]memory.ToolCreator
 	// enabledTools are the names of tools to enable.
 	enabledTools map[string]bool
+	// instructionBuilder builds the memory instruction string from enabled tools and default prompt.
+	instructionBuilder func(enabledTools []string, defaultPrompt string) string
 }
 
 // MemoryService is an in-memory implementation of memory.Service.
@@ -129,6 +131,26 @@ func WithToolEnabled(toolName string, enabled bool) ServiceOpt {
 		}
 		opts.enabledTools[toolName] = enabled
 	}
+}
+
+// WithInstructionBuilder sets a custom instruction builder used by internal GenerateInstruction.
+// The builder receives enabled tool names and the framework's default prompt, and should return the final prompt.
+func WithInstructionBuilder(builder func(enabledTools []string, defaultPrompt string) string) ServiceOpt {
+	return func(opts *serviceOpts) {
+		opts.instructionBuilder = builder
+	}
+}
+
+// BuildInstruction allows the internal memory package to obtain a customized instruction if provided.
+// Returns (prompt, true) when custom builder is configured; otherwise ("", false).
+func (s *MemoryService) BuildInstruction(enabledTools []string, defaultPrompt string) (string, bool) {
+	s.mu.RLock()
+	builder := s.opts.instructionBuilder
+	s.mu.RUnlock()
+	if builder == nil {
+		return "", false
+	}
+	return builder(enabledTools, defaultPrompt), true
 }
 
 // getAppMemories gets or creates app memories for the given app name.

--- a/memory/inmemory/in_memory_memory_service_test.go
+++ b/memory/inmemory/in_memory_memory_service_test.go
@@ -13,9 +13,11 @@ package inmemory
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 
+	imemory "trpc.group/trpc-go/trpc-agent-go/internal/memory"
 	"trpc.group/trpc-go/trpc-agent-go/memory"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
@@ -431,6 +433,33 @@ func TestMemoryService_Tools(t *testing.T) {
 	tools = service.Tools()
 	if len(tools) != 0 {
 		t.Errorf("expected no tools when all disabled, got %d", len(tools))
+	}
+}
+
+func TestWithInstructionBuilder_AndGenerateInstruction(t *testing.T) {
+	// Create a service with a custom instruction builder.
+	svc := NewMemoryService(
+		WithInstructionBuilder(func(enabledTools []string, defaultPrompt string) string {
+			if len(enabledTools) == 0 {
+				t.Fatalf("expected enabled tools to be non-empty")
+			}
+			if !strings.Contains(defaultPrompt, "Available memory tools:") {
+				t.Fatalf("expected default prompt to contain tools list")
+			}
+			return "TEST_BUILDER_PROMPT"
+		}),
+	)
+
+	// Ensure default tools exist so enabledTools is non-empty.
+	tools := svc.Tools()
+	if len(tools) == 0 {
+		t.Fatalf("expected default tools to be enabled")
+	}
+
+	// Call the shared instruction generator.
+	got := imemory.GenerateInstruction(svc)
+	if got != "TEST_BUILDER_PROMPT" {
+		t.Fatalf("expected builder prompt to be used, got: %q", got)
 	}
 }
 

--- a/memory/inmemory/in_memory_memory_service_test.go
+++ b/memory/inmemory/in_memory_memory_service_test.go
@@ -463,6 +463,26 @@ func TestWithInstructionBuilder_AndGenerateInstruction(t *testing.T) {
 	}
 }
 
+func TestGenerateInstruction_DefaultWhenNoBuilder(t *testing.T) {
+	// Create a service WITHOUT a custom instruction builder.
+	svc := NewMemoryService()
+
+	// Ensure default tools exist so enabledTools is non-empty.
+	tools := svc.Tools()
+	if len(tools) == 0 {
+		t.Fatalf("expected default tools to be enabled")
+	}
+
+	// Call the shared instruction generator. Since builder is nil, it should use default.
+	got := imemory.GenerateInstruction(svc)
+	if !strings.Contains(got, "You have access to memory tools") {
+		t.Fatalf("expected default instruction content, got: %q", got)
+	}
+	if !strings.Contains(got, "Available memory tools:") {
+		t.Fatalf("expected tools list in default instruction, got: %q", got)
+	}
+}
+
 // mockTool implements tool.Tool for testing.
 type mockTool struct{ name string }
 

--- a/memory/memory.go
+++ b/memory/memory.go
@@ -58,6 +58,10 @@ type Service interface {
 
 	// Tools returns the list of available memory tools.
 	Tools() []tool.Tool
+
+	// BuildInstruction allows the service to customize the memory instruction prompt.
+	// If ok is false, callers should use the provided defaultPrompt.
+	BuildInstruction(enabledTools []string, defaultPrompt string) (prompt string, ok bool)
 }
 
 // ToolCreator creates a tool with a given memory service.

--- a/memory/redis/redis_memory_options.go
+++ b/memory/redis/redis_memory_options.go
@@ -23,6 +23,9 @@ type ServiceOpts struct {
 	toolCreators map[string]memory.ToolCreator
 	enabledTools map[string]bool
 	extraOptions []interface{}
+
+	// Instruction builder used to customize memory instruction.
+	instructionBuilder func(enabledTools []string, defaultPrompt string) string
 }
 
 // ServiceOpt is the option for the redis memory service.
@@ -80,5 +83,13 @@ func WithToolEnabled(toolName string, enabled bool) ServiceOpt {
 func WithExtraOptions(extraOptions ...interface{}) ServiceOpt {
 	return func(opts *ServiceOpts) {
 		opts.extraOptions = append(opts.extraOptions, extraOptions...)
+	}
+}
+
+// WithInstructionBuilder sets a custom instruction builder used by internal GenerateInstruction.
+// The builder receives enabled tool names and the framework's default prompt, and should return the final prompt.
+func WithInstructionBuilder(builder func(enabledTools []string, defaultPrompt string) string) ServiceOpt {
+	return func(opts *ServiceOpts) {
+		opts.instructionBuilder = builder
 	}
 }

--- a/memory/redis/redis_memory_service.go
+++ b/memory/redis/redis_memory_service.go
@@ -293,3 +293,13 @@ func generateMemoryID(mem *memory.Memory) string {
 func getUserMemKey(userKey memory.UserKey) string {
 	return fmt.Sprintf("mem:{%s}:%s", userKey.AppName, userKey.UserID)
 }
+
+// BuildInstruction allows the internal memory package to obtain a customized instruction if provided.
+// Returns (prompt, true) when custom builder is configured; otherwise ("", false).
+func (s *Service) BuildInstruction(enabledTools []string, defaultPrompt string) (string, bool) {
+	builder := s.opts.instructionBuilder
+	if builder == nil {
+		return "", false
+	}
+	return builder(enabledTools, defaultPrompt), true
+}

--- a/memory/redis/redis_memory_service_test.go
+++ b/memory/redis/redis_memory_service_test.go
@@ -444,6 +444,20 @@ func TestWithInstructionBuilder_AndGenerateInstruction_Redis(t *testing.T) {
 	}
 }
 
+func TestGenerateInstruction_DefaultWhenNoBuilder_Redis(t *testing.T) {
+	svc, cleanup := newTestService(t)
+	defer cleanup()
+
+	// No builder is set. The generator should return default instruction.
+	got := imemory.GenerateInstruction(svc)
+	if !strings.Contains(got, "You have access to memory tools") {
+		t.Fatalf("expected default instruction content for redis, got: %q", got)
+	}
+	if !strings.Contains(got, "Available memory tools:") {
+		t.Fatalf("expected tools list in default instruction for redis, got: %q", got)
+	}
+}
+
 func TestService_InvalidKeys(t *testing.T) {
 	svc, cleanup := newTestService(t)
 	defer cleanup()

--- a/memory/redis/redis_memory_service_test.go
+++ b/memory/redis/redis_memory_service_test.go
@@ -10,6 +10,7 @@ package redis
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	imemory "trpc.group/trpc-go/trpc-agent-go/internal/memory"
 	"trpc.group/trpc-go/trpc-agent-go/memory"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
@@ -408,6 +410,38 @@ func TestService_Tools_DefaultEnabled(t *testing.T) {
 	assert.True(t, names[memory.LoadToolName])
 	assert.False(t, names[memory.DeleteToolName])
 	assert.False(t, names[memory.ClearToolName])
+}
+
+func TestWithInstructionBuilder_AndGenerateInstruction_Redis(t *testing.T) {
+	svc, cleanup := newTestService(t)
+	defer cleanup()
+
+	// Recreate service with builder (need to construct new service due to options on creation)
+	url, _ := setupTestRedis(t)
+	var err error
+	svc, err = NewService(
+		WithRedisClientURL(url),
+		WithInstructionBuilder(func(enabledTools []string, defaultPrompt string) string {
+			if len(enabledTools) == 0 {
+				t.Fatalf("expected enabled tools to be non-empty")
+			}
+			if !strings.Contains(defaultPrompt, "Available memory tools:") {
+				t.Fatalf("expected default prompt to contain tools list")
+			}
+			return "TEST_BUILDER_PROMPT_REDIS"
+		}),
+	)
+	require.NoError(t, err)
+
+	// Verify defaults provide tools
+	tools := svc.Tools()
+	require.NotEmpty(t, tools)
+
+	// Ensure the internal generator uses the builder
+	got := imemory.GenerateInstruction(svc)
+	if got != "TEST_BUILDER_PROMPT_REDIS" {
+		t.Fatalf("expected builder prompt to be used for redis, got: %q", got)
+	}
 }
 
 func TestService_InvalidKeys(t *testing.T) {

--- a/memory/tool/tool_test.go
+++ b/memory/tool/tool_test.go
@@ -120,6 +120,10 @@ func (m *mockMemoryService) Tools() []tool.Tool {
 	return []tool.Tool{}
 }
 
+func (m *mockMemoryService) BuildInstruction(enabledTools []string, defaultPrompt string) (string, bool) {
+	return "", false
+}
+
 // createMockContext creates a mock context with session information.
 func createMockContext(appName, userID string) context.Context {
 	mockSession := &session.Session{


### PR DESCRIPTION
- Added a new `BuildInstruction` method to the memory service interface, allowing customization of memory instruction prompts based on enabled tools.
- Implemented the custom instruction builder in both in-memory and Redis memory services.
- Updated tests to validate the functionality of the custom instruction builder.
- Enhanced README documentation to include examples of using the custom instruction builder.