### PR TITLE
{agent, runner}: wrap invocation context in runner

### DIFF
--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -539,10 +539,6 @@ func registerTools(tools []tool.Tool, toolSets []tool.ToolSet, kb knowledge.Know
 // Run implements the agent.Agent interface.
 // It executes the LLM agent flow and returns a channel of events.
 func (a *LLMAgent) Run(ctx context.Context, invocation *agent.Invocation) (<-chan *event.Event, error) {
-	// Ensure the invocation can be accessed by downstream components (e.g., tools)
-	// by embedding it into the context. This is necessary for tools like
-	// transfer_to_agent that rely on agent.InvocationFromContext(ctx).
-	ctx = agent.NewContextWithInvocation(ctx, invocation)
 	ctx, span := trace.Tracer.Start(ctx, fmt.Sprintf("agent_run [%s]", a.name))
 	defer span.End()
 	// Ensure the invocation has a model set.

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -154,6 +154,11 @@ func (r *runner) Run(
 		EventCompletionCh: eventCompletionCh,
 	}
 
+	// Ensure the invocation can be accessed by downstream components (e.g., tools)
+	// by embedding it into the context. This is necessary for tools like
+	// transfer_to_agent that rely on agent.InvocationFromContext(ctx).
+	ctx = agent.NewContextWithInvocation(ctx, invocation)
+
 	// Run the agent and get the event channel.
 	agentEventCh, err := r.agent.Run(ctx, invocation)
 	if err != nil {


### PR DESCRIPTION
- Implemented tests to verify that both GraphAgent and LLMAgent can access invocation from context when called through the runner, ensuring functionality after removing duplicate injection.
- Enhanced the runner to ensure invocation is embedded in the context for downstream components.
- Added a mock agent in the runner tests to validate invocation injection.