### PR TITLE
example/debugserver: refactor to support command-line model selection and custom address

### DIFF
--- a/examples/debugserver/README.md
+++ b/examples/debugserver/README.md
@@ -5,8 +5,8 @@ connect it to [ADK Web](https://github.com/google/adk-web).
 
 ## Prerequisites
 
-* Go 1.24+
-* NodeJS & npm (for running ADK Web UI)
+- Go 1.21+
+- NodeJS & npm (for running ADK Web UI)
 
 ## Running the Server
 
@@ -14,9 +14,23 @@ connect it to [ADK Web](https://github.com/google/adk-web).
 # From repository root
 cd examples/debugserver
 
-# Start the server on :8080 (default model: deepseek-chat)
-go run . -addr :8080
+# Start the server with default settings (model: deepseek-chat, addr: :8080)
+go run .
+
+# Start the server on custom port
+go run . -addr :9090
+
+# Start the server with different model
+go run . -model gpt-4
+
+# Start the server with custom model and port
+go run . -model gpt-4 -addr :9090
 ```
+
+### Command Line Options
+
+- `-model`: Name of the model to use (default: "deepseek-chat")
+- `-addr`: Listen address (default: ":8080")
 
 ## Running ADK Web UI
 
@@ -31,11 +45,11 @@ npm install
 npm run serve --backend=http://localhost:8080 -- --port=4200 --host=localhost
 ```
 
-Open <http://localhost:4200> in your browser.  In the left sidebar choose the
-`assistant` application, create a new session and start chatting.  Messages will be
+Open <http://localhost:4200> in your browser. In the left sidebar choose the
+`assistant` application, create a new session and start chatting. Messages will be
 sent to the Go server which streams responses in real-time via the `/run_sse`
 endpoint.
 
 ---
 
-Feel free to replace the agent logic or add more tools in `main.go` as needed. 
+Feel free to replace the agent logic in `main.go` or add more tools in `tools.go` as needed.

--- a/examples/debugserver/tools.go
+++ b/examples/debugserver/tools.go
@@ -1,0 +1,121 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package main
+
+import (
+	"context"
+	"strings"
+	"time"
+)
+
+// Constants for supported calculator operations.
+const (
+	opAdd      = "add"
+	opSubtract = "subtract"
+	opMultiply = "multiply"
+	opDivide   = "divide"
+)
+
+// calculatorArgs holds the input for the calculator tool.
+type calculatorArgs struct {
+	Operation string  `json:"operation" jsonschema:"description=The operation to perform,enum=add,enum=subtract,enum=multiply,enum=divide,required"`
+	A         float64 `json:"a" jsonschema:"description=First number operand,required"`
+	B         float64 `json:"b" jsonschema:"description=Second number operand,required"`
+}
+
+// calculatorResult holds the output for the calculator tool.
+type calculatorResult struct {
+	Operation string  `json:"operation"`
+	A         float64 `json:"a"`
+	B         float64 `json:"b"`
+	Result    float64 `json:"result"`
+}
+
+// timeArgs holds the input for the time tool.
+type timeArgs struct {
+	Timezone string `json:"timezone" jsonschema:"description=Timezone (UTC, EST, PST, CST) or leave empty for local,required"`
+}
+
+// timeResult holds the output for the time tool.
+type timeResult struct {
+	Timezone string `json:"timezone"`
+	Time     string `json:"time"`
+	Date     string `json:"date"`
+	Weekday  string `json:"weekday"`
+}
+
+// Calculator tool implementation.
+// calculate performs the requested mathematical operation.
+// It supports add, subtract, multiply, and divide operations.
+func calculate(ctx context.Context, args calculatorArgs) (calculatorResult, error) {
+	var result float64
+	// Select operation based on input.
+	switch strings.ToLower(args.Operation) {
+	case opAdd:
+		result = args.A + args.B
+	case opSubtract:
+		result = args.A - args.B
+	case opMultiply:
+		result = args.A * args.B
+	case opDivide:
+		if args.B != 0 {
+			result = args.A / args.B
+		}
+	}
+	return calculatorResult{
+		Operation: args.Operation,
+		A:         args.A,
+		B:         args.B,
+		Result:    result,
+	}, nil
+}
+
+// Time tool implementation.
+// getCurrentTime returns the current time for the specified timezone.
+// If the timezone is invalid or empty, it defaults to local time.
+func getCurrentTime(ctx context.Context, args timeArgs) (timeResult, error) {
+	loc := time.Local
+	zone := args.Timezone
+	// Attempt to load the specified timezone.
+	if zone != "" {
+		var err error
+		loc, err = time.LoadLocation(zone)
+		if err != nil {
+			loc = time.Local
+		}
+	}
+	now := time.Now().In(loc)
+	return timeResult{
+		Timezone: loc.String(),
+		Time:     now.Format("15:04:05"),
+		Date:     now.Format("2006-01-02"),
+		Weekday:  now.Weekday().String(),
+	}, nil
+}
+
+// intPtr returns a pointer to the given int value.
+func intPtr(i int) *int {
+	return &i
+}
+
+// floatPtr returns a pointer to the given float64 value.
+func floatPtr(f float64) *float64 {
+	return &f
+}
+
+// This example demonstrates how to integrate tRPC agent orchestration
+// with LLM-based tools, providing a simple HTTP server for manual
+// testing. It is intended as a reference for developers looking to build
+// custom LLM agents with tool support in Go.
+//
+// The calculator tool supports basic arithmetic operations, while the
+// time tool provides current time information for a given timezone.
+//
+// The code is structured for clarity and ease of extension.


### PR DESCRIPTION
- Added command-line flags for specifying the model and listen address in main.go.
- Updated README.md with new usage instructions for starting the server with different models and ports.
- Introduced tools.go for calculator and time functionalities, enhancing the server's capabilities.

close https://github.com/trpc-group/trpc-agent-go/issues/178