### PR TITLE
knowledge/vectorstore: refactor any and improve error handling

### DIFF
--- a/knowledge/vectorstore/inmemory/inmemory.go
+++ b/knowledge/vectorstore/inmemory/inmemory.go
@@ -12,12 +12,22 @@ package inmemory
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"sync"
 
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/document"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore"
+)
+
+var (
+	// errDocumentCannotBeNil is the error when the document is nil.
+	errDocumentCannotBeNil = errors.New("document cannot be nil")
+	// errDocumentIDCannotBeEmpty is the error when the document ID is empty.
+	errDocumentIDCannotBeEmpty = errors.New("document ID cannot be empty")
+	// errEmbeddingCannotBeEmpty is the error when the embedding is empty.
+	errEmbeddingCannotBeEmpty = errors.New("embedding cannot be empty")
 )
 
 // VectorStore implements vectorstore.VectorStore interface using in-memory storage.
@@ -48,13 +58,13 @@ func New(opts ...Option) *VectorStore {
 // Add implements vectorstore.VectorStore interface.
 func (vs *VectorStore) Add(ctx context.Context, doc *document.Document, embedding []float64) error {
 	if doc == nil {
-		return fmt.Errorf("document cannot be nil")
+		return errDocumentCannotBeNil
 	}
 	if doc.ID == "" {
-		return fmt.Errorf("document ID cannot be empty")
+		return errDocumentIDCannotBeEmpty
 	}
 	if len(embedding) == 0 {
-		return fmt.Errorf("embedding cannot be empty")
+		return errEmbeddingCannotBeEmpty
 	}
 
 	vs.mutex.Lock()
@@ -70,7 +80,7 @@ func (vs *VectorStore) Add(ctx context.Context, doc *document.Document, embeddin
 // Get implements vectorstore.VectorStore interface.
 func (vs *VectorStore) Get(ctx context.Context, id string) (*document.Document, []float64, error) {
 	if id == "" {
-		return nil, nil, fmt.Errorf("document ID cannot be empty")
+		return nil, nil, errDocumentIDCannotBeEmpty
 	}
 
 	vs.mutex.RLock()
@@ -95,13 +105,13 @@ func (vs *VectorStore) Get(ctx context.Context, id string) (*document.Document, 
 // Update implements vectorstore.VectorStore interface.
 func (vs *VectorStore) Update(ctx context.Context, doc *document.Document, embedding []float64) error {
 	if doc == nil {
-		return fmt.Errorf("document cannot be nil")
+		return errDocumentCannotBeNil
 	}
 	if doc.ID == "" {
-		return fmt.Errorf("document ID cannot be empty")
+		return errDocumentIDCannotBeEmpty
 	}
 	if len(embedding) == 0 {
-		return fmt.Errorf("embedding cannot be empty")
+		return errEmbeddingCannotBeEmpty
 	}
 
 	vs.mutex.Lock()
@@ -121,7 +131,7 @@ func (vs *VectorStore) Update(ctx context.Context, doc *document.Document, embed
 // Delete implements vectorstore.VectorStore interface.
 func (vs *VectorStore) Delete(ctx context.Context, id string) error {
 	if id == "" {
-		return fmt.Errorf("document ID cannot be empty")
+		return errDocumentIDCannotBeEmpty
 	}
 
 	vs.mutex.Lock()
@@ -140,10 +150,10 @@ func (vs *VectorStore) Delete(ctx context.Context, id string) error {
 // Search implements vectorstore.VectorStore interface.
 func (vs *VectorStore) Search(ctx context.Context, query *vectorstore.SearchQuery) (*vectorstore.SearchResult, error) {
 	if query == nil {
-		return nil, fmt.Errorf("query cannot be nil")
+		return nil, errors.New("query cannot be nil")
 	}
 	if len(query.Vector) == 0 {
-		return nil, fmt.Errorf("query vector cannot be empty")
+		return nil, errors.New("query vector cannot be empty")
 	}
 
 	vs.mutex.RLock()

--- a/knowledge/vectorstore/inmemory/inmemory_test.go
+++ b/knowledge/vectorstore/inmemory/inmemory_test.go
@@ -29,7 +29,7 @@ func TestVectorStore_CRUDAndSearch(t *testing.T) {
 	doc1 := &document.Document{
 		ID:      "doc1",
 		Content: "hello world",
-		Metadata: map[string]interface{}{
+		Metadata: map[string]any{
 			"lang": "en",
 		},
 	}
@@ -48,7 +48,7 @@ func TestVectorStore_CRUDAndSearch(t *testing.T) {
 	updatedDoc := &document.Document{
 		ID:      "doc1",
 		Content: "hello updated",
-		Metadata: map[string]interface{}{
+		Metadata: map[string]any{
 			"lang": "en",
 		},
 	}
@@ -61,7 +61,7 @@ func TestVectorStore_CRUDAndSearch(t *testing.T) {
 		Limit:    5,
 		MinScore: 0.0,
 		Filter: &vectorstore.SearchFilter{
-			Metadata: map[string]interface{}{
+			Metadata: map[string]any{
 				"lang": "en",
 			},
 		},
@@ -105,16 +105,17 @@ func TestSortByScore(t *testing.T) {
 }
 
 func TestMatchesFilter(t *testing.T) {
+	ctx := context.Background()
 	store := New()
 	doc := &document.Document{
 		ID:      "doc1",
 		Content: "data",
-		Metadata: map[string]interface{}{
+		Metadata: map[string]any{
 			"type": "test",
 		},
 	}
 	embedding := []float64{0.1, 0.2, 0.3}
-	require.NoError(t, store.Add(nil, doc, embedding))
+	require.NoError(t, store.Add(ctx, doc, embedding))
 
 	// Match by ID
 	filterByID := &vectorstore.SearchFilter{IDs: []string{"doc1"}}
@@ -125,27 +126,28 @@ func TestMatchesFilter(t *testing.T) {
 	require.False(t, store.matchesFilter("doc1", filterWrongID))
 
 	// Match by metadata
-	filterByMeta := &vectorstore.SearchFilter{Metadata: map[string]interface{}{"type": "test"}}
+	filterByMeta := &vectorstore.SearchFilter{Metadata: map[string]any{"type": "test"}}
 	require.True(t, store.matchesFilter("doc1", filterByMeta))
 
 	// Non-matching metadata
-	filterWrongMeta := &vectorstore.SearchFilter{Metadata: map[string]interface{}{"type": "prod"}}
+	filterWrongMeta := &vectorstore.SearchFilter{Metadata: map[string]any{"type": "prod"}}
 	require.False(t, store.matchesFilter("doc1", filterWrongMeta))
 }
 
 func TestVectorStore_ErrorPathsAndClose(t *testing.T) {
+	ctx := context.Background()
 	store := New()
 
 	// Get non-existent ID.
-	_, _, err := store.Get(nil, "missing")
+	_, _, err := store.Get(ctx, "missing")
 	require.Error(t, err)
 
 	// Delete non-existent ID.
-	err = store.Delete(nil, "missing")
+	err = store.Delete(ctx, "missing")
 	require.Error(t, err)
 
 	// Search with empty vector.
-	_, err = store.Search(nil, &vectorstore.SearchQuery{Vector: []float64{}})
+	_, err = store.Search(ctx, &vectorstore.SearchQuery{Vector: []float64{}})
 	require.Error(t, err)
 
 	// Close store.

--- a/knowledge/vectorstore/pgvector/pgvector_option.go
+++ b/knowledge/vectorstore/pgvector/pgvector_option.go
@@ -27,6 +27,7 @@ type options struct {
 	language     string  // Default: english, if you install zhparser or jieba, you can set it to your configuration
 }
 
+// defaultOptions is the default options for pgvector.
 var defaultOptions = options{
 	host:           "localhost",
 	port:           5432,
@@ -43,70 +44,70 @@ var defaultOptions = options{
 // Option is the option for pgvector.
 type Option func(*options)
 
-// WithHost sets the PostgreSQL host
+// WithHost sets the PostgreSQL host.
 func WithHost(host string) Option {
 	return func(o *options) {
 		o.host = host
 	}
 }
 
-// WithPort sets the PostgreSQL port
+// WithPort sets the PostgreSQL port.
 func WithPort(port int) Option {
 	return func(o *options) {
 		o.port = port
 	}
 }
 
-// WithUser sets the username for authentication
+// WithUser sets the username for authentication.
 func WithUser(user string) Option {
 	return func(o *options) {
 		o.user = user
 	}
 }
 
-// WithPassword sets the password for authentication
+// WithPassword sets the password for authentication.
 func WithPassword(password string) Option {
 	return func(o *options) {
 		o.password = password
 	}
 }
 
-// WithDatabase sets the database name
+// WithDatabase sets the database name.
 func WithDatabase(database string) Option {
 	return func(o *options) {
 		o.database = database
 	}
 }
 
-// WithTable sets the table name
+// WithTable sets the table name.
 func WithTable(table string) Option {
 	return func(o *options) {
 		o.table = table
 	}
 }
 
-// WithIndexDimension sets the vector dimension for the index
+// WithIndexDimension sets the vector dimension for the index.
 func WithIndexDimension(dimension int) Option {
 	return func(o *options) {
 		o.indexDimension = dimension
 	}
 }
 
-// WithSSLMode sets the SSL mode for connection
+// WithSSLMode sets the SSL mode for connection.
 func WithSSLMode(sslMode string) Option {
 	return func(o *options) {
 		o.sslMode = sslMode
 	}
 }
 
-// WithEnableTSVector sets the enable text search vector
+// WithEnableTSVector sets the enable text search vector.
 func WithEnableTSVector(enableTSVector bool) Option {
 	return func(o *options) {
 		o.enableTSVector = enableTSVector
 	}
 }
 
-// WithHybridSearchWeights sets the weights for hybrid search scoring
+// WithHybridSearchWeights sets the weights for hybrid search scoring.
 // vectorWeight: Weight for vector similarity (0.0-1.0)
 // textWeight: Weight for text relevance (0.0-1.0)
 // Note: weights will be normalized to sum to 1.0
@@ -125,7 +126,7 @@ func WithHybridSearchWeights(vectorWeight, textWeight float64) Option {
 	}
 }
 
-// WithLanguageExtension sets the language extension for the index
+// WithLanguageExtension sets the language extension for the index.
 func WithLanguageExtension(languageExtension string) Option {
 	return func(o *options) {
 		o.language = languageExtension

--- a/knowledge/vectorstore/pgvector/pgvector_search_test.go
+++ b/knowledge/vectorstore/pgvector/pgvector_search_test.go
@@ -21,19 +21,19 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore"
 )
 
-// PgVectorSearchTestSuite contains the search test suite for pgvector
+// PgVectorSearchTestSuite contains the search test suite for pgvector.
 type PgVectorSearchTestSuite struct {
 	suite.Suite
 	vs       *VectorStore
 	testDocs map[string]*document.Document // Store test documents for validation
 }
 
-// Run the search test suite
+// Run the search test suite.
 func TestPgVectorSearchSuite(t *testing.T) {
 	suite.Run(t, new(PgVectorSearchTestSuite))
 }
 
-// SetupSuite runs once before all tests
+// SetupSuite runs once before all tests.
 func (suite *PgVectorSearchTestSuite) SetupSuite() {
 	if host == "" {
 		suite.T().Skip("Skipping PgVector tests: PGVECTOR_HOST not set")
@@ -64,7 +64,7 @@ func (suite *PgVectorSearchTestSuite) SetupSuite() {
 	suite.testDocs = make(map[string]*document.Document)
 }
 
-// TearDownSuite runs once after all search tests
+// TearDownSuite runs once after all search tests.
 func (suite *PgVectorSearchTestSuite) TearDownSuite() {
 	if suite.vs != nil {
 		// Clean up test table
@@ -74,14 +74,14 @@ func (suite *PgVectorSearchTestSuite) TearDownSuite() {
 	}
 }
 
-// SetupTest runs before each search test
+// SetupTest runs before each search test.
 func (suite *PgVectorSearchTestSuite) SetupTest() {
 	// Clean up table data before each test
 	_, err := suite.vs.pool.Exec(context.Background(), "DELETE FROM "+table)
 	suite.NoError(err)
 }
 
-// validateSearchResult validates a single search result
+// validateSearchResult validates a single search result.
 func (suite *PgVectorSearchTestSuite) validateSearchResult(result *vectorstore.ScoredDocument) {
 	// Validate document structure
 	suite.NotNil(result.Document, "Document should not be nil")
@@ -99,7 +99,7 @@ func (suite *PgVectorSearchTestSuite) validateSearchResult(result *vectorstore.S
 	}
 }
 
-// validateDocumentContent compares returned document with original
+// validateDocumentContent compares returned document with original.
 func (suite *PgVectorSearchTestSuite) validateDocumentContent(expected, actual *document.Document) {
 	suite.Equal(expected.ID, actual.ID, "Document ID should match")
 	suite.Equal(expected.Name, actual.Name, "Document Name should match")
@@ -118,8 +118,8 @@ func (suite *PgVectorSearchTestSuite) validateDocumentContent(expected, actual *
 	}
 }
 
-// compareMetadataValues provides flexible comparison for metadata values
-func (suite *PgVectorSearchTestSuite) compareMetadataValues(expected, actual interface{}) bool {
+// compareMetadataValues provides flexible comparison for metadata values.
+func (suite *PgVectorSearchTestSuite) compareMetadataValues(expected, actual any) bool {
 	// Direct equality check
 	if expected == actual {
 		return true
@@ -136,7 +136,7 @@ func (suite *PgVectorSearchTestSuite) compareMetadataValues(expected, actual int
 			return e == float64(a)
 		}
 	case []string:
-		if a, ok := actual.([]interface{}); ok {
+		if a, ok := actual.([]any); ok {
 			if len(e) != len(a) {
 				return false
 			}
@@ -151,7 +151,7 @@ func (suite *PgVectorSearchTestSuite) compareMetadataValues(expected, actual int
 	return false
 }
 
-// validateSearchResults validates the complete search result set
+// validateSearchResults validates the complete search result set.
 func (suite *PgVectorSearchTestSuite) validateSearchResults(results []*vectorstore.ScoredDocument, expectedMinCount int) {
 	suite.GreaterOrEqual(len(results), expectedMinCount,
 		"Should return at least %d results", expectedMinCount)
@@ -171,7 +171,7 @@ func (suite *PgVectorSearchTestSuite) validateSearchResults(results []*vectorsto
 	}
 }
 
-// validateKeywordRelevance checks if results are relevant to the keyword query
+// validateKeywordRelevance checks if results are relevant to the keyword query.
 func (suite *PgVectorSearchTestSuite) validateKeywordRelevance(results []*vectorstore.ScoredDocument, keywords []string) {
 	for _, result := range results {
 		hasRelevantContent := false
@@ -192,11 +192,11 @@ func (suite *PgVectorSearchTestSuite) validateKeywordRelevance(results []*vector
 	}
 }
 
-// TestSearchModes tests different search modes
+// TestSearchModes tests different search modes.
 func (suite *PgVectorSearchTestSuite) TestSearchModes() {
 	ctx := context.Background()
 
-	// Setup test data
+	// Setup test data.
 	testDocs := []struct {
 		doc       *document.Document
 		embedding []float64
@@ -206,7 +206,7 @@ func (suite *PgVectorSearchTestSuite) TestSearchModes() {
 				ID:      "doc1",
 				Name:    "Python Programming",
 				Content: "Python is a powerful programming language for data science and machine learning",
-				Metadata: map[string]interface{}{
+				Metadata: map[string]any{
 					"category": "programming",
 					"language": "python",
 					"level":    "beginner",
@@ -219,7 +219,7 @@ func (suite *PgVectorSearchTestSuite) TestSearchModes() {
 				ID:      "doc2",
 				Name:    "Go Development",
 				Content: "Go is a fast and efficient language for system programming and web development",
-				Metadata: map[string]interface{}{
+				Metadata: map[string]any{
 					"category": "programming",
 					"language": "go",
 					"level":    "intermediate",
@@ -232,7 +232,7 @@ func (suite *PgVectorSearchTestSuite) TestSearchModes() {
 				ID:      "doc3",
 				Name:    "Data Science Tutorial",
 				Content: "Learn data science fundamentals with Python and machine learning algorithms",
-				Metadata: map[string]interface{}{
+				Metadata: map[string]any{
 					"category": "tutorial",
 					"language": "python",
 					"level":    "advanced",
@@ -309,7 +309,7 @@ func (suite *PgVectorSearchTestSuite) TestSearchModes() {
 			name: "filter search",
 			query: &vectorstore.SearchQuery{
 				Filter: &vectorstore.SearchFilter{
-					Metadata: map[string]interface{}{
+					Metadata: map[string]any{
 						"category": "programming",
 					},
 				},
@@ -375,30 +375,30 @@ func (suite *PgVectorSearchTestSuite) TestSearchModes() {
 	}
 }
 
-// TestHybridSearchWeights tests hybrid search weight configuration
+// TestHybridSearchWeights tests hybrid search weight configuration.
 func (suite *PgVectorSearchTestSuite) TestHybridSearchWeights() {
 	ctx := context.Background()
 
-	// Add test document
+	// Add test document.
 	doc := &document.Document{
 		ID:      "weight_test",
 		Name:    "Weight Test Document",
 		Content: "This document tests hybrid search weight configuration with machine learning",
-		Metadata: map[string]interface{}{
+		Metadata: map[string]any{
 			"category": "test",
 		},
 	}
 	embedding := []float64{0.1, 0.2, 0.3}
 	err := suite.vs.Add(ctx, doc, embedding)
 	suite.NoError(err)
-	// Store for validation
+	// Store for validation.
 	suite.testDocs[doc.ID] = doc
 
 	testCases := []struct {
 		name         string
 		vectorWeight float64
 		textWeight   float64
-		expectNorm   bool // Whether weights should be normalized
+		expectNorm   bool // Whether weights should be normalized.
 	}{
 		{
 			name:         "default weights",
@@ -434,7 +434,7 @@ func (suite *PgVectorSearchTestSuite) TestHybridSearchWeights() {
 
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
-			// Create a new vector store with specific weights
+			// Create a new vector store with specific weights.
 			table := "test_weights_" + time.Now().Format("150405")
 			vs, err := New(
 				WithHost(host),
@@ -452,11 +452,11 @@ func (suite *PgVectorSearchTestSuite) TestHybridSearchWeights() {
 				vs.Close()
 			}()
 
-			// Add the same test document
+			// Add the same test document.
 			err = vs.Add(ctx, doc, embedding)
 			suite.NoError(err)
 
-			// Perform hybrid search
+			// Perform hybrid search.
 			query := &vectorstore.SearchQuery{
 				Vector:     []float64{0.1, 0.2, 0.3},
 				Query:      "machine learning",
@@ -469,27 +469,27 @@ func (suite *PgVectorSearchTestSuite) TestHybridSearchWeights() {
 			suite.NotNil(result, "Search result should not be nil")
 			suite.Len(result.Results, 1, "Should return exactly 1 result")
 
-			// Validate search results content
+			// Validate search results content.
 			if len(result.Results) > 0 {
 				resultDoc := result.Results[0]
 
-				// Validate document structure
+				// Validate document structure.
 				suite.NotNil(resultDoc.Document, "Document should not be nil")
 				suite.Equal(doc.ID, resultDoc.Document.ID, "Document ID should match")
 				suite.Equal(doc.Name, resultDoc.Document.Name, "Document name should match")
 				suite.Equal(doc.Content, resultDoc.Document.Content, "Document content should match")
 
-				// Validate score
+				// Validate score.
 				suite.Greater(resultDoc.Score, 0.0, "Score should be positive")
 				suite.LessOrEqual(resultDoc.Score, 1.0, "Score should not exceed 1.0")
 
-				// Validate keyword relevance
+				// Validate keyword relevance.
 				content := strings.ToLower(resultDoc.Document.Name + " " + resultDoc.Document.Content)
 				suite.True(strings.Contains(content, "machine") || strings.Contains(content, "learning"),
 					"Result should be relevant to search keywords")
 			}
 
-			// Verify weights are correctly applied
+			// Verify weights are correctly applied.
 			if tc.expectNorm {
 				// For normalized weights, just ensure search works
 				suite.Greater(result.Results[0].Score, 0.0, "Normalized weights should produce valid scores")
@@ -506,11 +506,11 @@ func (suite *PgVectorSearchTestSuite) TestHybridSearchWeights() {
 	}
 }
 
-// TestMetadataFiltering tests different metadata filtering approaches
+// TestMetadataFiltering tests different metadata filtering approaches.
 func (suite *PgVectorSearchTestSuite) TestMetadataFiltering() {
 	ctx := context.Background()
 
-	// Setup test data with various metadata types
+	// Setup test data with various metadata types.
 	testDocs := []struct {
 		doc       *document.Document
 		embedding []float64
@@ -520,7 +520,7 @@ func (suite *PgVectorSearchTestSuite) TestMetadataFiltering() {
 				ID:      "meta1",
 				Name:    "Document 1",
 				Content: "Content with integer metadata",
-				Metadata: map[string]interface{}{
+				Metadata: map[string]any{
 					"priority": 1,
 					"active":   true,
 					"score":    95.5,
@@ -534,7 +534,7 @@ func (suite *PgVectorSearchTestSuite) TestMetadataFiltering() {
 				ID:      "meta2",
 				Name:    "Document 2",
 				Content: "Content with different metadata",
-				Metadata: map[string]interface{}{
+				Metadata: map[string]any{
 					"priority": 2,
 					"active":   false,
 					"score":    87.2,
@@ -548,7 +548,7 @@ func (suite *PgVectorSearchTestSuite) TestMetadataFiltering() {
 				ID:      "meta3",
 				Name:    "Document 3",
 				Content: "Content with mixed metadata",
-				Metadata: map[string]interface{}{
+				Metadata: map[string]any{
 					"priority": 1,
 					"active":   true,
 					"score":    92.8,
@@ -559,23 +559,23 @@ func (suite *PgVectorSearchTestSuite) TestMetadataFiltering() {
 		},
 	}
 
-	// Add test documents
+	// Add test documents.
 	for _, td := range testDocs {
 		err := suite.vs.Add(ctx, td.doc, td.embedding)
 		suite.NoError(err)
-		// Store for validation
+		// Store for validation.
 		suite.testDocs[td.doc.ID] = td.doc
 	}
 
 	testCases := []struct {
 		name          string
-		filter        map[string]interface{}
+		filter        map[string]any
 		expectedCount int
 		expectedIDs   []string
 	}{
 		{
 			name: "integer filter",
-			filter: map[string]interface{}{
+			filter: map[string]any{
 				"priority": 1,
 			},
 			expectedCount: 2,
@@ -583,7 +583,7 @@ func (suite *PgVectorSearchTestSuite) TestMetadataFiltering() {
 		},
 		{
 			name: "boolean filter",
-			filter: map[string]interface{}{
+			filter: map[string]any{
 				"active": true,
 			},
 			expectedCount: 2,
@@ -591,7 +591,7 @@ func (suite *PgVectorSearchTestSuite) TestMetadataFiltering() {
 		},
 		{
 			name: "string filter",
-			filter: map[string]interface{}{
+			filter: map[string]any{
 				"category": "urgent",
 			},
 			expectedCount: 2,
@@ -599,7 +599,7 @@ func (suite *PgVectorSearchTestSuite) TestMetadataFiltering() {
 		},
 		{
 			name: "float filter",
-			filter: map[string]interface{}{
+			filter: map[string]any{
 				"score": 95.5,
 			},
 			expectedCount: 1,
@@ -607,7 +607,7 @@ func (suite *PgVectorSearchTestSuite) TestMetadataFiltering() {
 		},
 		{
 			name: "multiple filters",
-			filter: map[string]interface{}{
+			filter: map[string]any{
 				"priority": 1,
 				"active":   true,
 			},
@@ -616,7 +616,7 @@ func (suite *PgVectorSearchTestSuite) TestMetadataFiltering() {
 		},
 		{
 			name: "no match filter",
-			filter: map[string]interface{}{
+			filter: map[string]any{
 				"priority": 999,
 			},
 			expectedCount: 0,
@@ -641,12 +641,12 @@ func (suite *PgVectorSearchTestSuite) TestMetadataFiltering() {
 			suite.Len(result.Results, tc.expectedCount,
 				"Should return exactly %d results", tc.expectedCount)
 
-			// Validate search results
+			// Validate search results.
 			if len(result.Results) > 0 {
 				suite.validateSearchResults(result.Results, tc.expectedCount)
 			}
 
-			// Verify the correct documents are returned
+			// Verify the correct documents are returned.
 			actualIDs := make([]string, len(result.Results))
 			for i, scored := range result.Results {
 				actualIDs[i] = scored.Document.ID
@@ -654,7 +654,7 @@ func (suite *PgVectorSearchTestSuite) TestMetadataFiltering() {
 			suite.ElementsMatch(tc.expectedIDs, actualIDs,
 				"Should return expected document IDs")
 
-			// Validate that all results match the filter criteria
+			// Validate that all results match the filter criteria.
 			for _, result := range result.Results {
 				for filterKey, filterValue := range tc.filter {
 					actualValue, exists := result.Document.Metadata[filterKey]
@@ -667,7 +667,7 @@ func (suite *PgVectorSearchTestSuite) TestMetadataFiltering() {
 	}
 }
 
-// TestSearchErrorHandling tests search-related error conditions
+// TestSearchErrorHandling tests search-related error conditions.
 func (suite *PgVectorSearchTestSuite) TestSearchErrorHandling() {
 	ctx := context.Background()
 
@@ -748,11 +748,11 @@ func (suite *PgVectorSearchTestSuite) TestSearchErrorHandling() {
 	}
 }
 
-// TestAdvancedSearchScenarios tests more complex search scenarios
+// TestAdvancedSearchScenarios tests more complex search scenarios.
 func (suite *PgVectorSearchTestSuite) TestAdvancedSearchScenarios() {
 	ctx := context.Background()
 
-	// Setup test data for advanced scenarios
+	// Setup test data for advanced scenarios.
 	testDocs := []struct {
 		doc       *document.Document
 		embedding []float64
@@ -762,7 +762,7 @@ func (suite *PgVectorSearchTestSuite) TestAdvancedSearchScenarios() {
 				ID:      "advanced1",
 				Name:    "Machine Learning Fundamentals",
 				Content: "Introduction to machine learning algorithms and neural networks",
-				Metadata: map[string]interface{}{
+				Metadata: map[string]any{
 					"category":   "education",
 					"difficulty": "beginner",
 					"rating":     4.5,
@@ -776,7 +776,7 @@ func (suite *PgVectorSearchTestSuite) TestAdvancedSearchScenarios() {
 				ID:      "advanced2",
 				Name:    "Deep Learning Applications",
 				Content: "Advanced neural network architectures and their applications",
-				Metadata: map[string]interface{}{
+				Metadata: map[string]any{
 					"category":   "education",
 					"difficulty": "advanced",
 					"rating":     4.8,
@@ -790,7 +790,7 @@ func (suite *PgVectorSearchTestSuite) TestAdvancedSearchScenarios() {
 				ID:      "advanced3",
 				Name:    "Python for Data Science",
 				Content: "Using Python libraries for data analysis and machine learning",
-				Metadata: map[string]interface{}{
+				Metadata: map[string]any{
 					"category":   "programming",
 					"difficulty": "intermediate",
 					"rating":     4.2,
@@ -801,11 +801,11 @@ func (suite *PgVectorSearchTestSuite) TestAdvancedSearchScenarios() {
 		},
 	}
 
-	// Add test documents
+	// Add test documents.
 	for _, td := range testDocs {
 		err := suite.vs.Add(ctx, td.doc, td.embedding)
 		suite.NoError(err)
-		// Store for validation
+		// Store for validation.
 		suite.testDocs[td.doc.ID] = td.doc
 	}
 
@@ -813,7 +813,7 @@ func (suite *PgVectorSearchTestSuite) TestAdvancedSearchScenarios() {
 		query := &vectorstore.SearchQuery{
 			Vector: []float64{0.2, 0.5, 0.3},
 			Filter: &vectorstore.SearchFilter{
-				Metadata: map[string]interface{}{
+				Metadata: map[string]any{
 					"category":   "education",
 					"difficulty": "beginner",
 				},
@@ -846,7 +846,7 @@ func (suite *PgVectorSearchTestSuite) TestAdvancedSearchScenarios() {
 		suite.NoError(err, "High similarity threshold search should not error")
 		suite.NotNil(result, "Search result should not be nil")
 
-		// Should find at least the exact match
+		// Should find at least the exact match.
 		suite.GreaterOrEqual(len(result.Results), 1,
 			"Should find at least 1 high similarity result")
 
@@ -862,7 +862,7 @@ func (suite *PgVectorSearchTestSuite) TestAdvancedSearchScenarios() {
 			Vector: []float64{0.2, 0.7, 0.3},
 			Query:  "machine learning neural networks",
 			Filter: &vectorstore.SearchFilter{
-				Metadata: map[string]interface{}{
+				Metadata: map[string]any{
 					"category": "education",
 				},
 			},
@@ -879,11 +879,11 @@ func (suite *PgVectorSearchTestSuite) TestAdvancedSearchScenarios() {
 		if len(result.Results) > 0 {
 			suite.validateSearchResults(result.Results, 1)
 
-			// Validate keyword relevance
+			// Validate keyword relevance.
 			suite.validateKeywordRelevance(result.Results,
 				[]string{"machine", "learning", "neural", "networks"})
 
-			// Verify all results match the filter
+			// Verify all results match the filter.
 			for _, scored := range result.Results {
 				category, exists := scored.Document.Metadata["category"]
 				suite.True(exists, "Category metadata should exist")
@@ -898,7 +898,7 @@ func (suite *PgVectorSearchTestSuite) TestAdvancedSearchScenarios() {
 func (suite *PgVectorSearchTestSuite) TestMinScoreFiltering() {
 	ctx := context.Background()
 
-	// Setup test data specifically for MinScore testing
+	// Setup test data specifically for MinScore testing.
 	testDocs := []struct {
 		doc       *document.Document
 		embedding []float64
@@ -908,7 +908,7 @@ func (suite *PgVectorSearchTestSuite) TestMinScoreFiltering() {
 				ID:      "minscore1",
 				Name:    "Artificial Intelligence Guide",
 				Content: "Comprehensive guide to artificial intelligence and machine learning concepts",
-				Metadata: map[string]interface{}{
+				Metadata: map[string]any{
 					"category": "education",
 					"type":     "guide",
 					"rating":   4.8,
@@ -921,7 +921,7 @@ func (suite *PgVectorSearchTestSuite) TestMinScoreFiltering() {
 				ID:      "minscore2",
 				Name:    "Programming Best Practices",
 				Content: "Essential programming practices for software development and code quality",
-				Metadata: map[string]interface{}{
+				Metadata: map[string]any{
 					"category": "programming",
 					"type":     "tutorial",
 					"rating":   4.5,
@@ -934,7 +934,7 @@ func (suite *PgVectorSearchTestSuite) TestMinScoreFiltering() {
 				ID:      "minscore3",
 				Name:    "Database Design Principles",
 				Content: "Database design fundamentals and normalization techniques for efficient data storage",
-				Metadata: map[string]interface{}{
+				Metadata: map[string]any{
 					"category": "database",
 					"type":     "reference",
 					"rating":   4.2,
@@ -944,11 +944,11 @@ func (suite *PgVectorSearchTestSuite) TestMinScoreFiltering() {
 		},
 	}
 
-	// Add test documents
+	// Add test documents.
 	for _, td := range testDocs {
 		err := suite.vs.Add(ctx, td.doc, td.embedding)
 		suite.NoError(err)
-		// Store for validation
+		// Store for validation.
 		suite.testDocs[td.doc.ID] = td.doc
 	}
 
@@ -964,13 +964,13 @@ func (suite *PgVectorSearchTestSuite) TestMinScoreFiltering() {
 		suite.NoError(err, "Vector search with MinScore should not error")
 		suite.NotNil(result, "Search result should not be nil")
 
-		// All results should meet the minimum score requirement
+		// All results should meet the minimum score requirement.
 		for _, scored := range result.Results {
 			suite.GreaterOrEqual(scored.Score, 0.6,
 				"All results should meet MinScore threshold of 0.6, got %.4f", scored.Score)
 		}
 
-		// Should find at least the highly similar document
+		// Should find at least the highly similar document.
 		suite.GreaterOrEqual(len(result.Results), 1,
 			"Should find at least 1 result with score >= 0.6")
 
@@ -989,13 +989,13 @@ func (suite *PgVectorSearchTestSuite) TestMinScoreFiltering() {
 		suite.NoError(err, "Keyword search with MinScore should not error")
 		suite.NotNil(result, "Search result should not be nil")
 
-		// All results should meet the minimum score requirement
+		// All results should meet the minimum score requirement.
 		for _, scored := range result.Results {
 			suite.GreaterOrEqual(scored.Score, 0.01,
 				"All results should meet MinScore threshold of 0.01, got %.4f", scored.Score)
 		}
 
-		// Should find relevant documents
+		// Should find relevant documents.
 		if len(result.Results) > 0 {
 			suite.validateKeywordRelevance(result.Results,
 				[]string{"artificial", "intelligence", "machine", "learning"})
@@ -1017,13 +1017,13 @@ func (suite *PgVectorSearchTestSuite) TestMinScoreFiltering() {
 		suite.NoError(err, "Hybrid search with MinScore should not error")
 		suite.NotNil(result, "Search result should not be nil")
 
-		// All results should meet the minimum score requirement
+		// All results should meet the minimum score requirement.
 		for _, scored := range result.Results {
 			suite.GreaterOrEqual(scored.Score, 0.3,
 				"All results should meet MinScore threshold of 0.3, got %.4f", scored.Score)
 		}
 
-		// Should combine semantic and keyword relevance
+		// Should combine semantic and keyword relevance.
 		if len(result.Results) > 0 {
 			suite.validateKeywordRelevance(result.Results,
 				[]string{"artificial", "intelligence", "programming"})
@@ -1044,7 +1044,7 @@ func (suite *PgVectorSearchTestSuite) TestMinScoreFiltering() {
 		suite.NoError(err, "Search with very high MinScore should not error")
 		suite.NotNil(result, "Search result should not be nil")
 
-		// Should return no results due to high threshold
+		// Should return no results due to high threshold.
 		suite.Equal(0, len(result.Results),
 			"Search with very high MinScore should return no results")
 
@@ -1055,7 +1055,7 @@ func (suite *PgVectorSearchTestSuite) TestMinScoreFiltering() {
 		query := &vectorstore.SearchQuery{
 			Vector: []float64{0.2, 0.8, 0.2},
 			Filter: &vectorstore.SearchFilter{
-				Metadata: map[string]interface{}{
+				Metadata: map[string]any{
 					"category": "education",
 				},
 			},
@@ -1068,7 +1068,7 @@ func (suite *PgVectorSearchTestSuite) TestMinScoreFiltering() {
 		suite.NoError(err, "Search with MinScore and metadata filter should not error")
 		suite.NotNil(result, "Search result should not be nil")
 
-		// All results should meet both criteria
+		// All results should meet both criteria.
 		for _, scored := range result.Results {
 			suite.GreaterOrEqual(scored.Score, 0.5,
 				"All results should meet MinScore threshold of 0.5, got %.4f", scored.Score)
@@ -1083,7 +1083,7 @@ func (suite *PgVectorSearchTestSuite) TestMinScoreFiltering() {
 	})
 
 	suite.Run("MinScore edge cases", func() {
-		// Test with MinScore = 0 (should return all results)
+		// Test with MinScore = 0 (should return all results).
 		query1 := &vectorstore.SearchQuery{
 			Vector:     []float64{0.5, 0.5, 0.5},
 			MinScore:   0.0,
@@ -1095,13 +1095,13 @@ func (suite *PgVectorSearchTestSuite) TestMinScoreFiltering() {
 		suite.NoError(err, "Search with MinScore 0.0 should not error")
 		suite.NotNil(result1, "Search result should not be nil")
 
-		// Should return documents (scores can be 0 or higher)
+		// Should return documents (scores can be 0 or higher).
 		for _, scored := range result1.Results {
 			suite.GreaterOrEqual(scored.Score, 0.0,
 				"All results should have score >= 0.0, got %.4f", scored.Score)
 		}
 
-		// Test with MinScore = 1.0 (perfect match only)
+		// Test with MinScore = 1.0 (perfect match only).
 		query2 := &vectorstore.SearchQuery{
 			Vector:     []float64{0.1, 0.9, 0.1}, // Exact match to minscore1
 			MinScore:   1.0,
@@ -1113,7 +1113,7 @@ func (suite *PgVectorSearchTestSuite) TestMinScoreFiltering() {
 		suite.NoError(err, "Search with MinScore 1.0 should not error")
 		suite.NotNil(result2, "Search result should not be nil")
 
-		// Should only return perfect or near-perfect matches
+		// Should only return perfect or near-perfect matches.
 		for _, scored := range result2.Results {
 			suite.GreaterOrEqual(scored.Score, 1.0,
 				"All results should meet MinScore threshold of 1.0, got %.4f", scored.Score)

--- a/knowledge/vectorstore/pgvector/pgvector_test.go
+++ b/knowledge/vectorstore/pgvector/pgvector_test.go
@@ -28,18 +28,18 @@ var (
 	table    = getEnvOrDefault("PGVECTOR_TABLE", "trpc_agent_unit_test_documents")
 )
 
-// PgVectorTestSuite contains the test suite for pgvector basic operations
+// PgVectorTestSuite contains the test suite for pgvector basic operations.
 type PgVectorTestSuite struct {
 	suite.Suite
 	vs *VectorStore
 }
 
-// Run the test suite
+// Run the test suite.
 func TestPgVectorSuite(t *testing.T) {
 	suite.Run(t, new(PgVectorTestSuite))
 }
 
-// SetupSuite runs once before all tests
+// SetupSuite runs once before all tests.
 func (suite *PgVectorTestSuite) SetupSuite() {
 	if host == "" {
 		suite.T().Skip("Skipping PgVector tests: PGVECTOR_HOST not set")
@@ -66,21 +66,21 @@ func (suite *PgVectorTestSuite) SetupSuite() {
 // TearDownSuite runs once after all tests
 func (suite *PgVectorTestSuite) TearDownSuite() {
 	if suite.vs != nil {
-		// Clean up test table
+		// Clean up test table.
 		_, err := suite.vs.pool.Exec(context.Background(), "DROP TABLE IF EXISTS "+table)
 		suite.NoError(err)
 		suite.vs.Close()
 	}
 }
 
-// SetupTest runs before each test
+// SetupTest runs before each test.
 func (suite *PgVectorTestSuite) SetupTest() {
 	// Clean up table data before each test
 	_, err := suite.vs.pool.Exec(context.Background(), "DELETE FROM "+table)
 	suite.NoError(err)
 }
 
-// TestAdd tests adding documents with embeddings
+// TestAdd tests adding documents with embeddings.
 func (suite *PgVectorTestSuite) TestAdd() {
 	ctx := context.Background()
 
@@ -96,7 +96,7 @@ func (suite *PgVectorTestSuite) TestAdd() {
 				ID:      "doc1",
 				Name:    "Test Document",
 				Content: "This is a test document for vector search",
-				Metadata: map[string]interface{}{
+				Metadata: map[string]any{
 					"category": "test",
 					"priority": 1,
 					"active":   true,
@@ -148,44 +148,44 @@ func (suite *PgVectorTestSuite) TestAdd() {
 	}
 }
 
-// TestCRUDOperations tests basic CRUD operations
+// TestCRUDOperations tests basic CRUD operations.
 func (suite *PgVectorTestSuite) TestCRUDOperations() {
 	ctx := context.Background()
 
-	// Test document
+	// Test document.
 	doc := &document.Document{
 		ID:      "crud_test",
 		Name:    "CRUD Test Document",
 		Content: "This document tests CRUD operations",
-		Metadata: map[string]interface{}{
+		Metadata: map[string]any{
 			"type":    "test",
 			"version": 1,
 		},
 	}
 	embedding := []float64{0.1, 0.2, 0.3}
 
-	// Test Add
+	// Test Add.
 	err := suite.vs.Add(ctx, doc, embedding)
 	suite.NoError(err)
 
-	// Test Get
+	// Test Get.
 	retrievedDoc, retrievedEmbedding, err := suite.vs.Get(ctx, doc.ID)
 	suite.NoError(err)
 	suite.Equal(doc.ID, retrievedDoc.ID)
 	suite.Equal(doc.Name, retrievedDoc.Name)
 	suite.Equal(doc.Content, retrievedDoc.Content)
-	// Use InDelta for float comparison due to precision loss in float64<->float32 conversion
+	// Use InDelta for float comparison due to precision loss in float64<->float32 conversion.
 	suite.Len(retrievedEmbedding, len(embedding))
 	for i, expected := range embedding {
 		suite.InDelta(expected, retrievedEmbedding[i], 0.0001)
 	}
 
-	// Test Update
+	// Test Update.
 	updatedDoc := &document.Document{
 		ID:      doc.ID,
 		Name:    "Updated Name",
 		Content: "Updated content for testing",
-		Metadata: map[string]interface{}{
+		Metadata: map[string]any{
 			"type":    "test",
 			"version": 2,
 			"updated": true,
@@ -196,27 +196,27 @@ func (suite *PgVectorTestSuite) TestCRUDOperations() {
 	err = suite.vs.Update(ctx, updatedDoc, updatedEmbedding)
 	suite.NoError(err)
 
-	// Verify update
+	// Verify update.
 	retrievedDoc, retrievedEmbedding, err = suite.vs.Get(ctx, doc.ID)
 	suite.NoError(err)
 	suite.Equal(updatedDoc.Name, retrievedDoc.Name)
 	suite.Equal(updatedDoc.Content, retrievedDoc.Content)
-	// Use InDelta for float comparison due to precision loss in float64<->float32 conversion
+	// Use InDelta for float comparison due to precision loss in float64<->float32 conversion.
 	suite.Len(retrievedEmbedding, len(updatedEmbedding))
 	for i, expected := range updatedEmbedding {
 		suite.InDelta(expected, retrievedEmbedding[i], 0.0001)
 	}
 
-	// Test Delete
+	// Test Delete.
 	err = suite.vs.Delete(ctx, doc.ID)
 	suite.NoError(err)
 
-	// Verify deletion
+	// Verify deletion.
 	_, _, err = suite.vs.Get(ctx, doc.ID)
 	suite.Error(err)
 }
 
-// TestErrorHandling tests various non-search error conditions
+// TestErrorHandling tests various non-search error conditions.
 func (suite *PgVectorTestSuite) TestErrorHandling() {
 	ctx := context.Background()
 
@@ -279,7 +279,8 @@ func (suite *PgVectorTestSuite) TestErrorHandling() {
 	}
 }
 
-// Helper functions for environment variable parsing used in tests
+// Helper functions for environment variable parsing used in tests.
+
 func getEnvOrDefault(key, defaultValue string) string {
 	if value := os.Getenv(key); value != "" {
 		return value

--- a/knowledge/vectorstore/tcvector/tcvector_option.go
+++ b/knowledge/vectorstore/tcvector/tcvector_option.go
@@ -26,7 +26,7 @@ type options struct {
 	enableTSVector bool
 	instanceName   string
 
-	// Hybrid search scoring weights
+	// Hybrid search scoring weights.
 	vectorWeight float64 // Default: Vector similarity weight 70%
 	textWeight   float64 // Default: Text relevance weight 30%
 	language     string  // Default: zh, options: zh, en
@@ -53,89 +53,89 @@ var defaultOptions = options{
 // Option is the option for tcvectordb.
 type Option func(*options)
 
-// WithURL sets the vector database URL
+// WithURL sets the vector database URL.
 func WithURL(url string) Option {
 	return func(o *options) {
 		o.url = url
 	}
 }
 
-// WithUsername sets the username for authentication
+// WithUsername sets the username for authentication.
 func WithUsername(username string) Option {
 	return func(o *options) {
 		o.username = username
 	}
 }
 
-// WithPassword sets the password for authentication
+// WithPassword sets the password for authentication.
 func WithPassword(password string) Option {
 	return func(o *options) {
 		o.password = password
 	}
 }
 
-// WithDatabase sets the database name
+// WithDatabase sets the database name.
 func WithDatabase(database string) Option {
 	return func(o *options) {
 		o.database = database
 	}
 }
 
-// WithCollection sets the collection name
+// WithCollection sets the collection name.
 func WithCollection(collection string) Option {
 	return func(o *options) {
 		o.collection = collection
 	}
 }
 
-// WithIndexDimension sets the vector dimension for the index
+// WithIndexDimension sets the vector dimension for the index.
 func WithIndexDimension(dimension uint32) Option {
 	return func(o *options) {
 		o.indexDimension = dimension
 	}
 }
 
-// WithReplicas sets the number of replicas
+// WithReplicas sets the number of replicas.
 func WithReplicas(replicas uint32) Option {
 	return func(o *options) {
 		o.replicas = replicas
 	}
 }
 
-// WithSharding sets the number of shards
+// WithSharding sets the number of shards.
 func WithSharding(sharding uint32) Option {
 	return func(o *options) {
 		o.sharding = sharding
 	}
 }
 
-// WithEnableTSVector sets the enableTSVector for the vector database
+// WithEnableTSVector sets the enableTSVector for the vector database.
 func WithEnableTSVector(enableTSVector bool) Option {
 	return func(o *options) {
 		o.enableTSVector = enableTSVector
 	}
 }
 
-// WithHybridSearchWeights sets the weights for hybrid search scoring
+// WithHybridSearchWeights sets the weights for hybrid search scoring.
 // vectorWeight: Weight for vector similarity (0.0-1.0)
 // textWeight: Weight for text relevance (0.0-1.0)
 // Note: weights will be normalized to sum to 1.0
 func WithHybridSearchWeights(vectorWeight, textWeight float64) Option {
 	return func(o *options) {
-		// Normalize weights to sum to 1.0
+		// Normalize weights to sum to 1.0.
 		total := vectorWeight + textWeight
 		if total > 0 {
 			o.vectorWeight = vectorWeight / total
 			o.textWeight = textWeight / total
 		} else {
-			// Fallback to defaults if invalid weights
+			// Fallback to defaults if invalid weights.
 			o.vectorWeight = 0.7
 			o.textWeight = 0.3
 		}
 	}
 }
 
-// WithLanguage sets the language for the vector database
+// WithLanguage sets the language for the vector database.
 func WithLanguage(language string) Option {
 	return func(o *options) {
 		o.language = language
@@ -151,7 +151,8 @@ func WithTCVectorInstance(name string) Option {
 	}
 }
 
-// WithFilterIndexFields sets the filter fields for the vector database. It will build index for the filter fields.
+// WithFilterIndexFields sets the filter fields for the vector database.
+// It will build index for the filter fields.
 func WithFilterIndexFields(fields []string) Option {
 	return func(o *options) {
 		o.filterFields = append(o.filterFields, fields...)

--- a/knowledge/vectorstore/tcvector/tcvector_search_test.go
+++ b/knowledge/vectorstore/tcvector/tcvector_search_test.go
@@ -22,7 +22,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore"
 )
 
-// TcVectorSearchTestSuite tests the new search methods
+// TcVectorSearchTestSuite tests the new search methods.
 type TcVectorSearchTestSuite struct {
 	suite.Suite
 	vs       *VectorStore
@@ -33,13 +33,13 @@ func TestTcVectorSearchSuite(t *testing.T) {
 	suite.Run(t, new(TcVectorSearchTestSuite))
 }
 
-// SetupSuite runs once before all tests
+// SetupSuite runs once before all tests.
 func (suite *TcVectorSearchTestSuite) SetupSuite() {
 	if urlStr == "" || key == "" {
 		suite.T().Skip("Skipping tcvector tests: VECTOR_STORE_URL and VECTOR_STORE_KEY must be set")
 	}
 
-	// Initialize vector store (skip if no configuration available)
+	// Initialize vector store (skip if no configuration available).
 	vs, err := New(
 		WithURL(urlStr),
 		WithUsername(user),
@@ -54,13 +54,13 @@ func (suite *TcVectorSearchTestSuite) SetupSuite() {
 		suite.T().Fatalf("Failed to initialize tcvector: %v", err)
 	}
 
-	// sleep 3 seconds to ensure the collection is ready
+	// sleep 3 seconds to ensure the collection is ready.
 	time.Sleep(3 * time.Second)
 
 	suite.vs = vs
 	suite.testDocs = make(map[string]*document.Document)
 
-	// Add test documents
+	// Add test documents.
 	testData := []struct {
 		doc       *document.Document
 		embedding []float64
@@ -70,7 +70,7 @@ func (suite *TcVectorSearchTestSuite) SetupSuite() {
 				ID:      "doc1",
 				Name:    "Python Programming Guide",
 				Content: "Python is a powerful programming language widely used for data science and machine learning",
-				Metadata: map[string]interface{}{
+				Metadata: map[string]any{
 					"category": "programming",
 					"language": "python",
 					"level":    "beginner",
@@ -85,7 +85,7 @@ func (suite *TcVectorSearchTestSuite) SetupSuite() {
 				ID:      "doc2",
 				Name:    "Go Language Development",
 				Content: "Go is a programming language developed by Google, known for its concurrency performance and simplicity",
-				Metadata: map[string]interface{}{
+				Metadata: map[string]any{
 					"category": "programming",
 					"language": "go",
 					"level":    "intermediate",
@@ -100,7 +100,7 @@ func (suite *TcVectorSearchTestSuite) SetupSuite() {
 				ID:      "doc3",
 				Name:    "Data Science Tutorial",
 				Content: "Data science combines statistics, machine learning and domain expertise to extract insights from data",
-				Metadata: map[string]interface{}{
+				Metadata: map[string]any{
 					"category": "data-science",
 					"field":    "analytics",
 					"level":    "advanced",
@@ -116,13 +116,13 @@ func (suite *TcVectorSearchTestSuite) SetupSuite() {
 	for _, td := range testData {
 		err := suite.vs.Add(ctx, td.doc, td.embedding)
 		suite.Require().NoError(err)
-		// Store for validation
+		// Store for validation.
 		suite.testDocs[td.doc.ID] = td.doc
 	}
 	suite.T().Log("test docs loaded")
 }
 
-// TearDownSuite runs once after all tests
+// TearDownSuite runs once after all tests.
 func (suite *TcVectorSearchTestSuite) TearDownSuite() {
 	if suite.vs == nil {
 		return
@@ -131,14 +131,14 @@ func (suite *TcVectorSearchTestSuite) TearDownSuite() {
 	suite.vs.Close()
 }
 
-// SetupTest runs before each test
+// SetupTest runs before each test.
 func (suite *TcVectorSearchTestSuite) SetupTest() {
 	if suite.vs == nil {
 		suite.T().Skip("Vector store not initialized")
 	}
 }
 
-// validateSearchResult validates a single search result
+// validateSearchResult validates a single search result.
 func (suite *TcVectorSearchTestSuite) validateSearchResult(result *vectorstore.ScoredDocument) {
 	suite.NotNil(result.Document, "Document should not be nil")
 	suite.GreaterOrEqual(result.Score, 0.0, "Score should be non-negative")
@@ -149,32 +149,32 @@ func (suite *TcVectorSearchTestSuite) validateSearchResult(result *vectorstore.S
 	suite.validateDocumentContent(originalDoc, result.Document)
 }
 
-// validateDocumentContent compares returned document with original
+// validateDocumentContent compares returned document with original.
 func (suite *TcVectorSearchTestSuite) validateDocumentContent(expected, actual *document.Document) {
 	suite.Equal(expected.ID, actual.ID, "Document ID should match")
 	suite.Equal(expected.Name, actual.Name, "Document Name should match")
 	suite.Equal(expected.Content, actual.Content, "Document Content should match")
-	// validate metadata
+	// validate metadata.
 	suite.NotNil(actual.Metadata, "Document metadata should not be nil")
 	for key, expectedValue := range expected.Metadata {
 		actualValue, exists := actual.Metadata[key]
 		suite.True(exists, "Metadata key '%s' should exist", key)
 
-		// Flexible type comparison for metadata
+		// Flexible type comparison for metadata.
 		suite.True(suite.compareMetadataValues(expectedValue, actualValue),
 			"Metadata '%s' should match: expected %v (%T), got %v (%T)",
 			key, expectedValue, expectedValue, actualValue, actualValue)
 	}
 }
 
-// compareMetadataValues provides flexible comparison for metadata values
-func (suite *TcVectorSearchTestSuite) compareMetadataValues(expected, actual interface{}) bool {
-	// Direct equality check
+// compareMetadataValues provides flexible comparison for metadata values.
+func (suite *TcVectorSearchTestSuite) compareMetadataValues(expected, actual any) bool {
+	// Direct equality check.
 	if expected == actual {
 		return true
 	}
 
-	// Handle numeric type conversions (JSON unmarshaling often converts to float64)
+	// Handle numeric type conversions (JSON unmarshaling often converts to float64).
 	switch a := actual.(type) {
 	case json.Number:
 		eStr := fmt.Sprintf("%v", expected)
@@ -202,8 +202,8 @@ func (suite *TcVectorSearchTestSuite) compareMetadataValues(expected, actual int
 			}
 		}
 		return true
-	case []interface{}:
-		if e, ok := expected.([]interface{}); ok {
+	case []any:
+		if e, ok := expected.([]any); ok {
 			if len(e) != len(a) {
 				return false
 			}
@@ -218,17 +218,17 @@ func (suite *TcVectorSearchTestSuite) compareMetadataValues(expected, actual int
 	return false
 }
 
-// validateSearchResults validates the complete search result set
+// validateSearchResults validates the complete search result set.
 func (suite *TcVectorSearchTestSuite) validateSearchResults(results []*vectorstore.ScoredDocument, expectedMinCount int) {
 	suite.GreaterOrEqual(len(results), expectedMinCount, "Should return at least %d results", expectedMinCount)
 
-	// Validate individual results
+	// Validate individual results.
 	for i, result := range results {
 		suite.validateSearchResult(result)
 		suite.T().Logf("Result %d: ID=%s, Name=%s, Score=%.4f", i+1, result.Document.ID, result.Document.Name, result.Score)
 	}
 
-	// Validate score ordering (descending)
+	// Validate score ordering (descending).
 	for i := 1; i < len(results); i++ {
 		suite.GreaterOrEqual(results[i-1].Score, results[i].Score,
 			"Results should be ordered by score (descending): result[%d].Score=%.4f >= result[%d].Score=%.4f",
@@ -236,7 +236,7 @@ func (suite *TcVectorSearchTestSuite) validateSearchResults(results []*vectorsto
 	}
 }
 
-// validateKeywordRelevance checks if results are relevant to the keyword query
+// validateKeywordRelevance checks if results are relevant to the keyword query.
 func (suite *TcVectorSearchTestSuite) validateKeywordRelevance(results []*vectorstore.ScoredDocument, keywords []string) {
 	for _, result := range results {
 		hasRelevantContent := false
@@ -249,7 +249,7 @@ func (suite *TcVectorSearchTestSuite) validateKeywordRelevance(results []*vector
 			}
 		}
 
-		// Log for debugging - keyword relevance might not be strict
+		// Log for debugging - keyword relevance might not be strict.
 		if !hasRelevantContent {
 			suite.T().Logf("Note: Document %s may not contain keywords %v",
 				result.Document.ID, keywords)
@@ -257,7 +257,7 @@ func (suite *TcVectorSearchTestSuite) validateKeywordRelevance(results []*vector
 	}
 }
 
-// TestSearchByVector tests pure vector similarity search
+// TestSearchByVector tests pure vector similarity search.
 func (suite *TcVectorSearchTestSuite) TestSearchByVector() {
 	ctx := context.Background()
 	query := &vectorstore.SearchQuery{
@@ -270,7 +270,7 @@ func (suite *TcVectorSearchTestSuite) TestSearchByVector() {
 	suite.NoError(err, "SearchByVector should not error")
 	suite.NotNil(result, "Search result should not be nil")
 
-	// Validate search results
+	// Validate search results.
 	suite.validateSearchResults(result.Results, 1)
 
 	// Verify results contain expected documents (doc1 and doc2 should be similar)
@@ -285,7 +285,7 @@ func (suite *TcVectorSearchTestSuite) TestSearchByVector() {
 	suite.Greater(topResult.Score, 0.0, "Top result should have positive similarity score")
 }
 
-// TestSearchByKeyword tests BM25-based keyword search
+// TestSearchByKeyword tests BM25-based keyword search.
 func (suite *TcVectorSearchTestSuite) TestSearchByKeyword() {
 	ctx := context.Background()
 	query := &vectorstore.SearchQuery{
@@ -298,18 +298,18 @@ func (suite *TcVectorSearchTestSuite) TestSearchByKeyword() {
 	suite.NoError(err, "SearchByKeyword should not error")
 	suite.NotNil(result, "Search result should not be nil")
 
-	// Validate search results
+	// Validate search results.
 	suite.validateSearchResults(result.Results, 1)
 
-	// Validate keyword relevance
+	// Validate keyword relevance.
 	suite.validateKeywordRelevance(result.Results, []string{"programming", "language"})
 
-	// Verify results contain documents with programming content
+	// Verify results contain documents with programming content.
 	foundProgDocs := false
 	for _, r := range result.Results {
 		if r.Document.ID == "doc1" || r.Document.ID == "doc2" {
 			foundProgDocs = true
-			// Validate that programming documents have relevant metadata
+			// Validate that programming documents have relevant metadata.
 			if category, ok := r.Document.Metadata["category"]; ok {
 				suite.Equal("programming", category, "Programming documents should have correct category")
 			}
@@ -319,7 +319,7 @@ func (suite *TcVectorSearchTestSuite) TestSearchByKeyword() {
 	suite.True(foundProgDocs, "Should find documents about programming languages")
 }
 
-// TestSearchByHybrid tests hybrid search combining vector and keyword matching
+// TestSearchByHybrid tests hybrid search combining vector and keyword matching.
 func (suite *TcVectorSearchTestSuite) TestSearchByHybrid() {
 	if suite.vs == nil {
 		suite.T().Skip("Vector store not initialized")
@@ -337,13 +337,13 @@ func (suite *TcVectorSearchTestSuite) TestSearchByHybrid() {
 	suite.NoError(err, "SearchByHybrid should not error")
 	suite.NotNil(result, "Search result should not be nil")
 
-	// Validate search results
+	// Validate search results.
 	suite.validateSearchResults(result.Results, 1)
 
-	// Validate keyword relevance
+	// Validate keyword relevance.
 	suite.validateKeywordRelevance(result.Results, []string{"programming"})
 
-	// Verify hybrid search finds programming documents
+	// Verify hybrid search finds programming documents.
 	foundProgDocs := false
 	maxScore := 0.0
 	for _, r := range result.Results {
@@ -352,7 +352,7 @@ func (suite *TcVectorSearchTestSuite) TestSearchByHybrid() {
 		}
 		if r.Document.ID == "doc1" || r.Document.ID == "doc2" {
 			foundProgDocs = true
-			// Hybrid search should potentially have higher scores than pure vector/keyword
+			// Hybrid search should potentially have higher scores than pure vector/keyword.
 			suite.T().Logf("Hybrid result - ID: %s, Score: %.4f", r.Document.ID, r.Score)
 		}
 	}
@@ -361,7 +361,7 @@ func (suite *TcVectorSearchTestSuite) TestSearchByHybrid() {
 	suite.Greater(maxScore, 0.0, "Hybrid search should return meaningful scores")
 }
 
-// TestSearchWithFilters tests search with metadata filters
+// TestSearchWithFilters tests search with metadata filters.
 func (suite *TcVectorSearchTestSuite) TestSearchWithFilters() {
 	if suite.vs == nil {
 		suite.T().Skip("Vector store not initialized")
@@ -371,7 +371,7 @@ func (suite *TcVectorSearchTestSuite) TestSearchWithFilters() {
 	query := &vectorstore.SearchQuery{
 		Vector: []float64{0.2, 0.3, 0.4},
 		Filter: &vectorstore.SearchFilter{
-			Metadata: map[string]interface{}{
+			Metadata: map[string]any{
 				"category": "programming",
 			},
 		},
@@ -383,11 +383,11 @@ func (suite *TcVectorSearchTestSuite) TestSearchWithFilters() {
 	suite.NoError(err, "Filtered search should not error")
 	suite.NotNil(result, "Search result should not be nil")
 
-	// Validate search results
+	// Validate search results.
 	if len(result.Results) > 0 {
 		suite.validateSearchResults(result.Results, 1)
 
-		// All results should match the filter
+		// All results should match the filter.
 		for _, r := range result.Results {
 			suite.T().Logf("Filtered Search - ID: %s, Category: %v, Level: %v",
 				r.Document.ID, r.Document.Metadata["category"], r.Document.Metadata["level"])
@@ -404,7 +404,7 @@ func (suite *TcVectorSearchTestSuite) TestSearchWithFilters() {
 	}
 }
 
-// TestSearchModeSelection tests automatic search mode selection
+// TestSearchModeSelection tests automatic search mode selection.
 func (suite *TcVectorSearchTestSuite) TestSearchModeSelection() {
 	if suite.vs == nil {
 		suite.T().Skip("Vector store not initialized")
@@ -427,7 +427,7 @@ func (suite *TcVectorSearchTestSuite) TestSearchModeSelection() {
 			},
 			expectedLog: "Should route to vector search",
 			validator: func(results []*vectorstore.ScoredDocument) {
-				// Vector search should prioritize similarity
+				// Vector search should prioritize similarity.
 				if len(results) > 0 {
 					suite.Greater(results[0].Score, 0.0, "Vector search should return similarity scores")
 				}
@@ -442,7 +442,7 @@ func (suite *TcVectorSearchTestSuite) TestSearchModeSelection() {
 			},
 			expectedLog: "Should route to keyword search",
 			validator: func(results []*vectorstore.ScoredDocument) {
-				// Keyword search should find relevant documents
+				// Keyword search should find relevant documents.
 				suite.validateKeywordRelevance(results, []string{"data", "science"})
 			},
 		},
@@ -456,7 +456,7 @@ func (suite *TcVectorSearchTestSuite) TestSearchModeSelection() {
 			},
 			expectedLog: "Should route to hybrid search",
 			validator: func(results []*vectorstore.ScoredDocument) {
-				// Hybrid search should combine both signals
+				// Hybrid search should combine both signals.
 				suite.validateKeywordRelevance(results, []string{"data"})
 				if len(results) > 0 {
 					suite.Greater(results[0].Score, 0.0, "Hybrid search should return meaningful scores")
@@ -474,7 +474,7 @@ func (suite *TcVectorSearchTestSuite) TestSearchModeSelection() {
 			},
 			expectedLog: "Should route to filter search",
 			validator: func(results []*vectorstore.ScoredDocument) {
-				// Filter search should return exact matches
+				// Filter search should return exact matches.
 				suite.Len(results, 2, "Filter search should return exactly 2 results")
 				foundDocs := make(map[string]bool)
 				for _, r := range results {
@@ -493,12 +493,12 @@ func (suite *TcVectorSearchTestSuite) TestSearchModeSelection() {
 			suite.NoError(err, "Search should not error for: %s", tc.expectedLog)
 			suite.NotNil(result, "Search result should not be nil")
 
-			// Validate basic result structure
+			// Validate basic result structure.
 			if len(result.Results) > 0 {
 				suite.validateSearchResults(result.Results, 0)
 			}
 
-			// Run specific validator
+			// Run specific validator.
 			if tc.validator != nil {
 				tc.validator(result.Results)
 			}

--- a/knowledge/vectorstore/tcvector/tcvector_test.go
+++ b/knowledge/vectorstore/tcvector/tcvector_test.go
@@ -35,12 +35,12 @@ func TestTCVectorSuite(t *testing.T) {
 	suite.Run(t, new(TCVectorTestSuite))
 }
 
-// TCVectorTestSuite contains test suite state
+// TCVectorTestSuite contains test suite state.
 type TCVectorTestSuite struct {
 	suite.Suite
 	vs          *VectorStore
 	ctx         context.Context
-	addedDocIDs []string // Track documents for cleanup
+	addedDocIDs []string // Track documents for cleanup.
 }
 
 var testData = []struct {
@@ -54,7 +54,7 @@ var testData = []struct {
 			ID:      "test_001",
 			Name:    "AI Fundamentals",
 			Content: "Artificial intelligence is a branch of computer science",
-			Metadata: map[string]interface{}{
+			Metadata: map[string]any{
 				"category": "AI",
 				"priority": 5,
 				"tags":     []string{"AI", "fundamentals"},
@@ -68,7 +68,7 @@ var testData = []struct {
 			ID:      "test_002",
 			Name:    "Machine Learning Algorithms",
 			Content: "Machine learning is the core technology of artificial intelligence",
-			Metadata: map[string]interface{}{
+			Metadata: map[string]any{
 				"category": "ML",
 				"priority": 8,
 				"tags":     []string{"ML", "algorithms"},
@@ -82,7 +82,7 @@ var testData = []struct {
 			ID:      "test_003",
 			Name:    "Deep Learning Framework",
 			Content: "Deep learning is a subset of machine learning",
-			Metadata: map[string]interface{}{
+			Metadata: map[string]any{
 				"category": "DL",
 				"priority": 6,
 				"tags":     []string{"DL", "framework"},
@@ -92,7 +92,7 @@ var testData = []struct {
 	},
 }
 
-// SetupSuite initializes the test suite
+// SetupSuite initializes the test suite.
 func (suite *TCVectorTestSuite) SetupSuite() {
 	suite.ctx = context.Background()
 	if urlStr == "" || key == "" {
@@ -115,11 +115,11 @@ func (suite *TCVectorTestSuite) SetupSuite() {
 	suite.addedDocIDs = make([]string, 0)
 
 	suite.T().Logf("Test suite setup completed with collection: %s", collection)
-	// sleep 3 seconds to ensure the collection is ready
+	// sleep 3 seconds to ensure the collection is ready.
 	time.Sleep(3 * time.Second)
 }
 
-// TearDownSuite cleans up test data
+// TearDownSuite cleans up test data.
 func (suite *TCVectorTestSuite) TearDownSuite() {
 	if suite.vs == nil {
 		return
@@ -129,23 +129,23 @@ func (suite *TCVectorTestSuite) TearDownSuite() {
 	suite.vs.Close()
 }
 
-// SetupTest runs before each test to ensure a clean state
+// SetupTest runs before each test to ensure a clean state.
 func (suite *TCVectorTestSuite) SetupTest() {
-	// Clean up any documents that were added in a previous test run
+	// Clean up any documents that were added in a previous test run.
 	for _, id := range suite.addedDocIDs {
 		_ = suite.vs.Delete(suite.ctx, id) // Ignore error as doc might already be deleted
 	}
-	// Reset the tracker
+	// Reset the tracker.
 	suite.addedDocIDs = make([]string, 0)
 }
 
-// validateDocument compares two documents for equality
+// validateDocument compares two documents for equality.
 func (suite *TCVectorTestSuite) validateDocument(expected *document.Document, actual *document.Document) {
 	suite.Equal(expected.ID, actual.ID, "Document ID should match")
 	suite.Equal(expected.Name, actual.Name, "Document Name should match")
 	suite.Equal(expected.Content, actual.Content, "Document Content should match")
 
-	// Validate metadata with more flexible type checking
+	// Validate metadata with more flexible type checking.
 	for key, expectedValue := range expected.Metadata {
 		actualValue, exists := actual.Metadata[key]
 		if !exists {
@@ -153,21 +153,21 @@ func (suite *TCVectorTestSuite) validateDocument(expected *document.Document, ac
 			continue
 		}
 
-		// More flexible comparison for different types
+		// More flexible comparison for different types.
 		suite.True(suite.compareMetadataValues(expectedValue, actualValue),
 			"Metadata %s should match: got %v (%T), expected %v (%T)",
 			key, actualValue, actualValue, expectedValue, expectedValue)
 	}
 }
 
-// compareMetadataValues provides flexible comparison for metadata values
-func (suite *TCVectorTestSuite) compareMetadataValues(expected, actual interface{}) bool {
-	// Direct equality
+// compareMetadataValues provides flexible comparison for metadata values.
+func (suite *TCVectorTestSuite) compareMetadataValues(expected, actual any) bool {
+	// Direct equality.
 	if reflect.DeepEqual(expected, actual) {
 		return true
 	}
 
-	// Handle numeric type conversions
+	// Handle numeric type conversions.
 	switch a := actual.(type) {
 	case json.Number:
 		eStr := fmt.Sprintf("%v", expected)
@@ -185,7 +185,7 @@ func (suite *TCVectorTestSuite) compareMetadataValues(expected, actual interface
 		}
 	}
 
-	// For slices, try element-wise comparison
+	// For slices, try element-wise comparison.
 	expectedVal := reflect.ValueOf(expected)
 	actualVal := reflect.ValueOf(actual)
 	if expectedVal.Kind() == reflect.Slice && actualVal.Kind() == reflect.Slice {
@@ -203,7 +203,7 @@ func (suite *TCVectorTestSuite) compareMetadataValues(expected, actual interface
 	return false
 }
 
-// validateVector compares two vectors for equality
+// validateVector compares two vectors for equality.
 func (suite *TCVectorTestSuite) validateVector(expected []float64, actual []float64, tolerance float64) {
 	suite.Require().Len(actual, len(expected), "Vector length should match")
 
@@ -244,7 +244,7 @@ func (suite *TCVectorTestSuite) TestAdd() {
 
 			suite.Require().NoError(err, "no error expected")
 
-			// Track for cleanup
+			// Track for cleanup.
 			suite.addedDocIDs = append(suite.addedDocIDs, tt.doc.ID)
 			retrievedDoc, retrievedVector, err := suite.vs.Get(suite.ctx, tt.doc.ID)
 			suite.Require().NoError(err, "query after add should succeed")
@@ -259,7 +259,7 @@ func (suite *TCVectorTestSuite) TestAdd() {
 }
 
 func (suite *TCVectorTestSuite) TestGet() {
-	// Setup: Add test document first
+	// Setup: Add test document first.
 	testDoc := testData[0]
 	err := suite.vs.Add(suite.ctx, testDoc.doc, testDoc.vector)
 	suite.Require().NoError(err, "Failed to add test document")
@@ -304,7 +304,7 @@ func (suite *TCVectorTestSuite) TestGet() {
 }
 
 func (suite *TCVectorTestSuite) TestUpdate() {
-	// Setup: Add test document
+	// Setup: Add test document.
 	testDoc := testData[0]
 	err := suite.vs.Add(suite.ctx, testDoc.doc, testDoc.vector)
 	suite.Require().NoError(err, "Failed to add test document")
@@ -323,7 +323,7 @@ func (suite *TCVectorTestSuite) TestUpdate() {
 				ID:      testDoc.doc.ID,
 				Name:    "Updated AI Fundamentals",
 				Content: "Updated content about artificial intelligence",
-				Metadata: map[string]interface{}{
+				Metadata: map[string]any{
 					"category":   "AI",
 					"priority":   9,
 					"tags":       []string{"AI", "fundamentals", "updated"},
@@ -358,7 +358,7 @@ func (suite *TCVectorTestSuite) TestUpdate() {
 }
 
 func (suite *TCVectorTestSuite) TestDelete() {
-	// Setup: Add test document
+	// Setup: Add test document.
 	testDoc := testData[0]
 	err := suite.vs.Add(suite.ctx, testDoc.doc, testDoc.vector)
 	suite.Require().NoError(err, "Failed to add test document")
@@ -376,7 +376,7 @@ func (suite *TCVectorTestSuite) TestDelete() {
 		{
 			name:    "non_existing_document",
 			id:      "non_existent_id",
-			wantErr: false, // Delete non-existing should not error
+			wantErr: false, // Delete non-existing should not error.
 		},
 	}
 
@@ -407,7 +407,7 @@ func (suite *TCVectorTestSuite) TestEdgeCases() {
 			SearchMode: vectorstore.SearchModeVector,
 		}
 		_, err := suite.vs.Search(suite.ctx, query)
-		// Empty vector search might be valid or invalid depending on implementation
+		// Empty vector search might be valid or invalid depending on implementation.
 		if err != nil {
 			suite.T().Logf("Empty vector search error (may be expected): %v", err)
 		}
@@ -430,7 +430,7 @@ func (suite *TCVectorTestSuite) TestEdgeCases() {
 	})
 }
 
-// Helper functions for environment variable parsing used in tests
+// Helper functions for environment variable parsing used in tests.
 func getEnvOrDefault(key, defaultValue string) string {
 	if value := os.Getenv(key); value != "" {
 		return value

--- a/knowledge/vectorstore/vectorstore.go
+++ b/knowledge/vectorstore/vectorstore.go
@@ -78,7 +78,7 @@ type SearchFilter struct {
 	IDs []string
 
 	// Metadata filters results by metadata key-value pairs.
-	Metadata map[string]interface{}
+	Metadata map[string]any
 }
 
 // SearchResult represents the result of a vector similarity search.


### PR DESCRIPTION
- Changed the type of Metadata in SearchFilter and related structures from `map[string]interface{}` to `map[string]any` for better type safety.
- Updated various test cases to reflect the new Metadata type.
- Introduced specific error variables for better error handling in the VectorStore methods.
- Enhanced comments for clarity and consistency across the codebase.

This update improves type safety and error management in the vector store implementation.