### PR TITLE
knowledge/vectorstore: fix default field values for Elasticsearch options

### DIFF
--- a/knowledge/vectorstore/elasticsearch/builder.go
+++ b/knowledge/vectorstore/elasticsearch/builder.go
@@ -36,9 +36,6 @@ func (vs *VectorStore) buildVectorSearchQuery(query *vectorstore.SearchQuery) (*
 
 	// Build script source dynamically to support custom embedding field.
 	embeddingField := vs.option.embeddingFieldName
-	if embeddingField == "" {
-		embeddingField = defaultFieldEmbedding
-	}
 	scriptSource := fmt.Sprintf("if (doc['%s'].size() > 0) { cosineSimilarity(params.query_vector, '%s') + 1.0 } else { 0.0 }", embeddingField, embeddingField)
 
 	// Create script for cosine similarity using esdsl.
@@ -68,15 +65,9 @@ func (vs *VectorStore) buildVectorSearchQuery(query *vectorstore.SearchQuery) (*
 // buildKeywordSearchQuery builds a keyword-based search query.
 func (vs *VectorStore) buildKeywordSearchQuery(query *vectorstore.SearchQuery) (*types.SearchRequestBody, error) {
 	contentField := vs.option.contentFieldName
-	if contentField == "" {
-		contentField = defaultFieldContent
-	}
 
 	// Create multi_match query using esdsl.
 	nameField := vs.option.nameFieldName
-	if nameField == "" {
-		nameField = defaultFieldName
-	}
 	multiMatchQuery := esdsl.NewMultiMatchQuery(query.Query).
 		Fields(fmt.Sprintf("%s^2", contentField), fmt.Sprintf("%s^1.5", nameField)).
 		Type(textquerytype.Bestfields)
@@ -104,9 +95,6 @@ func (vs *VectorStore) buildHybridSearchQuery(query *vectorstore.SearchQuery) (*
 
 	// Build script with custom embedding field.
 	embeddingField := vs.option.embeddingFieldName
-	if embeddingField == "" {
-		embeddingField = defaultFieldEmbedding
-	}
 	scriptSource := fmt.Sprintf("if (doc['%s'].size() > 0) { cosineSimilarity(params.query_vector, '%s') + 1.0 } else { 0.0 }", embeddingField, embeddingField)
 	script := esdsl.NewScript().
 		Source(esdsl.NewScriptSource().String(scriptSource)).
@@ -119,13 +107,7 @@ func (vs *VectorStore) buildHybridSearchQuery(query *vectorstore.SearchQuery) (*
 	scriptScoreQuery := esdsl.NewScriptScoreQuery(matchAllQuery, script)
 
 	contentField := vs.option.contentFieldName
-	if contentField == "" {
-		contentField = defaultFieldContent
-	}
 	nameField := vs.option.nameFieldName
-	if nameField == "" {
-		nameField = defaultFieldName
-	}
 	multiMatchQuery := esdsl.NewMultiMatchQuery(query.Query).
 		Fields(fmt.Sprintf("%s^2", contentField), fmt.Sprintf("%s^1.5", nameField)).
 		Type(textquerytype.Bestfields)
@@ -160,9 +142,6 @@ func (vs *VectorStore) buildFilterQuery(filter *vectorstore.SearchFilter) types.
 			fieldValues[i] = esdsl.NewFieldValue().String(id)
 		}
 		idField := vs.option.idFieldName
-		if idField == "" {
-			idField = defaultFieldID
-		}
 		termsQuery.AddTermsQuery(idField, esdsl.NewTermsQueryField().FieldValues(fieldValues...))
 		filters = append(filters, termsQuery)
 	}

--- a/knowledge/vectorstore/elasticsearch/elasticsearch.go
+++ b/knowledge/vectorstore/elasticsearch/elasticsearch.go
@@ -52,10 +52,6 @@ const (
 
 // Elasticsearch field name constants.
 const (
-	defaultFieldID        = "id"
-	defaultFieldName      = "name"
-	defaultFieldContent   = "content"
-	defaultFieldEmbedding = "embedding"
 	defaultFieldMetadata  = "metadata"
 	defaultFieldCreatedAt = "created_at"
 	defaultFieldUpdatedAt = "updated_at"
@@ -165,13 +161,10 @@ func (vs *VectorStore) buildIndexCreateBody() *indexCreateBody {
 	tm.Properties = make(map[string]types.Property)
 
 	// id: keyword
-	tm.Properties[defaultFieldID] = types.NewKeywordProperty()
+	tm.Properties[vs.option.idFieldName] = types.NewKeywordProperty()
 	// name/content: text
-	tm.Properties[defaultFieldName] = types.NewTextProperty()
+	tm.Properties[vs.option.nameFieldName] = types.NewTextProperty()
 	contentField := vs.option.contentFieldName
-	if contentField == "" {
-		contentField = defaultFieldContent
-	}
 	tm.Properties[contentField] = types.NewTextProperty()
 	// metadata: object with dynamic true
 	metaObj := types.NewObjectProperty()
@@ -190,9 +183,6 @@ func (vs *VectorStore) buildIndexCreateBody() *indexCreateBody {
 	sim := densevectorsimilarity.Cosine
 	dv.Similarity = &sim
 	embeddingField := vs.option.embeddingFieldName
-	if embeddingField == "" {
-		embeddingField = defaultFieldEmbedding
-	}
 	tm.Properties[embeddingField] = dv
 
 	// Settings: shards/replicas are strings in IndexSettings


### PR DESCRIPTION
- Eliminated default field values for ID, name, content, and embedding in the Elasticsearch builder.
- Updated query building methods to directly use the provided field names from options, enhancing flexibility and reducing hardcoded dependencies.

This change streamlines the configuration of Elasticsearch fields in the vector store implementation.