### PR TITLE
{examples/a2a, a2aagent, graph, flow}: improve graph a2asubagent example

### DIFF
--- a/graph/checkpoint_test.go
+++ b/graph/checkpoint_test.go
@@ -179,9 +179,9 @@ func TestCheckpointManager_Put_Smoke(t *testing.T) {
 	cfg := CreateCheckpointConfig("ln-put", "", "ns")
 	ck := NewCheckpoint(map[string]any{"a": 1}, map[string]int64{"a": 1}, nil)
 	meta := NewCheckpointMetadata(CheckpointSourceUpdate, 3)
-	_, err := cm.Put(nil, PutRequest{Config: cfg, Checkpoint: ck, Metadata: meta, NewVersions: map[string]int64{"a": 1}})
+	_, err := cm.Put(context.Background(), PutRequest{Config: cfg, Checkpoint: ck, Metadata: meta, NewVersions: map[string]int64{"a": 1}})
 	require.NoError(t, err)
-	got, err := cm.Get(nil, CreateCheckpointConfig("ln-put", ck.ID, "ns"))
+	got, err := cm.Get(context.Background(), CreateCheckpointConfig("ln-put", ck.ID, "ns"))
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	assert.Equal(t, ck.ID, got.ID)
@@ -193,7 +193,7 @@ type mockSaver struct{ byID map[string]*CheckpointTuple }
 func newMockSaver() *mockSaver { return &mockSaver{byID: map[string]*CheckpointTuple{}} }
 
 func (m *mockSaver) Get(_ context.Context, cfg map[string]any) (*Checkpoint, error) {
-	t, _ := m.GetTuple(nil, cfg)
+	t, _ := m.GetTuple(context.Background(), cfg)
 	if t == nil {
 		return nil, nil
 	}

--- a/graph/events.go
+++ b/graph/events.go
@@ -1203,8 +1203,14 @@ func NewGraphCompletionEvent(opts ...CompletionEventOption) *event.Event {
 	// consumers (including tests) can reconstruct state without additional logic.
 	if options.FinalState != nil {
 		for key, value := range options.FinalState {
+			// Skip internal/ephemeral keys that are not JSON-serializable or can race
+			// due to concurrent updates (e.g., execution context and callbacks).
 			if key == MetadataKeyNode || key == MetadataKeyPregel || key == MetadataKeyChannel ||
-				key == MetadataKeyState || key == MetadataKeyCompletion {
+				key == MetadataKeyState || key == MetadataKeyCompletion ||
+				key == StateKeyExecContext || key == StateKeyParentAgent ||
+				key == StateKeyToolCallbacks || key == StateKeyModelCallbacks ||
+				key == StateKeyAgentCallbacks || key == StateKeyCurrentNodeID ||
+				key == StateKeySession {
 				continue
 			}
 			if jsonData, err := json.Marshal(value); err == nil {


### PR DESCRIPTION

- examples/graph/a2asubagent: show A2A streaming tokens with clear labels; suppress duplicate final output when A2A streamed; simplify stage logs; remove post-node duplicate prints
- a2aagent: use strings.Builder for streaming aggregation to avoid O(n^2)
- graph/executor: build completion event from deep-copied state; add reflective deep copy fallback to avoid concurrent map iteration during JSON marshal
- graph/events: filter exec_context, callbacks, parent_agent, current_node_id, session from final snapshot to avoid races and noise
- llmflow: treat context.Canceled as normal shutdown in streaming, avoiding spurious error events

All tests pass and example output is cleaner and race-free.