### PR TITLE
session/redis support asynchronous persistence session capability with…

### DIFF
--- a/session/redis/redis_session_options.go
+++ b/session/redis/redis_session_options.go
@@ -13,13 +13,14 @@ import "time"
 
 // ServiceOpts is the options for the redis session service.
 type ServiceOpts struct {
-	sessionEventLimit int
-	url               string
-	instanceName      string
-	extraOptions      []interface{}
-	sessionTTL        time.Duration // TTL for session state and event list
-	appStateTTL       time.Duration // TTL for app state
-	userStateTTL      time.Duration // TTL for user state
+	sessionEventLimit      int
+	url                    string
+	instanceName           string
+	extraOptions           []interface{}
+	sessionTTL             time.Duration // TTL for session state and event list
+	appStateTTL            time.Duration // TTL for app state
+	userStateTTL           time.Duration // TTL for user state
+	enableAsyncPersistence bool
 }
 
 // ServiceOpt is the option for the redis session service.
@@ -77,5 +78,13 @@ func WithAppStateTTL(ttl time.Duration) ServiceOpt {
 func WithUserStateTTL(ttl time.Duration) ServiceOpt {
 	return func(opts *ServiceOpts) {
 		opts.userStateTTL = ttl
+	}
+}
+
+// WithEnableAsyncPersistence enables async persistence for session state and event list.
+// if not set, default is false.
+func WithEnableAsyncPersistence(enable bool) ServiceOpt {
+	return func(opts *ServiceOpts) {
+		opts.enableAsyncPersistence = enable
 	}
 }

--- a/session/redis/redis_session_service_test.go
+++ b/session/redis/redis_session_service_test.go
@@ -177,12 +177,29 @@ func TestService_CreateSession(t *testing.T) {
 
 func TestService_AppendEvent_UpdateTime(t *testing.T) {
 	tests := []struct {
-		name        string
-		setupEvents func() []*event.Event
-		validate    func(t *testing.T, initialTime time.Time, finalSess *session.Session, events []*event.Event)
+		name                   string
+		enableAsyncPersistence bool
+		setupEvents            func() []*event.Event
+		validate               func(t *testing.T, initialTime time.Time, finalSess *session.Session, events []*event.Event)
 	}{
 		{
 			name: "single_event_updates_time",
+			setupEvents: func() []*event.Event {
+				return []*event.Event{
+					createTestEvent("event123", "test-agent", "Test message for append event test", time.Now(), false),
+				}
+			},
+			validate: func(t *testing.T, initialTime time.Time, finalSess *session.Session, events []*event.Event) {
+				assert.True(t, finalSess.UpdatedAt.After(initialTime),
+					"UpdatedAt should be updated after appending event. Initial: %v, Updated: %v",
+					initialTime, finalSess.UpdatedAt)
+				assert.Equal(t, 1, len(finalSess.Events))
+				assert.Equal(t, events[0].ID, finalSess.Events[0].ID)
+			},
+		},
+		{
+			name:                   "single_event_updates_time_aysnc_persistence",
+			enableAsyncPersistence: true,
 			setupEvents: func() []*event.Event {
 				return []*event.Event{
 					createTestEvent("event123", "test-agent", "Test message for append event test", time.Now(), false),
@@ -246,7 +263,8 @@ func TestService_AppendEvent_UpdateTime(t *testing.T) {
 			redisURL, cleanup := setupTestRedis(t)
 			defer cleanup()
 
-			service, err := NewService(WithRedisClientURL(redisURL))
+			service, err := NewService(WithRedisClientURL(redisURL),
+				WithEnableAsyncPersistence(tt.enableAsyncPersistence))
 			require.NoError(t, err)
 			defer service.Close()
 


### PR DESCRIPTION
1. In scenarios with low concurrent user numbers, enabling asynchronous persistence can reduce the event publishing rate.