### PR TITLE
{agent, internal/flow/processor}: improve context handling in tests and clean up unused test function

### DIFF
--- a/agent/invocation_test.go
+++ b/agent/invocation_test.go
@@ -158,7 +158,9 @@ func TestAddNoticeChannelAndWait(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			if tt.ctxDelay > 0 {
-				ctx, _ = context.WithTimeout(ctx, tt.ctxDelay)
+				innerCtx, cancel := context.WithTimeout(ctx, tt.ctxDelay)
+				defer cancel()
+				ctx = innerCtx
 			}
 			complete := false
 			startTime := time.Now()

--- a/internal/flow/processor/functioncall_test.go
+++ b/internal/flow/processor/functioncall_test.go
@@ -1158,9 +1158,8 @@ func TestHandleFunctionCallsAndSendEvent_StopErrorEmitsErrorEvent(t *testing.T) 
 	p := NewFunctionCallResponseProcessor(false)
 
 	inv := &agent.Invocation{
-		AgentName:         "test-agent",
-		InvocationID:      "inv-err",
-		EventCompletionCh: make(chan string),
+		AgentName:    "test-agent",
+		InvocationID: "inv-err",
 	}
 
 	// Tool returns StopError so executeToolCall propagates error.
@@ -1301,12 +1300,4 @@ func TestMarshalChunkToText_MarshalError(t *testing.T) {
 	// Passing a function is not JSON-serializable, forcing fmt.Sprintf path.
 	text := marshalChunkToText(func() {})
 	require.NotEmpty(t, text)
-}
-
-func TestCheckContextCancelled(t *testing.T) {
-	p := NewFunctionCallResponseProcessor(false)
-	require.NoError(t, p.checkContextCancelled(context.Background()))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-	require.Error(t, p.checkContextCancelled(ctx))
 }


### PR DESCRIPTION
- Updated TestAddNoticeChannelAndWait to ensure proper context timeout handling with cancellation.
- Removed the unused TestCheckContextCancelled function to streamline test suite.