### PR TITLE
{event,invocation,processor/content}: ​​refactor event struct for improved filtering and clearer Branch field guidelines​​ 

### DIFF
--- a/agent/a2aagent/a2a_converter.go
+++ b/agent/a2aagent/a2a_converter.go
@@ -212,7 +212,12 @@ func (d *defaultA2AEventConverter) buildRespEvent(
 		Role:    model.RoleAssistant,
 		Content: content,
 	}
-	event := event.New(invocation.InvocationID, agentName)
+	event := event.New(
+		invocation.InvocationID,
+		agentName,
+		event.WithBranch(invocation.Branch),
+		event.WithFilterKey(invocation.GetEventFilterKey()),
+	)
 	if isStreaming {
 		event.Response = &model.Response{
 			Choices:   []model.Choice{{Delta: message}},

--- a/agent/chainagent/chain_agent.go
+++ b/agent/chainagent/chain_agent.go
@@ -105,15 +105,15 @@ func (a *ChainAgent) createSubAgentInvocation(
 	subAgent agent.Agent,
 	baseInvocation *agent.Invocation,
 ) *agent.Invocation {
-	// Create a copy of the invocation - no shared state mutation.
-	subInvocation := baseInvocation.Clone(agent.WithInvocationAgent(subAgent))
-
-	// Set branch info to track sequence in multi-agent scenarios.
-	// Do not include sub-agent name in branch, so that the chain sub-agents can
-	// observe each other's events.
-	if subInvocation.Branch == "" {
-		subInvocation.Branch = a.name
+	eventFilterKey := baseInvocation.GetEventFilterKey()
+	if eventFilterKey == "" {
+		eventFilterKey = subAgent.Info().Name
 	}
+	// Create a copy of the invocation - no shared state mutation.
+	subInvocation := baseInvocation.Clone(
+		agent.WithInvocationAgent(subAgent),
+		agent.WithInvocationEventFilterKey(eventFilterKey),
+	)
 
 	return subInvocation
 }

--- a/agent/chainagent/chain_agent_test.go
+++ b/agent/chainagent/chain_agent_test.go
@@ -351,34 +351,22 @@ func TestCreateSubAgentInvocation(t *testing.T) {
 	parent := New(
 		"parent",
 	)
-	base := &agent.Invocation{
-		InvocationID: "inv-1",
-		AgentName:    "parent",
-		Message:      model.Message{Role: model.RoleUser, Content: "hi"},
-		Branch:       "root",
-	}
-
-	sub := &mockMinimalAgent{name: "child"}
-	inv := parent.createSubAgentInvocation(sub, base)
-
-	require.Equal(t, "child", inv.AgentName)
-	require.Equal(t, "root", inv.Branch)
-	// Ensure original invocation not mutated.
-	require.Equal(t, "parent", base.AgentName)
-	require.Equal(t, "root", base.Branch)
-}
-
-func TestCreateSubAgentInvokeNoBranch(t *testing.T) {
-	parent := New(
-		"parent",
+	base := agent.NewInvocation(
+		agent.WithInvocationAgent(parent),
+		agent.WithInvocationEventFilterKey("root"),
+		agent.WithInvocationMessage(model.Message{Role: model.RoleUser, Content: "hi"}),
 	)
-	base := &agent.Invocation{InvocationID: "id", AgentName: "parent"}
-	sub := &mockMinimalAgent{name: "child"}
+	require.Equal(t, "parent", base.AgentName)
+	require.Equal(t, "parent", base.Branch)
+	require.Equal(t, "root", base.GetEventFilterKey())
 
+	sub := &mockMinimalAgent{name: "child"}
 	inv := parent.createSubAgentInvocation(sub, base)
 
 	require.Equal(t, "child", inv.AgentName)
-	require.Equal(t, "parent", inv.Branch)
+	require.Equal(t, "root", base.GetEventFilterKey())
+	// Ensure original invocation not mutated.
+	require.Equal(t, "parent"+agent.BranchDelimiter+"child", inv.Branch)
 }
 
 func TestChainAgent_FindSubAgentAndInfo(t *testing.T) {

--- a/agent/cycleagent/cycle_agent.go
+++ b/agent/cycleagent/cycle_agent.go
@@ -125,15 +125,15 @@ func (a *CycleAgent) createSubAgentInvocation(
 	subAgent agent.Agent,
 	baseInvocation *agent.Invocation,
 ) *agent.Invocation {
-	// Create a copy of the invocation - no shared state mutation.
-	subInvocation := baseInvocation.Clone(agent.WithInvocationAgent(subAgent))
-
-	// Set branch info for hierarchical event filtering.
-	// Do not use the sub-agent name here, it will cause the sub-agent unable to see the
-	// previous agent's conversation history.
-	if subInvocation.Branch == "" {
-		subInvocation.Branch = a.name
+	eventFilterKey := baseInvocation.GetEventFilterKey()
+	if eventFilterKey == "" {
+		eventFilterKey = subAgent.Info().Name
 	}
+	// Create a copy of the invocation - no shared state mutation.
+	subInvocation := baseInvocation.Clone(
+		agent.WithInvocationAgent(subAgent),
+		agent.WithInvocationEventFilterKey(eventFilterKey),
+	)
 
 	return subInvocation
 }

--- a/agent/cycleagent/cycle_agent_test.go
+++ b/agent/cycleagent/cycle_agent_test.go
@@ -533,14 +533,14 @@ func (e *errorAgent) Run(ctx context.Context, inv *agent.Invocation) (<-chan *ev
 
 func TestCycleAgent_CreateSubAgentInvoke(t *testing.T) {
 	parent := newFromLegacy(legacyOptions{Name: "parent"})
-	base := &agent.Invocation{InvocationID: "base", AgentName: "parent", Branch: "branchA"}
+	base := agent.NewInvocation(agent.WithInvocationAgent(parent))
 	child := &noopAgent{name: "child"}
 
 	inv := parent.createSubAgentInvocation(child, base)
 
 	require.Equal(t, "child", inv.AgentName)
 	// Branch should stay unchanged when base.Branch non-empty.
-	require.Equal(t, "branchA", inv.Branch)
+	require.Equal(t, "parent"+agent.BranchDelimiter+"child", inv.Branch)
 	// Ensure TransferInfo cleared.
 	require.Nil(t, inv.TransferInfo)
 }

--- a/agent/invocation.go
+++ b/agent/invocation.go
@@ -31,6 +31,12 @@ const (
 
 	// AppendEventNoticeKeyPrefix is the prefix for append event notice keys
 	AppendEventNoticeKeyPrefix = "append_event:"
+
+	// BranchDelimiter is the delimiter for branch
+	BranchDelimiter = "/"
+
+	// EventFilterKeyDelimiter is the delimiter for event filter key
+	EventFilterKeyDelimiter = "/"
 )
 
 // TransferInfo contains information about a pending agent transfer.
@@ -51,7 +57,8 @@ type Invocation struct {
 	AgentName string
 	// InvocationID is the ID of the invocation.
 	InvocationID string
-	// Branch is the branch identifier for hierarchical event filtering.
+	// Branch records agent execution chain information.
+	// In multi-agent mode, this is useful for tracing agent execution trajectories.
 	Branch string
 	// EndInvocation is a flag that indicates if the invocation is complete.
 	EndInvocation bool
@@ -83,6 +90,9 @@ type Invocation struct {
 	// noticeChanMap is used to signal when events are written to the session.
 	noticeChanMap map[string]chan any
 	noticeMu      *sync.Mutex
+
+	// eventFilterKey is used to filter events for flow or agent
+	eventFilterKey string
 }
 
 // WaitNoticeTimeoutError represents an error that signals the wait notice timeout.
@@ -148,27 +158,50 @@ func NewInvocation(invocationOpts ...InvocationOptions) *Invocation {
 		opt(inv)
 	}
 
+	if inv.Branch == "" {
+		inv.Branch = inv.AgentName
+	}
+
+	if inv.eventFilterKey == "" && inv.AgentName != "" {
+		inv.eventFilterKey = inv.AgentName
+	}
+
 	return inv
 }
 
 // Clone clone a new invocation
 func (inv *Invocation) Clone(invocationOpts ...InvocationOptions) *Invocation {
 	newInv := &Invocation{
-		InvocationID:    inv.InvocationID,
-		Branch:          inv.Branch,
+		InvocationID:    uuid.NewString(),
 		Session:         inv.Session,
 		Message:         inv.Message,
 		RunOptions:      inv.RunOptions,
 		ArtifactService: inv.ArtifactService,
 		noticeMu:        inv.noticeMu,
 		noticeChanMap:   inv.noticeChanMap,
+		eventFilterKey:  inv.eventFilterKey,
 	}
 
 	for _, opt := range invocationOpts {
 		opt(newInv)
 	}
 
+	if inv.Branch != "" && newInv.AgentName != "" {
+		newInv.Branch = inv.Branch + BranchDelimiter + newInv.AgentName
+	} else if newInv.AgentName != "" {
+		newInv.Branch = newInv.AgentName
+	}
+
+	if newInv.eventFilterKey == "" && newInv.AgentName != "" {
+		newInv.eventFilterKey = newInv.AgentName
+	}
+
 	return newInv
+}
+
+// GetEventFilterKey get event filter key
+func (inv *Invocation) GetEventFilterKey() string {
+	return inv.eventFilterKey
 }
 
 // CreateBranchInvocation create a new invocation for branch agent

--- a/agent/invocation_options.go
+++ b/agent/invocation_options.go
@@ -126,3 +126,10 @@ func WithInvocationArtifactService(artifactService artifact.Service) InvocationO
 		inv.ArtifactService = artifactService
 	}
 }
+
+// WithInvocationEventFilterKey set eventFilterKey for the Invocation.
+func WithInvocationEventFilterKey(key string) InvocationOptions {
+	return func(inv *Invocation) {
+		inv.eventFilterKey = key
+	}
+}

--- a/agent/invocation_test.go
+++ b/agent/invocation_test.go
@@ -65,7 +65,7 @@ func TestInvocation_Clone(t *testing.T) {
 	subAgent := &mockAgent{name: "test-agent"}
 	subInv := inv.Clone(WithInvocationAgent(subAgent))
 	require.NotNil(t, subInv)
-	require.Equal(t, "test-invocation", subInv.InvocationID)
+	require.NotEqual(t, "test-invocation", subInv.InvocationID)
 	require.Equal(t, "test-agent", subInv.AgentName)
 	require.Equal(t, "Hello", subInv.Message.Content)
 	require.Equal(t, inv.noticeChanMap, subInv.noticeChanMap)

--- a/agent/parallelagent/parallel_agent.go
+++ b/agent/parallelagent/parallel_agent.go
@@ -105,13 +105,16 @@ func (a *ParallelAgent) createBranchInvocation(
 	baseInvocation *agent.Invocation,
 ) *agent.Invocation {
 	// Create unique invocation ID for this branch.
-	branchSuffix := a.name + "." + subAgent.Info().Name
-	branchInvocationID := baseInvocation.InvocationID + "." + branchSuffix
+	eventFilterKey := baseInvocation.GetEventFilterKey()
+	if eventFilterKey == "" {
+		eventFilterKey = a.name + agent.EventFilterKeyDelimiter + subAgent.Info().Name
+	} else {
+		eventFilterKey += agent.EventFilterKeyDelimiter + subAgent.Info().Name
+	}
 
 	branchInvocation := baseInvocation.Clone(
 		agent.WithInvocationAgent(subAgent),
-		agent.WithInvocationID(branchInvocationID),
-		agent.WithInvocationBranch(branchInvocationID),
+		agent.WithInvocationEventFilterKey(eventFilterKey),
 	)
 
 	return branchInvocation

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -230,7 +230,13 @@ func (f *Flow) handleAfterModelCallbacks(
 
 // createLLMResponseEvent creates a new LLM response event.
 func (f *Flow) createLLMResponseEvent(invocation *agent.Invocation, response *model.Response, llmRequest *model.Request) *event.Event {
-	llmResponseEvent := event.New(invocation.InvocationID, invocation.AgentName, event.WithResponse(response), event.WithBranch(invocation.Branch))
+	llmResponseEvent := event.New(
+		invocation.InvocationID,
+		invocation.AgentName,
+		event.WithResponse(response),
+		event.WithBranch(invocation.Branch),
+		event.WithFilterKey(invocation.GetEventFilterKey()),
+	)
 	if len(response.Choices) > 0 && len(response.Choices[0].Message.ToolCalls) > 0 {
 		llmResponseEvent.LongRunningToolIDs = collectLongRunningToolIDs(response.Choices[0].Message.ToolCalls, llmRequest.Tools)
 	}

--- a/internal/flow/processor/basic.go
+++ b/internal/flow/processor/basic.go
@@ -76,7 +76,12 @@ func (p *BasicRequestProcessor) ProcessRequest(
 
 	// Send a preprocessing event.
 	if invocation != nil {
-		evt := event.New(invocation.InvocationID, invocation.AgentName)
+		evt := event.New(
+			invocation.InvocationID,
+			invocation.AgentName,
+			event.WithBranch(invocation.Branch),
+			event.WithFilterKey(invocation.GetEventFilterKey()),
+		)
 		evt.Object = model.ObjectTypePreprocessingBasic
 
 		select {

--- a/internal/flow/processor/codeexecution.go
+++ b/internal/flow/processor/codeexecution.go
@@ -57,7 +57,11 @@ func (p *CodeExecutionResponseProcessor) ProcessResponse(
 	truncatedContent := rsp.Choices[0].Message.Content // todo: truncate the content
 
 	//  [Step 2] Executes the code and emit 2 Events for code and execution result.
-	ch <- event.New(invocation.InvocationID, invocation.AgentName, event.WithBranch(invocation.Branch),
+	ch <- event.New(
+		invocation.InvocationID,
+		invocation.AgentName,
+		event.WithBranch(invocation.Branch),
+		event.WithFilterKey(invocation.GetEventFilterKey()),
 		event.WithObject(model.ObjectTypePostprocessingCodeExecution),
 		event.WithResponse(&model.Response{
 			Choices: []model.Choice{
@@ -72,7 +76,11 @@ func (p *CodeExecutionResponseProcessor) ProcessResponse(
 		ExecutionID: invocation.Session.ID,
 	})
 	if err != nil {
-		ch <- event.New(invocation.InvocationID, invocation.AgentName, event.WithBranch(invocation.Branch),
+		ch <- event.New(
+			invocation.InvocationID,
+			invocation.AgentName,
+			event.WithBranch(invocation.Branch),
+			event.WithFilterKey(invocation.GetEventFilterKey()),
 			event.WithObject(model.ObjectTypePostprocessingCodeExecution),
 			event.WithResponse(&model.Response{
 				Choices: []model.Choice{
@@ -83,7 +91,11 @@ func (p *CodeExecutionResponseProcessor) ProcessResponse(
 			}))
 		return
 	}
-	ch <- event.New(invocation.InvocationID, invocation.AgentName, event.WithBranch(invocation.Branch),
+	ch <- event.New(
+		invocation.InvocationID,
+		invocation.AgentName,
+		event.WithBranch(invocation.Branch),
+		event.WithFilterKey(invocation.GetEventFilterKey()),
 		event.WithObject(model.ObjectTypePostprocessingCodeExecution),
 		event.WithResponse(&model.Response{
 			Choices: []model.Choice{

--- a/internal/flow/processor/content.go
+++ b/internal/flow/processor/content.go
@@ -89,7 +89,7 @@ func (p *ContentRequestProcessor) ProcessRequest(
 	// Process session events if available and includeContents is not "none".
 	if p.IncludeContents != IncludeContentsNone && invocation.Session != nil {
 		sessionMessages := p.getContents(
-			invocation.Branch, // Current branch for filtering
+			invocation.GetEventFilterKey(), // Current branch for filtering
 			invocation.Session.Events,
 			invocation.AgentName, // Current agent name for filtering
 		)
@@ -110,12 +110,14 @@ func (p *ContentRequestProcessor) ProcessRequest(
 
 	// Send a preprocessing event.
 	if invocation != nil {
-		evt := event.New(invocation.InvocationID, invocation.AgentName)
-		evt.Object = model.ObjectTypePreprocessingContent
-		evt.Branch = invocation.Branch // Set branch for hierarchical event filtering
-
 		select {
-		case ch <- evt:
+		case ch <- event.New(
+			invocation.InvocationID,
+			invocation.AgentName,
+			event.WithBranch(invocation.Branch),
+			event.WithFilterKey(invocation.GetEventFilterKey()),
+			event.WithObject(model.ObjectTypePreprocessingContent),
+		):
 			log.Debugf("Content request processor: sent preprocessing event")
 		case <-ctx.Done():
 			log.Debugf("Content request processor: context cancelled")
@@ -125,7 +127,7 @@ func (p *ContentRequestProcessor) ProcessRequest(
 
 // getContents gets the contents for the LLM request from session events.
 func (p *ContentRequestProcessor) getContents(
-	currentBranch string,
+	filterKey string,
 	events []event.Event,
 	agentName string,
 ) []model.Message {
@@ -141,12 +143,12 @@ func (p *ContentRequestProcessor) getContents(
 
 		// Skip events without content, or generated neither by user nor by model
 		// or has empty text. E.g. events purely for mutating session states.
-		if !p.hasValidContent(&evt) {
+		if p.IncludeContents == IncludeContentsFiltered && !evt.ValidContent() {
 			continue
 		}
 
 		// Skip events not belong to current branch.
-		if !p.isEventBelongsToBranch(currentBranch, &evt) {
+		if !evt.Filter(filterKey) {
 			continue
 		}
 
@@ -176,40 +178,6 @@ func (p *ContentRequestProcessor) getContents(
 	}
 
 	return messages
-}
-
-// hasValidContent checks if an event has valid content for message generation.
-func (p *ContentRequestProcessor) hasValidContent(evt *event.Event) bool {
-	// Check if event has choices with content.
-	if len(evt.Choices) > 0 {
-		for _, choice := range evt.Choices {
-			if choice.Message.Content != "" {
-				return true
-			}
-			if choice.Delta.Content != "" {
-				return true
-			}
-		}
-	}
-	if len(evt.Choices) > 0 && evt.Choices[0].Message.ToolID != "" {
-		return true
-	}
-	if len(evt.Choices) > 0 && len(evt.Choices[0].Message.ToolCalls) > 0 {
-		return true
-	}
-	return false
-}
-
-// isEventBelongsToBranch checks if an event belongs to a specific branch.
-// Event belongs to a branch when event.branch is prefix of the invocation branch.
-func (p *ContentRequestProcessor) isEventBelongsToBranch(
-	invocationBranch string,
-	evt *event.Event,
-) bool {
-	if invocationBranch == "" || evt.Branch == "" {
-		return true
-	}
-	return strings.HasPrefix(invocationBranch, evt.Branch)
 }
 
 // isOtherAgentReply checks whether the event is a reply from another agent.
@@ -297,11 +265,11 @@ func (p *ContentRequestProcessor) rearrangeLatestFuncResp(
 
 	// Check if latest event is a function response.
 	lastEvent := events[len(events)-1]
-	if !p.isFunctionResponseEvent(&lastEvent) {
+	if !lastEvent.IsToolResultReponse() {
 		return events
 	}
 
-	functionResponseIDs := p.getFunctionResponseIDs(&lastEvent)
+	functionResponseIDs := lastEvent.GetToolResultIDs()
 	if len(functionResponseIDs) == 0 {
 		return events
 	}
@@ -310,9 +278,9 @@ func (p *ContentRequestProcessor) rearrangeLatestFuncResp(
 	functionCallEventIdx := -1
 	for i := len(events) - 2; i >= 0; i-- {
 		evt := &events[i]
-		if p.isFunctionCallEvent(evt) {
-			functionCallIDs := p.getFunctionCallIDs(evt)
-			for responseID := range functionResponseIDs {
+		if evt.IsToolCallReponse() {
+			functionCallIDs := toMap(evt.GetToolCallIDs())
+			for _, responseID := range functionResponseIDs {
 				if functionCallIDs[responseID] {
 					functionCallEventIdx = i
 					break
@@ -332,9 +300,9 @@ func (p *ContentRequestProcessor) rearrangeLatestFuncResp(
 	var functionResponseEvents []event.Event
 	for i := functionCallEventIdx + 1; i < len(events); i++ {
 		evt := &events[i]
-		if p.isFunctionResponseEvent(evt) {
-			responseIDs := p.getFunctionResponseIDs(evt)
-			for responseID := range functionResponseIDs {
+		if evt.IsToolResultReponse() {
+			responseIDs := toMap(evt.GetToolResultIDs())
+			for _, responseID := range functionResponseIDs {
 				if responseIDs[responseID] {
 					functionResponseEvents = append(functionResponseEvents, *evt)
 					break
@@ -366,9 +334,9 @@ func (p *ContentRequestProcessor) rearrangeAsyncFuncRespHist(
 		// Create a local copy to avoid implicit memory aliasing.
 		evt := evt
 
-		if p.isFunctionResponseEvent(&evt) {
-			responseIDs := p.getFunctionResponseIDs(&evt)
-			for responseID := range responseIDs {
+		if evt.IsToolResultReponse() {
+			responseIDs := evt.GetToolResultIDs()
+			for _, responseID := range responseIDs {
 				functionCallIDToResponseEventIndex[responseID] = i
 			}
 		}
@@ -379,13 +347,13 @@ func (p *ContentRequestProcessor) rearrangeAsyncFuncRespHist(
 		// Create a local copy to avoid implicit memory aliasing.
 		evt := evt
 
-		if p.isFunctionResponseEvent(&evt) {
+		if evt.IsToolResultReponse() {
 			// Function response should be handled with function call below.
 			continue
-		} else if p.isFunctionCallEvent(&evt) {
-			functionCallIDs := p.getFunctionCallIDs(&evt)
+		} else if evt.IsToolCallReponse() {
+			functionCallIDs := evt.GetToolCallIDs()
 			var responseEventIndices []int
-			for callID := range functionCallIDs {
+			for _, callID := range functionCallIDs {
 				if idx, exists := functionCallIDToResponseEventIndex[callID]; exists {
 					responseEventIndices = append(responseEventIndices, idx)
 				}
@@ -414,40 +382,6 @@ func (p *ContentRequestProcessor) rearrangeAsyncFuncRespHist(
 	return resultEvents
 }
 
-// Helper functions for function call/response detection and processing.
-
-func (p *ContentRequestProcessor) isFunctionCallEvent(evt *event.Event) bool {
-	if len(evt.Choices) == 0 {
-		return false
-	}
-	return len(evt.Choices[0].Message.ToolCalls) > 0
-}
-
-func (p *ContentRequestProcessor) isFunctionResponseEvent(evt *event.Event) bool {
-	if len(evt.Choices) == 0 {
-		return false
-	}
-	return evt.Choices[0].Message.ToolID != ""
-}
-
-func (p *ContentRequestProcessor) getFunctionCallIDs(evt *event.Event) map[string]bool {
-	ids := make(map[string]bool)
-	if len(evt.Choices) > 0 {
-		for _, toolCall := range evt.Choices[0].Message.ToolCalls {
-			ids[toolCall.ID] = true
-		}
-	}
-	return ids
-}
-
-func (p *ContentRequestProcessor) getFunctionResponseIDs(evt *event.Event) map[string]bool {
-	ids := make(map[string]bool)
-	if len(evt.Choices) > 0 && evt.Choices[0].Message.ToolID != "" {
-		ids[evt.Choices[0].Message.ToolID] = true
-	}
-	return ids
-}
-
 // mergeFunctionResponseEvents merges a list of function_response events into one event.
 func (p *ContentRequestProcessor) mergeFunctionResponseEvents(
 	functionResponseEvents []event.Event,
@@ -474,4 +408,12 @@ func (p *ContentRequestProcessor) mergeFunctionResponseEvents(
 	}
 
 	return mergedEvent
+}
+
+func toMap(ids []string) map[string]bool {
+	m := make(map[string]bool)
+	for _, id := range ids {
+		m[id] = true
+	}
+	return m
 }

--- a/internal/flow/processor/functioncall.go
+++ b/internal/flow/processor/functioncall.go
@@ -729,6 +729,7 @@ func (f *FunctionCallResponseProcessor) buildPartialToolResponseEvent(
 		inv.AgentName,
 		event.WithResponse(resp),
 		event.WithBranch(inv.Branch),
+		event.WithFilterKey(inv.GetEventFilterKey()),
 	)
 }
 
@@ -858,9 +859,11 @@ func mergeParallelToolCallResponseEvents(es []*event.Event) *event.Event {
 			baseEvent.Author,
 			event.WithResponse(resp),
 			event.WithBranch(baseEvent.Branch),
+			event.WithFilterKey(baseEvent.GetFilterKey()),
 		)
 	} else {
 		// Fallback: construct without base metadata.
+		// TODO: filterKey not set
 		merged = event.New("", "", event.WithResponse(resp))
 	}
 	// If any child event prefers skipping summarization, propagate it.

--- a/internal/flow/processor/identity.go
+++ b/internal/flow/processor/identity.go
@@ -104,8 +104,13 @@ func (p *IdentityRequestProcessor) ProcessRequest(
 
 	// Send a preprocessing event.
 	if invocation != nil {
-		evt := event.New(invocation.InvocationID, invocation.AgentName)
-		evt.Object = model.ObjectTypePreprocessingIdentity
+		evt := event.New(
+			invocation.InvocationID,
+			invocation.AgentName,
+			event.WithObject(model.ObjectTypePreprocessingIdentity),
+			event.WithBranch(invocation.Branch),
+			event.WithFilterKey(invocation.GetEventFilterKey()),
+		)
 
 		select {
 		case ch <- evt:

--- a/internal/flow/processor/instruction.go
+++ b/internal/flow/processor/instruction.go
@@ -217,8 +217,13 @@ func (p *InstructionRequestProcessor) sendPreprocessingEvent(
 		return
 	}
 
-	evt := event.New(invocation.InvocationID, invocation.AgentName)
-	evt.Object = model.ObjectTypePreprocessingInstruction
+	evt := event.New(
+		invocation.InvocationID,
+		invocation.AgentName,
+		event.WithBranch(invocation.Branch),
+		event.WithFilterKey(invocation.GetEventFilterKey()),
+		event.WithObject(model.ObjectTypePreprocessingInstruction),
+	)
 
 	select {
 	case ch <- evt:

--- a/internal/flow/processor/output.go
+++ b/internal/flow/processor/output.go
@@ -100,9 +100,14 @@ func (p *OutputResponseProcessor) emitTypedStructuredOutput(
 		log.Errorf("Structured output unmarshal failed: %v", err)
 		return
 	}
-	typedEvt := event.New(invocation.InvocationID, invocation.AgentName,
+	typedEvt := event.New(
+		invocation.InvocationID,
+		invocation.AgentName,
 		event.WithObject(model.ObjectTypeStateUpdate),
 		event.WithStructuredOutputPayload(instance),
+		event.WithStructuredOutputPayload(instance),
+		event.WithBranch(invocation.Branch),
+		event.WithFilterKey(invocation.GetEventFilterKey()),
 	)
 	typedEvt.RequiresCompletion = true
 	select {
@@ -142,6 +147,8 @@ func (p *OutputResponseProcessor) handleOutputKey(
 	stateEvent := event.New(invocation.InvocationID, invocation.AgentName,
 		event.WithObject(model.ObjectTypeStateUpdate),
 		event.WithStateDelta(stateDelta),
+		event.WithBranch(invocation.Branch),
+		event.WithFilterKey(invocation.GetEventFilterKey()),
 	)
 	stateEvent.RequiresCompletion = true
 	select {

--- a/internal/flow/processor/planning.go
+++ b/internal/flow/processor/planning.go
@@ -73,8 +73,13 @@ func (p *PlanningRequestProcessor) ProcessRequest(
 
 	// Send a preprocessing event.
 	if invocation != nil {
-		evt := event.New(invocation.InvocationID, invocation.AgentName)
-		evt.Object = model.ObjectTypePreprocessingPlanning
+		evt := event.New(
+			invocation.InvocationID,
+			invocation.AgentName,
+			event.WithBranch(invocation.Branch),
+			event.WithFilterKey(invocation.GetEventFilterKey()),
+			event.WithObject(model.ObjectTypePreprocessingPlanning),
+		)
 
 		select {
 		case ch <- evt:
@@ -156,8 +161,13 @@ func (p *PlanningResponseProcessor) ProcessResponse(
 
 	// Send a postprocessing event.
 	if invocation != nil {
-		evt := event.New(invocation.InvocationID, invocation.AgentName)
-		evt.Object = model.ObjectTypePostprocessingPlanning
+		evt := event.New(
+			invocation.InvocationID,
+			invocation.AgentName,
+			event.WithBranch(invocation.Branch),
+			event.WithFilterKey(invocation.GetEventFilterKey()),
+			event.WithObject(model.ObjectTypePostprocessingPlanning),
+		)
 
 		select {
 		case ch <- evt:

--- a/internal/flow/processor/transfer.go
+++ b/internal/flow/processor/transfer.go
@@ -75,8 +75,13 @@ func (p *TransferResponseProcessor) ProcessResponse(
 	}
 
 	// Create transfer event to notify about the handoff.
-	transferEvent := event.New(invocation.InvocationID, invocation.AgentName)
-	transferEvent.Object = model.ObjectTypeTransfer
+	transferEvent := event.New(
+		invocation.InvocationID,
+		invocation.AgentName,
+		event.WithBranch(invocation.Branch),
+		event.WithFilterKey(invocation.GetEventFilterKey()),
+		event.WithObject(model.ObjectTypeTransfer),
+	)
 	transferEvent.Response = &model.Response{
 		ID:        "transfer-" + rsp.ID,
 		Object:    model.ObjectTypeTransfer,
@@ -107,7 +112,6 @@ func (p *TransferResponseProcessor) ProcessResponse(
 	targetInvocation := invocation.Clone(
 		agent.WithInvocationAgent(targetAgent),
 		agent.WithInvocationEndInvocation(transferInfo.EndInvocation),
-		agent.WithInvocationBranch(invocation.Branch),
 	)
 
 	// Set the message for the target agent.

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -124,7 +124,7 @@ func (r *runner) Run(
 	}
 
 	// Generate invocation ID.
-	invocationID := "invocation-" + uuid.New().String()
+	invocationID := uuid.New().String()
 
 	// Append the incoming user message to the session if it has content.
 	if message.Content != "" {
@@ -161,6 +161,7 @@ func (r *runner) Run(
 		agent.WithInvocationAgent(r.agent),
 		agent.WithInvocationRunOptions(ro),
 		agent.WithInvocationArtifactService(r.artifactService),
+		agent.WithInvocationEventFilterKey("runner"),
 	)
 
 	// Ensure the invocation can be accessed by downstream components (e.g., tools)

--- a/session/redis/redis_session_service.go
+++ b/session/redis/redis_session_service.go
@@ -690,7 +690,7 @@ func processEventCmd(cmd *redis.StringSliceCmd) ([]event.Event, error) {
 	events := make([]event.Event, 0, len(eventsBytes))
 	for _, eventBytes := range eventsBytes {
 		event := &event.Event{}
-		if err := json.Unmarshal([]byte(eventBytes), &event); err != nil {
+		if err := event.Unmarshal([]byte(eventBytes)); err != nil {
 			return nil, fmt.Errorf("unmarshal event failed: %w", err)
 		}
 		events = append(events, *event)
@@ -718,7 +718,7 @@ func (s *Service) addEvent(ctx context.Context, key session.Key, event *event.Ev
 		return fmt.Errorf("marshal session state failed: %w", err)
 	}
 
-	eventBytes, err := json.Marshal(event)
+	eventBytes, err := event.Marshal()
 	if err != nil {
 		return fmt.Errorf("marshal event failed: %w", err)
 	}


### PR DESCRIPTION
1.  The `Branch` field is an exported field. When used for agent event visibility filtering, it poses usage risks. For example, if the business layer modifies the field value, the agent may fail to retrieve the corresponding event. Perhaps this field should only be used within the framework
2. The following improvements have been made to address the above issues:
- [ ] The `Branch` field is now used to record and track the Agent execution chain information, making it easier to observe the Agent chain details when an Event is generated.
- [ ] Added a non-exported field `filterKey` to both invocation and event, specifically for framework-level event filtering processing.
- [ ] Added a non-exported field `version` for `Event` to ensure proper processing of persisted old version event data.
- [ ] Introduced a new eventJSON struct to handle the serialization and deserialization of `Event`, specifically for processing the non-exported fields `filterKey` and `version`.