### PR TITLE
flow/processor: drain parallel results channel to avoid missing tool responses

### DIFF
--- a/internal/flow/processor/functioncall_test.go
+++ b/internal/flow/processor/functioncall_test.go
@@ -1201,8 +1201,7 @@ func TestCollectParallelToolResults_ContextCancelled(t *testing.T) {
 	p := NewFunctionCallResponseProcessor(true)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	res := p.collectParallelToolResults(ctx, make(chan toolResult),
-		make(chan struct{}), 2)
+	res := p.collectParallelToolResults(ctx, make(chan toolResult), 2)
 	require.NotNil(t, res)
 }
 


### PR DESCRIPTION


Previously, collectParallelToolResults could return early when the 'done' signal was selected before all buffered results from resultChan were consumed. This caused nondeterministic partial results (e.g., only 1 choice collected when 2 were expected).

Changes:
- Remove dependence on a separate 'done' signal; drain resultChan until close.
- Preserve order by index and respect context cancellation for partial returns.
- Update call site and test to match new function signature.

Impact:
- Deterministic and complete collection of parallel tool call results.
- Fixes TestExecuteToolCallsInParallel and stabilizes parallel tool handling.