### PR TITLE
graph: correct empty metadata filter handling and improve example event reporting

### DIFF
--- a/graph/checkpoint/inmemory/inmemory.go
+++ b/graph/checkpoint/inmemory/inmemory.go
@@ -489,7 +489,8 @@ func (s *Saver) passesBeforeFilter(tuple *graph.CheckpointTuple, checkpoints map
 
 // passesMetadataFilter checks if checkpoint passes the metadata filter.
 func (s *Saver) passesMetadataFilter(tuple *graph.CheckpointTuple, metadata map[string]any) bool {
-	if metadata == nil {
+	// Treat nil or empty metadata map as "no metadata filter".
+	if len(metadata) == 0 {
 		return true
 	}
 

--- a/graph/checkpoint/sqlite/sqlite.go
+++ b/graph/checkpoint/sqlite/sqlite.go
@@ -428,10 +428,9 @@ func (s *Saver) processSingleRow(ctx context.Context, rows *sql.Rows,
 }
 
 // matchesMetadataFilter checks if a tuple matches the metadata filter.
-func (s *Saver) matchesMetadataFilter(tuple *graph.CheckpointTuple,
-	filter *graph.CheckpointFilter) bool {
-
-	if filter == nil || filter.Metadata == nil {
+func (s *Saver) matchesMetadataFilter(tuple *graph.CheckpointTuple, filter *graph.CheckpointFilter) bool {
+	// Treat nil or empty metadata map as "no metadata filter".
+	if filter == nil || len(filter.Metadata) == 0 {
 		return true
 	}
 


### PR DESCRIPTION

- SQLite saver: treat nil/empty metadata filter as no filter in matchesMetadataFilter to avoid unintended exclusion when only Limit is set.
- In-memory saver: same behavior in passesMetadataFilter for parity with SQLite.
- Example CLI: detect node execution by parsing _node_metadata regardless of author; remove unreliable current_node_id fallback; avoid double-counting by not incrementing from metadata path; keep counting from explicit graph.node.complete events.
- Example CLI: allow multi-word additional input on resume by joining remaining args and trimming quotes.

Why
- The list command constructed a CheckpointFilter with an empty Metadata map, which SQLite treated as a real filter. Because tuple.Metadata.Extra is nil (omitempty), everything was filtered, yielding "No checkpoints found" while tree/history worked (they used nil filter).
- Event parsing previously assumed author == graph-node or relied on current_node_id in completion events, which is not guaranteed. Parsing _node_metadata is robust.

Impact
- list <lineage-id> now returns the expected checkpoints across storage backends.
- Node execution reporting in the example reflects actual runs; "No nodes executed" shows only when the frontier has no work (e.g., rerunning a lineage at its terminal checkpoint).