### PR TITLE
docs: fix edit_url and improve the robustness of multi-level lists

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: tRPC-Agent-Go
 site_url: https://trpc-group.github.io/trpc-agent-go/
 repo_url: https://github.com/trpc-group/trpc-agent-go
 repo_name: trpc-group/trpc-agent-go
-edit_uri: edit/main/docs/
+edit_uri: edit/main/docs/mkdocs/
 docs_dir: mkdocs/
 
 nav:
@@ -95,6 +95,7 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.snippets
   - pymdownx.superfences
+  - mdx_truly_sane_lists
 
 extra_css:
   - assets/stylesheets/extra.css

--- a/docs/mkdocs/assets/requirements.txt
+++ b/docs/mkdocs/assets/requirements.txt
@@ -6,3 +6,4 @@ mkdocs-git-revision-date-localized-plugin==1.4.7
 mkdocs-material==9.6.17
 mkdocs-material-extensions==1.3.1
 mkdocs-static-i18n==1.3.0
+mdx_truly_sane_lists==1.3


### PR DESCRIPTION
1. fix edit_url
2. add mdx_truly_sane_lists, allowed rendering of multi-level lists with 2/4 spaces