### PR TITLE
graph: pass pre-callback state to node; reorder AfterNode callbacks

### DIFF
--- a/examples/graph/per_node_callbacks/README.md
+++ b/examples/graph/per_node_callbacks/README.md
@@ -32,8 +32,8 @@ Global BeforeNode Callbacks → Per-Node BeforeNode Callbacks → Node Execution
    - Can add metadata
 
 3. **OnNodeError Callbacks**: Execute when node fails
-   - Cannot change the error
-   - Useful for logging, monitoring, cleanup
+   - Cannot change the error nor continue execution
+   - Useful for logging/metrics; changes to state here are not persisted
 
 ## 🚀 Usage
 
@@ -74,8 +74,7 @@ graph.NewStateGraph(schema).
     AddNode("risky_node", riskyFunction,
         graph.WithNodeErrorCallback(func(ctx context.Context, callbackCtx *graph.NodeCallbackContext, state graph.State, err error) {
             fmt.Printf("Node %s failed: %v\n", callbackCtx.NodeID, err)
-            // Set fallback state
-            state["fallback_result"] = "default_value"
+            // Note: This callback is observational. Use for logging/metrics only.
         }),
     )
 ```
@@ -148,9 +147,9 @@ Input: Hello World
 - Pre-callbacks can return custom results to skip node execution
 - Useful for implementing conditional logic
 
-### 3. **Error Recovery**
-- Error callbacks can set fallback values
-- Graceful handling of node failures
+### 3. **Error Observability**
+- Error callbacks provide hooks for logging/metrics
+- Execution stops on error; use conditional logic or Commands for recovery paths
 
 ### 4. **Monitoring and Logging**
 - Global callbacks for application-wide monitoring
@@ -198,15 +197,12 @@ graph.WithPostNodeCallback(func(ctx context.Context, callbackCtx *graph.NodeCall
 })
 ```
 
-### 4. **Error Recovery**
+### 4. **Error Hooks**
 ```go
 graph.WithNodeErrorCallback(func(ctx context.Context, callbackCtx *graph.NodeCallbackContext, state graph.State, err error) {
-    // Log error for debugging
+    // Observe failures (non-recoverable at this point)
     fmt.Printf("Node %s failed: %v\n", callbackCtx.NodeID, err)
-    
-    // Set fallback state
-    state["error_recovery"] = true
-    state["fallback_result"] = "default_value"
+    // emit metrics, traces, etc.
 })
 ```
 

--- a/graph/executor.go
+++ b/graph/executor.go
@@ -1208,6 +1208,13 @@ func (e *Executor) executeSingleTask(
 		return err
 	}
 
+	// Ensure pre-callback state mutations are visible to the node function.
+	// We pass the callback-mutated state copy as the task input so that
+	// executeNodeFunction uses it (instead of rebuilding from the global state).
+	// This preserves overlay application done in buildTaskStateCopy and respects
+	// any in-place state changes made by before-node callbacks.
+	t.Input = stateCopy
+
 	// Execute the node function.
 	result, err := e.executeNodeFunction(nodeCtx, execCtx, t)
 	if err != nil {
@@ -1427,15 +1434,18 @@ func (e *Executor) mergeNodeCallbacks(global, perNode *NodeCallbacks) *NodeCallb
 	// Create a new merged callbacks instance.
 	merged := NewNodeCallbacks()
 
-	// Add global callbacks first (they execute first).
+	// Add global callbacks first for Before and OnNodeError.
 	merged.BeforeNode = append(merged.BeforeNode, global.BeforeNode...)
-	merged.AfterNode = append(merged.AfterNode, global.AfterNode...)
 	merged.OnNodeError = append(merged.OnNodeError, global.OnNodeError...)
 
-	// Add per-node callbacks (they execute after global callbacks).
+	// For per-node callbacks, Before callbacks execute after global.
 	merged.BeforeNode = append(merged.BeforeNode, perNode.BeforeNode...)
-	merged.AfterNode = append(merged.AfterNode, perNode.AfterNode...)
 	merged.OnNodeError = append(merged.OnNodeError, perNode.OnNodeError...)
+
+	// For After callbacks, execute per-node first, then global, so per-node can
+	// shape/override the result before global observers run.
+	merged.AfterNode = append(merged.AfterNode, perNode.AfterNode...)
+	merged.AfterNode = append(merged.AfterNode, global.AfterNode...)
 
 	return merged
 }


### PR DESCRIPTION
This change modifies tRPC-Agent-Go to ensure that state mutations performed by BeforeNode callbacks are visible to the node function and to refine the execution order of AfterNode callbacks.

Previously, executeNodeFunction rebuilt input state from global state, ignoring the overlay produced in buildTaskStateCopy and any in-place mutations made by BeforeNode callbacks. The executor now sets task.Input to the callback-mutated state copy, so node functions receive the correct view of state.

Callback merge semantics are updated so per-node AfterNode callbacks run before global AfterNode callbacks. This allows per-node logic to shape or override results before global observers run. The order of BeforeNode and OnNodeError remains global first.

Examples and documentation are updated to reflect that OnNodeError is observational and that conditional skip behavior can be implemented via pre-callback state updates. Example event handling now reads node metadata regardless of author.