### PR TITLE
tool/agent: enhance event filtering in StreamableCall to support sub-agent context

### DIFF
--- a/internal/flow/processor/content_messages_test.go
+++ b/internal/flow/processor/content_messages_test.go
@@ -65,6 +65,42 @@ func TestProcessRequest_IncludeInvocationMessage_WhenNoSession(t *testing.T) {
 	require.True(t, model.MessagesEqual(model.NewUserMessage("hi there"), req.Messages[0]))
 }
 
+// When session exists but has no events for the current branch, the invocation
+// message should still be included so sub agent gets the tool args.
+func TestProcessRequest_IncludeInvocationMessage_WhenNoBranchEvents(t *testing.T) {
+	// Session has events, but authored under a different filter key/branch.
+	sess := &session.Session{}
+	// Event authored by other-agent; with IncludeContentsFiltered and filterKey
+	// set to current agent, this should be filtered out.
+	sess.Events = append(sess.Events, event.Event{
+		Response: &model.Response{
+			Done:    true,
+			Choices: []model.Choice{{Index: 0, Message: model.NewAssistantMessage("context")}},
+		},
+		Author:    "other-agent",
+		FilterKey: "other-agent",
+		Version:   event.CurrentVersion,
+	})
+
+	// Build invocation explicitly with filter key set to sub-agent branch.
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationMessage(model.NewUserMessage("{\\\"target\\\":\\\"svc\\\"}")),
+		agent.WithInvocationEventFilterKey("sub-agent"),
+	)
+	inv.AgentName = "sub-agent"
+
+	req := &model.Request{}
+	ch := make(chan *event.Event, 1)
+	p := NewContentRequestProcessor()
+
+	p.ProcessRequest(context.Background(), inv, req, ch)
+
+	// The other-agent event is filtered out; invocation message must be added.
+	require.Equal(t, 1, len(req.Messages))
+	require.True(t, model.MessagesEqual(inv.Message, req.Messages[0]))
+}
+
 func newSessionEvent(author string, msg model.Message) event.Event {
 	return event.Event{
 		Response: &model.Response{

--- a/tool/agent/agent_tool.go
+++ b/tool/agent/agent_tool.go
@@ -162,6 +162,10 @@ func (at *Tool) StreamableCall(ctx context.Context, jsonArgs []byte) (*tool.Stre
 			subInv := parentInv.Clone(
 				agent.WithInvocationAgent(at.agent),
 				agent.WithInvocationMessage(message),
+				// Reset event filter key to the sub-agent name so that content
+				// processors fetch session messages belonging to the sub-agent,
+				// not the parent agent.
+				agent.WithInvocationEventFilterKey(at.agent.Info().Name),
 			)
 			subCtx := agent.NewInvocationContext(ctx, subInv)
 			evCh, err := at.agent.Run(subCtx, subInv)


### PR DESCRIPTION
This update modifies the StreamableCall method to reset the event filter key to the sub-agent's name, ensuring that content processors fetch messages specific to the sub-agent rather than the parent agent. Additionally, the test suite is updated to assert that the sub-agent correctly sees its own name as the filter key during invocation, improving the accuracy of event handling in nested agent scenarios.