### PR TITLE
knowledge/vectorstore/elasticsearch: add support for extra builder-specific options

### DIFF
--- a/knowledge/vectorstore/elasticsearch/elasticsearch.go
+++ b/knowledge/vectorstore/elasticsearch/elasticsearch.go
@@ -111,6 +111,7 @@ func New(opts ...Option) (*VectorStore, error) {
 		storage.WithEnableDebugLogger(option.enableDebugLogger),
 		storage.WithRetryOnStatus(option.retryOnStatus),
 		storage.WithMaxRetries(option.maxRetries),
+		storage.WithExtraOptions(option.extraOptions...),
 		storage.WithVersion(option.version),
 	)
 	if err != nil {

--- a/knowledge/vectorstore/elasticsearch/options.go
+++ b/knowledge/vectorstore/elasticsearch/options.go
@@ -58,6 +58,8 @@ type options struct {
 	contentFieldName string
 	// embeddingFieldName is the Elasticsearch field name for embedding.
 	embeddingFieldName string
+	// extraOptions allows passing builder-specific extras to the storage client.
+	extraOptions []any
 }
 
 // defaultOptions returns default configuration.
@@ -221,5 +223,12 @@ func WithContentField(field string) Option {
 func WithEmbeddingField(field string) Option {
 	return func(o *options) {
 		o.embeddingFieldName = field
+	}
+}
+
+// WithExtraOptions sets extra builder-specific options for the storage client.
+func WithExtraOptions(extraOptions ...any) Option {
+	return func(o *options) {
+		o.extraOptions = append(o.extraOptions, extraOptions...)
 	}
 }

--- a/knowledge/vectorstore/elasticsearch/options_test.go
+++ b/knowledge/vectorstore/elasticsearch/options_test.go
@@ -62,3 +62,21 @@ func TestOptionSettersOverrideValues(t *testing.T) {
 	assert.Equal(t, "body", opt.contentFieldName)
 	assert.Equal(t, "vec", opt.embeddingFieldName)
 }
+
+func TestWithExtraOptions(t *testing.T) {
+	t.Run("accumulation", func(t *testing.T) {
+		opt := defaultOptions
+
+		WithExtraOptions("first")(&opt)
+		WithExtraOptions(2, true)(&opt)
+
+		assert.Equal(t, []any{"first", 2, true}, opt.extraOptions)
+	})
+
+	t.Run("empty noop", func(t *testing.T) {
+		opt := defaultOptions
+
+		WithExtraOptions()(&opt)
+		assert.Nil(t, opt.extraOptions)
+	})
+}


### PR DESCRIPTION
This update introduces the ability to pass additional options to the storage client via the new WithExtraOptions function. The options struct is modified to include an extraOptions field, and corresponding tests are added to ensure correct accumulation and handling of these options.