### PR TITLE
graph: include instruction + user_input in model execution events and fix test validation

### DIFF
--- a/graph/state_graph.go
+++ b/graph/state_graph.go
@@ -535,7 +535,9 @@ func (r *llmRunner) executeModel(
 			nodeID = id
 		}
 	}
-	modelInput := extractModelInput(State{StateKeyMessages: messages}, "")
+	// Build model input metadata from the original state and instruction
+	// so events accurately reflect both instruction and user input.
+	modelInput := extractModelInput(state, r.instruction)
 	startTime := time.Now()
 	modelName := getModelName(r.llmModel)
 	emitModelStartEvent(eventChan, invocationID, modelName, nodeID, modelInput, startTime)

--- a/graph/state_graph_additional_test.go
+++ b/graph/state_graph_additional_test.go
@@ -121,6 +121,8 @@ func TestBuilderOptions_Destinations_And_Callbacks(t *testing.T) {
 		RegisterOnNodeError(onErr1)
 
 	// Add node with destinations and per-node callbacks
+	// Also add the declared destination node "A" so validation succeeds.
+	sg.AddNode("A", func(ctx context.Context, st State) (any, error) { return st, nil })
 	sg.AddNode("n", func(ctx context.Context, st State) (any, error) { return st, nil },
 		WithDestinations(map[string]string{"A": "toA"}),
 		WithNodeCallbacks(cbs),


### PR DESCRIPTION

- LLM node: build ModelExecutionEvent input from real state + instruction, so events contain combined "instruction\n\nuser_input" as expected by tests.
- Tests: add declared destination node "A" to satisfy graph validation.

Updates tests and aligns event metadata with runtime behavior.