### PR TITLE
{model, internal/flow}: fix transfer tool call by preventing EndInvocation propagation to target agents

### DIFF
--- a/internal/flow/processor/transfer.go
+++ b/internal/flow/processor/transfer.go
@@ -102,9 +102,11 @@ func (p *TransferResponseProcessor) ProcessResponse(
 	}
 
 	// Create new invocation for the target agent.
+	// Do NOT propagate EndInvocation from the coordinator.
+	// end_invocation is intended to end the current (parent) invocation
+	// after transfer, not the target agent's invocation.
 	targetInvocation := invocation.Clone(
 		agent.WithInvocationAgent(targetAgent),
-		agent.WithInvocationEndInvocation(transferInfo.EndInvocation),
 	)
 
 	// Set the message for the target agent.

--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -1019,10 +1019,17 @@ func (m *Model) processAccumulatedToolCalls(
 			}
 		}
 
+		// Some providers (e.g., gpt-5-nano) may omit the tool_call ID.
+		// Synthesize a stable ID from the index to ensure proper pairing.
+		synthesizedID := toolCall.ID
+		if synthesizedID == "" {
+			synthesizedID = fmt.Sprintf("auto_call_%d", originalIndex)
+		}
+
 		accumulatedToolCalls = append(accumulatedToolCalls, model.ToolCall{
 			Index: func() *int { idx := originalIndex; return &idx }(),
-			ID:    toolCall.ID,
-			Type:  functionToolType, // openapi only supports a function type for now.
+			ID:    synthesizedID,
+			Type:  functionToolType, // OpenAI supports function tools for now.
 			Function: model.FunctionDefinitionParam{
 				Name:      toolCall.Function.Name,
 				Arguments: []byte(toolCall.Function.Arguments),
@@ -1147,8 +1154,13 @@ func (m *Model) handleNonStreamingResponse(
 
 			response.Choices[i].Message.ToolCalls = make([]model.ToolCall, len(choice.Message.ToolCalls))
 			for j, toolCall := range choice.Message.ToolCalls {
+				id := toolCall.ID
+				if id == "" {
+					// Synthesize ID for providers that omit it (e.g., gpt-5-nano).
+					id = fmt.Sprintf("auto_call_%d", j)
+				}
 				response.Choices[i].Message.ToolCalls[j] = model.ToolCall{
-					ID:   toolCall.ID,
+					ID:   id,
 					Type: string(toolCall.Type),
 					Function: model.FunctionDefinitionParam{
 						Name:      toolCall.Function.Name,

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -1483,6 +1483,17 @@ func TestModel_GenerateContent_StreamingBatchProcessing(t *testing.T) {
 			expectedCount: 1,
 		},
 		{
+			name: "ToolCall_NoID_Synthesized", // first tool call lacks id entirely; expect synthesized auto_call_0.
+			chunks: []string{
+				`data: {"id":"test","object":"chat.completion.chunk","created":1699200000,"model":"gpt-3.5-turbo","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}`,
+				`data: {"id":"test","object":"chat.completion.chunk","created":1699200000,"model":"gpt-3.5-turbo","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"type":"function","function":{"name":"calc","arguments":"{\"a\":1}"}}]},"finish_reason":null}]}`,
+				`data: {"id":"test","object":"chat.completion.chunk","created":1699200000,"model":"gpt-3.5-turbo","choices":[{"index":0,"delta":{"content":""},"finish_reason":"tool_calls"}]}`,
+			},
+			expectedTool:  "calc",
+			expectedArgs:  `{"a":1}`,
+			expectedCount: 1,
+		},
+		{
 			name: "ID_Index_Mapping_Verification", // Test ID -> Index mapping with multiple tool calls.
 			chunks: []string{
 				`data: {"id":"test","object":"chat.completion.chunk","created":1699200000,"model":"gpt-3.5-turbo","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}`,                                                                                       // Start boundary


### PR DESCRIPTION
- Updated the TransferResponseProcessor to ensure that the EndInvocation flag from the coordinator is not passed to the target agent's invocation.
- Modified the mockAgent struct in transfer_test.go to track whether the EndInvocation was incorrectly marked as ended, and added a test to verify this behavior.
- Introduced a new test case in openai_test.go to handle tool calls that lack an ID, ensuring synthesized IDs are generated correctly for proper pairing.