### PR TITLE
graph: document node I/O conventions and add examples with tools

### DIFF
--- a/examples/graph/io_conventions/README.md
+++ b/examples/graph/io_conventions/README.md
@@ -1,0 +1,68 @@
+## Graph I/O Conventions (LLM Node + Agent Node)
+
+This example demonstrates, end‑to‑end, how node input/output is handled via graph state and how downstream nodes consume upstream results. It focuses on two special node types: LLM node and Agent node.
+
+What it shows
+
+- Function node writes a state delta (custom keys) for downstream nodes.
+- LLM node consumes one‑shot messages and user_input; it appends assistant output to messages and updates last_response/node_responses.
+- Agent node (sub‑agent) receives the full graph state via Invocation.RunOptions.RuntimeState and, when finished, updates last_response/node_responses.
+- A collector node shows how to read:
+  - Built‑in outputs: state["last_response"], state["node_responses"][nodeID]
+  - Custom outputs from previous nodes (e.g., parsed_time)
+
+Run
+
+1) With flags (recommended when testing custom providers):
+
+   go run ./examples/graph/io_conventions \
+     -api-key "$OPENAI_API_KEY" \
+     -base-url "$OPENAI_BASE_URL" \
+     -model deepseek-chat
+
+2) Or via env (flags optional):
+
+   export OPENAI_API_KEY=sk-...
+   export OPENAI_BASE_URL=https://api.deepseek.com
+   go run ./examples/graph/io_conventions
+
+Interactive usage
+
+- Built-in commands:
+  - help     — show help
+  - samples  — show sample inputs
+  - demo     — run a short scripted demo
+  - exit     — quit
+
+- Sample inputs to try:
+  - schedule a sync tomorrow at 10am
+  - today at 3 pm standup
+  - summarize what you understood
+
+Expected output
+
+- 💬 streaming assistant text
+- 📦 Final payload printed by the collector node, e.g.:
+
+  {
+    "parsed_time": "2025-09-23T10:00:00+08:00",
+    "llm_summary": "User wants to schedule a sync tomorrow at 10am.",
+    "agent_last":  "Sure, I can help schedule that...",
+    "node_responses": { "llm_summary": "...", "assistant": "..." }
+  }
+
+Key I/O conventions
+
+- Input via state
+  - User input: state["user_input"] (one‑shot). Cleared after LLM/Agent node consumes it.
+  - One‑shot messages override: state["one_shot_messages"]
+  - Custom keys: add them in a function node (e.g., state["parsed_time"]) for downstream.
+- LLM node output
+  - Appends assistant messages to state["messages"]
+  - Sets state["last_response"] to the last assistant text
+  - Sets state["node_responses"][<llm_node_id>] = last assistant text
+- Agent node (sub‑agent) I/O
+  - Receives full graph state through inv.RunOptions.RuntimeState (readable in model/tool callbacks).
+  - On finish, sets state["last_response"] and state["node_responses"][<agent_node_id>].
+
+See docs: docs/mkdocs/en/graph.md → “Node I/O Conventions”.

--- a/examples/graph/io_conventions/main.go
+++ b/examples/graph/io_conventions/main.go
@@ -1,0 +1,346 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/graphagent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/graph"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/model/openai"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+	"trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+)
+
+var (
+	modelName = flag.String("model", os.Getenv("MODEL_NAME"), "OpenAI‑compatible model name (e.g., deepseek-chat)")
+	baseURL   = flag.String("base-url", os.Getenv("OPENAI_BASE_URL"), "OpenAI‑compatible base URL")
+	apiKey    = flag.String("api-key", os.Getenv("OPENAI_API_KEY"), "API key")
+	verbose   = flag.Bool("v", false, "Verbose: print model/tool metadata")
+)
+
+func main() {
+	flag.Parse()
+	if *modelName == "" {
+		*modelName = "deepseek-chat"
+	}
+	fmt.Printf("🔧 IO Conventions Example\nModel: %s\n", *modelName)
+	fmt.Println(strings.Repeat("=", 56))
+	if *apiKey == "" && os.Getenv("OPENAI_API_KEY") == "" {
+		fmt.Println("💡 Hint: provide -api-key/-base-url or set OPENAI_API_KEY/OPENAI_BASE_URL")
+	}
+
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	// Build the graph
+	g, err := buildGraph()
+	if err != nil {
+		return err
+	}
+
+	// Sub‑agent: simple English assistant that can read runtime state
+	sub := buildSubAgent(*modelName, *baseURL, *apiKey)
+
+	// GraphAgent
+	ga, err := graphagent.New(
+		"io-conventions",
+		g,
+		graphagent.WithDescription("Graph I/O conventions demo"),
+		graphagent.WithInitialState(graph.State{}),
+		graphagent.WithSubAgents([]agent.Agent{sub}),
+	)
+	if err != nil {
+		return err
+	}
+
+	// Runner + memory session
+	sessionSvc := inmemory.NewSessionService()
+	r := runner.NewRunner("io-conventions-app", ga, runner.WithSessionService(sessionSvc))
+
+	// Interactive
+	user := "user"
+	session := fmt.Sprintf("sess-%d", time.Now().Unix())
+	fmt.Printf("✅ Ready. Session: %s\n", session)
+	printSamples()
+
+	sc := bufio.NewScanner(os.Stdin)
+	for {
+		fmt.Print("> ")
+		if !sc.Scan() {
+			break
+		}
+		msg := strings.TrimSpace(sc.Text())
+		if msg == "" {
+			continue
+		}
+		if strings.EqualFold(msg, "exit") || strings.EqualFold(msg, "quit") {
+			break
+		}
+		if strings.EqualFold(msg, "help") {
+			printHelp()
+			continue
+		}
+		if strings.EqualFold(msg, "samples") {
+			printSamples()
+			continue
+		}
+		if strings.EqualFold(msg, "demo") {
+			runDemo(r, user, session)
+			continue
+		}
+
+		// Run with runtime state (could carry caller metadata)
+		evs, err := r.Run(context.Background(), user, session, model.NewUserMessage(msg),
+			agent.WithRuntimeState(map[string]any{"request_ts": time.Now().Format(time.RFC3339)}),
+		)
+		if err != nil {
+			fmt.Println("❌", err)
+			continue
+		}
+		if err := stream(evs, *verbose); err != nil {
+			fmt.Println("❌", err)
+		}
+	}
+	return sc.Err()
+}
+
+// buildGraph defines: parse_input -> llm_summary -> subagent -> collect
+func buildGraph() (*graph.Graph, error) {
+	schema := graph.MessagesStateSchema()
+	// Custom keys to illustrate I/O flow
+	schema.AddField("parsed_time", graph.StateField{Type: reflect.TypeOf(""), Reducer: graph.DefaultReducer})
+	schema.AddField("llm_summary", graph.StateField{Type: reflect.TypeOf(""), Reducer: graph.DefaultReducer})
+	schema.AddField("final_payload", graph.StateField{Type: reflect.TypeOf(map[string]any{}), Reducer: graph.MergeReducer, Default: func() any { return map[string]any{} }})
+
+	sg := graph.NewStateGraph(schema)
+	sg.AddNode("parse_input", parseInput)
+
+	// LLM node: summarizes intent. It consumes one_shot_messages (from parse_input)
+	mdl := openai.New(*modelName, openai.WithBaseURL(*baseURL), openai.WithAPIKey(*apiKey))
+	sg.AddLLMNode(
+		"llm_summary",
+		mdl,
+		"You write exactly one short sentence starting with 'Intent:'. Do not explain parsing. Do not discuss time in detail. If a scheduling time exists, include it succinctly in parentheses. English only.",
+		nil,
+	)
+
+	// Collect LLM's textual output into a custom key for downstream use
+	sg.AddNode("capture_llm", captureLLM)
+
+	// Sub‑agent node
+	sg.AddAgentNode("assistant")
+
+	// Final collector shows how to read last_response/node_responses/custom keys
+	sg.AddNode("collect", collect)
+
+	// Wiring
+	sg.AddEdge("parse_input", "llm_summary")
+	sg.AddEdge("llm_summary", "capture_llm")
+	sg.AddEdge("capture_llm", "assistant")
+	sg.AddEdge("assistant", "collect")
+	sg.SetEntryPoint("parse_input").SetFinishPoint("collect")
+	return sg.Compile()
+}
+
+// parseInput extracts a simple time expression and writes both one_shot_messages and parsed_time.
+func parseInput(ctx context.Context, state graph.State) (any, error) {
+	in, _ := state[graph.StateKeyUserInput].(string)
+	pt := parseTime(in)
+	// Provide one_shot_messages to guide the LLM node. Make it tool-friendly and constrained.
+	sysText := "You will produce exactly one sentence: 'Intent: <short intent>'. " +
+		"If a concrete time has been parsed, include it in parentheses. " +
+		"Never explain how parsing works. Do not ask questions. English only."
+	if pt != "" {
+		sysText += " Parsed time: " + pt
+	}
+	sys := model.NewSystemMessage(sysText)
+	oneShot := []model.Message{sys}
+	return graph.State{
+		"parsed_time":                 pt,
+		graph.StateKeyOneShotMessages: oneShot,
+	}, nil
+}
+
+// captureLLM copies last_response into a custom key
+func captureLLM(ctx context.Context, state graph.State) (any, error) {
+	s, _ := state[graph.StateKeyLastResponse].(string)
+	return graph.State{"llm_summary": s}, nil
+}
+
+// collect builds a final payload by reading outputs from previous nodes
+func collect(ctx context.Context, state graph.State) (any, error) {
+	last, _ := state[graph.StateKeyLastResponse].(string)
+	parsed, _ := state["parsed_time"].(string)
+	llmSum, _ := state["llm_summary"].(string)
+	var fromNodes map[string]any
+	if m, ok := state[graph.StateKeyNodeResponses].(map[string]any); ok {
+		fromNodes = m
+	}
+
+	payload := map[string]any{
+		"parsed_time":    parsed,
+		"llm_summary":    llmSum,
+		"agent_last":     last,
+		"node_responses": fromNodes,
+	}
+	// Pretty‑print once for demo
+	b, _ := json.MarshalIndent(payload, "", "  ")
+	fmt.Printf("\n📦 Final payload (collector):\n%s\n\n", string(b))
+	return graph.State{"final_payload": payload}, nil
+}
+
+// buildSubAgent creates a simple assistant that reads parsed_time from runtime state
+func buildSubAgent(name, baseURL, apiKey string) agent.Agent {
+	mdl := openai.New(name, openai.WithBaseURL(baseURL), openai.WithAPIKey(apiKey))
+	mcb := model.NewCallbacks().RegisterBeforeModel(func(ctx context.Context, req *model.Request) (*model.Response, error) {
+		inv, _ := agent.InvocationFromContext(ctx)
+		if inv == nil || inv.RunOptions.RuntimeState == nil {
+			return nil, nil
+		}
+		pt, _ := inv.RunOptions.RuntimeState["parsed_time"].(string)
+		if pt != "" {
+			req.Messages = append([]model.Message{model.NewSystemMessage("Use parsed_time=" + pt + " if relevant.")}, req.Messages...)
+		}
+		return nil, nil
+	})
+	ag := llmagent.New(
+		"assistant",
+		llmagent.WithModel(mdl),
+		llmagent.WithInstruction("You are a helpful assistant. Always answer in English."),
+		llmagent.WithGenerationConfig(model.GenerationConfig{Stream: true}),
+		llmagent.WithModelCallbacks(mcb),
+	)
+	return ag
+}
+
+func stream(ch <-chan *event.Event, verbose bool) error {
+	var streaming bool
+	for e := range ch {
+		if e == nil {
+			continue
+		}
+		if e.Error != nil {
+			fmt.Printf("❌ %s\n", e.Error.Message)
+			continue
+		}
+		// Model/Tool metadata (from graph LLM node)
+		if verbose {
+			if e.StateDelta != nil {
+				if b, ok := e.StateDelta[graph.MetadataKeyModel]; ok && len(b) > 0 {
+					var md graph.ModelExecutionMetadata
+					if json.Unmarshal(b, &md) == nil {
+						if md.Phase == graph.ModelExecutionPhaseStart {
+							fmt.Printf("🤖 [MODEL] start node=%s\n", md.NodeID)
+						}
+						if md.Phase == graph.ModelExecutionPhaseComplete {
+							fmt.Printf("✅ [MODEL] done node=%s\n", md.NodeID)
+						}
+					}
+				}
+			}
+		}
+		// Streaming text
+		if len(e.Choices) > 0 {
+			c := e.Choices[0]
+			if c.Delta.Content != "" {
+				if !streaming {
+					fmt.Print("💬 ")
+					streaming = true
+				}
+				fmt.Print(c.Delta.Content)
+			}
+			if c.Delta.Content == "" && streaming {
+				fmt.Println()
+				streaming = false
+			}
+		}
+		if e.Done {
+			break
+		}
+	}
+	return nil
+}
+
+// parseTime: tiny helper for demo
+func parseTime(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	re := regexp.MustCompile(`\b(today|tomorrow)\b.*?\b(\d{1,2})(?::(\d{2}))?\s*(am|pm)?\b`)
+	if m := re.FindStringSubmatch(s); len(m) >= 3 {
+		base := time.Now()
+		if m[1] == "tomorrow" {
+			base = base.Add(24 * time.Hour)
+		}
+		h, _ := strconv.Atoi(m[2])
+		min := 0
+		if m[3] != "" {
+			min, _ = strconv.Atoi(m[3])
+		}
+		ap := m[4]
+		if ap == "pm" && h < 12 {
+			h += 12
+		}
+		if ap == "am" && h == 12 {
+			h = 0
+		}
+		t := time.Date(base.Year(), base.Month(), base.Day(), h, min, 0, 0, base.Location())
+		return t.Format(time.RFC3339)
+	}
+	return ""
+}
+
+func printSamples() {
+	fmt.Println("💡 Type 'help' for commands. Try:")
+	fmt.Println("   • schedule a sync tomorrow at 10am")
+	fmt.Println("   • today at 3 pm standup")
+	fmt.Println("   • summarize what you understood")
+}
+
+func printHelp() {
+	fmt.Println("📚 Commands:")
+	fmt.Println("   help     - show this help")
+	fmt.Println("   samples  - print sample inputs")
+	fmt.Println("   demo     - run a short scripted demo")
+	fmt.Println("   exit     - quit")
+}
+
+func runDemo(r runner.Runner, user, session string) {
+	inputs := []string{
+		"schedule a sync tomorrow at 10am",
+		"what did you understand?",
+	}
+	for _, in := range inputs {
+		fmt.Printf("> %s\n", in)
+		evs, err := r.Run(context.Background(), user, session, model.NewUserMessage(in))
+		if err != nil {
+			fmt.Println("❌", err)
+			continue
+		}
+		_ = stream(evs, *verbose)
+	}
+}

--- a/examples/graph/io_conventions_tools/README.md
+++ b/examples/graph/io_conventions_tools/README.md
@@ -1,0 +1,59 @@
+## Graph I/O With Tools Node
+
+This example extends the I/O conventions demo by adding a Tools node. It shows a full path:
+
+- parse_input → llm_decider (with tool definitions)
+- If the LLM requests a tool call → tools → capture_tool → collect
+- Otherwise (no tool call) → assistant (sub‑agent) → collect
+
+What it demonstrates
+
+- How an LLM node declares tools so the model can emit tool_calls
+- How a Tools node executes those calls and appends tool responses to messages
+- How a downstream node parses the latest tool response JSON and saves a structured result into state
+- How to read final data in a collector (last_response, node_responses, and custom state keys like meeting)
+
+Run
+
+1) With flags (when using non‑OpenAI providers):
+
+   go run ./examples/graph/io_conventions_tools \
+     -api-key "$OPENAI_API_KEY" \
+     -base-url "$OPENAI_BASE_URL" \
+     -model deepseek-chat
+
+2) Or via env:
+
+   export OPENAI_API_KEY=sk-...
+   export OPENAI_BASE_URL=https://api.deepseek.com
+   go run ./examples/graph/io_conventions_tools
+
+Interactive usage
+
+- Commands:
+  - help     — show help
+  - samples  — sample inputs
+  - demo     — short scripted demo
+  - exit     — quit
+
+- Try inputs:
+  - schedule a meeting tomorrow at 10am titled sync with Alex
+  - schedule team standup today at 3 pm
+  - tell me a fun fact (fallback path, no tool call)
+
+Expected output
+
+- 💬 streaming assistant text
+- A final payload that may include a structured meeting result when the tool path is taken, for example:
+
+  {
+    "meeting": {
+      "meeting_id": "mtg-20250923-1000",
+      "title": "sync with Alex",
+      "time": "2025-09-23T10:00:00+08:00"
+    },
+    "agent_last": "…",
+    "node_responses": { "llm_decider": "…", "assistant": "…" },
+    "parsed_time": "2025-09-23T10:00:00+08:00"
+  }
+

--- a/examples/graph/io_conventions_tools/main.go
+++ b/examples/graph/io_conventions_tools/main.go
@@ -1,0 +1,377 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/graphagent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/graph"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/model/openai"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+	"trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+	"trpc.group/trpc-go/trpc-agent-go/tool/function"
+)
+
+var (
+	modelName = flag.String("model", os.Getenv("MODEL_NAME"), "OpenAI‑compatible model name (e.g., deepseek-chat)")
+	baseURL   = flag.String("base-url", os.Getenv("OPENAI_BASE_URL"), "OpenAI‑compatible base URL")
+	apiKey    = flag.String("api-key", os.Getenv("OPENAI_API_KEY"), "API key")
+	verbose   = flag.Bool("v", false, "Verbose: print model/tool metadata")
+)
+
+func main() {
+	flag.Parse()
+	if *modelName == "" {
+		*modelName = "deepseek-chat"
+	}
+	fmt.Printf("🧩 IO Conventions — Tools Node\nModel: %s\n", *modelName)
+	fmt.Println(strings.Repeat("=", 56))
+	if *apiKey == "" && os.Getenv("OPENAI_API_KEY") == "" {
+		fmt.Println("💡 Hint: provide -api-key/-base-url or set OPENAI_API_KEY/OPENAI_BASE_URL")
+	}
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	g, tools, err := buildGraph()
+	if err != nil {
+		return err
+	}
+
+	sub := buildSubAgent(*modelName, *baseURL, *apiKey)
+	ga, err := graphagent.New(
+		"io-tools",
+		g,
+		graphagent.WithDescription("Graph I/O with Tools node"),
+		graphagent.WithInitialState(graph.State{}),
+		graphagent.WithSubAgents([]agent.Agent{sub}),
+		// Optionally pass ToolCallbacks/ModelCallbacks via GraphAgent if needed.
+	)
+	if err != nil {
+		return err
+	}
+
+	_ = tools // tools var kept to signal declared tools; graph nodes hold actual refs.
+
+	sessSvc := inmemory.NewSessionService()
+	r := runner.NewRunner("io-tools-app", ga, runner.WithSessionService(sessSvc))
+
+	user := "user"
+	session := fmt.Sprintf("sess-%d", time.Now().Unix())
+	fmt.Printf("✅ Ready. Session: %s\n", session)
+	printSamples()
+
+	sc := bufio.NewScanner(os.Stdin)
+	for {
+		fmt.Print("> ")
+		if !sc.Scan() {
+			break
+		}
+		msg := strings.TrimSpace(sc.Text())
+		if msg == "" {
+			continue
+		}
+		if strings.EqualFold(msg, "exit") || strings.EqualFold(msg, "quit") {
+			break
+		}
+		if strings.EqualFold(msg, "help") {
+			printHelp()
+			continue
+		}
+		if strings.EqualFold(msg, "samples") {
+			printSamples()
+			continue
+		}
+		if strings.EqualFold(msg, "demo") {
+			runDemo(r, user, session)
+			continue
+		}
+
+		evs, err := r.Run(context.Background(), user, session, model.NewUserMessage(msg),
+			agent.WithRuntimeState(map[string]any{"request_ts": time.Now().Format(time.RFC3339)}),
+		)
+		if err != nil {
+			fmt.Println("❌", err)
+			continue
+		}
+		_ = stream(evs, *verbose)
+	}
+	return sc.Err()
+}
+
+// buildGraph: parse_input -> llm_decider -> (tools or assistant) -> capture_tool (if tools) -> collect
+func buildGraph() (*graph.Graph, map[string]tool.Tool, error) {
+	schema := graph.MessagesStateSchema()
+	schema.AddField("parsed_time", graph.StateField{Type: reflect.TypeOf(""), Reducer: graph.DefaultReducer})
+	schema.AddField("meeting", graph.StateField{Type: reflect.TypeOf(map[string]any{}), Reducer: graph.MergeReducer, Default: func() any { return map[string]any{} }})
+	schema.AddField("final_payload", graph.StateField{Type: reflect.TypeOf(map[string]any{}), Reducer: graph.MergeReducer, Default: func() any { return map[string]any{} }})
+
+	sg := graph.NewStateGraph(schema)
+	sg.AddNode("parse_input", parseInput)
+
+	mdl := openai.New(*modelName, openai.WithBaseURL(*baseURL), openai.WithAPIKey(*apiKey))
+
+	// Define a callable tool that simulates meeting scheduling.
+	type args struct{ Title, When string }
+	type result struct{ MeetingID, Title, Time string }
+	schedule := function.NewFunctionTool(func(ctx context.Context, in args) (result, error) {
+		if in.When == "" {
+			// Allow runtime override from parsed_time if the LLM omitted it
+			inv, _ := agent.InvocationFromContext(ctx)
+			if inv != nil && inv.RunOptions.RuntimeState != nil {
+				if pt, ok := inv.RunOptions.RuntimeState["parsed_time"].(string); ok && pt != "" {
+					in.When = pt
+				}
+			}
+		}
+		if in.Title == "" {
+			in.Title = "meeting"
+		}
+		if in.When == "" {
+			in.When = time.Now().Format(time.RFC3339)
+		}
+		id := fmt.Sprintf("mtg-%s", time.Now().Format("20060102-1504"))
+		return result{MeetingID: id, Title: in.Title, Time: in.When}, nil
+	}, function.WithName("schedule_meeting"), function.WithDescription("Schedule a meeting using Title and When"))
+
+	tools := map[string]tool.Tool{"schedule_meeting": schedule}
+
+	// LLM decider has tool declaration so it may emit tool_calls
+	sg.AddLLMNode(
+		"llm_decider",
+		mdl,
+		"You plan user intents. If the user asks to schedule a meeting, CALL the schedule_meeting tool with concise {title, when}. Otherwise, respond briefly.",
+		tools,
+	)
+
+	// Tools node executes tool calls when present
+	sg.AddToolsNode("tools", tools)
+
+	// After tools, capture the JSON response into state["meeting"]
+	sg.AddNode("capture_tool", captureTool)
+
+	// Sub‑agent fallback when no tool call
+	sg.AddAgentNode("assistant")
+
+	// Collector prints final payload
+	sg.AddNode("collect", collect)
+
+	// Wiring with conditional tools edge: llm_decider -> tools OR assistant
+	sg.AddToolsConditionalEdges("llm_decider", "tools", "assistant")
+	sg.AddEdge("parse_input", "llm_decider")
+	sg.AddEdge("tools", "capture_tool")
+	sg.AddEdge("capture_tool", "collect")
+	sg.AddEdge("assistant", "collect")
+
+	sg.SetEntryPoint("parse_input").SetFinishPoint("collect")
+	g, err := sg.Compile()
+	return g, tools, err
+}
+
+// parseInput writes parsed_time and an intent‑shaping one_shot system message.
+func parseInput(ctx context.Context, state graph.State) (any, error) {
+	in, _ := state[graph.StateKeyUserInput].(string)
+	pt := parseTime(in)
+	sys := model.NewSystemMessage("Context: if a scheduling request is present, call schedule_meeting. Parsed time: " + pt)
+	return graph.State{
+		"parsed_time":                 pt,
+		graph.StateKeyOneShotMessages: []model.Message{sys},
+	}, nil
+}
+
+// captureTool finds the latest tool.response in messages and stores structured JSON in state["meeting"].
+func captureTool(ctx context.Context, state graph.State) (any, error) {
+	msgs, _ := state[graph.StateKeyMessages].([]model.Message)
+	if len(msgs) == 0 {
+		return nil, nil
+	}
+	for i := len(msgs) - 1; i >= 0; i-- {
+		m := msgs[i]
+		if m.Role == model.RoleTool && strings.TrimSpace(m.Content) != "" {
+			var out map[string]any
+			if err := json.Unmarshal([]byte(m.Content), &out); err == nil {
+				return graph.State{"meeting": out}, nil
+			}
+			break
+		}
+		if m.Role == model.RoleUser {
+			break
+		}
+	}
+	return nil, nil
+}
+
+// collect prints final payload (meeting if present + last_response + node_responses + parsed_time)
+func collect(ctx context.Context, state graph.State) (any, error) {
+	last, _ := state[graph.StateKeyLastResponse].(string)
+	parsed, _ := state["parsed_time"].(string)
+	var meeting map[string]any
+	if v, ok := state["meeting"].(map[string]any); ok {
+		meeting = v
+	}
+	var fromNodes map[string]any
+	if m, ok := state[graph.StateKeyNodeResponses].(map[string]any); ok {
+		fromNodes = m
+	}
+
+	payload := map[string]any{
+		"parsed_time":    parsed,
+		"meeting":        meeting,
+		"agent_last":     last,
+		"node_responses": fromNodes,
+	}
+	b, _ := json.MarshalIndent(payload, "", "  ")
+	fmt.Printf("\n📦 Final payload (collector):\n%s\n\n", string(b))
+	return graph.State{"final_payload": payload}, nil
+}
+
+// buildSubAgent: simple assistant fallback
+func buildSubAgent(name, baseURL, apiKey string) agent.Agent {
+	mdl := openai.New(name, openai.WithBaseURL(baseURL), openai.WithAPIKey(apiKey))
+	ag := llmagent.New(
+		"assistant",
+		llmagent.WithModel(mdl),
+		llmagent.WithInstruction("You are a helpful assistant. Be brief. English only."),
+		llmagent.WithGenerationConfig(model.GenerationConfig{Stream: true}),
+	)
+	return ag
+}
+
+func stream(ch <-chan *event.Event, verbose bool) error {
+	var streaming bool
+	for e := range ch {
+		if e == nil {
+			continue
+		}
+		if e.Error != nil {
+			fmt.Printf("❌ %s\n", e.Error.Message)
+			continue
+		}
+		if verbose && e.StateDelta != nil {
+			if b, ok := e.StateDelta[graph.MetadataKeyModel]; ok && len(b) > 0 {
+				var md graph.ModelExecutionMetadata
+				if json.Unmarshal(b, &md) == nil {
+					if md.Phase == graph.ModelExecutionPhaseStart {
+						fmt.Printf("🤖 [MODEL] start node=%s\n", md.NodeID)
+					}
+					if md.Phase == graph.ModelExecutionPhaseComplete {
+						fmt.Printf("✅ [MODEL] done node=%s\n", md.NodeID)
+					}
+				}
+			}
+			if b, ok := e.StateDelta[graph.MetadataKeyTool]; ok && len(b) > 0 {
+				var td graph.ToolExecutionMetadata
+				if json.Unmarshal(b, &td) == nil {
+					if td.Phase == graph.ToolExecutionPhaseStart {
+						fmt.Printf("🔧 [TOOL] start %s\n", td.ToolName)
+					}
+					if td.Phase == graph.ToolExecutionPhaseComplete {
+						fmt.Printf("✅ [TOOL] done %s\n", td.ToolName)
+					}
+				}
+			}
+		}
+		if len(e.Choices) > 0 {
+			c := e.Choices[0]
+			if c.Delta.Content != "" {
+				if !streaming {
+					fmt.Print("💬 ")
+					streaming = true
+				}
+				fmt.Print(c.Delta.Content)
+			}
+			if c.Delta.Content == "" && streaming {
+				fmt.Println()
+				streaming = false
+			}
+		}
+		if e.Done {
+			break
+		}
+	}
+	return nil
+}
+
+// parseTime: tiny helper for demo
+func parseTime(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	re := regexp.MustCompile(`\b(today|tomorrow)\b.*?\b(\d{1,2})(?::(\d{2}))?\s*(am|pm)?\b`)
+	if m := re.FindStringSubmatch(s); len(m) >= 3 {
+		base := time.Now()
+		if m[1] == "tomorrow" {
+			base = base.Add(24 * time.Hour)
+		}
+		h, _ := strconv.Atoi(m[2])
+		min := 0
+		if m[3] != "" {
+			min, _ = strconv.Atoi(m[3])
+		}
+		ap := m[4]
+		if ap == "pm" && h < 12 {
+			h += 12
+		}
+		if ap == "am" && h == 12 {
+			h = 0
+		}
+		t := time.Date(base.Year(), base.Month(), base.Day(), h, min, 0, 0, base.Location())
+		return t.Format(time.RFC3339)
+	}
+	return ""
+}
+
+func printSamples() {
+	fmt.Println("💡 Type 'help' for commands. Try:")
+	fmt.Println("   • schedule a meeting tomorrow at 10am titled sync with Alex")
+	fmt.Println("   • schedule team standup today at 3 pm")
+	fmt.Println("   • tell me a fun fact")
+}
+
+func printHelp() {
+	fmt.Println("📚 Commands:")
+	fmt.Println("   help     - show this help")
+	fmt.Println("   samples  - print sample inputs")
+	fmt.Println("   demo     - run a short scripted demo")
+	fmt.Println("   exit     - quit")
+}
+
+func runDemo(r runner.Runner, user, session string) {
+	inputs := []string{
+		"schedule a meeting tomorrow at 10am titled sync with Alex",
+		"tell me a fun fact",
+	}
+	for _, in := range inputs {
+		fmt.Printf("> %s\n", in)
+		evs, err := r.Run(context.Background(), user, session, model.NewUserMessage(in))
+		if err != nil {
+			fmt.Println("❌", err)
+			continue
+		}
+		_ = stream(evs, *verbose)
+	}
+}


### PR DESCRIPTION
Add two end-to-end examples to make graph state I/O patterns easy to learn:

- examples/graph/io_conventions: Function + LLM + Agent. Interactive runner, sample inputs, optional verbose model metadata. Shows how upstream nodes write custom keys and how downstream nodes read built-in keys like last_response and node_responses.
- examples/graph/io_conventions_tools: Adds a Tools node path. LLM declares tools, Tools node executes tool_calls, capture_tool parses latest tool.response JSON into state (e.g. meeting), collector builds a final payload.

Docs:
- docs/mkdocs/en/graph.md and zh/graph.md: Introduce a "Node I/O Conventions" section, list the exact state key constants (with import path and source files), and show event metadata keys (_model_metadata/_tool_metadata) with sample snippets.

Motivation: clarify how LLM/Agent/Tools nodes consume/produce state, and provide runnable demos with friendly UX (help/samples/demo) for quick onboarding.

PR-Type: type/documentation, type/feature

RELEASE NOTES: New graph I/O examples (with Tools path) and documentation clarifying state key constants and node input/output conventions.