### PR TITLE
fix(telemetry): enhance langfuse integration with output capture

### DIFF
--- a/examples/telemetry/jaeger-prometheus/main.go
+++ b/examples/telemetry/jaeger-prometheus/main.go
@@ -94,7 +94,10 @@ func main() {
 			ctx, span := atrace.Tracer.Start(ctx, "process-message")
 			span.SetAttributes(attribute.String("user-message", msg))
 			defer span.End()
-			err := a.ProcessMessage(ctx, msg)
+			result, err := a.ProcessMessage(ctx, msg)
+			if result != "" {
+				span.SetAttributes(attribute.String("output", result))
+			}
 			if err != nil {
 				span.SetAttributes(attribute.String("error", err.Error()))
 				log.Fatalf("Chat system failed to run: %v", err)

--- a/telemetry/langfuse/attribute.go
+++ b/telemetry/langfuse/attribute.go
@@ -12,8 +12,8 @@ package langfuse
 // Langfuse-Trace attributes
 const (
 	traceName      = "langfuse.trace.name"
-	traceUserID    = "user.id"
-	traceSessionID = "session.id"
+	traceUserID    = "langfuse.user.id"
+	traceSessionID = "langfuse.session.id"
 	traceTags      = "langfuse.trace.tags"
 	tracePublic    = "langfuse.trace.public"
 	traceMetadata  = "langfuse.trace.metadata"

--- a/telemetry/langfuse/exporter.go
+++ b/telemetry/langfuse/exporter.go
@@ -251,71 +251,26 @@ func transformExecuteTool(span *tracepb.Span) {
 func transformRunRunner(span *tracepb.Span) {
 	var newAttributes []*commonpb.KeyValue
 
+	newAttributes = append(newAttributes, &commonpb.KeyValue{
+		Key: observationType,
+		Value: &commonpb.AnyValue{
+			Value: &commonpb.AnyValue_StringValue{StringValue: "agent"},
+		},
+	})
 	// Process existing attributes
 	for _, attr := range span.Attributes {
 		switch attr.Key {
-		case itelemetry.KeyRunnerName:
-			if attr.Value != nil {
-				newAttributes = append(newAttributes, &commonpb.KeyValue{
-					Key: traceName,
-					Value: &commonpb.AnyValue{
-						Value: &commonpb.AnyValue_StringValue{StringValue: attr.Value.GetStringValue()},
-					},
-				})
-			} else {
-				newAttributes = append(newAttributes, &commonpb.KeyValue{
-					Key: traceName,
-					Value: &commonpb.AnyValue{
-						Value: &commonpb.AnyValue_StringValue{StringValue: "N/A"},
-					},
-				})
-			}
-			// Skip this attribute (delete it)
-		case itelemetry.KeyRunnerUserID:
-			if attr.Value != nil {
-				newAttributes = append(newAttributes, &commonpb.KeyValue{
-					Key: traceUserID,
-					Value: &commonpb.AnyValue{
-						Value: &commonpb.AnyValue_StringValue{StringValue: attr.Value.GetStringValue()},
-					},
-				})
-			} else {
-				newAttributes = append(newAttributes, &commonpb.KeyValue{
-					Key: traceUserID,
-					Value: &commonpb.AnyValue{
-						Value: &commonpb.AnyValue_StringValue{StringValue: "N/A"},
-					},
-				})
-			}
-			// Skip this attribute (delete it)
-		case itelemetry.KeyRunnerSessionID:
-			if attr.Value != nil {
-				newAttributes = append(newAttributes, &commonpb.KeyValue{
-					Key: traceSessionID,
-					Value: &commonpb.AnyValue{
-						Value: &commonpb.AnyValue_StringValue{StringValue: attr.Value.GetStringValue()},
-					},
-				})
-			} else {
-				newAttributes = append(newAttributes, &commonpb.KeyValue{
-					Key: traceSessionID,
-					Value: &commonpb.AnyValue{
-						Value: &commonpb.AnyValue_StringValue{StringValue: "N/A"},
-					},
-				})
-			}
-			// Skip this attribute (delete it)
 		case itelemetry.KeyRunnerInput:
 			if attr.Value != nil {
 				newAttributes = append(newAttributes, &commonpb.KeyValue{
-					Key: traceInput,
+					Key: observationInput,
 					Value: &commonpb.AnyValue{
 						Value: &commonpb.AnyValue_StringValue{StringValue: attr.Value.GetStringValue()},
 					},
 				})
 			} else {
 				newAttributes = append(newAttributes, &commonpb.KeyValue{
-					Key: traceInput,
+					Key: observationInput,
 					Value: &commonpb.AnyValue{
 						Value: &commonpb.AnyValue_StringValue{StringValue: "N/A"},
 					},
@@ -325,14 +280,14 @@ func transformRunRunner(span *tracepb.Span) {
 		case itelemetry.KeyRunnerOutput:
 			if attr.Value != nil {
 				newAttributes = append(newAttributes, &commonpb.KeyValue{
-					Key: traceOutput,
+					Key: observationOutput,
 					Value: &commonpb.AnyValue{
 						Value: &commonpb.AnyValue_StringValue{StringValue: attr.Value.GetStringValue()},
 					},
 				})
 			} else {
 				newAttributes = append(newAttributes, &commonpb.KeyValue{
-					Key: traceOutput,
+					Key: observationOutput,
 					Value: &commonpb.AnyValue{
 						Value: &commonpb.AnyValue_StringValue{StringValue: "N/A"},
 					},


### PR DESCRIPTION
This resolves the langfuse integration problems where input/output attributes weren't being properly captured and displayed in langfuse traces after the upgrade from trpc-agent-go v0.0.3 to v0.2.0.