### PR TITLE
knowledge/vectorstore/elasticsearch: fix search query builders to handle empty filters without post-filters

### DIFF
--- a/knowledge/vectorstore/elasticsearch/builder.go
+++ b/knowledge/vectorstore/elasticsearch/builder.go
@@ -56,7 +56,9 @@ func (vs *VectorStore) buildVectorSearchQuery(query *vectorstore.SearchQuery) (*
 
 	// Add filters if specified.
 	if query.Filter != nil {
-		searchBody.PostFilter(vs.buildFilterQuery(query.Filter))
+		if filterQuery := vs.buildFilterQuery(query.Filter); filterQuery != nil {
+			searchBody.PostFilter(filterQuery)
+		}
 	}
 
 	return searchBody.SearchRequestBodyCaster(), nil
@@ -79,7 +81,9 @@ func (vs *VectorStore) buildKeywordSearchQuery(query *vectorstore.SearchQuery) (
 
 	// Add filters if specified.
 	if query.Filter != nil {
-		searchBody.PostFilter(vs.buildFilterQuery(query.Filter))
+		if filterQuery := vs.buildFilterQuery(query.Filter); filterQuery != nil {
+			searchBody.PostFilter(filterQuery)
+		}
 	}
 
 	return searchBody.SearchRequestBodyCaster(), nil
@@ -124,7 +128,9 @@ func (vs *VectorStore) buildHybridSearchQuery(query *vectorstore.SearchQuery) (*
 
 	// Add filters if specified.
 	if query.Filter != nil {
-		searchBody.PostFilter(vs.buildFilterQuery(query.Filter))
+		if filterQuery := vs.buildFilterQuery(query.Filter); filterQuery != nil {
+			searchBody.PostFilter(filterQuery)
+		}
 	}
 
 	return searchBody.SearchRequestBodyCaster(), nil

--- a/knowledge/vectorstore/elasticsearch/builder_test.go
+++ b/knowledge/vectorstore/elasticsearch/builder_test.go
@@ -150,3 +150,43 @@ func TestBuildHybridSearchQueryWithFilter(t *testing.T) {
 	// Verify that PostFilter is set when filter is provided
 	assert.NotNil(t, result.PostFilter)
 }
+
+func TestBuildVectorSearchQuery_WithEmptyFilter_NoPostFilter(t *testing.T) {
+	vs := &VectorStore{option: options{maxResults: 10}}
+	query := &vectorstore.SearchQuery{
+		Vector:     []float64{0.1, 0.2},
+		SearchMode: vectorstore.SearchModeVector,
+		Filter:     &vectorstore.SearchFilter{},
+	}
+	res, err := vs.buildVectorSearchQuery(query)
+	require.NoError(t, err)
+	assert.NotNil(t, res)
+	assert.Nil(t, res.PostFilter)
+}
+
+func TestBuildKeywordSearchQuery_WithEmptyFilter_NoPostFilter(t *testing.T) {
+	vs := &VectorStore{option: options{maxResults: 10}}
+	query := &vectorstore.SearchQuery{
+		Query:      "hello",
+		SearchMode: vectorstore.SearchModeKeyword,
+		Filter:     &vectorstore.SearchFilter{},
+	}
+	res, err := vs.buildKeywordSearchQuery(query)
+	require.NoError(t, err)
+	assert.NotNil(t, res)
+	assert.Nil(t, res.PostFilter)
+}
+
+func TestBuildHybridSearchQuery_WithEmptyFilter_NoPostFilter(t *testing.T) {
+	vs := &VectorStore{option: options{maxResults: 10}}
+	query := &vectorstore.SearchQuery{
+		Vector:     []float64{0.1, 0.2},
+		Query:      "hello",
+		SearchMode: vectorstore.SearchModeHybrid,
+		Filter:     &vectorstore.SearchFilter{},
+	}
+	res, err := vs.buildHybridSearchQuery(query)
+	require.NoError(t, err)
+	assert.NotNil(t, res)
+	assert.Nil(t, res.PostFilter)
+}


### PR DESCRIPTION
- Updated `buildVectorSearchQuery`, `buildKeywordSearchQuery`, and `buildHybridSearchQuery` methods to only set PostFilter if a valid filter query is generated.
- Added new unit tests to verify that empty filters do not result in post-filters being set for vector, keyword, and hybrid search queries.