### PR TITLE
tool/callbacks: change BeforeToolCallback to accept pointer to jsonArgs

### DIFF
--- a/examples/callbacks/README.md
+++ b/examples/callbacks/README.md
@@ -109,7 +109,7 @@ modelCallbacks := model.NewCallbacks().
 ```go
 // Traditional registration
 toolCallbacks := tool.NewCallbacks()
-toolCallbacks.RegisterBeforeTool(func(ctx context.Context, toolName string, toolDeclaration *tool.Declaration, jsonArgs []byte) (any, error) {
+toolCallbacks.RegisterBeforeTool(func(ctx context.Context, toolName string, toolDeclaration *tool.Declaration, jsonArgs *[]byte) (any, error) {
     // Your logic here
     return nil, nil
 })
@@ -120,7 +120,7 @@ toolCallbacks.RegisterAfterTool(func(ctx context.Context, toolName string, toolD
 
 // Chain registration (recommended)
 toolCallbacks := tool.NewCallbacks().
-    RegisterBeforeTool(func(ctx context.Context, toolName string, toolDeclaration *tool.Declaration, jsonArgs []byte) (any, error) {
+    RegisterBeforeTool(func(ctx context.Context, toolName string, toolDeclaration *tool.Declaration, jsonArgs *[]byte) (any, error) {
         // Your logic here
         return nil, nil
     }).
@@ -187,7 +187,7 @@ modelCallbacks.RegisterAfterModel(func(ctx context.Context, req *model.Request, 
 **Example: Mocking a tool result in BeforeToolCallback**
 
 ```go
-toolCallbacks.RegisterBeforeTool(func(ctx context.Context, toolName string, toolDeclaration *tool.Declaration, jsonArgs []byte) (any, error) {
+toolCallbacks.RegisterBeforeTool(func(ctx context.Context, toolName string, toolDeclaration *tool.Declaration, jsonArgs *[]byte) (any, error) {
     if toolName == "calculator" && strings.Contains(string(jsonArgs), "42") {
         // Return a mock result and skip actual tool execution.
         return calculatorResult{Operation: "custom", A: 42, B: 42, Result: 4242}, nil

--- a/examples/callbacks/README.md
+++ b/examples/callbacks/README.md
@@ -49,7 +49,7 @@ This example demonstrates how to use the `Runner` orchestration component in a m
 
 ### 2. ToolCallbacks
 
-- **BeforeToolCallback**: Triggered before each tool invocation. Use for argument validation, mocking tool results, or logging.
+- **BeforeToolCallback**: Triggered before each tool invocation. Use for argument validation, mocking tool results, logging, or **modifying tool arguments**. The `jsonArgs` parameter is a pointer, allowing callbacks to modify arguments that will be passed to the tool.
 - **AfterToolCallback**: Triggered after each tool invocation. Use for result post-processing, formatting, or logging.
 
 **Example output:**
@@ -57,8 +57,16 @@ This example demonstrates how to use the `Runner` orchestration component in a m
 ```
 🟠 BeforeToolCallback: tool=calculator, args={"operation":"add","a":1,"b":2}
 🟠 BeforeToolCallback: ✅ Invocation present in ctx (agent=..., id=...)
+🟠 BeforeToolCallback: Modified args for calculator: {"original":{"operation":"add","a":1,"b":2},"timestamp":"1703123456"}
 🟤 AfterToolCallback: tool=calculator, args={...}, result=..., err=<nil>
 ```
+
+**Key Feature**: The `BeforeToolCallback` receives `jsonArgs` as a pointer (`*[]byte`), enabling scenarios like:
+
+- **Argument Modification**: Modify tool arguments before execution
+- **Argument Validation**: Validate and sanitize inputs
+- **Argument Enrichment**: Add metadata, timestamps, or context to arguments
+- **Argument Transformation**: Convert or reformat arguments for specific tools
 
 ### 3. AgentCallbacks
 
@@ -165,7 +173,7 @@ After declaring and registering your callbacks, pass them to the agent during co
 You can short-circuit (skip) the default execution of a model, tool, or agent by returning a non-nil response/result from the corresponding callback. This is useful for mocking, early returns, blocking, or custom logic.
 
 - **ModelCallbacks**: If `BeforeModelCallback` returns a non-nil `*model.Response`, the model will not be called and this response will be used directly.
-- **ToolCallbacks**: If `BeforeToolCallback` returns a non-nil result, the tool will not be executed and this result will be used directly.
+- **ToolCallbacks**: If `BeforeToolCallback` returns a non-nil result, the tool will not be executed and this result will be used directly. Additionally, `BeforeToolCallback` can modify tool arguments via the `jsonArgs` pointer parameter.
 - **AgentCallbacks**: If `BeforeAgentCallback` returns a non-nil `*model.Response`, the agent execution will be skipped and this response will be used.
 
 **Example: Using original request in AfterModelCallback**
@@ -188,9 +196,24 @@ modelCallbacks.RegisterAfterModel(func(ctx context.Context, req *model.Request, 
 
 ```go
 toolCallbacks.RegisterBeforeTool(func(ctx context.Context, toolName string, toolDeclaration *tool.Declaration, jsonArgs *[]byte) (any, error) {
-    if toolName == "calculator" && strings.Contains(string(jsonArgs), "42") {
+    if toolName == "calculator" && jsonArgs != nil && strings.Contains(string(*jsonArgs), "42") {
         // Return a mock result and skip actual tool execution.
         return calculatorResult{Operation: "custom", A: 42, B: 42, Result: 4242}, nil
+    }
+    return nil, nil
+})
+```
+
+**Example: Modifying tool arguments in BeforeToolCallback**
+
+```go
+toolCallbacks.RegisterBeforeTool(func(ctx context.Context, toolName string, toolDeclaration *tool.Declaration, jsonArgs *[]byte) (any, error) {
+    if jsonArgs != nil && toolName == "calculator" {
+        // Add timestamp to arguments for logging purposes
+        originalArgs := string(*jsonArgs)
+        modifiedArgs := fmt.Sprintf(`{"original":%s,"timestamp":"%d"}`, originalArgs, time.Now().Unix())
+        *jsonArgs = []byte(modifiedArgs)
+        fmt.Printf("Modified args for %s: %s\n", toolName, modifiedArgs)
     }
     return nil, nil
 })
@@ -263,6 +286,7 @@ go run . -streaming=false
   - Input/output interception and modification
   - Content safety and moderation
   - Tool mocking or fallback
+  - **Tool argument modification and enrichment**
   - **Original request access for content restoration**
 
 ---
@@ -274,6 +298,7 @@ go run . -streaming=false
 - **Safety & Compliance**: Moderate model outputs and tool results
 - **Business Extensions**: Insert custom business logic as needed
 - **Content Processing**: Access original input for post-processing workflows
+- **Argument Processing**: Modify, validate, or enrich tool arguments before execution
 
 ---
 

--- a/examples/callbacks/callbacks.go
+++ b/examples/callbacks/callbacks.go
@@ -37,7 +37,7 @@ var (
 		})
 
 	_ = tool.NewCallbacks().
-		RegisterBeforeTool(func(ctx context.Context, toolName string, toolDeclaration *tool.Declaration, jsonArgs []byte) (any, error) {
+		RegisterBeforeTool(func(ctx context.Context, toolName string, toolDeclaration *tool.Declaration, jsonArgs *[]byte) (any, error) {
 			fmt.Printf("🌐 Global BeforeTool: executing %s\n", toolName)
 			return nil, nil
 		}).
@@ -122,8 +122,12 @@ func (c *multiTurnChatWithCallbacks) createToolCallbacks() *tool.Callbacks {
 
 // createBeforeToolCallback creates the before tool callback.
 func (c *multiTurnChatWithCallbacks) createBeforeToolCallback() tool.BeforeToolCallback {
-	return func(ctx context.Context, toolName string, toolDeclaration *tool.Declaration, jsonArgs []byte) (any, error) {
-		fmt.Printf("\n🟠 BeforeToolCallback: tool=%s, args=%s\n", toolName, string(jsonArgs))
+	return func(ctx context.Context, toolName string, toolDeclaration *tool.Declaration, jsonArgs *[]byte) (any, error) {
+		if jsonArgs != nil {
+			fmt.Printf("\n🟠 BeforeToolCallback: tool=%s, args=%s\n", toolName, string(*jsonArgs))
+		} else {
+			fmt.Printf("\n🟠 BeforeToolCallback: tool=%s, args=<nil>\n", toolName)
+		}
 
 		if inv, ok := agent.InvocationFromContext(ctx); ok && inv != nil {
 			fmt.Printf("🟠 BeforeToolCallback: ✅ Invocation present in ctx (agent=%s, id=%s)\n", inv.AgentName, inv.InvocationID)
@@ -131,7 +135,7 @@ func (c *multiTurnChatWithCallbacks) createBeforeToolCallback() tool.BeforeToolC
 			fmt.Printf("🟠 BeforeToolCallback: ❌ Invocation NOT found in ctx\n")
 		}
 
-		if c.shouldReturnCustomToolResult(toolName, jsonArgs) {
+		if jsonArgs != nil && c.shouldReturnCustomToolResult(toolName, *jsonArgs) {
 			fmt.Println("\n🟠 BeforeToolCallback: triggered, custom result returned for calculator with 42.")
 			return c.createCustomCalculatorResult(), nil
 		}

--- a/examples/callbacks/timer/callbacks.go
+++ b/examples/callbacks/timer/callbacks.go
@@ -226,7 +226,7 @@ func (e *toolTimerExample) createAfterModelCallback() model.AfterModelCallback {
 
 // createBeforeToolCallback creates the before tool callback for timing.
 func (e *toolTimerExample) createBeforeToolCallback() tool.BeforeToolCallback {
-	return func(ctx context.Context, toolName string, toolDeclaration *tool.Declaration, jsonArgs []byte) (any, error) {
+	return func(ctx context.Context, toolName string, toolDeclaration *tool.Declaration, jsonArgs *[]byte) (any, error) {
 		// Record start time and store it in the instance variable.
 		startTime := time.Now()
 		if e.toolStartTimes == nil {
@@ -240,7 +240,12 @@ func (e *toolTimerExample) createBeforeToolCallback() tool.BeforeToolCallback {
 			"tool_execution",
 			trace.WithAttributes(
 				attribute.String("tool.name", toolName),
-				attribute.String("tool.args", string(jsonArgs)),
+				attribute.String("tool.args", func() string {
+					if jsonArgs == nil {
+						return ""
+					}
+					return string(*jsonArgs)
+				}()),
 			),
 		)
 		// Store span in instance variable for later use.
@@ -250,7 +255,11 @@ func (e *toolTimerExample) createBeforeToolCallback() tool.BeforeToolCallback {
 		e.toolSpans[toolName] = span
 
 		fmt.Printf("⏱️  BeforeToolCallback: %s started at %s\n", toolName, startTime.Format("15:04:05.000"))
-		fmt.Printf("   Args: %s\n", string(jsonArgs))
+		if jsonArgs != nil {
+			fmt.Printf("   Args: %s\n", string(*jsonArgs))
+		} else {
+			fmt.Printf("   Args: <nil>\n")
+		}
 
 		return nil, nil
 	}

--- a/examples/graph/subagent_runtime_state/main.go
+++ b/examples/graph/subagent_runtime_state/main.go
@@ -183,7 +183,7 @@ func buildGraphAndSubAgent(modelName, baseURL, apiKey string) (*graph.Graph, age
 		return nil, nil
 	})
 
-	toolCbs := (&tool.Callbacks{}).RegisterBeforeTool(func(ctx context.Context, toolName string, decl *tool.Declaration, args []byte) (any, error) {
+	toolCbs := (&tool.Callbacks{}).RegisterBeforeTool(func(ctx context.Context, toolName string, decl *tool.Declaration, args *[]byte) (any, error) {
 		// Demonstrate we can read parsed_time from runtime state inside sub‑agent callback
 		if inv, ok := agent.InvocationFromContext(ctx); ok && inv != nil && inv.RunOptions.RuntimeState != nil {
 			if v, ok2 := inv.RunOptions.RuntimeState["parsed_time"].(string); ok2 && v != "" {

--- a/graph/checkpoint_test.go
+++ b/graph/checkpoint_test.go
@@ -490,7 +490,7 @@ func TestRunTool_CallbackShortCircuitAndErrors(t *testing.T) {
 	cbs := tool.NewCallbacks().RegisterBeforeTool(func(ctx context.Context, toolName string, d *tool.Declaration, args *[]byte) (any, error) {
 		return map[string]any{"short": true}, nil
 	})
-	res, err := runTool(ctx, call, cbs, tdecl)
+	res, _, err := runTool(ctx, call, cbs, tdecl)
 	require.NoError(t, err)
 	m, _ := res.(map[string]any)
 	require.Equal(t, true, m["short"])
@@ -499,20 +499,20 @@ func TestRunTool_CallbackShortCircuitAndErrors(t *testing.T) {
 	cbs2 := tool.NewCallbacks().RegisterBeforeTool(func(ctx context.Context, toolName string, d *tool.Declaration, args *[]byte) (any, error) {
 		return nil, assert.AnError
 	})
-	_, err = runTool(ctx, call, cbs2, tdecl)
+	_, _, err = runTool(ctx, call, cbs2, tdecl)
 	require.Error(t, err)
 
 	// After callback returns custom result
 	cbs3 := tool.NewCallbacks().RegisterAfterTool(func(ctx context.Context, toolName string, d *tool.Declaration, args []byte, result any, runErr error) (any, error) {
 		return map[string]any{"override": true}, nil
 	})
-	res, err = runTool(ctx, call, cbs3, tdecl)
+	res, _, err = runTool(ctx, call, cbs3, tdecl)
 	require.NoError(t, err)
 	m2, _ := res.(map[string]any)
 	require.Equal(t, true, m2["override"])
 
 	// Not callable tool
-	_, err = runTool(ctx, call, nil, &notCallableTool{})
+	_, _, err = runTool(ctx, call, nil, &notCallableTool{})
 	require.Error(t, err)
 }
 

--- a/graph/checkpoint_test.go
+++ b/graph/checkpoint_test.go
@@ -487,7 +487,7 @@ func TestRunTool_CallbackShortCircuitAndErrors(t *testing.T) {
 	call := model.ToolCall{ID: "id", Function: model.FunctionDefinitionParam{Name: "echo", Arguments: []byte(`{"x":1}`)}}
 
 	// Before callback returns custom result
-	cbs := tool.NewCallbacks().RegisterBeforeTool(func(ctx context.Context, toolName string, d *tool.Declaration, args []byte) (any, error) {
+	cbs := tool.NewCallbacks().RegisterBeforeTool(func(ctx context.Context, toolName string, d *tool.Declaration, args *[]byte) (any, error) {
 		return map[string]any{"short": true}, nil
 	})
 	res, err := runTool(ctx, call, cbs, tdecl)
@@ -496,7 +496,7 @@ func TestRunTool_CallbackShortCircuitAndErrors(t *testing.T) {
 	require.Equal(t, true, m["short"])
 
 	// Before callback returns error
-	cbs2 := tool.NewCallbacks().RegisterBeforeTool(func(ctx context.Context, toolName string, d *tool.Declaration, args []byte) (any, error) {
+	cbs2 := tool.NewCallbacks().RegisterBeforeTool(func(ctx context.Context, toolName string, d *tool.Declaration, args *[]byte) (any, error) {
 		return nil, assert.AnError
 	})
 	_, err = runTool(ctx, call, cbs2, tdecl)

--- a/graph/state_graph.go
+++ b/graph/state_graph.go
@@ -853,7 +853,7 @@ func runTool(
 ) (any, error) {
 	if toolCallbacks != nil {
 		customResult, err := toolCallbacks.RunBeforeTool(
-			ctx, toolCall.Function.Name, t.Declaration(), toolCall.Function.Arguments)
+			ctx, toolCall.Function.Name, t.Declaration(), &toolCall.Function.Arguments)
 		if err != nil {
 			return nil, fmt.Errorf("callback before tool error: %w", err)
 		}

--- a/graph/state_graph.go
+++ b/graph/state_graph.go
@@ -845,40 +845,51 @@ func NewAgentNodeFunc(agentName string, opts ...Option) NodeFunc {
 	}
 }
 
+// runTool executes a tool with before/after callbacks and returns the result.
+// Parameters:
+//   - ctx: context for cancellation and tracing
+//   - toolCall: the tool call to execute, including function name and arguments
+//   - toolCallbacks: callbacks to execute before and after tool execution
+//   - t: the tool implementation to execute
+//
+// Returns:
+//   - any: the result from tool execution or custom callback result
+//   - []byte: the modified arguments after before-tool callbacks (for telemetry)
+//   - error: any error that occurred during execution
 func runTool(
 	ctx context.Context,
 	toolCall model.ToolCall,
 	toolCallbacks *tool.Callbacks,
 	t tool.Tool,
-) (any, error) {
+) (any, []byte, error) {
 	if toolCallbacks != nil {
 		customResult, err := toolCallbacks.RunBeforeTool(
 			ctx, toolCall.Function.Name, t.Declaration(), &toolCall.Function.Arguments)
 		if err != nil {
-			return nil, fmt.Errorf("callback before tool error: %w", err)
+			return nil, toolCall.Function.Arguments, fmt.Errorf("callback before tool error: %w", err)
 		}
 		if customResult != nil {
-			return customResult, nil
+			return customResult, toolCall.Function.Arguments, nil
 		}
 	}
 	if callableTool, ok := t.(tool.CallableTool); ok {
 		result, err := callableTool.Call(ctx, toolCall.Function.Arguments)
 		if err != nil {
-			return nil, fmt.Errorf("tool %s call failed: %w", toolCall.Function.Name, err)
+			return nil, toolCall.Function.Arguments, fmt.Errorf("tool %s call failed: %w", toolCall.Function.Name, err)
 		}
 		if toolCallbacks != nil {
 			customResult, err := toolCallbacks.RunAfterTool(
 				ctx, toolCall.Function.Name, t.Declaration(), toolCall.Function.Arguments, result, err)
 			if err != nil {
-				return nil, fmt.Errorf("callback after tool error: %w", err)
+				return nil, toolCall.Function.Arguments, fmt.Errorf("callback after tool error: %w", err)
 			}
 			if customResult != nil {
-				return customResult, nil
+				return customResult, toolCall.Function.Arguments, nil
 			}
 		}
-		return result, nil
+		return result, toolCall.Function.Arguments, nil
 	}
-	return nil, fmt.Errorf("tool %s is not callable", toolCall.Function.Name)
+	return nil, toolCall.Function.Arguments, fmt.Errorf("tool %s is not callable", toolCall.Function.Name)
 }
 
 // extractModelInput extracts the model input from state and instruction.
@@ -1119,15 +1130,15 @@ func executeSingleToolCall(ctx context.Context, config singleToolCallConfig) (mo
 		}
 	}
 
-	// Emit tool execution start event.
+	// Execute the tool with callbacks and get modified arguments.
+	ctx, span := trace.Tracer.Start(ctx, fmt.Sprintf("%s %s", itelemetry.SpanNamePrefixExecuteTool, config.ToolCall.Function.Name))
+	result, modifiedArgs, err := runTool(ctx, config.ToolCall, config.ToolCallbacks, t)
+
+	// Emit tool execution start event with modified arguments.
 	emitToolStartEvent(
 		config.EventChan, config.InvocationID, name, id, nodeID,
-		startTime, config.ToolCall.Function.Arguments,
+		startTime, modifiedArgs,
 	)
-
-	// Execute the tool.
-	ctx, span := trace.Tracer.Start(ctx, fmt.Sprintf("%s %s", itelemetry.SpanNamePrefixExecuteTool, config.ToolCall.Function.Name))
-	result, err := runTool(ctx, config.ToolCall, config.ToolCallbacks, t)
 	// Emit tool execution complete event.
 	event := emitToolCompleteEvent(toolCompleteEventConfig{
 		EventChan:    config.EventChan,
@@ -1138,9 +1149,9 @@ func executeSingleToolCall(ctx context.Context, config singleToolCallConfig) (mo
 		StartTime:    startTime,
 		Result:       result,
 		Error:        err,
-		Arguments:    config.ToolCall.Function.Arguments,
+		Arguments:    modifiedArgs,
 	})
-	itelemetry.TraceToolCall(span, t.Declaration(), config.ToolCall.Function.Arguments, event)
+	itelemetry.TraceToolCall(span, t.Declaration(), modifiedArgs, event)
 	span.End()
 
 	if err != nil {

--- a/internal/flow/processor/functioncall.go
+++ b/internal/flow/processor/functioncall.go
@@ -552,7 +552,7 @@ func (p *FunctionCallResponseProcessor) executeToolWithCallbacks(
 			ctx,
 			toolCall.Function.Name,
 			toolDeclaration,
-			toolCall.Function.Arguments,
+			&toolCall.Function.Arguments,
 		)
 		if callbackErr != nil {
 			log.Errorf("Before tool callback failed for %s: %v", toolCall.Function.Name, callbackErr)

--- a/internal/flow/processor/functioncall.go
+++ b/internal/flow/processor/functioncall.go
@@ -203,7 +203,7 @@ func (p *FunctionCallResponseProcessor) executeSingleToolCallSequential(
 		ctx, fmt.Sprintf("%s %s", itelemetry.SpanNamePrefixExecuteTool, toolCall.Function.Name),
 	)
 	defer span.End()
-	choice, err := p.executeToolCall(
+	choice, modifiedArgs, err := p.executeToolCall(
 		ctxWithInvocation, invocation, toolCall, tools, index, eventChan,
 	)
 	if err != nil {
@@ -221,7 +221,7 @@ func (p *FunctionCallResponseProcessor) executeSingleToolCallSequential(
 	}
 	decl := p.lookupDeclaration(tools, toolCall.Function.Name)
 	itelemetry.TraceToolCall(
-		span, decl, toolCall.Function.Arguments, toolEvent,
+		span, decl, modifiedArgs, toolEvent,
 	)
 	return toolEvent, nil
 }
@@ -300,7 +300,7 @@ func (p *FunctionCallResponseProcessor) runParallelToolCall(
 	defer span.End()
 
 	// Execute the tool (streamable or callable) with callbacks.
-	choice, err := p.executeToolCall(
+	choice, modifiedArgs, err := p.executeToolCall(
 		ctxWithInvocation, invocation, tc, tools, index, eventChan,
 	)
 	if err != nil {
@@ -334,7 +334,7 @@ func (p *FunctionCallResponseProcessor) runParallelToolCall(
 	}
 	// Include declaration for telemetry even when tool is missing.
 	decl := p.lookupDeclaration(tools, tc.Function.Name)
-	itelemetry.TraceToolCall(span, decl, tc.Function.Arguments, toolCallResponseEvent)
+	itelemetry.TraceToolCall(span, decl, modifiedArgs, toolCallResponseEvent)
 	// Send result back to aggregator.
 	p.sendToolResult(
 		ctx, resultChan, toolResult{index: index, event: toolCallResponseEvent},
@@ -418,6 +418,18 @@ func (p *FunctionCallResponseProcessor) buildMergedParallelEvent(
 }
 
 // executeToolCall executes a single tool call and returns the choice.
+// Parameters:
+//   - ctx: context for cancellation and tracing
+//   - invocation: agent invocation context containing agent name, model info, etc.
+//   - toolCall: the tool call to execute, including function name and arguments
+//   - tools: map of available tools by name
+//   - index: index of this tool call in the batch (for error reporting)
+//   - eventChan: channel for emitting events during execution
+//
+// Returns:
+//   - *model.Choice: the result choice containing tool response
+//   - []byte: the modified arguments after before-tool callbacks (for telemetry)
+//   - error: any error that occurred during execution
 func (p *FunctionCallResponseProcessor) executeToolCall(
 	ctx context.Context,
 	invocation *agent.Invocation,
@@ -425,7 +437,7 @@ func (p *FunctionCallResponseProcessor) executeToolCall(
 	tools map[string]tool.Tool,
 	index int,
 	eventChan chan<- *event.Event,
-) (*model.Choice, error) {
+) (*model.Choice, []byte, error) {
 	// Check if tool exists.
 	tl, exists := tools[toolCall.Function.Name]
 	if !exists {
@@ -442,24 +454,24 @@ func (p *FunctionCallResponseProcessor) executeToolCall(
 		} else {
 			log.Errorf("CallableTool %s not found (agent=%s, model=%s)",
 				toolCall.Function.Name, invocation.AgentName, invocation.Model.Info().Name)
-			return p.createErrorChoice(index, toolCall.ID, ErrorToolNotFound), nil
+			return p.createErrorChoice(index, toolCall.ID, ErrorToolNotFound), toolCall.Function.Arguments, nil
 		}
 	}
 
 	log.Debugf("Executing tool %s with args: %s", toolCall.Function.Name, string(toolCall.Function.Arguments))
 
 	// Execute the tool with callbacks.
-	result, err := p.executeToolWithCallbacks(ctx, invocation, toolCall, tl, eventChan)
+	result, modifiedArgs, err := p.executeToolWithCallbacks(ctx, invocation, toolCall, tl, eventChan)
 	if err != nil {
 		if _, ok := agent.AsStopError(err); ok {
-			return nil, err
+			return nil, modifiedArgs, err
 		}
-		return p.createErrorChoice(index, toolCall.ID, err.Error()), nil
+		return p.createErrorChoice(index, toolCall.ID, err.Error()), modifiedArgs, nil
 	}
 	//  allow to return nil not provide function response.
 	if r, ok := tl.(function.LongRunner); ok && r.LongRunning() {
 		if result == nil {
-			return nil, nil
+			return nil, modifiedArgs, nil
 		}
 	}
 
@@ -467,7 +479,7 @@ func (p *FunctionCallResponseProcessor) executeToolCall(
 	resultBytes, err := json.Marshal(result)
 	if err != nil {
 		log.Errorf("Failed to marshal tool result for %s: %v", toolCall.Function.Name, err)
-		return p.createErrorChoice(index, toolCall.ID, ErrorMarshalResult), nil
+		return p.createErrorChoice(index, toolCall.ID, ErrorMarshalResult), modifiedArgs, nil
 	}
 
 	log.Debugf("CallableTool %s executed successfully, result: %s", toolCall.Function.Name, string(resultBytes))
@@ -479,7 +491,7 @@ func (p *FunctionCallResponseProcessor) executeToolCall(
 			Content: string(resultBytes),
 			ToolID:  toolCall.ID,
 		},
-	}, nil
+	}, modifiedArgs, nil
 }
 
 // waitForCompletion waits for event completion if required.
@@ -538,13 +550,14 @@ func (p *FunctionCallResponseProcessor) collectParallelToolResults(
 }
 
 // executeToolWithCallbacks executes a tool with before/after callbacks.
+// Returns (result, modifiedArguments, error).
 func (p *FunctionCallResponseProcessor) executeToolWithCallbacks(
 	ctx context.Context,
 	invocation *agent.Invocation,
 	toolCall model.ToolCall,
 	tl tool.Tool,
 	eventChan chan<- *event.Event,
-) (any, error) {
+) (any, []byte, error) {
 	toolDeclaration := tl.Declaration()
 	// Run before tool callbacks if they exist.
 	if p.toolCallbacks != nil {
@@ -556,18 +569,18 @@ func (p *FunctionCallResponseProcessor) executeToolWithCallbacks(
 		)
 		if callbackErr != nil {
 			log.Errorf("Before tool callback failed for %s: %v", toolCall.Function.Name, callbackErr)
-			return nil, fmt.Errorf("tool callback error: %w", callbackErr)
+			return nil, toolCall.Function.Arguments, fmt.Errorf("tool callback error: %w", callbackErr)
 		}
 		if customResult != nil {
 			// Use custom result from callback.
-			return customResult, nil
+			return customResult, toolCall.Function.Arguments, nil
 		}
 	}
 
 	// Execute the actual tool.
 	result, err := p.executeTool(ctx, invocation, toolCall, tl, eventChan)
 	if err != nil {
-		return nil, err
+		return nil, toolCall.Function.Arguments, err
 	}
 
 	// Run after tool callbacks if they exist.
@@ -582,13 +595,13 @@ func (p *FunctionCallResponseProcessor) executeToolWithCallbacks(
 		)
 		if callbackErr != nil {
 			log.Errorf("After tool callback failed for %s: %v", toolCall.Function.Name, callbackErr)
-			return nil, fmt.Errorf("tool callback error: %w", callbackErr)
+			return nil, toolCall.Function.Arguments, fmt.Errorf("tool callback error: %w", callbackErr)
 		}
 		if customResult != nil {
 			result = customResult
 		}
 	}
-	return result, nil
+	return result, toolCall.Function.Arguments, nil
 }
 
 // isStreamable returns true if the tool supports streaming and its stream

--- a/internal/flow/processor/functioncall_test.go
+++ b/internal/flow/processor/functioncall_test.go
@@ -1379,7 +1379,7 @@ func TestCollectParallelToolResults_ContextCancelled(t *testing.T) {
 func TestExecuteToolWithCallbacks_BeforeCustomResult(t *testing.T) {
 	cb := tool.NewCallbacks()
 	cb.RegisterBeforeTool(func(_ context.Context, _ string,
-		_ *tool.Declaration, _ []byte) (any, error) {
+		_ *tool.Declaration, _ *[]byte) (any, error) {
 		return map[string]any{"v": 1}, nil
 	})
 	p := NewFunctionCallResponseProcessor(false, cb)
@@ -1396,7 +1396,7 @@ func TestExecuteToolWithCallbacks_BeforeCustomResult(t *testing.T) {
 func TestExecuteToolWithCallbacks_BeforeError(t *testing.T) {
 	cb := tool.NewCallbacks()
 	cb.RegisterBeforeTool(func(_ context.Context, _ string,
-		_ *tool.Declaration, _ []byte) (any, error) {
+		_ *tool.Declaration, _ *[]byte) (any, error) {
 		return nil, fmt.Errorf("fail")
 	})
 	p := NewFunctionCallResponseProcessor(false, cb)

--- a/internal/flow/processor/functioncall_test.go
+++ b/internal/flow/processor/functioncall_test.go
@@ -109,7 +109,7 @@ func TestExecuteToolCall_MapsSubAgentToTransfer(t *testing.T) {
 		},
 	}
 
-	choice, err := p.executeToolCall(ctx, inv, pc, tools, 0, nil)
+	choice, _, err := p.executeToolCall(ctx, inv, pc, tools, 0, nil)
 	require.NoError(t, err)
 	require.NotNil(t, choice)
 
@@ -151,7 +151,7 @@ func TestExecuteToolCall(t *testing.T) {
 		},
 	}
 
-	choice, err := p.executeToolCall(ctx, inv, pc, tools, 0, nil)
+	choice, _, err := p.executeToolCall(ctx, inv, pc, tools, 0, nil)
 	res, _ := json.Marshal("Tokyo'weather is good")
 	require.NoError(t, err)
 	require.NotNil(t, choice)
@@ -600,7 +600,7 @@ func TestExecuteToolCall_ToolNotFound_ReturnsErrorChoice(t *testing.T) {
 		},
 	}
 
-	choice, err := p.executeToolCall(ctx, inv, pc2, tools, 0, nil)
+	choice, _, err := p.executeToolCall(ctx, inv, pc2, tools, 0, nil)
 	require.NoError(t, err)
 	require.NotNil(t, choice)
 	assert.Equal(t, ErrorToolNotFound, choice.Message.Content)
@@ -1387,7 +1387,7 @@ func TestExecuteToolWithCallbacks_BeforeCustomResult(t *testing.T) {
 	inv := &agent.Invocation{}
 	tl := &mockCallableTool{declaration: &tool.Declaration{Name: "t"},
 		callFn: func(_ context.Context, _ []byte) (any, error) { return "x", nil }}
-	res, err := p.executeToolWithCallbacks(ctx, inv, model.ToolCall{Function: model.FunctionDefinitionParam{Name: "t"}}, tl, nil)
+	res, _, err := p.executeToolWithCallbacks(ctx, inv, model.ToolCall{Function: model.FunctionDefinitionParam{Name: "t"}}, tl, nil)
 	require.NoError(t, err)
 	b, _ := json.Marshal(map[string]any{"v": 1})
 	require.JSONEq(t, string(b), string(mustJSON(res)))
@@ -1404,7 +1404,7 @@ func TestExecuteToolWithCallbacks_BeforeError(t *testing.T) {
 	inv := &agent.Invocation{}
 	tl := &mockCallableTool{declaration: &tool.Declaration{Name: "t"},
 		callFn: func(_ context.Context, _ []byte) (any, error) { return "x", nil }}
-	_, err := p.executeToolWithCallbacks(ctx, inv, model.ToolCall{Function: model.FunctionDefinitionParam{Name: "t"}}, tl, nil)
+	_, _, err := p.executeToolWithCallbacks(ctx, inv, model.ToolCall{Function: model.FunctionDefinitionParam{Name: "t"}}, tl, nil)
 	require.Error(t, err)
 }
 
@@ -1419,7 +1419,7 @@ func TestExecuteToolWithCallbacks_AfterOverrideAndError(t *testing.T) {
 	inv := &agent.Invocation{}
 	tl := &mockCallableTool{declaration: &tool.Declaration{Name: "t"},
 		callFn: func(_ context.Context, _ []byte) (any, error) { return "x", nil }}
-	res, err := p.executeToolWithCallbacks(ctx, inv, model.ToolCall{Function: model.FunctionDefinitionParam{Name: "t"}}, tl, nil)
+	res, _, err := p.executeToolWithCallbacks(ctx, inv, model.ToolCall{Function: model.FunctionDefinitionParam{Name: "t"}}, tl, nil)
 	require.NoError(t, err)
 	b, _ := json.Marshal(map[string]any{"ok": true})
 	require.JSONEq(t, string(b), string(mustJSON(res)))
@@ -1432,7 +1432,7 @@ func TestExecuteToolWithCallbacks_AfterOverrideAndError(t *testing.T) {
 	})
 	inv2 := &agent.Invocation{}
 	p.toolCallbacks = cb
-	_, err = p.executeToolWithCallbacks(ctx, inv2, model.ToolCall{Function: model.FunctionDefinitionParam{Name: "t"}}, tl, nil)
+	_, _, err = p.executeToolWithCallbacks(ctx, inv2, model.ToolCall{Function: model.FunctionDefinitionParam{Name: "t"}}, tl, nil)
 	require.Error(t, err)
 }
 

--- a/tool/callbacks.go
+++ b/tool/callbacks.go
@@ -18,7 +18,7 @@ import (
 // Returns (customResult, error).
 // - customResult: if not nil, this result will be returned and tool execution will be skipped.
 // - error: if not nil, tool execution will be stopped with this error.
-type BeforeToolCallback func(ctx context.Context, toolName string, toolDeclaration *Declaration, jsonArgs []byte) (any, error)
+type BeforeToolCallback func(ctx context.Context, toolName string, toolDeclaration *Declaration, jsonArgs *[]byte) (any, error)
 
 // AfterToolCallback is called after a tool is executed.
 // Returns (customResult, error).
@@ -58,7 +58,7 @@ func (c *Callbacks) RunBeforeTool(
 	ctx context.Context,
 	toolName string,
 	toolDeclaration *Declaration,
-	jsonArgs []byte,
+	jsonArgs *[]byte,
 ) (any, error) {
 	for _, cb := range c.BeforeTool {
 		customResult, err := cb(ctx, toolName, toolDeclaration, jsonArgs)


### PR DESCRIPTION
- Updated the BeforeToolCallback signature to accept a pointer to jsonArgs instead of a byte slice.
- Adjusted all relevant callback implementations and tests to handle the new argument type, ensuring proper argument modification and nil checks.
- Enhanced logging in callbacks to handle nil jsonArgs gracefully.