### PR TITLE
docs: add Callbacks documentation and update mkdocs navigation

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -9,12 +9,13 @@ nav:
   - Overview: index.md
   - Components:
       - Agent:
-        - Agent: agent.md
-        - Multi Agent: multiagent.md
-        - Graph Agent: graph.md
-        - Custom Agent: custom-agent.md
+          - Agent: agent.md
+          - Multi Agent: multiagent.md
+          - Graph Agent: graph.md
+          - Custom Agent: custom-agent.md
       - Runner: runner.md
       - Model: model.md
+      - Callbacks: callbacks.md
       - Memory: memory.md
       - Artifact: artifact.md
       - Tool: tool.md
@@ -43,13 +44,14 @@ plugins:
           nav:
             - 概览: index.md
             - 组件:
-                - Agent: 
-                  - Agent: agent.md
-                  - Multi Agent: multiagent.md
-                  - Graph Agent: graph.md
-                  - 自定义 Agent: custom-agent.md
+                - Agent:
+                    - Agent: agent.md
+                    - Multi Agent: multiagent.md
+                    - Graph Agent: graph.md
+                    - 自定义 Agent: custom-agent.md
                 - Runner: runner.md
                 - Model: model.md
+                - Callbacks: callbacks.md
                 - Memory: memory.md
                 - Artifact: artifact.md
                 - Tool: tool.md

--- a/docs/mkdocs/en/callbacks.md
+++ b/docs/mkdocs/en/callbacks.md
@@ -1,0 +1,251 @@
+## Callbacks
+
+This page describes the callback system used across the project to intercept,
+observe, and customize model inference, tool invocation, and agent execution.
+
+The callback system comes in three categories:
+
+- ModelCallbacks
+- ToolCallbacks
+- AgentCallbacks
+
+Each category provides a Before and an After callback. A Before callback can
+short-circuit the default execution by returning a non-nil custom response.
+
+---
+
+## ModelCallbacks
+
+- BeforeModelCallback: Runs before a model inference.
+- AfterModelCallback: Runs after the model finishes (or per streaming phase).
+
+Signatures:
+
+```go
+type BeforeModelCallback func(ctx context.Context, req *model.Request) (*model.Response, error)
+type AfterModelCallback  func(ctx context.Context, req *model.Request, resp *model.Response, runErr error) (*model.Response, error)
+```
+
+Key points:
+
+- Before can return a non-nil response to skip the model call.
+- After receives the original request, useful for content restoration and
+  post-processing.
+
+Example:
+
+```go
+modelCallbacks := model.NewCallbacks().
+  RegisterBeforeModel(func(ctx context.Context, req *model.Request) (*model.Response, error) {
+    // Block or mock as needed.
+    return nil, nil
+  }).
+  RegisterAfterModel(func(ctx context.Context, req *model.Request, resp *model.Response, runErr error) (*model.Response, error) {
+    // Post-process response with access to the original request.
+    return nil, nil
+  })
+```
+
+---
+
+## ToolCallbacks
+
+- BeforeToolCallback: Runs before each tool invocation.
+- AfterToolCallback: Runs after each tool invocation.
+
+Signatures:
+
+```go
+// Before: can short-circuit with a custom result and can mutate arguments via pointer.
+type BeforeToolCallback func(
+  ctx context.Context,
+  toolName string,
+  toolDeclaration *tool.Declaration,
+  jsonArgs *[]byte, // pointer: mutations are visible to the caller
+) (any, error)
+
+// After: can override the result.
+type AfterToolCallback func(
+  ctx context.Context,
+  toolName string,
+  toolDeclaration *tool.Declaration,
+  jsonArgs []byte,
+  result any,
+  runErr error,
+) (any, error)
+```
+
+Argument mutation (important):
+
+- jsonArgs is passed as a pointer (`*[]byte`) to BeforeToolCallback.
+- The callback may replace the slice (e.g., `*jsonArgs = newBytes`).
+- The mutated arguments will be used for:
+  - The actual tool execution.
+  - Telemetry traces and graph events (emitToolStartEvent/emitToolCompleteEvent).
+
+Short-circuiting:
+
+- If BeforeToolCallback returns a non-nil custom result, the tool is skipped
+  and that result is used directly.
+
+Example:
+
+```go
+toolCallbacks := tool.NewCallbacks().
+  RegisterBeforeTool(func(ctx context.Context, toolName string, d *tool.Declaration, jsonArgs *[]byte) (any, error) {
+    if jsonArgs != nil && toolName == "calculator" {
+      // Enrich arguments.
+      original := string(*jsonArgs)
+      enriched := []byte(fmt.Sprintf(`{"original":%s,"ts":%d}`, original, time.Now().Unix()))
+      *jsonArgs = enriched
+    }
+    return nil, nil
+  }).
+  RegisterAfterTool(func(ctx context.Context, toolName string, d *tool.Declaration, args []byte, result any, runErr error) (any, error) {
+    // Optionally override result or log.
+    return nil, nil
+  })
+```
+
+Telemetry and events:
+
+- Modified arguments are propagated to:
+  - `TraceToolCall` telemetry attributes.
+  - Graph events emitted by `emitToolStartEvent` and `emitToolCompleteEvent`.
+
+---
+
+## AgentCallbacks
+
+- BeforeAgentCallback: Runs before agent execution.
+- AfterAgentCallback: Runs after agent execution.
+
+Signatures:
+
+```go
+type BeforeAgentCallback func(ctx context.Context, inv *agent.Invocation) (*model.Response, error)
+type AfterAgentCallback  func(ctx context.Context, inv *agent.Invocation, runErr error) (*model.Response, error)
+```
+
+Key points:
+
+- Before can short-circuit with a custom model.Response.
+- After can return a replacement response.
+
+Example:
+
+```go
+agentCallbacks := agent.NewCallbacks().
+  RegisterBeforeAgent(func(ctx context.Context, inv *agent.Invocation) (*model.Response, error) {
+    return nil, nil
+  }).
+  RegisterAfterAgent(func(ctx context.Context, inv *agent.Invocation, runErr error) (*model.Response, error) {
+    return nil, nil
+  })
+```
+
+---
+
+## Access Invocation in Callbacks
+
+Callbacks can access the current agent invocation via context to correlate
+events, add tracing, or implement per-invocation logic.
+
+```go
+if inv, ok := agent.InvocationFromContext(ctx); ok && inv != nil {
+  fmt.Printf("invocation id=%s, agent=%s\n", inv.InvocationID, inv.AgentName)
+}
+```
+
+This pattern is showcased in the examples where Before/After callbacks print
+the presence of an invocation.
+
+---
+
+## Global Callbacks and Chain Registration
+
+You can define reusable global callbacks using chain registration.
+
+```go
+_ = model.NewCallbacks().
+  RegisterBeforeModel(func(ctx context.Context, req *model.Request) (*model.Response, error) {
+    fmt.Printf("Global BeforeModel: %d messages.\n", len(req.Messages))
+    return nil, nil
+  }).
+  RegisterAfterModel(func(ctx context.Context, req *model.Request, rsp *model.Response, err error) (*model.Response, error) {
+    fmt.Println("Global AfterModel: completed.")
+    return nil, nil
+  })
+
+_ = tool.NewCallbacks().
+  RegisterBeforeTool(func(ctx context.Context, toolName string, d *tool.Declaration, jsonArgs *[]byte) (any, error) {
+    fmt.Printf("Global BeforeTool: %s.\n", toolName)
+    // jsonArgs is a pointer; modifications are visible to the caller.
+    return nil, nil
+  }).
+  RegisterAfterTool(func(ctx context.Context, toolName string, d *tool.Declaration, jsonArgs []byte, result any, runErr error) (any, error) {
+    fmt.Printf("Global AfterTool: %s done.\n", toolName)
+    return nil, nil
+  })
+
+_ = agent.NewCallbacks().
+  RegisterBeforeAgent(func(ctx context.Context, inv *agent.Invocation) (*model.Response, error) {
+    fmt.Printf("Global BeforeAgent: %s.\n", inv.AgentName)
+    return nil, nil
+  }).
+  RegisterAfterAgent(func(ctx context.Context, inv *agent.Invocation, runErr error) (*model.Response, error) {
+    fmt.Println("Global AfterAgent: completed.")
+    return nil, nil
+  })
+```
+
+---
+
+## Mocking and Argument Mutation Examples
+
+Mock a tool result and short-circuit execution:
+
+```go
+toolCallbacks.RegisterBeforeTool(func(ctx context.Context, toolName string, d *tool.Declaration, jsonArgs *[]byte) (any, error) {
+  if toolName == "calculator" && jsonArgs != nil && strings.Contains(string(*jsonArgs), "42") {
+    return calculatorResult{Operation: "custom", A: 42, B: 42, Result: 4242}, nil
+  }
+  return nil, nil
+})
+```
+
+Modify arguments prior to execution (and telemetry/event reporting):
+
+```go
+toolCallbacks.RegisterBeforeTool(func(ctx context.Context, toolName string, d *tool.Declaration, jsonArgs *[]byte) (any, error) {
+  if jsonArgs != nil && toolName == "calculator" {
+    originalArgs := string(*jsonArgs)
+    modifiedArgs := fmt.Sprintf(`{"original":%s,"timestamp":"%d"}`, originalArgs, time.Now().Unix())
+    *jsonArgs = []byte(modifiedArgs)
+  }
+  return nil, nil
+})
+```
+
+Both examples mirror the runnable demo under [examples/callbacks](../../../examples/callbacks/).
+
+---
+
+## Running the Callbacks Example
+
+```bash
+cd examples/callbacks
+export OPENAI_API_KEY="your-api-key"
+
+# Basic
+go run .
+
+# Choose model
+go run . -model gpt-4o-mini
+
+# Disable streaming
+go run . -streaming=false
+```
+
+Observe logs for Before/After callbacks, argument mutation messages, and tool
+responses.

--- a/docs/mkdocs/zh/callbacks.md
+++ b/docs/mkdocs/zh/callbacks.md
@@ -4,18 +4,18 @@
 
 回调分为三类：
 
-- ModelCallbacks（模型回调）.
-- ToolCallbacks（工具回调）.
-- AgentCallbacks（代理回调）.
+- ModelCallbacks（模型回调）
+- ToolCallbacks（工具回调）
+- AgentCallbacks（代理回调）
 
-每类都有 Before 与 After 两种回调。Before 回调可以通过返回非空结果短路默认执行。
+每类都有 Before 与 After 两种回调。Before 回调可以通过返回非空结果提前返回，跳过默认执行。
 
 ---
 
 ## ModelCallbacks
 
-- BeforeModelCallback：模型推理前触发.
-- AfterModelCallback：模型完成后触发（或按流式阶段）.
+- BeforeModelCallback：模型推理前触发
+- AfterModelCallback：模型完成后触发（或按流式阶段）
 
 签名：
 
@@ -26,8 +26,8 @@ type AfterModelCallback  func(ctx context.Context, req *model.Request, resp *mod
 
 要点：
 
-- Before 可返回非空响应以跳过模型调用.
-- After 可获取原始请求 `req`，便于内容还原与后处理.
+- Before 可返回非空响应以跳过模型调用
+- After 可获取原始请求 `req`，便于内容还原与后处理
 
 示例：
 
@@ -45,13 +45,13 @@ modelCallbacks := model.NewCallbacks().
 
 ## ToolCallbacks
 
-- BeforeToolCallback：工具调用前触发.
-- AfterToolCallback：工具调用后触发.
+- BeforeToolCallback：工具调用前触发
+- AfterToolCallback：工具调用后触发
 
 签名：
 
 ```go
-// Before：可短路并可通过指针修改参数.
+// Before：可提前返回，并可通过指针修改参数
 type BeforeToolCallback func(
   ctx context.Context,
   toolName string,
@@ -59,7 +59,7 @@ type BeforeToolCallback func(
   jsonArgs *[]byte, // 指针：可修改，修改对调用方可见
 ) (any, error)
 
-// After：可覆盖结果.
+// After：可覆盖结果
 type AfterToolCallback func(
   ctx context.Context,
   toolName string,
@@ -72,14 +72,14 @@ type AfterToolCallback func(
 
 参数修改（重要）：
 
-- BeforeToolCallback 接收 `*[]byte`，回调内部可替换切片（如 `*jsonArgs = newBytes`）.
+- BeforeToolCallback 接收 `*[]byte`，回调内部可替换切片（如 `*jsonArgs = newBytes`）
 - 修改后的参数将用于：
-  - 实际工具执行.
-  - 遥测 Trace 与图事件（emitToolStartEvent/emitToolCompleteEvent）上报.
+  - 实际工具执行
+  - 可观测 Trace 与图事件（emitToolStartEvent/emitToolCompleteEvent）上报
 
-短路：
+提前返回：
 
-- BeforeToolCallback 返回非空结果时，会跳过实际工具执行，直接使用该结果.
+- BeforeToolCallback 返回非空结果时，会跳过实际工具执行，直接使用该结果
 
 示例：
 
@@ -98,19 +98,19 @@ toolCallbacks := tool.NewCallbacks().
   })
 ```
 
-遥测与事件：
+可观测与事件：
 
 - 修改后的参数会同步到：
 
-  - `TraceToolCall` 遥测属性.
-  - 图事件 `emitToolStartEvent` 与 `emitToolCompleteEvent`.
+  - `TraceToolCall` 可观测属性
+  - 图事件 `emitToolStartEvent` 与 `emitToolCompleteEvent`
 
 ---
 
 ## AgentCallbacks
 
-- BeforeAgentCallback：Agent 执行前触发.
-- AfterAgentCallback：Agent 执行后触发.
+- BeforeAgentCallback：Agent 执行前触发
+- AfterAgentCallback：Agent 执行后触发
 
 签名：
 
@@ -121,8 +121,8 @@ type AfterAgentCallback  func(ctx context.Context, inv *agent.Invocation, runErr
 
 要点：
 
-- Before 可返回自定义 `*model.Response` 以短路.
-- After 可返回替换响应.
+- Before 可返回自定义 `*model.Response` 以中止后续流程
+- After 可返回替换响应
 
 示例：
 
@@ -192,7 +192,7 @@ _ = agent.NewCallbacks().
 
 ## Mock 与参数修改示例
 
-Mock 工具结果并短路执行：
+Mock 工具结果并中止后续流程：
 
 ```go
 toolCallbacks.RegisterBeforeTool(func(ctx context.Context, toolName string, d *tool.Declaration, jsonArgs *[]byte) (any, error) {
@@ -203,7 +203,7 @@ toolCallbacks.RegisterBeforeTool(func(ctx context.Context, toolName string, d *t
 })
 ```
 
-执行前修改参数（并在遥测/事件中体现）：
+执行前修改参数（并在可观测/事件中体现）：
 
 ```go
 toolCallbacks.RegisterBeforeTool(func(ctx context.Context, toolName string, d *tool.Declaration, jsonArgs *[]byte) (any, error) {

--- a/docs/mkdocs/zh/callbacks.md
+++ b/docs/mkdocs/zh/callbacks.md
@@ -138,7 +138,7 @@ type AfterAgentCallback  func(ctx context.Context, inv *agent.Invocation, runErr
 
 要点：
 
-- Before 可返回自定义 `*model.Response` 以中止后续流程
+- Before 可返回自定义 `*model.Response` 以中止后续模型调用
 - After 可返回替换响应
 
 示例：
@@ -223,7 +223,7 @@ _ = agent.NewCallbacks().
 
 ## Mock 与参数修改示例
 
-Mock 工具结果并中止后续流程：
+Mock 工具结果并中止后续工具调用：
 
 ```go
 toolCallbacks.RegisterBeforeTool(func(ctx context.Context, toolName string, d *tool.Declaration, jsonArgs *[]byte) (any, error) {

--- a/docs/mkdocs/zh/callbacks.md
+++ b/docs/mkdocs/zh/callbacks.md
@@ -1,0 +1,239 @@
+## 回调（Callbacks）
+
+本文介绍项目中的回调系统，用于拦截、观测与定制模型推理、工具调用与 Agent 执行。
+
+回调分为三类：
+
+- ModelCallbacks（模型回调）.
+- ToolCallbacks（工具回调）.
+- AgentCallbacks（代理回调）.
+
+每类都有 Before 与 After 两种回调。Before 回调可以通过返回非空结果短路默认执行。
+
+---
+
+## ModelCallbacks
+
+- BeforeModelCallback：模型推理前触发.
+- AfterModelCallback：模型完成后触发（或按流式阶段）.
+
+签名：
+
+```go
+type BeforeModelCallback func(ctx context.Context, req *model.Request) (*model.Response, error)
+type AfterModelCallback  func(ctx context.Context, req *model.Request, resp *model.Response, runErr error) (*model.Response, error)
+```
+
+要点：
+
+- Before 可返回非空响应以跳过模型调用.
+- After 可获取原始请求 `req`，便于内容还原与后处理.
+
+示例：
+
+```go
+modelCallbacks := model.NewCallbacks().
+  RegisterBeforeModel(func(ctx context.Context, req *model.Request) (*model.Response, error) {
+    return nil, nil
+  }).
+  RegisterAfterModel(func(ctx context.Context, req *model.Request, resp *model.Response, runErr error) (*model.Response, error) {
+    return nil, nil
+  })
+```
+
+---
+
+## ToolCallbacks
+
+- BeforeToolCallback：工具调用前触发.
+- AfterToolCallback：工具调用后触发.
+
+签名：
+
+```go
+// Before：可短路并可通过指针修改参数.
+type BeforeToolCallback func(
+  ctx context.Context,
+  toolName string,
+  toolDeclaration *tool.Declaration,
+  jsonArgs *[]byte, // 指针：可修改，修改对调用方可见
+) (any, error)
+
+// After：可覆盖结果.
+type AfterToolCallback func(
+  ctx context.Context,
+  toolName string,
+  toolDeclaration *tool.Declaration,
+  jsonArgs []byte,
+  result any,
+  runErr error,
+) (any, error)
+```
+
+参数修改（重要）：
+
+- BeforeToolCallback 接收 `*[]byte`，回调内部可替换切片（如 `*jsonArgs = newBytes`）.
+- 修改后的参数将用于：
+  - 实际工具执行.
+  - 遥测 Trace 与图事件（emitToolStartEvent/emitToolCompleteEvent）上报.
+
+短路：
+
+- BeforeToolCallback 返回非空结果时，会跳过实际工具执行，直接使用该结果.
+
+示例：
+
+```go
+toolCallbacks := tool.NewCallbacks().
+  RegisterBeforeTool(func(ctx context.Context, toolName string, d *tool.Declaration, jsonArgs *[]byte) (any, error) {
+    if jsonArgs != nil && toolName == "calculator" {
+      origin := string(*jsonArgs)
+      enriched := []byte(fmt.Sprintf(`{"original":%s,"ts":%d}`, origin, time.Now().Unix()))
+      *jsonArgs = enriched
+    }
+    return nil, nil
+  }).
+  RegisterAfterTool(func(ctx context.Context, toolName string, d *tool.Declaration, args []byte, result any, runErr error) (any, error) {
+    return nil, nil
+  })
+```
+
+遥测与事件：
+
+- 修改后的参数会同步到：
+
+  - `TraceToolCall` 遥测属性.
+  - 图事件 `emitToolStartEvent` 与 `emitToolCompleteEvent`.
+
+---
+
+## AgentCallbacks
+
+- BeforeAgentCallback：Agent 执行前触发.
+- AfterAgentCallback：Agent 执行后触发.
+
+签名：
+
+```go
+type BeforeAgentCallback func(ctx context.Context, inv *agent.Invocation) (*model.Response, error)
+type AfterAgentCallback  func(ctx context.Context, inv *agent.Invocation, runErr error) (*model.Response, error)
+```
+
+要点：
+
+- Before 可返回自定义 `*model.Response` 以短路.
+- After 可返回替换响应.
+
+示例：
+
+```go
+agentCallbacks := agent.NewCallbacks().
+  RegisterBeforeAgent(func(ctx context.Context, inv *agent.Invocation) (*model.Response, error) {
+    return nil, nil
+  }).
+  RegisterAfterAgent(func(ctx context.Context, inv *agent.Invocation, runErr error) (*model.Response, error) {
+    return nil, nil
+  })
+```
+
+---
+
+## 在回调中访问 Invocation
+
+回调可通过 context 获取当前的 Invocation 以便做关联日志、追踪或按次逻辑。
+
+```go
+if inv, ok := agent.InvocationFromContext(ctx); ok && inv != nil {
+  fmt.Printf("invocation id=%s, agent=%s\n", inv.InvocationID, inv.AgentName)
+}
+```
+
+示例工程在 Before/After 回调中打印了 Invocation 的存在性。
+
+---
+
+## 全局回调与链式注册
+
+可通过链式注册构建可复用的全局回调配置。
+
+```go
+_ = model.NewCallbacks().
+  RegisterBeforeModel(func(ctx context.Context, req *model.Request) (*model.Response, error) {
+    fmt.Printf("Global BeforeModel: %d messages.\n", len(req.Messages))
+    return nil, nil
+  }).
+  RegisterAfterModel(func(ctx context.Context, req *model.Request, rsp *model.Response, err error) (*model.Response, error) {
+    fmt.Println("Global AfterModel: completed.")
+    return nil, nil
+  })
+
+_ = tool.NewCallbacks().
+  RegisterBeforeTool(func(ctx context.Context, toolName string, d *tool.Declaration, jsonArgs *[]byte) (any, error) {
+    fmt.Printf("Global BeforeTool: %s.\n", toolName)
+    return nil, nil
+  }).
+  RegisterAfterTool(func(ctx context.Context, toolName string, d *tool.Declaration, jsonArgs []byte, result any, runErr error) (any, error) {
+    fmt.Printf("Global AfterTool: %s done.\n", toolName)
+    return nil, nil
+  })
+
+_ = agent.NewCallbacks().
+  RegisterBeforeAgent(func(ctx context.Context, inv *agent.Invocation) (*model.Response, error) {
+    fmt.Printf("Global BeforeAgent: %s.\n", inv.AgentName)
+    return nil, nil
+  }).
+  RegisterAfterAgent(func(ctx context.Context, inv *agent.Invocation, runErr error) (*model.Response, error) {
+    fmt.Println("Global AfterAgent: completed.")
+    return nil, nil
+  })
+```
+
+---
+
+## Mock 与参数修改示例
+
+Mock 工具结果并短路执行：
+
+```go
+toolCallbacks.RegisterBeforeTool(func(ctx context.Context, toolName string, d *tool.Declaration, jsonArgs *[]byte) (any, error) {
+  if toolName == "calculator" && jsonArgs != nil && strings.Contains(string(*jsonArgs), "42") {
+    return calculatorResult{Operation: "custom", A: 42, B: 42, Result: 4242}, nil
+  }
+  return nil, nil
+})
+```
+
+执行前修改参数（并在遥测/事件中体现）：
+
+```go
+toolCallbacks.RegisterBeforeTool(func(ctx context.Context, toolName string, d *tool.Declaration, jsonArgs *[]byte) (any, error) {
+  if jsonArgs != nil && toolName == "calculator" {
+    originalArgs := string(*jsonArgs)
+    modifiedArgs := fmt.Sprintf(`{"original":%s,"timestamp":"%d"}`, originalArgs, time.Now().Unix())
+    *jsonArgs = []byte(modifiedArgs)
+  }
+  return nil, nil
+})
+```
+
+以上示例与 [`examples/callbacks`](../../../examples/callbacks/) 可运行示例保持一致。
+
+---
+
+## 运行示例
+
+```bash
+cd examples/callbacks
+export OPENAI_API_KEY="your-api-key"
+
+# 基本运行
+go run .
+
+# 指定模型
+go run . -model gpt-4o-mini
+
+# 关闭流式
+go run . -streaming=false
+```
+
+可在日志中观察 Before/After 回调、参数修改与工具返回信息。


### PR DESCRIPTION
- Introduced a new Callbacks documentation page detailing the callback system, including ModelCallbacks, ToolCallbacks, and AgentCallbacks.
- Updated mkdocs.yml to include the new Callbacks section in both English and Chinese navigation.
- Improved formatting and structure of existing navigation entries for better readability.