### PR TITLE
{flow,agent_tool,processor/functioncall}: improve the notification wating time during multiple rounds of flow sessions to prevent message non persistence in multi-agent mode

### DIFF
--- a/agent/invocation.go
+++ b/agent/invocation.go
@@ -271,8 +271,8 @@ func EmitEvent(ctx context.Context, inv *Invocation, ch chan<- *event.Event,
 }
 
 // GetAppendEventNoticeKey get append event notice key.
-func GetAppendEventNoticeKey(eventId string) string {
-	return AppendEventNoticeKeyPrefix + eventId
+func GetAppendEventNoticeKey(eventID string) string {
+	return AppendEventNoticeKeyPrefix + eventID
 }
 
 // AddNoticeChannelAndWait add notice channel and wait it complete

--- a/agent/invocation.go
+++ b/agent/invocation.go
@@ -270,6 +270,11 @@ func EmitEvent(ctx context.Context, inv *Invocation, ch chan<- *event.Event,
 	return event.EmitEvent(ctx, ch, e)
 }
 
+// GetAppendEventNoticeKey get append event notice key.
+func GetAppendEventNoticeKey(eventId string) string {
+	return AppendEventNoticeKeyPrefix + eventId
+}
+
 // AddNoticeChannelAndWait add notice channel and wait it complete
 func (inv *Invocation) AddNoticeChannelAndWait(ctx context.Context, key string, timeout time.Duration) error {
 	ch := inv.AddNoticeChannel(ctx, key)

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -140,7 +140,7 @@ func (f *Flow) emitStartEventAndWait(ctx context.Context, invocation *agent.Invo
 	agent.EmitEvent(ctx, invocation, eventChan, startEvent)
 
 	// Wait for completion notice.
-	completionID := agent.AppendEventNoticeKeyPrefix + startEvent.ID
+	completionID := agent.GetAppendEventNoticeKey(startEvent.ID)
 	err := invocation.AddNoticeChannelAndWait(ctx, completionID, eventCompletionTimeout)
 	if errors.Is(err, context.Canceled) {
 		return err

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -130,7 +130,12 @@ func (f *Flow) Run(ctx context.Context, invocation *agent.Invocation) (<-chan *e
 
 func (f *Flow) emitStartEventAndWait(ctx context.Context, invocation *agent.Invocation,
 	eventChan chan<- *event.Event) error {
-	startEvent := event.New(invocation.InvocationID, invocation.AgentName)
+	invocationID, agentName := "", ""
+	if invocation != nil {
+		invocationID = invocation.InvocationID
+		agentName = invocation.AgentName
+	}
+	startEvent := event.New(invocationID, agentName)
 	startEvent.RequiresCompletion = true
 	agent.EmitEvent(ctx, invocation, eventChan, startEvent)
 

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -140,6 +140,7 @@ func (f *Flow) emitStartEventAndWait(ctx context.Context, invocation *agent.Invo
 	agent.EmitEvent(ctx, invocation, eventChan, startEvent)
 
 	// Wait for completion notice.
+	// Ensure that the events of the previous agent or the previous step have been synchronized to the session.
 	completionID := agent.GetAppendEventNoticeKey(startEvent.ID)
 	err := invocation.AddNoticeChannelAndWait(ctx, completionID, eventCompletionTimeout)
 	if errors.Is(err, context.Canceled) {

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -13,6 +13,7 @@ package llmflow
 import (
 	"context"
 	"errors"
+	"time"
 
 	oteltrace "go.opentelemetry.io/otel/trace"
 
@@ -29,6 +30,9 @@ import (
 
 const (
 	defaultChannelBufferSize = 256
+
+	// Timeout for event completion signaling.
+	eventCompletionTimeout = 5 * time.Second
 )
 
 // Options contains configuration options for creating a Flow.
@@ -74,8 +78,8 @@ func (f *Flow) Run(ctx context.Context, invocation *agent.Invocation) (<-chan *e
 		defer close(eventChan)
 
 		for {
-			// Check if context is cancelled.
-			if err := agent.CheckContextCancelled(ctx); err != nil {
+			// emit start event and wait for completion notice.
+			if err := f.emitStartEventAndWait(ctx, invocation, eventChan); err != nil {
 				return
 			}
 
@@ -122,6 +126,21 @@ func (f *Flow) Run(ctx context.Context, invocation *agent.Invocation) (<-chan *e
 	}()
 
 	return eventChan, nil
+}
+
+func (f *Flow) emitStartEventAndWait(ctx context.Context, invocation *agent.Invocation,
+	eventChan chan<- *event.Event) error {
+	startEvent := event.New(invocation.InvocationID, invocation.AgentName)
+	startEvent.RequiresCompletion = true
+	agent.EmitEvent(ctx, invocation, eventChan, startEvent)
+
+	// Wait for completion notice.
+	completionID := agent.AppendEventNoticeKeyPrefix + startEvent.ID
+	err := invocation.AddNoticeChannelAndWait(ctx, completionID, eventCompletionTimeout)
+	if errors.Is(err, context.Canceled) {
+		return err
+	}
+	return nil
 }
 
 // runOneStep executes one step of the flow (one LLM call cycle).

--- a/internal/flow/llmflow/llmflow_endinvocation_test.go
+++ b/internal/flow/llmflow/llmflow_endinvocation_test.go
@@ -42,7 +42,7 @@ func TestPreprocess_StopsAfterEndInvocation(t *testing.T) {
 	}
 
 	f := New(reqProcs, nil, Options{})
-	inv := &agent.Invocation{InvocationID: "inv-pre", AgentName: "agent-pre"}
+	inv := agent.NewInvocation()
 
 	// Act
 	ch, err := f.Run(context.Background(), inv)
@@ -55,8 +55,8 @@ func TestPreprocess_StopsAfterEndInvocation(t *testing.T) {
 
 	// Assert
 	require.True(t, called, "subsequent processors should run after EndInvocation")
-	require.Len(t, events, 2)
-	require.Equal(t, "preprocess.end", events[0].Object)
+	require.Len(t, events, 3)
+	require.Equal(t, "preprocess.end", events[1].Object)
 }
 
 // twoChunkModel returns two streaming chunks to ensure we break after EndInvocation.

--- a/internal/flow/processor/functioncall.go
+++ b/internal/flow/processor/functioncall.go
@@ -391,7 +391,6 @@ func (p *FunctionCallResponseProcessor) buildMergedParallelEvent(
 	} else {
 		mergedEvent = mergeParallelToolCallResponseEvents(toolCallEvents)
 	}
-	mergedEvent.RequiresCompletion = true
 	if len(toolCallEvents) > 1 {
 		_, span := trace.Tracer.Start(
 			ctx, fmt.Sprintf("%s (merged)", itelemetry.SpanNamePrefixExecuteTool),

--- a/internal/flow/processor/functioncall.go
+++ b/internal/flow/processor/functioncall.go
@@ -12,7 +12,6 @@ package processor
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -39,9 +38,6 @@ const (
 	ErrorStreamableToolExecution = "Error: streamable tool execution failed"
 	// ErrorMarshalResult is the error message for failed to marshal result.
 	ErrorMarshalResult = "Error: failed to marshal result"
-
-	// Timeout for event completion signaling.
-	eventCompletionTimeout = 5 * time.Second
 )
 
 // summarizationSkipper is implemented by tools that can indicate whether
@@ -112,17 +108,6 @@ func (p *FunctionCallResponseProcessor) ProcessResponse(
 	// after this tool response so the flow does not perform an extra LLM call.
 	if functioncallResponseEvent.Actions != nil && functioncallResponseEvent.Actions.SkipSummarization {
 		invocation.EndInvocation = true
-		return
-	}
-
-	// Wait for completion if required.
-	if err := p.waitForCompletion(ctx, invocation, functioncallResponseEvent); err != nil {
-		agent.EmitEvent(ctx, invocation, ch, event.NewErrorEvent(
-			invocation.InvocationID,
-			invocation.AgentName,
-			model.ErrorTypeFlowError,
-			err.Error(),
-		))
 		return
 	}
 }
@@ -492,20 +477,6 @@ func (p *FunctionCallResponseProcessor) executeToolCall(
 			ToolID:  toolCall.ID,
 		},
 	}, modifiedArgs, nil
-}
-
-// waitForCompletion waits for event completion if required.
-func (p *FunctionCallResponseProcessor) waitForCompletion(ctx context.Context, invocation *agent.Invocation, lastEvent *event.Event) error {
-	if !lastEvent.RequiresCompletion {
-		return nil
-	}
-
-	completionID := agent.AppendEventNoticeKeyPrefix + lastEvent.ID
-	err := invocation.AddNoticeChannelAndWait(ctx, completionID, eventCompletionTimeout)
-	if errors.Is(err, context.Canceled) {
-		return err
-	}
-	return nil
 }
 
 // createErrorChoice creates an error choice for tool execution failures.

--- a/internal/flow/processor/functioncall_test.go
+++ b/internal/flow/processor/functioncall_test.go
@@ -951,7 +951,6 @@ func TestHandleFunctionCalls_SkipSummarizationSequential_SetsEndInvocation(t *te
 	require.NotNil(t, evt.Actions)
 	require.True(t, evt.Actions.SkipSummarization)
 	require.True(t, inv.EndInvocation, "invocation should be marked to end when skipping summarization")
-	require.True(t, evt.RequiresCompletion)
 }
 
 // Verify SkipSummarization propagation in the no-child-events path (e.g., long-running returns nil).

--- a/internal/flow/processor/functioncall_test.go
+++ b/internal/flow/processor/functioncall_test.go
@@ -1223,30 +1223,6 @@ func TestExecuteStreamableTool_ForwardsInnerEvents(t *testing.T) {
 	}
 }
 
-func TestWaitForCompletion_SignalReceived(t *testing.T) {
-	f := NewFunctionCallResponseProcessor(false, nil)
-	ctx := context.Background()
-	ch := make(chan string, 1)
-	inv := agent.NewInvocation()
-	evt := event.New("inv-comp", "author")
-	evt.RequiresCompletion = true
-	// send completion
-	ch <- "done-1"
-	err := f.waitForCompletion(ctx, inv, evt)
-	require.NoError(t, err)
-}
-
-func TestWaitForCompletion_ContextCancelled(t *testing.T) {
-	f := NewFunctionCallResponseProcessor(false, nil)
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-	inv := agent.NewInvocation()
-	evt := event.New("inv-comp2", "author")
-	evt.RequiresCompletion = true
-	err := f.waitForCompletion(ctx, inv, evt)
-	require.Error(t, err)
-}
-
 // Mock tool for transfer testing
 type mockTransferTool struct {
 	name        string

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -224,7 +224,7 @@ func (r *runner) Run(
 			}
 
 			if agentEvent.RequiresCompletion {
-				completionID := agent.AppendEventNoticeKeyPrefix + agentEvent.ID
+				completionID := agent.GetAppendEventNoticeKey(agentEvent.ID)
 				invocation.NotifyCompletion(ctx, completionID)
 			}
 

--- a/tool/agent/agent_tool.go
+++ b/tool/agent/agent_tool.go
@@ -15,7 +15,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/google/uuid"
 	"trpc.group/trpc-go/trpc-agent-go/agent"
@@ -185,28 +184,9 @@ func (at *Tool) StreamableCall(ctx context.Context, jsonArgs []byte) (*tool.Stre
 				)
 				agent.InjectIntoEvent(subInv, evt) // This will set the uniqueFilterKey.
 
-				// Mark event as requiring completion notification for synchronization.
-				evt.RequiresCompletion = true
-
 				// Send the tool input event as the first event in the stream.
-
 				if stream.Writer.Send(tool.StreamChunk{Content: evt}, nil) {
 					return
-				}
-
-				// Wait for the event to be processed and stored in session before starting sub-agent.
-				// This prevents race condition where sub-agent's subsequent LLM calls happen before tool input is stored.
-				completionID := agent.AppendEventNoticeKeyPrefix + evt.ID
-
-				// Use a reasonable timeout to avoid blocking.
-				waitTimeout := agent.WaitNoticeWithoutTimeout
-				if subInv.Session != nil && len(subInv.Session.Events) == 0 {
-					waitTimeout = 5 * time.Second
-				}
-
-				if err := subInv.AddNoticeChannelAndWait(ctx, completionID, waitTimeout); err != nil {
-					log.Warnf("AgentTool: Failed to wait for tool input event completion: %v", err)
-					// Continue anyway - this is not a fatal error.
 				}
 			}
 


### PR DESCRIPTION
1. Migration of completion waiting notification from processor to flow.
2. In multi-agent mode, it is necessary to ensure that the events of the previous agent have been appended to the session when executing the next agent