### PR TITLE
internal/flow: sanitize markdown language fences for output_schema

### DIFF
--- a/internal/flow/processor/output.go
+++ b/internal/flow/processor/output.go
@@ -125,11 +125,12 @@ func (p *OutputResponseProcessor) handleOutputKey(
 	result := content
 	// If output_schema is present, ensure content is JSON.
 	if p.outputSchema != nil {
-		if strings.TrimSpace(content) == "" {
+		cleaned := sanitizeJSONContent(content)
+		if strings.TrimSpace(cleaned) == "" {
 			return
 		}
 		var parsedJSON any
-		if err := json.Unmarshal([]byte(content), &parsedJSON); err != nil {
+		if err := json.Unmarshal([]byte(cleaned), &parsedJSON); err != nil {
 			log.Warnf("Failed to parse output as JSON for output_schema validation: %v", err)
 			return
 		}
@@ -200,4 +201,35 @@ func extractFirstJSONObject(s string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+// sanitizeJSONContent removes Markdown code fences (e.g., ```json) and surrounding whitespace.
+// Some LLMs (Large Language Models) may emit code fences like ```json or language hints
+// (e.g., ```json, ```JSON) even when asked for raw JSON. Feeding the content directly to json.Unmarshal
+// would fail because of these extra characters. This helper function strips the fences and returns
+// a clean JSON payload.
+func sanitizeJSONContent(s string) string {
+	s = strings.TrimSpace(s)
+	if !strings.HasPrefix(s, "```") {
+		return s
+	}
+	cleaned := strings.TrimPrefix(s, "```")
+	idx1 := strings.Index(cleaned, "[")
+	if idx1 < 0 {
+		idx1 = len(cleaned)
+	}
+	idx2 := strings.Index(cleaned, "{")
+	if idx2 < 0 {
+		idx2 = len(cleaned)
+	}
+	minIdx := min(idx1, idx2)
+	if minIdx == len(cleaned) {
+		// Unexpected case, no JSON object/array found, return the original content as a fallback.
+		return s
+	}
+	// Remove start fences.
+	cleaned = cleaned[minIdx:]
+	// Remove end fences.
+	cleaned = strings.TrimSuffix(cleaned, "```")
+	return strings.TrimSpace(cleaned)
 }

--- a/internal/flow/processor/output_test.go
+++ b/internal/flow/processor/output_test.go
@@ -12,7 +12,9 @@ package processor
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/model"
@@ -208,4 +210,99 @@ func TestOutputResponseProcessor_ProcessResponse_PartialResponse(t *testing.T) {
 	if len(events) != 0 {
 		t.Errorf("Expected 0 events for partial response, got %d", len(events))
 	}
+}
+
+func TestSanitizeJSONContentVariants(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "standard",
+			input: "```json\n{\"city\":\"Beijing\"}\n```",
+			want:  "{\"city\":\"Beijing\"}",
+		},
+		{
+			name:  "no_language",
+			input: "```\n{\"city\":\"Beijing\"}\n```",
+			want:  "{\"city\":\"Beijing\"}",
+		},
+		{
+			name:  "same_line_language",
+			input: "```json {\"city\":\"Beijing\"}```",
+			want:  "{\"city\":\"Beijing\"}",
+		},
+		{
+			name:  "multiple_prefix",
+			input: "```json\njson\n{\"city\":\"Beijing\"}\n```",
+			want:  "{\"city\":\"Beijing\"}",
+		},
+		{
+			name:  "windows_newline",
+			input: "```json\r\n{\"city\":\"Beijing\"}\r\n```",
+			want:  "{\"city\":\"Beijing\"}",
+		},
+		{
+			name:  "embedded_backticks",
+			input: "```json\n{\"city\":\"Beijing\",\"note\":\"contains ``` fence inside\"}\n```",
+			want:  "{\"city\":\"Beijing\",\"note\":\"contains ``` fence inside\"}",
+		},
+		{
+			name:  "multiline_string",
+			input: "```json\n{\"city\":\"Beijing\\n123\"}\n```",
+			want:  "{\"city\":\"Beijing\\n123\"}",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sanitizeJSONContent(tc.input); got != tc.want {
+				t.Fatalf("expected %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestOutputResponseProcessor_HandleOutputKey_WithFencedContent(t *testing.T) {
+	ctx := context.Background()
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"city": map[string]any{
+				"type": "string",
+			},
+		},
+	}
+	processor := NewOutputResponseProcessor("weather", schema)
+	invocation := agent.NewInvocation()
+	content := "```json\n{\"city\":\"Shanghai\"}\n```"
+
+	eventCh := make(chan *event.Event, 1)
+	done := make(chan struct{})
+	go func() {
+		processor.handleOutputKey(ctx, invocation, content, eventCh)
+		close(done)
+	}()
+
+	var evt *event.Event
+	select {
+	case evt = <-eventCh:
+		assert.NotNil(t, evt)
+	case <-time.After(time.Second):
+		assert.Fail(t, "timed out waiting for event")
+	}
+
+	assert.True(t, evt.RequiresCompletion)
+	invocation.NotifyCompletion(ctx, agent.AppendEventNoticeKeyPrefix+evt.ID)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		assert.Fail(t, "handleOutputKey did not finish")
+	}
+
+	value, ok := evt.StateDelta["weather"]
+	assert.True(t, ok)
+	assert.Equal(t, "```json\n{\"city\":\"Shanghai\"}\n```", string(value))
 }

--- a/internal/flow/processor/output_test.go
+++ b/internal/flow/processor/output_test.go
@@ -219,7 +219,12 @@ func TestSanitizeJSONContentVariants(t *testing.T) {
 		want  string
 	}{
 		{
-			name:  "standard",
+			name:  "normal",
+			input: "{\"city\":\"Beijing\"}",
+			want:  "{\"city\":\"Beijing\"}",
+		},
+		{
+			name:  "with_fences",
 			input: "```json\n{\"city\":\"Beijing\"}\n```",
 			want:  "{\"city\":\"Beijing\"}",
 		},


### PR DESCRIPTION
Expected repsonse: 
```json
{\"city\":\"Shanghai\"}
```
But some llms repsonse likes below, which failing to json.Unmarshal
``````json
```json{\"city\":\"Shanghai\"}```
``````
Sanitize markdown language fences for output_schema.