### PR TITLE
WIP tool: add recursive structure support in JSON schema

### DIFF
--- a/internal/tool/recursive_test.go
+++ b/internal/tool/recursive_test.go
@@ -1,0 +1,152 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package tool_test
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	itool "trpc.group/trpc-go/trpc-agent-go/internal/tool"
+)
+
+// TreeNode represents a recursive tree structure
+type TreeNode struct {
+	Name     string      `json:"name"`
+	Children []*TreeNode `json:"children,omitempty"`
+}
+
+// LinkedListNode represents a recursive linked list structure
+type LinkedListNode struct {
+	Value int             `json:"value"`
+	Next  *LinkedListNode `json:"next,omitempty"`
+}
+
+// MutuallyRecursiveA and MutuallyRecursiveB represent mutually recursive structures
+type MutuallyRecursiveA struct {
+	Name string              `json:"name"`
+	B    *MutuallyRecursiveB `json:"b,omitempty"`
+}
+
+type MutuallyRecursiveB struct {
+	Value int                 `json:"value"`
+	A     *MutuallyRecursiveA `json:"a,omitempty"`
+}
+
+func TestGenerateJSONSchema_RecursiveStructure(t *testing.T) {
+	t.Run("tree node recursive structure", func(t *testing.T) {
+		// This should not panic and should generate a schema with $ref and $defs
+		result := itool.GenerateJSONSchema(reflect.TypeOf(TreeNode{}))
+		resultJson, _ := json.MarshalIndent(result, "", "  ")
+		t.Logf("%s", resultJson)
+
+		if result.Type != "object" {
+			t.Errorf("expected object type, got %s", result.Type)
+		}
+
+		// Check that we have properties
+		if result.Properties == nil {
+			t.Fatal("expected properties to be set")
+		}
+
+		// Check name property
+		if result.Properties["name"] == nil || result.Properties["name"].Type != "string" {
+			t.Errorf("expected name property of type string")
+		}
+
+		// Check children property
+		if result.Properties["children"] == nil || result.Properties["children"].Type != "array" {
+			t.Errorf("expected children property of type array")
+		}
+
+		// The children items should use $ref to avoid infinite recursion
+		if result.Properties["children"].Items == nil {
+			t.Fatal("expected children items to be defined")
+		}
+
+		// Check if we have $defs defined for recursive types
+		if result.Defs == nil {
+			t.Errorf("expected $defs to be defined for recursive structure")
+		}
+
+		// Check that children items use $ref
+		if result.Properties["children"].Items.Ref != "#/$defs/treenode" {
+			t.Errorf("expected children items to reference #/$defs/treenode, got %s", result.Properties["children"].Items.Ref)
+		}
+
+		// Check the definition in $defs
+		treeDef := result.Defs["treenode"]
+		if treeDef == nil {
+			t.Fatal("expected treenode definition in $defs")
+		}
+
+		if treeDef.Type != "object" {
+			t.Errorf("expected treenode definition type to be object, got %s", treeDef.Type)
+		}
+
+		// Check that the definition also uses $ref for children
+		if treeDef.Properties["children"].Items == nil || treeDef.Properties["children"].Items.Ref != "#/$defs/treenode" {
+			t.Errorf("expected treenode definition children items to reference #/$defs/treenode")
+		}
+	})
+
+	t.Run("linked list recursive structure", func(t *testing.T) {
+		// This should not panic and should generate a schema with $ref and $defs
+		result := itool.GenerateJSONSchema(reflect.TypeOf(LinkedListNode{}))
+		resultJson, _ := json.MarshalIndent(result, "", "  ")
+		t.Logf("%s", resultJson)
+
+		if result.Type != "object" {
+			t.Errorf("expected object type, got %s", result.Type)
+		}
+
+		// Check that we have properties
+		if result.Properties == nil {
+			t.Fatal("expected properties to be set")
+		}
+
+		// Check value property
+		if result.Properties["value"] == nil || result.Properties["value"].Type != "integer" {
+			t.Errorf("expected value property of type integer")
+		}
+
+		// Check next property - should use $ref to avoid infinite recursion
+		if result.Properties["next"] == nil {
+			t.Fatal("expected next property to be defined")
+		}
+
+		// Check if we have $defs defined for recursive types
+		if result.Defs == nil {
+			t.Errorf("expected $defs to be defined for recursive structure")
+		}
+	})
+
+	t.Run("mutually recursive structures", func(t *testing.T) {
+		// This should not panic and should generate a schema with $ref and $defs
+		result := itool.GenerateJSONSchema(reflect.TypeOf(MutuallyRecursiveA{}))
+		resultJson, _ := json.MarshalIndent(result, "", "  ")
+		t.Logf("%s", resultJson)
+
+		if result.Type != "object" {
+			t.Errorf("expected object type, got %s", result.Type)
+		}
+
+		// Check that we have $defs for both types
+		if result.Defs == nil {
+			t.Fatal("expected $defs to be defined for mutually recursive structures")
+		}
+
+		// Should have definitions for both types
+		expectedDefs := 2 // MutuallyRecursiveA and MutuallyRecursiveB
+		if len(result.Defs) < expectedDefs {
+			t.Errorf("expected at least %d definitions in $defs, got %d", expectedDefs, len(result.Defs))
+		}
+	})
+}

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -23,13 +23,55 @@ import (
 
 // GenerateJSONSchema generates a basic JSON schema from a reflect.Type.
 func GenerateJSONSchema(t reflect.Type) *tool.Schema {
-	schema := &tool.Schema{Type: "object"}
+	// Use a context to track visited types and handle recursion
+	ctx := &schemaContext{
+		visited: make(map[reflect.Type]string),
+		defs:    make(map[string]*tool.Schema),
+	}
 
+	schema := generateJSONSchemaWithContext(t, ctx)
+
+	// Add $defs to the root schema if we have any definitions
+	if len(ctx.defs) > 0 {
+		schema.Defs = ctx.defs
+	}
+
+	return schema
+}
+
+// schemaContext tracks the state during schema generation to handle recursion
+type schemaContext struct {
+	visited map[reflect.Type]string // Maps types to their definition names
+	defs    map[string]*tool.Schema // Stores reusable schema definitions
+}
+
+// generateJSONSchemaWithContext generates a JSON schema with recursion handling
+func generateJSONSchemaWithContext(t reflect.Type, ctx *schemaContext) *tool.Schema {
+	return generateJSONSchemaWithContextInternal(t, ctx, true)
+}
+
+// generateJSONSchemaWithContextInternal generates a JSON schema with recursion handling
+func generateJSONSchemaWithContextInternal(t reflect.Type, ctx *schemaContext, isRoot bool) *tool.Schema {
 	// Handle different kinds of types.
 	switch t.Kind() {
 	case reflect.Struct:
+		// Check if we've already seen this struct type
+		if defName, exists := ctx.visited[t]; exists {
+			// Return a reference to the existing definition
+			return &tool.Schema{Ref: "#/$defs/" + defName}
+		}
+
+		// Generate a unique name for this type
+		defName := generateDefName(t)
+		ctx.visited[t] = defName
+
+		// Create the schema for this struct
+		schema := &tool.Schema{Type: "object"}
 		properties := map[string]*tool.Schema{}
 		required := make([]string, 0)
+
+		// Check if this struct has recursive fields
+		hasRecursion := hasRecursiveFields(t)
 
 		for i := 0; i < t.NumField(); i++ {
 			field := t.Field(i)
@@ -57,21 +99,29 @@ func GenerateJSONSchema(t reflect.Type) *tool.Schema {
 			}
 
 			// Generate schema for field type.
-			fieldSchema := GenerateFieldSchema(field.Type)
+			fieldSchema := generateFieldSchemaWithContextInternal(field.Type, ctx, false)
 
 			// Parse jsonschema tag to customize the schema
-			isRequiredByTag, err := parseJSONSchemaTag(field.Type, field.Tag, fieldSchema)
-			if err != nil {
-				log.Errorf("parseJSONSchemaTag error for field %s: %v", fieldName, err)
-				// Continue execution with the field schema as is
+			// Only apply jsonschema tags if the field schema is not a reference
+			if fieldSchema.Ref == "" {
+				isRequiredByTag, err := parseJSONSchemaTag(field.Type, field.Tag, fieldSchema)
+				if err != nil {
+					log.Errorf("parseJSONSchemaTag error for field %s: %v", fieldName, err)
+					// Continue execution with the field schema as is
+				}
+
+				// Check if field is required (not a pointer and no omitempty, or explicitly marked as required by jsonschema tag).
+				if (field.Type.Kind() != reflect.Ptr && !isOmitEmpty) || isRequiredByTag {
+					required = append(required, fieldName)
+				}
+			} else {
+				// For reference fields, check if they should be required based on type and omitempty
+				if field.Type.Kind() != reflect.Ptr && !isOmitEmpty {
+					required = append(required, fieldName)
+				}
 			}
 
 			properties[fieldName] = fieldSchema
-
-			// Check if field is required (not a pointer and no omitempty, or explicitly marked as required by jsonschema tag).
-			if (field.Type.Kind() != reflect.Ptr && !isOmitEmpty) || isRequiredByTag {
-				required = append(required, fieldName)
-			}
 		}
 
 		schema.Properties = properties
@@ -79,16 +129,106 @@ func GenerateJSONSchema(t reflect.Type) *tool.Schema {
 			schema.Required = required
 		}
 
+		// Store the definition if we have recursion or if it's not the root
+		if hasRecursion || !isRoot {
+			// Create a copy of the schema for the definition to avoid circular references
+			defSchema := &tool.Schema{
+				Type:       schema.Type,
+				Properties: make(map[string]*tool.Schema),
+				Required:   schema.Required,
+			}
+
+			// Copy properties but ensure we use references for recursive types
+			for propName, propSchema := range schema.Properties {
+				defSchema.Properties[propName] = propSchema
+			}
+
+			ctx.defs[defName] = defSchema
+		}
+
+		// For the root type with recursion, return the actual schema
+		// For nested recursive types, return a reference
+		if isRoot {
+			return schema
+		}
+
+		return &tool.Schema{Ref: "#/$defs/" + defName}
+
 	case reflect.Ptr:
 		// For function tool parameters, we typically use value types
 		// So we can just return the element type schema.
-		return GenerateFieldSchema(t.Elem())
+		return generateFieldSchemaWithContextInternal(t.Elem(), ctx, isRoot)
 
 	default:
-		return GenerateFieldSchema(t)
+		return generateFieldSchemaWithContextInternal(t, ctx, isRoot)
+	}
+}
+
+// hasRecursiveFields checks if a struct type has fields that reference itself
+func hasRecursiveFields(t reflect.Type) bool {
+	return checkRecursion(t, t, make(map[reflect.Type]bool))
+}
+
+// checkRecursion recursively checks if targetType appears in the fields of currentType
+func checkRecursion(targetType, currentType reflect.Type, visited map[reflect.Type]bool) bool {
+	if visited[currentType] {
+		return false
+	}
+	visited[currentType] = true
+
+	switch currentType.Kind() {
+	case reflect.Struct:
+		for i := 0; i < currentType.NumField(); i++ {
+			field := currentType.Field(i)
+			if !field.IsExported() {
+				continue
+			}
+
+			fieldType := field.Type
+			// Check through pointers, slices, and arrays
+			for fieldType.Kind() == reflect.Ptr || fieldType.Kind() == reflect.Slice || fieldType.Kind() == reflect.Array {
+				fieldType = fieldType.Elem()
+			}
+
+			if fieldType == targetType {
+				return true
+			}
+
+			if fieldType.Kind() == reflect.Struct && checkRecursion(targetType, fieldType, visited) {
+				return true
+			}
+		}
+	case reflect.Slice, reflect.Array:
+		elemType := currentType.Elem()
+		for elemType.Kind() == reflect.Ptr {
+			elemType = elemType.Elem()
+		}
+		if elemType == targetType {
+			return true
+		}
+		if elemType.Kind() == reflect.Struct && checkRecursion(targetType, elemType, visited) {
+			return true
+		}
+	case reflect.Ptr:
+		elemType := currentType.Elem()
+		if elemType == targetType {
+			return true
+		}
+		if elemType.Kind() == reflect.Struct && checkRecursion(targetType, elemType, visited) {
+			return true
+		}
 	}
 
-	return schema
+	return false
+}
+
+// generateDefName creates a unique definition name for a type
+func generateDefName(t reflect.Type) string {
+	// Use the type name if available, otherwise use a generic name
+	if t.Name() != "" {
+		return strings.ToLower(t.Name())
+	}
+	return "anonymousStruct"
 }
 
 // parseJSONSchemaTag parses jsonschema struct tag and applies the settings to the schema.
@@ -156,6 +296,21 @@ func parseJSONSchemaTag(fieldType reflect.Type, tag reflect.StructTag, schema *t
 
 // GenerateFieldSchema generates schema for a specific field type.
 func GenerateFieldSchema(t reflect.Type) *tool.Schema {
+	// Create a new context for backward compatibility
+	ctx := &schemaContext{
+		visited: make(map[reflect.Type]string),
+		defs:    make(map[string]*tool.Schema),
+	}
+	return generateFieldSchemaWithContext(t, ctx)
+}
+
+// generateFieldSchemaWithContext generates schema for a specific field type with recursion handling.
+func generateFieldSchemaWithContext(t reflect.Type, ctx *schemaContext) *tool.Schema {
+	return generateFieldSchemaWithContextInternal(t, ctx, false)
+}
+
+// generateFieldSchemaWithContextInternal generates schema for a specific field type with recursion handling.
+func generateFieldSchemaWithContextInternal(t reflect.Type, ctx *schemaContext, isRoot bool) *tool.Schema {
 	switch t.Kind() {
 	case reflect.String:
 		return &tool.Schema{Type: "string"}
@@ -170,18 +325,64 @@ func GenerateFieldSchema(t reflect.Type) *tool.Schema {
 	case reflect.Slice, reflect.Array:
 		return &tool.Schema{
 			Type:  "array",
-			Items: GenerateFieldSchema(t.Elem()),
+			Items: generateFieldSchemaWithContextInternal(t.Elem(), ctx, false),
 		}
 	case reflect.Map:
 		return &tool.Schema{
 			Type:                 "object",
-			AdditionalProperties: GenerateFieldSchema(t.Elem()),
+			AdditionalProperties: generateFieldSchemaWithContextInternal(t.Elem(), ctx, false),
 		}
 	case reflect.Ptr:
 		// For function tool parameters, we typically use value types
 		// So we can just return the element type schema
-		return GenerateFieldSchema(t.Elem())
+		return generateFieldSchemaWithContextInternal(t.Elem(), ctx, isRoot)
 	case reflect.Struct:
+		// Check if we've already seen this struct type
+		if defName, exists := ctx.visited[t]; exists {
+			// Return a reference to the existing definition
+			return &tool.Schema{Ref: "#/$defs/" + defName}
+		}
+
+		// Check if this struct has recursive fields
+		hasRecursion := hasRecursiveFields(t)
+
+		// If no recursion, generate inline schema for backward compatibility
+		if !hasRecursion {
+			nestedSchema := &tool.Schema{
+				Type:       "object",
+				Properties: make(map[string]*tool.Schema),
+			}
+
+			for i := 0; i < t.NumField(); i++ {
+				field := t.Field(i)
+				if !field.IsExported() {
+					continue
+				}
+
+				jsonTag := field.Tag.Get("json")
+				if jsonTag == "-" {
+					continue
+				}
+
+				fieldName := field.Name
+				if jsonTag != "" {
+					if commaIdx := strings.Index(jsonTag, ","); commaIdx != -1 {
+						fieldName = jsonTag[:commaIdx]
+					} else {
+						fieldName = jsonTag
+					}
+				}
+
+				nestedSchema.Properties[fieldName] = generateFieldSchemaWithContextInternal(field.Type, ctx, false)
+			}
+
+			return nestedSchema
+		}
+
+		// Generate a unique name for this type
+		defName := generateDefName(t)
+		ctx.visited[t] = defName
+
 		nestedSchema := &tool.Schema{
 			Type:       "object",
 			Properties: make(map[string]*tool.Schema),
@@ -207,10 +408,13 @@ func GenerateFieldSchema(t reflect.Type) *tool.Schema {
 				}
 			}
 
-			nestedSchema.Properties[fieldName] = GenerateFieldSchema(field.Type)
+			nestedSchema.Properties[fieldName] = generateFieldSchemaWithContextInternal(field.Type, ctx, false)
 		}
 
-		return nestedSchema
+		// Store the definition
+		ctx.defs[defName] = nestedSchema
+
+		return &tool.Schema{Ref: "#/$defs/" + defName}
 	default:
 		// Default to any type
 		return &tool.Schema{Type: "object"}

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -63,7 +63,7 @@ type Declaration struct {
 // and to validate that incoming data conforms to the expected structure.
 type Schema struct {
 	//  Type Specifies the data type (e.g., "object", "array", "string", "number")
-	Type        string   `json:"type"`
+	Type        string   `json:"type,omitempty"`
 	Description string   `json:"description,omitempty"`
 	Required    []string `json:"required,omitempty"`
 	// Properties of the arguments, each with its own schema
@@ -76,4 +76,8 @@ type Schema struct {
 	Default any `json:"default,omitempty"`
 	// Enum contains the list of allowed values for the parameter
 	Enum []any `json:"enum,omitempty"`
+	// Ref is used for JSON Schema references to avoid infinite recursion
+	Ref string `json:"$ref,omitempty"`
+	// Defs contains reusable schema definitions
+	Defs map[string]*Schema `json:"$defs,omitempty"`
 }


### PR DESCRIPTION
Implement $ref and $defs in schema generator to handle recursive and mutually recursive data structures.