### PR TITLE
docs: restructure navigation and enable Mermaid diagrams

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -23,10 +23,11 @@ nav:
       - Knowledge: knowledge.md
       - Planner: planner.md
       - Event: event.md
-  - Debug: debugserver.md
-  - AG-UI: agui.md
+  - Server:
+    - Debug: debugserver.md
+    - AG-UI: agui.md
+    - A2A: a2a.md
   - Observability: observability.md
-  - A2A: a2a.md
   - Ecosystem: ecosystem.md
 
 plugins:
@@ -61,10 +62,11 @@ plugins:
                 - Planner: planner.md
                 - Graph: graph.md
                 - Event: event.md
-            - 调试: debugserver.md
-            - AG-UI: agui.md
+            - 服务:
+              - 调试: debugserver.md
+              - AG-UI: agui.md
+              - A2A: a2a.md
             - 可观测: observability.md
-            - A2A: a2a.md
             - 生态: ecosystem.md
   - git-revision-date-localized:
       enable_creation_date: true
@@ -101,7 +103,10 @@ markdown_extensions:
       pygments_lang_class: true
   - pymdownx.inlinehilite
   - pymdownx.snippets
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
   - mdx_truly_sane_lists
 
 extra_css:

--- a/docs/mkdocs/en/callbacks.md
+++ b/docs/mkdocs/en/callbacks.md
@@ -255,7 +255,7 @@ toolCallbacks.RegisterBeforeTool(func(ctx context.Context, toolName string, d *t
 })
 ```
 
-Both examples mirror the runnable demo under [examples/callbacks](../../../examples/callbacks/).
+Both examples mirror the runnable demo under [examples/callbacks](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/callbacks).
 
 ---
 

--- a/docs/mkdocs/zh/callbacks.md
+++ b/docs/mkdocs/zh/callbacks.md
@@ -247,7 +247,7 @@ toolCallbacks.RegisterBeforeTool(func(ctx context.Context, toolName string, d *t
 })
 ```
 
-以上示例与 [`examples/callbacks`](../../../examples/callbacks/) 可运行示例保持一致。
+以上示例与 [`examples/callbacks`](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/callbacks) 可运行示例保持一致。
 
 ---
 


### PR DESCRIPTION
## 1. reorganize documentation navigation
<img width="600" height="200" alt="image" src="https://github.com/user-attachments/assets/a768bcd7-7468-4245-84a6-b394707da58d" />

## 2. enable Mermaid diagrams
<img width="880" height="236" alt="image" src="https://github.com/user-attachments/assets/1b43ec89-eae6-4ea3-81e3-24f931adc7f6" />


## 3. change relative example path to url