### PR TITLE
storage: make default client builders private and simplify registry lookups

### DIFF
--- a/storage/postgres/postgres.go
+++ b/storage/postgres/postgres.go
@@ -102,10 +102,8 @@ func RegisterPostgresInstance(name string, opts ...ClientBuilderOpt) {
 
 // GetPostgresInstance gets the postgres instance options by name.
 func GetPostgresInstance(name string) ([]ClientBuilderOpt, bool) {
-	if _, ok := postgresRegistry[name]; !ok {
-		return nil, false
-	}
-	return postgresRegistry[name], true
+	instance, ok := postgresRegistry[name]
+	return instance, ok
 }
 
 // Client defines the interface for PostgreSQL operations.

--- a/storage/redis/redis.go
+++ b/storage/redis/redis.go
@@ -25,7 +25,7 @@ var redisRegistry map[string][]ClientBuilderOpt
 
 type clientBuilder func(builderOpts ...ClientBuilderOpt) (redis.UniversalClient, error)
 
-var globalBuilder clientBuilder = DefaultClientBuilder
+var globalBuilder clientBuilder = defaultClientBuilder
 
 // SetClientBuilder sets the redis client builder.
 func SetClientBuilder(builder clientBuilder) {
@@ -37,8 +37,8 @@ func GetClientBuilder() clientBuilder {
 	return globalBuilder
 }
 
-// DefaultClientBuilder is the default redis client builder.
-func DefaultClientBuilder(builderOpts ...ClientBuilderOpt) (redis.UniversalClient, error) {
+// defaultClientBuilder is the default redis client builder.
+func defaultClientBuilder(builderOpts ...ClientBuilderOpt) (redis.UniversalClient, error) {
 	o := &ClientBuilderOpts{}
 	for _, opt := range builderOpts {
 		opt(o)
@@ -113,8 +113,6 @@ func RegisterRedisInstance(name string, opts ...ClientBuilderOpt) {
 
 // GetRedisInstance gets the redis instance options.
 func GetRedisInstance(name string) ([]ClientBuilderOpt, bool) {
-	if _, ok := redisRegistry[name]; !ok {
-		return nil, false
-	}
-	return redisRegistry[name], true
+	instance, ok := redisRegistry[name]
+	return instance, ok
 }

--- a/storage/redis/redis_test.go
+++ b/storage/redis/redis_test.go
@@ -45,7 +45,7 @@ func TestSetGetClientBuilder(t *testing.T) {
 // Test the default builder validates empty URL.
 func TestDefaultClientBuilder_EmptyURL(t *testing.T) {
 	const expected = "redis: url is empty"
-	_, err := DefaultClientBuilder()
+	_, err := defaultClientBuilder()
 	require.Error(t, err)
 	require.Equal(t, expected, err.Error())
 }
@@ -56,7 +56,7 @@ func TestDefaultClientBuilder_InvalidURL(t *testing.T) {
 		badURL = "127.0.0.1:6379"
 		prefix = "redis: parse url 127.0.0.1:6379:"
 	)
-	_, err := DefaultClientBuilder(WithClientBuilderURL(badURL))
+	_, err := defaultClientBuilder(WithClientBuilderURL(badURL))
 	require.Error(t, err)
 	require.True(t, strings.HasPrefix(err.Error(), prefix))
 }
@@ -65,7 +65,7 @@ func TestDefaultClientBuilder_InvalidURL(t *testing.T) {
 // non-nil client without connecting.
 func TestDefaultClientBuilder_ParseURLSuccess(t *testing.T) {
 	const urlStr = "redis://user:pass@127.0.0.1:6379/0"
-	client, err := DefaultClientBuilder(
+	client, err := defaultClientBuilder(
 		WithClientBuilderURL(urlStr),
 	)
 	require.NoError(t, err)
@@ -90,7 +90,7 @@ func TestRegisterAndGetRedisInstance(t *testing.T) {
 	require.NotEmpty(t, opts, "expected at least one option")
 
 	// Build a client using the stored options to ensure they are usable.
-	client, err := DefaultClientBuilder(opts...)
+	client, err := defaultClientBuilder(opts...)
 	require.NoError(t, err, "unexpected error building client with stored opts")
 	require.NotNil(t, client, "expected non-nil client from stored options")
 }

--- a/storage/tcvector/tcvector.go
+++ b/storage/tcvector/tcvector.go
@@ -36,7 +36,7 @@ type ClientInterface interface {
 type clientBuilder func(builderOpts ...ClientBuilderOpt) (ClientInterface, error)
 
 // clientBuilder is the function to build the global tcvectordb client.
-var globalBuilder clientBuilder = DefaultClientBuilder
+var globalBuilder clientBuilder = defaultClientBuilder
 
 // SetClientBuilder sets the client builder for tcvectordb.
 func SetClientBuilder(builder clientBuilder) {
@@ -48,8 +48,8 @@ func GetClientBuilder() clientBuilder {
 	return globalBuilder
 }
 
-// DefaultClientBuilder is the default client builder for tcvectordb.
-func DefaultClientBuilder(builderOpts ...ClientBuilderOpt) (ClientInterface, error) {
+// defaultClientBuilder is the default client builder for tcvectordb.
+func defaultClientBuilder(builderOpts ...ClientBuilderOpt) (ClientInterface, error) {
 	opts := &ClientBuilderOpts{}
 	for _, opt := range builderOpts {
 		opt(opts)
@@ -111,8 +111,6 @@ func RegisterTcVectorInstance(name string, opts ...ClientBuilderOpt) {
 
 // GetTcVectorInstance gets the tcvectordb instance options.
 func GetTcVectorInstance(name string) ([]ClientBuilderOpt, bool) {
-	if _, ok := tcvectorRegistry[name]; !ok {
-		return nil, false
-	}
-	return tcvectorRegistry[name], true
+	instance, ok := tcvectorRegistry[name]
+	return instance, ok
 }

--- a/storage/tcvector/tcvector_test.go
+++ b/storage/tcvector/tcvector_test.go
@@ -51,15 +51,15 @@ func TestSetGetClientBuilder(t *testing.T) {
 }
 
 func TestDefaultClientBuilder_ValidatesRequired(t *testing.T) {
-	_, err := DefaultClientBuilder()
+	_, err := defaultClientBuilder()
 	require.Error(t, err)
 	require.Equal(t, "HTTPURL is required", err.Error())
 
-	_, err = DefaultClientBuilder(WithClientBuilderHTTPURL("http://localhost"))
+	_, err = defaultClientBuilder(WithClientBuilderHTTPURL("http://localhost"))
 	require.Error(t, err)
 	require.Equal(t, "UserName is required", err.Error())
 
-	_, err = DefaultClientBuilder(
+	_, err = defaultClientBuilder(
 		WithClientBuilderHTTPURL("http://localhost"),
 		WithClientBuilderUserName("user"),
 	)
@@ -68,7 +68,7 @@ func TestDefaultClientBuilder_ValidatesRequired(t *testing.T) {
 }
 
 func TestDefaultClientBuilder_Success(t *testing.T) {
-	cli, err := DefaultClientBuilder(
+	cli, err := defaultClientBuilder(
 		WithClientBuilderHTTPURL("http://localhost"),
 		WithClientBuilderUserName("user"),
 		WithClientBuilderKey("key"),
@@ -93,7 +93,7 @@ func TestRegisterAndGetTcVectorInstance(t *testing.T) {
 	require.True(t, ok, "expected instance to exist")
 	require.GreaterOrEqual(t, len(opts), 3, "expected 3 options")
 
-	cli, err := DefaultClientBuilder(opts...)
+	cli, err := defaultClientBuilder(opts...)
 	require.NoError(t, err)
 	require.NotNil(t, cli)
 }
@@ -105,7 +105,7 @@ func TestDefaultClientBuilder_InvalidURL(t *testing.T) {
 		user   = "user"
 		key    = "key"
 	)
-	_, err := DefaultClientBuilder(
+	_, err := defaultClientBuilder(
 		WithClientBuilderHTTPURL(badURL),
 		WithClientBuilderUserName(user),
 		WithClientBuilderKey(key),


### PR DESCRIPTION
- make default client builders private
- simplify registry lookups