### PR TITLE
model: add PromptTokensDetails to  observe Prompt/Context caching

### DIFF
--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -1339,6 +1339,9 @@ func (m *Model) createFinalResponse(
 			PromptTokens:     int(acc.Usage.PromptTokens),
 			CompletionTokens: int(acc.Usage.CompletionTokens),
 			TotalTokens:      int(acc.Usage.TotalTokens),
+			PromptTokensDetails: model.PromptTokensDetails{
+				CachedTokens: int(acc.Usage.PromptTokensDetails.CachedTokens),
+			},
 		},
 		Timestamp: time.Now(),
 		Done:      !hasToolCall,
@@ -1458,6 +1461,9 @@ func (m *Model) handleNonStreamingResponse(
 			PromptTokens:     int(chatCompletion.Usage.PromptTokens),
 			CompletionTokens: int(chatCompletion.Usage.CompletionTokens),
 			TotalTokens:      int(chatCompletion.Usage.TotalTokens),
+			PromptTokensDetails: model.PromptTokensDetails{
+				CachedTokens: int(chatCompletion.Usage.PromptTokensDetails.CachedTokens),
+			},
 		}
 	}
 

--- a/model/response.go
+++ b/model/response.go
@@ -78,6 +78,15 @@ type Usage struct {
 
 	// TotalTokens is the total number of tokens in the response.
 	TotalTokens int `json:"total_tokens"`
+
+	// PromptTokensDetails is the details of the prompt tokens.
+	PromptTokensDetails PromptTokensDetails `json:"prompt_tokens_details"`
+}
+
+// PromptTokensDetails is the details of the prompt tokens.
+type PromptTokensDetails struct {
+	// CachedTokens is the number of cached tokens in the prompt.
+	CachedTokens int `json:"cached_tokens"`
 }
 
 // Response is the response from the model.


### PR DESCRIPTION
- [Claude Cookbook: Prompt caching through the Claude API](https://github.com/anthropics/claude-cookbooks/blob/main/misc/prompt_caching.ipynb)
- [OpenAI Prompt Caching in the API](https://openai.com/index/api-prompt-caching/)
- [OpenAI Prompt caching](https://platform.openai.com/docs/guides/prompt-caching)
- [DeepSeek Context Caching](https://api-docs.deepseek.com/guides/kv_cache)
- [DeepSeek API introduces Context Caching on Disk, cutting prices by an order of magnitude](https://api-docs.deepseek.com/news/news0802)