### PR TITLE
event: add JSON marshal/unmarshal to avoid field shadowing

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -285,16 +285,15 @@ func EmitEventWithTimeout(ctx context.Context, ch chan<- *Event,
 // MarshalJSON implements json.Marshaler and produces a format that
 // preserves legacy flattened fields while also embedding minimal
 // response metadata (ID/timestamp) under the dedicated "response" key.
-func (e *Event) MarshalJSON() ([]byte, error) {
+func (e Event) MarshalJSON() ([]byte, error) {
 	payload := jsonEvent{
-		eventNoMethods: (*eventNoMethods)(e),
+		eventNoMethods: (*eventNoMethods)(&e),
 	}
 	if e.Response != nil {
-		meta := responseMeta{
+		payload.Response = &responseMeta{
 			ID:        e.Response.ID,
 			Timestamp: e.Response.Timestamp,
 		}
-		payload.Response = &meta
 	}
 	return json.Marshal(payload)
 }
@@ -303,14 +302,17 @@ func (e *Event) MarshalJSON() ([]byte, error) {
 // payloads and the new nested-response representation, preferring the nested
 // response when present.
 func (e *Event) UnmarshalJSON(data []byte) error {
+	// First parse the flat structure.
 	var flat eventNoMethods
 	if err := json.Unmarshal(data, &flat); err != nil {
 		return err
 	}
 	*e = Event(flat)
+	// Then try to read nested metadata.
 	var nested struct {
 		Response *responseMeta `json:"response,omitempty"`
 	}
+	// Tolerate nested part failure, it does not affect the overall failure, preserve the flat fields.
 	if err := json.Unmarshal(data, &nested); err != nil {
 		log.Warnf("unmarshal response: %v", err)
 		return nil
@@ -325,18 +327,18 @@ func (e *Event) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// eventNoMethods is an alias for Event without methods.
-// It is used to avoid recursive calls to MarshalJSON and UnmarshalJSON.
+// eventNoMethods is the alias of Event for avoiding recursive calls of custom MarshalJSON/UnmarshalJSON.
 type eventNoMethods Event
 
-// jsonEvent is the JSON representation of the event.
-type jsonEvent struct {
-	*eventNoMethods
-	Response *responseMeta `json:"response,omitempty"`
-}
-
-// responseMeta stores only metadata fields that may conflict with Event-level fields.
+// responseMeta is the minimal response metadata for JSON nested.
 type responseMeta struct {
 	ID        string    `json:"id,omitempty"`
 	Timestamp time.Time `json:"timestamp,omitempty"`
+}
+
+// jsonEvent is the final JSON structure to be output/read,
+// including flat event fields and nested response metadata.
+type jsonEvent struct {
+	*eventNoMethods
+	Response *responseMeta `json:"response,omitempty"`
 }


### PR DESCRIPTION
Implement custom JSON encoding/decoding for Event to define a format that keeps legacy flat fields while adding a nested “response” object, preventing anonymous-embedding collisions (e.g., Event.ID vs Response.ID).