### PR TITLE
tool: print warning log when name or description is empty

### DIFF
--- a/tool/function/function_tool.go
+++ b/tool/function/function_tool.go
@@ -17,6 +17,7 @@ import (
 	"reflect"
 
 	itool "trpc.group/trpc-go/trpc-agent-go/internal/tool"
+	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
 
@@ -91,6 +92,12 @@ func NewFunctionTool[I, O any](fn func(context.Context, I) (O, error), opts ...O
 	// Apply provided options
 	for _, opt := range opts {
 		opt(options)
+	}
+	if options.name == "" {
+		log.Warnf("FunctionTool: name is empty")
+	}
+	if options.description == "" {
+		log.Warnf("FunctionTool: description is empty")
 	}
 
 	var (


### PR DESCRIPTION
When creating a tool using NewFunctionTool, you generally need to set a name and description. If they are empty, LLM may return a bad request. However, there is currently no mandatory requirement to set a name and description, so a warning-level log has been added.