### PR TITLE
examples: fix parallel execution issue in graph_debugserver

### DIFF
--- a/examples/graph_debugserver/main.go
+++ b/examples/graph_debugserver/main.go
@@ -162,9 +162,9 @@ Example: For "3*4", call calculator with operation="multiply", a=3, b=4`,
 
 	// Add workflow edges - let tools return to analyze for result processing
 	stateGraph.AddEdge("parse_input", "analyze")
+	// AddToolsConditionalEdges handles routing: tool_calls → tools, otherwise → format_result
 	stateGraph.AddToolsConditionalEdges("analyze", "tools", "format_result")
-	stateGraph.AddEdge("tools", "analyze")         // Tools return to analyze to process results
-	stateGraph.AddEdge("analyze", "format_result") // Direct path when no tools needed or after tool processing
+	stateGraph.AddEdge("tools", "analyze") // Tools return to analyze to process results
 
 	// Build and compile the graph
 	workflowGraph, err := stateGraph.Compile()


### PR DESCRIPTION
Remove redundant AddEdge that caused tools and format_result to execute in parallel when analyze returns tool_call. AddToolsConditionalEdges already handles all routing cases.