### PR TITLE
doc: fix summary document

### DIFF
--- a/docs/mkdocs/en/session.md
+++ b/docs/mkdocs/en/session.md
@@ -79,6 +79,8 @@ func main() {
         llmagent.WithModel(llm),
         llmagent.WithSystemPrompt("You are a helpful assistant"),
         llmagent.WithAddSessionSummary(true), // Optional: enable summary injection to context
+        // Note: WithAddSessionSummary(true) ignores WithMaxHistoryRuns configuration
+        // Summary includes all history, incremental events fully retained
     )
 
     // 5. Create Runner and inject Session Service
@@ -236,15 +238,20 @@ After enabling summary, the framework prepends the summary as a system message t
 ┌─────────────────────────────────────────┐
 │ System Prompt                           │
 ├─────────────────────────────────────────┤
-│ Session Summary (system message)        │ ← Compressed history
+│ Session Summary (system message)        │ ← Compressed version of historical conversations
+│ - Updated at: 2024-01-10 14:30          │   (events before updated_at)
+│ - Includes: Event1 ~ Event20            │
 ├─────────────────────────────────────────┤
-│ Event 1 (after summary)                 │ ┐
-│ Event 2                                 │ │
-│ Event 3                                 │ │ New events
-│ ...                                     │ │ (fully retained)
+│ Event 21 (user message)                 │ ┐
+│ Event 22 (assistant response)           │ │
+│ Event 23 (user message)                 │ │ All new conversations after summary
+│ Event 24 (assistant response)           │ │ (fully retained, no truncation)
+│ ...                                     │ │
 │ Event N (current message)               │ ┘
 └─────────────────────────────────────────┘
 ```
+
+**Important Note:** When `WithAddSessionSummary(true)` is enabled, the `WithMaxHistoryRuns` parameter is ignored, and all events after the summary are fully retained.
 
 For detailed configuration and advanced usage, see the [Session Summary](#session-summary) section.
 
@@ -1072,23 +1079,26 @@ sess, err := sessionService.GetSession(ctx, key,
     session.WithEventTime(time.Now().Add(-1*time.Hour)))
 ```
 
-## Session Summary
+## Session Summarization
 
 ### Overview
 
-As conversations continue to grow, maintaining complete event history can consume significant memory and may exceed LLM context window limits. The session summary feature uses LLM to automatically compress historical conversations into concise summaries, significantly reducing memory usage and token consumption while preserving important context.
+As conversations grow longer, maintaining full event history can become memory-intensive and may exceed LLM context windows. The session summarization feature automatically compresses historical conversation content into concise summaries using LLM-based summarization, reducing memory usage while preserving important context for future interactions.
 
-**Core Features:**
+### Key Features
 
-- **Automatic Triggering**: Automatically generate summaries based on event count, token count, or time thresholds
-- **Incremental Processing**: Only process new events since the last summary
-- **LLM-Driven**: Use configured LLM model to generate high-quality summaries
-- **Non-Destructive**: Original events fully preserved, summaries stored separately
-- **Asynchronous Processing**: Execute asynchronously in background without blocking conversation flow
+- **Automatic summarization**: Automatically trigger summaries based on configurable conditions such as event count, token count, or time threshold.
+- **Incremental summarization**: Only new events since the last summary are processed, avoiding redundant computation.
+- **LLM-powered**: Uses any configured LLM model to generate high-quality, context-aware summaries.
+- **Non-destructive**: Original events remain unchanged; summaries are stored separately.
+- **Asynchronous processing**: Summary jobs are processed asynchronously to avoid blocking the main conversation flow.
+- **Customizable prompts**: Configure custom summarization prompts and word limits.
 
-### Basic Configuration
+### Basic Usage
 
-#### Step 1: Create Summarizer
+#### Configure Summarizer
+
+Create a summarizer with an LLM model and configure trigger conditions:
 
 ```go
 import (
@@ -1097,62 +1107,55 @@ import (
     "trpc.group/trpc-go/trpc-agent-go/model/openai"
 )
 
-// Create LLM model for summarization
+// Create LLM model for summarization.
 summaryModel, err := openai.NewModel(
     openai.WithAPIKey("your-api-key"),
     openai.WithModelName("gpt-4"),
 )
+if err != nil {
+    panic(err)
+}
 
-// Create summarizer and configure trigger conditions
+// Create summarizer with trigger conditions.
 summarizer := summary.NewSummarizer(
     summaryModel,
-    summary.WithChecksAny(                     // Trigger when any condition is met
-        summary.CheckEventThreshold(20),       // Trigger after 20 events
-        summary.CheckTokenThreshold(4000),     // Trigger after 4000 tokens
-        summary.CheckTimeThreshold(5*time.Minute), // Trigger after 5 minutes of inactivity
-    ),
-    summary.WithMaxSummaryWords(200),          // Limit summary to 200 words
+    summary.WithEventThreshold(20),        // Trigger after 20 events.
+    summary.WithTokenThreshold(4000),      // Trigger after 4000 tokens.
+    summary.WithMaxSummaryWords(200),      // Limit summary to 200 words.
 )
 ```
 
-#### Step 2: Configure Session Service
+#### Integrate with Session Service
+
+Attach the summarizer to your session service (in-memory or Redis):
 
 ```go
-// Memory storage
-sessionService := inmemory.NewSessionService(
-    inmemory.WithSummarizer(summarizer),
-    inmemory.WithAsyncSummaryNum(2),
-    inmemory.WithSummaryQueueSize(100),
-    inmemory.WithSummaryJobTimeout(30*time.Second),
+import (
+    "time"
+    "trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+    "trpc.group/trpc-go/trpc-agent-go/session/redis"
 )
 
-// Redis storage
+// Option 1: In-memory session service with summarizer.
+sessionService := inmemory.NewSessionService(
+    inmemory.WithSummarizer(summarizer),
+    inmemory.WithAsyncSummaryNum(2),                // 2 async workers.
+    inmemory.WithSummaryQueueSize(100),             // Queue size 100.
+    inmemory.WithSummaryJobTimeout(30*time.Second), // 30s timeout per job.
+)
+
+// Option 2: Redis session service with summarizer.
 sessionService, err := redis.NewService(
     redis.WithRedisClientURL("redis://localhost:6379"),
     redis.WithSummarizer(summarizer),
-    redis.WithAsyncSummaryNum(4),
-    redis.WithSummaryQueueSize(200),
-)
-
-// PostgreSQL storage
-sessionService, err := postgres.NewService(
-    postgres.WithHost("localhost"),
-    postgres.WithPassword("your-password"),
-    postgres.WithSummarizer(summarizer),
-    postgres.WithAsyncSummaryNum(2),
-    postgres.WithSummaryQueueSize(100),
-)
-
-// MySQL storage
-sessionService, err := mysql.NewService(
-    mysql.WithMySQLClientDSN("user:password@tcp(localhost:3306)/db?charset=utf8mb4&parseTime=True&loc=Local"),
-    mysql.WithSummarizer(summarizer),
-    mysql.WithAsyncSummaryNum(2),
-    mysql.WithSummaryQueueSize(100),
+    redis.WithAsyncSummaryNum(4),           // 4 async workers.
+    redis.WithSummaryQueueSize(200),        // Queue size 200.
 )
 ```
 
-#### Step 3: Configure Agent and Runner
+#### Automatic Summarization in Runner
+
+Once configured, the Runner automatically triggers summarization. You can also configure the LLM agent to use summaries in context:
 
 ```go
 import (
@@ -1160,104 +1163,257 @@ import (
     "trpc.group/trpc-go/trpc-agent-go/runner"
 )
 
-// Create Agent (enable summary injection)
+// Create agent with summary injection enabled.
 llmAgent := llmagent.New(
     "my-agent",
     llmagent.WithModel(summaryModel),
-    llmagent.WithAddSessionSummary(true),   // Enable summary injection
+    llmagent.WithAddSessionSummary(true),   // Inject summary as system message.
+    llmagent.WithMaxHistoryRuns(10),        // Keep last 10 runs when summary exists.
 )
 
-// Create Runner
-r := runner.NewRunner(
+// Create runner with session service.
+runner := runner.NewRunner(
     "my-agent",
     llmAgent,
     runner.WithSessionService(sessionService),
 )
 
-// Run conversation - summary automatically managed
-eventChan, err := r.Run(ctx, userID, sessionID, userMessage)
+// Summaries are automatically created and injected during conversation.
+eventChan, err := runner.Run(ctx, userID, sessionID, userMessage)
 ```
 
-### Summary Trigger Mechanism
+**How it works:**
 
-**Automatic Triggering (Recommended):** Runner automatically checks trigger conditions after each conversation completes, generating summaries asynchronously in background when conditions are met.
+The framework provides two distinct modes for managing conversation context sent to the LLM:
 
-**Manual Triggering:**
+**Mode 1: With Summary (`WithAddSessionSummary(true)`)**
+
+- The session summary is prepended as a system message.
+- **All incremental events** after the summary timestamp are included (no truncation).
+- This ensures complete context: condensed history (summary) + all new conversations since summarization.
+- `WithMaxHistoryRuns` is **ignored** in this mode.
+
+**Mode 2: Without Summary (`WithAddSessionSummary(false)`)**
+
+- No summary is prepended.
+- Only the **most recent `MaxHistoryRuns` conversation turns** are included.
+- When `MaxHistoryRuns=0` (default), no limit is applied and all history is included.
+- Use this mode for short sessions or when you want direct control over context window size.
+
+**Context Construction Details:**
+
+```
+When AddSessionSummary = true:
+┌─────────────────────────────────────┐
+│ System Prompt                       │
+├─────────────────────────────────────┤
+│ Session Summary (system message)    │ ← Condensed history
+├─────────────────────────────────────┤
+│ Event 1 (after summary timestamp)   │ ┐
+│ Event 2                             │ │ All incremental
+│ Event 3                             │ │ events since
+│ ...                                 │ │ last summary
+│ Event N (current)                   │ ┘
+└─────────────────────────────────────┘
+
+When AddSessionSummary = false:
+┌─────────────────────────────────────┐
+│ System Prompt                       │
+├─────────────────────────────────────┤
+│ Event N-k+1                         │ ┐
+│ Event N-k+2                         │ │ Last k turns
+│ ...                                 │ │ (if MaxHistoryRuns=k)
+│ Event N (current)                   │ ┘
+└─────────────────────────────────────┘
+```
+
+**Best Practices:**
+
+- For long-running sessions, use `WithAddSessionSummary(true)` to maintain full context while managing token usage.
+- For short sessions or when testing, use `WithAddSessionSummary(false)` with appropriate `MaxHistoryRuns`.
+- The Runner automatically enqueues async summary jobs after appending events to the session.
+
+### Configuration Options
+
+#### Summarizer Options
+
+Configure the summarizer behavior with the following options:
+
+**Trigger Conditions:**
+
+- **`WithEventThreshold(eventCount int)`**: Trigger summarization when the number of events exceeds the threshold. Example: `WithEventThreshold(20)` triggers after 20 events.
+- **`WithTokenThreshold(tokenCount int)`**: Trigger summarization when the total token count exceeds the threshold. Example: `WithTokenThreshold(4000)` triggers after 4000 tokens.
+- **`WithTimeThreshold(interval time.Duration)`**: Trigger summarization when time elapsed since the last event exceeds the interval. Example: `WithTimeThreshold(5*time.Minute)` triggers after 5 minutes of inactivity.
+
+**Composite Conditions:**
+
+- **`WithChecksAll(checks ...Checker)`**: Require all conditions to be met (AND logic). Use with `Check*` functions (not `With*`). Example:
+  ```go
+  summary.WithChecksAll(
+      summary.CheckEventThreshold(10),
+      summary.CheckTokenThreshold(2000),
+  )
+  ```
+- **`WithChecksAny(checks ...Checker)`**: Trigger if any condition is met (OR logic). Use with `Check*` functions (not `With*`). Example:
+  ```go
+  summary.WithChecksAny(
+      summary.CheckEventThreshold(50),
+      summary.CheckTimeThreshold(10*time.Minute),
+  )
+  ```
+
+**Note:** Use `Check*` functions (like `CheckEventThreshold`) inside `WithChecksAll` and `WithChecksAny`. Use `With*` functions (like `WithEventThreshold`) as direct options to `NewSummarizer`. The `Check*` functions create checker instances, while `With*` functions are option setters.
+
+**Summary Generation:**
+
+- **`WithMaxSummaryWords(maxWords int)`**: Limit the summary to a maximum word count. The limit is included in the prompt to guide the model's generation. Example: `WithMaxSummaryWords(150)` requests summaries within 150 words.
+- **`WithPrompt(prompt string)`**: Provide a custom summarization prompt. The prompt must include the placeholder `{conversation_text}`, which will be replaced with the conversation content. Optionally include `{max_summary_words}` for word limit instructions.
+
+**Example with custom prompt:**
 
 ```go
-// Asynchronous summarization (recommended) - background processing, non-blocking
+customPrompt := `Analyze the following conversation and provide a concise summary
+focusing on key decisions, action items, and important context.
+Keep it within {max_summary_words} words.
+
+<conversation>
+{conversation_text}
+</conversation>
+
+Summary:`
+
+summarizer := summary.NewSummarizer(
+    summaryModel,
+    summary.WithPrompt(customPrompt),
+    summary.WithMaxSummaryWords(100),
+    summary.WithEventThreshold(15),
+)
+```
+
+#### Session Service Options
+
+Configure async summary processing in session services:
+
+- **`WithSummarizer(s summary.SessionSummarizer)`**: Inject the summarizer into the session service.
+- **`WithAsyncSummaryNum(num int)`**: Set the number of async worker goroutines for summary processing. Default is 2. More workers allow higher concurrency but consume more resources.
+- **`WithSummaryQueueSize(size int)`**: Set the size of the summary job queue. Default is 100. Larger queues allow more pending jobs but consume more memory.
+- **`WithSummaryJobTimeout(timeout time.Duration)`** _(in-memory only)_: Set the timeout for processing a single summary job. Default is 30 seconds.
+
+### Manual Summarization
+
+You can manually trigger summarization using the session service APIs:
+
+```go
+// Asynchronous summarization (recommended) - background processing, non-blocking.
 err := sessionService.EnqueueSummaryJob(
     ctx,
     sess,
-    session.SummaryFilterKeyAllContents,
-    false, // force=false, respects trigger conditions
+    session.SummaryFilterKeyAllContents, // Full session summary.
+    false,                                // force=false, respects trigger conditions.
 )
 
-// Synchronous summarization - immediate processing, blocking
+// Synchronous summarization - immediate processing, blocking.
 err := sessionService.CreateSessionSummary(
     ctx,
     sess,
     session.SummaryFilterKeyAllContents,
-    false,
+    false, // force=false, respects trigger conditions.
 )
 
-// Force summarization - bypass trigger conditions
+// Asynchronous force summarization - bypass trigger conditions.
 err := sessionService.EnqueueSummaryJob(
     ctx,
     sess,
     session.SummaryFilterKeyAllContents,
-    true, // force=true, bypass all trigger condition checks
+    true, // force=true, bypass all trigger condition checks.
+)
+
+// Synchronous force summarization - immediate forced generation.
+err := sessionService.CreateSessionSummary(
+    ctx,
+    sess,
+    session.SummaryFilterKeyAllContents,
+    true, // force=true, bypass all trigger condition checks.
 )
 ```
 
-### Context Injection Mechanism
+**API Description:**
 
-**Mode 1: Enable Summary Injection (Recommended)**
+- **`EnqueueSummaryJob`**: Asynchronous summarization (recommended)
+
+  - Background processing, non-blocking
+  - Automatic fallback to sync processing on failure
+  - Suitable for production environments
+
+- **`CreateSessionSummary`**: Synchronous summarization
+  - Immediate processing, blocking current operation
+  - Direct result return
+  - Suitable for debugging or scenarios requiring immediate results
+
+**Parameter Description:**
+
+- **filterKey**: `session.SummaryFilterKeyAllContents` indicates generating summary for the complete session
+- **force parameter**:
+  - `false`: Respects configured trigger conditions (event count, token count, time threshold, etc.), only generates summary when conditions are met
+  - `true`: Forces summary generation, completely ignores all trigger condition checks, executes regardless of session state
+
+**Usage Scenarios:**
+
+| Scenario                   | API                            | force   | Description                                      |
+| -------------------------- | ------------------------------ | ------- | ------------------------------------------------ |
+| Normal auto-summary        | Automatically called by Runner | `false` | Auto-generates when trigger conditions met       |
+| Session end                | `EnqueueSummaryJob`            | `true`  | Force generate final complete summary            |
+| User requests view         | `CreateSessionSummary`         | `true`  | Immediately generate and return                  |
+| Scheduled batch processing | `EnqueueSummaryJob`            | `false` | Batch check and process qualified sessions       |
+| Debug/testing              | `CreateSessionSummary`         | `true`  | Immediate execution, convenient for verification |
+
+### Retrieve Summary
+
+Get the latest summary text from a session:
 
 ```go
-llmagent.WithAddSessionSummary(true)
+summaryText, found := sessionService.GetSessionSummaryText(ctx, sess)
+if found {
+    fmt.Printf("Summary: %s\n", summaryText)
+}
 ```
 
-- Summary automatically prepended as system message to LLM input
-- Includes all incremental events after summary timestamp
-- Ensures complete context: condensed history + complete new conversations
+### How It Works
 
-**Mode 2: Without Summary**
+1. **Incremental Processing**: The summarizer tracks the last summarization time for each session. On subsequent runs, it only processes events that occurred after the last summary.
 
-```go
-llmagent.WithAddSessionSummary(false)
-llmagent.WithMaxHistoryRuns(10)  // Include only last 10 conversation rounds
-```
+2. **Delta Summarization**: New events are combined with the previous summary (prepended as a system event) to generate an updated summary that incorporates both old context and new information.
 
-### Advanced Summarizer Options
+3. **Trigger Evaluation**: Before generating a summary, the summarizer evaluates configured trigger conditions (event count, token count, time threshold). If conditions aren't met and `force=false`, summarization is skipped.
 
-```go
-summarizer := summary.NewSummarizer(
-    summaryModel,
-    // Trigger conditions
-    summary.WithEventThreshold(20),
-    summary.WithTokenThreshold(4000),
-    summary.WithTimeThreshold(5*time.Minute),
+4. **Async Workers**: Summary jobs are distributed across multiple worker goroutines using hash-based distribution. This ensures jobs for the same session are processed sequentially while different sessions can be processed in parallel.
 
-    // Composite conditions (any met)
-    summary.WithChecksAny(
-        summary.CheckEventThreshold(50),
-        summary.CheckTimeThreshold(10*time.Minute),
-    ),
+5. **Fallback Mechanism**: If async enqueueing fails (queue full, context cancelled, or workers not initialized), the system automatically falls back to synchronous processing.
 
-    // Composite conditions (all met)
-    summary.WithChecksAll(
-        summary.CheckEventThreshold(10),
-        summary.CheckTokenThreshold(2000),
-    ),
+### Best Practices
 
-    // Summary generation
-    summary.WithMaxSummaryWords(200),
-    summary.WithPrompt(customPrompt),
-)
-```
+1. **Choose appropriate thresholds**: Set event/token thresholds based on your LLM's context window and conversation patterns. For GPT-4 (8K context), consider `WithTokenThreshold(4000)` to leave room for responses.
+
+2. **Use async processing**: Always use `EnqueueSummaryJob` instead of `CreateSessionSummary` in production to avoid blocking the conversation flow.
+
+3. **Monitor queue sizes**: If you see frequent "queue is full" warnings, increase `WithSummaryQueueSize` or `WithAsyncSummaryNum`.
+
+4. **Customize prompts**: Tailor the summarization prompt to your application's needs. For example, if you're building a customer support agent, focus on key issues and resolutions.
+
+5. **Balance word limits**: Set `WithMaxSummaryWords` to balance between preserving context and reducing token usage. Typical values range from 100-300 words.
+
+6. **Test trigger conditions**: Experiment with different combinations of `WithChecksAny` and `WithChecksAll` to find the right balance between summary frequency and cost.
+
+### Performance Considerations
+
+- **LLM costs**: Each summary generation calls the LLM. Monitor your trigger conditions to balance cost and context preservation.
+- **Memory usage**: Summaries are stored in addition to events. Configure appropriate TTLs to manage memory in long-running sessions.
+- **Async workers**: More workers increase throughput but consume more resources. Start with 2-4 workers and scale based on load.
+- **Queue capacity**: Size the queue based on your expected concurrency and summary generation time.
 
 ### Complete Example
+
+Here's a complete example demonstrating all components together:
 
 ```go
 package main
@@ -1277,17 +1433,13 @@ import (
 func main() {
     ctx := context.Background()
 
-    // Create LLM model
-    llm, err := openai.NewModel(
+    // Create LLM model for both chat and summarization.
+    llm, _ := openai.NewModel(
         openai.WithAPIKey("your-api-key"),
         openai.WithModelName("gpt-4"),
     )
-    if err != nil {
-        // Handle error...
-        return
-    }
 
-    // Create summarizer
+    // Create summarizer with flexible trigger conditions.
     summarizer := summary.NewSummarizer(
         llm,
         summary.WithMaxSummaryWords(200),
@@ -1298,7 +1450,7 @@ func main() {
         ),
     )
 
-    // Create session service
+    // Create session service with summarizer.
     sessionService := inmemory.NewSessionService(
         inmemory.WithSummarizer(summarizer),
         inmemory.WithAsyncSummaryNum(2),
@@ -1306,52 +1458,32 @@ func main() {
         inmemory.WithSummaryJobTimeout(30*time.Second),
     )
 
-    // Create Agent
+    // Create agent with summary injection enabled.
     agent := llmagent.New(
         "my-agent",
         llmagent.WithModel(llm),
         llmagent.WithAddSessionSummary(true),
+        llmagent.WithMaxHistoryRuns(10),
     )
 
-    // Create Runner
+    // Create runner.
     r := runner.NewRunner("my-app", agent,
         runner.WithSessionService(sessionService))
 
-    // Run conversation
+    // Run conversation - summaries are automatically managed.
     userMsg := model.NewUserMessage("Tell me about AI")
-    eventChan, err := r.Run(ctx, "user123", "session456", userMsg)
-    if err != nil {
-        // Handle error...
-        return
-    }
+    eventChan, _ := r.Run(ctx, "user123", "session456", userMsg)
 
-    // Consume events
+    // Consume events.
     for event := range eventChan {
-        if event == nil || event.Response == nil {
-            continue
-        }
-        if event.Response.Error != nil {
-            // Handle error event...
-            continue
-        }
-        if len(event.Response.Choices) > 0 {
-            choice := event.Response.Choices[0]
-            if choice.Delta.Content != "" {
-                // Process streaming content...
-            } else if choice.Message.Content != "" {
-                // Process complete content...
-            }
-        }
-        if event.IsFinalResponse() {
-            break
-        }
+        // Handle events...
     }
 }
 ```
 
 ## References
 
-- [Session Example](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/runner)
-- [Summary Example](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/summary)
+- [Session example](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/runner)
+- [Summary example](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/summary)
 
-By properly using session management in combination with session summary mechanisms, you can build stateful intelligent Agents that maintain conversation context while efficiently managing memory, providing users with continuous and personalized interaction experiences.
+By properly using session management, in combination with session summarization mechanisms, you can build stateful intelligent Agents that maintain conversation context while efficiently managing memory, providing users with continuous and personalized interaction experiences while ensuring the long-term sustainability of your system.

--- a/docs/mkdocs/zh/session.md
+++ b/docs/mkdocs/zh/session.md
@@ -79,6 +79,8 @@ func main() {
         llmagent.WithModel(llm),
         llmagent.WithSystemPrompt("你是一个智能助手"),
         llmagent.WithAddSessionSummary(true), // 可选：启用摘要注入到上下文
+        // 注意：WithAddSessionSummary(true) 时会忽略 WithMaxHistoryRuns 配置
+        // 摘要会包含所有历史，增量事件会完整保留
     )
 
     // 5. 创建 Runner 并注入 Session Service
@@ -245,6 +247,8 @@ r := runner.NewRunner("my-agent", llmAgent,
 │ Event N (current message)               │ ┘
 └─────────────────────────────────────────┘
 ```
+
+**重要提示：** 启用 `WithAddSessionSummary(true)` 时，`WithMaxHistoryRuns` 参数将被忽略，摘要后的所有事件都会完整保留。
 
 详细配置和高级用法请参见 [会话摘要](#会话摘要) 章节。
 
@@ -1081,18 +1085,22 @@ sess, err := sessionService.GetSession(ctx, key,
 **核心特性：**
 
 - **自动触发**：根据事件数量、token 数量或时间阈值自动生成摘要
-- **增量处理**：只处理自上次摘要以来的新事件
-- **LLM 驱动**：使用配置的 LLM 模型生成高质量摘要
+- **增量处理**：只处理自上次摘要以来的新事件，避免重复计算
+- **LLM 驱动**：使用任何配置的 LLM 模型生成高质量、上下文感知的摘要
 - **非破坏性**：原始事件完整保留，摘要单独存储
 - **异步处理**：后台异步执行，不阻塞对话流程
+- **灵活配置**：支持自定义触发条件、提示词和字数限制
 
 ### 基础配置
 
 #### 步骤 1：创建摘要器
 
+使用 LLM 模型创建摘要器并配置触发条件：
+
 ```go
 import (
     "time"
+
     "trpc.group/trpc-go/trpc-agent-go/session/summary"
     "trpc.group/trpc-go/trpc-agent-go/model/openai"
 )
@@ -1102,6 +1110,9 @@ summaryModel, err := openai.NewModel(
     openai.WithAPIKey("your-api-key"),
     openai.WithModelName("gpt-4"),
 )
+if err != nil {
+    panic(err)
+}
 
 // 创建摘要器并配置触发条件
 summarizer := summary.NewSummarizer(
@@ -1117,21 +1128,29 @@ summarizer := summary.NewSummarizer(
 
 #### 步骤 2：配置会话服务
 
+将摘要器集成到会话服务（内存或 Redis）：
+
 ```go
-// 内存存储
-sessionService := inmemory.NewSessionService(
-    inmemory.WithSummarizer(summarizer),
-    inmemory.WithAsyncSummaryNum(2),
-    inmemory.WithSummaryQueueSize(100),
-    inmemory.WithSummaryJobTimeout(30*time.Second),
+import (
+    "time"
+    "trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+    "trpc.group/trpc-go/trpc-agent-go/session/redis"
 )
 
-// Redis 存储
+// 内存存储（开发/测试）
+sessionService := inmemory.NewSessionService(
+    inmemory.WithSummarizer(summarizer),
+    inmemory.WithAsyncSummaryNum(2),                // 2 个异步 worker
+    inmemory.WithSummaryQueueSize(100),             // 队列大小 100
+    inmemory.WithSummaryJobTimeout(30*time.Second), // 单个任务超时 30 秒
+)
+
+// Redis 存储（生产环境）
 sessionService, err := redis.NewService(
     redis.WithRedisClientURL("redis://localhost:6379"),
     redis.WithSummarizer(summarizer),
-    redis.WithAsyncSummaryNum(4),
-    redis.WithSummaryQueueSize(200),
+    redis.WithAsyncSummaryNum(4),           // 4 个异步 worker
+    redis.WithSummaryQueueSize(200),        // 队列大小 200
 )
 
 // PostgreSQL 存储
@@ -1139,20 +1158,22 @@ sessionService, err := postgres.NewService(
     postgres.WithHost("localhost"),
     postgres.WithPassword("your-password"),
     postgres.WithSummarizer(summarizer),
-    postgres.WithAsyncSummaryNum(2),
-    postgres.WithSummaryQueueSize(100),
+    postgres.WithAsyncSummaryNum(2),       // 2 个异步 worker
+    postgres.WithSummaryQueueSize(100),    // 队列大小 100
 )
 
 // MySQL 存储
 sessionService, err := mysql.NewService(
     mysql.WithMySQLClientDSN("user:password@tcp(localhost:3306)/db?charset=utf8mb4&parseTime=True&loc=Local"),
     mysql.WithSummarizer(summarizer),
-    mysql.WithAsyncSummaryNum(2),
-    mysql.WithSummaryQueueSize(100),
+    mysql.WithAsyncSummaryNum(2),           // 2个异步 worker
+    mysql.WithSummaryQueueSize(100),        // 队列大小 100
 )
 ```
 
 #### 步骤 3：配置 Agent 和 Runner
+
+创建 Agent 并配置摘要注入行为：
 
 ```go
 import (
@@ -1160,11 +1181,12 @@ import (
     "trpc.group/trpc-go/trpc-agent-go/runner"
 )
 
-// 创建 Agent（启用摘要注入）
+// 创建 Agent（配置摘要注入行为）
 llmAgent := llmagent.New(
     "my-agent",
     llmagent.WithModel(summaryModel),
     llmagent.WithAddSessionSummary(true),   // 启用摘要注入
+    llmagent.WithMaxHistoryRuns(10),        // 配合使用（见下方说明）
 )
 
 // 创建 Runner
@@ -1174,90 +1196,307 @@ r := runner.NewRunner(
     runner.WithSessionService(sessionService),
 )
 
-// 运行对话 - 摘要自动管理
+// 运行对话 - 摘要将自动管理
 eventChan, err := r.Run(ctx, userID, sessionID, userMessage)
 ```
 
+完成以上配置后，摘要功能即可自动运行。
+
 ### 摘要触发机制
 
-**自动触发（推荐）：** Runner 在每次对话完成后自动检查触发条件，满足条件时在后台异步生成摘要。
+#### 自动触发（推荐）
 
-**手动触发：**
+**Runner 自动触发：** 在每次对话完成后，Runner 会自动检查触发条件，满足条件时在后台异步生成摘要，无需手动干预。
+
+**触发时机：**
+
+- 事件数量达到阈值（`WithEventThreshold`）
+- Token 数量达到阈值（`WithTokenThreshold`）
+- 距上次事件超过指定时间（`WithTimeThreshold`）
+- 满足自定义组合条件（`WithChecksAny` / `WithChecksAll`）
+
+#### 手动触发
+
+某些场景下，你可能需要手动触发摘要：
 
 ```go
 // 异步摘要（推荐）- 后台处理，不阻塞
 err := sessionService.EnqueueSummaryJob(
     ctx,
     sess,
-    session.SummaryFilterKeyAllContents,
-    false, // force=false，遵守触发条件
+    session.SummaryFilterKeyAllContents, // 对完整会话生成摘要
+    false,                               // force=false，遵守触发条件
 )
 
-// 同步摘要 - 立即处理，会阻塞
+// 同步摘要 - 立即处理，会阻塞当前操作
 err := sessionService.CreateSessionSummary(
     ctx,
     sess,
     session.SummaryFilterKeyAllContents,
-    false,
+    false, // force=false，遵守触发条件
 )
 
-// 强制摘要 - 忽略触发条件
+// 异步强制摘要 - 忽略触发条件，强制生成
 err := sessionService.EnqueueSummaryJob(
     ctx,
     sess,
     session.SummaryFilterKeyAllContents,
-    true, // force=true，绕过触发条件
+    true, // force=true，绕过所有触发条件检查
+)
+
+// 同步强制摘要 - 立即强制生成
+err := sessionService.CreateSessionSummary(
+    ctx,
+    sess,
+    session.SummaryFilterKeyAllContents,
+    true, // force=true，绕过所有触发条件检查
 )
 ```
 
+**API 说明：**
+
+- **`EnqueueSummaryJob`**：异步摘要（推荐）
+
+  - 后台处理，不阻塞当前操作
+  - 失败时自动回退到同步处理
+  - 适合生产环境
+
+- **`CreateSessionSummary`**：同步摘要
+  - 立即处理，会阻塞当前操作
+  - 直接返回处理结果
+  - 适合调试或需要立即获取结果的场景
+
+**参数说明：**
+
+- **filterKey**：`session.SummaryFilterKeyAllContents` 表示对完整会话生成摘要
+- **force 参数**：
+  - `false`：遵守配置的触发条件（事件数、token 数、时间阈值等），只有满足条件才生成摘要
+  - `true`：强制生成摘要，完全忽略所有触发条件检查，无论会话状态如何都会执行
+
+**使用场景：**
+
+| 场景         | API                    | force   | 说明                         |
+| ------------ | ---------------------- | ------- | ---------------------------- |
+| 正常自动摘要 | 由 Runner 自动调用     | `false` | 满足触发条件时自动生成       |
+| 会话结束     | `EnqueueSummaryJob`    | `true`  | 强制生成最终完整摘要         |
+| 用户请求查看 | `CreateSessionSummary` | `true`  | 立即生成并返回               |
+| 定时批量处理 | `EnqueueSummaryJob`    | `false` | 批量检查并处理符合条件的会话 |
+| 调试测试     | `CreateSessionSummary` | `true`  | 立即执行，方便验证           |
+
 ### 上下文注入机制
 
-**模式 1：启用摘要注入（推荐）**
+框架提供两种模式来管理发送给 LLM 的对话上下文：
+
+#### 模式 1：启用摘要注入（推荐）
 
 ```go
 llmagent.WithAddSessionSummary(true)
 ```
 
-- 摘要作为系统消息自动前置到 LLM 输入
-- 包含摘要时间点之后的所有增量事件
-- 保证完整上下文：浓缩历史 + 完整新对话
+**工作方式：**
 
-**模式 2：不使用摘要**
+- 摘要作为系统消息自动前置到 LLM 输入
+- 包含摘要时间点之后的**所有增量事件**（不截断）
+- 保证完整上下文：浓缩历史 + 完整新对话
+- **`WithMaxHistoryRuns` 参数被忽略**
+
+**上下文结构：**
+
+```
+┌─────────────────────────────────────────┐
+│ System Prompt                           │
+├─────────────────────────────────────────┤
+│ Session Summary (system message)        │ ← Compressed history
+├─────────────────────────────────────────┤
+│ Event 1 (after summary)                 │ ┐
+│ Event 2                                 │ │
+│ Event 3                                 │ │ New events after summary
+│ ...                                     │ │ (fully retained)
+│ Event N (current message)               │ ┘
+└─────────────────────────────────────────┘
+```
+
+**适用场景：** 长期运行的会话，需要保持完整历史上下文同时控制 token 消耗。
+
+#### 模式 2：不使用摘要
 
 ```go
 llmagent.WithAddSessionSummary(false)
-llmagent.WithMaxHistoryRuns(10)  // 只包含最近 10 轮对话
+llmagent.WithMaxHistoryRuns(10)  // 限制历史轮次
 ```
 
-### 摘要器高级选项
+**工作方式：**
+
+- 不添加摘要消息
+- 只包含最近 `MaxHistoryRuns` 轮对话
+- `MaxHistoryRuns=0` 时不限制，包含所有历史
+
+**上下文结构：**
+
+```
+┌─────────────────────────────────────────┐
+│ System Prompt                           │
+├─────────────────────────────────────────┤
+│ Event N-k+1                             │ ┐
+│ Event N-k+2                             │ │ Last k runs
+│ ...                                     │ │ (MaxHistoryRuns=k)
+│ Event N (current message)               │ ┘
+└─────────────────────────────────────────┘
+```
+
+**适用场景：** 短会话、测试环境，或需要精确控制上下文窗口大小。
+
+#### 模式选择建议
+
+| 场景                   | 推荐配置                                         | 说明                       |
+| ---------------------- | ------------------------------------------------ | -------------------------- |
+| 长期会话（客服、助手） | `AddSessionSummary=true`                         | 保持完整上下文，优化 token |
+| 短期会话（单次咨询）   | `AddSessionSummary=false`<br>`MaxHistoryRuns=10` | 简单直接，无需摘要开销     |
+| 调试测试               | `AddSessionSummary=false`<br>`MaxHistoryRuns=5`  | 快速验证，减少干扰         |
+| 高并发场景             | `AddSessionSummary=true`<br>增加 worker 数量     | 异步处理，不影响响应速度   |
+
+### 高级配置
+
+#### 摘要器选项
+
+使用以下选项配置摘要器行为：
+
+**触发条件：**
+
+- **`WithEventThreshold(eventCount int)`**：当事件数量超过阈值时触发摘要。示例：`WithEventThreshold(20)` 在 20 个事件后触发。
+- **`WithTokenThreshold(tokenCount int)`**：当总 token 数量超过阈值时触发摘要。示例：`WithTokenThreshold(4000)` 在 4000 个 token 后触发。
+- **`WithTimeThreshold(interval time.Duration)`**：当自上次事件后经过的时间超过间隔时触发摘要。示例：`WithTimeThreshold(5*time.Minute)` 在 5 分钟无活动后触发。
+
+**组合条件：**
+
+- **`WithChecksAll(checks ...Checker)`**：要求所有条件都满足（AND 逻辑）。使用 `Check*` 函数（不是 `With*`）。示例：
+  ```go
+  summary.WithChecksAll(
+      summary.CheckEventThreshold(10),
+      summary.CheckTokenThreshold(2000),
+  )
+  ```
+- **`WithChecksAny(checks ...Checker)`**：任何条件满足即触发（OR 逻辑）。使用 `Check*` 函数（不是 `With*`）。示例：
+  ```go
+  summary.WithChecksAny(
+      summary.CheckEventThreshold(50),
+      summary.CheckTimeThreshold(10*time.Minute),
+  )
+  ```
+
+**注意：**在 `WithChecksAll` 和 `WithChecksAny` 中使用 `Check*` 函数（如 `CheckEventThreshold`）。将 `With*` 函数（如 `WithEventThreshold`）作为 `NewSummarizer` 的直接选项使用。`Check*` 函数创建检查器实例，而 `With*` 函数是选项设置器。
+
+**摘要生成：**
+
+- **`WithMaxSummaryWords(maxWords int)`**：限制摘要的最大字数。该限制会包含在提示词中以指导模型生成。示例：`WithMaxSummaryWords(150)` 请求在 150 字以内的摘要。
+- **`WithPrompt(prompt string)`**：提供自定义摘要提示词。提示词必须包含占位符 `{conversation_text}`，它会被对话内容替换。可选包含 `{max_summary_words}` 用于字数限制指令。
+
+**自定义提示词示例：**
 
 ```go
+customPrompt := `分析以下对话并提供简洁的摘要，重点关注关键决策、行动项和重要上下文。
+请控制在 {max_summary_words} 字以内。
+
+<conversation>
+{conversation_text}
+</conversation>
+
+摘要：`
+
 summarizer := summary.NewSummarizer(
     summaryModel,
-    // 触发条件
-    summary.WithEventThreshold(20),
-    summary.WithTokenThreshold(4000),
-    summary.WithTimeThreshold(5*time.Minute),
-
-    // 组合条件（任一满足）
-    summary.WithChecksAny(
-        summary.CheckEventThreshold(50),
-        summary.CheckTimeThreshold(10*time.Minute),
-    ),
-
-    // 组合条件（全部满足）
-    summary.WithChecksAll(
-        summary.CheckEventThreshold(10),
-        summary.CheckTokenThreshold(2000),
-    ),
-
-    // 摘要生成
-    summary.WithMaxSummaryWords(200),
     summary.WithPrompt(customPrompt),
+    summary.WithMaxSummaryWords(100),
+    summary.WithEventThreshold(15),
 )
 ```
 
+#### 会话服务选项
+
+在会话服务中配置异步摘要处理：
+
+- **`WithSummarizer(s summary.SessionSummarizer)`**：将摘要器注入到会话服务中。
+- **`WithAsyncSummaryNum(num int)`**：设置用于摘要处理的异步 worker goroutine 数量。默认为 2。更多 worker 允许更高并发但消耗更多资源。
+- **`WithSummaryQueueSize(size int)`**：设置摘要任务队列的大小。默认为 100。更大的队列允许更多待处理任务但消耗更多内存。
+- **`WithSummaryJobTimeout(timeout time.Duration)`** _（仅内存模式）_：设置处理单个摘要任务的超时时间。默认为 30 秒。
+
+### 手动触发摘要
+
+可以使用会话服务 API 手动触发摘要：
+
+```go
+// 同步摘要
+err := sessionService.CreateSessionSummary(
+    ctx,
+    sess,
+    session.SummaryFilterKeyAllContents, // 完整会话摘要。
+    false,                                // force=false，遵守触发条件。
+)
+
+// 异步摘要（推荐）
+err := sessionService.EnqueueSummaryJob(
+    ctx,
+    sess,
+    session.SummaryFilterKeyAllContents,
+    false, // force=false。
+)
+
+// 强制摘要，不考虑触发条件
+err := sessionService.EnqueueSummaryJob(
+    ctx,
+    sess,
+    session.SummaryFilterKeyAllContents,
+    true, // force=true，绕过触发条件。
+)
+```
+
+### 获取摘要
+
+从会话中获取最新的摘要文本：
+
+```go
+summaryText, found := sessionService.GetSessionSummaryText(ctx, sess)
+if found {
+    fmt.Printf("摘要：%s\n", summaryText)
+}
+```
+
+### 工作原理
+
+1. **增量处理**：摘要器跟踪每个会话的上次摘要时间。在后续运行中，它只处理上次摘要后发生的事件。
+
+2. **增量摘要**：新事件与先前的摘要（作为系统事件前置）组合，生成一个既包含旧上下文又包含新信息的更新摘要。
+
+3. **触发条件评估**：在生成摘要之前，摘要器会评估配置的触发条件（事件计数、token 计数、时间阈值）。如果条件未满足且 `force=false`，则跳过摘要。
+
+4. **异步 Worker**：摘要任务使用基于哈希的分发策略分配到多个 worker goroutine。这确保同一会话的任务按顺序处理，而不同会话可以并行处理。
+
+5. **回退机制**：如果异步入队失败（队列已满、上下文取消或 worker 未初始化），系统会自动回退到同步处理。
+
+### 最佳实践
+
+1. **选择合适的阈值**：根据 LLM 的上下文窗口和对话模式设置事件/token 阈值。对于 GPT-4（8K 上下文），考虑使用 `WithTokenThreshold(4000)` 为响应留出空间。
+
+2. **使用异步处理**：在生产环境中始终使用 `EnqueueSummaryJob` 而不是 `CreateSessionSummary`，以避免阻塞对话流程。
+
+3. **监控队列大小**：如果频繁看到"queue is full"警告，请增加 `WithSummaryQueueSize` 或 `WithAsyncSummaryNum`。
+
+4. **自定义提示词**：根据应用需求定制摘要提示词。例如，如果你正在构建客户支持 Agent，应关注关键问题和解决方案。
+
+5. **平衡字数限制**：设置 `WithMaxSummaryWords` 以在保留上下文和减少 token 使用之间取得平衡。典型值范围为 100-300 字。
+
+6. **测试触发条件**：尝试不同的 `WithChecksAny` 和 `WithChecksAll` 组合，找到摘要频率和成本之间的最佳平衡。
+
+### 性能考虑
+
+- **LLM 成本**：每次摘要生成都会调用 LLM。监控触发条件以平衡成本和上下文保留。
+- **内存使用**：摘要与事件一起存储。配置适当的 TTL 以管理长时间运行会话中的内存。
+- **异步 Worker**：更多 worker 会提高吞吐量但消耗更多资源。从 2-4 个 worker 开始，根据负载进行扩展。
+- **队列容量**：根据预期的并发量和摘要生成时间调整队列大小。
+
 ### 完整示例
+
+以下是演示所有组件如何协同工作的完整示例：
 
 ```go
 package main
@@ -1277,17 +1516,13 @@ import (
 func main() {
     ctx := context.Background()
 
-    // 创建 LLM 模型
-    llm, err := openai.NewModel(
+    // 创建用于聊天和摘要的 LLM 模型
+    llm, _ := openai.NewModel(
         openai.WithAPIKey("your-api-key"),
         openai.WithModelName("gpt-4"),
     )
-    if err != nil {
-        // 处理错误...
-        return
-    }
 
-    // 创建摘要器
+    // 创建带灵活触发条件的摘要器
     summarizer := summary.NewSummarizer(
         llm,
         summary.WithMaxSummaryWords(200),
@@ -1298,7 +1533,7 @@ func main() {
         ),
     )
 
-    // 创建会话服务
+    // 创建带摘要器的会话服务
     sessionService := inmemory.NewSessionService(
         inmemory.WithSummarizer(summarizer),
         inmemory.WithAsyncSummaryNum(2),
@@ -1306,45 +1541,25 @@ func main() {
         inmemory.WithSummaryJobTimeout(30*time.Second),
     )
 
-    // 创建 Agent
+    // 创建启用摘要注入的 agent
     agent := llmagent.New(
         "my-agent",
         llmagent.WithModel(llm),
         llmagent.WithAddSessionSummary(true),
+        llmagent.WithMaxHistoryRuns(10),
     )
 
-    // 创建 Runner
+    // 创建 runner
     r := runner.NewRunner("my-app", agent,
         runner.WithSessionService(sessionService))
 
-    // 运行对话
+    // 运行对话 - 摘要会自动管理
     userMsg := model.NewUserMessage("跟我讲讲 AI")
-    eventChan, err := r.Run(ctx, "user123", "session456", userMsg)
-    if err != nil {
-        // 处理错误...
-        return
-    }
+    eventChan, _ := r.Run(ctx, "user123", "session456", userMsg)
 
     // 消费事件
     for event := range eventChan {
-        if event == nil || event.Response == nil {
-            continue
-        }
-        if event.Response.Error != nil {
-            // 处理错误事件...
-            continue
-        }
-        if len(event.Response.Choices) > 0 {
-            choice := event.Response.Choices[0]
-            if choice.Delta.Content != "" {
-                // 处理流式内容...
-            } else if choice.Message.Content != "" {
-                // 处理完整内容...
-            }
-        }
-        if event.IsFinalResponse() {
-            break
-        }
+        // 处理事件...
     }
 }
 ```
@@ -1354,4 +1569,4 @@ func main() {
 - [会话示例](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/runner)
 - [摘要示例](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/summary)
 
-通过合理使用会话管理功能，结合会话摘要机制，你可以构建有状态的智能 Agent，在保持对话上下文的同时高效管理内存，为用户提供连续、个性化的交互体验。
+通过合理使用会话管理功能，结合会话摘要机制，你可以构建有状态的智能 Agent，在保持对话上下文的同时高效管理内存，为用户提供连续、个性化的交互体验，同时确保系统长期运行的可持续性。


### PR DESCRIPTION
修复这个MR中重构了session.md时导致部分summary的文档说明缺失的问题，https://github.com/trpc-group/trpc-agent-go/pull/702