### PR TITLE
{agent, runner}: support initializing invocaiton state at runner.Run

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -176,6 +176,11 @@ func (r *runner) Run(
 		agent.WithInvocationEventFilterKey(r.appName),
 	)
 
+	// Initialize invocation state from RunOptions if provided.
+	if ro.InitialInvocationState != nil {
+		invocation.SetStates(ro.InitialInvocationState)
+	}
+
 	// If caller provided a history via RunOptions and the session is empty,
 	// persist that history into the session exactly once, so subsequent turns
 	// and tool calls build on the same canonical transcript.


### PR DESCRIPTION
- Added `WithInvocationState` function to set initial invocation state in `RunOptions`.
- Introduced `SetStates` method in the `Invocation` struct for atomic state updates.
- Enhanced tests to verify the functionality of initial invocation state, including scenarios for setting, overwriting, and handling empty states.
- Updated the runner to initialize invocation state from `RunOptions` during execution.