### PR TITLE
agent: add generic getter for typed runtime state retrieval

### DIFF
--- a/agent/invocation.go
+++ b/agent/invocation.go
@@ -139,6 +139,35 @@ func WithRuntimeState(state map[string]any) RunOption {
 	}
 }
 
+// GetRuntimeStateValue retrieves a typed value from the runtime state.
+//
+// Returns the typed value and true if the key exists and the type matches,
+// or the zero value and false otherwise.
+//
+// Example:
+//
+//	if userID, ok := GetRuntimeStateValue[string](&inv.RunOptions, "user_id"); ok {
+//	    log.Printf("User ID: %s", userID)
+//	}
+//	if roomID, ok := GetRuntimeStateValue[int](&inv.RunOptions, "room_id"); ok {
+//	    log.Printf("Room ID: %d", roomID)
+//	}
+func GetRuntimeStateValue[T any](opts *RunOptions, key string) (T, bool) {
+	var zero T
+	if opts == nil || opts.RuntimeState == nil {
+		return zero, false
+	}
+	val, ok := opts.RuntimeState[key]
+	if !ok {
+		return zero, false
+	}
+	typedVal, ok := val.(T)
+	if !ok {
+		return zero, false
+	}
+	return typedVal, true
+}
+
 // WithKnowledgeFilter sets the metadata filter for the RunOptions.
 func WithKnowledgeFilter(filter map[string]any) RunOption {
 	return func(opts *RunOptions) {


### PR DESCRIPTION
- Implemented GetRuntimeStateValue to retrieve typed values from the runtime state in RunOptions.
- Added comprehensive unit tests covering various scenarios including key not found, nil options, type matching, type mismatch, and complex types.
- Enhanced test coverage for runtime state retrieval with different data types such as strings, integers, booleans, slices, maps, and structs.