### PR TITLE
{docs, agent}: enhance AfterAgentArgs to include FullResponseEvent

### DIFF
--- a/agent/callbacks.go
+++ b/agent/callbacks.go
@@ -13,6 +13,7 @@ package agent
 import (
 	"context"
 
+	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 )
 
@@ -63,6 +64,8 @@ type BeforeAgentCallbackStructured = func(
 type AfterAgentArgs struct {
 	// Invocation is the invocation context.
 	Invocation *Invocation
+	// FullResponseEvent is the final response event from agent execution (may be nil).
+	FullResponseEvent *event.Event
 	// Error is the error occurred during agent execution (may be nil).
 	Error error
 }

--- a/agent/chainagent/chain_agent.go
+++ b/agent/chainagent/chain_agent.go
@@ -144,7 +144,7 @@ func (a *ChainAgent) executeChainRun(
 	e, tokenUsage := a.executeSubAgents(ctx, invocation, eventChan)
 	// Handle after agent callbacks.
 	if a.agentCallbacks != nil {
-		e = a.handleAfterAgentCallbacks(ctx, invocation, eventChan)
+		e = a.handleAfterAgentCallbacks(ctx, invocation, eventChan, e)
 	}
 	itelemetry.TraceAfterInvokeAgent(span, e, tokenUsage)
 }
@@ -262,11 +262,13 @@ func (a *ChainAgent) handleAfterAgentCallbacks(
 	ctx context.Context,
 	invocation *agent.Invocation,
 	eventChan chan<- *event.Event,
+	fullRespEvent *event.Event,
 ) *event.Event {
 
 	result, err := a.agentCallbacks.RunAfterAgent(ctx, &agent.AfterAgentArgs{
-		Invocation: invocation,
-		Error:      nil,
+		Invocation:        invocation,
+		Error:             nil,
+		FullResponseEvent: fullRespEvent,
 	})
 	// Use the context from result if provided.
 	if result != nil && result.Context != nil {

--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -544,8 +544,9 @@ func (a *LLMAgent) wrapEventChannel(
 		// After all events are processed, run after agent callbacks
 		if a.agentCallbacks != nil {
 			result, err := a.agentCallbacks.RunAfterAgent(ctx, &agent.AfterAgentArgs{
-				Invocation: invocation,
-				Error:      agentErr,
+				Invocation:        invocation,
+				Error:             agentErr,
+				FullResponseEvent: fullRespEvent,
 			})
 			// Use the context from result if provided.
 			if result != nil && result.Context != nil {

--- a/docs/mkdocs/zh/callbacks.md
+++ b/docs/mkdocs/zh/callbacks.md
@@ -287,8 +287,9 @@ type BeforeAgentResult struct {
 }
 
 type AfterAgentArgs struct {
-    Invocation *agent.Invocation  // 调用上下文
-    Error      error              // Agent 执行过程中发生的错误
+    Invocation        *agent.Invocation  // 调用上下文
+    FullResponseEvent *event.Event       // Agent 执行后的最终响应事件（可能为 nil）
+    Error             error              // Agent 执行过程中发生的错误（可能为 nil）
 }
 
 type AfterAgentResult struct {
@@ -311,6 +312,7 @@ type AfterAgentCallbackStructured  func(ctx context.Context, args *agent.AfterAg
 - 可访问完整的调用上下文，便于实现丰富的按次逻辑
 - Before 可返回自定义 `*model.Response` 以中止后续模型调用
 - After 可返回替换响应
+- `AfterAgentArgs.FullResponseEvent` 提供对 agent 最终输出结果的访问，可用于日志记录、监控、后处理等场景
 
 ### 回调执行控制
 
@@ -365,16 +367,19 @@ agentCallbacks := agent.NewCallbacks().
     }
     return nil, nil
   }).
-  // After：在成功响应末尾追加标注
+  // After：在成功响应末尾追加标注，可以访问 FullResponseEvent 获取最终响应事件
   RegisterAfterAgent(func(ctx context.Context, args *agent.AfterAgentArgs) (*agent.AfterAgentResult, error) {
     if args.Error != nil {
       return nil, args.Error
     }
-    if args.Invocation != nil && args.Invocation.Response != nil && len(args.Invocation.Response.Choices) > 0 {
-      c := args.Invocation.Response.Choices[0]
-      c.Message.Content = c.Message.Content + "\n\n-- handled by agent callback"
-      args.Invocation.Response.Choices[0] = c
-      return &agent.AfterAgentResult{CustomResponse: args.Invocation.Response}, nil
+    // 可以通过 FullResponseEvent 访问 agent 的最终输出结果
+    if args.FullResponseEvent != nil && args.FullResponseEvent.Response != nil {
+      if len(args.FullResponseEvent.Response.Choices) > 0 {
+        c := args.FullResponseEvent.Response.Choices[0]
+        c.Message.Content = c.Message.Content + "\n\n-- handled by agent callback"
+        args.FullResponseEvent.Response.Choices[0] = c
+        return &agent.AfterAgentResult{CustomResponse: args.FullResponseEvent.Response}, nil
+      }
     }
     return nil, nil
   })


### PR DESCRIPTION
- Added FullResponseEvent to AfterAgentArgs for better access to the final response event from agent execution.
- Updated various agent implementations to pass FullResponseEvent during after agent callbacks.
- Introduced new unit tests to validate the handling of FullResponseEvent in callbacks.
- Updated documentation to reflect changes in AfterAgentArgs structure and usage.