### PR TITLE
graph: return Done Response event but keep not emit it

### DIFF
--- a/graph/state_graph.go
+++ b/graph/state_graph.go
@@ -949,12 +949,12 @@ func processModelResponse(ctx context.Context, config modelResponseConfig) (cont
 		}
 	}
 	var llmEvent *event.Event
+	author := config.LLMModel.Info().Name
+	if config.NodeID != "" {
+		author = config.NodeID
+	}
+	llmEvent = event.NewResponseEvent(config.InvocationID, author, config.Response)
 	if config.EventChan != nil && !config.Response.Done {
-		author := config.LLMModel.Info().Name
-		if config.NodeID != "" {
-			author = config.NodeID
-		}
-		llmEvent = event.NewResponseEvent(config.InvocationID, author, config.Response)
 		invocation, ok := agent.InvocationFromContext(ctx)
 		if !ok {
 			invocation = agent.NewInvocation(


### PR DESCRIPTION
The Done Response(completed response) contains accumulated partial chunks. completed response is useful for telemetry