### PR TITLE
internal/state: preserve numeric literals in session state injection

### DIFF
--- a/internal/state/state_injection.go
+++ b/internal/state/state_injection.go
@@ -11,6 +11,7 @@
 package state
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"regexp"
@@ -95,13 +96,7 @@ func InjectSessionState(template string, invocation *agent.Invocation) (string, 
 		// Get the value from session state.
 		if invocation != nil && invocation.Session != nil && invocation.Session.State != nil {
 			if jsonBytes, exists := invocation.Session.State[varName]; exists {
-				// Try to unmarshal as JSON first.
-				var jsonValue any
-				if err := json.Unmarshal(jsonBytes, &jsonValue); err == nil {
-					return fmt.Sprintf("%v", jsonValue)
-				}
-				// If JSON unmarshaling fails, treat as string.
-				return string(jsonBytes)
+				return renderStateValue(jsonBytes)
 			}
 		}
 
@@ -115,6 +110,27 @@ func InjectSessionState(template string, invocation *agent.Invocation) (string, 
 		return match
 	})
 	return result, nil
+}
+
+// renderStateValue converts a raw state value to its string representation.
+// It preserves JSON semantics while avoiding scientific notation and precision
+// issues for numeric literals by decoding them into json.Number.
+func renderStateValue(raw []byte) string {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	var jsonValue any
+	if err := dec.Decode(&jsonValue); err != nil {
+		// Not valid JSON, treat as plain string.
+		return string(raw)
+	}
+	switch v := jsonValue.(type) {
+	case string:
+		return v
+	case json.Number:
+		return v.String()
+	default:
+		return fmt.Sprintf("%v", v)
+	}
 }
 
 // isValidStateName checks if the variable name is a valid state name.

--- a/internal/state/state_injection_test.go
+++ b/internal/state/state_injection_test.go
@@ -248,3 +248,19 @@ func TestInjectSessionState_MustachePlaceholders(t *testing.T) {
 		t.Fatalf("InjectSessionState invalid mustache: got %q err=%v", s, err)
 	}
 }
+
+func TestInjectSessionState_RawNumericString(t *testing.T) {
+	// Prepare invocation session state with a raw numeric-looking string value.
+	sm := make(session.StateMap)
+	sm["code"] = []byte("123456789012345678901234567890")
+	inv := &agent.Invocation{Session: &session.Session{State: sm}}
+
+	s, err := InjectSessionState("Code: {code}", inv)
+	if err != nil {
+		t.Fatalf("InjectSessionState raw numeric string: unexpected error: %v", err)
+	}
+	const want = "Code: 123456789012345678901234567890"
+	if s != want {
+		t.Fatalf("InjectSessionState raw numeric string: got %q, want %q", s, want)
+	}
+}


### PR DESCRIPTION
Use json.Decoder with UseNumber in InjectSessionState to parse session state values. Preserve JSON numeric literals via json.Number.String() to avoid scientific notation and precision issues in placeholder injection. Keep existing behavior for JSON strings (unquoted), objects, arrays, booleans, and fall back to plain string  injection for non-JSON values.