### PR TITLE
examples/graph: reorder error handling in streaming response processing

### DIFF
--- a/examples/graph/basic/main.go
+++ b/examples/graph/basic/main.go
@@ -739,11 +739,6 @@ func (w *documentWorkflow) processStreamingResponse(eventChan <-chan *event.Even
 		completionEvent        *event.Event
 	)
 	for event := range eventChan {
-		// Handle errors.
-		if event.Error != nil {
-			fmt.Printf("❌ Error: %s\n", event.Error.Message)
-			continue
-		}
 		// Track node/tool/model execution events via metadata (author may be nodeID).
 		if event.StateDelta != nil {
 			// Try to extract node metadata from StateDelta.
@@ -860,6 +855,12 @@ func (w *documentWorkflow) processStreamingResponse(eventChan <-chan *event.Even
 					}
 				}
 			}
+		}
+		// Handle errors after metadata so error-phase
+		// node/tool/model events are observable.
+		if event.Error != nil {
+			fmt.Printf("❌ Error: %s\n", event.Error.Message)
+			continue
 		}
 		// Process streaming content from LLM nodes (events with model names as authors).
 		if len(event.Response.Choices) > 0 {

--- a/examples/graph/fanout/main.go
+++ b/examples/graph/fanout/main.go
@@ -521,10 +521,10 @@ func (w *fanoutWorkflow) processStreamingResponse(eventChan <-chan *event.Event)
 		completionEvent *event.Event
 	)
 	for event := range eventChan {
+		w.handleGraphNodeEvent(event, maxPreviewLen)
 		if w.handleErrorEvent(event) {
 			continue
 		}
-		w.handleGraphNodeEvent(event, maxPreviewLen)
 		w.handleStreamingChoices(event, &workflowStarted)
 		w.trackStageProgress(event, &stageCount)
 		if event.IsRunnerCompletion() {

--- a/examples/graph/io_conventions_tools/main.go
+++ b/examples/graph/io_conventions_tools/main.go
@@ -271,10 +271,6 @@ func stream(ch <-chan *event.Event, verbose bool) error {
 		if e == nil {
 			continue
 		}
-		if e.Error != nil {
-			fmt.Printf("❌ %s\n", e.Error.Message)
-			continue
-		}
 		if verbose && e.StateDelta != nil {
 			if b, ok := e.StateDelta[graph.MetadataKeyModel]; ok && len(b) > 0 {
 				var md graph.ModelExecutionMetadata
@@ -298,6 +294,10 @@ func stream(ch <-chan *event.Event, verbose bool) error {
 					}
 				}
 			}
+		}
+		if e.Error != nil {
+			fmt.Printf("❌ %s\n", e.Error.Message)
+			continue
 		}
 		if len(e.Choices) > 0 {
 			c := e.Choices[0]

--- a/examples/graph/per_node_callbacks/main.go
+++ b/examples/graph/per_node_callbacks/main.go
@@ -385,12 +385,6 @@ func (w *perNodeCallbacksWorkflow) processStreamingResponse(eventChan <-chan *ev
 	)
 
 	for event := range eventChan {
-		// Handle errors.
-		if event.Error != nil {
-			fmt.Printf("❌ Error: %s\n", event.Error.Message)
-			continue
-		}
-
 		// Track node execution events via metadata regardless of author.
 		if event.StateDelta != nil {
 			if nodeData, exists := event.StateDelta[graph.MetadataKeyNode]; exists {
@@ -406,6 +400,13 @@ func (w *perNodeCallbacksWorkflow) processStreamingResponse(eventChan <-chan *ev
 					}
 				}
 			}
+		}
+
+		// Handle errors after metadata so per-node error callbacks
+		// can be observed via metadata.
+		if event.Error != nil {
+			fmt.Printf("❌ Error: %s\n", event.Error.Message)
+			continue
 		}
 
 		// Process streaming content from LLM nodes.

--- a/examples/graph/react/main.go
+++ b/examples/graph/react/main.go
@@ -174,12 +174,6 @@ func streamEvents(eventChan <-chan *event.Event) error {
 		if evt == nil {
 			continue
 		}
-		if evt.Error != nil {
-			fmt.Printf("error: %s\n", evt.Error.Message)
-			lineOpen = false
-			continue
-		}
-
 		if label := maybeStartNode(evt); label != "" {
 			flushStream()
 			if lineOpen {
@@ -240,6 +234,12 @@ func streamEvents(eventChan <-chan *event.Event) error {
 
 		if evt.Response != nil && evt.Response.Done {
 			flushStream()
+		}
+
+		if evt.Error != nil {
+			fmt.Printf("error: %s\n", evt.Error.Message)
+			lineOpen = false
+			continue
 		}
 	}
 

--- a/examples/graph/retry/main.go
+++ b/examples/graph/retry/main.go
@@ -214,10 +214,6 @@ func handleStreaming(ch <-chan *event.Event) error {
 		started bool
 	)
 	for ev := range ch {
-		if ev.Error != nil {
-			fmt.Printf("❌ Error: %s\n", ev.Error.Message)
-			continue
-		}
 		// Show retry metadata when verbose
 		if *verbose && ev.StateDelta != nil {
 			if b, ok := ev.StateDelta[graph.MetadataKeyNode]; ok {
@@ -234,6 +230,10 @@ func handleStreaming(ch <-chan *event.Event) error {
 					}
 				}
 			}
+		}
+		if ev.Error != nil {
+			fmt.Printf("❌ Error: %s\n", ev.Error.Message)
+			continue
 		}
 		// Stream model deltas
 		if len(ev.Response.Choices) > 0 {

--- a/examples/graph/subagent_runtime_state/main.go
+++ b/examples/graph/subagent_runtime_state/main.go
@@ -344,12 +344,6 @@ func streamEvents(ch <-chan *event.Event) error {
 		if e == nil {
 			continue
 		}
-		// Errors
-		if e.Error != nil {
-			fmt.Printf("❌ %s\n", e.Error.Message)
-			continue
-		}
-
 		// Print minimal execution metadata from StateDelta (model/tool phases)
 		if e.StateDelta != nil {
 			if md, ok := e.StateDelta[graph.MetadataKeyModel]; ok && len(md) > 0 {
@@ -384,6 +378,12 @@ func streamEvents(ch <-chan *event.Event) error {
 					}
 				}
 			}
+		}
+
+		// Errors
+		if e.Error != nil {
+			fmt.Printf("❌ %s\n", e.Error.Message)
+			continue
 		}
 
 		// Fallback: sub-agent tool.response without graph metadata

--- a/examples/graph/subgraph/main.go
+++ b/examples/graph/subgraph/main.go
@@ -388,10 +388,6 @@ func stream(ch <-chan *event.Event, verbose bool) error {
 		if e == nil {
 			continue
 		}
-		if e.Error != nil {
-			fmt.Printf("\n[error:%s] %s\n", e.Error.Type, e.Error.Message)
-			continue
-		}
 		// Print streaming deltas.
 		if e.Response != nil && len(e.Response.Choices) > 0 {
 			choice := e.Response.Choices[0]
@@ -411,7 +407,10 @@ func stream(ch <-chan *event.Event, verbose bool) error {
 		// Verbose: print tool/model metadata and filter key.
 		if verbose && e.StateDelta != nil {
 			if e.FilterKey != "" {
-				fmt.Printf("\n[filter] %s\n", e.FilterKey)
+				fmt.Printf(
+					"\n[filter] %s\n",
+					e.FilterKey,
+				)
 			}
 			if b, ok := e.StateDelta[graph.MetadataKeyModel]; ok && len(b) > 0 {
 				fmt.Printf("\n[model] %s\n", string(b))
@@ -425,6 +424,13 @@ func stream(ch <-chan *event.Event, verbose bool) error {
 			if b, ok := e.StateDelta[keyFinal]; ok && len(b) > 0 {
 				fmt.Printf("\n[final] %s\n", string(b))
 			}
+		}
+		if e.Error != nil {
+			fmt.Printf(
+				"\n[error:%s] %s\n",
+				e.Error.Type, e.Error.Message,
+			)
+			continue
 		}
 	}
 	return nil


### PR DESCRIPTION
Reorganized error handling in the processStreamingResponse function across multiple examples to ensure that node-level metadata is processed before handling errors. This change improves the visibility of error-phase events related to node execution while maintaining the overall functionality of the event processing logic.