### PR TITLE
docs: clarify summarization trigger conditions in session docs and comments

### DIFF
--- a/docs/mkdocs/en/session.md
+++ b/docs/mkdocs/en/session.md
@@ -51,8 +51,8 @@ func main() {
     summarizer := summary.NewSummarizer(
         llm, // Use same LLM model for summary generation
         summary.WithChecksAny(                         // Trigger when any condition is met
-            summary.CheckEventThreshold(20),           // Trigger when exceeds 20 events
-            summary.CheckTokenThreshold(4000),         // Trigger when exceeds 4000 tokens
+            summary.CheckEventThreshold(20),           // Trigger when 20+ new events since last summary
+            summary.CheckTokenThreshold(4000),         // Trigger when 4000+ new tokens since last summary
             summary.CheckTimeThreshold(5*time.Minute), // Trigger after 5 minutes of inactivity
         ),
         summary.WithMaxSummaryWords(200), // Limit summary to 200 words
@@ -197,8 +197,8 @@ import (
 summarizer := summary.NewSummarizer(
     summaryModel,
     summary.WithChecksAny(                         // Trigger when any condition is met
-        summary.CheckEventThreshold(20),           // Trigger when exceeds 20 events
-        summary.CheckTokenThreshold(4000),         // Trigger when exceeds 4000 tokens
+        summary.CheckEventThreshold(20),           // Trigger when 20+ new events since last summary
+        summary.CheckTokenThreshold(4000),         // Trigger when 4000+ new tokens since last summary
         summary.CheckTimeThreshold(5*time.Minute), // Trigger after 5 minutes of inactivity
     ),
     summary.WithMaxSummaryWords(200),              // Limit summary to 200 words
@@ -1120,8 +1120,8 @@ summaryModel := openai.New("gpt-4", openai.WithAPIKey("your-api-key"))
 // Create summarizer with trigger conditions.
 summarizer := summary.NewSummarizer(
     summaryModel,
-    summary.WithEventThreshold(20),        // Trigger when exceeds 20 events.
-    summary.WithTokenThreshold(4000),      // Trigger when exceeds 4000 tokens.
+    summary.WithEventThreshold(20),        // Trigger when 20+ new events since last summary.
+    summary.WithTokenThreshold(4000),      // Trigger when 4000+ new tokens since last summary.
     summary.WithMaxSummaryWords(200),      // Limit summary to 200 words.
 )
 ```
@@ -1242,8 +1242,8 @@ Configure the summarizer behavior with the following options:
 
 **Trigger Conditions:**
 
-- **`WithEventThreshold(eventCount int)`**: Trigger summarization when the number of events exceeds the threshold. Example: `WithEventThreshold(20)` triggers when exceeds 20 events.
-- **`WithTokenThreshold(tokenCount int)`**: Trigger summarization when the total token count exceeds the threshold. Example: `WithTokenThreshold(4000)` triggers when exceeds 4000 tokens.
+- **`WithEventThreshold(eventCount int)`**: Trigger summarization when the number of new events since last summary exceeds the threshold. Example: `WithEventThreshold(20)` triggers when 20+ new events have occurred since last summary.
+- **`WithTokenThreshold(tokenCount int)`**: Trigger summarization when the new token count since last summary exceeds the threshold. Example: `WithTokenThreshold(4000)` triggers when 4000+ new tokens have been added since last summary.
 - **`WithTimeThreshold(interval time.Duration)`**: Trigger summarization when time elapsed since the last event exceeds the interval. Example: `WithTimeThreshold(5*time.Minute)` triggers after 5 minutes of inactivity.
 
 **Composite Conditions:**
@@ -1387,7 +1387,7 @@ if found {
 
 2. **Delta Summarization**: New events are combined with the previous summary (prepended as a system event) to generate an updated summary that incorporates both old context and new information.
 
-3. **Trigger Evaluation**: Before generating a summary, the summarizer evaluates configured trigger conditions (event count, token count, time threshold). If conditions aren't met and `force=false`, summarization is skipped.
+3. **Trigger Evaluation**: Before generating a summary, the summarizer evaluates configured trigger conditions (based on incremental event count, token count, and time threshold since last summary). If conditions aren't met and `force=false`, summarization is skipped.
 
 4. **Async Workers**: Summary jobs are distributed across multiple worker goroutines using hash-based distribution. This ensures jobs for the same session are processed sequentially while different sessions can be processed in parallel.
 

--- a/docs/mkdocs/zh/session.md
+++ b/docs/mkdocs/zh/session.md
@@ -1123,8 +1123,8 @@ summaryModel := openai.New("gpt-4", openai.WithAPIKey("your-api-key"))
 summarizer := summary.NewSummarizer(
     summaryModel,
     summary.WithChecksAny(                     // 任一条件满足即触发
-        summary.CheckEventThreshold(20),       // 超过 20 个事件后触发
-        summary.CheckTokenThreshold(4000),     // 超过 4000 个 token 后触发
+        summary.CheckEventThreshold(20),       // 自上次摘要后新增 20 个事件后触发
+        summary.CheckTokenThreshold(4000),     // 自上次摘要后新增 4000 个 token 后触发
         summary.CheckTimeThreshold(5*time.Minute), // 5 分钟无活动后触发
     ),
     summary.WithMaxSummaryWords(200),          // 限制摘要在 200 字以内
@@ -1368,8 +1368,8 @@ llmagent.WithMaxHistoryRuns(10)  // 限制历史轮次
 
 **触发条件：**
 
-- **`WithEventThreshold(eventCount int)`**：当事件数量超过阈值时触发摘要。示例：`WithEventThreshold(20)` 在超过 20 个事件后触发。
-- **`WithTokenThreshold(tokenCount int)`**：当总 token 数量超过阈值时触发摘要。示例：`WithTokenThreshold(4000)` 在超过 4000 个 token 后触发。
+- **`WithEventThreshold(eventCount int)`**：当自上次摘要后的事件数量超过阈值时触发摘要。示例：`WithEventThreshold(20)` 在自上次摘要后新增 20 个事件后触发。
+- **`WithTokenThreshold(tokenCount int)`**：当自上次摘要后的 token 数量超过阈值时触发摘要。示例：`WithTokenThreshold(4000)` 在自上次摘要后新增 4000 个 token 后触发。
 - **`WithTimeThreshold(interval time.Duration)`**：当自上次事件后经过的时间超过间隔时触发摘要。示例：`WithTimeThreshold(5*time.Minute)` 在 5 分钟无活动后触发。
 
 **组合条件：**
@@ -1474,7 +1474,7 @@ if found {
 
 2. **增量摘要**：新事件与先前的摘要（作为系统事件前置）组合，生成一个既包含旧上下文又包含新信息的更新摘要。
 
-3. **触发条件评估**：在生成摘要之前，摘要器会评估配置的触发条件（事件计数、token 计数、时间阈值）。如果条件未满足且 `force=false`，则跳过摘要。
+3. **触发条件评估**：在生成摘要之前，摘要器会评估配置的触发条件（基于自上次摘要后的增量事件计数、token 计数、时间阈值）。如果条件未满足且 `force=false`，则跳过摘要。
 
 4. **异步 Worker**：摘要任务使用基于哈希的分发策略分配到多个 worker goroutine。这确保同一会话的任务按顺序处理，而不同会话可以并行处理。
 

--- a/session/summary/checker.go
+++ b/session/summary/checker.go
@@ -22,7 +22,7 @@ import (
 type Checker func(sess *session.Session) bool
 
 // CheckEventThreshold creates a checker that triggers when the total number of
-// events in the session is greater than or equal to the specified threshold.
+// events in the session is greater than the specified threshold.
 // This is a simple proxy for conversation growth and is inexpensive to compute.
 // Example: CheckEventThreshold(30) will trigger once there are at least 30 events.
 func CheckEventThreshold(eventCount int) Checker {
@@ -32,7 +32,7 @@ func CheckEventThreshold(eventCount int) Checker {
 }
 
 // CheckTimeThreshold creates a checker that triggers when the time elapsed since
-// the last event is greater than or equal to the given interval.
+// the last event is greater than to the given interval.
 // This is useful to ensure periodic summarization in long-running sessions.
 // Example: CheckTimeThreshold(5*time.Minute) triggers if no events occurred in five minutes.
 func CheckTimeThreshold(interval time.Duration) Checker {


### PR DESCRIPTION
- Updated documentation to specify that event and token thresholds trigger summarization based on new events and tokens since the last summary.
- Adjusted comments in code examples to reflect the new descriptions for clarity.
- Ensured consistency in both English and Chinese documentation regarding summarization behavior.