### PR TITLE
agent/graphagent: collect agent error for after agent callback

### DIFF
--- a/agent/graphagent/graph_agent.go
+++ b/agent/graphagent/graph_agent.go
@@ -333,10 +333,25 @@ func (ga *GraphAgent) wrapEventChannel(
 				return
 			}
 		}
+
+		// Collect error from the final response event so after-agent
+		// callbacks can observe execution failures, matching LLMAgent
+		// semantics.
+		var agentErr error
+		if fullRespEvent != nil &&
+			fullRespEvent.Response != nil &&
+			fullRespEvent.Response.Error != nil {
+			agentErr = fmt.Errorf(
+				"%s: %s",
+				fullRespEvent.Response.Error.Type,
+				fullRespEvent.Response.Error.Message,
+			)
+		}
+
 		// After all events are processed, run after agent callbacks
 		result, err := ga.agentCallbacks.RunAfterAgent(ctx, &agent.AfterAgentArgs{
 			Invocation:        invocation,
-			Error:             nil,
+			Error:             agentErr,
 			FullResponseEvent: fullRespEvent,
 		})
 		// Use the context from result if provided.


### PR DESCRIPTION
- Modified the GraphAgent to collect and pass execution errors to after-agent callbacks, aligning with expected behavior.
- Updated the TestGraphAgent_AfterCallbackReturnsResponse to verify that the after-agent callback receives a nil error on successful execution.
- Added TestGraphAgent_AfterCallbackReceivesExecutionError to ensure that the after-agent callback correctly handles and receives errors from execution failures.