### PR TITLE
summary: add pre/post summary hooks for input/output modification

### DIFF
--- a/docs/mkdocs/en/session.md
+++ b/docs/mkdocs/en/session.md
@@ -223,6 +223,31 @@ r := runner.NewRunner("my-agent", llmAgent,
     runner.WithSessionService(sessionService))
 ```
 
+#### Summary hooks (pre/post)
+
+You can inject hooks to tweak summary input or output:
+
+```go
+summarizer := summary.NewSummarizer(
+    summaryModel,
+    summary.WithPreSummaryHook(func(ctx *summary.PreSummaryHookContext) error {
+        // Optionally modify ctx.Text or ctx.Events before summarization.
+        return nil
+    }),
+    summary.WithPostSummaryHook(func(ctx *summary.PostSummaryHookContext) error {
+        // Optionally modify ctx.Summary before returning to caller.
+        return nil
+    }),
+    summary.WithSummaryHookAbortOnError(true), // Abort when hook returns error (optional).
+)
+```
+
+Notes:
+
+- Pre-hook can mutate `ctx.Text` (preferred) or `ctx.Events`; post-hook can mutate `ctx.Summary`.
+- Default behavior ignores hook errors; enable abort with
+  `WithSummaryHookAbortOnError(true)`.
+
 **Context Injection Mechanism:**
 
 After enabling summary, the framework prepends the summary as a system message to the LLM input, while including all incremental events after the summary timestamp to ensure complete context:

--- a/docs/mkdocs/zh/session.md
+++ b/docs/mkdocs/zh/session.md
@@ -223,6 +223,30 @@ r := runner.NewRunner("my-agent", llmAgent,
     runner.WithSessionService(sessionService))
 ```
 
+#### 摘要前后置 Hook
+
+可以通过 Hook 调整摘要输入或输出：
+
+```go
+summarizer := summary.NewSummarizer(
+    summaryModel,
+    summary.WithPreSummaryHook(func(ctx *summary.PreSummaryHookContext) error {
+        // 可在摘要前修改 ctx.Text 或 ctx.Events
+        return nil
+    }),
+    summary.WithPostSummaryHook(func(ctx *summary.PostSummaryHookContext) error {
+        // 可在摘要返回前修改 ctx.Summary
+        return nil
+    }),
+    summary.WithSummaryHookAbortOnError(true), // Hook 报错时中断（可选）。
+)
+```
+
+说明：
+
+- Pre-hook 主要修改 `ctx.Text`，也可调整 `ctx.Events`；Post-hook 可修改 `ctx.Summary`。
+- 默认忽略 Hook 错误，需中断时使用 `WithSummaryHookAbortOnError(true)`。
+
 **上下文注入机制：**
 
 启用摘要后，框架会将摘要作为系统消息前置到 LLM 输入，同时包含摘要时间点之后的所有增量事件，保证完整上下文：

--- a/session/summary/hooks.go
+++ b/session/summary/hooks.go
@@ -1,0 +1,37 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package summary
+
+import (
+	"context"
+
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+// PreSummaryHookContext carries all inputs for pre-summary hooks.
+type PreSummaryHookContext struct {
+	Ctx     context.Context
+	Session *session.Session
+	Events  []event.Event
+	Text    string
+}
+
+// PreSummaryHook adjusts or enriches input text before summarization, e.g. add tool-call info, redact, or reorder events.
+type PreSummaryHook func(in *PreSummaryHookContext) error
+
+// PostSummaryHookContext post-processes model output, e.g. append tags, trim, or add checklists.
+type PostSummaryHookContext struct {
+	Ctx     context.Context
+	Session *session.Session
+	Summary string
+}
+
+// PostSummaryHook post-processes model output, e.g. append tags, trim, or add checklists.
+type PostSummaryHook func(in *PostSummaryHookContext) error

--- a/session/summary/options.go
+++ b/session/summary/options.go
@@ -86,3 +86,25 @@ func WithChecksAny(checks ...Checker) Option {
 		}
 	}
 }
+
+// WithPreSummaryHook sets a pre-summary hook to modify text before the model call.
+func WithPreSummaryHook(h PreSummaryHook) Option {
+	return func(s *sessionSummarizer) {
+		s.preHook = h
+	}
+}
+
+// WithPostSummaryHook sets a post-summary hook to modify the summary before returning.
+func WithPostSummaryHook(h PostSummaryHook) Option {
+	return func(s *sessionSummarizer) {
+		s.postHook = h
+	}
+}
+
+// WithSummaryHookAbortOnError decides whether to abort when a hook returns an error.
+// Default false: ignore hook errors and use original text/summary; true: return error.
+func WithSummaryHookAbortOnError(abort bool) Option {
+	return func(s *sessionSummarizer) {
+		s.hookAbortOnError = abort
+	}
+}

--- a/session/summary/summarizer_hook_test.go
+++ b/session/summary/summarizer_hook_test.go
@@ -1,0 +1,156 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package summary
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+type echoPromptModel struct {
+	lastPrompt string
+}
+
+func (m *echoPromptModel) Info() model.Info {
+	return model.Info{Name: "echo"}
+}
+
+func (m *echoPromptModel) GenerateContent(ctx context.Context, req *model.Request) (<-chan *model.Response, error) {
+	ch := make(chan *model.Response, 1)
+	if len(req.Messages) > 0 {
+		m.lastPrompt = req.Messages[0].Content
+	}
+	ch <- &model.Response{
+		Done: true,
+		Choices: []model.Choice{{
+			Message: model.Message{Content: m.lastPrompt},
+		}},
+	}
+	close(ch)
+	return ch, nil
+}
+
+func newEventWithContent(content string) event.Event {
+	return event.Event{
+		Author: "user",
+		Response: &model.Response{
+			Choices: []model.Choice{{Message: model.Message{Content: content}}},
+		},
+	}
+}
+
+func TestSessionSummarizer_PreHook_ModifiesInput(t *testing.T) {
+	model := &echoPromptModel{}
+	s := NewSummarizer(model, WithPreSummaryHook(func(in *PreSummaryHookContext) error {
+		in.Text = "HOOKED_TEXT"
+		return nil
+	}))
+
+	sess := &session.Session{ID: "sess", Events: []event.Event{newEventWithContent("origin")}}
+	summary, err := s.Summarize(context.Background(), sess)
+	require.NoError(t, err)
+	assert.Contains(t, summary, "HOOKED_TEXT")
+	assert.NotContains(t, summary, "origin")
+}
+
+func TestSessionSummarizer_PreHook_ErrorBehavior(t *testing.T) {
+	model := &echoPromptModel{}
+	hookErr := assert.AnError
+
+	t.Run("abort on error", func(t *testing.T) {
+		s := NewSummarizer(model,
+			WithPreSummaryHook(func(in *PreSummaryHookContext) error {
+				return hookErr
+			}),
+			WithSummaryHookAbortOnError(true),
+		)
+		sess := &session.Session{ID: "sess", Events: []event.Event{newEventWithContent("origin")}}
+		_, err := s.Summarize(context.Background(), sess)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "pre-summary hook failed")
+	})
+
+	t.Run("fallback on error", func(t *testing.T) {
+		s := NewSummarizer(model,
+			WithPreSummaryHook(func(in *PreSummaryHookContext) error {
+				return hookErr
+			}),
+			WithSummaryHookAbortOnError(false),
+		)
+		sess := &session.Session{ID: "sess", Events: []event.Event{newEventWithContent("origin")}}
+		summary, err := s.Summarize(context.Background(), sess)
+		require.NoError(t, err)
+		assert.Contains(t, summary, "origin")
+	})
+}
+
+func TestSessionSummarizer_PreHook_ModifiesEventsAndRebuildsText(t *testing.T) {
+	model := &echoPromptModel{}
+	s := NewSummarizer(model, WithPreSummaryHook(func(in *PreSummaryHookContext) error {
+		in.Events = []event.Event{newEventWithContent("new-content")}
+		in.Text = ""
+		return nil
+	}))
+
+	sess := &session.Session{ID: "sess", Events: []event.Event{newEventWithContent("origin")}}
+	summary, err := s.Summarize(context.Background(), sess)
+	require.NoError(t, err)
+	assert.Contains(t, summary, "new-content")
+	assert.NotContains(t, summary, "origin")
+}
+
+func TestSessionSummarizer_PostHook_ModifiesOutput(t *testing.T) {
+	model := &echoPromptModel{}
+	s := NewSummarizer(model, WithPostSummaryHook(func(in *PostSummaryHookContext) error {
+		in.Summary = "POST_HOOKED"
+		return nil
+	}))
+
+	sess := &session.Session{ID: "sess", Events: []event.Event{newEventWithContent("origin")}}
+	summary, err := s.Summarize(context.Background(), sess)
+	require.NoError(t, err)
+	assert.Equal(t, "POST_HOOKED", summary)
+}
+
+func TestSessionSummarizer_PostHook_ErrorBehavior(t *testing.T) {
+	model := &echoPromptModel{}
+	hookErr := assert.AnError
+
+	t.Run("abort on error", func(t *testing.T) {
+		s := NewSummarizer(model,
+			WithPostSummaryHook(func(in *PostSummaryHookContext) error {
+				return hookErr
+			}),
+			WithSummaryHookAbortOnError(true),
+		)
+		sess := &session.Session{ID: "sess", Events: []event.Event{newEventWithContent("origin")}}
+		_, err := s.Summarize(context.Background(), sess)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "post-summary hook failed")
+	})
+
+	t.Run("fallback on error", func(t *testing.T) {
+		s := NewSummarizer(model,
+			WithPostSummaryHook(func(in *PostSummaryHookContext) error {
+				return hookErr
+			}),
+			WithSummaryHookAbortOnError(false),
+		)
+		sess := &session.Session{ID: "sess", Events: []event.Event{newEventWithContent("origin")}}
+		summary, err := s.Summarize(context.Background(), sess)
+		require.NoError(t, err)
+		assert.Contains(t, summary, "origin")
+	})
+}


### PR DESCRIPTION
- Introduced pre-summary and post-summary hooks to allow customization of the summarization process.
- Implemented `WithPreSummaryHook` and `WithPostSummaryHook` options for modifying input text and output summary, respectively.
- Added error handling options to abort summarization on hook errors.
- Updated documentation in English and Chinese to reflect these new features.
- Included comprehensive tests for hook functionality and error handling.