### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@ English | [中文](README.zh_CN.md)
 
 # tRPC-Agent-Go
 
+[![Run in Smithery](https://smithery.ai/badge/skills/trpc-group)](https://smithery.ai/skills?ns=trpc-group&utm_source=github&utm_medium=badge)
+
+
 [![Go Reference](https://pkg.go.dev/badge/trpc.group/trpc-go/trpc-agent-go.svg)](https://pkg.go.dev/trpc.group/trpc-go/trpc-agent-go)
 [![Go Report Card](https://goreportcard.com/badge/github.com/trpc-group/trpc-agent-go)](https://goreportcard.com/report/github.com/trpc-group/trpc-agent-go)
 [![LICENSE](https://img.shields.io/badge/license-Apache--2.0-green.svg)](https://github.com/trpc-group/trpc-agent-go/blob/main/LICENSE)


### PR DESCRIPTION
## Add "Run in Smithery" Badge

This badge lets users discover and try your Claude Skills directly from GitHub.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/trpc-group)](https://smithery.ai/skills?ns=trpc-group&utm_source=github&utm_medium=badge)

### What's Smithery?
[Smithery](https://smithery.ai) is a platform where developers discover and install Claude Skills and MCP servers. Adding this badge helps users find and install your 3 skills with one click.

---

Feel free to adjust the placement or close this PR if you're not interested. Thanks for building awesome skills!