### PR TITLE
git-action: remove detailed output of unit test in github action

### DIFF
--- a/.github/scripts/run-go-tests.sh
+++ b/.github/scripts/run-go-tests.sh
@@ -71,7 +71,7 @@ for mod in "${gomodules[@]}"; do
   echo "module import path: ${module_path}"
   (
     cd "${mod_dir}"
-    go test -v -coverprofile=coverage.out ./...
+    go test -coverprofile=coverage.out ./...
   )
   relative_prefix="${mod_dir#./}"
   if [ "${relative_prefix}" = "" ] || [ "${relative_prefix}" = "." ]; then


### PR DESCRIPTION
The current unit test outputs are too verbose, and opening GitHub Actions to check specific unit test issues often causes the page to freeze or crash.
