### PR TITLE
internal/flow: insert summary after the first system message

### DIFF
--- a/docs/mkdocs/en/session.md
+++ b/docs/mkdocs/en/session.md
@@ -689,10 +689,10 @@ sessionService, err := postgres.NewService(
 
 **Delete Behavior Comparison:**
 
-| Configuration      | Delete Operation                | Query Behavior              | Data Recovery   |
-| ------------------ | ------------------------------- | --------------------------- | --------------- |
+| Configuration      | Delete Operation                | Query Behavior                                                                   | Data Recovery   |
+| ------------------ | ------------------------------- | -------------------------------------------------------------------------------- | --------------- |
 | `softDelete=true`  | `UPDATE SET deleted_at = NOW()` | Queries include `WHERE deleted_at IS NULL`, returning only non-soft-deleted rows | Recoverable     |
-| `softDelete=false` | `DELETE FROM ...`               | Query all records           | Not recoverable |
+| `softDelete=false` | `DELETE FROM ...`               | Query all records                                                                | Not recoverable |
 
 **TTL Auto Cleanup:**
 
@@ -947,10 +947,10 @@ sessionService, err := mysql.NewService(
 
 **Delete Behavior Comparison:**
 
-| Configuration      | Delete Operation                | Query Behavior              | Data Recovery   |
-| ------------------ | ------------------------------- | --------------------------- | --------------- |
+| Configuration      | Delete Operation                | Query Behavior                                                                   | Data Recovery   |
+| ------------------ | ------------------------------- | -------------------------------------------------------------------------------- | --------------- |
 | `softDelete=true`  | `UPDATE SET deleted_at = NOW()` | Queries include `WHERE deleted_at IS NULL`, returning only non-soft-deleted rows | Recoverable     |
-| `softDelete=false` | `DELETE FROM ...`               | Query all records           | Not recoverable |
+| `softDelete=false` | `DELETE FROM ...`               | Query all records                                                                | Not recoverable |
 
 **TTL Auto Cleanup:**
 
@@ -1228,7 +1228,7 @@ The framework provides two distinct modes for managing conversation context sent
 
 **Mode 1: With Summary (`WithAddSessionSummary(true)`)**
 
-- The session summary is prepended as a system message.
+- The session summary is inserted as a separate system message after the first existing system message (or prepended if no system message exists).
 - **All incremental events** after the summary timestamp are included (no truncation).
 - This ensures complete context: condensed history (summary) + all new conversations since summarization.
 - `WithMaxHistoryRuns` is **ignored** in this mode.
@@ -1245,9 +1245,9 @@ The framework provides two distinct modes for managing conversation context sent
 ```
 When AddSessionSummary = true:
 ┌─────────────────────────────────────┐
-│ System Prompt                       │
+│ Existing System Message (optional)  │ ← If present
 ├─────────────────────────────────────┤
-│ Session Summary (system message)    │ ← Condensed history
+│ Session Summary (system message)    │ ← Inserted after first system message
 ├─────────────────────────────────────┤
 │ Event 1 (after summary timestamp)   │ ┐
 │ Event 2                             │ │ All incremental

--- a/internal/flow/processor/content.go
+++ b/internal/flow/processor/content.go
@@ -195,11 +195,12 @@ func (p *ContentRequestProcessor) ProcessRequest(
 			// Add session summary as a system message if enabled and available.
 			// Also get the summary's UpdatedAt to ensure consistency with incremental messages.
 			if msg, updatedAt := p.getSessionSummaryMessage(invocation); msg != nil {
-				// Merge existing system messages first, then merge summary into the single system message.
+				// Insert summary as a separate system message after the first system message.
 				systemMsgIndex := findSystemMessageIndex(req.Messages)
 				if systemMsgIndex >= 0 {
-					// Merge summary into the existing system message.
-					req.Messages[systemMsgIndex].Content += "\n\n" + msg.Content
+					// Insert summary as a new system message after the first system message.
+					req.Messages = append(req.Messages[:systemMsgIndex+1],
+						append([]model.Message{*msg}, req.Messages[systemMsgIndex+1:]...)...)
 				} else {
 					// No system message exists, prepend new system message.
 					req.Messages = append([]model.Message{*msg}, req.Messages...)

--- a/internal/flow/processor/content_messages_test.go
+++ b/internal/flow/processor/content_messages_test.go
@@ -246,8 +246,8 @@ func newSessionEvent(author string, msg model.Message) event.Event {
 	}
 }
 
-// Test that session summary is merged into the last system message.
-func TestProcessRequest_SessionSummary_MergeWithSystemMessages(t *testing.T) {
+// Test that session summary is inserted as a separate system message after the first system message.
+func TestProcessRequest_SessionSummary_InsertAsSeparateSystemMessage(t *testing.T) {
 	// Create session with summary
 	sess := &session.Session{
 		Summaries: map[string]*session.Summary{
@@ -276,12 +276,16 @@ func TestProcessRequest_SessionSummary_MergeWithSystemMessages(t *testing.T) {
 	p1 := NewContentRequestProcessor(WithAddSessionSummary(true))
 	p1.ProcessRequest(context.Background(), inv1, req1, nil)
 
-	// Should have 2 messages: merged system, user
-	require.Equal(t, 3, len(req1.Messages))
+	// Should have 4 messages: system, summary system, user, current request
+	require.Equal(t, 4, len(req1.Messages))
 	require.Equal(t, model.RoleSystem, req1.Messages[0].Role)
-	require.Equal(t, "existing system prompt\n\nSession summary content", req1.Messages[0].Content)
+	require.Equal(t, "existing system prompt", req1.Messages[0].Content)
+	require.Equal(t, model.RoleSystem, req1.Messages[1].Role)
+	require.Equal(t, "Session summary content", req1.Messages[1].Content)
 	require.Equal(t, model.RoleUser, req1.Messages[2].Role)
-	require.Equal(t, "current request", req1.Messages[2].Content)
+	require.Equal(t, "user question", req1.Messages[2].Content)
+	require.Equal(t, model.RoleUser, req1.Messages[3].Role)
+	require.Equal(t, "current request", req1.Messages[3].Content)
 
 	// Test case 2: Request has only user message (no system message)
 	req2 := &model.Request{
@@ -300,12 +304,14 @@ func TestProcessRequest_SessionSummary_MergeWithSystemMessages(t *testing.T) {
 	p2 := NewContentRequestProcessor(WithAddSessionSummary(true))
 	p2.ProcessRequest(context.Background(), inv2, req2, nil)
 
-	// Should have 2 messages: new system, user
+	// Should have 3 messages: summary system, user, current request
 	require.Equal(t, 3, len(req2.Messages))
 	require.Equal(t, model.RoleSystem, req2.Messages[0].Role)
 	require.Equal(t, "Session summary content", req2.Messages[0].Content)
 	require.Equal(t, model.RoleUser, req2.Messages[1].Role)
 	require.Equal(t, "user question", req2.Messages[1].Content)
+	require.Equal(t, model.RoleUser, req2.Messages[2].Role)
+	require.Equal(t, "current request", req2.Messages[2].Content)
 
 	// Test case 3: Request has multiple system messages
 	req3 := &model.Request{
@@ -326,12 +332,79 @@ func TestProcessRequest_SessionSummary_MergeWithSystemMessages(t *testing.T) {
 	p3 := NewContentRequestProcessor(WithAddSessionSummary(true))
 	p3.ProcessRequest(context.Background(), inv3, req3, nil)
 
-	// Should have 2 messages: merged system (system1 + system2 + summary), user
-	require.Equal(t, 4, len(req3.Messages))
+	// Should have 5 messages: system1, summary system, system2, user, current request
+	require.Equal(t, 5, len(req3.Messages))
 	require.Equal(t, model.RoleSystem, req3.Messages[0].Role)
-	require.Equal(t, "system 1\n\nSession summary content", req3.Messages[0].Content)
-	require.Equal(t, model.RoleUser, req3.Messages[2].Role)
-	require.Equal(t, "user question", req3.Messages[2].Content)
+	require.Equal(t, "system 1", req3.Messages[0].Content)
+	require.Equal(t, model.RoleSystem, req3.Messages[1].Role)
+	require.Equal(t, "Session summary content", req3.Messages[1].Content)
+	require.Equal(t, model.RoleSystem, req3.Messages[2].Role)
+	require.Equal(t, "system 2", req3.Messages[2].Content)
+	require.Equal(t, model.RoleUser, req3.Messages[3].Role)
+	require.Equal(t, "user question", req3.Messages[3].Content)
+	require.Equal(t, model.RoleUser, req3.Messages[4].Role)
+	require.Equal(t, "current request", req3.Messages[4].Content)
+}
+
+// Test additional edge cases for session summary insertion.
+func TestProcessRequest_SessionSummary_EdgeCases(t *testing.T) {
+	// Create session with summary
+	sess := &session.Session{
+		Summaries: map[string]*session.Summary{
+			"test-agent": {
+				Summary:   "Session summary content",
+				UpdatedAt: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+
+	// Test case 1: Empty request messages
+	req1 := &model.Request{
+		Messages: []model.Message{},
+	}
+
+	inv1 := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationEventFilterKey("test-agent"),
+		agent.WithInvocationMessage(model.NewUserMessage("current request")),
+	)
+	inv1.AgentName = "test-agent"
+
+	p1 := NewContentRequestProcessor(WithAddSessionSummary(true))
+	p1.ProcessRequest(context.Background(), inv1, req1, nil)
+
+	// Should have 2 messages: summary system, current request
+	require.Equal(t, 2, len(req1.Messages))
+	require.Equal(t, model.RoleSystem, req1.Messages[0].Role)
+	require.Equal(t, "Session summary content", req1.Messages[0].Content)
+	require.Equal(t, model.RoleUser, req1.Messages[1].Role)
+	require.Equal(t, "current request", req1.Messages[1].Content)
+
+	// Test case 2: Only system messages
+	req2 := &model.Request{
+		Messages: []model.Message{
+			model.NewSystemMessage("system prompt"),
+		},
+	}
+
+	inv2 := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationEventFilterKey("test-agent"),
+		agent.WithInvocationMessage(model.NewUserMessage("current request")),
+	)
+	inv2.AgentName = "test-agent"
+
+	p2 := NewContentRequestProcessor(WithAddSessionSummary(true))
+	p2.ProcessRequest(context.Background(), inv2, req2, nil)
+
+	// Should have 3 messages: system, summary system, current request
+	require.Equal(t, 3, len(req2.Messages))
+	require.Equal(t, model.RoleSystem, req2.Messages[0].Role)
+	require.Equal(t, "system prompt", req2.Messages[0].Content)
+	require.Equal(t, model.RoleSystem, req2.Messages[1].Role)
+	require.Equal(t, "Session summary content", req2.Messages[1].Content)
+	require.Equal(t, model.RoleUser, req2.Messages[2].Role)
+	require.Equal(t, "current request", req2.Messages[2].Content)
 }
 
 func newSessionEventWithBranch(author, filterKey, branch string, msg model.Message) event.Event {


### PR DESCRIPTION
- Clarified that session summaries are inserted as separate system messages after the first existing system message.
- Updated related documentation in both English and Chinese to reflect this change.
- Modified tests to ensure correct behavior of session summary insertion in various scenarios, including edge cases.