### PR TITLE
internal/state/state_injection: support placeholder replacement with invocation isolation

### DIFF
--- a/docs/mkdocs/en/agent.md
+++ b/docs/mkdocs/en/agent.md
@@ -95,6 +95,7 @@ LLMAgent automatically injects session state into `Instruction` and the optional
 - `{key}`: Replace with the string value of `session.State["key"]`
 - `{key?}`: Optional; if missing, replaced with an empty string
 - `{user:subkey}` / `{app:subkey}` / `{temp:subkey}`: Use user/app/temp scoped keys (session services merge app/user state into session with these prefixes)
+- `{invocation:subkey}:` Replaces with the value of fmt.Sprintf("%+v", `invocation.state["subkey"]`). (The state can be set via invocation.SetState(k, v))
 
 Notes:
 
@@ -112,6 +113,9 @@ llm := llmagent.New(
     "User interests: {user:topics?}. App banner: {app:banner?}.",
   ),
 )
+
+inv := agent.NewInvoction()
+inv.SetState("case", "case-1")
 
 // Initialize session state (Runner + SessionService)
 _ = sessionService.UpdateUserState(ctx, session.UserKey{AppName: app, UserID: user}, session.StateMap{

--- a/docs/mkdocs/zh/agent.md
+++ b/docs/mkdocs/zh/agent.md
@@ -79,6 +79,7 @@ LLMAgent 会自动在 `Instruction` 和可选的 `SystemPrompt` 中注入会话�
 - `{key}`：替换为 `session.State["key"]` 的字符串值
 - `{key?}`：可选；如果不存在，替换为空字符串
 - `{user:subkey}` / `{app:subkey}` / `{temp:subkey}`：访问用户/应用/临时命名空间（SessionService 会把 app/user 作用域的状态合并进 session，并带上前缀）
+- `{invocation:subkey}` ：替换为fmt.Sprintf("%+v",`invocation.state["subkey"]`)的值，（可以通过invocation.SetState(k,v)来设置）。
 
 注意：
 
@@ -93,9 +94,13 @@ llm := llmagent.New(
   llmagent.WithModel(modelInstance),
   llmagent.WithInstruction(
     "You are a research assistant. Focus: {research_topics}. " +
-    "User interests: {user:topics?}. App banner: {app:banner?}.",
+    "User interests: {user:topics?}. App banner: {app:banner?}." +
+    "Invocation case: {invocation:case}",
   ),
 )
+
+inv := agent.NewInvoction()
+inv.SetState("case", "case-1")
 
 // 通过 SessionService 初始化状态（用户态/应用态 + 会话本地键）
 _ = sessionService.UpdateUserState(ctx, session.UserKey{AppName: app, UserID: user}, session.StateMap{

--- a/internal/state/state_injection_test.go
+++ b/internal/state/state_injection_test.go
@@ -24,6 +24,7 @@ func TestInjectSessionState(t *testing.T) {
 		state       map[string]any
 		expected    string
 		expectError bool
+		invState    map[string]any
 	}{
 		{
 			name:        "empty template",
@@ -116,6 +117,13 @@ func TestInjectSessionState(t *testing.T) {
 			expected:    "Enabled: true, Active: false",
 			expectError: false,
 		},
+		{
+			name:        "invocation values",
+			template:    "Enabled: {invocation:enabled}, name: {invocation:name}",
+			invState:    map[string]any{"enabled": true, "name": "name-123"},
+			expected:    "Enabled: true, name: name-123",
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -133,6 +141,11 @@ func TestInjectSessionState(t *testing.T) {
 				Session: &session.Session{
 					State: stateMap,
 				},
+			}
+			if tt.invState != nil {
+				for k, v := range tt.invState {
+					invocation.SetState(k, v)
+				}
 			}
 
 			result, err := InjectSessionState(tt.template, invocation)


### PR DESCRIPTION
It is necessary to support invocation-level placeholder substitution, as variable values at the task level need to be isolated when the same llmagent is executed by multiple parallel tasks.