### PR TITLE
{docs, examples}: fix WithToolFilterFunc mistakenly written as WithToolFilter

### DIFF
--- a/docs/mkdocs/en/tool.md
+++ b/docs/mkdocs/en/tool.md
@@ -256,7 +256,7 @@ mcpToolSet := mcp.NewMCPToolSet(
         Args:      []string{"run", "./stdio_server/main.go"},
         Timeout:   10 * time.Second,
     },
-    mcp.WithToolFilter(mcp.NewIncludeFilter("echo", "add")), // Optional: tool filter.
+    mcp.WithToolFilterFunc(tool.NewIncludeToolNamesFilter("echo", "add")), // Optional: tool filter.
 )
 
 // (Optional but recommended) Explicitly initialize MCP: connect + initialize + list tools.

--- a/docs/mkdocs/zh/tool.md
+++ b/docs/mkdocs/zh/tool.md
@@ -255,7 +255,7 @@ mcpToolSet := mcp.NewMCPToolSet(
         Args:      []string{"run", "./stdio_server/main.go"},
         Timeout:   10 * time.Second,
     },
-    mcp.WithToolFilter(mcp.NewIncludeFilter("echo", "add")), // 可选：工具过滤
+    mcp.WithToolFilterFunc(tool.NewIncludeToolNamesFilter("echo", "add")), // 可选：工具过滤
 )
 
 // （可选但推荐）显式初始化 MCP：建立连接 + 初始化会话 + 列工具

--- a/examples/mcptool/README.md
+++ b/examples/mcptool/README.md
@@ -113,7 +113,7 @@ stdioToolSet := mcp.NewMCPToolSet(
         Args:      []string{"run", "./stdioserver/main.go"},
         Timeout:   10 * time.Second,
     },
-    mcp.WithToolFilter(mcp.NewIncludeFilter("echo", "add")),
+    mcp.WithToolFilterFunc(tool.NewIncludeToolNamesFilter("echo", "add")),
 )
 ```
 
@@ -132,7 +132,7 @@ sseToolSet := mcp.NewMCPToolSet(
             "User-Agent": "trpc-agent-go/1.0.0",
         },
     },
-    mcp.WithToolFilter(mcp.NewIncludeFilter("sse_recipe", "sse_health_tip")),
+    mcp.WithToolFilterFunc(tool.NewIncludeToolNamesFilter("sse_recipe", "sse_health_tip")),
     mcp.WithMCPOptions(
         // WithRetry: Custom retry configuration for fine-tuned control
         // Retry sequence: 1s -> 1.5s -> 2.25s -> 3.375s -> 5.0625s (capped at 15s)
@@ -162,7 +162,7 @@ streamableToolSet := mcp.NewMCPToolSet(
         ServerURL: "http://localhost:3000/mcp",
         Timeout:   10 * time.Second,
     },
-    mcp.WithToolFilter(mcp.NewIncludeFilter("get_weather", "get_news")),
+    mcp.WithToolFilterFunc(tool.NewIncludeToolNamesFilter("get_weather", "get_news")),
     mcp.WithMCPOptions(
         // WithSimpleRetry(3): Uses default settings with 3 retry attempts
         // - MaxRetries: 3 (range: 0-10)


### PR DESCRIPTION
related issue: https://github.com/trpc-group/trpc-agent-go/pull/918