### PR TITLE
docs: clarify sub-agent isolation for multi-turn tools

### DIFF
--- a/docs/mkdocs/en/graph.md
+++ b/docs/mkdocs/en/graph.md
@@ -666,8 +666,14 @@ func preparePromptNode(ctx context.Context, state graph.State) (any, error) {
 - `RemoveAllMessages{}` is a special `MessageOp` that `MessageReducer` recognizes
   and uses to clear the message list
 - Must set `RemoveAllMessages{}` **before** setting `StateKeyUserInput`
-- `WithSubgraphIsolatedMessages(true)` only works for `AddSubgraphNode`, not for
-  `AddLLMNode`; use `RemoveAllMessages` to isolate messages between LLM nodes
+- `WithSubgraphIsolatedMessages(true)` only works for `AddSubgraphNode` (agent
+  nodes), not for `AddLLMNode`; use `RemoveAllMessages` to isolate messages
+  between LLM nodes
+- For agent nodes, `WithSubgraphIsolatedMessages(true)` disables seeding
+  session history into the sub‑agent’s request. This also hides tool call
+  results, so it breaks multi‑turn tool calling. Use it only for single‑turn
+  sub‑agents; otherwise, isolate via sub‑agent message filtering (see “Agent
+  nodes: isolation vs multi‑turn tool calls”).
 
 ### 3. GraphAgent Configuration Options
 
@@ -770,6 +776,33 @@ stateGraph.AddAgentNode("assistant",
 
 > The agent node uses its ID for the lookup, so keep `AddAgentNode("assistant")`
 > aligned with `subAgent.Info().Name == "assistant"`.
+
+#### Agent nodes: isolation vs multi‑turn tool calls
+
+Tool calling is usually multi‑turn within a single run: the model returns a
+tool call, the framework executes the tool, then the next model request must
+include the tool result (a `role=tool` message) so the model can continue.
+
+`WithSubgraphIsolatedMessages(true)` is a **strong isolation switch**: it
+prevents the sub‑agent from reading any session history when building the next
+model request (internally it sets `include_contents="none"` for the sub‑agent).
+This makes the sub‑agent “black‑box” (it only sees the current `user_input`),
+but it also means the sub‑agent will not see tool results, so it cannot do
+multi‑turn tool calling.
+
+If a sub‑agent needs tools **and** needs to continue after tools return:
+
+- Do **not** enable `WithSubgraphIsolatedMessages(true)` on that agent node.
+- Instead, keep session seeding enabled and isolate the sub‑agent by filtering
+  its message history to only its own invocation. For `LLMAgent`, use:
+  `llmagent.WithMessageFilterMode(llmagent.IsolatedInvocation)`.
+
+Symptoms of the misconfiguration:
+
+- The second model request looks the same as the first one (tool results never
+  appear in the prompt).
+- The agent repeats the first tool call or loops because it never “sees” the
+  tool output.
 
 ### 4. Conditional Routing
 
@@ -2481,7 +2514,8 @@ sg.AddAgentNode("orchestrator",
         }
         return nil, nil
     }),
-    // Optional: isolate child sub‑agent from session contents
+    // Optional: isolate child sub‑agent from session contents.
+    // Use only when the sub‑agent is single‑turn (no multi‑turn tool calls).
     graph.WithSubgraphIsolatedMessages(true),
 )
 ```
@@ -2492,7 +2526,9 @@ sg.AddAgentNode("orchestrator",
 // Declarative option that automatically maps last_response → user_input
 sg.AddAgentNode("orchestrator",
     graph.WithSubgraphInputFromLastResponse(),
-    graph.WithSubgraphIsolatedMessages(true), // optional: isolate for true "pass only results"
+    // Optional: isolate for true "pass only results".
+    // Use only when the sub‑agent is single‑turn (no multi‑turn tool calls).
+    graph.WithSubgraphIsolatedMessages(true),
 )
 ```
 


### PR DESCRIPTION

- Added a new EN/ZH section explaining why `WithSubgraphIsolatedMessages(true)` breaks multi-turn tool calls for sub-agents (tool results are not seeded into the next model turn).
- Updated the "pass only results" examples to warn when isolation is safe and when to prefer sub-agent message filtering (`llmagent.IsolatedInvocation`).


