### PR TITLE
.github: skip fork repository tag validation

### DIFF
--- a/.github/workflows/prc.yml
+++ b/.github/workflows/prc.yml
@@ -248,13 +248,14 @@ jobs:
         run: pip install -r mkdocs/assets/requirements.txt
       - name: Build documentation
         run: mkdocs build --strict
-  go-mod-version-check:
-    name: go.mod version check
+  check-go-mod-version:
+    name: check go.mod version
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          fetch-tags: true
       - uses: actions/setup-go@v5
         with:
           go-version: "1.21"


### PR DESCRIPTION
- In forked repo, the tag validation will fail (maybe net error?). Skip when it is unable to fetch tags.
- before: https://github.com/Rememorio/trpc-agent-go/actions/runs/20480014141/job/58851647512
- after: https://github.com/Rememorio/trpc-agent-go/actions/runs/20480930498/job/58854093206