### PR TITLE
telemetry: skip token usage attributes for InvokeAgent spans

### DIFF
--- a/telemetry/langfuse/exporter.go
+++ b/telemetry/langfuse/exporter.go
@@ -145,8 +145,6 @@ func transformInvokeAgent(span *tracepb.Span) {
 					},
 				})
 			}
-			// Skip this attribute (delete it)
-		case itelemetry.KeyGenAIUsageInputTokens, itelemetry.KeyGenAIUsageOutputTokens:
 			// Skip token usage attributes for InvokeAgent observations.
 			//
 			// Reason: the top-level span represents the whole trace, and Langfuse aggregates token
@@ -154,6 +152,7 @@ func transformInvokeAgent(span *tracepb.Span) {
 			// InvokeAgent spans (to support Galileo); previously only Chat spans had token usage.
 			// Keeping token attributes on InvokeAgent would make Langfuse double count tokens
 			// compared to the old behavior (Chat-only token accounting).
+		case itelemetry.KeyGenAIUsageInputTokens, itelemetry.KeyGenAIUsageOutputTokens:
 		default:
 			newAttributes = append(newAttributes, attr)
 		}

--- a/telemetry/langfuse/exporter_test.go
+++ b/telemetry/langfuse/exporter_test.go
@@ -232,6 +232,18 @@ func TestTransformInvokeAgent(t *testing.T) {
 				},
 			},
 			{
+				Key: itelemetry.KeyGenAIUsageInputTokens,
+				Value: &commonpb.AnyValue{
+					Value: &commonpb.AnyValue_IntValue{IntValue: 123},
+				},
+			},
+			{
+				Key: itelemetry.KeyGenAIUsageOutputTokens,
+				Value: &commonpb.AnyValue{
+					Value: &commonpb.AnyValue_IntValue{IntValue: 456},
+				},
+			},
+			{
 				Key: "other.attribute",
 				Value: &commonpb.AnyValue{
 					Value: &commonpb.AnyValue_StringValue{StringValue: "keep-this"},
@@ -253,6 +265,12 @@ func TestTransformInvokeAgent(t *testing.T) {
 	assert.Equal(t, `[{"role":"user","content":"hi"}]`, attrMap[observationInput])
 	assert.Equal(t, `[{"role":"assistant","content":"hello"}]`, attrMap[observationOutput])
 	assert.Equal(t, "keep-this", attrMap["other.attribute"])
+
+	// Token usage attributes should be filtered out for InvokeAgent observations.
+	for _, attr := range span.Attributes {
+		assert.NotEqual(t, itelemetry.KeyGenAIUsageInputTokens, attr.Key)
+		assert.NotEqual(t, itelemetry.KeyGenAIUsageOutputTokens, attr.Key)
+	}
 }
 
 func TestTransformCallLLM(t *testing.T) {


### PR DESCRIPTION
Updated the transformInvokeAgent function to exclude token usage attributes (input and output tokens) from InvokeAgent observations. This change prevents double counting of tokens in Langfuse, aligning with the previous behavior where only Chat spans accounted for token usage.