### PR TITLE
tool: add ToolCallID to Before/AfterToolArgs

### DIFF
--- a/graph/state_graph.go
+++ b/graph/state_graph.go
@@ -1685,6 +1685,7 @@ func runBeforeToolPluginCallbacks(
 	}
 
 	args := &tool.BeforeToolArgs{
+		ToolCallID:  toolCall.ID,
 		ToolName:    toolCall.Function.Name,
 		Declaration: decl,
 		Arguments:   toolCall.Function.Arguments,
@@ -1718,6 +1719,7 @@ func runBeforeToolCallbacks(
 	}
 
 	args := &tool.BeforeToolArgs{
+		ToolCallID:  toolCall.ID,
 		ToolName:    toolCall.Function.Name,
 		Declaration: decl,
 		Arguments:   toolCall.Function.Arguments,
@@ -1769,6 +1771,7 @@ func runAfterToolPluginCallbacks(
 	}
 
 	args := &tool.AfterToolArgs{
+		ToolCallID:  toolCall.ID,
 		ToolName:    toolCall.Function.Name,
 		Declaration: decl,
 		Arguments:   toolCall.Function.Arguments,
@@ -1802,6 +1805,7 @@ func runAfterToolCallbacks(
 	}
 
 	args := &tool.AfterToolArgs{
+		ToolCallID:  toolCall.ID,
 		ToolName:    toolCall.Function.Name,
 		Declaration: decl,
 		Arguments:   toolCall.Function.Arguments,

--- a/internal/flow/processor/functioncall.go
+++ b/internal/flow/processor/functioncall.go
@@ -973,6 +973,7 @@ func (p *FunctionCallResponseProcessor) runBeforeToolPluginCallbacks(
 	}
 
 	args := &tool.BeforeToolArgs{
+		ToolCallID:  toolCall.ID,
 		ToolName:    toolCall.Function.Name,
 		Declaration: toolDeclaration,
 		Arguments:   toolCall.Function.Arguments,
@@ -1010,6 +1011,7 @@ func (p *FunctionCallResponseProcessor) runBeforeToolCallbacks(
 	}
 
 	args := &tool.BeforeToolArgs{
+		ToolCallID:  toolCall.ID,
 		ToolName:    toolCall.Function.Name,
 		Declaration: toolDeclaration,
 		Arguments:   toolCall.Function.Arguments,
@@ -1056,6 +1058,7 @@ func (p *FunctionCallResponseProcessor) runAfterToolPluginCallbacks(
 	}
 
 	args := &tool.AfterToolArgs{
+		ToolCallID:  toolCall.ID,
 		ToolName:    toolCall.Function.Name,
 		Declaration: toolDeclaration,
 		Arguments:   toolCall.Function.Arguments,
@@ -1094,6 +1097,7 @@ func (p *FunctionCallResponseProcessor) runAfterToolCallbacks(
 	}
 
 	args := &tool.AfterToolArgs{
+		ToolCallID:  toolCall.ID,
 		ToolName:    toolCall.Function.Name,
 		Declaration: toolDeclaration,
 		Arguments:   toolCall.Function.Arguments,

--- a/tool/callbacks.go
+++ b/tool/callbacks.go
@@ -42,6 +42,8 @@ type AfterToolCallback = func(
 
 // BeforeToolArgs contains all parameters for before tool callback.
 type BeforeToolArgs struct {
+	// ToolCallID is the ID of the tool call issued by the model.
+	ToolCallID string
 	// ToolName is the name of the tool.
 	ToolName string
 	// Declaration is the tool declaration.
@@ -75,6 +77,8 @@ type BeforeToolCallbackStructured = func(
 
 // AfterToolArgs contains all parameters for after tool callback.
 type AfterToolArgs struct {
+	// ToolCallID is the ID of the tool call issued by the model.
+	ToolCallID string
 	// ToolName is the name of the tool.
 	ToolName string
 	// Declaration is the tool declaration.


### PR DESCRIPTION
- Introduced ToolCallID field to BeforeToolArgs and AfterToolArgs structures to track tool call identifiers.
- Updated relevant callback functions to populate ToolCallID during execution.
- Added unit tests to verify ToolCallID handling in before and after tool callbacks, ensuring correct capture and propagation of tool call identifiers.