### PR TITLE
{internal/flow/processor, examples}: aggregate summaries with matching prefix and rewrite filterKey example

### DIFF
--- a/examples/summary/filterkey/tools.go
+++ b/examples/summary/filterkey/tools.go
@@ -12,9 +12,6 @@ import (
 	"context"
 	"strings"
 	"time"
-
-	"trpc.group/trpc-go/trpc-agent-go/event"
-	"trpc.group/trpc-go/trpc-agent-go/session"
 )
 
 // calculate performs basic mathematical operations.
@@ -108,22 +105,3 @@ type timeResult struct {
 
 // Helper functions for creating pointers to primitive types.
 func intPtr(i int) *int { return &i }
-
-// extractContent extracts content from event for aggregation.
-func extractContent(evt *event.Event) string {
-	if evt == nil || evt.Response == nil || len(evt.Response.Choices) == 0 {
-		return ""
-	}
-	return evt.Response.Choices[0].Message.Content
-}
-
-// getSummaryFromSession returns a structured summary from the session if present.
-func getSummaryFromSession(sess *session.Session, filterKey string) (string, bool) {
-	if sess == nil || sess.Summaries == nil {
-		return "", false
-	}
-	if s, ok := sess.Summaries[filterKey]; ok && s != nil && s.Summary != "" {
-		return s.Summary, true
-	}
-	return "", false
-}

--- a/internal/flow/processor/content.go
+++ b/internal/flow/processor/content.go
@@ -24,6 +24,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/graph"
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
 )
 
 // Content inclusion options.
@@ -297,16 +298,57 @@ func (p *ContentRequestProcessor) getSessionSummaryMessage(inv *agent.Invocation
 		return nil, time.Time{}
 	}
 	filter := inv.GetEventFilterKey()
-	// For IncludeContentsAll, prefer the full-session summary under empty filter key.
+	// For BranchFilterModeAll, prefer the full-session summary under empty filter key.
 	if p.BranchFilterMode == BranchFilterModeAll {
 		filter = ""
 	}
+
+	// Try exact match first.
 	sum := inv.Session.Summaries[filter]
-	if sum == nil || sum.Summary == "" {
-		return nil, time.Time{}
+	if sum != nil && sum.Summary != "" {
+		content := formatSummaryContent(sum.Summary)
+		return &model.Message{Role: model.RoleSystem, Content: content}, sum.UpdatedAt
 	}
-	content := formatSummaryContent(sum.Summary)
-	return &model.Message{Role: model.RoleSystem, Content: content}, sum.UpdatedAt
+
+	// For BranchFilterModePrefix, aggregate summaries with matching prefix.
+	// This handles the case where events have custom filterKeys (e.g., "app/user-messages")
+	// but the invocation's eventFilterKey is the app prefix (e.g., "app").
+	if p.BranchFilterMode == BranchFilterModePrefix && filter != "" {
+		summaryText, updatedAt := p.aggregatePrefixSummaries(inv.Session.Summaries, filter)
+		if summaryText != "" {
+			content := formatSummaryContent(summaryText)
+			return &model.Message{Role: model.RoleSystem, Content: content}, updatedAt
+		}
+	}
+	return nil, time.Time{}
+}
+
+// aggregatePrefixSummaries aggregates all summaries whose keys have the given prefix.
+func (p *ContentRequestProcessor) aggregatePrefixSummaries(
+	summaries map[string]*session.Summary,
+	prefix string,
+) (string, time.Time) {
+	var parts []string
+	var latestTime time.Time
+	filterPrefix := prefix + agent.EventFilterKeyDelimiter
+
+	for key, sum := range summaries {
+		if sum == nil || sum.Summary == "" {
+			continue
+		}
+		// Check if key matches prefix (key starts with "prefix/" or key equals prefix).
+		keyWithDelim := key + agent.EventFilterKeyDelimiter
+		if key == prefix || strings.HasPrefix(keyWithDelim, filterPrefix) {
+			parts = append(parts, sum.Summary)
+			if sum.UpdatedAt.After(latestTime) {
+				latestTime = sum.UpdatedAt
+			}
+		}
+	}
+	if len(parts) == 0 {
+		return "", time.Time{}
+	}
+	return strings.Join(parts, "\n\n"), latestTime
 }
 
 // formatSummaryContent formats summary content with tags and notes.


### PR DESCRIPTION
- Updated the main example to demonstrate the use of AppendEventHook for setting custom filterKeys, allowing for separate summaries per category.
- Added commands for switching filterKeys and displaying summaries based on the current filterKey.
- Improved README documentation to clarify key concepts and usage instructions.
- Refactored code for better organization and clarity, including the addition of debug mode for request message logging.