### PR TITLE
tool: preserve ToolCallID across context clone

### DIFF
--- a/tool/agent/agent_tool.go
+++ b/tool/agent/agent_tool.go
@@ -448,7 +448,18 @@ func (at *Tool) collectResponse(evCh <-chan *event.Event) (string, error) {
 func (at *Tool) StreamableCall(ctx context.Context, jsonArgs []byte) (*tool.StreamReader, error) {
 	stream := tool.NewStream(64)
 
+	toolCallID, hasToolCallID := tool.ToolCallIDFromContext(ctx)
+
 	runCtx := agent.CloneContext(ctx)
+	if hasToolCallID && toolCallID != "" {
+		if _, ok := tool.ToolCallIDFromContext(runCtx); !ok {
+			runCtx = context.WithValue(
+				runCtx,
+				tool.ContextKeyToolCallID{},
+				toolCallID,
+			)
+		}
+	}
 	go func(ctx context.Context) {
 		defer stream.Writer.Close()
 


### PR DESCRIPTION
Preserve tool call ID in AgentTool StreamableCall after goroutine context cloning, so completion deferral and session persistence semantics stay correct even when a context cloner drops context values.

- Restore ToolCallID in cloned context when missing
- Add regression test for cloner dropping ToolCallID