### PR TITLE
{docs, examples}: clarify LANGFUSE_HOST format for Langfuse

### DIFF
--- a/docs/mkdocs/en/observability.md
+++ b/docs/mkdocs/en/observability.md
@@ -27,8 +27,8 @@ Refer to the Langfuse self-hosting guide for local or cloud deployment. For a qu
 ```bash
 export LANGFUSE_PUBLIC_KEY="your-public-key"
 export LANGFUSE_SECRET_KEY="your-secret-key"
-export LANGFUSE_HOST="your-langfuse-host"
-export LANGFUSE_INSECURE="true" # for insecure connections (development only)
+export LANGFUSE_HOST="your-langfuse-host" # In host:port format (no scheme), e.g. "cloud.langfuse.com:443" or "localhost:3000".
+export LANGFUSE_INSECURE="true" # Use "true" for local http (development only).
 ```
 
 ```go
@@ -53,6 +53,8 @@ func main() {
 ```
 
 See the complete example at [examples/telemetry/langfuse](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/telemetry/langfuse).
+
+Note: `LANGFUSE_HOST` is passed to OpenTelemetry `otlptracehttp.WithEndpoint`, so it must not include `http://` or `https://`. The scheme is controlled by `LANGFUSE_INSECURE`, and the path is fixed to `/api/public/otel/v1/traces`.
 
 Run the example:
 

--- a/docs/mkdocs/zh/observability.md
+++ b/docs/mkdocs/zh/observability.md
@@ -29,7 +29,7 @@ Langfuse 是专为 LLM 应用设计的可观测平台，支持通过 OpenTelemet
 ```bash
 export LANGFUSE_PUBLIC_KEY="your-public-key"
 export LANGFUSE_SECRET_KEY="your-secret-key"
-export LANGFUSE_HOST="your-langfuse-host"
+export LANGFUSE_HOST="your-langfuse-host" # 以 host:port 形式填写（不带 http:// 协议头），例如 "cloud.langfuse.com:443" 或 "localhost:3000".
 export LANGFUSE_INSECURE="true" # 用于不安全连接（仅限开发环境）
 ```
 
@@ -55,6 +55,8 @@ func main() {
 ```
 
 完整示例可参考 [examples/telemetry/langfuse](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/telemetry/langfuse)。
+
+注意：`LANGFUSE_HOST` 会直接传给 OpenTelemetry 的 `otlptracehttp.WithEndpoint`，因此不能包含 `http://` 或 `https://`。协议由 `LANGFUSE_INSECURE` 控制，路径固定为 `/api/public/otel/v1/traces`。
 
 运行示例：
 

--- a/examples/agui/server/langfuse/README.md
+++ b/examples/agui/server/langfuse/README.md
@@ -13,9 +13,11 @@ Langfuse offers multiple deployment options. See the [official self-hosting guid
 ```bash
 export LANGFUSE_PUBLIC_KEY="your-public-key"
 export LANGFUSE_SECRET_KEY="your-secret-key"
-export LANGFUSE_HOST="localhost:3000"          # Langfuse host in host:port format (no http://)
-export LANGFUSE_INSECURE="true"                # keep false in production
+export LANGFUSE_HOST="localhost:3000"          # In host:port format (no scheme), e.g. "cloud.langfuse.com:443" or "localhost:3000".
+export LANGFUSE_INSECURE="true"                # Use "true" for local http (development only).
 ```
+
+Note: `LANGFUSE_HOST` is passed to OpenTelemetry `otlptracehttp.WithEndpoint`, so it must not include `http://` or `https://`. The scheme is controlled by `LANGFUSE_INSECURE`, and the path is fixed to `/api/public/otel/v1/traces`.
 
 ## Run
 

--- a/examples/telemetry/langfuse/README.md
+++ b/examples/telemetry/langfuse/README.md
@@ -14,9 +14,11 @@ For this example, you can quickly get started by [deploying Langfuse locally or 
 ```bash
 export LANGFUSE_PUBLIC_KEY="your-public-key"
 export LANGFUSE_SECRET_KEY="your-secret-key"
-export LANGFUSE_HOST="your-langfuse-host"
-export LANGFUSE_INSECURE="true" # for insecure connections (development only)
+export LANGFUSE_HOST="your-langfuse-host" # In host:port format (no scheme), e.g. "cloud.langfuse.com:443" or "localhost:3000".
+export LANGFUSE_INSECURE="true" # Use "true" for local http (development only).
 ```
+
+Note: `LANGFUSE_HOST` is passed to OpenTelemetry `otlptracehttp.WithEndpoint`, so it must not include `http://` or `https://`. The scheme is controlled by `LANGFUSE_INSECURE`, and the path is fixed to `/api/public/otel/v1/traces`.
 
 ```go
 import (
@@ -33,7 +35,7 @@ func main() {
 		log.Fatalf("Failed to start trace telemetry: %v", err)
 	}
 	defer func() {
-		if err := clean(); err != nil {
+		if err := clean(context.Background()); err != nil {
 			log.Printf("Failed to clean up trace telemetry: %v", err)
 		}
 	}()


### PR DESCRIPTION
Clarifies that LANGFUSE_HOST should be provided in host:port format without a scheme across the Langfuse telemetry example, the AG-UI Langfuse example, and the observability docs. Adds an explanation that the value is passed to OpenTelemetry otlptracehttp.WithEndpoint (scheme controlled by LANGFUSE_INSECURE, path fixed to /api/public/otel/v1/traces) and aligns the telemetry example README cleanup snippet with the Start signature.