### PR TITLE
skill: make skills tooling guidance configurable

### DIFF
--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -240,8 +240,18 @@ func buildRequestProcessorsWithAgent(a *LLMAgent, options *Options) []flow.Reque
 	// sees available skills (names/descriptions) and any loaded
 	// SKILL.md/doc texts before deciding on tool calls.
 	if options.skillsRepository != nil {
+		var skillsOpts []processor.SkillsRequestProcessorOption
+		if options.skillsToolingGuidance != nil {
+			skillsOpts = append(
+				skillsOpts,
+				processor.WithSkillsToolingGuidance(
+					*options.skillsToolingGuidance,
+				),
+			)
+		}
 		skillsProcessor := processor.NewSkillsRequestProcessor(
 			options.skillsRepository,
+			skillsOpts...,
 		)
 		requestProcessors = append(requestProcessors, skillsProcessor)
 	}

--- a/agent/llmagent/llm_agent_skill_test.go
+++ b/agent/llmagent/llm_agent_skill_test.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -29,6 +30,9 @@ import (
 
 const (
 	testSkillName = "echoer"
+
+	skillsOverviewHeader        = "Available skills:"
+	skillsToolingGuidanceHeader = "Tooling and workspace guidance:"
 )
 
 // createTestSkill makes a minimal skill folder with SKILL.md.
@@ -218,6 +222,65 @@ func TestLLMAgent_SkillRun_AllowedCommands_Enforced(t *testing.T) {
 	require.NoError(t, err)
 	_, err = tl.(tool.CallableTool).Call(context.Background(), blockB)
 	require.Error(t, err)
+}
+
+func TestLLMAgent_WithSkillsToolingGuidance_Disabled(t *testing.T) {
+	root := createTestSkill(t)
+	repo, err := skill.NewFSRepository(root)
+	require.NoError(t, err)
+
+	makeReq := func(opts *Options) *model.Request {
+		t.Helper()
+		procs := buildRequestProcessors("tester", opts)
+		inv := &agent.Invocation{
+			InvocationID: "inv1",
+			AgentName:    "tester",
+			Message:      model.NewUserMessage("u"),
+			Session:      &session.Session{},
+		}
+		req := &model.Request{}
+		for _, p := range procs {
+			p.ProcessRequest(context.Background(), inv, req, nil)
+		}
+		return req
+	}
+
+	{
+		opts := &Options{}
+		WithSkills(repo)(opts)
+		req := makeReq(opts)
+		var sys string
+		for _, msg := range req.Messages {
+			if msg.Role != model.RoleSystem {
+				continue
+			}
+			if strings.Contains(msg.Content, skillsOverviewHeader) {
+				sys = msg.Content
+				break
+			}
+		}
+		require.NotEmpty(t, sys)
+		require.Contains(t, sys, skillsToolingGuidanceHeader)
+	}
+
+	{
+		opts := &Options{}
+		WithSkills(repo)(opts)
+		WithSkillsToolingGuidance("")(opts)
+		req := makeReq(opts)
+		var sys string
+		for _, msg := range req.Messages {
+			if msg.Role != model.RoleSystem {
+				continue
+			}
+			if strings.Contains(msg.Content, skillsOverviewHeader) {
+				sys = msg.Content
+				break
+			}
+		}
+		require.NotEmpty(t, sys)
+		require.NotContains(t, sys, skillsToolingGuidanceHeader)
+	}
 }
 
 func TestLLMAgent_SkillRun_DeniedCommands_Enforced(t *testing.T) {

--- a/agent/llmagent/option.go
+++ b/agent/llmagent/option.go
@@ -219,6 +219,8 @@ type Options struct {
 
 	// skillsRepository enables agent skills when non-nil.
 	skillsRepository skill.Repository
+	// skillsToolingGuidance overrides the built-in skills guidance block.
+	skillsToolingGuidance *string
 	// skillRunAllowedCommands restricts skill_run to allowlisted commands.
 	skillRunAllowedCommands []string
 	// skillRunDeniedCommands rejects denylisted commands for skill_run.
@@ -349,6 +351,22 @@ func WithRefreshToolSetsOnRun(refresh bool) Option {
 func WithSkills(repo skill.Repository) Option {
 	return func(opts *Options) {
 		opts.skillsRepository = repo
+	}
+}
+
+// WithSkillsToolingGuidance overrides the tooling/workspace guidance
+// block appended to the skills overview in the system message.
+//
+// Behavior:
+//   - Not configured: use the built-in default guidance.
+//   - Configured with empty string: omit the guidance block.
+//   - Configured with non-empty string: append the provided text.
+func WithSkillsToolingGuidance(
+	guidance string,
+) Option {
+	return func(opts *Options) {
+		text := guidance
+		opts.skillsToolingGuidance = &text
 	}
 }
 

--- a/docs/mkdocs/en/skill.md
+++ b/docs/mkdocs/en/skill.md
@@ -102,9 +102,12 @@ Key points:
 - Tools are auto‑registered with `WithSkills`: `skill_load`,
   `skill_select_docs`, `skill_list_docs`, and `skill_run` show up
   automatically; no manual wiring required.
-- Auto prompt guidance is injected in the system message so the model
-  learns to `skill_load` first, select docs with `skill_select_docs`
-  as needed, and then `skill_run` at the right time.
+- By default, the framework appends a small `Tooling and workspace guidance:`
+  block after the `Available skills:` list in the system message.
+  - Disable it (to save prompt tokens): `llmagent.WithSkillsToolingGuidance("")`.
+  - Or replace it with your own text: `llmagent.WithSkillsToolingGuidance("...")`.
+  - If you disable it, make sure your instruction tells the model when to use
+    `skill_load`, `skill_select_docs`, and `skill_run`.
   - Loader: [tool/skill/load.go](https://github.com/trpc-group/trpc-agent-go/blob/main/tool/skill/load.go)
   - Runner: [tool/skill/run.go](https://github.com/trpc-group/trpc-agent-go/blob/main/tool/skill/run.go)
 

--- a/docs/mkdocs/zh/skill.md
+++ b/docs/mkdocs/zh/skill.md
@@ -102,10 +102,12 @@ agent := llmagent.New(
 - 工具自动注册：开启 `WithSkills` 后，`skill_load`、
   `skill_select_docs`、`skill_list_docs` 与 `skill_run`
   会自动出现在工具列表中，无需手动添加。
-- 自动提示注入：框架会在系统消息中加入简洁的“工具使用指引”，
-  引导模型在合适时机先 `skill_load`，需要时用 `skill_select_docs`
-  选择文档，再 `skill_run`（参见源码
-  的指引文案拼接逻辑）。
+- 默认提示指引：框架会在系统消息里，在 `Available skills:` 列表后追加一段
+  `Tooling and workspace guidance:` 指引文本。
+  - 关闭该指引（减少提示词占用）：`llmagent.WithSkillsToolingGuidance("")`。
+  - 或用自定义文本替换：`llmagent.WithSkillsToolingGuidance("...")`。
+  - 如果你关闭它，请在自己的指令里说明何时使用 `skill_load`、
+    `skill_select_docs` 和 `skill_run`。
   - 加载器： [tool/skill/load.go](https://github.com/trpc-group/trpc-agent-go/blob/main/tool/skill/load.go)
   - 运行器： [tool/skill/run.go](https://github.com/trpc-group/trpc-agent-go/blob/main/tool/skill/run.go)
 

--- a/examples/skillrun/README.md
+++ b/examples/skillrun/README.md
@@ -36,6 +36,7 @@ tool calls and tool responses, and executes skill scripts via the
 | `-model`        | Name of the model to use           | `deepseek-chat`  |
 | `-stream`       | Stream responses                   | `true`           |
 | `-skills-root`  | Skills repository root directory   | `env or ./skills` |
+| `-skills-guidance` | Include built-in skills tooling/workspace guidance in the system message | `true` |
 | `-executor`     | Workspace executor: local|container | `local`          |
 | `-inputs-host`  | Host dir exposed as `inputs/` inside skill workspaces (local or container) | `` |
 | `-artifacts`    | Save files via artifact service     | `false`          |
@@ -49,6 +50,13 @@ cd examples/skillrun
 export OPENAI_API_KEY="your-api-key"
 # Optional: export SKILLS_ROOT to point at your skills repo
 go run .
+```
+
+To reduce system prompt size (for example, when you only need docs and
+won't run commands), disable the built-in guidance:
+
+```bash
+go run . -skills-guidance=false
 ```
 
 Workspace paths and env vars:


### PR DESCRIPTION
Adds llmagent.WithSkillsToolingGuidance(...) to disable or override the default 'Tooling and workspace guidance' block injected with the skills overview.

- Updates docs (EN/ZH) and the skillrun example
- Adds unit tests for default and disabled behavior