### PR TITLE
{agent, graph}: rerange option field orders and refactor to solve linter

### DIFF
--- a/agent/graphagent/option.go
+++ b/agent/graphagent/option.go
@@ -89,6 +89,9 @@ type Options struct {
 	// MaxHistoryRuns sets the maximum number of history messages when AddSessionSummary is false.
 	// When 0 (default), no limit is applied.
 	MaxHistoryRuns int
+	// summaryFormatter allows custom formatting of session summary content.
+	// When nil (default), uses default formatSummaryContent function.
+	summaryFormatter func(summary string) string
 
 	// MessageTimelineFilterMode is the message timeline filter mode.
 	messageTimelineFilterMode string
@@ -98,9 +101,6 @@ type Options struct {
 	// conversations. This is useful for models like DeepSeek that output reasoning_content
 	// in thinking mode.
 	ReasoningContentMode string
-	// summaryFormatter allows custom formatting of session summary content.
-	// When nil (default), uses default formatSummaryContent function.
-	summaryFormatter func(summary string) string
 }
 
 var (

--- a/agent/llmagent/option.go
+++ b/agent/llmagent/option.go
@@ -173,6 +173,12 @@ type Options struct {
 	// AddSessionSummary controls whether to prepend the current branch summary
 	// as a system message when available (default: false).
 	AddSessionSummary bool
+	// MaxHistoryRuns sets the maximum number of history messages when AddSessionSummary is false.
+	// When 0 (default), no limit is applied.
+	MaxHistoryRuns int
+	// summaryFormatter allows custom formatting of session summary content.
+	// When nil (default), uses the default formatSummaryContent function.
+	summaryFormatter func(summary string) string
 
 	// MaxLLMCalls is an optional upper bound on the number of LLM calls
 	// allowed per invocation for this agent. When the value is:
@@ -187,10 +193,6 @@ type Options struct {
 	//   - > 0: the limit is enforced per invocation.
 	//   - <= 0: no limit is applied (default, preserves existing behavior).
 	MaxToolIterations int
-
-	// MaxHistoryRuns sets the maximum number of history messages when AddSessionSummary is false.
-	// When 0 (default), no limit is applied.
-	MaxHistoryRuns int
 
 	// PreserveSameBranch controls whether the content request processor
 	// should preserve original roles (assistant/tool) for events that
@@ -237,10 +239,6 @@ type Options struct {
 	// multi-turn conversations. This is particularly important for DeepSeek
 	// models where reasoning_content should be discarded from previous turns.
 	ReasoningContentMode string
-
-	// summaryFormatter allows custom formatting of session summary content.
-	// When nil (default), uses the default formatSummaryContent function.
-	summaryFormatter func(summary string) string
 
 	toolFilter tool.FilterFunc
 }

--- a/graph/executor.go
+++ b/graph/executor.go
@@ -483,30 +483,28 @@ func (e *Executor) processResumeCommand(execState, initialState State) State {
 	return execState
 }
 
-// buildExecutionContext constructs the execution context including versionsSeen.
-func (e *Executor) buildExecutionContext(
-	eventChan chan<- *event.Event,
-	invocationID string,
-	state State,
-	resumed bool,
-	lastCheckpoint *Checkpoint,
-) *ExecutionContext {
-	// Restore per-node versionsSeen from the last checkpoint if present.
+// restoreVersionsSeen restores per-node versionsSeen from the last checkpoint.
+func (e *Executor) restoreVersionsSeen(resumed bool, lastCheckpoint *Checkpoint) map[string]map[string]int64 {
 	versionsSeen := make(map[string]map[string]int64)
-	if resumed && lastCheckpoint != nil && lastCheckpoint.VersionsSeen != nil {
-		for nodeID, nodeVersions := range lastCheckpoint.VersionsSeen {
-			versionsSeen[nodeID] = make(map[string]int64)
-			for ch, version := range nodeVersions {
-				versionsSeen[nodeID][ch] = version
-			}
-		}
-		log.Debugf(
-			"Restored versionsSeen for %d nodes from checkpoint",
-			len(versionsSeen),
-		)
+	if !resumed || lastCheckpoint == nil || lastCheckpoint.VersionsSeen == nil {
+		return versionsSeen
 	}
 
-	// Build per-execution channels from the graph's static channel definitions.
+	for nodeID, nodeVersions := range lastCheckpoint.VersionsSeen {
+		versionsSeen[nodeID] = make(map[string]int64)
+		for ch, version := range nodeVersions {
+			versionsSeen[nodeID][ch] = version
+		}
+	}
+	log.Debugf(
+		"Restored versionsSeen for %d nodes from checkpoint",
+		len(versionsSeen),
+	)
+	return versionsSeen
+}
+
+// buildChannelManager creates per-execution channels from the graph's static channel definitions.
+func (e *Executor) buildChannelManager() *channel.Manager {
 	channelManager := channel.NewChannelManager()
 	for name, ch := range e.graph.getAllChannels() {
 		if ch == nil {
@@ -516,11 +514,51 @@ func (e *Executor) buildExecutionContext(
 		if ch.Behavior != channel.BehaviorBarrier {
 			continue
 		}
-		if perRunCh, ok := channelManager.GetChannel(name); ok &&
-			perRunCh != nil {
+		if perRunCh, ok := channelManager.GetChannel(name); ok && perRunCh != nil {
 			perRunCh.SetBarrierExpected(ch.BarrierExpected)
 		}
 	}
+	return channelManager
+}
+
+// restoreChannelVersions seeds channel versions from the last checkpoint for resumed executions.
+func (e *Executor) restoreChannelVersions(execCtx *ExecutionContext, resumed bool, lastCheckpoint *Checkpoint) {
+	if !resumed || lastCheckpoint == nil || lastCheckpoint.ChannelVersions == nil {
+		return
+	}
+
+	for name, version := range lastCheckpoint.ChannelVersions {
+		if ch, ok := execCtx.channels.GetChannel(name); ok && ch != nil {
+			ch.Version = version
+		}
+	}
+}
+
+// restoreBarrierSets restores barrier sets from the last checkpoint for resumed executions.
+func (e *Executor) restoreBarrierSets(execCtx *ExecutionContext, resumed bool, lastCheckpoint *Checkpoint) {
+	if !resumed || lastCheckpoint == nil || len(lastCheckpoint.BarrierSets) == 0 {
+		return
+	}
+
+	for name, seen := range lastCheckpoint.BarrierSets {
+		ch, ok := execCtx.channels.GetChannel(name)
+		if !ok || ch == nil {
+			continue
+		}
+		ch.SetBarrierSeen(seen)
+	}
+}
+
+// buildExecutionContext constructs the execution context including versionsSeen.
+func (e *Executor) buildExecutionContext(
+	eventChan chan<- *event.Event,
+	invocationID string,
+	state State,
+	resumed bool,
+	lastCheckpoint *Checkpoint,
+) *ExecutionContext {
+	versionsSeen := e.restoreVersionsSeen(resumed, lastCheckpoint)
+	channelManager := e.buildChannelManager()
 
 	execCtx := &ExecutionContext{
 		Graph:          e.graph,
@@ -535,24 +573,8 @@ func (e *Executor) buildExecutionContext(
 
 	// For resumed executions, seed channel versions from the last checkpoint so
 	// version-based triggering semantics can continue to function correctly.
-	if resumed && lastCheckpoint != nil && lastCheckpoint.ChannelVersions != nil {
-		for name, version := range lastCheckpoint.ChannelVersions {
-			if ch, ok := execCtx.channels.GetChannel(name); ok && ch != nil {
-				ch.Version = version
-			}
-		}
-	}
-
-	if resumed && lastCheckpoint != nil && len(lastCheckpoint.BarrierSets) > 0 {
-		for name, seen := range lastCheckpoint.BarrierSets {
-			ch, ok := execCtx.channels.GetChannel(name)
-			if !ok || ch == nil {
-				continue
-			}
-			ch.SetBarrierSeen(seen)
-		}
-	}
-
+	e.restoreChannelVersions(execCtx, resumed, lastCheckpoint)
+	e.restoreBarrierSets(execCtx, resumed, lastCheckpoint)
 	return execCtx
 }
 


### PR DESCRIPTION
refactor to solve linters.

```textplain
model/openai/openai.go:825:1: cyclomatic complexity 21 of func `(*Model).handleStreamingResponse` is high (> 20) (gocyclo)
func (m *Model) handleStreamingResponse(
```