### PR TITLE
memory: remove unnecessary mutex from memory service

### DIFF
--- a/memory/mysql/service.go
+++ b/memory/mysql/service.go
@@ -16,7 +16,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
-	"sync"
 	"time"
 
 	"trpc.group/trpc-go/trpc-agent-go/memory"
@@ -40,7 +39,6 @@ type Service struct {
 	db        storage.Client
 	tableName string
 
-	mu               sync.Mutex
 	cachedTools      map[string]tool.Tool
 	precomputedTools []tool.Tool
 	autoMemoryWorker *imemory.AutoMemoryWorker

--- a/memory/postgres/service.go
+++ b/memory/postgres/service.go
@@ -16,7 +16,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
-	"sync"
 	"time"
 
 	"trpc.group/trpc-go/trpc-agent-go/internal/session/sqldb"
@@ -41,7 +40,6 @@ type Service struct {
 	db        storage.Client
 	tableName string
 
-	mu               sync.Mutex
 	cachedTools      map[string]tool.Tool
 	precomputedTools []tool.Tool
 	autoMemoryWorker *imemory.AutoMemoryWorker

--- a/memory/redis/service.go
+++ b/memory/redis/service.go
@@ -15,7 +15,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
-	"sync"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -41,7 +40,6 @@ type Service struct {
 	opts        ServiceOpts
 	redisClient redis.UniversalClient
 
-	mu               sync.Mutex
 	cachedTools      map[string]tool.Tool
 	precomputedTools []tool.Tool
 	autoMemoryWorker *imemory.AutoMemoryWorker


### PR DESCRIPTION
Eliminated the unused mutex field from the Service struct in MySQL, Postgres, and Redis memory service files.