### PR TITLE
{docs, examples}: add TDesign AG-UI chat client

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ Example: [examples/agui](examples/agui)
 
 - Exposes a Runner through the AG-UI (Agent-User Interaction) protocol.
 - Built-in Server-Sent Events (SSE) server, plus client samples (for example,
-  CopilotKit).
+  CopilotKit and TDesign Chat).
 
 ### 10. Evaluation
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -425,7 +425,7 @@ sg.SetFinishPoint("A").SetFinishPoint("B")
 示例：[examples/agui](examples/agui)
 
 - 通过 AG-UI（Agent-User Interaction）协议对外暴露 Runner。
-- 默认提供 Server-Sent Events（SSE）服务端实现，并提供客户端示例（例如 CopilotKit）。
+- 默认提供 Server-Sent Events（SSE）服务端实现，并提供客户端示例（例如 CopilotKit、TDesign Chat）。
 
 ### 10. 评测（Evaluation）
 

--- a/docs/mkdocs/en/agui.md
+++ b/docs/mkdocs/en/agui.md
@@ -37,7 +37,10 @@ A complete version of this example lives in [examples/agui/server/default](https
 
 For an in-depth guide to Runners, refer to the [runner](./runner.md) documentation.
 
-On the client side you can pair the server with frameworks that understand the AG-UI protocol, such as [CopilotKit](https://github.com/CopilotKit/CopilotKit). It provides React/Next.js components with built-in SSE subscriptions. The sample at [examples/agui/client/copilotkit](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/client/copilotkit) builds a web UI that communicates with the agent through AG-UI, as shown below.
+On the client side you can pair the server with frameworks that understand the AG-UI protocol, such as [CopilotKit](https://github.com/CopilotKit/CopilotKit). It provides React/Next.js components with built-in SSE subscriptions. This repository ships with two runnable web UI samples:
+
+- [examples/agui/client/tdesign-chat](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/client/tdesign-chat): a Vite + React client built with TDesign that demonstrates custom events, graph interrupt approvals (human-in-the-loop), message snapshot loading, and report side panels.
+- [examples/agui/client/copilotkit](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/client/copilotkit): a Next.js client built with CopilotKit.
 
 ![copilotkit](../assets/img/agui/copilotkit.png)
 
@@ -780,7 +783,7 @@ When a run starts with resume input, the AG-UI server emits an extra `ACTIVITY_D
 }
 ```
 
-For a complete example, see [examples/agui/server/graph](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/server/graph).
+For a complete example, see [examples/agui/server/graph](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/server/graph). For a client implementation, see [examples/agui/client/tdesign-chat](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/client/tdesign-chat).
 
 ## Best Practices
 
@@ -826,6 +829,6 @@ If a long-form document is inserted directly into the main conversation, it can 
    * When a `close_report_document` tool event is captured: close the document panel (or mark it as completed).
 
 The effect is shown below. For a full example, refer to
-[examples/agui/server/report](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/server/report).
+[examples/agui/server/report](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/server/report). The corresponding client implementation lives in [examples/agui/client/tdesign-chat](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/client/tdesign-chat).
 
 ![report](../assets/gif/agui/report.gif)

--- a/docs/mkdocs/zh/agui.md
+++ b/docs/mkdocs/zh/agui.md
@@ -37,7 +37,10 @@ if err := http.ListenAndServe("127.0.0.1:8080", server.Handler()); err != nil {
 
 Runner 全面的使用方法参见 [runner](./runner.md)。
 
-在前端侧，可以配合 [CopilotKit](https://github.com/CopilotKit/CopilotKit) 等支持 AG-UI 协议的客户端框架，它提供 React/Next.js 组件并内置 SSE 订阅能力。[examples/agui/client/copilotkit](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/client/copilotkit) 使用 CopilotKit 搭建了 Web UI 界面，通过 AG-UI 协议与 Agent 通信，效果如下图所示。
+在前端侧，可以配合 [CopilotKit](https://github.com/CopilotKit/CopilotKit) 和 [TDesign Chat](https://tdesign.tencent.com/react-chat/overview) 等支持 AG-UI 协议的客户端框架，它提供 React/Next.js 组件并内置 SSE 订阅能力。仓库内提供两个可运行的 Web UI 示例：
+
+- [examples/agui/client/tdesign-chat](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/client/tdesign-chat)：基于 Vite + React + TDesign 的客户端，演示自定义事件、Graph interrupt 审批、消息快照加载以及报告侧边栏等能力。
+- [examples/agui/client/copilotkit](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/client/copilotkit)：基于 CopilotKit 搭建的 Next.js 客户端。
 
 ![copilotkit](../assets/img/agui/copilotkit.png)
 
@@ -785,7 +788,7 @@ server, err := agui.New(
 }
 ```
 
-完整示例可参考 [examples/agui/server/graph](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/server/graph)。
+完整示例可参考 [examples/agui/server/graph](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/server/graph)，前端渲染与审批交互可参考 [examples/agui/client/tdesign-chat](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/client/tdesign-chat)。
 
 ## 最佳实践
 
@@ -830,6 +833,6 @@ server, err := agui.New(
    - 当捕捉到 `open_report_document` 工具事件时：创建文档面板，并将其后的文本消息内容写入该文档面板；
    - 当捕捉到 `close_report_document` 工具事件时：关闭文档面板（或将其标记为生成完成）。
 
-实际效果如下图所示，完整示例可参考 [examples/agui/server/report](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/server/report)。
+实际效果如下图所示，完整示例可参考 [examples/agui/server/report](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/server/report)，前端实现可参考 [examples/agui/client/tdesign-chat](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/client/tdesign-chat)。
 
 ![report](../assets/gif/agui/report.gif)

--- a/examples/agui/README.md
+++ b/examples/agui/README.md
@@ -14,7 +14,15 @@ This folder collects runnable demos that showcase how to integrate the `tRPC-Age
 go run ./server/default
 ```
 
-2. In another terminal start the CopilotKit client:
+2. In another terminal start the TDesign chat client::
+
+```bash
+cd ./client/tdesign-chat
+pnpm install
+pnpm dev
+```
+
+Or start the CopilotKit client:
 
 ```bash
 cd ./client/copilotkit

--- a/examples/agui/client/README.md
+++ b/examples/agui/client/README.md
@@ -4,6 +4,7 @@ Runnable client front-ends that consume the AG-UI SSE stream exposed by the exam
 
 ## Available Clients
 
+- [tdesign-chat/](tdesign-chat/) – Vite + React chat UI built with TDesign that demonstrates handling custom events, graph interrupts, and report side panels.
 - [copilotkit/](copilotkit/) – Next.js web chat built with CopilotKit that renders AG-UI responses in the browser.
 - [raw/](raw/) – Minimal Go terminal client that prints every SSE event for inspection.
 - [event_emitter/](event_emitter/) – Go client that demonstrates handling custom events, progress updates, and streaming text from NodeFunc.

--- a/examples/agui/client/tdesign-chat/README.md
+++ b/examples/agui/client/tdesign-chat/README.md
@@ -1,203 +1,29 @@
-# TDesign Chat + AG-UI Demo
+# TDesign Chat Client for AG-UI
 
-## ✨ 特性
+This example provides a lightweight web chat UI built with `tdesign-react`. It connects to any AG-UI server that exposes an SSE endpoint (for example the servers under `examples/agui/server/*`) and renders:
 
-这是一个使用 **Vite + React + TDesign Chat** 构建的 AG-UI 客户端示例，展示了如何与 Go AG-UI 服务进行集成。
+- Streaming assistant text (`TEXT_MESSAGE_*`)
+- Tool calls / results (`TOOL_CALL_*`)
+- Custom events (`CUSTOM`) including:
+  - Think stream (`think_*`) as a dedicated “Thinking” block
+  - React planner tags (`react.*`)
+  - Progress updates (`node.progress`)
+- Graph activity patches (`ACTIVITY_DELTA`) including Human-in-the-loop interrupts
+- Report mode document sidebar (`open_report_document` / `close_report_document`)
 
-TDesign Chat 现已支持适配 AG-UI 协议：
-- 完整适配16个标准AG-UI协议事件
-- 原生 `TOOL_CALL_*` 事件处理和自定义工具组件注册机制
-- 内置 `STATE_SNAPSHOT` 和 `STATE_DELTA` 支持
-- 自动工具调用生命周期管理
-- 支持消息回填
-- 支持多种框架（vue/react/webcomponent），多端（web和微信小程序）
-- 继续了解更多，[react版本](https://tdesign.tencent.com/react-chat/agui)，[vue版本](https://tdesign.tencent.com/chat/components/chatbot)
-
-## 📋 环境要求
-
-- Node.js >= 16
-- Go >= 1.21
-- pnpm 或 npm
-
-## 🚀 快速开始
-
-### 一键启动（推荐）
-
-**终端 1：启动后端**
-
-```bash
-cd /Users/caolin/workspace/private/trpc-agent-go/examples/agui/server/default
-go run main.go
-```
-
-服务将运行在 `http://127.0.0.1:8080/agui`
-
-**终端 2：启动前端**
-
-```bash
-cd /Users/caolin/workspace/private/trpc-agent-go/examples/agui/client/tdesign-chat
-pnpm install && pnpm dev
-```
-
-**访问应用**
-
-打开浏览器访问：`http://localhost:3000`
-
-**测试示例**
-
-输入：`Calculate 2*(10+11)`
-
-应该看到：
-1. AI 解释计算思路
-2. 计算器工具被调用
-3. 显示计算过程和结果（42）
-
-### 分步启动
-
-如果你想分步执行，可以按照以下步骤：
-
-**1. 启动 AG-UI 服务端**
-
-```bash
-cd ../../server/default
-go run main.go
-```
-
-**2. 安装依赖**
+## Start
 
 ```bash
 pnpm install
-# 或
-npm install
-```
-
-**3. 启动开发服务器**
-
-```bash
 pnpm dev
-# 或
-npm run dev
 ```
 
-**4. 打开浏览器**
+By default, the app connects directly to `http://127.0.0.1:8080/agui` (no proxy required).
 
-访问 `http://localhost:3000`，尝试发送消息：
+In the header you can configure:
 
-```
-Calculate 2*(10+11), first explain the idea, then calculate, and finally give the conclusion.
-```
+- `IP:Port` + `实时对话` (or a full URL) for the AG-UI SSE endpoint.
+- `Thread` (defaults to a short random id) and `User` for session routing.
+- `消息快照` (defaults to `/history`) to load a message snapshot when applying the connection.
 
-## 🌍 环境变量
-
-可以通过环境变量自定义 AG-UI 端点：
-
-```bash
-# 创建 .env 文件
-cp .env.example .env
-
-# 编辑 .env
-VITE_AGUI_ENDPOINT=http://your-server:port/agui
-```
-
-默认值：`http://127.0.0.1:8080/agui`
-
-## 📁 项目结构
-
-```
-tdesign-chat/
-├── src/
-│   ├── App.tsx           # 主应用组件（聊天逻辑 + 工具注册）
-│   ├── main.tsx          # 应用入口
-│   └── index.css         # 全局样式
-├── index.html            # HTML 模板
-├── package.json          # 依赖配置
-├── tsconfig.json         # TypeScript 配置
-├── vite.config.ts        # Vite 配置
-└── README.md             # 本文件
-```
-
-## 🔧 核心实现
-
-### 工具注册
-
-使用 `useAgentToolcall` 注册计算器工具：
-
-```tsx
-useAgentToolcall([
-  {
-    name: 'calculator',
-    description: '计算器工具',
-    parameters: [
-      { name: 'operation', type: 'string', required: true },
-      { name: 'a', type: 'number', required: true },
-      { name: 'b', type: 'number', required: true },
-    ],
-    component: CalculatorTool,  // 自定义 React 组件
-  },
-]);
-```
-
-### 聊天配置
-
-配置聊天服务，发送正确的 AG-UI 协议消息：
-
-```tsx
-const { chatEngine, messages, status } = useChat({
-  chatServiceConfig: {
-    endpoint: 'http://127.0.0.1:8080/agui',
-    protocol: 'agui',  // 启用 AG-UI 协议
-    stream: true,
-    onRequest: (params: ChatRequestParams) => {
-      const runId = `run-${Date.now()}`;
-      
-      return {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          threadId: threadId,  // 会话ID（整个对话保持不变）
-          runId: runId,        // 运行ID（每次请求唯一）
-          messages: [
-            {
-              role: 'user',
-              content: params.prompt,
-            }
-          ],
-        }),
-      };
-    },
-  },
-});
-```
-
-**请求格式：**
-
-后端期望的 JSON 结构：
-```json
-{
-  "threadId": "session-1732777776000",
-  "runId": "run-1732777776123",
-  "messages": [
-    {
-      "role": "user",
-      "content": "Calculate 2*(10+11)..."
-    }
-  ]
-}
-```
-
-### 工具组件示例
-
-```tsx
-const CalculatorTool: React.FC<ToolcallComponentProps<Args, Result>> = ({
-  status,   // 'pending' | 'executing' | 'complete' | 'error'
-  args,     // 工具参数
-  result,   // 工具执行结果
-  error,    // 错误对象（如果失败）
-}) => {
-  return (
-    <Card>
-      {/* 根据 status 和数据渲染工具 UI */}
-    </Card>
-  );
-};
-```
+Then open the printed local URL (typically `http://localhost:5173`).

--- a/examples/agui/client/tdesign-chat/index.html
+++ b/examples/agui/client/tdesign-chat/index.html
@@ -1,12 +1,13 @@
-<!DOCTYPE html>
-<html lang="zh-CN">
+<!doctype html>
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>TDesign Chat + AG-UI Demo</title>
+    <title>AG-UI TDesign Chat</title>
   </head>
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>
+

--- a/examples/agui/client/tdesign-chat/package.json
+++ b/examples/agui/client/tdesign-chat/package.json
@@ -1,24 +1,27 @@
 {
-  "name": "tdesign-chat-agui-demo",
-  "version": "1.0.0",
+  "name": "agui-tdesign-chat",
+  "version": "0.1.0",
+  "private": true,
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
-    "preview": "vite preview"
+    "build": "tsc -p tsconfig.json --noEmit && vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@tdesign-react/chat": "^1.0.2-alpha.1",
+    "@tdesign-react/chat": "^1.0.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-markdown": "^10.1.0",
     "tdesign-icons-react": "^0.6.1",
-    "tdesign-react": "^1.15.8"
+    "tdesign-react": "^1.16.3"
   },
   "devDependencies": {
-    "@types/react": "^18.3.12",
-    "@types/react-dom": "^18.3.1",
+    "@types/react": "^18.3.5",
+    "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.4",
-    "typescript": "^5.6.3",
+    "typescript": "^5.5.4",
     "vite": "^5.4.11"
   }
 }

--- a/examples/agui/client/tdesign-chat/src/App.tsx
+++ b/examples/agui/client/tdesign-chat/src/App.tsx
@@ -1,284 +1,1061 @@
-import React, { useRef, useState, useMemo, useCallback } from 'react';
-import { LoadingIcon, CheckCircleFilledIcon, CloseCircleFilledIcon } from 'tdesign-icons-react';
+import { useEffect, useMemo, useRef, useState, type FC } from "react";
+import { ChatMarkdown, ChatMessage, ToolCallRenderer, agentToolcallRegistry, type ToolCall } from "@tdesign-react/chat";
 import {
-  ChatList,
-  ChatSender,
-  ChatMessage,
-  ChatActionBar,
-  isAIMessage,
-  ToolCallRenderer,
-  useChat,
-  useAgentToolcall,
-} from '@tdesign-react/chat';
-import type {
-  TdChatMessageConfig,
-  TdChatSenderParams,
-  ChatMessagesData,
-  ChatRequestParams,
-  AIMessageContent,
-  ToolcallComponentProps,
-  TdChatActionsName,
-} from '@tdesign-react/chat';
+  Alert,
+  Button,
+  Divider,
+  Drawer,
+  Input,
+  Layout,
+  Progress,
+  Space,
+  Tag,
+  Textarea,
+} from "tdesign-react";
+import { ChatIcon, RefreshIcon } from "tdesign-icons-react";
+import { formatTimestamp } from "./agui/format";
+import { useAguiChat, type RawAguiEvent, type UiMessage } from "./hooks/useAguiChat";
 
-// 默认提示语
-const DEFAULT_PROMPT = 'Calculate 2*(10+11), first explain the idea, then calculate, and finally give the conclusion.';
+const AGUI_OPEN_REPORT_EVENT = "agui-open-report";
+const AGUI_GRAPH_APPROVAL_EVENT = "agui-graph-approval";
+const REPORT_OPEN_TOOL_NAME = "open_report_sidebar";
+const GRAPH_APPROVAL_TOOL_NAME = "graph_interrupt_approval";
+const DEFAULT_INPUT_MESSAGE = "计算123+456";
 
-// ==================== 类型定义 ====================
-
-interface CalculatorArgs {
-  operation: string;
-  a: number;
-  b: number;
+function createThreadId(): string {
+  if (typeof crypto !== "undefined") {
+    if (typeof crypto.randomUUID === "function") {
+      return crypto.randomUUID().replace(/-/g, "").slice(0, 12);
+    }
+    if (typeof crypto.getRandomValues === "function") {
+      const bytes = new Uint8Array(6);
+      crypto.getRandomValues(bytes);
+      return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+    }
+  }
+  const rand = Math.random().toString(16).slice(2).padEnd(12, "0");
+  return rand.slice(0, 12);
 }
 
-interface CalculatorResult {
-  result: number;
+function isHttpUrl(value: string): boolean {
+  return /^https?:\/\//i.test(value.trim());
 }
 
-// ==================== 工具组件 ====================
+function isLoopbackHost(hostname: string): boolean {
+  const normalized = hostname.trim().toLowerCase();
+  return normalized === "localhost" || normalized === "127.0.0.1";
+}
 
-const CalculatorTool: React.FC<ToolcallComponentProps<CalculatorArgs, CalculatorResult>> = ({
-  status,
-  args,
-  result,
-  error,
-}) => {
-  const operatorMap: Record<string, string> = {
-    add: '+',
-    subtract: '-',
-    multiply: '×',
-    divide: '÷',
-    power: '^',
-    '+': '+',
-    '-': '-',
-    '*': '×',
-    '/': '÷',
-    '^': '^',
+function parseHostname(address: string): string {
+  const trimmed = address.trim();
+  if (!trimmed) {
+    return "";
+  }
+  try {
+    return new URL(trimmed).hostname;
+  } catch {}
+  try {
+    return new URL(`http://${trimmed}`).hostname;
+  } catch {}
+  return "";
+}
+
+function shouldUseDevProxy(base: string): boolean {
+  if (!import.meta.env.DEV) {
+    return false;
+  }
+  if (typeof window === "undefined") {
+    return false;
+  }
+  const baseHost = parseHostname(base);
+  if (!isLoopbackHost(baseHost)) {
+    return false;
+  }
+  return !isLoopbackHost(window.location.hostname);
+}
+
+function normalizePath(path: string): string {
+  const trimmed = path.trim();
+  if (!trimmed) {
+    return "/";
+  }
+  if (trimmed.startsWith("/")) {
+    return trimmed;
+  }
+  return `/${trimmed}`;
+}
+
+function buildHttpUrl(base: string, pathOrUrl: string): string {
+  const trimmed = pathOrUrl.trim();
+  if (!trimmed) {
+    return "";
+  }
+  if (isHttpUrl(trimmed)) {
+    if (shouldUseDevProxy(trimmed)) {
+      try {
+        const url = new URL(trimmed);
+        return normalizePath(url.pathname + url.search);
+      } catch {
+        return trimmed;
+      }
+    }
+    return trimmed;
+  }
+  if (shouldUseDevProxy(base)) {
+    return normalizePath(trimmed);
+  }
+  const baseTrimmed = base.trim() || "127.0.0.1:8080";
+  const baseUrl = isHttpUrl(baseTrimmed) ? baseTrimmed : `http://${baseTrimmed}`;
+  return new URL(normalizePath(trimmed), baseUrl).toString();
+}
+
+type ToolcallStatus = "idle" | "executing" | "complete" | "error";
+type ToolcallComponentProps = {
+  status: ToolcallStatus;
+  args: Record<string, unknown>;
+  result?: unknown;
+  error?: Error;
+  respond?: (response: unknown) => void;
+  agentState?: Record<string, unknown>;
+};
+
+function formatToolcallValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  if (typeof value === "string") {
+    return value.trim();
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function toolcallStatusLabel(status: ToolcallStatus): string {
+  if (status === "executing") {
+    return "Running";
+  }
+  if (status === "complete") {
+    return "Done";
+  }
+  if (status === "error") {
+    return "Error";
+  }
+  return "Idle";
+}
+
+function toolcallStatusTheme(status: ToolcallStatus): "default" | "primary" | "success" | "danger" {
+  if (status === "executing") {
+    return "primary";
+  }
+  if (status === "complete") {
+    return "success";
+  }
+  if (status === "error") {
+    return "danger";
+  }
+  return "default";
+}
+
+function reportStatusTheme(status: string): "warning" | "success" | "default" {
+  if (status === "open") {
+    return "warning";
+  }
+  if (status === "closed") {
+    return "success";
+  }
+  return "default";
+}
+
+function reportStatusLabel(status: string): string {
+  if (status === "open") {
+    return "生成中";
+  }
+  if (status === "closed") {
+    return "已完成";
+  }
+  return status || "Unknown";
+}
+
+const toolcallComponentCache = new Map<string, FC<ToolcallComponentProps>>();
+
+function extractReportDocumentId(result: unknown): string {
+  if (!result || typeof result !== "object") {
+    return "";
+  }
+  const anyResult = result as any;
+  const documentId = typeof anyResult.documentId === "string"
+    ? anyResult.documentId
+    : typeof anyResult.documentID === "string"
+      ? anyResult.documentID
+      : "";
+  return documentId.trim();
+}
+
+function extractReportTitle(args: Record<string, unknown>, result: unknown): string {
+  if (result && typeof result === "object" && typeof (result as any).title === "string") {
+    return String((result as any).title).trim() || "Report";
+  }
+  if (typeof args?.title === "string") {
+    return String(args.title).trim() || "Report";
+  }
+  return "Report";
+}
+
+function getGenericToolcallComponent(toolCallName: string): FC<ToolcallComponentProps> {
+  const cached = toolcallComponentCache.get(toolCallName);
+  if (cached) {
+    return cached;
+  }
+  const Component: FC<ToolcallComponentProps> = ({ status, args, result, error }) => {
+    const argsText = formatToolcallValue(args);
+    const resultText = formatToolcallValue(result);
+    const errorText = error ? String(error.message || error) : "";
+    const hasResult = result !== undefined;
+
+    return (
+      <details className="toolcall">
+        <summary className="toolcall__summary">
+          <span className="toolcall__summary-title">{toolCallName}</span>
+        </summary>
+        <div className="toolcall__body">
+          <Space size="small" align="center" breakLine>
+            <Tag theme={toolcallStatusTheme(status)} variant="outline">{toolcallStatusLabel(status)}</Tag>
+          </Space>
+          <Divider style={{ margin: "10px 0" }} />
+          <div className="toolcall__panels">
+            <details className="toolcall__panel">
+              <summary className="toolcall__panel-summary">
+                <span className="toolcall__panel-title">工具调用</span>
+              </summary>
+              <pre className="toolcall__code">{argsText || "(empty)"}</pre>
+            </details>
+            <details className="toolcall__panel">
+              <summary className="toolcall__panel-summary">
+                <span className="toolcall__panel-title">工具结果</span>
+              </summary>
+              {status === "error" ? (
+                <pre className="toolcall__code">{errorText || "(unknown error)"}</pre>
+              ) : (
+                <pre className="toolcall__code">{hasResult ? resultText || "(empty)" : "等待结果..."}</pre>
+              )}
+            </details>
+          </div>
+        </div>
+      </details>
+    );
+  };
+  toolcallComponentCache.set(toolCallName, Component);
+  return Component;
+}
+
+function ensureToolcallRegistered(toolCallName: string) {
+  if (!toolCallName) {
+    return;
+  }
+  if (agentToolcallRegistry.get(toolCallName)) {
+    return;
+  }
+  agentToolcallRegistry.register({
+    name: toolCallName,
+    description: `AG-UI tool call: ${toolCallName}.`,
+    component: getGenericToolcallComponent(toolCallName),
+  });
+}
+
+ensureToolcallRegistered("calculator");
+ensureToolcallRegistered("open_report_document");
+ensureToolcallRegistered("close_report_document");
+
+agentToolcallRegistry.register({
+  name: REPORT_OPEN_TOOL_NAME,
+  description: "Open a report sidebar in the AG-UI frontend.",
+  component: ({ args, result }) => {
+    const documentId = extractReportDocumentId(result);
+    const title = extractReportTitle(args, result);
+    const reportStatus = result && typeof result === "object" && typeof (result as any).status === "string"
+      ? String((result as any).status)
+      : "open";
+    const createdAt = result && typeof result === "object" && typeof (result as any).createdAt === "string"
+      ? String((result as any).createdAt)
+      : "";
+    const closedAt = result && typeof result === "object" && typeof (result as any).closedAt === "string"
+      ? String((result as any).closedAt)
+      : "";
+    const reason = result && typeof result === "object" && typeof (result as any).reason === "string"
+      ? String((result as any).reason)
+      : "";
+
+    return (
+      <div className="toolcall">
+        <div className="toolcall__summary">
+          <span className="toolcall__summary-title">打开报告</span>
+        </div>
+        <div className="toolcall__body">
+          <Space size="small" align="center" breakLine>
+            <Tag theme={reportStatusTheme(reportStatus)} variant="outline">{reportStatusLabel(reportStatus)}</Tag>
+            <Button
+              size="small"
+              theme="primary"
+              disabled={!documentId}
+              onClick={() => {
+                if (!documentId) {
+                  return;
+                }
+                window.dispatchEvent(new CustomEvent(AGUI_OPEN_REPORT_EVENT, { detail: { documentId } }));
+              }}
+            >
+              打开报告
+            </Button>
+          </Space>
+          <Divider style={{ margin: "10px 0" }} />
+          <Space direction="vertical" size="small" style={{ width: "100%" }}>
+            <div>
+              <Tag theme="default" variant="outline">Title</Tag>{" "}
+              <span>{title}</span>
+            </div>
+            {documentId ? (
+              <div>
+                <Tag theme="default" variant="outline">docId</Tag>{" "}
+                <span>{documentId}</span>
+              </div>
+            ) : null}
+            {createdAt ? (
+              <div>
+                <Tag theme="default" variant="outline">createdAt</Tag>{" "}
+                <span>{createdAt}</span>
+              </div>
+            ) : null}
+            {closedAt ? (
+              <div>
+                <Tag theme="default" variant="outline">closedAt</Tag>{" "}
+                <span>{closedAt}</span>
+              </div>
+            ) : null}
+            {reason ? (
+              <div>
+                <Tag theme="default" variant="outline">reason</Tag>{" "}
+                <span>{reason}</span>
+              </div>
+            ) : null}
+          </Space>
+        </div>
+      </div>
+    );
+  },
+});
+
+agentToolcallRegistry.register({
+  name: GRAPH_APPROVAL_TOOL_NAME,
+  description: "Approve an AG-UI graph interrupt in the frontend.",
+  component: ({ args }) => {
+    const prompt = typeof (args as any)?.prompt === "string" ? String((args as any).prompt) : "";
+    const decision = typeof (args as any)?.decision === "string" ? String((args as any).decision) : "pending";
+    const decided = decision === "approve" || decision === "dismiss";
+    const alertTheme: "success" | "warning" | "error" = decision === "approve" ? "success" : decision === "dismiss" ? "error" : "warning";
+    const decisionLabel = decision === "approve" ? "已选择：允许" : decision === "dismiss" ? "已选择：拒绝" : "";
+    const decisionTagTheme: "success" | "danger" = decision === "approve" ? "success" : "danger";
+
+    return (
+      <div className="toolcall">
+        <Alert
+          theme={alertTheme}
+          title="审批（人机交互）"
+          message={prompt ? <div style={{ whiteSpace: "pre-wrap" }}>{prompt}</div> : undefined}
+          operation={(
+            decided ? (
+              <Tag theme={decisionTagTheme} variant="outline">{decisionLabel}</Tag>
+            ) : (
+              <Space size="small">
+                <Button
+                  size="small"
+                  theme="primary"
+                  onClick={() => window.dispatchEvent(new CustomEvent(AGUI_GRAPH_APPROVAL_EVENT, { detail: { action: "approve" } }))}
+                >
+                  允许
+                </Button>
+                <Button
+                  size="small"
+                  variant="outline"
+                  theme="danger"
+                  onClick={() => window.dispatchEvent(new CustomEvent(AGUI_GRAPH_APPROVAL_EVENT, { detail: { action: "dismiss" } }))}
+                >
+                  拒绝
+                </Button>
+              </Space>
+            )
+          )}
+        />
+      </div>
+    );
+  },
+});
+
+function summarizeRawEvent(event: RawAguiEvent): string {
+  const payload = event.payload as any;
+  if (event.type === "CUSTOM") {
+    const name = typeof payload?.name === "string" ? payload.name : "";
+    return name ? `name=${name}` : "";
+  }
+  if (event.type === "ACTIVITY_DELTA") {
+    const activityType = typeof payload?.activityType === "string" ? payload.activityType : "";
+    return activityType ? `activityType=${activityType}` : "";
+  }
+  if (event.type === "TEXT_MESSAGE_START") {
+    const id = typeof payload?.messageId === "string" ? payload.messageId : "";
+    return id ? `messageId=${id}` : "";
+  }
+  if (event.type === "TEXT_MESSAGE_CONTENT") {
+    const delta = typeof payload?.delta === "string" ? payload.delta : "";
+    const trimmed = delta.replace(/\s+/g, " ").trim();
+    if (!trimmed) {
+      return "";
+    }
+    const short = trimmed.length > 42 ? `${trimmed.slice(0, 42)}…` : trimmed;
+    return `delta=${short}`;
+  }
+  if (event.type === "TOOL_CALL_START") {
+    const tool = typeof payload?.toolCallName === "string" ? payload.toolCallName : "";
+    return tool ? `tool=${tool}` : "";
+  }
+  if (event.type === "TOOL_CALL_ARGS") {
+    const delta = typeof payload?.delta === "string" ? payload.delta : "";
+    const trimmed = delta.replace(/\s+/g, " ").trim();
+    if (!trimmed) {
+      return "";
+    }
+    const short = trimmed.length > 42 ? `${trimmed.slice(0, 42)}…` : trimmed;
+    return `args=${short}`;
+  }
+  if (event.type === "TOOL_CALL_RESULT") {
+    const id = typeof payload?.toolCallId === "string" ? payload.toolCallId : "";
+    return id ? `toolCallId=${id}` : "";
+  }
+  if (event.type === "RUN_FINISHED") {
+    const result = typeof payload?.result === "string" ? payload.result : "";
+    return result ? `result=${result}` : "";
+  }
+  return "";
+}
+
+function isVisibleMainMessage(message: UiMessage): boolean {
+  if (message.kind === "thinking") {
+    return true;
+  }
+  if (message.kind === "tool-call") {
+    return true;
+  }
+  if (message.kind === "text" && (message.role === "user" || message.role === "assistant")) {
+    return true;
+  }
+  return false;
+}
+
+type RenderedChatItem =
+  | {
+      kind: "user";
+      key: string;
+      message: UiMessage;
+    }
+  | {
+      kind: "assistant";
+      key: string;
+      messages: UiMessage[];
+    };
+
+function groupChatItems(messages: UiMessage[]): RenderedChatItem[] {
+  const items: RenderedChatItem[] = [];
+  let assistantGroup: UiMessage[] = [];
+
+  const flushAssistantGroup = () => {
+    if (assistantGroup.length === 0) {
+      return;
+    }
+    items.push({
+      kind: "assistant",
+      key: `assistant-${assistantGroup[0]?.id ?? "unknown"}`,
+      messages: assistantGroup,
+    });
+    assistantGroup = [];
   };
 
-  const getOperatorSymbol = () => {
-    if (!args?.operation) return '';
-    return operatorMap[args.operation] || args.operation;
+  for (const message of messages) {
+    if (message.kind === "text" && message.role === "user") {
+      flushAssistantGroup();
+      items.push({ kind: "user", key: `user-${message.id}`, message });
+      continue;
+    }
+    assistantGroup.push(message);
+  }
+
+  flushAssistantGroup();
+  return items;
+}
+
+export default function App() {
+  const [serverAddress, setServerAddress] = useState<string>("127.0.0.1:8080");
+  const [serverAddressDraft, setServerAddressDraft] = useState<string>("127.0.0.1:8080");
+  const [endpointPath, setEndpointPath] = useState<string>("/agui");
+  const [endpointPathDraft, setEndpointPathDraft] = useState<string>("/agui");
+  const [historyPathDraft, setHistoryPathDraft] = useState<string>("/history");
+  const [historyHint, setHistoryHint] = useState<string>("");
+  const [userId, setUserId] = useState<string>("demo-user");
+  const initialThreadId = useMemo(() => createThreadId(), []);
+  const [threadId, setThreadId] = useState<string>(initialThreadId);
+  const [threadIdDraft, setThreadIdDraft] = useState<string>(initialThreadId);
+  const [input, setInput] = useState<string>(DEFAULT_INPUT_MESSAGE);
+  const [isComposing, setIsComposing] = useState(false);
+  const [errorDrawerOpen, setErrorDrawerOpen] = useState(false);
+  const [dismissedError, setDismissedError] = useState<string | null>(null);
+
+  const forwardedProps = useMemo(() => ({ userId }), [userId]);
+  const endpoint = useMemo(() => buildHttpUrl(serverAddress, endpointPath), [endpointPath, serverAddress]);
+
+  const chat = useAguiChat({
+    endpoint,
+    threadId,
+    forwardedProps,
+  });
+
+  const activeReport = useMemo(() => {
+    if (!chat.activeReportId) {
+      return null;
+    }
+    return chat.reportSessions.find((session) => session.documentId === chat.activeReportId) ?? null;
+  }, [chat.activeReportId, chat.reportSessions]);
+
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent).detail as any;
+      const documentId = typeof detail?.documentId === "string" ? detail.documentId : "";
+      if (!documentId) {
+        return;
+      }
+      chat.openReport(documentId);
+    };
+    window.addEventListener(AGUI_OPEN_REPORT_EVENT, handler as EventListener);
+    return () => {
+      window.removeEventListener(AGUI_OPEN_REPORT_EVENT, handler as EventListener);
+    };
+  }, [chat.openReport]);
+
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent).detail as any;
+      const action = typeof detail?.action === "string" ? detail.action : "";
+      if (action === "approve") {
+        void chat.approveGraphInterrupt();
+        return;
+      }
+      if (action === "dismiss") {
+        void chat.dismissGraphInterrupt();
+      }
+    };
+    window.addEventListener(AGUI_GRAPH_APPROVAL_EVENT, handler as EventListener);
+    return () => {
+      window.removeEventListener(AGUI_GRAPH_APPROVAL_EVENT, handler as EventListener);
+    };
+  }, [chat.approveGraphInterrupt, chat.dismissGraphInterrupt]);
+
+  const send = async () => {
+    if (chat.inProgress) {
+      return;
+    }
+    const text = input.trim();
+    if (!text) {
+      return;
+    }
+    setInput("");
+    await chat.send(text);
   };
 
-  const getStatusBadge = () => {
-    if (status === 'executing') {
-      return (
-        <span className="status-badge status-badge--executing">
-          <LoadingIcon />
-          计算中...
-        </span>
-      );
+  const canSend = !chat.inProgress;
+
+  const chatRef = useRef<HTMLDivElement | null>(null);
+  const [shouldAutoScroll, setShouldAutoScroll] = useState(true);
+  const rawRef = useRef<HTMLDivElement | null>(null);
+  const [rawShouldAutoScroll, setRawShouldAutoScroll] = useState(true);
+
+  useEffect(() => {
+    if (!rawShouldAutoScroll) {
+      return;
     }
-    if (status === 'complete') {
-      return (
-        <span className="status-badge status-badge--complete">
-          <CheckCircleFilledIcon />
-          计算完成
-        </span>
-      );
+    const container = rawRef.current;
+    if (!container) {
+      return;
     }
-    if (status === 'error') {
-      return (
-        <span className="status-badge status-badge--error">
-          <CloseCircleFilledIcon />
-          计算失败
-        </span>
-      );
+    const id = window.requestAnimationFrame(() => {
+      container.scrollTop = container.scrollHeight;
+    });
+    return () => window.cancelAnimationFrame(id);
+  }, [chat.rawEvents, rawShouldAutoScroll]);
+
+  const visibleMessages = useMemo(() => chat.messages.filter(isVisibleMainMessage), [chat.messages]);
+
+  useEffect(() => {
+    if (!shouldAutoScroll) {
+      return;
     }
-    return null;
+    const container = chatRef.current;
+    if (!container) {
+      return;
+    }
+    const id = window.requestAnimationFrame(() => {
+      container.scrollTop = container.scrollHeight;
+    });
+    return () => window.cancelAnimationFrame(id);
+  }, [visibleMessages, shouldAutoScroll]);
+
+  const renderedItems = useMemo(() => groupChatItems(visibleMessages), [visibleMessages]);
+
+  useEffect(() => {
+    if (!chat.lastError) {
+      setDismissedError(null);
+      setErrorDrawerOpen(false);
+    }
+  }, [chat.lastError]);
+
+  const errorSummary = useMemo(() => {
+    const error = chat.lastError || "";
+    if (!error) {
+      return "";
+    }
+    const firstLine = error.split(/\r?\n/)[0] ?? error;
+    const trimmed = firstLine.trim() || error.trim();
+    if (!trimmed) {
+      return "";
+    }
+    return trimmed.length > 140 ? `${trimmed.slice(0, 140)}…` : trimmed;
+  }, [chat.lastError]);
+
+  const showErrorBanner = Boolean(chat.lastError) && dismissedError !== chat.lastError;
+
+  const applyConnection = async () => {
+    if (chat.inProgress) {
+      chat.stop();
+    }
+    chat.reset();
+    setInput(DEFAULT_INPUT_MESSAGE);
+
+    const nextServerAddress = serverAddressDraft.trim() || "127.0.0.1:8080";
+    const nextEndpointPath = endpointPathDraft.trim() || "/agui";
+    const nextHistoryPath = historyPathDraft.trim() || "/history";
+    const nextThreadId = threadIdDraft.trim() || createThreadId();
+
+    setServerAddress(nextServerAddress);
+    setServerAddressDraft(nextServerAddress);
+    setEndpointPath(nextEndpointPath);
+    setEndpointPathDraft(nextEndpointPath);
+    setHistoryPathDraft(nextHistoryPath);
+    setThreadId(nextThreadId);
+    setThreadIdDraft(nextThreadId);
+
+    setHistoryHint("正在载入历史...");
+    const result = await chat.loadHistory({
+      endpoint: buildHttpUrl(nextServerAddress, nextHistoryPath),
+      threadId: nextThreadId,
+      forwardedProps,
+    });
+    if (result.ok) {
+      setHistoryHint(result.count > 0 ? "" : "暂无历史记录");
+      return;
+    }
+    const message = result.message || "";
+    if (message.includes("session not found")) {
+      setHistoryHint("暂无历史记录");
+      return;
+    }
+    setHistoryHint("");
   };
 
-  const cardClassName = `tool-card ${status === 'executing' ? 'tool-card--executing' : ''} ${
-    status === 'error' ? 'tool-card--error' : ''
-  }`;
+  const toolcallNames = useMemo(() => {
+    const names = new Set<string>();
+    for (const message of visibleMessages) {
+      if (message.kind === "tool-call" && message.toolCall?.toolCallName) {
+        names.add(message.toolCall.toolCallName);
+      }
+    }
+    return Array.from(names).sort();
+  }, [visibleMessages]);
+
+  useEffect(() => {
+    for (const name of toolcallNames) {
+      ensureToolcallRegistered(name);
+    }
+  }, [toolcallNames]);
 
   return (
-    <div className={cardClassName}>
-      <div className="tool-card__header">
-        <span className="tool-card__icon">🧮</span>
-        <span>计算器工具</span>
-        {getStatusBadge()}
-      </div>
-
-      {args && (
-        <div className="tool-card__body">
-          <div className="tool-card__args">
-            <div style={{ fontSize: '14px', marginBottom: '4px' }}>
-              <strong>计算表达式：</strong>
+    <Layout className="app">
+      <Layout.Content className="app__content">
+        <div className="app__body">
+          <aside className="app__sider">
+            <div className="app__sider-header">
+              <Space size="small" align="center">
+                <strong>AG-UI 事件</strong>
+                <Tag theme="default" variant="outline">{chat.rawEvents.length}</Tag>
+              </Space>
+              <Space size="small">
+                <Button size="small" variant="outline" onClick={chat.clearRawEvents}>
+                  清空
+                </Button>
+              </Space>
             </div>
-            <div style={{ fontSize: '18px', fontWeight: 600, color: '#0052d9' }}>
-              {args.a} {getOperatorSymbol()} {args.b}
+            <div
+              className="app__sider-content"
+              ref={rawRef}
+              onScroll={() => {
+                const el = rawRef.current;
+                if (!el) {
+                  return;
+                }
+                const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
+                setRawShouldAutoScroll(distance < 80);
+              }}
+            >
+              {chat.rawEvents.length === 0 ? (
+                <div className="raw-events__empty">等待事件...</div>
+              ) : (
+                <div className="raw-events">
+                  {chat.rawEvents.map((event) => (
+                    <details key={event.id} className="raw-event">
+                      <summary className="raw-event__summary">
+                        <span className="raw-event__time">{formatTimestamp(event.timestamp)}</span>
+                        <Tag theme="default" variant="outline">{event.type}</Tag>
+                        <span className="raw-event__extra">{summarizeRawEvent(event)}</span>
+                      </summary>
+                      <pre className="raw-event__body">
+                        {JSON.stringify(event.payload, null, 2)}
+                      </pre>
+                    </details>
+                  ))}
+                </div>
+              )}
+            </div>
+          </aside>
+
+          <div className="app__chat-area">
+	            <div className="app__topbar">
+	              <div className="status-row">
+                <div className="status-row__left">
+                  <Space size="small" align="center">
+                    <ChatIcon />
+                    <strong>AG-UI TDesign Chat</strong>
+                  </Space>
+                  {chat.graphNodeId ? <Tag theme="warning" variant="outline">node: {chat.graphNodeId}</Tag> : null}
+                  {chat.finishReason && chat.finishReason !== "stop"
+                    ? <Tag theme="success" variant="outline">finish: {chat.finishReason}</Tag>
+                    : null}
+                </div>
+
+                <div className="status-row__center">
+                  <Input
+                    label="IP:Port"
+                    value={serverAddressDraft}
+                    onChange={(v) => {
+                      const next = String(v);
+                      setServerAddressDraft(next);
+                      setServerAddress(next);
+                    }}
+                    className="header-field"
+                    style={{ width: "100%" }}
+                    placeholder="127.0.0.1:8080"
+                  />
+
+                  <Input
+                    label="实时对话"
+                    value={endpointPathDraft}
+                    onChange={(v) => {
+                      const next = String(v);
+                      setEndpointPathDraft(next);
+                      setEndpointPath(next);
+                    }}
+                    className="header-field"
+                    style={{ width: "100%" }}
+                    placeholder="/agui 或 完整URL"
+                  />
+
+                  <Input
+                    label="消息快照"
+                    value={historyPathDraft}
+                    onChange={(v) => setHistoryPathDraft(String(v))}
+                    className="header-field"
+                    style={{ width: "100%" }}
+                    placeholder="/history"
+                  />
+
+                  <Input
+                    label="Thread"
+                    value={threadIdDraft}
+                    onChange={(v) => {
+                      const next = String(v);
+                      setThreadIdDraft(next);
+                      if (next.trim()) {
+                        setThreadId(next);
+                      }
+                    }}
+                    className="header-field"
+                    style={{ width: "100%" }}
+                    placeholder="留空自动生成"
+                  />
+
+                  <Input
+                    label="User"
+                    value={userId}
+                    onChange={(v) => setUserId(String(v))}
+                    className="header-field"
+                    style={{ width: "100%" }}
+                    placeholder="demo-user"
+                  />
+                </div>
+
+                <div className="status-row__right">
+                  {chat.progress ? (
+                    <Progress
+                      theme="line"
+                      percentage={Math.max(0, Math.min(100, Math.round(chat.progress.percent)))}
+                      label={chat.progress.label ? chat.progress.label : undefined}
+                      style={{ width: 200 }}
+                    />
+                  ) : null}
+
+                  {historyHint ? (
+                    <span className="status-row__hint" title={historyHint}>
+                      <Tag theme="default" variant="outline">{historyHint}</Tag>
+                    </span>
+                  ) : null}
+
+                  <Button variant="outline" onClick={applyConnection} disabled={chat.inProgress}>
+                    载入历史
+                  </Button>
+
+                  <Button
+                    variant="outline"
+                    icon={<RefreshIcon />}
+                    onClick={() => {
+                      chat.reset();
+                      const nextThreadId = createThreadId();
+                      setThreadId(nextThreadId);
+                      setThreadIdDraft(nextThreadId);
+                      setHistoryHint("");
+                      setInput(DEFAULT_INPUT_MESSAGE);
+                    }}
+                  >
+                    新会话
+                  </Button>
+                </div>
+              </div>
+            </div>
+
+            <div
+              className="chat"
+              ref={chatRef}
+              onScroll={() => {
+                const el = chatRef.current;
+                if (!el) {
+                  return;
+                }
+                const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
+                setShouldAutoScroll(distance < 80);
+              }}
+            >
+              {visibleMessages.length === 0 ? (
+                <div className="chat__empty">
+                  <div>输入内容后发送。</div>
+                </div>
+              ) : (
+                <div className="chat__list">
+                  {renderedItems.map((item) => {
+                    if (item.kind === "user") {
+                      return (
+                        <ChatMessage
+                          key={item.key}
+                          role="user"
+                          name="You"
+                          placement="right"
+                          content={[{ type: "text", data: item.message.content || "" }] as any}
+                          variant="base"
+                        />
+                      );
+                    }
+
+                    const blocks: any[] = [];
+                    const toolSlots: JSX.Element[] = [];
+
+                    for (const message of item.messages) {
+                      if (message.kind === "thinking") {
+                        blocks.push({
+                          type: "thinking",
+                          data: { title: message.title ?? "Thinking", text: message.content || "" },
+                          status: message.status,
+                        });
+                        continue;
+                      }
+
+                      if (message.kind === "tool-call" && message.toolCall) {
+                        const toolCall: ToolCall = {
+                          toolCallId: message.toolCall.toolCallId,
+                          toolCallName: message.toolCall.toolCallName,
+                          parentMessageId: message.toolCall.parentMessageId,
+                          args: message.toolCall.args,
+                          result: message.toolCall.result,
+                        };
+                        const index = blocks.length;
+                        blocks.push({ type: "toolcall", data: toolCall });
+                        toolSlots.push(
+                          <div key={toolCall.toolCallId} slot={`toolcall-${index}`} className="toolcall__slot">
+                            <ToolCallRenderer toolCall={toolCall} />
+                          </div>,
+                        );
+                        continue;
+                      }
+
+                      if (message.kind === "text" && message.role === "assistant") {
+                        blocks.push({ type: "markdown", data: message.content || "" });
+                      }
+                    }
+
+                    return (
+                      <ChatMessage
+                        key={item.key}
+                        role="assistant"
+                        name="Assistant"
+                        placement="left"
+                        content={blocks as any}
+                        variant="base"
+                        chatContentProps={{
+                          thinking: {
+                            maxHeight: 320,
+                            layout: "border",
+                            collapsed: false,
+                          },
+                        }}
+                      >
+                        {toolSlots}
+                      </ChatMessage>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+
+            <div className="composer">
+              <Space direction="vertical" style={{ width: "100%" }} size="small">
+                {showErrorBanner ? (
+                  <Alert
+                    theme="error"
+                    title="运行失败"
+                    message={errorSummary || "发生错误，点击“详情”查看。"}
+                    closeBtn
+                    onClose={() => {
+                      setDismissedError(chat.lastError);
+                      setErrorDrawerOpen(false);
+                    }}
+                    operation={(
+                      <Button
+                        size="small"
+                        variant="outline"
+                        onClick={() => setErrorDrawerOpen(true)}
+                      >
+                        详情
+                      </Button>
+                    )}
+                  />
+                ) : null}
+                <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                  <div style={{ flex: 1 }}>
+                    <Textarea
+                      value={input}
+                      onChange={(v) => setInput(String(v))}
+                      placeholder="输入消息..."
+                      autosize={{ minRows: 2, maxRows: 6 }}
+                      disabled={!canSend}
+                      onCompositionStart={() => setIsComposing(true)}
+                      onCompositionEnd={() => setIsComposing(false)}
+                      onKeydown={(_, ctx) => {
+                        const e = ctx.e;
+                        if (e.key !== "Enter") {
+                          return;
+                        }
+                        if (e.shiftKey) {
+                          return;
+                        }
+                        if (isComposing) {
+                          return;
+                        }
+                        e.preventDefault();
+                        void send();
+                      }}
+                    />
+                  </div>
+                  <Button theme="primary" onClick={send} disabled={!canSend}>
+                    发送
+                  </Button>
+                </div>
+              </Space>
             </div>
           </div>
         </div>
-      )}
+      </Layout.Content>
 
-      {status === 'complete' && result && (
-        <div className="tool-card__result">
-          <div className="tool-card__result-label">计算结果</div>
-          <div className="tool-card__result-value">= {result.result}</div>
-        </div>
-      )}
-
-      {status === 'error' && error && (
-        <div className="tool-card__error">❌ 错误: {error.message || '计算失败'}</div>
-      )}
-    </div>
-  );
-};
-
-// ==================== 主组件 ====================
-
-export default function App() {
-  const listRef = useRef<any>(null);
-  const [inputValue, setInputValue] = useState<string>(DEFAULT_PROMPT);
-  // 保持会话ID，用于多轮对话
-  const [threadId] = useState(() => `session-${Date.now()}`);
-
-  // 注册计算器工具
-  useAgentToolcall([
-    {
-      name: 'calculator',
-      description: '计算器工具，支持加减乘除和幂运算',
-      parameters: [
-        { name: 'operation', type: 'string', required: true },
-        { name: 'a', type: 'number', required: true },
-        { name: 'b', type: 'number', required: true },
-      ],
-      component: CalculatorTool,
-    },
-  ]);
-
-  // 聊天配置
-  const { chatEngine, messages, status } = useChat({
-    defaultMessages: [],
-    chatServiceConfig: {
-      endpoint: 'http://127.0.0.1:8080/agui',
-      protocol: 'agui',
-      stream: true,
-      onRequest: (params: ChatRequestParams) => {
-        // 生成唯一的 run ID
-        const runId = `run-${Date.now()}`;
-        
-        return {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            threadId: threadId,  // 会话ID（保持不变）
-            runId: runId,        // 运行ID（每次请求唯一）
-            messages: [
-              {
-                role: 'user',
-                content: params.prompt,
-              }
-            ],
-          }),
-        };
-      },
-      onError: (err: Error | Response) => {
-        console.error('AG-UI 服务错误:', err);
-      },
-    },
-  });
-
-  const senderLoading = useMemo(() => status === 'pending' || status === 'streaming', [status]);
-
-  // 消息配置
-  const messageProps: TdChatMessageConfig = {
-    user: {
-      variant: 'base',
-      placement: 'right',
-      avatar: 'https://tdesign.gtimg.com/site/avatar.jpg',
-    },
-    assistant: {
-      placement: 'left',
-      avatar: 'https://tdesign.gtimg.com/site/chat-avatar.png',
-    },
-  };
-
-  // 操作栏配置
-  const getActionBar = (isLast: boolean): TdChatActionsName[] => {
-    const actions: TdChatActionsName[] = ['good', 'bad', 'copy'];
-    if (isLast) actions.unshift('replay');
-    return actions;
-  };
-
-  // 操作处理
-  const handleAction = useCallback(
-    (name: string) => {
-      if (name === 'replay') {
-        chatEngine.regenerateAIMessage();
-      }
-    },
-    [chatEngine]
-  );
-
-  // 渲染消息内容
-  const renderMessageContent = useCallback((item: AIMessageContent, index: number, isLast: boolean) => {
-    // 工具调用渲染
-    if (item.type === 'toolcall' || item.type.startsWith('toolcall-')) {
-      return (
-        <div slot={`${item.type}-${index}`} key={`toolcall-${index}`}>
-          <ToolCallRenderer toolCall={item.data} />
-        </div>
-      );
-    }
-    return null;
-  }, []);
-
-  // 渲染消息体
-  const renderMsgContents = useCallback(
-    (message: ChatMessagesData, isLast: boolean) => (
-      <>
-        {message.content?.map((item, index) => renderMessageContent(item as AIMessageContent, index, isLast))}
-        {isAIMessage(message) && message.status === 'complete' && (
-          <ChatActionBar slot="actionbar" actionBar={getActionBar(isLast)} handleAction={handleAction} />
+      <Drawer
+        header={activeReport ? `Report · ${activeReport.title}` : "Report"}
+        visible={chat.reportDrawerOpen}
+        onClose={() => chat.setReportOpen(false)}
+        closeBtn={false}
+        footer={(
+          <div className="report-drawer__footer">
+            <Button theme="primary" onClick={() => chat.setReportOpen(false)}>
+              关闭
+            </Button>
+          </div>
         )}
-      </>
-    ),
-    [renderMessageContent, handleAction]
-  );
+        size="480px"
+      >
+        {activeReport ? (
+          <div className="report-drawer__content">
+            <Space direction="vertical" style={{ width: "100%" }} size="small">
+              <Space size="small" align="center">
+                <Tag theme={activeReport.status === "open" ? "warning" : "success"} variant="outline">
+                  {activeReport.status === "open" ? "生成中" : "已完成"}
+                </Tag>
+                <Tag theme="default" variant="outline">docId: {activeReport.documentId}</Tag>
+                {activeReport.closedAt ? (
+                  <Tag theme="default" variant="outline">closedAt: {activeReport.closedAt}</Tag>
+                ) : null}
+              </Space>
+              {activeReport.reason ? (
+                <div>
+                  <Tag theme="default" variant="outline">reason</Tag>{" "}
+                  <span>{activeReport.reason}</span>
+                </div>
+              ) : null}
+              <Divider style={{ margin: "8px 0" }} />
+              <ChatMarkdown content={activeReport.content || "Waiting for report content..."} />
+            </Space>
+          </div>
+        ) : (
+          <div>Waiting for report document...</div>
+        )}
+      </Drawer>
 
-  // 发送消息
-  const handleSend = async (e: CustomEvent<TdChatSenderParams>) => {
-    const { value } = e.detail;
-    await chatEngine.sendUserMessage({ prompt: value });
-    setInputValue('');
-    setTimeout(() => {
-      listRef.current?.scrollList({ to: 'bottom' });
-    }, 100);
-  };
-
-  return (
-    <div className="agui-chat">
-      <div className="agui-chat__container">
-        <header className="agui-chat__header">
-          <h1 className="agui-chat__title">AG-UI + TDesign Chat Demo</h1>
-          <p className="agui-chat__subtitle">与 Go AG-UI 服务进行对话 | 支持工具调用 | 支持流式响应</p>
-        </header>
-
-        <div className="agui-chat__content">
-          <ChatList ref={listRef}>
-            {messages.map((message, idx) => (
-              <ChatMessage key={message.id} {...messageProps[message.role]} message={message}>
-                {renderMsgContents(message, idx === messages.length - 1)}
-              </ChatMessage>
-            ))}
-          </ChatList>
-
-          <ChatSender
-            value={inputValue}
-            placeholder={DEFAULT_PROMPT}
-            loading={senderLoading}
-            onChange={(e: CustomEvent) => setInputValue(e.detail)}
-            onSend={handleSend as any}
-            onStop={() => chatEngine.abortChat()}
-          />
-        </div>
-      </div>
-    </div>
+      <Drawer
+        header="错误详情"
+        visible={errorDrawerOpen}
+        onClose={() => setErrorDrawerOpen(false)}
+        closeBtn={false}
+        footer={(
+          <div className="report-drawer__footer">
+            <Button theme="primary" onClick={() => setErrorDrawerOpen(false)}>
+              关闭
+            </Button>
+          </div>
+        )}
+        size="520px"
+      >
+        <pre className="toolcall__code">{chat.lastError || "暂无错误信息。"}</pre>
+      </Drawer>
+    </Layout>
   );
 }

--- a/examples/agui/client/tdesign-chat/src/agui/format.ts
+++ b/examples/agui/client/tdesign-chat/src/agui/format.ts
@@ -1,0 +1,57 @@
+export function safeJsonParse(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+export function formatStructured(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return "";
+    }
+    const parsed = safeJsonParse(trimmed);
+    if (typeof parsed === "string") {
+      return parsed;
+    }
+    try {
+      return JSON.stringify(parsed, null, 2);
+    } catch {
+      return trimmed;
+    }
+  }
+  if (typeof value === "object") {
+    const maybeContent = (value as any)?.content;
+    if (typeof maybeContent === "string") {
+      return maybeContent.trimStart();
+    }
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch {
+      return String(value);
+    }
+  }
+  return String(value);
+}
+
+export function formatTimestamp(timestamp: number): string {
+  try {
+    const date = new Date(timestamp);
+    if (Number.isNaN(date.getTime())) {
+      return String(timestamp);
+    }
+    return new Intl.DateTimeFormat(undefined, {
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    }).format(date);
+  } catch {
+    return String(timestamp);
+  }
+}
+

--- a/examples/agui/client/tdesign-chat/src/agui/sse.ts
+++ b/examples/agui/client/tdesign-chat/src/agui/sse.ts
@@ -1,0 +1,84 @@
+export type AguiSseEvent = Record<string, any>;
+
+function parseSseFrame(frame: string): AguiSseEvent | null {
+  const lines = frame.split(/\r?\n/);
+  const dataLines: string[] = [];
+  for (const line of lines) {
+    if (line.startsWith("data:")) {
+      dataLines.push(line.slice("data:".length).trimStart());
+    }
+  }
+  const data = dataLines.join("\n").trim();
+  if (!data) {
+    return null;
+  }
+  try {
+    return JSON.parse(data) as AguiSseEvent;
+  } catch {
+    return { type: "RAW", raw: data };
+  }
+}
+
+export async function streamAguiSse(
+  url: string,
+  payload: unknown,
+  options: {
+    headers?: Record<string, string>;
+    signal?: AbortSignal;
+    onEvent: (evt: AguiSseEvent) => void;
+  },
+): Promise<void> {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "text/event-stream",
+      ...(options.headers ?? {}),
+    },
+    body: JSON.stringify(payload),
+    signal: options.signal,
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(`AG-UI request failed (${response.status}): ${text || response.statusText}`);
+  }
+
+  if (!response.body) {
+    throw new Error("AG-UI response body is empty.");
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) {
+      break;
+    }
+    buffer += decoder.decode(value, { stream: true });
+    buffer = buffer.replace(/\r\n/g, "\n");
+
+    while (true) {
+      const boundaryIndex = buffer.indexOf("\n\n");
+      if (boundaryIndex === -1) {
+        break;
+      }
+      const frame = buffer.slice(0, boundaryIndex);
+      buffer = buffer.slice(boundaryIndex + 2);
+      const event = parseSseFrame(frame);
+      if (event) {
+        options.onEvent(event);
+      }
+    }
+  }
+
+  const tail = buffer.trim();
+  if (tail) {
+    const event = parseSseFrame(tail);
+    if (event) {
+      options.onEvent(event);
+    }
+  }
+}

--- a/examples/agui/client/tdesign-chat/src/hooks/useAguiChat.ts
+++ b/examples/agui/client/tdesign-chat/src/hooks/useAguiChat.ts
@@ -1,0 +1,1631 @@
+import { useCallback, useRef, useState } from "react";
+import { formatStructured, safeJsonParse } from "../agui/format";
+import { streamAguiSse, type AguiSseEvent } from "../agui/sse";
+
+export type UiMessageRole = "user" | "assistant" | "tool" | "system";
+
+export type UiMessageKind =
+  | "text"
+  | "thinking"
+  | "tool-call"
+  | "tool-result"
+  | "custom"
+  | "system";
+
+export type UiMessage = {
+  id: string;
+  role: UiMessageRole;
+  kind: UiMessageKind;
+  title?: string;
+  content: string;
+  status?: "pending" | "streaming" | "complete" | "stop" | "error";
+  toolCall?: {
+    toolCallId: string;
+    toolCallName: string;
+    parentMessageId?: string;
+    args?: string;
+    result?: string;
+  };
+  timestamp: number;
+};
+
+export type RawAguiEvent = {
+  id: string;
+  type: string;
+  timestamp: number;
+  payload: AguiSseEvent;
+};
+
+type GraphInterrupt = {
+  key: string;
+  prompt: string;
+  checkpointId?: string;
+  lineageId?: string;
+};
+
+export type ReportSession = {
+  status: "open" | "closed";
+  title: string;
+  documentId: string;
+  createdAt?: string;
+  closedAt?: string;
+  reason?: string;
+  content: string;
+};
+
+export type AguiChatConfig = {
+  endpoint: string;
+  threadId: string;
+  forwardedProps?: Record<string, unknown>;
+};
+
+export type HistoryLoadResult =
+  | { ok: true; count: number }
+  | { ok: false; message: string };
+
+const REPORT_OPEN_TOOL_NAME = "open_report_sidebar";
+const GRAPH_APPROVAL_TOOL_NAME = "graph_interrupt_approval";
+
+function randomId(prefix: string) {
+  const now = Date.now();
+  const rand = Math.random().toString(16).slice(2);
+  return `${prefix}_${now}_${rand}`;
+}
+
+function sanitizeIdPart(value: string, maxLength = 96): string {
+  return value.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, maxLength);
+}
+
+function graphInterruptIdentity(interrupt: GraphInterrupt): string {
+  return [interrupt.checkpointId ?? "", interrupt.lineageId ?? "", interrupt.key ?? ""].filter(Boolean).join("|");
+}
+
+function isSessionNotFoundError(message: string): boolean {
+  return /session not found/i.test(message);
+}
+
+function normalizeRole(value: unknown): UiMessageRole {
+  if (value === "user" || value === "assistant" || value === "tool" || value === "system") {
+    return value;
+  }
+  return "assistant";
+}
+
+function extractActivityValue(value: unknown): Record<string, any> | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  return value as Record<string, any>;
+}
+
+function applyJsonPatch(root: Record<string, any>, ops: any[]) {
+  for (const op of ops) {
+    const operation = op?.op;
+    const path = typeof op?.path === "string" ? op.path : "";
+    const value = op?.value;
+    if (!path.startsWith("/")) {
+      continue;
+    }
+    const segments = path
+      .split("/")
+      .slice(1)
+      .filter(Boolean)
+      .map((seg: string) => seg.replace(/~1/g, "/").replace(/~0/g, "~"));
+    if (segments.length === 0) {
+      continue;
+    }
+    let target: any = root;
+    for (let i = 0; i < segments.length - 1; i += 1) {
+      const key = segments[i];
+      if (!target[key] || typeof target[key] !== "object") {
+        target[key] = {};
+      }
+      target = target[key];
+    }
+    const last = segments[segments.length - 1];
+    if (operation === "remove") {
+      delete target[last];
+      continue;
+    }
+    if (operation === "add" || operation === "replace") {
+      target[last] = value;
+    }
+  }
+}
+
+function normalizeJsonString(raw: string): string | undefined {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  try {
+    JSON.parse(trimmed);
+    return trimmed;
+  } catch {
+    return JSON.stringify(trimmed);
+  }
+}
+
+function restoreFromMessagesSnapshot(evt: AguiSseEvent): {
+  messages: UiMessage[];
+  reportSessions: ReportSession[];
+  activeReportId: string | null;
+  graphNodeId?: string;
+  graphInterrupt: GraphInterrupt | null;
+} {
+  const now = Date.now();
+  const timestamp = typeof evt.timestamp === "number" ? evt.timestamp : now;
+  const snapshotMessages = Array.isArray((evt as any).messages) ? (evt as any).messages : [];
+
+  const uiMessages: UiMessage[] = [];
+  const messageIndexById = new Map<string, number>();
+  const toolCallIndexById = new Map<string, number>();
+  const toolCallNameById = new Map<string, string>();
+  const toolCallArgsById = new Map<string, string>();
+
+  const activityState: Record<string, any> = {};
+  let graphNodeId: string | undefined;
+  let graphInterrupt: GraphInterrupt | null = null;
+
+  let activeThinkingIndex: number | null = null;
+  const reportSessions: ReportSession[] = [];
+  let activeReportId: string | null = null;
+
+  const upsertUiMessage = (id: string, updater: (prev: UiMessage | null) => UiMessage) => {
+    const index = messageIndexById.get(id);
+    if (index === undefined) {
+      const created = updater(null);
+      messageIndexById.set(created.id, uiMessages.length);
+      uiMessages.push(created);
+      return;
+    }
+    const prev = uiMessages[index] ?? null;
+    uiMessages[index] = updater(prev);
+  };
+
+  const upsertThinking = (updater: (prev: UiMessage | null) => UiMessage) => {
+    if (activeThinkingIndex === null) {
+      const created = updater(null);
+      activeThinkingIndex = uiMessages.length;
+      messageIndexById.set(created.id, activeThinkingIndex);
+      uiMessages.push(created);
+      return;
+    }
+    const prev = uiMessages[activeThinkingIndex] ?? null;
+    uiMessages[activeThinkingIndex] = updater(prev);
+  };
+
+  const getActiveReportSession = () => {
+    if (!activeReportId) {
+      return null;
+    }
+    return reportSessions.find((session) => session.documentId === activeReportId) ?? null;
+  };
+
+  const upsertReportSession = (next: ReportSession) => {
+    const index = reportSessions.findIndex((session) => session.documentId === next.documentId);
+    if (index === -1) {
+      reportSessions.push(next);
+      return;
+    }
+    reportSessions[index] = { ...reportSessions[index], ...next };
+  };
+
+  const appendReportContent = (text: string) => {
+    const active = getActiveReportSession();
+    if (!active || active.status !== "open") {
+      return;
+    }
+    const needsGap = active.content.trim().length > 0;
+    active.content = needsGap ? `${active.content}\n\n${text}` : `${active.content}${text}`;
+  };
+
+  for (const msg of snapshotMessages) {
+    const role = typeof msg?.role === "string" ? msg.role : "";
+
+    if (role === "user") {
+      const userContent = typeof msg?.content === "string" ? msg.content : formatStructured(msg?.content);
+      if (!userContent.trim()) {
+        activeThinkingIndex = null;
+        continue;
+      }
+
+      uiMessages.push({
+        id: typeof msg?.id === "string" ? msg.id : randomId("user_snapshot"),
+        role: "user",
+        kind: "text",
+        title: typeof msg?.name === "string" ? msg.name : "You",
+        content: userContent,
+        timestamp,
+      });
+      messageIndexById.set(uiMessages[uiMessages.length - 1].id, uiMessages.length - 1);
+      activeThinkingIndex = null;
+      continue;
+    }
+
+    if (role === "assistant") {
+      const content = typeof msg?.content === "string" ? msg.content : formatStructured(msg?.content);
+      if (getActiveReportSession()?.status === "open") {
+        if (content.trim()) {
+          appendReportContent(content);
+        }
+      } else if (content.trim()) {
+        uiMessages.push({
+          id: typeof msg?.id === "string" ? msg.id : randomId("assistant_snapshot"),
+          role: "assistant",
+          kind: "text",
+          title: typeof msg?.name === "string" ? msg.name : "Assistant",
+          content,
+          timestamp,
+        });
+        messageIndexById.set(uiMessages[uiMessages.length - 1].id, uiMessages.length - 1);
+      }
+
+      const toolCalls = Array.isArray(msg?.toolCalls) ? msg.toolCalls : [];
+      for (const toolCall of toolCalls) {
+        const toolCallId = typeof toolCall?.id === "string" ? toolCall.id : randomId("toolcall_snapshot");
+        const toolCallName = typeof toolCall?.function?.name === "string"
+          ? toolCall.function.name
+          : typeof toolCall?.name === "string"
+            ? toolCall.name
+            : "tool";
+        const args = typeof toolCall?.function?.arguments === "string"
+          ? toolCall.function.arguments
+          : typeof toolCall?.arguments === "string"
+            ? toolCall.arguments
+            : "";
+
+        toolCallNameById.set(toolCallId, toolCallName);
+        toolCallArgsById.set(toolCallId, args);
+
+        const next: UiMessage = {
+          id: toolCallId,
+          role: "assistant",
+          kind: "tool-call",
+          title: `Tool call: ${toolCallName}`,
+          content: args,
+          status: "complete",
+          toolCall: {
+            toolCallId,
+            toolCallName,
+            parentMessageId: typeof msg?.id === "string" ? msg.id : undefined,
+            args,
+          },
+          timestamp,
+        };
+        toolCallIndexById.set(toolCallId, uiMessages.length);
+        messageIndexById.set(toolCallId, uiMessages.length);
+        uiMessages.push(next);
+      }
+      continue;
+    }
+
+    if (role === "tool") {
+      const toolCallId = typeof msg?.toolCallId === "string" ? msg.toolCallId : "";
+      const raw = typeof msg?.content === "string" ? msg.content : formatStructured(msg?.content);
+      const normalized = raw ? normalizeJsonString(raw) : undefined;
+      const toolCallName = toolCallId ? toolCallNameById.get(toolCallId) : undefined;
+
+      if (toolCallName === "open_report_document") {
+        const payload = raw ? safeJsonParse(raw) : {};
+        const title = typeof (payload as any)?.title === "string" ? (payload as any).title : "Report";
+        const documentId = typeof (payload as any)?.documentId === "string"
+          ? (payload as any).documentId
+          : toolCallId || randomId("doc");
+        const createdAt = typeof (payload as any)?.createdAt === "string" ? (payload as any).createdAt : undefined;
+        upsertReportSession({ status: "open", title, documentId, createdAt, content: "" });
+        activeReportId = documentId;
+        const actionPayload: Record<string, any> = { title, documentId, status: "open" };
+        if (createdAt) {
+          actionPayload.createdAt = createdAt;
+        }
+        uiMessages.push({
+          id: `report_open_${documentId}`,
+          role: "assistant",
+          kind: "tool-call",
+          title: "Open report",
+          content: "",
+          status: "complete",
+          toolCall: {
+            toolCallId: `report_open_${documentId}`,
+            toolCallName: REPORT_OPEN_TOOL_NAME,
+            args: "",
+            result: JSON.stringify(actionPayload, null, 2),
+          },
+          timestamp,
+        });
+      }
+
+      if (toolCallName === "close_report_document" && activeReportId) {
+        const payload = raw ? safeJsonParse(raw) : {};
+        const closedAt = typeof (payload as any)?.closedAt === "string" ? (payload as any).closedAt : undefined;
+        const reason = typeof (payload as any)?.reason === "string"
+          ? (payload as any).reason
+          : typeof (payload as any)?.message === "string"
+            ? (payload as any).message
+            : undefined;
+        const active = getActiveReportSession();
+        upsertReportSession({
+          status: "closed",
+          title: active?.title ?? "Report",
+          documentId: activeReportId,
+          createdAt: active?.createdAt,
+          content: active?.content ?? "",
+          closedAt,
+          reason,
+        });
+
+        const actionMessageId = `report_open_${activeReportId}`;
+        const actionIndex = uiMessages.findIndex((entry) => entry.id === actionMessageId);
+        if (actionIndex !== -1) {
+          const payload: Record<string, any> = {
+            title: active?.title ?? "Report",
+            documentId: activeReportId,
+            status: "closed",
+          };
+          if (active?.createdAt) {
+            payload.createdAt = active.createdAt;
+          }
+          if (closedAt) {
+            payload.closedAt = closedAt;
+          }
+          if (reason) {
+            payload.reason = reason;
+          }
+          const prev = uiMessages[actionIndex];
+          uiMessages[actionIndex] = {
+            ...prev,
+            toolCall: prev.toolCall
+              ? { ...prev.toolCall, result: JSON.stringify(payload, null, 2) }
+              : { toolCallId: actionMessageId, toolCallName: REPORT_OPEN_TOOL_NAME, args: "", result: JSON.stringify(payload, null, 2) },
+          };
+        }
+      }
+
+      if (toolCallId && toolCallIndexById.has(toolCallId)) {
+        const index = toolCallIndexById.get(toolCallId)!;
+        const prev = uiMessages[index];
+        const name = prev?.toolCall?.toolCallName ?? toolCallNameById.get(toolCallId) ?? "tool";
+        const args = prev?.toolCall?.args ?? toolCallArgsById.get(toolCallId) ?? prev?.content ?? "";
+        uiMessages[index] = {
+          id: toolCallId,
+          role: "assistant",
+          kind: "tool-call",
+          title: `Tool call: ${name}`,
+          content: args,
+          status: "complete",
+          toolCall: {
+            toolCallId,
+            toolCallName: name,
+            parentMessageId: prev?.toolCall?.parentMessageId,
+            args,
+            result: normalized ?? prev?.toolCall?.result,
+          },
+          timestamp: prev?.timestamp ?? timestamp,
+        };
+        messageIndexById.set(toolCallId, index);
+      } else if (toolCallId && raw.trim()) {
+        const name = toolCallNameById.get(toolCallId) ?? "tool";
+        const args = toolCallArgsById.get(toolCallId) ?? "";
+        toolCallIndexById.set(toolCallId, uiMessages.length);
+        messageIndexById.set(toolCallId, uiMessages.length);
+        uiMessages.push({
+          id: toolCallId,
+          role: "assistant",
+          kind: "tool-call",
+          title: `Tool call: ${name}`,
+          content: args,
+          status: "complete",
+          toolCall: {
+            toolCallId,
+            toolCallName: name,
+            args,
+            result: normalized,
+          },
+          timestamp,
+        });
+      } else if (raw.trim()) {
+        const toolCallIdFallback = typeof msg?.id === "string" ? msg.id : randomId("tool_result");
+        const name = typeof msg?.name === "string" ? msg.name : "tool";
+        toolCallNameById.set(toolCallIdFallback, name);
+        toolCallArgsById.set(toolCallIdFallback, "");
+        toolCallIndexById.set(toolCallIdFallback, uiMessages.length);
+        messageIndexById.set(toolCallIdFallback, uiMessages.length);
+        uiMessages.push({
+          id: toolCallIdFallback,
+          role: "assistant",
+          kind: "tool-call",
+          title: `Tool result: ${name}`,
+          content: "",
+          status: "complete",
+          toolCall: {
+            toolCallId: toolCallIdFallback,
+            toolCallName: name,
+            args: "",
+            result: normalized,
+          },
+          timestamp,
+        });
+      }
+      activeThinkingIndex = null;
+      continue;
+    }
+
+    if (role === "activity") {
+      const activityType = typeof msg?.activityType === "string" ? msg.activityType : "";
+      if (activityType === "ACTIVITY_DELTA") {
+        const content = msg?.content as any;
+        const patch = Array.isArray(content?.patch) ? content.patch : [];
+        applyJsonPatch(activityState, patch);
+
+        const node = activityState.node;
+        if (node && typeof node.nodeId === "string") {
+          graphNodeId = node.nodeId;
+        }
+
+        if (Object.prototype.hasOwnProperty.call(activityState, "interrupt")) {
+          const interrupt = activityState.interrupt;
+          if (!interrupt) {
+            graphInterrupt = null;
+          } else if (typeof interrupt === "object") {
+            const key = typeof interrupt.key === "string" ? interrupt.key : "";
+            const prompt = typeof interrupt.prompt === "string" ? interrupt.prompt : "Interrupt received.";
+            graphInterrupt = {
+              key,
+              prompt,
+              checkpointId: typeof interrupt.checkpointId === "string" ? interrupt.checkpointId : undefined,
+              lineageId: typeof interrupt.lineageId === "string" ? interrupt.lineageId : undefined,
+            };
+
+            const identity = graphInterruptIdentity(graphInterrupt);
+            const messageId = identity ? `graph_interrupt_${sanitizeIdPart(identity) || "interrupt"}` : randomId("graph_interrupt");
+            upsertUiMessage(messageId, (prev) => {
+              const prevArgs = prev?.toolCall?.args ?? "";
+              const parsed = prevArgs ? safeJsonParse(prevArgs) : null;
+              const prevDecision = parsed && typeof parsed === "object" && typeof (parsed as any).decision === "string"
+                ? String((parsed as any).decision)
+                : "pending";
+              const decision = prevDecision === "approve" || prevDecision === "dismiss" ? prevDecision : "pending";
+              const args = JSON.stringify({ prompt, decision }, null, 2);
+              const nextTimestamp = prev?.timestamp ?? timestamp;
+              return {
+                id: messageId,
+                role: "assistant",
+                kind: "tool-call",
+                title: "Graph interrupt approval",
+                content: "",
+                status: "complete",
+                toolCall: {
+                  toolCallId: messageId,
+                  toolCallName: GRAPH_APPROVAL_TOOL_NAME,
+                  parentMessageId: prev?.toolCall?.parentMessageId,
+                  args,
+                  result: prev?.toolCall?.result,
+                },
+                timestamp: nextTimestamp,
+              };
+            });
+          }
+        }
+
+        if (activityState.resume && typeof activityState.resume === "object") {
+          const resume = activityState.resume as any;
+          const checkpointId = typeof resume.checkpointId === "string" ? resume.checkpointId : "";
+          const lineageId = typeof resume.lineageId === "string" ? resume.lineageId : "";
+          const resumeMap = resume.resumeMap && typeof resume.resumeMap === "object" ? resume.resumeMap as Record<string, any> : {};
+          const resumeKey = Object.keys(resumeMap)[0] ?? "";
+          const resumeValue = resumeKey ? resumeMap[resumeKey] : undefined;
+          const decision = resumeKey && resumeValue ? "approve" : "dismiss";
+
+          const identity = [checkpointId, lineageId, resumeKey].filter(Boolean).join("|");
+          if (identity) {
+            const messageId = `graph_interrupt_${sanitizeIdPart(identity) || "interrupt"}`;
+            upsertUiMessage(messageId, (prev) => {
+              const prevArgs = prev?.toolCall?.args ?? "";
+              const parsed = prevArgs ? safeJsonParse(prevArgs) : null;
+              const prompt = parsed && typeof parsed === "object" ? String((parsed as any).prompt ?? "") : "";
+              const args = JSON.stringify({ prompt, decision }, null, 2);
+              const nextTimestamp = prev?.timestamp ?? timestamp;
+              return {
+                id: messageId,
+                role: "assistant",
+                kind: "tool-call",
+                title: "Graph interrupt approval",
+                content: "",
+                status: "complete",
+                toolCall: {
+                  toolCallId: messageId,
+                  toolCallName: GRAPH_APPROVAL_TOOL_NAME,
+                  parentMessageId: prev?.toolCall?.parentMessageId,
+                  args,
+                  result: prev?.toolCall?.result,
+                },
+                timestamp: nextTimestamp,
+              };
+            });
+          }
+        }
+
+        delete activityState.resume;
+        continue;
+      }
+
+      if (activityType !== "CUSTOM") {
+        continue;
+      }
+      const content = msg?.content;
+      const name = typeof (content as any)?.name === "string" ? (content as any).name : "";
+      const value = (content as any)?.value;
+
+      if (name === "think_start") {
+        upsertThinking(() => ({
+          id: typeof msg?.id === "string" ? msg.id : randomId("thinking_snapshot"),
+          role: "assistant",
+          kind: "thinking",
+          title: "Thinking",
+          content: "",
+          status: "streaming",
+          timestamp,
+        }));
+        continue;
+      }
+
+      if (name === "think_content") {
+        const chunk = typeof value === "string" ? value : formatStructured(value);
+        if (!chunk) {
+          continue;
+        }
+        upsertThinking((prev) => {
+          const previous = prev?.content ?? "";
+          return {
+            id: prev?.id ?? randomId("thinking_snapshot"),
+            role: "assistant",
+            kind: "thinking",
+            title: prev?.title ?? "Thinking",
+            content: previous + chunk,
+            status: "streaming",
+            timestamp: prev?.timestamp ?? timestamp,
+          };
+        });
+        continue;
+      }
+
+      if (name === "think_end") {
+        if (activeThinkingIndex !== null) {
+          const prev = uiMessages[activeThinkingIndex] ?? null;
+          uiMessages[activeThinkingIndex] = {
+            id: prev?.id ?? (typeof msg?.id === "string" ? msg.id : randomId("thinking_snapshot")),
+            role: "assistant",
+            kind: "thinking",
+            title: prev?.title ?? "Thinking",
+            content: prev?.content ?? "",
+            status: "complete",
+            timestamp: prev?.timestamp ?? timestamp,
+          };
+        }
+        activeThinkingIndex = null;
+        continue;
+      }
+
+      if (name === "node.progress") {
+        continue;
+      }
+
+      if (name.startsWith("react.")) {
+        const suffix = name.slice("react.".length);
+        const title = suffix ? `React ${suffix}` : "React event";
+        const text = formatStructured(value);
+        if (!text) {
+          continue;
+        }
+        uiMessages.push({
+          id: typeof msg?.id === "string" ? msg.id : randomId("react_snapshot"),
+          role: "assistant",
+          kind: "thinking",
+          title,
+          content: text,
+          status: "complete",
+          timestamp,
+        });
+        activeThinkingIndex = null;
+        continue;
+      }
+
+      const text = formatStructured(value);
+      if (!text) {
+        continue;
+      }
+      uiMessages.push({
+        id: typeof msg?.id === "string" ? msg.id : randomId("custom_snapshot"),
+        role: "assistant",
+        kind: "thinking",
+        title: name ? `Custom ${name}` : "Custom event",
+        content: text,
+        status: "complete",
+        timestamp,
+      });
+      activeThinkingIndex = null;
+      continue;
+    }
+  }
+
+  if (activeThinkingIndex !== null) {
+    const prev = uiMessages[activeThinkingIndex] ?? null;
+    uiMessages[activeThinkingIndex] = {
+      id: prev?.id ?? randomId("thinking_snapshot"),
+      role: "assistant",
+      kind: "thinking",
+      title: prev?.title ?? "Thinking",
+      content: prev?.content ?? "",
+      status: prev?.status ?? "complete",
+      timestamp: prev?.timestamp ?? timestamp,
+    };
+  }
+
+  return {
+    messages: uiMessages,
+    reportSessions,
+    activeReportId,
+    graphNodeId,
+    graphInterrupt,
+  };
+}
+
+export function useAguiChat(config: AguiChatConfig) {
+  const [messages, setMessages] = useState<UiMessage[]>([]);
+  const [rawEvents, setRawEvents] = useState<RawAguiEvent[]>([]);
+  const [inProgress, setInProgress] = useState(false);
+  const [finishReason, setFinishReason] = useState<string | undefined>();
+  const [lastError, setLastError] = useState<string | null>(null);
+  const [graphNodeId, setGraphNodeId] = useState<string | undefined>();
+  const [graphInterrupt, setGraphInterrupt] = useState<GraphInterrupt | null>(null);
+  const [progress, setProgress] = useState<{ percent: number; label?: string } | null>(null);
+  const [reportSessions, setReportSessions] = useState<ReportSession[]>([]);
+  const [activeReportId, setActiveReportId] = useState<string | null>(null);
+  const [reportDrawerOpen, setReportDrawerOpen] = useState(false);
+
+  const abortRef = useRef<AbortController | null>(null);
+  const messageIndexByIdRef = useRef<Map<string, number>>(new Map());
+  const toolCallNameByIdRef = useRef<Map<string, string>>(new Map());
+  const toolCallArgsByIdRef = useRef<Map<string, string>>(new Map());
+  const activityStateRef = useRef<Record<string, any>>({});
+  const activeThinkingRef = useRef<{ id: string; active: boolean } | null>(null);
+  const reportSessionsRef = useRef<ReportSession[]>([]);
+  const writingReportIdRef = useRef<string | null>(null);
+  const graphInterruptIdentityRef = useRef<string | null>(null);
+  const graphApprovalMessageIdRef = useRef<string | null>(null);
+  const rawEventsRef = useRef<RawAguiEvent[]>([]);
+  const rawEventsFlushRef = useRef<number | null>(null);
+
+  reportSessionsRef.current = reportSessions;
+
+  const addMessage = useCallback((message: UiMessage) => {
+    setMessages((prev) => {
+      const next = [...prev, message];
+      messageIndexByIdRef.current.set(message.id, next.length - 1);
+      return next;
+    });
+  }, []);
+
+  const replaceMessages = useCallback((next: UiMessage[]) => {
+    messageIndexByIdRef.current.clear();
+    toolCallNameByIdRef.current.clear();
+    toolCallArgsByIdRef.current.clear();
+    activeThinkingRef.current = null;
+
+    next.forEach((msg, index) => {
+      messageIndexByIdRef.current.set(msg.id, index);
+      if (msg.kind === "tool-call" && msg.toolCall?.toolCallId) {
+        toolCallNameByIdRef.current.set(msg.toolCall.toolCallId, msg.toolCall.toolCallName);
+        if (typeof msg.toolCall.args === "string") {
+          toolCallArgsByIdRef.current.set(msg.toolCall.toolCallId, msg.toolCall.args);
+        }
+      }
+    });
+
+    setMessages(next);
+  }, []);
+
+  const upsertMessage = useCallback((id: string, updater: (msg: UiMessage | null) => UiMessage) => {
+    setMessages((prev) => {
+      const index = messageIndexByIdRef.current.get(id);
+      if (index === undefined) {
+        const created = updater(null);
+        const next = [...prev, created];
+        messageIndexByIdRef.current.set(created.id, next.length - 1);
+        return next;
+      }
+      const existing = prev[index] ?? null;
+      const updated = updater(existing);
+      const next = prev.slice();
+      next[index] = updated;
+      return next;
+    });
+  }, []);
+
+  const flushRawEvents = useCallback(() => {
+    rawEventsFlushRef.current = null;
+    setRawEvents([...rawEventsRef.current]);
+  }, []);
+
+  const setReportOpen = useCallback((open: boolean) => {
+    setReportDrawerOpen(open);
+  }, []);
+
+  const openReport = useCallback((documentId: string) => {
+    if (!documentId) {
+      return;
+    }
+    setActiveReportId(documentId);
+    setReportDrawerOpen(true);
+  }, []);
+
+  const updateReportSessions = useCallback((updater: (prev: ReportSession[]) => ReportSession[]) => {
+    const next = updater(reportSessionsRef.current);
+    reportSessionsRef.current = next;
+    setReportSessions(next);
+  }, []);
+
+  const appendRawEvent = useCallback(
+    (evt: AguiSseEvent) => {
+      const timestamp = typeof evt.timestamp === "number" ? evt.timestamp : Date.now();
+      const type = typeof evt.type === "string" ? evt.type : "UNKNOWN";
+      const next: RawAguiEvent = {
+        id: randomId("raw"),
+        type,
+        timestamp,
+        payload: evt,
+      };
+      const limit = 800;
+      const prev = rawEventsRef.current;
+      rawEventsRef.current = prev.length >= limit ? [...prev.slice(prev.length - limit + 1), next] : [...prev, next];
+      if (rawEventsFlushRef.current === null) {
+        rawEventsFlushRef.current = window.requestAnimationFrame(flushRawEvents);
+      }
+    },
+    [flushRawEvents],
+  );
+
+  const clearRawEvents = useCallback(() => {
+    rawEventsRef.current = [];
+    flushRawEvents();
+  }, [flushRawEvents]);
+
+  const abortActiveRun = useCallback(() => {
+    const controller = abortRef.current;
+    if (!controller) {
+      return;
+    }
+    controller.abort();
+    abortRef.current = null;
+  }, []);
+
+  const handleCustomEvent = useCallback(
+    (evt: AguiSseEvent) => {
+      const name = typeof evt.name === "string" ? evt.name : "custom";
+      const value = evt.value;
+
+      if (name === "think_start") {
+        const id = randomId("thinking");
+        activeThinkingRef.current = { id, active: true };
+        addMessage({
+          id,
+          role: "assistant",
+          kind: "thinking",
+          title: "Thinking",
+          content: "",
+          status: "streaming",
+          timestamp: evt.timestamp ?? Date.now(),
+        });
+        return;
+      }
+
+      if (name === "think_content") {
+        const chunk = typeof value === "string" ? value : formatStructured(value);
+        const active = activeThinkingRef.current;
+        if (!active?.id) {
+          const id = randomId("thinking");
+          activeThinkingRef.current = { id, active: true };
+          addMessage({
+            id,
+            role: "assistant",
+            kind: "thinking",
+            title: "Thinking",
+            content: chunk,
+            status: "streaming",
+            timestamp: evt.timestamp ?? Date.now(),
+          });
+          return;
+        }
+        upsertMessage(active.id, (msg) => {
+          const prev = msg?.content ?? "";
+          return {
+            id: active.id,
+            role: "assistant",
+            kind: "thinking",
+            title: "Thinking",
+            content: prev + chunk,
+            status: "streaming",
+            timestamp: msg?.timestamp ?? evt.timestamp ?? Date.now(),
+          };
+        });
+        return;
+      }
+
+      if (name === "think_end") {
+        const active = activeThinkingRef.current;
+        if (active?.id) {
+          upsertMessage(active.id, (msg) => {
+            return {
+              id: active.id,
+              role: "assistant",
+              kind: "thinking",
+              title: msg?.title ?? "Thinking",
+              content: msg?.content ?? "",
+              status: "complete",
+              timestamp: msg?.timestamp ?? evt.timestamp ?? Date.now(),
+            };
+          });
+        }
+        activeThinkingRef.current = null;
+        return;
+      }
+
+      if (name === "node.progress") {
+        const parsed = extractActivityValue(value) ?? {};
+        const percent = Number(parsed.progress ?? parsed.percent ?? parsed.value ?? 0);
+        const label = typeof parsed.message === "string" ? parsed.message : undefined;
+        if (!Number.isNaN(percent)) {
+          setProgress({ percent, label });
+        }
+        return;
+      }
+
+      if (name.startsWith("react.")) {
+        const content = formatStructured(value);
+        if (!content) {
+          return;
+        }
+        const suffix = name.slice("react.".length);
+        const title = suffix ? `React ${suffix}` : "React event";
+        addMessage({
+          id: randomId("react"),
+          role: "assistant",
+          kind: "thinking",
+          title,
+          content,
+          status: "complete",
+          timestamp: evt.timestamp ?? Date.now(),
+        });
+        return;
+      }
+    },
+    [addMessage, upsertMessage],
+  );
+
+  const handleActivityDelta = useCallback(
+    (evt: AguiSseEvent) => {
+      const ops = Array.isArray(evt.patch) ? evt.patch : [];
+      const root = activityStateRef.current;
+      applyJsonPatch(root, ops);
+
+      const node = root.node;
+      if (node && typeof node.nodeId === "string") {
+        setGraphNodeId(node.nodeId);
+      }
+
+      if (Object.prototype.hasOwnProperty.call(root, "interrupt")) {
+        const interrupt = root.interrupt;
+        if (!interrupt) {
+          setGraphInterrupt(null);
+          graphInterruptIdentityRef.current = null;
+          graphApprovalMessageIdRef.current = null;
+        } else if (typeof interrupt === "object") {
+          const key = typeof interrupt.key === "string" ? interrupt.key : "";
+          const prompt = typeof interrupt.prompt === "string" ? interrupt.prompt : "Interrupt received.";
+          const nextInterrupt: GraphInterrupt = {
+            key,
+            prompt,
+            checkpointId: typeof interrupt.checkpointId === "string" ? interrupt.checkpointId : undefined,
+            lineageId: typeof interrupt.lineageId === "string" ? interrupt.lineageId : undefined,
+          };
+          setGraphInterrupt(nextInterrupt);
+
+          const identity = graphInterruptIdentity(nextInterrupt);
+          if (identity && graphInterruptIdentityRef.current !== identity) {
+            graphInterruptIdentityRef.current = identity;
+            graphApprovalMessageIdRef.current = `graph_interrupt_${sanitizeIdPart(identity) || "interrupt"}`;
+          }
+          if (!graphApprovalMessageIdRef.current) {
+            graphApprovalMessageIdRef.current = randomId("graph_interrupt");
+          }
+
+          const messageId = graphApprovalMessageIdRef.current;
+          upsertMessage(messageId, (msg) => {
+            const prevArgs = msg?.toolCall?.args ?? "";
+            const parsed = prevArgs ? safeJsonParse(prevArgs) : null;
+            const prevDecision = parsed && typeof parsed === "object" && typeof (parsed as any).decision === "string"
+              ? String((parsed as any).decision)
+              : "pending";
+            const decision = prevDecision === "approve" || prevDecision === "dismiss" ? prevDecision : "pending";
+            const args = JSON.stringify({ prompt, decision }, null, 2);
+            const timestamp = msg?.timestamp ?? evt.timestamp ?? Date.now();
+            return {
+              id: messageId,
+              role: "assistant",
+              kind: "tool-call",
+              title: "Graph interrupt approval",
+              content: "",
+              status: "complete",
+              toolCall: {
+                toolCallId: messageId,
+                toolCallName: GRAPH_APPROVAL_TOOL_NAME,
+                parentMessageId: msg?.toolCall?.parentMessageId,
+                args,
+                result: msg?.toolCall?.result,
+              },
+              timestamp,
+            };
+          });
+        }
+      }
+
+      delete root.resume;
+    },
+    [upsertMessage],
+  );
+
+  const handleToolCallResult = useCallback(
+    (evt: AguiSseEvent) => {
+      const toolCallId = typeof evt.toolCallId === "string" ? evt.toolCallId : "";
+      const toolName = toolCallNameByIdRef.current.get(toolCallId) ?? "";
+      const raw = typeof evt.content === "string" ? evt.content : "";
+      const structured = raw ? formatStructured(safeJsonParse(raw)) : "";
+      const normalized = structured ? normalizeJsonString(structured) : undefined;
+
+      if (toolName === "open_report_document") {
+        const payload = (typeof raw === "string" && raw ? safeJsonParse(raw) : {}) as any;
+        const title = typeof payload?.title === "string" ? payload.title : "Report";
+        const documentId = typeof payload?.documentId === "string" ? payload.documentId : toolCallId || randomId("doc");
+        const createdAt = typeof payload?.createdAt === "string" ? payload.createdAt : undefined;
+        const next: ReportSession = { status: "open", title, documentId, createdAt, content: "" };
+        writingReportIdRef.current = documentId;
+        updateReportSessions((prev) => {
+          const index = prev.findIndex((session) => session.documentId === documentId);
+          if (index === -1) {
+            return [...prev, next];
+          }
+          const copy = prev.slice();
+          copy[index] = { ...copy[index], ...next };
+          return copy;
+        });
+        setActiveReportId(documentId);
+        setReportDrawerOpen(true);
+
+        const actionMessageId = `report_open_${documentId}`;
+        const actionPayload: Record<string, any> = { title, documentId, status: "open" };
+        if (createdAt) {
+          actionPayload.createdAt = createdAt;
+        }
+        upsertMessage(actionMessageId, (msg) => {
+          const timestamp = msg?.timestamp ?? evt.timestamp ?? Date.now();
+          return {
+            id: actionMessageId,
+            role: "assistant",
+            kind: "tool-call",
+            title: "Open report",
+            content: "",
+            status: "complete",
+            toolCall: {
+              toolCallId: actionMessageId,
+              toolCallName: REPORT_OPEN_TOOL_NAME,
+              parentMessageId: typeof evt.parentMessageId === "string" ? evt.parentMessageId : msg?.toolCall?.parentMessageId,
+              args: "",
+              result: JSON.stringify(actionPayload, null, 2),
+            },
+            timestamp,
+          };
+        });
+      }
+
+      if (toolName === "close_report_document") {
+        const payload = (typeof raw === "string" && raw ? safeJsonParse(raw) : {}) as any;
+        const closedAt = typeof payload?.closedAt === "string" ? payload.closedAt : undefined;
+        const reason = typeof payload?.reason === "string"
+          ? payload.reason
+          : typeof payload?.message === "string"
+            ? payload.message
+            : undefined;
+        const payloadDocumentId = typeof payload?.documentId === "string" ? payload.documentId : "";
+        const targetId = payloadDocumentId.trim()
+          || writingReportIdRef.current
+          || reportSessionsRef.current.slice().reverse().find((session) => session.status === "open")?.documentId
+          || "";
+        if (targetId) {
+          const session = reportSessionsRef.current.find((entry) => entry.documentId === targetId) ?? null;
+          updateReportSessions((prev) => {
+            const index = prev.findIndex((session) => session.documentId === targetId);
+            if (index === -1) {
+              return prev;
+            }
+            const copy = prev.slice();
+            copy[index] = { ...copy[index], status: "closed", closedAt, reason };
+            return copy;
+          });
+          const actionMessageId = `report_open_${targetId}`;
+          const actionPayload: Record<string, any> = {
+            title: session?.title ?? "Report",
+            documentId: targetId,
+            status: "closed",
+          };
+          if (session?.createdAt) {
+            actionPayload.createdAt = session.createdAt;
+          }
+          if (closedAt) {
+            actionPayload.closedAt = closedAt;
+          }
+          if (reason) {
+            actionPayload.reason = reason;
+          }
+          upsertMessage(actionMessageId, (msg) => {
+            const timestamp = msg?.timestamp ?? evt.timestamp ?? Date.now();
+            return {
+              id: actionMessageId,
+              role: "assistant",
+              kind: "tool-call",
+              title: "Open report",
+              content: "",
+              status: "complete",
+              toolCall: {
+                toolCallId: actionMessageId,
+                toolCallName: REPORT_OPEN_TOOL_NAME,
+                parentMessageId: msg?.toolCall?.parentMessageId,
+                args: "",
+                result: JSON.stringify(actionPayload, null, 2),
+              },
+              timestamp,
+            };
+          });
+        }
+        if (writingReportIdRef.current && writingReportIdRef.current === targetId) {
+          writingReportIdRef.current = null;
+        }
+      }
+
+      if (toolCallId) {
+        upsertMessage(toolCallId, (msg) => {
+          const args = msg?.toolCall?.args ?? toolCallArgsByIdRef.current.get(toolCallId) ?? msg?.content ?? "";
+          const name = msg?.toolCall?.toolCallName ?? (toolName || "tool");
+          return {
+            id: toolCallId,
+            role: "assistant",
+            kind: "tool-call",
+            title: `Tool call: ${name}`,
+            content: args,
+            status: "complete",
+            toolCall: {
+              toolCallId,
+              toolCallName: name,
+              parentMessageId: typeof evt.parentMessageId === "string" ? evt.parentMessageId : msg?.toolCall?.parentMessageId,
+              args,
+              result: normalized ?? msg?.toolCall?.result,
+            },
+            timestamp: msg?.timestamp ?? evt.timestamp ?? Date.now(),
+          };
+        });
+      }
+    },
+    [updateReportSessions, upsertMessage],
+  );
+
+  const handleEvent = useCallback(
+    (evt: AguiSseEvent) => {
+      const type = typeof evt.type === "string" ? evt.type : "UNKNOWN";
+
+      if (type === "RUN_STARTED") {
+        appendRawEvent(evt);
+        setInProgress(true);
+        setFinishReason(undefined);
+        setLastError(null);
+        setGraphNodeId(undefined);
+        setGraphInterrupt(null);
+        setProgress(null);
+        return;
+      }
+
+      if (type === "RUN_FINISHED") {
+        appendRawEvent(evt);
+        setInProgress(false);
+        abortRef.current = null;
+        const result = typeof evt.result === "string" ? evt.result : undefined;
+        setFinishReason(result);
+        return;
+      }
+
+      if (type === "RUN_ERROR") {
+        appendRawEvent(evt);
+        setInProgress(false);
+        abortRef.current = null;
+        const msg = typeof evt.message === "string" ? evt.message : "Run error.";
+        setLastError(msg);
+        return;
+      }
+
+      if (type === "TEXT_MESSAGE_START") {
+        appendRawEvent(evt);
+        const writingId = writingReportIdRef.current;
+        if (writingId) {
+          const active = reportSessionsRef.current.find((session) => session.documentId === writingId) ?? null;
+          if (active?.status === "open") {
+            updateReportSessions((prev) => {
+              const index = prev.findIndex((session) => session.documentId === writingId);
+              if (index === -1) {
+                return prev;
+              }
+              const current = prev[index];
+              const needsGap = current.content.trim().length > 0;
+              if (!needsGap) {
+                return prev;
+              }
+              const copy = prev.slice();
+              copy[index] = { ...current, content: `${current.content}\n\n` };
+              return copy;
+            });
+            return;
+          }
+        }
+        const messageId = typeof evt.messageId === "string" ? evt.messageId : randomId("assistant");
+        addMessage({
+          id: messageId,
+          role: normalizeRole(evt.role),
+          kind: "text",
+          title: "Assistant",
+          content: "",
+          timestamp: evt.timestamp ?? Date.now(),
+        });
+        return;
+      }
+
+      if (type === "TEXT_MESSAGE_CONTENT") {
+        appendRawEvent(evt);
+        const delta = typeof evt.delta === "string" ? evt.delta : "";
+        if (!delta) {
+          return;
+        }
+        const writingId = writingReportIdRef.current;
+        if (writingId) {
+          const active = reportSessionsRef.current.find((session) => session.documentId === writingId) ?? null;
+          if (active?.status === "open") {
+            updateReportSessions((prev) => {
+              const index = prev.findIndex((session) => session.documentId === writingId);
+              if (index === -1) {
+                return prev;
+              }
+              const current = prev[index];
+              const copy = prev.slice();
+              copy[index] = { ...current, content: current.content + delta };
+              return copy;
+            });
+            return;
+          }
+        }
+        const messageId = typeof evt.messageId === "string" ? evt.messageId : "";
+        if (!messageId) {
+          return;
+        }
+        upsertMessage(messageId, (msg) => {
+          const prev = msg?.content ?? "";
+          return {
+            id: messageId,
+            role: "assistant",
+            kind: "text",
+            title: msg?.title ?? "Assistant",
+            content: prev + delta,
+            timestamp: msg?.timestamp ?? evt.timestamp ?? Date.now(),
+          };
+        });
+        return;
+      }
+
+      if (type === "TOOL_CALL_START") {
+        appendRawEvent(evt);
+        const toolCallId = typeof evt.toolCallId === "string" ? evt.toolCallId : randomId("tool_call");
+        const toolCallName = typeof evt.toolCallName === "string" ? evt.toolCallName : "tool";
+        toolCallNameByIdRef.current.set(toolCallId, toolCallName);
+        toolCallArgsByIdRef.current.set(toolCallId, "");
+
+        addMessage({
+          id: toolCallId,
+          role: "assistant",
+          kind: "tool-call",
+          title: `Tool call: ${toolCallName}`,
+          content: "",
+          status: "streaming",
+          toolCall: {
+            toolCallId,
+            toolCallName,
+            parentMessageId: typeof evt.parentMessageId === "string" ? evt.parentMessageId : undefined,
+            args: "",
+          },
+          timestamp: evt.timestamp ?? Date.now(),
+        });
+        return;
+      }
+
+      if (type === "TOOL_CALL_ARGS") {
+        appendRawEvent(evt);
+        const toolCallId = typeof evt.toolCallId === "string" ? evt.toolCallId : "";
+        const delta = typeof evt.delta === "string" ? evt.delta : "";
+        if (!toolCallId || !delta) {
+          return;
+        }
+        const prev = toolCallArgsByIdRef.current.get(toolCallId) ?? "";
+        toolCallArgsByIdRef.current.set(toolCallId, prev + delta);
+        upsertMessage(toolCallId, (msg) => {
+          const next = (msg?.content ?? "") + delta;
+          const toolCallName = msg?.toolCall?.toolCallName ?? toolCallNameByIdRef.current.get(toolCallId) ?? "tool";
+          return {
+            id: toolCallId,
+            role: "assistant",
+            kind: "tool-call",
+            title: msg?.title ?? "Tool call",
+            content: next,
+            status: msg?.status ?? "streaming",
+            toolCall: {
+              toolCallId,
+              toolCallName,
+              parentMessageId: msg?.toolCall?.parentMessageId,
+              args: next,
+              result: msg?.toolCall?.result,
+            },
+            timestamp: msg?.timestamp ?? evt.timestamp ?? Date.now(),
+          };
+        });
+        return;
+      }
+
+      if (type === "TOOL_CALL_RESULT") {
+        appendRawEvent(evt);
+        handleToolCallResult(evt);
+        return;
+      }
+
+      if (type === "CUSTOM") {
+        appendRawEvent(evt);
+        handleCustomEvent(evt);
+        return;
+      }
+
+      if (type === "ACTIVITY_DELTA") {
+        appendRawEvent(evt);
+        handleActivityDelta(evt);
+        return;
+      }
+      appendRawEvent(evt);
+    },
+    [addMessage, appendRawEvent, handleActivityDelta, handleCustomEvent, handleToolCallResult, updateReportSessions, upsertMessage],
+  );
+
+  const stop = useCallback(() => {
+    abortActiveRun();
+    setInProgress(false);
+  }, [abortActiveRun]);
+
+  const run = useCallback(
+    async (payload: Record<string, any>) => {
+      abortActiveRun();
+      const controller = new AbortController();
+      abortRef.current = controller;
+      setInProgress(true);
+
+      try {
+        await streamAguiSse(config.endpoint, payload, {
+          signal: controller.signal,
+          onEvent: handleEvent,
+        });
+      } catch (error: any) {
+        if (controller.signal.aborted) {
+          return;
+        }
+        setInProgress(false);
+        abortRef.current = null;
+        setLastError(String(error?.message ?? error));
+      }
+    },
+    [abortActiveRun, config.endpoint, handleEvent],
+  );
+
+  const loadHistory = useCallback(
+    async (options?: { endpoint?: string; threadId?: string; forwardedProps?: Record<string, unknown> }): Promise<HistoryLoadResult> => {
+      const historyEndpoint = options?.endpoint ?? "";
+      if (!historyEndpoint) {
+        const message = "history endpoint is empty";
+        setLastError(message);
+        return { ok: false, message };
+      }
+
+      abortActiveRun();
+      setLastError(null);
+      const controller = new AbortController();
+      abortRef.current = controller;
+      setInProgress(true);
+
+      let snapshotEvent: AguiSseEvent | null = null;
+      let runError: string | null = null;
+
+      const threadId = options?.threadId ?? config.threadId;
+      const forwardedProps = options?.forwardedProps ?? config.forwardedProps;
+
+      const payload: Record<string, any> = {
+        threadId,
+        runId: randomId("history"),
+        messages: [{ role: "user", content: "" }],
+      };
+      if (forwardedProps && Object.keys(forwardedProps).length > 0) {
+        payload.forwardedProps = forwardedProps;
+      }
+
+      try {
+        await streamAguiSse(historyEndpoint, payload, {
+          signal: controller.signal,
+          onEvent: (evt) => {
+            appendRawEvent(evt);
+            const type = typeof evt.type === "string" ? evt.type : "";
+            if (type === "MESSAGES_SNAPSHOT") {
+              snapshotEvent = evt;
+            }
+            if (type === "RUN_ERROR") {
+              runError = typeof (evt as any).message === "string" ? (evt as any).message : "Run error.";
+            }
+          },
+        });
+      } catch (error: any) {
+        if (controller.signal.aborted) {
+          setInProgress(false);
+          abortRef.current = null;
+          return { ok: false, message: "aborted" };
+        }
+        const message = String(error?.message ?? error);
+        setInProgress(false);
+        abortRef.current = null;
+        if (!isSessionNotFoundError(message)) {
+          setLastError(message);
+        }
+        return { ok: false, message };
+      }
+
+      setInProgress(false);
+      abortRef.current = null;
+
+      if (!snapshotEvent) {
+        const message = runError ?? "history snapshot not found";
+        if (!isSessionNotFoundError(message)) {
+          setLastError(message);
+        }
+        return { ok: false, message };
+      }
+
+      const restored = restoreFromMessagesSnapshot(snapshotEvent);
+      replaceMessages(restored.messages);
+      reportSessionsRef.current = restored.reportSessions;
+      setReportSessions(restored.reportSessions);
+      const openReport = restored.reportSessions.slice().reverse().find((session) => session.status === "open") ?? null;
+      writingReportIdRef.current = openReport ? openReport.documentId : null;
+      const nextActiveReportId = openReport?.documentId ?? restored.activeReportId;
+      setActiveReportId(nextActiveReportId);
+      setReportDrawerOpen(Boolean(openReport));
+      setGraphNodeId(restored.graphNodeId);
+      setGraphInterrupt(restored.graphInterrupt);
+
+      return { ok: true, count: restored.messages.length };
+    },
+    [abortActiveRun, appendRawEvent, config.forwardedProps, config.threadId, replaceMessages, setLastError],
+  );
+
+  const send = useCallback(
+    async (text: string) => {
+      const trimmed = text.trim();
+      if (!trimmed) {
+        return;
+      }
+
+      addMessage({
+        id: randomId("user"),
+        role: "user",
+        kind: "text",
+        title: "You",
+        content: trimmed,
+        timestamp: Date.now(),
+      });
+
+      const payload: Record<string, any> = {
+        threadId: config.threadId,
+        runId: randomId("run"),
+        messages: [{ role: "user", content: trimmed }],
+      };
+      if (config.forwardedProps && Object.keys(config.forwardedProps).length > 0) {
+        payload.forwardedProps = config.forwardedProps;
+      }
+
+      await run(payload);
+    },
+    [addMessage, config.forwardedProps, config.threadId, run],
+  );
+
+  const approveGraphInterrupt = useCallback(async () => {
+    if (!graphInterrupt) {
+      return;
+    }
+
+    const identity = graphInterruptIdentity(graphInterrupt);
+    const derivedMessageId = identity ? `graph_interrupt_${sanitizeIdPart(identity) || "interrupt"}` : "";
+    const messageId = graphApprovalMessageIdRef.current || derivedMessageId || randomId("graph_interrupt");
+    graphApprovalMessageIdRef.current = messageId;
+
+    upsertMessage(messageId, (msg) => {
+      const prevArgs = msg?.toolCall?.args ?? "";
+      const parsed = prevArgs ? safeJsonParse(prevArgs) : null;
+      const prompt = graphInterrupt.prompt || (parsed && typeof parsed === "object" ? String((parsed as any).prompt ?? "") : "");
+      const args = JSON.stringify({ prompt, decision: "approve" }, null, 2);
+      return {
+        id: msg?.id ?? messageId,
+        role: "assistant",
+        kind: "tool-call",
+        title: msg?.title ?? "Graph interrupt approval",
+        content: msg?.content ?? "",
+        status: msg?.status ?? "complete",
+        toolCall: {
+          toolCallId: messageId,
+          toolCallName: GRAPH_APPROVAL_TOOL_NAME,
+          parentMessageId: msg?.toolCall?.parentMessageId,
+          args,
+          result: msg?.toolCall?.result,
+        },
+        timestamp: msg?.timestamp ?? Date.now(),
+      };
+    });
+
+    const resumeMap: Record<string, any> = {};
+    if (graphInterrupt.key) {
+      resumeMap[graphInterrupt.key] = true;
+    }
+
+    const state: Record<string, any> = {};
+    if (graphInterrupt.lineageId) {
+      state.lineage_id = graphInterrupt.lineageId;
+    }
+    if (graphInterrupt.checkpointId) {
+      state.checkpoint_id = graphInterrupt.checkpointId;
+    }
+    state.resume_map = resumeMap;
+
+    const payload: Record<string, any> = {
+      threadId: config.threadId,
+      runId: randomId("run"),
+      state,
+      messages: [{ role: "user", content: "" }],
+    };
+    if (config.forwardedProps && Object.keys(config.forwardedProps).length > 0) {
+      payload.forwardedProps = config.forwardedProps;
+    }
+
+    setGraphInterrupt(null);
+    graphInterruptIdentityRef.current = null;
+    graphApprovalMessageIdRef.current = null;
+    await run(payload);
+  }, [config.forwardedProps, config.threadId, graphInterrupt, run, upsertMessage]);
+
+  const dismissGraphInterrupt = useCallback(async () => {
+    const identity = graphInterrupt ? graphInterruptIdentity(graphInterrupt) : "";
+    const derivedMessageId = identity ? `graph_interrupt_${sanitizeIdPart(identity) || "interrupt"}` : "";
+    const messageId = graphApprovalMessageIdRef.current || derivedMessageId || (graphInterrupt ? randomId("graph_interrupt") : "");
+    if (messageId) {
+      graphApprovalMessageIdRef.current = messageId;
+      upsertMessage(messageId, (msg) => {
+        const prevArgs = msg?.toolCall?.args ?? "";
+        const parsed = prevArgs ? safeJsonParse(prevArgs) : null;
+        const prompt = graphInterrupt?.prompt || (parsed && typeof parsed === "object" ? String((parsed as any).prompt ?? "") : "");
+        const args = JSON.stringify({ prompt, decision: "dismiss" }, null, 2);
+        return {
+          id: msg?.id ?? messageId,
+          role: "assistant",
+          kind: "tool-call",
+          title: msg?.title ?? "Graph interrupt approval",
+          content: msg?.content ?? "",
+          status: msg?.status ?? "complete",
+          toolCall: {
+            toolCallId: messageId,
+            toolCallName: GRAPH_APPROVAL_TOOL_NAME,
+            parentMessageId: msg?.toolCall?.parentMessageId,
+            args,
+            result: msg?.toolCall?.result,
+          },
+          timestamp: msg?.timestamp ?? Date.now(),
+        };
+      });
+    }
+
+    if (!graphInterrupt) {
+      setGraphInterrupt(null);
+      graphInterruptIdentityRef.current = null;
+      graphApprovalMessageIdRef.current = null;
+      return;
+    }
+
+    const resumeMap: Record<string, any> = {};
+    if (graphInterrupt.key) {
+      resumeMap[graphInterrupt.key] = false;
+    }
+
+    const state: Record<string, any> = {};
+    if (graphInterrupt.lineageId) {
+      state.lineage_id = graphInterrupt.lineageId;
+    }
+    if (graphInterrupt.checkpointId) {
+      state.checkpoint_id = graphInterrupt.checkpointId;
+    }
+    state.resume_map = resumeMap;
+
+    const payload: Record<string, any> = {
+      threadId: config.threadId,
+      runId: randomId("run"),
+      state,
+      messages: [{ role: "user", content: "" }],
+    };
+    if (config.forwardedProps && Object.keys(config.forwardedProps).length > 0) {
+      payload.forwardedProps = config.forwardedProps;
+    }
+
+    setGraphInterrupt(null);
+    graphInterruptIdentityRef.current = null;
+    graphApprovalMessageIdRef.current = null;
+    await run(payload);
+  }, [config.forwardedProps, config.threadId, graphInterrupt, run, upsertMessage]);
+
+  const reset = useCallback(() => {
+    abortActiveRun();
+    setMessages([]);
+    messageIndexByIdRef.current.clear();
+    toolCallNameByIdRef.current.clear();
+    toolCallArgsByIdRef.current.clear();
+    activityStateRef.current = {};
+    activeThinkingRef.current = null;
+    reportSessionsRef.current = [];
+    writingReportIdRef.current = null;
+    clearRawEvents();
+    setFinishReason(undefined);
+    setLastError(null);
+    setGraphNodeId(undefined);
+    setGraphInterrupt(null);
+    graphInterruptIdentityRef.current = null;
+    graphApprovalMessageIdRef.current = null;
+    setProgress(null);
+    setReportSessions([]);
+    setActiveReportId(null);
+    setReportDrawerOpen(false);
+  }, [abortActiveRun, clearRawEvents]);
+
+  return {
+    messages,
+    rawEvents,
+    inProgress,
+    finishReason,
+    lastError,
+    graphNodeId,
+    graphInterrupt,
+    progress,
+    reportSessions,
+    activeReportId,
+    reportDrawerOpen,
+    setReportOpen,
+    setReportDrawerOpen,
+    openReport,
+    loadHistory,
+    send,
+    stop,
+    reset,
+    approveGraphInterrupt,
+    dismissGraphInterrupt,
+    clearRawEvents,
+  };
+}

--- a/examples/agui/client/tdesign-chat/src/index.css
+++ b/examples/agui/client/tdesign-chat/src/index.css
@@ -1,197 +1,431 @@
 * {
   box-sizing: border-box;
-  padding: 0;
-  margin: 0;
 }
 
 html,
-body {
-  max-width: 100vw;
-  height: 100vh;
-  overflow: hidden;
+body,
+#root {
+  height: 100%;
+  margin: 0;
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC', 'Hiragino Sans GB',
-    'Microsoft YaHei', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Hiragino Sans GB",
+    "Microsoft YaHei", "Helvetica Neue", Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-#root {
-  width: 100%;
+:root {
+  color-scheme: light;
+}
+
+.app {
   height: 100%;
-}
-
-.agui-chat {
-  width: 100vw;
-  height: 100vh;
   display: flex;
   flex-direction: column;
-  background: #f5f5f5;
+  background: var(--td-bg-color-container, #f5f5f5);
 }
 
-.agui-chat__container {
+.app__header {
+  padding: 12px 16px;
+  height: auto;
+  min-height: var(--td-comp-size-xxxl, 64px);
+  border-bottom: 1px solid var(--td-border-level-1-color, #e7e7e7);
+  background: var(--td-bg-color-container, #fff);
+  overflow-x: auto;
+}
+
+.app__topbar {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--td-border-level-1-color, #e7e7e7);
+  background: var(--td-bg-color-container, #fff);
+  overflow-x: auto;
+}
+
+.app__content {
   flex: 1;
+  overflow: hidden;
   display: flex;
   flex-direction: column;
-  max-width: 1200px;
-  width: 100%;
-  margin: 0 auto;
-  background: #ffffff;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
 }
 
-.agui-chat__header {
-  padding: 16px 24px;
-  border-bottom: 1px solid #e7e7e7;
-  background: #ffffff;
-  margin-bottom: 8px;
+.app__body {
+  flex: 1;
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: 360px 1fr;
+  min-height: 0;
 }
 
-.agui-chat__title {
-  font-size: 18px;
-  font-weight: 600;
-  color: #000000;
-  margin: 0;
+.app__body--sider-hidden {
+  grid-template-columns: 0 1fr;
 }
 
-.agui-chat__subtitle {
+.app__body--sider-hidden .app__sider {
+  display: none;
+}
+
+.app__sider {
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--td-border-level-1-color, #e7e7e7);
+  background: var(--td-bg-color-container, #fff);
+  min-width: 0;
+}
+
+.app__sider-header {
+  padding: 12px 12px;
+  border-bottom: 1px solid var(--td-border-level-1-color, #e7e7e7);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.app__sider-content {
+  flex: 1;
+  overflow: auto;
+  padding: 12px;
+  min-height: 0;
+  background: var(--td-bg-color-secondarycontainer, #fafafa);
+}
+
+.raw-events__empty {
+  color: var(--td-font-gray-2, #666);
+  font-size: 13px;
+}
+
+.raw-events {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.raw-event {
+  border: 1px solid var(--td-border-level-1-color, #e7e7e7);
+  border-radius: 8px;
+  background: var(--td-bg-color-container, #fff);
+  padding: 8px 10px;
+}
+
+.raw-event__summary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  list-style: none;
+}
+
+.raw-event__summary::-webkit-details-marker {
+  display: none;
+}
+
+.raw-event__time {
+  color: var(--td-font-gray-2, #666);
   font-size: 12px;
-  color: #666666;
-  margin-top: 4px;
+  white-space: nowrap;
 }
 
-.agui-chat__content {
-  flex: 1;
+.raw-event__extra {
+  color: var(--td-font-gray-2, #666);
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.raw-event__body {
+  margin: 8px 0 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--td-text-color-secondary, #4b4b4b);
+}
+
+.app__chat-area {
+  overflow: hidden;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  min-height: 0;
+}
+
+.chat {
+  overflow: auto;
+  padding: 16px;
+}
+
+.chat__list {
   display: flex;
   flex-direction: column;
+  gap: 12px;
+  padding-bottom: 8px;
+}
+
+.chat__list t-chat-item::part(t-chat__item__content) {
+  width: auto;
+  max-width: min(760px, 100%);
+}
+
+.toolcall__slot {
+  width: 100%;
+}
+
+.toolcall {
+  border: 1px solid var(--td-border-level-1-color, #e7e7e7);
+  border-radius: 10px;
+  background: var(--td-bg-color-secondarycontainer, #fafafa);
+  padding: 10px 12px;
+}
+
+.toolcall[open] {
+  background: var(--td-bg-color-container, #fff);
+}
+
+.toolcall__summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  cursor: pointer;
+  list-style: none;
+}
+
+.toolcall__summary::-webkit-details-marker {
+  display: none;
+}
+
+.toolcall__summary-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--td-text-color-primary, #1f1f1f);
+}
+
+.toolcall__body {
+  margin-top: 10px;
+}
+
+.toolcall__panels {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.toolcall__panel {
+  border: 1px solid var(--td-border-level-1-color, #e7e7e7);
+  border-radius: 10px;
+  background: var(--td-bg-color-secondarycontainer, #fafafa);
+  padding: 10px 12px;
+}
+
+.toolcall__panel[open] {
+  background: var(--td-bg-color-container, #fff);
+}
+
+.toolcall__panel-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  cursor: pointer;
+  list-style: none;
+}
+
+.toolcall__panel-summary::-webkit-details-marker {
+  display: none;
+}
+
+.toolcall__panel-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--td-text-color-primary, #1f1f1f);
+}
+
+.toolcall__code {
+  margin: 8px 0 0;
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--td-border-level-1-color, #e7e7e7);
+  background: var(--td-bg-color-secondarycontainer, #fafafa);
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--td-text-color-secondary, #4b4b4b);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    "Courier New", monospace;
+}
+
+.chat__empty {
+  height: 100%;
+  display: grid;
+  place-items: center;
+  color: var(--td-font-gray-2, #666);
+}
+
+.composer {
+  padding: 12px 16px;
+  border-top: 1px solid var(--td-border-level-1-color, #e7e7e7);
+  background: var(--td-bg-color-container, #fff);
+}
+
+.message {
+  display: flex;
+  margin-bottom: 12px;
+}
+
+.message--user {
+  justify-content: flex-end;
+}
+
+.message__bubble {
+  max-width: min(760px, 100%);
+  padding: 10px 12px;
+  border-radius: 10px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+  background: var(--td-bg-color-container, #fff);
+}
+
+.message--user .message__bubble {
+  background: #e8f3ff;
+}
+
+.message__meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 6px;
+  gap: 8px;
+}
+
+.message__meta-right {
+  color: var(--td-font-gray-2, #666);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.message__content {
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--td-text-color-primary, #1f1f1f);
+}
+
+.message__content pre {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.message__content code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    "Courier New", monospace;
+}
+
+.message__content :is(p, ul, ol) {
+  margin: 0 0 8px;
+}
+
+.message__content :is(p:last-child, ul:last-child, ol:last-child) {
+  margin-bottom: 0;
+}
+
+.status-row {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  column-gap: 32px;
+  min-width: 0;
+}
+
+.status-row__left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: nowrap;
+  min-width: 0;
   overflow: hidden;
 }
 
-/* 工具调用卡片样式 */
-.tool-card {
-  margin-top: 12px;
-  padding: 12px 16px;
-  border-radius: 8px;
-  background: #f5f7fa;
-  border: 1px solid #e7e7e7;
-}
-
-.tool-card__header {
-  display: flex;
+.status-row__center {
+  display: grid;
+  grid-template-columns:
+    minmax(150px, 190px)
+    minmax(120px, 160px)
+    minmax(120px, 160px)
+    minmax(150px, 210px)
+    minmax(110px, 150px);
+  justify-content: end;
   align-items: center;
   gap: 8px;
-  margin-bottom: 8px;
-  font-size: 14px;
-  font-weight: 600;
-  color: #333333;
+  min-width: 0;
 }
 
-.tool-card__icon {
-  font-size: 16px;
-}
-
-.tool-card__body {
-  font-size: 13px;
-  color: #666666;
-  line-height: 1.6;
-}
-
-.tool-card__args {
-  background: #ffffff;
-  padding: 8px 12px;
-  border-radius: 4px;
-  border: 1px solid #e7e7e7;
-  margin-top: 8px;
-}
-
-.tool-card__result {
-  margin-top: 8px;
-  padding: 8px 12px;
-  background: #ffffff;
-  border-radius: 4px;
-  border: 1px solid #d9f7be;
-  background-color: #f6ffed;
-}
-
-.tool-card__result-label {
-  font-size: 12px;
-  color: #52c41a;
-  font-weight: 500;
-  margin-bottom: 4px;
-}
-
-.tool-card__result-value {
-  font-size: 16px;
-  font-weight: 600;
-  color: #000000;
-}
-
-.tool-card--executing {
-  border-color: #0052d9;
-  background-color: #f2f5ff;
-}
-
-.tool-card--error {
-  border-color: #e34d59;
-  background-color: #fff1f0;
-}
-
-.tool-card__error {
-  color: #e34d59;
-  font-size: 13px;
-  margin-top: 8px;
-}
-
-/* 状态标签 */
-.status-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 2px 8px;
-  border-radius: 4px;
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.status-badge--executing {
-  background: #e6f0ff;
-  color: #0052d9;
-}
-
-.status-badge--complete {
-  background: #d9f7be;
-  color: #52c41a;
-}
-
-.status-badge--error {
-  background: #ffa39e;
-  color: #e34d59;
-}
-
-/* 自定义事件样式 */
-.custom-event-card {
-  margin-top: 12px;
-  padding: 12px 16px;
-  border-radius: 8px;
-  background: #fff7e6;
-  border: 1px solid #ffd591;
-}
-
-.custom-event-card__header {
+.status-row__right {
   display: flex;
   align-items: center;
+  justify-content: flex-end;
   gap: 8px;
-  margin-bottom: 8px;
-  font-size: 14px;
-  font-weight: 600;
-  color: #ad6800;
+  flex-wrap: nowrap;
 }
 
-.custom-event-card__body {
-  font-size: 13px;
-  color: #666666;
+.status-row__hint {
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.header-field .t-input {
+  border-radius: var(--td-radius-default);
+  background-color: var(--td-bg-color-container, #fff);
+  border: 1px solid var(--td-border-level-2-color);
+  box-shadow: none;
+  padding: 0;
+}
+
+.header-field .t-input:hover,
+.header-field .t-input:focus,
+.header-field .t-input:focus-within,
+.header-field .t-input.t-input--focused {
+  background-color: var(--td-bg-color-container, #fff);
+  border-color: var(--td-border-level-2-color);
+  box-shadow: none;
+}
+
+.header-field .t-input__prefix {
+  white-space: nowrap;
+  background-color: var(--td-bg-color-specialcomponent);
+  border-right: 1px solid var(--td-border-level-2-color);
+  padding: 0 10px;
+  color: var(--td-text-color-secondary, #4b4b4b);
+  font-size: 12px;
+  border-top-left-radius: var(--td-radius-default);
+  border-bottom-left-radius: var(--td-radius-default);
+}
+
+.header-field .t-input__prefix:not(:empty) {
+  margin-right: 0;
+}
+
+.header-field .t-input__inner {
+  padding: 0 10px;
+}
+
+.report-drawer__content {
+  height: 100%;
+  overflow: auto;
+  padding-right: 8px;
+}
+
+.report-drawer__footer {
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.report-drawer__content pre {
   white-space: pre-wrap;
   word-break: break-word;
 }

--- a/examples/agui/client/tdesign-chat/src/main.tsx
+++ b/examples/agui/client/tdesign-chat/src/main.tsx
@@ -1,12 +1,12 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import App from './App';
-import 'tdesign-react/es/style/index.css';
-import '@tdesign-react/chat/es/style/index.js';
-import './index.css';
+import React from "react";
+import ReactDOM from "react-dom/client";
+import "tdesign-react/es/style/index.css";
+import "@tdesign-react/chat/es/style/index.js";
+import App from "./App";
+import "./index.css";
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
+ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/examples/agui/client/tdesign-chat/tsconfig.json
+++ b/examples/agui/client/tdesign-chat/tsconfig.json
@@ -14,7 +14,8 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vite/client"]
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/examples/agui/client/tdesign-chat/tsconfig.node.json
+++ b/examples/agui/client/tdesign-chat/tsconfig.node.json
@@ -8,3 +8,4 @@
   },
   "include": ["vite.config.ts"]
 }
+

--- a/examples/agui/client/tdesign-chat/vite.config.ts
+++ b/examples/agui/client/tdesign-chat/vite.config.ts
@@ -1,9 +1,24 @@
-import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
+import react from "@vitejs/plugin-react";
+import { defineConfig, loadEnv } from "vite";
 
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    port: 3000,
-  },
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  const proxyTarget = env.VITE_AG_UI_PROXY_TARGET || "http://127.0.0.1:8080";
+
+  return {
+    plugins: [react()],
+    server: {
+      proxy: {
+        "/agui": {
+          target: proxyTarget,
+          changeOrigin: true,
+        },
+        "/history": {
+          target: proxyTarget,
+          changeOrigin: true,
+        },
+      },
+    },
+  };
 });
+


### PR DESCRIPTION
Adds a runnable Vite + React + TDesign AG-UI chat client example with raw event inspection, message snapshot loading, graph interrupt approvals (human-in-the-loop), and report side panels, and updates the AG-UI documentation to reference the new client.