### PR TITLE
evaluation: support any JSON values for tool arguments/result

### DIFF
--- a/evaluation/evalset/evalcase.go
+++ b/evaluation/evalset/evalcase.go
@@ -46,10 +46,10 @@ type Invocation struct {
 
 // Tool represents a single tool invocation and its execution result.
 type Tool struct {
-	ID        string         `json:"id,omitempty"`        // Tool call ID.
-	Name      string         `json:"name,omitempty"`      // Tool name.
-	Arguments map[string]any `json:"arguments,omitempty"` // Tool call parameters.
-	Result    map[string]any `json:"result,omitempty"`    // Tool execution result.
+	ID        string `json:"id,omitempty"`        // Tool call ID.
+	Name      string `json:"name,omitempty"`      // Tool name.
+	Arguments any    `json:"arguments,omitempty"` // Tool call parameters.
+	Result    any    `json:"result,omitempty"`    // Tool execution result.
 }
 
 // SessionInput represents values that help initialize a session.

--- a/evaluation/metric/criterion/json/options.go
+++ b/evaluation/metric/criterion/json/options.go
@@ -18,7 +18,7 @@ type options struct {
 	ignoreTree      map[string]any
 	matchStrategy   JSONMatchStrategy
 	numberTolerance *float64
-	compare         func(actual, expected map[string]any) (bool, error)
+	compare         func(actual, expected any) (bool, error)
 }
 
 // newOptions creates a Options with the provided options.
@@ -62,7 +62,7 @@ func WithNumberTolerance(tolerance float64) Option {
 }
 
 // WithCompare sets the compare function.
-func WithCompare(compare func(actual, expected map[string]any) (bool, error)) Option {
+func WithCompare(compare func(actual, expected any) (bool, error)) Option {
 	return func(o *options) {
 		o.compare = compare
 	}

--- a/evaluation/metric/criterion/json/options_test.go
+++ b/evaluation/metric/criterion/json/options_test.go
@@ -36,7 +36,7 @@ func TestWithIgnoreTreeAndCompare(t *testing.T) {
 	called := false
 	opts := newOptions(
 		WithIgnoreTree(map[string]any{"k": true}),
-		WithCompare(func(actual, expected map[string]any) (bool, error) {
+		WithCompare(func(actual, expected any) (bool, error) {
 			called = true
 			return true, nil
 		}),

--- a/evaluation/metric/criterion/tooltrajectory/tooltrajectory_test.go
+++ b/evaluation/metric/criterion/tooltrajectory/tooltrajectory_test.go
@@ -328,6 +328,23 @@ func TestToolTrajectoryStrategyMatchBranches(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "arguments mismatch")
 
+	// Arguments array mismatch.
+	ok, err = strategy.Match(
+		&evalset.Tool{Name: "a", Arguments: []any{float64(1)}},
+		&evalset.Tool{Name: "a", Arguments: []any{float64(2)}},
+	)
+	assert.False(t, ok)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "arguments mismatch")
+
+	// Arguments array match.
+	ok, err = strategy.Match(
+		&evalset.Tool{Name: "a", Arguments: []any{float64(1), float64(2)}},
+		&evalset.Tool{Name: "a", Arguments: []any{float64(1), float64(2)}},
+	)
+	assert.True(t, ok)
+	assert.NoError(t, err)
+
 	// Result mismatch.
 	strategy = &ToolTrajectoryStrategy{
 		Result: &criterionjson.JSONCriterion{},
@@ -339,6 +356,23 @@ func TestToolTrajectoryStrategyMatchBranches(t *testing.T) {
 	assert.False(t, ok)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "result mismatch")
+
+	// Result array mismatch.
+	ok, err = strategy.Match(
+		&evalset.Tool{Name: "a", Result: []any{float64(1)}},
+		&evalset.Tool{Name: "a", Result: []any{float64(2)}},
+	)
+	assert.False(t, ok)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "result mismatch")
+
+	// Result array match.
+	ok, err = strategy.Match(
+		&evalset.Tool{Name: "a", Result: []any{float64(1), float64(2)}},
+		&evalset.Tool{Name: "a", Result: []any{float64(1), float64(2)}},
+	)
+	assert.True(t, ok)
+	assert.NoError(t, err)
 
 	// Success path.
 	strategy = &ToolTrajectoryStrategy{}

--- a/evaluation/service/internal/inference/inference.go
+++ b/evaluation/service/internal/inference/inference.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
@@ -133,15 +134,10 @@ func convertTools(event *event.Event) ([]*evalset.Tool, error) {
 	tools := []*evalset.Tool{}
 	for _, choice := range event.Response.Choices {
 		for _, toolCall := range choice.Message.ToolCalls {
-			args := map[string]any{}
-			if err := json.Unmarshal(toolCall.Function.Arguments, &args); err != nil {
-				return nil, fmt.Errorf("unmarshal tool call arguments %s for tool %s: %w",
-					string(toolCall.Function.Arguments), toolCall.ID, err)
-			}
 			tool := &evalset.Tool{
 				ID:        toolCall.ID,
 				Name:      toolCall.Function.Name,
-				Arguments: args,
+				Arguments: parseToolCallArguments(toolCall.Function.Arguments),
 			}
 			tools = append(tools, tool)
 		}
@@ -149,21 +145,37 @@ func convertTools(event *event.Event) ([]*evalset.Tool, error) {
 	return tools, nil
 }
 
+func parseToolCallArguments(arguments []byte) any {
+	trimmed := strings.TrimSpace(string(arguments))
+	if trimmed == "" {
+		return map[string]any{}
+	}
+	var value any
+	if err := json.Unmarshal([]byte(trimmed), &value); err == nil {
+		return value
+	}
+	return string(arguments)
+}
+
 // mergeToolResultResponse merges the tool result response into the tools.
 func mergeToolResultResponse(event *event.Event, toolIDIdx map[string]int, tools []*evalset.Tool) error {
 	for _, choice := range event.Response.Choices {
-		idx, ok := toolIDIdx[choice.Message.ToolID]
+		toolID := choice.Message.ToolID
+		idx, ok := toolIDIdx[toolID]
 		if !ok {
-			return fmt.Errorf("tool ID %s not found in tool ID index for tool result response", choice.Message.ToolID)
+			return fmt.Errorf("tool ID %s not found in tool ID index for tool result response", toolID)
 		}
-		result := map[string]any{}
-		if err := json.Unmarshal([]byte(choice.Message.Content), &result); err != nil {
-			return fmt.Errorf("unmarshal tool result response %s for tool %s: %w",
-				choice.Message.Content, choice.Message.ToolID, err)
-		}
-		tools[idx].Result = result
+		tools[idx].Result = parseToolResultContent(choice.Message.Content)
 	}
 	return nil
+}
+
+func parseToolResultContent(content string) any {
+	var value any
+	if err := json.Unmarshal([]byte(content), &value); err == nil {
+		return value
+	}
+	return content
 }
 
 func buildSeedMessages(messages []*model.Message) ([]model.Message, error) {


### PR DESCRIPTION
Evaluation inference previously assumed tool call arguments and tool result content always decode into JSON objects, which caused evaluation runs to fail when tools returned strings, arrays, or non-JSON content; this change stores tool arguments and results as generic JSON values when possible and keeps the raw string when decoding fails so tool trajectory evaluation can proceed without aborting.