### PR TITLE
fix(trace): simplify JSON marshaling for invocation messages

### DIFF
--- a/internal/telemetry/trace.go
+++ b/internal/telemetry/trace.go
@@ -288,7 +288,7 @@ func TraceBeforeInvokeAgent(span trace.Span, invoke *agent.Invocation, agentDesc
 	if invoke != nil && len(invoke.RunOptions.SpanAttributes) > 0 {
 		span.SetAttributes(invoke.RunOptions.SpanAttributes...)
 	}
-	if bts, err := json.Marshal(&model.Request{Messages: []model.Message{invoke.Message}}); err == nil {
+	if bts, err := json.Marshal([]model.Message{invoke.Message}); err == nil {
 		span.SetAttributes(
 			attribute.String(KeyGenAIInputMessages, string(bts)),
 		)


### PR DESCRIPTION
Updated the TraceBeforeInvokeAgent function to directly marshal the invocation message without wrapping it in a model.Request structure. This change streamlines the attribute setting for spans in telemetry tracing.