### PR TITLE
examples: implement ConsecutiveUserMessageHook for handling consecutive user messages

### DIFF
--- a/examples/session/hook/README.md
+++ b/examples/session/hook/README.md
@@ -40,11 +40,21 @@ The `-consecutive` flag enables handling of consecutive user messages via `Appen
 
 | Strategy | Behavior |
 |----------|----------|
-| `merge` | Merge current message into previous user message |
+| `merge` | Merge current message into previous user message (also re-checks for violations) |
 | `placeholder` | Insert a placeholder assistant response before appending |
 | `skip` | Skip the current event entirely |
 
 This demonstrates that `AppendEventHook` can be used as an alternative to `WithOnConsecutiveUserMessage` for more complex scenarios where you need additional control over the event processing pipeline.
+
+### When do consecutive user messages occur?
+
+Consecutive user messages happen when a user message is written to the session but no assistant response follows. Common scenarios:
+
+1. **User disconnection**: User sends a message, disconnects before receiving response, then reconnects and sends another message.
+2. **Network issues**: Client retries due to timeout while the first request was already processed.
+3. **Rapid messaging**: User sends multiple messages before the assistant can respond.
+
+The demo simulates this by directly appending a user message to the session without waiting for an assistant response. When `-consecutive` is enabled, you'll see the hook handle this scenario.
 
 ## Expected flow (sample)
 1) Normal message passes through, stored as-is.  

--- a/examples/session/hook/hooks.go
+++ b/examples/session/hook/hooks.go
@@ -11,6 +11,7 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -168,19 +169,52 @@ func appendTags(existing string, tags ...string) string {
 	return strings.Join(parts, event.TagDelimiter)
 }
 
+// Supported consecutive user message strategies.
+const (
+	strategyMerge       = "merge"
+	strategyPlaceholder = "placeholder"
+	strategySkip        = "skip"
+)
+
+// validConsecutiveStrategies returns the list of valid strategy names.
+func validConsecutiveStrategies() []string {
+	return []string{strategyMerge, strategyPlaceholder, strategySkip}
+}
+
+// isValidConsecutiveStrategy checks if the given strategy is valid.
+func isValidConsecutiveStrategy(s string) bool {
+	return slices.Contains(validConsecutiveStrategies(), strings.ToLower(s))
+}
+
 // ConsecutiveUserMessageHook handles consecutive user messages scenario.
 // When a user sends multiple messages without receiving assistant response,
 // it merges the messages or inserts a placeholder response.
 //
+// Supported strategies:
+//   - "merge": Merge current message content into the previous user message.
+//   - "placeholder": Insert a placeholder assistant response before appending.
+//   - "skip": Skip the current event entirely.
+//
 // This demonstrates using AppendEventHook as an alternative to
 // WithOnConsecutiveUserMessage option.
+//
+// NOTE: The "placeholder" strategy directly appends to sess.Events, bypassing
+// other hooks and storage persistence. In production, consider using the
+// session service's AppendEvent method or the dedicated
+// WithOnConsecutiveUserMessage option for proper event handling.
 func ConsecutiveUserMessageHook(strategy string) session.AppendEventHook {
+	// Normalize strategy to lowercase.
+	strategy = strings.ToLower(strategy)
+
 	return func(ctx *session.AppendEventContext, next func() error) error {
 		evt := ctx.Event
 		sess := ctx.Session
 
-		// Only handle user messages.
+		// Only handle user messages with valid choices.
 		if evt == nil || evt.Response == nil || !evt.Response.IsUserMessage() {
+			return next()
+		}
+		if len(evt.Response.Choices) == 0 {
 			return next()
 		}
 
@@ -190,7 +224,9 @@ func ConsecutiveUserMessageHook(strategy string) session.AppendEventHook {
 		var lastUserEvent *event.Event
 		if len(sess.Events) > 0 {
 			lastEvent := &sess.Events[len(sess.Events)-1]
-			if lastEvent.Response != nil && lastEvent.Response.IsUserMessage() {
+			if lastEvent.Response != nil &&
+				lastEvent.Response.IsUserMessage() &&
+				len(lastEvent.Response.Choices) > 0 {
 				isConsecutive = true
 				lastUserEvent = lastEvent
 			}
@@ -204,19 +240,28 @@ func ConsecutiveUserMessageHook(strategy string) session.AppendEventHook {
 		fmt.Printf("  [Hook] Consecutive user messages detected, strategy: %s\n", strategy)
 
 		switch strategy {
-		case "merge":
+		case strategyMerge:
 			// Merge current message into the previous one.
 			sess.EventMu.Lock()
 			prevContent := lastUserEvent.Response.Choices[0].Message.Content
 			currContent := evt.Response.Choices[0].Message.Content
-			lastUserEvent.Response.Choices[0].Message.Content = prevContent + "\n" + currContent
+			mergedContent := prevContent + "\n" + currContent
+			lastUserEvent.Response.Choices[0].Message.Content = mergedContent
+
+			// Re-check merged content for prohibited words and update tag.
+			if word := containsProhibitedWord(mergedContent); word != "" {
+				lastUserEvent.Tag = appendTags(lastUserEvent.Tag, ViolationTagPrefix+word)
+				fmt.Printf("  [Hook] Merged content contains prohibited word: %s\n", word)
+			}
 			sess.EventMu.Unlock()
-			fmt.Printf("  [Hook] Merged messages: %s\n", truncate(prevContent+"\n"+currContent, 50))
+			fmt.Printf("  [Hook] Merged messages: %s\n", truncate(mergedContent, 50))
 			// Skip appending current event (already merged).
 			return nil
 
-		case "placeholder":
+		case strategyPlaceholder:
 			// Insert a placeholder assistant response before this event.
+			// NOTE: This directly modifies sess.Events, bypassing hooks and storage.
+			// For production use, consider using the session service's AppendEvent.
 			placeholder := &event.Event{
 				ID: fmt.Sprintf("placeholder-%d", time.Now().UnixNano()),
 				Response: &model.Response{
@@ -231,21 +276,22 @@ func ConsecutiveUserMessageHook(strategy string) session.AppendEventHook {
 					},
 				},
 			}
-			// Temporarily unlock to call AppendEvent-like logic (simplified here).
 			sess.EventMu.Lock()
 			sess.Events = append(sess.Events, *placeholder)
 			sess.EventMu.Unlock()
 			fmt.Printf("  [Hook] Inserted placeholder response\n")
 			return next()
 
-		case "skip":
+		case strategySkip:
 			// Skip the current event.
 			fmt.Printf("  [Hook] Skipped duplicate user message: %s\n",
 				truncate(evt.Response.Choices[0].Message.Content, 30))
 			return nil
 
 		default:
-			// Default: just proceed.
+			// Unknown strategy, log warning and proceed with default behavior.
+			fmt.Printf("  [Hook] Unknown strategy %q, proceeding with default behavior. "+
+				"Valid strategies: %v\n", strategy, validConsecutiveStrategies())
 			return next()
 		}
 	}


### PR DESCRIPTION
- Added ConsecutiveUserMessageHook to manage scenarios where users send multiple messages without receiving a response from the assistant.
- Introduced strategies for handling consecutive messages: merge, placeholder, and skip.
- Updated main.go to include a flag for selecting the consecutive message handling strategy.
- Enhanced README.md to document the new hook and its usage, including examples for each strategy.

This change improves user experience by allowing more flexible handling of consecutive messages in the session context.

## 由 Sourcery 提供的摘要

为会话钩子示例新增一个用于处理在现有内容过滤钩子基础上，连续用户消息的示例。

新增功能：
- 引入 `ConsecutiveUserMessageHook`，用于自定义当用户在没有助手回复的情况下连续发送多条消息时的处理行为，支持合并（merge）、占位（placeholder）和跳过（skip）等策略。
- 在会话钩子示例中添加命令行参数，用于选择连续用户消息处理策略。

改进：
- 扩展示例会话钩子，展示在一个示例中同时进行内容过滤和连续用户消息处理。

文档：
- 更新会话钩子 README，涵盖新的连续用户消息钩子、其策略、使用示例，以及对该示例的修订描述。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a session hook example for handling consecutive user messages alongside existing content-filter hooks.

New Features:
- Introduce ConsecutiveUserMessageHook to customize behavior when users send multiple messages without assistant responses, supporting merge, placeholder, and skip strategies.
- Add a command-line flag to select the consecutive user message handling strategy in the session hook example.

Enhancements:
- Expand the session hook example to demonstrate both content filtering and consecutive user message handling in a single demo.

Documentation:
- Update the session hook README to cover the new consecutive user message hook, its strategies, usage examples, and revised description of the example.

</details>