### PR TITLE
event: improve context error logging in event emission

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -279,7 +279,8 @@ func EmitEventWithTimeout(ctx context.Context, ch chan<- *Event,
 	if err := ctx.Err(); err != nil {
 		log.WarnfContext(
 			ctx,
-			"EmitEventWithTimeout: context cancelled, event: %+v",
+			"EmitEventWithTimeout: context error: %v, event: %+v",
+			err,
 			*e,
 		)
 		return err
@@ -293,12 +294,14 @@ func EmitEventWithTimeout(ctx context.Context, ch chan<- *Event,
 		case ch <- e:
 			log.TracefContext(ctx, "EmitEventWithTimeout: event sent, event: %+v", *e)
 		case <-ctx.Done():
+			err := ctx.Err()
 			log.WarnfContext(
 				ctx,
-				"EmitEventWithTimeout: context cancelled, event: %+v",
+				"EmitEventWithTimeout: context error: %v, event: %+v",
+				err,
 				*e,
 			)
-			return ctx.Err()
+			return err
 		}
 		return nil
 	}
@@ -307,12 +310,14 @@ func EmitEventWithTimeout(ctx context.Context, ch chan<- *Event,
 	case ch <- e:
 		log.TracefContext(ctx, "EmitEventWithTimeout: event sent, event: %+v", *e)
 	case <-ctx.Done():
+		err := ctx.Err()
 		log.WarnfContext(
 			ctx,
-			"EmitEventWithTimeout: context cancelled, event: %+v",
+			"EmitEventWithTimeout: context error: %v, event: %+v",
+			err,
 			*e,
 		)
-		return ctx.Err()
+		return err
 	case <-time.After(timeout):
 		log.WarnfContext(
 			ctx,


### PR DESCRIPTION
## Summary by Sourcery

改进 `EmitEventWithTimeout` 中与上下文相关的错误报告和传递。

增强内容：
- 当 context 结束时，在 `EmitEventWithTimeout` 的警告日志中包含底层的 context 错误。
- 一致地返回捕获到的 context 错误值，而不是在代码中内联调用 `ctx.Err()`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve context-related error reporting and propagation in EmitEventWithTimeout.

Enhancements:
- Include the underlying context error in EmitEventWithTimeout warning logs when the context is done.
- Return the captured context error value consistently instead of calling ctx.Err() inline.

</details>