### PR TITLE
model/gemini: keep tool calls when part text is empty

### DIFF
--- a/model/gemini/gemini.go
+++ b/model/gemini/gemini.go
@@ -201,13 +201,12 @@ func (m *Model) convertContentBlock(candidates []*genai.Candidate) (model.Messag
 		}
 		if candidate.Content != nil {
 			for _, part := range candidate.Content.Parts {
-				if len(part.Text) == 0 {
-					continue
-				}
-				if part.Thought {
-					reasoningBuilder.WriteString(part.Text)
-				} else {
-					textBuilder.WriteString(part.Text)
+				if part.Text != "" {
+					if part.Thought {
+						reasoningBuilder.WriteString(part.Text)
+					} else {
+						textBuilder.WriteString(part.Text)
+					}
 				}
 				if part.FunctionCall != nil {
 					args, _ := json.Marshal(part.FunctionCall.Args)


### PR DESCRIPTION
Fix Gemini response parsing to avoid dropping function calls when a part has empty text, which prevents tool calls from being lost for models such as gemini-3-pro-preview. 
Close #1087.