### PR TITLE
{server/agui, docs}: add outermost-only graph interrupt activity option

### DIFF
--- a/docs/mkdocs/en/agui.md
+++ b/docs/mkdocs/en/agui.md
@@ -666,6 +666,8 @@ server, err := agui.New(
 Here’s an example of usage:
 
 ```go
+import "trpc.group/trpc-go/trpc-agent-go/server/agui"
+
 server, err := agui.New(
     runner,
     agui.WithBasePath("/agui"),                // Set the AG-UI prefix route.
@@ -691,6 +693,8 @@ With `GraphAgent`, a single run typically executes multiple nodes along the grap
 This event is disabled by default; enable it via `agui.WithGraphNodeLifecycleActivityEnabled(true)` when constructing the AG-UI server.
 
 ```go
+import "trpc.group/trpc-go/trpc-agent-go/server/agui"
+
 server, err := agui.New(
 	runner,
 	agui.WithGraphNodeLifecycleActivityEnabled(true),
@@ -764,6 +768,8 @@ For the node failure end phase (`phase=error`, non-interrupt), it includes an er
 This event is disabled by default; enable it via `agui.WithGraphNodeInterruptActivityEnabled(true)` when constructing the AG-UI server.
 
 ```go
+import "trpc.group/trpc-go/trpc-agent-go/server/agui"
+
 server, err := agui.New(
 	runner,
 	agui.WithGraphNodeInterruptActivityEnabled(true),
@@ -793,6 +799,18 @@ server, err := agui.New(
 ```
 
 This event indicates the run is paused at the node. The frontend can render `/interrupt.prompt` as the interrupt UI and use `/interrupt.key` to decide which resume value to provide. `checkpointId` and `lineageId` can be used to resume from the correct checkpoint and correlate runs.
+
+In multi-level GraphAgent setups, subgraph interrupts bubble up and the stream may contain multiple `graph.node.interrupt` events by default. If the client only wants to keep the outermost interrupt used for resuming, enable `agui.WithGraphNodeInterruptActivityTopLevelOnly(true)`; when enabled, only the outermost interrupt event is emitted.
+
+```go
+import "trpc.group/trpc-go/trpc-agent-go/server/agui"
+
+server, err := agui.New(
+	runner,
+	agui.WithGraphNodeInterruptActivityEnabled(true),
+	agui.WithGraphNodeInterruptActivityTopLevelOnly(true),
+)
+```
 
 #### Resume ack (`graph.node.interrupt`)
 

--- a/docs/mkdocs/zh/agui.md
+++ b/docs/mkdocs/zh/agui.md
@@ -669,6 +669,8 @@ server, err := agui.New(
 使用示例如下所示
 
 ```go
+import "trpc.group/trpc-go/trpc-agent-go/server/agui"
+
 server, err := agui.New(
     runner,
     agui.WithBasePath("/agui"),                // 设置 AG-UI 前缀路由
@@ -696,6 +698,8 @@ if err != nil {
 该事件默认关闭，可在创建 AG-UI Server 时通过 `agui.WithGraphNodeLifecycleActivityEnabled(true)` 开启。
 
 ```go
+import "trpc.group/trpc-go/trpc-agent-go/server/agui"
+
 server, err := agui.New(
 	runner,
 	agui.WithGraphNodeLifecycleActivityEnabled(true),
@@ -769,6 +773,8 @@ server, err := agui.New(
 该事件默认关闭，可在创建 AG-UI Server 时通过 `agui.WithGraphNodeInterruptActivityEnabled(true)` 开启。
 
 ```go
+import "trpc.group/trpc-go/trpc-agent-go/server/agui"
+
 server, err := agui.New(
 	runner,
 	agui.WithGraphNodeInterruptActivityEnabled(true),
@@ -798,6 +804,18 @@ server, err := agui.New(
 ```
 
 该事件表示执行在该节点暂停。前端可使用 `/interrupt.prompt` 渲染中断提示，并用 `/interrupt.key` 选择需要提供的恢复值。`checkpointId` 与 `lineageId` 可用于定位需要恢复的 checkpoint 并关联多次 run。
+
+如果使用多级 GraphAgent，子图中断会向上冒泡，事件流中默认可能出现多条 `graph.node.interrupt`。如果前端只希望保留用于恢复的最外层中断，可额外开启 `agui.WithGraphNodeInterruptActivityTopLevelOnly(true)`，开启后仅发送最外层中断事件。
+
+```go
+import "trpc.group/trpc-go/trpc-agent-go/server/agui"
+
+server, err := agui.New(
+	runner,
+	agui.WithGraphNodeInterruptActivityEnabled(true),
+	agui.WithGraphNodeInterruptActivityTopLevelOnly(true),
+)
+```
 
 #### 恢复回执（`graph.node.interrupt`）
 

--- a/server/agui/options.go
+++ b/server/agui/options.go
@@ -128,6 +128,13 @@ func WithGraphNodeInterruptActivityEnabled(enabled bool) Option {
 	}
 }
 
+// WithGraphNodeInterruptActivityTopLevelOnly controls whether the AG-UI server only emits graph interrupt activity events for the top-level invocation.
+func WithGraphNodeInterruptActivityTopLevelOnly(enabled bool) Option {
+	return func(o *options) {
+		o.aguiRunnerOptions = append(o.aguiRunnerOptions, aguirunner.WithGraphNodeInterruptActivityTopLevelOnly(enabled))
+	}
+}
+
 // WithMessagesSnapshotPath sets the HTTP path for the messages snapshot handler, "/history" in default.
 func WithMessagesSnapshotPath(p string) Option {
 	return func(o *options) {

--- a/server/agui/options_test.go
+++ b/server/agui/options_test.go
@@ -92,6 +92,12 @@ func TestWithGraphNodeInterruptActivityEnabled(t *testing.T) {
 	assert.True(t, ro.GraphNodeInterruptActivityEnabled)
 }
 
+func TestWithGraphNodeInterruptActivityTopLevelOnly(t *testing.T) {
+	opts := newOptions(WithGraphNodeInterruptActivityTopLevelOnly(true))
+	ro := aguirunner.NewOptions(opts.aguiRunnerOptions...)
+	assert.True(t, ro.GraphNodeInterruptActivityTopLevelOnly)
+}
+
 func TestWithCancelEnabled(t *testing.T) {
 	opts := newOptions(WithCancelEnabled(true))
 	assert.True(t, opts.cancelEnabled)

--- a/server/agui/runner/options.go
+++ b/server/agui/runner/options.go
@@ -23,44 +23,47 @@ import (
 )
 
 const (
-	defaultTimeout                           = time.Hour
-	defaultGraphNodeLifecycleActivityEnabled = false
-	defaultGraphNodeInterruptActivityEnabled = false
+	defaultTimeout                                = time.Hour
+	defaultGraphNodeLifecycleActivityEnabled      = false
+	defaultGraphNodeInterruptActivityEnabled      = false
+	defaultGraphNodeInterruptActivityTopLevelOnly = false
 )
 
 // Options holds the options for the runner.
 type Options struct {
-	TranslatorFactory                 TranslatorFactory     // TranslatorFactory creates a translator for an AG-UI run.
-	UserIDResolver                    UserIDResolver        // UserIDResolver derives the user identifier for an AG-UI run.
-	TranslateCallbacks                *translator.Callbacks // TranslateCallbacks translates the run events to AG-UI events.
-	RunAgentInputHook                 RunAgentInputHook     // RunAgentInputHook allows modifying the run input before processing.
-	AppName                           string                // AppName is the name of the application.
-	SessionService                    session.Service       // SessionService is the session service.
-	StateResolver                     StateResolver         // StateResolver resolves runtime state for an AG-UI run.
-	RunOptionResolver                 RunOptionResolver     // RunOptionResolver resolves the runner options for an AG-UI run.
-	AggregatorFactory                 aggregator.Factory    // AggregatorFactory builds an aggregator for each run.
-	AggregationOption                 []aggregator.Option   // AggregationOption is the aggregation options for each run.
-	FlushInterval                     time.Duration         // FlushInterval controls how often buffered AG-UI events are flushed for a session.
-	StartSpan                         StartSpan             // StartSpan starts a span for an AG-UI run.
-	Timeout                           time.Duration         // Timeout controls how long a run is allowed to execute.
-	GraphNodeLifecycleActivityEnabled bool                  // GraphNodeLifecycleActivityEnabled enables graph node lifecycle activity events.
-	GraphNodeInterruptActivityEnabled bool                  // GraphNodeInterruptActivityEnabled enables graph interrupt activity events.
+	TranslatorFactory                      TranslatorFactory     // TranslatorFactory creates a translator for an AG-UI run.
+	UserIDResolver                         UserIDResolver        // UserIDResolver derives the user identifier for an AG-UI run.
+	TranslateCallbacks                     *translator.Callbacks // TranslateCallbacks translates the run events to AG-UI events.
+	RunAgentInputHook                      RunAgentInputHook     // RunAgentInputHook allows modifying the run input before processing.
+	AppName                                string                // AppName is the name of the application.
+	SessionService                         session.Service       // SessionService is the session service.
+	StateResolver                          StateResolver         // StateResolver resolves runtime state for an AG-UI run.
+	RunOptionResolver                      RunOptionResolver     // RunOptionResolver resolves the runner options for an AG-UI run.
+	AggregatorFactory                      aggregator.Factory    // AggregatorFactory builds an aggregator for each run.
+	AggregationOption                      []aggregator.Option   // AggregationOption is the aggregation options for each run.
+	FlushInterval                          time.Duration         // FlushInterval controls how often buffered AG-UI events are flushed for a session.
+	StartSpan                              StartSpan             // StartSpan starts a span for an AG-UI run.
+	Timeout                                time.Duration         // Timeout controls how long a run is allowed to execute.
+	GraphNodeLifecycleActivityEnabled      bool                  // GraphNodeLifecycleActivityEnabled enables graph node lifecycle activity events.
+	GraphNodeInterruptActivityEnabled      bool                  // GraphNodeInterruptActivityEnabled enables graph interrupt activity events.
+	GraphNodeInterruptActivityTopLevelOnly bool                  // GraphNodeInterruptActivityTopLevelOnly drops nested graph interrupt activity events.
 }
 
 // NewOptions creates a new options instance.
 func NewOptions(opt ...Option) *Options {
 	opts := &Options{
-		UserIDResolver:                    defaultUserIDResolver,
-		TranslatorFactory:                 defaultTranslatorFactory,
-		RunAgentInputHook:                 defaultRunAgentInputHook,
-		StateResolver:                     defaultStateResolver,
-		RunOptionResolver:                 defaultRunOptionResolver,
-		AggregatorFactory:                 aggregator.New,
-		FlushInterval:                     track.DefaultFlushInterval,
-		StartSpan:                         defaultStartSpan,
-		Timeout:                           defaultTimeout,
-		GraphNodeLifecycleActivityEnabled: defaultGraphNodeLifecycleActivityEnabled,
-		GraphNodeInterruptActivityEnabled: defaultGraphNodeInterruptActivityEnabled,
+		UserIDResolver:                         defaultUserIDResolver,
+		TranslatorFactory:                      defaultTranslatorFactory,
+		RunAgentInputHook:                      defaultRunAgentInputHook,
+		StateResolver:                          defaultStateResolver,
+		RunOptionResolver:                      defaultRunOptionResolver,
+		AggregatorFactory:                      aggregator.New,
+		FlushInterval:                          track.DefaultFlushInterval,
+		StartSpan:                              defaultStartSpan,
+		Timeout:                                defaultTimeout,
+		GraphNodeLifecycleActivityEnabled:      defaultGraphNodeLifecycleActivityEnabled,
+		GraphNodeInterruptActivityEnabled:      defaultGraphNodeInterruptActivityEnabled,
+		GraphNodeInterruptActivityTopLevelOnly: defaultGraphNodeInterruptActivityTopLevelOnly,
 	}
 	for _, o := range opt {
 		o(opts)
@@ -192,6 +195,13 @@ func WithGraphNodeLifecycleActivityEnabled(enabled bool) Option {
 func WithGraphNodeInterruptActivityEnabled(enabled bool) Option {
 	return func(o *Options) {
 		o.GraphNodeInterruptActivityEnabled = enabled
+	}
+}
+
+// WithGraphNodeInterruptActivityTopLevelOnly enables emitting graph interrupt activity events only for the top-level invocation.
+func WithGraphNodeInterruptActivityTopLevelOnly(enabled bool) Option {
+	return func(o *Options) {
+		o.GraphNodeInterruptActivityTopLevelOnly = enabled
 	}
 }
 

--- a/server/agui/runner/options_test.go
+++ b/server/agui/runner/options_test.go
@@ -68,6 +68,7 @@ func TestNewOptionsDefaults(t *testing.T) {
 	assert.Equal(t, time.Hour, opts.Timeout)
 	assert.False(t, opts.GraphNodeLifecycleActivityEnabled)
 	assert.False(t, opts.GraphNodeInterruptActivityEnabled)
+	assert.False(t, opts.GraphNodeInterruptActivityTopLevelOnly)
 }
 
 func TestWithUserIDResolver(t *testing.T) {
@@ -115,6 +116,11 @@ func TestWithGraphNodeLifecycleActivityEnabled(t *testing.T) {
 func TestWithGraphNodeInterruptActivityEnabled(t *testing.T) {
 	opts := NewOptions(WithGraphNodeInterruptActivityEnabled(true))
 	assert.True(t, opts.GraphNodeInterruptActivityEnabled)
+}
+
+func TestWithGraphNodeInterruptActivityTopLevelOnly(t *testing.T) {
+	opts := NewOptions(WithGraphNodeInterruptActivityTopLevelOnly(true))
+	assert.True(t, opts.GraphNodeInterruptActivityTopLevelOnly)
 }
 
 func TestWithTranslateCallbacks(t *testing.T) {

--- a/server/agui/runner/runner.go
+++ b/server/agui/runner/runner.go
@@ -63,41 +63,43 @@ func New(r trunner.Runner, opt ...Option) Runner {
 		}
 	}
 	run := &runner{
-		runner:                            r,
-		appName:                           opts.AppName,
-		translatorFactory:                 opts.TranslatorFactory,
-		graphNodeLifecycleActivityEnabled: opts.GraphNodeLifecycleActivityEnabled,
-		graphNodeInterruptActivityEnabled: opts.GraphNodeInterruptActivityEnabled,
-		userIDResolver:                    opts.UserIDResolver,
-		translateCallbacks:                opts.TranslateCallbacks,
-		runAgentInputHook:                 opts.RunAgentInputHook,
-		stateResolver:                     opts.StateResolver,
-		runOptionResolver:                 opts.RunOptionResolver,
-		tracker:                           tracker,
-		running:                           make(map[session.Key]*sessionContext),
-		startSpan:                         opts.StartSpan,
-		timeout:                           opts.Timeout,
+		runner:                                 r,
+		appName:                                opts.AppName,
+		translatorFactory:                      opts.TranslatorFactory,
+		graphNodeLifecycleActivityEnabled:      opts.GraphNodeLifecycleActivityEnabled,
+		graphNodeInterruptActivityEnabled:      opts.GraphNodeInterruptActivityEnabled,
+		graphNodeInterruptActivityTopLevelOnly: opts.GraphNodeInterruptActivityTopLevelOnly,
+		userIDResolver:                         opts.UserIDResolver,
+		translateCallbacks:                     opts.TranslateCallbacks,
+		runAgentInputHook:                      opts.RunAgentInputHook,
+		stateResolver:                          opts.StateResolver,
+		runOptionResolver:                      opts.RunOptionResolver,
+		tracker:                                tracker,
+		running:                                make(map[session.Key]*sessionContext),
+		startSpan:                              opts.StartSpan,
+		timeout:                                opts.Timeout,
 	}
 	return run
 }
 
 // runner is the default implementation of the Runner.
 type runner struct {
-	appName                           string
-	runner                            trunner.Runner
-	translatorFactory                 TranslatorFactory
-	graphNodeLifecycleActivityEnabled bool
-	graphNodeInterruptActivityEnabled bool
-	userIDResolver                    UserIDResolver
-	translateCallbacks                *translator.Callbacks
-	runAgentInputHook                 RunAgentInputHook
-	stateResolver                     StateResolver
-	runOptionResolver                 RunOptionResolver
-	tracker                           track.Tracker
-	runningMu                         sync.Mutex
-	running                           map[session.Key]*sessionContext
-	startSpan                         StartSpan
-	timeout                           time.Duration
+	appName                                string
+	runner                                 trunner.Runner
+	translatorFactory                      TranslatorFactory
+	graphNodeLifecycleActivityEnabled      bool
+	graphNodeInterruptActivityEnabled      bool
+	graphNodeInterruptActivityTopLevelOnly bool
+	userIDResolver                         UserIDResolver
+	translateCallbacks                     *translator.Callbacks
+	runAgentInputHook                      RunAgentInputHook
+	stateResolver                          StateResolver
+	runOptionResolver                      RunOptionResolver
+	tracker                                track.Tracker
+	runningMu                              sync.Mutex
+	running                                map[session.Key]*sessionContext
+	startSpan                              StartSpan
+	timeout                                time.Duration
 }
 
 type sessionContext struct {
@@ -195,6 +197,7 @@ func (r *runner) Run(ctx context.Context, runAgentInput *adapter.RunAgentInput) 
 		runAgentInput,
 		translator.WithGraphNodeLifecycleActivityEnabled(r.graphNodeLifecycleActivityEnabled),
 		translator.WithGraphNodeInterruptActivityEnabled(r.graphNodeInterruptActivityEnabled),
+		translator.WithGraphNodeInterruptActivityTopLevelOnly(r.graphNodeInterruptActivityTopLevelOnly),
 	)
 	if err != nil {
 		span.End()

--- a/server/agui/translator/options.go
+++ b/server/agui/translator/options.go
@@ -11,8 +11,9 @@ package translator
 
 // options configures which graph-related AG-UI events the translator emits.
 type options struct {
-	graphNodeLifecycleActivityEnabled bool // graphNodeLifecycleActivityEnabled enables graph node lifecycle activity events.
-	graphNodeInterruptActivityEnabled bool // graphNodeInterruptActivityEnabled enables graph interrupt activity events.
+	graphNodeLifecycleActivityEnabled      bool // graphNodeLifecycleActivityEnabled enables graph node lifecycle activity events.
+	graphNodeInterruptActivityEnabled      bool // graphNodeInterruptActivityEnabled enables graph interrupt activity events.
+	graphNodeInterruptActivityTopLevelOnly bool // graphNodeInterruptActivityTopLevelOnly drops nested graph interrupt activity events.
 }
 
 // Option is a function that configures the options.
@@ -40,5 +41,13 @@ func WithGraphNodeLifecycleActivityEnabled(enabled bool) Option {
 func WithGraphNodeInterruptActivityEnabled(enabled bool) Option {
 	return func(o *options) {
 		o.graphNodeInterruptActivityEnabled = enabled
+	}
+}
+
+// WithGraphNodeInterruptActivityTopLevelOnly controls whether the translator only emits
+// graph interrupt activity events for the top-level invocation.
+func WithGraphNodeInterruptActivityTopLevelOnly(enabled bool) Option {
+	return func(o *options) {
+		o.graphNodeInterruptActivityTopLevelOnly = enabled
 	}
 }


### PR DESCRIPTION
Add an AG-UI option to suppress nested graph.node.interrupt activity events in multi-level GraphAgent runs and emit only the outermost interrupt event used for resuming, reducing duplicate interrupt prompts without changing resume semantics.