### PR TITLE
graph: remove createTask debug logging

### DIFF
--- a/graph/executor.go
+++ b/graph/executor.go
@@ -1219,41 +1219,6 @@ func (e *Executor) createTask(nodeID string, state State, step int) *Task {
 		return nil
 	}
 
-	log.Debugf(
-		"🔧 createTask: creating task for nodeID='%s', step=%d",
-		nodeID,
-		step,
-	)
-	stateKeys := make([]string, 0, len(state))
-	for k := range state {
-		stateKeys = append(stateKeys, k)
-	}
-	log.Debugf(
-		"🔧 createTask: state has %d keys: %v",
-		len(state),
-		stateKeys,
-	)
-
-	// Log key state values that we're interested in tracking
-	// State prepared for task
-
-	if stepCountVal, exists := state[StateFieldStepCount]; exists {
-		log.Debugf(
-			"🔧 createTask: state contains step_count=%v (type: %T)",
-			stepCountVal,
-			stepCountVal,
-		)
-	}
-
-	// Special logging for final node to track the counter issue
-	if nodeID == "final" {
-		log.Debugf(
-			"🔧 createTask: FINAL NODE - counter=%v, step_count=%v",
-			state[StateFieldCounter],
-			state[StateFieldStepCount],
-		)
-	}
-
 	return &Task{
 		NodeID:   nodeID,
 		Input:    state,


### PR DESCRIPTION
## Summary
- Remove heavy debug-only logging in `Executor.createTask` that enumerated all
  state keys and special-cased the `"final"` node.
- Avoid potential sensitive state leakage when debug logging is enabled.
- Avoid unnecessary CPU/allocation overhead from building `stateKeys`
  regardless of log level.

## Tests
- `go test ./...` (Go 1.21.1)

## Summary by Sourcery

从图执行器任务创建路径中移除仅用于调试的日志，以降低开销并避免在日志中泄露状态细节。

Bug 修复：
- 防止通过 `Executor.createTask` 中的调试日志潜在泄露敏感状态数据。

增强：
- 删除 `Executor.createTask` 中不必要的调试日志，以在创建任务时减少 CPU 和内存分配开销。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove debug-only logging from the graph executor task creation path to reduce overhead and avoid leaking state details in logs.

Bug Fixes:
- Prevent potential leakage of sensitive state data through debug logging in Executor.createTask.

Enhancements:
- Eliminate unnecessary debug logging in Executor.createTask to reduce CPU and allocation overhead when creating tasks.

</details>