### PR TITLE
agent/graphagent: return error on nil invocation

### DIFF
--- a/agent/graphagent/graph_agent.go
+++ b/agent/graphagent/graph_agent.go
@@ -12,6 +12,7 @@ package graphagent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -29,6 +30,8 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/telemetry/trace"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
+
+const invocationNilErrMsg = "invocation is nil"
 
 // GraphAgent is an agent that executes a graph.
 type GraphAgent struct {
@@ -86,6 +89,9 @@ func New(name string, g *graph.Graph, opts ...Option) (*GraphAgent, error) {
 
 // Run executes the graph with the provided invocation.
 func (ga *GraphAgent) Run(ctx context.Context, invocation *agent.Invocation) (<-chan *event.Event, error) {
+	if invocation == nil {
+		return nil, errors.New(invocationNilErrMsg)
+	}
 	// Setup invocation
 	ga.setupInvocation(invocation)
 

--- a/agent/graphagent/graph_agent_test.go
+++ b/agent/graphagent/graph_agent_test.go
@@ -111,6 +111,31 @@ func TestGraphAgentWithOptions(t *testing.T) {
 	}
 }
 
+func TestGraphAgentRun_NilInvocation(t *testing.T) {
+	const nodeNoop = "noop"
+
+	stateGraph := graph.NewStateGraph(graph.NewStateSchema())
+	stateGraph.AddNode(
+		nodeNoop,
+		func(context.Context, graph.State) (any, error) {
+			return nil, nil
+		},
+	)
+	stateGraph.SetEntryPoint(nodeNoop)
+	stateGraph.SetFinishPoint(nodeNoop)
+
+	g, err := stateGraph.Compile()
+	require.NoError(t, err)
+
+	graphAgent, err := New("test-agent", g)
+	require.NoError(t, err)
+
+	eventCh, err := graphAgent.Run(context.Background(), nil)
+	require.Error(t, err)
+	require.Nil(t, eventCh)
+	require.Equal(t, invocationNilErrMsg, err.Error())
+}
+
 func TestGraphAgent_WithMaxConcurrency(t *testing.T) {
 	const (
 		nodeRoot       = "root"


### PR DESCRIPTION
## Summary
- Return a clear error when `GraphAgent.Run` receives a nil `invocation`
  (consistent with `Executor.Execute`).
- Add a regression test to ensure we return an error instead of panicking.

## Tests
- `go test ./...` (Go 1.21.1)

## Summary by Sourcery

确保 `GraphAgent.Run` 在处理 `nil` invocation 时不会触发 panic，而是安全地处理。

Bug Fixes:
- 当以 `nil` invocation 调用 `GraphAgent.Run` 时，返回清晰的错误信息，而不是触发 panic。

Tests:
- 添加回归测试，验证当以 `nil` invocation 调用 `GraphAgent.Run` 时，会返回错误且不会返回事件通道（event channel）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure GraphAgent.Run safely handles nil invocations instead of panicking.

Bug Fixes:
- Return a clear error when GraphAgent.Run is called with a nil invocation rather than panicking.

Tests:
- Add a regression test verifying that GraphAgent.Run returns an error and no event channel when invoked with a nil invocation.

</details>