### PR TITLE
WIP agui: add custom event for message content parts in user message recording

### DIFF
--- a/server/agui/runner/runner.go
+++ b/server/agui/runner/runner.go
@@ -567,7 +567,7 @@ func (r *runner) recordUserMessage(ctx context.Context, key session.Key, message
 		events = append(events, aguievents.NewTextMessageContentEvent(messageID, message.Content))
 	}
 	events = append(events, aguievents.NewTextMessageEndEvent(messageID))
-	for len(message.ContentParts) > 0 {
+	if len(message.ContentParts) > 0 {
 		events = append(events, aguievents.NewCustomEvent(fmt.Sprintf("message.content.part-%s", messageID), aguievents.WithValue(message.ContentParts)))
 	}
 	for _, evt := range events {


### PR DESCRIPTION
- Introduced a loop to append custom events for each part of the message content in the recordUserMessage function.
- This enhancement allows for better tracking and handling of messages that are split into multiple parts.

## Summary by Sourcery

新功能：
- 为用户消息触发一个自定义事件，其中包含消息内容部分，以改进追踪和处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Emit a custom event for user messages that includes the message content parts for improved tracking and handling.

</details>