### PR TITLE
checkpoint/redis: downgrade go-redis to v9.16.0

### DIFF
--- a/graph/checkpoint/redis/go.mod
+++ b/graph/checkpoint/redis/go.mod
@@ -10,7 +10,7 @@ replace (
 require (
 	github.com/alicebob/miniredis/v2 v2.35.0
 	github.com/google/uuid v1.6.0
-	github.com/redis/go-redis/v9 v9.17.0
+	github.com/redis/go-redis/v9 v9.16.0
 	github.com/stretchr/testify v1.10.0
 	trpc.group/trpc-go/trpc-agent-go v0.6.0
 	trpc.group/trpc-go/trpc-agent-go/storage/redis v0.6.0

--- a/graph/checkpoint/redis/go.sum
+++ b/graph/checkpoint/redis/go.sum
@@ -33,8 +33,8 @@ github.com/mattn/go-sqlite3 v1.14.32 h1:JD12Ag3oLy1zQA+BNn74xRgaBbdhbNIDYvQUEuuE
 github.com/mattn/go-sqlite3 v1.14.32/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/redis/go-redis/v9 v9.17.0 h1:K6E+ZlYN95KSMmZeEQPbU/c++wfmEvfFB17yEAq/VhM=
-github.com/redis/go-redis/v9 v9.17.0/go.mod h1:u410H11HMLoB+TP67dz8rL9s6QW2j76l0//kSOd3370=
+github.com/redis/go-redis/v9 v9.16.0 h1:OotgqgLSRCmzfqChbQyG1PHC3tLNR89DG4jdOERSEP4=
+github.com/redis/go-redis/v9 v9.16.0/go.mod h1:u410H11HMLoB+TP67dz8rL9s6QW2j76l0//kSOd3370=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=


### PR DESCRIPTION
Downgrade go-redis from v9.17.0 to v9.16.0 to maintain compatibility with trpc-database/goredis. This avoids the breaking change introduced in v9.17.0 where ACLGenPass method was added to UniversalClient interface.

## 由 Sourcery 提供的摘要

构建：
- 在 `go.mod` 中将 `go-redis` 模块版本从 `v9.17.0` 调整为 `v9.16.0`，以避免破坏性的接口变更。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Adjust go-redis module version from v9.17.0 to v9.16.0 in go.mod to avoid a breaking interface change.

</details>