### PR TITLE
fileref: add public file refs

### DIFF
--- a/examples/skill/main.go
+++ b/examples/skill/main.go
@@ -41,8 +41,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
 	localexec "trpc.group/trpc-go/trpc-agent-go/codeexecutor/local"
 	"trpc.group/trpc-go/trpc-agent-go/event"
-	"trpc.group/trpc-go/trpc-agent-go/internal/fileref"
-	"trpc.group/trpc-go/trpc-agent-go/internal/toolcache"
+	"trpc.group/trpc-go/trpc-agent-go/fileref"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/model/openai"
 	"trpc.group/trpc-go/trpc-agent-go/planner/react"
@@ -553,11 +552,9 @@ func readFileContent(
 
 	if _, err := os.Stat(filePath); os.IsNotExist(err) {
 		if looksLikeSkillWorkspacePath(cacheKey) {
-			if content, _, ok := toolcache.
-				LookupSkillRunOutputFileFromContext(
-					ctx,
-					cacheKey,
-				); ok {
+			ref := fileref.WorkspaceRef(cacheKey)
+			content, _, handled, err := fileref.TryRead(ctx, ref)
+			if handled && err == nil {
 				return ReadFileResponse{
 					Content:  content,
 					FileType: "text",

--- a/fileref/fileref.go
+++ b/fileref/fileref.go
@@ -1,0 +1,89 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+// Package fileref provides a public API for parsing and reading file
+// references like workspace://... and artifact://....
+//
+// These references are used by tools to share a unified file view.
+package fileref
+
+import (
+	"context"
+
+	internal "trpc.group/trpc-go/trpc-agent-go/internal/fileref"
+)
+
+const (
+	// SchemeArtifact is the artifact:// file ref scheme.
+	SchemeArtifact = internal.SchemeArtifact
+	// SchemeWorkspace is the workspace:// file ref scheme.
+	SchemeWorkspace = internal.SchemeWorkspace
+
+	// ArtifactPrefix is the "artifact://" prefix.
+	ArtifactPrefix = internal.ArtifactPrefix
+	// WorkspacePrefix is the "workspace://" prefix.
+	WorkspacePrefix = internal.WorkspacePrefix
+)
+
+// Ref is a parsed file reference.
+//
+// When Scheme is empty, Path is a caller-defined local path
+// (for example, relative to a file tool base directory).
+type Ref = internal.Ref
+
+// WorkspaceFile is a read-only view of an exported skill_run output.
+// It is safe to pass across tools because it contains inline content.
+type WorkspaceFile struct {
+	Name     string
+	Content  string
+	MIMEType string
+}
+
+// WorkspaceRef builds a workspace:// reference for the given relative path.
+func WorkspaceRef(rel string) string {
+	return internal.WorkspaceRef(rel)
+}
+
+// Parse parses raw into a Ref.
+//
+// When the returned Ref has an empty Scheme, the caller should treat Path as
+// a local path (for example, relative to a tool base directory).
+func Parse(raw string) (Ref, error) {
+	return internal.Parse(raw)
+}
+
+// TryRead reads raw if it is a supported file reference.
+//
+// When handled is false, raw is not a reference and the caller should treat
+// it as a local path.
+func TryRead(
+	ctx context.Context,
+	raw string,
+) (string, string, bool, error) {
+	return internal.TryRead(ctx, raw)
+}
+
+// WorkspaceFiles returns files exported from skill_run output_files in ctx.
+func WorkspaceFiles(ctx context.Context) []WorkspaceFile {
+	files := internal.WorkspaceFiles(ctx)
+	if len(files) == 0 {
+		return nil
+	}
+
+	out := make([]WorkspaceFile, 0, len(files))
+	for _, f := range files {
+		out = append(out, WorkspaceFile{
+			Name:     f.Name,
+			Content:  f.Content,
+			MIMEType: f.MIMEType,
+		})
+	}
+	return out
+}

--- a/fileref/fileref_test.go
+++ b/fileref/fileref_test.go
@@ -1,0 +1,240 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package fileref_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/artifact"
+	artifactinmemory "trpc.group/trpc-go/trpc-agent-go/artifact/inmemory"
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
+	"trpc.group/trpc-go/trpc-agent-go/fileref"
+	"trpc.group/trpc-go/trpc-agent-go/internal/toolcache"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+func TestParse_NoScheme(t *testing.T) {
+	ref, err := fileref.Parse("out/a.txt")
+	require.NoError(t, err)
+	require.Empty(t, ref.Scheme)
+	require.Equal(t, "out/a.txt", ref.Path)
+}
+
+func TestParse_EmptyString(t *testing.T) {
+	ref, err := fileref.Parse("   ")
+	require.NoError(t, err)
+	require.Empty(t, ref.Scheme)
+	require.Empty(t, ref.Path)
+}
+
+func TestParse_WorkspaceScheme(t *testing.T) {
+	ref, err := fileref.Parse("workspace://out/a.txt")
+	require.NoError(t, err)
+	require.Equal(t, fileref.SchemeWorkspace, ref.Scheme)
+	require.Equal(t, "out/a.txt", ref.Path)
+}
+
+func TestParse_Workspace_EmptyOrDot(t *testing.T) {
+	ref, err := fileref.Parse("workspace://.")
+	require.NoError(t, err)
+	require.Equal(t, fileref.SchemeWorkspace, ref.Scheme)
+	require.Empty(t, ref.Path)
+}
+
+func TestParse_Workspace_CleansToDot(t *testing.T) {
+	ref, err := fileref.Parse("workspace://a/..")
+	require.NoError(t, err)
+	require.Equal(t, fileref.SchemeWorkspace, ref.Scheme)
+	require.Empty(t, ref.Path)
+}
+
+func TestParse_ArtifactScheme(t *testing.T) {
+	ref, err := fileref.Parse("artifact://x.txt@12")
+	require.NoError(t, err)
+	require.Equal(t, fileref.SchemeArtifact, ref.Scheme)
+	require.Equal(t, "x.txt", ref.ArtifactName)
+	require.NotNil(t, ref.ArtifactVersion)
+	require.Equal(t, 12, *ref.ArtifactVersion)
+}
+
+func TestParse_UnsupportedScheme(t *testing.T) {
+	_, err := fileref.Parse("unknown://x")
+	require.Error(t, err)
+}
+
+func TestParse_Artifact_InvalidRef(t *testing.T) {
+	_, err := fileref.Parse("artifact://x@bad")
+	require.Error(t, err)
+}
+
+func TestParse_Artifact_EmptyNameAfterParse(t *testing.T) {
+	_, err := fileref.Parse("artifact://@1")
+	require.Error(t, err)
+}
+
+func TestParse_Artifact_EmptyName(t *testing.T) {
+	_, err := fileref.Parse("artifact://")
+	require.Error(t, err)
+}
+
+func TestParse_Workspace_InvalidPath(t *testing.T) {
+	_, err := fileref.Parse("workspace://../x")
+	require.Error(t, err)
+
+	_, err = fileref.Parse("workspace:///abs")
+	require.Error(t, err)
+}
+
+func TestWorkspaceRef(t *testing.T) {
+	require.Equal(t, "workspace://out/a.txt", fileref.WorkspaceRef("out/a.txt"))
+}
+
+func TestTryRead_Workspace_FromCache(t *testing.T) {
+	inv := agent.NewInvocation()
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+
+	toolcache.StoreSkillRunOutputFilesFromContext(
+		ctx,
+		[]codeexecutor.File{{
+			Name:     "out/a.txt",
+			Content:  "hi",
+			MIMEType: "text/plain",
+		}},
+	)
+
+	content, mime, handled, err := fileref.TryRead(
+		ctx,
+		"workspace://out/a.txt",
+	)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, "hi", content)
+	require.Equal(t, "text/plain", mime)
+}
+
+func TestTryRead_Workspace_NotExported(t *testing.T) {
+	inv := agent.NewInvocation()
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+
+	content, mime, handled, err := fileref.TryRead(
+		ctx,
+		"workspace://out/a.txt",
+	)
+	require.Error(t, err)
+	require.True(t, handled)
+	require.Empty(t, content)
+	require.Empty(t, mime)
+}
+
+func TestTryRead_Artifact_NoService(t *testing.T) {
+	content, mime, handled, err := fileref.TryRead(
+		context.Background(),
+		"artifact://x.txt@1",
+	)
+	require.Error(t, err)
+	require.True(t, handled)
+	require.Empty(t, content)
+	require.Empty(t, mime)
+}
+
+func TestTryRead_Artifact_WithService(t *testing.T) {
+	svc := artifactinmemory.NewService()
+	sess := session.NewSession("app", "user", "sess")
+
+	inv := agent.NewInvocation()
+	inv.Session = sess
+	inv.ArtifactService = svc
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+
+	info := artifact.SessionInfo{
+		AppName:   sess.AppName,
+		UserID:    sess.UserID,
+		SessionID: sess.ID,
+	}
+	ctxIO := codeexecutor.WithArtifactService(ctx, svc)
+	ctxIO = codeexecutor.WithArtifactSession(ctxIO, info)
+	_, err := codeexecutor.SaveArtifactHelper(
+		ctxIO,
+		"x.txt",
+		[]byte("hi"),
+		"text/plain",
+	)
+	require.NoError(t, err)
+
+	content, mime, handled, err := fileref.TryRead(ctx, "artifact://x.txt")
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, "hi", content)
+	require.Equal(t, "text/plain", mime)
+}
+
+func TestTryRead_NoScheme_NotHandled(t *testing.T) {
+	content, mime, handled, err := fileref.TryRead(
+		context.Background(),
+		"out/a.txt",
+	)
+	require.NoError(t, err)
+	require.False(t, handled)
+	require.Empty(t, content)
+	require.Empty(t, mime)
+}
+
+func TestTryRead_ParseErrorHandled(t *testing.T) {
+	content, mime, handled, err := fileref.TryRead(
+		context.Background(),
+		"unknown://x",
+	)
+	require.Error(t, err)
+	require.True(t, handled)
+	require.Empty(t, content)
+	require.Empty(t, mime)
+}
+
+func TestTryRead_Artifact_WithServiceInContext(t *testing.T) {
+	svc := artifactinmemory.NewService()
+
+	ctx := context.Background()
+	ctx = codeexecutor.WithArtifactService(ctx, svc)
+	ctx = codeexecutor.WithArtifactSession(ctx, artifact.SessionInfo{})
+
+	_, err := codeexecutor.SaveArtifactHelper(
+		ctx,
+		"x.txt",
+		[]byte("hi"),
+		"text/plain",
+	)
+	require.NoError(t, err)
+
+	content, mime, handled, err := fileref.TryRead(ctx, "artifact://x.txt")
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, "hi", content)
+	require.Equal(t, "text/plain", mime)
+}
+
+func TestWorkspaceFiles(t *testing.T) {
+	inv := agent.NewInvocation()
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+
+	toolcache.StoreSkillRunOutputFilesFromContext(
+		ctx,
+		[]codeexecutor.File{{Name: "out/a.txt", Content: "hi"}},
+	)
+
+	files := fileref.WorkspaceFiles(ctx)
+	require.Len(t, files, 1)
+	require.Equal(t, "out/a.txt", files[0].Name)
+	require.Equal(t, "hi", files[0].Content)
+}


### PR DESCRIPTION
## What
- Add public package `fileref` to parse/read `workspace://` and `artifact://` refs.
- Update `examples/skill` to use `fileref` instead of importing `internal/*`.

## Why
Examples are user-facing. Importing `internal/*` makes the code hard to reuse in external projects and couples examples to internal APIs.

## Tests
- `/Users/guoqizhou/sdk/go1.24.9/bin/go test ./...`
- `cd examples/skill && /Users/guoqizhou/sdk/go1.24.9/bin/go test ./...`

## Summary by Sourcery

公开一个用于解析和读取 workspace 与 artifact 文件引用的公共 `fileref` 包，并将技能示例迁移为使用该包而非内部 API。

New Features:
- 引入公共 `fileref` 包，用于解析 `workspace://` 和 `artifact://` 引用，并提供帮助方法读取被引用的内容以及列出已导出的 workspace 文件。

Enhancements:
- 重构技能示例，使其依赖新的公共 `fileref` 包，而不是内部的 `fileref` 和 `toolcache` 包。

Tests:
- 添加单元测试，覆盖 `fileref` 解析、通过上下文读取 workspace 和 artifact 引用，以及列出已导出的 workspace 文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Expose a public fileref package for parsing and reading workspace and artifact file references and migrate the skill example to use it instead of internal APIs.

New Features:
- Introduce a public fileref package that parses workspace:// and artifact:// references and provides helpers to read referenced content and list exported workspace files.

Enhancements:
- Refactor the skill example to depend on the new public fileref package instead of internal fileref and toolcache packages.

Tests:
- Add unit tests covering fileref parsing, reading workspace and artifact references via context, and listing exported workspace files.

</details>