### PR TITLE
WIP lsc: add ContinueOnToolError run option

### DIFF
--- a/agent/invocation.go
+++ b/agent/invocation.go
@@ -475,6 +475,14 @@ func WithToolCallArgumentsJSONRepairEnabled(enabled bool) RunOption {
 	}
 }
 
+// WithContinueOnToolError sets whether the framework continues when a tool returns an error.
+func WithContinueOnToolError(continueOnError bool) RunOption {
+	return func(opts *RunOptions) {
+		v := continueOnError
+		opts.ContinueOnToolError = &v
+	}
+}
+
 // WithA2ARequestOptions sets the A2A request options for the RunOptions.
 // These options will be passed to A2A agent's SendMessage and StreamMessage calls.
 // This allows passing dynamic HTTP headers or other request-specific options for each run.
@@ -686,9 +694,14 @@ type RunOptions struct {
 	// assistant tool_call response so the caller can execute the tool
 	// externally and later provide tool results (RoleTool messages).
 	ToolExecutionFilter tool.FilterFunc
+
 	// ToolCallArgumentsJSONRepairEnabled enables best-effort JSON repair for tool call arguments.
 	// When nil, JSON repair is disabled by default.
 	ToolCallArgumentsJSONRepairEnabled *bool
+
+	// ContinueOnToolError controls whether the framework continues execution when a tool returns an error.
+	// When nil, each executor uses its historical default behavior.
+	ContinueOnToolError *bool
 }
 
 // NewInvocation create a new invocation

--- a/agent/invocation_test.go
+++ b/agent/invocation_test.go
@@ -650,6 +650,18 @@ func TestWithGlobalInstruction(t *testing.T) {
 	require.Equal(t, testRunGlobalInstruction, opts.GlobalInstruction)
 }
 
+func TestWithContinueOnToolError(t *testing.T) {
+	opts := &RunOptions{}
+	WithContinueOnToolError(true)(opts)
+	require.NotNil(t, opts.ContinueOnToolError)
+	require.True(t, *opts.ContinueOnToolError)
+
+	opts = &RunOptions{}
+	WithContinueOnToolError(false)(opts)
+	require.NotNil(t, opts.ContinueOnToolError)
+	require.False(t, *opts.ContinueOnToolError)
+}
+
 func TestWithModel_Integration(t *testing.T) {
 	mockModel := &mockModel{name: "custom-model"}
 

--- a/docs/mkdocs/en/runner.md
+++ b/docs/mkdocs/en/runner.md
@@ -281,6 +281,10 @@ Some models may emit non-strict JSON arguments for `tool_calls` (for example, un
 
 When `agent.WithToolCallArgumentsJSONRepairEnabled(true)` is enabled in `runner.Run`, the framework will best-effort repair `toolCall.Function.Arguments`. For detailed usage, see [Tool Call Arguments Auto Repair](./runner.md#tool-call-arguments-auto-repair).
 
+#### Continue on Tool Errors
+
+When `agent.WithContinueOnToolError(true)` is enabled in `runner.Run`, tool execution failures (including invalid arguments, missing tools, or tool runtime errors) are returned as tool messages and the next LLM turn continues. When unset, Non-GraphAgent runs default to continue. GraphAgent runs default to stop. To force stopping on tool failures, explicitly set `agent.WithContinueOnToolError(false)`.
+
 #### Provide Conversation History (auto-seed + session reuse)
 
 If your upstream service maintains the conversation and you want the agent to

--- a/docs/mkdocs/en/tool.md
+++ b/docs/mkdocs/en/tool.md
@@ -12,6 +12,7 @@ The Tool system is a core component of the tRPC-Agent-Go framework, enabling Age
 - **🔄 MCP Protocol**: Full support for STDIO, SSE, and Streamable HTTP transports.
 - **🛠️ Configuration Support**: Provides configuration options and filter support.
 - **🧹 Arguments Repair**: Optionally enable `agent.WithToolCallArgumentsJSONRepairEnabled(true)` to best-effort repair `tool_calls` `arguments`, improving robustness for tool execution and external parsing.
+- **🧯 Continue on Tool Errors**: Optionally enable `agent.WithContinueOnToolError(true)` to continue the run when a tool fails, and send the error back as a tool message for the corresponding tool call.
 
 ### Core Concepts
 
@@ -914,6 +915,18 @@ ch, err := r.Run(ctx, userID, sessionID, model.NewUserMessage("..."),
     agent.WithToolCallArgumentsJSONRepairEnabled(true),
 )
 ```
+
+#### Continue on Tool Errors
+
+Tools may fail due to invalid arguments, missing registrations, runtime errors, or panics. With `agent.WithContinueOnToolError(true)`, the framework writes the failure reason back as a tool message for the corresponding tool call and proceeds to the next LLM turn, giving the model a chance to correct and retry.
+
+```go
+ch, err := r.Run(ctx, userID, sessionID, model.NewUserMessage("..."),
+    agent.WithContinueOnToolError(true),
+)
+```
+
+When unset, `ContinueOnToolError` is `nil` and each executor keeps its historical default behavior. Non-GraphAgent runs default to continue. GraphAgent runs default to stop. To force stopping on tool failures, explicitly set `agent.WithContinueOnToolError(false)`.
 
 ## Quick Start
 

--- a/docs/mkdocs/zh/runner.md
+++ b/docs/mkdocs/zh/runner.md
@@ -281,6 +281,10 @@ eventChan, err := r.Run(
 
 在 `runner.Run` 中启用 `agent.WithToolCallArgumentsJSONRepairEnabled(true)` 后，框架会对 `toolCall.Function.Arguments` 做一次尽力修复，详细使用方法可参照 [ToolCall参数自动修复](./runner.md#tool-call-参数自动修复)。
 
+#### 工具错误继续执行
+
+在 `runner.Run` 中启用 `agent.WithContinueOnToolError(true)` 后，当工具执行失败时，框架会把错误信息写成对应的 tool message，并继续进入下一轮 LLM 调用。工具执行失败包括参数解析失败、工具未注册、工具返回 error 等情况。当未显式设置时，非 GraphAgent 场景默认继续执行。GraphAgent 场景默认停止执行。如需强制工具失败时停止，可显式设置 `agent.WithContinueOnToolError(false)`。
+
 #### 传入对话历史（auto-seed + 复用 Session）
 
 如果上游服务已经维护了会话历史，并希望让 Agent 看见这些上下文，可以直接传入整段

--- a/docs/mkdocs/zh/tool.md
+++ b/docs/mkdocs/zh/tool.md
@@ -12,6 +12,7 @@ Tool 工具系统是 tRPC-Agent-Go 框架的核心组件，为 Agent 提供了�
 - **🔄 MCP 协议**：完整支持 STDIO、SSE、Streamable HTTP 三种传输方式
 - **🛠️ 配置支持**：提供配置选项和过滤器支持
 - **🧹 参数修复**：可选启用 `agent.WithToolCallArgumentsJSONRepairEnabled(true)`，对 `tool_calls` 的 `arguments` 做一次尽力 JSON 修复，提升工具执行与外部解析的鲁棒性
+- **🧯 错误继续执行**：可选启用 `agent.WithContinueOnToolError(true)`，当工具执行失败时仍继续下一轮，并将错误信息作为对应 `tool_call` 的 tool message 回传给模型
 
 ### 核心概念
 
@@ -905,6 +906,18 @@ ch, err := r.Run(ctx, userID, sessionID, model.NewUserMessage("..."),
     agent.WithToolCallArgumentsJSONRepairEnabled(true),
 )
 ```
+
+#### 工具错误继续执行
+
+工具在执行时可能因为参数解析失败、工具未注册、工具返回 error / panic 等原因失败。此时你可以通过 `agent.WithContinueOnToolError(true)` 控制框架把失败原因作为对应 `tool_call` 的 tool message 写回，并继续进入下一轮 LLM 调用，让模型有机会自我纠正与重试。
+
+```go
+ch, err := r.Run(ctx, userID, sessionID, model.NewUserMessage("..."),
+    agent.WithContinueOnToolError(true),
+)
+```
+
+当未显式设置时，`ContinueOnToolError` 为 `nil`，不同执行器会保持各自的历史默认行为。非 GraphAgent 场景默认继续执行。GraphAgent 场景默认停止执行。如需强制工具失败时停止，可显式设置 `agent.WithContinueOnToolError(false)`。
 
 ## 快速开始
 

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -36,3 +36,11 @@ type ResponseProcessor interface {
 	// ProcessResponse processes the response and sends events directly to the provided channel.
 	ProcessResponse(ctx context.Context, invocation *agent.Invocation, req *model.Request, rsp *model.Response, ch chan<- *event.Event)
 }
+
+// ContinueOnToolErrorEnabled resolves ContinueOnToolError with a default value.
+func ContinueOnToolErrorEnabled(invocation *agent.Invocation, defaultValue bool) bool {
+	if invocation == nil || invocation.RunOptions.ContinueOnToolError == nil {
+		return defaultValue
+	}
+	return *invocation.RunOptions.ContinueOnToolError
+}

--- a/internal/flow/flow_test.go
+++ b/internal/flow/flow_test.go
@@ -1,0 +1,35 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package flow
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+)
+
+func TestContinueOnToolErrorEnabled(t *testing.T) {
+	assert.True(t, ContinueOnToolErrorEnabled(nil, true))
+	assert.False(t, ContinueOnToolErrorEnabled(nil, false))
+
+	inv := &agent.Invocation{}
+	assert.True(t, ContinueOnToolErrorEnabled(inv, true))
+	assert.False(t, ContinueOnToolErrorEnabled(inv, false))
+
+	v := true
+	inv.RunOptions.ContinueOnToolError = &v
+	assert.True(t, ContinueOnToolErrorEnabled(inv, false))
+
+	v = false
+	inv.RunOptions.ContinueOnToolError = &v
+	assert.False(t, ContinueOnToolErrorEnabled(inv, true))
+}


### PR DESCRIPTION
This change adds a tri-state ContinueOnToolError run option that preserves historical defaults across non-GraphAgent and GraphAgent executors, and when enabled, converts tool execution failures into tool messages so the next LLM turn can continue. Tool call history sanitization is split into PR #1118.