### PR TITLE
a2agent: include message role to A2A event response

### DIFF
--- a/agent/a2aagent/a2a_converter.go
+++ b/agent/a2aagent/a2a_converter.go
@@ -500,16 +500,13 @@ func buildEventResponse(
 func buildStreamingResponse(messageID string, result *parseResult, role protocol.MessageRole) *model.Response {
 	now := time.Now()
 
-	// Convert A2A protocol role to internal model role
-	internalRole := convertA2ARoleToModelRole(role)
-
 	// Tool call: use Message (tool calls are complete units, not streamed incrementally)
 	if len(result.toolCalls) > 0 {
 		return &model.Response{
 			ID: messageID,
 			Choices: []model.Choice{{
 				Message: model.Message{
-					Role:             internalRole,
+					Role:             model.RoleAssistant,
 					Content:          result.textContent,
 					ReasoningContent: result.reasoningContent,
 					ToolCalls:        result.toolCalls,
@@ -560,6 +557,8 @@ func buildStreamingResponse(messageID string, result *parseResult, role protocol
 		objectType = model.ObjectTypeChatCompletionChunk
 	}
 
+	// Convert A2A protocol role to internal model role
+	internalRole := convertA2ARoleToModelRole(role)
 	return &model.Response{
 		ID: messageID,
 		Choices: []model.Choice{{
@@ -604,17 +603,12 @@ func extractObjectType(result *parseResult) string {
 // In non-streaming mode, all content uses Message (not Delta).
 func buildNonStreamingResponse(messageID string, result *parseResult, role protocol.MessageRole) *model.Response {
 	now := time.Now()
-
-	// Convert A2A protocol role to internal model role
-	internalRole := convertA2ARoleToModelRole(role)
-
 	var choices []model.Choice
-
 	// Tool call: assistant requesting tool execution
 	if len(result.toolCalls) > 0 {
 		choices = append(choices, model.Choice{
 			Message: model.Message{
-				Role:             internalRole,
+				Role:             model.RoleAssistant,
 				Content:          result.textContent,
 				ReasoningContent: result.reasoningContent,
 				ToolCalls:        result.toolCalls,
@@ -645,6 +639,7 @@ func buildNonStreamingResponse(messageID string, result *parseResult, role proto
 		} else if result.codeExecutionResult != "" {
 			content = result.codeExecutionResult
 		}
+		internalRole := convertA2ARoleToModelRole(role)
 		choices = append(choices, model.Choice{
 			Message: model.Message{
 				Role:             internalRole,

--- a/agent/a2aagent/a2a_converter_test.go
+++ b/agent/a2aagent/a2a_converter_test.go
@@ -2447,3 +2447,41 @@ func TestBuildNonStreamingResponse_WithReasoningContent(t *testing.T) {
 		t.Errorf("expected reasoningContent %q, got %q", "Thinking...", msg.ReasoningContent)
 	}
 }
+
+func TestConvertA2ARoleToModelRole(t *testing.T) {
+	tests := []struct {
+		name     string
+		role     protocol.MessageRole
+		expected model.Role
+	}{
+		{
+			name:     "MessageRoleUser converts to RoleUser",
+			role:     protocol.MessageRoleUser,
+			expected: model.RoleUser,
+		},
+		{
+			name:     "MessageRoleAgent converts to RoleAssistant",
+			role:     protocol.MessageRoleAgent,
+			expected: model.RoleAssistant,
+		},
+		{
+			name:     "unknown role defaults to RoleAssistant",
+			role:     protocol.MessageRole("unknown"),
+			expected: model.RoleAssistant,
+		},
+		{
+			name:     "empty role defaults to RoleAssistant",
+			role:     protocol.MessageRole(""),
+			expected: model.RoleAssistant,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := convertA2ARoleToModelRole(tt.role)
+			if result != tt.expected {
+				t.Errorf("convertA2ARoleToModelRole(%v) = %v, want %v", tt.role, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary by Sourcery

在事件响应中传播 A2A 消息角色，这样流式和非流式响应都能携带正确的内部模型角色。

增强内容：
- 引入一个辅助工具，将协议消息角色映射到内部模型角色，并在流式和非流式响应构建器中应用。

测试：
- 更新 A2A 转换器测试，以覆盖角色在流式和非流式响应以及事件构建中的传播。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Propagate A2A message roles into event responses so that streaming and non-streaming responses carry the correct internal model role.

Enhancements:
- Introduce a helper to map protocol message roles to internal model roles and apply it in both streaming and non-streaming response builders.

Tests:
- Update A2A converter tests to cover role propagation into streaming and non-streaming responses and event construction.

</details>