### PR TITLE
graph: reject unknown conditional routing targets

### DIFF
--- a/graph/executor.go
+++ b/graph/executor.go
@@ -2806,6 +2806,18 @@ func (e *Executor) processConditionalResult(
 		}
 	}
 
+	if target != End {
+		if _, exists := e.graph.Node(target); !exists {
+			return fmt.Errorf(
+				"conditional edge from %s returned %q; "+
+					"target node %q does not exist",
+				condEdge.From,
+				result,
+				target,
+			)
+		}
+	}
+
 	// Create and trigger the target channel.
 	channelName := fmt.Sprintf("%s%s", ChannelBranchPrefix, target)
 	e.graph.addChannel(channelName, channel.BehaviorLastValue)

--- a/graph/executor_checkpoint_test.go
+++ b/graph/executor_checkpoint_test.go
@@ -839,6 +839,8 @@ func TestExecutor_ProcessConditionalResult_SetsStepMark(t *testing.T) {
 	)
 
 	g := New(NewStateSchema())
+	require.NoError(t, g.addNode(&Node{ID: fromNode}))
+	require.NoError(t, g.addNode(&Node{ID: targetNode}))
 	exec := &Executor{graph: g}
 	ec := exec.buildExecutionContext(nil, "inv", State{}, false, nil)
 	condEdge := &ConditionalEdge{

--- a/graph/executor_test.go
+++ b/graph/executor_test.go
@@ -2289,6 +2289,56 @@ func TestProcessConditionalEdges_Multi_SkipEmpty(t *testing.T) {
 	require.False(t, okEmpty, "expected no channel for empty branch key")
 }
 
+func TestExecutor_ConditionalUnknownTarget_ReturnsError(t *testing.T) {
+	const (
+		nodeStart    = "start"
+		unknownRoute = "missing_node"
+		invID        = "inv-unknown-target"
+	)
+
+	sg := NewStateGraph(NewStateSchema())
+	sg.AddNode(nodeStart, func(ctx context.Context, s State) (any, error) {
+		return s, nil
+	})
+	sg.SetEntryPoint(nodeStart)
+	sg.AddConditionalEdges(
+		nodeStart,
+		func(ctx context.Context, s State) (string, error) {
+			return unknownRoute, nil
+		},
+		nil,
+	)
+
+	g, err := sg.Compile()
+	require.NoError(t, err)
+
+	exec, err := NewExecutor(g)
+	require.NoError(t, err)
+
+	events, err := exec.Execute(
+		context.Background(),
+		State{},
+		&agent.Invocation{InvocationID: invID},
+	)
+	require.NoError(t, err)
+
+	var gotErr *model.ResponseError
+	for ev := range events {
+		if ev.Error != nil {
+			gotErr = ev.Error
+		}
+	}
+	require.NotNil(t, gotErr)
+	require.Contains(t, gotErr.Message, unknownRoute)
+
+	channelName := ChannelBranchPrefix + unknownRoute
+	_, channelExists := g.getChannel(channelName)
+	require.False(t, channelExists)
+	triggerToNodes := g.getTriggerToNodes()
+	_, triggerExists := triggerToNodes[channelName]
+	require.False(t, triggerExists)
+}
+
 // minimalNoopNode returns a trivial node function for building test graphs.
 func minimalNoopNode(_ context.Context, _ State) (any, error) { return nil, nil }
 


### PR DESCRIPTION
## What
- Validate conditional edge results: resolved targets must exist (or be __end__).
- Avoid creating branch channels/triggers for unknown targets.

## Why
- Today, an unknown conditional result can silently "route to nowhere" (no task created) and also grow channel/trigger maps over time.

## Tests
- go test ./... -count=1

## Summary by Sourcery

在状态图执行器中验证条件路由的目标，以防止路由到不存在的节点。

Bug 修复：
- 当条件边解析到一个不存在的目标节点时，返回错误，而不是静默地路由到无处可去。

测试：
- 增加测试覆盖，确保未知的条件目标会抛出 `ResponseError`，且不会创建分支通道或触发器。
- 调整检查点测试，在处理条件结果之前显式注册源节点和目标节点。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Validate conditional routing targets in the state graph executor to prevent routing to non-existent nodes.

Bug Fixes:
- Return an error when a conditional edge resolves to a non-existent target node instead of silently routing to nowhere.

Tests:
- Add coverage to ensure unknown conditional targets surface a ResponseError and do not create branch channels or triggers.
- Adjust checkpoint tests to explicitly register source and target nodes before processing conditional results.

</details>