### PR TITLE
agent: update error type handling in A2A and LLM agents

### DIFF
--- a/agent/a2aagent/a2a_agent.go
+++ b/agent/a2aagent/a2a_agent.go
@@ -164,7 +164,8 @@ func (r *A2AAgent) Run(ctx context.Context, invocation *agent.Invocation) (<-cha
 
 	if r.a2aClient == nil {
 		span.SetStatus(codes.Error, "A2A client is nil")
-		span.SetAttributes(attribute.String(itelemetry.KeyErrorType, itelemetry.ValueDefaultErrorType))
+
+		span.SetAttributes(attribute.String(itelemetry.KeyErrorType, model.ErrorTypeRunError))
 		span.End()
 		return nil, fmt.Errorf("A2A client is nil")
 	}
@@ -172,7 +173,7 @@ func (r *A2AAgent) Run(ctx context.Context, invocation *agent.Invocation) (<-cha
 	// Validate A2A request options early
 	if err := r.validateA2ARequestOptions(invocation); err != nil {
 		span.SetStatus(codes.Error, err.Error())
-		span.SetAttributes(attribute.String(itelemetry.KeyErrorType, itelemetry.ValueDefaultErrorType))
+		span.SetAttributes(attribute.String(itelemetry.KeyErrorType, model.ErrorTypeRunError))
 		span.End()
 		return nil, err
 	}
@@ -187,7 +188,7 @@ func (r *A2AAgent) Run(ctx context.Context, invocation *agent.Invocation) (<-cha
 	}
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
-		span.SetAttributes(attribute.String(itelemetry.KeyErrorType, itelemetry.ValueDefaultErrorType))
+		span.SetAttributes(attribute.String(itelemetry.KeyErrorType, model.ErrorTypeRunError))
 		span.End()
 		return nil, err
 	}

--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -494,7 +494,7 @@ func (a *LLMAgent) Run(ctx context.Context, invocation *agent.Invocation) (e <-c
 		}
 		// Handle actual errors
 		span.SetStatus(codes.Error, err.Error())
-		span.SetAttributes(attribute.String(itelemetry.KeyErrorType, itelemetry.ValueDefaultErrorType))
+		span.SetAttributes(attribute.String(itelemetry.KeyErrorType, model.ErrorTypeRunError))
 		span.End()
 		return nil, err
 	}


### PR DESCRIPTION
## Summary by Sourcery

在发生运行失败时，为 A2A 和 LLM 代理标准化错误遥测类型。

增强内容：
- 在 A2A 代理失败时，为遥测 span 设置特定的运行错误类型，而不是使用默认错误类型。
- 在 LLM 代理失败时，为遥测 span 设置特定的运行错误类型，而不是使用默认错误类型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize error telemetry types for A2A and LLM agents when run failures occur.

Enhancements:
- Set a specific run error type in telemetry spans for A2A agent failures instead of using a default error type.
- Set a specific run error type in telemetry spans for LLM agent failures instead of using a default error type.

</details>