### PR TITLE
tool/skill: avoid host workspace mutations

### DIFF
--- a/tool/skill/run.go
+++ b/tool/skill/run.go
@@ -585,13 +585,13 @@ func (t *RunTool) skillLinksPresent(
 			Timeout: 5 * time.Second,
 		},
 	)
+	if err != nil {
+		return false, err
+	}
 	if rr.ExitCode == 0 {
 		return true, nil
 	}
-	if rr.ExitCode > 0 {
-		return false, nil
-	}
-	return false, err
+	return false, nil
 }
 
 // linkWorkspaceDirs creates convenience symlinks under the staged

--- a/tool/skill/run_test.go
+++ b/tool/skill/run_test.go
@@ -1922,7 +1922,12 @@ func TestRunTool_skillLinksPresent_ExitCodes(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, ok)
 
-	r.res = codeexecutor.RunResult{ExitCode: -1}
+	r.err = fmt.Errorf(errRunFail)
+	ok, err = rt.skillLinksPresent(ctx, eng, ws, testSkillName)
+	require.Error(t, err)
+	require.False(t, ok)
+
+	r.res = codeexecutor.RunResult{ExitCode: 0}
 	r.err = fmt.Errorf(errRunFail)
 	ok, err = rt.skillLinksPresent(ctx, eng, ws, testSkillName)
 	require.Error(t, err)


### PR DESCRIPTION
### Problem
- `RunTool.stageSkill` used host-side `os.*` helpers
  (`EnsureLayout` / `LoadMetadata` / `SaveMetadata`) against `ws.Path`.
- This breaks when `ws.Path` is not a host path (e.g. container / remote
  sandbox) and forces sandbox + host to share one filesystem layout.

### Change
- Load/save `metadata.json` via `Engine.FS()` inside the workspace.
- Verify staged skill symlinks via `Engine.Runner()` inside the workspace.
- Keep metadata updates atomic via temp file + `mv` in the workspace.

### Notes
- No public API changes; local behavior stays the same while
  container/remote engines stop touching host paths.

## Summary by Sourcery

通过引擎的文件系统和运行器来处理工作区元数据以及校验技能符号链接（symlink），以避免直接修改宿主机工作区，并支持非宿主机驱动的工作区。

Enhancements:
- 通过引擎文件系统加载和保存工作区元数据，使用默认值和时间戳管理，替代宿主机侧的元数据辅助工具。
- 通过限定在工作区范围内的引擎运行器命令来检查技能符号链接是否存在，而不是直接检查宿主机文件系统。
- 在工作区内使用临时文件和移动操作以原子方式更新工作区元数据。

Tests:
- 调整并扩展技能暂存（staging）测试，用于覆盖新的基于工作区的元数据和符号链接处理路径，以及更新后的错误场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Route workspace metadata handling and skill symlink verification through the engine’s filesystem and runner to avoid direct host workspace mutations and support non-host-backed workspaces.

Enhancements:
- Load and save workspace metadata via the engine filesystem with defaulting and timestamp management instead of host-side metadata helpers.
- Perform skill symlink presence checks via engine runner commands scoped to the workspace rather than direct host filesystem inspection.
- Atomically update workspace metadata within the workspace using a temporary file and move operation.

Tests:
- Adjust and extend skill staging tests to exercise the new workspace-based metadata and symlink handling paths and updated error cases.

</details>
