### PR TITLE
session/redis: fix TrimConversations key helpers

### DIFF
--- a/session/redis/service.go
+++ b/session/redis/service.go
@@ -629,7 +629,7 @@ func (s *Service) TrimConversations(
 		opt.ConversationCount = 1
 	}
 
-	eventKey := getEventKey(key)
+	eventKey := s.getEventKey(key)
 	targetReqIDs := make(map[string]struct{})
 	var toDelete []any
 	var deletedEvents []event.Event
@@ -685,10 +685,10 @@ func (s *Service) TrimConversations(
 	pipe := s.redisClient.TxPipeline()
 	pipe.ZRem(ctx, eventKey, toDelete...)
 	// Refresh TTL for all session-related keys to keep them consistent.
-	sessKey := getSessionStateKey(key)
-	sumKey := getSessionSummaryKey(key)
-	appStateKey := getAppStateKey(key.AppName)
-	userStateKey := getUserStateKey(key)
+	sessKey := s.getSessionStateKey(key)
+	sumKey := s.getSessionSummaryKey(key)
+	appStateKey := s.getAppStateKey(key.AppName)
+	userStateKey := s.getUserStateKey(key)
 	s.appendSessionTTL(ctx, pipe, key, sessKey, sumKey, appStateKey, userStateKey)
 	if _, err := pipe.Exec(ctx); err != nil {
 		return nil, fmt.Errorf("trim events: remove events: %w", err)

--- a/session/redis/service_test.go
+++ b/session/redis/service_test.go
@@ -3945,8 +3945,8 @@ func TestService_TrimConversations_TTLRefresh(t *testing.T) {
 	client := buildRedisClient(t, redisURL)
 	defer client.Close()
 
-	eventKey := getEventKey(key)
-	sessKey := getSessionStateKey(key)
+	eventKey := service.getEventKey(key)
+	sessKey := service.getSessionStateKey(key)
 
 	eventTTL := client.TTL(ctx, eventKey).Val()
 	sessTTL := client.TTL(ctx, sessKey).Val()


### PR DESCRIPTION
Fix TrimConversations to use Service-scoped redis key helpers so key prefix configuration is applied consistently, restoring builds for examples that import session/redis.