### PR TITLE
tool/skill: require runner for workspace cleanup

### DIFF
--- a/tool/skill/run.go
+++ b/tool/skill/run.go
@@ -19,7 +19,6 @@ import (
 	"mime"
 	"os"
 	"path"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -654,11 +653,7 @@ func (t *RunTool) removeWorkspacePath(
 		return nil
 	}
 	if eng == nil || eng.Runner() == nil {
-		if ws.Path == "" {
-			return nil
-		}
-		p := filepath.Join(ws.Path, filepath.FromSlash(target))
-		return os.RemoveAll(p)
+		return fmt.Errorf("workspace runner is not configured")
 	}
 	var sb strings.Builder
 	sb.WriteString("set -e; if [ -e ")

--- a/tool/skill/run_test.go
+++ b/tool/skill/run_test.go
@@ -1853,7 +1853,7 @@ func TestSkillStagingHelpers_EarlyReturns(t *testing.T) {
 	require.False(t, ok)
 
 	require.NoError(t, rt.removeWorkspacePath(ctx, nil, ws, ""))
-	require.NoError(t, rt.removeWorkspacePath(
+	require.Error(t, rt.removeWorkspacePath(
 		ctx,
 		nil,
 		ws,


### PR DESCRIPTION
Problem
- `skill_run` should not mutate workspace paths via host-local filesystem calls when the engine runner is missing.

Change
- Remove the local `os.RemoveAll` fallback in `removeWorkspacePath`.
- Return a clear error when the workspace runner is not configured.

Tests
- go test ./...

## Summary by Sourcery

要求在技能工作区清理时必须配置 workspace runner，而不是回退到本地文件系统删除。

Bug 修复：
- 当未配置 engine runner 时，防止在技能工作区清理期间对本地文件系统产生非预期的修改。

测试：
- 更新工作区清理相关测试，当缺少 workspace runner 时应期望抛出错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Require a configured workspace runner for skill workspace cleanup instead of falling back to local filesystem deletion.

Bug Fixes:
- Prevent unintended local filesystem mutations during skill workspace cleanup when no engine runner is configured.

Tests:
- Update workspace cleanup tests to expect an error when the workspace runner is missing.

</details>