### PR TITLE
llmagent: make code execution processor optional

### DIFF
--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -141,7 +141,12 @@ func New(name string, opts ...Option) *LLMAgent {
 		responseProcessors = append(responseProcessors, planningResponseProcessor)
 	}
 
-	responseProcessors = append(responseProcessors, processor.NewCodeExecutionResponseProcessor())
+	if options.EnableCodeExecutionResponseProcessor {
+		responseProcessors = append(
+			responseProcessors,
+			processor.NewCodeExecutionResponseProcessor(),
+		)
+	}
 
 	// Add output response processor if output_key or output_schema is configured or structured output is requested.
 	if options.OutputKey != "" || options.OutputSchema != nil || options.StructuredOutput != nil {

--- a/agent/llmagent/option.go
+++ b/agent/llmagent/option.go
@@ -82,8 +82,9 @@ const (
 
 var (
 	defaultOptions = Options{
-		ChannelBufferSize:          defaultChannelBufferSize,
-		EndInvocationAfterTransfer: true,
+		ChannelBufferSize:                    defaultChannelBufferSize,
+		EnableCodeExecutionResponseProcessor: true,
+		EndInvocationAfterTransfer:           true,
 		// Default to rewriting same-branch lineage events to user context so
 		// that downstream agents see a consolidated user message stream unless
 		// explicitly opted into preserving assistant/tool roles.
@@ -130,6 +131,11 @@ type Options struct {
 	// ChannelBufferSize is the buffer size for event channels (default: 256).
 	ChannelBufferSize int
 	codeExecutor      codeexecutor.CodeExecutor
+	// EnableCodeExecutionResponseProcessor controls whether the agent
+	// auto-executes fenced code blocks from model responses.
+	//
+	// Default: true (preserves existing behavior).
+	EnableCodeExecutionResponseProcessor bool
 	// Tools is the list of tools available to the agent.
 	Tools []tool.Tool
 	// ToolSets is the list of tool sets available to the agent.
@@ -357,6 +363,14 @@ func WithChannelBufferSize(size int) Option {
 func WithCodeExecutor(ce codeexecutor.CodeExecutor) Option {
 	return func(opts *Options) {
 		opts.codeExecutor = ce
+	}
+}
+
+// WithEnableCodeExecutionResponseProcessor controls whether the agent
+// auto-executes fenced code blocks found in model responses.
+func WithEnableCodeExecutionResponseProcessor(enable bool) Option {
+	return func(opts *Options) {
+		opts.EnableCodeExecutionResponseProcessor = enable
 	}
 }
 

--- a/docs/mkdocs/en/skill.md
+++ b/docs/mkdocs/en/skill.md
@@ -112,6 +112,10 @@ Key points:
 - Tools are auto‑registered with `WithSkills`: `skill_load`,
   `skill_select_docs`, `skill_list_docs`, and `skill_run` show up
   automatically; no manual wiring required.
+- Note: when `WithCodeExecutor` is set, LLMAgent will (by default) try to
+  execute Markdown fenced code blocks in model responses. If you only need
+  the executor for `skill_run`, disable this behavior with
+  `llmagent.WithEnableCodeExecutionResponseProcessor(false)`.
 - By default, the framework appends a small `Tooling and workspace guidance:`
   block after the `Available skills:` list in the system message.
   - Disable it (to save prompt tokens): `llmagent.WithSkillsToolingGuidance("")`.

--- a/docs/mkdocs/zh/skill.md
+++ b/docs/mkdocs/zh/skill.md
@@ -112,6 +112,10 @@ agent := llmagent.New(
 - 工具自动注册：开启 `WithSkills` 后，`skill_load`、
   `skill_select_docs`、`skill_list_docs` 与 `skill_run`
   会自动出现在工具列表中，无需手动添加。
+- 注意：当你同时设置了 `WithCodeExecutor` 时，LLMAgent 默认会尝试执行
+  模型回复里的 Markdown 围栏代码块。如果你只是为了给 `skill_run` 提供运行时，
+  不希望自动执行代码块，可以加上
+  `llmagent.WithEnableCodeExecutionResponseProcessor(false)`。
 - 默认提示指引：框架会在系统消息里，在 `Available skills:` 列表后追加一段
   `Tooling and workspace guidance:` 指引文本。
   - 关闭该指引（减少提示词占用）：`llmagent.WithSkillsToolingGuidance("")`。


### PR DESCRIPTION
Problem
- LLMAgent always installs processor.NewCodeExecutionResponseProcessor().
- When WithCodeExecutor is set only to provide a runtime for skill_run, Markdown fenced code blocks in model replies may be executed unexpectedly.

Change
- Add llmagent.WithEnableCodeExecutionResponseProcessor(bool) (default: true).
- Gate NewCodeExecutionResponseProcessor behind this option.
- Update skills docs to call out the default behavior and the opt-out.

Tests
- go test ./...

## Summary by Sourcery

使 LLMAgent 的自动代码执行响应处理器变为可选，同时保持当前的默认行为不变。

新功能：
- 添加一个 `Options` 标志和构造函数选项，用于启用或禁用对模型响应中代码块（fenced code blocks）的自动执行。

增强：
- 在 LLMAgent 初始化过程中接入新选项，使代码执行响应处理器仅在启用时才会安装。

文档：
- 在英文和中文的技能文档中说明默认的自动执行行为以及用于退出（opt-out）的标志。

测试：
- 添加单元测试，使用一个计数型代码执行器，覆盖默认启用与显式禁用代码执行响应处理的情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make LLMAgent's automatic code-execution response processor optional while preserving existing default behavior.

New Features:
- Add an Options flag and constructor option to enable or disable automatic execution of fenced code blocks in model responses.

Enhancements:
- Wire the new option into LLMAgent initialization so the code execution response processor is only installed when enabled.

Documentation:
- Document the default auto-execution behavior and the opt-out flag in both English and Chinese skills documentation.

Tests:
- Add unit tests covering default-enabled and explicitly-disabled code execution response processing using a counting code executor.

</details>