### PR TITLE
memory: return defensive copy of precomputed tools

### DIFF
--- a/memory/inmemory/service.go
+++ b/memory/inmemory/service.go
@@ -317,7 +317,9 @@ func (s *MemoryService) SearchMemories(ctx context.Context, userKey memory.UserK
 // In agentic mode, all enabled tools are returned.
 // The tools list is pre-computed at service creation time.
 func (s *MemoryService) Tools() []tool.Tool {
-	return s.precomputedTools
+	result := make([]tool.Tool, len(s.precomputedTools))
+	copy(result, s.precomputedTools)
+	return result
 }
 
 // EnqueueAutoMemoryJob enqueues an auto memory extraction job for async

--- a/memory/inmemory/service.go
+++ b/memory/inmemory/service.go
@@ -13,6 +13,7 @@ package inmemory
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 	"sync"
 	"time"
@@ -317,9 +318,7 @@ func (s *MemoryService) SearchMemories(ctx context.Context, userKey memory.UserK
 // In agentic mode, all enabled tools are returned.
 // The tools list is pre-computed at service creation time.
 func (s *MemoryService) Tools() []tool.Tool {
-	result := make([]tool.Tool, len(s.precomputedTools))
-	copy(result, s.precomputedTools)
-	return result
+	return slices.Clone(s.precomputedTools)
 }
 
 // EnqueueAutoMemoryJob enqueues an auto memory extraction job for async

--- a/memory/mysql/service.go
+++ b/memory/mysql/service.go
@@ -379,7 +379,9 @@ func (s *Service) SearchMemories(ctx context.Context, userKey memory.UserKey, qu
 // In agentic mode, all enabled tools are returned.
 // The tools list is pre-computed at service creation time.
 func (s *Service) Tools() []tool.Tool {
-	return s.precomputedTools
+	result := make([]tool.Tool, len(s.precomputedTools))
+	copy(result, s.precomputedTools)
+	return result
 }
 
 // EnqueueAutoMemoryJob enqueues an auto memory extraction job for async

--- a/memory/mysql/service.go
+++ b/memory/mysql/service.go
@@ -15,6 +15,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"sort"
 	"time"
 
@@ -379,9 +380,7 @@ func (s *Service) SearchMemories(ctx context.Context, userKey memory.UserKey, qu
 // In agentic mode, all enabled tools are returned.
 // The tools list is pre-computed at service creation time.
 func (s *Service) Tools() []tool.Tool {
-	result := make([]tool.Tool, len(s.precomputedTools))
-	copy(result, s.precomputedTools)
-	return result
+	return slices.Clone(s.precomputedTools)
 }
 
 // EnqueueAutoMemoryJob enqueues an auto memory extraction job for async

--- a/memory/pgvector/service.go
+++ b/memory/pgvector/service.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -496,9 +497,7 @@ func (s *Service) SearchMemories(
 // In agentic mode, all enabled tools are returned.
 // The tools list is pre-computed at service creation time.
 func (s *Service) Tools() []tool.Tool {
-	result := make([]tool.Tool, len(s.precomputedTools))
-	copy(result, s.precomputedTools)
-	return result
+	return slices.Clone(s.precomputedTools)
 }
 
 // EnqueueAutoMemoryJob enqueues an auto memory extraction job for async processing.

--- a/memory/pgvector/service.go
+++ b/memory/pgvector/service.go
@@ -496,7 +496,9 @@ func (s *Service) SearchMemories(
 // In agentic mode, all enabled tools are returned.
 // The tools list is pre-computed at service creation time.
 func (s *Service) Tools() []tool.Tool {
-	return s.precomputedTools
+	result := make([]tool.Tool, len(s.precomputedTools))
+	copy(result, s.precomputedTools)
+	return result
 }
 
 // EnqueueAutoMemoryJob enqueues an auto memory extraction job for async processing.

--- a/memory/postgres/service.go
+++ b/memory/postgres/service.go
@@ -442,7 +442,9 @@ func (s *Service) SearchMemories(ctx context.Context, userKey memory.UserKey, qu
 // In agentic mode, all enabled tools are returned.
 // The tools list is pre-computed at service creation time.
 func (s *Service) Tools() []tool.Tool {
-	return s.precomputedTools
+	result := make([]tool.Tool, len(s.precomputedTools))
+	copy(result, s.precomputedTools)
+	return result
 }
 
 // EnqueueAutoMemoryJob enqueues an auto memory extraction job for async

--- a/memory/postgres/service.go
+++ b/memory/postgres/service.go
@@ -15,6 +15,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"sort"
 	"time"
 
@@ -442,9 +443,7 @@ func (s *Service) SearchMemories(ctx context.Context, userKey memory.UserKey, qu
 // In agentic mode, all enabled tools are returned.
 // The tools list is pre-computed at service creation time.
 func (s *Service) Tools() []tool.Tool {
-	result := make([]tool.Tool, len(s.precomputedTools))
-	copy(result, s.precomputedTools)
-	return result
+	return slices.Clone(s.precomputedTools)
 }
 
 // EnqueueAutoMemoryJob enqueues an auto memory extraction job for async

--- a/memory/redis/service.go
+++ b/memory/redis/service.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"sort"
 	"time"
 
@@ -287,9 +288,7 @@ func (s *Service) SearchMemories(ctx context.Context, userKey memory.UserKey, qu
 // In agentic mode, all enabled tools are returned.
 // The tools list is pre-computed at service creation time.
 func (s *Service) Tools() []tool.Tool {
-	result := make([]tool.Tool, len(s.precomputedTools))
-	copy(result, s.precomputedTools)
-	return result
+	return slices.Clone(s.precomputedTools)
 }
 
 // EnqueueAutoMemoryJob enqueues an auto memory extraction job for async

--- a/memory/redis/service.go
+++ b/memory/redis/service.go
@@ -287,7 +287,9 @@ func (s *Service) SearchMemories(ctx context.Context, userKey memory.UserKey, qu
 // In agentic mode, all enabled tools are returned.
 // The tools list is pre-computed at service creation time.
 func (s *Service) Tools() []tool.Tool {
-	return s.precomputedTools
+	result := make([]tool.Tool, len(s.precomputedTools))
+	copy(result, s.precomputedTools)
+	return result
 }
 
 // EnqueueAutoMemoryJob enqueues an auto memory extraction job for async


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 通过返回已复制的切片而不是原始切片，防止调用内存服务 `Tools()` 的使用方修改底层预计算工具切片。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent callers of memory service Tools() from mutating the underlying precomputed tools slice by returning a copied slice instead of the original.

</details>