### PR TITLE
fix tool hook res ignore && invocation get parent

### DIFF
--- a/agent/invocation.go
+++ b/agent/invocation.go
@@ -782,6 +782,14 @@ func (inv *Invocation) GetEventFilterKey() string {
 	return inv.eventFilterKey
 }
 
+// GetParentInvocation get parent invocation.
+func (inv *Invocation) GetParentInvocation() *Invocation {
+	if inv == nil {
+		return nil
+	}
+	return inv.parent
+}
+
 // InjectIntoEvent inject invocation information into event.
 func InjectIntoEvent(inv *Invocation, e *event.Event) {
 	if e == nil || inv == nil {

--- a/agent/invocation_test.go
+++ b/agent/invocation_test.go
@@ -438,6 +438,46 @@ func TestInvocation_GetEventFilterKey(t *testing.T) {
 	}
 }
 
+func TestInvocation_GetParentInvocation(t *testing.T) {
+	tests := []struct {
+		name     string
+		inv      *Invocation
+		validate func(*testing.T, *Invocation)
+	}{
+		{
+			name: "nil invocation",
+			inv:  nil,
+			validate: func(t *testing.T, parent *Invocation) {
+				require.Nil(t, parent)
+			},
+		},
+		{
+			name: "invocation without parent",
+			inv:  NewInvocation(),
+			validate: func(t *testing.T, parent *Invocation) {
+				require.Nil(t, parent)
+			},
+		},
+		{
+			name: "invocation with parent",
+			inv:  NewInvocation(WithInvocationID("test-inv-id")).Clone(),
+			validate: func(t *testing.T, parent *Invocation) {
+				require.NotNil(t, parent)
+				require.Equal(t, "test-inv-id", parent.InvocationID)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				parent := tt.inv.GetParentInvocation()
+				tt.validate(t, parent)
+			},
+		)
+	}
+}
+
 func TestInjectIntoEvent(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -139,7 +139,7 @@ func (r *Registry) BeforeTool(cb tool.BeforeToolCallbackStructured) {
 		) {
 			res, err := cb(ctx, args)
 			if err != nil {
-				return nil, fmt.Errorf("%s: %w", r.name, err)
+				return res, fmt.Errorf("%s: %w", r.name, err)
 			}
 			return res, nil
 		},
@@ -157,7 +157,7 @@ func (r *Registry) AfterTool(cb tool.AfterToolCallbackStructured) {
 		) {
 			res, err := cb(ctx, args)
 			if err != nil {
-				return nil, fmt.Errorf("%s: %w", r.name, err)
+				return res, fmt.Errorf("%s: %w", r.name, err)
 			}
 			return res, nil
 		},


### PR DESCRIPTION
1. plugin BeforeTool/AfterTool return result when error.
2. Invocation add GetParentInvocation method.

## Summary by Sourcery

即使回调发生错误也返回插件工具钩子结果，并在 `Invocation` 类型上暴露父级调用的访问能力。

New Features:
- 在 `Invocation` 上新增 `GetParentInvocation` 方法，以安全地获取其父级调用。

Bug Fixes:
- 确保 `BeforeTool` 和 `AfterTool` 插件回调在发生错误时，仍会连同错误一起返回其部分结果，而不是将其丢弃。

Tests:
- 添加单元测试，覆盖 `GetParentInvocation` 在 `nil`、无父级以及克隆调用场景下的行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Return plugin tool hook results even when callbacks error and expose parent invocation access on the Invocation type.

New Features:
- Add GetParentInvocation method on Invocation to retrieve its parent safely.

Bug Fixes:
- Ensure BeforeTool and AfterTool plugin callbacks return their partial results alongside errors instead of discarding them.

Tests:
- Add unit tests covering GetParentInvocation behavior for nil, parentless, and cloned invocations.

</details>