### PR TITLE
{server/agui, docs, examples}: add message snapshot continuation

### DIFF
--- a/docs/mkdocs/en/agui.md
+++ b/docs/mkdocs/en/agui.md
@@ -113,7 +113,7 @@ To enable message snapshots, configure the following options:
 - `agui.WithSessionService(service)` injects the `session.Service` used to look up historical events;
 - `aguirunner.WithUserIDResolver(resolver)` customises how `userID` is resolved, defaulting to `"user"`.
 
-When handling a message snapshot request, the framework extracts `threadId` as the `SessionID` from the AG-UI request body `RunAgentInput`, resolves `userID` using the custom `UserIDResolver`, and then builds `session.Key` with `appName`. It then queries the `Session` via `session.Service`, converts the stored events `Session.Events` into AG-UI messages, wraps them in a `MESSAGES_SNAPSHOT` event, and sends matching `RUN_STARTED` and `RUN_FINISHED` events.
+When handling a message snapshot request, the framework extracts `threadId` as the `SessionID` from the AG-UI request body `RunAgentInput`, resolves `userID` using the custom `UserIDResolver`, builds `session.Key` with `appName`, reads the persisted events from session storage, reconstructs the message list required by `MessagesSnapshot`, wraps it into a `MESSAGES_SNAPSHOT` event, and sends matching `RUN_STARTED` and `RUN_FINISHED` events.
 
 Example:
 
@@ -137,7 +137,7 @@ resolver := func(ctx context.Context, input *adapter.RunAgentInput) (string, err
     return user, nil
 }
 
-sessionService := inmemory.NewService(context.Background())
+sessionService := inmemory.NewSessionService()
 server, err := agui.New(
     runner,
     agui.WithPath("/chat"),                    // Customise the real-time conversation route, defaults to "/".
@@ -537,10 +537,10 @@ server, err := agui.New(
     agui.WithMessagesSnapshotEnabled(true),
     agui.WithAppName(appName),
     agui.WithSessionService(sessionService),
+    agui.WithFlushInterval(time.Second), // Set the periodic flush interval for aggregation results, default is 1 second.
     agui.WithAGUIRunnerOptions(
         aguirunner.WithUserIDResolver(userIDResolver),
         aguirunner.WithAggregationOption(aggregator.WithEnabled(true)), // Enable event aggregation, enabled by default.
-        aguirunner.WithFlushInterval(time.Second),                      // Set the periodic flush interval for aggregation results, default is 1 second.
     ),
 )
 ```
@@ -656,6 +656,40 @@ server, err := agui.New(
     ),
 )
 ```
+
+### Message Snapshot Continuation
+
+By default, `/history` (the message snapshot route) returns a one-shot snapshot and closes the connection immediately. When a user refreshes or reconnects in the middle of a real-time conversation (run), or opens the page in a new tab, the snapshot alone may not cover the events that continue to be produced after the snapshot boundary. If you want to keep streaming subsequent AG-UI events after the snapshot, enable message snapshot continuation.
+
+When enabled, after sending `MESSAGES_SNAPSHOT` the server continues streaming subsequent events over the same SSE connection until it reads `RUN_FINISHED` or `RUN_ERROR` (or reaches the continuation duration limit). The sequence becomes:
+
+`RUN_STARTED → MESSAGES_SNAPSHOT → ...events... → RUN_FINISHED/RUN_ERROR`
+
+Message snapshot continuation provides the following configuration options:
+
+- `agui.WithMessagesSnapshotFollowEnabled(true)`: enables message snapshot continuation (disabled by default);
+- `agui.WithMessagesSnapshotFollowMaxDuration(d)`: limits the maximum continuation duration to avoid waiting indefinitely;
+- `agui.WithFlushInterval(d)`: controls how often historical events are flushed; the continuation polling interval reuses this value.
+
+Example:
+
+```go
+import "time"
+
+server, err := agui.New(
+    runner,
+    agui.WithAppName(appName),
+    agui.WithSessionService(sessionService),
+    agui.WithMessagesSnapshotEnabled(true),
+    agui.WithMessagesSnapshotFollowEnabled(true),
+    agui.WithMessagesSnapshotFollowMaxDuration(30*time.Second),
+    agui.WithFlushInterval(50*time.Millisecond),
+)
+```
+
+A complete example can be found at [examples/agui/server/follow](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/server/follow), and the frontend can refer to [examples/agui/client/tdesign-chat](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/client/tdesign-chat).
+
+In a multi-instance deployment, instances must share the same `SessionService`; otherwise `/history` cannot read historical events written by other instances.
 
 ### Setting the BasePath for Routes
 

--- a/examples/agui/server/README.md
+++ b/examples/agui/server/README.md
@@ -13,3 +13,4 @@ This directory shows AG-UI servers that can talk to the AG-UI client examples.
 - [`langfuse/`](langfuse/) – This example shows how AG-UI Server customizes reporting through TranslateCallback and connects to the langfuse observability platform.
 - [`report/`](report/) – Report-focused LLMAgent that delivers answers as structured reports in a dedicated view for easy consumption.
 - [`thinkaggregator/`](thinkaggregator/) – Surfaces model reasoning ("think") as custom events and aggregates them per session before persistence.
+- [`follow/`](follow/) – Enables `MessagesSnapshot` follow mode so `/history` continues streaming persisted events until the run finishes.

--- a/examples/agui/server/follow/README.md
+++ b/examples/agui/server/follow/README.md
@@ -1,0 +1,62 @@
+# MessagesSnapshot Follow AG-UI Server
+
+This example exposes both the regular AG-UI SSE endpoint and the message snapshot endpoint, with follow mode enabled.
+
+When a client calls `POST /history` while the `threadId` is still producing events, the server will:
+
+1. Emit `MESSAGES_SNAPSHOT`.
+2. Continue streaming the subsequent persisted events until the run finishes.
+
+## Run
+
+From the `examples/agui` module:
+
+```bash
+cd server/follow
+go run .
+```
+
+Endpoints (by default):
+
+- Chat endpoint: `http://127.0.0.1:8080/agui`
+- Snapshot endpoint: `http://127.0.0.1:8080/history`
+
+## Verify follow behaviour
+
+1) Start a long chat stream (Terminal A):
+
+```bash
+curl -N -H 'Content-Type: application/json' \
+  -d '{
+    "threadId": "demo-thread",
+    "runId": "live-run",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Please write a very long story so the response streams for a while."
+      }
+    ]
+  }' \
+  http://127.0.0.1:8080/agui
+```
+
+2) While the chat is still streaming, request history (Terminal B):
+
+```bash
+curl -N -H 'Content-Type: application/json' \
+  -d '{
+    "threadId": "demo-thread",
+    "runId": "history-run"
+  }' \
+  http://127.0.0.1:8080/history
+```
+
+You should see:
+
+- `RUN_STARTED` (synthetic history run)
+- `MESSAGES_SNAPSHOT`
+- Followed by additional `TEXT_MESSAGE_*` events until `RUN_FINISHED`
+
+## Notes
+
+This example uses an in-memory session store and is intended for single-process demos.

--- a/examples/agui/server/follow/agent.go
+++ b/examples/agui/server/follow/agent.go
@@ -1,0 +1,82 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"math"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/model/openai"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+	"trpc.group/trpc-go/trpc-agent-go/tool/function"
+)
+
+func newAgent() agent.Agent {
+	modelInstance := openai.New(*modelName)
+	generationConfig := model.GenerationConfig{
+		MaxTokens:   intPtr(2048),
+		Temperature: floatPtr(0.7),
+		Stream:      *isStream,
+	}
+	calculatorTool := function.NewFunctionTool(
+		calculator,
+		function.WithName("calculator"),
+		function.WithDescription("A calculator tool, you can use it to calculate the result of the operation. "+
+			"a is the first number, b is the second number, "+
+			"the operation can be add, subtract, multiply, divide, power."),
+	)
+	return llmagent.New(
+		"agui-agent",
+		llmagent.WithTools([]tool.Tool{calculatorTool}),
+		llmagent.WithModel(modelInstance),
+		llmagent.WithGenerationConfig(generationConfig),
+		llmagent.WithInstruction("You are a helpful assistant."),
+	)
+}
+
+func calculator(ctx context.Context, args calculatorArgs) (calculatorResult, error) {
+	var result float64
+	switch args.Operation {
+	case "add", "+":
+		result = args.A + args.B
+	case "subtract", "-":
+		result = args.A - args.B
+	case "multiply", "*":
+		result = args.A * args.B
+	case "divide", "/":
+		result = args.A / args.B
+	case "power", "^":
+		result = math.Pow(args.A, args.B)
+	default:
+		return calculatorResult{Result: 0}, fmt.Errorf("invalid operation: %s", args.Operation)
+	}
+	return calculatorResult{Result: result}, nil
+}
+
+type calculatorArgs struct {
+	Operation string  `json:"operation" description:"add, subtract, multiply, divide, power"`
+	A         float64 `json:"a" description:"First number"`
+	B         float64 `json:"b" description:"Second number"`
+}
+
+type calculatorResult struct {
+	Result float64 `json:"result"`
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func floatPtr(f float64) *float64 {
+	return &f
+}

--- a/examples/agui/server/follow/main.go
+++ b/examples/agui/server/follow/main.go
@@ -1,0 +1,83 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package main demonstrates how to enable /history follow mode so a snapshot request can continue streaming persisted AG-UI events until the active run finishes.
+package main
+
+import (
+	"context"
+	"flag"
+	"net/http"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/log"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+	"trpc.group/trpc-go/trpc-agent-go/server/agui"
+	"trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
+	aguirunner "trpc.group/trpc-go/trpc-agent-go/server/agui/runner"
+	"trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+)
+
+var (
+	modelName            = flag.String("model", "deepseek-v3.2", "Model to use")
+	isStream             = flag.Bool("stream", true, "Whether to stream the response")
+	address              = flag.String("address", "127.0.0.1:8080", "Listen address")
+	path                 = flag.String("path", "/agui", "HTTP path")
+	messagesSnapshotPath = flag.String("messages-snapshot-path", "/history", "Messages snapshot HTTP path")
+	flushInterval        = flag.Duration("flush-interval", 50*time.Millisecond, "Flush interval for persisting aggregated track events.")
+	followEnabled        = flag.Bool("follow-enabled", true, "Whether to enable /history follow mode.")
+	followMaxDuration    = flag.Duration("follow-max-duration", 60*time.Second, "Maximum duration to follow after emitting MESSAGES_SNAPSHOT.")
+)
+
+const appName = "demo-app"
+
+func main() {
+	flag.Parse()
+	sessionService := inmemory.NewSessionService()
+	agent := newAgent()
+	r := runner.NewRunner(appName, agent, runner.WithSessionService(sessionService))
+	defer r.Close()
+	server, err := agui.New(
+		r,
+		agui.WithPath(*path),
+		agui.WithMessagesSnapshotPath(*messagesSnapshotPath),
+		agui.WithMessagesSnapshotEnabled(true),
+		agui.WithFlushInterval(*flushInterval),
+		agui.WithAppName(appName),
+		agui.WithSessionService(sessionService),
+		agui.WithMessagesSnapshotFollowEnabled(*followEnabled),
+		agui.WithMessagesSnapshotFollowMaxDuration(*followMaxDuration),
+		agui.WithAGUIRunnerOptions(
+			aguirunner.WithUserIDResolver(userIDResolver),
+		),
+	)
+	if err != nil {
+		log.Fatalf("failed to create AG-UI server: %v", err)
+	}
+	log.Infof("AG-UI: serving agent %q on http://%s%s", agent.Info().Name, *address, *path)
+	log.Infof("AG-UI: messages snapshot available at http://%s%s", *address, *messagesSnapshotPath)
+	log.Infof("AG-UI: messages snapshot follow enabled=%v maxDuration=%s", *followEnabled, followMaxDuration.String())
+	if err := http.ListenAndServe(*address, server.Handler()); err != nil {
+		log.Fatalf("server stopped with error: %v", err)
+	}
+}
+
+func userIDResolver(ctx context.Context, input *adapter.RunAgentInput) (string, error) {
+	forwardedProps, ok := input.ForwardedProps.(map[string]any)
+	if !ok {
+		return "anonymous", nil
+	}
+	user, ok := forwardedProps["userId"].(string)
+	if !ok {
+		return "anonymous", nil
+	}
+	if user != "" {
+		return user, nil
+	}
+	return "anonymous", nil
+}

--- a/server/agui/internal/track/tracker.go
+++ b/server/agui/internal/track/tracker.go
@@ -33,7 +33,7 @@ type Tracker interface {
 	// AppendEvent appends an AG-UI event to the session track.
 	AppendEvent(ctx context.Context, key session.Key, event aguievents.Event) error
 	// GetEvents retrieves the AG-UI track events from the session.
-	GetEvents(ctx context.Context, key session.Key) (*session.TrackEvents, error)
+	GetEvents(ctx context.Context, key session.Key, opts ...session.Option) (*session.TrackEvents, error)
 	// Flush flushes any pending aggregated events for the given session key.
 	Flush(ctx context.Context, key session.Key) error
 }
@@ -93,11 +93,11 @@ func (t *tracker) AppendEvent(ctx context.Context, key session.Key, event aguiev
 }
 
 // GetEvents retrieves the AG-UI track events from the session.
-func (t *tracker) GetEvents(ctx context.Context, key session.Key) (*session.TrackEvents, error) {
+func (t *tracker) GetEvents(ctx context.Context, key session.Key, opts ...session.Option) (*session.TrackEvents, error) {
 	if err := key.CheckSessionKey(); err != nil {
 		return nil, fmt.Errorf("session key: %w", err)
 	}
-	sess, err := t.sessionService.GetSession(ctx, key)
+	sess, err := t.sessionService.GetSession(ctx, key, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("get session: %w", err)
 	}

--- a/server/agui/options.go
+++ b/server/agui/options.go
@@ -114,6 +114,13 @@ func WithTimeout(d time.Duration) Option {
 	}
 }
 
+// WithFlushInterval sets how often buffered AG-UI events are flushed for a session.
+func WithFlushInterval(d time.Duration) Option {
+	return func(o *options) {
+		o.aguiRunnerOptions = append(o.aguiRunnerOptions, aguirunner.WithFlushInterval(d))
+	}
+}
+
 // WithGraphNodeLifecycleActivityEnabled controls whether the AG-UI server emits graph node lifecycle activity events.
 func WithGraphNodeLifecycleActivityEnabled(enabled bool) Option {
 	return func(o *options) {
@@ -146,6 +153,20 @@ func WithMessagesSnapshotPath(p string) Option {
 func WithMessagesSnapshotEnabled(e bool) Option {
 	return func(o *options) {
 		o.messagesSnapshotEnabled = e
+	}
+}
+
+// WithMessagesSnapshotFollowEnabled controls whether the messages snapshot handler tails persisted track events.
+func WithMessagesSnapshotFollowEnabled(enabled bool) Option {
+	return func(o *options) {
+		o.aguiRunnerOptions = append(o.aguiRunnerOptions, aguirunner.WithMessagesSnapshotFollowEnabled(enabled))
+	}
+}
+
+// WithMessagesSnapshotFollowMaxDuration sets the maximum duration for messages snapshot tailing.
+func WithMessagesSnapshotFollowMaxDuration(d time.Duration) Option {
+	return func(o *options) {
+		o.aguiRunnerOptions = append(o.aguiRunnerOptions, aguirunner.WithMessagesSnapshotFollowMaxDuration(d))
 	}
 }
 

--- a/server/agui/options_test.go
+++ b/server/agui/options_test.go
@@ -80,6 +80,12 @@ func TestWithTimeout(t *testing.T) {
 	assert.Equal(t, 2*time.Second, ro.Timeout)
 }
 
+func TestWithFlushInterval(t *testing.T) {
+	opts := newOptions(WithFlushInterval(2 * time.Second))
+	ro := aguirunner.NewOptions(opts.aguiRunnerOptions...)
+	assert.Equal(t, 2*time.Second, ro.FlushInterval)
+}
+
 func TestWithGraphNodeLifecycleActivityEnabled(t *testing.T) {
 	opts := newOptions(WithGraphNodeLifecycleActivityEnabled(true))
 	ro := aguirunner.NewOptions(opts.aguiRunnerOptions...)
@@ -96,6 +102,18 @@ func TestWithGraphNodeInterruptActivityTopLevelOnly(t *testing.T) {
 	opts := newOptions(WithGraphNodeInterruptActivityTopLevelOnly(true))
 	ro := aguirunner.NewOptions(opts.aguiRunnerOptions...)
 	assert.True(t, ro.GraphNodeInterruptActivityTopLevelOnly)
+}
+
+func TestWithMessagesSnapshotFollowEnabled(t *testing.T) {
+	opts := newOptions(WithMessagesSnapshotFollowEnabled(true))
+	ro := aguirunner.NewOptions(opts.aguiRunnerOptions...)
+	assert.True(t, ro.MessagesSnapshotFollowEnabled)
+}
+
+func TestWithMessagesSnapshotFollowMaxDuration(t *testing.T) {
+	opts := newOptions(WithMessagesSnapshotFollowMaxDuration(2 * time.Second))
+	ro := aguirunner.NewOptions(opts.aguiRunnerOptions...)
+	assert.Equal(t, 2*time.Second, ro.MessagesSnapshotFollowMaxDuration)
 }
 
 func TestWithCancelEnabled(t *testing.T) {

--- a/server/agui/runner/messagessnapshot.go
+++ b/server/agui/runner/messagessnapshot.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	aguievents "github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/events"
 	"trpc.group/trpc-go/trpc-agent-go/agent"
@@ -78,7 +79,7 @@ func (r *runner) messagesSnapshot(ctx context.Context, input *runInput, events c
 		return
 	}
 
-	messagesSnapshotEvent, err := r.getMessagesSnapshotEvent(ctx, input.key)
+	messagesSnapshotEvent, trackEvents, err := r.getMessagesSnapshotEvent(ctx, input.key)
 	if err != nil {
 		log.ErrorfContext(
 			ctx,
@@ -104,6 +105,11 @@ func (r *runner) messagesSnapshot(ctx context.Context, input *runInput, events c
 			aguievents.WithRunID(runID)), input)
 		return
 	}
+
+	if r.messagesSnapshotFollowEnabled && trackEvents != nil && !trackEndsWithTerminalRunEvent(trackEvents.Events) {
+		r.messagesSnapshotFollow(ctx, input, events, trackEvents)
+		return
+	}
 	// Emit a RUN_FINISHED event to signal downstream consumers there is no more data.
 	if !r.emitEvent(ctx, events, aguievents.NewRunFinishedEvent(threadID, runID), input) {
 		return
@@ -113,14 +119,135 @@ func (r *runner) messagesSnapshot(ctx context.Context, input *runInput, events c
 // getMessagesSnapshotEvent loads AG-UI track events and converts them to an AG-UI MessagesSnapshotEvent.
 // In order to fetch the history messages as much as possible, still return the messages even if there is an error.
 func (r *runner) getMessagesSnapshotEvent(ctx context.Context,
-	sessionKey session.Key) (*aguievents.MessagesSnapshotEvent, error) {
+	sessionKey session.Key) (*aguievents.MessagesSnapshotEvent, *session.TrackEvents, error) {
 	trackEvents, err := r.tracker.GetEvents(ctx, sessionKey)
 	if err != nil {
-		return nil, fmt.Errorf("get track events: %w", err)
+		return nil, nil, fmt.Errorf("get track events: %w", err)
 	}
 	messages, err := reduce.Reduce(r.appName, sessionKey.UserID, trackEvents.Events)
 	if err != nil {
 		err = fmt.Errorf("reduce track events: %w", err)
 	}
-	return aguievents.NewMessagesSnapshotEvent(messages), err
+	return aguievents.NewMessagesSnapshotEvent(messages), trackEvents, err
+}
+
+func (r *runner) messagesSnapshotFollow(
+	ctx context.Context,
+	input *runInput,
+	events chan<- aguievents.Event,
+	initial *session.TrackEvents,
+) {
+	cursorTime := lastTrackTimestamp(initial)
+	pollInterval := r.flushInterval
+	if pollInterval <= 0 {
+		r.emitEvent(ctx, events, aguievents.NewRunErrorEvent("messages snapshot follow requires a positive flush interval",
+			aguievents.WithRunID(input.runID)), input)
+		return
+	}
+	maxDuration := r.messagesSnapshotFollowMaxDuration
+	if maxDuration <= 0 {
+		maxDuration = r.timeout
+	}
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+	var timer *time.Timer
+	var timeout <-chan time.Time
+	if maxDuration > 0 {
+		timer = time.NewTimer(maxDuration)
+		defer timer.Stop()
+		timeout = timer.C
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timeout:
+			r.emitEvent(ctx, events, aguievents.NewRunErrorEvent("messages snapshot follow timeout",
+				aguievents.WithRunID(input.runID)), input)
+			return
+		case <-ticker.C:
+			if !r.handleMessagesSnapshotFollowTick(ctx, input, events, &cursorTime) {
+				return
+			}
+		}
+	}
+}
+
+func (r *runner) handleMessagesSnapshotFollowTick(
+	ctx context.Context,
+	input *runInput,
+	events chan<- aguievents.Event,
+	cursorTime *time.Time,
+) bool {
+	trackEvents, err := r.tracker.GetEvents(ctx, input.key, session.WithEventTime(*cursorTime))
+	if err != nil {
+		r.emitEvent(ctx, events, aguievents.NewRunErrorEvent(fmt.Sprintf("follow track events: %v", err),
+			aguievents.WithRunID(input.runID)), input)
+		return false
+	}
+	if trackEvents == nil || len(trackEvents.Events) == 0 {
+		return true
+	}
+	for _, trackEvent := range trackEvents.Events {
+		if !trackEvent.Timestamp.After(*cursorTime) {
+			continue
+		}
+		*cursorTime = trackEvent.Timestamp
+		if len(trackEvent.Payload) == 0 {
+			continue
+		}
+		evt, err := aguievents.EventFromJSON(trackEvent.Payload)
+		if err != nil {
+			log.WarnfContext(ctx, "agui messages snapshot follow: decode track event: %v", err)
+			continue
+		}
+		terminal, terminalErr := terminalRunSignal(evt)
+		if terminal {
+			if terminalErr != "" {
+				r.emitEvent(ctx, events, aguievents.NewRunErrorEvent(terminalErr,
+					aguievents.WithRunID(input.runID)), input)
+				return false
+			}
+			r.emitEvent(ctx, events, aguievents.NewRunFinishedEvent(input.threadID, input.runID), input)
+			return false
+		}
+		if !r.emitEvent(ctx, events, evt, input) {
+			return false
+		}
+	}
+	return true
+}
+
+func trackEndsWithTerminalRunEvent(events []session.TrackEvent) bool {
+	if len(events) == 0 {
+		return false
+	}
+	last := events[len(events)-1]
+	if len(last.Payload) == 0 {
+		return false
+	}
+	evt, err := aguievents.EventFromJSON(last.Payload)
+	if err != nil {
+		return false
+	}
+	terminal, _ := terminalRunSignal(evt)
+	return terminal
+}
+
+func terminalRunSignal(evt aguievents.Event) (terminal bool, errMessage string) {
+	switch e := evt.(type) {
+	case *aguievents.RunFinishedEvent:
+		return true, ""
+	case *aguievents.RunErrorEvent:
+		return true, e.Message
+	default:
+		return false, ""
+	}
+}
+
+func lastTrackTimestamp(trackEvents *session.TrackEvents) time.Time {
+	if trackEvents == nil || len(trackEvents.Events) == 0 {
+		return time.Time{}
+	}
+	return trackEvents.Events[len(trackEvents.Events)-1].Timestamp
 }

--- a/server/agui/runner/messagessnapshot_test.go
+++ b/server/agui/runner/messagessnapshot_test.go
@@ -12,6 +12,7 @@ package runner
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -375,6 +376,274 @@ func TestMessagesSnapshotReduceErrorEmitsSnapshotThenError(t *testing.T) {
 	assert.Contains(t, errEvt.Message, "reduce track events")
 }
 
+func TestMessagesSnapshotFollowUntilTerminalEvent(t *testing.T) {
+	base := time.Now().Add(-time.Second)
+	initial := &session.TrackEvents{
+		Track: track.TrackAGUI,
+		Events: []session.TrackEvent{
+			newTrackEventAt(t, aguievents.NewTextMessageStartEvent("msg-1", aguievents.WithRole("assistant")), base),
+			newTrackEventAt(t, aguievents.NewTextMessageContentEvent("msg-1", "hello"), base.Add(time.Millisecond)),
+			newTrackEventAt(t, aguievents.NewTextMessageEndEvent("msg-1"), base.Add(2*time.Millisecond)),
+		},
+	}
+	follow := &session.TrackEvents{
+		Track: track.TrackAGUI,
+		Events: []session.TrackEvent{
+			newTrackEventAt(t, aguievents.NewCustomEvent("node.progress", aguievents.WithValue(map[string]any{"p": 1})),
+				base.Add(3*time.Millisecond)),
+			newTrackEventAt(t, aguievents.NewRunFinishedEvent("thread", "real-run"), base.Add(4*time.Millisecond)),
+		},
+	}
+	r := &runner{
+		runner:                            noopBaseRunner{},
+		userIDResolver:                    NewOptions().UserIDResolver,
+		runAgentInputHook:                 NewOptions().RunAgentInputHook,
+		appName:                           "demo",
+		tracker:                           &sequenceTracker{first: initial, second: follow},
+		flushInterval:                     5 * time.Millisecond,
+		timeout:                           100 * time.Millisecond,
+		messagesSnapshotFollowEnabled:     true,
+		messagesSnapshotFollowMaxDuration: 100 * time.Millisecond,
+	}
+
+	stream, err := r.MessagesSnapshot(
+		context.Background(),
+		&adapter.RunAgentInput{ThreadID: "thread", RunID: "req-run"},
+	)
+	require.NoError(t, err)
+
+	collected := collectAGUIEvents(t, stream)
+	require.Len(t, collected, 4)
+	require.IsType(t, (*aguievents.RunStartedEvent)(nil), collected[0])
+	require.IsType(t, (*aguievents.MessagesSnapshotEvent)(nil), collected[1])
+	require.IsType(t, (*aguievents.CustomEvent)(nil), collected[2])
+	finished, ok := collected[3].(*aguievents.RunFinishedEvent)
+	require.True(t, ok)
+	require.Equal(t, "req-run", finished.RunID())
+}
+
+func TestTrackEndsWithTerminalRunEvent(t *testing.T) {
+	base := time.Now().Add(-time.Second)
+	nonTerminal := newTrackEventAt(t, aguievents.NewCustomEvent("node.progress", aguievents.WithValue(map[string]any{"p": 1})), base)
+	finished := newTrackEventAt(t, aguievents.NewRunFinishedEvent("thread", "run"), base.Add(time.Millisecond))
+	runErr := newTrackEventAt(t, aguievents.NewRunErrorEvent("boom"), base.Add(2*time.Millisecond))
+
+	require.False(t, trackEndsWithTerminalRunEvent(nil))
+	require.False(t, trackEndsWithTerminalRunEvent([]session.TrackEvent{}))
+	require.False(t, trackEndsWithTerminalRunEvent([]session.TrackEvent{{Track: track.TrackAGUI, Timestamp: base}}))
+	require.False(t, trackEndsWithTerminalRunEvent([]session.TrackEvent{{Track: track.TrackAGUI, Payload: []byte("{"), Timestamp: base}}))
+	require.False(t, trackEndsWithTerminalRunEvent([]session.TrackEvent{finished, nonTerminal}))
+	require.True(t, trackEndsWithTerminalRunEvent([]session.TrackEvent{nonTerminal, finished}))
+	require.True(t, trackEndsWithTerminalRunEvent([]session.TrackEvent{nonTerminal, runErr}))
+}
+
+func TestMessagesSnapshotFollowSkipsWhenInitialAlreadyTerminal(t *testing.T) {
+	base := time.Now().Add(-time.Second)
+	initial := &session.TrackEvents{
+		Track: track.TrackAGUI,
+		Events: []session.TrackEvent{
+			newTrackEventAt(t, aguievents.NewTextMessageStartEvent("msg-1", aguievents.WithRole("assistant")), base),
+			newTrackEventAt(t, aguievents.NewTextMessageContentEvent("msg-1", "hello"), base.Add(time.Millisecond)),
+			newTrackEventAt(t, aguievents.NewTextMessageEndEvent("msg-1"), base.Add(2*time.Millisecond)),
+			newTrackEventAt(t, aguievents.NewRunFinishedEvent("thread", "real-run"), base.Add(3*time.Millisecond)),
+		},
+	}
+	follow := &session.TrackEvents{
+		Track: track.TrackAGUI,
+		Events: []session.TrackEvent{
+			newTrackEventAt(t, aguievents.NewCustomEvent("node.progress", aguievents.WithValue(map[string]any{"p": 1})),
+				base.Add(4*time.Millisecond)),
+		},
+	}
+	tr := &sequenceTracker{first: initial, second: follow}
+	r := &runner{
+		runner:                            noopBaseRunner{},
+		userIDResolver:                    NewOptions().UserIDResolver,
+		runAgentInputHook:                 NewOptions().RunAgentInputHook,
+		appName:                           "demo",
+		tracker:                           tr,
+		flushInterval:                     time.Millisecond,
+		timeout:                           50 * time.Millisecond,
+		messagesSnapshotFollowEnabled:     true,
+		messagesSnapshotFollowMaxDuration: 50 * time.Millisecond,
+	}
+
+	stream, err := r.MessagesSnapshot(context.Background(), &adapter.RunAgentInput{ThreadID: "thread", RunID: "req-run"})
+	require.NoError(t, err)
+
+	collected := collectAGUIEvents(t, stream)
+	require.Len(t, collected, 3)
+	require.IsType(t, (*aguievents.RunStartedEvent)(nil), collected[0])
+	require.IsType(t, (*aguievents.MessagesSnapshotEvent)(nil), collected[1])
+	require.IsType(t, (*aguievents.RunFinishedEvent)(nil), collected[2])
+
+	tr.mu.Lock()
+	calls := tr.calls
+	tr.mu.Unlock()
+	require.Equal(t, 1, calls)
+}
+
+func TestMessagesSnapshotFollowEmitsRunErrorOnTerminalErrorEvent(t *testing.T) {
+	base := time.Now().Add(-time.Second)
+	initial := &session.TrackEvents{
+		Track: track.TrackAGUI,
+		Events: []session.TrackEvent{
+			newTrackEventAt(t, aguievents.NewTextMessageStartEvent("msg-1", aguievents.WithRole("assistant")), base),
+			newTrackEventAt(t, aguievents.NewTextMessageContentEvent("msg-1", "hello"), base.Add(time.Millisecond)),
+			newTrackEventAt(t, aguievents.NewTextMessageEndEvent("msg-1"), base.Add(2*time.Millisecond)),
+		},
+	}
+	follow := &session.TrackEvents{
+		Track: track.TrackAGUI,
+		Events: []session.TrackEvent{
+			newTrackEventAt(t, aguievents.NewCustomEvent("node.progress", aguievents.WithValue(map[string]any{"p": 1})),
+				base.Add(3*time.Millisecond)),
+			newTrackEventAt(t, aguievents.NewRunErrorEvent("boom"), base.Add(4*time.Millisecond)),
+		},
+	}
+	r := &runner{
+		runner:                            noopBaseRunner{},
+		userIDResolver:                    NewOptions().UserIDResolver,
+		runAgentInputHook:                 NewOptions().RunAgentInputHook,
+		appName:                           "demo",
+		tracker:                           &sequenceTracker{first: initial, second: follow},
+		flushInterval:                     time.Millisecond,
+		timeout:                           100 * time.Millisecond,
+		messagesSnapshotFollowEnabled:     true,
+		messagesSnapshotFollowMaxDuration: 100 * time.Millisecond,
+	}
+
+	stream, err := r.MessagesSnapshot(context.Background(), &adapter.RunAgentInput{ThreadID: "thread", RunID: "req-run"})
+	require.NoError(t, err)
+
+	collected := collectAGUIEvents(t, stream)
+	require.Len(t, collected, 4)
+	require.IsType(t, (*aguievents.RunStartedEvent)(nil), collected[0])
+	require.IsType(t, (*aguievents.MessagesSnapshotEvent)(nil), collected[1])
+	require.IsType(t, (*aguievents.CustomEvent)(nil), collected[2])
+	errEvt, ok := collected[3].(*aguievents.RunErrorEvent)
+	require.True(t, ok)
+	require.Equal(t, "req-run", errEvt.RunID())
+	require.Equal(t, "boom", errEvt.Message)
+}
+
+func TestMessagesSnapshotFollowEmitsRunErrorOnFollowGetEventsError(t *testing.T) {
+	base := time.Now().Add(-time.Second)
+	initial := &session.TrackEvents{
+		Track: track.TrackAGUI,
+		Events: []session.TrackEvent{
+			newTrackEventAt(t, aguievents.NewTextMessageStartEvent("msg-1", aguievents.WithRole("assistant")), base),
+			newTrackEventAt(t, aguievents.NewTextMessageContentEvent("msg-1", "hello"), base.Add(time.Millisecond)),
+			newTrackEventAt(t, aguievents.NewTextMessageEndEvent("msg-1"), base.Add(2*time.Millisecond)),
+		},
+	}
+	r := &runner{
+		runner:                            noopBaseRunner{},
+		userIDResolver:                    NewOptions().UserIDResolver,
+		runAgentInputHook:                 NewOptions().RunAgentInputHook,
+		appName:                           "demo",
+		tracker:                           &errorAfterFirstTracker{first: initial, err: errors.New("boom")},
+		flushInterval:                     time.Millisecond,
+		timeout:                           100 * time.Millisecond,
+		messagesSnapshotFollowEnabled:     true,
+		messagesSnapshotFollowMaxDuration: 100 * time.Millisecond,
+	}
+
+	stream, err := r.MessagesSnapshot(context.Background(), &adapter.RunAgentInput{ThreadID: "thread", RunID: "req-run"})
+	require.NoError(t, err)
+
+	collected := collectAGUIEvents(t, stream)
+	require.Len(t, collected, 3)
+	require.IsType(t, (*aguievents.RunStartedEvent)(nil), collected[0])
+	require.IsType(t, (*aguievents.MessagesSnapshotEvent)(nil), collected[1])
+	errEvt, ok := collected[2].(*aguievents.RunErrorEvent)
+	require.True(t, ok)
+	require.Equal(t, "req-run", errEvt.RunID())
+	require.Contains(t, errEvt.Message, "follow track events: boom")
+}
+
+func TestMessagesSnapshotFollowEmitsTimeoutWhenNoTerminalEvent(t *testing.T) {
+	base := time.Now().Add(-time.Second)
+	initial := &session.TrackEvents{
+		Track: track.TrackAGUI,
+		Events: []session.TrackEvent{
+			newTrackEventAt(t, aguievents.NewTextMessageStartEvent("msg-1", aguievents.WithRole("assistant")), base),
+			newTrackEventAt(t, aguievents.NewTextMessageContentEvent("msg-1", "hello"), base.Add(time.Millisecond)),
+			newTrackEventAt(t, aguievents.NewTextMessageEndEvent("msg-1"), base.Add(2*time.Millisecond)),
+		},
+	}
+	empty := &session.TrackEvents{Track: track.TrackAGUI}
+	r := &runner{
+		runner:                            noopBaseRunner{},
+		userIDResolver:                    NewOptions().UserIDResolver,
+		runAgentInputHook:                 NewOptions().RunAgentInputHook,
+		appName:                           "demo",
+		tracker:                           &sequenceTracker{first: initial, second: empty},
+		flushInterval:                     time.Millisecond,
+		timeout:                           0,
+		messagesSnapshotFollowEnabled:     true,
+		messagesSnapshotFollowMaxDuration: 10 * time.Millisecond,
+	}
+
+	stream, err := r.MessagesSnapshot(context.Background(), &adapter.RunAgentInput{ThreadID: "thread", RunID: "req-run"})
+	require.NoError(t, err)
+
+	collected := collectAGUIEvents(t, stream)
+	require.Len(t, collected, 3)
+	require.IsType(t, (*aguievents.RunStartedEvent)(nil), collected[0])
+	require.IsType(t, (*aguievents.MessagesSnapshotEvent)(nil), collected[1])
+	errEvt, ok := collected[2].(*aguievents.RunErrorEvent)
+	require.True(t, ok)
+	require.Equal(t, "req-run", errEvt.RunID())
+	require.Equal(t, "messages snapshot follow timeout", errEvt.Message)
+}
+
+func TestMessagesSnapshotFollowSkipsInvalidAndNonIncrementalTrackEvents(t *testing.T) {
+	base := time.Now().Add(-time.Second)
+	initial := &session.TrackEvents{
+		Track: track.TrackAGUI,
+		Events: []session.TrackEvent{
+			newTrackEventAt(t, aguievents.NewTextMessageStartEvent("msg-1", aguievents.WithRole("assistant")), base),
+			newTrackEventAt(t, aguievents.NewTextMessageContentEvent("msg-1", "hello"), base.Add(time.Millisecond)),
+			newTrackEventAt(t, aguievents.NewTextMessageEndEvent("msg-1"), base.Add(2*time.Millisecond)),
+		},
+	}
+	follow := &session.TrackEvents{
+		Track: track.TrackAGUI,
+		Events: []session.TrackEvent{
+			// Same timestamp as the initial cursor should be ignored.
+			{Track: track.TrackAGUI, Payload: []byte(`{"type":"CUSTOM","name":"ignored"}`), Timestamp: base.Add(2 * time.Millisecond)},
+			// Invalid JSON should be skipped.
+			{Track: track.TrackAGUI, Payload: []byte("{"), Timestamp: base.Add(3 * time.Millisecond)},
+			// Empty payload should be skipped.
+			{Track: track.TrackAGUI, Payload: nil, Timestamp: base.Add(4 * time.Millisecond)},
+			newTrackEventAt(t, aguievents.NewRunFinishedEvent("thread", "real-run"), base.Add(5*time.Millisecond)),
+		},
+	}
+	r := &runner{
+		runner:                            noopBaseRunner{},
+		userIDResolver:                    NewOptions().UserIDResolver,
+		runAgentInputHook:                 NewOptions().RunAgentInputHook,
+		appName:                           "demo",
+		tracker:                           &sequenceTracker{first: initial, second: follow},
+		flushInterval:                     time.Millisecond,
+		timeout:                           100 * time.Millisecond,
+		messagesSnapshotFollowEnabled:     true,
+		messagesSnapshotFollowMaxDuration: 100 * time.Millisecond,
+	}
+
+	stream, err := r.MessagesSnapshot(context.Background(), &adapter.RunAgentInput{ThreadID: "thread", RunID: "req-run"})
+	require.NoError(t, err)
+
+	collected := collectAGUIEvents(t, stream)
+	require.Len(t, collected, 3)
+	require.IsType(t, (*aguievents.RunStartedEvent)(nil), collected[0])
+	require.IsType(t, (*aguievents.MessagesSnapshotEvent)(nil), collected[1])
+	finished, ok := collected[2].(*aguievents.RunFinishedEvent)
+	require.True(t, ok)
+	require.Equal(t, "req-run", finished.RunID())
+}
+
 func collectAGUIEvents(t *testing.T, ch <-chan aguievents.Event) []aguievents.Event {
 	t.Helper()
 	var events []aguievents.Event
@@ -395,6 +664,17 @@ func newTrackEvent(t *testing.T, evt aguievents.Event) session.TrackEvent {
 	}
 }
 
+func newTrackEventAt(t *testing.T, evt aguievents.Event, ts time.Time) session.TrackEvent {
+	t.Helper()
+	payload, err := evt.ToJSON()
+	require.NoError(t, err)
+	return session.TrackEvent{
+		Track:     track.TrackAGUI,
+		Payload:   append([]byte(nil), payload...),
+		Timestamp: ts,
+	}
+}
+
 type noopBaseRunner struct{}
 
 func (noopBaseRunner) Run(ctx context.Context, userID, sessionID string, message model.Message,
@@ -406,6 +686,31 @@ func (noopBaseRunner) Run(ctx context.Context, userID, sessionID string, message
 
 func (noopBaseRunner) Close() error { return nil }
 
+type sequenceTracker struct {
+	mu     sync.Mutex
+	calls  int
+	first  *session.TrackEvents
+	second *session.TrackEvents
+}
+
+func (s *sequenceTracker) AppendEvent(ctx context.Context, key session.Key, event aguievents.Event) error {
+	return nil
+}
+
+func (s *sequenceTracker) GetEvents(ctx context.Context, key session.Key, opts ...session.Option) (*session.TrackEvents, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	if s.calls == 1 {
+		return s.first, nil
+	}
+	return s.second, nil
+}
+
+func (s *sequenceTracker) Flush(ctx context.Context, key session.Key) error {
+	return nil
+}
+
 type blockingTracker struct {
 	unblock <-chan struct{}
 	events  *session.TrackEvents
@@ -415,12 +720,37 @@ func (b *blockingTracker) AppendEvent(ctx context.Context, key session.Key, even
 	return nil
 }
 
-func (b *blockingTracker) GetEvents(ctx context.Context, key session.Key) (*session.TrackEvents, error) {
+func (b *blockingTracker) GetEvents(ctx context.Context, key session.Key, opts ...session.Option) (*session.TrackEvents, error) {
 	<-b.unblock
 	return b.events, nil
 }
 
 func (b *blockingTracker) Flush(ctx context.Context, key session.Key) error {
+	return nil
+}
+
+type errorAfterFirstTracker struct {
+	mu    sync.Mutex
+	calls int
+	first *session.TrackEvents
+	err   error
+}
+
+func (t *errorAfterFirstTracker) AppendEvent(ctx context.Context, key session.Key, event aguievents.Event) error {
+	return nil
+}
+
+func (t *errorAfterFirstTracker) GetEvents(ctx context.Context, key session.Key, opts ...session.Option) (*session.TrackEvents, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.calls++
+	if t.calls == 1 {
+		return t.first, nil
+	}
+	return nil, t.err
+}
+
+func (t *errorAfterFirstTracker) Flush(ctx context.Context, key session.Key) error {
 	return nil
 }
 

--- a/server/agui/runner/options.go
+++ b/server/agui/runner/options.go
@@ -42,6 +42,8 @@ type Options struct {
 	AggregatorFactory                      aggregator.Factory    // AggregatorFactory builds an aggregator for each run.
 	AggregationOption                      []aggregator.Option   // AggregationOption is the aggregation options for each run.
 	FlushInterval                          time.Duration         // FlushInterval controls how often buffered AG-UI events are flushed for a session.
+	MessagesSnapshotFollowEnabled          bool                  // MessagesSnapshotFollowEnabled enables tailing persisted AG-UI track events after MESSAGES_SNAPSHOT.
+	MessagesSnapshotFollowMaxDuration      time.Duration         // MessagesSnapshotFollowMaxDuration bounds how long tailing can run before emitting RUN_ERROR.
 	StartSpan                              StartSpan             // StartSpan starts a span for an AG-UI run.
 	Timeout                                time.Duration         // Timeout controls how long a run is allowed to execute.
 	GraphNodeLifecycleActivityEnabled      bool                  // GraphNodeLifecycleActivityEnabled enables graph node lifecycle activity events.
@@ -154,6 +156,20 @@ func WithAggregatorFactory(factory aggregator.Factory) Option {
 func WithFlushInterval(d time.Duration) Option {
 	return func(o *Options) {
 		o.FlushInterval = d
+	}
+}
+
+// WithMessagesSnapshotFollowEnabled enables or disables tailing persisted track events after a snapshot.
+func WithMessagesSnapshotFollowEnabled(enabled bool) Option {
+	return func(o *Options) {
+		o.MessagesSnapshotFollowEnabled = enabled
+	}
+}
+
+// WithMessagesSnapshotFollowMaxDuration sets the maximum duration for snapshot tailing.
+func WithMessagesSnapshotFollowMaxDuration(d time.Duration) Option {
+	return func(o *Options) {
+		o.MessagesSnapshotFollowMaxDuration = d
 	}
 }
 

--- a/server/agui/runner/options_test.go
+++ b/server/agui/runner/options_test.go
@@ -219,3 +219,13 @@ func TestWithTimeout(t *testing.T) {
 	opts := NewOptions(WithTimeout(2 * time.Second))
 	assert.Equal(t, 2*time.Second, opts.Timeout)
 }
+
+func TestWithMessagesSnapshotFollowEnabled(t *testing.T) {
+	opts := NewOptions(WithMessagesSnapshotFollowEnabled(true))
+	assert.True(t, opts.MessagesSnapshotFollowEnabled)
+}
+
+func TestWithMessagesSnapshotFollowMaxDuration(t *testing.T) {
+	opts := NewOptions(WithMessagesSnapshotFollowMaxDuration(2 * time.Second))
+	assert.Equal(t, 2*time.Second, opts.MessagesSnapshotFollowMaxDuration)
+}

--- a/server/agui/runner/runner.go
+++ b/server/agui/runner/runner.go
@@ -77,7 +77,10 @@ func New(r trunner.Runner, opt ...Option) Runner {
 		tracker:                                tracker,
 		running:                                make(map[session.Key]*sessionContext),
 		startSpan:                              opts.StartSpan,
+		flushInterval:                          opts.FlushInterval,
 		timeout:                                opts.Timeout,
+		messagesSnapshotFollowEnabled:          opts.MessagesSnapshotFollowEnabled,
+		messagesSnapshotFollowMaxDuration:      opts.MessagesSnapshotFollowMaxDuration,
 	}
 	return run
 }
@@ -99,7 +102,10 @@ type runner struct {
 	runningMu                              sync.Mutex
 	running                                map[session.Key]*sessionContext
 	startSpan                              StartSpan
+	flushInterval                          time.Duration
 	timeout                                time.Duration
+	messagesSnapshotFollowEnabled          bool
+	messagesSnapshotFollowMaxDuration      time.Duration
 }
 
 type sessionContext struct {

--- a/server/agui/runner/runner_test.go
+++ b/server/agui/runner/runner_test.go
@@ -1608,7 +1608,7 @@ func (f *flushRecorder) AppendEvent(ctx context.Context, key session.Key, event 
 	return nil
 }
 
-func (f *flushRecorder) GetEvents(ctx context.Context, key session.Key) (*session.TrackEvents, error) {
+func (f *flushRecorder) GetEvents(ctx context.Context, key session.Key, opts ...session.Option) (*session.TrackEvents, error) {
 	return nil, nil
 }
 
@@ -1630,7 +1630,7 @@ func (r *recordingTracker) AppendEvent(ctx context.Context, key session.Key, eve
 	return nil
 }
 
-func (r *recordingTracker) GetEvents(ctx context.Context, key session.Key) (*session.TrackEvents, error) {
+func (r *recordingTracker) GetEvents(ctx context.Context, key session.Key, opts ...session.Option) (*session.TrackEvents, error) {
 	return nil, nil
 }
 
@@ -1652,7 +1652,7 @@ func (e *errorTracker) AppendEvent(ctx context.Context,
 }
 
 func (e *errorTracker) GetEvents(ctx context.Context,
-	_ session.Key) (*session.TrackEvents, error) {
+	_ session.Key, _ ...session.Option) (*session.TrackEvents, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
Add optional message snapshot continuation for the AG-UI /history route so clients can keep receiving persisted AG-UI events after MESSAGES_SNAPSHOT until a terminal RUN_FINISHED/RUN_ERROR or a configured timeout, with updated options, docs, and an end-to-end follow example.