### PR TITLE
model/gemini: update ObjectTypeChatCompletion and ObjectTypeChatCompletionChunk

### DIFF
--- a/model/gemini/accumulator.go
+++ b/model/gemini/accumulator.go
@@ -59,6 +59,7 @@ func (a *Accumulator) Accumulate(resp *model.Response) {
 func (a *Accumulator) BuildResponse() *model.Response {
 	now := time.Now()
 	return &model.Response{
+		Object:    model.ObjectTypeChatCompletion,
 		Model:     a.Model,
 		Created:   now.Unix(),
 		Timestamp: now,

--- a/model/gemini/accumulator_test.go
+++ b/model/gemini/accumulator_test.go
@@ -66,6 +66,7 @@ func TestAccumulator_BuildResponse(t *testing.T) {
 				Usage:            model.Usage{},
 			},
 			want: &model.Response{
+				Object: model.ObjectTypeChatCompletion,
 				Usage: &model.Usage{
 					PromptTokens:     1,
 					CompletionTokens: 1,


### PR DESCRIPTION
## Summary by Sourcery

优化 Gemini 聊天补全响应的构造方式，以区分最终响应和分块响应，并确保对象元数据正确。

增强内容：
- 将响应构建拆分为专门处理最终响应和分块响应的辅助方法，并由一个共享的构建器提供支持，以一致地设置对象类型、done 和 partial 标志位。
- 确保由累加器构建的响应和 Gemini 响应能够正确设置 `ObjectTypeChatCompletion` 或 `ObjectTypeChatCompletionChunk`，包括在响应为 `nil` 的情况下。

测试：
- 扩展并重命名单元测试，以覆盖最终响应与分块响应的行为，包括 `nil` 和空响应，并断言完整响应的相等性，而不仅仅是部分字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine Gemini chat completion response construction to distinguish final and chunked responses and ensure correct object metadata.

Enhancements:
- Split response building into dedicated final and chunk response helpers backed by a shared builder that sets object type, done, and partial flags consistently.
- Ensure accumulator-built responses and Gemini responses set ObjectTypeChatCompletion or ObjectTypeChatCompletionChunk appropriately, including for nil responses.

Tests:
- Expand and rename unit tests to cover final vs chunk response behavior, including nil and empty responses, and to assert full response equality instead of selected fields.

</details>