### PR TITLE
examples: fix parameter typo in toolsearch report

### DIFF
--- a/examples/toolsearch/README.md
+++ b/examples/toolsearch/README.md
@@ -43,7 +43,7 @@ examples/toolsearch/toollibrary/small/
 
 #### LLM Search
 
-| paramter name | paramter value |
+| parameter name | parameter value |
 | --- | --- |
 | SystemPrompt | Your goal is to select the most relevant tools for answering the user's query.<br><br>IMPORTANT: List the tool names in order of relevance, with the most relevant first.<br>If you exceed the maximum number of tools, only the first {MaxTools} will be used.<br><br>Available tools:<br>- {ToolName-1}: {ToolDescription-1}<br>- {ToolName-2}: {ToolDescription-2}<br>......<br>- {ToolName-n}: {ToolDescription-n} |
 | Chat Model | deepseek v3.2, 使用[对话补全（chat/completions） Request](https://api-docs.deepseek.com/zh-cn/api/create-chat-completion) 里面的默认参数 |
@@ -51,7 +51,7 @@ examples/toolsearch/toollibrary/small/
 
 #### Knowledge Search
 
-| paramter name | paramter value |
+| parameter name | parameter value |
 | --- | --- |
 | SystemPrompt | Your goal is to identify the most relevant tools for answering the user's query.<br>Provide a natural-language description of the kind of tool needed (e.g., 'weather information', 'currency conversion', 'stock prices'). |
 | Chat Model | deepseek v3.2, 使用[对话补全（chat/completions） Request](https://api-docs.deepseek.com/zh-cn/api/create-chat-completion) 里面的默认参数 |


### PR DESCRIPTION
Fixes a typo in the toolsearch report table headers by replacing 'paramter' with 'parameter'.

## 由 Sourcery 提供的总结

文档：
- 修正 toolsearch README 中 LLM Search 和 Knowledge Search 表格里 “parameter” 列标题的拼写错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Fix the spelling of the 'parameter' column headers in the LLM Search and Knowledge Search tables in the toolsearch README.

</details>