### PR TITLE
model/hunyuan: force tcp4 for httptest servers

### DIFF
--- a/model/hunyuan/internal/hunyuan/client_test.go
+++ b/model/hunyuan/internal/hunyuan/client_test.go
@@ -156,6 +156,13 @@ func TestHmacSha256(t *testing.T) {
 func newTCP4TestServer(t *testing.T, h http.Handler) *httptest.Server {
 	t.Helper()
 	ts := httptest.NewUnstartedServer(h)
+
+	// NewUnstartedServer allocates a default listener. Close it before
+	// overriding to avoid leaking the FD.
+	if ts.Listener != nil {
+		_ = ts.Listener.Close()
+	}
+
 	ln, err := net.Listen("tcp4", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("failed to listen on tcp4 127.0.0.1:0: %v", err)


### PR DESCRIPTION
Fixes test flakiness/failure in restricted environments where listening on IPv6 loopback (::1) is not permitted.

Switch mock servers to a tcp4 listener bound to 127.0.0.1:0.

- go test ./...: PASS

## Summary
- Add a helper to start httptest servers on tcp4 (127.0.0.1:0)
- Update HunYuan chat completion tests to use the helper
