### PR TITLE
examples: remove extra newline in chunking preview

### DIFF
--- a/examples/knowledge/sources/fixed-chunking/main.go
+++ b/examples/knowledge/sources/fixed-chunking/main.go
@@ -95,7 +95,7 @@ func main() {
 		fmt.Printf("  Chunk %d: ID=%s, Size=%d chars\n", i+1, chunk.ID, len(chunk.Content))
 		fmt.Printf("    Preview: %s\n", preview)
 	}
-	fmt.Println("--- End of Chunking Preview ---\n")
+	fmt.Println("--- End of Chunking Preview ---")
 
 	// Create file source with custom chunking strategy
 	sources := []source.Source{

--- a/examples/knowledge/sources/recursive-chunking/main.go
+++ b/examples/knowledge/sources/recursive-chunking/main.go
@@ -102,7 +102,7 @@ func main() {
 		fmt.Printf("  Chunk %d: ID=%s, Size=%d chars\n", i+1, chunk.ID, len(chunk.Content))
 		fmt.Printf("    Preview: %s\n", preview)
 	}
-	fmt.Println("--- End of Chunking Preview ---\n")
+	fmt.Println("--- End of Chunking Preview ---")
 
 	// Create file source with recursive chunking strategy
 	sources := []source.Source{


### PR DESCRIPTION
Remove the redundant newline escape sequence in the chunking preview end marker output for the fixed and recursive chunking examples.

## Summary by Sourcery

从固定分块和递归分块示例中，移除分块预览结束标记输出中多余的尾随换行符。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove redundant trailing newline from the chunking preview end marker output in the fixed and recursive chunking examples.

</details>