### PR TITLE
skill: prevent skill_run cwd traversal

### DIFF
--- a/tool/skill/run.go
+++ b/tool/skill/run.go
@@ -790,6 +790,7 @@ func resolveCWD(cwd string, name string) string {
 	// start with known workspace dirs like "/skills" or "/work".
 	base := path.Join(codeexecutor.DirSkills, name)
 	s := strings.TrimSpace(cwd)
+	s = strings.ReplaceAll(s, "\\", "/")
 	if s == "" {
 		return base
 	}

--- a/tool/skill/run_test.go
+++ b/tool/skill/run_test.go
@@ -1378,7 +1378,10 @@ func TestRunTool_RelativeCWD_TraversalDoesNotEscapeWorkspace(t *testing.T) {
 
 	pwd := strings.TrimSpace(lines[0])
 	wsRoot := strings.TrimSpace(lines[1])
-	require.True(t, strings.HasPrefix(pwd, wsRoot))
+
+	rel, err := filepath.Rel(wsRoot, pwd)
+	require.NoError(t, err)
+	require.False(t, strings.HasPrefix(rel, ".."))
 }
 
 func TestResolveCWD_WorkspaceEnvPathAllowlist(t *testing.T) {
@@ -1386,6 +1389,7 @@ func TestResolveCWD_WorkspaceEnvPathAllowlist(t *testing.T) {
 
 	// traversal should fallback
 	require.Equal(t, base, resolveCWD("$"+codeexecutor.WorkspaceEnvDirKey+"/../..", "x"))
+	require.Equal(t, base, resolveCWD("$"+codeexecutor.WorkspaceEnvDirKey+"\\..\\..", "x"))
 
 	// allowed roots under workspace
 	require.Equal(t, codeexecutor.DirWork, resolveCWD("$"+codeexecutor.WorkspaceEnvDirKey+"/"+codeexecutor.DirWork, "x"))
@@ -1401,6 +1405,11 @@ func TestResolveCWD_AbsPathAllowlist(t *testing.T) {
 	require.Equal(t, codeexecutor.DirWork, resolveCWD("/"+codeexecutor.DirWork, "x"))
 	require.Equal(t, base, resolveCWD("/etc", "x"))
 	require.Equal(t, ".", resolveCWD("/", "x"))
+}
+
+func TestResolveCWD_RelPath_BackslashTraversalDoesNotEscape(t *testing.T) {
+	base := path.Join(codeexecutor.DirSkills, "x")
+	require.Equal(t, base, resolveCWD("..\\..\\..", "x"))
 }
 
 // Validate Declaration basics and required fields.


### PR DESCRIPTION
### What
Prevent skill_run cwd traversal from escaping the workspace.

### Why
Relative/env cwd could resolve outside the intended workspace, breaking isolation and making runs unpredictable.

### Test
- go test ./...

## Summary by Sourcery

防止在解析工作目录（cwd）时，使技能执行的工作目录逃离工作空间。

Bug 修复：
- 确保 `resolveCWD` 在处理相对路径和基于 workspace 环境变量的路径时，将其限制在工作空间及已知子目录之内。
- 在将基础路径与用户提供的 `cwd` 值拼接时，防止目录遍历攻击。

测试：
- 新增测试，验证类似目录遍历风格的相对 `cwd` 无法逃离工作空间，并且最终生效的工作目录始终位于工作空间根目录之下。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent skill execution working directory from escaping the workspace via cwd resolution.

Bug Fixes:
- Ensure resolveCWD clamps relative and workspace-env-based paths to stay within the workspace and known subdirectories.
- Guard against directory traversal when joining base paths with user-supplied cwd values.

Tests:
- Add a test verifying that a traversal-style relative cwd cannot escape the workspace and that the effective working directory remains under the workspace root.

</details>