### PR TITLE
model/provider: correct callbacks to Gemini in provider

### DIFF
--- a/model/provider/go.mod
+++ b/model/provider/go.mod
@@ -2,8 +2,6 @@ module trpc.group/trpc-go/trpc-agent-go/model/provider
 
 go 1.24.1
 
-toolchain go1.24.4
-
 replace (
 	trpc.group/trpc-go/trpc-agent-go => ../../
 	trpc.group/trpc-go/trpc-agent-go/model/anthropic => ../../model/anthropic
@@ -17,6 +15,7 @@ require (
 	github.com/ollama/ollama v0.13.1
 	github.com/openai/openai-go v1.12.0
 	github.com/stretchr/testify v1.11.1
+	google.golang.org/genai v1.36.0
 	trpc.group/trpc-go/trpc-agent-go v0.6.0
 	trpc.group/trpc-go/trpc-agent-go/model/anthropic v0.0.0-20251126064502-c8c2594d2519
 	trpc.group/trpc-go/trpc-agent-go/model/gemini v0.8.1-0.20251222024650-ea147adf3d21
@@ -53,7 +52,6 @@ require (
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/text v0.31.0 // indirect
-	google.golang.org/genai v1.36.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251124214823-79d6a2a48846 // indirect
 	google.golang.org/grpc v1.77.0 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect

--- a/model/provider/options.go
+++ b/model/provider/options.go
@@ -10,6 +10,7 @@
 package provider
 
 import (
+	"maps"
 	"net/http"
 
 	"trpc.group/trpc-go/trpc-agent-go/model"
@@ -161,6 +162,18 @@ func WithCallbacks(cb Callbacks) Option {
 		if cb.AnthropicStreamComplete != nil {
 			o.Callbacks.AnthropicStreamComplete = cb.AnthropicStreamComplete
 		}
+		if cb.GeminiChatRequest != nil {
+			o.Callbacks.GeminiChatRequest = cb.GeminiChatRequest
+		}
+		if cb.GeminiChatResponse != nil {
+			o.Callbacks.GeminiChatResponse = cb.GeminiChatResponse
+		}
+		if cb.GeminiChatChunk != nil {
+			o.Callbacks.GeminiChatChunk = cb.GeminiChatChunk
+		}
+		if cb.GeminiStreamComplete != nil {
+			o.Callbacks.GeminiStreamComplete = cb.GeminiStreamComplete
+		}
 		if cb.OllamaChatRequest != nil {
 			o.Callbacks.OllamaChatRequest = cb.OllamaChatRequest
 		}
@@ -172,6 +185,18 @@ func WithCallbacks(cb Callbacks) Option {
 		}
 		if cb.OllamaChatChunk != nil {
 			o.Callbacks.OllamaChatChunk = cb.OllamaChatChunk
+		}
+		if cb.HunyuanChatRequest != nil {
+			o.Callbacks.HunyuanChatRequest = cb.HunyuanChatRequest
+		}
+		if cb.HunyuanChatResponse != nil {
+			o.Callbacks.HunyuanChatResponse = cb.HunyuanChatResponse
+		}
+		if cb.HunyuanChatChunk != nil {
+			o.Callbacks.HunyuanChatChunk = cb.HunyuanChatChunk
+		}
+		if cb.HunyuanStreamComplete != nil {
+			o.Callbacks.HunyuanStreamComplete = cb.HunyuanStreamComplete
 		}
 	}
 }
@@ -189,9 +214,7 @@ func WithExtraFields(fields map[string]any) Option {
 		if o.ExtraFields == nil {
 			o.ExtraFields = make(map[string]any)
 		}
-		for k, v := range fields {
-			o.ExtraFields[k] = v
-		}
+		maps.Copy(o.ExtraFields, fields)
 	}
 }
 

--- a/model/provider/provider.go
+++ b/model/provider/provider.go
@@ -193,16 +193,16 @@ func anthropicProvider(opts *Options) (model.Model, error) {
 func geminiProvider(opts *Options) (model.Model, error) {
 	var res []gemini.Option
 	if cb := opts.Callbacks; cb != nil {
-		if cb.AnthropicChatRequest != nil {
+		if cb.GeminiChatRequest != nil {
 			res = append(res, gemini.WithChatRequestCallback(cb.GeminiChatRequest))
 		}
-		if cb.AnthropicChatResponse != nil {
+		if cb.GeminiChatResponse != nil {
 			res = append(res, gemini.WithChatResponseCallback(cb.GeminiChatResponse))
 		}
-		if cb.AnthropicChatChunk != nil {
+		if cb.GeminiChatChunk != nil {
 			res = append(res, gemini.WithChatChunkCallback(cb.GeminiChatChunk))
 		}
-		if cb.AnthropicStreamComplete != nil {
+		if cb.GeminiStreamComplete != nil {
 			res = append(res, gemini.WithChatStreamCompleteCallback(cb.GeminiStreamComplete))
 		}
 	}

--- a/model/provider/provider_test.go
+++ b/model/provider/provider_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ollama/ollama/api"
 	openaisdk "github.com/openai/openai-go"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/genai"
 
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/model/anthropic"
@@ -72,6 +73,7 @@ func TestOpenAIFactoryAppliesOptions(t *testing.T) {
 	}
 
 	fields := map[string]any{"tenant": "internal"}
+	headers := map[string]string{"X-Test-Header": "test-value"}
 	bufSize := 42
 	enabled := true
 	maxTokens := 256
@@ -81,6 +83,7 @@ func TestOpenAIFactoryAppliesOptions(t *testing.T) {
 	WithBaseURL("https://api.example.com")(opts)
 	WithHTTPClientName("custom-client")(opts)
 	WithHTTPClientTransport(http.DefaultTransport)(opts)
+	WithHeaders(headers)(opts)
 	WithCallbacks(cb)(opts)
 	WithChannelBufferSize(bufSize)(opts)
 	WithExtraFields(fields)(opts)
@@ -122,11 +125,13 @@ func TestAnthropicFactoryAppliesOptions(t *testing.T) {
 	}
 
 	bufSize := 64
+	headers := map[string]string{"X-Test-Header": "test-value"}
 	opts := &Options{ModelName: "claude"}
 	WithAPIKey("anthropic-key")(opts)
 	WithBaseURL("https://anthropic.example.com")(opts)
 	WithHTTPClientName("anthropic-client")(opts)
 	WithHTTPClientTransport(http.DefaultTransport)(opts)
+	WithHeaders(headers)(opts)
 	WithCallbacks(cb)(opts)
 	WithChannelBufferSize(bufSize)(opts)
 	WithAnthropicOption(anthropic.WithAnthropicRequestOptions(option.WithJSONSet("tenant", "internal")))(opts)
@@ -390,15 +395,38 @@ func TestModelWithAllOptions(t *testing.T) {
 		WithTailoringStrategy(strategy),
 		WithTokenTailoringConfig(config),
 		WithCallbacks(Callbacks{
-			GeminiChatChunk:      nil,
-			GeminiChatRequest:    nil,
-			GeminiStreamComplete: nil,
-			GeminiChatResponse:   nil,
+			GeminiChatChunk: gemini.ChatChunkCallbackFunc(func(
+				context.Context,
+				[]*genai.Content,
+				*genai.GenerateContentConfig,
+				*genai.GenerateContentResponse,
+			) {
+			}),
+			GeminiChatRequest: gemini.ChatRequestCallbackFunc(func(
+				context.Context,
+				[]*genai.Content,
+			) {
+			}),
+			GeminiStreamComplete: gemini.ChatStreamCompleteCallbackFunc(func(
+				context.Context,
+				[]*genai.Content,
+				*genai.GenerateContentConfig,
+				*model.Response,
+			) {
+			}),
+			GeminiChatResponse: gemini.ChatResponseCallbackFunc(func(
+				context.Context,
+				[]*genai.Content,
+				*genai.GenerateContentConfig,
+				*genai.GenerateContentResponse,
+			) {
+			}),
 		}),
 		WithGeminiOption(gemini.WithGeminiClientConfig(nil)),
 	)
-	assert.Error(t, err)
-	assert.Nil(t, modelInstance)
+	assert.NoError(t, err)
+	assert.NotNil(t, modelInstance)
+	assert.Equal(t, "gemini-pro", modelInstance.Info().Name)
 
 	modelInstance, err = Model(
 		"ollama",
@@ -434,6 +462,12 @@ func TestModelWithAllOptions(t *testing.T) {
 		WithTokenCounter(counter),
 		WithTailoringStrategy(strategy),
 		WithTokenTailoringConfig(config),
+		WithCallbacks(Callbacks{
+			HunyuanChatRequest:    makeFunc[hunyuan.ChatRequestCallbackFunc](),
+			HunyuanChatResponse:   makeFunc[hunyuan.ChatResponseCallbackFunc](),
+			HunyuanChatChunk:      makeFunc[hunyuan.ChatChunkCallbackFunc](),
+			HunyuanStreamComplete: makeFunc[hunyuan.ChatStreamCompleteCallbackFunc](),
+		}),
 		WithHunyuanOption(hunyuan.WithSecretId("test-secret-id"),
 			hunyuan.WithSecretKey("test-secret-key")),
 	)
@@ -495,4 +529,12 @@ func (testModel) GenerateContent(context.Context, *model.Request) (<-chan *model
 
 func (testModel) Info() model.Info {
 	return model.Info{Name: "test"}
+}
+
+func makeFunc[T any]() T {
+	fnType := reflect.TypeOf((*T)(nil)).Elem()
+	fn := reflect.MakeFunc(fnType, func([]reflect.Value) []reflect.Value {
+		return nil
+	})
+	return fn.Interface().(T)
 }

--- a/model/provider/provider_test.go
+++ b/model/provider/provider_test.go
@@ -422,10 +422,18 @@ func TestModelWithAllOptions(t *testing.T) {
 			) {
 			}),
 		}),
-		WithGeminiOption(gemini.WithGeminiClientConfig(nil)),
+		WithGeminiOption(gemini.WithGeminiClientConfig(&genai.ClientConfig{
+			APIKey:     "test-key",
+			Backend:    2,
+			HTTPClient: http.DefaultClient,
+		})),
 	)
-	assert.NoError(t, err)
-	assert.NotNil(t, modelInstance)
+	if !assert.NoError(t, err) {
+		return
+	}
+	if !assert.NotNil(t, modelInstance) {
+		return
+	}
 	assert.Equal(t, "gemini-pro", modelInstance.Info().Name)
 
 	modelInstance, err = Model(


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 修复 Gemini 提供方在配置与聊天相关的回调时，错误地使用 Anthropic 回调字段的问题，现在改为正确使用 Gemini 的回调字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct Gemini provider to use Gemini callback fields instead of Anthropic callback fields when configuring chat-related callbacks.

</details>