### PR TITLE
evaluation: add pass metrics and expose EvalSetResult

### DIFF
--- a/evaluation/evaluation_test.go
+++ b/evaluation/evaluation_test.go
@@ -336,7 +336,7 @@ func TestAgentEvaluatorCollectCaseResultsGetEvalSetError(t *testing.T) {
 		evalSetManager: evalsetinmemory.New(),
 		numRuns:        1,
 	}
-	_, err := ae.collectCaseResults(ctx, "set")
+	_, _, err := ae.collectCaseResults(ctx, "set")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "get eval set")
 	assert.ErrorIs(t, err, os.ErrNotExist)
@@ -372,7 +372,7 @@ func TestAgentEvaluatorCollectCaseResultsSortByEvalSetOrder(t *testing.T) {
 		evalResultManager: evalresultinmemory.New(),
 		numRuns:           1,
 	}
-	results, err := ae.collectCaseResults(ctx, evalSetID)
+	results, _, err := ae.collectCaseResults(ctx, evalSetID)
 	assert.NoError(t, err)
 	assert.Len(t, results, 2)
 	assert.Equal(t, "B", results[0].EvalCaseID)
@@ -408,7 +408,7 @@ func TestAgentEvaluatorCollectCaseResultsSortKnownCaseFirst(t *testing.T) {
 		evalResultManager: evalresultinmemory.New(),
 		numRuns:           1,
 	}
-	results, err := ae.collectCaseResults(ctx, evalSetID)
+	results, _, err := ae.collectCaseResults(ctx, evalSetID)
 	assert.NoError(t, err)
 	assert.Len(t, results, 2)
 	assert.Equal(t, "A", results[0].EvalCaseID)
@@ -438,7 +438,7 @@ func TestAgentEvaluatorCollectCaseResultsSortLexicographically(t *testing.T) {
 		evalResultManager: evalresultinmemory.New(),
 		numRuns:           1,
 	}
-	results, err := ae.collectCaseResults(ctx, evalSetID)
+	results, _, err := ae.collectCaseResults(ctx, evalSetID)
 	assert.NoError(t, err)
 	assert.Len(t, results, 2)
 	assert.Equal(t, "a", results[0].EvalCaseID)

--- a/evaluation/pass.go
+++ b/evaluation/pass.go
@@ -1,0 +1,259 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package evaluation
+
+import (
+	"fmt"
+	"math"
+)
+
+// PassAtK computes the pass@k metric used in LLM / agent evaluation.
+//
+// pass@k measures the probability that at least one correct solution
+// appears among k independently sampled model outputs.
+//
+// It is commonly used to evaluate stochastic systems (LLMs / agents)
+// where multiple attempts are allowed.
+//
+// Formally:
+//
+//	Given:
+//	  n = total number of sampled attempts
+//	  c = number of successful attempts among n
+//	  k = number of attempts we hypothetically select (k <= n)
+//
+//	pass@k is defined as:
+//
+//	  pass@k = 1 - C(n-c, k) / C(n, k)
+//
+//	where C(a, b) is the binomial coefficient ("a choose b").
+//
+// Interpretation:
+//
+//	From the n observed runs, imagine randomly selecting k runs
+//	without replacement. pass@k is the probability that at least
+//	one of those k runs is successful.
+//
+// This is the unbiased estimator introduced in the Codex / HumanEval
+// benchmarks and is now standard in LLM evaluation.
+//
+// Why this formula:
+//
+//   - Uses all n samples (not just the first k)
+//   - Avoids ordering bias
+//   - Provides lower-variance estimates when n > k
+//
+// # Numerical Method
+//
+// Directly computing factorials or combinations will overflow for
+// realistic n. Therefore this implementation operates in log-space
+// using math.Lgamma:
+//
+//	ln(n!) = Lgamma(n+1)
+//
+// The formula becomes:
+//
+//	logP = ln((n-c)!)
+//	     + ln((n-k)!)
+//	     - ln((n-c-k)!)
+//	     - ln(n!)
+//
+//	pass@k = 1 - exp(logP)
+//
+// This avoids overflow and maintains numerical stability.
+//
+// Parameters
+//
+//	n : total number of sampled runs (must be >= 0)
+//	c : number of successful runs (must satisfy 0 <= c <= n)
+//	k : target k for pass@k (must satisfy 1 <= k <= n)
+//
+// Return value
+//
+//	A float64 in [0, 1] representing pass@k.
+//
+// Edge cases:
+//
+//   - If c == 0, returns 0
+//   - If n-c < k, returns 1 (impossible to select k failures)
+//
+// IMPORTANT:
+//
+//	This function assumes all n samples are independent and identically
+//	distributed. In agent evaluations, callers must ensure:
+//
+//	  - Agent state is reset between runs
+//	  - No memory/tool cache leakage
+//	  - Each run is a fresh stochastic sample
+//
+// Otherwise pass@k will be systematically overestimated.
+func PassAtK(n, c, k int) (float64, error) {
+	if n < 0 {
+		return 0.0, fmt.Errorf("n must be >= 0")
+	}
+	if k <= 0 {
+		return 0.0, fmt.Errorf("k must be >= 1")
+	}
+	if c < 0 {
+		return 0.0, fmt.Errorf("c must be >= 0")
+	}
+	if c > n {
+		return 0.0, fmt.Errorf("c cannot exceed n")
+	}
+	if k > n {
+		return 0.0, fmt.Errorf("k cannot exceed n")
+	}
+	// No successes observed.
+	if c == 0 {
+		return 0.0, nil
+	}
+	// Fewer than k failures exist -> at least one success guaranteed.
+	if n-c < k {
+		return 1.0, nil
+	}
+	nf := float64(n)
+	cf := float64(c)
+	kf := float64(k)
+	// log((n-c)!)
+	a, _ := math.Lgamma(nf - cf + 1)
+	// log((n-k)!)
+	b, _ := math.Lgamma(nf - kf + 1)
+	// log((n-c-k)!)
+	d, _ := math.Lgamma(nf - cf - kf + 1)
+	// log(n!)
+	e, _ := math.Lgamma(nf + 1)
+	// log probability of drawing k failures
+	logP := a + b - d - e
+	// pass@k = 1 - exp(logP)
+	//
+	// Use Expm1 for better precision when logP is close to zero:
+	//   1 - exp(x) == -expm1(x)
+	return -math.Expm1(logP), nil
+}
+
+// PassHatK computes the pass^k metric used in LLM / agent reliability evaluation.
+//
+// # Concept
+//
+// pass^k estimates the probability that
+// a system succeeds k times in a row, assuming each run is an independent
+// Bernoulli trial with identical success probability.
+//
+// Given:
+//
+//	n = total number of sampled runs
+//	c = number of successful runs among n
+//	k = number of consecutive successes required
+//
+// We first estimate the single-run success probability:
+//
+//	p = c / n
+//
+// Then:
+//
+//	pass^k = p^k
+//
+// Interpretation:
+//
+//	pass^k answers:
+//
+//	  "If I run this system k times independently, what is the probability
+//	   that all k runs succeed?"
+//
+// This metric emphasizes reliability and consistency, in contrast to pass@k,
+// which measures whether at least one success appears.
+//
+// Typical usage:
+//
+//   - pass@k  : measures peak capability
+//   - pass^k  : measures stability / robustness
+//
+// Statistical Assumptions
+//
+//   - Each run is independent
+//   - Each run follows the same success distribution
+//
+// In agent systems this requires:
+//
+//   - Full reset between runs
+//   - No memory leakage
+//   - No tool cache reuse
+//
+// Otherwise pass^k will be overestimated.
+//
+// # Numerical Notes
+//
+// This implementation uses log-space:
+//
+//	pass^k = exp(k * log(p))
+//
+// instead of:
+//
+//	pow(p, k)
+//
+// which improves stability when p is very small or k is large.
+//
+// Parameters
+//
+//	n : total number of sampled runs (must be > 0)
+//	c : number of successful runs (must satisfy 0 <= c <= n)
+//	k : number of consecutive successes required (must be >= 1)
+//
+// Return value
+//
+//	A float64 in [0, 1] representing pass^k.
+//
+// Edge cases:
+//
+//   - If c == 0, returns 0
+//   - If c == n, returns 1
+func PassHatK(n, c, k int) (float64, error) {
+	if n <= 0 {
+		return 0.0, fmt.Errorf("n must be > 0")
+	}
+	if k <= 0 {
+		return 0.0, fmt.Errorf("k must be >= 1")
+	}
+	if c < 0 {
+		return 0.0, fmt.Errorf("c must be >= 0")
+	}
+	if c > n {
+		return 0.0, fmt.Errorf("c cannot exceed n")
+	}
+
+	// No successes observed.
+	if c == 0 {
+		return 0.0, nil
+	}
+	// All runs successful.
+	if c == n {
+		return 1.0, nil
+	}
+	p := float64(c) / float64(n)
+	// Compute p^k in log-space for numerical stability: p^k = exp(k * log(p))
+	return math.Exp(float64(k) * math.Log(p)), nil
+}
+
+// ParsePassNC extracts (n, c) from an EvaluationResult for pass@k / pass^k calculations.
+func ParsePassNC(result *EvaluationResult) (n, c int, err error) {
+	if result == nil {
+		return 0, 0, fmt.Errorf("evaluation result is nil")
+	}
+	if result.EvalResult == nil {
+		return 0, 0, fmt.Errorf("eval set result is nil")
+	}
+	if result.EvalResult.Summary == nil {
+		return 0, 0, fmt.Errorf("eval set result summary is nil")
+	}
+	if result.EvalResult.Summary.RunStatusCounts == nil {
+		return 0, 0, fmt.Errorf("run status counts is nil")
+	}
+	return result.EvalResult.Summary.NumRuns, result.EvalResult.Summary.RunStatusCounts.Passed, nil
+}

--- a/evaluation/pass_test.go
+++ b/evaluation/pass_test.go
@@ -1,0 +1,167 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package evaluation
+
+import (
+	"math"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
+)
+
+func chooseBig(n, k int64) *big.Int {
+	if k < 0 || k > n {
+		return big.NewInt(0)
+	}
+	if k == 0 || k == n {
+		return big.NewInt(1)
+	}
+	// Symmetry: C(n,k) == C(n,n-k)
+	if k > n-k {
+		k = n - k
+	}
+	res := big.NewInt(1)
+	for i := int64(1); i <= k; i++ {
+		res.Mul(res, big.NewInt(n-k+i))
+		res.Div(res, big.NewInt(i))
+	}
+	return res
+}
+
+func expectedPassAtK(n, c, k int) float64 {
+	// pass@k = 1 - C(n-c,k) / C(n,k)
+	num := new(big.Rat).SetInt(chooseBig(int64(n-c), int64(k)))
+	den := new(big.Rat).SetInt(chooseBig(int64(n), int64(k)))
+	if den.Sign() == 0 {
+		return 0
+	}
+	ratio := new(big.Rat).Quo(num, den)
+	one := big.NewRat(1, 1)
+	exp := new(big.Rat).Sub(one, ratio)
+	f, _ := exp.Float64()
+	return f
+}
+
+func TestPassAtK_ValidatesArgs(t *testing.T) {
+	_, err := PassAtK(-1, 0, 1)
+	require.Error(t, err)
+	_, err = PassAtK(1, 0, 0)
+	require.Error(t, err)
+	_, err = PassAtK(1, -1, 1)
+	require.Error(t, err)
+	_, err = PassAtK(1, 2, 1)
+	require.Error(t, err)
+	_, err = PassAtK(1, 0, 2)
+	require.Error(t, err)
+}
+
+func TestPassAtK_EdgeCases(t *testing.T) {
+	got, err := PassAtK(10, 0, 1)
+	require.NoError(t, err)
+	require.Equal(t, 0.0, got)
+
+	got, err = PassAtK(10, 10, 1)
+	require.NoError(t, err)
+	require.Equal(t, 1.0, got)
+
+	// n-c < k => guaranteed at least one success.
+	got, err = PassAtK(5, 4, 2) // failures=1, pick 2 => impossible
+	require.NoError(t, err)
+	require.Equal(t, 1.0, got)
+}
+
+func TestPassAtK_KnownSmallValues(t *testing.T) {
+	cases := []struct {
+		n, c, k int
+	}{
+		{n: 5, c: 1, k: 1},
+		{n: 5, c: 1, k: 2},
+		{n: 10, c: 3, k: 1},
+		{n: 10, c: 3, k: 5},
+		{n: 20, c: 7, k: 3},
+	}
+	for _, tc := range cases {
+		got, err := PassAtK(tc.n, tc.c, tc.k)
+		require.NoError(t, err)
+		want := expectedPassAtK(tc.n, tc.c, tc.k)
+		require.InEpsilon(t, want, got, 1e-12)
+	}
+}
+
+func TestPassHatK_ValidatesArgs(t *testing.T) {
+	_, err := PassHatK(0, 0, 1)
+	require.Error(t, err)
+	_, err = PassHatK(1, 0, 0)
+	require.Error(t, err)
+	_, err = PassHatK(1, -1, 1)
+	require.Error(t, err)
+	_, err = PassHatK(1, 2, 1)
+	require.Error(t, err)
+}
+
+func TestPassHatK_EdgeCasesAndKnownValue(t *testing.T) {
+	got, err := PassHatK(10, 0, 3)
+	require.NoError(t, err)
+	require.Equal(t, 0.0, got)
+
+	got, err = PassHatK(10, 10, 3)
+	require.NoError(t, err)
+	require.Equal(t, 1.0, got)
+
+	// p = 5/10 = 0.5 => p^2 = 0.25
+	got, err = PassHatK(10, 5, 2)
+	require.NoError(t, err)
+	require.InDelta(t, 0.25, got, 1e-12)
+}
+
+func TestParsePassNC_NilAndMissingFields(t *testing.T) {
+	_, _, err := ParsePassNC(nil)
+	require.Error(t, err)
+
+	_, _, err = ParsePassNC(&EvaluationResult{})
+	require.Error(t, err)
+
+	_, _, err = ParsePassNC(&EvaluationResult{EvalResult: &evalresult.EvalSetResult{}})
+	require.Error(t, err)
+
+	_, _, err = ParsePassNC(&EvaluationResult{EvalResult: &evalresult.EvalSetResult{
+		Summary: &evalresult.EvalSetResultSummary{},
+	}})
+	require.Error(t, err)
+}
+
+func TestParsePassNC_OK(t *testing.T) {
+	res := &EvaluationResult{
+		EvalResult: &evalresult.EvalSetResult{
+			Summary: &evalresult.EvalSetResultSummary{
+				NumRuns: 4,
+				RunStatusCounts: &evalresult.EvalStatusCounts{
+					Passed: 2,
+					Failed: 2,
+				},
+			},
+		},
+	}
+	n, c, err := ParsePassNC(res)
+	require.NoError(t, err)
+	require.Equal(t, 4, n)
+	require.Equal(t, 2, c)
+}
+
+func TestPassAtK_IsProbability(t *testing.T) {
+	got, err := PassAtK(100, 1, 1)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, got, 0.0)
+	require.LessOrEqual(t, got, 1.0)
+	require.False(t, math.IsNaN(got))
+}


### PR DESCRIPTION
Add pass@k and pass^k metrics functions for probabilistic evaluation along with helper for extracting n and c from EvaluationResult and expose EvalSetResult in the public EvaluationResult struct to access aggregated results. The implementation uses numerical stable methods including log-space computation for PassAtK and PassHatK to avoid overflow.

## Summary by Sourcery

添加概率评估指标工具，并通过公共评估 API 暴露聚合后的评估集（eval-set）结果。

新功能：
- 在 `EvaluationResult` 上暴露评估集的聚合结果，使底层的 `EvalSetResult` 对调用方可访问。
- 引入 `PassAtK` 和 `PassHatK` 辅助函数，用于从评估结果中计算 pass@k 和 pass^k 可靠性指标。
- 添加 `ParsePassNC` 辅助函数，从 `EvaluationResult` 中提取运行次数和成功次数，用于指标计算。

测试：
- 添加单元测试，验证 `PassAtK` 和 `PassHatK` 的行为、数值稳定性和参数校验，以及 `ParsePassNC` 的边界情况和成功路径。
- 更新现有的智能体评估器测试，以适配 `collectCaseResults` 新返回的 `EvalSetResult`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add probabilistic evaluation metrics utilities and expose aggregated eval-set results through the public evaluation API.

New Features:
- Expose eval-set aggregate results on EvaluationResult to make underlying EvalSetResult accessible to callers.
- Introduce PassAtK and PassHatK helper functions for computing pass@k and pass^k reliability metrics from evaluation outcomes.
- Add a ParsePassNC helper to derive run and success counts from EvaluationResult for metric computation.

Tests:
- Add unit tests validating PassAtK and PassHatK behavior, numerical stability, and argument validation, as well as ParsePassNC edge cases and success path.
- Update existing agent evaluator tests to account for the newly returned EvalSetResult from collectCaseResults.

</details>