### PR TITLE
{model, session/summary}: add configurable approx runes per token option

### DIFF
--- a/docs/mkdocs/en/model.md
+++ b/docs/mkdocs/en/model.md
@@ -1246,7 +1246,159 @@ Per-request headers
 - Chat completion per-request base URL override is not exposed; create a
   second model with a different base URL or alter `r.URL` in middleware.
 
-#### 6. Token Tailoring
+#### 6. Token Counter
+
+The Token Counter is used to estimate the token count of text content. The framework provides `SimpleTokenCounter` as the default implementation, supporting custom token counting logic to meet different scenario requirements.
+
+##### SimpleTokenCounter
+
+`SimpleTokenCounter` provides a very rough token estimation based on UTF-8 character count. Its features include:
+
+**Core Features:**
+
+- **Lightweight**: Does not depend on external tokenizers, only uses character length estimation
+- **Model-agnostic**: Suitable for all OpenAI-compatible models
+- **Multimodal Support**: Supports message content, reasoning content (ReasoningContent), and tool calls
+
+**Estimation Principle:**
+
+Uses heuristic rules: approximately `N` UTF-8 characters per token, where `N` can be configured via `WithApproxRunesPerToken`.
+
+**Usage:**
+
+```go
+import "trpc.group/trpc-go/trpc-agent-go/model"
+
+// Use default configuration (English scenario)
+counter := model.NewSimpleTokenCounter()
+
+// Adjust for Chinese scenarios (Chinese has higher token density)
+counter := model.NewSimpleTokenCounter(
+    model.WithApproxRunesPerToken(1.6),  // Approx. 1.6 chars/token
+)
+
+// Adjust for other languages or specific models
+counter := model.NewSimpleTokenCounter(
+    model.WithApproxRunesPerToken(3.5),  // Approx. 3.5 chars/token
+)
+```
+
+**Parameter Description:**
+
+**`WithApproxRunesPerToken(v float64)`**
+
+- **Purpose**: Set the approximate number of characters per token
+- **Type**: float64
+- **Default Value**: 4.0 (approx. 4 characters per token, suitable for English scenarios)
+- **Value Constraint**: Values <= 0 will be ignored, keeping the default value
+
+**Recommended Values for Common Languages:**
+
+| Language/Scenario | Recommended Value | Description |
+| -------------- | ------- | ---- |
+| English text     | 4.0     | Default value, suitable for English words and common Latin characters |
+| Chinese text     | 1.6-1.8  | Chinese characters have higher token density than English, use smaller values |
+| Japanese text    | 2.0-2.5  | Japanese character token density is between Chinese and English |
+| Mixed text       | 3.0      | Trade-off value for mixed Chinese/English scenarios |
+
+**Important Notes:**
+
+- **Empirical Values**: The recommended values above are empirical estimates. Actual token count depends on the specific model's tokenizer implementation.
+- **Uncertainty**: If you're uncertain about language mix or model characteristics, keep the default value (4.0).
+- **Model Differences**: Different model vendors (OpenAI, DeepSeek, Hunyuan) have different tokenizer implementations, which may require adjusting this parameter.
+- **Accuracy Consideration**: `SimpleTokenCounter` only provides rough estimation. If you need accurate token counting, consider using the model provider's tokenizer API (e.g., OpenAI's tiktoken).
+
+**Custom Token Counter**
+
+If `SimpleTokenCounter`'s rough estimation doesn't meet your requirements, you can implement a custom `TokenCounter` interface:
+
+```go
+import (
+    "context"
+    "fmt"
+    "trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+type MyCustomCounter struct{}
+
+func (c *MyCustomCounter) CountTokens(ctx context.Context, message model.Message) (int, error) {
+    // Calculate tokens for message content, reasoning content, and tool calls
+    total := 0
+
+    // Process main content
+    if len(message.Content) > 0 {
+        total += len(message.Content)  // Example: use more accurate algorithm
+    }
+
+    // Process reasoning content
+    if len(message.ReasoningContent) > 0 {
+        total += len(message.ReasoningContent)
+    }
+
+    // Process multimodal content
+    for _, part := range message.ContentParts {
+        if part.Text != nil {
+            total += len(*part.Text)
+        }
+    }
+
+    // Process tool calls
+    for _, toolCall := range message.ToolCalls {
+        total += len(toolCall.Function.Name)
+        total += len(string(toolCall.Function.Arguments))
+    }
+
+    return total, nil
+}
+
+func (c *MyCustomCounter) CountTokensRange(ctx context.Context, messages []model.Message, start, end int) (int, error) {
+    if start < 0 || end > len(messages) || start >= end {
+        return 0, fmt.Errorf("invalid range: start=%d, end=%d, len=%d", start, end, len(messages))
+    }
+
+    total := 0
+    for i := start; i < end; i++ {
+        tokens, err := c.CountTokens(ctx, messages[i])
+        if err != nil {
+            return 0, err
+        }
+        total += tokens
+    }
+    return total, nil
+}
+
+// Use custom counter when creating a model
+llm := openai.New("deepseek-chat",
+    openai.WithTokenCounter(&MyCustomCounter{}),
+)
+```
+
+**Using Token Counter in Summarizer**
+
+`SimpleTokenCounter` can also be used with the `session/summary` module to control summary triggering:
+
+```go
+import (
+    "trpc.group/trpc-go/trpc-agent-go/model"
+    "trpc.group/trpc-go/trpc-agent-go/session/summary"
+)
+
+// 1. Create a counter optimized for Chinese
+counter := model.NewSimpleTokenCounter(
+    model.WithApproxRunesPerToken(1.6),  // Recommended value for Chinese scenarios
+)
+
+// 2. Set as global counter (affects all summary triggers)
+summary.SetTokenCounter(counter)
+
+// 3. Create summarizer
+summarizer := summary.NewSummarizer(
+    summaryModel,
+    summary.CheckTokenThreshold(4000),  // Uses your custom counter for evaluation
+)
+```
+
+#### 7. Token Tailoring
 
 Token Tailoring is an intelligent message management technique designed to automatically trim messages when they exceed the model's context window limits, ensuring requests can be successfully sent to the LLM API. This feature is particularly useful for long conversation scenarios, allowing you to keep the message list within the model's token limits while preserving key context.
 

--- a/docs/mkdocs/en/model.md
+++ b/docs/mkdocs/en/model.md
@@ -1394,7 +1394,7 @@ summary.SetTokenCounter(counter)
 // 3. Create summarizer
 summarizer := summary.NewSummarizer(
     summaryModel,
-    summary.CheckTokenThreshold(4000),  // Uses your custom counter for evaluation
+    summary.WithTokenThreshold(4000),  // Uses your custom counter for evaluation
 )
 ```
 

--- a/docs/mkdocs/zh/model.md
+++ b/docs/mkdocs/zh/model.md
@@ -1385,7 +1385,7 @@ summary.SetTokenCounter(counter)
 // 3. 创建摘要器
 summarizer := summary.NewSummarizer(
     summaryModel,
-    summary.CheckTokenThreshold(4000),  // 使用自定义计数器评估
+    summary.WithTokenThreshold(4000),  // 使用自定义计数器评估
 )
 ```
 

--- a/docs/mkdocs/zh/model.md
+++ b/docs/mkdocs/zh/model.md
@@ -1237,7 +1237,159 @@ llm := openai.New("deepseek-chat",
 - 对“对话补全”而言，目前未暴露单次调用级别的 BaseURL 覆盖；如需切
   换，请新建一个使用不同 BaseURL 的模型，或在中间件中修改 `r.URL`。
 
-#### 6. Token 裁剪（Token Tailoring）
+#### 6. Token 计数器（Token Counter）
+
+Token 计数器用于估算文本内容的 token 数量。框架提供了 `SimpleTokenCounter` 作为默认实现，支持自定义 token 计数逻辑以满足不同场景的需求。
+
+##### SimpleTokenCounter
+
+`SimpleTokenCounter` 提供了一个非常粗略的 token 估算，基于 UTF-8 字符数量计算。它的特点是：
+
+**核心特性：**
+
+- **轻量级**：不依赖外部 tokenizer，仅使用字符长度估算
+- **模型无关**：适用于所有 OpenAI 兼容的模型
+- **多模态支持**：支持消息内容、推理内容（ReasoningContent）和工具调用
+
+**估算原理：**
+
+使用启发式规则：每 token 大约对应 `N` 个 UTF-8 字符，其中 `N` 可通过 `WithApproxRunesPerToken` 配置。
+
+**使用方式：**
+
+```go
+import "trpc.group/trpc-go/trpc-agent-go/model"
+
+// 使用默认配置（英文场景）
+counter := model.NewSimpleTokenCounter()
+
+// 针对中文场景调整（中文 token 密度更高）
+counter := model.NewSimpleTokenCounter(
+    model.WithApproxRunesPerToken(1.6),  // 约 1.6 字符/token
+)
+
+// 针对其他语言或特定模型调整
+counter := model.NewSimpleTokenCounter(
+    model.WithApproxRunesPerToken(3.5),  // 约 3.5 字符/token
+)
+```
+
+**参数说明：**
+
+**`WithApproxRunesPerToken(v float64)`**
+
+- **作用**：设置每 token 大约对应的字符数
+- **类型**：float64
+- **默认值**：4.0（约每 4 个字符对应 1 个 token，适合英文场景）
+- **值限制**：<= 0 的值会被忽略，保持默认值
+
+**常见语言的推荐值：**
+
+| 语言/场景          | 推荐值 | 说明 |
+| --------------- | ------- | ---- |
+| 英文文本        | 4.0     | 默认值，适合英文单词和常见拉丁字符 |
+| 中文文本        | 1.6-1.8  | 中文字符的 token 密度高于英文，建议使用较小的值 |
+| 日文文本        | 2.0-2.5  | 日文字符 token 密度介于中英文之间 |
+| 混合文本        | 3.0      | 中英混合场景的折中值 |
+
+**重要提示：**
+
+- **经验值**：上述推荐值为经验值，实际 token 数量取决于具体模型的 tokenizer 实现。
+- **不确定场景**：如果您不确定语言混合或使用的模型特性，建议保留默认值（4.0）。
+- **模型差异**：不同模型厂商（如 OpenAI、DeepSeek、混元）的 tokenizer 实现不同，可能需要调整此参数。
+- **精度考虑**：`SimpleTokenCounter` 仅提供粗略估算。如果需要精确的 token 计算，建议使用模型提供商提供的 tokenizer API（如 OpenAI 的 tiktoken）。
+
+**自定义 Token Counter**
+
+如果 `SimpleTokenCounter` 的粗略估算不能满足需求，可以实现自定义的 `TokenCounter` 接口：
+
+```go
+import (
+    "context"
+    "fmt"
+    "trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+type MyCustomCounter struct{}
+
+func (c *MyCustomCounter) CountTokens(ctx context.Context, message model.Message) (int, error) {
+    // 计算消息内容、推理内容和工具调用的 token 数量
+    total := 0
+
+    // 处理主内容
+    if len(message.Content) > 0 {
+        total += len(message.Content)  // 示例：使用更精确的算法
+    }
+
+    // 处理推理内容
+    if len(message.ReasoningContent) > 0 {
+        total += len(message.ReasoningContent)
+    }
+
+    // 处理多模态内容
+    for _, part := range message.ContentParts {
+        if part.Text != nil {
+            total += len(*part.Text)
+        }
+    }
+
+    // 处理工具调用
+    for _, toolCall := range message.ToolCalls {
+        total += len(toolCall.Function.Name)
+        total += len(string(toolCall.Function.Arguments))
+    }
+
+    return total, nil
+}
+
+func (c *MyCustomCounter) CountTokensRange(ctx context.Context, messages []model.Message, start, end int) (int, error) {
+    if start < 0 || end > len(messages) || start >= end {
+        return 0, fmt.Errorf("invalid range: start=%d, end=%d, len=%d", start, end, len(messages))
+    }
+
+    total := 0
+    for i := start; i < end; i++ {
+        tokens, err := c.CountTokens(ctx, messages[i])
+        if err != nil {
+            return 0, err
+        }
+        total += tokens
+    }
+    return total, nil
+}
+
+// 在创建模型时使用自定义计数器
+llm := openai.New("deepseek-chat",
+    openai.WithTokenCounter(&MyCustomCounter{}),
+)
+```
+
+**在摘要器中使用 Token Counter**
+
+`SimpleTokenCounter` 也可以与 `session/summary` 模块配合使用，用于控制摘要触发：
+
+```go
+import (
+    "trpc.group/trpc-go/trpc-agent-go/model"
+    "trpc.group/trpc-go/trpc-agent-go/session/summary"
+)
+
+// 1. 创建针对中文优化的计数器
+counter := model.NewSimpleTokenCounter(
+    model.WithApproxRunesPerToken(1.6),  // 中文场景推荐值
+)
+
+// 2. 设置为全局计数器（影响所有摘要触发）
+summary.SetTokenCounter(counter)
+
+// 3. 创建摘要器
+summarizer := summary.NewSummarizer(
+    summaryModel,
+    summary.CheckTokenThreshold(4000),  // 使用自定义计数器评估
+)
+```
+
+#### 7. Token 裁剪（Token Tailoring）
 
 Token Tailoring 是一种智能的消息管理技术，用于在消息超出模型上下文窗口限制时自动裁剪消息，确保请求能够成功发送到 LLM API。该功能特别适用于长对话场景，能够在保留关键上下文的同时，将消息列表控制在模型的 token 限制内。
 

--- a/docs/mkdocs/zh/session.md
+++ b/docs/mkdocs/zh/session.md
@@ -1739,6 +1739,46 @@ llmagent.WithMaxHistoryRuns(10)  // 限制历史轮次
 - **`WithPrompt(prompt string)`**：提供自定义摘要提示词。提示词必须包含占位符 `{conversation_text}`，它会被对话内容替换。可选包含 `{max_summary_words}` 用于字数限制指令。
 - **`WithSkipRecent(skipFunc SkipRecentFunc)`**：通过自定义函数在摘要时跳过**最近**事件。函数接收所有事件并返回应跳过的尾部事件数量，返回 0 表示不跳过。适合避免总结最近、可能不完整的对话，或实现基于时间/内容的跳过策略。
 
+#### Token 计数器配置（Token Counter Configuration）
+
+默认情况下，`CheckTokenThreshold` 使用内置的 `SimpleTokenCounter` 基于文本长度估算 token 数量。如果您需要自定义 token 计数行为（例如，为特定模型使用更精确的 tokenizer），可以使用 `summary.SetTokenCounter` 设置全局 token 计数器：
+
+```go
+import (
+    "trpc.group/trpc-go/trpc-agent-go/model"
+    "trpc.group/trpc-go/trpc-agent-go/session/summary"
+)
+
+// 设置自定义 token 计数器（影响该进程中的所有 CheckTokenThreshold 评估）
+summary.SetTokenCounter(model.NewSimpleTokenCounter())
+
+// 或者使用自定义实现
+type MyCustomCounter struct{}
+
+func (c *MyCustomCounter) CountTokens(ctx context.Context, message model.Message) (int, error) {
+    // 您的自定义 token 计数逻辑
+    // 例如：使用 tiktoken、huggingface tokenizer 等
+    return estimatedTokens, nil
+}
+
+summary.SetTokenCounter(&MyCustomCounter{})
+
+// 创建带 token 阈值检查器的摘要器
+summarizer := summary.NewSummarizer(
+    summaryModel,
+    summary.CheckTokenThreshold(4000),  // 将使用您的自定义计数器
+)
+```
+
+**重要说明：**
+
+- **全局影响**：`SetTokenCounter` 会影响当前进程中所有的 `CheckTokenThreshold` 评估。建议在应用初始化时一次性设置。
+- **默认计数器**：如果不设置，将使用默认配置的 `SimpleTokenCounter`（约每 token 对应 4 个字符）。
+- **使用场景**：
+  - 需要精确估算 token 时使用准确的 tokenizer（如 tiktoken）
+  - 针对特定语言的模型进行调整（中文模型的 token 密度可能不同）
+  - 集成模型特定的计数 API 以获得更好的准确性
+
 **工具调用格式化：**
 
 默认情况下，摘要器会将工具调用和工具结果包含在发送给 LLM 进行总结的对话文本中。默认格式为：

--- a/model/token_tailor.go
+++ b/model/token_tailor.go
@@ -121,7 +121,12 @@ func (c *SimpleTokenCounter) CountTokens(_ context.Context, message Message) (in
 		total += c.countToolCallRunes(toolCall)
 	}
 
-	total = int(float64(total) / c.approxRunesPerToken)
+	runesPerToken := c.approxRunesPerToken
+	if runesPerToken <= 0 {
+		// Fall back to default to avoid division by zero.
+		runesPerToken = defaultApproxRunesPerToken
+	}
+	total = int(float64(total) / runesPerToken)
 
 	// Total should be at least 1 if message is not empty.
 	if isMessageNotEmpty(message) {

--- a/model/token_tailor.go
+++ b/model/token_tailor.go
@@ -15,7 +15,26 @@ import (
 	"unicode/utf8"
 )
 
-const approxRunesPerToken = 4 // heuristic: ~1 token per 4 UTF-8 runes
+// defaultApproxRunesPerToken is the default approximate runes per token heuristic.
+const defaultApproxRunesPerToken = 4.0
+
+type simpleTokenCounterOptions struct {
+	approxRunesPerToken float64
+}
+
+// SimpleTokenCounterOption configures a SimpleTokenCounter.
+type SimpleTokenCounterOption func(*simpleTokenCounterOptions)
+
+// WithApproxRunesPerToken sets the approximate runes per token heuristic.
+// This is a heuristic and may vary across languages and models.
+func WithApproxRunesPerToken(v float64) SimpleTokenCounterOption {
+	return func(o *simpleTokenCounterOptions) {
+		if v <= 0 {
+			return
+		}
+		o.approxRunesPerToken = v
+	}
+}
 
 // TokenTailoringConfig holds custom token tailoring budget parameters.
 // This configuration allows advanced users to fine-tune the token allocation strategy.
@@ -56,12 +75,23 @@ type TailoringStrategy interface {
 }
 
 // SimpleTokenCounter provides a very rough token estimation based on rune length.
-// Heuristic: approximately one token per four UTF-8 runes for text content fields.
-type SimpleTokenCounter struct{}
+// Heuristic: approximately one token per several UTF-8 runes for text fields.
+type SimpleTokenCounter struct {
+	approxRunesPerToken float64
+}
 
-// NewSimpleTokenCounter creates a SimpleTokenCounter with a max token budget.
-func NewSimpleTokenCounter() *SimpleTokenCounter {
-	return &SimpleTokenCounter{}
+// NewSimpleTokenCounter creates a SimpleTokenCounter.
+func NewSimpleTokenCounter(opts ...SimpleTokenCounterOption) *SimpleTokenCounter {
+	o := simpleTokenCounterOptions{
+		approxRunesPerToken: defaultApproxRunesPerToken,
+	}
+	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
+		opt(&o)
+	}
+	return &SimpleTokenCounter{approxRunesPerToken: o.approxRunesPerToken}
 }
 
 // CountTokens estimates tokens for a single message.
@@ -69,24 +99,26 @@ func (c *SimpleTokenCounter) CountTokens(_ context.Context, message Message) (in
 	total := 0
 
 	// Count main content.
-	total += utf8.RuneCountInString(message.Content) / approxRunesPerToken
+	total += utf8.RuneCountInString(message.Content)
 
 	// Count reasoning content if present.
 	if message.ReasoningContent != "" {
-		total += utf8.RuneCountInString(message.ReasoningContent) / approxRunesPerToken
+		total += utf8.RuneCountInString(message.ReasoningContent)
 	}
 
 	// Count text parts in multimodal content.
 	for _, part := range message.ContentParts {
 		if part.Text != nil {
-			total += utf8.RuneCountInString(*part.Text) / approxRunesPerToken
+			total += utf8.RuneCountInString(*part.Text)
 		}
 	}
 
 	// Count tool calls.
 	for _, toolCall := range message.ToolCalls {
-		total += c.countToolCallRunes(toolCall) / approxRunesPerToken
+		total += c.countToolCallRunes(toolCall)
 	}
+
+	total = int(float64(total) / c.approxRunesPerToken)
 
 	// Total should be at least 1 if message is not empty.
 	if isMessageNotEmpty(message) {
@@ -612,8 +644,6 @@ func (s *TailOutStrategy) TailorMessages(ctx context.Context, messages []Message
 	return ensureTailoredWithinBudget(ctx, s.tokenCounter, result, maxTokens)
 }
 
-// binarySearchMaxHeadCount finds the maximum number of head messages that fit with preserved tail.
-
 // calculatePreservedHeadCount calculates the number of preserved head messages.
 // It preserves all consecutive system messages from the beginning.
 func calculatePreservedHeadCount(messages []Message) int {
@@ -637,7 +667,10 @@ func buildPrefixSum(ctx context.Context, tokenCounter TokenCounter, messages []M
 		tokens, err := tokenCounter.CountTokens(ctx, msg)
 		if err != nil {
 			// In case of error, use a fallback estimation.
-			prefixSum[i+1] = prefixSum[i] + utf8.RuneCountInString(msg.Content)/approxRunesPerToken
+			prefixSum[i+1] = prefixSum[i] + int(
+				float64(utf8.RuneCountInString(msg.Content))/
+					defaultApproxRunesPerToken,
+			)
 		} else {
 			prefixSum[i+1] = prefixSum[i] + tokens
 		}

--- a/model/token_tailor_test.go
+++ b/model/token_tailor_test.go
@@ -93,6 +93,41 @@ func TestSimpleTokenCounter_WithApproxRunesPerToken(t *testing.T) {
 	}
 }
 
+func TestSimpleTokenCounter_CountTokens_ApproxRunesPerTokenFallback(t *testing.T) {
+	ctx := context.Background()
+	msg := NewUserMessage("hello")
+
+	baselineCounter := NewSimpleTokenCounter()
+	baselineTokens, err := baselineCounter.CountTokens(ctx, msg)
+	require.NoError(t, err)
+	require.Greater(t, baselineTokens, 0)
+
+	tests := []struct {
+		name                string
+		approxRunesPerToken float64
+	}{
+		{
+			name:                "zero_value_falls_back_to_default",
+			approxRunesPerToken: 0,
+		},
+		{
+			name:                "negative_value_falls_back_to_default",
+			approxRunesPerToken: -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			counter := &SimpleTokenCounter{
+				approxRunesPerToken: tt.approxRunesPerToken,
+			}
+			gotTokens, err := counter.CountTokens(ctx, msg)
+			require.NoError(t, err)
+			assert.Equal(t, baselineTokens, gotTokens)
+		})
+	}
+}
+
 // TestSimpleTokenCounter_CountTokens_DetailedCoverage tests all code paths in CountTokens function.
 func TestSimpleTokenCounter_CountTokens_DetailedCoverage(t *testing.T) {
 	counter := NewSimpleTokenCounter()

--- a/session/summary/checker.go
+++ b/session/summary/checker.go
@@ -10,6 +10,7 @@ package summary
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
 	"trpc.group/trpc-go/trpc-agent-go/event"
@@ -25,11 +26,33 @@ import (
 // When no custom checkers are supplied, a default set is used.
 type Checker func(sess *session.Session) bool
 
-var (
-	// tokenCounter is a shared token counter instance.
-	// model.SimpleTokenCounter is stateless and concurrency-safe.
-	tokenCounter = model.NewSimpleTokenCounter()
-)
+var defaultTokenCounter atomic.Value
+
+func init() {
+	defaultTokenCounter.Store((model.NewSimpleTokenCounter()))
+}
+
+func getTokenCounter() model.TokenCounter {
+	v := defaultTokenCounter.Load()
+	if v == nil {
+		return model.NewSimpleTokenCounter()
+	}
+
+	counter := v.(model.TokenCounter)
+	if counter == nil {
+		return model.NewSimpleTokenCounter()
+	}
+	return counter
+}
+
+// SetTokenCounter sets the default TokenCounter used by summary checkers.
+// This affects all future CheckTokenThreshold evaluations in this process.
+func SetTokenCounter(counter model.TokenCounter) {
+	if counter == nil {
+		counter = model.NewSimpleTokenCounter()
+	}
+	defaultTokenCounter.Store(counter)
+}
 
 // filterDeltaEvents returns events that occurred strictly after the last
 // summarized timestamp stored in session state. If the timestamp is not set
@@ -85,13 +108,14 @@ func CheckTimeThreshold(interval time.Duration) Checker {
 	}
 }
 
+// checkTokenThresholdFromText checks if the token count of the given text exceeds the threshold.
 func checkTokenThresholdFromText(tokenCount int, conversationText string) bool {
 	if conversationText == "" {
 		return false
 	}
 
 	// SimpleTokenCounter.CountTokens currently never returns an error.
-	tokens, _ := tokenCounter.CountTokens(
+	tokens, _ := getTokenCounter().CountTokens(
 		context.Background(),
 		model.Message{Content: conversationText},
 	)


### PR DESCRIPTION
## Summary by Sourcery

使令牌计数启发式可配置，并允许摘要令牌阈值检查使用可插拔的令牌计数器。

New Features:
- 通过选项为 `SimpleTokenCounter` 添加可配置的“每个 token 的近似 rune 数”启发式参数。
- 允许会话摘要令牌阈值检查器使用可配置的默认 `TokenCounter`。

Enhancements:
- 优化 `SimpleTokenCounter` 的实现，在应用启发式除数之前先聚合 rune 计数。
- 在 `TailOutStrategy` 的回退路径中进行令牌计数时，使用安全的默认 `SimpleTokenCounter`。

Tests:
- 增加覆盖 `SimpleTokenCounter` 配置的测试，包括自定义和无效的“每个 token 的近似 rune 数”值。
- 增加测试以验证 `SetTokenCounter` 会影响并且可以重置令牌阈值检查行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make token counting heuristics configurable and allow summary token threshold checks to use a pluggable token counter.

New Features:
- Add a configurable approximate runes-per-token heuristic to SimpleTokenCounter via options.
- Allow the session summary token threshold checker to use a configurable default TokenCounter.

Enhancements:
- Refine SimpleTokenCounter implementation to aggregate rune counts before applying the heuristic divisor.
- Use a safe default SimpleTokenCounter when token counting in TailOutStrategy fallback paths.

Tests:
- Add tests covering SimpleTokenCounter configuration, including custom and invalid approx runes-per-token values.
- Add tests verifying that SetTokenCounter influences and can reset token threshold checking behavior.

</details>