### PR TITLE
model: add context window for OpenAI GPT-5.2

### DIFF
--- a/model/internal/model/model_info.go
+++ b/model/internal/model/model_info.go
@@ -31,6 +31,13 @@ var ModelContextWindows = map[string]int{
 	"o3":         200000,
 	"o4-mini":    200000,
 
+	// OpenAI GPT-5.2
+	"gpt-5.2":           400000,
+	"gpt-5.2-instant":   400000,
+	"gpt-5.2-codex-max": 400000,
+	"gpt-5.2-mini":      400000,
+	"gpt-5.2-nano":      400000,
+
 	// OpenAI GPT-5.1
 	"gpt-5.1":           400000,
 	"gpt-5.1-instant":   400000,

--- a/model/internal/model/model_info_test.go
+++ b/model/internal/model/model_info_test.go
@@ -42,6 +42,16 @@ func TestResolveContextWindow(t *testing.T) {
 			expected:  200000,
 		},
 		{
+			name:      "exact match - GPT-5.2",
+			modelName: "gpt-5.2",
+			expected:  400000,
+		},
+		{
+			name:      "exact match - GPT-5.2-instant",
+			modelName: "gpt-5.2-instant",
+			expected:  400000,
+		},
+		{
 			name:      "case insensitive match",
 			modelName: "GPT-4O",
 			expected:  128000,


### PR DESCRIPTION
- Added context window sizes for OpenAI GPT-5.2 series
- Reference: https://platform.openai.com/docs/models/gpt-5.2

## Summary by Sourcery

为 OpenAI GPT-5.2 模型系列添加上下文窗口配置，并用测试进行覆盖。

新功能：
- 支持解析 OpenAI GPT-5.2 各模型变体的上下文窗口大小，包括 instant、codex-max、mini 和 nano。

测试：
- 扩展上下文窗口解析测试以覆盖 GPT-5.2 和 GPT-5.2-instant 模型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add context window configuration for the OpenAI GPT-5.2 model family and cover it with tests.

New Features:
- Support resolving context window sizes for the OpenAI GPT-5.2 model variants, including instant, codex-max, mini, and nano.

Tests:
- Extend context window resolution tests to cover GPT-5.2 and GPT-5.2-instant models.

</details>