### PR TITLE
docs: fix base path usage

### DIFF
--- a/docs/mkdocs/en/agui.md
+++ b/docs/mkdocs/en/agui.md
@@ -739,7 +739,7 @@ import "trpc.group/trpc-go/trpc-agent-go/server/agui"
 
 server, err := agui.New(
     runner,
-    agui.WithBasePath("/agui"),                // Set the AG-UI prefix route.
+    agui.WithBasePath("/agui/"),               // Set the AG-UI prefix route.
     agui.WithPath("/chat"),                    // Set the real-time conversation route, default is "/".
     agui.WithCancelEnabled(true),              // Enable the cancel route.
     agui.WithCancelPath("/cancel"),            // Set the cancel route, default is "/cancel".

--- a/docs/mkdocs/zh/agui.md
+++ b/docs/mkdocs/zh/agui.md
@@ -748,7 +748,7 @@ import "trpc.group/trpc-go/trpc-agent-go/server/agui"
 
 server, err := agui.New(
     runner,
-    agui.WithBasePath("/agui"),                // 设置 AG-UI 前缀路由
+    agui.WithBasePath("/agui/"),               // 设置 AG-UI 前缀路由
     agui.WithPath("/chat"),                    // 设置实时对话路由，默认为 "/"
     agui.WithCancelEnabled(true),              // 开启取消路由
     agui.WithCancelPath("/cancel"),            // 设置取消路由，默认为 "/cancel"


### PR DESCRIPTION
## Summary by Sourcery

修正英文和中文文档中 AG-UI 基础路径示例，添加末尾斜杠，以提供准确的配置指导。

文档：
- 在英文文档中更新 AG-UI 基础路径示例配置，使用带有末尾斜杠的路径。
- 在中文文档中更新 AG-UI 基础路径示例配置，使用带有末尾斜杠的路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Correct AG-UI base path examples in the English and Chinese documentation to include a trailing slash for accurate configuration guidance.

Documentation:
- Update AG-UI base path in English docs to use a trailing slash in the example configuration.
- Update AG-UI base path in Chinese docs to use a trailing slash in the example configuration.

</details>