### PR TITLE
memory/extractor: add model callbacks to memory extractor

### DIFF
--- a/docs/mkdocs/en/memory.md
+++ b/docs/mkdocs/en/memory.md
@@ -1275,6 +1275,29 @@ memExtractor := extractor.NewExtractor(
 )
 ```
 
+#### Model callbacks (before/after)
+
+The extractor also supports injecting before/after model callbacks via `model.Callbacks` (structured only). This is useful for tracing, request rewriting, or short-circuiting the model call in tests.
+
+```go
+callbacks := model.NewCallbacks().RegisterBeforeModel(
+    func(ctx context.Context, args *model.BeforeModelArgs) (*model.BeforeModelResult, error) {
+        // You can modify args.Request or return CustomResponse.
+        return nil, nil
+    },
+).RegisterAfterModel(
+    func(ctx context.Context, args *model.AfterModelArgs) (*model.AfterModelResult, error) {
+        // You can inspect/override args.Response.
+        return nil, nil
+    },
+)
+
+memExtractor := extractor.NewExtractor(
+    extractorModel,
+    extractor.WithModelCallbacks(callbacks),
+)
+```
+
 #### ExtractionContext
 
 The `ExtractionContext` provides information for checker decisions:

--- a/docs/mkdocs/zh/memory.md
+++ b/docs/mkdocs/zh/memory.md
@@ -1324,6 +1324,29 @@ memExtractor := extractor.NewExtractor(
 )
 ```
 
+#### 模型回调（Before/After Model）
+
+提取器也支持通过 `model.Callbacks` 注入 before/after 回调（仅支持 structured），用于埋点、改写请求，或在测试中短路模型调用。
+
+```go
+callbacks := model.NewCallbacks().RegisterBeforeModel(
+    func(ctx context.Context, args *model.BeforeModelArgs) (*model.BeforeModelResult, error) {
+        // You can modify args.Request or return CustomResponse.
+        return nil, nil
+    },
+).RegisterAfterModel(
+    func(ctx context.Context, args *model.AfterModelArgs) (*model.AfterModelResult, error) {
+        // You can inspect/override args.Response.
+        return nil, nil
+    },
+)
+
+memExtractor := extractor.NewExtractor(
+    extractorModel,
+    extractor.WithModelCallbacks(callbacks),
+)
+```
+
 #### ExtractionContext
 
 `ExtractionContext` 为检查器提供决策所需的上下文信息：


### PR DESCRIPTION
## Summary by Sourcery

为 memory extractor 添加对模型调用前/后的回调支持，以便在抽取过程中拦截和自定义请求/响应。

新特性：
- 通过新的 `WithModelCallbacks` 选项，在 memory extractor 上引入可配置的模型前/后回调。
- 允许「模型前回调」修改请求，或通过自定义的模型响应直接短路抽取流程。
- 允许「模型后回调」检查或覆写模型响应，包括替换错误响应。

增强：
- 扩展 extractor 流程，在模型调用与响应处理的前后运行模型回调，并支持上下文传递。
- 增强测试用 mock model，用于跟踪调用和记录最后一次请求，以验证回调行为。

文档：
- 在英文和中文的 memory 相关文档中记录对模型调用前/后回调的支持，并包含使用示例。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for before/after model callbacks in the memory extractor to allow request/response interception and customization during extraction.

New Features:
- Introduce configurable before/after model callbacks on the memory extractor via a new WithModelCallbacks option.
- Allow before-model callbacks to modify requests or short-circuit extraction with a custom model response.
- Allow after-model callbacks to inspect or override model responses, including replacing error responses.

Enhancements:
- Extend the extractor flow to run before/after model callbacks around model invocation and response handling, including context propagation.
- Enhance the test mock model to track calls and last request for validating callback behavior.

Documentation:
- Document the new before/after model callback support for the memory extractor in both English and Chinese memory documentation, including usage examples.

</details>