### PR TITLE
evaluation: attach ctxmsg container to evaluation context

### DIFF
--- a/ctxmsg/ctxmsg.go
+++ b/ctxmsg/ctxmsg.go
@@ -1,0 +1,128 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+// Package ctxmsg provides a context-attached message container for passing structured data through an execution flow.
+// It currently supports metadata and may be extended with additional fields.
+package ctxmsg
+
+import (
+	"context"
+	"sync"
+)
+
+// ContextKey is the key type used to store message related values in a context.
+type ContextKey string
+
+// ContextKeyMessage is the key used to store the message in a context.
+const ContextKeyMessage = ContextKey("TRPC_AGENT_MESSAGE")
+
+// Msg represents a context-attached container that can carry runtime fields.
+type Msg interface {
+	// Metadata returns the current metadata map.
+	Metadata() MetaData
+	// SetMetadata replaces the message metadata with the provided map.
+	SetMetadata(MetaData)
+}
+
+// EnsureMessage ensures ctx contains a message and returns it.
+func EnsureMessage(ctx context.Context) (context.Context, Msg) {
+	if m, ok := ctx.Value(ContextKeyMessage).(*msg); ok {
+		return ctx, m
+	}
+	return withNewMessage(ctx)
+}
+
+func withNewMessage(ctx context.Context) (context.Context, Msg) {
+	m := msgPool.Get().(*msg)
+	ctx = context.WithValue(ctx, ContextKeyMessage, m)
+	m.context = ctx
+	return ctx, m
+}
+
+// Message returns the message stored in ctx.
+func Message(ctx context.Context) Msg {
+	if m, ok := ctx.Value(ContextKeyMessage).(*msg); ok {
+		return m
+	}
+	return &msg{context: ctx}
+}
+
+// WithCloneMessage attaches a new message to ctx and returns the updated context and message.
+// If ctx already contains a message, its metadata is shallow-cloned into the new message.
+func WithCloneMessage(ctx context.Context) (context.Context, Msg) {
+	newMsg := msgPool.Get().(*msg)
+	if oldMsg, ok := ctx.Value(ContextKeyMessage).(*msg); ok {
+		newMsg.metadata = oldMsg.metadata.Clone()
+	}
+	ctx = context.WithValue(ctx, ContextKeyMessage, newMsg)
+	newMsg.context = ctx
+	return ctx, newMsg
+}
+
+type msg struct {
+	metadata MetaData
+	context  context.Context
+}
+
+var msgPool = sync.Pool{
+	New: func() any {
+		return &msg{}
+	},
+}
+
+// New returns a message from the pool.
+func New() Msg {
+	m := msgPool.Get().(*msg)
+	m.resetDefault()
+	m.metadata = make(MetaData)
+	return m
+}
+
+func (m *msg) resetDefault() {
+	m.metadata = nil
+	m.context = nil
+}
+
+// PutBackMessage returns a message back to the pool.
+func PutBackMessage(sourceMsg Msg) {
+	m, ok := sourceMsg.(*msg)
+	if !ok || m == nil {
+		return
+	}
+	m.resetDefault()
+	msgPool.Put(m)
+}
+
+// MetaData stores message metadata.
+type MetaData map[string][]byte
+
+// Clone returns a shallow copy of the metadata map.
+func (m MetaData) Clone() MetaData {
+	if m == nil {
+		return nil
+	}
+	md := make(MetaData, len(m))
+	for k, v := range m {
+		md[k] = v
+	}
+	return md
+}
+
+// Metadata returns the current metadata map.
+func (m *msg) Metadata() MetaData {
+	if m.metadata == nil {
+		m.metadata = make(MetaData)
+	}
+	return m.metadata
+}
+
+// SetMetadata replaces the message metadata with the provided map.
+func (m *msg) SetMetadata(md MetaData) {
+	m.metadata = md
+}

--- a/ctxmsg/ctxmsg_test.go
+++ b/ctxmsg/ctxmsg_test.go
@@ -1,0 +1,168 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package ctxmsg
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMessageMetadataAndSetMetadata(t *testing.T) {
+	msg := New()
+
+	md := msg.Metadata()
+	assert.NotNil(t, md)
+
+	md["k"] = []byte("v")
+	assert.Contains(t, msg.Metadata(), "k")
+	assert.Equal(t, []byte("v"), msg.Metadata()["k"])
+
+	msg.SetMetadata(MetaData{"k": []byte("v2")})
+	assert.Equal(t, []byte("v2"), msg.Metadata()["k"])
+
+	repl := MetaData{"k": []byte("v3")}
+	msg.SetMetadata(repl)
+	repl["k"] = []byte("v4")
+	assert.Equal(t, []byte("v4"), msg.Metadata()["k"])
+
+	msg.SetMetadata(nil)
+	assert.NotContains(t, msg.Metadata(), "k")
+
+	PutBackMessage(msg)
+}
+
+func TestWithNewMessageAttachesMessage(t *testing.T) {
+	base := context.Background()
+	ctx, m := withNewMessage(base)
+	assert.NotNil(t, ctx.Value(ContextKeyMessage))
+
+	got := Message(ctx)
+	assert.Same(t, m.(*msg), got.(*msg))
+	PutBackMessage(m)
+}
+
+func TestWithCloneMessageCreatesMessageWhenMissing(t *testing.T) {
+	base := context.Background()
+	ctx, m := WithCloneMessage(base)
+	assert.NotNil(t, ctx.Value(ContextKeyMessage))
+	assert.Same(t, m.(*msg), Message(ctx).(*msg))
+	PutBackMessage(m)
+}
+
+func TestWithCloneMessageClonesMetadataWhenPresent(t *testing.T) {
+	base := context.Background()
+	ctx, old := withNewMessage(base)
+	old.Metadata()["a"] = []byte("value")
+
+	ctx2, cloned := WithCloneMessage(ctx)
+	assert.NotNil(t, ctx2.Value(ContextKeyMessage))
+	assert.NotSame(t, old, cloned)
+
+	assert.Equal(t, []byte("value"), cloned.Metadata()["a"])
+
+	old.Metadata()["a"][0] = 'V'
+	assert.Equal(t, old.Metadata()["a"], cloned.Metadata()["a"])
+
+	cloned.Metadata()["new"] = []byte("x")
+	_, ok := old.Metadata()["new"]
+	assert.False(t, ok)
+
+	old.Metadata()["old"] = []byte("y")
+	_, ok = cloned.Metadata()["old"]
+	assert.False(t, ok)
+
+	PutBackMessage(old)
+	PutBackMessage(cloned)
+}
+
+func TestMetaDataClone(t *testing.T) {
+	orig := MetaData{
+		"a": []byte("value"),
+	}
+	clone := orig.Clone()
+	assert.Equal(t, orig["a"], clone["a"])
+
+	orig["a"][0] = 'V'
+	assert.Equal(t, orig["a"], clone["a"])
+
+	clone["b"] = []byte("x")
+	_, ok := orig["b"]
+	assert.False(t, ok)
+}
+
+func TestMetaDataCloneNil(t *testing.T) {
+	var orig MetaData
+	assert.Nil(t, orig.Clone())
+}
+
+func TestMessagePoolClearsMetadata(t *testing.T) {
+	msg := New()
+	msg.Metadata()["k"] = []byte("v")
+	PutBackMessage(msg)
+
+	msg2 := New()
+	_, ok := msg2.Metadata()["k"]
+	assert.False(t, ok)
+	PutBackMessage(msg2)
+}
+
+func TestMessageReturnsExistingMessage(t *testing.T) {
+	base := context.Background()
+	ctx, m := withNewMessage(base)
+	got := Message(ctx)
+	assert.Same(t, m.(*msg), got.(*msg))
+	PutBackMessage(m)
+}
+
+func TestMessageReturnsStandaloneMessageWhenMissing(t *testing.T) {
+	base := context.Background()
+	msg := Message(base)
+	msg.Metadata()["k"] = []byte("v")
+	assert.Equal(t, []byte("v"), msg.Metadata()["k"])
+}
+
+func TestMessageKeepsContextWhenMissing(t *testing.T) {
+	base := context.Background()
+	m := Message(base).(*msg)
+	assert.Equal(t, base, m.context)
+}
+
+func TestEnsureMessageCreatesAndAttachesMessage(t *testing.T) {
+	base := context.Background()
+	ctx, m := EnsureMessage(base)
+	assert.NotNil(t, m)
+	assert.NotNil(t, ctx.Value(ContextKeyMessage))
+	assert.Same(t, m.(*msg), Message(ctx).(*msg))
+	PutBackMessage(m)
+}
+
+func TestEnsureMessageReturnsExistingMessage(t *testing.T) {
+	base := context.Background()
+	ctx, m := withNewMessage(base)
+	ctx2, got := EnsureMessage(ctx)
+	assert.Same(t, ctx, ctx2)
+	assert.Same(t, m.(*msg), got.(*msg))
+	PutBackMessage(m)
+}
+
+type stubMsg struct{}
+
+func (stubMsg) Metadata() MetaData {
+	return nil
+}
+
+func (stubMsg) SetMetadata(MetaData) {}
+
+func TestPutBackMessageIgnoresNonPoolMessages(t *testing.T) {
+	assert.NotPanics(t, func() { PutBackMessage(stubMsg{}) })
+	assert.NotPanics(t, func() { PutBackMessage(nil) })
+}

--- a/evaluation/evaluation.go
+++ b/evaluation/evaluation.go
@@ -17,6 +17,7 @@ import (
 	"sort"
 	"time"
 
+	"trpc.group/trpc-go/trpc-agent-go/ctxmsg"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/registry"
@@ -116,6 +117,8 @@ func (a *agentEvaluator) Evaluate(ctx context.Context, evalSetID string) (*Evalu
 	if evalSetID == "" {
 		return nil, errors.New("eval set id is not configured")
 	}
+	ctx, msg := ctxmsg.WithCloneMessage(ctx)
+	defer ctxmsg.PutBackMessage(msg)
 	start := time.Now()
 	// Gather per-case results.
 	evalCases, evalSetResult, err := a.collectCaseResults(ctx, evalSetID)

--- a/evaluation/evaluation_test.go
+++ b/evaluation/evaluation_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/ctxmsg"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
 	evalresultinmemory "trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult/inmemory"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
@@ -94,6 +95,36 @@ func (c *countingService) Evaluate(ctx context.Context, req *service.EvaluateReq
 
 func (c *countingService) Close() error {
 	atomic.AddInt32(&c.closed, 1)
+	return nil
+}
+
+type messageProbeService struct {
+	inferenceMessage ctxmsg.Msg
+	evaluateMessage  ctxmsg.Msg
+	evaluateHasKey   bool
+}
+
+func (s *messageProbeService) Inference(ctx context.Context, req *service.InferenceRequest) ([]*service.InferenceResult, error) {
+	msg := ctxmsg.Message(ctx)
+	s.inferenceMessage = msg
+	md := msg.Metadata()
+	md["probe"] = []byte("value")
+	msg.SetMetadata(md)
+	return []*service.InferenceResult{}, nil
+}
+
+func (s *messageProbeService) Evaluate(ctx context.Context, req *service.EvaluateRequest) (*service.EvalSetRunResult, error) {
+	msg := ctxmsg.Message(ctx)
+	s.evaluateMessage = msg
+	_, s.evaluateHasKey = msg.Metadata()["probe"]
+	return &service.EvalSetRunResult{
+		AppName:         req.AppName,
+		EvalSetID:       req.EvalSetID,
+		EvalCaseResults: []*evalresult.EvalCaseResult{},
+	}, nil
+}
+
+func (s *messageProbeService) Close() error {
 	return nil
 }
 
@@ -230,6 +261,26 @@ func TestNewAgentEvaluatorValidation(t *testing.T) {
 	assert.True(t, ok)
 	assert.NotNil(t, impl.evalService)
 	assert.NoError(t, ae.Close())
+}
+
+func TestAgentEvaluatorEvaluateAttachesMessage(t *testing.T) {
+	ctx := context.Background()
+	appName := "app"
+
+	svc := &messageProbeService{}
+	ae := &agentEvaluator{
+		appName:           appName,
+		evalService:       svc,
+		metricManager:     metricinmemory.New(),
+		evalResultManager: evalresultinmemory.New(),
+		numRuns:           1,
+	}
+
+	_, err := ae.Evaluate(ctx, "set")
+	assert.NoError(t, err)
+	assert.NotNil(t, svc.inferenceMessage)
+	assert.Same(t, svc.inferenceMessage, svc.evaluateMessage)
+	assert.True(t, svc.evaluateHasKey)
 }
 
 func TestNewAgentEvaluatorWithCustomService(t *testing.T) {


### PR DESCRIPTION
Introduce ctxmsg, a context-attached container for passing structured metadata through an execution flow, and wire it into evaluation so the same message instance is shared across inference and evaluate phases without relying on context mutation.