### PR TITLE
{evaluation, docs}: support parallel evaluation across cases

### DIFF
--- a/evaluation/evaluation.go
+++ b/evaluation/evaluation.go
@@ -58,7 +58,7 @@ func New(appName string, runner runner.Runner, opt ...Option) (AgentEvaluator, e
 	if a.numRuns <= 0 {
 		return nil, errors.New("num runs must be greater than 0")
 	}
-	if opts.evalCaseParallelInferenceEnabled && opts.evalCaseParallelism <= 0 {
+	if (opts.evalCaseParallelInferenceEnabled || opts.evalCaseParallelEvaluationEnabled) && opts.evalCaseParallelism <= 0 {
 		return nil, errors.New("eval case parallelism must be greater than 0")
 	}
 	if a.evalResultManager == nil {
@@ -73,6 +73,7 @@ func New(appName string, runner runner.Runner, opt ...Option) (AgentEvaluator, e
 			service.WithCallbacks(opts.callbacks),
 			service.WithEvalCaseParallelism(opts.evalCaseParallelism),
 			service.WithEvalCaseParallelInferenceEnabled(opts.evalCaseParallelInferenceEnabled),
+			service.WithEvalCaseParallelEvaluationEnabled(opts.evalCaseParallelEvaluationEnabled),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("create eval service: %w", err)

--- a/evaluation/evaluation_test.go
+++ b/evaluation/evaluation_test.go
@@ -249,6 +249,14 @@ func TestNewAgentEvaluatorValidation(t *testing.T) {
 	)
 	assert.Error(t, err)
 
+	_, err = New(
+		"app",
+		stubRunner{},
+		WithEvalCaseParallelEvaluationEnabled(true),
+		WithEvalCaseParallelism(0),
+	)
+	assert.Error(t, err)
+
 	_, err = New("app", stubRunner{}, WithEvalResultManager(nil))
 	assert.Error(t, err)
 	if err != nil {

--- a/evaluation/options.go
+++ b/evaluation/options.go
@@ -27,28 +27,30 @@ const defaultNumRuns = 1
 
 // options holds the configuration options for the evaluation.
 type options struct {
-	evalSetManager                   evalset.Manager
-	evalResultManager                evalresult.Manager
-	metricManager                    metric.Manager
-	registry                         registry.Registry
-	evalService                      service.Service
-	callbacks                        *service.Callbacks
-	numRuns                          int
-	evalCaseParallelism              int
-	evalCaseParallelInferenceEnabled bool
+	evalSetManager                    evalset.Manager
+	evalResultManager                 evalresult.Manager
+	metricManager                     metric.Manager
+	registry                          registry.Registry
+	evalService                       service.Service
+	callbacks                         *service.Callbacks
+	numRuns                           int
+	evalCaseParallelism               int
+	evalCaseParallelInferenceEnabled  bool
+	evalCaseParallelEvaluationEnabled bool
 }
 
 // newOptions creates a new options with the default values.
 func newOptions(opt ...Option) *options {
 	// Initialize options with default values.
 	opts := &options{
-		numRuns:                          defaultNumRuns,
-		evalSetManager:                   evalsetinmemory.New(),
-		evalResultManager:                evalresultinmemory.New(),
-		metricManager:                    metricinmemory.New(),
-		registry:                         registry.New(),
-		evalCaseParallelism:              runtime.GOMAXPROCS(0),
-		evalCaseParallelInferenceEnabled: false,
+		numRuns:                           defaultNumRuns,
+		evalSetManager:                    evalsetinmemory.New(),
+		evalResultManager:                 evalresultinmemory.New(),
+		metricManager:                     metricinmemory.New(),
+		registry:                          registry.New(),
+		evalCaseParallelism:               runtime.GOMAXPROCS(0),
+		evalCaseParallelInferenceEnabled:  false,
+		evalCaseParallelEvaluationEnabled: false,
 	}
 	// Apply user options.
 	for _, o := range opt {
@@ -109,7 +111,7 @@ func WithNumRuns(numRuns int) Option {
 	}
 }
 
-// WithEvalCaseParallelism sets the maximum number of eval cases inferred in parallel.
+// WithEvalCaseParallelism sets the maximum number of eval cases processed in parallel.
 func WithEvalCaseParallelism(parallelism int) Option {
 	return func(o *options) {
 		o.evalCaseParallelism = parallelism
@@ -120,5 +122,12 @@ func WithEvalCaseParallelism(parallelism int) Option {
 func WithEvalCaseParallelInferenceEnabled(enabled bool) Option {
 	return func(o *options) {
 		o.evalCaseParallelInferenceEnabled = enabled
+	}
+}
+
+// WithEvalCaseParallelEvaluationEnabled enables or disables parallel evaluation across eval cases.
+func WithEvalCaseParallelEvaluationEnabled(enabled bool) Option {
+	return func(o *options) {
+		o.evalCaseParallelEvaluationEnabled = enabled
 	}
 }

--- a/evaluation/options_test.go
+++ b/evaluation/options_test.go
@@ -49,6 +49,7 @@ func TestNewOptionsDefaults(t *testing.T) {
 	assert.Nil(t, opts.callbacks)
 	assert.Equal(t, runtime.GOMAXPROCS(0), opts.evalCaseParallelism)
 	assert.False(t, opts.evalCaseParallelInferenceEnabled)
+	assert.False(t, opts.evalCaseParallelEvaluationEnabled)
 }
 
 func TestWithEvalSetManager(t *testing.T) {
@@ -106,4 +107,9 @@ func TestWithEvalCaseParallelism(t *testing.T) {
 func TestWithEvalCaseParallelInferenceEnabled(t *testing.T) {
 	opts := newOptions(WithEvalCaseParallelInferenceEnabled(true))
 	assert.True(t, opts.evalCaseParallelInferenceEnabled)
+}
+
+func TestWithEvalCaseParallelEvaluationEnabled(t *testing.T) {
+	opts := newOptions(WithEvalCaseParallelEvaluationEnabled(true))
+	assert.True(t, opts.evalCaseParallelEvaluationEnabled)
 }

--- a/evaluation/service/local/local.go
+++ b/evaluation/service/local/local.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/panjf2000/ants/v2"
@@ -36,15 +37,17 @@ const reasonSeparator = ";"
 
 // local is a local implementation of service.Service.
 type local struct {
-	runner                           runner.Runner
-	evalSetManager                   evalset.Manager
-	evalResultManager                evalresult.Manager
-	registry                         registry.Registry
-	sessionIDSupplier                func(ctx context.Context) string
-	callbacks                        *service.Callbacks
-	evalCaseParallelism              int
-	evalCaseParallelInferenceEnabled bool
-	evalCaseInferencePool            *ants.PoolWithFunc
+	runner                            runner.Runner
+	evalSetManager                    evalset.Manager
+	evalResultManager                 evalresult.Manager
+	registry                          registry.Registry
+	sessionIDSupplier                 func(ctx context.Context) string
+	callbacks                         *service.Callbacks
+	evalCaseParallelism               int
+	evalCaseParallelInferenceEnabled  bool
+	evalCaseParallelEvaluationEnabled bool
+	evalCaseInferencePool             *ants.PoolWithFunc
+	evalCaseEvaluationPool            *ants.PoolWithFunc
 }
 
 // New returns a new local evaluation service.
@@ -54,7 +57,7 @@ func New(runner runner.Runner, opt ...service.Option) (service.Service, error) {
 		return nil, errors.New("runner is nil")
 	}
 	opts := service.NewOptions(opt...)
-	if opts.EvalCaseParallelInferenceEnabled && opts.EvalCaseParallelism <= 0 {
+	if (opts.EvalCaseParallelInferenceEnabled || opts.EvalCaseParallelEvaluationEnabled) && opts.EvalCaseParallelism <= 0 {
 		return nil, errors.New("eval case parallelism must be greater than 0")
 	}
 	if opts.EvalSetManager == nil {
@@ -70,14 +73,15 @@ func New(runner runner.Runner, opt ...service.Option) (service.Service, error) {
 		return nil, errors.New("session id supplier is nil")
 	}
 	service := &local{
-		runner:                           runner,
-		evalSetManager:                   opts.EvalSetManager,
-		evalResultManager:                opts.EvalResultManager,
-		registry:                         opts.Registry,
-		sessionIDSupplier:                opts.SessionIDSupplier,
-		callbacks:                        opts.Callbacks,
-		evalCaseParallelism:              opts.EvalCaseParallelism,
-		evalCaseParallelInferenceEnabled: opts.EvalCaseParallelInferenceEnabled,
+		runner:                            runner,
+		evalSetManager:                    opts.EvalSetManager,
+		evalResultManager:                 opts.EvalResultManager,
+		registry:                          opts.Registry,
+		sessionIDSupplier:                 opts.SessionIDSupplier,
+		callbacks:                         opts.Callbacks,
+		evalCaseParallelism:               opts.EvalCaseParallelism,
+		evalCaseParallelInferenceEnabled:  opts.EvalCaseParallelInferenceEnabled,
+		evalCaseParallelEvaluationEnabled: opts.EvalCaseParallelEvaluationEnabled,
 	}
 	if service.evalCaseParallelInferenceEnabled {
 		pool, err := createEvalCaseInferencePool(service.evalCaseParallelism)
@@ -86,6 +90,13 @@ func New(runner runner.Runner, opt ...service.Option) (service.Service, error) {
 		}
 		service.evalCaseInferencePool = pool
 	}
+	if service.evalCaseParallelEvaluationEnabled {
+		pool, err := createEvalCaseEvaluationPool(service.evalCaseParallelism)
+		if err != nil {
+			return nil, fmt.Errorf("create eval case evaluation pool: %w", err)
+		}
+		service.evalCaseEvaluationPool = pool
+	}
 	return service, nil
 }
 
@@ -93,6 +104,9 @@ func New(runner runner.Runner, opt ...service.Option) (service.Service, error) {
 func (s *local) Close() error {
 	if s.evalCaseInferencePool != nil {
 		s.evalCaseInferencePool.Release()
+	}
+	if s.evalCaseEvaluationPool != nil {
+		s.evalCaseEvaluationPool.Release()
 	}
 	return nil
 }
@@ -189,8 +203,61 @@ func (s *local) Evaluate(ctx context.Context, req *service.EvaluateRequest) (run
 			err = afterErr
 		}
 	}()
-	evalCaseResults := make([]*evalresult.EvalCaseResult, 0, len(req.InferenceResults))
-	for _, inferenceResult := range req.InferenceResults {
+	evalCaseResults, err := s.evaluateCaseResults(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("evaluate case results (app=%s, evalSetID=%s): %w", req.AppName, req.EvalSetID, err)
+	}
+	runResult = &service.EvalSetRunResult{
+		AppName:         req.AppName,
+		EvalSetID:       req.EvalSetID,
+		EvalCaseResults: evalCaseResults,
+	}
+	return runResult, nil
+}
+
+func (s *local) evaluateCaseResults(ctx context.Context, req *service.EvaluateRequest) ([]*evalresult.EvalCaseResult, error) {
+	if s.evalCaseParallelEvaluationEnabled {
+		return s.evaluateCaseResultsParallel(ctx, req)
+	}
+	return s.evaluateCaseResultsSerial(ctx, req)
+}
+
+func (s *local) evaluateCaseResultsParallel(ctx context.Context, req *service.EvaluateRequest) ([]*evalresult.EvalCaseResult, error) {
+	results := make([]*evalresult.EvalCaseResult, len(req.InferenceResults))
+	evalErrors := make([]error, len(req.InferenceResults))
+	var wg sync.WaitGroup
+	for idx, inferenceResult := range req.InferenceResults {
+		wg.Add(1)
+		param := evalCaseEvaluationParamPool.Get().(*evalCaseEvaluationParam)
+		param.idx = idx
+		param.ctx = ctx
+		param.req = req
+		param.inferenceResult = inferenceResult
+		param.svc = s
+		param.results = results
+		param.errs = evalErrors
+		param.wg = &wg
+		if err := s.evalCaseEvaluationPool.Invoke(param); err != nil {
+			wg.Done()
+			evalCaseID := ""
+			if inferenceResult != nil {
+				evalCaseID = inferenceResult.EvalCaseID
+			}
+			evalErrors[idx] = fmt.Errorf("submit evaluation task for eval case %s: %w", evalCaseID, err)
+			param.reset()
+			evalCaseEvaluationParamPool.Put(param)
+		}
+	}
+	wg.Wait()
+	if err := errors.Join(evalErrors...); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (s *local) evaluateCaseResultsSerial(ctx context.Context, req *service.EvaluateRequest) ([]*evalresult.EvalCaseResult, error) {
+	results := make([]*evalresult.EvalCaseResult, len(req.InferenceResults))
+	for idx, inferenceResult := range req.InferenceResults {
 		caseResult, err := s.evaluateCase(ctx, req, inferenceResult)
 		if err != nil {
 			evalCaseID := ""
@@ -200,14 +267,9 @@ func (s *local) Evaluate(ctx context.Context, req *service.EvaluateRequest) (run
 			return nil, fmt.Errorf("evaluate case (app=%s, evalSetID=%s, evalCaseID=%s): %w",
 				req.AppName, req.EvalSetID, evalCaseID, err)
 		}
-		evalCaseResults = append(evalCaseResults, caseResult)
+		results[idx] = caseResult
 	}
-	runResult = &service.EvalSetRunResult{
-		AppName:         req.AppName,
-		EvalSetID:       req.EvalSetID,
-		EvalCaseResults: evalCaseResults,
-	}
-	return runResult, nil
+	return results, nil
 }
 
 func (s *local) evaluateCase(ctx context.Context, req *service.EvaluateRequest, inferenceResult *service.InferenceResult) (result *evalresult.EvalCaseResult, err error) {

--- a/evaluation/service/local/pool.go
+++ b/evaluation/service/local/pool.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 
 	"github.com/panjf2000/ants/v2"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/service"
 )
@@ -63,6 +64,66 @@ func createEvalCaseInferencePool(size int) (*ants.PoolWithFunc, error) {
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create eval case inference pool: %w", err)
+	}
+	return pool, nil
+}
+
+type evalCaseEvaluationParam struct {
+	idx             int
+	ctx             context.Context
+	req             *service.EvaluateRequest
+	inferenceResult *service.InferenceResult
+	svc             *local
+	results         []*evalresult.EvalCaseResult
+	errs            []error
+	wg              *sync.WaitGroup
+}
+
+func (p *evalCaseEvaluationParam) reset() {
+	p.idx = 0
+	p.ctx = nil
+	p.req = nil
+	p.inferenceResult = nil
+	p.svc = nil
+	p.results = nil
+	p.errs = nil
+	p.wg = nil
+}
+
+var evalCaseEvaluationParamPool = &sync.Pool{
+	New: func() any { return new(evalCaseEvaluationParam) },
+}
+
+func createEvalCaseEvaluationPool(size int) (*ants.PoolWithFunc, error) {
+	if size <= 0 {
+		return nil, errors.New("pool size must be greater than 0")
+	}
+	pool, err := ants.NewPoolWithFunc(size, func(args any) {
+		param, ok := args.(*evalCaseEvaluationParam)
+		if !ok {
+			panic("eval case evaluation pool args type error")
+		}
+		wg := param.wg
+		defer func() {
+			wg.Done()
+			param.reset()
+			evalCaseEvaluationParamPool.Put(param)
+		}()
+		caseResult, err := param.svc.evaluateCase(param.ctx, param.req, param.inferenceResult)
+		if err != nil {
+			evalCaseID := ""
+			if param.inferenceResult != nil {
+				evalCaseID = param.inferenceResult.EvalCaseID
+			}
+			err = fmt.Errorf("evaluate case (app=%s, evalSetID=%s, evalCaseID=%s): %w",
+				param.req.AppName, param.req.EvalSetID, evalCaseID, err)
+			param.errs[param.idx] = err
+			return
+		}
+		param.results[param.idx] = caseResult
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create eval case evaluation pool: %w", err)
 	}
 	return pool, nil
 }

--- a/evaluation/service/options.go
+++ b/evaluation/service/options.go
@@ -23,13 +23,14 @@ import (
 
 // Options holds the options for the evaluation service.
 type Options struct {
-	EvalSetManager                   evalset.Manager                  // EvalSetManager is used to store and retrieve eval set.
-	EvalResultManager                evalresult.Manager               // EvalResultManager is used to store and retrieve eval results.
-	Registry                         registry.Registry                // Registry is used to store and retrieve evaluator.
-	SessionIDSupplier                func(ctx context.Context) string // SessionIDSupplier is used to generate session IDs.
-	Callbacks                        *Callbacks                       // Callbacks holds evaluation callbacks.
-	EvalCaseParallelism              int                              // EvalCaseParallelism controls concurrent inference across eval cases.
-	EvalCaseParallelInferenceEnabled bool                             // EvalCaseParallelInferenceEnabled toggles parallel inference across eval cases.
+	EvalSetManager                    evalset.Manager                  // EvalSetManager is used to store and retrieve eval set.
+	EvalResultManager                 evalresult.Manager               // EvalResultManager is used to store and retrieve eval results.
+	Registry                          registry.Registry                // Registry is used to store and retrieve evaluator.
+	SessionIDSupplier                 func(ctx context.Context) string // SessionIDSupplier is used to generate session IDs.
+	Callbacks                         *Callbacks                       // Callbacks holds evaluation callbacks.
+	EvalCaseParallelism               int                              // EvalCaseParallelism controls concurrent eval case processing.
+	EvalCaseParallelInferenceEnabled  bool                             // EvalCaseParallelInferenceEnabled toggles parallel inference across eval cases.
+	EvalCaseParallelEvaluationEnabled bool                             // EvalCaseParallelEvaluationEnabled toggles parallel evaluation across eval cases.
 }
 
 // Option defines a function type for configuring the evaluation service.
@@ -44,8 +45,9 @@ func NewOptions(opt ...Option) *Options {
 		SessionIDSupplier: func(ctx context.Context) string {
 			return uuid.New().String()
 		},
-		EvalCaseParallelism:              runtime.GOMAXPROCS(0),
-		EvalCaseParallelInferenceEnabled: false,
+		EvalCaseParallelism:               runtime.GOMAXPROCS(0),
+		EvalCaseParallelInferenceEnabled:  false,
+		EvalCaseParallelEvaluationEnabled: false,
 	}
 	for _, o := range opt {
 		o(opts)
@@ -92,7 +94,7 @@ func WithCallbacks(c *Callbacks) Option {
 	}
 }
 
-// WithEvalCaseParallelism sets the maximum number of eval cases inferred in parallel.
+// WithEvalCaseParallelism sets the maximum number of eval cases processed in parallel.
 func WithEvalCaseParallelism(parallelism int) Option {
 	return func(o *Options) {
 		o.EvalCaseParallelism = parallelism
@@ -103,5 +105,12 @@ func WithEvalCaseParallelism(parallelism int) Option {
 func WithEvalCaseParallelInferenceEnabled(enabled bool) Option {
 	return func(o *Options) {
 		o.EvalCaseParallelInferenceEnabled = enabled
+	}
+}
+
+// WithEvalCaseParallelEvaluationEnabled enables or disables parallel evaluation across eval cases.
+func WithEvalCaseParallelEvaluationEnabled(enabled bool) Option {
+	return func(o *Options) {
+		o.EvalCaseParallelEvaluationEnabled = enabled
 	}
 }

--- a/evaluation/service/options_test.go
+++ b/evaluation/service/options_test.go
@@ -31,6 +31,7 @@ func TestNewOptionsDefaults(t *testing.T) {
 	assert.Nil(t, opts.Callbacks)
 	assert.Equal(t, runtime.GOMAXPROCS(0), opts.EvalCaseParallelism)
 	assert.False(t, opts.EvalCaseParallelInferenceEnabled)
+	assert.False(t, opts.EvalCaseParallelEvaluationEnabled)
 
 	sessionID := opts.SessionIDSupplier(context.Background())
 	assert.NotEmpty(t, sessionID)
@@ -85,4 +86,9 @@ func TestWithEvalCaseParallelism(t *testing.T) {
 func TestWithEvalCaseParallelInferenceEnabled(t *testing.T) {
 	opts := NewOptions(WithEvalCaseParallelInferenceEnabled(true))
 	assert.True(t, opts.EvalCaseParallelInferenceEnabled)
+}
+
+func TestWithEvalCaseParallelEvaluationEnabled(t *testing.T) {
+	opts := NewOptions(WithEvalCaseParallelEvaluationEnabled(true))
+	assert.True(t, opts.EvalCaseParallelEvaluationEnabled)
 }


### PR DESCRIPTION
Add EvalCase-level parallel evaluation to the local evaluation service via a new option, backed by an ants worker pool, while preserving case result order and aggregating per-case errors before returning; documentation is updated accordingly.

## Summary by Sourcery

为本地评估服务新增可配置的 EvalCase 级并行评估能力，同时保持结果顺序并聚合每个用例的错误，并为新行为编写文档。

新功能：
- 在评估和服务配置 API 中新增选项，用于开启跨 eval case 的并行评估。
- 在本地评估服务中创建基于 worker pool 的并行评估路径，使多个 eval case 可以并发处理，同时保持结果与输入顺序一致。

增强改进：
- 当启用并行推理或并行评估任一项时，对 eval case 并行度配置进行校验。
- 明确说明 eval case 并行度控制的是整体 eval case 的处理过程，而不仅仅是推理阶段，并确保在文档中说明推理阶段和评估阶段回调的并发语义。

文档：
- 更新英文和中文评估文档，描述 EvalCase 级并行评估、配置示例、结果顺序保证以及评估回调的并发注意事项。

测试：
- 扩展单元测试，覆盖默认配置、并行评估配置的校验、worker pool 的创建、结果排序、错误聚合，以及并行评估相关的新配置标志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable EvalCase-level parallel evaluation to the local evaluation service while preserving result ordering and aggregating per-case errors, and document the new behavior.

New Features:
- Introduce an option to enable parallel evaluation across eval cases in the evaluation and service options APIs.
- Create a worker-pool-backed parallel evaluation path in the local evaluation service that processes eval cases concurrently while maintaining input order of results.

Enhancements:
- Validate eval case parallelism whenever either parallel inference or parallel evaluation is enabled.
- Clarify that eval case parallelism controls overall eval case processing, not just inference, and ensure callback concurrency semantics are documented for both inference and evaluation phases.

Documentation:
- Update English and Chinese evaluation documentation to describe EvalCase-level parallel evaluation, configuration examples, ordering guarantees, and concurrency considerations for evaluation callbacks.

Tests:
- Extend unit tests to cover default options, validation for parallel evaluation configuration, worker pool creation, result ordering, error aggregation, and new option flags for parallel evaluation.

</details>