### PR TITLE
telemery: track prompt cache tokens in metrics and traces

### DIFF
--- a/internal/telemetry/metric_test.go
+++ b/internal/telemetry/metric_test.go
@@ -199,6 +199,11 @@ func TestChatMetricsTracker_TrackResponse(t *testing.T) {
 		Usage: &model.Usage{
 			PromptTokens:     10,
 			CompletionTokens: 5,
+			PromptTokensDetails: model.PromptTokensDetails{
+				CachedTokens:        7,
+				CacheReadTokens:     11,
+				CacheCreationTokens: 13,
+			},
 		},
 	}
 
@@ -221,12 +226,26 @@ func TestChatMetricsTracker_TrackResponse(t *testing.T) {
 	if tracker.totalCompletionTokens != 5 {
 		t.Errorf("expected totalCompletionTokens=5, got %d", tracker.totalCompletionTokens)
 	}
+	if tracker.totalPromptCachedTokens != 7 {
+		t.Errorf("expected totalPromptCachedTokens=7, got %d", tracker.totalPromptCachedTokens)
+	}
+	if tracker.totalPromptCacheReadTokens != 11 {
+		t.Errorf("expected totalPromptCacheReadTokens=11, got %d", tracker.totalPromptCacheReadTokens)
+	}
+	if tracker.totalPromptCacheCreationTokens != 13 {
+		t.Errorf("expected totalPromptCacheCreationTokens=13, got %d", tracker.totalPromptCacheCreationTokens)
+	}
 
 	// Second response
 	response2 := &model.Response{
 		Usage: &model.Usage{
 			PromptTokens:     0,
 			CompletionTokens: 3,
+			PromptTokensDetails: model.PromptTokensDetails{
+				CachedTokens:        2,
+				CacheReadTokens:     5,
+				CacheCreationTokens: 8,
+			},
 		},
 	}
 	firstTokenDuration := tracker.firstTokenTimeDuration
@@ -240,6 +259,15 @@ func TestChatMetricsTracker_TrackResponse(t *testing.T) {
 	}
 	if tracker.totalCompletionTokens != 3 {
 		t.Errorf("expected totalCompletionTokens=3, got %d", tracker.totalCompletionTokens)
+	}
+	if tracker.totalPromptCachedTokens != 2 {
+		t.Errorf("expected totalPromptCachedTokens=2, got %d", tracker.totalPromptCachedTokens)
+	}
+	if tracker.totalPromptCacheReadTokens != 5 {
+		t.Errorf("expected totalPromptCacheReadTokens=5, got %d", tracker.totalPromptCacheReadTokens)
+	}
+	if tracker.totalPromptCacheCreationTokens != 8 {
+		t.Errorf("expected totalPromptCacheCreationTokens=8, got %d", tracker.totalPromptCacheCreationTokens)
 	}
 }
 
@@ -265,6 +293,15 @@ func TestChatMetricsTracker_TrackResponse_NilUsage(t *testing.T) {
 	}
 	if tracker.totalCompletionTokens != 0 {
 		t.Errorf("expected totalCompletionTokens=0, got %d", tracker.totalCompletionTokens)
+	}
+	if tracker.totalPromptCachedTokens != 0 {
+		t.Errorf("expected totalPromptCachedTokens=0, got %d", tracker.totalPromptCachedTokens)
+	}
+	if tracker.totalPromptCacheReadTokens != 0 {
+		t.Errorf("expected totalPromptCacheReadTokens=0, got %d", tracker.totalPromptCacheReadTokens)
+	}
+	if tracker.totalPromptCacheCreationTokens != 0 {
+		t.Errorf("expected totalPromptCacheCreationTokens=0, got %d", tracker.totalPromptCacheCreationTokens)
 	}
 }
 

--- a/internal/telemetry/trace.go
+++ b/internal/telemetry/trace.go
@@ -159,31 +159,34 @@ var (
 	KeyGenAIOperationName = semconvtrace.KeyGenAIOperationName
 	KeyGenAISystem        = semconvtrace.KeyGenAISystem
 
-	KeyGenAIRequestModel            = semconvtrace.KeyGenAIRequestModel
-	KeyGenAIRequestIsStream         = semconvtrace.KeyGenAIRequestIsStream
-	KeyGenAIRequestChoiceCount      = semconvtrace.KeyGenAIRequestChoiceCount
-	KeyGenAIInputMessages           = semconvtrace.KeyGenAIInputMessages
-	KeyGenAIOutputMessages          = semconvtrace.KeyGenAIOutputMessages
-	KeyGenAIAgentName               = semconvtrace.KeyGenAIAgentName
-	KeyGenAIConversationID          = semconvtrace.KeyGenAIConversationID
-	KeyGenAIUsageOutputTokens       = semconvtrace.KeyGenAIUsageOutputTokens
-	KeyGenAIUsageInputTokens        = semconvtrace.KeyGenAIUsageInputTokens
-	KeyGenAIProviderName            = semconvtrace.KeyGenAIProviderName
-	KeyGenAIAgentDescription        = semconvtrace.KeyGenAIAgentDescription
-	KeyGenAIResponseFinishReasons   = semconvtrace.KeyGenAIResponseFinishReasons
-	KeyGenAIResponseID              = semconvtrace.KeyGenAIResponseID
-	KeyGenAIResponseModel           = semconvtrace.KeyGenAIResponseModel
-	KeyGenAIRequestStopSequences    = semconvtrace.KeyGenAIRequestStopSequences
-	KeyGenAIRequestFrequencyPenalty = semconvtrace.KeyGenAIRequestFrequencyPenalty
-	KeyGenAIRequestMaxTokens        = semconvtrace.KeyGenAIRequestMaxTokens
-	KeyGenAIRequestPresencePenalty  = semconvtrace.KeyGenAIRequestPresencePenalty
-	KeyGenAIRequestTemperature      = semconvtrace.KeyGenAIRequestTemperature
-	KeyGenAIRequestTopP             = semconvtrace.KeyGenAIRequestTopP
-	KeyGenAISystemInstructions      = semconvtrace.KeyGenAISystemInstructions
-	KeyGenAITokenType               = semconvtrace.KeyGenAITokenType
-	KeyGenAITaskType                = semconvtrace.KeyGenAITaskType
-	KeyGenAIRequestThinkingEnabled  = semconvtrace.KeyGenAIRequestThinkingEnabled
-	KeyGenAIRequestToolDefinitions  = "gen_ai.request.tool.definitions"
+	KeyGenAIRequestModel                  = semconvtrace.KeyGenAIRequestModel
+	KeyGenAIRequestIsStream               = semconvtrace.KeyGenAIRequestIsStream
+	KeyGenAIRequestChoiceCount            = semconvtrace.KeyGenAIRequestChoiceCount
+	KeyGenAIInputMessages                 = semconvtrace.KeyGenAIInputMessages
+	KeyGenAIOutputMessages                = semconvtrace.KeyGenAIOutputMessages
+	KeyGenAIAgentName                     = semconvtrace.KeyGenAIAgentName
+	KeyGenAIConversationID                = semconvtrace.KeyGenAIConversationID
+	KeyGenAIUsageOutputTokens             = semconvtrace.KeyGenAIUsageOutputTokens
+	KeyGenAIUsageInputTokens              = semconvtrace.KeyGenAIUsageInputTokens
+	KeyGenAIUsageInputTokensCached        = semconvtrace.KeyGenAIUsageInputTokensCached
+	KeyGenAIUsageInputTokensCacheRead     = semconvtrace.KeyGenAIUsageInputTokensCacheRead
+	KeyGenAIUsageInputTokensCacheCreation = semconvtrace.KeyGenAIUsageInputTokensCacheCreation
+	KeyGenAIProviderName                  = semconvtrace.KeyGenAIProviderName
+	KeyGenAIAgentDescription              = semconvtrace.KeyGenAIAgentDescription
+	KeyGenAIResponseFinishReasons         = semconvtrace.KeyGenAIResponseFinishReasons
+	KeyGenAIResponseID                    = semconvtrace.KeyGenAIResponseID
+	KeyGenAIResponseModel                 = semconvtrace.KeyGenAIResponseModel
+	KeyGenAIRequestStopSequences          = semconvtrace.KeyGenAIRequestStopSequences
+	KeyGenAIRequestFrequencyPenalty       = semconvtrace.KeyGenAIRequestFrequencyPenalty
+	KeyGenAIRequestMaxTokens              = semconvtrace.KeyGenAIRequestMaxTokens
+	KeyGenAIRequestPresencePenalty        = semconvtrace.KeyGenAIRequestPresencePenalty
+	KeyGenAIRequestTemperature            = semconvtrace.KeyGenAIRequestTemperature
+	KeyGenAIRequestTopP                   = semconvtrace.KeyGenAIRequestTopP
+	KeyGenAISystemInstructions            = semconvtrace.KeyGenAISystemInstructions
+	KeyGenAITokenType                     = semconvtrace.KeyGenAITokenType
+	KeyGenAITaskType                      = semconvtrace.KeyGenAITaskType
+	KeyGenAIRequestThinkingEnabled        = semconvtrace.KeyGenAIRequestThinkingEnabled
+	KeyGenAIRequestToolDefinitions        = "gen_ai.request.tool.definitions"
 
 	KeyGenAIToolName          = semconvtrace.KeyGenAIToolName
 	KeyGenAIToolDescription   = semconvtrace.KeyGenAIToolDescription
@@ -561,6 +564,19 @@ func buildResponseAttributes(rsp *model.Response) []attribute.KeyValue {
 			attribute.Int(KeyGenAIUsageInputTokens, rsp.Usage.PromptTokens),
 			attribute.Int(KeyGenAIUsageOutputTokens, rsp.Usage.CompletionTokens),
 		)
+		// Prompt cache tokens (if provided by the model provider)
+		if cached := rsp.Usage.PromptTokensDetails.CachedTokens; cached != 0 {
+			// OpenAI: cached_tokens
+			attrs = append(attrs, attribute.Int(KeyGenAIUsageInputTokensCached, cached))
+		}
+		if cacheRead := rsp.Usage.PromptTokensDetails.CacheReadTokens; cacheRead != 0 {
+			// Anthropic: cache_read_tokens
+			attrs = append(attrs, attribute.Int(KeyGenAIUsageInputTokensCacheRead, cacheRead))
+		}
+		if cacheCreation := rsp.Usage.PromptTokensDetails.CacheCreationTokens; cacheCreation != 0 {
+			// Anthropic: cache_creation_tokens
+			attrs = append(attrs, attribute.Int(KeyGenAIUsageInputTokensCacheCreation, cacheCreation))
+		}
 	}
 
 	// Add choices attributes

--- a/internal/telemetry/trace_test.go
+++ b/internal/telemetry/trace_test.go
@@ -825,6 +825,11 @@ func TestBuildResponseAttributes(t *testing.T) {
 				Usage: &model.Usage{
 					PromptTokens:     10,
 					CompletionTokens: 20,
+					PromptTokensDetails: model.PromptTokensDetails{
+						CachedTokens:        7,
+						CacheReadTokens:     11,
+						CacheCreationTokens: 13,
+					},
 				},
 			},
 		},
@@ -856,6 +861,19 @@ func TestBuildResponseAttributes(t *testing.T) {
 				// Verify basic attributes
 				require.True(t, hasAttr(attrs, KeyGenAIResponseModel, tt.rsp.Model))
 				require.True(t, hasAttr(attrs, KeyGenAIResponseID, tt.rsp.ID))
+
+				// Verify cached prompt tokens attribute when provided
+				if tt.rsp.Usage != nil {
+					if tt.rsp.Usage.PromptTokensDetails.CachedTokens != 0 {
+						require.True(t, hasAttr(attrs, KeyGenAIUsageInputTokensCached, int64(tt.rsp.Usage.PromptTokensDetails.CachedTokens)))
+					}
+					if tt.rsp.Usage.PromptTokensDetails.CacheReadTokens != 0 {
+						require.True(t, hasAttr(attrs, KeyGenAIUsageInputTokensCacheRead, int64(tt.rsp.Usage.PromptTokensDetails.CacheReadTokens)))
+					}
+					if tt.rsp.Usage.PromptTokensDetails.CacheCreationTokens != 0 {
+						require.True(t, hasAttr(attrs, KeyGenAIUsageInputTokensCacheCreation, int64(tt.rsp.Usage.PromptTokensDetails.CacheCreationTokens)))
+					}
+				}
 			}
 		})
 	}

--- a/telemetry/semconv/metrics/metrics.go
+++ b/telemetry/semconv/metrics/metrics.go
@@ -17,6 +17,12 @@ const (
 	KeyTRPCAgentGoInputTokenType = "input" // #nosec G101 - this is a metric key name, not a credential.
 	// KeyTRPCAgentGoOutputTokenType represents the type of output token.
 	KeyTRPCAgentGoOutputTokenType = "output" // #nosec G101 - this is a metric key name, not a credential.
+	// KeyTRPCAgentGoInputCachedTokenType represents the cached portion of input(prompt) tokens.
+	KeyTRPCAgentGoInputCachedTokenType = "input_cached" // #nosec G101 - this is a metric key name, not a credential.
+	// KeyTRPCAgentGoInputCacheReadTokenType represents tokens read from prompt cache (Anthropic).
+	KeyTRPCAgentGoInputCacheReadTokenType = "input_cache_read" // #nosec G101 - this is a metric key name, not a credential.
+	// KeyTRPCAgentGoInputCacheCreationTokenType represents tokens used to create prompt cache (Anthropic).
+	KeyTRPCAgentGoInputCacheCreationTokenType = "input_cache_creation" // #nosec G101 - this is a metric key name, not a credential.
 	// KeyTRPCAgentGoStream represents the stream of the response.
 	KeyTRPCAgentGoStream = "trpc_agent_go.is_stream" // #nosec G101 - this is a metric key name, not a credential.
 	// KeyMetricName represents the name of the metric.

--- a/telemetry/semconv/trace/trace.go
+++ b/telemetry/semconv/trace/trace.go
@@ -70,6 +70,15 @@ const (
 	KeyGenAIUsageOutputTokens = "gen_ai.usage.output_tokens" // #nosec G101 - this is a metric key name, not a credential.
 	// KeyGenAIUsageInputTokens is the attribute key for input token count.
 	KeyGenAIUsageInputTokens = "gen_ai.usage.input_tokens" // #nosec G101 - this is a metric key name, not a credential.
+	// KeyGenAIUsageInputTokensCached is the attribute key for cached input token count.
+	// Note: This is an extension field used to report prompt cache tokens; it is not part of the upstream GenAI semantic conventions yet.
+	KeyGenAIUsageInputTokensCached = "gen_ai.usage.input_tokens.cached" // #nosec G101 - this is a metric key name, not a credential.
+	// KeyGenAIUsageInputTokensCacheRead is the attribute key for tokens read from cache (Anthropic).
+	// Note: This is an extension field; it is not part of the upstream GenAI semantic conventions yet.
+	KeyGenAIUsageInputTokensCacheRead = "gen_ai.usage.input_tokens.cache_read" // #nosec G101 - this is a metric key name, not a credential.
+	// KeyGenAIUsageInputTokensCacheCreation is the attribute key for tokens used to create cache (Anthropic).
+	// Note: This is an extension field; it is not part of the upstream GenAI semantic conventions yet.
+	KeyGenAIUsageInputTokensCacheCreation = "gen_ai.usage.input_tokens.cache_creation" // #nosec G101 - this is a metric key name, not a credential.
 	// KeyGenAIProviderName is the attribute key for provider name.
 	KeyGenAIProviderName = "gen_ai.provider.name"
 	// KeyGenAIAgentDescription is the attribute key for agent description.


### PR DESCRIPTION
## Summary by Sourcery

在遥测追踪和指标中跟踪用于对话响应的提示缓存（prompt cache）令牌使用情况。

New Features:
- 暴露新的语义约定键，用于表示已缓存、缓存读取以及缓存创建的提示输入令牌数量。
- 在现有输入和输出令牌指标之外，分别记录已缓存、缓存读取和缓存创建的提示令牌遥测指标。

Enhancements:
- 当服务提供商提供相关信息时，在模型响应的 span 属性中包含提示缓存令牌的详细信息。

Tests:
- 扩展遥测指标和追踪测试，以覆盖提示缓存令牌字段，并确保其正确传播到指标和属性中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Track prompt cache token usage in telemetry traces and metrics for chat responses.

New Features:
- Expose new semantic-convention keys to represent cached, cache-read, and cache-creation prompt input tokens.
- Record separate telemetry metrics for cached, cache-read, and cache-creation prompt tokens alongside existing input and output token metrics.

Enhancements:
- Include prompt cache token details in span attributes for model responses when providers supply this information.

Tests:
- Extend telemetry metric and trace tests to cover prompt cache token fields and ensure correct propagation into metrics and attributes.

</details>