### PR TITLE
{docs, examples}: use onlyTree for skill evaluation example

### DIFF
--- a/docs/mkdocs/en/evaluation.md
+++ b/docs/mkdocs/en/evaluation.md
@@ -2396,7 +2396,7 @@ The computation of pass@k and pass^k relies on independence and identical distri
 
 ### Skills Evaluation
 
-Agent Skills are exposed as built-in tools: `skill_load` and `skill_run`, so you can evaluate whether the agent uses Skills correctly with the same tool trajectory evaluator. In practice, `skill_run` results contain volatile fields such as `stdout`, `stderr`, `duration_ms`, and inline `output_files` content. Prefer configuring a per-tool strategy to ignore these keys and only assert stable fields such as `skill`, requested `output_files`, and `exit_code` and `timed_out`.
+Agent Skills are exposed as built-in tools: `skill_load` and `skill_run`, so you can evaluate whether the agent uses Skills correctly with the same tool trajectory evaluator. In practice, `skill_run` results contain volatile fields such as `stdout`, `stderr`, `duration_ms`, and inline `output_files` content. Prefer using `onlyTree` in a per-tool strategy to assert only stable fields such as `skill`, requested `output_files`, and `exit_code` and `timed_out`, letting other volatile keys be ignored.
 
 A minimal example is shown below.
 
@@ -2449,9 +2449,8 @@ Metric `toolTrajectory` snippet:
         "toolStrategy": {
           "skill_load": {
             "arguments": {
-              "ignoreTree": {
-                "docs": true,
-                "include_all_docs": true
+              "onlyTree": {
+                "skill": true
               },
               "matchStrategy": "exact"
             },
@@ -2461,28 +2460,16 @@ Metric `toolTrajectory` snippet:
           },
           "skill_run": {
             "arguments": {
-              "ignoreTree": {
-                "command": true,
-                "cwd": true,
-                "env": true,
-                "timeout": true,
-                "inputs": true,
-                "outputs": true,
-                "save_as_artifacts": true,
-                "omit_inline_content": true,
-                "artifact_prefix": true
+              "onlyTree": {
+                "skill": true,
+                "output_files": true
               },
               "matchStrategy": "exact"
             },
             "result": {
-              "ignoreTree": {
-                "stdout": true,
-                "stderr": true,
-                "duration_ms": true,
-                "warnings": true,
-                "primary_output": true,
-                "output_files": true,
-                "artifact_files": true
+              "onlyTree": {
+                "exit_code": true,
+                "timed_out": true
               },
               "matchStrategy": "exact"
             }

--- a/docs/mkdocs/zh/evaluation.md
+++ b/docs/mkdocs/zh/evaluation.md
@@ -2399,9 +2399,9 @@ pass@k 与 pass^k 的计算依赖运行之间的独立性与同分布假设，�
 
 ### Skills 评估
 
-Agent Skills 以工具 `skill_load` 与 `skill_run` 形式暴露，因此也可以复用工具轨迹评估器来评估 Agent 是否按预期使用 Skills。实践中 `skill_run` 的结果通常包含波动字段，例如 `stdout`、`stderr`、`duration_ms`，以及收集到的 `output_files` 内联内容。建议通过按工具覆盖策略忽略这些字段，仅对稳定字段进行回归校验，例如 `skill`、请求的 `output_files`，以及 `exit_code` 与 `timed_out`。
+Agent Skills 以工具 `skill_load` 与 `skill_run` 形式暴露，因此也可以复用工具轨迹评估器来评估 Agent 是否按预期使用 Skills。实践中 `skill_run` 的结果通常包含波动字段，例如 `stdout`、`stderr`、`duration_ms`，以及收集到的 `output_files` 内联内容。建议在按工具覆盖策略中使用 `onlyTree` 只对比稳定字段，例如 `skill`、请求的 `output_files`，以及 `exit_code` 与 `timed_out`，未被选中的字段将被忽略。
 
-下面给出一个最小示例，展示如何在 EvalSet 中声明预期的工具轨迹，并在 Metric 中忽略 `skill_run` 的波动字段。
+下面给出一个最小示例，展示如何在 EvalSet 中声明预期的工具轨迹，并在 Metric 中通过 `onlyTree` 仅校验稳定字段。
 
 EvalSet 中的 `tools` 片段示例如下：
 
@@ -2452,9 +2452,8 @@ Metric 的 `toolTrajectory` 配置示例如下：
         "toolStrategy": {
           "skill_load": {
             "arguments": {
-              "ignoreTree": {
-                "docs": true,
-                "include_all_docs": true
+              "onlyTree": {
+                "skill": true
               },
               "matchStrategy": "exact"
             },
@@ -2464,28 +2463,16 @@ Metric 的 `toolTrajectory` 配置示例如下：
           },
           "skill_run": {
             "arguments": {
-              "ignoreTree": {
-                "command": true,
-                "cwd": true,
-                "env": true,
-                "timeout": true,
-                "inputs": true,
-                "outputs": true,
-                "save_as_artifacts": true,
-                "omit_inline_content": true,
-                "artifact_prefix": true
+              "onlyTree": {
+                "skill": true,
+                "output_files": true
               },
               "matchStrategy": "exact"
             },
             "result": {
-              "ignoreTree": {
-                "stdout": true,
-                "stderr": true,
-                "duration_ms": true,
-                "warnings": true,
-                "primary_output": true,
-                "output_files": true,
-                "artifact_files": true
+              "onlyTree": {
+                "exit_code": true,
+                "timed_out": true
               },
               "matchStrategy": "exact"
             }

--- a/examples/evaluation/skill/data/skill-eval-app/skill-call-basic.metrics.json
+++ b/examples/evaluation/skill/data/skill-eval-app/skill-call-basic.metrics.json
@@ -23,9 +23,8 @@
               "matchStrategy": "exact"
             },
             "arguments": {
-              "ignoreTree": {
-                "docs": true,
-                "include_all_docs": true
+              "onlyTree": {
+                "skill": true
               },
               "matchStrategy": "exact"
             },
@@ -38,28 +37,16 @@
               "matchStrategy": "exact"
             },
             "arguments": {
-              "ignoreTree": {
-                "command": true,
-                "cwd": true,
-                "env": true,
-                "timeout": true,
-                "inputs": true,
-                "outputs": true,
-                "save_as_artifacts": true,
-                "omit_inline_content": true,
-                "artifact_prefix": true
+              "onlyTree": {
+                "skill": true,
+                "output_files": true
               },
               "matchStrategy": "exact"
             },
             "result": {
-              "ignoreTree": {
-                "stdout": true,
-                "stderr": true,
-                "duration_ms": true,
-                "warnings": true,
-                "primary_output": true,
-                "output_files": true,
-                "artifact_files": true
+              "onlyTree": {
+                "exit_code": true,
+                "timed_out": true
               },
               "matchStrategy": "exact"
             }

--- a/examples/evaluation/skill/output/skill-eval-app/skill-eval-app_skill-call-basic_370dc583-f4b2-48f5-b6f2-9f0df1034a08.evalset_result.json
+++ b/examples/evaluation/skill/output/skill-eval-app/skill-eval-app_skill-call-basic_370dc583-f4b2-48f5-b6f2-9f0df1034a08.evalset_result.json
@@ -33,9 +33,8 @@
                     "matchStrategy": "exact"
                   },
                   "arguments": {
-                    "ignoreTree": {
-                      "docs": true,
-                      "include_all_docs": true
+                    "onlyTree": {
+                      "skill": true
                     },
                     "matchStrategy": "exact"
                   },
@@ -48,28 +47,16 @@
                     "matchStrategy": "exact"
                   },
                   "arguments": {
-                    "ignoreTree": {
-                      "artifact_prefix": true,
-                      "command": true,
-                      "cwd": true,
-                      "env": true,
-                      "inputs": true,
-                      "omit_inline_content": true,
-                      "outputs": true,
-                      "save_as_artifacts": true,
-                      "timeout": true
+                    "onlyTree": {
+                      "skill": true,
+                      "output_files": true
                     },
                     "matchStrategy": "exact"
                   },
                   "result": {
-                    "ignoreTree": {
-                      "artifact_files": true,
-                      "duration_ms": true,
-                      "output_files": true,
-                      "primary_output": true,
-                      "stderr": true,
-                      "stdout": true,
-                      "warnings": true
+                    "onlyTree": {
+                      "exit_code": true,
+                      "timed_out": true
                     },
                     "matchStrategy": "exact"
                   }
@@ -199,9 +186,8 @@
                         "matchStrategy": "exact"
                       },
                       "arguments": {
-                        "ignoreTree": {
-                          "docs": true,
-                          "include_all_docs": true
+                        "onlyTree": {
+                          "skill": true
                         },
                         "matchStrategy": "exact"
                       },
@@ -214,28 +200,16 @@
                         "matchStrategy": "exact"
                       },
                       "arguments": {
-                        "ignoreTree": {
-                          "artifact_prefix": true,
-                          "command": true,
-                          "cwd": true,
-                          "env": true,
-                          "inputs": true,
-                          "omit_inline_content": true,
-                          "outputs": true,
-                          "save_as_artifacts": true,
-                          "timeout": true
+                        "onlyTree": {
+                          "skill": true,
+                          "output_files": true
                         },
                         "matchStrategy": "exact"
                       },
                       "result": {
-                        "ignoreTree": {
-                          "artifact_files": true,
-                          "duration_ms": true,
-                          "output_files": true,
-                          "primary_output": true,
-                          "stderr": true,
-                          "stdout": true,
-                          "warnings": true
+                        "onlyTree": {
+                          "exit_code": true,
+                          "timed_out": true
                         },
                         "matchStrategy": "exact"
                       }


### PR DESCRIPTION
Switch the skill evaluation example metric configuration from ignoreTree to onlyTree to compare only stable fields, and update the example evalset result snapshot and evaluation documentation accordingly.

## Summary by Sourcery

更新技能评估配置示例和快照，使用 `onlyTree` 策略替代 `ignoreTree`，仅断言稳定字段。

增强：
- 调整技能评估度量配置示例，在匹配参数和结果时，对 `skill_load` 和 `skill_run` 两个工具都使用 `onlyTree`。

文档：
- 明确英文和中文评估文档中的说明，推荐基于 `onlyTree` 的按工具策略，仅比较稳定的技能字段，并隐式忽略不稳定字段。

测试：
- 刷新技能评估示例度量和评测集结果工件，使其与新的基于 `onlyTree` 的配置保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update skill evaluation configuration examples and snapshots to assert only stable fields using the `onlyTree` strategy instead of `ignoreTree`.

Enhancements:
- Adjust skill evaluation metric configuration examples to use `onlyTree` for both `skill_load` and `skill_run` tools when matching arguments and results.

Documentation:
- Clarify English and Chinese evaluation docs to recommend `onlyTree`-based per-tool strategies that compare only stable skill fields and implicitly ignore volatile ones.

Tests:
- Refresh skill evaluation example metric and evalset result artifacts to align with the new `onlyTree`-based configuration.

</details>