### PR TITLE
{server/agui, docs}: add cancel-on-context-done option

### DIFF
--- a/docs/mkdocs/en/agui.md
+++ b/docs/mkdocs/en/agui.md
@@ -93,6 +93,20 @@ Even if the client SSE connection is closed, the backend continues executing unt
 
 A complete example is available at [examples/agui/server/default](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/server/default).
 
+#### Connection close and cancellation semantics
+
+By default, the AG-UI service decouples an Agent run from the request's cancellation signal. Even if the SSE connection is interrupted (e.g., due to a page refresh), and the request `ctx` is cancelled, the backend run will continue until it finishes normally, is actively cancelled via the cancellation route, or times out.
+
+If you want the Agent run to stop when the request `ctx` ends (i.e., when the client disconnects or `ctx` is cancelled), you can explicitly enable this option:
+
+```go
+server, err := agui.New(
+    runner,
+    agui.WithPath("/agui"),
+    agui.WithCancelOnContextDoneEnabled(true),
+)
+```
+
 #### Multimodal user input
 
 For `role=user` messages, `content` can also be a multimodal array. Each item is an `InputContent` fragment:

--- a/docs/mkdocs/zh/agui.md
+++ b/docs/mkdocs/zh/agui.md
@@ -93,6 +93,20 @@ type RunAgentInput struct {
 
 完整代码示例参见 [examples/agui/server/default](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/server/default)。
 
+#### 连接断开与取消语义
+
+默认情况下，AG-UI 服务会将一次 Agent 运行与请求的取消信号解耦，即使 SSE 连接断开，例如页面刷新导致连接中断，并触发请求 `ctx` 被取消，后端 run 仍会继续执行，直到正常结束、通过取消路由主动取消，或触发超时。
+
+如果你希望请求 `ctx` 结束即停止 Agent 运行，也就是客户端断开或 `ctx` cancel 时停止 Agent 运行，可以显式开启：
+
+```go
+server, err := agui.New(
+    runner,
+    agui.WithPath("/agui"),
+    agui.WithCancelOnContextDoneEnabled(true),
+)
+```
+
 #### 多模态输入
 
 对于 `role=user` 的消息，`content` 也可以是一个多模态数组，每个元素是一个 `InputContent` 片段，例如：

--- a/server/agui/options.go
+++ b/server/agui/options.go
@@ -90,6 +90,13 @@ func WithCancelEnabled(e bool) Option {
 	}
 }
 
+// WithCancelOnContextDoneEnabled controls whether an AG-UI run is canceled when the request context is done.
+func WithCancelOnContextDoneEnabled(enabled bool) Option {
+	return func(o *options) {
+		o.aguiRunnerOptions = append(o.aguiRunnerOptions, aguirunner.WithCancelOnContextDoneEnabled(enabled))
+	}
+}
+
 // ServiceFactory is a function that creates AG-UI service.
 type ServiceFactory func(runner aguirunner.Runner, opt ...service.Option) service.Service
 

--- a/server/agui/options_test.go
+++ b/server/agui/options_test.go
@@ -120,3 +120,9 @@ func TestWithCancelEnabled(t *testing.T) {
 	opts := newOptions(WithCancelEnabled(true))
 	assert.True(t, opts.cancelEnabled)
 }
+
+func TestWithCancelOnContextDoneEnabled(t *testing.T) {
+	opts := newOptions(WithCancelOnContextDoneEnabled(true))
+	ro := aguirunner.NewOptions(opts.aguiRunnerOptions...)
+	assert.True(t, ro.CancelOnContextDoneEnabled)
+}

--- a/server/agui/runner/options.go
+++ b/server/agui/runner/options.go
@@ -46,6 +46,7 @@ type Options struct {
 	MessagesSnapshotFollowMaxDuration      time.Duration         // MessagesSnapshotFollowMaxDuration bounds how long tailing can run before emitting RUN_ERROR.
 	StartSpan                              StartSpan             // StartSpan starts a span for an AG-UI run.
 	Timeout                                time.Duration         // Timeout controls how long a run is allowed to execute.
+	CancelOnContextDoneEnabled             bool                  // CancelOnContextDoneEnabled cancels the run when the parent context is done.
 	GraphNodeLifecycleActivityEnabled      bool                  // GraphNodeLifecycleActivityEnabled enables graph node lifecycle activity events.
 	GraphNodeInterruptActivityEnabled      bool                  // GraphNodeInterruptActivityEnabled enables graph interrupt activity events.
 	GraphNodeInterruptActivityTopLevelOnly bool                  // GraphNodeInterruptActivityTopLevelOnly drops nested graph interrupt activity events.
@@ -197,6 +198,13 @@ func WithStartSpan(start StartSpan) Option {
 func WithTimeout(d time.Duration) Option {
 	return func(o *Options) {
 		o.Timeout = d
+	}
+}
+
+// WithCancelOnContextDoneEnabled controls whether a run is canceled when the parent context is done.
+func WithCancelOnContextDoneEnabled(enabled bool) Option {
+	return func(o *Options) {
+		o.CancelOnContextDoneEnabled = enabled
 	}
 }
 

--- a/server/agui/runner/options_test.go
+++ b/server/agui/runner/options_test.go
@@ -66,6 +66,7 @@ func TestNewOptionsDefaults(t *testing.T) {
 	assert.NotNil(t, span)
 
 	assert.Equal(t, time.Hour, opts.Timeout)
+	assert.False(t, opts.CancelOnContextDoneEnabled)
 	assert.False(t, opts.GraphNodeLifecycleActivityEnabled)
 	assert.False(t, opts.GraphNodeInterruptActivityEnabled)
 	assert.False(t, opts.GraphNodeInterruptActivityTopLevelOnly)
@@ -218,6 +219,11 @@ func TestWithStartSpan(t *testing.T) {
 func TestWithTimeout(t *testing.T) {
 	opts := NewOptions(WithTimeout(2 * time.Second))
 	assert.Equal(t, 2*time.Second, opts.Timeout)
+}
+
+func TestWithCancelOnContextDoneEnabled(t *testing.T) {
+	opts := NewOptions(WithCancelOnContextDoneEnabled(true))
+	assert.True(t, opts.CancelOnContextDoneEnabled)
 }
 
 func TestWithMessagesSnapshotFollowEnabled(t *testing.T) {


### PR DESCRIPTION
Adds an opt-in option to cancel AG-UI runs when the request context is done to support legacy client-disconnect cancellation semantics, and updates the AG-UI guides in English and Chinese to document the default detached behavior and configuration.

## Summary by Sourcery

为 AG-UI 运行新增一个选项，当请求上下文结束时可以取消运行，并文档化默认行为及可配置的取消机制。

New Features:
- 引入可配置的 `CancelOnContextDone` 选项，用于在启用时将 AG-UI 运行的生命周期与请求上下文绑定。

Enhancements:
- 在 AG-UI runner 和 service 的选项中向下传递 `CancelOnContextDoneEnabled` 选项，用于控制执行上下文的处理方式。

Documentation:
- 在英文和中文指南中记录 AG-UI 连接关闭与取消的语义，包括如何启用基于请求上下文的取消机制。

Tests:
- 为 AG-UI runner 和 service 选项中新增的 `CancelOnContextDone` 选项的接线与行为添加单元测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an option to cancel AG-UI runs when the request context is done and document the default and configurable cancellation behavior.

New Features:
- Introduce a configurable CancelOnContextDone option for AG-UI runs to tie run lifetime to the request context when enabled.

Enhancements:
- Propagate the CancelOnContextDoneEnabled option through AG-UI runner and service options to control execution context handling.

Documentation:
- Document AG-UI connection close and cancellation semantics in English and Chinese guides, including how to enable request-context-based cancellation.

Tests:
- Add unit tests covering the new CancelOnContextDone option wiring and behavior in the AG-UI runner and service options.

</details>