### PR TITLE
skills: avoid duplicate loaded markers

### DIFF
--- a/internal/flow/processor/skills_test.go
+++ b/internal/flow/processor/skills_test.go
@@ -533,7 +533,7 @@ func TestSkillsToolResultRequestProcessor_MaterializesIntoLastToolMsg(
 
 	require.Equal(t, baseOut, req.Messages[2].Content)
 	lastTool := req.Messages[3].Content
-	require.Contains(t, lastTool, baseOut)
+	require.NotContains(t, lastTool, baseOut)
 	require.Contains(t, lastTool, "[Loaded] calc")
 	require.Contains(t, lastTool, "B")
 	require.Contains(t, lastTool, "[Doc] USAGE.md")
@@ -602,6 +602,27 @@ func TestSkillsToolResultRequestProcessor_FallbackSystemMessageAdded(
 		}
 		require.NotContains(t, m.Content, skillsLoadedContextHeader)
 	}
+}
+
+func TestSkillsToolResultRequestProcessor_BuildToolResultContent_Base(
+	t *testing.T,
+) {
+	repo := &mockRepo{
+		full: map[string]*skill.Skill{
+			"calc": {Summary: skill.Summary{Name: "calc"}, Body: "B"},
+		},
+	}
+
+	p := NewSkillsToolResultRequestProcessor(repo)
+	out, ok := p.buildToolResultContent(
+		context.Background(),
+		nil,
+		"calc",
+		"ok",
+	)
+	require.True(t, ok)
+	require.Contains(t, out, "ok")
+	require.Contains(t, out, "[Loaded] calc")
 }
 
 func TestSkillsToolResultRequestProcessor_SkillLoadModeOnce_Offloads(

--- a/internal/flow/processor/skills_tool_result.go
+++ b/internal/flow/processor/skills_tool_result.go
@@ -242,6 +242,14 @@ func parseLoadedSkillFromText(content string) string {
 	return name
 }
 
+func isLoadedToolStub(toolOutput string, skillName string) bool {
+	name := parseLoadedSkillFromText(toolOutput)
+	if name == "" {
+		return false
+	}
+	return strings.EqualFold(name, skillName)
+}
+
 func (p *SkillsToolResultRequestProcessor) buildToolResultContent(
 	ctx context.Context,
 	inv *agent.Invocation,
@@ -261,6 +269,9 @@ func (p *SkillsToolResultRequestProcessor) buildToolResultContent(
 
 	var b strings.Builder
 	base := strings.TrimSpace(toolOutput)
+	if base != "" && isLoadedToolStub(base, skillName) {
+		base = ""
+	}
 	if base != "" {
 		b.WriteString(base)
 		b.WriteString("\n\n")


### PR DESCRIPTION
## What
Avoid duplicate "loaded" markers in `skill_load` tool-result materialization.

When `WithSkillsLoadedContentInToolResults(true)` is enabled, the framework expands the last `skill_load` tool result into:
- A `[Loaded] <skill>` block
- (Previously) the original short tool stub `loaded: <skill>`

That produced two "loaded" lines in the same tool message.

## How
- If the tool output is exactly a `loaded: <skill>` stub, omit it from the expanded tool message.
- Keep the persisted tool output and session state semantics unchanged.

## Tests
- `go test ./internal/flow/processor -count=1`

## 由 Sourcery 提供的总结

在启用技能加载内容扩展时，防止在实体化的工具结果中出现重复的技能已加载标记。

Bug 修复：
- 在扩展的工具结果消息中省略多余的简短 “loaded: \<skill\>” 工具桩，同时保留持久化的工具输出和会话状态语义。

测试：
- 更新技能工具结果实体化测试，以断言基础工具输出桩不会包含在最终扩展的工具消息中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent duplicate skill-loaded markers from appearing in materialized tool results when skills-loaded content expansion is enabled.

Bug Fixes:
- Omit redundant short "loaded: <skill>" tool stubs from expanded tool result messages while preserving persisted tool output and session state semantics.

Tests:
- Update skills tool result materialization test to assert that the base tool output stub is not included in the final expanded tool message.

</details>