### PR TITLE
docs: enrich SkillLoadMode guidance

### DIFF
--- a/docs/mkdocs/en/skill.md
+++ b/docs/mkdocs/en/skill.md
@@ -98,12 +98,20 @@ How this relates to `SkillLoadMode` (common pitfall):
 Practical guidance (especially with
 `WithSkillsLoadedContentInToolResults(true)`):
 
-- `SkillLoadModeSession` can be more prompt-cache friendly because you
-  do not need to re-run `skill_load` every turn; the message sequence
-  stays more stable and the shared prefix tends to be longer. The trade
-  off is a larger prompt.
-- Use `session` only for a small number of skills you truly need across
-  the whole session; use `turn/once` otherwise.
+- First, be clear about *which* caching scenario you mean:
+  - **Within a single turn** (multiple model calls inside one
+    `Runner.Run`): `turn` and `session` behave similarly because both
+    keep loaded content available within the run. The more important
+    lever is usually *where* you materialize content (system vs tool
+    result).
+  - **Across turns**: `session` can be more prompt-cache friendly
+    because you load once and avoid repeating `skill_load` every turn.
+    The trade-off is a larger prompt and the need to manage clearing.
+- Rule of thumb:
+  - Default to `turn` (least-privilege, smaller prompts, less likely to
+    trigger truncation/summary).
+  - Use `session` only for a small number of skills you truly need
+    across the whole session, and keep docs selection tight.
 - Keep docs selection tight (avoid `include_all_docs` when possible).
   Otherwise the prompt can grow quickly and trigger truncation/summary.
   That increases the chance of falling back to a system message, which

--- a/docs/mkdocs/zh/skill.md
+++ b/docs/mkdocs/zh/skill.md
@@ -89,9 +89,15 @@ system message，确保模型仍能看到已加载内容。
 
 实践建议（尤其是 `WithSkillsLoadedContentInToolResults(true)` 时）：
 
-- `SkillLoadModeSession` 往往更利于 prompt cache：你不需要每轮都重新
-  `skill_load`，消息序列更稳定、共同前缀更长；但代价是上下文会更大。
-- 只对“整个会话都需要”的少量技能使用 `session`；其余用 `turn/once`。
+- 先确认你在讨论哪种“缓存”场景：
+  - **同一轮对话内**（一次 `Runner.Run` 里多次调用模型）：`turn` 与
+    `session` 基本等价，因为它们都会让“本轮已加载内容”在该轮内可见。
+    更关键的开关通常是“注入到 system 还是 tool result”。
+  - **跨多轮对话**：`session` 可能更利于 prompt cache，因为你只需加载一次，
+    后续不必反复 `skill_load`；但代价是上下文更大、需要更主动地管理清理。
+- 经验法则：
+  - 默认用 `turn`（最小权限、上下文更小、也更不容易触发截断/summary）。
+  - 仅对“整段会话都会反复用到”的少量技能用 `session`，并严格控制 docs。
 - 严格控制 docs 选择（尽量不要 `include_all_docs=true`），否则很容易把
   上下文塞爆，进而触发 history 截断/summary，导致回退为 system message，
   prompt cache 的收益会下降。


### PR DESCRIPTION
## What
Improve the `SkillLoadMode` documentation, especially when combined with
`WithSkillsLoadedContentInToolResults(true)`.

This clarifies:
- Why a later turn may still show a stored `skill_load` tool result as a short
  `loaded: <name>` stub (no body/docs materialized)
- How `SkillLoadMode` controls whether bodies/docs can be materialized across
  turns
- Practical prompt-cache tradeoffs for `turn/once/session` modes

## Why
Users frequently inspect traces and expect loaded skill content to appear inside
`skill_load` tool results across turns. The behavior depends on both the
materialization mode and the `SkillLoadMode` lifecycle of session state.

## Scope
Docs only.

## Summary by Sourcery

阐明在英文和中文技能文档中，`SkillLoadMode` 如何影响技能内容实体化以及跨多轮对话中的工具结果行为。

Documentation:
- 在英文和中文的 `SkillLoadMode` 文档中补充说明，解释跨轮次的技能主体/文档持久化机制，以及与提示缓存（prompt-cache）之间的权衡。
- 记录常见的陷阱场景：工具结果中只出现 `loaded: <name>` 占位内容的情况，并说明如何配置工具结果实体化和 `SkillLoadModeSession` 以避免这些问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify how SkillLoadMode interacts with skill content materialization and tool-result behavior across turns in both English and Chinese skill docs.

Documentation:
- Expand English and Chinese SkillLoadMode documentation with guidance on cross-turn skill body/docs persistence and prompt-cache tradeoffs.
- Document common pitfalls where only `loaded: <name>` stubs appear in tool results and how to configure tool-result materialization and SkillLoadModeSession to avoid them.

</details>