### PR TITLE
meory/redis: add Redis key prefix support and fix hash tag

### DIFF
--- a/docs/mkdocs/en/memory.md
+++ b/docs/mkdocs/en/memory.md
@@ -793,7 +793,7 @@ redisService, err := memoryredis.NewService(
 - `WithRedisClientURL(url)`: Redis connection URL (recommended)
 - `WithRedisInstance(name)`: Use pre-registered Redis instance
 - `WithMemoryLimit(limit)`: Memory limit per user
-- `WithKeyPrefix(prefix)`: Set a prefix for all Redis keys. When set, every key is prepixed with `prefix:`. For example, if `prefix` is `"myapp"`, the key `mem:{app:user}` becomes `myapp:mem:{app:user}`. Default is empty (no prefix). This is useful for sharing a single Redis instance across multiple environments or services
+- `WithKeyPrefix(prefix)`: Set a prefix for all Redis keys. When set, every key is prefixed with `prefix:`. For example, if `prefix` is `"myapp"`, the key `mem:{app:user}` becomes `myapp:mem:{app:user}`. Default is empty (no prefix). This is useful for sharing a single Redis instance across multiple environments or services
 - `WithCustomTool(toolName, creator)`: Register custom tool
 - `WithToolEnabled(toolName, enabled)`: Enable/disable tool
 - `WithExtraOptions(...options)`: Extra options passed to Redis client

--- a/docs/mkdocs/en/memory.md
+++ b/docs/mkdocs/en/memory.md
@@ -793,11 +793,21 @@ redisService, err := memoryredis.NewService(
 - `WithRedisClientURL(url)`: Redis connection URL (recommended)
 - `WithRedisInstance(name)`: Use pre-registered Redis instance
 - `WithMemoryLimit(limit)`: Memory limit per user
+- `WithKeyPrefix(prefix)`: Set a prefix for all Redis keys. When set, every key is prepixed with `prefix:`. For example, if `prefix` is `"myapp"`, the key `mem:{app:user}` becomes `myapp:mem:{app:user}`. Default is empty (no prefix). This is useful for sharing a single Redis instance across multiple environments or services
 - `WithCustomTool(toolName, creator)`: Register custom tool
 - `WithToolEnabled(toolName, enabled)`: Enable/disable tool
 - `WithExtraOptions(...options)`: Extra options passed to Redis client
 
 **Note**: `WithRedisClientURL` takes priority over `WithRedisInstance`
+
+**Key prefix example**:
+
+```go
+redisService, err := memoryredis.NewService(
+    memoryredis.WithRedisClientURL("redis://localhost:6379"),
+    memoryredis.WithKeyPrefix("prod"),
+)
+```
 
 ### MySQL Storage
 

--- a/docs/mkdocs/zh/memory.md
+++ b/docs/mkdocs/zh/memory.md
@@ -884,11 +884,21 @@ redisService, err := memoryredis.NewService(
 - `WithRedisClientURL(url)`: Redis 连接 URL（推荐）
 - `WithRedisInstance(name)`: 使用预注册的 Redis 实例
 - `WithMemoryLimit(limit)`: 每用户记忆上限
+- `WithKeyPrefix(prefix)`: 设置 Redis key 前缀。设置后所有 key 都会以 `prefix:` 开头。例如 `prefix` 为 `"myapp"` 时，key `mem:{app:user}` 变为 `myapp:mem:{app:user}`。默认为空（无前缀）。适用于多环境或多服务共享同一 Redis 实例的场景
 - `WithCustomTool(toolName, creator)`: 注册自定义工具
 - `WithToolEnabled(toolName, enabled)`: 启用/禁用工具
 - `WithExtraOptions(...options)`: 传递给 Redis 客户端的额外选项
 
 **注意**：`WithRedisClientURL` 优先级高于 `WithRedisInstance`
+
+**Key 前缀示例**：
+
+```go
+redisService, err := memoryredis.NewService(
+    memoryredis.WithRedisClientURL("redis://localhost:6379"),
+    memoryredis.WithKeyPrefix("prod"),
+)
+```
 
 ### MySQL 存储
 

--- a/memory/redis/options.go
+++ b/memory/redis/options.go
@@ -31,6 +31,12 @@ type ServiceOpts struct {
 	url          string
 	instanceName string
 	memoryLimit  int
+	// keyPrefix is the prefix for all redis keys.
+	// If set, all keys will be prefixed with this value
+	// followed by a colon. For example, if keyPrefix is
+	// "myapp", key "mem:{app:user}" becomes
+	// "myapp:mem:{app:user}".
+	keyPrefix string
 
 	// Tool related settings.
 	toolCreators      map[string]memory.ToolCreator
@@ -166,5 +172,16 @@ func WithMemoryQueueSize(size int) ServiceOpt {
 func WithMemoryJobTimeout(timeout time.Duration) ServiceOpt {
 	return func(opts *ServiceOpts) {
 		opts.memoryJobTimeout = timeout
+	}
+}
+
+// WithKeyPrefix sets the prefix for all redis keys.
+// If set, all keys will be prefixed with this value
+// followed by a colon. For example, if keyPrefix is
+// "myapp", key "mem:{app:user}" becomes
+// "myapp:mem:{app:user}".
+func WithKeyPrefix(prefix string) ServiceOpt {
+	return func(opts *ServiceOpts) {
+		opts.keyPrefix = prefix
 	}
 }

--- a/memory/redis/service.go
+++ b/memory/redis/service.go
@@ -119,7 +119,7 @@ func (s *Service) AddMemory(ctx context.Context, userKey memory.UserKey, memoryS
 	if err := userKey.CheckUserKey(); err != nil {
 		return err
 	}
-	key := getUserMemKey(userKey)
+	key := s.getUserMemKey(userKey)
 
 	// Enforce memory limit by HLen.
 	if s.opts.memoryLimit > 0 {
@@ -162,7 +162,7 @@ func (s *Service) UpdateMemory(ctx context.Context, memoryKey memory.Key, memory
 	if err := memoryKey.CheckMemoryKey(); err != nil {
 		return err
 	}
-	key := getUserMemKey(memory.UserKey{AppName: memoryKey.AppName, UserID: memoryKey.UserID})
+	key := s.getUserMemKey(memory.UserKey{AppName: memoryKey.AppName, UserID: memoryKey.UserID})
 
 	bytes, err := s.redisClient.HGet(ctx, key, memoryKey.MemoryID).Bytes()
 	if err != nil {
@@ -194,7 +194,7 @@ func (s *Service) DeleteMemory(ctx context.Context, memoryKey memory.Key) error 
 	if err := memoryKey.CheckMemoryKey(); err != nil {
 		return err
 	}
-	key := getUserMemKey(memory.UserKey{AppName: memoryKey.AppName, UserID: memoryKey.UserID})
+	key := s.getUserMemKey(memory.UserKey{AppName: memoryKey.AppName, UserID: memoryKey.UserID})
 	if err := s.redisClient.HDel(ctx, key, memoryKey.MemoryID).Err(); err != nil && err != redis.Nil {
 		return fmt.Errorf("delete memory entry failed: %w", err)
 	}
@@ -206,7 +206,7 @@ func (s *Service) ClearMemories(ctx context.Context, userKey memory.UserKey) err
 	if err := userKey.CheckUserKey(); err != nil {
 		return err
 	}
-	key := getUserMemKey(userKey)
+	key := s.getUserMemKey(userKey)
 	if err := s.redisClient.Del(ctx, key).Err(); err != nil && err != redis.Nil {
 		return fmt.Errorf("clear memories failed: %w", err)
 	}
@@ -218,7 +218,7 @@ func (s *Service) ReadMemories(ctx context.Context, userKey memory.UserKey, limi
 	if err := userKey.CheckUserKey(); err != nil {
 		return nil, err
 	}
-	key := getUserMemKey(userKey)
+	key := s.getUserMemKey(userKey)
 	all, err := s.redisClient.HGetAll(ctx, key).Result()
 	if err == redis.Nil {
 		return []*memory.Entry{}, nil
@@ -253,7 +253,7 @@ func (s *Service) SearchMemories(ctx context.Context, userKey memory.UserKey, qu
 	if err := userKey.CheckUserKey(); err != nil {
 		return nil, err
 	}
-	key := getUserMemKey(userKey)
+	key := s.getUserMemKey(userKey)
 	all, err := s.redisClient.HGetAll(ctx, key).Result()
 	if err == redis.Nil {
 		return []*memory.Entry{}, nil
@@ -312,7 +312,35 @@ func (s *Service) Close() error {
 	return nil
 }
 
+// prefixedKey adds the configured key prefix to the given
+// base key. If no prefix is configured, returns the base
+// key unchanged.
+func (s *Service) prefixedKey(base string) string {
+	if s.opts.keyPrefix != "" {
+		return s.opts.keyPrefix + ":" + base
+	}
+	return base
+}
+
 // getUserMemKey builds the Redis key for a user's memories.
-func getUserMemKey(userKey memory.UserKey) string {
-	return fmt.Sprintf("mem:{%s}:%s", userKey.AppName, userKey.UserID)
+// The hash tag includes both AppName and UserID so that
+// each user's hash is independently distributed across
+// Redis Cluster slots.
+//
+// Key format change: the hash tag was changed from
+// {AppName} to {AppName:UserID} for better cluster slot
+// distribution. If you are upgrading from a version that
+// used the old key format "mem:{AppName}:UserID", you
+// must migrate your data. See the memory documentation
+// for migration instructions.
+func (s *Service) getUserMemKey(
+	userKey memory.UserKey,
+) string {
+	return s.prefixedKey(
+		fmt.Sprintf(
+			"mem:{%s:%s}",
+			userKey.AppName,
+			userKey.UserID,
+		),
+	)
 }

--- a/memory/redis/service_test.go
+++ b/memory/redis/service_test.go
@@ -29,6 +29,11 @@ import (
 )
 
 func TestGetUserMemKey(t *testing.T) {
+	url, cleanup := setupTestRedis(t)
+	defer cleanup()
+	svc, err := NewService(WithRedisClientURL(url))
+	require.NoError(t, err)
+
 	tests := []struct {
 		name     string
 		userKey  memory.UserKey
@@ -40,7 +45,7 @@ func TestGetUserMemKey(t *testing.T) {
 				AppName: "test-app",
 				UserID:  "test-user",
 			},
-			expected: "mem:{test-app}:test-user",
+			expected: "mem:{test-app:test-user}",
 		},
 		{
 			name: "user key with special characters",
@@ -48,16 +53,33 @@ func TestGetUserMemKey(t *testing.T) {
 				AppName: "my-app-123",
 				UserID:  "user_456",
 			},
-			expected: "mem:{my-app-123}:user_456",
+			expected: "mem:{my-app-123:user_456}",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			key := getUserMemKey(tt.userKey)
+			key := svc.getUserMemKey(tt.userKey)
 			assert.Equal(t, tt.expected, key)
 		})
 	}
+}
+
+func TestGetUserMemKeyWithPrefix(t *testing.T) {
+	url, cleanup := setupTestRedis(t)
+	defer cleanup()
+	svc, err := NewService(
+		WithRedisClientURL(url),
+		WithKeyPrefix("myapp"),
+	)
+	require.NoError(t, err)
+
+	userKey := memory.UserKey{
+		AppName: "test-app",
+		UserID:  "test-user",
+	}
+	key := svc.getUserMemKey(userKey)
+	assert.Equal(t, "myapp:mem:{test-app:test-user}", key)
 }
 
 func TestServiceOpts_Defaults(t *testing.T) {
@@ -172,11 +194,13 @@ func TestServiceOpts_CombinedOptions(t *testing.T) {
 	WithRedisClientURL("redis://localhost:6379")(&opts)
 	WithMemoryLimit(1000)(&opts)
 	WithRedisInstance("backup-instance")(&opts)
+	WithKeyPrefix("myprefix")(&opts)
 
 	// Verify all options are set correctly.
 	assert.Equal(t, "redis://localhost:6379", opts.url)
 	assert.Equal(t, 1000, opts.memoryLimit)
 	assert.Equal(t, "backup-instance", opts.instanceName)
+	assert.Equal(t, "myprefix", opts.keyPrefix)
 }
 
 func TestServiceOpts_ToolManagement(t *testing.T) {
@@ -566,6 +590,73 @@ func TestNewService_ConnectionSuccess(t *testing.T) {
 	assert.NotNil(t, entries)
 }
 
+func TestWithKeyPrefix(t *testing.T) {
+	opts := ServiceOpts{}
+	WithKeyPrefix("myprefix")(&opts)
+	assert.Equal(t, "myprefix", opts.keyPrefix)
+}
+
+func TestWithKeyPrefix_Empty(t *testing.T) {
+	opts := ServiceOpts{keyPrefix: "existing"}
+	WithKeyPrefix("")(&opts)
+	assert.Equal(t, "", opts.keyPrefix)
+}
+
+func TestService_WithKeyPrefix_E2E(t *testing.T) {
+	url, cleanup := setupTestRedis(t)
+	defer cleanup()
+
+	const prefix = "test-prefix"
+
+	svc, err := NewService(
+		WithRedisClientURL(url),
+		WithKeyPrefix(prefix),
+	)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	userKey := memory.UserKey{
+		AppName: "test-app",
+		UserID:  "u1",
+	}
+
+	// Add a memory.
+	require.NoError(t, svc.AddMemory(
+		ctx, userKey, "hello world", []string{"greeting"},
+	))
+
+	// Read it back.
+	entries, err := svc.ReadMemories(ctx, userKey, 10)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "hello world", entries[0].Memory.Memory)
+
+	// Verify the actual Redis key contains the prefix.
+	key := svc.getUserMemKey(userKey)
+	assert.Equal(
+		t,
+		prefix+":mem:{test-app:u1}",
+		key,
+	)
+
+	// Search should also work with prefix.
+	results, err := svc.SearchMemories(
+		ctx, userKey, "hello",
+	)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	// Different prefix = isolated data.
+	svc2, err := NewService(
+		WithRedisClientURL(url),
+		WithKeyPrefix("other-prefix"),
+	)
+	require.NoError(t, err)
+	entries2, err := svc2.ReadMemories(ctx, userKey, 10)
+	require.NoError(t, err)
+	assert.Len(t, entries2, 0)
+}
+
 func TestNewService_InstanceName_ConnectionFailure(t *testing.T) {
 	// Register an instance with invalid Redis address that will fail on ping.
 	storage.RegisterRedisInstance("test-instance-failure", storage.WithClientBuilderURL("redis://255.255.255.255:6379"))
@@ -732,7 +823,7 @@ func TestService_UpdateMemory_UnmarshalError(t *testing.T) {
 	require.Len(t, entries, 1)
 
 	// Manually corrupt the data in Redis to trigger unmarshal error
-	key := getUserMemKey(userKey)
+	key := svc.getUserMemKey(userKey)
 	svc.redisClient.HSet(ctx, key, entries[0].ID, []byte("invalid json"))
 
 	// Try to update - should get unmarshal error
@@ -753,7 +844,7 @@ func TestService_ReadMemories_UnmarshalError(t *testing.T) {
 	userKey := memory.UserKey{AppName: "test-app", UserID: "u1"}
 
 	// Manually add corrupted data to Redis
-	key := getUserMemKey(userKey)
+	key := svc.getUserMemKey(userKey)
 	svc.redisClient.HSet(ctx, key, "corrupt-id", []byte("invalid json"))
 
 	// Try to read - should get unmarshal error
@@ -773,7 +864,7 @@ func TestService_SearchMemories_UnmarshalError(t *testing.T) {
 	userKey := memory.UserKey{AppName: "test-app", UserID: "u1"}
 
 	// Manually add corrupted data to Redis
-	key := getUserMemKey(userKey)
+	key := svc.getUserMemKey(userKey)
 	svc.redisClient.HSet(ctx, key, "corrupt-id", []byte("invalid json"))
 
 	// Try to search - should get unmarshal error

--- a/memory/redis/service_test.go
+++ b/memory/redis/service_test.go
@@ -28,12 +28,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
 
-func TestGetUserMemKey(t *testing.T) {
-	url, cleanup := setupTestRedis(t)
-	defer cleanup()
-	svc, err := NewService(WithRedisClientURL(url))
-	require.NoError(t, err)
-
+func TestBuildUserMemKey(t *testing.T) {
 	tests := []struct {
 		name     string
 		userKey  memory.UserKey
@@ -59,7 +54,7 @@ func TestGetUserMemKey(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			key := svc.getUserMemKey(tt.userKey)
+			key := buildUserMemKey(tt.userKey)
 			assert.Equal(t, tt.expected, key)
 		})
 	}
@@ -80,6 +75,11 @@ func TestGetUserMemKeyWithPrefix(t *testing.T) {
 	}
 	key := svc.getUserMemKey(userKey)
 	assert.Equal(t, "myapp:mem:{test-app:test-user}", key)
+}
+
+func TestPrefixedKey_NoDoubleColon(t *testing.T) {
+	s := &Service{opts: ServiceOpts{keyPrefix: "myapp:"}}
+	assert.Equal(t, "myapp:mem:{a:b}", s.prefixedKey("mem:{a:b}"))
 }
 
 func TestServiceOpts_Defaults(t *testing.T) {


### PR DESCRIPTION
## Summary by Sourcery

添加可配置的 Redis 键前缀，并更新内存键格式，使用组合的 AppName+UserID 哈希标签，以获得更好的 Redis 集群分布，并相应地更新服务逻辑、测试和文档。

新功能：
- 为基于 Redis 的内存服务引入键前缀选项，使所有键都可以按环境或服务进行命名空间隔离。

增强：
- 更改 Redis 内存键格式，使用同时包含 AppName 和 UserID 的哈希标签，以改进集群槽位分布。
- 将所有 Redis 键的构造统一通过服务方法进行，并在其中应用已配置的键前缀。

文档：
- 为 `WithKeyPrefix` 选项编写文档，并在英文和中文的内存存储指南中提供使用示例。

测试：
- 扩展和调整 Redis 服务测试，以覆盖新的键前缀行为、更新后的键格式，以及选项从配置到生效的端到端连接。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable Redis key prefixing and update memory key format to use a combined AppName+UserID hash tag for better Redis Cluster distribution, updating service logic, tests, and docs accordingly.

New Features:
- Introduce a key prefix option for the Redis-backed memory service so all keys can be namespaced per environment or service.

Enhancements:
- Change the Redis memory key format to use a hash tag containing both AppName and UserID to improve cluster slot distribution.
- Route all Redis key construction through service methods that apply the configured key prefix.

Documentation:
- Document the WithKeyPrefix option and provide usage examples in both English and Chinese memory storage guides.

Tests:
- Extend and adjust Redis service tests to cover the new key prefix behavior, updated key format, and option wiring end-to-end.

</details>