### PR TITLE
fix: support for alternative reasoning data e.g. Ollama

### DIFF
--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -1350,7 +1350,11 @@ func extractReasoningContent(extraFields map[string]respjson.Field) string {
 	}
 	reasoningField, ok := extraFields[model.ReasoningContentKey]
 	if !ok {
-		return ""
+		// Ollama and some providers use "reasoning" instead of "reasoning_content".
+		reasoningField, ok = extraFields[model.ReasoningContentKeyAlt]
+		if !ok {
+			return ""
+		}
 	}
 	reasoningStr, err := strconv.Unquote(reasoningField.Raw())
 	if err == nil {

--- a/model/request.go
+++ b/model/request.go
@@ -38,6 +38,8 @@ const (
 	ThinkingTokensKey = "thinking_tokens"
 	// ReasoningContentKey is the key used for reasoning content in API responses.
 	ReasoningContentKey = "reasoning_content"
+	// ReasoningContentKeyAlt is the alternative key used by some providers (e.g. Ollama).
+	ReasoningContentKeyAlt = "reasoning"
 	// EnabledThinkingKey is the key used for enabling thinking mode in API requests e.g. Qwen model.
 	EnabledThinkingKey = "enabled_thinking"
 )


### PR DESCRIPTION

I have read the CLA Document and I hereby sign the CLA


## 由 Sourcery 提供的摘要

添加对部分服务商使用的替代“reasoning”元数据字段的支持，从而能够一致地提取推理内容。

新功能：
- 支持从一些服务商（如 Ollama）使用的备用响应字段中提取推理内容。

改进：
- 将替代的推理字段键集中定义在共享请求模型中，便于在多个服务商之间复用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for alternative reasoning metadata keys used by some providers so reasoning content can be extracted consistently.

New Features:
- Support extracting reasoning content from an alternative response key used by providers like Ollama.

Enhancements:
- Centralize the alternative reasoning key definition in the shared request model for reuse across providers.

</details>