### PR TITLE
fix: more robust codeblock unmarshalling

### DIFF
--- a/tool/codeexec/codeexec.go
+++ b/tool/codeexec/codeexec.go
@@ -170,28 +170,23 @@ func unmarshalCodeBlocks(raw json.RawMessage) ([]codeexecutor.CodeBlock, error) 
 
 	// If the LLM double-encoded the array as a JSON string, unwrap and re-parse.
 	if s, ok := val.(string); ok {
-		if err := json.Unmarshal([]byte(s), &val); err != nil {
+		raw = json.RawMessage(s)
+		if err := json.Unmarshal(raw, &val); err != nil {
 			return nil, err
 		}
-	}
-
-	// Re-marshal the normalized value so we can decode into the target type.
-	normalized, err := json.Marshal(val)
-	if err != nil {
-		return nil, err
 	}
 
 	switch val.(type) {
 	case []any:
 		var blocks []codeexecutor.CodeBlock
-		if err := json.Unmarshal(normalized, &blocks); err != nil {
+		if err := json.Unmarshal(raw, &blocks); err != nil {
 			return nil, err
 		}
 		return blocks, nil
 	case map[string]any:
 		// Single object — wrap into a slice.
 		var block codeexecutor.CodeBlock
-		if err := json.Unmarshal(normalized, &block); err != nil {
+		if err := json.Unmarshal(raw, &block); err != nil {
 			return nil, err
 		}
 		return []codeexecutor.CodeBlock{block}, nil

--- a/tool/codeexec/codeexec_test.go
+++ b/tool/codeexec/codeexec_test.go
@@ -344,6 +344,16 @@ func Test_unmarshalCodeBlocks(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	t.Run("array with non-object element", func(t *testing.T) {
+		_, err := unmarshalCodeBlocks(json.RawMessage(`[42]`))
+		require.Error(t, err)
+	})
+
+	t.Run("object with invalid field type", func(t *testing.T) {
+		_, err := unmarshalCodeBlocks(json.RawMessage(`{"language":[1,2,3],"code":"x"}`))
+		require.Error(t, err)
+	})
+
 	t.Run("whitespace before value", func(t *testing.T) {
 		raw := json.RawMessage(`  [{"language":"python","code":"1"}]`)
 		blocks, err := unmarshalCodeBlocks(raw)


### PR DESCRIPTION
I have encountered codeblocks from certain models (e.g. Kimi) where the codeblock is not in an array. I am re-submitting this with tests because #1232 was closed (accidentally?). 

I have read the CLA Document and I hereby sign the CLA

## Summary by Sourcery

提高在从 LLM 响应中反序列化 `code_blocks` 时，`execute-code` 工具的健壮性。

Bug Fixes:
- 处理以双重编码 JSON 字符串形式提供的 `code_blocks`，以及以单个对象而非数组形式提供的 `code_blocks`，从而避免在这些 LLM 特殊行为下出现失败。

Tests:
- 为双重编码的 `code_blocks` 字符串、单对象形式的 `code_blocks`，以及格式错误或无效的 `code_blocks` 负载添加测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve robustness of the execute-code tool when unmarshalling code_blocks from LLM responses.

Bug Fixes:
- Handle code_blocks provided as a double-encoded JSON string and as a single object instead of an array, avoiding failures on these LLM quirks.

Tests:
- Add test coverage for double-encoded code_blocks strings, single-object code_blocks, and malformed or invalid code_blocks payloads.

</details>