### PR TITLE
fix(gemini): prevent duplicate output by separating Delta/Message on streaming responses

### DIFF
--- a/model/gemini/gemini_test.go
+++ b/model/gemini/gemini_test.go
@@ -332,9 +332,6 @@ func TestModel_buildFinalResponse(t *testing.T) {
 						Message: model.Message{
 							Role: model.RoleAssistant,
 						},
-						Delta: model.Message{
-							Role: model.RoleAssistant,
-						},
 					},
 				},
 			},
@@ -386,20 +383,6 @@ func TestModel_buildFinalResponse(t *testing.T) {
 					{
 						Index:        0,
 						FinishReason: &finishReason,
-						Delta: model.Message{
-							Role:             model.RoleAssistant,
-							ReasoningContent: "Thought",
-							Content:          "Answer",
-							ToolCalls: []model.ToolCall{
-								{
-									ID: "id",
-									Function: model.FunctionDefinitionParam{
-										Name:      "function_call",
-										Arguments: functionArgsBytes,
-									},
-								},
-							},
-						},
 						Message: model.Message{
 							Role:             model.RoleAssistant,
 							ReasoningContent: "Thought",
@@ -464,19 +447,6 @@ func TestModel_buildFinalResponse(t *testing.T) {
 					{
 						Index:        0,
 						FinishReason: &finishReason,
-						Delta: model.Message{
-							Role:    model.RoleAssistant,
-							Content: "Answer",
-							ToolCalls: []model.ToolCall{
-								{
-									ID: "id",
-									Function: model.FunctionDefinitionParam{
-										Name:      "function_call",
-										Arguments: functionArgsBytes,
-									},
-								},
-							},
-						},
 						Message: model.Message{
 							Role:    model.RoleAssistant,
 							Content: "Answer",
@@ -579,20 +549,6 @@ func TestModel_buildChunkResponse(t *testing.T) {
 						Index:        0,
 						FinishReason: &finishReason,
 						Delta: model.Message{
-							Role:             model.RoleAssistant,
-							ReasoningContent: "Thought",
-							Content:          "Answer",
-							ToolCalls: []model.ToolCall{
-								{
-									ID: "id",
-									Function: model.FunctionDefinitionParam{
-										Name:      "function_call",
-										Arguments: functionArgsBytes,
-									},
-								},
-							},
-						},
-						Message: model.Message{
 							Role:             model.RoleAssistant,
 							ReasoningContent: "Thought",
 							Content:          "Answer",
@@ -1152,7 +1108,7 @@ func TestModel_GenerateContentStreamingError(t *testing.T) {
 		assert.NotNil(t, resp)
 		assert.Nil(t, resp.Error)
 		assert.Len(t, resp.Choices, 1)
-		assert.Equal(t, "partial response", resp.Choices[0].Message.Content)
+		assert.Equal(t, "partial response", resp.Choices[0].Delta.Content)
 
 		// Second response should be the error
 		errorResp := <-respChan


### PR DESCRIPTION
Confidence: Medium

## Problem


Gemini streaming responses cause **duplicate text output** in downstream consumers. The full LLM response appears twice in the chat UI — once during streaming and once when the final accumulated response arrives.
## Root Cause
In [buildChatCompletionResponse](./model/gemini/gemini.go:261:0-313:1), both [Message](cci:1://file:///Users/sabithks/src/github.com/appcd-dev/genie/pkg/messenger/agui/event_adapter.go:30:0-41:1) and [Delta](./runner/runner.go:1125:0-1138:1) were set to the **same value** for all response types (streaming chunks and final responses):
```go
response.Choices = []model.Choice{
    {
        Message: message,  // ← set on streaming chunks too
        Delta:   message,  // ← identical value
    },
}
```

## Summary by Sourcery

通过在流式模式下将部分片段使用 Delta、最终响应使用 Message 来区分处理，调整 Gemini 对话补全的响应逻辑，以避免重复内容。

Bug Fixes:
- 通过仅在 Gemini 的部分流式响应中设置 Delta、在最终响应中设置 Message，防止在流式消费端出现重复的 LLM 输出。

Tests:
- 更新 Gemini 模型测试，以反映对流式片段使用 Delta、对最终响应使用 Message 的新区分方式，并包含对流式错误处理的预期测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust Gemini chat completion responses to avoid duplicate content in streaming mode by separating use of Delta for partial chunks and Message for final responses.

Bug Fixes:
- Prevent duplicate LLM output in streaming consumers by only setting Delta on partial Gemini responses and Message on final responses.

Tests:
- Update Gemini model tests to reflect the new separation of Delta for streaming chunks and Message for final responses, including expectations for streaming error handling.

</details>