### PR TITLE
internal/flow/llmflow: recover panics in Flow.Run

### DIFF
--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -170,18 +170,13 @@ func recoverFlowRunPanic(
 		return
 	}
 
-	panicValue, ok := flowPanicValue(recovered)
-	if !ok {
-		panic(recovered)
-	}
-
 	stack := debug.Stack()
 	log.ErrorfContext(
 		ctx,
 		flowRunPanicLogFmt,
 		flowInvocationID(invocation),
 		flowAgentName(invocation),
-		panicValue,
+		recovered,
 		string(stack),
 	)
 
@@ -189,20 +184,9 @@ func recoverFlowRunPanic(
 		flowInvocationID(invocation),
 		flowAgentName(invocation),
 		model.ErrorTypeFlowError,
-		fmt.Sprintf(flowRunPanicErrFmt, panicValue),
+		fmt.Sprintf(flowRunPanicErrFmt, recovered),
 	)
 	agent.EmitEvent(ctx, invocation, eventChan, errorEvent)
-}
-
-func flowPanicValue(recovered any) (any, bool) {
-	switch v := recovered.(type) {
-	case error:
-		return v, true
-	case string:
-		return v, true
-	default:
-		return nil, false
-	}
 }
 
 func flowInvocationID(invocation *agent.Invocation) string {

--- a/internal/flow/llmflow/llmflow_test.go
+++ b/internal/flow/llmflow/llmflow_test.go
@@ -333,32 +333,27 @@ func TestRecoverFlowRunPanic_NoPanic(t *testing.T) {
 	}()
 }
 
-func TestRecoverFlowRunPanic_RePanicsUnknownType(t *testing.T) {
-	require.PanicsWithValue(
-		t,
-		flowRunPanicTestUnknownValue,
-		func() {
-			defer recoverFlowRunPanic(context.Background(), nil, nil)
-			panic(flowRunPanicTestUnknownValue)
-		},
-	)
-}
+func TestRecoverFlowRunPanic_EmitsEventForUnknownType(t *testing.T) {
+	ctx := context.Background()
+	invocation := &agent.Invocation{
+		InvocationID: "test-invocation",
+		AgentName:    "test-agent",
+	}
+	eventChan := make(chan *event.Event, 1)
 
-func TestFlowPanicValue(t *testing.T) {
-	errorVal, ok := flowPanicValue(errors.New(flowRunPanicTestMsg))
-	require.True(t, ok)
+	func() {
+		defer recoverFlowRunPanic(ctx, invocation, eventChan)
+		panic(flowRunPanicTestUnknownValue)
+	}()
 
-	errorPanic, ok := errorVal.(error)
-	require.True(t, ok)
-	require.Equal(t, flowRunPanicTestMsg, errorPanic.Error())
-
-	stringVal, ok := flowPanicValue(flowRunPanicTestMsg)
-	require.True(t, ok)
-	require.Equal(t, flowRunPanicTestMsg, stringVal)
-
-	unknownVal, ok := flowPanicValue(flowRunPanicTestUnknownValue)
-	require.False(t, ok)
-	require.Nil(t, unknownVal)
+	select {
+	case evt := <-eventChan:
+		require.NotNil(t, evt.Error)
+		require.Equal(t, model.ErrorTypeFlowError, evt.Error.Type)
+		require.Contains(t, evt.Error.Message, "123")
+	default:
+		t.Fatal("expected error event")
+	}
 }
 
 func TestFlowInvocationIDAndAgentName(t *testing.T) {


### PR DESCRIPTION
## Summary
- Recover panics in the `Flow.Run` goroutine, log the stack trace, and emit a `flow_error` event instead of crashing the whole process.
- Add a regression test that panics in a request processor and asserts an error event is emitted.

## Notes
- The recovery only handles `error` and `string` panic values (unknown types are re-panicked).

## Testing
- go test ./internal/flow/llmflow -count=1

## Summary by Sourcery

在执行 flow 时处理 panic，而不会使进程崩溃，并将其作为 flow 错误事件进行呈现。

Bug 修复：
- 在 `Flow.Run` 中从 panic 中恢复，记录堆栈跟踪并发出 `flow_error` 事件，而不是终止进程。

测试：
- 添加一个回归测试，模拟请求处理器中的 panic，并断言会发出 `flow_error` 事件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle panics during flow execution without crashing the process and surface them as flow error events.

Bug Fixes:
- Recover from panics in Flow.Run, logging the stack trace and emitting a flow_error event instead of terminating the process.

Tests:
- Add a regression test that simulates a panic in a request processor and asserts that a flow_error event is emitted.

</details>