### PR TITLE
docs: use English within Chinese-language directories

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -78,7 +78,7 @@ plugins:
                 - Runner: runner.md
                 - Model: model.md
                 - Callbacks: callbacks.md
-                - 插件: plugin.md
+                - Plugins: plugin.md
                 - Memory: memory.md
                 - Artifact: artifact.md
                 - Skill: skill.md


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- 将中文文档导航中的插件部分标签从中文术语重命名为英文标签 **`Plugins`**。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Rename the plugin section label in the Chinese docs navigation from a Chinese term to the English label 'Plugins'.

</details>