### PR TITLE
example: suppress false positive B603 warning for subprocess.Popen

### DIFF
--- a/examples/knowledge/evaluation/knowledge_system/trpc_agent_go/knowledge_base.py
+++ b/examples/knowledge/evaluation/knowledge_system/trpc_agent_go/knowledge_base.py
@@ -83,6 +83,7 @@ class TRPCAgentGoKnowledgeBase(KnowledgeBase):
             raise RuntimeError(f"Go binary not found at {GO_SERVICE_PATH}")
 
         print(f"Starting Go service on port {self.port} (search_mode={self.search_mode})...")
+        # nosec B603: GO_SERVICE_PATH is a static local binary, args are internal config not user input.
         TRPCAgentGoKnowledgeBase._process = subprocess.Popen(  # nosec B603
             [GO_SERVICE_PATH, f"--port={self.port}", f"--vectorstore={self.vectorstore}", f"--search-mode={self.search_mode}"],
             cwd=GO_SERVICE_DIR,


### PR DESCRIPTION
…comment

## Summary by Sourcery

Bug Fixes:
- 防止在示例知识库中用于启动 Go 服务的 `subprocess.Popen` 调用触发 Bandit B603 误报警告。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent a false-positive Bandit B603 warning for the subprocess.Popen call used to start the Go service in the example knowledge base.

</details>