### PR TITLE
ci: add cursoragent to CLA allowlist

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -28,4 +28,5 @@ jobs:
           path-to-signatures: 'signatures/${{ github.event.repository.name }}-${{ github.repository_id }}/cla.json'
           path-to-document: 'https://github.com/trpc-group/cla-database/blob/main/Tencent-Contributor-License-Agreement.md'
           # branch should not be protected
-          branch: 'main' 
+          branch: 'main'
+          allowlist: cursoragent

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.3.1
+        uses: contributor-assistant/github-action@v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_DATABASE_ACCESS_TOKEN }}


### PR DESCRIPTION
Bot accounts do not need to sign the Contributor License Agreement. Adding cursoragent to the allowlist so automated PRs from Cursor Agent are not blocked by the CLA check.

## Summary by Sourcery

杂项：
- 通过从已配置的目标分支中删除结尾空白字符，规范 CLA 工作流中的格式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Normalize formatting in the CLA workflow by removing trailing whitespace from the configured target branch.

</details>
- 通过从已配置的目标分支中移除尾随空格来整理 CLA GitHub Actions 工作流。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

杂项：
- 通过从已配置的目标分支中删除结尾空白字符，规范 CLA 工作流中的格式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Normalize formatting in the CLA workflow by removing trailing whitespace from the configured target branch.

</details>

</details>