### PR TITLE
feat: support MCP tool _meta field with backward compatibility

### DIFF
--- a/internal/flow/processor/functioncall.go
+++ b/internal/flow/processor/functioncall.go
@@ -803,6 +803,7 @@ func (p *FunctionCallResponseProcessor) executeToolCall(
 	}
 
 	// Marshal the result to JSON for the default tool message.
+	// Note: mcpToolResult implements MarshalJSON to only marshal Content for backward compatibility.
 	resultBytes, err := json.Marshal(result)
 	if err != nil {
 		// Marshal failures (for example, NaN in floats) do not
@@ -1115,6 +1116,7 @@ func (p *FunctionCallResponseProcessor) runAfterToolCallbacks(
 		Arguments:   toolCall.Function.Arguments,
 		Result:      toolResult,
 		Error:       toolErr,
+		Meta:        extractMetaFromResult(toolResult),
 	}
 	afterResult, err := p.toolCallbacks.RunAfterTool(ctx, args)
 	if err != nil {
@@ -1134,6 +1136,22 @@ func (p *FunctionCallResponseProcessor) runAfterToolCallbacks(
 		toolResult = afterResult.CustomResult
 	}
 	return ctx, toolResult, nil
+}
+
+// extractMetaFromResult extracts metadata from tool result.
+// For MCP mcpToolResult, returns the Meta field.
+func extractMetaFromResult(result any) map[string]any {
+	if result == nil {
+		return nil
+	}
+	// Check for our wrapped mcpToolResult type (from tool/mcp package)
+	type metaGetter interface {
+		GetMeta() map[string]any
+	}
+	if mg, ok := result.(metaGetter); ok {
+		return mg.GetMeta()
+	}
+	return nil
 }
 
 // executeToolWithCallbacks executes a tool with before/after callbacks.

--- a/tool/callbacks.go
+++ b/tool/callbacks.go
@@ -107,6 +107,9 @@ type AfterToolArgs struct {
 	Result any
 	// Error is the error occurred during tool execution (may be nil).
 	Error error
+	// Meta contains optional metadata from the tool result.
+	// For MCP tools, this includes the _meta field from CallToolResult.
+	Meta map[string]any
 }
 
 // AfterToolResult contains the return value for after tool callback.

--- a/tool/mcp/toolset_additional_test.go
+++ b/tool/mcp/toolset_additional_test.go
@@ -117,9 +117,9 @@ func TestSessionManager_CallTool_UsesStructuredContentWhenContentEmpty(t *testin
 
 	result, err := manager.callTool(context.Background(), "test-tool", map[string]any{"key": "value"})
 	require.NoError(t, err)
-	require.Len(t, result, 1)
+	require.Len(t, result.Content, 1)
 
-	structuredText, ok := result[0].(mcp.TextContent)
+	structuredText, ok := result.Content[0].(mcp.TextContent)
 	require.True(t, ok)
 
 	expectedJSON, err := json.Marshal(structured)
@@ -144,9 +144,9 @@ func TestSessionManager_CallTool_IgnoresStructuredContentWhenContentPresent(t *t
 
 	result, err := manager.callTool(context.Background(), "test-tool", map[string]any{"key": "value"})
 	require.NoError(t, err)
-	require.Len(t, result, 1)
+	require.Len(t, result.Content, 1)
 
-	original, ok := result[0].(mcp.TextContent)
+	original, ok := result.Content[0].(mcp.TextContent)
 	require.True(t, ok)
 	assert.Equal(t, "original", original.Text)
 }
@@ -165,7 +165,7 @@ func TestSessionManager_CallTool_NoContentNoStructured(t *testing.T) {
 
 	result, err := manager.callTool(context.Background(), "test-tool", nil)
 	require.NoError(t, err)
-	assert.Len(t, result, 0)
+	assert.Len(t, result.Content, 0)
 }
 
 func TestSessionManager_CallTool_StructuredContentMarshalError(t *testing.T) {
@@ -184,7 +184,7 @@ func TestSessionManager_CallTool_StructuredContentMarshalError(t *testing.T) {
 	result, err := manager.callTool(context.Background(), "test-tool", nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "marshal structured content")
-	assert.Len(t, result, 0)
+	assert.Nil(t, result)
 }
 
 // TestSessionManager_CallTool_Error tests callTool when CallTool returns an error


### PR DESCRIPTION
## Summary by Sourcery

为 MCP 工具保留向后兼容的 JSON 结果的同时，暴露工具元数据，并将其贯穿传递到工具执行后的回调中。

New Features:
- 包装 MCP 工具调用结果，对外暴露一个 Meta 访问器，同时保持其 JSON 表示形式仍为旧版的 Content 数组。
- 通过在 AfterToolArgs 上新增 Meta 字段，将 MCP 工具的 `_meta` 元数据传递到 AfterTool 回调中。

Enhancements:
- 更改 MCP 会话管理器中的工具调用，使其返回完整的 CallToolResult 对象，在保留元数据的同时处理结构化内容。
- 在函数调用处理器中添加从工具结果中提取元数据的工具方法，并在调用工具执行后的回调时使用这些元数据。

Tests:
- 更新 MCP 会话管理器测试以适配新的 CallToolResult 返回类型，并在 content 或 structured content 存在或为 nil 的情况下验证其行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Preserve backward-compatible JSON results for MCP tools while exposing tool metadata and wiring it through to after-tool callbacks.

New Features:
- Wrap MCP tool call results to expose a Meta accessor while keeping the JSON representation as the legacy Content array.
- Propagate MCP tool _meta metadata into AfterTool callbacks via a new Meta field on AfterToolArgs.

Enhancements:
- Change MCP session manager tool calls to return the full CallToolResult object, handling structured content while retaining metadata.
- Add utility to extract metadata from tool results in the function call processor and use it when invoking after-tool callbacks.

Tests:
- Update MCP session manager tests to work with the new CallToolResult return type and validate behavior when content or structured content are present or nil.

</details>