### PR TITLE
model/gemini: normalize tool schemas for function calling

### DIFF
--- a/model/gemini/gemini.go
+++ b/model/gemini/gemini.go
@@ -556,11 +556,12 @@ func normalizeToolSchema(toolName, schemaKind string, schema *tool.Schema) any {
 			toolName,
 			err,
 		)
-		return map[string]any{
-			"type":       "object",
-			"properties": map[string]any{},
-		}
+		return emptyObjectSchema()
 	}
+	return normalizeToolSchemaBytes(toolName, schemaKind, schemaBytes)
+}
+
+func normalizeToolSchemaBytes(toolName, schemaKind string, schemaBytes []byte) any {
 	var out map[string]any
 	if err := json.Unmarshal(schemaBytes, &out); err != nil {
 		log.Warnf(
@@ -569,10 +570,7 @@ func normalizeToolSchema(toolName, schemaKind string, schema *tool.Schema) any {
 			toolName,
 			err,
 		)
-		return map[string]any{
-			"type":       "object",
-			"properties": map[string]any{},
-		}
+		return emptyObjectSchema()
 	}
 	// Some function-calling implementations are strict about top-level object schemas having
 	// an explicit `properties` key, even for no-arg tools.
@@ -582,6 +580,13 @@ func normalizeToolSchema(toolName, schemaKind string, schema *tool.Schema) any {
 		}
 	}
 	return out
+}
+
+func emptyObjectSchema() map[string]any {
+	return map[string]any{
+		"type":       "object",
+		"properties": map[string]any{},
+	}
 }
 
 // convertContentPart converts a single content part to Gemini format.

--- a/model/gemini/gemini_test.go
+++ b/model/gemini/gemini_test.go
@@ -261,6 +261,21 @@ func TestNormalizeToolSchema_MarshalErrorFallsBack(t *testing.T) {
 	require.Empty(t, props)
 }
 
+func TestNormalizeToolSchema_NilSchemaReturnsNil(t *testing.T) {
+	require.Nil(t, normalizeToolSchema("tool", "input", nil))
+}
+
+func TestNormalizeToolSchema_UnmarshalErrorFallsBack(t *testing.T) {
+	normalized := normalizeToolSchemaBytes("tool", "input", []byte("{"))
+
+	out, ok := normalized.(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "object", out["type"])
+	props, ok := out["properties"].(map[string]any)
+	require.True(t, ok)
+	require.Empty(t, props)
+}
+
 func TestModel_buildChatConfig(t *testing.T) {
 	var (
 		MaxTokens        = 10


### PR DESCRIPTION
close https://github.com/trpc-group/trpc-agent-go/issues/1252

## Summary by Sourcery

规范 Gemini 工具的函数调用模式（schema），以避免出现空的参数模式，并确保对象结构的一致性。

Bug 修复：
- 在发送给 Gemini 的请求中，对于没有输入模式的工具，避免发送空的 `parametersJsonSchema`。

增强：
- 在发送给 Gemini 之前，先对工具的输入和输出 JSON 模式进行规范化，确保对象模式始终包含 `properties` 字段。

测试：
- 新增测试，用于验证在序列化时，对于输入模式为 nil 的工具，会省略 `parametersJsonSchema` 字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize Gemini tool schemas for function calling to avoid null parameter schemas and ensure consistent object structure.

Bug Fixes:
- Avoid sending a null parametersJsonSchema for tools without input schemas in Gemini requests.

Enhancements:
- Normalize tool input and output JSON schemas before sending them to Gemini, ensuring object schemas always include a properties field.

Tests:
- Add a test verifying that tools with nil input schemas omit the parametersJsonSchema field when marshaled.

</details>