### PR TITLE
{docs, examples}: clarify graph node hooks

### DIFF
--- a/examples/graph/runner_plugin_node_callbacks/README.md
+++ b/examples/graph/runner_plugin_node_callbacks/README.md
@@ -1,0 +1,49 @@
+# Runner Plugin + Graph Node Callbacks
+
+This example answers a common question:
+
+> Runner plugins can hook `agent/model/tool/event`.  
+> How do I intercept **graph nodes** globally (including function nodes)?
+
+In this project, **graph nodes are not a Runner plugin hook point**.
+Graph node execution happens inside the graph engine, and the graph package
+provides its own hook system: `graph.NodeCallbacks`.
+
+This example shows an *advanced* pattern:
+
+- Use a **Runner plugin** (`BeforeAgent`) to inject `graph.NodeCallbacks` into
+  `Invocation.RunOptions.RuntimeState`.
+- The graph engine reads `graph.StateKeyNodeCallbacks` from runtime state and
+  treats it as **graph-wide node callbacks** for that run.
+
+## What you will learn
+
+1. How to build a tiny graph with function nodes.
+2. How to write `graph.NodeCallbacks` (`BeforeNode` / `AfterNode`).
+3. How to inject those callbacks from a Runner plugin.
+
+## Run it
+
+```bash
+cd examples/graph/runner_plugin_node_callbacks
+go run . -input "hello plugin hooks"
+```
+
+## What to look for
+
+- You should see `[node before]` and `[node after]` logs for each node.
+- The final answer is produced by the last function node by writing
+  `graph.StateKeyLastResponse`.
+
+## When you should *not* use this
+
+If you control the graph construction, prefer the simpler API:
+
+```go
+graph.NewStateGraph(schema).
+    WithNodeCallbacks(globalCallbacks)
+```
+
+The injection approach is mainly for cases where you need runner-scoped
+cross-cutting behavior without changing every graph builder.
+

--- a/examples/graph/runner_plugin_node_callbacks/main.go
+++ b/examples/graph/runner_plugin_node_callbacks/main.go
@@ -1,0 +1,311 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+// Package main demonstrates how to apply graph NodeCallbacks from a
+// runner-scoped plugin.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"reflect"
+	"strings"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/graphagent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/graph"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/plugin"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+)
+
+const (
+	appName     = "runner-plugin-node-callbacks"
+	agentName   = "demo-graph"
+	userID      = "demo-user"
+	sessionPref = "demo-session"
+
+	nodeUpper  = "upper"
+	nodeAnswer = "answer"
+
+	stateKeyUpper = "upper_text"
+
+	answerPrefix = "Uppercase: "
+	emptyInput   = "(empty)"
+
+	pluginName = "inject_node_callbacks"
+)
+
+var input = flag.String(
+	"input",
+	"hello plugin hooks",
+	"User input for the graph",
+)
+
+func main() {
+	flag.Parse()
+
+	g, err := buildGraph()
+	if err != nil {
+		log.Fatalf("build graph: %v", err)
+	}
+
+	ga, err := graphagent.New(agentName, g)
+	if err != nil {
+		log.Fatalf("create graph agent: %v", err)
+	}
+
+	cb := newNodeLoggerCallbacks()
+	p := &nodeCallbacksPlugin{callbacks: cb}
+
+	r := runner.NewRunner(
+		appName,
+		ga,
+		runner.WithPlugins(p),
+	)
+	defer r.Close()
+
+	ctx := context.Background()
+	sessionID := fmt.Sprintf("%s-%d", sessionPref, time.Now().Unix())
+
+	events, err := r.Run(
+		ctx,
+		userID,
+		sessionID,
+		model.NewUserMessage(*input),
+		agent.WithStreamMode(agent.StreamModeTasks),
+	)
+	if err != nil {
+		log.Fatalf("run: %v", err)
+	}
+
+	completion := waitRunnerCompletion(events)
+	if err := printCompletion(completion); err != nil {
+		log.Fatalf("print result: %v", err)
+	}
+}
+
+func buildGraph() (*graph.Graph, error) {
+	schema := graph.NewStateSchema().
+		AddField(graph.StateKeyUserInput, graph.StateField{
+			Type:    reflect.TypeOf(""),
+			Reducer: graph.DefaultReducer,
+		}).
+		AddField(stateKeyUpper, graph.StateField{
+			Type:    reflect.TypeOf(""),
+			Reducer: graph.DefaultReducer,
+		}).
+		AddField(graph.StateKeyLastResponse, graph.StateField{
+			Type:    reflect.TypeOf(""),
+			Reducer: graph.DefaultReducer,
+		})
+
+	return graph.NewStateGraph(schema).
+		AddNode(nodeUpper, upperNode).
+		AddNode(nodeAnswer, answerNode).
+		SetEntryPoint(nodeUpper).
+		AddEdge(nodeUpper, nodeAnswer).
+		SetFinishPoint(nodeAnswer).
+		Compile()
+}
+
+func upperNode(ctx context.Context, state graph.State) (any, error) {
+	_ = ctx
+	input, _ := state[graph.StateKeyUserInput].(string)
+	return graph.State{
+		stateKeyUpper: strings.ToUpper(input),
+	}, nil
+}
+
+func answerNode(ctx context.Context, state graph.State) (any, error) {
+	_ = ctx
+	upper, _ := state[stateKeyUpper].(string)
+	if upper == "" {
+		upper = emptyInput
+	}
+	answer := answerPrefix + upper
+	return graph.State{
+		graph.StateKeyLastResponse: answer,
+	}, nil
+}
+
+func newNodeLoggerCallbacks() *graph.NodeCallbacks {
+	return graph.NewNodeCallbacks().
+		RegisterBeforeNode(beforeNodeLog).
+		RegisterAfterNode(afterNodeLog).
+		RegisterOnNodeError(onNodeErrorLog)
+}
+
+func beforeNodeLog(
+	ctx context.Context,
+	cbCtx *graph.NodeCallbackContext,
+	state graph.State,
+) (any, error) {
+	_ = ctx
+	_ = state
+
+	if cbCtx == nil || cbCtx.NodeType != graph.NodeTypeFunction {
+		return nil, nil
+	}
+
+	fmt.Printf(
+		"[node before] step=%d id=%s\n",
+		cbCtx.StepNumber,
+		cbCtx.NodeID,
+	)
+	return nil, nil
+}
+
+func afterNodeLog(
+	ctx context.Context,
+	cbCtx *graph.NodeCallbackContext,
+	state graph.State,
+	result any,
+	nodeErr error,
+) (any, error) {
+	_ = ctx
+	_ = state
+	_ = result
+	_ = nodeErr
+
+	if cbCtx == nil || cbCtx.NodeType != graph.NodeTypeFunction {
+		return nil, nil
+	}
+
+	fmt.Printf(
+		"[node after]  step=%d id=%s\n",
+		cbCtx.StepNumber,
+		cbCtx.NodeID,
+	)
+	return nil, nil
+}
+
+func onNodeErrorLog(
+	ctx context.Context,
+	cbCtx *graph.NodeCallbackContext,
+	state graph.State,
+	err error,
+) {
+	_ = ctx
+	_ = state
+
+	if cbCtx == nil || err == nil {
+		return
+	}
+
+	fmt.Printf(
+		"[node error] id=%s err=%v\n",
+		cbCtx.NodeID,
+		err,
+	)
+}
+
+type nodeCallbacksPlugin struct {
+	callbacks *graph.NodeCallbacks
+}
+
+func (p *nodeCallbacksPlugin) Name() string { return pluginName }
+
+func (p *nodeCallbacksPlugin) Register(reg *plugin.Registry) {
+	reg.BeforeAgent(p.beforeAgent)
+}
+
+func (p *nodeCallbacksPlugin) beforeAgent(
+	ctx context.Context,
+	args *agent.BeforeAgentArgs,
+) (*agent.BeforeAgentResult, error) {
+	_ = ctx
+	if p == nil || p.callbacks == nil {
+		return nil, nil
+	}
+	if args == nil || args.Invocation == nil {
+		return nil, nil
+	}
+
+	inv := args.Invocation
+	if inv.RunOptions.RuntimeState == nil {
+		inv.RunOptions.RuntimeState = make(map[string]any)
+	}
+	if inv.RunOptions.RuntimeState[graph.StateKeyNodeCallbacks] != nil {
+		return nil, nil
+	}
+	inv.RunOptions.RuntimeState[graph.StateKeyNodeCallbacks] = p.callbacks
+	return nil, nil
+}
+
+func waitRunnerCompletion(events <-chan *event.Event) *event.Event {
+	var completion *event.Event
+	for e := range events {
+		if e == nil || e.Response == nil {
+			continue
+		}
+		if e.Response.Object == model.ObjectTypeRunnerCompletion {
+			completion = e
+		}
+	}
+	return completion
+}
+
+func printCompletion(e *event.Event) error {
+	if e == nil || e.Response == nil {
+		return errors.New("missing runner completion event")
+	}
+
+	fmt.Println()
+	fmt.Println("Final answer:")
+	if text, ok := assistantText(e); ok {
+		fmt.Println(text)
+	}
+
+	fmt.Println()
+	fmt.Println("Selected final state values:")
+	if upper, ok := stateString(e.StateDelta, stateKeyUpper); ok {
+		fmt.Printf("- %s: %s\n", stateKeyUpper, upper)
+	}
+	if last, ok := stateString(e.StateDelta, graph.StateKeyLastResponse); ok {
+		fmt.Printf("- %s: %s\n", graph.StateKeyLastResponse, last)
+	}
+	return nil
+}
+
+func assistantText(e *event.Event) (string, bool) {
+	if e == nil || e.Response == nil {
+		return "", false
+	}
+	if len(e.Response.Choices) == 0 {
+		return "", false
+	}
+	msg := e.Response.Choices[0].Message
+	if msg.Role != model.RoleAssistant || msg.Content == "" {
+		return "", false
+	}
+	return msg.Content, true
+}
+
+func stateString(delta map[string][]byte, key string) (string, bool) {
+	if delta == nil || key == "" {
+		return "", false
+	}
+	raw, ok := delta[key]
+	if !ok || len(raw) == 0 {
+		return "", false
+	}
+	var out string
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return "", false
+	}
+	return out, true
+}


### PR DESCRIPTION
## What
Clarify how to hook graph node execution (including function nodes) and how it relates to Runner plugins.

## Why
Runner plugins expose hook points for agent/model/tool/event, but graph nodes are executed inside the graph engine. Users were unsure how to apply cross-cutting logic globally across nodes.

## Changes
- Docs (EN/ZH): add a Graph node hooks section to plugin docs and expand graph docs with:
  - graph-wide vs per-node NodeCallbacks
  - callback execution order
  - advanced pattern: inject `graph.StateKeyNodeCallbacks` via `BeforeAgent`
  - StreamMode filtering notes
  - links to runnable examples
- Example: add `examples/graph/runner_plugin_node_callbacks` to demonstrate injecting NodeCallbacks from a Runner plugin.

## Test
- `CGO_ENABLED=0 go test ./agent ./agent/graphagent ./plugin ./runner`
- `CGO_ENABLED=0 go test ./...` (in `examples/graph/runner_plugin_node_callbacks`)

## 由 Sourcery 提供的摘要

文档化并演示如何应用图节点回调（包括来自 Runner 插件的回调），以在图节点执行周围实现横切行为。

新功能：
- 引入一个可运行示例，通过 Runner 插件注入图节点回调，用于记录函数节点的执行。

增强：
- 阐明 Runner 插件钩子与图节点回调之间的关系，包括在运行器作用域内跨图节点行为的高级模式。

文档：
- 解释图范围（graph-wide）与按节点（per-node）的节点回调、它们的执行顺序，以及如何在图引擎中进行配置（EN/ZH 图与插件文档）。
- 描述 Runner 插件如何观察图节点的生命周期事件，并通过运行时状态注入图范围的节点回调，包括关于 StreamMode 过滤的说明（EN/ZH 插件文档）。
- 为一个新示例添加 README 文档，展示由 Runner 插件驱动的节点回调。

测试：
- 提供一个新的示例程序，通过 Runner 插件串联并演示 Runner、GraphAgent 和图节点回调的配合使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document and demonstrate how to apply graph node callbacks, including from Runner plugins, to enable cross-cutting behavior around graph node execution.

New Features:
- Introduce a runnable example that injects graph node callbacks from a Runner plugin to log function node execution.

Enhancements:
- Clarify the relationship between Runner plugin hooks and graph node callbacks, including advanced patterns for runner-scoped behavior across graph nodes.

Documentation:
- Explain graph-wide vs per-node node callbacks, their execution order, and how to configure them in the graph engine (EN/ZH graph and plugin docs).
- Describe how Runner plugins can observe graph node lifecycle events and inject graph-wide node callbacks via runtime state, including StreamMode filtering notes (EN/ZH plugin docs).
- Add README documentation for a new example showing Runner plugin–driven node callbacks.

Tests:
- Provide a new example program exercising Runner, GraphAgent, and graph node callbacks wired through a Runner plugin.

</details>