### PR TITLE
docs: clarify skill_run artifact saving

### DIFF
--- a/docs/mkdocs/en/skill.md
+++ b/docs/mkdocs/en/skill.md
@@ -561,8 +561,19 @@ Input:
   inline content. Use `output_files[*].ref` with `read_file` when you
   need text content later.
 - `artifact_prefix` (optional): prefix for the legacy artifact path
-  - If the Artifact service is not configured, `skill_run` keeps
-    returning `output_files` and reports a `warnings` entry.
+  - `save_as_artifacts` is best-effort. If `skill_run` cannot access an
+    Artifact service from the current tool context, it keeps returning
+    `output_files` and adds a `warnings` entry (no hard error).
+  - Common causes:
+    - `skill_run` is invoked outside a Runner invocation (missing
+      `agent.InvocationFromContext(ctx)`)
+    - Artifact service is not configured (missing
+      `runner.WithArtifactService(...)`)
+    - Session identifiers are empty (for example, calling
+      `Runner.Run(ctx, "", "", ...)`, or an AG-UI request missing
+      `thread_id`)
+  - Example warning:
+    - `save_as_artifacts requested but session app/user/session IDs are missing; outputs are not persisted`
 
 Guidance:
 - Prefer using `skill_run` only for commands explicitly required by the
@@ -765,6 +776,12 @@ Common spans:
 - Timeouts/non‑zero exit codes: inspect command/deps/`timeout`; in
   container mode, network is disabled by default
 - Missing output files: check your glob patterns and output locations
+- Artifacts not saved (for example, COS/S3): check `artifact_files` and
+  `warnings` in the `skill_run` result; `save_as_artifacts` is skipped
+  when the invocation/session info is missing, and COS/S3 paths are
+  derived from `{app_name}/{user_id}/{session_id}` (or `{app_name}/{user_id}/user`
+  for `user:` artifacts) and the returned `artifact_files[*].name` +
+  `artifact_files[*].version`.
 
 ## References and Examples
 

--- a/docs/mkdocs/zh/skill.md
+++ b/docs/mkdocs/zh/skill.md
@@ -542,8 +542,17 @@ agent := llmagent.New(
   非文本输出的 `content` 也会始终为空。需要文本内容时，可用
   `output_files[*].ref` 配合 `read_file` 按需读取。
 - `artifact_prefix`（可选）：与 `save_as_artifacts` 配合的前缀。
-  - 若未配置制品服务（Artifact service），`skill_run` 会继续
-    返回 `output_files`，并在 `warnings` 中给出提示。
+  - `save_as_artifacts` 为 best-effort：当 `skill_run` 无法从当前
+    工具上下文访问制品服务时，不会报硬错误，仍会返回
+    `output_files`，并在 `warnings` 中给出原因。
+  - 常见原因：
+    - `skill_run` 未在 Runner 的 invocation 上下文中执行
+      （缺少 `agent.InvocationFromContext(ctx)`）
+    - 未配置制品服务（未设置 `runner.WithArtifactService(...)`）
+    - 会话标识为空（例如调用 `Runner.Run(ctx, "", "", ...)`，
+      或 AG-UI 请求缺少 `thread_id`）
+  - 示例 warning：
+    - `save_as_artifacts requested but session app/user/session IDs are missing; outputs are not persisted`
 
 建议：
 - 建议 `skill_run` 尽量只用于执行 Skill 文档里描述的流程
@@ -744,6 +753,11 @@ agent := llmagent.New(
 - 超时/非零退出码：检查命令、依赖与 `timeout` 参数；容器模式下
   网络默认关闭，避免依赖网络的脚本
 - 输出文件未返回：检查 `output_files` 通配符是否指向正确位置
+- 制品未落 COS/S3：检查 `skill_run` 返回的 `artifact_files` 与
+  `warnings`；若 invocation/session 信息缺失，`save_as_artifacts`
+  会被跳过；在 COS/S3 中可按 `{app_name}/{user_id}/{session_id}`
+  （或 `user:` 制品的 `{app_name}/{user_id}/user`）+
+  `artifact_files[*].name` + `artifact_files[*].version` 的结构定位。
 
 ## 参考与示例
 


### PR DESCRIPTION
Problem
- Users may set `save_as_artifacts=true` for `skill_run` and configure an Artifact service, but still not see files in COS/S3.
- The legacy `save_as_artifacts` path is best-effort, so failures can show up as a `warnings` entry instead of a hard error.

What changed
- docs/mkdocs/en/skill.md: document prerequisites, common skip causes, an example warning, and a troubleshooting entry.
- docs/mkdocs/zh/skill.md: same updates in Chinese.

Why
- `skill_run` skips `save_as_artifacts` when invocation/session info is missing (for example: running outside Runner, missing Artifact service, or empty app/user/session IDs).

Test Plan
- Docs-only change.

## Summary by Sourcery

明确说明 `skill_run` 何时保存构件（artifacts），以及如何排查在 COS/S3 中缺失的构件。

文档：
- 扩展英文版 `skill_run` 文档，补充前置条件、构件未被保存的常见原因、示例警告信息，以及构件在 COS/S3 中的路径结构说明。
- 在中文版 `skill_run` 文档中同步这些说明和故障排查指导。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify when skill_run saves artifacts and how to troubleshoot missing artifacts in COS/S3.

Documentation:
- Expand English skill_run documentation with prerequisites, common reasons artifacts are not saved, example warnings, and COS/S3 path structure for artifacts.
- Mirror the same clarifications and troubleshooting guidance in the Chinese skill_run documentation.

</details>