### PR TITLE
{examples, model/openai}: enhance token tracking with cache metrics

### DIFF
--- a/model/openai/options.go
+++ b/model/openai/options.go
@@ -316,6 +316,9 @@ func inverseOpenAISDKAddChunkUsage(u model.Usage, delta model.Usage) model.Usage
 		PromptTokens:     u.PromptTokens - delta.PromptTokens,
 		CompletionTokens: u.CompletionTokens - delta.CompletionTokens,
 		TotalTokens:      u.TotalTokens - delta.TotalTokens,
+		PromptTokensDetails: model.PromptTokensDetails{
+			CachedTokens: int(u.PromptTokensDetails.CachedTokens - delta.PromptTokensDetails.CachedTokens),
+		},
 	}
 }
 


### PR DESCRIPTION
Added new fields to track cached prompt tokens, cache read, and cache write metrics in both session and turn usage structures. Updated the processing and display functions to include these metrics, providing more detailed insights into token usage during sessions.

## 由 Sourcery 提供的总结

在 token tracker 示例和 OpenAI 用量工具中增强 token 跟踪与报告功能，加入 prompt 缓存使用指标。

新功能：
- 在 token tracker 示例中，按轮次和整个会话维度跟踪缓存的 prompt tokens、缓存读取次数和缓存写入次数。
- 在会话总结和每轮输出中显示详细的 prompt 缓存使用统计信息，包括每轮的平均值。

增强项：
- 在 OpenAI 用量增量计算中传递 prompt token 缓存详细信息，以保持缓存 token 计数的准确性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance token tracking and reporting with prompt cache usage metrics across the token tracker example and OpenAI usage utilities.

New Features:
- Track cached prompt tokens, cache reads, and cache writes per turn and across the entire session in the token tracker example.
- Display detailed prompt cache usage statistics, including averages per turn, in session summaries and per-turn output.

Enhancements:
- Propagate prompt token cache details through OpenAI usage delta calculations to maintain accurate cached token counts.

</details>