### PR TITLE
telemetry: align cache token attributes with OpenTelemetry semantic conventions

### DIFF
--- a/internal/telemetry/trace.go
+++ b/internal/telemetry/trace.go
@@ -172,8 +172,8 @@ var (
 	KeyGenAIUsageOutputTokens             = semconvtrace.KeyGenAIUsageOutputTokens
 	KeyGenAIUsageInputTokens              = semconvtrace.KeyGenAIUsageInputTokens
 	KeyGenAIUsageInputTokensCached        = semconvtrace.KeyGenAIUsageInputTokensCached
-	KeyGenAIUsageInputTokensCacheRead     = semconvtrace.KeyGenAIUsageInputTokensCacheRead
-	KeyGenAIUsageInputTokensCacheCreation = semconvtrace.KeyGenAIUsageInputTokensCacheCreation
+	KeyGenAIUsageCacheReadInputTokens     = semconvtrace.KeyGenAIUsageCacheReadInputTokens
+	KeyGenAIUsageCacheCreationInputTokens = semconvtrace.KeyGenAIUsageCacheCreationInputTokens
 	KeyGenAIProviderName                  = semconvtrace.KeyGenAIProviderName
 	KeyGenAIAgentDescription              = semconvtrace.KeyGenAIAgentDescription
 	KeyGenAIResponseFinishReasons         = semconvtrace.KeyGenAIResponseFinishReasons
@@ -583,11 +583,11 @@ func buildResponseAttributes(rsp *model.Response) []attribute.KeyValue {
 		}
 		if cacheRead := rsp.Usage.PromptTokensDetails.CacheReadTokens; cacheRead != 0 {
 			// Anthropic: cache_read_tokens
-			attrs = append(attrs, attribute.Int(KeyGenAIUsageInputTokensCacheRead, cacheRead))
+			attrs = append(attrs, attribute.Int(KeyGenAIUsageCacheReadInputTokens, cacheRead))
 		}
 		if cacheCreation := rsp.Usage.PromptTokensDetails.CacheCreationTokens; cacheCreation != 0 {
 			// Anthropic: cache_creation_tokens
-			attrs = append(attrs, attribute.Int(KeyGenAIUsageInputTokensCacheCreation, cacheCreation))
+			attrs = append(attrs, attribute.Int(KeyGenAIUsageCacheCreationInputTokens, cacheCreation))
 		}
 	}
 

--- a/internal/telemetry/trace_test.go
+++ b/internal/telemetry/trace_test.go
@@ -886,10 +886,10 @@ func TestBuildResponseAttributes(t *testing.T) {
 						require.True(t, hasAttr(attrs, KeyGenAIUsageInputTokensCached, int64(tt.rsp.Usage.PromptTokensDetails.CachedTokens)))
 					}
 					if tt.rsp.Usage.PromptTokensDetails.CacheReadTokens != 0 {
-						require.True(t, hasAttr(attrs, KeyGenAIUsageInputTokensCacheRead, int64(tt.rsp.Usage.PromptTokensDetails.CacheReadTokens)))
+						require.True(t, hasAttr(attrs, KeyGenAIUsageCacheReadInputTokens, int64(tt.rsp.Usage.PromptTokensDetails.CacheReadTokens)))
 					}
 					if tt.rsp.Usage.PromptTokensDetails.CacheCreationTokens != 0 {
-						require.True(t, hasAttr(attrs, KeyGenAIUsageInputTokensCacheCreation, int64(tt.rsp.Usage.PromptTokensDetails.CacheCreationTokens)))
+						require.True(t, hasAttr(attrs, KeyGenAIUsageCacheCreationInputTokens, int64(tt.rsp.Usage.PromptTokensDetails.CacheCreationTokens)))
 					}
 				}
 			}

--- a/telemetry/langfuse/exporter.go
+++ b/telemetry/langfuse/exporter.go
@@ -155,8 +155,8 @@ func transformInvokeAgent(span *tracepb.Span) {
 			// Keeping token attributes on InvokeAgent would make Langfuse double count tokens
 			// compared to the old behavior (Chat-only token accounting).
 		case itelemetry.KeyGenAIUsageInputTokens, itelemetry.KeyGenAIUsageOutputTokens,
-			itelemetry.KeyGenAIUsageInputTokensCached, itelemetry.KeyGenAIUsageInputTokensCacheRead,
-			itelemetry.KeyGenAIUsageInputTokensCacheCreation:
+			itelemetry.KeyGenAIUsageInputTokensCached, itelemetry.KeyGenAIUsageCacheReadInputTokens,
+			itelemetry.KeyGenAIUsageCacheCreationInputTokens:
 		default:
 			newAttributes = append(newAttributes, attr)
 		}
@@ -231,9 +231,9 @@ func collectLLMSpanAttributes(attrs []*commonpb.KeyValue) llmSpanCollected {
 			c.usage.Output = attr.Value.GetIntValue()
 		case itelemetry.KeyGenAIUsageInputTokensCached:
 			c.usage.InputCached = attr.Value.GetIntValue()
-		case itelemetry.KeyGenAIUsageInputTokensCacheRead:
+		case itelemetry.KeyGenAIUsageCacheReadInputTokens:
 			c.usage.InputCacheRead = attr.Value.GetIntValue()
-		case itelemetry.KeyGenAIUsageInputTokensCacheCreation:
+		case itelemetry.KeyGenAIUsageCacheCreationInputTokens:
 			c.usage.InputCacheCreation = attr.Value.GetIntValue()
 		default:
 			c.attrs = append(c.attrs, attr)

--- a/telemetry/langfuse/exporter_test.go
+++ b/telemetry/langfuse/exporter_test.go
@@ -581,13 +581,13 @@ func TestTransformCallLLM_UsageDetails(t *testing.T) {
 			}
 			if tt.cacheReadTokens != 0 {
 				attrs = append(attrs, &commonpb.KeyValue{
-					Key:   itelemetry.KeyGenAIUsageInputTokensCacheRead,
+					Key:   itelemetry.KeyGenAIUsageCacheReadInputTokens,
 					Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_IntValue{IntValue: tt.cacheReadTokens}},
 				})
 			}
 			if tt.cacheCreationTokens != 0 {
 				attrs = append(attrs, &commonpb.KeyValue{
-					Key:   itelemetry.KeyGenAIUsageInputTokensCacheCreation,
+					Key:   itelemetry.KeyGenAIUsageCacheCreationInputTokens,
 					Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_IntValue{IntValue: tt.cacheCreationTokens}},
 				})
 			}
@@ -600,8 +600,8 @@ func TestTransformCallLLM_UsageDetails(t *testing.T) {
 				assert.NotEqual(t, itelemetry.KeyGenAIUsageInputTokens, attr.Key)
 				assert.NotEqual(t, itelemetry.KeyGenAIUsageOutputTokens, attr.Key)
 				assert.NotEqual(t, itelemetry.KeyGenAIUsageInputTokensCached, attr.Key)
-				assert.NotEqual(t, itelemetry.KeyGenAIUsageInputTokensCacheRead, attr.Key)
-				assert.NotEqual(t, itelemetry.KeyGenAIUsageInputTokensCacheCreation, attr.Key)
+				assert.NotEqual(t, itelemetry.KeyGenAIUsageCacheReadInputTokens, attr.Key)
+				assert.NotEqual(t, itelemetry.KeyGenAIUsageCacheCreationInputTokens, attr.Key)
 			}
 
 			// Check usage_details attribute
@@ -654,11 +654,11 @@ func TestTransformInvokeAgent_CacheTokensFiltered(t *testing.T) {
 				Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_IntValue{IntValue: 30}},
 			},
 			{
-				Key:   itelemetry.KeyGenAIUsageInputTokensCacheRead,
+				Key:   itelemetry.KeyGenAIUsageCacheReadInputTokens,
 				Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_IntValue{IntValue: 20}},
 			},
 			{
-				Key:   itelemetry.KeyGenAIUsageInputTokensCacheCreation,
+				Key:   itelemetry.KeyGenAIUsageCacheCreationInputTokens,
 				Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_IntValue{IntValue: 10}},
 			},
 		},
@@ -671,8 +671,8 @@ func TestTransformInvokeAgent_CacheTokensFiltered(t *testing.T) {
 		assert.NotEqual(t, itelemetry.KeyGenAIUsageInputTokens, attr.Key)
 		assert.NotEqual(t, itelemetry.KeyGenAIUsageOutputTokens, attr.Key)
 		assert.NotEqual(t, itelemetry.KeyGenAIUsageInputTokensCached, attr.Key)
-		assert.NotEqual(t, itelemetry.KeyGenAIUsageInputTokensCacheRead, attr.Key)
-		assert.NotEqual(t, itelemetry.KeyGenAIUsageInputTokensCacheCreation, attr.Key)
+		assert.NotEqual(t, itelemetry.KeyGenAIUsageCacheReadInputTokens, attr.Key)
+		assert.NotEqual(t, itelemetry.KeyGenAIUsageCacheCreationInputTokens, attr.Key)
 	}
 }
 

--- a/telemetry/semconv/trace/trace.go
+++ b/telemetry/semconv/trace/trace.go
@@ -73,12 +73,12 @@ const (
 	// KeyGenAIUsageInputTokensCached is the attribute key for cached input token count.
 	// Note: This is an extension field used to report prompt cache tokens; it is not part of the upstream GenAI semantic conventions yet.
 	KeyGenAIUsageInputTokensCached = "gen_ai.usage.input_tokens.cached" // #nosec G101 - this is a metric key name, not a credential.
-	// KeyGenAIUsageInputTokensCacheRead is the attribute key for tokens read from cache (Anthropic).
-	// Note: This is an extension field; it is not part of the upstream GenAI semantic conventions yet.
-	KeyGenAIUsageInputTokensCacheRead = "gen_ai.usage.input_tokens.cache_read" // #nosec G101 - this is a metric key name, not a credential.
-	// KeyGenAIUsageInputTokensCacheCreation is the attribute key for tokens used to create cache (Anthropic).
-	// Note: This is an extension field; it is not part of the upstream GenAI semantic conventions yet.
-	KeyGenAIUsageInputTokensCacheCreation = "gen_ai.usage.input_tokens.cache_creation" // #nosec G101 - this is a metric key name, not a credential.
+	// KeyGenAIUsageCacheReadInputTokens is the attribute key for tokens read from cache (Anthropic).
+	// Reference: https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/
+	KeyGenAIUsageCacheReadInputTokens = "gen_ai.usage.cache_read.input_tokens" // #nosec G101 - this is a metric key name, not a credential.
+	// KeyGenAIUsageCacheCreationInputTokens is the attribute key for tokens used to create cache (Anthropic).
+	// Reference: https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/
+	KeyGenAIUsageCacheCreationInputTokens = "gen_ai.usage.cache_creation.input_tokens" // #nosec G101 - this is a metric key name, not a credential.
 	// KeyGenAIProviderName is the attribute key for provider name.
 	KeyGenAIProviderName = "gen_ai.provider.name"
 	// KeyGenAIAgentDescription is the attribute key for agent description.


### PR DESCRIPTION
Align cache token attributes with OpenTelemetry semantic conventions to use `gen_ai.usage.cache_read.input_tokens` and `gen_ai.usage.cache_creation.input_tokens`.

---
<p><a href="https://cursor.com/agents/bc-6b1b5f09-6e3d-4cb9-9b01-4e989d1fff5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b1b5f09-6e3d-4cb9-9b01-4e989d1fff5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

## Summary by Sourcery

使 GenAI 缓存 token 使用属性与最新的 OpenTelemetry 语义约定保持一致。

Enhancements:
- 重命名内部 GenAI 缓存 token 属性键，使其符合 `gen_ai.usage.cache_read.input_tokens` 和 `gen_ai.usage.cache_creation.input_tokens` 语义约定。
- 在遥测导出、采集以及 Langfuse 集成逻辑中传播更新后的缓存 token 属性键。

Tests:
- 更新遥测和 Langfuse 导出器测试，以针对新的缓存 token 属性键进行断言。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align GenAI cache token usage attributes with the latest OpenTelemetry semantic conventions.

Enhancements:
- Rename internal GenAI cache token attribute keys to match `gen_ai.usage.cache_read.input_tokens` and `gen_ai.usage.cache_creation.input_tokens` semantic conventions.
- Propagate updated cache token attribute keys through telemetry export, collection, and Langfuse integration logic.

Tests:
- Update telemetry and Langfuse exporter tests to assert against the new cache token attribute keys.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

使 GenAI 缓存 token 使用属性与最新的 OpenTelemetry 语义约定保持一致。

Enhancements:
- 重命名内部 GenAI 缓存 token 属性键，使其符合 `gen_ai.usage.cache_read.input_tokens` 和 `gen_ai.usage.cache_creation.input_tokens` 语义约定。
- 在遥测导出、采集以及 Langfuse 集成逻辑中传播更新后的缓存 token 属性键。

Tests:
- 更新遥测和 Langfuse 导出器测试，以针对新的缓存 token 属性键进行断言。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align GenAI cache token usage attributes with the latest OpenTelemetry semantic conventions.

Enhancements:
- Rename internal GenAI cache token attribute keys to match `gen_ai.usage.cache_read.input_tokens` and `gen_ai.usage.cache_creation.input_tokens` semantic conventions.
- Propagate updated cache token attribute keys through telemetry export, collection, and Langfuse integration logic.

Tests:
- Update telemetry and Langfuse exporter tests to assert against the new cache token attribute keys.

</details>

</details>