### PR TITLE
checkpoint/redis: atomic Put/PutFull via Lua and hash-tags

### DIFF
--- a/graph/checkpoint/redis/saver.go
+++ b/graph/checkpoint/redis/saver.go
@@ -129,6 +129,17 @@ end
 return 1
 `)
 
+func ttlMilliseconds(ttl time.Duration) int64 {
+	if ttl <= 0 {
+		return 0
+	}
+	ttlMs := ttl.Milliseconds()
+	if ttlMs == 0 {
+		return 1
+	}
+	return ttlMs
+}
+
 func checkpointKey(lineageID, checkpointNS, checkpointID string) string {
 	return fmt.Sprintf("%s{%s}:%s:%s", keyPrefixCheckpoint, lineageID, checkpointNS, checkpointID)
 }
@@ -432,7 +443,7 @@ func (s *Saver) Put(ctx context.Context, req graph.PutRequest) (map[string]any, 
 		lineageNSKey(lineageID),
 	}
 	args := []any{
-		s.opts.ttl.Milliseconds(),
+		ttlMilliseconds(s.opts.ttl),
 		lineageID,
 		checkpointNS,
 		checkpointID,
@@ -526,7 +537,7 @@ func (s *Saver) PutFull(ctx context.Context, req graph.PutFullRequest) (map[stri
 		writeKey,
 	}
 	args := []any{
-		s.opts.ttl.Milliseconds(),
+		ttlMilliseconds(s.opts.ttl),
 		lineageID,
 		checkpointNS,
 		checkpointID,

--- a/graph/checkpoint/redis/saver_test.go
+++ b/graph/checkpoint/redis/saver_test.go
@@ -78,6 +78,14 @@ func TestNewSaverWithRedisInstance_buildFailed(t *testing.T) {
 	require.Nil(t, saver)
 }
 
+func TestTTLMilliseconds(t *testing.T) {
+	assert.Equal(t, int64(0), ttlMilliseconds(0))
+	assert.Equal(t, int64(0), ttlMilliseconds(-time.Second))
+	assert.Equal(t, int64(1), ttlMilliseconds(500*time.Microsecond))
+	assert.Equal(t, int64(1), ttlMilliseconds(time.Millisecond))
+	assert.Equal(t, int64(1500), ttlMilliseconds(1500*time.Millisecond))
+}
+
 func TestNewSaverWithRedisOption_Error(t *testing.T) {
 	saver, err := NewSaver(WithRedisClientURL(""))
 	require.Error(t, err)


### PR DESCRIPTION
## Summary by Sourcery

通过按 lineage 实现 Redis checkpoint 写入的原子性与同机部署，从而提高一致性和集群行为。

Enhancements:
- 使用 Lua 脚本替换基于 pipeline 的 `Put` 和 `PutFull` checkpoint 写入，在 Redis 中执行原子的多键更新和 TTL 管理。
- 在 checkpoint、timestamp、writes 和 lineage 命名空间键中引入 Redis hash tag，确保同一 lineage 相关的键共置于同一个集群槽位。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make Redis checkpoint writes atomic and colocated by lineage for improved consistency and clustering behavior.

Enhancements:
- Replace pipeline-based Put and PutFull checkpoint writes with Lua scripts to perform atomic multi-key updates and TTL management in Redis.
- Introduce Redis hash tags into checkpoint, timestamp, writes, and lineage namespace keys to ensure related keys for a lineage are colocated in the same cluster slot.

</details>