### PR TITLE
graph: make state clone safe for json serialization

### DIFF
--- a/graph/state.go
+++ b/graph/state.go
@@ -218,7 +218,10 @@ func (s State) safeClone() State {
 		if isUnsafeStateKey(k) {
 			continue
 		}
-		clone[k] = v
+		// Use jsonSafeCopy so that nested non-serializable
+		// types (chan, func, sync.Mutex, etc.) are stripped
+		// and the result is safe for json.Marshal.
+		clone[k] = jsonSafeCopy(v)
 	}
 	return clone
 }

--- a/graph/utils_test.go
+++ b/graph/utils_test.go
@@ -690,6 +690,293 @@ func TestJSONSafeCopy_SliceWithMixed(t *testing.T) {
 	assert.Nil(t, result[2])
 }
 
+// ---------- additional coverage tests ----------
+
+func TestJSONSafeCopy_DeepCopierInterface(t *testing.T) {
+	// Covers deepCopyByInterface success path inside
+	// jsonSafeCopyWithVisited (L327-329).
+	orig := deepCopoerStruct{Name: "dc", age: 99}
+	result := jsonSafeCopy(orig)
+	dc, ok := result.(deepCopoerStruct)
+	require.True(t, ok)
+	assert.Equal(t, "dc", dc.Name)
+	assert.Equal(t, 99, dc.age)
+}
+
+func TestJSONSafeCopy_DeepCopierViaReflect(t *testing.T) {
+	// Covers deepCopyByReflectValue DeepCopier path (L252-254)
+	// and jsonSafeReflect DeepCopier branch (L398-400).
+	// The wrapper has an unsafe field (Ch) so jsonSafeCopyStruct
+	// calls structToJSONSafeMap which recurses jsonSafeReflect
+	// on the Inner field — hitting deepCopyByReflectValue.
+	type wrapper struct {
+		Inner deepCopoerStruct
+		Ch    chan int
+	}
+	orig := wrapper{
+		Inner: deepCopoerStruct{Name: "w", age: 7},
+		Ch:    make(chan int),
+	}
+	result := jsonSafeCopy(orig)
+	m, ok := result.(map[string]any)
+	require.True(t, ok)
+	dc, ok := m["Inner"].(deepCopoerStruct)
+	require.True(t, ok)
+	assert.Equal(t, "w", dc.Name)
+}
+
+func TestJSONSafeCopy_NilSliceAny(t *testing.T) {
+	// Covers jsonSafeFastPath nil []any branch (L357-359).
+	var s []any
+	result := jsonSafeCopy(s)
+	assert.Nil(t, result)
+}
+
+func TestJSONSafeCopy_IntAndFloat64Slices(t *testing.T) {
+	// Covers jsonSafeFastPath []int (L374-377) and
+	// []float64 (L378-381) branches.
+	ints := []int{10, 20, 30}
+	resultInts := jsonSafeCopy(ints)
+	assert.Equal(t, []int{10, 20, 30}, resultInts)
+
+	floats := []float64{1.1, 2.2}
+	resultFloats := jsonSafeCopy(floats)
+	assert.Equal(t, []float64{1.1, 2.2}, resultFloats)
+}
+
+func TestJSONSafeCopy_ArrayWithUnsafe(t *testing.T) {
+	// Covers jsonSafeReflect Array branch (L413-414) and
+	// jsonSafeCopyArray (L494-503, was 0%).
+	type s struct {
+		Items [2]chan int
+	}
+	orig := s{Items: [2]chan int{make(chan int), make(chan int)}}
+	result := jsonSafeCopy(orig)
+	m, ok := result.(map[string]any)
+	require.True(t, ok)
+	items, ok := m["Items"].([]any)
+	require.True(t, ok)
+	assert.Len(t, items, 2)
+	// Channels become nil.
+	assert.Nil(t, items[0])
+	assert.Nil(t, items[1])
+}
+
+func TestJSONSafeCopy_NilPointerInUnsafeStruct(t *testing.T) {
+	// Covers jsonSafeCopyPointer nil branch (L429-431)
+	// via jsonSafe path (struct has chan -> unsafe -> map).
+	type s struct {
+		Ptr *int
+		Ch  chan int
+	}
+	orig := s{Ptr: nil, Ch: make(chan int)}
+	result := jsonSafeCopy(orig)
+	m, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Nil(t, m["Ptr"])
+}
+
+func TestJSONSafeCopy_PointerToChanStruct(t *testing.T) {
+	// Covers jsonSafeCopyPointer inner==nil path (L440-442)
+	// when pointed-to value converts to nil.
+	ch := make(chan int)
+	result := jsonSafeCopy(&ch)
+	assert.Nil(t, result)
+}
+
+func TestJSONSafeCopy_PointerCycleInUnsafeStruct(t *testing.T) {
+	// Covers jsonSafeCopyPointer cache hit (L433-435).
+	// The struct has a chan field so it goes through jsonSafe path.
+	type node struct {
+		Name string
+		Next *node
+		Ch   chan int
+	}
+	a := &node{Name: "a", Ch: make(chan int)}
+	b := &node{Name: "b", Ch: make(chan int), Next: a}
+	a.Next = b
+
+	result := jsonSafeCopy(a)
+	require.NotNil(t, result)
+}
+
+func TestJSONSafeCopy_NilMapInUnsafeStruct(t *testing.T) {
+	// Covers jsonSafeCopyMap nil branch (L454-456)
+	// via jsonSafe path.
+	type s struct {
+		M  map[int]string
+		Ch chan int
+	}
+	orig := s{M: nil, Ch: make(chan int)}
+	result := jsonSafeCopy(orig)
+	m, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Nil(t, m["M"])
+}
+
+func TestJSONSafeCopy_MapCacheHitInUnsafe(t *testing.T) {
+	// Covers jsonSafeCopyMap cache hit (L458-460).
+	// Two struct fields reference the same underlying map so
+	// the second visit returns from cache.
+	type s struct {
+		A  map[int]string
+		B  map[int]string
+		Ch chan int
+	}
+	shared := map[int]string{1: "one"}
+	orig := s{A: shared, B: shared, Ch: make(chan int)}
+	result := jsonSafeCopy(orig)
+	m, ok := result.(map[string]any)
+	require.True(t, ok)
+	a, ok := m["A"].(map[string]any)
+	require.True(t, ok)
+	b, ok := m["B"].(map[string]any)
+	require.True(t, ok)
+	// Both should point to the same map (cache hit).
+	assert.Equal(t,
+		reflect.ValueOf(a).Pointer(),
+		reflect.ValueOf(b).Pointer(),
+	)
+}
+
+func TestJSONSafeCopy_NilSliceInUnsafeStruct(t *testing.T) {
+	// Covers jsonSafeCopySlice nil branch (L478-480)
+	// via jsonSafe path.
+	type s struct {
+		Items []int
+		Ch    chan int
+	}
+	orig := s{Items: nil, Ch: make(chan int)}
+	result := jsonSafeCopy(orig)
+	m, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Nil(t, m["Items"])
+}
+
+func TestJSONSafeCopy_SliceCacheHitInUnsafe(t *testing.T) {
+	// Covers jsonSafeCopySlice cache hit (L482-484).
+	// Two struct fields reference the same slice.
+	type s struct {
+		A  []int
+		B  []int
+		Ch chan int
+	}
+	shared := []int{1, 2, 3}
+	orig := s{A: shared, B: shared, Ch: make(chan int)}
+	result := jsonSafeCopy(orig)
+	m, ok := result.(map[string]any)
+	require.True(t, ok)
+	a, ok := m["A"].([]any)
+	require.True(t, ok)
+	b, ok := m["B"].([]any)
+	require.True(t, ok)
+	assert.Equal(t,
+		reflect.ValueOf(a).Pointer(),
+		reflect.ValueOf(b).Pointer(),
+	)
+}
+
+func TestJSONSafeCopy_TimeViaUnsafeStruct(t *testing.T) {
+	// Covers jsonSafeCopyStruct time branch (L512-514).
+	// The outer struct has a chan field, so structToJSONSafeMap
+	// is called, and the inner time.Time field goes through
+	// jsonSafeReflect -> jsonSafeCopyStruct which checks isTimeType.
+	type s struct {
+		T  time.Time
+		Ch chan int
+	}
+	now := time.Now()
+	orig := s{T: now, Ch: make(chan int)}
+	result := jsonSafeCopy(orig)
+	m, ok := result.(map[string]any)
+	require.True(t, ok)
+	rt, ok := m["T"].(time.Time)
+	require.True(t, ok)
+	assert.True(t, rt.Equal(now))
+}
+
+func TestJSONSafeReflect_InvalidValue(t *testing.T) {
+	// Covers jsonSafeReflect invalid value (L395-397).
+	visited := make(map[uintptr]any)
+	result := jsonSafeReflect(reflect.Value{}, visited)
+	assert.Nil(t, result)
+}
+
+func TestMapValueIsJSONUnsafe_InvalidAndNilInterface(t *testing.T) {
+	// Covers mapValueIsJSONUnsafe invalid value (L567-569).
+	assert.False(t, mapValueIsJSONUnsafe(reflect.Value{}))
+	// Covers nil interface in interface (L571-572).
+	var iface any
+	rv := reflect.ValueOf(&iface).Elem()
+	assert.False(t, mapValueIsJSONUnsafe(rv))
+}
+
+func TestCopyInterface_DeepCopier(t *testing.T) {
+	// Covers copyInterface DeepCopier branch (L104-106).
+	var iface any = &deepCopoerStruct{Name: "if", age: 1}
+	rv := reflect.ValueOf(&iface).Elem()
+	visited := make(map[uintptr]any)
+	result := copyInterface(rv, visited)
+	dc, ok := result.(deepCopoerStruct)
+	require.True(t, ok)
+	assert.Equal(t, "if", dc.Name)
+}
+
+func TestCopyPointer_DeepCopier(t *testing.T) {
+	// Covers copyPointer DeepCopier branch (L118-120).
+	orig := &deepCopoerStruct{Name: "cp", age: 2}
+	rv := reflect.ValueOf(orig)
+	visited := make(map[uintptr]any)
+	result := copyPointer(rv, visited)
+	dc, ok := result.(deepCopoerStruct)
+	require.True(t, ok)
+	assert.Equal(t, "cp", dc.Name)
+}
+
+func TestCopyMap_CacheHit(t *testing.T) {
+	// Covers copyMap cache hit (L133-135).
+	m := map[string]int{"a": 1}
+	rv := reflect.ValueOf(m)
+	visited := make(map[uintptr]any)
+	visited[rv.Pointer()] = m
+	result := copyMap(rv, visited)
+	assert.Equal(t, m, result)
+}
+
+func TestCopySlice_CacheHit(t *testing.T) {
+	// Covers copySlice cache hit (L151-153).
+	s := []int{1, 2, 3}
+	rv := reflect.ValueOf(s)
+	visited := make(map[uintptr]any)
+	visited[rv.Pointer()] = s
+	result := copySlice(rv, visited)
+	assert.Equal(t, s, result)
+}
+
+func TestCopyStruct_ConvertibleAndFallback(t *testing.T) {
+	// Covers copyStruct ConvertibleTo (L201-203) branch.
+	// deepCopyReflect on an int32 field returns int (via
+	// rv.Interface()), which is not directly AssignableTo
+	// int32 but is ConvertibleTo int32.
+	type myInt int32
+	type s struct {
+		V myInt
+	}
+	orig := s{V: 42}
+	visited := make(map[uintptr]any)
+	result := copyStruct(reflect.ValueOf(orig), visited)
+	res, ok := result.(s)
+	require.True(t, ok)
+	assert.Equal(t, myInt(42), res.V)
+}
+
+func TestDeepCopyByReflectValue_Invalid(t *testing.T) {
+	// Covers deepCopyByReflectValue invalid path (L249-251).
+	out, ok := deepCopyByReflectValue(reflect.Value{})
+	assert.Nil(t, out)
+	assert.False(t, ok)
+}
+
 func TestHasJSONUnsafeField(t *testing.T) {
 	type safe struct {
 		A string

--- a/graph/utils_test.go
+++ b/graph/utils_test.go
@@ -706,9 +706,30 @@ func TestHasJSONUnsafeField(t *testing.T) {
 		A  string
 		Ch chan int `json:"-"`
 	}
+	type selfRef struct {
+		Name string
+		Next *selfRef
+	}
+	type withSliceChan struct {
+		Items []chan int
+	}
+	type withArrayChan struct {
+		Items [2]chan int
+	}
+	type withMapChanValue struct {
+		Items map[string]chan int
+	}
+	type withMapChanKey struct {
+		Items map[chan int]string
+	}
 
 	assert.False(t, hasJSONUnsafeField(reflect.TypeOf(safe{})))
 	assert.True(t, hasJSONUnsafeField(reflect.TypeOf(withChan{})))
 	assert.True(t, hasJSONUnsafeField(reflect.TypeOf(nested{})))
 	assert.False(t, hasJSONUnsafeField(reflect.TypeOf(ignoredUnsafe{})))
+	assert.False(t, hasJSONUnsafeField(reflect.TypeOf(selfRef{})))
+	assert.True(t, hasJSONUnsafeField(reflect.TypeOf(withSliceChan{})))
+	assert.True(t, hasJSONUnsafeField(reflect.TypeOf(withArrayChan{})))
+	assert.True(t, hasJSONUnsafeField(reflect.TypeOf(withMapChanValue{})))
+	assert.True(t, hasJSONUnsafeField(reflect.TypeOf(withMapChanKey{})))
 }


### PR DESCRIPTION
【问题】Langfuse trace 序列化失败

【错误信息】
langfuse.observation.output: "<not json serializable>: json: unsupported type: chan<- *event.Event"

【问题位置】
graph/state_graph.go:452
workflow := &itelemetry.Workflow{Request: state.safeClone()}

【根因】
1. State 中存储了 ExecutionContext，包含 EventChan (chan<- *event.Event)
2. safeClone() 虽然会过滤 isUnsafeStateKey 的顶层 key，但 deepCopyAny 对某些嵌套结构处理不完整
3. json.Marshal(workflow.Request) 序列化失败

【建议】
1. 优化 deepCopyAny 对 channel 类型的处理
2. 或在 TraceWorkflow 序列化前过滤不可序列化的字段

## Summary by Sourcery

使图状态克隆和深拷贝工具在 JSON 序列化时保持安全，并扩展与 JSON 安全拷贝和时间处理相关的测试覆盖率。

增强内容：
- 添加 `jsonSafeCopy` 及相关辅助函数，用于生成深拷贝对象，并省略或规范化诸如通道、函数和不安全指针等对 JSON 不安全的值。
- 更新 `State.safeClone` 以使用对 JSON 安全的深拷贝，这样在保持对 JSON 友好数据的同时，克隆后的状态仍可安全地传入 `json.Marshal`。
- 优化时间类型检测逻辑，使其基于 `reflect.Type` 工作，从而在拷贝逻辑中对 `time.Time` 及可转换的类时间类型进行更加健壮的处理。

测试：
- 重构现有深拷贝测试以使用 testify 断言，并扩展覆盖范围到通道、函数、时间变体、`DeepCopier` 路径、循环引用以及对 JSON 不安全的值。
- 为 `jsonSafeCopy` 添加全面测试，覆盖结构体、map、切片、数组、时间类型、JSON 标签、循环引用以及共享引用等情况。
- 添加 `State.safeClone` 测试，以验证不安全键被过滤、嵌套数据被深拷贝、对 JSON 不安全的字段被删除或置零，以及克隆后的状态可被 JSON 正常序列化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make graph state cloning and deep-copy utilities JSON-serialization safe and extend test coverage for JSON-safe copying and time handling.

Enhancements:
- Add jsonSafeCopy and related helpers to produce deep copies that omit or normalize JSON-unsafe values like channels, functions, and unsafe pointers.
- Update State.safeClone to use JSON-safe deep copying so cloned state remains safe to json.Marshal while preserving JSON-friendly data.
- Refine time type detection to operate on reflect.Type for more robust handling of time.Time and convertible time-like types in copy logic.

Tests:
- Refactor existing deep copy tests to use testify assertions and expand coverage to channels, functions, time variants, DeepCopier paths, cycles, and JSON-unsafe values.
- Add comprehensive tests for jsonSafeCopy across structs, maps, slices, arrays, time types, JSON tags, cycles, and shared references.
- Add State.safeClone tests to verify unsafe keys are filtered, nested data is deep-copied, JSON-unsafe fields are dropped or zeroed, and cloned state is JSON-marshallable.

</details>

增强内容：
- 引入 `jsonSafeCopy` 及相关辅助函数，用于在深拷贝值时剔除或规范化诸如通道、函数和不安全指针等对 JSON 不安全的类型。
- 更新 `State.safeClone` 以使用对 JSON 安全的深拷贝，从而在克隆状态时省略或转换嵌套的不可序列化字段，同时保留对 JSON 友好的数据。
- 优化时间类型检测逻辑，使其基于 `reflect.Type` 工作，从而在深拷贝逻辑中更好地处理 `time.Time` 及可转换的类似时间类型。

测试：
- 重构现有的深拷贝测试以使用 `testify` 断言，并扩展覆盖范围到通道、函数、时间变体、循环引用以及 `DeepCopier` 路径。
- 为 `jsonSafeCopy` 添加全面测试，覆盖结构体、map、切片、数组、时间类型、JSON 标签、循环引用以及混合/不安全值。
- 添加 `State.safeClone` 测试，以验证不安全键被过滤、嵌套数据被深度拷贝、对 JSON 不安全的字段被省略或置空，并且克隆后的状态可以被 JSON 编码（marshal）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

使图状态克隆和深拷贝工具在 JSON 序列化时保持安全，并扩展与 JSON 安全拷贝和时间处理相关的测试覆盖率。

增强内容：
- 添加 `jsonSafeCopy` 及相关辅助函数，用于生成深拷贝对象，并省略或规范化诸如通道、函数和不安全指针等对 JSON 不安全的值。
- 更新 `State.safeClone` 以使用对 JSON 安全的深拷贝，这样在保持对 JSON 友好数据的同时，克隆后的状态仍可安全地传入 `json.Marshal`。
- 优化时间类型检测逻辑，使其基于 `reflect.Type` 工作，从而在拷贝逻辑中对 `time.Time` 及可转换的类时间类型进行更加健壮的处理。

测试：
- 重构现有深拷贝测试以使用 testify 断言，并扩展覆盖范围到通道、函数、时间变体、`DeepCopier` 路径、循环引用以及对 JSON 不安全的值。
- 为 `jsonSafeCopy` 添加全面测试，覆盖结构体、map、切片、数组、时间类型、JSON 标签、循环引用以及共享引用等情况。
- 添加 `State.safeClone` 测试，以验证不安全键被过滤、嵌套数据被深拷贝、对 JSON 不安全的字段被删除或置零，以及克隆后的状态可被 JSON 正常序列化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make graph state cloning and deep-copy utilities JSON-serialization safe and extend test coverage for JSON-safe copying and time handling.

Enhancements:
- Add jsonSafeCopy and related helpers to produce deep copies that omit or normalize JSON-unsafe values like channels, functions, and unsafe pointers.
- Update State.safeClone to use JSON-safe deep copying so cloned state remains safe to json.Marshal while preserving JSON-friendly data.
- Refine time type detection to operate on reflect.Type for more robust handling of time.Time and convertible time-like types in copy logic.

Tests:
- Refactor existing deep copy tests to use testify assertions and expand coverage to channels, functions, time variants, DeepCopier paths, cycles, and JSON-unsafe values.
- Add comprehensive tests for jsonSafeCopy across structs, maps, slices, arrays, time types, JSON tags, cycles, and shared references.
- Add State.safeClone tests to verify unsafe keys are filtered, nested data is deep-copied, JSON-unsafe fields are dropped or zeroed, and cloned state is JSON-marshallable.

</details>

</details>

增强点：
- 引入对 JSON 安全的深拷贝工具，用于剔除或规范化 channel、函数、不安全指针以及其他对 JSON 不安全的值，并将其接入 `State.safeClone`。
- 扩展深拷贝逻辑，以更好地识别类似时间的类型，并在结构体、map、slice、数组和指针上区分对 JSON 安全与不安全的种类。

测试：
- 重构深拷贝测试，使用 testify 断言以获得更清晰的预期与失败信息。
- 为 `jsonSafeCopy` 添加广泛的覆盖范围，涵盖结构体、map、slice、数组、时间类型、JSON 标签、循环图以及对 JSON 不安全的值。
- 添加 `State.safeClone` 的测试，用于验证对不安全键的过滤、对嵌套数据的深拷贝、对嵌套 JSON 不安全字段的处理，以及克隆状态整体的 JSON 可序列化性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

使图状态克隆和深拷贝工具在 JSON 序列化时保持安全，并扩展与 JSON 安全拷贝和时间处理相关的测试覆盖率。

增强内容：
- 添加 `jsonSafeCopy` 及相关辅助函数，用于生成深拷贝对象，并省略或规范化诸如通道、函数和不安全指针等对 JSON 不安全的值。
- 更新 `State.safeClone` 以使用对 JSON 安全的深拷贝，这样在保持对 JSON 友好数据的同时，克隆后的状态仍可安全地传入 `json.Marshal`。
- 优化时间类型检测逻辑，使其基于 `reflect.Type` 工作，从而在拷贝逻辑中对 `time.Time` 及可转换的类时间类型进行更加健壮的处理。

测试：
- 重构现有深拷贝测试以使用 testify 断言，并扩展覆盖范围到通道、函数、时间变体、`DeepCopier` 路径、循环引用以及对 JSON 不安全的值。
- 为 `jsonSafeCopy` 添加全面测试，覆盖结构体、map、切片、数组、时间类型、JSON 标签、循环引用以及共享引用等情况。
- 添加 `State.safeClone` 测试，以验证不安全键被过滤、嵌套数据被深拷贝、对 JSON 不安全的字段被删除或置零，以及克隆后的状态可被 JSON 正常序列化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make graph state cloning and deep-copy utilities JSON-serialization safe and extend test coverage for JSON-safe copying and time handling.

Enhancements:
- Add jsonSafeCopy and related helpers to produce deep copies that omit or normalize JSON-unsafe values like channels, functions, and unsafe pointers.
- Update State.safeClone to use JSON-safe deep copying so cloned state remains safe to json.Marshal while preserving JSON-friendly data.
- Refine time type detection to operate on reflect.Type for more robust handling of time.Time and convertible time-like types in copy logic.

Tests:
- Refactor existing deep copy tests to use testify assertions and expand coverage to channels, functions, time variants, DeepCopier paths, cycles, and JSON-unsafe values.
- Add comprehensive tests for jsonSafeCopy across structs, maps, slices, arrays, time types, JSON tags, cycles, and shared references.
- Add State.safeClone tests to verify unsafe keys are filtered, nested data is deep-copied, JSON-unsafe fields are dropped or zeroed, and cloned state is JSON-marshallable.

</details>

增强内容：
- 引入 `jsonSafeCopy` 及相关辅助函数，用于在深拷贝值时剔除或规范化诸如通道、函数和不安全指针等对 JSON 不安全的类型。
- 更新 `State.safeClone` 以使用对 JSON 安全的深拷贝，从而在克隆状态时省略或转换嵌套的不可序列化字段，同时保留对 JSON 友好的数据。
- 优化时间类型检测逻辑，使其基于 `reflect.Type` 工作，从而在深拷贝逻辑中更好地处理 `time.Time` 及可转换的类似时间类型。

测试：
- 重构现有的深拷贝测试以使用 `testify` 断言，并扩展覆盖范围到通道、函数、时间变体、循环引用以及 `DeepCopier` 路径。
- 为 `jsonSafeCopy` 添加全面测试，覆盖结构体、map、切片、数组、时间类型、JSON 标签、循环引用以及混合/不安全值。
- 添加 `State.safeClone` 测试，以验证不安全键被过滤、嵌套数据被深度拷贝、对 JSON 不安全的字段被省略或置空，并且克隆后的状态可以被 JSON 编码（marshal）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

使图状态克隆和深拷贝工具在 JSON 序列化时保持安全，并扩展与 JSON 安全拷贝和时间处理相关的测试覆盖率。

增强内容：
- 添加 `jsonSafeCopy` 及相关辅助函数，用于生成深拷贝对象，并省略或规范化诸如通道、函数和不安全指针等对 JSON 不安全的值。
- 更新 `State.safeClone` 以使用对 JSON 安全的深拷贝，这样在保持对 JSON 友好数据的同时，克隆后的状态仍可安全地传入 `json.Marshal`。
- 优化时间类型检测逻辑，使其基于 `reflect.Type` 工作，从而在拷贝逻辑中对 `time.Time` 及可转换的类时间类型进行更加健壮的处理。

测试：
- 重构现有深拷贝测试以使用 testify 断言，并扩展覆盖范围到通道、函数、时间变体、`DeepCopier` 路径、循环引用以及对 JSON 不安全的值。
- 为 `jsonSafeCopy` 添加全面测试，覆盖结构体、map、切片、数组、时间类型、JSON 标签、循环引用以及共享引用等情况。
- 添加 `State.safeClone` 测试，以验证不安全键被过滤、嵌套数据被深拷贝、对 JSON 不安全的字段被删除或置零，以及克隆后的状态可被 JSON 正常序列化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make graph state cloning and deep-copy utilities JSON-serialization safe and extend test coverage for JSON-safe copying and time handling.

Enhancements:
- Add jsonSafeCopy and related helpers to produce deep copies that omit or normalize JSON-unsafe values like channels, functions, and unsafe pointers.
- Update State.safeClone to use JSON-safe deep copying so cloned state remains safe to json.Marshal while preserving JSON-friendly data.
- Refine time type detection to operate on reflect.Type for more robust handling of time.Time and convertible time-like types in copy logic.

Tests:
- Refactor existing deep copy tests to use testify assertions and expand coverage to channels, functions, time variants, DeepCopier paths, cycles, and JSON-unsafe values.
- Add comprehensive tests for jsonSafeCopy across structs, maps, slices, arrays, time types, JSON tags, cycles, and shared references.
- Add State.safeClone tests to verify unsafe keys are filtered, nested data is deep-copied, JSON-unsafe fields are dropped or zeroed, and cloned state is JSON-marshallable.

</details>

</details>

</details>

增强功能：
- 添加 `jsonSafeCopy` 及其辅助函数，在深度拷贝值时移除或转换诸如通道、函数和不安全指针等不适用于 JSON 的类型。
- 更新 `State.safeClone` 以使用 JSON 安全的深度拷贝，从而移除或规范化嵌套的不可序列化类型，以便进行 JSON 编码（marshalling）。

测试：
- 重构现有的深度拷贝测试，使用 testify 的断言以获得更清晰的期望表达和失败信息。
- 为 `jsonSafeCopy` 添加全面测试，覆盖结构体、map、slice、时间类型、JSON 标签以及混合/不安全值。
- 为 `State.safeClone` 添加测试，以验证不安全的键被过滤、嵌套的不可序列化字段被省略或置为 null，并且克隆后的状态可以进行 JSON 编码。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

使图状态克隆和深拷贝工具在 JSON 序列化时保持安全，并扩展与 JSON 安全拷贝和时间处理相关的测试覆盖率。

增强内容：
- 添加 `jsonSafeCopy` 及相关辅助函数，用于生成深拷贝对象，并省略或规范化诸如通道、函数和不安全指针等对 JSON 不安全的值。
- 更新 `State.safeClone` 以使用对 JSON 安全的深拷贝，这样在保持对 JSON 友好数据的同时，克隆后的状态仍可安全地传入 `json.Marshal`。
- 优化时间类型检测逻辑，使其基于 `reflect.Type` 工作，从而在拷贝逻辑中对 `time.Time` 及可转换的类时间类型进行更加健壮的处理。

测试：
- 重构现有深拷贝测试以使用 testify 断言，并扩展覆盖范围到通道、函数、时间变体、`DeepCopier` 路径、循环引用以及对 JSON 不安全的值。
- 为 `jsonSafeCopy` 添加全面测试，覆盖结构体、map、切片、数组、时间类型、JSON 标签、循环引用以及共享引用等情况。
- 添加 `State.safeClone` 测试，以验证不安全键被过滤、嵌套数据被深拷贝、对 JSON 不安全的字段被删除或置零，以及克隆后的状态可被 JSON 正常序列化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make graph state cloning and deep-copy utilities JSON-serialization safe and extend test coverage for JSON-safe copying and time handling.

Enhancements:
- Add jsonSafeCopy and related helpers to produce deep copies that omit or normalize JSON-unsafe values like channels, functions, and unsafe pointers.
- Update State.safeClone to use JSON-safe deep copying so cloned state remains safe to json.Marshal while preserving JSON-friendly data.
- Refine time type detection to operate on reflect.Type for more robust handling of time.Time and convertible time-like types in copy logic.

Tests:
- Refactor existing deep copy tests to use testify assertions and expand coverage to channels, functions, time variants, DeepCopier paths, cycles, and JSON-unsafe values.
- Add comprehensive tests for jsonSafeCopy across structs, maps, slices, arrays, time types, JSON tags, cycles, and shared references.
- Add State.safeClone tests to verify unsafe keys are filtered, nested data is deep-copied, JSON-unsafe fields are dropped or zeroed, and cloned state is JSON-marshallable.

</details>

增强内容：
- 引入 `jsonSafeCopy` 及相关辅助函数，用于在深拷贝值时剔除或规范化诸如通道、函数和不安全指针等对 JSON 不安全的类型。
- 更新 `State.safeClone` 以使用对 JSON 安全的深拷贝，从而在克隆状态时省略或转换嵌套的不可序列化字段，同时保留对 JSON 友好的数据。
- 优化时间类型检测逻辑，使其基于 `reflect.Type` 工作，从而在深拷贝逻辑中更好地处理 `time.Time` 及可转换的类似时间类型。

测试：
- 重构现有的深拷贝测试以使用 `testify` 断言，并扩展覆盖范围到通道、函数、时间变体、循环引用以及 `DeepCopier` 路径。
- 为 `jsonSafeCopy` 添加全面测试，覆盖结构体、map、切片、数组、时间类型、JSON 标签、循环引用以及混合/不安全值。
- 添加 `State.safeClone` 测试，以验证不安全键被过滤、嵌套数据被深度拷贝、对 JSON 不安全的字段被省略或置空，并且克隆后的状态可以被 JSON 编码（marshal）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

使图状态克隆和深拷贝工具在 JSON 序列化时保持安全，并扩展与 JSON 安全拷贝和时间处理相关的测试覆盖率。

增强内容：
- 添加 `jsonSafeCopy` 及相关辅助函数，用于生成深拷贝对象，并省略或规范化诸如通道、函数和不安全指针等对 JSON 不安全的值。
- 更新 `State.safeClone` 以使用对 JSON 安全的深拷贝，这样在保持对 JSON 友好数据的同时，克隆后的状态仍可安全地传入 `json.Marshal`。
- 优化时间类型检测逻辑，使其基于 `reflect.Type` 工作，从而在拷贝逻辑中对 `time.Time` 及可转换的类时间类型进行更加健壮的处理。

测试：
- 重构现有深拷贝测试以使用 testify 断言，并扩展覆盖范围到通道、函数、时间变体、`DeepCopier` 路径、循环引用以及对 JSON 不安全的值。
- 为 `jsonSafeCopy` 添加全面测试，覆盖结构体、map、切片、数组、时间类型、JSON 标签、循环引用以及共享引用等情况。
- 添加 `State.safeClone` 测试，以验证不安全键被过滤、嵌套数据被深拷贝、对 JSON 不安全的字段被删除或置零，以及克隆后的状态可被 JSON 正常序列化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make graph state cloning and deep-copy utilities JSON-serialization safe and extend test coverage for JSON-safe copying and time handling.

Enhancements:
- Add jsonSafeCopy and related helpers to produce deep copies that omit or normalize JSON-unsafe values like channels, functions, and unsafe pointers.
- Update State.safeClone to use JSON-safe deep copying so cloned state remains safe to json.Marshal while preserving JSON-friendly data.
- Refine time type detection to operate on reflect.Type for more robust handling of time.Time and convertible time-like types in copy logic.

Tests:
- Refactor existing deep copy tests to use testify assertions and expand coverage to channels, functions, time variants, DeepCopier paths, cycles, and JSON-unsafe values.
- Add comprehensive tests for jsonSafeCopy across structs, maps, slices, arrays, time types, JSON tags, cycles, and shared references.
- Add State.safeClone tests to verify unsafe keys are filtered, nested data is deep-copied, JSON-unsafe fields are dropped or zeroed, and cloned state is JSON-marshallable.

</details>

</details>

增强点：
- 引入对 JSON 安全的深拷贝工具，用于剔除或规范化 channel、函数、不安全指针以及其他对 JSON 不安全的值，并将其接入 `State.safeClone`。
- 扩展深拷贝逻辑，以更好地识别类似时间的类型，并在结构体、map、slice、数组和指针上区分对 JSON 安全与不安全的种类。

测试：
- 重构深拷贝测试，使用 testify 断言以获得更清晰的预期与失败信息。
- 为 `jsonSafeCopy` 添加广泛的覆盖范围，涵盖结构体、map、slice、数组、时间类型、JSON 标签、循环图以及对 JSON 不安全的值。
- 添加 `State.safeClone` 的测试，用于验证对不安全键的过滤、对嵌套数据的深拷贝、对嵌套 JSON 不安全字段的处理，以及克隆状态整体的 JSON 可序列化性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

使图状态克隆和深拷贝工具在 JSON 序列化时保持安全，并扩展与 JSON 安全拷贝和时间处理相关的测试覆盖率。

增强内容：
- 添加 `jsonSafeCopy` 及相关辅助函数，用于生成深拷贝对象，并省略或规范化诸如通道、函数和不安全指针等对 JSON 不安全的值。
- 更新 `State.safeClone` 以使用对 JSON 安全的深拷贝，这样在保持对 JSON 友好数据的同时，克隆后的状态仍可安全地传入 `json.Marshal`。
- 优化时间类型检测逻辑，使其基于 `reflect.Type` 工作，从而在拷贝逻辑中对 `time.Time` 及可转换的类时间类型进行更加健壮的处理。

测试：
- 重构现有深拷贝测试以使用 testify 断言，并扩展覆盖范围到通道、函数、时间变体、`DeepCopier` 路径、循环引用以及对 JSON 不安全的值。
- 为 `jsonSafeCopy` 添加全面测试，覆盖结构体、map、切片、数组、时间类型、JSON 标签、循环引用以及共享引用等情况。
- 添加 `State.safeClone` 测试，以验证不安全键被过滤、嵌套数据被深拷贝、对 JSON 不安全的字段被删除或置零，以及克隆后的状态可被 JSON 正常序列化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make graph state cloning and deep-copy utilities JSON-serialization safe and extend test coverage for JSON-safe copying and time handling.

Enhancements:
- Add jsonSafeCopy and related helpers to produce deep copies that omit or normalize JSON-unsafe values like channels, functions, and unsafe pointers.
- Update State.safeClone to use JSON-safe deep copying so cloned state remains safe to json.Marshal while preserving JSON-friendly data.
- Refine time type detection to operate on reflect.Type for more robust handling of time.Time and convertible time-like types in copy logic.

Tests:
- Refactor existing deep copy tests to use testify assertions and expand coverage to channels, functions, time variants, DeepCopier paths, cycles, and JSON-unsafe values.
- Add comprehensive tests for jsonSafeCopy across structs, maps, slices, arrays, time types, JSON tags, cycles, and shared references.
- Add State.safeClone tests to verify unsafe keys are filtered, nested data is deep-copied, JSON-unsafe fields are dropped or zeroed, and cloned state is JSON-marshallable.

</details>

增强内容：
- 引入 `jsonSafeCopy` 及相关辅助函数，用于在深拷贝值时剔除或规范化诸如通道、函数和不安全指针等对 JSON 不安全的类型。
- 更新 `State.safeClone` 以使用对 JSON 安全的深拷贝，从而在克隆状态时省略或转换嵌套的不可序列化字段，同时保留对 JSON 友好的数据。
- 优化时间类型检测逻辑，使其基于 `reflect.Type` 工作，从而在深拷贝逻辑中更好地处理 `time.Time` 及可转换的类似时间类型。

测试：
- 重构现有的深拷贝测试以使用 `testify` 断言，并扩展覆盖范围到通道、函数、时间变体、循环引用以及 `DeepCopier` 路径。
- 为 `jsonSafeCopy` 添加全面测试，覆盖结构体、map、切片、数组、时间类型、JSON 标签、循环引用以及混合/不安全值。
- 添加 `State.safeClone` 测试，以验证不安全键被过滤、嵌套数据被深度拷贝、对 JSON 不安全的字段被省略或置空，并且克隆后的状态可以被 JSON 编码（marshal）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

使图状态克隆和深拷贝工具在 JSON 序列化时保持安全，并扩展与 JSON 安全拷贝和时间处理相关的测试覆盖率。

增强内容：
- 添加 `jsonSafeCopy` 及相关辅助函数，用于生成深拷贝对象，并省略或规范化诸如通道、函数和不安全指针等对 JSON 不安全的值。
- 更新 `State.safeClone` 以使用对 JSON 安全的深拷贝，这样在保持对 JSON 友好数据的同时，克隆后的状态仍可安全地传入 `json.Marshal`。
- 优化时间类型检测逻辑，使其基于 `reflect.Type` 工作，从而在拷贝逻辑中对 `time.Time` 及可转换的类时间类型进行更加健壮的处理。

测试：
- 重构现有深拷贝测试以使用 testify 断言，并扩展覆盖范围到通道、函数、时间变体、`DeepCopier` 路径、循环引用以及对 JSON 不安全的值。
- 为 `jsonSafeCopy` 添加全面测试，覆盖结构体、map、切片、数组、时间类型、JSON 标签、循环引用以及共享引用等情况。
- 添加 `State.safeClone` 测试，以验证不安全键被过滤、嵌套数据被深拷贝、对 JSON 不安全的字段被删除或置零，以及克隆后的状态可被 JSON 正常序列化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make graph state cloning and deep-copy utilities JSON-serialization safe and extend test coverage for JSON-safe copying and time handling.

Enhancements:
- Add jsonSafeCopy and related helpers to produce deep copies that omit or normalize JSON-unsafe values like channels, functions, and unsafe pointers.
- Update State.safeClone to use JSON-safe deep copying so cloned state remains safe to json.Marshal while preserving JSON-friendly data.
- Refine time type detection to operate on reflect.Type for more robust handling of time.Time and convertible time-like types in copy logic.

Tests:
- Refactor existing deep copy tests to use testify assertions and expand coverage to channels, functions, time variants, DeepCopier paths, cycles, and JSON-unsafe values.
- Add comprehensive tests for jsonSafeCopy across structs, maps, slices, arrays, time types, JSON tags, cycles, and shared references.
- Add State.safeClone tests to verify unsafe keys are filtered, nested data is deep-copied, JSON-unsafe fields are dropped or zeroed, and cloned state is JSON-marshallable.

</details>

</details>

</details>

</details>