### PR TITLE
internal/flow/processor: annotate attached files

### DIFF
--- a/internal/flow/processor/content.go
+++ b/internal/flow/processor/content.go
@@ -204,6 +204,12 @@ const (
 	contentHasSessionSummaryStateKey = "processor:content:has_session_summary"
 )
 
+const (
+	attachedFilesAnnotationPrefix = "Attached files"
+	attachedFileNameFallbackFmt   = "upload_%d"
+	attachedFilesMaxPreview       = 20
+)
+
 // NewContentRequestProcessor creates a new content request processor.
 func NewContentRequestProcessor(opts ...ContentOption) *ContentRequestProcessor {
 	processor := &ContentRequestProcessor{
@@ -327,7 +333,8 @@ func (p *ContentRequestProcessor) ProcessRequest(
 	}
 
 	if model.HasPayload(invocation.Message) && needToAddInvocationMessage {
-		req.Messages = append(req.Messages, invocation.Message)
+		msg := annotateUserMessageWithAttachedFiles(invocation.Message)
+		req.Messages = append(req.Messages, msg)
 		log.DebugfContext(
 			ctx,
 			"Content request processor: added invocation message with "+
@@ -512,7 +519,106 @@ func (p *ContentRequestProcessor) getIncrementMessages(inv *agent.Invocation, si
 	if !p.AddSessionSummary && p.MaxHistoryRuns > 0 {
 		messages = applyMaxHistoryRuns(messages, p.MaxHistoryRuns)
 	}
+	messages = annotateUserMessagesWithAttachedFiles(messages)
 	return messages
+}
+
+func annotateUserMessagesWithAttachedFiles(
+	messages []model.Message,
+) []model.Message {
+	if len(messages) == 0 {
+		return messages
+	}
+	for i := range messages {
+		messages[i] = annotateUserMessageWithAttachedFiles(messages[i])
+	}
+	return messages
+}
+
+func annotateUserMessageWithAttachedFiles(
+	msg model.Message,
+) model.Message {
+	if msg.Role != model.RoleUser && msg.Role != "" {
+		return msg
+	}
+	if len(msg.ContentParts) == 0 {
+		return msg
+	}
+	if hasAttachedFilesAnnotation(msg.ContentParts) {
+		return msg
+	}
+	text := buildAttachedFilesAnnotationText(msg.ContentParts)
+	if text == "" {
+		return msg
+	}
+	annotation := model.ContentPart{
+		Type: model.ContentTypeText,
+		Text: &text,
+	}
+	parts := make([]model.ContentPart, 0, len(msg.ContentParts)+1)
+	parts = append(parts, annotation)
+	parts = append(parts, msg.ContentParts...)
+	msg.ContentParts = parts
+	return msg
+}
+
+func hasAttachedFilesAnnotation(parts []model.ContentPart) bool {
+	for _, part := range parts {
+		if part.Type != model.ContentTypeText || part.Text == nil {
+			continue
+		}
+		if strings.HasPrefix(
+			strings.TrimSpace(*part.Text),
+			attachedFilesAnnotationPrefix,
+		) {
+			return true
+		}
+	}
+	return false
+}
+
+func buildAttachedFilesAnnotationText(
+	parts []model.ContentPart,
+) string {
+	names, count := fileNamesForAnnotation(parts)
+	if count == 0 {
+		return ""
+	}
+	var b strings.Builder
+	fmt.Fprintf(
+		&b,
+		"%s (%d): ",
+		attachedFilesAnnotationPrefix,
+		count,
+	)
+	b.WriteString(strings.Join(names, ", "))
+	if count > len(names) {
+		fmt.Fprintf(&b, " (+%d more)", count-len(names))
+	}
+	b.WriteString("\n")
+	return b.String()
+}
+
+func fileNamesForAnnotation(
+	parts []model.ContentPart,
+) ([]string, int) {
+	names := make([]string, 0, len(parts))
+	count := 0
+	for _, part := range parts {
+		if part.Type != model.ContentTypeFile || part.File == nil {
+			continue
+		}
+		count++
+		if len(names) >= attachedFilesMaxPreview {
+			continue
+		}
+		name := strings.TrimSpace(part.File.Name)
+		if name == "" {
+			name = fmt.Sprintf(attachedFileNameFallbackFmt, count)
+		}
+		names = append(names, name)
+	}
+	return names, count
 }
 
 // applyMaxHistoryRuns trims messages to at most maxRuns entries from the tail.
@@ -662,6 +768,7 @@ func (p *ContentRequestProcessor) getCurrentInvocationMessages(inv *agent.Invoca
 	}
 
 	messages = p.mergeUserMessages(messages)
+	messages = annotateUserMessagesWithAttachedFiles(messages)
 	return messages
 }
 

--- a/internal/flow/processor/content_test.go
+++ b/internal/flow/processor/content_test.go
@@ -3934,3 +3934,74 @@ func TestContentRequestProcessor_FormatSummary_DefaultFormatter(t *testing.T) {
 	assert.Contains(t, result, "<summary_of_previous_interactions>",
 		"default formatter should use XML tags")
 }
+
+func TestContentRequestProcessor_AnnotatesUserFileInputs(t *testing.T) {
+	p := NewContentRequestProcessor()
+
+	const (
+		invocationID = "inv"
+		pdfMimeType  = "application/pdf"
+		fileAName    = "a.pdf"
+		fileBName    = "b.pdf"
+	)
+
+	userMsg := model.Message{
+		Role: model.RoleUser,
+		ContentParts: []model.ContentPart{
+			{
+				Type: model.ContentTypeFile,
+				File: &model.File{
+					Name:     fileAName,
+					Data:     []byte("a"),
+					MimeType: pdfMimeType,
+				},
+			},
+			{
+				Type: model.ContentTypeFile,
+				File: &model.File{
+					Name:     fileBName,
+					Data:     []byte("b"),
+					MimeType: pdfMimeType,
+				},
+			},
+		},
+	}
+	ev := event.NewResponseEvent(invocationID, "user", &model.Response{
+		Choices: []model.Choice{{Message: userMsg}},
+	})
+	inv := &agent.Invocation{
+		InvocationID: invocationID,
+		AgentName:    "agent",
+		Session: &session.Session{
+			Events: []event.Event{*ev},
+		},
+	}
+	req := &model.Request{}
+	ch := make(chan *event.Event, 1)
+	p.ProcessRequest(context.Background(), inv, req, ch)
+
+	if !assert.Len(t, req.Messages, 1) {
+		return
+	}
+	msg := req.Messages[0]
+	assert.Equal(t, model.RoleUser, msg.Role)
+
+	if !assert.GreaterOrEqual(t, len(msg.ContentParts), 3) {
+		return
+	}
+	first := msg.ContentParts[0]
+	assert.Equal(t, model.ContentTypeText, first.Type)
+	if assert.NotNil(t, first.Text) {
+		assert.Contains(t, *first.Text, attachedFilesAnnotationPrefix)
+		assert.Contains(t, *first.Text, fileAName)
+		assert.Contains(t, *first.Text, fileBName)
+	}
+
+	fileParts := 0
+	for _, part := range msg.ContentParts {
+		if part.Type == model.ContentTypeFile && part.File != nil {
+			fileParts++
+		}
+	}
+	assert.Equal(t, 2, fileParts)
+}


### PR DESCRIPTION
## Problem
When users upload files as message content parts, some model providers omit
file parts in chat requests. The model may think there are no attachments
until `skill_run` stages them.

## Solution
- If a user message contains file content parts, prepend a small text
  annotation like `Attached files (N): ...` before sending messages to
  the model.
- This is request-only (no session mutation) and keeps `skill_run`
  staging behavior unchanged.

## Tests
- `go test ./internal/flow/processor`

## Summary by Sourcery

为包含文件内容部分的用户消息添加标注，使模型在请求载荷中能明确获知所附文件，而无需改变会话状态或 `skill_run` 行为。

Enhancements:
- 在增量和当前调用这两种消息流中，对包含文件内容部分的用户消息前追加一段可读性良好的“附加文件”标注。
- 通过检测现有的“附加文件”提示来避免重复标注，并将预览限制在一个有界的文件名列表内，同时提供合理的回退方案。

Tests:
- 添加处理器测试，用于验证用户的文件输入在向外发送的请求中既能被保留，又能正确加上“附加文件”文本前缀标注。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Annotate user messages that include file content parts so models are explicitly informed about attached files in request payloads without altering session state or skill_run behavior.

Enhancements:
- Prepend a human-readable attached-files annotation to user messages that contain file content parts in both incremental and current invocation message flows.
- Avoid duplicating annotations by detecting existing attached-file notices and limiting the preview to a bounded list of file names with sensible fallbacks.

Tests:
- Add processor tests to verify that user file inputs are preserved and correctly annotated with an attached-files text prefix in outgoing requests.

</details>