### PR TITLE
graph: run after-node callbacks on node errors

### DIFF
--- a/docs/mkdocs/en/graph.md
+++ b/docs/mkdocs/en/graph.md
@@ -4194,6 +4194,94 @@ Recommendations:
 - Internal/volatile keys are filtered from final snapshots and should not be emitted (see [graph/internal_keys.go:16](https://github.com/trpc-group/trpc-agent-go/blob/main/graph/internal_keys.go#L16)).
 - For textual intermediate outputs, prefer existing model streaming events (`choice.Delta.Content`).
 
+#### Recover from non-fatal node errors
+
+By default, if a node returns a non‑nil `error`, graph execution stops and the
+Executor emits an error event.
+
+Sometimes you want a *non‑fatal* error:
+
+- Record the error (for debugging/monitoring or to show in the final output)
+- Keep running the rest of the graph
+
+You can implement this with an After‑node callback (`WithPostNodeCallback` or
+graph‑wide `WithNodeCallbacks`).
+
+How it works:
+
+- Your callback receives `nodeErr error`.
+  - `nodeErr == nil`: the node succeeded
+  - `nodeErr != nil`: the node failed (possibly after retries)
+- If you decide the error is **non‑fatal**, return a **non‑nil** replacement
+  result and `nil` error.
+  - The replacement result is handled like a normal node result: it can be
+    `graph.State`, `*graph.Command`, or `[]*graph.Command`.
+  - Returning `graph.State{...}` is a common way to both recover and record the
+    error in state.
+- If you return `nil, nil` on a failure, the original node error is preserved
+  and the graph still fails.
+
+Example: collect non‑fatal errors into `stateKeyNodeErrors` while continuing:
+
+```go
+import (
+    "context"
+    "errors"
+    "reflect"
+
+    "trpc.group/trpc-go/trpc-agent-go/graph"
+)
+
+const (
+    stateKeyNodeErrors = "node_errors"
+)
+
+var errNonFatal = errors.New("non-fatal error")
+
+func failingNode(ctx context.Context, st graph.State) (any, error) {
+    return nil, errNonFatal
+}
+
+func buildGraph() (*graph.Graph, error) {
+    schema := graph.MessagesStateSchema()
+    schema.AddField(stateKeyNodeErrors, graph.StateField{
+        Type:    reflect.TypeOf([]string{}),
+        Reducer: graph.StringSliceReducer,
+        Default: func() any { return []string{} },
+    })
+
+    sg := graph.NewStateGraph(schema)
+    sg.AddNode("N", failingNode)
+
+    cbs := graph.NewNodeCallbacks().RegisterAfterNode(func(
+        ctx context.Context,
+        cb *graph.NodeCallbackContext,
+        st graph.State,
+        result any,
+        nodeErr error,
+    ) (any, error) {
+        if nodeErr == nil {
+            return nil, nil
+        }
+        // Decide whether it's fatal.
+        if !errors.Is(nodeErr, errNonFatal) {
+            return nil, nil // keep it fatal
+        }
+        // Non-fatal: record it and keep running.
+        return graph.State{
+            stateKeyNodeErrors: []string{
+                cb.NodeID + ": " + nodeErr.Error(),
+            },
+        }, nil
+    })
+    sg.WithNodeCallbacks(cbs)
+
+    sg.SetEntryPoint("N")
+    sg.SetFinishPoint("N")
+    return sg.Compile()
+}
+```
+
 You can also configure agent‑level callbacks:
 
 ```go

--- a/docs/mkdocs/zh/graph.md
+++ b/docs/mkdocs/zh/graph.md
@@ -4140,6 +4140,86 @@ func buildGraph() (*graph.Graph, error) {
 - 内部/易变键不会被序列化到最终快照，亦不建议外发（参考 [graph/internal_keys.go:16](https://github.com/trpc-group/trpc-agent-go/blob/main/graph/internal_keys.go#L16)）；
 - 文本类中间结果优先复用模型流式事件（`choice.Delta.Content`）。
 
+#### 将节点错误视为“非致命”并继续执行
+
+默认情况下，如果某个节点返回了非空 `error`，图会停止执行，Executor 会发出错误事件。
+
+有些业务场景希望把部分错误当作**非致命错误**：
+
+- 记录错误信息（便于排查/监控，或供后续节点/最终输出使用）
+- 不中断图执行，继续跑后续节点
+
+可以用 After 节点回调（`WithPostNodeCallback` 或图级 `WithNodeCallbacks`）来实现：
+
+- 回调会收到 `nodeErr error`：
+  - `nodeErr == nil`：节点成功
+  - `nodeErr != nil`：节点失败（可能经历过重试）
+- 如果你判定这是**非致命错误**，回调需要返回一个**非 nil** 的“替代结果”以及 `nil` error：
+  - 替代结果会按“正常节点返回值”处理：可以是 `graph.State`、`*graph.Command` 或 `[]*graph.Command`。
+  - 常见做法是返回 `graph.State{...}`：既完成“恢复”，又把错误写入 state。
+- 如果在失败时返回 `nil, nil`，原始错误会保留，图依旧会失败。
+
+示例：把非致命错误收集到 `stateKeyNodeErrors` 并继续执行：
+
+```go
+import (
+    "context"
+    "errors"
+    "reflect"
+
+    "trpc.group/trpc-go/trpc-agent-go/graph"
+)
+
+const (
+    stateKeyNodeErrors = "node_errors"
+)
+
+var errNonFatal = errors.New("non-fatal error")
+
+func failingNode(ctx context.Context, st graph.State) (any, error) {
+    return nil, errNonFatal
+}
+
+func buildGraph() (*graph.Graph, error) {
+    schema := graph.MessagesStateSchema()
+    schema.AddField(stateKeyNodeErrors, graph.StateField{
+        Type:    reflect.TypeOf([]string{}),
+        Reducer: graph.StringSliceReducer,
+        Default: func() any { return []string{} },
+    })
+
+    sg := graph.NewStateGraph(schema)
+    sg.AddNode("N", failingNode)
+
+    cbs := graph.NewNodeCallbacks().RegisterAfterNode(func(
+        ctx context.Context,
+        cb *graph.NodeCallbackContext,
+        st graph.State,
+        result any,
+        nodeErr error,
+    ) (any, error) {
+        if nodeErr == nil {
+            return nil, nil
+        }
+        // Decide whether it's fatal.
+        if !errors.Is(nodeErr, errNonFatal) {
+            return nil, nil // keep it fatal
+        }
+        // Non-fatal: record it and keep running.
+        return graph.State{
+            stateKeyNodeErrors: []string{
+                cb.NodeID + ": " + nodeErr.Error(),
+            },
+        }, nil
+    })
+    sg.WithNodeCallbacks(cbs)
+
+    sg.SetEntryPoint("N")
+    sg.SetFinishPoint("N")
+    return sg.Compile()
+}
+```
+
 也可以在 Agent 级别配置回调：
 
 ```go

--- a/graph/callbacks.go
+++ b/graph/callbacks.go
@@ -48,10 +48,15 @@ type BeforeNodeCallback func(
 	state State,
 ) (any, error)
 
-// AfterNodeCallback is called after a node is executed.
+// AfterNodeCallback is called after a node execution finishes (both success
+// and final failure).
+//
 // Returns (customResult, error).
-// - customResult: if not nil, this result will be used instead of the actual node result.
-// - error: if not nil, this error will be returned.
+//
+//   - customResult: if not nil, it replaces the node result. When nodeErr is
+//     non-nil, returning a non-nil customResult with a nil error recovers the
+//     node and allows graph execution to continue.
+//   - error: if not nil, it replaces the node error and stops graph execution.
 type AfterNodeCallback func(
 	ctx context.Context,
 	callbackCtx *NodeCallbackContext,

--- a/graph/executor.go
+++ b/graph/executor.go
@@ -2491,9 +2491,18 @@ func (e *Executor) handleCachedResult(
 	nodeCtx *nodeExecutionContext,
 ) error {
 	// Run after node callbacks on cache hit.
-	if res, err := e.runAfterCallbacks(
-		ctx, invocation, nodeCtx.mergedCallbacks, nodeCtx.callbackCtx,
-		nodeCtx.stateCopy, result, execCtx, t.NodeID, nodeCtx.nodeType, step,
+	if res, _, err := e.runAfterCallbacks(
+		ctx,
+		invocation,
+		nodeCtx.mergedCallbacks,
+		nodeCtx.callbackCtx,
+		nodeCtx.stateCopy,
+		result,
+		nil,
+		execCtx,
+		t.NodeID,
+		nodeCtx.nodeType,
+		step,
 	); err != nil {
 		return err
 	} else if res != nil {
@@ -2577,7 +2586,23 @@ func (e *Executor) executeTaskWithRetry(
 		}
 		shouldRetry, retryErr := e.evaluateRetryDecision(ctx, invocation, execCtx, t, step, nodeCtx, retryCtx)
 		if !shouldRetry {
-			return retryErr
+			if IsInterruptError(retryErr) {
+				return retryErr
+			}
+			if !errors.Is(retryErr, err) {
+				return retryErr
+			}
+			return e.finalizeFailedExecution(
+				ctx,
+				invocation,
+				execCtx,
+				t,
+				result,
+				retryErr,
+				err,
+				step,
+				nodeCtx,
+			)
 		}
 
 		attempt++
@@ -2603,9 +2628,18 @@ func (e *Executor) finalizeSuccessfulExecution(
 	nodeCtx *nodeExecutionContext,
 ) error {
 	// Run after node callbacks on success.
-	if res, aerr := e.runAfterCallbacks(
-		ctx, invocation, nodeCtx.mergedCallbacks, nodeCtx.callbackCtx, nodeCtx.stateCopy, result,
-		execCtx, t.NodeID, nodeCtx.nodeType, step,
+	if res, _, aerr := e.runAfterCallbacks(
+		ctx,
+		invocation,
+		nodeCtx.mergedCallbacks,
+		nodeCtx.callbackCtx,
+		nodeCtx.stateCopy,
+		result,
+		nil,
+		execCtx,
+		t.NodeID,
+		nodeCtx.nodeType,
+		step,
 	); aerr != nil {
 		return aerr
 	} else if res != nil {
@@ -2657,6 +2691,114 @@ func (e *Executor) finalizeSuccessfulExecution(
 	// Emit node completion event for the overall node run (no cache hit).
 	e.emitNodeCompleteEvent(ctx, invocation, execCtx, t.NodeID, nodeCtx.nodeType, step, nodeCtx.nodeStart, false)
 	if err := e.emitNodeBarrierAndWait(ctx, invocation, execCtx, t.NodeID, step); err != nil {
+		return fmt.Errorf("emit node barrier: %w", err)
+	}
+	return nil
+}
+
+func (e *Executor) finalizeFailedExecution(
+	ctx context.Context,
+	invocation *agent.Invocation,
+	execCtx *ExecutionContext,
+	t *Task,
+	result any,
+	retryErr error,
+	nodeErr error,
+	step int,
+	nodeCtx *nodeExecutionContext,
+) error {
+	if nodeCtx == nil || nodeCtx.mergedCallbacks == nil {
+		return retryErr
+	}
+
+	res, overridden, aerr := e.runAfterCallbacks(
+		ctx,
+		invocation,
+		nodeCtx.mergedCallbacks,
+		nodeCtx.callbackCtx,
+		nodeCtx.stateCopy,
+		result,
+		nodeErr,
+		execCtx,
+		t.NodeID,
+		nodeCtx.nodeType,
+		step,
+	)
+	if aerr != nil {
+		return aerr
+	}
+	if !overridden {
+		return retryErr
+	}
+	return e.finalizeRecoveredExecution(
+		ctx,
+		invocation,
+		execCtx,
+		t,
+		res,
+		step,
+		nodeCtx,
+	)
+}
+
+func (e *Executor) finalizeRecoveredExecution(
+	ctx context.Context,
+	invocation *agent.Invocation,
+	execCtx *ExecutionContext,
+	t *Task,
+	result any,
+	step int,
+	nodeCtx *nodeExecutionContext,
+) error {
+	e.syncResumeState(execCtx, nodeCtx.stateCopy)
+
+	routed, herr := e.handleNodeResult(
+		ctx,
+		invocation,
+		execCtx,
+		t,
+		result,
+		step,
+	)
+	if herr != nil {
+		return herr
+	}
+
+	e.updateVersionsSeen(execCtx, t.NodeID, t.Triggers)
+
+	if !routed {
+		if err := e.processConditionalEdges(
+			ctx,
+			invocation,
+			execCtx,
+			t.NodeID,
+			step,
+		); err != nil {
+			return fmt.Errorf(
+				"conditional edge processing failed for node %s: %w",
+				t.NodeID,
+				err,
+			)
+		}
+	}
+
+	e.emitNodeCompleteEvent(
+		ctx,
+		invocation,
+		execCtx,
+		t.NodeID,
+		nodeCtx.nodeType,
+		step,
+		nodeCtx.nodeStart,
+		false,
+	)
+	if err := e.emitNodeBarrierAndWait(
+		ctx,
+		invocation,
+		execCtx,
+		t.NodeID,
+		step,
+	); err != nil {
 		return fmt.Errorf("emit node barrier: %w", err)
 	}
 	return nil
@@ -2966,25 +3108,74 @@ func (e *Executor) runAfterCallbacks(
 	cbCtx *NodeCallbackContext,
 	stateCopy State,
 	result any,
+	nodeErr error,
 	execCtx *ExecutionContext,
 	nodeID string,
 	nodeType NodeType,
 	step int,
-) (any, error) {
+) (any, bool, error) {
 	if callbacks == nil {
-		return nil, nil
+		return nil, false, nil
 	}
-	customResult, err := callbacks.RunAfterNode(ctx, cbCtx, stateCopy, result, nil)
+	customResult, overridden, err := runAfterNodeCallbacks(
+		ctx,
+		callbacks,
+		cbCtx,
+		stateCopy,
+		result,
+		nodeErr,
+	)
 	if err != nil {
 		callbacks.RunOnNodeError(ctx, cbCtx, stateCopy, err)
 		e.syncResumeState(execCtx, stateCopy)
 		e.emitNodeErrorEvent(ctx, invocation, execCtx, nodeID, nodeType, step, err)
 		if berr := e.emitNodeBarrierAndWait(ctx, invocation, execCtx, nodeID, step); berr != nil {
-			return nil, fmt.Errorf("emit node barrier: %w", berr)
+			return nil, false, fmt.Errorf("emit node barrier: %w", berr)
 		}
-		return nil, fmt.Errorf("after node callback failed for node %s: %w", nodeID, err)
+		return nil, false, fmt.Errorf(
+			"after node callback failed for node %s: %w",
+			nodeID,
+			err,
+		)
 	}
-	return customResult, nil
+	return customResult, overridden, nil
+}
+
+func runAfterNodeCallbacks(
+	ctx context.Context,
+	callbacks *NodeCallbacks,
+	callbackCtx *NodeCallbackContext,
+	state State,
+	result any,
+	nodeErr error,
+) (any, bool, error) {
+	if callbacks == nil {
+		return result, false, nil
+	}
+
+	currentResult := result
+	var overridden bool
+	for _, cb := range callbacks.AfterNode {
+		if cb == nil {
+			continue
+		}
+		customResult, err := cb(
+			ctx,
+			callbackCtx,
+			state,
+			currentResult,
+			nodeErr,
+		)
+		if err != nil {
+			return nil, false, err
+		}
+		if customResult == nil {
+			continue
+		}
+		overridden = true
+		currentResult = customResult
+	}
+	return currentResult, overridden, nil
 }
 
 // mergeNodeCallbacks merges global and per-node callbacks.

--- a/graph/executor_node_barrier_test.go
+++ b/graph/executor_node_barrier_test.go
@@ -279,7 +279,19 @@ func TestRunAfterCallbacks_BarrierWaitErrorPropagates(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
 	defer cancel()
 
-	result, err := exec.runAfterCallbacks(ctx, inv, callbacks, nil, State{}, nil, execCtx, "N", NodeTypeFunction, 1)
+	result, _, err := exec.runAfterCallbacks(
+		ctx,
+		inv,
+		callbacks,
+		nil,
+		State{},
+		nil,
+		nil,
+		execCtx,
+		"N",
+		NodeTypeFunction,
+		1,
+	)
 	require.Nil(t, result)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "node barrier")

--- a/graph/executor_test.go
+++ b/graph/executor_test.go
@@ -12,6 +12,7 @@ package graph
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -1230,6 +1231,143 @@ func TestAfterCallbackOverride(t *testing.T) {
 	rv, ok := final["result"].(string)
 	require.True(t, ok)
 	require.Equal(t, "override", rv)
+}
+
+func TestAfterCallbackRunsOnNodeError(t *testing.T) {
+	boom := errors.New("boom")
+
+	g := NewStateGraph(NewStateSchema())
+	g.AddNode("N", func(ctx context.Context, s State) (any, error) {
+		return nil, boom
+	})
+	g.SetEntryPoint("N").SetFinishPoint("N")
+
+	var afterCalls int32
+	var afterSawNilResult int32
+	var afterSawErr atomic.Value
+	cbs := NewNodeCallbacks().RegisterAfterNode(func(
+		ctx context.Context,
+		cb *NodeCallbackContext,
+		st State,
+		result any,
+		nodeErr error,
+	) (any, error) {
+		atomic.AddInt32(&afterCalls, 1)
+		if result == nil {
+			atomic.StoreInt32(&afterSawNilResult, 1)
+		}
+		if nodeErr != nil {
+			afterSawErr.Store(nodeErr)
+		}
+		return nil, nil
+	})
+	g.WithNodeCallbacks(cbs)
+
+	compiled, err := g.Compile()
+	require.NoError(t, err)
+	exec, err := NewExecutor(compiled)
+	require.NoError(t, err)
+
+	ch, err := exec.Execute(
+		context.Background(),
+		State{},
+		&agent.Invocation{InvocationID: "inv-after-on-error"},
+	)
+	require.NoError(t, err)
+
+	var sawPregelError bool
+	for evt := range ch {
+		if evt.Object != ObjectTypeGraphPregelStep {
+			continue
+		}
+		if evt.Response == nil || evt.Response.Error == nil {
+			continue
+		}
+		sawPregelError = true
+	}
+
+	require.True(t, sawPregelError)
+	require.Equal(t, int32(1), atomic.LoadInt32(&afterCalls))
+	require.Equal(t, int32(1), atomic.LoadInt32(&afterSawNilResult))
+
+	got, ok := afterSawErr.Load().(error)
+	require.True(t, ok)
+	require.ErrorIs(t, got, boom)
+}
+
+func TestAfterCallbackCanRecoverNodeError(t *testing.T) {
+	boom := errors.New("boom")
+
+	g := NewStateGraph(NewStateSchema())
+	g.AddNode("N", func(ctx context.Context, s State) (any, error) {
+		return nil, boom
+	})
+	g.SetEntryPoint("N").SetFinishPoint("N")
+
+	var afterCalls int32
+	var afterSawErr atomic.Value
+	cbs := NewNodeCallbacks().RegisterAfterNode(func(
+		ctx context.Context,
+		cb *NodeCallbackContext,
+		st State,
+		result any,
+		nodeErr error,
+	) (any, error) {
+		atomic.AddInt32(&afterCalls, 1)
+		if nodeErr != nil {
+			afterSawErr.Store(nodeErr)
+		}
+		return State{"ok": true}, nil
+	})
+	g.WithNodeCallbacks(cbs)
+
+	compiled, err := g.Compile()
+	require.NoError(t, err)
+	exec, err := NewExecutor(compiled)
+	require.NoError(t, err)
+
+	ch, err := exec.Execute(
+		context.Background(),
+		State{},
+		&agent.Invocation{InvocationID: "inv-after-recover"},
+	)
+	require.NoError(t, err)
+
+	var sawPregelError bool
+	final := make(State)
+	for ev := range ch {
+		if ev.Object == ObjectTypeGraphPregelStep &&
+			ev.Response != nil &&
+			ev.Response.Error != nil {
+			sawPregelError = true
+		}
+		if ev.Done && ev.StateDelta != nil {
+			for k, vb := range ev.StateDelta {
+				switch k {
+				case MetadataKeyNode, MetadataKeyPregel,
+					MetadataKeyChannel, MetadataKeyState,
+					MetadataKeyCompletion:
+					continue
+				default:
+				}
+				var v any
+				if err := json.Unmarshal(vb, &v); err == nil {
+					final[k] = v
+				}
+			}
+		}
+	}
+
+	require.False(t, sawPregelError)
+	require.Equal(t, int32(1), atomic.LoadInt32(&afterCalls))
+
+	got, ok := afterSawErr.Load().(error)
+	require.True(t, ok)
+	require.ErrorIs(t, got, boom)
+
+	okv, ok := final["ok"].(bool)
+	require.True(t, ok)
+	require.True(t, okv)
 }
 
 func TestBeforeCallbackError_BarrierWaitsForCompletion(t *testing.T) {


### PR DESCRIPTION
## What
- Run `AfterNode` callbacks even when a node returns an error (`nodeErr` is passed through).
- Allow `AfterNode` to recover non-fatal node errors by returning a non-nil replacement result with `nil` error.

## Why
This enables a unified post-processing hook to classify fatal vs non-fatal node errors, continue the graph for non-fatal errors, and collect node error info without forcing every node to encode errors into `StateDelta`.

## How
- `Executor.executeTaskWithRetry` runs after-node callbacks on final failure.
- Recovery uses the callback's non-nil custom result to continue execution.
- Docs add a recipe + example for collecting non-fatal errors.
- Tests cover both fatal and recovered error paths.

## Tests
- `go test ./... -count=1`

## Summary by Sourcery

允许图在 After-node 回调中观察节点错误，并在需要时恢复失败节点，同时相应更新执行流程、测试和文档。

新功能：
- 支持将节点执行错误传入 AfterNode 回调，以实现统一的后处理逻辑。
- 允许 AfterNode 回调通过返回替代结果将节点错误标记为非致命，从而继续图的执行。

增强：
- 为失败和已恢复的节点执行添加收尾路径，使已恢复的结果可以像成功的节点输出一样进行路由。
- 扩展 after-node 回调运行器以处理多个回调，跟踪结果覆盖情况，并传播合适的错误事件和屏障事件。

文档：
- 记录如何通过 After-node 回调将节点错误视为非致命错误，并在英文和中文的图文档中加入示例配方。

测试：
- 添加执行器测试，用于验证 AfterNode 回调在节点出错时运行，并且可以在不产生图级错误的情况下恢复失败。
- 调整现有测试，以适配新的 AfterNode 回调函数签名以及与节点屏障相关的行为变化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow graph after-node callbacks to observe node errors and optionally recover failed nodes, while updating execution flow, tests, and docs accordingly.

New Features:
- Support passing node execution errors into AfterNode callbacks for unified post-processing.
- Enable AfterNode callbacks to mark node errors as non-fatal by returning a replacement result that continues graph execution.

Enhancements:
- Add finalization paths for failed and recovered node executions so recovered results are routed like successful node outputs.
- Extend after-node callback runner to handle multiple callbacks, track result overrides, and propagate appropriate error and barrier events.

Documentation:
- Document how to treat node errors as non-fatal using After-node callbacks, including an example recipe in both English and Chinese graph documentation.

Tests:
- Add executor tests verifying AfterNode callbacks run on node error and can recover failures without emitting graph errors.
- Adjust existing tests to account for the new AfterNode callback signature and behavior around node barriers.

</details>