### PR TITLE
Command injection vulnerability

### DIFF
--- a/openclaw/skills/model-usage/scripts/model_usage.py
+++ b/openclaw/skills/model-usage/scripts/model_usage.py
@@ -31,7 +31,15 @@ def eprint(msg: str) -> None:
     print(msg, file=sys.stderr)
 
 
+ALLOWED_PROVIDERS = frozenset({"codex", "claude"})
+
+
 def run_codexbar_cost(provider: str) -> List[Dict[str, Any]]:
+    if provider not in ALLOWED_PROVIDERS:
+        raise ValueError(
+            f"Invalid provider: {provider!r}. "
+            f"Must be one of: {', '.join(sorted(ALLOWED_PROVIDERS))}"
+        )
     cmd = ["codexbar", "cost", "--format", "json", "--provider", provider]
     try:
         output = subprocess.check_output(cmd, text=True)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix command injection vulnerability in `model_usage.py` by adding explicit allow-list validation.

Although `argparse` restricts the `provider` parameter, direct calls to `run_codexbar_cost` could bypass this validation. Explicitly validating the `provider` against an allow-list within the function provides defense-in-depth against potential command injection.

---
<p><a href="https://cursor.com/agents/bc-707a7aa1-13cb-42f0-98de-b54b0d660dfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-707a7aa1-13cb-42f0-98de-b54b0d660dfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->

## Summary by Sourcery

错误修复：
- 在调用外部成本计算命令之前，先将 `provider` 参数与允许列表进行校验，以防止潜在的命令注入。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent potential command injection by validating the provider argument against an allow-list before invoking the external cost calculation command.

</details>
- 为模型使用成本计算中的 provider 参数添加允许列表检查，以防止通过直接函数调用进行的潜在命令注入。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

错误修复：
- 在调用外部成本计算命令之前，先将 `provider` 参数与允许列表进行校验，以防止潜在的命令注入。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent potential command injection by validating the provider argument against an allow-list before invoking the external cost calculation command.

</details>

</details>