### PR TITLE
docs: add call count limits docs for agents

### DIFF
--- a/docs/mkdocs/en/agent.md
+++ b/docs/mkdocs/en/agent.md
@@ -443,7 +443,7 @@ agent := llmagent.New(
 **Behavior:**
 
 - **`WithMaxLLMCalls`**: When LLM call count exceeds the limit, a `StopError` is returned and the current invocation terminates.
-- **`WithMaxToolIterations`**: When tool iteration count exceeds the limit, a `StopError` is returned and the current invocation terminates.
+- **`WithMaxToolIterations`**: When tool iteration count exceeds the limit, a `flow_error` response event is emitted and the invocation ends. It does not return a `StopError`.
 - Both limits are independent and can be used separately or together.
 - These limits are per-invocation; different `runner.Run()` calls maintain independent counts.
 

--- a/docs/mkdocs/zh/agent.md
+++ b/docs/mkdocs/zh/agent.md
@@ -417,7 +417,7 @@ agent := llmagent.New(
 **行为说明：**
 
 - **`WithMaxLLMCalls`**：当 LLM 调用次数超过限制时，会返回 `StopError`，终止当前调用。
-- **`WithMaxToolIterations`**：当工具迭代次数超过限制时，会返回 `StopError`，终止当前调用。
+- **`WithMaxToolIterations`**：当工具迭代次数超过限制时，会发送 `flow_error` 响应事件并结束调用，不会返回 `StopError`。
 - 两个限制相互独立，可以单独使用或组合使用。
 - 这些限制是每次调用级别的，不同的 `runner.Run()` 调用会各自独立计数。
 


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

在英文和中文的 Agent 文档中补充关于调用次数限制安全机制的说明。

文档更新：
- 在英文版 Agent 文档中解释每次 Agent 调用可配置的「最大 LLM 调用次数」和「最大工具迭代次数」限制，包括当超过限制时的行为说明以及在生产环境中的推荐使用方式。
- 在中文版 Agent 文档中新增与上述相同的调用次数限制配置说明和使用指引。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document call count limit safety mechanisms for agents in both English and Chinese agent docs.

Documentation:
- Explain configurable limits for maximum LLM calls and tool iterations per agent invocation, including behavior when limits are exceeded and recommended production usage, in the English agent documentation.
- Add equivalent call count limit configuration and usage guidance to the Chinese agent documentation.

</details>