### PR TITLE
session/summary: exclude sub-agent events from primary threshold checks

### DIFF
--- a/examples/summary/subagent/README.md
+++ b/examples/summary/subagent/README.md
@@ -1,0 +1,149 @@
+# Sub-Agent Summarization Example
+
+This example demonstrates session summarization when the primary agent delegates
+work to a sub-agent via `agenttool`. It uses intentionally low token/event
+thresholds so that summarisation triggers quickly, making it easy to observe how
+summaries are generated for both the primary agent branch and the sub-agent
+branch.
+
+## Key Concepts
+
+- **AgentTool delegation**: The parent agent wraps a child agent as a tool and
+  delegates math questions to it.
+- **Branch summaries**: Each agent branch (primary and child) gets its own
+  summary keyed by `FilterKey`.
+- **Full-session summary**: A separate summary covering all events across all
+  branches is also generated.
+- **Threshold isolation**: Sub-agent tokens/events do not inflate the primary
+  agent's threshold checks, preventing premature summarisation of the parent
+  branch.
+
+## Architecture
+
+```
+Parent Agent (summary-subagent-demo)
+└── Math Specialist Agent Tool (math-specialist-<uuid>)
+    └── Calculator Function Tool
+```
+
+When the parent receives a math question it delegates to the math-specialist
+agent tool. The framework records events under separate `FilterKey` values:
+
+- `summary-subagent-demo` — parent agent events.
+- `math-specialist-<uuid>` — child agent events (isolated branch).
+
+The summariser produces up to three summaries:
+
+| Summary key                  | Contents                            |
+|------------------------------|-------------------------------------|
+| `summary-subagent-demo`      | Parent agent branch only.           |
+| `math-specialist-<uuid>`     | Child agent branch only.            |
+| `(full-session)`             | All events merged.                  |
+
+## Prerequisites
+
+- Go 1.21 or later.
+- Model configuration via environment variables.
+
+Environment variables:
+
+- `OPENAI_API_KEY`: API key for the model service.
+- `OPENAI_BASE_URL` (optional): Base URL for the model API endpoint.
+- `MODEL_NAME` (optional): Model name. Default: `deepseek-v3.2`.
+
+## Run
+
+```bash
+cd examples/summary/subagent
+export OPENAI_API_KEY="your-api-key"
+go run .
+```
+
+With a specific model:
+
+```bash
+MODEL_NAME=gpt-4o-mini go run .
+```
+
+## Interactive Commands
+
+| Command   | Description                                 |
+|-----------|---------------------------------------------|
+| `/show`   | Display all summaries generated so far.     |
+| `/events` | Dump session events with FilterKey info.    |
+| `/exit`   | Quit the demo.                              |
+
+## Example Session
+
+```
+Session Summarization + Sub-Agent Demo
+Model:          deepseek-v3.2
+TokenThreshold: 200
+EventThreshold: 2
+Session:        sess-1741234567
+============================================================
+You: what is 123 * 456?
+Assistant: ...delegates to math-specialist...
+The result of 123 × 456 is 56,088.
+
+You: /events
+Total events: 7
+  [0] author=user          filterKey=summary-subagent-demo    content=what is 123 * 456?
+  [1] author=parent-agent  filterKey=summary-subagent-demo    content=<tool call to math-specialist>
+  [2] author=math-spec...  filterKey=math-specialist-abc123   content=<tool call to calculator>
+  [3] author=math-spec...  filterKey=math-specialist-abc123   content=<tool response>
+  [4] author=math-spec...  filterKey=math-specialist-abc123   content=The result is 56088.
+  [5] author=parent-agent  filterKey=summary-subagent-demo    content=<tool result>
+  [6] author=parent-agent  filterKey=summary-subagent-demo    content=The result of 123 × 456 is 56,088.
+
+You: /show
+--- Summary [math-specialist-abc123] ---
+User asked to calculate 123 * 456 using the calculator tool. Result: 56088.
+
+--- Summary [(full-session)] ---
+The user asked to compute 123 * 456. The parent agent delegated to a math
+specialist which used a calculator tool and returned 56088.
+
+--- Summary [summary-subagent-demo] ---
+User requested 123 * 456. Delegated to math-specialist agent tool. Result: 56088.
+
+You: /exit
+Bye.
+```
+
+## What to Observe
+
+1. **Three distinct summaries** — the parent branch, child branch, and
+   full-session summary are all generated independently.
+2. **Threshold isolation** — the child agent's events/tokens do not count
+   toward the parent's threshold. The parent summary triggers only when the
+   parent's own events exceed the threshold.
+3. **Summary injection** — on subsequent turns, `[summary injected into prompt]`
+   is printed when the framework prepends the latest summary to the LLM request.
+
+## Implementation Highlights
+
+```go
+// Low thresholds for quick triggering.
+sum := summary.NewSummarizer(
+    llm,
+    summary.WithMaxSummaryWords(100),
+    summary.WithChecksAny(
+        summary.CheckTokenThreshold(200),
+        summary.CheckEventThreshold(2),
+    ),
+)
+
+// Child agent wrapped as a tool.
+childTool := agenttool.NewTool(
+    childAgent,
+    agenttool.WithStreamInner(true),
+)
+
+// Parent agent with summary injection enabled.
+parentLLM := llmagent.New(
+    parentAgent,
+    llmagent.WithTools([]tool.Tool{childTool}),
+    llmagent.WithAddSessionSummary(true),
+)
+```

--- a/examples/summary/subagent/main.go
+++ b/examples/summary/subagent/main.go
@@ -1,0 +1,329 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package main demonstrates session summarization behaviour when
+// the primary agent delegates to a sub-agent via agenttool.
+//
+// It uses a low token threshold so that summarisation triggers
+// quickly, making it easy to observe which events are included in
+// the threshold check and when the summary fires.
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/model/openai"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+	"trpc.group/trpc-go/trpc-agent-go/session/summary"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+	agenttool "trpc.group/trpc-go/trpc-agent-go/tool/agent"
+	"trpc.group/trpc-go/trpc-agent-go/tool/function"
+)
+
+const (
+	appName        = "summary-subagent-demo"
+	parentAgent    = "parent-agent"
+	childAgentName = "math-specialist"
+)
+
+func main() {
+	modelName := os.Getenv("MODEL_NAME")
+	if modelName == "" {
+		modelName = "deepseek-v3.2"
+	}
+	chat := &demo{modelName: modelName}
+	if err := chat.run(); err != nil {
+		fmt.Printf("Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+type demo struct {
+	modelName      string
+	runner         runner.Runner
+	sessionService session.Service
+	userID         string
+	sessionID      string
+}
+
+func (d *demo) run() error {
+	ctx := context.Background()
+	if err := d.setup(); err != nil {
+		return fmt.Errorf("setup failed: %w", err)
+	}
+	defer d.runner.Close()
+	return d.startChat(ctx)
+}
+
+func (d *demo) setup() error {
+	llm := openai.New(d.modelName)
+
+	// Low thresholds to make summary trigger quickly.
+	const tokenThreshold = 200
+	sum := summary.NewSummarizer(
+		llm,
+		summary.WithMaxSummaryWords(100),
+		summary.WithChecksAny(
+			summary.CheckTokenThreshold(tokenThreshold),
+			summary.CheckEventThreshold(2),
+		),
+	)
+
+	d.sessionService = inmemory.NewSessionService(
+		inmemory.WithSummarizer(sum),
+		inmemory.WithAsyncSummaryNum(1),
+		inmemory.WithSummaryQueueSize(64),
+		inmemory.WithSummaryJobTimeout(45*time.Second),
+	)
+
+	// Child agent with a calculator tool.
+	calculatorTool := function.NewFunctionTool(
+		calculate,
+		function.WithName("calculator"),
+		function.WithDescription(
+			"Perform basic arithmetic (add, subtract, multiply, divide)."),
+	)
+
+	childAgent := llmagent.New(
+		childAgentName,
+		llmagent.WithModel(llm),
+		llmagent.WithDescription(
+			"A specialist for mathematical calculations."),
+		llmagent.WithInstruction(
+			"You are a math specialist. Use the calculator tool "+
+				"for any arithmetic. Return the result concisely."),
+		llmagent.WithGenerationConfig(model.GenerationConfig{
+			MaxTokens: intPtr(800),
+			Stream:    true,
+		}),
+		llmagent.WithTools([]tool.Tool{calculatorTool}),
+	)
+
+	// Wrap the child agent as a tool for the parent.
+	childTool := agenttool.NewTool(
+		childAgent,
+		agenttool.WithStreamInner(true),
+	)
+
+	// Parent agent.
+	parentLLM := llmagent.New(
+		parentAgent,
+		llmagent.WithModel(llm),
+		llmagent.WithDescription("A helpful AI assistant."),
+		llmagent.WithInstruction(
+			"For math questions delegate to the math-specialist "+
+				"agent tool. For other questions answer directly."),
+		llmagent.WithGenerationConfig(model.GenerationConfig{
+			MaxTokens: intPtr(1500),
+			Stream:    true,
+		}),
+		llmagent.WithTools([]tool.Tool{childTool}),
+		llmagent.WithAddSessionSummary(true),
+		// Register a BeforeModel callback to show when the summary
+		// has been injected.
+		llmagent.WithModelCallbacks(
+			model.NewCallbacks().RegisterBeforeModel(
+				beforeModel)),
+	)
+
+	d.runner = runner.NewRunner(
+		appName, parentLLM,
+		runner.WithSessionService(d.sessionService),
+	)
+
+	d.userID = "user"
+	d.sessionID = fmt.Sprintf("sess-%d", time.Now().Unix())
+
+	fmt.Println("Session Summarization + Sub-Agent Demo")
+	fmt.Printf("Model:          %s\n", d.modelName)
+	fmt.Printf("TokenThreshold: %d\n", tokenThreshold)
+	fmt.Printf("EventThreshold: %d\n", 2)
+	fmt.Printf("Session:        %s\n", d.sessionID)
+	fmt.Println(strings.Repeat("=", 60))
+	return nil
+}
+
+func (d *demo) startChat(ctx context.Context) error {
+	sc := bufio.NewScanner(os.Stdin)
+	fmt.Println("Commands:")
+	fmt.Println("  /show   - display all summaries")
+	fmt.Println("  /events - dump session events")
+	fmt.Println("  /exit   - quit")
+	fmt.Println()
+
+	for {
+		fmt.Print("You: ")
+		if !sc.Scan() {
+			break
+		}
+		input := strings.TrimSpace(sc.Text())
+		if input == "" {
+			continue
+		}
+		switch strings.ToLower(input) {
+		case "/exit":
+			fmt.Println("Bye.")
+			return nil
+		case "/show":
+			d.showSummaries(ctx)
+			continue
+		case "/events":
+			d.dumpEvents(ctx)
+			continue
+		}
+		if err := d.chat(ctx, input); err != nil {
+			fmt.Printf("Error: %v\n", err)
+		}
+	}
+	return sc.Err()
+}
+
+func (d *demo) chat(ctx context.Context, msg string) error {
+	evtCh, err := d.runner.Run(
+		ctx, d.userID, d.sessionID,
+		model.NewUserMessage(msg),
+	)
+	if err != nil {
+		return err
+	}
+	fmt.Print("Assistant: ")
+	for evt := range evtCh {
+		if evt.Error != nil {
+			fmt.Printf("\nError: %s\n", evt.Error.Message)
+			continue
+		}
+		if evt.Response == nil || len(evt.Response.Choices) == 0 {
+			continue
+		}
+		c := evt.Response.Choices[0]
+		if c.Delta.Content != "" {
+			fmt.Print(c.Delta.Content)
+		}
+		if evt.Done {
+			fmt.Println()
+		}
+	}
+	return nil
+}
+
+func (d *demo) showSummaries(ctx context.Context) {
+	sess, err := d.sessionService.GetSession(ctx, session.Key{
+		AppName: appName, UserID: d.userID, SessionID: d.sessionID,
+	})
+	if err != nil || sess == nil {
+		fmt.Printf("load session failed: %v\n", err)
+		return
+	}
+	sess.SummariesMu.RLock()
+	defer sess.SummariesMu.RUnlock()
+
+	if len(sess.Summaries) == 0 {
+		fmt.Println("[no summaries yet]")
+		return
+	}
+	for key, s := range sess.Summaries {
+		display := key
+		if key == "" {
+			display = "(full-session)"
+		}
+		text := "<empty>"
+		if s != nil && s.Summary != "" {
+			text = s.Summary
+		}
+		fmt.Printf("--- Summary [%s] ---\n%s\n\n", display, text)
+	}
+}
+
+func (d *demo) dumpEvents(ctx context.Context) {
+	sess, err := d.sessionService.GetSession(ctx, session.Key{
+		AppName: appName, UserID: d.userID, SessionID: d.sessionID,
+	})
+	if err != nil || sess == nil {
+		fmt.Printf("load session failed: %v\n", err)
+		return
+	}
+	fmt.Printf("Total events: %d\n", len(sess.Events))
+	for i, e := range sess.Events {
+		content := extractPreview(e)
+		fmt.Printf("  [%d] author=%-20s filterKey=%-30s content=%s\n",
+			i, e.Author, e.FilterKey, content)
+	}
+}
+
+func extractPreview(e event.Event) string {
+	if e.Response == nil || len(e.Response.Choices) == 0 {
+		return "<no content>"
+	}
+	c := e.Response.Choices[0].Message.Content
+	if c == "" {
+		c = e.Response.Choices[0].Delta.Content
+	}
+	if len(c) > 80 {
+		c = c[:80] + "..."
+	}
+	return c
+}
+
+func beforeModel(
+	_ context.Context, args *model.BeforeModelArgs,
+) (*model.BeforeModelResult, error) {
+	for _, msg := range args.Request.Messages {
+		if msg.Role == model.RoleSystem &&
+			strings.Contains(msg.Content,
+				"<summary_of_previous_interactions>") {
+			fmt.Println("[summary injected into prompt]")
+			break
+		}
+	}
+	return nil, nil
+}
+
+// calculate performs basic arithmetic.
+func calculate(
+	_ context.Context, args calcArgs,
+) (calcResult, error) {
+	var r float64
+	switch strings.ToLower(args.Op) {
+	case "add", "+":
+		r = args.A + args.B
+	case "subtract", "-":
+		r = args.A - args.B
+	case "multiply", "*":
+		r = args.A * args.B
+	case "divide", "/":
+		if args.B != 0 {
+			r = args.A / args.B
+		}
+	}
+	return calcResult{Op: args.Op, A: args.A, B: args.B, Result: r}, nil
+}
+
+type calcArgs struct {
+	Op string  `json:"operation" jsonschema:"description=add subtract multiply divide"`
+	A  float64 `json:"a" jsonschema:"description=First number"`
+	B  float64 `json:"b" jsonschema:"description=Second number"`
+}
+
+type calcResult struct {
+	Op     string  `json:"operation"`
+	A      float64 `json:"a"`
+	B      float64 `json:"b"`
+	Result float64 `json:"result"`
+}
+
+func intPtr(i int) *int { return &i }

--- a/session/summary/checker.go
+++ b/session/summary/checker.go
@@ -91,17 +91,24 @@ func filterDeltaEvents(sess *session.Session) []event.Event {
 // parent-level threshold checks in the full-session summary scenario.
 //
 // The function distinguishes two cases by inspecting whether the events
-// contain multiple distinct FilterKey values:
+// contain multiple distinct non-empty FilterKey values:
 //
-//  1. Single FilterKey (branch summary) — all events share one key
-//     because computeDeltaSince already filtered by that branch.
-//     No further filtering is needed; return the events as-is.
+//  1. Single non-empty FilterKey (branch summary) — all events with a
+//     non-empty FilterKey share the same value because computeDeltaSince
+//     already filtered by that branch. No further filtering is needed;
+//     return the events as-is.
 //
-//  2. Mixed FilterKeys (full-session summary) — events come from
-//     both the primary agent and one or more sub-agents. Only events
-//     whose FilterKey matches the session's AppName (the primary
-//     agent's key) are retained so that sub-agent tokens/counts do
-//     not inflate the parent threshold.
+//  2. Mixed non-empty FilterKeys (full-session summary) — events come
+//     from both the primary agent and one or more sub-agents. Only
+//     events whose FilterKey matches the session's AppName (the primary
+//     agent's key) are retained so that sub-agent tokens/counts do not
+//     inflate the parent threshold.
+//
+// Events with an empty FilterKey (e.g. synthetic summary events created
+// by prependPrevSummary) are ignored when determining whether the set is
+// mixed, and are always kept in the output. This prevents a single
+// prepended summary event from incorrectly triggering the mixed-key
+// filtering path for what is actually a single-branch summary.
 //
 // When AppName is empty, no filtering is applied for backward
 // compatibility with sessions that do not set an AppName.
@@ -111,25 +118,37 @@ func filterPrimaryEvents(
 	if appName == "" || len(events) == 0 {
 		return events
 	}
-	// Detect whether the events contain multiple distinct FilterKeys.
-	first := events[0].FilterKey
+	// Detect whether the events contain multiple distinct non-empty
+	// FilterKeys. Empty FilterKeys are ignored because they come
+	// from synthetic events (e.g. prepended previous summary).
+	var firstNonEmpty string
 	mixed := false
-	for i := 1; i < len(events); i++ {
-		if events[i].FilterKey != first {
+	for i := range events {
+		fk := events[i].FilterKey
+		if fk == "" {
+			continue
+		}
+		if firstNonEmpty == "" {
+			firstNonEmpty = fk
+			continue
+		}
+		if fk != firstNonEmpty {
 			mixed = true
 			break
 		}
 	}
 	if !mixed {
-		// All events share one FilterKey (branch summary) — no
-		// additional filtering required.
+		// All non-empty FilterKeys are identical (branch summary)
+		// or there are no non-empty keys at all — no additional
+		// filtering required.
 		return events
 	}
-	// Mixed FilterKeys (full-session summary) — keep only events
-	// that belong to the primary agent.
+	// Mixed non-empty FilterKeys (full-session summary) — keep
+	// events that belong to the primary agent plus any events with
+	// an empty FilterKey (synthetic summary events).
 	out := make([]event.Event, 0, len(events))
 	for _, e := range events {
-		if e.FilterKey == appName {
+		if e.FilterKey == appName || e.FilterKey == "" {
 			out = append(out, e)
 		}
 	}

--- a/session/summary/checker.go
+++ b/session/summary/checker.go
@@ -87,12 +87,67 @@ func filterDeltaEvents(sess *session.Session) []event.Event {
 	return out
 }
 
-// CheckEventThreshold creates a checker that triggers when the number of events
-// since the last summary exceeds the given threshold.
+// filterPrimaryEvents prevents sub-agent events from inflating
+// parent-level threshold checks in the full-session summary scenario.
+//
+// The function distinguishes two cases by inspecting whether the events
+// contain multiple distinct FilterKey values:
+//
+//  1. Single FilterKey (branch summary) — all events share one key
+//     because computeDeltaSince already filtered by that branch.
+//     No further filtering is needed; return the events as-is.
+//
+//  2. Mixed FilterKeys (full-session summary) — events come from
+//     both the primary agent and one or more sub-agents. Only events
+//     whose FilterKey matches the session's AppName (the primary
+//     agent's key) are retained so that sub-agent tokens/counts do
+//     not inflate the parent threshold.
+//
+// When AppName is empty, no filtering is applied for backward
+// compatibility with sessions that do not set an AppName.
+func filterPrimaryEvents(
+	events []event.Event, appName string,
+) []event.Event {
+	if appName == "" || len(events) == 0 {
+		return events
+	}
+	// Detect whether the events contain multiple distinct FilterKeys.
+	first := events[0].FilterKey
+	mixed := false
+	for i := 1; i < len(events); i++ {
+		if events[i].FilterKey != first {
+			mixed = true
+			break
+		}
+	}
+	if !mixed {
+		// All events share one FilterKey (branch summary) — no
+		// additional filtering required.
+		return events
+	}
+	// Mixed FilterKeys (full-session summary) — keep only events
+	// that belong to the primary agent.
+	out := make([]event.Event, 0, len(events))
+	for _, e := range events {
+		if e.FilterKey == appName {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// CheckEventThreshold creates a checker that triggers when the number of
+// primary-agent events since the last summary exceeds the given threshold.
+// Sub-agent events (FilterKey != AppName) are excluded from the count so
+// that child agent activity does not inflate the parent threshold.
 func CheckEventThreshold(eventCount int) Checker {
 	return func(sess *session.Session) bool {
 		delta := filterDeltaEvents(sess)
-		return len(delta) > eventCount
+		if len(delta) == 0 {
+			return false
+		}
+		primary := filterPrimaryEvents(delta, sess.AppName)
+		return len(primary) > eventCount
 	}
 }
 
@@ -122,21 +177,31 @@ func checkTokenThresholdFromText(tokenCount int, conversationText string) bool {
 	return tokens > tokenCount
 }
 
-// CheckTokenThreshold creates a checker that triggers when the estimated token
-// count of the events since the last summary exceeds the given threshold.
+// CheckTokenThreshold creates a checker that triggers when the estimated
+// token count of the primary-agent events since the last summary exceeds
+// the given threshold. Sub-agent events (FilterKey != AppName) are excluded
+// so that child agent tokens do not inflate the parent threshold check.
 //
 // Note:
-// Token accounting via model usage is not stable once session summary injection
-// is enabled. For consistent gating, we estimate tokens from the delta events.
+// Token accounting via model usage is not stable once session summary
+// injection is enabled. For consistent gating, we estimate tokens from
+// the delta events.
 func CheckTokenThreshold(tokenCount int) Checker {
 	return func(sess *session.Session) bool {
 		delta := filterDeltaEvents(sess)
 		if len(delta) == 0 {
 			return false
 		}
-
-		conversationText := extractConversationText(delta, nil, nil)
-		return checkTokenThresholdFromText(tokenCount, conversationText)
+		primary := filterPrimaryEvents(delta, sess.AppName)
+		if len(primary) == 0 {
+			return false
+		}
+		conversationText := extractConversationText(
+			primary, nil, nil,
+		)
+		return checkTokenThresholdFromText(
+			tokenCount, conversationText,
+		)
 	}
 }
 

--- a/session/summary/checker_test.go
+++ b/session/summary/checker_test.go
@@ -107,6 +107,48 @@ func TestCheckEventThreshold(t *testing.T) {
 		}
 		assert.True(t, checker(sess))
 	})
+
+	t.Run("sub-agent events excluded from count", func(t *testing.T) {
+		// Full-session scenario: 1 primary + 5 sub-agent events.
+		// Mixed FilterKeys → only primary counted. 1 > 2 = false.
+		const appName = "my-app"
+		checker := CheckEventThreshold(2)
+		events := []event.Event{
+			{Timestamp: time.Now(), FilterKey: appName},
+		}
+		for i := 0; i < 5; i++ {
+			events = append(events, event.Event{
+				Timestamp: time.Now(),
+				FilterKey: "sub-agent-abc",
+			})
+		}
+		sess := &session.Session{
+			AppName: appName,
+			Events:  events,
+		}
+		assert.False(t, checker(sess))
+	})
+
+	t.Run("branch summary counts all events in branch", func(t *testing.T) {
+		// Branch-summary scenario: computeDeltaSince already
+		// pre-filtered to one sub-agent branch. All events share
+		// the same FilterKey, so they are all counted.
+		const appName = "my-app"
+		checker := CheckEventThreshold(2)
+		events := make([]event.Event, 5)
+		for i := range events {
+			events[i] = event.Event{
+				Timestamp: time.Now(),
+				FilterKey: "sub-agent-abc",
+			}
+		}
+		sess := &session.Session{
+			AppName: appName,
+			Events:  events,
+		}
+		// Single FilterKey → no filtering → 5 > 2 = true.
+		assert.True(t, checker(sess))
+	})
 }
 
 func TestCheckTimeThreshold(t *testing.T) {
@@ -255,6 +297,102 @@ func TestCheckTokenThreshold(t *testing.T) {
 			},
 		}
 
+		assert.True(t, checker(sess))
+	})
+
+	t.Run("sub-agent events excluded from token count", func(t *testing.T) {
+		// Threshold is 100 tokens. The sub-agent event has enough
+		// tokens to exceed it, but the primary event does not.
+		const (
+			threshold = 100
+			appName   = "my-app"
+		)
+		checker := CheckTokenThreshold(threshold)
+		sess := &session.Session{
+			AppName: appName,
+			Events: []event.Event{
+				{
+					Author:    "user",
+					FilterKey: appName,
+					Timestamp: time.Now(),
+					Response: &model.Response{Choices: []model.Choice{{
+						Message: model.Message{
+							Content: "short user message",
+						},
+					}}},
+				},
+				{
+					Author:    "assistant",
+					FilterKey: "sub-agent-abc-123",
+					Timestamp: time.Now(),
+					Response: &model.Response{Choices: []model.Choice{{
+						Message: model.Message{
+							Content: strings.Repeat("x", 2000),
+						},
+					}}},
+				},
+			},
+		}
+		// Without filtering, total tokens >> 100. With filtering,
+		// only the short primary event is counted.
+		assert.False(t, checker(sess))
+	})
+
+	t.Run("only sub-agent events yields false", func(t *testing.T) {
+		// Full-session scenario: primary event below threshold,
+		// sub-agent event above threshold. Mixed FilterKeys trigger
+		// filtering, so only the small primary event is counted.
+		const appName = "my-app"
+		checker := CheckTokenThreshold(100)
+		sess := &session.Session{
+			AppName: appName,
+			Events: []event.Event{
+				{
+					Author:    "user",
+					FilterKey: appName,
+					Timestamp: time.Now(),
+					Response: &model.Response{Choices: []model.Choice{{
+						Message: model.Message{Content: "hi"},
+					}}},
+				},
+				{
+					Author:    "assistant",
+					FilterKey: "child-agent-xyz",
+					Timestamp: time.Now(),
+					Response: &model.Response{Choices: []model.Choice{{
+						Message: model.Message{
+							Content: strings.Repeat("a", 800),
+						},
+					}}},
+				},
+			},
+		}
+		assert.False(t, checker(sess))
+	})
+
+	t.Run("branch summary counts all events in branch", func(t *testing.T) {
+		// Branch-summary scenario: computeDeltaSince already
+		// pre-filtered events to one sub-agent branch. All events
+		// share the same FilterKey, so filterPrimaryEvents should
+		// NOT discard them even though they differ from AppName.
+		const appName = "my-app"
+		checker := CheckTokenThreshold(10)
+		sess := &session.Session{
+			AppName: appName,
+			Events: []event.Event{
+				{
+					Author:    "assistant",
+					FilterKey: "child-agent-xyz",
+					Timestamp: time.Now(),
+					Response: &model.Response{Choices: []model.Choice{{
+						Message: model.Message{
+							Content: strings.Repeat("a", 800),
+						},
+					}}},
+				},
+			},
+		}
+		// Single FilterKey → no filtering → triggers.
 		assert.True(t, checker(sess))
 	})
 }

--- a/session/summary/checker_test.go
+++ b/session/summary/checker_test.go
@@ -149,6 +149,29 @@ func TestCheckEventThreshold(t *testing.T) {
 		// Single FilterKey → no filtering → 5 > 2 = true.
 		assert.True(t, checker(sess))
 	})
+
+	t.Run("prepended summary event does not break branch detection", func(t *testing.T) {
+		// prependPrevSummary inserts a synthetic event with
+		// FilterKey="" at the head of the event list. This empty
+		// FilterKey must not cause filterPrimaryEvents to treat
+		// the set as "mixed" and discard all sub-agent events.
+		const appName = "my-app"
+		checker := CheckEventThreshold(2)
+		events := []event.Event{
+			// Synthetic summary event (FilterKey="").
+			{Timestamp: time.Now(), FilterKey: ""},
+			{Timestamp: time.Now(), FilterKey: "sub-agent-abc"},
+			{Timestamp: time.Now(), FilterKey: "sub-agent-abc"},
+			{Timestamp: time.Now(), FilterKey: "sub-agent-abc"},
+		}
+		sess := &session.Session{
+			AppName: appName,
+			Events:  events,
+		}
+		// Empty FilterKey is ignored in mixed detection → single
+		// non-empty key "sub-agent-abc" → 4 > 2 = true.
+		assert.True(t, checker(sess))
+	})
 }
 
 func TestCheckTimeThreshold(t *testing.T) {
@@ -393,6 +416,41 @@ func TestCheckTokenThreshold(t *testing.T) {
 			},
 		}
 		// Single FilterKey → no filtering → triggers.
+		assert.True(t, checker(sess))
+	})
+
+	t.Run("prepended summary event does not break branch detection", func(t *testing.T) {
+		// prependPrevSummary inserts a synthetic event with
+		// FilterKey="" at the head. This must not cause
+		// filterPrimaryEvents to treat the set as "mixed" and
+		// discard all sub-agent events.
+		const appName = "my-app"
+		checker := CheckTokenThreshold(10)
+		sess := &session.Session{
+			AppName: appName,
+			Events: []event.Event{
+				{
+					Author:    "system",
+					FilterKey: "",
+					Timestamp: time.Now(),
+					Response: &model.Response{Choices: []model.Choice{{
+						Message: model.Message{Content: "prev summary"},
+					}}},
+				},
+				{
+					Author:    "assistant",
+					FilterKey: "child-agent-xyz",
+					Timestamp: time.Now(),
+					Response: &model.Response{Choices: []model.Choice{{
+						Message: model.Message{
+							Content: strings.Repeat("a", 800),
+						},
+					}}},
+				},
+			},
+		}
+		// Empty FilterKey ignored in mixed detection → single
+		// non-empty key → triggers.
 		assert.True(t, checker(sess))
 	})
 }


### PR DESCRIPTION
## Summary by Sourcery

将会话摘要阈值限定在主代理活动上，并新增一个可运行的子代理会话总结示例。

New Features:
- 添加过滤器，在评估会话摘要阈值时区分主代理事件和子代理事件。
- 引入一个子代理会话总结演示示例，展示代理与工具的委托、分支级摘要以及完整会话摘要。

Enhancements:
- 更新事件计数和 token 计数阈值检查器，使其在完整会话摘要中忽略子代理事件，同时在分支级摘要中仍然统计这些事件。

Documentation:
- 为新的子代理会话总结示例撰写文档，包含使用说明，以及对“分支摘要”与“完整会话摘要”的说明。

Tests:
- 扩展检查器测试，用于覆盖主代理与子代理事件过滤在事件计数和 token 计数阈值两方面的测试场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Isolate session summary thresholds to primary-agent activity and add a runnable sub-agent summarization example.

New Features:
- Add a filter that distinguishes primary-agent and sub-agent events when evaluating session summary thresholds.
- Introduce a sub-agent session summarization demo that showcases agent-tool delegation, branch summaries, and full-session summaries.

Enhancements:
- Update event-count and token-count threshold checkers to ignore sub-agent events in full-session summaries while still counting them in per-branch summaries.

Documentation:
- Document the new sub-agent summarization example with usage instructions and an explanation of branch vs full-session summaries.

Tests:
- Extend checker tests to cover primary vs sub-agent event filtering for both event-count and token-count thresholds.

</details>