### PR TITLE
graph: preserve result on node error

### DIFF
--- a/graph/executor_test.go
+++ b/graph/executor_test.go
@@ -1370,6 +1370,97 @@ func TestAfterCallbackCanRecoverNodeError(t *testing.T) {
 	require.True(t, okv)
 }
 
+func TestAfterCallbackCanRecoverWithOriginalResult(t *testing.T) {
+	const (
+		nodeID       = "N"
+		invocationID = "inv-after-recover-original"
+
+		stateKeyPartial = "partial"
+	)
+
+	boom := errors.New("boom")
+
+	g := NewStateGraph(NewStateSchema())
+	g.AddNode(nodeID, func(ctx context.Context, s State) (any, error) {
+		return State{stateKeyPartial: true}, boom
+	})
+	g.SetEntryPoint(nodeID).SetFinishPoint(nodeID)
+
+	type afterSeen struct {
+		result any
+		err    error
+	}
+
+	var seen atomic.Value
+	seen.Store(afterSeen{})
+
+	cbs := NewNodeCallbacks().RegisterAfterNode(func(
+		ctx context.Context,
+		cb *NodeCallbackContext,
+		st State,
+		result any,
+		nodeErr error,
+	) (any, error) {
+		seen.Store(afterSeen{result: result, err: nodeErr})
+		return result, nil
+	})
+	g.WithNodeCallbacks(cbs)
+
+	compiled, err := g.Compile()
+	require.NoError(t, err)
+	exec, err := NewExecutor(compiled)
+	require.NoError(t, err)
+
+	ch, err := exec.Execute(
+		context.Background(),
+		State{},
+		&agent.Invocation{InvocationID: invocationID},
+	)
+	require.NoError(t, err)
+
+	var sawPregelError bool
+	final := make(State)
+	for ev := range ch {
+		if ev.Object == ObjectTypeGraphPregelStep &&
+			ev.Response != nil &&
+			ev.Response.Error != nil {
+			sawPregelError = true
+		}
+		if ev.Done && ev.StateDelta != nil {
+			for k, vb := range ev.StateDelta {
+				switch k {
+				case MetadataKeyNode, MetadataKeyPregel,
+					MetadataKeyChannel, MetadataKeyState,
+					MetadataKeyCompletion:
+					continue
+				default:
+				}
+				var v any
+				if err := json.Unmarshal(vb, &v); err == nil {
+					final[k] = v
+				}
+			}
+		}
+	}
+
+	require.False(t, sawPregelError)
+
+	got := seen.Load().(afterSeen)
+	require.ErrorIs(t, got.err, boom)
+	require.NotNil(t, got.result)
+
+	partial, ok := got.result.(State)
+	require.True(t, ok)
+
+	gotPartial, ok := partial[stateKeyPartial].(bool)
+	require.True(t, ok)
+	require.True(t, gotPartial)
+
+	statePartial, ok := final[stateKeyPartial].(bool)
+	require.True(t, ok)
+	require.True(t, statePartial)
+}
+
 func TestBeforeCallbackError_BarrierWaitsForCompletion(t *testing.T) {
 	var nodeRuns int32
 	var onErrCalls int32

--- a/graph/state_graph.go
+++ b/graph/state_graph.go
@@ -456,11 +456,11 @@ func (sg *StateGraph) AddNode(id string, function NodeFunc, opts ...Option) *Sta
 		}()
 
 		response, err := function(ctx, state)
+		workflow.Response = response
 		if err != nil {
 			workflow.Error = err
-			return nil, err
+			return response, err
 		}
-		workflow.Response = response
 		return response, nil
 	}
 


### PR DESCRIPTION
What
- Preserve node return value when a node returns a non-nil error, so after-node callbacks can inspect or reuse the original result.

Why
- StateGraph.AddNode wrapped node funcs and discarded the result on error, making AfterNodeCallback always see result == nil on node errors.

Tests
- go test ./...

## Summary by Sourcery

在节点返回错误时保留其执行结果，以便节点后的回调能够检查并重用部分结果。

Bug Fixes:
- 确保 `StateGraph` 节点包装器在发生错误时返回原始结果而不是丢弃它，从而允许回调在失败时观察到部分状态。

Tests:
- 添加回归测试，验证节点后的回调能够收到原始节点结果，并且即使节点返回错误，部分状态也会被提交。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Preserve node execution results when a node returns an error so after-node callbacks can inspect and reuse partial results.

Bug Fixes:
- Ensure StateGraph node wrappers return the original result alongside errors instead of discarding it, allowing callbacks to observe partial state on failures.

Tests:
- Add a regression test verifying after-node callbacks receive the original node result and that partial state is committed even when the node returns an error.

</details>