### PR TITLE
artifact/cos: use  Content-Disposition header to set filename

### DIFF
--- a/artifact/cos/client.go
+++ b/artifact/cos/client.go
@@ -20,7 +20,7 @@ import (
 // client interface is unstable and may change in the future.
 type client interface {
 	GetBucket(ctx context.Context, prefix string) (*cos.BucketGetResult, error)
-	PutObject(ctx context.Context, name string, content io.Reader, mimeType string) error
+	PutObject(ctx context.Context, name string, content io.Reader, opt cos.ObjectPutOptions) error
 	GetObject(ctx context.Context, name string) (body io.ReadCloser, header http.Header, err error)
 	DeleteObject(ctx context.Context, name string) error
 }
@@ -38,14 +38,8 @@ func (c *cosClient) GetBucket(ctx context.Context, prefix string) (*cos.BucketGe
 	return result, err
 }
 
-func (c *cosClient) PutObject(ctx context.Context, name string, content io.Reader, mimeType string) error {
-	opt := &cos.ObjectPutOptions{
-		ObjectPutHeaderOptions: &cos.ObjectPutHeaderOptions{
-			ContentType: mimeType,
-		},
-	}
-
-	_, err := c.Client.Object.Put(ctx, name, content, opt)
+func (c *cosClient) PutObject(ctx context.Context, name string, content io.Reader, opt cos.ObjectPutOptions) error {
+	_, err := c.Client.Object.Put(ctx, name, content, &opt)
 	return err
 }
 func (c *cosClient) GetObject(ctx context.Context, name string) (body io.ReadCloser, header http.Header, err error) {

--- a/artifact/cos/service.go
+++ b/artifact/cos/service.go
@@ -35,6 +35,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"mime"
 	"sort"
 	"strconv"
 	"strings"
@@ -142,7 +143,15 @@ func (s *Service) SaveArtifact(
 
 	// Upload the artifact data
 	reader := bytes.NewReader(art.Data)
-	err = s.cosClient.PutObject(ctx, objectName, reader, art.MimeType)
+	putOpts := cos.ObjectPutOptions{
+		ObjectPutHeaderOptions: &cos.ObjectPutHeaderOptions{
+			ContentType: art.MimeType,
+			ContentDisposition: mime.FormatMediaType("attachment", map[string]string{
+				"filename": filename,
+			}),
+		},
+	}
+	err = s.cosClient.PutObject(ctx, objectName, reader, putOpts)
 	if err != nil {
 		return 0, fmt.Errorf("failed to upload artifact: %w", err)
 	}

--- a/artifact/cos/service_test.go
+++ b/artifact/cos/service_test.go
@@ -202,7 +202,7 @@ func createMockService() (*Service, *MockTransport) {
 
 type stubClient struct {
 	getBucketFn    func(context.Context, string) (*cos.BucketGetResult, error)
-	putObjectFn    func(context.Context, string, io.Reader, string) error
+	putObjectFn    func(context.Context, string, io.Reader, cos.ObjectPutOptions) error
 	getObjectFn    func(context.Context, string) (io.ReadCloser, http.Header, error)
 	deleteObjectFn func(context.Context, string) error
 }
@@ -221,12 +221,12 @@ func (c *stubClient) PutObject(
 	ctx context.Context,
 	name string,
 	content io.Reader,
-	mimeType string,
+	opt cos.ObjectPutOptions,
 ) error {
 	if c.putObjectFn == nil {
 		return nil
 	}
-	return c.putObjectFn(ctx, name, content, mimeType)
+	return c.putObjectFn(ctx, name, content, opt)
 }
 
 func (c *stubClient) GetObject(


### PR DESCRIPTION
https://www.tencentcloud.com/techpedia/105002

## Summary by Sourcery

在上传构建产物（artifacts）时使用 COS 对象上传选项，以便支持设置诸如 Content-Disposition 等响应头。

新特性：
- 根据原始文件名为上传的构建产物设置 `Content-Disposition` 响应头，使下载时使用有意义的文件名。

改进：
- 重构 COS 客户端的 `PutObject` API，使其接收完整的 `cos.ObjectPutOptions` 结构体，而不只是 MIME 类型，从而支持更丰富的上传配置。
- 更新 COS 服务测试和 stub 客户端，以反映新的 `PutObject` 方法签名及选项处理方式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Use COS object put options when uploading artifacts to support setting response headers such as content disposition.

New Features:
- Set the Content-Disposition header for uploaded artifacts based on the original filename so downloads use a meaningful filename.

Enhancements:
- Refactor the COS client PutObject API to accept a full cos.ObjectPutOptions struct instead of just a MIME type, enabling richer upload configuration.
- Update COS service tests and stub client to reflect the new PutObject signature and options handling.

</details>