### PR TITLE
session/summary: handle multiple tool results in choices

### DIFF
--- a/session/summary/summarizer.go
+++ b/session/summary/summarizer.go
@@ -382,36 +382,42 @@ func extractConversationText(
 		if e.Response == nil || len(e.Response.Choices) == 0 {
 			continue
 		}
-		msg := e.Response.Choices[0].Message
 		author := e.Author
 		if author == "" {
 			author = authorUnknown
 		}
 
-		// Handle tool calls from assistant.
-		// Note: A message may contain both ToolCalls and Content (e.g., "Let me check
-		// the weather" + tool call), so we process both without using continue.
-		if len(msg.ToolCalls) > 0 {
-			for _, tc := range msg.ToolCalls {
-				toolCallText := toolCallFmt(tc)
-				if toolCallText != "" {
-					parts = append(parts, fmt.Sprintf("%s: %s", author, toolCallText))
+		// Iterate over all choices, not just the first one.
+		// When model returns multiple tool call results, they may be distributed
+		// across different choices (len(e.Response.Choices) > 1).
+		for _, choice := range e.Response.Choices {
+			msg := choice.Message
+
+			// Handle tool calls from assistant.
+			// Note: A message may contain both ToolCalls and Content (e.g., "Let me check
+			// the weather" + tool call), so we process both without using continue.
+			if len(msg.ToolCalls) > 0 {
+				for _, tc := range msg.ToolCalls {
+					toolCallText := toolCallFmt(tc)
+					if toolCallText != "" {
+						parts = append(parts, fmt.Sprintf("%s: %s", author, toolCallText))
+					}
 				}
 			}
-		}
 
-		// Handle tool response.
-		if msg.ToolID != "" {
-			toolRespText := toolResultFmt(msg)
-			if toolRespText != "" {
-				parts = append(parts, fmt.Sprintf("%s: %s", author, toolRespText))
+			// Handle tool response.
+			if msg.ToolID != "" {
+				toolRespText := toolResultFmt(msg)
+				if toolRespText != "" {
+					parts = append(parts, fmt.Sprintf("%s: %s", author, toolRespText))
+				}
+				continue // Tool responses don't have additional content.
 			}
-			continue // Tool responses don't have additional content.
-		}
 
-		// Handle regular message content.
-		if trimmed := strings.TrimSpace(msg.Content); trimmed != "" {
-			parts = append(parts, fmt.Sprintf("%s: %s", author, trimmed))
+			// Handle regular message content.
+			if trimmed := strings.TrimSpace(msg.Content); trimmed != "" {
+				parts = append(parts, fmt.Sprintf("%s: %s", author, trimmed))
+			}
 		}
 	}
 

--- a/session/summary/summarizer_test.go
+++ b/session/summary/summarizer_test.go
@@ -567,6 +567,82 @@ func TestSessionSummarizer_ExtractConversationText_WithToolCalls(t *testing.T) {
 		require.NoError(t, err)
 		assert.Contains(t, text, "[tool returned: done]")
 	})
+
+	t.Run("handles multiple tool results in separate choices", func(t *testing.T) {
+		// When model returns multiple tool calls, results may be distributed
+		// across different choices (len(e.Response.Choices) > 1).
+		sess := &session.Session{
+			ID: "test-multi-choices",
+			Events: []event.Event{
+				{
+					Author: "user",
+					Response: &model.Response{Choices: []model.Choice{{
+						Message: model.Message{Content: "Check weather in multiple cities"},
+					}}},
+				},
+				{
+					Author: "assistant",
+					Response: &model.Response{Choices: []model.Choice{{
+						Message: model.Message{
+							ToolCalls: []model.ToolCall{
+								{
+									ID:   "call_beijing",
+									Type: "function",
+									Function: model.FunctionDefinitionParam{
+										Name:      "get_weather",
+										Arguments: []byte(`{"city":"Beijing"}`),
+									},
+								},
+								{
+									ID:   "call_shanghai",
+									Type: "function",
+									Function: model.FunctionDefinitionParam{
+										Name:      "get_weather",
+										Arguments: []byte(`{"city":"Shanghai"}`),
+									},
+								},
+							},
+						},
+					}}},
+				},
+				{
+					Author: "tool",
+					Response: &model.Response{Choices: []model.Choice{
+						{
+							Message: model.Message{
+								ToolID:   "call_beijing",
+								ToolName: "get_weather",
+								Content:  `{"temperature": 25, "weather": "sunny"}`,
+							},
+						},
+						{
+							Message: model.Message{
+								ToolID:   "call_shanghai",
+								ToolName: "get_weather",
+								Content:  `{"temperature": 22, "weather": "cloudy"}`,
+							},
+						},
+					}},
+				},
+				{
+					Author: "assistant",
+					Response: &model.Response{Choices: []model.Choice{{
+						Message: model.Message{Content: "Beijing is sunny, Shanghai is cloudy."},
+					}}},
+				},
+			},
+		}
+
+		text, err := s.Summarize(context.Background(), sess)
+		require.NoError(t, err)
+		// Both tool calls should be extracted.
+		assert.Contains(t, text, "[Called tool: get_weather")
+		assert.Contains(t, text, "Beijing")
+		assert.Contains(t, text, "Shanghai")
+		// Both tool results should be extracted.
+		assert.Contains(t, text, "sunny")
+		assert.Contains(t, text, "cloudy")
+	})
 }
 
 func TestSessionSummarizer_CustomToolFormatters(t *testing.T) {


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

当工具调用及其结果分散在多个回复选项中，而不是只出现在第一个选项中时，正确处理对话摘要。

Bug 修复：
- 确保从一条消息的所有回复选项中提取工具调用和工具结果，而不是只从第一个选项中提取。

测试：
- 为这样一些会话添加测试覆盖率：其中多个工具调用及其结果分布在不同的回复选项中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle conversation summarization when tool calls and results are spread across multiple response choices instead of only the first choice.

Bug Fixes:
- Ensure tool calls and tool results are extracted from all response choices rather than just the first choice in a message.

Tests:
- Add test coverage for sessions where multiple tool calls and their results are distributed across separate choices.

</details>