### PR TITLE
openclaw: make model usage codexbar command static

### DIFF
--- a/openclaw/skills/model-usage/scripts/model_usage.py
+++ b/openclaw/skills/model-usage/scripts/model_usage.py
@@ -14,7 +14,7 @@ import subprocess
 import sys
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
 
 
 def positive_int(value: str) -> int:
@@ -34,18 +34,34 @@ def eprint(msg: str) -> None:
 ALLOWED_PROVIDERS = frozenset({"codex", "claude"})
 
 
+def _run_codexbar_cost_codex() -> str:
+    return subprocess.check_output(
+        ["codexbar", "cost", "--format", "json", "--provider", "codex"],
+        text=True,
+    )
+
+
+def _run_codexbar_cost_claude() -> str:
+    return subprocess.check_output(
+        ["codexbar", "cost", "--format", "json", "--provider", "claude"],
+        text=True,
+    )
+
+
+CODEXBAR_COST_RUNNERS: Dict[str, Callable[[], str]] = {
+    "codex": _run_codexbar_cost_codex,
+    "claude": _run_codexbar_cost_claude,
+}
+
+
 def run_codexbar_cost(provider: str) -> List[Dict[str, Any]]:
     if provider not in ALLOWED_PROVIDERS:
         raise ValueError(
             f"Invalid provider: {provider!r}. "
             f"Must be one of: {', '.join(sorted(ALLOWED_PROVIDERS))}"
         )
-    if provider == "codex":
-        cmd = ["codexbar", "cost", "--format", "json", "--provider", "codex"]
-    else:
-        cmd = ["codexbar", "cost", "--format", "json", "--provider", "claude"]
     try:
-        output = subprocess.check_output(cmd, text=True)
+        output = CODEXBAR_COST_RUNNERS[provider]()
     except FileNotFoundError:
         raise RuntimeError("codexbar not found on PATH. Install CodexBar CLI first.")
     except subprocess.CalledProcessError as exc:


### PR DESCRIPTION
Fix issues at [sourcery-ai](https://github.com/trpc-group/trpc-agent-go/pull/1316/checks?check_run_id=66129695168)
<img width="1141" height="290" alt="image" src="https://github.com/user-attachments/assets/22ab14c0-903d-4c99-bfc2-c057b5be6996" />


## Summary by Sourcery

改进：
- 将动态插入的 codexbar 提供者参数替换为固定的、针对不同提供者的命令变体，同时保留现有的提供者校验逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Replace dynamically interpolated codexbar provider argument with fixed provider-specific command variants while preserving existing provider validation.

</details>