### PR TITLE
model: check ReasoningContent at HasPayload

### DIFF
--- a/model/message_validator.go
+++ b/model/message_validator.go
@@ -19,9 +19,12 @@ const (
 	roleGroupAssistant
 )
 
-// HasPayload reports whether the message has non-empty Content or ContentParts.
+// HasPayload reports whether the message has non-empty Content, ContentParts,
+// or ReasoningContent.
 func HasPayload(msg Message) bool {
-	return msg.Content != "" || len(msg.ContentParts) > 0
+	return msg.Content != "" ||
+		len(msg.ContentParts) > 0 ||
+		msg.ReasoningContent != ""
 }
 
 func roleGroupOf(role Role) roleGroupKind {

--- a/model/message_validator_test.go
+++ b/model/message_validator_test.go
@@ -91,6 +91,45 @@ func TestEnsureNonEmptyContent_PreservesNonEmpty(t *testing.T) {
 	require.Equal(t, "q", out[0].Content)
 }
 
+func TestHasPayload(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  Message
+		want bool
+	}{
+		{
+			name: "content",
+			msg:  Message{Content: "hello"},
+			want: true,
+		},
+		{
+			name: "content parts",
+			msg: Message{
+				ContentParts: []ContentPart{{Type: ContentTypeText}},
+			},
+			want: true,
+		},
+		{
+			name: "reasoning content",
+			msg: Message{
+				ReasoningContent: "thinking",
+			},
+			want: true,
+		},
+		{
+			name: "empty message",
+			msg:  Message{},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, HasPayload(tt.msg))
+		})
+	}
+}
+
 func TestValidateAndFixMessageSequence_DropsOrphanPrefix(t *testing.T) {
 	messages := []Message{
 		NewAssistantMessage("orphan"),

--- a/model/response_test.go
+++ b/model/response_test.go
@@ -641,6 +641,28 @@ func TestResponse_IsValidContent(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "valid reasoning content in message",
+			rsp: &Response{
+				Choices: []Choice{{
+					Message: Message{
+						ReasoningContent: "let me think",
+					},
+				}},
+			},
+			want: true,
+		},
+		{
+			name: "valid reasoning content in delta",
+			rsp: &Response{
+				Choices: []Choice{{
+					Delta: Message{
+						ReasoningContent: "streaming thought",
+					},
+				}},
+			},
+			want: true,
+		},
+		{
 			name: "no valid content",
 			rsp: &Response{
 				Choices: []Choice{{


### PR DESCRIPTION
- Updated the HasPayload function to check for non-empty ReasoningContent in addition to Content and ContentParts.
- Added unit tests for HasPayload to cover various message scenarios, including cases with reasoning content and empty messages.
- Extended response validation tests to include reasoning content in messages and deltas.

This improves the robustness of message validation and ensures proper handling of reasoning content in the system.

## Summary by Sourcery

扩展消息负载（payload）检测范围，将推理内容（reasoning content）纳入考虑，并在消息和响应处理的整个流程中对其进行验证。

增强内容：
- 在消息验证中，将 `ReasoningContent` 视为有效的负载（payload）。

测试：
- 为 `HasPayload` 添加单元测试，覆盖普通内容、内容片段、推理内容以及空消息等场景。
- 扩展响应验证测试，使其在完整消息和增量（delta）中都接受推理内容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Expand message payload detection to account for reasoning content and validate it throughout message and response handling.

Enhancements:
- Treat ReasoningContent as valid payload in message validation.

Tests:
- Add unit tests for HasPayload covering content, content parts, reasoning content, and empty messages.
- Extend response validation tests to accept reasoning content in both full messages and deltas.

</details>