### PR TITLE
refactor: replace telemetry keys with semconvtrace constants

### DIFF
--- a/agent/a2aagent/a2a_agent.go
+++ b/agent/a2aagent/a2a_agent.go
@@ -31,6 +31,7 @@ import (
 	itelemetry "trpc.group/trpc-go/trpc-agent-go/internal/telemetry"
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/model"
+	semconvtrace "trpc.group/trpc-go/trpc-agent-go/telemetry/semconv/trace"
 	"trpc.group/trpc-go/trpc-agent-go/telemetry/trace"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
@@ -167,7 +168,7 @@ func (r *A2AAgent) Run(ctx context.Context, invocation *agent.Invocation) (<-cha
 	if r.a2aClient == nil {
 		span.SetStatus(codes.Error, "A2A client is nil")
 
-		span.SetAttributes(attribute.String(itelemetry.KeyErrorType, itelemetry.ToErrorType(err, model.ErrorTypeRunError)))
+		span.SetAttributes(attribute.String(semconvtrace.KeyErrorType, itelemetry.ToErrorType(err, model.ErrorTypeRunError)))
 		span.End()
 		return nil, fmt.Errorf("A2A client is nil")
 	}
@@ -175,7 +176,7 @@ func (r *A2AAgent) Run(ctx context.Context, invocation *agent.Invocation) (<-cha
 	// Validate A2A request options early
 	if err := r.validateA2ARequestOptions(invocation); err != nil {
 		span.SetStatus(codes.Error, err.Error())
-		span.SetAttributes(attribute.String(itelemetry.KeyErrorType, itelemetry.ToErrorType(err, model.ErrorTypeRunError)))
+		span.SetAttributes(attribute.String(semconvtrace.KeyErrorType, itelemetry.ToErrorType(err, model.ErrorTypeRunError)))
 		span.End()
 		return nil, err
 	}
@@ -190,7 +191,7 @@ func (r *A2AAgent) Run(ctx context.Context, invocation *agent.Invocation) (<-cha
 	}
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
-		span.SetAttributes(attribute.String(itelemetry.KeyErrorType, itelemetry.ToErrorType(err, model.ErrorTypeRunError)))
+		span.SetAttributes(attribute.String(semconvtrace.KeyErrorType, itelemetry.ToErrorType(err, model.ErrorTypeRunError)))
 		span.End()
 		return nil, err
 	}

--- a/agent/a2aagent/a2a_agent_test.go
+++ b/agent/a2aagent/a2a_agent_test.go
@@ -33,6 +33,7 @@ import (
 	itelemetry "trpc.group/trpc-go/trpc-agent-go/internal/telemetry"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
+	semconvtrace "trpc.group/trpc-go/trpc-agent-go/telemetry/semconv/trace"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
 
@@ -428,10 +429,10 @@ func TestWrapEventChannelWithTelemetry_AccumulatesTokenUsage(t *testing.T) {
 	}
 
 	attrs := spans[0].Attributes()
-	if !hasAttr(attrs, attribute.Int(itelemetry.KeyGenAIUsageInputTokens, finalEvent.Response.Usage.PromptTokens)) {
+	if !hasAttr(attrs, attribute.Int(semconvtrace.KeyGenAIUsageInputTokens, finalEvent.Response.Usage.PromptTokens)) {
 		t.Fatalf("expected input token usage to be recorded, attrs=%v", attrs)
 	}
-	if !hasAttr(attrs, attribute.Int(itelemetry.KeyGenAIUsageOutputTokens, finalEvent.Response.Usage.CompletionTokens)) {
+	if !hasAttr(attrs, attribute.Int(semconvtrace.KeyGenAIUsageOutputTokens, finalEvent.Response.Usage.CompletionTokens)) {
 		t.Fatalf("expected output token usage to be recorded, attrs=%v", attrs)
 	}
 }

--- a/agent/graphagent/graph_agent.go
+++ b/agent/graphagent/graph_agent.go
@@ -27,6 +27,7 @@ import (
 	itelemetry "trpc.group/trpc-go/trpc-agent-go/internal/telemetry"
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/model"
+	semconvtrace "trpc.group/trpc-go/trpc-agent-go/telemetry/semconv/trace"
 	"trpc.group/trpc-go/trpc-agent-go/telemetry/trace"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
@@ -124,7 +125,7 @@ func (ga *GraphAgent) runWithBarrier(ctx context.Context, invocation *agent.Invo
 		evt := event.NewErrorEvent(invocation.InvocationID, invocation.AgentName,
 			model.ErrorTypeFlowError, err.Error())
 		span.SetStatus(codes.Error, err.Error())
-		span.SetAttributes(attribute.String(itelemetry.KeyErrorType, itelemetry.ToErrorType(err, model.ErrorTypeFlowError)))
+		span.SetAttributes(attribute.String(semconvtrace.KeyErrorType, itelemetry.ToErrorType(err, model.ErrorTypeFlowError)))
 		if emitErr := agent.EmitEvent(ctx, invocation, out, evt); emitErr != nil {
 			log.Errorf("graphagent: emit error event failed: %v", emitErr)
 		}
@@ -135,7 +136,7 @@ func (ga *GraphAgent) runWithBarrier(ctx context.Context, invocation *agent.Invo
 		evt := event.NewErrorEvent(invocation.InvocationID, invocation.AgentName,
 			model.ErrorTypeFlowError, err.Error())
 		span.SetStatus(codes.Error, err.Error())
-		span.SetAttributes(attribute.String(itelemetry.KeyErrorType, itelemetry.ToErrorType(err, model.ErrorTypeFlowError)))
+		span.SetAttributes(attribute.String(semconvtrace.KeyErrorType, itelemetry.ToErrorType(err, model.ErrorTypeFlowError)))
 		if emitErr := agent.EmitEvent(ctx, invocation, out, evt); emitErr != nil {
 			log.Errorf("graphagent: emit error event failed: %v.", emitErr)
 		}
@@ -144,7 +145,7 @@ func (ga *GraphAgent) runWithBarrier(ctx context.Context, invocation *agent.Invo
 	for evt := range innerChan {
 		if err := event.EmitEvent(ctx, out, evt); err != nil {
 			span.SetStatus(codes.Error, err.Error())
-			span.SetAttributes(attribute.String(itelemetry.KeyErrorType, itelemetry.ToErrorType(err, model.ErrorTypeFlowError)))
+			span.SetAttributes(attribute.String(semconvtrace.KeyErrorType, itelemetry.ToErrorType(err, model.ErrorTypeFlowError)))
 			log.Errorf("graphagent: emit event failed: %v.", err)
 			return
 		}

--- a/agent/graphagent/graph_agent_test.go
+++ b/agent/graphagent/graph_agent_test.go
@@ -29,11 +29,11 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/graph"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/barrier"
-	itelemetry "trpc.group/trpc-go/trpc-agent-go/internal/telemetry"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	"trpc.group/trpc-go/trpc-agent-go/session/inmemory"
 	"trpc.group/trpc-go/trpc-agent-go/session/summary"
+	semconvtrace "trpc.group/trpc-go/trpc-agent-go/telemetry/semconv/trace"
 	"trpc.group/trpc-go/trpc-agent-go/telemetry/trace"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
@@ -1875,7 +1875,7 @@ func TestGraphAgent_RunWithBarrier_EmitEventError(t *testing.T) {
 	attrs := agentSpan.getAttributes()
 	var errorTypeAttr *attribute.KeyValue
 	for i := range attrs {
-		if string(attrs[i].Key) == string(itelemetry.KeyErrorType) {
+		if string(attrs[i].Key) == string(semconvtrace.KeyErrorType) {
 			errorTypeAttr = &attrs[i]
 			break
 		}

--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -34,6 +34,7 @@ import (
 	knowledgetool "trpc.group/trpc-go/trpc-agent-go/knowledge/tool"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/planner"
+	semconvtrace "trpc.group/trpc-go/trpc-agent-go/telemetry/semconv/trace"
 	"trpc.group/trpc-go/trpc-agent-go/telemetry/trace"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 	toolskill "trpc.group/trpc-go/trpc-agent-go/tool/skill"
@@ -648,7 +649,7 @@ func (a *LLMAgent) Run(ctx context.Context, invocation *agent.Invocation) (e <-c
 		}
 		// Handle actual errors
 		span.SetStatus(codes.Error, err.Error())
-		span.SetAttributes(attribute.String(itelemetry.KeyErrorType, itelemetry.ToErrorType(err, model.ErrorTypeRunError)))
+		span.SetAttributes(attribute.String(semconvtrace.KeyErrorType, itelemetry.ToErrorType(err, model.ErrorTypeRunError)))
 		span.End()
 		return nil, err
 	}

--- a/graph/state_graph.go
+++ b/graph/state_graph.go
@@ -40,6 +40,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
+	semconvtrace "trpc.group/trpc-go/trpc-agent-go/telemetry/semconv/trace"
 	"trpc.group/trpc-go/trpc-agent-go/telemetry/trace"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
@@ -1970,8 +1971,8 @@ func finalizeInvokeAgentSpan(span oteltrace.Span, errp *error) {
 	err := *errp
 	span.SetStatus(codes.Error, err.Error())
 	span.SetAttributes(attribute.String(
-		itelemetry.KeyErrorType,
-		itelemetry.ToErrorType(err, itelemetry.ValueDefaultErrorType),
+		semconvtrace.KeyErrorType,
+		itelemetry.ToErrorType(err, semconvtrace.ValueDefaultErrorType),
 	))
 	span.End()
 }
@@ -2271,7 +2272,7 @@ func NewAgentNodeFunc(agentName string, opts ...Option) NodeFunc {
 			emitAgentErrorEvent(ctx, eventChan, invocationID, nodeID, startTime, endTime, err)
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			tracker.SetResponseErrorType(itelemetry.ValueDefaultErrorType)
+			tracker.SetResponseErrorType(semconvtrace.ValueDefaultErrorType)
 			return nil, fmt.Errorf("failed to run agent %s: %w", agentName, err)
 		}
 

--- a/internal/telemetry/metric_chat.go
+++ b/internal/telemetry/metric_chat.go
@@ -20,6 +20,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/telemetry/metric/histogram"
 	"trpc.group/trpc-go/trpc-agent-go/telemetry/semconv/metrics"
+	semconvtrace "trpc.group/trpc-go/trpc-agent-go/telemetry/semconv/trace"
 )
 
 var (
@@ -65,33 +66,33 @@ type chatAttributes struct {
 
 func (a chatAttributes) toAttributes() []attribute.KeyValue {
 	attrs := []attribute.KeyValue{
-		attribute.String(KeyGenAIOperationName, OperationChat),
-		attribute.String(KeyGenAISystem, a.RequestModelName),
-		attribute.String(KeyGenAIRequestModel, a.RequestModelName),
+		attribute.String(semconvtrace.KeyGenAIOperationName, OperationChat),
+		attribute.String(semconvtrace.KeyGenAISystem, a.RequestModelName),
+		attribute.String(semconvtrace.KeyGenAIRequestModel, a.RequestModelName),
 		attribute.Bool(metrics.KeyTRPCAgentGoStream, a.Stream),
 	}
 	if a.ResponseModelName != "" {
-		attrs = append(attrs, attribute.String(KeyGenAIResponseModel, a.ResponseModelName))
+		attrs = append(attrs, attribute.String(semconvtrace.KeyGenAIResponseModel, a.ResponseModelName))
 	}
 	if a.AppName != "" {
-		attrs = append(attrs, attribute.String(KeyTRPCAgentGoAppName, a.AppName))
+		attrs = append(attrs, attribute.String(semconvtrace.KeyTRPCAgentGoAppName, a.AppName))
 	}
 	if a.UserID != "" {
-		attrs = append(attrs, attribute.String(KeyTRPCAgentGoUserID, a.UserID))
+		attrs = append(attrs, attribute.String(semconvtrace.KeyTRPCAgentGoUserID, a.UserID))
 	}
 	if a.SessionID != "" {
-		attrs = append(attrs, attribute.String(KeyGenAIConversationID, a.SessionID))
+		attrs = append(attrs, attribute.String(semconvtrace.KeyGenAIConversationID, a.SessionID))
 	}
 	if a.TaskType != "" {
-		attrs = append(attrs, attribute.String(KeyGenAITaskType, a.TaskType))
+		attrs = append(attrs, attribute.String(semconvtrace.KeyGenAITaskType, a.TaskType))
 	}
 	if a.ErrorType != "" {
-		attrs = append(attrs, attribute.String(KeyErrorType, a.ErrorType))
+		attrs = append(attrs, attribute.String(semconvtrace.KeyErrorType, a.ErrorType))
 	} else if a.Error != nil {
-		attrs = append(attrs, attribute.String(KeyErrorType, ToErrorType(a.Error, ValueDefaultErrorType)))
+		attrs = append(attrs, attribute.String(semconvtrace.KeyErrorType, ToErrorType(a.Error, semconvtrace.ValueDefaultErrorType)))
 	}
 	if a.AgentName != "" {
-		attrs = append(attrs, attribute.String(KeyGenAIAgentName, a.AgentName))
+		attrs = append(attrs, attribute.String(semconvtrace.KeyGenAIAgentName, a.AgentName))
 	}
 
 	return attrs
@@ -271,28 +272,28 @@ func (t *ChatMetricsTracker) RecordMetrics() func() {
 		// Record input token usage
 		if ChatMetricGenAIClientTokenUsage != nil {
 			ChatMetricGenAIClientTokenUsage.Record(t.ctx, int64(t.totalPromptTokens),
-				metric.WithAttributes(append(otelAttrs, attribute.String(KeyGenAITokenType, metrics.KeyTRPCAgentGoInputTokenType))...))
+				metric.WithAttributes(append(otelAttrs, attribute.String(semconvtrace.KeyGenAITokenType, metrics.KeyTRPCAgentGoInputTokenType))...))
 		}
 		// Record cached prompt token usage (subset of input tokens)
 		if ChatMetricGenAIClientTokenUsage != nil {
 			ChatMetricGenAIClientTokenUsage.Record(t.ctx, int64(t.totalPromptCachedTokens),
-				metric.WithAttributes(append(otelAttrs, attribute.String(KeyGenAITokenType, metrics.KeyTRPCAgentGoInputCachedTokenType))...))
+				metric.WithAttributes(append(otelAttrs, attribute.String(semconvtrace.KeyGenAITokenType, metrics.KeyTRPCAgentGoInputCachedTokenType))...))
 		}
 		// Record tokens read from prompt cache (Anthropic)
 		if ChatMetricGenAIClientTokenUsage != nil {
 			ChatMetricGenAIClientTokenUsage.Record(t.ctx, int64(t.totalPromptCacheReadTokens),
-				metric.WithAttributes(append(otelAttrs, attribute.String(KeyGenAITokenType, metrics.KeyTRPCAgentGoInputCacheReadTokenType))...))
+				metric.WithAttributes(append(otelAttrs, attribute.String(semconvtrace.KeyGenAITokenType, metrics.KeyTRPCAgentGoInputCacheReadTokenType))...))
 		}
 		// Record tokens used to create prompt cache (Anthropic)
 		if ChatMetricGenAIClientTokenUsage != nil {
 			ChatMetricGenAIClientTokenUsage.Record(t.ctx, int64(t.totalPromptCacheCreationTokens),
-				metric.WithAttributes(append(otelAttrs, attribute.String(KeyGenAITokenType, metrics.KeyTRPCAgentGoInputCacheCreationTokenType))...))
+				metric.WithAttributes(append(otelAttrs, attribute.String(semconvtrace.KeyGenAITokenType, metrics.KeyTRPCAgentGoInputCacheCreationTokenType))...))
 		}
 
 		// Record output token usage
 		if ChatMetricGenAIClientTokenUsage != nil {
 			ChatMetricGenAIClientTokenUsage.Record(t.ctx, int64(t.totalCompletionTokens),
-				metric.WithAttributes(append(otelAttrs, attribute.String(KeyGenAITokenType, metrics.KeyTRPCAgentGoOutputTokenType))...))
+				metric.WithAttributes(append(otelAttrs, attribute.String(semconvtrace.KeyGenAITokenType, metrics.KeyTRPCAgentGoOutputTokenType))...))
 		}
 
 		// Calculate and record derived metrics

--- a/internal/telemetry/metric_execute_tool.go
+++ b/internal/telemetry/metric_execute_tool.go
@@ -17,6 +17,7 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	"trpc.group/trpc-go/trpc-agent-go/telemetry/metric/histogram"
 	"trpc.group/trpc-go/trpc-agent-go/telemetry/semconv/metrics"
+	semconvtrace "trpc.group/trpc-go/trpc-agent-go/telemetry/semconv/trace"
 )
 
 var (
@@ -43,26 +44,26 @@ type ExecuteToolAttributes struct {
 
 func (a ExecuteToolAttributes) toAttributes() []attribute.KeyValue {
 	attrs := []attribute.KeyValue{
-		attribute.String(KeyGenAIOperationName, OperationExecuteTool),
-		attribute.String(KeyGenAISystem, a.RequestModelName),
-		attribute.String(KeyGenAIToolName, a.ToolName),
+		attribute.String(semconvtrace.KeyGenAIOperationName, OperationExecuteTool),
+		attribute.String(semconvtrace.KeyGenAISystem, a.RequestModelName),
+		attribute.String(semconvtrace.KeyGenAIToolName, a.ToolName),
 	}
 	if a.AppName != "" {
-		attrs = append(attrs, attribute.String(KeyTRPCAgentGoAppName, a.AppName))
+		attrs = append(attrs, attribute.String(semconvtrace.KeyTRPCAgentGoAppName, a.AppName))
 	}
 	if a.UserID != "" {
-		attrs = append(attrs, attribute.String(KeyTRPCAgentGoUserID, a.UserID))
+		attrs = append(attrs, attribute.String(semconvtrace.KeyTRPCAgentGoUserID, a.UserID))
 	}
 	if a.SessionID != "" {
-		attrs = append(attrs, attribute.String(KeyGenAIConversationID, a.SessionID))
+		attrs = append(attrs, attribute.String(semconvtrace.KeyGenAIConversationID, a.SessionID))
 	}
 	if a.AgentName != "" {
-		attrs = append(attrs, attribute.String(KeyGenAIAgentName, a.AgentName))
+		attrs = append(attrs, attribute.String(semconvtrace.KeyGenAIAgentName, a.AgentName))
 	}
 	if a.ErrorType != "" {
-		attrs = append(attrs, attribute.String(KeyErrorType, a.ErrorType))
+		attrs = append(attrs, attribute.String(semconvtrace.KeyErrorType, a.ErrorType))
 	} else if a.Error != nil {
-		attrs = append(attrs, attribute.String(KeyErrorType, ToErrorType(a.Error, ValueDefaultErrorType)))
+		attrs = append(attrs, attribute.String(semconvtrace.KeyErrorType, ToErrorType(a.Error, semconvtrace.ValueDefaultErrorType)))
 	}
 	return attrs
 }

--- a/internal/telemetry/metric_invoke_agent.go
+++ b/internal/telemetry/metric_invoke_agent.go
@@ -19,6 +19,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/telemetry/metric/histogram"
 	"trpc.group/trpc-go/trpc-agent-go/telemetry/semconv/metrics"
+	semconvtrace "trpc.group/trpc-go/trpc-agent-go/telemetry/semconv/trace"
 )
 
 var (
@@ -49,23 +50,23 @@ type invokeAgentAttributes struct {
 
 func (a invokeAgentAttributes) toAttributes() []attribute.KeyValue {
 	attrs := []attribute.KeyValue{
-		attribute.String(KeyGenAIOperationName, OperationInvokeAgent),
+		attribute.String(semconvtrace.KeyGenAIOperationName, OperationInvokeAgent),
 		attribute.Bool(metrics.KeyTRPCAgentGoStream, a.Stream),
-		attribute.String(KeyGenAISystem, a.System),
+		attribute.String(semconvtrace.KeyGenAISystem, a.System),
 	}
 	if a.AppName != "" {
-		attrs = append(attrs, attribute.String(KeyTRPCAgentGoAppName, a.AppName))
+		attrs = append(attrs, attribute.String(semconvtrace.KeyTRPCAgentGoAppName, a.AppName))
 	}
 	if a.UserID != "" {
-		attrs = append(attrs, attribute.String(KeyTRPCAgentGoUserID, a.UserID))
+		attrs = append(attrs, attribute.String(semconvtrace.KeyTRPCAgentGoUserID, a.UserID))
 	}
 	if a.AgentName != "" {
-		attrs = append(attrs, attribute.String(KeyGenAIAgentName, a.AgentName))
+		attrs = append(attrs, attribute.String(semconvtrace.KeyGenAIAgentName, a.AgentName))
 	}
 	if a.ErrorType != "" {
-		attrs = append(attrs, attribute.String(KeyErrorType, a.ErrorType))
+		attrs = append(attrs, attribute.String(semconvtrace.KeyErrorType, a.ErrorType))
 	} else if a.Error != nil {
-		attrs = append(attrs, attribute.String(KeyErrorType, ToErrorType(a.Error, ValueDefaultErrorType)))
+		attrs = append(attrs, attribute.String(semconvtrace.KeyErrorType, ToErrorType(a.Error, semconvtrace.ValueDefaultErrorType)))
 	}
 
 	return attrs
@@ -161,13 +162,13 @@ func (t *InvokeAgentTracker) RecordMetrics() func() {
 		// Record input token usage
 		if InvokeAgentMetricGenAIClientTokenUsage != nil {
 			InvokeAgentMetricGenAIClientTokenUsage.Record(t.ctx, int64(t.totalPromptTokens),
-				metric.WithAttributes(append(otelAttrs, attribute.String(KeyGenAITokenType, metrics.KeyTRPCAgentGoInputTokenType))...))
+				metric.WithAttributes(append(otelAttrs, attribute.String(semconvtrace.KeyGenAITokenType, metrics.KeyTRPCAgentGoInputTokenType))...))
 		}
 
 		// Record output token usage
 		if InvokeAgentMetricGenAIClientTokenUsage != nil {
 			InvokeAgentMetricGenAIClientTokenUsage.Record(t.ctx, int64(t.totalCompletionTokens),
-				metric.WithAttributes(append(otelAttrs, attribute.String(KeyGenAITokenType, metrics.KeyTRPCAgentGoOutputTokenType))...))
+				metric.WithAttributes(append(otelAttrs, attribute.String(semconvtrace.KeyGenAITokenType, metrics.KeyTRPCAgentGoOutputTokenType))...))
 		}
 
 	}

--- a/internal/telemetry/metric_invoke_agent_test.go
+++ b/internal/telemetry/metric_invoke_agent_test.go
@@ -25,6 +25,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	"trpc.group/trpc-go/trpc-agent-go/telemetry/metric/histogram"
 	"trpc.group/trpc-go/trpc-agent-go/telemetry/semconv/metrics"
+	semconvtrace "trpc.group/trpc-go/trpc-agent-go/telemetry/semconv/trace"
 )
 
 func TestInvokeAgentAttributes_toAttributes(t *testing.T) {
@@ -45,13 +46,13 @@ func TestInvokeAgentAttributes_toAttributes(t *testing.T) {
 				Error:     errors.New("test error"),
 			},
 			expected: []attribute.KeyValue{
-				attribute.String(KeyGenAIOperationName, OperationInvokeAgent),
+				attribute.String(semconvtrace.KeyGenAIOperationName, OperationInvokeAgent),
 				attribute.Bool(metrics.KeyTRPCAgentGoStream, true),
-				attribute.String(KeyGenAISystem, "gpt-4"),
-				attribute.String(KeyTRPCAgentGoAppName, "test-app"),
-				attribute.String(KeyTRPCAgentGoUserID, "user-123"),
-				attribute.String(KeyGenAIAgentName, "test-agent"),
-				attribute.String(KeyErrorType, "rate_limit"),
+				attribute.String(semconvtrace.KeyGenAISystem, "gpt-4"),
+				attribute.String(semconvtrace.KeyTRPCAgentGoAppName, "test-app"),
+				attribute.String(semconvtrace.KeyTRPCAgentGoUserID, "user-123"),
+				attribute.String(semconvtrace.KeyGenAIAgentName, "test-agent"),
+				attribute.String(semconvtrace.KeyErrorType, "rate_limit"),
 			},
 		},
 		{
@@ -61,9 +62,9 @@ func TestInvokeAgentAttributes_toAttributes(t *testing.T) {
 				Stream: false,
 			},
 			expected: []attribute.KeyValue{
-				attribute.String(KeyGenAIOperationName, OperationInvokeAgent),
+				attribute.String(semconvtrace.KeyGenAIOperationName, OperationInvokeAgent),
 				attribute.Bool(metrics.KeyTRPCAgentGoStream, false),
-				attribute.String(KeyGenAISystem, "gpt-3.5"),
+				attribute.String(semconvtrace.KeyGenAISystem, "gpt-3.5"),
 			},
 		},
 		{
@@ -73,10 +74,10 @@ func TestInvokeAgentAttributes_toAttributes(t *testing.T) {
 				Error:  errors.New("some error"),
 			},
 			expected: []attribute.KeyValue{
-				attribute.String(KeyGenAIOperationName, OperationInvokeAgent),
+				attribute.String(semconvtrace.KeyGenAIOperationName, OperationInvokeAgent),
 				attribute.Bool(metrics.KeyTRPCAgentGoStream, false),
-				attribute.String(KeyGenAISystem, "gpt-4"),
-				attribute.String(KeyErrorType, ValueDefaultErrorType),
+				attribute.String(semconvtrace.KeyGenAISystem, "gpt-4"),
+				attribute.String(semconvtrace.KeyErrorType, semconvtrace.ValueDefaultErrorType),
 			},
 		},
 		{
@@ -89,9 +90,9 @@ func TestInvokeAgentAttributes_toAttributes(t *testing.T) {
 				ErrorType: "",
 			},
 			expected: []attribute.KeyValue{
-				attribute.String(KeyGenAIOperationName, OperationInvokeAgent),
+				attribute.String(semconvtrace.KeyGenAIOperationName, OperationInvokeAgent),
 				attribute.Bool(metrics.KeyTRPCAgentGoStream, false),
-				attribute.String(KeyGenAISystem, "claude-3"),
+				attribute.String(semconvtrace.KeyGenAISystem, "claude-3"),
 			},
 		},
 	}

--- a/internal/telemetry/metric_test.go
+++ b/internal/telemetry/metric_test.go
@@ -24,6 +24,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	"trpc.group/trpc-go/trpc-agent-go/telemetry/metric/histogram"
 	"trpc.group/trpc-go/trpc-agent-go/telemetry/semconv/metrics"
+	semconvtrace "trpc.group/trpc-go/trpc-agent-go/telemetry/semconv/trace"
 )
 
 // mockModel implements model.Model interface for testing.
@@ -59,16 +60,16 @@ func TestChatAttributes_toAttributes(t *testing.T) {
 				Error:             errors.New("test error"),
 			},
 			expected: []attribute.KeyValue{
-				attribute.String(KeyGenAIOperationName, OperationChat),
-				attribute.String(KeyGenAISystem, "gpt-4"),
-				attribute.String(KeyGenAIRequestModel, "gpt-4"),
+				attribute.String(semconvtrace.KeyGenAIOperationName, OperationChat),
+				attribute.String(semconvtrace.KeyGenAISystem, "gpt-4"),
+				attribute.String(semconvtrace.KeyGenAIRequestModel, "gpt-4"),
 				attribute.Bool(metrics.KeyTRPCAgentGoStream, true),
-				attribute.String(KeyGenAIResponseModel, "gpt-4-0613"),
-				attribute.String(KeyTRPCAgentGoAppName, "test-app"),
-				attribute.String(KeyTRPCAgentGoUserID, "user-123"),
-				attribute.String(KeyGenAIConversationID, "session-456"),
-				attribute.String(KeyErrorType, "rate_limit"),
-				attribute.String(KeyGenAIAgentName, "test-agent"),
+				attribute.String(semconvtrace.KeyGenAIResponseModel, "gpt-4-0613"),
+				attribute.String(semconvtrace.KeyTRPCAgentGoAppName, "test-app"),
+				attribute.String(semconvtrace.KeyTRPCAgentGoUserID, "user-123"),
+				attribute.String(semconvtrace.KeyGenAIConversationID, "session-456"),
+				attribute.String(semconvtrace.KeyErrorType, "rate_limit"),
+				attribute.String(semconvtrace.KeyGenAIAgentName, "test-agent"),
 			},
 		},
 		{
@@ -78,9 +79,9 @@ func TestChatAttributes_toAttributes(t *testing.T) {
 				Stream:           false,
 			},
 			expected: []attribute.KeyValue{
-				attribute.String(KeyGenAIOperationName, OperationChat),
-				attribute.String(KeyGenAISystem, "gpt-3.5"),
-				attribute.String(KeyGenAIRequestModel, "gpt-3.5"),
+				attribute.String(semconvtrace.KeyGenAIOperationName, OperationChat),
+				attribute.String(semconvtrace.KeyGenAISystem, "gpt-3.5"),
+				attribute.String(semconvtrace.KeyGenAIRequestModel, "gpt-3.5"),
 				attribute.Bool(metrics.KeyTRPCAgentGoStream, false),
 			},
 		},
@@ -93,12 +94,12 @@ func TestChatAttributes_toAttributes(t *testing.T) {
 				TaskType:         "summarize demo",
 			},
 			expected: []attribute.KeyValue{
-				attribute.String(KeyGenAIOperationName, OperationChat),
-				attribute.String(KeyGenAISystem, "gpt-4"),
-				attribute.String(KeyGenAIRequestModel, "gpt-4"),
+				attribute.String(semconvtrace.KeyGenAIOperationName, OperationChat),
+				attribute.String(semconvtrace.KeyGenAISystem, "gpt-4"),
+				attribute.String(semconvtrace.KeyGenAIRequestModel, "gpt-4"),
 				attribute.Bool(metrics.KeyTRPCAgentGoStream, false),
-				attribute.String(KeyGenAIConversationID, "session-1"),
-				attribute.String(KeyGenAITaskType, "summarize demo"),
+				attribute.String(semconvtrace.KeyGenAIConversationID, "session-1"),
+				attribute.String(semconvtrace.KeyGenAITaskType, "summarize demo"),
 			},
 		},
 		{
@@ -108,11 +109,11 @@ func TestChatAttributes_toAttributes(t *testing.T) {
 				Error:            errors.New("some error"),
 			},
 			expected: []attribute.KeyValue{
-				attribute.String(KeyGenAIOperationName, OperationChat),
-				attribute.String(KeyGenAISystem, "gpt-4"),
-				attribute.String(KeyGenAIRequestModel, "gpt-4"),
+				attribute.String(semconvtrace.KeyGenAIOperationName, OperationChat),
+				attribute.String(semconvtrace.KeyGenAISystem, "gpt-4"),
+				attribute.String(semconvtrace.KeyGenAIRequestModel, "gpt-4"),
 				attribute.Bool(metrics.KeyTRPCAgentGoStream, false),
-				attribute.String(KeyErrorType, ValueDefaultErrorType),
+				attribute.String(semconvtrace.KeyErrorType, semconvtrace.ValueDefaultErrorType),
 			},
 		},
 		{
@@ -127,9 +128,9 @@ func TestChatAttributes_toAttributes(t *testing.T) {
 				AgentName:         "",
 			},
 			expected: []attribute.KeyValue{
-				attribute.String(KeyGenAIOperationName, OperationChat),
-				attribute.String(KeyGenAISystem, "claude-3"),
-				attribute.String(KeyGenAIRequestModel, "claude-3"),
+				attribute.String(semconvtrace.KeyGenAIOperationName, OperationChat),
+				attribute.String(semconvtrace.KeyGenAISystem, "claude-3"),
+				attribute.String(semconvtrace.KeyGenAIRequestModel, "claude-3"),
 				attribute.Bool(metrics.KeyTRPCAgentGoStream, false),
 			},
 		},
@@ -677,14 +678,14 @@ func TestExecuteToolAttributes_toAttributes(t *testing.T) {
 				Error:            errors.New("test error"),
 			},
 			expected: []attribute.KeyValue{
-				attribute.String(KeyGenAIOperationName, OperationExecuteTool),
-				attribute.String(KeyGenAISystem, "gpt-4"),
-				attribute.String(KeyGenAIToolName, "calculator"),
-				attribute.String(KeyTRPCAgentGoAppName, "test-app"),
-				attribute.String(KeyTRPCAgentGoUserID, "user-123"),
-				attribute.String(KeyGenAIConversationID, "session-456"),
-				attribute.String(KeyGenAIAgentName, "test-agent"),
-				attribute.String(KeyErrorType, "timeout"),
+				attribute.String(semconvtrace.KeyGenAIOperationName, OperationExecuteTool),
+				attribute.String(semconvtrace.KeyGenAISystem, "gpt-4"),
+				attribute.String(semconvtrace.KeyGenAIToolName, "calculator"),
+				attribute.String(semconvtrace.KeyTRPCAgentGoAppName, "test-app"),
+				attribute.String(semconvtrace.KeyTRPCAgentGoUserID, "user-123"),
+				attribute.String(semconvtrace.KeyGenAIConversationID, "session-456"),
+				attribute.String(semconvtrace.KeyGenAIAgentName, "test-agent"),
+				attribute.String(semconvtrace.KeyErrorType, "timeout"),
 			},
 		},
 		{
@@ -694,9 +695,9 @@ func TestExecuteToolAttributes_toAttributes(t *testing.T) {
 				ToolName:         "search",
 			},
 			expected: []attribute.KeyValue{
-				attribute.String(KeyGenAIOperationName, OperationExecuteTool),
-				attribute.String(KeyGenAISystem, "gpt-3.5"),
-				attribute.String(KeyGenAIToolName, "search"),
+				attribute.String(semconvtrace.KeyGenAIOperationName, OperationExecuteTool),
+				attribute.String(semconvtrace.KeyGenAISystem, "gpt-3.5"),
+				attribute.String(semconvtrace.KeyGenAIToolName, "search"),
 			},
 		},
 		{
@@ -707,10 +708,10 @@ func TestExecuteToolAttributes_toAttributes(t *testing.T) {
 				Error:            errors.New("some error"),
 			},
 			expected: []attribute.KeyValue{
-				attribute.String(KeyGenAIOperationName, OperationExecuteTool),
-				attribute.String(KeyGenAISystem, "gpt-4"),
-				attribute.String(KeyGenAIToolName, "tool1"),
-				attribute.String(KeyErrorType, ValueDefaultErrorType),
+				attribute.String(semconvtrace.KeyGenAIOperationName, OperationExecuteTool),
+				attribute.String(semconvtrace.KeyGenAISystem, "gpt-4"),
+				attribute.String(semconvtrace.KeyGenAIToolName, "tool1"),
+				attribute.String(semconvtrace.KeyErrorType, semconvtrace.ValueDefaultErrorType),
 			},
 		},
 	}

--- a/internal/telemetry/trace.go
+++ b/internal/telemetry/trace.go
@@ -69,13 +69,6 @@ const (
 	KeyGenAIWorkflowID = "gen_ai.workflow.id"
 )
 
-var (
-	// KeyGenAIWorkflowRequest is the request of the workflow.
-	KeyGenAIWorkflowRequest = semconvtrace.KeyGenAIWorkflowRequest
-	// KeyGenAIWorkflowResponse is the response of the workflow.
-	KeyGenAIWorkflowResponse = semconvtrace.KeyGenAIWorkflowResponse
-)
-
 // Workflow is the workflow information.
 type Workflow struct {
 	Name     string
@@ -95,27 +88,27 @@ func TraceWorkflow(span trace.Span, workflow *Workflow) {
 	if !span.IsRecording() {
 		return
 	}
-	span.SetAttributes(attribute.String(KeyGenAIOperationName, OperationWorkflow))
+	span.SetAttributes(attribute.String(semconvtrace.KeyGenAIOperationName, OperationWorkflow))
 	span.SetAttributes(attribute.String(KeyGenAIWorkflowName, workflow.Name))
 	span.SetAttributes(attribute.String(KeyGenAIWorkflowID, workflow.ID))
 	if workflow.Request != nil {
 		request, err := json.Marshal(workflow.Request)
 		if err != nil {
-			span.SetAttributes(attribute.String(KeyGenAIWorkflowRequest, fmt.Sprintf("<not json serializable: %v>", err)))
+			span.SetAttributes(attribute.String(semconvtrace.KeyGenAIWorkflowRequest, fmt.Sprintf("<not json serializable: %v>", err)))
 		} else {
-			span.SetAttributes(attribute.String(KeyGenAIWorkflowRequest, string(request)))
+			span.SetAttributes(attribute.String(semconvtrace.KeyGenAIWorkflowRequest, string(request)))
 		}
 	}
 	if workflow.Response != nil {
 		response, err := json.Marshal(workflow.Response)
 		if err != nil {
-			span.SetAttributes(attribute.String(KeyGenAIWorkflowResponse, fmt.Sprintf("<not json serializable>: %v", err)))
+			span.SetAttributes(attribute.String(semconvtrace.KeyGenAIWorkflowResponse, fmt.Sprintf("<not json serializable>: %v", err)))
 		} else {
-			span.SetAttributes(attribute.String(KeyGenAIWorkflowResponse, string(response)))
+			span.SetAttributes(attribute.String(semconvtrace.KeyGenAIWorkflowResponse, string(response)))
 		}
 	}
 	if workflow.Error != nil {
-		span.SetAttributes(attribute.String(KeyErrorType, ToErrorType(workflow.Error, ValueDefaultErrorType)))
+		span.SetAttributes(attribute.String(semconvtrace.KeyErrorType, ToErrorType(workflow.Error, semconvtrace.ValueDefaultErrorType)))
 		span.SetStatus(codes.Error, workflow.Error.Error())
 		span.RecordError(workflow.Error)
 	}
@@ -138,116 +131,50 @@ const (
 	ProtocolHTTP string = "http"
 )
 
-// Telemetry attribute keys aliases from semconv package.
-var (
-	ResourceServiceNamespace = semconvtrace.ResourceServiceNamespace
-	ResourceServiceName      = semconvtrace.ResourceServiceName
-	ResourceServiceVersion   = semconvtrace.ResourceServiceVersion
-
-	KeyEventID      = semconvtrace.KeyEventID
-	KeyInvocationID = semconvtrace.KeyInvocationID
-	KeyLLMRequest   = semconvtrace.KeyLLMRequest
-	KeyLLMResponse  = semconvtrace.KeyLLMResponse
-
-	KeyRunnerName      = semconvtrace.KeyRunnerName
-	KeyRunnerUserID    = semconvtrace.KeyRunnerUserID
-	KeyRunnerSessionID = semconvtrace.KeyRunnerSessionID
-	KeyRunnerInput     = semconvtrace.KeyRunnerInput
-	KeyRunnerOutput    = semconvtrace.KeyRunnerOutput
-
-	KeyTRPCAgentGoAppName                = semconvtrace.KeyTRPCAgentGoAppName
-	KeyTRPCAgentGoUserID                 = semconvtrace.KeyTRPCAgentGoUserID
-	KeyTRPCAgentGoClientTimeToFirstToken = semconvtrace.KeyTRPCAgentGoClientTimeToFirstToken
-
-	KeyGenAIOperationName = semconvtrace.KeyGenAIOperationName
-	KeyGenAISystem        = semconvtrace.KeyGenAISystem
-
-	KeyGenAIRequestModel                  = semconvtrace.KeyGenAIRequestModel
-	KeyGenAIRequestIsStream               = semconvtrace.KeyGenAIRequestIsStream
-	KeyGenAIRequestChoiceCount            = semconvtrace.KeyGenAIRequestChoiceCount
-	KeyGenAIInputMessages                 = semconvtrace.KeyGenAIInputMessages
-	KeyGenAIOutputMessages                = semconvtrace.KeyGenAIOutputMessages
-	KeyGenAIAgentName                     = semconvtrace.KeyGenAIAgentName
-	KeyGenAIConversationID                = semconvtrace.KeyGenAIConversationID
-	KeyGenAIUsageOutputTokens             = semconvtrace.KeyGenAIUsageOutputTokens
-	KeyGenAIUsageInputTokens              = semconvtrace.KeyGenAIUsageInputTokens
-	KeyGenAIUsageInputTokensCached        = semconvtrace.KeyGenAIUsageInputTokensCached
-	KeyGenAIUsageInputTokensCacheRead     = semconvtrace.KeyGenAIUsageInputTokensCacheRead
-	KeyGenAIUsageInputTokensCacheCreation = semconvtrace.KeyGenAIUsageInputTokensCacheCreation
-	KeyGenAIProviderName                  = semconvtrace.KeyGenAIProviderName
-	KeyGenAIAgentDescription              = semconvtrace.KeyGenAIAgentDescription
-	KeyGenAIResponseFinishReasons         = semconvtrace.KeyGenAIResponseFinishReasons
-	KeyGenAIResponseID                    = semconvtrace.KeyGenAIResponseID
-	KeyGenAIResponseModel                 = semconvtrace.KeyGenAIResponseModel
-	KeyGenAIRequestStopSequences          = semconvtrace.KeyGenAIRequestStopSequences
-	KeyGenAIRequestFrequencyPenalty       = semconvtrace.KeyGenAIRequestFrequencyPenalty
-	KeyGenAIRequestMaxTokens              = semconvtrace.KeyGenAIRequestMaxTokens
-	KeyGenAIRequestPresencePenalty        = semconvtrace.KeyGenAIRequestPresencePenalty
-	KeyGenAIRequestTemperature            = semconvtrace.KeyGenAIRequestTemperature
-	KeyGenAIRequestTopP                   = semconvtrace.KeyGenAIRequestTopP
-	KeyGenAISystemInstructions            = semconvtrace.KeyGenAISystemInstructions
-	KeyGenAITokenType                     = semconvtrace.KeyGenAITokenType
-	KeyGenAITaskType                      = semconvtrace.KeyGenAITaskType
-	KeyGenAIRequestThinkingEnabled        = semconvtrace.KeyGenAIRequestThinkingEnabled
-	KeyGenAIRequestToolDefinitions        = semconvtrace.KeyGenAIRequestToolDefinitions
-
-	KeyGenAIToolName          = semconvtrace.KeyGenAIToolName
-	KeyGenAIToolDescription   = semconvtrace.KeyGenAIToolDescription
-	KeyGenAIToolCallID        = semconvtrace.KeyGenAIToolCallID
-	KeyGenAIToolCallArguments = semconvtrace.KeyGenAIToolCallArguments
-	KeyGenAIToolCallResult    = semconvtrace.KeyGenAIToolCallResult
-
-	KeyErrorType          = semconvtrace.KeyErrorType
-	KeyErrorMessage       = semconvtrace.KeyErrorMessage
-	ValueDefaultErrorType = semconvtrace.ValueDefaultErrorType
-
-	SystemTRPCGoAgent = semconvtrace.SystemTRPCGoAgent
-)
-
 // TraceToolCall traces the invocation of a tool call.
 func TraceToolCall(span trace.Span, sess *session.Session, declaration *tool.Declaration, args []byte, rspEvent *event.Event, err error) {
 	span.SetAttributes(
-		attribute.String(KeyGenAISystem, SystemTRPCGoAgent),
-		attribute.String(KeyGenAIOperationName, OperationExecuteTool),
-		attribute.String(KeyGenAIToolName, declaration.Name),
-		attribute.String(KeyGenAIToolDescription, declaration.Description),
+		attribute.String(semconvtrace.KeyGenAISystem, semconvtrace.SystemTRPCGoAgent),
+		attribute.String(semconvtrace.KeyGenAIOperationName, OperationExecuteTool),
+		attribute.String(semconvtrace.KeyGenAIToolName, declaration.Name),
+		attribute.String(semconvtrace.KeyGenAIToolDescription, declaration.Description),
 	)
 	if rspEvent != nil {
-		span.SetAttributes(attribute.String(KeyEventID, rspEvent.ID))
+		span.SetAttributes(attribute.String(semconvtrace.KeyEventID, rspEvent.ID))
 	}
 	if sess != nil {
 		span.SetAttributes(
-			attribute.String(KeyGenAIConversationID, sess.ID),
-			attribute.String(KeyRunnerUserID, sess.UserID),
+			attribute.String(semconvtrace.KeyGenAIConversationID, sess.ID),
+			attribute.String(semconvtrace.KeyRunnerUserID, sess.UserID),
 		)
 	}
 
 	// args is json-encoded.
-	span.SetAttributes(attribute.String(KeyGenAIToolCallArguments, string(args)))
+	span.SetAttributes(attribute.String(semconvtrace.KeyGenAIToolCallArguments, string(args)))
 	if rspEvent != nil && rspEvent.Response != nil {
 		if e := rspEvent.Response.Error; e != nil {
 			span.SetStatus(codes.Error, e.Message)
-			span.SetAttributes(attribute.String(KeyErrorType, e.Type), attribute.String(KeyErrorMessage, e.Message))
+			span.SetAttributes(attribute.String(semconvtrace.KeyErrorType, e.Type), attribute.String(semconvtrace.KeyErrorMessage, e.Message))
 		} else if err != nil {
 			span.SetStatus(codes.Error, err.Error())
-			span.SetAttributes(attribute.String(KeyErrorType, ToErrorType(err, ValueDefaultErrorType)), attribute.String(KeyErrorMessage, err.Error()))
+			span.SetAttributes(attribute.String(semconvtrace.KeyErrorType, ToErrorType(err, semconvtrace.ValueDefaultErrorType)), attribute.String(semconvtrace.KeyErrorMessage, err.Error()))
 		}
 
 		if callIDs := rspEvent.Response.GetToolCallIDs(); len(callIDs) > 0 {
-			span.SetAttributes(attribute.String(KeyGenAIToolCallID, callIDs[0]))
+			span.SetAttributes(attribute.String(semconvtrace.KeyGenAIToolCallID, callIDs[0]))
 		}
 		if bts, err := json.Marshal(rspEvent.Response); err == nil {
-			span.SetAttributes(attribute.String(KeyGenAIToolCallResult, string(bts)))
+			span.SetAttributes(attribute.String(semconvtrace.KeyGenAIToolCallResult, string(bts)))
 		} else {
-			span.SetAttributes(attribute.String(KeyGenAIToolCallResult, "<not json serializable>"))
+			span.SetAttributes(attribute.String(semconvtrace.KeyGenAIToolCallResult, "<not json serializable>"))
 		}
 	}
 
 	// Setting empty llm request and response (as UI expect these) while not
 	// applicable for tool_response.
 	span.SetAttributes(
-		attribute.String(KeyLLMRequest, "{}"),
-		attribute.String(KeyLLMResponse, "{}"),
+		attribute.String(semconvtrace.KeyLLMRequest, "{}"),
+		attribute.String(semconvtrace.KeyLLMResponse, "{}"),
 	)
 }
 
@@ -259,34 +186,34 @@ const ToolNameMergedTools = "(merged tools)"
 // for preventing trace-query requests typically sent by web UIs.
 func TraceMergedToolCalls(span trace.Span, rspEvent *event.Event) {
 	span.SetAttributes(
-		attribute.String(KeyGenAISystem, SystemTRPCGoAgent),
-		attribute.String(KeyGenAIOperationName, OperationExecuteTool),
-		attribute.String(KeyGenAIToolName, ToolNameMergedTools),
-		attribute.String(KeyGenAIToolDescription, "(merged tools)"),
-		attribute.String(KeyGenAIToolCallArguments, "N/A"),
+		attribute.String(semconvtrace.KeyGenAISystem, semconvtrace.SystemTRPCGoAgent),
+		attribute.String(semconvtrace.KeyGenAIOperationName, OperationExecuteTool),
+		attribute.String(semconvtrace.KeyGenAIToolName, ToolNameMergedTools),
+		attribute.String(semconvtrace.KeyGenAIToolDescription, "(merged tools)"),
+		attribute.String(semconvtrace.KeyGenAIToolCallArguments, "N/A"),
 	)
 	if rspEvent != nil && rspEvent.Response != nil {
 		if callIDs := rspEvent.Response.GetToolCallIDs(); len(callIDs) > 0 {
-			span.SetAttributes(attribute.String(KeyGenAIToolCallID, callIDs[0]))
+			span.SetAttributes(attribute.String(semconvtrace.KeyGenAIToolCallID, callIDs[0]))
 		}
 		if e := rspEvent.Response.Error; e != nil {
 			span.SetStatus(codes.Error, e.Message)
-			span.SetAttributes(attribute.String(KeyErrorType, e.Type), attribute.String(KeyErrorMessage, e.Message))
+			span.SetAttributes(attribute.String(semconvtrace.KeyErrorType, e.Type), attribute.String(semconvtrace.KeyErrorMessage, e.Message))
 		}
-		span.SetAttributes(attribute.String(KeyEventID, rspEvent.ID))
+		span.SetAttributes(attribute.String(semconvtrace.KeyEventID, rspEvent.ID))
 
 		if bts, err := json.Marshal(rspEvent.Response); err == nil {
-			span.SetAttributes(attribute.String(KeyGenAIToolCallResult, string(bts)))
+			span.SetAttributes(attribute.String(semconvtrace.KeyGenAIToolCallResult, string(bts)))
 		} else {
-			span.SetAttributes(attribute.String(KeyGenAIToolCallResult, "<not json serializable>"))
+			span.SetAttributes(attribute.String(semconvtrace.KeyGenAIToolCallResult, "<not json serializable>"))
 		}
 	}
 
 	// Setting empty llm request and response (as UI expect these) while not
 	// applicable for tool_response.
 	span.SetAttributes(
-		attribute.String(KeyLLMRequest, "{}"),
-		attribute.String(KeyLLMResponse, "{}"),
+		attribute.String(semconvtrace.KeyLLMRequest, "{}"),
+		attribute.String(semconvtrace.KeyLLMResponse, "{}"),
 	)
 }
 
@@ -300,45 +227,45 @@ func TraceBeforeInvokeAgent(span trace.Span, invoke *agent.Invocation, agentDesc
 	}
 	if bts, err := json.Marshal([]model.Message{invoke.Message}); err == nil {
 		span.SetAttributes(
-			attribute.String(KeyGenAIInputMessages, string(bts)),
+			attribute.String(semconvtrace.KeyGenAIInputMessages, string(bts)),
 		)
 	} else {
-		span.SetAttributes(attribute.String(KeyGenAIInputMessages, "<not json serializable>"))
+		span.SetAttributes(attribute.String(semconvtrace.KeyGenAIInputMessages, "<not json serializable>"))
 	}
 	span.SetAttributes(
-		attribute.String(KeyGenAISystem, SystemTRPCGoAgent),
-		attribute.String(KeyGenAIOperationName, OperationInvokeAgent),
-		attribute.String(KeyGenAIAgentName, invoke.AgentName),
-		attribute.String(KeyInvocationID, invoke.InvocationID),
-		attribute.String(KeyGenAIAgentDescription, agentDescription),
-		attribute.String(KeyGenAISystemInstructions, instructions),
+		attribute.String(semconvtrace.KeyGenAISystem, semconvtrace.SystemTRPCGoAgent),
+		attribute.String(semconvtrace.KeyGenAIOperationName, OperationInvokeAgent),
+		attribute.String(semconvtrace.KeyGenAIAgentName, invoke.AgentName),
+		attribute.String(semconvtrace.KeyInvocationID, invoke.InvocationID),
+		attribute.String(semconvtrace.KeyGenAIAgentDescription, agentDescription),
+		attribute.String(semconvtrace.KeyGenAISystemInstructions, instructions),
 	)
 	if genConfig != nil {
-		span.SetAttributes(attribute.StringSlice(KeyGenAIRequestStopSequences, genConfig.Stop))
+		span.SetAttributes(attribute.StringSlice(semconvtrace.KeyGenAIRequestStopSequences, genConfig.Stop))
 		if fp := genConfig.FrequencyPenalty; fp != nil {
-			span.SetAttributes(attribute.Float64(KeyGenAIRequestFrequencyPenalty, *fp))
+			span.SetAttributes(attribute.Float64(semconvtrace.KeyGenAIRequestFrequencyPenalty, *fp))
 		}
 		if mt := genConfig.MaxTokens; mt != nil {
-			span.SetAttributes(attribute.Int(KeyGenAIRequestMaxTokens, *mt))
+			span.SetAttributes(attribute.Int(semconvtrace.KeyGenAIRequestMaxTokens, *mt))
 		}
 		if pp := genConfig.PresencePenalty; pp != nil {
-			span.SetAttributes(attribute.Float64(KeyGenAIRequestPresencePenalty, *pp))
+			span.SetAttributes(attribute.Float64(semconvtrace.KeyGenAIRequestPresencePenalty, *pp))
 		}
 		if tp := genConfig.Temperature; tp != nil {
-			span.SetAttributes(attribute.Float64(KeyGenAIRequestTemperature, *tp))
+			span.SetAttributes(attribute.Float64(semconvtrace.KeyGenAIRequestTemperature, *tp))
 		}
 		if tp := genConfig.TopP; tp != nil {
-			span.SetAttributes(attribute.Float64(KeyGenAIRequestTopP, *tp))
+			span.SetAttributes(attribute.Float64(semconvtrace.KeyGenAIRequestTopP, *tp))
 		}
 		if te := genConfig.ThinkingEnabled; te != nil {
-			span.SetAttributes(attribute.Bool(KeyGenAIRequestThinkingEnabled, *te))
+			span.SetAttributes(attribute.Bool(semconvtrace.KeyGenAIRequestThinkingEnabled, *te))
 		}
 	}
 
 	if invoke.Session != nil {
 		span.SetAttributes(
-			attribute.String(KeyRunnerUserID, invoke.Session.UserID),
-			attribute.String(KeyGenAIConversationID, invoke.Session.ID),
+			attribute.String(semconvtrace.KeyRunnerUserID, invoke.Session.UserID),
+			attribute.String(semconvtrace.KeyGenAIConversationID, invoke.Session.ID),
 		)
 	}
 }
@@ -365,7 +292,7 @@ func TraceAfterInvokeAgent(span trace.Span, rspEvent *event.Event, tokenUsage *T
 	if len(rsp.Choices) > 0 {
 		if bts, err := json.Marshal(rsp.Choices); err == nil {
 			span.SetAttributes(
-				attribute.String(KeyGenAIOutputMessages, string(bts)),
+				attribute.String(semconvtrace.KeyGenAIOutputMessages, string(bts)),
 			)
 		}
 		var finishReasons []string
@@ -376,22 +303,22 @@ func TraceAfterInvokeAgent(span trace.Span, rspEvent *event.Event, tokenUsage *T
 				finishReasons = append(finishReasons, "")
 			}
 		}
-		span.SetAttributes(attribute.StringSlice(KeyGenAIResponseFinishReasons, finishReasons))
+		span.SetAttributes(attribute.StringSlice(semconvtrace.KeyGenAIResponseFinishReasons, finishReasons))
 
 	}
-	span.SetAttributes(attribute.String(KeyGenAIResponseModel, rsp.Model))
+	span.SetAttributes(attribute.String(semconvtrace.KeyGenAIResponseModel, rsp.Model))
 	if tokenUsage != nil {
-		span.SetAttributes(attribute.Int(KeyGenAIUsageInputTokens, tokenUsage.PromptTokens))
-		span.SetAttributes(attribute.Int(KeyGenAIUsageOutputTokens, tokenUsage.CompletionTokens))
+		span.SetAttributes(attribute.Int(semconvtrace.KeyGenAIUsageInputTokens, tokenUsage.PromptTokens))
+		span.SetAttributes(attribute.Int(semconvtrace.KeyGenAIUsageOutputTokens, tokenUsage.CompletionTokens))
 	}
-	span.SetAttributes(attribute.String(KeyGenAIResponseID, rsp.ID))
+	span.SetAttributes(attribute.String(semconvtrace.KeyGenAIResponseID, rsp.ID))
 
 	if e := rsp.Error; e != nil {
 		span.SetStatus(codes.Error, e.Message)
-		span.SetAttributes(attribute.String(KeyErrorType, e.Type), attribute.String(KeyErrorMessage, e.Message))
+		span.SetAttributes(attribute.String(semconvtrace.KeyErrorType, e.Type), attribute.String(semconvtrace.KeyErrorMessage, e.Message))
 	}
 	if timeToFirstToken > 0 {
-		span.SetAttributes(attribute.Float64(KeyTRPCAgentGoClientTimeToFirstToken, timeToFirstToken.Seconds()))
+		span.SetAttributes(attribute.Float64(semconvtrace.KeyTRPCAgentGoClientTimeToFirstToken, timeToFirstToken.Seconds()))
 	}
 }
 
@@ -422,8 +349,8 @@ func TraceChat(span trace.Span, attributes *TraceChatAttributes) {
 		return
 	}
 	attrs := []attribute.KeyValue{
-		attribute.String(KeyGenAISystem, SystemTRPCGoAgent),
-		attribute.String(KeyGenAIOperationName, OperationChat),
+		attribute.String(semconvtrace.KeyGenAISystem, semconvtrace.SystemTRPCGoAgent),
+		attribute.String(semconvtrace.KeyGenAIOperationName, OperationChat),
 	}
 	if attributes == nil {
 		span.SetAttributes(attrs...)
@@ -431,10 +358,10 @@ func TraceChat(span trace.Span, attributes *TraceChatAttributes) {
 	}
 
 	if attributes.EventID != "" {
-		attrs = append(attrs, attribute.String(KeyEventID, attributes.EventID))
+		attrs = append(attrs, attribute.String(semconvtrace.KeyEventID, attributes.EventID))
 	}
 	if attributes.TimeToFirstToken > 0 {
-		attrs = append(attrs, attribute.Float64(KeyTRPCAgentGoClientTimeToFirstToken, attributes.TimeToFirstToken.Seconds()))
+		attrs = append(attrs, attribute.Float64(semconvtrace.KeyTRPCAgentGoClientTimeToFirstToken, attributes.TimeToFirstToken.Seconds()))
 	}
 	if attributes.TaskType != "" {
 		attrs = append(attrs, attribute.String(semconvtrace.KeyGenAITaskType, attributes.TaskType))
@@ -465,18 +392,18 @@ func buildInvocationAttributes(invoke *agent.Invocation) []attribute.KeyValue {
 	}
 
 	attrs := []attribute.KeyValue{
-		attribute.String(KeyInvocationID, invoke.InvocationID),
+		attribute.String(semconvtrace.KeyInvocationID, invoke.InvocationID),
 	}
 
 	if invoke.Session != nil {
 		attrs = append(attrs,
-			attribute.String(KeyGenAIConversationID, invoke.Session.ID),
-			attribute.String(KeyRunnerUserID, invoke.Session.UserID),
+			attribute.String(semconvtrace.KeyGenAIConversationID, invoke.Session.ID),
+			attribute.String(semconvtrace.KeyRunnerUserID, invoke.Session.UserID),
 		)
 	}
 
 	if invoke.Model != nil {
-		attrs = append(attrs, attribute.String(KeyGenAIRequestModel, invoke.Model.Info().Name))
+		attrs = append(attrs, attribute.String(semconvtrace.KeyGenAIRequestModel, invoke.Model.Info().Name))
 	}
 
 	return attrs
@@ -489,40 +416,40 @@ func buildRequestAttributes(req *model.Request) []attribute.KeyValue {
 	}
 
 	attrs := []attribute.KeyValue{
-		attribute.StringSlice(KeyGenAIRequestStopSequences, req.GenerationConfig.Stop),
-		attribute.Int(KeyGenAIRequestChoiceCount, 1),
+		attribute.StringSlice(semconvtrace.KeyGenAIRequestStopSequences, req.GenerationConfig.Stop),
+		attribute.Int(semconvtrace.KeyGenAIRequestChoiceCount, 1),
 	}
 
 	// Add generation config attributes
 	genConfig := req.GenerationConfig
 	// Add stream attribute only when it's true
 	if genConfig.Stream {
-		attrs = append(attrs, attribute.Bool(KeyGenAIRequestIsStream, true))
+		attrs = append(attrs, attribute.Bool(semconvtrace.KeyGenAIRequestIsStream, true))
 	}
 	if fp := genConfig.FrequencyPenalty; fp != nil {
-		attrs = append(attrs, attribute.Float64(KeyGenAIRequestFrequencyPenalty, *fp))
+		attrs = append(attrs, attribute.Float64(semconvtrace.KeyGenAIRequestFrequencyPenalty, *fp))
 	}
 	if mt := genConfig.MaxTokens; mt != nil {
-		attrs = append(attrs, attribute.Int(KeyGenAIRequestMaxTokens, *mt))
+		attrs = append(attrs, attribute.Int(semconvtrace.KeyGenAIRequestMaxTokens, *mt))
 	}
 	if pp := genConfig.PresencePenalty; pp != nil {
-		attrs = append(attrs, attribute.Float64(KeyGenAIRequestPresencePenalty, *pp))
+		attrs = append(attrs, attribute.Float64(semconvtrace.KeyGenAIRequestPresencePenalty, *pp))
 	}
 	if tp := genConfig.Temperature; tp != nil {
-		attrs = append(attrs, attribute.Float64(KeyGenAIRequestTemperature, *tp))
+		attrs = append(attrs, attribute.Float64(semconvtrace.KeyGenAIRequestTemperature, *tp))
 	}
 	if tp := genConfig.TopP; tp != nil {
-		attrs = append(attrs, attribute.Float64(KeyGenAIRequestTopP, *tp))
+		attrs = append(attrs, attribute.Float64(semconvtrace.KeyGenAIRequestTopP, *tp))
 	}
 	if te := genConfig.ThinkingEnabled; te != nil {
-		attrs = append(attrs, attribute.Bool(KeyGenAIRequestThinkingEnabled, *te))
+		attrs = append(attrs, attribute.Bool(semconvtrace.KeyGenAIRequestThinkingEnabled, *te))
 	}
 
 	// Add request body
 	if bts, err := json.Marshal(req); err == nil {
-		attrs = append(attrs, attribute.String(KeyLLMRequest, string(bts)))
+		attrs = append(attrs, attribute.String(semconvtrace.KeyLLMRequest, string(bts)))
 	} else {
-		attrs = append(attrs, attribute.String(KeyLLMRequest, "<not json serializable>"))
+		attrs = append(attrs, attribute.String(semconvtrace.KeyLLMRequest, "<not json serializable>"))
 	}
 
 	// Add tool definitions as best-effort structured array (JSON string fallback)
@@ -539,16 +466,16 @@ func buildRequestAttributes(req *model.Request) []attribute.KeyValue {
 
 		if len(definitions) > 0 {
 			if bts, err := json.Marshal(definitions); err == nil {
-				attrs = append(attrs, attribute.String(KeyGenAIRequestToolDefinitions, string(bts)))
+				attrs = append(attrs, attribute.String(semconvtrace.KeyGenAIRequestToolDefinitions, string(bts)))
 			}
 		}
 	}
 
 	// Add messages
 	if bts, err := json.Marshal(req.Messages); err == nil {
-		attrs = append(attrs, attribute.String(KeyGenAIInputMessages, string(bts)))
+		attrs = append(attrs, attribute.String(semconvtrace.KeyGenAIInputMessages, string(bts)))
 	} else {
-		attrs = append(attrs, attribute.String(KeyGenAIInputMessages, "<not json serializable>"))
+		attrs = append(attrs, attribute.String(semconvtrace.KeyGenAIInputMessages, "<not json serializable>"))
 	}
 
 	return attrs
@@ -561,40 +488,40 @@ func buildResponseAttributes(rsp *model.Response) []attribute.KeyValue {
 	}
 
 	attrs := []attribute.KeyValue{
-		attribute.String(KeyGenAIResponseModel, rsp.Model),
-		attribute.String(KeyGenAIResponseID, rsp.ID),
+		attribute.String(semconvtrace.KeyGenAIResponseModel, rsp.Model),
+		attribute.String(semconvtrace.KeyGenAIResponseID, rsp.ID),
 	}
 
 	// Add error type if present
 	if e := rsp.Error; e != nil {
-		attrs = append(attrs, attribute.String(KeyErrorType, e.Type), attribute.String(KeyErrorMessage, e.Message))
+		attrs = append(attrs, attribute.String(semconvtrace.KeyErrorType, e.Type), attribute.String(semconvtrace.KeyErrorMessage, e.Message))
 	}
 
 	// Add usage attributes
 	if rsp.Usage != nil {
 		attrs = append(attrs,
-			attribute.Int(KeyGenAIUsageInputTokens, rsp.Usage.PromptTokens),
-			attribute.Int(KeyGenAIUsageOutputTokens, rsp.Usage.CompletionTokens),
+			attribute.Int(semconvtrace.KeyGenAIUsageInputTokens, rsp.Usage.PromptTokens),
+			attribute.Int(semconvtrace.KeyGenAIUsageOutputTokens, rsp.Usage.CompletionTokens),
 		)
 		// Prompt cache tokens (if provided by the model provider)
 		if cached := rsp.Usage.PromptTokensDetails.CachedTokens; cached != 0 {
 			// OpenAI: cached_tokens
-			attrs = append(attrs, attribute.Int(KeyGenAIUsageInputTokensCached, cached))
+			attrs = append(attrs, attribute.Int(semconvtrace.KeyGenAIUsageInputTokensCached, cached))
 		}
 		if cacheRead := rsp.Usage.PromptTokensDetails.CacheReadTokens; cacheRead != 0 {
 			// Anthropic: cache_read_tokens
-			attrs = append(attrs, attribute.Int(KeyGenAIUsageInputTokensCacheRead, cacheRead))
+			attrs = append(attrs, attribute.Int(semconvtrace.KeyGenAIUsageInputTokensCacheRead, cacheRead))
 		}
 		if cacheCreation := rsp.Usage.PromptTokensDetails.CacheCreationTokens; cacheCreation != 0 {
 			// Anthropic: cache_creation_tokens
-			attrs = append(attrs, attribute.Int(KeyGenAIUsageInputTokensCacheCreation, cacheCreation))
+			attrs = append(attrs, attribute.Int(semconvtrace.KeyGenAIUsageInputTokensCacheCreation, cacheCreation))
 		}
 	}
 
 	// Add choices attributes
 	if len(rsp.Choices) > 0 {
 		if bts, err := json.Marshal(rsp.Choices); err == nil {
-			attrs = append(attrs, attribute.String(KeyGenAIOutputMessages, string(bts)))
+			attrs = append(attrs, attribute.String(semconvtrace.KeyGenAIOutputMessages, string(bts)))
 		}
 
 		// Extract finish reasons
@@ -606,14 +533,14 @@ func buildResponseAttributes(rsp *model.Response) []attribute.KeyValue {
 				finishReasons = append(finishReasons, "")
 			}
 		}
-		attrs = append(attrs, attribute.StringSlice(KeyGenAIResponseFinishReasons, finishReasons))
+		attrs = append(attrs, attribute.StringSlice(semconvtrace.KeyGenAIResponseFinishReasons, finishReasons))
 	}
 
 	// Add response body
 	if bts, err := json.Marshal(rsp); err == nil {
-		attrs = append(attrs, attribute.String(KeyLLMResponse, string(bts)))
+		attrs = append(attrs, attribute.String(semconvtrace.KeyLLMResponse, string(bts)))
 	} else {
-		attrs = append(attrs, attribute.String(KeyLLMResponse, "<not json serializable>"))
+		attrs = append(attrs, attribute.String(semconvtrace.KeyLLMResponse, "<not json serializable>"))
 	}
 
 	return attrs

--- a/internal/telemetry/trace_test.go
+++ b/internal/telemetry/trace_test.go
@@ -137,7 +137,7 @@ func TestTraceWorkflow(t *testing.T) {
 
 		TraceWorkflow(span, wf)
 
-		if !hasAttr(span.attrs, KeyGenAIOperationName, OperationWorkflow) {
+		if !hasAttr(span.attrs, semconvtrace.KeyGenAIOperationName, OperationWorkflow) {
 			t.Fatalf("missing operation name attribute")
 		}
 		if !hasAttr(span.attrs, KeyGenAIWorkflowName, "myflow") {
@@ -162,8 +162,8 @@ func TestTraceWorkflow(t *testing.T) {
 
 		TraceWorkflow(span, wf)
 
-		require.True(t, hasAttr(span.attrs, KeyGenAIWorkflowRequest, `{"a":"req"}`))
-		require.True(t, hasAttr(span.attrs, KeyGenAIWorkflowResponse, `{"a":"rsp"}`))
+		require.True(t, hasAttr(span.attrs, semconvtrace.KeyGenAIWorkflowRequest, `{"a":"req"}`))
+		require.True(t, hasAttr(span.attrs, semconvtrace.KeyGenAIWorkflowResponse, `{"a":"rsp"}`))
 		require.NotEqual(t, codes.Error, span.status, "did not expect error status")
 	})
 
@@ -180,10 +180,10 @@ func TestTraceWorkflow(t *testing.T) {
 
 		var gotReq, gotRsp string
 		for _, kv := range span.attrs {
-			if string(kv.Key) == KeyGenAIWorkflowRequest {
+			if string(kv.Key) == semconvtrace.KeyGenAIWorkflowRequest {
 				gotReq = kv.Value.AsString()
 			}
-			if string(kv.Key) == KeyGenAIWorkflowResponse {
+			if string(kv.Key) == semconvtrace.KeyGenAIWorkflowResponse {
 				gotRsp = kv.Value.AsString()
 			}
 		}
@@ -200,7 +200,7 @@ func TestTraceWorkflow(t *testing.T) {
 
 		TraceWorkflow(span, wf)
 
-		require.True(t, hasAttr(span.attrs, KeyErrorType, ValueDefaultErrorType))
+		require.True(t, hasAttr(span.attrs, semconvtrace.KeyErrorType, semconvtrace.ValueDefaultErrorType))
 		require.Equal(t, codes.Error, span.status)
 		require.Equal(t, "boom", span.statusDesc)
 		require.Len(t, span.recordedErrors, 1)
@@ -265,7 +265,7 @@ func TestTraceBeforeAfter_Tool_Merged_Chat_Embedding(t *testing.T) {
 	inv := &agent.Invocation{AgentName: "alpha", InvocationID: "inv-1", Session: &session.Session{ID: "sess-1", UserID: "u-1"}}
 	s := newRecordingSpan()
 	TraceBeforeInvokeAgent(s, inv, "desc", "inst", gc)
-	if !hasAttr(s.attrs, KeyGenAIAgentName, "alpha") {
+	if !hasAttr(s.attrs, semconvtrace.KeyGenAIAgentName, "alpha") {
 		t.Fatalf("missing agent name")
 	}
 
@@ -286,12 +286,12 @@ func TestTraceBeforeAfter_Tool_Merged_Chat_Embedding(t *testing.T) {
 	evt2 := event.New("eid2", "a", event.WithResponse(rsp2))
 	s3 := newRecordingSpan()
 	TraceToolCall(s3, nil, decl, args, evt2, nil)
-	if !hasAttr(s3.attrs, KeyGenAIToolCallID, "c1") {
+	if !hasAttr(s3.attrs, semconvtrace.KeyGenAIToolCallID, "c1") {
 		t.Fatalf("missing call id")
 	}
 	s4 := newRecordingSpan()
 	TraceMergedToolCalls(s4, evt2)
-	if !hasAttr(s4.attrs, KeyGenAIToolName, ToolNameMergedTools) {
+	if !hasAttr(s4.attrs, semconvtrace.KeyGenAIToolName, ToolNameMergedTools) {
 		t.Fatalf("missing merged tool name")
 	}
 
@@ -306,7 +306,7 @@ func TestTraceBeforeAfter_Tool_Merged_Chat_Embedding(t *testing.T) {
 		EventID:          "e1",
 		TimeToFirstToken: 0,
 	})
-	if !hasAttr(s5.attrs, KeyInvocationID, "i1") {
+	if !hasAttr(s5.attrs, semconvtrace.KeyInvocationID, "i1") {
 		t.Fatalf("missing invocation id")
 	}
 
@@ -327,7 +327,7 @@ func TestTraceBeforeAfter_Tool_Merged_Chat_Embedding(t *testing.T) {
 		ServerAddress:         &srvAddr,
 		ServerPort:            &srvPort,
 	})
-	if !hasAttr(s6.attrs, KeyGenAIRequestModel, "text-emb") {
+	if !hasAttr(s6.attrs, semconvtrace.KeyGenAIRequestModel, "text-emb") {
 		t.Fatalf("missing model")
 	}
 	if !hasAttr(s6.attrs, semconvtrace.KeyGenAIRequestEncodingFormats, []string{"floats"}) {
@@ -360,13 +360,13 @@ func TestTraceBeforeAfter_Tool_Merged_Chat_Embedding(t *testing.T) {
 	if s7.status != codes.Error {
 		t.Fatalf("embedding expected error status")
 	}
-	if !hasAttr(s7.attrs, KeyGenAIUsageInputTokens, tok) {
+	if !hasAttr(s7.attrs, semconvtrace.KeyGenAIUsageInputTokens, tok) {
 		t.Fatalf("missing input token")
 	}
-	if !hasAttr(s7.attrs, KeyErrorType, ValueDefaultErrorType) {
+	if !hasAttr(s7.attrs, semconvtrace.KeyErrorType, semconvtrace.ValueDefaultErrorType) {
 		t.Fatalf("missing error type")
 	}
-	if !hasAttr(s7.attrs, KeyErrorMessage, "bad") {
+	if !hasAttr(s7.attrs, semconvtrace.KeyErrorMessage, "bad") {
 		t.Fatalf("missing error message")
 	}
 }
@@ -507,9 +507,9 @@ func TestTraceToolCall_NilPaths(t *testing.T) {
 			TraceToolCall(span, tt.sess, decl, args, tt.rspEvent, tt.err)
 
 			// Verify basic attributes are always set
-			require.True(t, hasAttr(span.attrs, KeyGenAISystem, SystemTRPCGoAgent))
-			require.True(t, hasAttr(span.attrs, KeyGenAIOperationName, OperationExecuteTool))
-			require.True(t, hasAttr(span.attrs, KeyGenAIToolName, "test_tool"))
+			require.True(t, hasAttr(span.attrs, semconvtrace.KeyGenAISystem, semconvtrace.SystemTRPCGoAgent))
+			require.True(t, hasAttr(span.attrs, semconvtrace.KeyGenAIOperationName, OperationExecuteTool))
+			require.True(t, hasAttr(span.attrs, semconvtrace.KeyGenAIToolName, "test_tool"))
 
 			// Verify error status when err is provided
 			if tt.err != nil && tt.rspEvent != nil && tt.rspEvent.Response != nil && tt.rspEvent.Response.Error == nil {
@@ -540,8 +540,8 @@ func TestTraceMergedToolCalls_NilPaths(t *testing.T) {
 			TraceMergedToolCalls(span, tt.rspEvent)
 
 			// Verify basic attributes are always set
-			require.True(t, hasAttr(span.attrs, KeyGenAISystem, SystemTRPCGoAgent))
-			require.True(t, hasAttr(span.attrs, KeyGenAIToolName, ToolNameMergedTools))
+			require.True(t, hasAttr(span.attrs, semconvtrace.KeyGenAISystem, semconvtrace.SystemTRPCGoAgent))
+			require.True(t, hasAttr(span.attrs, semconvtrace.KeyGenAIToolName, ToolNameMergedTools))
 		})
 	}
 }
@@ -577,8 +577,8 @@ func TestTraceBeforeInvokeAgent_NilPaths(t *testing.T) {
 			span := newRecordingSpan()
 			TraceBeforeInvokeAgent(span, tt.invoke, "desc", "instructions", tt.genConfig)
 
-			require.True(t, hasAttr(span.attrs, KeyGenAIAgentName, "test-agent"))
-			require.True(t, hasAttr(span.attrs, KeyInvocationID, "inv1"))
+			require.True(t, hasAttr(span.attrs, semconvtrace.KeyGenAIAgentName, "test-agent"))
+			require.True(t, hasAttr(span.attrs, semconvtrace.KeyInvocationID, "inv1"))
 		})
 	}
 }
@@ -620,8 +620,8 @@ func TestTraceAfterInvokeAgent_NilPaths(t *testing.T) {
 			TraceAfterInvokeAgent(span, tt.rspEvent, tt.tokenUsage, 0)
 
 			if tt.tokenUsage != nil && tt.rspEvent != nil && tt.rspEvent.Response != nil {
-				require.True(t, hasAttr(span.attrs, KeyGenAIUsageInputTokens, int64(tt.tokenUsage.PromptTokens)))
-				require.True(t, hasAttr(span.attrs, KeyGenAIUsageOutputTokens, int64(tt.tokenUsage.CompletionTokens)))
+				require.True(t, hasAttr(span.attrs, semconvtrace.KeyGenAIUsageInputTokens, int64(tt.tokenUsage.PromptTokens)))
+				require.True(t, hasAttr(span.attrs, semconvtrace.KeyGenAIUsageOutputTokens, int64(tt.tokenUsage.CompletionTokens)))
 			}
 		})
 	}
@@ -651,7 +651,7 @@ func TestTraceChat_WithTimeToFirstToken(t *testing.T) {
 		TimeToFirstToken: 100 * time.Millisecond,
 	})
 
-	require.True(t, hasAttr(span.attrs, KeyTRPCAgentGoClientTimeToFirstToken, 0.1))
+	require.True(t, hasAttr(span.attrs, semconvtrace.KeyTRPCAgentGoClientTimeToFirstToken, 0.1))
 }
 
 func TestTraceChat_WithTaskType(t *testing.T) {
@@ -792,7 +792,7 @@ func TestBuildRequestAttributes_ToolDefinitions(t *testing.T) {
 
 	var toolAttr *attribute.KeyValue
 	for i := range attrs {
-		if string(attrs[i].Key) == KeyGenAIRequestToolDefinitions {
+		if string(attrs[i].Key) == semconvtrace.KeyGenAIRequestToolDefinitions {
 			toolAttr = &attrs[i]
 			break
 		}
@@ -877,19 +877,19 @@ func TestBuildResponseAttributes(t *testing.T) {
 			} else {
 				require.NotNil(t, attrs)
 				// Verify basic attributes
-				require.True(t, hasAttr(attrs, KeyGenAIResponseModel, tt.rsp.Model))
-				require.True(t, hasAttr(attrs, KeyGenAIResponseID, tt.rsp.ID))
+				require.True(t, hasAttr(attrs, semconvtrace.KeyGenAIResponseModel, tt.rsp.Model))
+				require.True(t, hasAttr(attrs, semconvtrace.KeyGenAIResponseID, tt.rsp.ID))
 
 				// Verify cached prompt tokens attribute when provided
 				if tt.rsp.Usage != nil {
 					if tt.rsp.Usage.PromptTokensDetails.CachedTokens != 0 {
-						require.True(t, hasAttr(attrs, KeyGenAIUsageInputTokensCached, int64(tt.rsp.Usage.PromptTokensDetails.CachedTokens)))
+						require.True(t, hasAttr(attrs, semconvtrace.KeyGenAIUsageInputTokensCached, int64(tt.rsp.Usage.PromptTokensDetails.CachedTokens)))
 					}
 					if tt.rsp.Usage.PromptTokensDetails.CacheReadTokens != 0 {
-						require.True(t, hasAttr(attrs, KeyGenAIUsageInputTokensCacheRead, int64(tt.rsp.Usage.PromptTokensDetails.CacheReadTokens)))
+						require.True(t, hasAttr(attrs, semconvtrace.KeyGenAIUsageInputTokensCacheRead, int64(tt.rsp.Usage.PromptTokensDetails.CacheReadTokens)))
 					}
 					if tt.rsp.Usage.PromptTokensDetails.CacheCreationTokens != 0 {
-						require.True(t, hasAttr(attrs, KeyGenAIUsageInputTokensCacheCreation, int64(tt.rsp.Usage.PromptTokensDetails.CacheCreationTokens)))
+						require.True(t, hasAttr(attrs, semconvtrace.KeyGenAIUsageInputTokensCacheCreation, int64(tt.rsp.Usage.PromptTokensDetails.CacheCreationTokens)))
 					}
 				}
 			}
@@ -959,7 +959,7 @@ func TestTraceToolCall_EmptyToolCallIDs(t *testing.T) {
 
 	TraceToolCall(span, nil, decl, args, evt, nil)
 
-	require.True(t, hasAttr(span.attrs, KeyGenAIToolName, "test_tool"))
+	require.True(t, hasAttr(span.attrs, semconvtrace.KeyGenAIToolName, "test_tool"))
 }
 
 func TestTraceMergedToolCalls_WithError(t *testing.T) {
@@ -978,7 +978,7 @@ func TestTraceMergedToolCalls_WithError(t *testing.T) {
 	TraceMergedToolCalls(span, evt)
 
 	require.Equal(t, codes.Error, span.status)
-	require.True(t, hasAttr(span.attrs, KeyGenAIToolCallID, "call1"))
+	require.True(t, hasAttr(span.attrs, semconvtrace.KeyGenAIToolCallID, "call1"))
 }
 
 func TestTraceBeforeInvokeAgent_JSONMarshalError(t *testing.T) {
@@ -993,7 +993,7 @@ func TestTraceBeforeInvokeAgent_JSONMarshalError(t *testing.T) {
 
 	TraceBeforeInvokeAgent(span, inv, "desc", "instructions", nil)
 
-	require.True(t, hasAttr(span.attrs, KeyGenAIAgentName, "test-agent"))
+	require.True(t, hasAttr(span.attrs, semconvtrace.KeyGenAIAgentName, "test-agent"))
 }
 
 func TestBuildRequestAttributes_JSONMarshalPaths(t *testing.T) {
@@ -1007,7 +1007,7 @@ func TestBuildRequestAttributes_JSONMarshalPaths(t *testing.T) {
 	// Verify LLM request attribute is set
 	found := false
 	for _, attr := range attrs {
-		if string(attr.Key) == KeyLLMRequest {
+		if string(attr.Key) == semconvtrace.KeyLLMRequest {
 			found = true
 			break
 		}
@@ -1028,7 +1028,7 @@ func TestBuildResponseAttributes_JSONMarshalPaths(t *testing.T) {
 	// Verify LLM response attribute is set
 	found := false
 	for _, attr := range attrs {
-		if string(attr.Key) == KeyLLMResponse {
+		if string(attr.Key) == semconvtrace.KeyLLMResponse {
 			found = true
 			break
 		}
@@ -1151,7 +1151,7 @@ func TestBuildRequestAttributes_StreamAttribute(t *testing.T) {
 
 			found := false
 			for _, attr := range attrs {
-				if string(attr.Key) == KeyGenAIRequestIsStream {
+				if string(attr.Key) == semconvtrace.KeyGenAIRequestIsStream {
 					found = true
 					require.Equal(t, tt.expectStream, attr.Value.AsBool())
 					break

--- a/telemetry/langfuse/exporter.go
+++ b/telemetry/langfuse/exporter.go
@@ -24,6 +24,7 @@ import (
 
 	itelemetry "trpc.group/trpc-go/trpc-agent-go/internal/telemetry"
 	"trpc.group/trpc-go/trpc-agent-go/model"
+	semconvtrace "trpc.group/trpc-go/trpc-agent-go/telemetry/semconv/trace"
 	"trpc.group/trpc-go/trpc-agent-go/telemetry/tracetransform"
 )
 
@@ -96,7 +97,7 @@ func transformSpan(span *tracepb.Span) {
 	// Find the operation name
 	var operationName string
 	for _, attr := range span.Attributes {
-		if attr.Key == itelemetry.KeyGenAIOperationName {
+		if attr.Key == semconvtrace.KeyGenAIOperationName {
 			if attr.Value != nil && attr.Value.GetStringValue() != "" {
 				operationName = attr.Value.GetStringValue()
 				break
@@ -129,7 +130,7 @@ func transformInvokeAgent(span *tracepb.Span) {
 
 	for _, attr := range span.Attributes {
 		switch attr.Key {
-		case itelemetry.KeyGenAIInputMessages:
+		case semconvtrace.KeyGenAIInputMessages:
 			if attr.Value != nil {
 				newAttributes = append(newAttributes, &commonpb.KeyValue{
 					Key: observationInput,
@@ -139,7 +140,7 @@ func transformInvokeAgent(span *tracepb.Span) {
 				})
 			}
 			// Skip this attribute (delete it)
-		case itelemetry.KeyGenAIOutputMessages:
+		case semconvtrace.KeyGenAIOutputMessages:
 			if attr.Value != nil {
 				newAttributes = append(newAttributes, &commonpb.KeyValue{
 					Key: observationOutput,
@@ -155,9 +156,9 @@ func transformInvokeAgent(span *tracepb.Span) {
 			// InvokeAgent spans (to support Galileo); previously only Chat spans had token usage.
 			// Keeping token attributes on InvokeAgent would make Langfuse double count tokens
 			// compared to the old behavior (Chat-only token accounting).
-		case itelemetry.KeyGenAIUsageInputTokens, itelemetry.KeyGenAIUsageOutputTokens,
-			itelemetry.KeyGenAIUsageInputTokensCached, itelemetry.KeyGenAIUsageInputTokensCacheRead,
-			itelemetry.KeyGenAIUsageInputTokensCacheCreation:
+		case semconvtrace.KeyGenAIUsageInputTokens, semconvtrace.KeyGenAIUsageOutputTokens,
+			semconvtrace.KeyGenAIUsageInputTokensCached, semconvtrace.KeyGenAIUsageInputTokensCacheRead,
+			semconvtrace.KeyGenAIUsageInputTokensCacheCreation:
 		default:
 			newAttributes = append(newAttributes, attr)
 		}
@@ -214,27 +215,27 @@ func collectLLMSpanAttributes(attrs []*commonpb.KeyValue) llmSpanCollected {
 	var c llmSpanCollected
 	for _, attr := range attrs {
 		switch attr.Key {
-		case itelemetry.KeyGenAIConversationID, itelemetry.KeyRunnerSessionID, traceSessionID:
+		case semconvtrace.KeyGenAIConversationID, semconvtrace.KeyRunnerSessionID, traceSessionID:
 			c.sessionID = attr.Value
-		case itelemetry.KeyRunnerUserID:
+		case semconvtrace.KeyRunnerUserID:
 			c.attrs = append(c.attrs, &commonpb.KeyValue{Key: traceUserID, Value: attr.Value})
-		case itelemetry.KeyLLMRequest:
+		case semconvtrace.KeyLLMRequest:
 			c.llmRequest = getStringPtr(attr.Value)
-		case itelemetry.KeyGenAIInputMessages:
+		case semconvtrace.KeyGenAIInputMessages:
 			c.inputMessages = getStringPtr(attr.Value)
-		case itelemetry.KeyGenAIRequestToolDefinitions:
+		case semconvtrace.KeyGenAIRequestToolDefinitions:
 			c.toolDefinitions = getStringPtr(attr.Value)
-		case itelemetry.KeyLLMResponse:
+		case semconvtrace.KeyLLMResponse:
 			c.attrs = append(c.attrs, stringKV(observationOutput, truncateObservationLLMResponse(stringValueOrNA(attr.Value))))
-		case itelemetry.KeyGenAIUsageInputTokens:
+		case semconvtrace.KeyGenAIUsageInputTokens:
 			c.usage.Input = attr.Value.GetIntValue()
-		case itelemetry.KeyGenAIUsageOutputTokens:
+		case semconvtrace.KeyGenAIUsageOutputTokens:
 			c.usage.Output = attr.Value.GetIntValue()
-		case itelemetry.KeyGenAIUsageInputTokensCached:
+		case semconvtrace.KeyGenAIUsageInputTokensCached:
 			c.usage.InputCached = attr.Value.GetIntValue()
-		case itelemetry.KeyGenAIUsageInputTokensCacheRead:
+		case semconvtrace.KeyGenAIUsageInputTokensCacheRead:
 			c.usage.InputCacheRead = attr.Value.GetIntValue()
-		case itelemetry.KeyGenAIUsageInputTokensCacheCreation:
+		case semconvtrace.KeyGenAIUsageInputTokensCacheCreation:
 			c.usage.InputCacheCreation = attr.Value.GetIntValue()
 		default:
 			c.attrs = append(c.attrs, attr)
@@ -563,11 +564,11 @@ func transformExecuteTool(span *tracepb.Span) {
 	var llmSessionID *commonpb.AnyValue
 	for _, attr := range span.Attributes {
 		switch attr.Key {
-		case itelemetry.KeyGenAIConversationID, itelemetry.KeyRunnerSessionID, traceSessionID:
+		case semconvtrace.KeyGenAIConversationID, semconvtrace.KeyRunnerSessionID, traceSessionID:
 			llmSessionID = attr.Value
-		case itelemetry.KeyRunnerUserID:
+		case semconvtrace.KeyRunnerUserID:
 			newAttributes = append(newAttributes, &commonpb.KeyValue{Key: traceUserID, Value: attr.Value})
-		case itelemetry.KeyGenAIToolCallArguments:
+		case semconvtrace.KeyGenAIToolCallArguments:
 			if attr.Value != nil {
 				newAttributes = append(newAttributes, &commonpb.KeyValue{
 					Key: observationInput,
@@ -584,7 +585,7 @@ func transformExecuteTool(span *tracepb.Span) {
 				})
 			}
 			// Skip this attribute (delete it)
-		case itelemetry.KeyGenAIToolCallResult:
+		case semconvtrace.KeyGenAIToolCallResult:
 			if attr.Value != nil {
 				newAttributes = append(newAttributes, &commonpb.KeyValue{
 					Key: observationOutput,
@@ -630,11 +631,11 @@ func transformWorkflow(span *tracepb.Span) {
 	var llmSessionID *commonpb.AnyValue
 	for _, attr := range span.Attributes {
 		switch attr.Key {
-		case itelemetry.KeyGenAIConversationID, itelemetry.KeyRunnerSessionID, traceSessionID:
+		case semconvtrace.KeyGenAIConversationID, semconvtrace.KeyRunnerSessionID, traceSessionID:
 			llmSessionID = attr.Value
-		case itelemetry.KeyRunnerUserID:
+		case semconvtrace.KeyRunnerUserID:
 			newAttributes = append(newAttributes, &commonpb.KeyValue{Key: traceUserID, Value: attr.Value})
-		case itelemetry.KeyGenAIWorkflowRequest:
+		case semconvtrace.KeyGenAIWorkflowRequest:
 			if attr.Value != nil {
 				newAttributes = append(newAttributes, &commonpb.KeyValue{
 					Key: observationInput,
@@ -651,7 +652,7 @@ func transformWorkflow(span *tracepb.Span) {
 				})
 			}
 			// Skip this attribute (delete it)
-		case itelemetry.KeyGenAIWorkflowResponse:
+		case semconvtrace.KeyGenAIWorkflowResponse:
 			if attr.Value != nil {
 				newAttributes = append(newAttributes, &commonpb.KeyValue{
 					Key: observationOutput,

--- a/telemetry/langfuse/exporter_test.go
+++ b/telemetry/langfuse/exporter_test.go
@@ -25,6 +25,7 @@ import (
 
 	itelemetry "trpc.group/trpc-go/trpc-agent-go/internal/telemetry"
 	"trpc.group/trpc-go/trpc-agent-go/model"
+	semconvtrace "trpc.group/trpc-go/trpc-agent-go/telemetry/semconv/trace"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
 
@@ -157,7 +158,7 @@ func TestTransformSpan(t *testing.T) {
 				Name: "test-span",
 				Attributes: []*commonpb.KeyValue{
 					{
-						Key: itelemetry.KeyGenAIOperationName,
+						Key: semconvtrace.KeyGenAIOperationName,
 						Value: &commonpb.AnyValue{
 							Value: &commonpb.AnyValue_StringValue{StringValue: itelemetry.OperationChat},
 						},
@@ -173,7 +174,7 @@ func TestTransformSpan(t *testing.T) {
 				Name: "test-span",
 				Attributes: []*commonpb.KeyValue{
 					{
-						Key: itelemetry.KeyGenAIOperationName,
+						Key: semconvtrace.KeyGenAIOperationName,
 						Value: &commonpb.AnyValue{
 							Value: &commonpb.AnyValue_StringValue{StringValue: itelemetry.OperationExecuteTool},
 						},
@@ -189,7 +190,7 @@ func TestTransformSpan(t *testing.T) {
 				Name: "test-span",
 				Attributes: []*commonpb.KeyValue{
 					{
-						Key: itelemetry.KeyGenAIOperationName,
+						Key: semconvtrace.KeyGenAIOperationName,
 						Value: &commonpb.AnyValue{
 							Value: &commonpb.AnyValue_StringValue{StringValue: itelemetry.OperationWorkflow},
 						},
@@ -251,25 +252,25 @@ func TestTransformInvokeAgent(t *testing.T) {
 		Name: "agent-span",
 		Attributes: []*commonpb.KeyValue{
 			{
-				Key: itelemetry.KeyGenAIInputMessages,
+				Key: semconvtrace.KeyGenAIInputMessages,
 				Value: &commonpb.AnyValue{
 					Value: &commonpb.AnyValue_StringValue{StringValue: `[{"role":"user","content":"hi"}]`},
 				},
 			},
 			{
-				Key: itelemetry.KeyGenAIOutputMessages,
+				Key: semconvtrace.KeyGenAIOutputMessages,
 				Value: &commonpb.AnyValue{
 					Value: &commonpb.AnyValue_StringValue{StringValue: `[{"role":"assistant","content":"hello"}]`},
 				},
 			},
 			{
-				Key: itelemetry.KeyGenAIUsageInputTokens,
+				Key: semconvtrace.KeyGenAIUsageInputTokens,
 				Value: &commonpb.AnyValue{
 					Value: &commonpb.AnyValue_IntValue{IntValue: 123},
 				},
 			},
 			{
-				Key: itelemetry.KeyGenAIUsageOutputTokens,
+				Key: semconvtrace.KeyGenAIUsageOutputTokens,
 				Value: &commonpb.AnyValue{
 					Value: &commonpb.AnyValue_IntValue{IntValue: 456},
 				},
@@ -299,8 +300,8 @@ func TestTransformInvokeAgent(t *testing.T) {
 
 	// Token usage attributes should be filtered out for InvokeAgent observations.
 	for _, attr := range span.Attributes {
-		assert.NotEqual(t, itelemetry.KeyGenAIUsageInputTokens, attr.Key)
-		assert.NotEqual(t, itelemetry.KeyGenAIUsageOutputTokens, attr.Key)
+		assert.NotEqual(t, semconvtrace.KeyGenAIUsageInputTokens, attr.Key)
+		assert.NotEqual(t, semconvtrace.KeyGenAIUsageOutputTokens, attr.Key)
 	}
 }
 
@@ -316,13 +317,13 @@ func TestTransformCallLLM(t *testing.T) {
 				Name: "llm-call",
 				Attributes: []*commonpb.KeyValue{
 					{
-						Key: itelemetry.KeyLLMRequest,
+						Key: semconvtrace.KeyLLMRequest,
 						Value: &commonpb.AnyValue{
 							Value: &commonpb.AnyValue_StringValue{StringValue: `{"prompt": "Hello", "generation_config": {"temperature": 0.7}}`},
 						},
 					},
 					{
-						Key: itelemetry.KeyLLMResponse,
+						Key: semconvtrace.KeyLLMResponse,
 						Value: &commonpb.AnyValue{
 							Value: &commonpb.AnyValue_StringValue{StringValue: `{"text": "Hello! How can I help you?"}`},
 						},
@@ -349,11 +350,11 @@ func TestTransformCallLLM(t *testing.T) {
 				Name: "llm-call",
 				Attributes: []*commonpb.KeyValue{
 					{
-						Key:   itelemetry.KeyLLMRequest,
+						Key:   semconvtrace.KeyLLMRequest,
 						Value: nil,
 					},
 					{
-						Key: itelemetry.KeyLLMResponse,
+						Key: semconvtrace.KeyLLMResponse,
 						Value: &commonpb.AnyValue{
 							Value: &commonpb.AnyValue_StringValue{StringValue: "response"},
 						},
@@ -372,13 +373,13 @@ func TestTransformCallLLM(t *testing.T) {
 				Name: "llm-call",
 				Attributes: []*commonpb.KeyValue{
 					{
-						Key: itelemetry.KeyLLMRequest,
+						Key: semconvtrace.KeyLLMRequest,
 						Value: &commonpb.AnyValue{
 							Value: &commonpb.AnyValue_StringValue{StringValue: "request"},
 						},
 					},
 					{
-						Key:   itelemetry.KeyLLMResponse,
+						Key:   semconvtrace.KeyLLMResponse,
 						Value: nil,
 					},
 				},
@@ -409,8 +410,8 @@ func TestTransformCallLLM(t *testing.T) {
 
 			// Check that LLM-specific attributes are removed
 			for _, attr := range tt.input.Attributes {
-				assert.NotEqual(t, itelemetry.KeyLLMRequest, attr.Key, "LLM request attribute should be removed")
-				assert.NotEqual(t, itelemetry.KeyLLMResponse, attr.Key, "LLM response attribute should be removed")
+				assert.NotEqual(t, semconvtrace.KeyLLMRequest, attr.Key, "LLM request attribute should be removed")
+				assert.NotEqual(t, semconvtrace.KeyLLMResponse, attr.Key, "LLM response attribute should be removed")
 			}
 		})
 	}
@@ -436,19 +437,19 @@ func TestTransformCallLLM_PromptWithTools(t *testing.T) {
 		Name: "llm-call",
 		Attributes: []*commonpb.KeyValue{
 			{
-				Key: itelemetry.KeyLLMRequest,
+				Key: semconvtrace.KeyLLMRequest,
 				Value: &commonpb.AnyValue{
 					Value: &commonpb.AnyValue_StringValue{StringValue: `{"generation_config": {"temperature": 0.7}}`},
 				},
 			},
 			{
-				Key: itelemetry.KeyGenAIInputMessages,
+				Key: semconvtrace.KeyGenAIInputMessages,
 				Value: &commonpb.AnyValue{
 					Value: &commonpb.AnyValue_StringValue{StringValue: `[{"role":"user","content":"hi"}]`},
 				},
 			},
 			{
-				Key: itelemetry.KeyGenAIRequestToolDefinitions,
+				Key: semconvtrace.KeyGenAIRequestToolDefinitions,
 				Value: &commonpb.AnyValue{
 					Value: &commonpb.AnyValue_StringValue{StringValue: string(defsJSON)},
 				},
@@ -461,8 +462,8 @@ func TestTransformCallLLM_PromptWithTools(t *testing.T) {
 	attrMap := make(map[string]string)
 	for _, attr := range span.Attributes {
 		attrMap[attr.Key] = attr.Value.GetStringValue()
-		assert.NotEqual(t, itelemetry.KeyGenAIInputMessages, attr.Key, "input messages should be folded into observation.input")
-		assert.NotEqual(t, itelemetry.KeyGenAIRequestToolDefinitions, attr.Key, "tool definitions should be folded into observation.input")
+		assert.NotEqual(t, semconvtrace.KeyGenAIInputMessages, attr.Key, "input messages should be folded into observation.input")
+		assert.NotEqual(t, semconvtrace.KeyGenAIRequestToolDefinitions, attr.Key, "tool definitions should be folded into observation.input")
 	}
 
 	inputStr := attrMap[observationInput]
@@ -551,13 +552,13 @@ func TestTransformCallLLM_UsageDetails(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			attrs := []*commonpb.KeyValue{
 				{
-					Key: itelemetry.KeyLLMRequest,
+					Key: semconvtrace.KeyLLMRequest,
 					Value: &commonpb.AnyValue{
 						Value: &commonpb.AnyValue_StringValue{StringValue: `{"prompt":"hello"}`},
 					},
 				},
 				{
-					Key: itelemetry.KeyLLMResponse,
+					Key: semconvtrace.KeyLLMResponse,
 					Value: &commonpb.AnyValue{
 						Value: &commonpb.AnyValue_StringValue{StringValue: `{"text":"world"}`},
 					},
@@ -566,31 +567,31 @@ func TestTransformCallLLM_UsageDetails(t *testing.T) {
 			// Add token usage attributes (only non-zero values, matching how buildResponseAttributes works)
 			if tt.inputTokens != 0 {
 				attrs = append(attrs, &commonpb.KeyValue{
-					Key:   itelemetry.KeyGenAIUsageInputTokens,
+					Key:   semconvtrace.KeyGenAIUsageInputTokens,
 					Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_IntValue{IntValue: tt.inputTokens}},
 				})
 			}
 			if tt.outputTokens != 0 {
 				attrs = append(attrs, &commonpb.KeyValue{
-					Key:   itelemetry.KeyGenAIUsageOutputTokens,
+					Key:   semconvtrace.KeyGenAIUsageOutputTokens,
 					Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_IntValue{IntValue: tt.outputTokens}},
 				})
 			}
 			if tt.cachedTokens != 0 {
 				attrs = append(attrs, &commonpb.KeyValue{
-					Key:   itelemetry.KeyGenAIUsageInputTokensCached,
+					Key:   semconvtrace.KeyGenAIUsageInputTokensCached,
 					Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_IntValue{IntValue: tt.cachedTokens}},
 				})
 			}
 			if tt.cacheReadTokens != 0 {
 				attrs = append(attrs, &commonpb.KeyValue{
-					Key:   itelemetry.KeyGenAIUsageInputTokensCacheRead,
+					Key:   semconvtrace.KeyGenAIUsageInputTokensCacheRead,
 					Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_IntValue{IntValue: tt.cacheReadTokens}},
 				})
 			}
 			if tt.cacheCreationTokens != 0 {
 				attrs = append(attrs, &commonpb.KeyValue{
-					Key:   itelemetry.KeyGenAIUsageInputTokensCacheCreation,
+					Key:   semconvtrace.KeyGenAIUsageInputTokensCacheCreation,
 					Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_IntValue{IntValue: tt.cacheCreationTokens}},
 				})
 			}
@@ -600,11 +601,11 @@ func TestTransformCallLLM_UsageDetails(t *testing.T) {
 
 			// Verify original gen_ai.usage.* attributes are removed
 			for _, attr := range span.Attributes {
-				assert.NotEqual(t, itelemetry.KeyGenAIUsageInputTokens, attr.Key)
-				assert.NotEqual(t, itelemetry.KeyGenAIUsageOutputTokens, attr.Key)
-				assert.NotEqual(t, itelemetry.KeyGenAIUsageInputTokensCached, attr.Key)
-				assert.NotEqual(t, itelemetry.KeyGenAIUsageInputTokensCacheRead, attr.Key)
-				assert.NotEqual(t, itelemetry.KeyGenAIUsageInputTokensCacheCreation, attr.Key)
+				assert.NotEqual(t, semconvtrace.KeyGenAIUsageInputTokens, attr.Key)
+				assert.NotEqual(t, semconvtrace.KeyGenAIUsageOutputTokens, attr.Key)
+				assert.NotEqual(t, semconvtrace.KeyGenAIUsageInputTokensCached, attr.Key)
+				assert.NotEqual(t, semconvtrace.KeyGenAIUsageInputTokensCacheRead, attr.Key)
+				assert.NotEqual(t, semconvtrace.KeyGenAIUsageInputTokensCacheCreation, attr.Key)
 			}
 
 			// Check usage_details attribute
@@ -633,35 +634,35 @@ func TestTransformInvokeAgent_CacheTokensFiltered(t *testing.T) {
 		Name: "agent-span",
 		Attributes: []*commonpb.KeyValue{
 			{
-				Key: itelemetry.KeyGenAIInputMessages,
+				Key: semconvtrace.KeyGenAIInputMessages,
 				Value: &commonpb.AnyValue{
 					Value: &commonpb.AnyValue_StringValue{StringValue: `[{"role":"user","content":"hi"}]`},
 				},
 			},
 			{
-				Key: itelemetry.KeyGenAIOutputMessages,
+				Key: semconvtrace.KeyGenAIOutputMessages,
 				Value: &commonpb.AnyValue{
 					Value: &commonpb.AnyValue_StringValue{StringValue: `[{"role":"assistant","content":"hello"}]`},
 				},
 			},
 			{
-				Key:   itelemetry.KeyGenAIUsageInputTokens,
+				Key:   semconvtrace.KeyGenAIUsageInputTokens,
 				Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_IntValue{IntValue: 100}},
 			},
 			{
-				Key:   itelemetry.KeyGenAIUsageOutputTokens,
+				Key:   semconvtrace.KeyGenAIUsageOutputTokens,
 				Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_IntValue{IntValue: 50}},
 			},
 			{
-				Key:   itelemetry.KeyGenAIUsageInputTokensCached,
+				Key:   semconvtrace.KeyGenAIUsageInputTokensCached,
 				Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_IntValue{IntValue: 30}},
 			},
 			{
-				Key:   itelemetry.KeyGenAIUsageInputTokensCacheRead,
+				Key:   semconvtrace.KeyGenAIUsageInputTokensCacheRead,
 				Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_IntValue{IntValue: 20}},
 			},
 			{
-				Key:   itelemetry.KeyGenAIUsageInputTokensCacheCreation,
+				Key:   semconvtrace.KeyGenAIUsageInputTokensCacheCreation,
 				Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_IntValue{IntValue: 10}},
 			},
 		},
@@ -671,11 +672,11 @@ func TestTransformInvokeAgent_CacheTokensFiltered(t *testing.T) {
 
 	// All token usage attributes (including cache ones) should be filtered out
 	for _, attr := range span.Attributes {
-		assert.NotEqual(t, itelemetry.KeyGenAIUsageInputTokens, attr.Key)
-		assert.NotEqual(t, itelemetry.KeyGenAIUsageOutputTokens, attr.Key)
-		assert.NotEqual(t, itelemetry.KeyGenAIUsageInputTokensCached, attr.Key)
-		assert.NotEqual(t, itelemetry.KeyGenAIUsageInputTokensCacheRead, attr.Key)
-		assert.NotEqual(t, itelemetry.KeyGenAIUsageInputTokensCacheCreation, attr.Key)
+		assert.NotEqual(t, semconvtrace.KeyGenAIUsageInputTokens, attr.Key)
+		assert.NotEqual(t, semconvtrace.KeyGenAIUsageOutputTokens, attr.Key)
+		assert.NotEqual(t, semconvtrace.KeyGenAIUsageInputTokensCached, attr.Key)
+		assert.NotEqual(t, semconvtrace.KeyGenAIUsageInputTokensCacheRead, attr.Key)
+		assert.NotEqual(t, semconvtrace.KeyGenAIUsageInputTokensCacheCreation, attr.Key)
 	}
 }
 
@@ -691,13 +692,13 @@ func TestTransformExecuteTool(t *testing.T) {
 				Name: "tool-call",
 				Attributes: []*commonpb.KeyValue{
 					{
-						Key: itelemetry.KeyGenAIToolCallArguments,
+						Key: semconvtrace.KeyGenAIToolCallArguments,
 						Value: &commonpb.AnyValue{
 							Value: &commonpb.AnyValue_StringValue{StringValue: `{"arg1": "value1"}`},
 						},
 					},
 					{
-						Key: itelemetry.KeyGenAIToolCallResult,
+						Key: semconvtrace.KeyGenAIToolCallResult,
 						Value: &commonpb.AnyValue{
 							Value: &commonpb.AnyValue_StringValue{StringValue: `{"result": "success"}`},
 						},
@@ -723,11 +724,11 @@ func TestTransformExecuteTool(t *testing.T) {
 				Name: "tool-call",
 				Attributes: []*commonpb.KeyValue{
 					{
-						Key:   itelemetry.KeyGenAIToolCallArguments,
+						Key:   semconvtrace.KeyGenAIToolCallArguments,
 						Value: nil,
 					},
 					{
-						Key: itelemetry.KeyGenAIToolCallResult,
+						Key: semconvtrace.KeyGenAIToolCallResult,
 						Value: &commonpb.AnyValue{
 							Value: &commonpb.AnyValue_StringValue{StringValue: "response"},
 						},
@@ -760,8 +761,8 @@ func TestTransformExecuteTool(t *testing.T) {
 
 			// Check that tool-specific attributes are removed
 			for _, attr := range tt.input.Attributes {
-				assert.NotEqual(t, itelemetry.KeyGenAIToolCallArguments, attr.Key, "tool args attribute should be removed")
-				assert.NotEqual(t, itelemetry.KeyGenAIToolCallResult, attr.Key, "tool response attribute should be removed")
+				assert.NotEqual(t, semconvtrace.KeyGenAIToolCallArguments, attr.Key, "tool args attribute should be removed")
+				assert.NotEqual(t, semconvtrace.KeyGenAIToolCallResult, attr.Key, "tool response attribute should be removed")
 			}
 		})
 	}
@@ -772,25 +773,25 @@ func TestTransformWorkflow(t *testing.T) {
 		Name: "workflow-span",
 		Attributes: []*commonpb.KeyValue{
 			{
-				Key: itelemetry.KeyRunnerSessionID,
+				Key: semconvtrace.KeyRunnerSessionID,
 				Value: &commonpb.AnyValue{
 					Value: &commonpb.AnyValue_StringValue{StringValue: "sess-1"},
 				},
 			},
 			{
-				Key: itelemetry.KeyRunnerUserID,
+				Key: semconvtrace.KeyRunnerUserID,
 				Value: &commonpb.AnyValue{
 					Value: &commonpb.AnyValue_StringValue{StringValue: "user-1"},
 				},
 			},
 			{
-				Key: itelemetry.KeyGenAIWorkflowRequest,
+				Key: semconvtrace.KeyGenAIWorkflowRequest,
 				Value: &commonpb.AnyValue{
 					Value: &commonpb.AnyValue_StringValue{StringValue: `{"req":true}`},
 				},
 			},
 			{
-				Key: itelemetry.KeyGenAIWorkflowResponse,
+				Key: semconvtrace.KeyGenAIWorkflowResponse,
 				Value: &commonpb.AnyValue{
 					Value: &commonpb.AnyValue_StringValue{StringValue: `{"ok":true}`},
 				},
@@ -821,10 +822,10 @@ func TestTransformWorkflow(t *testing.T) {
 	assert.Equal(t, "keep-this", attrMap["other.attribute"])
 
 	for _, attr := range span.Attributes {
-		assert.NotEqual(t, itelemetry.KeyGenAIWorkflowRequest, attr.Key)
-		assert.NotEqual(t, itelemetry.KeyGenAIWorkflowResponse, attr.Key)
-		assert.NotEqual(t, itelemetry.KeyRunnerSessionID, attr.Key)
-		assert.NotEqual(t, itelemetry.KeyRunnerUserID, attr.Key)
+		assert.NotEqual(t, semconvtrace.KeyGenAIWorkflowRequest, attr.Key)
+		assert.NotEqual(t, semconvtrace.KeyGenAIWorkflowResponse, attr.Key)
+		assert.NotEqual(t, semconvtrace.KeyRunnerSessionID, attr.Key)
+		assert.NotEqual(t, semconvtrace.KeyRunnerUserID, attr.Key)
 	}
 }
 
@@ -833,23 +834,23 @@ func TestTransformWorkflow_NilRequestResponse(t *testing.T) {
 		Name: "workflow-span-nil",
 		Attributes: []*commonpb.KeyValue{
 			{
-				Key: itelemetry.KeyRunnerSessionID,
+				Key: semconvtrace.KeyRunnerSessionID,
 				Value: &commonpb.AnyValue{
 					Value: &commonpb.AnyValue_StringValue{StringValue: "sess-2"},
 				},
 			},
 			{
-				Key: itelemetry.KeyRunnerUserID,
+				Key: semconvtrace.KeyRunnerUserID,
 				Value: &commonpb.AnyValue{
 					Value: &commonpb.AnyValue_StringValue{StringValue: "user-2"},
 				},
 			},
 			{
-				Key:   itelemetry.KeyGenAIWorkflowRequest,
+				Key:   semconvtrace.KeyGenAIWorkflowRequest,
 				Value: nil,
 			},
 			{
-				Key:   itelemetry.KeyGenAIWorkflowResponse,
+				Key:   semconvtrace.KeyGenAIWorkflowResponse,
 				Value: nil,
 			},
 		},
@@ -871,10 +872,10 @@ func TestTransformWorkflow_NilRequestResponse(t *testing.T) {
 	assert.Equal(t, "sess-2", attrMap[traceSessionID])
 
 	for _, attr := range span.Attributes {
-		assert.NotEqual(t, itelemetry.KeyGenAIWorkflowRequest, attr.Key)
-		assert.NotEqual(t, itelemetry.KeyGenAIWorkflowResponse, attr.Key)
-		assert.NotEqual(t, itelemetry.KeyRunnerSessionID, attr.Key)
-		assert.NotEqual(t, itelemetry.KeyRunnerUserID, attr.Key)
+		assert.NotEqual(t, semconvtrace.KeyGenAIWorkflowRequest, attr.Key)
+		assert.NotEqual(t, semconvtrace.KeyGenAIWorkflowResponse, attr.Key)
+		assert.NotEqual(t, semconvtrace.KeyRunnerSessionID, attr.Key)
+		assert.NotEqual(t, semconvtrace.KeyRunnerUserID, attr.Key)
 	}
 }
 
@@ -1006,19 +1007,19 @@ func TestTransformationPipeline(t *testing.T) {
 							Name:    "test-llm-span",
 							Attributes: []*commonpb.KeyValue{
 								{
-									Key: itelemetry.KeyGenAIOperationName,
+									Key: semconvtrace.KeyGenAIOperationName,
 									Value: &commonpb.AnyValue{
 										Value: &commonpb.AnyValue_StringValue{StringValue: itelemetry.OperationChat},
 									},
 								},
 								{
-									Key: itelemetry.KeyLLMRequest,
+									Key: semconvtrace.KeyLLMRequest,
 									Value: &commonpb.AnyValue{
 										Value: &commonpb.AnyValue_StringValue{StringValue: `{"prompt": "test"}`},
 									},
 								},
 								{
-									Key: itelemetry.KeyLLMResponse,
+									Key: semconvtrace.KeyLLMResponse,
 									Value: &commonpb.AnyValue{
 										Value: &commonpb.AnyValue_StringValue{StringValue: `{"text": "response"}`},
 									},
@@ -1061,9 +1062,9 @@ func TestTransformationPipeline(t *testing.T) {
 		case observationType:
 			foundObservationType = true
 			assert.Equal(t, "generation", attr.Value.GetStringValue())
-		case itelemetry.KeyLLMRequest:
+		case semconvtrace.KeyLLMRequest:
 			hasLLMRequest = true
-		case itelemetry.KeyLLMResponse:
+		case semconvtrace.KeyLLMResponse:
 			hasLLMResponse = true
 		case observationInput:
 			hasObservationInput = true
@@ -1140,11 +1141,11 @@ func TestTransformInvokeAgent_TruncatesObservationInputOutput(t *testing.T) {
 		Name: "agent-span",
 		Attributes: []*commonpb.KeyValue{
 			{
-				Key:   itelemetry.KeyGenAIInputMessages,
+				Key:   semconvtrace.KeyGenAIInputMessages,
 				Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: bigIn}},
 			},
 			{
-				Key:   itelemetry.KeyGenAIOutputMessages,
+				Key:   semconvtrace.KeyGenAIOutputMessages,
 				Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: bigOut}},
 			},
 		},
@@ -1205,11 +1206,11 @@ func TestTransformInvokeAgent_TruncateUsesTypedMessages(t *testing.T) {
 		Name: "agent-span-typed",
 		Attributes: []*commonpb.KeyValue{
 			{
-				Key:   itelemetry.KeyGenAIInputMessages,
+				Key:   semconvtrace.KeyGenAIInputMessages,
 				Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: string(inputJSON)}},
 			},
 			{
-				Key:   itelemetry.KeyGenAIOutputMessages,
+				Key:   semconvtrace.KeyGenAIOutputMessages,
 				Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: string(outputJSON)}},
 			},
 		},
@@ -1254,15 +1255,15 @@ func TestTransformCallLLM_TruncatesObservationInputOutput(t *testing.T) {
 		Name: "llm-call",
 		Attributes: []*commonpb.KeyValue{
 			{
-				Key:   itelemetry.KeyGenAIOperationName,
+				Key:   semconvtrace.KeyGenAIOperationName,
 				Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: itelemetry.OperationChat}},
 			},
 			{
-				Key:   itelemetry.KeyLLMRequest,
+				Key:   semconvtrace.KeyLLMRequest,
 				Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: bigReq}},
 			},
 			{
-				Key:   itelemetry.KeyLLMResponse,
+				Key:   semconvtrace.KeyLLMResponse,
 				Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: bigResp}},
 			},
 		},
@@ -1294,11 +1295,11 @@ func TestTransformExecuteTool_TruncatesObservationInputOutput(t *testing.T) {
 		Name: "tool-call",
 		Attributes: []*commonpb.KeyValue{
 			{
-				Key:   itelemetry.KeyGenAIToolCallArguments,
+				Key:   semconvtrace.KeyGenAIToolCallArguments,
 				Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: bigArgs}},
 			},
 			{
-				Key:   itelemetry.KeyGenAIToolCallResult,
+				Key:   semconvtrace.KeyGenAIToolCallResult,
 				Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: bigRes}},
 			},
 		},
@@ -1330,11 +1331,11 @@ func TestTransformWorkflow_TruncatesObservationInputOutput(t *testing.T) {
 		Name: "workflow-span",
 		Attributes: []*commonpb.KeyValue{
 			{
-				Key:   itelemetry.KeyGenAIWorkflowRequest,
+				Key:   semconvtrace.KeyGenAIWorkflowRequest,
 				Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: bigReq}},
 			},
 			{
-				Key:   itelemetry.KeyGenAIWorkflowResponse,
+				Key:   semconvtrace.KeyGenAIWorkflowResponse,
 				Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: bigResp}},
 			},
 		},
@@ -1369,19 +1370,19 @@ func BenchmarkTransform(b *testing.B) {
 							Name:    "test-span",
 							Attributes: []*commonpb.KeyValue{
 								{
-									Key: itelemetry.KeyGenAIOperationName,
+									Key: semconvtrace.KeyGenAIOperationName,
 									Value: &commonpb.AnyValue{
 										Value: &commonpb.AnyValue_StringValue{StringValue: itelemetry.OperationChat},
 									},
 								},
 								{
-									Key: itelemetry.KeyLLMRequest,
+									Key: semconvtrace.KeyLLMRequest,
 									Value: &commonpb.AnyValue{
 										Value: &commonpb.AnyValue_StringValue{StringValue: `{"prompt": "test"}`},
 									},
 								},
 								{
-									Key: itelemetry.KeyLLMResponse,
+									Key: semconvtrace.KeyLLMResponse,
 									Value: &commonpb.AnyValue{
 										Value: &commonpb.AnyValue_StringValue{StringValue: `{"text": "response"}`},
 									},

--- a/telemetry/langfuse/tracer.go
+++ b/telemetry/langfuse/tracer.go
@@ -20,6 +20,7 @@ import (
 	"go.opentelemetry.io/otel/trace/noop"
 
 	itelemetry "trpc.group/trpc-go/trpc-agent-go/internal/telemetry"
+	semconvtrace "trpc.group/trpc-go/trpc-agent-go/telemetry/semconv/trace"
 
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 
@@ -79,9 +80,9 @@ func start(ctx context.Context, opts ...otlptracehttp.Option) (clean func(contex
 	if provider == nil {
 		res, err := resource.New(ctx,
 			resource.WithAttributes(
-				semconv.ServiceNamespace(itelemetry.ResourceServiceNamespace),
-				semconv.ServiceName(itelemetry.ResourceServiceName),
-				semconv.ServiceVersion(itelemetry.ResourceServiceVersion),
+				semconv.ServiceNamespace(semconvtrace.ResourceServiceNamespace),
+				semconv.ServiceName(semconvtrace.ResourceServiceName),
+				semconv.ServiceVersion(semconvtrace.ResourceServiceVersion),
 			),
 		)
 		if err != nil {


### PR DESCRIPTION
Updated telemetry attribute keys in various agent files to use the new semconvtrace constants for consistency and improved clarity. This change enhances the maintainability of the code by centralizing the definition of telemetry keys. Affected files include a2a_agent.go, graph_agent.go, llm_agent.go, and several test files.

No functional changes were made; this is purely a refactor for better code organization.

## Summary by Sourcery

重构遥测属性的使用方式，在追踪、指标、代理以及 Langfuse 集成中直接依赖共享的 `semconvtrace` 常量，移除本地别名，同时保持运行时行为不变。

增强内容：
- 在追踪和指标代码中，用对 `semconvtrace` 常量的直接引用替换内部遥测键别名。
- 将代理的错误与 token 使用遥测（A2A、图、LLM 和图状态）与 `semconvtrace` 定义的键对齐，以保持一致性。
- 更新 Langfuse 导出器和追踪器，使其使用 `semconvtrace` 常量读取和发出遥测属性。
- 调整遥测和代理包中的单元测试与集成测试，使其断言基于 `semconvtrace` 键而不是内部别名。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor telemetry attribute usage to rely directly on shared semconvtrace constants across tracing, metrics, agents, and Langfuse integration, removing local aliases while preserving runtime behavior.

Enhancements:
- Replace internal telemetry key aliases with direct references to semconvtrace constants in tracing and metric code.
- Align agent error and token usage telemetry (A2A, graph, LLM, and graph state) with semconvtrace-defined keys for consistency.
- Update Langfuse exporter and tracer to read and emit telemetry attributes using semconvtrace constants.
- Adjust unit and integration tests throughout telemetry and agent packages to assert against semconvtrace keys instead of internal aliases.

</details>