### PR TITLE
telemetry: align chat TTFT reporting with invoke agent

### DIFF
--- a/internal/telemetry/metric_chat.go
+++ b/internal/telemetry/metric_chat.go
@@ -35,7 +35,7 @@ var (
 	// ChatMetricGenAIClientOperationDuration records the distribution of total chat operation durations in seconds.
 	ChatMetricGenAIClientOperationDuration *histogram.DynamicFloat64Histogram
 	// ChatMetricGenAIServerTimeToFirstToken records the distribution of time to first token latency in seconds.
-	// This measures the time from request start until the first token is received.
+	// This measures the time from request start until the first meaningful response payload is received.
 	ChatMetricGenAIServerTimeToFirstToken *histogram.DynamicFloat64Histogram
 	// ChatMetricTRPCAgentGoClientTimeToFirstToken records the distribution of time to first token latency in seconds.
 	// Note: This metric is reported alongside ChatMetricGenAIServerTimeToFirstToken with the same value.
@@ -158,17 +158,16 @@ func (t *ChatMetricsTracker) TrackResponse(response *model.Response) {
 	}
 	var now time.Time
 	// Track first token timing (for both metrics and timing info)
-	if t.isFirstToken {
+	if t.isFirstToken && response.IsValidContent() {
 		if now.IsZero() {
 			now = time.Now()
 		}
-		// Always record firstTokenTimeDuration for metrics (even if no content)
+		// Record TTFT only when the first meaningful response payload arrives.
 		t.firstTokenTimeDuration = now.Sub(t.start)
 		t.isFirstToken = false
 
-		// Update FirstTokenDuration in TimingInfo only if not already recorded (first LLM call only)
-		// Meaningful content = reasoning content, regular content, or tool calls
-		if t.timingInfo != nil && t.timingInfo.FirstTokenDuration == 0 && len(response.Choices) > 0 {
+		// Update FirstTokenDuration in TimingInfo only if not already recorded (first LLM call only).
+		if t.timingInfo != nil && t.timingInfo.FirstTokenDuration == 0 {
 			t.timingInfo.FirstTokenDuration = now.Sub(t.start)
 		}
 
@@ -259,14 +258,16 @@ func (t *ChatMetricsTracker) RecordMetrics() func() {
 			ChatMetricGenAIClientOperationDuration.Record(t.ctx, requestDuration.Seconds(), metric.WithAttributes(otelAttrs...))
 		}
 
-		// Record time to first token (report both metrics with the same value)
-		if ChatMetricGenAIServerTimeToFirstToken != nil {
-			ChatMetricGenAIServerTimeToFirstToken.Record(t.ctx, t.firstTokenTimeDuration.Seconds(),
-				metric.WithAttributes(otelAttrs...))
-		}
-		if ChatMetricTRPCAgentGoClientTimeToFirstToken != nil {
-			ChatMetricTRPCAgentGoClientTimeToFirstToken.Record(t.ctx, t.firstTokenTimeDuration.Seconds(),
-				metric.WithAttributes(otelAttrs...))
+		// Record time to first token only when a meaningful payload was observed.
+		if t.firstTokenTimeDuration > 0 {
+			if ChatMetricGenAIServerTimeToFirstToken != nil {
+				ChatMetricGenAIServerTimeToFirstToken.Record(t.ctx, t.firstTokenTimeDuration.Seconds(),
+					metric.WithAttributes(otelAttrs...))
+			}
+			if ChatMetricTRPCAgentGoClientTimeToFirstToken != nil {
+				ChatMetricTRPCAgentGoClientTimeToFirstToken.Record(t.ctx, t.firstTokenTimeDuration.Seconds(),
+					metric.WithAttributes(otelAttrs...))
+			}
 		}
 
 		// Record input token usage

--- a/internal/telemetry/metric_chat_test.go
+++ b/internal/telemetry/metric_chat_test.go
@@ -15,7 +15,12 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/telemetry/metric/histogram"
+	"trpc.group/trpc-go/trpc-agent-go/telemetry/semconv/metrics"
 )
 
 func TestChatMetricsTracker_RecordMetrics_NoMetrics_ReturnsNoop(t *testing.T) {
@@ -61,7 +66,8 @@ func TestChatMetricsTracker_TrackResponse_ReasoningDuration_UsesLazyNow(t *testi
 	tracker := NewChatMetricsTracker(ctx, nil, req, timingInfo, nil, nil)
 
 	tracker.TrackResponse(&model.Response{})
-	require.False(t, tracker.isFirstToken, "expected first token to be consumed")
+	require.True(t, tracker.isFirstToken, "expected empty chunk to be ignored for TTFT")
+	require.Zero(t, tracker.firstTokenTimeDuration, "expected TTFT to remain unset after empty chunk")
 
 	tracker.TrackResponse(&model.Response{
 		Choices: []model.Choice{
@@ -70,6 +76,8 @@ func TestChatMetricsTracker_TrackResponse_ReasoningDuration_UsesLazyNow(t *testi
 			},
 		},
 	})
+	require.False(t, tracker.isFirstToken, "expected reasoning payload to consume first token")
+	require.Greater(t, tracker.firstTokenTimeDuration, time.Duration(0), "expected TTFT to be recorded on first meaningful payload")
 	require.False(t, tracker.firstReasoningTime.IsZero(), "expected reasoning start time to be recorded")
 	require.Equal(t, tracker.firstReasoningTime, tracker.lastReasoningTime, "expected first reasoning chunk to update last time")
 
@@ -91,4 +99,90 @@ func TestChatMetricsTracker_TrackResponse_ReasoningDuration_UsesLazyNow(t *testi
 		},
 	})
 	require.Greater(t, timingInfo.ReasoningDuration, time.Duration(0), "expected reasoning duration to be recorded")
+}
+
+func TestChatMetricsTracker_RecordMetrics_SkipsTimeToFirstTokenWithoutValidContent(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	originalProvider := MeterProvider
+	originalChatMeter := ChatMeter
+	originalRequestCnt := ChatMetricTRPCAgentGoClientRequestCnt
+	originalTokenUsage := ChatMetricGenAIClientTokenUsage
+	originalOperationDuration := ChatMetricGenAIClientOperationDuration
+	originalServerTimeToFirstToken := ChatMetricGenAIServerTimeToFirstToken
+	originalClientTimeToFirstToken := ChatMetricTRPCAgentGoClientTimeToFirstToken
+	originalTimePerOutputToken := ChatMetricTRPCAgentGoClientTimePerOutputToken
+	originalOutputTokenPerTime := ChatMetricTRPCAgentGoClientOutputTokenPerTime
+	t.Cleanup(func() {
+		MeterProvider = originalProvider
+		ChatMeter = originalChatMeter
+		ChatMetricTRPCAgentGoClientRequestCnt = originalRequestCnt
+		ChatMetricGenAIClientTokenUsage = originalTokenUsage
+		ChatMetricGenAIClientOperationDuration = originalOperationDuration
+		ChatMetricGenAIServerTimeToFirstToken = originalServerTimeToFirstToken
+		ChatMetricTRPCAgentGoClientTimeToFirstToken = originalClientTimeToFirstToken
+		ChatMetricTRPCAgentGoClientTimePerOutputToken = originalTimePerOutputToken
+		ChatMetricTRPCAgentGoClientOutputTokenPerTime = originalOutputTokenPerTime
+	})
+
+	MeterProvider = provider
+	ChatMeter = provider.Meter(metrics.MeterNameChat)
+
+	var err error
+	ChatMetricTRPCAgentGoClientRequestCnt, err = ChatMeter.Int64Counter(metrics.MetricTRPCAgentGoClientRequestCnt)
+	require.NoError(t, err)
+	ChatMetricGenAIClientTokenUsage, err = histogram.NewDynamicInt64Histogram(provider, metrics.MeterNameChat, metrics.MetricGenAIClientTokenUsage)
+	require.NoError(t, err)
+	ChatMetricGenAIClientOperationDuration, err = histogram.NewDynamicFloat64Histogram(provider, metrics.MeterNameChat, metrics.MetricGenAIClientOperationDuration)
+	require.NoError(t, err)
+	ChatMetricGenAIServerTimeToFirstToken, err = histogram.NewDynamicFloat64Histogram(
+		provider,
+		metrics.MeterNameChat,
+		metrics.MetricGenAIServerTimeToFirstToken,
+		metric.WithDescription("Time to first token for server"),
+		metric.WithUnit("s"),
+	)
+	require.NoError(t, err)
+	ChatMetricTRPCAgentGoClientTimeToFirstToken, err = histogram.NewDynamicFloat64Histogram(
+		provider,
+		metrics.MeterNameChat,
+		metrics.MetricTRPCAgentGoClientTimeToFirstToken,
+		metric.WithDescription("Time to first token for client"),
+		metric.WithUnit("s"),
+	)
+	require.NoError(t, err)
+	ChatMetricTRPCAgentGoClientTimePerOutputToken = nil
+	ChatMetricTRPCAgentGoClientOutputTokenPerTime = nil
+
+	ctx := context.Background()
+	tracker := NewChatMetricsTracker(ctx, nil, nil, &model.TimingInfo{}, nil, nil)
+	tracker.TrackResponse(&model.Response{
+		Usage: &model.Usage{
+			PromptTokens:     10,
+			CompletionTokens: 5,
+		},
+	})
+
+	tracker.RecordMetrics()()
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(ctx, &rm))
+
+	metricNames := collectMetricNames(rm)
+	require.Contains(t, metricNames, metrics.MetricTRPCAgentGoClientRequestCnt)
+	require.Contains(t, metricNames, metrics.MetricGenAIClientTokenUsage)
+	require.Contains(t, metricNames, metrics.MetricGenAIClientOperationDuration)
+	require.NotContains(t, metricNames, metrics.MetricGenAIServerTimeToFirstToken)
+	require.NotContains(t, metricNames, metrics.MetricTRPCAgentGoClientTimeToFirstToken)
+}
+
+func collectMetricNames(rm metricdata.ResourceMetrics) []string {
+	var names []string
+	for _, scopeMetrics := range rm.ScopeMetrics {
+		for _, metric := range scopeMetrics.Metrics {
+			names = append(names, metric.Name)
+		}
+	}
+	return names
 }

--- a/internal/telemetry/metric_invoke_agent.go
+++ b/internal/telemetry/metric_invoke_agent.go
@@ -153,8 +153,8 @@ func (t *InvokeAgentTracker) RecordMetrics() func() {
 			InvokeAgentMetricGenAIClientOperationDuration.Record(t.ctx, requestDuration.Seconds(), metric.WithAttributes(otelAttrs...))
 		}
 
-		// Record time to first token
-		if InvokeAgentMetricGenAIClientTimeToFirstToken != nil {
+		// Record time to first token only when a meaningful payload was observed.
+		if t.firstTokenTimeDuration > 0 && InvokeAgentMetricGenAIClientTimeToFirstToken != nil {
 			InvokeAgentMetricGenAIClientTimeToFirstToken.Record(t.ctx, t.firstTokenTimeDuration.Seconds(),
 				metric.WithAttributes(otelAttrs...))
 		}

--- a/internal/telemetry/metric_invoke_agent_test.go
+++ b/internal/telemetry/metric_invoke_agent_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
@@ -651,4 +652,6 @@ func TestInvokeAgentTracker_RecordMetrics_NoTokens(t *testing.T) {
 	if len(rm.ScopeMetrics) == 0 {
 		t.Error("expected metrics to be recorded even without tokens")
 	}
+	metricNames := collectMetricNames(rm)
+	require.NotContains(t, metricNames, metrics.MetricTRPCAgentGoClientTimeToFirstToken)
 }

--- a/internal/telemetry/metric_test.go
+++ b/internal/telemetry/metric_test.go
@@ -197,6 +197,13 @@ func TestChatMetricsTracker_TrackResponse(t *testing.T) {
 
 	// First response
 	response1 := &model.Response{
+		Choices: []model.Choice{
+			{
+				Delta: model.Message{
+					Content: "Hello",
+				},
+			},
+		},
 		Usage: &model.Usage{
 			PromptTokens:     10,
 			CompletionTokens: 5,
@@ -278,6 +285,13 @@ func TestChatMetricsTracker_TrackResponse_NilUsage(t *testing.T) {
 	tracker := NewChatMetricsTracker(ctx, nil, nil, timingInfo, nil, nil)
 
 	response := &model.Response{
+		Choices: []model.Choice{
+			{
+				Delta: model.Message{
+					Content: "Hello",
+				},
+			},
+		},
 		Usage: nil,
 	}
 
@@ -334,7 +348,15 @@ func TestChatMetricsTracker_FirstTokenTimeDuration(t *testing.T) {
 	}
 
 	time.Sleep(10 * time.Millisecond)
-	tracker.TrackResponse(&model.Response{})
+	tracker.TrackResponse(&model.Response{
+		Choices: []model.Choice{
+			{
+				Delta: model.Message{
+					Content: "Hello",
+				},
+			},
+		},
+	})
 
 	if tracker.FirstTokenTimeDuration() == 0 {
 		t.Error("FirstTokenTimeDuration should be non-zero after tracking response")
@@ -543,6 +565,13 @@ func TestChatMetricsTracker_RecordMetrics(t *testing.T) {
 	// Simulate some responses
 	time.Sleep(10 * time.Millisecond)
 	tracker.TrackResponse(&model.Response{
+		Choices: []model.Choice{
+			{
+				Delta: model.Message{
+					Content: "Hello",
+				},
+			},
+		},
 		Usage: &model.Usage{
 			PromptTokens:     10,
 			CompletionTokens: 2,


### PR DESCRIPTION
Only record time_to_first_token after the first meaningful response payload is observed, and skip TTFT histogram samples when no valid content is received. Add tests to ensure empty chunks no longer count as TTFT.

## Summary by Sourcery

将 chat 和 invoke-agent 流程中的 time-to-first-token（TTFT）埋点对齐为：仅在收到有意义的响应负载时才记录，并在未产生有效内容时跳过 TTFT 指标。

Bug Fixes:
- 确保 chat 的 TTFT 只在收到首个有意义的响应负载后才被记录，而不是在任意初始空数据块时记录。
- 当在 chat 或 invoke-agent 流程中未收到任何有效内容时，避免记录 TTFT 直方图数据。

Enhancements:
- 明确 TTFT 指标文档，并在 chat 和 invoke-agent 的遥测中，仅在持续时间为正值时才记录 TTFT。

Tests:
- 扩展 chat 和 invoke-agent 的遥测测试，以覆盖包含空数据块时的 TTFT 行为，并验证在未观察到有意义负载时会省略 TTFT 指标。
- 更新现有的 chat 追踪器测试，加入非空的 choices，使 TTFT 计时由有意义的内容驱动。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align time-to-first-token telemetry for chat and invoke-agent flows to only record when a meaningful response payload is received, and skip TTFT metrics when no valid content is emitted.

Bug Fixes:
- Ensure chat TTFT is only captured after the first meaningful response payload instead of any initial empty chunk.
- Prevent TTFT histograms from being recorded when no valid content is received in chat or invoke-agent flows.

Enhancements:
- Clarify TTFT metric documentation and gate TTFT recording on a positive duration for both chat and invoke-agent telemetry.

Tests:
- Extend chat and invoke-agent telemetry tests to cover TTFT behavior with empty chunks and verify TTFT metrics are omitted when no meaningful payload is observed.
- Update existing chat tracker tests to include non-empty choices so TTFT timing is driven by meaningful content.

</details>