### PR TITLE
[WIP] fix(agent): always register InstructionProcessor to support run-time WithInstruction

### DIFF
--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -205,10 +205,10 @@ func buildRequestProcessorsWithAgent(a *LLMAgent, options *Options) []flow.Reque
 	}
 
 	// 3. Instruction processor - adds instruction content and system prompt.
-	if options.Instruction != "" || options.GlobalInstruction != "" ||
-		len(options.ModelInstructions) > 0 ||
-		len(options.ModelGlobalInstructions) > 0 ||
-		(options.StructuredOutput != nil && options.StructuredOutput.JSONSchema != nil) {
+	// Always register the instruction processor so that run-time options
+	// (e.g. agent.WithInstruction passed to runner.Run) are honoured even
+	// when no static instruction was set at construction time.
+	{
 		instructionOpts := []processor.InstructionRequestProcessorOption{
 			processor.WithOutputSchema(options.OutputSchema),
 		}

--- a/agent/llmagent/llm_agent_test.go
+++ b/agent/llmagent/llm_agent_test.go
@@ -2000,3 +2000,63 @@ func TestLLMAgent_MessageFilterMode(t *testing.T) {
 	require.Equal(t, options.messageTimelineFilterMode, "request")
 	require.Equal(t, options.messageBranchFilterMode, "exact")
 }
+
+// TestLLMAgent_RunOptionInstruction_NoStaticInstruction verifies that
+// InstructionProcessor is registered even when no static instruction is
+// configured at construction time (regression test for the bug where the
+// processor was skipped entirely when options.Instruction == "").
+func TestLLMAgent_RunOptionInstruction_NoStaticInstruction(t *testing.T) {
+	// Agent created WITHOUT any WithInstruction / WithGlobalInstruction.
+	agt := New("test-agent")
+
+	reqProcs := buildRequestProcessorsWithAgent(agt, &agt.option)
+
+	var instrProc *processor.InstructionRequestProcessor
+	for _, rp := range reqProcs {
+		if p, ok := rp.(*processor.InstructionRequestProcessor); ok {
+			instrProc = p
+			break
+		}
+	}
+	// The processor must be present so that run-time WithInstruction works.
+	require.NotNil(t, instrProc,
+		"InstructionRequestProcessor must be registered even when no static instruction is set")
+}
+
+// TestLLMAgent_RunOptionInstruction_OverridesAtRuntime verifies that passing
+// agent.WithInstruction as a RunOption actually injects the instruction into
+// the request when no static instruction was set at construction time.
+func TestLLMAgent_RunOptionInstruction_OverridesAtRuntime(t *testing.T) {
+	const runtimeInstruction = "you are a helpful assistant at runtime"
+
+	// Agent created WITHOUT any WithInstruction.
+	agt := New("test-agent")
+
+	reqProcs := buildRequestProcessorsWithAgent(agt, &agt.option)
+
+	var instrProc *processor.InstructionRequestProcessor
+	for _, rp := range reqProcs {
+		if p, ok := rp.(*processor.InstructionRequestProcessor); ok {
+			instrProc = p
+			break
+		}
+	}
+	require.NotNil(t, instrProc)
+
+	// Simulate what runner.Run does: create an Invocation and apply RunOptions.
+	inv := &agent.Invocation{}
+	agent.WithInstruction(runtimeInstruction)(&inv.RunOptions)
+	agt.setupInvocation(inv)
+
+	req := &model.Request{
+		Messages: []model.Message{},
+	}
+	eventCh := make(chan *event.Event, 10)
+	instrProc.ProcessRequest(context.Background(), inv, req, eventCh)
+
+	// The run-time instruction must have been injected into the request.
+	require.NotEmpty(t, req.Messages,
+		"instruction message should have been prepended to the request")
+	require.Contains(t, req.Messages[0].Content, runtimeInstruction,
+		"run-time instruction should appear in the first message")
+}


### PR DESCRIPTION
## Problem

`InstructionProcessor` was only registered in the pipeline when a static `Instruction`, `GlobalInstruction`, `ModelInstructions`, `ModelGlobalInstructions`, or `StructuredOutput` schema was configured at agent construction time.

This caused a silent bug: if a caller relied **only** on the run-time `agent.WithInstruction()` option (e.g. via `runner.Run(..., agent.WithInstruction("..."))`), the instruction was completely ignored because the processor responsible for injecting it was never added to the pipeline.

## Fix

Unconditionally register `InstructionProcessor`. When no instruction is configured the processor resolves to an empty string and exits early, so there is **no behavioural change for existing users**.

## Changes

- `agent/llmagent/llm_agent.go`: replace the conditional `if` guard with an unconditional block `{}` so `InstructionProcessor` is always wired into the request pipeline.

## Tests

All existing tests pass (`agent/llmagent` + `internal/flow/processor`).

## Summary by Sourcery

Bug Fixes:
- 修复了这样的问题：当在构建 agent 时没有设置静态指令或模式（schema）时，运行时提供的指令（例如通过 `agent.WithInstruction` 提供的指令）不再被忽略。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure runtime-provided instructions (e.g. via agent.WithInstruction) are no longer ignored when no static instruction or schema is set at agent construction time.

</details>