### PR TITLE
docs: use picgo urls for openclaw runtime images

### DIFF
--- a/docs/mkdocs/en/openclaw-runtime.md
+++ b/docs/mkdocs/en/openclaw-runtime.md
@@ -266,27 +266,27 @@ produce the output, and send the result back as a file.
 For example, after a PDF is uploaded, the system can extract requested
 content directly:
 
-<img src="../assets/img/openclaw-runtime/pdf-text-extraction-en.png" alt="Extracting text from a PDF" style="display: block; margin: 20px auto; max-width: 100%; max-height: 700px;" />
+<img src="https://raw.githubusercontent.com/WineChord/trpc-agent-go/picgo_assets/picgo/openclaw-runtime/pdf-text-extraction-en.png" alt="Extracting text from a PDF" style="display: block; margin: 20px auto; max-width: 100%; max-height: 700px;" />
 
 It can also split a PDF into multiple pages and send a new file back:
 
-<img src="../assets/img/openclaw-runtime/pdf-splitting-en.png" alt="Splitting a PDF into multiple files or pages" style="display: block; margin: 20px auto; max-width: 100%; max-height: 760px;" />
+<img src="https://raw.githubusercontent.com/WineChord/trpc-agent-go/picgo_assets/picgo/openclaw-runtime/pdf-splitting-en.png" alt="Splitting a PDF into multiple files or pages" style="display: block; margin: 20px auto; max-width: 100%; max-height: 760px;" />
 
 Voice input can drive document processing as well. In the next example,
 the user asks by voice to merge selected pages into a single PDF:
 
-<img src="../assets/img/openclaw-runtime/voice-pdf-merge-en.png" alt="Merging PDF pages via voice input" style="display: block; margin: 20px auto; max-width: 100%; max-height: 720px;" />
+<img src="https://raw.githubusercontent.com/WineChord/trpc-agent-go/picgo_assets/picgo/openclaw-runtime/voice-pdf-merge-en.png" alt="Merging PDF pages via voice input" style="display: block; margin: 20px auto; max-width: 100%; max-height: 720px;" />
 
 The system can also generate a Word document for reporting directly
 from the input materials:
 
-<img src="../assets/img/openclaw-runtime/voice-word-generation-en.png" alt="Generating a Word document from voice instructions" style="display: block; margin: 20px auto; max-width: 100%; max-height: 760px;" />
+<img src="https://raw.githubusercontent.com/WineChord/trpc-agent-go/picgo_assets/picgo/openclaw-runtime/voice-word-generation-en.png" alt="Generating a Word document from voice instructions" style="display: block; margin: 20px auto; max-width: 100%; max-height: 760px;" />
 
 Excel processing follows the same end-to-end path. In the example
 below, the user asks by voice to keep the first row and delete the
 rest, and the processed spreadsheet is returned directly:
 
-<img src="../assets/img/openclaw-runtime/voice-excel-edit-en.png" alt="Editing an Excel sheet via voice input" style="display: block; margin: 20px auto; max-width: 100%; max-height: 820px;" />
+<img src="https://raw.githubusercontent.com/WineChord/trpc-agent-go/picgo_assets/picgo/openclaw-runtime/voice-excel-edit-en.png" alt="Editing an Excel sheet via voice input" style="display: block; margin: 20px auto; max-width: 100%; max-height: 820px;" />
 
 What these examples show is that one runtime can accept files, process
 multimodal input, execute tools, and return files without requiring a
@@ -297,23 +297,23 @@ separate workflow for each file type.
 In image-understanding scenarios, a picture can go directly into the
 model as multimodal input:
 
-<img src="../assets/img/openclaw-runtime/image-understanding-en.png" alt="Image understanding and recognition" style="display: block; margin: 20px auto; max-width: 100%; max-height: 620px;" />
+<img src="https://raw.githubusercontent.com/WineChord/trpc-agent-go/picgo_assets/picgo/openclaw-runtime/image-understanding-en.png" alt="Image understanding and recognition" style="display: block; margin: 20px auto; max-width: 100%; max-height: 620px;" />
 
 Video scenarios usually go through a "process the media first, then
 hand it to the model" path. In the example below, the user asks for
 the first frame of a video to be extracted and sent back as an image:
 
-<img src="../assets/img/openclaw-runtime/video-frame-extraction-en.png" alt="Processing video and returning a frame" style="display: block; margin: 20px auto; max-width: 100%; max-height: 820px;" />
+<img src="https://raw.githubusercontent.com/WineChord/trpc-agent-go/picgo_assets/picgo/openclaw-runtime/video-frame-extraction-en.png" alt="Processing video and returning a frame" style="display: block; margin: 20px auto; max-width: 100%; max-height: 820px;" />
 
 In video OCR scenarios, the system can first identify the target frame
 and then continue with text extraction. This example first extracts the
 last frame:
 
-<img src="../assets/img/openclaw-runtime/video-ocr-step-1-en.png" alt="Extracting a frame for video OCR, step 1" style="display: block; margin: 20px auto; max-width: 100%; max-height: 820px;" />
+<img src="https://raw.githubusercontent.com/WineChord/trpc-agent-go/picgo_assets/picgo/openclaw-runtime/video-ocr-step-1-en.png" alt="Extracting a frame for video OCR, step 1" style="display: block; margin: 20px auto; max-width: 100%; max-height: 820px;" />
 
 After confirming the target frame, it returns the recognized text:
 
-<img src="../assets/img/openclaw-runtime/video-ocr-step-2-en.png" alt="Returning recognized text from video OCR, step 2" style="display: block; margin: 20px auto; max-width: 100%; max-height: 820px;" />
+<img src="https://raw.githubusercontent.com/WineChord/trpc-agent-go/picgo_assets/picgo/openclaw-runtime/video-ocr-step-2-en.png" alt="Returning recognized text from video OCR, step 2" style="display: block; margin: 20px auto; max-width: 100%; max-height: 820px;" />
 
 The point here is not any single tool in isolation. The point is that
 multimodal input can enter Gateway and still flow through one unified
@@ -328,19 +328,19 @@ systems.
 In the next example, the system first performs a weather query and then
 writes the current conversation into Apple Notes:
 
-<img src="../assets/img/openclaw-runtime/skill-and-apple-notes-en.png" alt="Using a Skill and creating a new Apple Note" style="display: block; margin: 20px auto; max-width: 100%; max-height: 620px;" />
+<img src="https://raw.githubusercontent.com/WineChord/trpc-agent-go/picgo_assets/picgo/openclaw-runtime/skill-and-apple-notes-en.png" alt="Using a Skill and creating a new Apple Note" style="display: block; margin: 20px auto; max-width: 100%; max-height: 620px;" />
 
 The resulting note looks like this:
 
-<img src="../assets/img/openclaw-runtime/apple-notes-result-en.png" alt="Apple Note created successfully" style="display: block; margin: 20px auto; max-width: 100%; max-height: 240px;" />
+<img src="https://raw.githubusercontent.com/WineChord/trpc-agent-go/picgo_assets/picgo/openclaw-runtime/apple-notes-result-en.png" alt="Apple Note created successfully" style="display: block; margin: 20px auto; max-width: 100%; max-height: 240px;" />
 
 Likewise, reminders can be created directly from the conversation:
 
-<img src="../assets/img/openclaw-runtime/create-reminder-en.png" alt="Creating a reminder from the chat" style="display: block; margin: 20px auto; max-width: 100%; max-height: 360px;" />
+<img src="https://raw.githubusercontent.com/WineChord/trpc-agent-go/picgo_assets/picgo/openclaw-runtime/create-reminder-en.png" alt="Creating a reminder from the chat" style="display: block; margin: 20px auto; max-width: 100%; max-height: 360px;" />
 
 And the result looks like this:
 
-<img src="../assets/img/openclaw-runtime/reminder-result-en.png" alt="Reminder created successfully" style="display: block; margin: 20px auto; max-width: 100%; max-height: 320px;" />
+<img src="https://raw.githubusercontent.com/WineChord/trpc-agent-go/picgo_assets/picgo/openclaw-runtime/reminder-result-en.png" alt="Reminder created successfully" style="display: block; margin: 20px auto; max-width: 100%; max-height: 320px;" />
 
 These examples show that the "action" of the runtime does not have to
 stop at text output. The Agent can organize tools and system
@@ -353,13 +353,13 @@ plan rather than immediately. In the example below, the user first
 checks and clears existing jobs, then asks the system to report local
 CPU usage every minute:
 
-<img src="../assets/img/openclaw-runtime/scheduled-tasks-en.png" alt="Managing scheduled tasks" style="display: block; margin: 20px auto; max-width: 100%; max-height: 720px;" />
+<img src="https://raw.githubusercontent.com/WineChord/trpc-agent-go/picgo_assets/picgo/openclaw-runtime/scheduled-tasks-en.png" alt="Managing scheduled tasks" style="display: block; margin: 20px auto; max-width: 100%; max-height: 720px;" />
 
 Besides in-chat commands, the current implementation also provides a
 local Admin UI for viewing instance information, Gateway routes, jobs,
 execution sessions, uploaded files, and debug traces:
 
-<img src="../assets/img/openclaw-runtime/admin-ui-en.png" alt="Admin UI for runtime inspection and debugging" style="display: block; margin: 20px auto; max-width: 100%; max-height: 520px;" />
+<img src="https://raw.githubusercontent.com/WineChord/trpc-agent-go/picgo_assets/picgo/openclaw-runtime/admin-ui-en.png" alt="Admin UI for runtime inspection and debugging" style="display: block; margin: 20px auto; max-width: 100%; max-height: 520px;" />
 
 This is the runtime support layer. It does not directly determine
 whether the model is clever, but it directly determines whether the

--- a/docs/mkdocs/zh/openclaw-runtime.md
+++ b/docs/mkdocs/zh/openclaw-runtime.md
@@ -241,26 +241,26 @@ curl -sS 'http://127.0.0.1:8080/healthz'
 
 例如，上传 PDF 后可以直接提取指定内容：
 
-<img src="../assets/img/openclaw-runtime/telegram-pdf-text-extraction.png" alt="提取 PDF 文字" style="display: block; margin: 20px auto; max-width: 100%; max-height: 700px;" />
+<img src="https://raw.githubusercontent.com/WineChord/trpc-agent-go/picgo_assets/picgo/openclaw-runtime/telegram-pdf-text-extraction.png" alt="提取 PDF 文字" style="display: block; margin: 20px auto; max-width: 100%; max-height: 700px;" />
 
 也可以把一个 PDF 拆分为多个页面后再回传新文件：
 
-<img src="../assets/img/openclaw-runtime/telegram-pdf-splitting.png" alt="拆分 PDF" style="display: block; margin: 20px auto; max-width: 100%; max-height: 760px;" />
+<img src="https://raw.githubusercontent.com/WineChord/trpc-agent-go/picgo_assets/picgo/openclaw-runtime/telegram-pdf-splitting.png" alt="拆分 PDF" style="display: block; margin: 20px auto; max-width: 100%; max-height: 760px;" />
 
 语音输入同样可以驱动文档处理。下面这个例子中，
 用户通过语音要求把指定页面合并成一个 PDF：
 
-<img src="../assets/img/openclaw-runtime/telegram-voice-pdf-merge.jpg" alt="通过语音合并 PDF" style="display: block; margin: 20px auto; max-width: 100%; max-height: 720px;" />
+<img src="https://raw.githubusercontent.com/WineChord/trpc-agent-go/picgo_assets/picgo/openclaw-runtime/telegram-voice-pdf-merge.jpg" alt="通过语音合并 PDF" style="display: block; margin: 20px auto; max-width: 100%; max-height: 720px;" />
 
 系统也可以基于输入材料直接生成汇报用 Word 文档：
 
-<img src="../assets/img/openclaw-runtime/telegram-voice-word-generation.jpg" alt="通过语音生成 Word 文档" style="display: block; margin: 20px auto; max-width: 100%; max-height: 760px;" />
+<img src="https://raw.githubusercontent.com/WineChord/trpc-agent-go/picgo_assets/picgo/openclaw-runtime/telegram-voice-word-generation.jpg" alt="通过语音生成 Word 文档" style="display: block; margin: 20px auto; max-width: 100%; max-height: 760px;" />
 
 Excel 处理也沿用同一条链路。下面这个例子里，
 用户通过语音要求保留第一行并删除其余行，
 处理后的表格文件会直接回传：
 
-<img src="../assets/img/openclaw-runtime/telegram-voice-excel-edit.jpg" alt="通过语音操作 Excel" style="display: block; margin: 20px auto; max-width: 100%; max-height: 820px;" />
+<img src="https://raw.githubusercontent.com/WineChord/trpc-agent-go/picgo_assets/picgo/openclaw-runtime/telegram-voice-excel-edit.jpg" alt="通过语音操作 Excel" style="display: block; margin: 20px auto; max-width: 100%; max-height: 820px;" />
 
 这组能力说明的是，同一套 Runtime 可以同时承接文件输入、
 多模态理解、工具执行和文件输出，而不必为不同文件类型
@@ -270,21 +270,21 @@ Excel 处理也沿用同一条链路。下面这个例子里，
 
 在图像理解场景下，图片可以直接作为多模态输入进入模型能力：
 
-<img src="../assets/img/openclaw-runtime/telegram-image-understanding.png" alt="图片识别" style="display: block; margin: 20px auto; max-width: 100%; max-height: 620px;" />
+<img src="https://raw.githubusercontent.com/WineChord/trpc-agent-go/picgo_assets/picgo/openclaw-runtime/telegram-image-understanding.png" alt="图片识别" style="display: block; margin: 20px auto; max-width: 100%; max-height: 620px;" />
 
 视频场景则通常要经过“先处理媒体，再交给模型”的链路。
 例如下面这个例子中，用户要求提取视频第一帧并回发图片：
 
-<img src="../assets/img/openclaw-runtime/telegram-video-frame-extraction.jpg" alt="视频处理" style="display: block; margin: 20px auto; max-width: 100%; max-height: 820px;" />
+<img src="https://raw.githubusercontent.com/WineChord/trpc-agent-go/picgo_assets/picgo/openclaw-runtime/telegram-video-frame-extraction.jpg" alt="视频处理" style="display: block; margin: 20px auto; max-width: 100%; max-height: 820px;" />
 
 在视频 OCR 场景中，系统可以先定位目标帧，再继续做文字识别。
 下面这个例子先提取出最后一帧：
 
-<img src="../assets/img/openclaw-runtime/telegram-video-ocr-step-1.jpg" alt="视频提取文字 1" style="display: block; margin: 20px auto; max-width: 100%; max-height: 820px;" />
+<img src="https://raw.githubusercontent.com/WineChord/trpc-agent-go/picgo_assets/picgo/openclaw-runtime/telegram-video-ocr-step-1.jpg" alt="视频提取文字 1" style="display: block; margin: 20px auto; max-width: 100%; max-height: 820px;" />
 
 确认目标帧后，再返回识别出的文字内容：
 
-<img src="../assets/img/openclaw-runtime/telegram-video-ocr-step-2.jpg" alt="视频提取文字 2" style="display: block; margin: 20px auto; max-width: 100%; max-height: 820px;" />
+<img src="https://raw.githubusercontent.com/WineChord/trpc-agent-go/picgo_assets/picgo/openclaw-runtime/telegram-video-ocr-step-2.jpg" alt="视频提取文字 2" style="display: block; margin: 20px auto; max-width: 100%; max-height: 820px;" />
 
 这部分展示的重点不是某一个具体工具，
 而是多模态输入在进入 Gateway 后，
@@ -298,19 +298,19 @@ Excel 处理也沿用同一条链路。下面这个例子里，
 例如下面这个例子中，系统先做天气查询，
 再把当前聊天记录写入 Apple 备忘录：
 
-<img src="../assets/img/openclaw-runtime/telegram-skill-apple-notes.png" alt="使用 Skill 与新建备忘录" style="display: block; margin: 20px auto; max-width: 100%; max-height: 620px;" />
+<img src="https://raw.githubusercontent.com/WineChord/trpc-agent-go/picgo_assets/picgo/openclaw-runtime/telegram-skill-apple-notes.png" alt="使用 Skill 与新建备忘录" style="display: block; margin: 20px auto; max-width: 100%; max-height: 620px;" />
 
 对应的备忘录结果如下：
 
-<img src="../assets/img/openclaw-runtime/apple-notes-result.png" alt="Apple 备忘录创建成功" style="display: block; margin: 20px auto; max-width: 100%; max-height: 240px;" />
+<img src="https://raw.githubusercontent.com/WineChord/trpc-agent-go/picgo_assets/picgo/openclaw-runtime/apple-notes-result.png" alt="Apple 备忘录创建成功" style="display: block; margin: 20px auto; max-width: 100%; max-height: 240px;" />
 
 类似地，也可以在会话中直接创建提醒事项：
 
-<img src="../assets/img/openclaw-runtime/create-reminder.png" alt="创建提醒事项" style="display: block; margin: 20px auto; max-width: 100%; max-height: 360px;" />
+<img src="https://raw.githubusercontent.com/WineChord/trpc-agent-go/picgo_assets/picgo/openclaw-runtime/create-reminder.png" alt="创建提醒事项" style="display: block; margin: 20px auto; max-width: 100%; max-height: 360px;" />
 
 对应结果如下：
 
-<img src="../assets/img/openclaw-runtime/reminder-result.png" alt="提醒事项创建成功" style="display: block; margin: 20px auto; max-width: 100%; max-height: 320px;" />
+<img src="https://raw.githubusercontent.com/WineChord/trpc-agent-go/picgo_assets/picgo/openclaw-runtime/reminder-result.png" alt="提醒事项创建成功" style="display: block; margin: 20px auto; max-width: 100%; max-height: 320px;" />
 
 这类场景说明，运行时中的“动作”不必局限在文本输出，
 Agent 可以真正把工具和系统能力组织成一条可执行链路。
@@ -321,13 +321,13 @@ Agent 可以真正把工具和系统能力组织成一条可执行链路。
 下面这个例子中，用户先查看并清理当前任务，
 再要求系统每分钟回报一次本机 CPU 使用率：
 
-<img src="../assets/img/openclaw-runtime/scheduled-tasks.png" alt="定时任务" style="display: block; margin: 20px auto; max-width: 100%; max-height: 720px;" />
+<img src="https://raw.githubusercontent.com/WineChord/trpc-agent-go/picgo_assets/picgo/openclaw-runtime/scheduled-tasks.png" alt="定时任务" style="display: block; margin: 20px auto; max-width: 100%; max-height: 720px;" />
 
 除了会话内命令，当前实现还提供本地 Admin UI，
 用于查看实例信息、Gateway 路由、任务、执行会话、
 上传文件和调试痕迹：
 
-<img src="../assets/img/openclaw-runtime/admin-ui.png" alt="Admin UI" style="display: block; margin: 20px auto; max-width: 100%; max-height: 520px;" />
+<img src="https://raw.githubusercontent.com/WineChord/trpc-agent-go/picgo_assets/picgo/openclaw-runtime/admin-ui.png" alt="Admin UI" style="display: block; margin: 20px auto; max-width: 100%; max-height: 520px;" />
 
 这一部分对应的是运行时配套能力。
 它不直接决定模型是否聪明，但直接决定系统是否可维护、


### PR DESCRIPTION
## Summary
- upload the OpenClaw runtime guide screenshots with PicGo to the `picgo_assets` branch on the fork
- switch the English and Chinese runtime guides to those hosted image URLs
- keep the article content unchanged and only replace image references

## Testing
- python -m mkdocs build -f docs/mkdocs.yml -d /tmp/trpc-agent-go-docs-site-picgo

## 由 Sourcery 提供的总结

文档：
- 将英文和中文的 OpenClaw 运行时指南中的所有截图，统一切换为使用由 PicGo 托管的 GitHub 图片 URL，同时保持文字内容不变。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Switch English and Chinese OpenClaw runtime guides to use PicGo-hosted GitHub image URLs for all screenshots, keeping the written content unchanged.

</details>