### PR TITLE
skill: use yaml.v3 for frontmatter parsing to handle multi-line scalars

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	golang.org/x/text v0.21.0
 	google.golang.org/grpc v1.65.0
 	google.golang.org/protobuf v1.34.2
+	gopkg.in/yaml.v3 v3.0.1
 	trpc.group/trpc-go/trpc-a2a-go v0.2.5
 	trpc.group/trpc-go/trpc-mcp-go v0.0.10
 )
@@ -83,5 +84,4 @@ require (
 	golang.org/x/sys v0.30.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240822170219-fc7c04adadcd // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240822170219-fc7c04adadcd // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/skill/repository.go
+++ b/skill/repository.go
@@ -18,14 +18,14 @@
 package skill
 
 import (
-	"bufio"
-	"errors"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 // skillFile is the canonical skill definition filename.
@@ -223,116 +223,70 @@ func (r *FSRepository) readDocs(dir string) []Doc {
 }
 
 // parseSummary returns front matter name/description only.
+// YAML parse errors are treated as empty metadata (matching
+// openclaw/internal/skills.Repository.index behaviour) so that a skill
+// with malformed frontmatter is still discoverable via folder name.
 func parseSummary(path string) (Summary, error) {
 	b, err := os.ReadFile(path)
 	if err != nil {
 		return Summary{}, err
 	}
-	fm, _ := splitFrontMatter(string(b))
-	s := Summary{
+	fm, _, _ := splitFrontMatter(string(b))
+	if fm == nil {
+		fm = map[string]string{}
+	}
+	return Summary{
 		Name:        fm["name"],
 		Description: fm["description"],
-	}
-	return s, nil
+	}, nil
 }
 
 // parseFull returns front matter and the Markdown body.
+// Like parseSummary, YAML errors are non-fatal; the body is always
+// returned so the skill remains usable with degraded metadata.
 func parseFull(path string) (Summary, string, error) {
 	b, err := os.ReadFile(path)
 	if err != nil {
 		return Summary{}, "", err
 	}
-	text := string(b)
-	fm, body := splitFrontMatter(text)
-	s := Summary{
+	fm, body, _ := splitFrontMatter(string(b))
+	if fm == nil {
+		fm = map[string]string{}
+	}
+	return Summary{
 		Name:        fm["name"],
 		Description: fm["description"],
-	}
-	return s, body, nil
+	}, body, nil
 }
 
-// readFrontMatter reads YAML front matter block into a simple map.
-func readFrontMatter(r *bufio.Reader) (map[string]string, string,
-	error) {
-	line, err := r.ReadString('\n')
-	if err != nil {
-		return nil, "", err
-	}
-	if strings.TrimSpace(line) != "---" {
-		return nil, "", errors.New("no front matter")
-	}
-	m := map[string]string{}
-	var b strings.Builder
-	for {
-		l, err2 := r.ReadString('\n')
-		if err2 != nil {
-			return nil, "", err2
-		}
-		if strings.TrimSpace(l) == "---" {
-			break
-		}
-		b.WriteString(l)
-	}
-	for _, l := range strings.Split(b.String(), "\n") {
-		l = strings.TrimSpace(l)
-		if l == "" || strings.HasPrefix(l, "#") {
-			continue
-		}
-		// crude YAML: key: value
-		if i := strings.Index(l, ":"); i >= 0 {
-			k := strings.TrimSpace(l[:i])
-			v := strings.TrimSpace(l[i+1:])
-			m[k] = strings.Trim(v, " \"'")
-		}
-	}
-	rest, _ := ioReadAll(r)
-	return m, rest, nil
-}
-
-// splitFrontMatter splits text into map and body.
-func splitFrontMatter(text string) (map[string]string, string) {
+// splitFrontMatter splits text into a map and body using proper YAML parsing
+// so that multi-line scalars (>, |, etc.) are handled correctly.
+// It returns a non-nil error when the delimited YAML block is malformed,
+// matching the error semantics of openclaw/internal/skills.parseFrontMatter.
+// Missing front matter (no opening/closing ---) is not an error; callers
+// fall back to the folder name in that case.
+func splitFrontMatter(text string) (map[string]string, string, error) {
 	text = strings.ReplaceAll(text, "\r\n", "\n")
 	if !strings.HasPrefix(text, "---\n") {
-		return map[string]string{}, text
+		return map[string]string{}, text, nil
 	}
 	idx := strings.Index(text[4:], "\n---\n")
 	if idx < 0 {
-		// No closing; treat whole as body.
-		return map[string]string{}, text
+		return map[string]string{}, text, nil
 	}
 	fm := text[4 : 4+idx]
 	body := text[4+idx+5:]
-	m := map[string]string{}
-	for _, l := range strings.Split(fm, "\n") {
-		l = strings.TrimSpace(l)
-		if l == "" || strings.HasPrefix(l, "#") {
-			continue
-		}
-		if i := strings.Index(l, ":"); i >= 0 {
-			k := strings.TrimSpace(l[:i])
-			v := strings.TrimSpace(l[i+1:])
-			m[k] = strings.Trim(v, " \"'")
+	raw := map[string]any{}
+	if err := yaml.Unmarshal([]byte(fm), &raw); err != nil {
+		return nil, body, fmt.Errorf("invalid YAML front matter: %w", err)
+	}
+	m := make(map[string]string, len(raw))
+	for k, v := range raw {
+		if s, ok := v.(string); ok {
+			m[k] = strings.TrimSpace(s)
 		}
 	}
-	return m, body
-}
-
-func ioReadAll(r *bufio.Reader) (string, error) {
-	var b strings.Builder
-	for {
-		s, err := r.ReadString('\n')
-		b.WriteString(s)
-		if err != nil {
-			if errors.Is(err, os.ErrClosed) {
-				break
-			}
-			if err.Error() == "EOF" {
-				break
-			}
-			return b.String(), nil
-		}
-	}
-	return b.String(), nil
+	return m, body, nil
 }
 
 func isDocFile(name string) bool {

--- a/skill/repository_test.go
+++ b/skill/repository_test.go
@@ -14,10 +14,8 @@ package skill
 import (
 	"archive/tar"
 	"archive/zip"
-	"bufio"
 	"bytes"
 	"compress/gzip"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -292,24 +290,15 @@ func TestParseHelpers_And_DocFlags(t *testing.T) {
 	require.Equal(t, "nm", full.Name)
 	require.Contains(t, body, "Body here")
 
-	// readFrontMatter: missing leading '---' should error.
-	rd := bufio.NewReader(strings.NewReader("nope\n"))
-	_, _, err = readFrontMatter(rd)
-	require.Error(t, err)
-
 	// splitFrontMatter variations.
-	m, bod := splitFrontMatter("hello")
+	m, bod, fmErr := splitFrontMatter("hello")
+	require.NoError(t, fmErr)
 	require.Equal(t, 0, len(m))
 	require.Equal(t, "hello", bod)
-	m, bod = splitFrontMatter("---\nname: z\n---\nB")
+	m, bod, fmErr = splitFrontMatter("---\nname: z\n---\nB")
+	require.NoError(t, fmErr)
 	require.Equal(t, "z", m["name"])
 	require.Equal(t, "B", bod)
-
-	// ioReadAll helper returns the remaining text.
-	rd2 := bufio.NewReader(strings.NewReader("A\nB\n"))
-	s, err := ioReadAll(rd2)
-	require.NoError(t, err)
-	require.Equal(t, "A\nB\n", s)
 
 	// isDocFile helper
 	require.True(t, isDocFile("x.md"))
@@ -345,32 +334,111 @@ func TestFSRepository_DuplicateSkill_PrefersFirst(t *testing.T) {
 
 func TestSplitFrontMatter_NoClosing(t *testing.T) {
 	txt := "---\nname: z\n"
-	m, body := splitFrontMatter(txt)
+	m, body, err := splitFrontMatter(txt)
+	require.NoError(t, err)
 	// No closing delimiter: body should be original text.
 	require.Equal(t, 0, len(m))
 	require.Equal(t, txt, body)
 }
 
-// errAfterReader returns one line then a non-EOF error to exercise the
-// ioReadAll branch that returns accumulated text on unexpected errors.
-type errAfterReader struct {
-	gave bool
-}
-
-func (e *errAfterReader) Read(p []byte) (int, error) {
-	if !e.gave {
-		e.gave = true
-		copy(p, []byte("A\n"))
-		return 2, nil
+func TestSplitFrontMatter_MultiLineDescription(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantName string
+		wantDesc string
+		wantBody string
+	}{
+		{
+			name: "folded block scalar (>)",
+			input: "---\nname: my-skill\ndescription: >\n" +
+				"  First line of desc.\n  Second line of desc.\n" +
+				"---\n# Body\n",
+			wantName: "my-skill",
+			wantDesc: "First line of desc. Second line of desc.",
+			wantBody: "# Body\n",
+		},
+		{
+			name: "literal block scalar (|)",
+			input: "---\nname: my-skill\ndescription: |\n" +
+				"  Line one.\n  Line two.\n" +
+				"---\n# Body\n",
+			wantName: "my-skill",
+			wantDesc: "Line one.\nLine two.",
+			wantBody: "# Body\n",
+		},
+		{
+			name: "folded strip (>-)",
+			input: "---\nname: my-skill\ndescription: >-\n" +
+				"  No trailing newline.\n" +
+				"---\n# Body\n",
+			wantName: "my-skill",
+			wantDesc: "No trailing newline.",
+			wantBody: "# Body\n",
+		},
+		{
+			name: "folded with embedded colons",
+			input: "---\nname: multi-lang-tool\ndescription: >\n" +
+				"  A tool for translations. Usage: invoke \"skill: multi-lang-tool\".\n" +
+				"---\n# Skill Body\n",
+			wantName: "multi-lang-tool",
+			wantDesc: "A tool for translations. Usage: invoke \"skill: multi-lang-tool\".",
+			wantBody: "# Skill Body\n",
+		},
 	}
-	return 0, errors.New("boom")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, body, err := splitFrontMatter(tc.input)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantName, m["name"])
+			require.Equal(t, tc.wantDesc, m["description"])
+			require.Equal(t, tc.wantBody, body)
+		})
+	}
 }
 
-func TestIOReadAll_NonEOFErrorReturnsAccumulated(t *testing.T) {
-	rd := bufio.NewReader(&errAfterReader{})
-	s, err := ioReadAll(rd)
+func TestSplitFrontMatter_InvalidYAMLReturnsError(t *testing.T) {
+	input := "---\n: invalid yaml [\n---\nbody\n"
+	_, _, err := splitFrontMatter(input)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid YAML front matter")
+}
+
+func TestSplitFrontMatter_TrimSpace(t *testing.T) {
+	input := "---\nname: \" my-skill \"\ndescription: |+\n  hello\n\n\n---\nbody\n"
+	m, body, err := splitFrontMatter(input)
 	require.NoError(t, err)
-	require.Equal(t, "A\n", s)
+	require.Equal(t, "my-skill", m["name"])
+	require.Equal(t, "hello", m["description"])
+	require.Equal(t, "body\n", body)
+}
+
+func TestFSRepository_MalformedYAML_StillDiscoverable(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "bad-yaml")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+
+	// Valid --- delimiters but malformed YAML content between them.
+	err := os.WriteFile(
+		filepath.Join(dir, skillFile),
+		[]byte("---\n: invalid yaml [\n---\n# Body\n"),
+		0o644,
+	)
+	require.NoError(t, err)
+
+	repo, err := NewFSRepository(root)
+	require.NoError(t, err)
+
+	// Skill should still be discovered using folder name.
+	sums := repo.Summaries()
+	require.Len(t, sums, 1)
+	require.Equal(t, "bad-yaml", sums[0].Name)
+
+	// Get should return the body even though metadata is empty.
+	sk, err := repo.Get("bad-yaml")
+	require.NoError(t, err)
+	require.Equal(t, "bad-yaml", sk.Summary.Name)
+	require.Contains(t, sk.Body, "# Body")
 }
 
 func TestFSRepository_Summaries_IgnoresBrokenAfterScan(t *testing.T) {
@@ -405,32 +473,6 @@ func TestParseFull_ErrorOnMissingFile(t *testing.T) {
 	_, _, err := parseFull(filepath.Join(t.TempDir(),
 		"does-not-exist.md"))
 	require.Error(t, err)
-}
-
-func TestReadFrontMatter_UnclosedReturnsError(t *testing.T) {
-	rd := bufio.NewReader(strings.NewReader(
-		"---\nkey: v\n"))
-	_, _, err := readFrontMatter(rd)
-	require.Error(t, err)
-}
-
-// closedAfterReader yields one line then os.ErrClosed.
-type closedAfterReader struct{ gave bool }
-
-func (c *closedAfterReader) Read(p []byte) (int, error) {
-	if !c.gave {
-		c.gave = true
-		copy(p, []byte("X\n"))
-		return 2, nil
-	}
-	return 0, os.ErrClosed
-}
-
-func TestIOReadAll_ClosedReturnsAccumulated(t *testing.T) {
-	rd := bufio.NewReader(&closedAfterReader{})
-	s, err := ioReadAll(rd)
-	require.NoError(t, err)
-	require.Equal(t, "X\n", s)
 }
 
 func TestFSRepository_Summaries_NameFallback(t *testing.T) {


### PR DESCRIPTION
## Summary by Sourcery

在确保元数据格式错误不会导致失败（从而技能依然可被发现和使用）的前提下，为技能使用基于 YAML v3 的 front matter 解析。

增强内容：
- 用基于 `yaml.v3` 的解析替换自定义 front matter 解析器，以正确处理多行标量，并对字符串值进行去空白处理。
- 在摘要/全文解析中，将格式错误的 YAML front matter 视为非致命错误，这样元数据有问题的技能仍然可以通过文件夹名称进行索引，其正文内容也依然可访问。

构建：
- 将 `gopkg.in/yaml.v3` 提升为 front matter 解析的直接依赖。

测试：
- 扩展仓库 front matter 测试，覆盖多行 YAML 标量、无效 YAML 的错误处理、空白字符修剪，以及在元数据格式错误情况下的行为，同时移除对已废弃 helper 的测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Use YAML v3-based front matter parsing for skills while keeping malformed metadata non-fatal so skills remain discoverable and usable.

Enhancements:
- Replace custom front matter parser with yaml.v3-based parsing that correctly handles multi-line scalars and trims string values.
- Treat malformed YAML front matter as non-fatal in summary/full parsing so skills with bad metadata are still indexed by folder name and their bodies remain accessible.

Build:
- Promote gopkg.in/yaml.v3 to a direct dependency for front matter parsing.

Tests:
- Expand repository front matter tests to cover multi-line YAML scalars, invalid YAML error handling, whitespace trimming, and behavior with malformed metadata while removing tests for deprecated helpers.

</details>