### PR TITLE
{agent, telemetry}: record stream trace attributes in invoke_agent span

### DIFF
--- a/agent/a2aagent/a2a_agent.go
+++ b/agent/a2aagent/a2a_agent.go
@@ -159,11 +159,24 @@ func (r *A2AAgent) validateA2ARequestOptions(invocation *agent.Invocation) error
 
 // Run implements the Agent interface
 func (r *A2AAgent) Run(ctx context.Context, invocation *agent.Invocation) (<-chan *event.Event, error) {
-	var err error
-	ctx, span := trace.Tracer.Start(ctx, fmt.Sprintf("%s %s", itelemetry.OperationInvokeAgent, r.name))
-	itelemetry.TraceBeforeInvokeAgent(span, invocation, r.description, "", nil)
 	useStreaming := r.shouldUseStreaming(invocation)
-	tracker := itelemetry.NewInvokeAgentTracker(ctx, invocation, useStreaming, &err)
+	ctx, span := trace.Tracer.Start(ctx, fmt.Sprintf("%s %s", itelemetry.OperationInvokeAgent, r.name))
+	traceAttrs := &itelemetry.TraceBeforeInvokeAgentAttributes{
+		SpanAttributes:   invocation.RunOptions.SpanAttributes,
+		InputMessages:    []model.Message{invocation.Message},
+		AgentName:        invocation.AgentName,
+		InvocationID:     invocation.InvocationID,
+		AgentDescription: r.description,
+		Stream:           &useStreaming,
+	}
+	if invocation.Session != nil {
+		traceAttrs.SessionID = invocation.Session.ID
+		traceAttrs.UserID = invocation.Session.UserID
+	}
+	itelemetry.TraceBeforeInvokeAgent(span, traceAttrs)
+
+	var err error
+	tracker := itelemetry.NewInvokeAgentTracker(ctx, invocation, &useStreaming, &err)
 
 	if r.a2aClient == nil {
 		span.SetStatus(codes.Error, "A2A client is nil")

--- a/agent/chainagent/chain_agent.go
+++ b/agent/chainagent/chain_agent.go
@@ -85,9 +85,23 @@ func (a *ChainAgent) executeChainRun(
 	eventChan chan<- *event.Event,
 ) {
 	ctx, span := trace.Tracer.Start(ctx, fmt.Sprintf("%s %s", itelemetry.OperationInvokeAgent, a.name))
-	itelemetry.TraceBeforeInvokeAgent(span, invocation, "chain-agent", "", nil)
+	stream := resolveInvokeAgentStream(invocation, nil)
+
+	traceAttrs := &itelemetry.TraceBeforeInvokeAgentAttributes{
+		SpanAttributes:   invocation.RunOptions.SpanAttributes,
+		InputMessages:    []model.Message{invocation.Message},
+		AgentName:        invocation.AgentName,
+		InvocationID:     invocation.InvocationID,
+		AgentDescription: "chain-agent",
+		Stream:           stream,
+	}
+	if invocation.Session != nil {
+		traceAttrs.SessionID = invocation.Session.ID
+		traceAttrs.UserID = invocation.Session.UserID
+	}
+	itelemetry.TraceBeforeInvokeAgent(span, traceAttrs)
 	var trackerErr error
-	tracker := itelemetry.NewInvokeAgentTracker(ctx, invocation, false, &trackerErr)
+	tracker := itelemetry.NewInvokeAgentTracker(ctx, invocation, stream, &trackerErr)
 	defer func() {
 		tracker.RecordMetrics()()
 		span.End()
@@ -113,6 +127,19 @@ func (a *ChainAgent) executeChainRun(
 		e = a.handleAfterAgentCallbacks(ctx, invocation, eventChan, e)
 	}
 	itelemetry.TraceAfterInvokeAgent(span, e, tokenUsage, tracker.FirstTokenTimeDuration())
+}
+
+func resolveInvokeAgentStream(
+	invocation *agent.Invocation,
+	genCfg *model.GenerationConfig,
+) *bool {
+	if invocation != nil && invocation.RunOptions.Stream != nil {
+		return invocation.RunOptions.Stream
+	}
+	if genCfg != nil {
+		return &genCfg.Stream
+	}
+	return nil
 }
 
 // setupInvocation prepares the invocation for execution.

--- a/agent/graphagent/graph_agent.go
+++ b/agent/graphagent/graph_agent.go
@@ -116,7 +116,18 @@ func (ga *GraphAgent) Run(ctx context.Context, invocation *agent.Invocation) (<-
 // pipeline and forwards all events to the provided output channel.
 func (ga *GraphAgent) runWithBarrier(ctx context.Context, invocation *agent.Invocation, out chan<- *event.Event) {
 	ctx, span := trace.Tracer.Start(ctx, fmt.Sprintf("%s %s", itelemetry.OperationInvokeAgent, invocation.AgentName))
-	itelemetry.TraceBeforeInvokeAgent(span, invocation, ga.description, "", nil)
+	traceAttrs := &itelemetry.TraceBeforeInvokeAgentAttributes{
+		SpanAttributes:   invocation.RunOptions.SpanAttributes,
+		InputMessages:    []model.Message{invocation.Message},
+		AgentName:        invocation.AgentName,
+		InvocationID:     invocation.InvocationID,
+		AgentDescription: ga.description,
+	}
+	if invocation.Session != nil {
+		traceAttrs.SessionID = invocation.Session.ID
+		traceAttrs.UserID = invocation.Session.UserID
+	}
+	itelemetry.TraceBeforeInvokeAgent(span, traceAttrs)
 	defer span.End()
 	defer close(out)
 	// Emit a barrier event and wait for completion in a dedicated goroutine so that the runner can append all prior

--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -618,24 +618,35 @@ func (a *LLMAgent) Run(ctx context.Context, invocation *agent.Invocation) (e <-c
 			a.name,
 		),
 	)
-	effectiveGenConfig := a.genConfig
-	if invocation.RunOptions.Stream != nil {
-		effectiveGenConfig.Stream = *invocation.RunOptions.Stream
-	}
+	stream := resolveInvokeAgentStream(invocation, &a.genConfig)
 
 	promptText := a.systemPromptForInvocation(invocation) +
 		a.instructionForInvocation(invocation)
-	itelemetry.TraceBeforeInvokeAgent(
-		span,
-		invocation,
-		a.description,
-		promptText,
-		&effectiveGenConfig,
-	)
+	traceAttrs := &itelemetry.TraceBeforeInvokeAgentAttributes{
+		SpanAttributes:     invocation.RunOptions.SpanAttributes,
+		InputMessages:      []model.Message{invocation.Message},
+		AgentName:          invocation.AgentName,
+		InvocationID:       invocation.InvocationID,
+		AgentDescription:   a.description,
+		SystemInstructions: promptText,
+		Stop:               a.genConfig.Stop,
+		Stream:             stream,
+		FrequencyPenalty:   a.genConfig.FrequencyPenalty,
+		MaxTokens:          a.genConfig.MaxTokens,
+		PresencePenalty:    a.genConfig.PresencePenalty,
+		Temperature:        a.genConfig.Temperature,
+		TopP:               a.genConfig.TopP,
+		ThinkingEnabled:    a.genConfig.ThinkingEnabled,
+	}
+	if invocation.Session != nil {
+		traceAttrs.SessionID = invocation.Session.ID
+		traceAttrs.UserID = invocation.Session.UserID
+	}
+	itelemetry.TraceBeforeInvokeAgent(span, traceAttrs)
 	tracker := itelemetry.NewInvokeAgentTracker(
 		ctx,
 		invocation,
-		effectiveGenConfig.Stream,
+		stream,
 		&err,
 	)
 
@@ -655,6 +666,19 @@ func (a *LLMAgent) Run(ctx context.Context, invocation *agent.Invocation) (e <-c
 	}
 
 	return a.wrapEventChannelWithTelemetry(ctx, invocation, flowEventChan, span, tracker), nil
+}
+
+func resolveInvokeAgentStream(
+	invocation *agent.Invocation,
+	genCfg *model.GenerationConfig,
+) *bool {
+	if invocation != nil && invocation.RunOptions.Stream != nil {
+		return invocation.RunOptions.Stream
+	}
+	if genCfg != nil {
+		return &genCfg.Stream
+	}
+	return nil
 }
 
 // executeAgentFlow executes the agent flow with before agent callbacks.

--- a/graph/state_graph.go
+++ b/graph/state_graph.go
@@ -2120,14 +2120,14 @@ func mapParentInputFromLastResponse(
 func resolveInvokeAgentStream(
 	invocation *agent.Invocation,
 	genCfg *model.GenerationConfig,
-) bool {
+) *bool {
 	if invocation != nil && invocation.RunOptions.Stream != nil {
-		return *invocation.RunOptions.Stream
+		return invocation.RunOptions.Stream
 	}
 	if genCfg != nil {
-		return genCfg.Stream
+		return &genCfg.Stream
 	}
-	return false
+	return nil
 }
 
 func setSubgraphInterruptState(
@@ -2240,15 +2240,30 @@ func NewAgentNodeFunc(agentName string, opts ...Option) NodeFunc {
 			cfg.userInputKey,
 		)
 
-		itelemetry.TraceBeforeInvokeAgent(
-			span,
-			invocation,
-			targetAgent.Info().Description,
-			"",
-			cfg.llmGenerationConfig,
-		)
-
 		stream := resolveInvokeAgentStream(invocation, cfg.llmGenerationConfig)
+		traceAttrs := &itelemetry.TraceBeforeInvokeAgentAttributes{
+			SpanAttributes:   invocation.RunOptions.SpanAttributes,
+			InputMessages:    []model.Message{invocation.Message},
+			AgentName:        invocation.AgentName,
+			InvocationID:     invocation.InvocationID,
+			AgentDescription: targetAgent.Info().Description,
+			Stream:           stream,
+		}
+		if invocation.Session != nil {
+			traceAttrs.SessionID = invocation.Session.ID
+			traceAttrs.UserID = invocation.Session.UserID
+		}
+		if cfg.llmGenerationConfig != nil {
+			traceAttrs.Stop = cfg.llmGenerationConfig.Stop
+			traceAttrs.FrequencyPenalty = cfg.llmGenerationConfig.FrequencyPenalty
+			traceAttrs.MaxTokens = cfg.llmGenerationConfig.MaxTokens
+			traceAttrs.PresencePenalty = cfg.llmGenerationConfig.PresencePenalty
+			traceAttrs.Temperature = cfg.llmGenerationConfig.Temperature
+			traceAttrs.TopP = cfg.llmGenerationConfig.TopP
+			traceAttrs.ThinkingEnabled = cfg.llmGenerationConfig.ThinkingEnabled
+		}
+		itelemetry.TraceBeforeInvokeAgent(span, traceAttrs)
+
 		tracker := itelemetry.NewInvokeAgentTracker(
 			ctx,
 			invocation,

--- a/internal/telemetry/metric_invoke_agent.go
+++ b/internal/telemetry/metric_invoke_agent.go
@@ -43,7 +43,7 @@ type invokeAgentAttributes struct {
 	AppName   string
 	UserID    string
 	System    string
-	Stream    bool
+	Stream    *bool
 	ErrorType string
 	Error     error
 }
@@ -51,8 +51,10 @@ type invokeAgentAttributes struct {
 func (a invokeAgentAttributes) toAttributes() []attribute.KeyValue {
 	attrs := []attribute.KeyValue{
 		attribute.String(semconvtrace.KeyGenAIOperationName, OperationInvokeAgent),
-		attribute.Bool(metrics.KeyTRPCAgentGoStream, a.Stream),
 		attribute.String(semconvtrace.KeyGenAISystem, a.System),
+	}
+	if a.Stream != nil {
+		attrs = append(attrs, attribute.Bool(metrics.KeyTRPCAgentGoStream, *a.Stream))
 	}
 	if a.AppName != "" {
 		attrs = append(attrs, attribute.String(semconvtrace.KeyTRPCAgentGoAppName, a.AppName))
@@ -88,7 +90,7 @@ type InvokeAgentTracker struct {
 func NewInvokeAgentTracker(
 	ctx context.Context,
 	invocation *agent.Invocation,
-	stream bool,
+	stream *bool,
 	err *error,
 ) *InvokeAgentTracker {
 	attributes := invokeAgentAttributes{Stream: stream, Error: *err}

--- a/internal/telemetry/metric_invoke_agent_test.go
+++ b/internal/telemetry/metric_invoke_agent_test.go
@@ -29,6 +29,10 @@ import (
 	semconvtrace "trpc.group/trpc-go/trpc-agent-go/telemetry/semconv/trace"
 )
 
+func boolPtr(v bool) *bool {
+	return &v
+}
+
 func TestInvokeAgentAttributes_toAttributes(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -42,7 +46,7 @@ func TestInvokeAgentAttributes_toAttributes(t *testing.T) {
 				AppName:   "test-app",
 				UserID:    "user-123",
 				System:    "gpt-4",
-				Stream:    true,
+				Stream:    boolPtr(true),
 				ErrorType: "rate_limit",
 				Error:     errors.New("test error"),
 			},
@@ -57,10 +61,10 @@ func TestInvokeAgentAttributes_toAttributes(t *testing.T) {
 			},
 		},
 		{
-			name: "minimal fields",
+			name: "minimal fields with explicit false stream",
 			attrs: invokeAgentAttributes{
 				System: "gpt-3.5",
-				Stream: false,
+				Stream: boolPtr(false),
 			},
 			expected: []attribute.KeyValue{
 				attribute.String(semconvtrace.KeyGenAIOperationName, OperationInvokeAgent),
@@ -76,7 +80,6 @@ func TestInvokeAgentAttributes_toAttributes(t *testing.T) {
 			},
 			expected: []attribute.KeyValue{
 				attribute.String(semconvtrace.KeyGenAIOperationName, OperationInvokeAgent),
-				attribute.Bool(metrics.KeyTRPCAgentGoStream, false),
 				attribute.String(semconvtrace.KeyGenAISystem, "gpt-4"),
 				attribute.String(semconvtrace.KeyErrorType, semconvtrace.ValueDefaultErrorType),
 			},
@@ -92,7 +95,6 @@ func TestInvokeAgentAttributes_toAttributes(t *testing.T) {
 			},
 			expected: []attribute.KeyValue{
 				attribute.String(semconvtrace.KeyGenAIOperationName, OperationInvokeAgent),
-				attribute.Bool(metrics.KeyTRPCAgentGoStream, false),
 				attribute.String(semconvtrace.KeyGenAISystem, "claude-3"),
 			},
 		},
@@ -127,7 +129,7 @@ func TestNewInvokeAgentTracker(t *testing.T) {
 	}
 	var err error
 
-	tracker := NewInvokeAgentTracker(ctx, invocation, true, &err)
+	tracker := NewInvokeAgentTracker(ctx, invocation, boolPtr(true), &err)
 
 	if tracker == nil {
 		t.Fatal("expected non-nil tracker")
@@ -150,7 +152,7 @@ func TestNewInvokeAgentTracker(t *testing.T) {
 	if tracker.attributes.AppName != "test-app" {
 		t.Errorf("expected AppName=test-app, got %s", tracker.attributes.AppName)
 	}
-	if !tracker.attributes.Stream {
+	if tracker.attributes.Stream == nil || !*tracker.attributes.Stream {
 		t.Error("expected Stream to be true")
 	}
 	if tracker.start.IsZero() {
@@ -171,7 +173,7 @@ func TestNewInvokeAgentTracker_NilInvocation(t *testing.T) {
 	ctx := context.Background()
 	var err error
 
-	tracker := NewInvokeAgentTracker(ctx, nil, false, &err)
+	tracker := NewInvokeAgentTracker(ctx, nil, nil, &err)
 
 	if tracker == nil {
 		t.Fatal("expected non-nil tracker")
@@ -182,8 +184,8 @@ func TestNewInvokeAgentTracker_NilInvocation(t *testing.T) {
 	if tracker.attributes.System != "" {
 		t.Error("expected empty System")
 	}
-	if tracker.attributes.Stream {
-		t.Error("expected Stream to be false")
+	if tracker.attributes.Stream != nil {
+		t.Error("expected Stream to be nil")
 	}
 }
 
@@ -383,7 +385,7 @@ func TestInvokeAgentTracker_TrackResponse(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			var err error
-			tracker := NewInvokeAgentTracker(ctx, nil, false, &err)
+			tracker := NewInvokeAgentTracker(ctx, nil, nil, &err)
 
 			for i, response := range tt.responses {
 				if i == 0 && tt.waitBeforeFirstResponse {
@@ -400,7 +402,7 @@ func TestInvokeAgentTracker_TrackResponse(t *testing.T) {
 func TestInvokeAgentTracker_SetResponseErrorType(t *testing.T) {
 	ctx := context.Background()
 	var err error
-	tracker := NewInvokeAgentTracker(ctx, nil, false, &err)
+	tracker := NewInvokeAgentTracker(ctx, nil, nil, &err)
 
 	if tracker.attributes.ErrorType != "" {
 		t.Error("expected empty ErrorType initially")
@@ -420,7 +422,7 @@ func TestInvokeAgentTracker_SetResponseErrorType(t *testing.T) {
 func TestInvokeAgentTracker_FirstTokenTimeDuration(t *testing.T) {
 	ctx := context.Background()
 	var err error
-	tracker := NewInvokeAgentTracker(ctx, nil, false, &err)
+	tracker := NewInvokeAgentTracker(ctx, nil, nil, &err)
 
 	if tracker.FirstTokenTimeDuration() != 0 {
 		t.Error("initial FirstTokenTimeDuration should be 0")
@@ -494,7 +496,7 @@ func TestInvokeAgentTracker_RecordMetrics(t *testing.T) {
 		},
 	}
 
-	tracker := NewInvokeAgentTracker(ctx, inv, true, &err)
+	tracker := NewInvokeAgentTracker(ctx, inv, boolPtr(true), &err)
 
 	// Simulate some responses
 	time.Sleep(10 * time.Millisecond)
@@ -579,7 +581,7 @@ func TestInvokeAgentTracker_RecordMetrics_WithError(t *testing.T) {
 
 	ctx := context.Background()
 	testErr := errors.New("test error")
-	tracker := NewInvokeAgentTracker(ctx, nil, false, &testErr)
+	tracker := NewInvokeAgentTracker(ctx, nil, nil, &testErr)
 	tracker.SetResponseErrorType("rate_limit")
 
 	recordFunc := tracker.RecordMetrics()
@@ -637,7 +639,7 @@ func TestInvokeAgentTracker_RecordMetrics_NoTokens(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	tracker := NewInvokeAgentTracker(ctx, nil, false, &err)
+	tracker := NewInvokeAgentTracker(ctx, nil, nil, &err)
 
 	// Record metrics without any responses
 	recordFunc := tracker.RecordMetrics()
@@ -653,5 +655,5 @@ func TestInvokeAgentTracker_RecordMetrics_NoTokens(t *testing.T) {
 		t.Error("expected metrics to be recorded even without tokens")
 	}
 	metricNames := collectMetricNames(rm)
-	require.NotContains(t, metricNames, metrics.MetricTRPCAgentGoClientTimeToFirstToken)
+	require.Contains(t, metricNames, metrics.MetricTRPCAgentGoClientTimeToFirstToken)
 }

--- a/internal/telemetry/trace.go
+++ b/internal/telemetry/trace.go
@@ -217,56 +217,87 @@ func TraceMergedToolCalls(span trace.Span, rspEvent *event.Event) {
 	)
 }
 
+// TraceBeforeInvokeAgentAttributes contains TraceBeforeInvokeAgent inputs other than span.
+//
+// It is used to keep TraceBeforeInvokeAgent signatures stable as parameters evolve.
+type TraceBeforeInvokeAgentAttributes struct {
+	SpanAttributes []attribute.KeyValue
+
+	InputMessages []model.Message
+
+	AgentName    string
+	InvocationID string
+	SessionID    string
+	UserID       string
+
+	AgentDescription   string
+	SystemInstructions string
+
+	Stop             []string
+	Stream           *bool
+	FrequencyPenalty *float64
+	MaxTokens        *int
+	PresencePenalty  *float64
+	Temperature      *float64
+	TopP             *float64
+	ThinkingEnabled  *bool
+}
+
 // TraceBeforeInvokeAgent traces the before invocation of an agent.
-func TraceBeforeInvokeAgent(span trace.Span, invoke *agent.Invocation, agentDescription, instructions string, genConfig *model.GenerationConfig) {
-	if !span.IsRecording() {
+func TraceBeforeInvokeAgent(span trace.Span, attrs *TraceBeforeInvokeAgentAttributes) {
+	if !span.IsRecording() || attrs == nil {
 		return
 	}
-	if invoke != nil && len(invoke.RunOptions.SpanAttributes) > 0 {
-		span.SetAttributes(invoke.RunOptions.SpanAttributes...)
+	if len(attrs.SpanAttributes) > 0 {
+		span.SetAttributes(attrs.SpanAttributes...)
 	}
-	if bts, err := json.Marshal([]model.Message{invoke.Message}); err == nil {
-		span.SetAttributes(
-			attribute.String(semconvtrace.KeyGenAIInputMessages, string(bts)),
-		)
-	} else {
-		span.SetAttributes(attribute.String(semconvtrace.KeyGenAIInputMessages, "<not json serializable>"))
+	if len(attrs.InputMessages) > 0 {
+		if bts, err := json.Marshal(attrs.InputMessages); err == nil {
+			span.SetAttributes(
+				attribute.String(semconvtrace.KeyGenAIInputMessages, string(bts)),
+			)
+		} else {
+			span.SetAttributes(attribute.String(semconvtrace.KeyGenAIInputMessages, "<not json serializable>"))
+		}
 	}
 	span.SetAttributes(
 		attribute.String(semconvtrace.KeyGenAISystem, semconvtrace.SystemTRPCGoAgent),
 		attribute.String(semconvtrace.KeyGenAIOperationName, OperationInvokeAgent),
-		attribute.String(semconvtrace.KeyGenAIAgentName, invoke.AgentName),
-		attribute.String(semconvtrace.KeyInvocationID, invoke.InvocationID),
-		attribute.String(semconvtrace.KeyGenAIAgentDescription, agentDescription),
-		attribute.String(semconvtrace.KeyGenAISystemInstructions, instructions),
+		attribute.String(semconvtrace.KeyGenAIAgentName, attrs.AgentName),
+		attribute.String(semconvtrace.KeyInvocationID, attrs.InvocationID),
+		attribute.String(semconvtrace.KeyGenAIAgentDescription, attrs.AgentDescription),
+		attribute.String(semconvtrace.KeyGenAISystemInstructions, attrs.SystemInstructions),
 	)
-	if genConfig != nil {
-		span.SetAttributes(attribute.StringSlice(semconvtrace.KeyGenAIRequestStopSequences, genConfig.Stop))
-		if fp := genConfig.FrequencyPenalty; fp != nil {
-			span.SetAttributes(attribute.Float64(semconvtrace.KeyGenAIRequestFrequencyPenalty, *fp))
-		}
-		if mt := genConfig.MaxTokens; mt != nil {
-			span.SetAttributes(attribute.Int(semconvtrace.KeyGenAIRequestMaxTokens, *mt))
-		}
-		if pp := genConfig.PresencePenalty; pp != nil {
-			span.SetAttributes(attribute.Float64(semconvtrace.KeyGenAIRequestPresencePenalty, *pp))
-		}
-		if tp := genConfig.Temperature; tp != nil {
-			span.SetAttributes(attribute.Float64(semconvtrace.KeyGenAIRequestTemperature, *tp))
-		}
-		if tp := genConfig.TopP; tp != nil {
-			span.SetAttributes(attribute.Float64(semconvtrace.KeyGenAIRequestTopP, *tp))
-		}
-		if te := genConfig.ThinkingEnabled; te != nil {
-			span.SetAttributes(attribute.Bool(semconvtrace.KeyGenAIRequestThinkingEnabled, *te))
-		}
+	if len(attrs.Stop) > 0 {
+		span.SetAttributes(attribute.StringSlice(semconvtrace.KeyGenAIRequestStopSequences, attrs.Stop))
+	}
+	if attrs.Stream != nil && *attrs.Stream {
+		span.SetAttributes(attribute.Bool(semconvtrace.KeyGenAIRequestIsStream, true))
+	}
+	if fp := attrs.FrequencyPenalty; fp != nil {
+		span.SetAttributes(attribute.Float64(semconvtrace.KeyGenAIRequestFrequencyPenalty, *fp))
+	}
+	if mt := attrs.MaxTokens; mt != nil {
+		span.SetAttributes(attribute.Int(semconvtrace.KeyGenAIRequestMaxTokens, *mt))
+	}
+	if pp := attrs.PresencePenalty; pp != nil {
+		span.SetAttributes(attribute.Float64(semconvtrace.KeyGenAIRequestPresencePenalty, *pp))
+	}
+	if tp := attrs.Temperature; tp != nil {
+		span.SetAttributes(attribute.Float64(semconvtrace.KeyGenAIRequestTemperature, *tp))
+	}
+	if tp := attrs.TopP; tp != nil {
+		span.SetAttributes(attribute.Float64(semconvtrace.KeyGenAIRequestTopP, *tp))
+	}
+	if te := attrs.ThinkingEnabled; te != nil {
+		span.SetAttributes(attribute.Bool(semconvtrace.KeyGenAIRequestThinkingEnabled, *te))
 	}
 
-	if invoke.Session != nil {
-		span.SetAttributes(
-			attribute.String(semconvtrace.KeyRunnerUserID, invoke.Session.UserID),
-			attribute.String(semconvtrace.KeyGenAIConversationID, invoke.Session.ID),
-		)
+	if attrs.UserID != "" {
+		span.SetAttributes(attribute.String(semconvtrace.KeyRunnerUserID, attrs.UserID))
+	}
+	if attrs.SessionID != "" {
+		span.SetAttributes(attribute.String(semconvtrace.KeyGenAIConversationID, attrs.SessionID))
 	}
 }
 

--- a/internal/telemetry/trace_test.go
+++ b/internal/telemetry/trace_test.go
@@ -102,6 +102,38 @@ func newRecordingSpan() *recordingSpan {
 	return &recordingSpan{Span: sp}
 }
 
+func newTraceBeforeInvokeAgentAttributes(
+	inv *agent.Invocation,
+	agentDescription, instructions string,
+	genConfig *model.GenerationConfig,
+) *TraceBeforeInvokeAgentAttributes {
+	attrs := &TraceBeforeInvokeAgentAttributes{
+		AgentDescription:   agentDescription,
+		SystemInstructions: instructions,
+	}
+	if inv != nil {
+		attrs.SpanAttributes = inv.RunOptions.SpanAttributes
+		attrs.InputMessages = []model.Message{inv.Message}
+		attrs.AgentName = inv.AgentName
+		attrs.InvocationID = inv.InvocationID
+		if inv.Session != nil {
+			attrs.SessionID = inv.Session.ID
+			attrs.UserID = inv.Session.UserID
+		}
+	}
+	if genConfig != nil {
+		attrs.Stop = genConfig.Stop
+		attrs.Stream = &genConfig.Stream
+		attrs.FrequencyPenalty = genConfig.FrequencyPenalty
+		attrs.MaxTokens = genConfig.MaxTokens
+		attrs.PresencePenalty = genConfig.PresencePenalty
+		attrs.Temperature = genConfig.Temperature
+		attrs.TopP = genConfig.TopP
+		attrs.ThinkingEnabled = genConfig.ThinkingEnabled
+	}
+	return attrs
+}
+
 func hasAttr(attrs []attribute.KeyValue, key string, want any) bool {
 	for _, kv := range attrs {
 		if string(kv.Key) == key {
@@ -253,7 +285,7 @@ func TestTraceFunctions_NonRecordingSpan_ReturnsEarly(t *testing.T) {
 	require.False(t, span.IsRecording(), "expected noop span to be non-recording")
 
 	TraceWorkflow(span, &Workflow{Name: "wf", ID: "wf-1"})
-	TraceBeforeInvokeAgent(span, nil, "", "", nil)
+	TraceBeforeInvokeAgent(span, nil)
 	TraceAfterInvokeAgent(span, nil, nil, 0)
 	TraceChat(span, nil)
 }
@@ -261,12 +293,24 @@ func TestTraceFunctions_NonRecordingSpan_ReturnsEarly(t *testing.T) {
 func TestTraceBeforeAfter_Tool_Merged_Chat_Embedding(t *testing.T) {
 	// Before invoke
 	fp, mt, pp, tp, topP := 0.5, 128, 0.25, 0.7, 0.9
-	gc := &model.GenerationConfig{Stop: []string{"END"}, FrequencyPenalty: &fp, MaxTokens: &mt, PresencePenalty: &pp, Temperature: &tp, TopP: &topP}
+	stream := true
+	gc := &model.GenerationConfig{
+		Stop:             []string{"END"},
+		Stream:           stream,
+		FrequencyPenalty: &fp,
+		MaxTokens:        &mt,
+		PresencePenalty:  &pp,
+		Temperature:      &tp,
+		TopP:             &topP,
+	}
 	inv := &agent.Invocation{AgentName: "alpha", InvocationID: "inv-1", Session: &session.Session{ID: "sess-1", UserID: "u-1"}}
 	s := newRecordingSpan()
-	TraceBeforeInvokeAgent(s, inv, "desc", "inst", gc)
+	TraceBeforeInvokeAgent(s, newTraceBeforeInvokeAgentAttributes(inv, "desc", "inst", gc))
 	if !hasAttr(s.attrs, semconvtrace.KeyGenAIAgentName, "alpha") {
 		t.Fatalf("missing agent name")
+	}
+	if !hasAttr(s.attrs, semconvtrace.KeyGenAIRequestIsStream, true) {
+		t.Fatalf("missing stream attribute")
 	}
 
 	// After invoke with error and choices
@@ -379,7 +423,7 @@ func TestTraceBeforeInvokeAgent_WithSpanAttributes(t *testing.T) {
 		RunOptions:   agent.RunOptions{SpanAttributes: []attribute.KeyValue{attribute.String("custom.attr", "v1")}},
 	}
 	span := newRecordingSpan()
-	TraceBeforeInvokeAgent(span, inv, "desc", "inst", nil)
+	TraceBeforeInvokeAgent(span, newTraceBeforeInvokeAgentAttributes(inv, "desc", "inst", nil))
 	require.True(t, hasAttr(span.attrs, "custom.attr", "v1"), "custom span attribute should be applied")
 }
 
@@ -548,39 +592,44 @@ func TestTraceMergedToolCalls_NilPaths(t *testing.T) {
 
 func TestTraceBeforeInvokeAgent_NilPaths(t *testing.T) {
 	tests := []struct {
-		name      string
-		invoke    *agent.Invocation
-		genConfig *model.GenerationConfig
+		name  string
+		attrs *TraceBeforeInvokeAgentAttributes
 	}{
 		{
 			name: "nil generation config",
-			invoke: &agent.Invocation{
+			attrs: newTraceBeforeInvokeAgentAttributes(&agent.Invocation{
 				AgentName:    "test-agent",
 				InvocationID: "inv1",
 				Session:      &session.Session{ID: "sess1", UserID: "user1"},
-			},
-			genConfig: nil,
+			}, "desc", "instructions", nil),
 		},
 		{
 			name: "nil session",
-			invoke: &agent.Invocation{
+			attrs: newTraceBeforeInvokeAgentAttributes(&agent.Invocation{
 				AgentName:    "test-agent",
 				InvocationID: "inv1",
 				Session:      nil,
-			},
-			genConfig: &model.GenerationConfig{},
+			}, "desc", "instructions", &model.GenerationConfig{}),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			span := newRecordingSpan()
-			TraceBeforeInvokeAgent(span, tt.invoke, "desc", "instructions", tt.genConfig)
+			TraceBeforeInvokeAgent(span, tt.attrs)
 
 			require.True(t, hasAttr(span.attrs, semconvtrace.KeyGenAIAgentName, "test-agent"))
 			require.True(t, hasAttr(span.attrs, semconvtrace.KeyInvocationID, "inv1"))
 		})
 	}
+}
+
+func TestTraceBeforeInvokeAgent_NilAttributes(t *testing.T) {
+	span := newRecordingSpan()
+
+	TraceBeforeInvokeAgent(span, nil)
+
+	require.Empty(t, span.attrs)
 }
 
 func TestTraceAfterInvokeAgent_NilPaths(t *testing.T) {
@@ -991,7 +1040,7 @@ func TestTraceBeforeInvokeAgent_JSONMarshalError(t *testing.T) {
 		Message:      model.Message{Role: model.RoleUser, Content: "test"},
 	}
 
-	TraceBeforeInvokeAgent(span, inv, "desc", "instructions", nil)
+	TraceBeforeInvokeAgent(span, newTraceBeforeInvokeAgentAttributes(inv, "desc", "instructions", nil))
 
 	require.True(t, hasAttr(span.attrs, semconvtrace.KeyGenAIAgentName, "test-agent"))
 }


### PR DESCRIPTION
- Refactor the `TraceBeforeInvokeAgent` function to accept a new `TraceBeforeInvokeAgentAttributes` struct, consolidating parameters for better clarity and maintainability.
- Update agent implementations (A2A, Chain, Graph, LLM) to utilize the new tracing attributes, ensuring consistent telemetry data collection across different agents.
- Introduce a helper function `resolveInvokeAgentStream` to streamline stream option handling in agent invocations.
- Modify tests to accommodate changes in telemetry attribute handling, ensuring robust coverage for the new structure.

This update improves the organization of telemetry data and enhances the clarity of agent invocation tracing.

## Summary by Sourcery

通过引入共享的属性结构体、显式的流处理方式，并统一各 agent 间的追踪与指标记录方式，来统一并增强 agent 调用的遥测能力。

Enhancements:
- 引入 `TraceBeforeInvokeAgentAttributes`，用于封装传入 `TraceBeforeInvokeAgent` 的 agent 调用上下文和生成配置。
- 为 agent 调用记录与流相关的追踪属性，并通过 `resolveInvokeAgentStream` 对流进行集中解析，该函数被各个 agent 和图状态处理逻辑共享。
- 更新 invoke-agent 指标逻辑，将 stream 标志视为可选项，仅在其被显式设置时才发出相应的指标属性。

Tests:
- 调整遥测与指标测试，以覆盖新的属性结构体、基于指针的流语义（包括 `nil`）、JSON 编码行为以及“首个 token 出现时间”（time-to-first-token）指标记录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify and enrich agent invocation telemetry by introducing a shared attribute struct, explicit stream handling, and aligning tracing and metric recording across agents.

Enhancements:
- Introduce TraceBeforeInvokeAgentAttributes to encapsulate agent invocation context and generation settings passed into TraceBeforeInvokeAgent.
- Record stream-related trace attributes for agent invocations and centralize stream resolution via resolveInvokeAgentStream shared by agents and graph state handling.
- Update invoke-agent metrics to treat the stream flag as optional and only emit the corresponding metric attribute when it is explicitly set.

Tests:
- Adjust telemetry and metric tests to cover the new attribute struct, pointer-based stream semantics (including nil), JSON marshaling behavior, and time-to-first-token metric recording.

</details>