### PR TITLE
fix: disable automatic module sum checks until lfs budget recovers

### DIFF
--- a/.github/workflows/module-sum-check.yml
+++ b/.github/workflows/module-sum-check.yml
@@ -1,0 +1,20 @@
+name: Module Sum Check
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  check-current-module-sums:
+    name: check current module sums
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          lfs: true
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.21"
+      - name: Validate Git LFS files are excluded from published modules
+        run: bash .github/scripts/check-lfs-excluded.sh
+      - name: Compare module zip sums (VCS vs working tree)
+        run: bash .github/scripts/check-current-module-sums.sh

--- a/.github/workflows/prc.yml
+++ b/.github/workflows/prc.yml
@@ -263,19 +263,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: Validate Git LFS files are excluded from published modules
         run: bash .github/scripts/check-lfs-excluded.sh
-  check-current-module-sums:
-    name: check current module sums
-    runs-on: ubuntu-latest
-    needs: check-lfs-excluded
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          lfs: true
-      - uses: actions/setup-go@v5
-        with:
-          go-version: "1.21"
-      - name: Compare module zip sums (VCS vs working tree)
-        run: bash .github/scripts/check-current-module-sums.sh
   check-go-sumdb:
     name: check sum.golang.org checksums
     runs-on: ubuntu-latest


### PR DESCRIPTION
This change removes the LFS-backed module sum validation from the regular pull request workflow and keeps it as a manual workflow only so routine PR updates stop failing and stop consuming more LFS bandwidth while the repository is over its current Git LFS budget.

## Summary by Sourcery

在主 PR 工作流中禁用自动模块校验和验证，并将其改为手动按需触发的 GitHub Actions 工作流，以减少 Git LFS 的使用。

CI：
- 从标准 PR 验证工作流中移除模块校验和比较任务。
- 新增一个单独的、手动触发的 GitHub Actions 工作流，以按需运行 LFS 和模块校验和验证。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Disable automatic module checksum validation in the main PR workflow and expose it as a manual, on-demand GitHub Actions workflow to reduce Git LFS usage.

CI:
- Remove the module sum comparison job from the standard PR validation workflow.
- Add a separate, manually triggered GitHub Actions workflow to run LFS and module checksum validation on demand.

</details>