### PR TITLE
{examples/memory, examples/session}: align root module version

### DIFF
--- a/examples/memory/go.mod
+++ b/examples/memory/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/asg017/sqlite-vec-go-bindings v0.1.6
 	github.com/mattn/go-sqlite3 v1.14.32
 	github.com/ncruces/go-sqlite3 v0.17.1
-	trpc.group/trpc-go/trpc-agent-go v1.1.1
+	trpc.group/trpc-go/trpc-agent-go v1.6.1-0.20260311094958-7b74ee59e339
 	trpc.group/trpc-go/trpc-agent-go/memory/mysql v1.1.1
 	trpc.group/trpc-go/trpc-agent-go/memory/pgvector v1.1.1
 	trpc.group/trpc-go/trpc-agent-go/memory/postgres v1.1.1

--- a/examples/session/go.mod
+++ b/examples/session/go.mod
@@ -18,7 +18,7 @@ replace (
 require (
 	github.com/google/uuid v1.6.0
 	github.com/mattn/go-sqlite3 v1.14.32
-	trpc.group/trpc-go/trpc-agent-go v0.5.0
+	trpc.group/trpc-go/trpc-agent-go v1.6.1-0.20260311094958-7b74ee59e339
 	trpc.group/trpc-go/trpc-agent-go/session/clickhouse v0.0.0-20260107012516-0827a2e089f0
 	trpc.group/trpc-go/trpc-agent-go/session/mysql v0.0.0-20251126064502-c8c2594d2519
 	trpc.group/trpc-go/trpc-agent-go/session/postgres v0.0.0-20251126064502-c8c2594d2519


### PR DESCRIPTION
## Summary
- align `examples/memory` and `examples/session` with the root module pseudo-version introduced by #1395
- restore the examples `go mod tidy` and examples build checks after the sqlite module version fix landed

## Testing
- `bash .github/scripts/check-examples.sh`
- `bash .github/scripts/check-examples-build.sh`

Follow-up to #1395

## Summary by Sourcery

使示例模块与根模块的 trpc-agent-go 伪版本保持一致，并恢复与示例检查的兼容性。

Bug Fixes（错误修复）:
- 更新 `examples/memory` 和 `examples/session` 以使用根模块的 `trpc-agent-go` 伪版本，从而修复与主模块之间的版本偏差问题。

Build（构建）:
- 通过在示例的 `go.mod` 文件中统一使用相同的 `trpc-agent-go` 版本，恢复对示例执行 `go mod tidy` 和构建检查的能力。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align example modules with the root trpc-agent-go pseudo-version and restore compatibility with example checks.

Bug Fixes:
- Update examples/memory and examples/session to use the root trpc-agent-go pseudo-version to fix version skew with the main module.

Build:
- Restore the ability to run go mod tidy and build checks for the examples by standardizing the trpc-agent-go version used in their go.mod files.

</details>