### PR TITLE
skill: accept front matter closing fence at EOF

### DIFF
--- a/skill/repository.go
+++ b/skill/repository.go
@@ -21,6 +21,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -30,6 +31,8 @@ import (
 
 // skillFile is the canonical skill definition filename.
 const skillFile = "SKILL.md"
+
+const frontMatterDelimiter = "---"
 
 // EnvSkillsRoot is the environment variable name that points to the
 // skills repository root directory used by examples and runtimes.
@@ -255,25 +258,53 @@ func parseFull(path string) (Summary, string, error) {
 func readFrontMatter(r *bufio.Reader) (map[string]string, string,
 	error) {
 	line, err := r.ReadString('\n')
-	if err != nil {
+	if err != nil && !errors.Is(err, io.EOF) {
 		return nil, "", err
 	}
-	if strings.TrimSpace(line) != "---" {
+	if strings.TrimSpace(line) != frontMatterDelimiter {
 		return nil, "", errors.New("no front matter")
 	}
-	m := map[string]string{}
 	var b strings.Builder
 	for {
 		l, err2 := r.ReadString('\n')
+		if err2 != nil && !errors.Is(err2, io.EOF) {
+			return nil, "", err2
+		}
+		if strings.TrimSpace(l) == frontMatterDelimiter {
+			break
+		}
 		if err2 != nil {
 			return nil, "", err2
 		}
-		if strings.TrimSpace(l) == "---" {
-			break
-		}
 		b.WriteString(l)
 	}
-	for _, l := range strings.Split(b.String(), "\n") {
+	m := parseFrontMatterMap(b.String())
+	rest, _ := ioReadAll(r)
+	return m, rest, nil
+}
+
+// splitFrontMatter splits text into map and body.
+func splitFrontMatter(text string) (map[string]string, string) {
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	lines := strings.Split(text, "\n")
+	if len(lines) == 0 || lines[0] != frontMatterDelimiter {
+		return map[string]string{}, text
+	}
+	for i := 1; i < len(lines); i++ {
+		if lines[i] != frontMatterDelimiter {
+			continue
+		}
+		fm := strings.Join(lines[1:i], "\n")
+		body := strings.Join(lines[i+1:], "\n")
+		return parseFrontMatterMap(fm), body
+	}
+	// No closing; treat whole as body.
+	return map[string]string{}, text
+}
+
+func parseFrontMatterMap(text string) map[string]string {
+	m := map[string]string{}
+	for _, l := range strings.Split(text, "\n") {
 		l = strings.TrimSpace(l)
 		if l == "" || strings.HasPrefix(l, "#") {
 			continue
@@ -285,36 +316,7 @@ func readFrontMatter(r *bufio.Reader) (map[string]string, string,
 			m[k] = strings.Trim(v, " \"'")
 		}
 	}
-	rest, _ := ioReadAll(r)
-	return m, rest, nil
-}
-
-// splitFrontMatter splits text into map and body.
-func splitFrontMatter(text string) (map[string]string, string) {
-	text = strings.ReplaceAll(text, "\r\n", "\n")
-	if !strings.HasPrefix(text, "---\n") {
-		return map[string]string{}, text
-	}
-	idx := strings.Index(text[4:], "\n---\n")
-	if idx < 0 {
-		// No closing; treat whole as body.
-		return map[string]string{}, text
-	}
-	fm := text[4 : 4+idx]
-	body := text[4+idx+5:]
-	m := map[string]string{}
-	for _, l := range strings.Split(fm, "\n") {
-		l = strings.TrimSpace(l)
-		if l == "" || strings.HasPrefix(l, "#") {
-			continue
-		}
-		if i := strings.Index(l, ":"); i >= 0 {
-			k := strings.TrimSpace(l[:i])
-			v := strings.TrimSpace(l[i+1:])
-			m[k] = strings.Trim(v, " \"'")
-		}
-	}
-	return m, body
+	return m
 }
 
 func ioReadAll(r *bufio.Reader) (string, error) {

--- a/skill/repository_test.go
+++ b/skill/repository_test.go
@@ -304,6 +304,15 @@ func TestParseHelpers_And_DocFlags(t *testing.T) {
 	m, bod = splitFrontMatter("---\nname: z\n---\nB")
 	require.Equal(t, "z", m["name"])
 	require.Equal(t, "B", bod)
+	m, bod = splitFrontMatter("---\nname: z\n---")
+	require.Equal(t, "z", m["name"])
+	require.Empty(t, bod)
+
+	rd3 := bufio.NewReader(strings.NewReader("---\nname: z\n---"))
+	m, bod, err = readFrontMatter(rd3)
+	require.NoError(t, err)
+	require.Equal(t, "z", m["name"])
+	require.Empty(t, bod)
 
 	// ioReadAll helper returns the remaining text.
 	rd2 := bufio.NewReader(strings.NewReader("A\nB\n"))
@@ -315,6 +324,19 @@ func TestParseHelpers_And_DocFlags(t *testing.T) {
 	require.True(t, isDocFile("x.md"))
 	require.True(t, isDocFile("y.TXT"))
 	require.False(t, isDocFile("z.bin"))
+}
+
+func TestParseFull_FrontMatterClosingFenceAtEOF(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, skillFile)
+	data := "---\nname: eof\ndescription: desc\n---"
+	require.NoError(t, os.WriteFile(p, []byte(data), 0o644))
+
+	sum, body, err := parseFull(p)
+	require.NoError(t, err)
+	require.Equal(t, "eof", sum.Name)
+	require.Equal(t, "desc", sum.Description)
+	require.Empty(t, body)
 }
 
 func TestFSRepository_DuplicateSkill_PrefersFirst(t *testing.T) {


### PR DESCRIPTION
## What
- Accept a closing front matter fence when a `SKILL.md` file ends on the final `---` line.
- Reuse the same front matter parsing helper for both split and reader paths.
- Add regression tests for EOF-terminated front matter.

## Why
Some valid skill files omit the trailing newline after the closing fence. The current parser only recognizes the closing fence when it is followed by a newline, so `name` and `description` are ignored and the whole file is treated as body text.

## Tests
- `go test ./skill`
- `cd openclaw && go test ./...`

## Summary by Sourcery

处理在文件末尾以闭合分隔符结束的 SKILL front matter 块，并在不同代码路径之间共享通用解析逻辑。

Bug 修复：
- 能够在文件末尾识别 front matter 的闭合分隔符，即使没有末尾换行符，也能解析技能名称和描述。

增强：
- 将通用的 front matter 解析逻辑提取为可复用的助手函数，并引入命名的分隔符常量，以保持解析逻辑的一致性。

测试：
- 添加单元测试，覆盖字符串拆分和基于 reader 的解析器在 EOF 结束的 front matter 情况，同时增加一个 `parseFull` 风格的集成测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle SKILL front matter blocks that end with a closing fence at EOF and share common parsing logic between code paths.

Bug Fixes:
- Recognize front matter closing fences at end-of-file so skill name and description are parsed even without a trailing newline.

Enhancements:
- Extract shared front matter parsing into a reusable helper and introduce a named delimiter constant to keep parsing logic consistent.

Tests:
- Add unit tests covering EOF-terminated front matter for both string-splitting and reader-based parsers, plus a parseFull integration-style test.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

处理在文件末尾以闭合分隔符结束的 SKILL front matter 块，并在不同代码路径之间共享通用解析逻辑。

Bug 修复：
- 能够在文件末尾识别 front matter 的闭合分隔符，即使没有末尾换行符，也能解析技能名称和描述。

增强：
- 将通用的 front matter 解析逻辑提取为可复用的助手函数，并引入命名的分隔符常量，以保持解析逻辑的一致性。

测试：
- 添加单元测试，覆盖字符串拆分和基于 reader 的解析器在 EOF 结束的 front matter 情况，同时增加一个 `parseFull` 风格的集成测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle SKILL front matter blocks that end with a closing fence at EOF and share common parsing logic between code paths.

Bug Fixes:
- Recognize front matter closing fences at end-of-file so skill name and description are parsed even without a trailing newline.

Enhancements:
- Extract shared front matter parsing into a reusable helper and introduce a named delimiter constant to keep parsing logic consistent.

Tests:
- Add unit tests covering EOF-terminated front matter for both string-splitting and reader-based parsers, plus a parseFull integration-style test.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

处理在文件末尾以闭合分隔符结束的 SKILL front matter 块，并在不同代码路径之间共享通用解析逻辑。

Bug 修复：
- 能够在文件末尾识别 front matter 的闭合分隔符，即使没有末尾换行符，也能解析技能名称和描述。

增强：
- 将通用的 front matter 解析逻辑提取为可复用的助手函数，并引入命名的分隔符常量，以保持解析逻辑的一致性。

测试：
- 添加单元测试，覆盖字符串拆分和基于 reader 的解析器在 EOF 结束的 front matter 情况，同时增加一个 `parseFull` 风格的集成测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle SKILL front matter blocks that end with a closing fence at EOF and share common parsing logic between code paths.

Bug Fixes:
- Recognize front matter closing fences at end-of-file so skill name and description are parsed even without a trailing newline.

Enhancements:
- Extract shared front matter parsing into a reusable helper and introduce a named delimiter constant to keep parsing logic consistent.

Tests:
- Add unit tests covering EOF-terminated front matter for both string-splitting and reader-based parsers, plus a parseFull integration-style test.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

处理在文件末尾以闭合分隔符结束的 SKILL front matter 块，并在不同代码路径之间共享通用解析逻辑。

Bug 修复：
- 能够在文件末尾识别 front matter 的闭合分隔符，即使没有末尾换行符，也能解析技能名称和描述。

增强：
- 将通用的 front matter 解析逻辑提取为可复用的助手函数，并引入命名的分隔符常量，以保持解析逻辑的一致性。

测试：
- 添加单元测试，覆盖字符串拆分和基于 reader 的解析器在 EOF 结束的 front matter 情况，同时增加一个 `parseFull` 风格的集成测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle SKILL front matter blocks that end with a closing fence at EOF and share common parsing logic between code paths.

Bug Fixes:
- Recognize front matter closing fences at end-of-file so skill name and description are parsed even without a trailing newline.

Enhancements:
- Extract shared front matter parsing into a reusable helper and introduce a named delimiter constant to keep parsing logic consistent.

Tests:
- Add unit tests covering EOF-terminated front matter for both string-splitting and reader-based parsers, plus a parseFull integration-style test.

</details>

</details>

</details>