### PR TITLE
tool/file: add schema descriptions for file tool inputs

### DIFF
--- a/tool/file/listfile.go
+++ b/tool/file/listfile.go
@@ -26,10 +26,10 @@ import (
 // listFileRequest represents the input for the list file operation.
 type listFileRequest struct {
 	// Path is a relative directory under base_directory.
-	Path string `json:"path"`
+	Path string `json:"path" jsonschema:"description=Relative directory path under base_directory or workspace:// directory ref; empty means the base directory"`
 
 	// WithSize returns the size of the files.
-	WithSize bool `json:"with_size"`
+	WithSize bool `json:"with_size" jsonschema:"description=Whether to include file sizes in files_with_size"`
 }
 
 // listFileResponse represents the output from the list file operation.

--- a/tool/file/readfile.go
+++ b/tool/file/readfile.go
@@ -28,7 +28,7 @@ import (
 
 // readFileRequest represents the input for the read file operation.
 type readFileRequest struct {
-	FileName  string `json:"file_name" jsonschema:"description=Relative file path under base_directory or workspace:// file ref to read"`
+	FileName  string `json:"file_name" jsonschema:"description=Relative file path under base_directory or workspace:// or artifact:// file ref to read"`
 	StartLine *int   `json:"start_line,omitempty" jsonschema:"description=Optional 1-based start line to begin reading from"`
 	NumLines  *int   `json:"num_lines,omitempty" jsonschema:"description=Optional maximum number of lines to return"`
 }

--- a/tool/file/readfile.go
+++ b/tool/file/readfile.go
@@ -28,9 +28,9 @@ import (
 
 // readFileRequest represents the input for the read file operation.
 type readFileRequest struct {
-	FileName  string `json:"file_name" jsonschema:"description=Relative path"`
-	StartLine *int   `json:"start_line,omitempty" jsonschema:"description=Start"`
-	NumLines  *int   `json:"num_lines,omitempty" jsonschema:"description=Max"`
+	FileName  string `json:"file_name" jsonschema:"description=Relative file path under base_directory or workspace:// file ref to read"`
+	StartLine *int   `json:"start_line,omitempty" jsonschema:"description=Optional 1-based start line to begin reading from"`
+	NumLines  *int   `json:"num_lines,omitempty" jsonschema:"description=Optional maximum number of lines to return"`
 }
 
 // readFileResponse represents the output from the read file operation.

--- a/tool/file/readmultiplefiles.go
+++ b/tool/file/readmultiplefiles.go
@@ -27,8 +27,8 @@ import (
 // readMultipleFilesRequest represents the input for the read multiple files
 // operation.
 type readMultipleFilesRequest struct {
-	Patterns      []string `json:"patterns" jsonschema:"description=Globs"`
-	CaseSensitive bool     `json:"case_sensitive" jsonschema:"description=Case"`
+	Patterns      []string `json:"patterns" jsonschema:"description=Glob patterns to read such as *.go or workspace://out/*.txt"`
+	CaseSensitive bool     `json:"case_sensitive" jsonschema:"description=Whether glob matching should be case-sensitive"`
 }
 
 // readMultipleFilesResponse represents the output from the

--- a/tool/file/replacecontent.go
+++ b/tool/file/replacecontent.go
@@ -24,13 +24,13 @@ import (
 // replaceContentRequest represents the input for the replace content
 // operation.
 type replaceContentRequest struct {
-	FileName string `json:"file_name"`
+	FileName string `json:"file_name" jsonschema:"description=Relative file path under base_directory to modify"`
 	// OldString is replaced by NewString. It can be multi-line.
-	OldString string `json:"old_string"`
+	OldString string `json:"old_string" jsonschema:"description=Existing text to replace; supports multi-line content"`
 	// NewString is inserted in place of OldString. It can be multi-line.
-	NewString string `json:"new_string"`
+	NewString string `json:"new_string" jsonschema:"description=Replacement text; supports multi-line content"`
 	// NumReplacements limits replacements (default 1). Negative means all.
-	NumReplacements int `json:"num_replacements,omitempty"`
+	NumReplacements int `json:"num_replacements,omitempty" jsonschema:"description=Optional replacement limit; 0 means 1 and negative means replace all matches"`
 }
 
 // replaceContentResponse represents the output from the replace content

--- a/tool/file/savefile.go
+++ b/tool/file/savefile.go
@@ -24,11 +24,11 @@ import (
 // saveFileRequest represents the input for the save file operation.
 type saveFileRequest struct {
 	// FileName is a path relative to base_directory.
-	FileName string `json:"file_name"`
+	FileName string `json:"file_name" jsonschema:"description=Relative file path under base_directory to write"`
 	// Contents is the file content to write.
-	Contents string `json:"contents"`
+	Contents string `json:"contents" jsonschema:"description=Text content to write into the file"`
 	// Overwrite controls whether an existing file is replaced.
-	Overwrite bool `json:"overwrite"`
+	Overwrite bool `json:"overwrite" jsonschema:"description=Whether to replace the file if it already exists"`
 }
 
 // saveFileResponse represents the output from the save file operation.

--- a/tool/file/schema_test.go
+++ b/tool/file/schema_test.go
@@ -36,7 +36,7 @@ func TestFileTool_InputSchemaDescriptions(t *testing.T) {
 			"overwrite": "Whether to replace the file if it already exists",
 		},
 		"read_file": {
-			"file_name":  "Relative file path under base_directory or workspace:// file ref to read",
+			"file_name":  "Relative file path under base_directory or workspace:// or artifact:// file ref to read",
 			"start_line": "Optional 1-based start line to begin reading from",
 			"num_lines":  "Optional maximum number of lines to return",
 		},
@@ -54,8 +54,8 @@ func TestFileTool_InputSchemaDescriptions(t *testing.T) {
 			"case_sensitive": "Whether glob matching should be case-sensitive",
 		},
 		"search_content": {
-			"path":                   "Relative directory path under base_directory or workspace:// directory ref; can also be a single file path",
-			"file_pattern":           "Glob pattern for files to search or a direct workspace:// file ref",
+			"path":                   "Relative directory path under base_directory or workspace:// directory ref; can also be a single local or workspace file path",
+			"file_pattern":           "Glob pattern for files to search or a direct workspace:// or artifact:// file ref",
 			"file_case_sensitive":    "Whether file pattern matching should be case-sensitive",
 			"content_pattern":        "Regular expression to search for within matched files",
 			"content_case_sensitive": "Whether regular expression matching should be case-sensitive",

--- a/tool/file/schema_test.go
+++ b/tool/file/schema_test.go
@@ -1,0 +1,88 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package file
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	toolpkg "trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+func TestFileTool_InputSchemaDescriptions(t *testing.T) {
+	set, err := NewToolSet(WithBaseDir(t.TempDir()))
+	require.NoError(t, err)
+
+	declarations := make(map[string]*toolpkg.Declaration)
+	for _, candidate := range set.Tools(context.Background()) {
+		decl := candidate.Declaration()
+		declarations[decl.Name] = decl
+	}
+
+	expected := map[string]map[string]string{
+		"save_file": {
+			"file_name": "Relative file path under base_directory to write",
+			"contents":  "Text content to write into the file",
+			"overwrite": "Whether to replace the file if it already exists",
+		},
+		"read_file": {
+			"file_name":  "Relative file path under base_directory or workspace:// file ref to read",
+			"start_line": "Optional 1-based start line to begin reading from",
+			"num_lines":  "Optional maximum number of lines to return",
+		},
+		"read_multiple_files": {
+			"patterns":       "Glob patterns to read such as *.go or workspace://out/*.txt",
+			"case_sensitive": "Whether glob matching should be case-sensitive",
+		},
+		"list_file": {
+			"path":      "Relative directory path under base_directory or workspace:// directory ref; empty means the base directory",
+			"with_size": "Whether to include file sizes in files_with_size",
+		},
+		"search_file": {
+			"path":           "Relative directory path under base_directory or workspace:// directory ref; empty means the base directory",
+			"pattern":        "Glob pattern to match files or folders such as *.go or **/*.md",
+			"case_sensitive": "Whether glob matching should be case-sensitive",
+		},
+		"search_content": {
+			"path":                   "Relative directory path under base_directory or workspace:// directory ref; can also be a single file path",
+			"file_pattern":           "Glob pattern for files to search or a direct workspace:// file ref",
+			"file_case_sensitive":    "Whether file pattern matching should be case-sensitive",
+			"content_pattern":        "Regular expression to search for within matched files",
+			"content_case_sensitive": "Whether regular expression matching should be case-sensitive",
+		},
+		"replace_content": {
+			"file_name":        "Relative file path under base_directory to modify",
+			"old_string":       "Existing text to replace; supports multi-line content",
+			"new_string":       "Replacement text; supports multi-line content",
+			"num_replacements": "Optional replacement limit; 0 means 1 and negative means replace all matches",
+		},
+	}
+
+	for toolName, properties := range expected {
+		decl, ok := declarations[toolName]
+		require.Truef(t, ok, "missing declaration for %s", toolName)
+		require.NotNilf(t, decl.InputSchema, "missing input schema for %s", toolName)
+
+		for propertyName, wantDescription := range properties {
+			propertySchema, ok := decl.InputSchema.Properties[propertyName]
+			require.Truef(
+				t,
+				ok,
+				"missing %s input schema property for %s",
+				propertyName,
+				toolName,
+			)
+			assert.Equal(t, wantDescription, propertySchema.Description)
+		}
+	}
+}

--- a/tool/file/schema_test.go
+++ b/tool/file/schema_test.go
@@ -54,7 +54,7 @@ func TestFileTool_InputSchemaDescriptions(t *testing.T) {
 			"case_sensitive": "Whether glob matching should be case-sensitive",
 		},
 		"search_content": {
-			"path":                   "Relative directory path under base_directory or workspace:// directory ref; can also be a single local or workspace file path",
+			"path":                   "Relative directory path under base_directory or workspace:// directory ref; can also be a single local file path",
 			"file_pattern":           "Glob pattern for files to search or a direct workspace:// or artifact:// file ref",
 			"file_case_sensitive":    "Whether file pattern matching should be case-sensitive",
 			"content_pattern":        "Regular expression to search for within matched files",

--- a/tool/file/searchcontent.go
+++ b/tool/file/searchcontent.go
@@ -29,7 +29,7 @@ import (
 // searchContentRequest represents the input for the search content operation.
 type searchContentRequest struct {
 	// Path is a relative directory under base_directory.
-	Path string `json:"path" jsonschema:"description=Relative directory path under base_directory or workspace:// directory ref; can also be a single local or workspace file path"`
+	Path string `json:"path" jsonschema:"description=Relative directory path under base_directory or workspace:// directory ref; can also be a single local file path"`
 	// FilePattern selects files (glob or workspace://... for an exported
 	// workspace file).
 	FilePattern string `json:"file_pattern" jsonschema:"description=Glob pattern for files to search or a direct workspace:// or artifact:// file ref"`
@@ -179,13 +179,6 @@ func (f *fileToolSet) searchContentByPath(
 			"searching artifact:// path is not supported",
 		)
 	case fileref.SchemeWorkspace:
-		if matches, ok := f.searchSingleWorkspaceFile(
-			ctx,
-			pathRef.Path,
-			re,
-		); ok {
-			return fileref.WorkspaceRef(pathRef.Path), matches, nil
-		}
 		path := fileref.WorkspaceRef(pathRef.Path)
 		matches := f.searchWorkspaceContent(ctx, pathRef.Path, req, re)
 		return path, matches, nil
@@ -299,34 +292,6 @@ func (f *fileToolSet) searchSinglePath(
 		return nil, false
 	}
 	path := fileref.WorkspaceRef(reqPath)
-	match := searchTextContent(path, content, re)
-	if len(match.Matches) == 0 {
-		return []*fileMatch{}, true
-	}
-	match.Message = fmt.Sprintf(
-		"Found %d matches in file '%s'",
-		len(match.Matches),
-		path,
-	)
-	return []*fileMatch{match}, true
-}
-
-func (f *fileToolSet) searchSingleWorkspaceFile(
-	ctx context.Context,
-	path string,
-	re *regexp.Regexp,
-) ([]*fileMatch, bool) {
-	if strings.TrimSpace(path) == "" || re == nil {
-		return nil, false
-	}
-	content, _, ok := toolcache.LookupSkillRunOutputFileFromContext(ctx, path)
-	if !ok {
-		return nil, false
-	}
-	if int64(len(content)) > f.maxFileSize {
-		return []*fileMatch{}, true
-	}
-	path = fileref.WorkspaceRef(path)
 	match := searchTextContent(path, content, re)
 	if len(match.Matches) == 0 {
 		return []*fileMatch{}, true

--- a/tool/file/searchcontent.go
+++ b/tool/file/searchcontent.go
@@ -29,16 +29,16 @@ import (
 // searchContentRequest represents the input for the search content operation.
 type searchContentRequest struct {
 	// Path is a relative directory under base_directory.
-	Path string `json:"path"`
+	Path string `json:"path" jsonschema:"description=Relative directory path under base_directory or workspace:// directory ref; can also be a single file path"`
 	// FilePattern selects files (glob or workspace://... for an exported
 	// workspace file).
-	FilePattern string `json:"file_pattern"`
+	FilePattern string `json:"file_pattern" jsonschema:"description=Glob pattern for files to search or a direct workspace:// file ref"`
 	// FileCaseSensitive controls glob case matching.
-	FileCaseSensitive bool `json:"file_case_sensitive"`
+	FileCaseSensitive bool `json:"file_case_sensitive" jsonschema:"description=Whether file pattern matching should be case-sensitive"`
 	// ContentPattern is a regex applied per line.
-	ContentPattern string `json:"content_pattern"`
+	ContentPattern string `json:"content_pattern" jsonschema:"description=Regular expression to search for within matched files"`
 	// ContentCaseSensitive controls regex case matching.
-	ContentCaseSensitive bool `json:"content_case_sensitive"`
+	ContentCaseSensitive bool `json:"content_case_sensitive" jsonschema:"description=Whether regular expression matching should be case-sensitive"`
 }
 
 // searchContentResponse represents the output from the search content

--- a/tool/file/searchcontent.go
+++ b/tool/file/searchcontent.go
@@ -29,10 +29,10 @@ import (
 // searchContentRequest represents the input for the search content operation.
 type searchContentRequest struct {
 	// Path is a relative directory under base_directory.
-	Path string `json:"path" jsonschema:"description=Relative directory path under base_directory or workspace:// directory ref; can also be a single file path"`
+	Path string `json:"path" jsonschema:"description=Relative directory path under base_directory or workspace:// directory ref; can also be a single local or workspace file path"`
 	// FilePattern selects files (glob or workspace://... for an exported
 	// workspace file).
-	FilePattern string `json:"file_pattern" jsonschema:"description=Glob pattern for files to search or a direct workspace:// file ref"`
+	FilePattern string `json:"file_pattern" jsonschema:"description=Glob pattern for files to search or a direct workspace:// or artifact:// file ref"`
 	// FileCaseSensitive controls glob case matching.
 	FileCaseSensitive bool `json:"file_case_sensitive" jsonschema:"description=Whether file pattern matching should be case-sensitive"`
 	// ContentPattern is a regex applied per line.
@@ -179,6 +179,13 @@ func (f *fileToolSet) searchContentByPath(
 			"searching artifact:// path is not supported",
 		)
 	case fileref.SchemeWorkspace:
+		if matches, ok := f.searchSingleWorkspaceFile(
+			ctx,
+			pathRef.Path,
+			re,
+		); ok {
+			return fileref.WorkspaceRef(pathRef.Path), matches, nil
+		}
 		path := fileref.WorkspaceRef(pathRef.Path)
 		matches := f.searchWorkspaceContent(ctx, pathRef.Path, req, re)
 		return path, matches, nil
@@ -292,6 +299,34 @@ func (f *fileToolSet) searchSinglePath(
 		return nil, false
 	}
 	path := fileref.WorkspaceRef(reqPath)
+	match := searchTextContent(path, content, re)
+	if len(match.Matches) == 0 {
+		return []*fileMatch{}, true
+	}
+	match.Message = fmt.Sprintf(
+		"Found %d matches in file '%s'",
+		len(match.Matches),
+		path,
+	)
+	return []*fileMatch{match}, true
+}
+
+func (f *fileToolSet) searchSingleWorkspaceFile(
+	ctx context.Context,
+	path string,
+	re *regexp.Regexp,
+) ([]*fileMatch, bool) {
+	if strings.TrimSpace(path) == "" || re == nil {
+		return nil, false
+	}
+	content, _, ok := toolcache.LookupSkillRunOutputFileFromContext(ctx, path)
+	if !ok {
+		return nil, false
+	}
+	if int64(len(content)) > f.maxFileSize {
+		return []*fileMatch{}, true
+	}
+	path = fileref.WorkspaceRef(path)
 	match := searchTextContent(path, content, re)
 	if len(match.Matches) == 0 {
 		return []*fileMatch{}, true

--- a/tool/file/searchcontent_test.go
+++ b/tool/file/searchcontent_test.go
@@ -320,40 +320,6 @@ func TestSearchContent_PathFile_FromSkillRunCache(t *testing.T) {
 	assert.Len(t, rsp.FileMatches[0].Matches, 1)
 }
 
-func TestSearchContent_PathWorkspaceFile(t *testing.T) {
-	tempDir := t.TempDir()
-
-	set, err := NewToolSet(WithBaseDir(tempDir))
-	assert.NoError(t, err)
-	fts := set.(*fileToolSet)
-
-	inv := agent.NewInvocation()
-	ctx := agent.NewInvocationContext(context.Background(), inv)
-	toolcache.StoreSkillRunOutputFiles(inv, []codeexecutor.File{
-		{
-			Name:     "out/transcript.txt",
-			Content:  "freshly squeezed lemon juice\n",
-			MIMEType: "text/plain",
-		},
-	})
-
-	req := searchContentRequest{
-		Path:           fileref.WorkspaceRef("out/transcript.txt"),
-		FilePattern:    "*",
-		ContentPattern: "freshly squeezed lemon juice",
-	}
-	rsp, err := fts.searchContent(ctx, &req)
-	assert.NoError(t, err)
-	assert.Equal(t, fileref.WorkspaceRef("out/transcript.txt"), rsp.Path)
-	assert.Len(t, rsp.FileMatches, 1)
-	assert.Equal(
-		t,
-		fileref.WorkspaceRef("out/transcript.txt"),
-		rsp.FileMatches[0].FilePath,
-	)
-	assert.Len(t, rsp.FileMatches[0].Matches, 1)
-}
-
 func TestSearchContent_FilePattern_WorkspaceRef(t *testing.T) {
 	tempDir := t.TempDir()
 
@@ -538,62 +504,6 @@ func TestSearchSingleLocalFile_Branches(t *testing.T) {
 	matches, ok = fts.searchSingleLocalFile(noMatch, "nomatch.txt", re)
 	assert.True(t, ok)
 	assert.Empty(t, matches)
-}
-
-func TestSearchSingleWorkspaceFile_Branches(t *testing.T) {
-	base := t.TempDir()
-	set, err := NewToolSet(WithBaseDir(base), WithMaxFileSize(7))
-	assert.NoError(t, err)
-	fts := set.(*fileToolSet)
-
-	re := regexp.MustCompile("foo")
-
-	matches, ok := fts.searchSingleWorkspaceFile(context.Background(), "", re)
-	assert.False(t, ok)
-	assert.Nil(t, matches)
-
-	matches, ok = fts.searchSingleWorkspaceFile(context.Background(), "out/a.txt", nil)
-	assert.False(t, ok)
-	assert.Nil(t, matches)
-
-	inv := agent.NewInvocation()
-	ctx := agent.NewInvocationContext(context.Background(), inv)
-	toolcache.StoreSkillRunOutputFiles(inv, []codeexecutor.File{
-		{
-			Name:     "out/large.txt",
-			Content:  "12345678",
-			MIMEType: "text/plain",
-		},
-		{
-			Name:     "out/nomatch.txt",
-			Content:  "bar",
-			MIMEType: "text/plain",
-		},
-		{
-			Name:     "out/match.txt",
-			Content:  "foo\nbar",
-			MIMEType: "text/plain",
-		},
-	})
-
-	matches, ok = fts.searchSingleWorkspaceFile(ctx, "out/missing.txt", re)
-	assert.False(t, ok)
-	assert.Nil(t, matches)
-
-	matches, ok = fts.searchSingleWorkspaceFile(ctx, "out/large.txt", re)
-	assert.True(t, ok)
-	assert.Empty(t, matches)
-
-	matches, ok = fts.searchSingleWorkspaceFile(ctx, "out/nomatch.txt", re)
-	assert.True(t, ok)
-	assert.Empty(t, matches)
-
-	matches, ok = fts.searchSingleWorkspaceFile(ctx, "out/match.txt", re)
-	assert.True(t, ok)
-	assert.Len(t, matches, 1)
-	assert.Equal(t, fileref.WorkspaceRef("out/match.txt"), matches[0].FilePath)
-	assert.Len(t, matches[0].Matches, 1)
-	assert.Contains(t, matches[0].Message, "Found 1 matches")
 }
 
 func TestSearchSkillCache_Branches(t *testing.T) {

--- a/tool/file/searchcontent_test.go
+++ b/tool/file/searchcontent_test.go
@@ -320,6 +320,40 @@ func TestSearchContent_PathFile_FromSkillRunCache(t *testing.T) {
 	assert.Len(t, rsp.FileMatches[0].Matches, 1)
 }
 
+func TestSearchContent_PathWorkspaceFile(t *testing.T) {
+	tempDir := t.TempDir()
+
+	set, err := NewToolSet(WithBaseDir(tempDir))
+	assert.NoError(t, err)
+	fts := set.(*fileToolSet)
+
+	inv := agent.NewInvocation()
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+	toolcache.StoreSkillRunOutputFiles(inv, []codeexecutor.File{
+		{
+			Name:     "out/transcript.txt",
+			Content:  "freshly squeezed lemon juice\n",
+			MIMEType: "text/plain",
+		},
+	})
+
+	req := searchContentRequest{
+		Path:           fileref.WorkspaceRef("out/transcript.txt"),
+		FilePattern:    "*",
+		ContentPattern: "freshly squeezed lemon juice",
+	}
+	rsp, err := fts.searchContent(ctx, &req)
+	assert.NoError(t, err)
+	assert.Equal(t, fileref.WorkspaceRef("out/transcript.txt"), rsp.Path)
+	assert.Len(t, rsp.FileMatches, 1)
+	assert.Equal(
+		t,
+		fileref.WorkspaceRef("out/transcript.txt"),
+		rsp.FileMatches[0].FilePath,
+	)
+	assert.Len(t, rsp.FileMatches[0].Matches, 1)
+}
+
 func TestSearchContent_FilePattern_WorkspaceRef(t *testing.T) {
 	tempDir := t.TempDir()
 

--- a/tool/file/searchcontent_test.go
+++ b/tool/file/searchcontent_test.go
@@ -540,6 +540,62 @@ func TestSearchSingleLocalFile_Branches(t *testing.T) {
 	assert.Empty(t, matches)
 }
 
+func TestSearchSingleWorkspaceFile_Branches(t *testing.T) {
+	base := t.TempDir()
+	set, err := NewToolSet(WithBaseDir(base), WithMaxFileSize(7))
+	assert.NoError(t, err)
+	fts := set.(*fileToolSet)
+
+	re := regexp.MustCompile("foo")
+
+	matches, ok := fts.searchSingleWorkspaceFile(context.Background(), "", re)
+	assert.False(t, ok)
+	assert.Nil(t, matches)
+
+	matches, ok = fts.searchSingleWorkspaceFile(context.Background(), "out/a.txt", nil)
+	assert.False(t, ok)
+	assert.Nil(t, matches)
+
+	inv := agent.NewInvocation()
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+	toolcache.StoreSkillRunOutputFiles(inv, []codeexecutor.File{
+		{
+			Name:     "out/large.txt",
+			Content:  "12345678",
+			MIMEType: "text/plain",
+		},
+		{
+			Name:     "out/nomatch.txt",
+			Content:  "bar",
+			MIMEType: "text/plain",
+		},
+		{
+			Name:     "out/match.txt",
+			Content:  "foo\nbar",
+			MIMEType: "text/plain",
+		},
+	})
+
+	matches, ok = fts.searchSingleWorkspaceFile(ctx, "out/missing.txt", re)
+	assert.False(t, ok)
+	assert.Nil(t, matches)
+
+	matches, ok = fts.searchSingleWorkspaceFile(ctx, "out/large.txt", re)
+	assert.True(t, ok)
+	assert.Empty(t, matches)
+
+	matches, ok = fts.searchSingleWorkspaceFile(ctx, "out/nomatch.txt", re)
+	assert.True(t, ok)
+	assert.Empty(t, matches)
+
+	matches, ok = fts.searchSingleWorkspaceFile(ctx, "out/match.txt", re)
+	assert.True(t, ok)
+	assert.Len(t, matches, 1)
+	assert.Equal(t, fileref.WorkspaceRef("out/match.txt"), matches[0].FilePath)
+	assert.Len(t, matches[0].Matches, 1)
+	assert.Contains(t, matches[0].Message, "Found 1 matches")
+}
+
 func TestSearchSkillCache_Branches(t *testing.T) {
 	base := t.TempDir()
 	set, err := NewToolSet(WithBaseDir(base))

--- a/tool/file/searchfile.go
+++ b/tool/file/searchfile.go
@@ -25,11 +25,11 @@ import (
 // searchFileRequest represents the input for the search file operation.
 type searchFileRequest struct {
 	// Path is a relative directory under base_directory.
-	Path string `json:"path"`
+	Path string `json:"path" jsonschema:"description=Relative directory path under base_directory or workspace:// directory ref; empty means the base directory"`
 	// Pattern is a glob to match file names.
-	Pattern string `json:"pattern"`
+	Pattern string `json:"pattern" jsonschema:"description=Glob pattern to match files or folders such as *.go or **/*.md"`
 	// CaseSensitive controls glob case matching.
-	CaseSensitive bool `json:"case_sensitive"`
+	CaseSensitive bool `json:"case_sensitive" jsonschema:"description=Whether glob matching should be case-sensitive"`
 }
 
 // searchFileResponse represents the output from the search file operation.


### PR DESCRIPTION
## Background
- file tool request structs were missing `jsonschema:"description=..."` tags, which weakened tool selection and argument construction for `list_file`, `search_file`, `search_content`, and the rest of the file toolset

## Summary
- add input field descriptions to all file tool request structs under `tool/file`
- keep schema compatibility by only enriching descriptions without changing required fields or runtime behavior
- add a schema-level regression test that verifies every file tool declaration exposes the expected input descriptions

## Testing
- `go test ./tool/file`
- `go test ./...`

Fixes #1399

## Summary by Sourcery

为文件工具的输入 schema 增补描述性元数据，并添加回归测试，以确保所有文件工具都能暴露预期的输入描述。

增强内容：
- 为所有文件工具请求结构体添加 jsonschema 的 description 标签，在不改变运行时行为的前提下，更好地文档化并引导文件相关工具的使用。

测试：
- 引入基于 schema 的回归测试，用于验证每个文件工具声明是否暴露了正确的输入属性描述。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enrich file tool input schemas with descriptive metadata and add a regression test to ensure all file tools expose the expected input descriptions.

Enhancements:
- Add jsonschema description tags to all file tool request structs to better document and guide use of file-related tools without changing runtime behavior.

Tests:
- Introduce a schema-level regression test that verifies each file tool declaration exposes the correct input property descriptions.

</details>