### PR TITLE
internal: sanitize orphan tool calls

### DIFF
--- a/internal/flow/llmflow/llmflow_test.go
+++ b/internal/flow/llmflow/llmflow_test.go
@@ -84,6 +84,66 @@ func TestPreprocess_AddsAgentToolsWhenPresent(t *testing.T) {
 	require.Contains(t, req.Tools, "t1")
 }
 
+func TestPreprocess_DowngradesOrphanToolCallBeforeModel(t *testing.T) {
+	modelStub := &mockModel{
+		responses: []*model.Response{
+			{
+				Choices: []model.Choice{{
+					Message: model.Message{Role: model.RoleAssistant, Content: "ok"},
+				}},
+			},
+		},
+	}
+	f := New(
+		[]flow.RequestProcessor{
+			&seedMessagesRequestProcessor{
+				messages: []model.Message{
+					model.NewUserMessage("read file"),
+					{
+						Role: model.RoleAssistant,
+						ToolCalls: []model.ToolCall{
+							{
+								ID: "call_orphan",
+								Function: model.FunctionDefinitionParam{
+									Name:      "test_tool",
+									Arguments: []byte(`{"path":"a.txt"}`),
+								},
+							},
+						},
+					},
+					model.NewUserMessage("retry"),
+				},
+			},
+		},
+		nil,
+		Options{},
+	)
+	inv := agent.NewInvocation(
+		agent.WithInvocationAgent(&minimalAgent{tools: []tool.Tool{
+			&mockLongRunnerTool{name: "test_tool"},
+		}}),
+		agent.WithInvocationModel(modelStub),
+	)
+	req := &model.Request{Tools: map[string]tool.Tool{}}
+	ch := make(chan *event.Event, 4)
+
+	f.preprocess(context.Background(), inv, req, ch)
+	_, seq, err := f.callLLM(context.Background(), inv, req)
+	require.NoError(t, err)
+	seq(func(resp *model.Response) bool { return false })
+
+	captured := modelStub.LastRequest()
+	require.NotNil(t, captured)
+	require.Len(t, captured.Messages, 3)
+	require.Equal(t, model.RoleUser, captured.Messages[0].Role)
+	require.Equal(t, "read file", captured.Messages[0].Content)
+	require.Equal(t, model.RoleUser, captured.Messages[1].Role)
+	require.Contains(t, captured.Messages[1].Content, "[orphan_tool_call]")
+	require.Empty(t, captured.Messages[1].ToolCalls)
+	require.Equal(t, model.RoleUser, captured.Messages[2].Role)
+	require.Equal(t, "retry", captured.Messages[2].Content)
+}
+
 func TestCreateLLMResponseEvent_LongRunningIDs(t *testing.T) {
 	f := New(nil, nil, Options{})
 	inv := agent.NewInvocation()
@@ -204,6 +264,8 @@ type mockModel struct {
 	ShouldError bool
 	responses   []*model.Response
 	currentIdx  int
+	mu          sync.Mutex
+	requests    []*model.Request
 }
 
 func (m *mockModel) Info() model.Info {
@@ -216,6 +278,7 @@ func (m *mockModel) GenerateContent(ctx context.Context, req *model.Request) (<-
 	if m.ShouldError {
 		return nil, errors.New("mock model error")
 	}
+	m.recordRequest(req)
 
 	respChan := make(chan *model.Response, len(m.responses))
 
@@ -231,6 +294,44 @@ func (m *mockModel) GenerateContent(ctx context.Context, req *model.Request) (<-
 	}()
 
 	return respChan, nil
+}
+
+func (m *mockModel) recordRequest(req *model.Request) {
+	if req == nil {
+		return
+	}
+	cloned := &model.Request{
+		Messages: cloneMessagesForTest(req.Messages),
+	}
+	m.mu.Lock()
+	m.requests = append(m.requests, cloned)
+	m.mu.Unlock()
+}
+
+func (m *mockModel) LastRequest() *model.Request {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.requests) == 0 {
+		return nil
+	}
+	return m.requests[len(m.requests)-1]
+}
+
+func cloneMessagesForTest(messages []model.Message) []model.Message {
+	if messages == nil {
+		return nil
+	}
+	cloned := make([]model.Message, len(messages))
+	for i, msg := range messages {
+		cloned[i] = msg
+		if len(msg.ContentParts) > 0 {
+			cloned[i].ContentParts = append([]model.ContentPart(nil), msg.ContentParts...)
+		}
+		if len(msg.ToolCalls) > 0 {
+			cloned[i].ToolCalls = append([]model.ToolCall(nil), msg.ToolCalls...)
+		}
+	}
+	return cloned
 }
 
 type mockIterModel struct {
@@ -285,6 +386,19 @@ func (m *mockRequestProcessor) ProcessRequest(
 	case ch <- evt:
 	default:
 	}
+}
+
+type seedMessagesRequestProcessor struct {
+	messages []model.Message
+}
+
+func (p *seedMessagesRequestProcessor) ProcessRequest(
+	ctx context.Context,
+	invocation *agent.Invocation,
+	req *model.Request,
+	ch chan<- *event.Event,
+) {
+	req.Messages = append(req.Messages, cloneMessagesForTest(p.messages)...)
 }
 
 const flowRunPanicTestMsg = "boom"

--- a/internal/toolcall/sanitize.go
+++ b/internal/toolcall/sanitize.go
@@ -24,6 +24,7 @@ import (
 const (
 	invalidToolCallTag   = "[invalid_tool_call]"
 	invalidToolResultTag = "[invalid_tool_result]"
+	orphanToolCallTag    = "[orphan_tool_call]"
 	orphanToolResultTag  = "[orphan_tool_result]"
 )
 
@@ -40,8 +41,9 @@ var (
 // removes such tool calls from assistant messages and emits equivalent user messages that
 // preserve the original payload for context.
 //
-// This function also downgrades orphan tool result messages that are not associated with a
-// kept tool call message to avoid invalid tool message sequences in strict chat APIs.
+// This function also downgrades orphan tool calls that are not associated with a kept
+// tool result message, and orphan tool result messages that are not associated with a
+// kept tool call message, to avoid invalid tool message sequences in strict chat APIs.
 func SanitizeMessagesWithTools(messages []model.Message, tools map[string]tool.Tool) []model.Message {
 	if len(messages) == 0 {
 		return messages
@@ -87,26 +89,32 @@ type toolResultSplit struct {
 	orphan      []model.Message
 }
 
+type toolCallSplit struct {
+	kept   []model.ToolCall
+	orphan []model.ToolCall
+}
+
 // sanitizeToolRound sanitizes a single assistant tool-call round with its following tool results.
 func sanitizeToolRound(assistant model.Message, toolResults []model.Message, tools map[string]tool.Tool) []model.Message {
 	validation := validateToolCalls(assistant.ToolCalls, tools)
-	if len(validation.invalidToolCalls) == 0 {
-		assistant.ToolCalls = validation.validToolCalls
-		msgs := make([]model.Message, 0, 1+len(toolResults))
-		msgs = append(msgs, assistant)
-		msgs = append(msgs, toolResults...)
-		return msgs
-	}
+	split := splitToolResults(toolResults, validation.validIDs, validation.invalidIDs)
+	toolCallSplit := splitToolCalls(validation.validToolCalls, split.kept)
 	filteredAssistant := assistant
-	filteredAssistant.ToolCalls = validation.validToolCalls
+	filteredAssistant.ToolCalls = toolCallSplit.kept
 	if len(filteredAssistant.ToolCalls) == 0 {
 		filteredAssistant.ToolCalls = nil
 	}
-	split := splitToolResults(toolResults, validation.validIDs, validation.invalidIDs)
-	out := make([]model.Message, 0, 1+len(toolResults)+len(validation.invalidToolCalls)+len(split.orphan))
+	out := make(
+		[]model.Message,
+		0,
+		1+len(toolResults)+len(validation.invalidToolCalls)+len(toolCallSplit.orphan)+len(split.orphan),
+	)
 	if !isEmptyAssistantMessage(filteredAssistant) {
 		out = append(out, filteredAssistant)
 		out = append(out, split.kept...)
+	}
+	for _, orphanCall := range toolCallSplit.orphan {
+		out = append(out, downgradeOrphanToolCall(orphanCall))
 	}
 	for _, invalid := range validation.invalidToolCalls {
 		out = append(out, downgradeInvalidToolCall(invalid.call, invalid.reason))
@@ -116,6 +124,29 @@ func sanitizeToolRound(assistant model.Message, toolResults []model.Message, too
 	}
 	for _, orphan := range split.orphan {
 		out = append(out, downgradeOrphanToolResult(orphan))
+	}
+	return out
+}
+
+func splitToolCalls(toolCalls []model.ToolCall, toolResults []model.Message) toolCallSplit {
+	out := toolCallSplit{
+		kept: make([]model.ToolCall, 0, len(toolCalls)),
+	}
+	respondedIDs := make(map[string]struct{}, len(toolResults))
+	for _, tr := range toolResults {
+		if tr.ToolID == "" {
+			continue
+		}
+		respondedIDs[tr.ToolID] = struct{}{}
+	}
+	for _, tc := range toolCalls {
+		if tc.ID != "" {
+			if _, ok := respondedIDs[tc.ID]; ok {
+				out.kept = append(out.kept, tc)
+				continue
+			}
+		}
+		out.orphan = append(out.orphan, tc)
 	}
 	return out
 }
@@ -385,6 +416,21 @@ func downgradeInvalidToolCall(call model.ToolCall, reason string) model.Message 
 		"%s Tool call arguments were downgraded to a user message (%s).\nname: %s\nid: %s\narguments:\n```text\n%s\n```",
 		invalidToolCallTag,
 		reason,
+		call.Function.Name,
+		call.ID,
+		string(call.Function.Arguments),
+	)
+	return model.Message{
+		Role:    model.RoleUser,
+		Content: content,
+	}
+}
+
+// downgradeOrphanToolCall converts a tool call without a matching tool result into a user message.
+func downgradeOrphanToolCall(call model.ToolCall) model.Message {
+	content := fmt.Sprintf(
+		"%s Tool call was downgraded to a user message because no matching tool result exists.\nname: %s\nid: %s\narguments:\n```text\n%s\n```",
+		orphanToolCallTag,
 		call.Function.Name,
 		call.ID,
 		string(call.Function.Arguments),

--- a/internal/toolcall/sanitize_test.go
+++ b/internal/toolcall/sanitize_test.go
@@ -193,7 +193,7 @@ func TestSanitizeMessagesWithTools_DowngradesOrphanToolResult(t *testing.T) {
 	}
 }
 
-func TestSanitizeMessagesWithTools_PreservesNonObjectJSONArgumentsWhenToolsUnknown(t *testing.T) {
+func TestSanitizeMessagesWithTools_DowngradesOrphanToolCall(t *testing.T) {
 	in := []model.Message{
 		{
 			Role: model.RoleAssistant,
@@ -210,10 +210,83 @@ func TestSanitizeMessagesWithTools_PreservesNonObjectJSONArgumentsWhenToolsUnkno
 	}
 	out := SanitizeMessagesWithTools(in, nil)
 	if assert.Len(t, out, 1) {
+		assert.Equal(t, model.RoleUser, out[0].Role)
+		assert.Contains(t, out[0].Content, orphanToolCallTag)
+		assert.Contains(t, out[0].Content, "call_1")
+	}
+}
+
+func TestSanitizeMessagesWithTools_SplitsMatchedAndOrphanToolCalls(t *testing.T) {
+	in := []model.Message{
+		{
+			Role: model.RoleAssistant,
+			ToolCalls: []model.ToolCall{
+				{
+					ID: "call_keep",
+					Function: model.FunctionDefinitionParam{
+						Name:      "test_tool",
+						Arguments: []byte(`{"a":1}`),
+					},
+				},
+				{
+					ID: "call_orphan",
+					Function: model.FunctionDefinitionParam{
+						Name:      "test_tool",
+						Arguments: []byte(`{"b":2}`),
+					},
+				},
+			},
+		},
+		{
+			Role:     model.RoleTool,
+			ToolID:   "call_keep",
+			ToolName: "test_tool",
+			Content:  "ok",
+		},
+	}
+	out := SanitizeMessagesWithTools(in, nil)
+	if assert.Len(t, out, 3) {
+		assert.Equal(t, model.RoleAssistant, out[0].Role)
+		if assert.Len(t, out[0].ToolCalls, 1) {
+			assert.Equal(t, "call_keep", out[0].ToolCalls[0].ID)
+		}
+		assert.Equal(t, model.RoleTool, out[1].Role)
+		assert.Equal(t, "call_keep", out[1].ToolID)
+		assert.Equal(t, model.RoleUser, out[2].Role)
+		assert.Contains(t, out[2].Content, orphanToolCallTag)
+		assert.Contains(t, out[2].Content, "call_orphan")
+	}
+}
+
+func TestSanitizeMessagesWithTools_PreservesNonObjectJSONArgumentsWhenToolsUnknown(t *testing.T) {
+	in := []model.Message{
+		{
+			Role: model.RoleAssistant,
+			ToolCalls: []model.ToolCall{
+				{
+					ID: "call_1",
+					Function: model.FunctionDefinitionParam{
+						Name:      "test_tool",
+						Arguments: []byte(`"string"`),
+					},
+				},
+			},
+		},
+		{
+			Role:     model.RoleTool,
+			ToolID:   "call_1",
+			ToolName: "test_tool",
+			Content:  "ok",
+		},
+	}
+	out := SanitizeMessagesWithTools(in, nil)
+	if assert.Len(t, out, 2) {
 		assert.Equal(t, model.RoleAssistant, out[0].Role)
 		if assert.Len(t, out[0].ToolCalls, 1) {
 			assert.Equal(t, []byte(`"string"`), out[0].ToolCalls[0].Function.Arguments)
 		}
+		assert.Equal(t, model.RoleTool, out[1].Role)
+		assert.Equal(t, "call_1", out[1].ToolID)
 	}
 }
 


### PR DESCRIPTION
This change sanitizes orphan tool calls before model invocation by downgrading assistant tool calls that do not have matching tool results into user messages while keeping matched tool-call rounds intact, and it adds flow-level coverage to ensure the sanitized history is what reaches the model.

Fix #1402