### PR TITLE
session: fix mysql session issue

### DIFF
--- a/session/mysql/service.go
+++ b/session/mysql/service.go
@@ -293,7 +293,7 @@ func (s *Service) CreateSession(
 				WHERE app_name = ? AND user_id = ? AND session_id = ? AND deleted_at IS NULL`,
 				s.tableSessionStates,
 			),
-			sessBytes, sessState.CreatedAt, sessState.UpdatedAt, expiresAt,
+			string(sessBytes), sessState.CreatedAt, sessState.UpdatedAt, expiresAt,
 			key.AppName, key.UserID, key.SessionID,
 		)
 	} else {
@@ -303,7 +303,7 @@ func (s *Service) CreateSession(
 				VALUES (?, ?, ?, ?, ?, ?, ?)`,
 				s.tableSessionStates,
 			),
-			key.AppName, key.UserID, key.SessionID, sessBytes,
+			key.AppName, key.UserID, key.SessionID, string(sessBytes),
 			sessState.CreatedAt, sessState.UpdatedAt, expiresAt,
 		)
 	}
@@ -644,7 +644,7 @@ func (s *Service) UpdateSessionState(ctx context.Context, key session.Key, state
 	_, err = s.mysqlClient.Exec(ctx,
 		fmt.Sprintf(`UPDATE %s SET state = ?, updated_at = ?, expires_at = ?
 		 WHERE app_name = ? AND user_id = ? AND session_id = ? AND deleted_at IS NULL`, s.tableSessionStates),
-		updatedStateBytes, now, expiresAt,
+		string(updatedStateBytes), now, expiresAt,
 		key.AppName, key.UserID, key.SessionID)
 
 	if err != nil {

--- a/session/mysql/service_helper.go
+++ b/session/mysql/service_helper.go
@@ -308,7 +308,7 @@ func (s *Service) addEvent(ctx context.Context, key session.Key, event *event.Ev
 		_, err := tx.ExecContext(ctx,
 			fmt.Sprintf(`UPDATE %s SET state = ?, updated_at = ?, expires_at = ?
 			 WHERE app_name = ? AND user_id = ? AND session_id = ? AND deleted_at IS NULL`, s.tableSessionStates),
-			updatedStateBytes, sessState.UpdatedAt, expiresAt,
+			string(updatedStateBytes), sessState.UpdatedAt, expiresAt,
 			key.AppName, key.UserID, key.SessionID)
 		if err != nil {
 			return fmt.Errorf("update session state failed: %w", err)
@@ -319,7 +319,7 @@ func (s *Service) addEvent(ctx context.Context, key session.Key, event *event.Ev
 			_, err = tx.ExecContext(ctx,
 				fmt.Sprintf(`INSERT INTO %s (app_name, user_id, session_id, event, created_at, updated_at)
 				 VALUES (?, ?, ?, ?, ?, ?)`, s.tableSessionEvents),
-				key.AppName, key.UserID, key.SessionID, eventBytes, now, now)
+				key.AppName, key.UserID, key.SessionID, string(eventBytes), now, now)
 			if err != nil {
 				return fmt.Errorf("insert event failed: %w", err)
 			}
@@ -396,7 +396,7 @@ func (s *Service) addTrackEvent(ctx context.Context, key session.Key, trackEvent
 		_, err := tx.ExecContext(ctx,
 			fmt.Sprintf(`UPDATE %s SET state = ?, updated_at = ?, expires_at = ?
 			 WHERE app_name = ? AND user_id = ? AND session_id = ? AND deleted_at IS NULL`, s.tableSessionStates),
-			updatedStateBytes, sessState.UpdatedAt, expiresAt,
+			string(updatedStateBytes), sessState.UpdatedAt, expiresAt,
 			key.AppName, key.UserID, key.SessionID)
 		if err != nil {
 			return fmt.Errorf("update session state failed: %w", err)
@@ -406,7 +406,7 @@ func (s *Service) addTrackEvent(ctx context.Context, key session.Key, trackEvent
 		_, err = tx.ExecContext(ctx,
 			fmt.Sprintf(`INSERT INTO %s (app_name, user_id, session_id, track, event, created_at, updated_at, expires_at)
 			 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`, s.tableSessionTracks),
-			key.AppName, key.UserID, key.SessionID, trackEvent.Track, eventBytes,
+			key.AppName, key.UserID, key.SessionID, trackEvent.Track, string(eventBytes),
 			trackEvent.Timestamp, trackEvent.Timestamp, expiresAt)
 		if err != nil {
 			return fmt.Errorf("insert track event failed: %w", err)

--- a/session/mysql/service_test.go
+++ b/session/mysql/service_test.go
@@ -123,9 +123,14 @@ type sessionStateJSONMatcher struct {
 
 func (m *sessionStateJSONMatcher) Match(v driver.Value) bool {
 	m.t.Helper()
-	stateBytes, ok := v.([]byte)
-	if !ok {
-		m.t.Errorf("expected []byte for state, got %T", v)
+	var stateBytes []byte
+	switch vv := v.(type) {
+	case []byte:
+		stateBytes = vv
+	case string:
+		stateBytes = []byte(vv)
+	default:
+		m.t.Errorf("expected []byte or string for state, got %T", v)
 		return false
 	}
 

--- a/session/mysql/summary.go
+++ b/session/mysql/summary.go
@@ -73,7 +73,7 @@ func (s *Service) CreateSessionSummary(
 				deleted_at = NULL`,
 			s.tableSessionSummaries,
 		),
-		key.AppName, key.UserID, key.SessionID, filterKey, summaryBytes, sum.UpdatedAt, nil)
+		key.AppName, key.UserID, key.SessionID, filterKey, string(summaryBytes), sum.UpdatedAt, nil)
 	if err != nil {
 		return fmt.Errorf("upsert summary failed: %w", err)
 	}


### PR DESCRIPTION
## Summary by Sourcery

将 MySQL 会话数据作为字符串而非原始字节切片进行处理，以解决类型不匹配问题并提升兼容性。

Bug 修复：
- 允许测试中的会话状态匹配器同时接受用于存储状态的 `[]byte` 和 `string` 值。
- 在写入 MySQL 时，将会话状态、事件、跟踪事件和摘要以字符串形式存储，以避免驱动的类型问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle MySQL session data as strings instead of raw byte slices to resolve type mismatches and improve compatibility.

Bug Fixes:
- Allow session state matcher in tests to accept both []byte and string values for stored state.
- Store session state, events, track events, and summaries as strings when writing to MySQL to avoid driver type issues.

</details>