### PR TITLE
feat(tool/agent): add WithDescription option for custom agent tool description

### DIFF
--- a/tool/agent/agent_tool.go
+++ b/tool/agent/agent_tool.go
@@ -51,6 +51,7 @@ type agentToolOptions struct {
 	skipSummarization bool
 	streamInner       bool
 	historyScope      HistoryScope
+	description       *string
 }
 
 // WithSkipSummarization sets whether to skip summarization of the agent output.
@@ -66,6 +67,14 @@ func WithSkipSummarization(skip bool) Option {
 func WithStreamInner(enabled bool) Option {
 	return func(opts *agentToolOptions) {
 		opts.streamInner = enabled
+	}
+}
+
+// WithDescription sets the description exposed by the agent tool declaration.
+func WithDescription(description string) Option {
+	return func(opts *agentToolOptions) {
+		copiedDescription := description
+		opts.description = &copiedDescription
 	}
 }
 
@@ -138,13 +147,17 @@ func NewTool(agent agent.Agent, opts ...Option) *Tool {
 			Description: "The response from the agent",
 		}
 	}
+	description := info.Description
+	if options.description != nil {
+		description = *options.description
+	}
 	return &Tool{
 		agent:             agent,
 		skipSummarization: options.skipSummarization,
 		streamInner:       options.streamInner,
 		historyScope:      options.historyScope,
 		name:              info.Name,
-		description:       info.Description,
+		description:       description,
 		inputSchema:       inputSchema,
 		outputSchema:      outputSchema,
 	}

--- a/tool/agent/agent_tool_test.go
+++ b/tool/agent/agent_tool_test.go
@@ -125,6 +125,45 @@ func TestTool_Declaration(t *testing.T) {
 	}
 }
 
+func TestNewTool_WithDescription(t *testing.T) {
+	mockAgent := &mockAgent{
+		name:        "test-agent",
+		description: "A test agent for testing",
+	}
+
+	agentTool := NewTool(mockAgent, WithDescription("Custom tool description"))
+
+	if agentTool.description != "Custom tool description" {
+		t.Errorf("Expected description 'Custom tool description', got '%s'", agentTool.description)
+	}
+}
+
+func TestTool_Declaration_WithDescription(t *testing.T) {
+	mockAgent := &mockAgent{
+		name:        "test-agent",
+		description: "A test agent for testing",
+	}
+
+	declaration := NewTool(mockAgent, WithDescription("Custom tool description")).Declaration()
+
+	if declaration.Description != "Custom tool description" {
+		t.Errorf("Expected description 'Custom tool description', got '%s'", declaration.Description)
+	}
+}
+
+func TestTool_Declaration_WithEmptyDescription(t *testing.T) {
+	mockAgent := &mockAgent{
+		name:        "test-agent",
+		description: "A test agent for testing",
+	}
+
+	declaration := NewTool(mockAgent, WithDescription("")).Declaration()
+
+	if declaration.Description != "" {
+		t.Errorf("Expected empty description, got '%s'", declaration.Description)
+	}
+}
+
 func TestTool_Call(t *testing.T) {
 	mockAgent := &mockAgent{
 		name:        "test-agent",


### PR DESCRIPTION
给 agent tool 增加自定义 Description 的能力

原因：
当前 agent tool 的 description 只能从 agent 的 description 取，但是 agent 的 description 会被拼接到 system prompt 中，存在很多情况是不希望这个工具的 description 被拼接到 agent 的 system prompt 中的

## Summary by Sourcery

为代理工具增加支持，使其描述可以独立于底层代理进行覆盖。

新功能：
- 允许通过新的 `WithDescription` 选项为代理工具配置自定义描述。

测试：
- 添加测试以验证自定义工具描述是否被正确设置、正确传播到声明中，并且可以被显式设置为空。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for overriding an agent tool's description independently of the underlying agent.

New Features:
- Allow configuring a custom description for an agent tool via a new WithDescription option.

Tests:
- Add tests to verify custom tool descriptions are set correctly, propagated to declarations, and can be explicitly set to empty.

</details>