### PR TITLE
a2a: fix a2a function response parsing

### DIFF
--- a/agent/a2aagent/a2a_converter.go
+++ b/agent/a2aagent/a2a_converter.go
@@ -475,12 +475,19 @@ func processFunctionResponse(d *protocol.DataPart) (content string, id string, n
 		name = toolName
 	}
 
-	// Extract response content - server sends it as raw string
+	// Extract response content. Keep strings as-is, otherwise prefer JSON for
+	// structured values.
 	if response, ok := data[ia2a.ToolCallFieldResponse]; ok {
 		if responseStr, ok := response.(string); ok {
 			content = responseStr
+		} else if jsonBytes, err := json.Marshal(response); err == nil {
+			content = string(jsonBytes)
 		} else {
-			log.Debugf("Tool response is not a string: %T, skip", response)
+			log.Infof(
+				"Tool response JSON marshal failed for type %T, skip: %v",
+				response,
+				err,
+			)
 		}
 	}
 

--- a/agent/a2aagent/a2a_converter_test.go
+++ b/agent/a2aagent/a2a_converter_test.go
@@ -10,6 +10,7 @@
 package a2aagent
 
 import (
+	"encoding/json"
 	"testing"
 
 	"trpc.group/trpc-go/trpc-a2a-go/protocol"
@@ -1026,6 +1027,12 @@ func TestProcessFunctionResponse(t *testing.T) {
 		validateFunc func(t *testing.T, content, id, name string)
 	}
 
+	unmarshalableResponse := struct {
+		Ch chan int
+	}{
+		Ch: make(chan int),
+	}
+
 	tests := []testCase{
 		{
 			name: "valid tool response",
@@ -1080,15 +1087,51 @@ func TestProcessFunctionResponse(t *testing.T) {
 			},
 		},
 		{
-			name: "non-string response",
+			name: "numeric response marshals to json",
 			dataPart: &protocol.DataPart{
 				Data: map[string]any{
 					"response": 12345,
 				},
 			},
 			validateFunc: func(t *testing.T, content, id, name string) {
+				if content != "12345" {
+					t.Errorf("expected JSON number content, got %s", content)
+				}
+			},
+		},
+		{
+			name: "object response marshals to json",
+			dataPart: &protocol.DataPart{
+				Data: map[string]any{
+					"response": map[string]any{
+						"city": "Beijing",
+						"temp": 26,
+					},
+				},
+			},
+			validateFunc: func(t *testing.T, content, id, name string) {
+				var got map[string]any
+				if err := json.Unmarshal([]byte(content), &got); err != nil {
+					t.Fatalf("expected valid JSON object content, got %q: %v", content, err)
+				}
+				if got["city"] != "Beijing" {
+					t.Errorf("expected city Beijing, got %#v", got["city"])
+				}
+				if got["temp"] != float64(26) {
+					t.Errorf("expected temp 26, got %#v", got["temp"])
+				}
+			},
+		},
+		{
+			name: "unmarshalable response is skipped",
+			dataPart: &protocol.DataPart{
+				Data: map[string]any{
+					"response": unmarshalableResponse,
+				},
+			},
+			validateFunc: func(t *testing.T, content, id, name string) {
 				if content != "" {
-					t.Errorf("expected empty content for non-string response, got %s", content)
+					t.Errorf("expected empty content for unmarshalable response, got %q", content)
 				}
 			},
 		},

--- a/docs/mkdocs/en/a2a-interaction.md
+++ b/docs/mkdocs/en/a2a-interaction.md
@@ -294,6 +294,7 @@ A single Message can contain both reasoning content and formal reply as two Text
 | ---------------- | --------------- | -------------------------------------------------- |
 | HTTP Header      | `X-User-ID`    | User identifier (primary source)                   |
 | HTTP Header      | `traceparent`  | W3C Trace Context (auto-injected by OpenTelemetry) |
+| Message.Metadata | `interaction_spec_version` | Interaction specification version supported by the Client, used for capability negotiation |
 | Message.Metadata | `invocation_id`| Client-side invocation ID for trace correlation    |
 | Message.Metadata | `user_id`      | User identifier (supplementary)                    |
 
@@ -337,6 +338,7 @@ traceparent: 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01
         { "kind": "text", "text": "What's the weather in Beijing?" }
       ],
       "metadata": {
+        "interaction_spec_version": "0.1",
         "invocation_id": "inv-001",
         "user_id": "user_12345"
       }
@@ -443,6 +445,7 @@ Accept: text/event-stream
         { "kind": "text", "text": "What's the weather in Beijing?" }
       ],
       "metadata": {
+        "interaction_spec_version": "0.1",
         "invocation_id": "inv-002",
         "user_id": "user_12345"
       }

--- a/docs/mkdocs/zh/a2a-interaction.md
+++ b/docs/mkdocs/zh/a2a-interaction.md
@@ -287,6 +287,7 @@ Server 在每个响应的 Metadata 中携带 `llm_response_id`（来自 LLM API 
 | ------------------ | ----------------- | --------------------------------------------- |
 | HTTP Header      | `X-User-ID`     | 用户标识（主要来源）                        |
 | HTTP Header      | `traceparent`   | W3C Trace Context（OpenTelemetry 自动注入） |
+| Message.Metadata | `interaction_spec_version` | Client 支持的交互规范版本号，用于能力协商 |
 | Message.Metadata | `invocation_id` | Client 端调用 ID，用于追踪关联              |
 | Message.Metadata | `user_id`       | 用户标识（补充）                            |
 
@@ -330,6 +331,7 @@ traceparent: 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01
         { "kind": "text", "text": "北京天气如何？" }
       ],
       "metadata": {
+        "interaction_spec_version": "0.1",
         "invocation_id": "inv-001",
         "user_id": "user_12345"
       }
@@ -436,6 +438,7 @@ Accept: text/event-stream
         { "kind": "text", "text": "北京天气如何？" }
       ],
       "metadata": {
+        "interaction_spec_version": "0.1",
         "invocation_id": "inv-002",
         "user_id": "user_12345"
       }
@@ -534,4 +537,3 @@ data: {"kind":"artifact-update","taskId":"task-003","contextId":"ctx-001","artif
 
 - **`invocation_id`**（请求 Metadata）：标识 Client 端的单次 Agent 调用，Server 端可用于日志关联
 - **`llm_response_id`**（响应 Metadata）：标识 LLM 的原始响应 ID，Client 端用于消息聚合
-


### PR DESCRIPTION
## 由 Sourcery 提供的总结

改进 A2A 函数响应和交互元数据的处理与文档。

错误修复：
- 确保非字符串的工具响应在可能的情况下会被序列化为 JSON，仅在 JSON 序列化失败时才跳过。

功能增强：
- 在函数响应处理中新增对无法反序列化的工具响应的处理和日志记录。
- 在 A2A 交互文档中，通过记录 `interaction_spec_version` 字段来澄清并扩展交互元数据。

文档：
- 在英文和中文的 A2A 交互指南中记录 `interaction_spec_version` 元数据字段，并更新示例。

测试：
- 扩展 `processFunctionResponse` 的测试，以覆盖经过 JSON 序列化的数值与对象响应，以及无法反序列化的响应。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve processing and documentation of A2A function responses and interaction metadata.

Bug Fixes:
- Ensure non-string tool responses are marshalled to JSON when possible and skipped only if JSON marshalling fails.

Enhancements:
- Add handling and logging for unmarshalable tool responses in function response processing.
- Clarify and extend interaction metadata by documenting the interaction_spec_version field in A2A interaction docs.

Documentation:
- Document the interaction_spec_version metadata field in both English and Chinese A2A interaction guides with updated examples.

Tests:
- Extend processFunctionResponse tests to cover JSON-marshalled numeric and object responses and unmarshalable responses.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `interaction_spec_version` field to request metadata for compatibility negotiation.

* **Bug Fixes**
  * Improved structured response handling by automatically converting non-string responses to JSON format.

* **Documentation**
  * Updated interaction specification documentation with new metadata field and examples (English and Chinese).

* **Tests**
  * Added test coverage for JSON marshaling of numeric and object responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->