### PR TITLE
openclaw: do not check memory threshold so that extract every message automatically

### DIFF
--- a/codeexecutor/local/workspace_runtime_interactive_test.go
+++ b/codeexecutor/local/workspace_runtime_interactive_test.go
@@ -349,11 +349,12 @@ func TestRuntime_StartProgram_StdinAndPipeErrors(t *testing.T) {
 
 	provider, ok := proc.(codeexecutor.ProgramResultProvider)
 	require.True(t, ok)
-	require.Contains(
-		t,
-		provider.RunResult().Stdout,
-		"hello|override|ok",
-	)
+	require.Eventually(t, func() bool {
+		return strings.Contains(
+			provider.RunResult().Stdout,
+			"hello|override|ok",
+		)
+	}, time.Second, 20*time.Millisecond)
 	require.NoError(t, proc.Close())
 
 	cmd := exec.Command("sh", "-lc", "true")

--- a/codeexecutor/local/workspace_runtime_interactive_test.go
+++ b/codeexecutor/local/workspace_runtime_interactive_test.go
@@ -122,7 +122,7 @@ func TestRuntime_StartProgramInteractivePipes(t *testing.T) {
 		result = provider.RunResult()
 		return strings.Contains(result.Stdout, "out:hello") &&
 			strings.Contains(result.Stderr, "err:hello")
-	}, time.Second, 20*time.Millisecond)
+	}, 2*time.Second, 20*time.Millisecond)
 	require.NoError(t, proc.Close())
 }
 

--- a/openclaw/app/backends.go
+++ b/openclaw/app/backends.go
@@ -320,7 +320,7 @@ func newAutoMemoryExtractor(
 		return nil, errors.New("memory auto requires a model")
 	}
 
-	checks := make([]memextractor.Checker, 0, 2)
+	var checks []memextractor.Checker
 	if opts.MemoryAutoMessageThreshold > 0 {
 		checks = append(
 			checks,
@@ -335,33 +335,33 @@ func newAutoMemoryExtractor(
 			memextractor.CheckTimeInterval(opts.MemoryAutoTimeInterval),
 		)
 	}
-	if len(checks) == 0 {
-		checks = append(
-			checks,
-			memextractor.CheckMessageThreshold(
-				defaultMemoryAutoMessageThreshold,
-			),
-		)
-	}
-
-	policy, err := parseSummaryPolicy(opts.MemoryAutoPolicy)
-	if err != nil {
-		return nil, err
-	}
+	// When no checkers are configured, ShouldExtract always returns
+	// true so extraction runs on every turn.
 
 	extOpts := make([]memextractor.Option, 0, 2)
-	switch policy {
-	case summaryPolicyAny:
-		extOpts = append(
-			extOpts,
-			memextractor.WithCheckersAny(checks...),
-		)
-	case summaryPolicyAll:
-		for _, check := range checks {
-			extOpts = append(extOpts, memextractor.WithChecker(check))
+	if len(checks) > 0 {
+		policy, err := parseSummaryPolicy(opts.MemoryAutoPolicy)
+		if err != nil {
+			return nil, err
 		}
-	default:
-		return nil, fmt.Errorf("unsupported memory auto policy: %s", policy)
+		switch policy {
+		case summaryPolicyAny:
+			extOpts = append(
+				extOpts,
+				memextractor.WithCheckersAny(checks...),
+			)
+		case summaryPolicyAll:
+			for _, check := range checks {
+				extOpts = append(
+					extOpts,
+					memextractor.WithChecker(check),
+				)
+			}
+		default:
+			return nil, fmt.Errorf(
+				"unsupported memory auto policy: %s", policy,
+			)
+		}
 	}
 
 	return memextractor.NewExtractor(mdl, extOpts...), nil

--- a/openclaw/app/backends.go
+++ b/openclaw/app/backends.go
@@ -336,14 +336,16 @@ func newAutoMemoryExtractor(
 		)
 	}
 	// When no checkers are configured, ShouldExtract always returns
-	// true so extraction runs on every turn.
+	// true so extraction runs on every turn. We still validate
+	// MemoryAutoPolicy to catch misconfigurations early.
+
+	policy, err := parseSummaryPolicy(opts.MemoryAutoPolicy)
+	if err != nil {
+		return nil, err
+	}
 
 	extOpts := make([]memextractor.Option, 0, 2)
 	if len(checks) > 0 {
-		policy, err := parseSummaryPolicy(opts.MemoryAutoPolicy)
-		if err != nil {
-			return nil, err
-		}
 		switch policy {
 		case summaryPolicyAny:
 			extOpts = append(

--- a/openclaw/app/backends.go
+++ b/openclaw/app/backends.go
@@ -360,9 +360,7 @@ func newAutoMemoryExtractor(
 				)
 			}
 		default:
-			return nil, fmt.Errorf(
-				"unsupported memory auto policy: %s", policy,
-			)
+			return nil, fmt.Errorf("unsupported memory auto policy: %s", policy)
 		}
 	}
 

--- a/openclaw/app/backends_test.go
+++ b/openclaw/app/backends_test.go
@@ -72,7 +72,7 @@ func TestNewAutoMemoryExtractor_RequiresModel(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestNewAutoMemoryExtractor_DefaultThreshold(t *testing.T) {
+func TestNewAutoMemoryExtractor_NoCheckers(t *testing.T) {
 	t.Parallel()
 
 	mdl, err := modelFromOptions(runOptions{ModelMode: modeMock})
@@ -84,15 +84,10 @@ func TestNewAutoMemoryExtractor_DefaultThreshold(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, ext)
 
+	// Without checkers, ShouldExtract always returns true.
 	ctx := &memextractor.ExtractionContext{
 		Messages: make([]model.Message, 1),
 	}
-	require.False(t, ext.ShouldExtract(ctx))
-
-	ctx.Messages = make(
-		[]model.Message,
-		defaultMemoryAutoMessageThreshold+1,
-	)
 	require.True(t, ext.ShouldExtract(ctx))
 }
 

--- a/openclaw/app/backends_test.go
+++ b/openclaw/app/backends_test.go
@@ -118,6 +118,52 @@ func TestNewAutoMemoryExtractor_PolicyAll(t *testing.T) {
 	require.True(t, ext.ShouldExtract(ctx))
 }
 
+func TestNewAutoMemoryExtractor_PolicyAny(t *testing.T) {
+	t.Parallel()
+
+	mdl, err := modelFromOptions(runOptions{ModelMode: modeMock})
+	require.NoError(t, err)
+
+	ext, err := newAutoMemoryExtractor(mdl, runOptions{
+		MemoryAutoEnabled:          true,
+		MemoryAutoPolicy:           summaryPolicyAny,
+		MemoryAutoMessageThreshold: 2,
+		MemoryAutoTimeInterval:     time.Hour,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, ext)
+
+	now := time.Now()
+	ctx := &memextractor.ExtractionContext{
+		Messages:      make([]model.Message, 3),
+		LastExtractAt: &now,
+	}
+	// Message threshold is met.
+	require.True(t, ext.ShouldExtract(ctx))
+}
+
+func TestNewAutoMemoryExtractor_InvalidPolicy(t *testing.T) {
+	t.Parallel()
+
+	mdl, err := modelFromOptions(runOptions{ModelMode: modeMock})
+	require.NoError(t, err)
+
+	// Invalid policy without checkers still returns error.
+	_, err = newAutoMemoryExtractor(mdl, runOptions{
+		MemoryAutoEnabled: true,
+		MemoryAutoPolicy:  "invalid",
+	})
+	require.Error(t, err)
+
+	// Invalid policy with checkers also returns error.
+	_, err = newAutoMemoryExtractor(mdl, runOptions{
+		MemoryAutoEnabled:          true,
+		MemoryAutoPolicy:           "invalid",
+		MemoryAutoMessageThreshold: 1,
+	})
+	require.Error(t, err)
+}
+
 func TestNewSessionService_RedisRequiresConfig(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/app/run_options.go
+++ b/openclaw/app/run_options.go
@@ -53,7 +53,6 @@ const (
 	summaryPolicyAll = "all"
 
 	defaultSessionSummaryEventThreshold = 20
-	defaultMemoryAutoMessageThreshold   = 20
 	defaultSkillsLoadMode               = "turn"
 
 	flagAddSessionSummary = "add-session-summary"

--- a/openclaw/app/run_options.go
+++ b/openclaw/app/run_options.go
@@ -592,7 +592,7 @@ func parseRunOptions(args []string) (runOptions, error) {
 		&opts.MemoryAutoMessageThreshold,
 		"memory-auto-messages",
 		0,
-		"Extract when messages exceed N (0 uses default)",
+		"Extract when messages exceed N (0 disables threshold check)",
 	)
 	fs.DurationVar(
 		&opts.MemoryAutoTimeInterval,


### PR DESCRIPTION
## Summary by Sourcery

调整自动记忆抽取机制：当未配置任何消息或时间阈值检查器时，不再使用默认阈值，而是在每轮对话后都运行抽取。

Enhancements:
- 移除内置的默认记忆自动消息阈值，改为完全依赖已配置的检查器；当未配置任何检查器时，退回到“始终抽取”的行为。

Tests:
- 更新自动记忆抽取器的测试，用于验证在未配置检查器时的“始终抽取”行为，并移除对默认消息阈值的相关假设。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust automatic memory extraction so that, when no message or time threshold checkers are configured, extraction runs on every turn instead of using a default threshold.

Enhancements:
- Remove the implicit default memory auto message threshold and rely on configured checkers, falling back to always-extract behavior when none are set.

Tests:
- Update auto memory extractor tests to validate always-extract behavior when no checkers are configured and remove assumptions about a default message threshold.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Policy validation is skipped when no checkers are configured, preventing unintended threshold enforcement.

* **Refactor**
  * Removed implicit default checker so behavior follows explicit checker configuration and selected policy.

* **Tests**
  * Added/renamed tests for no-checker, "any" policy, and invalid policy; made runtime tests more robust by awaiting eventual output.

* **Chore**
  * CLI help text clarified: zero now disables the messages-threshold check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->