### PR TITLE
llmagent: skip post-tool processor when disabled

### DIFF
--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -331,16 +331,13 @@ func buildRequestProcessorsWithAgent(a *LLMAgent, options *Options) []flow.Reque
 }
 
 func appendPostToolProcessor(options *Options, requestProcessors []flow.RequestProcessor) []flow.RequestProcessor {
-	var postToolOpts []processor.PostToolOption
 	if options.postToolPromptEnabled != nil &&
 		!*options.postToolPromptEnabled {
-		// PostToolRequestProcessor treats an empty prompt as "disabled".
-		// Keep the processor registered, but skip prompt injection.
-		postToolOpts = append(
-			postToolOpts,
-			processor.WithPostToolPrompt(""),
-		)
-	} else if options.PostToolPrompt != "" {
+		return requestProcessors
+	}
+
+	var postToolOpts []processor.PostToolOption
+	if options.PostToolPrompt != "" {
 		postToolOpts = append(
 			postToolOpts,
 			processor.WithPostToolPrompt(options.PostToolPrompt),

--- a/agent/llmagent/llm_agent_test.go
+++ b/agent/llmagent/llm_agent_test.go
@@ -332,17 +332,25 @@ func TestBuildRequestProcessors_PostToolPromptInjection(t *testing.T) {
 		customPrompt  = "[Custom Prompt] Do not mention tools."
 	)
 
-	run := func(t *testing.T, opts *Options) string {
+	findPostToolProcessor := func(
+		t *testing.T,
+		opts *Options,
+	) *processor.PostToolRequestProcessor {
 		t.Helper()
 
 		procs := buildRequestProcessors("tester", opts)
-		var ptp *processor.PostToolRequestProcessor
 		for _, p := range procs {
 			if v, ok := p.(*processor.PostToolRequestProcessor); ok {
-				ptp = v
-				break
+				return v
 			}
 		}
+		return nil
+	}
+
+	run := func(t *testing.T, opts *Options) string {
+		t.Helper()
+
+		ptp := findPostToolProcessor(t, opts)
 		require.NotNil(t, ptp)
 
 		req := &model.Request{
@@ -377,16 +385,14 @@ func TestBuildRequestProcessors_PostToolPromptInjection(t *testing.T) {
 	t.Run("injection disabled", func(t *testing.T) {
 		opts := &Options{}
 		WithEnablePostToolPrompt(false)(opts)
-		got := run(t, opts)
-		require.Equal(t, systemContent, got)
+		require.Nil(t, findPostToolProcessor(t, opts))
 	})
 
 	t.Run("disable overrides custom prompt", func(t *testing.T) {
 		opts := &Options{}
 		WithPostToolPrompt(customPrompt)(opts)
 		WithEnablePostToolPrompt(false)(opts)
-		got := run(t, opts)
-		require.Equal(t, systemContent, got)
+		require.Nil(t, findPostToolProcessor(t, opts))
 	})
 }
 


### PR DESCRIPTION
## Summary
- stop registering the post-tool request processor when post-tool prompt injection is explicitly disabled
- keep the existing default behavior unchanged when the option is not set
- update llmagent tests to assert the processor is absent when disabled

## Testing
- go test ./agent/llmagent
- go test ./internal/flow/processor
- go test ./... (hits an existing unrelated failure in codeexecutor/local: TestRuntime_RunProgram_InjectsWorkspaceEnvs)

## Summary by Sourcery

当显式禁用工具执行后（post-tool）的提示注入功能时，跳过注册对应的请求处理器，并更新测试以反映在该配置下处理器不存在的情况。

Bug Fixes:
- 当相关选项被显式设置为 false 时，不再注册工具执行后请求处理器，从而确保工具执行后的提示注入功能被彻底禁用。

Tests:
- 更新 llmagent 的工具执行后提示注入测试，用于断言在禁用该功能时不存在工具执行后处理器，包括在同时配置了自定义提示的情况下。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Skip registering the post-tool request processor when post-tool prompt injection is explicitly disabled, and update tests to reflect the absence of the processor in this configuration.

Bug Fixes:
- Ensure post-tool prompt injection is fully disabled by not registering the post-tool request processor when the corresponding option is explicitly set to false.

Tests:
- Update llmagent post-tool prompt injection tests to assert that the post-tool processor is not present when disabled, including when a custom prompt is also configured.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved post-tool prompt handling to prevent unnecessary empty prompt injection when post-tool prompting is disabled. The system now correctly skips processing when the feature is not configured.

* **Tests**
  * Enhanced test validation to ensure post-tool processing is properly disabled and absent when the feature is deactivated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->