### PR TITLE
feat(a2a): add StructuredOutput → DataPart converter for custom event…

### DIFF
--- a/internal/a2a/a2a.go
+++ b/internal/a2a/a2a.go
@@ -33,6 +33,11 @@ const (
 	// Used by Google ADK for code execution scenarios.
 	DataPartMetadataTypeCodeExecutionResult = "code_execution_result"
 
+	// DataPartMetadataTypeCustomData is the metadata value for custom structured data DataPart.
+	// Used for events that carry structured output (e.g., RPC trace, decision details)
+	// via Event.StructuredOutput instead of plain text content.
+	DataPartMetadataTypeCustomData = "custom_data"
+
 	// ToolCallFieldID is the data field key for tool call ID.
 	ToolCallFieldID = "id"
 

--- a/server/a2a/README.md
+++ b/server/a2a/README.md
@@ -1,0 +1,90 @@
+# A2A Server — Event → A2A Message Converter
+
+## 概述
+
+`converter.go` 负责将 Agent 内部 `event.Event` 转换为 A2A 协议的 `Message`（unary）或 `StreamingMessageResult`（streaming）。
+
+## 转换流程（三阶段）
+
+```
+ConvertToA2AMessage / ConvertStreamingToA2AMessage:
+
+  阶段一：前置检查
+    nil / error / empty checks / graph object type 过滤
+
+  阶段二：主 Part 判定（互斥 if/else）
+    isToolCallEvent      → []Part{DataPart(function_call / function_response)}
+    isCodeExecutionEvent → []Part{DataPart(executable_code / code_execution_result)}
+    fallback             → []Part{TextPart(content + reasoning)}
+
+  阶段三：附属数据追加（正交维度）
+    if structuredOutputEnabled && StructuredOutput != nil:
+      parts = append(parts, DataPart(custom_data))
+    // 未来新增附属数据在这里继续 append
+```
+
+### 设计原则
+
+**ToolCall / CodeExecution / Content** 是互斥的事件主类型——一个 Event 只可能是其中一种。
+
+**StructuredOutput** 是事件的附属数据——任何类型的 Event 都可以同时携带。因此它作为**正交维度**在阶段三独立追加，不参与阶段二的互斥判定。
+
+## StructuredOutput 功能
+
+### 启用方式
+
+```go
+server, _ := a2a.New(
+    a2a.WithAgent(myAgent, true),
+    a2a.WithHost("localhost:8080"),
+    a2a.WithStructuredOutputEnabled(), // opt-in 启用
+)
+```
+
+### 行为
+
+| 场景 | 结果 |
+|------|------|
+| 未启用（默认） | `StructuredOutput` 被忽略 |
+| 启用 + `StructuredOutput` 为 `nil` | 不追加 |
+| 启用 + `StructuredOutput` 为无效 JSON | 不追加，不报错 |
+| 启用 + `StructuredOutput` 为有效数据 | 追加 `DataPart(custom_data)` |
+
+### 追加效果示例
+
+**Content + StructuredOutput：**
+```
+Message.Parts = [
+  TextPart("hello world"),          // 阶段二产生
+  DataPart({trace_id: "abc123"}),   // 阶段三追加，metadata.type = "custom_data"
+]
+```
+
+**ToolCall + StructuredOutput：**
+```
+Message.Parts = [
+  DataPart({id: "call-1", name: "my_tool", ...}),  // 阶段二产生，metadata.type = "function_call"
+  DataPart({extra: "data"}),                         // 阶段三追加，metadata.type = "custom_data"
+]
+```
+
+### ADK 兼容
+
+当 `WithADKCompatibility(true)` 启用时，追加的 DataPart 会同时携带 `type` 和 `adk_type` 元数据键。
+
+## 文件结构
+
+| 文件 | 职责 |
+|------|------|
+| `converter.go` | Event → A2A Message 转换逻辑，包含三阶段主流程 |
+| `server_option.go` | Server Option 定义，包括 `WithStructuredOutputEnabled()` |
+| `server.go` | Server 构建，将 option 传递给 converter |
+| `converter_test.go` | 覆盖所有转换场景的测试 |
+
+## 关键方法
+
+- `ConvertToA2AMessage()` — unary 转换入口
+- `ConvertStreamingToA2AMessage()` — streaming 转换入口
+- `appendStructuredOutput()` — 正交追加 StructuredOutput（unary）
+- `appendStructuredOutputStreaming()` — 正交追加 StructuredOutput（streaming）
+- `toDataPartPayload()` — StructuredOutput 数据规范化（支持 `map[string]any`、`[]byte`、`json.RawMessage`、任意 struct）

--- a/server/a2a/converter.go
+++ b/server/a2a/converter.go
@@ -124,6 +124,15 @@ func (c *defaultA2AMessageToAgentMessage) ConvertToAgentMessage(
 	return &msg, nil
 }
 
+// EventPartConverter is a hook that converts custom event data into A2A Parts.
+// It is invoked after ToolCall / CodeExecution checks but before the text fallback.
+//
+// Return semantics:
+//   - (parts, true, nil)  → use the returned parts to build the A2A message
+//   - (nil,   false, nil) → not handled, fall through to the downstream fallback (TextPart)
+//   - (_,     _,     err) → return error
+type EventPartConverter func(ctx context.Context, evt *event.Event) ([]protocol.Part, bool, error)
+
 // defaultEventToA2AMessage is the default implementation of EventToA2AMessageConverter.
 type defaultEventToA2AMessage struct {
 	// Enable ADK-compatible metadata keys (for example, "adk_type" instead
@@ -131,6 +140,7 @@ type defaultEventToA2AMessage struct {
 	adkCompatibility          bool
 	graphEventObjectAllowlist []string
 	streamingEventType        StreamingEventType
+	eventPartConverter        EventPartConverter
 }
 
 const graphObjectPrefix = "graph."
@@ -288,9 +298,16 @@ func (c *defaultEventToA2AMessage) ConvertToA2AMessage(
 		return c.convertCodeExecutionToA2AMessage(event)
 	}
 
-	// Check if the event carries structured output (e.g., RPC trace, decision details).
-	if hasStructuredOutput(event) {
-		return c.convertStructuredOutputToA2AMessage(event)
+	// Invoke the eventPartConverter hook if registered.
+	if c.eventPartConverter != nil {
+		parts, handled, err := c.eventPartConverter(ctx, event)
+		if err != nil {
+			return nil, err
+		}
+		if handled {
+			c.applyADKMetadataToParts(parts)
+			return c.buildA2AMessageFromParts(event, parts)
+		}
 	}
 
 	// Fallback to plain content conversion.
@@ -423,9 +440,16 @@ func (c *defaultEventToA2AMessage) ConvertStreamingToA2AMessage(
 		return c.convertCodeExecutionToA2AStreamingMessage(evt, options)
 	}
 
-	// Check if the event carries structured output (e.g., RPC trace, decision details).
-	if hasStructuredOutput(evt) {
-		return c.convertStructuredOutputToA2AStreamingMessage(evt, options)
+	// Invoke the eventPartConverter hook if registered.
+	if c.eventPartConverter != nil {
+		parts, handled, err := c.eventPartConverter(ctx, evt)
+		if err != nil {
+			return nil, err
+		}
+		if handled {
+			c.applyADKMetadataToParts(parts)
+			return c.convertPartsToA2AStreamingResult(evt, options, parts), nil
+		}
 	}
 
 	return c.convertDeltaContentToA2AStreamingMessage(ctx, evt, options)
@@ -693,9 +717,62 @@ func (c *defaultEventToA2AMessage) convertCodeExecutionToA2AStreamingMessage(
 	), nil
 }
 
-// hasStructuredOutput checks if an event carries a non-nil StructuredOutput payload.
-func hasStructuredOutput(evt *event.Event) bool {
-	return evt != nil && evt.StructuredOutput != nil
+// applyADKMetadataToParts iterates over hook-returned parts and, for DataParts
+// that carry a "type" metadata key, adds the corresponding "adk_type" key when
+// ADK compatibility is enabled. This keeps the hook implementation simple: it
+// only needs to set the standard "type" key.
+func (c *defaultEventToA2AMessage) applyADKMetadataToParts(parts []protocol.Part) {
+	if !c.adkCompatibility {
+		return
+	}
+	for _, part := range parts {
+		dp, ok := part.(*protocol.DataPart)
+		if !ok || dp.Metadata == nil {
+			continue
+		}
+		if typeVal, exists := dp.Metadata[ia2a.DataPartMetadataTypeKey]; exists {
+			dp.Metadata[ia2a.GetADKMetadataKey(ia2a.DataPartMetadataTypeKey)] = typeVal
+		}
+	}
+}
+
+// buildA2AMessageFromParts creates a unary A2A message from the given parts and
+// event metadata. It is shared between the eventPartConverter hook path and
+// internal converters.
+func (c *defaultEventToA2AMessage) buildA2AMessageFromParts(
+	evt *event.Event, parts []protocol.Part,
+) (protocol.UnaryMessageResult, error) {
+	if len(parts) == 0 {
+		return nil, nil
+	}
+	msg := protocol.NewMessage(protocol.MessageRoleAgent, parts)
+	msg.Metadata = c.buildMessageMetadata(evt)
+	return &msg, nil
+}
+
+// StructuredOutputPartConverter returns an EventPartConverter that converts
+// Event.StructuredOutput into a DataPart with metadata type "custom_data".
+//
+// Usage:
+//
+//	a2a.WithEventPartConverter(a2a.StructuredOutputPartConverter())
+func StructuredOutputPartConverter() EventPartConverter {
+	return func(ctx context.Context, evt *event.Event) ([]protocol.Part, bool, error) {
+		if evt.StructuredOutput == nil {
+			return nil, false, nil
+		}
+		data, ok := toDataPartPayload(evt.StructuredOutput)
+		if !ok {
+			return nil, false, nil
+		}
+		dataPart := protocol.NewDataPart(data)
+		dataPart.Metadata = map[string]any{
+			ia2a.DataPartMetadataTypeKey: ia2a.DataPartMetadataTypeCustomData,
+		}
+		// ADK compat (adk_type) is applied by the converter after hook return;
+		// the hook does not need to handle it.
+		return []protocol.Part{&dataPart}, true, nil
+	}
 }
 
 // toDataPartPayload normalises an arbitrary StructuredOutput value into a
@@ -735,46 +812,6 @@ func toDataPartPayload(v any) (any, bool) {
 		}
 		return out, true
 	}
-}
-
-// convertStructuredOutputToA2AMessage converts an event with StructuredOutput
-// into an A2A DataPart message (unary path).
-func (c *defaultEventToA2AMessage) convertStructuredOutputToA2AMessage(
-	evt *event.Event,
-) (protocol.UnaryMessageResult, error) {
-	data, ok := toDataPartPayload(evt.StructuredOutput)
-	if !ok {
-		return nil, nil
-	}
-
-	dataPart := protocol.NewDataPart(data)
-	c.setPartTypeMetadata(&dataPart, ia2a.DataPartMetadataTypeCustomData)
-
-	parts := []protocol.Part{&dataPart}
-	msg := protocol.NewMessage(protocol.MessageRoleAgent, parts)
-	msg.Metadata = c.buildMessageMetadata(evt)
-	return &msg, nil
-}
-
-// convertStructuredOutputToA2AStreamingMessage converts an event with
-// StructuredOutput into an A2A streaming result.
-// It reuses the unary converter then wraps via convertPartsToA2AStreamingResult,
-// following the same pattern as convertToolCallToA2AStreamingMessage.
-func (c *defaultEventToA2AMessage) convertStructuredOutputToA2AStreamingMessage(
-	evt *event.Event,
-	options EventToA2AStreamingOptions,
-) (protocol.StreamingMessageResult, error) {
-	unaryResult, err := c.convertStructuredOutputToA2AMessage(evt)
-	if err != nil || unaryResult == nil {
-		return nil, err
-	}
-
-	msg, ok := unaryResult.(*protocol.Message)
-	if !ok || len(msg.Parts) == 0 {
-		return nil, nil
-	}
-
-	return c.convertPartsToA2AStreamingResult(evt, options, msg.Parts), nil
 }
 
 // convertFilePart converts a protocol.FilePart to one or more model.ContentPart values.

--- a/server/a2a/converter.go
+++ b/server/a2a/converter.go
@@ -124,15 +124,6 @@ func (c *defaultA2AMessageToAgentMessage) ConvertToAgentMessage(
 	return &msg, nil
 }
 
-// EventPartConverter is a hook that converts custom event data into A2A Parts.
-// It is invoked after ToolCall / CodeExecution checks but before the text fallback.
-//
-// Return semantics:
-//   - (parts, true, nil)  → use the returned parts to build the A2A message
-//   - (nil,   false, nil) → not handled, fall through to the downstream fallback (TextPart)
-//   - (_,     _,     err) → return error
-type EventPartConverter func(ctx context.Context, evt *event.Event) ([]protocol.Part, bool, error)
-
 // defaultEventToA2AMessage is the default implementation of EventToA2AMessageConverter.
 type defaultEventToA2AMessage struct {
 	// Enable ADK-compatible metadata keys (for example, "adk_type" instead
@@ -140,7 +131,10 @@ type defaultEventToA2AMessage struct {
 	adkCompatibility          bool
 	graphEventObjectAllowlist []string
 	streamingEventType        StreamingEventType
-	eventPartConverter        EventPartConverter
+	// structuredOutputEnabled controls whether Event.StructuredOutput is
+	// converted to a DataPart and appended (orthogonally) to the A2A message.
+	// When false, StructuredOutput is silently ignored.
+	structuredOutputEnabled bool
 }
 
 const graphObjectPrefix = "graph."
@@ -288,30 +282,24 @@ func (c *defaultEventToA2AMessage) ConvertToA2AMessage(
 		return nil, nil
 	}
 
-	// Check if this is a tool call event.
-	if isToolCallEvent(event) {
-		return c.convertToolCallToA2AMessage(event)
+	// Phase 2: Main Part determination (mutually exclusive).
+	var result protocol.UnaryMessageResult
+	var err error
+
+	switch {
+	case isToolCallEvent(event):
+		result, err = c.convertToolCallToA2AMessage(event)
+	case isCodeExecutionEvent(event):
+		result, err = c.convertCodeExecutionToA2AMessage(event)
+	default:
+		result, err = c.convertContentToA2AMessage(ctx, event)
+	}
+	if err != nil {
+		return nil, err
 	}
 
-	// Check if this is a code execution event.
-	if isCodeExecutionEvent(event) {
-		return c.convertCodeExecutionToA2AMessage(event)
-	}
-
-	// Invoke the eventPartConverter hook if registered.
-	if c.eventPartConverter != nil {
-		parts, handled, err := c.eventPartConverter(ctx, event)
-		if err != nil {
-			return nil, err
-		}
-		if handled {
-			c.applyADKMetadataToParts(parts)
-			return c.buildA2AMessageFromParts(event, parts)
-		}
-	}
-
-	// Fallback to plain content conversion.
-	return c.convertContentToA2AMessage(ctx, event)
+	// Phase 3: Orthogonal StructuredOutput append (opt-in).
+	return c.appendStructuredOutput(event, result)
 }
 
 // convertCodeExecutionToA2AMessage converts code execution events to A2A DataPart messages.
@@ -431,28 +419,24 @@ func (c *defaultEventToA2AMessage) ConvertStreamingToA2AMessage(
 		return nil, nil
 	}
 
-	// Check if this is a tool call event
-	if isToolCallEvent(evt) {
-		return c.convertToolCallToA2AStreamingMessage(evt, options)
+	// Phase 2: Main Part determination (mutually exclusive).
+	var result protocol.StreamingMessageResult
+	var err error
+
+	switch {
+	case isToolCallEvent(evt):
+		result, err = c.convertToolCallToA2AStreamingMessage(evt, options)
+	case isCodeExecutionEvent(evt):
+		result, err = c.convertCodeExecutionToA2AStreamingMessage(evt, options)
+	default:
+		result, err = c.convertDeltaContentToA2AStreamingMessage(ctx, evt, options)
+	}
+	if err != nil {
+		return nil, err
 	}
 
-	if isCodeExecutionEvent(evt) {
-		return c.convertCodeExecutionToA2AStreamingMessage(evt, options)
-	}
-
-	// Invoke the eventPartConverter hook if registered.
-	if c.eventPartConverter != nil {
-		parts, handled, err := c.eventPartConverter(ctx, evt)
-		if err != nil {
-			return nil, err
-		}
-		if handled {
-			c.applyADKMetadataToParts(parts)
-			return c.convertPartsToA2AStreamingResult(evt, options, parts), nil
-		}
-	}
-
-	return c.convertDeltaContentToA2AStreamingMessage(ctx, evt, options)
+	// Phase 3: Orthogonal StructuredOutput append (opt-in).
+	return c.appendStructuredOutputStreaming(evt, options, result)
 }
 
 func (c *defaultEventToA2AMessage) convertMetadataOnlyToA2AMessageResult(
@@ -717,28 +701,66 @@ func (c *defaultEventToA2AMessage) convertCodeExecutionToA2AStreamingMessage(
 	), nil
 }
 
-// applyADKMetadataToParts iterates over hook-returned parts and, for DataParts
-// that carry a "type" metadata key, adds the corresponding "adk_type" key when
-// ADK compatibility is enabled. This keeps the hook implementation simple: it
-// only needs to set the standard "type" key.
-func (c *defaultEventToA2AMessage) applyADKMetadataToParts(parts []protocol.Part) {
-	if !c.adkCompatibility {
-		return
+// appendStructuredOutput appends a DataPart for Event.StructuredOutput to the
+// already-built unary result. It is a no-op when structuredOutputEnabled is
+// false or StructuredOutput is nil/invalid.
+func (c *defaultEventToA2AMessage) appendStructuredOutput(
+	evt *event.Event, result protocol.UnaryMessageResult,
+) (protocol.UnaryMessageResult, error) {
+	if !c.structuredOutputEnabled || evt.StructuredOutput == nil {
+		return result, nil
 	}
-	for _, part := range parts {
-		dp, ok := part.(*protocol.DataPart)
-		if !ok || dp.Metadata == nil {
-			continue
-		}
-		if typeVal, exists := dp.Metadata[ia2a.DataPartMetadataTypeKey]; exists {
-			dp.Metadata[ia2a.GetADKMetadataKey(ia2a.DataPartMetadataTypeKey)] = typeVal
-		}
+	data, ok := toDataPartPayload(evt.StructuredOutput)
+	if !ok {
+		return result, nil
+	}
+	dataPart := protocol.NewDataPart(data)
+	c.setPartTypeMetadata(&dataPart, ia2a.DataPartMetadataTypeCustomData)
+
+	// Append to existing Message.
+	if msg, ok := result.(*protocol.Message); ok {
+		msg.Parts = append(msg.Parts, &dataPart)
+		return msg, nil
+	}
+	// result is nil — create a new Message carrying only the DataPart.
+	return c.buildA2AMessageFromParts(evt, []protocol.Part{&dataPart})
+}
+
+// appendStructuredOutputStreaming appends a DataPart for Event.StructuredOutput
+// to the already-built streaming result.
+func (c *defaultEventToA2AMessage) appendStructuredOutputStreaming(
+	evt *event.Event,
+	options EventToA2AStreamingOptions,
+	result protocol.StreamingMessageResult,
+) (protocol.StreamingMessageResult, error) {
+	if !c.structuredOutputEnabled || evt.StructuredOutput == nil {
+		return result, nil
+	}
+	data, ok := toDataPartPayload(evt.StructuredOutput)
+	if !ok {
+		return result, nil
+	}
+	dataPart := protocol.NewDataPart(data)
+	c.setPartTypeMetadata(&dataPart, ia2a.DataPartMetadataTypeCustomData)
+
+	// Try to append to existing streaming result.
+	switch r := result.(type) {
+	case *protocol.Message:
+		r.Parts = append(r.Parts, &dataPart)
+		return r, nil
+	case *protocol.TaskArtifactUpdateEvent:
+		r.Artifact.Parts = append(r.Artifact.Parts, &dataPart)
+		return r, nil
+	default:
+		// result is nil or unrecognised — create new streaming result.
+		return c.convertPartsToA2AStreamingResult(
+			evt, options, []protocol.Part{&dataPart},
+		), nil
 	}
 }
 
 // buildA2AMessageFromParts creates a unary A2A message from the given parts and
-// event metadata. It is shared between the eventPartConverter hook path and
-// internal converters.
+// event metadata.
 func (c *defaultEventToA2AMessage) buildA2AMessageFromParts(
 	evt *event.Event, parts []protocol.Part,
 ) (protocol.UnaryMessageResult, error) {
@@ -748,31 +770,6 @@ func (c *defaultEventToA2AMessage) buildA2AMessageFromParts(
 	msg := protocol.NewMessage(protocol.MessageRoleAgent, parts)
 	msg.Metadata = c.buildMessageMetadata(evt)
 	return &msg, nil
-}
-
-// StructuredOutputPartConverter returns an EventPartConverter that converts
-// Event.StructuredOutput into a DataPart with metadata type "custom_data".
-//
-// Usage:
-//
-//	a2a.WithEventPartConverter(a2a.StructuredOutputPartConverter())
-func StructuredOutputPartConverter() EventPartConverter {
-	return func(ctx context.Context, evt *event.Event) ([]protocol.Part, bool, error) {
-		if evt.StructuredOutput == nil {
-			return nil, false, nil
-		}
-		data, ok := toDataPartPayload(evt.StructuredOutput)
-		if !ok {
-			return nil, false, nil
-		}
-		dataPart := protocol.NewDataPart(data)
-		dataPart.Metadata = map[string]any{
-			ia2a.DataPartMetadataTypeKey: ia2a.DataPartMetadataTypeCustomData,
-		}
-		// ADK compat (adk_type) is applied by the converter after hook return;
-		// the hook does not need to handle it.
-		return []protocol.Part{&dataPart}, true, nil
-	}
 }
 
 // toDataPartPayload normalises an arbitrary StructuredOutput value into a

--- a/server/a2a/converter.go
+++ b/server/a2a/converter.go
@@ -12,6 +12,7 @@ package a2a
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -287,6 +288,11 @@ func (c *defaultEventToA2AMessage) ConvertToA2AMessage(
 		return c.convertCodeExecutionToA2AMessage(event)
 	}
 
+	// Check if the event carries structured output (e.g., RPC trace, decision details).
+	if hasStructuredOutput(event) {
+		return c.convertStructuredOutputToA2AMessage(event)
+	}
+
 	// Fallback to plain content conversion.
 	return c.convertContentToA2AMessage(ctx, event)
 }
@@ -415,6 +421,11 @@ func (c *defaultEventToA2AMessage) ConvertStreamingToA2AMessage(
 
 	if isCodeExecutionEvent(evt) {
 		return c.convertCodeExecutionToA2AStreamingMessage(evt, options)
+	}
+
+	// Check if the event carries structured output (e.g., RPC trace, decision details).
+	if hasStructuredOutput(evt) {
+		return c.convertStructuredOutputToA2AStreamingMessage(evt, options)
 	}
 
 	return c.convertDeltaContentToA2AStreamingMessage(ctx, evt, options)
@@ -680,6 +691,90 @@ func (c *defaultEventToA2AMessage) convertCodeExecutionToA2AStreamingMessage(
 		options,
 		msg.Parts,
 	), nil
+}
+
+// hasStructuredOutput checks if an event carries a non-nil StructuredOutput payload.
+func hasStructuredOutput(evt *event.Event) bool {
+	return evt != nil && evt.StructuredOutput != nil
+}
+
+// toDataPartPayload normalises an arbitrary StructuredOutput value into a
+// type that protocol.NewDataPart accepts (typically map[string]any).
+//
+// Supported input types:
+//   - map[string]any         → used directly
+//   - []byte / json.RawMessage → json.Unmarshal into any
+//   - anything else          → json.Marshal then json.Unmarshal (round-trip)
+//
+// Returns (nil, false) when the conversion fails so the caller can skip the
+// event gracefully without panicking.
+func toDataPartPayload(v any) (any, bool) {
+	switch val := v.(type) {
+	case map[string]any:
+		return val, true
+	case []byte:
+		var out any
+		if err := json.Unmarshal(val, &out); err != nil {
+			return nil, false
+		}
+		return out, true
+	case json.RawMessage:
+		var out any
+		if err := json.Unmarshal(val, &out); err != nil {
+			return nil, false
+		}
+		return out, true
+	default:
+		b, err := json.Marshal(val)
+		if err != nil {
+			return nil, false
+		}
+		var out any
+		if err := json.Unmarshal(b, &out); err != nil {
+			return nil, false
+		}
+		return out, true
+	}
+}
+
+// convertStructuredOutputToA2AMessage converts an event with StructuredOutput
+// into an A2A DataPart message (unary path).
+func (c *defaultEventToA2AMessage) convertStructuredOutputToA2AMessage(
+	evt *event.Event,
+) (protocol.UnaryMessageResult, error) {
+	data, ok := toDataPartPayload(evt.StructuredOutput)
+	if !ok {
+		return nil, nil
+	}
+
+	dataPart := protocol.NewDataPart(data)
+	c.setPartTypeMetadata(&dataPart, ia2a.DataPartMetadataTypeCustomData)
+
+	parts := []protocol.Part{&dataPart}
+	msg := protocol.NewMessage(protocol.MessageRoleAgent, parts)
+	msg.Metadata = c.buildMessageMetadata(evt)
+	return &msg, nil
+}
+
+// convertStructuredOutputToA2AStreamingMessage converts an event with
+// StructuredOutput into an A2A streaming result.
+// It reuses the unary converter then wraps via convertPartsToA2AStreamingResult,
+// following the same pattern as convertToolCallToA2AStreamingMessage.
+func (c *defaultEventToA2AMessage) convertStructuredOutputToA2AStreamingMessage(
+	evt *event.Event,
+	options EventToA2AStreamingOptions,
+) (protocol.StreamingMessageResult, error) {
+	unaryResult, err := c.convertStructuredOutputToA2AMessage(evt)
+	if err != nil || unaryResult == nil {
+		return nil, err
+	}
+
+	msg, ok := unaryResult.(*protocol.Message)
+	if !ok || len(msg.Parts) == 0 {
+		return nil, nil
+	}
+
+	return c.convertPartsToA2AStreamingResult(evt, options, msg.Parts), nil
 }
 
 // convertFilePart converts a protocol.FilePart to one or more model.ContentPart values.

--- a/server/a2a/converter_test.go
+++ b/server/a2a/converter_test.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -3419,22 +3418,27 @@ func TestToDataPartPayload(t *testing.T) {
 
 func TestStructuredOutput_UnaryConversion(t *testing.T) {
 	ctx := context.Background()
-	hook := StructuredOutputPartConverter()
 
 	tests := []struct {
 		name            string
 		event           *event.Event
+		enabled         bool
 		expectNil       bool
 		checkDataType   string
 		checkObjectType string
+		// expectPartCount is the expected number of parts in the message.
+		// 0 means "don't check".
+		expectPartCount int
 	}{
 		{
-			name: "StructuredOutput map generates DataPart with custom_data type",
+			name: "Content + StructuredOutput coexist",
 			event: &event.Event{
 				Response: &model.Response{
 					Object: "graph.node.custom",
 					Choices: []model.Choice{{
-						Message: model.Message{},
+						Message: model.Message{
+							Content: "hello world",
+						},
 					}},
 				},
 				StructuredOutput: map[string]any{
@@ -3442,70 +3446,13 @@ func TestStructuredOutput_UnaryConversion(t *testing.T) {
 					"latency":  42.5,
 				},
 			},
+			enabled:         true,
 			expectNil:       false,
-			checkDataType:   ia2a.DataPartMetadataTypeCustomData,
+			expectPartCount: 2, // TextPart + DataPart
 			checkObjectType: "graph.node.custom",
 		},
 		{
-			name: "StructuredOutput []byte valid JSON generates DataPart",
-			event: &event.Event{
-				Response: &model.Response{
-					Object: "graph.node.custom",
-					Choices: []model.Choice{{
-						Message: model.Message{},
-					}},
-				},
-				StructuredOutput: []byte(`{"service":"my-svc","code":200}`),
-			},
-			expectNil:     false,
-			checkDataType: ia2a.DataPartMetadataTypeCustomData,
-		},
-		{
-			name: "StructuredOutput json.RawMessage generates DataPart",
-			event: &event.Event{
-				Response: &model.Response{
-					Object: "graph.node.custom",
-					Choices: []model.Choice{{
-						Message: model.Message{},
-					}},
-				},
-				StructuredOutput: json.RawMessage(`{"raw_key":"raw_val"}`),
-			},
-			expectNil:     false,
-			checkDataType: ia2a.DataPartMetadataTypeCustomData,
-		},
-		{
-			name: "StructuredOutput nil falls through to TextPart fallback",
-			event: &event.Event{
-				Response: &model.Response{
-					Object: "graph.node.custom",
-					Choices: []model.Choice{{
-						Message: model.Message{
-							Content: "fallback text",
-						},
-					}},
-				},
-				StructuredOutput: nil,
-			},
-			expectNil:     false,
-			checkDataType: "", // not a DataPart, should be a TextPart
-		},
-		{
-			name: "StructuredOutput invalid JSON []byte falls through to metadata-only message",
-			event: &event.Event{
-				Response: &model.Response{
-					Object: "graph.node.custom",
-					Choices: []model.Choice{{
-						Message: model.Message{},
-					}},
-				},
-				StructuredOutput: []byte(`not valid json {{{`),
-			},
-			expectNil:     false,
-			checkDataType: "metadata_only", // special sentinel: message has metadata but no content parts
-		},
-		{
-			name: "ToolCall event takes priority over StructuredOutput",
+			name: "ToolCall + StructuredOutput coexist",
 			event: &event.Event{
 				Response: &model.Response{
 					Object: "graph.node.custom",
@@ -3524,10 +3471,110 @@ func TestStructuredOutput_UnaryConversion(t *testing.T) {
 						},
 					}},
 				},
+				StructuredOutput: map[string]any{"extra": "data"},
+			},
+			enabled:         true,
+			expectNil:       false,
+			expectPartCount: 2, // DataPart(function_call) + DataPart(custom_data)
+		},
+		{
+			name: "CodeExecution + StructuredOutput coexist",
+			event: &event.Event{
+				Tag: string(event.CodeExecutionTag),
+				Response: &model.Response{
+					Object: model.ObjectTypePostprocessingCodeExecution,
+					Choices: []model.Choice{{
+						Message: model.Message{
+							Content: "print('hi')",
+						},
+					}},
+				},
+				StructuredOutput: map[string]any{"exec_id": "e1"},
+			},
+			enabled:         true,
+			expectNil:       false,
+			expectPartCount: 2, // DataPart(executable_code) + DataPart(custom_data)
+		},
+		{
+			name: "StructuredOutput []byte valid JSON",
+			event: &event.Event{
+				Response: &model.Response{
+					Object: "graph.node.custom",
+					Choices: []model.Choice{{
+						Message: model.Message{},
+					}},
+				},
+				StructuredOutput: []byte(`{"service":"my-svc","code":200}`),
+			},
+			enabled:       true,
+			expectNil:     false,
+			checkDataType: ia2a.DataPartMetadataTypeCustomData,
+		},
+		{
+			name: "StructuredOutput json.RawMessage",
+			event: &event.Event{
+				Response: &model.Response{
+					Object: "graph.node.custom",
+					Choices: []model.Choice{{
+						Message: model.Message{},
+					}},
+				},
+				StructuredOutput: json.RawMessage(`{"raw_key":"raw_val"}`),
+			},
+			enabled:       true,
+			expectNil:     false,
+			checkDataType: ia2a.DataPartMetadataTypeCustomData,
+		},
+		{
+			name: "StructuredOutput nil — not appended",
+			event: &event.Event{
+				Response: &model.Response{
+					Object: "graph.node.custom",
+					Choices: []model.Choice{{
+						Message: model.Message{
+							Content: "fallback text",
+						},
+					}},
+				},
+				StructuredOutput: nil,
+			},
+			enabled:         true,
+			expectNil:       false,
+			expectPartCount: 1, // only TextPart
+		},
+		{
+			name: "StructuredOutput invalid JSON — not appended, no error",
+			event: &event.Event{
+				Response: &model.Response{
+					Object: "graph.node.custom",
+					Choices: []model.Choice{{
+						Message: model.Message{
+							Content: "text",
+						},
+					}},
+				},
+				StructuredOutput: []byte(`not valid json {{{`),
+			},
+			enabled:         true,
+			expectNil:       false,
+			expectPartCount: 1, // only TextPart, invalid SO silently skipped
+		},
+		{
+			name: "Disabled — StructuredOutput ignored",
+			event: &event.Event{
+				Response: &model.Response{
+					Object: "graph.node.custom",
+					Choices: []model.Choice{{
+						Message: model.Message{
+							Content: "hello",
+						},
+					}},
+				},
 				StructuredOutput: map[string]any{"should": "be ignored"},
 			},
-			expectNil:     false,
-			checkDataType: ia2a.DataPartMetadataTypeFunctionCall, // ToolCall wins
+			enabled:         false,
+			expectNil:       false,
+			expectPartCount: 1, // only TextPart
 		},
 	}
 
@@ -3535,7 +3582,7 @@ func TestStructuredOutput_UnaryConversion(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			converter := &defaultEventToA2AMessage{
 				graphEventObjectAllowlist: []string{"graph.*"},
-				eventPartConverter:        hook,
+				structuredOutputEnabled:   tt.enabled,
 			}
 			result, err := converter.ConvertToA2AMessage(ctx, tt.event, EventToA2AUnaryOptions{CtxID: "ctx-1"})
 			if err != nil {
@@ -3558,30 +3605,16 @@ func TestStructuredOutput_UnaryConversion(t *testing.T) {
 				t.Fatalf("expected *protocol.Message, got %T", result)
 			}
 
-			if tt.checkDataType == "" {
-				// Expect a TextPart (nil StructuredOutput fallback case)
-				if len(msg.Parts) == 0 {
-					t.Fatal("expected at least one part")
-				}
-				if msg.Parts[0].GetKind() != protocol.KindText {
-					t.Errorf("expected TextPart, got kind %s", msg.Parts[0].GetKind())
-				}
-				return
+			if tt.expectPartCount > 0 && len(msg.Parts) != tt.expectPartCount {
+				t.Errorf("expected %d parts, got %d", tt.expectPartCount, len(msg.Parts))
 			}
 
-			if tt.checkDataType == "metadata_only" {
-				// Hook returned not-handled, fell through to text fallback which
-				// produced a metadata-only message (no content, but object_type set).
-				if msg.Metadata == nil {
-					t.Fatal("expected message metadata for metadata-only message")
+			if tt.checkDataType != "" {
+				dp := extractDataPartFromResult(t, result)
+				gotType := ia2a.GetDataPartType(dp.Metadata)
+				if gotType != tt.checkDataType {
+					t.Errorf("DataPart type = %q, want %q", gotType, tt.checkDataType)
 				}
-				return
-			}
-
-			dp := extractDataPartFromResult(t, result)
-			gotType := ia2a.GetDataPartType(dp.Metadata)
-			if gotType != tt.checkDataType {
-				t.Errorf("DataPart type = %q, want %q", gotType, tt.checkDataType)
 			}
 
 			if tt.checkObjectType != "" {
@@ -3599,25 +3632,28 @@ func TestStructuredOutput_UnaryConversion(t *testing.T) {
 func TestStructuredOutput_StreamingConversion(t *testing.T) {
 	ctx := context.Background()
 	opts := EventToA2AStreamingOptions{TaskID: "task-1", CtxID: "ctx-1"}
-	hook := StructuredOutputPartConverter()
 
 	tests := []struct {
 		name      string
 		event     *event.Event
+		enabled   bool
 		expectNil bool
 	}{
 		{
-			name: "streaming StructuredOutput map generates result",
+			name: "streaming Content + StructuredOutput coexist",
 			event: &event.Event{
 				Response: &model.Response{
 					ID:     "resp-1",
 					Object: "graph.node.custom",
 					Choices: []model.Choice{{
-						Message: model.Message{},
+						Delta: model.Message{
+							Content: "delta text",
+						},
 					}},
 				},
 				StructuredOutput: map[string]any{"stream_key": "stream_val"},
 			},
+			enabled:   true,
 			expectNil: false,
 		},
 		{
@@ -3634,21 +3670,42 @@ func TestStructuredOutput_StreamingConversion(t *testing.T) {
 				},
 				StructuredOutput: nil,
 			},
+			enabled:   true,
 			expectNil: false, // falls through to delta content
 		},
 		{
-			name: "streaming StructuredOutput invalid JSON falls through",
+			name: "streaming StructuredOutput invalid JSON — ignored",
 			event: &event.Event{
 				Response: &model.Response{
 					ID:     "resp-3",
 					Object: "graph.node.custom",
 					Choices: []model.Choice{{
-						Message: model.Message{},
+						Delta: model.Message{
+							Content: "delta",
+						},
 					}},
 				},
 				StructuredOutput: []byte(`{bad json`),
 			},
-			expectNil: false, // hook returns not-handled, falls through to delta/metadata
+			enabled:   true,
+			expectNil: false, // invalid SO ignored, falls through to delta
+		},
+		{
+			name: "streaming disabled — StructuredOutput ignored",
+			event: &event.Event{
+				Response: &model.Response{
+					ID:     "resp-4",
+					Object: "graph.node.custom",
+					Choices: []model.Choice{{
+						Delta: model.Message{
+							Content: "delta text",
+						},
+					}},
+				},
+				StructuredOutput: map[string]any{"should": "be ignored"},
+			},
+			enabled:   false,
+			expectNil: false,
 		},
 	}
 
@@ -3656,7 +3713,7 @@ func TestStructuredOutput_StreamingConversion(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			converter := &defaultEventToA2AMessage{
 				graphEventObjectAllowlist: []string{"graph.*"},
-				eventPartConverter:        hook,
+				structuredOutputEnabled:   tt.enabled,
 			}
 			result, err := converter.ConvertStreamingToA2AMessage(ctx, tt.event, opts)
 			if err != nil {
@@ -3678,14 +3735,15 @@ func TestStructuredOutput_StreamingConversion(t *testing.T) {
 func TestStructuredOutput_StreamingMessageType(t *testing.T) {
 	ctx := context.Background()
 	opts := EventToA2AStreamingOptions{TaskID: "task-1", CtxID: "ctx-1"}
-	hook := StructuredOutputPartConverter()
 
 	evt := &event.Event{
 		Response: &model.Response{
 			ID:     "resp-msg",
 			Object: "graph.node.custom",
 			Choices: []model.Choice{{
-				Message: model.Message{},
+				Delta: model.Message{
+					Content: "delta",
+				},
 			}},
 		},
 		StructuredOutput: map[string]any{"key": "val"},
@@ -3695,7 +3753,7 @@ func TestStructuredOutput_StreamingMessageType(t *testing.T) {
 	converter := &defaultEventToA2AMessage{
 		graphEventObjectAllowlist: []string{"graph.*"},
 		streamingEventType:        StreamingEventTypeMessage,
-		eventPartConverter:        hook,
+		structuredOutputEnabled:   true,
 	}
 	result, err := converter.ConvertStreamingToA2AMessage(ctx, evt, opts)
 	if err != nil {
@@ -3709,159 +3767,8 @@ func TestStructuredOutput_StreamingMessageType(t *testing.T) {
 	}
 }
 
-func TestStructuredOutputPartConverter(t *testing.T) {
+func TestStructuredOutput_ADKCompatibility(t *testing.T) {
 	ctx := context.Background()
-	hook := StructuredOutputPartConverter()
-
-	t.Run("nil StructuredOutput returns not handled", func(t *testing.T) {
-		evt := &event.Event{
-			Response: &model.Response{},
-		}
-		parts, handled, err := hook(ctx, evt)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if handled {
-			t.Error("expected handled=false for nil StructuredOutput")
-		}
-		if parts != nil {
-			t.Errorf("expected nil parts, got %v", parts)
-		}
-	})
-
-	t.Run("valid map returns DataPart", func(t *testing.T) {
-		evt := &event.Event{
-			Response:         &model.Response{},
-			StructuredOutput: map[string]any{"key": "val"},
-		}
-		parts, handled, err := hook(ctx, evt)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if !handled {
-			t.Error("expected handled=true")
-		}
-		if len(parts) != 1 {
-			t.Fatalf("expected 1 part, got %d", len(parts))
-		}
-		dp, ok := parts[0].(*protocol.DataPart)
-		if !ok {
-			t.Fatalf("expected *protocol.DataPart, got %T", parts[0])
-		}
-		gotType := ia2a.GetDataPartType(dp.Metadata)
-		if gotType != ia2a.DataPartMetadataTypeCustomData {
-			t.Errorf("type = %q, want %q", gotType, ia2a.DataPartMetadataTypeCustomData)
-		}
-	})
-
-	t.Run("invalid JSON returns not handled", func(t *testing.T) {
-		evt := &event.Event{
-			Response:         &model.Response{},
-			StructuredOutput: []byte(`{bad`),
-		}
-		parts, handled, err := hook(ctx, evt)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if handled {
-			t.Error("expected handled=false for invalid JSON")
-		}
-		if parts != nil {
-			t.Errorf("expected nil parts, got %v", parts)
-		}
-	})
-}
-
-func TestEventPartConverter_NoHookIgnoresStructuredOutput(t *testing.T) {
-	ctx := context.Background()
-
-	// Without a hook, StructuredOutput is ignored and we fall through to TextPart.
-	evt := &event.Event{
-		Response: &model.Response{
-			Object: "graph.node.custom",
-			Choices: []model.Choice{{
-				Message: model.Message{
-					Content: "hello",
-				},
-			}},
-		},
-		StructuredOutput: map[string]any{"should": "be ignored"},
-	}
-
-	converter := &defaultEventToA2AMessage{
-		graphEventObjectAllowlist: []string{"graph.*"},
-		// eventPartConverter is nil — no hook registered
-	}
-	result, err := converter.ConvertToA2AMessage(ctx, evt, EventToA2AUnaryOptions{CtxID: "ctx-1"})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
-	}
-
-	msg, ok := result.(*protocol.Message)
-	if !ok {
-		t.Fatalf("expected *protocol.Message, got %T", result)
-	}
-	if len(msg.Parts) == 0 {
-		t.Fatal("expected at least one part")
-	}
-	// Should be a TextPart, not a DataPart
-	if msg.Parts[0].GetKind() != protocol.KindText {
-		t.Errorf("expected TextPart fallback, got kind %s", msg.Parts[0].GetKind())
-	}
-}
-
-func TestEventPartConverter_HookNotHandledFallsThrough(t *testing.T) {
-	ctx := context.Background()
-
-	// Hook returns (nil, false, nil) — should fall through to TextPart.
-	notHandledHook := func(ctx context.Context, evt *event.Event) ([]protocol.Part, bool, error) {
-		return nil, false, nil
-	}
-
-	evt := &event.Event{
-		Response: &model.Response{
-			Object: "graph.node.custom",
-			Choices: []model.Choice{{
-				Message: model.Message{
-					Content: "fallback text",
-				},
-			}},
-		},
-	}
-
-	converter := &defaultEventToA2AMessage{
-		graphEventObjectAllowlist: []string{"graph.*"},
-		eventPartConverter:        notHandledHook,
-	}
-	result, err := converter.ConvertToA2AMessage(ctx, evt, EventToA2AUnaryOptions{CtxID: "ctx-1"})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
-	}
-
-	msg, ok := result.(*protocol.Message)
-	if !ok {
-		t.Fatalf("expected *protocol.Message, got %T", result)
-	}
-	if len(msg.Parts) == 0 {
-		t.Fatal("expected at least one part")
-	}
-	if msg.Parts[0].GetKind() != protocol.KindText {
-		t.Errorf("expected TextPart fallback, got kind %s", msg.Parts[0].GetKind())
-	}
-}
-
-func TestEventPartConverter_HookReturnsError(t *testing.T) {
-	ctx := context.Background()
-
-	errorHook := func(ctx context.Context, evt *event.Event) ([]protocol.Part, bool, error) {
-		return nil, false, fmt.Errorf("hook error")
-	}
 
 	evt := &event.Event{
 		Response: &model.Response{
@@ -3872,44 +3779,13 @@ func TestEventPartConverter_HookReturnsError(t *testing.T) {
 				},
 			}},
 		},
-	}
-
-	converter := &defaultEventToA2AMessage{
-		graphEventObjectAllowlist: []string{"graph.*"},
-		eventPartConverter:        errorHook,
-	}
-
-	// Unary path
-	_, err := converter.ConvertToA2AMessage(ctx, evt, EventToA2AUnaryOptions{CtxID: "ctx-1"})
-	if err == nil {
-		t.Fatal("expected error from hook, got nil")
-	}
-
-	// Streaming path
-	_, err = converter.ConvertStreamingToA2AMessage(ctx, evt, EventToA2AStreamingOptions{TaskID: "t-1", CtxID: "ctx-1"})
-	if err == nil {
-		t.Fatal("expected error from hook in streaming, got nil")
-	}
-}
-
-func TestEventPartConverter_ADKCompatibility(t *testing.T) {
-	ctx := context.Background()
-	hook := StructuredOutputPartConverter()
-
-	evt := &event.Event{
-		Response: &model.Response{
-			Object: "graph.node.custom",
-			Choices: []model.Choice{{
-				Message: model.Message{},
-			}},
-		},
 		StructuredOutput: map[string]any{"key": "val"},
 	}
 
 	converter := &defaultEventToA2AMessage{
 		graphEventObjectAllowlist: []string{"graph.*"},
 		adkCompatibility:          true,
-		eventPartConverter:        hook,
+		structuredOutputEnabled:   true,
 	}
 	result, err := converter.ConvertToA2AMessage(ctx, evt, EventToA2AUnaryOptions{CtxID: "ctx-1"})
 	if err != nil {
@@ -3919,7 +3795,25 @@ func TestEventPartConverter_ADKCompatibility(t *testing.T) {
 		t.Fatal("expected non-nil result")
 	}
 
-	dp := extractDataPartFromResult(t, result)
+	msg, ok := result.(*protocol.Message)
+	if !ok {
+		t.Fatalf("expected *protocol.Message, got %T", result)
+	}
+
+	// Find the custom_data DataPart (should be the last part)
+	var dp *protocol.DataPart
+	for i := len(msg.Parts) - 1; i >= 0; i-- {
+		if p, ok := msg.Parts[i].(*protocol.DataPart); ok {
+			if ia2a.GetDataPartType(p.Metadata) == ia2a.DataPartMetadataTypeCustomData {
+				dp = p
+				break
+			}
+		}
+	}
+	if dp == nil {
+		t.Fatal("expected a DataPart with custom_data type")
+	}
+
 	// Should have both "type" and "adk_type"
 	if dp.Metadata[ia2a.DataPartMetadataTypeKey] != ia2a.DataPartMetadataTypeCustomData {
 		t.Errorf("missing standard type key")

--- a/server/a2a/converter_test.go
+++ b/server/a2a/converter_test.go
@@ -13,6 +13,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"reflect"
 	"testing"
 
@@ -3339,5 +3340,354 @@ func TestDefaultEventToA2AMessage_StreamingReasoningContent(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// extractDataPartFromResult is a test helper that extracts the first DataPart from a UnaryMessageResult.
+func extractDataPartFromResult(t *testing.T, result protocol.UnaryMessageResult) *protocol.DataPart {
+	t.Helper()
+	msg, ok := result.(*protocol.Message)
+	if !ok {
+		t.Fatalf("expected *protocol.Message, got %T", result)
+	}
+	if len(msg.Parts) == 0 {
+		t.Fatal("expected at least one part")
+	}
+	part := msg.Parts[0]
+	switch p := part.(type) {
+	case *protocol.DataPart:
+		return p
+	case protocol.DataPart:
+		return &p
+	default:
+		t.Fatalf("expected DataPart, got %T", part)
+		return nil
+	}
+}
+
+func TestToDataPartPayload(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  any
+		wantOK bool
+	}{
+		{
+			name:   "map[string]any",
+			input:  map[string]any{"key": "value", "num": float64(42)},
+			wantOK: true,
+		},
+		{
+			name:   "valid JSON []byte",
+			input:  []byte(`{"foo":"bar"}`),
+			wantOK: true,
+		},
+		{
+			name:   "json.RawMessage",
+			input:  json.RawMessage(`{"raw":true}`),
+			wantOK: true,
+		},
+		{
+			name:   "invalid JSON []byte",
+			input:  []byte(`not valid json`),
+			wantOK: false,
+		},
+		{
+			name:   "struct type (round-trip)",
+			input:  struct{ Name string }{"test"},
+			wantOK: true,
+		},
+		{
+			name:   "nil (marshals to JSON null, result is nil)",
+			input:  nil,
+			wantOK: true, // json.Marshal(nil) → "null", which unmarshals to nil
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, ok := toDataPartPayload(tt.input)
+			if ok != tt.wantOK {
+				t.Errorf("toDataPartPayload() ok = %v, want %v", ok, tt.wantOK)
+			}
+			if tt.wantOK && tt.input != nil && result == nil {
+				t.Error("toDataPartPayload() returned nil result with ok=true")
+			}
+		})
+	}
+}
+
+func TestStructuredOutput_UnaryConversion(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name            string
+		event           *event.Event
+		expectNil       bool
+		checkDataType   string
+		checkObjectType string
+	}{
+		{
+			name: "StructuredOutput map generates DataPart with custom_data type",
+			event: &event.Event{
+				Response: &model.Response{
+					Object: "graph.node.custom",
+					Choices: []model.Choice{{
+						Message: model.Message{},
+					}},
+				},
+				StructuredOutput: map[string]any{
+					"trace_id": "abc123",
+					"latency":  42.5,
+				},
+			},
+			expectNil:       false,
+			checkDataType:   ia2a.DataPartMetadataTypeCustomData,
+			checkObjectType: "graph.node.custom",
+		},
+		{
+			name: "StructuredOutput []byte valid JSON generates DataPart",
+			event: &event.Event{
+				Response: &model.Response{
+					Object: "graph.node.custom",
+					Choices: []model.Choice{{
+						Message: model.Message{},
+					}},
+				},
+				StructuredOutput: []byte(`{"service":"my-svc","code":200}`),
+			},
+			expectNil:     false,
+			checkDataType: ia2a.DataPartMetadataTypeCustomData,
+		},
+		{
+			name: "StructuredOutput json.RawMessage generates DataPart",
+			event: &event.Event{
+				Response: &model.Response{
+					Object: "graph.node.custom",
+					Choices: []model.Choice{{
+						Message: model.Message{},
+					}},
+				},
+				StructuredOutput: json.RawMessage(`{"raw_key":"raw_val"}`),
+			},
+			expectNil:     false,
+			checkDataType: ia2a.DataPartMetadataTypeCustomData,
+		},
+		{
+			name: "StructuredOutput nil falls through to TextPart fallback",
+			event: &event.Event{
+				Response: &model.Response{
+					Object: "graph.node.custom",
+					Choices: []model.Choice{{
+						Message: model.Message{
+							Content: "fallback text",
+						},
+					}},
+				},
+				StructuredOutput: nil,
+			},
+			expectNil:     false,
+			checkDataType: "", // not a DataPart, should be a TextPart
+		},
+		{
+			name: "StructuredOutput invalid JSON []byte returns nil gracefully",
+			event: &event.Event{
+				Response: &model.Response{
+					Object: "graph.node.custom",
+					Choices: []model.Choice{{
+						Message: model.Message{},
+					}},
+				},
+				StructuredOutput: []byte(`not valid json {{{`),
+			},
+			expectNil: true,
+		},
+		{
+			name: "ToolCall event takes priority over StructuredOutput",
+			event: &event.Event{
+				Response: &model.Response{
+					Object: "graph.node.custom",
+					Choices: []model.Choice{{
+						Message: model.Message{
+							ToolCalls: []model.ToolCall{
+								{
+									ID:   "call-1",
+									Type: "function",
+									Function: model.FunctionDefinitionParam{
+										Name:      "my_tool",
+										Arguments: []byte(`{"arg":"val"}`),
+									},
+								},
+							},
+						},
+					}},
+				},
+				StructuredOutput: map[string]any{"should": "be ignored"},
+			},
+			expectNil:     false,
+			checkDataType: ia2a.DataPartMetadataTypeFunctionCall, // ToolCall wins
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			converter := &defaultEventToA2AMessage{
+				graphEventObjectAllowlist: []string{"graph.*"},
+			}
+			result, err := converter.ConvertToA2AMessage(ctx, tt.event, EventToA2AUnaryOptions{CtxID: "ctx-1"})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tt.expectNil {
+				if result != nil {
+					t.Errorf("expected nil result, got %T", result)
+				}
+				return
+			}
+
+			if result == nil {
+				t.Fatal("expected non-nil result")
+			}
+
+			msg, ok := result.(*protocol.Message)
+			if !ok {
+				t.Fatalf("expected *protocol.Message, got %T", result)
+			}
+
+			if tt.checkDataType == "" {
+				// Expect a TextPart (nil StructuredOutput fallback case)
+				if len(msg.Parts) == 0 {
+					t.Fatal("expected at least one part")
+				}
+				if msg.Parts[0].GetKind() != protocol.KindText {
+					t.Errorf("expected TextPart, got kind %s", msg.Parts[0].GetKind())
+				}
+				return
+			}
+
+			dp := extractDataPartFromResult(t, result)
+			gotType := ia2a.GetDataPartType(dp.Metadata)
+			if gotType != tt.checkDataType {
+				t.Errorf("DataPart type = %q, want %q", gotType, tt.checkDataType)
+			}
+
+			if tt.checkObjectType != "" {
+				if msg.Metadata == nil {
+					t.Fatal("expected message metadata")
+				}
+				if got := msg.Metadata[ia2a.MessageMetadataObjectTypeKey]; got != tt.checkObjectType {
+					t.Errorf("object_type = %v, want %v", got, tt.checkObjectType)
+				}
+			}
+		})
+	}
+}
+
+func TestStructuredOutput_StreamingConversion(t *testing.T) {
+	ctx := context.Background()
+	opts := EventToA2AStreamingOptions{TaskID: "task-1", CtxID: "ctx-1"}
+
+	tests := []struct {
+		name      string
+		event     *event.Event
+		expectNil bool
+	}{
+		{
+			name: "streaming StructuredOutput map generates result",
+			event: &event.Event{
+				Response: &model.Response{
+					ID:     "resp-1",
+					Object: "graph.node.custom",
+					Choices: []model.Choice{{
+						Message: model.Message{},
+					}},
+				},
+				StructuredOutput: map[string]any{"stream_key": "stream_val"},
+			},
+			expectNil: false,
+		},
+		{
+			name: "streaming StructuredOutput nil falls through",
+			event: &event.Event{
+				Response: &model.Response{
+					ID:     "resp-2",
+					Object: "graph.node.custom",
+					Choices: []model.Choice{{
+						Delta: model.Message{
+							Content: "delta text",
+						},
+					}},
+				},
+				StructuredOutput: nil,
+			},
+			expectNil: false, // falls through to delta content
+		},
+		{
+			name: "streaming StructuredOutput invalid JSON returns nil",
+			event: &event.Event{
+				Response: &model.Response{
+					ID:     "resp-3",
+					Object: "graph.node.custom",
+					Choices: []model.Choice{{
+						Message: model.Message{},
+					}},
+				},
+				StructuredOutput: []byte(`{bad json`),
+			},
+			expectNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			converter := &defaultEventToA2AMessage{
+				graphEventObjectAllowlist: []string{"graph.*"},
+			}
+			result, err := converter.ConvertStreamingToA2AMessage(ctx, tt.event, opts)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.expectNil {
+				if result != nil {
+					t.Errorf("expected nil result, got %T", result)
+				}
+			} else {
+				if result == nil {
+					t.Fatal("expected non-nil result")
+				}
+			}
+		})
+	}
+}
+
+func TestStructuredOutput_StreamingMessageType(t *testing.T) {
+	ctx := context.Background()
+	opts := EventToA2AStreamingOptions{TaskID: "task-1", CtxID: "ctx-1"}
+
+	evt := &event.Event{
+		Response: &model.Response{
+			ID:     "resp-msg",
+			Object: "graph.node.custom",
+			Choices: []model.Choice{{
+				Message: model.Message{},
+			}},
+		},
+		StructuredOutput: map[string]any{"key": "val"},
+	}
+
+	// Test with StreamingEventTypeMessage
+	converter := &defaultEventToA2AMessage{
+		graphEventObjectAllowlist: []string{"graph.*"},
+		streamingEventType:        StreamingEventTypeMessage,
+	}
+	result, err := converter.ConvertStreamingToA2AMessage(ctx, evt, opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if _, ok := result.(*protocol.Message); !ok {
+		t.Errorf("expected *protocol.Message for StreamingEventTypeMessage, got %T", result)
 	}
 }

--- a/server/a2a/converter_test.go
+++ b/server/a2a/converter_test.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -3418,6 +3419,7 @@ func TestToDataPartPayload(t *testing.T) {
 
 func TestStructuredOutput_UnaryConversion(t *testing.T) {
 	ctx := context.Background()
+	hook := StructuredOutputPartConverter()
 
 	tests := []struct {
 		name            string
@@ -3489,7 +3491,7 @@ func TestStructuredOutput_UnaryConversion(t *testing.T) {
 			checkDataType: "", // not a DataPart, should be a TextPart
 		},
 		{
-			name: "StructuredOutput invalid JSON []byte returns nil gracefully",
+			name: "StructuredOutput invalid JSON []byte falls through to metadata-only message",
 			event: &event.Event{
 				Response: &model.Response{
 					Object: "graph.node.custom",
@@ -3499,7 +3501,8 @@ func TestStructuredOutput_UnaryConversion(t *testing.T) {
 				},
 				StructuredOutput: []byte(`not valid json {{{`),
 			},
-			expectNil: true,
+			expectNil:     false,
+			checkDataType: "metadata_only", // special sentinel: message has metadata but no content parts
 		},
 		{
 			name: "ToolCall event takes priority over StructuredOutput",
@@ -3532,6 +3535,7 @@ func TestStructuredOutput_UnaryConversion(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			converter := &defaultEventToA2AMessage{
 				graphEventObjectAllowlist: []string{"graph.*"},
+				eventPartConverter:        hook,
 			}
 			result, err := converter.ConvertToA2AMessage(ctx, tt.event, EventToA2AUnaryOptions{CtxID: "ctx-1"})
 			if err != nil {
@@ -3565,6 +3569,15 @@ func TestStructuredOutput_UnaryConversion(t *testing.T) {
 				return
 			}
 
+			if tt.checkDataType == "metadata_only" {
+				// Hook returned not-handled, fell through to text fallback which
+				// produced a metadata-only message (no content, but object_type set).
+				if msg.Metadata == nil {
+					t.Fatal("expected message metadata for metadata-only message")
+				}
+				return
+			}
+
 			dp := extractDataPartFromResult(t, result)
 			gotType := ia2a.GetDataPartType(dp.Metadata)
 			if gotType != tt.checkDataType {
@@ -3586,6 +3599,7 @@ func TestStructuredOutput_UnaryConversion(t *testing.T) {
 func TestStructuredOutput_StreamingConversion(t *testing.T) {
 	ctx := context.Background()
 	opts := EventToA2AStreamingOptions{TaskID: "task-1", CtxID: "ctx-1"}
+	hook := StructuredOutputPartConverter()
 
 	tests := []struct {
 		name      string
@@ -3623,7 +3637,7 @@ func TestStructuredOutput_StreamingConversion(t *testing.T) {
 			expectNil: false, // falls through to delta content
 		},
 		{
-			name: "streaming StructuredOutput invalid JSON returns nil",
+			name: "streaming StructuredOutput invalid JSON falls through",
 			event: &event.Event{
 				Response: &model.Response{
 					ID:     "resp-3",
@@ -3634,7 +3648,7 @@ func TestStructuredOutput_StreamingConversion(t *testing.T) {
 				},
 				StructuredOutput: []byte(`{bad json`),
 			},
-			expectNil: true,
+			expectNil: false, // hook returns not-handled, falls through to delta/metadata
 		},
 	}
 
@@ -3642,6 +3656,7 @@ func TestStructuredOutput_StreamingConversion(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			converter := &defaultEventToA2AMessage{
 				graphEventObjectAllowlist: []string{"graph.*"},
+				eventPartConverter:        hook,
 			}
 			result, err := converter.ConvertStreamingToA2AMessage(ctx, tt.event, opts)
 			if err != nil {
@@ -3663,6 +3678,7 @@ func TestStructuredOutput_StreamingConversion(t *testing.T) {
 func TestStructuredOutput_StreamingMessageType(t *testing.T) {
 	ctx := context.Background()
 	opts := EventToA2AStreamingOptions{TaskID: "task-1", CtxID: "ctx-1"}
+	hook := StructuredOutputPartConverter()
 
 	evt := &event.Event{
 		Response: &model.Response{
@@ -3679,6 +3695,7 @@ func TestStructuredOutput_StreamingMessageType(t *testing.T) {
 	converter := &defaultEventToA2AMessage{
 		graphEventObjectAllowlist: []string{"graph.*"},
 		streamingEventType:        StreamingEventTypeMessage,
+		eventPartConverter:        hook,
 	}
 	result, err := converter.ConvertStreamingToA2AMessage(ctx, evt, opts)
 	if err != nil {
@@ -3689,5 +3706,226 @@ func TestStructuredOutput_StreamingMessageType(t *testing.T) {
 	}
 	if _, ok := result.(*protocol.Message); !ok {
 		t.Errorf("expected *protocol.Message for StreamingEventTypeMessage, got %T", result)
+	}
+}
+
+func TestStructuredOutputPartConverter(t *testing.T) {
+	ctx := context.Background()
+	hook := StructuredOutputPartConverter()
+
+	t.Run("nil StructuredOutput returns not handled", func(t *testing.T) {
+		evt := &event.Event{
+			Response: &model.Response{},
+		}
+		parts, handled, err := hook(ctx, evt)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if handled {
+			t.Error("expected handled=false for nil StructuredOutput")
+		}
+		if parts != nil {
+			t.Errorf("expected nil parts, got %v", parts)
+		}
+	})
+
+	t.Run("valid map returns DataPart", func(t *testing.T) {
+		evt := &event.Event{
+			Response:         &model.Response{},
+			StructuredOutput: map[string]any{"key": "val"},
+		}
+		parts, handled, err := hook(ctx, evt)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !handled {
+			t.Error("expected handled=true")
+		}
+		if len(parts) != 1 {
+			t.Fatalf("expected 1 part, got %d", len(parts))
+		}
+		dp, ok := parts[0].(*protocol.DataPart)
+		if !ok {
+			t.Fatalf("expected *protocol.DataPart, got %T", parts[0])
+		}
+		gotType := ia2a.GetDataPartType(dp.Metadata)
+		if gotType != ia2a.DataPartMetadataTypeCustomData {
+			t.Errorf("type = %q, want %q", gotType, ia2a.DataPartMetadataTypeCustomData)
+		}
+	})
+
+	t.Run("invalid JSON returns not handled", func(t *testing.T) {
+		evt := &event.Event{
+			Response:         &model.Response{},
+			StructuredOutput: []byte(`{bad`),
+		}
+		parts, handled, err := hook(ctx, evt)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if handled {
+			t.Error("expected handled=false for invalid JSON")
+		}
+		if parts != nil {
+			t.Errorf("expected nil parts, got %v", parts)
+		}
+	})
+}
+
+func TestEventPartConverter_NoHookIgnoresStructuredOutput(t *testing.T) {
+	ctx := context.Background()
+
+	// Without a hook, StructuredOutput is ignored and we fall through to TextPart.
+	evt := &event.Event{
+		Response: &model.Response{
+			Object: "graph.node.custom",
+			Choices: []model.Choice{{
+				Message: model.Message{
+					Content: "hello",
+				},
+			}},
+		},
+		StructuredOutput: map[string]any{"should": "be ignored"},
+	}
+
+	converter := &defaultEventToA2AMessage{
+		graphEventObjectAllowlist: []string{"graph.*"},
+		// eventPartConverter is nil — no hook registered
+	}
+	result, err := converter.ConvertToA2AMessage(ctx, evt, EventToA2AUnaryOptions{CtxID: "ctx-1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	msg, ok := result.(*protocol.Message)
+	if !ok {
+		t.Fatalf("expected *protocol.Message, got %T", result)
+	}
+	if len(msg.Parts) == 0 {
+		t.Fatal("expected at least one part")
+	}
+	// Should be a TextPart, not a DataPart
+	if msg.Parts[0].GetKind() != protocol.KindText {
+		t.Errorf("expected TextPart fallback, got kind %s", msg.Parts[0].GetKind())
+	}
+}
+
+func TestEventPartConverter_HookNotHandledFallsThrough(t *testing.T) {
+	ctx := context.Background()
+
+	// Hook returns (nil, false, nil) — should fall through to TextPart.
+	notHandledHook := func(ctx context.Context, evt *event.Event) ([]protocol.Part, bool, error) {
+		return nil, false, nil
+	}
+
+	evt := &event.Event{
+		Response: &model.Response{
+			Object: "graph.node.custom",
+			Choices: []model.Choice{{
+				Message: model.Message{
+					Content: "fallback text",
+				},
+			}},
+		},
+	}
+
+	converter := &defaultEventToA2AMessage{
+		graphEventObjectAllowlist: []string{"graph.*"},
+		eventPartConverter:        notHandledHook,
+	}
+	result, err := converter.ConvertToA2AMessage(ctx, evt, EventToA2AUnaryOptions{CtxID: "ctx-1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	msg, ok := result.(*protocol.Message)
+	if !ok {
+		t.Fatalf("expected *protocol.Message, got %T", result)
+	}
+	if len(msg.Parts) == 0 {
+		t.Fatal("expected at least one part")
+	}
+	if msg.Parts[0].GetKind() != protocol.KindText {
+		t.Errorf("expected TextPart fallback, got kind %s", msg.Parts[0].GetKind())
+	}
+}
+
+func TestEventPartConverter_HookReturnsError(t *testing.T) {
+	ctx := context.Background()
+
+	errorHook := func(ctx context.Context, evt *event.Event) ([]protocol.Part, bool, error) {
+		return nil, false, fmt.Errorf("hook error")
+	}
+
+	evt := &event.Event{
+		Response: &model.Response{
+			Object: "graph.node.custom",
+			Choices: []model.Choice{{
+				Message: model.Message{
+					Content: "text",
+				},
+			}},
+		},
+	}
+
+	converter := &defaultEventToA2AMessage{
+		graphEventObjectAllowlist: []string{"graph.*"},
+		eventPartConverter:        errorHook,
+	}
+
+	// Unary path
+	_, err := converter.ConvertToA2AMessage(ctx, evt, EventToA2AUnaryOptions{CtxID: "ctx-1"})
+	if err == nil {
+		t.Fatal("expected error from hook, got nil")
+	}
+
+	// Streaming path
+	_, err = converter.ConvertStreamingToA2AMessage(ctx, evt, EventToA2AStreamingOptions{TaskID: "t-1", CtxID: "ctx-1"})
+	if err == nil {
+		t.Fatal("expected error from hook in streaming, got nil")
+	}
+}
+
+func TestEventPartConverter_ADKCompatibility(t *testing.T) {
+	ctx := context.Background()
+	hook := StructuredOutputPartConverter()
+
+	evt := &event.Event{
+		Response: &model.Response{
+			Object: "graph.node.custom",
+			Choices: []model.Choice{{
+				Message: model.Message{},
+			}},
+		},
+		StructuredOutput: map[string]any{"key": "val"},
+	}
+
+	converter := &defaultEventToA2AMessage{
+		graphEventObjectAllowlist: []string{"graph.*"},
+		adkCompatibility:          true,
+		eventPartConverter:        hook,
+	}
+	result, err := converter.ConvertToA2AMessage(ctx, evt, EventToA2AUnaryOptions{CtxID: "ctx-1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	dp := extractDataPartFromResult(t, result)
+	// Should have both "type" and "adk_type"
+	if dp.Metadata[ia2a.DataPartMetadataTypeKey] != ia2a.DataPartMetadataTypeCustomData {
+		t.Errorf("missing standard type key")
+	}
+	adkKey := ia2a.GetADKMetadataKey(ia2a.DataPartMetadataTypeKey)
+	if dp.Metadata[adkKey] != ia2a.DataPartMetadataTypeCustomData {
+		t.Errorf("missing ADK type key %q", adkKey)
 	}
 }

--- a/server/a2a/server.go
+++ b/server/a2a/server.go
@@ -122,7 +122,7 @@ func buildProcessor(agent agent.Agent, sessionService session.Service, options *
 			adkCompatibility:          options.adkCompatibility,
 			graphEventObjectAllowlist: options.graphEventObjectAllowlist,
 			streamingEventType:        options.streamingEventType,
-			eventPartConverter:        options.eventPartConverter,
+			structuredOutputEnabled:   options.structuredOutputEnabled,
 		}
 	}
 

--- a/server/a2a/server.go
+++ b/server/a2a/server.go
@@ -122,6 +122,7 @@ func buildProcessor(agent agent.Agent, sessionService session.Service, options *
 			adkCompatibility:          options.adkCompatibility,
 			graphEventObjectAllowlist: options.graphEventObjectAllowlist,
 			streamingEventType:        options.streamingEventType,
+			eventPartConverter:        options.eventPartConverter,
 		}
 	}
 

--- a/server/a2a/server_option.go
+++ b/server/a2a/server_option.go
@@ -97,7 +97,7 @@ type options struct {
 	taskManagerBuilder        TaskManagerBuilder
 	a2aToAgentConverter       A2AMessageToAgentMessage
 	eventToA2AConverter       EventToA2AMessage
-	eventPartConverter        EventPartConverter
+	structuredOutputEnabled   bool
 	host                      string
 	extraOptions              []a2a.Option
 	errorHandler              ErrorHandler
@@ -307,15 +307,13 @@ func WithStreamingEventType(eventType StreamingEventType) Option {
 	}
 }
 
-// WithEventPartConverter registers a hook that converts custom event data into
-// A2A Parts. The hook is invoked after ToolCall / CodeExecution checks but
-// before the text fallback. Use [StructuredOutputPartConverter] for the
-// built-in StructuredOutput→DataPart conversion:
-//
-//	a2a.WithEventPartConverter(a2a.StructuredOutputPartConverter())
-func WithEventPartConverter(converter EventPartConverter) Option {
+// WithStructuredOutputEnabled enables the conversion of Event.StructuredOutput
+// into a DataPart (with metadata type "custom_data") that is appended
+// orthogonally to the A2A message. Without this option, StructuredOutput is
+// silently ignored.
+func WithStructuredOutputEnabled() Option {
 	return func(opts *options) {
-		opts.eventPartConverter = converter
+		opts.structuredOutputEnabled = true
 	}
 }
 

--- a/server/a2a/server_option.go
+++ b/server/a2a/server_option.go
@@ -97,6 +97,7 @@ type options struct {
 	taskManagerBuilder        TaskManagerBuilder
 	a2aToAgentConverter       A2AMessageToAgentMessage
 	eventToA2AConverter       EventToA2AMessage
+	eventPartConverter        EventPartConverter
 	host                      string
 	extraOptions              []a2a.Option
 	errorHandler              ErrorHandler
@@ -303,6 +304,18 @@ func WithADKCompatibility(enabled bool) Option {
 func WithStreamingEventType(eventType StreamingEventType) Option {
 	return func(opts *options) {
 		opts.streamingEventType = eventType
+	}
+}
+
+// WithEventPartConverter registers a hook that converts custom event data into
+// A2A Parts. The hook is invoked after ToolCall / CodeExecution checks but
+// before the text fallback. Use [StructuredOutputPartConverter] for the
+// built-in StructuredOutput→DataPart conversion:
+//
+//	a2a.WithEventPartConverter(a2a.StructuredOutputPartConverter())
+func WithEventPartConverter(converter EventPartConverter) Option {
+	return func(opts *options) {
+		opts.eventPartConverter = converter
 	}
 }
 


### PR DESCRIPTION
… data

Enable framework-level conversion of Event.StructuredOutput to A2A DataPart with metadata type "custom_data", replacing the current pattern of encoding structured JSON inside TextPart. This eliminates double JSON encoding and provides proper semantic typing for custom events (e.g., RPC trace, decision details).

## Summary by Sourcery

在框架层面新增将带有 StructuredOutput 的事件转换为 A2A DataPart 消息和流式结果的能力，并将其标记为自定义结构化数据，而不是普通文本。

新功能：
- 为一元（unary）和流式 A2A 消息引入一个 StructuredOutput 到 DataPart 的转换器，用于规范化各种结构化负载（payload）形态。
- 定义一种新的 DataPart 元数据类型，用于表示从 `Event.StructuredOutput` 发出的自定义结构化数据。

增强：
- 在存在 StructuredOutput 时优先使用基于 StructuredOutput 的 DataPart 生成逻辑，同时保留现有的代码执行与工具调用处理优先级。

测试：
- 新增单元测试，覆盖 StructuredOutput DataPart 负载规范化、一元与流式转换、相对于工具调用的优先级，以及在结构化数据无效或为 nil 时的回退行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add framework-level conversion of events with StructuredOutput into A2A DataPart messages and streaming results, tagged as custom structured data instead of plain text.

New Features:
- Introduce a StructuredOutput-to-DataPart converter for unary and streaming A2A messages that normalizes various structured payload shapes.
- Define a new DataPart metadata type for custom structured data emitted from Event.StructuredOutput.

Enhancements:
- Prefer StructuredOutput-based DataPart generation when present, while preserving existing code execution and tool call handling priorities.

Tests:
- Add unit tests covering StructuredOutput DataPart payload normalization, unary and streaming conversions, precedence over tool calls, and fallback behavior for invalid or nil structured data.

</details>