### PR TITLE
memory: make preload adapt to memory volume

### DIFF
--- a/agent/llmagent/option.go
+++ b/agent/llmagent/option.go
@@ -108,10 +108,14 @@ var (
 		// PreloadMemory configuration values:
 		//   - 0 (default): Disable preloading (use tools instead).
 		//   - N > 0: Use adaptive preload with budget N.
+		//     If query extraction is empty, the search fails, or the search
+		//     returns no matches, fall back to loading up to N memories
+		//     directly.
 		//   - -1: Load all memories.
-		//     WARNING: Loading all memories may significantly increase token usage
-		//     and API costs, especially for users with many stored memories.
-		//     Consider using a positive budget (e.g., 10-50) for production use.
+		//     WARNING: Loading all memories may significantly increase token
+		//     usage and API costs, especially for users with many stored
+		//     memories. Consider using a positive budget (e.g., 10-50) for
+		//     production use.
 		PreloadMemory: 0,
 
 		SkillLoadMode: SkillLoadModeTurn,
@@ -332,6 +336,9 @@ type Options struct {
 	// When > 0, it acts as an adaptive preload budget:
 	//   - If total memories <= N, preload all memories.
 	//   - If total memories > N, preload top-N search results.
+	//   - If query extraction is empty, the search fails, or the search
+	//     returns no matches, fall back to loading up to N memories
+	//     directly.
 	// When 0 (default), no memories are preloaded (use tools instead).
 	// When < 0, all memories are loaded.
 	PreloadMemory int
@@ -950,6 +957,9 @@ func WithMessageFilterMode(mode MessageFilterMode) Option {
 // WithPreloadMemory sets the framework-side preload behavior.
 //   - Set to 0 (default) to disable preloading (use tools instead).
 //   - Set to N (N > 0) to use adaptive preload with budget N.
+//     Small memory sets are preloaded in full. Larger sets use search and
+//     fall back to loading up to N memories directly when search cannot
+//     provide usable results.
 //   - Set to -1 to load all memories.
 //     WARNING: Loading all memories may significantly increase token usage
 //     and API costs, especially for users with many stored memories.

--- a/agent/llmagent/option.go
+++ b/agent/llmagent/option.go
@@ -107,11 +107,11 @@ var (
 		// Default to disable memory preloading (use tools instead).
 		// PreloadMemory configuration values:
 		//   - 0 (default): Disable preloading (use tools instead).
-		//   - N > 0: Load the most recent N memories.
+		//   - N > 0: Use adaptive preload with budget N.
 		//   - -1: Load all memories.
 		//     WARNING: Loading all memories may significantly increase token usage
 		//     and API costs, especially for users with many stored memories.
-		//     Consider using a positive limit (e.g., 10-50) for production use.
+		//     Consider using a positive budget (e.g., 10-50) for production use.
 		PreloadMemory: 0,
 
 		SkillLoadMode: SkillLoadModeTurn,
@@ -328,8 +328,10 @@ type Options struct {
 
 	toolFilter tool.FilterFunc
 
-	// PreloadMemory sets the number of memories to preload into system prompt.
-	// When > 0, the specified number of most recent memories are loaded.
+	// PreloadMemory controls framework-side memory preload.
+	// When > 0, it acts as an adaptive preload budget:
+	//   - If total memories <= N, preload all memories.
+	//   - If total memories > N, preload top-N search results.
 	// When 0 (default), no memories are preloaded (use tools instead).
 	// When < 0, all memories are loaded.
 	PreloadMemory int
@@ -945,13 +947,13 @@ func WithMessageFilterMode(mode MessageFilterMode) Option {
 	}
 }
 
-// WithPreloadMemory sets the number of memories to preload into system prompt.
+// WithPreloadMemory sets the framework-side preload behavior.
 //   - Set to 0 (default) to disable preloading (use tools instead).
-//   - Set to N (N > 0) to load the most recent N memories.
+//   - Set to N (N > 0) to use adaptive preload with budget N.
 //   - Set to -1 to load all memories.
 //     WARNING: Loading all memories may significantly increase token usage
 //     and API costs, especially for users with many stored memories.
-//     Consider using a positive limit (e.g., 10-50) for production use.
+//     Consider using a positive budget (e.g., 10-50) for production use.
 func WithPreloadMemory(limit int) Option {
 	return func(opts *Options) {
 		opts.PreloadMemory = limit

--- a/agent/llmagent/option_test.go
+++ b/agent/llmagent/option_test.go
@@ -235,12 +235,12 @@ func TestWithPreloadMemory(t *testing.T) {
 			expectedLimit: -1,
 		},
 		{
-			name:          "load specific number",
+			name:          "use adaptive preload budget",
 			limit:         5,
 			expectedLimit: 5,
 		},
 		{
-			name:          "load large number",
+			name:          "use large adaptive preload budget",
 			limit:         100,
 			expectedLimit: 100,
 		},

--- a/docs/mkdocs/en/memory.md
+++ b/docs/mkdocs/en/memory.md
@@ -1486,19 +1486,27 @@ llmAgent := llmagent.New(
     llmagent.WithTools(memoryService.Tools()),
     // Preload options:
     // llmagent.WithPreloadMemory(0),   // Disable preloading (default).
-    // llmagent.WithPreloadMemory(10),  // Load 10 most recent.
+    // llmagent.WithPreloadMemory(10),  // Adaptive preload budget 10.
+    //                                  // Loads all memories when count <= 10,
+    //                                  // otherwise injects top 10 search results.
     // llmagent.WithPreloadMemory(-1),  // Load all.
     //                                  // ⚠️ WARNING: Loading all memories may significantly
     //                                  //     increase token usage and API costs, especially
     //                                  //     for users with many stored memories. Consider
-    //                                  //     using a positive limit for production use.
-    // llmagent.WithPreloadMemory(10),  // Load 10 most recent (recommended for production).
+    //                                  //     using a positive budget for production use.
+    // llmagent.WithPreloadMemory(10),  // Recommended production setting.
 )
 ```
 
 When preloading is enabled, memories are automatically injected into the
 system prompt, giving the Agent context about the user without explicit
 tool calls.
+
+When `WithPreloadMemory(N)` uses a positive value, the framework first probes
+how many memories the user has. If the count is at most `N`, it injects all
+memories. If the count is larger than `N`, it switches to query-aware
+`memory_search` behavior internally and injects only the top `N` relevant
+results for the current user message.
 
 **Injection Mechanism**: Preloaded memories are **merged** into the existing
 system prompt rather than inserted as a separate system message. This ensures
@@ -1508,7 +1516,7 @@ Qwen3.5 series may return "System message must be at the beginning" error).
 
 **⚠️ Important Note**: Setting the configuration to `-1` loads all memories,
 which may significantly increase **Token Usage** and **API Costs**. By default,
-preloading is disabled (`0`), and we recommend using positive limits (e.g., `10-50`)
+preloading is disabled (`0`), and we recommend using positive budgets (e.g., `10-50`)
 to balance performance and cost.
 
 ### Hybrid Approach
@@ -1529,7 +1537,7 @@ llmAgent := llmagent.New(
     "assistant",
     llmagent.WithModel(model),
     llmagent.WithTools(memoryService.Tools()),  // Search by default; Load is optional.
-    llmagent.WithPreloadMemory(10),             // Preload recent memories.
+    llmagent.WithPreloadMemory(10),             // Adaptive preload budget.
 )
 ```
 

--- a/docs/mkdocs/en/memory.md
+++ b/docs/mkdocs/en/memory.md
@@ -1506,7 +1506,9 @@ When `WithPreloadMemory(N)` uses a positive value, the framework first probes
 how many memories the user has. If the count is at most `N`, it injects all
 memories. If the count is larger than `N`, it switches to query-aware
 `memory_search` behavior internally and injects only the top `N` relevant
-results for the current user message.
+results for the current user message. If query extraction is empty, the
+search fails, or the search returns no matches, it falls back to directly
+loading up to `N` memories.
 
 **Injection Mechanism**: Preloaded memories are **merged** into the existing
 system prompt rather than inserted as a separate system message. This ensures

--- a/docs/mkdocs/zh/memory.md
+++ b/docs/mkdocs/zh/memory.md
@@ -1549,6 +1549,8 @@ llmAgent := llmagent.New(
 当 `WithPreloadMemory(N)` 使用正数时，框架会先探测用户当前的 memory 总量。
 如果总量不超过 `N`，则直接全量注入；如果总量超过 `N`，则在框架内部切换为
 基于当前用户问题的 `memory_search` 语义，只注入最相关的前 `N` 条结果。
+如果当前 `query` 为空、检索报错，或检索结果为空，则会回退为直接加载最多
+`N` 条记忆。
 
 **注入机制**：预加载的记忆会**合并**到现有的系统提示词中，而不是作为独立的 system message 插入。这确保了请求中始终只有一个 system message，兼容某些对多个 system message 支持不完善的模型（如 Qwen3.5 系列可能会返回 "System message must be at the beginning" 错误）。
 

--- a/docs/mkdocs/zh/memory.md
+++ b/docs/mkdocs/zh/memory.md
@@ -1535,18 +1535,24 @@ llmAgent := llmagent.New(
     llmagent.WithTools(memoryService.Tools()),
     // 预加载选项：
     // llmagent.WithPreloadMemory(0),   // 禁用预加载（默认）。
-    // llmagent.WithPreloadMemory(10),  // 加载最近 10 条（推荐用于生产环境）。
+    // llmagent.WithPreloadMemory(10),  // 自适应预加载预算 10。
+    //                                  // 记忆总量 <= 10 时全量注入，
+    //                                  // 否则注入当前问题相关的前 10 条检索结果。
     // llmagent.WithPreloadMemory(-1),  // 加载全部。
     //                                  // ⚠️ 警告：全量加载可能显著增加 token 使用量和 API 成本，
-    //                                  //     特别是对于存储了大量记忆的用户。生产环境建议使用正数限制。
+    //                                  //     特别是对于存储了大量记忆的用户。生产环境建议使用正数预算。
 )
 ```
 
 启用预加载后，记忆会自动注入到系统提示词中，让 Agent 无需显式工具调用就能获得用户上下文。
 
+当 `WithPreloadMemory(N)` 使用正数时，框架会先探测用户当前的 memory 总量。
+如果总量不超过 `N`，则直接全量注入；如果总量超过 `N`，则在框架内部切换为
+基于当前用户问题的 `memory_search` 语义，只注入最相关的前 `N` 条结果。
+
 **注入机制**：预加载的记忆会**合并**到现有的系统提示词中，而不是作为独立的 system message 插入。这确保了请求中始终只有一个 system message，兼容某些对多个 system message 支持不完善的模型（如 Qwen3.5 系列可能会返回 "System message must be at the beginning" 错误）。
 
-**⚠️ 重要提示**：配置为 `-1` 会加载所有记忆，这可能会显著增加**Token 使用量**和**API 成本**。默认情况下预加载是禁用的（`0`），推荐使用正数限制（如 `10-50`）来平衡性能和成本。
+**⚠️ 重要提示**：配置为 `-1` 会加载所有记忆，这可能会显著增加**Token 使用量**和**API 成本**。默认情况下预加载是禁用的（`0`），推荐使用正数预算（如 `10-50`）来平衡性能和成本。
 
 ### 混合方案
 
@@ -1566,7 +1572,7 @@ llmAgent := llmagent.New(
     "assistant",
     llmagent.WithModel(model),
     llmagent.WithTools(memoryService.Tools()),  // 默认只有 search（load 可选）。
-    llmagent.WithPreloadMemory(10),             // 预加载最近记忆。
+    llmagent.WithPreloadMemory(10),             // 自适应预加载预算。
 )
 ```
 

--- a/examples/memory/README.md
+++ b/examples/memory/README.md
@@ -291,19 +291,24 @@ go run main.go -streaming=false
 
 ### Memory Integration Pattern
 
-Both examples follow a two-step memory integration pattern:
+Both examples follow a three-step memory integration pattern:
 
 ```go
-// Step 1: Register memory tools (agentic) or setup extractor (auto)
+// Step 1: Create the memory service.
+// Auto mode must be enabled here with an extractor.
+memoryService := memoryinmemory.NewMemoryService(
+    // memoryinmemory.WithExtractor(memExtractor), // Enable auto mode.
+)
+
+// Step 2: Wire memory into the agent and runner.
 llmAgent := llmagent.New(
     agentName,
     llmagent.WithModel(modelInstance),
-    llmagent.WithTools(memoryService.Tools()), // Agentic mode
-    // OR
-    llmagent.WithPreloadMemory(-1), // Auto mode with full preload
+    llmagent.WithTools(memoryService.Tools()), // Optional for agentic or hybrid mode.
+    llmagent.WithPreloadMemory(-1),            // Optional preload enhancement.
 )
 
-// Step 2: Set memory service in runner
+// Step 3: Set memory service in runner.
 runner := runner.NewRunner(
     appName,
     llmAgent,

--- a/examples/memory/README.md
+++ b/examples/memory/README.md
@@ -300,7 +300,7 @@ llmAgent := llmagent.New(
     llmagent.WithModel(modelInstance),
     llmagent.WithTools(memoryService.Tools()), // Agentic mode
     // OR
-    llmagent.WithPreloadMemory(-1), // Auto mode
+    llmagent.WithPreloadMemory(-1), // Auto mode with full preload
 )
 
 // Step 2: Set memory service in runner

--- a/examples/memory/auto/README.md
+++ b/examples/memory/auto/README.md
@@ -437,9 +437,12 @@ Use `-debug` flag to see preloaded memories in the system prompt.
 
 In auto memory mode, `WithPreloadMemory(N)` uses framework-managed adaptive
 preloading: small memory sets are injected in full, while larger memory sets
-inject only the top `N` search results for the current user message. Use
-`WithPreloadMemory(-1)` to force full preload, or enable `memory_load` via
-`WithToolEnabled(memory.LoadToolName, true)` for agent-driven loading.
+inject only the top `N` search results for the current user message. If
+query extraction is empty, the search fails, or the search returns no
+matches, it falls back to directly loading up to `N` memories. Use
+`WithPreloadMemory(-1)` to force full preload, or enable `memory_load`
+via `WithToolEnabled(memory.LoadToolName, true)` for agent-driven
+loading.
 
 ## Comparison with Manual Memory
 

--- a/examples/memory/auto/README.md
+++ b/examples/memory/auto/README.md
@@ -416,7 +416,9 @@ llmAgent := llmagent.New(
     llmagent.WithTools(memoryService.Tools()),
     // Preload options:
     // llmagent.WithPreloadMemory(0),   // Disable preloading (default).
-    // llmagent.WithPreloadMemory(10),  // Load 10 most recent.
+    // llmagent.WithPreloadMemory(10),  // Adaptive preload budget 10.
+    //                                  // Loads all memories when count <= 10,
+    //                                  // otherwise injects top 10 search results.
     // llmagent.WithPreloadMemory(-1),  // Load all.
 )
 ```
@@ -431,9 +433,13 @@ Use `-debug` flag to see preloaded memories in the system prompt.
 | **Control**     | Configured at agent creation       | Agent-driven, on-demand             |
 | **Token Usage** | Always included in context         | Only when agent calls the tool      |
 | **Auto Mode**   | Works with preloading              | Disabled by default, can be enabled |
-| **Use Case**    | Always need full context           | Selective memory access             |
+| **Use Case**    | Framework-managed adaptive context | Selective memory access             |
 
-In auto memory mode, you can use `WithPreloadMemory(-1)` to inject all memories into the system prompt, or enable `memory_load` tool via `WithToolEnabled(memory.LoadToolName, true)` for agent-driven loading.
+In auto memory mode, `WithPreloadMemory(N)` uses framework-managed adaptive
+preloading: small memory sets are injected in full, while larger memory sets
+inject only the top `N` search results for the current user message. Use
+`WithPreloadMemory(-1)` to force full preload, or enable `memory_load` via
+`WithToolEnabled(memory.LoadToolName, true)` for agent-driven loading.
 
 ## Comparison with Manual Memory
 

--- a/examples/memory/auto/main.go
+++ b/examples/memory/auto/main.go
@@ -202,8 +202,10 @@ func (c *autoMemoryChat) setup(_ context.Context) error {
 		llmagent.WithGenerationConfig(genConfig),
 		llmagent.WithTools(c.memoryService.Tools()),
 		llmagent.WithModelCallbacks(modelCallbacks),
-		// Memory preloading: inject memories into system prompt before each request.
-		// Use WithPreloadMemory(N) to load the most recent N memories.
+		// Memory preloading injects memories into the system prompt before
+		// each request.
+		// Use WithPreloadMemory(N) for adaptive preload: load all memories
+		// when count <= N, otherwise inject the top-N search results.
 		// Use WithPreloadMemory(-1) to load all memories.
 		// Default is 0 (disabled, use memory_search/memory_load tools instead).
 		llmagent.WithPreloadMemory(-1),

--- a/examples/memory/auto/main.go
+++ b/examples/memory/auto/main.go
@@ -205,7 +205,9 @@ func (c *autoMemoryChat) setup(_ context.Context) error {
 		// Memory preloading injects memories into the system prompt before
 		// each request.
 		// Use WithPreloadMemory(N) for adaptive preload: load all memories
-		// when count <= N, otherwise inject the top-N search results.
+		// when count <= N, otherwise inject the top-N search results and
+		// fall back to directly loading up to N memories if search cannot
+		// provide usable results.
 		// Use WithPreloadMemory(-1) to load all memories.
 		// Default is 0 (disabled, use memory_search/memory_load tools instead).
 		llmagent.WithPreloadMemory(-1),

--- a/internal/flow/processor/content.go
+++ b/internal/flow/processor/content.go
@@ -111,6 +111,9 @@ type ContentRequestProcessor struct {
 	// When > 0, it acts as an adaptive preload budget:
 	//   - If total memories <= N, preload all memories.
 	//   - If total memories > N, preload top-N search results.
+	//   - If query extraction is empty, the search fails, or the search
+	//     returns no matches, fall back to loading up to N memories
+	//     directly.
 	// When 0, no memories are preloaded (use tools instead).
 	// When < 0 (default), all memories are loaded.
 	PreloadMemory int
@@ -195,6 +198,9 @@ func WithReasoningContentMode(mode string) ContentOption {
 // WithPreloadMemory sets the framework-side memory preload behavior.
 //   - Set to 0 (default) to disable preloading (use tools instead).
 //   - Set to N (N > 0) to use adaptive preload with budget N.
+//     Small memory sets are preloaded in full. Larger sets use search and
+//     fall back to loading up to N memories directly when search cannot
+//     provide usable results.
 //   - Set to -1 to load all memories.
 //     WARNING: Loading all memories may significantly increase token usage
 //     and API costs, especially for users with many stored memories.

--- a/internal/flow/processor/content.go
+++ b/internal/flow/processor/content.go
@@ -107,8 +107,10 @@ type ContentRequestProcessor struct {
 	// conversations. Default is ReasoningContentModeDiscardPreviousTurns, which is
 	// recommended for DeepSeek thinking mode.
 	ReasoningContentMode string
-	// PreloadMemory sets the number of memories to preload into system prompt.
-	// When > 0, the specified number of most recent memories are loaded.
+	// PreloadMemory controls framework-side memory preload.
+	// When > 0, it acts as an adaptive preload budget:
+	//   - If total memories <= N, preload all memories.
+	//   - If total memories > N, preload top-N search results.
 	// When 0, no memories are preloaded (use tools instead).
 	// When < 0 (default), all memories are loaded.
 	PreloadMemory int
@@ -190,13 +192,13 @@ func WithReasoningContentMode(mode string) ContentOption {
 	}
 }
 
-// WithPreloadMemory sets the number of memories to preload into system prompt.
+// WithPreloadMemory sets the framework-side memory preload behavior.
 //   - Set to 0 (default) to disable preloading (use tools instead).
-//   - Set to N (N > 0) to load the most recent N memories.
+//   - Set to N (N > 0) to use adaptive preload with budget N.
 //   - Set to -1 to load all memories.
 //     WARNING: Loading all memories may significantly increase token usage
 //     and API costs, especially for users with many stored memories.
-//     Consider using a positive limit (e.g., 10-50) for production use.
+//     Consider using a positive budget (e.g., 10-50) for production use.
 func WithPreloadMemory(limit int) ContentOption {
 	return func(p *ContentRequestProcessor) {
 		p.PreloadMemory = limit
@@ -303,7 +305,7 @@ func (p *ContentRequestProcessor) ProcessRequest(
 		}
 
 		// Preload memories into system prompt if configured.
-		// PreloadMemory: 0 = disabled, -1 = all, N > 0 = most recent N.
+		// PreloadMemory: 0 = disabled, -1 = all, N > 0 = adaptive preload budget.
 		if p.PreloadMemory != 0 && invocation.MemoryService != nil {
 			if memMsg := p.getPreloadMemoryMessage(ctx, invocation); memMsg != nil {
 				p.injectSystemContextMessage(req, *memMsg)
@@ -1512,20 +1514,82 @@ func (p *ContentRequestProcessor) getPreloadMemoryMessage(
 	if userKey.AppName == "" || userKey.UserID == "" {
 		return nil
 	}
-	// Handle PreloadMemory: 0 = disabled, -1 = all, N > 0 = most recent N.
+	// Handle PreloadMemory: 0 = disabled, -1 = all, N > 0 = adaptive budget.
 	if p.PreloadMemory == 0 {
-		// PreloadMemory = 0 means disabled, return nil.
 		return nil
 	}
-	// PreloadMemory = -1 means all memories, use 0 for ReadMemories (no limit).
-	// PreloadMemory = N > 0 means most recent N memories.
-	// Here we use max to handle the case when PreloadMemory is negative.
-	limit := max(p.PreloadMemory, 0)
+	if p.PreloadMemory < 0 {
+		return p.loadPreloadMemoryMessage(ctx, inv, userKey, 0)
+	}
+	return p.getAdaptivePreloadMemoryMessage(ctx, inv, userKey, p.PreloadMemory)
+}
+
+// getAdaptivePreloadMemoryMessage preloads all memories for small memory sets
+// and falls back to query-aware search for larger sets.
+func (p *ContentRequestProcessor) getAdaptivePreloadMemoryMessage(
+	ctx context.Context,
+	inv *agent.Invocation,
+	userKey memory.UserKey,
+	budget int,
+) *model.Message {
+	const preloadProbeExtra = 1
+	probeLimit := budget + preloadProbeExtra
+	probeEntries, err := inv.MemoryService.ReadMemories(ctx, userKey, probeLimit)
+	if err != nil {
+		log.WarnfContext(ctx, "Failed to probe memories for preload: %v", err)
+		return nil
+	}
+	if len(probeEntries) == 0 {
+		return nil
+	}
+	if len(probeEntries) <= budget {
+		return newPreloadMemoryMessage(probeEntries)
+	}
+
+	query := buildPreloadSearchQuery(inv.Message)
+	if query == "" {
+		return p.loadPreloadMemoryMessage(ctx, inv, userKey, budget)
+	}
+
+	searchOpts := memory.SearchOptions{
+		Query:        query,
+		MaxResults:   budget,
+		Deduplicate:  true,
+		HybridSearch: true,
+	}
+	memories, err := inv.MemoryService.SearchMemories(
+		ctx,
+		userKey,
+		query,
+		memory.WithSearchOptions(searchOpts),
+	)
+	if err != nil {
+		log.WarnfContext(ctx, "Failed to search memories for preload: %v", err)
+		return p.loadPreloadMemoryMessage(ctx, inv, userKey, budget)
+	}
+	if len(memories) == 0 {
+		return p.loadPreloadMemoryMessage(ctx, inv, userKey, budget)
+	}
+	return newPreloadMemoryMessage(memories)
+}
+
+// loadPreloadMemoryMessage loads memories directly and formats them as a
+// system message.
+func (p *ContentRequestProcessor) loadPreloadMemoryMessage(
+	ctx context.Context,
+	inv *agent.Invocation,
+	userKey memory.UserKey,
+	limit int,
+) *model.Message {
 	memories, err := inv.MemoryService.ReadMemories(ctx, userKey, limit)
 	if err != nil {
 		log.WarnfContext(ctx, "Failed to preload memories: %v", err)
 		return nil
 	}
+	return newPreloadMemoryMessage(memories)
+}
+
+func newPreloadMemoryMessage(memories []*memory.Entry) *model.Message {
 	if len(memories) == 0 {
 		return nil
 	}
@@ -1533,6 +1597,26 @@ func (p *ContentRequestProcessor) getPreloadMemoryMessage(
 		Role:    model.RoleSystem,
 		Content: formatMemoryContent(memories),
 	}
+}
+
+// buildPreloadSearchQuery extracts the current user text used for adaptive
+// preload search.
+func buildPreloadSearchQuery(msg model.Message) string {
+	parts := make([]string, 0, 1+len(msg.ContentParts))
+	if text := strings.TrimSpace(msg.Content); text != "" {
+		parts = append(parts, text)
+	}
+	for _, part := range msg.ContentParts {
+		if part.Type != model.ContentTypeText || part.Text == nil {
+			continue
+		}
+		text := strings.TrimSpace(*part.Text)
+		if text == "" {
+			continue
+		}
+		parts = append(parts, text)
+	}
+	return strings.TrimSpace(strings.Join(parts, "\n"))
 }
 
 // formatMemoryContent formats memories for system prompt injection.

--- a/internal/flow/processor/content_memory_test.go
+++ b/internal/flow/processor/content_memory_test.go
@@ -206,10 +206,16 @@ func TestFormatMemoriesForPrompt(t *testing.T) {
 
 // mockMemoryService implements memory.Service for testing.
 type mockMemoryService struct {
-	memories   []*memory.Entry
-	readErr    error
-	readCalled bool
-	readLimit  int
+	memories      []*memory.Entry
+	readErr       error
+	readCalled    bool
+	readLimit     int
+	readLimits    []int
+	searchResults []*memory.Entry
+	searchErr     error
+	searchCalled  bool
+	searchQuery   string
+	searchOpts    memory.SearchOptions
 }
 
 func (m *mockMemoryService) AddMemory(ctx context.Context, userKey memory.UserKey, memoryStr string, topics []string, _ ...memory.AddOption) error {
@@ -231,14 +237,33 @@ func (m *mockMemoryService) ClearMemories(ctx context.Context, userKey memory.Us
 func (m *mockMemoryService) ReadMemories(ctx context.Context, userKey memory.UserKey, limit int) ([]*memory.Entry, error) {
 	m.readCalled = true
 	m.readLimit = limit
+	m.readLimits = append(m.readLimits, limit)
 	if m.readErr != nil {
 		return nil, m.readErr
 	}
-	return m.memories, nil
+	memories := m.memories
+	if limit > 0 && len(memories) > limit {
+		memories = memories[:limit]
+	}
+	result := make([]*memory.Entry, len(memories))
+	copy(result, memories)
+	return result, nil
 }
 
-func (m *mockMemoryService) SearchMemories(ctx context.Context, userKey memory.UserKey, query string, _ ...memory.SearchOption) ([]*memory.Entry, error) {
-	return nil, nil
+func (m *mockMemoryService) SearchMemories(ctx context.Context, userKey memory.UserKey, query string, opts ...memory.SearchOption) ([]*memory.Entry, error) {
+	m.searchCalled = true
+	m.searchQuery = query
+	m.searchOpts = memory.ResolveSearchOptions(query, opts)
+	if m.searchErr != nil {
+		return nil, m.searchErr
+	}
+	results := m.searchResults
+	if limit := m.searchOpts.MaxResults; limit > 0 && len(results) > limit {
+		results = results[:limit]
+	}
+	out := make([]*memory.Entry, len(results))
+	copy(out, results)
+	return out, nil
 }
 
 func (m *mockMemoryService) Tools() []tool.Tool {
@@ -251,6 +276,77 @@ func (m *mockMemoryService) EnqueueAutoMemoryJob(ctx context.Context, sess *sess
 
 func (m *mockMemoryService) Close() error {
 	return nil
+}
+
+func newTestMemoryEntry(id, content string) *memory.Entry {
+	return &memory.Entry{
+		ID:      id,
+		AppName: "app",
+		UserID:  "user",
+		Memory: &memory.Memory{
+			Memory: content,
+		},
+	}
+}
+
+func newTestInvocation(msg model.Message, svc *mockMemoryService) *agent.Invocation {
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(&session.Session{
+			AppName: "app",
+			UserID:  "user",
+		}),
+		agent.WithInvocationMessage(msg),
+	)
+	inv.MemoryService = svc
+	return inv
+}
+
+func TestBuildPreloadSearchQuery(t *testing.T) {
+	textPart := "Part text"
+	tests := []struct {
+		name string
+		msg  model.Message
+		want string
+	}{
+		{
+			name: "content only",
+			msg:  model.NewUserMessage("hello world"),
+			want: "hello world",
+		},
+		{
+			name: "content parts only",
+			msg: model.Message{
+				Role: model.RoleUser,
+				ContentParts: []model.ContentPart{
+					{Type: model.ContentTypeText, Text: &textPart},
+				},
+			},
+			want: "Part text",
+		},
+		{
+			name: "content and text parts",
+			msg: model.Message{
+				Role:    model.RoleUser,
+				Content: "Hello",
+				ContentParts: []model.ContentPart{
+					{Type: model.ContentTypeText, Text: &textPart},
+					{Type: model.ContentTypeImage},
+				},
+			},
+			want: "Hello\nPart text",
+		},
+		{
+			name: "empty payload",
+			msg:  model.Message{Role: model.RoleUser},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, buildPreloadSearchQuery(tt.msg))
+		})
+	}
 }
 
 func TestGetPreloadMemoryMessage(t *testing.T) {
@@ -307,16 +403,11 @@ func TestGetPreloadMemoryMessage(t *testing.T) {
 		mockSvc := &mockMemoryService{
 			readErr: assert.AnError,
 		}
-		inv := agent.NewInvocation(
-			agent.WithInvocationSession(&session.Session{
-				AppName: "app",
-				UserID:  "user",
-			}),
-		)
-		inv.MemoryService = mockSvc
+		inv := newTestInvocation(model.NewUserMessage("hello"), mockSvc)
 		msg := p.getPreloadMemoryMessage(context.Background(), inv)
 		assert.Nil(t, msg)
 		assert.True(t, mockSvc.readCalled)
+		assert.Equal(t, []int{0}, mockSvc.readLimits)
 	})
 
 	t.Run("empty memories returns nil", func(t *testing.T) {
@@ -339,19 +430,10 @@ func TestGetPreloadMemoryMessage(t *testing.T) {
 		p := NewContentRequestProcessor(WithPreloadMemory(-1))
 		mockSvc := &mockMemoryService{
 			memories: []*memory.Entry{
-				{
-					ID:     "mem-1",
-					Memory: &memory.Memory{Memory: "User likes coffee"},
-				},
+				newTestMemoryEntry("mem-1", "User likes coffee"),
 			},
 		}
-		inv := agent.NewInvocation(
-			agent.WithInvocationSession(&session.Session{
-				AppName: "app",
-				UserID:  "user",
-			}),
-		)
-		inv.MemoryService = mockSvc
+		inv := newTestInvocation(model.NewUserMessage("hello"), mockSvc)
 		msg := p.getPreloadMemoryMessage(context.Background(), inv)
 		assert.NotNil(t, msg)
 		assert.Equal(t, model.RoleSystem, msg.Role)
@@ -363,16 +445,10 @@ func TestGetPreloadMemoryMessage(t *testing.T) {
 		p := NewContentRequestProcessor(WithPreloadMemory(0))
 		mockSvc := &mockMemoryService{
 			memories: []*memory.Entry{
-				{ID: "mem-1", Memory: &memory.Memory{Memory: "test"}},
+				newTestMemoryEntry("mem-1", "test"),
 			},
 		}
-		inv := agent.NewInvocation(
-			agent.WithInvocationSession(&session.Session{
-				AppName: "app",
-				UserID:  "user",
-			}),
-		)
-		inv.MemoryService = mockSvc
+		inv := newTestInvocation(model.NewUserMessage("hello"), mockSvc)
 		msg := p.getPreloadMemoryMessage(context.Background(), inv)
 		assert.Nil(t, msg)
 		assert.False(t, mockSvc.readCalled)
@@ -382,57 +458,116 @@ func TestGetPreloadMemoryMessage(t *testing.T) {
 		p := NewContentRequestProcessor(WithPreloadMemory(-1))
 		mockSvc := &mockMemoryService{
 			memories: []*memory.Entry{
-				{ID: "mem-1", Memory: &memory.Memory{Memory: "test"}},
+				newTestMemoryEntry("mem-1", "test"),
 			},
 		}
-		inv := agent.NewInvocation(
-			agent.WithInvocationSession(&session.Session{
-				AppName: "app",
-				UserID:  "user",
-			}),
-		)
-		inv.MemoryService = mockSvc
+		inv := newTestInvocation(model.NewUserMessage("hello"), mockSvc)
 		p.getPreloadMemoryMessage(context.Background(), inv)
 		assert.Equal(t, 0, mockSvc.readLimit)
 		assert.True(t, mockSvc.readCalled)
+		assert.False(t, mockSvc.searchCalled)
 	})
 
-	t.Run("positive preload uses limit", func(t *testing.T) {
+	t.Run("positive preload loads all when count fits budget", func(t *testing.T) {
 		p := NewContentRequestProcessor(WithPreloadMemory(5))
 		mockSvc := &mockMemoryService{
 			memories: []*memory.Entry{
-				{ID: "mem-1", Memory: &memory.Memory{Memory: "test"}},
+				newTestMemoryEntry("mem-1", "one"),
+				newTestMemoryEntry("mem-2", "two"),
+				newTestMemoryEntry("mem-3", "three"),
 			},
 		}
-		inv := agent.NewInvocation(
-			agent.WithInvocationSession(&session.Session{
-				AppName: "app",
-				UserID:  "user",
-			}),
-		)
-		inv.MemoryService = mockSvc
-		p.getPreloadMemoryMessage(context.Background(), inv)
-		assert.Equal(t, 5, mockSvc.readLimit)
+		inv := newTestInvocation(model.NewUserMessage("hello"), mockSvc)
+		msg := p.getPreloadMemoryMessage(context.Background(), inv)
+		assert.NotNil(t, msg)
+		assert.Equal(t, []int{6}, mockSvc.readLimits)
 		assert.True(t, mockSvc.readCalled)
+		assert.False(t, mockSvc.searchCalled)
+		assert.Contains(t, msg.Content, "one")
+		assert.Contains(t, msg.Content, "three")
 	})
 
-	t.Run("zero preload disabled", func(t *testing.T) {
-		p := NewContentRequestProcessor(WithPreloadMemory(0))
+	t.Run("positive preload uses search when count exceeds budget", func(t *testing.T) {
+		p := NewContentRequestProcessor(WithPreloadMemory(2))
 		mockSvc := &mockMemoryService{
 			memories: []*memory.Entry{
-				{ID: "mem-1", Memory: &memory.Memory{Memory: "test"}},
+				newTestMemoryEntry("mem-1", "first"),
+				newTestMemoryEntry("mem-2", "second"),
+				newTestMemoryEntry("mem-3", "third"),
+			},
+			searchResults: []*memory.Entry{
+				newTestMemoryEntry("mem-search", "Relevant memory"),
 			},
 		}
-		inv := agent.NewInvocation(
-			agent.WithInvocationSession(&session.Session{
-				AppName: "app",
-				UserID:  "user",
-			}),
-		)
-		inv.MemoryService = mockSvc
+		inv := newTestInvocation(model.NewUserMessage("find relevant"), mockSvc)
 		msg := p.getPreloadMemoryMessage(context.Background(), inv)
-		assert.Nil(t, msg)
-		assert.False(t, mockSvc.readCalled)
+		assert.NotNil(t, msg)
+		assert.Equal(t, []int{3}, mockSvc.readLimits)
+		assert.True(t, mockSvc.searchCalled)
+		assert.Equal(t, "find relevant", mockSvc.searchQuery)
+		assert.Equal(t, 2, mockSvc.searchOpts.MaxResults)
+		assert.True(t, mockSvc.searchOpts.Deduplicate)
+		assert.True(t, mockSvc.searchOpts.HybridSearch)
+		assert.Contains(t, msg.Content, "Relevant memory")
+	})
+
+	t.Run("positive preload falls back to recent load when query is empty", func(t *testing.T) {
+		p := NewContentRequestProcessor(WithPreloadMemory(2))
+		mockSvc := &mockMemoryService{
+			memories: []*memory.Entry{
+				newTestMemoryEntry("mem-1", "first"),
+				newTestMemoryEntry("mem-2", "second"),
+				newTestMemoryEntry("mem-3", "third"),
+			},
+		}
+		inv := newTestInvocation(model.Message{Role: model.RoleUser}, mockSvc)
+		msg := p.getPreloadMemoryMessage(context.Background(), inv)
+		assert.NotNil(t, msg)
+		assert.Equal(t, []int{3, 2}, mockSvc.readLimits)
+		assert.False(t, mockSvc.searchCalled)
+		assert.Contains(t, msg.Content, "first")
+		assert.Contains(t, msg.Content, "second")
+		assert.NotContains(t, msg.Content, "third")
+	})
+
+	t.Run("positive preload falls back to recent load when search fails", func(t *testing.T) {
+		p := NewContentRequestProcessor(WithPreloadMemory(2))
+		mockSvc := &mockMemoryService{
+			memories: []*memory.Entry{
+				newTestMemoryEntry("mem-1", "first"),
+				newTestMemoryEntry("mem-2", "second"),
+				newTestMemoryEntry("mem-3", "third"),
+			},
+			searchErr: assert.AnError,
+		}
+		inv := newTestInvocation(model.NewUserMessage("hello"), mockSvc)
+		msg := p.getPreloadMemoryMessage(context.Background(), inv)
+		assert.NotNil(t, msg)
+		assert.Equal(t, []int{3, 2}, mockSvc.readLimits)
+		assert.True(t, mockSvc.searchCalled)
+		assert.Contains(t, msg.Content, "first")
+		assert.Contains(t, msg.Content, "second")
+		assert.NotContains(t, msg.Content, "third")
+	})
+
+	t.Run("positive preload falls back to recent load when search is empty", func(t *testing.T) {
+		p := NewContentRequestProcessor(WithPreloadMemory(2))
+		mockSvc := &mockMemoryService{
+			memories: []*memory.Entry{
+				newTestMemoryEntry("mem-1", "first"),
+				newTestMemoryEntry("mem-2", "second"),
+				newTestMemoryEntry("mem-3", "third"),
+			},
+			searchResults: []*memory.Entry{},
+		}
+		inv := newTestInvocation(model.NewUserMessage("hello"), mockSvc)
+		msg := p.getPreloadMemoryMessage(context.Background(), inv)
+		assert.NotNil(t, msg)
+		assert.Equal(t, []int{3, 2}, mockSvc.readLimits)
+		assert.True(t, mockSvc.searchCalled)
+		assert.Contains(t, msg.Content, "first")
+		assert.Contains(t, msg.Content, "second")
+		assert.NotContains(t, msg.Content, "third")
 	})
 }
 
@@ -487,6 +622,36 @@ func TestProcessRequest_WithPreloadMemory(t *testing.T) {
 		assert.Contains(t, req.Messages[0].Content, "You are a helpful assistant.")
 		assert.Contains(t, req.Messages[0].Content, "User Memories")
 		assert.Contains(t, req.Messages[0].Content, "User prefers dark mode")
+	})
+
+	t.Run("adaptive preload uses search result in system message", func(t *testing.T) {
+		p := NewContentRequestProcessor(
+			WithPreloadMemory(2),
+			WithAddSessionSummary(true),
+		)
+		mockSvc := &mockMemoryService{
+			memories: []*memory.Entry{
+				newTestMemoryEntry("mem-1", "first"),
+				newTestMemoryEntry("mem-2", "second"),
+				newTestMemoryEntry("mem-3", "third"),
+			},
+			searchResults: []*memory.Entry{
+				newTestMemoryEntry("mem-search", "User prefers dark mode"),
+			},
+		}
+		inv := newTestInvocation(model.NewUserMessage("dark mode"), mockSvc)
+		req := &model.Request{
+			Messages: []model.Message{
+				{Role: model.RoleSystem, Content: "You are a helpful assistant."},
+				{Role: model.RoleUser, Content: "hello"},
+			},
+		}
+		p.ProcessRequest(context.Background(), inv, req, nil)
+		assert.True(t, mockSvc.readCalled)
+		assert.True(t, mockSvc.searchCalled)
+		assert.Equal(t, []int{3}, mockSvc.readLimits)
+		assert.Contains(t, req.Messages[0].Content, "User prefers dark mode")
+		assert.NotContains(t, req.Messages[0].Content, "first")
 	})
 
 	t.Run("preload with no system message prepends memory", func(t *testing.T) {

--- a/openclaw/INTEGRATIONS.md
+++ b/openclaw/INTEGRATIONS.md
@@ -819,7 +819,9 @@ Recommendation: keep this small (like 10–50) so it stays readable and
 doesn't dominate the prompt.
 With a positive value, OpenClaw preloads all memories when the user has
 at most `N` memories, and otherwise injects the top `N` search results
-for the current user message.
+for the current user message. If query extraction is empty, the search
+fails, or the search returns no matches, it falls back to directly
+loading up to `N` memories.
 
 ### Cap raw history when you do not use summary (optional)
 

--- a/openclaw/INTEGRATIONS.md
+++ b/openclaw/INTEGRATIONS.md
@@ -807,16 +807,19 @@ threads.
 
 ### Preload memories into the prompt (optional)
 
-If you use a memory backend, you can preload recent memories into the
-system prompt:
+If you use a memory backend, you can preload memories into the system
+prompt:
 
 ```yaml
 agent:
-  preload_memory: 10   # 0=off, -1=all, N>0=most recent N
+  preload_memory: 10   # 0=off, -1=all, N>0=adaptive preload budget
 ```
 
 Recommendation: keep this small (like 10–50) so it stays readable and
 doesn't dominate the prompt.
+With a positive value, OpenClaw preloads all memories when the user has
+at most `N` memories, and otherwise injects the top `N` search results
+for the current user message.
 
 ### Cap raw history when you do not use summary (optional)
 

--- a/openclaw/app/run_options.go
+++ b/openclaw/app/run_options.go
@@ -343,7 +343,7 @@ func parseRunOptions(args []string) (runOptions, error) {
 		&opts.PreloadMemory,
 		flagPreloadMemory,
 		0,
-		"Preload N memories into system prompt (0=off, -1=all)",
+		"Preload memories into system prompt (0=off, -1=all, N>0=adaptive budget)",
 	)
 	fs.StringVar(
 		&opts.AgentInstruction,


### PR DESCRIPTION
## Summary
- change positive `WithPreloadMemory(N)` to framework-side adaptive preload: inject all memories when count is at most `N`, otherwise inject the top `N` search results for the current user message
- add preload coverage for adaptive load/search branching, search fallbacks, query extraction, and system prompt merging
- update the English and Chinese memory docs, the auto-memory example, and the OpenClaw integration docs to match the new preload semantics

## Test plan
- [x] `go test ./internal/flow/processor ./agent/llmagent`
- [x] `go test ./app` (from `openclaw/`)
