### PR TITLE
openclaw: align official skill dependency metadata support

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ tools := []tool.Tool{
 If you wire Skills through `LLMAgent` with `llmagent.WithCodeExecutor(...)`,
 consider also setting
 `llmagent.WithEnableCodeExecutionResponseProcessor(false)` so Markdown fenced
-code blocks in assistant text do not auto-execute while `skill_run` is
+code blocks embedded in assistant text do not auto-execute while `skill_run` is
 enabled.
 
 </td>
@@ -567,7 +567,7 @@ Example: [examples/skillrun](examples/skillrun)
   skill-focused examples (`examples/skill`, `examples/skillrun`,
   `examples/skilldynamicschema`, and
   `examples/structuredoutputskills`) follow this pattern so fenced code
-  blocks in assistant text do not auto-execute.
+  blocks embedded in assistant text do not auto-execute.
 
 ### 12. Artifacts
 

--- a/agent/llmagent/llm_agent_test.go
+++ b/agent/llmagent/llm_agent_test.go
@@ -1070,6 +1070,42 @@ func TestLLMAgent_EnableCodeExecutionResponseProcessor(t *testing.T) {
 		require.Equal(t, 0, exec.CallCount())
 		require.Equal(t, codeBlock, gotContent)
 	})
+
+	t.Run("non_executable_markdown_block", func(t *testing.T) {
+		exec := &countingCodeExecutor{}
+		agt := New(
+			"test",
+			WithModel(&mockModelWithResponse{
+				response: &model.Response{
+					Choices: []model.Choice{{
+						Message: model.Message{
+							Role: model.RoleAssistant,
+							Content: "```markdown\n" +
+								"# hello\n```",
+						},
+					}},
+					Done: true,
+				},
+			}),
+			WithCodeExecutor(exec),
+		)
+
+		events, err := agt.Run(context.Background(), newInvocation())
+		require.NoError(t, err)
+
+		gotContent := ""
+		for ev := range events {
+			if ev == nil || ev.Response == nil {
+				continue
+			}
+			if ev.IsFinalResponse() && len(ev.Choices) > 0 {
+				gotContent = ev.Choices[0].Message.Content
+			}
+		}
+
+		require.Equal(t, 0, exec.CallCount())
+		require.Equal(t, "```markdown\n# hello\n```", gotContent)
+	})
 }
 
 // TestLLMAgent_OptionsWithOutputKey tests WithOutputKey option.

--- a/agent/llmagent/option.go
+++ b/agent/llmagent/option.go
@@ -472,7 +472,8 @@ func WithCodeExecutor(ce codeexecutor.CodeExecutor) Option {
 }
 
 // WithEnableCodeExecutionResponseProcessor controls whether the agent
-// auto-executes fenced code blocks found in model responses.
+// auto-executes assistant replies that are exactly one runnable fenced
+// code block.
 func WithEnableCodeExecutionResponseProcessor(enable bool) Option {
 	return func(opts *Options) {
 		opts.EnableCodeExecutionResponseProcessor = enable

--- a/docs/mkdocs/en/openclaw-runtime.md
+++ b/docs/mkdocs/en/openclaw-runtime.md
@@ -921,6 +921,41 @@ effect, the more common reason is not "the Skill failed to load," but
 "its required config, environment variables, or binaries are not
 available yet."
 
+OpenClaw now also has a host-dependency inspection and bootstrap flow
+for Skills and file-tool profiles. In other words, `metadata.openclaw`
+is not only used to decide whether a Skill should load, but can also
+describe what the host is expected to provide:
+
+```bash
+cd openclaw
+go run ./cmd/openclaw inspect deps -skill nano-pdf
+go run ./cmd/openclaw bootstrap deps -skill nano-pdf -apply
+```
+
+This is useful when the issue is no longer "why was the Skill skipped,"
+but "what exactly do I need to install on this machine so the Skill can
+run end-to-end."
+
+At the moment, official OpenClaw Skill metadata can describe:
+
+- package-manager installs
+- Go module or binary installs
+- npm installs
+- managed-Python installs in the OpenClaw state directory
+- asset downloads
+
+There are two practical details worth remembering:
+
+- `inspect deps` and `bootstrap deps` can work from built-in dependency
+  profiles, specific Skills, or both.
+- An explicit `-skill ...` selection only plans the named Skills. It no
+  longer pulls in the default file-tool profiles automatically.
+
+`bootstrap deps --apply` is best-effort. User-space installs and
+downloads run first, while root-only system-package steps are reported
+as deferred rather than aborting the whole run. Downloaded assets are
+stored under `<state_dir>/tools/<skill>/...`.
+
 ## Best Practices
 
 In real adoption, the following practices are usually the most

--- a/docs/mkdocs/zh/openclaw-runtime.md
+++ b/docs/mkdocs/zh/openclaw-runtime.md
@@ -873,6 +873,41 @@ go run ./cmd/openclaw inspect config-keys -config ./openclaw.yaml
 “Skill 没加载”，而是它依赖的 config、env 或 bin
 还没有满足。
 
+现在 OpenClaw 还补上了一套面向 Skills 和文件工具档位的
+宿主机依赖检查与引导安装流程。也就是说，
+`metadata.openclaw` 不仅能决定一个 Skill 要不要加载，
+还可以描述这台机器应该准备哪些依赖：
+
+```bash
+cd openclaw
+go run ./cmd/openclaw inspect deps -skill nano-pdf
+go run ./cmd/openclaw bootstrap deps -skill nano-pdf -apply
+```
+
+这在排查问题时很重要，因为很多时候真正的问题已经不是
+“为什么 Skill 被跳过了”，而是
+“为了让这个 Skill 能完整跑起来，这台机器到底还缺什么”。
+
+目前，官方 OpenClaw Skill 元数据已经可以描述：
+
+- 包管理器安装
+- Go 模块或二进制安装
+- npm 安装
+- 在 OpenClaw state 目录下创建的托管 Python 环境安装
+- 资源下载
+
+有两个实践细节尤其需要记住：
+
+- `inspect deps` 和 `bootstrap deps` 可以同时基于内置依赖档位、
+  指定 Skill，或者两者的组合来规划。
+- 显式传 `-skill ...` 时，只会规划你点名的 Skill，
+  不会再自动把默认文件工具档位一起带上。
+
+`bootstrap deps --apply` 采用 best-effort 语义：
+优先执行用户态安装和下载；需要 root 权限的系统包步骤不会让整次
+执行直接失败，而是以 deferred 形式报告出来。下载的资源会落到
+`<state_dir>/tools/<skill>/...`。
+
 ## 最佳实践
 
 在实际落地中，下面几条经验通常最关键。

--- a/internal/flow/processor/codeexecution.go
+++ b/internal/flow/processor/codeexecution.go
@@ -11,12 +11,31 @@ package processor
 
 import (
 	"context"
+	"strings"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
 	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 )
+
+var nonExecutableCodeLanguages = map[string]struct{}{
+	"":          {},
+	"css":       {},
+	"csv":       {},
+	"html":      {},
+	"json":      {},
+	"markdown":  {},
+	"md":        {},
+	"mermaid":   {},
+	"plain":     {},
+	"plaintext": {},
+	"text":      {},
+	"txt":       {},
+	"xml":       {},
+	"yaml":      {},
+	"yml":       {},
+}
 
 // CodeExecutionResponseProcessor processes code execution responses from the model.
 type CodeExecutionResponseProcessor struct {
@@ -48,11 +67,15 @@ func (p *CodeExecutionResponseProcessor) ProcessResponse(
 		return
 	}
 
-	codeBlocks := codeexecutor.ExtractCodeBlock(rsp.Choices[0].Message.Content, e.CodeBlockDelimiter())
+	content := rsp.Choices[0].Message.Content
+	codeBlocks := autoExecutableCodeBlocks(
+		content,
+		e.CodeBlockDelimiter(),
+	)
 	if len(codeBlocks) == 0 {
 		return
 	}
-	truncatedContent := rsp.Choices[0].Message.Content // todo: truncate the content
+	truncatedContent := content // todo: truncate the content
 
 	//  [Step 2] Executes the code and emit 2 Events for code and execution result.
 	agent.EmitEvent(ctx, invocation, ch, event.New(
@@ -104,4 +127,38 @@ func (p *CodeExecutionResponseProcessor) ProcessResponse(
 	))
 	//  [Step 3] Skip processing the original model response to continue code generation loop.
 	rsp.Choices[0].Message.Content = ""
+}
+
+func autoExecutableCodeBlocks(
+	content string,
+	delimiter codeexecutor.CodeBlockDelimiter,
+) []codeexecutor.CodeBlock {
+	trimmed := strings.TrimSpace(content)
+	if trimmed == "" {
+		return nil
+	}
+
+	blocks := codeexecutor.ExtractCodeBlock(trimmed, delimiter)
+	if len(blocks) != 1 {
+		return nil
+	}
+
+	block := blocks[0]
+	if !isAutoExecutableCodeLanguage(block.Language) {
+		return nil
+	}
+
+	expected := delimiter.Start + strings.TrimSpace(block.Language) +
+		"\n" + block.Code + delimiter.End
+	if trimmed != expected {
+		return nil
+	}
+
+	return blocks
+}
+
+func isAutoExecutableCodeLanguage(language string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(language))
+	_, blocked := nonExecutableCodeLanguages[normalized]
+	return !blocked
 }

--- a/internal/flow/processor/codeexecution_test.go
+++ b/internal/flow/processor/codeexecution_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
@@ -68,6 +69,74 @@ func TestCodeExecutionResponseProcessor_EmitsCodeAndResultEvents(t *testing.T) {
 		resultMsg := evts[1].Response.Choices[0].Message.Content
 		assert.True(t, strings.Contains(resultMsg,
 			"Code execution result:") || strings.Contains(resultMsg, "OK"))
+	}
+}
+
+func TestCodeExecutionResponseProcessor_SkipsNonExecutableBlocks(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	ctx := context.Background()
+	proc := iprocessor.NewCodeExecutionResponseProcessor()
+
+	cases := []struct {
+		name    string
+		content string
+	}{
+		{
+			name: "text around block",
+			content: "Here you go:\n```bash\n" +
+				"echo hello\n```",
+		},
+		{
+			name: "markdown block",
+			content: "```markdown\n" +
+				"# title\n```",
+		},
+		{
+			name:    "plain unlabeled block",
+			content: "```\nhello\n```",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			inv := &agent.Invocation{
+				Agent:     &testAgent{exec: &stubExec{}},
+				Session:   &session.Session{ID: "test-session"},
+				AgentName: "test-agent",
+			}
+			rsp := &model.Response{
+				Done: true,
+				Choices: []model.Choice{{
+					Message: model.Message{
+						Role:    model.RoleAssistant,
+						Content: tc.content,
+					},
+				}},
+			}
+
+			ch := make(chan *event.Event, 4)
+			proc.ProcessResponse(
+				ctx,
+				inv,
+				&model.Request{},
+				rsp,
+				ch,
+			)
+
+			require.Len(t, ch, 0)
+			require.Len(t, rsp.Choices, 1)
+			require.Equal(
+				t,
+				tc.content,
+				rsp.Choices[0].Message.Content,
+			)
+		})
 	}
 }
 

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -692,6 +692,14 @@ missing, but installation is always explicit. The managed Python environment
 is created with access to the current system site-packages, so existing
 packages such as `pandas` remain visible after bootstrap.
 
+Official OpenClaw skill metadata can currently describe package-manager,
+Go, npm, managed-Python, and asset download install actions. Explicit
+`-skill ...` runs only plan the selected skills and no longer pull in the
+default dependency profiles automatically. `bootstrap deps --apply` is
+best-effort: user-space installs and downloads run first, while root-only
+steps are reported as deferred instead of aborting the entire run. Download
+actions store assets under `<state_dir>/tools/<skill>/...`.
+
 ### 5) Send a message
 
 Open a chat with your bot (or add it into a group) and send:

--- a/openclaw/app/deps_cmd.go
+++ b/openclaw/app/deps_cmd.go
@@ -136,6 +136,14 @@ func runBootstrapDeps(args []string) int {
 
 	result, err := ocdeps.ApplyPlan(context.Background(), plan)
 	printApplyResult(result)
+	if len(plan.Unresolved.Bins) > 0 ||
+		len(plan.Unresolved.AnyBins) > 0 {
+		fmt.Fprintf(
+			os.Stdout,
+			"Unresolved: %s\n",
+			formatMissing(plan.Unresolved),
+		)
+	}
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 1
@@ -228,9 +236,12 @@ func resolveDepsSources(
 	profileNames := splitCSV(opts.Profiles)
 	skillNames := splitCSV(opts.Skills)
 
-	profileSources, err := ocdeps.SourcesForProfiles(profileNames)
-	if err != nil {
-		return "", nil, nil, err
+	profileSources := []ocdeps.Source{}
+	if len(profileNames) > 0 {
+		profileSources, err = ocdeps.SourcesForProfiles(profileNames)
+		if err != nil {
+			return "", nil, nil, err
+		}
 	}
 	skillSources, err := resolveSkillDependencySources(stateDir, opts)
 	if err != nil {
@@ -412,14 +423,45 @@ func printApplyResult(result ocdeps.ApplyResult) {
 	if len(result.Steps) == 0 {
 		return
 	}
-	fmt.Fprintln(os.Stdout, "Applied:")
-	for _, step := range result.Steps {
-		fmt.Fprintf(
-			os.Stdout,
-			"- %s (exit=%d)\n",
-			step.Step.Label,
-			step.ExitCode,
-		)
+	printApplySteps("Applied", result.Steps, ocdepsStepStatusApplied)
+	printApplySteps("Deferred", result.Steps, ocdepsStepStatusDeferred)
+	printApplySteps("Failed", result.Steps, ocdepsStepStatusFailed)
+}
+
+const (
+	ocdepsStepStatusApplied  = "applied"
+	ocdepsStepStatusDeferred = "deferred"
+	ocdepsStepStatusFailed   = "failed"
+)
+
+func printApplySteps(
+	label string,
+	steps []ocdeps.StepResult,
+	status string,
+) {
+	filtered := make([]ocdeps.StepResult, 0, len(steps))
+	for _, step := range steps {
+		if step.Status == status {
+			filtered = append(filtered, step)
+		}
+	}
+	if len(filtered) == 0 {
+		return
+	}
+
+	fmt.Fprintf(os.Stdout, "%s:\n", label)
+	for _, step := range filtered {
+		line := fmt.Sprintf("- %s", step.Step.Label)
+		switch status {
+		case ocdepsStepStatusApplied:
+			line += fmt.Sprintf(" (exit=%d)", step.ExitCode)
+		case ocdepsStepStatusFailed:
+			line += fmt.Sprintf(" (exit=%d)", step.ExitCode)
+		}
+		fmt.Fprintln(os.Stdout, line)
+		if strings.TrimSpace(step.Error) != "" {
+			fmt.Fprintf(os.Stdout, "  %s\n", step.Error)
+		}
 	}
 }
 

--- a/openclaw/app/inspect_cmd_test.go
+++ b/openclaw/app/inspect_cmd_test.go
@@ -21,6 +21,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	ocdeps "trpc.group/trpc-go/trpc-agent-go/openclaw/internal/deps"
+	ocskills "trpc.group/trpc-go/trpc-agent-go/openclaw/internal/skills"
 	_ "trpc.group/trpc-go/trpc-agent-go/openclaw/plugins/telegram"
 )
 
@@ -174,6 +175,69 @@ metadata:
 	require.Contains(t, stdout, "definitely-missing-python-package")
 }
 
+func TestRunBootstrapDeps_WithSkillDoesNotAddDefaultProfiles(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	writeDepsSkill(t, root, "skillonly", `---
+name: skillonly
+description: skill-only deps
+metadata:
+  {
+    "openclaw":
+      {
+        "requires":
+          {
+            "bins": ["definitely_missing_bin"],
+          },
+      },
+  }
+---
+
+# skillonly
+`)
+
+	stdout, stderr := captureInspectOutput(t, func() {
+		require.Equal(t, 0, runBootstrap([]string{
+			bootstrapCmdDeps,
+			"-state-dir",
+			t.TempDir(),
+			"-skills-root",
+			root,
+			"-skill",
+			"skillonly",
+		}))
+	})
+
+	require.Empty(t, stderr)
+	require.Contains(t, stdout, "Selected: skillonly")
+	require.Contains(t, stdout, "Plan: nothing to install")
+	require.NotContains(
+		t,
+		stdout,
+		"definitely-missing-python-package",
+	)
+}
+
+func TestBuildPlanForSources_OfficialSkillMetadataBuilds(
+	t *testing.T,
+) {
+	root := filepath.Join("..", "skills")
+	repo, err := ocskills.NewRepository([]string{root})
+	require.NoError(t, err)
+
+	sources, err := repo.DependencySources(nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, sources)
+
+	_, err = ocdeps.BuildPlanForSources(
+		t.TempDir(),
+		nil,
+		sources,
+	)
+	require.NoError(t, err)
+}
+
 func TestRunBootstrap_HelpAndUnknownCommand(t *testing.T) {
 	stdout, stderr := captureInspectOutput(t, func() {
 		require.Equal(t, 2, runBootstrap(nil))
@@ -316,10 +380,24 @@ func TestDepsCommandHelpers(t *testing.T) {
 
 	stdout, stderr := captureInspectOutput(t, func() {
 		printApplyResult(ocdeps.ApplyResult{
-			Steps: []ocdeps.StepResult{{
-				Step:     ocdeps.Step{Label: "install"},
-				ExitCode: 0,
-			}},
+			Steps: []ocdeps.StepResult{
+				{
+					Step:     ocdeps.Step{Label: "install"},
+					Status:   "applied",
+					ExitCode: 0,
+				},
+				{
+					Step:   ocdeps.Step{Label: "defer"},
+					Status: "deferred",
+					Error:  "needs sudo",
+				},
+				{
+					Step:     ocdeps.Step{Label: "fail"},
+					Status:   "failed",
+					ExitCode: 3,
+					Error:    "boom",
+				},
+			},
 		})
 		printToolchain(ocdeps.Toolchain{})
 		require.Equal(t, 0, printJSON(map[string]string{"ok": "yes"}))
@@ -332,6 +410,12 @@ func TestDepsCommandHelpers(t *testing.T) {
 
 	require.Contains(t, stdout, "Applied:")
 	require.Contains(t, stdout, "install (exit=0)")
+	require.Contains(t, stdout, "Deferred:")
+	require.Contains(t, stdout, "defer")
+	require.Contains(t, stdout, "needs sudo")
+	require.Contains(t, stdout, "Failed:")
+	require.Contains(t, stdout, "fail (exit=3)")
+	require.Contains(t, stdout, "boom")
 	require.Contains(t, stdout, "Python: not found")
 	require.Contains(t, stdout, "\"ok\": \"yes\"")
 	require.Contains(t, stderr, "unsupported type")

--- a/openclaw/app/inspect_cmd_test.go
+++ b/openclaw/app/inspect_cmd_test.go
@@ -212,11 +212,51 @@ metadata:
 	require.Empty(t, stderr)
 	require.Contains(t, stdout, "Selected: skillonly")
 	require.Contains(t, stdout, "Plan: nothing to install")
+	require.Contains(t, stdout, "Unresolved:")
+	require.Contains(t, stdout, "definitely_missing_bin")
 	require.NotContains(
 		t,
 		stdout,
 		"definitely-missing-python-package",
 	)
+}
+
+func TestRunBootstrapDeps_ApplyPrintsUnresolved(t *testing.T) {
+	root := t.TempDir()
+	writeDepsSkill(t, root, "skillonly", `---
+name: skillonly
+description: skill-only deps
+metadata:
+  {
+    "openclaw":
+      {
+        "requires":
+          {
+            "bins": ["definitely_missing_bin"],
+          },
+      },
+  }
+---
+
+# skillonly
+`)
+
+	stdout, stderr := captureInspectOutput(t, func() {
+		require.Equal(t, 0, runBootstrap([]string{
+			bootstrapCmdDeps,
+			"-state-dir",
+			t.TempDir(),
+			"-skills-root",
+			root,
+			"-skill",
+			"skillonly",
+			"-apply",
+		}))
+	})
+
+	require.Empty(t, stderr)
+	require.Contains(t, stdout, "Unresolved:")
+	require.Contains(t, stdout, "definitely_missing_bin")
 }
 
 func TestBuildPlanForSources_OfficialSkillMetadataBuilds(

--- a/openclaw/app/tool_result_media.go
+++ b/openclaw/app/tool_result_media.go
@@ -282,16 +282,17 @@ func toolResultPathFromLine(line string) (string, bool) {
 		return "", false
 	}
 
-	for _, prefix := range []string{
-		toolResultMediaLineDir,
-		toolResultMediaLineFile,
-	} {
-		if strings.HasPrefix(trimmed, prefix) {
-			trimmed = strings.TrimSpace(
-				strings.TrimPrefix(trimmed, prefix),
-			)
-			break
-		}
+	switch {
+	case strings.HasPrefix(trimmed, toolResultMediaLineDir):
+		trimmed = strings.TrimSpace(
+			strings.TrimPrefix(trimmed, toolResultMediaLineDir),
+		)
+	case strings.HasPrefix(trimmed, toolResultMediaLineFile):
+		trimmed = strings.TrimSpace(
+			strings.TrimPrefix(trimmed, toolResultMediaLineFile),
+		)
+	default:
+		return "", false
 	}
 
 	return resolveToolResultPath(trimmed)

--- a/openclaw/app/tool_result_media_test.go
+++ b/openclaw/app/tool_result_media_test.go
@@ -79,7 +79,7 @@ func TestOpenClawToolResultMessages_AttachesOutputImagePaths(t *testing.T) {
 		&tool.ToolResultMessagesInput{
 			DefaultToolMessage: defaultMsg,
 			Result: map[string]any{
-				"output": path + "\n",
+				"output": toolResultMediaLineFile + " " + path + "\n",
 			},
 		},
 	)
@@ -290,9 +290,8 @@ func TestToolResultPathHelpers(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, path, got)
 
-	got, ok = toolResultPathFromLine(path)
-	require.True(t, ok)
-	require.Equal(t, path, got)
+	_, ok = toolResultPathFromLine(path)
+	require.False(t, ok)
 
 	_, ok = toolResultPathFromLine("MEDIA: relative.png")
 	require.False(t, ok)
@@ -325,6 +324,36 @@ func TestToolResultPathHelpers(t *testing.T) {
 			{Name: "two.jpg"},
 		}),
 	)
+}
+
+func TestOpenClawToolResultMessages_IgnoresBareDirectoryOutput(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	root := t.TempDir()
+	path := writeTestFile(t, root, "frame.png", []byte("png"))
+	defaultMsg := model.Message{
+		Role:    model.RoleTool,
+		ToolID:  "tool-1",
+		Content: "{}",
+	}
+
+	got, err := openClawToolResultMessages(
+		context.Background(),
+		&tool.ToolResultMessagesInput{
+			DefaultToolMessage: defaultMsg,
+			Result: map[string]any{
+				"output": root + "\n",
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.Nil(t, got)
+
+	paths := toolResultOutputPaths(root + "\n")
+	require.Nil(t, paths)
+	require.FileExists(t, path)
 }
 
 func writeTestImage(t *testing.T, name string) string {

--- a/openclaw/gwproto/types.go
+++ b/openclaw/gwproto/types.go
@@ -82,6 +82,8 @@ const (
 	StreamEventTypeRunProgress StreamEventType = "run.progress"
 	// StreamEventTypeRunCompleted marks successful stream completion.
 	StreamEventTypeRunCompleted StreamEventType = "run.completed"
+	// StreamEventTypeRunCanceled marks a request canceled by the client.
+	StreamEventTypeRunCanceled StreamEventType = "run.canceled"
 	// StreamEventTypeRunError marks a terminal stream error.
 	StreamEventTypeRunError StreamEventType = "run.error"
 

--- a/openclaw/internal/deps/catalog.go
+++ b/openclaw/internal/deps/catalog.go
@@ -27,12 +27,16 @@ const (
 )
 
 const (
-	InstallKindAPT  = "apt"
-	InstallKindBrew = "brew"
-	InstallKindDNF  = "dnf"
-	InstallKindPIP  = "pip"
-	InstallKindUV   = "uv"
-	InstallKindYUM  = "yum"
+	InstallKindAPT      = "apt"
+	InstallKindBrew     = "brew"
+	InstallKindDownload = "download"
+	InstallKindGo       = "go"
+	InstallKindDNF      = "dnf"
+	InstallKindNode     = "node"
+	InstallKindNPM      = "npm"
+	InstallKindPIP      = "pip"
+	InstallKindUV       = "uv"
+	InstallKindYUM      = "yum"
 )
 
 type PythonPackage struct {
@@ -50,13 +54,21 @@ type Requirement struct {
 }
 
 type InstallAction struct {
-	ID       string   `yaml:"id,omitempty" json:"id,omitempty"`
-	Kind     string   `yaml:"kind,omitempty" json:"kind,omitempty"`
-	Formula  string   `yaml:"formula,omitempty" json:"formula,omitempty"`
-	Package  string   `yaml:"package,omitempty" json:"package,omitempty"`
-	Packages []string `yaml:"packages,omitempty" json:"packages,omitempty"`
-	Bins     []string `yaml:"bins,omitempty" json:"bins,omitempty"`
-	Label    string   `yaml:"label,omitempty" json:"label,omitempty"`
+	ID              string   `yaml:"id,omitempty" json:"id,omitempty"`
+	Kind            string   `yaml:"kind,omitempty" json:"kind,omitempty"`
+	Formula         string   `yaml:"formula,omitempty" json:"formula,omitempty"`
+	Package         string   `yaml:"package,omitempty" json:"package,omitempty"`
+	Packages        []string `yaml:"packages,omitempty" json:"packages,omitempty"`
+	Bins            []string `yaml:"bins,omitempty" json:"bins,omitempty"`
+	Label           string   `yaml:"label,omitempty" json:"label,omitempty"`
+	Tap             string   `yaml:"tap,omitempty" json:"tap,omitempty"`
+	Module          string   `yaml:"module,omitempty" json:"module,omitempty"`
+	URL             string   `yaml:"url,omitempty" json:"url,omitempty"`
+	Archive         string   `yaml:"archive,omitempty" json:"archive,omitempty"`
+	TargetDir       string   `yaml:"targetDir,omitempty" json:"target_dir,omitempty"`
+	OS              []string `yaml:"os,omitempty" json:"os,omitempty"`
+	Extract         bool     `yaml:"extract,omitempty" json:"extract,omitempty"`
+	StripComponents int      `yaml:"stripComponents,omitempty" json:"strip_components,omitempty"`
 }
 
 type Source struct {
@@ -479,22 +491,41 @@ func normalizeInstallActions(
 	seen := map[string]struct{}{}
 	for _, raw := range actions {
 		action := InstallAction{
-			ID:       strings.TrimSpace(raw.ID),
-			Kind:     strings.ToLower(strings.TrimSpace(raw.Kind)),
-			Formula:  strings.TrimSpace(raw.Formula),
-			Package:  strings.TrimSpace(raw.Package),
-			Packages: normalizeStrings(raw.Packages),
-			Bins:     normalizeStrings(raw.Bins),
-			Label:    strings.TrimSpace(raw.Label),
+			ID:              strings.TrimSpace(raw.ID),
+			Kind:            strings.ToLower(strings.TrimSpace(raw.Kind)),
+			Formula:         strings.TrimSpace(raw.Formula),
+			Package:         strings.TrimSpace(raw.Package),
+			Packages:        normalizeStrings(raw.Packages),
+			Bins:            normalizeStrings(raw.Bins),
+			Label:           strings.TrimSpace(raw.Label),
+			Tap:             strings.TrimSpace(raw.Tap),
+			Module:          strings.TrimSpace(raw.Module),
+			URL:             strings.TrimSpace(raw.URL),
+			Archive:         strings.ToLower(strings.TrimSpace(raw.Archive)),
+			TargetDir:       strings.TrimSpace(raw.TargetDir),
+			OS:              normalizeOSList(raw.OS),
+			Extract:         raw.Extract,
+			StripComponents: raw.StripComponents,
 		}
 		if action.Kind == "" {
 			continue
+		}
+		if action.StripComponents < 0 {
+			action.StripComponents = 0
 		}
 		key := strings.Join([]string{
 			action.Kind,
 			action.ID,
 			action.Formula,
 			action.Package,
+			action.Tap,
+			action.Module,
+			action.URL,
+			action.Archive,
+			action.TargetDir,
+			strings.Join(action.OS, ","),
+			fmt.Sprintf("%t", action.Extract),
+			fmt.Sprintf("%d", action.StripComponents),
 			strings.Join(action.Packages, ","),
 		}, "\x00")
 		if _, ok := seen[key]; ok {
@@ -521,6 +552,31 @@ func normalizeStrings(values []string) []string {
 		out = append(out, value)
 	}
 	return out
+}
+
+func normalizeOSList(values []string) []string {
+	out := make([]string, 0, len(values))
+	seen := map[string]struct{}{}
+	for _, raw := range values {
+		value := normalizeOSName(raw)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}
+
+func normalizeOSName(raw string) string {
+	value := strings.ToLower(strings.TrimSpace(raw))
+	if value == "win32" {
+		return "windows"
+	}
+	return value
 }
 
 func MergeSources(sources ...Source) []Source {

--- a/openclaw/internal/deps/catalog_test.go
+++ b/openclaw/internal/deps/catalog_test.go
@@ -68,3 +68,25 @@ func TestCatalogHelpers(t *testing.T) {
 	require.Equal(t, "a", merged[0].Name)
 	require.Equal(t, "b", merged[1].Name)
 }
+
+func TestNormalizeInstallActions_NormalizesPlatformFields(t *testing.T) {
+	t.Parallel()
+
+	actions := normalizeInstallActions([]InstallAction{{
+		Kind:            "DOWNLOAD",
+		URL:             " https://example.com/a.zip ",
+		Archive:         "TGZ",
+		TargetDir:       " runtime ",
+		OS:              []string{" Linux ", "win32", "linux", ""},
+		Extract:         true,
+		StripComponents: -2,
+	}})
+	require.Len(t, actions, 1)
+	require.Equal(t, InstallKindDownload, actions[0].Kind)
+	require.Equal(t, "tgz", actions[0].Archive)
+	require.Equal(t, "runtime", actions[0].TargetDir)
+	require.Equal(t, []string{"linux", "windows"}, actions[0].OS)
+	require.True(t, actions[0].Extract)
+	require.Equal(t, 0, actions[0].StripComponents)
+	require.Equal(t, "windows", normalizeOSName("win32"))
+}

--- a/openclaw/internal/deps/download.go
+++ b/openclaw/internal/deps/download.go
@@ -1,0 +1,405 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package deps
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/bzip2"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	neturl "net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+func downloadInstallStep(
+	toolchain Toolchain,
+	sourceName string,
+	action InstallAction,
+) (Step, error) {
+	rawURL := strings.TrimSpace(action.URL)
+	if rawURL == "" {
+		return Step{}, fmt.Errorf(
+			"download install action %q is missing url",
+			action.Label,
+		)
+	}
+
+	targetPath, err := downloadTargetPath(
+		toolchain.StateDir,
+		sourceName,
+		action,
+	)
+	if err != nil {
+		return Step{}, err
+	}
+
+	return Step{
+		Label:           actionLabel(action, "Download tool assets"),
+		Kind:            stepKindDownload,
+		CommandLine:     downloadCommandLine(rawURL, targetPath),
+		URL:             rawURL,
+		TargetPath:      targetPath,
+		Archive:         action.Archive,
+		Extract:         action.Extract,
+		StripComponents: action.StripComponents,
+	}, nil
+}
+
+func executeDownloadStep(
+	ctx context.Context,
+	step Step,
+) (string, error) {
+	reader, cleanup, err := openDownloadReader(ctx, step.URL)
+	if err != nil {
+		return "", err
+	}
+	defer cleanup()
+
+	if step.Extract {
+		if err := os.MkdirAll(step.TargetPath, 0o755); err != nil {
+			return "", err
+		}
+		if err := extractArchive(
+			reader,
+			step.Archive,
+			step.TargetPath,
+			step.StripComponents,
+		); err != nil {
+			return "", err
+		}
+		return "downloaded to " + step.TargetPath, nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(step.TargetPath), 0o755); err != nil {
+		return "", err
+	}
+	file, err := os.Create(step.TargetPath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	if _, err := io.Copy(file, reader); err != nil {
+		return "", err
+	}
+	return "downloaded to " + step.TargetPath, nil
+}
+
+func downloadTargetPath(
+	stateDir string,
+	sourceName string,
+	action InstallAction,
+) (string, error) {
+	root, err := skillToolsRoot(stateDir, sourceName)
+	if err != nil {
+		return "", err
+	}
+
+	targetPath := root
+	if strings.TrimSpace(action.TargetDir) != "" {
+		targetPath, err = safeJoin(root, action.TargetDir)
+		if err != nil {
+			return "", err
+		}
+	}
+	if action.Extract {
+		return targetPath, nil
+	}
+
+	name := downloadFileName(action.URL)
+	if name == "" {
+		return "", fmt.Errorf("cannot infer download filename from url")
+	}
+	return safeJoin(targetPath, name)
+}
+
+func skillToolsRoot(
+	stateDir string,
+	sourceName string,
+) (string, error) {
+	cleanName := strings.TrimSpace(sourceName)
+	if cleanName == "" {
+		return "", fmt.Errorf("empty source name for tools root")
+	}
+	root := filepath.Join(
+		strings.TrimSpace(stateDir),
+		defaultToolsDir,
+		cleanName,
+	)
+	return filepath.Clean(root), nil
+}
+
+func safeJoin(root string, rel string) (string, error) {
+	cleanRoot := filepath.Clean(strings.TrimSpace(root))
+	if cleanRoot == "" {
+		return "", fmt.Errorf("empty root path")
+	}
+
+	cleanRel := filepath.Clean(strings.TrimSpace(rel))
+	if cleanRel == "." || cleanRel == "" {
+		return cleanRoot, nil
+	}
+	if filepath.IsAbs(cleanRel) {
+		return "", fmt.Errorf("absolute target path %q is not allowed", rel)
+	}
+	if cleanRel == ".." ||
+		strings.HasPrefix(cleanRel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("target path %q escapes root", rel)
+	}
+	return filepath.Join(cleanRoot, cleanRel), nil
+}
+
+func downloadCommandLine(
+	rawURL string,
+	targetPath string,
+) string {
+	return "download " + shellQuote(rawURL) + " -> " + shellQuote(targetPath)
+}
+
+func downloadFileName(rawURL string) string {
+	parsed, err := neturl.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return ""
+	}
+	return path.Base(parsed.Path)
+}
+
+func openDownloadReader(
+	ctx context.Context,
+	rawURL string,
+) (io.ReadCloser, func(), error) {
+	parsed, err := neturl.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	switch parsed.Scheme {
+	case "", "file":
+		path := parsed.Path
+		if path == "" {
+			path = rawURL
+		}
+		file, err := os.Open(path)
+		if err != nil {
+			return nil, nil, err
+		}
+		return file, func() { _ = file.Close() }, nil
+	case "http", "https":
+		req, err := http.NewRequestWithContext(
+			ctx,
+			http.MethodGet,
+			rawURL,
+			nil,
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return nil, nil, err
+		}
+		if resp.StatusCode < http.StatusOK ||
+			resp.StatusCode >= http.StatusMultipleChoices {
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+			_ = resp.Body.Close()
+			return nil, nil, fmt.Errorf(
+				"download %q failed: %s %s",
+				rawURL,
+				resp.Status,
+				strings.TrimSpace(string(body)),
+			)
+		}
+		return resp.Body, func() { _ = resp.Body.Close() }, nil
+	default:
+		return nil, nil, fmt.Errorf(
+			"unsupported download scheme %q",
+			parsed.Scheme,
+		)
+	}
+}
+
+func extractArchive(
+	reader io.Reader,
+	archiveKind string,
+	targetPath string,
+	stripComponents int,
+) error {
+	switch normalizeArchiveKind(archiveKind) {
+	case "tar.gz":
+		gz, err := gzip.NewReader(reader)
+		if err != nil {
+			return err
+		}
+		defer gz.Close()
+		return extractTar(gz, targetPath, stripComponents)
+	case "tar.bz2":
+		return extractTar(
+			bzip2.NewReader(reader),
+			targetPath,
+			stripComponents,
+		)
+	case "zip":
+		return extractZip(reader, targetPath, stripComponents)
+	default:
+		return fmt.Errorf("unsupported archive kind %q", archiveKind)
+	}
+}
+
+func normalizeArchiveKind(raw string) string {
+	kind := strings.ToLower(strings.TrimSpace(raw))
+	switch kind {
+	case "tgz":
+		return "tar.gz"
+	default:
+		return kind
+	}
+}
+
+func extractTar(
+	reader io.Reader,
+	targetPath string,
+	stripComponents int,
+) error {
+	tr := tar.NewReader(reader)
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		name, ok := archiveTargetName(
+			header.Name,
+			stripComponents,
+		)
+		if !ok {
+			continue
+		}
+		dst, err := safeJoin(targetPath, name)
+		if err != nil {
+			return err
+		}
+		if err := writeArchiveEntry(dst, header.FileInfo().Mode(), tr); err != nil {
+			return err
+		}
+	}
+}
+
+func extractZip(
+	reader io.Reader,
+	targetPath string,
+	stripComponents int,
+) error {
+	tmp, err := os.CreateTemp("", "openclaw-download-*.zip")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+
+	if _, err := io.Copy(tmp, reader); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+
+	archive, err := zip.OpenReader(tmpPath)
+	if err != nil {
+		return err
+	}
+	defer archive.Close()
+
+	for _, file := range archive.File {
+		name, ok := archiveTargetName(file.Name, stripComponents)
+		if !ok {
+			continue
+		}
+		dst, err := safeJoin(targetPath, name)
+		if err != nil {
+			return err
+		}
+		rc, err := file.Open()
+		if err != nil {
+			return err
+		}
+		err = writeArchiveEntry(dst, file.Mode(), rc)
+		_ = rc.Close()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func archiveTargetName(
+	name string,
+	stripComponents int,
+) (string, bool) {
+	cleaned := path.Clean(strings.TrimSpace(name))
+	if cleaned == "." || cleaned == "" {
+		return "", false
+	}
+	parts := strings.Split(cleaned, "/")
+	if stripComponents >= len(parts) {
+		return "", false
+	}
+	parts = parts[stripComponents:]
+	joined := path.Join(parts...)
+	if joined == "." || joined == "" {
+		return "", false
+	}
+	if joined == ".." || strings.HasPrefix(joined, "../") {
+		return "", false
+	}
+	return filepath.FromSlash(joined), true
+}
+
+func writeArchiveEntry(
+	dst string,
+	mode os.FileMode,
+	reader io.Reader,
+) error {
+	if mode.IsDir() {
+		return os.MkdirAll(dst, 0o755)
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	file, err := os.OpenFile(
+		dst,
+		os.O_CREATE|os.O_TRUNC|os.O_WRONLY,
+		archiveEntryPerm(mode),
+	)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	_, err = io.Copy(file, reader)
+	return err
+}
+
+func archiveEntryPerm(mode os.FileMode) os.FileMode {
+	perm := mode.Perm()
+	if perm == 0 {
+		return 0o644
+	}
+	return perm
+}

--- a/openclaw/internal/deps/download.go
+++ b/openclaw/internal/deps/download.go
@@ -23,7 +23,14 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 )
+
+const downloadHTTPTimeout = 30 * time.Minute
+
+var downloadHTTPClient = &http.Client{
+	Timeout: downloadHTTPTimeout,
+}
 
 func downloadInstallStep(
 	toolchain Toolchain,
@@ -87,16 +94,34 @@ func executeDownloadStep(
 	if err := os.MkdirAll(filepath.Dir(step.TargetPath), 0o755); err != nil {
 		return "", err
 	}
-	file, err := os.Create(step.TargetPath)
-	if err != nil {
-		return "", err
-	}
-	defer file.Close()
-
-	if _, err := io.Copy(file, reader); err != nil {
+	if err := writeDownloadFile(step.TargetPath, reader); err != nil {
 		return "", err
 	}
 	return "downloaded to " + step.TargetPath, nil
+}
+
+func writeDownloadFile(
+	targetPath string,
+	reader io.Reader,
+) error {
+	file, err := os.Create(targetPath)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+
+	if _, err := io.Copy(file, reader); err != nil {
+		_ = file.Close()
+		_ = os.Remove(targetPath)
+		return err
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(targetPath)
+		return err
+	}
+	return nil
 }
 
 func downloadTargetPath(
@@ -208,7 +233,7 @@ func openDownloadReader(
 		if err != nil {
 			return nil, nil, err
 		}
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := downloadHTTPClient.Do(req)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/openclaw/internal/deps/download_test.go
+++ b/openclaw/internal/deps/download_test.go
@@ -1,0 +1,173 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package deps
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDownloadHelpers(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(
+		t,
+		"tool.zip",
+		downloadFileName("https://example.com/tool.zip?x=1"),
+	)
+	require.Equal(t, "", downloadFileName("://bad"))
+
+	path, err := downloadTargetPath(t.TempDir(), "skill", InstallAction{
+		URL: "https://example.com/tool.zip",
+	})
+	require.NoError(t, err)
+	require.Contains(t, path, filepath.Join(defaultToolsDir, "skill"))
+	require.Contains(t, path, "tool.zip")
+
+	root, err := safeJoin(t.TempDir(), "runtime")
+	require.NoError(t, err)
+	require.NotEmpty(t, root)
+
+	_, err = safeJoin(t.TempDir(), "../escape")
+	require.Error(t, err)
+	_, err = skillToolsRoot(t.TempDir(), " ")
+	require.Error(t, err)
+}
+
+func TestOpenDownloadReader(t *testing.T) {
+	t.Parallel()
+
+	filePath := filepath.Join(t.TempDir(), "a.txt")
+	require.NoError(t, os.WriteFile(filePath, []byte("file"), 0o644))
+	reader, cleanup, err := openDownloadReader(context.Background(), filePath)
+	require.NoError(t, err)
+	defer cleanup()
+	data, readErr := io.ReadAll(reader)
+	require.NoError(t, readErr)
+	require.Equal(t, "file", string(data))
+
+	server := httptest.NewServer(http.HandlerFunc(func(
+		w http.ResponseWriter,
+		r *http.Request,
+	) {
+		_, _ = w.Write([]byte("http"))
+	}))
+	defer server.Close()
+
+	reader, cleanup, err = openDownloadReader(
+		context.Background(),
+		server.URL,
+	)
+	require.NoError(t, err)
+	defer cleanup()
+	data, readErr = io.ReadAll(reader)
+	require.NoError(t, readErr)
+	require.Equal(t, "http", string(data))
+
+	badServer := httptest.NewServer(http.HandlerFunc(func(
+		w http.ResponseWriter,
+		r *http.Request,
+	) {
+		http.Error(w, "boom", http.StatusBadGateway)
+	}))
+	defer badServer.Close()
+
+	_, _, err = openDownloadReader(context.Background(), badServer.URL)
+	require.ErrorContains(t, err, "502 Bad Gateway")
+	_, _, err = openDownloadReader(context.Background(), "ftp://example.com/x")
+	require.ErrorContains(t, err, "unsupported download scheme")
+}
+
+func TestWriteDownloadFile_CleansUpOnCopyError(t *testing.T) {
+	t.Parallel()
+
+	target := filepath.Join(t.TempDir(), "tool.bin")
+	err := writeDownloadFile(target, errorReader{})
+	require.Error(t, err)
+	_, statErr := os.Stat(target)
+	require.True(t, errors.Is(statErr, os.ErrNotExist))
+}
+
+func TestExecuteDownloadStep(t *testing.T) {
+	t.Parallel()
+
+	source := filepath.Join(t.TempDir(), "tool.txt")
+	require.NoError(t, os.WriteFile(source, []byte("hello"), 0o644))
+
+	target := filepath.Join(t.TempDir(), "out", "tool.txt")
+	out, err := executeDownloadStep(context.Background(), Step{
+		URL:        "file://" + source,
+		TargetPath: target,
+	})
+	require.NoError(t, err)
+	require.Contains(t, out, target)
+	data, readErr := os.ReadFile(target)
+	require.NoError(t, readErr)
+	require.Equal(t, "hello", string(data))
+}
+
+func TestExtractZip_StripsComponents(t *testing.T) {
+	t.Parallel()
+
+	var archive bytes.Buffer
+	writer := zip.NewWriter(&archive)
+	file, err := writer.Create("pkg/bin/tool")
+	require.NoError(t, err)
+	_, err = file.Write([]byte("hello"))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	target := t.TempDir()
+	err = extractZip(bytes.NewReader(archive.Bytes()), target, 1)
+	require.NoError(t, err)
+	data, readErr := os.ReadFile(filepath.Join(target, "bin", "tool"))
+	require.NoError(t, readErr)
+	require.Equal(t, "hello", string(data))
+
+	name, ok := archiveTargetName("pkg/bin/tool", 3)
+	require.False(t, ok)
+	require.Empty(t, name)
+}
+
+func TestArchiveHelpers(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "tar.gz", normalizeArchiveKind("tgz"))
+	require.Equal(t, "zip", normalizeArchiveKind(" zip "))
+	require.Equal(t, os.FileMode(0o644), archiveEntryPerm(0))
+	require.Equal(
+		t,
+		os.FileMode(0o755),
+		archiveEntryPerm(0o755),
+	)
+	err := extractArchive(
+		bytes.NewReader(nil),
+		"rar",
+		t.TempDir(),
+		0,
+	)
+	require.ErrorContains(t, err, "unsupported archive kind")
+}
+
+type errorReader struct{}
+
+func (errorReader) Read([]byte) (int, error) {
+	return 0, errors.New("copy failed")
+}

--- a/openclaw/internal/deps/exec.go
+++ b/openclaw/internal/deps/exec.go
@@ -46,8 +46,12 @@ func planStepCommand(
 		spec, err = pythonCommandSpec(step.Command[0])
 		env = mergedPlanEnv(toolchain)
 	case stepKindCommand:
-		spec, err = resolveExecutable(step.Command[0], "")
 		env = mergedPlanEnv(toolchain)
+		spec, err = resolveExecutable(
+			step.Command[0],
+			"",
+			envValue(env, envPath),
+		)
 	default:
 		return nil, fmt.Errorf("unsupported step kind %q", step.Kind)
 	}
@@ -108,20 +112,20 @@ func combinedOutputContext(
 }
 
 func pythonCommandSpec(command string) (executableSpec, error) {
-	return resolveExecutable(command, "")
+	return resolveExecutable(command, "", "")
 }
 
 func systemCommandSpec(manager string) (executableSpec, error) {
 	name := strings.ToLower(commandBase(manager))
 	switch name {
 	case InstallKindAPT:
-		return resolveExecutable(manager, name)
+		return resolveExecutable(manager, name, "")
 	case InstallKindBrew:
-		return resolveExecutable(manager, name)
+		return resolveExecutable(manager, name, "")
 	case InstallKindDNF:
-		return resolveExecutable(manager, name)
+		return resolveExecutable(manager, name, "")
 	case InstallKindYUM:
-		return resolveExecutable(manager, name)
+		return resolveExecutable(manager, name, "")
 	default:
 		return executableSpec{}, fmt.Errorf(
 			"unsupported package manager %q",
@@ -133,6 +137,7 @@ func systemCommandSpec(manager string) (executableSpec, error) {
 func resolveExecutable(
 	command string,
 	fallback string,
+	searchPath string,
 ) (executableSpec, error) {
 	name := strings.TrimSpace(command)
 	if name == "" {
@@ -150,11 +155,39 @@ func resolveExecutable(
 		return validateExecutablePath(path)
 	}
 
-	path, err := exec.LookPath(name)
+	path, err := lookPath(name, searchPath)
 	if err != nil {
 		return executableSpec{}, err
 	}
 	return validateExecutablePath(path)
+}
+
+func lookPath(
+	name string,
+	searchPath string,
+) (string, error) {
+	if strings.TrimSpace(searchPath) == "" {
+		return exec.LookPath(name)
+	}
+	for _, dir := range filepath.SplitList(searchPath) {
+		dir = strings.TrimSpace(dir)
+		if dir == "" {
+			continue
+		}
+		candidate := filepath.Join(dir, name)
+		if runtime.GOOS == "windows" {
+			for _, ext := range []string{"", ".exe", ".cmd", ".bat"} {
+				if _, err := os.Stat(candidate + ext); err == nil {
+					return candidate + ext, nil
+				}
+			}
+			continue
+		}
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, nil
+		}
+	}
+	return exec.LookPath(name)
 }
 
 func validateExecutablePath(path string) (executableSpec, error) {
@@ -193,6 +226,19 @@ func mergeStepEnv(
 		out = setPlanEnv(out, key, value)
 	}
 	return out
+}
+
+func envValue(
+	env []string,
+	key string,
+) string {
+	prefix := key + "="
+	for _, item := range env {
+		if strings.HasPrefix(item, prefix) {
+			return strings.TrimPrefix(item, prefix)
+		}
+	}
+	return ""
 }
 
 func commandDir(command string) string {

--- a/openclaw/internal/deps/exec.go
+++ b/openclaw/internal/deps/exec.go
@@ -45,6 +45,9 @@ func planStepCommand(
 	case stepKindPython, stepKindVenv:
 		spec, err = pythonCommandSpec(step.Command[0])
 		env = mergedPlanEnv(toolchain)
+	case stepKindCommand:
+		spec, err = resolveExecutable(step.Command[0], "")
+		env = mergedPlanEnv(toolchain)
 	default:
 		return nil, fmt.Errorf("unsupported step kind %q", step.Kind)
 	}
@@ -52,7 +55,7 @@ func planStepCommand(
 		return nil, err
 	}
 	cmd = newExecCommand(spec, step.Command[1:]...)
-	cmd.Env = env
+	cmd.Env = mergeStepEnv(env, step.Env)
 	return cmd, nil
 }
 
@@ -176,6 +179,20 @@ func newExecCommand(
 		Path: spec.path,
 		Args: append([]string{spec.path}, args...),
 	}
+}
+
+func mergeStepEnv(
+	base []string,
+	overrides map[string]string,
+) []string {
+	if len(overrides) == 0 {
+		return base
+	}
+	out := append([]string(nil), base...)
+	for key, value := range overrides {
+		out = setPlanEnv(out, key, value)
+	}
+	return out
 }
 
 func commandDir(command string) string {

--- a/openclaw/internal/deps/exec_test.go
+++ b/openclaw/internal/deps/exec_test.go
@@ -185,7 +185,7 @@ func TestSystemCommandSpec(t *testing.T) {
 }
 
 func TestResolveExecutable(t *testing.T) {
-	_, err := resolveExecutable("", "")
+	_, err := resolveExecutable("", "", "")
 	require.ErrorContains(t, err, "empty executable name")
 
 	if runtime.GOOS == "windows" {
@@ -198,12 +198,12 @@ func TestResolveExecutable(t *testing.T) {
 		"python3.12",
 		"printf explicit",
 	)
-	spec, err := resolveExecutable(explicitPath, "")
+	spec, err := resolveExecutable(explicitPath, "", "")
 	require.NoError(t, err)
 	require.Equal(t, explicitPath, spec.path)
 
 	dir := t.TempDir()
-	_, err = resolveExecutable(dir, "")
+	_, err = resolveExecutable(dir, "", "")
 	require.ErrorContains(t, err, "is a directory")
 
 	toolDir := t.TempDir()
@@ -214,9 +214,45 @@ func TestResolveExecutable(t *testing.T) {
 		"printf lookup",
 	)
 	t.Setenv("PATH", toolDir+string(os.PathListSeparator)+os.Getenv("PATH"))
-	spec, err = resolveExecutable("", "python-custom")
+	spec, err = resolveExecutable("", "python-custom", "")
 	require.NoError(t, err)
 	require.Equal(t, toolPath, spec.path)
+}
+
+func TestPlanStepCommand_UsesManagedPathForCommandStep(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell assertions run on unix-like systems")
+	}
+
+	stateDir := t.TempDir()
+	binDir := ManagedBinDir(stateDir)
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+
+	managedPath := writeTestCommand(
+		t,
+		binDir,
+		"managed-tool",
+		"printf managed",
+	)
+	hostPath := writeTestCommand(
+		t,
+		t.TempDir(),
+		"managed-tool",
+		"printf host",
+	)
+	t.Setenv("PATH", filepath.Dir(hostPath))
+
+	cmd, err := planStepCommand(Toolchain{StateDir: stateDir}, Step{
+		Kind:    stepKindCommand,
+		Command: []string{"managed-tool", "--version"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, managedPath, cmd.Path)
+	require.Equal(
+		t,
+		[]string{managedPath, "--version"},
+		cmd.Args,
+	)
 }
 
 func TestCommandPathHelpers(t *testing.T) {

--- a/openclaw/internal/deps/exec_test.go
+++ b/openclaw/internal/deps/exec_test.go
@@ -72,6 +72,32 @@ func TestPlanStepCommand(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, managerPath, cmd.Path)
 	require.Equal(t, []string{managerPath, "install", "-y"}, cmd.Args)
+
+	commandPath := writeTestCommand(
+		t,
+		t.TempDir(),
+		"custom-tool",
+		"printf command",
+	)
+	cmd, err = planStepCommand(Toolchain{StateDir: stateDir}, Step{
+		Kind:    stepKindCommand,
+		Command: []string{commandPath, "--version"},
+		Env: map[string]string{
+			envGoBin: "/tmp/bin",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, commandPath, cmd.Path)
+	require.Equal(
+		t,
+		[]string{commandPath, "--version"},
+		cmd.Args,
+	)
+	require.Contains(
+		t,
+		strings.Join(cmd.Env, "\n"),
+		envGoBin+"=/tmp/bin",
+	)
 }
 
 func TestCombinedOutputContext(t *testing.T) {

--- a/openclaw/internal/deps/install.go
+++ b/openclaw/internal/deps/install.go
@@ -48,6 +48,7 @@ type Step struct {
 	CommandLine     string            `json:"command_line"`
 	RequiresRoot    bool              `json:"requires_root,omitempty"`
 	Env             map[string]string `json:"env,omitempty"`
+	EnsureDirs      []string          `json:"ensure_dirs,omitempty"`
 	URL             string            `json:"url,omitempty"`
 	TargetPath      string            `json:"target_path,omitempty"`
 	Archive         string            `json:"archive,omitempty"`
@@ -401,6 +402,8 @@ func actionNeeded(
 	anyBins [][]string,
 	satisfiedGroups map[string]struct{},
 ) bool {
+	// Actions without declared bins cannot be filtered precisely, so
+	// keep the conservative default and include them in the plan.
 	if len(action.Bins) == 0 {
 		return true
 	}
@@ -736,6 +739,7 @@ func goInstallStep(
 		Kind:        stepKindCommand,
 		Command:     command,
 		CommandLine: shellQuote(command...),
+		EnsureDirs:  []string{binDir},
 		Env: map[string]string{
 			envGoBin: binDir,
 		},
@@ -754,7 +758,7 @@ func npmInstallStep(
 		)
 	}
 
-	prefix := ManagedPythonRoot(toolchain.StateDir)
+	prefix := ManagedToolPrefix(toolchain.StateDir)
 	command := append(
 		[]string{"npm", "install", "-g", "--prefix", prefix},
 		packages...,
@@ -764,6 +768,7 @@ func npmInstallStep(
 		Kind:        stepKindCommand,
 		Command:     command,
 		CommandLine: shellQuote(command...),
+		EnsureDirs:  []string{prefix},
 	}, nil
 }
 
@@ -848,6 +853,15 @@ func ensureStepWorkingDirs(
 ) error {
 	switch step.Kind {
 	case stepKindCommand:
+		dirs := normalizeStrings(step.EnsureDirs)
+		for _, dir := range dirs {
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				return err
+			}
+		}
+		if len(dirs) > 0 {
+			return nil
+		}
 		if dir := strings.TrimSpace(step.Env[envGoBin]); dir != "" {
 			return os.MkdirAll(dir, 0o755)
 		}

--- a/openclaw/internal/deps/install.go
+++ b/openclaw/internal/deps/install.go
@@ -22,19 +22,37 @@ import (
 )
 
 const (
-	stepKindSystem = "system"
-	stepKindPython = "python"
-	stepKindVenv   = "venv"
+	stepKindSystem   = "system"
+	stepKindPython   = "python"
+	stepKindVenv     = "venv"
+	stepKindCommand  = "command"
+	stepKindDownload = "download"
 
 	venvFlagSystemSitePackages = "--system-site-packages"
 )
 
+const (
+	stepStatusApplied  = "applied"
+	stepStatusDeferred = "deferred"
+	stepStatusFailed   = "failed"
+
+	envGoBin          = "GOBIN"
+	defaultToolsDir   = "tools"
+	pythonInstallName = "Install Python packages"
+)
+
 type Step struct {
-	Label        string   `json:"label"`
-	Kind         string   `json:"kind"`
-	Command      []string `json:"command"`
-	CommandLine  string   `json:"command_line"`
-	RequiresRoot bool     `json:"requires_root,omitempty"`
+	Label           string            `json:"label"`
+	Kind            string            `json:"kind"`
+	Command         []string          `json:"command"`
+	CommandLine     string            `json:"command_line"`
+	RequiresRoot    bool              `json:"requires_root,omitempty"`
+	Env             map[string]string `json:"env,omitempty"`
+	URL             string            `json:"url,omitempty"`
+	TargetPath      string            `json:"target_path,omitempty"`
+	Archive         string            `json:"archive,omitempty"`
+	Extract         bool              `json:"extract,omitempty"`
+	StripComponents int               `json:"strip_components,omitempty"`
 }
 
 type Plan struct {
@@ -51,8 +69,15 @@ type ApplyResult struct {
 
 type StepResult struct {
 	Step     Step   `json:"step"`
+	Status   string `json:"status,omitempty"`
 	Output   string `json:"output,omitempty"`
+	Error    string `json:"error,omitempty"`
 	ExitCode int    `json:"exit_code"`
+}
+
+type sourceInstallAction struct {
+	SourceName string
+	Action     InstallAction
 }
 
 func BuildPlan(stateDir string, profiles []string) (Plan, error) {
@@ -86,6 +111,14 @@ func BuildPlanForSources(
 
 	manager := report.Platform.PackageManager
 	pythonPkgs := collectPythonPackages(report.Missing.Python)
+	pythonPkgs = append(
+		pythonPkgs,
+		collectInstallPythonPackages(
+			report.Platform,
+			sources,
+			report.Missing,
+		)...,
+	)
 	if len(pythonPkgs) > 0 {
 		steps, err := pythonSteps(report.Toolchain, pythonPkgs)
 		if err != nil {
@@ -94,13 +127,35 @@ func BuildPlanForSources(
 		plan.Steps = append(plan.Steps, steps...)
 	}
 
+	commandSteps, err := commandInstallSteps(
+		report.Toolchain,
+		report.Platform,
+		sources,
+		report.Missing,
+	)
+	if err != nil {
+		return Plan{}, err
+	}
+	plan.Steps = append(plan.Steps, commandSteps...)
+
+	downloadSteps, err := downloadInstallSteps(
+		report.Toolchain,
+		report.Platform,
+		sources,
+		report.Missing,
+	)
+	if err != nil {
+		return Plan{}, err
+	}
+	plan.Steps = append(plan.Steps, downloadSteps...)
+
 	systemPkgs := collectSystemPackages(manager, sources, report.Missing)
 	if len(systemPkgs) > 0 {
 		plan.Steps = append(plan.Steps, newSystemStep(manager, systemPkgs))
 	}
 
 	plan.Unresolved = unresolvedMissing(
-		manager,
+		report.Platform,
 		sources,
 		report.Missing,
 	)
@@ -115,50 +170,53 @@ func ApplyPlan(
 		Steps: make([]StepResult, 0, len(plan.Steps)),
 	}
 	for _, step := range plan.Steps {
-		if len(step.Command) == 0 {
+		if step.Kind != stepKindDownload &&
+			len(step.Command) == 0 {
 			continue
 		}
 		if step.RequiresRoot && runtime.GOOS != "windows" &&
 			os.Geteuid() != 0 {
-			return result, fmt.Errorf(
-				"step %q requires root privileges; rerun as root "+
-					"or execute the printed command with sudo",
-				step.Label,
-			)
+			result.Steps = append(result.Steps, StepResult{
+				Step:   step,
+				Status: stepStatusDeferred,
+				Error: fmt.Sprintf(
+					"step %q requires root privileges; rerun as root "+
+						"or execute the printed command with sudo",
+					step.Label,
+				),
+			})
+			continue
 		}
 
-		cmd, err := planStepCommand(plan.Toolchain, step)
-		if err != nil {
-			return result, fmt.Errorf(
-				"step %q is invalid: %w",
-				step.Label,
-				err,
-			)
+		if err := ensureStepWorkingDirs(plan.Toolchain, step); err != nil {
+			result.Steps = append(result.Steps, StepResult{
+				Step:   step,
+				Status: stepStatusFailed,
+				Error:  err.Error(),
+			})
+			continue
 		}
-		out, err := combinedOutputContext(ctx, cmd)
-		exitCode := 0
+
+		out, exitCode, err := executePlanStep(ctx, plan.Toolchain, step)
 		if err != nil {
-			exitCode = -1
-			var exitErr *exec.ExitError
-			if errors.As(err, &exitErr) && exitErr.ProcessState != nil {
-				exitCode = exitErr.ProcessState.ExitCode()
-			}
 			result.Steps = append(result.Steps, StepResult{
 				Step:     step,
-				Output:   string(out),
+				Status:   stepStatusFailed,
+				Output:   out,
+				Error:    err.Error(),
 				ExitCode: exitCode,
 			})
-			return result, fmt.Errorf(
-				"step %q failed: %w",
-				step.Label,
-				err,
-			)
+			continue
 		}
 		result.Steps = append(result.Steps, StepResult{
 			Step:     step,
-			Output:   string(out),
+			Status:   stepStatusApplied,
+			Output:   out,
 			ExitCode: exitCode,
 		})
+	}
+	if hasStepStatus(result.Steps, stepStatusFailed) {
+		return result, fmt.Errorf("one or more install steps failed")
 	}
 	return result, nil
 }
@@ -172,32 +230,22 @@ func collectSystemPackages(
 	if manager == "" {
 		return nil
 	}
-
-	needBins := map[string]struct{}{}
-	for _, name := range missing.Bins {
-		needBins[name] = struct{}{}
-	}
-	for _, group := range missing.AnyBins {
-		for _, name := range group {
-			needBins[name] = struct{}{}
-		}
+	platform := Platform{
+		GOOS:           runtime.GOOS,
+		PackageManager: manager,
 	}
 
 	pkgs := map[string]struct{}{}
-	for _, source := range sources {
-		for _, action := range source.Install {
-			action = normalizeInstallActions(
-				[]InstallAction{action},
-			)[0]
-			if action.Kind != manager {
-				continue
-			}
-			if !coversAnyBin(action.Bins, needBins) {
-				continue
-			}
-			for _, pkg := range packagesForAction(action) {
-				pkgs[pkg] = struct{}{}
-			}
+	for _, selected := range selectInstallActionsForMissing(
+		platform,
+		sources,
+		missing,
+		func(action InstallAction) bool {
+			return action.Kind == manager
+		},
+	) {
+		for _, pkg := range packagesForAction(selected.Action) {
+			pkgs[pkg] = struct{}{}
 		}
 	}
 
@@ -216,6 +264,240 @@ func collectPythonPackages(pkgs []PythonPackage) []string {
 		out = append(out, pkg.Package)
 	}
 	return out
+}
+
+func collectInstallPythonPackages(
+	platform Platform,
+	sources []Source,
+	missing Missing,
+) []string {
+	actions := selectInstallActionsForMissing(
+		platform,
+		sources,
+		missing,
+		isPythonInstallKind,
+	)
+
+	pkgs := make([]string, 0, len(actions))
+	for _, action := range actions {
+		pkgs = append(pkgs, packagesForAction(action.Action)...)
+	}
+	return normalizeStrings(pkgs)
+}
+
+func commandInstallSteps(
+	toolchain Toolchain,
+	platform Platform,
+	sources []Source,
+	missing Missing,
+) ([]Step, error) {
+	actions := selectInstallActionsForMissing(
+		platform,
+		sources,
+		missing,
+		isCommandInstallKind,
+	)
+	steps := make([]Step, 0, len(actions))
+	for _, action := range actions {
+		step, err := commandInstallStep(toolchain, action.Action)
+		if err != nil {
+			return nil, err
+		}
+		steps = append(steps, step)
+	}
+	return steps, nil
+}
+
+func downloadInstallSteps(
+	toolchain Toolchain,
+	platform Platform,
+	sources []Source,
+	missing Missing,
+) ([]Step, error) {
+	actions := selectInstallActionsForMissing(
+		platform,
+		sources,
+		missing,
+		func(action InstallAction) bool {
+			return action.Kind == InstallKindDownload
+		},
+	)
+	steps := make([]Step, 0, len(actions))
+	for _, action := range actions {
+		step, err := downloadInstallStep(
+			toolchain,
+			action.SourceName,
+			action.Action,
+		)
+		if err != nil {
+			return nil, err
+		}
+		steps = append(steps, step)
+	}
+	return steps, nil
+}
+
+func selectInstallActionsForMissing(
+	platform Platform,
+	sources []Source,
+	missing Missing,
+	include func(InstallAction) bool,
+) []sourceInstallAction {
+	explicitBins := missingBinSet(Missing{Bins: missing.Bins})
+	out := make([]sourceInstallAction, 0)
+	seen := map[string]struct{}{}
+	satisfiedGroups := map[string]struct{}{}
+	for _, source := range sources {
+		for _, action := range normalizeInstallActions(source.Install) {
+			if !actionMatchesPlatform(action, platform.GOOS) {
+				continue
+			}
+			if !include(action) {
+				continue
+			}
+			if !actionNeeded(
+				action,
+				explicitBins,
+				missing.AnyBins,
+				satisfiedGroups,
+			) {
+				continue
+			}
+			key := installActionKey(action)
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			out = append(out, sourceInstallAction{
+				SourceName: source.Name,
+				Action:     action,
+			})
+			markSatisfiedAnyBinGroups(
+				action,
+				missing.AnyBins,
+				satisfiedGroups,
+			)
+		}
+	}
+	return out
+}
+
+func missingBinSet(missing Missing) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, name := range missing.Bins {
+		out[name] = struct{}{}
+	}
+	for _, group := range missing.AnyBins {
+		for _, name := range group {
+			out[name] = struct{}{}
+		}
+	}
+	return out
+}
+
+func actionNeeded(
+	action InstallAction,
+	explicitBins map[string]struct{},
+	anyBins [][]string,
+	satisfiedGroups map[string]struct{},
+) bool {
+	if len(action.Bins) == 0 {
+		return true
+	}
+	if coversAnyBin(action.Bins, explicitBins) {
+		return true
+	}
+	for _, group := range anyBins {
+		key := anyBinGroupKey(group)
+		if _, ok := satisfiedGroups[key]; ok {
+			continue
+		}
+		if actionCoversAnyGroupBin(action, group) {
+			return true
+		}
+	}
+	return false
+}
+
+func markSatisfiedAnyBinGroups(
+	action InstallAction,
+	anyBins [][]string,
+	satisfiedGroups map[string]struct{},
+) {
+	for _, group := range anyBins {
+		if !actionCoversAnyGroupBin(action, group) {
+			continue
+		}
+		satisfiedGroups[anyBinGroupKey(group)] = struct{}{}
+	}
+}
+
+func actionCoversAnyGroupBin(
+	action InstallAction,
+	group []string,
+) bool {
+	for _, name := range group {
+		for _, bin := range action.Bins {
+			if bin == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func anyBinGroupKey(group []string) string {
+	return strings.Join(group, "\x00")
+}
+
+func actionMatchesPlatform(
+	action InstallAction,
+	goos string,
+) bool {
+	if len(action.OS) == 0 {
+		return true
+	}
+	goos = normalizeOSName(goos)
+	for _, allowed := range action.OS {
+		if normalizeOSName(allowed) == goos {
+			return true
+		}
+	}
+	return false
+}
+
+func installActionKey(action InstallAction) string {
+	return strings.Join([]string{
+		action.Kind,
+		action.ID,
+		action.Formula,
+		action.Package,
+		action.Module,
+		action.URL,
+		action.Archive,
+		action.TargetDir,
+		strings.Join(action.Packages, ","),
+		strings.Join(action.Bins, ","),
+		strings.Join(action.OS, ","),
+	}, "\x00")
+}
+
+func isPythonInstallKind(action InstallAction) bool {
+	switch action.Kind {
+	case InstallKindPIP, InstallKindUV:
+		return true
+	default:
+		return false
+	}
+}
+
+func isCommandInstallKind(action InstallAction) bool {
+	switch action.Kind {
+	case InstallKindGo, InstallKindNode, InstallKindNPM:
+		return true
+	default:
+		return false
+	}
 }
 
 func pythonSteps(
@@ -318,19 +600,21 @@ func newSystemStep(manager string, pkgs []string) Step {
 }
 
 func unresolvedMissing(
-	manager string,
+	platform Platform,
 	sources []Source,
 	missing Missing,
 ) Missing {
-	manager = strings.ToLower(strings.TrimSpace(manager))
-	if manager == "" {
-		return normalizeMissing(missing)
-	}
-
 	coveredBins := map[string]struct{}{}
 	for _, source := range sources {
 		for _, action := range source.Install {
-			if strings.ToLower(strings.TrimSpace(action.Kind)) != manager {
+			normalized := normalizeInstallActions(
+				[]InstallAction{action},
+			)
+			if len(normalized) == 0 {
+				continue
+			}
+			action = normalized[0]
+			if !isActionCoveredByPlanner(platform, action) {
 				continue
 			}
 			for _, bin := range normalizeStrings(action.Bins) {
@@ -355,11 +639,37 @@ func unresolvedMissing(
 	return normalizeMissing(unresolved)
 }
 
+func isActionCoveredByPlanner(
+	platform Platform,
+	action InstallAction,
+) bool {
+	if !actionMatchesPlatform(action, platform.GOOS) {
+		return false
+	}
+
+	switch action.Kind {
+	case platform.PackageManager:
+		return true
+	case InstallKindGo, InstallKindNode, InstallKindNPM:
+		return true
+	case InstallKindPIP, InstallKindUV:
+		return true
+	case InstallKindDownload:
+		return true
+	default:
+		return false
+	}
+}
+
 func packagesForAction(action InstallAction) []string {
 	switch action.Kind {
 	case InstallKindBrew:
 		if action.Formula != "" {
-			return []string{action.Formula}
+			return []string{brewPackageName(action)}
+		}
+	case InstallKindGo:
+		if action.Module != "" {
+			return []string{action.Module}
 		}
 	case InstallKindAPT, InstallKindDNF, InstallKindYUM:
 		if len(action.Packages) > 0 {
@@ -376,6 +686,128 @@ func packagesForAction(action InstallAction) []string {
 		return []string{action.Package}
 	}
 	return append([]string(nil), action.Packages...)
+}
+
+func brewPackageName(action InstallAction) string {
+	formula := strings.TrimSpace(action.Formula)
+	tap := strings.TrimSpace(action.Tap)
+	if tap == "" || formula == "" || strings.Contains(formula, "/") {
+		return formula
+	}
+	return tap + "/" + formula
+}
+
+func commandInstallStep(
+	toolchain Toolchain,
+	action InstallAction,
+) (Step, error) {
+	switch action.Kind {
+	case InstallKindGo:
+		return goInstallStep(toolchain, action)
+	case InstallKindNode, InstallKindNPM:
+		return npmInstallStep(toolchain, action)
+	default:
+		return Step{}, fmt.Errorf(
+			"unsupported command install kind %q",
+			action.Kind,
+		)
+	}
+}
+
+func goInstallStep(
+	toolchain Toolchain,
+	action InstallAction,
+) (Step, error) {
+	module := strings.TrimSpace(action.Module)
+	if module == "" {
+		module = strings.TrimSpace(action.Package)
+	}
+	if module == "" {
+		return Step{}, fmt.Errorf(
+			"go install action %q is missing module",
+			action.Label,
+		)
+	}
+
+	binDir := ManagedBinDir(toolchain.StateDir)
+	command := []string{"go", "install", module}
+	return Step{
+		Label:       actionLabel(action, "Install Go tool"),
+		Kind:        stepKindCommand,
+		Command:     command,
+		CommandLine: shellQuote(command...),
+		Env: map[string]string{
+			envGoBin: binDir,
+		},
+	}, nil
+}
+
+func npmInstallStep(
+	toolchain Toolchain,
+	action InstallAction,
+) (Step, error) {
+	packages := packagesForAction(action)
+	if len(packages) == 0 {
+		return Step{}, fmt.Errorf(
+			"npm install action %q is missing package",
+			action.Label,
+		)
+	}
+
+	prefix := ManagedPythonRoot(toolchain.StateDir)
+	command := append(
+		[]string{"npm", "install", "-g", "--prefix", prefix},
+		packages...,
+	)
+	return Step{
+		Label:       actionLabel(action, "Install npm package"),
+		Kind:        stepKindCommand,
+		Command:     command,
+		CommandLine: shellQuote(command...),
+	}, nil
+}
+
+func actionLabel(action InstallAction, fallback string) string {
+	if strings.TrimSpace(action.Label) != "" {
+		return strings.TrimSpace(action.Label)
+	}
+	return fallback
+}
+
+func executePlanStep(
+	ctx context.Context,
+	toolchain Toolchain,
+	step Step,
+) (string, int, error) {
+	if step.Kind == stepKindDownload {
+		out, err := executeDownloadStep(ctx, step)
+		if err != nil {
+			return out, -1, err
+		}
+		return out, 0, nil
+	}
+
+	cmd, err := planStepCommand(toolchain, step)
+	if err != nil {
+		return "", 0, fmt.Errorf(
+			"step %q is invalid: %w",
+			step.Label,
+			err,
+		)
+	}
+
+	out, err := combinedOutputContext(ctx, cmd)
+	exitCode := 0
+	if err == nil {
+		return string(out), exitCode, nil
+	}
+
+	exitCode = -1
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ProcessState != nil {
+		exitCode = exitErr.ProcessState.ExitCode()
+	}
+	return string(out), exitCode, err
 }
 
 func coversAnyBin(
@@ -408,6 +840,55 @@ func mergedPlanEnv(toolchain Toolchain) []string {
 		base = setPlanEnv(base, key, value)
 	}
 	return base
+}
+
+func ensureStepWorkingDirs(
+	toolchain Toolchain,
+	step Step,
+) error {
+	switch step.Kind {
+	case stepKindCommand:
+		if dir := strings.TrimSpace(step.Env[envGoBin]); dir != "" {
+			return os.MkdirAll(dir, 0o755)
+		}
+		if len(step.Command) >= 6 &&
+			commandBase(step.Command[0]) == "npm" &&
+			step.Command[1] == "install" &&
+			step.Command[2] == "-g" &&
+			step.Command[3] == "--prefix" {
+			return os.MkdirAll(step.Command[4], 0o755)
+		}
+	case stepKindPython:
+		if strings.TrimSpace(toolchain.StateDir) != "" &&
+			toolchain.Python.Managed {
+			return os.MkdirAll(
+				ManagedBinDir(toolchain.StateDir),
+				0o755,
+			)
+		}
+	case stepKindDownload:
+		target := strings.TrimSpace(step.TargetPath)
+		if target == "" {
+			return fmt.Errorf("download step %q has empty target", step.Label)
+		}
+		if step.Extract {
+			return os.MkdirAll(target, 0o755)
+		}
+		return os.MkdirAll(filepath.Dir(target), 0o755)
+	}
+	return nil
+}
+
+func hasStepStatus(
+	steps []StepResult,
+	status string,
+) bool {
+	for _, step := range steps {
+		if step.Status == status {
+			return true
+		}
+	}
+	return false
 }
 
 func setPlanEnv(env []string, key string, value string) []string {

--- a/openclaw/internal/deps/install_test.go
+++ b/openclaw/internal/deps/install_test.go
@@ -95,29 +95,35 @@ func TestBuildPlanForSources_SystemPackages(t *testing.T) {
 func TestBuildPlanForSources_UserInstallSteps(t *testing.T) {
 	t.Parallel()
 
+	const (
+		goBinName   = "definitely-missing-go-bin"
+		nodeBinName = "definitely-missing-node-bin"
+		uvBinName   = "definitely-missing-uv-bin"
+	)
+
 	plan, err := BuildPlanForSources(
 		t.TempDir(),
 		[]string{"test"},
 		[]Source{{
 			Name: "test",
 			Requires: Requirement{
-				Bins: []string{"eightctl", "mcporter", "nano-pdf"},
+				Bins: []string{goBinName, nodeBinName, uvBinName},
 			},
 			Install: []InstallAction{
 				{
 					Kind:   InstallKindGo,
 					Module: "github.com/example/eightctl@latest",
-					Bins:   []string{"eightctl"},
+					Bins:   []string{goBinName},
 				},
 				{
 					Kind:    InstallKindNode,
 					Package: "mcporter",
-					Bins:    []string{"mcporter"},
+					Bins:    []string{nodeBinName},
 				},
 				{
 					Kind:    InstallKindUV,
 					Package: "nano-pdf",
-					Bins:    []string{"nano-pdf"},
+					Bins:    []string{uvBinName},
 				},
 			},
 		}},
@@ -136,6 +142,108 @@ func TestBuildPlanForSources_UserInstallSteps(t *testing.T) {
 	require.Equal(t, stepKindCommand, plan.Steps[3].Kind)
 	require.Contains(t, plan.Steps[3].CommandLine, "mcporter")
 	require.Empty(t, plan.Unresolved.Bins)
+}
+
+func TestInstallStepHelpers(t *testing.T) {
+	t.Parallel()
+
+	stateDir := t.TempDir()
+	goStep, err := goInstallStep(Toolchain{StateDir: stateDir}, InstallAction{
+		Kind:   InstallKindGo,
+		Module: "example.com/tool@latest",
+	})
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		[]string{ManagedBinDir(stateDir)},
+		goStep.EnsureDirs,
+	)
+	require.Equal(t, ManagedBinDir(stateDir), goStep.Env[envGoBin])
+
+	npmStep, err := npmInstallStep(
+		Toolchain{StateDir: stateDir},
+		InstallAction{
+			Kind:    InstallKindNPM,
+			Package: "pkg",
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		[]string{ManagedToolPrefix(stateDir)},
+		npmStep.EnsureDirs,
+	)
+	require.Contains(t, npmStep.Command, ManagedToolPrefix(stateDir))
+}
+
+func TestEnsureStepWorkingDirs_UsesEnsureDirs(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	ensureDir := filepath.Join(root, "npm-prefix")
+	err := ensureStepWorkingDirs(Toolchain{}, Step{
+		Kind:       stepKindCommand,
+		EnsureDirs: []string{"", ensureDir},
+		Env: map[string]string{
+			envGoBin: filepath.Join(root, "ignored"),
+		},
+	})
+	require.NoError(t, err)
+	info, statErr := os.Stat(ensureDir)
+	require.NoError(t, statErr)
+	require.True(t, info.IsDir())
+	_, statErr = os.Stat(filepath.Join(root, "ignored"))
+	require.Error(t, statErr)
+}
+
+func TestActionMatchesPlatform(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, actionMatchesPlatform(InstallAction{}, runtime.GOOS))
+	require.True(t, actionMatchesPlatform(
+		InstallAction{OS: []string{runtime.GOOS}},
+		runtime.GOOS,
+	))
+	require.True(t, actionMatchesPlatform(
+		InstallAction{OS: []string{"win32"}},
+		"windows",
+	))
+	require.False(t, actionMatchesPlatform(
+		InstallAction{OS: []string{"darwin"}},
+		"linux",
+	))
+}
+
+func TestSelectInstallActionsForMissing(t *testing.T) {
+	t.Parallel()
+
+	actions := selectInstallActionsForMissing(
+		Platform{GOOS: "linux", PackageManager: InstallKindAPT},
+		[]Source{{
+			Name: "demo",
+			Install: []InstallAction{
+				{
+					Kind: InstallKindGo,
+					Bins: []string{"go-bin"},
+				},
+				{
+					Kind: InstallKindGo,
+					Bins: []string{"go-bin"},
+					OS:   []string{"darwin"},
+				},
+				{
+					Kind: InstallKindNPM,
+					Bins: []string{"alt-bin"},
+				},
+			},
+		}},
+		Missing{
+			AnyBins: [][]string{{"go-bin", "alt-bin"}},
+		},
+		isCommandInstallKind,
+	)
+	require.Len(t, actions, 1)
+	require.Equal(t, InstallKindGo, actions[0].Action.Kind)
 }
 
 func TestBuildPlanForSources_AnyBinChoosesFirstInstallAction(

--- a/openclaw/internal/deps/install_test.go
+++ b/openclaw/internal/deps/install_test.go
@@ -10,6 +10,8 @@
 package deps
 
 import (
+	"archive/tar"
+	"compress/gzip"
 	"context"
 	"os"
 	"path/filepath"
@@ -90,6 +92,133 @@ func TestBuildPlanForSources_SystemPackages(t *testing.T) {
 	)
 }
 
+func TestBuildPlanForSources_UserInstallSteps(t *testing.T) {
+	t.Parallel()
+
+	plan, err := BuildPlanForSources(
+		t.TempDir(),
+		[]string{"test"},
+		[]Source{{
+			Name: "test",
+			Requires: Requirement{
+				Bins: []string{"eightctl", "mcporter", "nano-pdf"},
+			},
+			Install: []InstallAction{
+				{
+					Kind:   InstallKindGo,
+					Module: "github.com/example/eightctl@latest",
+					Bins:   []string{"eightctl"},
+				},
+				{
+					Kind:    InstallKindNode,
+					Package: "mcporter",
+					Bins:    []string{"mcporter"},
+				},
+				{
+					Kind:    InstallKindUV,
+					Package: "nano-pdf",
+					Bins:    []string{"nano-pdf"},
+				},
+			},
+		}},
+	)
+	require.NoError(t, err)
+	require.Len(t, plan.Steps, 4)
+	require.Equal(t, stepKindVenv, plan.Steps[0].Kind)
+	require.Equal(t, stepKindPython, plan.Steps[1].Kind)
+	require.Contains(t, plan.Steps[1].CommandLine, "nano-pdf")
+	require.Equal(t, stepKindCommand, plan.Steps[2].Kind)
+	require.Contains(
+		t,
+		plan.Steps[2].CommandLine,
+		"github.com/example/eightctl@latest",
+	)
+	require.Equal(t, stepKindCommand, plan.Steps[3].Kind)
+	require.Contains(t, plan.Steps[3].CommandLine, "mcporter")
+	require.Empty(t, plan.Unresolved.Bins)
+}
+
+func TestBuildPlanForSources_AnyBinChoosesFirstInstallAction(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	manager := DetectPackageManager()
+	if manager == "" {
+		t.Skip("no supported package manager")
+	}
+
+	primary := InstallAction{
+		Kind: manager,
+		Bins: []string{"preferred"},
+	}
+	fallback := InstallAction{
+		Kind: manager,
+		Bins: []string{"fallback"},
+	}
+	switch manager {
+	case InstallKindBrew:
+		primary.Formula = "preferred-pkg"
+		fallback.Formula = "fallback-pkg"
+	default:
+		primary.Package = "preferred-pkg"
+		fallback.Package = "fallback-pkg"
+	}
+
+	plan, err := BuildPlanForSources(
+		t.TempDir(),
+		[]string{"spotify"},
+		[]Source{{
+			Name: "spotify",
+			Requires: Requirement{
+				AnyBins: []string{"preferred", "fallback"},
+			},
+			Install: []InstallAction{primary, fallback},
+		}},
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, plan.Steps)
+	last := plan.Steps[len(plan.Steps)-1]
+	require.Equal(t, stepKindSystem, last.Kind)
+	require.Contains(t, last.CommandLine, "preferred-pkg")
+	require.NotContains(t, last.CommandLine, "fallback-pkg")
+}
+
+func TestBuildPlanForSources_DownloadActionWithoutBins(t *testing.T) {
+	t.Parallel()
+
+	plan, err := BuildPlanForSources(
+		t.TempDir(),
+		[]string{"tts"},
+		[]Source{{
+			Name: "tts",
+			Requires: Requirement{
+				Env: []string{"SHERPA_ONNX_RUNTIME_DIR"},
+			},
+			Install: []InstallAction{{
+				Kind:      InstallKindDownload,
+				URL:       "https://example.com/runtime.tar.gz",
+				Archive:   "tar.gz",
+				Extract:   true,
+				TargetDir: "runtime",
+			}},
+		}},
+	)
+	require.NoError(t, err)
+	require.Len(t, plan.Steps, 1)
+	require.Equal(t, stepKindDownload, plan.Steps[0].Kind)
+	require.Equal(
+		t,
+		filepath.Join(
+			plan.Toolchain.StateDir,
+			defaultToolsDir,
+			"tts",
+			"runtime",
+		),
+		plan.Steps[0].TargetPath,
+	)
+}
+
 func TestBuildPlan_ResolvesBuiltinProfiles(t *testing.T) {
 	t.Parallel()
 
@@ -139,6 +268,7 @@ func TestApplyPlan_RunsStepsAndCapturesFailures(t *testing.T) {
 	result, err := ApplyPlan(context.Background(), plan)
 	require.NoError(t, err)
 	require.Len(t, result.Steps, 1)
+	require.Equal(t, stepStatusApplied, result.Steps[0].Status)
 	require.Equal(t, 0, result.Steps[0].ExitCode)
 	require.Contains(
 		t,
@@ -167,6 +297,7 @@ func TestApplyPlan_RunsStepsAndCapturesFailures(t *testing.T) {
 	result, err = ApplyPlan(context.Background(), failPlan)
 	require.Error(t, err)
 	require.Len(t, result.Steps, 1)
+	require.Equal(t, stepStatusFailed, result.Steps[0].Status)
 	require.Equal(t, 3, result.Steps[0].ExitCode)
 	require.Equal(t, "fail", result.Steps[0].Output)
 }
@@ -182,8 +313,9 @@ func TestApplyPlan_RejectsUnsupportedExecutable(t *testing.T) {
 		}},
 	})
 	require.Error(t, err)
-	require.Empty(t, result.Steps)
-	require.Contains(t, err.Error(), "invalid")
+	require.Len(t, result.Steps, 1)
+	require.Equal(t, stepStatusFailed, result.Steps[0].Status)
+	require.Contains(t, result.Steps[0].Error, "invalid")
 }
 
 func TestApplyPlan_RejectsRootOnlyStep(t *testing.T) {
@@ -199,9 +331,43 @@ func TestApplyPlan_RejectsRootOnlyStep(t *testing.T) {
 			RequiresRoot: true,
 		}},
 	})
-	require.Error(t, err)
-	require.Empty(t, result.Steps)
-	require.Contains(t, err.Error(), "requires root privileges")
+	require.NoError(t, err)
+	require.Len(t, result.Steps, 1)
+	require.Equal(t, stepStatusDeferred, result.Steps[0].Status)
+	require.Contains(t, result.Steps[0].Error, "requires root privileges")
+}
+
+func TestApplyPlan_DownloadStepExtractsArchive(t *testing.T) {
+	t.Parallel()
+
+	archivePath := filepath.Join(t.TempDir(), "runtime.tar.gz")
+	writeTarGzArchive(
+		t,
+		archivePath,
+		map[string]string{
+			"pkg/bin/tool": "hello",
+		},
+	)
+
+	target := filepath.Join(t.TempDir(), "out")
+	result, err := ApplyPlan(context.Background(), Plan{
+		Steps: []Step{{
+			Label:           "download runtime",
+			Kind:            stepKindDownload,
+			URL:             "file://" + archivePath,
+			TargetPath:      target,
+			Archive:         "tar.gz",
+			Extract:         true,
+			StripComponents: 1,
+		}},
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Steps, 1)
+	require.Equal(t, stepStatusApplied, result.Steps[0].Status)
+
+	data, err := os.ReadFile(filepath.Join(target, "bin", "tool"))
+	require.NoError(t, err)
+	require.Equal(t, "hello", string(data))
 }
 
 func TestInstallHelpers(t *testing.T) {
@@ -231,6 +397,15 @@ func TestInstallHelpers(t *testing.T) {
 	)
 	require.Equal(
 		t,
+		[]string{"tap/tool"},
+		packagesForAction(InstallAction{
+			Kind:    InstallKindBrew,
+			Formula: "tool",
+			Tap:     "tap",
+		}),
+	)
+	require.Equal(
+		t,
 		[]string{"a", "b"},
 		packagesForAction(InstallAction{
 			Kind:     InstallKindAPT,
@@ -244,6 +419,14 @@ func TestInstallHelpers(t *testing.T) {
 			Package: "fallback",
 		}),
 	)
+	require.Equal(
+		t,
+		[]string{"github.com/example/tool@latest"},
+		packagesForAction(InstallAction{
+			Kind:   InstallKindGo,
+			Module: "github.com/example/tool@latest",
+		}),
+	)
 
 	covered := map[string]struct{}{
 		"one": {},
@@ -252,13 +435,20 @@ func TestInstallHelpers(t *testing.T) {
 	require.False(t, anyCovered([]string{"two"}, covered))
 
 	unresolved := unresolvedMissing(
-		InstallKindAPT,
+		Platform{
+			GOOS:           runtime.GOOS,
+			PackageManager: InstallKindAPT,
+		},
 		[]Source{{
 			Name: "demo",
 			Install: []InstallAction{{
 				Kind:     InstallKindAPT,
 				Packages: []string{"pkg"},
 				Bins:     []string{"one"},
+			}, {
+				Kind:   InstallKindGo,
+				Module: "example.com/two@latest",
+				Bins:   []string{"two"},
 			}},
 		}},
 		Missing{
@@ -266,7 +456,7 @@ func TestInstallHelpers(t *testing.T) {
 			AnyBins: [][]string{{"one", "other"}, {"x", "y"}},
 		},
 	)
-	require.Equal(t, []string{"two"}, unresolved.Bins)
+	require.Empty(t, unresolved.Bins)
 	require.Equal(t, [][]string{{"x", "y"}}, unresolved.AnyBins)
 
 	stateDir := t.TempDir()
@@ -297,6 +487,35 @@ func TestInstallHelpers(t *testing.T) {
 			{Name: "b"},
 		}),
 	)
+}
+
+func writeTarGzArchive(
+	t *testing.T,
+	path string,
+	files map[string]string,
+) {
+	t.Helper()
+
+	file, err := os.Create(path)
+	require.NoError(t, err)
+	defer file.Close()
+
+	gz := gzip.NewWriter(file)
+	defer gz.Close()
+
+	tw := tar.NewWriter(gz)
+	defer tw.Close()
+
+	for name, body := range files {
+		hdr := &tar.Header{
+			Name: name,
+			Mode: 0o755,
+			Size: int64(len(body)),
+		}
+		require.NoError(t, tw.WriteHeader(hdr))
+		_, err := tw.Write([]byte(body))
+		require.NoError(t, err)
+	}
 }
 
 func writeTestCommand(

--- a/openclaw/internal/deps/runtime.go
+++ b/openclaw/internal/deps/runtime.go
@@ -358,7 +358,7 @@ func inspectSource(
 	var missing Missing
 
 	for _, name := range source.Requires.Bins {
-		status := checkBin(name)
+		status := checkBin(toolchain, name)
 		report.Bins = append(report.Bins, status)
 		if !status.Found {
 			missing.Bins = append(missing.Bins, status.Name)
@@ -370,7 +370,7 @@ func inspectSource(
 			Names: append([]string(nil), source.Requires.AnyBins...),
 		}
 		for _, name := range source.Requires.AnyBins {
-			status := checkBin(name)
+			status := checkBin(toolchain, name)
 			if status.Found {
 				any.Found = append(any.Found, status)
 			}
@@ -407,11 +407,20 @@ func inspectSource(
 	return report, normalizeMissing(missing), nil
 }
 
-func checkBin(name string) BinStatus {
+func checkBin(toolchain Toolchain, name string) BinStatus {
 	name = strings.TrimSpace(name)
 	if name == "" {
 		return BinStatus{}
 	}
+
+	if path, ok := lookupManagedBin(toolchain, name); ok {
+		return BinStatus{
+			Name:  name,
+			Found: true,
+			Path:  path,
+		}
+	}
+
 	path, err := exec.LookPath(name)
 	if err != nil {
 		return BinStatus{Name: name}
@@ -421,6 +430,47 @@ func checkBin(name string) BinStatus {
 		Found: true,
 		Path:  path,
 	}
+}
+
+func lookupManagedBin(
+	toolchain Toolchain,
+	name string,
+) (string, bool) {
+	binDir := strings.TrimSpace(toolchain.BinDir)
+	if binDir == "" {
+		return "", false
+	}
+
+	for _, candidate := range managedBinCandidates(name) {
+		path := filepath.Join(binDir, candidate)
+		if !fileExists(path) {
+			continue
+		}
+		spec, err := validateExecutablePath(path)
+		if err != nil {
+			continue
+		}
+		return spec.path, true
+	}
+	return "", false
+}
+
+func managedBinCandidates(name string) []string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil
+	}
+	if runtime.GOOS != "windows" {
+		return []string{name}
+	}
+	out := []string{name}
+	for _, ext := range []string{".exe", ".cmd", ".bat"} {
+		if strings.HasSuffix(strings.ToLower(name), ext) {
+			return out
+		}
+		out = append(out, name+ext)
+	}
+	return out
 }
 
 func mergeMissing(left, right Missing) Missing {

--- a/openclaw/internal/deps/runtime.go
+++ b/openclaw/internal/deps/runtime.go
@@ -185,8 +185,15 @@ func ManagedPythonRoot(stateDir string) string {
 	return filepath.Join(root, defaultPythonEnvDir)
 }
 
+// ManagedToolPrefix returns the shared install prefix used for managed
+// tool binaries. Python, npm, and other managed CLIs intentionally
+// share this prefix so one PATH entry can expose all managed tools.
+func ManagedToolPrefix(stateDir string) string {
+	return ManagedPythonRoot(stateDir)
+}
+
 func ManagedBinDir(stateDir string) string {
-	root := ManagedPythonRoot(stateDir)
+	root := ManagedToolPrefix(stateDir)
 	if root == "" {
 		return ""
 	}

--- a/openclaw/internal/deps/runtime_test.go
+++ b/openclaw/internal/deps/runtime_test.go
@@ -282,6 +282,46 @@ func TestResolveExecutable_RejectsNonExecutablePath(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "python3")
 	require.NoError(t, os.WriteFile(path, []byte("x"), 0o644))
 
-	_, err := resolveExecutable(path, "")
+	_, err := resolveExecutable(path, "", "")
 	require.Error(t, err)
+}
+
+func TestManagedToolPrefixAndCandidates(t *testing.T) {
+	t.Parallel()
+
+	stateDir := t.TempDir()
+	require.Equal(
+		t,
+		ManagedPythonRoot(stateDir),
+		ManagedToolPrefix(stateDir),
+	)
+	require.Nil(t, managedBinCandidates(""))
+	if runtime.GOOS == "windows" {
+		require.Equal(
+			t,
+			[]string{"tool", "tool.exe", "tool.cmd", "tool.bat"},
+			managedBinCandidates("tool"),
+		)
+		return
+	}
+	require.Equal(t, []string{"tool"}, managedBinCandidates("tool"))
+}
+
+func TestLookPath_UsesSearchPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell assertions run on unix-like systems")
+	}
+
+	toolDir := t.TempDir()
+	toolPath := writeTestCommand(
+		t,
+		toolDir,
+		"search-tool",
+		"printf ok",
+	)
+	t.Setenv("PATH", t.TempDir())
+
+	path, err := lookPath("search-tool", toolDir)
+	require.NoError(t, err)
+	require.Equal(t, toolPath, path)
 }

--- a/openclaw/internal/deps/runtime_test.go
+++ b/openclaw/internal/deps/runtime_test.go
@@ -208,6 +208,38 @@ func TestInspectSourceAndNormalizeMissing(t *testing.T) {
 	)
 }
 
+func TestInspectSource_FindsManagedBin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("script assertions run on unix-like systems")
+	}
+
+	stateDir := t.TempDir()
+	binDir := ManagedBinDir(stateDir)
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	writeTestCommand(
+		t,
+		binDir,
+		"managed-tool",
+		"printf managed",
+	)
+
+	report, missing, err := inspectSource(
+		DetectToolchain(stateDir),
+		Source{
+			Name: "managed",
+			Requires: Requirement{
+				Bins: []string{"managed-tool"},
+			},
+		},
+		false,
+	)
+	require.NoError(t, err)
+	require.Len(t, report.Bins, 1)
+	require.True(t, report.Bins[0].Found)
+	require.Contains(t, report.Bins[0].Path, "managed-tool")
+	require.Empty(t, missing.Bins)
+}
+
 func TestCheckPythonPackages_CommandFailure(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/internal/gateway/process.go
+++ b/openclaw/internal/gateway/process.go
@@ -294,7 +294,11 @@ func (s *Server) CancelRequest(
 		}, http.StatusBadRequest
 	}
 
-	return s.managed.Cancel(rid), nil, http.StatusOK
+	canceled = s.managed.Cancel(rid)
+	if canceled && s.canceled != nil {
+		s.canceled.Mark(rid)
+	}
+	return canceled, nil, http.StatusOK
 }
 
 func (s *Server) ensureTrace(

--- a/openclaw/internal/gateway/server.go
+++ b/openclaw/internal/gateway/server.go
@@ -74,6 +74,7 @@ const (
 
 	emptyReplyFallbackText = "I didn't produce a visible " +
 		"reply. Please try again."
+	runCanceledMessage = "request canceled"
 )
 
 var errEmptyReplyValue = errors.New(errEmptyReply)
@@ -141,6 +142,8 @@ type Server struct {
 	mentionPatterns []string
 
 	lanes *laneLocker
+
+	canceled *cancelTracker
 
 	handler http.Handler
 
@@ -225,6 +228,7 @@ func New(r runner.Runner, opts ...Option) (*Server, error) {
 		requireMention:   options.requireMention,
 		mentionPatterns:  options.mentionPatterns,
 		lanes:            newLaneLocker(),
+		canceled:         newCancelTracker(),
 		recorder:         options.recorder,
 		uploads:          options.uploads,
 		audioTranscriber: audioTranscriber,
@@ -618,6 +622,47 @@ func (a *replyAccumulator) consumeDelta(rsp *model.Response) {
 type laneLocker struct {
 	mu    sync.Mutex
 	lanes map[string]*laneEntry
+}
+
+type cancelTracker struct {
+	mu  sync.Mutex
+	ids map[string]struct{}
+}
+
+func newCancelTracker() *cancelTracker {
+	return &cancelTracker{
+		ids: make(map[string]struct{}),
+	}
+}
+
+func (t *cancelTracker) Mark(requestID string) {
+	if t == nil {
+		return
+	}
+	requestID = strings.TrimSpace(requestID)
+	if requestID == "" {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.ids[requestID] = struct{}{}
+}
+
+func (t *cancelTracker) Take(requestID string) bool {
+	if t == nil {
+		return false
+	}
+	requestID = strings.TrimSpace(requestID)
+	if requestID == "" {
+		return false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if _, ok := t.ids[requestID]; !ok {
+		return false
+	}
+	delete(t.ids, requestID)
+	return true
 }
 
 func newLaneLocker() *laneLocker {

--- a/openclaw/internal/gateway/server_test.go
+++ b/openclaw/internal/gateway/server_test.go
@@ -2438,7 +2438,7 @@ func TestToolCallProgressSummaries(t *testing.T) {
 	update, ok = progressFromToolCall(model.ToolCall{
 		Function: model.FunctionDefinitionParam{
 			Name:      streamToolExecCommand,
-			Arguments: []byte(`{}`),
+			Arguments: []byte(`{"command":"go test ./..."}`),
 		},
 	})
 	require.True(t, ok)
@@ -2447,7 +2447,25 @@ func TestToolCallProgressSummaries(t *testing.T) {
 		gwproto.StreamProgressStageRunningTool,
 		update.stage,
 	)
-	require.Equal(t, progressSummaryTool, update.summary)
+	require.Equal(t, progressSummaryGoTest, update.summary)
+
+	update, ok = progressFromToolCall(model.ToolCall{
+		Function: model.FunctionDefinitionParam{
+			Name:      streamToolExecCommand,
+			Arguments: []byte(`{"command":"git status"}`),
+		},
+	})
+	require.True(t, ok)
+	require.Equal(t, progressSummaryGit, update.summary)
+
+	update, ok = progressFromToolCall(model.ToolCall{
+		Function: model.FunctionDefinitionParam{
+			Name:      streamToolExecCommand,
+			Arguments: []byte(`{"command":"rg TODO ."}`),
+		},
+	})
+	require.True(t, ok)
+	require.Equal(t, progressSummaryInspect, update.summary)
 
 	update, ok = progressFromToolCall(model.ToolCall{
 		Function: model.FunctionDefinitionParam{
@@ -2743,6 +2761,44 @@ func TestServer_StreamMessage_EmptyReplyFallback(t *testing.T) {
 		gwproto.StreamEventTypeRunCompleted,
 		events[3].Type,
 	)
+}
+
+func TestServer_StreamMessage_CanceledRequest(t *testing.T) {
+	t.Parallel()
+
+	srv, err := New(&staticRunner{})
+	require.NoError(t, err)
+	srv.canceled.Mark("req-1")
+
+	stream, apiErr, status := srv.StreamMessage(
+		context.Background(),
+		gwproto.MessageRequest{
+			From:      "u1",
+			Text:      "hello",
+			RequestID: "req-1",
+		},
+	)
+	require.Nil(t, apiErr)
+	require.Equal(t, http.StatusOK, status)
+
+	events := collectGatewayStreamEvents(t, stream)
+	require.Len(t, events, 3)
+	require.Equal(
+		t,
+		gwproto.StreamEventTypeRunStarted,
+		events[0].Type,
+	)
+	require.Equal(
+		t,
+		gwproto.StreamEventTypeRunProgress,
+		events[1].Type,
+	)
+	require.Equal(
+		t,
+		gwproto.StreamEventTypeRunCanceled,
+		events[2].Type,
+	)
+	require.Empty(t, events[2].Reply)
 }
 
 func TestServer_StreamMessage_DebugRecorderPaths(t *testing.T) {

--- a/openclaw/internal/gateway/stream.go
+++ b/openclaw/internal/gateway/stream.go
@@ -12,6 +12,7 @@ package gateway
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -25,18 +26,29 @@ import (
 )
 
 const (
-	traceStatusOK      = "ok"
-	traceStatusIgnored = "ignored"
-	traceStatusError   = "error"
+	traceStatusOK       = "ok"
+	traceStatusIgnored  = "ignored"
+	traceStatusError    = "error"
+	traceStatusCanceled = "canceled"
 
 	streamToolExecCommand    = "exec_command"
 	streamToolReadDocument   = "read_document"
 	streamToolReadSheet      = "read_spreadsheet"
+	streamToolReadFile       = "fs_read_file"
+	streamToolSaveFile       = "fs_save_file"
+	streamToolListDir        = "fs_list_dir"
+	streamToolSearch         = "fs_search"
+	streamToolApplyPatch     = "apply_patch"
 	progressSummaryPrepare   = "Preparing request"
 	progressSummaryDoc       = "Reading document"
 	progressSummarySheet     = "Reading spreadsheet"
 	progressSummaryTool      = "Running local tool"
 	progressSummaryAnswering = "Preparing final answer"
+	progressSummaryGoTest    = "Running go test"
+	progressSummaryPytest    = "Running pytest"
+	progressSummaryNPMTest   = "Running npm test"
+	progressSummaryGit       = "Running git command"
+	progressSummaryInspect   = "Inspecting workspace"
 )
 
 type streamOutcome struct {
@@ -349,6 +361,21 @@ func (s *Server) streamLocked(
 	}
 
 	if result.Error != nil {
+		if errors.Is(result.Error, context.Canceled) {
+			requestID := resolvedStreamRequestID(
+				result.RequestID,
+				run.requestID,
+			)
+			_ = sendStreamEvent(ctx, out, gwproto.StreamEvent{
+				Type:      gwproto.StreamEventTypeRunCanceled,
+				SessionID: run.sessionID,
+				RequestID: requestID,
+			})
+			return streamOutcome{
+				status: traceStatusCanceled,
+				errMsg: context.Canceled.Error(),
+			}
+		}
 		apiErr := gwproto.APIError{
 			Type:    errTypeInternal,
 			Message: result.Error.Error(),
@@ -368,14 +395,31 @@ func (s *Server) streamLocked(
 		}
 	}
 
-	reply := strings.TrimSpace(result.Text)
-	if reply == "" {
-		reply = emptyReplyFallbackText
-	}
 	requestID := resolvedStreamRequestID(
 		result.RequestID,
 		run.requestID,
 	)
+	if s.canceled != nil && s.canceled.Take(requestID) {
+		if !sendStreamEvent(ctx, out, gwproto.StreamEvent{
+			Type:      gwproto.StreamEventTypeRunCanceled,
+			SessionID: run.sessionID,
+			RequestID: requestID,
+		}) {
+			return streamOutcome{
+				status: traceStatusError,
+				errMsg: contextErrMessage(ctx),
+			}
+		}
+		return streamOutcome{
+			status: traceStatusCanceled,
+			errMsg: runCanceledMessage,
+		}
+	}
+
+	reply := strings.TrimSpace(result.Text)
+	if reply == "" {
+		reply = emptyReplyFallbackText
+	}
 	if !sendStreamEvent(ctx, out, gwproto.StreamEvent{
 		Type:      gwproto.StreamEventTypeMessageCompleted,
 		SessionID: run.sessionID,
@@ -473,7 +517,7 @@ func progressFromToolCall(
 	case streamToolExecCommand:
 		return progressUpdate{
 			stage:   gwproto.StreamProgressStageRunningTool,
-			summary: progressSummaryTool,
+			summary: execCommandProgressSummary(toolCall),
 		}, true
 	default:
 		if name == "" {
@@ -484,6 +528,62 @@ func progressFromToolCall(
 			summary: "Running " + name,
 		}, true
 	}
+}
+
+func execCommandProgressSummary(toolCall model.ToolCall) string {
+	const defaultSummary = progressSummaryTool
+
+	var args struct {
+		Command string `json:"command,omitempty"`
+	}
+	if err := json.Unmarshal(toolCall.Function.Arguments, &args); err != nil {
+		return defaultSummary
+	}
+
+	command := normalizeExecCommand(args.Command)
+	switch {
+	case command == "":
+		return defaultSummary
+	case strings.HasPrefix(command, "go test"):
+		return progressSummaryGoTest
+	case strings.HasPrefix(command, "pytest"),
+		strings.HasPrefix(command, "python -m pytest"):
+		return progressSummaryPytest
+	case strings.HasPrefix(command, "npm test"),
+		strings.HasPrefix(command, "pnpm test"),
+		strings.HasPrefix(command, "yarn test"),
+		strings.HasPrefix(command, "bun test"):
+		return progressSummaryNPMTest
+	case strings.HasPrefix(command, "git "):
+		return progressSummaryGit
+	case looksLikeWorkspaceInspection(command):
+		return progressSummaryInspect
+	default:
+		return defaultSummary
+	}
+}
+
+func normalizeExecCommand(command string) string {
+	command = strings.ToLower(strings.TrimSpace(command))
+	return strings.Join(strings.Fields(command), " ")
+}
+
+func looksLikeWorkspaceInspection(command string) bool {
+	for _, prefix := range []string{
+		"ls",
+		"find",
+		"rg ",
+		"cat ",
+		"sed ",
+		"head ",
+		"tail ",
+		"pwd",
+	} {
+		if strings.HasPrefix(command, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func readDocumentProgressSummary(toolCall model.ToolCall) string {

--- a/openclaw/internal/octool/file_tools.go
+++ b/openclaw/internal/octool/file_tools.go
@@ -296,7 +296,7 @@ func resolveDocumentPath(
 		return "", "", errors.New(errReadPathRequired)
 	}
 
-	resolved, err := resolveInputPath(path)
+	resolved, err := resolveInputPath(path, env)
 	if err != nil {
 		return "", "", err
 	}
@@ -321,7 +321,7 @@ func resolveSpreadsheetPath(
 		return "", "", errors.New(errReadPathRequired)
 	}
 
-	resolved, err := resolveInputPath(path)
+	resolved, err := resolveInputPath(path, env)
 	if err != nil {
 		return "", "", err
 	}
@@ -334,12 +334,18 @@ func resolveSpreadsheetPath(
 	return resolved, kind, nil
 }
 
-func resolveInputPath(rawPath string) (string, error) {
+func resolveInputPath(
+	rawPath string,
+	env map[string]string,
+) (string, error) {
 	path := strings.TrimSpace(rawPath)
 	if path == "" {
 		return "", errors.New(errReadPathRequired)
 	}
 	if resolved, ok := uploads.PathFromHostRef(path); ok {
+		path = resolved
+	}
+	if resolved, ok := resolveUploadContextPath(path, env); ok {
 		path = resolved
 	}
 
@@ -355,6 +361,101 @@ func resolveInputPath(rawPath string) (string, error) {
 		return "", fmt.Errorf("path is a directory: %s", localPath)
 	}
 	return localPath, nil
+}
+
+func resolveUploadContextPath(
+	path string,
+	env map[string]string,
+) (string, bool) {
+	path = strings.TrimSpace(path)
+	if path == "" || filepath.IsAbs(path) || path == "~" ||
+		strings.HasPrefix(path, "~/") {
+		return "", false
+	}
+
+	if matched := matchRecentUploadPath(path, env); matched != "" {
+		return matched, true
+	}
+
+	dir := strings.TrimSpace(env[envSessionUploadsDir])
+	if dir == "" {
+		return "", false
+	}
+	candidate := filepath.Join(dir, path)
+	if info, err := os.Stat(candidate); err == nil &&
+		info != nil && !info.IsDir() {
+		return candidate, true
+	}
+	return "", false
+}
+
+func matchRecentUploadPath(
+	rawPath string,
+	env map[string]string,
+) string {
+	rawPath = strings.TrimSpace(rawPath)
+	if rawPath == "" {
+		return ""
+	}
+
+	var recent []execUploadMeta
+	if raw := strings.TrimSpace(env[envRecentUploadsJSON]); raw != "" {
+		if err := json.Unmarshal([]byte(raw), &recent); err == nil {
+			for _, item := range recent {
+				if uploadMatchesReference(item, rawPath) {
+					return item.Path
+				}
+			}
+		}
+	}
+
+	latest := execUploadMeta{
+		Name:    strings.TrimSpace(env[envLastUploadName]),
+		Path:    strings.TrimSpace(env[envLastUploadPath]),
+		HostRef: strings.TrimSpace(env[envLastUploadHostRef]),
+	}
+	if uploadMatchesReference(latest, rawPath) {
+		return latest.Path
+	}
+	return ""
+}
+
+func uploadMatchesReference(
+	item execUploadMeta,
+	rawPath string,
+) bool {
+	for _, candidate := range uploadReferenceCandidates(item) {
+		if candidate == rawPath {
+			return true
+		}
+	}
+	return false
+}
+
+func uploadReferenceCandidates(item execUploadMeta) []string {
+	var out []string
+	out = appendUniqueTrimmed(out, item.Name)
+	out = appendUniqueTrimmed(out, item.Path)
+	out = appendUniqueTrimmed(out, filepath.Base(item.Path))
+	out = appendUniqueTrimmed(out, item.HostRef)
+	if hostPath, ok := uploads.PathFromHostRef(item.HostRef); ok {
+		out = appendUniqueTrimmed(out, hostPath)
+		out = appendUniqueTrimmed(out, filepath.Base(hostPath))
+	}
+	return out
+}
+
+func appendUniqueTrimmed(values []string, value string) []string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return values
+	}
+	for _, existing := range values {
+		if existing == value {
+			return values
+		}
+	}
+	return append(values, value)
 }
 
 func documentKindFromPath(path string) string {

--- a/openclaw/internal/octool/file_tools_test.go
+++ b/openclaw/internal/octool/file_tools_test.go
@@ -220,7 +220,7 @@ func TestReadDocumentHelpers(t *testing.T) {
 	)
 	require.ErrorContains(t, err, errDocumentUnsupported)
 
-	_, err = resolveInputPath(dirPath)
+	_, err = resolveInputPath(dirPath, nil)
 	require.ErrorContains(t, err, "directory")
 
 	require.Equal(t, docKindDOCX, documentKindFromPath(docxPath))
@@ -242,6 +242,30 @@ func TestReadDocumentHelpers(t *testing.T) {
 	require.ErrorContains(t, err, "exceeds page count")
 
 	require.Equal(t, "", pdfPageText(nil, 1))
+}
+
+func TestReadDocumentTool_ResolvesRelativeUploadName(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	pdfPath := createSamplePDF(t, []string{"relative upload"})
+	ctx := invocationContextWithUpload(
+		t,
+		pdfPath,
+		"0.pdf",
+		"application/pdf",
+	)
+	tool := newReadDocumentTool()
+
+	out, err := tool.Call(ctx, mustJSON(t, map[string]any{
+		"path": "0.pdf",
+	}))
+	require.NoError(t, err)
+
+	res := out.(readDocumentResult)
+	require.Equal(t, pdfPath, res.Path)
+	require.Contains(t, res.Text, "relative upload")
 }
 
 func TestReadSpreadsheetTool_CSVAndErrors(t *testing.T) {
@@ -278,6 +302,33 @@ func TestReadSpreadsheetTool_CSVAndErrors(t *testing.T) {
 
 	_, err = tool.Call(context.Background(), []byte("{"))
 	require.ErrorContains(t, err, "invalid args")
+}
+
+func TestReadSpreadsheetTool_ResolvesRelativeUploadName(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	xlsxPath := createSampleWorkbook(t)
+	ctx := invocationContextWithUpload(
+		t,
+		xlsxPath,
+		"sheet.xlsx",
+		"application/vnd.openxmlformats-officedocument."+
+			"spreadsheetml.sheet",
+	)
+	tool := newReadSpreadsheetTool()
+
+	out, err := tool.Call(ctx, mustJSON(t, map[string]any{
+		"path": "sheet.xlsx",
+		"row":  2,
+	}))
+	require.NoError(t, err)
+
+	res := out.(readSpreadsheetResult)
+	require.Equal(t, xlsxPath, res.Path)
+	require.Len(t, res.Rows, 1)
+	require.Equal(t, 2, res.Rows[0].Index)
 }
 
 func TestSpreadsheetHelpers(t *testing.T) {

--- a/openclaw/internal/skills/repository_test.go
+++ b/openclaw/internal/skills/repository_test.go
@@ -24,6 +24,54 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/deps"
 )
 
+var (
+	supportedOpenClawMetaFields = map[string]struct{}{
+		"emoji":      {},
+		"homepage":   {},
+		"install":    {},
+		"os":         {},
+		"primaryEnv": {},
+		"requires":   {},
+		"skillKey":   {},
+	}
+	supportedOpenClawRequireFields = map[string]struct{}{
+		"anyBins": {},
+		"bins":    {},
+		"config":  {},
+		"env":     {},
+		"python":  {},
+	}
+	supportedOpenClawInstallFields = map[string]struct{}{
+		"archive":         {},
+		"bins":            {},
+		"extract":         {},
+		"formula":         {},
+		"id":              {},
+		"kind":            {},
+		"label":           {},
+		"module":          {},
+		"os":              {},
+		"package":         {},
+		"packages":        {},
+		"stripComponents": {},
+		"tap":             {},
+		"targetDir":       {},
+		"url":             {},
+	}
+	supportedOpenClawInstallKinds = map[string]struct{}{
+		deps.InstallKindAPT:      {},
+		deps.InstallKindBrew:     {},
+		deps.InstallKindDNF:      {},
+		deps.InstallKindDownload: {},
+		deps.InstallKindGo:       {},
+		deps.InstallKindNode:     {},
+		deps.InstallKindNPM:      {},
+		deps.InstallKindPIP:      {},
+		deps.InstallKindUV:       {},
+		deps.InstallKindYUM:      {},
+	}
+)
+
 func TestParseFrontMatter_OpenClawMetadata(t *testing.T) {
 	content := `---
 name: coding-agent
@@ -87,10 +135,12 @@ metadata:
         "install":
           [
             {
-              "id": "brew",
-              "kind": "brew",
-              "formula": "poppler",
+              "id": "go",
+              "kind": "go",
+              "module": "example.com/tool@latest",
               "bins": ["pdftotext"],
+              "os": ["linux", "win32"],
+              "targetDir": "runtime",
             },
           ],
       },
@@ -108,8 +158,10 @@ metadata:
 	require.Len(t, meta.Requires.Python, 1)
 	require.Equal(t, "pypdf", meta.Requires.Python[0].Module)
 	require.Len(t, meta.Install, 1)
-	require.Equal(t, "brew", meta.Install[0].Kind)
-	require.Equal(t, "poppler", meta.Install[0].Formula)
+	require.Equal(t, "go", meta.Install[0].Kind)
+	require.Equal(t, "example.com/tool@latest", meta.Install[0].Module)
+	require.Equal(t, []string{"linux", "win32"}, meta.Install[0].OS)
+	require.Equal(t, "runtime", meta.Install[0].TargetDir)
 }
 
 func TestParseFrontMatter_NoFrontMatter(t *testing.T) {
@@ -182,6 +234,75 @@ func TestParseOpenClawMetadata_UnmarshalError(t *testing.T) {
 
 func TestAsString_NonString(t *testing.T) {
 	require.Empty(t, asString(123))
+}
+
+func TestOfficialOpenClawSkillMetadata_IsSupported(t *testing.T) {
+	root := filepath.Join("..", "..", "skills")
+	entries, err := os.ReadDir(root)
+	require.NoError(t, err)
+	require.NotEmpty(t, entries)
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		path := filepath.Join(root, entry.Name(), skillFileName)
+		fm, err := parseFrontMatterFile(path)
+		if errors.Is(err, errNoFrontMatter) {
+			continue
+		}
+		require.NoError(t, err, entry.Name())
+
+		rawMeta, ok := fm.Metadata[openClawMetadataKey]
+		if !ok {
+			continue
+		}
+		meta := normalizeStringAnyMap(rawMeta)
+		require.NotNil(t, meta, entry.Name())
+
+		for field := range meta {
+			_, ok := supportedOpenClawMetaFields[field]
+			require.True(t, ok, "%s meta field %q", entry.Name(), field)
+		}
+
+		requires := normalizeStringAnyMap(meta["requires"])
+		for field := range requires {
+			_, ok := supportedOpenClawRequireFields[field]
+			require.True(
+				t,
+				ok,
+				"%s requires field %q",
+				entry.Name(),
+				field,
+			)
+		}
+
+		rawInstall, _ := meta["install"].([]any)
+		for _, item := range rawInstall {
+			action := normalizeStringAnyMap(item)
+			require.NotNil(t, action, entry.Name())
+			for field := range action {
+				_, ok := supportedOpenClawInstallFields[field]
+				require.True(
+					t,
+					ok,
+					"%s install field %q",
+					entry.Name(),
+					field,
+				)
+			}
+			kind, _ := action["kind"].(string)
+			_, ok := supportedOpenClawInstallKinds[kind]
+			require.True(
+				t,
+				ok,
+				"%s install kind %q",
+				entry.Name(),
+				kind,
+			)
+		}
+	}
 }
 
 func TestRepository_GatesOnBins(t *testing.T) {

--- a/tool/file/file.go
+++ b/tool/file/file.go
@@ -36,9 +36,26 @@ const (
 	defaultCreateFileMode = os.FileMode(0644)
 	// defaultMaxFileSize is the default maximum file size to read, which is 1MB.
 	defaultMaxFileSize = 1024 * 1024
+	// missingFileHintMaxEntries limits how many top-level entries are
+	// suggested when a requested file is missing.
+	missingFileHintMaxEntries = 6
 )
 
-const inputsDirName = "inputs"
+const (
+	inputsDirName = "inputs"
+
+	missingFileEntriesSeparator = ", "
+	missingFileDirectorySuffix  = "/"
+	missingFileListToolName     = "list_file"
+	missingFileSearchToolName   = "search_file"
+	missingFileTopLevelPrefix   = "Top-level entries: "
+	missingFileBaseDirPrefix    = "Base directory: "
+	missingFileRecoveryGuidance = "Use " +
+		missingFileListToolName + " or " +
+		missingFileSearchToolName +
+		" to inspect available paths."
+	missingFileNoEntriesFallback = "(no visible entries)"
+)
 
 // Option is a functional option for configuring the file tool set.
 type Option func(*fileToolSet)
@@ -270,6 +287,54 @@ func (f *fileToolSet) normalizeInputsAlias(relativePath string) string {
 		return filepath.FromSlash(strings.TrimPrefix(slashed, prefix))
 	}
 	return raw
+}
+
+func (f *fileToolSet) missingFileHint() string {
+	if f == nil {
+		return ""
+	}
+
+	parts := []string{
+		missingFileBaseDirPrefix + f.baseDir,
+	}
+	if entries := f.topLevelEntriesHint(); entries != "" {
+		parts = append(
+			parts,
+			missingFileTopLevelPrefix+entries,
+		)
+	}
+	parts = append(parts, missingFileRecoveryGuidance)
+	return strings.Join(parts, ". ")
+}
+
+func (f *fileToolSet) topLevelEntriesHint() string {
+	if f == nil || strings.TrimSpace(f.baseDir) == "" {
+		return ""
+	}
+
+	entries, err := os.ReadDir(f.baseDir)
+	if err != nil {
+		return ""
+	}
+	if len(entries) == 0 {
+		return missingFileNoEntriesFallback
+	}
+
+	names := make([]string, 0, missingFileHintMaxEntries)
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() {
+			name += missingFileDirectorySuffix
+		}
+		names = append(names, name)
+		if len(names) >= missingFileHintMaxEntries {
+			break
+		}
+	}
+	if len(entries) > len(names) {
+		names = append(names, "...")
+	}
+	return strings.Join(names, missingFileEntriesSeparator)
 }
 
 // matchFiles matches files with the given pattern in the target path.

--- a/tool/file/file_test.go
+++ b/tool/file/file_test.go
@@ -219,3 +219,34 @@ func TestTools_InvalidBaseDir(t *testing.T) {
 	_, err = NewToolSet(WithBaseDir(file))
 	assert.Error(t, err)
 }
+
+func TestNormalizeInputsAlias_AndHints(t *testing.T) {
+	dir := t.TempDir()
+	set, err := NewToolSet(WithBaseDir(dir))
+	assert.NoError(t, err)
+	fts := set.(*fileToolSet)
+
+	assert.Equal(t, "", (*fileToolSet)(nil).missingFileHint())
+	assert.Equal(t, "", (*fileToolSet)(nil).topLevelEntriesHint())
+	assert.Equal(t, "", fts.normalizeInputsAlias("inputs"))
+	assert.Equal(t, "a.txt", fts.normalizeInputsAlias("inputs/a.txt"))
+	assert.Contains(t, fts.topLevelEntriesHint(), missingFileNoEntriesFallback)
+	assert.Contains(t, fts.missingFileHint(), missingFileRecoveryGuidance)
+}
+
+func TestTopLevelEntriesHint_TruncatesAndMarksDirectories(t *testing.T) {
+	dir := t.TempDir()
+	err := os.Mkdir(filepath.Join(dir, "aaa"), 0o755)
+	assert.NoError(t, err)
+	for i := 0; i < missingFileHintMaxEntries+1; i++ {
+		name := filepath.Join(dir, "file"+string(rune('a'+i)))
+		err := os.WriteFile(name, []byte("x"), 0o644)
+		assert.NoError(t, err)
+	}
+
+	set, err := NewToolSet(WithBaseDir(dir))
+	assert.NoError(t, err)
+	hint := set.(*fileToolSet).topLevelEntriesHint()
+	assert.Contains(t, hint, "aaa"+missingFileDirectorySuffix)
+	assert.Contains(t, hint, "...")
+}

--- a/tool/file/readfile.go
+++ b/tool/file/readfile.go
@@ -203,11 +203,17 @@ func (f *fileToolSet) readFileFromDiskOrCache(
 			}
 		}
 		rsp.Message = fmt.Sprintf(
-			"Error: cannot access file '%s': %v",
+			"Error: cannot access file '%s': %v. %s",
 			req.FileName,
 			err,
+			f.missingFileHint(),
 		)
-		return fmt.Errorf("accessing file '%s': %w", req.FileName, err)
+		return fmt.Errorf(
+			"accessing file '%s' under base directory '%s': %w",
+			req.FileName,
+			f.baseDir,
+			err,
+		)
 	}
 	if stat.IsDir() {
 		rsp.Message = fmt.Sprintf(

--- a/tool/file/readfile_test.go
+++ b/tool/file/readfile_test.go
@@ -90,6 +90,42 @@ func TestFileTool_ReadFile_NonExistFile(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestFileTool_ReadFile_NonExistFileIncludesHint(t *testing.T) {
+	tempDir := t.TempDir()
+	toolSet, err := NewToolSet(WithBaseDir(tempDir))
+	assert.NoError(t, err)
+	fileToolSet, ok := toolSet.(*fileToolSet)
+	assert.True(t, ok)
+
+	assert.NoError(
+		t,
+		os.Mkdir(filepath.Join(tempDir, "nested"), 0o755),
+	)
+	assert.NoError(
+		t,
+		os.WriteFile(
+			filepath.Join(tempDir, "README.md"),
+			[]byte("hello"),
+			0o644,
+		),
+	)
+
+	rsp, err := fileToolSet.readFile(
+		context.Background(),
+		&readFileRequest{FileName: "missing.txt"},
+	)
+	assert.Error(t, err)
+	assert.NotNil(t, rsp)
+	assert.Contains(t, rsp.Message, missingFileBaseDirPrefix+tempDir)
+	assert.Contains(t, rsp.Message, "README.md")
+	assert.Contains(
+		t,
+		rsp.Message,
+		"nested"+missingFileDirectorySuffix,
+	)
+	assert.Contains(t, rsp.Message, missingFileRecoveryGuidance)
+}
+
 func TestFileTool_ReadFile_Empty(t *testing.T) {
 	// Create a temporary directory for testing.
 	tempDir := t.TempDir()

--- a/tool/file/replacecontent.go
+++ b/tool/file/replacecontent.go
@@ -83,11 +83,17 @@ func (f *fileToolSet) replaceContent(
 	st, err := os.Stat(filePath)
 	if err != nil {
 		rsp.Message = fmt.Sprintf(
-			"Error: cannot access file '%s': %v",
+			"Error: cannot access file '%s': %v. %s",
 			req.FileName,
 			err,
+			f.missingFileHint(),
 		)
-		return rsp, fmt.Errorf("accessing file '%s': %w", req.FileName, err)
+		return rsp, fmt.Errorf(
+			"accessing file '%s' under base directory '%s': %w",
+			req.FileName,
+			f.baseDir,
+			err,
+		)
 	}
 	if st.IsDir() {
 		rsp.Message = fmt.Sprintf(

--- a/tool/file/replacecontent_test.go
+++ b/tool/file/replacecontent_test.go
@@ -254,3 +254,43 @@ func TestFileTool_ReplaceContent_NotExist(t *testing.T) {
 	_, err = fileToolSet.replaceContent(context.Background(), req)
 	assert.Error(t, err)
 }
+
+func TestFileTool_ReplaceContent_NotExistIncludesHint(t *testing.T) {
+	tempDir := t.TempDir()
+	toolSet, err := NewToolSet(WithBaseDir(tempDir))
+	assert.NoError(t, err)
+	fileToolSet, ok := toolSet.(*fileToolSet)
+	assert.True(t, ok)
+
+	assert.NoError(
+		t,
+		os.Mkdir(filepath.Join(tempDir, "pkg"), 0o755),
+	)
+	assert.NoError(
+		t,
+		os.WriteFile(
+			filepath.Join(tempDir, "go.mod"),
+			[]byte("module example.com/test"),
+			0o644,
+		),
+	)
+
+	rsp, err := fileToolSet.replaceContent(
+		context.Background(),
+		&replaceContentRequest{
+			FileName:  "missing.go",
+			OldString: "a",
+			NewString: "b",
+		},
+	)
+	assert.Error(t, err)
+	assert.NotNil(t, rsp)
+	assert.Contains(t, rsp.Message, missingFileBaseDirPrefix+tempDir)
+	assert.Contains(t, rsp.Message, "go.mod")
+	assert.Contains(
+		t,
+		rsp.Message,
+		"pkg"+missingFileDirectorySuffix,
+	)
+	assert.Contains(t, rsp.Message, missingFileRecoveryGuidance)
+}


### PR DESCRIPTION
## Summary
- align OpenClaw dependency bootstrap with the official skill metadata that current bundled skills actually use
- make `bootstrap deps --apply` best-effort so managed installs/downloads run first and root-only steps are deferred with a clear summary
- improve `tool/file` missing-file errors so code agents get the configured base dir and recovery hints instead of a dead end

## Testing
- `cd openclaw && go test ./... -count=1`
- `cd openclaw && go vet ./...`
- `go test ./tool/file -count=1`
- `go vet ./tool/file`
- `cd openclaw && go run ./cmd/openclaw bootstrap deps --state-dir \"$(mktemp -d)/state\" -skill sherpa-onnx-tts`
- `cd openclaw && go run ./cmd/openclaw bootstrap deps --state-dir \"$(mktemp -d)/state\" -skill eightctl,mcporter,nano-pdf`
- `cd openclaw && go run ./cmd/openclaw bootstrap deps --skills-root /data2/backup/data/projects/trpc-agent-go/openclaw/skills --state-dir \"$(mktemp -d)/state\" -skill anthropic-pptx,nano-pdf --apply`
