### PR TITLE
chore: add fallback CODEOWNERS reviewer rule

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,5 +3,83 @@
 # Order matters because later rules take precedence over earlier ones.
 # See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners.
 #
+# agent
+/agent/ @sandyskies @WineChord
+
+# artifact
+/artifact/ @sandyskies @liuzengh
+
+# benchmark
+/benchmark/ @sandyskies @Flash-LHR
+
+# codeexecutor
+/codeexecutor/ @sandyskies @liuzengh
+
+# docs
+/docs/ @sandyskies @WineChord @Flash-LHR
+
+# evaluation
+/evaluation/ @sandyskies @Flash-LHR
+
+# event
+/event/ @sandyskies @WineChord
+
+# examples
+/examples/ @sandyskies @WineChord
+
+# graph
+/graph/ @sandyskies @WineChord
+
+# internal
+/internal/ @sandyskies @WineChord @liuzengh @Flash-LHR @Rememorio @hyprh
+
+# knowledge
+/knowledge/ @sandyskies @hyprh
+
+# log
+/log/ @sandyskies @WineChord
+
+# memory
+/memory/ @sandyskies @Rememorio @hyprh
+
+# model
+/model/ @sandyskies @WineChord
+
+# openclaw
+/openclaw/ @sandyskies @WineChord
+
+# planner
+/planner/ @sandyskies @WineChord
+
+# plugin
+/plugin/ @sandyskies @WineChord
+
+# runner
+/runner/ @sandyskies @WineChord
+
+# server
+/server/ @sandyskies @WineChord @Flash-LHR
+
+# session
+/session/ @sandyskies @Rememorio @hyprh
+
+# skill
+/skill/ @sandyskies @WineChord
+
+# storage
+/storage/ @sandyskies @Rememorio @hyprh
+
+# team
+/team/ @sandyskies @WineChord
+
+# telemetry
+/telemetry/ @sandyskies @liuzengh
+
+# test
+/test/ @sandyskies @WineChord @Flash-LHR
+
+# tool
+/tool/ @sandyskies @liuzengh
+
 # Any listed reviewer can approve changes anywhere in the repository.
 * @bytethm @Flash-LHR @hyprh @liuzengh @Rememorio @sandyskies @WineChord


### PR DESCRIPTION
This change keeps the existing module-specific CODEOWNERS entries and adds a repository-wide fallback rule at the end of the file, with the shared reviewer list sorted alphabetically and including @bytethm, so that the final matching rule allows any listed code owner to approve cross-module pull requests.