### PR TITLE
.github: narrow review triggers

### DIFF
--- a/.github/workflows/owner-review-policy.yml
+++ b/.github/workflows/owner-review-policy.yml
@@ -1,7 +1,5 @@
 name: Owner Review Policy
 on:
-  pull_request_target:
-    types: [opened, reopened, synchronize, ready_for_review, edited]
   pull_request_review:
     types: [submitted, dismissed]
 permissions:
@@ -10,7 +8,14 @@ permissions:
 jobs:
   owner-review-policy:
     name: owner-review-policy
-    if: ${{ github.event.pull_request.state == 'open' }}
+    if: >-
+      ${{
+        github.event.pull_request.state == 'open' &&
+        (
+          github.event.action == 'dismissed' ||
+          github.event.review.state == 'approved'
+        )
+      }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This narrows the owner review policy workflow to pull_request_review events only and runs the required check only when an approval is submitted or dismissed. The goal is to keep a single review-driven gate for owner approval changes, avoid duplicate runs from pull_request_target, and rely on the existing stale approval dismissal setting to invalidate approvals after new commits are pushed.