### PR TITLE
{tool, internal}: support result-aware skip summarization

### DIFF
--- a/docs/mkdocs/en/agent.md
+++ b/docs/mkdocs/en/agent.md
@@ -491,13 +491,19 @@ for event := range eventChan {
         }
     }
 
-    // Check if completed (note: should not break on tool call completion)
+    // Check whether the current response is complete.
     if event.IsFinalResponse() {
         fmt.Println()
         break
     }
 }
 ```
+
+This example uses `event.IsFinalResponse()` because it only cares about when
+the current reply has been fully printed. If you need to wait until the whole
+`Runner.Run` is truly over, such as when `tool.response` may be followed by
+extra processing or when using GraphAgent, use
+`event.IsRunnerCompletion()` as the loop exit condition instead.
 
 The complete code for this example can be found at [examples/runner](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/runner)
 

--- a/docs/mkdocs/en/callbacks.md
+++ b/docs/mkdocs/en/callbacks.md
@@ -183,6 +183,7 @@ type AfterToolArgs struct {
 type AfterToolResult struct {
     Context      context.Context  // Optional context for subsequent operations
     CustomResult any              // If non-nil, replaces the original result
+    SkipSummarization bool        // If true, end the turn after tool.response
 }
 ```
 
@@ -201,6 +202,10 @@ Key points:
 - Arguments can be modified directly via `args.Arguments`.
 - If BeforeToolCallbackStructured returns a non-nil custom result, the tool is skipped and that result is used directly.
 - `ToolCallID` is available in `BeforeToolArgs` and `AfterToolArgs`.
+- `AfterToolResult.SkipSummarization` lets a callback end the turn after
+  `tool.response` when the tool result should be surfaced directly.
+- `SkipSummarization` only skips the extra summarization LLM call. The true
+  end-of-run marker is still `runner.completion` / `event.IsRunnerCompletion()`.
 
 ### Callback Execution Control
 
@@ -267,6 +272,27 @@ toolCallbacks := tool.NewCallbacks().
     return nil, nil
   })
 ```
+
+Dynamic skip-summarization example:
+
+```go
+toolCallbacks.RegisterAfterTool(func(ctx context.Context, args *tool.AfterToolArgs) (*tool.AfterToolResult, error) {
+  if args.Error != nil {
+    return nil, nil
+  }
+  out, ok := args.Result.(map[string]any)
+  if ok && out["action"] != nil {
+    return &tool.AfterToolResult{
+      SkipSummarization: true,
+    }, nil
+  }
+  return nil, nil
+})
+```
+
+This ends the turn after the tool response. It does not turn `tool.response`
+into a final assistant message, so consumers that need the real terminal
+signal should keep reading until `runner.completion`.
 
 **Usage**: After creating callbacks, pass them to the LLM Agent when creating it using the `llmagent.WithToolCallbacks()` option:
 

--- a/docs/mkdocs/en/event.md
+++ b/docs/mkdocs/en/event.md
@@ -286,6 +286,24 @@ if e.IsRunnerCompletion() {
 }
 ```
 
+Do not confuse `event.IsFinalResponse()` with
+`event.IsRunnerCompletion()`:
+
+- `event.IsFinalResponse()` reuses the embedded `Response` semantics. It only
+  says the current response payload has finished: it is not partial, not a
+  tool-call response, and `Response.Done == true`. This can be an assistant
+  message, a `tool.response`, or a terminal error response.
+- `event.IsRunnerCompletion()` asks whether Runner has emitted the terminal
+  `runner.completion` event. Only this signal means the entire `Runner.Run`
+  has finished and no more runtime events should be expected.
+
+Rule of thumb:
+
+- Use `IsFinalResponse()` when you only care whether the current payload is
+  complete.
+- Use `IsRunnerCompletion()` when deciding to stop consuming the event stream,
+  read final state, or treat the whole run as finished.
+
 ### Event Creation
 
 When developing custom Agent types or Processors, you need to create Events.
@@ -518,8 +536,8 @@ func (c *multiTurnChat) processResponse(eventChan <-chan *event.Event) error {
         if err := c.handleEvent(event, &toolCallsDetected, &assistantStarted, &fullContent); err != nil {
             return err
         }
-        // Check if it's the final event.
-        if event.IsFinalResponse() {
+        // Check if the run-completion event has arrived.
+        if event.IsRunnerCompletion() {
             fmt.Printf("\n")
             break
         }

--- a/docs/mkdocs/en/event.md
+++ b/docs/mkdocs/en/event.md
@@ -70,6 +70,10 @@ type EventActions struct {
 }
 ```
 
+`SkipSummarization` is a flow-control hint. It does not mean the current
+`tool.response` is a final assistant response. If you need the true terminal
+event for the run, continue consuming until `runner.completion`.
+
 #### FilterKey (hierarchical scope key)
 
 `FilterKey` is an optional string field on each event. Think of it as a

--- a/docs/mkdocs/en/tool.md
+++ b/docs/mkdocs/en/tool.md
@@ -549,6 +549,7 @@ child := agenttool.NewTool(
 - Completion signaling: Tool response events are marked `RequiresCompletion=true`; Runner sends completion automatically
 - De-duplication: When inner deltas are forwarded, avoid printing the aggregated final `tool.response` text again by default
 - Model compatibility: Some providers require a tool message after tool_calls; AgentTool automatically supplies the aggregated content
+- `WithSkipSummarization(true)` only skips the extra outer summarization LLM call. It does not make `tool.response` a final assistant response; keep consuming until `runner.completion` if you need the real terminal signal
 
 ## Tool Integration and Usage
 

--- a/docs/mkdocs/zh/agent.md
+++ b/docs/mkdocs/zh/agent.md
@@ -465,13 +465,18 @@ for event := range eventChan {
         }
     }
 
-    // 检查是否完成（注意：工具调用完成时不应该 break）
+    // 检查当前这条响应是否已完整结束
     if event.IsFinalResponse() {
         fmt.Println()
         break
     }
 }
 ```
+
+上面的示例使用 `event.IsFinalResponse()`，是因为它只关心“当前这条回复何时
+完整输出完”。如果你需要等待整次 `Runner.Run` 真正结束，例如
+`tool.response` 后可能还有后续处理，或在 GraphAgent 中还要等待图上其他节点
+完成，请改用 `event.IsRunnerCompletion()` 作为退出条件。
 
 该示例的完整代码可见 [examples/runner](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/runner)
 

--- a/docs/mkdocs/zh/callbacks.md
+++ b/docs/mkdocs/zh/callbacks.md
@@ -182,6 +182,7 @@ type AfterToolArgs struct {
 type AfterToolResult struct {
     Context      context.Context  // 可选，用于后续操作的上下文
     CustomResult any              // 非空时替换原始结果
+    SkipSummarization bool        // 为 true 时在 tool.response 后结束本轮
 }
 ```
 
@@ -200,6 +201,10 @@ type AfterToolCallbackStructured  func(ctx context.Context, args *tool.AfterTool
 - 可通过 `args.Arguments` 直接修改参数
 - BeforeToolCallbackStructured 返回非空自定义结果时，会跳过工具执行并直接使用该结果
 - `BeforeToolArgs` 和 `AfterToolArgs` 中提供了 `ToolCallID`
+- `AfterToolResult.SkipSummarization` 允许回调在判断工具结果后，让本轮在
+  `tool.response` 后直接结束
+- `SkipSummarization` 只会跳过额外的总结型 LLM 调用；真正的结束信号仍然是
+  `runner.completion` / `event.IsRunnerCompletion()`
 
 
 ### 回调执行控制
@@ -267,6 +272,27 @@ toolCallbacks := tool.NewCallbacks().
     return nil, nil
   })
 ```
+
+动态 skip summarization 示例：
+
+```go
+toolCallbacks.RegisterAfterTool(func(ctx context.Context, args *tool.AfterToolArgs) (*tool.AfterToolResult, error) {
+  if args.Error != nil {
+    return nil, nil
+  }
+  out, ok := args.Result.(map[string]any)
+  if ok && out["action"] != nil {
+    return &tool.AfterToolResult{
+      SkipSummarization: true,
+    }, nil
+  }
+  return nil, nil
+})
+```
+
+这会让本轮在工具响应后结束，但不会把 `tool.response` 变成最终
+assistant 响应。若消费侧需要真正的终止标记，仍应持续读取直到
+`runner.completion`。
 
 **使用方式**：创建 callbacks 后，需要在创建 LLM Agent 时通过 `llmagent.WithToolCallbacks()` 选项传入：
 

--- a/docs/mkdocs/zh/event.md
+++ b/docs/mkdocs/zh/event.md
@@ -69,6 +69,10 @@ type EventActions struct {
 }
 ```
 
+`SkipSummarization` 是一个流程控制提示，不表示当前这条
+`tool.response` 已经变成 assistant final response。若你需要整次运行真正的
+终止事件，仍应持续消费直到 `runner.completion`。
+
 #### FilterKey（层级作用域 key）
 
 `FilterKey` 是每条事件上的可选字段。你可以把它理解成“像路径一样的标签”，主要用在：

--- a/docs/mkdocs/zh/event.md
+++ b/docs/mkdocs/zh/event.md
@@ -284,6 +284,22 @@ if e.IsRunnerCompletion() {
 }
 ```
 
+不要混淆 `event.IsFinalResponse()` 与 `event.IsRunnerCompletion()`：
+
+- `event.IsFinalResponse()` 复用的是嵌入 `Response` 的判断逻辑。它只说明
+  当前这条响应已经结束：不是 partial、不是 tool-call response，且
+  `Response.Done == true`。这可能对应 assistant 文本、`tool.response`，
+  也可能是终止错误响应。
+- `event.IsRunnerCompletion()` 判断的是 Runner 是否发出了终止
+  `runner.completion` 事件。只有它返回 true，才表示整次 `Runner.Run`
+  已真正结束，后续不会再有新的运行事件。
+
+经验上：
+
+- 想判断“当前这条输出是否已经完整”，可使用 `IsFinalResponse()`
+- 想停止消费事件流、读取最终状态或把本次运行视为结束，应使用
+  `IsRunnerCompletion()`
+
 ### Event 创建
 
 在开发自定义 Agent 类型或 Processor 时，需要创建 Event。
@@ -514,8 +530,8 @@ func (c *multiTurnChat) processResponse(eventChan <-chan *event.Event) error {
             return err
         }
 
-        // 检查是否为最终事件
-        if event.IsFinalResponse() {
+        // 检查是否为整次运行完成事件
+        if event.IsRunnerCompletion() {
             fmt.Printf("\n")
             break
         }

--- a/docs/mkdocs/zh/tool.md
+++ b/docs/mkdocs/zh/tool.md
@@ -546,6 +546,7 @@ child := agenttool.NewTool(
 - 事件完成信号：工具响应事件会被标记 `RequiresCompletion=true`，Runner 会自动发送完成信号，无需手工处理
 - 内容去重：如果已转发子 Agent 的增量内容，默认不要再把最终 `tool.response` 的聚合内容打印出来
 - 模型兼容性：一些模型要求工具调用后必须跟随工具消息，AgentTool 已自动填充聚合后的工具内容满足此要求
+- `WithSkipSummarization(true)` 只会跳过额外的外层总结型 LLM 调用，不会把 `tool.response` 变成 assistant final response；如果你需要真正的终止信号，仍应持续消费到 `runner.completion`
 
 ## 工具集成与使用
 

--- a/examples/agenttool/main.go
+++ b/examples/agenttool/main.go
@@ -136,9 +136,11 @@ func (c *agentToolChat) setup(_ context.Context) error {
 	)
 
 	// Create agent tool that wraps the math specialist agent.
+	// SkipSummarization surfaces the child tool result directly.
+	// The run still finishes on runner.completion.
 	agentTool := agenttool.NewTool(
 		mathAgent,
-		agenttool.WithSkipSummarization(true),  // Skip summarization to get raw response
+		agenttool.WithSkipSummarization(true),
 		agenttool.WithStreamInner(c.showInner), // Stream inner agent deltas when requested
 	)
 

--- a/internal/flow/processor/functioncall.go
+++ b/internal/flow/processor/functioncall.go
@@ -346,9 +346,15 @@ func (p *FunctionCallResponseProcessor) executeSingleToolCallSequential(
 		defer span.End()
 	}
 	startTime := time.Now()
-	ctx, choices, modifiedArgs, shouldIgnoreError, err := p.executeToolCall(
-		ctx, invocation, toolCall, tools, index, eventChan,
-	)
+	ctx, choices, modifiedArgs, shouldIgnoreError, skipSummarization, err :=
+		p.executeToolCall(
+			ctx,
+			invocation,
+			toolCall,
+			tools,
+			index,
+			eventChan,
+		)
 	if err != nil {
 		if shouldIgnoreError {
 			// Create error choice for ignorable errors
@@ -359,23 +365,17 @@ func (p *FunctionCallResponseProcessor) executeSingleToolCallSequential(
 			return nil, err
 		}
 	}
-	if len(choices) == 0 {
-		return nil, nil
-	}
-	// Annotate only tool messages with ToolName for observability.
-	for i := range choices {
-		if choices[i].Message.Role == model.RoleTool && choices[i].Message.ToolName == "" {
-			choices[i].Message.ToolName = toolCall.Function.Name
-		}
-	}
-	toolEvent := newToolCallResponseEvent(
-		invocation, llmResponse, choices,
+	toolEvent := p.buildToolCallResponseEvent(
+		invocation,
+		llmResponse,
+		choices,
+		tools,
+		toolCall,
+		index,
+		skipSummarization,
 	)
-	if toolCall.Function.Name == transfer.TransferToolName {
-		toolEvent.Tag = event.TransferTag
-	}
-	if tl, ok := tools[toolCall.Function.Name]; ok {
-		p.annotateSkipSummarization(toolEvent, tl)
+	if toolEvent == nil {
+		return nil, nil
 	}
 	decl := p.lookupDeclaration(tools, toolCall.Function.Name)
 
@@ -385,7 +385,8 @@ func (p *FunctionCallResponseProcessor) executeSingleToolCallSequential(
 		agentName string
 	)
 	// Attach state delta if the tool provides it.
-	if err == nil && !hasSyntheticStateOnlyToolChoice(ctx) {
+	if err == nil && len(choices) > 0 &&
+		!hasSyntheticStateOnlyToolChoice(ctx) {
 		if tl, ok := tools[toolCall.Function.Name]; ok {
 			// Use the first choice as the canonical tool result for state
 			// delta.
@@ -519,9 +520,15 @@ func (p *FunctionCallResponseProcessor) runParallelToolCall(
 	}
 	startTime := time.Now()
 	// Execute the tool (streamable or callable) with callbacks.
-	ctx, choices, modifiedArgs, shouldIgnoreError, err := p.executeToolCall(
-		ctx, invocation, tc, tools, index, eventChan,
-	)
+	ctx, choices, modifiedArgs, shouldIgnoreError, skipSummarization, err :=
+		p.executeToolCall(
+			ctx,
+			invocation,
+			tc,
+			tools,
+			index,
+			eventChan,
+		)
 	// Handle errors based on whether they are ignorable or critical.
 	if err != nil {
 		log.ErrorfContext(
@@ -540,9 +547,12 @@ func (p *FunctionCallResponseProcessor) runParallelToolCall(
 		errorEvent := newToolCallResponseEvent(
 			invocation, llmResponse, []model.Choice{*errorChoice},
 		)
-		if tc.Function.Name == transfer.TransferToolName {
-			errorEvent.Tag = event.TransferTag
-		}
+		errorEvent = p.decorateToolCallResponseEvent(
+			errorEvent,
+			tools,
+			tc,
+			skipSummarization,
+		)
 		// Only propagate the error if it's not ignorable (e.g., stop errors)
 		var returnErr error
 		if !shouldIgnoreError {
@@ -553,27 +563,18 @@ func (p *FunctionCallResponseProcessor) runParallelToolCall(
 	}
 
 	// No error and at least one choice means we have tool result messages.
-	if len(choices) == 0 {
+	toolCallResponseEvent := p.buildToolCallResponseEvent(
+		invocation,
+		llmResponse,
+		choices,
+		tools,
+		tc,
+		index,
+		skipSummarization,
+	)
+	if toolCallResponseEvent == nil {
 		p.sendToolResult(ctx, resultChan, toolResult{index: index})
 		return
-	}
-
-	// Annotate only tool messages with ToolName for observability.
-	for i := range choices {
-		if choices[i].Message.Role == model.RoleTool && choices[i].Message.ToolName == "" {
-			choices[i].Message.ToolName = tc.Function.Name
-		}
-	}
-
-	toolCallResponseEvent := newToolCallResponseEvent(
-		invocation, llmResponse, choices,
-	)
-	if tc.Function.Name == transfer.TransferToolName {
-		toolCallResponseEvent.Tag = event.TransferTag
-	}
-	// Respect tool preference to skip outer summarization when present.
-	if tl, ok := tools[tc.Function.Name]; ok {
-		p.annotateSkipSummarization(toolCallResponseEvent, tl)
 	}
 	// Include declaration for telemetry even when tool is missing.
 	decl := p.lookupDeclaration(tools, tc.Function.Name)
@@ -595,7 +596,7 @@ func (p *FunctionCallResponseProcessor) runParallelToolCall(
 		}
 	}
 	// Attach state delta if the tool provides it.
-	if !hasSyntheticStateOnlyToolChoice(ctx) {
+	if len(choices) > 0 && !hasSyntheticStateOnlyToolChoice(ctx) {
 		if tl, ok := tools[tc.Function.Name]; ok {
 			// Use the first choice as the canonical tool result for state delta.
 			p.attachStateDelta(
@@ -623,6 +624,69 @@ func (p *FunctionCallResponseProcessor) runParallelToolCall(
 	p.sendToolResult(
 		ctx, resultChan, toolResult{index: index, event: toolCallResponseEvent},
 	)
+}
+
+func (p *FunctionCallResponseProcessor) buildToolCallResponseEvent(
+	invocation *agent.Invocation,
+	llmResponse *model.Response,
+	choices []model.Choice,
+	tools map[string]tool.Tool,
+	toolCall model.ToolCall,
+	index int,
+	skipSummarization bool,
+) *event.Event {
+	if len(choices) == 0 {
+		if !skipSummarization {
+			return nil
+		}
+		return p.decorateToolCallResponseEvent(
+			newMinimalToolCallResponseEvent(
+				invocation,
+				llmResponse,
+				toolCall,
+				index,
+			),
+			tools,
+			toolCall,
+			skipSummarization,
+		)
+	}
+	annotateToolChoicesWithName(choices, toolCall.Function.Name)
+	return p.decorateToolCallResponseEvent(
+		newToolCallResponseEvent(invocation, llmResponse, choices),
+		tools,
+		toolCall,
+		skipSummarization,
+	)
+}
+
+func annotateToolChoicesWithName(choices []model.Choice, toolName string) {
+	for i := range choices {
+		if choices[i].Message.Role == model.RoleTool &&
+			choices[i].Message.ToolName == "" {
+			choices[i].Message.ToolName = toolName
+		}
+	}
+}
+
+func (p *FunctionCallResponseProcessor) decorateToolCallResponseEvent(
+	ev *event.Event,
+	tools map[string]tool.Tool,
+	toolCall model.ToolCall,
+	skipSummarization bool,
+) *event.Event {
+	if ev == nil {
+		return nil
+	}
+	if toolCall.Function.Name == transfer.TransferToolName {
+		ev.Tag = event.TransferTag
+	}
+	if tl, ok := tools[toolCall.Function.Name]; ok {
+		p.annotateSkipSummarization(ev, tl, skipSummarization)
+	} else if skipSummarization {
+		markSkipSummarization(ev)
+	}
+	return ev
 }
 
 // attachStateDelta copies tool-provided state delta to the event.
@@ -674,19 +738,12 @@ func (p *FunctionCallResponseProcessor) attachStateDelta(
 
 // annotateSkipSummarization marks an event to skip outer summarization.
 func (p *FunctionCallResponseProcessor) annotateSkipSummarization(
-	ev *event.Event, tl tool.Tool,
+	ev *event.Event,
+	tl tool.Tool,
+	dynamic bool,
 ) {
-	// Unwrap NamedTool to inspect the original for preferences.
-	original := tl
-	if nameTool, ok := tl.(*itool.NamedTool); ok {
-		original = nameTool.Original()
-	}
-	if skipper, ok := original.(summarizationSkipper); ok &&
-		skipper.SkipSummarization() {
-		if ev.Actions == nil {
-			ev.Actions = &event.EventActions{}
-		}
-		ev.Actions.SkipSummarization = true
+	if dynamic || toolPrefersSkipSummarization(tl) {
+		markSkipSummarization(ev)
 	}
 }
 
@@ -722,28 +779,15 @@ func (p *FunctionCallResponseProcessor) buildMergedParallelEvent(
 	var mergedEvent *event.Event
 	if len(toolCallEvents) == 0 {
 		minimal := make([]model.Choice, 0, len(toolCalls))
-		for _, tc := range toolCalls {
-			minimal = append(minimal, model.Choice{
-				Index:   0,
-				Message: model.Message{Role: model.RoleTool, ToolID: tc.ID},
-			})
+		for i, tc := range toolCalls {
+			minimal = append(minimal, newMinimalToolChoice(tc, i))
 		}
 		mergedEvent = newToolCallResponseEvent(invocation, llmResponse, minimal)
 		for _, tc := range toolCalls {
-			if tl, ok := tools[tc.Function.Name]; ok {
-				// Unwrap NamedTool then check for preference.
-				original := tl
-				if nameTool, ok2 := tl.(*itool.NamedTool); ok2 {
-					original = nameTool.Original()
-				}
-				if skipper, ok2 := original.(summarizationSkipper); ok2 &&
-					skipper.SkipSummarization() {
-					if mergedEvent.Actions == nil {
-						mergedEvent.Actions = &event.EventActions{}
-					}
-					mergedEvent.Actions.SkipSummarization = true
-					break
-				}
+			if tl, ok := tools[tc.Function.Name]; ok &&
+				toolPrefersSkipSummarization(tl) {
+				markSkipSummarization(mergedEvent)
+				break
 			}
 		}
 	} else {
@@ -774,9 +818,11 @@ func (p *FunctionCallResponseProcessor) buildMergedParallelEvent(
 //
 // Returns:
 //   - context.Context: updated context from callbacks (if any)
-//   - *model.Choice: the result choice containing tool response (nil if error occurred)
+//   - []model.Choice: tool response choices (nil if no response is emitted)
 //   - []byte: the modified arguments after before-tool callbacks (for telemetry)
 //   - bool: shouldIgnoreError - true if the error is ignorable (e.g., tool not found, marshal error), false for critical errors (e.g., stop errors)
+//   - bool: skipSummarization - true if callbacks requested ending the turn
+//     after the tool response
 //   - error: any error that occurred during execution (no longer swallowed)
 func (p *FunctionCallResponseProcessor) executeToolCall(
 	ctx context.Context,
@@ -785,10 +831,11 @@ func (p *FunctionCallResponseProcessor) executeToolCall(
 	tools map[string]tool.Tool,
 	index int,
 	eventChan chan<- *event.Event,
-) (context.Context, []model.Choice, []byte, bool, error) {
+) (context.Context, []model.Choice, []byte, bool, bool, error) {
 	toolCall, tl, shouldIgnoreError, err := p.resolveToolCallTarget(ctx, invocation, toolCall, tools)
 	if err != nil || tl == nil {
-		return ctx, nil, toolCall.Function.Arguments, shouldIgnoreError, err
+		return ctx, nil, toolCall.Function.Arguments, shouldIgnoreError,
+			false, err
 	}
 
 	log.DebugfContext(
@@ -799,18 +846,25 @@ func (p *FunctionCallResponseProcessor) executeToolCall(
 	)
 
 	// Execute the tool with callbacks.
-	ctx, result, modifiedArgs, suppressDefaultToolMessage, err := p.executeToolWithCallbacks(ctx, invocation, toolCall, tl, eventChan)
+	ctx, result, modifiedArgs, suppressDefaultToolMessage,
+		skipSummarization, err := p.executeToolWithCallbacks(
+		ctx,
+		invocation,
+		toolCall,
+		tl,
+		eventChan,
+	)
 	// Only return error when it's a stop error
 	if err != nil {
 		if _, ok := agent.AsStopError(err); ok {
-			return ctx, nil, modifiedArgs, false, err
+			return ctx, nil, modifiedArgs, false, skipSummarization, err
 		}
-		return ctx, nil, modifiedArgs, true, err
+		return ctx, nil, modifiedArgs, true, skipSummarization, err
 	}
 	//  allow to return nil not provide function response.
 	if r, ok := tl.(function.LongRunner); ok && r.LongRunning() {
 		if result == nil {
-			return ctx, nil, modifiedArgs, true, nil
+			return ctx, nil, modifiedArgs, true, skipSummarization, nil
 		}
 	}
 	if suppressDefaultToolMessage {
@@ -822,7 +876,7 @@ func (p *FunctionCallResponseProcessor) executeToolCall(
 				toolCall.Function.Name,
 				err,
 			)
-			return ctx, nil, modifiedArgs, true,
+			return ctx, nil, modifiedArgs, true, skipSummarization,
 				fmt.Errorf("%s: %w", ErrorMarshalResult, err)
 		}
 		defaultChoices := []model.Choice{
@@ -830,7 +884,8 @@ func (p *FunctionCallResponseProcessor) executeToolCall(
 		}
 		ctx = markSyntheticStateOnlyToolChoice(ctx)
 		if p.toolCallbacks == nil || p.toolCallbacks.ToolResultMessages == nil {
-			return ctx, defaultChoices, modifiedArgs, true, nil
+			return ctx, defaultChoices, modifiedArgs, true,
+				skipSummarization, nil
 		}
 		customChoices, overridden, cbErr := p.applyToolResultMessagesCallback(
 			ctx,
@@ -842,12 +897,14 @@ func (p *FunctionCallResponseProcessor) executeToolCall(
 			defaultMsg,
 		)
 		if cbErr != nil {
-			return ctx, nil, modifiedArgs, true, cbErr
+			return ctx, nil, modifiedArgs, true, skipSummarization, cbErr
 		}
 		if overridden {
-			return ctx, customChoices, modifiedArgs, true, nil
+			return ctx, customChoices, modifiedArgs, true,
+				skipSummarization, nil
 		}
-		return ctx, defaultChoices, modifiedArgs, true, nil
+		return ctx, defaultChoices, modifiedArgs, true,
+			skipSummarization, nil
 	}
 
 	defaultMsg, err := buildDefaultToolMessage(toolCall.ID, result)
@@ -861,7 +918,7 @@ func (p *FunctionCallResponseProcessor) executeToolCall(
 			toolCall.Function.Name,
 			err,
 		)
-		return ctx, nil, modifiedArgs, true,
+		return ctx, nil, modifiedArgs, true, skipSummarization,
 			fmt.Errorf("%s: %w", ErrorMarshalResult, err)
 	}
 
@@ -882,7 +939,7 @@ func (p *FunctionCallResponseProcessor) executeToolCall(
 				defaultMsg,
 			)
 		if cbErr != nil {
-			return ctx, nil, modifiedArgs, true, cbErr
+			return ctx, nil, modifiedArgs, true, skipSummarization, cbErr
 		}
 		if overridden {
 			choices = customChoices
@@ -896,7 +953,7 @@ func (p *FunctionCallResponseProcessor) executeToolCall(
 		defaultMsg.Content,
 	)
 
-	return ctx, choices, modifiedArgs, true, nil
+	return ctx, choices, modifiedArgs, true, skipSummarization, nil
 }
 
 // resolveToolCallTarget resolves the callable tool, applies compatibility remapping,
@@ -1139,14 +1196,14 @@ func (p *FunctionCallResponseProcessor) runAfterToolPluginCallbacks(
 	toolDeclaration *tool.Declaration,
 	toolResult any,
 	toolErr error,
-) (context.Context, any, bool, error) {
+) (context.Context, any, bool, bool, error) {
 	if invocation == nil || invocation.Plugins == nil {
-		return ctx, toolResult, false, nil
+		return ctx, toolResult, false, false, nil
 	}
 
 	callbacks := invocation.Plugins.ToolCallbacks()
 	if callbacks == nil {
-		return ctx, toolResult, false, nil
+		return ctx, toolResult, false, false, nil
 	}
 
 	args := &tool.AfterToolArgs{
@@ -1166,16 +1223,18 @@ func (p *FunctionCallResponseProcessor) runAfterToolPluginCallbacks(
 			toolCall.Function.Name,
 			err,
 		)
-		return ctx, toolResult, false,
+		return ctx, toolResult, false, false,
 			fmt.Errorf("tool callback error: %w", err)
 	}
 	if afterResult != nil && afterResult.Context != nil {
 		ctx = afterResult.Context
 	}
+	skipSummarization := afterResult != nil &&
+		afterResult.SkipSummarization
 	if afterResult != nil && afterResult.CustomResult != nil {
-		return ctx, afterResult.CustomResult, true, nil
+		return ctx, afterResult.CustomResult, true, skipSummarization, nil
 	}
-	return ctx, toolResult, false, nil
+	return ctx, toolResult, false, skipSummarization, nil
 }
 
 func (p *FunctionCallResponseProcessor) runAfterToolCallbacks(
@@ -1184,9 +1243,9 @@ func (p *FunctionCallResponseProcessor) runAfterToolCallbacks(
 	toolDeclaration *tool.Declaration,
 	toolResult any,
 	toolErr error,
-) (context.Context, any, error) {
+) (context.Context, any, bool, error) {
 	if p.toolCallbacks == nil {
-		return ctx, toolResult, nil
+		return ctx, toolResult, false, nil
 	}
 
 	args := &tool.AfterToolArgs{
@@ -1206,16 +1265,19 @@ func (p *FunctionCallResponseProcessor) runAfterToolCallbacks(
 			toolCall.Function.Name,
 			err,
 		)
-		return ctx, toolResult, fmt.Errorf("tool callback error: %w", err)
+		return ctx, toolResult, false,
+			fmt.Errorf("tool callback error: %w", err)
 	}
 
 	if afterResult != nil && afterResult.Context != nil {
 		ctx = afterResult.Context
 	}
+	skipSummarization := afterResult != nil &&
+		afterResult.SkipSummarization
 	if afterResult != nil && afterResult.CustomResult != nil {
 		toolResult = afterResult.CustomResult
 	}
-	return ctx, toolResult, nil
+	return ctx, toolResult, skipSummarization, nil
 }
 
 // extractMetaFromResult extracts metadata from tool result.
@@ -1235,14 +1297,15 @@ func extractMetaFromResult(result any) map[string]any {
 }
 
 // executeToolWithCallbacks executes a tool with before/after callbacks.
-// Returns (context, result, modifiedArguments, suppressDefaultToolMessage, error).
+// Returns (context, result, modifiedArguments, suppressDefaultToolMessage,
+// skipSummarization, error).
 func (p *FunctionCallResponseProcessor) executeToolWithCallbacks(
 	ctx context.Context,
 	invocation *agent.Invocation,
 	toolCall model.ToolCall,
 	tl tool.Tool,
 	eventChan chan<- *event.Event,
-) (context.Context, any, []byte, bool, error) {
+) (context.Context, any, []byte, bool, bool, error) {
 	// Inject tool call ID into context for callbacks to use.
 	ctx = context.WithValue(ctx, tool.ContextKeyToolCallID{}, toolCall.ID)
 	// Repair tool call arguments in place when needed.
@@ -1257,10 +1320,11 @@ func (p *FunctionCallResponseProcessor) executeToolWithCallbacks(
 		toolDeclaration,
 	)
 	if err != nil {
-		return ctx, nil, toolCall.Function.Arguments, false, err
+		return ctx, nil, toolCall.Function.Arguments, false, false, err
 	}
 	if customResult != nil {
-		return ctx, customResult, toolCall.Function.Arguments, false, nil
+		return ctx, customResult, toolCall.Function.Arguments, false,
+			false, nil
 	}
 	ctx, toolCall, customResult, err = p.runBeforeToolCallbacks(
 		ctx,
@@ -1268,10 +1332,11 @@ func (p *FunctionCallResponseProcessor) executeToolWithCallbacks(
 		toolDeclaration,
 	)
 	if err != nil {
-		return ctx, nil, toolCall.Function.Arguments, false, err
+		return ctx, nil, toolCall.Function.Arguments, false, false, err
 	}
 	if customResult != nil {
-		return ctx, customResult, toolCall.Function.Arguments, false, nil
+		return ctx, customResult, toolCall.Function.Arguments, false,
+			false, nil
 	}
 	// Execute the actual tool.
 	ctx, toolResult, suppressDefaultToolMessage, toolErr := p.executeTool(
@@ -1292,24 +1357,27 @@ func (p *FunctionCallResponseProcessor) executeToolWithCallbacks(
 			toolErr,
 		)
 	}
-	ctx, toolResult, pluginOverride, err := p.runAfterToolPluginCallbacks(
-		ctx,
-		invocation,
-		toolCall,
-		toolDeclaration,
-		toolResult,
-		toolErr,
-	)
+	ctx, toolResult, pluginOverride, skipSummarization, err :=
+		p.runAfterToolPluginCallbacks(
+			ctx,
+			invocation,
+			toolCall,
+			toolDeclaration,
+			toolResult,
+			toolErr,
+		)
 	if err != nil {
-		return ctx, toolResult, toolCall.Function.Arguments, suppressDefaultToolMessage, err
+		return ctx, toolResult, toolCall.Function.Arguments,
+			suppressDefaultToolMessage, skipSummarization, err
 	}
 	if pluginOverride {
 		if toolResult != nil {
 			suppressDefaultToolMessage = false
 		}
-		return ctx, toolResult, toolCall.Function.Arguments, suppressDefaultToolMessage, toolErr
+		return ctx, toolResult, toolCall.Function.Arguments,
+			suppressDefaultToolMessage, skipSummarization, toolErr
 	}
-	ctx, toolResult, err = p.runAfterToolCallbacks(
+	ctx, toolResult, localSkip, err := p.runAfterToolCallbacks(
 		ctx,
 		toolCall,
 		toolDeclaration,
@@ -1317,12 +1385,14 @@ func (p *FunctionCallResponseProcessor) executeToolWithCallbacks(
 		toolErr,
 	)
 	if err != nil {
-		return ctx, toolResult, toolCall.Function.Arguments, suppressDefaultToolMessage, err
+		return ctx, toolResult, toolCall.Function.Arguments,
+			suppressDefaultToolMessage, skipSummarization || localSkip, err
 	}
 	if toolResult != nil {
 		suppressDefaultToolMessage = false
 	}
-	return ctx, toolResult, toolCall.Function.Arguments, suppressDefaultToolMessage, toolErr
+	return ctx, toolResult, toolCall.Function.Arguments,
+		suppressDefaultToolMessage, skipSummarization || localSkip, toolErr
 }
 
 // isStreamable returns true if the tool supports streaming and its stream
@@ -1720,6 +1790,33 @@ func newToolCallResponseEvent(
 	return e
 }
 
+func newMinimalToolCallResponseEvent(
+	invocation *agent.Invocation,
+	functionCallResponse *model.Response,
+	toolCall model.ToolCall,
+	index int,
+) *event.Event {
+	return newToolCallResponseEvent(
+		invocation,
+		functionCallResponse,
+		[]model.Choice{newMinimalToolChoice(toolCall, index)},
+	)
+}
+
+func newMinimalToolChoice(
+	toolCall model.ToolCall,
+	index int,
+) model.Choice {
+	return model.Choice{
+		Index: index,
+		Message: model.Message{
+			Role:     model.RoleTool,
+			ToolID:   toolCall.ID,
+			ToolName: toolCall.Function.Name,
+		},
+	}
+}
+
 func mergeParallelToolCallResponseEvents(es []*event.Event) *event.Event {
 	switch len(es) {
 	case 0:
@@ -1739,10 +1836,7 @@ func mergeParallelToolCallResponseEvents(es []*event.Event) *event.Event {
 		mergedEvent.StateDelta = mergedDelta
 	}
 	if shouldSkipSummarization(es) {
-		if mergedEvent.Actions == nil {
-			mergedEvent.Actions = &event.EventActions{}
-		}
-		mergedEvent.Actions.SkipSummarization = true
+		markSkipSummarization(mergedEvent)
 	}
 	return mergedEvent
 }
@@ -1822,6 +1916,30 @@ func shouldSkipSummarization(es []*event.Event) bool {
 		if e != nil && e.Actions != nil && e.Actions.SkipSummarization {
 			return true
 		}
+	}
+	return false
+}
+
+func markSkipSummarization(ev *event.Event) {
+	if ev == nil {
+		return
+	}
+	if ev.Actions == nil {
+		ev.Actions = &event.EventActions{}
+	}
+	ev.Actions.SkipSummarization = true
+}
+
+func toolPrefersSkipSummarization(tl tool.Tool) bool {
+	if tl == nil {
+		return false
+	}
+	original := tl
+	if nameTool, ok := tl.(*itool.NamedTool); ok {
+		original = nameTool.Original()
+	}
+	if skipper, ok := original.(summarizationSkipper); ok {
+		return skipper.SkipSummarization()
 	}
 	return false
 }

--- a/internal/flow/processor/functioncall_test.go
+++ b/internal/flow/processor/functioncall_test.go
@@ -269,7 +269,9 @@ func TestExecuteToolCall_MapsSubAgentToTransfer(t *testing.T) {
 		},
 	}
 
-	_, choices, _, _, err := p.executeToolCall(ctx, inv, pc, tools, 0, nil)
+	_, choices, _, _, _, err := p.executeToolCall(
+		ctx, inv, pc, tools, 0, nil,
+	)
 	require.NoError(t, err)
 	require.NotNil(t, choices)
 	require.NotEmpty(t, choices)
@@ -352,7 +354,9 @@ func TestExecuteToolCall(t *testing.T) {
 		},
 	}
 
-	_, choices, _, _, err := p.executeToolCall(ctx, inv, pc, tools, 0, nil)
+	_, choices, _, _, _, err := p.executeToolCall(
+		ctx, inv, pc, tools, 0, nil,
+	)
 	res, _ := json.Marshal("Tokyo'weather is good")
 	require.NoError(t, err)
 	require.Len(t, choices, 1)
@@ -382,7 +386,7 @@ func TestExecuteToolCall_StreamableFinalStateOnlyResultSkipsNullToolMessage(t *t
 		},
 	}
 	eventCh := make(chan *event.Event, 4)
-	_, choices, _, _, err := p.executeToolCall(
+	_, choices, _, _, _, err := p.executeToolCall(
 		ctx,
 		inv,
 		tc,
@@ -441,7 +445,9 @@ func TestExecuteToolCall_ToolResultMessagesCallback_Nil_NoOverride(t *testing.T)
 		},
 	}
 
-	_, choices, _, _, err := p.executeToolCall(ctx, inv, pc, tools, 0, nil)
+	_, choices, _, _, _, err := p.executeToolCall(
+		ctx, inv, pc, tools, 0, nil,
+	)
 	require.NoError(t, err)
 	require.True(t, called, "ToolResultMessages callback should be invoked")
 	require.Len(t, choices, 1)
@@ -485,7 +491,9 @@ func TestExecuteToolCall_ToolResultMessagesCallback_OverrideWithSingleMessage(t 
 		},
 	}
 
-	_, choices, _, _, err := p.executeToolCall(ctx, inv, pc, tools, 0, nil)
+	_, choices, _, _, _, err := p.executeToolCall(
+		ctx, inv, pc, tools, 0, nil,
+	)
 	require.NoError(t, err)
 	require.Len(t, choices, 1)
 
@@ -533,7 +541,9 @@ func TestExecuteToolCall_ToolResultMessagesCallback_OverrideWithMultipleMessages
 		},
 	}
 
-	_, choices, _, _, err := p.executeToolCall(ctx, inv, pc, tools, 0, nil)
+	_, choices, _, _, _, err := p.executeToolCall(
+		ctx, inv, pc, tools, 0, nil,
+	)
 	require.NoError(t, err)
 	require.Len(t, choices, 2)
 
@@ -573,7 +583,9 @@ func TestExecuteToolCall_ToolResultMessagesCallback_Error(t *testing.T) {
 		},
 	}
 
-	_, choices, _, shouldIgnore, err := p.executeToolCall(ctx, inv, tc, tools, 0, nil)
+	_, choices, _, shouldIgnore, _, err := p.executeToolCall(
+		ctx, inv, tc, tools, 0, nil,
+	)
 	require.Error(t, err)
 	require.True(t, shouldIgnore)
 	require.Nil(t, choices)
@@ -618,7 +630,7 @@ func TestExecuteToolCall_ToolResultMessagesCallback_Panic(t *testing.T) {
 	var err error
 	var shouldIgnore bool
 	require.NotPanics(t, func() {
-		_, _, _, shouldIgnore, err = p.executeToolCall(
+		_, _, _, shouldIgnore, _, err = p.executeToolCall(
 			ctx,
 			inv,
 			tc,
@@ -663,7 +675,9 @@ func TestExecuteToolCall_ToolResultMessagesCallback_UnsupportedReturnType(t *tes
 		},
 	}
 
-	_, choices, _, shouldIgnore, err := p.executeToolCall(ctx, inv, tc, tools, 0, nil)
+	_, choices, _, shouldIgnore, _, err := p.executeToolCall(
+		ctx, inv, tc, tools, 0, nil,
+	)
 	require.NoError(t, err)
 	require.True(t, shouldIgnore)
 	require.Len(t, choices, 1)
@@ -2110,7 +2124,9 @@ func TestExecuteToolCall_ToolNotFound_ReturnsErrorChoice(t *testing.T) {
 		},
 	}
 
-	_, choices, _, shouldIgnoreError, err := p.executeToolCall(ctx, inv, pc2, tools, 0, nil)
+	_, choices, _, shouldIgnoreError, _, err := p.executeToolCall(
+		ctx, inv, pc2, tools, 0, nil,
+	)
 	require.True(t, shouldIgnoreError)
 	require.Contains(t, err.Error(), ErrorToolNotFound)
 	require.Nil(t, choices)
@@ -2344,7 +2360,7 @@ func TestExecuteToolCall_MarshalError_IsIgnorable(t *testing.T) {
 	tools := map[string]tool.Tool{
 		"bad": &badResultTool{dec: &tool.Declaration{Name: "bad"}},
 	}
-	_, choices, _, ignorable, err := p.executeToolCall(
+	_, choices, _, ignorable, _, err := p.executeToolCall(
 		ctx, inv, pc, tools, 0, nil,
 	)
 	require.Error(t, err)
@@ -2712,7 +2728,7 @@ func TestExecuteToolCall_MarshalErrorIgnored(t *testing.T) {
 			Arguments: []byte(`{}`),
 		},
 	}
-	_, choices, _, ign, err := p.executeToolCall(
+	_, choices, _, ign, _, err := p.executeToolCall(
 		ctx, inv, tc, tools, 0, nil,
 	)
 	require.True(t, ign)
@@ -2835,6 +2851,248 @@ func TestHandleFunctionCalls_SkipSummarization_Parallel_PropagatesFlag(t *testin
 	require.True(t, evt.Actions.SkipSummarization)
 	// Parallel path returns early from handleFunctionCalls (via executeToolCallsInParallel),
 	// so EndInvocation is not toggled here. We only verify flag propagation.
+}
+
+func TestProcessResponse_AfterToolCallbackSkipSummarizationEndsInvocation(
+	t *testing.T,
+) {
+	callbacks := tool.NewCallbacks()
+	callbacks.RegisterAfterTool(func(
+		ctx context.Context,
+		args *tool.AfterToolArgs,
+	) (*tool.AfterToolResult, error) {
+		out, ok := args.Result.(map[string]any)
+		require.True(t, ok)
+		return &tool.AfterToolResult{
+			SkipSummarization: out["final"] == true,
+		}, nil
+	})
+
+	p := NewFunctionCallResponseProcessor(false, callbacks)
+	tl := &mockCallableTool{
+		declaration: &tool.Declaration{Name: "t"},
+		callFn: func(_ context.Context, _ []byte) (any, error) {
+			return map[string]any{"final": true}, nil
+		},
+	}
+	tools := map[string]tool.Tool{"t": tl}
+	inv := &agent.Invocation{InvocationID: "inv-cb", AgentName: "agent"}
+	req := &model.Request{Tools: tools}
+	rsp := &model.Response{Model: "m", Choices: []model.Choice{{
+		Message: model.Message{ToolCalls: []model.ToolCall{{
+			ID: "c1",
+			Function: model.FunctionDefinitionParam{
+				Name:      "t",
+				Arguments: []byte("{}"),
+			},
+		}}},
+	}}}
+
+	ch := make(chan *event.Event, 4)
+	defer close(ch)
+	p.ProcessResponse(context.Background(), inv, req, rsp, ch)
+
+	var got *event.Event
+	for e := range ch {
+		got = e
+		break
+	}
+	require.NotNil(t, got)
+	require.NotNil(t, got.Response)
+	require.NotNil(t, got.Actions)
+	require.True(t, got.Actions.SkipSummarization)
+	require.False(t, got.Response.Done)
+	require.False(t, got.IsFinalResponse())
+	require.True(t, inv.EndInvocation)
+}
+
+func TestProcessResponse_AfterToolCallbackSkipSummarization_LongRunningNilResult(
+	t *testing.T,
+) {
+	callbacks := tool.NewCallbacks()
+	callbacks.RegisterAfterTool(func(
+		ctx context.Context,
+		args *tool.AfterToolArgs,
+	) (*tool.AfterToolResult, error) {
+		require.Nil(t, args.Result)
+		return &tool.AfterToolResult{SkipSummarization: true}, nil
+	})
+
+	p := NewFunctionCallResponseProcessor(false, callbacks)
+	tl := &skipSummCallableTool{
+		declaration: &tool.Declaration{Name: "t"},
+		result:      nil,
+		longRun:     true,
+	}
+	tools := map[string]tool.Tool{"t": tl}
+	inv := &agent.Invocation{InvocationID: "inv-nil", AgentName: "agent"}
+	req := &model.Request{Tools: tools}
+	rsp := &model.Response{Model: "m", Choices: []model.Choice{{
+		Message: model.Message{ToolCalls: []model.ToolCall{{
+			ID: "c1",
+			Function: model.FunctionDefinitionParam{
+				Name:      "t",
+				Arguments: []byte("{}"),
+			},
+		}}},
+	}}}
+
+	ch := make(chan *event.Event, 4)
+	defer close(ch)
+	p.ProcessResponse(context.Background(), inv, req, rsp, ch)
+
+	var got *event.Event
+	for e := range ch {
+		got = e
+		break
+	}
+	require.NotNil(t, got)
+	require.NotNil(t, got.Response)
+	require.NotNil(t, got.Actions)
+	require.True(t, got.Actions.SkipSummarization)
+	require.Len(t, got.Response.Choices, 1)
+	require.Equal(t, 0, got.Response.Choices[0].Index)
+	require.Equal(t, "c1", got.Response.Choices[0].Message.ToolID)
+	require.Equal(t, "t", got.Response.Choices[0].Message.ToolName)
+	require.Empty(t, got.Response.Choices[0].Message.Content)
+	require.False(t, got.Response.Done)
+	require.False(t, got.IsFinalResponse())
+	require.True(t, inv.EndInvocation)
+}
+
+func TestHandleFunctionCalls_AfterToolCallbackSkipSummarizationParallelError(
+	t *testing.T,
+) {
+	callbacks := tool.NewCallbacks()
+	callbacks.RegisterAfterTool(func(
+		ctx context.Context,
+		args *tool.AfterToolArgs,
+	) (*tool.AfterToolResult, error) {
+		if args.Error == nil {
+			return nil, nil
+		}
+		return &tool.AfterToolResult{SkipSummarization: true}, nil
+	})
+
+	p := NewFunctionCallResponseProcessor(true, callbacks)
+	tErr := &mockCallableTool{
+		declaration: &tool.Declaration{Name: "te"},
+		callFn: func(_ context.Context, _ []byte) (any, error) {
+			return nil, fmt.Errorf("boom")
+		},
+	}
+	tOther := &mockCallableTool{
+		declaration: &tool.Declaration{Name: "to"},
+		callFn: func(_ context.Context, _ []byte) (any, error) {
+			return map[string]any{"ok": true}, nil
+		},
+	}
+	tools := map[string]tool.Tool{"te": tErr, "to": tOther}
+	inv := &agent.Invocation{InvocationID: "inv-perr", AgentName: "agent"}
+	toolCalls := []model.ToolCall{
+		{
+			ID: "c1",
+			Function: model.FunctionDefinitionParam{
+				Name:      "te",
+				Arguments: []byte("{}"),
+			},
+		},
+		{
+			ID: "c2",
+			Function: model.FunctionDefinitionParam{
+				Name:      "to",
+				Arguments: []byte("{}"),
+			},
+		},
+	}
+	rsp := &model.Response{
+		Model:   "m",
+		Choices: []model.Choice{{Message: model.Message{ToolCalls: toolCalls}}},
+	}
+
+	evt, err := p.handleFunctionCalls(context.Background(), inv, rsp, tools, nil)
+	require.NoError(t, err)
+	require.NotNil(t, evt)
+	require.NotNil(t, evt.Response)
+	require.NotNil(t, evt.Actions)
+	require.True(t, evt.Actions.SkipSummarization)
+	require.False(t, evt.Response.Done)
+	require.False(t, evt.IsFinalResponse())
+}
+
+func TestHandleFunctionCalls_AfterToolCallbackSkipSummarizationParallelLongRunningNilResult(
+	t *testing.T,
+) {
+	callbacks := tool.NewCallbacks()
+	callbacks.RegisterAfterTool(func(
+		ctx context.Context,
+		args *tool.AfterToolArgs,
+	) (*tool.AfterToolResult, error) {
+		if args.Result != nil {
+			return nil, nil
+		}
+		return &tool.AfterToolResult{SkipSummarization: true}, nil
+	})
+
+	p := NewFunctionCallResponseProcessor(true, callbacks)
+	tNil := &skipSummCallableTool{
+		declaration: &tool.Declaration{Name: "tn"},
+		result:      nil,
+		longRun:     true,
+	}
+	tOther := &mockCallableTool{
+		declaration: &tool.Declaration{Name: "to"},
+		callFn: func(_ context.Context, _ []byte) (any, error) {
+			return map[string]any{"ok": true}, nil
+		},
+	}
+	tools := map[string]tool.Tool{"to": tOther, "tn": tNil}
+	inv := &agent.Invocation{InvocationID: "inv-par-nil", AgentName: "agent"}
+	toolCalls := []model.ToolCall{
+		{
+			ID: "c1",
+			Function: model.FunctionDefinitionParam{
+				Name:      "to",
+				Arguments: []byte("{}"),
+			},
+		},
+		{
+			ID: "c2",
+			Function: model.FunctionDefinitionParam{
+				Name:      "tn",
+				Arguments: []byte("{}"),
+			},
+		},
+	}
+	rsp := &model.Response{
+		Model:   "m",
+		Choices: []model.Choice{{Message: model.Message{ToolCalls: toolCalls}}},
+	}
+
+	evt, err := p.handleFunctionCalls(context.Background(), inv, rsp, tools, nil)
+	require.NoError(t, err)
+	require.NotNil(t, evt)
+	require.NotNil(t, evt.Response)
+	require.NotNil(t, evt.Actions)
+	require.True(t, evt.Actions.SkipSummarization)
+	require.Len(t, evt.Response.Choices, 2)
+	require.False(t, evt.Response.Done)
+	require.False(t, evt.IsFinalResponse())
+
+	indices := map[string]int{}
+	var nilChoice *model.Choice
+	for i := range evt.Response.Choices {
+		choice := &evt.Response.Choices[i]
+		indices[choice.Message.ToolID] = choice.Index
+		if choice.Message.ToolID == "c2" {
+			nilChoice = choice
+		}
+	}
+	require.Equal(t, 0, indices["c1"])
+	require.Equal(t, 1, indices["c2"])
+	require.NotNil(t, nilChoice)
+	require.Equal(t, "tn", nilChoice.Message.ToolName)
+	require.Empty(t, nilChoice.Message.Content)
 }
 
 // stream tool forwarding a single final assistant message (no deltas).
@@ -4381,7 +4639,13 @@ func TestExecuteToolWithCallbacks_BeforeCustomResult(t *testing.T) {
 	inv := &agent.Invocation{}
 	tl := &mockCallableTool{declaration: &tool.Declaration{Name: "t"},
 		callFn: func(_ context.Context, _ []byte) (any, error) { return "x", nil }}
-	_, res, _, _, err := p.executeToolWithCallbacks(ctx, inv, model.ToolCall{Function: model.FunctionDefinitionParam{Name: "t"}}, tl, nil)
+	_, res, _, _, _, err := p.executeToolWithCallbacks(
+		ctx,
+		inv,
+		model.ToolCall{Function: model.FunctionDefinitionParam{Name: "t"}},
+		tl,
+		nil,
+	)
 	require.NoError(t, err)
 	b, _ := json.Marshal(map[string]any{"v": 1})
 	require.JSONEq(t, string(b), string(mustJSON(res)))
@@ -4447,7 +4711,7 @@ func TestExecuteToolWithCallbacks_PluginBeforeToolShortCircuit(t *testing.T) {
 		Function: model.FunctionDefinitionParam{Name: "t"},
 	}
 
-	_, res, _, _, err := proc.executeToolWithCallbacks(
+	_, res, _, _, _, err := proc.executeToolWithCallbacks(
 		context.Background(),
 		inv,
 		toolCall,
@@ -4506,7 +4770,7 @@ func TestExecuteToolWithCallbacks_PluginAfterToolOverrides(t *testing.T) {
 		Function: model.FunctionDefinitionParam{Name: "t"},
 	}
 
-	_, res, _, _, err := proc.executeToolWithCallbacks(
+	_, res, _, _, _, err := proc.executeToolWithCallbacks(
 		context.Background(),
 		inv,
 		toolCall,
@@ -4549,7 +4813,7 @@ func TestExecuteToolWithCallbacks_AfterToolReceivesNormalizedResultAndMeta(t *te
 		},
 	}
 
-	_, res, _, _, err := proc.executeToolWithCallbacks(
+	_, res, _, _, _, err := proc.executeToolWithCallbacks(
 		context.Background(),
 		nil,
 		model.ToolCall{Function: model.FunctionDefinitionParam{Name: "t"}},
@@ -4561,6 +4825,41 @@ func TestExecuteToolWithCallbacks_AfterToolReceivesNormalizedResultAndMeta(t *te
 	require.Equal(t, expectedResult, gotResult)
 	require.Equal(t, expectedMeta, gotMeta)
 	require.Same(t, rawResult, res)
+}
+
+func TestExecuteToolWithCallbacks_AfterToolCanRequestSkipSummarization(
+	t *testing.T,
+) {
+	callbacks := tool.NewCallbacks()
+	callbacks.RegisterAfterTool(func(
+		ctx context.Context,
+		args *tool.AfterToolArgs,
+	) (*tool.AfterToolResult, error) {
+		out, ok := args.Result.(map[string]any)
+		require.True(t, ok)
+		return &tool.AfterToolResult{
+			SkipSummarization: out["final"] == true,
+		}, nil
+	})
+
+	proc := NewFunctionCallResponseProcessor(false, callbacks)
+	tl := &mockCallableTool{
+		declaration: &tool.Declaration{Name: "t"},
+		callFn: func(_ context.Context, _ []byte) (any, error) {
+			return map[string]any{"final": true}, nil
+		},
+	}
+
+	_, res, _, _, skipSummarization, err := proc.executeToolWithCallbacks(
+		context.Background(),
+		nil,
+		model.ToolCall{Function: model.FunctionDefinitionParam{Name: "t"}},
+		tl,
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{"final": true}, res)
+	require.True(t, skipSummarization)
 }
 
 func TestExecuteToolWithCallbacks_PluginAfterToolReceivesNormalizedResultAndMeta(t *testing.T) {
@@ -4601,7 +4900,7 @@ func TestExecuteToolWithCallbacks_PluginAfterToolReceivesNormalizedResultAndMeta
 		},
 	}
 
-	_, res, _, _, err := proc.executeToolWithCallbacks(
+	_, res, _, _, _, err := proc.executeToolWithCallbacks(
 		context.Background(),
 		inv,
 		model.ToolCall{Function: model.FunctionDefinitionParam{Name: "t"}},
@@ -4613,6 +4912,47 @@ func TestExecuteToolWithCallbacks_PluginAfterToolReceivesNormalizedResultAndMeta
 	require.Equal(t, expectedResult, gotResult)
 	require.Equal(t, expectedMeta, gotMeta)
 	require.Same(t, rawResult, res)
+}
+
+func TestExecuteToolWithCallbacks_PluginAfterToolCanRequestSkipSummarization(
+	t *testing.T,
+) {
+	p := &hookPlugin{
+		name: "p",
+		reg: func(r *plugin.Registry) {
+			r.AfterTool(func(
+				ctx context.Context,
+				args *tool.AfterToolArgs,
+			) (*tool.AfterToolResult, error) {
+				out, ok := args.Result.(map[string]any)
+				require.True(t, ok)
+				return &tool.AfterToolResult{
+					SkipSummarization: out["final"] == true,
+				}, nil
+			})
+		},
+	}
+
+	pm := plugin.MustNewManager(p)
+	proc := NewFunctionCallResponseProcessor(false, nil)
+	inv := &agent.Invocation{Plugins: pm}
+	tl := &mockCallableTool{
+		declaration: &tool.Declaration{Name: "t"},
+		callFn: func(_ context.Context, _ []byte) (any, error) {
+			return map[string]any{"final": true}, nil
+		},
+	}
+
+	_, res, _, _, skipSummarization, err := proc.executeToolWithCallbacks(
+		context.Background(),
+		inv,
+		model.ToolCall{Function: model.FunctionDefinitionParam{Name: "t"}},
+		tl,
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{"final": true}, res)
+	require.True(t, skipSummarization)
 }
 
 func TestExecuteToolWithCallbacks_PluginBeforeToolError(t *testing.T) {
@@ -4657,7 +4997,7 @@ func TestExecuteToolWithCallbacks_PluginBeforeToolError(t *testing.T) {
 		Function: model.FunctionDefinitionParam{Name: "t"},
 	}
 
-	_, _, _, _, err := proc.executeToolWithCallbacks(
+	_, _, _, _, _, err := proc.executeToolWithCallbacks(
 		context.Background(),
 		inv,
 		toolCall,
@@ -4726,7 +5066,7 @@ func TestExecuteToolWithCallbacks_PluginBeforeToolArgsModified(
 		},
 	}
 
-	_, _, gotArgs, _, err := proc.executeToolWithCallbacks(
+	_, _, gotArgs, _, _, err := proc.executeToolWithCallbacks(
 		context.Background(),
 		inv,
 		toolCall,
@@ -4760,7 +5100,13 @@ func TestExecuteToolWithCallbacks_RepairsToolCallArgumentsWhenEnabled(t *testing
 		},
 	}
 
-	_, res, _, _, err := proc.executeToolWithCallbacks(context.Background(), inv, toolCall, tl, nil)
+	_, res, _, _, _, err := proc.executeToolWithCallbacks(
+		context.Background(),
+		inv,
+		toolCall,
+		tl,
+		nil,
+	)
 	require.NoError(t, err)
 	require.Equal(t, "ok", res)
 	require.Equal(t, "{\"a\":2}", toolArgs)
@@ -4793,7 +5139,7 @@ func TestExecuteToolWithCallbacks_PluginAfterToolError(t *testing.T) {
 		Function: model.FunctionDefinitionParam{Name: "t"},
 	}
 
-	_, _, _, _, err := proc.executeToolWithCallbacks(
+	_, _, _, _, _, err := proc.executeToolWithCallbacks(
 		context.Background(),
 		inv,
 		toolCall,
@@ -4850,7 +5196,7 @@ func TestExecuteToolWithCallbacks_PluginAfterToolOverridePreservesErr(
 		Function: model.FunctionDefinitionParam{Name: "t"},
 	}
 
-	_, res, _, _, err := proc.executeToolWithCallbacks(
+	_, res, _, _, _, err := proc.executeToolWithCallbacks(
 		context.Background(),
 		inv,
 		toolCall,
@@ -4873,7 +5219,13 @@ func TestExecuteToolWithCallbacks_BeforeError(t *testing.T) {
 	inv := &agent.Invocation{}
 	tl := &mockCallableTool{declaration: &tool.Declaration{Name: "t"},
 		callFn: func(_ context.Context, _ []byte) (any, error) { return "x", nil }}
-	_, _, _, _, err := p.executeToolWithCallbacks(ctx, inv, model.ToolCall{Function: model.FunctionDefinitionParam{Name: "t"}}, tl, nil)
+	_, _, _, _, _, err := p.executeToolWithCallbacks(
+		ctx,
+		inv,
+		model.ToolCall{Function: model.FunctionDefinitionParam{Name: "t"}},
+		tl,
+		nil,
+	)
 	require.Error(t, err)
 }
 
@@ -4888,7 +5240,13 @@ func TestExecuteToolWithCallbacks_AfterOverrideAndError(t *testing.T) {
 	inv := &agent.Invocation{}
 	tl := &mockCallableTool{declaration: &tool.Declaration{Name: "t"},
 		callFn: func(_ context.Context, _ []byte) (any, error) { return "x", nil }}
-	_, res, _, _, err := p.executeToolWithCallbacks(ctx, inv, model.ToolCall{Function: model.FunctionDefinitionParam{Name: "t"}}, tl, nil)
+	_, res, _, _, _, err := p.executeToolWithCallbacks(
+		ctx,
+		inv,
+		model.ToolCall{Function: model.FunctionDefinitionParam{Name: "t"}},
+		tl,
+		nil,
+	)
 	require.NoError(t, err)
 	b, _ := json.Marshal(map[string]any{"ok": true})
 	require.JSONEq(t, string(b), string(mustJSON(res)))
@@ -4901,7 +5259,13 @@ func TestExecuteToolWithCallbacks_AfterOverrideAndError(t *testing.T) {
 	})
 	inv2 := &agent.Invocation{}
 	p.toolCallbacks = cb
-	_, _, _, _, err = p.executeToolWithCallbacks(ctx, inv2, model.ToolCall{Function: model.FunctionDefinitionParam{Name: "t"}}, tl, nil)
+	_, _, _, _, _, err = p.executeToolWithCallbacks(
+		ctx,
+		inv2,
+		model.ToolCall{Function: model.FunctionDefinitionParam{Name: "t"}},
+		tl,
+		nil,
+	)
 	require.Error(t, err)
 }
 
@@ -5000,7 +5364,13 @@ func TestExecuteToolWithCallbacks_AgentToolRunErrorAfterBeforeToolContextReplace
 	tc := model.ToolCall{ID: "call-1", Function: model.FunctionDefinitionParam{Name: "agent-tool"}}
 	st := agenttool.NewTool(&runErrorSubAgent{name: "err-agent"}, agenttool.WithStreamInner(true))
 	ch := make(chan *event.Event, 1)
-	_, res, _, _, err := f.executeToolWithCallbacks(ctx, inv, tc, st, ch)
+	_, res, _, _, _, err := f.executeToolWithCallbacks(
+		ctx,
+		inv,
+		tc,
+		st,
+		ch,
+	)
 	require.NoError(t, err)
 	require.Equal(t, "agent tool run error: boom", res)
 	ev := <-ch
@@ -5084,7 +5454,13 @@ func TestExecuteToolWithCallbacks_BeforeToolContextReplacementDoesNotReinjectToo
 			return map[string]any{"ok": true}, nil
 		},
 	}
-	_, res, _, _, err := f.executeToolWithCallbacks(context.Background(), inv, tc, tl, nil)
+	_, res, _, _, _, err := f.executeToolWithCallbacks(
+		context.Background(),
+		inv,
+		tc,
+		tl,
+		nil,
+	)
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.False(t, sawToolCallID)
@@ -5108,7 +5484,13 @@ func TestExecuteTool_NamedTool(t *testing.T) {
 	require.Len(t, namedTools, 1)
 	nameTool := namedTools[0]
 	require.IsType(t, &itool.NamedTool{}, nameTool)
-	_, res, _, _, err := p.executeToolWithCallbacks(ctx, inv, model.ToolCall{Function: model.FunctionDefinitionParam{Name: "t"}}, nameTool, nil)
+	_, res, _, _, _, err := p.executeToolWithCallbacks(
+		ctx,
+		inv,
+		model.ToolCall{Function: model.FunctionDefinitionParam{Name: "t"}},
+		nameTool,
+		nil,
+	)
 	require.NoError(t, err)
 	b, _ := json.Marshal(map[string]any{"k": "v"})
 	require.JSONEq(t, string(b), string(mustJSON(res)))
@@ -5146,7 +5528,7 @@ func TestExecuteToolCall_StreamableFinalStateOnlyResultAfterToolContextReplaceme
 		},
 	}
 	eventCh := make(chan *event.Event, 4)
-	_, choices, _, _, err := p.executeToolCall(
+	_, choices, _, _, _, err := p.executeToolCall(
 		ctx,
 		inv,
 		tc,
@@ -5214,7 +5596,7 @@ func TestExecuteToolCall_StreamableFinalStateOnlyResultStillRunsToolResultMessag
 		},
 	}
 	eventCh := make(chan *event.Event, 4)
-	_, choices, _, _, err := p.executeToolCall(
+	_, choices, _, _, _, err := p.executeToolCall(
 		ctx,
 		inv,
 		tc,
@@ -5262,7 +5644,7 @@ func TestExecuteToolCall_StreamableFinalStateOnlyResultCallbackError(t *testing.
 		},
 	}
 	eventCh := make(chan *event.Event, 4)
-	_, choices, _, _, err := p.executeToolCall(
+	_, choices, _, _, _, err := p.executeToolCall(
 		ctx,
 		inv,
 		tc,
@@ -5304,7 +5686,7 @@ func TestExecuteToolCall_StreamableFinalStateOnlyResultCallbackFallsBackToDefaul
 		},
 	}
 	eventCh := make(chan *event.Event, 4)
-	_, choices, _, _, err := p.executeToolCall(
+	_, choices, _, _, _, err := p.executeToolCall(
 		ctx,
 		inv,
 		tc,
@@ -5393,7 +5775,8 @@ func TestShouldRequestStructuredStreamErrors_NilAndNamedTool(t *testing.T) {
 }
 
 func TestHasSyntheticStateOnlyToolChoice_NilContext(t *testing.T) {
-	require.False(t, hasSyntheticStateOnlyToolChoice(nil))
+	var ctx context.Context
+	require.False(t, hasSyntheticStateOnlyToolChoice(ctx))
 }
 
 func TestHandleFunctionCalls_PreservesCallbackDefaultStateOnlyToolChoiceAlongsideOtherToolResults(t *testing.T) {

--- a/tool/callbacks.go
+++ b/tool/callbacks.go
@@ -118,6 +118,8 @@ type AfterToolResult struct {
 	Context context.Context
 	// CustomResult if not nil, will replace the original result.
 	CustomResult any
+	// SkipSummarization requests ending the turn after the tool response.
+	SkipSummarization bool
 }
 
 // AfterToolCallbackStructured is called after a tool is executed.
@@ -125,6 +127,8 @@ type AfterToolResult struct {
 // - result: contains optional custom result and context for subsequent operations.
 //   - CustomResult: if not nil, this result will be used instead of the actual tool result.
 //   - Context: if not nil, will be used by the framework for subsequent operations.
+//   - SkipSummarization: if true, the framework will skip the extra
+//     post-tool LLM summarization step.
 //
 // - error: if not nil, this error will be returned.
 type AfterToolCallbackStructured = func(
@@ -456,6 +460,18 @@ func (c *Callbacks) processAfterToolResult(
 	}
 	if result.Context != nil {
 		*ctx = result.Context
+	}
+	if *lastResult != nil {
+		merged := *result
+		if merged.Context == nil {
+			merged.Context = (*lastResult).Context
+		}
+		if merged.CustomResult == nil {
+			merged.CustomResult = (*lastResult).CustomResult
+		}
+		merged.SkipSummarization = merged.SkipSummarization ||
+			(*lastResult).SkipSummarization
+		result = &merged
 	}
 	if result.CustomResult != nil {
 		*lastResult = result

--- a/tool/callbacks_test.go
+++ b/tool/callbacks_test.go
@@ -762,6 +762,40 @@ func TestRunAfterTool_NormalizesResultOnlyForCallbackInvocation(t *testing.T) {
 	require.Nil(t, result.CustomResult)
 }
 
+func TestRunAfterTool_PreservesSkipSummarizationAcrossCallbacks(t *testing.T) {
+	callbacks := tool.NewCallbacks(tool.WithContinueOnResponse(true))
+	marker := map[string]string{"result": "callback"}
+	secondCalled := false
+
+	callbacks.RegisterAfterTool(func(
+		ctx context.Context,
+		args *tool.AfterToolArgs,
+	) (*tool.AfterToolResult, error) {
+		return &tool.AfterToolResult{CustomResult: marker}, nil
+	})
+	callbacks.RegisterAfterTool(func(
+		ctx context.Context,
+		args *tool.AfterToolArgs,
+	) (*tool.AfterToolResult, error) {
+		secondCalled = true
+		return &tool.AfterToolResult{SkipSummarization: true}, nil
+	})
+
+	result, err := callbacks.RunAfterTool(context.Background(),
+		&tool.AfterToolArgs{
+			ToolName:    "test-tool",
+			Declaration: &tool.Declaration{Name: "test-tool"},
+			Arguments:   []byte("{}"),
+			Result:      map[string]any{"ok": true},
+		},
+	)
+	require.NoError(t, err)
+	require.True(t, secondCalled)
+	require.NotNil(t, result)
+	require.True(t, result.SkipSummarization)
+	require.Equal(t, marker, result.CustomResult)
+}
+
 func TestRunAfterTool_NoCallbacksPreservesOriginalResultShape(t *testing.T) {
 	callbacks := tool.NewCallbacks()
 


### PR DESCRIPTION
## Summary
- support `AfterToolResult.SkipSummarization` so after-tool callbacks can end a turn based on the actual tool result
- propagate callback-driven skip summarization through sequential, parallel, and long-running tool execution paths
- document the new callback behavior and add regression coverage

## Testing
- go test ./internal/flow/processor ./tool ./tool/function ./tool/agent ./runner
