### PR TITLE
WIP: serialize session state updates

### DIFF
--- a/session/postgres/service.go
+++ b/session/postgres/service.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -31,6 +32,8 @@ import (
 
 var _ session.Service = (*Service)(nil)
 var _ session.TrackService = (*Service)(nil)
+
+var errSessionNotFound = errors.New("session not found")
 
 // SessionState is the state of a session.
 type SessionState struct {
@@ -547,66 +550,54 @@ func (s *Service) UpdateSessionState(ctx context.Context, key session.Key, state
 		}
 	}
 
-	// Get current session state
-	var currentStateBytes []byte
-	err := s.pgClient.Query(ctx, func(rows *sql.Rows) error {
-		if rows.Next() {
-			return rows.Scan(&currentStateBytes)
+	err := s.pgClient.Transaction(ctx, func(tx *sql.Tx) error {
+		sessState, _, err := loadSessionStateForUpdate(ctx, tx, s.tableSessionStates, key)
+		if err != nil {
+			if errors.Is(err, errSessionNotFound) {
+				return fmt.Errorf("postgres session service update session state failed: session not found")
+			}
+			return fmt.Errorf("postgres session service update session state failed: %w", err)
 		}
-		return sql.ErrNoRows
-	}, fmt.Sprintf(`SELECT state FROM %s
-		WHERE app_name = $1 AND user_id = $2 AND session_id = $3 AND deleted_at IS NULL`, s.tableSessionStates),
-		key.AppName, key.UserID, key.SessionID)
 
-	if err == sql.ErrNoRows {
-		return fmt.Errorf("postgres session service update session state failed: session not found")
-	}
-	if err != nil {
-		return fmt.Errorf("postgres session service update session state failed: get session state: %w", err)
-	}
-
-	var sessState SessionState
-	if len(currentStateBytes) > 0 {
-		if err := json.Unmarshal(currentStateBytes, &sessState); err != nil {
-			return fmt.Errorf("postgres session service update session state failed: unmarshal state: %w", err)
+		now := time.Now()
+		if sessState.State == nil {
+			sessState.State = make(session.StateMap)
 		}
-	}
-	now := time.Now()
-	if sessState.State == nil {
-		sessState.State = make(session.StateMap)
-	}
-	for k, v := range state {
-		if v == nil {
-			sessState.State[k] = nil
-			continue
+		for k, v := range state {
+			if v == nil {
+				sessState.State[k] = nil
+				continue
+			}
+			copiedValue := make([]byte, len(v))
+			copy(copiedValue, v)
+			sessState.State[k] = copiedValue
 		}
-		copiedValue := make([]byte, len(v))
-		copy(copiedValue, v)
-		sessState.State[k] = copiedValue
-	}
-	sessState.UpdatedAt = now
+		sessState.UpdatedAt = now
 
-	updatedStateBytes, err := json.Marshal(sessState)
-	if err != nil {
-		return fmt.Errorf("postgres session service update session state failed: marshal state: %w", err)
-	}
+		updatedStateBytes, err := json.Marshal(sessState)
+		if err != nil {
+			return fmt.Errorf("postgres session service update session state failed: marshal state: %w", err)
+		}
 
-	var expiresAt *time.Time
-	if s.opts.sessionTTL > 0 {
-		t := now.Add(s.opts.sessionTTL)
-		expiresAt = &t
-	}
+		var expiresAt *time.Time
+		if s.opts.sessionTTL > 0 {
+			t := now.Add(s.opts.sessionTTL)
+			expiresAt = &t
+		}
 
-	_, err = s.pgClient.ExecContext(ctx,
-		fmt.Sprintf(`UPDATE %s SET state = $1, updated_at = $2, expires_at = $3
+		_, err = tx.ExecContext(ctx,
+			fmt.Sprintf(`UPDATE %s SET state = $1, updated_at = $2, expires_at = $3
 		 WHERE app_name = $4 AND user_id = $5 AND session_id = $6 AND deleted_at IS NULL`, s.tableSessionStates),
-		updatedStateBytes, now, expiresAt,
-		key.AppName, key.UserID, key.SessionID)
-
+			updatedStateBytes, now, expiresAt,
+			key.AppName, key.UserID, key.SessionID)
+		if err != nil {
+			return fmt.Errorf("postgres session service update session state failed: %w", err)
+		}
+		return nil
+	})
 	if err != nil {
-		return fmt.Errorf("postgres session service update session state failed: %w", err)
+		return err
 	}
-
 	return nil
 }
 

--- a/session/postgres/service_helper.go
+++ b/session/postgres/service_helper.go
@@ -233,75 +233,55 @@ func (s *Service) listSessions(
 }
 
 func (s *Service) addEvent(ctx context.Context, key session.Key, event *event.Event) error {
-	now := time.Now()
-
-	// Get current session state (always filter deleted records, but allow expired sessions).
-	var sessState *SessionState
-	var currentExpiresAt *time.Time
-	err := s.pgClient.Query(ctx, func(rows *sql.Rows) error {
-		if rows.Next() {
-			var stateBytes []byte
-			if err := rows.Scan(&stateBytes, &currentExpiresAt); err != nil {
-				return err
-			}
-			sessState = &SessionState{}
-			if err := json.Unmarshal(stateBytes, sessState); err != nil {
-				return fmt.Errorf("unmarshal session state failed: %w", err)
-			}
-		}
-		return nil
-	}, fmt.Sprintf(`SELECT state, expires_at FROM %s
-		WHERE app_name = $1 AND user_id = $2 AND session_id = $3
-		AND deleted_at IS NULL`, s.tableSessionStates),
-		key.AppName, key.UserID, key.SessionID)
-
-	if err != nil {
-		return fmt.Errorf("get session state failed: %w", err)
-	}
-	if sessState == nil {
-		return fmt.Errorf("session not found")
-	}
-
-	// Check if session is expired, log info if so.
-	if currentExpiresAt != nil && currentExpiresAt.Before(now) {
-		log.InfofContext(
-			ctx,
-			"appending event to expired session (app=%s, user=%s, "+
-				"session=%s), will extend expires_at",
-			key.AppName,
-			key.UserID,
-			key.SessionID,
-		)
-	}
-
-	sessState.UpdatedAt = now
-	if sessState.State == nil {
-		sessState.State = make(session.StateMap)
-	}
-	session.ApplyEventStateDeltaMap(sessState.State, event)
-	updatedStateBytes, err := json.Marshal(sessState)
-	if err != nil {
-		return fmt.Errorf("marshal session state failed: %w", err)
-	}
-
 	eventBytes, err := json.Marshal(event)
 	if err != nil {
 		return fmt.Errorf("marshal event failed: %w", err)
 	}
-
-	var expiresAt *time.Time
-	if s.opts.sessionTTL > 0 {
-		t := now.Add(s.opts.sessionTTL)
-		expiresAt = &t
-	}
+	var updatedAt time.Time
+	var updatedStateBytes []byte
 
 	// Use transaction to update session state and insert event.
 	err = s.pgClient.Transaction(ctx, func(tx *sql.Tx) error {
+		sessState, currentExpiresAt, err := loadSessionStateForUpdate(ctx, tx, s.tableSessionStates, key)
+		if err != nil {
+			return err
+		}
+
+		now := time.Now()
+		if currentExpiresAt != nil && currentExpiresAt.Before(now) {
+			log.InfofContext(
+				ctx,
+				"appending event to expired session (app=%s, user=%s, "+
+					"session=%s), will extend expires_at",
+				key.AppName,
+				key.UserID,
+				key.SessionID,
+			)
+		}
+
+		sessState.UpdatedAt = now
+		if sessState.State == nil {
+			sessState.State = make(session.StateMap)
+		}
+		session.ApplyEventStateDeltaMap(sessState.State, event)
+		updatedAt = now
+
+		updatedStateBytes, err = json.Marshal(sessState)
+		if err != nil {
+			return fmt.Errorf("marshal session state failed: %w", err)
+		}
+
+		var expiresAt *time.Time
+		if s.opts.sessionTTL > 0 {
+			t := now.Add(s.opts.sessionTTL)
+			expiresAt = &t
+		}
+
 		// Update session state
-		_, err := tx.ExecContext(ctx,
+		_, err = tx.ExecContext(ctx,
 			fmt.Sprintf(`UPDATE %s SET state = $1, updated_at = $2, expires_at = $3
 			 WHERE app_name = $4 AND user_id = $5 AND session_id = $6 AND deleted_at IS NULL`, s.tableSessionStates),
-			updatedStateBytes, sessState.UpdatedAt, expiresAt,
+			updatedStateBytes, updatedAt, expiresAt,
 			key.AppName, key.UserID, key.SessionID)
 		if err != nil {
 			return fmt.Errorf("update session state failed: %w", err)
@@ -327,82 +307,64 @@ func (s *Service) addEvent(ctx context.Context, key session.Key, event *event.Ev
 }
 
 func (s *Service) addTrackEvent(ctx context.Context, key session.Key, trackEvent *session.TrackEvent) error {
-	now := time.Now()
-
-	// Get current session state (always filter deleted records, but allow expired sessions).
-	var sessState *SessionState
-	var currentExpiresAt *time.Time
-	err := s.pgClient.Query(ctx, func(rows *sql.Rows) error {
-		if rows.Next() {
-			var stateBytes []byte
-			if err := rows.Scan(&stateBytes, &currentExpiresAt); err != nil {
-				return err
-			}
-			sessState = &SessionState{}
-			if err := json.Unmarshal(stateBytes, sessState); err != nil {
-				return fmt.Errorf("unmarshal session state failed: %w", err)
-			}
-		}
-		return nil
-	}, fmt.Sprintf(`SELECT state, expires_at FROM %s
-		WHERE app_name = $1 AND user_id = $2 AND session_id = $3
-		AND deleted_at IS NULL`, s.tableSessionStates),
-		key.AppName, key.UserID, key.SessionID)
-
-	if err != nil {
-		return fmt.Errorf("get session state failed: %w", err)
-	}
-	if sessState == nil {
-		return fmt.Errorf("session not found")
-	}
-
-	// Check if session is expired, log info if so.
-	if currentExpiresAt != nil && currentExpiresAt.Before(now) {
-		log.InfofContext(
-			ctx,
-			"appending track event to expired session (app=%s, "+
-				"user=%s, session=%s), will extend expires_at",
-			key.AppName,
-			key.UserID,
-			key.SessionID,
-		)
-	}
-
-	sess := &session.Session{
-		ID:      key.SessionID,
-		AppName: key.AppName,
-		UserID:  key.UserID,
-		State:   sessState.State,
-	}
-	if err := sess.AppendTrackEvent(trackEvent); err != nil {
-		return err
-	}
-	sessState.State = sess.SnapshotState()
-	sessState.UpdatedAt = sess.UpdatedAt
-
-	updatedStateBytes, err := json.Marshal(sessState)
-	if err != nil {
-		return fmt.Errorf("marshal session state failed: %w", err)
-	}
-
 	eventBytes, err := json.Marshal(trackEvent)
 	if err != nil {
 		return fmt.Errorf("marshal track event failed: %w", err)
 	}
-
-	var expiresAt *time.Time
-	if s.opts.sessionTTL > 0 {
-		t := now.Add(s.opts.sessionTTL)
-		expiresAt = &t
-	}
+	var updatedAt time.Time
+	var updatedStateBytes []byte
 
 	// Use transaction to update session state and insert track event.
 	err = s.pgClient.Transaction(ctx, func(tx *sql.Tx) error {
+		sessState, currentExpiresAt, err := loadSessionStateForUpdate(ctx, tx, s.tableSessionStates, key)
+		if err != nil {
+			return err
+		}
+
+		now := time.Now()
+		if currentExpiresAt != nil && currentExpiresAt.Before(now) {
+			log.InfofContext(
+				ctx,
+				"appending track event to expired session (app=%s, "+
+					"user=%s, session=%s), will extend expires_at",
+				key.AppName,
+				key.UserID,
+				key.SessionID,
+			)
+		}
+
+		if sessState.State == nil {
+			sessState.State = make(session.StateMap)
+		}
+		sess := &session.Session{
+			ID:      key.SessionID,
+			AppName: key.AppName,
+			UserID:  key.UserID,
+			State:   sessState.State,
+		}
+		if err := sess.AppendTrackEvent(trackEvent); err != nil {
+			return err
+		}
+		sessState.State = sess.SnapshotState()
+		sessState.UpdatedAt = now
+		updatedAt = now
+
+		updatedStateBytes, err = json.Marshal(sessState)
+		if err != nil {
+			return fmt.Errorf("marshal session state failed: %w", err)
+		}
+
+		var expiresAt *time.Time
+		if s.opts.sessionTTL > 0 {
+			t := now.Add(s.opts.sessionTTL)
+			expiresAt = &t
+		}
+
 		// Update session state.
-		_, err := tx.ExecContext(ctx,
+		_, err = tx.ExecContext(ctx,
 			fmt.Sprintf(`UPDATE %s SET state = $1, updated_at = $2, expires_at = $3
 			 WHERE app_name = $4 AND user_id = $5 AND session_id = $6 AND deleted_at IS NULL`, s.tableSessionStates),
-			updatedStateBytes, sessState.UpdatedAt, expiresAt,
+			updatedStateBytes, updatedAt, expiresAt,
 			key.AppName, key.UserID, key.SessionID)
 		if err != nil {
 			return fmt.Errorf("update session state failed: %w", err)
@@ -423,6 +385,38 @@ func (s *Service) addTrackEvent(ctx context.Context, key session.Key, trackEvent
 		return fmt.Errorf("store track event failed: %w", err)
 	}
 	return nil
+}
+
+func loadSessionStateForUpdate(
+	ctx context.Context,
+	tx *sql.Tx,
+	tableSessionStates string,
+	key session.Key,
+) (*SessionState, *time.Time, error) {
+	var stateBytes []byte
+	var currentExpiresAt *time.Time
+	err := tx.QueryRowContext(
+		ctx,
+		fmt.Sprintf(`SELECT state, expires_at FROM %s
+		WHERE app_name = $1 AND user_id = $2 AND session_id = $3
+		AND deleted_at IS NULL
+		FOR UPDATE`, tableSessionStates),
+		key.AppName, key.UserID, key.SessionID,
+	).Scan(&stateBytes, &currentExpiresAt)
+	if err == sql.ErrNoRows {
+		return nil, nil, errSessionNotFound
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("get session state failed: %w", err)
+	}
+
+	var sessState SessionState
+	if len(stateBytes) > 0 {
+		if err := json.Unmarshal(stateBytes, &sessState); err != nil {
+			return nil, nil, fmt.Errorf("unmarshal session state failed: %w", err)
+		}
+	}
+	return &sessState, currentExpiresAt, nil
 }
 
 func (s *Service) deleteSessionState(ctx context.Context, key session.Key) error {

--- a/session/postgres/service_test.go
+++ b/session/postgres/service_test.go
@@ -193,6 +193,17 @@ func createTestService(t *testing.T, db *sql.DB, opts ...ServiceOpt) *Service {
 	}
 }
 
+const selectSessionStateForUpdateSQL = "SELECT state, expires_at FROM session_states WHERE app_name = $1 AND user_id = $2 AND session_id = $3 AND deleted_at IS NULL FOR UPDATE"
+
+func expectLoadSessionStateForUpdate(
+	mock sqlmock.Sqlmock,
+	key session.Key,
+) *sqlmock.ExpectedQuery {
+	mock.ExpectBegin()
+	return mock.ExpectQuery(regexp.QuoteMeta(selectSessionStateForUpdateSQL)).
+		WithArgs(key.AppName, key.UserID, key.SessionID)
+}
+
 // TestServiceOpts contains options for creating a test service
 type TestServiceOpts struct {
 	sessionTTL         time.Duration
@@ -1349,9 +1360,8 @@ func TestUpdateSessionState_UnmarshalSessionEnvelope(t *testing.T) {
 	stateBytes, err := json.Marshal(existing)
 	require.NoError(t, err)
 
-	mock.ExpectQuery("SELECT state FROM session_states").
-		WithArgs(key.AppName, key.UserID, key.SessionID).
-		WillReturnRows(sqlmock.NewRows([]string{"state"}).AddRow(stateBytes))
+	expectLoadSessionStateForUpdate(mock, key).
+		WillReturnRows(sqlmock.NewRows([]string{"state", "expires_at"}).AddRow(stateBytes, nil))
 
 	expectedState := session.StateMap{
 		"existing": []byte("old"),
@@ -1373,6 +1383,7 @@ func TestUpdateSessionState_UnmarshalSessionEnvelope(t *testing.T) {
 			key.SessionID,
 		).
 		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
 
 	err = s.UpdateSessionState(context.Background(), key, session.StateMap{
 		"new": []byte("fresh"),
@@ -1402,9 +1413,8 @@ func TestUpdateSessionState_UnmarshalNilState(t *testing.T) {
 	stateBytes, err := json.Marshal(existing)
 	require.NoError(t, err)
 
-	mock.ExpectQuery("SELECT state FROM session_states").
-		WithArgs(key.AppName, key.UserID, key.SessionID).
-		WillReturnRows(sqlmock.NewRows([]string{"state"}).AddRow(stateBytes))
+	expectLoadSessionStateForUpdate(mock, key).
+		WillReturnRows(sqlmock.NewRows([]string{"state", "expires_at"}).AddRow(stateBytes, nil))
 
 	expectedState := session.StateMap{
 		"only": []byte("value"),
@@ -1425,6 +1435,7 @@ func TestUpdateSessionState_UnmarshalNilState(t *testing.T) {
 			key.SessionID,
 		).
 		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
 
 	err = s.UpdateSessionState(context.Background(), key, session.StateMap{
 		"only": []byte("value"),
@@ -1443,15 +1454,15 @@ func TestUpdateSessionState_UnmarshalError(t *testing.T) {
 		SessionID: "test-session",
 	}
 
-	mock.ExpectQuery("SELECT state FROM session_states").
-		WithArgs(key.AppName, key.UserID, key.SessionID).
-		WillReturnRows(sqlmock.NewRows([]string{"state"}).AddRow([]byte("{")))
+	expectLoadSessionStateForUpdate(mock, key).
+		WillReturnRows(sqlmock.NewRows([]string{"state", "expires_at"}).AddRow([]byte("{"), nil))
+	mock.ExpectRollback()
 
 	err := s.UpdateSessionState(context.Background(), key, session.StateMap{
 		"k": []byte("v"),
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unmarshal state")
+	assert.Contains(t, err.Error(), "unmarshal session state failed")
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -1488,9 +1499,9 @@ func TestUpdateSessionState_SessionNotFound_ErrNoRows(
 
 	key := session.Key{AppName: "app", UserID: "user", SessionID: "sess"}
 
-	mock.ExpectQuery("SELECT state FROM session_states").
-		WithArgs(key.AppName, key.UserID, key.SessionID).
-		WillReturnRows(sqlmock.NewRows([]string{"state"}))
+	expectLoadSessionStateForUpdate(mock, key).
+		WillReturnRows(sqlmock.NewRows([]string{"state", "expires_at"}))
+	mock.ExpectRollback()
 
 	err := s.UpdateSessionState(context.Background(), key, session.StateMap{"k": []byte("v")})
 	require.Error(t, err)
@@ -1506,9 +1517,9 @@ func TestUpdateSessionState_QueryError_Propagates(
 
 	key := session.Key{AppName: "app", UserID: "user", SessionID: "sess"}
 
-	mock.ExpectQuery("SELECT state FROM session_states").
-		WithArgs(key.AppName, key.UserID, key.SessionID).
+	expectLoadSessionStateForUpdate(mock, key).
 		WillReturnError(fmt.Errorf("db error"))
+	mock.ExpectRollback()
 
 	err := s.UpdateSessionState(context.Background(), key, session.StateMap{"k": []byte("v")})
 	require.Error(t, err)
@@ -1529,13 +1540,13 @@ func TestUpdateSessionState_UpdateError(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	mock.ExpectQuery("SELECT state FROM session_states").
-		WithArgs(key.AppName, key.UserID, key.SessionID).
-		WillReturnRows(sqlmock.NewRows([]string{"state"}).AddRow(stateBytes))
+	expectLoadSessionStateForUpdate(mock, key).
+		WillReturnRows(sqlmock.NewRows([]string{"state", "expires_at"}).AddRow(stateBytes, nil))
 
 	mock.ExpectExec(regexp.QuoteMeta("UPDATE session_states SET state = $1, updated_at = $2, expires_at = $3 WHERE app_name = $4 AND user_id = $5 AND session_id = $6 AND deleted_at IS NULL")).
 		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), key.AppName, key.UserID, key.SessionID).
 		WillReturnError(fmt.Errorf("update error"))
+	mock.ExpectRollback()
 
 	err = s.UpdateSessionState(context.Background(), key, session.StateMap{"k": []byte("v")})
 	require.Error(t, err)
@@ -1638,11 +1649,12 @@ func TestAppendEvent_SyncMode_ExpiredSession(t *testing.T) {
 	stateRows := sqlmock.NewRows([]string{"state", "expires_at"}).
 		AddRow(stateBytes, expiredAt)
 
-	mock.ExpectQuery("SELECT state, expires_at FROM session_states").
-		WithArgs("test-app", "test-user", "test-session").
+	expectLoadSessionStateForUpdate(mock, session.Key{
+		AppName:   "test-app",
+		UserID:    "test-user",
+		SessionID: "test-session",
+	}).
 		WillReturnRows(stateRows)
-
-	mock.ExpectBegin()
 	mock.ExpectExec("UPDATE session_states SET state").
 		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
 			"test-app", "test-user", "test-session").
@@ -1683,11 +1695,12 @@ func TestAppendTrackEvent_SyncMode(t *testing.T) {
 	stateRows := sqlmock.NewRows([]string{"state", "expires_at"}).
 		AddRow(stateBytes, nil)
 
-	mock.ExpectQuery("SELECT state, expires_at FROM session_states").
-		WithArgs("test-app", "test-user", "test-session").
+	expectLoadSessionStateForUpdate(mock, session.Key{
+		AppName:   "test-app",
+		UserID:    "test-user",
+		SessionID: "test-session",
+	}).
 		WillReturnRows(stateRows)
-
-	mock.ExpectBegin()
 
 	mock.ExpectExec("UPDATE session_states SET state").
 		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
@@ -3187,9 +3200,9 @@ func TestUpdateSessionState_SessionNotFound(t *testing.T) {
 		SessionID: "test-session",
 	}
 
-	mock.ExpectQuery("SELECT state FROM session_states").
-		WithArgs(key.AppName, key.UserID, key.SessionID).
-		WillReturnRows(sqlmock.NewRows([]string{"state"}))
+	expectLoadSessionStateForUpdate(mock, key).
+		WillReturnRows(sqlmock.NewRows([]string{"state", "expires_at"}))
+	mock.ExpectRollback()
 
 	err = s.UpdateSessionState(ctx, key, session.StateMap{
 		"key1": []byte("value1"),
@@ -3213,9 +3226,9 @@ func TestUpdateSessionState_QueryError(t *testing.T) {
 		SessionID: "test-session",
 	}
 
-	mock.ExpectQuery("SELECT state FROM session_states").
-		WithArgs(key.AppName, key.UserID, key.SessionID).
+	expectLoadSessionStateForUpdate(mock, key).
 		WillReturnError(fmt.Errorf("query failed"))
+	mock.ExpectRollback()
 
 	err = s.UpdateSessionState(ctx, key, session.StateMap{
 		"key1": []byte("value1"),
@@ -3241,18 +3254,18 @@ func TestUpdateSessionState_UnmarshalError_InvalidJSON(
 		SessionID: "test-session",
 	}
 
-	mock.ExpectQuery("SELECT state FROM session_states").
-		WithArgs(key.AppName, key.UserID, key.SessionID).
+	expectLoadSessionStateForUpdate(mock, key).
 		WillReturnRows(
-			sqlmock.NewRows([]string{"state"}).
-				AddRow([]byte("not-json")),
+			sqlmock.NewRows([]string{"state", "expires_at"}).
+				AddRow([]byte("not-json"), nil),
 		)
+	mock.ExpectRollback()
 
 	err = s.UpdateSessionState(ctx, key, session.StateMap{
 		"key1": []byte("value1"),
 	})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "unmarshal state")
+	require.Contains(t, err.Error(), "unmarshal session state failed")
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -3270,17 +3283,19 @@ func TestUpdateSessionState_Success(t *testing.T) {
 		SessionID: "test-session",
 	}
 
-	currentState := session.StateMap{
-		"existing": []byte(`"old"`),
+	currentState := SessionState{
+		ID: key.SessionID,
+		State: session.StateMap{
+			"existing": []byte(`"old"`),
+		},
 	}
 	currentBytes, err := json.Marshal(currentState)
 	require.NoError(t, err)
 
-	mock.ExpectQuery("SELECT state FROM session_states").
-		WithArgs(key.AppName, key.UserID, key.SessionID).
+	expectLoadSessionStateForUpdate(mock, key).
 		WillReturnRows(
-			sqlmock.NewRows([]string{"state"}).
-				AddRow(currentBytes),
+			sqlmock.NewRows([]string{"state", "expires_at"}).
+				AddRow(currentBytes, nil),
 		)
 
 	mock.ExpectExec("UPDATE session_states SET state").
@@ -3293,6 +3308,7 @@ func TestUpdateSessionState_Success(t *testing.T) {
 			key.SessionID,
 		).
 		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
 
 	err = s.UpdateSessionState(ctx, key, session.StateMap{
 		"newKey": []byte(`"newValue"`),

--- a/session/redis/internal/hashidx/lua.go
+++ b/session/redis/internal/hashidx/lua.go
@@ -11,6 +11,33 @@ package hashidx
 
 import "github.com/redis/go-redis/v9"
 
+// luaUpdateSessionState atomically compare-and-swaps session meta.
+// KEYS[1] = sessionMeta key
+// ARGV[1] = expectedMetaJSON, ARGV[2] = updatedMetaJSON, ARGV[3] = TTL (seconds)
+// Returns: 1 on success, 0 if session not found, 2 if current value changed
+var luaUpdateSessionState = redis.NewScript(`
+local sessionMetaKey = KEYS[1]
+local expectedMetaJSON = ARGV[1]
+local updatedMetaJSON = ARGV[2]
+local ttl = tonumber(ARGV[3])
+
+local metaJSON = redis.call('GET', sessionMetaKey)
+if not metaJSON then
+    return 0
+end
+if metaJSON ~= expectedMetaJSON then
+    return 2
+end
+
+if ttl > 0 then
+    redis.call('SET', sessionMetaKey, updatedMetaJSON, 'EX', ttl)
+else
+    redis.call('SET', sessionMetaKey, updatedMetaJSON, 'KEEPTTL')
+end
+
+return 1
+`)
+
 // luaAppendEvent appends an event atomically and applies StateDelta to session state.
 // KEYS[1] = sessionMeta key, KEYS[2] = evtdata key, KEYS[3] = evtidx:time key
 // ARGV[1] = eventID, ARGV[2] = eventJSON, ARGV[3] = timestamp, ARGV[4] = TTL (seconds), ARGV[5] = shouldStoreEvent (1 or 0)

--- a/session/redis/internal/hashidx/state.go
+++ b/session/redis/internal/hashidx/state.go
@@ -21,39 +21,87 @@ import (
 
 // UpdateSessionState updates the session-level state directly (HashIdx).
 func (c *Client) UpdateSessionState(ctx context.Context, key session.Key, state session.StateMap) error {
-	metaJSON, err := c.client.Get(ctx, c.keys.SessionMetaKey(key)).Bytes()
-	if err != nil {
-		if err == redis.Nil {
-			return fmt.Errorf("session not found")
+	ttlSeconds := int64(0)
+	if c.cfg.SessionTTL > 0 {
+		ttlSeconds = int64(c.cfg.SessionTTL.Seconds())
+	}
+
+	retryDelay := 5 * time.Millisecond
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
 		}
-		return fmt.Errorf("get session meta: %w", err)
+
+		metaJSON, err := c.client.Get(ctx, c.keys.SessionMetaKey(key)).Bytes()
+		if err != nil {
+			if err == redis.Nil {
+				return fmt.Errorf("session not found")
+			}
+			return fmt.Errorf("get session meta: %w", err)
+		}
+
+		var meta sessionMeta
+		if err := json.Unmarshal(metaJSON, &meta); err != nil {
+			return fmt.Errorf("unmarshal session meta: %w", err)
+		}
+
+		if meta.State == nil {
+			meta.State = make(session.StateMap)
+		}
+		for k, v := range state {
+			if v == nil {
+				meta.State[k] = nil
+				continue
+			}
+			copiedValue := make([]byte, len(v))
+			copy(copiedValue, v)
+			meta.State[k] = copiedValue
+		}
+		meta.UpdatedAt = time.Now()
+
+		updatedJSON, err := json.Marshal(meta)
+		if err != nil {
+			return fmt.Errorf("marshal session meta: %w", err)
+		}
+
+		result, err := luaUpdateSessionState.Run(
+			ctx,
+			c.client,
+			[]string{c.keys.SessionMetaKey(key)},
+			string(metaJSON),
+			string(updatedJSON),
+			ttlSeconds,
+		).Int()
+		if err != nil {
+			return fmt.Errorf("update session state: %w", err)
+		}
+		switch result {
+		case 1:
+			return nil
+		case 0:
+			return fmt.Errorf("session not found")
+		case 2:
+			timer := time.NewTimer(retryDelay)
+			select {
+			case <-ctx.Done():
+				if !timer.Stop() {
+					<-timer.C
+				}
+				return ctx.Err()
+			case <-timer.C:
+			}
+			if retryDelay < 100*time.Millisecond {
+				retryDelay *= 2
+				if retryDelay > 100*time.Millisecond {
+					retryDelay = 100 * time.Millisecond
+				}
+			}
+			continue
+		default:
+			return fmt.Errorf("update session state: unexpected script result %d", result)
+		}
 	}
 
-	var meta sessionMeta
-	if err := json.Unmarshal(metaJSON, &meta); err != nil {
-		return fmt.Errorf("unmarshal session meta: %w", err)
-	}
-
-	if meta.State == nil {
-		meta.State = make(session.StateMap)
-	}
-	for k, v := range state {
-		meta.State[k] = v
-	}
-	meta.UpdatedAt = time.Now()
-
-	updatedJSON, err := json.Marshal(meta)
-	if err != nil {
-		return fmt.Errorf("marshal session meta: %w", err)
-	}
-
-	// Use SetArgs with KeepTTL to preserve the original TTL set by CreateSession/GetSession.
-	if err := c.client.SetArgs(ctx, c.keys.SessionMetaKey(key), updatedJSON, redis.SetArgs{
-		KeepTTL: true,
-	}).Err(); err != nil {
-		return fmt.Errorf("update session state: %w", err)
-	}
-	return nil
 }
 
 // Exists checks if session exists.

--- a/session/redis/internal/hashidx/state_test.go
+++ b/session/redis/internal/hashidx/state_test.go
@@ -11,6 +11,7 @@ package hashidx
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -271,4 +272,76 @@ func TestClient_UpdateSessionState_NilState(t *testing.T) {
 	sess, err := c.GetSession(ctx, key, 0, time.Time{})
 	require.NoError(t, err)
 	assert.Equal(t, []byte("newval"), sess.State["newkey"])
+}
+
+func TestLuaUpdateSessionState_CompareAndSwap(t *testing.T) {
+	_, rdb := setupMiniredis(t)
+	c := NewClient(rdb, Config{SessionTTL: time.Hour})
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "uss-cas"}
+
+	_, err := c.CreateSession(ctx, key, session.StateMap{"existing": []byte("v1")})
+	require.NoError(t, err)
+
+	originalJSON, err := rdb.Get(ctx, c.keys.SessionMetaKey(key)).Bytes()
+	require.NoError(t, err)
+
+	var concurrentMeta sessionMeta
+	require.NoError(t, json.Unmarshal(originalJSON, &concurrentMeta))
+	concurrentMeta.State["other"] = []byte("v2")
+	concurrentJSON, err := json.Marshal(concurrentMeta)
+	require.NoError(t, err)
+	require.NoError(t, rdb.Set(ctx, c.keys.SessionMetaKey(key), concurrentJSON, time.Hour).Err())
+
+	var updatedMeta sessionMeta
+	require.NoError(t, json.Unmarshal(originalJSON, &updatedMeta))
+	updatedMeta.State["new"] = []byte("v3")
+	updatedJSON, err := json.Marshal(updatedMeta)
+	require.NoError(t, err)
+
+	result, err := luaUpdateSessionState.Run(
+		ctx,
+		rdb,
+		[]string{c.keys.SessionMetaKey(key)},
+		string(originalJSON),
+		string(updatedJSON),
+		int64(time.Hour.Seconds()),
+	).Int()
+	require.NoError(t, err)
+	assert.Equal(t, 2, result)
+
+	currentJSON, err := rdb.Get(ctx, c.keys.SessionMetaKey(key)).Bytes()
+	require.NoError(t, err)
+	assert.JSONEq(t, string(concurrentJSON), string(currentJSON))
+}
+
+func TestClient_UpdateSessionState_PreservesTracksAfterAppend(t *testing.T) {
+	_, rdb := setupMiniredis(t)
+	c := NewClient(rdb, defaultConfig())
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "uss-track"}
+
+	_, err := c.CreateSession(ctx, key, nil)
+	require.NoError(t, err)
+
+	tracksJSON, err := json.Marshal([]string{"alpha"})
+	require.NoError(t, err)
+	require.NoError(t, c.AppendTrackEvent(ctx, key, &session.TrackEvent{
+		Track:     "alpha",
+		Payload:   json.RawMessage(`"payload"`),
+		Timestamp: time.Now(),
+	}, tracksJSON))
+
+	require.NoError(t, c.UpdateSessionState(ctx, key, session.StateMap{
+		"marker": []byte("1"),
+	}))
+
+	sess, err := c.GetSession(ctx, key, 0, time.Time{})
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Equal(t, []byte("1"), sess.State["marker"])
+
+	tracks, err := session.TracksFromState(sess.State)
+	require.NoError(t, err)
+	assert.Contains(t, tracks, session.Track("alpha"))
 }


### PR DESCRIPTION
## Summary
- serialize mysql/postgres session-state read-modify-write paths with row locks
- add hashidx lua compare-and-set for UpdateSessionState and retry on concurrent writers
- keep this as WIP while mysql sqlmock coverage is still being updated

## Validation
- [x] `cd session/redis && go test ./...`
- [ ] `cd session/mysql && go test ./...` (currently failing due stale sqlmock expectations after transaction changes)
- [ ] `cd session/postgres && go test ./...` (not fully verified in this pass)
