### PR TITLE
{runner, docs}: clarify ToolSet lifecycle and cleanup

### DIFF
--- a/docs/mkdocs/en/runner.md
+++ b/docs/mkdocs/en/runner.md
@@ -204,6 +204,33 @@ Notes:
 - The factory is called once per `Runner.Run(...)`.
 - `agent.WithAgent(...)` still overrides everything (useful for tests).
 
+#### Resource Ownership Inside Agent Factories
+
+`AgentFactory` is ideal for request-scoped Agent construction, but it
+**does not transfer ownership of resources** created inside the factory.
+
+- The `Runner` only asks the factory for an `agent.Agent`.
+- `Runner.Close()` only closes resources created or owned by the Runner
+  itself; it does **not** automatically close request-scoped
+  `tool.ToolSet` instances, temporary MCP connections, sandbox sessions,
+  or similar resources created inside the factory.
+- The reason is structural: the `agent.Agent` interface does not expose a
+  `Close()` method, so the Runner has no generic way to reclaim those
+  resources.
+
+Recommended patterns:
+
+- If a `ToolSet` or external connection can be reused across requests,
+  create it once outside the factory, reuse it inside the factory, and
+  close it during application shutdown.
+- If a resource must be created per request, the caller should clean it
+  up explicitly after that run finishes. Common patterns are wrapping the
+  Agent with cleanup logic, or running cleanup from an after-agent
+  callback.
+
+This boundary is especially important when using MCP ToolSets. See the
+ToolSet lifecycle notes in the `tool` documentation for more details.
+
 ### 🔌 Plugins
 
 Runner plugins are global, runner-scoped hooks. Register plugins once and they

--- a/docs/mkdocs/en/tool.md
+++ b/docs/mkdocs/en/tool.md
@@ -288,6 +288,37 @@ agent := llmagent.New("mcp-assistant",
     llmagent.WithToolSets([]tool.ToolSet{mcpToolSet}))
 ```
 
+### ToolSet Lifecycle and Ownership
+
+The `ToolSet` interface explicitly includes `Close()`. That means the
+party that creates a ToolSet is also responsible for releasing the
+connections, sessions, caches, and other resources it owns.
+
+Important ownership boundaries:
+
+- `llmagent.WithToolSets(...)` only attaches a `ToolSet` to an Agent for
+  use. It does **not** transfer ownership.
+- `LLMAgent.AddToolSet(...)`, `LLMAgent.RemoveToolSet(...)`, and
+  `LLMAgent.SetToolSets(...)` only change which tools the Agent exposes.
+  They do **not** automatically call `Close()` on replaced or removed
+  ToolSets.
+- `runner.NewRunner(...)` and `runner.NewRunnerWithAgentFactory(...)`
+  likewise do not automatically reclaim a ToolSet just because an Agent
+  uses it.
+
+Recommended patterns:
+
+- **Long-lived ToolSet**: create it at startup, optionally call
+  `Init(ctx)`, reuse it across many runs, and close it during
+  application shutdown.
+- **Per-request ToolSet**: create it only for the current run, then
+  clean it up explicitly when that run finishes.
+
+If your goal is only to let a ToolSet fetch the **latest** tool list on
+each run, prefer `llmagent.WithRefreshToolSetsOnRun(true)`. That refreshes
+`ToolSet.Tools(ctx)` per run, but it does **not** recreate or close the
+ToolSet instance itself.
+
 ### Transport Configuration
 
 MCP ToolSet supports three transports via the `Transport` field:
@@ -404,6 +435,19 @@ ToolSets to honor a specific context for initialization or tool
 discovery without refreshing the tool list on every run, keep using the
 pattern shown in the `examples/mcptool/http_headers` example, where you
 manually call `toolSet.Tools(ctx)` and pass the tools via `WithTools`.
+
+Common pitfalls:
+
+- `WithRefreshToolSetsOnRun(true)` refreshes the **tool list**, not the
+  ToolSet instance itself. It does not automatically create, replace, or
+  close ToolSets for you.
+- `tools/call` uses the current run context, but if you call
+  `agent.Tools()` outside a run, the ToolSet will see
+  `context.Background()`.
+- If `initialize/tools/list` must strictly use a custom context
+  (for example, per-request auth headers or tracing values), the safer
+  pattern is usually to call `toolSet.Tools(ctx)` yourself and inject the
+  resulting tools via `WithTools(...)`.
 
 ## Agent Tool (AgentTool)
 
@@ -1006,6 +1050,16 @@ These methods are concurrency‑safe and automatically recompute:
 
 - Aggregated tools (direct tools + ToolSets + knowledge tools + skill tools)
 - User tool tracking (used by the smart filtering logic above)
+
+One important lifecycle detail:
+
+- `AddToolSet` does **not** automatically close a replaced ToolSet.
+- `RemoveToolSet` does **not** automatically close a removed ToolSet.
+- `SetToolSets` does **not** automatically close ToolSets from the
+  previous slice.
+
+If you created those ToolSet instances, you still need to close them
+explicitly at the right time.
 
 **Typical usage pattern:**
 

--- a/docs/mkdocs/zh/runner.md
+++ b/docs/mkdocs/zh/runner.md
@@ -203,6 +203,28 @@ _ = err
 - 每次调用 `Runner.Run(...)`，Factory 会被调用一次。
 - `agent.WithAgent(...)` 依然优先生效（测试时很方便）。
 
+#### Agent Factory 中的资源边界
+
+`AgentFactory` 适合按请求拼装 Agent 配置，但它**不会改变资源所有权**。
+
+- `Runner` 只负责调用 factory 获取一个 `agent.Agent`。
+- `Runner.Close()` 只会关闭 Runner 自己创建或持有的资源；它**不会**
+  自动关闭 factory 内部新建的 `tool.ToolSet`、临时 MCP 连接、沙箱会话
+  等请求级资源。
+- 原因是 `agent.Agent` 接口本身没有 `Close()`，因此 Runner 无法统一接管
+  这类资源的释放。
+
+实践建议：
+
+- 如果某个 `ToolSet` 或外部连接适合跨请求复用，优先在 factory 外创建一次，
+  然后在 factory 中复用；应用退出时再统一 `Close()`。
+- 如果资源必须按请求创建，调用方需要在本次 run 结束后自行清理。
+  常见做法是包装一个带清理逻辑的 Agent，或者在 Agent 的
+  after callback 中执行清理。
+
+这类边界在使用 MCP ToolSet 时尤其常见，详细说明可继续参考
+`tool` 文档中的 ToolSet 生命周期章节。
+
 ### 🔌 插件
 
 Runner 插件是一类全局、Runner 作用域的 Hook（钩子）。只需要在创建 Runner 时

--- a/docs/mkdocs/zh/tool.md
+++ b/docs/mkdocs/zh/tool.md
@@ -287,6 +287,33 @@ agent := llmagent.New("mcp-assistant",
     llmagent.WithToolSets([]tool.ToolSet{mcpToolSet}))
 ```
 
+### ToolSet 生命周期与所有权
+
+`ToolSet` 接口里显式提供了 `Close()`，这意味着它持有的连接、会话和缓存
+等资源需要由**创建它的一方**负责释放。
+
+几个容易混淆的边界：
+
+- `llmagent.WithToolSets(...)` 只是把 `ToolSet` 挂到 Agent 上使用，
+  **不会**转移其所有权。
+- `LLMAgent` 的 `AddToolSet(...)`、`RemoveToolSet(...)`、
+  `SetToolSets(...)` 只会更新 Agent 当前暴露的工具集合，
+  **不会**自动调用旧 `ToolSet` 的 `Close()`。
+- `runner.NewRunner(...)` 和 `runner.NewRunnerWithAgentFactory(...)`
+  也不会因为 Agent 使用了某个 `ToolSet`，就在 `Runner.Close()` 时
+  自动回收它。
+
+推荐的使用方式：
+
+- **长生命周期 ToolSet**：在应用启动时创建并可选执行 `Init(ctx)`，
+  多次请求复用；应用退出时统一 `Close()`。
+- **按请求创建的 ToolSet**：只在当前 run 内使用；当前 run 结束后由
+  调用方显式清理。
+
+如果你只是希望 ToolSet 在每次执行时重新获取**最新工具列表**，优先使用
+`llmagent.WithRefreshToolSetsOnRun(true)`。这会在每次 run 前重新调用
+`ToolSet.Tools(ctx)`，但**不会**为你重建或关闭 `ToolSet` 实例本身。
+
 ### 传输方式配置
 
 MCP ToolSet 通过 `Transport` 字段支持三种传输方式：
@@ -410,6 +437,16 @@ agent := llmagent.New(
 `context.Context` 在初始化或工具发现阶段做更细粒度的控制，同时又不希望
 在每次执行时刷新工具列表，可以参考 `examples/mcptool/http_headers`
 示例，手动调用 `toolSet.Tools(ctx)`，然后配合 `WithTools` 使用。
+
+常见误区：
+
+- `WithRefreshToolSetsOnRun(true)` 刷新的是**工具列表**，不是 `ToolSet`
+  实例本身；它不会自动新建、替换或关闭 `ToolSet`。
+- `tools/call` 会使用本次 run 的上下文，但如果你在执行期外直接调用
+  `agent.Tools()`，ToolSet 看到的是 `context.Background()`。
+- 如果你需要让 `initialize/tools/list` 也严格使用某个自定义上下文
+  （例如每次请求不同的认证头、追踪字段），更稳妥的做法通常是手动
+  `toolSet.Tools(ctx)`，再通过 `WithTools(...)` 注入。
 
 ## Agent 工具 (AgentTool)
 
@@ -997,6 +1034,14 @@ LLMAgent 提供了三个与 ToolSet 相关的运行时方法：
 
 - 聚合后的工具列表（显式 `WithTools` 工具 + ToolSet 工具 + 知识检索工具 + Skills 工具）
 - “用户工具”跟踪信息（用于前文介绍的智能过滤机制）
+
+需要特别注意：
+
+- `AddToolSet` 替换同名 ToolSet 时，**不会**自动 `Close()` 被替换掉的旧实例。
+- `RemoveToolSet` 删除 ToolSet 时，**不会**自动 `Close()` 被移除的实例。
+- `SetToolSets` 整体替换时，**不会**自动 `Close()` 旧切片里的实例。
+
+如果这些 ToolSet 是由你创建的，你仍然需要在合适的时机显式回收它们。
 
 **典型使用方式：**
 


### PR DESCRIPTION
## Summary
- document AgentFactory resource ownership and clarify that Runner does not close ToolSets created inside factories
- document ToolSet lifecycle ownership for WithToolSets and Runner usage patterns
- document that WithRefreshToolSetsOnRun(true) refreshes tool discovery only, and that AddToolSet/RemoveToolSet/SetToolSets do not auto-close previous ToolSets

## Testing
- git diff --check
- markdownlint not available in this environment
- mkdocs build --strict not available in this environment