### PR TITLE
model: fix race condition in chatRequestCallback invocation

### DIFF
--- a/model/anthropic/anthropic.go
+++ b/model/anthropic/anthropic.go
@@ -132,13 +132,16 @@ func (m *Model) GenerateContent(
 	if err != nil {
 		return nil, fmt.Errorf("build chat request: %w", err)
 	}
+	// Execute callback synchronously before starting the goroutine
+	// to avoid a race where the runner and HTTP handler finish
+	// (closing the SSE writer) while the callback is still running.
+	if m.chatRequestCallback != nil {
+		m.chatRequestCallback(ctx, chatRequest)
+	}
 	// Send chat request and handle response.
 	responseChan := make(chan *model.Response, m.channelBufferSize)
 	go func() {
 		defer close(responseChan)
-		if m.chatRequestCallback != nil {
-			m.chatRequestCallback(ctx, chatRequest)
-		}
 		if request.Stream {
 			m.handleStreamingResponse(ctx, *chatRequest, responseChan)
 			return

--- a/model/anthropic/anthropic_test.go
+++ b/model/anthropic/anthropic_test.go
@@ -1931,3 +1931,158 @@ func TestIntegration_AutoOptimalCacheStrategy(t *testing.T) {
 	}
 	assert.True(t, foundCacheControl, "expected cache control to be automatically applied to assistant message")
 }
+
+// TestChatRequestCallbackSynchronous verifies that
+// chatRequestCallback is invoked synchronously inside
+// GenerateContent, before the response goroutine starts.
+func TestChatRequestCallbackSynchronous(t *testing.T) {
+	tests := []struct {
+		name   string
+		stream bool
+	}{
+		{name: "non_streaming", stream: false},
+		{name: "streaming", stream: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orig := model.DefaultNewHTTPClient
+			t.Cleanup(func() {
+				model.DefaultNewHTTPClient = orig
+			})
+			if tt.stream {
+				sse := strings.Join([]string{
+					"event: message_start",
+					`data: {"type":"message_start",` +
+						`"message":{"id":"m1",` +
+						`"type":"message",` +
+						`"role":"assistant",` +
+						`"model":"claude","content":[]}}`,
+					"",
+					"event: content_block_start",
+					`data: {"type":` +
+						`"content_block_start",` +
+						`"index":0,"content_block":` +
+						`{"type":"text","text":""}}`,
+					"",
+					"event: content_block_delta",
+					`data: {"type":` +
+						`"content_block_delta",` +
+						`"index":0,"delta":` +
+						`{"type":"text_delta",` +
+						`"text":"hi"}}`,
+					"",
+					"event: content_block_stop",
+					`data: {"type":` +
+						`"content_block_stop","index":0}`,
+					"",
+					"event: message_delta",
+					`data: {"type":"message_delta",` +
+						`"delta":{"stop_reason":` +
+						`"end_turn","stop_sequence":""},` +
+						`"usage":{` +
+						`"cache_creation_input_tokens":0,` +
+						`"cache_read_input_tokens":0,` +
+						`"input_tokens":0,` +
+						`"output_tokens":0,` +
+						`"server_tool_use":` +
+						`{"web_search_requests":0}}}`,
+					"",
+					"event: message_stop",
+					`data: {"type":"message_stop"}`,
+					"",
+				}, "\n")
+				model.DefaultNewHTTPClient = func(
+					_ ...HTTPClientOption,
+				) model.HTTPClient {
+					return &http.Client{
+						Transport: rtFunc(
+							func(_ *http.Request,
+							) (*http.Response, error) {
+								h := make(http.Header)
+								h.Set("Content-Type",
+									"text/event-stream")
+								return &http.Response{
+									StatusCode: 200,
+									Header:     h,
+									Body: io.NopCloser(
+										strings.NewReader(sse)),
+								}, nil
+							}),
+					}
+				}
+			} else {
+				body := `{"id":"m1","model":"claude",` +
+					`"role":"assistant",` +
+					`"stop_reason":"end_turn",` +
+					`"stop_sequence":"",` +
+					`"type":"message",` +
+					`"usage":{` +
+					`"cache_creation_input_tokens":0,` +
+					`"cache_read_input_tokens":0,` +
+					`"input_tokens":1,` +
+					`"output_tokens":1,` +
+					`"server_tool_use":` +
+					`{"web_search_requests":0}},` +
+					`"content":[{"type":"text",` +
+					`"text":"hi"}]}`
+				model.DefaultNewHTTPClient = func(
+					_ ...HTTPClientOption,
+				) model.HTTPClient {
+					return &http.Client{
+						Transport: rtFunc(
+							func(_ *http.Request,
+							) (*http.Response, error) {
+								h := make(http.Header)
+								h.Set("Content-Type",
+									"application/json")
+								return &http.Response{
+									StatusCode: 200,
+									Header:     h,
+									Body: io.NopCloser(
+										strings.NewReader(body)),
+								}, nil
+							}),
+					}
+				}
+			}
+
+			var callCount int64
+			m := New("claude-test",
+				WithHTTPClientOptions(),
+				WithChatRequestCallback(
+					func(_ context.Context,
+						_ *anthropic.MessageNewParams,
+					) {
+						callCount++
+					}),
+			)
+
+			req := &model.Request{
+				Messages: []model.Message{
+					model.NewUserMessage("hi"),
+				},
+				GenerationConfig: model.GenerationConfig{
+					Stream: tt.stream,
+				},
+			}
+
+			ch, err := m.GenerateContent(
+				context.Background(), req)
+			assert.NoError(t, err)
+
+			// Callback must have fired synchronously
+			// before GenerateContent returned.
+			assert.Equal(t, int64(1), callCount,
+				"callback must execute exactly once "+
+					"before GenerateContent returns")
+
+			// Drain the channel to avoid goroutine leak.
+			for range ch {
+			}
+
+			// Confirm no extra invocations after drain.
+			assert.Equal(t, int64(1), callCount,
+				"callback must not be called more than once")
+		})
+	}
+}

--- a/model/anthropic/anthropic_test.go
+++ b/model/anthropic/anthropic_test.go
@@ -2068,7 +2068,7 @@ func TestChatRequestCallbackSynchronous(t *testing.T) {
 
 			ch, err := m.GenerateContent(
 				context.Background(), req)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			// Callback must have fired synchronously
 			// before GenerateContent returned.

--- a/model/anthropic/options.go
+++ b/model/anthropic/options.go
@@ -170,7 +170,10 @@ func WithAnthropicRequestOptions(opts ...option.RequestOption) Option {
 	}
 }
 
-// WithChatRequestCallback sets the function to be called before sending a chat request.
+// WithChatRequestCallback sets the function to be called before sending a
+// chat request. The callback runs synchronously in GenerateContent before
+// the response goroutine starts. Start your own goroutine in the callback
+// if asynchronous behavior is needed.
 func WithChatRequestCallback(fn ChatRequestCallbackFunc) Option {
 	return func(opts *options) {
 		opts.chatRequestCallback = fn

--- a/model/gemini/gemini.go
+++ b/model/gemini/gemini.go
@@ -107,21 +107,21 @@ func (m *Model) GenerateContent(
 	m.applyTokenTailoring(ctx, request)
 	chatRequest := m.convertMessages(request.Messages)
 	generateConfig := m.buildChatConfig(request)
+	// Execute callback synchronously before starting the goroutine
+	// to avoid a race where the runner and HTTP handler finish
+	// (closing the SSE writer) while the callback is still running.
+	if m.chatRequestCallback != nil {
+		m.chatRequestCallback(ctx, chatRequest)
+	}
 	responseChan := make(chan *model.Response, m.channelBufferSize)
 	go func() {
 		defer close(responseChan)
-
-		if m.chatRequestCallback != nil {
-			m.chatRequestCallback(ctx, chatRequest)
-		}
-
 		if request.Stream {
 			m.handleStreamingResponse(ctx, chatRequest, responseChan, generateConfig)
 		} else {
 			m.handleNonStreamingResponse(ctx, chatRequest, responseChan, generateConfig)
 		}
 	}()
-
 	return responseChan, nil
 }
 

--- a/model/gemini/gemini_test.go
+++ b/model/gemini/gemini_test.go
@@ -2286,7 +2286,7 @@ func TestChatRequestCallbackSynchronous(t *testing.T) {
 
 			ch, err := m.GenerateContent(
 				context.Background(), req)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			// Callback must have fired synchronously
 			// before GenerateContent returned.

--- a/model/gemini/gemini_test.go
+++ b/model/gemini/gemini_test.go
@@ -2203,3 +2203,104 @@ func TestModel_ContextCancellation_Streaming(t *testing.T) {
 		drainWithTimeout(t, respChan)
 	})
 }
+
+// TestChatRequestCallbackSynchronous verifies that
+// chatRequestCallback is invoked synchronously inside
+// GenerateContent, before the response goroutine starts.
+func TestChatRequestCallbackSynchronous(t *testing.T) {
+	subText := "text"
+	now := time.Now()
+	resp := &genai.GenerateContentResponse{
+		ResponseID:   "1",
+		CreateTime:   now,
+		ModelVersion: "v1",
+		Candidates: []*genai.Candidate{{
+			Content: &genai.Content{
+				Parts: []*genai.Part{{Text: "hi"}},
+			},
+			FinishReason: genai.FinishReason("stop"),
+		}},
+		UsageMetadata: &genai.GenerateContentResponseUsageMetadata{
+			TotalTokenCount: 1,
+		},
+	}
+
+	tests := []struct {
+		name   string
+		stream bool
+	}{
+		{name: "non_streaming", stream: false},
+		{name: "streaming", stream: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockClient := NewMockClient(ctrl)
+			mockModels := NewMockModels(ctrl)
+			mockClient.EXPECT().Models().
+				Return(mockModels).AnyTimes()
+
+			if tt.stream {
+				mockModels.EXPECT().
+					GenerateContentStream(
+						gomock.Any(), gomock.Any(),
+						gomock.Any(), gomock.Any()).
+					Return(seqFromSlice(
+						[]*genai.GenerateContentResponse{
+							resp,
+						})).AnyTimes()
+			} else {
+				mockModels.EXPECT().
+					GenerateContent(
+						gomock.Any(), gomock.Any(),
+						gomock.Any(), gomock.Any()).
+					Return(resp, nil).AnyTimes()
+			}
+
+			var callCount int64
+			m := &Model{
+				client: mockClient,
+				chatRequestCallback: func(
+					_ context.Context,
+					_ []*genai.Content,
+				) {
+					callCount++
+				},
+			}
+
+			req := &model.Request{
+				Messages: []model.Message{{
+					Role:    model.RoleUser,
+					Content: "hi",
+					ContentParts: []model.ContentPart{{
+						Type: model.ContentTypeText,
+						Text: &subText,
+					}},
+				}},
+				GenerationConfig: model.GenerationConfig{
+					Stream: tt.stream,
+				},
+			}
+
+			ch, err := m.GenerateContent(
+				context.Background(), req)
+			assert.NoError(t, err)
+
+			// Callback must have fired synchronously
+			// before GenerateContent returned.
+			assert.Equal(t, int64(1), callCount,
+				"callback must execute exactly once "+
+					"before GenerateContent returns")
+
+			// Drain the channel to avoid goroutine leak.
+			for range ch {
+			}
+
+			// Confirm no extra invocations after drain.
+			assert.Equal(t, int64(1), callCount,
+				"callback must not be called more than once")
+		})
+	}
+}

--- a/model/gemini/options.go
+++ b/model/gemini/options.go
@@ -106,7 +106,10 @@ func WithChannelBufferSize(size int) Option {
 	}
 }
 
-// WithChatRequestCallback sets the function to be called before sending a chat request.
+// WithChatRequestCallback sets the function to be called before sending a
+// chat request. The callback runs synchronously in GenerateContent before
+// the response goroutine starts. Start your own goroutine in the callback
+// if asynchronous behavior is needed.
 func WithChatRequestCallback(fn ChatRequestCallbackFunc) Option {
 	return func(opts *options) {
 		opts.chatRequestCallback = fn

--- a/model/huggingface/huggingface.go
+++ b/model/huggingface/huggingface.go
@@ -125,6 +125,13 @@ func (m *Model) GenerateContent(ctx context.Context, request *model.Request) (<-
 		return nil, fmt.Errorf("failed to convert request: %w", err)
 	}
 
+	// Execute callback synchronously before starting the goroutine
+	// to avoid a race where the runner and HTTP handler finish
+	// (closing the SSE writer) while the callback is still running.
+	if m.chatRequestCallback != nil {
+		m.chatRequestCallback(ctx, hfRequest)
+	}
+
 	// Create response channel.
 	responseChan := make(chan *model.Response, m.channelBufferSize)
 
@@ -195,11 +202,6 @@ func (m *Model) handleStreamingRequest(
 			m.chatStreamCompleteCallback(ctx, hfRequest, streamErr)
 		}
 	}()
-
-	// Call request callback if provided.
-	if m.chatRequestCallback != nil {
-		m.chatRequestCallback(ctx, hfRequest)
-	}
 
 	// Make streaming HTTP request.
 	hfRequest.Stream = true

--- a/model/huggingface/huggingface.go
+++ b/model/huggingface/huggingface.go
@@ -161,11 +161,6 @@ func (m *Model) handleNonStreamingRequest(
 ) {
 	defer close(responseChan)
 
-	// Call request callback if provided.
-	if m.chatRequestCallback != nil {
-		m.chatRequestCallback(ctx, hfRequest)
-	}
-
 	// Make HTTP request.
 	hfResponse, err := m.makeRequest(ctx, hfRequest)
 	if err != nil {

--- a/model/huggingface/huggingface_test.go
+++ b/model/huggingface/huggingface_test.go
@@ -3887,3 +3887,104 @@ func TestGenerateContent_TokenTailoringWithUserMaxTokens(t *testing.T) {
 	assert.Equal(t, userMaxTokens, *capturedRequest.MaxTokens, "应该使用用户指定的 MaxTokens")
 	t.Logf("用户指定的 MaxTokens 被正确保留: %d", *capturedRequest.MaxTokens)
 }
+
+// TestChatRequestCallbackSynchronous verifies that
+// chatRequestCallback is invoked synchronously inside
+// GenerateContent, before the response goroutine starts.
+func TestChatRequestCallbackSynchronous(t *testing.T) {
+	tests := []struct {
+		name   string
+		stream bool
+	}{
+		{name: "non_streaming", stream: false},
+		{name: "streaming", stream: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(
+				func(w http.ResponseWriter, r *http.Request) {
+					if !strings.HasSuffix(
+						r.URL.Path, "/chat/completions",
+					) {
+						http.Error(w, "not found",
+							http.StatusNotFound)
+						return
+					}
+					if tt.stream {
+						w.Header().Set("Content-Type",
+							"text/event-stream")
+						flusher, _ := w.(http.Flusher)
+						fmt.Fprint(w,
+							`data: {"id":"s","object":`+
+								`"chat.completion.chunk",`+
+								`"created":1,"model":"m",`+
+								`"choices":[{"index":0,`+
+								`"delta":{"role":"assistant",`+
+								`"content":"hi"},`+
+								`"finish_reason":"stop"}]}`+
+								"\n\n")
+						flusher.Flush()
+						fmt.Fprint(w,
+							"data: [DONE]\n\n")
+						flusher.Flush()
+						return
+					}
+					w.Header().Set("Content-Type",
+						"application/json")
+					fmt.Fprint(w,
+						`{"id":"n","object":`+
+							`"chat.completion",`+
+							`"created":1,"model":"m",`+
+							`"choices":[{"index":0,`+
+							`"message":{"role":"assistant",`+
+							`"content":"hi"},`+
+							`"finish_reason":"stop"}],`+
+							`"usage":{"prompt_tokens":1,`+
+							`"completion_tokens":1,`+
+							`"total_tokens":2}}`)
+				}))
+			defer server.Close()
+
+			var callCount int64
+			m, err := New("test-model",
+				WithAPIKey("key"),
+				WithBaseURL(server.URL),
+				WithChatRequestCallback(
+					func(_ context.Context,
+						_ *ChatCompletionRequest,
+					) {
+						callCount++
+					}),
+			)
+			require.NoError(t, err)
+
+			req := &model.Request{
+				Messages: []model.Message{
+					{Role: model.RoleUser,
+						Content: "hi"},
+				},
+				GenerationConfig: model.GenerationConfig{
+					Stream: tt.stream,
+				},
+			}
+
+			ch, err := m.GenerateContent(
+				context.Background(), req)
+			require.NoError(t, err)
+
+			// Callback must have fired synchronously
+			// before GenerateContent returned.
+			assert.Equal(t, int64(1), callCount,
+				"callback must execute exactly once "+
+					"before GenerateContent returns")
+
+			// Drain the channel to avoid goroutine leak.
+			for range ch {
+			}
+
+			// Confirm no extra invocations after drain.
+			assert.Equal(t, int64(1), callCount,
+				"callback must not be called more than once")
+		})
+	}
+}

--- a/model/huggingface/options.go
+++ b/model/huggingface/options.go
@@ -138,7 +138,10 @@ func WithHTTPClient(client *http.Client) Option {
 	}
 }
 
-// WithChatRequestCallback sets the function to be called before sending a chat request.
+// WithChatRequestCallback sets the function to be called before sending a
+// chat request. The callback runs synchronously in GenerateContent before
+// the response goroutine starts. Start your own goroutine in the callback
+// if asynchronous behavior is needed.
 func WithChatRequestCallback(fn ChatRequestCallbackFunc) Option {
 	return func(opts *options) {
 		opts.ChatRequestCallback = fn

--- a/model/hunyuan/hunyuan.go
+++ b/model/hunyuan/hunyuan.go
@@ -199,13 +199,16 @@ func (m *Model) GenerateContent(
 		return nil, fmt.Errorf("build chat request: %w", err)
 	}
 
+	// Execute callback synchronously before starting the goroutine
+	// to avoid a race where the runner and HTTP handler finish
+	// (closing the SSE writer) while the callback is still running.
+	if m.chatRequestCallback != nil {
+		m.chatRequestCallback(ctx, chatRequest)
+	}
 	// Send chat request and handle response.
 	responseChan := make(chan *model.Response, m.channelBufferSize)
 	go func() {
 		defer close(responseChan)
-		if m.chatRequestCallback != nil {
-			m.chatRequestCallback(ctx, chatRequest)
-		}
 		if request.Stream {
 			m.handleStreamingResponse(ctx, chatRequest, responseChan)
 			return

--- a/model/hunyuan/hunyuan_test.go
+++ b/model/hunyuan/hunyuan_test.go
@@ -1270,3 +1270,112 @@ func TestTokenTailoringCounterError(t *testing.T) {
 		t.Fatalf("Expected 1 response, got %d", len(responses))
 	}
 }
+
+// TestChatRequestCallbackSynchronous verifies that
+// chatRequestCallback is invoked synchronously inside
+// GenerateContent, before the response goroutine starts.
+func TestChatRequestCallbackSynchronous(t *testing.T) {
+	tests := []struct {
+		name   string
+		stream bool
+	}{
+		{name: "non_streaming", stream: false},
+		{name: "streaming", stream: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(
+				func(w http.ResponseWriter, r *http.Request) {
+					if tt.stream {
+						w.Header().Set("Content-Type",
+							"text/event-stream")
+						w.WriteHeader(http.StatusOK)
+						flusher, _ := w.(http.Flusher)
+						chunk := hunyuan.ChatCompletionResponse{
+							Id:      "s1",
+							Created: 1,
+							Choices: []*hunyuan.ChatCompletionResponseChoice{{
+								Index: 0,
+								Delta: &hunyuan.ChatCompletionResponseDelta{
+									Role:    "assistant",
+									Content: "hi",
+								},
+								FinishReason: "stop",
+							}},
+						}
+						data, _ := json.Marshal(chunk)
+						fmt.Fprintf(w,
+							"data: %s\n\n", data)
+						flusher.Flush()
+						fmt.Fprint(w, "data: [DONE]\n\n")
+						flusher.Flush()
+						return
+					}
+					w.Header().Set("Content-Type",
+						"application/json")
+					resp := struct {
+						Response hunyuan.ChatCompletionResponse `json:"Response"`
+					}{
+						Response: hunyuan.ChatCompletionResponse{
+							Id:      "n1",
+							Created: 1,
+							Choices: []*hunyuan.ChatCompletionResponseChoice{{
+								Index:        0,
+								FinishReason: "stop",
+								Message: &hunyuan.ChatCompletionMessageParam{
+									Role:    "assistant",
+									Content: "hi",
+								},
+							}},
+							Usage: hunyuan.ChatCompletionResponseUsage{
+								TotalTokens: 1,
+							},
+						},
+					}
+					json.NewEncoder(w).Encode(resp)
+				}))
+			defer srv.Close()
+
+			var callCount int64
+			m := New("hunyuan-lite",
+				WithSecretId("id"),
+				WithSecretKey("key"),
+				WithBaseUrl(srv.URL),
+				WithHost("test"),
+				WithChatRequestCallback(
+					func(_ context.Context,
+						_ *hunyuan.ChatCompletionNewParams,
+					) {
+						callCount++
+					}),
+			)
+
+			req := &model.Request{
+				Messages: []model.Message{
+					model.NewUserMessage("hi"),
+				},
+				GenerationConfig: model.GenerationConfig{
+					Stream: tt.stream,
+				},
+			}
+
+			ch, err := m.GenerateContent(
+				context.Background(), req)
+			assert.NoError(t, err)
+
+			// Callback must have fired synchronously
+			// before GenerateContent returned.
+			assert.Equal(t, int64(1), callCount,
+				"callback must execute exactly once "+
+					"before GenerateContent returns")
+
+			// Drain the channel to avoid goroutine leak.
+			for range ch {
+			}
+
+			// Confirm no extra invocations after drain.
+			assert.Equal(t, int64(1), callCount,
+				"callback must not be called more than once")
+		})
+	}
+}

--- a/model/hunyuan/hunyuan_test.go
+++ b/model/hunyuan/hunyuan_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/model/hunyuan/internal/hunyuan"
@@ -1290,7 +1291,13 @@ func TestChatRequestCallbackSynchronous(t *testing.T) {
 						w.Header().Set("Content-Type",
 							"text/event-stream")
 						w.WriteHeader(http.StatusOK)
-						flusher, _ := w.(http.Flusher)
+						flusher, ok := w.(http.Flusher)
+						if !ok {
+							http.Error(w,
+								"no flusher",
+								http.StatusInternalServerError)
+							return
+						}
 						chunk := hunyuan.ChatCompletionResponse{
 							Id:      "s1",
 							Created: 1,
@@ -1361,7 +1368,7 @@ func TestChatRequestCallbackSynchronous(t *testing.T) {
 
 			ch, err := m.GenerateContent(
 				context.Background(), req)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			// Callback must have fired synchronously
 			// before GenerateContent returned.

--- a/model/hunyuan/options.go
+++ b/model/hunyuan/options.go
@@ -79,7 +79,10 @@ func WithChannelBufferSize(size int) Option {
 	}
 }
 
-// WithChatRequestCallback sets the function to be called before sending a chat request.
+// WithChatRequestCallback sets the function to be called before sending a
+// chat request. The callback runs synchronously in GenerateContent before
+// the response goroutine starts. Start your own goroutine in the callback
+// if asynchronous behavior is needed.
 func WithChatRequestCallback(fn ChatRequestCallbackFunc) Option {
 	return func(opts *options) {
 		opts.chatRequestCallback = fn

--- a/model/ollama/ollama.go
+++ b/model/ollama/ollama.go
@@ -169,13 +169,16 @@ func (m *Model) GenerateContent(
 		return nil, fmt.Errorf("build chat request: %w", err)
 	}
 
+	// Execute callback synchronously before starting the goroutine
+	// to avoid a race where the runner and HTTP handler finish
+	// (closing the SSE writer) while the callback is still running.
+	if m.chatRequestCallback != nil {
+		m.chatRequestCallback(ctx, chatRequest)
+	}
 	// Send chat request and handle response.
 	responseChan := make(chan *model.Response, m.channelBufferSize)
 	go func() {
 		defer close(responseChan)
-		if m.chatRequestCallback != nil {
-			m.chatRequestCallback(ctx, chatRequest)
-		}
 		if request.Stream {
 			m.handleStreamingResponse(ctx, *chatRequest, responseChan)
 			return

--- a/model/ollama/ollama_test.go
+++ b/model/ollama/ollama_test.go
@@ -1034,3 +1034,110 @@ func Test_WithKeepAlive(t *testing.T) {
 	assert.NotNil(t, m.keepAlive)
 	assert.Equal(t, duration, m.keepAlive.Duration)
 }
+
+// TestChatRequestCallbackSynchronous verifies that
+// chatRequestCallback is invoked synchronously inside
+// GenerateContent, before the response goroutine starts.
+func TestChatRequestCallbackSynchronous(t *testing.T) {
+	tests := []struct {
+		name   string
+		stream bool
+	}{
+		{name: "non_streaming", stream: false},
+		{name: "streaming", stream: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(
+				func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type",
+						"application/json")
+					if r.URL.Path == "/api/show" {
+						json.NewEncoder(w).Encode(
+							map[string]any{
+								"model_info": map[string]any{
+									"llama.context_length": 4096,
+								},
+							})
+						return
+					}
+					if tt.stream {
+						flusher, ok :=
+							w.(http.Flusher)
+						if !ok {
+							http.Error(w,
+								"no flusher",
+								http.StatusInternalServerError)
+							return
+						}
+						chunks := []map[string]any{
+							{
+								"model":      "m",
+								"created_at": "2024-01-01T00:00:00Z",
+								"message": map[string]any{
+									"role":    "assistant",
+									"content": "hi",
+								},
+								"done":              true,
+								"prompt_eval_count": 1,
+								"eval_count":        1,
+							},
+						}
+						for _, c := range chunks {
+							json.NewEncoder(w).Encode(c)
+							flusher.Flush()
+						}
+						return
+					}
+					json.NewEncoder(w).Encode(
+						map[string]any{
+							"model":             "m",
+							"created_at":        "2024-01-01T00:00:00Z",
+							"message":           map[string]any{"role": "assistant", "content": "hi"},
+							"done":              true,
+							"prompt_eval_count": 1,
+							"eval_count":        1,
+						})
+				}))
+			defer srv.Close()
+
+			var callCount int64
+			m := New("test-model",
+				WithHost(srv.URL),
+				WithChatRequestCallback(
+					func(_ context.Context,
+						_ *api.ChatRequest,
+					) {
+						callCount++
+					}),
+			)
+
+			req := &model.Request{
+				Messages: []model.Message{
+					model.NewUserMessage("hi"),
+				},
+				GenerationConfig: model.GenerationConfig{
+					Stream: tt.stream,
+				},
+			}
+
+			ch, err := m.GenerateContent(
+				context.Background(), req)
+			require.NoError(t, err)
+
+			// Callback must have fired synchronously
+			// before GenerateContent returned.
+			assert.Equal(t, int64(1), callCount,
+				"callback must execute exactly once "+
+					"before GenerateContent returns")
+
+			// Drain the channel to avoid goroutine leak.
+			for range ch {
+			}
+
+			// Confirm no extra invocations after drain.
+			assert.Equal(t, int64(1), callCount,
+				"callback must not be called more than once")
+		})
+	}
+}

--- a/model/ollama/options.go
+++ b/model/ollama/options.go
@@ -136,7 +136,10 @@ func WithChannelBufferSize(size int) Option {
 	}
 }
 
-// WithChatRequestCallback sets the function to be called before sending a chat request.
+// WithChatRequestCallback sets the function to be called before sending a
+// chat request. The callback runs synchronously in GenerateContent before
+// the response goroutine starts. Start your own goroutine in the callback
+// if asynchronous behavior is needed.
 func WithChatRequestCallback(fn ChatRequestCallbackFunc) Option {
 	return func(opts *options) {
 		opts.chatRequestCallback = fn

--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -387,12 +387,15 @@ func (m *Model) GenerateContent(
 	if err != nil {
 		return nil, err
 	}
+	// Execute callback synchronously before starting the goroutine
+	// to avoid a race where the runner and HTTP handler finish
+	// (closing the SSE writer) while the callback is still running.
+	if m.chatRequestCallback != nil {
+		m.chatRequestCallback(ctx, chatRequest)
+	}
 	responseChan := make(chan *model.Response, m.channelBufferSize)
 	go func() {
 		defer close(responseChan)
-		if m.chatRequestCallback != nil {
-			m.chatRequestCallback(ctx, chatRequest)
-		}
 		if request.Stream {
 			m.handleStreamingResponse(ctx, *chatRequest, responseChan, opts...)
 		} else {

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -7012,3 +7012,90 @@ func TestAppendUserContentParts_SkipsInternalFiles(t *testing.T) {
 	require.Nil(t, fields)
 	require.Empty(t, dst)
 }
+
+// TestChatRequestCallbackSynchronous verifies that
+// chatRequestCallback is invoked synchronously inside
+// GenerateContent, before the response goroutine starts.
+func TestChatRequestCallbackSynchronous(t *testing.T) {
+	tests := []struct {
+		name   string
+		stream bool
+	}{
+		{name: "non_streaming", stream: false},
+		{name: "streaming", stream: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(
+				func(w http.ResponseWriter, r *http.Request) {
+					if !strings.HasSuffix(
+						r.URL.Path, "/chat/completions",
+					) {
+						http.Error(w, "not found",
+							http.StatusNotFound)
+						return
+					}
+					if tt.stream {
+						w.Header().Set("Content-Type",
+							"text/event-stream")
+						fmt.Fprint(w, "data: {\"id\":\"s\","+
+							"\"object\":\"chat.completion.chunk\","+
+							"\"created\":1,\"model\":\"m\","+
+							"\"choices\":[{\"index\":0,"+
+							"\"delta\":{\"content\":\"hi\"},"+
+							"\"finish_reason\":\"stop\"}]}\n\n")
+						fmt.Fprint(w, "data: [DONE]\n\n")
+						return
+					}
+					w.Header().Set("Content-Type",
+						"application/json")
+					fmt.Fprint(w, `{"id":"n","object":`+
+						`"chat.completion","created":1,`+
+						`"model":"m","choices":[{"index":0,`+
+						`"message":{"role":"assistant",`+
+						`"content":"hi"},`+
+						`"finish_reason":"stop"}]}`)
+				}))
+			defer server.Close()
+
+			var callCount int64
+			m := New("test-model",
+				WithBaseURL(server.URL),
+				WithAPIKey("key"),
+				WithChatRequestCallback(
+					func(_ context.Context,
+						_ *openai.ChatCompletionNewParams,
+					) {
+						callCount++
+					}),
+			)
+
+			req := &model.Request{
+				Messages: []model.Message{
+					model.NewUserMessage("hi"),
+				},
+				GenerationConfig: model.GenerationConfig{
+					Stream: tt.stream,
+				},
+			}
+
+			ch, err := m.GenerateContent(
+				context.Background(), req)
+			require.NoError(t, err)
+
+			// Callback must have fired synchronously
+			// before GenerateContent returned.
+			assert.Equal(t, int64(1), callCount,
+				"callback must execute exactly once "+
+					"before GenerateContent returns")
+
+			// Drain the channel to avoid goroutine leak.
+			for range ch {
+			}
+
+			// Confirm no extra invocations after drain.
+			assert.Equal(t, int64(1), callCount,
+				"callback must not be called more than once")
+		})
+	}
+}

--- a/model/openai/options.go
+++ b/model/openai/options.go
@@ -163,7 +163,10 @@ func WithChannelBufferSize(size int) Option {
 	}
 }
 
-// WithChatRequestCallback sets the function to be called before sending a chat request.
+// WithChatRequestCallback sets the function to be called before sending a
+// chat request. The callback runs synchronously in GenerateContent before
+// the response goroutine starts. Start your own goroutine in the callback
+// if asynchronous behavior is needed.
 func WithChatRequestCallback(fn ChatRequestCallbackFunc) Option {
 	return func(opts *options) {
 		opts.ChatRequestCallback = fn


### PR DESCRIPTION
## Summary
- Move `chatRequestCallback` invocation outside of response goroutine in all 6 model implementations (openai, hunyuan, anthropic, gemini, ollama, huggingface)
- Remove duplicate `chatRequestCallback` call in HuggingFace's `handleNonStreamingRequest`
- Add unit tests to verify callback is invoked synchronously before the response goroutine starts

The original bug: when using SSE streaming with agent callbacks that perform SSE output, a nil pointer panic could occur. The root cause was that `chatRequestCallback` was executed asynchronously in a goroutine, potentially after the runner and HTTP handler had finished, causing the underlying SSE writer connection to be closed.

## Testing
- `go test ./model/openai/ ./model/hunyuan/ ./model/huggingface/ -count=1`
- `(cd model/anthropic && go test . -count=1)`
- `(cd model/gemini && go test . -count=1)`
- `(cd model/ollama && go test . -count=1)`
- All 12 new sub-tests (`TestChatRequestCallbackSynchronous` streaming/non-streaming) pass