### PR TITLE
model: fix chat stream complete callback timing and recovering

### DIFF
--- a/model/anthropic/anthropic.go
+++ b/model/anthropic/anthropic.go
@@ -452,12 +452,18 @@ func (m *Model) handleStreamingResponse(
 	defer stream.Close()
 	// Accumulator to build final response.
 	acc := anthropic.Message{}
+	var (
+		finalResponse *model.Response
+		streamErr     error
+	)
+
+loop:
 	for stream.Next() {
 		chunk := stream.Current()
 		// Accumulate into accumulator.
 		if err := acc.Accumulate(chunk); err != nil {
-			m.sendErrorResponse(ctx, responseChan, model.ErrorTypeStreamError, err)
-			return
+			streamErr = err
+			break
 		}
 		if m.chatChunkCallback != nil {
 			m.chatChunkCallback(ctx, &chatRequest, &chunk)
@@ -465,8 +471,8 @@ func (m *Model) handleStreamingResponse(
 		// Build partial response.
 		response, err := buildStreamingPartialResponse(acc, chunk)
 		if err != nil {
-			m.sendErrorResponse(ctx, responseChan, model.ErrorTypeStreamError, err)
-			return
+			streamErr = err
+			break
 		}
 		if response == nil {
 			continue
@@ -475,10 +481,16 @@ func (m *Model) handleStreamingResponse(
 		select {
 		case responseChan <- response:
 		case <-ctx.Done():
-			return
+			streamErr = ctx.Err()
+			break loop
 		}
 	}
-	streamErr := stream.Err()
+	if streamErr == nil {
+		streamErr = stream.Err()
+	}
+	if streamErr == nil {
+		finalResponse = buildStreamingFinalResponse(acc)
+	}
 	if m.chatStreamCompleteCallback != nil {
 		var callbackAcc *anthropic.Message
 		if streamErr == nil {
@@ -491,8 +503,6 @@ func (m *Model) handleStreamingResponse(
 		m.sendErrorResponse(ctx, responseChan, model.ErrorTypeStreamError, streamErr)
 		return
 	}
-	// Emit final response built from the accumulator.
-	finalResponse := buildStreamingFinalResponse(acc)
 	select {
 	case responseChan <- finalResponse:
 	case <-ctx.Done():

--- a/model/anthropic/anthropic.go
+++ b/model/anthropic/anthropic.go
@@ -116,6 +116,54 @@ func (m *Model) Info() model.Info {
 	}
 }
 
+func (m *Model) runChatRequestCallback(
+	ctx context.Context,
+	chatRequest *anthropic.MessageNewParams,
+) {
+	if m.chatRequestCallback == nil {
+		return
+	}
+	defer imodel.RecoverCallbackPanic(ctx, "chat request callback")
+	m.chatRequestCallback(ctx, chatRequest)
+}
+
+func (m *Model) runChatResponseCallback(
+	ctx context.Context,
+	chatRequest *anthropic.MessageNewParams,
+	chatResponse *anthropic.Message,
+) {
+	if m.chatResponseCallback == nil {
+		return
+	}
+	defer imodel.RecoverCallbackPanic(ctx, "chat response callback")
+	m.chatResponseCallback(ctx, chatRequest, chatResponse)
+}
+
+func (m *Model) runChatChunkCallback(
+	ctx context.Context,
+	chatRequest *anthropic.MessageNewParams,
+	chatChunk *anthropic.MessageStreamEventUnion,
+) {
+	if m.chatChunkCallback == nil {
+		return
+	}
+	defer imodel.RecoverCallbackPanic(ctx, "chat chunk callback")
+	m.chatChunkCallback(ctx, chatRequest, chatChunk)
+}
+
+func (m *Model) runChatStreamCompleteCallback(
+	ctx context.Context,
+	chatRequest *anthropic.MessageNewParams,
+	chatResponse *anthropic.Message,
+	streamErr error,
+) {
+	if m.chatStreamCompleteCallback == nil {
+		return
+	}
+	defer imodel.RecoverCallbackPanic(ctx, "chat stream complete callback")
+	m.chatStreamCompleteCallback(ctx, chatRequest, chatResponse, streamErr)
+}
+
 // GenerateContent generates content from the model.
 func (m *Model) GenerateContent(
 	ctx context.Context,
@@ -135,9 +183,7 @@ func (m *Model) GenerateContent(
 	// Execute callback synchronously before starting the goroutine
 	// to avoid a race where the runner and HTTP handler finish
 	// (closing the SSE writer) while the callback is still running.
-	if m.chatRequestCallback != nil {
-		m.chatRequestCallback(ctx, chatRequest)
-	}
+	m.runChatRequestCallback(ctx, chatRequest)
 	// Send chat request and handle response.
 	responseChan := make(chan *model.Response, m.channelBufferSize)
 	go func() {
@@ -395,9 +441,7 @@ func (m *Model) handleNonStreamingResponse(
 		m.sendErrorResponse(ctx, responseChan, model.ErrorTypeAPIError, err)
 		return
 	}
-	if m.chatResponseCallback != nil {
-		m.chatResponseCallback(ctx, &chatRequest, message)
-	}
+	m.runChatResponseCallback(ctx, &chatRequest, message)
 	// Build final response payload.
 	now := time.Now()
 	response := &model.Response{
@@ -465,9 +509,7 @@ loop:
 			streamErr = err
 			break
 		}
-		if m.chatChunkCallback != nil {
-			m.chatChunkCallback(ctx, &chatRequest, &chunk)
-		}
+		m.runChatChunkCallback(ctx, &chatRequest, &chunk)
 		// Build partial response.
 		response, err := buildStreamingPartialResponse(acc, chunk)
 		if err != nil {
@@ -491,13 +533,11 @@ loop:
 	if streamErr == nil {
 		finalResponse = buildStreamingFinalResponse(acc)
 	}
-	if m.chatStreamCompleteCallback != nil {
-		var callbackAcc *anthropic.Message
-		if streamErr == nil {
-			callbackAcc = &acc
-		}
-		m.chatStreamCompleteCallback(ctx, &chatRequest, callbackAcc, streamErr)
+	var callbackAcc *anthropic.Message
+	if streamErr == nil {
+		callbackAcc = &acc
 	}
+	m.runChatStreamCompleteCallback(ctx, &chatRequest, callbackAcc, streamErr)
 	// Propagate stream error.
 	if streamErr != nil {
 		m.sendErrorResponse(ctx, responseChan, model.ErrorTypeStreamError, streamErr)

--- a/model/anthropic/anthropic.go
+++ b/model/anthropic/anthropic.go
@@ -478,9 +478,17 @@ func (m *Model) handleStreamingResponse(
 			return
 		}
 	}
+	streamErr := stream.Err()
+	if m.chatStreamCompleteCallback != nil {
+		var callbackAcc *anthropic.Message
+		if streamErr == nil {
+			callbackAcc = &acc
+		}
+		m.chatStreamCompleteCallback(ctx, &chatRequest, callbackAcc, streamErr)
+	}
 	// Propagate stream error.
-	if err := stream.Err(); err != nil {
-		m.sendErrorResponse(ctx, responseChan, model.ErrorTypeStreamError, err)
+	if streamErr != nil {
+		m.sendErrorResponse(ctx, responseChan, model.ErrorTypeStreamError, streamErr)
 		return
 	}
 	// Emit final response built from the accumulator.
@@ -488,14 +496,6 @@ func (m *Model) handleStreamingResponse(
 	select {
 	case responseChan <- finalResponse:
 	case <-ctx.Done():
-	}
-	// Call the stream complete callback after final response is sent.
-	if m.chatStreamCompleteCallback != nil {
-		var callbackAcc *anthropic.Message
-		if stream.Err() == nil {
-			callbackAcc = &acc
-		}
-		m.chatStreamCompleteCallback(ctx, &chatRequest, callbackAcc, stream.Err())
 	}
 }
 

--- a/model/anthropic/anthropic_test.go
+++ b/model/anthropic/anthropic_test.go
@@ -828,7 +828,8 @@ func Test_HandleStreamingResponse_EndToEnd_NoNetwork(t *testing.T) {
 		})}
 	}
 
-	var chunkCalled, streamCompleteCalled bool
+	var chunkCalled bool
+	streamCompleteCalled := make(chan struct{})
 	m := New(
 		"claude-test",
 		WithHTTPClientOptions(),
@@ -838,7 +839,7 @@ func Test_HandleStreamingResponse_EndToEnd_NoNetwork(t *testing.T) {
 		}),
 		WithChatStreamCompleteCallback(func(_ context.Context, _ *anthropic.MessageNewParams,
 			_ *anthropic.Message, _ error) {
-			streamCompleteCalled = true
+			close(streamCompleteCalled)
 		}),
 	)
 	req := &model.Request{
@@ -856,6 +857,12 @@ func Test_HandleStreamingResponse_EndToEnd_NoNetwork(t *testing.T) {
 	for resp := range ch {
 		if resp.Done {
 			final = resp
+			select {
+			case <-streamCompleteCalled:
+				// Success.
+			default:
+				t.Fatal("stream complete callback must run before final response is emitted")
+			}
 			break
 		}
 		if resp.IsPartial {
@@ -866,7 +873,11 @@ func Test_HandleStreamingResponse_EndToEnd_NoNetwork(t *testing.T) {
 	assert.NotNil(t, final)
 	assert.True(t, final.Done)
 	assert.True(t, chunkCalled)
-	assert.True(t, streamCompleteCalled)
+	select {
+	case <-streamCompleteCalled:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for stream complete callback")
+	}
 }
 
 func Test_HTTPClientOptions_AndAnthropicClientOptions(t *testing.T) {

--- a/model/anthropic/anthropic_test.go
+++ b/model/anthropic/anthropic_test.go
@@ -935,9 +935,75 @@ func Test_HandleStreamingResponse_StreamErrorUsesNilAccumulator(t *testing.T) {
 	select {
 	case <-callbackCalled:
 		assert.Nil(t, callbackAcc)
-		assert.Error(t, callbackErr)
+		assert.ErrorIs(t, callbackErr, streamErr)
 	case <-time.After(3 * time.Second):
 		t.Fatal("timeout waiting for stream complete callback")
+	}
+}
+
+func Test_HandleStreamingResponse_ContextCancelStillCallsCallback(t *testing.T) {
+	sse := strings.Join([]string{
+		"event: message_start",
+		"data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_sse_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-3-sonnet\",\"content\":[]}}",
+		"",
+		"event: content_block_start",
+		"data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}",
+		"",
+		"event: content_block_delta",
+		"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hi\"}}",
+		"",
+		"",
+	}, "\n")
+
+	orig := model.DefaultNewHTTPClient
+	t.Cleanup(func() { model.DefaultNewHTTPClient = orig })
+	model.DefaultNewHTTPClient = func(_ ...HTTPClientOption) model.HTTPClient {
+		return &http.Client{Transport: rtFunc(func(r *http.Request) (*http.Response, error) {
+			h := make(http.Header)
+			h.Set("Content-Type", "text/event-stream")
+			return &http.Response{
+				StatusCode: 200,
+				Header:     h,
+				Body:       io.NopCloser(strings.NewReader(sse)),
+			}, nil
+		})}
+	}
+
+	callbackCalled := make(chan struct{})
+	var callbackAcc *anthropic.Message
+	var callbackErr error
+	m := New(
+		"claude-test",
+		WithHTTPClientOptions(),
+		WithChatStreamCompleteCallback(func(_ context.Context,
+			_ *anthropic.MessageNewParams, acc *anthropic.Message, err error) {
+			callbackAcc = acc
+			callbackErr = err
+			close(callbackCalled)
+		}),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	responseChan := make(chan *model.Response)
+	m.handleStreamingResponse(ctx, anthropic.MessageNewParams{}, responseChan)
+
+	select {
+	case <-callbackCalled:
+		assert.Nil(t, callbackAcc)
+		require.ErrorIs(t, callbackErr, context.Canceled)
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for stream complete callback")
+	}
+	select {
+	case resp := <-responseChan:
+		t.Fatalf("unexpected response: %#v", resp)
+	default:
 	}
 }
 

--- a/model/anthropic/anthropic_test.go
+++ b/model/anthropic/anthropic_test.go
@@ -12,6 +12,7 @@ package anthropic
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -731,6 +732,12 @@ type rtFunc func(*http.Request) (*http.Response, error)
 // RoundTrip implements http.RoundTripper.
 func (f rtFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
 
+type errReader struct{ err error }
+
+func (r *errReader) Read(_ []byte) (int, error) {
+	return 0, r.err
+}
+
 func Test_HandleNonStreamingResponse_EndToEnd_NoNetwork(t *testing.T) {
 	// Mock HTTP client to return a fixed Anthropic message JSON body.
 	orig := model.DefaultNewHTTPClient
@@ -875,6 +882,60 @@ func Test_HandleStreamingResponse_EndToEnd_NoNetwork(t *testing.T) {
 	assert.True(t, chunkCalled)
 	select {
 	case <-streamCompleteCalled:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for stream complete callback")
+	}
+}
+
+func Test_HandleStreamingResponse_StreamErrorUsesNilAccumulator(t *testing.T) {
+	streamErr := errors.New("stream read error")
+
+	orig := model.DefaultNewHTTPClient
+	t.Cleanup(func() { model.DefaultNewHTTPClient = orig })
+	model.DefaultNewHTTPClient = func(_ ...HTTPClientOption) model.HTTPClient {
+		return &http.Client{Transport: rtFunc(func(r *http.Request) (*http.Response, error) {
+			h := make(http.Header)
+			h.Set("Content-Type", "text/event-stream")
+			return &http.Response{
+				StatusCode: 200,
+				Header:     h,
+				Body:       io.NopCloser(&errReader{err: streamErr}),
+			}, nil
+		})}
+	}
+
+	callbackCalled := make(chan struct{})
+	var callbackAcc *anthropic.Message
+	var callbackErr error
+	m := New(
+		"claude-test",
+		WithHTTPClientOptions(),
+		WithChatStreamCompleteCallback(func(_ context.Context,
+			_ *anthropic.MessageNewParams, acc *anthropic.Message, err error) {
+			callbackAcc = acc
+			callbackErr = err
+			close(callbackCalled)
+		}),
+	)
+	ctx := context.Background()
+	ch, err := m.GenerateContent(ctx, &model.Request{
+		Messages:         []model.Message{model.NewUserMessage("U")},
+		GenerationConfig: model.GenerationConfig{Stream: true},
+	})
+	require.NoError(t, err)
+
+	var responses []*model.Response
+	for resp := range ch {
+		responses = append(responses, resp)
+	}
+
+	require.Len(t, responses, 1)
+	assert.NotNil(t, responses[0].Error)
+	assert.True(t, responses[0].Done)
+	select {
+	case <-callbackCalled:
+		assert.Nil(t, callbackAcc)
+		assert.Error(t, callbackErr)
 	case <-time.After(3 * time.Second):
 		t.Fatal("timeout waiting for stream complete callback")
 	}

--- a/model/anthropic/anthropic_test.go
+++ b/model/anthropic/anthropic_test.go
@@ -927,6 +927,15 @@ func Test_HandleStreamingResponse_StreamErrorUsesNilAccumulator(t *testing.T) {
 	var responses []*model.Response
 	for resp := range ch {
 		responses = append(responses, resp)
+		if resp.Done && resp.Error != nil {
+			select {
+			case <-callbackCalled:
+				assert.Nil(t, callbackAcc)
+				assert.ErrorIs(t, callbackErr, streamErr)
+			default:
+				t.Fatal("stream complete callback must run before terminal error response is emitted")
+			}
+		}
 	}
 
 	require.Len(t, responses, 1)

--- a/model/anthropic/anthropic_test.go
+++ b/model/anthropic/anthropic_test.go
@@ -64,6 +64,79 @@ func Test_Model_Info(t *testing.T) {
 	assert.Equal(t, "claude-3-5-sonnet-latest", info.Name)
 }
 
+func TestModel_CallbackPanicsAreRecovered(t *testing.T) {
+	t.Run("request callback", func(t *testing.T) {
+		callbackCalled := false
+		m := &Model{
+			chatRequestCallback: func(ctx context.Context, req *anthropic.MessageNewParams) {
+				callbackCalled = true
+				panic("boom")
+			},
+		}
+
+		require.NotPanics(t, func() {
+			m.runChatRequestCallback(context.Background(), &anthropic.MessageNewParams{})
+		})
+		assert.True(t, callbackCalled)
+	})
+
+	t.Run("response callback", func(t *testing.T) {
+		callbackCalled := false
+		m := &Model{
+			chatResponseCallback: func(ctx context.Context, req *anthropic.MessageNewParams, resp *anthropic.Message) {
+				callbackCalled = true
+				panic("boom")
+			},
+		}
+
+		require.NotPanics(t, func() {
+			m.runChatResponseCallback(context.Background(), &anthropic.MessageNewParams{}, &anthropic.Message{})
+		})
+		assert.True(t, callbackCalled)
+	})
+
+	t.Run("chunk callback", func(t *testing.T) {
+		callbackCalled := false
+		m := &Model{
+			chatChunkCallback: func(ctx context.Context, req *anthropic.MessageNewParams, chunk *anthropic.MessageStreamEventUnion) {
+				callbackCalled = true
+				panic("boom")
+			},
+		}
+
+		require.NotPanics(t, func() {
+			chunk := anthropic.MessageStreamEventUnion{}
+			m.runChatChunkCallback(context.Background(), &anthropic.MessageNewParams{}, &chunk)
+		})
+		assert.True(t, callbackCalled)
+	})
+
+	t.Run("stream complete callback", func(t *testing.T) {
+		callbackCalled := false
+		m := &Model{
+			chatStreamCompleteCallback: func(
+				ctx context.Context,
+				req *anthropic.MessageNewParams,
+				resp *anthropic.Message,
+				err error,
+			) {
+				callbackCalled = true
+				panic("boom")
+			},
+		}
+
+		require.NotPanics(t, func() {
+			m.runChatStreamCompleteCallback(
+				context.Background(),
+				&anthropic.MessageNewParams{},
+				&anthropic.Message{},
+				nil,
+			)
+		})
+		assert.True(t, callbackCalled)
+	})
+}
+
 func TestWithHeaders_AppendsOptions(t *testing.T) {
 	o := &options{}
 	headers := map[string]string{

--- a/model/anthropic/options.go
+++ b/model/anthropic/options.go
@@ -196,7 +196,9 @@ func WithChatChunkCallback(fn ChatChunkCallbackFunc) Option {
 	}
 }
 
-// WithChatStreamCompleteCallback sets the function to be called when streaming is completed.
+// WithChatStreamCompleteCallback sets the function to be called when
+// streaming is completed. The callback runs synchronously before the
+// terminal streaming result is surfaced to the caller.
 // Called for both successful and failed streaming completions.
 func WithChatStreamCompleteCallback(fn ChatStreamCompleteCallbackFunc) Option {
 	return func(opts *options) {

--- a/model/gemini/gemini.go
+++ b/model/gemini/gemini.go
@@ -95,6 +95,56 @@ func (m *Model) Info() model.Info {
 	}
 }
 
+func (m *Model) runChatRequestCallback(
+	ctx context.Context,
+	chatRequest []*genai.Content,
+) {
+	if m.chatRequestCallback == nil {
+		return
+	}
+	defer imodel.RecoverCallbackPanic(ctx, "chat request callback")
+	m.chatRequestCallback(ctx, chatRequest)
+}
+
+func (m *Model) runChatResponseCallback(
+	ctx context.Context,
+	chatRequest []*genai.Content,
+	generateConfig *genai.GenerateContentConfig,
+	chatResponse *genai.GenerateContentResponse,
+) {
+	if m.chatResponseCallback == nil {
+		return
+	}
+	defer imodel.RecoverCallbackPanic(ctx, "chat response callback")
+	m.chatResponseCallback(ctx, chatRequest, generateConfig, chatResponse)
+}
+
+func (m *Model) runChatChunkCallback(
+	ctx context.Context,
+	chatRequest []*genai.Content,
+	generateConfig *genai.GenerateContentConfig,
+	chatResponse *genai.GenerateContentResponse,
+) {
+	if m.chatChunkCallback == nil {
+		return
+	}
+	defer imodel.RecoverCallbackPanic(ctx, "chat chunk callback")
+	m.chatChunkCallback(ctx, chatRequest, generateConfig, chatResponse)
+}
+
+func (m *Model) runChatStreamCompleteCallback(
+	ctx context.Context,
+	chatRequest []*genai.Content,
+	generateConfig *genai.GenerateContentConfig,
+	chatResponse *model.Response,
+) {
+	if m.chatStreamCompleteCallback == nil {
+		return
+	}
+	defer imodel.RecoverCallbackPanic(ctx, "chat stream complete callback")
+	m.chatStreamCompleteCallback(ctx, chatRequest, generateConfig, chatResponse)
+}
+
 // GenerateContent implements the model.Model interface.
 func (m *Model) GenerateContent(
 	ctx context.Context,
@@ -110,9 +160,7 @@ func (m *Model) GenerateContent(
 	// Execute callback synchronously before starting the goroutine
 	// to avoid a race where the runner and HTTP handler finish
 	// (closing the SSE writer) while the callback is still running.
-	if m.chatRequestCallback != nil {
-		m.chatRequestCallback(ctx, chatRequest)
-	}
+	m.runChatRequestCallback(ctx, chatRequest)
 	responseChan := make(chan *model.Response, m.channelBufferSize)
 	go func() {
 		defer close(responseChan)
@@ -254,9 +302,7 @@ func (m *Model) handleNonStreamingResponse(
 	}
 
 	// Call response callback on successful completion.
-	if m.chatResponseCallback != nil {
-		m.chatResponseCallback(ctx, chatRequest, generateConfig, chatCompletion)
-	}
+	m.runChatResponseCallback(ctx, chatRequest, generateConfig, chatCompletion)
 	response := m.buildFinalResponse(chatCompletion)
 	select {
 	case responseChan <- response:
@@ -288,9 +334,7 @@ func (m *Model) handleStreamingResponse(
 			// Flush already-buffered chunks so the caller sees partial data
 			// before the error (e.g. network interruption mid-stream).
 			for i, c := range chunks {
-				if m.chatChunkCallback != nil {
-					m.chatChunkCallback(ctx, chatRequest, generateConfig, rawChunks[i])
-				}
+				m.runChatChunkCallback(ctx, chatRequest, generateConfig, rawChunks[i])
 				select {
 				case responseChan <- c:
 				case <-ctx.Done():
@@ -364,9 +408,7 @@ func (m *Model) handleStreamingResponse(
 			return
 		}
 		finalResponse = m.buildFinalResponse(retryRaw)
-		if m.chatStreamCompleteCallback != nil {
-			m.chatStreamCompleteCallback(ctx, chatRequest, generateConfig, finalResponse)
-		}
+		m.runChatStreamCompleteCallback(ctx, chatRequest, generateConfig, finalResponse)
 		select {
 		case responseChan <- finalResponse:
 		case <-ctx.Done():
@@ -376,18 +418,14 @@ func (m *Model) handleStreamingResponse(
 
 	// Normal path: flush buffered chunks then the final Done=true response.
 	for i, chunk := range chunks {
-		if m.chatChunkCallback != nil {
-			m.chatChunkCallback(ctx, chatRequest, generateConfig, rawChunks[i])
-		}
+		m.runChatChunkCallback(ctx, chatRequest, generateConfig, rawChunks[i])
 		select {
 		case responseChan <- chunk:
 		case <-ctx.Done():
 			return
 		}
 	}
-	if m.chatStreamCompleteCallback != nil {
-		m.chatStreamCompleteCallback(ctx, chatRequest, generateConfig, finalResponse)
-	}
+	m.runChatStreamCompleteCallback(ctx, chatRequest, generateConfig, finalResponse)
 	select {
 	case responseChan <- finalResponse:
 	case <-ctx.Done():

--- a/model/gemini/gemini.go
+++ b/model/gemini/gemini.go
@@ -327,6 +327,13 @@ func (m *Model) handleStreamingResponse(
 	chatCompletion := m.client.Models().GenerateContentStream(
 		ctx, m.name, chatRequest, generateConfig)
 	acc := &Accumulator{}
+	sendTerminalResponse := func(resp *model.Response) {
+		m.runChatStreamCompleteCallback(ctx, chatRequest, generateConfig, resp)
+		select {
+		case responseChan <- resp:
+		case <-ctx.Done():
+		}
+	}
 	var chunks []*model.Response
 	var rawChunks []*genai.GenerateContentResponse
 	for chunk, err := range chatCompletion {
@@ -341,17 +348,14 @@ func (m *Model) handleStreamingResponse(
 					return
 				}
 			}
-			select {
-			case responseChan <- &model.Response{
+			sendTerminalResponse(&model.Response{
 				Error: &model.ResponseError{
 					Message: err.Error(),
 					Type:    model.ErrorTypeAPIError,
 				},
 				Timestamp: time.Now(),
 				Done:      true,
-			}:
-			case <-ctx.Done():
-			}
+			})
 			return
 		}
 		response := m.buildChunkResponse(chunk)
@@ -380,39 +384,29 @@ func (m *Model) handleStreamingResponse(
 			}
 		}
 		if retryErr != nil {
-			select {
-			case responseChan <- &model.Response{
+			sendTerminalResponse(&model.Response{
 				Error: &model.ResponseError{
 					Message: retryErr.Error(),
 					Type:    model.ErrorTypeAPIError,
 				},
 				Timestamp: time.Now(),
 				Done:      true,
-			}:
-			case <-ctx.Done():
-			}
+			})
 			return
 		}
 		if isMalformedFunctionCall(retryRaw) {
-			select {
-			case responseChan <- &model.Response{
+			sendTerminalResponse(&model.Response{
 				Error: &model.ResponseError{
 					Message: "gemini: MALFORMED_FUNCTION_CALL persists after retries",
 					Type:    model.ErrorTypeAPIError,
 				},
 				Timestamp: time.Now(),
 				Done:      true,
-			}:
-			case <-ctx.Done():
-			}
+			})
 			return
 		}
 		finalResponse = m.buildFinalResponse(retryRaw)
-		m.runChatStreamCompleteCallback(ctx, chatRequest, generateConfig, finalResponse)
-		select {
-		case responseChan <- finalResponse:
-		case <-ctx.Done():
-		}
+		sendTerminalResponse(finalResponse)
 		return
 	}
 
@@ -425,12 +419,7 @@ func (m *Model) handleStreamingResponse(
 			return
 		}
 	}
-	m.runChatStreamCompleteCallback(ctx, chatRequest, generateConfig, finalResponse)
-	select {
-	case responseChan <- finalResponse:
-	case <-ctx.Done():
-		return
-	}
+	sendTerminalResponse(finalResponse)
 }
 
 // convertContentBlock builds a single assistant message from Gemini Candidate.

--- a/model/gemini/gemini_test.go
+++ b/model/gemini/gemini_test.go
@@ -27,6 +27,98 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
 
+func TestModel_CallbackPanicsAreRecovered(t *testing.T) {
+	t.Run("request callback", func(t *testing.T) {
+		callbackCalled := false
+		m := &Model{
+			chatRequestCallback: func(ctx context.Context, chatRequest []*genai.Content) {
+				callbackCalled = true
+				panic("boom")
+			},
+		}
+
+		require.NotPanics(t, func() {
+			m.runChatRequestCallback(context.Background(), nil)
+		})
+		assert.True(t, callbackCalled)
+	})
+
+	t.Run("response callback", func(t *testing.T) {
+		callbackCalled := false
+		m := &Model{
+			chatResponseCallback: func(
+				ctx context.Context,
+				chatRequest []*genai.Content,
+				generateConfig *genai.GenerateContentConfig,
+				chatResponse *genai.GenerateContentResponse,
+			) {
+				callbackCalled = true
+				panic("boom")
+			},
+		}
+
+		require.NotPanics(t, func() {
+			m.runChatResponseCallback(
+				context.Background(),
+				nil,
+				&genai.GenerateContentConfig{},
+				&genai.GenerateContentResponse{},
+			)
+		})
+		assert.True(t, callbackCalled)
+	})
+
+	t.Run("chunk callback", func(t *testing.T) {
+		callbackCalled := false
+		m := &Model{
+			chatChunkCallback: func(
+				ctx context.Context,
+				chatRequest []*genai.Content,
+				generateConfig *genai.GenerateContentConfig,
+				chatResponse *genai.GenerateContentResponse,
+			) {
+				callbackCalled = true
+				panic("boom")
+			},
+		}
+
+		require.NotPanics(t, func() {
+			m.runChatChunkCallback(
+				context.Background(),
+				nil,
+				&genai.GenerateContentConfig{},
+				&genai.GenerateContentResponse{},
+			)
+		})
+		assert.True(t, callbackCalled)
+	})
+
+	t.Run("stream complete callback", func(t *testing.T) {
+		callbackCalled := false
+		m := &Model{
+			chatStreamCompleteCallback: func(
+				ctx context.Context,
+				chatRequest []*genai.Content,
+				generateConfig *genai.GenerateContentConfig,
+				chatResponse *model.Response,
+			) {
+				callbackCalled = true
+				panic("boom")
+			},
+		}
+
+		require.NotPanics(t, func() {
+			m.runChatStreamCompleteCallback(
+				context.Background(),
+				nil,
+				&genai.GenerateContentConfig{},
+				&model.Response{},
+			)
+		})
+		assert.True(t, callbackCalled)
+	})
+}
+
 func TestModel_convertMessages(t *testing.T) {
 	var (
 		text      = "Text"

--- a/model/gemini/gemini_test.go
+++ b/model/gemini/gemini_test.go
@@ -1366,7 +1366,8 @@ func TestModel_GenerateContentStreamingError(t *testing.T) {
 	})
 
 	t.Run("error_with_callbacks", func(t *testing.T) {
-		// Test that chunk callback is not called when error occurs immediately
+		// Test that an immediate streaming error skips chunk callbacks but still
+		// invokes the stream-complete callback before the error becomes visible.
 		streamErr := errors.New("callback test error")
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
@@ -1379,7 +1380,8 @@ func TestModel_GenerateContentStreamingError(t *testing.T) {
 			Return(seqWithImmediateError[*genai.GenerateContentResponse](streamErr)).AnyTimes()
 
 		chunkCallbackCalled := false
-		completeCallbackCalled := false
+		completeCallbackCalled := make(chan struct{})
+		var completeCallbackResp *model.Response
 
 		m := &Model{
 			client: mockClient,
@@ -1389,7 +1391,8 @@ func TestModel_GenerateContentStreamingError(t *testing.T) {
 			},
 			chatStreamCompleteCallback: func(ctx context.Context, chatRequest []*genai.Content,
 				generateConfig *genai.GenerateContentConfig, chatResponse *model.Response) {
-				completeCallbackCalled = true
+				completeCallbackResp = chatResponse
+				close(completeCallbackCalled)
 			},
 		}
 		respChan, err := m.GenerateContent(context.Background(), req)
@@ -1398,14 +1401,21 @@ func TestModel_GenerateContentStreamingError(t *testing.T) {
 		// Read response (error)
 		resp := <-respChan
 		assert.NotNil(t, resp.Error)
+		select {
+		case <-completeCallbackCalled:
+		default:
+			t.Fatal("stream-complete callback must run before error response is emitted")
+		}
 
 		// Wait for channel to close
 		for range respChan {
 		}
 
-		// Callbacks should not be called when error occurs immediately
+		// Chunk callbacks should still not run on immediate errors.
 		assert.False(t, chunkCallbackCalled, "chunk callback should not be called on immediate error")
-		assert.False(t, completeCallbackCalled, "complete callback should not be called on error")
+		require.NotNil(t, completeCallbackResp)
+		require.NotNil(t, completeCallbackResp.Error)
+		assert.Equal(t, "callback test error", completeCallbackResp.Error.Message)
 	})
 
 	t.Run("mid_stream_error_with_chunk_callback", func(t *testing.T) {
@@ -1430,11 +1440,18 @@ func TestModel_GenerateContentStreamingError(t *testing.T) {
 			Return(seqFromSliceWithError([]*genai.GenerateContentResponse{successChunk}, streamErr))
 
 		var chunkCallbackRaw []*genai.GenerateContentResponse
+		completeCallbackCalled := make(chan struct{})
+		var completeCallbackResp *model.Response
 		m := &Model{
 			client: mockClient,
 			chatChunkCallback: func(_ context.Context, _ []*genai.Content,
 				_ *genai.GenerateContentConfig, r *genai.GenerateContentResponse) {
 				chunkCallbackRaw = append(chunkCallbackRaw, r)
+			},
+			chatStreamCompleteCallback: func(_ context.Context, _ []*genai.Content,
+				_ *genai.GenerateContentConfig, r *model.Response) {
+				completeCallbackResp = r
+				close(completeCallbackCalled)
 			},
 		}
 		respChan, err := m.GenerateContent(context.Background(), req)
@@ -1451,9 +1468,17 @@ func TestModel_GenerateContentStreamingError(t *testing.T) {
 		require.Equal(t, "partial", responses[0].Choices[0].Delta.Content)
 		require.NotNil(t, responses[1].Error)
 		require.Equal(t, "mid-stream interruption", responses[1].Error.Message)
+		select {
+		case <-completeCallbackCalled:
+		default:
+			t.Fatal("stream-complete callback must run before error response is emitted")
+		}
 		// chatChunkCallback must have been called once (for the flushed chunk).
 		require.Len(t, chunkCallbackRaw, 1)
 		require.Equal(t, successChunk, chunkCallbackRaw[0])
+		require.NotNil(t, completeCallbackResp)
+		require.NotNil(t, completeCallbackResp.Error)
+		require.Equal(t, "mid-stream interruption", completeCallbackResp.Error.Message)
 	})
 }
 

--- a/model/gemini/gemini_test.go
+++ b/model/gemini/gemini_test.go
@@ -1457,21 +1457,21 @@ func TestModel_GenerateContentStreamingError(t *testing.T) {
 		respChan, err := m.GenerateContent(context.Background(), req)
 		require.NoError(t, err)
 
-		var responses []*model.Response
-		for r := range respChan {
-			responses = append(responses, r)
-		}
+		partialResp := <-respChan
+		require.NotNil(t, partialResp)
+		require.Nil(t, partialResp.Error)
+		require.Equal(t, "partial", partialResp.Choices[0].Delta.Content)
 
-		// One partial chunk then one error response.
-		require.Len(t, responses, 2)
-		require.Nil(t, responses[0].Error)
-		require.Equal(t, "partial", responses[0].Choices[0].Delta.Content)
-		require.NotNil(t, responses[1].Error)
-		require.Equal(t, "mid-stream interruption", responses[1].Error.Message)
+		errorResp := <-respChan
+		require.NotNil(t, errorResp)
+		require.NotNil(t, errorResp.Error)
+		require.Equal(t, "mid-stream interruption", errorResp.Error.Message)
 		select {
 		case <-completeCallbackCalled:
 		default:
 			t.Fatal("stream-complete callback must run before error response is emitted")
+		}
+		for range respChan {
 		}
 		// chatChunkCallback must have been called once (for the flushed chunk).
 		require.Len(t, chunkCallbackRaw, 1)

--- a/model/gemini/options.go
+++ b/model/gemini/options.go
@@ -132,7 +132,9 @@ func WithChatChunkCallback(fn ChatChunkCallbackFunc) Option {
 	}
 }
 
-// WithChatStreamCompleteCallback sets the function to be called when streaming is completed.
+// WithChatStreamCompleteCallback sets the function to be called when
+// streaming is completed. The callback runs synchronously before the
+// terminal streaming result is surfaced to the caller.
 // Called for both successful and failed streaming completions.
 func WithChatStreamCompleteCallback(fn ChatStreamCompleteCallbackFunc) Option {
 	return func(opts *options) {

--- a/model/huggingface/huggingface.go
+++ b/model/huggingface/huggingface.go
@@ -128,9 +128,7 @@ func (m *Model) GenerateContent(ctx context.Context, request *model.Request) (<-
 	// Execute callback synchronously before starting the goroutine
 	// to avoid a race where the runner and HTTP handler finish
 	// (closing the SSE writer) while the callback is still running.
-	if m.chatRequestCallback != nil {
-		m.chatRequestCallback(ctx, hfRequest)
-	}
+	m.runChatRequestCallback(ctx, hfRequest)
 
 	// Create response channel.
 	responseChan := make(chan *model.Response, m.channelBufferSize)
@@ -143,6 +141,53 @@ func (m *Model) GenerateContent(ctx context.Context, request *model.Request) (<-
 	}
 
 	return responseChan, nil
+}
+
+func (m *Model) runChatRequestCallback(
+	ctx context.Context,
+	hfRequest *ChatCompletionRequest,
+) {
+	if m.chatRequestCallback == nil {
+		return
+	}
+	defer imodel.RecoverCallbackPanic(ctx, "chat request callback")
+	m.chatRequestCallback(ctx, hfRequest)
+}
+
+func (m *Model) runChatResponseCallback(
+	ctx context.Context,
+	hfRequest *ChatCompletionRequest,
+	hfResponse *ChatCompletionResponse,
+) {
+	if m.chatResponseCallback == nil {
+		return
+	}
+	defer imodel.RecoverCallbackPanic(ctx, "chat response callback")
+	m.chatResponseCallback(ctx, hfRequest, hfResponse)
+}
+
+func (m *Model) runChatChunkCallback(
+	ctx context.Context,
+	hfRequest *ChatCompletionRequest,
+	chunk *ChatCompletionChunk,
+) {
+	if m.chatChunkCallback == nil {
+		return
+	}
+	defer imodel.RecoverCallbackPanic(ctx, "chat chunk callback")
+	m.chatChunkCallback(ctx, hfRequest, chunk)
+}
+
+func (m *Model) runChatStreamCompleteCallback(
+	ctx context.Context,
+	hfRequest *ChatCompletionRequest,
+	streamErr error,
+) {
+	if m.chatStreamCompleteCallback == nil {
+		return
+	}
+	defer imodel.RecoverCallbackPanic(ctx, "chat stream complete callback")
+	m.chatStreamCompleteCallback(ctx, hfRequest, streamErr)
 }
 
 // Info returns basic information about the model.
@@ -173,9 +218,7 @@ func (m *Model) handleNonStreamingRequest(
 	}
 
 	// Call response callback if provided.
-	if m.chatResponseCallback != nil {
-		m.chatResponseCallback(ctx, hfRequest, hfResponse)
-	}
+	m.runChatResponseCallback(ctx, hfRequest, hfResponse)
 
 	// Convert HuggingFace response to model.Response.
 	response := m.convertResponse(hfResponse)
@@ -193,9 +236,7 @@ func (m *Model) handleStreamingRequest(
 
 	var streamErr error
 	defer func() {
-		if m.chatStreamCompleteCallback != nil {
-			m.chatStreamCompleteCallback(ctx, hfRequest, streamErr)
-		}
+		m.runChatStreamCompleteCallback(ctx, hfRequest, streamErr)
 	}()
 
 	// Make streaming HTTP request.
@@ -253,9 +294,7 @@ func (m *Model) handleStreamingRequest(
 		}
 
 		// Call chunk callback if provided.
-		if m.chatChunkCallback != nil {
-			m.chatChunkCallback(ctx, hfRequest, &chunk)
-		}
+		m.runChatChunkCallback(ctx, hfRequest, &chunk)
 
 		// Convert chunk to model.Response.
 		response := m.convertChunk(&chunk)

--- a/model/huggingface/huggingface.go
+++ b/model/huggingface/huggingface.go
@@ -235,70 +235,73 @@ func (m *Model) handleStreamingRequest(
 	defer close(responseChan)
 
 	var streamErr error
-	defer func() {
-		m.runChatStreamCompleteCallback(ctx, hfRequest, streamErr)
-	}()
+	var terminalResponse *model.Response
 
 	// Make streaming HTTP request.
 	hfRequest.Stream = true
 	resp, err := m.makeStreamingRequest(ctx, hfRequest)
 	if err != nil {
 		streamErr = err
-		responseChan <- &model.Response{
+		terminalResponse = &model.Response{
 			Error: &model.ResponseError{
 				Message: fmt.Sprintf("failed to make streaming request: %v", err),
 			},
 		}
-		return
-	}
-	defer resp.Body.Close()
+	} else {
+		defer resp.Body.Close()
 
-	// Read and process streaming response.
-	// Use bufio.Reader instead of Scanner to avoid 64KB line limit.
-	reader := bufio.NewReader(resp.Body)
-	for {
-		line, err := reader.ReadString('\n')
-		if err != nil {
-			if err == io.EOF {
+		// Read and process streaming response.
+		// Use bufio.Reader instead of Scanner to avoid 64KB line limit.
+		reader := bufio.NewReader(resp.Body)
+		for {
+			line, err := reader.ReadString('\n')
+			if err != nil {
+				if err == io.EOF {
+					break
+				}
+				streamErr = err
+				terminalResponse = &model.Response{
+					Error: &model.ResponseError{
+						Message: fmt.Sprintf("error reading stream: %v", err),
+					},
+				}
 				break
 			}
-			streamErr = err
-			responseChan <- &model.Response{
-				Error: &model.ResponseError{
-					Message: fmt.Sprintf("error reading stream: %v", err),
-				},
+
+			line = strings.TrimSpace(line)
+
+			// Skip empty lines and comments.
+			if line == "" || !strings.HasPrefix(line, "data: ") {
+				continue
 			}
-			break
+
+			// Remove "data: " prefix.
+			data := strings.TrimPrefix(line, "data: ")
+
+			// Check for stream end.
+			if data == "[DONE]" {
+				break
+			}
+
+			// Parse chunk.
+			var chunk ChatCompletionChunk
+			if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+				log.Warnf("failed to parse chunk: %v, data: %s", err, data)
+				continue
+			}
+
+			// Call chunk callback if provided.
+			m.runChatChunkCallback(ctx, hfRequest, &chunk)
+
+			// Convert chunk to model.Response.
+			response := m.convertChunk(&chunk)
+			responseChan <- response
 		}
+	}
 
-		line = strings.TrimSpace(line)
-
-		// Skip empty lines and comments.
-		if line == "" || !strings.HasPrefix(line, "data: ") {
-			continue
-		}
-
-		// Remove "data: " prefix.
-		data := strings.TrimPrefix(line, "data: ")
-
-		// Check for stream end.
-		if data == "[DONE]" {
-			break
-		}
-
-		// Parse chunk.
-		var chunk ChatCompletionChunk
-		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
-			log.Warnf("failed to parse chunk: %v, data: %s", err, data)
-			continue
-		}
-
-		// Call chunk callback if provided.
-		m.runChatChunkCallback(ctx, hfRequest, &chunk)
-
-		// Convert chunk to model.Response.
-		response := m.convertChunk(&chunk)
-		responseChan <- response
+	m.runChatStreamCompleteCallback(ctx, hfRequest, streamErr)
+	if terminalResponse != nil {
+		responseChan <- terminalResponse
 	}
 }
 

--- a/model/huggingface/huggingface_test.go
+++ b/model/huggingface/huggingface_test.go
@@ -12,6 +12,7 @@ package huggingface
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -1302,10 +1303,16 @@ func TestModel_StreamingError(t *testing.T) {
 	}))
 	defer server.Close()
 
+	callbackCalled := make(chan struct{})
+	var callbackErr error
 	m, err := New(
 		"test-model",
 		WithAPIKey("invalid-key"),
 		WithBaseURL(server.URL),
+		WithChatStreamCompleteCallback(func(ctx context.Context, req *ChatCompletionRequest, err error) {
+			callbackErr = err
+			close(callbackCalled)
+		}),
 	)
 	require.NoError(t, err)
 
@@ -1325,11 +1332,20 @@ func TestModel_StreamingError(t *testing.T) {
 	var responses []*model.Response
 	for resp := range responseChan {
 		responses = append(responses, resp)
+		if resp.Error != nil {
+			select {
+			case <-callbackCalled:
+			default:
+				t.Fatal("stream-complete callback must run before error response is emitted")
+			}
+		}
 	}
 
 	require.NotEmpty(t, responses)
 	assert.NotNil(t, responses[0].Error)
 	assert.Contains(t, responses[0].Error.Message, "Unauthorized")
+	require.Error(t, callbackErr)
+	assert.Contains(t, callbackErr.Error(), "Unauthorized")
 }
 
 // TestModel_NonStreamingError tests non-streaming request error handling
@@ -2463,20 +2479,34 @@ func TestModel_NonStreamingWithError(t *testing.T) {
 
 // TestModel_StreamingReadError tests streaming with read error
 func TestModel_StreamingReadError(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/event-stream")
-		// Send one valid chunk then close connection abruptly
-		fmt.Fprint(w, `data: {"id":"test","object":"chat.completion.chunk","created":1234567890,"model":"test-model","choices":[{"index":0,"delta":{"role":"assistant","content":"test"},"finish_reason":null}]}`+"\n\n")
-		if f, ok := w.(http.Flusher); ok {
-			f.Flush()
-		}
-		// Connection will be closed by server shutdown
-	}))
-
+	streamErr := errors.New("stream read error")
+	callbackCalled := make(chan struct{})
+	var callbackErr error
+	customClient := &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			header := make(http.Header)
+			header.Set("Content-Type", "text/event-stream")
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     header,
+				Body: &errAfterReadCloser{
+					reader: strings.NewReader(
+						`data: {"id":"test","object":"chat.completion.chunk","created":1234567890,"model":"test-model","choices":[{"index":0,"delta":{"role":"assistant","content":"test"},"finish_reason":null}]}` + "\n\n",
+					),
+					err: streamErr,
+				},
+			}, nil
+		}),
+	}
 	m, err := New(
 		"test-model",
 		WithAPIKey("test-key"),
-		WithBaseURL(server.URL),
+		WithBaseURL("https://example.test"),
+		WithHTTPClient(customClient),
+		WithChatStreamCompleteCallback(func(ctx context.Context, req *ChatCompletionRequest, err error) {
+			callbackErr = err
+			close(callbackCalled)
+		}),
 	)
 	require.NoError(t, err)
 
@@ -2493,16 +2523,50 @@ func TestModel_StreamingReadError(t *testing.T) {
 	responseChan, err := m.GenerateContent(ctx, request)
 	require.NoError(t, err)
 
-	// Close server to simulate connection error
-	server.Close()
-
 	var responses []*model.Response
 	for resp := range responseChan {
 		responses = append(responses, resp)
+		if resp.Error != nil {
+			select {
+			case <-callbackCalled:
+			default:
+				t.Fatal("stream-complete callback must run before error response is emitted")
+			}
+		}
 	}
 
-	// Should receive at least one response (could be error or valid chunk)
-	require.NotEmpty(t, responses)
+	require.Len(t, responses, 2)
+	assert.Nil(t, responses[0].Error)
+	require.NotNil(t, responses[1].Error)
+	assert.Contains(t, responses[1].Error.Message, "stream read error")
+	require.ErrorIs(t, callbackErr, streamErr)
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type errAfterReadCloser struct {
+	reader *strings.Reader
+	err    error
+}
+
+func (r *errAfterReadCloser) Read(p []byte) (int, error) {
+	if r.reader.Len() > 0 {
+		return r.reader.Read(p)
+	}
+	if r.err != nil {
+		err := r.err
+		r.err = nil
+		return 0, err
+	}
+	return 0, io.EOF
+}
+
+func (r *errAfterReadCloser) Close() error {
+	return nil
 }
 
 // TestModel_TokenTailoringWithCustomConfig tests token tailoring with custom config

--- a/model/huggingface/huggingface_test.go
+++ b/model/huggingface/huggingface_test.go
@@ -29,6 +29,68 @@ import (
 
 const ApiKey = "*****"
 
+func TestModel_CallbackPanicsAreRecovered(t *testing.T) {
+	t.Run("request callback", func(t *testing.T) {
+		callbackCalled := false
+		m := &Model{
+			chatRequestCallback: func(ctx context.Context, req *ChatCompletionRequest) {
+				callbackCalled = true
+				panic("boom")
+			},
+		}
+
+		require.NotPanics(t, func() {
+			m.runChatRequestCallback(context.Background(), &ChatCompletionRequest{})
+		})
+		assert.True(t, callbackCalled)
+	})
+
+	t.Run("response callback", func(t *testing.T) {
+		callbackCalled := false
+		m := &Model{
+			chatResponseCallback: func(ctx context.Context, req *ChatCompletionRequest, resp *ChatCompletionResponse) {
+				callbackCalled = true
+				panic("boom")
+			},
+		}
+
+		require.NotPanics(t, func() {
+			m.runChatResponseCallback(context.Background(), &ChatCompletionRequest{}, &ChatCompletionResponse{})
+		})
+		assert.True(t, callbackCalled)
+	})
+
+	t.Run("chunk callback", func(t *testing.T) {
+		callbackCalled := false
+		m := &Model{
+			chatChunkCallback: func(ctx context.Context, req *ChatCompletionRequest, chunk *ChatCompletionChunk) {
+				callbackCalled = true
+				panic("boom")
+			},
+		}
+
+		require.NotPanics(t, func() {
+			m.runChatChunkCallback(context.Background(), &ChatCompletionRequest{}, &ChatCompletionChunk{})
+		})
+		assert.True(t, callbackCalled)
+	})
+
+	t.Run("stream complete callback", func(t *testing.T) {
+		callbackCalled := false
+		m := &Model{
+			chatStreamCompleteCallback: func(ctx context.Context, req *ChatCompletionRequest, err error) {
+				callbackCalled = true
+				panic("boom")
+			},
+		}
+
+		require.NotPanics(t, func() {
+			m.runChatStreamCompleteCallback(context.Background(), &ChatCompletionRequest{}, nil)
+		})
+		assert.True(t, callbackCalled)
+	})
+}
+
 func TestNew(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/model/huggingface/options.go
+++ b/model/huggingface/options.go
@@ -165,8 +165,7 @@ func WithChatChunkCallback(fn ChatChunkCallbackFunc) Option {
 }
 
 // WithChatStreamCompleteCallback sets the function to be called when
-// streaming is completed. The callback runs synchronously before the
-// terminal streaming result is surfaced to the caller.
+// streaming is completed.
 // Called for both successful and failed streaming completions.
 func WithChatStreamCompleteCallback(fn ChatStreamCompleteCallbackFunc) Option {
 	return func(opts *options) {

--- a/model/huggingface/options.go
+++ b/model/huggingface/options.go
@@ -164,7 +164,9 @@ func WithChatChunkCallback(fn ChatChunkCallbackFunc) Option {
 	}
 }
 
-// WithChatStreamCompleteCallback sets the function to be called when streaming is completed.
+// WithChatStreamCompleteCallback sets the function to be called when
+// streaming is completed. The callback runs synchronously before the
+// terminal streaming result is surfaced to the caller.
 // Called for both successful and failed streaming completions.
 func WithChatStreamCompleteCallback(fn ChatStreamCompleteCallbackFunc) Option {
 	return func(opts *options) {

--- a/model/hunyuan/hunyuan.go
+++ b/model/hunyuan/hunyuan.go
@@ -340,7 +340,10 @@ func (m *Model) handleStreamingResponse(
 	chatRequest *hunyuan.ChatCompletionNewParams,
 	responseChan chan<- *model.Response,
 ) {
-	var streamErr error
+	var (
+		streamErr     error
+		finalResponse *model.Response
+	)
 
 	err := m.client.ChatCompletionStream(ctx, chatRequest, func(chunk *hunyuan.ChatCompletionResponse) error {
 		if m.chatChunkCallback != nil {
@@ -352,6 +355,10 @@ func (m *Model) handleStreamingResponse(
 			return err
 		}
 		response.Model = m.name
+		if response.Done {
+			finalResponse = response
+			return nil
+		}
 
 		// Emit partial response.
 		select {
@@ -365,12 +372,23 @@ func (m *Model) handleStreamingResponse(
 
 	if err != nil {
 		streamErr = err
-		m.sendErrorResponse(ctx, responseChan, model.ErrorTypeStreamError, err)
 	}
 
-	// Call the stream complete callback.
+	// Call the stream complete callback before surfacing the terminal result.
 	if m.chatStreamCompleteCallback != nil {
 		m.chatStreamCompleteCallback(ctx, chatRequest, streamErr)
+	}
+
+	if streamErr != nil {
+		m.sendErrorResponse(ctx, responseChan, model.ErrorTypeStreamError, streamErr)
+		return
+	}
+	if finalResponse == nil {
+		return
+	}
+	select {
+	case responseChan <- finalResponse:
+	case <-ctx.Done():
 	}
 }
 

--- a/model/hunyuan/hunyuan.go
+++ b/model/hunyuan/hunyuan.go
@@ -182,6 +182,53 @@ func (m *Model) Info() model.Info {
 	}
 }
 
+func (m *Model) runChatRequestCallback(
+	ctx context.Context,
+	chatRequest *hunyuan.ChatCompletionNewParams,
+) {
+	if m.chatRequestCallback == nil {
+		return
+	}
+	defer imodel.RecoverCallbackPanic(ctx, "chat request callback")
+	m.chatRequestCallback(ctx, chatRequest)
+}
+
+func (m *Model) runChatResponseCallback(
+	ctx context.Context,
+	chatRequest *hunyuan.ChatCompletionNewParams,
+	chatResponse *hunyuan.ChatCompletionResponse,
+) {
+	if m.chatResponseCallback == nil {
+		return
+	}
+	defer imodel.RecoverCallbackPanic(ctx, "chat response callback")
+	m.chatResponseCallback(ctx, chatRequest, chatResponse)
+}
+
+func (m *Model) runChatChunkCallback(
+	ctx context.Context,
+	chatRequest *hunyuan.ChatCompletionNewParams,
+	chatChunk *hunyuan.ChatCompletionResponse,
+) {
+	if m.chatChunkCallback == nil {
+		return
+	}
+	defer imodel.RecoverCallbackPanic(ctx, "chat chunk callback")
+	m.chatChunkCallback(ctx, chatRequest, chatChunk)
+}
+
+func (m *Model) runChatStreamCompleteCallback(
+	ctx context.Context,
+	chatRequest *hunyuan.ChatCompletionNewParams,
+	streamErr error,
+) {
+	if m.chatStreamCompleteCallback == nil {
+		return
+	}
+	defer imodel.RecoverCallbackPanic(ctx, "chat stream complete callback")
+	m.chatStreamCompleteCallback(ctx, chatRequest, streamErr)
+}
+
 // GenerateContent generates content from the model.
 func (m *Model) GenerateContent(
 	ctx context.Context,
@@ -202,9 +249,7 @@ func (m *Model) GenerateContent(
 	// Execute callback synchronously before starting the goroutine
 	// to avoid a race where the runner and HTTP handler finish
 	// (closing the SSE writer) while the callback is still running.
-	if m.chatRequestCallback != nil {
-		m.chatRequestCallback(ctx, chatRequest)
-	}
+	m.runChatRequestCallback(ctx, chatRequest)
 	// Send chat request and handle response.
 	responseChan := make(chan *model.Response, m.channelBufferSize)
 	go func() {
@@ -316,9 +361,7 @@ func (m *Model) handleNonStreamingResponse(
 		return
 	}
 
-	if m.chatResponseCallback != nil {
-		m.chatResponseCallback(ctx, chatRequest, chatResponse)
-	}
+	m.runChatResponseCallback(ctx, chatRequest, chatResponse)
 
 	response, err := convertChatResponse(chatResponse)
 	if err != nil {
@@ -346,9 +389,7 @@ func (m *Model) handleStreamingResponse(
 	)
 
 	err := m.client.ChatCompletionStream(ctx, chatRequest, func(chunk *hunyuan.ChatCompletionResponse) error {
-		if m.chatChunkCallback != nil {
-			m.chatChunkCallback(ctx, chatRequest, chunk)
-		}
+		m.runChatChunkCallback(ctx, chatRequest, chunk)
 
 		response, err := convertChatResponse(chunk)
 		if err != nil {
@@ -375,9 +416,7 @@ func (m *Model) handleStreamingResponse(
 	}
 
 	// Call the stream complete callback before surfacing the terminal result.
-	if m.chatStreamCompleteCallback != nil {
-		m.chatStreamCompleteCallback(ctx, chatRequest, streamErr)
-	}
+	m.runChatStreamCompleteCallback(ctx, chatRequest, streamErr)
 
 	if streamErr != nil {
 		m.sendErrorResponse(ctx, responseChan, model.ErrorTypeStreamError, streamErr)

--- a/model/hunyuan/hunyuan_test.go
+++ b/model/hunyuan/hunyuan_test.go
@@ -426,6 +426,135 @@ func TestChatStreamCompleteCallbackBeforeFinalResponse(t *testing.T) {
 	}
 }
 
+func TestHandleStreamingResponseWithoutFinalChunk(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+
+		flusher, ok := w.(http.Flusher)
+		require.True(t, ok)
+
+		chunk := hunyuan.ChatCompletionResponse{
+			Id:      "stream-id-1",
+			Created: time.Now().Unix(),
+			Choices: []*hunyuan.ChatCompletionResponseChoice{
+				{
+					Index: 0,
+					Delta: &hunyuan.ChatCompletionResponseDelta{
+						Role:    "assistant",
+						Content: "Hello",
+					},
+				},
+			},
+		}
+		data, err := json.Marshal(chunk)
+		require.NoError(t, err)
+		_, err = fmt.Fprintf(w, "data: %s\n\n", string(data))
+		require.NoError(t, err)
+		flusher.Flush()
+		_, err = fmt.Fprint(w, "data: [DONE]\n\n")
+		require.NoError(t, err)
+		flusher.Flush()
+	}))
+	defer mockServer.Close()
+
+	streamCompleteCalled := make(chan error, 1)
+	m := New("hunyuan-lite",
+		WithSecretId("test-secret-id"),
+		WithSecretKey("test-secret-key"),
+		WithBaseUrl(mockServer.URL),
+		WithHost("test-host"),
+		WithChatStreamCompleteCallback(func(ctx context.Context,
+			chatRequest *hunyuan.ChatCompletionNewParams, streamErr error) {
+			streamCompleteCalled <- streamErr
+		}),
+	)
+
+	responseChan := make(chan *model.Response, 2)
+	m.handleStreamingResponse(context.Background(),
+		&hunyuan.ChatCompletionNewParams{}, responseChan)
+	close(responseChan)
+
+	var responses []*model.Response
+	for resp := range responseChan {
+		responses = append(responses, resp)
+	}
+
+	require.Len(t, responses, 1)
+	assert.True(t, responses[0].IsPartial)
+	assert.False(t, responses[0].Done)
+	select {
+	case streamErr := <-streamCompleteCalled:
+		assert.NoError(t, streamErr)
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for stream complete callback")
+	}
+}
+
+func TestHandleStreamingResponseCallbackOnContextCancel(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+
+		flusher, ok := w.(http.Flusher)
+		require.True(t, ok)
+
+		chunk := hunyuan.ChatCompletionResponse{
+			Id:      "stream-id-1",
+			Created: time.Now().Unix(),
+			Choices: []*hunyuan.ChatCompletionResponseChoice{
+				{
+					Index: 0,
+					Delta: &hunyuan.ChatCompletionResponseDelta{
+						Role:    "assistant",
+						Content: "Hello",
+					},
+				},
+			},
+		}
+		data, err := json.Marshal(chunk)
+		require.NoError(t, err)
+		_, err = fmt.Fprintf(w, "data: %s\n\n", string(data))
+		require.NoError(t, err)
+		flusher.Flush()
+	}))
+	defer mockServer.Close()
+
+	streamCompleteCalled := make(chan error, 1)
+	m := New("hunyuan-lite",
+		WithSecretId("test-secret-id"),
+		WithSecretKey("test-secret-key"),
+		WithBaseUrl(mockServer.URL),
+		WithHost("test-host"),
+		WithChatStreamCompleteCallback(func(ctx context.Context,
+			chatRequest *hunyuan.ChatCompletionNewParams, streamErr error) {
+			streamCompleteCalled <- streamErr
+		}),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	responseChan := make(chan *model.Response)
+	m.handleStreamingResponse(ctx, &hunyuan.ChatCompletionNewParams{}, responseChan)
+
+	select {
+	case streamErr := <-streamCompleteCalled:
+		require.ErrorIs(t, streamErr, context.Canceled)
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for stream complete callback")
+	}
+	select {
+	case resp := <-responseChan:
+		t.Fatalf("unexpected response: %#v", resp)
+	default:
+	}
+}
+
 func TestConvertMessage(t *testing.T) {
 	msg := model.Message{
 		Role:    model.RoleUser,

--- a/model/hunyuan/hunyuan_test.go
+++ b/model/hunyuan/hunyuan_test.go
@@ -427,12 +427,26 @@ func TestChatStreamCompleteCallbackBeforeFinalResponse(t *testing.T) {
 }
 
 func TestHandleStreamingResponseWithoutFinalChunk(t *testing.T) {
+	handlerErrCh := make(chan error, 1)
+	reportHandlerErr := func(err error) {
+		if err == nil {
+			return
+		}
+		select {
+		case handlerErrCh <- err:
+		default:
+		}
+	}
+
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)
 
 		flusher, ok := w.(http.Flusher)
-		require.True(t, ok)
+		if !ok {
+			reportHandlerErr(fmt.Errorf("response writer is not a flusher"))
+			return
+		}
 
 		chunk := hunyuan.ChatCompletionResponse{
 			Id:      "stream-id-1",
@@ -448,12 +462,19 @@ func TestHandleStreamingResponseWithoutFinalChunk(t *testing.T) {
 			},
 		}
 		data, err := json.Marshal(chunk)
-		require.NoError(t, err)
-		_, err = fmt.Fprintf(w, "data: %s\n\n", string(data))
-		require.NoError(t, err)
+		if err != nil {
+			reportHandlerErr(err)
+			return
+		}
+		if _, err = fmt.Fprintf(w, "data: %s\n\n", string(data)); err != nil {
+			reportHandlerErr(err)
+			return
+		}
 		flusher.Flush()
-		_, err = fmt.Fprint(w, "data: [DONE]\n\n")
-		require.NoError(t, err)
+		if _, err = fmt.Fprint(w, "data: [DONE]\n\n"); err != nil {
+			reportHandlerErr(err)
+			return
+		}
 		flusher.Flush()
 	}))
 	defer mockServer.Close()
@@ -489,15 +510,34 @@ func TestHandleStreamingResponseWithoutFinalChunk(t *testing.T) {
 	case <-time.After(3 * time.Second):
 		t.Fatal("timeout waiting for stream complete callback")
 	}
+	select {
+	case err := <-handlerErrCh:
+		require.NoError(t, err)
+	default:
+	}
 }
 
 func TestHandleStreamingResponseCallbackOnContextCancel(t *testing.T) {
+	handlerErrCh := make(chan error, 1)
+	reportHandlerErr := func(err error) {
+		if err == nil {
+			return
+		}
+		select {
+		case handlerErrCh <- err:
+		default:
+		}
+	}
+
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)
 
 		flusher, ok := w.(http.Flusher)
-		require.True(t, ok)
+		if !ok {
+			reportHandlerErr(fmt.Errorf("response writer is not a flusher"))
+			return
+		}
 
 		chunk := hunyuan.ChatCompletionResponse{
 			Id:      "stream-id-1",
@@ -513,9 +553,14 @@ func TestHandleStreamingResponseCallbackOnContextCancel(t *testing.T) {
 			},
 		}
 		data, err := json.Marshal(chunk)
-		require.NoError(t, err)
-		_, err = fmt.Fprintf(w, "data: %s\n\n", string(data))
-		require.NoError(t, err)
+		if err != nil {
+			reportHandlerErr(err)
+			return
+		}
+		if _, err = fmt.Fprintf(w, "data: %s\n\n", string(data)); err != nil {
+			reportHandlerErr(err)
+			return
+		}
 		flusher.Flush()
 	}))
 	defer mockServer.Close()
@@ -551,6 +596,11 @@ func TestHandleStreamingResponseCallbackOnContextCancel(t *testing.T) {
 	select {
 	case resp := <-responseChan:
 		t.Fatalf("unexpected response: %#v", resp)
+	default:
+	}
+	select {
+	case err := <-handlerErrCh:
+		require.NoError(t, err)
 	default:
 	}
 }

--- a/model/hunyuan/hunyuan_test.go
+++ b/model/hunyuan/hunyuan_test.go
@@ -78,6 +78,76 @@ func (testErrorCounter) CountTokensRange(ctx context.Context, messages []model.M
 	return 0, fmt.Errorf("count tokens range error")
 }
 
+func TestModel_CallbackPanicsAreRecovered(t *testing.T) {
+	t.Run("request callback", func(t *testing.T) {
+		callbackCalled := false
+		m := &Model{
+			chatRequestCallback: func(ctx context.Context, req *hunyuan.ChatCompletionNewParams) {
+				callbackCalled = true
+				panic("boom")
+			},
+		}
+
+		require.NotPanics(t, func() {
+			m.runChatRequestCallback(context.Background(), &hunyuan.ChatCompletionNewParams{})
+		})
+		assert.True(t, callbackCalled)
+	})
+
+	t.Run("response callback", func(t *testing.T) {
+		callbackCalled := false
+		m := &Model{
+			chatResponseCallback: func(ctx context.Context, req *hunyuan.ChatCompletionNewParams, resp *hunyuan.ChatCompletionResponse) {
+				callbackCalled = true
+				panic("boom")
+			},
+		}
+
+		require.NotPanics(t, func() {
+			m.runChatResponseCallback(
+				context.Background(),
+				&hunyuan.ChatCompletionNewParams{},
+				&hunyuan.ChatCompletionResponse{},
+			)
+		})
+		assert.True(t, callbackCalled)
+	})
+
+	t.Run("chunk callback", func(t *testing.T) {
+		callbackCalled := false
+		m := &Model{
+			chatChunkCallback: func(ctx context.Context, req *hunyuan.ChatCompletionNewParams, chunk *hunyuan.ChatCompletionResponse) {
+				callbackCalled = true
+				panic("boom")
+			},
+		}
+
+		require.NotPanics(t, func() {
+			m.runChatChunkCallback(
+				context.Background(),
+				&hunyuan.ChatCompletionNewParams{},
+				&hunyuan.ChatCompletionResponse{},
+			)
+		})
+		assert.True(t, callbackCalled)
+	})
+
+	t.Run("stream complete callback", func(t *testing.T) {
+		callbackCalled := false
+		m := &Model{
+			chatStreamCompleteCallback: func(ctx context.Context, req *hunyuan.ChatCompletionNewParams, err error) {
+				callbackCalled = true
+				panic("boom")
+			},
+		}
+
+		require.NotPanics(t, func() {
+			m.runChatStreamCompleteCallback(context.Background(), &hunyuan.ChatCompletionNewParams{}, nil)
+		})
+		assert.True(t, callbackCalled)
+	})
+}
+
 func TestNew(t *testing.T) {
 	m := New("hunyuan-lite",
 		WithSecretId("test-secret-id"),

--- a/model/hunyuan/hunyuan_test.go
+++ b/model/hunyuan/hunyuan_test.go
@@ -328,6 +328,104 @@ func TestGenerateContentStreamWithMockServer(t *testing.T) {
 	}
 }
 
+func TestChatStreamCompleteCallbackBeforeFinalResponse(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+
+		flusher, ok := w.(http.Flusher)
+		require.True(t, ok)
+
+		chunks := []hunyuan.ChatCompletionResponse{
+			{
+				Id:      "stream-id-1",
+				Created: time.Now().Unix(),
+				Choices: []*hunyuan.ChatCompletionResponseChoice{
+					{
+						Index: 0,
+						Delta: &hunyuan.ChatCompletionResponseDelta{
+							Role:    "assistant",
+							Content: "Hello",
+						},
+					},
+				},
+			},
+			{
+				Id:      "stream-id-2",
+				Created: time.Now().Unix(),
+				Choices: []*hunyuan.ChatCompletionResponseChoice{
+					{
+						Index: 0,
+						Delta: &hunyuan.ChatCompletionResponseDelta{
+							Content: " world",
+						},
+						FinishReason: "stop",
+					},
+				},
+			},
+		}
+
+		for _, chunk := range chunks {
+			data, err := json.Marshal(chunk)
+			require.NoError(t, err)
+			_, err = fmt.Fprintf(w, "data: %s\n\n", string(data))
+			require.NoError(t, err)
+			flusher.Flush()
+		}
+
+		_, err := fmt.Fprint(w, "data: [DONE]\n\n")
+		require.NoError(t, err)
+		flusher.Flush()
+	}))
+	defer mockServer.Close()
+
+	streamCompleteCalled := make(chan struct{})
+	m := New("hunyuan-lite",
+		WithSecretId("test-secret-id"),
+		WithSecretKey("test-secret-key"),
+		WithBaseUrl(mockServer.URL),
+		WithHost("test-host"),
+		WithChatStreamCompleteCallback(func(ctx context.Context,
+			chatRequest *hunyuan.ChatCompletionNewParams, streamErr error) {
+			close(streamCompleteCalled)
+		}),
+	)
+
+	ctx := context.Background()
+	request := &model.Request{
+		Messages: []model.Message{
+			model.NewUserMessage("Hello"),
+		},
+		GenerationConfig: model.GenerationConfig{
+			Stream: true,
+		},
+	}
+
+	responseChan, err := m.GenerateContent(ctx, request)
+	require.NoError(t, err)
+
+	var sawFinal bool
+	for resp := range responseChan {
+		if !resp.Done {
+			continue
+		}
+		sawFinal = true
+		select {
+		case <-streamCompleteCalled:
+			// Success.
+		default:
+			t.Fatal("stream complete callback must run before final response is emitted")
+		}
+		break
+	}
+	assert.True(t, sawFinal)
+	select {
+	case <-streamCompleteCalled:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for stream complete callback")
+	}
+}
+
 func TestConvertMessage(t *testing.T) {
 	msg := model.Message{
 		Role:    model.RoleUser,

--- a/model/hunyuan/options.go
+++ b/model/hunyuan/options.go
@@ -103,7 +103,9 @@ func WithChatChunkCallback(fn ChatChunkCallbackFunc) Option {
 	}
 }
 
-// WithChatStreamCompleteCallback sets the function to be called when streaming is completed.
+// WithChatStreamCompleteCallback sets the function to be called when
+// streaming is completed. The callback runs synchronously before the
+// terminal streaming result is surfaced to the caller.
 func WithChatStreamCompleteCallback(fn ChatStreamCompleteCallbackFunc) Option {
 	return func(opts *options) {
 		opts.chatStreamCompleteCallback = fn

--- a/model/internal/model/callback_recovery.go
+++ b/model/internal/model/callback_recovery.go
@@ -1,0 +1,30 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package model
+
+import (
+	"context"
+	"runtime/debug"
+
+	"trpc.group/trpc-go/trpc-agent-go/log"
+)
+
+// RecoverCallbackPanic converts provider callback panics into logged errors so
+// user-defined hooks cannot crash the framework's streaming goroutines.
+func RecoverCallbackPanic(ctx context.Context, stage string) {
+	if recovered := recover(); recovered != nil {
+		log.ErrorfContext(
+			ctx,
+			"%s panic: %v\n%s",
+			stage,
+			recovered,
+			string(debug.Stack()),
+		)
+	}
+}

--- a/model/internal/model/callback_recovery_test.go
+++ b/model/internal/model/callback_recovery_test.go
@@ -1,0 +1,69 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package model
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/log"
+)
+
+func TestRecoverCallbackPanic_NoPanic(t *testing.T) {
+	original := log.ErrorfContext
+	defer func() {
+		log.ErrorfContext = original
+	}()
+
+	logged := false
+	log.ErrorfContext = func(_ context.Context, format string, args ...any) {
+		logged = true
+	}
+
+	require.NotPanics(t, func() {
+		func() {
+			defer RecoverCallbackPanic(context.Background(), "test callback")
+		}()
+	})
+	assert.False(t, logged)
+}
+
+func TestRecoverCallbackPanic_RecoversAndLogs(t *testing.T) {
+	original := log.ErrorfContext
+	defer func() {
+		log.ErrorfContext = original
+	}()
+
+	logged := false
+	var capturedFormat string
+	var capturedArgs []any
+	log.ErrorfContext = func(_ context.Context, format string, args ...any) {
+		logged = true
+		capturedFormat = format
+		capturedArgs = args
+	}
+
+	require.NotPanics(t, func() {
+		func() {
+			defer RecoverCallbackPanic(context.Background(), "test callback")
+			panic("boom")
+		}()
+	})
+
+	require.True(t, logged)
+	assert.Equal(t, "%s panic: %v\n%s", capturedFormat)
+	require.Len(t, capturedArgs, 3)
+	assert.Equal(t, "test callback", capturedArgs[0])
+	assert.Equal(t, "boom", capturedArgs[1])
+	stack, ok := capturedArgs[2].(string)
+	require.True(t, ok)
+	assert.Contains(t, stack, "TestRecoverCallbackPanic_RecoversAndLogs")
+}

--- a/model/ollama/ollama.go
+++ b/model/ollama/ollama.go
@@ -330,7 +330,10 @@ func (m *Model) handleStreamingResponse(
 	chatRequest api.ChatRequest,
 	responseChan chan<- *model.Response,
 ) {
-	var streamErr error
+	var (
+		streamErr     error
+		finalResponse *model.Response
+	)
 
 	err := m.client.Chat(ctx, &chatRequest, func(chunk api.ChatResponse) error {
 		if m.chatChunkCallback != nil {
@@ -340,6 +343,10 @@ func (m *Model) handleStreamingResponse(
 		response, err := convertChatResponse(chunk)
 		if err != nil {
 			return err
+		}
+		if response.Done {
+			finalResponse = response
+			return nil
 		}
 
 		// Emit partial response.
@@ -354,12 +361,23 @@ func (m *Model) handleStreamingResponse(
 
 	if err != nil {
 		streamErr = err
-		m.sendErrorResponse(ctx, responseChan, model.ErrorTypeStreamError, err)
 	}
 
-	// Call the stream complete callback.
+	// Call the stream complete callback before surfacing the terminal result.
 	if m.chatStreamCompleteCallback != nil {
 		m.chatStreamCompleteCallback(ctx, &chatRequest, streamErr)
+	}
+
+	if streamErr != nil {
+		m.sendErrorResponse(ctx, responseChan, model.ErrorTypeStreamError, streamErr)
+		return
+	}
+	if finalResponse == nil {
+		return
+	}
+	select {
+	case responseChan <- finalResponse:
+	case <-ctx.Done():
 	}
 }
 

--- a/model/ollama/ollama.go
+++ b/model/ollama/ollama.go
@@ -152,6 +152,53 @@ func (m *Model) Info() model.Info {
 	}
 }
 
+func (m *Model) runChatRequestCallback(
+	ctx context.Context,
+	chatRequest *api.ChatRequest,
+) {
+	if m.chatRequestCallback == nil {
+		return
+	}
+	defer imodel.RecoverCallbackPanic(ctx, "chat request callback")
+	m.chatRequestCallback(ctx, chatRequest)
+}
+
+func (m *Model) runChatResponseCallback(
+	ctx context.Context,
+	chatRequest *api.ChatRequest,
+	chatResponse *api.ChatResponse,
+) {
+	if m.chatResponseCallback == nil {
+		return
+	}
+	defer imodel.RecoverCallbackPanic(ctx, "chat response callback")
+	m.chatResponseCallback(ctx, chatRequest, chatResponse)
+}
+
+func (m *Model) runChatChunkCallback(
+	ctx context.Context,
+	chatRequest *api.ChatRequest,
+	chatChunk *api.ChatResponse,
+) {
+	if m.chatChunkCallback == nil {
+		return
+	}
+	defer imodel.RecoverCallbackPanic(ctx, "chat chunk callback")
+	m.chatChunkCallback(ctx, chatRequest, chatChunk)
+}
+
+func (m *Model) runChatStreamCompleteCallback(
+	ctx context.Context,
+	chatRequest *api.ChatRequest,
+	streamErr error,
+) {
+	if m.chatStreamCompleteCallback == nil {
+		return
+	}
+	defer imodel.RecoverCallbackPanic(ctx, "chat stream complete callback")
+	m.chatStreamCompleteCallback(ctx, chatRequest, streamErr)
+}
+
 // GenerateContent generates content from the model.
 func (m *Model) GenerateContent(
 	ctx context.Context,
@@ -172,9 +219,7 @@ func (m *Model) GenerateContent(
 	// Execute callback synchronously before starting the goroutine
 	// to avoid a race where the runner and HTTP handler finish
 	// (closing the SSE writer) while the callback is still running.
-	if m.chatRequestCallback != nil {
-		m.chatRequestCallback(ctx, chatRequest)
-	}
+	m.runChatRequestCallback(ctx, chatRequest)
 	// Send chat request and handle response.
 	responseChan := make(chan *model.Response, m.channelBufferSize)
 	responseID := newResponseID()
@@ -309,9 +354,7 @@ func (m *Model) handleNonStreamingResponse(
 		return
 	}
 
-	if m.chatResponseCallback != nil {
-		m.chatResponseCallback(ctx, &chatRequest, &chatResponse)
-	}
+	m.runChatResponseCallback(ctx, &chatRequest, &chatResponse)
 
 	response, err := convertChatResponse(chatResponse, responseID)
 	if err != nil {
@@ -339,9 +382,7 @@ func (m *Model) handleStreamingResponse(
 	)
 
 	err := m.client.Chat(ctx, &chatRequest, func(chunk api.ChatResponse) error {
-		if m.chatChunkCallback != nil {
-			m.chatChunkCallback(ctx, &chatRequest, &chunk)
-		}
+		m.runChatChunkCallback(ctx, &chatRequest, &chunk)
 
 		response, err := convertChatResponse(chunk, responseID)
 		if err != nil {
@@ -367,9 +408,7 @@ func (m *Model) handleStreamingResponse(
 	}
 
 	// Call the stream complete callback before surfacing the terminal result.
-	if m.chatStreamCompleteCallback != nil {
-		m.chatStreamCompleteCallback(ctx, &chatRequest, streamErr)
-	}
+	m.runChatStreamCompleteCallback(ctx, &chatRequest, streamErr)
 
 	if streamErr != nil {
 		m.sendErrorResponse(ctx, responseChan, responseID, model.ErrorTypeStreamError, streamErr)

--- a/model/ollama/ollama_test.go
+++ b/model/ollama/ollama_test.go
@@ -641,6 +641,131 @@ func Test_HandleStreamingResponse(t *testing.T) {
 	}
 }
 
+// Test_HandleStreamingResponseWithoutFinalChunk tests a stream that ends
+// without a terminal done chunk.
+func Test_HandleStreamingResponseWithoutFinalChunk(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/api/chat") && !strings.HasPrefix(r.URL.Path, "/api/show") {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/show" {
+			resp := map[string]any{
+				"model_info": map[string]any{
+					"gptoss.context_length": 131072,
+				},
+			}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		flusher, ok := w.(http.Flusher)
+		require.True(t, ok)
+		chunk := map[string]any{
+			"model":      "llama3.2:latest",
+			"created_at": "2024-01-01T00:00:00Z",
+			"message":    map[string]any{"role": "assistant", "content": "Hello"},
+			"done":       false,
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(chunk))
+		flusher.Flush()
+	}))
+	defer srv.Close()
+
+	streamCompleteCalled := make(chan error, 1)
+	m := New("gpt-oss:20b",
+		WithHost(srv.URL),
+		WithChatStreamCompleteCallback(func(ctx context.Context,
+			req *api.ChatRequest, err error) {
+			streamCompleteCalled <- err
+		}),
+	)
+
+	responseChan := make(chan *model.Response, 2)
+	m.handleStreamingResponse(context.Background(), api.ChatRequest{}, responseChan)
+	close(responseChan)
+
+	var responses []*model.Response
+	for resp := range responseChan {
+		responses = append(responses, resp)
+	}
+
+	require.Len(t, responses, 1)
+	assert.True(t, responses[0].IsPartial)
+	assert.False(t, responses[0].Done)
+	select {
+	case streamErr := <-streamCompleteCalled:
+		assert.NoError(t, streamErr)
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for stream complete callback")
+	}
+}
+
+// Test_HandleStreamingResponseCallbackOnContextCancel tests callback timing
+// when streaming aborts with context cancellation.
+func Test_HandleStreamingResponseCallbackOnContextCancel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/api/chat") && !strings.HasPrefix(r.URL.Path, "/api/show") {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/show" {
+			resp := map[string]any{
+				"model_info": map[string]any{
+					"gptoss.context_length": 131072,
+				},
+			}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		flusher, ok := w.(http.Flusher)
+		require.True(t, ok)
+		chunk := map[string]any{
+			"model":      "llama3.2:latest",
+			"created_at": "2024-01-01T00:00:00Z",
+			"message":    map[string]any{"role": "assistant", "content": "Hello"},
+			"done":       false,
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(chunk))
+		flusher.Flush()
+	}))
+	defer srv.Close()
+
+	streamCompleteCalled := make(chan error, 1)
+	m := New("gpt-oss:20b",
+		WithHost(srv.URL),
+		WithChatStreamCompleteCallback(func(ctx context.Context,
+			req *api.ChatRequest, err error) {
+			streamCompleteCalled <- err
+		}),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	responseChan := make(chan *model.Response)
+	m.handleStreamingResponse(ctx, api.ChatRequest{}, responseChan)
+
+	select {
+	case streamErr := <-streamCompleteCalled:
+		require.ErrorIs(t, streamErr, context.Canceled)
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for stream complete callback")
+	}
+	select {
+	case resp := <-responseChan:
+		t.Fatalf("unexpected response: %#v", resp)
+	default:
+	}
+}
+
 // Test_HandleErrorResponse tests error response handling.
 func Test_HandleErrorResponse(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/model/ollama/ollama_test.go
+++ b/model/ollama/ollama_test.go
@@ -841,7 +841,8 @@ func Test_HandleStreamingResponseCallbackOnContextCancel(t *testing.T) {
 	select {
 	case resp := <-responseChan:
 		t.Fatalf("unexpected response: %#v", resp)
-	default:
+	case <-time.After(100 * time.Millisecond):
+		// no response after cancellation, as expected
 	}
 }
 

--- a/model/ollama/ollama_test.go
+++ b/model/ollama/ollama_test.go
@@ -587,14 +587,15 @@ func Test_HandleStreamingResponse(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	var chunkCalled, streamCompleteCalled bool
+	var chunkCalled bool
+	streamCompleteCalled := make(chan struct{})
 	m := New("gpt-oss:20b",
 		WithHost(srv.URL),
 		WithChatChunkCallback(func(ctx context.Context, req *api.ChatRequest, chunk *api.ChatResponse) {
 			chunkCalled = true
 		}),
 		WithChatStreamCompleteCallback(func(ctx context.Context, req *api.ChatRequest, err error) {
-			streamCompleteCalled = true
+			close(streamCompleteCalled)
 		}),
 	)
 
@@ -616,7 +617,12 @@ func Test_HandleStreamingResponse(t *testing.T) {
 	for resp := range ch {
 		if resp.Done {
 			final = resp
-			time.Sleep(time.Second)
+			select {
+			case <-streamCompleteCalled:
+				// Success.
+			default:
+				t.Fatal("stream complete callback must run before final response is emitted")
+			}
 			break
 		}
 		if resp.IsPartial {
@@ -628,7 +634,11 @@ func Test_HandleStreamingResponse(t *testing.T) {
 	assert.NotNil(t, final)
 	assert.True(t, final.Done)
 	assert.True(t, chunkCalled)
-	assert.True(t, streamCompleteCalled)
+	select {
+	case <-streamCompleteCalled:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for stream complete callback")
+	}
 }
 
 // Test_HandleErrorResponse tests error response handling.

--- a/model/ollama/ollama_test.go
+++ b/model/ollama/ollama_test.go
@@ -65,6 +65,68 @@ func Test_Model_Info(t *testing.T) {
 	assert.Equal(t, "llama3.2:latest", info.Name)
 }
 
+func TestModel_CallbackPanicsAreRecovered(t *testing.T) {
+	t.Run("request callback", func(t *testing.T) {
+		callbackCalled := false
+		m := &Model{
+			chatRequestCallback: func(ctx context.Context, req *api.ChatRequest) {
+				callbackCalled = true
+				panic("boom")
+			},
+		}
+
+		require.NotPanics(t, func() {
+			m.runChatRequestCallback(context.Background(), &api.ChatRequest{})
+		})
+		assert.True(t, callbackCalled)
+	})
+
+	t.Run("response callback", func(t *testing.T) {
+		callbackCalled := false
+		m := &Model{
+			chatResponseCallback: func(ctx context.Context, req *api.ChatRequest, resp *api.ChatResponse) {
+				callbackCalled = true
+				panic("boom")
+			},
+		}
+
+		require.NotPanics(t, func() {
+			m.runChatResponseCallback(context.Background(), &api.ChatRequest{}, &api.ChatResponse{})
+		})
+		assert.True(t, callbackCalled)
+	})
+
+	t.Run("chunk callback", func(t *testing.T) {
+		callbackCalled := false
+		m := &Model{
+			chatChunkCallback: func(ctx context.Context, req *api.ChatRequest, chunk *api.ChatResponse) {
+				callbackCalled = true
+				panic("boom")
+			},
+		}
+
+		require.NotPanics(t, func() {
+			m.runChatChunkCallback(context.Background(), &api.ChatRequest{}, &api.ChatResponse{})
+		})
+		assert.True(t, callbackCalled)
+	})
+
+	t.Run("stream complete callback", func(t *testing.T) {
+		callbackCalled := false
+		m := &Model{
+			chatStreamCompleteCallback: func(ctx context.Context, req *api.ChatRequest, err error) {
+				callbackCalled = true
+				panic("boom")
+			},
+		}
+
+		require.NotPanics(t, func() {
+			m.runChatStreamCompleteCallback(context.Background(), &api.ChatRequest{}, nil)
+		})
+		assert.True(t, callbackCalled)
+	})
+}
+
 // TestNew tests the constructor with various options.
 func TestNew(t *testing.T) {
 	tests := []struct {

--- a/model/ollama/options.go
+++ b/model/ollama/options.go
@@ -160,7 +160,9 @@ func WithChatChunkCallback(fn ChatChunkCallbackFunc) Option {
 	}
 }
 
-// WithChatStreamCompleteCallback sets the function to be called when streaming is completed.
+// WithChatStreamCompleteCallback sets the function to be called when
+// streaming is completed. The callback runs synchronously before the
+// terminal streaming result is surfaced to the caller.
 func WithChatStreamCompleteCallback(fn ChatStreamCompleteCallbackFunc) Option {
 	return func(opts *options) {
 		opts.chatStreamCompleteCallback = fn

--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -1302,6 +1302,9 @@ func (m *Model) handleStreamingResponseWithEmitter(
 		m.runChatChunkCallback(ctx, &chatRequest, &chunk)
 
 		if !emit(m.createPartialResponse(chunk)) {
+			if err := ctx.Err(); err != nil {
+				m.handleStreamCompleteCallback(ctx, chatRequest, acc, err)
+			}
 			return
 		}
 	}

--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -1271,10 +1271,10 @@ func (m *Model) handleStreamingResponseWithEmitter(
 		}
 	}
 
-	m.emitStreamingFinalResponse(ctx, stream, acc, idToIndexMap, extraFieldsMap, reasoningBuf.String(), emit)
-
-	// Call the stream complete callback after final response is emitted.
+	// Call the stream complete callback before the final response is emitted.
 	m.handleStreamCompleteCallback(ctx, chatRequest, acc, stream.Err())
+
+	m.emitStreamingFinalResponse(ctx, stream, acc, idToIndexMap, extraFieldsMap, reasoningBuf.String(), emit)
 }
 
 // sanitizeChunkForAccumulator returns a defensive copy of the given chunk that

--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -1621,10 +1621,189 @@ func (m *Model) handleStreamCompleteCallback(
 	}
 	var callbackAcc *openai.ChatCompletionAccumulator
 	if streamErr == nil {
-		callbackAcc = &acc
+		clonedAcc := cloneChatCompletionAccumulator(acc)
+		callbackAcc = &clonedAcc
 	}
 	defer imodel.RecoverCallbackPanic(ctx, "chat stream complete callback")
 	m.chatStreamCompleteCallback(ctx, &chatRequest, callbackAcc, streamErr)
+}
+
+func cloneChatCompletionAccumulator(acc openai.ChatCompletionAccumulator) openai.ChatCompletionAccumulator {
+	cloned := acc
+	cloned.ChatCompletion = cloneChatCompletion(acc.ChatCompletion)
+	return cloned
+}
+
+func cloneChatCompletion(chatCompletion openai.ChatCompletion) openai.ChatCompletion {
+	cloned := chatCompletion
+	cloned.JSON.ExtraFields = cloneRespJSONFieldMap(chatCompletion.JSON.ExtraFields)
+	cloned.Usage = cloneCompletionUsage(chatCompletion.Usage)
+	if chatCompletion.Choices != nil {
+		cloned.Choices = make([]openai.ChatCompletionChoice, len(chatCompletion.Choices))
+		for i, choice := range chatCompletion.Choices {
+			cloned.Choices[i] = cloneChatCompletionChoice(choice)
+		}
+	}
+	return cloned
+}
+
+func cloneChatCompletionChoice(choice openai.ChatCompletionChoice) openai.ChatCompletionChoice {
+	cloned := choice
+	cloned.JSON.ExtraFields = cloneRespJSONFieldMap(choice.JSON.ExtraFields)
+	cloned.Logprobs = cloneChatCompletionChoiceLogprobs(choice.Logprobs)
+	cloned.Message = cloneChatCompletionMessage(choice.Message)
+	return cloned
+}
+
+func cloneChatCompletionChoiceLogprobs(
+	logprobs openai.ChatCompletionChoiceLogprobs,
+) openai.ChatCompletionChoiceLogprobs {
+	cloned := logprobs
+	cloned.JSON.ExtraFields = cloneRespJSONFieldMap(logprobs.JSON.ExtraFields)
+	if logprobs.Content != nil {
+		cloned.Content = make([]openai.ChatCompletionTokenLogprob, len(logprobs.Content))
+		for i, token := range logprobs.Content {
+			cloned.Content[i] = cloneChatCompletionTokenLogprob(token)
+		}
+	}
+	if logprobs.Refusal != nil {
+		cloned.Refusal = make([]openai.ChatCompletionTokenLogprob, len(logprobs.Refusal))
+		for i, token := range logprobs.Refusal {
+			cloned.Refusal[i] = cloneChatCompletionTokenLogprob(token)
+		}
+	}
+	return cloned
+}
+
+func cloneChatCompletionTokenLogprob(
+	token openai.ChatCompletionTokenLogprob,
+) openai.ChatCompletionTokenLogprob {
+	cloned := token
+	cloned.JSON.ExtraFields = cloneRespJSONFieldMap(token.JSON.ExtraFields)
+	if token.Bytes != nil {
+		cloned.Bytes = append([]int64(nil), token.Bytes...)
+	}
+	if token.TopLogprobs != nil {
+		cloned.TopLogprobs = make([]openai.ChatCompletionTokenLogprobTopLogprob, len(token.TopLogprobs))
+		for i, top := range token.TopLogprobs {
+			cloned.TopLogprobs[i] = cloneChatCompletionTokenLogprobTopLogprob(top)
+		}
+	}
+	return cloned
+}
+
+func cloneChatCompletionTokenLogprobTopLogprob(
+	token openai.ChatCompletionTokenLogprobTopLogprob,
+) openai.ChatCompletionTokenLogprobTopLogprob {
+	cloned := token
+	cloned.JSON.ExtraFields = cloneRespJSONFieldMap(token.JSON.ExtraFields)
+	if token.Bytes != nil {
+		cloned.Bytes = append([]int64(nil), token.Bytes...)
+	}
+	return cloned
+}
+
+func cloneChatCompletionMessage(message openai.ChatCompletionMessage) openai.ChatCompletionMessage {
+	cloned := message
+	cloned.JSON.ExtraFields = cloneRespJSONFieldMap(message.JSON.ExtraFields)
+	cloned.Audio = cloneChatCompletionAudio(message.Audio)
+	cloned.FunctionCall = cloneChatCompletionMessageFunctionCall(message.FunctionCall)
+	if message.Annotations != nil {
+		cloned.Annotations = make([]openai.ChatCompletionMessageAnnotation, len(message.Annotations))
+		for i, annotation := range message.Annotations {
+			cloned.Annotations[i] = cloneChatCompletionMessageAnnotation(annotation)
+		}
+	}
+	if message.ToolCalls != nil {
+		cloned.ToolCalls = make([]openai.ChatCompletionMessageToolCall, len(message.ToolCalls))
+		for i, toolCall := range message.ToolCalls {
+			cloned.ToolCalls[i] = cloneChatCompletionMessageToolCall(toolCall)
+		}
+	}
+	return cloned
+}
+
+func cloneChatCompletionMessageAnnotation(
+	annotation openai.ChatCompletionMessageAnnotation,
+) openai.ChatCompletionMessageAnnotation {
+	cloned := annotation
+	cloned.JSON.ExtraFields = cloneRespJSONFieldMap(annotation.JSON.ExtraFields)
+	cloned.URLCitation = cloneChatCompletionMessageAnnotationURLCitation(annotation.URLCitation)
+	return cloned
+}
+
+func cloneChatCompletionMessageAnnotationURLCitation(
+	urlCitation openai.ChatCompletionMessageAnnotationURLCitation,
+) openai.ChatCompletionMessageAnnotationURLCitation {
+	cloned := urlCitation
+	cloned.JSON.ExtraFields = cloneRespJSONFieldMap(urlCitation.JSON.ExtraFields)
+	return cloned
+}
+
+func cloneChatCompletionAudio(audio openai.ChatCompletionAudio) openai.ChatCompletionAudio {
+	cloned := audio
+	cloned.JSON.ExtraFields = cloneRespJSONFieldMap(audio.JSON.ExtraFields)
+	return cloned
+}
+
+func cloneChatCompletionMessageFunctionCall(
+	functionCall openai.ChatCompletionMessageFunctionCall,
+) openai.ChatCompletionMessageFunctionCall {
+	cloned := functionCall
+	cloned.JSON.ExtraFields = cloneRespJSONFieldMap(functionCall.JSON.ExtraFields)
+	return cloned
+}
+
+func cloneChatCompletionMessageToolCall(
+	toolCall openai.ChatCompletionMessageToolCall,
+) openai.ChatCompletionMessageToolCall {
+	cloned := toolCall
+	cloned.JSON.ExtraFields = cloneRespJSONFieldMap(toolCall.JSON.ExtraFields)
+	cloned.Function = cloneChatCompletionMessageToolCallFunction(toolCall.Function)
+	return cloned
+}
+
+func cloneChatCompletionMessageToolCallFunction(
+	function openai.ChatCompletionMessageToolCallFunction,
+) openai.ChatCompletionMessageToolCallFunction {
+	cloned := function
+	cloned.JSON.ExtraFields = cloneRespJSONFieldMap(function.JSON.ExtraFields)
+	return cloned
+}
+
+func cloneCompletionUsage(usage openai.CompletionUsage) openai.CompletionUsage {
+	cloned := usage
+	cloned.JSON.ExtraFields = cloneRespJSONFieldMap(usage.JSON.ExtraFields)
+	cloned.CompletionTokensDetails = cloneCompletionUsageCompletionTokensDetails(usage.CompletionTokensDetails)
+	cloned.PromptTokensDetails = cloneCompletionUsagePromptTokensDetails(usage.PromptTokensDetails)
+	return cloned
+}
+
+func cloneCompletionUsageCompletionTokensDetails(
+	details openai.CompletionUsageCompletionTokensDetails,
+) openai.CompletionUsageCompletionTokensDetails {
+	cloned := details
+	cloned.JSON.ExtraFields = cloneRespJSONFieldMap(details.JSON.ExtraFields)
+	return cloned
+}
+
+func cloneCompletionUsagePromptTokensDetails(
+	details openai.CompletionUsagePromptTokensDetails,
+) openai.CompletionUsagePromptTokensDetails {
+	cloned := details
+	cloned.JSON.ExtraFields = cloneRespJSONFieldMap(details.JSON.ExtraFields)
+	return cloned
+}
+
+func cloneRespJSONFieldMap(fields map[string]respjson.Field) map[string]respjson.Field {
+	if fields == nil {
+		return nil
+	}
+	cloned := make(map[string]respjson.Field, len(fields))
+	for key, value := range fields {
+		cloned[key] = value
+	}
+	return cloned
 }
 
 // shouldSuppressChunk returns true when the chunk contains no meaningful delta

--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"runtime/debug"
 	"sort"
 	"strconv"
 	"strings"
@@ -367,18 +366,6 @@ func (m *Model) Info() model.Info {
 	}
 }
 
-func recoverOpenAICallbackPanic(ctx context.Context, stage string) {
-	if recovered := recover(); recovered != nil {
-		log.ErrorfContext(
-			ctx,
-			"%s panic: %v\n%s",
-			stage,
-			recovered,
-			string(debug.Stack()),
-		)
-	}
-}
-
 func (m *Model) runChatRequestCallback(
 	ctx context.Context,
 	chatRequest *openai.ChatCompletionNewParams,
@@ -386,7 +373,7 @@ func (m *Model) runChatRequestCallback(
 	if m.chatRequestCallback == nil {
 		return
 	}
-	defer recoverOpenAICallbackPanic(ctx, "chat request callback")
+	defer imodel.RecoverCallbackPanic(ctx, "chat request callback")
 	m.chatRequestCallback(ctx, chatRequest)
 }
 
@@ -398,7 +385,7 @@ func (m *Model) runChatResponseCallback(
 	if m.chatResponseCallback == nil {
 		return
 	}
-	defer recoverOpenAICallbackPanic(ctx, "chat response callback")
+	defer imodel.RecoverCallbackPanic(ctx, "chat response callback")
 	m.chatResponseCallback(ctx, chatRequest, chatResponse)
 }
 
@@ -410,7 +397,7 @@ func (m *Model) runChatChunkCallback(
 	if m.chatChunkCallback == nil {
 		return
 	}
-	defer recoverOpenAICallbackPanic(ctx, "chat chunk callback")
+	defer imodel.RecoverCallbackPanic(ctx, "chat chunk callback")
 	m.chatChunkCallback(ctx, chatRequest, chatChunk)
 }
 
@@ -1633,7 +1620,7 @@ func (m *Model) handleStreamCompleteCallback(
 	if streamErr == nil {
 		callbackAcc = &acc
 	}
-	defer recoverOpenAICallbackPanic(ctx, "chat stream complete callback")
+	defer imodel.RecoverCallbackPanic(ctx, "chat stream complete callback")
 	m.chatStreamCompleteCallback(ctx, &chatRequest, callbackAcc, streamErr)
 }
 

--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"runtime/debug"
 	"sort"
 	"strconv"
 	"strings"
@@ -366,6 +367,53 @@ func (m *Model) Info() model.Info {
 	}
 }
 
+func recoverOpenAICallbackPanic(ctx context.Context, stage string) {
+	if recovered := recover(); recovered != nil {
+		log.ErrorfContext(
+			ctx,
+			"%s panic: %v\n%s",
+			stage,
+			recovered,
+			string(debug.Stack()),
+		)
+	}
+}
+
+func (m *Model) runChatRequestCallback(
+	ctx context.Context,
+	chatRequest *openai.ChatCompletionNewParams,
+) {
+	if m.chatRequestCallback == nil {
+		return
+	}
+	defer recoverOpenAICallbackPanic(ctx, "chat request callback")
+	m.chatRequestCallback(ctx, chatRequest)
+}
+
+func (m *Model) runChatResponseCallback(
+	ctx context.Context,
+	chatRequest *openai.ChatCompletionNewParams,
+	chatResponse *openai.ChatCompletion,
+) {
+	if m.chatResponseCallback == nil {
+		return
+	}
+	defer recoverOpenAICallbackPanic(ctx, "chat response callback")
+	m.chatResponseCallback(ctx, chatRequest, chatResponse)
+}
+
+func (m *Model) runChatChunkCallback(
+	ctx context.Context,
+	chatRequest *openai.ChatCompletionNewParams,
+	chatChunk *openai.ChatCompletionChunk,
+) {
+	if m.chatChunkCallback == nil {
+		return
+	}
+	defer recoverOpenAICallbackPanic(ctx, "chat chunk callback")
+	m.chatChunkCallback(ctx, chatRequest, chatChunk)
+}
+
 // prepareChatRequest validates and mutates the request in-place before sending it to the provider.
 func (m *Model) prepareChatRequest(
 	ctx context.Context,
@@ -396,9 +444,7 @@ func (m *Model) GenerateContent(
 	// Execute callback synchronously before starting the goroutine
 	// to avoid a race where the runner and HTTP handler finish
 	// (closing the SSE writer) while the callback is still running.
-	if m.chatRequestCallback != nil {
-		m.chatRequestCallback(ctx, chatRequest)
-	}
+	m.runChatRequestCallback(ctx, chatRequest)
 	responseChan := make(chan *model.Response, m.channelBufferSize)
 	go func() {
 		defer close(responseChan)
@@ -421,9 +467,7 @@ func (m *Model) GenerateContentIter(
 		return nil, err
 	}
 	return func(yield func(*model.Response) bool) {
-		if m.chatRequestCallback != nil {
-			m.chatRequestCallback(ctx, chatRequest)
-		}
+		m.runChatRequestCallback(ctx, chatRequest)
 		emit := func(resp *model.Response) bool {
 			if ctx.Err() != nil {
 				return false
@@ -1268,9 +1312,7 @@ func (m *Model) handleStreamingResponseWithEmitter(
 			}
 		}
 
-		if m.chatChunkCallback != nil {
-			m.chatChunkCallback(ctx, &chatRequest, &chunk)
-		}
+		m.runChatChunkCallback(ctx, &chatRequest, &chunk)
 
 		if !emit(m.createPartialResponse(chunk)) {
 			return
@@ -1591,6 +1633,7 @@ func (m *Model) handleStreamCompleteCallback(
 	if streamErr == nil {
 		callbackAcc = &acc
 	}
+	defer recoverOpenAICallbackPanic(ctx, "chat stream complete callback")
 	m.chatStreamCompleteCallback(ctx, &chatRequest, callbackAcc, streamErr)
 }
 
@@ -2003,9 +2046,7 @@ func (m *Model) handleNonStreamingResponseWithEmitter(
 		return
 	}
 	// Call response callback on successful completion.
-	if m.chatResponseCallback != nil {
-		m.chatResponseCallback(ctx, &chatRequest, chatCompletion)
-	}
+	m.runChatResponseCallback(ctx, &chatRequest, chatCompletion)
 	emit(m.createResponseFromCompletion(chatCompletion))
 }
 

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -1105,17 +1105,24 @@ func TestModel_Callbacks(t *testing.T) {
 		responseChan, err := m.GenerateContent(ctx, request)
 		require.NoError(t, err, "failed to generate content: %v", err)
 
-		// Consume all responses
+		// Consume all responses and ensure the callback runs before
+		// the final response becomes visible to the caller.
 		for response := range responseChan {
-			if response.Done {
-				break
+			if !response.Done {
+				continue
 			}
+			select {
+			case <-callbackCalled:
+				// Success.
+			default:
+				require.Fail(t,
+					"stream complete callback must run before final response is emitted")
+			}
+			break
 		}
 
-		// Wait for callback with timeout
 		select {
 		case <-callbackCalled:
-			// Success - callback was called
 		case <-time.After(3 * time.Second):
 			require.Fail(t, "timeout waiting for stream complete callback")
 		}

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -1107,10 +1107,12 @@ func TestModel_Callbacks(t *testing.T) {
 
 		// Consume all responses and ensure the callback runs before
 		// the final response becomes visible to the caller.
+		sawDone := false
 		for response := range responseChan {
 			if !response.Done {
 				continue
 			}
+			sawDone = true
 			select {
 			case <-callbackCalled:
 				// Success.
@@ -1120,6 +1122,8 @@ func TestModel_Callbacks(t *testing.T) {
 			}
 			break
 		}
+		require.True(t, sawDone,
+			"expected terminal Done response to be emitted")
 
 		select {
 		case <-callbackCalled:

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -588,7 +588,7 @@ func TestModel_GenerateContentIter_StreamingContextCancellationRunsCallback(t *t
 	seq(func(resp *model.Response) bool {
 		responses = append(responses, resp)
 		cancel()
-		return true
+		return false
 	})
 
 	require.Len(t, responses, 1)
@@ -6898,6 +6898,54 @@ func TestModel_handleStreamCompleteCallback(t *testing.T) {
 			m.handleStreamCompleteCallback(context.Background(), chatRequest, acc, nil)
 		})
 		assert.True(t, callbackCalled)
+	})
+
+	t.Run("callback mutations do not affect original accumulator", func(t *testing.T) {
+		callbackCalled := false
+		callback := func(ctx context.Context, req *openai.ChatCompletionNewParams, acc *openai.ChatCompletionAccumulator, streamErr error) {
+			callbackCalled = true
+			require.NotNil(t, acc)
+			acc.Choices[0].Message.Content = "mutated"
+			acc.Choices[0].Message.ToolCalls[0].Function.Arguments = `{"city":"shanghai"}`
+			delete(acc.Choices[0].Message.JSON.ExtraFields, "reasoning_content")
+		}
+
+		m := New("test-model", WithAPIKey("test-key"), WithChatStreamCompleteCallback(callback))
+		chatRequest := openai.ChatCompletionNewParams{}
+		acc := openai.ChatCompletionAccumulator{
+			ChatCompletion: openai.ChatCompletion{
+				ID: "acc-id",
+				Choices: []openai.ChatCompletionChoice{
+					{
+						Index:        0,
+						FinishReason: "stop",
+						Message: openai.ChatCompletionMessage{
+							Content: "original",
+							ToolCalls: []openai.ChatCompletionMessageToolCall{
+								{
+									ID: "call-1",
+									Function: openai.ChatCompletionMessageToolCallFunction{
+										Name:      "weather",
+										Arguments: `{"city":"beijing"}`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		acc.Choices[0].Message.JSON.ExtraFields = map[string]respjson.Field{
+			"reasoning_content": {},
+		}
+
+		m.handleStreamCompleteCallback(context.Background(), chatRequest, acc, nil)
+
+		assert.True(t, callbackCalled)
+		assert.Equal(t, "original", acc.Choices[0].Message.Content)
+		assert.Equal(t, `{"city":"beijing"}`, acc.Choices[0].Message.ToolCalls[0].Function.Arguments)
+		_, exists := acc.Choices[0].Message.JSON.ExtraFields["reasoning_content"]
+		assert.True(t, exists)
 	})
 }
 

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -1508,6 +1508,98 @@ func TestModel_CallbackAssignment(t *testing.T) {
 	})
 }
 
+func TestModel_CallbackPanicsAreRecovered(t *testing.T) {
+	t.Run("request callback", func(t *testing.T) {
+		callbackCalled := false
+		m := New("test-model",
+			WithAPIKey("test-key"),
+			WithChatRequestCallback(func(ctx context.Context, req *openaigo.ChatCompletionNewParams) {
+				callbackCalled = true
+				panic("boom")
+			}),
+		)
+
+		require.NotPanics(t, func() {
+			m.runChatRequestCallback(context.Background(), &openaigo.ChatCompletionNewParams{})
+		})
+		assert.True(t, callbackCalled)
+	})
+
+	t.Run("response callback", func(t *testing.T) {
+		callbackCalled := false
+		m := New("test-model",
+			WithAPIKey("test-key"),
+			WithChatResponseCallback(func(
+				ctx context.Context,
+				req *openaigo.ChatCompletionNewParams,
+				resp *openaigo.ChatCompletion,
+			) {
+				callbackCalled = true
+				panic("boom")
+			}),
+		)
+
+		require.NotPanics(t, func() {
+			m.runChatResponseCallback(
+				context.Background(),
+				&openaigo.ChatCompletionNewParams{},
+				&openaigo.ChatCompletion{},
+			)
+		})
+		assert.True(t, callbackCalled)
+	})
+
+	t.Run("chunk callback", func(t *testing.T) {
+		callbackCalled := false
+		m := New("test-model",
+			WithAPIKey("test-key"),
+			WithChatChunkCallback(func(
+				ctx context.Context,
+				req *openaigo.ChatCompletionNewParams,
+				chunk *openaigo.ChatCompletionChunk,
+			) {
+				callbackCalled = true
+				panic("boom")
+			}),
+		)
+
+		require.NotPanics(t, func() {
+			m.runChatChunkCallback(
+				context.Background(),
+				&openaigo.ChatCompletionNewParams{},
+				&openaigo.ChatCompletionChunk{},
+			)
+		})
+		assert.True(t, callbackCalled)
+	})
+
+	t.Run("stream complete callback", func(t *testing.T) {
+		callbackCalled := false
+		m := New("test-model",
+			WithAPIKey("test-key"),
+			WithChatStreamCompleteCallback(func(
+				ctx context.Context,
+				req *openaigo.ChatCompletionNewParams,
+				acc *openaigo.ChatCompletionAccumulator,
+				streamErr error,
+			) {
+				callbackCalled = true
+				panic("boom")
+			}),
+		)
+
+		require.NotPanics(t, func() {
+			m.handleStreamCompleteCallback(
+				context.Background(),
+				openaigo.ChatCompletionNewParams{},
+				openaigo.ChatCompletionAccumulator{},
+				nil,
+			)
+		})
+		assert.True(t, callbackCalled)
+	})
+}
+
 // testStubCounter implements model.TokenCounter for unit tests.
 type testStubCounter struct{}
 
@@ -5033,6 +5125,86 @@ func TestStreamingCallbackIntegration(t *testing.T) {
 		assert.NotNil(t, capturedRequest, "expected request to be captured in callback")
 	})
 
+	t.Run("streaming continues when chat stream complete callback panics", func(t *testing.T) {
+		callbackCalled := make(chan struct{})
+		callback := func(
+			ctx context.Context,
+			req *openai.ChatCompletionNewParams,
+			acc *openai.ChatCompletionAccumulator,
+			err error,
+		) {
+			close(callbackCalled)
+			panic("boom")
+		}
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.Header().Set("Cache-Control", "no-cache")
+			w.Header().Set("Connection", "keep-alive")
+
+			chunks := []string{
+				`data: {"id":"test","object":"chat.completion.chunk","created":1699200000,"model":"gpt-3.5-turbo","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"},"finish_reason":null}]}`,
+				`data: {"id":"test","object":"chat.completion.chunk","created":1699200000,"model":"gpt-3.5-turbo","choices":[{"index":0,"delta":{"content":" world"},"finish_reason":null}]}`,
+				`data: {"id":"test","object":"chat.completion.chunk","created":1699200000,"model":"gpt-3.5-turbo","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+				`data: [DONE]`,
+			}
+
+			for _, chunk := range chunks {
+				fmt.Fprintf(w, "%s\n\n", chunk)
+				if f, ok := w.(http.Flusher); ok {
+					f.Flush()
+				}
+				time.Sleep(5 * time.Millisecond)
+			}
+		}))
+		defer server.Close()
+
+		m := New("gpt-3.5-turbo",
+			WithBaseURL(server.URL),
+			WithAPIKey("test-key"),
+			WithChatStreamCompleteCallback(callback),
+		)
+
+		req := &model.Request{
+			Messages: []model.Message{
+				model.NewUserMessage("Hello"),
+			},
+			GenerationConfig: model.GenerationConfig{
+				Stream: true,
+			},
+		}
+
+		responseChan, err := m.GenerateContent(context.Background(), req)
+		require.NoError(t, err)
+
+		var responses []*model.Response
+		timeout := time.After(2 * time.Second)
+	loop:
+		for {
+			select {
+			case resp, ok := <-responseChan:
+				if !ok {
+					break loop
+				}
+				responses = append(responses, resp)
+			case <-timeout:
+				t.Fatal("timed out waiting for streaming responses")
+			}
+		}
+
+		select {
+		case <-callbackCalled:
+		default:
+			t.Fatal("expected chat stream complete callback to be called")
+		}
+
+		require.NotEmpty(t, responses)
+		finalResp := responses[len(responses)-1]
+		require.True(t, finalResp.Done)
+		require.Len(t, finalResp.Choices, 1)
+		assert.Equal(t, "Hello world", finalResp.Choices[0].Message.Content)
+	})
+
 	t.Run("streaming with reasoning content handling", func(t *testing.T) {
 		// Create mock server with reasoning content
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -6639,6 +6811,23 @@ func TestModel_handleStreamCompleteCallback(t *testing.T) {
 		assert.Nil(t, capturedAcc)
 		assert.Error(t, capturedErr)
 		assert.Equal(t, "stream error", capturedErr.Error())
+	})
+
+	t.Run("callback panic is recovered", func(t *testing.T) {
+		callbackCalled := false
+		callback := func(ctx context.Context, req *openai.ChatCompletionNewParams, acc *openai.ChatCompletionAccumulator, streamErr error) {
+			callbackCalled = true
+			panic("boom")
+		}
+
+		m := New("test-model", WithAPIKey("test-key"), WithChatStreamCompleteCallback(callback))
+		chatRequest := openai.ChatCompletionNewParams{}
+		acc := openai.ChatCompletionAccumulator{}
+
+		require.NotPanics(t, func() {
+			m.handleStreamCompleteCallback(context.Background(), chatRequest, acc, nil)
+		})
+		assert.True(t, callbackCalled)
 	})
 }
 

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -532,6 +532,76 @@ func TestModel_GenerateContentIter_Streaming(t *testing.T) {
 	require.True(t, sawHello)
 }
 
+func TestModel_GenerateContentIter_StreamingContextCancellationRunsCallback(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/chat/completions") {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+
+		chunks := []string{
+			`data: {"id":"iter-stream-cancel","object":"chat.completion.chunk","created":1699200000,"model":"gpt-3.5-turbo","choices":[{"index":0,"delta":{"role":"assistant","content":"hello"},"finish_reason":null}]}`,
+			`data: {"id":"iter-stream-cancel","object":"chat.completion.chunk","created":1699200000,"model":"gpt-3.5-turbo","choices":[{"index":0,"delta":{"content":" world"},"finish_reason":null}]}`,
+			`data: [DONE]`,
+		}
+		for _, chunk := range chunks {
+			fmt.Fprintf(w, "%s\n\n", chunk)
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+		}
+	}))
+	defer server.Close()
+
+	callbackCalled := make(chan error, 1)
+	m := New("gpt-3.5-turbo",
+		WithBaseURL(server.URL),
+		WithAPIKey("test-key"),
+		WithChatStreamCompleteCallback(func(
+			ctx context.Context,
+			req *openaigo.ChatCompletionNewParams,
+			acc *openaigo.ChatCompletionAccumulator,
+			streamErr error,
+		) {
+			callbackCalled <- streamErr
+		}),
+	)
+
+	req := &model.Request{
+		Messages: []model.Message{
+			model.NewUserMessage("hi"),
+		},
+		GenerationConfig: model.GenerationConfig{
+			Stream: true,
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	seq, err := m.GenerateContentIter(ctx, req)
+	require.NoError(t, err)
+
+	var responses []*model.Response
+	seq(func(resp *model.Response) bool {
+		responses = append(responses, resp)
+		cancel()
+		return true
+	})
+
+	require.Len(t, responses, 1)
+	require.False(t, responses[0].Done)
+
+	select {
+	case streamErr := <-callbackCalled:
+		require.ErrorIs(t, streamErr, context.Canceled)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for stream complete callback")
+	}
+}
+
 func TestOptions_Validation(t *testing.T) {
 	tests := []struct {
 		name string

--- a/model/openai/options.go
+++ b/model/openai/options.go
@@ -189,7 +189,9 @@ func WithChatChunkCallback(fn ChatChunkCallbackFunc) Option {
 	}
 }
 
-// WithChatStreamCompleteCallback sets the function to be called when streaming is completed.
+// WithChatStreamCompleteCallback sets the function to be called when
+// streaming is completed. The callback runs synchronously before the
+// terminal streaming result is surfaced to the caller.
 // Called for both successful and failed streaming completions.
 func WithChatStreamCompleteCallback(fn ChatStreamCompleteCallbackFunc) Option {
 	return func(opts *options) {


### PR DESCRIPTION
## Summary
- run `WithChatStreamCompleteCallback` before the terminal streaming result becomes visible to callers in `openai`, `anthropic`, `hunyuan`, and `ollama`.
- cache terminal `Done` responses where needed so downstream SSE consumers do not observe stream completion before the callback finishes.
- document the callback timing contract and add regression tests that assert the callback fires before the final response.

## Testing
- `go test ./model/openai/ ./model/hunyuan/ -count=1 -timeout 180s`
- `(cd model/anthropic && go test . -count=1 -timeout 180s)`
- `(cd model/ollama && go test . -count=1 -timeout 180s)`