### PR TITLE
memory/extractor: append trailing user message to fix prefill rejection

### DIFF
--- a/memory/extractor/memory.go
+++ b/memory/extractor/memory.go
@@ -222,7 +222,7 @@ func (e *memoryExtractor) Metadata() map[string]any {
 }
 
 // extractionUserSuffix is appended as a trailing user message
-// when the conversation ends with an assistant message. Some
+// when the final message role is neither user nor tool. Some
 // model providers (e.g. Anthropic/Claude) reject requests
 // whose last message has role=assistant.
 const extractionUserSuffix = "Extract and manage memories " +
@@ -249,8 +249,13 @@ func (e *memoryExtractor) buildMessages(
 	// Ensure the sequence ends with a user message. Some
 	// providers reject requests that end with an assistant
 	// message (treated as unsupported prefill).
+	// Skip appending when the trailing assistant message
+	// carries tool_calls, because inserting a plain user
+	// message between a tool-call request and its results
+	// would violate the tool-result ordering constraint.
 	if last := result[len(result)-1]; last.Role != model.RoleUser &&
-		last.Role != model.RoleTool {
+		last.Role != model.RoleTool &&
+		len(last.ToolCalls) == 0 {
 		result = append(result,
 			model.NewUserMessage(extractionUserSuffix))
 	}

--- a/memory/extractor/memory_test.go
+++ b/memory/extractor/memory_test.go
@@ -1008,6 +1008,38 @@ func TestBuildMessages_TrailingAssistantSuffix(t *testing.T) {
 			result[len(result)-1].Role)
 	})
 
+	t.Run("assistant with tool_calls no suffix",
+		func(t *testing.T) {
+			// When the trailing assistant message carries
+			// tool_calls, appending a user message would
+			// break the tool-call → tool-result ordering.
+			msgs := []model.Message{
+				model.NewUserMessage("check weather"),
+				{
+					Role: model.RoleAssistant,
+					ToolCalls: []model.ToolCall{{
+						Type: "function",
+						ID:   "call_1",
+						Function: model.FunctionDefinitionParam{
+							Name: "get_weather",
+							Arguments: []byte(
+								`{"city":"Beijing"}`),
+						},
+					}},
+				},
+			}
+			result := ext.buildMessages(
+				context.Background(), msgs, nil,
+			)
+			// system + user + assistant(tool_calls).
+			// No trailing user message appended.
+			require.Len(t, result, 3)
+			assert.Equal(t, model.RoleAssistant,
+				result[len(result)-1].Role)
+			assert.NotEmpty(t,
+				result[len(result)-1].ToolCalls)
+		})
+
 	t.Run("extract with trailing assistant", func(t *testing.T) {
 		// Verify the full Extract path sends a request
 		// whose last message is user.


### PR DESCRIPTION
## Problem

Some model providers (e.g. Anthropic/Claude) reject requests whose last message has `role=assistant`, treating it as unsupported prefill. The auto memory extractor builds its request from conversation history which typically ends with an assistant reply, resulting in:

```
This model does not support assistant message prefill.
The conversation must end with a user message.
```

## Root Cause

`buildMessages` in `memory/extractor/memory.go` concatenates conversation messages after the system prompt without checking the final message role. After a normal turn the sequence is `[system, user, assistant]` — ending with assistant.

## Fix

Add a guard at the end of `buildMessages`: when the final message is neither `user` nor `tool`, append a short user-role instruction (`"Extract and manage memories from the conversation above."`) so the sequence always satisfies the provider constraint.

## Testing

- Added `TestBuildMessages_TrailingAssistantSuffix` with 4 sub-cases covering assistant-ending, user-ending, tool-ending, and full Extract path.
- All existing tests pass.
- Verified end-to-end with `claude-opus-4-6` via `examples/memory/auto` — no more extraction errors.