### PR TITLE
fix(planner/react): prevent standalone ACTION tags without real tool calls

### DIFF
--- a/planner/react/react_planner.go
+++ b/planner/react/react_planner.go
@@ -287,7 +287,7 @@ func (p *Planner) splitByLastPattern(
 // for the React planner.
 func (p *Planner) buildPlannerInstruction() string {
 	highLevelPreamble := strings.Join([]string{
-		"You are an autonomous AI agent that can solve problems by planning, executing using available tools, and reasoning step by step",
+		"You are an AI agent that solves problems step by step using available tools.",
 		"",
 		"WORKFLOW (execute one step at a time):",
 		"1. PLAN: Create a numbered plan under " + PlanningTag,


### PR DESCRIPTION
有用户反馈在react场景下，即使当前对话不需要进行工具，也会输出 action 标签，看起来是有问题，很可能是 trpc-agent-go 预置的 prompt 存在bug，  llm 模型配置为 deepseek3.2 。首先你需要结合 react 的原理，从第一性原理出发分析，并综合主流的 agent 框架实现判断这是否为bug，如果是bug的话，你需要修改example进行复现，如果复现成功则想办法修复这个问题，如果复现不成功则去分析可能出现的原因。  examples/react/main.go  run-test.sh