### PR TITLE
model/openai: restrict deepseek variant inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,9 @@ import (
 
 func main() {
     // Create model.
-    modelInstance := openai.New("deepseek-chat")
+    modelInstance := openai.New("deepseek-chat",
+        openai.WithVariant(openai.VariantDeepSeek),
+    )
 
     // Create tool.
     calculatorTool := function.NewFunctionTool(

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -264,7 +264,9 @@ import (
 
 func main() {
     // Create model.
-    modelInstance := openai.New("deepseek-chat")
+    modelInstance := openai.New("deepseek-chat",
+        openai.WithVariant(openai.VariantDeepSeek),
+    )
 
     // Create tool.
     calculatorTool := function.NewFunctionTool(

--- a/docs/mkdocs/en/model.md
+++ b/docs/mkdocs/en/model.md
@@ -1604,6 +1604,7 @@ The framework currently supports the following Variants:
 - DeepSeek platform adaptation
 - Default BaseURL：`https://api.deepseek.com`
 - API Key environment variable name：`DEEPSEEK_API_KEY`
+- DeepSeek-specific behavior is enabled when you explicitly set `WithVariant(openai.VariantDeepSeek)` or use the official DeepSeek API BaseURL
 - Other behaviors are consistent with standard OpenAI
 
 **4. VariantQwen（Qwen）**

--- a/docs/mkdocs/zh/model.md
+++ b/docs/mkdocs/zh/model.md
@@ -1592,6 +1592,7 @@ Variant 机制是 Model 模块的重要优化，用于处理不同 OpenAI 兼容
 - DeepSeek 平台适配
 - 默认 BaseURL：`https://api.deepseek.com`
 - API Key 环境变量名：`DEEPSEEK_API_KEY`
+- 显式设置 `WithVariant(openai.VariantDeepSeek)`，或使用官方 DeepSeek API BaseURL 时，才会启用 DeepSeek 特有行为
 - 其他行为与标准 OpenAI 一致
 
 **4. VariantQwen（千问）**

--- a/examples/model/switch/README.md
+++ b/examples/model/switch/README.md
@@ -1,153 +1,71 @@
 # Model Switching Example
 
-This example demonstrates two types of model switching using LLMAgent with the Runner:
+This example demonstrates two ways to switch models when using `LLMAgent` with the runner:
 
-1. **Agent-level switching** (`/switch`): Changes the agent's default model, affecting all subsequent requests.
-2. **Per-request switching** (`/model`): Overrides the model for a single request only using `agent.WithModelName()`, without affecting the agent's default.
+1. **Agent-level switching** via `/switch`: updates the agent's default model for all subsequent requests.
+2. **Per-request switching** via `/model`: overrides the model for one request only with `agent.WithModelName()`.
 
 ## Prerequisites
 
 - Go 1.21 or later
-- Valid OpenAI API key (or compatible API endpoint).
+- A valid API key for your OpenAI-compatible endpoint
 
-## Overview
+## Environment variables
 
-The example shows how to:
+The OpenAI SDK reads these automatically:
 
-1. Pre-register multiple models using `WithModels` when creating the agent.
-2. Specify an initial model with `WithModel`.
-3. **Agent-level switching**: Use `SetModelByName(modelName)` to change the agent's default model for all subsequent requests.
-4. **Per-request switching**: Use `agent.WithModelName()` as a RunOption to override the model for a single request only.
-5. Use the Runner to manage sessions and execute agent runs.
-6. Send user messages and print assistant responses.
+| Variable | Description | Default |
+| --- | --- | --- |
+| `OPENAI_API_KEY` | API key for the model service | none |
+| `OPENAI_BASE_URL` | Base URL for the model API endpoint | `https://api.openai.com/v1` |
 
-## Key Features
+If you want to talk to the official DeepSeek API, point `OPENAI_BASE_URL` at `https://api.deepseek.com/v1`.
 
-1. **Pre-registered Models**: Models are registered once with `WithModels` at agent creation.
-2. **Agent-level Switching**: Use `SetModelByName(modelName)` to change the agent's default model for all subsequent requests.
-3. **Per-request Switching**: Use `agent.WithModelName()` in RunOptions to override the model for a single request only.
-4. **Error Handling**: `SetModelByName` returns an error if the model name is not found.
-5. **Runner Integration**: Uses Runner for session management and agent execution.
-6. **Interactive Commands**: Use `/switch` for agent-level and `/model` for per-request switching.
-7. **Session Management**: Runner automatically manages session state and history.
-8. **Streaming Support**: Responses are streamed by default (controlled by the model).
+## Command-line arguments
 
-## Environment Variables
-
-The example supports the following environment variables (automatically read by the OpenAI SDK):
-
-| Variable          | Description                              | Default Value               |
-| ----------------- | ---------------------------------------- | --------------------------- |
-| `OPENAI_API_KEY`  | API key for the model service (required) | ``                          |
-| `OPENAI_BASE_URL` | Base URL for the model API endpoint      | `https://api.openai.com/v1` |
-
-Note: You do not need to read these variables in your own code; the SDK does it automatically when creating the client.
-
-## Command Line Arguments
-
-| Argument | Description          | Default Value   |
-| -------- | -------------------- | --------------- |
-| `-model` | Default model to use | `deepseek-chat` |
-| Argument | Description          | Default Value   |
-| -------- | -------------------- | --------------- |
+| Argument | Description | Default |
+| --- | --- | --- |
 | `-model` | Default model to use | `deepseek-chat` |
 
-## Running the Example
-
-### Using default values
+## Run the example
 
 ```bash
 cd examples/model/switch
 go run main.go
 ```
 
-### Using a custom default model
+With a different default model:
 
 ```bash
 cd examples/model/switch
 go run main.go -model deepseek-reasoner
-go run main.go -model deepseek-reasoner
 ```
 
-### With environment variables
+With environment variables:
 
 ```bash
 export OPENAI_API_KEY="your-api-key-here"
 export OPENAI_BASE_URL="https://api.deepseek.com/v1"
-export OPENAI_BASE_URL="https://api.deepseek.com/v1"
 
 cd examples/model/switch
-go run main.go -model deepseek-chat
 go run main.go -model deepseek-chat
 ```
 
 ## Commands
 
-- `/switch <model>`: **Agent-level switching** - Changes the agent's default model for all subsequent requests.
-- `/model <model>`: **Per-request switching** - Uses the specified model for the next request only (agent default unchanged).
-- `/new`: Starts a new session (clears session history).
-- `/exit`: Exits the program.
+- `/switch <model>`: change the agent's default model for all later requests
+- `/model <model>`: use a different model for the next request only
+- `/new`: start a new session
+- `/exit`: exit the program
 
-## Example Output
+## Package usage
 
-```text
-🚀 Model Switching Example
-Model: deepseek-chat
-Commands: /switch X, /model X, /new, /exit
-==================================================
-
-✅ Chat ready!
-
-💡 Special commands:
-   /switch <model>  - 🔄 Agent-level: change default model for all requests
-   /model <model>   - 🎯 Per-request: use model for next request only
-   /new             - 🆕 Start a new session
-   /exit            - 👋 End the conversation
-
-👤 You: What can you do?
-🤖 I can help answer questions, assist with writing, summarize content, and more.
-
-👤 You: /switch deepseek-reasoner
-✅ Agent-level switch: all requests will now use deepseek-reasoner
-👤 You: /switch deepseek-reasoner
-✅ Agent-level switch: all requests will now use deepseek-reasoner
-
-👤 You: Write a haiku about code.
-🤖 Silent lines compile
-   Logic flows like mountain streams
-   Bugs fade into dusk
-
-👤 You: /model deepseek-chat
-✅ Per-request mode: next request will use deepseek-chat (agent default unchanged)
-
-👤 You: What is 2+2?
-🔧 Per-request override: using model deepseek-chat for this request only
-🤖 The answer is 4.
-
-👤 You: What is the capital of France?
-🤖 The capital of France is Paris.
-(Note: This request uses deepseek-reasoner again, as the per-request override was only for one request)
-
-👤 You: /new
-🆕 New session started. Previous: session-1, Current: session-1730000000
-   (Session history has been cleared)
-
-👤 You: Hello again!
-🤖 Hello! How can I help you today?
-```
-
-## Package Usage
-
-Below is the core idea used in this example.
-
-### Agent-level Switching
-
-### Agent-level Switching
+### Agent-level switching
 
 ```go
 import (
     "context"
-    "trpc.group/trpc-go/trpc-agent-go/agent"
+
     "trpc.group/trpc-go/trpc-agent-go/agent"
     "trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
     "trpc.group/trpc-go/trpc-agent-go/model"
@@ -155,107 +73,51 @@ import (
     "trpc.group/trpc-go/trpc-agent-go/runner"
 )
 
-// Prepare models map.
-// Prepare models map.
-models := map[string]model.Model{
-    "deepseek-chat":     openai.New("deepseek-chat"),
-    "deepseek-reasoner": openai.New("deepseek-reasoner"),
-    "deepseek-chat":     openai.New("deepseek-chat"),
-    "deepseek-reasoner": openai.New("deepseek-reasoner"),
+func main() {
+    ctx := context.Background()
+
+    models := map[string]model.Model{
+        "deepseek-chat": openai.New(
+            "deepseek-chat",
+            openai.WithVariant(openai.VariantDeepSeek),
+        ),
+        "deepseek-reasoner": openai.New(
+            "deepseek-reasoner",
+            openai.WithVariant(openai.VariantDeepSeek),
+        ),
+    }
+
+    agt := llmagent.New(
+        "switching-agent",
+        llmagent.WithModels(models),
+        llmagent.WithModel(models["deepseek-chat"]),
+    )
+
+    r := runner.NewRunner("app-name", agt)
+    defer r.Close()
+
+    if err := agt.SetModelByName("deepseek-reasoner"); err != nil {
+        panic(err)
+    }
+
+    _, _ = r.Run(ctx, "user-1", "session-1", model.NewUserMessage("Hello"))
 }
-
-// Create agent with pre-registered models.
-// Create agent with pre-registered models.
-agt := llmagent.New("switching-agent",
-    llmagent.WithModels(models),
-    llmagent.WithModel(models["deepseek-chat"]),
-)
-    llmagent.WithModels(models),
-    llmagent.WithModel(models["deepseek-chat"]),
-)
-
-// Create runner.
-r := runner.NewRunner("app-name", agt)
-
-// Agent-level switching: affects all subsequent requests.
-err := agt.SetModelByName("deepseek-reasoner")
-if err != nil {
-    // Handle error: model not found.
-}
-
-// All subsequent requests will use deepseek-reasoner.
-events, _ := r.Run(ctx, userID, sessionID, model.NewUserMessage("Hello"))
 ```
 
-### Per-request Switching
+### Per-request switching
 
 ```go
-// Per-request switching: affects only one request.
-// Use agent.WithModelName() as a RunOption.
 events, err := r.Run(
     ctx,
     userID,
     sessionID,
     model.NewUserMessage("Hello"),
-    agent.WithModelName("deepseek-chat"), // Override for this request only.
+    agent.WithModelName("deepseek-chat"),
 )
+if err != nil {
+    // Handle error.
+}
 
-// This request uses deepseek-chat, but agent's default remains deepseek-reasoner.
-
-// Next request without override will use agent's default (deepseek-reasoner).
-events2, _ := r.Run(ctx, userID, sessionID, model.NewUserMessage("Next message"))
+// The next request without override will use the agent's default model again.
+_ = events
 ```
-
-## Comparison: Agent-level vs Per-request Switching
-
-| Feature                  | Agent-level (`/switch`)    | Per-request (`/model`)                    |
-| ------------------------ | -------------------------- | ----------------------------------------- |
-| Scope                    | All subsequent requests    | Single request only                       |
-| Affects other requests   | Yes                        | No                                        |
-| Agent state modification | Yes (via `SetModelByName`) | No                                        |
-| API                      | `SetModelByName(name)`     | `agent.WithModelName(name)` in RunOptions |
-| Use case                 | Global model switching     | Dynamic per-request routing               |
-| Thread-safe              | Yes (with mutex)           | Yes                                       |
-| Command                  | `/switch <model>`          | `/model <model>`                          |
-| Runner integration       | Direct agent method        | RunOption passed to `runner.Run()`        |
-
-## Important Notes
-
-- **Pre-registration Required**: Models must be registered with `WithModels` before they can be used.
-- **Error Handling**: `SetModelByName` returns an error if the model name is not found.
-- **Per-request Fallback**: If `ModelName` is not found in registered models, falls back to agent's default model.
-- **Runner Required**: This example uses the Runner for proper session management.
-- **Model Names**: Switching is based on exact model names (case-sensitive).
-- **Streaming**: Responses are streamed by default (handled by the OpenAI model).
-- **Telemetry**: Runner automatically handles session tracking and telemetry.
-
-## Security Notes
-
-- Never commit API keys to version control.
-- Use environment variables or a secure configuration system.
-
-## Use Cases
-
-### Agent-level Switching (`/switch`)
-
-- Change the default model for all users/sessions.
-- Switch to a different model tier (e.g., from chat to reasoner).
-- Global configuration changes.
-
-### Per-request Switching (`/model`)
-
-- **Cost Optimization**: Use cheaper models for simple queries, expensive models for complex tasks.
-- **Performance Tuning**: Switch to faster models for latency-sensitive requests.
-- **A/B Testing**: Compare different models' responses for the same query.
-- **User Preferences**: Allow users to select their preferred model per request.
-- **Dynamic Routing**: Route requests to different models based on content complexity.
-
-## Benefits
-
-1. **Simplicity**: Minimal code focused on switching models by name.
-2. **Flexibility**: Two switching modes for different use cases.
-3. **Type Safety**: Error handling ensures you only switch to registered models.
-4. **Maintainability**: No need to maintain model instances externally—just remember names.
-5. **Isolation**: Per-request switching doesn't affect other concurrent requests.
-6. **Runner Integration**: Automatic session management and history tracking.
-7. **Separation of Concerns**: Agent handles LLM logic; Runner handles sessions; example handles I/O and switching.

--- a/examples/model/switch/main.go
+++ b/examples/model/switch/main.go
@@ -104,8 +104,14 @@ func (a *chatApp) setup(_ context.Context) error {
 	// Prepare model map with pre-registered models.
 	// Pre-registration is required for name-based model switching.
 	models := map[string]model.Model{
-		"deepseek-chat":     openai.New("deepseek-chat"),
-		"deepseek-reasoner": openai.New("deepseek-reasoner"),
+		"deepseek-chat": openai.New(
+			"deepseek-chat",
+			openai.WithVariant(openai.VariantDeepSeek),
+		),
+		"deepseek-reasoner": openai.New(
+			"deepseek-reasoner",
+			openai.WithVariant(openai.VariantDeepSeek),
+		),
 	}
 
 	// Get the default model instance.

--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -45,11 +45,9 @@ const (
 	// defaultBatchEndpoint is the default batch endpoint.
 	defaultBatchEndpoint = openai.BatchNewParamsEndpointV1ChatCompletions
 	//nolint:gosec
-	deepSeekAPIKeyName        string = "DEEPSEEK_API_KEY"
-	defaultDeepSeekBaseURL    string = "https://api.deepseek.com"
-	deepSeekHostFragment      string = "deepseek.com"
-	deepSeekChatModelName     string = "deepseek-chat"
-	deepSeekReasonerModelName string = "deepseek-reasoner"
+	deepSeekAPIKeyName     string = "DEEPSEEK_API_KEY"
+	defaultDeepSeekBaseURL string = "https://api.deepseek.com"
+	deepSeekAPIHost        string = "api.deepseek.com"
 
 	//nolint:gosec
 	qwenAPIKeyName     string = "DASHSCOPE_API_KEY"
@@ -259,7 +257,7 @@ func New(name string, opts ...Option) *Model {
 		opt(&o)
 	}
 	if !o.variantSet {
-		o.Variant = inferVariant(name, o.BaseURL)
+		o.Variant = inferVariant(o.BaseURL)
 	}
 
 	cfg, cfgOK := variantConfigs[o.Variant]
@@ -329,21 +327,11 @@ func New(name string, opts ...Option) *Model {
 	}
 }
 
-func inferVariant(name string, baseURL string) Variant {
-	if isDeepSeekModelName(name) || isDeepSeekBaseURL(baseURL) {
+func inferVariant(baseURL string) Variant {
+	if isDeepSeekBaseURL(baseURL) {
 		return VariantDeepSeek
 	}
 	return VariantOpenAI
-}
-
-func isDeepSeekModelName(name string) bool {
-	normalized := strings.ToLower(strings.TrimSpace(name))
-	switch normalized {
-	case deepSeekChatModelName, deepSeekReasonerModelName:
-		return true
-	default:
-		return false
-	}
 }
 
 func isDeepSeekBaseURL(raw string) bool {
@@ -353,10 +341,9 @@ func isDeepSeekBaseURL(raw string) bool {
 	}
 	parsed, err := url.Parse(trimmed)
 	if err != nil {
-		return strings.Contains(strings.ToLower(trimmed), deepSeekHostFragment)
+		return false
 	}
-	host := strings.ToLower(parsed.Hostname())
-	return strings.Contains(host, deepSeekHostFragment)
+	return strings.EqualFold(parsed.Hostname(), deepSeekAPIHost)
 }
 
 // Info implements the model.Model interface.

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -86,24 +86,20 @@ func TestNew(t *testing.T) {
 			},
 		},
 		{
-			name:      "infer deepseek from model name",
+			name:      "does not infer deepseek from official model name",
 			modelName: "deepseek-chat",
-			opts:      nil,
-			expectOpts: []Option{
+			opts: []Option{
 				WithAPIKey(testKey),
-				WithBaseURL(defaultDeepSeekBaseURL),
-				WithVariant(VariantDeepSeek),
 			},
+			expectOpts: nil,
 		},
 		{
-			name:      "infer deepseek reasoner from model name",
+			name:      "does not infer deepseek from reasoner model name",
 			modelName: "deepseek-reasoner",
-			opts:      nil,
-			expectOpts: []Option{
+			opts: []Option{
 				WithAPIKey(testKey),
-				WithBaseURL(defaultDeepSeekBaseURL),
-				WithVariant(VariantDeepSeek),
 			},
+			expectOpts: nil,
 		},
 		{
 			name:      "does not infer deepseek from third party deepseek model name",
@@ -114,7 +110,7 @@ func TestNew(t *testing.T) {
 			expectOpts: nil,
 		},
 		{
-			name:      "infer deepseek from base url",
+			name:      "infers deepseek from official deepseek base url",
 			modelName: "custom-model",
 			opts: []Option{
 				WithBaseURL("https://api.deepseek.com/v1"),
@@ -126,12 +122,41 @@ func TestNew(t *testing.T) {
 			},
 		},
 		{
-			name:      "explicit variant beats deepseek inference",
+			name:      "explicit variant sets deepseek on official model name",
 			modelName: "deepseek-chat",
 			opts: []Option{
-				WithVariant(VariantOpenAI),
+				WithVariant(VariantDeepSeek),
 			},
-			expectOpts: nil,
+			expectOpts: []Option{
+				WithAPIKey(testKey),
+				WithBaseURL(defaultDeepSeekBaseURL),
+			},
+		},
+		{
+			name:      "explicit deepseek variant preserves custom proxy base url",
+			modelName: "deepseek-chat",
+			opts: []Option{
+				WithVariant(VariantDeepSeek),
+				WithBaseURL("https://proxy.example.com/v1"),
+			},
+			expectOpts: []Option{
+				WithAPIKey(testKey),
+				WithBaseURL("https://proxy.example.com/v1"),
+				WithVariant(VariantDeepSeek),
+			},
+		},
+		{
+			name:      "custom proxy base url before explicit deepseek variant is preserved",
+			modelName: "deepseek-chat",
+			opts: []Option{
+				WithBaseURL("https://proxy.example.com/v1"),
+				WithVariant(VariantDeepSeek),
+			},
+			expectOpts: []Option{
+				WithAPIKey(testKey),
+				WithBaseURL("https://proxy.example.com/v1"),
+				WithVariant(VariantDeepSeek),
+			},
 		},
 	}
 
@@ -156,122 +181,35 @@ func TestNew(t *testing.T) {
 	}
 }
 
-func TestIsDeepSeekModelName(t *testing.T) {
-	tests := []struct {
-		name      string
-		modelName string
-		want      bool
-	}{
-		{
-			name:      "matches chat model",
-			modelName: "deepseek-chat",
-			want:      true,
-		},
-		{
-			name:      "matches reasoner model",
-			modelName: "deepseek-reasoner",
-			want:      true,
-		},
-		{
-			name:      "matches after trim and lowercase",
-			modelName: " DEEPSEEK-CHAT ",
-			want:      true,
-		},
-		{
-			name:      "does not match third party deepseek model name",
-			modelName: "deepseek-v3.2",
-			want:      false,
-		},
-		{
-			name:      "does not match other providers",
-			modelName: "gpt-4o-mini",
-			want:      false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, isDeepSeekModelName(tt.modelName))
-		})
-	}
-}
-
-func TestInferVariant(t *testing.T) {
-	tests := []struct {
-		name    string
-		model   string
-		baseURL string
-		variant Variant
-	}{
-		{
-			name:    "deepseek family model with custom base url stays openai",
-			model:   "deepseek-v3.2",
-			baseURL: "https://api.custom.com/v1",
-			variant: VariantOpenAI,
-		},
-		{
-			name:    "deepseek family model without base url stays openai",
-			model:   "deepseek-v3.2",
-			variant: VariantOpenAI,
-		},
-		{
-			name:    "deepseek official model with custom base url still infers deepseek",
-			model:   "deepseek-chat",
-			baseURL: "https://api.custom.com/v1",
-			variant: VariantDeepSeek,
-		},
-		{
-			name:    "deepseek official host infers deepseek",
-			model:   "custom-model",
-			baseURL: "https://api.deepseek.com/v1",
-			variant: VariantDeepSeek,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.variant, inferVariant(tt.model, tt.baseURL))
-		})
-	}
-}
-
 func TestIsDeepSeekBaseURL(t *testing.T) {
-	const (
-		deepSeekURL        = "https://api.deepseek.com/v1"
-		upperDeepSeekURL   = " HTTPS://API.DEEPSEEK.COM/V1 "
-		invalidDeepSeekURL = "https://api.deepseek.com/%zz"
-		openAIURL          = "https://api.openai.com/v1"
-		emptyURL           = "   "
-	)
-
 	tests := []struct {
 		name   string
 		rawURL string
 		want   bool
 	}{
 		{
-			name:   "matches deepseek host",
-			rawURL: deepSeekURL,
+			name:   "matches official api host",
+			rawURL: "https://api.deepseek.com/v1",
 			want:   true,
 		},
 		{
-			name:   "matches deepseek host after trim and lowercase",
-			rawURL: upperDeepSeekURL,
+			name:   "matches official api host after trim and lowercase",
+			rawURL: " HTTPS://API.DEEPSEEK.COM/V1 ",
 			want:   true,
 		},
 		{
-			name:   "falls back to substring match on parse error",
-			rawURL: invalidDeepSeekURL,
-			want:   true,
-		},
-		{
-			name:   "does not match other hosts",
-			rawURL: openAIURL,
+			name:   "does not match non api deepseek host",
+			rawURL: "https://deepseek.com/v1",
 			want:   false,
 		},
 		{
-			name:   "empty url is not deepseek",
-			rawURL: emptyURL,
+			name:   "does not match custom proxy host",
+			rawURL: "https://deepseek-proxy.internal/v1",
+			want:   false,
+		},
+		{
+			name:   "parse error does not fall back to substring match",
+			rawURL: "https://api.deepseek.com/%zz",
 			want:   false,
 		},
 	}
@@ -4106,7 +4044,7 @@ func TestConvertUserMessageContent_HunyuanVariant(t *testing.T) {
 }
 
 func TestConvertUserMessageContent_DeepSeekVariant(t *testing.T) {
-	m := New("deepseek-chat")
+	m := New("deepseek-chat", WithVariant(VariantDeepSeek))
 
 	t.Run("omits non-text content parts", func(t *testing.T) {
 		message := model.Message{
@@ -5266,7 +5204,7 @@ func TestModel_buildChatRequest(t *testing.T) {
 		},
 		{
 			name:  "deepseek thinking",
-			model: New("deepseek-chat"),
+			model: New("deepseek-chat", WithVariant(VariantDeepSeek)),
 			args: args{
 				request: &model.Request{
 					Messages: []model.Message{},
@@ -5277,7 +5215,7 @@ func TestModel_buildChatRequest(t *testing.T) {
 				},
 			},
 			want1: []openaiopt.RequestOption{
-				openaiopt.WithJSONSet(model.ThinkingEnabledKey, true),
+				openaiopt.WithJSONSet("thinking", map[string]string{"type": "enabled"}),
 			},
 		},
 		{


### PR DESCRIPTION
## Summary
- restrict automatic DeepSeek variant inference to the official DeepSeek API base URL
- keep non-official OpenAI-compatible endpoints on the generic OpenAI-like path unless callers explicitly set `WithVariant(openai.VariantDeepSeek)`
- update tests and docs, and add explicit DeepSeek variant configuration in README and the model switching example

## Testing
- go test ./model/openai -count=1
- go test ./model/... -count=1
