### PR TITLE
evaluation: add optional run details to evaluation results

### DIFF
--- a/evaluation/evaluation.go
+++ b/evaluation/evaluation.go
@@ -14,11 +14,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"sort"
+	"sync"
 	"time"
 
 	"golang.org/x/sync/errgroup"
 	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/trace"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/registry"
@@ -64,6 +67,7 @@ func New(appName string, runner runner.Runner, opt ...Option) (AgentEvaluator, e
 		callbacks:                         opts.callbacks,
 		numRuns:                           opts.numRuns,
 		numRunsParallelEnabled:            opts.numRunsParallelEnabled,
+		runDetailsEnabled:                 opts.runDetailsEnabled,
 		runOptions:                        opts.runOptions,
 		evalCaseParallelism:               opts.evalCaseParallelism,
 		evalCaseParallelInferenceEnabled:  opts.evalCaseParallelInferenceEnabled,
@@ -114,6 +118,7 @@ type agentEvaluator struct {
 	callbacks                         *service.Callbacks
 	numRuns                           int
 	numRunsParallelEnabled            *bool
+	runDetailsEnabled                 bool
 	runOptions                        []agent.RunOption
 	evalCaseParallelism               *int
 	evalCaseParallelInferenceEnabled  *bool
@@ -132,10 +137,32 @@ type EvaluationResult struct {
 
 // EvaluationCaseResult aggregates the outcome of a single eval case across multiple runs.
 type EvaluationCaseResult struct {
-	EvalCaseID      string                         `json:"evalId"`          // EvalCaseID identifies the evaluation case.
-	OverallStatus   status.EvalStatus              `json:"overallStatus"`   // OverallStatus summarizes the overall status of case across runs.
-	EvalCaseResults []*evalresult.EvalCaseResult   `json:"evalCaseResults"` // EvalCaseResults stores the per-run results for this case.
-	MetricResults   []*evalresult.EvalMetricResult `json:"metricResults"`   // MetricResults lists aggregated metric outcomes across runs.
+	EvalCaseID      string                         `json:"evalId"`               // EvalCaseID identifies the evaluation case.
+	OverallStatus   status.EvalStatus              `json:"overallStatus"`        // OverallStatus summarizes the overall status of case across runs.
+	EvalCaseResults []*evalresult.EvalCaseResult   `json:"evalCaseResults"`      // EvalCaseResults stores the per-run results for this case.
+	MetricResults   []*evalresult.EvalMetricResult `json:"metricResults"`        // MetricResults lists aggregated metric outcomes across runs.
+	RunDetails      []*EvaluationCaseRunDetails    `json:"runDetails,omitempty"` // RunDetails stores optional per-run inference details for this case.
+}
+
+// EvaluationCaseRunDetails contains caller-facing details for a single run of an eval case.
+type EvaluationCaseRunDetails struct {
+	RunID     int                         `json:"runId,omitempty"`     // RunID identifies the evaluation run.
+	Inference *EvaluationInferenceDetails `json:"inference,omitempty"` // Inference stores the inference details captured during this run.
+}
+
+// EvaluationInferenceDetails contains caller-facing inference details for a single eval case run.
+type EvaluationInferenceDetails struct {
+	SessionID       string                `json:"sessionId,omitempty"`       // SessionID identifies the inference session used for this run.
+	UserID          string                `json:"userId,omitempty"`          // UserID identifies the user used for this run.
+	Status          status.EvalStatus     `json:"status,omitempty"`          // Status records the inference status for this run.
+	ErrorMessage    string                `json:"errorMessage,omitempty"`    // ErrorMessage records the inference failure message when present.
+	Inferences      []*evalset.Invocation `json:"inferences,omitempty"`      // Inferences stores the invocation outputs captured during this run.
+	ExecutionTraces []*trace.Trace        `json:"executionTraces,omitempty"` // ExecutionTraces stores the execution traces captured during this run.
+}
+
+type runDetailsCollector struct {
+	mu       sync.Mutex
+	byCaseID map[string]map[int]*EvaluationCaseRunDetails
 }
 
 // Evaluate evaluates agent against the specified eval set across multiple runs.
@@ -180,6 +207,7 @@ func (a *agentEvaluator) mergeCallOptions(opt ...Option) (*options, error) {
 		callbacks:                         a.callbacks,
 		numRuns:                           a.numRuns,
 		numRunsParallelEnabled:            a.numRunsParallelEnabled,
+		runDetailsEnabled:                 a.runDetailsEnabled,
 		runOptions:                        append([]agent.RunOption(nil), a.runOptions...),
 		evalCaseParallelism:               a.evalCaseParallelism,
 		evalCaseParallelInferenceEnabled:  a.evalCaseParallelInferenceEnabled,
@@ -237,6 +265,9 @@ func (a *agentEvaluator) collectCaseResults(ctx context.Context, evalSetID strin
 	// case results. So EvalCaseResults need to be grouped by case ID.
 	// caseResultsByID is a map from case ID to a list of eval case results.
 	caseResultsByID := make(map[string][]*evalresult.EvalCaseResult)
+	if opts.runDetailsEnabled {
+		opts.runDetailsCollector = newRunDetailsCollector()
+	}
 	// Run evaluation on the specified eval set across multiple inference runs.
 	evalSetResult, err := a.runEvaluation(ctx, evalSetID, opts)
 	if err != nil {
@@ -252,6 +283,9 @@ func (a *agentEvaluator) collectCaseResults(ctx context.Context, evalSetID strin
 		evalCaseResult, err := aggregateCaseRuns(caseID, runs)
 		if err != nil {
 			return nil, nil, fmt.Errorf("aggregate case runs: %w", err)
+		}
+		if opts.runDetailsEnabled {
+			evalCaseResult.RunDetails = collectRunDetails(runs, opts.runDetailsCollector.caseRunDetails(caseID))
 		}
 		evalCaseResults = append(evalCaseResults, evalCaseResult)
 	}
@@ -396,6 +430,9 @@ func (a *agentEvaluator) runEvaluationOnce(
 	if err != nil {
 		return nil, fmt.Errorf("run %d inference: %w", runID, err)
 	}
+	if opts.runDetailsCollector != nil {
+		opts.runDetailsCollector.add(runID, runInferenceResults)
+	}
 	evaluateRequest := &service.EvaluateRequest{
 		AppName:          a.appName,
 		EvalSetID:        evalSetID,
@@ -496,6 +533,82 @@ func aggregateCaseRuns(caseID string, runs []*evalresult.EvalCaseResult) (*Evalu
 		EvalCaseResults: runs,
 		MetricResults:   metricResults,
 	}, nil
+}
+
+func collectRunDetails(runs []*evalresult.EvalCaseResult, runDetailsByID map[int]*EvaluationCaseRunDetails) []*EvaluationCaseRunDetails {
+	if len(runDetailsByID) == 0 {
+		return nil
+	}
+	runDetails := make([]*EvaluationCaseRunDetails, 0, len(runs))
+	for _, run := range runs {
+		if run == nil {
+			continue
+		}
+		runDetail, ok := runDetailsByID[run.RunID]
+		if !ok {
+			continue
+		}
+		runDetails = append(runDetails, runDetail)
+	}
+	if len(runDetails) == 0 {
+		return nil
+	}
+	return runDetails
+}
+
+func newEvaluationInferenceDetails(inferenceResult *service.InferenceResult) *EvaluationInferenceDetails {
+	if inferenceResult == nil {
+		return nil
+	}
+	return &EvaluationInferenceDetails{
+		SessionID:       inferenceResult.SessionID,
+		UserID:          inferenceResult.UserID,
+		Status:          inferenceResult.Status,
+		ErrorMessage:    inferenceResult.ErrorMessage,
+		Inferences:      append([]*evalset.Invocation(nil), inferenceResult.Inferences...),
+		ExecutionTraces: append([]*trace.Trace(nil), inferenceResult.ExecutionTraces...),
+	}
+}
+
+func newRunDetailsCollector() *runDetailsCollector {
+	return &runDetailsCollector{
+		byCaseID: make(map[string]map[int]*EvaluationCaseRunDetails),
+	}
+}
+
+func (c *runDetailsCollector) add(runID int, inferenceResults []*service.InferenceResult) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, inferenceResult := range inferenceResults {
+		if inferenceResult == nil || inferenceResult.EvalCaseID == "" {
+			continue
+		}
+		if _, ok := c.byCaseID[inferenceResult.EvalCaseID]; !ok {
+			c.byCaseID[inferenceResult.EvalCaseID] = make(map[int]*EvaluationCaseRunDetails)
+		}
+		c.byCaseID[inferenceResult.EvalCaseID][runID] = &EvaluationCaseRunDetails{
+			RunID:     runID,
+			Inference: newEvaluationInferenceDetails(inferenceResult),
+		}
+	}
+}
+
+func (c *runDetailsCollector) caseRunDetails(caseID string) map[int]*EvaluationCaseRunDetails {
+	if c == nil || caseID == "" {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	runDetailsByID, ok := c.byCaseID[caseID]
+	if !ok {
+		return nil
+	}
+	result := make(map[int]*EvaluationCaseRunDetails, len(runDetailsByID))
+	maps.Copy(result, runDetailsByID)
+	return result
 }
 
 // summarizeOverallStatus summarizes the aggregate status across all cases in the evaluation.

--- a/evaluation/evaluation_test.go
+++ b/evaluation/evaluation_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"trpc.group/trpc-go/trpc-agent-go/agent"
+	agenttrace "trpc.group/trpc-go/trpc-agent-go/agent/trace"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
 	evalresultinmemory "trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult/inmemory"
 	evalresultlocal "trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult/local"
@@ -356,6 +357,7 @@ func defaultTestOptions(ae *agentEvaluator) *options {
 		judgeRunner:            ae.judgeRunner,
 		numRuns:                ae.numRuns,
 		numRunsParallelEnabled: ae.numRunsParallelEnabled,
+		runDetailsEnabled:      ae.runDetailsEnabled,
 		runOptions:             append([]agent.RunOption(nil), ae.runOptions...),
 	}
 }
@@ -1083,6 +1085,7 @@ func TestAgentEvaluatorEvaluateSuccess(t *testing.T) {
 	assert.Len(t, caseResult.MetricResults, 1)
 	assert.InDelta(t, 1.0, caseResult.MetricResults[0].Score, 0.001)
 	assert.Len(t, caseResult.EvalCaseResults, 2)
+	assert.Nil(t, caseResult.RunDetails)
 
 	assert.Len(t, svc.inferenceRequests, 2)
 	assert.Len(t, svc.evaluateRequests, 2)
@@ -1094,6 +1097,114 @@ func TestAgentEvaluatorEvaluateSuccess(t *testing.T) {
 		if req.EvaluateConfig != nil {
 			assert.Len(t, req.EvaluateConfig.EvalMetrics, 1)
 			assert.Equal(t, metricName, req.EvaluateConfig.EvalMetrics[0].MetricName)
+		}
+	}
+}
+
+func TestAgentEvaluatorEvaluateIncludesRunDetailsWhenEnabled(t *testing.T) {
+	ctx := context.Background()
+	appName := "app"
+	evalSetID := "set"
+	caseID := "case-1"
+	metricName := "metric"
+	metricMgr := metricinmemory.New()
+	err := metricMgr.Add(ctx, appName, evalSetID, &metric.EvalMetric{MetricName: metricName, Threshold: 1})
+	assert.NoError(t, err)
+	evalSetMgr := evalsetinmemory.New()
+	_, err = evalSetMgr.Create(ctx, appName, evalSetID)
+	assert.NoError(t, err)
+	runOneTrace := &agenttrace.Trace{RootInvocationID: "root-1", SessionID: "session-1", Status: agenttrace.TraceStatusCompleted}
+	runTwoTrace := &agenttrace.Trace{RootInvocationID: "root-2", SessionID: "session-2", Status: agenttrace.TraceStatusCompleted}
+	svc := &fakeService{
+		inferenceResults: [][]*service.InferenceResult{
+			{{
+				AppName:         appName,
+				EvalSetID:       evalSetID,
+				EvalCaseID:      caseID,
+				Inferences:      []*evalset.Invocation{{InvocationID: "inv-1"}},
+				SessionID:       "session-1",
+				UserID:          "user-1",
+				Status:          status.EvalStatusPassed,
+				ExecutionTraces: []*agenttrace.Trace{runOneTrace},
+			}},
+			{{
+				AppName:         appName,
+				EvalSetID:       evalSetID,
+				EvalCaseID:      caseID,
+				Inferences:      []*evalset.Invocation{{InvocationID: "inv-2"}},
+				SessionID:       "session-2",
+				UserID:          "user-2",
+				Status:          status.EvalStatusPassed,
+				ExecutionTraces: []*agenttrace.Trace{runTwoTrace},
+			}},
+		},
+		evaluateResults: []*service.EvalSetRunResult{
+			{
+				AppName:   appName,
+				EvalSetID: evalSetID,
+				EvalCaseResults: []*evalresult.EvalCaseResult{
+					makeEvalCaseResult(evalSetID, caseID, metricName, 0.5, 1, status.EvalStatusFailed),
+				},
+			},
+			{
+				AppName:   appName,
+				EvalSetID: evalSetID,
+				EvalCaseResults: []*evalresult.EvalCaseResult{
+					makeEvalCaseResult(evalSetID, caseID, metricName, 1.5, 1, status.EvalStatusPassed),
+				},
+			},
+		},
+	}
+	ae, err := New(
+		appName,
+		stubRunner{},
+		WithMetricManager(metricMgr),
+		WithEvalSetManager(evalSetMgr),
+		WithRegistry(registry.New()),
+		WithEvaluationService(svc),
+		WithNumRuns(2),
+	)
+	assert.NoError(t, err)
+	if err != nil {
+		return
+	}
+	defer func() {
+		assert.NoError(t, ae.Close())
+	}()
+	evaluationResult, err := ae.Evaluate(ctx, evalSetID, WithRunDetailsEnabled(true))
+	assert.NoError(t, err)
+	if !assert.Len(t, evaluationResult.EvalCases, 1) {
+		return
+	}
+	caseResult := evaluationResult.EvalCases[0]
+	if !assert.Len(t, caseResult.RunDetails, 2) {
+		return
+	}
+	assert.Equal(t, 1, caseResult.RunDetails[0].RunID)
+	assert.Equal(t, 1, caseResult.EvalCaseResults[0].RunID)
+	if assert.NotNil(t, caseResult.RunDetails[0].Inference) {
+		assert.Equal(t, "session-1", caseResult.RunDetails[0].Inference.SessionID)
+		assert.Equal(t, "user-1", caseResult.RunDetails[0].Inference.UserID)
+		assert.Equal(t, status.EvalStatusPassed, caseResult.RunDetails[0].Inference.Status)
+		if assert.Len(t, caseResult.RunDetails[0].Inference.Inferences, 1) {
+			assert.Equal(t, "inv-1", caseResult.RunDetails[0].Inference.Inferences[0].InvocationID)
+		}
+		if assert.Len(t, caseResult.RunDetails[0].Inference.ExecutionTraces, 1) {
+			assert.Equal(t, "root-1", caseResult.RunDetails[0].Inference.ExecutionTraces[0].RootInvocationID)
+			assert.Equal(t, "session-1", caseResult.RunDetails[0].Inference.ExecutionTraces[0].SessionID)
+		}
+	}
+	assert.Equal(t, 2, caseResult.RunDetails[1].RunID)
+	assert.Equal(t, 2, caseResult.EvalCaseResults[1].RunID)
+	if assert.NotNil(t, caseResult.RunDetails[1].Inference) {
+		assert.Equal(t, "session-2", caseResult.RunDetails[1].Inference.SessionID)
+		assert.Equal(t, "user-2", caseResult.RunDetails[1].Inference.UserID)
+		if assert.Len(t, caseResult.RunDetails[1].Inference.Inferences, 1) {
+			assert.Equal(t, "inv-2", caseResult.RunDetails[1].Inference.Inferences[0].InvocationID)
+		}
+		if assert.Len(t, caseResult.RunDetails[1].Inference.ExecutionTraces, 1) {
+			assert.Equal(t, "root-2", caseResult.RunDetails[1].Inference.ExecutionTraces[0].RootInvocationID)
+			assert.Equal(t, "session-2", caseResult.RunDetails[1].Inference.ExecutionTraces[0].SessionID)
 		}
 	}
 }

--- a/evaluation/options.go
+++ b/evaluation/options.go
@@ -44,6 +44,8 @@ type options struct {
 	evalCaseParallelism               *int
 	evalCaseParallelInferenceEnabled  *bool
 	evalCaseParallelEvaluationEnabled *bool
+	runDetailsEnabled                 bool
+	runDetailsCollector               *runDetailsCollector
 	runOptions                        []agent.RunOption
 }
 
@@ -163,6 +165,13 @@ func WithEvalCaseParallelInferenceEnabled(enabled bool) Option {
 func WithEvalCaseParallelEvaluationEnabled(enabled bool) Option {
 	return func(o *options) {
 		o.evalCaseParallelEvaluationEnabled = &enabled
+	}
+}
+
+// WithRunDetailsEnabled enables or disables per-run inference details in evaluation results.
+func WithRunDetailsEnabled(enabled bool) Option {
+	return func(o *options) {
+		o.runDetailsEnabled = enabled
 	}
 }
 

--- a/evaluation/options_test.go
+++ b/evaluation/options_test.go
@@ -51,6 +51,7 @@ func TestNewOptionsDefaults(t *testing.T) {
 	assert.Nil(t, opts.evalCaseParallelism)
 	assert.Nil(t, opts.evalCaseParallelInferenceEnabled)
 	assert.Nil(t, opts.evalCaseParallelEvaluationEnabled)
+	assert.False(t, opts.runDetailsEnabled)
 }
 
 func TestWithEvalSetManager(t *testing.T) {
@@ -153,6 +154,11 @@ func TestWithEvalCaseParallelEvaluationEnabled(t *testing.T) {
 		return
 	}
 	assert.True(t, *opts.evalCaseParallelEvaluationEnabled)
+}
+
+func TestWithRunDetailsEnabled(t *testing.T) {
+	opts := newOptions(WithRunDetailsEnabled(true))
+	assert.True(t, opts.runDetailsEnabled)
 }
 
 func TestOptionsValidateRejectsNilOptions(t *testing.T) {


### PR DESCRIPTION
This change adds an optional RunDetails field to EvaluationCaseResult so callers can retrieve per-run inference details, including execution traces, without changing the existing Evaluate API or touching persisted evalresult models. The new data is gated behind WithRunDetailsEnabled to preserve current behavior by default and keeps the returned structure aligned with existing per-run case results.