### PR TITLE
openclaw: normalize wecom cron delivery targets

### DIFF
--- a/openclaw/internal/cron/tool_test.go
+++ b/openclaw/internal/cron/tool_test.go
@@ -112,6 +112,87 @@ func TestToolAddSupportsExecutionPolicyAndHeadless(t *testing.T) {
 	require.Empty(t, job.Delivery.Target)
 }
 
+func TestToolAddNormalizesExplicitWeComTarget(t *testing.T) {
+	t.Parallel()
+
+	svc, err := NewService(
+		t.TempDir(),
+		&stubRunner{reply: "ok"},
+		outbound.NewRouter(),
+	)
+	require.NoError(t, err)
+
+	tool := NewTool(svc)
+	ctx := agent.NewInvocationContext(
+		context.Background(),
+		&agent.Invocation{
+			Session: &session.Session{
+				ID:     "stdin:session",
+				UserID: "user-1",
+			},
+		},
+	)
+
+	args, err := json.Marshal(map[string]any{
+		"action":        "add",
+		"message":       "share good news",
+		"schedule_kind": "every",
+		"every":         "10s",
+		"channel":       "wecom",
+		"target":        "wecom:thread:wecom:chat:chat-1",
+	})
+	require.NoError(t, err)
+
+	result, err := tool.Call(ctx, args)
+	require.NoError(t, err)
+
+	job, ok := result.(*Job)
+	require.True(t, ok)
+	require.Equal(t, outbound.DeliveryTarget{
+		Channel: "wecom",
+		Target:  "group:chat-1",
+	}, job.Delivery)
+}
+
+func TestToolAddRejectsInvalidExplicitWeComTarget(t *testing.T) {
+	t.Parallel()
+
+	svc, err := NewService(
+		t.TempDir(),
+		&stubRunner{reply: "ok"},
+		outbound.NewRouter(),
+	)
+	require.NoError(t, err)
+
+	tool := NewTool(svc)
+	ctx := agent.NewInvocationContext(
+		context.Background(),
+		&agent.Invocation{
+			Session: &session.Session{
+				ID:     "stdin:session",
+				UserID: "user-1",
+			},
+		},
+	)
+
+	args, err := json.Marshal(map[string]any{
+		"action":        "add",
+		"message":       "share good news",
+		"schedule_kind": "every",
+		"every":         "10s",
+		"channel":       "wecom",
+		"target":        "wecom:thread:unknown",
+	})
+	require.NoError(t, err)
+
+	_, err = tool.Call(ctx, args)
+	require.ErrorContains(
+		t,
+		err,
+		"outbound: invalid target for wecom",
+	)
+}
+
 func TestToolAddFailsWithoutResolvableDeliveryTarget(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/internal/outbound/resolve.go
+++ b/openclaw/internal/outbound/resolve.go
@@ -21,6 +21,17 @@ import (
 const (
 	runtimeStateDeliveryChannel = "openclaw.delivery.channel"
 	runtimeStateDeliveryTarget  = "openclaw.delivery.target"
+
+	wecomChannelName = "wecom"
+
+	wecomThreadPrefix = wecomChannelName + ":thread:"
+	wecomChatPrefix   = wecomChannelName + ":chat:"
+	wecomDMPrefix     = wecomChannelName + ":dm:"
+
+	wecomScopedUserSeparator = ":user:"
+
+	wecomGroupTargetPrefix  = "group:"
+	wecomSingleTargetPrefix = "single:"
 )
 
 // ResolveTarget chooses an outbound target from explicit args, runtime
@@ -39,6 +50,9 @@ func ResolveTarget(
 		return DeliveryTarget{}, fmt.Errorf(
 			"outbound: unable to resolve target",
 		)
+	}
+	if err := validateTarget(target); err != nil {
+		return DeliveryTarget{}, err
 	}
 	return target, nil
 }
@@ -62,10 +76,13 @@ func sanitizeTarget(target DeliveryTarget) DeliveryTarget {
 }
 
 func fillTargetFromOpaqueValue(target DeliveryTarget) DeliveryTarget {
-	if target.Channel != "" || target.Target == "" {
+	if target.Target == "" {
 		return target
 	}
-	if resolved, ok := resolveFromOpaqueTarget(target.Target); ok {
+	if resolved, ok := resolveTargetValue(
+		target.Channel,
+		target.Target,
+	); ok {
 		return resolved
 	}
 	return target
@@ -129,15 +146,154 @@ func ResolveTargetFromSessionID(sessionID string) (DeliveryTarget, bool) {
 			Target:  target,
 		}, true
 	}
-	return DeliveryTarget{}, false
-}
-
-func resolveFromOpaqueTarget(value string) (DeliveryTarget, bool) {
-	if target, ok := telegram.ResolveTextTargetFromSessionID(value); ok {
+	if target, ok := normalizeWeComTarget(sessionID); ok {
 		return DeliveryTarget{
-			Channel: telegram.ChannelName,
+			Channel: wecomChannelName,
 			Target:  target,
 		}, true
 	}
 	return DeliveryTarget{}, false
+}
+
+func resolveFromOpaqueTarget(value string) (DeliveryTarget, bool) {
+	return resolveTargetValue("", value)
+}
+
+func resolveTargetValue(
+	channelID string,
+	value string,
+) (DeliveryTarget, bool) {
+	if target, ok := resolveTelegramTargetValue(
+		channelID,
+		value,
+	); ok {
+		return target, true
+	}
+	if target, ok := resolveWeComTargetValue(
+		channelID,
+		value,
+	); ok {
+		return target, true
+	}
+	return DeliveryTarget{}, false
+}
+
+func resolveTelegramTargetValue(
+	channelID string,
+	value string,
+) (DeliveryTarget, bool) {
+	if channelID != "" && channelID != telegram.ChannelName {
+		return DeliveryTarget{}, false
+	}
+	target, ok := telegram.ResolveTextTargetFromSessionID(value)
+	if !ok {
+		return DeliveryTarget{}, false
+	}
+	return DeliveryTarget{
+		Channel: telegram.ChannelName,
+		Target:  target,
+	}, true
+}
+
+func resolveWeComTargetValue(
+	channelID string,
+	value string,
+) (DeliveryTarget, bool) {
+	if channelID != "" && channelID != wecomChannelName {
+		return DeliveryTarget{}, false
+	}
+	target, ok := normalizeWeComTarget(value)
+	if !ok {
+		return DeliveryTarget{}, false
+	}
+	return DeliveryTarget{
+		Channel: wecomChannelName,
+		Target:  target,
+	}, true
+}
+
+func validateTarget(target DeliveryTarget) error {
+	if target.Channel != wecomChannelName {
+		return nil
+	}
+	if _, ok := parseWeComPushTarget(target.Target); ok {
+		return nil
+	}
+	return fmt.Errorf(
+		"outbound: invalid target for %s: %s",
+		target.Channel,
+		target.Target,
+	)
+}
+
+func normalizeWeComTarget(value string) (string, bool) {
+	raw := strings.TrimSpace(value)
+	if target, ok := parseWeComPushTarget(raw); ok {
+		return target, true
+	}
+	switch {
+	case strings.HasPrefix(raw, wecomThreadPrefix):
+		return normalizeWeComTarget(
+			strings.TrimPrefix(raw, wecomThreadPrefix),
+		)
+	case strings.HasPrefix(raw, wecomChatPrefix):
+		return normalizeWeComChatTarget(
+			strings.TrimPrefix(raw, wecomChatPrefix),
+		)
+	case strings.HasPrefix(raw, wecomDMPrefix):
+		return normalizeWeComDMTarget(
+			strings.TrimPrefix(raw, wecomDMPrefix),
+		)
+	default:
+		return "", false
+	}
+}
+
+func normalizeWeComChatTarget(value string) (string, bool) {
+	chatID := strings.TrimSpace(value)
+	if idx := strings.Index(chatID, wecomScopedUserSeparator); idx >= 0 {
+		chatID = chatID[:idx]
+	}
+	chatID = strings.TrimSpace(chatID)
+	if chatID == "" {
+		return "", false
+	}
+	return wecomGroupTargetPrefix + chatID, true
+}
+
+func normalizeWeComDMTarget(value string) (string, bool) {
+	userID := strings.TrimSpace(value)
+	if userID == "" {
+		return "", false
+	}
+	return wecomSingleTargetPrefix + userID, true
+}
+
+func parseWeComPushTarget(value string) (string, bool) {
+	raw := strings.TrimSpace(value)
+	switch {
+	case strings.HasPrefix(raw, wecomGroupTargetPrefix):
+		return parseWeComPushTargetWithPrefix(
+			raw,
+			wecomGroupTargetPrefix,
+		)
+	case strings.HasPrefix(raw, wecomSingleTargetPrefix):
+		return parseWeComPushTargetWithPrefix(
+			raw,
+			wecomSingleTargetPrefix,
+		)
+	default:
+		return "", false
+	}
+}
+
+func parseWeComPushTargetWithPrefix(
+	value string,
+	prefix string,
+) (string, bool) {
+	id := strings.TrimSpace(strings.TrimPrefix(value, prefix))
+	if id == "" {
+		return "", false
+	}
+	return prefix + id, true
 }

--- a/openclaw/internal/outbound/resolve_test.go
+++ b/openclaw/internal/outbound/resolve_test.go
@@ -45,6 +45,72 @@ func TestResolveTarget_DMSessionWithSuffix(t *testing.T) {
 	}, target)
 }
 
+func TestResolveTarget_WeComSessionTarget(t *testing.T) {
+	t.Parallel()
+
+	target, err := ResolveTarget(
+		context.Background(),
+		DeliveryTarget{
+			Target: "wecom:thread:wecom:chat:chat-1",
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, DeliveryTarget{
+		Channel: "wecom",
+		Target:  "group:chat-1",
+	}, target)
+}
+
+func TestResolveTarget_WeComScopedGroupSession(t *testing.T) {
+	t.Parallel()
+
+	target, err := ResolveTarget(
+		context.Background(),
+		DeliveryTarget{
+			Target: "wecom:chat:chat-1:user:user-1",
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, DeliveryTarget{
+		Channel: "wecom",
+		Target:  "group:chat-1",
+	}, target)
+}
+
+func TestResolveTarget_ExplicitWeComTarget(t *testing.T) {
+	t.Parallel()
+
+	target, err := ResolveTarget(
+		context.Background(),
+		DeliveryTarget{
+			Channel: "wecom",
+			Target:  "wecom:thread:wecom:dm:user-1",
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, DeliveryTarget{
+		Channel: "wecom",
+		Target:  "single:user-1",
+	}, target)
+}
+
+func TestResolveTarget_RejectsInvalidWeComTarget(t *testing.T) {
+	t.Parallel()
+
+	_, err := ResolveTarget(
+		context.Background(),
+		DeliveryTarget{
+			Channel: "wecom",
+			Target:  "wecom:thread:unknown",
+		},
+	)
+	require.ErrorContains(
+		t,
+		err,
+		"outbound: invalid target for wecom",
+	)
+}
+
 func TestResolveTarget_RuntimeStateFallback(t *testing.T) {
 	ctx := invocationCtx(
 		t,
@@ -73,6 +139,23 @@ func TestResolveTarget_SessionFallback(t *testing.T) {
 	require.Equal(t, DeliveryTarget{
 		Channel: "telegram",
 		Target:  "999:topic:7",
+	}, target)
+}
+
+func TestResolveTarget_WeComSessionFallback(t *testing.T) {
+	t.Parallel()
+
+	ctx := invocationCtx(
+		t,
+		"wecom:chat:chat-1:user:user-1",
+		agent.RunOptions{},
+	)
+
+	target, err := ResolveTarget(ctx, DeliveryTarget{})
+	require.NoError(t, err)
+	require.Equal(t, DeliveryTarget{
+		Channel: "wecom",
+		Target:  "group:chat-1",
 	}, target)
 }
 


### PR DESCRIPTION
## Summary
- normalize WeCom chat and thread targets into canonical push targets before cron persists jobs
- reject invalid WeCom delivery targets at creation time instead of leaving runtime delivery failures
- add outbound and cron tests covering WeCom target normalization and validation

## Testing
- cd openclaw && GOWORK=off go test ./internal/outbound ./internal/cron -count=1