### PR TITLE
openclaw: infer auto OpenAI variant from base URL

### DIFF
--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -540,7 +540,9 @@ go run ./cmd/openclaw \
   -http-addr :8080
 ```
 
-By default, `-openai-variant` is `auto` and is inferred from `-model`.
+By default, `-openai-variant` is `auto` and is inferred from the official
+`OPENAI_BASE_URL` host. For custom proxies or other compatible endpoints, set
+`-openai-variant` explicitly.
 You can override it explicitly:
 
 ```bash

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -515,10 +515,12 @@ You can override the OpenAI-compatible base URL with:
 
 ### DeepSeek (OpenAI-compatible)
 
-If you use DeepSeek, set `DEEPSEEK_API_KEY`:
+If you use DeepSeek directly, set `DEEPSEEK_API_KEY` together with the official
+DeepSeek base URL:
 
 ```bash
 export DEEPSEEK_API_KEY="your-api-key"
+export OPENAI_BASE_URL="https://api.deepseek.com/v1"
 
 cd openclaw
 go run ./cmd/openclaw \
@@ -540,9 +542,10 @@ go run ./cmd/openclaw \
   -http-addr :8080
 ```
 
-By default, `-openai-variant` is `auto` and is inferred from the official
-`OPENAI_BASE_URL` host. For custom proxies or other compatible endpoints, set
-`-openai-variant` explicitly.
+By default, `-openai-variant` is `auto` and is inferred from the configured
+base URL host (`OPENAI_BASE_URL`, `-openai-base-url`, or `model.base_url`). For
+custom proxies or other compatible endpoints, set `-openai-variant`
+explicitly.
 You can override it explicitly:
 
 ```bash
@@ -1070,7 +1073,7 @@ If you already have an OpenClaw skills directory, you can reuse it:
 cd openclaw
 go run ./cmd/openclaw \
   -mode openai \
-  -model deepseek-chat \
+  -model gpt-5 \
   -skills-extra-dirs "/path/to/openclaw/skills"
 ```
 
@@ -1305,7 +1308,7 @@ To disable these tools explicitly:
 ```bash
 go run ./cmd/openclaw \
   -mode openai \
-  -model deepseek-chat \
+  -model gpt-5 \
   -config ./openclaw.yaml \
   -enable-openclaw-tools=false
 ```

--- a/openclaw/README.zh_CN.md
+++ b/openclaw/README.zh_CN.md
@@ -521,8 +521,10 @@ go run ./cmd/openclaw \
   -http-addr :8080
 ```
 
-默认情况下，`-openai-variant` 为 `auto`，会从 `-model` 推断。
-你可以显式覆盖：
+默认情况下，`-openai-variant` 为 `auto`，会根据官方
+`OPENAI_BASE_URL` 的 host 自动推断。对于自定义代理或其他兼容端点，
+请显式设置 `-openai-variant`。
+你也可以显式覆盖：
 
 ```bash
 export OPENAI_API_KEY="your-api-key"

--- a/openclaw/README.zh_CN.md
+++ b/openclaw/README.zh_CN.md
@@ -496,10 +496,12 @@ go run ./cmd/openclaw \
 
 ### DeepSeek（OpenAI 兼容）
 
-如果使用 DeepSeek，请设置 `DEEPSEEK_API_KEY`：
+如果你直连 DeepSeek，请同时设置 `DEEPSEEK_API_KEY` 和官方
+DeepSeek base URL：
 
 ```bash
 export DEEPSEEK_API_KEY="your-api-key"
+export OPENAI_BASE_URL="https://api.deepseek.com/v1"
 
 cd openclaw
 go run ./cmd/openclaw \
@@ -521,9 +523,10 @@ go run ./cmd/openclaw \
   -http-addr :8080
 ```
 
-默认情况下，`-openai-variant` 为 `auto`，会根据官方
-`OPENAI_BASE_URL` 的 host 自动推断。对于自定义代理或其他兼容端点，
-请显式设置 `-openai-variant`。
+默认情况下，`-openai-variant` 为 `auto`，会根据已配置的
+base URL host 自动推断（`OPENAI_BASE_URL`、`-openai-base-url`
+或 `model.base_url`）。对于自定义代理或其他兼容端点，请显式设置
+`-openai-variant`。
 你也可以显式覆盖：
 
 ```bash
@@ -970,7 +973,7 @@ OpenClaw 会将加载的技能正文/文档中的 `{baseDir}` 替换为本地技
 cd openclaw
 go run ./cmd/openclaw \
   -mode openai \
-  -model deepseek-chat \
+  -model gpt-5 \
   -skills-extra-dirs "/path/to/openclaw/skills"
 ```
 
@@ -1164,7 +1167,7 @@ OpenClaw 为默认 LLM agent 暴露了一个面向代码 agent 的宿主机 tool
 ```bash
 go run ./cmd/openclaw \
   -mode openai \
-  -model deepseek-chat \
+  -model gpt-5 \
   -config ./openclaw.yaml \
   -enable-openclaw-tools=false
 ```

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -24,6 +24,7 @@ import (
 	"hash/crc32"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -203,9 +204,9 @@ const (
 
 	defaultOpenAIVariant = openAIVariantAuto
 
-	deepSeekModelHint = "deepseek"
-	qwenModelHint     = "qwen"
-	hunyuanModelHint  = "hunyuan"
+	deepSeekAPIHost = "api.deepseek.com"
+	qwenAPIHost     = "dashscope.aliyuncs.com"
+	hunyuanAPIHost  = "api.hunyuan.cloud.tencent.com"
 
 	openAIBaseURLEnvName = "OPENAI_BASE_URL"
 	openAIModelEnvName   = "OPENAI_MODEL"
@@ -2311,7 +2312,8 @@ func newOpenAIModel(spec registry.ModelSpec) (model.Model, error) {
 		return nil, errors.New("openai model name is empty")
 	}
 
-	variant, err := parseOpenAIVariant(spec.OpenAIVariant, name)
+	baseURL := strings.TrimSpace(spec.BaseURL)
+	variant, err := parseOpenAIVariant(spec.OpenAIVariant, baseURL)
 	if err != nil {
 		return nil, err
 	}
@@ -2320,7 +2322,6 @@ func newOpenAIModel(spec registry.ModelSpec) (model.Model, error) {
 		openai.WithVariant(variant),
 		openai.WithOmitFileContentParts(true),
 	}
-	baseURL := strings.TrimSpace(spec.BaseURL)
 	if baseURL != "" {
 		opts = append(opts, openai.WithBaseURL(baseURL))
 	}
@@ -2355,11 +2356,11 @@ func modelFromOptions(opts runOptions) (model.Model, error) {
 
 func parseOpenAIVariant(
 	raw string,
-	modelName string,
+	baseURL string,
 ) (openai.Variant, error) {
 	v := strings.ToLower(strings.TrimSpace(raw))
 	if v == "" || v == openAIVariantAuto {
-		return inferOpenAIVariant(modelName), nil
+		return inferOpenAIVariant(baseURL), nil
 	}
 
 	variant := openai.Variant(v)
@@ -2374,18 +2375,37 @@ func parseOpenAIVariant(
 	}
 }
 
-func inferOpenAIVariant(modelName string) openai.Variant {
-	name := strings.ToLower(strings.TrimSpace(modelName))
+func inferOpenAIVariant(baseURL string) openai.Variant {
+	host, ok := openAIBaseURLHost(baseURL)
+	if !ok {
+		return openai.VariantOpenAI
+	}
 	switch {
-	case strings.Contains(name, deepSeekModelHint):
+	case strings.EqualFold(host, deepSeekAPIHost):
 		return openai.VariantDeepSeek
-	case strings.Contains(name, qwenModelHint):
+	case strings.EqualFold(host, qwenAPIHost):
 		return openai.VariantQwen
-	case strings.Contains(name, hunyuanModelHint):
+	case strings.EqualFold(host, hunyuanAPIHost):
 		return openai.VariantHunyuan
 	default:
 		return openai.VariantOpenAI
 	}
+}
+
+func openAIBaseURLHost(raw string) (string, bool) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", false
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return "", false
+	}
+	host := strings.TrimSpace(parsed.Hostname())
+	if host == "" {
+		return "", false
+	}
+	return host, true
 }
 
 func splitCSV(input string) []string {

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -1642,19 +1642,19 @@ func TestConfigFingerprint_Deterministic(t *testing.T) {
 }
 
 func TestParseOpenAIVariant_Explicit(t *testing.T) {
-	v, err := parseOpenAIVariant(string(openai.VariantOpenAI), "gpt-5")
+	v, err := parseOpenAIVariant(string(openai.VariantOpenAI), "")
 	require.NoError(t, err)
 	require.Equal(t, openai.VariantOpenAI, v)
 }
 
 func TestParseOpenAIVariant_Auto(t *testing.T) {
-	v, err := parseOpenAIVariant(openAIVariantAuto, "deepseek-chat")
+	v, err := parseOpenAIVariant(openAIVariantAuto, "https://api.deepseek.com/v1")
 	require.NoError(t, err)
 	require.Equal(t, openai.VariantDeepSeek, v)
 }
 
 func TestParseOpenAIVariant_Unknown(t *testing.T) {
-	_, err := parseOpenAIVariant("nope", "gpt-5")
+	_, err := parseOpenAIVariant("nope", "")
 	require.Error(t, err)
 }
 
@@ -1662,15 +1662,29 @@ func TestInferOpenAIVariant(t *testing.T) {
 	require.Equal(
 		t,
 		openai.VariantDeepSeek,
-		inferOpenAIVariant("deepseek-r1"),
+		inferOpenAIVariant("https://api.deepseek.com/v1"),
 	)
-	require.Equal(t, openai.VariantQwen, inferOpenAIVariant("qwen2.5"))
+	require.Equal(
+		t,
+		openai.VariantQwen,
+		inferOpenAIVariant("https://dashscope.aliyuncs.com/compatible-mode/v1"),
+	)
 	require.Equal(
 		t,
 		openai.VariantHunyuan,
-		inferOpenAIVariant("hunyuan-t1"),
+		inferOpenAIVariant("https://api.hunyuan.cloud.tencent.com/v1"),
 	)
-	require.Equal(t, openai.VariantOpenAI, inferOpenAIVariant("gpt-5"))
+	require.Equal(
+		t,
+		openai.VariantOpenAI,
+		inferOpenAIVariant("https://deepseek.com/v1"),
+	)
+	require.Equal(
+		t,
+		openai.VariantOpenAI,
+		inferOpenAIVariant("https://proxy.example.com/v1"),
+	)
+	require.Equal(t, openai.VariantOpenAI, inferOpenAIVariant("deepseek-chat"))
 }
 
 func TestNewModel_Mock(t *testing.T) {

--- a/openclaw/app/run_options.go
+++ b/openclaw/app/run_options.go
@@ -488,7 +488,7 @@ func parseRunOptions(args []string) (runOptions, error) {
 		&opts.OpenAIVariant,
 		"openai-variant",
 		defaultOpenAIVariant,
-		"OpenAI variant: auto, openai, deepseek, qwen, hunyuan",
+		"OpenAI variant: auto, openai, deepseek, qwen, hunyuan (auto uses official base URL)",
 	)
 	fs.StringVar(
 		&opts.OpenAIBaseURL,

--- a/openclaw/app/run_options.go
+++ b/openclaw/app/run_options.go
@@ -488,7 +488,7 @@ func parseRunOptions(args []string) (runOptions, error) {
 		&opts.OpenAIVariant,
 		"openai-variant",
 		defaultOpenAIVariant,
-		"OpenAI variant: auto, openai, deepseek, qwen, hunyuan (auto uses official base URL)",
+		"OpenAI variant: auto, openai, deepseek, qwen, hunyuan (auto uses configured base URL host)",
 	)
 	fs.StringVar(
 		&opts.OpenAIBaseURL,


### PR DESCRIPTION
## Summary
- align OpenClaw auto variant inference with `model/openai` by using the configured official base URL host instead of the model name
- keep custom proxies and third-party OpenAI-compatible endpoints on the generic OpenAI path unless callers explicitly set `-openai-variant`
- update tests and README/help text to document the base-URL-driven inference behavior

## Test plan
- [x] `cd openclaw && go test ./app -count=1`

Made with [Cursor](https://cursor.com)