### PR TITLE
openclaw: resolve actor labels in shared history

### DIFF
--- a/openclaw/app/conversation.go
+++ b/openclaw/app/conversation.go
@@ -56,10 +56,12 @@ func buildConversationRunOptionResolver(
 					},
 				)
 				if err == nil && sess != nil {
+					opts := historyOpts
+					opts.LabelOverrides = annotation.ActorLabels
 					history := conversation.
 						BuildInjectedContextMessages(
 							sess,
-							historyOpts,
+							opts,
 						)
 					if len(history) > 0 {
 						runOpts = append(

--- a/openclaw/app/conversation_test.go
+++ b/openclaw/app/conversation_test.go
@@ -37,6 +37,9 @@ func TestRunOptionResolversMergeRuntimeState(t *testing.T) {
 			HistoryMode: conversation.HistoryModeShared,
 			ActorID:     "user1",
 			ActorLabel:  "Alice",
+			ActorLabels: map[string]string{
+				"user1": "alice.dev",
+			},
 		},
 	)
 	require.NoError(t, err)
@@ -93,6 +96,9 @@ func TestRunOptionResolversMergeRuntimeState(t *testing.T) {
 			HistoryMode: conversation.HistoryModeShared,
 			ActorID:     "user1",
 			ActorLabel:  "Alice",
+			ActorLabels: map[string]string{
+				"user1": "alice.dev",
+			},
 		},
 		cfg.RuntimeState[conversation.RuntimeStateKey],
 	)
@@ -136,6 +142,9 @@ func TestBuildConversationRunOptionResolverSharedHistory(
 		conversation.Annotation{
 			ActorID:    "u-1",
 			ActorLabel: "Alice",
+			ActorLabels: map[string]string{
+				"u-1": "alice.dev",
+			},
 		},
 	))
 	require.NoError(
@@ -164,6 +173,9 @@ func TestBuildConversationRunOptionResolverSharedHistory(
 			HistoryMode: conversation.HistoryModeShared,
 			ActorID:     "u-1",
 			ActorLabel:  "Alice",
+			ActorLabels: map[string]string{
+				"u-1": "alice.dev",
+			},
 		},
 	)
 	require.NoError(t, err)
@@ -187,7 +199,11 @@ func TestBuildConversationRunOptionResolverSharedHistory(
 	}
 
 	require.Len(t, cfg.InjectedContextMessages, 2)
-	require.Contains(t, cfg.InjectedContextMessages[0].Content, "Speaker: Alice")
+	require.Contains(
+		t,
+		cfg.InjectedContextMessages[0].Content,
+		"Speaker: alice.dev",
+	)
 	require.Equal(
 		t,
 		includeContentsNone,
@@ -224,6 +240,9 @@ func TestBuildConversationRunOptionResolver_EdgeCases(t *testing.T) {
 			conversation.Annotation{
 				ActorID:    "u-1",
 				ActorLabel: "Alice",
+				ActorLabels: map[string]string{
+					"u-1": "alice.dev",
+				},
 			},
 		)
 		require.NoError(t, err)
@@ -245,6 +264,9 @@ func TestBuildConversationRunOptionResolver_EdgeCases(t *testing.T) {
 			conversation.Annotation{
 				ActorID:    "u-1",
 				ActorLabel: "Alice",
+				ActorLabels: map[string]string{
+					"u-1": "alice.dev",
+				},
 			},
 			cfg.RuntimeState[conversation.RuntimeStateKey],
 		)

--- a/openclaw/conversation/annotation.go
+++ b/openclaw/conversation/annotation.go
@@ -18,10 +18,11 @@ import (
 
 // Annotation stores channel-provided conversation metadata.
 type Annotation struct {
-	HistoryMode string `json:"history_mode,omitempty"`
-	ActorID     string `json:"actor_id,omitempty"`
-	ActorLabel  string `json:"actor_label,omitempty"`
-	QuoteText   string `json:"quote_text,omitempty"`
+	HistoryMode string            `json:"history_mode,omitempty"`
+	ActorID     string            `json:"actor_id,omitempty"`
+	ActorLabel  string            `json:"actor_label,omitempty"`
+	ActorLabels map[string]string `json:"actor_labels,omitempty"`
+	QuoteText   string            `json:"quote_text,omitempty"`
 }
 
 // MergeRequestExtension stores conversation metadata in request
@@ -30,7 +31,8 @@ func MergeRequestExtension(
 	extensions map[string]json.RawMessage,
 	annotation Annotation,
 ) (map[string]json.RawMessage, error) {
-	if isZeroAnnotation(annotation) {
+	annotation = normalizeAnnotation(annotation)
+	if isZeroRuntimeAnnotation(annotation) {
 		return extensions, nil
 	}
 	raw, err := json.Marshal(annotation)
@@ -65,7 +67,7 @@ func AnnotationFromRuntimeState(
 		return Annotation{}, false
 	}
 	annotation, ok := value.(Annotation)
-	if !ok || isZeroAnnotation(annotation) {
+	if !ok || isZeroRuntimeAnnotation(annotation) {
 		return Annotation{}, false
 	}
 	return annotation, true
@@ -73,7 +75,8 @@ func AnnotationFromRuntimeState(
 
 // RuntimeState returns runtime state for one run.
 func RuntimeState(annotation Annotation) map[string]any {
-	if isZeroAnnotation(annotation) {
+	annotation = normalizeAnnotation(annotation)
+	if isZeroRuntimeAnnotation(annotation) {
 		return nil
 	}
 	return map[string]any{
@@ -86,17 +89,14 @@ func SetEventAnnotation(
 	evt *event.Event,
 	annotation Annotation,
 ) error {
-	if isZeroAnnotation(annotation) {
+	evtAnnotation, ok := persistableEventAnnotation(annotation)
+	if !ok {
 		return nil
 	}
 	return event.SetExtension(
 		evt,
 		ExtensionKey,
-		eventAnnotation{
-			ActorID:    annotation.ActorID,
-			ActorLabel: annotation.ActorLabel,
-			QuoteText:  annotation.QuoteText,
-		},
+		evtAnnotation,
 	)
 }
 
@@ -111,6 +111,9 @@ func AnnotationFromEvent(
 	)
 	if err != nil || !ok {
 		return Annotation{}, ok, err
+	}
+	if isZeroEventAnnotation(eventAnnotation(decoded)) {
+		return Annotation{}, false, nil
 	}
 	return Annotation{
 		ActorID:    strings.TrimSpace(decoded.ActorID),
@@ -139,19 +142,74 @@ func decodeAnnotation(
 	if err := json.Unmarshal(raw, &decoded); err != nil {
 		return Annotation{}, false, err
 	}
-	decoded.HistoryMode = strings.TrimSpace(decoded.HistoryMode)
-	decoded.ActorID = strings.TrimSpace(decoded.ActorID)
-	decoded.ActorLabel = strings.TrimSpace(decoded.ActorLabel)
-	decoded.QuoteText = strings.TrimSpace(decoded.QuoteText)
-	if isZeroAnnotation(decoded) {
+	decoded = normalizeAnnotation(decoded)
+	if isZeroRuntimeAnnotation(decoded) {
 		return Annotation{}, false, nil
 	}
 	return decoded, true, nil
 }
 
-func isZeroAnnotation(annotation Annotation) bool {
+func isZeroRuntimeAnnotation(annotation Annotation) bool {
 	return strings.TrimSpace(annotation.HistoryMode) == "" &&
 		strings.TrimSpace(annotation.ActorID) == "" &&
+		strings.TrimSpace(annotation.ActorLabel) == "" &&
+		len(annotation.ActorLabels) == 0 &&
+		strings.TrimSpace(annotation.QuoteText) == ""
+}
+
+func normalizeAnnotation(annotation Annotation) Annotation {
+	annotation.HistoryMode = strings.TrimSpace(
+		annotation.HistoryMode,
+	)
+	annotation.ActorID = strings.TrimSpace(annotation.ActorID)
+	annotation.ActorLabel = strings.TrimSpace(
+		annotation.ActorLabel,
+	)
+	annotation.ActorLabels = normalizeActorLabels(
+		annotation.ActorLabels,
+	)
+	annotation.QuoteText = strings.TrimSpace(annotation.QuoteText)
+	return annotation
+}
+
+func normalizeActorLabels(
+	labels map[string]string,
+) map[string]string {
+	if len(labels) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(labels))
+	for actorID, label := range labels {
+		actorID = strings.TrimSpace(actorID)
+		label = strings.TrimSpace(label)
+		if actorID == "" || label == "" {
+			continue
+		}
+		out[actorID] = label
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func persistableEventAnnotation(
+	annotation Annotation,
+) (eventAnnotation, bool) {
+	annotation = normalizeAnnotation(annotation)
+	evtAnnotation := eventAnnotation{
+		ActorID:    annotation.ActorID,
+		ActorLabel: annotation.ActorLabel,
+		QuoteText:  annotation.QuoteText,
+	}
+	if isZeroEventAnnotation(evtAnnotation) {
+		return eventAnnotation{}, false
+	}
+	return evtAnnotation, true
+}
+
+func isZeroEventAnnotation(annotation eventAnnotation) bool {
+	return strings.TrimSpace(annotation.ActorID) == "" &&
 		strings.TrimSpace(annotation.ActorLabel) == "" &&
 		strings.TrimSpace(annotation.QuoteText) == ""
 }

--- a/openclaw/conversation/history.go
+++ b/openclaw/conversation/history.go
@@ -23,12 +23,14 @@ import (
 type HistoryOptions struct {
 	AddSessionSummary bool
 	MaxHistoryRuns    int
+	LabelOverrides    map[string]string
 }
 
 // TurnOptions controls speaker-aware turn projection.
 type TurnOptions struct {
-	Limit         int
-	IncludeSystem bool
+	Limit          int
+	IncludeSystem  bool
+	LabelOverrides map[string]string
 }
 
 // Turn is one speaker-aware conversation turn.
@@ -64,7 +66,11 @@ func BuildInjectedContextMessages(
 		}
 	}
 
-	history := buildVisibleHistory(sess.Events, since)
+	history := buildVisibleHistory(
+		sess.Events,
+		since,
+		normalizeActorLabels(opts.LabelOverrides),
+	)
 	if opts.MaxHistoryRuns > 0 && len(history) > opts.MaxHistoryRuns {
 		history = history[len(history)-opts.MaxHistoryRuns:]
 	}
@@ -84,6 +90,9 @@ func BuildTurns(
 	if sess == nil {
 		return nil
 	}
+	opts.LabelOverrides = normalizeActorLabels(
+		opts.LabelOverrides,
+	)
 	turns := buildTurns(sess.Events, opts)
 	if opts.Limit > 0 && len(turns) > opts.Limit {
 		turns = turns[len(turns)-opts.Limit:]
@@ -122,6 +131,7 @@ func BuildSummaryText(events []event.Event) string {
 func buildVisibleHistory(
 	events []event.Event,
 	since time.Time,
+	labelOverrides map[string]string,
 ) []model.Message {
 	out := make([]model.Message, 0, len(events))
 	for i := range events {
@@ -129,7 +139,10 @@ func buildVisibleHistory(
 		if !includeEvent(evt, since) {
 			continue
 		}
-		msgs := visibleMessagesFromEvent(evt)
+		msgs := visibleMessagesFromEvent(
+			evt,
+			labelOverrides,
+		)
 		out = append(out, msgs...)
 	}
 	return out
@@ -143,7 +156,11 @@ func buildTurns(
 	for i := range events {
 		out = append(
 			out,
-			turnsFromEvent(events[i], opts.IncludeSystem)...,
+			turnsFromEvent(
+				events[i],
+				opts.IncludeSystem,
+				opts.LabelOverrides,
+			)...,
 		)
 	}
 	return out
@@ -154,7 +171,10 @@ func buildSummaryLines(events []event.Event) []string {
 	var hasAnnotatedUser bool
 	for i := range events {
 		evt := events[i]
-		rendered, annotated := summaryLinesFromEvent(evt)
+		rendered, annotated := summaryLinesFromEvent(
+			evt,
+			nil,
+		)
 		if annotated {
 			hasAnnotatedUser = true
 		}
@@ -180,6 +200,7 @@ func includeEvent(evt event.Event, since time.Time) bool {
 func turnsFromEvent(
 	evt event.Event,
 	includeSystem bool,
+	labelOverrides map[string]string,
 ) []Turn {
 	if evt.Response == nil || evt.IsPartial ||
 		len(evt.Response.Choices) == 0 {
@@ -187,7 +208,7 @@ func turnsFromEvent(
 	}
 	switch evt.Author {
 	case authorUser:
-		return userTurnsFromEvent(evt)
+		return userTurnsFromEvent(evt, labelOverrides)
 	case authorSystem:
 		if !includeSystem {
 			return nil
@@ -198,9 +219,12 @@ func turnsFromEvent(
 	}
 }
 
-func visibleMessagesFromEvent(evt event.Event) []model.Message {
+func visibleMessagesFromEvent(
+	evt event.Event,
+	labelOverrides map[string]string,
+) []model.Message {
 	if evt.Author == authorUser {
-		msgs := visibleUserMessages(evt)
+		msgs := visibleUserMessages(evt, labelOverrides)
 		if len(msgs) > 0 {
 			return msgs
 		}
@@ -211,14 +235,21 @@ func visibleMessagesFromEvent(evt event.Event) []model.Message {
 	return visibleAssistantMessages(evt)
 }
 
-func visibleUserMessages(evt event.Event) []model.Message {
+func visibleUserMessages(
+	evt event.Event,
+	labelOverrides map[string]string,
+) []model.Message {
 	annotation, _, err := AnnotationFromEvent(evt)
 	if err != nil {
 		return nil
 	}
 	out := make([]model.Message, 0, len(evt.Response.Choices))
 	for _, choice := range evt.Response.Choices {
-		text := renderUserMessage(choice.Message, annotation)
+		text := renderUserMessage(
+			choice.Message,
+			annotation,
+			labelOverrides,
+		)
 		if text == "" {
 			continue
 		}
@@ -254,7 +285,10 @@ func visibleSystemMessages(evt event.Event) []model.Message {
 	return out
 }
 
-func userTurnsFromEvent(evt event.Event) []Turn {
+func userTurnsFromEvent(
+	evt event.Event,
+	labelOverrides map[string]string,
+) []Turn {
 	annotation, _, _ := AnnotationFromEvent(evt)
 	out := make([]Turn, 0, len(evt.Response.Choices))
 	for _, choice := range evt.Response.Choices {
@@ -264,7 +298,7 @@ func userTurnsFromEvent(evt event.Event) []Turn {
 		}
 		out = append(out, Turn{
 			Role:      string(model.RoleUser),
-			Speaker:   speakerLabel(annotation),
+			Speaker:   speakerLabel(annotation, labelOverrides),
 			ActorID:   strings.TrimSpace(annotation.ActorID),
 			QuoteText: strings.TrimSpace(annotation.QuoteText),
 			Text:      text,
@@ -308,7 +342,10 @@ func systemTurnsFromEvent(evt event.Event) []Turn {
 	return out
 }
 
-func summaryLinesFromEvent(evt event.Event) ([]string, bool) {
+func summaryLinesFromEvent(
+	evt event.Event,
+	labelOverrides map[string]string,
+) ([]string, bool) {
 	switch evt.Author {
 	case authorUser:
 		annotation, ok, err := AnnotationFromEvent(evt)
@@ -321,7 +358,10 @@ func summaryLinesFromEvent(evt event.Event) ([]string, bool) {
 			if text == "" {
 				continue
 			}
-			speaker := speakerLabel(annotation)
+			speaker := speakerLabel(
+				annotation,
+				labelOverrides,
+			)
 			if quote := strings.TrimSpace(annotation.QuoteText); quote != "" {
 				lines = append(
 					lines,
@@ -380,13 +420,17 @@ func summaryLinesFromEvent(evt event.Event) ([]string, bool) {
 func renderUserMessage(
 	msg model.Message,
 	annotation Annotation,
+	labelOverrides map[string]string,
 ) string {
 	text := messageText(msg)
 	if text == "" {
 		return ""
 	}
 	lines := []string{
-		contextSpeakerPrefix + ": " + speakerLabel(annotation),
+		contextSpeakerPrefix + ": " + speakerLabel(
+			annotation,
+			labelOverrides,
+		),
 	}
 	if quote := strings.TrimSpace(annotation.QuoteText); quote != "" {
 		lines = append(
@@ -458,7 +502,17 @@ func sessionSummary(
 	return text, sum.UpdatedAt, true
 }
 
-func speakerLabel(annotation Annotation) string {
+func speakerLabel(
+	annotation Annotation,
+	labelOverrides map[string]string,
+) string {
+	if actorID := strings.TrimSpace(annotation.ActorID); actorID != "" {
+		if label := strings.TrimSpace(
+			labelOverrides[actorID],
+		); label != "" {
+			return label
+		}
+	}
 	if label := strings.TrimSpace(annotation.ActorLabel); label != "" {
 		return label
 	}

--- a/openclaw/conversation/history_test.go
+++ b/openclaw/conversation/history_test.go
@@ -29,6 +29,7 @@ func TestMergeRequestExtensionRoundTrip(t *testing.T) {
 		HistoryMode: HistoryModeShared,
 		ActorID:     "u1",
 		ActorLabel:  "Alice",
+		ActorLabels: map[string]string{"u2": "Bob"},
 		QuoteText:   "hello",
 	})
 	require.NoError(t, err)
@@ -41,6 +42,11 @@ func TestMergeRequestExtensionRoundTrip(t *testing.T) {
 	require.Equal(t, HistoryModeShared, annotation.HistoryMode)
 	require.Equal(t, "u1", annotation.ActorID)
 	require.Equal(t, "Alice", annotation.ActorLabel)
+	require.Equal(
+		t,
+		map[string]string{"u2": "Bob"},
+		annotation.ActorLabels,
+	)
 	require.Equal(t, "hello", annotation.QuoteText)
 }
 
@@ -84,6 +90,22 @@ func TestAnnotationHelpers_EdgeCases(t *testing.T) {
 	_, ok = AnnotationFromRuntimeState(
 		map[string]any{RuntimeStateKey: Annotation{}},
 	)
+	require.False(t, ok)
+
+	runtimeOnly := Annotation{
+		ActorLabels: map[string]string{"u1": "Alice"},
+	}
+	state := RuntimeState(runtimeOnly)
+	require.NotNil(t, state)
+	annotation, ok := AnnotationFromRuntimeState(state)
+	require.True(t, ok)
+	require.Equal(t, runtimeOnly.ActorLabels, annotation.ActorLabels)
+
+	evtOnlyLabels := event.New("inv", authorUser)
+	err = SetEventAnnotation(evtOnlyLabels, runtimeOnly)
+	require.NoError(t, err)
+	_, ok, err = AnnotationFromEvent(*evtOnlyLabels)
+	require.NoError(t, err)
 	require.False(t, ok)
 
 	_, ok, err = AnnotationFromRequestExtensions(
@@ -135,12 +157,15 @@ func TestBuildInjectedContextMessages(t *testing.T) {
 	got := BuildInjectedContextMessages(sess, HistoryOptions{
 		AddSessionSummary: true,
 		MaxHistoryRuns:    10,
+		LabelOverrides: map[string]string{
+			"u2": "Robert",
+		},
 	})
 	require.Len(t, got, 3)
 	require.Equal(t, model.RoleSystem, got[0].Role)
 	require.Contains(t, got[0].Content, "older history")
 	require.Equal(t, model.RoleUser, got[1].Role)
-	require.Contains(t, got[1].Content, "Speaker: Bob")
+	require.Contains(t, got[1].Content, "Speaker: Robert")
 	require.Contains(t, got[1].Content, "Message: latest question")
 	require.Equal(t, model.RoleAssistant, got[2].Role)
 	require.Equal(t, "latest answer", got[2].Content)
@@ -210,14 +235,15 @@ func TestHistoryHelpers_RenderAndFilter(t *testing.T) {
 				ActorLabel: "Alice",
 				QuoteText:  "earlier",
 			},
+			nil,
 		),
 	)
 
-	require.Equal(t, authorUser, speakerLabel(Annotation{}))
+	require.Equal(t, authorUser, speakerLabel(Annotation{}, nil))
 	require.Equal(
 		t,
 		"u-1",
-		speakerLabel(Annotation{ActorID: "u-1"}),
+		speakerLabel(Annotation{ActorID: "u-1"}, nil),
 	)
 	require.Equal(
 		t,
@@ -225,7 +251,18 @@ func TestHistoryHelpers_RenderAndFilter(t *testing.T) {
 		speakerLabel(Annotation{
 			ActorID:    "u-1",
 			ActorLabel: "Bob",
-		}),
+		}, nil),
+	)
+	require.Equal(
+		t,
+		"Robert",
+		speakerLabel(
+			Annotation{
+				ActorID:    "u-1",
+				ActorLabel: "Bob",
+			},
+			map[string]string{"u-1": "Robert"},
+		),
 	)
 
 	require.Equal(
@@ -250,7 +287,7 @@ func TestHistoryHelpers_RenderAndFilter(t *testing.T) {
 	invalidUser.Extensions = map[string]json.RawMessage{
 		ExtensionKey: json.RawMessage("{"),
 	}
-	require.Nil(t, visibleUserMessages(*invalidUser))
+	require.Nil(t, visibleUserMessages(*invalidUser, nil))
 
 	assistantToolOnly := event.Event{
 		Author: authorAssistant,
@@ -271,7 +308,7 @@ func TestHistoryHelpers_RenderAndFilter(t *testing.T) {
 	)
 	require.Nil(
 		t,
-		turnsFromEvent(event.Event{}, true),
+		turnsFromEvent(event.Event{}, true, nil),
 	)
 	require.Nil(
 		t,
@@ -352,10 +389,13 @@ func TestBuildTurns(t *testing.T) {
 	got := BuildTurns(sess, TurnOptions{
 		Limit:         10,
 		IncludeSystem: false,
+		LabelOverrides: map[string]string{
+			"u1": "alice.dev",
+		},
 	})
 	require.Len(t, got, 2)
 	require.Equal(t, string(model.RoleUser), got[0].Role)
-	require.Equal(t, "Alice", got[0].Speaker)
+	require.Equal(t, "alice.dev", got[0].Speaker)
 	require.Equal(t, "u1", got[0].ActorID)
 	require.Equal(t, "the earlier topic", got[0].QuoteText)
 	require.Equal(t, "what changed", got[0].Text)
@@ -501,7 +541,7 @@ func TestHistoryHelpers_SystemTurnsAndSummary(t *testing.T) {
 	require.Equal(t, summarySpeakerSystem, turns[0].Speaker)
 	require.Equal(t, "carry forward", turns[0].Text)
 
-	lines, ok := summaryLinesFromEvent(sysEvt)
+	lines, ok := summaryLinesFromEvent(sysEvt, nil)
 	require.False(t, ok)
 	require.Equal(
 		t,

--- a/openclaw/internal/conversationtool/tool.go
+++ b/openclaw/internal/conversationtool/tool.go
@@ -88,11 +88,13 @@ func (t *Tool) Call(ctx context.Context, args []byte) (any, error) {
 	}
 
 	limit := normalizeLimit(in.Limit)
+	labelOverrides := conversationLabelOverrides(inv)
 	turns := conversation.BuildTurns(
 		inv.Session,
 		conversation.TurnOptions{
-			Limit:         limit,
-			IncludeSystem: in.IncludeSystem,
+			Limit:          limit,
+			IncludeSystem:  in.IncludeSystem,
+			LabelOverrides: labelOverrides,
 		},
 	)
 	transcript := conversation.FormatTurns(turns)
@@ -104,6 +106,21 @@ func (t *Tool) Call(ctx context.Context, args []byte) (any, error) {
 		"transcript":   transcript,
 		"turns":        turns,
 	}, nil
+}
+
+func conversationLabelOverrides(
+	inv *agent.Invocation,
+) map[string]string {
+	if inv == nil {
+		return nil
+	}
+	annotation, ok := conversation.AnnotationFromRuntimeState(
+		inv.RunOptions.RuntimeState,
+	)
+	if !ok {
+		return nil
+	}
+	return annotation.ActorLabels
 }
 
 func normalizeLimit(raw *int) int {

--- a/openclaw/internal/conversationtool/tool_test.go
+++ b/openclaw/internal/conversationtool/tool_test.go
@@ -41,6 +41,14 @@ func TestToolCall(t *testing.T) {
 	inv := agent.NewInvocation(
 		agent.WithInvocationSession(sess),
 	)
+	inv.RunOptions.RuntimeState = conversation.RuntimeState(
+		conversation.Annotation{
+			ActorLabels: map[string]string{
+				"u1": "alice.dev",
+				"u2": "bob.dev",
+			},
+		},
+	)
 	ctx := agent.NewInvocationContext(context.Background(), inv)
 
 	out, err := tool.Call(ctx, []byte(`{"limit":4}`))
@@ -53,12 +61,13 @@ func TestToolCall(t *testing.T) {
 	require.Contains(
 		t,
 		result["transcript"],
-		"Alice: hello",
+		"alice.dev: hello",
 	)
 	require.Contains(
 		t,
 		result["transcript"],
-		"Bob (replying to: hello): what did we decide?",
+		"bob.dev (replying to: hello): what did we "+
+			"decide?",
 	)
 	require.Contains(
 		t,
@@ -67,9 +76,9 @@ func TestToolCall(t *testing.T) {
 	)
 	turns := result["turns"].([]conversation.Turn)
 	require.Len(t, turns, 4)
-	require.Equal(t, "Alice", turns[0].Speaker)
+	require.Equal(t, "alice.dev", turns[0].Speaker)
 	require.Equal(t, "Assistant", turns[1].Speaker)
-	require.Equal(t, "Bob", turns[2].Speaker)
+	require.Equal(t, "bob.dev", turns[2].Speaker)
 	require.Equal(t, "Assistant", turns[3].Speaker)
 }
 


### PR DESCRIPTION
## Summary
- let openclaw apply runtime actor-label overrides when rendering shared history
- keep persisted actor ids stable while allowing request-scoped human-friendly labels in injected context and conversation recap
- avoid persisting runtime-only label maps onto events while preserving existing history option fields

## Testing
- GOWORK=off go test ./conversation ./app ./internal/conversationtool -count=1
