### PR TITLE
openclaw: tighten octool command safety policy

### DIFF
--- a/openclaw/internal/gateway/server_test.go
+++ b/openclaw/internal/gateway/server_test.go
@@ -40,8 +40,9 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/runner"
 )
 
+const testTimeout = 2 * time.Second
+
 const (
-	testTimeout   = 2 * time.Second
 	testShortWait = 100 * time.Millisecond
 
 	debugEventsFile     = "events.jsonl"
@@ -1410,10 +1411,8 @@ func TestServer_ProcessMessage_RunOptionResolver(t *testing.T) {
 
 	type ctxKey string
 
-	const (
-		resolverKey ctxKey = "resolver"
-		resolverTag        = "langfuse"
-	)
+	const resolverKey ctxKey = "resolver"
+	const resolverTag = "langfuse"
 
 	runner := &resolvingRunner{}
 	srv, err := New(
@@ -2288,7 +2287,7 @@ func TestServer_ProcessMessage_NilServer(t *testing.T) {
 	t.Parallel()
 
 	var srv *Server
-	rsp, status := srv.ProcessMessage(nil, gwproto.MessageRequest{})
+	rsp, status := srv.ProcessMessage(context.TODO(), gwproto.MessageRequest{})
 	require.Equal(t, http.StatusInternalServerError, status)
 	require.NotNil(t, rsp.Error)
 	require.Equal(t, errTypeInternal, rsp.Error.Type)
@@ -2367,7 +2366,7 @@ func TestServer_CancelRequest_NilContext(t *testing.T) {
 	srv, err := New(r)
 	require.NoError(t, err)
 
-	canceled, apiErr, status := srv.CancelRequest(nil, "req-1")
+	canceled, apiErr, status := srv.CancelRequest(context.TODO(), "req-1")
 	require.True(t, canceled)
 	require.Nil(t, apiErr)
 	require.Equal(t, http.StatusOK, status)
@@ -3452,7 +3451,7 @@ func TestServer_StreamMessage_EarlyResponses(t *testing.T) {
 
 	var nilSrv *Server
 	stream, apiErr, status := nilSrv.StreamMessage(
-		nil,
+		context.TODO(),
 		gwproto.MessageRequest{},
 	)
 	require.Nil(t, stream)
@@ -3792,7 +3791,7 @@ func TestSendProgressUpdateAndHelpers(t *testing.T) {
 		),
 	)
 	require.Len(t, collected, 2)
-	require.Equal(t, "stream canceled", contextErrMessage(nil))
+	require.Equal(t, "stream canceled", contextErrMessage(context.Background()))
 	require.Equal(
 		t,
 		context.Canceled.Error(),

--- a/openclaw/internal/octool/policy.go
+++ b/openclaw/internal/octool/policy.go
@@ -35,11 +35,23 @@ var (
 	)
 
 	sensitiveEnvRuntimeReadPatterns = []*regexp.Regexp{
-		regexp.MustCompile(`(?i)\bos\.environ(?:\.get\s*\(|\s*\[)`),
-		regexp.MustCompile(`(?i)\bos\.getenv\s*\(`),
-		regexp.MustCompile(`(?i)\bprocess\.env(?:\.[a-z0-9_]+|\s*\[)`),
-		regexp.MustCompile(`(?i)\bgetenv\s*\(`),
-		regexp.MustCompile(`(?i)\benv\s*\[`),
+		regexp.MustCompile(
+			`(?i)\bos\.environ\.get\s*\(\s*["']([a-z0-9_]+)["']`,
+		),
+		regexp.MustCompile(
+			`(?i)\bos\.environ\s*\[\s*["']([a-z0-9_]+)["']`,
+		),
+		regexp.MustCompile(
+			`(?i)\b(?:os\.)?getenv\s*\(\s*["']([a-z0-9_]+)["']`,
+		),
+		regexp.MustCompile(
+			`(?i)\b(?:os\.)?lookupenv\s*\(\s*["']([a-z0-9_]+)["']`,
+		),
+		regexp.MustCompile(`(?i)\bprocess\.env\.([a-z0-9_]+)\b`),
+		regexp.MustCompile(
+			`(?i)\bprocess\.env\s*\[\s*["']([a-z0-9_]+)["']`,
+		),
+		regexp.MustCompile(`(?i)\benv\s*\[\s*["']([a-z0-9_]+)["']`),
 	}
 
 	sensitivePathFragments = []string{
@@ -125,16 +137,22 @@ func newCommandRequest(params execParams) CommandRequest {
 }
 
 func blocksSensitiveEnv(command string) bool {
+	for _, pattern := range sensitiveEnvRuntimeReadPatterns {
+		matches := pattern.FindAllStringSubmatch(command, -1)
+		for _, match := range matches {
+			if len(match) < 2 {
+				continue
+			}
+			if sensitiveEnvNamePattern.MatchString(match[1]) {
+				return true
+			}
+		}
+	}
 	if !sensitiveEnvNamePattern.MatchString(command) {
 		return false
 	}
 	for _, hint := range sensitiveEnvReadHints {
 		if strings.Contains(command, hint) {
-			return true
-		}
-	}
-	for _, pattern := range sensitiveEnvRuntimeReadPatterns {
-		if pattern.MatchString(command) {
 			return true
 		}
 	}

--- a/openclaw/internal/octool/policy_test.go
+++ b/openclaw/internal/octool/policy_test.go
@@ -34,6 +34,39 @@ print(os.environ.get("OPENCLAW_MEMORY_FILE"))
 PY`))
 }
 
+func TestBlocksSensitivePath_BlocksSSHDirectoryAccess(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, blocksSensitivePath(`ls ~/.ssh/config`))
+}
+
+func TestBlocksSensitivePath_IgnoresEmbeddedDotEnvName(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, blocksSensitivePath(`cat /tmp/project.envfile`))
+}
+
+func TestContainsSensitivePathFragment_RequiresBoundaryBefore(t *testing.T) {
+	t.Parallel()
+
+	require.False(
+		t,
+		containsSensitivePathFragment(`cat prefix.bashrc`, `.bashrc`),
+	)
+}
+
+func TestSensitivePathBoundaryHelpers(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, hasSensitivePathBoundaryBefore(`.bashrc`, 0))
+	require.False(t, hasSensitivePathBoundaryBefore(`x.bashrc`, 1))
+
+	require.True(t, hasSensitivePathBoundaryAfter(`~/.ssh/config`, 6, `.ssh/`))
+	require.True(t, hasSensitivePathBoundaryAfter(`cat ~/.bashrc`, 13, `.bashrc`))
+	require.True(t, hasSensitivePathBoundaryAfter(`cat /tmp/.env.local`, 13, `.env`))
+	require.False(t, hasSensitivePathBoundaryAfter(`cat /tmp/.envfile`, 13, `.env`))
+}
+
 func TestBlocksSensitiveEnv_BlocksPythonSensitiveVarRead(t *testing.T) {
 	t.Parallel()
 
@@ -52,6 +85,50 @@ func TestBlocksSensitiveEnv_BlocksNodeSensitiveVarRead(t *testing.T) {
 			`node -e 'console.log(process.env.OPENAI_API_KEY)'`,
 		),
 	)
+}
+
+func TestBlocksSensitiveEnv_BlocksNodeBracketSensitiveVarRead(t *testing.T) {
+	t.Parallel()
+
+	require.True(
+		t,
+		blocksSensitiveEnv(
+			`node -e 'console.log(process.env["OPENAI_API_KEY"])'`,
+		),
+	)
+}
+
+func TestBlocksSensitiveEnv_BlocksGoLookupEnvSensitiveVarRead(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, blocksSensitiveEnv(`go run <<'EOF'
+package main
+
+import "os"
+
+func main() {
+	_, _ = os.LookupEnv("OPENAI_API_KEY")
+}
+EOF`))
+}
+
+func TestBlocksSensitiveEnv_AllowsSafeRuntimeReadWithSensitiveLocalNames(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	require.False(t, blocksSensitiveEnv(`python - <<'PY'
+import os
+token = "placeholder"
+api_key = "placeholder"
+print(os.environ.get("OPENCLAW_MEMORY_FILE"))
+PY`))
+}
+
+func TestBlocksSensitiveEnv_BlocksShellSensitiveExpansion(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, blocksSensitiveEnv(`echo $OPENAI_API_KEY`))
 }
 
 func TestChatCommandSafetyPolicy_AllowsPythonOsEnviron(t *testing.T) {
@@ -74,6 +151,23 @@ func TestChatCommandSafetyPolicy_BlocksPythonSensitiveEnvRead(t *testing.T) {
 import os
 print(os.environ.get("OPENAI_API_KEY"))
 PY`,
+	})
+	require.ErrorContains(t, err, reasonSensitiveEnv)
+}
+
+func TestChatCommandSafetyPolicy_BlocksGoLookupEnvSensitiveEnvRead(t *testing.T) {
+	t.Parallel()
+
+	err := NewChatCommandSafetyPolicy()(context.Background(), CommandRequest{
+		Command: `go run <<'EOF'
+package main
+
+import "os"
+
+func main() {
+	_, _ = os.LookupEnv("OPENAI_API_KEY")
+}
+EOF`,
 	})
 	require.ErrorContains(t, err, reasonSensitiveEnv)
 }

--- a/openclaw/internal/octool/tools_test.go
+++ b/openclaw/internal/octool/tools_test.go
@@ -775,7 +775,10 @@ func TestTools_NilManagers(t *testing.T) {
 func TestManager_ExecErrors(t *testing.T) {
 	mgr := NewManager()
 
-	_, err := mgr.Exec(nil, execParams{Command: "echo hi"})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := mgr.Exec(ctx, execParams{Command: "echo hi"})
 	require.Error(t, err)
 
 	_, err = mgr.Exec(context.Background(), execParams{})


### PR DESCRIPTION
## Summary
- split the octool policy work into a dedicated PR so the memory scope override change stays focused
- switch sensitive path detection to boundary-aware matching so `os.environ.get(\"OPENCLAW_MEMORY_FILE\")` no longer false-positives on `.env`
- block sensitive credential reads through runtime APIs such as Python `os.environ` and Node `process.env` while keeping non-sensitive memory file lookups working

## Test plan
- [x] `go test ./internal/octool`
