### PR TITLE
coderabbit: require bilingual review output

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -43,7 +43,7 @@ reviews:
     - "!**/*.o"
     - "!**/*.wasm"
 
-  high_level_summary_instructions: >-
+  high_level_summary_instructions: |-
     Please output a bilingual high-level summary.
     Show the English summary first.
     Wrap the Chinese translation in a Markdown-compatible HTML details block collapsed by default.


### PR DESCRIPTION
Switch CodeRabbit review output to English-first bilingual comments and summaries, collapse the Chinese translation by default, and translate the path-specific review guidance to English while keeping the framework-specific review intent intact.