### PR TITLE
server/a2a: dedupe structured task error payloads

### DIFF
--- a/docs/mkdocs/en/a2a-interaction.md
+++ b/docs/mkdocs/en/a2a-interaction.md
@@ -263,7 +263,8 @@ sequenceDiagram
 - `TaskStatusUpdateEvent` (submitted/completed): task lifecycle signals, no
   user content
 - `TaskStatusUpdateEvent` (failed/rejected/canceled) with structured error
-  metadata: terminal failure. Read outer metadata for machine branching and use
+  metadata: terminal failure. Read outer metadata first for machine branching,
+  treat `status.message.metadata` as the `0.1` compatibility mirror, and use
   `status.message.parts` only for display text.
 - `TaskArtifactUpdateEvent` with `lastChunk=true`: Stream end signal or aggregated result
 

--- a/docs/mkdocs/en/a2a-interaction.md
+++ b/docs/mkdocs/en/a2a-interaction.md
@@ -260,7 +260,11 @@ sequenceDiagram
 
 ### Client-Side Filtering Rules
 
-- `TaskStatusUpdateEvent` (submitted/completed): Task lifecycle signals, no user content
+- `TaskStatusUpdateEvent` (submitted/completed): task lifecycle signals, no
+  user content
+- `TaskStatusUpdateEvent` (failed/rejected/canceled) with structured error
+  metadata: terminal failure. Read outer metadata for machine branching and use
+  `status.message.parts` only for display text.
 - `TaskArtifactUpdateEvent` with `lastChunk=true`: Stream end signal or aggregated result
 
 ### Role of `llm_response_id`

--- a/docs/mkdocs/en/a2a.md
+++ b/docs/mkdocs/en/a2a.md
@@ -115,7 +115,8 @@ server, _ := a2aserver.New(
 Task state updates (`submitted`, `completed`) are still emitted as
 `TaskStatusUpdateEvent`. If `WithStructuredTaskErrors(true)` is enabled,
 terminal failures are also emitted as failed task status updates, with
-machine-readable fields on the outer metadata and display text in
+machine-readable fields preferred on the outer metadata, mirrored into
+`status.message.metadata` for `0.1` compatibility, and display text in
 `status.message.parts`.
 
 #### Direct A2A Protocol Client Call

--- a/docs/mkdocs/en/a2a.md
+++ b/docs/mkdocs/en/a2a.md
@@ -113,7 +113,10 @@ server, _ := a2aserver.New(
 ```
 
 Task state updates (`submitted`, `completed`) are still emitted as
-`TaskStatusUpdateEvent`.
+`TaskStatusUpdateEvent`. If `WithStructuredTaskErrors(true)` is enabled,
+terminal failures are also emitted as failed task status updates, with
+machine-readable fields on the outer metadata and display text in
+`status.message.parts`.
 
 #### Direct A2A Protocol Client Call
 

--- a/docs/mkdocs/en/error-handling.md
+++ b/docs/mkdocs/en/error-handling.md
@@ -777,6 +777,51 @@ With this option enabled:
 - only terminal errors become failed tasks; intermediate graph events such as
   `graph.node.error` continue to flow as graph observability events
 
+The payload is intentionally split into two layers:
+
+- outer `Task.Metadata` or `TaskStatusUpdateEvent.Metadata`: machine-readable
+  error fields such as `error_type`, `error_code`, `error_message`,
+  `task_state`, and `llm_response_id`
+- `Status.Message.Parts`: user-facing text to display directly
+- `Status.Message.Metadata`: left empty for structured task failures so the
+  same machine-readable fields are not mirrored a second time
+
+For example, a streaming terminal failure is shaped like this:
+
+```json
+{
+  "kind": "status-update",
+  "metadata": {
+    "object_type": "error",
+    "error_type": "flow_error",
+    "error_code": "REMOTE_VALIDATION_FAILED",
+    "error_message": "validation failed",
+    "task_state": "failed",
+    "llm_response_id": "resp-1"
+  },
+  "status": {
+    "state": "failed",
+    "message": {
+      "messageId": "resp-1",
+      "role": "agent",
+      "parts": [
+        {
+          "kind": "text",
+          "text": "validation failed"
+        }
+      ]
+    }
+  }
+}
+```
+
+That leads to a simple business-side rule:
+
+- branch on `status.state`
+- read structured fields from outer metadata
+- treat `status.message.parts` as display text, not as the primary source for
+  machine branching
+
 ### Client side
 
 `A2AAgent` recognizes those structured task failures automatically.
@@ -792,6 +837,13 @@ For failed, rejected, or canceled remote tasks, it now emits a normal
 In streaming mode, `A2AAgent` also stops emitting the synthetic final assistant
 message after a terminal task error. This avoids the ambiguous pattern of
 "error first, then normal final message".
+
+In other words, the default client path already follows the same rule:
+
+- outer metadata is used to rebuild `Response.Error`
+- `status.message.parts` is only a human-readable fallback channel
+- business code should keep branching on `evt.Response.Error`, not on parsed
+  text content
 
 Complete server and client setup:
 

--- a/docs/mkdocs/en/error-handling.md
+++ b/docs/mkdocs/en/error-handling.md
@@ -779,12 +779,12 @@ With this option enabled:
 
 The payload is intentionally split into two layers:
 
-- outer `Task.Metadata` or `TaskStatusUpdateEvent.Metadata`: machine-readable
-  error fields such as `error_type`, `error_code`, `error_message`,
-  `task_state`, and `llm_response_id`
+- outer `Task.Metadata` or `TaskStatusUpdateEvent.Metadata`: the preferred
+  machine-readable error fields such as `error_type`, `error_code`,
+  `error_message`, `task_state`, and `llm_response_id`
+- `Status.Message.Metadata`: the same machine-readable fields mirrored for A2A
+  interaction spec `0.1` compatibility
 - `Status.Message.Parts`: user-facing text to display directly
-- `Status.Message.Metadata`: left empty for structured task failures so the
-  same machine-readable fields are not mirrored a second time
 
 For example, a streaming terminal failure is shaped like this:
 
@@ -804,6 +804,14 @@ For example, a streaming terminal failure is shaped like this:
     "message": {
       "messageId": "resp-1",
       "role": "agent",
+      "metadata": {
+        "object_type": "error",
+        "error_type": "flow_error",
+        "error_code": "REMOTE_VALIDATION_FAILED",
+        "error_message": "validation failed",
+        "task_state": "failed",
+        "llm_response_id": "resp-1"
+      },
       "parts": [
         {
           "kind": "text",
@@ -818,7 +826,9 @@ For example, a streaming terminal failure is shaped like this:
 That leads to a simple business-side rule:
 
 - branch on `status.state`
-- read structured fields from outer metadata
+- read structured fields from outer metadata first
+- accept `status.message.metadata` as a compatibility mirror for legacy
+  consumers
 - treat `status.message.parts` as display text, not as the primary source for
   machine branching
 
@@ -840,7 +850,8 @@ message after a terminal task error. This avoids the ambiguous pattern of
 
 In other words, the default client path already follows the same rule:
 
-- outer metadata is used to rebuild `Response.Error`
+- outer metadata is the preferred source to rebuild `Response.Error`
+- `status.message.metadata` remains a compatibility mirror for `0.1`
 - `status.message.parts` is only a human-readable fallback channel
 - business code should keep branching on `evt.Response.Error`, not on parsed
   text content

--- a/docs/mkdocs/zh/a2a-interaction.md
+++ b/docs/mkdocs/zh/a2a-interaction.md
@@ -256,8 +256,9 @@ sequenceDiagram
 - `TaskStatusUpdateEvent`（submitted/completed）：任务生命周期信号，不含用户
   内容
 - 带 structured error metadata 的
-  `TaskStatusUpdateEvent`（failed/rejected/canceled）：终态失败。机器判断读取
-  外层 metadata，`status.message.parts` 只用于展示文本。
+  `TaskStatusUpdateEvent`（failed/rejected/canceled）：终态失败。机器判断优先读
+  外层 metadata，`status.message.metadata` 作为 `0.1` 的兼容镜像，
+  `status.message.parts` 只用于展示文本。
 - `TaskArtifactUpdateEvent` 且 `lastChunk=true`：流结束信号或聚合结果
 
 ### `llm_response_id` 的作用

--- a/docs/mkdocs/zh/a2a-interaction.md
+++ b/docs/mkdocs/zh/a2a-interaction.md
@@ -253,7 +253,11 @@ sequenceDiagram
 
 ### Client 端过滤规则
 
-- `TaskStatusUpdateEvent`（submitted/completed）：任务生命周期信号，不含用户内容
+- `TaskStatusUpdateEvent`（submitted/completed）：任务生命周期信号，不含用户
+  内容
+- 带 structured error metadata 的
+  `TaskStatusUpdateEvent`（failed/rejected/canceled）：终态失败。机器判断读取
+  外层 metadata，`status.message.parts` 只用于展示文本。
 - `TaskArtifactUpdateEvent` 且 `lastChunk=true`：流结束信号或聚合结果
 
 ### `llm_response_id` 的作用

--- a/docs/mkdocs/zh/a2a.md
+++ b/docs/mkdocs/zh/a2a.md
@@ -111,7 +111,8 @@ server, _ := a2aserver.New(
 
 任务状态更新（`submitted`、`completed`）仍然会以 `TaskStatusUpdateEvent` 的形式
 下发。如果开启 `WithStructuredTaskErrors(true)`，终态失败也会通过 failed
-`TaskStatusUpdateEvent` 下发：机器可读字段位于外层 metadata，展示文本位于
+`TaskStatusUpdateEvent` 下发：机器可读字段优先位于外层 metadata，并为了 `0.1`
+兼容继续镜像到 `status.message.metadata`，展示文本位于
 `status.message.parts`。
 
 #### 直接使用 A2A 协议客户端调用

--- a/docs/mkdocs/zh/a2a.md
+++ b/docs/mkdocs/zh/a2a.md
@@ -109,7 +109,10 @@ server, _ := a2aserver.New(
 )
 ```
 
-任务状态更新（`submitted`、`completed`）仍然会以 `TaskStatusUpdateEvent` 的形式下发。
+任务状态更新（`submitted`、`completed`）仍然会以 `TaskStatusUpdateEvent` 的形式
+下发。如果开启 `WithStructuredTaskErrors(true)`，终态失败也会通过 failed
+`TaskStatusUpdateEvent` 下发：机器可读字段位于外层 metadata，展示文本位于
+`status.message.parts`。
 
 #### 直接使用 A2A 协议客户端调用
 

--- a/docs/mkdocs/zh/error-handling.md
+++ b/docs/mkdocs/zh/error-handling.md
@@ -757,6 +757,50 @@ server, err := a2aserver.New(
 - 只有终态错误会转换成 failed task；`graph.node.error` 这类中间事件仍然按
   graph 事件继续透传
 
+这里的 payload 是按两层职责来组织的：
+
+- 外层 `Task.Metadata` 或 `TaskStatusUpdateEvent.Metadata`：机器可读的结构化
+  错误字段，例如 `error_type`、`error_code`、`error_message`、
+  `task_state`、`llm_response_id`
+- `Status.Message.Parts`：给人直接展示的文本
+- `Status.Message.Metadata`：对于 structured task failure 保持为空，避免把同一
+  份机器可读字段再镜像一遍
+
+一个 streaming 终态失败的 shape 大致如下：
+
+```json
+{
+  "kind": "status-update",
+  "metadata": {
+    "object_type": "error",
+    "error_type": "flow_error",
+    "error_code": "REMOTE_VALIDATION_FAILED",
+    "error_message": "validation failed",
+    "task_state": "failed",
+    "llm_response_id": "resp-1"
+  },
+  "status": {
+    "state": "failed",
+    "message": {
+      "messageId": "resp-1",
+      "role": "agent",
+      "parts": [
+        {
+          "kind": "text",
+          "text": "validation failed"
+        }
+      ]
+    }
+  }
+}
+```
+
+因此业务侧可以用一条稳定规则处理：
+
+- 用 `status.state` 判断任务终态
+- 用外层 metadata 读取结构化错误字段
+- `status.message.parts` 只作为展示文本，不作为机器判断的主来源
+
 ### Client 侧
 
 `A2AAgent` 会自动识别这类结构化 task failure。
@@ -771,6 +815,12 @@ server, err := a2aserver.New(
 
 在 streaming 模式下，`A2AAgent` 还会避免“先收到终态错误，再补一条正常 final
 assistant message”的歧义行为。
+
+换句话说，默认 client 路径已经遵循同一套规则：
+
+- 外层 metadata 用来重建 `Response.Error`
+- `status.message.parts` 只是给人读的兜底文本通道
+- 业务代码继续基于 `evt.Response.Error` 分支，而不是解析文本
 
 完整的 server / client 接入方式：
 

--- a/docs/mkdocs/zh/error-handling.md
+++ b/docs/mkdocs/zh/error-handling.md
@@ -759,12 +759,12 @@ server, err := a2aserver.New(
 
 这里的 payload 是按两层职责来组织的：
 
-- 外层 `Task.Metadata` 或 `TaskStatusUpdateEvent.Metadata`：机器可读的结构化
-  错误字段，例如 `error_type`、`error_code`、`error_message`、
-  `task_state`、`llm_response_id`
+- 外层 `Task.Metadata` 或 `TaskStatusUpdateEvent.Metadata`：推荐优先读取的
+  机器可读结构化错误字段，例如 `error_type`、`error_code`、
+  `error_message`、`task_state`、`llm_response_id`
+- `Status.Message.Metadata`：为了兼容 A2A interaction spec `0.1`，继续镜像
+  同一份机器可读字段
 - `Status.Message.Parts`：给人直接展示的文本
-- `Status.Message.Metadata`：对于 structured task failure 保持为空，避免把同一
-  份机器可读字段再镜像一遍
 
 一个 streaming 终态失败的 shape 大致如下：
 
@@ -784,6 +784,14 @@ server, err := a2aserver.New(
     "message": {
       "messageId": "resp-1",
       "role": "agent",
+      "metadata": {
+        "object_type": "error",
+        "error_type": "flow_error",
+        "error_code": "REMOTE_VALIDATION_FAILED",
+        "error_message": "validation failed",
+        "task_state": "failed",
+        "llm_response_id": "resp-1"
+      },
       "parts": [
         {
           "kind": "text",
@@ -798,7 +806,8 @@ server, err := a2aserver.New(
 因此业务侧可以用一条稳定规则处理：
 
 - 用 `status.state` 判断任务终态
-- 用外层 metadata 读取结构化错误字段
+- 优先用外层 metadata 读取结构化错误字段
+- `status.message.metadata` 只作为兼容旧客户端的镜像字段
 - `status.message.parts` 只作为展示文本，不作为机器判断的主来源
 
 ### Client 侧
@@ -818,7 +827,8 @@ assistant message”的歧义行为。
 
 换句话说，默认 client 路径已经遵循同一套规则：
 
-- 外层 metadata 用来重建 `Response.Error`
+- 外层 metadata 是重建 `Response.Error` 的首选来源
+- `status.message.metadata` 继续作为 `0.1` 的兼容镜像
 - `status.message.parts` 只是给人读的兜底文本通道
 - 业务代码继续基于 `evt.Response.Error` 分支，而不是解析文本
 

--- a/examples/a2aagent/error_handling/README.md
+++ b/examples/a2aagent/error_handling/README.md
@@ -39,7 +39,11 @@ With this option enabled:
 
 - unary requests return a failed `Task`
 - streaming requests emit a failed `TaskStatusUpdateEvent`
-- the task metadata keeps `error_type`, `error_code`, and `error_message`
+- outer task or status-event metadata keeps `error_type`, `error_code`,
+  `error_message`, and `task_state`
+- `status.message.parts` keeps the display text
+- `status.message.metadata` is intentionally left empty so structured fields are
+  not duplicated again
 
 ## Client-side setup
 
@@ -63,6 +67,46 @@ That means business code can keep one standard rule:
 - consume events
 - branch on `evt.Response.Error`
 - read `Type`, `Code`, and `Message`
+
+## How to read the remote payload
+
+Think of the remote failure payload as two channels:
+
+- machine channel: outer `Task.Metadata` or
+  `TaskStatusUpdateEvent.Metadata`
+- display channel: `status.message.parts`
+
+For a streaming failure, the payload is shaped like this:
+
+```json
+{
+  "kind": "status-update",
+  "metadata": {
+    "object_type": "error",
+    "error_type": "flow_error",
+    "error_code": "REMOTE_VALIDATION_FAILED",
+    "error_message": "validation failed",
+    "task_state": "failed"
+  },
+  "status": {
+    "state": "failed",
+    "message": {
+      "parts": [
+        {
+          "kind": "text",
+          "text": "validation failed"
+        }
+      ]
+    }
+  }
+}
+```
+
+The recommended business-side rule is therefore:
+
+- use `status.state` or reconstructed `evt.Response.Error` for branching
+- read structured fields from outer metadata
+- treat `status.message.parts` as text for logs, UI, or operator display
 
 ## Run the example
 

--- a/examples/a2aagent/error_handling/README.md
+++ b/examples/a2aagent/error_handling/README.md
@@ -41,9 +41,9 @@ With this option enabled:
 - streaming requests emit a failed `TaskStatusUpdateEvent`
 - outer task or status-event metadata keeps `error_type`, `error_code`,
   `error_message`, and `task_state`
+- `status.message.metadata` mirrors the same structured fields for A2A
+  interaction spec `0.1` compatibility
 - `status.message.parts` keeps the display text
-- `status.message.metadata` is intentionally left empty so structured fields are
-  not duplicated again
 
 ## Client-side setup
 
@@ -74,6 +74,7 @@ Think of the remote failure payload as two channels:
 
 - machine channel: outer `Task.Metadata` or
   `TaskStatusUpdateEvent.Metadata`
+- compatibility mirror: `status.message.metadata`
 - display channel: `status.message.parts`
 
 For a streaming failure, the payload is shaped like this:
@@ -91,6 +92,13 @@ For a streaming failure, the payload is shaped like this:
   "status": {
     "state": "failed",
     "message": {
+      "metadata": {
+        "object_type": "error",
+        "error_type": "flow_error",
+        "error_code": "REMOTE_VALIDATION_FAILED",
+        "error_message": "validation failed",
+        "task_state": "failed"
+      },
       "parts": [
         {
           "kind": "text",
@@ -105,7 +113,9 @@ For a streaming failure, the payload is shaped like this:
 The recommended business-side rule is therefore:
 
 - use `status.state` or reconstructed `evt.Response.Error` for branching
-- read structured fields from outer metadata
+- read structured fields from outer metadata first
+- treat `status.message.metadata` as a compatibility mirror for legacy
+  consumers
 - treat `status.message.parts` as text for logs, UI, or operator display
 
 ## Run the example

--- a/server/a2a/server.go
+++ b/server/a2a/server.go
@@ -292,6 +292,28 @@ func taskErrorState(
 	return protocol.TaskStateFailed
 }
 
+func buildTaskErrorMetadata(
+	agentEvent *event.Event,
+) map[string]any {
+	if agentEvent == nil || agentEvent.Response == nil {
+		return nil
+	}
+	respErr := agentEvent.Response.Error
+	if respErr == nil {
+		return nil
+	}
+
+	metadata := ia2a.WithResponseErrorMetadata(nil, respErr)
+	metadata[ia2a.MessageMetadataTaskStateKey] = string(
+		taskErrorState(respErr),
+	)
+	if agentEvent.Response.ID != "" {
+		metadata[ia2a.MessageMetadataResponseIDKey] =
+			agentEvent.Response.ID
+	}
+	return metadata
+}
+
 func buildTaskErrorMessage(
 	taskID string,
 	ctxID string,
@@ -315,17 +337,8 @@ func buildTaskErrorMessage(
 		&taskID,
 		&ctxID,
 	)
-	msg.Metadata = ia2a.WithResponseErrorMetadata(
-		msg.Metadata,
-		respErr,
-	)
-	msg.Metadata[ia2a.MessageMetadataTaskStateKey] = string(
-		taskErrorState(respErr),
-	)
 	if agentEvent.Response.ID != "" {
 		msg.MessageID = agentEvent.Response.ID
-		msg.Metadata[ia2a.MessageMetadataResponseIDKey] =
-			agentEvent.Response.ID
 	}
 	return &msg
 }
@@ -336,14 +349,16 @@ func buildStructuredFailureTask(
 	history []protocol.Message,
 	agentEvent *event.Event,
 ) *protocol.Task {
+	statusMsg := buildTaskErrorMessage(taskID, ctxID, agentEvent)
+	taskMetadata := buildTaskErrorMetadata(agentEvent)
 	task := protocol.NewTask(taskID, ctxID)
 	task.History = history
 	task.Status = protocol.TaskStatus{
 		State:     taskErrorState(agentEvent.Response.Error),
-		Message:   buildTaskErrorMessage(taskID, ctxID, agentEvent),
+		Message:   statusMsg,
 		Timestamp: time.Now().Format(time.RFC3339),
 	}
-	task.Metadata = task.Status.Message.Metadata
+	task.Metadata = taskMetadata
 	return task
 }
 

--- a/server/a2a/server.go
+++ b/server/a2a/server.go
@@ -98,6 +98,17 @@ func buildRuntimeState(metadata map[string]any) map[string]any {
 	return runtimeState
 }
 
+func cloneMetadata(metadata map[string]any) map[string]any {
+	if len(metadata) == 0 {
+		return nil
+	}
+	cloned := make(map[string]any, len(metadata))
+	for key, value := range metadata {
+		cloned[key] = value
+	}
+	return cloned
+}
+
 func buildProcessor(
 	agent agent.Agent,
 	sessionService session.Service,
@@ -318,6 +329,7 @@ func buildTaskErrorMessage(
 	taskID string,
 	ctxID string,
 	agentEvent *event.Event,
+	metadata map[string]any,
 ) *protocol.Message {
 	if agentEvent == nil || agentEvent.Response == nil {
 		return nil
@@ -337,6 +349,7 @@ func buildTaskErrorMessage(
 		&taskID,
 		&ctxID,
 	)
+	msg.Metadata = cloneMetadata(metadata)
 	if agentEvent.Response.ID != "" {
 		msg.MessageID = agentEvent.Response.ID
 	}
@@ -349,8 +362,13 @@ func buildStructuredFailureTask(
 	history []protocol.Message,
 	agentEvent *event.Event,
 ) *protocol.Task {
-	statusMsg := buildTaskErrorMessage(taskID, ctxID, agentEvent)
 	taskMetadata := buildTaskErrorMetadata(agentEvent)
+	statusMsg := buildTaskErrorMessage(
+		taskID,
+		ctxID,
+		agentEvent,
+		taskMetadata,
+	)
 	task := protocol.NewTask(taskID, ctxID)
 	task.History = history
 	task.Status = protocol.TaskStatus{

--- a/server/a2a/server_test.go
+++ b/server/a2a/server_test.go
@@ -3355,7 +3355,7 @@ func TestBuildTaskErrorMessage(t *testing.T) {
 	)
 
 	t.Run("nil event returns nil", func(t *testing.T) {
-		assert.Nil(t, buildTaskErrorMessage(taskID, ctxID, nil))
+		assert.Nil(t, buildTaskErrorMessage(taskID, ctxID, nil, nil))
 	})
 
 	t.Run("missing response returns nil", func(t *testing.T) {
@@ -3365,6 +3365,7 @@ func TestBuildTaskErrorMessage(t *testing.T) {
 				taskID,
 				ctxID,
 				&event.Event{},
+				nil,
 			),
 		)
 	})
@@ -3376,12 +3377,13 @@ func TestBuildTaskErrorMessage(t *testing.T) {
 			&event.Event{
 				Response: &model.Response{},
 			},
+			nil,
 		))
 	})
 
-	t.Run("response id and text are preserved without metadata", func(t *testing.T) {
+	t.Run("response id and text keep mirrored metadata", func(t *testing.T) {
 		const responseID = "resp-2"
-		msg := buildTaskErrorMessage(taskID, ctxID, &event.Event{
+		agentEvent := &event.Event{
 			Response: &model.Response{
 				ID: responseID,
 				Error: &model.ResponseError{
@@ -3389,11 +3391,29 @@ func TestBuildTaskErrorMessage(t *testing.T) {
 					Message: "task failed",
 				},
 			},
-		})
+		}
+		metadata := buildTaskErrorMetadata(agentEvent)
+		msg := buildTaskErrorMessage(
+			taskID,
+			ctxID,
+			agentEvent,
+			metadata,
+		)
 
 		if assert.NotNil(t, msg) {
 			assert.Equal(t, responseID, msg.MessageID)
-			assert.Nil(t, msg.Metadata)
+			if assert.NotNil(t, msg.Metadata) {
+				assert.Equal(
+					t,
+					metadata[ia2a.MessageMetadataErrorTypeKey],
+					msg.Metadata[ia2a.MessageMetadataErrorTypeKey],
+				)
+				assert.Equal(
+					t,
+					metadata[ia2a.MessageMetadataTaskStateKey],
+					msg.Metadata[ia2a.MessageMetadataTaskStateKey],
+				)
+			}
 			if assert.Len(t, msg.Parts, 1) {
 				var text string
 				switch part := msg.Parts[0].(type) {
@@ -3406,21 +3426,31 @@ func TestBuildTaskErrorMessage(t *testing.T) {
 					assert.Equal(t, "task failed", text)
 				}
 			}
+
+			metadata[ia2a.MessageMetadataErrorCodeKey] = "mutated"
+			_, ok := msg.Metadata[ia2a.MessageMetadataErrorCodeKey]
+			assert.False(t, ok)
 		}
 	})
 
 	t.Run("empty error message keeps empty parts", func(t *testing.T) {
-		msg := buildTaskErrorMessage(taskID, ctxID, &event.Event{
+		agentEvent := &event.Event{
 			Response: &model.Response{
 				Error: &model.ResponseError{
 					Type: model.ErrorTypeFlowError,
 				},
 			},
-		})
+		}
+		msg := buildTaskErrorMessage(
+			taskID,
+			ctxID,
+			agentEvent,
+			buildTaskErrorMetadata(agentEvent),
+		)
 
 		if assert.NotNil(t, msg) {
 			assert.NotEmpty(t, msg.MessageID)
-			assert.Nil(t, msg.Metadata)
+			assert.NotNil(t, msg.Metadata)
 			assert.Len(t, msg.Parts, 0)
 		}
 	})
@@ -3490,7 +3520,14 @@ func TestMessageProcessor_ProcessMessage_StructuredTaskError(
 	assert.NotNil(t, task.Metadata)
 	assert.Equal(t, code, task.Metadata[ia2a.MessageMetadataErrorCodeKey])
 	assert.NotNil(t, task.Status.Message)
-	assert.Nil(t, task.Status.Message.Metadata)
+	assert.Equal(
+		t,
+		task.Metadata[ia2a.MessageMetadataErrorCodeKey],
+		task.Status.Message.Metadata[ia2a.MessageMetadataErrorCodeKey],
+	)
+	task.Metadata["new_key"] = "task-only"
+	_, ok = task.Status.Message.Metadata["new_key"]
+	assert.False(t, ok)
 	assert.Len(t, task.Status.Message.Parts, 1)
 }
 
@@ -3636,7 +3673,13 @@ func TestMessageProcessor_ProcessBatchStreamingEvents_StructuredTaskError(
 			status.Metadata[ia2a.MessageMetadataErrorCodeKey],
 		)
 		if assert.NotNil(t, status.Status.Message) {
-			assert.Nil(t, status.Status.Message.Metadata)
+			messageMetadata := status.Status.Message.Metadata
+			messageCode := messageMetadata[ia2a.MessageMetadataErrorCodeKey]
+			assert.Equal(
+				t,
+				status.Metadata[ia2a.MessageMetadataErrorCodeKey],
+				messageCode,
+			)
 			assert.Len(t, status.Status.Message.Parts, 1)
 		}
 	default:
@@ -3717,7 +3760,13 @@ done:
 		status.Metadata[ia2a.MessageMetadataErrorCodeKey],
 	)
 	if assert.NotNil(t, status.Status.Message) {
-		assert.Nil(t, status.Status.Message.Metadata)
+		messageMetadata := status.Status.Message.Metadata
+		messageCode := messageMetadata[ia2a.MessageMetadataErrorCodeKey]
+		assert.Equal(
+			t,
+			status.Metadata[ia2a.MessageMetadataErrorCodeKey],
+			messageCode,
+		)
 		assert.Len(t, status.Status.Message.Parts, 1)
 	}
 }

--- a/server/a2a/server_test.go
+++ b/server/a2a/server_test.go
@@ -3267,6 +3267,165 @@ func TestMessageProcessor_ProcessMessage_MultipleEvents(t *testing.T) {
 	assert.Equal(t, 1, len(resultTask.Artifacts))
 }
 
+func TestBuildTaskErrorMetadata(t *testing.T) {
+	t.Run("nil event returns nil", func(t *testing.T) {
+		assert.Nil(t, buildTaskErrorMetadata(nil))
+	})
+
+	t.Run("missing response returns nil", func(t *testing.T) {
+		assert.Nil(
+			t,
+			buildTaskErrorMetadata(&event.Event{}),
+		)
+	})
+
+	t.Run("missing error returns nil", func(t *testing.T) {
+		assert.Nil(t, buildTaskErrorMetadata(&event.Event{
+			Response: &model.Response{},
+		}))
+	})
+
+	t.Run("flow error keeps failed metadata", func(t *testing.T) {
+		metadata := buildTaskErrorMetadata(&event.Event{
+			Response: &model.Response{
+				Error: &model.ResponseError{
+					Type:    model.ErrorTypeFlowError,
+					Message: "task failed",
+				},
+			},
+		})
+
+		if assert.NotNil(t, metadata) {
+			assert.Equal(
+				t,
+				model.ObjectTypeError,
+				metadata[ia2a.MessageMetadataObjectTypeKey],
+			)
+			assert.Equal(
+				t,
+				model.ErrorTypeFlowError,
+				metadata[ia2a.MessageMetadataErrorTypeKey],
+			)
+			assert.Equal(
+				t,
+				"task failed",
+				metadata[ia2a.MessageMetadataErrorMessageKey],
+			)
+			assert.Equal(
+				t,
+				string(protocol.TaskStateFailed),
+				metadata[ia2a.MessageMetadataTaskStateKey],
+			)
+			_, ok := metadata[ia2a.MessageMetadataResponseIDKey]
+			assert.False(t, ok)
+		}
+	})
+
+	t.Run("stop agent error keeps canceled state and response id", func(t *testing.T) {
+		const responseID = "resp-1"
+		metadata := buildTaskErrorMetadata(&event.Event{
+			Response: &model.Response{
+				ID: responseID,
+				Error: &model.ResponseError{
+					Type:    agent.ErrorTypeStopAgentError,
+					Message: "task canceled",
+				},
+			},
+		})
+
+		if assert.NotNil(t, metadata) {
+			assert.Equal(
+				t,
+				string(protocol.TaskStateCanceled),
+				metadata[ia2a.MessageMetadataTaskStateKey],
+			)
+			assert.Equal(
+				t,
+				responseID,
+				metadata[ia2a.MessageMetadataResponseIDKey],
+			)
+		}
+	})
+}
+
+func TestBuildTaskErrorMessage(t *testing.T) {
+	const (
+		taskID = "task-1"
+		ctxID  = "ctx-1"
+	)
+
+	t.Run("nil event returns nil", func(t *testing.T) {
+		assert.Nil(t, buildTaskErrorMessage(taskID, ctxID, nil))
+	})
+
+	t.Run("missing response returns nil", func(t *testing.T) {
+		assert.Nil(
+			t,
+			buildTaskErrorMessage(
+				taskID,
+				ctxID,
+				&event.Event{},
+			),
+		)
+	})
+
+	t.Run("missing error returns nil", func(t *testing.T) {
+		assert.Nil(t, buildTaskErrorMessage(
+			taskID,
+			ctxID,
+			&event.Event{
+				Response: &model.Response{},
+			},
+		))
+	})
+
+	t.Run("response id and text are preserved without metadata", func(t *testing.T) {
+		const responseID = "resp-2"
+		msg := buildTaskErrorMessage(taskID, ctxID, &event.Event{
+			Response: &model.Response{
+				ID: responseID,
+				Error: &model.ResponseError{
+					Type:    model.ErrorTypeFlowError,
+					Message: "task failed",
+				},
+			},
+		})
+
+		if assert.NotNil(t, msg) {
+			assert.Equal(t, responseID, msg.MessageID)
+			assert.Nil(t, msg.Metadata)
+			if assert.Len(t, msg.Parts, 1) {
+				var text string
+				switch part := msg.Parts[0].(type) {
+				case *protocol.TextPart:
+					text = part.Text
+				case protocol.TextPart:
+					text = part.Text
+				}
+				if assert.NotEmpty(t, text) {
+					assert.Equal(t, "task failed", text)
+				}
+			}
+		}
+	})
+
+	t.Run("empty error message keeps empty parts", func(t *testing.T) {
+		msg := buildTaskErrorMessage(taskID, ctxID, &event.Event{
+			Response: &model.Response{
+				Error: &model.ResponseError{
+					Type: model.ErrorTypeFlowError,
+				},
+			},
+		})
+
+		if assert.NotNil(t, msg) {
+			assert.NotEmpty(t, msg.MessageID)
+			assert.Nil(t, msg.Metadata)
+			assert.Len(t, msg.Parts, 0)
+		}
+	})
+}
+
 func TestMessageProcessor_ProcessMessage_StructuredTaskError(
 	t *testing.T,
 ) {

--- a/server/a2a/server_test.go
+++ b/server/a2a/server_test.go
@@ -3331,6 +3331,8 @@ func TestMessageProcessor_ProcessMessage_StructuredTaskError(
 	assert.NotNil(t, task.Metadata)
 	assert.Equal(t, code, task.Metadata[ia2a.MessageMetadataErrorCodeKey])
 	assert.NotNil(t, task.Status.Message)
+	assert.Nil(t, task.Status.Message.Metadata)
+	assert.Len(t, task.Status.Message.Parts, 1)
 }
 
 func TestMessageProcessor_ProcessMessage_MultipleEvents_PreservesArtifactMetadata(
@@ -3474,6 +3476,10 @@ func TestMessageProcessor_ProcessBatchStreamingEvents_StructuredTaskError(
 			code,
 			status.Metadata[ia2a.MessageMetadataErrorCodeKey],
 		)
+		if assert.NotNil(t, status.Status.Message) {
+			assert.Nil(t, status.Status.Message.Metadata)
+			assert.Len(t, status.Status.Message.Parts, 1)
+		}
 	default:
 		t.Fatal("expected task failure status event")
 	}
@@ -3551,6 +3557,10 @@ done:
 		code,
 		status.Metadata[ia2a.MessageMetadataErrorCodeKey],
 	)
+	if assert.NotNil(t, status.Status.Message) {
+		assert.Nil(t, status.Status.Message.Metadata)
+		assert.Len(t, status.Status.Message.Parts, 1)
+	}
 }
 
 func TestMessageProcessor_ProcessBatchStreamingEvents_GraphNodeErrorNotTerminal(


### PR DESCRIPTION
## Summary
- dedupe structured A2A terminal error payloads by keeping machine-readable fields only on the outer task or status metadata
- keep `status.message.parts` as the display channel and stop mirroring the same structured error metadata into `status.message.metadata`
- document the payload shape and branching rule in the English and Chinese A2A docs and the example README

## Root cause
The server built a structured error message and then reused that same metadata map as the outer task or status metadata. That made fields like `error_type`, `error_code`, `error_message`, and `task_state` appear twice in different layers of the same payload.

## Impact
- business code can branch on `status.state` plus outer metadata with a stable rule
- human-readable display text still lives in `status.message.parts`
- `A2AAgent` behavior stays compatible because it already rebuilds `Response.Error` from the outer metadata path

## Validation
- `go test ./server/a2a -run 'StructuredTaskError|StopAgentError'`
- `go test ./agent/a2aagent -run 'FailedStatus|FailedTask'`
- `go test ./internal/a2a`
- `go test ./...` hit an unrelated existing environment failure in `codeexecutor/local` where `TestRuntime_RunProgram_InjectsWorkspaceEnvs` observed the shell startup banner `=== Shell Startup ===` in stdout
