### PR TITLE
llmflow: harden context compaction rebuild

### DIFF
--- a/docs/mkdocs/en/session.md
+++ b/docs/mkdocs/en/session.md
@@ -283,15 +283,12 @@ Notes:
 
 **Context Injection Mechanism:**
 
-After enabling summary, the framework prepends the summary as a system message to the LLM input, while including all incremental events after the summary timestamp to ensure complete context:
+After enabling summary, the framework merges the summary into the existing system message when one exists, or prepends a new system message when none exists. It also includes all incremental events after the summary timestamp to ensure complete context:
 
-```
+```text
 ┌─────────────────────────────────────────┐
-│ System Prompt                           │
-├─────────────────────────────────────────┤
-│ Session Summary (system message)        │ ← Compressed version of historical conversations
-│ - Updated at: 2024-01-10 14:30          │   (events before updated_at)
-│ - Includes: Event1 ~ Event20            │
+│ System Prompt                           │ ← Existing system prompt, if present,
+│ (merged with Session Summary)           │    now merged with summary content
 ├─────────────────────────────────────────┤
 │ Event 21 (user message)                 │ ┐
 │ Event 22 (assistant response)           │ │
@@ -1819,7 +1816,7 @@ llmAgent := llmagent.New(
 
 **Context Construction Details:**
 
-```
+```text
 When AddSessionSummary = true:
 ┌─────────────────────────────────────┐
 │ System Prompt                       │ ← Existing system prompt, if present,

--- a/docs/mkdocs/zh/session.md
+++ b/docs/mkdocs/zh/session.md
@@ -284,7 +284,7 @@ summarizer := summary.NewSummarizer(
 
 启用摘要后，框架会将摘要合并到已有系统消息中；如果原来没有系统消息，则会前置插入一条新的系统消息。同时保留摘要时间点之后的所有增量事件，保证完整上下文：
 
-```
+```text
 When AddSessionSummary = true:
 ┌─────────────────────────────────────────┐
 │ System Prompt                           │ ← 若已存在系统消息，则与摘要合并；
@@ -1893,11 +1893,10 @@ agent := llmagent.New(
 
 **上下文结构：**
 
-```
+```text
 ┌─────────────────────────────────────────┐
-│ System Prompt                           │
-├─────────────────────────────────────────┤
-│ Session Summary (system message)        │ ← Compressed history
+│ System Prompt                           │ ← 若已存在系统消息，则与摘要合并；
+│ (merged with Session Summary)           │    否则前置插入新的系统消息
 ├─────────────────────────────────────────┤
 │ Event 1 (after summary)                 │ ┐
 │ Event 2                                 │ │

--- a/internal/flow/llmflow/context_compact_test.go
+++ b/internal/flow/llmflow/context_compact_test.go
@@ -10,6 +10,7 @@ package llmflow
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"sync"
 	"testing"
@@ -23,6 +24,8 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	"trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+	"trpc.group/trpc-go/trpc-agent-go/skill"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
 
 type summaryInjectingService struct {
@@ -178,6 +181,78 @@ func (m *compactingModel) GenerateContent(
 	ch := make(chan *model.Response)
 	close(ch)
 	return ch, nil
+}
+
+type toolsCheckingTailRequestProcessor struct {
+	sawNilTools         bool
+	sawStructuredOutput bool
+	sawStop             []string
+}
+
+func (p *toolsCheckingTailRequestProcessor) ProcessRequest(
+	_ context.Context,
+	_ *agent.Invocation,
+	_ *model.Request,
+	_ chan<- *event.Event,
+) {
+}
+
+func (p *toolsCheckingTailRequestProcessor) SupportsContextCompactionRebuild(
+	_ *agent.Invocation,
+) bool {
+	return true
+}
+
+func (p *toolsCheckingTailRequestProcessor) RebuildRequestForContextCompaction(
+	_ context.Context,
+	_ *agent.Invocation,
+	req *model.Request,
+) {
+	if req == nil {
+		return
+	}
+	if req.Tools == nil {
+		p.sawNilTools = true
+	}
+	p.sawStop = append([]string(nil), req.Stop...)
+	p.sawStructuredOutput = req.StructuredOutput != nil &&
+		req.StructuredOutput.JSONSchema != nil
+}
+
+type testSkillRepo struct {
+	skills map[string]*skill.Skill
+}
+
+func (r *testSkillRepo) Summaries() []skill.Summary {
+	if len(r.skills) == 0 {
+		return nil
+	}
+	out := make([]skill.Summary, 0, len(r.skills))
+	for _, sk := range r.skills {
+		if sk == nil {
+			continue
+		}
+		out = append(out, sk.Summary)
+	}
+	return out
+}
+
+func (r *testSkillRepo) Get(name string) (*skill.Skill, error) {
+	if r == nil || r.skills == nil {
+		return nil, errors.New("skill not found")
+	}
+	sk, ok := r.skills[name]
+	if !ok || sk == nil {
+		return nil, errors.New("skill not found")
+	}
+	return sk, nil
+}
+
+func (r *testSkillRepo) Path(name string) (string, error) {
+	if _, err := r.Get(name); err != nil {
+		return "", err
+	}
+	return "", nil
 }
 
 func TestMaybeCompactContextBeforeLLM_RebuildsRequestWithSummary(t *testing.T) {
@@ -621,6 +696,239 @@ func TestMaybeCompactContextBeforeLLM_RebuildsAfterPartialSummaryFailure(t *test
 	require.Equal(t, "current", rebuilt.Messages[1].Content)
 }
 
+func TestMaybeCompactContextBeforeLLM_RebuildPreservesPreContentRequestState(
+	t *testing.T,
+) {
+	modelName := "compact-retry-preserve-request-state"
+	model.RegisterModelContextWindow(modelName, 10000)
+
+	baseSvc := inmemory.NewSessionService()
+	t.Cleanup(func() {
+		require.NoError(t, baseSvc.Close())
+	})
+
+	service := &summaryInjectingService{Service: baseSvc}
+	tailProcessor := &toolsCheckingTailRequestProcessor{}
+	longContent := strings.Repeat("history ", 2000)
+	sess := &session.Session{
+		Events: []event.Event{{
+			RequestID: "req-old",
+			Timestamp: time.Now().Add(-time.Hour),
+			Response: &model.Response{
+				Done: true,
+				Choices: []model.Choice{{
+					Message: model.NewUserMessage(longContent),
+				}},
+			},
+		}},
+	}
+
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationSessionService(service),
+		agent.WithInvocationMessage(model.NewUserMessage("current")),
+		agent.WithInvocationRunOptions(agent.RunOptions{RequestID: "req-current"}),
+		agent.WithInvocationModel(&compactingModel{name: modelName}),
+		agent.WithInvocationEventFilterKey("branch/test"),
+	)
+
+	f := New(
+		[]flow.RequestProcessor{
+			processor.NewContentRequestProcessor(
+				processor.WithAddSessionSummary(true),
+			),
+			tailProcessor,
+		},
+		nil,
+		Options{
+			EnableContextCompaction:         true,
+			ContextCompactionThresholdRatio: 0.2,
+		},
+	)
+
+	req := &model.Request{
+		GenerationConfig: model.GenerationConfig{
+			Stop: []string{"DONE"},
+		},
+		StructuredOutput: &model.StructuredOutput{
+			Type: model.StructuredOutputJSONSchema,
+			JSONSchema: &model.JSONSchemaConfig{
+				Name:   "result",
+				Schema: map[string]any{"type": "object"},
+			},
+		},
+	}
+	rebuildPlan := f.preprocess(context.Background(), inv, req, nil)
+
+	rebuilt := f.maybeCompactContextBeforeLLM(
+		context.Background(),
+		inv,
+		req,
+		rebuildPlan,
+	)
+
+	require.Equal(t, 1, service.Calls())
+	require.NotSame(t, req, rebuilt)
+	require.False(t, tailProcessor.sawNilTools)
+	require.Equal(t, []string{"DONE"}, tailProcessor.sawStop)
+	require.True(t, tailProcessor.sawStructuredOutput)
+	require.Equal(t, []string{"DONE"}, rebuilt.Stop)
+	require.NotNil(t, rebuilt.StructuredOutput)
+	require.Equal(t, "result", rebuilt.StructuredOutput.JSONSchema.Name)
+	require.Equal(
+		t,
+		"object",
+		rebuilt.StructuredOutput.JSONSchema.Schema["type"],
+	)
+}
+
+func TestMaybeCompactContextBeforeLLM_RebuildsWithSkillsToolResultTailWhenSafe(
+	t *testing.T,
+) {
+	modelName := "compact-retry-skills-tail-safe"
+	model.RegisterModelContextWindow(modelName, 10000)
+
+	baseSvc := inmemory.NewSessionService()
+	t.Cleanup(func() {
+		require.NoError(t, baseSvc.Close())
+	})
+
+	service := &summaryInjectingService{Service: baseSvc}
+	repo := &testSkillRepo{
+		skills: map[string]*skill.Skill{
+			"calc": {
+				Summary: skill.Summary{Name: "calc", Description: "math"},
+				Body:    "calculator skill body",
+			},
+		},
+	}
+	longContent := strings.Repeat("history ", 2000)
+	sess := &session.Session{
+		State: session.StateMap{
+			skill.LoadedKey("tester", "calc"): []byte("1"),
+		},
+		Events: []event.Event{{
+			RequestID: "req-old",
+			Timestamp: time.Now().Add(-time.Hour),
+			Response: &model.Response{
+				Done: true,
+				Choices: []model.Choice{{
+					Message: model.NewUserMessage(longContent),
+				}},
+			},
+		}},
+	}
+
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationSessionService(service),
+		agent.WithInvocationMessage(model.NewUserMessage("current")),
+		agent.WithInvocationRunOptions(agent.RunOptions{RequestID: "req-current"}),
+		agent.WithInvocationModel(&compactingModel{name: modelName}),
+		agent.WithInvocationEventFilterKey("branch/test"),
+	)
+	inv.AgentName = "tester"
+
+	f := New(
+		[]flow.RequestProcessor{
+			processor.NewContentRequestProcessor(
+				processor.WithAddSessionSummary(true),
+			),
+			processor.NewSkillsToolResultRequestProcessor(
+				repo,
+				processor.WithSkillsToolResultLoadMode(processor.SkillLoadModeTurn),
+			),
+		},
+		nil,
+		Options{
+			EnableContextCompaction:         true,
+			ContextCompactionThresholdRatio: 0.2,
+		},
+	)
+
+	req := &model.Request{
+		Messages: []model.Message{
+			{
+				Role: model.RoleAssistant,
+				ToolCalls: []model.ToolCall{{
+					Type: "function",
+					ID:   "tc1",
+					Function: model.FunctionDefinitionParam{
+						Name:      "skill_load",
+						Arguments: []byte(`{"skill":"calc"}`),
+					},
+				}},
+			},
+			{
+				Role:     model.RoleTool,
+				ToolName: "skill_load",
+				ToolID:   "tc1",
+				Content:  "loaded: calc",
+			},
+		},
+	}
+	rebuildPlan := f.preprocess(context.Background(), inv, req, nil)
+	require.NotNil(t, rebuildPlan)
+
+	rebuilt := f.maybeCompactContextBeforeLLM(
+		context.Background(),
+		inv,
+		req,
+		rebuildPlan,
+	)
+
+	require.Equal(t, 1, service.Calls())
+	require.NotSame(t, req, rebuilt)
+	require.Len(t, rebuildPlan.tailProcessors, 1)
+	var rebuiltToolContent string
+	for _, msg := range rebuilt.Messages {
+		if msg.Role == model.RoleTool && msg.ToolName == "skill_load" {
+			rebuiltToolContent = msg.Content
+			break
+		}
+	}
+	require.Contains(t, rebuiltToolContent, "[Loaded] calc")
+	require.Contains(t, rebuiltToolContent, "calculator skill body")
+}
+
+func TestPreprocess_SkipsSkillsToolResultTailWhenLoadModeOnceIsActive(
+	t *testing.T,
+) {
+	repo := &testSkillRepo{
+		skills: map[string]*skill.Skill{
+			"calc": {
+				Summary: skill.Summary{Name: "calc"},
+				Body:    "calculator skill body",
+			},
+		},
+	}
+	inv := &agent.Invocation{
+		AgentName: "tester",
+		Session: &session.Session{
+			State: session.StateMap{
+				skill.LoadedKey("tester", "calc"): []byte("1"),
+			},
+		},
+	}
+
+	f := New(
+		[]flow.RequestProcessor{
+			processor.NewContentRequestProcessor(
+				processor.WithAddSessionSummary(true),
+			),
+			processor.NewSkillsToolResultRequestProcessor(
+				repo,
+				processor.WithSkillsToolResultLoadMode(processor.SkillLoadModeOnce),
+			),
+		},
+		nil,
+		Options{EnableContextCompaction: true},
+	)
+
+	rebuildPlan := f.preprocess(context.Background(), inv, &model.Request{}, nil)
+	require.Nil(t, rebuildPlan)
+}
+
 func TestMaybeCompactContextBeforeLLM_InitialGuards(t *testing.T) {
 	f := New(
 		[]flow.RequestProcessor{
@@ -669,6 +977,44 @@ func TestMaybeCompactContextBeforeLLM_InitialGuards(t *testing.T) {
 		req,
 		nil,
 	))
+}
+
+func TestRebuildRequestForContextCompaction_PopulatesFilteredTools(t *testing.T) {
+	f := New(nil, nil, Options{EnableContextCompaction: true})
+	inv := agent.NewInvocation(
+		agent.WithInvocationAgent(&minimalAgent{
+			tools: []tool.Tool{
+				&mockLongRunnerTool{name: "search"},
+			},
+		}),
+		agent.WithInvocationSession(&session.Session{}),
+	)
+	tailProcessor := &toolsCheckingTailRequestProcessor{}
+	rebuildPlan := &contextCompactionRebuildPlan{
+		beforeContent: &model.Request{},
+		contentProcessor: processor.NewContentRequestProcessor(
+			processor.WithAddSessionSummary(true),
+		),
+		tailProcessors: []contextCompactionTailProcessor{
+			tailProcessor,
+		},
+	}
+
+	require.Nil(t, f.rebuildRequestForContextCompaction(
+		context.Background(),
+		inv,
+		nil,
+	))
+
+	rebuilt := f.rebuildRequestForContextCompaction(
+		context.Background(),
+		inv,
+		rebuildPlan,
+	)
+
+	require.NotNil(t, rebuilt)
+	require.False(t, tailProcessor.sawNilTools)
+	require.Contains(t, rebuilt.Tools, "search")
 }
 
 func TestSupportsSyncSummaryRetry(t *testing.T) {
@@ -773,4 +1119,108 @@ func TestShouldSyncCompactContext(t *testing.T) {
 	require.True(t, shouldSyncCompactContext(context.Background(), inv, &model.Request{
 		Messages: []model.Message{model.NewUserMessage(strings.Repeat("a", 5000))},
 	}, 0.5))
+}
+
+func TestCloneRequestForContextCompaction_DeepCopiesMutableFields(t *testing.T) {
+	require.Nil(t, cloneRequestForContextCompaction(nil))
+
+	text := "hello"
+	index := 3
+	req := &model.Request{
+		Messages: []model.Message{{
+			Role: model.RoleUser,
+			ContentParts: []model.ContentPart{{
+				Type: model.ContentTypeText,
+				Text: &text,
+			}, {
+				Type: model.ContentTypeImage,
+				Image: &model.Image{
+					URL:    "https://example.com/a.png",
+					Data:   []byte{1, 2, 3},
+					Detail: "high",
+				},
+			}, {
+				Type: model.ContentTypeAudio,
+				Audio: &model.Audio{
+					Data:   []byte{4, 5, 6},
+					Format: "wav",
+				},
+			}, {
+				Type: model.ContentTypeFile,
+				File: &model.File{
+					Name: "test.txt",
+					Data: []byte("abc"),
+				},
+			}},
+			ToolCalls: []model.ToolCall{{
+				Type: "function",
+				ID:   "call-1",
+				Function: model.FunctionDefinitionParam{
+					Name:      "search",
+					Arguments: []byte(`{"q":"go"}`),
+				},
+				Index: &index,
+				ExtraFields: map[string]any{
+					"nested": map[string]any{"k": "v"},
+				},
+			}},
+		}},
+		GenerationConfig: model.GenerationConfig{
+			Stop: []string{"DONE"},
+		},
+		StructuredOutput: &model.StructuredOutput{
+			Type: model.StructuredOutputJSONSchema,
+			JSONSchema: &model.JSONSchemaConfig{
+				Name:   "schema",
+				Schema: map[string]any{"type": "object"},
+			},
+		},
+		Tools: map[string]tool.Tool{},
+	}
+
+	cloned := cloneRequestForContextCompaction(req)
+	require.NotNil(t, cloned)
+	require.NotSame(t, req, cloned)
+
+	req.Messages[0].ContentParts[0].Text = nil
+	req.Messages[0].ContentParts[1].Image.Data[0] = 9
+	req.Messages[0].ContentParts[2].Audio.Data[0] = 8
+	req.Messages[0].ContentParts[3].File.Data[0] = 'z'
+	req.Messages[0].ToolCalls[0].Function.Arguments[0] = '['
+	req.Messages[0].ToolCalls[0].ExtraFields["nested"] = map[string]any{"k": "changed"}
+	req.Messages[0].ToolCalls[0].Index = nil
+	req.Stop[0] = "STOP"
+	req.StructuredOutput.JSONSchema.Schema["type"] = "array"
+	req.Tools["search"] = nil
+
+	require.NotNil(t, cloned.Messages[0].ContentParts[0].Text)
+	require.Equal(t, "hello", *cloned.Messages[0].ContentParts[0].Text)
+	require.Equal(t, []byte{1, 2, 3}, cloned.Messages[0].ContentParts[1].Image.Data)
+	require.Equal(t, []byte{4, 5, 6}, cloned.Messages[0].ContentParts[2].Audio.Data)
+	require.Equal(t, []byte("abc"), cloned.Messages[0].ContentParts[3].File.Data)
+	require.Equal(
+		t,
+		[]byte(`{"q":"go"}`),
+		cloned.Messages[0].ToolCalls[0].Function.Arguments,
+	)
+	require.Equal(
+		t,
+		map[string]any{"nested": map[string]any{"k": "v"}},
+		cloned.Messages[0].ToolCalls[0].ExtraFields,
+	)
+	require.NotNil(t, cloned.Messages[0].ToolCalls[0].Index)
+	require.Equal(t, 3, *cloned.Messages[0].ToolCalls[0].Index)
+	require.Equal(t, []string{"DONE"}, cloned.Stop)
+	require.Equal(
+		t,
+		"object",
+		cloned.StructuredOutput.JSONSchema.Schema["type"],
+	)
+	require.Empty(t, cloned.Tools)
+	fallbackCloned := cloneJSONMapForContextCompaction(
+		map[string]any{"bad": make(chan int)},
+	)
+	_, ok := fallbackCloned["bad"].(chan int)
+	require.True(t, ok)
+	require.Nil(t, cloneJSONMapForContextCompaction(nil))
 }

--- a/internal/flow/llmflow/context_compact_test.go
+++ b/internal/flow/llmflow/context_compact_test.go
@@ -84,6 +84,85 @@ func (s *summaryFailingService) Calls() int {
 	return s.calls
 }
 
+type summaryPartialFailureService struct {
+	session.Service
+	mu    sync.Mutex
+	calls int
+	err   error
+}
+
+func (s *summaryPartialFailureService) CreateSessionSummary(
+	_ context.Context,
+	sess *session.Session,
+	filterKey string,
+	_ bool,
+) error {
+	s.mu.Lock()
+	s.calls++
+	s.mu.Unlock()
+
+	sess.SummariesMu.Lock()
+	defer sess.SummariesMu.Unlock()
+	if sess.Summaries == nil {
+		sess.Summaries = make(map[string]*session.Summary)
+	}
+	sess.Summaries[filterKey] = &session.Summary{
+		Summary:   "compressed despite persistence failure",
+		UpdatedAt: time.Now().Add(time.Minute),
+	}
+	return s.err
+}
+
+func (s *summaryPartialFailureService) Calls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+type countingRequestProcessor struct {
+	mu       sync.Mutex
+	calls    int
+	messages []model.Message
+}
+
+func (p *countingRequestProcessor) ProcessRequest(
+	_ context.Context,
+	_ *agent.Invocation,
+	req *model.Request,
+	_ chan<- *event.Event,
+) {
+	p.mu.Lock()
+	p.calls++
+	p.mu.Unlock()
+	if req == nil {
+		return
+	}
+	req.Messages = append(req.Messages, p.messages...)
+}
+
+func (p *countingRequestProcessor) Calls() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.calls
+}
+
+type unsafeTailRequestProcessor struct {
+	calls int
+}
+
+func (p *unsafeTailRequestProcessor) ProcessRequest(
+	_ context.Context,
+	_ *agent.Invocation,
+	req *model.Request,
+	_ chan<- *event.Event,
+) {
+	p.calls++
+	if req == nil {
+		return
+	}
+	req.Messages = append(req.Messages, model.NewSystemMessage("unsafe tail"))
+}
+
 type compactingModel struct {
 	name string
 }
@@ -150,7 +229,7 @@ func TestMaybeCompactContextBeforeLLM_RebuildsRequestWithSummary(t *testing.T) {
 	)
 
 	req := &model.Request{}
-	f.preprocess(context.Background(), inv, req, nil)
+	rebuildPlan := f.preprocess(context.Background(), inv, req, nil)
 	require.Len(t, req.Messages, 2)
 	require.Contains(t, req.Messages[0].Content, longContent)
 
@@ -158,6 +237,7 @@ func TestMaybeCompactContextBeforeLLM_RebuildsRequestWithSummary(t *testing.T) {
 		context.Background(),
 		inv,
 		req,
+		rebuildPlan,
 	)
 
 	require.Equal(t, 1, service.Calls())
@@ -200,11 +280,12 @@ func TestMaybeCompactContextBeforeLLM_SkipsWithoutSummaryAwareProcessor(t *testi
 	)
 
 	req := &model.Request{}
-	f.preprocess(context.Background(), inv, req, nil)
+	rebuildPlan := f.preprocess(context.Background(), inv, req, nil)
 	rebuilt := f.maybeCompactContextBeforeLLM(
 		context.Background(),
 		inv,
 		req,
+		rebuildPlan,
 	)
 
 	require.Equal(t, 0, service.Calls())
@@ -262,12 +343,13 @@ func TestMaybeCompactContextBeforeLLM_SkipsWhenSummaryInjectionDisabled(t *testi
 	)
 
 	req := &model.Request{}
-	f.preprocess(context.Background(), inv, req, nil)
+	rebuildPlan := f.preprocess(context.Background(), inv, req, nil)
 
 	rebuilt := f.maybeCompactContextBeforeLLM(
 		context.Background(),
 		inv,
 		req,
+		rebuildPlan,
 	)
 
 	require.Equal(t, 0, service.Calls())
@@ -326,16 +408,217 @@ func TestMaybeCompactContextBeforeLLM_SkipsWhenSummaryRefreshFails(t *testing.T)
 	)
 
 	req := &model.Request{}
-	f.preprocess(context.Background(), inv, req, nil)
+	rebuildPlan := f.preprocess(context.Background(), inv, req, nil)
 
 	rebuilt := f.maybeCompactContextBeforeLLM(
 		context.Background(),
 		inv,
 		req,
+		rebuildPlan,
 	)
 
 	require.Equal(t, 1, service.Calls())
 	require.Same(t, req, rebuilt)
+}
+
+func TestMaybeCompactContextBeforeLLM_RebuildsWithoutReplayingEarlierProcessors(t *testing.T) {
+	modelName := "compact-retry-safe-rebuild"
+	model.RegisterModelContextWindow(modelName, 10000)
+
+	baseSvc := inmemory.NewSessionService()
+	t.Cleanup(func() {
+		require.NoError(t, baseSvc.Close())
+	})
+
+	service := &summaryInjectingService{Service: baseSvc}
+	prefixProcessor := &countingRequestProcessor{
+		messages: []model.Message{model.NewSystemMessage("prefix guidance")},
+	}
+	longContent := strings.Repeat("history ", 2000)
+	sess := &session.Session{
+		Events: []event.Event{{
+			RequestID: "req-old",
+			Timestamp: time.Now().Add(-time.Hour),
+			Response: &model.Response{
+				Done: true,
+				Choices: []model.Choice{{
+					Message: model.NewUserMessage(longContent),
+				}},
+			},
+		}},
+	}
+
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationSessionService(service),
+		agent.WithInvocationMessage(model.NewUserMessage("current")),
+		agent.WithInvocationRunOptions(agent.RunOptions{RequestID: "req-current"}),
+		agent.WithInvocationModel(&compactingModel{name: modelName}),
+		agent.WithInvocationEventFilterKey("branch/test"),
+	)
+
+	f := New(
+		[]flow.RequestProcessor{
+			prefixProcessor,
+			processor.NewContentRequestProcessor(
+				processor.WithAddSessionSummary(true),
+			),
+			processor.NewTimeRequestProcessor(
+				processor.WithAddCurrentTime(true),
+			),
+		},
+		nil,
+		Options{
+			EnableContextCompaction:         true,
+			ContextCompactionThresholdRatio: 0.2,
+		},
+	)
+
+	req := &model.Request{}
+	rebuildPlan := f.preprocess(context.Background(), inv, req, nil)
+	require.Equal(t, 1, prefixProcessor.Calls())
+
+	rebuilt := f.maybeCompactContextBeforeLLM(
+		context.Background(),
+		inv,
+		req,
+		rebuildPlan,
+	)
+
+	require.Equal(t, 1, prefixProcessor.Calls())
+	require.Equal(t, 1, service.Calls())
+	require.NotSame(t, req, rebuilt)
+	require.Contains(t, rebuilt.Messages[0].Content, "prefix guidance")
+	require.Contains(t, rebuilt.Messages[0].Content, "compressed history")
+	require.Contains(t, rebuilt.Messages[0].Content, "The current time is:")
+	require.Equal(t, "current", rebuilt.Messages[len(rebuilt.Messages)-1].Content)
+}
+
+func TestMaybeCompactContextBeforeLLM_SkipsWhenUnsafeTailProcessorPresent(t *testing.T) {
+	modelName := "compact-retry-unsafe-tail"
+	model.RegisterModelContextWindow(modelName, 10000)
+
+	baseSvc := inmemory.NewSessionService()
+	t.Cleanup(func() {
+		require.NoError(t, baseSvc.Close())
+	})
+
+	service := &summaryInjectingService{Service: baseSvc}
+	longContent := strings.Repeat("history ", 2000)
+	sess := &session.Session{
+		Events: []event.Event{{
+			RequestID: "req-old",
+			Timestamp: time.Now().Add(-time.Hour),
+			Response: &model.Response{
+				Done: true,
+				Choices: []model.Choice{{
+					Message: model.NewUserMessage(longContent),
+				}},
+			},
+		}},
+	}
+
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationSessionService(service),
+		agent.WithInvocationMessage(model.NewUserMessage("current")),
+		agent.WithInvocationRunOptions(agent.RunOptions{RequestID: "req-current"}),
+		agent.WithInvocationModel(&compactingModel{name: modelName}),
+		agent.WithInvocationEventFilterKey("branch/test"),
+	)
+
+	f := New(
+		[]flow.RequestProcessor{
+			processor.NewContentRequestProcessor(
+				processor.WithAddSessionSummary(true),
+			),
+			&unsafeTailRequestProcessor{},
+		},
+		nil,
+		Options{
+			EnableContextCompaction:         true,
+			ContextCompactionThresholdRatio: 0.2,
+		},
+	)
+
+	req := &model.Request{}
+	rebuildPlan := f.preprocess(context.Background(), inv, req, nil)
+	require.Nil(t, rebuildPlan)
+
+	rebuilt := f.maybeCompactContextBeforeLLM(
+		context.Background(),
+		inv,
+		req,
+		rebuildPlan,
+	)
+
+	require.Equal(t, 0, service.Calls())
+	require.Same(t, req, rebuilt)
+}
+
+func TestMaybeCompactContextBeforeLLM_RebuildsAfterPartialSummaryFailure(t *testing.T) {
+	modelName := "compact-retry-partial-summary-error"
+	model.RegisterModelContextWindow(modelName, 10000)
+
+	baseSvc := inmemory.NewSessionService()
+	t.Cleanup(func() {
+		require.NoError(t, baseSvc.Close())
+	})
+
+	service := &summaryPartialFailureService{
+		Service: baseSvc,
+		err:     context.DeadlineExceeded,
+	}
+	longContent := strings.Repeat("history ", 2000)
+	sess := &session.Session{
+		Events: []event.Event{{
+			RequestID: "req-old",
+			Timestamp: time.Now().Add(-time.Hour),
+			Response: &model.Response{
+				Done: true,
+				Choices: []model.Choice{{
+					Message: model.NewUserMessage(longContent),
+				}},
+			},
+		}},
+	}
+
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationSessionService(service),
+		agent.WithInvocationMessage(model.NewUserMessage("current")),
+		agent.WithInvocationRunOptions(agent.RunOptions{RequestID: "req-current"}),
+		agent.WithInvocationModel(&compactingModel{name: modelName}),
+		agent.WithInvocationEventFilterKey("branch/test"),
+	)
+
+	f := New(
+		[]flow.RequestProcessor{
+			processor.NewContentRequestProcessor(
+				processor.WithAddSessionSummary(true),
+			),
+		},
+		nil,
+		Options{
+			EnableContextCompaction:         true,
+			ContextCompactionThresholdRatio: 0.2,
+		},
+	)
+
+	req := &model.Request{}
+	rebuildPlan := f.preprocess(context.Background(), inv, req, nil)
+
+	rebuilt := f.maybeCompactContextBeforeLLM(
+		context.Background(),
+		inv,
+		req,
+		rebuildPlan,
+	)
+
+	require.Equal(t, 1, service.Calls())
+	require.NotSame(t, req, rebuilt)
+	require.Contains(t, rebuilt.Messages[0].Content, "compressed despite persistence failure")
+	require.Equal(t, "current", rebuilt.Messages[1].Content)
 }
 
 func TestMaybeCompactContextBeforeLLM_InitialGuards(t *testing.T) {
@@ -361,21 +644,22 @@ func TestMaybeCompactContextBeforeLLM_InitialGuards(t *testing.T) {
 		require.NoError(t, inv.SessionService.Close())
 	})
 
-	require.Nil(t, f.maybeCompactContextBeforeLLM(context.Background(), inv, nil))
+	require.Nil(t, f.maybeCompactContextBeforeLLM(context.Background(), inv, nil, nil))
 
 	disabled := New(
 		f.requestProcessors,
 		nil,
 		Options{EnableContextCompaction: false},
 	)
-	require.Same(t, req, disabled.maybeCompactContextBeforeLLM(context.Background(), inv, req))
-	require.Same(t, req, f.maybeCompactContextBeforeLLM(context.Background(), nil, req))
+	require.Same(t, req, disabled.maybeCompactContextBeforeLLM(context.Background(), inv, req, nil))
+	require.Same(t, req, f.maybeCompactContextBeforeLLM(context.Background(), nil, req, nil))
 	require.Same(t, req, f.maybeCompactContextBeforeLLM(
 		context.Background(),
 		agent.NewInvocation(
 			agent.WithInvocationSessionService(inmemory.NewSessionService()),
 		),
 		req,
+		nil,
 	))
 	require.Same(t, req, f.maybeCompactContextBeforeLLM(
 		context.Background(),
@@ -383,6 +667,7 @@ func TestMaybeCompactContextBeforeLLM_InitialGuards(t *testing.T) {
 			agent.WithInvocationSession(&session.Session{}),
 		),
 		req,
+		nil,
 	))
 }
 

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -33,6 +33,7 @@ import (
 	itrace "trpc.group/trpc-go/trpc-agent-go/internal/trace"
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 	"trpc.group/trpc-go/trpc-agent-go/tool/function"
 )
@@ -80,6 +81,26 @@ type Flow struct {
 	syncSummaryIntraRun             bool
 	enableContextCompaction         bool
 	contextCompactionThresholdRatio float64
+}
+
+type contextCompactionTailProcessor interface {
+	RebuildRequestForContextCompaction(
+		ctx context.Context,
+		invocation *agent.Invocation,
+		req *model.Request,
+	)
+}
+
+type contextCompactionRebuildPlan struct {
+	beforeContent    *model.Request
+	contentProcessor *processor.ContentRequestProcessor
+	tailProcessors   []contextCompactionTailProcessor
+}
+
+type summarySnapshot struct {
+	exists    bool
+	summary   string
+	updatedAt time.Time
 }
 
 // New creates a new basic flow instance with the provided processors.
@@ -447,11 +468,16 @@ func (f *Flow) runOneStep(
 		Tools: make(map[string]tool.Tool), // Initialize tools map
 	}
 	// 1. Preprocess (prepare request).
-	f.preprocess(ctx, invocation, llmRequest, eventChan)
+	rebuildPlan := f.preprocess(ctx, invocation, llmRequest, eventChan)
 	if invocation.EndInvocation {
 		return lastEvent, nil
 	}
-	llmRequest = f.maybeCompactContextBeforeLLM(ctx, invocation, llmRequest)
+	llmRequest = f.maybeCompactContextBeforeLLM(
+		ctx,
+		invocation,
+		llmRequest,
+		rebuildPlan,
+	)
 	if invocation.EndInvocation {
 		return lastEvent, nil
 	}
@@ -845,10 +871,30 @@ func (f *Flow) preprocess(
 	invocation *agent.Invocation,
 	llmRequest *model.Request,
 	eventChan chan<- *event.Event,
-) {
+) *contextCompactionRebuildPlan {
+	var rebuildPlan *contextCompactionRebuildPlan
+
 	// Run request processors - they send events directly to the channel.
-	for _, processor := range f.requestProcessors {
-		processor.ProcessRequest(ctx, invocation, llmRequest, eventChan)
+	for _, requestProcessor := range f.requestProcessors {
+		if rebuildPlan == nil {
+			contentProcessor, ok := requestProcessor.(*processor.ContentRequestProcessor)
+			if ok &&
+				contentProcessor.AddSessionSummary &&
+				contentProcessor.TimelineFilterMode == processor.TimelineFilterAll {
+				rebuildPlan = &contextCompactionRebuildPlan{
+					beforeContent:    cloneRequestForContextCompaction(llmRequest),
+					contentProcessor: contentProcessor,
+				}
+			}
+		} else {
+			tailProcessor, ok := requestProcessor.(contextCompactionTailProcessor)
+			if !ok {
+				rebuildPlan = nil
+			} else {
+				rebuildPlan.tailProcessors = append(rebuildPlan.tailProcessors, tailProcessor)
+			}
+		}
+		requestProcessor.ProcessRequest(ctx, invocation, llmRequest, eventChan)
 	}
 	// Add tools to the request with optional filtering.
 	if invocation.Agent != nil {
@@ -859,6 +905,7 @@ func (f *Flow) preprocess(
 	}
 	// Sanitize invalid tool calls in history to avoid poisoning future requests.
 	llmRequest.Messages = toolcall.SanitizeMessagesWithTools(llmRequest.Messages, llmRequest.Tools)
+	return rebuildPlan
 }
 
 func normalizeContextCompactionThresholdRatio(ratio float64) float64 {
@@ -872,10 +919,12 @@ func (f *Flow) maybeCompactContextBeforeLLM(
 	ctx context.Context,
 	invocation *agent.Invocation,
 	req *model.Request,
+	rebuildPlan *contextCompactionRebuildPlan,
 ) *model.Request {
 	if req == nil || !f.enableContextCompaction || invocation == nil ||
 		invocation.Session == nil || invocation.SessionService == nil ||
-		!f.supportsSyncSummaryRetry() {
+		!f.supportsSyncSummaryRetry() || rebuildPlan == nil ||
+		rebuildPlan.beforeContent == nil || rebuildPlan.contentProcessor == nil {
 		return req
 	}
 	if !shouldSyncCompactContext(
@@ -887,19 +936,49 @@ func (f *Flow) maybeCompactContextBeforeLLM(
 		return req
 	}
 
-	if err := invocation.SessionService.CreateSessionSummary(
+	filterKey := invocation.GetEventFilterKey()
+	before := snapshotSummary(invocation.Session, filterKey)
+	err := invocation.SessionService.CreateSessionSummary(
 		ctx,
 		invocation.Session,
-		invocation.GetEventFilterKey(),
+		filterKey,
 		false,
-	); err != nil {
+	)
+	after := snapshotSummary(invocation.Session, filterKey)
+	if !before.advanced(after) {
+		if err != nil {
+			log.DebugfContext(
+				ctx,
+				"Pre-LLM context compaction skipped for agent %s: %v",
+				invocation.AgentName,
+				err,
+			)
+		}
+		return req
+	}
+
+	rebuilt := f.rebuildRequestForContextCompaction(
+		ctx,
+		invocation,
+		rebuildPlan,
+	)
+	if rebuilt == nil {
 		log.DebugfContext(
 			ctx,
-			"Pre-LLM context compaction skipped for agent %s: %v",
+			"Pre-LLM context compaction skipped for agent %s: safe rebuild unavailable",
+			invocation.AgentName,
+		)
+		return req
+	}
+
+	if err != nil {
+		log.WarnfContext(
+			ctx,
+			"Pre-LLM context compaction rebuilt request for agent %s after in-memory summary update; persistence failed: %v",
 			invocation.AgentName,
 			err,
 		)
-		return req
+		return rebuilt
 	}
 
 	log.DebugfContext(
@@ -907,11 +986,43 @@ func (f *Flow) maybeCompactContextBeforeLLM(
 		"Pre-LLM context compaction rebuilt request for agent %s",
 		invocation.AgentName,
 	)
+	return rebuilt
+}
 
-	rebuilt := &model.Request{
-		Tools: make(map[string]tool.Tool),
+func (f *Flow) rebuildRequestForContextCompaction(
+	ctx context.Context,
+	invocation *agent.Invocation,
+	rebuildPlan *contextCompactionRebuildPlan,
+) *model.Request {
+	if rebuildPlan == nil || rebuildPlan.beforeContent == nil ||
+		rebuildPlan.contentProcessor == nil {
+		return nil
 	}
-	f.preprocess(ctx, invocation, rebuilt, nil)
+
+	rebuilt := cloneRequestForContextCompaction(rebuildPlan.beforeContent)
+	if rebuilt == nil {
+		return nil
+	}
+	rebuildPlan.contentProcessor.ProcessRequest(ctx, invocation, rebuilt, nil)
+	for _, tailProcessor := range rebuildPlan.tailProcessors {
+		tailProcessor.RebuildRequestForContextCompaction(
+			ctx,
+			invocation,
+			rebuilt,
+		)
+	}
+	if rebuilt.Tools == nil {
+		rebuilt.Tools = make(map[string]tool.Tool)
+	}
+	if invocation.Agent != nil {
+		for _, t := range f.getFilteredTools(ctx, invocation) {
+			rebuilt.Tools[t.Declaration().Name] = t
+		}
+	}
+	rebuilt.Messages = toolcall.SanitizeMessagesWithTools(
+		rebuilt.Messages,
+		rebuilt.Tools,
+	)
 	return rebuilt
 }
 
@@ -927,6 +1038,57 @@ func (f *Flow) supportsSyncSummaryRetry() bool {
 		}
 	}
 	return false
+}
+
+func cloneRequestForContextCompaction(req *model.Request) *model.Request {
+	if req == nil {
+		return nil
+	}
+
+	cloned := &model.Request{
+		Messages:         append([]model.Message(nil), req.Messages...),
+		GenerationConfig: req.GenerationConfig,
+		StructuredOutput: req.StructuredOutput,
+	}
+	if len(req.Tools) > 0 {
+		cloned.Tools = make(map[string]tool.Tool, len(req.Tools))
+		for name, t := range req.Tools {
+			cloned.Tools[name] = t
+		}
+	}
+	return cloned
+}
+
+func snapshotSummary(sess *session.Session, filterKey string) summarySnapshot {
+	if sess == nil {
+		return summarySnapshot{}
+	}
+
+	sess.SummariesMu.RLock()
+	defer sess.SummariesMu.RUnlock()
+
+	summary := sess.Summaries[filterKey]
+	if summary == nil {
+		return summarySnapshot{}
+	}
+	return summarySnapshot{
+		exists:    true,
+		summary:   summary.Summary,
+		updatedAt: summary.UpdatedAt,
+	}
+}
+
+func (s summarySnapshot) advanced(next summarySnapshot) bool {
+	if !next.exists {
+		return false
+	}
+	if !s.exists {
+		return true
+	}
+	if next.updatedAt.After(s.updatedAt) {
+		return true
+	}
+	return next.summary != s.summary
 }
 
 func shouldSyncCompactContext(

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -84,6 +84,9 @@ type Flow struct {
 }
 
 type contextCompactionTailProcessor interface {
+	SupportsContextCompactionRebuild(
+		invocation *agent.Invocation,
+	) bool
 	RebuildRequestForContextCompaction(
 		ctx context.Context,
 		invocation *agent.Invocation,
@@ -888,7 +891,8 @@ func (f *Flow) preprocess(
 			}
 		} else {
 			tailProcessor, ok := requestProcessor.(contextCompactionTailProcessor)
-			if !ok {
+			if !ok ||
+				!tailProcessor.SupportsContextCompactionRebuild(invocation) {
 				rebuildPlan = nil
 			} else {
 				rebuildPlan.tailProcessors = append(rebuildPlan.tailProcessors, tailProcessor)
@@ -1003,6 +1007,9 @@ func (f *Flow) rebuildRequestForContextCompaction(
 	if rebuilt == nil {
 		return nil
 	}
+	if rebuilt.Tools == nil {
+		rebuilt.Tools = make(map[string]tool.Tool)
+	}
 	rebuildPlan.contentProcessor.ProcessRequest(ctx, invocation, rebuilt, nil)
 	for _, tailProcessor := range rebuildPlan.tailProcessors {
 		tailProcessor.RebuildRequestForContextCompaction(
@@ -1010,9 +1017,6 @@ func (f *Flow) rebuildRequestForContextCompaction(
 			invocation,
 			rebuilt,
 		)
-	}
-	if rebuilt.Tools == nil {
-		rebuilt.Tools = make(map[string]tool.Tool)
 	}
 	if invocation.Agent != nil {
 		for _, t := range f.getFilteredTools(ctx, invocation) {
@@ -1045,16 +1049,161 @@ func cloneRequestForContextCompaction(req *model.Request) *model.Request {
 		return nil
 	}
 
-	cloned := &model.Request{
-		Messages:         append([]model.Message(nil), req.Messages...),
-		GenerationConfig: req.GenerationConfig,
-		StructuredOutput: req.StructuredOutput,
-	}
-	if len(req.Tools) > 0 {
+	cloned := *req
+	cloned.Messages = cloneMessagesForContextCompaction(req.Messages)
+	cloned.GenerationConfig = cloneGenerationConfigForContextCompaction(
+		req.GenerationConfig,
+	)
+	cloned.StructuredOutput = cloneStructuredOutputForContextCompaction(
+		req.StructuredOutput,
+	)
+	if req.Tools != nil {
 		cloned.Tools = make(map[string]tool.Tool, len(req.Tools))
 		for name, t := range req.Tools {
 			cloned.Tools[name] = t
 		}
+	}
+	return &cloned
+}
+
+func cloneMessagesForContextCompaction(msgs []model.Message) []model.Message {
+	if msgs == nil {
+		return nil
+	}
+
+	cloned := make([]model.Message, len(msgs))
+	for i := range msgs {
+		cloned[i] = cloneMessageForContextCompaction(msgs[i])
+	}
+	return cloned
+}
+
+func cloneMessageForContextCompaction(msg model.Message) model.Message {
+	cloned := msg
+	cloned.ContentParts = cloneContentPartsForContextCompaction(
+		msg.ContentParts,
+	)
+	cloned.ToolCalls = cloneToolCallsForContextCompaction(msg.ToolCalls)
+	return cloned
+}
+
+func cloneContentPartsForContextCompaction(
+	parts []model.ContentPart,
+) []model.ContentPart {
+	if parts == nil {
+		return nil
+	}
+
+	cloned := make([]model.ContentPart, len(parts))
+	for i := range parts {
+		cloned[i] = cloneContentPartForContextCompaction(parts[i])
+	}
+	return cloned
+}
+
+func cloneContentPartForContextCompaction(
+	part model.ContentPart,
+) model.ContentPart {
+	cloned := part
+	if part.Text != nil {
+		text := *part.Text
+		cloned.Text = &text
+	}
+	if part.Image != nil {
+		image := *part.Image
+		if part.Image.Data != nil {
+			image.Data = append([]byte(nil), part.Image.Data...)
+		}
+		cloned.Image = &image
+	}
+	if part.Audio != nil {
+		audio := *part.Audio
+		if part.Audio.Data != nil {
+			audio.Data = append([]byte(nil), part.Audio.Data...)
+		}
+		cloned.Audio = &audio
+	}
+	if part.File != nil {
+		file := *part.File
+		if part.File.Data != nil {
+			file.Data = append([]byte(nil), part.File.Data...)
+		}
+		cloned.File = &file
+	}
+	return cloned
+}
+
+func cloneToolCallsForContextCompaction(
+	toolCalls []model.ToolCall,
+) []model.ToolCall {
+	if toolCalls == nil {
+		return nil
+	}
+
+	cloned := make([]model.ToolCall, len(toolCalls))
+	for i := range toolCalls {
+		cloned[i] = toolCalls[i]
+		if toolCalls[i].Function.Arguments != nil {
+			cloned[i].Function.Arguments = append(
+				[]byte(nil),
+				toolCalls[i].Function.Arguments...,
+			)
+		}
+		if toolCalls[i].Index != nil {
+			index := *toolCalls[i].Index
+			cloned[i].Index = &index
+		}
+		cloned[i].ExtraFields = cloneJSONMapForContextCompaction(
+			toolCalls[i].ExtraFields,
+		)
+	}
+	return cloned
+}
+
+func cloneGenerationConfigForContextCompaction(
+	cfg model.GenerationConfig,
+) model.GenerationConfig {
+	cloned := cfg
+	if cfg.Stop != nil {
+		cloned.Stop = append([]string(nil), cfg.Stop...)
+	}
+	return cloned
+}
+
+func cloneStructuredOutputForContextCompaction(
+	out *model.StructuredOutput,
+) *model.StructuredOutput {
+	if out == nil {
+		return nil
+	}
+
+	cloned := *out
+	if out.JSONSchema != nil {
+		schema := *out.JSONSchema
+		schema.Schema = cloneJSONMapForContextCompaction(out.JSONSchema.Schema)
+		cloned.JSONSchema = &schema
+	}
+	return &cloned
+}
+
+func cloneJSONMapForContextCompaction(
+	src map[string]any,
+) map[string]any {
+	if src == nil {
+		return nil
+	}
+
+	raw, err := json.Marshal(src)
+	if err == nil {
+		var cloned map[string]any
+		if err = json.Unmarshal(raw, &cloned); err == nil {
+			return cloned
+		}
+	}
+
+	cloned := make(map[string]any, len(src))
+	for k, v := range src {
+		cloned[k] = v
 	}
 	return cloned
 }

--- a/internal/flow/processor/posttool.go
+++ b/internal/flow/processor/posttool.go
@@ -104,6 +104,16 @@ func (p *PostToolRequestProcessor) ProcessRequest(
 	}
 }
 
+// RebuildRequestForContextCompaction re-applies post-tool prompting during the
+// safe sync-summary rebuild path without replaying the full processor chain.
+func (p *PostToolRequestProcessor) RebuildRequestForContextCompaction(
+	ctx context.Context,
+	invocation *agent.Invocation,
+	req *model.Request,
+) {
+	p.ProcessRequest(ctx, invocation, req, nil)
+}
+
 // hasPendingToolResultMessages returns true when the latest non-system message
 // in the request is a tool result. Historical tool results that are followed
 // by assistant or user messages do not count as pending.

--- a/internal/flow/processor/posttool.go
+++ b/internal/flow/processor/posttool.go
@@ -104,6 +104,14 @@ func (p *PostToolRequestProcessor) ProcessRequest(
 	}
 }
 
+// SupportsContextCompactionRebuild reports that post-tool prompting can be
+// safely replayed during the sync-summary rebuild path.
+func (p *PostToolRequestProcessor) SupportsContextCompactionRebuild(
+	_ *agent.Invocation,
+) bool {
+	return true
+}
+
 // RebuildRequestForContextCompaction re-applies post-tool prompting during the
 // safe sync-summary rebuild path without replaying the full processor chain.
 func (p *PostToolRequestProcessor) RebuildRequestForContextCompaction(

--- a/internal/flow/processor/posttool_test.go
+++ b/internal/flow/processor/posttool_test.go
@@ -182,6 +182,29 @@ func TestPostToolRequestProcessor_NoSystemMessage(t *testing.T) {
 	assert.Equal(t, model.RoleUser, req.Messages[1].Role)
 }
 
+func TestPostToolRequestProcessor_RebuildRequestForContextCompaction(
+	t *testing.T,
+) {
+	p := NewPostToolRequestProcessor()
+	req := &model.Request{
+		Messages: []model.Message{
+			model.NewSystemMessage("You are helpful."),
+			model.NewToolMessage("call_1", "search", "result"),
+		},
+	}
+
+	require.True(t, p.SupportsContextCompactionRebuild(&agent.Invocation{}))
+
+	p.RebuildRequestForContextCompaction(
+		context.Background(),
+		&agent.Invocation{},
+		req,
+	)
+
+	require.Len(t, req.Messages, 2)
+	assert.Contains(t, req.Messages[0].Content, "[Tool Prompt]")
+}
+
 func TestHasPendingToolResultMessages(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/flow/processor/skills_test.go
+++ b/internal/flow/processor/skills_test.go
@@ -1859,6 +1859,123 @@ func TestSkillsToolResultRequestProcessor_SessionSummary_AllowsFallback(
 	require.Equal(t, 1, matchCount)
 }
 
+func TestSkillsToolResultRequestProcessor_SupportsContextCompactionRebuild(
+	t *testing.T,
+) {
+	repo := &mockRepo{
+		sums: []skill.Summary{{Name: "calc", Description: "math"}},
+		full: map[string]*skill.Skill{
+			"calc": {Summary: skill.Summary{Name: "calc"}, Body: "B"},
+		},
+	}
+
+	t.Run("turn mode supports rebuild", func(t *testing.T) {
+		p := NewSkillsToolResultRequestProcessor(
+			repo,
+			WithSkillsToolResultLoadMode(SkillLoadModeTurn),
+		)
+		inv := &agent.Invocation{
+			AgentName: "tester",
+			Session: &session.Session{
+				State: session.StateMap{
+					skill.LoadedKey("tester", "calc"): []byte("1"),
+				},
+			},
+		}
+		require.True(t, p.SupportsContextCompactionRebuild(inv))
+	})
+
+	t.Run("once mode blocks rebuild when loaded skills exist", func(t *testing.T) {
+		p := NewSkillsToolResultRequestProcessor(
+			repo,
+			WithSkillsToolResultLoadMode(SkillLoadModeOnce),
+		)
+		inv := &agent.Invocation{
+			AgentName: "tester",
+			Session: &session.Session{
+				State: session.StateMap{
+					skill.LoadedKey("tester", "calc"): []byte("1"),
+				},
+			},
+		}
+		require.False(t, p.SupportsContextCompactionRebuild(inv))
+	})
+
+	t.Run("once mode stays safe when nothing is loaded", func(t *testing.T) {
+		p := NewSkillsToolResultRequestProcessor(
+			repo,
+			WithSkillsToolResultLoadMode(SkillLoadModeOnce),
+		)
+		inv := &agent.Invocation{
+			AgentName: "tester",
+			Session:   &session.Session{State: session.StateMap{}},
+		}
+		require.True(t, p.SupportsContextCompactionRebuild(inv))
+	})
+}
+
+func TestSkillsToolResultRequestProcessor_RebuildRequestForContextCompaction(
+	t *testing.T,
+) {
+	repo := &mockRepo{
+		sums: []skill.Summary{{Name: "calc", Description: "math"}},
+		full: map[string]*skill.Skill{
+			"calc": {Summary: skill.Summary{Name: "calc"}, Body: "B"},
+		},
+	}
+	inv := &agent.Invocation{
+		InvocationID: "inv1",
+		AgentName:    "tester",
+		Session: &session.Session{
+			State: session.StateMap{
+				skill.LoadedKey("tester", "calc"): []byte("1"),
+			},
+		},
+	}
+
+	args, err := json.Marshal(skillNameInput{Skill: "calc"})
+	require.NoError(t, err)
+
+	req := &model.Request{
+		Messages: []model.Message{
+			model.NewSystemMessage("sys"),
+			{
+				Role: model.RoleAssistant,
+				ToolCalls: []model.ToolCall{{
+					Type: "function",
+					ID:   "tc1",
+					Function: model.FunctionDefinitionParam{
+						Name:      skillToolLoad,
+						Arguments: args,
+					},
+				}},
+			},
+			{
+				Role:     model.RoleTool,
+				ToolName: skillToolLoad,
+				ToolID:   "tc1",
+				Content:  loadedPrefix + " calc",
+			},
+		},
+	}
+
+	p := NewSkillsToolResultRequestProcessor(
+		repo,
+		WithSkillsToolResultLoadMode(SkillLoadModeTurn),
+	)
+	p.RebuildRequestForContextCompaction(
+		context.Background(),
+		inv,
+		req,
+	)
+
+	require.Contains(t, req.Messages[2].Content, "[Loaded] calc")
+	require.Contains(t, req.Messages[2].Content, "B")
+	loaded, ok := inv.Session.GetState(skill.LoadedKey("tester", "calc"))
+	require.True(t, ok)
+	require.Equal(t, []byte("1"), loaded)
+}
+
 func TestHasSessionSummary(t *testing.T) {
 	require.False(t, hasSessionSummary(nil))
 

--- a/internal/flow/processor/skills_tool_result.go
+++ b/internal/flow/processor/skills_tool_result.go
@@ -136,11 +136,51 @@ func (p *SkillsToolResultRequestProcessor) ProcessRequest(
 	}
 
 	maybeMigrateLegacySkillState(ctx, inv, ch)
+	loaded := p.applyLoadedSkillContext(ctx, inv, req, repo)
+	p.maybeOffloadLoadedSkills(ctx, inv, loaded, ch)
+}
 
+// SupportsContextCompactionRebuild reports whether loaded skill materialization
+// can be safely replayed during the sync-summary rebuild path.
+func (p *SkillsToolResultRequestProcessor) SupportsContextCompactionRebuild(
+	inv *agent.Invocation,
+) bool {
+	if p.loadMode != SkillLoadModeOnce {
+		return true
+	}
+	if inv == nil || inv.Session == nil {
+		return true
+	}
+	return len(p.getLoadedSkills(inv)) == 0
+}
+
+// RebuildRequestForContextCompaction reapplies loaded skill materialization
+// without mutating session state during the sync-summary rebuild path.
+func (p *SkillsToolResultRequestProcessor) RebuildRequestForContextCompaction(
+	ctx context.Context,
+	inv *agent.Invocation,
+	req *model.Request,
+) {
+	if req == nil || inv == nil || inv.Session == nil {
+		return
+	}
+	repo := p.repositoryForInvocation(inv)
+	if repo == nil {
+		return
+	}
+	p.applyLoadedSkillContext(ctx, inv, req, repo)
+}
+
+func (p *SkillsToolResultRequestProcessor) applyLoadedSkillContext(
+	ctx context.Context,
+	inv *agent.Invocation,
+	req *model.Request,
+	repo skill.Repository,
+) []string {
 	loaded := p.getLoadedSkills(inv)
 	if len(loaded) == 0 {
 		p.removeLoadedContextMessage(req)
-		return
+		return nil
 	}
 	sort.Strings(loaded) // stable prompt order
 
@@ -186,8 +226,7 @@ func (p *SkillsToolResultRequestProcessor) ProcessRequest(
 	} else {
 		p.upsertLoadedContextMessage(req, fallbackContent)
 	}
-
-	p.maybeOffloadLoadedSkills(ctx, inv, loaded, ch)
+	return loaded
 }
 
 func (p *SkillsToolResultRequestProcessor) repositoryForInvocation(

--- a/internal/flow/processor/time.go
+++ b/internal/flow/processor/time.go
@@ -106,6 +106,14 @@ func (p *TimeRequestProcessor) ProcessRequest(
 	p.addTimeToSystemMessage(req, timeContent)
 }
 
+// SupportsContextCompactionRebuild reports that time decoration can be safely
+// replayed during the sync-summary rebuild path.
+func (p *TimeRequestProcessor) SupportsContextCompactionRebuild(
+	_ *agent.Invocation,
+) bool {
+	return true
+}
+
 // RebuildRequestForContextCompaction re-applies time decoration during the
 // safe sync-summary rebuild path without replaying the full processor chain.
 func (p *TimeRequestProcessor) RebuildRequestForContextCompaction(

--- a/internal/flow/processor/time.go
+++ b/internal/flow/processor/time.go
@@ -106,6 +106,16 @@ func (p *TimeRequestProcessor) ProcessRequest(
 	p.addTimeToSystemMessage(req, timeContent)
 }
 
+// RebuildRequestForContextCompaction re-applies time decoration during the
+// safe sync-summary rebuild path without replaying the full processor chain.
+func (p *TimeRequestProcessor) RebuildRequestForContextCompaction(
+	ctx context.Context,
+	invocation *agent.Invocation,
+	req *model.Request,
+) {
+	p.ProcessRequest(ctx, invocation, req, nil)
+}
+
 // getCurrentTime returns the current time string with timezone support.
 func (p *TimeRequestProcessor) getCurrentTime() string {
 	var loc *time.Location

--- a/internal/flow/processor/time_test.go
+++ b/internal/flow/processor/time_test.go
@@ -164,6 +164,32 @@ func TestTimeRequestProcessor_ProcessRequest_WithExistingSystemMessage(t *testin
 	}
 }
 
+func TestTimeRequestProcessor_RebuildRequestForContextCompaction(t *testing.T) {
+	processor := NewTimeRequestProcessor(WithAddCurrentTime(true))
+	req := &model.Request{
+		Messages: []model.Message{
+			model.NewSystemMessage("Existing system message"),
+		},
+	}
+
+	if !processor.SupportsContextCompactionRebuild(&agent.Invocation{}) {
+		t.Fatal("expected rebuild support")
+	}
+
+	processor.RebuildRequestForContextCompaction(
+		context.Background(),
+		&agent.Invocation{},
+		req,
+	)
+
+	if len(req.Messages) != 1 {
+		t.Fatalf("Expected 1 message, got %d", len(req.Messages))
+	}
+	if !strings.Contains(req.Messages[0].Content, "The current time is:") {
+		t.Fatalf("Expected time content to be added, got: %s", req.Messages[0].Content)
+	}
+}
+
 func TestTimeRequestProcessor_ProcessRequest_AppendsToLastSystem(
 	t *testing.T,
 ) {


### PR DESCRIPTION
## Summary

Follow-up to #1564.

- rebuild pre-LLM context compaction from the request state captured before `ContentRequestProcessor` instead of replaying the full request processor chain
- skip sync summary retry when post-content processors are not safe to rebuild, and keep using advanced in-memory summaries even if persistence fails after `CreateSessionSummary`
- align the EN/ZH session docs with the merged-summary contract and add language tags to the affected diagram fences

## Testing

- go test ./internal/flow/llmflow ./internal/flow/processor`
- go test ./agent/llmagent ./agent/graphagent`
