### PR TITLE
openclaw: scope MEMORY.md file tools to user memory

### DIFF
--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -670,6 +670,7 @@ func NewRuntime(
 			SkillsToolingGuide: opts.SkillsToolingGuide,
 			KnowledgesConfig:   opts.KnowledgesConfig,
 			StateDir:           resolvedStateDir,
+			MemoryFileStore:    fileMemoryStore,
 
 			EnableLocalExec:     opts.EnableLocalExec,
 			EnableOpenClawTools: opts.EnableOpenClawTools,
@@ -1098,6 +1099,7 @@ func run(ctx context.Context, args []string) error {
 			SkillsToolingGuide: opts.SkillsToolingGuide,
 			KnowledgesConfig:   opts.KnowledgesConfig,
 			StateDir:           resolvedStateDir,
+			MemoryFileStore:    fileMemoryStore,
 
 			EnableLocalExec:     opts.EnableLocalExec,
 			EnableOpenClawTools: opts.EnableOpenClawTools,
@@ -1939,6 +1941,11 @@ func newAgent(
 	}
 
 	callbacks := tool.NewCallbacks()
+	registerMemoryFileToolCallback(
+		callbacks,
+		cfg.MemoryFileStore,
+		cfg.StateDir,
+	)
 	callbacks.RegisterToolResultMessages(openClawToolResultMessages)
 	opts = append(opts, llmagent.WithToolCallbacks(callbacks))
 
@@ -2134,6 +2141,8 @@ type agentConfig struct {
 	KnowledgesConfig   map[string]*yaml.Node
 
 	StateDir string
+
+	MemoryFileStore *memoryfile.Store
 
 	EnableLocalExec bool
 

--- a/openclaw/app/memory_file_tool_callback.go
+++ b/openclaw/app/memory_file_tool_callback.go
@@ -12,6 +12,7 @@ package app
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -26,13 +27,13 @@ import (
 const (
 	memoryToolFileName = "MEMORY.md"
 
-	memoryToolReadFile       = "read_file"
-	memoryToolSaveFile       = "save_file"
-	memoryToolReplaceContent = "replace_content"
-
 	memoryToolReadFileFS       = "fs_read_file"
 	memoryToolSaveFileFS       = "fs_save_file"
 	memoryToolReplaceContentFS = "fs_replace_content"
+)
+
+var errMemorySaveFileExists = errors.New(
+	"memory file exists and overwrite=false",
 )
 
 type memoryToolTarget struct {
@@ -109,13 +110,13 @@ func newMemoryFileToolCallback(
 		}
 
 		switch normalizeMemoryToolName(args.ToolName) {
-		case memoryToolReadFile:
+		case memoryToolReadFileFS:
 			return handleMemoryReadFileTool(
 				target,
 				stateDir,
 				args.Arguments,
 			)
-		case memoryToolSaveFile:
+		case memoryToolSaveFileFS:
 			return handleMemorySaveFileTool(
 				ctx,
 				store,
@@ -123,7 +124,7 @@ func newMemoryFileToolCallback(
 				target,
 				args.Arguments,
 			)
-		case memoryToolReplaceContent:
+		case memoryToolReplaceContentFS:
 			return handleMemoryReplaceContentTool(
 				ctx,
 				store,
@@ -139,12 +140,12 @@ func newMemoryFileToolCallback(
 
 func normalizeMemoryToolName(name string) string {
 	switch strings.TrimSpace(name) {
-	case memoryToolReadFile, memoryToolReadFileFS:
-		return memoryToolReadFile
-	case memoryToolSaveFile, memoryToolSaveFileFS:
-		return memoryToolSaveFile
-	case memoryToolReplaceContent, memoryToolReplaceContentFS:
-		return memoryToolReplaceContent
+	case memoryToolReadFileFS:
+		return memoryToolReadFileFS
+	case memoryToolSaveFileFS:
+		return memoryToolSaveFileFS
+	case memoryToolReplaceContentFS:
+		return memoryToolReplaceContentFS
 	default:
 		return ""
 	}
@@ -248,13 +249,20 @@ func handleMemorySaveFileTool(
 		target.AppName,
 		target.UserID,
 		func(current string) (string, error) {
-			return mergeMemorySaveContents(
+			return nextMemorySaveContents(
 				current,
 				req.Contents,
 				req.Overwrite,
-			), nil
+			)
 		},
 	)
+	if errors.Is(err, errMemorySaveFileExists) {
+		rsp.Message = fmt.Sprintf(
+			"Error: file exists and overwrite=false: %s",
+			req.FileName,
+		)
+		return memoryToolResult(rsp), nil
+	}
 	if err != nil {
 		rsp.Message = fmt.Sprintf("Error: %v", err)
 		return memoryToolResult(rsp), nil
@@ -350,21 +358,29 @@ func isMemoryFileAlias(fileName string) bool {
 	return strings.EqualFold(normalized, memoryToolFileName)
 }
 
-func mergeMemorySaveContents(
+func nextMemorySaveContents(
 	existing string,
 	incoming string,
 	overwrite bool,
-) string {
-	if overwrite || looksLikeFullMemoryDocument(incoming) {
-		return incoming
+) (string, error) {
+	if overwrite {
+		return incoming, nil
 	}
+
 	incomingTrimmed := strings.TrimSpace(incoming)
 	if incomingTrimmed == "" {
-		return existing
+		return "", errMemorySaveFileExists
 	}
 	if strings.Contains(existing, incomingTrimmed) {
-		return existing
+		return existing, nil
 	}
+	if !looksLikeMemoryAppendSnippet(incomingTrimmed) {
+		return "", errMemorySaveFileExists
+	}
+	return appendMemorySnippet(existing, incomingTrimmed), nil
+}
+
+func appendMemorySnippet(existing string, incomingTrimmed string) string {
 	existingTrimmed := strings.TrimRight(existing, "\n")
 	if existingTrimmed == "" {
 		return incomingTrimmed + "\n"
@@ -372,12 +388,18 @@ func mergeMemorySaveContents(
 	return existingTrimmed + "\n\n" + incomingTrimmed + "\n"
 }
 
-func looksLikeFullMemoryDocument(text string) bool {
-	trimmed := strings.TrimSpace(text)
-	return strings.HasPrefix(trimmed, "# Memory") ||
-		strings.Contains(trimmed, "## Long-term facts") ||
-		strings.Contains(trimmed, "## Preferences") ||
-		strings.Contains(trimmed, "## Repeated working style")
+func looksLikeMemoryAppendSnippet(text string) bool {
+	for _, line := range strings.Split(text, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if !strings.HasPrefix(trimmed, "- ") &&
+			!strings.HasPrefix(trimmed, "* ") {
+			return false
+		}
+	}
+	return true
 }
 
 func sliceMemoryTextByLines(

--- a/openclaw/app/memory_file_tool_callback.go
+++ b/openclaw/app/memory_file_tool_callback.go
@@ -1,0 +1,431 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/memoryfile"
+)
+
+const (
+	memoryToolFileName = "MEMORY.md"
+
+	memoryToolReadFile       = "read_file"
+	memoryToolSaveFile       = "save_file"
+	memoryToolReplaceContent = "replace_content"
+
+	memoryToolReadFileFS       = "fs_read_file"
+	memoryToolSaveFileFS       = "fs_save_file"
+	memoryToolReplaceContentFS = "fs_replace_content"
+)
+
+type memoryToolTarget struct {
+	AppName string
+	UserID  string
+	Path    string
+}
+
+type memoryReadFileRequest struct {
+	FileName  string `json:"file_name"`
+	StartLine *int   `json:"start_line,omitempty"`
+	NumLines  *int   `json:"num_lines,omitempty"`
+}
+
+type memoryReadFileResponse struct {
+	BaseDirectory string `json:"base_directory"`
+	FileName      string `json:"file_name"`
+	Contents      string `json:"contents"`
+	Message       string `json:"message"`
+}
+
+type memorySaveFileRequest struct {
+	FileName  string `json:"file_name"`
+	Contents  string `json:"contents"`
+	Overwrite bool   `json:"overwrite"`
+}
+
+type memorySaveFileResponse struct {
+	BaseDirectory string `json:"base_directory"`
+	FileName      string `json:"file_name"`
+	Message       string `json:"message"`
+}
+
+type memoryReplaceContentRequest struct {
+	FileName        string `json:"file_name"`
+	OldString       string `json:"old_string"`
+	NewString       string `json:"new_string"`
+	NumReplacements int    `json:"num_replacements,omitempty"`
+}
+
+type memoryReplaceContentResponse struct {
+	BaseDirectory string `json:"base_directory"`
+	FileName      string `json:"file_name"`
+	Message       string `json:"message"`
+}
+
+func registerMemoryFileToolCallback(
+	callbacks *tool.Callbacks,
+	store *memoryfile.Store,
+	stateDir string,
+) {
+	if callbacks == nil || store == nil {
+		return
+	}
+	callbacks.RegisterBeforeTool(
+		newMemoryFileToolCallback(store, stateDir),
+	)
+}
+
+func newMemoryFileToolCallback(
+	store *memoryfile.Store,
+	stateDir string,
+) tool.BeforeToolCallbackStructured {
+	return func(
+		ctx context.Context,
+		args *tool.BeforeToolArgs,
+	) (*tool.BeforeToolResult, error) {
+		if store == nil || args == nil {
+			return nil, nil
+		}
+		target, ok, err := memoryToolTargetFromContext(ctx, store)
+		if err != nil || !ok {
+			return nil, err
+		}
+
+		switch normalizeMemoryToolName(args.ToolName) {
+		case memoryToolReadFile:
+			return handleMemoryReadFileTool(
+				target,
+				stateDir,
+				args.Arguments,
+			)
+		case memoryToolSaveFile:
+			return handleMemorySaveFileTool(
+				ctx,
+				store,
+				stateDir,
+				target,
+				args.Arguments,
+			)
+		case memoryToolReplaceContent:
+			return handleMemoryReplaceContentTool(
+				ctx,
+				store,
+				stateDir,
+				target,
+				args.Arguments,
+			)
+		default:
+			return nil, nil
+		}
+	}
+}
+
+func normalizeMemoryToolName(name string) string {
+	switch strings.TrimSpace(name) {
+	case memoryToolReadFile, memoryToolReadFileFS:
+		return memoryToolReadFile
+	case memoryToolSaveFile, memoryToolSaveFileFS:
+		return memoryToolSaveFile
+	case memoryToolReplaceContent, memoryToolReplaceContentFS:
+		return memoryToolReplaceContent
+	default:
+		return ""
+	}
+}
+
+func memoryToolTargetFromContext(
+	ctx context.Context,
+	store *memoryfile.Store,
+) (memoryToolTarget, bool, error) {
+	inv, ok := agent.InvocationFromContext(ctx)
+	if !ok || inv == nil || inv.Session == nil || store == nil {
+		return memoryToolTarget{}, false, nil
+	}
+	appName := strings.TrimSpace(inv.Session.AppName)
+	userID := strings.TrimSpace(inv.Session.UserID)
+	if appName == "" || userID == "" {
+		return memoryToolTarget{}, false, nil
+	}
+	path, err := store.EnsureMemory(ctx, appName, userID)
+	if err != nil {
+		return memoryToolTarget{}, false, err
+	}
+	return memoryToolTarget{
+		AppName: appName,
+		UserID:  userID,
+		Path:    path,
+	}, true, nil
+}
+
+func handleMemoryReadFileTool(
+	target memoryToolTarget,
+	baseDir string,
+	args []byte,
+) (*tool.BeforeToolResult, error) {
+	var req memoryReadFileRequest
+	if err := json.Unmarshal(args, &req); err != nil {
+		return nil, nil
+	}
+	if !isMemoryFileAlias(req.FileName) {
+		return nil, nil
+	}
+
+	rsp := memoryReadFileResponse{
+		BaseDirectory: baseDir,
+		FileName:      req.FileName,
+	}
+	raw, err := os.ReadFile(target.Path)
+	if err != nil {
+		rsp.Message = fmt.Sprintf("Error: cannot read file: %v", err)
+		return memoryToolResult(rsp), nil
+	}
+
+	chunk, start, end, total, empty, err := sliceMemoryTextByLines(
+		string(raw),
+		req.StartLine,
+		req.NumLines,
+	)
+	if err != nil {
+		rsp.Message = fmt.Sprintf("Error: %v", err)
+		return memoryToolResult(rsp), nil
+	}
+	rsp.Contents = chunk
+	if empty {
+		rsp.Message = fmt.Sprintf(
+			"Successfully read %s, but file is empty",
+			req.FileName,
+		)
+		return memoryToolResult(rsp), nil
+	}
+	rsp.Message = fmt.Sprintf(
+		"Successfully read %s, start line: %d, end line: %d, total lines: %d",
+		req.FileName,
+		start,
+		end,
+		total,
+	)
+	return memoryToolResult(rsp), nil
+}
+
+func handleMemorySaveFileTool(
+	ctx context.Context,
+	store *memoryfile.Store,
+	stateDir string,
+	target memoryToolTarget,
+	args []byte,
+) (*tool.BeforeToolResult, error) {
+	var req memorySaveFileRequest
+	if err := json.Unmarshal(args, &req); err != nil {
+		return nil, nil
+	}
+	if !isMemoryFileAlias(req.FileName) {
+		return nil, nil
+	}
+
+	rsp := memorySaveFileResponse{
+		BaseDirectory: stateDir,
+		FileName:      req.FileName,
+	}
+	_, err := store.UpdateMemory(
+		ctx,
+		target.AppName,
+		target.UserID,
+		func(current string) (string, error) {
+			return mergeMemorySaveContents(
+				current,
+				req.Contents,
+				req.Overwrite,
+			), nil
+		},
+	)
+	if err != nil {
+		rsp.Message = fmt.Sprintf("Error: %v", err)
+		return memoryToolResult(rsp), nil
+	}
+	rsp.Message = fmt.Sprintf("Successfully saved: %s", req.FileName)
+	return memoryToolResult(rsp), nil
+}
+
+func handleMemoryReplaceContentTool(
+	ctx context.Context,
+	store *memoryfile.Store,
+	stateDir string,
+	target memoryToolTarget,
+	args []byte,
+) (*tool.BeforeToolResult, error) {
+	var req memoryReplaceContentRequest
+	if err := json.Unmarshal(args, &req); err != nil {
+		return nil, nil
+	}
+	if !isMemoryFileAlias(req.FileName) {
+		return nil, nil
+	}
+
+	rsp := memoryReplaceContentResponse{
+		BaseDirectory: stateDir,
+		FileName:      req.FileName,
+	}
+	if req.OldString == "" {
+		rsp.Message = "Error: old_string cannot be empty"
+		return memoryToolResult(rsp), nil
+	}
+	if req.OldString == req.NewString {
+		rsp.Message = "old_string equals new_string; no changes made"
+		return memoryToolResult(rsp), nil
+	}
+
+	totalCount := 0
+	numReplacements := 0
+	_, err := store.UpdateMemory(
+		ctx,
+		target.AppName,
+		target.UserID,
+		func(current string) (string, error) {
+			totalCount = strings.Count(current, req.OldString)
+			if totalCount == 0 {
+				return current, nil
+			}
+			numReplacements = req.NumReplacements
+			if numReplacements == 0 {
+				numReplacements = 1
+			}
+			if numReplacements < 0 || numReplacements > totalCount {
+				numReplacements = totalCount
+			}
+			return strings.Replace(
+				current,
+				req.OldString,
+				req.NewString,
+				numReplacements,
+			), nil
+		},
+	)
+	if err != nil {
+		rsp.Message = fmt.Sprintf("Error: %v", err)
+		return memoryToolResult(rsp), nil
+	}
+	if totalCount == 0 {
+		rsp.Message = fmt.Sprintf(
+			"'%s' not found in '%s'",
+			req.OldString,
+			req.FileName,
+		)
+		return memoryToolResult(rsp), nil
+	}
+	rsp.Message = fmt.Sprintf(
+		"Successfully replaced %d of %d in '%s'",
+		numReplacements,
+		totalCount,
+		req.FileName,
+	)
+	return memoryToolResult(rsp), nil
+}
+
+func memoryToolResult(result any) *tool.BeforeToolResult {
+	return &tool.BeforeToolResult{CustomResult: result}
+}
+
+func isMemoryFileAlias(fileName string) bool {
+	normalized := filepath.ToSlash(strings.TrimSpace(fileName))
+	for strings.HasPrefix(normalized, "./") {
+		normalized = strings.TrimPrefix(normalized, "./")
+	}
+	return strings.EqualFold(normalized, memoryToolFileName)
+}
+
+func mergeMemorySaveContents(
+	existing string,
+	incoming string,
+	overwrite bool,
+) string {
+	if overwrite || looksLikeFullMemoryDocument(incoming) {
+		return incoming
+	}
+	incomingTrimmed := strings.TrimSpace(incoming)
+	if incomingTrimmed == "" {
+		return existing
+	}
+	if strings.Contains(existing, incomingTrimmed) {
+		return existing
+	}
+	existingTrimmed := strings.TrimRight(existing, "\n")
+	if existingTrimmed == "" {
+		return incomingTrimmed + "\n"
+	}
+	return existingTrimmed + "\n\n" + incomingTrimmed + "\n"
+}
+
+func looksLikeFullMemoryDocument(text string) bool {
+	trimmed := strings.TrimSpace(text)
+	return strings.HasPrefix(trimmed, "# Memory") ||
+		strings.Contains(trimmed, "## Long-term facts") ||
+		strings.Contains(trimmed, "## Preferences") ||
+		strings.Contains(trimmed, "## Repeated working style")
+}
+
+func sliceMemoryTextByLines(
+	text string,
+	startLine *int,
+	numLines *int,
+) (string, int, int, int, bool, error) {
+	if text == "" {
+		return "", 0, 0, 0, true, nil
+	}
+	lines := strings.Split(text, "\n")
+	total := len(lines)
+
+	start := 1
+	if startLine != nil {
+		if *startLine <= 0 {
+			return "", 0, 0, 0, false, fmt.Errorf(
+				"start line must be > 0: %d",
+				*startLine,
+			)
+		}
+		start = *startLine
+	}
+	limit := total
+	if numLines != nil {
+		if *numLines <= 0 {
+			return "", 0, 0, 0, false, fmt.Errorf(
+				"number of lines must be > 0: %d",
+				*numLines,
+			)
+		}
+		limit = *numLines
+	}
+	if start > total {
+		return "", 0, 0, total, false, fmt.Errorf(
+			"start line is out of range, start line: %d, total lines: %d",
+			start,
+			total,
+		)
+	}
+	end := start + limit - 1
+	if end > total {
+		end = total
+	}
+	return strings.Join(lines[start-1:end], "\n"),
+		start,
+		end,
+		total,
+		false,
+		nil
+}

--- a/openclaw/app/memory_file_tool_callback_test.go
+++ b/openclaw/app/memory_file_tool_callback_test.go
@@ -196,6 +196,497 @@ func TestMemoryFileToolCallback_SaveFilePreservesOverwriteGuard(
 	require.Equal(t, "# Memory\n\n- Existing fact\n", string(raw))
 }
 
+func TestRegisterMemoryFileToolCallback(t *testing.T) {
+	t.Parallel()
+
+	stateDir, store := newTestMemoryFileStore(t)
+	registerMemoryFileToolCallback(nil, store, stateDir)
+
+	callbacks := tool.NewCallbacks()
+	registerMemoryFileToolCallback(callbacks, nil, stateDir)
+	require.Empty(t, callbacks.BeforeTool)
+
+	registerMemoryFileToolCallback(callbacks, store, stateDir)
+	require.Len(t, callbacks.BeforeTool, 1)
+
+	result, err := callbacks.RunBeforeTool(newTestMemoryToolContext(), &tool.BeforeToolArgs{
+		ToolName:  memoryToolReadFileFS,
+		Arguments: []byte(`{"file_name":"MEMORY.md"}`),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+}
+
+func TestMemoryFileToolCallback_NoopsWhenUnavailable(t *testing.T) {
+	t.Parallel()
+
+	stateDir, store := newTestMemoryFileStore(t)
+	args := &tool.BeforeToolArgs{
+		ToolName:  memoryToolReadFileFS,
+		Arguments: []byte(`{"file_name":"MEMORY.md"}`),
+	}
+
+	callback := newMemoryFileToolCallback(nil, stateDir)
+	result, err := callback(newTestMemoryToolContext(), args)
+	require.NoError(t, err)
+	require.Nil(t, result)
+
+	callback = newMemoryFileToolCallback(store, stateDir)
+	result, err = callback(newTestMemoryToolContext(), nil)
+	require.NoError(t, err)
+	require.Nil(t, result)
+
+	result, err = callback(context.Background(), args)
+	require.NoError(t, err)
+	require.Nil(t, result)
+
+	noSessionCtx := agent.NewInvocationContext(
+		context.Background(),
+		agent.NewInvocation(),
+	)
+	result, err = callback(noSessionCtx, args)
+	require.NoError(t, err)
+	require.Nil(t, result)
+
+	blankAppCtx := agent.NewInvocationContext(
+		context.Background(),
+		agent.NewInvocation(agent.WithInvocationSession(
+			session.NewSession(" ", testMemoryUserID, "memory-tool-session"),
+		)),
+	)
+	result, err = callback(blankAppCtx, args)
+	require.NoError(t, err)
+	require.Nil(t, result)
+
+	blankUserCtx := agent.NewInvocationContext(
+		context.Background(),
+		agent.NewInvocation(agent.WithInvocationSession(
+			session.NewSession(testMemoryAppName, " ", "memory-tool-session"),
+		)),
+	)
+	result, err = callback(blankUserCtx, args)
+	require.NoError(t, err)
+	require.Nil(t, result)
+}
+
+func TestMemoryFileToolCallback_TargetResolutionError(t *testing.T) {
+	t.Parallel()
+
+	stateDir := t.TempDir()
+	root := filepath.Join(t.TempDir(), "memory-root")
+	require.NoError(t, os.WriteFile(root, []byte("x"), 0o600))
+
+	store, err := memoryfile.NewStore(root)
+	require.NoError(t, err)
+
+	callback := newMemoryFileToolCallback(store, stateDir)
+	result, err := callback(newTestMemoryToolContext(), &tool.BeforeToolArgs{
+		ToolName:  memoryToolReadFileFS,
+		Arguments: []byte(`{"file_name":"MEMORY.md"}`),
+	})
+	require.Error(t, err)
+	require.Nil(t, result)
+}
+
+func TestHandleMemoryReadFileTool_Branches(t *testing.T) {
+	t.Parallel()
+
+	baseDir := t.TempDir()
+	target := memoryToolTarget{
+		Path: filepath.Join(t.TempDir(), memoryToolFileName),
+	}
+
+	result, err := handleMemoryReadFileTool(target, baseDir, []byte(`{`))
+	require.NoError(t, err)
+	require.Nil(t, result)
+
+	result, err = handleMemoryReadFileTool(
+		target,
+		baseDir,
+		[]byte(`{"file_name":"notes.md"}`),
+	)
+	require.NoError(t, err)
+	require.Nil(t, result)
+
+	result, err = handleMemoryReadFileTool(
+		target,
+		baseDir,
+		[]byte(`{"file_name":"MEMORY.md"}`),
+	)
+	require.NoError(t, err)
+	rsp := requireMemoryReadFileResponse(t, result)
+	require.Contains(t, rsp.Message, "Error: cannot read file")
+
+	require.NoError(t, os.WriteFile(target.Path, []byte(""), 0o600))
+	result, err = handleMemoryReadFileTool(
+		target,
+		baseDir,
+		[]byte(`{"file_name":"./memory.md"}`),
+	)
+	require.NoError(t, err)
+	rsp = requireMemoryReadFileResponse(t, result)
+	require.Equal(t, "Successfully read ./memory.md, but file is empty", rsp.Message)
+
+	require.NoError(t, os.WriteFile(
+		target.Path,
+		[]byte("line1\nline2\nline3"),
+		0o600,
+	))
+	result, err = handleMemoryReadFileTool(
+		target,
+		baseDir,
+		[]byte(`{"file_name":"MEMORY.md","start_line":2,"num_lines":2}`),
+	)
+	require.NoError(t, err)
+	rsp = requireMemoryReadFileResponse(t, result)
+	require.Equal(t, "line2\nline3", rsp.Contents)
+	require.Equal(
+		t,
+		"Successfully read MEMORY.md, start line: 2, end line: 3, total lines: 3",
+		rsp.Message,
+	)
+
+	result, err = handleMemoryReadFileTool(
+		target,
+		baseDir,
+		[]byte(`{"file_name":"MEMORY.md","start_line":0}`),
+	)
+	require.NoError(t, err)
+	rsp = requireMemoryReadFileResponse(t, result)
+	require.Equal(t, "Error: start line must be > 0: 0", rsp.Message)
+
+	result, err = handleMemoryReadFileTool(
+		target,
+		baseDir,
+		[]byte(`{"file_name":"MEMORY.md","num_lines":0}`),
+	)
+	require.NoError(t, err)
+	rsp = requireMemoryReadFileResponse(t, result)
+	require.Equal(t, "Error: number of lines must be > 0: 0", rsp.Message)
+
+	result, err = handleMemoryReadFileTool(
+		target,
+		baseDir,
+		[]byte(`{"file_name":"MEMORY.md","start_line":5}`),
+	)
+	require.NoError(t, err)
+	rsp = requireMemoryReadFileResponse(t, result)
+	require.Equal(
+		t,
+		"Error: start line is out of range, start line: 5, total lines: 3",
+		rsp.Message,
+	)
+}
+
+func TestHandleMemorySaveFileTool_Branches(t *testing.T) {
+	t.Parallel()
+
+	stateDir, store := newTestMemoryFileStore(t)
+	target := newTestMemoryToolTarget(t, store)
+
+	result, err := handleMemorySaveFileTool(
+		context.Background(),
+		store,
+		stateDir,
+		target,
+		[]byte(`{`),
+	)
+	require.NoError(t, err)
+	require.Nil(t, result)
+
+	result, err = handleMemorySaveFileTool(
+		context.Background(),
+		store,
+		stateDir,
+		target,
+		[]byte(`{"file_name":"notes.md","contents":"ignored","overwrite":true}`),
+	)
+	require.NoError(t, err)
+	require.Nil(t, result)
+
+	require.NoError(t, os.WriteFile(
+		target.Path,
+		[]byte("# Memory\n\n- Existing fact\n"),
+		0o600,
+	))
+	result, err = handleMemorySaveFileTool(
+		context.Background(),
+		store,
+		stateDir,
+		target,
+		[]byte(`{"file_name":"MEMORY.md","contents":"- Existing fact","overwrite":false}`),
+	)
+	require.NoError(t, err)
+	rsp := requireMemorySaveFileResponse(t, result)
+	require.Equal(t, "Successfully saved: MEMORY.md", rsp.Message)
+
+	raw, err := os.ReadFile(target.Path)
+	require.NoError(t, err)
+	require.Equal(t, "# Memory\n\n- Existing fact\n", string(raw))
+
+	result, err = handleMemorySaveFileTool(
+		context.Background(),
+		store,
+		stateDir,
+		target,
+		[]byte(`{"file_name":"MEMORY.md","contents":"","overwrite":false}`),
+	)
+	require.NoError(t, err)
+	rsp = requireMemorySaveFileResponse(t, result)
+	require.Equal(
+		t,
+		"Error: file exists and overwrite=false: MEMORY.md",
+		rsp.Message,
+	)
+
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	result, err = handleMemorySaveFileTool(
+		canceledCtx,
+		store,
+		stateDir,
+		target,
+		[]byte(`{"file_name":"MEMORY.md","contents":"replacement","overwrite":true}`),
+	)
+	require.NoError(t, err)
+	rsp = requireMemorySaveFileResponse(t, result)
+	require.Equal(t, "Error: context canceled", rsp.Message)
+
+	result, err = handleMemorySaveFileTool(
+		context.Background(),
+		store,
+		stateDir,
+		target,
+		[]byte(`{"file_name":"MEMORY.md","contents":"replacement","overwrite":true}`),
+	)
+	require.NoError(t, err)
+	rsp = requireMemorySaveFileResponse(t, result)
+	require.Equal(t, "Successfully saved: MEMORY.md", rsp.Message)
+
+	raw, err = os.ReadFile(target.Path)
+	require.NoError(t, err)
+	require.Equal(t, "replacement", string(raw))
+}
+
+func TestHandleMemoryReplaceContentTool_Branches(t *testing.T) {
+	t.Parallel()
+
+	stateDir, store := newTestMemoryFileStore(t)
+	target := newTestMemoryToolTarget(t, store)
+
+	result, err := handleMemoryReplaceContentTool(
+		context.Background(),
+		store,
+		stateDir,
+		target,
+		[]byte(`{`),
+	)
+	require.NoError(t, err)
+	require.Nil(t, result)
+
+	result, err = handleMemoryReplaceContentTool(
+		context.Background(),
+		store,
+		stateDir,
+		target,
+		[]byte(`{"file_name":"notes.md","old_string":"a","new_string":"b"}`),
+	)
+	require.NoError(t, err)
+	require.Nil(t, result)
+
+	result, err = handleMemoryReplaceContentTool(
+		context.Background(),
+		store,
+		stateDir,
+		target,
+		[]byte(`{"file_name":"MEMORY.md","old_string":"","new_string":"b"}`),
+	)
+	require.NoError(t, err)
+	rsp := requireMemoryReplaceContentResponse(t, result)
+	require.Equal(t, "Error: old_string cannot be empty", rsp.Message)
+
+	result, err = handleMemoryReplaceContentTool(
+		context.Background(),
+		store,
+		stateDir,
+		target,
+		[]byte(`{"file_name":"MEMORY.md","old_string":"same","new_string":"same"}`),
+	)
+	require.NoError(t, err)
+	rsp = requireMemoryReplaceContentResponse(t, result)
+	require.Equal(t, "old_string equals new_string; no changes made", rsp.Message)
+
+	require.NoError(t, os.WriteFile(
+		target.Path,
+		[]byte("alpha beta alpha"),
+		0o600,
+	))
+	result, err = handleMemoryReplaceContentTool(
+		context.Background(),
+		store,
+		stateDir,
+		target,
+		[]byte(`{"file_name":"MEMORY.md","old_string":"missing","new_string":"beta"}`),
+	)
+	require.NoError(t, err)
+	rsp = requireMemoryReplaceContentResponse(t, result)
+	require.Equal(t, "'missing' not found in 'MEMORY.md'", rsp.Message)
+
+	result, err = handleMemoryReplaceContentTool(
+		context.Background(),
+		store,
+		stateDir,
+		target,
+		[]byte(`{"file_name":"MEMORY.md","old_string":"alpha","new_string":"gamma","num_replacements":-1}`),
+	)
+	require.NoError(t, err)
+	rsp = requireMemoryReplaceContentResponse(t, result)
+	require.Equal(
+		t,
+		"Successfully replaced 2 of 2 in 'MEMORY.md'",
+		rsp.Message,
+	)
+
+	raw, err := os.ReadFile(target.Path)
+	require.NoError(t, err)
+	require.Equal(t, "gamma beta gamma", string(raw))
+
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	result, err = handleMemoryReplaceContentTool(
+		canceledCtx,
+		store,
+		stateDir,
+		target,
+		[]byte(`{"file_name":"MEMORY.md","old_string":"gamma","new_string":"delta"}`),
+	)
+	require.NoError(t, err)
+	rsp = requireMemoryReplaceContentResponse(t, result)
+	require.Equal(t, "Error: context canceled", rsp.Message)
+}
+
+func TestMemoryFileHelpers(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, memoryToolReadFileFS, normalizeMemoryToolName("  fs_read_file  "))
+	require.Equal(t, memoryToolSaveFileFS, normalizeMemoryToolName(memoryToolSaveFileFS))
+	require.Equal(
+		t,
+		memoryToolReplaceContentFS,
+		normalizeMemoryToolName(memoryToolReplaceContentFS),
+	)
+	require.Empty(t, normalizeMemoryToolName("read_file"))
+
+	require.True(t, isMemoryFileAlias("./MEMORY.md"))
+	require.True(t, isMemoryFileAlias("././memory.md"))
+	require.False(t, isMemoryFileAlias("notes/MEMORY.md"))
+
+	next, err := nextMemorySaveContents("current", "replacement", true)
+	require.NoError(t, err)
+	require.Equal(t, "replacement", next)
+
+	_, err = nextMemorySaveContents("current", " ", false)
+	require.ErrorIs(t, err, errMemorySaveFileExists)
+
+	next, err = nextMemorySaveContents(
+		"# Memory\n\n- Existing fact\n",
+		"- Existing fact",
+		false,
+	)
+	require.NoError(t, err)
+	require.Equal(t, "# Memory\n\n- Existing fact\n", next)
+
+	_, err = nextMemorySaveContents("current", "full replacement text", false)
+	require.ErrorIs(t, err, errMemorySaveFileExists)
+
+	next, err = nextMemorySaveContents("", "* Favorite editor: Cursor", false)
+	require.NoError(t, err)
+	require.Equal(t, "* Favorite editor: Cursor\n", next)
+
+	next, err = nextMemorySaveContents(
+		"# Memory\n\n- Existing fact\n",
+		"- New fact",
+		false,
+	)
+	require.NoError(t, err)
+	require.Equal(t, "# Memory\n\n- Existing fact\n\n- New fact\n", next)
+
+	require.False(t, looksLikeMemoryAppendSnippet("not a bullet"))
+	require.True(t, looksLikeMemoryAppendSnippet("- First fact\n\n* Second fact"))
+	require.NotNil(t, memoryToolResult("custom"))
+}
+
+func TestSliceMemoryTextByLines(t *testing.T) {
+	t.Parallel()
+
+	chunk, start, end, total, empty, err := sliceMemoryTextByLines("", nil, nil)
+	require.NoError(t, err)
+	require.Empty(t, chunk)
+	require.Zero(t, start)
+	require.Zero(t, end)
+	require.Zero(t, total)
+	require.True(t, empty)
+
+	chunk, start, end, total, empty, err = sliceMemoryTextByLines(
+		"one\ntwo\nthree",
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, "one\ntwo\nthree", chunk)
+	require.Equal(t, 1, start)
+	require.Equal(t, 3, end)
+	require.Equal(t, 3, total)
+	require.False(t, empty)
+
+	startLine := 2
+	numLines := 1
+	chunk, start, end, total, empty, err = sliceMemoryTextByLines(
+		"one\ntwo\nthree",
+		&startLine,
+		&numLines,
+	)
+	require.NoError(t, err)
+	require.Equal(t, "two", chunk)
+	require.Equal(t, 2, start)
+	require.Equal(t, 2, end)
+	require.Equal(t, 3, total)
+	require.False(t, empty)
+
+	startLine = 2
+	numLines = 5
+	chunk, start, end, total, empty, err = sliceMemoryTextByLines(
+		"one\ntwo\nthree",
+		&startLine,
+		&numLines,
+	)
+	require.NoError(t, err)
+	require.Equal(t, "two\nthree", chunk)
+	require.Equal(t, 2, start)
+	require.Equal(t, 3, end)
+	require.Equal(t, 3, total)
+	require.False(t, empty)
+
+	startLine = 0
+	_, _, _, _, _, err = sliceMemoryTextByLines("one\ntwo", &startLine, nil)
+	require.EqualError(t, err, "start line must be > 0: 0")
+
+	startLine = 1
+	numLines = 0
+	_, _, _, _, _, err = sliceMemoryTextByLines("one\ntwo", &startLine, &numLines)
+	require.EqualError(t, err, "number of lines must be > 0: 0")
+
+	startLine = 3
+	_, _, _, total, empty, err = sliceMemoryTextByLines("one\ntwo", &startLine, nil)
+	require.EqualError(
+		t,
+		err,
+		"start line is out of range, start line: 3, total lines: 2",
+	)
+	require.Equal(t, 2, total)
+	require.False(t, empty)
+}
+
 func newTestMemoryFileStore(t *testing.T) (string, *memoryfile.Store) {
 	t.Helper()
 
@@ -207,6 +698,25 @@ func newTestMemoryFileStore(t *testing.T) (string, *memoryfile.Store) {
 	return stateDir, store
 }
 
+func newTestMemoryToolTarget(
+	t *testing.T,
+	store *memoryfile.Store,
+) memoryToolTarget {
+	t.Helper()
+
+	path, err := store.EnsureMemory(
+		context.Background(),
+		testMemoryAppName,
+		testMemoryUserID,
+	)
+	require.NoError(t, err)
+	return memoryToolTarget{
+		AppName: testMemoryAppName,
+		UserID:  testMemoryUserID,
+		Path:    path,
+	}
+}
+
 func newTestMemoryToolContext() context.Context {
 	inv := agent.NewInvocation(agent.WithInvocationSession(
 		session.NewSession(
@@ -216,4 +726,40 @@ func newTestMemoryToolContext() context.Context {
 		),
 	))
 	return agent.NewInvocationContext(context.Background(), inv)
+}
+
+func requireMemoryReadFileResponse(
+	t *testing.T,
+	result *tool.BeforeToolResult,
+) memoryReadFileResponse {
+	t.Helper()
+
+	require.NotNil(t, result)
+	rsp, ok := result.CustomResult.(memoryReadFileResponse)
+	require.True(t, ok)
+	return rsp
+}
+
+func requireMemorySaveFileResponse(
+	t *testing.T,
+	result *tool.BeforeToolResult,
+) memorySaveFileResponse {
+	t.Helper()
+
+	require.NotNil(t, result)
+	rsp, ok := result.CustomResult.(memorySaveFileResponse)
+	require.True(t, ok)
+	return rsp
+}
+
+func requireMemoryReplaceContentResponse(
+	t *testing.T,
+	result *tool.BeforeToolResult,
+) memoryReplaceContentResponse {
+	t.Helper()
+
+	require.NotNil(t, result)
+	rsp, ok := result.CustomResult.(memoryReplaceContentResponse)
+	require.True(t, ok)
+	return rsp
 }

--- a/openclaw/app/memory_file_tool_callback_test.go
+++ b/openclaw/app/memory_file_tool_callback_test.go
@@ -101,6 +101,21 @@ func TestMemoryFileToolCallback_ReadFilePrefersScopedMemory(t *testing.T) {
 	require.NotContains(t, rsp.Contents, "root memory")
 }
 
+func TestMemoryFileToolCallback_DoesNotInterceptGenericReadFile(t *testing.T) {
+	t.Parallel()
+
+	stateDir, store := newTestMemoryFileStore(t)
+	ctx := newTestMemoryToolContext()
+	callback := newMemoryFileToolCallback(store, stateDir)
+
+	result, err := callback(ctx, &tool.BeforeToolArgs{
+		ToolName:  "read_file",
+		Arguments: []byte(`{"file_name":"MEMORY.md"}`),
+	})
+	require.NoError(t, err)
+	require.Nil(t, result)
+}
+
 func TestMemoryFileToolCallback_ReplaceContentUsesScopedMemory(t *testing.T) {
 	t.Parallel()
 
@@ -142,6 +157,43 @@ func TestMemoryFileToolCallback_ReplaceContentUsesScopedMemory(t *testing.T) {
 	rootRaw, err := os.ReadFile(rootPath)
 	require.NoError(t, err)
 	require.Contains(t, string(rootRaw), "Hello Root")
+}
+
+func TestMemoryFileToolCallback_SaveFilePreservesOverwriteGuard(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	stateDir, store := newTestMemoryFileStore(t)
+	ctx := newTestMemoryToolContext()
+	callback := newMemoryFileToolCallback(store, stateDir)
+
+	path, err := store.EnsureMemory(
+		context.Background(),
+		testMemoryAppName,
+		testMemoryUserID,
+	)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, []byte("# Memory\n\n- Existing fact\n"), 0o600))
+
+	result, err := callback(ctx, &tool.BeforeToolArgs{
+		ToolName:  memoryToolSaveFileFS,
+		Arguments: []byte(`{"file_name":"MEMORY.md","contents":"replacement text","overwrite":false}`),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	rsp, ok := result.CustomResult.(memorySaveFileResponse)
+	require.True(t, ok)
+	require.Equal(
+		t,
+		"Error: file exists and overwrite=false: MEMORY.md",
+		rsp.Message,
+	)
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, "# Memory\n\n- Existing fact\n", string(raw))
 }
 
 func newTestMemoryFileStore(t *testing.T) (string, *memoryfile.Store) {

--- a/openclaw/app/memory_file_tool_callback_test.go
+++ b/openclaw/app/memory_file_tool_callback_test.go
@@ -1,0 +1,167 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package app
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/memoryfile"
+)
+
+const (
+	testMemoryAppName = "openclaw"
+	testMemoryUserID  = "wecom:dm:test-user"
+	testMemoryName    = "Sample User"
+	testMemoryOldText = "Original Name"
+	testMemoryNewText = "Updated Name"
+)
+
+func TestMemoryFileToolCallback_SaveFileWritesScopedMemory(t *testing.T) {
+	t.Parallel()
+
+	stateDir, store := newTestMemoryFileStore(t)
+	ctx := newTestMemoryToolContext()
+	callback := newMemoryFileToolCallback(store, stateDir)
+
+	result, err := callback(ctx, &tool.BeforeToolArgs{
+		ToolName: memoryToolSaveFileFS,
+		Arguments: []byte(
+			`{"file_name":"MEMORY.md","contents":"- User name: ` +
+				testMemoryName +
+				`\n","overwrite":false}`,
+		),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	rsp, ok := result.CustomResult.(memorySaveFileResponse)
+	require.True(t, ok)
+	require.Equal(t, "Successfully saved: MEMORY.md", rsp.Message)
+
+	path, err := store.EnsureMemory(
+		context.Background(),
+		testMemoryAppName,
+		testMemoryUserID,
+	)
+	require.NoError(t, err)
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Contains(t, string(raw), "# Memory")
+	require.Contains(t, string(raw), "- User name: "+testMemoryName)
+
+	_, err = os.Stat(filepath.Join(stateDir, memoryToolFileName))
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestMemoryFileToolCallback_ReadFilePrefersScopedMemory(t *testing.T) {
+	t.Parallel()
+
+	stateDir, store := newTestMemoryFileStore(t)
+	ctx := newTestMemoryToolContext()
+	callback := newMemoryFileToolCallback(store, stateDir)
+
+	path, err := store.EnsureMemory(
+		context.Background(),
+		testMemoryAppName,
+		testMemoryUserID,
+	)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, []byte("scoped memory\n"), 0o600))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(stateDir, memoryToolFileName),
+		[]byte("root memory\n"),
+		0o600,
+	))
+
+	result, err := callback(ctx, &tool.BeforeToolArgs{
+		ToolName:  memoryToolReadFileFS,
+		Arguments: []byte(`{"file_name":"MEMORY.md"}`),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	rsp, ok := result.CustomResult.(memoryReadFileResponse)
+	require.True(t, ok)
+	require.Contains(t, rsp.Contents, "scoped memory")
+	require.NotContains(t, rsp.Contents, "root memory")
+}
+
+func TestMemoryFileToolCallback_ReplaceContentUsesScopedMemory(t *testing.T) {
+	t.Parallel()
+
+	stateDir, store := newTestMemoryFileStore(t)
+	ctx := newTestMemoryToolContext()
+	callback := newMemoryFileToolCallback(store, stateDir)
+
+	path, err := store.EnsureMemory(
+		context.Background(),
+		testMemoryAppName,
+		testMemoryUserID,
+	)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, []byte("Hello "+testMemoryOldText+"\n"), 0o600))
+	rootPath := filepath.Join(stateDir, memoryToolFileName)
+	require.NoError(t, os.WriteFile(rootPath, []byte("Hello Root\n"), 0o600))
+
+	result, err := callback(ctx, &tool.BeforeToolArgs{
+		ToolName: memoryToolReplaceContentFS,
+		Arguments: []byte(
+			`{"file_name":"MEMORY.md","old_string":"` +
+				testMemoryOldText +
+				`","new_string":"` +
+				testMemoryNewText +
+				`"}`,
+		),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	rsp, ok := result.CustomResult.(memoryReplaceContentResponse)
+	require.True(t, ok)
+	require.Equal(t, "Successfully replaced 1 of 1 in 'MEMORY.md'", rsp.Message)
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Contains(t, string(raw), testMemoryNewText)
+
+	rootRaw, err := os.ReadFile(rootPath)
+	require.NoError(t, err)
+	require.Contains(t, string(rootRaw), "Hello Root")
+}
+
+func newTestMemoryFileStore(t *testing.T) (string, *memoryfile.Store) {
+	t.Helper()
+
+	stateDir := t.TempDir()
+	root, err := memoryfile.DefaultRoot(stateDir)
+	require.NoError(t, err)
+	store, err := memoryfile.NewStore(root)
+	require.NoError(t, err)
+	return stateDir, store
+}
+
+func newTestMemoryToolContext() context.Context {
+	inv := agent.NewInvocation(agent.WithInvocationSession(
+		session.NewSession(
+			testMemoryAppName,
+			testMemoryUserID,
+			"memory-tool-session",
+		),
+	))
+	return agent.NewInvocationContext(context.Background(), inv)
+}

--- a/openclaw/internal/memoryfile/store.go
+++ b/openclaw/internal/memoryfile/store.go
@@ -102,6 +102,54 @@ func (s *Store) EnsureMemory(
 	return path, nil
 }
 
+func (s *Store) UpdateMemory(
+	ctx context.Context,
+	appName string,
+	userID string,
+	update func(current string) (string, error),
+) (string, error) {
+	if s == nil {
+		return "", errors.New("memoryfile: nil store")
+	}
+	if update == nil {
+		return "", errors.New("memoryfile: nil update func")
+	}
+	if err := contextErr(ctx); err != nil {
+		return "", err
+	}
+	path, err := s.MemoryPath(appName, userID)
+	if err != nil {
+		return "", err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := contextErr(ctx); err != nil {
+		return "", err
+	}
+	if !fileExists(path) {
+		if err := writeFileAtomic(path, []byte(DefaultTemplate())); err != nil {
+			return "", err
+		}
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	next, err := update(string(raw))
+	if err != nil {
+		return "", err
+	}
+	if err := contextErr(ctx); err != nil {
+		return "", err
+	}
+	if err := writeFileAtomic(path, []byte(next)); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
 func (s *Store) ReadFile(path string, maxBytes int) (string, error) {
 	if s == nil {
 		return "", errors.New("memoryfile: nil store")

--- a/openclaw/internal/memoryfile/store_test.go
+++ b/openclaw/internal/memoryfile/store_test.go
@@ -12,6 +12,7 @@ package memoryfile
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -369,6 +370,214 @@ func TestEnsureMemory_WriteFileErrorReturnsError(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = store.EnsureMemory(context.Background(), "demo-app", "u1")
+	require.Error(t, err)
+}
+
+func TestStoreUpdateMemoryCreatesAndWrites(t *testing.T) {
+	t.Parallel()
+
+	root, err := DefaultRoot(t.TempDir())
+	require.NoError(t, err)
+	store, err := NewStore(root)
+	require.NoError(t, err)
+
+	path, err := store.UpdateMemory(
+		context.Background(),
+		"demo-app",
+		"u1",
+		func(current string) (string, error) {
+			require.Contains(t, current, "# Memory")
+			return current + "\n- Added fact\n", nil
+		},
+	)
+	require.NoError(t, err)
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Contains(t, string(raw), "- Added fact")
+}
+
+func TestStoreUpdateMemoryUpdatesExistingFile(t *testing.T) {
+	t.Parallel()
+
+	root, err := DefaultRoot(t.TempDir())
+	require.NoError(t, err)
+	store, err := NewStore(root)
+	require.NoError(t, err)
+
+	path, err := store.MemoryPath("demo-app", "u1")
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), dirPerm))
+	require.NoError(t, os.WriteFile(path, []byte("original"), filePerm))
+
+	got, err := store.UpdateMemory(
+		context.Background(),
+		"demo-app",
+		"u1",
+		func(current string) (string, error) {
+			require.Equal(t, "original", current)
+			return "updated", nil
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, path, got)
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, "updated", string(raw))
+}
+
+func TestStoreUpdateMemory_NilStoreReturnsError(t *testing.T) {
+	t.Parallel()
+
+	var store *Store
+	_, err := store.UpdateMemory(
+		context.Background(),
+		"demo-app",
+		"u1",
+		func(current string) (string, error) {
+			return current, nil
+		},
+	)
+	require.Error(t, err)
+}
+
+func TestStoreUpdateMemory_NilUpdateReturnsError(t *testing.T) {
+	t.Parallel()
+
+	root, err := DefaultRoot(t.TempDir())
+	require.NoError(t, err)
+	store, err := NewStore(root)
+	require.NoError(t, err)
+
+	_, err = store.UpdateMemory(context.Background(), "demo-app", "u1", nil)
+	require.Error(t, err)
+}
+
+func TestStoreUpdateMemory_CanceledContextReturnsError(t *testing.T) {
+	t.Parallel()
+
+	root, err := DefaultRoot(t.TempDir())
+	require.NoError(t, err)
+	store, err := NewStore(root)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = store.UpdateMemory(
+		ctx,
+		"demo-app",
+		"u1",
+		func(current string) (string, error) {
+			return current, nil
+		},
+	)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestStoreUpdateMemory_EmptyScopeReturnsError(t *testing.T) {
+	t.Parallel()
+
+	root, err := DefaultRoot(t.TempDir())
+	require.NoError(t, err)
+	store, err := NewStore(root)
+	require.NoError(t, err)
+
+	_, err = store.UpdateMemory(
+		context.Background(),
+		" ",
+		"u1",
+		func(current string) (string, error) {
+			return current, nil
+		},
+	)
+	require.Error(t, err)
+}
+
+func TestStoreUpdateMemory_UpdateFuncErrorKeepsOriginalFile(t *testing.T) {
+	t.Parallel()
+
+	root, err := DefaultRoot(t.TempDir())
+	require.NoError(t, err)
+	store, err := NewStore(root)
+	require.NoError(t, err)
+
+	path, err := store.MemoryPath("demo-app", "u1")
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), dirPerm))
+	require.NoError(t, os.WriteFile(path, []byte("original"), filePerm))
+
+	updateErr := errors.New("boom")
+	_, err = store.UpdateMemory(
+		context.Background(),
+		"demo-app",
+		"u1",
+		func(current string) (string, error) {
+			require.Equal(t, "original", current)
+			return "", updateErr
+		},
+	)
+	require.ErrorIs(t, err, updateErr)
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, "original", string(raw))
+}
+
+func TestStoreUpdateMemory_CanceledAfterUpdateKeepsOriginalFile(t *testing.T) {
+	t.Parallel()
+
+	root, err := DefaultRoot(t.TempDir())
+	require.NoError(t, err)
+	store, err := NewStore(root)
+	require.NoError(t, err)
+
+	path, err := store.MemoryPath("demo-app", "u1")
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), dirPerm))
+	require.NoError(t, os.WriteFile(path, []byte("original"), filePerm))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	_, err = store.UpdateMemory(
+		ctx,
+		"demo-app",
+		"u1",
+		func(current string) (string, error) {
+			cancel()
+			return "updated", nil
+		},
+	)
+	require.ErrorIs(t, err, context.Canceled)
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, "original", string(raw))
+}
+
+func TestStoreUpdateMemory_WriteErrorReturnsError(t *testing.T) {
+	t.Parallel()
+
+	root, err := DefaultRoot(t.TempDir())
+	require.NoError(t, err)
+	store, err := NewStore(root)
+	require.NoError(t, err)
+
+	path, err := store.MemoryPath("demo-app", "u1")
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), dirPerm))
+	require.NoError(t, os.WriteFile(path, []byte("original"), filePerm))
+
+	_, err = store.UpdateMemory(
+		context.Background(),
+		"demo-app",
+		"u1",
+		func(current string) (string, error) {
+			require.NoError(t, os.Remove(path))
+			require.NoError(t, os.Mkdir(path, dirPerm))
+			return "updated", nil
+		},
+	)
 	require.Error(t, err)
 }
 


### PR DESCRIPTION
## Summary
- route bare `MEMORY.md` file-tool reads and writes to the active file-backed user memory instead of the OpenClaw state root
- keep the fix scoped to file-backed memory by registering the callback only when a memory file store is configured
- add neutral tests for save, read, and replace flows so DM-written durable memory remains visible in later chats

## Test plan
- [x] `go test ./app ./internal/memoryfile`
- [x] verified the callback tests cover save, read, and replace behavior for scoped memory files
