### PR TITLE
{agent,processor,openclaw,docs}: guard oversized tool results

### DIFF
--- a/agent/graphagent/graph_agent.go
+++ b/agent/graphagent/graph_agent.go
@@ -431,8 +431,8 @@ func (ga *GraphAgent) createInitialState(ctx context.Context, invocation *agent.
 			processor.WithContextCompactionToolResultMaxTokens(
 				ga.options.ContextCompactionToolResultMaxTokens,
 			),
-			processor.WithOversizedToolResultMaxTokens(
-				ga.options.OversizedToolResultMaxTokens,
+			processor.WithContextCompactionOversizedToolResultMaxTokens(
+				ga.options.ContextCompactionOversizedToolResultMaxTokens,
 			),
 			processor.WithPreserveSameBranch(true),
 			processor.WithTimelineFilterMode(ga.options.messageTimelineFilterMode),

--- a/agent/graphagent/graph_agent.go
+++ b/agent/graphagent/graph_agent.go
@@ -431,6 +431,9 @@ func (ga *GraphAgent) createInitialState(ctx context.Context, invocation *agent.
 			processor.WithContextCompactionToolResultMaxTokens(
 				ga.options.ContextCompactionToolResultMaxTokens,
 			),
+			processor.WithOversizedToolResultMaxTokens(
+				ga.options.OversizedToolResultMaxTokens,
+			),
 			processor.WithPreserveSameBranch(true),
 			processor.WithTimelineFilterMode(ga.options.messageTimelineFilterMode),
 			processor.WithBranchFilterMode(ga.options.messageBranchFilterMode),

--- a/agent/graphagent/option.go
+++ b/agent/graphagent/option.go
@@ -263,6 +263,17 @@ func WithContextCompactionKeepRecentRequests(n int) Option {
 	}
 }
 
+// WithOversizedToolResultMaxTokens sets the token threshold above which any
+// tool result (including from the current request) is truncated using
+// head+tail preservation.
+func WithOversizedToolResultMaxTokens(tokens int) Option {
+	return func(opts *Options) {
+		if tokens >= 0 {
+			opts.OversizedToolResultMaxTokens = tokens
+		}
+	}
+}
+
 // WithMessageTimelineFilterMode sets the message timeline filter mode.
 func WithMessageTimelineFilterMode(mode string) Option {
 	return func(opts *Options) {

--- a/agent/graphagent/option.go
+++ b/agent/graphagent/option.go
@@ -116,6 +116,10 @@ type Options struct {
 	// ContextCompactionKeepRecentRequests preserves the latest N completed
 	// requests in full when request-side context compaction is enabled.
 	ContextCompactionKeepRecentRequests int
+	// OversizedToolResultMaxTokens sets the token threshold above which any
+	// tool result (including from the current request) is truncated using
+	// head+tail preservation.
+	OversizedToolResultMaxTokens int
 	// summaryFormatter allows custom formatting of session summary content.
 	// When nil (default), uses default formatSummaryContent function.
 	summaryFormatter func(summary string) string
@@ -145,6 +149,7 @@ var (
 		ChannelBufferSize:                    defaultChannelBufferSize,
 		ContextCompactionToolResultMaxTokens: processor.DefaultContextCompactionToolResultMaxTokens,
 		ContextCompactionKeepRecentRequests:  processor.DefaultContextCompactionKeepRecentRequests,
+		OversizedToolResultMaxTokens:         processor.DefaultOversizedToolResultMaxTokens,
 	}
 )
 

--- a/agent/graphagent/option.go
+++ b/agent/graphagent/option.go
@@ -116,10 +116,11 @@ type Options struct {
 	// ContextCompactionKeepRecentRequests preserves the latest N completed
 	// requests in full when request-side context compaction is enabled.
 	ContextCompactionKeepRecentRequests int
-	// OversizedToolResultMaxTokens sets the token threshold above which any
-	// tool result (including from the current request) is truncated using
-	// head+tail preservation.
-	OversizedToolResultMaxTokens int
+	// ContextCompactionOversizedToolResultMaxTokens sets the token threshold
+	// above which any tool result (including from the current request) is
+	// truncated using head+tail preservation. Fires regardless of
+	// EnableContextCompaction. 0 disables it.
+	ContextCompactionOversizedToolResultMaxTokens int
 	// summaryFormatter allows custom formatting of session summary content.
 	// When nil (default), uses default formatSummaryContent function.
 	summaryFormatter func(summary string) string
@@ -149,7 +150,7 @@ var (
 		ChannelBufferSize:                    defaultChannelBufferSize,
 		ContextCompactionToolResultMaxTokens: processor.DefaultContextCompactionToolResultMaxTokens,
 		ContextCompactionKeepRecentRequests:  processor.DefaultContextCompactionKeepRecentRequests,
-		OversizedToolResultMaxTokens:         processor.DefaultOversizedToolResultMaxTokens,
+		ContextCompactionOversizedToolResultMaxTokens: processor.DefaultContextCompactionOversizedToolResultMaxTokens,
 	}
 )
 
@@ -263,13 +264,13 @@ func WithContextCompactionKeepRecentRequests(n int) Option {
 	}
 }
 
-// WithOversizedToolResultMaxTokens sets the token threshold above which any
-// tool result (including from the current request) is truncated using
-// head+tail preservation.
-func WithOversizedToolResultMaxTokens(tokens int) Option {
+// WithContextCompactionOversizedToolResultMaxTokens sets the token threshold
+// above which any tool result (including from the current request) is truncated
+// using head+tail preservation. Fires regardless of EnableContextCompaction.
+func WithContextCompactionOversizedToolResultMaxTokens(tokens int) Option {
 	return func(opts *Options) {
 		if tokens >= 0 {
-			opts.OversizedToolResultMaxTokens = tokens
+			opts.ContextCompactionOversizedToolResultMaxTokens = tokens
 		}
 	}
 }

--- a/agent/graphagent/option.go
+++ b/agent/graphagent/option.go
@@ -147,9 +147,9 @@ type Options struct {
 
 var (
 	defaultOptions = Options{
-		ChannelBufferSize:                    defaultChannelBufferSize,
-		ContextCompactionToolResultMaxTokens: processor.DefaultContextCompactionToolResultMaxTokens,
-		ContextCompactionKeepRecentRequests:  processor.DefaultContextCompactionKeepRecentRequests,
+		ChannelBufferSize:                             defaultChannelBufferSize,
+		ContextCompactionToolResultMaxTokens:          processor.DefaultContextCompactionToolResultMaxTokens,
+		ContextCompactionKeepRecentRequests:           processor.DefaultContextCompactionKeepRecentRequests,
 		ContextCompactionOversizedToolResultMaxTokens: processor.DefaultContextCompactionOversizedToolResultMaxTokens,
 	}
 )

--- a/agent/graphagent/option_test.go
+++ b/agent/graphagent/option_test.go
@@ -161,10 +161,10 @@ func TestWithContextCompactionOptions(t *testing.T) {
 	WithContextCompactionKeepRecentRequests(-1)(opts)
 	require.Equal(t, 2, opts.ContextCompactionKeepRecentRequests)
 
-	WithOversizedToolResultMaxTokens(4096)(opts)
-	require.Equal(t, 4096, opts.OversizedToolResultMaxTokens)
-	WithOversizedToolResultMaxTokens(-1)(opts)
-	require.Equal(t, 4096, opts.OversizedToolResultMaxTokens)
+	WithContextCompactionOversizedToolResultMaxTokens(4096)(opts)
+	require.Equal(t, 4096, opts.ContextCompactionOversizedToolResultMaxTokens)
+	WithContextCompactionOversizedToolResultMaxTokens(-1)(opts)
+	require.Equal(t, 4096, opts.ContextCompactionOversizedToolResultMaxTokens)
 }
 
 func TestWithReasoningContentMode(t *testing.T) {

--- a/agent/graphagent/option_test.go
+++ b/agent/graphagent/option_test.go
@@ -160,6 +160,11 @@ func TestWithContextCompactionOptions(t *testing.T) {
 	require.Equal(t, 2, opts.ContextCompactionKeepRecentRequests)
 	WithContextCompactionKeepRecentRequests(-1)(opts)
 	require.Equal(t, 2, opts.ContextCompactionKeepRecentRequests)
+
+	WithOversizedToolResultMaxTokens(4096)(opts)
+	require.Equal(t, 4096, opts.OversizedToolResultMaxTokens)
+	WithOversizedToolResultMaxTokens(-1)(opts)
+	require.Equal(t, 4096, opts.OversizedToolResultMaxTokens)
 }
 
 func TestWithReasoningContentMode(t *testing.T) {

--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -331,6 +331,9 @@ func buildRequestProcessorsWithAgent(a *LLMAgent, options *Options) []flow.Reque
 		processor.WithContextCompactionToolResultMaxTokens(
 			options.ContextCompactionToolResultMaxTokens,
 		),
+		processor.WithOversizedToolResultMaxTokens(
+			options.OversizedToolResultMaxTokens,
+		),
 		processor.WithPreserveSameBranch(options.PreserveSameBranch),
 		processor.WithTimelineFilterMode(options.messageTimelineFilterMode),
 		processor.WithBranchFilterMode(options.messageBranchFilterMode),

--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -331,8 +331,8 @@ func buildRequestProcessorsWithAgent(a *LLMAgent, options *Options) []flow.Reque
 		processor.WithContextCompactionToolResultMaxTokens(
 			options.ContextCompactionToolResultMaxTokens,
 		),
-		processor.WithOversizedToolResultMaxTokens(
-			options.OversizedToolResultMaxTokens,
+		processor.WithContextCompactionOversizedToolResultMaxTokens(
+			options.ContextCompactionOversizedToolResultMaxTokens,
 		),
 		processor.WithPreserveSameBranch(options.PreserveSameBranch),
 		processor.WithTimelineFilterMode(options.messageTimelineFilterMode),

--- a/agent/llmagent/option.go
+++ b/agent/llmagent/option.go
@@ -140,7 +140,7 @@ var (
 		ContextCompactionThresholdRatio:      0.7,
 		ContextCompactionToolResultMaxTokens: processor.DefaultContextCompactionToolResultMaxTokens,
 		ContextCompactionKeepRecentRequests:  processor.DefaultContextCompactionKeepRecentRequests,
-		OversizedToolResultMaxTokens:         processor.DefaultOversizedToolResultMaxTokens,
+		ContextCompactionOversizedToolResultMaxTokens: processor.DefaultContextCompactionOversizedToolResultMaxTokens,
 
 		skillRunRequireSkillLoaded: true,
 	}
@@ -275,11 +275,11 @@ type Options struct {
 	// ContextCompactionKeepRecentRequests preserves the latest N completed
 	// requests in full when request-side context compaction is enabled.
 	ContextCompactionKeepRecentRequests int
-	// OversizedToolResultMaxTokens sets the token threshold above which any
-	// tool result (including from the current request) is truncated using
-	// head+tail preservation. Protects against single tool results large
-	// enough to overflow the context window on their own.
-	OversizedToolResultMaxTokens int
+	// ContextCompactionOversizedToolResultMaxTokens sets the token threshold
+	// above which any tool result (including from the current request) is
+	// truncated using head+tail preservation. This fires regardless of
+	// EnableContextCompaction. 0 disables it.
+	ContextCompactionOversizedToolResultMaxTokens int
 	// summaryFormatter allows custom formatting of session summary content.
 	// When nil (default), uses the default formatSummaryContent function.
 	summaryFormatter func(summary string) string
@@ -1049,14 +1049,14 @@ func WithContextCompactionKeepRecentRequests(n int) Option {
 	}
 }
 
-// WithOversizedToolResultMaxTokens sets the token threshold above which any
-// tool result (including from the current request) is truncated using
-// head+tail preservation. Protects against single tool results large
-// enough to overflow the context window on their own.
-func WithOversizedToolResultMaxTokens(tokens int) Option {
+// WithContextCompactionOversizedToolResultMaxTokens sets the token threshold
+// above which any tool result (including from the current request) is truncated
+// using head+tail preservation. This fires regardless of
+// EnableContextCompaction. 0 disables it.
+func WithContextCompactionOversizedToolResultMaxTokens(tokens int) Option {
 	return func(opts *Options) {
 		if tokens >= 0 {
-			opts.OversizedToolResultMaxTokens = tokens
+			opts.ContextCompactionOversizedToolResultMaxTokens = tokens
 		}
 	}
 }

--- a/agent/llmagent/option.go
+++ b/agent/llmagent/option.go
@@ -136,10 +136,10 @@ var (
 
 		SkipSkillsFallbackOnSessionSummary: true,
 
-		EnableContextCompaction:              false,
-		ContextCompactionThresholdRatio:      0.7,
-		ContextCompactionToolResultMaxTokens: processor.DefaultContextCompactionToolResultMaxTokens,
-		ContextCompactionKeepRecentRequests:  processor.DefaultContextCompactionKeepRecentRequests,
+		EnableContextCompaction:                       false,
+		ContextCompactionThresholdRatio:               0.7,
+		ContextCompactionToolResultMaxTokens:          processor.DefaultContextCompactionToolResultMaxTokens,
+		ContextCompactionKeepRecentRequests:           processor.DefaultContextCompactionKeepRecentRequests,
 		ContextCompactionOversizedToolResultMaxTokens: processor.DefaultContextCompactionOversizedToolResultMaxTokens,
 
 		skillRunRequireSkillLoaded: true,

--- a/agent/llmagent/option.go
+++ b/agent/llmagent/option.go
@@ -140,6 +140,7 @@ var (
 		ContextCompactionThresholdRatio:      0.7,
 		ContextCompactionToolResultMaxTokens: processor.DefaultContextCompactionToolResultMaxTokens,
 		ContextCompactionKeepRecentRequests:  processor.DefaultContextCompactionKeepRecentRequests,
+		OversizedToolResultMaxTokens:         processor.DefaultOversizedToolResultMaxTokens,
 
 		skillRunRequireSkillLoaded: true,
 	}
@@ -274,6 +275,11 @@ type Options struct {
 	// ContextCompactionKeepRecentRequests preserves the latest N completed
 	// requests in full when request-side context compaction is enabled.
 	ContextCompactionKeepRecentRequests int
+	// OversizedToolResultMaxTokens sets the token threshold above which any
+	// tool result (including from the current request) is truncated using
+	// head+tail preservation. Protects against single tool results large
+	// enough to overflow the context window on their own.
+	OversizedToolResultMaxTokens int
 	// summaryFormatter allows custom formatting of session summary content.
 	// When nil (default), uses the default formatSummaryContent function.
 	summaryFormatter func(summary string) string
@@ -1039,6 +1045,18 @@ func WithContextCompactionKeepRecentRequests(n int) Option {
 	return func(opts *Options) {
 		if n >= 0 {
 			opts.ContextCompactionKeepRecentRequests = n
+		}
+	}
+}
+
+// WithOversizedToolResultMaxTokens sets the token threshold above which any
+// tool result (including from the current request) is truncated using
+// head+tail preservation. Protects against single tool results large
+// enough to overflow the context window on their own.
+func WithOversizedToolResultMaxTokens(tokens int) Option {
+	return func(opts *Options) {
+		if tokens >= 0 {
+			opts.OversizedToolResultMaxTokens = tokens
 		}
 	}
 }

--- a/agent/llmagent/option_test.go
+++ b/agent/llmagent/option_test.go
@@ -100,10 +100,10 @@ func TestWithContextCompactionOptions(t *testing.T) {
 	WithContextCompactionKeepRecentRequests(-1)(opts)
 	require.Equal(t, 3, opts.ContextCompactionKeepRecentRequests)
 
-	WithOversizedToolResultMaxTokens(4096)(opts)
-	require.Equal(t, 4096, opts.OversizedToolResultMaxTokens)
-	WithOversizedToolResultMaxTokens(-1)(opts)
-	require.Equal(t, 4096, opts.OversizedToolResultMaxTokens)
+	WithContextCompactionOversizedToolResultMaxTokens(4096)(opts)
+	require.Equal(t, 4096, opts.ContextCompactionOversizedToolResultMaxTokens)
+	WithContextCompactionOversizedToolResultMaxTokens(-1)(opts)
+	require.Equal(t, 4096, opts.ContextCompactionOversizedToolResultMaxTokens)
 }
 
 func TestWithMessageFilterMode(t *testing.T) {

--- a/agent/llmagent/option_test.go
+++ b/agent/llmagent/option_test.go
@@ -99,6 +99,11 @@ func TestWithContextCompactionOptions(t *testing.T) {
 	require.Equal(t, 3, opts.ContextCompactionKeepRecentRequests)
 	WithContextCompactionKeepRecentRequests(-1)(opts)
 	require.Equal(t, 3, opts.ContextCompactionKeepRecentRequests)
+
+	WithOversizedToolResultMaxTokens(4096)(opts)
+	require.Equal(t, 4096, opts.OversizedToolResultMaxTokens)
+	WithOversizedToolResultMaxTokens(-1)(opts)
+	require.Equal(t, 4096, opts.OversizedToolResultMaxTokens)
 }
 
 func TestWithMessageFilterMode(t *testing.T) {

--- a/docs/mkdocs/en/session.md
+++ b/docs/mkdocs/en/session.md
@@ -1787,9 +1787,9 @@ The framework provides two distinct modes for managing conversation context sent
 
 When `WithEnableContextCompaction(true)` is enabled, the framework adds a lightweight Phase 1 compaction pass before the LLM call:
 
-- Historical oversized tool results from older requests are replaced with a placeholder while keeping `ToolID` and `ToolName`.
-- The current request is never compacted.
-- The latest `ContextCompactionKeepRecentRequests` completed requests are kept intact.
+- **Pass 1** — Historical tool results from older requests that exceed `ContextCompactionToolResultMaxTokens` (default 1024 tokens) are replaced with a placeholder while keeping `ToolID` and `ToolName`.
+- **Pass 2** — Any single tool result (including the current request) exceeding `OversizedToolResultMaxTokens` (default 8192 tokens) is truncated using head+tail preservation with a `[...N characters truncated...]` marker.
+- The latest `ContextCompactionKeepRecentRequests` completed requests are exempt from Pass 1 (but not Pass 2).
 - If `WithAddSessionSummary(true)` is also enabled and the rebuilt request still approaches the model context window, the framework performs one synchronous `CreateSessionSummary(...)` retry before calling the model.
 - Model-layer token tailoring remains the final fallback.
 
@@ -1800,7 +1800,8 @@ llmAgent := llmagent.New(
     llmagent.WithAddSessionSummary(true),
     llmagent.WithEnableContextCompaction(true),
     llmagent.WithContextCompactionThresholdRatio(0.7),
-    llmagent.WithContextCompactionToolResultMaxTokens(1024),
+    llmagent.WithContextCompactionToolResultMaxTokens(1024),  // Pass 1: old tool results → placeholder
+    llmagent.WithOversizedToolResultMaxTokens(8192),          // Pass 2: any huge result → head+tail
     llmagent.WithContextCompactionKeepRecentRequests(1),
 )
 ```
@@ -1810,7 +1811,7 @@ llmAgent := llmagent.New(
 - No summary is prepended.
 - Only the **most recent `MaxHistoryRuns` conversation turns** are included.
 - When `MaxHistoryRuns=0` (default), no limit is applied and all history is included.
-- If `WithEnableContextCompaction(true)` is enabled, oversized tool results in older retained requests can still be compacted during request projection.
+- If `WithEnableContextCompaction(true)` is enabled, oversized tool results in older retained requests can still be compacted (Pass 1) and extremely large tool results in any request can be head+tail truncated (Pass 2) during request projection.
 - The pre-LLM synchronous summary retry is disabled in this mode.
 - Use this mode for short sessions or when you want direct control over context window size.
 

--- a/docs/mkdocs/en/session.md
+++ b/docs/mkdocs/en/session.md
@@ -1788,7 +1788,7 @@ The framework provides two distinct modes for managing conversation context sent
 When `WithEnableContextCompaction(true)` is enabled, the framework adds a lightweight Phase 1 compaction pass before the LLM call:
 
 - **Pass 1** — Historical tool results from older requests that exceed `ContextCompactionToolResultMaxTokens` (default 1024 tokens) are replaced with a placeholder while keeping `ToolID` and `ToolName`.
-- **Pass 2** — Any single tool result (including the current request) exceeding `OversizedToolResultMaxTokens` (default 8192 tokens) is truncated using head+tail preservation with a `[...N characters truncated...]` marker.
+- **Pass 2** — Any single tool result (including the current request) exceeding `ContextCompactionOversizedToolResultMaxTokens` (default 8192 tokens) is truncated using head+tail preservation with a `[...N characters truncated...]` marker. Pass 2 fires independently of `EnableContextCompaction`.
 - The latest `ContextCompactionKeepRecentRequests` completed requests are exempt from Pass 1 (but not Pass 2).
 - If `WithAddSessionSummary(true)` is also enabled and the rebuilt request still approaches the model context window, the framework performs one synchronous `CreateSessionSummary(...)` retry before calling the model.
 - Model-layer token tailoring remains the final fallback.
@@ -1801,7 +1801,7 @@ llmAgent := llmagent.New(
     llmagent.WithEnableContextCompaction(true),
     llmagent.WithContextCompactionThresholdRatio(0.7),
     llmagent.WithContextCompactionToolResultMaxTokens(1024),  // Pass 1: old tool results → placeholder
-    llmagent.WithOversizedToolResultMaxTokens(8192),          // Pass 2: any huge result → head+tail
+    llmagent.WithContextCompactionOversizedToolResultMaxTokens(8192),  // Pass 2: any huge result → head+tail
     llmagent.WithContextCompactionKeepRecentRequests(1),
 )
 ```

--- a/docs/mkdocs/en/session/index.md
+++ b/docs/mkdocs/en/session/index.md
@@ -81,7 +81,8 @@ func main() {
         // Optional: compact oversized historical tool results before the LLM call
         // WithAddSessionSummary(true) additionally enables one sync summary retry when needed
         llmagent.WithEnableContextCompaction(true),
-        llmagent.WithContextCompactionToolResultMaxTokens(1024),
+        llmagent.WithContextCompactionToolResultMaxTokens(1024),  // old tool results → placeholder
+        llmagent.WithOversizedToolResultMaxTokens(8192),          // any huge result → head+tail truncation
         llmagent.WithContextCompactionKeepRecentRequests(1),
         // Note: WithAddSessionSummary(true) ignores WithMaxHistoryRuns
         // Summary includes all history, incremental events are fully retained

--- a/docs/mkdocs/en/session/index.md
+++ b/docs/mkdocs/en/session/index.md
@@ -82,7 +82,7 @@ func main() {
         // WithAddSessionSummary(true) additionally enables one sync summary retry when needed
         llmagent.WithEnableContextCompaction(true),
         llmagent.WithContextCompactionToolResultMaxTokens(1024),  // old tool results → placeholder
-        llmagent.WithOversizedToolResultMaxTokens(8192),          // any huge result → head+tail truncation
+        llmagent.WithContextCompactionOversizedToolResultMaxTokens(8192),  // any huge result → head+tail truncation
         llmagent.WithContextCompactionKeepRecentRequests(1),
         // Note: WithAddSessionSummary(true) ignores WithMaxHistoryRuns
         // Summary includes all history, incremental events are fully retained

--- a/docs/mkdocs/en/session/summary.md
+++ b/docs/mkdocs/en/session/summary.md
@@ -608,13 +608,17 @@ When `WithEnableContextCompaction(true)` is enabled, the framework adds two comp
 - The current request and the latest `ContextCompactionKeepRecentRequests` completed requests are never affected
 - This cleans up accumulated long tool outputs from earlier conversation turns
 
-**Pass 2 — Oversized tool result truncation** (`OversizedToolResultMaxTokens`, default 8192 tokens):
+**Pass 2 — Oversized tool result truncation** (`ContextCompactionOversizedToolResultMaxTokens`, default 8192 tokens):
 
 - Applies to **all** tool results including the current request
 - Tool results exceeding this threshold are truncated using head+tail preservation: the beginning and end of the content are kept, with a `[...N characters truncated...]` marker in the middle
 - This is the safety net for single tool results large enough to overflow the context window on their own (e.g. `web_fetch` returning 800K+ chars of HTML)
 
 The two passes have different roles: Pass 1 aggressively cleans old history (low threshold, full replacement); Pass 2 is a high-threshold guard that only kicks in for extreme cases but protects the current request too.
+
+Additionally:
+
+Pass 2 fires regardless of `EnableContextCompaction`; it only requires `ContextCompactionOversizedToolResultMaxTokens > 0`.
 
 Additionally:
 
@@ -629,7 +633,7 @@ agent := llmagent.New(
     llmagent.WithEnableContextCompaction(true),
     llmagent.WithContextCompactionThresholdRatio(0.7),
     llmagent.WithContextCompactionToolResultMaxTokens(1024),  // Pass 1: old tool results → placeholder
-    llmagent.WithOversizedToolResultMaxTokens(8192),          // Pass 2: any huge result → head+tail
+    llmagent.WithContextCompactionOversizedToolResultMaxTokens(8192),  // Pass 2: any huge result → head+tail
     llmagent.WithContextCompactionKeepRecentRequests(1),
 )
 ```
@@ -669,7 +673,7 @@ llmagent.WithMaxHistoryRuns(10)
 - No summary message added
 - Only includes the most recent `MaxHistoryRuns` conversation turns
 - `MaxHistoryRuns=0` means no limit, includes all history
-- If `WithEnableContextCompaction(true)` is enabled, oversized tool results in older retained requests can still be compacted during request projection, and extremely large tool results in any request (including the current one) will be head+tail truncated
+- If `WithEnableContextCompaction(true)` is enabled, oversized tool results in older retained requests can still be compacted during request projection; additionally, extremely large tool results in any request (including the current one) will be head+tail truncated whenever `ContextCompactionOversizedToolResultMaxTokens > 0` (this fires even without `EnableContextCompaction`)
 - The pre-LLM synchronous summary retry is disabled in this mode
 
 **Context structure**:
@@ -696,7 +700,7 @@ llmagent.WithMaxHistoryRuns(10)
 
 If your long sessions frequently contain large tool outputs such as search results, logs, or code scan output, enable `EnableContextCompaction=true`. Pair it with `AddSessionSummary=true` when you also want the pre-LLM synchronous summary retry.
 
-> **Tip**: If your agent uses tools like `web_fetch` that can return extremely large results in a single call, `OversizedToolResultMaxTokens` is particularly valuable — it prevents a single tool result from consuming the entire context window, even when that result belongs to the current (protected) request.
+> **Tip**: If your agent uses tools like `web_fetch` that can return extremely large results in a single call, `ContextCompactionOversizedToolResultMaxTokens` is particularly valuable — it prevents a single tool result from consuming the entire context window, even when that result belongs to the current (protected) request. It fires independently of `EnableContextCompaction`.
 
 ## Summary Format Customization
 

--- a/docs/mkdocs/en/session/summary.md
+++ b/docs/mkdocs/en/session/summary.md
@@ -600,11 +600,24 @@ llmagent.WithAddSessionSummary(true)
 
 **Optional: Prompt-side context compaction**
 
-When `WithEnableContextCompaction(true)` is enabled, the framework adds a lightweight Phase 1 compaction pass before the LLM call:
+When `WithEnableContextCompaction(true)` is enabled, the framework adds two compaction passes before the LLM call:
 
-- Historical oversized tool results from older requests are replaced with a placeholder while keeping `ToolID` and `ToolName`
-- The current request is never compacted
-- The latest `ContextCompactionKeepRecentRequests` completed requests are kept intact
+**Pass 1 — Historical tool result placeholder** (`ContextCompactionToolResultMaxTokens`, default 1024 tokens):
+
+- Tool results from **older** requests that exceed the threshold are replaced entirely with a short placeholder while keeping `ToolID` and `ToolName`
+- The current request and the latest `ContextCompactionKeepRecentRequests` completed requests are never affected
+- This cleans up accumulated long tool outputs from earlier conversation turns
+
+**Pass 2 — Oversized tool result truncation** (`OversizedToolResultMaxTokens`, default 8192 tokens):
+
+- Applies to **all** tool results including the current request
+- Tool results exceeding this threshold are truncated using head+tail preservation: the beginning and end of the content are kept, with a `[...N characters truncated...]` marker in the middle
+- This is the safety net for single tool results large enough to overflow the context window on their own (e.g. `web_fetch` returning 800K+ chars of HTML)
+
+The two passes have different roles: Pass 1 aggressively cleans old history (low threshold, full replacement); Pass 2 is a high-threshold guard that only kicks in for extreme cases but protects the current request too.
+
+Additionally:
+
 - If `WithAddSessionSummary(true)` is also enabled and the rebuilt request still approaches the model context window, the framework performs one synchronous `CreateSessionSummary(...)` retry before calling the model
 - Model-layer token tailoring remains the final fallback
 
@@ -615,7 +628,8 @@ agent := llmagent.New(
     llmagent.WithAddSessionSummary(true),
     llmagent.WithEnableContextCompaction(true),
     llmagent.WithContextCompactionThresholdRatio(0.7),
-    llmagent.WithContextCompactionToolResultMaxTokens(1024),
+    llmagent.WithContextCompactionToolResultMaxTokens(1024),  // Pass 1: old tool results → placeholder
+    llmagent.WithOversizedToolResultMaxTokens(8192),          // Pass 2: any huge result → head+tail
     llmagent.WithContextCompactionKeepRecentRequests(1),
 )
 ```
@@ -655,7 +669,7 @@ llmagent.WithMaxHistoryRuns(10)
 - No summary message added
 - Only includes the most recent `MaxHistoryRuns` conversation turns
 - `MaxHistoryRuns=0` means no limit, includes all history
-- If `WithEnableContextCompaction(true)` is enabled, oversized tool results in older retained requests can still be compacted during request projection
+- If `WithEnableContextCompaction(true)` is enabled, oversized tool results in older retained requests can still be compacted during request projection, and extremely large tool results in any request (including the current one) will be head+tail truncated
 - The pre-LLM synchronous summary retry is disabled in this mode
 
 **Context structure**:
@@ -681,6 +695,8 @@ llmagent.WithMaxHistoryRuns(10)
 | High concurrency | `AddSessionSummary=true`<br>Increase worker count | Async processing, no impact on response speed |
 
 If your long sessions frequently contain large tool outputs such as search results, logs, or code scan output, enable `EnableContextCompaction=true`. Pair it with `AddSessionSummary=true` when you also want the pre-LLM synchronous summary retry.
+
+> **Tip**: If your agent uses tools like `web_fetch` that can return extremely large results in a single call, `OversizedToolResultMaxTokens` is particularly valuable — it prevents a single tool result from consuming the entire context window, even when that result belongs to the current (protected) request.
 
 ## Summary Format Customization
 

--- a/docs/mkdocs/zh/session.md
+++ b/docs/mkdocs/zh/session.md
@@ -1873,7 +1873,7 @@ llmagent.WithAddSessionSummary(true)
 当开启 `WithEnableContextCompaction(true)` 时，框架会在真正调用模型前执行两遍压缩：
 
 - **Pass 1** — 旧 request 中超过 `ContextCompactionToolResultMaxTokens`（默认 1024 tokens）的 tool result 整体替换为占位符，保留 `ToolID` 和 `ToolName`
-- **Pass 2** — 任意 request（包括当前 request）中超过 `OversizedToolResultMaxTokens`（默认 8192 tokens）的单个 tool result，使用首尾保留策略截断，中间插入 `[...N characters truncated...]` 标记
+- **Pass 2** — 任意 request（包括当前 request）中超过 `ContextCompactionOversizedToolResultMaxTokens`（默认 8192 tokens）的单个 tool result，使用首尾保留策略截断，中间插入 `[...N characters truncated...]` 标记。Pass 2 独立于 `EnableContextCompaction`，只要设置了值就会生效
 - 最近 `ContextCompactionKeepRecentRequests` 个已完成 request 不受 Pass 1 影响（但 Pass 2 仍会生效）
 - 如果同时开启了 `WithAddSessionSummary(true)`，并且压完后请求仍接近 context window，会在 LLM 调用前同步执行一次 `CreateSessionSummary(...)` 并重建 request
 - 模型层的 token tailoring 仍然作为最后兜底
@@ -1886,7 +1886,7 @@ agent := llmagent.New(
     llmagent.WithEnableContextCompaction(true),
     llmagent.WithContextCompactionThresholdRatio(0.7),
     llmagent.WithContextCompactionToolResultMaxTokens(1024),  // Pass 1: 旧 tool result → 占位符
-    llmagent.WithOversizedToolResultMaxTokens(8192),          // Pass 2: 任意超大 result → 首尾保留截断
+    llmagent.WithContextCompactionOversizedToolResultMaxTokens(8192),  // Pass 2: 任意超大 result → 首尾保留截断
     llmagent.WithContextCompactionKeepRecentRequests(1),
 )
 ```

--- a/docs/mkdocs/zh/session.md
+++ b/docs/mkdocs/zh/session.md
@@ -1870,12 +1870,11 @@ llmagent.WithAddSessionSummary(true)
 
 **可选：Prompt 侧上下文压缩**
 
-当开启 `WithEnableContextCompaction(true)` 时，框架会在真正调用模型前增加一层轻量压缩：
+当开启 `WithEnableContextCompaction(true)` 时，框架会在真正调用模型前执行两遍压缩：
 
-- 只压缩旧 request 中过长的 `tool result`
-- 只替换正文，仍保留 `ToolID` 和 `ToolName`
-- 当前 request 永远不压
-- 最近 `ContextCompactionKeepRecentRequests` 个已完成 request 会完整保留
+- **Pass 1** — 旧 request 中超过 `ContextCompactionToolResultMaxTokens`（默认 1024 tokens）的 tool result 整体替换为占位符，保留 `ToolID` 和 `ToolName`
+- **Pass 2** — 任意 request（包括当前 request）中超过 `OversizedToolResultMaxTokens`（默认 8192 tokens）的单个 tool result，使用首尾保留策略截断，中间插入 `[...N characters truncated...]` 标记
+- 最近 `ContextCompactionKeepRecentRequests` 个已完成 request 不受 Pass 1 影响（但 Pass 2 仍会生效）
 - 如果同时开启了 `WithAddSessionSummary(true)`，并且压完后请求仍接近 context window，会在 LLM 调用前同步执行一次 `CreateSessionSummary(...)` 并重建 request
 - 模型层的 token tailoring 仍然作为最后兜底
 
@@ -1886,7 +1885,8 @@ agent := llmagent.New(
     llmagent.WithAddSessionSummary(true),
     llmagent.WithEnableContextCompaction(true),
     llmagent.WithContextCompactionThresholdRatio(0.7),
-    llmagent.WithContextCompactionToolResultMaxTokens(1024),
+    llmagent.WithContextCompactionToolResultMaxTokens(1024),  // Pass 1: 旧 tool result → 占位符
+    llmagent.WithOversizedToolResultMaxTokens(8192),          // Pass 2: 任意超大 result → 首尾保留截断
     llmagent.WithContextCompactionKeepRecentRequests(1),
 )
 ```
@@ -1920,7 +1920,7 @@ llmagent.WithMaxHistoryRuns(10)  // 限制历史轮次
 - 不添加摘要消息
 - 只包含最近 `MaxHistoryRuns` 轮对话
 - `MaxHistoryRuns=0` 时不限制，包含所有历史
-- 如果开启 `WithEnableContextCompaction(true)`，保留下来的旧 request 中超长 `tool result` 仍可在 request projection 阶段被压缩
+- 如果开启 `WithEnableContextCompaction(true)`，旧 request 中超长 tool result 仍可在 request projection 阶段被压缩（Pass 1），同时任意 request 中的超大 tool result 也会被首尾保留截断（Pass 2）
 - 这个模式下不会触发 pre-LLM 的同步摘要重试
 
 **上下文结构：**

--- a/docs/mkdocs/zh/session/index.md
+++ b/docs/mkdocs/zh/session/index.md
@@ -81,7 +81,7 @@ func main() {
         llmagent.WithEnableContextCompaction(true), // 可选：压缩历史超长 tool result
         // 配合 WithAddSessionSummary(true) 时，还会在必要时多一次同步摘要重试
         llmagent.WithContextCompactionToolResultMaxTokens(1024),  // 旧 tool result → 占位符
-        llmagent.WithOversizedToolResultMaxTokens(8192),          // 超大 result → 首尾保留截断
+        llmagent.WithContextCompactionOversizedToolResultMaxTokens(8192),  // 超大 result → 首尾保留截断
         llmagent.WithContextCompactionKeepRecentRequests(1),
         // 注意：WithAddSessionSummary(true) 时会忽略 WithMaxHistoryRuns 配置
         // 摘要会包含所有历史，增量事件会完整保留

--- a/docs/mkdocs/zh/session/index.md
+++ b/docs/mkdocs/zh/session/index.md
@@ -80,7 +80,8 @@ func main() {
         llmagent.WithAddSessionSummary(true), // 可选：启用摘要注入到上下文
         llmagent.WithEnableContextCompaction(true), // 可选：压缩历史超长 tool result
         // 配合 WithAddSessionSummary(true) 时，还会在必要时多一次同步摘要重试
-        llmagent.WithContextCompactionToolResultMaxTokens(1024),
+        llmagent.WithContextCompactionToolResultMaxTokens(1024),  // 旧 tool result → 占位符
+        llmagent.WithOversizedToolResultMaxTokens(8192),          // 超大 result → 首尾保留截断
         llmagent.WithContextCompactionKeepRecentRequests(1),
         // 注意：WithAddSessionSummary(true) 时会忽略 WithMaxHistoryRuns 配置
         // 摘要会包含所有历史，增量事件会完整保留

--- a/docs/mkdocs/zh/session/summary.md
+++ b/docs/mkdocs/zh/session/summary.md
@@ -612,13 +612,15 @@ llmagent.WithAddSessionSummary(true)
 - 当前 request 和最近 `ContextCompactionKeepRecentRequests` 个已完成 request 不受影响
 - 适合清理已不重要的历史工具输出
 
-**Pass 2 — 超大 tool result 截断**（`OversizedToolResultMaxTokens`，默认 8192 tokens）：
+**Pass 2 — 超大 tool result 截断**（`ContextCompactionOversizedToolResultMaxTokens`，默认 8192 tokens）：
 
 - 作用于**所有 tool result，包括当前 request 的**
 - 超过阈值的 tool result 会使用首尾保留策略截断：保留内容的开头和结尾，中间插入 `[...N characters truncated...]` 标记
 - 这是防止单个超大 tool result 直接撑爆 context window 的安全网（例如 `web_fetch` 返回 800K+ 字符的 HTML）
 
 两遍压缩的定位不同：Pass 1 低阈值、全量替换，激进清理旧历史；Pass 2 高阈值、只在极端情况触发，但能保护当前 request。
+
+Pass 2 独立于 `EnableContextCompaction`，只要 `ContextCompactionOversizedToolResultMaxTokens > 0` 就会生效。
 
 此外：
 
@@ -633,7 +635,7 @@ agent := llmagent.New(
     llmagent.WithEnableContextCompaction(true),
     llmagent.WithContextCompactionThresholdRatio(0.7),
     llmagent.WithContextCompactionToolResultMaxTokens(1024),  // Pass 1: 旧 tool result → 占位符
-    llmagent.WithOversizedToolResultMaxTokens(8192),          // Pass 2: 任意超大 result → 首尾保留截断
+    llmagent.WithContextCompactionOversizedToolResultMaxTokens(8192),  // Pass 2: 任意超大 result → 首尾保留截断
     llmagent.WithContextCompactionKeepRecentRequests(1),
 )
 ```
@@ -673,7 +675,7 @@ llmagent.WithMaxHistoryRuns(10)  // 限制历史轮次
 - 不添加摘要消息
 - 只包含最近 `MaxHistoryRuns` 轮对话
 - `MaxHistoryRuns=0` 时不限制，包含所有历史
-- 如果开启 `WithEnableContextCompaction(true)`，保留下来的旧 request 中超长 `tool result` 仍可在 request projection 阶段被压缩，同时任意 request（包括当前 request）中的超大 tool result 也会被首尾保留截断
+- 如果开启 `WithEnableContextCompaction(true)`，保留下来的旧 request 中超长 `tool result` 仍可在 request projection 阶段被压缩；此外只要 `ContextCompactionOversizedToolResultMaxTokens > 0`（即使未开启 `EnableContextCompaction`），任意 request 中的超大 tool result 也会被首尾保留截断
 - 这个模式下不会触发 pre-LLM 的同步摘要重试
 
 **上下文结构**：
@@ -700,7 +702,7 @@ llmagent.WithMaxHistoryRuns(10)  // 限制历史轮次
 
 如果你的长会话里经常出现搜索结果、日志、代码扫描输出这类长 `tool result`，建议开启 `EnableContextCompaction=true`。如果你还希望在接近 context window 时多一次同步摘要兜底，再配合 `AddSessionSummary=true` 一起使用。
 
-> **提示**：如果你的 agent 使用了 `web_fetch` 等可能单次返回超大结果的工具，`OversizedToolResultMaxTokens` 尤为重要——它能防止单个 tool result 吃光整个 context window，即使该 result 属于当前正在处理的（受保护的）request。
+> **提示**：如果你的 agent 使用了 `web_fetch` 等可能单次返回超大结果的工具，`ContextCompactionOversizedToolResultMaxTokens` 尤为重要——它能防止单个 tool result 吃光整个 context window，即使该 result 属于当前正在处理的（受保护的）request。它独立于 `EnableContextCompaction`，默认开启。
 
 ## 摘要格式自定义
 

--- a/docs/mkdocs/zh/session/summary.md
+++ b/docs/mkdocs/zh/session/summary.md
@@ -604,12 +604,24 @@ llmagent.WithAddSessionSummary(true)
 
 **可选：Prompt 侧上下文压缩**
 
-当开启 `WithEnableContextCompaction(true)` 时，框架会在真正调用模型前增加一层轻量压缩：
+当开启 `WithEnableContextCompaction(true)` 时，框架会在真正调用模型前执行两遍压缩：
 
-- 只压缩旧 request 中过长的 `tool result`
-- 只替换正文，仍保留 `ToolID` 和 `ToolName`
-- 当前 request 永远不压
-- 最近 `ContextCompactionKeepRecentRequests` 个已完成 request 会完整保留
+**Pass 1 — 历史 tool result 占位替换**（`ContextCompactionToolResultMaxTokens`，默认 1024 tokens）：
+
+- 只作用于**旧 request** 中超过阈值的 `tool result`，将其内容整体替换为简短占位符，但保留 `ToolID` 和 `ToolName`
+- 当前 request 和最近 `ContextCompactionKeepRecentRequests` 个已完成 request 不受影响
+- 适合清理已不重要的历史工具输出
+
+**Pass 2 — 超大 tool result 截断**（`OversizedToolResultMaxTokens`，默认 8192 tokens）：
+
+- 作用于**所有 tool result，包括当前 request 的**
+- 超过阈值的 tool result 会使用首尾保留策略截断：保留内容的开头和结尾，中间插入 `[...N characters truncated...]` 标记
+- 这是防止单个超大 tool result 直接撑爆 context window 的安全网（例如 `web_fetch` 返回 800K+ 字符的 HTML）
+
+两遍压缩的定位不同：Pass 1 低阈值、全量替换，激进清理旧历史；Pass 2 高阈值、只在极端情况触发，但能保护当前 request。
+
+此外：
+
 - 如果同时开启了 `WithAddSessionSummary(true)`，并且压完后请求仍接近 context window，会在 LLM 调用前同步执行一次 `CreateSessionSummary(...)` 并重建 request
 - 模型层的 token tailoring 仍然作为最后兜底
 
@@ -620,7 +632,8 @@ agent := llmagent.New(
     llmagent.WithAddSessionSummary(true),
     llmagent.WithEnableContextCompaction(true),
     llmagent.WithContextCompactionThresholdRatio(0.7),
-    llmagent.WithContextCompactionToolResultMaxTokens(1024),
+    llmagent.WithContextCompactionToolResultMaxTokens(1024),  // Pass 1: 旧 tool result → 占位符
+    llmagent.WithOversizedToolResultMaxTokens(8192),          // Pass 2: 任意超大 result → 首尾保留截断
     llmagent.WithContextCompactionKeepRecentRequests(1),
 )
 ```
@@ -660,7 +673,7 @@ llmagent.WithMaxHistoryRuns(10)  // 限制历史轮次
 - 不添加摘要消息
 - 只包含最近 `MaxHistoryRuns` 轮对话
 - `MaxHistoryRuns=0` 时不限制，包含所有历史
-- 如果开启 `WithEnableContextCompaction(true)`，保留下来的旧 request 中超长 `tool result` 仍可在 request projection 阶段被压缩
+- 如果开启 `WithEnableContextCompaction(true)`，保留下来的旧 request 中超长 `tool result` 仍可在 request projection 阶段被压缩，同时任意 request（包括当前 request）中的超大 tool result 也会被首尾保留截断
 - 这个模式下不会触发 pre-LLM 的同步摘要重试
 
 **上下文结构**：
@@ -686,6 +699,8 @@ llmagent.WithMaxHistoryRuns(10)  // 限制历史轮次
 | 高并发场景 | `AddSessionSummary=true`<br>增加 worker 数量 | 异步处理，不影响响应速度 |
 
 如果你的长会话里经常出现搜索结果、日志、代码扫描输出这类长 `tool result`，建议开启 `EnableContextCompaction=true`。如果你还希望在接近 context window 时多一次同步摘要兜底，再配合 `AddSessionSummary=true` 一起使用。
+
+> **提示**：如果你的 agent 使用了 `web_fetch` 等可能单次返回超大结果的工具，`OversizedToolResultMaxTokens` 尤为重要——它能防止单个 tool result 吃光整个 context window，即使该 result 属于当前正在处理的（受保护的）request。
 
 ## 摘要格式自定义
 

--- a/internal/flow/processor/content.go
+++ b/internal/flow/processor/content.go
@@ -1120,87 +1120,142 @@ func (p *ContentRequestProcessor) getCurrentInvocationMessages(inv *agent.Invoca
 		return nil
 	}
 
-	var events []event.Event
-	inv.Session.EventMu.RLock()
-	for _, evt := range inv.Session.Events {
-		// Only include events from current invocation
-		if evt.InvocationID != inv.InvocationID {
-			continue
-		}
-		// Skip invalid events
-		if evt.Response == nil || evt.IsPartial || !evt.IsValidContent() {
-			continue
-		}
-		// use error fill message content if message content is empty
-		if len(evt.Response.Choices) > 0 && evt.Response.Choices[0].Message.Content == "" && evt.Response.Error != nil {
-			rsp := evt.Response.Clone()
-			rsp.Choices[0].Message.Content = fmt.Sprintf("type: %s, message: %s", rsp.Error.Type, rsp.Error.Message)
-			evt.Response = rsp
-		}
-		events = append(events, evt)
-	}
-	inv.Session.EventMu.RUnlock()
-
-	// insert invocation message if not already included
-	var hasInvocationMessage bool
-	for _, evt := range events {
-		if invocationMessageEqual(inv.Message, evt.Choices[0].Message) {
-			hasInvocationMessage = true
-			break
-		}
-	}
-	if !hasInvocationMessage && model.HasPayload(inv.Message) {
+	events := p.collectCurrentInvocationEvents(inv)
+	if !containsInvocationMessage(events, inv.Message) &&
+		model.HasPayload(inv.Message) {
 		events = p.insertInvocationMessage(events, inv)
 	}
 
+	messages := p.projectCurrentInvocationMessages(inv, events)
+	messages = p.mergeUserMessages(messages)
+	messages = p.truncateOversizedToolResultMessages(messages)
+	messages = annotateUserMessagesWithAttachedFiles(messages)
+	return messages
+}
+
+func (p *ContentRequestProcessor) collectCurrentInvocationEvents(
+	inv *agent.Invocation,
+) []event.Event {
+	var events []event.Event
+	inv.Session.EventMu.RLock()
+	for _, evt := range inv.Session.Events {
+		if !isCurrentInvocationEligibleEvent(evt, inv.InvocationID) {
+			continue
+		}
+		events = append(events, normalizeCurrentInvocationEvent(evt))
+	}
+	inv.Session.EventMu.RUnlock()
+	return events
+}
+
+func isCurrentInvocationEligibleEvent(
+	evt event.Event,
+	invocationID string,
+) bool {
+	return evt.InvocationID == invocationID &&
+		evt.Response != nil &&
+		!evt.IsPartial &&
+		evt.IsValidContent()
+}
+
+func normalizeCurrentInvocationEvent(evt event.Event) event.Event {
+	if len(evt.Response.Choices) > 0 &&
+		evt.Response.Choices[0].Message.Content == "" &&
+		evt.Response.Error != nil {
+		rsp := evt.Response.Clone()
+		rsp.Choices[0].Message.Content = fmt.Sprintf(
+			"type: %s, message: %s",
+			rsp.Error.Type,
+			rsp.Error.Message,
+		)
+		evt.Response = rsp
+	}
+	return evt
+}
+
+func containsInvocationMessage(
+	events []event.Event,
+	invocationMessage model.Message,
+) bool {
+	for _, evt := range events {
+		if len(evt.Choices) == 0 {
+			continue
+		}
+		if invocationMessageEqual(invocationMessage, evt.Choices[0].Message) {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *ContentRequestProcessor) projectCurrentInvocationMessages(
+	inv *agent.Invocation,
+	events []event.Event,
+) []model.Message {
 	resultEvents := p.rearrangeLatestFuncResp(events)
 	resultEvents = p.rearrangeAsyncFuncRespHist(resultEvents)
 
-	// Get current request ID for reasoning content filtering.
 	currentRequestID := inv.RunOptions.RequestID
-
-	// Convert events to messages with reasoning content handling.
 	var messages []model.Message
 	for _, evt := range resultEvents {
-		// Convert foreign events or keep as-is (consistent with getIncrementMessages).
-		ev := evt
-		if p.isOtherAgentReply(inv.AgentName, inv.Branch, &ev) {
-			ev = p.convertForeignEvent(&ev)
-		}
-		if len(ev.Choices) > 0 {
-			for _, choice := range ev.Choices {
-				msg := choice.Message
-				msg = p.processReasoningContent(msg, evt.RequestID, currentRequestID)
-				msg = p.projectEventMessage(inv, evt, msg)
-				if isEmptyAssistantMessage(msg) {
-					continue
-				}
-				messages = append(messages, msg)
-			}
-		}
+		messages = append(
+			messages,
+			p.projectMessagesForEvent(inv, evt, currentRequestID)...,
+		)
+	}
+	return messages
+}
+
+func (p *ContentRequestProcessor) projectMessagesForEvent(
+	inv *agent.Invocation,
+	evt event.Event,
+	currentRequestID string,
+) []model.Message {
+	ev := evt
+	if p.isOtherAgentReply(inv.AgentName, inv.Branch, &ev) {
+		ev = p.convertForeignEvent(&ev)
+	}
+	if len(ev.Choices) == 0 {
+		return nil
 	}
 
-	messages = p.mergeUserMessages(messages)
-	if p.ContextCompactionConfig.Enabled &&
-		p.ContextCompactionConfig.OversizedToolResultMaxTokens > 0 {
-		var cloned bool
-		for i := range messages {
-			msg, truncated, _ := truncateOversizedToolResultMessage(
-				context.Background(),
-				messages[i],
-				p.ContextCompactionConfig.OversizedToolResultMaxTokens,
-			)
-			if !truncated {
-				continue
-			}
-			if !cloned {
-				messages = append([]model.Message(nil), messages...)
-				cloned = true
-			}
-			messages[i] = msg
+	var messages []model.Message
+	for _, choice := range ev.Choices {
+		msg := choice.Message
+		msg = p.processReasoningContent(msg, evt.RequestID, currentRequestID)
+		msg = p.projectEventMessage(inv, evt, msg)
+		if isEmptyAssistantMessage(msg) {
+			continue
 		}
+		messages = append(messages, msg)
 	}
-	messages = annotateUserMessagesWithAttachedFiles(messages)
+	return messages
+}
+
+func (p *ContentRequestProcessor) truncateOversizedToolResultMessages(
+	messages []model.Message,
+) []model.Message {
+	if !p.ContextCompactionConfig.Enabled ||
+		p.ContextCompactionConfig.OversizedToolResultMaxTokens <= 0 {
+		return messages
+	}
+
+	var cloned bool
+	for i := range messages {
+		msg, truncated, _ := truncateOversizedToolResultMessage(
+			context.Background(),
+			messages[i],
+			p.ContextCompactionConfig.OversizedToolResultMaxTokens,
+		)
+		if !truncated {
+			continue
+		}
+		if !cloned {
+			messages = append([]model.Message(nil), messages...)
+			cloned = true
+		}
+		messages[i] = msg
+	}
 	return messages
 }
 

--- a/internal/flow/processor/content.go
+++ b/internal/flow/processor/content.go
@@ -320,6 +320,16 @@ func WithContextCompactionToolResultMaxTokens(tokens int) ContentOption {
 	}
 }
 
+// WithOversizedToolResultMaxTokens sets the token threshold above which any
+// tool result (including from the current request) is truncated using
+// head+tail preservation. This protects against single tool results that are
+// large enough to overflow the context window on their own.
+func WithOversizedToolResultMaxTokens(tokens int) ContentOption {
+	return func(p *ContentRequestProcessor) {
+		p.ContextCompactionConfig.OversizedToolResultMaxTokens = tokens
+	}
+}
+
 // WithFewShotResolver sets an invocation-aware few-shot resolver.
 func WithFewShotResolver(
 	resolver func(*agent.Invocation) [][]model.Message,
@@ -368,8 +378,9 @@ func NewContentRequestProcessor(opts ...ContentOption) *ContentRequestProcessor 
 		PreloadSessionRecall:           0,
 		PreloadSessionRecallSearchMode: session.SearchModeHybrid,
 		ContextCompactionConfig: ContextCompactionConfig{
-			KeepRecentRequests:  DefaultContextCompactionKeepRecentRequests,
-			ToolResultMaxTokens: DefaultContextCompactionToolResultMaxTokens,
+			KeepRecentRequests:           DefaultContextCompactionKeepRecentRequests,
+			ToolResultMaxTokens:          DefaultContextCompactionToolResultMaxTokens,
+			OversizedToolResultMaxTokens: DefaultOversizedToolResultMaxTokens,
 		},
 	}
 

--- a/internal/flow/processor/content.go
+++ b/internal/flow/processor/content.go
@@ -320,11 +320,11 @@ func WithContextCompactionToolResultMaxTokens(tokens int) ContentOption {
 	}
 }
 
-// WithOversizedToolResultMaxTokens sets the token threshold above which any
-// tool result (including from the current request) is truncated using
-// head+tail preservation. This protects against single tool results that are
-// large enough to overflow the context window on their own.
-func WithOversizedToolResultMaxTokens(tokens int) ContentOption {
+// WithContextCompactionOversizedToolResultMaxTokens sets the token threshold
+// above which any tool result (including from the current request) is truncated
+// using head+tail preservation. This safety net fires regardless of whether
+// EnableContextCompaction is set.
+func WithContextCompactionOversizedToolResultMaxTokens(tokens int) ContentOption {
 	return func(p *ContentRequestProcessor) {
 		p.ContextCompactionConfig.OversizedToolResultMaxTokens = tokens
 	}
@@ -380,7 +380,7 @@ func NewContentRequestProcessor(opts ...ContentOption) *ContentRequestProcessor 
 		ContextCompactionConfig: ContextCompactionConfig{
 			KeepRecentRequests:           DefaultContextCompactionKeepRecentRequests,
 			ToolResultMaxTokens:          DefaultContextCompactionToolResultMaxTokens,
-			OversizedToolResultMaxTokens: DefaultOversizedToolResultMaxTokens,
+			OversizedToolResultMaxTokens: DefaultContextCompactionOversizedToolResultMaxTokens,
 		},
 	}
 
@@ -1235,8 +1235,7 @@ func (p *ContentRequestProcessor) projectMessagesForEvent(
 func (p *ContentRequestProcessor) truncateOversizedToolResultMessages(
 	messages []model.Message,
 ) []model.Message {
-	if !p.ContextCompactionConfig.Enabled ||
-		p.ContextCompactionConfig.OversizedToolResultMaxTokens <= 0 {
+	if p.ContextCompactionConfig.OversizedToolResultMaxTokens <= 0 {
 		return messages
 	}
 

--- a/internal/flow/processor/content.go
+++ b/internal/flow/processor/content.go
@@ -1181,6 +1181,25 @@ func (p *ContentRequestProcessor) getCurrentInvocationMessages(inv *agent.Invoca
 	}
 
 	messages = p.mergeUserMessages(messages)
+	if p.ContextCompactionConfig.Enabled &&
+		p.ContextCompactionConfig.OversizedToolResultMaxTokens > 0 {
+		var cloned bool
+		for i := range messages {
+			msg, truncated, _ := truncateOversizedToolResultMessage(
+				context.Background(),
+				messages[i],
+				p.ContextCompactionConfig.OversizedToolResultMaxTokens,
+			)
+			if !truncated {
+				continue
+			}
+			if !cloned {
+				messages = append([]model.Message(nil), messages...)
+				cloned = true
+			}
+			messages[i] = msg
+		}
+	}
 	messages = annotateUserMessagesWithAttachedFiles(messages)
 	return messages
 }

--- a/internal/flow/processor/content_test.go
+++ b/internal/flow/processor/content_test.go
@@ -12,11 +12,13 @@ package processor
 import (
 	"context"
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/event"
@@ -1705,6 +1707,17 @@ func TestNewContentRequestProcessor(t *testing.T) {
 				return &w
 			}(),
 		},
+		{
+			name: "oversized tool result limit option",
+			args: []ContentOption{
+				WithOversizedToolResultMaxTokens(64),
+			},
+			want: func() *ContentRequestProcessor {
+				w := *defaultWant
+				w.ContextCompactionConfig.OversizedToolResultMaxTokens = 64
+				return &w
+			}(),
+		},
 	}
 
 	for _, tt := range tests {
@@ -2453,6 +2466,80 @@ func TestContentRequestProcessor_IncludeContentsNoneSkipsHistory(t *testing.T) {
 	if msg.Role != model.RoleUser || msg.Content != "current" {
 		t.Fatalf("unexpected message: %+v", msg)
 	}
+}
+
+func TestContentRequestProcessor_IncludeContentsNoneTruncatesOversizedToolResults(t *testing.T) {
+	p := NewContentRequestProcessor(
+		WithEnableContextCompaction(true),
+		WithOversizedToolResultMaxTokens(32),
+	)
+
+	sess := &session.Session{
+		EventMu: sync.RWMutex{},
+		Events: []event.Event{
+			{
+				Author:       "assistant",
+				RequestID:    "req-1",
+				InvocationID: "inv-1",
+				Response: &model.Response{
+					Choices: []model.Choice{
+						{
+							Message: model.Message{
+								Role: model.RoleAssistant,
+								ToolCalls: []model.ToolCall{
+									{
+										ID: "call-1",
+										Function: model.FunctionDefinitionParam{
+											Name:      "fetch",
+											Arguments: []byte(`{}`),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Author:       "tool",
+				RequestID:    "req-1",
+				InvocationID: "inv-1",
+				Response: &model.Response{
+					Object: model.ObjectTypeToolResponse,
+					Choices: []model.Choice{
+						{
+							Message: model.NewToolMessage(
+								"call-1",
+								"fetch",
+								"HEAD-"+strings.Repeat("middle-", 400)+"-TAIL",
+							),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationID("inv-1"),
+		agent.WithInvocationMessage(model.NewUserMessage("current")),
+		agent.WithInvocationRunOptions(agent.RunOptions{
+			RequestID: "req-1",
+			RuntimeState: map[string]any{
+				"include_contents": "none",
+			},
+		}),
+	)
+
+	req := &model.Request{}
+	p.ProcessRequest(context.Background(), inv, req, nil)
+
+	require.Len(t, req.Messages, 3)
+	require.Equal(t, model.RoleTool, req.Messages[2].Role)
+	require.Contains(t, req.Messages[2].Content, "[... ")
+	require.True(t, strings.HasPrefix(req.Messages[2].Content, "HEAD-"))
+	require.True(t, strings.HasSuffix(req.Messages[2].Content, "-TAIL"))
 }
 
 func TestContentRequestProcessor_getFilterIncrementMessages(t *testing.T) {

--- a/internal/flow/processor/content_test.go
+++ b/internal/flow/processor/content_test.go
@@ -1626,8 +1626,9 @@ func TestNewContentRequestProcessor(t *testing.T) {
 		PreloadMemory:                  0, // Default to disable preloading.
 		PreloadSessionRecallSearchMode: session.SearchModeHybrid,
 		ContextCompactionConfig: ContextCompactionConfig{
-			KeepRecentRequests:  DefaultContextCompactionKeepRecentRequests,
-			ToolResultMaxTokens: DefaultContextCompactionToolResultMaxTokens,
+			KeepRecentRequests:           DefaultContextCompactionKeepRecentRequests,
+			ToolResultMaxTokens:          DefaultContextCompactionToolResultMaxTokens,
+			OversizedToolResultMaxTokens: DefaultOversizedToolResultMaxTokens,
 		},
 	}
 

--- a/internal/flow/processor/content_test.go
+++ b/internal/flow/processor/content_test.go
@@ -1630,7 +1630,7 @@ func TestNewContentRequestProcessor(t *testing.T) {
 		ContextCompactionConfig: ContextCompactionConfig{
 			KeepRecentRequests:           DefaultContextCompactionKeepRecentRequests,
 			ToolResultMaxTokens:          DefaultContextCompactionToolResultMaxTokens,
-			OversizedToolResultMaxTokens: DefaultOversizedToolResultMaxTokens,
+			OversizedToolResultMaxTokens: DefaultContextCompactionOversizedToolResultMaxTokens,
 		},
 	}
 
@@ -1710,7 +1710,7 @@ func TestNewContentRequestProcessor(t *testing.T) {
 		{
 			name: "oversized tool result limit option",
 			args: []ContentOption{
-				WithOversizedToolResultMaxTokens(64),
+				WithContextCompactionOversizedToolResultMaxTokens(64),
 			},
 			want: func() *ContentRequestProcessor {
 				w := *defaultWant
@@ -2471,7 +2471,7 @@ func TestContentRequestProcessor_IncludeContentsNoneSkipsHistory(t *testing.T) {
 func TestContentRequestProcessor_IncludeContentsNoneTruncatesOversizedToolResults(t *testing.T) {
 	p := NewContentRequestProcessor(
 		WithEnableContextCompaction(true),
-		WithOversizedToolResultMaxTokens(32),
+		WithContextCompactionOversizedToolResultMaxTokens(32),
 	)
 
 	sess := &session.Session{

--- a/internal/flow/processor/context_compact.go
+++ b/internal/flow/processor/context_compact.go
@@ -366,16 +366,20 @@ func truncateMiddle(s string, maxChars int) string {
 		return s
 	}
 
-	halfBudget := maxChars / 2
 	removed := runeCount - maxChars
+	marker := fmt.Sprintf("\n\n[... %d characters truncated ...]\n\n", removed)
+	markerLen := utf8.RuneCountInString(marker)
+
+	available := maxChars - markerLen
+	if available < 2 {
+		runes := []rune(s)
+		return string(runes[:maxChars])
+	}
+	halfBudget := available / 2
 
 	runes := []rune(s)
 	head := string(runes[:halfBudget])
 	tail := string(runes[runeCount-halfBudget:])
-	marker := fmt.Sprintf(
-		"\n\n[... %d characters truncated ...]\n\n",
-		removed,
-	)
 	return head + marker + tail
 }
 

--- a/internal/flow/processor/context_compact.go
+++ b/internal/flow/processor/context_compact.go
@@ -77,17 +77,11 @@ func compactIncrementEvents(
 	cfg ContextCompactionConfig,
 ) ([]event.Event, ContextCompactionStats) {
 	cfg = normalizeContextCompactionConfig(cfg)
-	currentKey := compactionUnitKey(currentRequestID, currentInvocationID)
-	if !cfg.Enabled || cfg.ToolResultMaxTokens <= 0 ||
-		len(events) == 0 || currentKey == "" {
+	if !cfg.Enabled || len(events) == 0 ||
+		(cfg.ToolResultMaxTokens <= 0 &&
+			cfg.OversizedToolResultMaxTokens <= 0) {
 		return events, ContextCompactionStats{}
 	}
-
-	protectedRequestIDs := collectProtectedRequestIDs(
-		events,
-		currentKey,
-		cfg.KeepRecentRequests,
-	)
 
 	compacted := make([]event.Event, len(events))
 	copy(compacted, events)
@@ -95,42 +89,52 @@ func compactIncrementEvents(
 	var stats ContextCompactionStats
 
 	// Pass 1: historical tool results → full placeholder replacement.
-	for i := range compacted {
-		evt := compacted[i]
-		unitKey := compactionUnitKey(evt.RequestID, evt.InvocationID)
-		if unitKey == "" {
-			continue
-		}
-		if _, keep := protectedRequestIDs[unitKey]; keep {
-			continue
-		}
-		if evt.Response == nil || len(evt.Response.Choices) == 0 {
-			continue
-		}
-
-		var choiceChanged bool
-		clonedResponse := evt.Response
-		for j := range evt.Response.Choices {
-			msg, compactedMsg, savedTokens := compactHistoricalToolResultMessage(
-				ctx,
-				evt.Response.Choices[j].Message,
-				cfg.ToolResultMaxTokens,
+	if cfg.ToolResultMaxTokens > 0 {
+		currentKey := compactionUnitKey(currentRequestID, currentInvocationID)
+		if currentKey != "" {
+			protectedRequestIDs := collectProtectedRequestIDs(
+				events,
+				currentKey,
+				cfg.KeepRecentRequests,
 			)
-			if !compactedMsg {
-				continue
-			}
-			if !choiceChanged {
-				clonedResponse = evt.Response.Clone()
-				choiceChanged = true
-			}
-			clonedResponse.Choices[j].Message = msg
-			stats.ToolResultsCompacted++
-			stats.EstimatedTokensSaved += savedTokens
-		}
+			for i := range compacted {
+				evt := compacted[i]
+				unitKey := compactionUnitKey(evt.RequestID, evt.InvocationID)
+				if unitKey == "" {
+					continue
+				}
+				if _, keep := protectedRequestIDs[unitKey]; keep {
+					continue
+				}
+				if evt.Response == nil || len(evt.Response.Choices) == 0 {
+					continue
+				}
 
-		if choiceChanged {
-			evt.Response = clonedResponse
-			compacted[i] = evt
+				var choiceChanged bool
+				clonedResponse := evt.Response
+				for j := range evt.Response.Choices {
+					msg, compactedMsg, savedTokens := compactHistoricalToolResultMessage(
+						ctx,
+						evt.Response.Choices[j].Message,
+						cfg.ToolResultMaxTokens,
+					)
+					if !compactedMsg {
+						continue
+					}
+					if !choiceChanged {
+						clonedResponse = evt.Response.Clone()
+						choiceChanged = true
+					}
+					clonedResponse.Choices[j].Message = msg
+					stats.ToolResultsCompacted++
+					stats.EstimatedTokensSaved += savedTokens
+				}
+
+				if choiceChanged {
+					evt.Response = clonedResponse
+					compacted[i] = evt
+				}
+			}
 		}
 	}
 

--- a/internal/flow/processor/context_compact.go
+++ b/internal/flow/processor/context_compact.go
@@ -331,11 +331,13 @@ func truncateOversizedToolResultMessage(
 	maxChars := maxTokens * 4
 	truncated := truncateMiddle(msg.Content, maxChars)
 
-	result := model.Message{
-		Role:     msg.Role,
-		Content:  truncated,
-		ToolID:   msg.ToolID,
-		ToolName: msg.ToolName,
+	result := msg
+	result.Content = truncated
+	if len(msg.ContentParts) > 0 {
+		result.ContentParts = append([]model.ContentPart(nil), msg.ContentParts...)
+	}
+	if len(msg.ToolCalls) > 0 {
+		result.ToolCalls = append([]model.ToolCall(nil), msg.ToolCalls...)
 	}
 	resultTokens, err := counter.CountTokens(ctx, result)
 	if err != nil || resultTokens >= originalTokens {

--- a/internal/flow/processor/context_compact.go
+++ b/internal/flow/processor/context_compact.go
@@ -92,49 +92,15 @@ func compactIncrementEvents(
 	if cfg.ToolResultMaxTokens > 0 {
 		currentKey := compactionUnitKey(currentRequestID, currentInvocationID)
 		if currentKey != "" {
-			protectedRequestIDs := collectProtectedRequestIDs(
-				events,
+			passEvents, passStats := applyHistoricalToolResultPass(
+				ctx,
+				compacted,
 				currentKey,
 				cfg.KeepRecentRequests,
+				cfg.ToolResultMaxTokens,
 			)
-			for i := range compacted {
-				evt := compacted[i]
-				unitKey := compactionUnitKey(evt.RequestID, evt.InvocationID)
-				if unitKey == "" {
-					continue
-				}
-				if _, keep := protectedRequestIDs[unitKey]; keep {
-					continue
-				}
-				if evt.Response == nil || len(evt.Response.Choices) == 0 {
-					continue
-				}
-
-				var choiceChanged bool
-				clonedResponse := evt.Response
-				for j := range evt.Response.Choices {
-					msg, compactedMsg, savedTokens := compactHistoricalToolResultMessage(
-						ctx,
-						evt.Response.Choices[j].Message,
-						cfg.ToolResultMaxTokens,
-					)
-					if !compactedMsg {
-						continue
-					}
-					if !choiceChanged {
-						clonedResponse = evt.Response.Clone()
-						choiceChanged = true
-					}
-					clonedResponse.Choices[j].Message = msg
-					stats.ToolResultsCompacted++
-					stats.EstimatedTokensSaved += savedTokens
-				}
-
-				if choiceChanged {
-					evt.Response = clonedResponse
-					compacted[i] = evt
-				}
-			}
+			compacted = passEvents
+			stats = mergeContextCompactionStats(stats, passStats)
 		}
 	}
 
@@ -143,40 +109,141 @@ func compactIncrementEvents(
 	// guard the next LLM call will exceed the context window even though the
 	// tool result belongs to the current (protected) request.
 	if cfg.OversizedToolResultMaxTokens > 0 {
-		for i := range compacted {
-			evt := compacted[i]
-			if evt.Response == nil || len(evt.Response.Choices) == 0 {
-				continue
-			}
-
-			var choiceChanged bool
-			clonedResponse := evt.Response
-			for j := range evt.Response.Choices {
-				msg, truncated, savedTokens := truncateOversizedToolResultMessage(
-					ctx,
-					evt.Response.Choices[j].Message,
-					cfg.OversizedToolResultMaxTokens,
-				)
-				if !truncated {
-					continue
-				}
-				if !choiceChanged {
-					clonedResponse = evt.Response.Clone()
-					choiceChanged = true
-				}
-				clonedResponse.Choices[j].Message = msg
-				stats.ToolResultsCompacted++
-				stats.EstimatedTokensSaved += savedTokens
-			}
-
-			if choiceChanged {
-				evt.Response = clonedResponse
-				compacted[i] = evt
-			}
-		}
+		passEvents, passStats := applyOversizedToolResultPass(
+			ctx,
+			compacted,
+			cfg.OversizedToolResultMaxTokens,
+		)
+		compacted = passEvents
+		stats = mergeContextCompactionStats(stats, passStats)
 	}
 
 	return compacted, stats
+}
+
+func applyHistoricalToolResultPass(
+	ctx context.Context,
+	events []event.Event,
+	currentKey string,
+	keepRecentRequests int,
+	maxTokens int,
+) ([]event.Event, ContextCompactionStats) {
+	protectedRequestIDs := collectProtectedRequestIDs(
+		events,
+		currentKey,
+		keepRecentRequests,
+	)
+
+	var stats ContextCompactionStats
+	for i := range events {
+		evt, changed, compactedCount, savedTokens := compactHistoricalToolResultEvent(
+			ctx,
+			events[i],
+			protectedRequestIDs,
+			maxTokens,
+		)
+		if !changed {
+			continue
+		}
+		events[i] = evt
+		stats.ToolResultsCompacted += compactedCount
+		stats.EstimatedTokensSaved += savedTokens
+	}
+	return events, stats
+}
+
+func compactHistoricalToolResultEvent(
+	ctx context.Context,
+	evt event.Event,
+	protectedRequestIDs map[string]struct{},
+	maxTokens int,
+) (event.Event, bool, int, int) {
+	unitKey := compactionUnitKey(evt.RequestID, evt.InvocationID)
+	if unitKey == "" {
+		return evt, false, 0, 0
+	}
+	if _, keep := protectedRequestIDs[unitKey]; keep {
+		return evt, false, 0, 0
+	}
+	return rewriteToolResultEventMessages(
+		ctx,
+		evt,
+		maxTokens,
+		compactHistoricalToolResultMessage,
+	)
+}
+
+func applyOversizedToolResultPass(
+	ctx context.Context,
+	events []event.Event,
+	maxTokens int,
+) ([]event.Event, ContextCompactionStats) {
+	var stats ContextCompactionStats
+	for i := range events {
+		evt, changed, compactedCount, savedTokens := rewriteToolResultEventMessages(
+			ctx,
+			events[i],
+			maxTokens,
+			truncateOversizedToolResultMessage,
+		)
+		if !changed {
+			continue
+		}
+		events[i] = evt
+		stats.ToolResultsCompacted += compactedCount
+		stats.EstimatedTokensSaved += savedTokens
+	}
+	return events, stats
+}
+
+func rewriteToolResultEventMessages(
+	ctx context.Context,
+	evt event.Event,
+	maxTokens int,
+	rewrite func(context.Context, model.Message, int) (model.Message, bool, int),
+) (event.Event, bool, int, int) {
+	if evt.Response == nil || len(evt.Response.Choices) == 0 {
+		return evt, false, 0, 0
+	}
+
+	var (
+		choiceChanged   bool
+		compactedCount  int
+		totalSavedToken int
+	)
+	clonedResponse := evt.Response
+	for j := range evt.Response.Choices {
+		msg, changed, savedTokens := rewrite(
+			ctx,
+			evt.Response.Choices[j].Message,
+			maxTokens,
+		)
+		if !changed {
+			continue
+		}
+		if !choiceChanged {
+			clonedResponse = evt.Response.Clone()
+			choiceChanged = true
+		}
+		clonedResponse.Choices[j].Message = msg
+		compactedCount++
+		totalSavedToken += savedTokens
+	}
+	if !choiceChanged {
+		return evt, false, 0, 0
+	}
+
+	evt.Response = clonedResponse
+	return evt, true, compactedCount, totalSavedToken
+}
+
+func mergeContextCompactionStats(
+	base ContextCompactionStats,
+	delta ContextCompactionStats,
+) ContextCompactionStats {
+	base.ToolResultsCompacted += delta.ToolResultsCompacted
+	base.EstimatedTokensSaved += delta.EstimatedTokensSaved
+	return base
 }
 
 func collectProtectedRequestIDs(

--- a/internal/flow/processor/context_compact.go
+++ b/internal/flow/processor/context_compact.go
@@ -10,6 +10,8 @@ package processor
 
 import (
 	"context"
+	"fmt"
+	"unicode/utf8"
 
 	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/model"
@@ -24,6 +26,12 @@ const (
 	// placeholder.
 	DefaultContextCompactionToolResultMaxTokens = 1024
 
+	// DefaultOversizedToolResultMaxTokens is the token threshold above which
+	// ANY tool result (including current request) is truncated to head+tail.
+	// This is the safety net for tool results so large they alone could
+	// overflow the context window (e.g. web_fetch returning 800K+ chars).
+	DefaultOversizedToolResultMaxTokens = 8192
+
 	historicalToolResultPlaceholder = "Historical tool result omitted to save context."
 )
 
@@ -33,6 +41,10 @@ type ContextCompactionConfig struct {
 	Enabled             bool
 	KeepRecentRequests  int
 	ToolResultMaxTokens int
+	// OversizedToolResultMaxTokens is the token threshold above which any
+	// tool result (including current-request results) is truncated using
+	// head+tail preservation. 0 disables this safety net.
+	OversizedToolResultMaxTokens int
 }
 
 // ContextCompactionStats reports how much prompt history was compacted during
@@ -50,6 +62,9 @@ func normalizeContextCompactionConfig(
 	}
 	if cfg.ToolResultMaxTokens < 0 {
 		cfg.ToolResultMaxTokens = 0
+	}
+	if cfg.OversizedToolResultMaxTokens < 0 {
+		cfg.OversizedToolResultMaxTokens = 0
 	}
 	return cfg
 }
@@ -78,6 +93,8 @@ func compactIncrementEvents(
 	copy(compacted, events)
 
 	var stats ContextCompactionStats
+
+	// Pass 1: historical tool results → full placeholder replacement.
 	for i := range compacted {
 		evt := compacted[i]
 		unitKey := compactionUnitKey(evt.RequestID, evt.InvocationID)
@@ -114,6 +131,44 @@ func compactIncrementEvents(
 		if choiceChanged {
 			evt.Response = clonedResponse
 			compacted[i] = evt
+		}
+	}
+
+	// Pass 2: oversized tool results (including current request) → head+tail
+	// truncation. A single web_fetch can return 800K+ chars; without this
+	// guard the next LLM call will exceed the context window even though the
+	// tool result belongs to the current (protected) request.
+	if cfg.OversizedToolResultMaxTokens > 0 {
+		for i := range compacted {
+			evt := compacted[i]
+			if evt.Response == nil || len(evt.Response.Choices) == 0 {
+				continue
+			}
+
+			var choiceChanged bool
+			clonedResponse := evt.Response
+			for j := range evt.Response.Choices {
+				msg, truncated, savedTokens := truncateOversizedToolResultMessage(
+					ctx,
+					evt.Response.Choices[j].Message,
+					cfg.OversizedToolResultMaxTokens,
+				)
+				if !truncated {
+					continue
+				}
+				if !choiceChanged {
+					clonedResponse = evt.Response.Clone()
+					choiceChanged = true
+				}
+				clonedResponse.Choices[j].Message = msg
+				stats.ToolResultsCompacted++
+				stats.EstimatedTokensSaved += savedTokens
+			}
+
+			if choiceChanged {
+				evt.Response = clonedResponse
+				compacted[i] = evt
+			}
 		}
 	}
 
@@ -172,6 +227,75 @@ func compactionUnitKey(requestID, invocationID string) string {
 	default:
 		return ""
 	}
+}
+
+// truncateOversizedToolResultMessage applies head+tail truncation to any tool
+// result whose estimated token count exceeds maxTokens. Unlike the historical
+// placeholder compaction, this preserves the beginning and end of the content
+// so the model can still see key information. Inspired by Codex's
+// truncate_middle_chars and Claude Code's per-tool maxResultSizeChars.
+func truncateOversizedToolResultMessage(
+	ctx context.Context,
+	msg model.Message,
+	maxTokens int,
+) (model.Message, bool, int) {
+	if msg.Role != model.RoleTool || msg.ToolID == "" || maxTokens <= 0 {
+		return msg, false, 0
+	}
+	if msg.Content == "" && len(msg.ContentParts) == 0 {
+		return msg, false, 0
+	}
+	if msg.Content == historicalToolResultPlaceholder {
+		return msg, false, 0
+	}
+
+	counter := model.NewSimpleTokenCounter()
+	originalTokens, err := counter.CountTokens(ctx, msg)
+	if err != nil || originalTokens <= maxTokens {
+		return msg, false, 0
+	}
+
+	// Approximate the character budget from the token budget.
+	// SimpleTokenCounter uses ~4 chars/token, so we reverse that.
+	maxChars := maxTokens * 4
+	truncated := truncateMiddle(msg.Content, maxChars)
+
+	result := model.Message{
+		Role:     msg.Role,
+		Content:  truncated,
+		ToolID:   msg.ToolID,
+		ToolName: msg.ToolName,
+	}
+	resultTokens, err := counter.CountTokens(ctx, result)
+	if err != nil || resultTokens >= originalTokens {
+		return msg, false, 0
+	}
+
+	return result, true, originalTokens - resultTokens
+}
+
+// truncateMiddle keeps the first half and last half of the content (by
+// character count) up to maxChars total, inserting a marker in the middle
+// showing how much was removed. This preserves the beginning (usually
+// contains key structure/headers) and end (usually contains conclusions)
+// of the tool output.
+func truncateMiddle(s string, maxChars int) string {
+	runeCount := utf8.RuneCountInString(s)
+	if runeCount <= maxChars {
+		return s
+	}
+
+	halfBudget := maxChars / 2
+	removed := runeCount - maxChars
+
+	runes := []rune(s)
+	head := string(runes[:halfBudget])
+	tail := string(runes[runeCount-halfBudget:])
+	marker := fmt.Sprintf(
+		"\n\n[... %d characters truncated ...]\n\n",
+		removed,
+	)
+	return head + marker + tail
 }
 
 func compactHistoricalToolResultMessage(

--- a/internal/flow/processor/context_compact.go
+++ b/internal/flow/processor/context_compact.go
@@ -26,11 +26,12 @@ const (
 	// placeholder.
 	DefaultContextCompactionToolResultMaxTokens = 1024
 
-	// DefaultOversizedToolResultMaxTokens is the token threshold above which
-	// ANY tool result (including current request) is truncated to head+tail.
-	// This is the safety net for tool results so large they alone could
-	// overflow the context window (e.g. web_fetch returning 800K+ chars).
-	DefaultOversizedToolResultMaxTokens = 8192
+	// DefaultContextCompactionOversizedToolResultMaxTokens is the token
+	// threshold above which ANY tool result (including current request) is
+	// truncated to head+tail. This is the safety net for tool results so
+	// large they alone could overflow the context window (e.g. web_fetch
+	// returning 800K+ chars).
+	DefaultContextCompactionOversizedToolResultMaxTokens = 8192
 
 	historicalToolResultPlaceholder = "Historical tool result omitted to save context."
 )
@@ -41,9 +42,10 @@ type ContextCompactionConfig struct {
 	Enabled             bool
 	KeepRecentRequests  int
 	ToolResultMaxTokens int
-	// OversizedToolResultMaxTokens is the token threshold above which any
-	// tool result (including current-request results) is truncated using
-	// head+tail preservation. 0 disables this safety net.
+	// OversizedToolResultMaxTokens is the token threshold above which any tool
+	// result (including current-request results) is truncated using head+tail
+	// preservation. This safety net fires regardless of the Enabled flag.
+	// 0 disables it.
 	OversizedToolResultMaxTokens int
 }
 
@@ -77,9 +79,13 @@ func compactIncrementEvents(
 	cfg ContextCompactionConfig,
 ) ([]event.Event, ContextCompactionStats) {
 	cfg = normalizeContextCompactionConfig(cfg)
-	if !cfg.Enabled || len(events) == 0 ||
-		(cfg.ToolResultMaxTokens <= 0 &&
-			cfg.OversizedToolResultMaxTokens <= 0) {
+	if len(events) == 0 {
+		return events, ContextCompactionStats{}
+	}
+
+	pass1Active := cfg.Enabled && cfg.ToolResultMaxTokens > 0
+	pass2Active := cfg.OversizedToolResultMaxTokens > 0
+	if !pass1Active && !pass2Active {
 		return events, ContextCompactionStats{}
 	}
 
@@ -89,7 +95,8 @@ func compactIncrementEvents(
 	var stats ContextCompactionStats
 
 	// Pass 1: historical tool results → full placeholder replacement.
-	if cfg.ToolResultMaxTokens > 0 {
+	// Gated on Enabled (requires context compaction to be on).
+	if pass1Active {
 		currentKey := compactionUnitKey(currentRequestID, currentInvocationID)
 		if currentKey != "" {
 			passEvents, passStats := applyHistoricalToolResultPass(
@@ -105,10 +112,8 @@ func compactIncrementEvents(
 	}
 
 	// Pass 2: oversized tool results (including current request) → head+tail
-	// truncation. A single web_fetch can return 800K+ chars; without this
-	// guard the next LLM call will exceed the context window even though the
-	// tool result belongs to the current (protected) request.
-	if cfg.OversizedToolResultMaxTokens > 0 {
+	// truncation. This safety net fires independently of EnableContextCompaction.
+	if pass2Active {
 		passEvents, passStats := applyOversizedToolResultPass(
 			ctx,
 			compacted,
@@ -305,6 +310,9 @@ func compactionUnitKey(requestID, invocationID string) string {
 // placeholder compaction, this preserves the beginning and end of the content
 // so the model can still see key information. Inspired by Codex's
 // truncate_middle_chars and Claude Code's per-tool maxResultSizeChars.
+//
+// TODO: text ContentParts are preserved as-is; truncating individual text parts
+// inside ContentParts is deferred until multimodal tool results are common.
 func truncateOversizedToolResultMessage(
 	ctx context.Context,
 	msg model.Message,

--- a/internal/flow/processor/context_compact_test.go
+++ b/internal/flow/processor/context_compact_test.go
@@ -200,14 +200,53 @@ func TestCompactHistoricalToolResultMessage_SkipsWhenPlaceholderIsNotSmaller(t *
 
 func TestNormalizeContextCompactionConfig(t *testing.T) {
 	cfg := normalizeContextCompactionConfig(ContextCompactionConfig{
-		Enabled:             true,
-		KeepRecentRequests:  -1,
-		ToolResultMaxTokens: -5,
+		Enabled:                     true,
+		KeepRecentRequests:          -1,
+		ToolResultMaxTokens:         -5,
+		OversizedToolResultMaxTokens: -9,
 	})
 
 	require.True(t, cfg.Enabled)
 	require.Zero(t, cfg.KeepRecentRequests)
 	require.Zero(t, cfg.ToolResultMaxTokens)
+	require.Zero(t, cfg.OversizedToolResultMaxTokens)
+}
+
+func TestCompactIncrementEvents_TruncatesOversizedCurrentToolResult(t *testing.T) {
+	content := "HEAD-" + strings.Repeat("middle-", 400) + "-TAIL"
+	evt := event.Event{
+		RequestID:    "req-current",
+		InvocationID: "inv-current",
+		FilterKey:    "test-agent",
+		Response: &model.Response{
+			Done: true,
+			Choices: []model.Choice{{
+				Message: model.NewToolMessage("tool-call-current", "worker", content),
+			}},
+		},
+	}
+
+	compacted, stats := compactIncrementEvents(
+		context.Background(),
+		[]event.Event{evt},
+		"req-current",
+		"inv-current",
+		ContextCompactionConfig{
+			Enabled:                     true,
+			KeepRecentRequests:          1,
+			ToolResultMaxTokens:         10,
+			OversizedToolResultMaxTokens: 32,
+		},
+	)
+
+	require.Len(t, compacted, 1)
+	got := compacted[0].Response.Choices[0].Message.Content
+	require.NotEqual(t, content, got)
+	require.Contains(t, got, "[... ")
+	require.True(t, strings.HasPrefix(got, "HEAD-"))
+	require.True(t, strings.HasSuffix(got, "-TAIL"))
+	require.Equal(t, 1, stats.ToolResultsCompacted)
+	require.Greater(t, stats.EstimatedTokensSaved, 0)
 }
 
 func TestContentRequestProcessor_ProcessRequest_ContextCompactionWithoutSummary(t *testing.T) {

--- a/internal/flow/processor/context_compact_test.go
+++ b/internal/flow/processor/context_compact_test.go
@@ -200,9 +200,9 @@ func TestCompactHistoricalToolResultMessage_SkipsWhenPlaceholderIsNotSmaller(t *
 
 func TestNormalizeContextCompactionConfig(t *testing.T) {
 	cfg := normalizeContextCompactionConfig(ContextCompactionConfig{
-		Enabled:                     true,
-		KeepRecentRequests:          -1,
-		ToolResultMaxTokens:         -5,
+		Enabled:                      true,
+		KeepRecentRequests:           -1,
+		ToolResultMaxTokens:          -5,
 		OversizedToolResultMaxTokens: -9,
 	})
 
@@ -232,9 +232,9 @@ func TestCompactIncrementEvents_TruncatesOversizedCurrentToolResult(t *testing.T
 		"req-current",
 		"inv-current",
 		ContextCompactionConfig{
-			Enabled:                     true,
-			KeepRecentRequests:          1,
-			ToolResultMaxTokens:         10,
+			Enabled:                      true,
+			KeepRecentRequests:           1,
+			ToolResultMaxTokens:          10,
 			OversizedToolResultMaxTokens: 32,
 		},
 	)

--- a/internal/flow/processor/context_compact_test.go
+++ b/internal/flow/processor/context_compact_test.go
@@ -200,9 +200,9 @@ func TestCompactHistoricalToolResultMessage_SkipsWhenPlaceholderIsNotSmaller(t *
 
 func TestNormalizeContextCompactionConfig(t *testing.T) {
 	cfg := normalizeContextCompactionConfig(ContextCompactionConfig{
-		Enabled:                      true,
-		KeepRecentRequests:           -1,
-		ToolResultMaxTokens:          -5,
+		Enabled:                     true,
+		KeepRecentRequests:          -1,
+		ToolResultMaxTokens:         -5,
 		OversizedToolResultMaxTokens: -9,
 	})
 
@@ -232,9 +232,9 @@ func TestCompactIncrementEvents_TruncatesOversizedCurrentToolResult(t *testing.T
 		"req-current",
 		"inv-current",
 		ContextCompactionConfig{
-			Enabled:                      true,
-			KeepRecentRequests:           1,
-			ToolResultMaxTokens:          10,
+			Enabled:                     true,
+			KeepRecentRequests:          1,
+			ToolResultMaxTokens:         10,
 			OversizedToolResultMaxTokens: 32,
 		},
 	)
@@ -381,12 +381,17 @@ func TestTruncateOversizedToolResultMessage_ContentPartsOnlyKeepsPayload(t *test
 }
 
 func TestTruncateMiddle(t *testing.T) {
-	require.Equal(t, "short", truncateMiddle("short", 10))
+	require.Equal(t, "short", truncateMiddle("short", 100))
 
-	truncated := truncateMiddle("ABCDEFGHIJ0123456789", 10)
-	require.Contains(t, truncated, "[... 10 characters truncated ...]")
-	require.True(t, strings.HasPrefix(truncated, "ABCDE"))
-	require.True(t, strings.HasSuffix(truncated, "56789"))
+	input := strings.Repeat("x", 500)
+	truncated := truncateMiddle(input, 200)
+	require.Contains(t, truncated, "[... 300 characters truncated ...]")
+	require.LessOrEqual(t, len([]rune(truncated)), 200,
+		"output must not exceed maxChars")
+
+	tiny := truncateMiddle("ABCDEFGHIJ0123456789", 10)
+	require.Equal(t, "ABCDEFGHIJ", tiny,
+		"when marker is too large, fall back to head-only truncation")
 }
 
 func TestContentRequestProcessor_ProcessRequest_ContextCompactionWithoutSummary(t *testing.T) {

--- a/internal/flow/processor/context_compact_test.go
+++ b/internal/flow/processor/context_compact_test.go
@@ -249,6 +249,56 @@ func TestCompactIncrementEvents_TruncatesOversizedCurrentToolResult(t *testing.T
 	require.Greater(t, stats.EstimatedTokensSaved, 0)
 }
 
+func TestCompactIncrementEvents_TruncatesOversizedHistoricalToolResult(t *testing.T) {
+	content := "HEAD-" + strings.Repeat("middle-", 400) + "-TAIL"
+	events := []event.Event{
+		{
+			RequestID:    "req-current",
+			InvocationID: "inv-current",
+			FilterKey:    "test-agent",
+			Response: &model.Response{
+				Done: true,
+				Choices: []model.Choice{{
+					Message: model.NewToolMessage("tool-call-current", "worker", "ok"),
+				}},
+			},
+		},
+		{
+			RequestID:    "req-history",
+			InvocationID: "inv-history",
+			FilterKey:    "test-agent",
+			Response: &model.Response{
+				Done: true,
+				Choices: []model.Choice{{
+					Message: model.NewToolMessage("tool-call-history", "worker", content),
+				}},
+			},
+		},
+	}
+
+	compacted, stats := compactIncrementEvents(
+		context.Background(),
+		events,
+		"req-current",
+		"inv-current",
+		ContextCompactionConfig{
+			Enabled:                      true,
+			KeepRecentRequests:           1,
+			ToolResultMaxTokens:          10,
+			OversizedToolResultMaxTokens: 32,
+		},
+	)
+
+	require.Len(t, compacted, 2)
+	got := compacted[1].Response.Choices[0].Message.Content
+	require.NotEqual(t, content, got)
+	require.Contains(t, got, "[... ")
+	require.True(t, strings.HasPrefix(got, "HEAD-"))
+	require.True(t, strings.HasSuffix(got, "-TAIL"))
+	require.Equal(t, 1, stats.ToolResultsCompacted)
+	require.Greater(t, stats.EstimatedTokensSaved, 0)
+}
+
 func TestCompactIncrementEvents_Pass2WorksWithoutPass1Context(t *testing.T) {
 	content := "HEAD-" + strings.Repeat("middle-", 400) + "-TAIL"
 	evt := event.Event{

--- a/internal/flow/processor/context_compact_test.go
+++ b/internal/flow/processor/context_compact_test.go
@@ -332,6 +332,54 @@ func TestCompactIncrementEvents_Pass2WorksWithoutPass1Context(t *testing.T) {
 	require.Greater(t, stats.EstimatedTokensSaved, 0)
 }
 
+func TestTruncateOversizedToolResultMessage_PreservesContentParts(t *testing.T) {
+	partText := "structured payload"
+	msg := model.Message{
+		Role:    model.RoleTool,
+		Content: "HEAD-" + strings.Repeat("middle-", 400) + "-TAIL",
+		ContentParts: []model.ContentPart{{
+			Type: model.ContentTypeText,
+			Text: &partText,
+		}},
+		ToolID:   "tool-call-current",
+		ToolName: "worker",
+	}
+
+	compacted, changed, savedTokens := truncateOversizedToolResultMessage(
+		context.Background(),
+		msg,
+		32,
+	)
+
+	require.True(t, changed)
+	require.Greater(t, savedTokens, 0)
+	require.Contains(t, compacted.Content, "[... ")
+	require.Equal(t, msg.ContentParts, compacted.ContentParts)
+}
+
+func TestTruncateOversizedToolResultMessage_ContentPartsOnlyKeepsPayload(t *testing.T) {
+	partText := strings.Repeat("segment-", 400)
+	msg := model.Message{
+		Role: model.RoleTool,
+		ContentParts: []model.ContentPart{{
+			Type: model.ContentTypeText,
+			Text: &partText,
+		}},
+		ToolID:   "tool-call-current",
+		ToolName: "worker",
+	}
+
+	compacted, changed, savedTokens := truncateOversizedToolResultMessage(
+		context.Background(),
+		msg,
+		32,
+	)
+
+	require.False(t, changed)
+	require.Zero(t, savedTokens)
+	require.Equal(t, msg, compacted)
+}
+
 func TestTruncateMiddle(t *testing.T) {
 	require.Equal(t, "short", truncateMiddle("short", 10))
 

--- a/internal/flow/processor/context_compact_test.go
+++ b/internal/flow/processor/context_compact_test.go
@@ -249,6 +249,48 @@ func TestCompactIncrementEvents_TruncatesOversizedCurrentToolResult(t *testing.T
 	require.Greater(t, stats.EstimatedTokensSaved, 0)
 }
 
+func TestCompactIncrementEvents_Pass2WorksWithoutPass1Context(t *testing.T) {
+	content := "HEAD-" + strings.Repeat("middle-", 400) + "-TAIL"
+	evt := event.Event{
+		InvocationID: "inv-current",
+		FilterKey:    "test-agent",
+		Response: &model.Response{
+			Done: true,
+			Choices: []model.Choice{{
+				Message: model.NewToolMessage("tool-call-current", "worker", content),
+			}},
+		},
+	}
+
+	compacted, stats := compactIncrementEvents(
+		context.Background(),
+		[]event.Event{evt},
+		"",
+		"",
+		ContextCompactionConfig{
+			Enabled:                      true,
+			ToolResultMaxTokens:          0,
+			OversizedToolResultMaxTokens: 32,
+		},
+	)
+
+	require.Len(t, compacted, 1)
+	got := compacted[0].Response.Choices[0].Message.Content
+	require.NotEqual(t, content, got)
+	require.Contains(t, got, "[... ")
+	require.Equal(t, 1, stats.ToolResultsCompacted)
+	require.Greater(t, stats.EstimatedTokensSaved, 0)
+}
+
+func TestTruncateMiddle(t *testing.T) {
+	require.Equal(t, "short", truncateMiddle("short", 10))
+
+	truncated := truncateMiddle("ABCDEFGHIJ0123456789", 10)
+	require.Contains(t, truncated, "[... 10 characters truncated ...]")
+	require.True(t, strings.HasPrefix(truncated, "ABCDE"))
+	require.True(t, strings.HasSuffix(truncated, "56789"))
+}
+
 func TestContentRequestProcessor_ProcessRequest_ContextCompactionWithoutSummary(t *testing.T) {
 	sess := &session.Session{
 		Events: []event.Event{

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -647,15 +647,15 @@ func NewRuntime(
 			}
 		}
 		ag, skillsRepo, err = newAgent(mdl, agentConfig{
-			AppName:                     opts.AppName,
-			AddSessionSummary:           opts.AddSessionSummary,
-			EnableContextCompaction:     opts.EnableContextCompaction,
+			AppName:                 opts.AppName,
+			AddSessionSummary:       opts.AddSessionSummary,
+			EnableContextCompaction: opts.EnableContextCompaction,
 			ContextCompactionOversizedToolResultMaxTokens: opts.ContextCompactionOversizedToolResultMaxTokens,
-			MaxHistoryRuns:              opts.MaxHistoryRuns,
-			PreloadMemory:               opts.PreloadMemory,
-			GenerationConfig:            opts.GenerationConfig,
-			Instruction:                 prompts.Instruction,
-			SystemPrompt:                prompts.SystemPrompt,
+			MaxHistoryRuns:   opts.MaxHistoryRuns,
+			PreloadMemory:    opts.PreloadMemory,
+			GenerationConfig: opts.GenerationConfig,
+			Instruction:      prompts.Instruction,
+			SystemPrompt:     prompts.SystemPrompt,
 
 			SkillsRoot:      opts.SkillsRoot,
 			SkillsExtraDirs: splitCSV(opts.SkillsExtraDir),
@@ -1078,15 +1078,15 @@ func run(ctx context.Context, args []string) error {
 			}
 		}
 		ag, skillsRepo, err = newAgent(mdl, agentConfig{
-			AppName:                     opts.AppName,
-			AddSessionSummary:           opts.AddSessionSummary,
-			EnableContextCompaction:     opts.EnableContextCompaction,
+			AppName:                 opts.AppName,
+			AddSessionSummary:       opts.AddSessionSummary,
+			EnableContextCompaction: opts.EnableContextCompaction,
 			ContextCompactionOversizedToolResultMaxTokens: opts.ContextCompactionOversizedToolResultMaxTokens,
-			MaxHistoryRuns:              opts.MaxHistoryRuns,
-			PreloadMemory:               opts.PreloadMemory,
-			GenerationConfig:            opts.GenerationConfig,
-			Instruction:                 prompts.Instruction,
-			SystemPrompt:                prompts.SystemPrompt,
+			MaxHistoryRuns:   opts.MaxHistoryRuns,
+			PreloadMemory:    opts.PreloadMemory,
+			GenerationConfig: opts.GenerationConfig,
+			Instruction:      prompts.Instruction,
+			SystemPrompt:     prompts.SystemPrompt,
 
 			SkillsRoot:      opts.SkillsRoot,
 			SkillsExtraDirs: splitCSV(opts.SkillsExtraDir),
@@ -2126,14 +2126,14 @@ func channelsFromRegistry(
 type agentConfig struct {
 	AppName string
 
-	AddSessionSummary            bool
-	EnableContextCompaction      bool
+	AddSessionSummary                             bool
+	EnableContextCompaction                       bool
 	ContextCompactionOversizedToolResultMaxTokens int
-	MaxHistoryRuns               int
-	PreloadMemory                int
-	GenerationConfig             *model.GenerationConfig
-	Instruction                  string
-	SystemPrompt                 string
+	MaxHistoryRuns                                int
+	PreloadMemory                                 int
+	GenerationConfig                              *model.GenerationConfig
+	Instruction                                   string
+	SystemPrompt                                  string
 
 	SkillsRoot         string
 	SkillsExtraDirs    []string

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -647,14 +647,15 @@ func NewRuntime(
 			}
 		}
 		ag, skillsRepo, err = newAgent(mdl, agentConfig{
-			AppName:                 opts.AppName,
-			AddSessionSummary:       opts.AddSessionSummary,
-			EnableContextCompaction: opts.EnableContextCompaction,
-			MaxHistoryRuns:          opts.MaxHistoryRuns,
-			PreloadMemory:           opts.PreloadMemory,
-			GenerationConfig:        opts.GenerationConfig,
-			Instruction:             prompts.Instruction,
-			SystemPrompt:            prompts.SystemPrompt,
+			AppName:                      opts.AppName,
+			AddSessionSummary:            opts.AddSessionSummary,
+			EnableContextCompaction:      opts.EnableContextCompaction,
+			OversizedToolResultMaxTokens: opts.OversizedToolResultMaxTokens,
+			MaxHistoryRuns:               opts.MaxHistoryRuns,
+			PreloadMemory:                opts.PreloadMemory,
+			GenerationConfig:             opts.GenerationConfig,
+			Instruction:                  prompts.Instruction,
+			SystemPrompt:                 prompts.SystemPrompt,
 
 			SkillsRoot:      opts.SkillsRoot,
 			SkillsExtraDirs: splitCSV(opts.SkillsExtraDir),
@@ -1077,14 +1078,15 @@ func run(ctx context.Context, args []string) error {
 			}
 		}
 		ag, skillsRepo, err = newAgent(mdl, agentConfig{
-			AppName:                 opts.AppName,
-			AddSessionSummary:       opts.AddSessionSummary,
-			EnableContextCompaction: opts.EnableContextCompaction,
-			MaxHistoryRuns:          opts.MaxHistoryRuns,
-			PreloadMemory:           opts.PreloadMemory,
-			GenerationConfig:        opts.GenerationConfig,
-			Instruction:             prompts.Instruction,
-			SystemPrompt:            prompts.SystemPrompt,
+			AppName:                      opts.AppName,
+			AddSessionSummary:            opts.AddSessionSummary,
+			EnableContextCompaction:      opts.EnableContextCompaction,
+			OversizedToolResultMaxTokens: opts.OversizedToolResultMaxTokens,
+			MaxHistoryRuns:               opts.MaxHistoryRuns,
+			PreloadMemory:                opts.PreloadMemory,
+			GenerationConfig:             opts.GenerationConfig,
+			Instruction:                  prompts.Instruction,
+			SystemPrompt:                 prompts.SystemPrompt,
 
 			SkillsRoot:      opts.SkillsRoot,
 			SkillsExtraDirs: splitCSV(opts.SkillsExtraDir),
@@ -1891,6 +1893,7 @@ func newAgent(
 		llmagent.WithGlobalInstruction(strings.TrimSpace(cfg.SystemPrompt)),
 		llmagent.WithAddSessionSummary(cfg.AddSessionSummary),
 		llmagent.WithEnableContextCompaction(cfg.EnableContextCompaction),
+		llmagent.WithOversizedToolResultMaxTokens(cfg.OversizedToolResultMaxTokens),
 		llmagent.WithMaxHistoryRuns(cfg.MaxHistoryRuns),
 		llmagent.WithPreloadMemory(cfg.PreloadMemory),
 		llmagent.WithEventMessageProjector(
@@ -2123,13 +2126,14 @@ func channelsFromRegistry(
 type agentConfig struct {
 	AppName string
 
-	AddSessionSummary       bool
-	EnableContextCompaction bool
-	MaxHistoryRuns          int
-	PreloadMemory           int
-	GenerationConfig        *model.GenerationConfig
-	Instruction             string
-	SystemPrompt            string
+	AddSessionSummary            bool
+	EnableContextCompaction      bool
+	OversizedToolResultMaxTokens int
+	MaxHistoryRuns               int
+	PreloadMemory                int
+	GenerationConfig             *model.GenerationConfig
+	Instruction                  string
+	SystemPrompt                 string
 
 	SkillsRoot         string
 	SkillsExtraDirs    []string

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -647,15 +647,15 @@ func NewRuntime(
 			}
 		}
 		ag, skillsRepo, err = newAgent(mdl, agentConfig{
-			AppName:                      opts.AppName,
-			AddSessionSummary:            opts.AddSessionSummary,
-			EnableContextCompaction:      opts.EnableContextCompaction,
-			OversizedToolResultMaxTokens: opts.OversizedToolResultMaxTokens,
-			MaxHistoryRuns:               opts.MaxHistoryRuns,
-			PreloadMemory:                opts.PreloadMemory,
-			GenerationConfig:             opts.GenerationConfig,
-			Instruction:                  prompts.Instruction,
-			SystemPrompt:                 prompts.SystemPrompt,
+			AppName:                     opts.AppName,
+			AddSessionSummary:           opts.AddSessionSummary,
+			EnableContextCompaction:     opts.EnableContextCompaction,
+			ContextCompactionOversizedToolResultMaxTokens: opts.ContextCompactionOversizedToolResultMaxTokens,
+			MaxHistoryRuns:              opts.MaxHistoryRuns,
+			PreloadMemory:               opts.PreloadMemory,
+			GenerationConfig:            opts.GenerationConfig,
+			Instruction:                 prompts.Instruction,
+			SystemPrompt:                prompts.SystemPrompt,
 
 			SkillsRoot:      opts.SkillsRoot,
 			SkillsExtraDirs: splitCSV(opts.SkillsExtraDir),
@@ -1078,15 +1078,15 @@ func run(ctx context.Context, args []string) error {
 			}
 		}
 		ag, skillsRepo, err = newAgent(mdl, agentConfig{
-			AppName:                      opts.AppName,
-			AddSessionSummary:            opts.AddSessionSummary,
-			EnableContextCompaction:      opts.EnableContextCompaction,
-			OversizedToolResultMaxTokens: opts.OversizedToolResultMaxTokens,
-			MaxHistoryRuns:               opts.MaxHistoryRuns,
-			PreloadMemory:                opts.PreloadMemory,
-			GenerationConfig:             opts.GenerationConfig,
-			Instruction:                  prompts.Instruction,
-			SystemPrompt:                 prompts.SystemPrompt,
+			AppName:                     opts.AppName,
+			AddSessionSummary:           opts.AddSessionSummary,
+			EnableContextCompaction:     opts.EnableContextCompaction,
+			ContextCompactionOversizedToolResultMaxTokens: opts.ContextCompactionOversizedToolResultMaxTokens,
+			MaxHistoryRuns:              opts.MaxHistoryRuns,
+			PreloadMemory:               opts.PreloadMemory,
+			GenerationConfig:            opts.GenerationConfig,
+			Instruction:                 prompts.Instruction,
+			SystemPrompt:                prompts.SystemPrompt,
 
 			SkillsRoot:      opts.SkillsRoot,
 			SkillsExtraDirs: splitCSV(opts.SkillsExtraDir),
@@ -1893,7 +1893,7 @@ func newAgent(
 		llmagent.WithGlobalInstruction(strings.TrimSpace(cfg.SystemPrompt)),
 		llmagent.WithAddSessionSummary(cfg.AddSessionSummary),
 		llmagent.WithEnableContextCompaction(cfg.EnableContextCompaction),
-		llmagent.WithOversizedToolResultMaxTokens(cfg.OversizedToolResultMaxTokens),
+		llmagent.WithContextCompactionOversizedToolResultMaxTokens(cfg.ContextCompactionOversizedToolResultMaxTokens),
 		llmagent.WithMaxHistoryRuns(cfg.MaxHistoryRuns),
 		llmagent.WithPreloadMemory(cfg.PreloadMemory),
 		llmagent.WithEventMessageProjector(
@@ -2128,7 +2128,7 @@ type agentConfig struct {
 
 	AddSessionSummary            bool
 	EnableContextCompaction      bool
-	OversizedToolResultMaxTokens int
+	ContextCompactionOversizedToolResultMaxTokens int
 	MaxHistoryRuns               int
 	PreloadMemory                int
 	GenerationConfig             *model.GenerationConfig

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -647,13 +647,14 @@ func NewRuntime(
 			}
 		}
 		ag, skillsRepo, err = newAgent(mdl, agentConfig{
-			AppName:           opts.AppName,
-			AddSessionSummary: opts.AddSessionSummary,
-			MaxHistoryRuns:    opts.MaxHistoryRuns,
-			PreloadMemory:     opts.PreloadMemory,
-			GenerationConfig:  opts.GenerationConfig,
-			Instruction:       prompts.Instruction,
-			SystemPrompt:      prompts.SystemPrompt,
+			AppName:                 opts.AppName,
+			AddSessionSummary:       opts.AddSessionSummary,
+			EnableContextCompaction: opts.EnableContextCompaction,
+			MaxHistoryRuns:          opts.MaxHistoryRuns,
+			PreloadMemory:           opts.PreloadMemory,
+			GenerationConfig:        opts.GenerationConfig,
+			Instruction:             prompts.Instruction,
+			SystemPrompt:            prompts.SystemPrompt,
 
 			SkillsRoot:      opts.SkillsRoot,
 			SkillsExtraDirs: splitCSV(opts.SkillsExtraDir),
@@ -1076,13 +1077,14 @@ func run(ctx context.Context, args []string) error {
 			}
 		}
 		ag, skillsRepo, err = newAgent(mdl, agentConfig{
-			AppName:           opts.AppName,
-			AddSessionSummary: opts.AddSessionSummary,
-			MaxHistoryRuns:    opts.MaxHistoryRuns,
-			PreloadMemory:     opts.PreloadMemory,
-			GenerationConfig:  opts.GenerationConfig,
-			Instruction:       prompts.Instruction,
-			SystemPrompt:      prompts.SystemPrompt,
+			AppName:                 opts.AppName,
+			AddSessionSummary:       opts.AddSessionSummary,
+			EnableContextCompaction: opts.EnableContextCompaction,
+			MaxHistoryRuns:          opts.MaxHistoryRuns,
+			PreloadMemory:           opts.PreloadMemory,
+			GenerationConfig:        opts.GenerationConfig,
+			Instruction:             prompts.Instruction,
+			SystemPrompt:            prompts.SystemPrompt,
 
 			SkillsRoot:      opts.SkillsRoot,
 			SkillsExtraDirs: splitCSV(opts.SkillsExtraDir),
@@ -1888,6 +1890,7 @@ func newAgent(
 		llmagent.WithInstruction(instruction),
 		llmagent.WithGlobalInstruction(strings.TrimSpace(cfg.SystemPrompt)),
 		llmagent.WithAddSessionSummary(cfg.AddSessionSummary),
+		llmagent.WithEnableContextCompaction(cfg.EnableContextCompaction),
 		llmagent.WithMaxHistoryRuns(cfg.MaxHistoryRuns),
 		llmagent.WithPreloadMemory(cfg.PreloadMemory),
 		llmagent.WithEventMessageProjector(
@@ -2120,12 +2123,13 @@ func channelsFromRegistry(
 type agentConfig struct {
 	AppName string
 
-	AddSessionSummary bool
-	MaxHistoryRuns    int
-	PreloadMemory     int
-	GenerationConfig  *model.GenerationConfig
-	Instruction       string
-	SystemPrompt      string
+	AddSessionSummary       bool
+	EnableContextCompaction bool
+	MaxHistoryRuns          int
+	PreloadMemory           int
+	GenerationConfig        *model.GenerationConfig
+	Instruction             string
+	SystemPrompt            string
 
 	SkillsRoot         string
 	SkillsExtraDirs    []string

--- a/openclaw/app/run_options.go
+++ b/openclaw/app/run_options.go
@@ -63,11 +63,11 @@ const (
 	defaultSessionSummaryEventThreshold = 20
 	defaultSkillsLoadMode               = "turn"
 
-	flagAddSessionSummary            = "add-session-summary"
-	flagEnableContextCompaction      = "enable-context-compaction"
-	flagOversizedToolResultMaxTokens = "oversized-tool-result-max-tokens"
-	flagMaxHistoryRuns               = "max-history-runs"
-	flagPreloadMemory                = "preload-memory"
+	flagAddSessionSummary             = "add-session-summary"
+	flagEnableContextCompaction       = "enable-context-compaction"
+	flagContextCompactionOversizedToolResultMaxTokens = "context-compaction-oversized-tool-result-max-tokens"
+	flagMaxHistoryRuns                = "max-history-runs"
+	flagPreloadMemory                 = "preload-memory"
 
 	flagAgentInstruction       = "agent-instruction"
 	flagAgentInstructionFiles  = "agent-instruction-files"
@@ -135,11 +135,11 @@ type runOptions struct {
 	A2AName           string
 	A2ADescription    string
 
-	AddSessionSummary            bool
-	EnableContextCompaction      bool
-	OversizedToolResultMaxTokens int
-	MaxHistoryRuns               int
-	PreloadMemory                int
+	AddSessionSummary       bool
+	EnableContextCompaction bool
+	ContextCompactionOversizedToolResultMaxTokens int
+	MaxHistoryRuns          int
+	PreloadMemory           int
 
 	AgentInstruction       string
 	AgentInstructionFiles  string
@@ -361,9 +361,9 @@ func parseRunOptions(args []string) (runOptions, error) {
 		"Enable prompt-side context compaction to control context window growth",
 	)
 	fs.IntVar(
-		&opts.OversizedToolResultMaxTokens,
-		flagOversizedToolResultMaxTokens,
-		processor.DefaultOversizedToolResultMaxTokens,
+		&opts.ContextCompactionOversizedToolResultMaxTokens,
+		flagContextCompactionOversizedToolResultMaxTokens,
+		processor.DefaultContextCompactionOversizedToolResultMaxTokens,
 		"Truncate oversized tool results with head+tail preservation (0=disable)",
 	)
 	fs.IntVar(
@@ -939,11 +939,11 @@ type debugRecorderConfig struct {
 type agentRunConfig struct {
 	Type *string `yaml:"type,omitempty"`
 
-	AddSessionSummary            *bool `yaml:"add_session_summary,omitempty"`
-	EnableContextCompaction      *bool `yaml:"enable_context_compaction,omitempty"`
-	OversizedToolResultMaxTokens *int  `yaml:"oversized_tool_result_max_tokens,omitempty"`
-	MaxHistoryRuns               *int  `yaml:"max_history_runs,omitempty"`
-	PreloadMemory                *int  `yaml:"preload_memory,omitempty"`
+	AddSessionSummary       *bool `yaml:"add_session_summary,omitempty"`
+	EnableContextCompaction *bool `yaml:"enable_context_compaction,omitempty"`
+	ContextCompactionOversizedToolResultMaxTokens *int `yaml:"context_compaction_oversized_tool_result_max_tokens,omitempty"`
+	MaxHistoryRuns          *int  `yaml:"max_history_runs,omitempty"`
+	PreloadMemory           *int  `yaml:"preload_memory,omitempty"`
 
 	Instruction      *string  `yaml:"instruction,omitempty"`
 	InstructionFiles []string `yaml:"instruction_files,omitempty"`
@@ -1305,9 +1305,9 @@ func (cfg *fileConfig) apply(
 			!flagWasSet(set, flagEnableContextCompaction) {
 			opts.EnableContextCompaction = *cfg.Agent.EnableContextCompaction
 		}
-		if cfg.Agent.OversizedToolResultMaxTokens != nil &&
-			!flagWasSet(set, flagOversizedToolResultMaxTokens) {
-			opts.OversizedToolResultMaxTokens = *cfg.Agent.OversizedToolResultMaxTokens
+		if cfg.Agent.ContextCompactionOversizedToolResultMaxTokens != nil &&
+			!flagWasSet(set, flagContextCompactionOversizedToolResultMaxTokens) {
+			opts.ContextCompactionOversizedToolResultMaxTokens = *cfg.Agent.ContextCompactionOversizedToolResultMaxTokens
 		}
 		if cfg.Agent.MaxHistoryRuns != nil &&
 			!flagWasSet(set, flagMaxHistoryRuns) {

--- a/openclaw/app/run_options.go
+++ b/openclaw/app/run_options.go
@@ -24,6 +24,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	ia2a "trpc.group/trpc-go/trpc-agent-go/internal/a2a"
+	"trpc.group/trpc-go/trpc-agent-go/internal/flow/processor"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	ocskills "trpc.group/trpc-go/trpc-agent-go/openclaw/internal/skills"
 )
@@ -62,9 +63,11 @@ const (
 	defaultSessionSummaryEventThreshold = 20
 	defaultSkillsLoadMode               = "turn"
 
-	flagAddSessionSummary = "add-session-summary"
-	flagMaxHistoryRuns    = "max-history-runs"
-	flagPreloadMemory     = "preload-memory"
+	flagAddSessionSummary            = "add-session-summary"
+	flagEnableContextCompaction      = "enable-context-compaction"
+	flagOversizedToolResultMaxTokens = "oversized-tool-result-max-tokens"
+	flagMaxHistoryRuns               = "max-history-runs"
+	flagPreloadMemory                = "preload-memory"
 
 	flagAgentInstruction       = "agent-instruction"
 	flagAgentInstructionFiles  = "agent-instruction-files"
@@ -132,10 +135,11 @@ type runOptions struct {
 	A2AName           string
 	A2ADescription    string
 
-	AddSessionSummary       bool
-	EnableContextCompaction bool
-	MaxHistoryRuns          int
-	PreloadMemory           int
+	AddSessionSummary            bool
+	EnableContextCompaction      bool
+	OversizedToolResultMaxTokens int
+	MaxHistoryRuns               int
+	PreloadMemory                int
 
 	AgentInstruction       string
 	AgentInstructionFiles  string
@@ -352,9 +356,15 @@ func parseRunOptions(args []string) (runOptions, error) {
 	)
 	fs.BoolVar(
 		&opts.EnableContextCompaction,
-		"enable-context-compaction",
+		flagEnableContextCompaction,
 		false,
 		"Enable prompt-side context compaction to control context window growth",
+	)
+	fs.IntVar(
+		&opts.OversizedToolResultMaxTokens,
+		flagOversizedToolResultMaxTokens,
+		processor.DefaultOversizedToolResultMaxTokens,
+		"Truncate oversized tool results with head+tail preservation (0=disable)",
 	)
 	fs.IntVar(
 		&opts.MaxHistoryRuns,
@@ -929,10 +939,11 @@ type debugRecorderConfig struct {
 type agentRunConfig struct {
 	Type *string `yaml:"type,omitempty"`
 
-	AddSessionSummary       *bool `yaml:"add_session_summary,omitempty"`
-	EnableContextCompaction *bool `yaml:"enable_context_compaction,omitempty"`
-	MaxHistoryRuns          *int  `yaml:"max_history_runs,omitempty"`
-	PreloadMemory           *int  `yaml:"preload_memory,omitempty"`
+	AddSessionSummary            *bool `yaml:"add_session_summary,omitempty"`
+	EnableContextCompaction      *bool `yaml:"enable_context_compaction,omitempty"`
+	OversizedToolResultMaxTokens *int  `yaml:"oversized_tool_result_max_tokens,omitempty"`
+	MaxHistoryRuns               *int  `yaml:"max_history_runs,omitempty"`
+	PreloadMemory                *int  `yaml:"preload_memory,omitempty"`
 
 	Instruction      *string  `yaml:"instruction,omitempty"`
 	InstructionFiles []string `yaml:"instruction_files,omitempty"`
@@ -1291,8 +1302,12 @@ func (cfg *fileConfig) apply(
 			opts.AddSessionSummary = *cfg.Agent.AddSessionSummary
 		}
 		if cfg.Agent.EnableContextCompaction != nil &&
-			!flagWasSet(set, "enable-context-compaction") {
+			!flagWasSet(set, flagEnableContextCompaction) {
 			opts.EnableContextCompaction = *cfg.Agent.EnableContextCompaction
+		}
+		if cfg.Agent.OversizedToolResultMaxTokens != nil &&
+			!flagWasSet(set, flagOversizedToolResultMaxTokens) {
+			opts.OversizedToolResultMaxTokens = *cfg.Agent.OversizedToolResultMaxTokens
 		}
 		if cfg.Agent.MaxHistoryRuns != nil &&
 			!flagWasSet(set, flagMaxHistoryRuns) {

--- a/openclaw/app/run_options.go
+++ b/openclaw/app/run_options.go
@@ -132,9 +132,10 @@ type runOptions struct {
 	A2AName           string
 	A2ADescription    string
 
-	AddSessionSummary bool
-	MaxHistoryRuns    int
-	PreloadMemory     int
+	AddSessionSummary       bool
+	EnableContextCompaction bool
+	MaxHistoryRuns          int
+	PreloadMemory           int
 
 	AgentInstruction       string
 	AgentInstructionFiles  string
@@ -348,6 +349,12 @@ func parseRunOptions(args []string) (runOptions, error) {
 		flagAddSessionSummary,
 		false,
 		"Prepend session summary to the model context (optional)",
+	)
+	fs.BoolVar(
+		&opts.EnableContextCompaction,
+		"enable-context-compaction",
+		false,
+		"Enable prompt-side context compaction to control context window growth",
 	)
 	fs.IntVar(
 		&opts.MaxHistoryRuns,
@@ -922,9 +929,10 @@ type debugRecorderConfig struct {
 type agentRunConfig struct {
 	Type *string `yaml:"type,omitempty"`
 
-	AddSessionSummary *bool `yaml:"add_session_summary,omitempty"`
-	MaxHistoryRuns    *int  `yaml:"max_history_runs,omitempty"`
-	PreloadMemory     *int  `yaml:"preload_memory,omitempty"`
+	AddSessionSummary       *bool `yaml:"add_session_summary,omitempty"`
+	EnableContextCompaction *bool `yaml:"enable_context_compaction,omitempty"`
+	MaxHistoryRuns          *int  `yaml:"max_history_runs,omitempty"`
+	PreloadMemory           *int  `yaml:"preload_memory,omitempty"`
 
 	Instruction      *string  `yaml:"instruction,omitempty"`
 	InstructionFiles []string `yaml:"instruction_files,omitempty"`
@@ -1281,6 +1289,10 @@ func (cfg *fileConfig) apply(
 		if cfg.Agent.AddSessionSummary != nil &&
 			!flagWasSet(set, flagAddSessionSummary) {
 			opts.AddSessionSummary = *cfg.Agent.AddSessionSummary
+		}
+		if cfg.Agent.EnableContextCompaction != nil &&
+			!flagWasSet(set, "enable-context-compaction") {
+			opts.EnableContextCompaction = *cfg.Agent.EnableContextCompaction
 		}
 		if cfg.Agent.MaxHistoryRuns != nil &&
 			!flagWasSet(set, flagMaxHistoryRuns) {

--- a/openclaw/app/run_options.go
+++ b/openclaw/app/run_options.go
@@ -63,11 +63,11 @@ const (
 	defaultSessionSummaryEventThreshold = 20
 	defaultSkillsLoadMode               = "turn"
 
-	flagAddSessionSummary             = "add-session-summary"
-	flagEnableContextCompaction       = "enable-context-compaction"
+	flagAddSessionSummary                             = "add-session-summary"
+	flagEnableContextCompaction                       = "enable-context-compaction"
 	flagContextCompactionOversizedToolResultMaxTokens = "context-compaction-oversized-tool-result-max-tokens"
-	flagMaxHistoryRuns                = "max-history-runs"
-	flagPreloadMemory                 = "preload-memory"
+	flagMaxHistoryRuns                                = "max-history-runs"
+	flagPreloadMemory                                 = "preload-memory"
 
 	flagAgentInstruction       = "agent-instruction"
 	flagAgentInstructionFiles  = "agent-instruction-files"
@@ -135,11 +135,11 @@ type runOptions struct {
 	A2AName           string
 	A2ADescription    string
 
-	AddSessionSummary       bool
-	EnableContextCompaction bool
+	AddSessionSummary                             bool
+	EnableContextCompaction                       bool
 	ContextCompactionOversizedToolResultMaxTokens int
-	MaxHistoryRuns          int
-	PreloadMemory           int
+	MaxHistoryRuns                                int
+	PreloadMemory                                 int
 
 	AgentInstruction       string
 	AgentInstructionFiles  string
@@ -939,11 +939,11 @@ type debugRecorderConfig struct {
 type agentRunConfig struct {
 	Type *string `yaml:"type,omitempty"`
 
-	AddSessionSummary       *bool `yaml:"add_session_summary,omitempty"`
-	EnableContextCompaction *bool `yaml:"enable_context_compaction,omitempty"`
-	ContextCompactionOversizedToolResultMaxTokens *int `yaml:"context_compaction_oversized_tool_result_max_tokens,omitempty"`
-	MaxHistoryRuns          *int  `yaml:"max_history_runs,omitempty"`
-	PreloadMemory           *int  `yaml:"preload_memory,omitempty"`
+	AddSessionSummary                             *bool `yaml:"add_session_summary,omitempty"`
+	EnableContextCompaction                       *bool `yaml:"enable_context_compaction,omitempty"`
+	ContextCompactionOversizedToolResultMaxTokens *int  `yaml:"context_compaction_oversized_tool_result_max_tokens,omitempty"`
+	MaxHistoryRuns                                *int  `yaml:"max_history_runs,omitempty"`
+	PreloadMemory                                 *int  `yaml:"preload_memory,omitempty"`
 
 	Instruction      *string  `yaml:"instruction,omitempty"`
 	InstructionFiles []string `yaml:"instruction_files,omitempty"`

--- a/openclaw/app/run_options_test.go
+++ b/openclaw/app/run_options_test.go
@@ -269,6 +269,7 @@ agent:
   claude_env: ["A=B"]
   claude_work_dir: "/tmp/work"
   add_session_summary: false
+  enable_context_compaction: false
   max_history_runs: 123
   preload_memory: 2
 `)
@@ -290,6 +291,7 @@ agent:
 		"-agent-ralph-verify-env", "X=1",
 		"-claude-bin", "/tmp/claude",
 		"-add-session-summary",
+		"-enable-context-compaction",
 		"-max-history-runs", "9",
 		"-preload-memory", "-1",
 	})
@@ -309,6 +311,7 @@ agent:
 	require.Equal(t, "X=1", opts.RalphLoopVerifyEnv)
 	require.Equal(t, "/tmp/claude", opts.ClaudeBin)
 	require.True(t, opts.AddSessionSummary)
+	require.True(t, opts.EnableContextCompaction)
 	require.Equal(t, 9, opts.MaxHistoryRuns)
 	require.Equal(t, -1, opts.PreloadMemory)
 }
@@ -548,6 +551,7 @@ agent:
   claude_env: ["FOO=bar","X=1"]
   claude_work_dir: "/tmp/work"
   add_session_summary: true
+  enable_context_compaction: true
   max_history_runs: 50
   preload_memory: 10
   instruction: "instruction"
@@ -684,6 +688,7 @@ memory:
 	require.Equal(t, "/tmp/work", opts.ClaudeWorkDir)
 
 	require.True(t, opts.AddSessionSummary)
+	require.True(t, opts.EnableContextCompaction)
 	require.Equal(t, 50, opts.MaxHistoryRuns)
 	require.Equal(t, 10, opts.PreloadMemory)
 	require.Equal(t, "instruction", opts.AgentInstruction)

--- a/openclaw/app/run_options_test.go
+++ b/openclaw/app/run_options_test.go
@@ -270,6 +270,7 @@ agent:
   claude_work_dir: "/tmp/work"
   add_session_summary: false
   enable_context_compaction: false
+  oversized_tool_result_max_tokens: 2048
   max_history_runs: 123
   preload_memory: 2
 `)
@@ -292,6 +293,7 @@ agent:
 		"-claude-bin", "/tmp/claude",
 		"-add-session-summary",
 		"-enable-context-compaction",
+		"-oversized-tool-result-max-tokens", "256",
 		"-max-history-runs", "9",
 		"-preload-memory", "-1",
 	})
@@ -312,6 +314,7 @@ agent:
 	require.Equal(t, "/tmp/claude", opts.ClaudeBin)
 	require.True(t, opts.AddSessionSummary)
 	require.True(t, opts.EnableContextCompaction)
+	require.Equal(t, 256, opts.OversizedToolResultMaxTokens)
 	require.Equal(t, 9, opts.MaxHistoryRuns)
 	require.Equal(t, -1, opts.PreloadMemory)
 }
@@ -552,6 +555,7 @@ agent:
   claude_work_dir: "/tmp/work"
   add_session_summary: true
   enable_context_compaction: true
+  oversized_tool_result_max_tokens: 4096
   max_history_runs: 50
   preload_memory: 10
   instruction: "instruction"
@@ -689,6 +693,7 @@ memory:
 
 	require.True(t, opts.AddSessionSummary)
 	require.True(t, opts.EnableContextCompaction)
+	require.Equal(t, 4096, opts.OversizedToolResultMaxTokens)
 	require.Equal(t, 50, opts.MaxHistoryRuns)
 	require.Equal(t, 10, opts.PreloadMemory)
 	require.Equal(t, "instruction", opts.AgentInstruction)

--- a/openclaw/app/run_options_test.go
+++ b/openclaw/app/run_options_test.go
@@ -270,7 +270,7 @@ agent:
   claude_work_dir: "/tmp/work"
   add_session_summary: false
   enable_context_compaction: false
-  oversized_tool_result_max_tokens: 2048
+  context_compaction_oversized_tool_result_max_tokens: 2048
   max_history_runs: 123
   preload_memory: 2
 `)
@@ -293,7 +293,7 @@ agent:
 		"-claude-bin", "/tmp/claude",
 		"-add-session-summary",
 		"-enable-context-compaction",
-		"-oversized-tool-result-max-tokens", "256",
+		"-context-compaction-oversized-tool-result-max-tokens", "256",
 		"-max-history-runs", "9",
 		"-preload-memory", "-1",
 	})
@@ -314,7 +314,7 @@ agent:
 	require.Equal(t, "/tmp/claude", opts.ClaudeBin)
 	require.True(t, opts.AddSessionSummary)
 	require.True(t, opts.EnableContextCompaction)
-	require.Equal(t, 256, opts.OversizedToolResultMaxTokens)
+	require.Equal(t, 256, opts.ContextCompactionOversizedToolResultMaxTokens)
 	require.Equal(t, 9, opts.MaxHistoryRuns)
 	require.Equal(t, -1, opts.PreloadMemory)
 }
@@ -555,7 +555,7 @@ agent:
   claude_work_dir: "/tmp/work"
   add_session_summary: true
   enable_context_compaction: true
-  oversized_tool_result_max_tokens: 4096
+  context_compaction_oversized_tool_result_max_tokens: 4096
   max_history_runs: 50
   preload_memory: 10
   instruction: "instruction"
@@ -693,7 +693,7 @@ memory:
 
 	require.True(t, opts.AddSessionSummary)
 	require.True(t, opts.EnableContextCompaction)
-	require.Equal(t, 4096, opts.OversizedToolResultMaxTokens)
+	require.Equal(t, 4096, opts.ContextCompactionOversizedToolResultMaxTokens)
 	require.Equal(t, 50, opts.MaxHistoryRuns)
 	require.Equal(t, 10, opts.PreloadMemory)
 	require.Equal(t, "instruction", opts.AgentInstruction)


### PR DESCRIPTION
## Summary
- add a high-threshold head+tail truncation pass for oversized tool results, including the current request
- wire `OversizedToolResultMaxTokens` through agent options and OpenClaw config
- document the two compaction passes and add focused processor coverage

## Test plan
- [x] `go test ./internal/flow/processor ./agent/llmagent ./agent/graphagent`
- [x] `cd openclaw && go test ./app`
