### PR TITLE
session/summary: align token gating with effective input

### DIFF
--- a/session/summary/checker.go
+++ b/session/summary/checker.go
@@ -36,6 +36,9 @@ var (
 	defaultTokenCounter   model.TokenCounter = model.NewSimpleTokenCounter()
 )
 
+const tokenThresholdConversationTextStateKey = session.StateTempPrefix +
+	"summary:token_threshold_conversation_text"
+
 func getTokenCounter() model.TokenCounter {
 	defaultTokenCounterMu.RLock()
 	counter := defaultTokenCounter
@@ -212,6 +215,8 @@ func checkTokenThresholdFromText(
 // token count of the primary-agent events since the last summary exceeds
 // the given threshold. Sub-agent events (FilterKey != AppName) are excluded
 // so that child agent tokens do not inflate the parent threshold check.
+// When a summarizer injects effective summary text into the session state,
+// that text takes precedence over the default event extraction logic.
 //
 // Note:
 // Token accounting via model usage is not stable once session summary
@@ -241,6 +246,13 @@ func checkTokenThreshold(
 	tokenCount int,
 	sess *session.Session,
 ) bool {
+	if conversationText, ok := getInjectedTokenThresholdConversationText(sess); ok {
+		return checkTokenThresholdFromText(
+			ctx,
+			tokenCount,
+			conversationText,
+		)
+	}
 	delta := filterDeltaEvents(sess)
 	if len(delta) == 0 {
 		return false
@@ -257,6 +269,19 @@ func checkTokenThreshold(
 		tokenCount,
 		conversationText,
 	)
+}
+
+func getInjectedTokenThresholdConversationText(
+	sess *session.Session,
+) (string, bool) {
+	if sess == nil {
+		return "", false
+	}
+	raw, ok := sess.GetState(tokenThresholdConversationTextStateKey)
+	if !ok {
+		return "", false
+	}
+	return string(raw), true
 }
 
 // ChecksAll composes multiple checkers using AND logic.

--- a/session/summary/checker_test.go
+++ b/session/summary/checker_test.go
@@ -454,6 +454,29 @@ func TestCheckTokenThreshold(t *testing.T) {
 		// non-empty key → triggers.
 		assert.True(t, checker(sess))
 	})
+
+	t.Run("injected conversation text takes precedence", func(t *testing.T) {
+		checker := CheckTokenThreshold(100)
+		sess := &session.Session{
+			Events: []event.Event{
+				{
+					Author:    "tool",
+					Timestamp: time.Now(),
+					Response: &model.Response{Choices: []model.Choice{{
+						Message: model.Message{
+							ToolID:   "call-1",
+							ToolName: "read_file",
+							Content:  strings.Repeat("x", 2000),
+						},
+					}}},
+				},
+			},
+			State: session.StateMap{
+				tokenThresholdConversationTextStateKey: []byte("short"),
+			},
+		}
+		assert.False(t, checker(sess))
+	})
 }
 
 func TestCheckTokenThreshold_EmptyEvents(t *testing.T) {

--- a/session/summary/options_test.go
+++ b/session/summary/options_test.go
@@ -94,6 +94,146 @@ func TestOptions(t *testing.T) {
 		assert.Equal(t, 1, counter.miss)
 	})
 
+	t.Run("WithTokenThreshold honors skipRecent-filtered input", func(t *testing.T) {
+		s := NewSummarizer(
+			&testModel{},
+			WithSkipRecent(func(_ []event.Event) int { return 2 }),
+			WithTokenThreshold(100),
+		)
+		sess := &session.Session{Events: []event.Event{
+			{
+				Author:    "user",
+				Timestamp: time.Now(),
+				Response: &model.Response{Choices: []model.Choice{{
+					Message: model.Message{Content: "short"},
+				}}},
+			},
+			{
+				Author:    "assistant",
+				Timestamp: time.Now(),
+				Response: &model.Response{Choices: []model.Choice{{
+					Message: model.Message{Content: "reply"},
+				}}},
+			},
+			{
+				Author:    "user",
+				Timestamp: time.Now(),
+				Response: &model.Response{Choices: []model.Choice{{
+					Message: model.Message{Content: strings.Repeat("a", 800)},
+				}}},
+			},
+			{
+				Author:    "assistant",
+				Timestamp: time.Now(),
+				Response: &model.Response{Choices: []model.Choice{{
+					Message: model.Message{Content: strings.Repeat("b", 800)},
+				}}},
+			},
+		}}
+		assert.False(t, s.ShouldSummarize(sess))
+	})
+
+	t.Run("WithTokenThreshold honors summarizer tool result formatter", func(t *testing.T) {
+		s := NewSummarizer(
+			&testModel{},
+			WithToolResultFormatter(func(model.Message) string { return "" }),
+			WithTokenThreshold(100),
+		)
+		sess := &session.Session{Events: []event.Event{
+			{
+				Author:    "tool",
+				Timestamp: time.Now(),
+				Response: &model.Response{Choices: []model.Choice{{
+					Message: model.Message{
+						ToolID:   "call-1",
+						ToolName: "read_file",
+						Content:  strings.Repeat("x", 2000),
+					},
+				}}},
+			},
+		}}
+		assert.False(t, s.ShouldSummarize(sess))
+	})
+
+	t.Run("WithChecksAny token checker honors skipRecent-filtered input", func(t *testing.T) {
+		s := NewSummarizer(
+			&testModel{},
+			WithSkipRecent(func(_ []event.Event) int { return 2 }),
+			WithChecksAny(CheckTokenThreshold(100)),
+		)
+		sess := &session.Session{Events: []event.Event{
+			{
+				Author:    "user",
+				Timestamp: time.Now(),
+				Response: &model.Response{Choices: []model.Choice{{
+					Message: model.Message{Content: "short"},
+				}}},
+			},
+			{
+				Author:    "assistant",
+				Timestamp: time.Now(),
+				Response: &model.Response{Choices: []model.Choice{{
+					Message: model.Message{Content: "reply"},
+				}}},
+			},
+			{
+				Author:    "user",
+				Timestamp: time.Now(),
+				Response: &model.Response{Choices: []model.Choice{{
+					Message: model.Message{Content: strings.Repeat("a", 800)},
+				}}},
+			},
+			{
+				Author:    "assistant",
+				Timestamp: time.Now(),
+				Response: &model.Response{Choices: []model.Choice{{
+					Message: model.Message{Content: strings.Repeat("b", 800)},
+				}}},
+			},
+		}}
+		assert.False(t, s.ShouldSummarize(sess))
+	})
+
+	t.Run("WithChecksAny token checker honors summarizer tool result formatter", func(t *testing.T) {
+		s := NewSummarizer(
+			&testModel{},
+			WithToolResultFormatter(func(model.Message) string { return "" }),
+			WithChecksAny(CheckTokenThreshold(100)),
+		)
+		sess := &session.Session{Events: []event.Event{
+			{
+				Author:    "tool",
+				Timestamp: time.Now(),
+				Response: &model.Response{Choices: []model.Choice{{
+					Message: model.Message{
+						ToolID:   "call-1",
+						ToolName: "read_file",
+						Content:  strings.Repeat("x", 2000),
+					},
+				}}},
+			},
+		}}
+		assert.False(t, s.ShouldSummarize(sess))
+	})
+
+	t.Run("effective empty input suppresses summarize even when custom checks pass", func(t *testing.T) {
+		s := NewSummarizer(
+			&testModel{},
+			WithSkipRecent(func(events []event.Event) int { return len(events) }),
+			WithChecksAny(func(*session.Session) bool { return true }),
+		)
+		sess := &session.Session{Events: []event.Event{
+			{
+				Author:    "user",
+				Timestamp: time.Now(),
+				Response: &model.Response{Choices: []model.Choice{{
+					Message: model.Message{Content: "hello"},
+				}}},
+			},
+		}}
+		assert.False(t, s.ShouldSummarize(sess))
+	})
+
 	t.Run("WithEventThreshold", func(t *testing.T) {
 		s := NewSummarizer(&testModel{}, WithEventThreshold(2))
 		md := s.Metadata()

--- a/session/summary/summarizer.go
+++ b/session/summary/summarizer.go
@@ -218,9 +218,14 @@ func (s *sessionSummarizer) ShouldSummarizeWithContext(
 	if sess == nil || len(sess.Events) == 0 {
 		return false
 	}
+	if len(s.filterEventsForSummary(sess.Events)) == 0 {
+		return false
+	}
+
+	checkSess := s.buildCheckSession(sess)
 
 	for _, check := range s.checks {
-		if !check(ctx, sess) {
+		if !check(ctx, checkSess) {
 			return false
 		}
 	}
@@ -300,6 +305,23 @@ func (s *sessionSummarizer) recordLastIncludedTimestamp(sess *session.Session, e
 	}
 	last := events[len(events)-1].Timestamp.UTC()
 	sess.SetState(lastIncludedTsKey, []byte(last.Format(time.RFC3339Nano)))
+}
+
+func (s *sessionSummarizer) buildCheckSession(
+	sess *session.Session,
+) *session.Session {
+	if sess == nil {
+		return nil
+	}
+	checkSess := sess.Clone()
+	delta := filterDeltaEvents(checkSess)
+	filtered := s.filterEventsForSummary(delta)
+	primary := filterPrimaryEvents(filtered, checkSess.AppName)
+	checkSess.SetState(
+		tokenThresholdConversationTextStateKey,
+		[]byte(s.extractConversationText(primary)),
+	)
+	return checkSess
 }
 
 // filterEventsForSummary filters events for summarization, excluding recent events

--- a/session/summary/summarizer_test.go
+++ b/session/summary/summarizer_test.go
@@ -1506,6 +1506,41 @@ func TestSessionSummarizer_RecordLastIncludedTimestamp_NoStateOrEvents(t *testin
 	})
 }
 
+func TestSessionSummarizer_BuildCheckSession(t *testing.T) {
+	t.Run("returns nil for nil session", func(t *testing.T) {
+		s := &sessionSummarizer{}
+		assert.Nil(t, s.buildCheckSession(nil))
+	})
+
+	t.Run("injects effective token text from formatter-aware delta", func(t *testing.T) {
+		s := &sessionSummarizer{
+			toolResultFormatter: func(model.Message) string { return "" },
+		}
+		sess := &session.Session{
+			Events: []event.Event{
+				{
+					Author:    "tool",
+					Timestamp: time.Now(),
+					Response: &model.Response{Choices: []model.Choice{{
+						Message: model.Message{
+							ToolID:   "call-1",
+							ToolName: "read_file",
+							Content:  strings.Repeat("x", 2000),
+						},
+					}}},
+				},
+			},
+		}
+
+		checkSess := s.buildCheckSession(sess)
+		require.NotNil(t, checkSess)
+
+		raw, ok := checkSess.GetState(tokenThresholdConversationTextStateKey)
+		require.True(t, ok)
+		assert.Empty(t, string(raw))
+	})
+}
+
 func TestSessionSummarizer_Metadata_IncludesSkipRecent(t *testing.T) {
 	s := NewSummarizer(&fakeModel{}, WithSkipRecent(func(_ []event.Event) int { return 3 }))
 	metadata := s.Metadata()


### PR DESCRIPTION
## Summary
- make WithTokenThreshold evaluate the same effective summary input that the summarizer will actually use after skipRecent filtering
- suppress summary attempts when skipRecent removes all candidate events so async workers stop failing with empty summary input
- add coverage for skipRecent-aware token gating, custom tool result formatters, and the empty-input guard

## Testing
- go test ./session/summary
- go test ./...
- (cd openclaw && go test ./...)
