### PR TITLE
openclaw/skills: watch local skill roots

### DIFF
--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -1185,9 +1185,9 @@ result messages. This keeps the system prompt more stable while still
 letting `SkillLoadMode` control how long loaded skill state survives.
 
 When `skills.watch` is enabled, changes under local filesystem skill
-roots are picked up automatically on the next turn. Official install
-flows should still prefer staged publish plus explicit refresh after the
-final rename.
+roots are picked up automatically after the watch debounce fires.
+Official install flows should still prefer staged publish plus explicit
+refresh after the final rename.
 
 The built-in skills guidance is also more runtime-oriented by default:
 the agent prefers skill-owned scripts when present and may use minimal

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -1159,6 +1159,10 @@ skills:
   # Optional: restrict which bundled skills are enabled by default.
   # Applies only to bundled skills under ./openclaw/skills.
   allowBundled: ["gh-issues", "notion"]
+  # Watch mutable local skill roots and refresh automatically.
+  watch: true
+  watch_bundled: false
+  watch_debounce_ms: 250
   load_mode: "turn" # once|turn|session
   loaded_content_in_tool_results: true
   max_loaded_skills: 0
@@ -1179,6 +1183,11 @@ skills:
 OpenClaw defaults to materializing loaded skill bodies/docs into tool
 result messages. This keeps the system prompt more stable while still
 letting `SkillLoadMode` control how long loaded skill state survives.
+
+When `skills.watch` is enabled, changes under local filesystem skill
+roots are picked up automatically on the next turn. Official install
+flows should still prefer staged publish plus explicit refresh after the
+final rename.
 
 The built-in skills guidance is also more runtime-oriented by default:
 the agent prefers skill-owned scripts when present and may use minimal

--- a/openclaw/app/admin_server.go
+++ b/openclaw/app/admin_server.go
@@ -123,6 +123,7 @@ func buildAdminConfig(
 	adminAddr string,
 	adminURL string,
 	skillsRepo *ocskills.Repository,
+	skillsWatch *ocskills.WatchService,
 ) admin.Config {
 	return admin.Config{
 		AppName:        opts.AppName,
@@ -146,7 +147,12 @@ func buildAdminConfig(
 		DebugDir:       debugDir,
 		Channels:       channelIDs(channels),
 		GatewayRoutes:  routes,
-		Skills:         buildAdminSkillsProvider(opts, stateDir, skillsRepo),
+		Skills: buildAdminSkillsProvider(
+			opts,
+			stateDir,
+			skillsRepo,
+			skillsWatch,
+		),
 		Browser: buildBrowserAdminConfig(
 			opts.ToolProviders,
 			browserManaged,
@@ -260,6 +266,7 @@ type adminSkillsProvider struct {
 	mu           sync.RWMutex
 	configPath   string
 	repo         *ocskills.Repository
+	watch        *ocskills.WatchService
 	roots        []string
 	bundledRoot  string
 	configKeys   []string
@@ -271,6 +278,7 @@ func buildAdminSkillsProvider(
 	opts runOptions,
 	stateDir string,
 	repo *ocskills.Repository,
+	watch *ocskills.WatchService,
 ) admin.SkillsStatusProvider {
 	cwd, _ := os.Getwd()
 	cfg := agentConfig{
@@ -281,6 +289,7 @@ func buildAdminSkillsProvider(
 	return &adminSkillsProvider{
 		configPath:   strings.TrimSpace(opts.ConfigPath),
 		repo:         repo,
+		watch:        watch,
 		roots:        resolveSkillRoots(cwd, cfg),
 		bundledRoot:  resolveBundledSkillsRoot(cwd, stateDir),
 		configKeys:   resolveSkillConfigKeys(opts),

--- a/openclaw/app/admin_server_test.go
+++ b/openclaw/app/admin_server_test.go
@@ -100,6 +100,7 @@ nodes:
 		"127.0.0.1:8081",
 		"http://127.0.0.1:8081",
 		nil,
+		nil,
 	)
 
 	require.Len(t, cfg.Browser.Providers, 1)

--- a/openclaw/app/admin_skills_config.go
+++ b/openclaw/app/admin_skills_config.go
@@ -38,16 +38,27 @@ func (p *adminSkillsProvider) SkillsStatus() (ocskills.StatusReport, error) {
 	p.mu.RUnlock()
 
 	if repo != nil {
-		return repo.Status(), nil
+		report := repo.Status()
+		if p.watch != nil {
+			report.Watch = p.watch.Status()
+		}
+		return report, nil
 	}
 
-	return ocskills.BuildStatus(
+	report, err := ocskills.BuildStatus(
 		roots,
 		ocskills.WithBundledSkillsRoot(bundledRoot),
 		ocskills.WithConfigKeys(configKeys),
 		ocskills.WithAllowBundled(allowBundled),
 		ocskills.WithSkillConfigs(skillConfigs),
 	)
+	if err != nil {
+		return ocskills.StatusReport{}, err
+	}
+	if p.watch != nil {
+		report.Watch = p.watch.Status()
+	}
+	return report, nil
 }
 
 func (p *adminSkillsProvider) SkillsConfigPath() string {
@@ -77,9 +88,13 @@ func (p *adminSkillsProvider) RefreshSkills() error {
 
 	p.mu.RLock()
 	repo := p.repo
+	watch := p.watch
 	p.mu.RUnlock()
 	if repo == nil {
 		return fmt.Errorf("live skills repository is not available")
+	}
+	if watch != nil {
+		return watch.Refresh()
 	}
 	return repo.Refresh()
 }

--- a/openclaw/app/admin_skills_config_test.go
+++ b/openclaw/app/admin_skills_config_test.go
@@ -167,6 +167,94 @@ description: "Probe weather prerequisites"
 	require.Equal(t, "weather-probe", report.Skills[0].Name)
 }
 
+func TestAdminSkillsProviderSkillsStatus_AttachesWatchStatus(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeTestSkill(t, root, "weather-probe", `---
+name: weather-probe
+description: "Probe weather prerequisites"
+---
+
+# weather-probe
+`)
+
+	repo, err := ocskills.NewRepository([]string{root})
+	require.NoError(t, err)
+
+	watch := ocskills.NewWatchService(
+		repo,
+		[]string{root},
+		ocskills.WatchConfig{Enabled: false},
+	)
+	require.NotNil(t, watch)
+	t.Cleanup(func() {
+		require.NoError(t, watch.Close())
+	})
+
+	provider := &adminSkillsProvider{
+		roots: []string{root},
+		watch: watch,
+	}
+
+	report, err := provider.SkillsStatus()
+	require.NoError(t, err)
+	require.Len(t, report.Skills, 1)
+	require.NotNil(t, report.Watch)
+	require.False(t, report.Watch.Enabled)
+}
+
+func TestAdminSkillsProviderSkillsStatus_BuildError(t *testing.T) {
+	t.Parallel()
+
+	provider := &adminSkillsProvider{
+		roots: []string{"cos://bucket/skills.zip"},
+	}
+
+	_, err := provider.SkillsStatus()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported skills root URL")
+}
+
+func TestAdminSkillsProviderRefreshSkills_UsesWatchRefresh(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	repo, err := ocskills.NewRepository([]string{root})
+	require.NoError(t, err)
+
+	watch := ocskills.NewWatchService(
+		repo,
+		[]string{root},
+		ocskills.WatchConfig{Enabled: false},
+	)
+	require.NotNil(t, watch)
+	t.Cleanup(func() {
+		require.NoError(t, watch.Close())
+	})
+
+	provider := &adminSkillsProvider{
+		repo:  repo,
+		watch: watch,
+	}
+
+	writeTestSkill(t, root, "weather-probe", `---
+name: weather-probe
+description: "Probe weather prerequisites"
+---
+
+# weather-probe
+`)
+
+	require.NoError(t, provider.RefreshSkills())
+
+	report, err := provider.SkillsStatus()
+	require.NoError(t, err)
+	require.Len(t, report.Skills, 1)
+	require.NotNil(t, report.Watch)
+	require.Equal(t, "manual", report.Watch.LastRefreshReason)
+}
+
 func TestAdminSkillsProviderHelpersAndFallbackStatus(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -471,6 +471,7 @@ type Runtime struct {
 	sessionSvc        closeFunc
 	memorySvc         closeFunc
 	cronSvc           closeFunc
+	skillsWatch       closeFunc
 	toolSets          []tool.ToolSet
 	telemetryShutdown func(context.Context) error
 }
@@ -627,9 +628,10 @@ func NewRuntime(
 	extraTools = append(extraTools, openClawTools.tools...)
 
 	var (
-		toolSets   []tool.ToolSet
-		ag         agent.Agent
-		skillsRepo *ocskills.Repository
+		toolSets    []tool.ToolSet
+		ag          agent.Agent
+		skillsRepo  *ocskills.Repository
+		skillsWatch *ocskills.WatchService
 	)
 	if agentType == agentTypeClaudeCode {
 		ag, err = newClaudeCodeAgent(opts)
@@ -646,7 +648,7 @@ func NewRuntime(
 				Err:  fmt.Errorf("create toolsets failed: %w", err),
 			}
 		}
-		ag, skillsRepo, err = newAgent(mdl, agentConfig{
+		agentCfg := agentConfig{
 			AppName:                 opts.AppName,
 			AddSessionSummary:       opts.AddSessionSummary,
 			EnableContextCompaction: opts.EnableContextCompaction,
@@ -663,16 +665,19 @@ func NewRuntime(
 			SkillsAllowBundled: splitCSV(
 				opts.SkillsAllowBundled,
 			),
-			SkillConfigs:       opts.SkillConfigs,
-			SkillConfigKeys:    resolveSkillConfigKeys(opts),
-			SkillsLoadMode:     opts.SkillsLoadMode,
-			SkillsMaxLoaded:    opts.SkillsMaxLoaded,
-			SkillsToolResults:  opts.SkillsToolResults,
-			SkillsSkipFallback: opts.SkillsSkipFallback,
-			SkillsToolingGuide: opts.SkillsToolingGuide,
-			KnowledgesConfig:   opts.KnowledgesConfig,
-			StateDir:           resolvedStateDir,
-			MemoryFileStore:    fileMemoryStore,
+			SkillConfigs:        opts.SkillConfigs,
+			SkillConfigKeys:     resolveSkillConfigKeys(opts),
+			SkillsWatch:         opts.SkillsWatch,
+			SkillsWatchBundled:  opts.SkillsWatchBundled,
+			SkillsWatchDebounce: opts.SkillsWatchDebounce,
+			SkillsLoadMode:      opts.SkillsLoadMode,
+			SkillsMaxLoaded:     opts.SkillsMaxLoaded,
+			SkillsToolResults:   opts.SkillsToolResults,
+			SkillsSkipFallback:  opts.SkillsSkipFallback,
+			SkillsToolingGuide:  opts.SkillsToolingGuide,
+			KnowledgesConfig:    opts.KnowledgesConfig,
+			StateDir:            resolvedStateDir,
+			MemoryFileStore:     fileMemoryStore,
 
 			EnableLocalExec:     opts.EnableLocalExec,
 			EnableOpenClawTools: opts.EnableOpenClawTools,
@@ -682,7 +687,21 @@ func NewRuntime(
 			ToolSets:      opts.ToolSets,
 
 			RefreshToolSetsOnRun: opts.RefreshToolSetsOnRun,
-		}, extraTools, toolSets)
+		}
+		ag, skillsRepo, err = newAgent(
+			mdl,
+			agentCfg,
+			extraTools,
+			toolSets,
+		)
+		if err == nil {
+			cwd, _ := os.Getwd()
+			skillsWatch = newSkillsWatchService(
+				cwd,
+				agentCfg,
+				skillsRepo,
+			)
+		}
 	}
 	if err != nil {
 		closeToolSets(toolSets)
@@ -692,6 +711,7 @@ func NewRuntime(
 		}
 	}
 	rt.toolSets = toolSets
+	rt.skillsWatch = skillsWatch
 
 	bridgedSessionSvc := conversationscope.WrapSessionService(sessionSvc)
 	runnerOpts := []runner.Option{
@@ -870,6 +890,7 @@ func NewRuntime(
 			opts.AdminAddr,
 			adminURL,
 			skillsRepo,
+			skillsWatch,
 		))
 		rt.Admin = AdminSurface{
 			Handler: adminSvc.Handler(),
@@ -893,6 +914,11 @@ func (r *Runtime) Close() error {
 	}
 	if r.cronRunner != nil {
 		_ = r.cronRunner.Close()
+	}
+	if r.skillsWatch != nil {
+		if err := r.skillsWatch.Close(); err != nil {
+			errs = append(errs, err)
+		}
 	}
 	closeToolSets(r.toolSets)
 	closeMemoryService(r.memorySvc)
@@ -1055,12 +1081,21 @@ func run(ctx context.Context, args []string) error {
 	extraTools = append(extraTools, openClawTools.tools...)
 
 	var (
-		toolSets   []tool.ToolSet
-		ag         agent.Agent
-		skillsRepo *ocskills.Repository
+		toolSets    []tool.ToolSet
+		ag          agent.Agent
+		skillsRepo  *ocskills.Repository
+		skillsWatch *ocskills.WatchService
 	)
 	defer func() {
 		closeToolSets(toolSets)
+	}()
+	defer func() {
+		if skillsWatch == nil {
+			return
+		}
+		if err := skillsWatch.Close(); err != nil {
+			log.Warnf("close skills watch failed: %v", err)
+		}
 	}()
 	if agentType == agentTypeClaudeCode {
 		ag, err = newClaudeCodeAgent(opts)
@@ -1077,7 +1112,7 @@ func run(ctx context.Context, args []string) error {
 				Err:  fmt.Errorf("create toolsets failed: %w", err),
 			}
 		}
-		ag, skillsRepo, err = newAgent(mdl, agentConfig{
+		agentCfg := agentConfig{
 			AppName:                 opts.AppName,
 			AddSessionSummary:       opts.AddSessionSummary,
 			EnableContextCompaction: opts.EnableContextCompaction,
@@ -1094,16 +1129,19 @@ func run(ctx context.Context, args []string) error {
 			SkillsAllowBundled: splitCSV(
 				opts.SkillsAllowBundled,
 			),
-			SkillConfigs:       opts.SkillConfigs,
-			SkillConfigKeys:    resolveSkillConfigKeys(opts),
-			SkillsLoadMode:     opts.SkillsLoadMode,
-			SkillsMaxLoaded:    opts.SkillsMaxLoaded,
-			SkillsToolResults:  opts.SkillsToolResults,
-			SkillsSkipFallback: opts.SkillsSkipFallback,
-			SkillsToolingGuide: opts.SkillsToolingGuide,
-			KnowledgesConfig:   opts.KnowledgesConfig,
-			StateDir:           resolvedStateDir,
-			MemoryFileStore:    fileMemoryStore,
+			SkillConfigs:        opts.SkillConfigs,
+			SkillConfigKeys:     resolveSkillConfigKeys(opts),
+			SkillsWatch:         opts.SkillsWatch,
+			SkillsWatchBundled:  opts.SkillsWatchBundled,
+			SkillsWatchDebounce: opts.SkillsWatchDebounce,
+			SkillsLoadMode:      opts.SkillsLoadMode,
+			SkillsMaxLoaded:     opts.SkillsMaxLoaded,
+			SkillsToolResults:   opts.SkillsToolResults,
+			SkillsSkipFallback:  opts.SkillsSkipFallback,
+			SkillsToolingGuide:  opts.SkillsToolingGuide,
+			KnowledgesConfig:    opts.KnowledgesConfig,
+			StateDir:            resolvedStateDir,
+			MemoryFileStore:     fileMemoryStore,
 
 			EnableLocalExec:     opts.EnableLocalExec,
 			EnableOpenClawTools: opts.EnableOpenClawTools,
@@ -1113,7 +1151,21 @@ func run(ctx context.Context, args []string) error {
 			ToolSets:      opts.ToolSets,
 
 			RefreshToolSetsOnRun: opts.RefreshToolSetsOnRun,
-		}, extraTools, toolSets)
+		}
+		ag, skillsRepo, err = newAgent(
+			mdl,
+			agentCfg,
+			extraTools,
+			toolSets,
+		)
+		if err == nil {
+			cwd, _ := os.Getwd()
+			skillsWatch = newSkillsWatchService(
+				cwd,
+				agentCfg,
+				skillsRepo,
+			)
+		}
 	}
 	if err != nil {
 		return &exitError{
@@ -1319,6 +1371,7 @@ func run(ctx context.Context, args []string) error {
 			adminBinding.addr,
 			adminBinding.url,
 			skillsRepo,
+			skillsWatch,
 		))
 		adminSrv = &http.Server{
 			Handler:           adminSvc.Handler(),
@@ -2135,18 +2188,21 @@ type agentConfig struct {
 	Instruction                                   string
 	SystemPrompt                                  string
 
-	SkillsRoot         string
-	SkillsExtraDirs    []string
-	SkillsDebug        bool
-	SkillsAllowBundled []string
-	SkillConfigs       map[string]ocskills.SkillConfig
-	SkillConfigKeys    []string
-	SkillsLoadMode     string
-	SkillsMaxLoaded    int
-	SkillsToolResults  bool
-	SkillsSkipFallback bool
-	SkillsToolingGuide *string
-	KnowledgesConfig   map[string]*yaml.Node
+	SkillsRoot          string
+	SkillsExtraDirs     []string
+	SkillsDebug         bool
+	SkillsAllowBundled  []string
+	SkillConfigs        map[string]ocskills.SkillConfig
+	SkillConfigKeys     []string
+	SkillsWatch         bool
+	SkillsWatchBundled  bool
+	SkillsWatchDebounce time.Duration
+	SkillsLoadMode      string
+	SkillsMaxLoaded     int
+	SkillsToolResults   bool
+	SkillsSkipFallback  bool
+	SkillsToolingGuide  *string
+	KnowledgesConfig    map[string]*yaml.Node
 
 	StateDir string
 
@@ -2299,6 +2355,30 @@ func resolveSkillRoots(cwd string, cfg agentConfig) []string {
 	}
 	roots = append(roots, cfg.SkillsExtraDirs...)
 	return roots
+}
+
+func newSkillsWatchService(
+	cwd string,
+	cfg agentConfig,
+	repo *ocskills.Repository,
+) *ocskills.WatchService {
+	if repo == nil {
+		return nil
+	}
+
+	return ocskills.NewWatchService(
+		repo,
+		resolveSkillRoots(cwd, cfg),
+		ocskills.WatchConfig{
+			Enabled:      cfg.SkillsWatch,
+			Debounce:     cfg.SkillsWatchDebounce,
+			WatchBundled: cfg.SkillsWatchBundled,
+			BundledRoot: resolveBundledSkillsRoot(
+				cwd,
+				cfg.StateDir,
+			),
+		},
+	)
 }
 
 func resolveWorkspaceSkillsRoot(cwd, raw string) string {

--- a/openclaw/app/run_options.go
+++ b/openclaw/app/run_options.go
@@ -62,6 +62,7 @@ const (
 
 	defaultSessionSummaryEventThreshold = 20
 	defaultSkillsLoadMode               = "turn"
+	defaultSkillsWatchDebounce          = 250 * time.Millisecond
 
 	flagAddSessionSummary                             = "add-session-summary"
 	flagEnableContextCompaction                       = "enable-context-compaction"
@@ -88,11 +89,14 @@ const (
 
 	flagEnableParallelTools = "enable-parallel-tools"
 
-	flagSkillsAllowBundled = "skills-allow-bundled"
-	flagSkillsLoadMode     = "skills-load-mode"
-	flagSkillsMaxLoaded    = "skills-max-loaded"
-	flagSkillsToolResults  = "skills-loaded-content-in-tool-results"
-	flagSkillsSkipFallback = "skills-skip-fallback-on-session-summary"
+	flagSkillsAllowBundled  = "skills-allow-bundled"
+	flagSkillsWatch         = "skills-watch"
+	flagSkillsWatchBundled  = "skills-watch-bundled"
+	flagSkillsWatchDebounce = "skills-watch-debounce"
+	flagSkillsLoadMode      = "skills-load-mode"
+	flagSkillsMaxLoaded     = "skills-max-loaded"
+	flagSkillsToolResults   = "skills-loaded-content-in-tool-results"
+	flagSkillsSkipFallback  = "skills-skip-fallback-on-session-summary"
 
 	flagDebugRecorder     = "debug-recorder"
 	flagDebugRecorderDir  = "debug-recorder-dir"
@@ -166,24 +170,27 @@ type runOptions struct {
 	ClaudeEnv          string
 	ClaudeWorkDir      string
 
-	ModelMode          string
-	OpenAIModel        string
-	OpenAIVariant      string
-	OpenAIBaseURL      string
-	GenerationConfig   *model.GenerationConfig
-	ModelConfig        *yaml.Node
-	KnowledgesConfig   map[string]*yaml.Node
-	SkillsRoot         string
-	SkillsExtraDir     string
-	SkillsDebug        bool
-	SkillsAllowBundled string
-	SkillConfigs       map[string]ocskills.SkillConfig
-	SkillsLoadMode     string
-	SkillsMaxLoaded    int
-	SkillsToolResults  bool
-	SkillsSkipFallback bool
-	SkillsToolingGuide *string
-	StateDir           string
+	ModelMode           string
+	OpenAIModel         string
+	OpenAIVariant       string
+	OpenAIBaseURL       string
+	GenerationConfig    *model.GenerationConfig
+	ModelConfig         *yaml.Node
+	KnowledgesConfig    map[string]*yaml.Node
+	SkillsRoot          string
+	SkillsExtraDir      string
+	SkillsDebug         bool
+	SkillsAllowBundled  string
+	SkillConfigs        map[string]ocskills.SkillConfig
+	SkillsWatch         bool
+	SkillsWatchBundled  bool
+	SkillsWatchDebounce time.Duration
+	SkillsLoadMode      string
+	SkillsMaxLoaded     int
+	SkillsToolResults   bool
+	SkillsSkipFallback  bool
+	SkillsToolingGuide  *string
+	StateDir            string
 
 	DebugRecorderEnabled bool
 	DebugRecorderDir     string
@@ -252,9 +259,11 @@ func parseRunOptions(args []string) (runOptions, error) {
 		OpenAIModel:   defaultOpenAIModelName(),
 		OpenAIVariant: defaultOpenAIVariant,
 
-		SkillsLoadMode:     defaultSkillsLoadMode,
-		SkillsToolResults:  true,
-		SkillsSkipFallback: true,
+		SkillsWatch:         true,
+		SkillsWatchDebounce: defaultSkillsWatchDebounce,
+		SkillsLoadMode:      defaultSkillsLoadMode,
+		SkillsToolResults:   true,
+		SkillsSkipFallback:  true,
 
 		SessionBackend: sessionBackendInMemory,
 		MemoryBackend:  memoryBackendInMemory,
@@ -563,6 +572,24 @@ func parseRunOptions(args []string) (runOptions, error) {
 		flagSkillsAllowBundled,
 		"",
 		"Comma-separated allowlist of bundled skills",
+	)
+	fs.BoolVar(
+		&opts.SkillsWatch,
+		flagSkillsWatch,
+		true,
+		"Watch local skill roots and refresh automatically",
+	)
+	fs.DurationVar(
+		&opts.SkillsWatchDebounce,
+		flagSkillsWatchDebounce,
+		defaultSkillsWatchDebounce,
+		"Debounce for automatic skill refreshes",
+	)
+	fs.BoolVar(
+		&opts.SkillsWatchBundled,
+		flagSkillsWatchBundled,
+		false,
+		"Also watch bundled skills roots for local changes",
 	)
 	fs.StringVar(
 		&opts.SkillsLoadMode,
@@ -1012,12 +1039,17 @@ type skillsConfig struct {
 	ExtraDirs []string `yaml:"extra_dirs,omitempty"`
 	Debug     *bool    `yaml:"debug,omitempty"`
 
-	AllowBundled      []string `yaml:"allow_bundled,omitempty"`
-	AllowBundledCamel []string `yaml:"allowBundled,omitempty"`
-	LoadMode          *string  `yaml:"load_mode,omitempty"`
-	LoadModeCamel     *string  `yaml:"loadMode,omitempty"`
-	MaxLoadedSkills   *int     `yaml:"max_loaded_skills,omitempty"`
-	MaxLoadedCamel    *int     `yaml:"maxLoadedSkills,omitempty"`
+	AllowBundled       []string `yaml:"allow_bundled,omitempty"`
+	AllowBundledCamel  []string `yaml:"allowBundled,omitempty"`
+	Watch              *bool    `yaml:"watch,omitempty"`
+	WatchBundled       *bool    `yaml:"watch_bundled,omitempty"`
+	WatchBundledCamel  *bool    `yaml:"watchBundled,omitempty"`
+	WatchDebounceMS    *int     `yaml:"watch_debounce_ms,omitempty"`
+	WatchDebounceCamel *int     `yaml:"watchDebounceMs,omitempty"`
+	LoadMode           *string  `yaml:"load_mode,omitempty"`
+	LoadModeCamel      *string  `yaml:"loadMode,omitempty"`
+	MaxLoadedSkills    *int     `yaml:"max_loaded_skills,omitempty"`
+	MaxLoadedCamel     *int     `yaml:"maxLoadedSkills,omitempty"`
 
 	ToolResults          *bool   `yaml:"loaded_content_in_tool_results,omitempty"`
 	ToolResultsCamel     *bool   `yaml:"loadedContentInToolResults,omitempty"`
@@ -1479,6 +1511,28 @@ func (cfg *fileConfig) apply(
 				allowBundled,
 				csvDelimiter,
 			)
+		}
+		if cfg.Skills.Watch != nil &&
+			!flagWasSet(set, flagSkillsWatch) {
+			opts.SkillsWatch = *cfg.Skills.Watch
+		}
+		watchBundled := firstBoolPtr(
+			cfg.Skills.WatchBundled,
+			cfg.Skills.WatchBundledCamel,
+		)
+		if watchBundled != nil &&
+			!flagWasSet(set, flagSkillsWatchBundled) {
+			opts.SkillsWatchBundled = *watchBundled
+		}
+		watchDebounceMS := firstIntPtr(
+			cfg.Skills.WatchDebounceMS,
+			cfg.Skills.WatchDebounceCamel,
+		)
+		if watchDebounceMS != nil &&
+			!flagWasSet(set, flagSkillsWatchDebounce) {
+			opts.SkillsWatchDebounce = time.Duration(
+				*watchDebounceMS,
+			) * time.Millisecond
 		}
 		if len(cfg.Skills.Entries) > 0 {
 			opts.SkillConfigs = convertSkillConfigs(
@@ -1954,6 +2008,12 @@ func finalizeRunOptions(opts *runOptions) error {
 		return err
 	}
 	opts.SkillsLoadMode = mode
+	if opts.SkillsWatchDebounce < 0 {
+		return fmt.Errorf(
+			"invalid skills watch debounce: %v",
+			opts.SkillsWatchDebounce,
+		)
+	}
 	opts.MemoryBackend = resolveMemoryBackendType(opts.MemoryBackend)
 	opts.AdminAddr = strings.TrimSpace(opts.AdminAddr)
 	if opts.AdminEnabled && opts.AdminAddr == "" {

--- a/openclaw/app/run_options_test.go
+++ b/openclaw/app/run_options_test.go
@@ -1179,3 +1179,18 @@ func TestFinalizeRunOptions_ApproxRunesPerToken(t *testing.T) {
 		require.Error(t, finalizeRunOptions(opts))
 	})
 }
+
+func TestFinalizeRunOptions_SkillsWatchDebounce(t *testing.T) {
+	t.Parallel()
+
+	opts := &runOptions{
+		SkillsWatchDebounce: -time.Millisecond,
+	}
+
+	err := finalizeRunOptions(opts)
+	require.EqualError(
+		t,
+		err,
+		"invalid skills watch debounce: -1ms",
+	)
+}

--- a/openclaw/app/run_options_test.go
+++ b/openclaw/app/run_options_test.go
@@ -605,6 +605,9 @@ skills:
   extra_dirs: ["/extra1","/extra2"]
   debug: true
   allowBundled: ["gh-issues","notion"]
+  watch: false
+  watch_bundled: true
+  watch_debounce_ms: 125
   load_mode: "session"
   max_loaded_skills: 3
   loaded_content_in_tool_results: false
@@ -744,6 +747,9 @@ memory:
 	require.Equal(t, "/extra1,/extra2", opts.SkillsExtraDir)
 	require.True(t, opts.SkillsDebug)
 	require.Equal(t, "gh-issues,notion", opts.SkillsAllowBundled)
+	require.False(t, opts.SkillsWatch)
+	require.True(t, opts.SkillsWatchBundled)
+	require.Equal(t, 125*time.Millisecond, opts.SkillsWatchDebounce)
 	require.Equal(t, "session", opts.SkillsLoadMode)
 	require.Equal(t, 3, opts.SkillsMaxLoaded)
 	require.False(t, opts.SkillsToolResults)
@@ -1043,6 +1049,13 @@ func TestParseRunOptions_SkillsDefaults(t *testing.T) {
 
 	opts, err := parseRunOptions(nil)
 	require.NoError(t, err)
+	require.True(t, opts.SkillsWatch)
+	require.False(t, opts.SkillsWatchBundled)
+	require.Equal(
+		t,
+		defaultSkillsWatchDebounce,
+		opts.SkillsWatchDebounce,
+	)
 	require.Equal(t, defaultSkillsLoadMode, opts.SkillsLoadMode)
 	require.True(t, opts.SkillsToolResults)
 	require.True(t, opts.SkillsSkipFallback)

--- a/openclaw/go.mod
+++ b/openclaw/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.26.0
 	github.com/alicebob/miniredis/v2 v2.35.0
 	github.com/creack/pty v1.1.24
+	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-pdf/fpdf v0.9.0
 	github.com/google/uuid v1.6.0
 	github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728
@@ -98,7 +99,6 @@ require (
 	github.com/elastic/go-elasticsearch/v8 v8.19.0 // indirect
 	github.com/elastic/go-elasticsearch/v9 v9.1.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/getkin/kin-openapi v0.133.0 // indirect
 	github.com/go-ego/gse v1.0.0 // indirect
 	github.com/go-faster/city v1.0.1 // indirect

--- a/openclaw/go.mod
+++ b/openclaw/go.mod
@@ -98,6 +98,7 @@ require (
 	github.com/elastic/go-elasticsearch/v8 v8.19.0 // indirect
 	github.com/elastic/go-elasticsearch/v9 v9.1.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/getkin/kin-openapi v0.133.0 // indirect
 	github.com/go-ego/gse v1.0.0 // indirect
 	github.com/go-faster/city v1.0.1 // indirect

--- a/openclaw/go.sum
+++ b/openclaw/go.sum
@@ -57,6 +57,8 @@ github.com/elastic/go-elasticsearch/v9 v9.1.0 h1:+qmeMi+Zuyc/BzTWxHUouGJX5aF567I
 github.com/elastic/go-elasticsearch/v9 v9.1.0/go.mod h1:2PB5YQPpY5tWbF65MRqzEXA31PZOdXCkloQSOZtU14I=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
+github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/getkin/kin-openapi v0.133.0 h1:pJdmNohVIJ97r4AUFtEXRXwESr8b0bD721u/Tz6k8PQ=
 github.com/getkin/kin-openapi v0.133.0/go.mod h1:boAciF6cXk5FhPqe/NQeBTeenbjqU4LhWBf09ILVvWE=
 github.com/go-ego/gse v1.0.0 h1:GNbtH1WP7Yd1VvCZ85fIK6eVEe7RctmgmnwliEPUMNA=

--- a/openclaw/internal/skills/status.go
+++ b/openclaw/internal/skills/status.go
@@ -60,6 +60,7 @@ type StatusEntry struct {
 
 type StatusReport struct {
 	Skills []StatusEntry `json:"skills,omitempty"`
+	Watch  *WatchStatus  `json:"watch,omitempty"`
 }
 
 func BuildStatus(roots []string, opts ...Option) (StatusReport, error) {

--- a/openclaw/internal/skills/watch.go
+++ b/openclaw/internal/skills/watch.go
@@ -10,6 +10,7 @@
 package skills
 
 import (
+	iofs "io/fs"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -272,8 +273,16 @@ func (s *WatchService) relevantEvent(
 
 	s.watchMu.RLock()
 	defer s.watchMu.RUnlock()
-	if _, ok := s.watched[path]; ok {
-		return path, true
+	current := path
+	for current != "." && current != "" {
+		if _, ok := s.watched[current]; ok {
+			return path, true
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			break
+		}
+		current = parent
 	}
 	return "", false
 }
@@ -348,19 +357,7 @@ func (s *WatchService) desiredWatchDirs() map[string]struct{} {
 			continue
 		}
 		if watchDirExists(root) {
-			dirs[root] = struct{}{}
-			entries, err := os.ReadDir(root)
-			if err != nil {
-				continue
-			}
-			for _, entry := range entries {
-				if !entry.IsDir() {
-					continue
-				}
-				if isIgnoredWatchName(entry.Name()) {
-					continue
-				}
-				path := filepath.Join(root, entry.Name())
+			for path := range collectWatchDirs(root) {
 				dirs[path] = struct{}{}
 			}
 			continue
@@ -370,6 +367,27 @@ func (s *WatchService) desiredWatchDirs() map[string]struct{} {
 			dirs[parent] = struct{}{}
 		}
 	}
+	return dirs
+}
+
+func collectWatchDirs(root string) map[string]struct{} {
+	dirs := map[string]struct{}{}
+	_ = filepath.WalkDir(
+		root,
+		func(path string, d iofs.DirEntry, err error) error {
+			if err != nil {
+				return nil
+			}
+			if !d.IsDir() {
+				return nil
+			}
+			if path != root && isIgnoredWatchName(d.Name()) {
+				return filepath.SkipDir
+			}
+			dirs[path] = struct{}{}
+			return nil
+		},
+	)
 	return dirs
 }
 

--- a/openclaw/internal/skills/watch.go
+++ b/openclaw/internal/skills/watch.go
@@ -1,0 +1,488 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package skills
+
+import (
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+
+	"trpc.group/trpc-go/trpc-agent-go/log"
+)
+
+const (
+	watchRefreshReasonManual = "manual"
+	watchRefreshReasonWatch  = "watch"
+)
+
+var defaultWatchIgnoredNames = map[string]struct{}{
+	".cache":        {},
+	".git":          {},
+	".mypy_cache":   {},
+	".pytest_cache": {},
+	".venv":         {},
+	"__pycache__":   {},
+	"build":         {},
+	"dist":          {},
+	"node_modules":  {},
+	"venv":          {},
+}
+
+type WatchConfig struct {
+	Enabled      bool
+	Debounce     time.Duration
+	WatchBundled bool
+	BundledRoot  string
+}
+
+type WatchStatus struct {
+	Enabled           bool       `json:"enabled"`
+	WatchBundled      bool       `json:"watch_bundled"`
+	DebounceMS        int        `json:"debounce_ms,omitempty"`
+	Roots             []string   `json:"roots,omitempty"`
+	Generation        int64      `json:"generation,omitempty"`
+	LastRefreshAt     *time.Time `json:"last_refresh_at,omitempty"`
+	LastRefreshReason string     `json:"last_refresh_reason,omitempty"`
+	LastChangedPath   string     `json:"last_changed_path,omitempty"`
+	LastError         string     `json:"last_error,omitempty"`
+}
+
+type WatchService struct {
+	repo *Repository
+	cfg  WatchConfig
+
+	stateMu sync.RWMutex
+	watchMu sync.RWMutex
+
+	watcher *fsnotify.Watcher
+	roots   []string
+	watched map[string]struct{}
+
+	done chan struct{}
+	wg   sync.WaitGroup
+
+	refreshMu sync.Mutex
+
+	generation        int64
+	lastRefreshAt     time.Time
+	lastRefreshReason string
+	lastChangedPath   string
+	lastError         string
+}
+
+func NewWatchService(
+	repo *Repository,
+	roots []string,
+	cfg WatchConfig,
+) *WatchService {
+	if repo == nil {
+		return nil
+	}
+
+	svc := &WatchService{
+		repo:    repo,
+		cfg:     cfg,
+		roots:   normalizeWatchRoots(roots, cfg),
+		watched: map[string]struct{}{},
+		done:    make(chan struct{}),
+	}
+	if !cfg.Enabled || len(svc.roots) == 0 {
+		return svc
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		svc.recordError(err)
+		log.Warnf("skills watcher init failed: %v", err)
+		return svc
+	}
+	svc.watcher = watcher
+	if err := svc.syncWatches(); err != nil {
+		svc.recordError(err)
+		log.Warnf("skills watcher sync failed: %v", err)
+	}
+
+	svc.wg.Add(1)
+	go svc.loop()
+	return svc
+}
+
+func (s *WatchService) Close() error {
+	if s == nil {
+		return nil
+	}
+	close(s.done)
+	s.wg.Wait()
+
+	s.watchMu.Lock()
+	defer s.watchMu.Unlock()
+	if s.watcher == nil {
+		return nil
+	}
+	err := s.watcher.Close()
+	s.watcher = nil
+	s.watched = map[string]struct{}{}
+	return err
+}
+
+func (s *WatchService) Refresh() error {
+	return s.refresh(watchRefreshReasonManual, "")
+}
+
+func (s *WatchService) Status() *WatchStatus {
+	if s == nil {
+		return nil
+	}
+
+	s.stateMu.RLock()
+	defer s.stateMu.RUnlock()
+
+	status := &WatchStatus{
+		Enabled:      s.cfg.Enabled,
+		WatchBundled: s.cfg.WatchBundled,
+		DebounceMS:   int(s.cfg.Debounce / time.Millisecond),
+		Roots:        append([]string(nil), s.roots...),
+		Generation:   s.generation,
+		LastError:    strings.TrimSpace(s.lastError),
+	}
+	if !s.lastRefreshAt.IsZero() {
+		ts := s.lastRefreshAt
+		status.LastRefreshAt = &ts
+	}
+	status.LastRefreshReason = strings.TrimSpace(
+		s.lastRefreshReason,
+	)
+	status.LastChangedPath = strings.TrimSpace(s.lastChangedPath)
+	return status
+}
+
+func (s *WatchService) loop() {
+	defer s.wg.Done()
+	if s == nil || s.watcher == nil {
+		return
+	}
+
+	var (
+		timer       *time.Timer
+		timerC      <-chan time.Time
+		pendingPath string
+	)
+	stopTimer := func() {
+		if timer == nil {
+			return
+		}
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+		timer = nil
+		timerC = nil
+	}
+	resetTimer := func() {
+		delay := s.cfg.Debounce
+		if timer == nil {
+			timer = time.NewTimer(delay)
+			timerC = timer.C
+			return
+		}
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+		timer.Reset(delay)
+	}
+
+	for {
+		select {
+		case <-s.done:
+			stopTimer()
+			return
+		case event, ok := <-s.watcher.Events:
+			if !ok {
+				stopTimer()
+				return
+			}
+			path, ok := s.relevantEvent(event)
+			if !ok {
+				continue
+			}
+			pendingPath = path
+			resetTimer()
+		case err, ok := <-s.watcher.Errors:
+			if !ok || err == nil {
+				continue
+			}
+			s.recordError(err)
+			log.Warnf("skills watcher error: %v", err)
+		case <-timerC:
+			if err := s.refresh(
+				watchRefreshReasonWatch,
+				pendingPath,
+			); err != nil {
+				log.Warnf("skills watcher refresh failed: %v", err)
+			}
+			pendingPath = ""
+			timer = nil
+			timerC = nil
+		}
+	}
+}
+
+func (s *WatchService) relevantEvent(
+	event fsnotify.Event,
+) (string, bool) {
+	path := filepath.Clean(strings.TrimSpace(event.Name))
+	if path == "." || path == "" {
+		return "", false
+	}
+	if isIgnoredWatchPath(path) {
+		return "", false
+	}
+	if filepath.Base(path) == skillFileName {
+		return path, true
+	}
+
+	for _, root := range s.roots {
+		if path == root {
+			return path, true
+		}
+		if event.Op&fsnotify.Create != 0 &&
+			filepath.Dir(path) == root &&
+			watchDirExists(path) {
+			return path, true
+		}
+	}
+
+	s.watchMu.RLock()
+	defer s.watchMu.RUnlock()
+	if _, ok := s.watched[path]; ok {
+		return path, true
+	}
+	return "", false
+}
+
+func (s *WatchService) refresh(
+	reason string,
+	changedPath string,
+) error {
+	if s == nil || s.repo == nil {
+		return nil
+	}
+
+	s.refreshMu.Lock()
+	defer s.refreshMu.Unlock()
+
+	err := s.repo.Refresh()
+	if err == nil {
+		if syncErr := s.syncWatches(); syncErr != nil {
+			err = syncErr
+		}
+	}
+
+	s.stateMu.Lock()
+	s.lastRefreshAt = time.Now()
+	s.lastRefreshReason = strings.TrimSpace(reason)
+	s.lastChangedPath = strings.TrimSpace(changedPath)
+	if err != nil {
+		s.lastError = err.Error()
+	} else {
+		s.lastError = ""
+		s.generation++
+	}
+	s.stateMu.Unlock()
+	return err
+}
+
+func (s *WatchService) syncWatches() error {
+	s.watchMu.Lock()
+	defer s.watchMu.Unlock()
+
+	if s == nil || s.watcher == nil {
+		return nil
+	}
+
+	want := s.desiredWatchDirs()
+	for path := range s.watched {
+		if _, ok := want[path]; ok {
+			continue
+		}
+		if err := s.watcher.Remove(path); err != nil &&
+			!isIgnorableWatchError(err) {
+			return err
+		}
+		delete(s.watched, path)
+	}
+	for path := range want {
+		if _, ok := s.watched[path]; ok {
+			continue
+		}
+		if err := s.watcher.Add(path); err != nil {
+			return err
+		}
+		s.watched[path] = struct{}{}
+	}
+	return nil
+}
+
+func (s *WatchService) desiredWatchDirs() map[string]struct{} {
+	dirs := map[string]struct{}{}
+	for _, root := range s.roots {
+		if root == "" {
+			continue
+		}
+		if watchDirExists(root) {
+			dirs[root] = struct{}{}
+			entries, err := os.ReadDir(root)
+			if err != nil {
+				continue
+			}
+			for _, entry := range entries {
+				if !entry.IsDir() {
+					continue
+				}
+				if isIgnoredWatchName(entry.Name()) {
+					continue
+				}
+				path := filepath.Join(root, entry.Name())
+				dirs[path] = struct{}{}
+			}
+			continue
+		}
+		parent := nearestExistingWatchParent(root)
+		if parent != "" {
+			dirs[parent] = struct{}{}
+		}
+	}
+	return dirs
+}
+
+func (s *WatchService) recordError(err error) {
+	if s == nil || err == nil {
+		return
+	}
+	s.stateMu.Lock()
+	s.lastError = err.Error()
+	s.stateMu.Unlock()
+}
+
+func normalizeWatchRoots(
+	roots []string,
+	cfg WatchConfig,
+) []string {
+	bundled := normalizeWatchPath(cfg.BundledRoot)
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(roots))
+	for _, root := range roots {
+		normalized := normalizeWatchPath(root)
+		if normalized == "" {
+			continue
+		}
+		if !cfg.WatchBundled && bundled != "" &&
+			normalized == bundled {
+			continue
+		}
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		out = append(out, normalized)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func normalizeWatchPath(raw string) string {
+	path := strings.TrimSpace(raw)
+	if path == "" {
+		return ""
+	}
+	if strings.Contains(path, "://") {
+		u, err := url.Parse(path)
+		if err != nil {
+			return ""
+		}
+		switch strings.ToLower(strings.TrimSpace(u.Scheme)) {
+		case "file":
+			if u.Host != "" && u.Host != "localhost" {
+				return ""
+			}
+			path = filepath.FromSlash(u.Path)
+		default:
+			return ""
+		}
+	}
+	if abs, err := filepath.Abs(path); err == nil {
+		path = abs
+	}
+	if resolved, err := filepath.EvalSymlinks(path); err == nil &&
+		strings.TrimSpace(resolved) != "" {
+		path = resolved
+	}
+	return filepath.Clean(path)
+}
+
+func nearestExistingWatchParent(path string) string {
+	current := filepath.Clean(strings.TrimSpace(path))
+	for current != "." && current != "" {
+		parent := filepath.Dir(current)
+		if parent == current {
+			if watchDirExists(parent) {
+				return parent
+			}
+			return ""
+		}
+		if watchDirExists(parent) {
+			return parent
+		}
+		current = parent
+	}
+	return ""
+}
+
+func isIgnoredWatchPath(path string) bool {
+	for _, part := range strings.Split(filepath.Clean(path), string(os.PathSeparator)) {
+		if isIgnoredWatchName(part) {
+			return true
+		}
+	}
+	return false
+}
+
+func isIgnoredWatchName(name string) bool {
+	_, ok := defaultWatchIgnoredNames[strings.TrimSpace(name)]
+	return ok
+}
+
+func isIgnorableWatchError(err error) bool {
+	if err == nil {
+		return false
+	}
+	text := strings.ToLower(strings.TrimSpace(err.Error()))
+	return strings.Contains(text, "can't remove non-existent") ||
+		strings.Contains(text, "file already closed")
+}
+
+func watchDirExists(path string) bool {
+	st, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return st.IsDir()
+}

--- a/openclaw/internal/skills/watch_test.go
+++ b/openclaw/internal/skills/watch_test.go
@@ -1,0 +1,113 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/skill"
+)
+
+const watchTestSkill = `---
+name: demo
+description: test
+---
+
+hello
+`
+
+func TestWatchService_RefreshesWhenSkillAdded(t *testing.T) {
+	root := t.TempDir()
+	repo, err := NewRepository([]string{root})
+	require.NoError(t, err)
+
+	watch := NewWatchService(repo, []string{root}, WatchConfig{
+		Enabled:  true,
+		Debounce: 20 * time.Millisecond,
+	})
+	require.NotNil(t, watch)
+	t.Cleanup(func() {
+		require.NoError(t, watch.Close())
+	})
+
+	writeSkill(t, root, "demo", watchTestSkill)
+
+	require.Eventually(t, func() bool {
+		return hasSkillSummary(repo.Summaries(), "demo")
+	}, time.Second, 10*time.Millisecond)
+
+	status := watch.Status()
+	require.NotNil(t, status)
+	require.Equal(t, watchRefreshReasonWatch, status.LastRefreshReason)
+	require.NotNil(t, status.LastRefreshAt)
+	require.GreaterOrEqual(t, status.Generation, int64(1))
+}
+
+func TestWatchService_RefreshesWhenRootCreatedLater(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "skills")
+	repo, err := NewRepository([]string{root})
+	require.NoError(t, err)
+
+	watch := NewWatchService(repo, []string{root}, WatchConfig{
+		Enabled:  true,
+		Debounce: 20 * time.Millisecond,
+	})
+	require.NotNil(t, watch)
+	t.Cleanup(func() {
+		require.NoError(t, watch.Close())
+	})
+
+	require.NoError(t, os.MkdirAll(root, 0o755))
+	writeSkill(t, root, "demo", watchTestSkill)
+
+	require.Eventually(t, func() bool {
+		return hasSkillSummary(repo.Summaries(), "demo")
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestWatchService_DisabledDoesNotRefresh(t *testing.T) {
+	root := t.TempDir()
+	repo, err := NewRepository([]string{root})
+	require.NoError(t, err)
+
+	watch := NewWatchService(repo, []string{root}, WatchConfig{
+		Enabled: false,
+	})
+	require.NotNil(t, watch)
+	t.Cleanup(func() {
+		require.NoError(t, watch.Close())
+	})
+
+	writeSkill(t, root, "demo", watchTestSkill)
+	time.Sleep(120 * time.Millisecond)
+
+	require.False(t, hasSkillSummary(repo.Summaries(), "demo"))
+	status := watch.Status()
+	require.NotNil(t, status)
+	require.False(t, status.Enabled)
+}
+
+func hasSkillSummary(
+	summaries []skill.Summary,
+	name string,
+) bool {
+	for _, summary := range summaries {
+		if summary.Name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/openclaw/internal/skills/watch_test.go
+++ b/openclaw/internal/skills/watch_test.go
@@ -10,11 +10,14 @@
 package skills
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/stretchr/testify/require"
 
 	"trpc.group/trpc-go/trpc-agent-go/skill"
@@ -27,6 +30,11 @@ description: test
 
 hello
 `
+
+const (
+	watchErrClosed = "file already closed"
+	watchErrRemove = "can't remove non-existent watch"
+)
 
 func TestWatchService_RefreshesWhenSkillAdded(t *testing.T) {
 	root := t.TempDir()
@@ -98,6 +106,228 @@ func TestWatchService_DisabledDoesNotRefresh(t *testing.T) {
 	status := watch.Status()
 	require.NotNil(t, status)
 	require.False(t, status.Enabled)
+}
+
+func TestWatchService_NilReceiverHelpers(t *testing.T) {
+	t.Parallel()
+
+	var watch *WatchService
+	require.NoError(t, watch.Close())
+	require.NoError(t, watch.Refresh())
+	require.Nil(t, watch.Status())
+
+	watch.recordError(errors.New("boom"))
+}
+
+func TestWatchService_ManualRefreshUpdatesStatus(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	repo, err := NewRepository([]string{root})
+	require.NoError(t, err)
+
+	watch := NewWatchService(repo, []string{root}, WatchConfig{
+		Enabled: false,
+	})
+	require.NotNil(t, watch)
+	t.Cleanup(func() {
+		require.NoError(t, watch.Close())
+	})
+
+	writeSkill(t, root, "demo", watchTestSkill)
+
+	require.NoError(t, watch.Refresh())
+	require.True(t, hasSkillSummary(repo.Summaries(), "demo"))
+
+	status := watch.Status()
+	require.NotNil(t, status)
+	require.Equal(t, watchRefreshReasonManual, status.LastRefreshReason)
+	require.NotNil(t, status.LastRefreshAt)
+	require.Equal(t, filepath.Clean(root), status.Roots[0])
+	require.GreaterOrEqual(t, status.Generation, int64(1))
+}
+
+func TestWatchService_HelperFunctions(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	localRoot := filepath.Join(root, "local")
+	bundledRoot := filepath.Join(root, "bundled")
+	linkRoot := filepath.Join(root, "linked")
+	require.NoError(t, os.MkdirAll(localRoot, 0o755))
+	require.NoError(t, os.MkdirAll(bundledRoot, 0o755))
+	require.NoError(t, os.Symlink(localRoot, linkRoot))
+
+	fileURL := fmt.Sprintf("file://localhost%s", filepath.ToSlash(localRoot))
+	remoteURL := fmt.Sprintf("file://remote%s", filepath.ToSlash(localRoot))
+
+	require.Equal(t, "", normalizeWatchPath(""))
+	require.Equal(t, "", normalizeWatchPath("http://[::1"))
+	require.Equal(
+		t,
+		"",
+		normalizeWatchPath("https://example.com/skills"),
+	)
+	require.Equal(t, "", normalizeWatchPath(remoteURL))
+	require.Equal(t, localRoot, normalizeWatchPath(fileURL))
+	require.Equal(t, localRoot, normalizeWatchPath(linkRoot))
+
+	require.Equal(
+		t,
+		[]string{localRoot},
+		normalizeWatchRoots(
+			[]string{
+				" ",
+				bundledRoot,
+				fileURL,
+				localRoot,
+				"https://example.com/skills",
+			},
+			WatchConfig{
+				BundledRoot:  bundledRoot,
+				WatchBundled: false,
+			},
+		),
+	)
+	require.Equal(
+		t,
+		[]string{bundledRoot},
+		normalizeWatchRoots(
+			[]string{bundledRoot},
+			WatchConfig{
+				BundledRoot:  bundledRoot,
+				WatchBundled: true,
+			},
+		),
+	)
+
+	missingRoot := filepath.Join(root, "missing", "skills")
+	require.Equal(t, root, nearestExistingWatchParent(missingRoot))
+	require.Equal(t, "", nearestExistingWatchParent(""))
+	require.Equal(
+		t,
+		string(os.PathSeparator),
+		nearestExistingWatchParent(string(os.PathSeparator)),
+	)
+
+	require.True(
+		t,
+		isIgnoredWatchPath(filepath.Join(root, "node_modules", "pkg")),
+	)
+	require.False(t, isIgnoredWatchPath(filepath.Join(root, "demo")))
+	require.True(t, isIgnoredWatchName("node_modules"))
+	require.False(t, isIgnoredWatchName("demo"))
+
+	require.False(t, isIgnorableWatchError(nil))
+	require.True(t, isIgnorableWatchError(errors.New(watchErrRemove)))
+	require.True(t, isIgnorableWatchError(errors.New(watchErrClosed)))
+	require.False(t, isIgnorableWatchError(errors.New("boom")))
+
+	require.True(t, watchDirExists(root))
+	require.False(t, watchDirExists(filepath.Join(root, "missing")))
+}
+
+func TestWatchService_RelevantEventAndDesiredWatchDirs(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	repo, err := NewRepository([]string{root})
+	require.NoError(t, err)
+
+	skillDir := filepath.Join(root, "demo")
+	ignoredDir := filepath.Join(root, "node_modules")
+	plainFile := filepath.Join(root, "note.txt")
+	watchedDir := filepath.Join(root, "watched")
+	missingRoot := filepath.Join(t.TempDir(), "missing", "skills")
+
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+	require.NoError(t, os.MkdirAll(ignoredDir, 0o755))
+	require.NoError(t, os.MkdirAll(watchedDir, 0o755))
+	require.NoError(t, os.WriteFile(plainFile, []byte("note"), 0o644))
+
+	watch := &WatchService{
+		repo: repo,
+		roots: []string{
+			root,
+			missingRoot,
+			"",
+		},
+		watched: map[string]struct{}{
+			watchedDir: {},
+		},
+	}
+
+	dirs := watch.desiredWatchDirs()
+	require.Contains(t, dirs, root)
+	require.Contains(t, dirs, skillDir)
+	require.Contains(
+		t,
+		dirs,
+		nearestExistingWatchParent(missingRoot),
+	)
+	require.NotContains(t, dirs, ignoredDir)
+	require.NotContains(t, dirs, plainFile)
+
+	path, ok := watch.relevantEvent(fsnotify.Event{Name: " "})
+	require.False(t, ok)
+	require.Empty(t, path)
+
+	path, ok = watch.relevantEvent(fsnotify.Event{
+		Name: filepath.Join(ignoredDir, skillFileName),
+	})
+	require.False(t, ok)
+	require.Empty(t, path)
+
+	skillPath := filepath.Join(skillDir, skillFileName)
+	path, ok = watch.relevantEvent(fsnotify.Event{Name: skillPath})
+	require.True(t, ok)
+	require.Equal(t, skillPath, path)
+
+	path, ok = watch.relevantEvent(fsnotify.Event{Name: root})
+	require.True(t, ok)
+	require.Equal(t, root, path)
+
+	newDir := filepath.Join(root, "new-skill")
+	require.NoError(t, os.MkdirAll(newDir, 0o755))
+	path, ok = watch.relevantEvent(fsnotify.Event{
+		Name: newDir,
+		Op:   fsnotify.Create,
+	})
+	require.True(t, ok)
+	require.Equal(t, newDir, path)
+
+	path, ok = watch.relevantEvent(fsnotify.Event{Name: watchedDir})
+	require.True(t, ok)
+	require.Equal(t, watchedDir, path)
+
+	path, ok = watch.relevantEvent(fsnotify.Event{Name: plainFile})
+	require.False(t, ok)
+	require.Empty(t, path)
+}
+
+func TestWatchService_RecordErrorAndSyncWithoutWatcher(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	repo, err := NewRepository([]string{root})
+	require.NoError(t, err)
+
+	watch := NewWatchService(repo, []string{root}, WatchConfig{
+		Enabled: false,
+	})
+	require.NotNil(t, watch)
+	t.Cleanup(func() {
+		require.NoError(t, watch.Close())
+	})
+
+	require.NoError(t, watch.syncWatches())
+
+	watch.recordError(nil)
+	watch.recordError(errors.New("boom"))
+
+	status := watch.Status()
+	require.NotNil(t, status)
+	require.Equal(t, "boom", status.LastError)
 }
 
 func hasSkillSummary(

--- a/openclaw/internal/skills/watch_test.go
+++ b/openclaw/internal/skills/watch_test.go
@@ -86,6 +86,38 @@ func TestWatchService_RefreshesWhenRootCreatedLater(t *testing.T) {
 	}, time.Second, 10*time.Millisecond)
 }
 
+func TestWatchService_RefreshesWhenNestedFileChanges(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	skillDir := writeSkill(t, root, "demo", watchTestSkill)
+	guideDir := filepath.Join(skillDir, "docs")
+	guidePath := filepath.Join(guideDir, "guide.md")
+	require.NoError(t, os.MkdirAll(guideDir, 0o755))
+	require.NoError(t, os.WriteFile(guidePath, []byte("v1"), 0o644))
+
+	repo, err := NewRepository([]string{root})
+	require.NoError(t, err)
+
+	watch := NewWatchService(repo, []string{root}, WatchConfig{
+		Enabled:  true,
+		Debounce: 20 * time.Millisecond,
+	})
+	require.NotNil(t, watch)
+	t.Cleanup(func() {
+		require.NoError(t, watch.Close())
+	})
+
+	require.NoError(t, os.WriteFile(guidePath, []byte("v2"), 0o644))
+
+	require.Eventually(t, func() bool {
+		status := watch.Status()
+		return status != nil &&
+			status.Generation >= 1 &&
+			status.LastChangedPath == guidePath
+	}, time.Second, 10*time.Millisecond)
+}
+
 func TestWatchService_DisabledDoesNotRefresh(t *testing.T) {
 	root := t.TempDir()
 	repo, err := NewRepository([]string{root})
@@ -235,15 +267,19 @@ func TestWatchService_RelevantEventAndDesiredWatchDirs(t *testing.T) {
 	require.NoError(t, err)
 
 	skillDir := filepath.Join(root, "demo")
+	nestedDir := filepath.Join(skillDir, "docs")
+	nestedFile := filepath.Join(nestedDir, "guide.md")
 	ignoredDir := filepath.Join(root, "node_modules")
-	plainFile := filepath.Join(root, "note.txt")
+	outsideFile := filepath.Join(t.TempDir(), "note.txt")
 	watchedDir := filepath.Join(root, "watched")
 	missingRoot := filepath.Join(t.TempDir(), "missing", "skills")
 
 	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+	require.NoError(t, os.MkdirAll(nestedDir, 0o755))
 	require.NoError(t, os.MkdirAll(ignoredDir, 0o755))
 	require.NoError(t, os.MkdirAll(watchedDir, 0o755))
-	require.NoError(t, os.WriteFile(plainFile, []byte("note"), 0o644))
+	require.NoError(t, os.WriteFile(nestedFile, []byte("guide"), 0o644))
+	require.NoError(t, os.WriteFile(outsideFile, []byte("note"), 0o644))
 
 	watch := &WatchService{
 		repo: repo,
@@ -253,6 +289,8 @@ func TestWatchService_RelevantEventAndDesiredWatchDirs(t *testing.T) {
 			"",
 		},
 		watched: map[string]struct{}{
+			root:       {},
+			nestedDir:  {},
 			watchedDir: {},
 		},
 	}
@@ -260,13 +298,14 @@ func TestWatchService_RelevantEventAndDesiredWatchDirs(t *testing.T) {
 	dirs := watch.desiredWatchDirs()
 	require.Contains(t, dirs, root)
 	require.Contains(t, dirs, skillDir)
+	require.Contains(t, dirs, nestedDir)
 	require.Contains(
 		t,
 		dirs,
 		nearestExistingWatchParent(missingRoot),
 	)
 	require.NotContains(t, dirs, ignoredDir)
-	require.NotContains(t, dirs, plainFile)
+	require.NotContains(t, dirs, outsideFile)
 
 	path, ok := watch.relevantEvent(fsnotify.Event{Name: " "})
 	require.False(t, ok)
@@ -300,7 +339,11 @@ func TestWatchService_RelevantEventAndDesiredWatchDirs(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, watchedDir, path)
 
-	path, ok = watch.relevantEvent(fsnotify.Event{Name: plainFile})
+	path, ok = watch.relevantEvent(fsnotify.Event{Name: nestedFile})
+	require.True(t, ok)
+	require.Equal(t, nestedFile, path)
+
+	path, ok = watch.relevantEvent(fsnotify.Event{Name: outsideFile})
 	require.False(t, ok)
 	require.Empty(t, path)
 }

--- a/openclaw/openclaw.yaml
+++ b/openclaw/openclaw.yaml
@@ -19,6 +19,15 @@ model:
   name: "gpt-5"
   openai_variant: "auto"
 
+# skills:
+#   extra_dirs:
+#     - "${HOME}/.codex/skills"
+#     - "./.agents/skills"
+#   watch: true
+#   watch_bundled: false
+#   watch_debounce_ms: 250
+#   load_mode: "turn" # once|turn|session
+
 tools:
   enable_parallel_tools: true
   providers:


### PR DESCRIPTION
## Summary
- add a local skills watch service in `openclaw/internal/skills` that watches mutable filesystem skill roots and debounces refreshes
- wire the watcher into OpenClaw runtime startup, admin status, and manual refresh handling
- expose `skills.watch`, `skills.watch_bundled`, and `skills.watch_debounce_ms` in OpenClaw config parsing and document the new behavior

## Root Cause
The Go OpenClaw runtime only discovered new skill directories during repository construction or an explicit `Refresh()`. `Summaries()` re-read existing `SKILL.md` files but never re-scanned roots, so manually uploaded skills under local roots stayed invisible until an admin-triggered refresh.

## Testing
- `cd openclaw && go test ./...`
