### PR TITLE
{llmagent,openclaw}: restore generation config default compatibility

### DIFF
--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -382,10 +382,14 @@ func buildRequestProcessorsWithAgent(a *LLMAgent, options *Options) []flow.Reque
 func resolveDefaultGenerationConfig(
 	options *Options,
 ) model.GenerationConfig {
-	if options != nil && options.generationConfigConfigured {
-		return options.GenerationConfig
+	if options == nil {
+		return model.GenerationConfig{}
 	}
-	return model.GenerationConfig{Stream: true}
+	// Preserve LLMAgent's historical default: when callers do not explicitly
+	// configure generation behavior, the zero-value config is forwarded as-is.
+	// Higher-level wrappers (for example OpenClaw) can still opt into their own
+	// defaults by explicitly calling WithGenerationConfig.
+	return options.GenerationConfig
 }
 
 func hasStaticOutputResponseProcessor(options *Options) bool {

--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -109,8 +109,6 @@ func New(name string, opts ...Option) *LLMAgent {
 	// Initialize models map and determine the initial model.
 	initialModel, models := initializeModels(&options)
 
-	resolvedGenCfg := resolveDefaultGenerationConfig(&options)
-
 	// Construct the agent first so request processors can access dynamic getters.
 	a := &LLMAgent{
 		name:              name,
@@ -123,7 +121,7 @@ func New(name string, opts ...Option) *LLMAgent {
 		modelGlobalInstructions: cloneTextPromptMap(
 			options.ModelGlobalInstructions,
 		),
-		genConfig:            resolvedGenCfg,
+		genConfig:            options.GenerationConfig,
 		codeExecutor:         options.codeExecutor,
 		tools:                tools,
 		userToolNames:        userToolNames,
@@ -210,9 +208,7 @@ func buildRequestProcessorsWithAgent(a *LLMAgent, options *Options) []flow.Reque
 
 	// 1. Basic processor - handles generation config.
 	basicOptions := []processor.BasicOption{
-		processor.WithGenerationConfig(
-			resolveDefaultGenerationConfig(options),
-		),
+		processor.WithGenerationConfig(options.GenerationConfig),
 	}
 	basicProcessor := processor.NewBasicRequestProcessor(basicOptions...)
 	requestProcessors = append(requestProcessors, basicProcessor)
@@ -377,19 +373,6 @@ func buildRequestProcessorsWithAgent(a *LLMAgent, options *Options) []flow.Reque
 	requestProcessors = appendTimeProcessor(options, requestProcessors)
 
 	return requestProcessors
-}
-
-func resolveDefaultGenerationConfig(
-	options *Options,
-) model.GenerationConfig {
-	if options == nil {
-		return model.GenerationConfig{}
-	}
-	// Preserve LLMAgent's historical default: when callers do not explicitly
-	// configure generation behavior, the zero-value config is forwarded as-is.
-	// Higher-level wrappers (for example OpenClaw) can still opt into their own
-	// defaults by explicitly calling WithGenerationConfig.
-	return options.GenerationConfig
 }
 
 func hasStaticOutputResponseProcessor(options *Options) bool {

--- a/agent/llmagent/option.go
+++ b/agent/llmagent/option.go
@@ -185,9 +185,6 @@ type Options struct {
 	ModelGlobalInstructions map[string]string
 	// GenerationConfig contains the generation configuration.
 	GenerationConfig model.GenerationConfig
-	// generationConfigConfigured records whether callers explicitly set
-	// generation configuration through WithGenerationConfig.
-	generationConfigConfigured bool
 	// ChannelBufferSize is the buffer size for event channels (default: 256).
 	ChannelBufferSize int
 	codeExecutor      codeexecutor.CodeExecutor
@@ -547,7 +544,6 @@ func WithModelGlobalInstructions(prompts map[string]string) Option {
 func WithGenerationConfig(config model.GenerationConfig) Option {
 	return func(opts *Options) {
 		opts.GenerationConfig = config
-		opts.generationConfigConfigured = true
 	}
 }
 

--- a/agent/llmagent/option_test.go
+++ b/agent/llmagent/option_test.go
@@ -259,7 +259,6 @@ func TestWithSkipSkillsFallbackOnSessionSummary(t *testing.T) {
 func TestNew_DefaultGenerationConfigKeepsLegacyNonStreaming(t *testing.T) {
 	a := New("test-agent")
 	require.False(t, a.genConfig.Stream)
-	require.False(t, a.option.generationConfigConfigured)
 }
 
 func TestWithGenerationConfig_ExplicitFalseDisablesStreaming(
@@ -270,7 +269,6 @@ func TestWithGenerationConfig_ExplicitFalseDisablesStreaming(
 		WithGenerationConfig(model.GenerationConfig{Stream: false}),
 	)
 	require.False(t, a.genConfig.Stream)
-	require.True(t, a.option.generationConfigConfigured)
 }
 
 func TestBuildRequestProcessors_DefaultGenerationConfigUsesZeroValue(

--- a/agent/llmagent/option_test.go
+++ b/agent/llmagent/option_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/internal/flow/processor"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
@@ -259,6 +260,61 @@ func TestWithSkipSkillsFallbackOnSessionSummary(t *testing.T) {
 func TestNew_DefaultGenerationConfigKeepsLegacyNonStreaming(t *testing.T) {
 	a := New("test-agent")
 	require.False(t, a.genConfig.Stream)
+}
+
+func TestLLMAgent_Run_DefaultGenerationConfigUsesPublicStreamingBehavior(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	runAndCapture := func(
+		t *testing.T,
+		runOptions ...agent.RunOption,
+	) *model.Request {
+		t.Helper()
+
+		mdl := &captureModel{}
+		agt := New("test-agent", WithModel(mdl))
+
+		invOpts := []agent.InvocationOptions{
+			agent.WithInvocationMessage(model.NewUserMessage("hi")),
+			agent.WithInvocationSession(&session.Session{}),
+		}
+		if len(runOptions) > 0 {
+			invOpts = append(
+				invOpts,
+				agent.WithInvocationRunOptions(
+					agent.NewRunOptions(runOptions...),
+				),
+			)
+		}
+		inv := agent.NewInvocation(invOpts...)
+
+		ch, err := agt.Run(context.Background(), inv)
+		require.NoError(t, err)
+
+		ctx := context.Background()
+		for evt := range ch {
+			if evt != nil && evt.RequiresCompletion {
+				key := agent.GetAppendEventNoticeKey(evt.ID)
+				_ = inv.AddNoticeChannel(ctx, key)
+				_ = inv.NotifyCompletion(ctx, key)
+			}
+		}
+
+		require.NotNil(t, mdl.got)
+		return mdl.got
+	}
+
+	t.Run("default is non-streaming", func(t *testing.T) {
+		req := runAndCapture(t)
+		require.False(t, req.GenerationConfig.Stream)
+	})
+
+	t.Run("per-run override enables streaming", func(t *testing.T) {
+		req := runAndCapture(t, agent.WithStream(true))
+		require.True(t, req.GenerationConfig.Stream)
+	})
 }
 
 func TestWithGenerationConfig_ExplicitFalseDisablesStreaming(

--- a/agent/llmagent/option_test.go
+++ b/agent/llmagent/option_test.go
@@ -256,9 +256,9 @@ func TestWithSkipSkillsFallbackOnSessionSummary(t *testing.T) {
 	require.False(t, b.option.SkipSkillsFallbackOnSessionSummary)
 }
 
-func TestNew_DefaultGenerationConfigKeepsStreaming(t *testing.T) {
+func TestNew_DefaultGenerationConfigKeepsLegacyNonStreaming(t *testing.T) {
 	a := New("test-agent")
-	require.True(t, a.genConfig.Stream)
+	require.False(t, a.genConfig.Stream)
 	require.False(t, a.option.generationConfigConfigured)
 }
 
@@ -273,7 +273,7 @@ func TestWithGenerationConfig_ExplicitFalseDisablesStreaming(
 	require.True(t, a.option.generationConfigConfigured)
 }
 
-func TestBuildRequestProcessors_DefaultGenerationConfigUsesStreamTrue(
+func TestBuildRequestProcessors_DefaultGenerationConfigUsesZeroValue(
 	t *testing.T,
 ) {
 	procs := buildRequestProcessors("test-agent", &Options{})
@@ -285,7 +285,7 @@ func TestBuildRequestProcessors_DefaultGenerationConfigUsesStreamTrue(
 		}
 	}
 	require.NotNil(t, basicProc)
-	require.True(t, basicProc.GenerationConfig.Stream)
+	require.False(t, basicProc.GenerationConfig.Stream)
 }
 
 func TestWithMaxLimits_OnOptions(t *testing.T) {

--- a/docs/mkdocs/en/agent.md
+++ b/docs/mkdocs/en/agent.md
@@ -54,6 +54,14 @@ genConfig := model.GenerationConfig{
 }
 ```
 
+If you do not explicitly pass `llmagent.WithGenerationConfig(...)`,
+`LLMAgent` forwards the zero-value `model.GenerationConfig{}` by default,
+so the default behavior is non-streaming (`Stream=false`). If you need
+streaming output, set `Stream: true` explicitly, or override it per
+request with `agent.WithStream(true)`. Higher-level wrappers may choose
+their own explicit defaults. For example, OpenClaw enables streaming by
+default.
+
 ### Creating LLMAgent
 
 Use the model instance and configuration to create an LLMAgent, while setting the Agent's Description and Instruction.

--- a/docs/mkdocs/en/model.md
+++ b/docs/mkdocs/en/model.md
@@ -216,6 +216,13 @@ type GenerationConfig struct {
 }
 ```
 
+`GenerationConfig` itself is just a plain struct, and its zero value
+means `Stream=false`. For `LLMAgent`, if you omit
+`llmagent.WithGenerationConfig(...)`, the framework forwards that zero
+value as-is, so the default behavior is non-streaming. Higher-level
+wrappers can still choose different semantics by setting their own
+explicit defaults.
+
 ### Response Structure
 
 ```go

--- a/docs/mkdocs/zh/agent.md
+++ b/docs/mkdocs/zh/agent.md
@@ -54,6 +54,12 @@ genConfig := model.GenerationConfig{
 }
 ```
 
+如果没有显式传入 `llmagent.WithGenerationConfig(...)`，`LLMAgent`
+默认会透传零值 `model.GenerationConfig{}`，因此默认是非流式
+（`Stream=false`）。如果你需要流式输出，请显式设置
+`Stream: true`，或在单次请求上使用 `agent.WithStream(true)`。
+某些上层封装可能会自行设置不同的默认值，例如 OpenClaw 会显式开启流式。
+
 ### 创建 LLMAgent
 
 使用模型实例和配置创建 LLMAgent，同时设置 Agent 的 Description 与 Instruction。

--- a/docs/mkdocs/zh/model.md
+++ b/docs/mkdocs/zh/model.md
@@ -216,6 +216,11 @@ type GenerationConfig struct {
 }
 ```
 
+`GenerationConfig` 本身只是一个普通结构体，它的零值等价于
+`Stream=false`。对 `LLMAgent` 来说，如果没有显式传入
+`llmagent.WithGenerationConfig(...)`，框架会直接使用这个零值，
+因此默认是非流式。更上层的封装如果需要不同语义，也可以显式设置自己的默认值。
+
 ### Response 结构
 
 ```go

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -1887,10 +1887,16 @@ func newAgent(
 		)
 	}
 
+	genConfig := model.GenerationConfig{Stream: true}
+	if cfg.GenerationConfig != nil {
+		genConfig = *cfg.GenerationConfig
+	}
+
 	opts := []llmagent.Option{
 		llmagent.WithModel(mdl),
 		llmagent.WithInstruction(instruction),
 		llmagent.WithGlobalInstruction(strings.TrimSpace(cfg.SystemPrompt)),
+		llmagent.WithGenerationConfig(genConfig),
 		llmagent.WithAddSessionSummary(cfg.AddSessionSummary),
 		llmagent.WithEnableContextCompaction(cfg.EnableContextCompaction),
 		llmagent.WithContextCompactionOversizedToolResultMaxTokens(cfg.ContextCompactionOversizedToolResultMaxTokens),
@@ -1900,12 +1906,6 @@ func newAgent(
 			conversation.ProjectEventMessage,
 		),
 		llmagent.WithEnableParallelTools(cfg.EnableParallelTools),
-	}
-	if cfg.GenerationConfig != nil {
-		opts = append(
-			opts,
-			llmagent.WithGenerationConfig(*cfg.GenerationConfig),
-		)
 	}
 	opts = append(opts, llmagent.WithSkills(repo))
 	opts = append(


### PR DESCRIPTION
## Summary
- restore LLMAgent's legacy zero-value generation config default so callers without `WithGenerationConfig` keep non-streaming behavior
- make OpenClaw pass an explicit generation config so it preserves its default streaming behavior independently of LLMAgent defaults
- update LLMAgent regression tests around the default generation config behavior

## Testing
- go test ./agent/llmagent


## Reference
#1559 