### PR TITLE
{tool/mcpbroker, examples}: add on-demand MCP discovery and invocation

### DIFF
--- a/docs/mkdocs/en/tool.md
+++ b/docs/mkdocs/en/tool.md
@@ -449,6 +449,258 @@ Common pitfalls:
   pattern is usually to call `toolSet.Tools(ctx)` yourself and inject the
   resulting tools via `WithTools(...)`.
 
+### MCP Broker (On-Demand MCP Discovery)
+
+In addition to expanding remote MCP tools into first-class Tools, the
+framework also provides another integration style:
+`tool/mcpbroker`.
+
+The core idea of `mcpbroker` is:
+
+- do not expose every remote MCP tool up front
+- expose only a very small broker surface first
+- let the model discover and call remote MCP tools only when needed
+
+This is a better fit when the remote MCP surface is large, but a single
+request usually needs only a small subset of that surface.
+
+#### When to Use MCP Broker
+
+Use `mcpbroker` when:
+
+- an MCP server exposes many tools and you do not want to send the full
+  tool surface to the model on every turn
+- some tools are long-tail or backup capabilities rather than hot-path tools
+- a Skill, System Prompt, or User Prompt reveals an MCP endpoint that
+  should be connected dynamically
+- you want a smaller and more stable initial tool surface
+
+Keep using `mcp.NewMCPToolSet()` when:
+
+- the capability is high-frequency, stable, and already known
+- you want remote MCP tools to become first-class Tools directly
+- you care more about shorter execution paths and stronger schema-level
+  constraints
+
+The two patterns can be mixed:
+
+- use `MCP ToolSet` for hot-path capabilities
+- use `mcpbroker` for long-tail or dynamically discovered capabilities
+
+#### How It Differs from MCP ToolSet
+
+The main difference is **when** remote MCP tools become visible:
+
+- `MCP ToolSet`
+  - performs `initialize + tools/list`
+  - expands remote MCP tools into model-visible Tools
+- `mcpbroker`
+  - initially exposes only 4 broker tools
+  - the model discovers servers, then tools, then inspects selected schemas, then calls a concrete tool
+
+You can think of them as:
+
+- `MCP ToolSet`: directly mount remote tools
+- `mcpbroker`: discover remote tools on demand
+
+Typical trade-offs:
+
+- `MCP ToolSet`: faster and more strongly constrained, but larger tool surface
+- `mcpbroker`: lighter on context and better for long-tail / dynamic capabilities, but usually slower because discovery adds extra steps
+
+#### Basic Integration
+
+```go
+import (
+    "time"
+
+    "trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+    "trpc.group/trpc-go/trpc-agent-go/tool/mcp"
+    "trpc.group/trpc-go/trpc-agent-go/tool/mcpbroker"
+)
+
+broker := mcpbroker.New(
+    mcpbroker.WithServers(map[string]mcp.ConnectionConfig{
+        "local_stdio_code": {
+            Transport: "stdio",
+            Command:   "go",
+            Args:      []string{"run", "./stdio_server/main.go"},
+            Timeout:   10 * time.Second,
+        },
+    }),
+    mcpbroker.WithAllowAdHocHTTP(true),
+)
+
+agent := llmagent.New(
+    "assistant",
+    llmagent.WithModel(model),
+    llmagent.WithTools(broker.Tools()),
+)
+```
+
+Today `mcpbroker` is a **tool-layer integration**. Unlike `Skill`, it
+does not automatically inject routing guidance into the system prompt.
+If you want the model to behave more predictably, it is still useful to
+add a small amount of business-level instruction such as:
+
+- when to list named servers first
+- when to use `mcp_list_tools` first
+- when to expand selected tools with `mcp_inspect_tools`
+- when to prefer broker over direct tools
+
+#### The 4 Model-Visible Broker Tools
+
+The model only sees these 4 tools:
+
+- `mcp_list_servers`
+- `mcp_list_tools`
+- `mcp_inspect_tools`
+- `mcp_call`
+
+The recommended flow is usually:
+
+1. `mcp_list_servers()` to inspect named servers already known to the broker
+2. `mcp_list_tools(selector)` to inspect a server or ad-hoc MCP endpoint with lightweight summaries
+3. `mcp_inspect_tools(selector, tools[])` to expand schema for only the selected tools
+4. `mcp_call(selector, arguments)` to call one concrete MCP tool
+
+So instead of seeing the entire remote tool surface immediately, the
+model explores it progressively through the broker.
+
+#### Selector Mental Model
+
+`mcpbroker` intentionally avoids a mixed input model like
+`server_name + tool_name + url`. Instead it uses a unified `selector`:
+
+- In `mcp_list_tools`:
+  - named server: `local_stdio_code`
+  - ad-hoc URL: `https://example.com/mcp`
+- In `mcp_call`:
+  - named tool: `local_stdio_code.add`
+  - ad-hoc URL tool: `https://example.com/mcp.add`
+
+If an ad-hoc HTTP endpoint would make dot-based selectors ambiguous, `mcpbroker`
+also supports:
+
+- `https://example.com/mcp#tool=add`
+
+Remote MCP tool parameters always go into:
+
+- `mcp_call(..., arguments={...})`
+
+and not into top-level wrapper fields.
+
+#### Progressive Discovery Flow
+
+- start with `mcp_list_tools` for lightweight summaries
+- only use `mcp_inspect_tools` when preparing to call a specific tool
+
+Compared with sending every full schema up front, this is usually more
+friendly to tight context budgets.
+
+#### Dynamic URL and Skill Scenarios
+
+`mcpbroker` supports ad-hoc HTTP MCP targets:
+
+```go
+broker := mcpbroker.New(
+    mcpbroker.WithAllowAdHocHTTP(true),
+)
+```
+
+`WithAllowAdHocHTTP(true)` makes `selector` model-controlled input for
+HTTP(S) MCP targets. In production, validate or allowlist the URL, domain, and
+path before treating ad-hoc HTTP as a trusted integration path.
+
+In practice, dynamic connection still requires some **information
+source** to tell the model:
+
+- that this MCP endpoint exists
+- what it roughly does
+- which URL should be used
+
+That source can be:
+
+- a System Prompt
+- a User Prompt
+- a Skill
+- a knowledge source
+
+In other words, `mcpbroker` solves “how to connect / inspect / call”.
+It does not solve “why would the model think of connecting to this MCP
+in the first place”.
+
+This makes `mcpbroker` a natural companion to Skills. Some Skills only
+need a dedicated MCP capability while that Skill is relevant, so those
+MCP tools do not need to stay exposed as global tools for the whole
+conversation. Other Skills may reveal an incremental MCP endpoint that
+is only known after the Skill is loaded. In both cases, the Skill can
+act as the information source, while `mcpbroker` handles the dynamic
+connection and progressive tool/schema disclosure.
+
+See:
+
+- `examples/mcpbroker/basic`
+
+That example includes:
+
+- a named local MCP server
+- a Skill that reveals a remote streamable HTTP MCP endpoint
+- a model flow like `skill_load -> mcp_list_tools -> mcp_inspect_tools -> mcp_call`
+
+#### Auth Hooks (Per-Run Header Injection)
+
+For HTTP MCP targets, `mcpbroker` also provides runtime auth hooks:
+
+- `WithHTTPHeaderInjector(...)`
+- `WithErrorInterceptor(...)`
+
+These hooks are useful when:
+
+- you do not want the model to provide `Authorization` itself
+- you need to inject a user-specific token on every request
+- you want business code to wrap 401/403 responses into clearer errors
+
+Example:
+
+```go
+broker := mcpbroker.New(
+    mcpbroker.WithAllowAdHocHTTP(true),
+    mcpbroker.WithHTTPHeaderInjector(func(ctx context.Context, req *mcpbroker.HeaderInjectRequest) (map[string]string, error) {
+        token, _ := resolveUserTokenFromContext(ctx, req.BaseURL)
+        if token == "" {
+            return nil, nil
+        }
+        return map[string]string{
+            "Authorization": "Bearer " + token,
+        }, nil
+    }),
+    mcpbroker.WithErrorInterceptor(func(ctx context.Context, req *mcpbroker.BrokerErrorRequest) (*mcpbroker.BrokerErrorDecision, error) {
+        if isUnauthorized(req.Err) {
+            return &mcpbroker.BrokerErrorDecision{
+                Handled:   true,
+                WrapError: fmt.Errorf("the current user must authorize this provider in the host application before retrying"),
+            }, nil
+        }
+        return nil, nil
+    }),
+)
+```
+
+The key design point is:
+
+- the model chooses the `selector`
+- business code resolves headers from `ctx`
+- `mcpbroker` does not manage a full OAuth session state machine
+
+When `WithAllowAdHocHTTP(true)` is enabled, URL selectors may come from
+model-visible context. In production, validate `req.IsAdHoc` and `req.BaseURL`
+inside your `HTTPHeaderInjector` before returning sensitive headers.
+
+See:
+
+- `examples/mcpbroker/authhooks`
+
 ## Agent Tool (AgentTool)
 
 AgentTool lets you expose an existing Agent as a tool to be used by a parent Agent. Compared with a plain function tool, AgentTool provides:

--- a/docs/mkdocs/zh/tool.md
+++ b/docs/mkdocs/zh/tool.md
@@ -448,6 +448,249 @@ agent := llmagent.New(
   （例如每次请求不同的认证头、追踪字段），更稳妥的做法通常是手动
   `toolSet.Tools(ctx)`，再通过 `WithTools(...)` 注入。
 
+### MCP Broker（按需发现 MCP）
+
+除了直接把远端 MCP 工具展开成一等 Tool 之外，框架还提供了另一种
+接入方式：`tool/mcpbroker`。
+
+`mcpbroker` 的核心思路是：
+
+- 不在一开始把远端 MCP 的全部工具都暴露给模型
+- 先只暴露少量 broker 工具
+- 让模型在需要时再逐步发现和调用远端 MCP 能力
+
+这类模式更适合**长尾工具很多、但单次请求只会命中少量工具**的场景。
+
+#### 什么时候用 MCP Broker
+
+推荐使用 `mcpbroker` 的场景：
+
+- 某个 MCP 服务工具很多，不希望每轮都把完整工具表面塞给模型
+- 某些能力是“储备能力”或“长尾能力”，并不是高频调用
+- 需要通过 Skill、System Prompt、User Prompt 等增量信息，动态连接某个远端 MCP endpoint
+- 希望用较小、较稳定的初始工具面换取更低的上下文压力
+
+更适合继续使用 `mcp.NewMCPToolSet()` 的场景：
+
+- 高频、稳定、已知能力
+- 希望把远端工具直接升格成一等 Tool
+- 更看重调用路径更短、约束更强、工具调用成功率更高
+
+这两种方式可以组合使用：
+
+- 高频热点能力继续使用 `MCP ToolSet`
+- 低频长尾能力放进 `mcpbroker`
+
+#### 与 MCP ToolSet 的区别
+
+两者的主要区别是“工具暴露时机”不同：
+
+- `MCP ToolSet`
+  - 在初始化或运行时先 `initialize + tools/list`
+  - 把远端每个 MCP tool 直接变成 Agent 可见 Tool
+- `mcpbroker`
+  - 初始只暴露 4 个 broker 工具
+  - 模型先发现 server，再发现 tool，再检查指定 tool 的 schema，最后再调用
+
+可以把它理解为：
+
+- `MCP ToolSet`：直接挂远端工具
+- `mcpbroker`：按需发现远端工具
+
+典型 trade-off：
+
+- `MCP ToolSet`：更快、更强约束，但工具面更大
+- `mcpbroker`：更省上下文、更适合长尾与动态能力，但多一步 discovery，整体可能更慢
+
+#### 基本接入方式
+
+```go
+import (
+    "time"
+
+    "trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+    "trpc.group/trpc-go/trpc-agent-go/tool/mcp"
+    "trpc.group/trpc-go/trpc-agent-go/tool/mcpbroker"
+)
+
+broker := mcpbroker.New(
+    mcpbroker.WithServers(map[string]mcp.ConnectionConfig{
+        "local_stdio_code": {
+            Transport: "stdio",
+            Command:   "go",
+            Args:      []string{"run", "./stdio_server/main.go"},
+            Timeout:   10 * time.Second,
+        },
+    }),
+    mcpbroker.WithAllowAdHocHTTP(true),
+)
+
+agent := llmagent.New(
+    "assistant",
+    llmagent.WithModel(model),
+    llmagent.WithTools(broker.Tools()),
+)
+```
+
+当前 `mcpbroker` 是**工具层接入**，不会像 `Skill` 那样自动向
+`System Prompt` 注入策略提示。如果你希望模型更稳定地理解：
+
+- 什么时候先列 server
+- 什么时候先 `mcp_list_tools`
+- 什么时候再 `mcp_inspect_tools`
+- 什么时候再 `mcp_call`
+
+通常仍然建议在业务侧 instruction 里补少量高层 guidance。
+
+#### 模型可见的 4 个工具
+
+当前模型只会看到这 4 个工具：
+
+- `mcp_list_servers`
+- `mcp_list_tools`
+- `mcp_inspect_tools`
+- `mcp_call`
+
+推荐的调用顺序通常是：
+
+1. `mcp_list_servers()`：查看 broker 已知的命名 MCP server
+2. `mcp_list_tools(selector)`：查看某个 server 或远端 URL 的轻量工具目录
+3. `mcp_inspect_tools(selector, tools[])`：只展开指定工具的 schema
+4. `mcp_call(selector, arguments)`：调用具体 MCP tool
+
+这意味着模型不再一开始就看到完整远端工具集，而是先通过 broker
+渐进式探索。
+
+#### Selector 心智模型
+
+`mcpbroker` 的核心输入不是 `server_name + tool_name + url` 的混合对象，
+而是统一使用 `selector`：
+
+- 在 `mcp_list_tools` 中：
+  - 命名 server：`local_stdio_code`
+  - 动态 URL：`https://example.com/mcp`
+- 在 `mcp_call` 中：
+  - 命名 tool：`local_stdio_code.add`
+  - 动态 URL tool：`https://example.com/mcp.add`
+
+如果某个 ad-hoc HTTP endpoint 会让点分隔 selector 产生歧义，也支持：
+
+- `https://example.com/mcp#tool=add`
+
+真正的 MCP tool 参数统一放在：
+
+- `mcp_call(..., arguments={...})`
+
+而不是放在顶层字段里。
+
+#### 渐进式发现方式
+
+- 先用 `mcp_list_tools` 获取轻量摘要
+- 只有准备调用某个具体 tool 时，再用 `mcp_inspect_tools`
+  只展开该 tool 的 schema
+
+这和“先把完整 schema 全部塞给模型”相比，更适合上下文预算紧张的场景。
+
+#### 动态 URL 与 Skill 场景
+
+`mcpbroker` 支持 ad-hoc HTTP MCP：
+
+```go
+broker := mcpbroker.New(
+    mcpbroker.WithAllowAdHocHTTP(true),
+)
+```
+
+`WithAllowAdHocHTTP(true)` 会让 HTTP(S) MCP 的 `selector` 成为模型可控输入。
+生产环境里，建议先在业务侧对 URL、域名和路径做 allowlist 或其它校验，
+再把 ad-hoc HTTP 当成可信集成路径使用。
+
+这类动态连接通常需要先有一个“信息来源”告诉模型：
+
+- 这个 MCP endpoint 存在
+- 它大概能做什么
+- 该用什么 URL 去连接
+
+这个信息来源可以是：
+
+- System Prompt
+- User Prompt
+- Skill
+- 知识库
+
+也就是说，`mcpbroker` 解决的是“如何连、如何看、如何调”，
+而不是“模型为什么会想到去连这个 MCP”。
+
+这也让 `mcpbroker` 很适合与 Skill 配合使用。有些 Skill 只在自身
+场景下需要某个专用 MCP 能力，这类 MCP 工具不一定要在整个会话中
+长期作为全局工具暴露；还有些 Skill 会在加载后提供一个增量出现的
+远端 MCP endpoint。此时 Skill 可以负责提供“这个 MCP 存在、能做什么、
+该连哪个 URL”的信息来源，而 `mcpbroker` 负责动态连接以及渐进式暴露
+工具和 schema。
+
+完整示例可参考：
+
+- `examples/mcpbroker/basic`
+
+其中包含：
+
+- 本地命名 MCP server
+- Skill 提供远端 streamable HTTP MCP endpoint
+- 模型通过 `skill_load -> mcp_list_tools -> mcp_inspect_tools -> mcp_call` 动态连接远端 MCP
+
+#### 鉴权 Hook（Per-Run Header 注入）
+
+对于 HTTP 型 MCP，`mcpbroker` 还提供两类运行时扩展点：
+
+- `WithHTTPHeaderInjector(...)`
+- `WithErrorInterceptor(...)`
+
+适用场景：
+
+- 不希望让模型直接携带 `Authorization`
+- 需要根据当前用户、租户、workspace，在每次调用时动态注入 token
+- 希望在远端返回 401/403 时，由业务层把底层错误包装成更友好的错误信息
+
+示例：
+
+```go
+broker := mcpbroker.New(
+    mcpbroker.WithAllowAdHocHTTP(true),
+    mcpbroker.WithHTTPHeaderInjector(func(ctx context.Context, req *mcpbroker.HeaderInjectRequest) (map[string]string, error) {
+        token, _ := resolveUserTokenFromContext(ctx, req.BaseURL)
+        if token == "" {
+            return nil, nil
+        }
+        return map[string]string{
+            "Authorization": "Bearer " + token,
+        }, nil
+    }),
+    mcpbroker.WithErrorInterceptor(func(ctx context.Context, req *mcpbroker.BrokerErrorRequest) (*mcpbroker.BrokerErrorDecision, error) {
+        if isUnauthorized(req.Err) {
+            return &mcpbroker.BrokerErrorDecision{
+                Handled:   true,
+                WrapError: fmt.Errorf("当前用户需要先在宿主系统完成授权，然后再重试"),
+            }, nil
+        }
+        return nil, nil
+    }),
+)
+```
+
+这里的设计重点是：
+
+- 模型只负责选择 `selector`
+- 业务代码负责从 `ctx` 中识别当前用户，并注入 HTTP Header
+- `mcpbroker` 本身不管理复杂的 OAuth session 状态机
+
+开启 `WithAllowAdHocHTTP(true)` 后，URL selector 可能来自模型可见上下文。
+生产环境中应在 `HTTPHeaderInjector` 里基于 `req.IsAdHoc` 和 `req.BaseURL`
+做 allowlist / URL 校验，再返回敏感 Header。
+
+完整示例可参考：
+
+- `examples/mcpbroker/authhooks`
+
 ## Agent 工具 (AgentTool)
 
 AgentTool 允许把一个现有的 Agent 以工具的形式暴露给上层 Agent 使用。相比普通函数工具，AgentTool 的优势在于：

--- a/examples/mcpbroker/authhooks/README.md
+++ b/examples/mcpbroker/authhooks/README.md
@@ -1,0 +1,119 @@
+# MCP Broker Auth Hook Example
+
+This example demonstrates the new runtime auth hooks for `tool/mcpbroker`:
+
+- `WithHTTPHeaderInjector(...)`
+- `WithErrorInterceptor(...)`
+
+Unlike the `basic` example, this one does not involve a model. It calls the
+broker tools directly to show the execution path clearly:
+
+1. list named servers
+2. try to inspect a protected HTTP MCP without a user token
+3. observe the business-wrapped authorization error
+4. add a user token to `context.Context`
+5. inspect tools again and call the protected MCP tool successfully
+
+## What It Covers
+
+- Named protected HTTP MCP server
+- Optional ad-hoc protected HTTP MCP path
+- Per-run `Authorization` header injection from `context.Context`
+- Unauthorized error wrapping through `ErrorInterceptor`
+
+## Usage
+
+```bash
+cd examples/mcpbroker/authhooks
+go run .
+```
+
+Try ad-hoc mode:
+
+```bash
+go run . -mode adhoc
+```
+
+Flags:
+
+- `-mode`: `named` or `adhoc`, default `named`
+- `-token`: token stored into `context.Context` for the successful path, default `demo-user-token`
+
+## Expected Output
+
+You should see:
+
+- named server discovery
+- one failed `mcp_list_tools` call without a token
+- one successful `mcp_list_tools` call with a token
+- one successful `mcp_inspect_tools` call for `whoami`
+- one successful `mcp_call` for `whoami`
+
+The protected MCP server only accepts:
+
+```text
+Authorization: Bearer demo-user-token
+```
+
+The broker hook resolves that header from the request context, not from
+model-visible arguments.
+
+Example output:
+
+```text
+== MCP Broker Auth Hook Example ==
+Mode: named
+Protected URL: http://127.0.0.1:<port>/mcp
+
+mcp_list_servers:
+{
+  "servers": [
+    {
+      "name": "secure_http",
+      "transport": "streamable"
+    }
+  ]
+}
+
+== Without token ==
+mcp_list_tools error: authorization required for http://127.0.0.1:<port>/mcp (list_tools)
+
+== With token ==
+mcp_list_tools:
+{
+  "tools": [
+    {
+      "name": "whoami",
+      "selector": "secure_http.whoami",
+      "signature": "whoami()",
+      "description": "Return the current caller identity derived from the bearer token.",
+      "has_output_schema": false
+    }
+  ]
+}
+
+mcp_inspect_tools:
+{
+  "tools": [
+    {
+      "name": "whoami",
+      "selector": "secure_http.whoami",
+      "description": "Return the current caller identity derived from the bearer token.",
+      "has_output_schema": false,
+      "input_schema": {
+        "type": "object"
+      }
+    }
+  ]
+}
+
+mcp_call:
+{
+  "content": [
+    {
+      "type": "text",
+      "text": "current caller: demo-user"
+    }
+  ]
+}
+```

--- a/examples/mcpbroker/authhooks/main.go
+++ b/examples/mcpbroker/authhooks/main.go
@@ -1,0 +1,214 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+	mcpcfg "trpc.group/trpc-go/trpc-agent-go/tool/mcp"
+	"trpc.group/trpc-go/trpc-agent-go/tool/mcpbroker"
+	tmcp "trpc.group/trpc-go/trpc-mcp-go"
+)
+
+type ctxKey string
+
+const userTokenKey ctxKey = "user-token"
+
+var (
+	mode  = flag.String("mode", "named", "Broker target mode: named or adhoc")
+	token = flag.String("token", "demo-user-token", "User token injected through context for the successful path")
+)
+
+func main() {
+	flag.Parse()
+
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "auth hook example failed: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	server := startProtectedDemoServer("Bearer " + *token)
+	defer server.Close()
+
+	broker := mcpbroker.New(
+		mcpbroker.WithServers(map[string]mcpcfg.ConnectionConfig{
+			"secure_http": {
+				ServerURL: server.URL,
+				Transport: "streamable_http",
+			},
+		}),
+		mcpbroker.WithAllowAdHocHTTP(true),
+		mcpbroker.WithHTTPHeaderInjector(func(ctx context.Context, req *mcpbroker.HeaderInjectRequest) (map[string]string, error) {
+			value, _ := ctx.Value(userTokenKey).(string)
+			if value == "" {
+				return nil, nil
+			}
+			return map[string]string{
+				"Authorization": "Bearer " + value,
+			}, nil
+		}),
+		mcpbroker.WithErrorInterceptor(func(ctx context.Context, req *mcpbroker.BrokerErrorRequest) (*mcpbroker.BrokerErrorDecision, error) {
+			if req.Err == nil {
+				return nil, nil
+			}
+			errText := strings.ToLower(req.Err.Error())
+			if !strings.Contains(errText, "unauthorized") &&
+				!strings.Contains(errText, "authorization") {
+				return nil, nil
+			}
+			return &mcpbroker.BrokerErrorDecision{
+				Handled:   true,
+				WrapError: fmt.Errorf("authorization required for %s (%s)", req.BaseURL, req.Phase),
+			}, nil
+		}),
+	)
+
+	fmt.Println("== MCP Broker Auth Hook Example ==")
+	fmt.Printf("Mode: %s\n", *mode)
+	fmt.Printf("Protected URL: %s\n\n", server.URL)
+
+	serversResult, err := callBrokerTool(context.Background(), broker.Tools(), "mcp_list_servers", map[string]any{})
+	if err != nil {
+		return err
+	}
+	printJSON("mcp_list_servers", serversResult)
+
+	selector := "secure_http"
+	callSelector := "secure_http.whoami"
+	if *mode == "adhoc" {
+		selector = server.URL
+		callSelector = server.URL + ".whoami"
+	}
+
+	fmt.Println("== Without token ==")
+	_, err = callBrokerTool(context.Background(), broker.Tools(), "mcp_list_tools", map[string]any{
+		"selector": selector,
+	})
+	if err != nil {
+		fmt.Printf("mcp_list_tools error: %v\n\n", err)
+	}
+
+	ctx := context.WithValue(context.Background(), userTokenKey, *token)
+
+	fmt.Println("== With token ==")
+	listToolsResult, err := callBrokerTool(ctx, broker.Tools(), "mcp_list_tools", map[string]any{
+		"selector": selector,
+	})
+	if err != nil {
+		return err
+	}
+	printJSON("mcp_list_tools", listToolsResult)
+
+	inspectResult, err := callBrokerTool(ctx, broker.Tools(), "mcp_inspect_tools", map[string]any{
+		"selector": selector,
+		"tools":    []string{"whoami"},
+	})
+	if err != nil {
+		return err
+	}
+	printJSON("mcp_inspect_tools", inspectResult)
+
+	callResult, err := callBrokerTool(ctx, broker.Tools(), "mcp_call", map[string]any{
+		"selector":  callSelector,
+		"arguments": map[string]any{},
+	})
+	if err != nil {
+		return err
+	}
+	printJSON("mcp_call", callResult)
+
+	return nil
+}
+
+func callBrokerTool(ctx context.Context, tools []tool.Tool, name string, args map[string]any) (any, error) {
+	var callable tool.CallableTool
+	for _, tl := range tools {
+		if tl.Declaration().Name != name {
+			continue
+		}
+		ct, ok := tl.(tool.CallableTool)
+		if !ok {
+			return nil, fmt.Errorf("tool %q is not callable", name)
+		}
+		callable = ct
+		break
+	}
+	if callable == nil {
+		return nil, fmt.Errorf("tool %q not found", name)
+	}
+
+	data, err := json.Marshal(args)
+	if err != nil {
+		return nil, fmt.Errorf("marshal tool args: %w", err)
+	}
+	return callable.Call(ctx, data)
+}
+
+func printJSON(title string, value any) {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		fmt.Printf("%s: %+v\n\n", title, value)
+		return
+	}
+	fmt.Printf("%s:\n%s\n\n", title, string(data))
+}
+
+type protectedDemoServer struct {
+	server *httptest.Server
+	URL    string
+}
+
+func startProtectedDemoServer(requiredAuth string) *protectedDemoServer {
+	mcpServer := tmcp.NewServer(
+		"mcpbroker-authhooks-demo",
+		"1.0.0",
+		tmcp.WithServerPath("/mcp"),
+	)
+
+	whoami := tmcp.NewTool(
+		"whoami",
+		tmcp.WithDescription("Return the current caller identity derived from the bearer token."),
+	)
+	mcpServer.RegisterTool(whoami, func(ctx context.Context, req *tmcp.CallToolRequest) (*tmcp.CallToolResult, error) {
+		_ = ctx
+		_ = req
+		return tmcp.NewTextResult("current caller: demo-user"), nil
+	})
+
+	baseHandler := mcpServer.HTTPHandler()
+	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != requiredAuth {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		baseHandler.ServeHTTP(w, r)
+	}))
+
+	return &protectedDemoServer{
+		server: httpServer,
+		URL:    httpServer.URL + "/mcp",
+	}
+}
+
+func (s *protectedDemoServer) Close() {
+	if s == nil || s.server == nil {
+		return
+	}
+	s.server.Close()
+}

--- a/examples/mcpbroker/basic/README.md
+++ b/examples/mcpbroker/basic/README.md
@@ -1,0 +1,258 @@
+# MCP Broker Example
+
+This example demonstrates the `tool/mcpbroker` flow for `LLMAgent`,
+including a skill-discovered remote MCP endpoint.
+
+Unlike the legacy `tool/mcp` example, the model does not see every
+remote MCP tool up front. The MCP surface stays brokered through:
+
+- `mcp_list_servers`
+- `mcp_list_tools`
+- `mcp_inspect_tools`
+- `mcp_call`
+
+This demo also enables skills in `knowledge_only` mode, so the model can
+progressively load a skill that reveals an ad-hoc streamable HTTP MCP URL:
+
+- `skill_load`
+- `skill_list_docs`
+- `skill_select_docs`
+
+The agent uses those tools to progressively discover, inspect, and call
+MCP tools on demand. `mcp_list_tools` returns lightweight summaries, and
+`mcp_inspect_tools` expands schema only for selected tools instead of
+dumping an entire catalog worth of raw schema.
+
+This is not a `skill_run` scenario. The remote MCP service is already
+running before the first model turn. The skill only documents the remote
+endpoint and what that endpoint can do.
+
+## What This Example Covers
+
+- A local `stdio` MCP server with a wider tool catalog:
+  - utility: `echo`, `add`
+  - issue workflows: `issue_create`, `issue_list`, `issue_comment`
+  - docs workflows: `doc_search`, `doc_read`
+  - calendar workflows: `calendar_create`, `calendar_list`
+  - meeting workflows: `meeting_schedule`, `meeting_cancel`
+- A local streamable HTTP MCP server started by the example process
+  itself before the conversation begins, but only exposed to the model
+  through the skill
+  `remote-http-mcp`
+- `LLMAgent + Runner` interactive chat
+- Broker-enabled MCP discovery and invocation
+- Code-configured named server
+- Skill-driven discovery of an ad-hoc HTTP MCP endpoint
+- No `skill_run`; only `skill_load`, `skill_list_docs`, and
+  `skill_select_docs`
+
+## Prerequisites
+
+- Go 1.24 or later
+- Valid OpenAI-compatible credentials
+
+## Environment Variables
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `OPENAI_API_KEY` | API key for the model service | required |
+| `OPENAI_BASE_URL` | Base URL for the model API endpoint | `https://api.openai.com/v1` |
+
+## Usage
+
+Run from the repository root:
+
+```bash
+cd examples/mcpbroker/basic
+export OPENAI_API_KEY="<your-api-key>"
+go run .
+```
+
+With an OpenAI-compatible proxy:
+
+```bash
+cd examples/mcpbroker/basic
+export OPENAI_BASE_URL="https://your-openai-compatible-endpoint/v1"
+export OPENAI_API_KEY="<your-api-key>"
+go run . -model gpt-5 -streaming=false
+```
+
+Keep real API keys in your shell environment. Do not write them into README
+files, committed scripts, or logs.
+
+Run a single-turn prompt:
+
+```bash
+go run . -prompt "Create a calendar event titled \"Broker demo review\" starting at 2026-04-07T15:00:00+08:00 and invite alice@example.com."
+```
+
+Run a one-shot local stdio demo:
+
+```bash
+go run . -model gpt-5 -streaming=false \
+  -prompt "Create a calendar event titled \"Broker demo review\" starting at 2026-04-07T15:00:00+08:00 and invite alice@example.com."
+```
+
+Run a one-shot skill-discovered remote HTTP demo:
+
+```bash
+go run . -model gpt-5 -streaming=false \
+  -prompt "Load the skill remote-http-mcp, find its remote MCP endpoint, inspect the announcement tools there, and publish an announcement titled \"Broker via skill\" to engineers saying \"Remote MCP connected successfully.\""
+```
+
+Real one-shot run excerpt:
+
+```bash
+go run . -model gpt-5 -streaming=false \
+  -prompt "Create a calendar event titled \"Broker demo review\" starting at 2026-04-07T15:00:00+08:00 and invite alice@example.com."
+```
+
+Output:
+
+```text
+🚀 MCP Broker Example
+Model: gpt-5
+Variant: auto
+Streaming: false
+Agent-visible tools: mcp_call, mcp_inspect_tools, mcp_list_servers, mcp_list_tools, skill_list_docs, skill_load, skill_select_docs
+Demo named servers: local_stdio_code
+Demo skills: remote-http-mcp
+========================================================================
+
+🤖 Assistant:
+🔧 Tool calls:
+   • mcp_list_servers
+     Args: {}
+🔄 Executing tools...
+
+✅ Tool results:
+   • {"servers":[{"name":"local_stdio_code","transport":"stdio"}]}
+
+🔧 Tool calls:
+   • mcp_list_tools
+     Args: {"selector":"local_stdio_code"}
+🔄 Executing tools...
+
+✅ Tool results:
+   • {"tools":[{"name":"add","selector":"local_stdio_code.add","signature":"add(a: number, b: number)","description":"Add two numbers and return the numeric result.","has_output_schema":false},{"name":"calendar_create","selector":"local_stdio_code.calendar_create","signature":"calendar_create(title: string, start_time: string, attendee?: string)","description":"Create a calendar event with title and start time.","has_output_schema":false},{"name":"calendar_list","selector":"local_stdio_code.calendar_list","signature":"calendar_list(day?: string)","description":"List upcoming calendar events for an optional day.","has_output_schema":false},{"name":"doc_read","selector":"local_stdio_code.doc_read","signature":"doc_read(doc_id: string)","description":"Read a documentation article by document identifier.","has_output_schema":false},{"name":"doc_search","selector":"local_stdio_code.doc_search","signature":"doc_search(query: string, product?: string)","description":"Search documentation articles by query and optional product area.","has_output_schema":false},{"name":"echo","selector":"local_stdio_code.echo","signature":"echo(text: string, prefix?: string)","description":"Echo text back to the caller with an optional prefix.","has_output_schema":false},{"name":"issue_comment","selector":"local_stdio_code.issue_comment","signature":"issue_comment(issue_id: string, body: string)","description":"Add a comment to an existing issue.","has_output_schema":false},{"name":"issue_create","selector":"local_stdio_code.issue_create","signature":"issue_create(title: string, description?: string, priority?: string)","description":"Create a project issue with title, optional description, and priority.","has_output_schema":false},{"name":"issue_list","selector":"local_stdio_code.issue_list","signature":"issue_list(assignee?: string, status?: string)","description":"List project issues filtered by optional status or assignee.","has_output_schema":false},{"name":"meeting_cancel","selector":"local_stdio_code.meeting_cancel","signature":"meeting_cancel(meeting_id: string)","description":"Cancel an online meeting by meeting identifier.","has_output_schema":false},{"name":"meeting_schedule","selector":"local_stdio_code.meeting_schedule","signature":"meeting_schedule(topic: string, participants?: number)","description":"Schedule an online meeting with topic and participant count.","has_output_schema":false}]}
+
+🔧 Tool calls:
+   • mcp_inspect_tools
+     Args: {"selector":"local_stdio_code","tools":["calendar_create"]}
+🔄 Executing tools...
+
+✅ Tool results:
+   • {"tools":[{"name":"calendar_create","selector":"local_stdio_code.calendar_create","description":"Create a calendar event with title and start time.","has_output_schema":false,"input_schema":{"properties":{"attendee":{"description":"Optional attendee email.","type":"string"},"start_time":{"description":"Event start time in ISO-8601 format.","type":"string"},"title":{"description":"Event title.","type":"string"}},"required":["title","start_time"],"type":"object"}}]}
+
+🔧 Tool calls:
+   • mcp_call
+     Args: {"arguments":{"attendee":"alice@example.com","start_time":"2026-04-07T15:00:00+08:00","title":"Broker demo review"},"selector":"local_stdio_code.calendar_create"}
+🔄 Executing tools...
+
+✅ Tool results:
+   • {"content":[{"type":"text","text":"Created calendar event \"Broker demo review\" at 2026-04-07T15:00:00+08:00 attendee=\"alice@example.com\""}]}
+
+🤖 Assistant: Event created: “Broker demo review” on 2026-04-07 at 15:00 (+08:00), with alice@example.com invited.
+```
+
+The broker first lists lightweight tool summaries, then inspects only the
+selected tool schema, and finally calls the concrete MCP tool.
+
+Flags:
+
+- `-model`: model name, default `gpt-4o-mini`
+- `-variant`: optional OpenAI provider variant. If empty, infer from `OPENAI_BASE_URL`
+- `-streaming`: enable streaming output, default `true`
+- `-prompt`: optional one-shot prompt
+
+## Sample Prompts
+
+- `What MCP servers are available to you?`
+- `Create a calendar event titled "Broker demo review" starting at 2026-04-07T15:00:00+08:00 and invite alice@example.com.`
+- `Create an issue titled "Broker demo" with high priority.`
+- `Search the documentation for "MCP broker".`
+- `What is 12 plus 30?`
+- `Echo the text "hello broker".`
+- `Load the skill remote-http-mcp, find its remote MCP endpoint, inspect the announcement tools there, and publish an announcement titled "Broker via skill".`
+- `Use the remote-http-mcp skill to search the remote FAQ for "broker routing".`
+
+## How It Works
+
+The example starts an `LLMAgent` with broker tools plus built-in skill
+knowledge tools:
+
+```go
+broker := mcpbroker.New(
+    mcpbroker.WithServers(map[string]mcp.ConnectionConfig{
+        "local_stdio_code": {
+            Transport: "stdio",
+            Command:   "go",
+            Args:      []string{"run", serverPath},
+            Timeout:   10 * time.Second,
+        },
+    }),
+    mcpbroker.WithAllowAdHocHTTP(true),
+)
+
+agent := llmagent.New(
+    "mcp-broker-assistant",
+    llmagent.WithModel(modelInstance),
+    llmagent.WithTools(broker.Tools()),
+    llmagent.WithSkills(repo),
+    llmagent.WithSkillToolProfile(llmagent.SkillToolProfileKnowledgeOnly),
+)
+```
+
+The named local MCP server is still a plain `stdio` server:
+
+```go
+server := mcp.NewStdioServer("mcpbroker-demo-server", "1.0.0")
+server.RegisterTool(echoTool, ...)
+server.RegisterTool(addTool, ...)
+server.RegisterTool(issueCreateTool, ...)
+server.RegisterTool(docSearchTool, ...)
+server.RegisterTool(calendarCreateTool, ...)
+```
+
+The remote MCP server is a streamable HTTP server started in-process
+before the conversation begins:
+
+```go
+remote := startRemoteHTTPDemoServer()
+skillsRoot, _ := prepareRenderedSkillsRoot(exampleDir, remote.url)
+repo, _ := skill.NewFSRepository(skillsRoot)
+```
+
+The generated skill `remote-http-mcp` contains the exact ad-hoc MCP URL
+and tells the model to use selectors like:
+
+```text
+http://127.0.0.1:<port>/mcp
+http://127.0.0.1:<port>/mcp.announcement_publish
+```
+
+That skill does not start or manage the server. It only tells the model
+that this already-running endpoint can be connected dynamically through
+`mcp_list_tools`, `mcp_inspect_tools`, and `mcp_call`.
+
+## Expected Effect
+
+The visible tool surface to the model stays relatively small and stable:
+
+- For named MCPs, the model first discovers named servers with `mcp_list_servers`
+- For skill-provided remote MCPs, the model first loads the skill to get
+  the endpoint, then uses `mcp_list_tools` against that ad-hoc URL
+- It then uses `mcp_inspect_tools` to expand schema only for the selected tools
+- Only then does it call a concrete MCP tool with `mcp_call`
+
+With the wider local demo catalog, prompts like "find the issue creation
+tool" or "find the doc search tool" should naturally push the model
+toward targeted inspection instead of reading full schemas for the entire
+catalog every time.
+The skill-backed remote server adds a second path: dynamic endpoint
+discovery without pre-registering that remote MCP as a named broker
+server.
+
+That is the main difference from the old `tool/mcp` path, where remote
+MCP tools are expanded into the model's tool list before the turn
+starts.

--- a/examples/mcpbroker/basic/httpdemo.go
+++ b/examples/mcpbroker/basic/httpdemo.go
@@ -1,0 +1,113 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http/httptest"
+	"strings"
+
+	mcp "trpc.group/trpc-go/trpc-mcp-go"
+)
+
+const remoteSkillName = "remote-http-mcp"
+
+type remoteHTTPDemo struct {
+	server *httptest.Server
+	url    string
+}
+
+func startRemoteHTTPDemoServer() *remoteHTTPDemo {
+	server := mcp.NewServer(
+		"mcpbroker-remote-http-demo",
+		"1.0.0",
+		mcp.WithServerPath("/mcp"),
+	)
+
+	pingTool := mcp.NewTool(
+		"service_ping",
+		mcp.WithDescription("Check whether the remote announcement MCP service is reachable."),
+	)
+	server.RegisterTool(pingTool, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return mcp.NewTextResult("remote announcement MCP service is healthy"), nil
+	})
+
+	announcementPublishTool := mcp.NewTool(
+		"announcement_publish",
+		mcp.WithDescription("Publish an internal announcement with title, audience, and body."),
+		mcp.WithString("title", mcp.Required(), mcp.Description("Announcement title.")),
+		mcp.WithString("audience", mcp.Required(), mcp.Description("Target audience such as engineers or sales.")),
+		mcp.WithString("body", mcp.Required(), mcp.Description("Announcement body text.")),
+	)
+	server.RegisterTool(announcementPublishTool, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		_ = ctx
+		title, _ := req.Params.Arguments["title"].(string)
+		audience, _ := req.Params.Arguments["audience"].(string)
+		body, _ := req.Params.Arguments["body"].(string)
+		return mcp.NewTextResult(
+			fmt.Sprintf("Published announcement %q to %s: %s", title, audience, body),
+		), nil
+	})
+
+	announcementListTool := mcp.NewTool(
+		"announcement_list",
+		mcp.WithDescription("List recent announcements for an optional audience."),
+		mcp.WithString("audience", mcp.Description("Optional target audience filter.")),
+	)
+	server.RegisterTool(announcementListTool, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		_ = ctx
+		audience, _ := req.Params.Arguments["audience"].(string)
+		if strings.TrimSpace(audience) == "" {
+			audience = "everyone"
+		}
+		return mcp.NewTextResult(
+			fmt.Sprintf("Recent announcements for %s: release-freeze, broker-rollout", audience),
+		), nil
+	})
+
+	faqSearchTool := mcp.NewTool(
+		"faq_search",
+		mcp.WithDescription("Search remote FAQ entries by query."),
+		mcp.WithString("query", mcp.Required(), mcp.Description("FAQ search query.")),
+	)
+	server.RegisterTool(faqSearchTool, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		_ = ctx
+		query, _ := req.Params.Arguments["query"].(string)
+		return mcp.NewTextResult(
+			fmt.Sprintf("FAQ matches for %q: faq-remote-setup, faq-broker-routing", query),
+		), nil
+	})
+
+	faqReadTool := mcp.NewTool(
+		"faq_read",
+		mcp.WithDescription("Read a remote FAQ entry by id."),
+		mcp.WithString("entry_id", mcp.Required(), mcp.Description("FAQ entry id.")),
+	)
+	server.RegisterTool(faqReadTool, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		_ = ctx
+		entryID, _ := req.Params.Arguments["entry_id"].(string)
+		return mcp.NewTextResult(
+			fmt.Sprintf("FAQ %s: use mcp_list_tools and mcp_inspect_tools before mcp_call when the remote tool surface is unknown", entryID),
+		), nil
+	})
+
+	httpServer := httptest.NewServer(server.HTTPHandler())
+	return &remoteHTTPDemo{
+		server: httpServer,
+		url:    httpServer.URL + "/mcp",
+	}
+}
+
+func (d *remoteHTTPDemo) Close() {
+	if d == nil || d.server == nil {
+		return
+	}
+	d.server.Close()
+}

--- a/examples/mcpbroker/basic/main.go
+++ b/examples/mcpbroker/basic/main.go
@@ -1,0 +1,474 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package main demonstrates how to use the MCP broker tools with LLMAgent.
+package main
+
+import (
+	"bufio"
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/model/openai"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+	sessioninmemory "trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+	"trpc.group/trpc-go/trpc-agent-go/skill"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+	mcpcfg "trpc.group/trpc-go/trpc-agent-go/tool/mcp"
+	"trpc.group/trpc-go/trpc-agent-go/tool/mcpbroker"
+)
+
+var (
+	modelName = flag.String("model", "gpt-4o-mini", "Name of the model to use")
+	variant   = flag.String("variant", "", "Optional provider variant. If empty, infer from OPENAI_BASE_URL")
+	streaming = flag.Bool("streaming", true, "Enable streaming mode for responses")
+	prompt    = flag.String("prompt", "", "Optional single-turn prompt. If empty, start interactive chat")
+)
+
+const (
+	appName   = "mcp-broker-demo"
+	agentName = "mcp-broker-assistant"
+)
+
+func main() {
+	flag.Parse()
+
+	chat := &mcpBrokerChat{
+		modelName: *modelName,
+		variant:   *variant,
+		streaming: *streaming,
+		prompt:    strings.TrimSpace(*prompt),
+	}
+
+	if err := chat.run(); err != nil {
+		log.Fatalf("chat failed: %v", err)
+	}
+}
+
+type mcpBrokerChat struct {
+	modelName          string
+	variant            string
+	streaming          bool
+	prompt             string
+	runner             runner.Runner
+	userID             string
+	sessionID          string
+	visibleTools       []string
+	generatedSkillsDir string
+	preferredServer    string
+	availableServerIDs []string
+	availableSkillIDs  []string
+	remoteMCPURL       string
+	remoteHTTPDemo     *remoteHTTPDemo
+}
+
+func (c *mcpBrokerChat) run() error {
+	ctx := context.Background()
+	if err := c.setup(ctx); err != nil {
+		return fmt.Errorf("setup failed: %w", err)
+	}
+	defer c.runner.Close()
+	defer c.cleanupGeneratedSkillsDir()
+	defer c.closeRemoteHTTPDemo()
+
+	c.printBanner()
+
+	if c.prompt != "" {
+		return c.processMessage(ctx, c.prompt)
+	}
+	return c.startChat(ctx)
+}
+
+func (c *mcpBrokerChat) setup(_ context.Context) error {
+	exampleDir, err := exampleDir()
+	if err != nil {
+		return err
+	}
+	remoteDemo := startRemoteHTTPDemoServer()
+	remoteMCPURL := remoteDemo.url
+
+	skillsDir, err := prepareRenderedSkillsRoot(exampleDir, remoteMCPURL)
+	if err != nil {
+		remoteDemo.Close()
+		return err
+	}
+
+	repo, err := skill.NewFSRepository(skillsDir)
+	if err != nil {
+		remoteDemo.Close()
+		_ = os.RemoveAll(skillsDir)
+		return fmt.Errorf("load generated skills repo: %w", err)
+	}
+
+	serverPath := filepath.Join(exampleDir, "stdioserver", "main.go")
+
+	brokerOpts, serverIDs, preferredServer, err := c.buildBrokerOptions(serverPath)
+	if err != nil {
+		remoteDemo.Close()
+		_ = os.RemoveAll(skillsDir)
+		return err
+	}
+	c.generatedSkillsDir = skillsDir
+	c.availableServerIDs = serverIDs
+	c.availableSkillIDs = skillNames(repo)
+	c.preferredServer = preferredServer
+	c.remoteHTTPDemo = remoteDemo
+	c.remoteMCPURL = remoteMCPURL
+
+	broker := mcpbroker.New(brokerOpts...)
+
+	modelOpts := []openai.Option{}
+	if strings.TrimSpace(c.variant) != "" {
+		modelOpts = append(modelOpts, openai.WithVariant(openai.Variant(c.variant)))
+	}
+	modelInstance := openai.New(c.modelName, modelOpts...)
+	sessionService := sessioninmemory.NewSessionService()
+
+	genConfig := model.GenerationConfig{
+		MaxTokens: intPtr(2000),
+		Stream:    c.streaming,
+	}
+
+	instruction := strings.Join([]string{
+		"You are a helpful assistant demonstrating MCP broker style tool usage.",
+		"Your MCP entry points are mcp_list_servers, mcp_list_tools, mcp_inspect_tools, and mcp_call.",
+		"The remote MCP service used in this example is already running before the conversation starts.",
+		"Do not try to start the remote MCP service yourself. The skill only documents its endpoint and capabilities.",
+		"When the user asks about MCP capabilities, inspect named servers first.",
+		"Use mcp_list_tools with a selector such as local_stdio_code or https://example.com/mcp.",
+		"When you need exact parameter structure for one or more tools, call mcp_inspect_tools with their names before calling them.",
+		"When using mcp_call, pass a selector such as local_stdio_code.add or https://example.com/mcp.add.",
+		"With mcp_call, always put remote MCP tool parameters inside the arguments object, and use {} when the tool takes no parameters.",
+		"Never put MCP tool parameters like a, b, text, or issueId at the top level of mcp_call.",
+		"Do not infer a tool result from the user request. If a tool call fails or returns an incomplete result, inspect the target tools and retry with corrected arguments.",
+		"Prefer named servers over ad-hoc URLs when possible.",
+		fmt.Sprintf("There is also a skill named %q that reveals a remote streamable HTTP MCP endpoint. Load that skill before using the remote ad-hoc path.", remoteSkillName),
+		fmt.Sprintf("Prefer server %q for the local demo unless the user asks for another named server.", c.preferredServer),
+	}, " ")
+
+	llmAgent := llmagent.New(
+		agentName,
+		llmagent.WithModel(modelInstance),
+		llmagent.WithDescription("A demo assistant that discovers and calls MCP tools through broker tools."),
+		llmagent.WithInstruction(instruction),
+		llmagent.WithGenerationConfig(genConfig),
+		llmagent.WithTools(broker.Tools()),
+		llmagent.WithSkills(repo),
+		llmagent.WithSkillToolProfile(llmagent.SkillToolProfileKnowledgeOnly),
+	)
+	c.visibleTools = toolNames(llmAgent.Tools())
+
+	c.runner = runner.NewRunner(
+		appName,
+		llmAgent,
+		runner.WithSessionService(sessionService),
+	)
+	c.userID = "demo-user"
+	c.sessionID = fmt.Sprintf("mcp-broker-session-%d", time.Now().Unix())
+
+	return nil
+}
+
+func (c *mcpBrokerChat) buildBrokerOptions(serverPath string) (
+	[]mcpbroker.Option,
+	[]string,
+	string,
+	error,
+) {
+	opts := []mcpbroker.Option{
+		mcpbroker.WithAllowAdHocHTTP(true),
+		mcpbroker.WithServers(map[string]mcpcfg.ConnectionConfig{
+			"local_stdio_code": {
+				Transport: "stdio",
+				Command:   "go",
+				Args:      []string{"run", serverPath},
+				Timeout:   10 * time.Second,
+			},
+		}),
+	}
+	return opts, []string{"local_stdio_code"}, "local_stdio_code", nil
+}
+
+func (c *mcpBrokerChat) cleanupGeneratedSkillsDir() {
+	if strings.TrimSpace(c.generatedSkillsDir) == "" {
+		return
+	}
+	_ = os.RemoveAll(c.generatedSkillsDir)
+}
+
+func (c *mcpBrokerChat) closeRemoteHTTPDemo() {
+	if c.remoteHTTPDemo == nil {
+		return
+	}
+	c.remoteHTTPDemo.Close()
+}
+
+func (c *mcpBrokerChat) printBanner() {
+	fmt.Printf("🚀 MCP Broker Example\n")
+	fmt.Printf("Model: %s\n", c.modelName)
+	if strings.TrimSpace(c.variant) == "" {
+		fmt.Printf("Variant: auto\n")
+	} else {
+		fmt.Printf("Variant: %s\n", c.variant)
+	}
+	fmt.Printf("Streaming: %t\n", c.streaming)
+	fmt.Printf("Agent-visible tools: %s\n", strings.Join(c.visibleTools, ", "))
+	fmt.Printf("Demo named servers: %s\n", strings.Join(c.availableServerIDs, ", "))
+	if len(c.availableSkillIDs) > 0 {
+		fmt.Printf("Demo skills: %s\n", strings.Join(c.availableSkillIDs, ", "))
+	}
+	if c.prompt == "" {
+		fmt.Println("Type '/tips' for sample prompts, '/visible-tools' to print the visible tools, or '/exit' to quit.")
+	}
+	fmt.Println(strings.Repeat("=", 72))
+}
+
+func (c *mcpBrokerChat) startChat(ctx context.Context) error {
+	scanner := bufio.NewScanner(os.Stdin)
+	for {
+		fmt.Print("👤 You: ")
+		if !scanner.Scan() {
+			break
+		}
+
+		userInput := strings.TrimSpace(scanner.Text())
+		if userInput == "" {
+			continue
+		}
+
+		switch strings.ToLower(userInput) {
+		case "/exit":
+			fmt.Println("👋 Goodbye!")
+			return nil
+		case "/tips":
+			c.printTips()
+			continue
+		case "/visible-tools":
+			fmt.Printf("Visible tools: %s\n\n", strings.Join(c.visibleTools, ", "))
+			continue
+		}
+
+		if err := c.processMessage(ctx, userInput); err != nil {
+			fmt.Printf("❌ Error: %v\n\n", err)
+			continue
+		}
+		fmt.Println()
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("input scanner error: %w", err)
+	}
+	return nil
+}
+
+func (c *mcpBrokerChat) printTips() {
+	fmt.Println("💡 Sample prompts:")
+	fmt.Println("   1. What MCP servers are available to you?")
+	fmt.Printf("   2. Inspect server %q and summarize its tools.\n", c.preferredServer)
+	fmt.Printf("   3. Find the issue creation tool on %q, inspect its schema, and create an issue titled 'Broker demo'.\n", c.preferredServer)
+	fmt.Printf("   4. Find the documentation search tool on %q and search for 'MCP broker'.\n", c.preferredServer)
+	fmt.Printf("   5. Use %q to add 12 and 30.\n", c.preferredServer)
+	fmt.Printf("   6. Use %q to echo the text 'hello broker'.\n", c.preferredServer)
+	fmt.Printf("   7. Load the skill %q, find its already-running remote MCP endpoint, inspect the announcement tools there, and publish an announcement titled 'Broker via skill'.\n", remoteSkillName)
+	fmt.Println()
+}
+
+func (c *mcpBrokerChat) processMessage(ctx context.Context, userMessage string) error {
+	eventChan, err := c.runner.Run(
+		ctx,
+		c.userID,
+		c.sessionID,
+		model.NewUserMessage(userMessage),
+		agent.WithRequestID(uuid.NewString()),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to run agent: %w", err)
+	}
+	return c.processResponse(eventChan)
+}
+
+func (c *mcpBrokerChat) processResponse(eventChan <-chan *event.Event) error {
+	fmt.Print("🤖 Assistant: ")
+
+	var (
+		toolCallsDetected bool
+		assistantStarted  bool
+	)
+
+	for evt := range eventChan {
+		if evt == nil {
+			continue
+		}
+		if evt.Error != nil {
+			return fmt.Errorf("runner event error: %s", evt.Error.Message)
+		}
+		if c.handleToolCalls(evt, &toolCallsDetected, &assistantStarted) {
+			continue
+		}
+		if c.handleToolResponses(evt) {
+			continue
+		}
+		c.handleContent(evt, &toolCallsDetected, &assistantStarted)
+		if evt.IsFinalResponse() {
+			fmt.Println()
+			return nil
+		}
+	}
+	return nil
+}
+
+func (c *mcpBrokerChat) handleToolCalls(
+	evt *event.Event,
+	toolCallsDetected *bool,
+	assistantStarted *bool,
+) bool {
+	if evt.Response == nil || len(evt.Response.Choices) == 0 {
+		return false
+	}
+	toolCalls := evt.Response.Choices[0].Message.ToolCalls
+	if len(toolCalls) == 0 {
+		return false
+	}
+
+	*toolCallsDetected = true
+	if *assistantStarted {
+		fmt.Println()
+	}
+	fmt.Println()
+	fmt.Println("🔧 Tool calls:")
+	for _, toolCall := range toolCalls {
+		fmt.Printf("   • %s (ID: %s)\n", toolCall.Function.Name, toolCall.ID)
+		if len(toolCall.Function.Arguments) > 0 {
+			fmt.Printf("     Args: %s\n", compactJSON(toolCall.Function.Arguments))
+		}
+	}
+	fmt.Println("🔄 Executing tools...")
+	return true
+}
+
+func (c *mcpBrokerChat) handleToolResponses(evt *event.Event) bool {
+	if evt.Response == nil || len(evt.Response.Choices) == 0 {
+		return false
+	}
+
+	printed := false
+	for _, choice := range evt.Response.Choices {
+		if choice.Message.Role != model.RoleTool || choice.Message.ToolID == "" {
+			continue
+		}
+		if !printed {
+			fmt.Println()
+			fmt.Println("✅ Tool results:")
+			printed = true
+		}
+		fmt.Printf("   • %s\n", preview(choice.Message.Content, 220))
+	}
+	return printed
+}
+
+func (c *mcpBrokerChat) handleContent(
+	evt *event.Event,
+	toolCallsDetected *bool,
+	assistantStarted *bool,
+) {
+	if evt.Response == nil || len(evt.Response.Choices) == 0 {
+		return
+	}
+
+	content := extractContent(evt.Response.Choices[0], c.streaming)
+	if content == "" {
+		return
+	}
+	if !*assistantStarted {
+		if *toolCallsDetected {
+			fmt.Println()
+			fmt.Print("🤖 Assistant: ")
+		}
+		*assistantStarted = true
+	}
+	fmt.Print(content)
+}
+
+func exampleDir() (string, error) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("resolve example directory: runtime.Caller failed")
+	}
+	return filepath.Dir(file), nil
+}
+
+func toolNames(tools []tool.Tool) []string {
+	names := make([]string, 0, len(tools))
+	for _, tl := range tools {
+		if tl == nil || tl.Declaration() == nil {
+			continue
+		}
+		names = append(names, tl.Declaration().Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func skillNames(repo skill.Repository) []string {
+	if repo == nil {
+		return nil
+	}
+	summaries := repo.Summaries()
+	names := make([]string, 0, len(summaries))
+	for _, summary := range summaries {
+		if strings.TrimSpace(summary.Name) == "" {
+			continue
+		}
+		names = append(names, summary.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func extractContent(choice model.Choice, streaming bool) string {
+	if streaming {
+		return choice.Delta.Content
+	}
+	return choice.Message.Content
+}
+
+func compactJSON(raw []byte) string {
+	text := strings.TrimSpace(string(raw))
+	if text == "" {
+		return "{}"
+	}
+	return text
+}
+
+func preview(text string, max int) string {
+	text = strings.TrimSpace(text)
+	if len(text) <= max {
+		return text
+	}
+	if max <= 3 {
+		return text[:max]
+	}
+	return text[:max-3] + "..."
+}
+
+func intPtr(v int) *int {
+	return &v
+}

--- a/examples/mcpbroker/basic/skillrepo.go
+++ b/examples/mcpbroker/basic/skillrepo.go
@@ -1,0 +1,75 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const remoteMCPURLPlaceholder = "__REMOTE_MCP_URL__"
+
+func prepareRenderedSkillsRoot(exampleDir string, remoteMCPURL string) (string, error) {
+	templateRoot := filepath.Join(exampleDir, "skills")
+	renderedRoot, err := os.MkdirTemp("", "trpc-agent-go-mcpbroker-skills-*")
+	if err != nil {
+		return "", fmt.Errorf("create rendered skills root: %w", err)
+	}
+
+	if err := copySkillTemplateTree(templateRoot, renderedRoot, map[string]string{
+		remoteMCPURLPlaceholder: remoteMCPURL,
+	}); err != nil {
+		_ = os.RemoveAll(renderedRoot)
+		return "", err
+	}
+	return renderedRoot, nil
+}
+
+func copySkillTemplateTree(srcRoot string, dstRoot string, replacements map[string]string) error {
+	replacerArgs := make([]string, 0, len(replacements)*2)
+	for oldValue, newValue := range replacements {
+		replacerArgs = append(replacerArgs, oldValue, newValue)
+	}
+	replacer := strings.NewReplacer(replacerArgs...)
+
+	return filepath.WalkDir(srcRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		relPath, err := filepath.Rel(srcRoot, path)
+		if err != nil {
+			return fmt.Errorf("resolve skill template path %q: %w", path, err)
+		}
+		if relPath == "." {
+			return nil
+		}
+
+		targetPath := filepath.Join(dstRoot, relPath)
+		if d.IsDir() {
+			return os.MkdirAll(targetPath, 0o755)
+		}
+
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read skill template %q: %w", path, err)
+		}
+		rendered := replacer.Replace(string(content))
+		if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+			return fmt.Errorf("create skill template dir %q: %w", targetPath, err)
+		}
+		if err := os.WriteFile(targetPath, []byte(rendered), 0o644); err != nil {
+			return fmt.Errorf("write rendered skill file %q: %w", targetPath, err)
+		}
+		return nil
+	})
+}

--- a/examples/mcpbroker/basic/skills/remote-http-mcp/SKILL.md
+++ b/examples/mcpbroker/basic/skills/remote-http-mcp/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: remote-http-mcp
+description: Connect to a remote streamable HTTP MCP service that exposes announcements and FAQ tools.
+---
+
+Overview
+
+This skill points to a remote MCP service that is not preconfigured as a
+named broker server. Load this skill when you need to discover or call
+that remote service dynamically.
+
+The remote MCP service is already running for this example. This skill
+does not start it. This skill only documents the endpoint and the
+recommended broker workflow.
+
+Remote MCP Endpoint
+
+- Base URL: `__REMOTE_MCP_URL__`
+- Transport: streamable HTTP
+
+Workflow
+
+After this skill is loaded:
+
+1. If you need more connection detail, call `skill_list_docs` or
+   `skill_select_docs`.
+2. Use `mcp_list_tools` with selector `__REMOTE_MCP_URL__`.
+3. When you know the candidate tool names, use `mcp_inspect_tools`
+   to inspect only those tools.
+4. When you know the tool, call `mcp_call` with the selector returned
+   by `mcp_list_tools` or `mcp_inspect_tools`.
+5. Always pass remote MCP arguments inside `mcp_call.arguments`.
+
+Rules
+
+- Do not invent a different endpoint. Use the exact base URL in this skill.
+- Do not try to start this MCP service through `skill_run` or any other
+  command. It is already running.
+- Prefer `mcp_list_tools` first, then inspect only the specific tool or
+  tools you plan to call.
+- Prefer tool selectors returned by `mcp_list_tools` or
+  `mcp_inspect_tools`. If you must construct an ad-hoc URL selector and
+  dot-based parsing would be ambiguous, use the `#tool=` form, for example
+  `__REMOTE_MCP_URL__#tool=announcement_publish`.
+- If you need announcement publishing, look for `announcement_publish`.
+- If you need FAQ tools, look for `faq_search` or `faq_read`.

--- a/examples/mcpbroker/basic/skills/remote-http-mcp/docs/usage.md
+++ b/examples/mcpbroker/basic/skills/remote-http-mcp/docs/usage.md
@@ -1,0 +1,39 @@
+Remote HTTP MCP Usage
+
+Use this skill when the user asks for a capability that is not covered by
+the named stdio demo servers and you need the dynamic remote MCP path.
+
+The remote MCP service is already running. Do not start it. Just connect
+to the URL exposed by this skill.
+
+Suggested broker calls
+
+Announcement publishing path:
+
+1. List tools:
+
+   `mcp_list_tools(selector="__REMOTE_MCP_URL__")`
+
+2. Inspect the announcement tool:
+
+   `mcp_inspect_tools(selector="__REMOTE_MCP_URL__", tools=["announcement_publish"])`
+
+3. Publish an announcement with the selector returned by the broker:
+
+   `mcp_call(selector="__REMOTE_MCP_URL__.announcement_publish", arguments={"title":"Broker via skill","audience":"engineers","body":"Remote MCP connected successfully."})`
+
+FAQ search path:
+
+1. List tools:
+
+   `mcp_list_tools(selector="__REMOTE_MCP_URL__")`
+
+2. Inspect FAQ tools:
+
+   `mcp_inspect_tools(selector="__REMOTE_MCP_URL__", tools=["faq_search"])`
+
+Prefer selectors returned by `mcp_list_tools` or `mcp_inspect_tools`.
+If a hand-written ad-hoc URL selector would be ambiguous, use the
+`#tool=` form, for example:
+
+`mcp_call(selector="__REMOTE_MCP_URL__#tool=announcement_publish", arguments={"title":"Broker via skill","audience":"engineers","body":"Remote MCP connected successfully."})`

--- a/examples/mcpbroker/basic/stdioserver/main.go
+++ b/examples/mcpbroker/basic/stdioserver/main.go
@@ -1,0 +1,186 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	mcp "trpc.group/trpc-go/trpc-mcp-go"
+)
+
+func main() {
+	server := mcp.NewStdioServer("mcpbroker-demo-server", "1.0.0")
+
+	echoTool := mcp.NewTool(
+		"echo",
+		mcp.WithDescription("Echo text back to the caller with an optional prefix."),
+		mcp.WithString("text", mcp.Required(), mcp.Description("Text to echo.")),
+		mcp.WithString("prefix", mcp.Description("Optional prefix. Defaults to 'Echo: '.")),
+	)
+	server.RegisterTool(echoTool, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		text, _ := req.Params.Arguments["text"].(string)
+		prefix, _ := req.Params.Arguments["prefix"].(string)
+		if strings.TrimSpace(prefix) == "" {
+			prefix = "Echo: "
+		}
+		return mcp.NewTextResult(prefix + text), nil
+	})
+
+	addTool := mcp.NewTool(
+		"add",
+		mcp.WithDescription("Add two numbers and return the numeric result."),
+		mcp.WithNumber("a", mcp.Required(), mcp.Description("First number.")),
+		mcp.WithNumber("b", mcp.Required(), mcp.Description("Second number.")),
+	)
+	server.RegisterTool(addTool, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		a, _ := req.Params.Arguments["a"].(float64)
+		b, _ := req.Params.Arguments["b"].(float64)
+		return mcp.NewTextResult(fmt.Sprintf("%g", a+b)), nil
+	})
+
+	issueCreateTool := mcp.NewTool(
+		"issue_create",
+		mcp.WithDescription("Create a project issue with title, optional description, and priority."),
+		mcp.WithString("title", mcp.Required(), mcp.Description("Issue title.")),
+		mcp.WithString("description", mcp.Description("Optional issue description.")),
+		mcp.WithString("priority", mcp.Description("Optional priority such as low, medium, or high.")),
+	)
+	server.RegisterTool(issueCreateTool, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		title, _ := req.Params.Arguments["title"].(string)
+		description, _ := req.Params.Arguments["description"].(string)
+		priority, _ := req.Params.Arguments["priority"].(string)
+		if strings.TrimSpace(priority) == "" {
+			priority = "medium"
+		}
+		return mcp.NewTextResult(
+			fmt.Sprintf("Created issue %q with priority=%s description=%q", title, priority, description),
+		), nil
+	})
+
+	issueListTool := mcp.NewTool(
+		"issue_list",
+		mcp.WithDescription("List project issues filtered by optional status or assignee."),
+		mcp.WithString("status", mcp.Description("Optional status filter such as open or closed.")),
+		mcp.WithString("assignee", mcp.Description("Optional assignee name.")),
+	)
+	server.RegisterTool(issueListTool, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		status, _ := req.Params.Arguments["status"].(string)
+		assignee, _ := req.Params.Arguments["assignee"].(string)
+		if strings.TrimSpace(status) == "" {
+			status = "open"
+		}
+		if strings.TrimSpace(assignee) == "" {
+			assignee = "anyone"
+		}
+		return mcp.NewTextResult(
+			fmt.Sprintf("Listing %s issues assigned to %s", status, assignee),
+		), nil
+	})
+
+	issueCommentTool := mcp.NewTool(
+		"issue_comment",
+		mcp.WithDescription("Add a comment to an existing issue."),
+		mcp.WithString("issue_id", mcp.Required(), mcp.Description("Issue identifier.")),
+		mcp.WithString("body", mcp.Required(), mcp.Description("Comment content.")),
+	)
+	server.RegisterTool(issueCommentTool, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		issueID, _ := req.Params.Arguments["issue_id"].(string)
+		body, _ := req.Params.Arguments["body"].(string)
+		return mcp.NewTextResult(
+			fmt.Sprintf("Added comment to issue %s: %q", issueID, body),
+		), nil
+	})
+
+	docSearchTool := mcp.NewTool(
+		"doc_search",
+		mcp.WithDescription("Search documentation articles by query and optional product area."),
+		mcp.WithString("query", mcp.Required(), mcp.Description("Search query.")),
+		mcp.WithString("product", mcp.Description("Optional product area filter.")),
+	)
+	server.RegisterTool(docSearchTool, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		query, _ := req.Params.Arguments["query"].(string)
+		product, _ := req.Params.Arguments["product"].(string)
+		if strings.TrimSpace(product) == "" {
+			product = "all"
+		}
+		return mcp.NewTextResult(
+			fmt.Sprintf("Found docs for query=%q in product=%q", query, product),
+		), nil
+	})
+
+	docReadTool := mcp.NewTool(
+		"doc_read",
+		mcp.WithDescription("Read a documentation article by document identifier."),
+		mcp.WithString("doc_id", mcp.Required(), mcp.Description("Document identifier.")),
+	)
+	server.RegisterTool(docReadTool, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		docID, _ := req.Params.Arguments["doc_id"].(string)
+		return mcp.NewTextResult(fmt.Sprintf("Reading document %s", docID)), nil
+	})
+
+	calendarCreateTool := mcp.NewTool(
+		"calendar_create",
+		mcp.WithDescription("Create a calendar event with title and start time."),
+		mcp.WithString("title", mcp.Required(), mcp.Description("Event title.")),
+		mcp.WithString("start_time", mcp.Required(), mcp.Description("Event start time in ISO-8601 format.")),
+		mcp.WithString("attendee", mcp.Description("Optional attendee email.")),
+	)
+	server.RegisterTool(calendarCreateTool, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		title, _ := req.Params.Arguments["title"].(string)
+		startTime, _ := req.Params.Arguments["start_time"].(string)
+		attendee, _ := req.Params.Arguments["attendee"].(string)
+		return mcp.NewTextResult(
+			fmt.Sprintf("Created calendar event %q at %s attendee=%q", title, startTime, attendee),
+		), nil
+	})
+
+	calendarListTool := mcp.NewTool(
+		"calendar_list",
+		mcp.WithDescription("List upcoming calendar events for an optional day."),
+		mcp.WithString("day", mcp.Description("Optional day filter in YYYY-MM-DD format.")),
+	)
+	server.RegisterTool(calendarListTool, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		day, _ := req.Params.Arguments["day"].(string)
+		if strings.TrimSpace(day) == "" {
+			day = "today"
+		}
+		return mcp.NewTextResult(fmt.Sprintf("Listing calendar events for %s", day)), nil
+	})
+
+	meetingScheduleTool := mcp.NewTool(
+		"meeting_schedule",
+		mcp.WithDescription("Schedule an online meeting with topic and participant count."),
+		mcp.WithString("topic", mcp.Required(), mcp.Description("Meeting topic.")),
+		mcp.WithNumber("participants", mcp.Description("Optional participant count estimate.")),
+	)
+	server.RegisterTool(meetingScheduleTool, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		topic, _ := req.Params.Arguments["topic"].(string)
+		participants, _ := req.Params.Arguments["participants"].(float64)
+		return mcp.NewTextResult(
+			fmt.Sprintf("Scheduled meeting topic=%q participants=%g", topic, participants),
+		), nil
+	})
+
+	meetingCancelTool := mcp.NewTool(
+		"meeting_cancel",
+		mcp.WithDescription("Cancel an online meeting by meeting identifier."),
+		mcp.WithString("meeting_id", mcp.Required(), mcp.Description("Meeting identifier.")),
+	)
+	server.RegisterTool(meetingCancelTool, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		meetingID, _ := req.Params.Arguments["meeting_id"].(string)
+		return mcp.NewTextResult(fmt.Sprintf("Cancelled meeting %s", meetingID)), nil
+	})
+
+	if err := server.Start(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/tool/mcpbroker/broker.go
+++ b/tool/mcpbroker/broker.go
@@ -1,0 +1,431 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+// Package mcpbroker provides opt-in MCP discovery/call broker tools.
+package mcpbroker
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+	mcpcfg "trpc.group/trpc-go/trpc-agent-go/tool/mcp"
+)
+
+const (
+	listServersToolName  = "mcp_list_servers"
+	listToolsToolName    = "mcp_list_tools"
+	inspectToolsToolName = "mcp_inspect_tools"
+	callToolToolName     = "mcp_call"
+)
+
+const (
+	originCode = "code"
+)
+
+const (
+	targetTypeStdio = "stdio"
+	targetTypeHTTP  = "http"
+)
+
+var defaultSensitiveHeaderDenylist = []string{
+	"authorization",
+	"proxy-authorization",
+	"cookie",
+	"set-cookie",
+	"x-api-key",
+}
+
+// Broker provides a small set of MCP management tools for agents.
+type Broker struct {
+	options brokerOptions
+}
+
+// Option configures a Broker.
+type Option func(*brokerOptions)
+
+type brokerOptions struct {
+	servers                     map[string]mcpcfg.ConnectionConfig
+	allowAdHocHTTP              bool
+	adhocSensitiveHeaderDenyset map[string]struct{}
+	httpHeaderInjector          HTTPHeaderInjector
+	errorInterceptor            ErrorInterceptor
+}
+
+// HTTPHeaderInjector resolves per-run HTTP headers for MCP requests.
+type HTTPHeaderInjector func(context.Context, *HeaderInjectRequest) (map[string]string, error)
+
+// HeaderInjectRequest describes an MCP HTTP request before execution.
+type HeaderInjectRequest struct {
+	Selector  string
+	BaseURL   string
+	ToolName  string
+	Phase     string
+	Transport string
+	IsAdHoc   bool
+}
+
+// ErrorInterceptor lets business code classify and transform MCP HTTP errors.
+type ErrorInterceptor func(context.Context, *BrokerErrorRequest) (*BrokerErrorDecision, error)
+
+// BrokerErrorRequest describes an MCP HTTP operation error.
+type BrokerErrorRequest struct {
+	Selector  string
+	BaseURL   string
+	ToolName  string
+	Phase     string
+	Transport string
+	IsAdHoc   bool
+	Err       error
+}
+
+// BrokerErrorDecision controls how an intercepted error is surfaced.
+type BrokerErrorDecision struct {
+	WrapError error
+	Handled   bool
+}
+
+// New creates a new MCP broker.
+func New(opts ...Option) *Broker {
+	options := brokerOptions{
+		servers: make(map[string]mcpcfg.ConnectionConfig),
+		adhocSensitiveHeaderDenyset: func() map[string]struct{} {
+			result := make(map[string]struct{}, len(defaultSensitiveHeaderDenylist))
+			for _, name := range defaultSensitiveHeaderDenylist {
+				result[name] = struct{}{}
+			}
+			return result
+		}(),
+	}
+
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	return &Broker{options: options}
+}
+
+// WithServers adds named MCP server configurations provided by code.
+func WithServers(servers map[string]mcpcfg.ConnectionConfig) Option {
+	return func(opts *brokerOptions) {
+		if len(servers) == 0 {
+			return
+		}
+		if opts.servers == nil {
+			opts.servers = make(map[string]mcpcfg.ConnectionConfig, len(servers))
+		}
+		for name, cfg := range servers {
+			opts.servers[name] = cloneConnectionConfig(cfg)
+		}
+	}
+}
+
+// WithAllowAdHocHTTP controls whether ad-hoc HTTP MCP targets are allowed.
+func WithAllowAdHocHTTP(enabled bool) Option {
+	return func(opts *brokerOptions) {
+		opts.allowAdHocHTTP = enabled
+	}
+}
+
+// WithAdHocSensitiveHeaderDenylist adds case-insensitive denylist header names
+// for ad-hoc HTTP MCP calls.
+func WithAdHocSensitiveHeaderDenylist(headers []string) Option {
+	return func(opts *brokerOptions) {
+		if len(headers) == 0 {
+			return
+		}
+		if opts.adhocSensitiveHeaderDenyset == nil {
+			opts.adhocSensitiveHeaderDenyset = make(map[string]struct{})
+		}
+		for _, header := range headers {
+			header = strings.ToLower(strings.TrimSpace(header))
+			if header == "" {
+				continue
+			}
+			opts.adhocSensitiveHeaderDenyset[header] = struct{}{}
+		}
+	}
+}
+
+// WithHTTPHeaderInjector injects per-run HTTP headers derived from context and target metadata.
+func WithHTTPHeaderInjector(fn HTTPHeaderInjector) Option {
+	return func(opts *brokerOptions) {
+		opts.httpHeaderInjector = fn
+	}
+}
+
+// WithErrorInterceptor intercepts HTTP MCP execution errors and may translate them for model consumption.
+func WithErrorInterceptor(fn ErrorInterceptor) Option {
+	return func(opts *brokerOptions) {
+		opts.errorInterceptor = fn
+	}
+}
+
+// Tools returns the broker's MCP management tools.
+func (b *Broker) Tools() []tool.Tool {
+	return newBrokerTools(b)
+}
+
+type namedServer struct {
+	Name       string
+	Origin     string
+	TargetType string
+	Config     mcpcfg.ConnectionConfig
+}
+
+func (b *Broker) resolveNamedServers() ([]namedServer, map[string]namedServer, error) {
+	merged := make(map[string]namedServer, len(b.options.servers))
+	for name, cfg := range b.options.servers {
+		server, serverErr := normalizeNamedServer(name, cfg, originCode)
+		if serverErr != nil {
+			return nil, nil, serverErr
+		}
+		if _, exists := merged[server.Name]; exists {
+			return nil, nil, fmt.Errorf("duplicate MCP server name after normalization: %s", server.Name)
+		}
+		merged[server.Name] = server
+	}
+
+	list := make([]namedServer, 0, len(merged))
+	for _, server := range merged {
+		list = append(list, server)
+	}
+	sort.Slice(list, func(i, j int) bool {
+		return list[i].Name < list[j].Name
+	})
+
+	return list, merged, nil
+}
+
+func (b *Broker) resolveTarget(input targetInput) (resolvedTarget, error) {
+	serverName := strings.TrimSpace(input.ServerName)
+	urlValue := strings.TrimSpace(input.URL)
+
+	if serverName == "" && urlValue == "" {
+		return resolvedTarget{}, fmt.Errorf("exactly one of server_name or url is required")
+	}
+
+	if serverName != "" {
+		_, merged, err := b.resolveNamedServers()
+		if err != nil {
+			return resolvedTarget{}, err
+		}
+		server, ok := merged[serverName]
+		if !ok {
+			return resolvedTarget{}, fmt.Errorf("unknown MCP server: %s", serverName)
+		}
+		return resolvedTarget{
+			Name:       server.Name,
+			Origin:     server.Origin,
+			TargetType: server.TargetType,
+			Config:     server.Config,
+		}, nil
+	}
+
+	if !b.options.allowAdHocHTTP {
+		return resolvedTarget{}, fmt.Errorf("ad-hoc HTTP MCP is disabled")
+	}
+
+	config, targetType, err := b.buildAdHocConfig(input)
+	if err != nil {
+		return resolvedTarget{}, err
+	}
+	return resolvedTarget{
+		Origin:     "adhoc",
+		TargetType: targetType,
+		Config:     config,
+	}, nil
+}
+
+func (b *Broker) listServers(ctx context.Context, _ listServersInput) (listServersOutput, error) {
+	servers, _, err := b.resolveNamedServers()
+	if err != nil {
+		return listServersOutput{}, err
+	}
+
+	output := listServersOutput{Servers: make([]listServersServer, 0, len(servers))}
+	for _, server := range servers {
+		output.Servers = append(output.Servers, listServersServer{
+			Name:      server.Name,
+			Transport: server.Config.Transport,
+		})
+	}
+	return output, nil
+}
+
+func (b *Broker) resolveListSelector(
+	selector string,
+	transport string,
+	headers map[string]string,
+) (resolvedTarget, string, error) {
+	selector = strings.TrimSpace(selector)
+	if selector == "" {
+		return resolvedTarget{}, "", fmt.Errorf("selector is required")
+	}
+
+	if looksLikeHTTPSelector(selector) {
+		target, err := b.resolveTarget(targetInput{
+			URL:       selector,
+			Transport: transport,
+			Headers:   headers,
+		})
+		if err != nil {
+			return resolvedTarget{}, "", err
+		}
+		return target, selector, nil
+	}
+
+	target, err := b.resolveTarget(targetInput{
+		ServerName: selector,
+		Transport:  transport,
+		Headers:    headers,
+	})
+	if err != nil {
+		return resolvedTarget{}, "", err
+	}
+	return target, selector, nil
+}
+
+func (b *Broker) resolveCallSelector(
+	selector string,
+	transport string,
+	headers map[string]string,
+) (resolvedTarget, string, string, error) {
+	selector = strings.TrimSpace(selector)
+	if selector == "" {
+		return resolvedTarget{}, "", "", fmt.Errorf("selector is required")
+	}
+
+	if looksLikeHTTPSelector(selector) {
+		baseURL, toolName, err := splitHTTPToolSelector(selector)
+		if err != nil {
+			return resolvedTarget{}, "", "", err
+		}
+		target, targetErr := b.resolveTarget(targetInput{
+			URL:       baseURL,
+			Transport: transport,
+			Headers:   headers,
+		})
+		if targetErr != nil {
+			return resolvedTarget{}, "", "", targetErr
+		}
+		return target, baseURL, toolName, nil
+	}
+
+	serverName, toolName, err := b.splitNamedToolSelector(selector)
+	if err != nil {
+		return resolvedTarget{}, "", "", err
+	}
+	target, targetErr := b.resolveTarget(targetInput{
+		ServerName: serverName,
+		Transport:  transport,
+		Headers:    headers,
+	})
+	if targetErr != nil {
+		return resolvedTarget{}, "", "", targetErr
+	}
+	return target, serverName, toolName, nil
+}
+
+func (b *Broker) splitNamedToolSelector(selector string) (string, string, error) {
+	selector = strings.TrimSpace(selector)
+	if selector == "" {
+		return "", "", fmt.Errorf("selector is required")
+	}
+
+	_, merged, err := b.resolveNamedServers()
+	if err != nil {
+		return "", "", err
+	}
+
+	bestName := ""
+	for name := range merged {
+		prefix := name + "."
+		if strings.HasPrefix(selector, prefix) && len(name) > len(bestName) {
+			bestName = name
+		}
+	}
+	if bestName != "" {
+		toolName := strings.TrimSpace(strings.TrimPrefix(selector, bestName+"."))
+		if toolName == "" {
+			return "", "", fmt.Errorf("call selector must be <server>.<tool>, <url>.<tool>, or <url>#tool=<tool>")
+		}
+		return bestName, toolName, nil
+	}
+
+	lastDot := strings.LastIndex(selector, ".")
+	if lastDot <= 0 || lastDot == len(selector)-1 {
+		return "", "", fmt.Errorf("call selector must be <server>.<tool>, <url>.<tool>, or <url>#tool=<tool>")
+	}
+
+	serverName := strings.TrimSpace(selector[:lastDot])
+	if _, ok := merged[serverName]; !ok {
+		return "", "", fmt.Errorf("unknown MCP server: %s", serverName)
+	}
+	return serverName, strings.TrimSpace(selector[lastDot+1:]), nil
+}
+
+func splitHTTPToolSelector(selector string) (string, string, error) {
+	selector = strings.TrimSpace(selector)
+	if fragmentIndex := strings.Index(selector, "#tool="); fragmentIndex >= 0 {
+		baseURL := strings.TrimSpace(selector[:fragmentIndex])
+		toolName := strings.TrimSpace(selector[fragmentIndex+len("#tool="):])
+		if baseURL == "" || toolName == "" {
+			return "", "", fmt.Errorf("call selector must be <server>.<tool>, <url>.<tool>, or <url>#tool=<tool>")
+		}
+		return baseURL, toolName, nil
+	}
+
+	parsedURL, err := url.Parse(selector)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid HTTP selector %q: %w", selector, err)
+	}
+	pathValue := parsedURL.EscapedPath()
+	lastSlash := strings.LastIndex(pathValue, "/")
+	segment := pathValue[lastSlash+1:]
+	firstDot := strings.Index(segment, ".")
+	if firstDot <= 0 || firstDot == len(segment)-1 {
+		return "", "", fmt.Errorf("call selector must be <server>.<tool>, <url>.<tool>, or <url>#tool=<tool>")
+	}
+
+	toolName := strings.TrimSpace(segment[firstDot+1:])
+	parsedURL.Path = strings.TrimSpace(pathValue[:lastSlash+1] + segment[:firstDot])
+	parsedURL.RawPath = parsedURL.Path
+	baseURL := strings.TrimSpace(parsedURL.String())
+	if baseURL == "" || toolName == "" {
+		return "", "", fmt.Errorf("call selector must be <server>.<tool>, <url>.<tool>, or <url>#tool=<tool>")
+	}
+	return baseURL, toolName, nil
+}
+
+func shouldUseFragmentHTTPToolSelector(selector string) bool {
+	selector = strings.TrimSpace(selector)
+	parsedURL, err := url.Parse(selector)
+	if err != nil {
+		return true
+	}
+	if parsedURL.RawQuery != "" || parsedURL.Fragment != "" {
+		return true
+	}
+	pathValue := parsedURL.EscapedPath()
+	if pathValue == "" {
+		return false
+	}
+	lastSlash := strings.LastIndex(pathValue, "/")
+	segment := pathValue[lastSlash+1:]
+	return strings.Contains(segment, ".")
+}
+
+func looksLikeHTTPSelector(selector string) bool {
+	selector = strings.ToLower(strings.TrimSpace(selector))
+	return strings.HasPrefix(selector, "http://") || strings.HasPrefix(selector, "https://")
+}

--- a/tool/mcpbroker/broker_test.go
+++ b/tool/mcpbroker/broker_test.go
@@ -1,0 +1,1184 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package mcpbroker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	agenttool "trpc.group/trpc-go/trpc-agent-go/tool"
+	legacymcp "trpc.group/trpc-go/trpc-agent-go/tool/mcp"
+	tmcp "trpc.group/trpc-go/trpc-mcp-go"
+)
+
+type brokerHTTPServer struct {
+	URL string
+
+	server       *httptest.Server
+	mu           sync.Mutex
+	methodCount  map[string]int
+	lastXTest    string
+	lastAuth     string
+	requiredAuth string
+}
+
+func startBrokerHTTPServer(t *testing.T) *brokerHTTPServer {
+	t.Helper()
+	return startBrokerHTTPServerWithOptions(t, brokerHTTPServerOptions{})
+}
+
+type brokerHTTPServerOptions struct {
+	RequiredAuth       string
+	RegisterDottedTool bool
+	RegisterStructured bool
+	ServerPath         string
+}
+
+func startBrokerHTTPServerWithOptions(t *testing.T, opts brokerHTTPServerOptions) *brokerHTTPServer {
+	t.Helper()
+
+	mcpServer := tmcp.NewServer(
+		"broker-test-server",
+		"1.0.0",
+		tmcp.WithServerPath(func() string {
+			if strings.TrimSpace(opts.ServerPath) != "" {
+				return opts.ServerPath
+			}
+			return "/mcp"
+		}()),
+	)
+
+	type echoOutput struct {
+		Message string `json:"message"`
+	}
+
+	echoTool := tmcp.NewTool(
+		"echo",
+		tmcp.WithDescription("Echo text."),
+		tmcp.WithString("text", tmcp.Required(), tmcp.Description("Text to echo.")),
+		tmcp.WithOutputStruct[echoOutput](),
+	)
+	mcpServer.RegisterTool(echoTool, func(ctx context.Context, req *tmcp.CallToolRequest) (*tmcp.CallToolResult, error) {
+		text, _ := req.Params.Arguments["text"].(string)
+		return tmcp.NewTextResult("Echo: " + text), nil
+	})
+
+	addTool := tmcp.NewTool(
+		"add",
+		tmcp.WithDescription("Add two numbers."),
+		tmcp.WithNumber("a", tmcp.Required(), tmcp.Description("First number.")),
+		tmcp.WithNumber("b", tmcp.Required(), tmcp.Description("Second number.")),
+	)
+	mcpServer.RegisterTool(addTool, func(ctx context.Context, req *tmcp.CallToolRequest) (*tmcp.CallToolResult, error) {
+		a, _ := req.Params.Arguments["a"].(float64)
+		b, _ := req.Params.Arguments["b"].(float64)
+		return tmcp.NewTextResult(fmt.Sprintf("%g", a+b)), nil
+	})
+
+	if opts.RegisterStructured {
+		type structuredOutput struct {
+			Message string `json:"message"`
+		}
+
+		structuredTool := tmcp.NewTool(
+			"structured_echo",
+			tmcp.WithDescription("Echo text as structured output."),
+			tmcp.WithString("text", tmcp.Required(), tmcp.Description("Text to echo.")),
+			tmcp.WithOutputStruct[structuredOutput](),
+		)
+		mcpServer.RegisterTool(structuredTool, func(ctx context.Context, req *tmcp.CallToolRequest) (*tmcp.CallToolResult, error) {
+			text, _ := req.Params.Arguments["text"].(string)
+			message := "Echo: " + text
+			return &tmcp.CallToolResult{
+				Content:           []tmcp.Content{tmcp.NewTextContent("duplicate text: " + message)},
+				StructuredContent: map[string]any{"message": message},
+			}, nil
+		})
+	}
+
+	if opts.RegisterDottedTool {
+		dottedTool := tmcp.NewTool(
+			"smartsheet.list_tables",
+			tmcp.WithDescription("List tables for a smart sheet."),
+			tmcp.WithString("file_id", tmcp.Required(), tmcp.Description("Sheet file id.")),
+		)
+		mcpServer.RegisterTool(dottedTool, func(ctx context.Context, req *tmcp.CallToolRequest) (*tmcp.CallToolResult, error) {
+			fileID, _ := req.Params.Arguments["file_id"].(string)
+			return tmcp.NewTextResult("tables for " + fileID), nil
+		})
+	}
+
+	result := &brokerHTTPServer{
+		methodCount:  map[string]int{},
+		requiredAuth: opts.RequiredAuth,
+	}
+
+	baseHandler := mcpServer.HTTPHandler()
+	result.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader := r.Header.Get("Authorization")
+		if result.requiredAuth != "" && authHeader != result.requiredAuth {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		if r.Method == http.MethodPost {
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			r.Body = io.NopCloser(bytes.NewReader(body))
+
+			var request struct {
+				Method string `json:"method"`
+			}
+			if err := json.Unmarshal(body, &request); err == nil && request.Method != "" {
+				result.mu.Lock()
+				result.methodCount[request.Method]++
+				result.mu.Unlock()
+			}
+		}
+
+		result.mu.Lock()
+		result.lastXTest = r.Header.Get("X-Test")
+		result.lastAuth = authHeader
+		result.mu.Unlock()
+
+		baseHandler.ServeHTTP(w, r)
+	}))
+	serverPath := opts.ServerPath
+	if strings.TrimSpace(serverPath) == "" {
+		serverPath = "/mcp"
+	}
+	result.URL = result.server.URL + serverPath
+	return result
+}
+
+func (s *brokerHTTPServer) Close() {
+	s.server.Close()
+}
+
+func (s *brokerHTTPServer) MethodCount(method string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.methodCount[method]
+}
+
+func (s *brokerHTTPServer) LastXTest() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastXTest
+}
+
+func (s *brokerHTTPServer) LastAuthorization() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastAuth
+}
+
+func packageDir(t *testing.T) string {
+	t.Helper()
+	_, currentFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	return filepath.Dir(currentFile)
+}
+
+func stdioServerDir(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(packageDir(t), "testdata", "stdio_server")
+}
+
+func TestListServers_ReturnsConfiguredServers(t *testing.T) {
+	broker := New(
+		WithServers(map[string]legacymcp.ConnectionConfig{
+			"from_code": {
+				Command: "go",
+				Args:    []string{"run", "./server"},
+			},
+		}),
+	)
+
+	output, err := broker.listServers(context.Background(), listServersInput{})
+	require.NoError(t, err)
+	require.Len(t, output.Servers, 1)
+
+	require.Equal(t, "from_code", output.Servers[0].Name)
+	require.Equal(t, "stdio", output.Servers[0].Transport)
+}
+
+func TestResolveNamedServers_TrimsNamesAndRejectsCollisions(t *testing.T) {
+	broker := New(WithServers(map[string]legacymcp.ConnectionConfig{
+		" trimmed ": {
+			Command: "go",
+		},
+	}))
+
+	servers, merged, err := broker.resolveNamedServers()
+	require.NoError(t, err)
+	require.Len(t, servers, 1)
+	require.Equal(t, "trimmed", servers[0].Name)
+	require.Contains(t, merged, "trimmed")
+	require.NotContains(t, merged, " trimmed ")
+
+	target, err := broker.resolveTarget(targetInput{ServerName: " trimmed "})
+	require.NoError(t, err)
+	require.Equal(t, "trimmed", target.Name)
+
+	broker = New(WithServers(map[string]legacymcp.ConnectionConfig{
+		"dup": {
+			Command: "go",
+		},
+		" dup ": {
+			Command: "go",
+		},
+	}))
+	_, _, err = broker.resolveNamedServers()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duplicate MCP server name")
+}
+
+func TestListTools_TargetValidation(t *testing.T) {
+	broker := New(WithServers(map[string]legacymcp.ConnectionConfig{
+		"named": {
+			Command: "go",
+			Args:    []string{"run", stdioServerDir(t)},
+			Timeout: 10 * time.Second,
+		},
+	}))
+
+	_, err := broker.listTools(context.Background(), listToolsInput{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "selector is required")
+
+	output, err := broker.listTools(context.Background(), listToolsInput{
+		Selector:  "named",
+		Transport: "streamable",
+		Headers:   map[string]string{"X-Test": "ignored"},
+	})
+	require.NoError(t, err)
+	require.Len(t, output.Tools, 2)
+}
+
+func TestListTools_ReturnsBriefSummariesOnly(t *testing.T) {
+	server := startBrokerHTTPServer(t)
+	defer server.Close()
+
+	broker := New(WithAllowAdHocHTTP(true))
+
+	output, err := broker.listTools(context.Background(), listToolsInput{Selector: server.URL})
+	require.NoError(t, err)
+	require.Len(t, output.Tools, 2)
+	require.NotEmpty(t, output.Tools[0].Signature)
+}
+
+func TestInspectTools_ReturnsInputSchemaOnlyByDefault(t *testing.T) {
+	server := startBrokerHTTPServer(t)
+	defer server.Close()
+
+	broker := New(WithAllowAdHocHTTP(true))
+	output, err := broker.inspectTools(context.Background(), inspectToolsInput{
+		Selector: server.URL,
+		Tools:    []string{"echo"},
+	})
+	require.NoError(t, err)
+	require.Len(t, output.Tools, 1)
+	require.NotNil(t, output.Tools[0].InputSchema)
+	require.Contains(t, output.Tools[0].InputSchema, "properties")
+	require.Nil(t, output.Tools[0].OutputSchema)
+	require.True(t, output.Tools[0].HasOutputSchema)
+}
+
+func TestInspectTools_IncludeOutputSchema(t *testing.T) {
+	server := startBrokerHTTPServer(t)
+	defer server.Close()
+
+	broker := New(WithAllowAdHocHTTP(true))
+	output, err := broker.inspectTools(context.Background(), inspectToolsInput{
+		Selector:            server.URL,
+		Tools:               []string{"echo"},
+		IncludeOutputSchema: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, output.Tools, 1)
+	require.NotNil(t, output.Tools[0].OutputSchema)
+	require.Contains(t, output.Tools[0].OutputSchema, "properties")
+}
+
+func TestInspectTools_Validation(t *testing.T) {
+	server := startBrokerHTTPServer(t)
+	defer server.Close()
+
+	broker := New(WithAllowAdHocHTTP(true))
+
+	_, err := broker.inspectTools(context.Background(), inspectToolsInput{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "tools is required")
+
+	_, err = broker.inspectTools(context.Background(), inspectToolsInput{
+		Selector: server.URL,
+		Tools:    []string{"missing"},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "requested MCP tools not found")
+}
+
+func TestAdHocHeaderDenylist_IsCaseInsensitive(t *testing.T) {
+	server := startBrokerHTTPServer(t)
+	defer server.Close()
+
+	broker := New(WithAllowAdHocHTTP(true))
+	_, err := broker.listTools(context.Background(), listToolsInput{
+		Selector: server.URL,
+		Headers:  map[string]string{"AUTHORIZATION": "Bearer token"},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not allowed")
+}
+
+func TestNamedStdioServer_ListTools(t *testing.T) {
+	broker := New(WithServers(map[string]legacymcp.ConnectionConfig{
+		"local_stdio": {
+			Command: "go",
+			Args:    []string{"run", stdioServerDir(t)},
+			Timeout: 10 * time.Second,
+		},
+	}))
+
+	output, err := broker.listTools(context.Background(), listToolsInput{
+		Selector: "local_stdio",
+	})
+	require.NoError(t, err)
+	require.Len(t, output.Tools, 2)
+	require.Equal(t, "add", output.Tools[0].Name)
+	require.Equal(t, "echo", output.Tools[1].Name)
+	require.Equal(t, "local_stdio.add", output.Tools[0].Selector)
+}
+
+func TestNamedHTTPServer_ListToolsAndCallTool(t *testing.T) {
+	server := startBrokerHTTPServer(t)
+	defer server.Close()
+
+	broker := New(WithServers(map[string]legacymcp.ConnectionConfig{
+		"http_named": {
+			ServerURL: server.URL,
+			Transport: "streamable_http",
+			Timeout:   5 * time.Second,
+		},
+	}))
+
+	toolsOutput, err := broker.listTools(context.Background(), listToolsInput{
+		Selector: "http_named",
+	})
+	require.NoError(t, err)
+	require.Len(t, toolsOutput.Tools, 2)
+
+	callOutput, err := broker.callTool(context.Background(), callToolInput{
+		Selector:  "http_named.echo",
+		Arguments: map[string]any{"text": "hello"},
+	})
+	require.NoError(t, err)
+	require.Len(t, callOutput.Content, 1)
+
+	textContent, ok := callOutput.Content[0].(tmcp.TextContent)
+	require.True(t, ok)
+	require.Equal(t, "Echo: hello", textContent.Text)
+}
+
+func TestAdHocHTTPServer_ListToolsAndCallTool(t *testing.T) {
+	server := startBrokerHTTPServer(t)
+	defer server.Close()
+
+	broker := New(WithAllowAdHocHTTP(true))
+
+	toolsOutput, err := broker.listTools(context.Background(), listToolsInput{
+		Selector: server.URL,
+		Headers:  map[string]string{"X-Test": "from-list"},
+	})
+	require.NoError(t, err)
+	require.Len(t, toolsOutput.Tools, 2)
+	require.Equal(t, "from-list", server.LastXTest())
+
+	callOutput, err := broker.callTool(context.Background(), callToolInput{
+		Selector: server.URL + ".echo",
+		Headers:  map[string]string{"X-Test": "from-call"},
+		Arguments: map[string]any{
+			"text": "ad-hoc",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "from-call", server.LastXTest())
+	require.Len(t, callOutput.Content, 1)
+}
+
+func TestCallTool_PrefersStructuredContent(t *testing.T) {
+	server := startBrokerHTTPServerWithOptions(t, brokerHTTPServerOptions{
+		RegisterStructured: true,
+	})
+	defer server.Close()
+
+	broker := New(WithAllowAdHocHTTP(true))
+
+	callOutput, err := broker.callTool(context.Background(), callToolInput{
+		Selector:  server.URL + ".structured_echo",
+		Arguments: map[string]any{"text": "structured"},
+	})
+	require.NoError(t, err)
+	require.Empty(t, callOutput.Content)
+
+	structured, ok := callOutput.StructuredContent.(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "Echo: structured", structured["message"])
+}
+
+func TestAdHocHTTPServer_DottedToolSelectorRoundTrip(t *testing.T) {
+	server := startBrokerHTTPServerWithOptions(t, brokerHTTPServerOptions{
+		RegisterDottedTool: true,
+	})
+	defer server.Close()
+
+	broker := New(WithAllowAdHocHTTP(true))
+
+	toolsOutput, err := broker.listTools(context.Background(), listToolsInput{
+		Selector: server.URL,
+	})
+	require.NoError(t, err)
+	dottedSelector := ""
+	for _, listed := range toolsOutput.Tools {
+		if listed.Name == "smartsheet.list_tables" {
+			dottedSelector = listed.Selector
+			break
+		}
+	}
+	require.Equal(t, server.URL+".smartsheet.list_tables", dottedSelector)
+
+	callOutput, err := broker.callTool(context.Background(), callToolInput{
+		Selector:  dottedSelector,
+		Arguments: map[string]any{"file_id": "sheet_123"},
+	})
+	require.NoError(t, err)
+	require.Len(t, callOutput.Content, 1)
+
+	textContent, ok := callOutput.Content[0].(tmcp.TextContent)
+	require.True(t, ok)
+	require.Equal(t, "tables for sheet_123", textContent.Text)
+}
+
+func TestAdHocHTTPServer_FragmentToolSelectorStillSupported(t *testing.T) {
+	server := startBrokerHTTPServerWithOptions(t, brokerHTTPServerOptions{
+		RegisterDottedTool: true,
+	})
+	defer server.Close()
+
+	broker := New(WithAllowAdHocHTTP(true))
+
+	callOutput, err := broker.callTool(context.Background(), callToolInput{
+		Selector:  server.URL + "#tool=smartsheet.list_tables",
+		Arguments: map[string]any{"file_id": "sheet_456"},
+	})
+	require.NoError(t, err)
+	require.Len(t, callOutput.Content, 1)
+
+	textContent, ok := callOutput.Content[0].(tmcp.TextContent)
+	require.True(t, ok)
+	require.Equal(t, "tables for sheet_456", textContent.Text)
+}
+
+func TestAdHocHTTPServer_QuerySelectorUsesFragmentForm(t *testing.T) {
+	server := startBrokerHTTPServer(t)
+	defer server.Close()
+
+	selector := server.URL + "?tenant=alpha"
+	broker := New(WithAllowAdHocHTTP(true))
+
+	toolsOutput, err := broker.listTools(context.Background(), listToolsInput{
+		Selector: selector,
+	})
+	require.NoError(t, err)
+	echoSelector := ""
+	for _, listed := range toolsOutput.Tools {
+		if listed.Name == "echo" {
+			echoSelector = listed.Selector
+			break
+		}
+	}
+	require.Equal(t, selector+"#tool=echo", echoSelector)
+
+	callOutput, err := broker.callTool(context.Background(), callToolInput{
+		Selector:  echoSelector,
+		Arguments: map[string]any{"text": "query"},
+	})
+	require.NoError(t, err)
+	require.Len(t, callOutput.Content, 1)
+
+	textContent, ok := callOutput.Content[0].(tmcp.TextContent)
+	require.True(t, ok)
+	require.Equal(t, "Echo: query", textContent.Text)
+}
+
+func TestAdHocHTTPServer_DottedEndpointUsesFragmentForm(t *testing.T) {
+	server := startBrokerHTTPServerWithOptions(t, brokerHTTPServerOptions{
+		ServerPath: "/v1/mcp.v2",
+	})
+	defer server.Close()
+
+	broker := New(WithAllowAdHocHTTP(true))
+
+	toolsOutput, err := broker.listTools(context.Background(), listToolsInput{
+		Selector: server.URL,
+	})
+	require.NoError(t, err)
+	echoSelector := ""
+	for _, listed := range toolsOutput.Tools {
+		if listed.Name == "echo" {
+			echoSelector = listed.Selector
+			break
+		}
+	}
+	require.Equal(t, server.URL+"#tool=echo", echoSelector)
+
+	callOutput, err := broker.callTool(context.Background(), callToolInput{
+		Selector:  echoSelector,
+		Arguments: map[string]any{"text": "path-dot"},
+	})
+	require.NoError(t, err)
+	require.Len(t, callOutput.Content, 1)
+
+	textContent, ok := callOutput.Content[0].(tmcp.TextContent)
+	require.True(t, ok)
+	require.Equal(t, "Echo: path-dot", textContent.Text)
+}
+
+func TestNamedServerWithDots_RoundTrip(t *testing.T) {
+	server := startBrokerHTTPServerWithOptions(t, brokerHTTPServerOptions{
+		RegisterDottedTool: true,
+	})
+	defer server.Close()
+
+	broker := New(WithServers(map[string]legacymcp.ConnectionConfig{
+		"docs.prod": {
+			ServerURL: server.URL,
+			Transport: "streamable_http",
+			Timeout:   5 * time.Second,
+		},
+	}))
+
+	toolsOutput, err := broker.listTools(context.Background(), listToolsInput{
+		Selector: "docs.prod",
+	})
+	require.NoError(t, err)
+	dottedSelector := ""
+	for _, listed := range toolsOutput.Tools {
+		if listed.Name == "smartsheet.list_tables" {
+			dottedSelector = listed.Selector
+			break
+		}
+	}
+	require.Equal(t, "docs.prod.smartsheet.list_tables", dottedSelector)
+
+	callOutput, err := broker.callTool(context.Background(), callToolInput{
+		Selector:  dottedSelector,
+		Arguments: map[string]any{"file_id": "sheet_named"},
+	})
+	require.NoError(t, err)
+	require.Len(t, callOutput.Content, 1)
+
+	textContent, ok := callOutput.Content[0].(tmcp.TextContent)
+	require.True(t, ok)
+	require.Equal(t, "tables for sheet_named", textContent.Text)
+}
+
+func TestNamedHTTPServer_HeaderInjectorAddsAuthorization(t *testing.T) {
+	server := startBrokerHTTPServerWithOptions(t, brokerHTTPServerOptions{
+		RequiredAuth: "Bearer named-token",
+	})
+	defer server.Close()
+
+	type ctxKey string
+	const tokenKey ctxKey = "token"
+
+	broker := New(
+		WithServers(map[string]legacymcp.ConnectionConfig{
+			"http_named": {
+				ServerURL: server.URL,
+				Transport: "streamable_http",
+				Timeout:   5 * time.Second,
+			},
+		}),
+		WithHTTPHeaderInjector(func(ctx context.Context, req *HeaderInjectRequest) (map[string]string, error) {
+			if req.BaseURL != server.URL || req.Phase != phaseListTools {
+				return nil, nil
+			}
+			token, _ := ctx.Value(tokenKey).(string)
+			if token == "" {
+				return nil, nil
+			}
+			return map[string]string{
+				"Authorization": "Bearer " + token,
+			}, nil
+		}),
+	)
+
+	output, err := broker.listTools(context.WithValue(context.Background(), tokenKey, "named-token"), listToolsInput{
+		Selector: "http_named",
+	})
+	require.NoError(t, err)
+	require.Len(t, output.Tools, 2)
+	require.Equal(t, "Bearer named-token", server.LastAuthorization())
+}
+
+func TestAdHocHTTPServer_HeaderInjectorCanInjectAuthorization(t *testing.T) {
+	server := startBrokerHTTPServerWithOptions(t, brokerHTTPServerOptions{
+		RequiredAuth: "Bearer adhoc-token",
+	})
+	defer server.Close()
+
+	broker := New(
+		WithAllowAdHocHTTP(true),
+		WithHTTPHeaderInjector(func(ctx context.Context, req *HeaderInjectRequest) (map[string]string, error) {
+			require.True(t, req.IsAdHoc)
+			require.Equal(t, server.URL, req.BaseURL)
+			return map[string]string{
+				"Authorization": "Bearer adhoc-token",
+			}, nil
+		}),
+	)
+
+	output, err := broker.listTools(context.Background(), listToolsInput{
+		Selector: server.URL,
+	})
+	require.NoError(t, err)
+	require.Len(t, output.Tools, 2)
+	require.Equal(t, "Bearer adhoc-token", server.LastAuthorization())
+}
+
+func TestNamedHTTPServer_HeaderInjectorCanonicalizesOverrides(t *testing.T) {
+	server := startBrokerHTTPServerWithOptions(t, brokerHTTPServerOptions{
+		RequiredAuth: "Bearer injected-token",
+	})
+	defer server.Close()
+
+	broker := New(
+		WithServers(map[string]legacymcp.ConnectionConfig{
+			"http_named": {
+				ServerURL: server.URL,
+				Headers:   map[string]string{"authorization": "Bearer configured-token"},
+			},
+		}),
+		WithHTTPHeaderInjector(func(ctx context.Context, req *HeaderInjectRequest) (map[string]string, error) {
+			return map[string]string{"Authorization": "Bearer injected-token"}, nil
+		}),
+	)
+
+	output, err := broker.listTools(context.Background(), listToolsInput{
+		Selector: "http_named",
+	})
+	require.NoError(t, err)
+	require.Len(t, output.Tools, 2)
+	require.Equal(t, "Bearer injected-token", server.LastAuthorization())
+}
+
+func TestErrorInterceptor_CanWrapListToolsError(t *testing.T) {
+	server := startBrokerHTTPServerWithOptions(t, brokerHTTPServerOptions{
+		RequiredAuth: "Bearer missing-token",
+	})
+	defer server.Close()
+
+	broker := New(
+		WithAllowAdHocHTTP(true),
+		WithErrorInterceptor(func(ctx context.Context, req *BrokerErrorRequest) (*BrokerErrorDecision, error) {
+			require.Equal(t, phaseListTools, req.Phase)
+			require.Equal(t, server.URL, req.BaseURL)
+			return &BrokerErrorDecision{
+				Handled:   true,
+				WrapError: fmt.Errorf("connect this provider in the host application before retrying"),
+			}, nil
+		}),
+	)
+
+	_, err := broker.listTools(context.Background(), listToolsInput{
+		Selector: server.URL,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "connect this provider in the host application before retrying")
+}
+
+func TestErrorInterceptor_CanWrapCallError(t *testing.T) {
+	server := startBrokerHTTPServerWithOptions(t, brokerHTTPServerOptions{
+		RequiredAuth: "Bearer missing-token",
+	})
+	defer server.Close()
+
+	broker := New(
+		WithAllowAdHocHTTP(true),
+		WithErrorInterceptor(func(ctx context.Context, req *BrokerErrorRequest) (*BrokerErrorDecision, error) {
+			require.Equal(t, phaseCallTool, req.Phase)
+			require.Equal(t, "echo", req.ToolName)
+			return &BrokerErrorDecision{
+				Handled:   true,
+				WrapError: fmt.Errorf("authorization required for %s", req.BaseURL),
+			}, nil
+		}),
+	)
+
+	_, err := broker.callTool(context.Background(), callToolInput{
+		Selector:  server.URL + ".echo",
+		Arguments: map[string]any{"text": "hello"},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "authorization required")
+}
+
+func TestOneShot_ReinitializesPerCall(t *testing.T) {
+	server := startBrokerHTTPServer(t)
+	defer server.Close()
+
+	broker := New(WithServers(map[string]legacymcp.ConnectionConfig{
+		"http_named": {
+			ServerURL: server.URL,
+		},
+	}))
+
+	_, err := broker.listTools(context.Background(), listToolsInput{Selector: "http_named"})
+	require.NoError(t, err)
+	_, err = broker.listTools(context.Background(), listToolsInput{Selector: "http_named"})
+	require.NoError(t, err)
+
+	require.Equal(t, 2, server.MethodCount("initialize"))
+	require.Equal(t, 2, server.MethodCount("tools/list"))
+}
+
+func TestBrokerTools_CoexistWithLegacyMCPToolSet(t *testing.T) {
+	server := startBrokerHTTPServer(t)
+	defer server.Close()
+
+	legacyToolSet := legacymcp.NewMCPToolSet(legacymcp.ConnectionConfig{
+		Transport: "streamable_http",
+		ServerURL: server.URL,
+		Timeout:   5 * time.Second,
+	})
+	require.NoError(t, legacyToolSet.Init(context.Background()))
+	defer legacyToolSet.Close()
+
+	broker := New()
+	agent := llmagent.New(
+		"broker-agent",
+		llmagent.WithTools(broker.Tools()),
+		llmagent.WithToolSets([]agenttool.ToolSet{legacyToolSet}),
+	)
+
+	names := make([]string, 0, len(agent.Tools()))
+	for _, tl := range agent.Tools() {
+		names = append(names, tl.Declaration().Name)
+	}
+
+	require.Contains(t, names, listServersToolName)
+	require.Contains(t, names, listToolsToolName)
+	require.Contains(t, names, inspectToolsToolName)
+	require.Contains(t, names, callToolToolName)
+	require.Contains(t, names, "mcp_echo")
+}
+
+func TestBrokerTools_PublicSurface(t *testing.T) {
+	broker := New()
+
+	tools := broker.Tools()
+	require.Len(t, tools, 4)
+
+	names := []string{
+		tools[0].Declaration().Name,
+		tools[1].Declaration().Name,
+		tools[2].Declaration().Name,
+		tools[3].Declaration().Name,
+	}
+	require.ElementsMatch(t, []string{
+		listServersToolName,
+		listToolsToolName,
+		inspectToolsToolName,
+		callToolToolName,
+	}, names)
+}
+
+func TestBrokerTools_HaveExplicitOutputSchemas(t *testing.T) {
+	broker := New()
+
+	for _, tl := range broker.Tools() {
+		decl := tl.Declaration()
+		require.NotNil(t, decl.OutputSchema, decl.Name)
+		require.Equal(t, "object", decl.OutputSchema.Type, decl.Name)
+	}
+}
+
+func TestCallTool_MissingSelector(t *testing.T) {
+	server := startBrokerHTTPServer(t)
+	defer server.Close()
+
+	broker := New(WithAllowAdHocHTTP(true))
+	_, err := broker.callTool(context.Background(), callToolInput{
+		Arguments: map[string]any{},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "selector is required")
+}
+
+func TestCallTool_MissingArgumentsObject(t *testing.T) {
+	server := startBrokerHTTPServer(t)
+	defer server.Close()
+
+	broker := New(WithAllowAdHocHTTP(true))
+	_, err := broker.callTool(context.Background(), callToolInput{
+		Selector: server.URL + ".echo",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "arguments is required")
+}
+
+func TestCallTool_MissingRequiredArguments(t *testing.T) {
+	server := startBrokerHTTPServer(t)
+	defer server.Close()
+
+	broker := New(WithAllowAdHocHTTP(true))
+	_, err := broker.callTool(context.Background(), callToolInput{
+		Selector:  server.URL + ".add",
+		Arguments: map[string]any{},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `missing required arguments for MCP tool "add": a, b`)
+}
+
+func TestCallTool_ExplicitNullRequiredArgumentIsNotMissing(t *testing.T) {
+	server := startBrokerHTTPServer(t)
+	defer server.Close()
+
+	broker := New(WithAllowAdHocHTTP(true))
+	output, err := broker.callTool(context.Background(), callToolInput{
+		Selector:  server.URL + ".echo",
+		Arguments: map[string]any{"text": nil},
+	})
+	require.NoError(t, err)
+	require.Len(t, output.Content, 1)
+}
+
+func TestCallTool_NamedServerIgnoresAdHocNoiseAndValidatesArguments(t *testing.T) {
+	server := startBrokerHTTPServer(t)
+	defer server.Close()
+
+	broker := New(WithServers(map[string]legacymcp.ConnectionConfig{
+		"http_named": {
+			ServerURL: server.URL,
+			Transport: "streamable_http",
+			Timeout:   5 * time.Second,
+		},
+	}))
+
+	_, err := broker.callTool(context.Background(), callToolInput{
+		Selector:  "http_named.add",
+		Transport: "streamable",
+		Headers:   map[string]string{"X-Test": "ignored"},
+		Arguments: map[string]any{},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `missing required arguments for MCP tool "add": a, b`)
+}
+
+func TestAllowCustomDenylistHeaders(t *testing.T) {
+	server := startBrokerHTTPServer(t)
+	defer server.Close()
+
+	broker := New(
+		WithAllowAdHocHTTP(true),
+		WithAdHocSensitiveHeaderDenylist([]string{"X-Internal-Token"}),
+	)
+
+	_, err := broker.listTools(context.Background(), listToolsInput{
+		Selector: server.URL,
+		Headers:  map[string]string{"x-internal-token": "secret"},
+	})
+	require.Error(t, err)
+	require.Contains(t, strings.ToLower(err.Error()), "x-internal-token")
+}
+
+func TestSelectToolsForInspection_MatchesExactCase(t *testing.T) {
+	selected, err := selectToolsForInspection([]tmcp.Tool{
+		{Name: "Foo"},
+		{Name: "foo"},
+	}, []string{"foo"})
+	require.NoError(t, err)
+	require.Len(t, selected, 1)
+	require.Equal(t, "foo", selected[0].Name)
+
+	_, err = selectToolsForInspection([]tmcp.Tool{{Name: "Foo"}}, []string{"foo"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "foo")
+}
+
+func TestSelectToolsForInspection_RejectsEmptyAndDeduplicates(t *testing.T) {
+	tools := []tmcp.Tool{{Name: "alpha"}, {Name: "beta"}}
+
+	selected, err := selectToolsForInspection(tools, []string{"alpha", " alpha ", "beta"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"alpha", "beta"}, []string{selected[0].Name, selected[1].Name})
+
+	_, err = selectToolsForInspection(tools, []string{" "})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "empty tool names")
+}
+
+func TestResolveTargetValidation(t *testing.T) {
+	broker := New(WithServers(map[string]legacymcp.ConnectionConfig{
+		"named": {Command: "go"},
+	}))
+
+	_, err := broker.resolveTarget(targetInput{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exactly one")
+
+	_, err = broker.resolveTarget(targetInput{ServerName: "missing"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown MCP server")
+
+	_, err = broker.resolveTarget(targetInput{URL: "https://example.com/mcp"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ad-hoc HTTP MCP is disabled")
+
+	target, err := New(WithAllowAdHocHTTP(true)).resolveTarget(targetInput{URL: "https://example.com/mcp"})
+	require.NoError(t, err)
+	require.Equal(t, "adhoc", target.Origin)
+	require.Equal(t, targetTypeHTTP, target.TargetType)
+}
+
+func TestSplitNamedToolSelectorBranches(t *testing.T) {
+	broker := New(WithServers(map[string]legacymcp.ConnectionConfig{
+		"docs":      {Command: "go"},
+		"docs.prod": {Command: "go"},
+	}))
+
+	server, toolName, err := broker.splitNamedToolSelector("docs.prod.smartsheet.list_tables")
+	require.NoError(t, err)
+	require.Equal(t, "docs.prod", server)
+	require.Equal(t, "smartsheet.list_tables", toolName)
+
+	server, toolName, err = broker.splitNamedToolSelector("docs.echo")
+	require.NoError(t, err)
+	require.Equal(t, "docs", server)
+	require.Equal(t, "echo", toolName)
+
+	_, _, err = broker.splitNamedToolSelector("")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "selector is required")
+
+	_, _, err = broker.splitNamedToolSelector("docs.")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "call selector")
+
+	_, _, err = broker.splitNamedToolSelector("missing.echo")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown MCP server")
+}
+
+func TestSplitHTTPToolSelectorBranches(t *testing.T) {
+	baseURL, toolName, err := splitHTTPToolSelector("https://example.com/mcp#tool=smartsheet.list_tables")
+	require.NoError(t, err)
+	require.Equal(t, "https://example.com/mcp", baseURL)
+	require.Equal(t, "smartsheet.list_tables", toolName)
+
+	baseURL, toolName, err = splitHTTPToolSelector("https://example.com/mcp.echo")
+	require.NoError(t, err)
+	require.Equal(t, "https://example.com/mcp", baseURL)
+	require.Equal(t, "echo", toolName)
+
+	for _, selector := range []string{
+		"https://example.com/mcp#tool=",
+		"#tool=echo",
+		"https://example.com/mcp",
+		"https://example.com/.echo",
+		"://bad",
+	} {
+		_, _, err = splitHTTPToolSelector(selector)
+		require.Error(t, err, selector)
+	}
+}
+
+func TestSelectorFormattingHelpers(t *testing.T) {
+	require.Equal(t, "", joinToolSelector("", "echo"))
+	require.Equal(t, "", joinToolSelector("server", ""))
+	require.Equal(t, "https://example.com/mcp?tenant=alpha#tool=echo", joinToolSelector("https://example.com/mcp?tenant=alpha", "echo"))
+	require.Equal(t, "https://example.com/v1/mcp.v2#tool=echo", joinToolSelector("https://example.com/v1/mcp.v2", "echo"))
+	require.Equal(t, "server.echo", joinToolSelector("server", "echo"))
+
+	require.True(t, shouldUseFragmentHTTPToolSelector("%"))
+	require.False(t, shouldUseFragmentHTTPToolSelector("https://example.com"))
+}
+
+func TestHeaderHelpers(t *testing.T) {
+	require.Nil(t, mergeHeaders(nil, nil))
+	require.Equal(t, map[string]string{"Authorization": "Bearer token"}, mergeHeaders(nil, map[string]string{"authorization": "Bearer token"}))
+	require.Equal(t, map[string]string{"X-Test": "base"}, mergeHeaders(map[string]string{"x-test": "base"}, nil))
+	require.Equal(t, map[string]string{"Authorization": "Bearer extra"}, mergeHeaders(
+		map[string]string{"authorization": "Bearer base"},
+		map[string]string{"Authorization": "Bearer extra", " ": "ignored"},
+	))
+	require.Equal(t, map[string]string{"X-Test": "ok"}, canonicalizeHeaders(map[string]string{" x-test ": "ok", " ": "ignored"}))
+	require.Nil(t, httpHeaderOptions(nil))
+	require.NotNil(t, httpHeaderOptions(map[string]string{" x-test ": "ok", " ": "ignored"}))
+}
+
+func TestErrorInterceptorBranches(t *testing.T) {
+	ctx := context.Background()
+	broker := New()
+	target := resolvedTarget{TargetType: targetTypeHTTP, Config: legacymcp.ConnectionConfig{Transport: "streamable"}}
+	meta := operationMetadata{Selector: "https://example.com/mcp", BaseURL: "https://example.com/mcp", Phase: phaseListTools}
+
+	handled, err := interceptHTTPOperationError(ctx, broker, target, meta, nil)
+	require.False(t, handled)
+	require.NoError(t, err)
+
+	handled, err = interceptHTTPOperationError(ctx, broker, resolvedTarget{TargetType: targetTypeStdio}, meta, fmt.Errorf("boom"))
+	require.False(t, handled)
+	require.Error(t, err)
+
+	broker = New(WithErrorInterceptor(func(context.Context, *BrokerErrorRequest) (*BrokerErrorDecision, error) {
+		return nil, nil
+	}))
+	handled, err = interceptHTTPOperationError(ctx, broker, target, meta, fmt.Errorf("boom"))
+	require.False(t, handled)
+	require.Error(t, err)
+
+	broker = New(WithErrorInterceptor(func(context.Context, *BrokerErrorRequest) (*BrokerErrorDecision, error) {
+		return nil, fmt.Errorf("interceptor failed")
+	}))
+	handled, err = interceptHTTPOperationError(ctx, broker, target, meta, fmt.Errorf("boom"))
+	require.True(t, handled)
+	require.Contains(t, err.Error(), "interceptor failed")
+
+	broker = New(WithErrorInterceptor(func(context.Context, *BrokerErrorRequest) (*BrokerErrorDecision, error) {
+		return &BrokerErrorDecision{Handled: true}, nil
+	}))
+	handled, err = interceptHTTPOperationError(ctx, broker, target, meta, fmt.Errorf("boom"))
+	require.True(t, handled)
+	require.Contains(t, err.Error(), "returned no wrapped error")
+}
+
+func TestSchemaHelpers(t *testing.T) {
+	require.Equal(t, "unknown", schemaTypeName(nil))
+	require.Equal(t, "unknown", schemaTypeName(map[string]any{}))
+	require.Equal(t, "string", schemaTypeName(map[string]any{"type": "string"}))
+	require.Equal(t, "number", schemaTypeName(map[string]any{"type": []any{"number"}}))
+	require.Equal(t, "array", schemaTypeName(map[string]any{"type": "array"}))
+	require.Equal(t, "array<string>", schemaTypeName(map[string]any{
+		"type":  "array",
+		"items": map[string]any{"type": "string"},
+	}))
+	require.Equal(t, "object", schemaTypeName(map[string]any{"type": "object"}))
+
+	_, ok := firstSchemaType([]any{""})
+	require.False(t, ok)
+	value, ok := firstSchemaType([]any{"boolean"})
+	require.True(t, ok)
+	require.Equal(t, "boolean", value)
+
+	require.Nil(t, schemaToMap(nil))
+	require.Nil(t, schemaToMap(make(chan int)))
+	require.Nil(t, schemaToMap([]string{"not", "an", "object"}))
+	require.Equal(t, "string", schemaToMap(map[string]any{"type": "string"})["type"])
+}
+
+func TestRenderToolSignature(t *testing.T) {
+	toolWithSchema := tmcp.NewTool(
+		"search",
+		tmcp.WithString("query", tmcp.Required()),
+		tmcp.WithNumber("limit"),
+	)
+	require.Equal(t, "search(query: string, limit?: number)", renderToolSignature(*toolWithSchema))
+
+	require.Equal(t, "empty()", renderToolSignature(tmcp.Tool{Name: "empty"}))
+}
+
+func TestWithTimeoutContext_UsesShorterDeadline(t *testing.T) {
+	parentLong, parentCancel := context.WithTimeout(context.Background(), time.Hour)
+	defer parentCancel()
+
+	child, cancel := withTimeoutContext(parentLong, 50*time.Millisecond)
+	defer cancel()
+
+	deadline, ok := child.Deadline()
+	require.True(t, ok)
+	require.Less(t, time.Until(deadline), time.Second)
+
+	parentShort, parentShortCancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer parentShortCancel()
+
+	child, cancel = withTimeoutContext(parentShort, time.Hour)
+	defer cancel()
+
+	childDeadline, ok := child.Deadline()
+	require.True(t, ok)
+	parentDeadline, ok := parentShort.Deadline()
+	require.True(t, ok)
+	require.Equal(t, parentDeadline, childDeadline)
+}
+
+func TestNormalizeConnectionConfigValidation(t *testing.T) {
+	_, _, err := normalizeConnectionConfig(legacymcp.ConnectionConfig{}, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "transport is required")
+
+	_, _, err = normalizeConnectionConfig(legacymcp.ConnectionConfig{
+		Command: "go",
+		Headers: map[string]string{
+			"X-Test": "bad",
+		},
+	}, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "stdio MCP cannot specify headers")
+
+	_, _, err = normalizeConnectionConfig(legacymcp.ConnectionConfig{
+		ServerURL: "ftp://example.com/mcp",
+	}, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "requires http or https")
+
+	_, _, err = normalizeConnectionConfig(legacymcp.ConnectionConfig{
+		ServerURL: "https://example.com/mcp",
+		Timeout:   -time.Second,
+	}, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "non-negative")
+
+	cfg, kind, err := normalizeConnectionConfig(legacymcp.ConnectionConfig{
+		ServerURL: "https://example.com/mcp",
+		Transport: "http",
+		Headers:   map[string]string{"X-Test": "ok"},
+	}, false)
+	require.NoError(t, err)
+	require.Equal(t, transportStreamable, kind)
+	require.Equal(t, "streamable", cfg.Transport)
+	require.Equal(t, "ok", cfg.Headers["X-Test"])
+
+	_, _, err = normalizeConnectionConfig(legacymcp.ConnectionConfig{
+		Command:   "go",
+		Transport: "stdio",
+	}, true)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ad-hoc MCP only supports HTTP")
+}

--- a/tool/mcpbroker/client.go
+++ b/tool/mcpbroker/client.go
@@ -1,0 +1,274 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package mcpbroker
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	mcpcfg "trpc.group/trpc-go/trpc-agent-go/tool/mcp"
+	tmcp "trpc.group/trpc-go/trpc-mcp-go"
+)
+
+var defaultClientInfo = tmcp.Implementation{
+	Name:    "trpc-agent-go",
+	Version: "1.0.0",
+}
+
+type resolvedTarget struct {
+	Name       string
+	Origin     string
+	TargetType string
+	Config     mcpcfg.ConnectionConfig
+}
+
+type targetInput struct {
+	ServerName string            `json:"server_name,omitempty"`
+	URL        string            `json:"url,omitempty"`
+	Transport  string            `json:"transport,omitempty"`
+	Headers    map[string]string `json:"headers,omitempty"`
+}
+
+const (
+	phaseListTools    = "list_tools"
+	phaseInspectTools = "inspect_tools"
+	phaseCallTool     = "call_tool"
+)
+
+type operationMetadata struct {
+	Selector string
+	BaseURL  string
+	ToolName string
+	Phase    string
+}
+
+func (b *Broker) buildAdHocConfig(input targetInput) (mcpcfg.ConnectionConfig, string, error) {
+	headers, err := b.sanitizeAdHocHeaders(input.Headers)
+	if err != nil {
+		return mcpcfg.ConnectionConfig{}, "", err
+	}
+
+	cfg, kind, err := normalizeConnectionConfig(mcpcfg.ConnectionConfig{
+		Transport: strings.TrimSpace(input.Transport),
+		ServerURL: strings.TrimSpace(input.URL),
+		Headers:   headers,
+	}, true)
+	if err != nil {
+		return mcpcfg.ConnectionConfig{}, "", err
+	}
+
+	targetType := targetTypeHTTP
+	if kind == transportStdio {
+		targetType = targetTypeStdio
+	}
+	return cfg, targetType, nil
+}
+
+func (b *Broker) sanitizeAdHocHeaders(headers map[string]string) (map[string]string, error) {
+	if len(headers) == 0 {
+		return nil, nil
+	}
+
+	result := make(map[string]string, len(headers))
+	for key, value := range headers {
+		normalized := strings.ToLower(strings.TrimSpace(key))
+		if normalized == "" {
+			return nil, fmt.Errorf("ad-hoc header name cannot be empty")
+		}
+		if _, denied := b.options.adhocSensitiveHeaderDenyset[normalized]; denied {
+			return nil, fmt.Errorf("ad-hoc header %q is not allowed", key)
+		}
+		result[http.CanonicalHeaderKey(strings.TrimSpace(key))] = value
+	}
+	return result, nil
+}
+
+func (b *Broker) withPreparedHTTPHeaders(
+	ctx context.Context,
+	target resolvedTarget,
+	meta operationMetadata,
+) (mcpcfg.ConnectionConfig, error) {
+	cfg := cloneConnectionConfig(target.Config)
+	if target.TargetType != targetTypeHTTP {
+		return cfg, nil
+	}
+
+	if b.options.httpHeaderInjector == nil {
+		return cfg, nil
+	}
+	isAdHoc := target.Origin == "adhoc"
+	injected, err := b.options.httpHeaderInjector(ctx, &HeaderInjectRequest{
+		Selector:  meta.Selector,
+		BaseURL:   meta.BaseURL,
+		ToolName:  meta.ToolName,
+		Phase:     meta.Phase,
+		Transport: cfg.Transport,
+		IsAdHoc:   isAdHoc,
+	})
+	if err != nil {
+		return mcpcfg.ConnectionConfig{}, err
+	}
+	if len(injected) == 0 {
+		return cfg, nil
+	}
+
+	cfg.Headers = mergeHeaders(cfg.Headers, injected)
+	return cfg, nil
+}
+
+func mergeHeaders(base map[string]string, extra map[string]string) map[string]string {
+	switch {
+	case len(base) == 0 && len(extra) == 0:
+		return nil
+	case len(base) == 0:
+		return canonicalizeHeaders(extra)
+	case len(extra) == 0:
+		return canonicalizeHeaders(base)
+	}
+
+	result := canonicalizeHeaders(base)
+	for key, value := range extra {
+		trimmed := strings.TrimSpace(key)
+		if trimmed == "" {
+			continue
+		}
+		result[http.CanonicalHeaderKey(trimmed)] = value
+	}
+	return result
+}
+
+func canonicalizeHeaders(headers map[string]string) map[string]string {
+	if len(headers) == 0 {
+		return nil
+	}
+	result := make(map[string]string, len(headers))
+	for key, value := range headers {
+		trimmed := strings.TrimSpace(key)
+		if trimmed == "" {
+			continue
+		}
+		result[http.CanonicalHeaderKey(trimmed)] = value
+	}
+	return result
+}
+
+func interceptHTTPOperationError(
+	ctx context.Context,
+	b *Broker,
+	target resolvedTarget,
+	meta operationMetadata,
+	err error,
+) (bool, error) {
+
+	if err == nil || target.TargetType != targetTypeHTTP || b.options.errorInterceptor == nil {
+		return false, err
+	}
+
+	decision, interceptErr := b.options.errorInterceptor(ctx, &BrokerErrorRequest{
+		Selector:  meta.Selector,
+		BaseURL:   meta.BaseURL,
+		ToolName:  meta.ToolName,
+		Phase:     meta.Phase,
+		Transport: target.Config.Transport,
+		IsAdHoc:   target.Origin == "adhoc",
+		Err:       err,
+	})
+	if interceptErr != nil {
+		return true, interceptErr
+	}
+	if decision == nil || !decision.Handled {
+		return false, err
+	}
+	if decision.WrapError != nil {
+		return true, decision.WrapError
+	}
+	return true, fmt.Errorf("broker error interceptor handled the error but returned no wrapped error")
+}
+
+func createClient(cfg mcpcfg.ConnectionConfig) (tmcp.Connector, error) {
+	clientInfo := cfg.ClientInfo
+	if clientInfo.Name == "" {
+		clientInfo = defaultClientInfo
+	}
+
+	_, kind, err := normalizeConnectionConfig(cfg, false)
+	if err != nil {
+		return nil, err
+	}
+
+	switch kind {
+	case transportStdio:
+		return tmcp.NewStdioClient(tmcp.StdioTransportConfig{
+			ServerParams: tmcp.StdioServerParameters{
+				Command: cfg.Command,
+				Args:    cfg.Args,
+			},
+			Timeout: cfg.Timeout,
+		}, clientInfo)
+	case transportSSE:
+		return tmcp.NewSSEClient(cfg.ServerURL, clientInfo, httpHeaderOptions(cfg.Headers)...)
+	case transportStreamable:
+		return tmcp.NewClient(cfg.ServerURL, clientInfo, httpHeaderOptions(cfg.Headers)...)
+	default:
+		return nil, fmt.Errorf("unsupported transport: %s", cfg.Transport)
+	}
+}
+
+func httpHeaderOptions(headers map[string]string) []tmcp.ClientOption {
+	if len(headers) == 0 {
+		return nil
+	}
+
+	httpHeaders := http.Header{}
+	for key, value := range headers {
+		trimmed := strings.TrimSpace(key)
+		if trimmed == "" {
+			continue
+		}
+		httpHeaders.Set(http.CanonicalHeaderKey(trimmed), value)
+	}
+	return []tmcp.ClientOption{tmcp.WithHTTPHeaders(httpHeaders)}
+}
+
+func withTimeoutContext(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if timeout <= 0 {
+		return ctx, func() {}
+	}
+	timeoutDeadline := time.Now().Add(timeout)
+	if deadline, hasDeadline := ctx.Deadline(); hasDeadline && deadline.Before(timeoutDeadline) {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, timeout)
+}
+
+func withOneShotClient[T any](ctx context.Context, cfg mcpcfg.ConnectionConfig, fn func(context.Context, tmcp.Connector) (T, error)) (T, error) {
+	var zero T
+
+	client, err := createClient(cfg)
+	if err != nil {
+		return zero, err
+	}
+	defer client.Close()
+
+	initCtx, cancel := withTimeoutContext(ctx, cfg.Timeout)
+	defer cancel()
+
+	if _, err := client.Initialize(initCtx, &tmcp.InitializeRequest{}); err != nil {
+		return zero, fmt.Errorf("initialize MCP client: %w", err)
+	}
+
+	opCtx, opCancel := withTimeoutContext(ctx, cfg.Timeout)
+	defer opCancel()
+
+	return fn(opCtx, client)
+}

--- a/tool/mcpbroker/config.go
+++ b/tool/mcpbroker/config.go
@@ -1,0 +1,162 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package mcpbroker
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	mcpcfg "trpc.group/trpc-go/trpc-agent-go/tool/mcp"
+)
+
+type transportKind string
+
+const (
+	transportStdio      transportKind = "stdio"
+	transportSSE        transportKind = "sse"
+	transportStreamable transportKind = "streamable"
+)
+
+func normalizeNamedServer(name string, cfg mcpcfg.ConnectionConfig, origin string) (namedServer, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return namedServer{}, fmt.Errorf("MCP server name cannot be empty")
+	}
+
+	normalizedCfg, kind, err := normalizeConnectionConfig(cfg, false)
+	if err != nil {
+		return namedServer{}, fmt.Errorf("invalid MCP server %q: %w", name, err)
+	}
+
+	targetType := targetTypeHTTP
+	if kind == transportStdio {
+		targetType = targetTypeStdio
+	}
+
+	return namedServer{
+		Name:       name,
+		Origin:     origin,
+		TargetType: targetType,
+		Config:     normalizedCfg,
+	}, nil
+}
+
+func normalizeConnectionConfig(cfg mcpcfg.ConnectionConfig, adHoc bool) (mcpcfg.ConnectionConfig, transportKind, error) {
+	command := strings.TrimSpace(cfg.Command)
+	serverURL := strings.TrimSpace(cfg.ServerURL)
+	transport, kind, err := normalizeTransport(cfg.Transport, command != "", serverURL != "", adHoc)
+	if err != nil {
+		return mcpcfg.ConnectionConfig{}, "", err
+	}
+
+	if cfg.Timeout < 0 {
+		return mcpcfg.ConnectionConfig{}, "", fmt.Errorf("timeout must be non-negative")
+	}
+
+	switch kind {
+	case transportStdio:
+		if command == "" {
+			return mcpcfg.ConnectionConfig{}, "", fmt.Errorf("stdio MCP requires command")
+		}
+		if serverURL != "" {
+			return mcpcfg.ConnectionConfig{}, "", fmt.Errorf("stdio MCP cannot specify server_url")
+		}
+		if len(cfg.Headers) > 0 {
+			return mcpcfg.ConnectionConfig{}, "", fmt.Errorf("stdio MCP cannot specify headers")
+		}
+	case transportSSE, transportStreamable:
+		if serverURL == "" {
+			return mcpcfg.ConnectionConfig{}, "", fmt.Errorf("HTTP MCP requires server_url")
+		}
+		if command != "" {
+			return mcpcfg.ConnectionConfig{}, "", fmt.Errorf("HTTP MCP cannot specify command")
+		}
+		parsedURL, parseErr := url.Parse(serverURL)
+		if parseErr != nil {
+			return mcpcfg.ConnectionConfig{}, "", fmt.Errorf("invalid server_url %q: %w", serverURL, parseErr)
+		}
+		if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+			return mcpcfg.ConnectionConfig{}, "", fmt.Errorf("HTTP MCP requires http or https URL")
+		}
+		if parsedURL.Host == "" {
+			return mcpcfg.ConnectionConfig{}, "", fmt.Errorf("HTTP MCP requires URL host")
+		}
+	default:
+		return mcpcfg.ConnectionConfig{}, "", fmt.Errorf("unsupported transport")
+	}
+
+	return mcpcfg.ConnectionConfig{
+		Transport:  transport,
+		ServerURL:  serverURL,
+		Headers:    cloneStringMap(cfg.Headers),
+		Command:    command,
+		Args:       cloneStringSlice(cfg.Args),
+		Timeout:    cfg.Timeout,
+		ClientInfo: cfg.ClientInfo,
+	}, kind, nil
+}
+
+func normalizeTransport(raw string, hasCommand, hasURL, adHoc bool) (string, transportKind, error) {
+	value := strings.ToLower(strings.TrimSpace(raw))
+	if value == "" {
+		switch {
+		case hasCommand && !hasURL:
+			return string(transportStdio), transportStdio, nil
+		case hasURL && !hasCommand:
+			return string(transportStreamable), transportStreamable, nil
+		default:
+			return "", "", fmt.Errorf("transport is required when command/url cannot be inferred")
+		}
+	}
+
+	switch value {
+	case "stdio":
+		if adHoc {
+			return "", "", fmt.Errorf("ad-hoc MCP only supports HTTP transports")
+		}
+		return value, transportStdio, nil
+	case "sse":
+		return value, transportSSE, nil
+	case "streamable", "streamable_http", "http":
+		return string(transportStreamable), transportStreamable, nil
+	default:
+		if adHoc {
+			return "", "", fmt.Errorf("ad-hoc MCP only supports streamable or sse transport")
+		}
+		return "", "", fmt.Errorf("unsupported transport: %s", raw)
+	}
+}
+
+func cloneConnectionConfig(cfg mcpcfg.ConnectionConfig) mcpcfg.ConnectionConfig {
+	cfg.Headers = cloneStringMap(cfg.Headers)
+	cfg.Args = cloneStringSlice(cfg.Args)
+	return cfg
+}
+
+func cloneStringMap(input map[string]string) map[string]string {
+	if input == nil {
+		return nil
+	}
+	result := make(map[string]string, len(input))
+	for key, value := range input {
+		result[key] = value
+	}
+	return result
+}
+
+func cloneStringSlice(input []string) []string {
+	if input == nil {
+		return nil
+	}
+	result := make([]string, len(input))
+	copy(result, input)
+	return result
+}

--- a/tool/mcpbroker/example_test.go
+++ b/tool/mcpbroker/example_test.go
@@ -1,0 +1,43 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package mcpbroker
+
+import (
+	"fmt"
+	"sort"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	mcpcfg "trpc.group/trpc-go/trpc-agent-go/tool/mcp"
+)
+
+func ExampleNew() {
+	broker := New(
+		WithServers(map[string]mcpcfg.ConnectionConfig{
+			"local_stdio": {
+				Command: "go",
+				Args:    []string{"run", "./mcpserver"},
+			},
+		}),
+		WithAllowAdHocHTTP(true),
+	)
+
+	agent := llmagent.New(
+		"assistant",
+		llmagent.WithTools(broker.Tools()),
+	)
+
+	names := make([]string, 0, len(agent.Tools()))
+	for _, tl := range agent.Tools() {
+		names = append(names, tl.Declaration().Name)
+	}
+	sort.Strings(names)
+	fmt.Println(names)
+	// Output: [mcp_call mcp_inspect_tools mcp_list_servers mcp_list_tools]
+}

--- a/tool/mcpbroker/testdata/stdio_server/main.go
+++ b/tool/mcpbroker/testdata/stdio_server/main.go
@@ -1,0 +1,48 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	mcp "trpc.group/trpc-go/trpc-mcp-go"
+)
+
+func main() {
+	server := mcp.NewStdioServer("broker-stdio-test", "1.0.0")
+
+	echoTool := mcp.NewTool(
+		"echo",
+		mcp.WithDescription("Echo text."),
+		mcp.WithString("text", mcp.Required(), mcp.Description("Text to echo.")),
+	)
+	server.RegisterTool(echoTool, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		text, _ := req.Params.Arguments["text"].(string)
+		return mcp.NewTextResult("Echo: " + text), nil
+	})
+
+	addTool := mcp.NewTool(
+		"add",
+		mcp.WithDescription("Add two numbers."),
+		mcp.WithNumber("a", mcp.Required(), mcp.Description("First number.")),
+		mcp.WithNumber("b", mcp.Required(), mcp.Description("Second number.")),
+	)
+	server.RegisterTool(addTool, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		a, _ := req.Params.Arguments["a"].(float64)
+		b, _ := req.Params.Arguments["b"].(float64)
+		return mcp.NewTextResult(fmt.Sprintf("%g", a+b)), nil
+	})
+
+	if err := server.Start(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/tool/mcpbroker/tools.go
+++ b/tool/mcpbroker/tools.go
@@ -1,0 +1,650 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package mcpbroker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+	"trpc.group/trpc-go/trpc-agent-go/tool/function"
+	tmcp "trpc.group/trpc-go/trpc-mcp-go"
+)
+
+type listServersInput struct{}
+
+type listServersOutput struct {
+	Servers []listServersServer `json:"servers"`
+}
+
+type listServersServer struct {
+	Name      string `json:"name"`
+	Transport string `json:"transport"`
+}
+
+type listToolsInput struct {
+	Selector  string            `json:"selector"`
+	Transport string            `json:"transport,omitempty"`
+	Headers   map[string]string `json:"headers,omitempty"`
+}
+
+type listToolsOutput struct {
+	Tools []listedTool `json:"tools"`
+}
+
+type listedTool struct {
+	Name            string `json:"name"`
+	Selector        string `json:"selector,omitempty"`
+	Signature       string `json:"signature,omitempty"`
+	Description     string `json:"description,omitempty"`
+	HasOutputSchema bool   `json:"has_output_schema"`
+}
+
+type inspectToolsInput struct {
+	Selector            string            `json:"selector"`
+	Tools               []string          `json:"tools"`
+	Transport           string            `json:"transport,omitempty"`
+	Headers             map[string]string `json:"headers,omitempty"`
+	IncludeOutputSchema bool              `json:"include_output_schema,omitempty"`
+}
+
+type inspectToolsOutput struct {
+	Tools []inspectedTool `json:"tools"`
+}
+
+type inspectedTool struct {
+	Name            string         `json:"name"`
+	Selector        string         `json:"selector,omitempty"`
+	Description     string         `json:"description,omitempty"`
+	HasOutputSchema bool           `json:"has_output_schema"`
+	InputSchema     map[string]any `json:"input_schema,omitempty"`
+	OutputSchema    map[string]any `json:"output_schema,omitempty"`
+}
+
+type callToolInput struct {
+	Selector  string            `json:"selector"`
+	Transport string            `json:"transport,omitempty"`
+	Headers   map[string]string `json:"headers,omitempty"`
+	Arguments map[string]any    `json:"arguments,omitempty"`
+}
+
+type callToolOutput struct {
+	Content           []any `json:"content,omitempty"`
+	StructuredContent any   `json:"structured_content,omitempty"`
+	IsError           bool  `json:"is_error,omitempty"`
+}
+
+func newBrokerTools(b *Broker) []tool.Tool {
+	return []tool.Tool{
+		function.NewFunctionTool(
+			b.listServers,
+			function.WithName(listServersToolName),
+			function.WithDescription("List named MCP servers already configured for this broker. Use this first when you expect the platform to have preconfigured MCP connections. This tool only returns named broker servers; it does not inspect arbitrary URLs."),
+			function.WithInputSchema(emptyObjectSchema()),
+			function.WithOutputSchema(listServersOutputSchema()),
+		),
+		function.NewFunctionTool(
+			b.listTools,
+			function.WithName(listToolsToolName),
+			function.WithDescription("List lightweight MCP tool summaries for a selector. Use a named server selector like local_stdio_code, or an ad-hoc HTTP MCP endpoint like https://example.com/mcp. This tool is for discovery only: it returns names, descriptions, signatures, selectors, and output-schema availability, but not raw JSON schema. Use mcp_inspect_tools on the specific tools you plan to call."),
+			function.WithInputSchema(listToolsInputSchema()),
+			function.WithOutputSchema(listToolsOutputSchema()),
+		),
+		function.NewFunctionTool(
+			b.inspectTools,
+			function.WithName(inspectToolsToolName),
+			function.WithDescription("Inspect specific MCP tools and return their input schema. Use this after mcp_list_tools when you need exact parameter structure for selected tools. Pass tool names exactly as returned by mcp_list_tools. By default this tool only returns input schema; set include_output_schema=true only when output schema is also needed."),
+			function.WithInputSchema(inspectToolsInputSchema()),
+			function.WithOutputSchema(inspectToolsOutputSchema()),
+		),
+		function.NewFunctionTool(
+			b.callTool,
+			function.WithName(callToolToolName),
+			function.WithDescription("Call exactly one MCP tool by selector. Use a tool selector like local_stdio_code.add or https://example.com/mcp.add. Prefer selectors returned by mcp_list_tools or mcp_inspect_tools. If an ad-hoc HTTP endpoint would make dot-based parsing ambiguous, you may also use https://example.com/mcp#tool=add. Always pass the remote MCP tool parameters inside the arguments object, never as top-level wrapper fields. Example: mcp_call(selector=\"local_stdio_code.add\", arguments={\"a\": 12, \"b\": 30}). If you need exact parameter structure first, call mcp_inspect_tools before mcp_call. When the selected MCP tool takes no parameters, pass arguments={} explicitly."),
+			function.WithInputSchema(callToolInputSchema()),
+			function.WithOutputSchema(callToolOutputSchema()),
+		),
+	}
+}
+
+func (b *Broker) listTools(ctx context.Context, input listToolsInput) (listToolsOutput, error) {
+	target, selectorPrefix, err := b.resolveListSelector(input.Selector, input.Transport, input.Headers)
+	if err != nil {
+		return listToolsOutput{}, err
+	}
+
+	cfg, err := b.withPreparedHTTPHeaders(ctx, target, operationMetadata{
+		Selector: input.Selector,
+		BaseURL:  target.Config.ServerURL,
+		Phase:    phaseListTools,
+	})
+	if err != nil {
+		return listToolsOutput{}, err
+	}
+
+	mcpTools, err := withOneShotClient(ctx, cfg, func(opCtx context.Context, client tmcp.Connector) ([]tmcp.Tool, error) {
+		result, listErr := client.ListTools(opCtx, &tmcp.ListToolsRequest{})
+		if listErr != nil {
+			return nil, fmt.Errorf("list MCP tools: %w", listErr)
+		}
+		return result.Tools, nil
+	})
+	if err != nil {
+		if handled, interceptErr := interceptHTTPOperationError(ctx, b, target, operationMetadata{
+			Selector: input.Selector,
+			BaseURL:  target.Config.ServerURL,
+			Phase:    phaseListTools,
+		}, err); handled {
+			return listToolsOutput{}, interceptErr
+		}
+		return listToolsOutput{}, err
+	}
+
+	sort.Slice(mcpTools, func(i, j int) bool {
+		return mcpTools[i].Name < mcpTools[j].Name
+	})
+
+	output := listToolsOutput{
+		Tools: make([]listedTool, 0, len(mcpTools)),
+	}
+	for _, mcpTool := range mcpTools {
+		output.Tools = append(output.Tools, listedTool{
+			Name:            mcpTool.Name,
+			Selector:        joinToolSelector(selectorPrefix, mcpTool.Name),
+			Signature:       renderToolSignature(mcpTool),
+			Description:     mcpTool.Description,
+			HasOutputSchema: mcpTool.OutputSchema != nil,
+		})
+	}
+	return output, nil
+}
+
+func (b *Broker) inspectTools(ctx context.Context, input inspectToolsInput) (inspectToolsOutput, error) {
+	if len(input.Tools) == 0 {
+		return inspectToolsOutput{}, fmt.Errorf("tools is required and must contain at least one tool name")
+	}
+
+	target, selectorPrefix, err := b.resolveListSelector(input.Selector, input.Transport, input.Headers)
+	if err != nil {
+		return inspectToolsOutput{}, err
+	}
+
+	cfg, err := b.withPreparedHTTPHeaders(ctx, target, operationMetadata{
+		Selector: input.Selector,
+		BaseURL:  target.Config.ServerURL,
+		Phase:    phaseInspectTools,
+	})
+	if err != nil {
+		return inspectToolsOutput{}, err
+	}
+
+	mcpTools, err := withOneShotClient(ctx, cfg, func(opCtx context.Context, client tmcp.Connector) ([]tmcp.Tool, error) {
+		result, listErr := client.ListTools(opCtx, &tmcp.ListToolsRequest{})
+		if listErr != nil {
+			return nil, fmt.Errorf("list MCP tools: %w", listErr)
+		}
+		return result.Tools, nil
+	})
+	if err != nil {
+		if handled, interceptErr := interceptHTTPOperationError(ctx, b, target, operationMetadata{
+			Selector: input.Selector,
+			BaseURL:  target.Config.ServerURL,
+			Phase:    phaseInspectTools,
+		}, err); handled {
+			return inspectToolsOutput{}, interceptErr
+		}
+		return inspectToolsOutput{}, err
+	}
+
+	selectedTools, err := selectToolsForInspection(mcpTools, input.Tools)
+	if err != nil {
+		return inspectToolsOutput{}, err
+	}
+
+	output := inspectToolsOutput{
+		Tools: make([]inspectedTool, 0, len(selectedTools)),
+	}
+	for _, mcpTool := range selectedTools {
+		item := inspectedTool{
+			Name:            mcpTool.Name,
+			Selector:        joinToolSelector(selectorPrefix, mcpTool.Name),
+			Description:     mcpTool.Description,
+			HasOutputSchema: mcpTool.OutputSchema != nil,
+			InputSchema:     schemaToMap(mcpTool.InputSchema),
+		}
+		if input.IncludeOutputSchema {
+			item.OutputSchema = schemaToMap(mcpTool.OutputSchema)
+		}
+		output.Tools = append(output.Tools, item)
+	}
+	return output, nil
+}
+
+func (b *Broker) callTool(ctx context.Context, input callToolInput) (callToolOutput, error) {
+	if input.Arguments == nil {
+		return callToolOutput{}, fmt.Errorf("arguments is required; pass {} when the MCP tool takes no parameters")
+	}
+
+	target, _, toolName, err := b.resolveCallSelector(input.Selector, input.Transport, input.Headers)
+	if err != nil {
+		return callToolOutput{}, err
+	}
+
+	cfg, err := b.withPreparedHTTPHeaders(ctx, target, operationMetadata{
+		Selector: input.Selector,
+		BaseURL:  target.Config.ServerURL,
+		ToolName: toolName,
+		Phase:    phaseCallTool,
+	})
+	if err != nil {
+		return callToolOutput{}, err
+	}
+
+	result, err := withOneShotClient(ctx, cfg, func(opCtx context.Context, client tmcp.Connector) (*tmcp.CallToolResult, error) {
+		if validateErr := validateCallToolArguments(opCtx, client, toolName, input.Arguments); validateErr != nil {
+			return nil, validateErr
+		}
+		callResult, callErr := client.CallTool(opCtx, &tmcp.CallToolRequest{
+			Params: tmcp.CallToolParams{
+				Name:      toolName,
+				Arguments: input.Arguments,
+			},
+		})
+		if callErr != nil {
+			return nil, fmt.Errorf("call MCP tool %q: %w", toolName, callErr)
+		}
+		return callResult, nil
+	})
+	if err != nil {
+		if handled, interceptErr := interceptHTTPOperationError(ctx, b, target, operationMetadata{
+			Selector: input.Selector,
+			BaseURL:  target.Config.ServerURL,
+			ToolName: toolName,
+			Phase:    phaseCallTool,
+		}, err); handled {
+			return callToolOutput{}, interceptErr
+		}
+		return callToolOutput{}, err
+	}
+
+	output := callToolOutput{
+		StructuredContent: result.StructuredContent,
+		IsError:           result.IsError,
+	}
+	if result.StructuredContent == nil && len(result.Content) > 0 {
+		output.Content = make([]any, len(result.Content))
+		for i, content := range result.Content {
+			output.Content[i] = content
+		}
+	}
+	return output, nil
+}
+
+func validateCallToolArguments(
+	ctx context.Context,
+	client tmcp.Connector,
+	toolName string,
+	arguments map[string]any,
+) error {
+	listResult, err := client.ListTools(ctx, &tmcp.ListToolsRequest{})
+	if err != nil {
+		return fmt.Errorf("list MCP tools for validation: %w", err)
+	}
+
+	var target *tmcp.Tool
+	for i := range listResult.Tools {
+		if listResult.Tools[i].Name == toolName {
+			target = &listResult.Tools[i]
+			break
+		}
+	}
+	if target == nil {
+		return fmt.Errorf("MCP tool %q not found", toolName)
+	}
+
+	if target.InputSchema == nil || len(target.InputSchema.Required) == 0 {
+		return nil
+	}
+
+	missing := make([]string, 0)
+	for _, field := range target.InputSchema.Required {
+		if arguments == nil {
+			missing = append(missing, field)
+			continue
+		}
+		if _, ok := arguments[field]; !ok {
+			missing = append(missing, field)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		return fmt.Errorf("missing required arguments for MCP tool %q: %s", toolName, strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+func emptyObjectSchema() *tool.Schema {
+	return &tool.Schema{
+		Type:                 "object",
+		AdditionalProperties: false,
+	}
+}
+
+func listToolsInputSchema() *tool.Schema {
+	return &tool.Schema{
+		Type:                 "object",
+		AdditionalProperties: false,
+		Required:             []string{"selector"},
+		Properties: map[string]*tool.Schema{
+			"selector":  {Type: "string", Description: "Required. Either a named server selector like local_stdio_code, or an ad-hoc HTTP MCP endpoint like https://example.com/mcp. Do not append the tool name here; this tool lists tools for the server/endpoint."},
+			"transport": {Type: "string", Description: "Optional ad-hoc HTTP transport override for URL selectors. Ignored for named selectors. Prefer omitting this unless you know the endpoint needs a specific HTTP mode. Supported values: streamable, sse.", Enum: []any{"streamable", "sse", "streamable_http", "http"}},
+			"headers": {
+				Type:                 "object",
+				Description:          "Optional non-sensitive headers for ad-hoc HTTP selectors. Ignored for named selectors. Do not put secrets here unless the platform explicitly allows it.",
+				AdditionalProperties: &tool.Schema{Type: "string"},
+			},
+		},
+	}
+}
+
+func inspectToolsInputSchema() *tool.Schema {
+	return &tool.Schema{
+		Type:                 "object",
+		AdditionalProperties: false,
+		Required:             []string{"selector", "tools"},
+		Properties: map[string]*tool.Schema{
+			"selector":  {Type: "string", Description: "Required. Either a named server selector like local_stdio_code, or an ad-hoc HTTP MCP endpoint like https://example.com/mcp. Do not append the tool name here; this tool inspects specific tools on the server/endpoint."},
+			"transport": {Type: "string", Description: "Optional ad-hoc HTTP transport override for URL selectors. Ignored for named selectors. Prefer omitting this unless you know the endpoint needs a specific HTTP mode. Supported values: streamable, sse.", Enum: []any{"streamable", "sse", "streamable_http", "http"}},
+			"headers": {
+				Type:                 "object",
+				Description:          "Optional non-sensitive headers for ad-hoc HTTP selectors. Ignored for named selectors. Do not put secrets here unless the platform explicitly allows it.",
+				AdditionalProperties: &tool.Schema{Type: "string"},
+			},
+			"tools": {
+				Type:        "array",
+				Description: "Required. The exact MCP tool names to inspect, for example [\"add\"] or [\"issue_create\", \"issue_comment\"]. Prefer names returned by mcp_list_tools.",
+				Items:       &tool.Schema{Type: "string"},
+			},
+			"include_output_schema": {Type: "boolean", Description: "Optional. Set true only when you also need the output schema. By default this tool only returns input schema."},
+		},
+	}
+}
+
+func callToolInputSchema() *tool.Schema {
+	return &tool.Schema{
+		Type:                 "object",
+		AdditionalProperties: false,
+		Required:             []string{"selector", "arguments"},
+		Properties: map[string]*tool.Schema{
+			"selector":  {Type: "string", Description: "Required. A tool selector like local_stdio_code.add or https://example.com/mcp.add. Prefer using the selector returned by mcp_list_tools instead of inventing one. If an ad-hoc HTTP endpoint would make dot-based parsing ambiguous, you may also use https://example.com/mcp#tool=add."},
+			"transport": {Type: "string", Description: "Optional ad-hoc HTTP transport override for URL selectors. Ignored for named selectors. Prefer omitting this unless the endpoint requires a specific HTTP mode. Supported values: streamable, sse.", Enum: []any{"streamable", "sse", "streamable_http", "http"}},
+			"headers": {
+				Type:                 "object",
+				Description:          "Optional non-sensitive headers for ad-hoc HTTP selectors. Ignored for named selectors. Do not put remote MCP tool parameters here.",
+				AdditionalProperties: &tool.Schema{Type: "string"},
+			},
+			"arguments": {
+				Type:                 "object",
+				Description:          "Required. Always pass an object. Put the selected remote MCP tool parameters here, for example {\"a\": 12, \"b\": 30}. Never place remote MCP tool parameters at the top level beside selector/transport/headers. Use {} when the selected MCP tool takes no parameters. If you need the exact parameter shape first, use mcp_inspect_tools.",
+				AdditionalProperties: true,
+			},
+		},
+	}
+}
+
+func listServersOutputSchema() *tool.Schema {
+	return &tool.Schema{
+		Type:                 "object",
+		AdditionalProperties: false,
+		Required:             []string{"servers"},
+		Properties: map[string]*tool.Schema{
+			"servers": {
+				Type: "array",
+				Items: &tool.Schema{
+					Type:                 "object",
+					AdditionalProperties: false,
+					Required:             []string{"name", "transport"},
+					Properties: map[string]*tool.Schema{
+						"name":      {Type: "string", Description: "Configured server name."},
+						"transport": {Type: "string", Description: "Resolved MCP transport."},
+					},
+				},
+			},
+		},
+	}
+}
+
+func listToolsOutputSchema() *tool.Schema {
+	return &tool.Schema{
+		Type:                 "object",
+		AdditionalProperties: false,
+		Required:             []string{"tools"},
+		Properties: map[string]*tool.Schema{
+			"tools": {
+				Type: "array",
+				Items: &tool.Schema{
+					Type:                 "object",
+					AdditionalProperties: false,
+					Required:             []string{"name", "has_output_schema"},
+					Properties: map[string]*tool.Schema{
+						"name":              {Type: "string", Description: "MCP tool name."},
+						"selector":          {Type: "string", Description: "Tool selector to use with mcp_call."},
+						"signature":         {Type: "string", Description: "Compact signature derived from the MCP tool input and output schemas."},
+						"description":       {Type: "string", Description: "MCP tool description."},
+						"has_output_schema": {Type: "boolean", Description: "Whether the MCP tool advertises an output schema."},
+					},
+				},
+			},
+		},
+	}
+}
+
+func inspectToolsOutputSchema() *tool.Schema {
+	return &tool.Schema{
+		Type:                 "object",
+		AdditionalProperties: false,
+		Required:             []string{"tools"},
+		Properties: map[string]*tool.Schema{
+			"tools": {
+				Type: "array",
+				Items: &tool.Schema{
+					Type:                 "object",
+					AdditionalProperties: false,
+					Required:             []string{"name", "has_output_schema"},
+					Properties: map[string]*tool.Schema{
+						"name":              {Type: "string", Description: "MCP tool name."},
+						"selector":          {Type: "string", Description: "Tool selector to use with mcp_call."},
+						"description":       {Type: "string", Description: "MCP tool description."},
+						"has_output_schema": {Type: "boolean", Description: "Whether the MCP tool advertises an output schema."},
+						"input_schema": {
+							Type:                 "object",
+							Description:          "MCP tool input schema.",
+							AdditionalProperties: true,
+						},
+						"output_schema": {
+							Type:                 "object",
+							Description:          "MCP tool output schema. Present only when include_output_schema=true and the MCP tool advertises one.",
+							AdditionalProperties: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func callToolOutputSchema() *tool.Schema {
+	return &tool.Schema{
+		Type:                 "object",
+		AdditionalProperties: false,
+		Properties: map[string]*tool.Schema{
+			"content": {
+				Type:        "array",
+				Description: "MCP content blocks returned by the remote tool. Present when the remote tool does not return structured content.",
+				Items: &tool.Schema{
+					Type:                 "object",
+					AdditionalProperties: true,
+				},
+			},
+			"structured_content": {
+				Type:                 "object",
+				Description:          "Structured content returned by the remote tool. When present, content is omitted to avoid duplicate result payloads.",
+				AdditionalProperties: true,
+			},
+			"is_error": {Type: "boolean", Description: "Present and true when the remote MCP tool reported an error result."},
+		},
+	}
+}
+
+func joinToolSelector(prefix string, toolName string) string {
+	prefix = strings.TrimSpace(prefix)
+	toolName = strings.TrimSpace(toolName)
+	if prefix == "" || toolName == "" {
+		return ""
+	}
+	if looksLikeHTTPSelector(prefix) && shouldUseFragmentHTTPToolSelector(prefix) {
+		return prefix + "#tool=" + toolName
+	}
+	return prefix + "." + toolName
+}
+
+func renderToolSignature(mcpTool tmcp.Tool) string {
+	params := make([]string, 0)
+	if mcpTool.InputSchema != nil {
+		requiredSet := make(map[string]struct{}, len(mcpTool.InputSchema.Required))
+		for _, name := range mcpTool.InputSchema.Required {
+			requiredSet[name] = struct{}{}
+			if ref, ok := mcpTool.InputSchema.Properties[name]; ok && ref != nil && ref.Value != nil {
+				params = append(params, fmt.Sprintf("%s: %s", name, schemaTypeName(ref.Value)))
+				continue
+			}
+			params = append(params, fmt.Sprintf("%s: unknown", name))
+		}
+
+		optionalNames := make([]string, 0, len(mcpTool.InputSchema.Properties))
+		for name := range mcpTool.InputSchema.Properties {
+			if _, ok := requiredSet[name]; ok {
+				continue
+			}
+			optionalNames = append(optionalNames, name)
+		}
+		sort.Strings(optionalNames)
+		for _, name := range optionalNames {
+			ref := mcpTool.InputSchema.Properties[name]
+			if ref == nil || ref.Value == nil {
+				params = append(params, fmt.Sprintf("%s?: unknown", name))
+				continue
+			}
+			params = append(params, fmt.Sprintf("%s?: %s", name, schemaTypeName(ref.Value)))
+		}
+	}
+
+	signature := fmt.Sprintf("%s(%s)", mcpTool.Name, strings.Join(params, ", "))
+	returnType := schemaTypeName(mcpTool.OutputSchema)
+	if returnType == "" || returnType == "object" || returnType == "unknown" {
+		return signature
+	}
+	return signature + " -> " + returnType
+}
+
+func schemaTypeName(schema any) string {
+	if schema == nil {
+		return "unknown"
+	}
+	schemaMap := schemaToMap(schema)
+	if len(schemaMap) == 0 {
+		return "unknown"
+	}
+
+	schemaType, ok := firstSchemaType(schemaMap["type"])
+	if !ok {
+		return "unknown"
+	}
+	switch schemaType {
+	case "array":
+		items, _ := schemaMap["items"].(map[string]any)
+		if len(items) == 0 {
+			return "array"
+		}
+		return "array<" + schemaTypeName(items) + ">"
+	case "object":
+		return "object"
+	default:
+		return schemaType
+	}
+}
+
+func firstSchemaType(value any) (string, bool) {
+	switch typed := value.(type) {
+	case string:
+		typed = strings.TrimSpace(typed)
+		return typed, typed != ""
+	case []any:
+		for _, item := range typed {
+			text, ok := firstSchemaType(item)
+			if ok {
+				return text, true
+			}
+		}
+	}
+	return "", false
+}
+
+func schemaToMap(schema any) map[string]any {
+	if schema == nil {
+		return nil
+	}
+	data, err := json.Marshal(schema)
+	if err != nil {
+		return nil
+	}
+	var result map[string]any
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil
+	}
+	return result
+}
+
+func selectToolsForInspection(mcpTools []tmcp.Tool, requested []string) ([]tmcp.Tool, error) {
+	index := make(map[string]tmcp.Tool, len(mcpTools))
+	for _, mcpTool := range mcpTools {
+		index[strings.TrimSpace(mcpTool.Name)] = mcpTool
+	}
+
+	selected := make([]tmcp.Tool, 0, len(requested))
+	missing := make([]string, 0)
+	seen := make(map[string]struct{}, len(requested))
+	for _, rawName := range requested {
+		name := strings.TrimSpace(rawName)
+		if name == "" {
+			return nil, fmt.Errorf("tools must not contain empty tool names")
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+
+		mcpTool, ok := index[name]
+		if !ok {
+			missing = append(missing, name)
+			continue
+		}
+		selected = append(selected, mcpTool)
+	}
+
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		return nil, fmt.Errorf("requested MCP tools not found: %s", strings.Join(missing, ", "))
+	}
+	return selected, nil
+}


### PR DESCRIPTION
Add tool/mcpbroker as a brokered MCP integration that exposes a small fixed tool surface for listing configured servers, listing lightweight tool summaries, inspecting selected tool schemas, and calling concrete MCP tools.

Support both preconfigured named MCP servers and ad-hoc HTTP MCP endpoints, including runtime HTTP header injection and error interception hooks for business-owned auth flows.

Add mcpbroker examples and documentation covering the basic broker flow, skill-discovered remote MCP endpoints, and auth hook usage.