### PR TITLE
{agent,runner}: support per-request app name override via RunOption

### DIFF
--- a/agent/invocation.go
+++ b/agent/invocation.go
@@ -222,6 +222,17 @@ func NewRunOptions(opts ...RunOption) RunOptions {
 // TraceStartedCallback receives the root span context for a run.
 type TraceStartedCallback func(oteltrace.SpanContext)
 
+// WithAppName overrides the runner's default app name for this specific run.
+//
+// This enables a single runner to serve multiple projects or tenants
+// by isolating session and memory data under different app names.
+// When not set, the runner uses its constructor-provided default app name.
+func WithAppName(name string) RunOption {
+	return func(opts *RunOptions) {
+		opts.AppName = name
+	}
+}
+
 // WithRuntimeState sets the runtime state for the RunOptions.
 func WithRuntimeState(state map[string]any) RunOption {
 	return func(opts *RunOptions) {
@@ -789,6 +800,16 @@ func setRunControlConfig(opts *RunOptions, cfg runControlConfig) {
 
 // RunOptions is the options for the Run method.
 type RunOptions struct {
+	// AppName overrides the runner's default app name for this specific run.
+	//
+	// When set, the runner uses this value instead of its constructor-provided
+	// app name for session keys, memory operations, and event filter keys.
+	// This enables a single runner instance to serve multiple projects or
+	// tenants, isolating their session and memory data by app name.
+	//
+	// If empty, the runner falls back to its default app name.
+	AppName string
+
 	// RuntimeState contains key-value pairs that will be merged into the initial state
 	// for this specific run. This allows callers to pass dynamic parameters
 	// (e.g., room ID, user context) without modifying the agent's base initial state.

--- a/docs/mkdocs/en/runner.md
+++ b/docs/mkdocs/en/runner.md
@@ -417,6 +417,44 @@ If you want the implementation-level mapping, this happens after one
 
 Runnable example: `examples/steer/`
 
+#### Per-Request App Name Override (multi-tenant isolation)
+
+By default, Runner uses the `appName` supplied at construction for session keys
+and event filter keys. If a single Runner instance serves multiple projects or
+tenants, you can override the app name on each `Run` call with
+`agent.WithAppName`:
+
+```go
+// One runner, two projects.
+r := runner.NewRunner("default-app", myAgent)
+
+// Project A — sessions are stored under "project-a".
+evA, _ := r.Run(ctx, userID, sessionID, msg,
+    agent.WithAppName("project-a"),
+)
+
+// Project B — sessions are stored under "project-b", fully isolated from A.
+evB, _ := r.Run(ctx, userID, sessionID, msg,
+    agent.WithAppName("project-b"),
+)
+```
+
+When `WithAppName` is **not** provided (or the value is empty), the runner
+falls back to the constructor-supplied default app name. The override affects:
+
+| Dimension | Default (no override) | With `WithAppName("X")` |
+|---|---|---|
+| `session.Key.AppName` | constructor `appName` | `"X"` |
+| Default `EventFilterKey` | constructor `appName` | `"X"` |
+
+Other runner-level registrations (observability `appid`, agent registry) remain
+bound to the original constructor `appName`.
+
+!!! note
+    `appName` must not be empty. If neither the constructor nor `WithAppName`
+    provides a non-empty value, the session service returns
+    `session.ErrAppNameRequired`.
+
 #### Detached Cancellation (background execution)
 
 In Go, `context.Context` (often named `ctx`) carries both cancellation and a

--- a/docs/mkdocs/zh/runner.md
+++ b/docs/mkdocs/zh/runner.md
@@ -405,6 +405,42 @@ tool(result B)
 
 可运行示例：`examples/steer/`
 
+#### 按请求覆盖 AppName（多租户隔离）
+
+默认情况下，Runner 使用构造时传入的 `appName` 作为 session key 和事件过滤 key。
+如果一个 Runner 实例需要同时服务多个项目或租户，可以在每次 `Run` 调用时通过
+`agent.WithAppName` 覆盖 app name：
+
+```go
+// 一个 Runner，两个项目。
+r := runner.NewRunner("default-app", myAgent)
+
+// 项目 A — session 数据存储在 "project-a" 下。
+evA, _ := r.Run(ctx, userID, sessionID, msg,
+    agent.WithAppName("project-a"),
+)
+
+// 项目 B — session 数据存储在 "project-b" 下，与 A 完全隔离。
+evB, _ := r.Run(ctx, userID, sessionID, msg,
+    agent.WithAppName("project-b"),
+)
+```
+
+当 **未传入** `WithAppName`（或值为空字符串）时，Runner 会回退到构造函数提供的
+默认 app name。此覆盖影响的维度如下：
+
+| 维度 | 默认（无覆盖） | 使用 `WithAppName("X")` |
+|---|---|---|
+| `session.Key.AppName` | 构造时 `appName` | `"X"` |
+| 默认 `EventFilterKey` | 构造时 `appName` | `"X"` |
+
+Runner 级别的其他注册（可观测性 `appid`、agent 注册表）仍然绑定到构造时的原始
+`appName`。
+
+!!! note
+    `appName` 不能为空。如果构造函数和 `WithAppName` 都没有提供非空值，
+    session 服务会返回 `session.ErrAppNameRequired`。
+
 #### DetachedCancel（忽略父 ctx cancel）
 
 在 Go 里，`context.Context`（通常命名为 `ctx`）同时承载“取消信号”和“截止时间”。

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -398,11 +398,19 @@ func (r *runner) Run(
 		ro.RequestID = uuid.NewString()
 	}
 
+	// Resolve per-request app name override. When the caller provides an
+	// AppName via RunOption, it takes precedence over the runner default so
+	// that a single runner can isolate session/memory data across projects.
+	effectiveAppName := r.appName
+	if ro.AppName != "" {
+		effectiveAppName = ro.AppName
+	}
+
 	execCtx, execCancel := r.newExecutionContext(ctx, ro)
 
 	// Resolve or create the session for this user and conversation.
 	sessionKey := session.Key{
-		AppName:   r.appName,
+		AppName:   effectiveAppName,
 		UserID:    userID,
 		SessionID: sessionID,
 	}
@@ -419,7 +427,7 @@ func (r *runner) Run(
 		return nil, fmt.Errorf("select agent: %w", err)
 	}
 
-	eventFilterKey := r.appName
+	eventFilterKey := effectiveAppName
 	if ro.EventFilterKey != "" {
 		eventFilterKey = ro.EventFilterKey
 	}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -469,49 +469,19 @@ func (r *runner) Run(
 	// If caller provided a history via RunOptions and the session is empty,
 	// persist that history into the session exactly once, so subsequent turns
 	// and tool calls build on the same canonical transcript.
-	if len(ro.Messages) > 0 && sess.GetEventCount() == 0 {
-		for _, msg := range ro.Messages {
-			author := ag.Info().Name
-			if msg.Role == model.RoleUser {
-				author = authorUser
-			}
-			m := msg
-			seedEvt := event.NewResponseEvent(
-				invocation.InvocationID,
-				author,
-				&model.Response{Done: false, Choices: []model.Choice{{Index: 0, Message: m}}},
-			)
-			agent.InjectIntoEvent(invocation, seedEvt)
-			seedEvt = r.applyEventPlugins(execCtx, invocation, seedEvt)
-			appendErr := r.sessionService.AppendEvent(
-				execCtx,
-				sess,
-				seedEvt,
-			)
-			if appendErr != nil {
-				steer.Clear(invocation)
-				r.unregisterRun(ro.RequestID)
-				execCancel()
-				return nil, appendErr
-			}
-		}
+	if err := r.seedSessionHistory(execCtx, sess, invocation, ag, ro); err != nil {
+		steer.Clear(invocation)
+		r.unregisterRun(ro.RequestID)
+		execCancel()
+		return nil, err
 	}
 
 	// Append the incoming message to the session if it has payload.
-	if model.HasPayload(message) && shouldAppendUserMessage(message, ro.Messages) {
-		evt := event.NewResponseEvent(
-			invocation.InvocationID,
-			authorUser,
-			&model.Response{Done: false, Choices: []model.Choice{{Index: 0, Message: message}}},
-		)
-		agent.InjectIntoEvent(invocation, evt)
-		evt = r.applyEventPlugins(execCtx, invocation, evt)
-		if err := r.sessionService.AppendEvent(execCtx, sess, evt); err != nil {
-			steer.Clear(invocation)
-			r.unregisterRun(ro.RequestID)
-			execCancel()
-			return nil, err
-		}
+	if err := r.appendIncomingMessage(execCtx, sess, invocation, message, ro); err != nil {
+		steer.Clear(invocation)
+		r.unregisterRun(ro.RequestID)
+		execCancel()
+		return nil, err
 	}
 
 	// Ensure the invocation can be accessed by downstream components (e.g., tools)
@@ -566,6 +536,62 @@ func (r *runner) Run(
 		flushChan,
 		handle,
 	), nil
+}
+
+// seedSessionHistory persists caller-supplied history messages into an empty
+// session so that subsequent turns and tool calls build on the same canonical
+// transcript. It is a no-op when no messages are provided or the session
+// already contains events.
+func (r *runner) seedSessionHistory(
+	ctx context.Context,
+	sess *session.Session,
+	invocation *agent.Invocation,
+	ag agent.Agent,
+	ro agent.RunOptions,
+) error {
+	if len(ro.Messages) == 0 || sess.GetEventCount() != 0 {
+		return nil
+	}
+	for _, msg := range ro.Messages {
+		author := ag.Info().Name
+		if msg.Role == model.RoleUser {
+			author = authorUser
+		}
+		m := msg
+		seedEvt := event.NewResponseEvent(
+			invocation.InvocationID,
+			author,
+			&model.Response{Done: false, Choices: []model.Choice{{Index: 0, Message: m}}},
+		)
+		agent.InjectIntoEvent(invocation, seedEvt)
+		seedEvt = r.applyEventPlugins(ctx, invocation, seedEvt)
+		if err := r.sessionService.AppendEvent(ctx, sess, seedEvt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// appendIncomingMessage appends the user's incoming message to the session
+// when it carries a payload and is not already covered by the seeded history.
+func (r *runner) appendIncomingMessage(
+	ctx context.Context,
+	sess *session.Session,
+	invocation *agent.Invocation,
+	message model.Message,
+	ro agent.RunOptions,
+) error {
+	if !model.HasPayload(message) || !shouldAppendUserMessage(message, ro.Messages) {
+		return nil
+	}
+	evt := event.NewResponseEvent(
+		invocation.InvocationID,
+		authorUser,
+		&model.Response{Done: false, Choices: []model.Choice{{Index: 0, Message: message}}},
+	)
+	agent.InjectIntoEvent(invocation, evt)
+	evt = r.applyEventPlugins(ctx, invocation, evt)
+	return r.sessionService.AppendEvent(ctx, sess, evt)
 }
 
 func (r *runner) Cancel(requestID string) bool {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1420,10 +1420,16 @@ func shouldPropagateFallbackState(err *model.ResponseError) bool {
 // emitRunnerCompletion creates and emits the final runner completion event,
 // optionally propagating graph-level completion data.
 func (r *runner) emitRunnerCompletion(ctx context.Context, loop *eventLoopContext) {
+	// Resolve per-request app name override for the completion Author.
+	completionAuthor := r.appName
+	if ro := loop.invocation.RunOptions; ro.AppName != "" {
+		completionAuthor = ro.AppName
+	}
+
 	// Create runner completion event.
 	runnerCompletionEvent := event.NewResponseEvent(
 		loop.invocation.InvocationID,
-		r.appName,
+		completionAuthor,
 		&model.Response{
 			ID:        "runner-completion-" + uuid.New().String(),
 			Object:    model.ObjectTypeRunnerCompletion,

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -7436,3 +7436,38 @@ func TestRunner_WithAppName_IsolatesDifferentProjects(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, sessDefault, "default app name should have no session")
 }
+
+// TestRunner_WithAppName_CompletionEventAuthor verifies that the runner
+// completion event uses the overridden app name as its Author, not the
+// runner's default app name.
+func TestRunner_WithAppName_CompletionEventAuthor(t *testing.T) {
+	const (
+		defaultAppName  = "default-app"
+		overrideAppName = "tenant-x"
+		userID          = "user-1"
+		sessionID       = "session-completion"
+	)
+
+	sessionService := sessioninmemory.NewSessionService()
+	ag := &mockAgent{name: "completion-author-agent"}
+	r := NewRunner(defaultAppName, ag, WithSessionService(sessionService))
+
+	ch, err := r.Run(
+		context.Background(),
+		userID,
+		sessionID,
+		model.NewUserMessage("hello"),
+		agent.WithAppName(overrideAppName),
+	)
+	require.NoError(t, err)
+
+	var completionAuthor string
+	for ev := range ch {
+		if ev.Response != nil && ev.Response.Object == model.ObjectTypeRunnerCompletion {
+			completionAuthor = ev.Author
+		}
+	}
+
+	assert.Equal(t, overrideAppName, completionAuthor,
+		"runner completion event Author should use the overridden app name")
+}

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -7298,3 +7298,141 @@ func createNamedRunnerTestSkillRepository(
 	require.NoError(t, err)
 	return repo
 }
+
+// TestRunner_WithAppName_OverridesSessionKey verifies that agent.WithAppName
+// overrides the runner's default app name for session isolation.
+func TestRunner_WithAppName_OverridesSessionKey(t *testing.T) {
+	const (
+		defaultAppName  = "default-app"
+		overrideAppName = "project-alpha"
+		userID          = "user-1"
+		sessionID       = "session-1"
+	)
+
+	sessionService := sessioninmemory.NewSessionService()
+	ag := &mockAgent{name: "app-name-agent"}
+	r := NewRunner(defaultAppName, ag, WithSessionService(sessionService))
+
+	// Run with overridden app name.
+	ch, err := r.Run(
+		context.Background(),
+		userID,
+		sessionID,
+		model.NewUserMessage("hello"),
+		agent.WithAppName(overrideAppName),
+	)
+	require.NoError(t, err)
+	for range ch {
+	}
+
+	// The session should exist under the overridden app name.
+	overrideSess, err := sessionService.GetSession(
+		context.Background(),
+		session.Key{AppName: overrideAppName, UserID: userID, SessionID: sessionID},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, overrideSess, "session should exist under overridden app name")
+
+	// The session should NOT exist under the default app name.
+	defaultSess, err := sessionService.GetSession(
+		context.Background(),
+		session.Key{AppName: defaultAppName, UserID: userID, SessionID: sessionID},
+	)
+	require.NoError(t, err)
+	assert.Nil(t, defaultSess, "session should not exist under default app name")
+}
+
+// TestRunner_WithAppName_FallbackToDefault verifies that when no AppName
+// override is provided, the runner uses its default app name.
+func TestRunner_WithAppName_FallbackToDefault(t *testing.T) {
+	const (
+		defaultAppName = "fallback-app"
+		userID         = "user-1"
+		sessionID      = "session-fallback"
+	)
+
+	sessionService := sessioninmemory.NewSessionService()
+	ag := &mockAgent{name: "fallback-agent"}
+	r := NewRunner(defaultAppName, ag, WithSessionService(sessionService))
+
+	ch, err := r.Run(
+		context.Background(),
+		userID,
+		sessionID,
+		model.NewUserMessage("hello"),
+	)
+	require.NoError(t, err)
+	for range ch {
+	}
+
+	// The session should exist under the default app name.
+	sess, err := sessionService.GetSession(
+		context.Background(),
+		session.Key{AppName: defaultAppName, UserID: userID, SessionID: sessionID},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, sess, "session should exist under default app name")
+}
+
+// TestRunner_WithAppName_IsolatesDifferentProjects verifies that two runs
+// with different AppName overrides create isolated sessions.
+func TestRunner_WithAppName_IsolatesDifferentProjects(t *testing.T) {
+	const (
+		defaultAppName = "shared-runner"
+		projectA       = "project-a"
+		projectB       = "project-b"
+		userID         = "user-1"
+		sessionID      = "shared-session"
+	)
+
+	sessionService := sessioninmemory.NewSessionService()
+	ag := &mockAgent{name: "isolation-agent"}
+	r := NewRunner(defaultAppName, ag, WithSessionService(sessionService))
+
+	// Run for project A.
+	chA, err := r.Run(
+		context.Background(),
+		userID,
+		sessionID,
+		model.NewUserMessage("hello from A"),
+		agent.WithAppName(projectA),
+	)
+	require.NoError(t, err)
+	for range chA {
+	}
+
+	// Run for project B.
+	chB, err := r.Run(
+		context.Background(),
+		userID,
+		sessionID,
+		model.NewUserMessage("hello from B"),
+		agent.WithAppName(projectB),
+	)
+	require.NoError(t, err)
+	for range chB {
+	}
+
+	// Both sessions should exist under their respective app names.
+	sessA, err := sessionService.GetSession(
+		context.Background(),
+		session.Key{AppName: projectA, UserID: userID, SessionID: sessionID},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, sessA, "project A session should exist")
+
+	sessB, err := sessionService.GetSession(
+		context.Background(),
+		session.Key{AppName: projectB, UserID: userID, SessionID: sessionID},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, sessB, "project B session should exist")
+
+	// Default app name should have no session.
+	sessDefault, err := sessionService.GetSession(
+		context.Background(),
+		session.Key{AppName: defaultAppName, UserID: userID, SessionID: sessionID},
+	)
+	require.NoError(t, err)
+	assert.Nil(t, sessDefault, "default app name should have no session")
+}


### PR DESCRIPTION
## Summary

Add per-request `AppName` override to `RunOptions`, enabling a single runner
instance to serve multiple projects or tenants with isolated session and memory
data.

## Motivation

Users deploying a shared agent across multiple projects need session and memory
data isolation by project. The storage layer already uses `app_name` as a
first-class isolation key, but the runner hardcodes the app name at
construction time, making it impossible to vary per request.

## Changes

### agent/invocation.go
- Add `AppName string` field to `RunOptions`.
- Add `WithAppName(name string) RunOption` helper.

### runner/runner.go
- In `Run()`, resolve `effectiveAppName` from `ro.AppName` (if set) with
  fallback to `r.appName`.
- Use `effectiveAppName` for session key and default event filter key.

### runner/runner_test.go
- `TestRunner_WithAppName_OverridesSessionKey`: verifies override creates
  session under the specified app name.
- `TestRunner_WithAppName_FallbackToDefault`: verifies fallback when no
  override is provided.
- `TestRunner_WithAppName_IsolatesDifferentProjects`: verifies two runs
  with different overrides produce isolated sessions.

## Usage

```go
r := runner.NewRunner("default-app", myAgent)

// Each request can specify its own app name for isolation.
events, _ := r.Run(ctx, userID, sessionID, msg,
    agent.WithAppName("project-" + projectID),
)
```

When `WithAppName` is not used, behavior is identical to before (uses the
runner's constructor app name).