### PR TITLE
processor: clear tool error when after-tool callback provides CustomResult

### DIFF
--- a/internal/flow/processor/functioncall.go
+++ b/internal/flow/processor/functioncall.go
@@ -1410,8 +1410,16 @@ func (p *FunctionCallResponseProcessor) executeToolWithCallbacks(
 // replaced the original (failed) tool result with a non-nil custom result.
 // In that case the original toolErr should be cleared so that the framework
 // sends the replacement result as the tool response message to the model.
+// StopError is excluded because it carries a control-flow signal that must
+// not be silently swallowed by a callback result replacement.
 func afterCallbackReplacedResult(toolErr error, toolResult any) bool {
-	return toolErr != nil && toolResult != nil
+	if toolErr == nil || toolResult == nil {
+		return false
+	}
+	if _, ok := agent.AsStopError(toolErr); ok {
+		return false
+	}
+	return true
 }
 
 // isStreamable returns true if the tool supports streaming and its stream

--- a/internal/flow/processor/functioncall.go
+++ b/internal/flow/processor/functioncall.go
@@ -1374,8 +1374,12 @@ func (p *FunctionCallResponseProcessor) executeToolWithCallbacks(
 		if toolResult != nil {
 			suppressDefaultToolMessage = false
 		}
+		pluginErr := toolErr
+		if afterCallbackReplacedResult(toolErr, toolResult) {
+			pluginErr = nil
+		}
 		return ctx, toolResult, toolCall.Function.Arguments,
-			suppressDefaultToolMessage, skipSummarization, toolErr
+			suppressDefaultToolMessage, skipSummarization, pluginErr
 	}
 	ctx, toolResult, localSkip, err := p.runAfterToolCallbacks(
 		ctx,
@@ -1391,8 +1395,23 @@ func (p *FunctionCallResponseProcessor) executeToolWithCallbacks(
 	if toolResult != nil {
 		suppressDefaultToolMessage = false
 	}
+	// When the after-tool callback replaced the result with a CustomResult,
+	// the original tool execution error should be cleared so that the
+	// caller uses the replacement result as the tool response message
+	// instead of discarding it due to a non-nil error.
+	if afterCallbackReplacedResult(toolErr, toolResult) {
+		toolErr = nil
+	}
 	return ctx, toolResult, toolCall.Function.Arguments,
 		suppressDefaultToolMessage, skipSummarization || localSkip, toolErr
+}
+
+// afterCallbackReplacedResult returns true when the after-tool callback has
+// replaced the original (failed) tool result with a non-nil custom result.
+// In that case the original toolErr should be cleared so that the framework
+// sends the replacement result as the tool response message to the model.
+func afterCallbackReplacedResult(toolErr error, toolResult any) bool {
+	return toolErr != nil && toolResult != nil
 }
 
 // isStreamable returns true if the tool supports streaming and its stream

--- a/internal/flow/processor/functioncall_test.go
+++ b/internal/flow/processor/functioncall_test.go
@@ -5329,6 +5329,56 @@ func TestExecuteToolCall_LocalAfterToolCustomResultProducesToolMessage(
 	require.Contains(t, choices[0].Message.Content, "Formatted error")
 }
 
+// TestExecuteToolWithCallbacks_StopErrorPreservedWithCustomResult verifies that
+// when a tool returns a StopError, the error is NOT cleared even if the
+// AfterTool callback provides a CustomResult. StopError is a control-flow
+// signal that must propagate so the agent can stop execution.
+func TestExecuteToolWithCallbacks_StopErrorPreservedWithCustomResult(
+	t *testing.T,
+) {
+	local := tool.NewCallbacks()
+	local.RegisterAfterTool(func(
+		ctx context.Context,
+		args *tool.AfterToolArgs,
+	) (*tool.AfterToolResult, error) {
+		if args.Error != nil {
+			return &tool.AfterToolResult{
+				CustomResult: "friendly stop message",
+			}, nil
+		}
+		return nil, nil
+	})
+
+	proc := NewFunctionCallResponseProcessor(false, local)
+	inv := &agent.Invocation{AgentName: "test-agent"}
+	tl := &mockCallableTool{
+		declaration: &tool.Declaration{Name: "stop_tool"},
+		callFn: func(_ context.Context, _ []byte) (any, error) {
+			return nil, agent.NewStopError("max iterations reached")
+		},
+	}
+	toolCall := model.ToolCall{
+		ID: "call-stop",
+		Function: model.FunctionDefinitionParam{
+			Name:      "stop_tool",
+			Arguments: []byte(`{}`),
+		},
+	}
+
+	_, _, _, _, _, err := proc.executeToolWithCallbacks(
+		context.Background(),
+		inv,
+		toolCall,
+		tl,
+		nil,
+	)
+	// StopError must be preserved even though the callback returned a
+	// CustomResult.
+	require.Error(t, err)
+	_, ok := agent.AsStopError(err)
+	require.True(t, ok, "expected StopError to be preserved")
+}
+
 func TestExecuteToolWithCallbacks_BeforeError(t *testing.T) {
 	cb := tool.NewCallbacks()
 	cb.RegisterBeforeTool(func(_ context.Context, _ string,

--- a/internal/flow/processor/functioncall_test.go
+++ b/internal/flow/processor/functioncall_test.go
@@ -5149,7 +5149,7 @@ func TestExecuteToolWithCallbacks_PluginAfterToolError(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestExecuteToolWithCallbacks_PluginAfterToolOverridePreservesErr(
+func TestExecuteToolWithCallbacks_PluginAfterToolOverrideClearsErr(
 	t *testing.T,
 ) {
 	localAfterCalled := false
@@ -5203,9 +5203,130 @@ func TestExecuteToolWithCallbacks_PluginAfterToolOverridePreservesErr(
 		tl,
 		nil,
 	)
-	require.ErrorIs(t, err, toolErr)
+	// When a plugin AfterTool callback replaces the failed tool result with
+	// a CustomResult, the original tool error should be cleared so that the
+	// framework sends the replacement as the tool response message.
+	require.NoError(t, err)
 	require.False(t, localAfterCalled)
 	require.Equal(t, map[string]any{"p": true}, res)
+}
+
+// TestExecuteToolWithCallbacks_LocalAfterToolCustomResultReplacesFailedResult
+// verifies that when a tool execution fails and the local AfterTool callback
+// returns a non-nil CustomResult, the original error is cleared and the
+// CustomResult is used as the tool response message to the model.
+// This is the exact scenario reported by users: MCP tool fails, AfterTool
+// callback formats a friendly error message via CustomResult, but the model
+// still sees the original failure.
+func TestExecuteToolWithCallbacks_LocalAfterToolCustomResultReplacesFailedResult(
+	t *testing.T,
+) {
+	replacementResult := map[string]string{
+		"status":  "error",
+		"message": "The tool encountered an issue, please try a different approach.",
+	}
+
+	local := tool.NewCallbacks()
+	local.RegisterAfterTool(func(
+		ctx context.Context,
+		args *tool.AfterToolArgs,
+	) (*tool.AfterToolResult, error) {
+		// Simulate the user's scenario: detect tool failure and provide
+		// a formatted custom result.
+		if args.Error != nil {
+			return &tool.AfterToolResult{
+				CustomResult: replacementResult,
+			}, nil
+		}
+		return nil, nil
+	})
+
+	proc := NewFunctionCallResponseProcessor(false, local)
+	inv := &agent.Invocation{AgentName: "test-agent"}
+	tl := &mockCallableTool{
+		declaration: &tool.Declaration{Name: "mcp_tool"},
+		callFn: func(_ context.Context, _ []byte) (any, error) {
+			return nil, errors.New("Tool Exec Failed: connection timeout")
+		},
+	}
+	toolCall := model.ToolCall{
+		ID: "call-1",
+		Function: model.FunctionDefinitionParam{
+			Name:      "mcp_tool",
+			Arguments: []byte(`{"query":"test"}`),
+		},
+	}
+
+	_, res, _, _, _, err := proc.executeToolWithCallbacks(
+		context.Background(),
+		inv,
+		toolCall,
+		tl,
+		nil,
+	)
+	// The original tool error should be cleared because the callback
+	// replaced the result.
+	require.NoError(t, err)
+	require.Equal(t, replacementResult, res)
+}
+
+// TestExecuteToolCall_LocalAfterToolCustomResultProducesToolMessage verifies
+// the end-to-end flow: a failed tool + AfterTool CustomResult produces a
+// proper RoleTool message with the custom content.
+func TestExecuteToolCall_LocalAfterToolCustomResultProducesToolMessage(
+	t *testing.T,
+) {
+	replacementResult := "Formatted error: tool timed out, please retry."
+
+	local := tool.NewCallbacks()
+	local.RegisterAfterTool(func(
+		ctx context.Context,
+		args *tool.AfterToolArgs,
+	) (*tool.AfterToolResult, error) {
+		if args.Error != nil {
+			return &tool.AfterToolResult{
+				CustomResult: replacementResult,
+			}, nil
+		}
+		return nil, nil
+	})
+
+	proc := NewFunctionCallResponseProcessor(false, local)
+	inv := &agent.Invocation{
+		AgentName: "test-agent",
+		Model:     &mockModel{},
+	}
+	tl := &mockCallableTool{
+		declaration: &tool.Declaration{Name: "mcp_tool"},
+		callFn: func(_ context.Context, _ []byte) (any, error) {
+			return nil, errors.New("Tool Exec Failed")
+		},
+	}
+	toolCall := model.ToolCall{
+		ID: "call-1",
+		Function: model.FunctionDefinitionParam{
+			Name:      "mcp_tool",
+			Arguments: []byte(`{}`),
+		},
+	}
+	tools := map[string]tool.Tool{"mcp_tool": tl}
+
+	_, choices, _, _, _, err := proc.executeToolCall(
+		context.Background(),
+		inv,
+		toolCall,
+		tools,
+		0,
+		nil,
+	)
+	// choices should not be nil; the custom result should appear as a
+	// RoleTool message.
+	require.NoError(t, err)
+	require.NotNil(t, choices)
+	require.Len(t, choices, 1)
+	require.Equal(t, model.RoleTool, choices[0].Message.Role)
+	require.Equal(t, "call-1", choices[0].Message.ToolID)
+	require.Contains(t, choices[0].Message.Content, "Formatted error")
 }
 
 func TestExecuteToolWithCallbacks_BeforeError(t *testing.T) {


### PR DESCRIPTION
## Problem

When a tool execution fails and the user's `AfterTool` callback returns a non-nil `CustomResult`, the framework preserves the original tool error. This causes the caller (`executeToolCall`) to discard the replacement result and report the raw error to the model.

This means users who register an `AfterTool` callback to intercept tool failures (e.g. MCP tool timeouts) and provide a human-friendly fallback message via `CustomResult` will find that the model still sees the original failure instead of their formatted replacement.

## Fix

After executing the after-tool callbacks (both plugin-level and local), check whether the callback replaced the result: if `toolErr != nil && toolResult != nil`, clear `toolErr` so that the framework sends the replacement `CustomResult` as the tool response message to the model.

A small helper `afterCallbackReplacedResult` encapsulates this check for both the plugin and local callback paths.

## Testing

- Updated the existing plugin after-tool override test to verify the error is cleared.
- Added `TestExecuteToolWithCallbacks_LocalAfterToolCustomResultReplacesFailedResult`: verifies that a local `AfterTool` callback returning `CustomResult` clears the original error at the `executeToolWithCallbacks` level.
- Added `TestExecuteToolCall_LocalAfterToolCustomResultProducesToolMessage`: end-to-end test verifying the full flow produces a proper `RoleTool` message with the custom content.