### PR TITLE
openclaw: fix shared-session runtime sync in conversationscope

### DIFF
--- a/openclaw/internal/conversationscope/session_service.go
+++ b/openclaw/internal/conversationscope/session_service.go
@@ -166,11 +166,17 @@ func (s *sessionService) AppendEvent(
 	evt *event.Event,
 	options ...session.Option,
 ) error {
-	return s.next.AppendEvent(
+	return s.withStorageSessionRuntimeSync(
 		ctx,
-		rewriteSessionForStorage(ctx, sess),
-		evt,
-		options...,
+		sess,
+		func(storageSess *session.Session) error {
+			return s.next.AppendEvent(
+				ctx,
+				storageSess,
+				evt,
+				options...,
+			)
+		},
 	)
 }
 
@@ -180,11 +186,17 @@ func (s *sessionService) CreateSessionSummary(
 	filterKey string,
 	force bool,
 ) error {
-	return s.next.CreateSessionSummary(
+	return s.withStorageSessionRuntimeSync(
 		ctx,
-		rewriteSessionForStorage(ctx, sess),
-		filterKey,
-		force,
+		sess,
+		func(storageSess *session.Session) error {
+			return s.next.CreateSessionSummary(
+				ctx,
+				storageSess,
+				filterKey,
+				force,
+			)
+		},
 	)
 }
 
@@ -194,11 +206,17 @@ func (s *sessionService) EnqueueSummaryJob(
 	filterKey string,
 	force bool,
 ) error {
-	return s.next.EnqueueSummaryJob(
+	return s.withStorageSessionRuntimeSync(
 		ctx,
-		rewriteSessionForStorage(ctx, sess),
-		filterKey,
-		force,
+		sess,
+		func(storageSess *session.Session) error {
+			return s.next.EnqueueSummaryJob(
+				ctx,
+				storageSess,
+				filterKey,
+				force,
+			)
+		},
 	)
 }
 
@@ -250,4 +268,49 @@ func rewriteSessionForUser(
 	cloned := sess.Clone()
 	cloned.UserID = userID
 	return cloned
+}
+
+// withStorageSessionRuntimeSync keeps the caller's canonical session runtime
+// state aligned with backend-visible mutations applied to a storage-scoped
+// clone. This preserves canonical UserID semantics while avoiding split-brain
+// state during the current invocation.
+func (s *sessionService) withStorageSessionRuntimeSync(
+	ctx context.Context,
+	sess *session.Session,
+	apply func(*session.Session) error,
+) error {
+	storageSess := rewriteSessionForStorage(ctx, sess)
+	if err := apply(storageSess); err != nil {
+		return err
+	}
+	syncSessionRuntimeState(sess, storageSess)
+	return nil
+}
+
+func syncSessionRuntimeState(
+	dst *session.Session,
+	src *session.Session,
+) {
+	if dst == nil || src == nil || dst == src {
+		return
+	}
+
+	snapshot := src.Clone()
+
+	dst.EventMu.Lock()
+	dst.Events = snapshot.Events
+	dst.EventMu.Unlock()
+
+	session.WithSessionState(snapshot.State)(dst)
+
+	dst.TracksMu.Lock()
+	dst.Tracks = snapshot.Tracks
+	dst.TracksMu.Unlock()
+
+	dst.SummariesMu.Lock()
+	dst.Summaries = snapshot.Summaries
+	dst.SummariesMu.Unlock()
+
+	dst.ServiceMeta = snapshot.ServiceMeta
+	dst.UpdatedAt = snapshot.UpdatedAt
 }

--- a/openclaw/internal/conversationscope/session_service_test.go
+++ b/openclaw/internal/conversationscope/session_service_test.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -55,12 +56,15 @@ type recordingSessionService struct {
 	updateSessionState  session.StateMap
 	appendSession       *session.Session
 	appendEvent         *event.Event
+	appendFunc          func(*session.Session, *event.Event)
 	createSummarySess   *session.Session
 	createSummaryKey    string
 	createSummaryForce  bool
+	createSummaryFunc   func(*session.Session, string, bool)
 	enqueueSummarySess  *session.Session
 	enqueueSummaryKey   string
 	enqueueSummaryForce bool
+	enqueueSummaryFunc  func(*session.Session, string, bool)
 	getSummarySess      *session.Session
 	getSummaryText      string
 	getSummaryOK        bool
@@ -208,6 +212,9 @@ func (r *recordingSessionService) AppendEvent(
 ) error {
 	r.appendSession = sess
 	r.appendEvent = evt
+	if r.appendFunc != nil {
+		r.appendFunc(sess, evt)
+	}
 	return nil
 }
 
@@ -220,6 +227,9 @@ func (r *recordingSessionService) CreateSessionSummary(
 	r.createSummarySess = sess
 	r.createSummaryKey = filterKey
 	r.createSummaryForce = force
+	if r.createSummaryFunc != nil {
+		r.createSummaryFunc(sess, filterKey, force)
+	}
 	return nil
 }
 
@@ -232,6 +242,9 @@ func (r *recordingSessionService) EnqueueSummaryJob(
 	r.enqueueSummarySess = sess
 	r.enqueueSummaryKey = filterKey
 	r.enqueueSummaryForce = force
+	if r.enqueueSummaryFunc != nil {
+		r.enqueueSummaryFunc(sess, filterKey, force)
+	}
 	return nil
 }
 
@@ -360,6 +373,13 @@ func TestWrapSessionService_UsesContextStorageScopeForStorage(t *testing.T) {
 			),
 		),
 	)
+	require.Equal(t, "canonical-user", sess.UserID)
+	require.Len(t, sess.Events, 2)
+	require.True(
+		t,
+		sess.Events[1].Response.Choices[0].Message.Role ==
+			model.RoleAssistant,
+	)
 
 	updated, err := base.GetSession(context.Background(), storageKey)
 	require.NoError(t, err)
@@ -369,6 +389,61 @@ func TestWrapSessionService_UsesContextStorageScopeForStorage(t *testing.T) {
 	raw, ok := updated.GetState("migrated")
 	require.True(t, ok)
 	require.Equal(t, []byte("yes"), raw)
+}
+
+func TestWrapSessionService_SyncsSummaryRuntimeState(t *testing.T) {
+	t.Parallel()
+
+	const filterKey = "branch"
+
+	updatedAt := time.Date(
+		2026,
+		time.April,
+		8,
+		20,
+		11,
+		0,
+		0,
+		time.UTC,
+	)
+	rec := &recordingSessionService{
+		createSummaryFunc: func(
+			sess *session.Session,
+			filterKey string,
+			force bool,
+		) {
+			sess.SummariesMu.Lock()
+			sess.Summaries = map[string]*session.Summary{
+				filterKey: {
+					Summary:   "group summary",
+					UpdatedAt: updatedAt,
+				},
+			}
+			sess.SummariesMu.Unlock()
+			sess.UpdatedAt = updatedAt
+		},
+	}
+	wrapped := WrapSessionService(rec)
+	ctx := WithStorageUserID(context.Background(), "chat-scope")
+	sess := session.NewSession(
+		"demo-app",
+		"canonical-user",
+		"sess-1",
+	)
+
+	err := wrapped.CreateSessionSummary(ctx, sess, filterKey, true)
+	require.NoError(t, err)
+	require.Equal(t, "canonical-user", sess.UserID)
+	require.Equal(t, updatedAt, sess.UpdatedAt)
+
+	sess.SummariesMu.RLock()
+	sum := sess.Summaries[filterKey]
+	sess.SummariesMu.RUnlock()
+
+	require.NotNil(t, sum)
+	require.Equal(t, "group summary", sum.Summary)
+	require.Equal(t, updatedAt, sum.UpdatedAt)
+	require.Equal(t, "chat-scope", rec.createSummarySess.UserID)
 }
 
 func TestWrapSessionService_WithoutStorageOverrideKeepsCanonicalUser(t *testing.T) {


### PR DESCRIPTION
## What changed
- keep canonical sessions in sync after storage-scope rewrites for mutating session calls
- route `AppendEvent`, `CreateSessionSummary`, and `EnqueueSummaryJob` through a small wrapper that copies backend-visible runtime mutations back into the caller session
- add regression tests for shared-scope event history and summary state sync

## Why
Group/shared history mode rewrites session storage keys to a conversation-scoped user. The wrapper previously cloned the session for storage writes, so backends mutated a storage-scoped clone while the current invocation kept reading a stale canonical session. In practice this let events persist successfully but prevented the next model request from seeing newly appended assistant/tool history.

## Impact
- shared-session flows keep current-turn runtime history aligned with persisted writes
- canonical `Session.UserID` semantics stay unchanged for callers and downstream features
- no backend-specific special casing was introduced

## Validation
- `cd openclaw && go test ./internal/conversationscope`
- `cd openclaw && go test ./...`
- `cd openclaw && go test -cover ./internal/conversationscope` (`95.7%`)

## Notes
Repository-root `go test ./...` still has unrelated environment-sensitive failures in this shell:
- `codeexecutor/local.TestRuntime_RunProgram_InjectsWorkspaceEnvs` sees the shell startup banner in stdout
- `telemetry/langfuse/config.TestFromEnv_Defaults` picks up preset `LANGFUSE_*` env vars
