### PR TITLE
{agent, internal, docs}: add per-run code executor overrides

### DIFF
--- a/agent/invocation.go
+++ b/agent/invocation.go
@@ -21,6 +21,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	oteltrace "go.opentelemetry.io/otel/trace"
 	"trpc.group/trpc-go/trpc-agent-go/artifact"
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
 	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/internal/jsonschema"
 	"trpc.group/trpc-go/trpc-agent-go/internal/tracecapture"
@@ -559,6 +560,15 @@ func WithModelName(name string) RunOption {
 	}
 }
 
+// WithCodeExecutor sets the code executor for this specific run.
+// If set, it temporarily overrides the agent's default code executor for this
+// request only.
+func WithCodeExecutor(exec codeexecutor.CodeExecutor) RunOption {
+	return func(opts *RunOptions) {
+		opts.CodeExecutor = exec
+	}
+}
+
 // WithStream enables or disables streaming for this specific run.
 //
 // When set, it overrides the agent's default Stream setting for this Run.
@@ -929,6 +939,11 @@ type RunOptions struct {
 	// The agent will look up the model by name from its registered models.
 	// If both Model and ModelName are set, Model takes precedence.
 	ModelName string
+
+	// CodeExecutor is the code executor to use for this specific run.
+	// If set, it temporarily overrides the agent's default code executor for
+	// this request only.
+	CodeExecutor codeexecutor.CodeExecutor
 
 	// Stream overrides GenerationConfig.Stream for this run when non-nil.
 	//

--- a/agent/invocation_messages_test.go
+++ b/agent/invocation_messages_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
@@ -133,6 +134,13 @@ func TestWithMaxRunDuration(t *testing.T) {
 	require.Equal(t, maxRun, ro.MaxRunDuration)
 }
 
+func TestWithCodeExecutor(t *testing.T) {
+	exec := &invocationTestCodeExecutor{}
+	var ro RunOptions
+	WithCodeExecutor(exec)(&ro)
+	require.Same(t, exec, ro.CodeExecutor)
+}
+
 func TestWithA2ARequestOptions(t *testing.T) {
 	tests := []struct {
 		name string
@@ -163,6 +171,19 @@ func TestWithA2ARequestOptions(t *testing.T) {
 			}
 		})
 	}
+}
+
+type invocationTestCodeExecutor struct{}
+
+func (*invocationTestCodeExecutor) ExecuteCode(
+	context.Context,
+	codeexecutor.CodeExecutionInput,
+) (codeexecutor.CodeExecutionResult, error) {
+	return codeexecutor.CodeExecutionResult{}, nil
+}
+
+func (*invocationTestCodeExecutor) CodeBlockDelimiter() codeexecutor.CodeBlockDelimiter {
+	return codeexecutor.CodeBlockDelimiter{Start: "```", End: "```"}
 }
 
 func TestMultipleRunOptions(t *testing.T) {

--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -272,6 +272,9 @@ func buildRequestProcessorsWithAgent(a *LLMAgent, options *Options) []flow.Reque
 		),
 		processor.WithSkillLoadMode(options.SkillLoadMode),
 		processor.WithSkillToolFlags(skillFlags),
+		processor.WithSkillToolFlagsResolver(
+			a.skillToolFlagsForInvocation,
+		),
 	)
 	if options.MaxLoadedSkills > 0 {
 		skillsOpts = append(
@@ -294,26 +297,22 @@ func buildRequestProcessorsWithAgent(a *LLMAgent, options *Options) []flow.Reque
 	requestProcessors = append(requestProcessors, skillsProcessor)
 
 	// 6. Workspace exec processor - injects executor/workspace guidance
-	// whenever workspace_exec is registered, even without a skills repo.
-	if executorSupportsWorkspaceExec(options) {
-		var workspaceOpts []processor.WorkspaceExecRequestProcessorOption
-		if executorSupportsWorkspaceExecSessions(options) {
-			workspaceOpts = append(
-				workspaceOpts,
-				processor.WithWorkspaceExecSessionsEnabled(),
-			)
-		}
-		workspaceOpts = append(
-			workspaceOpts,
-			processor.WithWorkspaceExecSkillsRepositoryResolver(
-				a.skillRepositoryForInvocation,
-			),
-		)
-		requestProcessors = append(
-			requestProcessors,
-			processor.NewWorkspaceExecRequestProcessor(workspaceOpts...),
-		)
+	// when the current invocation exposes workspace_exec capability.
+	workspaceOpts := []processor.WorkspaceExecRequestProcessorOption{
+		processor.WithWorkspaceExecEnabledResolver(
+			a.supportsWorkspaceExecForInvocation,
+		),
+		processor.WithWorkspaceExecSessionsResolver(
+			a.supportsWorkspaceExecSessionsForInvocation,
+		),
+		processor.WithWorkspaceExecSkillsRepositoryResolver(
+			a.skillRepositoryForInvocation,
+		),
 	}
+	requestProcessors = append(
+		requestProcessors,
+		processor.NewWorkspaceExecRequestProcessor(workspaceOpts...),
+	)
 
 	// 7. Content processor - appends conversation/context history.
 	contentOpts := []processor.ContentOption{
@@ -615,12 +614,13 @@ func appendSkillTools(
 	options *Options,
 	runTool *toolskill.RunTool,
 ) []tool.Tool {
-	return appendSkillToolsWithRepo(
+	return appendSkillToolsWithRepoAndFlags(
 		allTools,
 		options,
 		options.skillsRepository,
 		nil,
 		runTool,
+		mustResolveSkillToolFlags(options),
 	)
 }
 
@@ -631,11 +631,27 @@ func appendSkillToolsWithRepo(
 	reg *codeexecutor.WorkspaceRegistry,
 	runTool *toolskill.RunTool,
 ) []tool.Tool {
+	return appendSkillToolsWithRepoAndFlags(
+		allTools,
+		options,
+		repo,
+		reg,
+		runTool,
+		mustResolveSkillToolFlags(options),
+	)
+}
+
+func appendSkillToolsWithRepoAndFlags(
+	allTools []tool.Tool,
+	options *Options,
+	repo skill.Repository,
+	reg *codeexecutor.WorkspaceRegistry,
+	runTool *toolskill.RunTool,
+	skillFlags skillprofile.Flags,
+) []tool.Tool {
 	if repo == nil {
 		return allTools
 	}
-
-	skillFlags := mustResolveSkillToolFlags(options)
 	if skillFlags.Load {
 		allTools = append(
 			allTools,
@@ -659,7 +675,7 @@ func appendSkillToolsWithRepo(
 	}
 
 	if runTool == nil {
-		runTool = buildSkillRunToolWithRepo(options, repo, reg)
+		runTool = buildSkillRunToolWithRepo(options, repo, reg, nil)
 	}
 	if skillFlags.Run {
 		allTools = append(allTools, runTool)
@@ -667,10 +683,6 @@ func appendSkillToolsWithRepo(
 	if !skillFlags.RequiresExecSessionTools() {
 		return allTools
 	}
-	if !executorSupportsInteractive(options) {
-		return allTools
-	}
-
 	execTool := toolskill.NewExecTool(runTool)
 	if skillFlags.Exec {
 		allTools = append(allTools, execTool)
@@ -697,6 +709,20 @@ func appendSkillToolsWithRepo(
 }
 
 func mustResolveSkillToolFlags(options *Options) skillprofile.Flags {
+	var exec codeexecutor.CodeExecutor
+	if options != nil {
+		exec = options.codeExecutor
+	}
+	return mustResolveSkillToolFlagsWithExecutor(options, exec)
+}
+
+func mustResolveSkillToolFlagsWithExecutor(
+	options *Options,
+	exec codeexecutor.CodeExecutor,
+) skillprofile.Flags {
+	if options == nil {
+		return skillprofile.Flags{}
+	}
 	flags, err := skillprofile.ResolveFlags(
 		options.skillToolProfile,
 		options.allowedSkillTools,
@@ -715,8 +741,7 @@ func mustResolveSkillToolFlags(options *Options) skillprofile.Flags {
 			"skill_run and skill_exec require skill_load when " +
 			"WithSkillRunRequireSkillLoaded is enabled")
 	}
-
-	if !executorSupportsInteractive(options) {
+	if !codeExecutorSupportsInteractive(exec) {
 		flags = flags.WithoutInteractiveExecution()
 	}
 	return flags
@@ -728,11 +753,33 @@ func appendWorkspaceExecTool(
 	reg *codeexecutor.WorkspaceRegistry,
 	inv *agent.Invocation,
 ) []tool.Tool {
-	if !executorSupportsWorkspaceExec(options) {
+	var exec codeexecutor.CodeExecutor
+	if options != nil {
+		exec = options.codeExecutor
+	}
+	return appendWorkspaceExecToolWithExecutor(
+		allTools,
+		exec,
+		codeExecutorSupportsWorkspaceExec(exec),
+		codeExecutorSupportsWorkspaceExecSessions(exec),
+		reg,
+		inv,
+	)
+}
+
+func appendWorkspaceExecToolWithExecutor(
+	allTools []tool.Tool,
+	exec codeexecutor.CodeExecutor,
+	enabled bool,
+	sessional bool,
+	reg *codeexecutor.WorkspaceRegistry,
+	inv *agent.Invocation,
+) []tool.Tool {
+	if !enabled {
 		return allTools
 	}
 	execTool := toolworkspaceexec.NewExecTool(
-		options.codeExecutor,
+		exec,
 		toolworkspaceexec.WithWorkspaceRegistry(reg),
 	)
 	allTools = append(
@@ -745,7 +792,7 @@ func appendWorkspaceExecTool(
 			toolworkspaceexec.NewSaveArtifactTool(execTool),
 		)
 	}
-	if executorSupportsWorkspaceExecSessions(options) {
+	if sessional {
 		allTools = append(
 			allTools,
 			toolworkspaceexec.NewWriteStdinTool(execTool),
@@ -767,6 +814,7 @@ func buildSkillRunTool(
 		options,
 		options.skillsRepository,
 		reg,
+		nil,
 	)
 }
 
@@ -774,8 +822,11 @@ func buildSkillRunToolWithRepo(
 	options *Options,
 	repo skill.Repository,
 	reg *codeexecutor.WorkspaceRegistry,
+	exec codeexecutor.CodeExecutor,
 ) *toolskill.RunTool {
-	exec := options.codeExecutor
+	if exec == nil && options != nil {
+		exec = options.codeExecutor
+	}
 	if exec == nil {
 		exec = defaultCodeExecutor()
 	}
@@ -837,7 +888,14 @@ func buildSkillRunToolWithRepo(
 // a local engine which does support interactive sessions, so we
 // return true in those cases.
 func executorSupportsInteractive(options *Options) bool {
-	exec := options.codeExecutor
+	var exec codeexecutor.CodeExecutor
+	if options != nil {
+		exec = options.codeExecutor
+	}
+	return codeExecutorSupportsInteractive(exec)
+}
+
+func codeExecutorSupportsInteractive(exec codeexecutor.CodeExecutor) bool {
 	if exec == nil {
 		exec = defaultCodeExecutor()
 	}
@@ -860,10 +918,17 @@ func executorSupportsInteractive(options *Options) bool {
 // not fall back to the local engine because that would silently move
 // commands onto the agent host instead of the configured executor.
 func executorSupportsWorkspaceExec(options *Options) bool {
-	if options == nil || options.codeExecutor == nil {
+	if options == nil {
 		return false
 	}
-	ep, ok := options.codeExecutor.(codeexecutor.EngineProvider)
+	return codeExecutorSupportsWorkspaceExec(options.codeExecutor)
+}
+
+func codeExecutorSupportsWorkspaceExec(exec codeexecutor.CodeExecutor) bool {
+	if exec == nil {
+		return false
+	}
+	ep, ok := exec.(codeexecutor.EngineProvider)
 	if !ok || ep == nil {
 		return false
 	}
@@ -877,10 +942,19 @@ func executorSupportsWorkspaceExec(options *Options) bool {
 // executorSupportsWorkspaceExecSessions reports whether workspace_exec can
 // expose interactive session helpers such as workspace_write_stdin.
 func executorSupportsWorkspaceExecSessions(options *Options) bool {
-	if !executorSupportsWorkspaceExec(options) {
+	if options == nil {
 		return false
 	}
-	ep := options.codeExecutor.(codeexecutor.EngineProvider)
+	return codeExecutorSupportsWorkspaceExecSessions(options.codeExecutor)
+}
+
+func codeExecutorSupportsWorkspaceExecSessions(
+	exec codeexecutor.CodeExecutor,
+) bool {
+	if !codeExecutorSupportsWorkspaceExec(exec) {
+		return false
+	}
+	ep := exec.(codeexecutor.EngineProvider)
 	eng := ep.Engine()
 	if eng == nil || eng.Runner() == nil {
 		return false

--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -614,12 +614,17 @@ func appendSkillTools(
 	options *Options,
 	runTool *toolskill.RunTool,
 ) []tool.Tool {
+	var exec codeexecutor.CodeExecutor
+	if options != nil {
+		exec = options.codeExecutor
+	}
 	return appendSkillToolsWithRepoAndFlags(
 		allTools,
 		options,
 		options.skillsRepository,
 		nil,
 		runTool,
+		exec,
 		mustResolveSkillToolFlags(options),
 	)
 }
@@ -631,12 +636,17 @@ func appendSkillToolsWithRepo(
 	reg *codeexecutor.WorkspaceRegistry,
 	runTool *toolskill.RunTool,
 ) []tool.Tool {
+	var exec codeexecutor.CodeExecutor
+	if options != nil {
+		exec = options.codeExecutor
+	}
 	return appendSkillToolsWithRepoAndFlags(
 		allTools,
 		options,
 		repo,
 		reg,
 		runTool,
+		exec,
 		mustResolveSkillToolFlags(options),
 	)
 }
@@ -647,6 +657,7 @@ func appendSkillToolsWithRepoAndFlags(
 	repo skill.Repository,
 	reg *codeexecutor.WorkspaceRegistry,
 	runTool *toolskill.RunTool,
+	exec codeexecutor.CodeExecutor,
 	skillFlags skillprofile.Flags,
 ) []tool.Tool {
 	if repo == nil {
@@ -675,7 +686,7 @@ func appendSkillToolsWithRepoAndFlags(
 	}
 
 	if runTool == nil {
-		runTool = buildSkillRunToolWithRepo(options, repo, reg, nil)
+		runTool = buildSkillRunToolWithRepo(options, repo, reg, exec)
 	}
 	if skillFlags.Run {
 		allTools = append(allTools, runTool)

--- a/agent/llmagent/llm_agent_skill_test.go
+++ b/agent/llmagent/llm_agent_skill_test.go
@@ -243,6 +243,23 @@ func TestLLMAgent_InvocationToolSurface_RunCodeExecutorOverridesStaticExecutor(
 	require.Nil(t, findTool(tools, "skill_write_stdin"))
 	require.Nil(t, findTool(tools, "skill_poll_session"))
 	require.Nil(t, findTool(tools, "skill_kill_session"))
+
+	runTool, ok := findTool(tools, "skill_run").(*toolskill.RunTool)
+	require.True(t, ok)
+	runToolVal := reflect.ValueOf(runTool).Elem()
+	execField := reflect.NewAt(
+		runToolVal.FieldByName("exec").Type(),
+		unsafe.Pointer(runToolVal.FieldByName("exec").UnsafeAddr()),
+	).Elem()
+	require.Same(t, inv.RunOptions.CodeExecutor, execField.Interface())
+	args := map[string]any{"skill": testSkillName, "command": "echo ok"}
+	b, err := json.Marshal(args)
+	require.NoError(t, err)
+	_, err = runTool.Call(context.Background(), b)
+	require.NoError(t, err)
+	overrideExec, ok := inv.RunOptions.CodeExecutor.(*stubExec)
+	require.True(t, ok)
+	require.True(t, overrideExec.ran)
 }
 
 func TestLLMAgent_WorkspaceSaveArtifactRegisteredForInvocationCapability(

--- a/agent/llmagent/llm_agent_skill_test.go
+++ b/agent/llmagent/llm_agent_skill_test.go
@@ -193,6 +193,58 @@ func TestLLMAgent_WorkspaceExecOmittedWithoutExplicitExecutor(t *testing.T) {
 	require.False(t, names["workspace_save_artifact"])
 }
 
+func TestLLMAgent_InvocationToolSurface_UsesRunCodeExecutorForWorkspaceExec(
+	t *testing.T,
+) {
+	root := createTestSkill(t)
+	repo, err := skill.NewFSRepository(root)
+	require.NoError(t, err)
+	a := New("tester", WithSkills(repo))
+	inv := &agent.Invocation{
+		RunOptions: agent.NewRunOptions(
+			agent.WithCodeExecutor(&interactiveStubExec{}),
+		),
+	}
+
+	tools, _ := a.InvocationToolSurface(context.Background(), inv)
+	require.NotNil(t, findTool(tools, "workspace_exec"))
+	require.NotNil(t, findTool(tools, "workspace_write_stdin"))
+	require.NotNil(t, findTool(tools, "workspace_kill_session"))
+	require.NotNil(t, findTool(tools, "skill_run"))
+	require.NotNil(t, findTool(tools, "skill_exec"))
+	require.NotNil(t, findTool(tools, "skill_write_stdin"))
+	require.NotNil(t, findTool(tools, "skill_poll_session"))
+	require.NotNil(t, findTool(tools, "skill_kill_session"))
+}
+
+func TestLLMAgent_InvocationToolSurface_RunCodeExecutorOverridesStaticExecutor(
+	t *testing.T,
+) {
+	root := createTestSkill(t)
+	repo, err := skill.NewFSRepository(root)
+	require.NoError(t, err)
+	a := New(
+		"tester",
+		WithSkills(repo),
+		WithCodeExecutor(&interactiveStubExec{}),
+	)
+	inv := &agent.Invocation{
+		RunOptions: agent.NewRunOptions(
+			agent.WithCodeExecutor(&stubExec{}),
+		),
+	}
+
+	tools, _ := a.InvocationToolSurface(context.Background(), inv)
+	require.NotNil(t, findTool(tools, "workspace_exec"))
+	require.Nil(t, findTool(tools, "workspace_write_stdin"))
+	require.Nil(t, findTool(tools, "workspace_kill_session"))
+	require.NotNil(t, findTool(tools, "skill_run"))
+	require.Nil(t, findTool(tools, "skill_exec"))
+	require.Nil(t, findTool(tools, "skill_write_stdin"))
+	require.Nil(t, findTool(tools, "skill_poll_session"))
+	require.Nil(t, findTool(tools, "skill_kill_session"))
+}
+
 func TestLLMAgent_WorkspaceSaveArtifactRegisteredForInvocationCapability(
 	t *testing.T,
 ) {
@@ -1425,6 +1477,43 @@ func TestLLMAgent_GuidanceIncludesExecForInteractiveExecutor(t *testing.T) {
 	require.NotContains(t, sys, "workspace_save_artifact")
 	require.Contains(t, sys, "workspace_write_stdin")
 	require.Contains(t, sys, "workspace_kill_session")
+}
+
+func TestLLMAgent_GuidanceRunCodeExecutorOverrideDisablesInteractiveTools(
+	t *testing.T,
+) {
+	root := createTestSkill(t)
+	repo, err := skill.NewFSRepository(root)
+	require.NoError(t, err)
+
+	opts := &Options{}
+	WithSkills(repo)(opts)
+
+	procs := buildRequestProcessors("tester", opts)
+	inv := &agent.Invocation{
+		InvocationID: "inv1",
+		AgentName:    "tester",
+		Message:      model.NewUserMessage("u"),
+		Session:      &session.Session{},
+		RunOptions: agent.NewRunOptions(
+			agent.WithCodeExecutor(&stubExec{}),
+		),
+	}
+	req := &model.Request{}
+	for _, p := range procs {
+		p.ProcessRequest(context.Background(), inv, req, nil)
+	}
+
+	sys := findSystemMessageContaining(req, skillsOverviewHeader)
+	require.NotEmpty(t, sys)
+	require.Contains(t, sys, workspaceExecGuidanceHeader)
+	require.Contains(t, sys, "workspace_exec")
+	require.NotContains(t, sys, "skill_exec")
+	require.NotContains(t, sys, "skill_write_stdin")
+	require.NotContains(t, sys, "skill_poll_session")
+	require.NotContains(t, sys, "skill_kill_session")
+	require.NotContains(t, sys, "workspace_write_stdin")
+	require.NotContains(t, sys, "workspace_kill_session")
 }
 
 func TestLLMAgent_WorkspaceExecGuidanceWithoutSkillsRepo(t *testing.T) {

--- a/agent/llmagent/llm_agent_test.go
+++ b/agent/llmagent/llm_agent_test.go
@@ -1134,11 +1134,12 @@ func TestLLMAgent_EnableCodeExecutionResponseProcessor(t *testing.T) {
 		}
 	}
 
-	newInvocation := func() *agent.Invocation {
+	newInvocation := func(opts ...agent.RunOption) *agent.Invocation {
 		return &agent.Invocation{
 			Message:      model.NewUserMessage("hi"),
 			InvocationID: "test-invocation",
 			Session:      &session.Session{ID: "test-session"},
+			RunOptions:   agent.NewRunOptions(opts...),
 		}
 	}
 
@@ -1182,6 +1183,27 @@ func TestLLMAgent_EnableCodeExecutionResponseProcessor(t *testing.T) {
 
 		require.Equal(t, 0, exec.CallCount())
 		require.Equal(t, codeBlock, gotContent)
+	})
+
+	t.Run("run_override_takes_precedence", func(t *testing.T) {
+		staticExec := &countingCodeExecutor{}
+		overrideExec := &countingCodeExecutor{}
+		agt := New(
+			"test",
+			WithModel(newMockModel()),
+			WithCodeExecutor(staticExec),
+		)
+
+		events, err := agt.Run(
+			context.Background(),
+			newInvocation(agent.WithCodeExecutor(overrideExec)),
+		)
+		require.NoError(t, err)
+		for range events {
+		}
+
+		require.Equal(t, 0, staticExec.CallCount())
+		require.Equal(t, 1, overrideExec.CallCount())
 	})
 
 	t.Run("non_executable_markdown_block", func(t *testing.T) {

--- a/agent/llmagent/surface_runtime.go
+++ b/agent/llmagent/surface_runtime.go
@@ -195,6 +195,7 @@ func (a *LLMAgent) InvocationToolSurface(
 		effectiveSkills,
 		workspaceRegistry,
 		nil,
+		effectiveExec,
 		mustResolveSkillToolFlagsWithExecutor(
 			&options,
 			effectiveExec,

--- a/agent/llmagent/surface_runtime.go
+++ b/agent/llmagent/surface_runtime.go
@@ -15,6 +15,7 @@ import (
 	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
 	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
 	"trpc.group/trpc-go/trpc-agent-go/internal/flow/llmflow"
+	"trpc.group/trpc-go/trpc-agent-go/internal/skillprofile"
 	"trpc.group/trpc-go/trpc-agent-go/internal/surfacepatch"
 	itool "trpc.group/trpc-go/trpc-agent-go/internal/tool"
 	"trpc.group/trpc-go/trpc-agent-go/model"
@@ -76,6 +77,50 @@ func (a *LLMAgent) modelSurfaceForInvocation(
 	return patch.Model()
 }
 
+func (a *LLMAgent) codeExecutorForInvocation(
+	inv *agent.Invocation,
+) codeexecutor.CodeExecutor {
+	if inv != nil && inv.RunOptions.CodeExecutor != nil {
+		return inv.RunOptions.CodeExecutor
+	}
+	if a == nil {
+		return nil
+	}
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if a.codeExecutor != nil {
+		return a.codeExecutor
+	}
+	return a.option.codeExecutor
+}
+
+func (a *LLMAgent) supportsWorkspaceExecForInvocation(
+	inv *agent.Invocation,
+) bool {
+	return codeExecutorSupportsWorkspaceExec(a.codeExecutorForInvocation(inv))
+}
+
+func (a *LLMAgent) supportsWorkspaceExecSessionsForInvocation(
+	inv *agent.Invocation,
+) bool {
+	return codeExecutorSupportsWorkspaceExecSessions(a.codeExecutorForInvocation(inv))
+}
+
+func (a *LLMAgent) skillToolFlagsForInvocation(
+	inv *agent.Invocation,
+) skillprofile.Flags {
+	if a == nil {
+		return skillprofile.Flags{}
+	}
+	a.mu.RLock()
+	options := a.option
+	a.mu.RUnlock()
+	return mustResolveSkillToolFlagsWithExecutor(
+		&options,
+		a.codeExecutorForInvocation(inv),
+	)
+}
+
 // ExecutionTraceAppliedSurfaceIDs reports the effective surfaces that affected one invocation step.
 func (a *LLMAgent) ExecutionTraceAppliedSurfaceIDs(inv *agent.Invocation) []string {
 	nodeID := agent.InvocationSurfaceRootNodeID(inv)
@@ -129,24 +174,31 @@ func (a *LLMAgent) InvocationToolSurface(
 	allTools = appendKnowledgeTools(allTools, &options)
 
 	effectiveSkills := a.skillRepositoryForInvocation(inv)
+	effectiveExec := a.codeExecutorForInvocation(inv)
 	var workspaceRegistry *codeexecutor.WorkspaceRegistry
-	if effectiveSkills != nil && options.codeExecutor != nil {
+	if effectiveSkills != nil && effectiveExec != nil {
 		workspaceRegistry = buildWorkspaceRegistry()
-	} else if executorSupportsWorkspaceExec(&options) {
+	} else if codeExecutorSupportsWorkspaceExec(effectiveExec) {
 		workspaceRegistry = buildWorkspaceRegistry()
 	}
-	allTools = appendWorkspaceExecTool(
+	allTools = appendWorkspaceExecToolWithExecutor(
 		allTools,
-		&options,
+		effectiveExec,
+		codeExecutorSupportsWorkspaceExec(effectiveExec),
+		codeExecutorSupportsWorkspaceExecSessions(effectiveExec),
 		workspaceRegistry,
 		inv,
 	)
-	allTools = appendSkillToolsWithRepo(
+	allTools = appendSkillToolsWithRepoAndFlags(
 		allTools,
 		&options,
 		effectiveSkills,
 		workspaceRegistry,
 		nil,
+		mustResolveSkillToolFlagsWithExecutor(
+			&options,
+			effectiveExec,
+		),
 	)
 	if len(subAgents) == 0 {
 		return allTools, userToolNames

--- a/agent/llmagent/surface_runtime_test.go
+++ b/agent/llmagent/surface_runtime_test.go
@@ -514,3 +514,47 @@ func TestLLMAgent_Run_SurfacePatch_AddsSkillsWithoutStaticRepository(t *testing.
 	require.Contains(t, m.got.Tools, "skill_load")
 	require.Contains(t, m.got.Tools, "workspace_exec")
 }
+
+func TestLLMAgent_SurfaceRuntimeHelpers_NilAgentBranches(t *testing.T) {
+	var agt *LLMAgent
+	require.Nil(t, agt.codeExecutorForInvocation(nil))
+	flags := agt.skillToolFlagsForInvocation(nil)
+	require.False(t, flags.Load)
+	require.False(t, flags.SelectDocs)
+	require.False(t, flags.ListDocs)
+	require.False(t, flags.Run)
+	require.False(t, flags.Exec)
+	require.False(t, flags.WriteStdin)
+	require.False(t, flags.PollSession)
+	require.False(t, flags.KillSession)
+}
+
+func TestLLMAgent_AppendSkillToolsWithRepo_UsesResolvedFlags(t *testing.T) {
+	opts := &Options{}
+	WithSkillToolProfile(SkillToolProfileKnowledgeOnly)(opts)
+	tools := appendSkillToolsWithRepo(
+		nil,
+		opts,
+		&mockSkillRepository{
+			summaries: []skill.Summary{{Name: "skill-a", Description: "desc"}},
+		},
+		nil,
+		nil,
+	)
+	require.NotNil(t, findTool(tools, "skill_load"))
+	require.NotNil(t, findTool(tools, "skill_select_docs"))
+	require.NotNil(t, findTool(tools, "skill_list_docs"))
+	require.Nil(t, findTool(tools, "skill_run"))
+}
+
+func TestLLMAgent_SkillToolFlagsAndWorkspaceExecSessionHelpers_NilOptions(
+	t *testing.T,
+) {
+	flags := mustResolveSkillToolFlagsWithExecutor(nil, nil)
+	require.False(t, flags.Load)
+	require.False(t, flags.SelectDocs)
+	require.False(t, flags.ListDocs)
+	require.False(t, flags.Run)
+	require.False(t, flags.Exec)
+	require.False(t, executorSupportsWorkspaceExecSessions(nil))
+}

--- a/docs/mkdocs/en/runner.md
+++ b/docs/mkdocs/en/runner.md
@@ -540,6 +540,28 @@ it to `WithSurfacePatchForNode(...)`. If you need to patch multiple nodes in
 the same run, pass multiple `WithSurfacePatchForNode(...)` options. For full
 details and more examples, see [Agent: Override Runtime Surfaces by `nodeID`](./agent.md#override-runtime-surfaces-by-nodeid).
 
+### Override `code executor` Per Run
+
+If you need to specify a different execution environment for a particular
+request, pass `agent.WithCodeExecutor(exec)` to `runner.Run(...)`.
+
+```go
+events, err := r.Run(
+    ctx,
+    userID,
+    sessionID,
+    model.NewUserMessage("Run the release checklist skill."),
+    agent.WithCodeExecutor(containerExec),
+)
+```
+
+Notes:
+
+- This option applies only to the current `runner.Run(...)` call and does not change the agent's default configuration.
+- If the agent was created with `llmagent.WithCodeExecutor(...)`, the executor passed here temporarily overrides that default for this run.
+- All capabilities that depend on a code executor use the executor passed here for this run, including `workspace_exec`, `skill_run`, and interactive skill session tools.
+- If you only need to provide an execution environment for `skill_run` and do not want Markdown fenced code blocks in model replies to auto-execute, set `llmagent.WithEnableCodeExecutionResponseProcessor(false)` when creating the agent. See [Skill](./skill.md) for more details.
+
 ### ✅ Detecting End-of-Run and Reading Final Output (Graph-friendly)
 
 When driving a GraphAgent workflow, the LLM’s “final response” is not the end of

--- a/docs/mkdocs/en/runner.md
+++ b/docs/mkdocs/en/runner.md
@@ -543,7 +543,8 @@ details and more examples, see [Agent: Override Runtime Surfaces by `nodeID`](./
 ### Override `code executor` Per Run
 
 If you need to specify a different execution environment for a particular
-request, pass `agent.WithCodeExecutor(exec)` to `runner.Run(...)`.
+request on an agent that resolves its executor from `RunOptions.CodeExecutor`,
+such as `LLMAgent`, pass `agent.WithCodeExecutor(exec)` to `runner.Run(...)`.
 
 ```go
 events, err := r.Run(
@@ -558,6 +559,7 @@ events, err := r.Run(
 Notes:
 
 - This option applies only to the current `runner.Run(...)` call and does not change the agent's default configuration.
+- This option only applies to agents that read `RunOptions.CodeExecutor`. If you use a custom agent, make sure its implementation handles this run option.
 - If the agent was created with `llmagent.WithCodeExecutor(...)`, the executor passed here temporarily overrides that default for this run.
 - All capabilities that depend on a code executor use the executor passed here for this run, including `workspace_exec`, `skill_run`, and interactive skill session tools.
 - If you only need to provide an execution environment for `skill_run` and do not want Markdown fenced code blocks in model replies to auto-execute, set `llmagent.WithEnableCodeExecutionResponseProcessor(false)` when creating the agent. See [Skill](./skill.md) for more details.

--- a/docs/mkdocs/en/skill.md
+++ b/docs/mkdocs/en/skill.md
@@ -335,10 +335,11 @@ Key points:
     `llmagent.WithSkillRunRequireSkillLoaded(false)`.
   - Executor requirement follows the final registered tool set:
     any configuration without `skill_run` / `skill_exec` does not need
-    `WithCodeExecutor(...)`.
-- Note: when `WithCodeExecutor` is set, LLMAgent will (by default) try to
-  execute Markdown fenced code blocks in model responses. If you only need
-  the executor for `skill_run`, disable this behavior with
+    `llmagent.WithCodeExecutor(...)` or `agent.WithCodeExecutor(...)`.
+- Note: when `llmagent.WithCodeExecutor(...)` is set, or when
+  `agent.WithCodeExecutor(...)` is passed to `runner.Run(...)`, LLMAgent will
+  (by default) try to execute Markdown fenced code blocks in model responses.
+  If you only need the executor for `skill_run`, disable this behavior with
   `llmagent.WithEnableCodeExecutionResponseProcessor(false)`.
 - By default, the framework appends a small `Tooling and workspace guidance:`
   block after the `Available skills:` list in the system message.

--- a/docs/mkdocs/zh/runner.md
+++ b/docs/mkdocs/zh/runner.md
@@ -527,7 +527,7 @@ events, err := r.Run(
 
 #### 按运行临时覆盖 `code executor`
 
-如果需要为同一个 Agent 的不同请求指定不同的执行环境，可以在 `runner.Run(...)` 中直接传入 `agent.WithCodeExecutor(exec)`。
+如果需要为会从 `RunOptions.CodeExecutor` 解析执行器的 Agent 在不同请求中指定不同的执行环境，例如 `LLMAgent`，可以在 `runner.Run(...)` 中直接传入 `agent.WithCodeExecutor(exec)`。
 
 ```go
 events, err := r.Run(
@@ -542,6 +542,7 @@ events, err := r.Run(
 说明：
 
 - 该选项仅对当前这一次 `runner.Run(...)` 调用生效，不会修改 Agent 的默认配置。
+- 该选项仅对会读取 `RunOptions.CodeExecutor` 的 Agent 生效；如果使用自定义 Agent，请确认其实现会处理该运行参数。
 - 如果创建 Agent 时已经设置 `llmagent.WithCodeExecutor(...)`，则此处传入的执行器会在本次运行中临时覆盖默认值。
 - 本次运行中所有依赖代码执行器的能力，均会使用此处传入的执行器，例如 `workspace_exec`、`skill_run` 和交互式 skill 会话工具。
 - 如果仅需为 `skill_run` 提供运行环境，而不希望模型自动执行回复中的 Markdown 围栏代码，可在创建 Agent 时设置 `llmagent.WithEnableCodeExecutionResponseProcessor(false)`。更多说明见 [Skill 文档](./skill.md)。

--- a/docs/mkdocs/zh/runner.md
+++ b/docs/mkdocs/zh/runner.md
@@ -467,7 +467,7 @@ eventChan, err := r.Run(
 
 部分模型在生成 `tool_calls` 时，可能产出非严格 JSON 的参数（例如对象 key 未加引号、尾逗号等），从而导致工具执行或外部解析失败。
 
-在 `runner.Run` 中启用 `agent.WithToolCallArgumentsJSONRepairEnabled(true)` 后，框架会对 `toolCall.Function.Arguments` 做一次尽力修复，详细使用方法可参照 [ToolCall参数自动修复](./runner.md#tool-call-参数自动修复)。
+在 `runner.Run` 中启用 `agent.WithToolCallArgumentsJSONRepairEnabled(true)` 后，框架会对 `toolCall.Function.Arguments` 做一次尽力修复，详细使用方法可参照 [ToolCall参数自动修复](./runner.md#tool-call)。
 
 #### 传入对话历史（auto-seed + 复用 Session）
 
@@ -523,7 +523,28 @@ events, err := r.Run(
 推荐先通过 `structure.Export(...)` 获取稳定 `nodeID`，再把它传给
 `WithSurfacePatchForNode(...)`。同一次运行中如果要覆盖多个节点，可以重复传多个
 `WithSurfacePatchForNode(...)`。完整说明与更多示例见
-[Agent 使用文档：按 `nodeID` 覆盖运行时 surface](./agent.md#按-nodeid-覆盖运行时-surface)。
+[Agent 使用文档：按 `nodeID` 覆盖运行时 surface](./agent.md#nodeid-surface)。
+
+#### 按运行临时覆盖 `code executor`
+
+如果需要为同一个 Agent 的不同请求指定不同的执行环境，可以在 `runner.Run(...)` 中直接传入 `agent.WithCodeExecutor(exec)`。
+
+```go
+events, err := r.Run(
+    ctx,
+    userID,
+    sessionID,
+    model.NewUserMessage("Run the release checklist skill."),
+    agent.WithCodeExecutor(containerExec),
+)
+```
+
+说明：
+
+- 该选项仅对当前这一次 `runner.Run(...)` 调用生效，不会修改 Agent 的默认配置。
+- 如果创建 Agent 时已经设置 `llmagent.WithCodeExecutor(...)`，则此处传入的执行器会在本次运行中临时覆盖默认值。
+- 本次运行中所有依赖代码执行器的能力，均会使用此处传入的执行器，例如 `workspace_exec`、`skill_run` 和交互式 skill 会话工具。
+- 如果仅需为 `skill_run` 提供运行环境，而不希望模型自动执行回复中的 Markdown 围栏代码，可在创建 Agent 时设置 `llmagent.WithEnableCodeExecutionResponseProcessor(false)`。更多说明见 [Skill 文档](./skill.md)。
 
 ## ✅ 图式流程的“优雅结束”与最终结果读取
 

--- a/docs/mkdocs/zh/skill.md
+++ b/docs/mkdocs/zh/skill.md
@@ -313,8 +313,9 @@ agent := llmagent.New(
     `llmagent.WithSkillRunRequireSkillLoaded(false)`。
   - 是否需要执行器，取决于最终注册的工具集：
     只要没有 `skill_run` / `skill_exec`，就不需要
-    `WithCodeExecutor(...)`。
-- 注意：当你同时设置了 `WithCodeExecutor` 时，LLMAgent 默认会尝试执行
+    `llmagent.WithCodeExecutor(...)` 或 `agent.WithCodeExecutor(...)`。
+- 注意：当你设置了 `llmagent.WithCodeExecutor(...)`，或者在
+  `runner.Run(...)` 里传入 `agent.WithCodeExecutor(...)` 时，LLMAgent 默认会尝试执行
   模型回复里的 Markdown 围栏代码块。如果你只是为了给 `skill_run` 提供运行时，
   不希望自动执行代码块，可以加上
   `llmagent.WithEnableCodeExecutionResponseProcessor(false)`。

--- a/internal/flow/processor/codeexecution.go
+++ b/internal/flow/processor/codeexecution.go
@@ -54,11 +54,7 @@ func (p *CodeExecutionResponseProcessor) ProcessResponse(
 	if invocation == nil || rsp == nil || rsp.IsPartial {
 		return
 	}
-	ce, ok := invocation.Agent.(agent.CodeExecutor)
-	if !ok || ce == nil {
-		return
-	}
-	e := ce.CodeExecutor()
+	e := codeExecutorForInvocation(invocation)
 	if e == nil {
 		return
 	}
@@ -127,6 +123,22 @@ func (p *CodeExecutionResponseProcessor) ProcessResponse(
 	))
 	//  [Step 3] Skip processing the original model response to continue code generation loop.
 	rsp.Choices[0].Message.Content = ""
+}
+
+func codeExecutorForInvocation(
+	invocation *agent.Invocation,
+) codeexecutor.CodeExecutor {
+	if invocation == nil {
+		return nil
+	}
+	if invocation.RunOptions.CodeExecutor != nil {
+		return invocation.RunOptions.CodeExecutor
+	}
+	ce, ok := invocation.Agent.(agent.CodeExecutor)
+	if !ok || ce == nil {
+		return nil
+	}
+	return ce.CodeExecutor()
 }
 
 func autoExecutableCodeBlocks(

--- a/internal/flow/processor/codeexecution_internal_test.go
+++ b/internal/flow/processor/codeexecution_internal_test.go
@@ -1,0 +1,25 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package processor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+)
+
+func TestCodeExecutorForInvocation_NilInvocation(t *testing.T) {
+	require.Nil(t, codeExecutorForInvocation(nil))
+}
+
+func TestCodeExecutorForInvocation_NoAgentExecutor(t *testing.T) {
+	require.Nil(t, codeExecutorForInvocation(&agent.Invocation{}))
+}

--- a/internal/flow/processor/codeexecution_test.go
+++ b/internal/flow/processor/codeexecution_test.go
@@ -140,13 +140,57 @@ func TestCodeExecutionResponseProcessor_SkipsNonExecutableBlocks(
 	}
 }
 
+func TestCodeExecutionResponseProcessor_UsesRunCodeExecutorOverride(
+	t *testing.T,
+) {
+	ctx := context.Background()
+	proc := iprocessor.NewCodeExecutionResponseProcessor()
+
+	inv := &agent.Invocation{
+		Agent: &testAgent{
+			exec: &stubExec{output: "static"},
+		},
+		Session:   &session.Session{ID: "test-session"},
+		AgentName: "test-agent",
+		RunOptions: agent.RunOptions{
+			CodeExecutor: &stubExec{output: "override"},
+		},
+	}
+	rsp := &model.Response{
+		Done: true,
+		Choices: []model.Choice{
+			{Message: model.Message{
+				Role:    model.RoleAssistant,
+				Content: "```bash\necho hello\n```",
+			}},
+		},
+	}
+
+	ch := make(chan *event.Event, 4)
+	proc.ProcessResponse(ctx, inv, &model.Request{}, rsp, ch)
+
+	require.Len(t, ch, 2)
+	<-ch
+	result := <-ch
+	require.NotNil(t, result)
+	require.NotNil(t, result.Response)
+	require.Len(t, result.Response.Choices, 1)
+	require.Contains(t, result.Response.Choices[0].Message.Content, "override")
+}
+
 // stubExec is a simple CodeExecutor stub returning a fixed output
-type stubExec struct{}
+type stubExec struct {
+	output string
+}
 
 func (s *stubExec) ExecuteCode(
 	ctx context.Context, input codeexecutor.CodeExecutionInput,
 ) (codeexecutor.CodeExecutionResult, error) {
-	return codeexecutor.CodeExecutionResult{Output: "OK"}, nil
+	output := s.output
+	if output == "" {
+		output = "OK"
+	}
+	return codeexecutor.CodeExecutionResult{Output: output}, nil
 }
 func (s *stubExec) CodeBlockDelimiter() codeexecutor.CodeBlockDelimiter {
 	return codeexecutor.CodeBlockDelimiter{Start: "```", End: "```"}

--- a/internal/flow/processor/skills.go
+++ b/internal/flow/processor/skills.go
@@ -53,6 +53,7 @@ type skillsRequestProcessorOptions struct {
 	maxLoadedSkills   int
 	toolProfile       string
 	toolFlags         skillprofile.Flags
+	toolFlagsResolver func(*agent.Invocation) skillprofile.Flags
 	hasToolFlags      bool
 	execToolsDisabled bool
 	repoResolver      func(*agent.Invocation) skill.Repository
@@ -124,6 +125,15 @@ func WithSkillToolFlags(flags skillprofile.Flags) SkillsRequestProcessorOption {
 	}
 }
 
+// WithSkillToolFlagsResolver sets an invocation-aware skill tool capability resolver.
+func WithSkillToolFlagsResolver(
+	resolver func(*agent.Invocation) skillprofile.Flags,
+) SkillsRequestProcessorOption {
+	return func(o *skillsRequestProcessorOptions) {
+		o.toolFlagsResolver = resolver
+	}
+}
+
 // WithSkillExecToolsDisabled tells the processor that skill_exec and its
 // companion session tools were not registered (e.g. because the executor
 // does not support interactive sessions).  The processor omits the
@@ -169,13 +179,14 @@ func WithMaxLoadedSkills(max int) SkillsRequestProcessorOption {
 //   - skill.DocsKey(agentName, skillName) ->
 //     "*" or JSON array of file names.
 type SkillsRequestProcessor struct {
-	repo            skill.Repository
-	repoResolver    func(*agent.Invocation) skill.Repository
-	toolingGuidance *string
-	loadMode        string
-	toolResultMode  bool
-	maxLoadedSkills int
-	toolFlags       skillprofile.Flags
+	repo              skill.Repository
+	repoResolver      func(*agent.Invocation) skill.Repository
+	toolingGuidance   *string
+	loadMode          string
+	toolResultMode    bool
+	maxLoadedSkills   int
+	toolFlags         skillprofile.Flags
+	toolFlagsResolver func(*agent.Invocation) skillprofile.Flags
 }
 
 const (
@@ -207,13 +218,14 @@ func NewSkillsRequestProcessor(
 		flags = flags.WithoutInteractiveExecution()
 	}
 	return &SkillsRequestProcessor{
-		repo:            repo,
-		repoResolver:    options.repoResolver,
-		toolingGuidance: options.toolingGuidance,
-		loadMode:        normalizeSkillLoadMode(options.loadMode),
-		toolResultMode:  options.toolResultMode,
-		maxLoadedSkills: options.maxLoadedSkills,
-		toolFlags:       flags,
+		repo:              repo,
+		repoResolver:      options.repoResolver,
+		toolingGuidance:   options.toolingGuidance,
+		loadMode:          normalizeSkillLoadMode(options.loadMode),
+		toolResultMode:    options.toolResultMode,
+		maxLoadedSkills:   options.maxLoadedSkills,
+		toolFlags:         flags,
+		toolFlagsResolver: options.toolFlagsResolver,
 	}
 }
 
@@ -247,7 +259,7 @@ func (p *SkillsRequestProcessor) ProcessRequest(
 
 	// 1) Always inject overview (names + descriptions) into system
 	//    message. Merge into existing system message if present.
-	p.injectOverview(ctx, req, repo)
+	p.injectOverview(ctx, inv, req, repo)
 
 	loaded := p.getLoadedSkills(inv)
 	loaded = p.maybeCapLoadedSkills(ctx, inv, loaded, ch)
@@ -649,6 +661,7 @@ func (p *SkillsRequestProcessor) maybeOffloadLoadedSkills(
 
 func (p *SkillsRequestProcessor) injectOverview(
 	ctx context.Context,
+	inv *agent.Invocation,
 	req *model.Request,
 	repo skill.Repository,
 ) {
@@ -663,10 +676,11 @@ func (p *SkillsRequestProcessor) injectOverview(
 		line := fmt.Sprintf("- %s: %s\n", s.Name, s.Description)
 		b.WriteString(line)
 	}
-	if capability := p.capabilityGuidanceText(); capability != "" {
+	flags := p.toolFlagsForInvocation(inv)
+	if capability := p.capabilityGuidanceText(flags); capability != "" {
 		b.WriteString(capability)
 	}
-	if guidance := p.toolingGuidanceText(); guidance != "" {
+	if guidance := p.toolingGuidanceText(flags); guidance != "" {
 		b.WriteString(guidance)
 	}
 	overview := b.String()
@@ -688,25 +702,38 @@ func (p *SkillsRequestProcessor) injectOverview(
 	req.Messages = append([]model.Message{msg}, req.Messages...)
 }
 
-func (p *SkillsRequestProcessor) toolingGuidanceText() string {
+func (p *SkillsRequestProcessor) toolFlagsForInvocation(
+	inv *agent.Invocation,
+) skillprofile.Flags {
+	if p.toolFlagsResolver != nil {
+		return p.toolFlagsResolver(inv)
+	}
+	return p.toolFlags
+}
+
+func (p *SkillsRequestProcessor) toolingGuidanceText(
+	flags skillprofile.Flags,
+) string {
 	if p.toolingGuidance == nil {
-		return defaultToolingAndWorkspaceGuidance(p.toolFlags)
+		return defaultToolingAndWorkspaceGuidance(flags)
 	}
 	return normalizeGuidance(*p.toolingGuidance)
 }
 
-func (p *SkillsRequestProcessor) capabilityGuidanceText() string {
+func (p *SkillsRequestProcessor) capabilityGuidanceText(
+	flags skillprofile.Flags,
+) string {
 	if p.toolingGuidance != nil && *p.toolingGuidance == "" {
 		return ""
 	}
-	if p.toolFlags.Run {
+	if flags.Run {
 		return ""
 	}
 	var b strings.Builder
 	b.WriteString("\n")
 	b.WriteString(skillsCapabilityHeader)
 	b.WriteString("\n")
-	if p.toolFlags.Load {
+	if flags.Load {
 		b.WriteString("- This configuration supports skill discovery and ")
 		b.WriteString("knowledge loading only.\n")
 		b.WriteString("- Built-in skill execution tools are unavailable in ")
@@ -718,7 +745,7 @@ func (p *SkillsRequestProcessor) capabilityGuidanceText() string {
 		b.WriteString("that execution is unavailable in the current mode.\n")
 		return b.String()
 	}
-	if p.toolFlags.HasDocHelpers() {
+	if flags.HasDocHelpers() {
 		b.WriteString("- This configuration supports skill discovery and ")
 		b.WriteString("skill doc inspection only.\n")
 		b.WriteString("- Built-in skill loading and execution tools are ")

--- a/internal/flow/processor/skills_test.go
+++ b/internal/flow/processor/skills_test.go
@@ -390,7 +390,7 @@ func TestSkillsRequestProcessor_CapabilityGuidance_CatalogOnly(t *testing.T) {
 		&mockRepo{},
 		WithSkillToolFlags(skillprofile.Flags{}),
 	)
-	text := p.capabilityGuidanceText()
+	text := p.capabilityGuidanceText(p.toolFlags)
 	require.Contains(t, text, skillsCapabilityHeader)
 	require.Contains(t, text, "exposes skill summaries only")
 	require.Contains(t, text, "catalog of possible capabilities")

--- a/internal/flow/processor/skills_test.go
+++ b/internal/flow/processor/skills_test.go
@@ -396,6 +396,19 @@ func TestSkillsRequestProcessor_CapabilityGuidance_CatalogOnly(t *testing.T) {
 	require.Contains(t, text, "catalog of possible capabilities")
 }
 
+func TestSkillsRequestProcessor_ToolFlagsResolverOverridesStaticFlags(t *testing.T) {
+	p := NewSkillsRequestProcessor(
+		&mockRepo{},
+		WithSkillToolFlags(skillprofile.Flags{Load: true}),
+		WithSkillToolFlagsResolver(func(*agent.Invocation) skillprofile.Flags {
+			return skillprofile.Flags{Run: true}
+		}),
+	)
+	flags := p.toolFlagsForInvocation(&agent.Invocation{})
+	require.False(t, flags.Load)
+	require.True(t, flags.Run)
+}
+
 func TestDefaultToolingAndWorkspaceGuidance_CatalogOnly(t *testing.T) {
 	text := defaultToolingAndWorkspaceGuidance(skillprofile.Flags{})
 	require.Contains(t, text, skillsToolingGuidanceHeader)

--- a/internal/flow/processor/workspaceexec.go
+++ b/internal/flow/processor/workspaceexec.go
@@ -25,9 +25,11 @@ const (
 )
 
 type workspaceExecRequestProcessorOptions struct {
-	sessionTools  bool
-	hasSkillsRepo bool
-	repoResolver  func(*agent.Invocation) skill.Repository
+	sessionTools     bool
+	hasSkillsRepo    bool
+	repoResolver     func(*agent.Invocation) skill.Repository
+	enabledResolver  func(*agent.Invocation) bool
+	sessionsResolver func(*agent.Invocation) bool
 }
 
 // WorkspaceExecRequestProcessorOption configures
@@ -39,6 +41,26 @@ type WorkspaceExecRequestProcessorOption func(*workspaceExecRequestProcessorOpti
 func WithWorkspaceExecSessionsEnabled() WorkspaceExecRequestProcessorOption {
 	return func(o *workspaceExecRequestProcessorOptions) {
 		o.sessionTools = true
+	}
+}
+
+// WithWorkspaceExecEnabledResolver sets an invocation-aware workspace_exec
+// capability resolver.
+func WithWorkspaceExecEnabledResolver(
+	resolver func(*agent.Invocation) bool,
+) WorkspaceExecRequestProcessorOption {
+	return func(o *workspaceExecRequestProcessorOptions) {
+		o.enabledResolver = resolver
+	}
+}
+
+// WithWorkspaceExecSessionsResolver sets an invocation-aware resolver for
+// workspace_exec session helper capability.
+func WithWorkspaceExecSessionsResolver(
+	resolver func(*agent.Invocation) bool,
+) WorkspaceExecRequestProcessorOption {
+	return func(o *workspaceExecRequestProcessorOptions) {
+		o.sessionsResolver = resolver
 	}
 }
 
@@ -65,6 +87,8 @@ type WorkspaceExecRequestProcessor struct {
 	sessionTools     bool
 	staticSkillsRepo bool
 	repoResolver     func(*agent.Invocation) skill.Repository
+	enabledResolver  func(*agent.Invocation) bool
+	sessionsResolver func(*agent.Invocation) bool
 }
 
 // NewWorkspaceExecRequestProcessor creates a new
@@ -83,6 +107,8 @@ func NewWorkspaceExecRequestProcessor(
 		sessionTools:     options.sessionTools,
 		staticSkillsRepo: options.hasSkillsRepo,
 		repoResolver:     options.repoResolver,
+		enabledResolver:  options.enabledResolver,
+		sessionsResolver: options.sessionsResolver,
 	}
 }
 
@@ -131,6 +157,9 @@ func (p *WorkspaceExecRequestProcessor) ProcessRequest(
 func (p *WorkspaceExecRequestProcessor) guidanceText(
 	inv *agent.Invocation,
 ) string {
+	if !p.enabledForInvocation(inv) {
+		return ""
+	}
 	var b strings.Builder
 	b.WriteString(workspaceExecGuidanceHeader)
 	b.WriteString("\n")
@@ -165,7 +194,7 @@ func (p *WorkspaceExecRequestProcessor) guidanceText(
 		b.WriteString("workspace_exec does not stage skills ")
 		b.WriteString("automatically.\n")
 	}
-	if p.sessionTools {
+	if p.sessionToolsForInvocation(inv) {
 		b.WriteString("- When workspace_exec starts a command that keeps ")
 		b.WriteString("running or waits for stdin, continue with ")
 		b.WriteString("workspace_write_stdin. When chars is empty, ")
@@ -178,6 +207,24 @@ func (p *WorkspaceExecRequestProcessor) guidanceText(
 		b.WriteString("session.\n")
 	}
 	return b.String()
+}
+
+func (p *WorkspaceExecRequestProcessor) enabledForInvocation(
+	inv *agent.Invocation,
+) bool {
+	if p.enabledResolver != nil {
+		return p.enabledResolver(inv)
+	}
+	return true
+}
+
+func (p *WorkspaceExecRequestProcessor) sessionToolsForInvocation(
+	inv *agent.Invocation,
+) bool {
+	if p.sessionsResolver != nil {
+		return p.sessionsResolver(inv)
+	}
+	return p.sessionTools
 }
 
 func (p *WorkspaceExecRequestProcessor) hasSkillsRepo(

--- a/internal/flow/processor/workspaceexec_test.go
+++ b/internal/flow/processor/workspaceexec_test.go
@@ -165,3 +165,25 @@ func TestWorkspaceExecRequestProcessor_ProcessRequest_ResolverCanDisableSkillsGu
 	require.NotEmpty(t, req.Messages)
 	require.NotContains(t, req.Messages[0].Content, "Paths under skills/")
 }
+
+func TestWorkspaceExecRequestProcessor_ProcessRequest_DisabledByResolver(
+	t *testing.T,
+) {
+	p := NewWorkspaceExecRequestProcessor(
+		WithWorkspaceExecEnabledResolver(
+			func(*agent.Invocation) bool {
+				return false
+			},
+		),
+	)
+	req := &model.Request{}
+
+	p.ProcessRequest(
+		context.Background(),
+		&agent.Invocation{AgentName: "tester"},
+		req,
+		nil,
+	)
+
+	require.Empty(t, req.Messages)
+}

--- a/internal/flow/processor/workspaceexec_test.go
+++ b/internal/flow/processor/workspaceexec_test.go
@@ -187,3 +187,27 @@ func TestWorkspaceExecRequestProcessor_ProcessRequest_DisabledByResolver(
 
 	require.Empty(t, req.Messages)
 }
+
+func TestWorkspaceExecRequestProcessor_ProcessRequest_SessionToolsEnabledByResolver(
+	t *testing.T,
+) {
+	p := NewWorkspaceExecRequestProcessor(
+		WithWorkspaceExecSessionsResolver(
+			func(*agent.Invocation) bool {
+				return true
+			},
+		),
+	)
+	req := &model.Request{}
+
+	p.ProcessRequest(
+		context.Background(),
+		&agent.Invocation{AgentName: "tester"},
+		req,
+		nil,
+	)
+
+	require.NotEmpty(t, req.Messages)
+	require.Contains(t, req.Messages[0].Content, "workspace_write_stdin")
+	require.Contains(t, req.Messages[0].Content, "workspace_kill_session")
+}


### PR DESCRIPTION
This adds a run-scoped code executor override through agent.WithCodeExecutor(...) and carries the effective executor through llmagent tool surface resolution, skills and workspace guidance, and code execution response handling so per-run executor changes consistently affect the runtime capabilities that the model sees and uses.