### PR TITLE
admin: simplify prompt page reading flow

### DIFF
--- a/openclaw/admin/prompts.go
+++ b/openclaw/admin/prompts.go
@@ -11,6 +11,7 @@ package admin
 
 import (
 	"net/http"
+	"strconv"
 	"strings"
 )
 
@@ -175,6 +176,64 @@ func hasPromptValue(raw string) bool {
 
 func promptValuesDiffer(left string, right string) bool {
 	return strings.TrimSpace(left) != strings.TrimSpace(right)
+}
+
+const promptSummaryMaxRunes = 120
+
+func promptCollapsedSummary(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "No prompt text is currently active."
+	}
+	snippet := promptSummarySnippet(trimmed)
+	lineCount := promptLineCount(trimmed)
+	if lineCount <= 1 {
+		return "1 line. Starts with: " + snippet
+	}
+	return strconv.Itoa(lineCount) +
+		" lines. Starts with: " + snippet
+}
+
+func promptSummarySnippet(raw string) string {
+	for _, line := range strings.Split(raw, "\n") {
+		line = strings.Join(strings.Fields(line), " ")
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		runes := []rune(line)
+		if len(runes) <= promptSummaryMaxRunes {
+			return line
+		}
+		return string(runes[:promptSummaryMaxRunes]) + "..."
+	}
+	return ""
+}
+
+func promptLineCount(raw string) int {
+	if strings.TrimSpace(raw) == "" {
+		return 0
+	}
+	return len(strings.Split(strings.TrimRight(raw, "\n"), "\n"))
+}
+
+func promptInlineEditorTitle(bundle PromptBundleState) string {
+	if strings.TrimSpace(bundle.Title) == "" {
+		return "Text Stored In Config"
+	}
+	return bundle.Title + " Config Text"
+}
+
+func promptInlineEditorSummary(bundle PromptBundleState) string {
+	return "This edits the text stored directly in the config file " +
+		"for this block. It is combined with any file-based sources " +
+		"before the live prompt is assembled."
+}
+
+func promptRuntimeEditorSummary(bundle PromptBundleState) string {
+	return "This temporary text replaces the configured text for " +
+		"the running process only. Clear it to fall back to config " +
+		"and files."
 }
 
 func (s *Service) promptsStatus() PromptsStatus {
@@ -627,17 +686,24 @@ const promptsPageTemplateHTML = `
         prompt blocks in this runtime.
       </p>
       {{range .Prompts.Previews}}
-      <article class="card" style="margin-top: 18px;" id="preview-{{.Key}}">
-        <h3>{{.Title}}</h3>
-        {{if .Summary}}
-        <p class="subtle">{{.Summary}}</p>
-        {{end}}
-        {{if .Content}}
-        <div class="memory-preview">{{.Content}}</div>
-        {{else}}
-        <p class="empty">No prompt content is currently active.</p>
-        {{end}}
-      </article>
+      <details class="card prompt-detail" style="margin-top: 18px;" id="preview-{{.Key}}">
+        <summary>
+          <strong>{{.Title}}</strong>
+          {{if .Summary}}
+          <p class="subtle prompt-detail-copy">{{.Summary}}</p>
+          {{end}}
+          <p class="subtle prompt-detail-hint">
+            {{promptCollapsedSummary .Content}}
+          </p>
+        </summary>
+        <div class="prompt-detail-body">
+          {{if .Content}}
+          <div class="memory-preview">{{.Content}}</div>
+          {{else}}
+          <p class="empty">No prompt content is currently active.</p>
+          {{end}}
+        </div>
+      </details>
       {{end}}
     </section>
     {{end}}
@@ -657,7 +723,7 @@ const promptsPageTemplateHTML = `
         <p class="subtle">{{.Summary}}</p>
         {{end}}
         <dl class="meta">
-          <dt>Source</dt>
+          <dt>Source Setup</dt>
           <dd>{{if .SourceSummary}}{{.SourceSummary}}{{else}}-{{end}}</dd>
           <dt>Editable Files</dt>
           <dd>{{len .Files}}</dd>
@@ -671,29 +737,48 @@ const promptsPageTemplateHTML = `
         {{end}}
 
         <div class="panels" style="grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));">
-          <article class="card">
-            <h4 style="margin: 0 0 10px;">
-              {{if .EffectiveLabel}}{{.EffectiveLabel}}{{else}}Effective Prompt{{end}}
-            </h4>
-            {{if .EffectiveValue}}
-            <div class="memory-preview">{{.EffectiveValue}}</div>
-            {{else}}
-            <p class="empty">This block does not add any prompt text.</p>
-            {{end}}
-          </article>
+          <details class="card prompt-detail">
+            <summary>
+              <strong>
+                {{if .EffectiveLabel}}{{.EffectiveLabel}}{{else}}Effective Prompt{{end}}
+              </strong>
+              <p class="subtle prompt-detail-hint">
+                {{promptCollapsedSummary .EffectiveValue}}
+              </p>
+            </summary>
+            <div class="prompt-detail-body">
+              {{if .EffectiveValue}}
+              <div class="memory-preview">{{.EffectiveValue}}</div>
+              {{else}}
+              <p class="empty">This block does not add any prompt text.</p>
+              {{end}}
+            </div>
+          </details>
           {{if and (hasPromptValue .ConfiguredValue) (promptValuesDiffer .ConfiguredValue .EffectiveValue)}}
-          <article class="card">
-            <h4 style="margin: 0 0 10px;">
-              {{if .ConfiguredLabel}}{{.ConfiguredLabel}}{{else}}Configured Prompt{{end}}
-            </h4>
-            <div class="memory-preview">{{.ConfiguredValue}}</div>
-          </article>
+          <details class="card prompt-detail">
+            <summary>
+              <strong>
+                {{if .ConfiguredLabel}}{{.ConfiguredLabel}}{{else}}Configured Prompt{{end}}
+              </strong>
+              <p class="subtle prompt-detail-hint">
+                {{promptCollapsedSummary .ConfiguredValue}}
+              </p>
+            </summary>
+            <div class="prompt-detail-body">
+              <div class="memory-preview">{{.ConfiguredValue}}</div>
+            </div>
+          </details>
           {{end}}
         </div>
 
         {{if .InlineEditable}}
         <div class="card" style="margin-top: 16px;">
-          <h4 style="margin: 0 0 10px;">Inline Source</h4>
+          <h4 style="margin: 0 0 10px;">
+            {{promptInlineEditorTitle .}}
+          </h4>
+          <p class="subtle">
+            {{promptInlineEditorSummary .}}
+          </p>
           <form method="post" action="/api/prompts/inline">
             <input type="hidden" name="bundle_key" value="{{.Key}}">
             <input type="hidden" name="return_path" value="/prompts">
@@ -703,7 +788,7 @@ const promptsPageTemplateHTML = `
               style="width: 100%; min-height: 160px; margin-top: 12px;"
             >{{.InlineValue}}</textarea>
             <div class="actions" style="margin-top: 12px;">
-              <button type="submit">Save Inline Value</button>
+              <button type="submit">Save Config Text</button>
             </div>
           </form>
         </div>
@@ -713,7 +798,7 @@ const promptsPageTemplateHTML = `
         <div class="card" style="margin-top: 16px;">
           <h4 style="margin: 0 0 10px;">Runtime Override</h4>
           <p class="subtle">
-            Leave this empty to fall back to the configured prompt sources.
+            {{promptRuntimeEditorSummary .}}
           </p>
           <form method="post" action="/api/prompts/runtime">
             <input type="hidden" name="bundle_key" value="{{.Key}}">

--- a/openclaw/admin/service.go
+++ b/openclaw/admin/service.go
@@ -2037,13 +2037,17 @@ func isAllowedDebugFile(name string) bool {
 
 var adminPage = template.Must(
 	template.New("admin").Funcs(template.FuncMap{
-		"formatTime":             formatTime,
-		"browserEndpointSummary": browserEndpointSummary,
-		"displayAdminAppName":    displayAdminAppName,
-		"promptSections":         promptSections,
-		"promptBlockCount":       promptBlockCount,
-		"hasPromptValue":         hasPromptValue,
-		"promptValuesDiffer":     promptValuesDiffer,
+		"formatTime":                 formatTime,
+		"browserEndpointSummary":     browserEndpointSummary,
+		"displayAdminAppName":        displayAdminAppName,
+		"promptSections":             promptSections,
+		"promptBlockCount":           promptBlockCount,
+		"hasPromptValue":             hasPromptValue,
+		"promptValuesDiffer":         promptValuesDiffer,
+		"promptCollapsedSummary":     promptCollapsedSummary,
+		"promptInlineEditorTitle":    promptInlineEditorTitle,
+		"promptInlineEditorSummary":  promptInlineEditorSummary,
+		"promptRuntimeEditorSummary": promptRuntimeEditorSummary,
 	}).Parse(
 		adminPageHTML +
 			promptsPageTemplateHTML +
@@ -2674,7 +2678,31 @@ const adminPageHTML = `<!doctype html>
     .memory-preview {
       max-width: 540px;
       color: #3f3932;
+      overflow-wrap: anywhere;
       white-space: pre-wrap;
+    }
+    .prompt-detail {
+      overflow: hidden;
+    }
+    .prompt-detail[open] {
+      border-color: rgba(15, 111, 97, 0.28);
+      box-shadow: 0 14px 28px rgba(35, 29, 22, 0.08);
+    }
+    .prompt-detail summary {
+      list-style: none;
+      cursor: pointer;
+    }
+    .prompt-detail summary::-webkit-details-marker {
+      display: none;
+    }
+    .prompt-detail-copy,
+    .prompt-detail-hint {
+      margin: 8px 0 0;
+    }
+    .prompt-detail-body {
+      margin-top: 14px;
+      padding-top: 14px;
+      border-top: 1px solid var(--line);
     }
     .memory-scope {
       display: grid;

--- a/openclaw/admin/service_test.go
+++ b/openclaw/admin/service_test.go
@@ -1392,6 +1392,10 @@ func TestService_PromptsPageAndActions(t *testing.T) {
 	require.Contains(t, rec.Body.String(), "Core Prompt")
 	require.Contains(t, rec.Body.String(), "Instruction")
 	require.Contains(t, rec.Body.String(), "Final Prompt Preview")
+	require.Contains(t, rec.Body.String(), "prompt-detail")
+	require.Contains(t, rec.Body.String(), "Instruction Config Text")
+	require.Contains(t, rec.Body.String(), "Save Config Text")
+	require.NotContains(t, rec.Body.String(), "Inline Source")
 	require.NotContains(t, rec.Body.String(), "Agent Personas")
 	require.Contains(t, rec.Body.String(), "/personas")
 
@@ -1482,6 +1486,28 @@ func TestService_PromptsPageAndActions(t *testing.T) {
 	require.Equal(t, "agent", personas.storeKey)
 	require.Equal(t, "Warm", personas.personaName)
 	require.Equal(t, "custom prompt", personas.personaBody)
+}
+
+func TestPromptCollapsedSummary(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	require.Equal(
+		t,
+		"No prompt text is currently active.",
+		promptCollapsedSummary(""),
+	)
+	require.Equal(
+		t,
+		"1 line. Starts with: single line",
+		promptCollapsedSummary("single line"),
+	)
+	require.Equal(
+		t,
+		"2 lines. Starts with: first line",
+		promptCollapsedSummary("first line\nsecond line"),
+	)
 }
 
 func TestService_IdentityPageAndActions(t *testing.T) {

--- a/openclaw/admin/service_test.go
+++ b/openclaw/admin/service_test.go
@@ -1510,6 +1510,47 @@ func TestPromptCollapsedSummary(
 	)
 }
 
+func TestPromptHelperFunctions(t *testing.T) {
+	t.Parallel()
+
+	longLine := strings.Repeat("a", promptSummaryMaxRunes+5)
+	require.Equal(
+		t,
+		strings.Repeat("a", promptSummaryMaxRunes)+"...",
+		promptSummarySnippet(longLine),
+	)
+	require.Equal(
+		t,
+		"first real line",
+		promptSummarySnippet("\n\n first   real   line \nsecond"),
+	)
+	require.Equal(t, "", promptSummarySnippet("\n \n\t"))
+
+	require.Equal(t, 0, promptLineCount(""))
+	require.Equal(t, 2, promptLineCount("first\nsecond\n"))
+
+	require.Equal(
+		t,
+		"Text Stored In Config",
+		promptInlineEditorTitle(PromptBundleState{}),
+	)
+	require.Equal(
+		t,
+		"Instruction Config Text",
+		promptInlineEditorTitle(PromptBundleState{Title: "Instruction"}),
+	)
+	require.Contains(
+		t,
+		promptInlineEditorSummary(PromptBundleState{}),
+		"config file",
+	)
+	require.Contains(
+		t,
+		promptRuntimeEditorSummary(PromptBundleState{}),
+		"running process only",
+	)
+}
+
 func TestService_IdentityPageAndActions(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/app/admin_prompts.go
+++ b/openclaw/app/admin_prompts.go
@@ -549,9 +549,9 @@ func adminPromptBundleSummary(key string) string {
 func adminPromptConfiguredLabel(key string) string {
 	switch strings.TrimSpace(key) {
 	case adminPromptInstructionBundle:
-		return "Configured Instruction Sources"
+		return "Configured Instruction Text"
 	case adminPromptSystemBundle:
-		return "Configured System Sources"
+		return "Configured System Text"
 	default:
 		return "Configured Prompt"
 	}
@@ -560,11 +560,11 @@ func adminPromptConfiguredLabel(key string) string {
 func adminPromptEffectiveLabel(key string) string {
 	switch strings.TrimSpace(key) {
 	case adminPromptInstructionBundle:
-		return "Effective Instruction"
+		return "Live Instruction Text"
 	case adminPromptSystemBundle:
-		return "Effective System Prompt"
+		return "Live System Text"
 	default:
-		return "Effective Prompt"
+		return "Live Prompt Text"
 	}
 }
 
@@ -572,18 +572,18 @@ func adminPromptSourceSummary(key string, fileCount int) string {
 	switch strings.TrimSpace(key) {
 	case adminPromptInstructionBundle:
 		if fileCount == 0 {
-			return "Built-in defaults"
+			return "Built-in text"
 		}
 	case adminPromptSystemBundle:
 		if fileCount == 0 {
-			return "Inline or runtime-only configuration"
+			return "Config text or runtime-only text"
 		}
 	}
 	if fileCount == 1 {
-		return "1 editable file"
+		return "1 file"
 	}
 	if fileCount > 1 {
-		return fmt.Sprintf("%d editable files", fileCount)
+		return fmt.Sprintf("%d files", fileCount)
 	}
 	return "No editable files"
 }

--- a/openclaw/app/admin_prompts_test.go
+++ b/openclaw/app/admin_prompts_test.go
@@ -75,6 +75,17 @@ func TestAdminPromptProviderStatus(t *testing.T) {
 		status.Bundles[0].ConfiguredValue,
 	)
 	require.Equal(t, "Instruction", status.Bundles[0].Title)
+	require.Equal(
+		t,
+		"Configured Instruction Text",
+		status.Bundles[0].ConfiguredLabel,
+	)
+	require.Equal(
+		t,
+		"Live Instruction Text",
+		status.Bundles[0].EffectiveLabel,
+	)
+	require.Equal(t, "1 file", status.Bundles[0].SourceSummary)
 	require.Len(t, status.Bundles[0].Files, 1)
 	require.True(t, status.Bundles[0].CreateEnabled)
 
@@ -83,6 +94,17 @@ func TestAdminPromptProviderStatus(t *testing.T) {
 		"system from file",
 		status.Bundles[1].ConfiguredValue,
 	)
+	require.Equal(
+		t,
+		"Configured System Text",
+		status.Bundles[1].ConfiguredLabel,
+	)
+	require.Equal(
+		t,
+		"Live System Text",
+		status.Bundles[1].EffectiveLabel,
+	)
+	require.Equal(t, "1 file", status.Bundles[1].SourceSummary)
 	require.Len(t, status.Bundles[1].Files, 1)
 	require.False(t, status.Bundles[1].CreateEnabled)
 }

--- a/openclaw/app/admin_prompts_test.go
+++ b/openclaw/app/admin_prompts_test.go
@@ -549,3 +549,38 @@ func TestAdminPromptProviderAdditionalCoverage(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, filepath.IsAbs(path))
 }
+
+func TestAdminPromptHelperLabelsAndSourceSummary(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(
+		t,
+		"Configured Prompt",
+		adminPromptConfiguredLabel("other"),
+	)
+	require.Equal(
+		t,
+		"Live Prompt Text",
+		adminPromptEffectiveLabel("other"),
+	)
+	require.Equal(
+		t,
+		"Built-in text",
+		adminPromptSourceSummary(adminPromptInstructionBundle, 0),
+	)
+	require.Equal(
+		t,
+		"Config text or runtime-only text",
+		adminPromptSourceSummary(adminPromptSystemBundle, 0),
+	)
+	require.Equal(
+		t,
+		"No editable files",
+		adminPromptSourceSummary("other", 0),
+	)
+	require.Equal(
+		t,
+		"2 files",
+		adminPromptSourceSummary("other", 2),
+	)
+}

--- a/openclaw/internal/skills/watch_test.go
+++ b/openclaw/internal/skills/watch_test.go
@@ -53,7 +53,15 @@ func TestWatchService_RefreshesWhenSkillAdded(t *testing.T) {
 	writeSkill(t, root, "demo", watchTestSkill)
 
 	require.Eventually(t, func() bool {
-		return hasSkillSummary(repo.Summaries(), "demo")
+		if !hasSkillSummary(repo.Summaries(), "demo") {
+			return false
+		}
+		status := watch.Status()
+		return status != nil &&
+			status.LastRefreshReason ==
+				watchRefreshReasonWatch &&
+			status.LastRefreshAt != nil &&
+			status.Generation >= 1
 	}, time.Second, 10*time.Millisecond)
 
 	status := watch.Status()


### PR DESCRIPTION
## Summary
- make long prompt previews and full prompt previews collapsed by default in the admin UI
- rename inline prompt controls to clearer config-text wording and tighten source descriptions
- keep the prompt page focused on short summaries first, with full content available on demand

## Why
The prompt page had become hard to scan after the runtime prompt work landed. Large prompt bodies were always expanded, and labels like `Inline Source` did not clearly explain that the content came from config text rather than prompt files. This follow-up keeps the same prompt-management model, but makes the page easier to read and less confusing.

## Validation
- go test ./admin ./app
- go test -cover ./admin ./app
