### PR TITLE
{server/agui, docs}: add app name resolver

### DIFF
--- a/docs/mkdocs/en/agui.md
+++ b/docs/mkdocs/en/agui.md
@@ -205,11 +205,12 @@ To enable message snapshots, configure the following options:
 
 - `agui.WithMessagesSnapshotEnabled(true)` enables message snapshots;
 - `agui.WithMessagesSnapshotPath` sets the custom message snapshot route, defaulting to `/history`;
-- `agui.WithAppName(name)` specifies the application name;
+- `agui.WithAppName(name)` specifies the application name as the default `AppName`;
+- `agui.WithAppNameResolver(resolver)` is optional and overrides `AppName` per request;
 - `agui.WithSessionService(service)` injects the `session.Service` used to look up historical events;
 - `aguirunner.WithUserIDResolver(resolver)` customises how `userID` is resolved, defaulting to `"user"`.
 
-When handling a message snapshot request, the framework extracts `threadId` as the `SessionID` from the AG-UI request body `RunAgentInput`, resolves `userID` using the custom `UserIDResolver`, builds `session.Key` with `appName`, reads the persisted events from session storage, reconstructs the message list required by `MessagesSnapshot`, wraps it into a `MESSAGES_SNAPSHOT` event, and sends matching `RUN_STARTED` and `RUN_FINISHED` events.
+When handling a message snapshot request, the framework extracts `threadId` as the `SessionID` from the AG-UI request body `RunAgentInput`, resolves `userID` using the custom `UserIDResolver`, prefers the `appName` returned by `AppNameResolver`, and falls back to `agui.WithAppName(name)` when the resolver returns an empty value. These values are used to build `session.Key`, read the persisted events from session storage, reconstruct the message list required by `MessagesSnapshot`, wrap it into a `MESSAGES_SNAPSHOT` event, and send matching `RUN_STARTED` and `RUN_FINISHED` events.
 
 Example:
 
@@ -433,6 +434,45 @@ resolver := func(ctx context.Context, input *adapter.RunAgentInput) (string, err
 
 runner := runner.NewRunner(agent.Info().Name, agent)
 server, _ := agui.New(runner, agui.WithAGUIRunnerOptions(aguirunner.WithUserIDResolver(resolver)))
+```
+
+### Custom `AppNameResolver`
+
+By default, AG-UI uses `agui.WithAppName(name)` as the static `AppName` and combines it with `userID` and `threadId` to form the `SessionKey`.
+
+If you need to switch `AppName` per request, implement `AppNameResolver` and inject it with `agui.WithAppNameResolver`. When `AppNameResolver` returns a non-empty string, it overrides `AppName` for that request. When it returns an empty string, the framework falls back to `agui.WithAppName(name)`.
+
+The real-time conversation route, cancel route, and message snapshot route all share the same `AppName` resolution logic. Requests to `/agui`, `/cancel`, and `/history` for the same session should therefore carry the same business identifier.
+
+When message snapshots are enabled, you still need to configure `agui.WithAppName(name)` at startup as the default value. `AppNameResolver` only provides request-level overrides.
+
+```go
+import (
+    "context"
+
+    "trpc.group/trpc-go/trpc-agent-go/runner"
+    "trpc.group/trpc-go/trpc-agent-go/server/agui"
+    "trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
+)
+
+resolver := func(ctx context.Context, input *adapter.RunAgentInput) (string, error) {
+    forwardedProps, ok := input.ForwardedProps.(map[string]any)
+    if !ok || forwardedProps == nil {
+        return "", nil
+    }
+    appName, ok := forwardedProps["appName"].(string)
+    if !ok || appName == "" {
+        return "", nil
+    }
+    return appName, nil
+}
+
+runner := runner.NewRunner(agent.Info().Name, agent)
+server, _ := agui.New(
+    runner,
+    agui.WithAppName("default-app"),
+    agui.WithAppNameResolver(resolver),
+)
 ```
 
 ### Custom `RunOptionResolver`

--- a/docs/mkdocs/en/agui.md
+++ b/docs/mkdocs/en/agui.md
@@ -448,8 +448,6 @@ When message snapshots are enabled, you still need to configure `agui.WithAppNam
 
 ```go
 import (
-    "context"
-
     "trpc.group/trpc-go/trpc-agent-go/runner"
     "trpc.group/trpc-go/trpc-agent-go/server/agui"
     "trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"

--- a/docs/mkdocs/zh/agui.md
+++ b/docs/mkdocs/zh/agui.md
@@ -203,11 +203,12 @@ curl -X POST http://localhost:8080/cancel \
 
 - `agui.WithMessagesSnapshotEnabled(true)` 启用消息快照功能；
 - `agui.WithMessagesSnapshotPath` 设置消息快照路由的自定义路径，默认为 `/history`；
-- `agui.WithAppName(name)` 指定应用名；
+- `agui.WithAppName(name)` 指定应用名，作为默认 `AppName`；
+- `agui.WithAppNameResolver(resolver)` 可选，用于按请求覆盖 `AppName`；
 - `agui.WithSessionService(service)` 注入 `session.Service` 用于查询历史事件；
 - `aguirunner.WithUserIDResolver(resolver)` 自定义 `userID` 解析逻辑，默认恒为 `"user"`。
 
-框架在处理消息快照请求时会从 AG-UI 请求体 `RunAgentInput` 中解析 `threadId` 作为 `SessionID`，结合自定义 `UserIDResolver` 得到 `userID`，再与 `appName` 组装得到 `session.Key`，并从会话存储中读取已持久化的事件，将其还原为 `MessagesSnapshot` 所需的消息列表，封装成 `MESSAGES_SNAPSHOT` 事件，同时发送配套的 `RUN_STARTED`、`RUN_FINISHED` 事件。
+框架在处理消息快照请求时会从 AG-UI 请求体 `RunAgentInput` 中解析 `threadId` 作为 `SessionID`，结合自定义 `UserIDResolver` 得到 `userID`，再优先使用 `AppNameResolver` 返回的 `appName`；若未返回值，则回退到 `agui.WithAppName(name)`。三者共同组装得到 `session.Key`，并从会话存储中读取已持久化的事件，将其还原为 `MessagesSnapshot` 所需的消息列表，封装成 `MESSAGES_SNAPSHOT` 事件，同时发送配套的 `RUN_STARTED`、`RUN_FINISHED` 事件。
 
 代码示例如下：
 
@@ -430,6 +431,45 @@ resolver := func(ctx context.Context, input *adapter.RunAgentInput) (string, err
 
 runner := runner.NewRunner(agent.Info().Name, agent)
 server, _ := agui.New(runner, agui.WithAGUIRunnerOptions(aguirunner.WithUserIDResolver(resolver)))
+```
+
+### 自定义 `AppNameResolver`
+
+默认情况下，AG-UI 使用 `agui.WithAppName(name)` 作为静态 `AppName`，并将其与 `userID`、`threadId` 一起组成 `SessionKey`。
+
+如果希望按请求动态切换 `AppName`，可以实现 `AppNameResolver` 并通过 `agui.WithAppNameResolver` 注入。`AppNameResolver` 返回非空字符串时，会覆盖本次请求的 `AppName`；若返回空字符串，则继续回退到 `agui.WithAppName(name)`。
+
+实时对话路由、取消路由和消息快照路由会复用同一套 `AppName` 解析逻辑，因此，同一会话的 `/agui`、`/cancel`、`/history` 请求应传入一致的业务标识。
+
+需要注意的是，若开启了消息快照功能，服务启动时仍然需要显式配置 `agui.WithAppName(name)` 作为默认值；`AppNameResolver` 只负责请求级覆盖。
+
+```go
+import (
+    "context"
+
+    "trpc.group/trpc-go/trpc-agent-go/runner"
+    "trpc.group/trpc-go/trpc-agent-go/server/agui"
+    "trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
+)
+
+resolver := func(ctx context.Context, input *adapter.RunAgentInput) (string, error) {
+    forwardedProps, ok := input.ForwardedProps.(map[string]any)
+    if !ok || forwardedProps == nil {
+        return "", nil
+    }
+    appName, ok := forwardedProps["appName"].(string)
+    if !ok || appName == "" {
+        return "", nil
+    }
+    return appName, nil
+}
+
+runner := runner.NewRunner(agent.Info().Name, agent)
+server, _ := agui.New(
+    runner,
+    agui.WithAppName("default-app"),
+    agui.WithAppNameResolver(resolver),
+)
 ```
 
 ### 自定义 `RunOptionResolver`

--- a/docs/mkdocs/zh/agui.md
+++ b/docs/mkdocs/zh/agui.md
@@ -445,8 +445,6 @@ server, _ := agui.New(runner, agui.WithAGUIRunnerOptions(aguirunner.WithUserIDRe
 
 ```go
 import (
-    "context"
-
     "trpc.group/trpc-go/trpc-agent-go/runner"
     "trpc.group/trpc-go/trpc-agent-go/server/agui"
     "trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"

--- a/server/agui/agui.go
+++ b/server/agui/agui.go
@@ -25,7 +25,7 @@ import (
 // Server provides AG-UI server.
 type Server struct {
 	basePath       string          // basePath is the base path for the service.
-	appName        string          // appName is required when history snapshots are enabled.
+	appName        string          // appName is the static app name configured for the AG-UI runner.
 	path           string          // path is the chat message endpoint path.
 	handler        http.Handler    // handler serves chat and optional history routes.
 	sessionService session.Service // sessionService backs stored conversations for snapshots.

--- a/server/agui/options.go
+++ b/server/agui/options.go
@@ -206,6 +206,13 @@ func WithAppName(n string) Option {
 	}
 }
 
+// WithAppNameResolver sets the app name resolver.
+func WithAppNameResolver(r aguirunner.AppNameResolver) Option {
+	return func(o *options) {
+		o.aguiRunnerOptions = append(o.aguiRunnerOptions, aguirunner.WithAppNameResolver(r))
+	}
+}
+
 // WithSessionService sets the session service.
 func WithSessionService(service session.Service) Option {
 	return func(o *options) {

--- a/server/agui/options_test.go
+++ b/server/agui/options_test.go
@@ -10,11 +10,13 @@
 package agui
 
 import (
+	"context"
 	"net/http"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
 	aguirunner "trpc.group/trpc-go/trpc-agent-go/server/agui/runner"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/service"
 )
@@ -143,4 +145,19 @@ func TestWithCancelOnContextDoneEnabled(t *testing.T) {
 	opts := newOptions(WithCancelOnContextDoneEnabled(true))
 	ro := aguirunner.NewOptions(opts.aguiRunnerOptions...)
 	assert.True(t, ro.CancelOnContextDoneEnabled)
+}
+
+func TestWithAppNameResolver(t *testing.T) {
+	called := false
+	resolver := func(ctx context.Context, input *adapter.RunAgentInput) (string, error) {
+		called = true
+		return "custom-app", nil
+	}
+	opts := newOptions(WithAppNameResolver(resolver))
+	ro := aguirunner.NewOptions(opts.aguiRunnerOptions...)
+	assert.NotNil(t, ro.AppNameResolver)
+	appName, err := ro.AppNameResolver(context.Background(), nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "custom-app", appName)
+	assert.True(t, called)
 }

--- a/server/agui/runner/cancel.go
+++ b/server/agui/runner/cancel.go
@@ -36,12 +36,16 @@ func (r *runner) Cancel(ctx context.Context, runAgentInput *adapter.RunAgentInpu
 	if err != nil {
 		return fmt.Errorf("run input hook: %w", err)
 	}
+	appName, err := r.resolveAppName(ctx, runAgentInput)
+	if err != nil {
+		return fmt.Errorf("resolve app name: %w", err)
+	}
 	userID, err := r.userIDResolver(ctx, runAgentInput)
 	if err != nil {
 		return fmt.Errorf("resolve user ID: %w", err)
 	}
 	key := session.Key{
-		AppName:   r.appName,
+		AppName:   appName,
 		UserID:    userID,
 		SessionID: runAgentInput.ThreadID,
 	}

--- a/server/agui/runner/cancel_test.go
+++ b/server/agui/runner/cancel_test.go
@@ -524,3 +524,15 @@ func TestCancelUserIDResolverError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "resolve user ID")
 }
+
+func TestCancelAppNameResolverError(t *testing.T) {
+	r := &runner{
+		runner: &fakeRunner{},
+		appNameResolver: func(context.Context, *adapter.RunAgentInput) (string, error) {
+			return "", errors.New("boom")
+		},
+		userIDResolver: NewOptions().UserIDResolver,
+	}
+	err := r.Cancel(context.Background(), &adapter.RunAgentInput{ThreadID: "thread", RunID: "run"})
+	assert.ErrorContains(t, err, "resolve app name")
+}

--- a/server/agui/runner/cancel_test.go
+++ b/server/agui/runner/cancel_test.go
@@ -169,6 +169,47 @@ func TestCancelIgnoresRunID(t *testing.T) {
 	collectEvents(t, events)
 }
 
+func TestCancelUsesResolvedAppName(t *testing.T) {
+	ctxCh := make(chan context.Context, 1)
+	underlying := &waitCancelRunner{ctxCh: ctxCh}
+	r := New(
+		underlying,
+		WithAppName("static-app"),
+		WithAppNameResolver(forwardedPropsAppNameResolver),
+	).(*runner)
+	input := &adapter.RunAgentInput{
+		ThreadID:       "thread",
+		RunID:          "run",
+		ForwardedProps: map[string]any{"appName": "dynamic-app"},
+		Messages:       []types.Message{{Role: types.RoleUser, Content: "hi"}},
+	}
+	events, err := r.Run(context.Background(), input)
+	assert.NoError(t, err)
+	select {
+	case evt := <-events:
+		assert.IsType(t, (*aguievents.RunStartedEvent)(nil), evt)
+	case <-time.After(3 * time.Second):
+		assert.FailNow(t, "timeout waiting for RUN_STARTED")
+	}
+	runCtx := <-ctxCh
+	assert.NotNil(t, runCtx)
+	err = r.Cancel(context.Background(), &adapter.RunAgentInput{
+		ThreadID:       "thread",
+		RunID:          "other-run",
+		ForwardedProps: map[string]any{"appName": "dynamic-app"},
+	})
+	assert.NoError(t, err)
+	assert.Eventually(t, func() bool {
+		select {
+		case <-runCtx.Done():
+			return true
+		default:
+			return false
+		}
+	}, 5*time.Second, 10*time.Millisecond)
+	collectEvents(t, events)
+}
+
 func TestCancelClosesReasoningStream(t *testing.T) {
 	r := New(
 		&reasoningWaitRunner{},

--- a/server/agui/runner/messagessnapshot.go
+++ b/server/agui/runner/messagessnapshot.go
@@ -38,9 +38,6 @@ func (r *runner) MessagesSnapshot(ctx context.Context,
 	if runAgentInput == nil {
 		return nil, errors.New("run input cannot be nil")
 	}
-	if r.appName == "" {
-		return nil, errors.New("app name is empty")
-	}
 	if r.tracker == nil {
 		return nil, errors.New("tracker is nil")
 	}
@@ -48,13 +45,20 @@ func (r *runner) MessagesSnapshot(ctx context.Context,
 	if err != nil {
 		return nil, fmt.Errorf("run input hook: %w", err)
 	}
+	appName, err := r.resolveAppName(ctx, runAgentInput)
+	if err != nil {
+		return nil, fmt.Errorf("resolve app name: %w", err)
+	}
+	if appName == "" {
+		return nil, errors.New("app name is empty")
+	}
 	userID, err := r.userIDResolver(ctx, runAgentInput)
 	if err != nil {
 		return nil, fmt.Errorf("resolve user ID: %w", err)
 	}
 	input := &runInput{
 		key: session.Key{
-			AppName:   r.appName,
+			AppName:   appName,
 			UserID:    userID,
 			SessionID: runAgentInput.ThreadID,
 		},
@@ -124,7 +128,7 @@ func (r *runner) getMessagesSnapshotEvent(ctx context.Context,
 	if err != nil {
 		return nil, nil, fmt.Errorf("get track events: %w", err)
 	}
-	messages, err := reduce.Reduce(r.appName, sessionKey.UserID, trackEvents.Events)
+	messages, err := reduce.Reduce(sessionKey.AppName, sessionKey.UserID, trackEvents.Events)
 	if err != nil {
 		err = fmt.Errorf("reduce track events: %w", err)
 	}

--- a/server/agui/runner/messagessnapshot_test.go
+++ b/server/agui/runner/messagessnapshot_test.go
@@ -137,6 +137,40 @@ func TestMessagesSnapshotHappyPath(t *testing.T) {
 	require.IsType(t, (*aguievents.RunFinishedEvent)(nil), collected[2])
 }
 
+func TestMessagesSnapshotUsesResolvedAppName(t *testing.T) {
+	svc := &testSessionService{
+		trackEvents: []session.TrackEvent{
+			newTrackEvent(t, aguievents.NewTextMessageStartEvent("assistant-1", aguievents.WithRole("assistant"))),
+			newTrackEvent(t, aguievents.NewTextMessageContentEvent("assistant-1", "hello")),
+			newTrackEvent(t, aguievents.NewTextMessageEndEvent("assistant-1")),
+		},
+	}
+	tracker, err := track.New(svc)
+	require.NoError(t, err)
+	r := &runner{
+		runner:            noopBaseRunner{},
+		userIDResolver:    NewOptions().UserIDResolver,
+		appNameResolver:   forwardedPropsAppNameResolver,
+		runAgentInputHook: NewOptions().RunAgentInputHook,
+		appName:           "static-app",
+		tracker:           tracker,
+	}
+	stream, err := r.MessagesSnapshot(context.Background(), &adapter.RunAgentInput{
+		ThreadID:       "thread",
+		RunID:          "run",
+		ForwardedProps: map[string]any{"appName": "dynamic-app"},
+	})
+	require.NoError(t, err)
+	collected := collectAGUIEvents(t, stream)
+	require.Len(t, collected, 3)
+	snapshot, ok := collected[1].(*aguievents.MessagesSnapshotEvent)
+	require.True(t, ok)
+	require.Len(t, snapshot.Messages, 1)
+	assert.Equal(t, "dynamic-app", svc.lastGetKey.AppName)
+	assert.Equal(t, types.RoleAssistant, snapshot.Messages[0].Role)
+	assert.Equal(t, "dynamic-app", snapshot.Messages[0].Name)
+}
+
 func TestMessagesSnapshotPreservesDistinctCanonicalToolCallIDsAcrossTurns(t *testing.T) {
 	firstToolCallID := "trpc-agent-go-toolcall:inv-1:rsp-1:call-1:c0:t0"
 	secondToolCallID := "trpc-agent-go-toolcall:inv-2:rsp-2:call-1:c0:t0"
@@ -1021,6 +1055,7 @@ type testSessionService struct {
 	trackEvents   []session.TrackEvent
 	getErr        error
 	returnNil     bool
+	lastGetKey    session.Key
 	appendTrackFn func(ctx context.Context, sess *session.Session,
 		evt *session.TrackEvent, opts ...session.Option) error
 }
@@ -1038,6 +1073,7 @@ func (s *testSessionService) GetSession(ctx context.Context, key session.Key,
 	if s.returnNil {
 		return nil, nil
 	}
+	s.lastGetKey = key
 	sess := &session.Session{AppName: key.AppName, UserID: key.UserID, ID: key.SessionID}
 	if len(s.trackEvents) > 0 {
 		sess.Tracks = map[session.Track]*session.TrackEvents{

--- a/server/agui/runner/messagessnapshot_test.go
+++ b/server/agui/runner/messagessnapshot_test.go
@@ -476,6 +476,27 @@ func TestMessagesSnapshotUserIDResolverError(t *testing.T) {
 	assert.Contains(t, err.Error(), "resolve user ID")
 }
 
+func TestMessagesSnapshotAppNameResolverError(t *testing.T) {
+	svc := &testSessionService{}
+	tracker, err := track.New(svc)
+	require.NoError(t, err)
+	r := &runner{
+		runner: noopBaseRunner{},
+		appNameResolver: func(context.Context, *adapter.RunAgentInput) (string, error) {
+			return "", errors.New("boom")
+		},
+		userIDResolver:    NewOptions().UserIDResolver,
+		runAgentInputHook: NewOptions().RunAgentInputHook,
+		tracker:           tracker,
+	}
+	stream, err := r.MessagesSnapshot(
+		context.Background(),
+		&adapter.RunAgentInput{ThreadID: "thread", RunID: "run"},
+	)
+	assert.Nil(t, stream)
+	assert.ErrorContains(t, err, "resolve app name")
+}
+
 func TestMessagesSnapshotRunAgentInputHookError(t *testing.T) {
 	svc := &testSessionService{}
 	tracker, err := track.New(svc)

--- a/server/agui/runner/options.go
+++ b/server/agui/runner/options.go
@@ -39,6 +39,7 @@ type Options struct {
 	TranslateCallbacks                     *translator.Callbacks // TranslateCallbacks translates the run events to AG-UI events.
 	RunAgentInputHook                      RunAgentInputHook     // RunAgentInputHook allows modifying the run input before processing.
 	AppName                                string                // AppName is the name of the application.
+	AppNameResolver                        AppNameResolver       // AppNameResolver derives the app name for an AG-UI run.
 	SessionService                         session.Service       // SessionService is the session service.
 	StateResolver                          StateResolver         // StateResolver resolves runtime state for an AG-UI run.
 	RunOptionResolver                      RunOptionResolver     // RunOptionResolver resolves the runner options for an AG-UI run.
@@ -64,6 +65,7 @@ func NewOptions(opt ...Option) *Options {
 		UserIDResolver:                         defaultUserIDResolver,
 		TranslatorFactory:                      defaultTranslatorFactory,
 		RunAgentInputHook:                      defaultRunAgentInputHook,
+		AppNameResolver:                        defaultAppNameResolver,
 		StateResolver:                          defaultStateResolver,
 		RunOptionResolver:                      defaultRunOptionResolver,
 		AggregatorFactory:                      aggregator.New,
@@ -126,6 +128,16 @@ func WithRunAgentInputHook(hook RunAgentInputHook) Option {
 func WithAppName(n string) Option {
 	return func(o *Options) {
 		o.AppName = n
+	}
+}
+
+// AppNameResolver is a function that derives the app name for an AG-UI run.
+type AppNameResolver func(ctx context.Context, input *adapter.RunAgentInput) (string, error)
+
+// WithAppNameResolver sets the app name resolver.
+func WithAppNameResolver(r AppNameResolver) Option {
+	return func(o *Options) {
+		o.AppNameResolver = r
 	}
 }
 
@@ -271,6 +283,11 @@ func defaultTranslatorFactory(ctx context.Context, input *adapter.RunAgentInput,
 // defaultRunAgentInputHook returns the input unchanged.
 func defaultRunAgentInputHook(ctx context.Context, input *adapter.RunAgentInput) (*adapter.RunAgentInput, error) {
 	return input, nil
+}
+
+// defaultAppNameResolver returns no dynamic app name.
+func defaultAppNameResolver(ctx context.Context, input *adapter.RunAgentInput) (string, error) {
+	return "", nil
 }
 
 // defaultRunOptionResolver is the default run option resolver.

--- a/server/agui/runner/options_test.go
+++ b/server/agui/runner/options_test.go
@@ -48,6 +48,11 @@ func TestNewOptionsDefaults(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Same(t, input, modified)
 
+	assert.NotNil(t, opts.AppNameResolver)
+	appName, err := opts.AppNameResolver(context.Background(), input)
+	assert.NoError(t, err)
+	assert.Empty(t, appName)
+
 	assert.NotNil(t, opts.StateResolver)
 	resolvedState, err := opts.StateResolver(context.Background(), input)
 	assert.NoError(t, err)
@@ -169,6 +174,20 @@ func TestWithRunAgentInputHook(t *testing.T) {
 func TestWithAppName(t *testing.T) {
 	opts := NewOptions(WithAppName("custom-app"))
 	assert.Equal(t, "custom-app", opts.AppName)
+}
+
+func TestWithAppNameResolver(t *testing.T) {
+	called := false
+	resolver := func(ctx context.Context, input *adapter.RunAgentInput) (string, error) {
+		called = true
+		return "custom-app", nil
+	}
+	opts := NewOptions(WithAppNameResolver(resolver))
+	assert.NotNil(t, opts.AppNameResolver)
+	appName, err := opts.AppNameResolver(context.Background(), nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "custom-app", appName)
+	assert.True(t, called)
 }
 
 func TestWithSessionService(t *testing.T) {

--- a/server/agui/runner/runner.go
+++ b/server/agui/runner/runner.go
@@ -72,6 +72,7 @@ func New(r trunner.Runner, opt ...Option) Runner {
 	run := &runner{
 		runner:                                 r,
 		appName:                                opts.AppName,
+		appNameResolver:                        opts.AppNameResolver,
 		translatorFactory:                      opts.TranslatorFactory,
 		graphNodeLifecycleActivityEnabled:      opts.GraphNodeLifecycleActivityEnabled,
 		graphNodeInterruptActivityEnabled:      opts.GraphNodeInterruptActivityEnabled,
@@ -99,6 +100,7 @@ func New(r trunner.Runner, opt ...Option) Runner {
 // runner is the default implementation of the Runner.
 type runner struct {
 	appName                                string
+	appNameResolver                        AppNameResolver
 	runner                                 trunner.Runner
 	translatorFactory                      TranslatorFactory
 	graphNodeLifecycleActivityEnabled      bool
@@ -223,6 +225,10 @@ func (r *runner) Run(ctx context.Context, runAgentInput *adapter.RunAgentInput) 
 	if err != nil {
 		return nil, fmt.Errorf("resolve run option: %w", err)
 	}
+	appName, err := r.resolveAppName(ctx, runAgentInput)
+	if err != nil {
+		return nil, fmt.Errorf("resolve app name: %w", err)
+	}
 	runtimeState, err := r.stateResolver(ctx, runAgentInput)
 	if err != nil {
 		return nil, fmt.Errorf("resolve state: %w", err)
@@ -248,7 +254,7 @@ func (r *runner) Run(ctx context.Context, runAgentInput *adapter.RunAgentInput) 
 	}
 	input := &runInput{
 		key: session.Key{
-			AppName:   r.appName,
+			AppName:   appName,
 			UserID:    userID,
 			SessionID: runAgentInput.ThreadID,
 		},
@@ -622,6 +628,20 @@ func (r *runner) applyRunAgentInputHook(ctx context.Context,
 		return input, nil
 	}
 	return newInput, nil
+}
+
+func (r *runner) resolveAppName(ctx context.Context, input *adapter.RunAgentInput) (string, error) {
+	if r.appNameResolver == nil {
+		return r.appName, nil
+	}
+	appName, err := r.appNameResolver(ctx, input)
+	if err != nil {
+		return "", err
+	}
+	if appName != "" {
+		return appName, nil
+	}
+	return r.appName, nil
 }
 
 func (r *runner) handleBeforeTranslate(ctx context.Context, event *event.Event) (*event.Event, error) {

--- a/server/agui/runner/runner_test.go
+++ b/server/agui/runner/runner_test.go
@@ -889,6 +889,47 @@ func TestRecordUserMessageTracksCustomEvent(t *testing.T) {
 	assert.Equal(t, "hi", content)
 }
 
+func TestRunUsesResolvedAppNameForTrackKey(t *testing.T) {
+	tracker := &recordingTracker{}
+	underlying := &fakeRunner{
+		run: func(ctx context.Context, userID, sessionID string, message model.Message,
+			_ ...agent.RunOption) (<-chan *agentevent.Event, error) {
+			ch := make(chan *agentevent.Event)
+			close(ch)
+			return ch, nil
+		},
+	}
+	r := &runner{
+		appName:            "static-app",
+		appNameResolver:    forwardedPropsAppNameResolver,
+		runner:             underlying,
+		translatorFactory:  defaultTranslatorFactory,
+		userIDResolver:     func(context.Context, *adapter.RunAgentInput) (string, error) { return "demo-user", nil },
+		stateResolver:      defaultStateResolver,
+		runOptionResolver:  defaultRunOptionResolver,
+		tracker:            tracker,
+		startSpan:          defaultStartSpan,
+		translateCallbacks: nil,
+	}
+	input := &adapter.RunAgentInput{
+		ThreadID:       "thread",
+		RunID:          "run",
+		ForwardedProps: map[string]any{"appName": "dynamic-app"},
+		Messages:       []types.Message{{ID: "user-msg-1", Role: types.RoleUser, Content: "hi"}},
+	}
+	ch, err := r.Run(context.Background(), input)
+	require.NoError(t, err)
+	collectEvents(t, ch)
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+	require.NotEmpty(t, tracker.keys)
+	for _, key := range tracker.keys {
+		assert.Equal(t, "dynamic-app", key.AppName)
+		assert.Equal(t, "demo-user", key.UserID)
+		assert.Equal(t, "thread", key.SessionID)
+	}
+}
+
 func TestRecordUserMessageRejectsNilAndNonUserRole(t *testing.T) {
 	r := &runner{}
 	key := session.Key{AppName: "app", UserID: "demo-user", SessionID: "thread"}
@@ -2069,12 +2110,14 @@ func (f *flushRecorder) Flush(ctx context.Context, key session.Key) error {
 type recordingTracker struct {
 	mu         sync.Mutex
 	events     []aguievents.Event
+	keys       []session.Key
 	flushCount int
 }
 
 func (r *recordingTracker) AppendEvent(ctx context.Context, key session.Key, event aguievents.Event) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	r.keys = append(r.keys, key)
 	r.events = append(r.events, event)
 	return nil
 }
@@ -2108,6 +2151,15 @@ func (e *errorTracker) GetEvents(ctx context.Context,
 func (e *errorTracker) Flush(ctx context.Context,
 	_ session.Key) error {
 	return e.flushErr
+}
+
+func forwardedPropsAppNameResolver(_ context.Context, input *adapter.RunAgentInput) (string, error) {
+	props, ok := input.ForwardedProps.(map[string]any)
+	if !ok || props == nil {
+		return "", nil
+	}
+	appName, _ := props["appName"].(string)
+	return appName, nil
 }
 
 type spySpan struct {

--- a/server/agui/runner/runner_test.go
+++ b/server/agui/runner/runner_test.go
@@ -930,6 +930,53 @@ func TestRunUsesResolvedAppNameForTrackKey(t *testing.T) {
 	}
 }
 
+func TestRunAppNameResolverError(t *testing.T) {
+	underlying := &fakeRunner{}
+	r := &runner{
+		runner:            underlying,
+		appNameResolver:   func(context.Context, *adapter.RunAgentInput) (string, error) { return "", errors.New("boom") },
+		translatorFactory: defaultTranslatorFactory,
+		userIDResolver:    func(context.Context, *adapter.RunAgentInput) (string, error) { return "demo-user", nil },
+		stateResolver:     defaultStateResolver,
+		runOptionResolver: defaultRunOptionResolver,
+		startSpan:         defaultStartSpan,
+	}
+	input := &adapter.RunAgentInput{
+		ThreadID: "thread",
+		RunID:    "run",
+		Messages: []types.Message{{Role: types.RoleUser, Content: "hi"}},
+	}
+	ch, err := r.Run(context.Background(), input)
+	assert.Nil(t, ch)
+	assert.ErrorContains(t, err, "resolve app name")
+	assert.Equal(t, 0, underlying.calls)
+}
+
+func TestResolveAppNameFallsBackToStaticAppName(t *testing.T) {
+	r := &runner{appName: "static-app"}
+	appName, err := r.resolveAppName(context.Background(), &adapter.RunAgentInput{})
+	assert.NoError(t, err)
+	assert.Equal(t, "static-app", appName)
+	r.appNameResolver = func(context.Context, *adapter.RunAgentInput) (string, error) {
+		return "", nil
+	}
+	appName, err = r.resolveAppName(context.Background(), &adapter.RunAgentInput{})
+	assert.NoError(t, err)
+	assert.Equal(t, "static-app", appName)
+}
+
+func TestResolveAppNameReturnsResolverError(t *testing.T) {
+	r := &runner{
+		appName: "static-app",
+		appNameResolver: func(context.Context, *adapter.RunAgentInput) (string, error) {
+			return "", errors.New("boom")
+		},
+	}
+	appName, err := r.resolveAppName(context.Background(), &adapter.RunAgentInput{})
+	assert.Empty(t, appName)
+	assert.EqualError(t, err, "boom")
+}
+
 func TestRecordUserMessageRejectsNilAndNonUserRole(t *testing.T) {
 	r := &runner{}
 	key := session.Key{AppName: "app", UserID: "demo-user", SessionID: "thread"}


### PR DESCRIPTION
This adds request-level AppNameResolver support to AG-UI so run, cancel, and history requests can resolve the same session key without reusing RunOptionResolver, keeps WithAppName as the default and startup baseline for message snapshots, and updates the Chinese and English AG-UI guides to describe the new override path.