### PR TITLE
openclaw: add admin tracked chats view

### DIFF
--- a/openclaw/admin/chats.go
+++ b/openclaw/admin/chats.go
@@ -138,9 +138,9 @@ func chatNameSourceLabel(chat ChatView) string {
 		return source
 	}
 	if strings.TrimSpace(chat.ChatAssistantOverride) != "" {
-		return "chat override"
+		return "Current chat name"
 	}
-	return "global default"
+	return "Default name"
 }
 
 func chatOverrideSample(
@@ -203,8 +203,8 @@ const chatsPageTemplateHTML = `
         <p class="subtle">
           This view shows tracked chat state from the runtime. It is not
           a full transcript browser. Use it to inspect each chat's
-          effective assistant name, chat-level override, persona,
-          workspace, and recent session history.
+          current name, whether that chat is using its own name or the
+          default name, plus persona, workspace, and recent sessions.
         </p>
         {{if .Chats.ChatOverrideHelp}}
         <div class="notice" style="margin-top: 14px;">
@@ -305,18 +305,24 @@ const chatsPageTemplateHTML = `
               -
             {{end}}
           </dd>
-          <dt>Name Source</dt>
+          <dt>Why This Name</dt>
           <dd>{{chatNameSourceLabel .SelectedChat}}</dd>
-          <dt>Chat Override</dt>
+          <dt>Current Chat Name</dt>
           <dd>
             {{if .SelectedChat.ChatAssistantOverride}}
               {{.SelectedChat.ChatAssistantOverride}}
             {{else}}
-              (unset)
+              (using default name)
             {{end}}
           </dd>
-          <dt>Overrides Global</dt>
-          <dd>{{.SelectedChat.OverridesGlobal}}</dd>
+          <dt>Using Its Own Name</dt>
+          <dd>
+            {{if .SelectedChat.OverridesGlobal}}
+              yes
+            {{else}}
+              no
+            {{end}}
+          </dd>
           <dt>Current Session</dt>
           <dd><code>{{.SelectedChat.CurrentSessionID}}</code></dd>
           <dt>Recall Session</dt>

--- a/openclaw/admin/chats.go
+++ b/openclaw/admin/chats.go
@@ -16,7 +16,11 @@ import (
 	"time"
 )
 
-const routeChatsJSON = "/api/chats"
+const (
+	routeChatsJSON = "/api/chats"
+
+	knownUserSeparator = ", "
+)
 
 type ChatsProvider interface {
 	ChatsStatus() (ChatsStatus, error)
@@ -52,7 +56,13 @@ type ChatView struct {
 	PersonaPinned         bool              `json:"persona_pinned"`
 	WorkspacePath         string            `json:"workspace_path,omitempty"`
 	KnownUserIDs          []string          `json:"known_user_ids,omitempty"`
+	KnownUsers            []KnownUserView   `json:"known_users,omitempty"`
 	History               []ChatSessionView `json:"history,omitempty"`
+}
+
+type KnownUserView struct {
+	UserID string `json:"user_id,omitempty"`
+	Label  string `json:"label,omitempty"`
 }
 
 type ChatSessionView struct {
@@ -126,10 +136,36 @@ func chatDisplayLabel(chat ChatView) string {
 }
 
 func chatKnownUsers(chat ChatView) string {
+	if len(chat.KnownUsers) != 0 {
+		parts := make([]string, 0, len(chat.KnownUsers))
+		for _, user := range chat.KnownUsers {
+			label := chatKnownUserLabel(user)
+			if label == "" {
+				continue
+			}
+			parts = append(parts, label)
+		}
+		if len(parts) != 0 {
+			return strings.Join(parts, knownUserSeparator)
+		}
+	}
 	if len(chat.KnownUserIDs) == 0 {
 		return "-"
 	}
-	return strings.Join(chat.KnownUserIDs, ", ")
+	return strings.Join(chat.KnownUserIDs, knownUserSeparator)
+}
+
+func chatKnownUserLabel(user KnownUserView) string {
+	userID := strings.TrimSpace(user.UserID)
+	label := strings.TrimSpace(user.Label)
+	switch {
+	case label != "" && userID != "" && label != userID:
+		return label + " (" + userID + ")"
+	case label != "":
+		return label
+	default:
+		return userID
+	}
 }
 
 func chatNameSourceLabel(chat ChatView) string {

--- a/openclaw/admin/chats.go
+++ b/openclaw/admin/chats.go
@@ -188,9 +188,11 @@ const chatsPageTemplateHTML = `
         <span class="stat-label">Global Name</span>
         <span class="stat-value">
           {{if .Identity.EffectiveName}}
-            {{.Identity.EffectiveName}}
+            <a href="/identity#identity-global">
+              {{.Identity.EffectiveName}}
+            </a>
           {{else}}
-            -
+            <a href="/identity#identity-global">-</a>
           {{end}}
         </span>
       </article>

--- a/openclaw/admin/chats.go
+++ b/openclaw/admin/chats.go
@@ -1,0 +1,379 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package admin
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+)
+
+const routeChatsJSON = "/api/chats"
+
+type ChatsProvider interface {
+	ChatsStatus() (ChatsStatus, error)
+}
+
+type ChatsStatus struct {
+	Enabled               bool       `json:"enabled"`
+	Error                 string     `json:"error,omitempty"`
+	TotalCount            int        `json:"total_count"`
+	OverrideCount         int        `json:"override_count"`
+	GlobalAssistantName   string     `json:"global_assistant_name,omitempty"`
+	RuntimeAssistantName  string     `json:"runtime_assistant_name,omitempty"`
+	ChatOverrideHelp      string     `json:"chat_override_help,omitempty"`
+	GlobalAssistantSource string     `json:"global_assistant_source,omitempty"`
+	Chats                 []ChatView `json:"chats,omitempty"`
+}
+
+type ChatView struct {
+	BaseSessionID         string            `json:"base_session_id,omitempty"`
+	DisplayLabel          string            `json:"display_label,omitempty"`
+	Kind                  string            `json:"kind,omitempty"`
+	KindLabel             string            `json:"kind_label,omitempty"`
+	CurrentSessionID      string            `json:"current_session_id,omitempty"`
+	RecallSessionID       string            `json:"recall_session_id,omitempty"`
+	LastActivity          time.Time         `json:"last_activity,omitempty"`
+	Epoch                 int64             `json:"epoch,omitempty"`
+	EffectiveAssistant    string            `json:"effective_assistant,omitempty"`
+	ChatAssistantOverride string            `json:"chat_assistant_override,omitempty"`
+	NameSource            string            `json:"name_source,omitempty"`
+	OverridesGlobal       bool              `json:"overrides_global"`
+	PersonaID             string            `json:"persona_id,omitempty"`
+	PersonaLabel          string            `json:"persona_label,omitempty"`
+	PersonaPinned         bool              `json:"persona_pinned"`
+	WorkspacePath         string            `json:"workspace_path,omitempty"`
+	KnownUserIDs          []string          `json:"known_user_ids,omitempty"`
+	History               []ChatSessionView `json:"history,omitempty"`
+}
+
+type ChatSessionView struct {
+	SessionID    string    `json:"session_id,omitempty"`
+	LastActivity time.Time `json:"last_activity,omitempty"`
+}
+
+func (s *Service) chatsStatus() ChatsStatus {
+	if s == nil || s.cfg.Chats == nil {
+		return ChatsStatus{}
+	}
+	status, err := s.cfg.Chats.ChatsStatus()
+	if err != nil {
+		return ChatsStatus{
+			Enabled: true,
+			Error:   strings.TrimSpace(err.Error()),
+		}
+	}
+	status.Enabled = true
+	status.TotalCount = len(status.Chats)
+	status.OverrideCount = chatOverrideCount(status.Chats)
+	return status
+}
+
+func (s *Service) handleChatsJSON(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	writeJSON(w, http.StatusOK, s.chatsStatus())
+}
+
+func selectedChatID(r *http.Request) string {
+	if r == nil || r.URL == nil {
+		return ""
+	}
+	return strings.TrimSpace(r.URL.Query().Get(queryChatID))
+}
+
+func selectChatView(
+	status ChatsStatus,
+	selectedID string,
+) *ChatView {
+	selectedID = strings.TrimSpace(selectedID)
+	if selectedID == "" {
+		if len(status.Chats) == 0 {
+			return nil
+		}
+		selectedID = strings.TrimSpace(status.Chats[0].BaseSessionID)
+	}
+	for i := range status.Chats {
+		chatID := strings.TrimSpace(status.Chats[i].BaseSessionID)
+		if chatID != selectedID {
+			continue
+		}
+		selected := status.Chats[i]
+		return &selected
+	}
+	return nil
+}
+
+func chatDisplayLabel(chat ChatView) string {
+	label := strings.TrimSpace(chat.DisplayLabel)
+	if label != "" {
+		return label
+	}
+	return strings.TrimSpace(chat.BaseSessionID)
+}
+
+func chatKnownUsers(chat ChatView) string {
+	if len(chat.KnownUserIDs) == 0 {
+		return "-"
+	}
+	return strings.Join(chat.KnownUserIDs, ", ")
+}
+
+func chatNameSourceLabel(chat ChatView) string {
+	source := strings.TrimSpace(chat.NameSource)
+	if source != "" {
+		return source
+	}
+	if strings.TrimSpace(chat.ChatAssistantOverride) != "" {
+		return "chat override"
+	}
+	return "global default"
+}
+
+func chatOverrideSample(
+	status ChatsStatus,
+	limit int,
+) []ChatView {
+	overrides := make([]ChatView, 0, len(status.Chats))
+	for _, chat := range status.Chats {
+		if !chat.OverridesGlobal {
+			continue
+		}
+		overrides = append(overrides, chat)
+	}
+	sort.SliceStable(overrides, func(i, j int) bool {
+		return overrides[i].LastActivity.After(overrides[j].LastActivity)
+	})
+	if limit <= 0 || len(overrides) <= limit {
+		return overrides
+	}
+	return overrides[:limit]
+}
+
+func chatOverrideCount(chats []ChatView) int {
+	count := 0
+	for _, chat := range chats {
+		if chat.OverridesGlobal {
+			count++
+		}
+	}
+	return count
+}
+
+const chatsPageTemplateHTML = `
+{{define "chatsPage"}}
+    <section class="stats">
+      <article class="card">
+        <span class="stat-label">Tracked Chats</span>
+        <span class="stat-value">{{.Chats.TotalCount}}</span>
+      </article>
+      <article class="card">
+        <span class="stat-label">Name Overrides</span>
+        <span class="stat-value">{{.Chats.OverrideCount}}</span>
+      </article>
+      <article class="card">
+        <span class="stat-label">Global Name</span>
+        <span class="stat-value">
+          {{if .Identity.EffectiveName}}
+            {{.Identity.EffectiveName}}
+          {{else}}
+            -
+          {{end}}
+        </span>
+      </article>
+    </section>
+
+    {{if .Chats.Enabled}}
+    <section class="panels">
+      <article class="card">
+        <h2>Tracked Chats</h2>
+        <p class="subtle">
+          This view shows tracked chat state from the runtime. It is not
+          a full transcript browser. Use it to inspect per-chat names,
+          personas, workspaces, and recent session-line history.
+        </p>
+        {{if .Chats.Error}}
+        <div class="notice err" style="margin-top: 12px;">
+          {{.Chats.Error}}
+        </div>
+        {{end}}
+        {{if .Chats.Chats}}
+        <table>
+          <thead>
+            <tr>
+              <th>Chat</th>
+              <th>Assistant</th>
+              <th>Persona</th>
+              <th>Last Activity</th>
+              <th>Open</th>
+            </tr>
+          </thead>
+          <tbody>
+            {{range .Chats.Chats}}
+            <tr>
+              <td>
+                <strong>{{chatDisplayLabel .}}</strong>
+                {{if .KindLabel}}
+                  <br><span class="subtle">{{.KindLabel}}</span>
+                {{end}}
+              </td>
+              <td>
+                {{if .EffectiveAssistant}}
+                  {{.EffectiveAssistant}}
+                {{else}}
+                  -
+                {{end}}
+                <br><span class="subtle">{{chatNameSourceLabel .}}</span>
+              </td>
+              <td>
+                {{if .PersonaLabel}}
+                  {{.PersonaLabel}}
+                {{else if .PersonaID}}
+                  {{.PersonaID}}
+                {{else}}
+                  -
+                {{end}}
+              </td>
+              <td>{{formatTime .LastActivity}}</td>
+              <td>
+                <a
+                  href="/chats?chat_id={{.BaseSessionID}}"
+                >
+                  inspect
+                </a>
+              </td>
+            </tr>
+            {{end}}
+          </tbody>
+        </table>
+        {{else}}
+        <p class="empty">No tracked chats are available yet.</p>
+        {{end}}
+      </article>
+
+      <article class="card">
+        <h2>Chat Detail</h2>
+        {{if .SelectedChat}}
+        <dl class="meta">
+          <dt>Chat</dt>
+          <dd><code>{{.SelectedChat.BaseSessionID}}</code></dd>
+          <dt>Kind</dt>
+          <dd>
+            {{if .SelectedChat.KindLabel}}
+              {{.SelectedChat.KindLabel}}
+            {{else if .SelectedChat.Kind}}
+              {{.SelectedChat.Kind}}
+            {{else}}
+              -
+            {{end}}
+          </dd>
+          <dt>Current Name</dt>
+          <dd>
+            {{if .SelectedChat.EffectiveAssistant}}
+              {{.SelectedChat.EffectiveAssistant}}
+            {{else}}
+              -
+            {{end}}
+          </dd>
+          <dt>Name Source</dt>
+          <dd>{{chatNameSourceLabel .SelectedChat}}</dd>
+          <dt>Chat Override</dt>
+          <dd>
+            {{if .SelectedChat.ChatAssistantOverride}}
+              {{.SelectedChat.ChatAssistantOverride}}
+            {{else}}
+              (unset)
+            {{end}}
+          </dd>
+          <dt>Overrides Global</dt>
+          <dd>{{.SelectedChat.OverridesGlobal}}</dd>
+          <dt>Current Session</dt>
+          <dd><code>{{.SelectedChat.CurrentSessionID}}</code></dd>
+          <dt>Recall Session</dt>
+          <dd>
+            {{if .SelectedChat.RecallSessionID}}
+              <code>{{.SelectedChat.RecallSessionID}}</code>
+            {{else}}
+              -
+            {{end}}
+          </dd>
+          <dt>Epoch</dt>
+          <dd>{{.SelectedChat.Epoch}}</dd>
+          <dt>Persona</dt>
+          <dd>
+            {{if .SelectedChat.PersonaLabel}}
+              {{.SelectedChat.PersonaLabel}}
+            {{else if .SelectedChat.PersonaID}}
+              {{.SelectedChat.PersonaID}}
+            {{else}}
+              -
+            {{end}}
+            {{if .SelectedChat.PersonaPinned}}
+              <br><span class="subtle">pinned for this chat</span>
+            {{end}}
+          </dd>
+          <dt>Workspace</dt>
+          <dd>
+            {{if .SelectedChat.WorkspacePath}}
+              <code>{{.SelectedChat.WorkspacePath}}</code>
+            {{else}}
+              -
+            {{end}}
+          </dd>
+          <dt>Known Users</dt>
+          <dd>{{chatKnownUsers .SelectedChat}}</dd>
+          <dt>Last Activity</dt>
+          <dd>{{formatTime .SelectedChat.LastActivity}}</dd>
+          <dt>JSON</dt>
+          <dd><a href="/api/chats">/api/chats</a></dd>
+        </dl>
+
+        <h3 style="margin: 18px 0 8px;">Tracked Session Lines</h3>
+        {{if .SelectedChat.History}}
+        <table>
+          <thead>
+            <tr>
+              <th>Session ID</th>
+              <th>Last Activity</th>
+            </tr>
+          </thead>
+          <tbody>
+            {{range .SelectedChat.History}}
+            <tr>
+              <td><code>{{.SessionID}}</code></td>
+              <td>{{formatTime .LastActivity}}</td>
+            </tr>
+            {{end}}
+          </tbody>
+        </table>
+        {{else}}
+        <p class="empty">No session-line history has been tracked yet.</p>
+        {{end}}
+        {{else}}
+        <p class="empty">
+          Choose a tracked chat from the list to inspect its current
+          state.
+        </p>
+        {{end}}
+      </article>
+    </section>
+    {{else}}
+    <section class="card" style="margin-top: 24px;">
+      <p class="empty">Chat tracking is not available for this runtime.</p>
+    </section>
+    {{end}}
+{{end}}
+`

--- a/openclaw/admin/chats.go
+++ b/openclaw/admin/chats.go
@@ -202,63 +202,80 @@ const chatsPageTemplateHTML = `
         <h2>Tracked Chats</h2>
         <p class="subtle">
           This view shows tracked chat state from the runtime. It is not
-          a full transcript browser. Use it to inspect per-chat names,
-          personas, workspaces, and recent session-line history.
+          a full transcript browser. Use it to inspect each chat's
+          effective assistant name, chat-level override, persona,
+          workspace, and recent session history.
         </p>
+        {{if .Chats.ChatOverrideHelp}}
+        <div class="notice" style="margin-top: 14px;">
+          {{.Chats.ChatOverrideHelp}}
+        </div>
+        {{end}}
         {{if .Chats.Error}}
         <div class="notice err" style="margin-top: 12px;">
           {{.Chats.Error}}
         </div>
         {{end}}
         {{if .Chats.Chats}}
-        <table>
-          <thead>
-            <tr>
-              <th>Chat</th>
-              <th>Assistant</th>
-              <th>Persona</th>
-              <th>Last Activity</th>
-              <th>Open</th>
-            </tr>
-          </thead>
-          <tbody>
-            {{range .Chats.Chats}}
-            <tr>
-              <td>
-                <strong>{{chatDisplayLabel .}}</strong>
-                {{if .KindLabel}}
-                  <br><span class="subtle">{{.KindLabel}}</span>
-                {{end}}
-              </td>
-              <td>
-                {{if .EffectiveAssistant}}
-                  {{.EffectiveAssistant}}
-                {{else}}
-                  -
-                {{end}}
-                <br><span class="subtle">{{chatNameSourceLabel .}}</span>
-              </td>
-              <td>
-                {{if .PersonaLabel}}
-                  {{.PersonaLabel}}
-                {{else if .PersonaID}}
-                  {{.PersonaID}}
-                {{else}}
-                  -
-                {{end}}
-              </td>
-              <td>{{formatTime .LastActivity}}</td>
-              <td>
-                <a
-                  href="/chats?chat_id={{.BaseSessionID}}"
-                >
-                  inspect
-                </a>
-              </td>
-            </tr>
-            {{end}}
-          </tbody>
-        </table>
+        <div class="chat-list">
+          {{range .Chats.Chats}}
+          <article class="chat-card">
+            <div class="chat-card-head">
+              <div class="chat-card-copy">
+                <div class="chat-card-title">{{chatDisplayLabel .}}</div>
+                <div class="chat-card-kind">
+                  {{if .KindLabel}}
+                    {{.KindLabel}}
+                  {{else if .Kind}}
+                    {{.Kind}}
+                  {{else}}
+                    Tracked chat
+                  {{end}}
+                </div>
+              </div>
+              <div class="chat-card-link">
+                <a href="/chats?chat_id={{.BaseSessionID}}">inspect</a>
+              </div>
+            </div>
+            <div class="chat-card-grid">
+              <div class="chat-card-meta">
+                <div class="chat-card-label">Current Name</div>
+                <div class="chat-card-value">
+                  {{if .EffectiveAssistant}}
+                    {{.EffectiveAssistant}}
+                  {{else}}
+                    -
+                  {{end}}
+                </div>
+              </div>
+              <div class="chat-card-meta">
+                <div class="chat-card-label">Name Source</div>
+                <div class="chat-card-value">
+                  {{chatNameSourceLabel .}}
+                </div>
+              </div>
+              <div class="chat-card-meta">
+                <div class="chat-card-label">Persona</div>
+                <div class="chat-card-value">
+                  {{if .PersonaLabel}}
+                    {{.PersonaLabel}}
+                  {{else if .PersonaID}}
+                    {{.PersonaID}}
+                  {{else}}
+                    -
+                  {{end}}
+                </div>
+              </div>
+              <div class="chat-card-meta">
+                <div class="chat-card-label">Last Activity</div>
+                <div class="chat-card-value">
+                  {{formatTime .LastActivity}}
+                </div>
+              </div>
+            </div>
+          </article>
+          {{end}}
+        </div>
         {{else}}
         <p class="empty">No tracked chats are available yet.</p>
         {{end}}
@@ -341,7 +358,7 @@ const chatsPageTemplateHTML = `
           <dd><a href="/api/chats">/api/chats</a></dd>
         </dl>
 
-        <h3 style="margin: 18px 0 8px;">Tracked Session Lines</h3>
+        <h3 style="margin: 18px 0 8px;">Recent Sessions</h3>
         {{if .SelectedChat.History}}
         <table>
           <thead>
@@ -360,7 +377,7 @@ const chatsPageTemplateHTML = `
           </tbody>
         </table>
         {{else}}
-        <p class="empty">No session-line history has been tracked yet.</p>
+        <p class="empty">No recent sessions have been tracked yet.</p>
         {{end}}
         {{else}}
         <p class="empty">

--- a/openclaw/admin/identity.go
+++ b/openclaw/admin/identity.go
@@ -217,6 +217,65 @@ const identityPageTemplateHTML = `
         </div>
       </form>
     </section>
+
+    {{if .Chats.Enabled}}
+    <section class="card" style="margin-top: 24px;" id="identity-chats">
+      <h2>Chat Overrides</h2>
+      <p class="subtle">
+        Chat-specific names override the global default inside one chat.
+        They persist on that chat line until cleared, even if the user
+        starts a new session epoch with <code>/new</code>.
+      </p>
+      <dl class="meta" style="margin-top: 14px;">
+        <dt>Active Overrides</dt>
+        <dd>{{.Chats.OverrideCount}}</dd>
+        <dt>Tracked Chats</dt>
+        <dd>{{.Chats.TotalCount}}</dd>
+        <dt>Open</dt>
+        <dd><a href="/chats">Chats</a></dd>
+      </dl>
+      {{if chatOverrideSample .Chats 6}}
+      <table style="margin-top: 16px;">
+        <thead>
+          <tr>
+            <th>Chat</th>
+            <th>Current Name</th>
+            <th>Override</th>
+            <th>Last Activity</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{range chatOverrideSample .Chats 6}}
+          <tr>
+            <td>
+              <a href="/chats?chat_id={{.BaseSessionID}}">
+                {{chatDisplayLabel .}}
+              </a>
+            </td>
+            <td>
+              {{if .EffectiveAssistant}}
+                {{.EffectiveAssistant}}
+              {{else}}
+                -
+              {{end}}
+            </td>
+            <td>
+              {{if .ChatAssistantOverride}}
+                {{.ChatAssistantOverride}}
+              {{else}}
+                -
+              {{end}}
+            </td>
+            <td>{{formatTime .LastActivity}}</td>
+          </tr>
+          {{end}}
+        </tbody>
+      </table>
+      {{else}}
+      <p class="empty">No chat-specific name overrides are active.</p>
+      {{end}}
+    </section>
+    {{end}}
     {{else}}
     <section class="card" style="margin-top: 24px;">
       <p class="empty">Identity management is not available for this runtime.</p>

--- a/openclaw/admin/identity.go
+++ b/openclaw/admin/identity.go
@@ -245,7 +245,11 @@ const identityPageTemplateHTML = `
         <dt>Open</dt>
         <dd><a href="/chats">Chats</a></dd>
       </dl>
-      {{if chatOverrideSample .Chats 6}}
+      {{if .Chats.Error}}
+      <div class="notice err" style="margin-top: 12px;">
+        {{.Chats.Error}}
+      </div>
+      {{else if chatOverrideSample .Chats 6}}
       <table style="margin-top: 16px;">
         <thead>
           <tr>

--- a/openclaw/admin/identity.go
+++ b/openclaw/admin/identity.go
@@ -120,8 +120,9 @@ const identityPageTemplateHTML = `
       <article class="card">
         <h2>Identity</h2>
         <p class="subtle">
-          Set the assistant's global default name. This affects new
-          chats unless a chat-specific name override is active.
+          Set the assistant's global default name. This is the fallback
+          name for new chats and for any existing chat that does not
+          have its own chat-level override.
         </p>
         <dl class="meta">
           <dt>Assistant Name</dt>
@@ -150,9 +151,19 @@ const identityPageTemplateHTML = `
     <section class="card" style="margin-top: 24px;" id="identity-global">
       <h2>Assistant Name</h2>
       <p class="subtle">
-        This is the global default name. Chat-scoped overrides can still
-        replace it for one active conversation.
+        This is the global fallback name. It can affect other users'
+        private chats and other groups, but only when those chats do
+        not already have their own chat-level override.
       </p>
+      <div class="notice" style="margin-top: 14px;">
+        <strong>How it works</strong><br>
+        1. If one chat already renamed the bot inside that chat, that
+        chat keeps using its own name.<br>
+        2. If another user opens a new private chat and has not renamed
+        the bot there yet, they will see this global name.<br>
+        3. If another group never set its own override, it also falls
+        back to this global name.
+      </div>
       {{if .Identity.Error}}
       <div class="notice err" style="margin-top: 12px;">
         {{.Identity.Error}}
@@ -222,9 +233,10 @@ const identityPageTemplateHTML = `
     <section class="card" style="margin-top: 24px;" id="identity-chats">
       <h2>Chat Overrides</h2>
       <p class="subtle">
-        Chat-specific names override the global default inside one chat.
-        They persist on that chat line until cleared, even if the user
-        starts a new session epoch with <code>/new</code>.
+        A chat override only changes the bot's name inside one tracked
+        chat. It wins over the global fallback, and it stays there until
+        cleared, even if the user starts a new session epoch with
+        <code>/new</code>.
       </p>
       <dl class="meta" style="margin-top: 14px;">
         <dt>Active Overrides</dt>

--- a/openclaw/admin/identity.go
+++ b/openclaw/admin/identity.go
@@ -84,9 +84,9 @@ func (s *Service) handleSaveIdentity(
 		)
 		return
 	}
-	message := "Saved assistant name."
+	message := "Saved default name."
 	if strings.TrimSpace(name) == "" {
-		message = "Cleared assistant name."
+		message = "Cleared default name."
 	}
 	s.redirectWithMessageAt(
 		w,
@@ -118,14 +118,13 @@ const identityPageTemplateHTML = `
 {{define "identityPage"}}
     <section class="panels">
       <article class="card">
-        <h2>Identity</h2>
+        <h2>Default Name</h2>
         <p class="subtle">
-          Set the assistant's global default name. This is the fallback
-          name for new chats and for any existing chat that does not
-          have its own chat-level override.
+          This is the default name used by new chats and by any existing
+          chat that has not picked its own current name yet.
         </p>
         <dl class="meta">
-          <dt>Assistant Name</dt>
+          <dt>Default Name</dt>
           <dd>
             {{if .Identity.EffectiveName}}
               {{.Identity.EffectiveName}}
@@ -149,20 +148,21 @@ const identityPageTemplateHTML = `
 
     {{if .Identity.Enabled}}
     <section class="card" style="margin-top: 24px;" id="identity-global">
-      <h2>Assistant Name</h2>
+      <h2>How Naming Works</h2>
       <p class="subtle">
-        This is the global fallback name. It can affect other users'
-        private chats and other groups, but only when those chats do
-        not already have their own chat-level override.
+        There are only two rules:
       </p>
       <div class="notice" style="margin-top: 14px;">
-        <strong>How it works</strong><br>
-        1. If one chat already renamed the bot inside that chat, that
-        chat keeps using its own name.<br>
-        2. If another user opens a new private chat and has not renamed
-        the bot there yet, they will see this global name.<br>
-        3. If another group never set its own override, it also falls
-        back to this global name.
+        <strong>1. Current chat name wins.</strong><br>
+        If one chat already renamed the bot, that chat keeps using its
+        own name.<br><br>
+        <strong>2. Default name fills the gaps.</strong><br>
+        New chats, and old chats that never picked their own name, fall
+        back to the default name shown here.<br><br>
+        <strong>Commands.</strong><br>
+        Use <code>/name &lt;name&gt;</code> to rename the bot inside one
+        chat. Use <code>/name global &lt;name&gt;</code> to change the
+        default name.
       </div>
       {{if .Identity.Error}}
       <div class="notice err" style="margin-top: 12px;">
@@ -170,7 +170,7 @@ const identityPageTemplateHTML = `
       </div>
       {{end}}
       <dl class="meta" style="margin-top: 14px;">
-        <dt>Effective Name</dt>
+        <dt>Current Default Name</dt>
         <dd>
           {{if .Identity.EffectiveName}}
             {{.Identity.EffectiveName}}
@@ -178,7 +178,7 @@ const identityPageTemplateHTML = `
             -
           {{end}}
         </dd>
-        <dt>Configured Global Name</dt>
+        <dt>Configured Default Name</dt>
         <dd>
           {{if .Identity.ConfiguredName}}
             {{.Identity.ConfiguredName}}
@@ -214,7 +214,7 @@ const identityPageTemplateHTML = `
       <form method="post" action="/api/identity/save" style="margin-top: 16px;">
         <input type="hidden" name="return_path" value="/identity">
         <input type="hidden" name="return_to" value="identity-global">
-        <label for="assistant-name">Assistant Name</label>
+        <label for="assistant-name">Default Name</label>
         <input
           id="assistant-name"
           type="text"
@@ -224,22 +224,21 @@ const identityPageTemplateHTML = `
           style="width: 100%; margin-top: 8px;"
         >
         <div class="actions" style="margin-top: 12px;">
-          <button type="submit">Save Assistant Name</button>
+          <button type="submit">Save Default Name</button>
         </div>
       </form>
     </section>
 
     {{if .Chats.Enabled}}
     <section class="card" style="margin-top: 24px;" id="identity-chats">
-      <h2>Chat Overrides</h2>
+      <h2>Chats Using Their Own Name</h2>
       <p class="subtle">
-        A chat override only changes the bot's name inside one tracked
-        chat. It wins over the global fallback, and it stays there until
-        cleared, even if the user starts a new session epoch with
-        <code>/new</code>.
+        These chats are not using the default name. Each one already has
+        its own current chat name, so changing the default name will not
+        replace it.
       </p>
       <dl class="meta" style="margin-top: 14px;">
-        <dt>Active Overrides</dt>
+        <dt>Chats Using Their Own Name</dt>
         <dd>{{.Chats.OverrideCount}}</dd>
         <dt>Tracked Chats</dt>
         <dd>{{.Chats.TotalCount}}</dd>
@@ -252,7 +251,7 @@ const identityPageTemplateHTML = `
           <tr>
             <th>Chat</th>
             <th>Current Name</th>
-            <th>Override</th>
+            <th>Current Chat Name</th>
             <th>Last Activity</th>
           </tr>
         </thead>

--- a/openclaw/admin/service.go
+++ b/openclaw/admin/service.go
@@ -111,7 +111,7 @@ const (
 		"persona definitions exposed by this runtime."
 	pageSummaryChats = "" +
 		"Inspect tracked chats, chat-specific assistant-name " +
-		"overrides, personas, and recent session-line history."
+		"overrides, personas, and recent session history."
 )
 
 type adminView string
@@ -2300,8 +2300,14 @@ const adminPageHTML = `<!doctype html>
     .meta dt {
       color: var(--muted);
       font-weight: 700;
+      min-width: 0;
     }
-    .meta dd { margin: 0; }
+    .meta dd {
+      margin: 0;
+      min-width: 0;
+      overflow-wrap: anywhere;
+      word-break: break-word;
+    }
     a { color: var(--accent); }
     code {
       background: rgba(15, 111, 97, 0.08);
@@ -2334,8 +2340,11 @@ const adminPageHTML = `<!doctype html>
     th, td {
       text-align: left;
       vertical-align: top;
+      min-width: 0;
       padding: 12px 10px;
       border-top: 1px solid var(--line);
+      overflow-wrap: anywhere;
+      word-break: break-word;
     }
     th {
       color: var(--muted);
@@ -2801,6 +2810,65 @@ const adminPageHTML = `<!doctype html>
       color: var(--muted);
       font-weight: 700;
       white-space: nowrap;
+    }
+    .chat-list {
+      display: grid;
+      gap: 14px;
+      margin-top: 16px;
+    }
+    .chat-card {
+      border: 1px solid var(--line);
+      border-radius: 18px;
+      padding: 16px 18px;
+      background: rgba(255, 253, 248, 0.72);
+    }
+    .chat-card-head {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+    .chat-card-copy {
+      min-width: 0;
+      flex: 1 1 280px;
+    }
+    .chat-card-title {
+      font-size: 18px;
+      font-weight: 700;
+      line-height: 1.35;
+      overflow-wrap: anywhere;
+      word-break: break-word;
+    }
+    .chat-card-kind {
+      margin-top: 6px;
+      color: var(--muted);
+    }
+    .chat-card-link {
+      flex: 0 0 auto;
+      white-space: nowrap;
+    }
+    .chat-card-grid {
+      display: grid;
+      gap: 10px 18px;
+      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+      margin-top: 14px;
+    }
+    .chat-card-meta {
+      min-width: 0;
+    }
+    .chat-card-label {
+      color: var(--muted);
+      font-size: 12px;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+    .chat-card-value {
+      margin-top: 6px;
+      line-height: 1.45;
+      overflow-wrap: anywhere;
+      word-break: break-word;
     }
     @media (max-width: 760px) {
       .app-shell {

--- a/openclaw/admin/service.go
+++ b/openclaw/admin/service.go
@@ -36,6 +36,7 @@ const (
 	routePrompts    = "/prompts"
 	routeIdentity   = "/identity"
 	routePersonas   = "/personas"
+	routeChats      = "/chats"
 	routeMemory     = "/memory"
 	routeAutomation = "/automation"
 	routeSessions   = "/sessions"
@@ -62,6 +63,7 @@ const (
 
 	queryNotice    = "notice"
 	queryError     = "error"
+	queryChatID    = "chat_id"
 	querySessionID = "session_id"
 	queryChannel   = "channel"
 	queryUserID    = "user_id"
@@ -107,6 +109,9 @@ const (
 	pageSummaryPersonas = "" +
 		"Manage the default persona and any file-backed " +
 		"persona definitions exposed by this runtime."
+	pageSummaryChats = "" +
+		"Inspect tracked chats, chat-specific assistant-name " +
+		"overrides, personas, and recent session-line history."
 )
 
 type adminView string
@@ -117,6 +122,7 @@ const (
 	viewPrompts    adminView = "prompts"
 	viewIdentity   adminView = "identity"
 	viewPersonas   adminView = "personas"
+	viewChats      adminView = "chats"
 	viewMemory     adminView = "memory"
 	viewAutomation adminView = "automation"
 	viewSessions   adminView = "sessions"
@@ -161,6 +167,7 @@ type Config struct {
 	Prompts       PromptsProvider
 	Identity      IdentityProvider
 	Personas      PersonasProvider
+	Chats         ChatsProvider
 	MemoryFiles   MemoryFileStore
 	Browser       BrowserConfig
 
@@ -296,6 +303,10 @@ func (s *Service) Handler() http.Handler {
 		wrapRelativeLinksFunc(s.handlePersonasPage),
 	)
 	mux.HandleFunc(
+		routeChats,
+		wrapRelativeLinksFunc(s.handleChatsPage),
+	)
+	mux.HandleFunc(
 		routeMemory,
 		wrapRelativeLinksFunc(s.handleMemoryPage),
 	)
@@ -320,6 +331,7 @@ func (s *Service) Handler() http.Handler {
 	mux.HandleFunc(routePromptsJSON, s.handlePromptsJSON)
 	mux.HandleFunc(routeIdentityJSON, s.handleIdentityJSON)
 	mux.HandleFunc(routePersonasJSON, s.handlePersonasJSON)
+	mux.HandleFunc(routeChatsJSON, s.handleChatsJSON)
 	mux.HandleFunc(routeMemoryFilesJSON, s.handleMemoryFilesJSON)
 	mux.HandleFunc(routeMemoryFile, s.handleMemoryFile)
 	mux.HandleFunc(
@@ -569,6 +581,8 @@ type pageData struct {
 	Prompts        PromptsStatus
 	Identity       IdentityStatus
 	Personas       PersonasStatus
+	Chats          ChatsStatus
+	SelectedChat   *ChatView
 	Notice         string
 	Error          string
 	RefreshSeconds int
@@ -649,6 +663,8 @@ func (s *Service) snapshotForView(view adminView) snapshot {
 		out.Memory = s.memoryStatus()
 	case viewAutomation:
 		out.Cron = s.cronStatus()
+	case viewChats:
+		out.Exec = s.execStatus()
 	case viewSessions:
 		out.Exec = s.execStatus()
 		out.Uploads = s.uploadsStatus()
@@ -992,6 +1008,13 @@ func (s *Service) handlePersonasPage(
 	s.renderPage(w, r, viewPersonas)
 }
 
+func (s *Service) handleChatsPage(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	s.renderPage(w, r, viewChats)
+}
+
 func (s *Service) handleMemoryPage(
 	w http.ResponseWriter,
 	r *http.Request,
@@ -1037,11 +1060,14 @@ func (s *Service) renderPage(
 		return
 	}
 
+	chats := s.chatsStatus()
 	data := pageData{
 		Snapshot:       s.snapshotForView(view),
 		Prompts:        s.promptsStatus(),
 		Identity:       s.identityStatus(),
 		Personas:       s.personasStatus(),
+		Chats:          chats,
+		SelectedChat:   selectChatView(chats, selectedChatID(r)),
 		Notice:         strings.TrimSpace(r.URL.Query().Get(queryNotice)),
 		Error:          strings.TrimSpace(r.URL.Query().Get(queryError)),
 		RefreshSeconds: refreshSeconds,
@@ -1071,7 +1097,7 @@ func adminNavSections(active adminView) []adminNavSection {
 				{Label: "Prompts", Path: routePrompts},
 				{Label: "Identity", Path: routeIdentity},
 				{Label: "Personas", Path: routePersonas},
-				{Label: "Sessions", Path: routeSessions},
+				{Label: "Chats", Path: routeChats},
 				{Label: "Memory", Path: routeMemory},
 				{Label: "Automation", Path: routeAutomation},
 			},
@@ -1079,6 +1105,7 @@ func adminNavSections(active adminView) []adminNavSection {
 		{
 			Label: "Diagnostics",
 			Items: []adminNavItem{
+				{Label: "Runtime Sessions", Path: routeSessions},
 				{Label: "Debug", Path: routeDebug},
 				{Label: "Browser", Path: routeBrowser},
 			},
@@ -1103,12 +1130,14 @@ func pageTitle(view adminView) string {
 		return "Identity"
 	case viewPersonas:
 		return "Personas"
+	case viewChats:
+		return "Chats"
 	case viewMemory:
 		return "Memory"
 	case viewAutomation:
 		return "Automation"
 	case viewSessions:
-		return "Sessions"
+		return "Runtime Sessions"
 	case viewDebug:
 		return "Debug"
 	case viewBrowser:
@@ -1128,6 +1157,8 @@ func pageSummary(view adminView) string {
 		return pageSummaryIdentity
 	case viewPersonas:
 		return pageSummaryPersonas
+	case viewChats:
+		return pageSummaryChats
 	case viewMemory:
 		return "Inspect durable memory storage, file-backed MEMORY.md scopes, and memory inventory."
 	case viewAutomation:
@@ -1330,6 +1361,8 @@ func navPath(raw string) string {
 		return routeIdentity
 	case routePersonas:
 		return routePersonas
+	case routeChats:
+		return routeChats
 	case routeMemory:
 		return routeMemory
 	case routeAutomation:
@@ -1357,6 +1390,8 @@ func navViewForPath(path string) adminView {
 		return viewIdentity
 	case routePersonas:
 		return viewPersonas
+	case routeChats:
+		return viewChats
 	case routeMemory:
 		return viewMemory
 	case routeAutomation:
@@ -2057,9 +2092,14 @@ var adminPage = template.Must(
 		"personaDisplayName":         personaDisplayName,
 		"personaKindLabel":           personaKindLabel,
 		"personaSummaryText":         personaSummaryText,
+		"chatDisplayLabel":           chatDisplayLabel,
+		"chatKnownUsers":             chatKnownUsers,
+		"chatNameSourceLabel":        chatNameSourceLabel,
+		"chatOverrideSample":         chatOverrideSample,
 	}).Parse(
 		adminPageHTML +
 			promptsPageTemplateHTML +
+			chatsPageTemplateHTML +
 			identityPageTemplateHTML +
 			personasPageTemplateHTML,
 	),
@@ -3475,6 +3515,10 @@ const adminPageHTML = `<!doctype html>
 
     {{if eq .View "personas"}}
     {{template "personasPage" .}}
+    {{end}}
+
+    {{if eq .View "chats"}}
+    {{template "chatsPage" .}}
     {{end}}
 
     {{if eq .View "memory"}}

--- a/openclaw/admin/service.go
+++ b/openclaw/admin/service.go
@@ -104,14 +104,14 @@ const (
 		"Edit the main prompt blocks, inspect the assembled " +
 		"prompt previews, and keep file-level edits in one place."
 	pageSummaryIdentity = "" +
-		"Set the assistant's global default name while keeping " +
-		"the runtime product as a separate read-only fact."
+		"Set the default name, keep current-chat names readable, " +
+		"and leave the runtime product as a separate read-only fact."
 	pageSummaryPersonas = "" +
 		"Manage the default persona and any file-backed " +
 		"persona definitions exposed by this runtime."
 	pageSummaryChats = "" +
-		"Inspect tracked chats, chat-specific assistant-name " +
-		"overrides, personas, and recent session history."
+		"Inspect each chat's current name, default-name fallback, " +
+		"persona, and recent session history."
 )
 
 type adminView string

--- a/openclaw/admin/service_test.go
+++ b/openclaw/admin/service_test.go
@@ -1681,6 +1681,43 @@ func TestService_IdentityPageShowsChatOverrides(t *testing.T) {
 	)
 }
 
+func TestService_IdentityPageShowsChatsError(t *testing.T) {
+	t.Parallel()
+
+	identity := &stubIdentityProvider{
+		status: IdentityStatus{
+			Enabled:        true,
+			ConfiguredName: "Claw",
+			EffectiveName:  "Claw",
+			RuntimeProduct: "trpc-claw",
+			SourcePath:     "/tmp/IDENTITY.md",
+		},
+	}
+	chats := &stubChatsProvider{
+		status: ChatsStatus{
+			Enabled: true,
+			Error:   "chat status failed",
+		},
+	}
+	svc := New(Config{
+		Identity: identity,
+		Chats:    chats,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, routeIdentity, nil)
+	rec := httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := rec.Body.String()
+	require.Contains(t, body, "chat status failed")
+	require.NotContains(
+		t,
+		body,
+		"No chat-specific name overrides are active.",
+	)
+}
+
 func TestService_ChatsPageAndJSON(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/admin/service_test.go
+++ b/openclaw/admin/service_test.go
@@ -121,6 +121,11 @@ type stubPersonasProvider struct {
 	deleteCount int
 }
 
+type stubChatsProvider struct {
+	status ChatsStatus
+	err    error
+}
+
 func (p stubBMP) BrowserManagedStatus() BrowserManagedService {
 	return p.status
 }
@@ -315,6 +320,16 @@ func (p *stubPersonasProvider) SetDefaultPersona(
 	p.defaultCount++
 	p.defaultPersona = personaID
 	return p.defaultErr
+}
+
+func (p *stubChatsProvider) ChatsStatus() (
+	ChatsStatus,
+	error,
+) {
+	if p == nil {
+		return ChatsStatus{}, nil
+	}
+	return p.status, p.err
 }
 
 func (r *stubRunner) Run(
@@ -1268,6 +1283,12 @@ func TestAdminHelpers_PageMetadataAndNavigation(t *testing.T) {
 			summary: pageSummaryPersonas,
 		},
 		{
+			path:    routeChats,
+			view:    viewChats,
+			title:   "Chats",
+			summary: pageSummaryChats,
+		},
+		{
 			path:    routeMemory,
 			view:    viewMemory,
 			title:   "Memory",
@@ -1282,7 +1303,7 @@ func TestAdminHelpers_PageMetadataAndNavigation(t *testing.T) {
 		{
 			path:    routeSessions,
 			view:    viewSessions,
-			title:   "Sessions",
+			title:   "Runtime Sessions",
 			summary: "Review exec sessions, upload sessions, and recently persisted files.",
 		},
 		{
@@ -1609,6 +1630,124 @@ func TestService_IdentityPageAndActions(t *testing.T) {
 	require.Equal(t, http.StatusSeeOther, rec.Code)
 	require.Equal(t, 1, identity.saveCount)
 	require.Equal(t, "Nora", identity.saveName)
+}
+
+func TestService_IdentityPageShowsChatOverrides(t *testing.T) {
+	t.Parallel()
+
+	identity := &stubIdentityProvider{
+		status: IdentityStatus{
+			Enabled:        true,
+			ConfiguredName: "Claw",
+			EffectiveName:  "Claw",
+			RuntimeProduct: "trpc-claw",
+			SourcePath:     "/tmp/IDENTITY.md",
+		},
+	}
+	chats := &stubChatsProvider{
+		status: ChatsStatus{
+			Enabled:       true,
+			OverrideCount: 1,
+			Chats: []ChatView{{
+				BaseSessionID:         "wecom:dm:alice",
+				DisplayLabel:          "Direct Message / alice",
+				EffectiveAssistant:    "林妹妹",
+				ChatAssistantOverride: "林妹妹",
+				OverridesGlobal:       true,
+				LastActivity:          time.Unix(1700000000, 0),
+			}},
+		},
+	}
+	svc := New(Config{
+		Identity: identity,
+		Chats:    chats,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, routeIdentity, nil)
+	rec := httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := rec.Body.String()
+	require.Contains(t, body, "Chat Overrides")
+	require.Contains(t, body, "Active Overrides")
+	require.Contains(t, body, "Direct Message / alice")
+	require.Contains(t, body, "林妹妹")
+	require.Contains(
+		t,
+		body,
+		"chats?chat_id=wecom%3adm%3aalice",
+	)
+}
+
+func TestService_ChatsPageAndJSON(t *testing.T) {
+	t.Parallel()
+
+	chats := &stubChatsProvider{
+		status: ChatsStatus{
+			Enabled:             true,
+			GlobalAssistantName: "Claw",
+			Chats: []ChatView{{
+				BaseSessionID:         "wecom:dm:alice",
+				DisplayLabel:          "Direct Message / alice",
+				KindLabel:             "Direct message",
+				CurrentSessionID:      "wecom:dm:alice:171",
+				RecallSessionID:       "wecom:dm:alice",
+				LastActivity:          time.Unix(1700000000, 0),
+				Epoch:                 171,
+				EffectiveAssistant:    "林妹妹",
+				ChatAssistantOverride: "林妹妹",
+				NameSource:            "chat override",
+				OverridesGlobal:       true,
+				PersonaLabel:          "Creative",
+				WorkspacePath:         "/repo",
+				KnownUserIDs:          []string{"alice"},
+				History: []ChatSessionView{{
+					SessionID:    "wecom:dm:alice:171",
+					LastActivity: time.Unix(1700000000, 0),
+				}},
+			}},
+		},
+	}
+	identity := &stubIdentityProvider{
+		status: IdentityStatus{
+			Enabled:        true,
+			EffectiveName:  "Claw",
+			RuntimeProduct: "trpc-claw",
+		},
+	}
+	svc := New(Config{
+		Chats:    chats,
+		Identity: identity,
+	})
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		routeChats+"?chat_id=wecom%3Adm%3Aalice",
+		nil,
+	)
+	rec := httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := rec.Body.String()
+	require.Contains(t, body, "Tracked Chats")
+	require.Contains(t, body, "Chat Detail")
+	require.Contains(t, body, "Direct Message / alice")
+	require.Contains(t, body, "chat override")
+	require.Contains(t, body, "Tracked Session Lines")
+	require.Contains(t, body, "<code>wecom:dm:alice</code>")
+
+	req = httptest.NewRequest(http.MethodGet, routeChatsJSON, nil)
+	rec = httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "\"override_count\": 1")
+	require.Contains(
+		t,
+		rec.Body.String(),
+		"\"base_session_id\": \"wecom:dm:alice\"",
+	)
 }
 
 func TestService_PersonasPageAndActions(t *testing.T) {

--- a/openclaw/admin/service_test.go
+++ b/openclaw/admin/service_test.go
@@ -1601,7 +1601,8 @@ func TestService_IdentityPageAndActions(t *testing.T) {
 	rec := httptest.NewRecorder()
 	svc.Handler().ServeHTTP(rec, req)
 	require.Equal(t, http.StatusOK, rec.Code)
-	require.Contains(t, rec.Body.String(), "Assistant Name")
+	require.Contains(t, rec.Body.String(), "Default Name")
+	require.Contains(t, rec.Body.String(), "How Naming Works")
 	require.Contains(t, rec.Body.String(), "trpc-claw")
 	require.Contains(t, rec.Body.String(), "/api/identity")
 
@@ -1669,8 +1670,8 @@ func TestService_IdentityPageShowsChatOverrides(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, rec.Code)
 	body := rec.Body.String()
-	require.Contains(t, body, "Chat Overrides")
-	require.Contains(t, body, "Active Overrides")
+	require.Contains(t, body, "Chats Using Their Own Name")
+	require.Contains(t, body, "Current chat name wins")
 	require.Contains(t, body, "Direct Message / alice")
 	require.Contains(t, body, "林妹妹")
 	require.Contains(
@@ -1697,7 +1698,7 @@ func TestService_ChatsPageAndJSON(t *testing.T) {
 				Epoch:                 171,
 				EffectiveAssistant:    "林妹妹",
 				ChatAssistantOverride: "林妹妹",
-				NameSource:            "chat override",
+				NameSource:            "Current chat name",
 				OverridesGlobal:       true,
 				PersonaLabel:          "Creative",
 				WorkspacePath:         "/repo",
@@ -1734,7 +1735,7 @@ func TestService_ChatsPageAndJSON(t *testing.T) {
 	require.Contains(t, body, "Tracked Chats")
 	require.Contains(t, body, "Chat Detail")
 	require.Contains(t, body, "Direct Message / alice")
-	require.Contains(t, body, "chat override")
+	require.Contains(t, body, "Current chat name")
 	require.Contains(t, body, "Recent Sessions")
 	require.Contains(t, body, "<code>wecom:dm:alice</code>")
 

--- a/openclaw/admin/service_test.go
+++ b/openclaw/admin/service_test.go
@@ -1718,6 +1718,47 @@ func TestService_IdentityPageShowsChatsError(t *testing.T) {
 	)
 }
 
+func TestService_IdentityPageClearAction(t *testing.T) {
+	t.Parallel()
+
+	identity := &stubIdentityProvider{
+		status: IdentityStatus{
+			Enabled:        true,
+			ConfiguredName: "Claw",
+			EffectiveName:  "Claw",
+			RuntimeProduct: "trpc-claw",
+			SourcePath:     "/tmp/IDENTITY.md",
+		},
+	}
+	svc := New(Config{Identity: identity})
+
+	values := url.Values{
+		formAssistantName: {""},
+		formReturnPath:    {routeIdentity},
+		formReturnTo:      {"identity-global"},
+	}
+	req := httptest.NewRequest(
+		http.MethodPost,
+		routeIdentitySave,
+		strings.NewReader(values.Encode()),
+	)
+	req.Header.Set(
+		"Content-Type",
+		"application/x-www-form-urlencoded",
+	)
+	rec := httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusSeeOther, rec.Code)
+	require.Equal(t, 1, identity.saveCount)
+	require.Empty(t, identity.saveName)
+	require.Contains(
+		t,
+		rec.Header().Get("Location"),
+		"Cleared+default+name.",
+	)
+}
+
 func TestService_ChatsPageAndJSON(t *testing.T) {
 	t.Parallel()
 
@@ -1787,6 +1828,135 @@ func TestService_ChatsPageAndJSON(t *testing.T) {
 		rec.Body.String(),
 		"\"base_session_id\": \"wecom:dm:alice\"",
 	)
+}
+
+func TestService_ChatsPageFallbackStates(t *testing.T) {
+	t.Parallel()
+
+	svc := New(Config{})
+
+	req := httptest.NewRequest(http.MethodGet, routeChats, nil)
+	rec := httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(
+		t,
+		rec.Body.String(),
+		"Chat tracking is not available for this runtime.",
+	)
+
+	chats := &stubChatsProvider{
+		status: ChatsStatus{
+			Enabled: true,
+		},
+	}
+	svc = New(Config{Chats: chats})
+
+	req = httptest.NewRequest(
+		http.MethodGet,
+		routeChats+"?chat_id=missing",
+		nil,
+	)
+	rec = httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(
+		t,
+		rec.Body.String(),
+		"No tracked chats are available yet.",
+	)
+	require.Contains(
+		t,
+		rec.Body.String(),
+		"Choose a tracked chat from the list to inspect its current",
+	)
+
+	req = httptest.NewRequest(http.MethodPost, routeChatsJSON, nil)
+	rec = httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rec, req)
+	require.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+}
+
+func TestChatsHelpers(t *testing.T) {
+	t.Parallel()
+
+	require.Empty(t, selectedChatID(nil))
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		routeChats+"?chat_id=%20wecom%3Adm%3Abob%20",
+		nil,
+	)
+	require.Equal(t, "wecom:dm:bob", selectedChatID(req))
+
+	status := ChatsStatus{
+		Chats: []ChatView{
+			{
+				BaseSessionID: "wecom:dm:alice",
+				LastActivity:  time.Unix(1700000000, 0),
+			},
+			{
+				BaseSessionID:         "wecom:group:room-1",
+				DisplayLabel:          "Room 1",
+				ChatAssistantOverride: "林妹妹",
+				OverridesGlobal:       true,
+				LastActivity:          time.Unix(1700000100, 0),
+				KnownUserIDs:          []string{"alice", "bob"},
+			},
+			{
+				BaseSessionID:   "wecom:dm:bob",
+				OverridesGlobal: true,
+				LastActivity:    time.Unix(1700000050, 0),
+				NameSource:      "Custom source",
+			},
+		},
+	}
+
+	selected := selectChatView(status, "")
+	require.NotNil(t, selected)
+	require.Equal(t, "wecom:dm:alice", selected.BaseSessionID)
+
+	selected = selectChatView(status, "wecom:dm:bob")
+	require.NotNil(t, selected)
+	require.Equal(t, "wecom:dm:bob", selected.BaseSessionID)
+
+	require.Nil(t, selectChatView(status, "missing"))
+	require.Nil(t, selectChatView(ChatsStatus{}, ""))
+
+	require.Equal(
+		t,
+		"wecom:dm:alice",
+		chatDisplayLabel(ChatView{BaseSessionID: "wecom:dm:alice"}),
+	)
+	require.Equal(t, "-", chatKnownUsers(ChatView{}))
+	require.Equal(t, "alice, bob", chatKnownUsers(status.Chats[1]))
+	require.Equal(
+		t,
+		"Current chat name",
+		chatNameSourceLabel(ChatView{
+			ChatAssistantOverride: "林妹妹",
+		}),
+	)
+	require.Equal(
+		t,
+		"Custom source",
+		chatNameSourceLabel(status.Chats[2]),
+	)
+	require.Equal(t, "Default name", chatNameSourceLabel(ChatView{}))
+
+	sample := chatOverrideSample(status, 1)
+	require.Len(t, sample, 1)
+	require.Equal(t, "wecom:group:room-1", sample[0].BaseSessionID)
+
+	sample = chatOverrideSample(status, 0)
+	require.Len(t, sample, 2)
+
+	sample = chatOverrideSample(status, 5)
+	require.Len(t, sample, 2)
+
+	require.Equal(t, 2, chatOverrideCount(status.Chats))
 }
 
 func TestService_PersonasPageAndActions(t *testing.T) {

--- a/openclaw/admin/service_test.go
+++ b/openclaw/admin/service_test.go
@@ -1780,7 +1780,10 @@ func TestService_ChatsPageAndJSON(t *testing.T) {
 				OverridesGlobal:       true,
 				PersonaLabel:          "Creative",
 				WorkspacePath:         "/repo",
-				KnownUserIDs:          []string{"alice"},
+				KnownUsers: []KnownUserView{{
+					UserID: "alice",
+					Label:  "Alice Chen",
+				}},
 				History: []ChatSessionView{{
 					SessionID:    "wecom:dm:alice:171",
 					LastActivity: time.Unix(1700000000, 0),
@@ -1817,6 +1820,7 @@ func TestService_ChatsPageAndJSON(t *testing.T) {
 	require.Contains(t, body, "Recent Sessions")
 	require.Contains(t, body, "<code>wecom:dm:alice</code>")
 	require.Contains(t, body, "href=\"identity#identity-global\"")
+	require.Contains(t, body, "Alice Chen (alice)")
 
 	req = httptest.NewRequest(http.MethodGet, routeChatsJSON, nil)
 	rec = httptest.NewRecorder()
@@ -1932,6 +1936,31 @@ func TestChatsHelpers(t *testing.T) {
 	)
 	require.Equal(t, "-", chatKnownUsers(ChatView{}))
 	require.Equal(t, "alice, bob", chatKnownUsers(status.Chats[1]))
+	require.Equal(
+		t,
+		"Alice (T00010001), Bob (T00010002)",
+		chatKnownUsers(ChatView{
+			KnownUsers: []KnownUserView{
+				{
+					UserID: "T00010001",
+					Label:  "Alice",
+				},
+				{
+					UserID: "T00010002",
+					Label:  "Bob",
+				},
+			},
+		}),
+	)
+	require.Equal(
+		t,
+		"T00010003",
+		chatKnownUsers(ChatView{
+			KnownUsers: []KnownUserView{{
+				UserID: "T00010003",
+			}},
+		}),
+	)
 	require.Equal(
 		t,
 		"Current chat name",

--- a/openclaw/admin/service_test.go
+++ b/openclaw/admin/service_test.go
@@ -1735,7 +1735,7 @@ func TestService_ChatsPageAndJSON(t *testing.T) {
 	require.Contains(t, body, "Chat Detail")
 	require.Contains(t, body, "Direct Message / alice")
 	require.Contains(t, body, "chat override")
-	require.Contains(t, body, "Tracked Session Lines")
+	require.Contains(t, body, "Recent Sessions")
 	require.Contains(t, body, "<code>wecom:dm:alice</code>")
 
 	req = httptest.NewRequest(http.MethodGet, routeChatsJSON, nil)

--- a/openclaw/admin/service_test.go
+++ b/openclaw/admin/service_test.go
@@ -1738,6 +1738,7 @@ func TestService_ChatsPageAndJSON(t *testing.T) {
 	require.Contains(t, body, "Current chat name")
 	require.Contains(t, body, "Recent Sessions")
 	require.Contains(t, body, "<code>wecom:dm:alice</code>")
+	require.Contains(t, body, "href=\"identity#identity-global\"")
 
 	req = httptest.NewRequest(http.MethodGet, routeChatsJSON, nil)
 	rec = httptest.NewRecorder()

--- a/openclaw/app/admin_identity.go
+++ b/openclaw/app/admin_identity.go
@@ -1,0 +1,215 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package app
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/admin"
+)
+
+const (
+	adminIdentityFileName = "IDENTITY.md"
+
+	adminIdentityFilePerm = 0o600
+	adminIdentityDirPerm  = 0o700
+
+	adminAssistantNameMaxRunes = 32
+
+	adminIdentityFallbackRuntime = "runtime product"
+
+	adminDefaultNameSourceFile = "Default name from IDENTITY.md"
+	adminDefaultNameSourceApp  = "Default name from runtime product"
+
+	adminChatsHelpText = "" +
+		"This runtime does not keep a separate current name per " +
+		"chat yet. Every chat uses the default name shown on the " +
+		"Identity page."
+
+	adminIdentityTrimCutset = "" +
+		"\"'“”‘’<>《》「」『』【】()（）[]"
+)
+
+type adminIdentityProvider struct {
+	filePath       string
+	runtimeProduct string
+}
+
+type adminChatsProvider struct {
+	identity *adminIdentityProvider
+}
+
+func buildAdminIdentityProvider(
+	stateDir string,
+	runtimeProduct string,
+) *adminIdentityProvider {
+	return &adminIdentityProvider{
+		filePath: filepath.Join(
+			strings.TrimSpace(stateDir),
+			adminIdentityFileName,
+		),
+		runtimeProduct: defaultAdminRuntimeProduct(runtimeProduct),
+	}
+}
+
+func buildAdminChatsProvider(
+	identity *adminIdentityProvider,
+) *adminChatsProvider {
+	if identity == nil {
+		return nil
+	}
+	return &adminChatsProvider{identity: identity}
+}
+
+func defaultAdminRuntimeProduct(raw string) string {
+	product := strings.TrimSpace(raw)
+	if product != "" {
+		return product
+	}
+	return appName
+}
+
+func normalizeAdminAssistantName(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+
+	trimmed = strings.Trim(trimmed, adminIdentityTrimCutset)
+	trimmed = strings.TrimSpace(trimmed)
+	if trimmed == "" {
+		return ""
+	}
+
+	fields := strings.Fields(trimmed)
+	if len(fields) != 0 {
+		trimmed = strings.Join(fields, " ")
+	}
+
+	runes := []rune(trimmed)
+	if len(runes) > adminAssistantNameMaxRunes {
+		runes = runes[:adminAssistantNameMaxRunes]
+	}
+	return strings.TrimSpace(string(runes))
+}
+
+func readAdminAssistantName(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", nil
+	}
+
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return normalizeAdminAssistantName(string(data)), nil
+}
+
+func writeAdminAssistantName(
+	path string,
+	name string,
+) error {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return fmt.Errorf("admin identity path is unavailable")
+	}
+	if err := os.MkdirAll(
+		filepath.Dir(path),
+		adminIdentityDirPerm,
+	); err != nil {
+		return err
+	}
+
+	body := ""
+	name = normalizeAdminAssistantName(name)
+	if name != "" {
+		body = name + "\n"
+	}
+	return os.WriteFile(
+		path,
+		[]byte(body),
+		adminIdentityFilePerm,
+	)
+}
+
+func identityDefaultNameSource(
+	status admin.IdentityStatus,
+) string {
+	if strings.TrimSpace(status.ConfiguredName) != "" {
+		return adminDefaultNameSourceFile
+	}
+	return adminDefaultNameSourceApp
+}
+
+func (p *adminIdentityProvider) IdentityStatus() (
+	admin.IdentityStatus,
+	error,
+) {
+	if p == nil {
+		return admin.IdentityStatus{}, nil
+	}
+
+	configured, err := readAdminAssistantName(p.filePath)
+	if err != nil {
+		return admin.IdentityStatus{}, err
+	}
+
+	effective := configured
+	fallbackSource := ""
+	if effective == "" {
+		effective = p.runtimeProduct
+		fallbackSource = adminIdentityFallbackRuntime
+	}
+
+	return admin.IdentityStatus{
+		Enabled:        true,
+		ConfiguredName: configured,
+		EffectiveName:  effective,
+		RuntimeProduct: p.runtimeProduct,
+		SourcePath:     strings.TrimSpace(p.filePath),
+		FallbackSource: fallbackSource,
+	}, nil
+}
+
+func (p *adminIdentityProvider) SaveAssistantName(name string) error {
+	if p == nil {
+		return fmt.Errorf("identity provider is unavailable")
+	}
+	return writeAdminAssistantName(p.filePath, name)
+}
+
+func (p *adminChatsProvider) ChatsStatus() (
+	admin.ChatsStatus,
+	error,
+) {
+	if p == nil {
+		return admin.ChatsStatus{}, nil
+	}
+
+	identity, err := p.identity.IdentityStatus()
+	if err != nil {
+		return admin.ChatsStatus{}, err
+	}
+
+	return admin.ChatsStatus{
+		Enabled:               true,
+		GlobalAssistantName:   strings.TrimSpace(identity.EffectiveName),
+		RuntimeAssistantName:  strings.TrimSpace(identity.RuntimeProduct),
+		GlobalAssistantSource: identityDefaultNameSource(identity),
+		ChatOverrideHelp:      adminChatsHelpText,
+	}, nil
+}

--- a/openclaw/app/admin_server.go
+++ b/openclaw/app/admin_server.go
@@ -127,6 +127,10 @@ func buildAdminConfig(
 	skillsWatch *ocskills.WatchService,
 	memoryFiles admin.MemoryFileStore,
 ) admin.Config {
+	identity := buildAdminIdentityProvider(
+		stateDir,
+		opts.AppName,
+	)
 	return admin.Config{
 		AppName:        opts.AppName,
 		InstanceID:     instanceID,
@@ -159,6 +163,8 @@ func buildAdminConfig(
 			opts,
 			promptController,
 		),
+		Identity:    identity,
+		Chats:       buildAdminChatsProvider(identity),
 		MemoryFiles: memoryFiles,
 		Browser: buildBrowserAdminConfig(
 			opts.ToolProviders,

--- a/openclaw/app/admin_server_test.go
+++ b/openclaw/app/admin_server_test.go
@@ -269,3 +269,76 @@ func TestNormalizeAdminAssistantName(t *testing.T) {
 	require.Len(t, []rune(got), adminAssistantNameMaxRunes)
 	require.Equal(t, raw[:adminAssistantNameMaxRunes], got)
 }
+
+func TestAdminIdentityHelpers(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, buildAdminChatsProvider(nil))
+	require.Equal(t, appName, defaultAdminRuntimeProduct(" "))
+	require.Equal(
+		t,
+		"",
+		normalizeAdminAssistantName(" 【】 "),
+	)
+
+	name, err := readAdminAssistantName("")
+	require.NoError(t, err)
+	require.Empty(t, name)
+
+	name, err = readAdminAssistantName(
+		filepath.Join(t.TempDir(), "IDENTITY.md"),
+	)
+	require.NoError(t, err)
+	require.Empty(t, name)
+
+	err = writeAdminAssistantName("", "Nora")
+	require.Error(t, err)
+
+	var nilIdentity *adminIdentityProvider
+	status, err := nilIdentity.IdentityStatus()
+	require.NoError(t, err)
+	require.Equal(t, admin.IdentityStatus{}, status)
+	require.Error(t, nilIdentity.SaveAssistantName("Nora"))
+
+	var nilChats *adminChatsProvider
+	chatsStatus, err := nilChats.ChatsStatus()
+	require.NoError(t, err)
+	require.Equal(t, admin.ChatsStatus{}, chatsStatus)
+}
+
+func TestAdminIdentityProvider_FallbackAndErrors(t *testing.T) {
+	t.Parallel()
+
+	stateDir := t.TempDir()
+	identity := buildAdminIdentityProvider(stateDir, "runtime-product")
+
+	status, err := identity.IdentityStatus()
+	require.NoError(t, err)
+	require.Equal(t, "runtime-product", status.EffectiveName)
+	require.Empty(t, status.ConfiguredName)
+	require.Equal(t, adminIdentityFallbackRuntime, status.FallbackSource)
+	require.Equal(
+		t,
+		adminDefaultNameSourceApp,
+		identityDefaultNameSource(status),
+	)
+
+	err = identity.SaveAssistantName("")
+	require.NoError(t, err)
+
+	status, err = identity.IdentityStatus()
+	require.NoError(t, err)
+	require.Equal(t, "runtime-product", status.EffectiveName)
+	require.Empty(t, status.ConfiguredName)
+
+	badIdentity := &adminIdentityProvider{
+		filePath:       stateDir,
+		runtimeProduct: "runtime-product",
+	}
+	_, err = badIdentity.IdentityStatus()
+	require.Error(t, err)
+
+	chats := buildAdminChatsProvider(badIdentity)
+	_, err = chats.ChatsStatus()
+	require.Error(t, err)
+}

--- a/openclaw/app/admin_server_test.go
+++ b/openclaw/app/admin_server_test.go
@@ -11,6 +11,7 @@ package app
 
 import (
 	"net"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -181,4 +182,90 @@ nodes:
 	require.Equal(t, "openclaw", provider.Profiles[0].Name)
 	require.Len(t, provider.Nodes, 1)
 	require.Equal(t, "edge", provider.Nodes[0].ID)
+}
+
+func TestBuildAdminConfig_IncludesIdentityAndChatsProviders(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	stateDir := t.TempDir()
+	cfg := buildAdminConfig(
+		runOptions{
+			AppName: "openclaw",
+		},
+		agentTypeLLM,
+		"instance-1",
+		admin.LangfuseStatus{},
+		stateDir,
+		filepath.Join(stateDir, "debug"),
+		time.Unix(0, 0),
+		nil,
+		admin.Routes{},
+		nil,
+		nil,
+		nil,
+		nil,
+		"127.0.0.1:8081",
+		"http://127.0.0.1:8081",
+		nil,
+		nil,
+		nil,
+	)
+
+	require.NotNil(t, cfg.Identity)
+	require.NotNil(t, cfg.Chats)
+
+	identityStatus, err := cfg.Identity.IdentityStatus()
+	require.NoError(t, err)
+	require.Equal(t, "openclaw", identityStatus.EffectiveName)
+	require.Equal(t, "openclaw", identityStatus.RuntimeProduct)
+	require.Equal(
+		t,
+		filepath.Join(stateDir, adminIdentityFileName),
+		identityStatus.SourcePath,
+	)
+	require.Equal(
+		t,
+		adminIdentityFallbackRuntime,
+		identityStatus.FallbackSource,
+	)
+
+	err = cfg.Identity.SaveAssistantName("  Nora   Claw  ")
+	require.NoError(t, err)
+
+	identityStatus, err = cfg.Identity.IdentityStatus()
+	require.NoError(t, err)
+	require.Equal(t, "Nora Claw", identityStatus.ConfiguredName)
+	require.Equal(t, "Nora Claw", identityStatus.EffectiveName)
+	require.Empty(t, identityStatus.FallbackSource)
+
+	chatsStatus, err := cfg.Chats.ChatsStatus()
+	require.NoError(t, err)
+	require.True(t, chatsStatus.Enabled)
+	require.Equal(t, "Nora Claw", chatsStatus.GlobalAssistantName)
+	require.Equal(t, "openclaw", chatsStatus.RuntimeAssistantName)
+	require.Equal(
+		t,
+		adminDefaultNameSourceFile,
+		chatsStatus.GlobalAssistantSource,
+	)
+	require.Contains(t, chatsStatus.ChatOverrideHelp, "default name")
+	require.Empty(t, chatsStatus.Chats)
+}
+
+func TestNormalizeAdminAssistantName(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "", normalizeAdminAssistantName("   "))
+	require.Equal(
+		t,
+		"Nora Claw",
+		normalizeAdminAssistantName(" “Nora   Claw” "),
+	)
+
+	raw := "1234567890123456789012345678901234567890"
+	got := normalizeAdminAssistantName(raw)
+	require.Len(t, []rune(got), adminAssistantNameMaxRunes)
+	require.Equal(t, raw[:adminAssistantNameMaxRunes], got)
 }


### PR DESCRIPTION
## Summary
- add a shared admin `Chats` page backed by an optional `ChatsProvider`
- surface active chat-specific assistant-name overrides on the `Identity` page
- rename the old `Sessions` nav label to `Runtime Sessions` to reduce ambiguity

## Why
The existing admin surface had no way to inspect per-chat assistant-name overrides or the tracked chat state coming from WeCom session tracking. Operators could change the global identity, but they could not easily tell when a specific chat was overriding it.

## User Impact
- admins can inspect tracked chats, current effective assistant names, persona/workspace state, and recent session-line history
- the identity page now calls out active chat overrides and links directly to the relevant chat state
- runtime sessions remain available, but the navigation label is clearer

## Validation
- `go test ./admin ./app`
