### PR TITLE
server/agui: emit reasoning role for reasoning start events

### DIFF
--- a/server/agui/internal/reduce/reduce.go
+++ b/server/agui/internal/reduce/reduce.go
@@ -372,10 +372,10 @@ func (r *reducer) handleReasoningMessageStart(e *aguievents.ReasoningMessageStar
 		return fmt.Errorf("duplicate reasoning message start: %s", e.MessageID)
 	}
 	role := e.Role
-	if role == "" {
-		role = string(model.RoleAssistant)
-	}
-	if role != string(model.RoleAssistant) {
+	switch role {
+	case "", string(types.RoleReasoning), string(model.RoleAssistant):
+		role = string(types.RoleReasoning)
+	default:
 		return fmt.Errorf("unsupported role: %s", role)
 	}
 	name := r.appName
@@ -465,7 +465,7 @@ func (r *reducer) handleReasoningChunk(e *aguievents.ReasoningMessageChunkEvent)
 	}
 	r.messages = append(r.messages, msg)
 	r.reasonings[messageID] = &reasoningState{
-		role:  string(model.RoleAssistant),
+		role:  string(types.RoleReasoning),
 		name:  r.appName,
 		phase: reasoningReceiving,
 		index: len(r.messages) - 1,
@@ -503,7 +503,7 @@ func (r *reducer) handleReasoningEncryptedValue(e *aguievents.ReasoningEncrypted
 		}
 		r.messages = append(r.messages, msg)
 		r.reasonings[e.EntityID] = &reasoningState{
-			role:  string(model.RoleAssistant),
+			role:  string(types.RoleReasoning),
 			name:  r.appName,
 			phase: reasoningEnded,
 			index: len(r.messages) - 1,

--- a/server/agui/internal/reduce/reduce_test.go
+++ b/server/agui/internal/reduce/reduce_test.go
@@ -227,7 +227,7 @@ func TestReduceAllowsUnclosedTextMessage(t *testing.T) {
 
 func TestReduceReasoningMessageLifecycle(t *testing.T) {
 	events := trackEventsFrom(
-		aguievents.NewReasoningMessageStartEvent("reasoning-msg-1", "assistant"),
+		aguievents.NewReasoningMessageStartEvent("reasoning-msg-1", "reasoning"),
 		aguievents.NewReasoningMessageContentEvent("reasoning-msg-1", "a"),
 		aguievents.NewReasoningMessageContentEvent("reasoning-msg-1", "b"),
 		aguievents.NewReasoningMessageEndEvent("reasoning-msg-1"),
@@ -248,7 +248,7 @@ func TestReduceReasoningMessageLifecycle(t *testing.T) {
 func TestReduceReasoningMessageLifecycleWithStartEndEvents(t *testing.T) {
 	events := trackEventsFrom(
 		aguievents.NewReasoningStartEvent("reasoning-msg-1"),
-		aguievents.NewReasoningMessageStartEvent("reasoning-msg-1", "assistant"),
+		aguievents.NewReasoningMessageStartEvent("reasoning-msg-1", "reasoning"),
 		aguievents.NewReasoningMessageContentEvent("reasoning-msg-1", "summary"),
 		aguievents.NewReasoningMessageEndEvent("reasoning-msg-1"),
 		aguievents.NewReasoningEndEvent("reasoning-msg-1"),
@@ -273,22 +273,34 @@ func TestReduceReasoningMessageStartDefaultsRole(t *testing.T) {
 	assert.Equal(t, types.RoleReasoning, msgs[0].Role)
 }
 
-func TestReduceReasoningMessageStartDuplicate(t *testing.T) {
+func TestReduceReasoningMessageStartAcceptsLegacyAssistantRole(t *testing.T) {
 	events := trackEventsFrom(
 		aguievents.NewReasoningMessageStartEvent("reasoning-msg-1", "assistant"),
-		aguievents.NewReasoningMessageStartEvent("reasoning-msg-1", "assistant"),
+		aguievents.NewReasoningMessageContentEvent("reasoning-msg-1", "hello"),
+		aguievents.NewReasoningMessageEndEvent("reasoning-msg-1"),
+	)
+	msgs, err := Reduce(testAppName, testUserID, events)
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, types.RoleReasoning, msgs[0].Role)
+}
+
+func TestReduceReasoningMessageStartDuplicate(t *testing.T) {
+	events := trackEventsFrom(
+		aguievents.NewReasoningMessageStartEvent("reasoning-msg-1", "reasoning"),
+		aguievents.NewReasoningMessageStartEvent("reasoning-msg-1", "reasoning"),
 	)
 	assertReduceError(t, events, "duplicate reasoning message start: reasoning-msg-1")
 }
 
 func TestReduceReasoningMessageStartMissingID(t *testing.T) {
 	events := trackEventsFrom(
-		aguievents.NewReasoningMessageStartEvent("", "assistant"),
+		aguievents.NewReasoningMessageStartEvent("", "reasoning"),
 	)
 	assertReduceError(t, events, "reasoning message start missing id")
 }
 
-func TestReduceReasoningMessageRoleMustBeAssistant(t *testing.T) {
+func TestReduceReasoningMessageStartRejectsUnsupportedRole(t *testing.T) {
 	events := trackEventsFrom(
 		aguievents.NewReasoningMessageStartEvent("reasoning-msg-1", "user"),
 	)
@@ -304,7 +316,7 @@ func TestReduceReasoningContentWithoutStart(t *testing.T) {
 
 func TestReduceReasoningContentAfterEnd(t *testing.T) {
 	events := trackEventsFrom(
-		aguievents.NewReasoningMessageStartEvent("reasoning-msg-1", "assistant"),
+		aguievents.NewReasoningMessageStartEvent("reasoning-msg-1", "reasoning"),
 		aguievents.NewReasoningMessageEndEvent("reasoning-msg-1"),
 		aguievents.NewReasoningMessageContentEvent("reasoning-msg-1", "late"),
 	)
@@ -320,7 +332,7 @@ func TestReduceReasoningEndWithoutStart(t *testing.T) {
 
 func TestReduceReasoningEndDuplicate(t *testing.T) {
 	events := trackEventsFrom(
-		aguievents.NewReasoningMessageStartEvent("reasoning-msg-1", "assistant"),
+		aguievents.NewReasoningMessageStartEvent("reasoning-msg-1", "reasoning"),
 		aguievents.NewReasoningMessageEndEvent("reasoning-msg-1"),
 		aguievents.NewReasoningMessageEndEvent("reasoning-msg-1"),
 	)
@@ -329,7 +341,7 @@ func TestReduceReasoningEndDuplicate(t *testing.T) {
 
 func TestReduceAllowsUnclosedReasoningMessage(t *testing.T) {
 	events := trackEventsFrom(
-		aguievents.NewReasoningMessageStartEvent("reasoning-msg-1", "assistant"),
+		aguievents.NewReasoningMessageStartEvent("reasoning-msg-1", "reasoning"),
 		aguievents.NewReasoningMessageContentEvent("reasoning-msg-1", "hello"),
 	)
 	msgs, err := Reduce(testAppName, testUserID, events)
@@ -403,7 +415,7 @@ func TestReduceReasoningMessageChunkClearsContextOnEnd(t *testing.T) {
 	next := "b"
 
 	events := trackEventsFrom(
-		aguievents.NewReasoningMessageStartEvent(messageID, "assistant"),
+		aguievents.NewReasoningMessageStartEvent(messageID, "reasoning"),
 		aguievents.NewReasoningMessageChunkEvent(&messageID, &delta),
 		aguievents.NewReasoningMessageEndEvent(messageID),
 		aguievents.NewReasoningMessageChunkEvent(nil, &next),
@@ -421,7 +433,7 @@ func TestReduceReasoningMessageChunkAllowsNilDelta(t *testing.T) {
 
 func TestReduceReasoningEncryptedValue(t *testing.T) {
 	events := trackEventsFrom(
-		aguievents.NewReasoningMessageStartEvent("reasoning-msg-1", "assistant"),
+		aguievents.NewReasoningMessageStartEvent("reasoning-msg-1", "reasoning"),
 		aguievents.NewReasoningMessageContentEvent("reasoning-msg-1", "summary"),
 		aguievents.NewReasoningMessageEndEvent("reasoning-msg-1"),
 		aguievents.NewReasoningEncryptedValueEvent(aguievents.ReasoningEncryptedValueSubtypeMessage, "reasoning-msg-1", "encrypted"),
@@ -452,7 +464,7 @@ func TestReduceReasoningEncryptedValueCreatesMessageWhenMissing(t *testing.T) {
 
 func TestReduceKeepsOpenReasoningMessageWithoutContent(t *testing.T) {
 	events := trackEventsFrom(
-		aguievents.NewReasoningMessageStartEvent("reasoning-msg-1", "assistant"),
+		aguievents.NewReasoningMessageStartEvent("reasoning-msg-1", "reasoning"),
 	)
 	msgs, err := Reduce(testAppName, testUserID, events)
 	require.NoError(t, err)

--- a/server/agui/runner/messagessnapshot_test.go
+++ b/server/agui/runner/messagessnapshot_test.go
@@ -578,7 +578,7 @@ func TestMessagesSnapshotFollowContinuesOpenReasoningFromSnapshot(t *testing.T) 
 	initial := &session.TrackEvents{
 		Track: track.TrackAGUI,
 		Events: []session.TrackEvent{
-			newTrackEventAt(t, aguievents.NewReasoningMessageStartEvent("reasoning-msg-1", "assistant"), base),
+			newTrackEventAt(t, aguievents.NewReasoningMessageStartEvent("reasoning-msg-1", "reasoning"), base),
 		},
 	}
 	follow := &session.TrackEvents{

--- a/server/agui/translator/translator.go
+++ b/server/agui/translator/translator.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	aguievents "github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/events"
+	aguitypes "github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/types"
 	"github.com/google/uuid"
 	agentevent "trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/graph"
@@ -381,7 +382,7 @@ func (t *translator) reasoningEvents(rsp *model.Response) ([]aguievents.Event, e
 			t.receivingReasoning = true
 			events = append(events,
 				aguievents.NewReasoningStartEvent(reasoningID),
-				aguievents.NewReasoningMessageStartEvent(reasoningID, model.RoleAssistant.String()),
+				aguievents.NewReasoningMessageStartEvent(reasoningID, string(aguitypes.RoleReasoning)),
 			)
 		case model.ObjectTypeChatCompletion:
 			if rsp.Choices[0].Message.ReasoningContent == "" {
@@ -397,7 +398,7 @@ func (t *translator) reasoningEvents(rsp *model.Response) ([]aguievents.Event, e
 			t.lastReasoningMessageID = reasoningID
 			events = append(events,
 				aguievents.NewReasoningStartEvent(reasoningID),
-				aguievents.NewReasoningMessageStartEvent(reasoningID, model.RoleAssistant.String()),
+				aguievents.NewReasoningMessageStartEvent(reasoningID, string(aguitypes.RoleReasoning)),
 				aguievents.NewReasoningMessageContentEvent(reasoningID, rsp.Choices[0].Message.ReasoningContent),
 				aguievents.NewReasoningMessageEndEvent(reasoningID),
 				aguievents.NewReasoningEndEvent(reasoningID),

--- a/server/agui/translator/translator_test.go
+++ b/server/agui/translator/translator_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	aguievents "github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/events"
+	aguitypes "github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/types"
 	"github.com/stretchr/testify/assert"
 	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
 	agentevent "trpc.group/trpc-go/trpc-agent-go/event"
@@ -864,7 +865,9 @@ func TestTranslateReasoningStreamEndsOnContent(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, events, 3)
 	assert.IsType(t, (*aguievents.ReasoningStartEvent)(nil), events[0])
-	assert.IsType(t, (*aguievents.ReasoningMessageStartEvent)(nil), events[1])
+	start, ok := events[1].(*aguievents.ReasoningMessageStartEvent)
+	assert.True(t, ok)
+	assert.Equal(t, string(aguitypes.RoleReasoning), start.Role)
 	assert.IsType(t, (*aguievents.ReasoningMessageContentEvent)(nil), events[2])
 	assert.True(t, tr.receivingReasoning)
 	assert.Equal(t, "msg-1", tr.lastReasoningMessageID)
@@ -936,7 +939,9 @@ func TestTranslateReasoningNonStreamPrecedesText(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, events, 8)
 	assert.IsType(t, (*aguievents.ReasoningStartEvent)(nil), events[0])
-	assert.IsType(t, (*aguievents.ReasoningMessageStartEvent)(nil), events[1])
+	start, ok := events[1].(*aguievents.ReasoningMessageStartEvent)
+	assert.True(t, ok)
+	assert.Equal(t, string(aguitypes.RoleReasoning), start.Role)
 	assert.IsType(t, (*aguievents.ReasoningMessageContentEvent)(nil), events[2])
 	assert.IsType(t, (*aguievents.ReasoningMessageEndEvent)(nil), events[3])
 	assert.IsType(t, (*aguievents.ReasoningEndEvent)(nil), events[4])


### PR DESCRIPTION
This updates AG-UI reasoning message start events to emit the current "reasoning" role expected by the AG-UI schemas while keeping the reducer backward compatible with previously stored "assistant" reasoning events so existing snapshots continue to load.