### PR TITLE
admin: add chat history view

### DIFF
--- a/openclaw/admin/chats.go
+++ b/openclaw/admin/chats.go
@@ -26,6 +26,10 @@ type ChatsProvider interface {
 	ChatsStatus() (ChatsStatus, error)
 }
 
+type ChatDetailProvider interface {
+	ChatDetail(baseSessionID string) (ChatView, error)
+}
+
 type ChatsStatus struct {
 	Enabled               bool       `json:"enabled"`
 	Error                 string     `json:"error,omitempty"`
@@ -39,25 +43,26 @@ type ChatsStatus struct {
 }
 
 type ChatView struct {
-	BaseSessionID         string            `json:"base_session_id,omitempty"`
-	DisplayLabel          string            `json:"display_label,omitempty"`
-	Kind                  string            `json:"kind,omitempty"`
-	KindLabel             string            `json:"kind_label,omitempty"`
-	CurrentSessionID      string            `json:"current_session_id,omitempty"`
-	RecallSessionID       string            `json:"recall_session_id,omitempty"`
-	LastActivity          time.Time         `json:"last_activity,omitempty"`
-	Epoch                 int64             `json:"epoch,omitempty"`
-	EffectiveAssistant    string            `json:"effective_assistant,omitempty"`
-	ChatAssistantOverride string            `json:"chat_assistant_override,omitempty"`
-	NameSource            string            `json:"name_source,omitempty"`
-	OverridesGlobal       bool              `json:"overrides_global"`
-	PersonaID             string            `json:"persona_id,omitempty"`
-	PersonaLabel          string            `json:"persona_label,omitempty"`
-	PersonaPinned         bool              `json:"persona_pinned"`
-	WorkspacePath         string            `json:"workspace_path,omitempty"`
-	KnownUserIDs          []string          `json:"known_user_ids,omitempty"`
-	KnownUsers            []KnownUserView   `json:"known_users,omitempty"`
-	History               []ChatSessionView `json:"history,omitempty"`
+	BaseSessionID         string               `json:"base_session_id,omitempty"`
+	DisplayLabel          string               `json:"display_label,omitempty"`
+	Kind                  string               `json:"kind,omitempty"`
+	KindLabel             string               `json:"kind_label,omitempty"`
+	CurrentSessionID      string               `json:"current_session_id,omitempty"`
+	RecallSessionID       string               `json:"recall_session_id,omitempty"`
+	LastActivity          time.Time            `json:"last_activity,omitempty"`
+	Epoch                 int64                `json:"epoch,omitempty"`
+	EffectiveAssistant    string               `json:"effective_assistant,omitempty"`
+	ChatAssistantOverride string               `json:"chat_assistant_override,omitempty"`
+	NameSource            string               `json:"name_source,omitempty"`
+	OverridesGlobal       bool                 `json:"overrides_global"`
+	PersonaID             string               `json:"persona_id,omitempty"`
+	PersonaLabel          string               `json:"persona_label,omitempty"`
+	PersonaPinned         bool                 `json:"persona_pinned"`
+	WorkspacePath         string               `json:"workspace_path,omitempty"`
+	KnownUserIDs          []string             `json:"known_user_ids,omitempty"`
+	KnownUsers            []KnownUserView      `json:"known_users,omitempty"`
+	History               []ChatSessionView    `json:"history,omitempty"`
+	Transcript            []ChatTranscriptView `json:"transcript,omitempty"`
 }
 
 type KnownUserView struct {
@@ -68,6 +73,23 @@ type KnownUserView struct {
 type ChatSessionView struct {
 	SessionID    string    `json:"session_id,omitempty"`
 	LastActivity time.Time `json:"last_activity,omitempty"`
+}
+
+type ChatTranscriptView struct {
+	SessionID    string         `json:"session_id,omitempty"`
+	LastActivity time.Time      `json:"last_activity,omitempty"`
+	Current      bool           `json:"current"`
+	Recall       bool           `json:"recall"`
+	Truncated    bool           `json:"truncated"`
+	Turns        []ChatTurnView `json:"turns,omitempty"`
+}
+
+type ChatTurnView struct {
+	Role      string    `json:"role,omitempty"`
+	Speaker   string    `json:"speaker,omitempty"`
+	QuoteText string    `json:"quote_text,omitempty"`
+	Text      string    `json:"text,omitempty"`
+	Timestamp time.Time `json:"timestamp,omitempty"`
 }
 
 func (s *Service) chatsStatus() ChatsStatus {
@@ -177,6 +199,42 @@ func chatNameSourceLabel(chat ChatView) string {
 		return "Current chat name"
 	}
 	return "Default name"
+}
+
+func chatHasTranscript(chat ChatView) bool {
+	return len(chat.Transcript) != 0
+}
+
+func chatTranscriptLabel(view ChatTranscriptView) string {
+	switch {
+	case view.Current:
+		return "Current session"
+	case view.Recall:
+		return "Recall session"
+	default:
+		return "Recent session"
+	}
+}
+
+func chatTurnSpeaker(view ChatTurnView) string {
+	speaker := strings.TrimSpace(view.Speaker)
+	if speaker != "" {
+		return speaker
+	}
+	switch strings.TrimSpace(view.Role) {
+	case "user":
+		return "User"
+	case "assistant":
+		return "Assistant"
+	case "system":
+		return "System"
+	default:
+		return "Turn"
+	}
+}
+
+func hasTime(value time.Time) bool {
+	return !value.IsZero()
 }
 
 func chatOverrideSample(
@@ -320,109 +378,223 @@ const chatsPageTemplateHTML = `
       </article>
 
       <article class="card">
-        <h2>Chat Detail</h2>
+        <h2>Selected Chat</h2>
         {{if .SelectedChat}}
-        <dl class="meta">
-          <dt>Chat</dt>
-          <dd><code>{{.SelectedChat.BaseSessionID}}</code></dd>
-          <dt>Kind</dt>
-          <dd>
-            {{if .SelectedChat.KindLabel}}
-              {{.SelectedChat.KindLabel}}
-            {{else if .SelectedChat.Kind}}
-              {{.SelectedChat.Kind}}
-            {{else}}
-              -
-            {{end}}
-          </dd>
-          <dt>Current Name</dt>
-          <dd>
-            {{if .SelectedChat.EffectiveAssistant}}
-              {{.SelectedChat.EffectiveAssistant}}
-            {{else}}
-              -
-            {{end}}
-          </dd>
-          <dt>Why This Name</dt>
-          <dd>{{chatNameSourceLabel .SelectedChat}}</dd>
-          <dt>Current Chat Name</dt>
-          <dd>
-            {{if .SelectedChat.ChatAssistantOverride}}
-              {{.SelectedChat.ChatAssistantOverride}}
-            {{else}}
-              (using default name)
-            {{end}}
-          </dd>
-          <dt>Using Its Own Name</dt>
-          <dd>
-            {{if .SelectedChat.OverridesGlobal}}
-              yes
-            {{else}}
-              no
-            {{end}}
-          </dd>
-          <dt>Current Session</dt>
-          <dd><code>{{.SelectedChat.CurrentSessionID}}</code></dd>
-          <dt>Recall Session</dt>
-          <dd>
-            {{if .SelectedChat.RecallSessionID}}
-              <code>{{.SelectedChat.RecallSessionID}}</code>
-            {{else}}
-              -
-            {{end}}
-          </dd>
-          <dt>Epoch</dt>
-          <dd>{{.SelectedChat.Epoch}}</dd>
-          <dt>Persona</dt>
-          <dd>
-            {{if .SelectedChat.PersonaLabel}}
-              {{.SelectedChat.PersonaLabel}}
-            {{else if .SelectedChat.PersonaID}}
-              {{.SelectedChat.PersonaID}}
-            {{else}}
-              -
-            {{end}}
-            {{if .SelectedChat.PersonaPinned}}
-              <br><span class="subtle">pinned for this chat</span>
-            {{end}}
-          </dd>
-          <dt>Workspace</dt>
-          <dd>
-            {{if .SelectedChat.WorkspacePath}}
-              <code>{{.SelectedChat.WorkspacePath}}</code>
-            {{else}}
-              -
-            {{end}}
-          </dd>
-          <dt>Known Users</dt>
-          <dd>{{chatKnownUsers .SelectedChat}}</dd>
-          <dt>Last Activity</dt>
-          <dd>{{formatTime .SelectedChat.LastActivity}}</dd>
-          <dt>JSON</dt>
-          <dd><a href="/api/chats">/api/chats</a></dd>
-        </dl>
+        <section class="chat-detail-section" id="chat-overview">
+          <div class="chat-detail-head">
+            <h3>Overview</h3>
+            <p class="subtle">
+              Current state for this chat, including the name it is
+              actually using right now.
+            </p>
+          </div>
+          <dl class="meta">
+            <dt>Chat</dt>
+            <dd><code>{{.SelectedChat.BaseSessionID}}</code></dd>
+            <dt>Kind</dt>
+            <dd>
+              {{if .SelectedChat.KindLabel}}
+                {{.SelectedChat.KindLabel}}
+              {{else if .SelectedChat.Kind}}
+                {{.SelectedChat.Kind}}
+              {{else}}
+                -
+              {{end}}
+            </dd>
+            <dt>Current Name</dt>
+            <dd>
+              {{if .SelectedChat.EffectiveAssistant}}
+                {{.SelectedChat.EffectiveAssistant}}
+              {{else}}
+                -
+              {{end}}
+            </dd>
+            <dt>Why This Name</dt>
+            <dd>{{chatNameSourceLabel .SelectedChat}}</dd>
+            <dt>Current Chat Name</dt>
+            <dd>
+              {{if .SelectedChat.ChatAssistantOverride}}
+                {{.SelectedChat.ChatAssistantOverride}}
+              {{else}}
+                (using the default name)
+              {{end}}
+            </dd>
+            <dt>Using Its Own Name</dt>
+            <dd>
+              {{if .SelectedChat.OverridesGlobal}}
+                yes
+              {{else}}
+                no
+              {{end}}
+            </dd>
+            <dt>Current Session</dt>
+            <dd><code>{{.SelectedChat.CurrentSessionID}}</code></dd>
+            <dt>Recall Session</dt>
+            <dd>
+              {{if .SelectedChat.RecallSessionID}}
+                <code>{{.SelectedChat.RecallSessionID}}</code>
+              {{else}}
+                -
+              {{end}}
+            </dd>
+            <dt>Epoch</dt>
+            <dd>{{.SelectedChat.Epoch}}</dd>
+            <dt>Persona</dt>
+            <dd>
+              {{if .SelectedChat.PersonaLabel}}
+                {{.SelectedChat.PersonaLabel}}
+              {{else if .SelectedChat.PersonaID}}
+                {{.SelectedChat.PersonaID}}
+              {{else}}
+                -
+              {{end}}
+              {{if .SelectedChat.PersonaPinned}}
+                <br><span class="subtle">pinned for this chat</span>
+              {{end}}
+            </dd>
+            <dt>Workspace</dt>
+            <dd>
+              {{if .SelectedChat.WorkspacePath}}
+                <code>{{.SelectedChat.WorkspacePath}}</code>
+              {{else}}
+                -
+              {{end}}
+            </dd>
+            <dt>Known Users</dt>
+            <dd>{{chatKnownUsers .SelectedChat}}</dd>
+            <dt>Last Activity</dt>
+            <dd>{{formatTime .SelectedChat.LastActivity}}</dd>
+            <dt>JSON</dt>
+            <dd><a href="/api/chats">/api/chats</a></dd>
+          </dl>
 
-        <h3 style="margin: 18px 0 8px;">Recent Sessions</h3>
-        {{if .SelectedChat.History}}
-        <table>
-          <thead>
-            <tr>
-              <th>Session ID</th>
-              <th>Last Activity</th>
-            </tr>
-          </thead>
-          <tbody>
-            {{range .SelectedChat.History}}
-            <tr>
-              <td><code>{{.SessionID}}</code></td>
-              <td>{{formatTime .LastActivity}}</td>
-            </tr>
+          <h4 style="margin: 18px 0 8px;">Recent Sessions</h4>
+          {{if .SelectedChat.History}}
+          <table>
+            <thead>
+              <tr>
+                <th>Session ID</th>
+                <th>Last Activity</th>
+              </tr>
+            </thead>
+            <tbody>
+              {{range .SelectedChat.History}}
+              <tr>
+                <td><code>{{.SessionID}}</code></td>
+                <td>{{formatTime .LastActivity}}</td>
+              </tr>
+              {{end}}
+            </tbody>
+          </table>
+          {{else}}
+          <p class="empty">No recent sessions have been tracked yet.</p>
+          {{end}}
+        </section>
+
+        <section class="chat-detail-section" id="chat-history">
+          <div class="chat-detail-head">
+            <h3>History</h3>
+            <p class="subtle">
+              Recent visible turns from this chat's tracked session
+              lines. Large transcripts are intentionally bounded here.
+            </p>
+          </div>
+          {{if .SelectedChatError}}
+          <div class="notice err">{{.SelectedChatError}}</div>
+          {{else if chatHasTranscript .SelectedChat}}
+          <div class="chat-transcript-list">
+            {{range .SelectedChat.Transcript}}
+            <article class="chat-transcript-card">
+              <div class="chat-transcript-head">
+                <div>
+                  <div class="chat-transcript-title">
+                    {{chatTranscriptLabel .}}
+                  </div>
+                  <div class="subtle">
+                    <code>{{.SessionID}}</code>
+                  </div>
+                </div>
+                <div class="subtle">{{formatTime .LastActivity}}</div>
+              </div>
+              <div class="chat-turn-list">
+                {{range .Turns}}
+                <article class="chat-turn">
+                  <div class="chat-turn-head">
+                    <span class="chat-turn-speaker">
+                      {{chatTurnSpeaker .}}
+                    </span>
+                    {{if hasTime .Timestamp}}
+                    <span class="subtle">{{formatTime .Timestamp}}</span>
+                    {{end}}
+                  </div>
+                  {{if .QuoteText}}
+                  <blockquote class="chat-turn-quote">
+                    {{.QuoteText}}
+                  </blockquote>
+                  {{end}}
+                  <div class="chat-turn-text">{{.Text}}</div>
+                </article>
+                {{end}}
+              </div>
+              {{if .Truncated}}
+              <p class="subtle" style="margin-top: 10px;">
+                Showing the most recent turns for this session line.
+              </p>
+              {{end}}
+            </article>
             {{end}}
-          </tbody>
-        </table>
-        {{else}}
-        <p class="empty">No recent sessions have been tracked yet.</p>
-        {{end}}
+          </div>
+          {{else}}
+          <p class="empty">
+            No recent transcript is available for this chat yet.
+          </p>
+          {{end}}
+        </section>
+
+        <section class="chat-detail-section" id="chat-actions">
+          <div class="chat-detail-head">
+            <h3>Actions</h3>
+            <p class="subtle">
+              Use the correct surface for the kind of name change you
+              want to make.
+            </p>
+          </div>
+          <div class="chat-action-grid">
+            <article class="chat-action-card">
+              <h4>Default Name</h4>
+              <p class="subtle">
+                Change the default name used by new chats and by chats
+                that do not keep their own current-chat name.
+              </p>
+              <p><a href="/identity#identity-global">Open Identity</a></p>
+            </article>
+            <article class="chat-action-card">
+              <h4>Current Chat Name</h4>
+              {{if .SelectedChat.OverridesGlobal}}
+              <p class="subtle">
+                This chat is using its own current-chat name. Change or
+                clear it from the chat itself if you want this chat to
+                fall back to the default name again.
+              </p>
+              {{else}}
+              <p class="subtle">
+                This chat is already using the default name. Rename it
+                from the chat itself if you want this chat to use its
+                own name.
+              </p>
+              {{end}}
+            </article>
+            <article class="chat-action-card">
+              <h4>Persona</h4>
+              <p class="subtle">
+                Persona defaults and templates live in the Personas
+                admin view. Chat-specific persona state is shown in the
+                overview above.
+              </p>
+              <p><a href="/personas">Open Personas</a></p>
+            </article>
+          </div>
+        </section>
         {{else}}
         <p class="empty">
           Choose a tracked chat from the list to inspect its current

--- a/openclaw/admin/chats.go
+++ b/openclaw/admin/chats.go
@@ -18,9 +18,13 @@ import (
 )
 
 const (
-	routeChatsJSON = "/api/chats"
+	routeChatsJSON       = "/api/chats"
+	routeChatHistoryJSON = "/api/chats/history"
 
 	knownUserSeparator = ", "
+
+	chatHistoryItemKindSession = "session"
+	chatHistoryItemKindTurn    = "turn"
 )
 
 type ChatsProvider interface {
@@ -29,6 +33,13 @@ type ChatsProvider interface {
 
 type ChatDetailProvider interface {
 	ChatDetail(baseSessionID string) (ChatView, error)
+}
+
+type ChatHistoryProvider interface {
+	ChatHistory(
+		baseSessionID string,
+		cursor string,
+	) (ChatHistoryPage, error)
 }
 
 type ChatsStatus struct {
@@ -67,6 +78,30 @@ type ChatView struct {
 	History               []ChatSessionView    `json:"history,omitempty"`
 	TranscriptTruncated   bool                 `json:"transcript_truncated"`
 	Transcript            []ChatTranscriptView `json:"transcript,omitempty"`
+}
+
+type ChatHistoryPage struct {
+	BaseSessionID     string            `json:"base_session_id,omitempty"`
+	SessionLineCount  int               `json:"session_line_count"`
+	TurnCount         int               `json:"turn_count"`
+	ReturnedTurnCount int               `json:"returned_turn_count"`
+	NextCursor        string            `json:"next_cursor,omitempty"`
+	Bounded           bool              `json:"bounded"`
+	Items             []ChatHistoryItem `json:"items,omitempty"`
+}
+
+type ChatHistoryItem struct {
+	Kind         string    `json:"kind,omitempty"`
+	SessionID    string    `json:"session_id,omitempty"`
+	SessionLabel string    `json:"session_label,omitempty"`
+	LastActivity time.Time `json:"last_activity,omitempty"`
+	Current      bool      `json:"current"`
+	Recall       bool      `json:"recall"`
+	Role         string    `json:"role,omitempty"`
+	Speaker      string    `json:"speaker,omitempty"`
+	QuoteText    string    `json:"quote_text,omitempty"`
+	Text         string    `json:"text,omitempty"`
+	Timestamp    time.Time `json:"timestamp,omitempty"`
 }
 
 type KnownUserView struct {
@@ -125,6 +160,41 @@ func (s *Service) handleChatsJSON(
 		return
 	}
 	writeJSON(w, http.StatusOK, s.chatsStatus())
+}
+
+func (s *Service) handleChatHistoryJSON(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s == nil || s.cfg.Chats == nil {
+		http.Error(w, "chat history not available", http.StatusNotFound)
+		return
+	}
+	provider, ok := s.cfg.Chats.(ChatHistoryProvider)
+	if !ok {
+		http.Error(w, "chat history not available", http.StatusNotFound)
+		return
+	}
+	baseSessionID := selectedChatID(r)
+	if baseSessionID == "" {
+		http.Error(w, "chat_id is required", http.StatusBadRequest)
+		return
+	}
+	cursor := strings.TrimSpace(r.URL.Query().Get(queryCursor))
+	page, err := provider.ChatHistory(baseSessionID, cursor)
+	if err != nil {
+		http.Error(
+			w,
+			strings.TrimSpace(err.Error()),
+			http.StatusInternalServerError,
+		)
+		return
+	}
+	writeJSON(w, http.StatusOK, page)
 }
 
 func selectedChatID(r *http.Request) string {
@@ -210,6 +280,10 @@ func chatNameSourceLabel(chat ChatView) string {
 
 func chatHasTranscript(chat ChatView) bool {
 	return len(chat.Transcript) != 0
+}
+
+func chatHistoryAPIPath() string {
+	return routeChatHistoryJSON
 }
 
 func chatVisibleHistory(chat ChatView) []ChatSessionView {
@@ -651,192 +725,44 @@ const chatsPageTemplateHTML = `
             <summary>
               <h3>History</h3>
               <p class="subtle">
-                Recent visible turns from this chat's tracked session
-                lines. Large transcripts stay bounded here by design.
+                Load the newest visible messages for this chat, then
+                keep scrolling upward into older conversation history.
               </p>
               <p class="subtle chat-disclosure-meta">
-                {{chatTranscriptSummary .SelectedChat}}
+                {{chatHistorySummary .SelectedChat}}
               </p>
             </summary>
             <div class="chat-disclosure-body">
               {{if .SelectedChatError}}
               <div class="notice err">{{.SelectedChatError}}</div>
-              {{else if chatHasTranscript .SelectedChat}}
-              {{$visibleTranscript := chatVisibleTranscript .SelectedChat}}
-              {{$hiddenTranscript := chatHiddenTranscript .SelectedChat}}
-              <div class="chat-transcript-list">
-                {{range $visibleTranscript}}
-                <article class="chat-transcript-card">
-                  <div class="chat-transcript-head">
-                    <div>
-                      <div class="chat-transcript-title">
-                        {{chatTranscriptLabel .}}
-                      </div>
-                      <div class="subtle">
-                        <code>{{.SessionID}}</code>
-                      </div>
-                    </div>
-                    <div class="subtle">{{formatTime .LastActivity}}</div>
-                  </div>
-                  {{$visibleTurns := chatVisibleTurns .}}
-                  {{$hiddenTurns := chatHiddenTurns .}}
-                  <div class="chat-turn-list">
-                    {{range $visibleTurns}}
-                    <article class="chat-turn">
-                      <div class="chat-turn-head">
-                        <span class="chat-turn-speaker">
-                          {{chatTurnSpeaker .}}
-                        </span>
-                        {{if hasTime .Timestamp}}
-                        <span class="subtle">{{formatTime .Timestamp}}</span>
-                        {{end}}
-                      </div>
-                      {{if .QuoteText}}
-                      <blockquote class="chat-turn-quote">
-                        {{.QuoteText}}
-                      </blockquote>
-                      {{end}}
-                      <div class="chat-turn-text">{{.Text}}</div>
-                    </article>
-                    {{end}}
-                  </div>
-                  {{if $hiddenTurns}}
-                  <details class="chat-disclosure-more">
-                    <summary>
-                      Show {{len $hiddenTurns}} older turns
-                    </summary>
-                    <div class="chat-disclosure-body">
-                      <div class="chat-turn-list">
-                        {{range $hiddenTurns}}
-                        <article class="chat-turn">
-                          <div class="chat-turn-head">
-                            <span class="chat-turn-speaker">
-                              {{chatTurnSpeaker .}}
-                            </span>
-                            {{if hasTime .Timestamp}}
-                            <span class="subtle">{{formatTime .Timestamp}}</span>
-                            {{end}}
-                          </div>
-                          {{if .QuoteText}}
-                          <blockquote class="chat-turn-quote">
-                            {{.QuoteText}}
-                          </blockquote>
-                          {{end}}
-                          <div class="chat-turn-text">{{.Text}}</div>
-                        </article>
-                        {{end}}
-                      </div>
-                    </div>
-                  </details>
-                  {{end}}
-                  {{if .Truncated}}
-                  <p class="subtle" style="margin-top: 10px;">
-                    Showing the most recent turns for this session line.
-                  </p>
-                  {{end}}
-                </article>
-                {{end}}
-              </div>
-              {{if $hiddenTranscript}}
-              <details class="chat-disclosure-more">
-                <summary>
-                  Show {{len $hiddenTranscript}} older session lines
-                </summary>
-                <div class="chat-disclosure-body">
-                  <div class="chat-transcript-list">
-                    {{range $hiddenTranscript}}
-                    <article class="chat-transcript-card">
-                      <div class="chat-transcript-head">
-                        <div>
-                          <div class="chat-transcript-title">
-                            {{chatTranscriptLabel .}}
-                          </div>
-                          <div class="subtle">
-                            <code>{{.SessionID}}</code>
-                          </div>
-                        </div>
-                        <div class="subtle">
-                          {{formatTime .LastActivity}}
-                        </div>
-                      </div>
-                      {{$visibleTurns := chatVisibleTurns .}}
-                      {{$hiddenTurns := chatHiddenTurns .}}
-                      <div class="chat-turn-list">
-                        {{range $visibleTurns}}
-                        <article class="chat-turn">
-                          <div class="chat-turn-head">
-                            <span class="chat-turn-speaker">
-                              {{chatTurnSpeaker .}}
-                            </span>
-                            {{if hasTime .Timestamp}}
-                            <span class="subtle">
-                              {{formatTime .Timestamp}}
-                            </span>
-                            {{end}}
-                          </div>
-                          {{if .QuoteText}}
-                          <blockquote class="chat-turn-quote">
-                            {{.QuoteText}}
-                          </blockquote>
-                          {{end}}
-                          <div class="chat-turn-text">{{.Text}}</div>
-                        </article>
-                        {{end}}
-                      </div>
-                      {{if $hiddenTurns}}
-                      <details class="chat-disclosure-more">
-                        <summary>
-                          Show {{len $hiddenTurns}} older turns
-                        </summary>
-                        <div class="chat-disclosure-body">
-                          <div class="chat-turn-list">
-                            {{range $hiddenTurns}}
-                            <article class="chat-turn">
-                              <div class="chat-turn-head">
-                                <span class="chat-turn-speaker">
-                                  {{chatTurnSpeaker .}}
-                                </span>
-                                {{if hasTime .Timestamp}}
-                                <span class="subtle">
-                                  {{formatTime .Timestamp}}
-                                </span>
-                                {{end}}
-                              </div>
-                              {{if .QuoteText}}
-                              <blockquote class="chat-turn-quote">
-                                {{.QuoteText}}
-                              </blockquote>
-                              {{end}}
-                              <div class="chat-turn-text">{{.Text}}</div>
-                            </article>
-                            {{end}}
-                          </div>
-                        </div>
-                      </details>
-                      {{end}}
-                      {{if .Truncated}}
-                      <p class="subtle" style="margin-top: 10px;">
-                        Showing the most recent turns for this session
-                        line.
-                      </p>
-                      {{end}}
-                    </article>
-                    {{end}}
-                  </div>
-                </div>
-              </details>
-              {{end}}
-              {{if .SelectedChat.TranscriptTruncated}}
-              <p class="subtle" style="margin-top: 12px;">
-                Showing the most recent session lines in this admin
-                view.
-              </p>
-              {{end}}
               {{else}}
-              <p class="empty">
-                No recent chat transcript is available in this runtime
-                for this chat right now.
-              </p>
+              <div
+                class="chat-history-shell"
+                data-chat-history-root
+                data-chat-history-path="{{chatHistoryAPIPath}}"
+                data-chat-id="{{.SelectedChat.BaseSessionID}}"
+              >
+                <p class="subtle chat-history-status"
+                  data-chat-history-meta>
+                  Expand this panel to load the newest visible
+                  messages for this chat.
+                </p>
+                <div class="chat-history-toolbar"
+                  data-chat-history-toolbar hidden>
+                  <button type="button" class="chat-history-more"
+                    data-chat-history-more hidden>
+                    Load older messages
+                  </button>
+                </div>
+                <div class="notice err"
+                  data-chat-history-error hidden></div>
+                <p class="empty"
+                  data-chat-history-empty hidden></p>
+                <p class="subtle chat-history-bounded"
+                  data-chat-history-bounded hidden></p>
+                <div class="chat-timeline"
+                  data-chat-history-items></div>
+              </div>
               {{end}}
             </div>
           </details>

--- a/openclaw/admin/chats.go
+++ b/openclaw/admin/chats.go
@@ -10,6 +10,7 @@
 package admin
 
 import (
+	"fmt"
 	"net/http"
 	"sort"
 	"strings"
@@ -61,7 +62,10 @@ type ChatView struct {
 	WorkspacePath         string               `json:"workspace_path,omitempty"`
 	KnownUserIDs          []string             `json:"known_user_ids,omitempty"`
 	KnownUsers            []KnownUserView      `json:"known_users,omitempty"`
+	HistoryTotalCount     int                  `json:"history_total_count"`
+	HistoryTruncated      bool                 `json:"history_truncated"`
 	History               []ChatSessionView    `json:"history,omitempty"`
+	TranscriptTruncated   bool                 `json:"transcript_truncated"`
 	Transcript            []ChatTranscriptView `json:"transcript,omitempty"`
 }
 
@@ -73,6 +77,7 @@ type KnownUserView struct {
 type ChatSessionView struct {
 	SessionID    string    `json:"session_id,omitempty"`
 	LastActivity time.Time `json:"last_activity,omitempty"`
+	Visible      bool      `json:"visible"`
 }
 
 type ChatTranscriptView struct {
@@ -80,6 +85,7 @@ type ChatTranscriptView struct {
 	LastActivity time.Time      `json:"last_activity,omitempty"`
 	Current      bool           `json:"current"`
 	Recall       bool           `json:"recall"`
+	Visible      bool           `json:"visible"`
 	Truncated    bool           `json:"truncated"`
 	Turns        []ChatTurnView `json:"turns,omitempty"`
 }
@@ -90,6 +96,7 @@ type ChatTurnView struct {
 	QuoteText string    `json:"quote_text,omitempty"`
 	Text      string    `json:"text,omitempty"`
 	Timestamp time.Time `json:"timestamp,omitempty"`
+	Visible   bool      `json:"visible"`
 }
 
 func (s *Service) chatsStatus() ChatsStatus {
@@ -203,6 +210,122 @@ func chatNameSourceLabel(chat ChatView) string {
 
 func chatHasTranscript(chat ChatView) bool {
 	return len(chat.Transcript) != 0
+}
+
+func chatVisibleHistory(chat ChatView) []ChatSessionView {
+	return visibleChatSessions(chat.History, true)
+}
+
+func chatHiddenHistory(chat ChatView) []ChatSessionView {
+	return visibleChatSessions(chat.History, false)
+}
+
+func visibleChatSessions(
+	sessions []ChatSessionView,
+	visible bool,
+) []ChatSessionView {
+	if len(sessions) == 0 {
+		return nil
+	}
+	result := make([]ChatSessionView, 0, len(sessions))
+	for _, session := range sessions {
+		if session.Visible != visible {
+			continue
+		}
+		result = append(result, session)
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
+func chatVisibleTranscript(chat ChatView) []ChatTranscriptView {
+	return visibleChatTranscript(chat.Transcript, true)
+}
+
+func chatHiddenTranscript(chat ChatView) []ChatTranscriptView {
+	return visibleChatTranscript(chat.Transcript, false)
+}
+
+func visibleChatTranscript(
+	transcript []ChatTranscriptView,
+	visible bool,
+) []ChatTranscriptView {
+	if len(transcript) == 0 {
+		return nil
+	}
+	result := make([]ChatTranscriptView, 0, len(transcript))
+	for _, view := range transcript {
+		if view.Visible != visible {
+			continue
+		}
+		result = append(result, view)
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
+func chatVisibleTurns(view ChatTranscriptView) []ChatTurnView {
+	return visibleChatTurns(view.Turns, true)
+}
+
+func chatHiddenTurns(view ChatTranscriptView) []ChatTurnView {
+	return visibleChatTurns(view.Turns, false)
+}
+
+func visibleChatTurns(
+	turns []ChatTurnView,
+	visible bool,
+) []ChatTurnView {
+	if len(turns) == 0 {
+		return nil
+	}
+	result := make([]ChatTurnView, 0, len(turns))
+	for _, turn := range turns {
+		if turn.Visible != visible {
+			continue
+		}
+		result = append(result, turn)
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
+func chatTranscriptSummary(chat ChatView) string {
+	sessionCount := len(chat.Transcript)
+	turnCount := 0
+	for _, transcript := range chat.Transcript {
+		turnCount += len(transcript.Turns)
+	}
+	switch {
+	case sessionCount == 0:
+		return "No recent transcript is currently available."
+	case turnCount == 0:
+		return fmt.Sprintf("%d recent session lines", sessionCount)
+	default:
+		return fmt.Sprintf(
+			"%d recent session lines · %d visible turns",
+			sessionCount,
+			turnCount,
+		)
+	}
+}
+
+func chatHistorySummary(chat ChatView) string {
+	count := chat.HistoryTotalCount
+	switch {
+	case count <= 0:
+		return "No tracked sessions are currently available."
+	case count == 1:
+		return "1 tracked session line"
+	default:
+		return fmt.Sprintf("%d tracked session lines", count)
+	}
 }
 
 func chatTranscriptLabel(view ChatTranscriptView) string {
@@ -470,6 +593,8 @@ const chatsPageTemplateHTML = `
 
           <h4 style="margin: 18px 0 8px;">Recent Sessions</h4>
           {{if .SelectedChat.History}}
+          {{$visibleHistory := chatVisibleHistory .SelectedChat}}
+          {{$hiddenHistory := chatHiddenHistory .SelectedChat}}
           <table>
             <thead>
               <tr>
@@ -478,7 +603,7 @@ const chatsPageTemplateHTML = `
               </tr>
             </thead>
             <tbody>
-              {{range .SelectedChat.History}}
+              {{range $visibleHistory}}
               <tr>
                 <td><code>{{.SessionID}}</code></td>
                 <td>{{formatTime .LastActivity}}</td>
@@ -486,69 +611,235 @@ const chatsPageTemplateHTML = `
               {{end}}
             </tbody>
           </table>
+          {{if $hiddenHistory}}
+          <details class="chat-disclosure-more">
+            <summary>
+              Show {{len $hiddenHistory}} older tracked sessions
+            </summary>
+            <div class="chat-disclosure-body">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Session ID</th>
+                    <th>Last Activity</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {{range $hiddenHistory}}
+                  <tr>
+                    <td><code>{{.SessionID}}</code></td>
+                    <td>{{formatTime .LastActivity}}</td>
+                  </tr>
+                  {{end}}
+                </tbody>
+              </table>
+            </div>
+          </details>
+          {{end}}
+          {{if .SelectedChat.HistoryTruncated}}
+          <p class="subtle" style="margin-top: 10px;">
+            Showing the most recent tracked sessions in this admin view.
+          </p>
+          {{end}}
           {{else}}
           <p class="empty">No recent sessions have been tracked yet.</p>
           {{end}}
         </section>
 
         <section class="chat-detail-section" id="chat-history">
-          <div class="chat-detail-head">
-            <h3>History</h3>
-            <p class="subtle">
-              Recent visible turns from this chat's tracked session
-              lines. Large transcripts are intentionally bounded here.
-            </p>
-          </div>
-          {{if .SelectedChatError}}
-          <div class="notice err">{{.SelectedChatError}}</div>
-          {{else if chatHasTranscript .SelectedChat}}
-          <div class="chat-transcript-list">
-            {{range .SelectedChat.Transcript}}
-            <article class="chat-transcript-card">
-              <div class="chat-transcript-head">
-                <div>
-                  <div class="chat-transcript-title">
-                    {{chatTranscriptLabel .}}
+          <details class="chat-disclosure">
+            <summary>
+              <h3>History</h3>
+              <p class="subtle">
+                Recent visible turns from this chat's tracked session
+                lines. Large transcripts stay bounded here by design.
+              </p>
+              <p class="subtle chat-disclosure-meta">
+                {{chatTranscriptSummary .SelectedChat}}
+              </p>
+            </summary>
+            <div class="chat-disclosure-body">
+              {{if .SelectedChatError}}
+              <div class="notice err">{{.SelectedChatError}}</div>
+              {{else if chatHasTranscript .SelectedChat}}
+              {{$visibleTranscript := chatVisibleTranscript .SelectedChat}}
+              {{$hiddenTranscript := chatHiddenTranscript .SelectedChat}}
+              <div class="chat-transcript-list">
+                {{range $visibleTranscript}}
+                <article class="chat-transcript-card">
+                  <div class="chat-transcript-head">
+                    <div>
+                      <div class="chat-transcript-title">
+                        {{chatTranscriptLabel .}}
+                      </div>
+                      <div class="subtle">
+                        <code>{{.SessionID}}</code>
+                      </div>
+                    </div>
+                    <div class="subtle">{{formatTime .LastActivity}}</div>
                   </div>
-                  <div class="subtle">
-                    <code>{{.SessionID}}</code>
-                  </div>
-                </div>
-                <div class="subtle">{{formatTime .LastActivity}}</div>
-              </div>
-              <div class="chat-turn-list">
-                {{range .Turns}}
-                <article class="chat-turn">
-                  <div class="chat-turn-head">
-                    <span class="chat-turn-speaker">
-                      {{chatTurnSpeaker .}}
-                    </span>
-                    {{if hasTime .Timestamp}}
-                    <span class="subtle">{{formatTime .Timestamp}}</span>
+                  {{$visibleTurns := chatVisibleTurns .}}
+                  {{$hiddenTurns := chatHiddenTurns .}}
+                  <div class="chat-turn-list">
+                    {{range $visibleTurns}}
+                    <article class="chat-turn">
+                      <div class="chat-turn-head">
+                        <span class="chat-turn-speaker">
+                          {{chatTurnSpeaker .}}
+                        </span>
+                        {{if hasTime .Timestamp}}
+                        <span class="subtle">{{formatTime .Timestamp}}</span>
+                        {{end}}
+                      </div>
+                      {{if .QuoteText}}
+                      <blockquote class="chat-turn-quote">
+                        {{.QuoteText}}
+                      </blockquote>
+                      {{end}}
+                      <div class="chat-turn-text">{{.Text}}</div>
+                    </article>
                     {{end}}
                   </div>
-                  {{if .QuoteText}}
-                  <blockquote class="chat-turn-quote">
-                    {{.QuoteText}}
-                  </blockquote>
+                  {{if $hiddenTurns}}
+                  <details class="chat-disclosure-more">
+                    <summary>
+                      Show {{len $hiddenTurns}} older turns
+                    </summary>
+                    <div class="chat-disclosure-body">
+                      <div class="chat-turn-list">
+                        {{range $hiddenTurns}}
+                        <article class="chat-turn">
+                          <div class="chat-turn-head">
+                            <span class="chat-turn-speaker">
+                              {{chatTurnSpeaker .}}
+                            </span>
+                            {{if hasTime .Timestamp}}
+                            <span class="subtle">{{formatTime .Timestamp}}</span>
+                            {{end}}
+                          </div>
+                          {{if .QuoteText}}
+                          <blockquote class="chat-turn-quote">
+                            {{.QuoteText}}
+                          </blockquote>
+                          {{end}}
+                          <div class="chat-turn-text">{{.Text}}</div>
+                        </article>
+                        {{end}}
+                      </div>
+                    </div>
+                  </details>
                   {{end}}
-                  <div class="chat-turn-text">{{.Text}}</div>
+                  {{if .Truncated}}
+                  <p class="subtle" style="margin-top: 10px;">
+                    Showing the most recent turns for this session line.
+                  </p>
+                  {{end}}
                 </article>
                 {{end}}
               </div>
-              {{if .Truncated}}
-              <p class="subtle" style="margin-top: 10px;">
-                Showing the most recent turns for this session line.
+              {{if $hiddenTranscript}}
+              <details class="chat-disclosure-more">
+                <summary>
+                  Show {{len $hiddenTranscript}} older session lines
+                </summary>
+                <div class="chat-disclosure-body">
+                  <div class="chat-transcript-list">
+                    {{range $hiddenTranscript}}
+                    <article class="chat-transcript-card">
+                      <div class="chat-transcript-head">
+                        <div>
+                          <div class="chat-transcript-title">
+                            {{chatTranscriptLabel .}}
+                          </div>
+                          <div class="subtle">
+                            <code>{{.SessionID}}</code>
+                          </div>
+                        </div>
+                        <div class="subtle">
+                          {{formatTime .LastActivity}}
+                        </div>
+                      </div>
+                      {{$visibleTurns := chatVisibleTurns .}}
+                      {{$hiddenTurns := chatHiddenTurns .}}
+                      <div class="chat-turn-list">
+                        {{range $visibleTurns}}
+                        <article class="chat-turn">
+                          <div class="chat-turn-head">
+                            <span class="chat-turn-speaker">
+                              {{chatTurnSpeaker .}}
+                            </span>
+                            {{if hasTime .Timestamp}}
+                            <span class="subtle">
+                              {{formatTime .Timestamp}}
+                            </span>
+                            {{end}}
+                          </div>
+                          {{if .QuoteText}}
+                          <blockquote class="chat-turn-quote">
+                            {{.QuoteText}}
+                          </blockquote>
+                          {{end}}
+                          <div class="chat-turn-text">{{.Text}}</div>
+                        </article>
+                        {{end}}
+                      </div>
+                      {{if $hiddenTurns}}
+                      <details class="chat-disclosure-more">
+                        <summary>
+                          Show {{len $hiddenTurns}} older turns
+                        </summary>
+                        <div class="chat-disclosure-body">
+                          <div class="chat-turn-list">
+                            {{range $hiddenTurns}}
+                            <article class="chat-turn">
+                              <div class="chat-turn-head">
+                                <span class="chat-turn-speaker">
+                                  {{chatTurnSpeaker .}}
+                                </span>
+                                {{if hasTime .Timestamp}}
+                                <span class="subtle">
+                                  {{formatTime .Timestamp}}
+                                </span>
+                                {{end}}
+                              </div>
+                              {{if .QuoteText}}
+                              <blockquote class="chat-turn-quote">
+                                {{.QuoteText}}
+                              </blockquote>
+                              {{end}}
+                              <div class="chat-turn-text">{{.Text}}</div>
+                            </article>
+                            {{end}}
+                          </div>
+                        </div>
+                      </details>
+                      {{end}}
+                      {{if .Truncated}}
+                      <p class="subtle" style="margin-top: 10px;">
+                        Showing the most recent turns for this session
+                        line.
+                      </p>
+                      {{end}}
+                    </article>
+                    {{end}}
+                  </div>
+                </div>
+              </details>
+              {{end}}
+              {{if .SelectedChat.TranscriptTruncated}}
+              <p class="subtle" style="margin-top: 12px;">
+                Showing the most recent session lines in this admin
+                view.
               </p>
               {{end}}
-            </article>
-            {{end}}
-          </div>
-          {{else}}
-          <p class="empty">
-            No recent transcript is available for this chat yet.
-          </p>
-          {{end}}
+              {{else}}
+              <p class="empty">
+                No recent chat transcript is available in this runtime
+                for this chat right now.
+              </p>
+              {{end}}
+            </div>
+          </details>
         </section>
 
         <section class="chat-detail-section" id="chat-actions">

--- a/openclaw/admin/service.go
+++ b/openclaw/admin/service.go
@@ -74,6 +74,7 @@ const (
 	queryName      = "name"
 	queryPath      = "path"
 	queryDownload  = "download"
+	queryCursor    = "cursor"
 	formJobID      = "job_id"
 	formSkillKey   = "skill_key"
 	formSkillName  = "skill_name"
@@ -332,6 +333,7 @@ func (s *Service) Handler() http.Handler {
 	mux.HandleFunc(routeIdentityJSON, s.handleIdentityJSON)
 	mux.HandleFunc(routePersonasJSON, s.handlePersonasJSON)
 	mux.HandleFunc(routeChatsJSON, s.handleChatsJSON)
+	mux.HandleFunc(routeChatHistoryJSON, s.handleChatHistoryJSON)
 	mux.HandleFunc(routeMemoryFilesJSON, s.handleMemoryFilesJSON)
 	mux.HandleFunc(routeMemoryFile, s.handleMemoryFile)
 	mux.HandleFunc(
@@ -582,6 +584,7 @@ type pageData struct {
 	Identity          IdentityStatus
 	Personas          PersonasStatus
 	Chats             ChatsStatus
+	ChatHistoryPath   string
 	SelectedChat      *ChatView
 	SelectedChatError string
 	Notice            string
@@ -1063,18 +1066,19 @@ func (s *Service) renderPage(
 
 	chats := s.chatsStatus()
 	data := pageData{
-		Snapshot:       s.snapshotForView(view),
-		Prompts:        s.promptsStatus(),
-		Identity:       s.identityStatus(),
-		Personas:       s.personasStatus(),
-		Chats:          chats,
-		Notice:         strings.TrimSpace(r.URL.Query().Get(queryNotice)),
-		Error:          strings.TrimSpace(r.URL.Query().Get(queryError)),
-		RefreshSeconds: refreshSeconds,
-		View:           view,
-		PageTitle:      pageTitle(view),
-		PageSummary:    pageSummary(view),
-		NavSections:    adminNavSections(view),
+		Snapshot:        s.snapshotForView(view),
+		Prompts:         s.promptsStatus(),
+		Identity:        s.identityStatus(),
+		Personas:        s.personasStatus(),
+		Chats:           chats,
+		ChatHistoryPath: routeChatHistoryJSON,
+		Notice:          strings.TrimSpace(r.URL.Query().Get(queryNotice)),
+		Error:           strings.TrimSpace(r.URL.Query().Get(queryError)),
+		RefreshSeconds:  refreshSeconds,
+		View:            view,
+		PageTitle:       pageTitle(view),
+		PageSummary:     pageSummary(view),
+		NavSections:     adminNavSections(view),
 	}
 	if view == viewChats {
 		data.SelectedChat, data.SelectedChatError = resolveSelectedChat(
@@ -2220,6 +2224,7 @@ var adminPage = template.Must(
 		"personaKindLabel":           personaKindLabel,
 		"personaSummaryText":         personaSummaryText,
 		"chatDisplayLabel":           chatDisplayLabel,
+		"chatHistoryAPIPath":         chatHistoryAPIPath,
 		"chatHiddenHistory":          chatHiddenHistory,
 		"chatHiddenTranscript":       chatHiddenTranscript,
 		"chatHiddenTurns":            chatHiddenTurns,
@@ -3065,6 +3070,64 @@ const adminPageHTML = `<!doctype html>
     }
     .chat-disclosure-more {
       margin-top: 12px;
+    }
+    .chat-history-shell {
+      margin-top: 14px;
+    }
+    .chat-history-status {
+      margin: 0;
+    }
+    .chat-history-toolbar {
+      margin: 14px 0 0;
+    }
+    .chat-history-more {
+      width: 100%;
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      padding: 12px 14px;
+      background: rgba(255, 253, 248, 0.82);
+      color: var(--ink);
+      font: inherit;
+      text-align: left;
+      cursor: pointer;
+      transition: border-color 120ms ease, box-shadow 120ms ease;
+    }
+    .chat-history-more:hover,
+    .chat-history-more:focus {
+      border-color: rgba(15, 111, 97, 0.38);
+      box-shadow: 0 12px 24px rgba(35, 29, 22, 0.08);
+      outline: none;
+    }
+    .chat-history-bounded {
+      margin: 12px 0 0;
+    }
+    .chat-timeline {
+      display: grid;
+      gap: 12px;
+      margin-top: 14px;
+    }
+    .chat-timeline-session {
+      padding-top: 12px;
+      border-top: 1px solid var(--line);
+    }
+    .chat-timeline-session:first-child {
+      padding-top: 0;
+      border-top: 0;
+    }
+    .chat-timeline-session-head {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+    .chat-timeline-session-label {
+      margin: 0;
+      font-size: 16px;
+      font-weight: 700;
+    }
+    .chat-timeline-session-meta {
+      margin-top: 6px;
     }
     .chat-transcript-list {
       display: grid;
@@ -4805,6 +4868,350 @@ const adminPageHTML = `<!doctype html>
       });
       refresh();
       restoreScrollPosition();
+    })();
+
+    (function () {
+      const roots = Array.from(
+        document.querySelectorAll("[data-chat-history-root]")
+      );
+      if (!roots.length) return;
+
+      const itemKindSession = "session";
+      const itemKindTurn = "turn";
+      const fallbackHistoryError = "Unable to load chat history right now.";
+      const fallbackHistoryEmpty =
+        "No recent chat transcript is available in this runtime " +
+        "for this chat right now.";
+      const historyLoadingText = "Loading recent messages...";
+      const historyMoreText = "Load older messages";
+      const historyBoundedText =
+        "This admin view only loads the most recent tracked " +
+        "session lines for this chat.";
+
+      const formatDateTime = (value) => {
+        if (!value) return "";
+        const parsed = new Date(value);
+        if (Number.isNaN(parsed.getTime())) return value;
+        return parsed.toLocaleString(undefined, {
+          year: "numeric",
+          month: "2-digit",
+          day: "2-digit",
+          hour: "2-digit",
+          minute: "2-digit",
+          second: "2-digit",
+          hour12: false,
+          timeZoneName: "short",
+        });
+      };
+
+      const speakerLabel = (item) => {
+        if (item && typeof item.speaker === "string" && item.speaker.trim()) {
+          return item.speaker.trim();
+        }
+        const role = item && typeof item.role === "string"
+          ? item.role.trim()
+          : "";
+        switch (role) {
+          case "user":
+            return "User";
+          case "assistant":
+            return "Assistant";
+          case "system":
+            return "System";
+          default:
+            return "Turn";
+        }
+      };
+
+      const setText = (node, text) => {
+        if (!node) return;
+        node.textContent = text;
+      };
+
+      const createDiv = (className, text) => {
+        const node = document.createElement("div");
+        if (className) {
+          node.className = className;
+        }
+        if (typeof text === "string") {
+          node.textContent = text;
+        }
+        return node;
+      };
+
+      const updateMeta = (root, page) => {
+        const meta = root.querySelector("[data-chat-history-meta]");
+        if (!meta || !page) return;
+        const loaded = Number(root.getAttribute("data-chat-history-loaded") || "0");
+        const total = Number(page.turn_count || 0);
+        const sessions = Number(page.session_line_count || 0);
+        if (total <= 0) {
+          meta.textContent = fallbackHistoryEmpty;
+          return;
+        }
+        const parts = [];
+        parts.push(
+          "Showing " + String(loaded) + " of " + String(total) +
+          " messages"
+        );
+        if (sessions > 0) {
+          parts.push("from " + String(sessions) + " recent session lines");
+        }
+        meta.textContent = parts.join(" ");
+      };
+
+      const updateBoundedNote = (root, bounded) => {
+        const note = root.querySelector("[data-chat-history-bounded]");
+        if (!note) return;
+        note.hidden = !bounded;
+        if (bounded) {
+          note.textContent = historyBoundedText;
+        }
+      };
+
+      const updateMoreButton = (root, nextCursor) => {
+        const toolbar = root.querySelector("[data-chat-history-toolbar]");
+        const button = root.querySelector("[data-chat-history-more]");
+        if (!toolbar || !button) return;
+        const hasMore = typeof nextCursor === "string" && nextCursor !== "";
+        toolbar.hidden = !hasMore;
+        button.hidden = !hasMore;
+        button.disabled = false;
+        button.textContent = historyMoreText;
+        if (hasMore) {
+          button.setAttribute("data-chat-history-next", nextCursor);
+        } else {
+          button.removeAttribute("data-chat-history-next");
+        }
+      };
+
+      const clearMessages = (root) => {
+        const error = root.querySelector("[data-chat-history-error]");
+        const empty = root.querySelector("[data-chat-history-empty]");
+        if (error) {
+          error.hidden = true;
+          error.textContent = "";
+        }
+        if (empty) {
+          empty.hidden = true;
+          empty.textContent = "";
+        }
+      };
+
+      const showError = (root, message) => {
+        const error = root.querySelector("[data-chat-history-error]");
+        const empty = root.querySelector("[data-chat-history-empty]");
+        if (empty) {
+          empty.hidden = true;
+          empty.textContent = "";
+        }
+        if (!error) return;
+        error.hidden = false;
+        error.textContent = message || fallbackHistoryError;
+      };
+
+      const showEmpty = (root, message) => {
+        const empty = root.querySelector("[data-chat-history-empty]");
+        const error = root.querySelector("[data-chat-history-error]");
+        if (error) {
+          error.hidden = true;
+          error.textContent = "";
+        }
+        if (!empty) return;
+        empty.hidden = false;
+        empty.textContent = message || fallbackHistoryEmpty;
+      };
+
+      const renderSessionItem = (item) => {
+        const wrapper = createDiv("chat-timeline-session");
+        const head = createDiv("chat-timeline-session-head");
+        const copy = document.createElement("div");
+        const title = createDiv(
+          "chat-timeline-session-label",
+          item.session_label || "Recent session"
+        );
+        const meta = createDiv("subtle chat-timeline-session-meta");
+        const code = document.createElement("code");
+        code.textContent = item.session_id || "";
+        meta.appendChild(code);
+        copy.appendChild(title);
+        copy.appendChild(meta);
+        head.appendChild(copy);
+        if (item.last_activity) {
+          head.appendChild(
+            createDiv("subtle", formatDateTime(item.last_activity))
+          );
+        }
+        wrapper.appendChild(head);
+        return wrapper;
+      };
+
+      const renderTurnItem = (item) => {
+        const article = document.createElement("article");
+        article.className = "chat-turn";
+        const head = createDiv("chat-turn-head");
+        head.appendChild(
+          createDiv("chat-turn-speaker", speakerLabel(item))
+        );
+        if (item.timestamp) {
+          head.appendChild(
+            createDiv("subtle", formatDateTime(item.timestamp))
+          );
+        }
+        article.appendChild(head);
+        if (typeof item.quote_text === "string" && item.quote_text.trim()) {
+          article.appendChild(
+            createDiv("chat-turn-quote", item.quote_text)
+          );
+        }
+        article.appendChild(
+          createDiv("chat-turn-text", item.text || "")
+        );
+        return article;
+      };
+
+      const renderHistoryItem = (item) => {
+        if (!item || typeof item.kind !== "string") {
+          return null;
+        }
+        if (item.kind === itemKindSession) {
+          return renderSessionItem(item);
+        }
+        if (item.kind === itemKindTurn) {
+          return renderTurnItem(item);
+        }
+        return null;
+      };
+
+      const updateLoading = (root, loading) => {
+        root.setAttribute(
+          "data-chat-history-loading",
+          loading ? "true" : "false"
+        );
+        const button = root.querySelector("[data-chat-history-more]");
+        if (!button) return;
+        button.disabled = loading;
+        if (loading) {
+          button.textContent = historyLoadingText;
+        } else if (button.hidden !== true) {
+          button.textContent = historyMoreText;
+        }
+      };
+
+      const fetchHistory = async (root, cursor) => {
+        const path = root.getAttribute("data-chat-history-path") || "";
+        const chatID = root.getAttribute("data-chat-id") || "";
+        const url = new URL(path, window.location.origin);
+        url.searchParams.set("chat_id", chatID);
+        if (cursor) {
+          url.searchParams.set("cursor", cursor);
+        }
+        const response = await fetch(url.toString(), {
+          headers: { Accept: "application/json" },
+        });
+        if (!response.ok) {
+          const text = (await response.text()).trim();
+          throw new Error(text || fallbackHistoryError);
+        }
+        return response.json();
+      };
+
+      const loadHistory = async (root, cursor) => {
+        const items = root.querySelector("[data-chat-history-items]");
+        if (!items) return;
+        if (root.getAttribute("data-chat-history-loading") === "true") {
+          return;
+        }
+        const prepend = typeof cursor === "string" && cursor !== "";
+        const anchor = prepend ? items.firstElementChild : null;
+        const anchorTop = anchor ? anchor.getBoundingClientRect().top : 0;
+        updateLoading(root, true);
+        clearMessages(root);
+        try {
+          const page = await fetchHistory(root, cursor);
+          const fragment = document.createDocumentFragment();
+          const pageItems = Array.isArray(page.items) ? page.items : [];
+          pageItems.forEach((item) => {
+            const node = renderHistoryItem(item);
+            if (node) {
+              fragment.appendChild(node);
+            }
+          });
+          if (!prepend) {
+            items.innerHTML = "";
+          }
+          if (prepend) {
+            items.prepend(fragment);
+          } else {
+            items.appendChild(fragment);
+          }
+
+          const loaded = Number(
+            root.getAttribute("data-chat-history-loaded") || "0"
+          ) + Number(page.returned_turn_count || 0);
+          root.setAttribute(
+            "data-chat-history-loaded",
+            String(loaded)
+          );
+          updateMeta(root, page);
+          updateBoundedNote(root, Boolean(page.bounded));
+          updateMoreButton(root, page.next_cursor || "");
+
+          if (!pageItems.length && Number(page.turn_count || 0) === 0) {
+            showEmpty(root, fallbackHistoryEmpty);
+          }
+          if (prepend && anchor) {
+            window.scrollBy(
+              0,
+              anchor.getBoundingClientRect().top - anchorTop
+            );
+          }
+          root.setAttribute("data-chat-history-loaded-once", "true");
+        } catch (err) {
+          showError(
+            root,
+            err && typeof err.message === "string"
+              ? err.message
+              : fallbackHistoryError
+          );
+        } finally {
+          updateLoading(root, false);
+        }
+      };
+
+      roots.forEach((root) => {
+        const disclosure = root.closest("details");
+        const button = root.querySelector("[data-chat-history-more]");
+        if (button) {
+          button.addEventListener("click", () => {
+            const nextCursor =
+              button.getAttribute("data-chat-history-next") || "";
+            if (!nextCursor) return;
+            loadHistory(root, nextCursor);
+          });
+        }
+        const ensureLoaded = () => {
+          if (
+            root.getAttribute("data-chat-history-loaded-once") ===
+            "true"
+          ) {
+            return;
+          }
+          loadHistory(root, "");
+        };
+        if (disclosure) {
+          disclosure.addEventListener("toggle", () => {
+            if (disclosure.open) {
+              ensureLoaded();
+            }
+          });
+          if (disclosure.open) {
+            ensureLoaded();
+          }
+          return;
+        }
+        ensureLoaded();
+      });
     })();
 
     (function () {

--- a/openclaw/admin/service.go
+++ b/openclaw/admin/service.go
@@ -10,6 +10,7 @@
 package admin
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"html/template"
@@ -60,6 +61,7 @@ const (
 	routeDebugSessionsJSON = "/api/debug/sessions"
 	routeDebugTracesJSON   = "/api/debug/traces"
 	routeDebugFile         = "/debug/file"
+	routePageStateJSON     = "/api/page/state"
 
 	queryNotice    = "notice"
 	queryError     = "error"
@@ -75,6 +77,7 @@ const (
 	queryPath      = "path"
 	queryDownload  = "download"
 	queryCursor    = "cursor"
+	queryView      = "view"
 	formJobID      = "job_id"
 	formSkillKey   = "skill_key"
 	formSkillName  = "skill_name"
@@ -328,6 +331,7 @@ func (s *Service) Handler() http.Handler {
 		wrapRelativeLinksFunc(s.handleBrowserPage),
 	)
 	mux.HandleFunc(routeStatusJSON, s.handleStatusJSON)
+	mux.HandleFunc(routePageStateJSON, s.handlePageStateJSON)
 	mux.HandleFunc(routeSkillsJSON, s.handleSkillsJSON)
 	mux.HandleFunc(routePromptsJSON, s.handlePromptsJSON)
 	mux.HandleFunc(routeIdentityJSON, s.handleIdentityJSON)
@@ -589,11 +593,35 @@ type pageData struct {
 	SelectedChatError string
 	Notice            string
 	Error             string
-	RefreshSeconds    int
+	PageRefresh       pageRefreshData
 	View              adminView
 	PageTitle         string
 	PageSummary       string
 	NavSections       []adminNavSection
+}
+
+type pageRefreshData struct {
+	CurrentPath     string
+	StatePath       string
+	Token           string
+	UpdatedAt       time.Time
+	IntervalSeconds int
+	Watch           bool
+}
+
+type pageStateStatus struct {
+	Token     string    `json:"token,omitempty"`
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
+}
+
+type pageRefreshInput struct {
+	Snapshot          snapshot
+	Prompts           PromptsStatus
+	Identity          IdentityStatus
+	Personas          PersonasStatus
+	Chats             ChatsStatus
+	SelectedChat      *ChatView
+	SelectedChatError string
 }
 
 type adminNavSection struct {
@@ -1064,17 +1092,20 @@ func (s *Service) renderPage(
 		return
 	}
 
+	snapshot := s.snapshotForView(view)
+	prompts := s.promptsStatus()
+	identity := s.identityStatus()
+	personas := s.personasStatus()
 	chats := s.chatsStatus()
 	data := pageData{
-		Snapshot:        s.snapshotForView(view),
-		Prompts:         s.promptsStatus(),
-		Identity:        s.identityStatus(),
-		Personas:        s.personasStatus(),
+		Snapshot:        snapshot,
+		Prompts:         prompts,
+		Identity:        identity,
+		Personas:        personas,
 		Chats:           chats,
 		ChatHistoryPath: routeChatHistoryJSON,
 		Notice:          strings.TrimSpace(r.URL.Query().Get(queryNotice)),
 		Error:           strings.TrimSpace(r.URL.Query().Get(queryError)),
-		RefreshSeconds:  refreshSeconds,
 		View:            view,
 		PageTitle:       pageTitle(view),
 		PageSummary:     pageSummary(view),
@@ -1087,6 +1118,19 @@ func (s *Service) renderPage(
 			selectedChatID(r),
 		)
 	}
+	data.PageRefresh = buildPageRefreshData(
+		r,
+		view,
+		pageRefreshInput{
+			Snapshot:          snapshot,
+			Prompts:           prompts,
+			Identity:          identity,
+			Personas:          personas,
+			Chats:             chats,
+			SelectedChat:      data.SelectedChat,
+			SelectedChatError: data.SelectedChatError,
+		},
+	)
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if err := adminPage.Execute(w, data); err != nil {
@@ -1305,6 +1349,136 @@ func pageSummary(view adminView) string {
 	}
 }
 
+func pageRefreshWatch(view adminView) bool {
+	switch view {
+	case viewOverview,
+		viewSkills,
+		viewChats,
+		viewMemory,
+		viewAutomation,
+		viewSessions,
+		viewDebug,
+		viewBrowser:
+		return true
+	default:
+		return false
+	}
+}
+
+func buildPageRefreshData(
+	r *http.Request,
+	view adminView,
+	input pageRefreshInput,
+) pageRefreshData {
+	return pageRefreshData{
+		CurrentPath:     pageRefreshCurrentPath(r),
+		StatePath:       pageRefreshStatePath(r, view),
+		Token:           pageRefreshToken(view, input),
+		UpdatedAt:       input.Snapshot.GeneratedAt,
+		IntervalSeconds: refreshSeconds,
+		Watch:           pageRefreshWatch(view),
+	}
+}
+
+func pageRefreshCurrentPath(r *http.Request) string {
+	if r == nil || r.URL == nil {
+		return routeOverview
+	}
+	values := r.URL.Query()
+	values.Del(queryNotice)
+	values.Del(queryError)
+	path := strings.TrimSpace(r.URL.Path)
+	if path == "" {
+		path = routeOverview
+	}
+	if encoded := values.Encode(); encoded != "" {
+		return path + "?" + encoded
+	}
+	return path
+}
+
+func pageRefreshStatePath(
+	r *http.Request,
+	view adminView,
+) string {
+	values := url.Values{}
+	values.Set(queryView, string(view))
+	if view == viewChats {
+		if chatID := selectedChatID(r); chatID != "" {
+			values.Set(queryChatID, chatID)
+		}
+	}
+	return routePageStateJSON + "?" + values.Encode()
+}
+
+func pageRefreshToken(
+	view adminView,
+	input pageRefreshInput,
+) string {
+	switch view {
+	case viewPrompts:
+		return refreshTokenForValue(input.Prompts)
+	case viewIdentity:
+		return refreshTokenForValue(input.Identity)
+	case viewPersonas:
+		return refreshTokenForValue(input.Personas)
+	case viewChats:
+		return refreshTokenForValue(struct {
+			Chats             ChatsStatus `json:"chats"`
+			SelectedChat      *ChatView   `json:"selected_chat,omitempty"`
+			SelectedChatError string      `json:"selected_chat_error,omitempty"`
+		}{
+			Chats:             input.Chats,
+			SelectedChat:      compactChatView(input.SelectedChat),
+			SelectedChatError: input.SelectedChatError,
+		})
+	default:
+		snapshot := input.Snapshot
+		snapshot.GeneratedAt = time.Time{}
+		return refreshTokenForValue(snapshot)
+	}
+}
+
+func compactChatView(chat *ChatView) *ChatView {
+	if chat == nil {
+		return nil
+	}
+	copy := *chat
+	copy.History = nil
+	copy.Transcript = nil
+	return &copy
+}
+
+func refreshTokenForValue(value any) string {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(data)
+	return fmt.Sprintf("%x", sum[:])
+}
+
+func (s *Service) pageRefreshInput(
+	r *http.Request,
+	view adminView,
+) pageRefreshInput {
+	input := pageRefreshInput{
+		Snapshot: s.snapshotForView(view),
+		Prompts:  s.promptsStatus(),
+		Identity: s.identityStatus(),
+		Personas: s.personasStatus(),
+		Chats:    s.chatsStatus(),
+	}
+	if view == viewChats {
+		input.SelectedChat, input.SelectedChatError = resolveSelectedChat(
+			input.Chats,
+			s.cfg.Chats,
+			selectedChatID(r),
+		)
+	}
+	return input
+}
+
 func (s *Service) handleStatusJSON(
 	w http.ResponseWriter,
 	r *http.Request,
@@ -1314,6 +1488,25 @@ func (s *Service) handleStatusJSON(
 		return
 	}
 	writeJSON(w, http.StatusOK, s.Snapshot())
+}
+
+func (s *Service) handlePageStateJSON(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	view := adminView(strings.TrimSpace(r.URL.Query().Get(queryView)))
+	if view == "" {
+		view = viewOverview
+	}
+	input := s.pageRefreshInput(r, view)
+	writeJSON(w, http.StatusOK, pageStateStatus{
+		Token:     pageRefreshToken(view, input),
+		UpdatedAt: input.Snapshot.GeneratedAt,
+	})
 }
 
 func (s *Service) handleSkillsJSON(
@@ -2253,7 +2446,6 @@ const adminPageHTML = `<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <meta http-equiv="refresh" content="{{.RefreshSeconds}}">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>TRPC-CLAW admin</title>
   <style>
@@ -2378,6 +2570,51 @@ const adminPageHTML = `<!doctype html>
     }
     .page-header {
       margin-bottom: 18px;
+    }
+    .page-toolbar {
+      margin-top: 16px;
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px 16px;
+    }
+    .page-toolbar-copy {
+      display: grid;
+      gap: 4px;
+      min-width: 0;
+    }
+    .page-toolbar-updated {
+      color: var(--muted);
+      font-size: 13px;
+      font-weight: 700;
+      letter-spacing: 0.02em;
+    }
+    .page-toolbar-note {
+      color: var(--muted);
+      font-size: 14px;
+      max-width: 720px;
+    }
+    .page-refresh-link {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 40px;
+      padding: 8px 14px;
+      border-radius: 999px;
+      border: 1px solid var(--line);
+      background: rgba(255, 253, 248, 0.92);
+      color: var(--ink);
+      text-decoration: none;
+      font-weight: 700;
+      box-shadow: var(--shadow);
+    }
+    .page-refresh-link:hover {
+      border-color: rgba(15, 111, 97, 0.28);
+      color: var(--accent);
+    }
+    .page-refresh-alert {
+      margin-top: 16px;
     }
     .page-kicker {
       margin: 0 0 10px;
@@ -3273,7 +3510,36 @@ const adminPageHTML = `<!doctype html>
           <p class="page-kicker">TRPC-CLAW admin</p>
           <h1>{{.PageTitle}}</h1>
           <p class="subtle">{{.PageSummary}}</p>
+          <div class="page-toolbar">
+            <div class="page-toolbar-copy">
+              <div class="page-toolbar-updated">
+                Updated {{formatTime .PageRefresh.UpdatedAt}}
+              </div>
+              {{if .PageRefresh.Watch}}
+              <div class="page-toolbar-note">
+                This page watches for newer runtime state without
+                interrupting your reading or editing.
+              </div>
+              {{end}}
+            </div>
+            <a class="page-refresh-link" href="{{.PageRefresh.CurrentPath}}">
+              Refresh page
+            </a>
+          </div>
         </header>
+        {{if .PageRefresh.Watch}}
+        <div
+          class="notice page-refresh-alert"
+          hidden
+          data-page-stale-root
+          data-page-state-path="{{.PageRefresh.StatePath}}"
+          data-page-state-token="{{.PageRefresh.Token}}"
+          data-page-refresh-interval="{{.PageRefresh.IntervalSeconds}}"
+        >
+          New runtime state is available for this page.
+          <a href="{{.PageRefresh.CurrentPath}}">Refresh page</a>
+        </div>
+        {{end}}
         {{if .Notice}}<div class="notice ok">{{.Notice}}</div>{{end}}
         {{if .Error}}<div class="notice err">{{.Error}}</div>{{end}}
 
@@ -4706,6 +4972,50 @@ const adminPageHTML = `<!doctype html>
     </section>
     {{end}}
   <script>
+    (function () {
+      const root = document.querySelector("[data-page-stale-root]");
+      if (!root) return;
+
+      const statePath = root.getAttribute("data-page-state-path") || "";
+      const initialToken =
+        root.getAttribute("data-page-state-token") || "";
+      const intervalValue = Number(
+        root.getAttribute("data-page-refresh-interval") || "0"
+      );
+      if (!statePath || !initialToken || intervalValue <= 0) {
+        return;
+      }
+
+      let currentToken = initialToken;
+      let stopped = false;
+
+      const poll = async () => {
+        if (stopped || document.hidden) {
+          return;
+        }
+        try {
+          const response = await fetch(statePath, {
+            headers: { Accept: "application/json" },
+          });
+          if (!response.ok) {
+            return;
+          }
+          const payload = await response.json();
+          const nextToken =
+            payload && typeof payload.token === "string"
+              ? payload.token
+              : "";
+          if (!nextToken || nextToken === currentToken) {
+            return;
+          }
+          root.hidden = false;
+          stopped = true;
+        } catch (_) {}
+      };
+
+      window.setInterval(poll, intervalValue * 1000);
+    })();
+
     (function () {
       const root = document.querySelector("[data-skills-root]");
       if (!root) return;

--- a/openclaw/admin/service.go
+++ b/openclaw/admin/service.go
@@ -1141,6 +1141,25 @@ func mergeChatView(
 	detail ChatView,
 ) ChatView {
 	merged := base
+	if strings.TrimSpace(merged.DisplayLabel) == "" {
+		merged.DisplayLabel = strings.TrimSpace(detail.DisplayLabel)
+	}
+	if strings.TrimSpace(merged.Kind) == "" {
+		merged.Kind = strings.TrimSpace(detail.Kind)
+	}
+	if strings.TrimSpace(merged.KindLabel) == "" {
+		merged.KindLabel = strings.TrimSpace(detail.KindLabel)
+	}
+	if strings.TrimSpace(merged.CurrentSessionID) == "" {
+		merged.CurrentSessionID = strings.TrimSpace(
+			detail.CurrentSessionID,
+		)
+	}
+	if strings.TrimSpace(merged.RecallSessionID) == "" {
+		merged.RecallSessionID = strings.TrimSpace(
+			detail.RecallSessionID,
+		)
+	}
 	if !detail.LastActivity.IsZero() {
 		merged.LastActivity = detail.LastActivity
 	}

--- a/openclaw/admin/service.go
+++ b/openclaw/admin/service.go
@@ -1076,11 +1076,13 @@ func (s *Service) renderPage(
 		PageSummary:    pageSummary(view),
 		NavSections:    adminNavSections(view),
 	}
-	data.SelectedChat, data.SelectedChatError = resolveSelectedChat(
-		chats,
-		s.cfg.Chats,
-		selectedChatID(r),
-	)
+	if view == viewChats {
+		data.SelectedChat, data.SelectedChatError = resolveSelectedChat(
+			chats,
+			s.cfg.Chats,
+			selectedChatID(r),
+		)
+	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if err := adminPage.Execute(w, data); err != nil {
@@ -1111,7 +1113,76 @@ func resolveSelectedChat(
 	if err != nil {
 		return selected, strings.TrimSpace(err.Error())
 	}
-	return &detail, ""
+	merged := mergeChatView(*selected, detail)
+	return &merged, ""
+}
+
+func mergeChatView(
+	base ChatView,
+	detail ChatView,
+) ChatView {
+	merged := base
+	if value := strings.TrimSpace(detail.BaseSessionID); value != "" {
+		merged.BaseSessionID = value
+	}
+	if value := strings.TrimSpace(detail.DisplayLabel); value != "" {
+		merged.DisplayLabel = value
+	}
+	if value := strings.TrimSpace(detail.Kind); value != "" {
+		merged.Kind = value
+	}
+	if value := strings.TrimSpace(detail.KindLabel); value != "" {
+		merged.KindLabel = value
+	}
+	if value := strings.TrimSpace(detail.CurrentSessionID); value != "" {
+		merged.CurrentSessionID = value
+	}
+	if value := strings.TrimSpace(detail.RecallSessionID); value != "" {
+		merged.RecallSessionID = value
+	}
+	if !detail.LastActivity.IsZero() {
+		merged.LastActivity = detail.LastActivity
+	}
+	if detail.Epoch != 0 {
+		merged.Epoch = detail.Epoch
+	}
+	if value := strings.TrimSpace(detail.EffectiveAssistant); value != "" {
+		merged.EffectiveAssistant = value
+	}
+	if value := strings.TrimSpace(detail.ChatAssistantOverride); value != "" {
+		merged.ChatAssistantOverride = value
+	}
+	if value := strings.TrimSpace(detail.NameSource); value != "" {
+		merged.NameSource = value
+	}
+	if detail.OverridesGlobal {
+		merged.OverridesGlobal = true
+	}
+	if value := strings.TrimSpace(detail.PersonaID); value != "" {
+		merged.PersonaID = value
+	}
+	if value := strings.TrimSpace(detail.PersonaLabel); value != "" {
+		merged.PersonaLabel = value
+	}
+	if detail.PersonaPinned {
+		merged.PersonaPinned = true
+	}
+	if value := strings.TrimSpace(detail.WorkspacePath); value != "" {
+		merged.WorkspacePath = value
+	}
+	if len(detail.KnownUserIDs) != 0 {
+		merged.KnownUserIDs = detail.KnownUserIDs
+	}
+	if len(detail.KnownUsers) != 0 {
+		merged.KnownUsers = detail.KnownUsers
+	}
+	if len(detail.History) != 0 {
+		merged.History = detail.History
+	}
+	if len(detail.Transcript) != 0 {
+		merged.Transcript = detail.Transcript
+	}
+	return merged
 }
 
 func adminNavSections(active adminView) []adminNavSection {

--- a/openclaw/admin/service.go
+++ b/openclaw/admin/service.go
@@ -1199,8 +1199,17 @@ func mergeChatView(
 	if len(detail.History) != 0 {
 		merged.History = detail.History
 	}
+	if detail.HistoryTotalCount != 0 {
+		merged.HistoryTotalCount = detail.HistoryTotalCount
+	}
+	if detail.HistoryTruncated {
+		merged.HistoryTruncated = true
+	}
 	if len(detail.Transcript) != 0 {
 		merged.Transcript = detail.Transcript
+	}
+	if detail.TranscriptTruncated {
+		merged.TranscriptTruncated = true
 	}
 	return merged
 }
@@ -2211,12 +2220,20 @@ var adminPage = template.Must(
 		"personaKindLabel":           personaKindLabel,
 		"personaSummaryText":         personaSummaryText,
 		"chatDisplayLabel":           chatDisplayLabel,
+		"chatHiddenHistory":          chatHiddenHistory,
+		"chatHiddenTranscript":       chatHiddenTranscript,
+		"chatHiddenTurns":            chatHiddenTurns,
 		"chatKnownUsers":             chatKnownUsers,
 		"chatHasTranscript":          chatHasTranscript,
+		"chatHistorySummary":         chatHistorySummary,
 		"chatNameSourceLabel":        chatNameSourceLabel,
 		"chatTranscriptLabel":        chatTranscriptLabel,
+		"chatTranscriptSummary":      chatTranscriptSummary,
 		"chatTurnSpeaker":            chatTurnSpeaker,
 		"chatOverrideSample":         chatOverrideSample,
+		"chatVisibleHistory":         chatVisibleHistory,
+		"chatVisibleTranscript":      chatVisibleTranscript,
+		"chatVisibleTurns":           chatVisibleTurns,
 		"hasTime":                    hasTime,
 	}).Parse(
 		adminPageHTML +
@@ -3009,6 +3026,45 @@ const adminPageHTML = `<!doctype html>
     .chat-action-card h4,
     .chat-transcript-title {
       margin: 0;
+    }
+    .chat-disclosure,
+    .chat-disclosure-more {
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      background: rgba(255, 253, 248, 0.72);
+      overflow: hidden;
+    }
+    .chat-disclosure[open],
+    .chat-disclosure-more[open] {
+      border-color: rgba(15, 111, 97, 0.28);
+      box-shadow: 0 14px 28px rgba(35, 29, 22, 0.08);
+    }
+    .chat-disclosure summary,
+    .chat-disclosure-more summary {
+      list-style: none;
+      cursor: pointer;
+      padding: 14px 16px;
+    }
+    .chat-disclosure summary::-webkit-details-marker,
+    .chat-disclosure-more summary::-webkit-details-marker {
+      display: none;
+    }
+    .chat-disclosure-meta {
+      margin: 8px 0 0;
+    }
+    .chat-disclosure-body {
+      margin-top: 0;
+      padding: 0 16px 16px;
+      border-top: 1px solid var(--line);
+    }
+    .chat-disclosure-body > :first-child {
+      margin-top: 14px;
+    }
+    .chat-disclosure-body > :last-child {
+      margin-bottom: 0;
+    }
+    .chat-disclosure-more {
+      margin-top: 12px;
     }
     .chat-transcript-list {
       display: grid;

--- a/openclaw/admin/service.go
+++ b/openclaw/admin/service.go
@@ -110,8 +110,8 @@ const (
 		"Manage the default persona and any file-backed " +
 		"persona definitions exposed by this runtime."
 	pageSummaryChats = "" +
-		"Inspect each chat's current name, default-name fallback, " +
-		"persona, and recent session history."
+		"Inspect each chat's current state, recent transcript, " +
+		"and the safest next step for names and persona."
 )
 
 type adminView string
@@ -577,19 +577,20 @@ type skillInstallView struct {
 }
 
 type pageData struct {
-	Snapshot       snapshot
-	Prompts        PromptsStatus
-	Identity       IdentityStatus
-	Personas       PersonasStatus
-	Chats          ChatsStatus
-	SelectedChat   *ChatView
-	Notice         string
-	Error          string
-	RefreshSeconds int
-	View           adminView
-	PageTitle      string
-	PageSummary    string
-	NavSections    []adminNavSection
+	Snapshot          snapshot
+	Prompts           PromptsStatus
+	Identity          IdentityStatus
+	Personas          PersonasStatus
+	Chats             ChatsStatus
+	SelectedChat      *ChatView
+	SelectedChatError string
+	Notice            string
+	Error             string
+	RefreshSeconds    int
+	View              adminView
+	PageTitle         string
+	PageSummary       string
+	NavSections       []adminNavSection
 }
 
 type adminNavSection struct {
@@ -1067,7 +1068,6 @@ func (s *Service) renderPage(
 		Identity:       s.identityStatus(),
 		Personas:       s.personasStatus(),
 		Chats:          chats,
-		SelectedChat:   selectChatView(chats, selectedChatID(r)),
 		Notice:         strings.TrimSpace(r.URL.Query().Get(queryNotice)),
 		Error:          strings.TrimSpace(r.URL.Query().Get(queryError)),
 		RefreshSeconds: refreshSeconds,
@@ -1076,6 +1076,11 @@ func (s *Service) renderPage(
 		PageSummary:    pageSummary(view),
 		NavSections:    adminNavSections(view),
 	}
+	data.SelectedChat, data.SelectedChatError = resolveSelectedChat(
+		chats,
+		s.cfg.Chats,
+		selectedChatID(r),
+	)
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if err := adminPage.Execute(w, data); err != nil {
@@ -1085,6 +1090,28 @@ func (s *Service) renderPage(
 			http.StatusInternalServerError,
 		)
 	}
+}
+
+func resolveSelectedChat(
+	status ChatsStatus,
+	provider ChatsProvider,
+	selectedID string,
+) (*ChatView, string) {
+	selected := selectChatView(status, selectedID)
+	if selected == nil {
+		return nil, ""
+	}
+	detailProvider, ok := provider.(ChatDetailProvider)
+	if !ok {
+		return selected, ""
+	}
+	detail, err := detailProvider.ChatDetail(
+		strings.TrimSpace(selected.BaseSessionID),
+	)
+	if err != nil {
+		return selected, strings.TrimSpace(err.Error())
+	}
+	return &detail, ""
 }
 
 func adminNavSections(active adminView) []adminNavSection {
@@ -2094,8 +2121,12 @@ var adminPage = template.Must(
 		"personaSummaryText":         personaSummaryText,
 		"chatDisplayLabel":           chatDisplayLabel,
 		"chatKnownUsers":             chatKnownUsers,
+		"chatHasTranscript":          chatHasTranscript,
 		"chatNameSourceLabel":        chatNameSourceLabel,
+		"chatTranscriptLabel":        chatTranscriptLabel,
+		"chatTurnSpeaker":            chatTurnSpeaker,
 		"chatOverrideSample":         chatOverrideSample,
+		"hasTime":                    hasTime,
 	}).Parse(
 		adminPageHTML +
 			promptsPageTemplateHTML +
@@ -2869,6 +2900,82 @@ const adminPageHTML = `<!doctype html>
       line-height: 1.45;
       overflow-wrap: anywhere;
       word-break: break-word;
+    }
+    .chat-detail-section + .chat-detail-section {
+      margin-top: 24px;
+      padding-top: 22px;
+      border-top: 1px solid var(--line);
+    }
+    .chat-detail-head {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 12px;
+      flex-wrap: wrap;
+      margin-bottom: 12px;
+    }
+    .chat-detail-head h3,
+    .chat-action-card h4,
+    .chat-transcript-title {
+      margin: 0;
+    }
+    .chat-transcript-list {
+      display: grid;
+      gap: 14px;
+      margin-top: 12px;
+    }
+    .chat-transcript-card,
+    .chat-action-card {
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      padding: 14px 16px;
+      background: rgba(255, 253, 248, 0.72);
+      min-width: 0;
+    }
+    .chat-transcript-head {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+    .chat-turn-list {
+      display: grid;
+      gap: 10px;
+      margin-top: 14px;
+    }
+    .chat-turn {
+      border-left: 3px solid rgba(15, 111, 97, 0.2);
+      padding-left: 12px;
+      min-width: 0;
+    }
+    .chat-turn-head {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+    .chat-turn-speaker {
+      font-weight: 700;
+    }
+    .chat-turn-quote {
+      margin: 8px 0 0;
+      padding-left: 12px;
+      border-left: 2px solid var(--line);
+      color: var(--muted);
+    }
+    .chat-turn-text {
+      margin-top: 8px;
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+      word-break: break-word;
+    }
+    .chat-action-grid {
+      display: grid;
+      gap: 12px;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      margin-top: 12px;
     }
     @media (max-width: 760px) {
       .app-shell {

--- a/openclaw/admin/service.go
+++ b/openclaw/admin/service.go
@@ -1113,8 +1113,27 @@ func resolveSelectedChat(
 	if err != nil {
 		return selected, strings.TrimSpace(err.Error())
 	}
+	if err := validateChatDetail(*selected, detail); err != nil {
+		return selected, strings.TrimSpace(err.Error())
+	}
 	merged := mergeChatView(*selected, detail)
 	return &merged, ""
+}
+
+func validateChatDetail(base ChatView, detail ChatView) error {
+	baseSessionID := strings.TrimSpace(base.BaseSessionID)
+	detailSessionID := strings.TrimSpace(detail.BaseSessionID)
+	if detailSessionID == "" || baseSessionID == "" {
+		return nil
+	}
+	if detailSessionID == baseSessionID {
+		return nil
+	}
+	return fmt.Errorf(
+		"chat detail mismatch: expected %q, got %q",
+		baseSessionID,
+		detailSessionID,
+	)
 }
 
 func mergeChatView(
@@ -1122,24 +1141,6 @@ func mergeChatView(
 	detail ChatView,
 ) ChatView {
 	merged := base
-	if value := strings.TrimSpace(detail.BaseSessionID); value != "" {
-		merged.BaseSessionID = value
-	}
-	if value := strings.TrimSpace(detail.DisplayLabel); value != "" {
-		merged.DisplayLabel = value
-	}
-	if value := strings.TrimSpace(detail.Kind); value != "" {
-		merged.Kind = value
-	}
-	if value := strings.TrimSpace(detail.KindLabel); value != "" {
-		merged.KindLabel = value
-	}
-	if value := strings.TrimSpace(detail.CurrentSessionID); value != "" {
-		merged.CurrentSessionID = value
-	}
-	if value := strings.TrimSpace(detail.RecallSessionID); value != "" {
-		merged.RecallSessionID = value
-	}
 	if !detail.LastActivity.IsZero() {
 		merged.LastActivity = detail.LastActivity
 	}

--- a/openclaw/admin/service_test.go
+++ b/openclaw/admin/service_test.go
@@ -126,6 +126,7 @@ type stubChatsProvider struct {
 	err    error
 
 	detail       ChatView
+	detailRaw    bool
 	detailErr    error
 	detailChatID string
 	detailCount  int
@@ -289,7 +290,11 @@ func (p *stubChatsProvider) ChatDetail(
 	if p.detailErr != nil {
 		return ChatView{}, p.detailErr
 	}
-	if strings.TrimSpace(p.detail.BaseSessionID) != "" {
+	if p.detailRaw {
+		return p.detail, nil
+	}
+	if strings.TrimSpace(p.detail.BaseSessionID) ==
+		strings.TrimSpace(baseSessionID) {
 		return p.detail, nil
 	}
 	for _, chat := range p.status.Chats {
@@ -2132,11 +2137,11 @@ func TestChatsHelpers(t *testing.T) {
 	chats := &stubChatsProvider{
 		status: status,
 		detail: ChatView{
-			BaseSessionID: "wecom:dm:bob",
 			Transcript: []ChatTranscriptView{{
 				SessionID: "wecom:dm:bob:2",
 			}},
 		},
+		detailRaw: true,
 	}
 	selected, detailErr := resolveSelectedChat(
 		status,
@@ -2149,6 +2154,28 @@ func TestChatsHelpers(t *testing.T) {
 	require.Equal(t, "Custom source", selected.NameSource)
 	require.True(t, selected.OverridesGlobal)
 	require.Equal(t, "wecom:dm:bob", chats.detailChatID)
+
+	chats.detail = ChatView{
+		BaseSessionID: "wrong",
+		Transcript: []ChatTranscriptView{{
+			SessionID: "wrong:2",
+		}},
+	}
+	chats.detailRaw = true
+	selected, detailErr = resolveSelectedChat(
+		status,
+		chats,
+		"wecom:dm:bob",
+	)
+	require.NotNil(t, selected)
+	require.Equal(
+		t,
+		"chat detail mismatch: expected \"wecom:dm:bob\", got \"wrong\"",
+		detailErr,
+	)
+	require.Nil(t, selected.Transcript)
+	require.Equal(t, "wecom:dm:bob", selected.BaseSessionID)
+	require.Equal(t, "Custom source", selected.NameSource)
 
 	selected, detailErr = resolveSelectedChat(
 		status,

--- a/openclaw/admin/service_test.go
+++ b/openclaw/admin/service_test.go
@@ -1905,6 +1905,12 @@ func TestService_ChatsPageAndJSON(t *testing.T) {
 	require.Equal(t, "wecom:dm:alice", chats.detailChatID)
 	require.Equal(t, 1, chats.detailCount)
 
+	req = httptest.NewRequest(http.MethodGet, routeOverview, nil)
+	rec = httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, 1, chats.detailCount)
+
 	req = httptest.NewRequest(http.MethodGet, routeChatsJSON, nil)
 	rec = httptest.NewRecorder()
 	svc.Handler().ServeHTTP(rec, req)
@@ -2140,6 +2146,8 @@ func TestChatsHelpers(t *testing.T) {
 	require.NotNil(t, selected)
 	require.Empty(t, detailErr)
 	require.Len(t, selected.Transcript, 1)
+	require.Equal(t, "Custom source", selected.NameSource)
+	require.True(t, selected.OverridesGlobal)
 	require.Equal(t, "wecom:dm:bob", chats.detailChatID)
 
 	selected, detailErr = resolveSelectedChat(
@@ -2159,6 +2167,24 @@ func TestChatsHelpers(t *testing.T) {
 	)
 	require.NotNil(t, selected)
 	require.Equal(t, "boom", detailErr)
+
+	merged := mergeChatView(
+		ChatView{
+			BaseSessionID:   "wecom:dm:bob",
+			DisplayLabel:    "Bob",
+			NameSource:      "Current chat name",
+			OverridesGlobal: true,
+		},
+		ChatView{
+			Transcript: []ChatTranscriptView{{
+				SessionID: "wecom:dm:bob:2",
+			}},
+		},
+	)
+	require.Equal(t, "Bob", merged.DisplayLabel)
+	require.Equal(t, "Current chat name", merged.NameSource)
+	require.True(t, merged.OverridesGlobal)
+	require.Len(t, merged.Transcript, 1)
 
 	selected, detailErr = resolveSelectedChat(
 		status,

--- a/openclaw/admin/service_test.go
+++ b/openclaw/admin/service_test.go
@@ -12,6 +12,7 @@ package admin
 import (
 	"compress/gzip"
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -617,6 +618,9 @@ func TestServiceHandlerRendersOverview(t *testing.T) {
 	require.Contains(t, body, `action="api/cron/jobs/clear"`)
 	require.Contains(t, body, "127.0.0.1:8080")
 	require.Contains(t, body, "telegram")
+	require.Contains(t, body, "Refresh page")
+	require.Contains(t, body, `data-page-stale-root`)
+	require.NotContains(t, body, `http-equiv="refresh"`)
 }
 
 func TestServiceHandlerRendersSkillsInventory(t *testing.T) {
@@ -1072,6 +1076,56 @@ func TestServiceRenderPageRejectsNonGET(t *testing.T) {
 	require.Contains(t, rr.Body.String(), "method not allowed")
 }
 
+func TestServicePageStateJSONEndpointStableAcrossClockTicks(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 4, 13, 21, 0, 0, 0, time.UTC)
+	svc := New(
+		Config{
+			AppName: "openclaw",
+			Chats: &stubChatsProvider{
+				status: ChatsStatus{
+					Enabled: true,
+					Chats: []ChatView{{
+						BaseSessionID:      "wecom:dm:T00320026A",
+						DisplayLabel:       "DM · wineguo (T00320026A)",
+						EffectiveAssistant: "winechord",
+					}},
+				},
+			},
+		},
+		WithClock(func() time.Time {
+			return now
+		}),
+	)
+
+	handler := svc.Handler()
+	path := routePageStateJSON + "?" + url.Values{
+		queryView: []string{string(viewChats)},
+	}.Encode()
+
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var first pageStateStatus
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &first))
+	require.NotEmpty(t, first.Token)
+	require.Equal(t, now, first.UpdatedAt)
+
+	now = now.Add(30 * time.Second)
+	req = httptest.NewRequest(http.MethodGet, path, nil)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var second pageStateStatus
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &second))
+	require.Equal(t, first.Token, second.Token)
+	require.Equal(t, now, second.UpdatedAt)
+}
+
 func TestServiceSkillsStatusErrorRetainsRecoveryFields(t *testing.T) {
 	t.Parallel()
 
@@ -1492,6 +1546,12 @@ func TestService_PromptsPageAndActions(t *testing.T) {
 	require.Contains(t, rec.Body.String(), "prompt-detail")
 	require.Contains(t, rec.Body.String(), "Instruction Config Text")
 	require.Contains(t, rec.Body.String(), "Save Config Text")
+	require.Contains(t, rec.Body.String(), "Refresh page")
+	require.NotContains(
+		t,
+		rec.Body.String(),
+		`data-page-state-path="/api/page/state?view=prompts"`,
+	)
 	require.NotContains(t, rec.Body.String(), "Inline Source")
 	require.NotContains(t, rec.Body.String(), "Agent Personas")
 	require.Contains(t, rec.Body.String(), "/personas")
@@ -1670,6 +1730,12 @@ func TestService_IdentityPageAndActions(t *testing.T) {
 	require.Contains(t, rec.Body.String(), "How Naming Works")
 	require.Contains(t, rec.Body.String(), "trpc-claw")
 	require.Contains(t, rec.Body.String(), "/api/identity")
+	require.Contains(t, rec.Body.String(), "Refresh page")
+	require.NotContains(
+		t,
+		rec.Body.String(),
+		`data-page-state-path="/api/page/state?view=identity"`,
+	)
 
 	req = httptest.NewRequest(http.MethodGet, routeIdentityJSON, nil)
 	rec = httptest.NewRecorder()

--- a/openclaw/admin/service_test.go
+++ b/openclaw/admin/service_test.go
@@ -131,6 +131,11 @@ type stubChatsProvider struct {
 	detailCount  int
 }
 
+type stubStatusOnlyChatsProvider struct {
+	status ChatsStatus
+	err    error
+}
+
 func (p stubBMP) BrowserManagedStatus() BrowserManagedService {
 	return p.status
 }
@@ -257,6 +262,16 @@ func (p *stubPromptsProvider) DeletePromptFile(
 }
 
 func (p *stubChatsProvider) ChatsStatus() (ChatsStatus, error) {
+	if p == nil {
+		return ChatsStatus{}, nil
+	}
+	return p.status, p.err
+}
+
+func (p *stubStatusOnlyChatsProvider) ChatsStatus() (
+	ChatsStatus,
+	error,
+) {
 	if p == nil {
 		return ChatsStatus{}, nil
 	}
@@ -2070,8 +2085,28 @@ func TestChatsHelpers(t *testing.T) {
 	)
 	require.Equal(
 		t,
+		"User",
+		chatTurnSpeaker(ChatTurnView{Role: "user"}),
+	)
+	require.Equal(
+		t,
 		"Assistant",
 		chatTurnSpeaker(ChatTurnView{Role: "assistant"}),
+	)
+	require.Equal(
+		t,
+		"System",
+		chatTurnSpeaker(ChatTurnView{Role: "system"}),
+	)
+	require.Equal(
+		t,
+		"Turn",
+		chatTurnSpeaker(ChatTurnView{Role: "tool"}),
+	)
+	require.Equal(
+		t,
+		"Alice Chen",
+		chatKnownUserLabel(KnownUserView{Label: "Alice Chen"}),
 	)
 	require.False(t, hasTime(time.Time{}))
 	require.True(t, hasTime(time.Unix(1700000000, 0)))
@@ -2107,6 +2142,15 @@ func TestChatsHelpers(t *testing.T) {
 	require.Len(t, selected.Transcript, 1)
 	require.Equal(t, "wecom:dm:bob", chats.detailChatID)
 
+	selected, detailErr = resolveSelectedChat(
+		status,
+		&stubStatusOnlyChatsProvider{status: status},
+		"wecom:dm:bob",
+	)
+	require.NotNil(t, selected)
+	require.Empty(t, detailErr)
+	require.Nil(t, selected.Transcript)
+
 	chats.detailErr = errors.New("boom")
 	selected, detailErr = resolveSelectedChat(
 		status,
@@ -2115,6 +2159,25 @@ func TestChatsHelpers(t *testing.T) {
 	)
 	require.NotNil(t, selected)
 	require.Equal(t, "boom", detailErr)
+
+	selected, detailErr = resolveSelectedChat(
+		status,
+		chats,
+		"missing",
+	)
+	require.Nil(t, selected)
+	require.Empty(t, detailErr)
+}
+
+func TestService_ChatsStatusError(t *testing.T) {
+	t.Parallel()
+
+	svc := New(Config{
+		Chats: &stubChatsProvider{err: errors.New("boom")},
+	})
+	status := svc.chatsStatus()
+	require.True(t, status.Enabled)
+	require.Equal(t, "boom", status.Error)
 }
 
 func TestService_PersonasPageAndActions(t *testing.T) {

--- a/openclaw/admin/service_test.go
+++ b/openclaw/admin/service_test.go
@@ -2213,6 +2213,23 @@ func TestChatsHelpers(t *testing.T) {
 	require.True(t, merged.OverridesGlobal)
 	require.Len(t, merged.Transcript, 1)
 
+	merged = mergeChatView(
+		ChatView{BaseSessionID: "wecom:dm:alice"},
+		ChatView{
+			BaseSessionID:    "wecom:dm:alice",
+			DisplayLabel:     "Alice",
+			Kind:             "dm",
+			KindLabel:        "Direct message",
+			CurrentSessionID: "sess-2",
+			RecallSessionID:  "sess-1",
+		},
+	)
+	require.Equal(t, "Alice", merged.DisplayLabel)
+	require.Equal(t, "dm", merged.Kind)
+	require.Equal(t, "Direct message", merged.KindLabel)
+	require.Equal(t, "sess-2", merged.CurrentSessionID)
+	require.Equal(t, "sess-1", merged.RecallSessionID)
+
 	selected, detailErr = resolveSelectedChat(
 		status,
 		chats,

--- a/openclaw/admin/service_test.go
+++ b/openclaw/admin/service_test.go
@@ -1828,9 +1828,11 @@ func TestService_ChatsPageAndJSON(t *testing.T) {
 					UserID: "alice",
 					Label:  "Alice Chen",
 				}},
+				HistoryTotalCount: 1,
 				History: []ChatSessionView{{
 					SessionID:    "wecom:dm:alice:171",
 					LastActivity: time.Unix(1700000000, 0),
+					Visible:      true,
 				}},
 			}},
 		},
@@ -1852,24 +1854,46 @@ func TestService_ChatsPageAndJSON(t *testing.T) {
 				UserID: "alice",
 				Label:  "Alice Chen",
 			}},
+			HistoryTotalCount:   2,
+			HistoryTruncated:    true,
+			TranscriptTruncated: true,
 			History: []ChatSessionView{{
 				SessionID:    "wecom:dm:alice:171",
 				LastActivity: time.Unix(1700000000, 0),
+				Visible:      true,
+			}, {
+				SessionID:    "wecom:dm:alice:170",
+				LastActivity: time.Unix(1699999990, 0),
+				Visible:      false,
 			}},
 			Transcript: []ChatTranscriptView{{
 				SessionID:    "wecom:dm:alice:171",
 				LastActivity: time.Unix(1700000000, 0),
 				Current:      true,
+				Visible:      true,
 				Turns: []ChatTurnView{{
 					Role:      "user",
 					Speaker:   "Alice Chen",
 					Text:      "Who are you listening to?",
 					Timestamp: time.Unix(1700000000, 0),
+					Visible:   false,
 				}, {
 					Role:      "assistant",
 					Speaker:   "林妹妹",
 					Text:      "I am using this chat's current name.",
 					Timestamp: time.Unix(1700000010, 0),
+					Visible:   true,
+				}},
+			}, {
+				SessionID:    "wecom:dm:alice:170",
+				LastActivity: time.Unix(1699999990, 0),
+				Visible:      false,
+				Turns: []ChatTurnView{{
+					Role:      "assistant",
+					Speaker:   "林妹妹",
+					Text:      "Older session reply.",
+					Timestamp: time.Unix(1699999990, 0),
+					Visible:   true,
 				}},
 			}},
 		},
@@ -1907,6 +1931,14 @@ func TestService_ChatsPageAndJSON(t *testing.T) {
 	require.Contains(t, body, "href=\"identity#identity-global\"")
 	require.Contains(t, body, "Alice Chen (alice)")
 	require.Contains(t, body, "I am using this chat&#39;s current name.")
+	require.Contains(t, body, "Show 1 older tracked sessions")
+	require.Contains(t, body, "Show 1 older turns")
+	require.Contains(t, body, "Show 1 older session lines")
+	require.Contains(
+		t,
+		body,
+		"Showing the most recent tracked sessions in this admin view.",
+	)
 	require.Equal(t, "wecom:dm:alice", chats.detailChatID)
 	require.Equal(t, 1, chats.detailCount)
 
@@ -2028,6 +2060,16 @@ func TestChatsHelpers(t *testing.T) {
 		"wecom:dm:alice",
 		chatDisplayLabel(ChatView{BaseSessionID: "wecom:dm:alice"}),
 	)
+	require.Equal(
+		t,
+		"No tracked sessions are currently available.",
+		chatHistorySummary(ChatView{}),
+	)
+	require.Equal(
+		t,
+		"2 tracked session lines",
+		chatHistorySummary(ChatView{HistoryTotalCount: 2}),
+	)
 	require.Equal(t, "-", chatKnownUsers(ChatView{}))
 	require.Equal(t, "alice, bob", chatKnownUsers(status.Chats[1]))
 	require.Equal(
@@ -2076,6 +2118,20 @@ func TestChatsHelpers(t *testing.T) {
 	}))
 	require.Equal(
 		t,
+		"No recent transcript is currently available.",
+		chatTranscriptSummary(ChatView{}),
+	)
+	require.Equal(
+		t,
+		"1 recent session lines · 2 visible turns",
+		chatTranscriptSummary(ChatView{
+			Transcript: []ChatTranscriptView{{
+				Turns: []ChatTurnView{{}, {}},
+			}},
+		}),
+	)
+	require.Equal(
+		t,
 		"Current session",
 		chatTranscriptLabel(ChatTranscriptView{Current: true}),
 	)
@@ -2118,6 +2174,52 @@ func TestChatsHelpers(t *testing.T) {
 		t,
 		"Alice Chen",
 		chatKnownUserLabel(KnownUserView{Label: "Alice Chen"}),
+	)
+	require.Len(
+		t,
+		chatVisibleHistory(ChatView{
+			History: []ChatSessionView{{Visible: true}, {Visible: false}},
+		}),
+		1,
+	)
+	require.Len(
+		t,
+		chatHiddenHistory(ChatView{
+			History: []ChatSessionView{{Visible: true}, {Visible: false}},
+		}),
+		1,
+	)
+	require.Len(
+		t,
+		chatVisibleTranscript(ChatView{
+			Transcript: []ChatTranscriptView{
+				{Visible: true}, {Visible: false},
+			},
+		}),
+		1,
+	)
+	require.Len(
+		t,
+		chatHiddenTranscript(ChatView{
+			Transcript: []ChatTranscriptView{
+				{Visible: true}, {Visible: false},
+			},
+		}),
+		1,
+	)
+	require.Len(
+		t,
+		chatVisibleTurns(ChatTranscriptView{
+			Turns: []ChatTurnView{{Visible: true}, {Visible: false}},
+		}),
+		1,
+	)
+	require.Len(
+		t,
+		chatHiddenTurns(ChatTranscriptView{
+			Turns: []ChatTurnView{{Visible: true}, {Visible: false}},
+		}),
+		1,
 	)
 	require.False(t, hasTime(time.Time{}))
 	require.True(t, hasTime(time.Unix(1700000000, 0)))
@@ -2197,12 +2299,16 @@ func TestChatsHelpers(t *testing.T) {
 
 	merged := mergeChatView(
 		ChatView{
-			BaseSessionID:   "wecom:dm:bob",
-			DisplayLabel:    "Bob",
-			NameSource:      "Current chat name",
-			OverridesGlobal: true,
+			BaseSessionID:       "wecom:dm:bob",
+			DisplayLabel:        "Bob",
+			NameSource:          "Current chat name",
+			OverridesGlobal:     true,
+			HistoryTotalCount:   2,
+			TranscriptTruncated: true,
 		},
 		ChatView{
+			HistoryTotalCount: 3,
+			HistoryTruncated:  true,
 			Transcript: []ChatTranscriptView{{
 				SessionID: "wecom:dm:bob:2",
 			}},
@@ -2211,6 +2317,9 @@ func TestChatsHelpers(t *testing.T) {
 	require.Equal(t, "Bob", merged.DisplayLabel)
 	require.Equal(t, "Current chat name", merged.NameSource)
 	require.True(t, merged.OverridesGlobal)
+	require.Equal(t, 3, merged.HistoryTotalCount)
+	require.True(t, merged.HistoryTruncated)
+	require.True(t, merged.TranscriptTruncated)
 	require.Len(t, merged.Transcript, 1)
 
 	merged = mergeChatView(

--- a/openclaw/admin/service_test.go
+++ b/openclaw/admin/service_test.go
@@ -125,11 +125,16 @@ type stubChatsProvider struct {
 	status ChatsStatus
 	err    error
 
-	detail       ChatView
-	detailRaw    bool
-	detailErr    error
-	detailChatID string
-	detailCount  int
+	history       ChatHistoryPage
+	historyErr    error
+	historyChatID string
+	historyCursor string
+	historyCount  int
+	detail        ChatView
+	detailRaw     bool
+	detailErr     error
+	detailChatID  string
+	detailCount   int
 }
 
 type stubStatusOnlyChatsProvider struct {
@@ -303,6 +308,22 @@ func (p *stubChatsProvider) ChatDetail(
 		}
 	}
 	return ChatView{}, nil
+}
+
+func (p *stubChatsProvider) ChatHistory(
+	baseSessionID string,
+	cursor string,
+) (ChatHistoryPage, error) {
+	if p == nil {
+		return ChatHistoryPage{}, nil
+	}
+	p.historyCount++
+	p.historyChatID = baseSessionID
+	p.historyCursor = cursor
+	if p.historyErr != nil {
+		return ChatHistoryPage{}, p.historyErr
+	}
+	return p.history, nil
 }
 
 func (p *stubIdentityProvider) IdentityStatus() (
@@ -1854,9 +1875,8 @@ func TestService_ChatsPageAndJSON(t *testing.T) {
 				UserID: "alice",
 				Label:  "Alice Chen",
 			}},
-			HistoryTotalCount:   2,
-			HistoryTruncated:    true,
-			TranscriptTruncated: true,
+			HistoryTotalCount: 2,
+			HistoryTruncated:  true,
 			History: []ChatSessionView{{
 				SessionID:    "wecom:dm:alice:171",
 				LastActivity: time.Unix(1700000000, 0),
@@ -1866,35 +1886,32 @@ func TestService_ChatsPageAndJSON(t *testing.T) {
 				LastActivity: time.Unix(1699999990, 0),
 				Visible:      false,
 			}},
-			Transcript: []ChatTranscriptView{{
+		},
+		history: ChatHistoryPage{
+			BaseSessionID:     "wecom:dm:alice",
+			SessionLineCount:  2,
+			TurnCount:         3,
+			ReturnedTurnCount: 2,
+			NextCursor:        "2",
+			Bounded:           true,
+			Items: []ChatHistoryItem{{
+				Kind:         chatHistoryItemKindSession,
 				SessionID:    "wecom:dm:alice:171",
+				SessionLabel: "Current session",
 				LastActivity: time.Unix(1700000000, 0),
 				Current:      true,
-				Visible:      true,
-				Turns: []ChatTurnView{{
-					Role:      "user",
-					Speaker:   "Alice Chen",
-					Text:      "Who are you listening to?",
-					Timestamp: time.Unix(1700000000, 0),
-					Visible:   false,
-				}, {
-					Role:      "assistant",
-					Speaker:   "林妹妹",
-					Text:      "I am using this chat's current name.",
-					Timestamp: time.Unix(1700000010, 0),
-					Visible:   true,
-				}},
 			}, {
-				SessionID:    "wecom:dm:alice:170",
-				LastActivity: time.Unix(1699999990, 0),
-				Visible:      false,
-				Turns: []ChatTurnView{{
-					Role:      "assistant",
-					Speaker:   "林妹妹",
-					Text:      "Older session reply.",
-					Timestamp: time.Unix(1699999990, 0),
-					Visible:   true,
-				}},
+				Kind:      chatHistoryItemKindTurn,
+				Role:      "assistant",
+				Speaker:   "林妹妹",
+				Text:      "I am using this chat's current name.",
+				Timestamp: time.Unix(1700000010, 0),
+			}, {
+				Kind:      chatHistoryItemKindTurn,
+				Role:      "assistant",
+				Speaker:   "林妹妹",
+				Text:      "Older session reply.",
+				Timestamp: time.Unix(1699999990, 0),
 			}},
 		},
 	}
@@ -1930,10 +1947,14 @@ func TestService_ChatsPageAndJSON(t *testing.T) {
 	require.Contains(t, body, "<code>wecom:dm:alice</code>")
 	require.Contains(t, body, "href=\"identity#identity-global\"")
 	require.Contains(t, body, "Alice Chen (alice)")
-	require.Contains(t, body, "I am using this chat&#39;s current name.")
+	require.Contains(t, body, "data-chat-history-root")
+	require.Contains(t, body, routeChatHistoryJSON)
+	require.Contains(
+		t,
+		body,
+		"Expand this panel to load the newest visible",
+	)
 	require.Contains(t, body, "Show 1 older tracked sessions")
-	require.Contains(t, body, "Show 1 older turns")
-	require.Contains(t, body, "Show 1 older session lines")
 	require.Contains(
 		t,
 		body,
@@ -1941,6 +1962,24 @@ func TestService_ChatsPageAndJSON(t *testing.T) {
 	)
 	require.Equal(t, "wecom:dm:alice", chats.detailChatID)
 	require.Equal(t, 1, chats.detailCount)
+
+	req = httptest.NewRequest(
+		http.MethodGet,
+		routeChatHistoryJSON+"?chat_id=wecom%3Adm%3Aalice",
+		nil,
+	)
+	rec = httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(
+		t,
+		rec.Body.String(),
+		"\"text\": \"I am using this chat's current name.\"",
+	)
+	require.Contains(t, rec.Body.String(), "\"next_cursor\": \"2\"")
+	require.Equal(t, "wecom:dm:alice", chats.historyChatID)
+	require.Empty(t, chats.historyCursor)
+	require.Equal(t, 1, chats.historyCount)
 
 	req = httptest.NewRequest(http.MethodGet, routeOverview, nil)
 	rec = httptest.NewRecorder()
@@ -2007,6 +2046,20 @@ func TestService_ChatsPageFallbackStates(t *testing.T) {
 	rec = httptest.NewRecorder()
 	svc.Handler().ServeHTTP(rec, req)
 	require.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+
+	svc = New(Config{
+		Chats: &stubStatusOnlyChatsProvider{
+			status: ChatsStatus{Enabled: true},
+		},
+	})
+	req = httptest.NewRequest(
+		http.MethodGet,
+		routeChatHistoryJSON+"?chat_id=missing",
+		nil,
+	)
+	rec = httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rec, req)
+	require.Equal(t, http.StatusNotFound, rec.Code)
 }
 
 func TestChatsHelpers(t *testing.T) {

--- a/openclaw/admin/service_test.go
+++ b/openclaw/admin/service_test.go
@@ -124,6 +124,11 @@ type stubPersonasProvider struct {
 type stubChatsProvider struct {
 	status ChatsStatus
 	err    error
+
+	detail       ChatView
+	detailErr    error
+	detailChatID string
+	detailCount  int
 }
 
 func (p stubBMP) BrowserManagedStatus() BrowserManagedService {
@@ -251,6 +256,35 @@ func (p *stubPromptsProvider) DeletePromptFile(
 	return p.deleteErr
 }
 
+func (p *stubChatsProvider) ChatsStatus() (ChatsStatus, error) {
+	if p == nil {
+		return ChatsStatus{}, nil
+	}
+	return p.status, p.err
+}
+
+func (p *stubChatsProvider) ChatDetail(
+	baseSessionID string,
+) (ChatView, error) {
+	if p == nil {
+		return ChatView{}, nil
+	}
+	p.detailCount++
+	p.detailChatID = baseSessionID
+	if p.detailErr != nil {
+		return ChatView{}, p.detailErr
+	}
+	if strings.TrimSpace(p.detail.BaseSessionID) != "" {
+		return p.detail, nil
+	}
+	for _, chat := range p.status.Chats {
+		if chat.BaseSessionID == baseSessionID {
+			return chat, nil
+		}
+	}
+	return ChatView{}, nil
+}
+
 func (p *stubIdentityProvider) IdentityStatus() (
 	IdentityStatus,
 	error,
@@ -320,16 +354,6 @@ func (p *stubPersonasProvider) SetDefaultPersona(
 	p.defaultCount++
 	p.defaultPersona = personaID
 	return p.defaultErr
-}
-
-func (p *stubChatsProvider) ChatsStatus() (
-	ChatsStatus,
-	error,
-) {
-	if p == nil {
-		return ChatsStatus{}, nil
-	}
-	return p.status, p.err
 }
 
 func (r *stubRunner) Run(
@@ -1790,6 +1814,45 @@ func TestService_ChatsPageAndJSON(t *testing.T) {
 				}},
 			}},
 		},
+		detail: ChatView{
+			BaseSessionID:         "wecom:dm:alice",
+			DisplayLabel:          "Direct Message / alice",
+			KindLabel:             "Direct message",
+			CurrentSessionID:      "wecom:dm:alice:171",
+			RecallSessionID:       "wecom:dm:alice",
+			LastActivity:          time.Unix(1700000000, 0),
+			Epoch:                 171,
+			EffectiveAssistant:    "林妹妹",
+			ChatAssistantOverride: "林妹妹",
+			NameSource:            "Current chat name",
+			OverridesGlobal:       true,
+			PersonaLabel:          "Creative",
+			WorkspacePath:         "/repo",
+			KnownUsers: []KnownUserView{{
+				UserID: "alice",
+				Label:  "Alice Chen",
+			}},
+			History: []ChatSessionView{{
+				SessionID:    "wecom:dm:alice:171",
+				LastActivity: time.Unix(1700000000, 0),
+			}},
+			Transcript: []ChatTranscriptView{{
+				SessionID:    "wecom:dm:alice:171",
+				LastActivity: time.Unix(1700000000, 0),
+				Current:      true,
+				Turns: []ChatTurnView{{
+					Role:      "user",
+					Speaker:   "Alice Chen",
+					Text:      "Who are you listening to?",
+					Timestamp: time.Unix(1700000000, 0),
+				}, {
+					Role:      "assistant",
+					Speaker:   "林妹妹",
+					Text:      "I am using this chat's current name.",
+					Timestamp: time.Unix(1700000010, 0),
+				}},
+			}},
+		},
 	}
 	identity := &stubIdentityProvider{
 		status: IdentityStatus{
@@ -1814,13 +1877,18 @@ func TestService_ChatsPageAndJSON(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec.Code)
 	body := rec.Body.String()
 	require.Contains(t, body, "Tracked Chats")
-	require.Contains(t, body, "Chat Detail")
+	require.Contains(t, body, "Selected Chat")
 	require.Contains(t, body, "Direct Message / alice")
 	require.Contains(t, body, "Current chat name")
-	require.Contains(t, body, "Recent Sessions")
+	require.Contains(t, body, "Overview")
+	require.Contains(t, body, "History")
+	require.Contains(t, body, "Actions")
 	require.Contains(t, body, "<code>wecom:dm:alice</code>")
 	require.Contains(t, body, "href=\"identity#identity-global\"")
 	require.Contains(t, body, "Alice Chen (alice)")
+	require.Contains(t, body, "I am using this chat&#39;s current name.")
+	require.Equal(t, "wecom:dm:alice", chats.detailChatID)
+	require.Equal(t, 1, chats.detailCount)
 
 	req = httptest.NewRequest(http.MethodGet, routeChatsJSON, nil)
 	rec = httptest.NewRecorder()
@@ -1974,6 +2042,39 @@ func TestChatsHelpers(t *testing.T) {
 		chatNameSourceLabel(status.Chats[2]),
 	)
 	require.Equal(t, "Default name", chatNameSourceLabel(ChatView{}))
+	require.False(t, chatHasTranscript(ChatView{}))
+	require.True(t, chatHasTranscript(ChatView{
+		Transcript: []ChatTranscriptView{{
+			SessionID: "wecom:dm:alice:171",
+		}},
+	}))
+	require.Equal(
+		t,
+		"Current session",
+		chatTranscriptLabel(ChatTranscriptView{Current: true}),
+	)
+	require.Equal(
+		t,
+		"Recall session",
+		chatTranscriptLabel(ChatTranscriptView{Recall: true}),
+	)
+	require.Equal(
+		t,
+		"Recent session",
+		chatTranscriptLabel(ChatTranscriptView{}),
+	)
+	require.Equal(
+		t,
+		"Alice Chen",
+		chatTurnSpeaker(ChatTurnView{Speaker: "Alice Chen"}),
+	)
+	require.Equal(
+		t,
+		"Assistant",
+		chatTurnSpeaker(ChatTurnView{Role: "assistant"}),
+	)
+	require.False(t, hasTime(time.Time{}))
+	require.True(t, hasTime(time.Unix(1700000000, 0)))
 
 	sample := chatOverrideSample(status, 1)
 	require.Len(t, sample, 1)
@@ -1986,6 +2087,34 @@ func TestChatsHelpers(t *testing.T) {
 	require.Len(t, sample, 2)
 
 	require.Equal(t, 2, chatOverrideCount(status.Chats))
+
+	chats := &stubChatsProvider{
+		status: status,
+		detail: ChatView{
+			BaseSessionID: "wecom:dm:bob",
+			Transcript: []ChatTranscriptView{{
+				SessionID: "wecom:dm:bob:2",
+			}},
+		},
+	}
+	selected, detailErr := resolveSelectedChat(
+		status,
+		chats,
+		"wecom:dm:bob",
+	)
+	require.NotNil(t, selected)
+	require.Empty(t, detailErr)
+	require.Len(t, selected.Transcript, 1)
+	require.Equal(t, "wecom:dm:bob", chats.detailChatID)
+
+	chats.detailErr = errors.New("boom")
+	selected, detailErr = resolveSelectedChat(
+		status,
+		chats,
+		"wecom:dm:bob",
+	)
+	require.NotNil(t, selected)
+	require.Equal(t, "boom", detailErr)
 }
 
 func TestService_PersonasPageAndActions(t *testing.T) {

--- a/openclaw/app/admin_identity.go
+++ b/openclaw/app/admin_identity.go
@@ -10,12 +10,20 @@
 package app
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
+	"time"
+	"unicode/utf8"
 
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/admin"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/conversation"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/conversationscope"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/cron"
+	"trpc.group/trpc-go/trpc-agent-go/session"
 )
 
 const (
@@ -32,12 +40,20 @@ const (
 	adminDefaultNameSourceApp  = "Default name from runtime product"
 
 	adminChatsHelpText = "" +
-		"This runtime does not keep a separate current name per " +
-		"chat yet. Every chat uses the default name shown on the " +
-		"Identity page."
+		"This runtime uses one default name across chats. " +
+		"The Chats page shows tracked conversation scopes and " +
+		"their recent history, but it does not keep a separate " +
+		"current name for each chat."
 
 	adminIdentityTrimCutset = "" +
 		"\"'“”‘’<>《》「」『』【】()（）[]"
+
+	adminChatKindTracked = "tracked"
+	adminChatKindLabel   = "Tracked chat"
+
+	adminChatTranscriptSessionLimit = 3
+	adminChatTranscriptTurnLimit    = 12
+	adminChatTranscriptTextLimit    = 1500
 )
 
 type adminIdentityProvider struct {
@@ -47,6 +63,8 @@ type adminIdentityProvider struct {
 
 type adminChatsProvider struct {
 	identity *adminIdentityProvider
+	appName  string
+	session  session.Service
 }
 
 func buildAdminIdentityProvider(
@@ -64,11 +82,17 @@ func buildAdminIdentityProvider(
 
 func buildAdminChatsProvider(
 	identity *adminIdentityProvider,
+	appName string,
+	sessionSvc session.Service,
 ) *adminChatsProvider {
 	if identity == nil {
 		return nil
 	}
-	return &adminChatsProvider{identity: identity}
+	return &adminChatsProvider{
+		identity: identity,
+		appName:  strings.TrimSpace(appName),
+		session:  sessionSvc,
+	}
 }
 
 func defaultAdminRuntimeProduct(raw string) string {
@@ -204,6 +228,13 @@ func (p *adminChatsProvider) ChatsStatus() (
 	if err != nil {
 		return admin.ChatsStatus{}, err
 	}
+	chats, err := p.chatViews(
+		strings.TrimSpace(identity.EffectiveName),
+		identityDefaultNameSource(identity),
+	)
+	if err != nil {
+		return admin.ChatsStatus{}, err
+	}
 
 	return admin.ChatsStatus{
 		Enabled:               true,
@@ -211,5 +242,301 @@ func (p *adminChatsProvider) ChatsStatus() (
 		RuntimeAssistantName:  strings.TrimSpace(identity.RuntimeProduct),
 		GlobalAssistantSource: identityDefaultNameSource(identity),
 		ChatOverrideHelp:      adminChatsHelpText,
+		Chats:                 chats,
 	}, nil
+}
+
+func (p *adminChatsProvider) ChatDetail(
+	baseSessionID string,
+) (admin.ChatView, error) {
+	baseSessionID = strings.TrimSpace(baseSessionID)
+	if baseSessionID == "" {
+		return admin.ChatView{}, fmt.Errorf("chat_id is required")
+	}
+	if p == nil || p.identity == nil {
+		return admin.ChatView{}, fmt.Errorf("chat provider is unavailable")
+	}
+
+	identity, err := p.identity.IdentityStatus()
+	if err != nil {
+		return admin.ChatView{}, err
+	}
+	sessions, err := p.chatSessions(baseSessionID)
+	if err != nil {
+		return admin.ChatView{}, err
+	}
+	if len(sessions) == 0 {
+		return admin.ChatView{}, fmt.Errorf("tracked chat not found")
+	}
+
+	detail := buildAdminTrackedChatView(
+		baseSessionID,
+		strings.TrimSpace(identity.EffectiveName),
+		identityDefaultNameSource(identity),
+		sessions,
+	)
+	detail.Transcript = buildAdminChatTranscript(
+		strings.TrimSpace(p.appName),
+		p.session,
+		baseSessionID,
+		sessions,
+	)
+	return detail, nil
+}
+
+func (p *adminChatsProvider) chatViews(
+	defaultName string,
+	defaultSource string,
+) ([]admin.ChatView, error) {
+	scopes, err := conversationscope.ListIndexedStorageScopes(
+		context.Background(),
+		p.session,
+		p.appName,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if len(scopes) == 0 {
+		return nil, nil
+	}
+
+	chats := make([]admin.ChatView, 0, len(scopes))
+	for _, scope := range scopes {
+		sessions, err := p.chatSessions(scope)
+		if err != nil {
+			return nil, err
+		}
+		if len(sessions) == 0 {
+			continue
+		}
+		chats = append(
+			chats,
+			buildAdminTrackedChatView(
+				scope,
+				defaultName,
+				defaultSource,
+				sessions,
+			),
+		)
+	}
+	sort.Slice(chats, func(i int, j int) bool {
+		left := chats[i].LastActivity
+		right := chats[j].LastActivity
+		switch {
+		case left.Equal(right):
+			return chats[i].BaseSessionID < chats[j].BaseSessionID
+		case right.IsZero():
+			return true
+		case left.IsZero():
+			return false
+		default:
+			return left.After(right)
+		}
+	})
+	if len(chats) == 0 {
+		return nil, nil
+	}
+	return chats, nil
+}
+
+func (p *adminChatsProvider) chatSessions(
+	baseSessionID string,
+) ([]*session.Session, error) {
+	baseSessionID = strings.TrimSpace(baseSessionID)
+	if baseSessionID == "" || strings.TrimSpace(p.appName) == "" ||
+		p.session == nil {
+		return nil, nil
+	}
+	sessions, err := p.session.ListSessions(
+		context.Background(),
+		session.UserKey{
+			AppName: p.appName,
+			UserID:  baseSessionID,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	filtered := make([]*session.Session, 0, len(sessions))
+	for _, sess := range sessions {
+		if sess == nil || strings.TrimSpace(sess.ID) == "" {
+			continue
+		}
+		if cron.IsRunSessionID(sess.ID) {
+			continue
+		}
+		filtered = append(filtered, sess)
+	}
+	sort.Slice(filtered, func(i int, j int) bool {
+		left := sessionActivityTime(filtered[i])
+		right := sessionActivityTime(filtered[j])
+		switch {
+		case left.Equal(right):
+			return filtered[i].ID < filtered[j].ID
+		case right.IsZero():
+			return true
+		case left.IsZero():
+			return false
+		default:
+			return left.After(right)
+		}
+	})
+	if len(filtered) == 0 {
+		return nil, nil
+	}
+	return filtered, nil
+}
+
+func buildAdminTrackedChatView(
+	baseSessionID string,
+	defaultName string,
+	defaultSource string,
+	sessions []*session.Session,
+) admin.ChatView {
+	history := make([]admin.ChatSessionView, 0, len(sessions))
+	for _, sess := range sessions {
+		history = append(history, admin.ChatSessionView{
+			SessionID:    strings.TrimSpace(sess.ID),
+			LastActivity: sessionActivityTime(sess),
+		})
+	}
+	currentSessionID := ""
+	lastActivity := timeZero()
+	if len(sessions) != 0 {
+		currentSessionID = strings.TrimSpace(sessions[0].ID)
+		lastActivity = sessionActivityTime(sessions[0])
+	}
+	return admin.ChatView{
+		BaseSessionID:      strings.TrimSpace(baseSessionID),
+		DisplayLabel:       strings.TrimSpace(baseSessionID),
+		Kind:               adminChatKindTracked,
+		KindLabel:          adminChatKindLabel,
+		CurrentSessionID:   currentSessionID,
+		LastActivity:       lastActivity,
+		EffectiveAssistant: strings.TrimSpace(defaultName),
+		NameSource:         strings.TrimSpace(defaultSource),
+		History:            history,
+	}
+}
+
+func buildAdminChatTranscript(
+	appName string,
+	sessionSvc session.Service,
+	baseSessionID string,
+	sessions []*session.Session,
+) []admin.ChatTranscriptView {
+	if strings.TrimSpace(appName) == "" || sessionSvc == nil ||
+		strings.TrimSpace(baseSessionID) == "" || len(sessions) == 0 {
+		return nil
+	}
+	if len(sessions) > adminChatTranscriptSessionLimit {
+		sessions = sessions[:adminChatTranscriptSessionLimit]
+	}
+	transcript := make([]admin.ChatTranscriptView, 0, len(sessions))
+	currentSessionID := strings.TrimSpace(sessions[0].ID)
+	for _, sess := range sessions {
+		view, ok := buildAdminChatTranscriptView(
+			appName,
+			sessionSvc,
+			baseSessionID,
+			currentSessionID,
+			sess,
+		)
+		if !ok {
+			continue
+		}
+		transcript = append(transcript, view)
+	}
+	if len(transcript) == 0 {
+		return nil
+	}
+	return transcript
+}
+
+func buildAdminChatTranscriptView(
+	appName string,
+	sessionSvc session.Service,
+	baseSessionID string,
+	currentSessionID string,
+	sessionMeta *session.Session,
+) (admin.ChatTranscriptView, bool) {
+	if sessionMeta == nil {
+		return admin.ChatTranscriptView{}, false
+	}
+	sessionID := strings.TrimSpace(sessionMeta.ID)
+	if sessionID == "" {
+		return admin.ChatTranscriptView{}, false
+	}
+	sess, err := sessionSvc.GetSession(
+		context.Background(),
+		session.Key{
+			AppName:   strings.TrimSpace(appName),
+			UserID:    strings.TrimSpace(baseSessionID),
+			SessionID: sessionID,
+		},
+	)
+	if err != nil || sess == nil {
+		return admin.ChatTranscriptView{}, false
+	}
+
+	turns := conversation.BuildTurns(sess, conversation.TurnOptions{})
+	truncated := false
+	if len(turns) > adminChatTranscriptTurnLimit {
+		turns = turns[len(turns)-adminChatTranscriptTurnLimit:]
+		truncated = true
+	}
+	mapped := make([]admin.ChatTurnView, 0, len(turns))
+	for _, turn := range turns {
+		text := trimAdminChatTranscriptText(turn.Text)
+		quote := trimAdminChatTranscriptText(turn.QuoteText)
+		if strings.TrimSpace(text) == "" &&
+			strings.TrimSpace(quote) == "" {
+			continue
+		}
+		mapped = append(mapped, admin.ChatTurnView{
+			Role:      strings.TrimSpace(turn.Role),
+			Speaker:   strings.TrimSpace(turn.Speaker),
+			QuoteText: quote,
+			Text:      text,
+			Timestamp: turn.Timestamp,
+		})
+	}
+	if len(mapped) == 0 {
+		return admin.ChatTranscriptView{}, false
+	}
+	return admin.ChatTranscriptView{
+		SessionID:    sessionID,
+		LastActivity: sessionActivityTime(sessionMeta),
+		Current:      sessionID == strings.TrimSpace(currentSessionID),
+		Truncated:    truncated,
+		Turns:        mapped,
+	}, true
+}
+
+func trimAdminChatTranscriptText(text string) string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return ""
+	}
+	if utf8.RuneCountInString(text) <= adminChatTranscriptTextLimit {
+		return text
+	}
+	runes := []rune(text)
+	return strings.TrimSpace(
+		string(runes[:adminChatTranscriptTextLimit]),
+	) + "..."
+}
+
+func sessionActivityTime(sess *session.Session) time.Time {
+	if sess == nil {
+		return timeZero()
+	}
+	if !sess.UpdatedAt.IsZero() {
+		return sess.UpdatedAt
+	}
+	return sess.CreatedAt
+}
+
+func timeZero() time.Time {
+	return time.Time{}
 }

--- a/openclaw/app/admin_identity.go
+++ b/openclaw/app/admin_identity.go
@@ -51,8 +51,12 @@ const (
 	adminChatKindTracked = "tracked"
 	adminChatKindLabel   = "Tracked chat"
 
-	adminChatTranscriptSessionLimit = 3
-	adminChatTranscriptTurnLimit    = 12
+	adminChatHistorySessionLimit    = 12
+	adminChatHistoryVisibleCount    = 5
+	adminChatTranscriptSessionLimit = 8
+	adminChatTranscriptVisibleCount = 2
+	adminChatTranscriptTurnLimit    = 18
+	adminChatTranscriptTurnVisible  = 6
 	adminChatTranscriptTextLimit    = 1500
 )
 
@@ -275,12 +279,13 @@ func (p *adminChatsProvider) ChatDetail(
 		identityDefaultNameSource(identity),
 		sessions,
 	)
-	detail.Transcript, err = buildAdminChatTranscript(
-		strings.TrimSpace(p.appName),
-		p.session,
-		baseSessionID,
-		sessions,
-	)
+	detail.Transcript, detail.TranscriptTruncated, err =
+		buildAdminChatTranscript(
+			strings.TrimSpace(p.appName),
+			p.session,
+			baseSessionID,
+			sessions,
+		)
 	if err != nil {
 		return admin.ChatView{}, err
 	}
@@ -396,11 +401,18 @@ func buildAdminTrackedChatView(
 	defaultSource string,
 	sessions []*session.Session,
 ) admin.ChatView {
+	totalHistoryCount := len(sessions)
+	historyTruncated := false
+	if len(sessions) > adminChatHistorySessionLimit {
+		sessions = sessions[:adminChatHistorySessionLimit]
+		historyTruncated = true
+	}
 	history := make([]admin.ChatSessionView, 0, len(sessions))
-	for _, sess := range sessions {
+	for i, sess := range sessions {
 		history = append(history, admin.ChatSessionView{
 			SessionID:    strings.TrimSpace(sess.ID),
 			LastActivity: sessionActivityTime(sess),
+			Visible:      i < adminChatHistoryVisibleCount,
 		})
 	}
 	currentSessionID := ""
@@ -418,6 +430,8 @@ func buildAdminTrackedChatView(
 		LastActivity:       lastActivity,
 		EffectiveAssistant: strings.TrimSpace(defaultName),
 		NameSource:         strings.TrimSpace(defaultSource),
+		HistoryTotalCount:  totalHistoryCount,
+		HistoryTruncated:   historyTruncated,
 		History:            history,
 	}
 }
@@ -427,17 +441,19 @@ func buildAdminChatTranscript(
 	sessionSvc session.Service,
 	baseSessionID string,
 	sessions []*session.Session,
-) ([]admin.ChatTranscriptView, error) {
+) ([]admin.ChatTranscriptView, bool, error) {
 	if strings.TrimSpace(appName) == "" || sessionSvc == nil ||
 		strings.TrimSpace(baseSessionID) == "" || len(sessions) == 0 {
-		return nil, nil
+		return nil, false, nil
 	}
+	truncated := false
 	if len(sessions) > adminChatTranscriptSessionLimit {
 		sessions = sessions[:adminChatTranscriptSessionLimit]
+		truncated = true
 	}
 	transcript := make([]admin.ChatTranscriptView, 0, len(sessions))
 	currentSessionID := strings.TrimSpace(sessions[0].ID)
-	for _, sess := range sessions {
+	for i, sess := range sessions {
 		view, ok, err := buildAdminChatTranscriptView(
 			appName,
 			sessionSvc,
@@ -446,17 +462,19 @@ func buildAdminChatTranscript(
 			sess,
 		)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		if !ok {
 			continue
 		}
+		view.Visible = i < adminChatTranscriptVisibleCount ||
+			view.Current || view.Recall
 		transcript = append(transcript, view)
 	}
 	if len(transcript) == 0 {
-		return nil, nil
+		return nil, truncated, nil
 	}
-	return transcript, nil
+	return transcript, truncated, nil
 }
 
 func buildAdminChatTranscriptView(
@@ -519,6 +537,9 @@ func buildAdminChatTranscriptView(
 	}
 	if len(mapped) == 0 {
 		return admin.ChatTranscriptView{}, false, nil
+	}
+	for i := range mapped {
+		mapped[i].Visible = i >= len(mapped)-adminChatTranscriptTurnVisible
 	}
 	return admin.ChatTranscriptView{
 		SessionID:    sessionID,

--- a/openclaw/app/admin_identity.go
+++ b/openclaw/app/admin_identity.go
@@ -275,12 +275,15 @@ func (p *adminChatsProvider) ChatDetail(
 		identityDefaultNameSource(identity),
 		sessions,
 	)
-	detail.Transcript = buildAdminChatTranscript(
+	detail.Transcript, err = buildAdminChatTranscript(
 		strings.TrimSpace(p.appName),
 		p.session,
 		baseSessionID,
 		sessions,
 	)
+	if err != nil {
+		return admin.ChatView{}, err
+	}
 	return detail, nil
 }
 
@@ -424,10 +427,10 @@ func buildAdminChatTranscript(
 	sessionSvc session.Service,
 	baseSessionID string,
 	sessions []*session.Session,
-) []admin.ChatTranscriptView {
+) ([]admin.ChatTranscriptView, error) {
 	if strings.TrimSpace(appName) == "" || sessionSvc == nil ||
 		strings.TrimSpace(baseSessionID) == "" || len(sessions) == 0 {
-		return nil
+		return nil, nil
 	}
 	if len(sessions) > adminChatTranscriptSessionLimit {
 		sessions = sessions[:adminChatTranscriptSessionLimit]
@@ -435,22 +438,25 @@ func buildAdminChatTranscript(
 	transcript := make([]admin.ChatTranscriptView, 0, len(sessions))
 	currentSessionID := strings.TrimSpace(sessions[0].ID)
 	for _, sess := range sessions {
-		view, ok := buildAdminChatTranscriptView(
+		view, ok, err := buildAdminChatTranscriptView(
 			appName,
 			sessionSvc,
 			baseSessionID,
 			currentSessionID,
 			sess,
 		)
+		if err != nil {
+			return nil, err
+		}
 		if !ok {
 			continue
 		}
 		transcript = append(transcript, view)
 	}
 	if len(transcript) == 0 {
-		return nil
+		return nil, nil
 	}
-	return transcript
+	return transcript, nil
 }
 
 func buildAdminChatTranscriptView(
@@ -459,13 +465,13 @@ func buildAdminChatTranscriptView(
 	baseSessionID string,
 	currentSessionID string,
 	sessionMeta *session.Session,
-) (admin.ChatTranscriptView, bool) {
+) (admin.ChatTranscriptView, bool, error) {
 	if sessionMeta == nil {
-		return admin.ChatTranscriptView{}, false
+		return admin.ChatTranscriptView{}, false, nil
 	}
 	sessionID := strings.TrimSpace(sessionMeta.ID)
 	if sessionID == "" {
-		return admin.ChatTranscriptView{}, false
+		return admin.ChatTranscriptView{}, false, nil
 	}
 	sess, err := sessionSvc.GetSession(
 		context.Background(),
@@ -475,8 +481,18 @@ func buildAdminChatTranscriptView(
 			SessionID: sessionID,
 		},
 	)
-	if err != nil || sess == nil {
-		return admin.ChatTranscriptView{}, false
+	if err != nil {
+		return admin.ChatTranscriptView{}, false, fmt.Errorf(
+			"load chat transcript for %q: %w",
+			sessionID,
+			err,
+		)
+	}
+	if sess == nil {
+		return admin.ChatTranscriptView{}, false, fmt.Errorf(
+			"load chat transcript for %q: session not found",
+			sessionID,
+		)
 	}
 
 	turns := conversation.BuildTurns(sess, conversation.TurnOptions{})
@@ -502,7 +518,7 @@ func buildAdminChatTranscriptView(
 		})
 	}
 	if len(mapped) == 0 {
-		return admin.ChatTranscriptView{}, false
+		return admin.ChatTranscriptView{}, false, nil
 	}
 	return admin.ChatTranscriptView{
 		SessionID:    sessionID,
@@ -510,7 +526,7 @@ func buildAdminChatTranscriptView(
 		Current:      sessionID == strings.TrimSpace(currentSessionID),
 		Truncated:    truncated,
 		Turns:        mapped,
-	}, true
+	}, true, nil
 }
 
 func trimAdminChatTranscriptText(text string) string {

--- a/openclaw/app/admin_server.go
+++ b/openclaw/app/admin_server.go
@@ -21,6 +21,8 @@ import (
 	"syscall"
 	"time"
 
+	"trpc.group/trpc-go/trpc-agent-go/session"
+
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/admin"
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/channel"
 	ocbrowser "trpc.group/trpc-go/trpc-agent-go/openclaw/internal/browser"
@@ -126,6 +128,7 @@ func buildAdminConfig(
 	skillsRepo *ocskills.Repository,
 	skillsWatch *ocskills.WatchService,
 	memoryFiles admin.MemoryFileStore,
+	sessionSvc session.Service,
 ) admin.Config {
 	identity := buildAdminIdentityProvider(
 		stateDir,
@@ -163,8 +166,12 @@ func buildAdminConfig(
 			opts,
 			promptController,
 		),
-		Identity:    identity,
-		Chats:       buildAdminChatsProvider(identity),
+		Identity: identity,
+		Chats: buildAdminChatsProvider(
+			identity,
+			opts.AppName,
+			sessionSvc,
+		),
 		MemoryFiles: memoryFiles,
 		Browser: buildBrowserAdminConfig(
 			opts.ToolProviders,

--- a/openclaw/app/admin_server_test.go
+++ b/openclaw/app/admin_server_test.go
@@ -644,6 +644,36 @@ func TestAdminChatsProvider_ViewsAndTranscriptHelpers(t *testing.T) {
 	require.Empty(t, chat.CurrentSessionID)
 	require.True(t, chat.LastActivity.IsZero())
 	require.Empty(t, chat.History)
+	require.Zero(t, chat.HistoryTotalCount)
+	require.False(t, chat.HistoryTruncated)
+
+	manySessions := make([]*session.Session, 0, adminChatHistorySessionLimit+2)
+	for i := 0; i < adminChatHistorySessionLimit+2; i++ {
+		manySessions = append(manySessions, &session.Session{
+			ID:        fmt.Sprintf("chat-many:%02d", i),
+			UpdatedAt: time.Unix(int64(1700001000+i), 0).UTC(),
+		})
+	}
+	chat = buildAdminTrackedChatView(
+		"chat-many",
+		"Nora",
+		adminDefaultNameSourceFile,
+		manySessions,
+	)
+	require.Len(t, chat.History, adminChatHistorySessionLimit)
+	require.Equal(
+		t,
+		adminChatHistorySessionLimit+2,
+		chat.HistoryTotalCount,
+	)
+	require.True(t, chat.HistoryTruncated)
+	visibleHistory := 0
+	for _, item := range chat.History {
+		if item.Visible {
+			visibleHistory++
+		}
+	}
+	require.Equal(t, adminChatHistoryVisibleCount, visibleHistory)
 
 	require.True(t, sessionActivityTime(nil).IsZero())
 	require.Equal(t, time.Time{}, timeZero())
@@ -787,12 +817,52 @@ func TestAdminChatTranscriptHelpers_EdgeCases(t *testing.T) {
 	)
 
 	sessions := []*session.Session{current, middle, older, oldest}
+	for i := 0; i < adminChatTranscriptSessionLimit; i++ {
+		sessionID := fmt.Sprintf("sess-extra-%02d", i)
+		extra, err := baseSvc.CreateSession(
+			ctx,
+			session.Key{
+				AppName:   appName,
+				UserID:    baseID,
+				SessionID: sessionID,
+			},
+			nil,
+		)
+		require.NoError(t, err)
+		extra.CreatedAt = time.Unix(
+			1700000000-int64(i+10),
+			0,
+		).UTC()
+		require.NoError(
+			t,
+			baseSvc.AppendEvent(
+				ctx,
+				extra,
+				event.NewResponseEvent(
+					"inv",
+					"user",
+					&model.Response{
+						Choices: []model.Choice{{
+							Message: model.NewUserMessage(sessionID),
+						}},
+					},
+				),
+			),
+		)
+		sessions = append(sessions, extra)
+	}
 
-	transcript, err := buildAdminChatTranscript("", baseSvc, baseID, sessions)
+	transcript, truncated, err := buildAdminChatTranscript(
+		"",
+		baseSvc,
+		baseID,
+		sessions,
+	)
 	require.NoError(t, err)
 	require.Nil(t, transcript)
+	require.False(t, truncated)
 
-	transcript, err = buildAdminChatTranscript(
+	transcript, truncated, err = buildAdminChatTranscript(
 		appName,
 		nil,
 		baseID,
@@ -800,8 +870,9 @@ func TestAdminChatTranscriptHelpers_EdgeCases(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Nil(t, transcript)
+	require.False(t, truncated)
 
-	transcript, err = buildAdminChatTranscript(
+	transcript, truncated, err = buildAdminChatTranscript(
 		appName,
 		baseSvc,
 		"",
@@ -809,8 +880,9 @@ func TestAdminChatTranscriptHelpers_EdgeCases(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Nil(t, transcript)
+	require.False(t, truncated)
 
-	transcript, err = buildAdminChatTranscript(
+	transcript, truncated, err = buildAdminChatTranscript(
 		appName,
 		baseSvc,
 		baseID,
@@ -818,18 +890,30 @@ func TestAdminChatTranscriptHelpers_EdgeCases(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Nil(t, transcript)
+	require.False(t, truncated)
 
-	transcript, err = buildAdminChatTranscript(
+	transcript, truncated, err = buildAdminChatTranscript(
 		appName,
 		baseSvc,
 		baseID,
 		sessions,
 	)
 	require.NoError(t, err)
+	require.True(t, truncated)
 	require.Len(t, transcript, adminChatTranscriptSessionLimit)
 	require.True(t, transcript[0].Current)
+	require.True(t, transcript[0].Visible)
+	require.True(t, transcript[1].Visible)
+	require.False(t, transcript[2].Visible)
 	require.True(t, transcript[0].Truncated)
 	require.Len(t, transcript[0].Turns, adminChatTranscriptTurnLimit)
+	visibleTurns := 0
+	for _, turn := range transcript[0].Turns {
+		if turn.Visible {
+			visibleTurns++
+		}
+	}
+	require.Equal(t, adminChatTranscriptTurnVisible, visibleTurns)
 	require.Equal(
 		t,
 		"sess-current",

--- a/openclaw/app/admin_server_test.go
+++ b/openclaw/app/admin_server_test.go
@@ -12,8 +12,10 @@ package app
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -29,7 +31,10 @@ import (
 
 type transcriptErrorSessionService struct {
 	session.Service
-	getErr error
+	getErr     error
+	getNil     bool
+	listErr    error
+	listByUser map[string][]*session.Session
 }
 
 func (s transcriptErrorSessionService) GetSession(
@@ -40,7 +45,24 @@ func (s transcriptErrorSessionService) GetSession(
 	if s.getErr != nil {
 		return nil, s.getErr
 	}
+	if s.getNil {
+		return nil, nil
+	}
 	return s.Service.GetSession(ctx, key, options...)
+}
+
+func (s transcriptErrorSessionService) ListSessions(
+	ctx context.Context,
+	userKey session.UserKey,
+	options ...session.Option,
+) ([]*session.Session, error) {
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+	if s.listByUser != nil {
+		return s.listByUser[userKey.UserID], nil
+	}
+	return s.Service.ListSessions(ctx, userKey, options...)
 }
 
 func TestOpenAdminBinding_AutoPortFallback(t *testing.T) {
@@ -418,6 +440,10 @@ func TestAdminIdentityHelpers(t *testing.T) {
 	chatsStatus, err := nilChats.ChatsStatus()
 	require.NoError(t, err)
 	require.Equal(t, admin.ChatsStatus{}, chatsStatus)
+
+	_, err = nilChats.ChatDetail("chat-scope")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "chat provider is unavailable")
 }
 
 func TestAdminIdentityProvider_FallbackAndErrors(t *testing.T) {
@@ -455,4 +481,453 @@ func TestAdminIdentityProvider_FallbackAndErrors(t *testing.T) {
 	chats := buildAdminChatsProvider(badIdentity, "openclaw", nil)
 	_, err = chats.ChatsStatus()
 	require.Error(t, err)
+}
+
+func TestAdminChatsProvider_ViewsAndTranscriptHelpers(t *testing.T) {
+	t.Parallel()
+
+	baseSvc := sessioninmemory.NewSessionService()
+	now := time.Unix(1700000200, 0).UTC()
+	tie := time.Unix(1700000100, 0).UTC()
+
+	wrapper := transcriptErrorSessionService{
+		Service: baseSvc,
+		listByUser: map[string][]*session.Session{
+			"chat-new": {{
+				ID:        "chat-new:sess",
+				UserID:    "chat-new",
+				UpdatedAt: now,
+			}},
+			"chat-a": {{
+				ID:        "chat-a:sess",
+				UserID:    "chat-a",
+				CreatedAt: tie,
+			}},
+			"chat-b": {{
+				ID:        "chat-b:sess",
+				UserID:    "chat-b",
+				CreatedAt: tie,
+			}},
+			"chat-zero": {{
+				ID:     "chat-zero:sess",
+				UserID: "chat-zero",
+			}},
+			"chat-filter": {
+				nil,
+				{
+					UserID:    "chat-filter",
+					UpdatedAt: now,
+				},
+				{
+					ID:        "cron:job-1:123",
+					UserID:    "chat-filter",
+					UpdatedAt: now,
+				},
+				{
+					ID:        "chat-filter:old",
+					UserID:    "chat-filter",
+					CreatedAt: tie,
+				},
+				{
+					ID:        "chat-filter:new",
+					UserID:    "chat-filter",
+					UpdatedAt: now,
+				},
+			},
+			"chat-skip": {{
+				ID:     "cron:run:demo",
+				UserID: "chat-skip",
+			}},
+		},
+	}
+
+	ctx := context.Background()
+	for _, scope := range []string{
+		"chat-zero",
+		"chat-b",
+		"chat-new",
+		"chat-a",
+		"chat-skip",
+	} {
+		require.NoError(
+			t,
+			conversationscope.RememberIndexedStorageScope(
+				ctx,
+				wrapper,
+				"openclaw",
+				scope,
+			),
+		)
+	}
+
+	provider := buildAdminChatsProvider(
+		buildAdminIdentityProvider(t.TempDir(), "runtime-product"),
+		"openclaw",
+		wrapper,
+	)
+	require.NotNil(t, provider)
+
+	chats, err := provider.chatViews("Nora", adminDefaultNameSourceFile)
+	require.NoError(t, err)
+	require.Len(t, chats, 4)
+	require.Equal(t, "chat-new", chats[0].BaseSessionID)
+	require.Equal(t, "chat-a", chats[1].BaseSessionID)
+	require.Equal(t, "chat-b", chats[2].BaseSessionID)
+	require.Equal(t, "chat-zero", chats[3].BaseSessionID)
+	require.Equal(t, "Nora", chats[0].EffectiveAssistant)
+	require.Equal(t, adminChatKindTracked, chats[0].Kind)
+	require.Equal(t, adminChatKindLabel, chats[0].KindLabel)
+
+	emptySessions, err := provider.chatSessions("")
+	require.NoError(t, err)
+	require.Nil(t, emptySessions)
+
+	provider = buildAdminChatsProvider(
+		buildAdminIdentityProvider(t.TempDir(), "runtime-product"),
+		"",
+		wrapper,
+	)
+	emptySessions, err = provider.chatSessions("chat-new")
+	require.NoError(t, err)
+	require.Nil(t, emptySessions)
+
+	filteredSessions, err := buildAdminChatsProvider(
+		buildAdminIdentityProvider(t.TempDir(), "runtime-product"),
+		"openclaw",
+		wrapper,
+	).chatSessions("chat-filter")
+	require.NoError(t, err)
+	require.Len(t, filteredSessions, 2)
+	require.Equal(t, "chat-filter:new", filteredSessions[0].ID)
+	require.Equal(t, "chat-filter:old", filteredSessions[1].ID)
+
+	errorProvider := buildAdminChatsProvider(
+		buildAdminIdentityProvider(t.TempDir(), "runtime-product"),
+		"openclaw",
+		transcriptErrorSessionService{
+			Service: baseSvc,
+			listErr: errors.New("list boom"),
+		},
+	)
+	_, err = errorProvider.chatSessions("chat-new")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "list boom")
+	_, err = errorProvider.chatViews("Nora", adminDefaultNameSourceFile)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "list boom")
+	_, err = provider.ChatDetail("")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "chat_id is required")
+	_, err = buildAdminChatsProvider(
+		buildAdminIdentityProvider(t.TempDir(), "runtime-product"),
+		"openclaw",
+		baseSvc,
+	).ChatDetail("chat-missing")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "tracked chat not found")
+
+	emptyViews, err := buildAdminChatsProvider(
+		buildAdminIdentityProvider(t.TempDir(), "runtime-product"),
+		"openclaw",
+		baseSvc,
+	).chatViews("Nora", adminDefaultNameSourceFile)
+	require.NoError(t, err)
+	require.Nil(t, emptyViews)
+
+	chat := buildAdminTrackedChatView(
+		"chat-empty",
+		"Nora",
+		adminDefaultNameSourceFile,
+		nil,
+	)
+	require.Equal(t, "chat-empty", chat.BaseSessionID)
+	require.Empty(t, chat.CurrentSessionID)
+	require.True(t, chat.LastActivity.IsZero())
+	require.Empty(t, chat.History)
+
+	require.True(t, sessionActivityTime(nil).IsZero())
+	require.Equal(t, time.Time{}, timeZero())
+}
+
+func TestAdminChatTranscriptHelpers_EdgeCases(t *testing.T) {
+	t.Parallel()
+
+	baseSvc := sessioninmemory.NewSessionService()
+	ctx := context.Background()
+	const (
+		appName = "openclaw"
+		baseID  = "chat-scope"
+	)
+
+	current, err := baseSvc.CreateSession(
+		ctx,
+		session.Key{
+			AppName:   appName,
+			UserID:    baseID,
+			SessionID: "sess-current",
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	current.CreatedAt = time.Unix(1700000000, 0).UTC()
+	current.UpdatedAt = time.Unix(1700000300, 0).UTC()
+
+	longText := strings.Repeat("x", adminChatTranscriptTextLimit+5)
+	for i := 0; i < adminChatTranscriptTurnLimit+1; i++ {
+		evt := event.NewResponseEvent(
+			"inv",
+			"user",
+			&model.Response{
+				Choices: []model.Choice{{
+					Message: model.NewUserMessage(
+						fmt.Sprintf("turn-%02d", i),
+					),
+				}},
+			},
+		)
+		evt.Timestamp = time.Unix(int64(1700000300+i), 0).UTC()
+		if i == adminChatTranscriptTurnLimit {
+			evt = event.NewResponseEvent(
+				"inv",
+				"user",
+				&model.Response{
+					Choices: []model.Choice{{
+						Message: model.NewUserMessage(longText),
+					}},
+				},
+			)
+			evt.Timestamp = time.Unix(1700000500, 0).UTC()
+		}
+		require.NoError(t, baseSvc.AppendEvent(ctx, current, evt))
+	}
+
+	middle, err := baseSvc.CreateSession(
+		ctx,
+		session.Key{
+			AppName:   appName,
+			UserID:    baseID,
+			SessionID: "sess-middle",
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	middle.CreatedAt = time.Unix(1700000100, 0).UTC()
+	middle.UpdatedAt = time.Unix(1700000200, 0).UTC()
+	require.NoError(
+		t,
+		baseSvc.AppendEvent(
+			ctx,
+			middle,
+			event.NewResponseEvent(
+				"inv",
+				"user",
+				&model.Response{
+					Choices: []model.Choice{{
+						Message: model.NewUserMessage("middle"),
+					}},
+				},
+			),
+		),
+	)
+
+	older, err := baseSvc.CreateSession(
+		ctx,
+		session.Key{
+			AppName:   appName,
+			UserID:    baseID,
+			SessionID: "sess-older",
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	older.CreatedAt = time.Unix(1700000050, 0).UTC()
+	require.NoError(
+		t,
+		baseSvc.AppendEvent(
+			ctx,
+			older,
+			event.NewResponseEvent(
+				"inv",
+				"user",
+				&model.Response{
+					Choices: []model.Choice{{
+						Message: model.NewUserMessage("older"),
+					}},
+				},
+			),
+		),
+	)
+
+	oldest, err := baseSvc.CreateSession(
+		ctx,
+		session.Key{
+			AppName:   appName,
+			UserID:    baseID,
+			SessionID: "sess-oldest",
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	oldest.CreatedAt = time.Unix(1700000001, 0).UTC()
+	require.NoError(
+		t,
+		baseSvc.AppendEvent(
+			ctx,
+			oldest,
+			event.NewResponseEvent(
+				"inv",
+				"user",
+				&model.Response{
+					Choices: []model.Choice{{
+						Message: model.NewUserMessage("oldest"),
+					}},
+				},
+			),
+		),
+	)
+
+	sessions := []*session.Session{current, middle, older, oldest}
+
+	transcript, err := buildAdminChatTranscript("", baseSvc, baseID, sessions)
+	require.NoError(t, err)
+	require.Nil(t, transcript)
+
+	transcript, err = buildAdminChatTranscript(
+		appName,
+		nil,
+		baseID,
+		sessions,
+	)
+	require.NoError(t, err)
+	require.Nil(t, transcript)
+
+	transcript, err = buildAdminChatTranscript(
+		appName,
+		baseSvc,
+		"",
+		sessions,
+	)
+	require.NoError(t, err)
+	require.Nil(t, transcript)
+
+	transcript, err = buildAdminChatTranscript(
+		appName,
+		baseSvc,
+		baseID,
+		nil,
+	)
+	require.NoError(t, err)
+	require.Nil(t, transcript)
+
+	transcript, err = buildAdminChatTranscript(
+		appName,
+		baseSvc,
+		baseID,
+		sessions,
+	)
+	require.NoError(t, err)
+	require.Len(t, transcript, adminChatTranscriptSessionLimit)
+	require.True(t, transcript[0].Current)
+	require.True(t, transcript[0].Truncated)
+	require.Len(t, transcript[0].Turns, adminChatTranscriptTurnLimit)
+	require.Equal(
+		t,
+		"sess-current",
+		transcript[0].SessionID,
+	)
+	require.True(
+		t,
+		strings.HasSuffix(
+			transcript[0].Turns[len(transcript[0].Turns)-1].Text,
+			"...",
+		),
+	)
+	require.Equal(t, "sess-middle", transcript[1].SessionID)
+	require.Equal(t, "sess-older", transcript[2].SessionID)
+
+	view, ok, err := buildAdminChatTranscriptView(
+		appName,
+		baseSvc,
+		baseID,
+		"sess-current",
+		nil,
+	)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Equal(t, admin.ChatTranscriptView{}, view)
+
+	view, ok, err = buildAdminChatTranscriptView(
+		appName,
+		baseSvc,
+		baseID,
+		"sess-current",
+		&session.Session{},
+	)
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	nilSvc := transcriptErrorSessionService{
+		Service: baseSvc,
+		getNil:  true,
+	}
+	_, ok, err = buildAdminChatTranscriptView(
+		appName,
+		nilSvc,
+		baseID,
+		"sess-current",
+		&session.Session{ID: "sess-missing"},
+	)
+	require.Error(t, err)
+	require.False(t, ok)
+	require.Contains(t, err.Error(), "session not found")
+
+	blank, err := baseSvc.CreateSession(
+		ctx,
+		session.Key{
+			AppName:   appName,
+			UserID:    baseID,
+			SessionID: "sess-blank",
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	blank.CreatedAt = time.Unix(1700000400, 0).UTC()
+	require.NoError(
+		t,
+		baseSvc.AppendEvent(
+			ctx,
+			blank,
+			event.NewResponseEvent(
+				"inv",
+				"user",
+				&model.Response{
+					Choices: []model.Choice{{
+						Message: model.NewUserMessage(" "),
+					}},
+				},
+			),
+		),
+	)
+
+	blankView, ok, err := buildAdminChatTranscriptView(
+		appName,
+		baseSvc,
+		baseID,
+		"sess-current",
+		blank,
+	)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Equal(t, admin.ChatTranscriptView{}, blankView)
+
+	require.Empty(t, trimAdminChatTranscriptText("   "))
+	require.Equal(
+		t,
+		"hello",
+		trimAdminChatTranscriptText("  hello  "),
+	)
+	require.True(
+		t,
+		strings.HasSuffix(trimAdminChatTranscriptText(longText), "..."),
+	)
 }

--- a/openclaw/app/admin_server_test.go
+++ b/openclaw/app/admin_server_test.go
@@ -10,6 +10,7 @@
 package app
 
 import (
+	"context"
 	"net"
 	"path/filepath"
 	"testing"
@@ -17,7 +18,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/admin"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/conversationscope"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	sessioninmemory "trpc.group/trpc-go/trpc-agent-go/session/inmemory"
 )
 
 func TestOpenAdminBinding_AutoPortFallback(t *testing.T) {
@@ -101,6 +107,7 @@ nodes:
 		nil,
 		"127.0.0.1:8081",
 		"http://127.0.0.1:8081",
+		nil,
 		nil,
 		nil,
 		nil,
@@ -190,6 +197,52 @@ func TestBuildAdminConfig_IncludesIdentityAndChatsProviders(
 	t.Parallel()
 
 	stateDir := t.TempDir()
+	ctx := context.Background()
+	baseSessions := sessioninmemory.NewSessionService()
+	wrappedSessions := conversationscope.WrapSessionService(baseSessions)
+	_, err := wrappedSessions.CreateSession(
+		ctx,
+		session.Key{
+			AppName:   "openclaw",
+			UserID:    "chat-scope",
+			SessionID: "sess-1",
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	sess, err := wrappedSessions.GetSession(
+		ctx,
+		session.Key{
+			AppName:   "openclaw",
+			UserID:    "chat-scope",
+			SessionID: "sess-1",
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	userEvt := event.NewResponseEvent(
+		"inv",
+		"user",
+		&model.Response{
+			Choices: []model.Choice{{
+				Message: model.NewUserMessage("hello"),
+			}},
+		},
+	)
+	userEvt.Timestamp = time.Unix(1700000000, 0)
+	require.NoError(t, wrappedSessions.AppendEvent(ctx, sess, userEvt))
+	replyEvt := event.NewResponseEvent(
+		"inv",
+		"assistant",
+		&model.Response{
+			Choices: []model.Choice{{
+				Message: model.NewAssistantMessage("hi"),
+			}},
+		},
+	)
+	replyEvt.Timestamp = time.Unix(1700000010, 0)
+	require.NoError(t, wrappedSessions.AppendEvent(ctx, sess, replyEvt))
+
 	cfg := buildAdminConfig(
 		runOptions{
 			AppName: "openclaw",
@@ -211,6 +264,7 @@ func TestBuildAdminConfig_IncludesIdentityAndChatsProviders(
 		nil,
 		nil,
 		nil,
+		wrappedSessions,
 	)
 
 	require.NotNil(t, cfg.Identity)
@@ -251,7 +305,18 @@ func TestBuildAdminConfig_IncludesIdentityAndChatsProviders(
 		chatsStatus.GlobalAssistantSource,
 	)
 	require.Contains(t, chatsStatus.ChatOverrideHelp, "default name")
-	require.Empty(t, chatsStatus.Chats)
+	require.Len(t, chatsStatus.Chats, 1)
+	require.Equal(t, "chat-scope", chatsStatus.Chats[0].BaseSessionID)
+	require.Equal(t, "sess-1", chatsStatus.Chats[0].CurrentSessionID)
+
+	detailProvider, ok := cfg.Chats.(admin.ChatDetailProvider)
+	require.True(t, ok)
+	detail, err := detailProvider.ChatDetail("chat-scope")
+	require.NoError(t, err)
+	require.Len(t, detail.Transcript, 1)
+	require.Len(t, detail.Transcript[0].Turns, 2)
+	require.Equal(t, "hello", detail.Transcript[0].Turns[0].Text)
+	require.Equal(t, "hi", detail.Transcript[0].Turns[1].Text)
 }
 
 func TestNormalizeAdminAssistantName(t *testing.T) {
@@ -273,7 +338,7 @@ func TestNormalizeAdminAssistantName(t *testing.T) {
 func TestAdminIdentityHelpers(t *testing.T) {
 	t.Parallel()
 
-	require.Nil(t, buildAdminChatsProvider(nil))
+	require.Nil(t, buildAdminChatsProvider(nil, "", nil))
 	require.Equal(t, appName, defaultAdminRuntimeProduct(" "))
 	require.Equal(
 		t,
@@ -338,7 +403,7 @@ func TestAdminIdentityProvider_FallbackAndErrors(t *testing.T) {
 	_, err = badIdentity.IdentityStatus()
 	require.Error(t, err)
 
-	chats := buildAdminChatsProvider(badIdentity)
+	chats := buildAdminChatsProvider(badIdentity, "openclaw", nil)
 	_, err = chats.ChatsStatus()
 	require.Error(t, err)
 }

--- a/openclaw/app/admin_server_test.go
+++ b/openclaw/app/admin_server_test.go
@@ -11,6 +11,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"net"
 	"path/filepath"
 	"testing"
@@ -25,6 +26,22 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	sessioninmemory "trpc.group/trpc-go/trpc-agent-go/session/inmemory"
 )
+
+type transcriptErrorSessionService struct {
+	session.Service
+	getErr error
+}
+
+func (s transcriptErrorSessionService) GetSession(
+	ctx context.Context,
+	key session.Key,
+	options ...session.Option,
+) (*session.Session, error) {
+	if s.getErr != nil {
+		return nil, s.getErr
+	}
+	return s.Service.GetSession(ctx, key, options...)
+}
 
 func TestOpenAdminBinding_AutoPortFallback(t *testing.T) {
 	t.Parallel()
@@ -317,6 +334,38 @@ func TestBuildAdminConfig_IncludesIdentityAndChatsProviders(
 	require.Len(t, detail.Transcript[0].Turns, 2)
 	require.Equal(t, "hello", detail.Transcript[0].Turns[0].Text)
 	require.Equal(t, "hi", detail.Transcript[0].Turns[1].Text)
+
+	cfg = buildAdminConfig(
+		runOptions{
+			AppName: "openclaw",
+		},
+		agentTypeLLM,
+		"instance-1",
+		admin.LangfuseStatus{},
+		stateDir,
+		filepath.Join(stateDir, "debug"),
+		time.Unix(0, 0),
+		nil,
+		admin.Routes{},
+		nil,
+		nil,
+		nil,
+		nil,
+		"127.0.0.1:8081",
+		"http://127.0.0.1:8081",
+		nil,
+		nil,
+		nil,
+		transcriptErrorSessionService{
+			Service: wrappedSessions,
+			getErr:  errors.New("transcript boom"),
+		},
+	)
+	detailProvider, ok = cfg.Chats.(admin.ChatDetailProvider)
+	require.True(t, ok)
+	_, err = detailProvider.ChatDetail("chat-scope")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "transcript boom")
 }
 
 func TestNormalizeAdminAssistantName(t *testing.T) {

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -1044,6 +1044,7 @@ func NewRuntime(
 			skillsRepo,
 			skillsWatch,
 			fileMemoryStore,
+			rt.SessionService(),
 		)
 		rt.applyAdminConfig(adminCfg)
 	}
@@ -1528,6 +1529,7 @@ func run(ctx context.Context, args []string) error {
 			skillsRepo,
 			skillsWatch,
 			fileMemoryStore,
+			bridgedSessionSvc,
 		))
 		adminSrv = &http.Server{
 			Handler:           adminSvc.Handler(),

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -46,6 +46,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/model/openai"
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/conversation"
 	"trpc.group/trpc-go/trpc-agent-go/runner"
+	"trpc.group/trpc-go/trpc-agent-go/session"
 	sessioninmemory "trpc.group/trpc-go/trpc-agent-go/session/inmemory"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 
@@ -469,6 +470,8 @@ type Runtime struct {
 	Channels []channel.Channel
 	prompts  *RuntimePromptController
 	adminCfg *admin.Config
+	appName  string
+	session  session.Service
 
 	runner            runner.Runner
 	cronRunner        closeFunc
@@ -534,6 +537,20 @@ func (r *Runtime) PromptController() *RuntimePromptController {
 		return nil
 	}
 	return r.prompts
+}
+
+func (r *Runtime) AppName() string {
+	if r == nil {
+		return ""
+	}
+	return strings.TrimSpace(r.appName)
+}
+
+func (r *Runtime) SessionService() session.Service {
+	if r == nil {
+		return nil
+	}
+	return r.session
 }
 
 func (r *Runtime) ConfigureAdmin(
@@ -706,6 +723,7 @@ func NewRuntime(
 		resolvedStateDir,
 	)
 	log.Infof("Instance: %s", instanceID)
+	rt.appName = opts.AppName
 
 	sessionSvc, err := newSessionService(mdl, opts)
 	if err != nil {
@@ -846,6 +864,7 @@ func NewRuntime(
 	rt.skillsWatch = skillsWatch
 
 	bridgedSessionSvc := conversationscope.WrapSessionService(sessionSvc)
+	rt.session = bridgedSessionSvc
 	runnerOpts := []runner.Option{
 		runner.WithSessionService(bridgedSessionSvc),
 		runner.WithPlugins(conversation.Plugin{}),

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -319,11 +319,20 @@ func TestRuntimePromptControllerMethod(t *testing.T) {
 	t.Parallel()
 
 	ctrl := &RuntimePromptController{}
-	rt := &Runtime{prompts: ctrl}
+	sessSvc := sessioninmemory.NewSessionService()
+	rt := &Runtime{
+		prompts: ctrl,
+		appName: "openclaw",
+		session: sessSvc,
+	}
 	require.Same(t, ctrl, rt.PromptController())
+	require.Equal(t, "openclaw", rt.AppName())
+	require.Same(t, sessSvc, rt.SessionService())
 
 	var nilRuntime *Runtime
 	require.Nil(t, nilRuntime.PromptController())
+	require.Empty(t, nilRuntime.AppName())
+	require.Nil(t, nilRuntime.SessionService())
 }
 
 func TestRuntimeConfigureAdmin(t *testing.T) {

--- a/openclaw/internal/conversationscope/index.go
+++ b/openclaw/internal/conversationscope/index.go
@@ -18,6 +18,7 @@ import (
 )
 
 const storageUserStatePrefix = "openclaw.conversation_storage_user:"
+const storageScopeStatePrefix = "openclaw.conversation_storage_scope:"
 
 var storageUserStateValue = []byte("1")
 
@@ -83,6 +84,52 @@ func ListIndexedStorageUsers(
 	return indexedStorageUsersFromState(state), nil
 }
 
+// RememberIndexedStorageScope records one persisted conversation scope at
+// app level so admin surfaces can enumerate known chats.
+func RememberIndexedStorageScope(
+	ctx context.Context,
+	svc session.Service,
+	appName string,
+	storageUserID string,
+) error {
+	if svc == nil {
+		return nil
+	}
+	appName = strings.TrimSpace(appName)
+	storageUserID = strings.TrimSpace(storageUserID)
+	if appName == "" || storageUserID == "" {
+		return nil
+	}
+	return svc.UpdateAppState(
+		ctx,
+		appName,
+		session.StateMap{
+			storageScopeStateKey(storageUserID): storageUserStateValue,
+		},
+	)
+}
+
+// ListIndexedStorageScopes lists persisted conversation scopes remembered
+// for the application.
+func ListIndexedStorageScopes(
+	ctx context.Context,
+	svc session.Service,
+	appName string,
+) ([]string, error) {
+	if svc == nil {
+		return nil, nil
+	}
+	appName = strings.TrimSpace(appName)
+	if appName == "" {
+		return nil, nil
+	}
+	state, err := svc.ListAppStates(ctx, appName)
+	if err != nil {
+		return nil, err
+	}
+	return indexedStorageScopesFromState(state), nil
+}
+
 // DeleteIndexedStorageUser removes one remembered storage scope index.
 func DeleteIndexedStorageUser(
 	ctx context.Context,
@@ -139,10 +186,47 @@ func indexedStorageUsersFromState(state session.StateMap) []string {
 	return out
 }
 
+func indexedStorageScopesFromState(state session.StateMap) []string {
+	if len(state) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(state))
+	out := make([]string, 0, len(state))
+	for key, value := range state {
+		if value == nil || !strings.HasPrefix(key, storageScopeStatePrefix) {
+			continue
+		}
+		storageUserID := strings.TrimSpace(
+			strings.TrimPrefix(key, storageScopeStatePrefix),
+		)
+		if storageUserID == "" {
+			continue
+		}
+		if _, ok := seen[storageUserID]; ok {
+			continue
+		}
+		seen[storageUserID] = struct{}{}
+		out = append(out, storageUserID)
+	}
+	sort.Strings(out)
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 func storageUserStateKey(storageUserID string) string {
 	storageUserID = strings.TrimSpace(storageUserID)
 	if storageUserID == "" {
 		return ""
 	}
 	return storageUserStatePrefix + storageUserID
+}
+
+func storageScopeStateKey(storageUserID string) string {
+	storageUserID = strings.TrimSpace(storageUserID)
+	if storageUserID == "" {
+		return ""
+	}
+	return storageScopeStatePrefix + storageUserID
 }

--- a/openclaw/internal/conversationscope/session_service.go
+++ b/openclaw/internal/conversationscope/session_service.go
@@ -53,6 +53,17 @@ func (s *sessionService) CreateSession(
 			err,
 		)
 	}
+	if err := RememberIndexedStorageScope(
+		ctx,
+		s.next,
+		key.AppName,
+		storageKey.UserID,
+	); err != nil {
+		return nil, fmt.Errorf(
+			"remember indexed storage scope for create session: %w",
+			err,
+		)
+	}
 	return rewriteSessionForUser(sess, key.UserID), nil
 }
 
@@ -75,6 +86,17 @@ func (s *sessionService) GetSession(
 	); err != nil {
 		return nil, fmt.Errorf(
 			"remember indexed storage user for get session: %w",
+			err,
+		)
+	}
+	if err := RememberIndexedStorageScope(
+		ctx,
+		s.next,
+		key.AppName,
+		storageKey.UserID,
+	); err != nil {
+		return nil, fmt.Errorf(
+			"remember indexed storage scope for get session: %w",
 			err,
 		)
 	}

--- a/openclaw/internal/conversationscope/session_service.go
+++ b/openclaw/internal/conversationscope/session_service.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 
 	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 )
 
@@ -59,8 +60,11 @@ func (s *sessionService) CreateSession(
 		key.AppName,
 		storageKey.UserID,
 	); err != nil {
-		return nil, fmt.Errorf(
-			"remember indexed storage scope for create session: %w",
+		log.Warnf(
+			"conversation scope: skip create-session scope index "+
+				"%q/%q: %v",
+			key.AppName,
+			storageKey.UserID,
 			err,
 		)
 	}
@@ -95,8 +99,11 @@ func (s *sessionService) GetSession(
 		key.AppName,
 		storageKey.UserID,
 	); err != nil {
-		return nil, fmt.Errorf(
-			"remember indexed storage scope for get session: %w",
+		log.Warnf(
+			"conversation scope: skip get-session scope index "+
+				"%q/%q: %v",
+			key.AppName,
+			storageKey.UserID,
 			err,
 		)
 	}

--- a/openclaw/internal/conversationscope/session_service_test.go
+++ b/openclaw/internal/conversationscope/session_service_test.go
@@ -40,9 +40,12 @@ type recordingSessionService struct {
 	deleteKey           session.Key
 	updateAppName       string
 	updateAppState      session.StateMap
+	updateAppStateErr   error
 	deleteAppName       string
 	deleteAppKey        string
 	listAppName         string
+	listAppStates       session.StateMap
+	listAppStatesErr    error
 	updateUserKey       session.UserKey
 	updateUserState     session.StateMap
 	updateUserStateErr  error
@@ -139,7 +142,7 @@ func (r *recordingSessionService) UpdateAppState(
 ) error {
 	r.updateAppName = appName
 	r.updateAppState = state
-	return nil
+	return r.updateAppStateErr
 }
 
 func (r *recordingSessionService) DeleteAppState(
@@ -157,6 +160,12 @@ func (r *recordingSessionService) ListAppStates(
 	appName string,
 ) (session.StateMap, error) {
 	r.listAppName = appName
+	if r.listAppStatesErr != nil {
+		return nil, r.listAppStatesErr
+	}
+	if r.listAppStates != nil {
+		return r.listAppStates, nil
+	}
 	return session.StateMap{"a": []byte("b")}, nil
 }
 
@@ -519,6 +528,32 @@ func TestIndexedStorageUsersLifecycle(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Equal(t, []string{"chat-scope-2"}, storageUsers)
+
+	require.NoError(
+		t,
+		RememberIndexedStorageScope(
+			context.Background(),
+			svc,
+			"demo-app",
+			"chat-scope",
+		),
+	)
+	require.NoError(
+		t,
+		RememberIndexedStorageScope(
+			context.Background(),
+			svc,
+			"demo-app",
+			"chat-scope-2",
+		),
+	)
+	scopes, err := ListIndexedStorageScopes(
+		context.Background(),
+		svc,
+		"demo-app",
+	)
+	require.NoError(t, err)
+	require.Equal(t, []string{"chat-scope", "chat-scope-2"}, scopes)
 }
 
 func TestIndexedStorageUsersHelpers_EdgeCases(t *testing.T) {
@@ -597,6 +632,7 @@ func TestIndexedStorageUsersHelpers_EdgeCases(t *testing.T) {
 	require.Contains(t, err.Error(), "delete boom")
 
 	require.Nil(t, indexedStorageUsersFromState(nil))
+	require.Nil(t, indexedStorageScopesFromState(nil))
 	require.Equal(
 		t,
 		[]string{"a", "z"},
@@ -608,7 +644,53 @@ func TestIndexedStorageUsersHelpers_EdgeCases(t *testing.T) {
 			"other":                        []byte("1"),
 		}),
 	)
+	require.Equal(
+		t,
+		[]string{"a", "z"},
+		indexedStorageScopesFromState(session.StateMap{
+			storageScopeStatePrefix + " z ": []byte("1"),
+			storageScopeStatePrefix + "a":   []byte("1"),
+			storageScopeStatePrefix + " a ": []byte("1"),
+			storageScopeStatePrefix + "b":   nil,
+			"other":                         []byte("1"),
+		}),
+	)
 	require.Equal(t, "", storageUserStateKey("   "))
+	require.Equal(t, "", storageScopeStateKey("   "))
+
+	require.NoError(
+		t,
+		RememberIndexedStorageScope(
+			context.Background(),
+			nil,
+			"demo-app",
+			"chat-scope",
+		),
+	)
+	scopes, err := ListIndexedStorageScopes(
+		context.Background(),
+		nil,
+		"demo-app",
+	)
+	require.NoError(t, err)
+	require.Nil(t, scopes)
+
+	scopes, err = ListIndexedStorageScopes(
+		context.Background(),
+		sessioninmemory.NewSessionService(),
+		" ",
+	)
+	require.NoError(t, err)
+	require.Nil(t, scopes)
+
+	rec.listAppStatesErr = errors.New("app list boom")
+	_, err = ListIndexedStorageScopes(
+		context.Background(),
+		rec,
+		"demo-app",
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "app list boom")
 }
 
 func TestWrapSessionService_DelegatesAdministrativeMethods(t *testing.T) {
@@ -865,6 +947,36 @@ func TestWrapSessionService_CreateSession_PropagatesIndexingError(t *testing.T) 
 	require.Contains(t, err.Error(), "index boom")
 }
 
+func TestWrapSessionService_CreateSession_PropagatesScopeIndexError(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	rec := &recordingSessionService{
+		updateAppStateErr: errors.New("scope boom"),
+	}
+	wrapped := WrapSessionService(rec)
+
+	sess, err := wrapped.CreateSession(
+		WithStorageUserID(context.Background(), "chat-scope"),
+		session.Key{
+			AppName:   "demo-app",
+			UserID:    "canonical-user",
+			SessionID: "sess-1",
+		},
+		nil,
+	)
+	require.Error(t, err)
+	require.Nil(t, sess)
+	require.Equal(t, "demo-app", rec.updateAppName)
+	require.Contains(
+		t,
+		err.Error(),
+		"remember indexed storage scope for create session",
+	)
+	require.Contains(t, err.Error(), "scope boom")
+}
+
 func TestWrapSessionService_GetSession_PropagatesIndexingError(t *testing.T) {
 	t.Parallel()
 
@@ -894,4 +1006,33 @@ func TestWrapSessionService_GetSession_PropagatesIndexingError(t *testing.T) {
 		"remember indexed storage user for get session",
 	)
 	require.Contains(t, err.Error(), "index boom")
+}
+
+func TestWrapSessionService_GetSession_PropagatesScopeIndexError(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	rec := &recordingSessionService{
+		updateAppStateErr: errors.New("scope boom"),
+	}
+	wrapped := WrapSessionService(rec)
+
+	sess, err := wrapped.GetSession(
+		WithStorageUserID(context.Background(), "chat-scope"),
+		session.Key{
+			AppName:   "demo-app",
+			UserID:    "canonical-user",
+			SessionID: "sess-1",
+		},
+	)
+	require.Error(t, err)
+	require.Nil(t, sess)
+	require.Equal(t, "demo-app", rec.updateAppName)
+	require.Contains(
+		t,
+		err.Error(),
+		"remember indexed storage scope for get session",
+	)
+	require.Contains(t, err.Error(), "scope boom")
 }

--- a/openclaw/internal/conversationscope/session_service_test.go
+++ b/openclaw/internal/conversationscope/session_service_test.go
@@ -947,7 +947,7 @@ func TestWrapSessionService_CreateSession_PropagatesIndexingError(t *testing.T) 
 	require.Contains(t, err.Error(), "index boom")
 }
 
-func TestWrapSessionService_CreateSession_PropagatesScopeIndexError(
+func TestWrapSessionService_CreateSession_IgnoresScopeIndexError(
 	t *testing.T,
 ) {
 	t.Parallel()
@@ -966,15 +966,10 @@ func TestWrapSessionService_CreateSession_PropagatesScopeIndexError(
 		},
 		nil,
 	)
-	require.Error(t, err)
-	require.Nil(t, sess)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
 	require.Equal(t, "demo-app", rec.updateAppName)
-	require.Contains(
-		t,
-		err.Error(),
-		"remember indexed storage scope for create session",
-	)
-	require.Contains(t, err.Error(), "scope boom")
+	require.Equal(t, "canonical-user", sess.UserID)
 }
 
 func TestWrapSessionService_GetSession_PropagatesIndexingError(t *testing.T) {
@@ -1008,7 +1003,7 @@ func TestWrapSessionService_GetSession_PropagatesIndexingError(t *testing.T) {
 	require.Contains(t, err.Error(), "index boom")
 }
 
-func TestWrapSessionService_GetSession_PropagatesScopeIndexError(
+func TestWrapSessionService_GetSession_IgnoresScopeIndexError(
 	t *testing.T,
 ) {
 	t.Parallel()
@@ -1026,13 +1021,8 @@ func TestWrapSessionService_GetSession_PropagatesScopeIndexError(
 			SessionID: "sess-1",
 		},
 	)
-	require.Error(t, err)
-	require.Nil(t, sess)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
 	require.Equal(t, "demo-app", rec.updateAppName)
-	require.Contains(
-		t,
-		err.Error(),
-		"remember indexed storage scope for get session",
-	)
-	require.Contains(t, err.Error(), "scope boom")
+	require.Equal(t, "canonical-user", sess.UserID)
 }


### PR DESCRIPTION
## What changed
- redesign the shared admin `Chats` view around `Overview`, `History`, and `Actions`
- add a shared `ChatDetailProvider` interface so downstream runtimes can supply richer per-chat details lazily
- extend the chat detail model with bounded transcript sections and turn-level rendering helpers
- expose runtime app/session accessors needed by downstream chat detail providers

## Why
The current `Chats` page only shows chat state. It does not help answer what happened in a specific chat without dropping into debug artifacts. This change keeps `Chats` as the production-chat entry point, then adds a bounded transcript view without turning the page into an unbounded raw transcript browser.

## Impact
- shared admin users get a clearer `Chats` experience with state, bounded history, and next-step guidance
- downstream runtimes can add real chat history without changing the shared template structure again
- no existing provider is forced to implement transcript support; the detail path is optional

## Validation
- `go test ./admin ./app`
- `go test ./...`
