### PR TITLE
{docs, examples}: add streamtool example and streaming tool guidance

### DIFF
--- a/docs/mkdocs/en/agui.md
+++ b/docs/mkdocs/en/agui.md
@@ -1093,3 +1093,28 @@ The effect is shown below. For a full example, refer to
 [examples/agui/server/report](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/server/report). The corresponding client implementation lives in [examples/agui/client/tdesign-chat](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/client/tdesign-chat).
 
 ![report](../assets/gif/agui/report.gif)
+
+### Streaming Tool Execution Results
+
+When a tool runs on the server and the frontend needs to show execution progress continuously, it is helpful to separate the event stream into three layers. `TOOL_CALL_START`, `TOOL_CALL_ARGS`, and `TOOL_CALL_END` describe the tool invocation itself. `ACTIVITY_SNAPSHOT` and `ACTIVITY_DELTA` carry progress, phases, or intermediate status during execution. `TOOL_CALL_RESULT` remains the final tool result. This gives the frontend a clear boundary between in-progress state and the completed result, while keeping Message Snapshot replay aligned with the standard tool-result semantics.
+
+A typical event stream looks like this:
+
+```text
+RUN_STARTED
+→ TOOL_CALL_START
+→ TOOL_CALL_ARGS
+→ TOOL_CALL_END
+→ ACTIVITY_SNAPSHOT
+→ ACTIVITY_DELTA
+→ ACTIVITY_DELTA
+→ ...
+→ ACTIVITY_DELTA   # completed
+→ TOOL_CALL_RESULT
+→ TEXT_MESSAGE_*
+→ RUN_FINISHED
+```
+
+In practice, this is usually implemented by wrapping the default Translator. The default Translator continues to handle the standard `TOOL_CALL_*` events and the final `TOOL_CALL_RESULT`. The custom layer only rewrites intermediate tool-result updates. A robust approach is to iterate over the `innerEvents` returned by the default Translator and examine each event in order. Non-target events pass through unchanged. A target `ToolCallResultEvent` can be rewritten into `ACTIVITY_SNAPSHOT` or `ACTIVITY_DELTA` while the tool is still running. When the tool finishes, a completed `ACTIVITY_DELTA` can be inserted immediately before the original `TOOL_CALL_RESULT`. This keeps the default behavior intact for text events, graph activity events, and other tool events.
+
+For a complete example, see [examples/agui/server/streamtool](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/server/streamtool). The example uses a minimal `StreamableTool` that emits incrementing numbers and a custom Translator that turns partial `tool.response` updates into `tool.execution` activity events while preserving the final `TOOL_CALL_RESULT`.

--- a/docs/mkdocs/zh/agui.md
+++ b/docs/mkdocs/zh/agui.md
@@ -1102,3 +1102,28 @@ server, err := agui.New(
 实际效果如下图所示，完整示例可参考 [examples/agui/server/report](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/server/report)，前端实现可参考 [examples/agui/client/tdesign-chat](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/client/tdesign-chat)。
 
 ![report](../assets/gif/agui/report.gif)
+
+### 流式工具执行结果
+
+当工具在服务端执行，且前端需要持续展示执行中的状态时，可以将事件流分成三层来组织。`TOOL_CALL_START`、`TOOL_CALL_ARGS`、`TOOL_CALL_END` 用于描述工具调用本身，`ACTIVITY_SNAPSHOT`、`ACTIVITY_DELTA` 用于承载执行过程中的进度、阶段或日志，`TOOL_CALL_RESULT` 则保留给最终工具结果。这样前端可以分别渲染执行中的状态和最终结果，消息快照回放时也能继续依赖标准的工具结果语义。
+
+推荐的事件流大致如下：
+
+```text
+RUN_STARTED
+→ TOOL_CALL_START
+→ TOOL_CALL_ARGS
+→ TOOL_CALL_END
+→ ACTIVITY_SNAPSHOT
+→ ACTIVITY_DELTA
+→ ACTIVITY_DELTA
+→ ...
+→ ACTIVITY_DELTA   # completed
+→ TOOL_CALL_RESULT
+→ TEXT_MESSAGE_*
+→ RUN_FINISHED
+```
+
+在实现上，通常可以通过自定义 Translator 包装默认 Translator。默认 Translator 继续负责标准 `TOOL_CALL_*` 与最终 `TOOL_CALL_RESULT` 的翻译，自定义部分只处理工具执行过程中的中间结果。比较稳妥的写法是遍历默认 Translator 返回的 `innerEvents`，逐个判断事件类型，并仅对目标 `ToolCallResultEvent` 做改写。partial 结果可以改写为 `ACTIVITY_SNAPSHOT` 或 `ACTIVITY_DELTA`，final 结果则在原始 `TOOL_CALL_RESULT` 之前插入一条 completed 的 `ACTIVITY_DELTA`。其余事件保持原样透传，这样可以保留文本、Graph 活动和其他工具事件的既有行为。
+
+完整示例可参考 [examples/agui/server/streamtool](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/server/streamtool)。该示例使用一个最小 `StreamableTool` 持续输出递增数字，并通过自定义 Translator 将 partial `tool.response` 转为 `tool.execution` 活动事件，同时保留标准 `TOOL_CALL_RESULT` 作为最终结果。

--- a/examples/agui/server/README.md
+++ b/examples/agui/server/README.md
@@ -9,6 +9,7 @@ This directory shows AG-UI servers that can talk to the AG-UI client examples.
 - [`event_emitter/`](event_emitter/) – Demonstrates Node EventEmitter for emitting custom events, progress updates, and streaming text from NodeFunc.
 - [`finishresult/`](finishresult/) – Demonstrates populating `RUN_FINISHED.result` by wrapping the default translator.
 - [`externaltool/`](externaltool/) – Demonstrates a two-call external tool workflow (`role=user` then `role=tool`) backed by `GraphAgent` interrupts.
+- [`streamtool/`](streamtool/) – Demonstrates a minimal `StreamableTool` that streams incremental numeric progress as `ACTIVITY_SNAPSHOT` / `ACTIVITY_DELTA` while preserving a final `TOOL_CALL_RESULT`.
 - [`graph/`](graph/) – Demonstrates graph node start activity events via `ACTIVITY_DELTA`.
 - [`react/`](react/) – The server showcases how React planner tags are streamed as custom AG-UI events.
 - [`langfuse/`](langfuse/) – This example shows how AG-UI Server customizes reporting through TranslateCallback and connects to the langfuse observability platform.

--- a/examples/agui/server/streamtool/README.md
+++ b/examples/agui/server/streamtool/README.md
@@ -1,0 +1,100 @@
+# Stream Tool AG-UI Server
+
+This example demonstrates a minimal real `StreamableTool` wired into AG-UI with a custom translator.
+
+The tool simply counts upward and streams numeric progress updates:
+
+- partial tool output becomes `ACTIVITY_SNAPSHOT` and `ACTIVITY_DELTA`
+- the final tool output remains a standard `TOOL_CALL_RESULT`
+
+This keeps the example focused on the event model instead of tool-specific business logic.
+
+## What This Example Shows
+
+- A real `StreamableTool` built with `function.NewStreamableFunctionTool`.
+- A custom translator that turns partial `tool.response` events into `tool.execution` activity updates.
+- A final `TOOL_CALL_RESULT` that still carries the structured tool result for the next LLM turn and for history replay.
+- `MessagesSnapshot` enabled, so activity and final tool result can be replayed from `/history`.
+
+## Run
+
+From the `examples/agui` module:
+
+```bash
+export OPENAI_API_KEY="your-api-key"
+export OPENAI_BASE_URL="https://your-openai-compatible-base-url" # Optional.
+
+go run ./server/streamtool \
+  -model deepseek-chat \
+  -address 127.0.0.1:8080 \
+  -path /agui
+```
+
+The server exposes:
+
+- chat endpoint: `http://127.0.0.1:8080/agui`
+- history endpoint: `http://127.0.0.1:8080/history`
+
+## Try It
+
+Prompts that work well with this example:
+
+- `Count to 5 with 200 millisecond updates.`
+- `Run the counting tool for 8 steps.`
+- `Count to 3 slowly, then tell me the final result.`
+
+The agent is instructed to call `count_progress` exactly once for every user request before answering.
+
+## Expected Event Shape
+
+When the model calls the tool, the stream looks like:
+
+```text
+RUN_STARTED
+TOOL_CALL_START
+TOOL_CALL_ARGS
+TOOL_CALL_END
+ACTIVITY_SNAPSHOT(activityType="tool.execution")
+ACTIVITY_DELTA(activityType="tool.execution")
+ACTIVITY_DELTA(activityType="tool.execution")
+...
+ACTIVITY_DELTA(activityType="tool.execution")   # phase=completed
+TOOL_CALL_RESULT
+TEXT_MESSAGE_*
+RUN_FINISHED
+```
+
+This is the key behavior demonstrated by the example:
+
+- intermediate tool execution is rendered as activity updates
+- the final tool output remains a standard `TOOL_CALL_RESULT`
+
+## Inspect the Raw SSE Stream
+
+You can inspect the raw protocol stream with `curl`:
+
+```bash
+curl -N http://127.0.0.1:8080/agui \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "threadId": "streamtool-demo",
+    "runId": "streamtool-run-1",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Count to 5 with 200 millisecond updates."
+      }
+    ]
+  }'
+```
+
+Look for:
+
+- `TOOL_CALL_*` frames
+- `ACTIVITY_SNAPSHOT` / `ACTIVITY_DELTA` with `activityType: "tool.execution"`
+- a single final `TOOL_CALL_RESULT`
+
+## Notes
+
+- The counting tool is intentionally small so the event flow is easy to inspect.
+- The final tool result is still returned through the normal tool-response path, so the assistant can summarize the completed step count in its final answer.

--- a/examples/agui/server/streamtool/agent.go
+++ b/examples/agui/server/streamtool/agent.go
@@ -1,0 +1,28 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+func newAgent(modelInstance model.Model, generationConfig model.GenerationConfig) *llmagent.LLMAgent {
+	progressTool := newCountProgressTool()
+	return llmagent.New(
+		"agui-streamtool-agent",
+		llmagent.WithModel(modelInstance),
+		llmagent.WithGenerationConfig(generationConfig),
+		llmagent.WithInstruction("You demonstrate a streaming tool. "+
+			"For every user request, you must call count_progress exactly once before answering. "+
+			"Use the final tool result when you summarize what happened."),
+		llmagent.WithTools([]tool.Tool{progressTool}),
+	)
+}

--- a/examples/agui/server/streamtool/main.go
+++ b/examples/agui/server/streamtool/main.go
@@ -1,0 +1,76 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package main demonstrates an AG-UI server that keeps TOOL_CALL_* and final
+// TOOL_CALL_RESULT semantics intact while surfacing tool execution progress as
+// ACTIVITY_SNAPSHOT and ACTIVITY_DELTA events.
+package main
+
+import (
+	"flag"
+	"net/http"
+
+	"trpc.group/trpc-go/trpc-agent-go/log"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/model/openai"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+	"trpc.group/trpc-go/trpc-agent-go/server/agui"
+	aguirunner "trpc.group/trpc-go/trpc-agent-go/server/agui/runner"
+	sessioninmemory "trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+)
+
+const appName = "agui-streamtool-demo"
+
+var (
+	modelName            = flag.String("model", "deepseek-chat", "OpenAI-compatible model name.")
+	isStream             = flag.Bool("stream", true, "Whether to stream the model response.")
+	address              = flag.String("address", "127.0.0.1:8080", "Listen address.")
+	path                 = flag.String("path", "/agui", "HTTP path.")
+	messagesSnapshotPath = flag.String("messages-snapshot-path", "/history", "Messages snapshot HTTP path.")
+)
+
+func main() {
+	flag.Parse()
+	modelInstance := openai.New(*modelName)
+	generationConfig := model.GenerationConfig{
+		MaxTokens:   intPtr(768),
+		Temperature: floatPtr(0.1),
+		Stream:      *isStream,
+	}
+	agent := newAgent(modelInstance, generationConfig)
+	sessionService := sessioninmemory.NewSessionService()
+	run := runner.NewRunner(appName, agent, runner.WithSessionService(sessionService))
+	defer run.Close()
+	server, err := agui.New(
+		run,
+		agui.WithAppName(appName),
+		agui.WithPath(*path),
+		agui.WithMessagesSnapshotEnabled(true),
+		agui.WithMessagesSnapshotPath(*messagesSnapshotPath),
+		agui.WithSessionService(sessionService),
+		agui.WithAGUIRunnerOptions(
+			aguirunner.WithTranslatorFactory(newTranslator),
+		),
+	)
+	if err != nil {
+		log.Fatalf("create AG-UI server failed: %v", err)
+	}
+	log.Infof("AG-UI: serving agent %q on http://%s%s", agent.Info().Name, *address, *path)
+	log.Infof("AG-UI: messages snapshot available at http://%s%s", *address, *messagesSnapshotPath)
+	if err := http.ListenAndServe(*address, server.Handler()); err != nil {
+		log.Fatalf("server stopped with error: %v", err)
+	}
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func floatPtr(f float64) *float64 {
+	return &f
+}

--- a/examples/agui/server/streamtool/tool.go
+++ b/examples/agui/server/streamtool/tool.go
@@ -1,0 +1,129 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+	"trpc.group/trpc-go/trpc-agent-go/tool/function"
+)
+
+const (
+	countProgressToolName   = "count_progress"
+	defaultCountSteps       = 5
+	maxCountSteps           = 20
+	defaultCountDelayMS     = 200
+	minCountDelayMS         = 50
+	maxCountDelayMS         = 2000
+	defaultCountStepLatency = 200 * time.Millisecond
+)
+
+type countProgressArgs struct {
+	Steps   int `json:"steps,omitempty" description:"How many steps to count before finishing."`
+	DelayMS int `json:"delay_ms,omitempty" description:"Delay in milliseconds between streamed updates."`
+}
+
+type countProgressUpdate struct {
+	Current int `json:"current"`
+	Total   int `json:"total"`
+}
+
+type countProgressResult struct {
+	Completed int `json:"completed"`
+	Total     int `json:"total"`
+}
+
+func newCountProgressTool() tool.Tool {
+	return function.NewStreamableFunctionTool[countProgressArgs, countProgressResult](
+		func(ctx context.Context, args countProgressArgs) (*tool.StreamReader, error) {
+			stream := tool.NewStream(16)
+			go runCountProgress(ctx, normalizeCountProgressArgs(args), stream.Writer)
+			return stream.Reader, nil
+		},
+		function.WithName(countProgressToolName),
+		function.WithDescription("Count upward step by step and stream numeric progress updates before returning a final result."),
+	)
+}
+
+func normalizeCountProgressArgs(args countProgressArgs) countProgressArgs {
+	if args.Steps <= 0 {
+		args.Steps = defaultCountSteps
+	}
+	if args.Steps > maxCountSteps {
+		args.Steps = maxCountSteps
+	}
+	if args.DelayMS <= 0 {
+		args.DelayMS = defaultCountDelayMS
+	}
+	if args.DelayMS < minCountDelayMS {
+		args.DelayMS = minCountDelayMS
+	}
+	if args.DelayMS > maxCountDelayMS {
+		args.DelayMS = maxCountDelayMS
+	}
+	return args
+}
+
+func runCountProgress(ctx context.Context, args countProgressArgs, writer *tool.StreamWriter) {
+	defer writer.Close()
+	if args.Steps <= 0 {
+		writer.Send(tool.StreamChunk{}, errors.New("steps must be greater than zero"))
+		return
+	}
+	delay := time.Duration(args.DelayMS) * time.Millisecond
+	if delay <= 0 {
+		delay = defaultCountStepLatency
+	}
+	for step := 1; step <= args.Steps; step++ {
+		if err := ctx.Err(); err != nil {
+			writer.Send(tool.StreamChunk{}, err)
+			return
+		}
+		if err := sendCountProgressUpdate(ctx, writer, countProgressUpdate{
+			Current: step,
+			Total:   args.Steps,
+		}, delay); err != nil {
+			writer.Send(tool.StreamChunk{}, err)
+			return
+		}
+	}
+	writer.Send(tool.StreamChunk{
+		Content: tool.FinalResultChunk{Result: countProgressResult{
+			Completed: args.Steps,
+			Total:     args.Steps,
+		}},
+	}, nil)
+}
+
+func sendCountProgressUpdate(ctx context.Context, writer *tool.StreamWriter, progress countProgressUpdate, delay time.Duration) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if closed := writer.Send(tool.StreamChunk{Content: progress}, nil); closed {
+		return context.Canceled
+	}
+	return sleepWithContext(ctx, delay)
+}
+
+func sleepWithContext(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return ctx.Err()
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/examples/agui/server/streamtool/translator.go
+++ b/examples/agui/server/streamtool/translator.go
@@ -1,0 +1,147 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	aguievents "github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/events"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
+	"trpc.group/trpc-go/trpc-agent-go/server/agui/translator"
+)
+
+const toolExecutionActivityType = "tool.execution"
+
+type toolExecutionTranslator struct {
+	inner   translator.Translator
+	started map[string]bool
+}
+
+func newTranslator(ctx context.Context, input *adapter.RunAgentInput, opts ...translator.Option) (translator.Translator, error) {
+	inner, err := translator.New(ctx, input.ThreadID, input.RunID, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("create inner translator: %w", err)
+	}
+	return &toolExecutionTranslator{
+		inner:   inner,
+		started: make(map[string]bool),
+	}, nil
+}
+
+func (t *toolExecutionTranslator) Translate(ctx context.Context, evt *event.Event) ([]aguievents.Event, error) {
+	innerEvents, err := t.inner.Translate(ctx, evt)
+	if err != nil {
+		return nil, err
+	}
+	if evt == nil || evt.Response == nil || !evt.Response.IsToolResultResponse() {
+		return innerEvents, nil
+	}
+	return t.rewriteInnerEvents(innerEvents, evt.Response.IsPartial), nil
+}
+
+func (t *toolExecutionTranslator) rewriteInnerEvents(events []aguievents.Event, isPartial bool) []aguievents.Event {
+	if len(events) == 0 {
+		return nil
+	}
+	out := make([]aguievents.Event, 0, len(events)+1)
+	for _, evt := range events {
+		toolResultEvent, ok := evt.(*aguievents.ToolCallResultEvent)
+		if !ok {
+			out = append(out, evt)
+			continue
+		}
+		rewritten, ok := t.rewriteToolResultEvent(toolResultEvent, isPartial)
+		if !ok {
+			out = append(out, evt)
+			continue
+		}
+		out = append(out, rewritten...)
+	}
+	return out
+}
+
+func (t *toolExecutionTranslator) rewriteToolResultEvent(
+	toolResultEvent *aguievents.ToolCallResultEvent,
+	isPartial bool,
+) ([]aguievents.Event, bool) {
+	if toolResultEvent == nil {
+		return nil, false
+	}
+	if isPartial {
+		var update countProgressUpdate
+		if err := json.Unmarshal([]byte(toolResultEvent.Content), &update); err != nil {
+			return nil, false
+		}
+		return []aguievents.Event{
+			t.partialActivityEvent(toolResultEvent.ToolCallID, update),
+		}, true
+	}
+	if !t.started[toolResultEvent.ToolCallID] {
+		return nil, false
+	}
+	var result countProgressResult
+	if err := json.Unmarshal([]byte(toolResultEvent.Content), &result); err != nil {
+		return nil, false
+	}
+	delete(t.started, toolResultEvent.ToolCallID)
+	return []aguievents.Event{
+		t.finalActivityEvent(toolResultEvent.ToolCallID, result),
+		toolResultEvent,
+	}, true
+}
+
+func (t *toolExecutionTranslator) partialActivityEvent(toolCallID string, update countProgressUpdate) aguievents.Event {
+	activityID := activityMessageID(toolCallID)
+	progress := calculateActivityProgress(update.Current, update.Total)
+	if !t.started[toolCallID] {
+		t.started[toolCallID] = true
+		return aguievents.NewActivitySnapshotEvent(activityID, toolExecutionActivityType, map[string]any{
+			"toolCallId": toolCallID,
+			"current":    update.Current,
+			"total":      update.Total,
+			"progress":   progress,
+		})
+	}
+	return aguievents.NewActivityDeltaEvent(activityID, toolExecutionActivityType, []aguievents.JSONPatchOperation{
+		{Op: "replace", Path: "/current", Value: update.Current},
+		{Op: "replace", Path: "/total", Value: update.Total},
+		{Op: "replace", Path: "/progress", Value: progress},
+	})
+}
+
+func (t *toolExecutionTranslator) finalActivityEvent(toolCallID string, result countProgressResult) aguievents.Event {
+	return aguievents.NewActivityDeltaEvent(activityMessageID(toolCallID), toolExecutionActivityType, []aguievents.JSONPatchOperation{
+		{Op: "replace", Path: "/current", Value: result.Completed},
+		{Op: "replace", Path: "/total", Value: result.Total},
+		{Op: "replace", Path: "/progress", Value: 100},
+		{Op: "add", Path: "/result", Value: result},
+	})
+}
+
+func activityMessageID(toolCallID string) string {
+	return "tool-activity-" + toolCallID
+}
+
+func calculateActivityProgress(current, total int) float64 {
+	if total <= 0 {
+		return 100
+	}
+	return float64(current) / float64(total) * 100
+}
+
+func (t *toolExecutionTranslator) PostRunFinalizationEvents(ctx context.Context) ([]aguievents.Event, error) {
+	finalizer, ok := t.inner.(translator.PostRunFinalizingTranslator)
+	if !ok {
+		return nil, nil
+	}
+	return finalizer.PostRunFinalizationEvents(ctx)
+}


### PR DESCRIPTION
Add a minimal AG-UI streamtool server example that demonstrates rewriting partial tool results into activity events while preserving the final tool result, update the AG-UI server example index, and document the recommended pattern for streaming tool execution results in both the Chinese and English AG-UI guides.