### PR TITLE
{agent, internal}: unify telemetry error labels across chat and invoke-agent

### DIFF
--- a/agent/a2aagent/a2a_agent.go
+++ b/agent/a2aagent/a2a_agent.go
@@ -633,9 +633,15 @@ func (r *A2AAgent) wrapEventChannelWithTelemetry(
 	runCtx := agent.CloneContext(ctx)
 	go func(ctx context.Context) {
 		var fullRespEvent *event.Event
-		var responseErrorType string
 		tokenUsage := &itelemetry.TokenUsage{}
 		defer func() {
+			responseErrorType := ""
+			if fullRespEvent != nil && fullRespEvent.Response != nil && fullRespEvent.Response.Error != nil {
+				responseErrorType = itelemetry.FormatResponseErrorLabel(
+					fullRespEvent.Response.Error,
+					model.ErrorTypeRunError,
+				)
+			}
 			if startedSpan && fullRespEvent != nil {
 				log.DebugContext(ctx, "fullRespEvent is not ni")
 				itelemetry.TraceAfterInvokeAgent(span, fullRespEvent, tokenUsage, tracker.FirstTokenTimeDuration())
@@ -658,9 +664,6 @@ func (r *A2AAgent) wrapEventChannelWithTelemetry(
 					}
 					fullRespEvent = evt
 				}
-			}
-			if evt != nil && evt.Error != nil {
-				responseErrorType = evt.Error.Type
 			}
 			if err := event.EmitEvent(ctx, wrappedChan, evt); err != nil {
 				return

--- a/agent/a2aagent/a2a_agent.go
+++ b/agent/a2aagent/a2a_agent.go
@@ -644,7 +644,13 @@ func (r *A2AAgent) wrapEventChannelWithTelemetry(
 			}
 			if startedSpan && fullRespEvent != nil {
 				log.DebugContext(ctx, "fullRespEvent is not ni")
-				itelemetry.TraceAfterInvokeAgent(span, fullRespEvent, tokenUsage, tracker.FirstTokenTimeDuration())
+				itelemetry.TraceAfterInvokeAgent(
+					span,
+					fullRespEvent,
+					tokenUsage,
+					tracker.FirstTokenTimeDuration(),
+					model.ErrorTypeRunError,
+				)
 			}
 			tracker.SetResponseErrorType(responseErrorType)
 			tracker.RecordMetrics()()

--- a/agent/a2aagent/a2a_agent.go
+++ b/agent/a2aagent/a2a_agent.go
@@ -633,14 +633,17 @@ func (r *A2AAgent) wrapEventChannelWithTelemetry(
 	runCtx := agent.CloneContext(ctx)
 	go func(ctx context.Context) {
 		var fullRespEvent *event.Event
+		var responseErrorType string
 		tokenUsage := &itelemetry.TokenUsage{}
 		defer func() {
-			responseErrorType := ""
-			if fullRespEvent != nil && fullRespEvent.Response != nil && fullRespEvent.Response.Error != nil {
-				responseErrorType = itelemetry.FormatResponseErrorLabel(
-					fullRespEvent.Response.Error,
-					model.ErrorTypeRunError,
-				)
+			if fullRespEvent != nil && fullRespEvent.Response != nil {
+				responseErrorType = ""
+				if fullRespEvent.Response.Error != nil {
+					responseErrorType = itelemetry.FormatResponseErrorLabel(
+						fullRespEvent.Response.Error,
+						model.ErrorTypeRunError,
+					)
+				}
 			}
 			if startedSpan && fullRespEvent != nil {
 				log.DebugContext(ctx, "fullRespEvent is not ni")
@@ -670,6 +673,12 @@ func (r *A2AAgent) wrapEventChannelWithTelemetry(
 					}
 					fullRespEvent = evt
 				}
+			}
+			if evt != nil && evt.Error != nil {
+				responseErrorType = itelemetry.FormatResponseErrorLabel(
+					evt.Error,
+					model.ErrorTypeRunError,
+				)
 			}
 			if err := event.EmitEvent(ctx, wrappedChan, evt); err != nil {
 				return

--- a/agent/a2aagent/a2a_agent_test.go
+++ b/agent/a2aagent/a2a_agent_test.go
@@ -25,6 +25,8 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/propagation"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	oteltrace "go.opentelemetry.io/otel/trace"
@@ -38,6 +40,7 @@ import (
 	itelemetry "trpc.group/trpc-go/trpc-agent-go/internal/telemetry"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/telemetry/semconv/metrics"
 	semconvtrace "trpc.group/trpc-go/trpc-agent-go/telemetry/semconv/trace"
 	teletrace "trpc.group/trpc-go/trpc-agent-go/telemetry/trace"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
@@ -440,6 +443,107 @@ func TestWrapEventChannelWithTelemetry_AccumulatesTokenUsage(t *testing.T) {
 	if !hasAttr(attrs, attribute.Int(semconvtrace.KeyGenAIUsageOutputTokens, finalEvent.Response.Usage.CompletionTokens)) {
 		t.Fatalf("expected output token usage to be recorded, attrs=%v", attrs)
 	}
+}
+
+func TestWrapEventChannelWithTelemetry_PreservesFallbackErrorTypeWithoutFinalResponse(t *testing.T) {
+	reader := setupInvokeAgentMetricCapture(t)
+	invocation := &agent.Invocation{InvocationID: "inv-fallback", AgentName: "a2a"}
+	var trackerErr error
+	tracker := itelemetry.NewInvokeAgentTracker(context.Background(), invocation, false, &trackerErr)
+	originalChan := make(chan *event.Event, 1)
+	code := "429"
+	partialErrorEvent := &event.Event{
+		Response: &model.Response{
+			IsPartial: true,
+			Error: &model.ResponseError{
+				Type:    "rate_limit",
+				Code:    &code,
+				Message: "rate limited",
+			},
+		},
+	}
+	originalChan <- partialErrorEvent
+	close(originalChan)
+
+	wrappedChan := (&A2AAgent{}).wrapEventChannelWithTelemetry(
+		context.Background(),
+		invocation,
+		originalChan,
+		oteltrace.SpanFromContext(context.Background()),
+		tracker,
+		false,
+	)
+
+	var received []*event.Event
+	for evt := range wrappedChan {
+		received = append(received, evt)
+	}
+	require.Len(t, received, 1)
+	require.Same(t, partialErrorEvent, received[0])
+
+	rm := collectInvokeAgentMetrics(t, reader)
+	require.True(t, hasInvokeAgentMetricStringAttribute(
+		rm,
+		"gen_ai.client.request.cnt",
+		semconvtrace.KeyErrorType,
+		"rate_limit_429",
+	))
+}
+
+func TestWrapEventChannelWithTelemetry_ClearsFallbackErrorTypeOnFinalSuccess(t *testing.T) {
+	reader := setupInvokeAgentMetricCapture(t)
+	invocation := &agent.Invocation{InvocationID: "inv-success", AgentName: "a2a"}
+	var trackerErr error
+	tracker := itelemetry.NewInvokeAgentTracker(context.Background(), invocation, false, &trackerErr)
+	originalChan := make(chan *event.Event, 2)
+	code := "429"
+	partialErrorEvent := &event.Event{
+		Response: &model.Response{
+			IsPartial: true,
+			Error: &model.ResponseError{
+				Type:    "rate_limit",
+				Code:    &code,
+				Message: "rate limited",
+			},
+		},
+	}
+	finalSuccessEvent := event.NewResponseEvent(
+		"inv-success",
+		"a2a",
+		&model.Response{
+			IsPartial: false,
+			Choices: []model.Choice{{
+				Message: model.NewAssistantMessage("ok"),
+			}},
+		},
+	)
+	originalChan <- partialErrorEvent
+	originalChan <- finalSuccessEvent
+	close(originalChan)
+
+	wrappedChan := (&A2AAgent{}).wrapEventChannelWithTelemetry(
+		context.Background(),
+		invocation,
+		originalChan,
+		oteltrace.SpanFromContext(context.Background()),
+		tracker,
+		false,
+	)
+
+	var received []*event.Event
+	for evt := range wrappedChan {
+		received = append(received, evt)
+	}
+	require.Len(t, received, 2)
+	require.Same(t, partialErrorEvent, received[0])
+	require.Same(t, finalSuccessEvent, received[1])
+
+	rm := collectInvokeAgentMetrics(t, reader)
+	require.False(t, hasInvokeAgentMetricAttributeKey(
+		rm,
+		"gen_ai.client.request.cnt",
+		semconvtrace.KeyErrorType,
+	))
 }
 
 func useSpanRecorder(t *testing.T) *tracetest.SpanRecorder {
@@ -2398,6 +2502,95 @@ func hasAttr(attrs []attribute.KeyValue, target attribute.KeyValue) bool {
 	for _, attr := range attrs {
 		if attr.Key == target.Key && attr.Value == target.Value {
 			return true
+		}
+	}
+	return false
+}
+
+func setupInvokeAgentMetricCapture(t *testing.T) *sdkmetric.ManualReader {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	originalProvider := itelemetry.MeterProvider
+	originalMeter := itelemetry.InvokeAgentMeter
+	originalRequestCnt := itelemetry.InvokeAgentMetricGenAIRequestCnt
+	originalTokenUsage := itelemetry.InvokeAgentMetricGenAIClientTokenUsage
+	originalTimeToFirstToken := itelemetry.InvokeAgentMetricGenAIClientTimeToFirstToken
+	originalDuration := itelemetry.InvokeAgentMetricGenAIClientOperationDuration
+	t.Cleanup(func() {
+		itelemetry.MeterProvider = originalProvider
+		itelemetry.InvokeAgentMeter = originalMeter
+		itelemetry.InvokeAgentMetricGenAIRequestCnt = originalRequestCnt
+		itelemetry.InvokeAgentMetricGenAIClientTokenUsage = originalTokenUsage
+		itelemetry.InvokeAgentMetricGenAIClientTimeToFirstToken = originalTimeToFirstToken
+		itelemetry.InvokeAgentMetricGenAIClientOperationDuration = originalDuration
+	})
+
+	itelemetry.MeterProvider = provider
+	itelemetry.InvokeAgentMeter = provider.Meter(metrics.MeterNameInvokeAgent)
+	var err error
+	itelemetry.InvokeAgentMetricGenAIRequestCnt, err = itelemetry.InvokeAgentMeter.Int64Counter("gen_ai.client.request.cnt")
+	require.NoError(t, err)
+	itelemetry.InvokeAgentMetricGenAIClientTokenUsage = nil
+	itelemetry.InvokeAgentMetricGenAIClientTimeToFirstToken = nil
+	itelemetry.InvokeAgentMetricGenAIClientOperationDuration = nil
+	return reader
+}
+
+func collectInvokeAgentMetrics(t *testing.T, reader *sdkmetric.ManualReader) metricdata.ResourceMetrics {
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+	return rm
+}
+
+func hasInvokeAgentMetricStringAttribute(
+	rm metricdata.ResourceMetrics,
+	metricName string,
+	key string,
+	value string,
+) bool {
+	for _, scopeMetric := range rm.ScopeMetrics {
+		for _, metric := range scopeMetric.Metrics {
+			if metric.Name != metricName {
+				continue
+			}
+			sum, ok := metric.Data.(metricdata.Sum[int64])
+			if !ok {
+				continue
+			}
+			for _, point := range sum.DataPoints {
+				for _, attr := range point.Attributes.ToSlice() {
+					if string(attr.Key) == key && attr.Value.AsString() == value {
+						return true
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
+func hasInvokeAgentMetricAttributeKey(
+	rm metricdata.ResourceMetrics,
+	metricName string,
+	key string,
+) bool {
+	for _, scopeMetric := range rm.ScopeMetrics {
+		for _, metric := range scopeMetric.Metrics {
+			if metric.Name != metricName {
+				continue
+			}
+			sum, ok := metric.Data.(metricdata.Sum[int64])
+			if !ok {
+				continue
+			}
+			for _, point := range sum.DataPoints {
+				for _, attr := range point.Attributes.ToSlice() {
+					if string(attr.Key) == key {
+						return true
+					}
+				}
+			}
 		}
 	}
 	return false

--- a/agent/chainagent/chain_agent.go
+++ b/agent/chainagent/chain_agent.go
@@ -130,15 +130,17 @@ func (a *ChainAgent) executeChainRun(
 	}
 	// Execute sub-agents in sequence.
 	e, tokenUsage := a.executeSubAgents(ctx, invocation, eventChan, tracker)
-	if e != nil && e.Error != nil {
-		trackerErr = fmt.Errorf("%s: %s", e.Error.Type, e.Error.Message)
-		tracker.SetResponseErrorType(e.Error.Type)
-	}
 	// Handle after agent callbacks.
 	if a.agentCallbacks != nil {
 		if afterEvent := a.handleAfterAgentCallbacks(ctx, invocation, eventChan, e); afterEvent != nil {
 			e = afterEvent
 		}
+	}
+	if e != nil && e.Error != nil {
+		trackerErr = fmt.Errorf("%s: %s", e.Error.Type, e.Error.Message)
+		tracker.SetResponseErrorType(
+			itelemetry.FormatResponseErrorLabel(e.Error, model.ErrorTypeFlowError),
+		)
 	}
 	if startedSpan {
 		itelemetry.TraceAfterInvokeAgent(span, e, tokenUsage, tracker.FirstTokenTimeDuration())

--- a/agent/chainagent/chain_agent.go
+++ b/agent/chainagent/chain_agent.go
@@ -143,7 +143,13 @@ func (a *ChainAgent) executeChainRun(
 		)
 	}
 	if startedSpan {
-		itelemetry.TraceAfterInvokeAgent(span, e, tokenUsage, tracker.FirstTokenTimeDuration())
+		itelemetry.TraceAfterInvokeAgent(
+			span,
+			e,
+			tokenUsage,
+			tracker.FirstTokenTimeDuration(),
+			model.ErrorTypeFlowError,
+		)
 	}
 }
 

--- a/agent/graphagent/graph_agent.go
+++ b/agent/graphagent/graph_agent.go
@@ -286,7 +286,10 @@ func resolveGraphAgentErrorType(fullRespEvent *event.Event, operationErrorType s
 	if fullRespEvent == nil || fullRespEvent.Response == nil || fullRespEvent.Response.Error == nil {
 		return ""
 	}
-	return fullRespEvent.Response.Error.Type
+	return itelemetry.FormatResponseErrorLabel(
+		fullRespEvent.Response.Error,
+		model.ErrorTypeFlowError,
+	)
 }
 
 func recordTraceEvent(

--- a/agent/graphagent/graph_agent.go
+++ b/agent/graphagent/graph_agent.go
@@ -207,7 +207,13 @@ func (ga *GraphAgent) runWithBarrier(ctx context.Context, invocation *agent.Invo
 	var operationErrorType string
 	defer func() {
 		if tracingEnabled && fullRespEvent != nil {
-			itelemetry.TraceAfterInvokeAgent(span, fullRespEvent, tokenUsage, tracker.FirstTokenTimeDuration())
+			itelemetry.TraceAfterInvokeAgent(
+				span,
+				fullRespEvent,
+				tokenUsage,
+				tracker.FirstTokenTimeDuration(),
+				model.ErrorTypeFlowError,
+			)
 		}
 		tracker.SetResponseErrorType(resolveGraphAgentErrorType(fullRespEvent, operationErrorType))
 		tracker.RecordMetrics()()

--- a/agent/graphagent/graph_agent_test.go
+++ b/agent/graphagent/graph_agent_test.go
@@ -4166,6 +4166,7 @@ func TestGraphAgent_Run_ExecutionTraceCapturesComplexGraph(t *testing.T) {
 }
 
 func TestResolveGraphAgentErrorType(t *testing.T) {
+	code := "70002"
 	testCases := []struct {
 		name               string
 		fullRespEvent      *event.Event
@@ -4200,6 +4201,21 @@ func TestResolveGraphAgentErrorType(t *testing.T) {
 				"callback failed",
 			),
 			want: agent.ErrorTypeAgentCallbackError,
+		},
+		{
+			name: "final error response keeps code suffix",
+			fullRespEvent: event.NewResponseEvent(
+				"inv",
+				"graph-agent",
+				&model.Response{
+					Error: &model.ResponseError{
+						Type:    model.ErrorTypeFlowError,
+						Code:    &code,
+						Message: "graph failed",
+					},
+				},
+			),
+			want: model.ErrorTypeFlowError + "_70002",
 		},
 	}
 

--- a/agent/llmagent/extras_test.go
+++ b/agent/llmagent/extras_test.go
@@ -11,10 +11,13 @@ package llmagent
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/trace/noop"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
@@ -23,6 +26,8 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/knowledge"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/document"
 	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/telemetry/semconv/metrics"
+	semconvtrace "trpc.group/trpc-go/trpc-agent-go/telemetry/semconv/trace"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
 
@@ -188,6 +193,95 @@ func TestLLMAgent_AfterCbNoResp(t *testing.T) {
 	if count != 1 {
 		t.Fatalf("expected 1 event, got %d", count)
 	}
+}
+
+func TestLLMAgent_AfterCbErrorRecordsTelemetryErrorType(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	originalProvider := itelemetry.MeterProvider
+	originalMeter := itelemetry.InvokeAgentMeter
+	originalRequestCnt := itelemetry.InvokeAgentMetricGenAIRequestCnt
+	originalTokenUsage := itelemetry.InvokeAgentMetricGenAIClientTokenUsage
+	originalTimeToFirstToken := itelemetry.InvokeAgentMetricGenAIClientTimeToFirstToken
+	originalDuration := itelemetry.InvokeAgentMetricGenAIClientOperationDuration
+	t.Cleanup(func() {
+		itelemetry.MeterProvider = originalProvider
+		itelemetry.InvokeAgentMeter = originalMeter
+		itelemetry.InvokeAgentMetricGenAIRequestCnt = originalRequestCnt
+		itelemetry.InvokeAgentMetricGenAIClientTokenUsage = originalTokenUsage
+		itelemetry.InvokeAgentMetricGenAIClientTimeToFirstToken = originalTimeToFirstToken
+		itelemetry.InvokeAgentMetricGenAIClientOperationDuration = originalDuration
+	})
+
+	itelemetry.MeterProvider = provider
+	itelemetry.InvokeAgentMeter = provider.Meter(metrics.MeterNameInvokeAgent)
+	var err error
+	itelemetry.InvokeAgentMetricGenAIRequestCnt, err = itelemetry.InvokeAgentMeter.Int64Counter("gen_ai.client.request.cnt")
+	require.NoError(t, err)
+	itelemetry.InvokeAgentMetricGenAIClientTokenUsage = nil
+	itelemetry.InvokeAgentMetricGenAIClientTimeToFirstToken = nil
+	itelemetry.InvokeAgentMetricGenAIClientOperationDuration = nil
+
+	orig := make(chan *event.Event, 1)
+	orig <- event.New("id", "agent")
+	close(orig)
+
+	cb := agent.NewCallbacks()
+	cb.RegisterAfterAgent(func(ctx context.Context, inv *agent.Invocation, err error) (*model.Response, error) {
+		return nil, errors.New("after callback failed")
+	})
+
+	inv := &agent.Invocation{InvocationID: "id", AgentName: "agent"}
+	llm := &LLMAgent{agentCallbacks: cb}
+	var trackerErr error
+	tracker := itelemetry.NewInvokeAgentTracker(context.Background(), inv, false, &trackerErr)
+	wrapped := llm.wrapEventChannelWithTelemetry(context.Background(), inv, orig, noop.Span{}, tracker, false)
+
+	var events []*event.Event
+	for e := range wrapped {
+		events = append(events, e)
+	}
+	require.Len(t, events, 2)
+	require.NotNil(t, events[1].Response)
+	require.NotNil(t, events[1].Response.Error)
+	require.Equal(t, agent.ErrorTypeAgentCallbackError, events[1].Response.Error.Type)
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+	require.True(t, hasInvokeAgentMetricStringAttribute(
+		rm,
+		"gen_ai.client.request.cnt",
+		semconvtrace.KeyErrorType,
+		agent.ErrorTypeAgentCallbackError,
+	))
+}
+
+func hasInvokeAgentMetricStringAttribute(
+	rm metricdata.ResourceMetrics,
+	metricName string,
+	key string,
+	value string,
+) bool {
+	for _, scopeMetric := range rm.ScopeMetrics {
+		for _, metric := range scopeMetric.Metrics {
+			if metric.Name != metricName {
+				continue
+			}
+			sum, ok := metric.Data.(metricdata.Sum[int64])
+			if !ok {
+				continue
+			}
+			for _, point := range sum.DataPoints {
+				for _, attr := range point.Attributes.ToSlice() {
+					if string(attr.Key) == key && attr.Value.AsString() == value {
+						return true
+					}
+				}
+			}
+		}
+	}
+	return false
 }
 
 func TestLLMAgent_WithToolSet(t *testing.T) {

--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -1143,81 +1143,168 @@ func (a *LLMAgent) wrapEventChannelWithTelemetry(
 	runCtx := agent.CloneContext(ctx)
 	go func(ctx context.Context) {
 		var fullRespEvent *event.Event
+		var responseErrorType string
 		tokenUsage := &itelemetry.TokenUsage{}
 		defer func() {
-			responseErrorType := ""
-			if fullRespEvent != nil && fullRespEvent.Response != nil && fullRespEvent.Response.Error != nil {
-				responseErrorType = itelemetry.FormatResponseErrorLabel(
-					fullRespEvent.Response.Error,
-					model.ErrorTypeRunError,
-				)
-			}
-			if startedSpan && fullRespEvent != nil {
-				itelemetry.TraceAfterInvokeAgent(span, fullRespEvent, tokenUsage, tracker.FirstTokenTimeDuration())
-			}
-			tracker.SetResponseErrorType(responseErrorType)
-			tracker.RecordMetrics()()
-			if startedSpan {
-				span.End()
-			}
-			close(wrappedChan)
+			finalizeWrappedTelemetry(
+				span,
+				tracker,
+				fullRespEvent,
+				responseErrorType,
+				tokenUsage,
+				startedSpan,
+				wrappedChan,
+			)
 		}()
 		// Forward all events from the original channel
 		for evt := range originalChan {
-			if evt != nil && evt.Response != nil {
-				tracker.TrackResponse(evt.Response)
-				if !evt.Response.IsPartial {
-					if evt.Response.Usage != nil {
-						tokenUsage.PromptTokens += evt.Response.Usage.PromptTokens
-						tokenUsage.CompletionTokens += evt.Response.Usage.CompletionTokens
-						tokenUsage.TotalTokens += evt.Response.Usage.TotalTokens
-					}
-					fullRespEvent = evt
-				}
+			if trackedEvent := recordWrappedEventTelemetry(
+				evt,
+				tracker,
+				tokenUsage,
+				&responseErrorType,
+			); trackedEvent != nil {
+				fullRespEvent = trackedEvent
 			}
 			if err := event.EmitEvent(ctx, wrappedChan, evt); err != nil {
 				return
 			}
 		}
-		// Collect error from the final response event.
-		var agentErr error
-		if fullRespEvent != nil && fullRespEvent.Response != nil && fullRespEvent.Response.Error != nil {
-			agentErr = fmt.Errorf("%s: %s", fullRespEvent.Response.Error.Type, fullRespEvent.Response.Error.Message)
-		}
-
-		// After all events are processed, run after agent callbacks
-		if a.agentCallbacks != nil {
-			result, err := a.agentCallbacks.RunAfterAgent(ctx, &agent.AfterAgentArgs{
-				Invocation:        invocation,
-				Error:             agentErr,
-				FullResponseEvent: fullRespEvent,
-			})
-			// Use the context from result if provided.
-			if result != nil && result.Context != nil {
-				ctx = result.Context
-			}
-			var evt *event.Event
-			if err != nil {
-				// Send error event.
-				evt = event.NewErrorEvent(
-					invocation.InvocationID,
-					invocation.AgentName,
-					agent.ErrorTypeAgentCallbackError,
-					err.Error(),
-				)
-			} else if result != nil && result.CustomResponse != nil {
-				// Create an event from the custom response.
-				evt = event.NewResponseEvent(invocation.InvocationID, invocation.AgentName, result.CustomResponse)
-			}
-			if evt != nil {
-				fullRespEvent = evt
-			}
-
+		if ctx, evt := a.runAfterAgentCallback(ctx, invocation, fullRespEvent); evt != nil {
+			fullRespEvent = evt
 			agent.EmitEvent(ctx, invocation, wrappedChan, evt)
 		}
 	}(runCtx)
 
 	return wrappedChan
+}
+
+func finalizeWrappedTelemetry(
+	span sdktrace.Span,
+	tracker *itelemetry.InvokeAgentTracker,
+	fullRespEvent *event.Event,
+	responseErrorType string,
+	tokenUsage *itelemetry.TokenUsage,
+	startedSpan bool,
+	wrappedChan chan *event.Event,
+) {
+	responseErrorType = resolveWrappedResponseErrorType(fullRespEvent, responseErrorType)
+	if startedSpan && fullRespEvent != nil {
+		itelemetry.TraceAfterInvokeAgent(
+			span,
+			fullRespEvent,
+			tokenUsage,
+			tracker.FirstTokenTimeDuration(),
+			model.ErrorTypeRunError,
+		)
+	}
+	tracker.SetResponseErrorType(responseErrorType)
+	tracker.RecordMetrics()()
+	if startedSpan {
+		span.End()
+	}
+	close(wrappedChan)
+}
+
+func resolveWrappedResponseErrorType(fullRespEvent *event.Event, responseErrorType string) string {
+	if fullRespEvent == nil || fullRespEvent.Response == nil {
+		return responseErrorType
+	}
+	if fullRespEvent.Response.Error == nil {
+		return ""
+	}
+	return itelemetry.FormatResponseErrorLabel(
+		fullRespEvent.Response.Error,
+		model.ErrorTypeRunError,
+	)
+}
+
+func recordWrappedEventTelemetry(
+	evt *event.Event,
+	tracker *itelemetry.InvokeAgentTracker,
+	tokenUsage *itelemetry.TokenUsage,
+	responseErrorType *string,
+) *event.Event {
+	if evt == nil {
+		return nil
+	}
+	var fullRespEvent *event.Event
+	if evt.Response != nil {
+		tracker.TrackResponse(evt.Response)
+		if !evt.Response.IsPartial {
+			addWrappedTokenUsage(tokenUsage, evt.Response.Usage)
+			fullRespEvent = evt
+		}
+	}
+	if evt.Error != nil {
+		*responseErrorType = itelemetry.FormatResponseErrorLabel(
+			evt.Error,
+			model.ErrorTypeRunError,
+		)
+	}
+	return fullRespEvent
+}
+
+func addWrappedTokenUsage(tokenUsage *itelemetry.TokenUsage, usage *model.Usage) {
+	if usage == nil {
+		return
+	}
+	tokenUsage.PromptTokens += usage.PromptTokens
+	tokenUsage.CompletionTokens += usage.CompletionTokens
+	tokenUsage.TotalTokens += usage.TotalTokens
+}
+
+func (a *LLMAgent) runAfterAgentCallback(
+	ctx context.Context,
+	invocation *agent.Invocation,
+	fullRespEvent *event.Event,
+) (context.Context, *event.Event) {
+	if a.agentCallbacks == nil {
+		return ctx, nil
+	}
+	result, err := a.agentCallbacks.RunAfterAgent(ctx, &agent.AfterAgentArgs{
+		Invocation:        invocation,
+		Error:             wrappedAgentError(fullRespEvent),
+		FullResponseEvent: fullRespEvent,
+	})
+	if result != nil && result.Context != nil {
+		ctx = result.Context
+	}
+	return ctx, wrappedAfterAgentEvent(invocation, result, err)
+}
+
+func wrappedAgentError(fullRespEvent *event.Event) error {
+	if fullRespEvent == nil || fullRespEvent.Response == nil || fullRespEvent.Response.Error == nil {
+		return nil
+	}
+	return fmt.Errorf(
+		"%s: %s",
+		fullRespEvent.Response.Error.Type,
+		fullRespEvent.Response.Error.Message,
+	)
+}
+
+func wrappedAfterAgentEvent(
+	invocation *agent.Invocation,
+	result *agent.AfterAgentResult,
+	callbackErr error,
+) *event.Event {
+	if callbackErr != nil {
+		return event.NewErrorEvent(
+			invocation.InvocationID,
+			invocation.AgentName,
+			agent.ErrorTypeAgentCallbackError,
+			callbackErr.Error(),
+		)
+	}
+	if result == nil || result.CustomResponse == nil {
+		return nil
+	}
+	return event.NewResponseEvent(
+		invocation.InvocationID,
+		invocation.AgentName,
+		result.CustomResponse,
+	)
 }
 
 // Info implements the agent.Agent interface.

--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -1143,9 +1143,15 @@ func (a *LLMAgent) wrapEventChannelWithTelemetry(
 	runCtx := agent.CloneContext(ctx)
 	go func(ctx context.Context) {
 		var fullRespEvent *event.Event
-		var responseErrorType string
 		tokenUsage := &itelemetry.TokenUsage{}
 		defer func() {
+			responseErrorType := ""
+			if fullRespEvent != nil && fullRespEvent.Response != nil && fullRespEvent.Response.Error != nil {
+				responseErrorType = itelemetry.FormatResponseErrorLabel(
+					fullRespEvent.Response.Error,
+					model.ErrorTypeRunError,
+				)
+			}
 			if startedSpan && fullRespEvent != nil {
 				itelemetry.TraceAfterInvokeAgent(span, fullRespEvent, tokenUsage, tracker.FirstTokenTimeDuration())
 			}
@@ -1176,7 +1182,6 @@ func (a *LLMAgent) wrapEventChannelWithTelemetry(
 		// Collect error from the final response event.
 		var agentErr error
 		if fullRespEvent != nil && fullRespEvent.Response != nil && fullRespEvent.Response.Error != nil {
-			responseErrorType = fullRespEvent.Response.Error.Type
 			agentErr = fmt.Errorf("%s: %s", fullRespEvent.Response.Error.Type, fullRespEvent.Response.Error.Message)
 		}
 
@@ -1200,7 +1205,6 @@ func (a *LLMAgent) wrapEventChannelWithTelemetry(
 					agent.ErrorTypeAgentCallbackError,
 					err.Error(),
 				)
-				responseErrorType = agent.ErrorTypeAgentCallbackError
 			} else if result != nil && result.CustomResponse != nil {
 				// Create an event from the custom response.
 				evt = event.NewResponseEvent(invocation.InvocationID, invocation.AgentName, result.CustomResponse)

--- a/graph/state_graph_additional_test.go
+++ b/graph/state_graph_additional_test.go
@@ -3008,6 +3008,7 @@ func TestStartNodeSpan_DisableTracingUsesNoopSpan(t *testing.T) {
 		),
 		nil,
 		0,
+		model.ErrorTypeFlowError,
 	)
 
 	require.Empty(t, parentSpan.attributes)

--- a/internal/telemetry/errs.go
+++ b/internal/telemetry/errs.go
@@ -12,20 +12,26 @@ package telemetry
 import (
 	"fmt"
 
+	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/telemetry/errs"
 )
 
+// FormatResponseErrorLabel converts a response error into a telemetry label.
+func FormatResponseErrorLabel(respErr *model.ResponseError, fallback string) string {
+	if respErr == nil {
+		return fallback
+	}
+	label := fallback
+	if respErr.Type != "" {
+		label = respErr.Type
+	}
+	if respErr.Code != nil && *respErr.Code != "" {
+		return fmt.Sprintf("%s_%s", label, *respErr.Code)
+	}
+	return label
+}
+
 // ToErrorType converts an error to an error type.
 func ToErrorType(err error, errorType string) string {
-	e := errs.ToResponseError(err)
-	if e == nil {
-		return errorType
-	}
-	if e.Type != "" {
-		errorType = e.Type
-	}
-	if e.Code != nil && *e.Code != "" {
-		return fmt.Sprintf("%s_%s", errorType, *e.Code)
-	}
-	return errorType
+	return FormatResponseErrorLabel(errs.ToResponseError(err), errorType)
 }

--- a/internal/telemetry/errs_test.go
+++ b/internal/telemetry/errs_test.go
@@ -21,6 +21,65 @@ func strPtr(s string) *string {
 	return &s
 }
 
+func TestFormatResponseErrorLabel(t *testing.T) {
+	tests := []struct {
+		name     string
+		respErr  *model.ResponseError
+		fallback string
+		expected string
+	}{
+		{
+			name:     "nil response error returns fallback",
+			respErr:  nil,
+			fallback: "default_error",
+			expected: "default_error",
+		},
+		{
+			name: "response error with type and code returns type code",
+			respErr: &model.ResponseError{
+				Type: "api_error",
+				Code: strPtr("500"),
+			},
+			fallback: "default_error",
+			expected: "api_error_500",
+		},
+		{
+			name: "response error with type only returns type",
+			respErr: &model.ResponseError{
+				Type: "timeout",
+			},
+			fallback: "default_error",
+			expected: "timeout",
+		},
+		{
+			name: "response error with code only uses fallback",
+			respErr: &model.ResponseError{
+				Code: strPtr("404"),
+			},
+			fallback: "default_error",
+			expected: "default_error_404",
+		},
+		{
+			name: "response error with empty code ignores code",
+			respErr: &model.ResponseError{
+				Type: "validation_error",
+				Code: strPtr(""),
+			},
+			fallback: "default_error",
+			expected: "validation_error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FormatResponseErrorLabel(tt.respErr, tt.fallback)
+			if result != tt.expected {
+				t.Errorf("FormatResponseErrorLabel(%v, %q) = %q, want %q", tt.respErr, tt.fallback, result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestToErrorType(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/telemetry/metric_chat.go
+++ b/internal/telemetry/metric_chat.go
@@ -462,7 +462,10 @@ func (t *ChatMetricsTracker) buildAttributes() chatAttributes {
 			attrs.ResponseModelName = t.lastEvent.Response.Model
 		}
 		if t.lastEvent.Error != nil {
-			attrs.ErrorType = t.lastEvent.Error.Type
+			attrs.ErrorType = FormatResponseErrorLabel(
+				t.lastEvent.Error,
+				semconvtrace.ValueDefaultErrorType,
+			)
 		}
 	}
 

--- a/internal/telemetry/metric_chat_test.go
+++ b/internal/telemetry/metric_chat_test.go
@@ -19,6 +19,7 @@ import (
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	"trpc.group/trpc-go/trpc-agent-go/telemetry/metric/histogram"
@@ -276,6 +277,32 @@ func TestChatMetricsTracker_SetInvocationState_PreservesExistingMetricsAttribute
 	require.Equal(t, baseInvocation.Session.ID, attrs.SessionID)
 	require.Equal(t, baseInvocation.Session.UserID, attrs.UserID)
 	require.Equal(t, baseInvocation.Session.AppName, attrs.AppName)
+}
+
+func TestChatMetricsTracker_BuildAttributesFormatsErrorCode(t *testing.T) {
+	tracker := NewChatMetricsTracker(
+		context.Background(),
+		nil,
+		nil,
+		&model.TimingInfo{},
+		nil,
+		nil,
+	)
+	code := "429"
+	tracker.SetLastEvent(event.NewResponseEvent(
+		"inv-123",
+		"test-author",
+		&model.Response{
+			Error: &model.ResponseError{
+				Type:    "rate_limit",
+				Code:    &code,
+				Message: "rate limit exceeded",
+			},
+		},
+	))
+
+	attrs := tracker.buildAttributes()
+	require.Equal(t, "rate_limit_429", attrs.ErrorType)
 }
 
 func TestChatMetricsTracker_SetInvocationState_PreservesReasoningTimingWhenDisabled(t *testing.T) {

--- a/internal/telemetry/trace.go
+++ b/internal/telemetry/trace.go
@@ -172,7 +172,7 @@ func TraceToolCall(span trace.Span, sess *session.Session, declaration *tool.Dec
 	if rspEvent != nil && rspEvent.Response != nil {
 		if e := rspEvent.Response.Error; e != nil {
 			span.SetStatus(codes.Error, e.Message)
-			span.SetAttributes(attribute.String(semconvtrace.KeyErrorType, e.Type), attribute.String(semconvtrace.KeyErrorMessage, e.Message))
+			span.SetAttributes(responseErrorAttributes(e, semconvtrace.ValueDefaultErrorType)...)
 		} else if err != nil {
 			span.SetStatus(codes.Error, err.Error())
 			span.SetAttributes(attribute.String(semconvtrace.KeyErrorType, ToErrorType(err, semconvtrace.ValueDefaultErrorType)), attribute.String(semconvtrace.KeyErrorMessage, err.Error()))
@@ -216,7 +216,7 @@ func TraceMergedToolCalls(span trace.Span, rspEvent *event.Event) {
 		}
 		if e := rspEvent.Response.Error; e != nil {
 			span.SetStatus(codes.Error, e.Message)
-			span.SetAttributes(attribute.String(semconvtrace.KeyErrorType, e.Type), attribute.String(semconvtrace.KeyErrorMessage, e.Message))
+			span.SetAttributes(responseErrorAttributes(e, semconvtrace.ValueDefaultErrorType)...)
 		}
 		span.SetAttributes(attribute.String(semconvtrace.KeyEventID, rspEvent.ID))
 
@@ -327,7 +327,13 @@ type TokenUsage struct {
 }
 
 // TraceAfterInvokeAgent traces the after invocation of an agent.
-func TraceAfterInvokeAgent(span trace.Span, rspEvent *event.Event, tokenUsage *TokenUsage, timeToFirstToken time.Duration) {
+func TraceAfterInvokeAgent(
+	span trace.Span,
+	rspEvent *event.Event,
+	tokenUsage *TokenUsage,
+	timeToFirstToken time.Duration,
+	errorTypeFallback string,
+) {
 	if !span.IsRecording() {
 		return
 	}
@@ -366,7 +372,7 @@ func TraceAfterInvokeAgent(span trace.Span, rspEvent *event.Event, tokenUsage *T
 
 	if e := rsp.Error; e != nil {
 		span.SetStatus(codes.Error, e.Message)
-		span.SetAttributes(attribute.String(semconvtrace.KeyErrorType, e.Type), attribute.String(semconvtrace.KeyErrorMessage, e.Message))
+		span.SetAttributes(responseErrorAttributes(e, errorTypeFallback)...)
 	}
 }
 
@@ -422,7 +428,7 @@ func TraceChat(span trace.Span, attributes *TraceChatAttributes) {
 	attrs = append(attrs, buildRequestAttributes(attributes.Request)...)
 
 	// Add response attributes
-	attrs = append(attrs, buildResponseAttributes(attributes.Response)...)
+	attrs = append(attrs, buildResponseAttributes(attributes.Response, semconvtrace.ValueDefaultErrorType)...)
 
 	// Set all attributes at once
 	span.SetAttributes(attrs...)
@@ -530,7 +536,7 @@ func buildRequestAttributes(req *model.Request) []attribute.KeyValue {
 }
 
 // buildResponseAttributes builds response-related attributes.
-func buildResponseAttributes(rsp *model.Response) []attribute.KeyValue {
+func buildResponseAttributes(rsp *model.Response, errorTypeFallback string) []attribute.KeyValue {
 	if rsp == nil {
 		return nil
 	}
@@ -542,7 +548,7 @@ func buildResponseAttributes(rsp *model.Response) []attribute.KeyValue {
 
 	// Add error type if present
 	if e := rsp.Error; e != nil {
-		attrs = append(attrs, attribute.String(semconvtrace.KeyErrorType, e.Type), attribute.String(semconvtrace.KeyErrorMessage, e.Message))
+		attrs = append(attrs, responseErrorAttributes(e, errorTypeFallback)...)
 	}
 
 	// Add usage attributes
@@ -592,6 +598,19 @@ func buildResponseAttributes(rsp *model.Response) []attribute.KeyValue {
 	}
 
 	return attrs
+}
+
+func responseErrorAttributes(respErr *model.ResponseError, fallback string) []attribute.KeyValue {
+	if respErr == nil {
+		return nil
+	}
+	return []attribute.KeyValue{
+		attribute.String(
+			semconvtrace.KeyErrorType,
+			FormatResponseErrorLabel(respErr, fallback),
+		),
+		attribute.String(semconvtrace.KeyErrorMessage, respErr.Message),
+	}
 }
 
 // NewGRPCConn creates a new gRPC connection to the OpenTelemetry Collector.

--- a/internal/telemetry/trace_test.go
+++ b/internal/telemetry/trace_test.go
@@ -266,7 +266,7 @@ func TestTraceFunctions_NonRecordingSpan_ReturnsEarly(t *testing.T) {
 
 	TraceWorkflow(span, &Workflow{Name: "wf", ID: "wf-1"})
 	TraceBeforeInvokeAgent(span, nil, "", "", nil)
-	TraceAfterInvokeAgent(span, nil, nil, 0)
+	TraceAfterInvokeAgent(span, nil, nil, 0, model.ErrorTypeRunError)
 	TraceChat(span, nil)
 }
 
@@ -289,12 +289,22 @@ func TestTraceBeforeAfter_Tool_Merged_Chat_Embedding(t *testing.T) {
 
 	// After invoke with error and choices
 	stop := "stop"
-	rsp := &model.Response{ID: "rid", Model: "m-1", Usage: &model.Usage{PromptTokens: 1, CompletionTokens: 2}, Choices: []model.Choice{{FinishReason: &stop}, {}}, Error: &model.ResponseError{Message: "oops", Type: "api_error"}}
+	code := "70002"
+	rsp := &model.Response{
+		ID:      "rid",
+		Model:   "m-1",
+		Usage:   &model.Usage{PromptTokens: 1, CompletionTokens: 2},
+		Choices: []model.Choice{{FinishReason: &stop}, {}},
+		Error:   &model.ResponseError{Message: "oops", Type: "api_error", Code: &code},
+	}
 	evt := event.New("eid", "alpha", event.WithResponse(rsp))
 	s2 := newRecordingSpan()
-	TraceAfterInvokeAgent(s2, evt, nil, 0)
+	TraceAfterInvokeAgent(s2, evt, nil, 0, model.ErrorTypeRunError)
 	if s2.status != codes.Error {
 		t.Fatalf("expected error status")
+	}
+	if !hasAttr(s2.attrs, semconvtrace.KeyErrorType, "api_error_70002") {
+		t.Fatalf("missing error type suffix")
 	}
 
 	// Tool call and merged
@@ -712,7 +722,13 @@ func TestTraceAfterInvokeAgent_NilPaths(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			span := newRecordingSpan()
-			TraceAfterInvokeAgent(span, tt.rspEvent, tt.tokenUsage, tt.timeToFirstToken)
+			TraceAfterInvokeAgent(
+				span,
+				tt.rspEvent,
+				tt.tokenUsage,
+				tt.timeToFirstToken,
+				model.ErrorTypeRunError,
+			)
 
 			if tt.tokenUsage != nil {
 				require.True(t, hasAttr(span.attrs, semconvtrace.KeyGenAIUsageInputTokens, int64(tt.tokenUsage.PromptTokens)))
@@ -723,6 +739,32 @@ func TestTraceAfterInvokeAgent_NilPaths(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTraceAfterInvokeAgent_UsesFallbackForCodeOnlyErrors(t *testing.T) {
+	code := "70002"
+	span := newRecordingSpan()
+	TraceAfterInvokeAgent(
+		span,
+		event.New("evt-code", "author", event.WithResponse(&model.Response{
+			Error: &model.ResponseError{
+				Message: "failed",
+				Code:    &code,
+			},
+		})),
+		nil,
+		0,
+		model.ErrorTypeFlowError,
+	)
+
+	require.True(
+		t,
+		hasAttr(
+			span.attrs,
+			semconvtrace.KeyErrorType,
+			model.ErrorTypeFlowError+"_70002",
+		),
+	)
 }
 
 func TestTraceChat_WithTimeToFirstToken(t *testing.T) {
@@ -969,7 +1011,7 @@ func TestBuildResponseAttributes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			attrs := buildResponseAttributes(tt.rsp)
+			attrs := buildResponseAttributes(tt.rsp, semconvtrace.ValueDefaultErrorType)
 			if tt.rsp == nil {
 				require.Nil(t, attrs)
 			} else {
@@ -1060,6 +1102,25 @@ func TestTraceToolCall_EmptyToolCallIDs(t *testing.T) {
 	require.True(t, hasAttr(span.attrs, semconvtrace.KeyGenAIToolName, "test_tool"))
 }
 
+func TestTraceToolCall_UsesFormattedErrorType(t *testing.T) {
+	span := newRecordingSpan()
+	decl := &tool.Declaration{Name: "test_tool", Description: "test description"}
+	args, _ := json.Marshal(map[string]string{"key": "value"})
+	code := "42"
+	evt := event.New("evt1", "author", event.WithResponse(&model.Response{
+		Error: &model.ResponseError{
+			Type:    "api_error",
+			Code:    &code,
+			Message: "test error",
+		},
+	}))
+
+	TraceToolCall(span, nil, decl, args, evt, nil)
+
+	require.Equal(t, codes.Error, span.status)
+	require.True(t, hasAttr(span.attrs, semconvtrace.KeyErrorType, "api_error_42"))
+}
+
 func TestTraceMergedToolCalls_WithError(t *testing.T) {
 	span := newRecordingSpan()
 
@@ -1067,6 +1128,7 @@ func TestTraceMergedToolCalls_WithError(t *testing.T) {
 	rsp := &model.Response{
 		Error: &model.ResponseError{
 			Type:    "api_error",
+			Code:    func() *string { s := "42"; return &s }(),
 			Message: "test error",
 		},
 		Choices: []model.Choice{{Message: model.Message{ToolCalls: []model.ToolCall{{ID: "call1"}}}}},
@@ -1077,6 +1139,7 @@ func TestTraceMergedToolCalls_WithError(t *testing.T) {
 
 	require.Equal(t, codes.Error, span.status)
 	require.True(t, hasAttr(span.attrs, semconvtrace.KeyGenAIToolCallID, "call1"))
+	require.True(t, hasAttr(span.attrs, semconvtrace.KeyErrorType, "api_error_42"))
 }
 
 func TestTraceBeforeInvokeAgent_JSONMarshalError(t *testing.T) {
@@ -1121,7 +1184,7 @@ func TestBuildResponseAttributes_JSONMarshalPaths(t *testing.T) {
 		Model:   "gpt-4",
 		Choices: []model.Choice{{Message: model.Message{Role: model.RoleAssistant, Content: "test"}}},
 	}
-	attrs := buildResponseAttributes(rsp)
+	attrs := buildResponseAttributes(rsp, semconvtrace.ValueDefaultErrorType)
 	require.NotNil(t, attrs)
 
 	// Verify LLM response attribute is set
@@ -1162,7 +1225,14 @@ func TestTraceChat_WithChoicesAndError(t *testing.T) {
 	inv := &agent.Invocation{InvocationID: "i2"}
 	req := &model.Request{GenerationConfig: model.GenerationConfig{Stop: []string{"Z"}}, Messages: []model.Message{{Role: model.RoleUser, Content: "hello"}}}
 	stop := "stop"
-	rsp := &model.Response{ID: "rid3", Model: "m3", Usage: &model.Usage{PromptTokens: 2, CompletionTokens: 3}, Choices: []model.Choice{{FinishReason: &stop}}, Error: &model.ResponseError{Message: "bad", Type: "api_error"}}
+	code := "500"
+	rsp := &model.Response{
+		ID:      "rid3",
+		Model:   "m3",
+		Usage:   &model.Usage{PromptTokens: 2, CompletionTokens: 3},
+		Choices: []model.Choice{{FinishReason: &stop}},
+		Error:   &model.ResponseError{Message: "bad", Type: "api_error", Code: &code},
+	}
 	s := newRecordingSpan()
 	TraceChat(s, &TraceChatAttributes{
 		Invocation:       inv,
@@ -1174,6 +1244,7 @@ func TestTraceChat_WithChoicesAndError(t *testing.T) {
 	if s.status != codes.Error {
 		t.Fatalf("expected error status on chat")
 	}
+	require.True(t, hasAttr(s.attrs, semconvtrace.KeyErrorType, "api_error_500"))
 }
 
 // Cover error branch of NewGRPCConn using injected dialer.


### PR DESCRIPTION
Share one ResponseError label formatter so chat and invoke-agent metrics keep the same type and code suffixes. This keeps final agent responses and chat telemetry aligned on the same error taxonomy.

Made-with: Cursor