### PR TITLE
{agent,processor,docs}: refine summary user injection merge order

### DIFF
--- a/agent/graphagent/option.go
+++ b/agent/graphagent/option.go
@@ -52,7 +52,9 @@ const (
 	// message (default behavior).
 	SessionSummaryInjectionSystem = processor.SessionSummaryInjectionSystem
 	// SessionSummaryInjectionUser injects the session summary as a user
-	// message that participates in token-budget trimming.
+	// message that participates in token-budget trimming. The processor
+	// prefers merging it into the first user history/current message and only
+	// falls back to a trailing prefix user message when needed.
 	SessionSummaryInjectionUser = processor.SessionSummaryInjectionUser
 )
 

--- a/agent/llmagent/option.go
+++ b/agent/llmagent/option.go
@@ -84,8 +84,9 @@ const (
 	SessionSummaryInjectionSystem = processor.SessionSummaryInjectionSystem
 	// SessionSummaryInjectionUser injects the session summary as a user
 	// message that participates in token-budget trimming for sliding-window
-	// behavior. If the first history message is also user, the summary is
-	// merged into it.
+	// behavior. The processor prefers merging it into the first user
+	// history/current message and only falls back to a trailing prefix user
+	// message when needed.
 	SessionSummaryInjectionUser = processor.SessionSummaryInjectionUser
 )
 

--- a/docs/mkdocs/en/session/summary.md
+++ b/docs/mkdocs/en/session/summary.md
@@ -649,7 +649,7 @@ agent := llmagent.New(
 | Mode | Injection Position | Token Tailoring Behavior | Use Case |
 | --- | --- | --- | --- |
 | `SessionSummaryInjectionSystem` (default) | Merged into system message | Summary in preserved head, never trimmed | Summary must always be present |
-| `SessionSummaryInjectionUser` | User message between few-shot and history | Summary participates in round trimming, can be evicted | Sliding window for very long conversations |
+| `SessionSummaryInjectionUser` | Merged into the first user history/current message when possible; otherwise inserted near history | Summary participates in round trimming, can be evicted | Sliding window for very long conversations |
 
 **User mode message structure**:
 
@@ -690,7 +690,8 @@ When the first history message is not a user role, the summary is a standalone u
 
 **Notes**:
 
-- In user mode, if the first session history message is also a user role, the summary is **automatically merged** into it to avoid consecutive user messages (which some models reject)
+- In user mode, the processor first tries to merge the summary into the first user history/current message so it stays attached to the live user turn
+- If there is no user history/current message and the prompt prefix already ends with a user message (for example, injected context), the summary falls back to that trailing user message instead of adding another adjacent user block
 - User mode uses a more neutral default template ("Context from previous interactions") to avoid system-instruction tone in a user role message
 - Custom `WithSummaryFormatter` also applies to user mode
 - The summary **generation pipeline is unaffected** — injection mode only changes prompt assembly, not the summarizer itself

--- a/docs/mkdocs/zh/session/summary.md
+++ b/docs/mkdocs/zh/session/summary.md
@@ -652,7 +652,7 @@ agent := llmagent.New(
 | 模式 | 注入位置 | Token Tailoring 行为 | 适用场景 |
 | --- | --- | --- | --- |
 | `SessionSummaryInjectionSystem`（默认） | 合并到 system message | 摘要在 preserved head 中，不会被裁剪 | 需要摘要始终存在的场景 |
-| `SessionSummaryInjectionUser` | 作为 user message 插入 few-shot 和 history 之间 | 摘要参与普通轮次裁剪，可被滑动窗口淘汰 | 超长对话的滑动窗口场景 |
+| `SessionSummaryInjectionUser` | 优先合并到第一条 user history/current message；否则在靠近 history 的位置注入 | 摘要参与普通轮次裁剪，可被滑动窗口淘汰 | 超长对话的滑动窗口场景 |
 
 **User 模式的消息结构**：
 
@@ -693,7 +693,8 @@ agent := llmagent.New(
 
 **注意事项**：
 
-- User 模式下，如果 session history 的第一条消息也是 user role，摘要会**自动合并**到该消息中，避免产生连续的 user message（某些模型不接受）
+- User 模式下，processor 会优先把摘要合并到第一条 user history/current message，让摘要贴近当前生效的 user 轮次
+- 如果没有可合并的 user history/current message，但 prompt 前缀最后一条已经是 user message（例如 injected context），则会回退合并到那条 user message，避免额外再插入一条相邻的 user block
 - User 模式使用更中性的默认文案（"Context from previous interactions"），避免以系统指令的语气出现在 user role 中
 - 自定义的 `WithSummaryFormatter` 同样对 user 模式生效
 - 摘要的**生成链路不受影响**——注入模式只影响 prompt assembly 层，不影响 summarizer 本身

--- a/internal/flow/processor/content.go
+++ b/internal/flow/processor/content.go
@@ -691,8 +691,8 @@ func (p *ContentRequestProcessor) getSessionSummaryMessage(inv *agent.Invocation
 
 // prependSummaryUserMessage prepends the session summary as a user message
 // before history messages. It checks three merge opportunities in order:
-//  1. If the first history/current message is a user message, merge the
-//     summary into it so the summary stays attached to the live user turn.
+//  1. If history/current contains a user message, merge the summary into the
+//     first available one so the summary stays attached to the live user turn.
 //  2. If no such history/current user message exists and reqPrefix
 //     (req.Messages before history) ends with a user message, merge the
 //     summary into that trailing prefix message to avoid an extra adjacent
@@ -715,14 +715,17 @@ func (p *ContentRequestProcessor) prependSummaryUserMessage(
 		return messages
 	}
 
-	// Case 1: first history/current message is user — merge into it.
-	if len(messages) > 0 && messages[0].Role == model.RoleUser {
+	// Case 1: merge into the first available user history/current message.
+	for i := range messages {
+		if messages[i].Role != model.RoleUser {
+			continue
+		}
 		merged := make([]model.Message, len(messages))
 		copy(merged, messages)
-		if merged[0].Content == "" {
-			merged[0].Content = formatted
+		if merged[i].Content == "" {
+			merged[i].Content = formatted
 		} else {
-			merged[0].Content = formatted + mergedUserSeparator + merged[0].Content
+			merged[i].Content = formatted + mergedUserSeparator + merged[i].Content
 		}
 		return merged
 	}

--- a/internal/flow/processor/content.go
+++ b/internal/flow/processor/content.go
@@ -46,11 +46,13 @@ const (
 	SessionSummaryInjectionSystem SessionSummaryInjectionMode = "system"
 
 	// SessionSummaryInjectionUser injects the summary as a user message
-	// placed between few-shot examples and session history. If the first
-	// history message is also a user message, the summary is merged into it
-	// to avoid consecutive user messages that some models reject. This mode
-	// allows the summary to participate in token-budget trimming like any
-	// other user-anchored round, enabling a true sliding-window experience.
+	// placed near session history. The processor prefers merging it into the
+	// first user history/current message when possible; if none exists and
+	// the existing prompt prefix already ends with a user message, it falls
+	// back to merging there to avoid introducing an extra adjacent user
+	// block. This mode allows the summary to participate in token-budget
+	// trimming like any other user-anchored round, enabling a true
+	// sliding-window experience.
 	SessionSummaryInjectionUser SessionSummaryInjectionMode = "user"
 )
 
@@ -223,9 +225,10 @@ func WithAddSessionSummary(add bool) ContentOption {
 // Available modes:
 //   - SessionSummaryInjectionSystem (default): injects as system message,
 //     merged into existing system message or prepended.
-//   - SessionSummaryInjectionUser: injects as a user message between few-shot
-//     examples and session history. If the first history message is also user,
-//     the summary is merged into it to avoid consecutive user messages.
+//   - SessionSummaryInjectionUser: injects as a user message near history.
+//     The processor first tries to merge it into the first user
+//     history/current message; if none exists and the existing prompt prefix
+//     already ends with user, it falls back to merging there.
 func WithSessionSummaryInjectionMode(mode SessionSummaryInjectionMode) ContentOption {
 	return func(p *ContentRequestProcessor) {
 		switch mode {
@@ -593,11 +596,11 @@ func (p *ContentRequestProcessor) appendSessionMessages(
 	}
 
 	// When user-mode summary injection is active, prepend the summary as a
-	// user message before history. If the first history message is also a user
-	// message, merge the summary into it to avoid consecutive user messages
-	// that some providers reject. Also check if req.Messages already ends with
-	// a user message (e.g. from injected context or few-shot) and merge there
-	// instead of creating adjacent user messages.
+	// user message near history. Prefer merging into the first user
+	// history/current message so the summary stays attached to the live user
+	// turn. If no such message exists, fall back to a trailing user message in
+	// req.Messages (for example, injected context) to avoid creating an extra
+	// adjacent user block.
 	if summaryText != "" && p.SessionSummaryInjectionMode == SessionSummaryInjectionUser {
 		messages = p.prependSummaryUserMessage(summaryText, messages, req.Messages)
 	}
@@ -688,9 +691,12 @@ func (p *ContentRequestProcessor) getSessionSummaryMessage(inv *agent.Invocation
 
 // prependSummaryUserMessage prepends the session summary as a user message
 // before history messages. It checks three merge opportunities in order:
-//  1. If reqPrefix (req.Messages before history) ends with a user message,
-//     merge the summary into that trailing message to avoid adjacent user roles.
-//  2. If the first history message is a user message, merge the summary into it.
+//  1. If the first history/current message is a user message, merge the
+//     summary into it so the summary stays attached to the live user turn.
+//  2. If no such history/current user message exists and reqPrefix
+//     (req.Messages before history) ends with a user message, merge the
+//     summary into that trailing prefix message to avoid an extra adjacent
+//     user block.
 //  3. Otherwise prepend as an independent user message.
 //
 // When merging into reqPrefix, the function mutates reqPrefix in place and
@@ -709,19 +715,7 @@ func (p *ContentRequestProcessor) prependSummaryUserMessage(
 		return messages
 	}
 
-	// Case 1: reqPrefix (existing req.Messages) ends with a user message.
-	// Merge summary into that message to avoid consecutive user roles.
-	if len(reqPrefix) > 0 && reqPrefix[len(reqPrefix)-1].Role == model.RoleUser {
-		last := &reqPrefix[len(reqPrefix)-1]
-		if last.Content == "" {
-			last.Content = formatted
-		} else {
-			last.Content = last.Content + mergedUserSeparator + formatted
-		}
-		return messages
-	}
-
-	// Case 2: first history message is user — merge into it.
+	// Case 1: first history/current message is user — merge into it.
 	if len(messages) > 0 && messages[0].Role == model.RoleUser {
 		merged := make([]model.Message, len(messages))
 		copy(merged, messages)
@@ -731,6 +725,19 @@ func (p *ContentRequestProcessor) prependSummaryUserMessage(
 			merged[0].Content = formatted + mergedUserSeparator + merged[0].Content
 		}
 		return merged
+	}
+
+	// Case 2: reqPrefix (existing req.Messages) ends with a user message.
+	// Merge summary into that message only as a fallback when there is no
+	// user history/current message to attach the summary to.
+	if len(reqPrefix) > 0 && reqPrefix[len(reqPrefix)-1].Role == model.RoleUser {
+		last := &reqPrefix[len(reqPrefix)-1]
+		if last.Content == "" {
+			last.Content = formatted
+		} else {
+			last.Content = last.Content + mergedUserSeparator + formatted
+		}
+		return messages
 	}
 
 	// Case 3: prepend as independent user message.

--- a/internal/flow/processor/content_messages_test.go
+++ b/internal/flow/processor/content_messages_test.go
@@ -1298,7 +1298,25 @@ func TestPrependSummaryUserMessage(t *testing.T) {
 		require.Contains(t, result[0].Content, "original content")
 	})
 
-	t.Run("req_prefix_ends_with_user_merges_into_prefix", func(t *testing.T) {
+	t.Run("first_history_user_preferred_over_req_prefix_user", func(t *testing.T) {
+		prefix := []model.Message{
+			model.NewSystemMessage("system prompt"),
+			model.NewUserMessage("few-shot user example"),
+		}
+		msgs := []model.Message{
+			model.NewUserMessage("history user"),
+			model.NewAssistantMessage("history assistant"),
+		}
+		result := p.prependSummaryUserMessage("some summary", msgs, prefix)
+		// Summary should stay attached to the live history user message.
+		require.Equal(t, "few-shot user example", prefix[len(prefix)-1].Content)
+		require.Len(t, result, 2)
+		require.Contains(t, result[0].Content, "some summary")
+		require.Contains(t, result[0].Content, "history user")
+		require.Equal(t, model.RoleAssistant, result[1].Role)
+	})
+
+	t.Run("req_prefix_ends_with_user_merges_into_prefix_as_fallback", func(t *testing.T) {
 		prefix := []model.Message{
 			model.NewSystemMessage("system prompt"),
 			model.NewUserMessage("few-shot user example"),
@@ -1307,10 +1325,10 @@ func TestPrependSummaryUserMessage(t *testing.T) {
 			model.NewAssistantMessage("history assistant"),
 		}
 		result := p.prependSummaryUserMessage("some summary", msgs, prefix)
-		// Summary should be merged into prefix's last user message.
+		// With no user history/current message to attach to, fall back to the
+		// trailing prefix user message.
 		require.Contains(t, prefix[len(prefix)-1].Content, "some summary")
 		require.Contains(t, prefix[len(prefix)-1].Content, "few-shot user example")
-		// messages should be returned unchanged.
 		require.Equal(t, msgs, result)
 	})
 
@@ -1385,7 +1403,7 @@ func TestWithSessionSummaryInjectionMode(t *testing.T) {
 }
 
 // Test user injection mode with injected context ending in user message.
-func TestProcessRequest_SessionSummary_UserMode_InjectedContextEndsWithUser(t *testing.T) {
+func TestProcessRequest_SessionSummary_UserMode_PrefersCurrentUserOverInjectedContext(t *testing.T) {
 	summaryTime := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
 	sess := &session.Session{
 		Summaries: map[string]*session.Summary{
@@ -1419,23 +1437,82 @@ func TestProcessRequest_SessionSummary_UserMode_InjectedContextEndsWithUser(t *t
 	)
 	p.ProcessRequest(context.Background(), inv, req, nil)
 
-	// The summary should be merged into the injected context user message
-	// (the trailing user msg in req.Messages before history appended).
+	// The summary should stay attached to the live current user message instead
+	// of being merged into the injected-context prefix user message.
 	// System prompt should NOT contain the summary.
 	require.Equal(t, model.RoleSystem, req.Messages[0].Role)
 	require.NotContains(t, req.Messages[0].Content, "injected context summary",
 		"system prompt should not contain summary in user injection mode")
 
-	// Find the injected context message and verify summary was merged into it.
+	// Injected-context user message should remain untouched.
+	require.Equal(t, "injected context user msg", req.Messages[1].Content)
+
+	// Find the current user message and verify summary was merged into it.
 	foundMerged := false
 	for _, msg := range req.Messages {
 		if msg.Role == model.RoleUser &&
-			strings.Contains(msg.Content, "injected context user msg") &&
+			strings.Contains(msg.Content, "current request") &&
 			strings.Contains(msg.Content, "injected context summary") {
 			foundMerged = true
 			break
 		}
 	}
 	require.True(t, foundMerged,
-		"summary should be merged into the injected context user message")
+		"summary should be merged into the current user message")
+}
+
+func TestProcessRequest_SessionSummary_UserMode_FallsBackToInjectedContextUser(t *testing.T) {
+	summaryTime := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+	sess := &session.Session{
+		Summaries: map[string]*session.Summary{
+			"test-agent": {
+				Summary:   "fallback summary",
+				UpdatedAt: summaryTime,
+			},
+		},
+		Events: []event.Event{
+			{
+				Response: &model.Response{
+					Choices: []model.Choice{{
+						Message: model.NewAssistantMessage("history assistant"),
+					}},
+				},
+				Author:    "test-agent",
+				Timestamp: summaryTime.Add(time.Second),
+				FilterKey: "test-agent",
+				Version:   event.CurrentVersion,
+			},
+		},
+	}
+
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationEventFilterKey("test-agent"),
+		agent.WithInvocationMessage(model.NewToolMessage("tool-1", "search", "tool result")),
+		agent.WithInvocationRunOptions(agent.RunOptions{
+			InjectedContextMessages: []model.Message{
+				model.NewUserMessage("injected context user msg"),
+			},
+		}),
+	)
+	inv.AgentName = "test-agent"
+
+	req := &model.Request{
+		Messages: []model.Message{
+			model.NewSystemMessage("system prompt"),
+		},
+	}
+	p := NewContentRequestProcessor(
+		WithAddSessionSummary(true),
+		WithSessionSummaryInjectionMode(SessionSummaryInjectionUser),
+	)
+	p.ProcessRequest(context.Background(), inv, req, nil)
+
+	require.Equal(t, model.RoleSystem, req.Messages[0].Role)
+	require.NotContains(t, req.Messages[0].Content, "fallback summary")
+
+	// No user history/current message is available, so fallback merges into the
+	// injected-context user message instead of inserting a standalone user block.
+	require.Contains(t, req.Messages[1].Content, "injected context user msg")
+	require.Contains(t, req.Messages[1].Content, "fallback summary")
 }

--- a/internal/flow/processor/content_messages_test.go
+++ b/internal/flow/processor/content_messages_test.go
@@ -1338,6 +1338,25 @@ func TestPrependSummaryUserMessage(t *testing.T) {
 		require.Equal(t, model.RoleTool, result[2].Role)
 	})
 
+	t.Run("later_empty_history_user_preferred_over_req_prefix_user", func(t *testing.T) {
+		prefix := []model.Message{
+			model.NewSystemMessage("system prompt"),
+			model.NewUserMessage("few-shot user example"),
+		}
+		msgs := []model.Message{
+			model.NewAssistantMessage("history assistant"),
+			{Role: model.RoleUser, Content: ""},
+		}
+		result := p.prependSummaryUserMessage("some summary", msgs, prefix)
+		// An empty user message later in history/current should still win over
+		// the trailing prefix user, and the summary should become its content.
+		require.Equal(t, "few-shot user example", prefix[len(prefix)-1].Content)
+		require.Len(t, result, 2)
+		require.Equal(t, model.RoleAssistant, result[0].Role)
+		require.Equal(t, model.RoleUser, result[1].Role)
+		require.Contains(t, result[1].Content, "some summary")
+	})
+
 	t.Run("req_prefix_ends_with_user_merges_into_prefix_as_fallback", func(t *testing.T) {
 		prefix := []model.Message{
 			model.NewSystemMessage("system prompt"),

--- a/internal/flow/processor/content_messages_test.go
+++ b/internal/flow/processor/content_messages_test.go
@@ -1260,16 +1260,17 @@ func TestPrependSummaryUserMessage(t *testing.T) {
 		require.Contains(t, result[0].Content, "some summary")
 	})
 
-	t.Run("first_message_not_user", func(t *testing.T) {
+	t.Run("later_user_message_merges", func(t *testing.T) {
 		msgs := []model.Message{
 			model.NewAssistantMessage("hi"),
 			model.NewUserMessage("hello"),
 		}
 		result := p.prependSummaryUserMessage("some summary", msgs, nil)
-		require.Len(t, result, 3)
-		require.Equal(t, model.RoleUser, result[0].Role)
-		require.Contains(t, result[0].Content, "some summary")
-		require.Equal(t, model.RoleAssistant, result[1].Role)
+		require.Len(t, result, 2)
+		require.Equal(t, model.RoleAssistant, result[0].Role)
+		require.Equal(t, model.RoleUser, result[1].Role)
+		require.Contains(t, result[1].Content, "some summary")
+		require.Contains(t, result[1].Content, "hello")
 	})
 
 	t.Run("first_message_is_user_merges", func(t *testing.T) {
@@ -1314,6 +1315,27 @@ func TestPrependSummaryUserMessage(t *testing.T) {
 		require.Contains(t, result[0].Content, "some summary")
 		require.Contains(t, result[0].Content, "history user")
 		require.Equal(t, model.RoleAssistant, result[1].Role)
+	})
+
+	t.Run("later_history_user_preferred_over_req_prefix_user", func(t *testing.T) {
+		prefix := []model.Message{
+			model.NewSystemMessage("system prompt"),
+			model.NewUserMessage("few-shot user example"),
+		}
+		msgs := []model.Message{
+			model.NewAssistantMessage("history assistant"),
+			model.NewUserMessage("current user"),
+			model.NewToolMessage("tool-1", "search", "tool result"),
+		}
+		result := p.prependSummaryUserMessage("some summary", msgs, prefix)
+		// Even when history starts with assistant/tool output, the summary
+		// should merge into the first available user message in history/current.
+		require.Equal(t, "few-shot user example", prefix[len(prefix)-1].Content)
+		require.Len(t, result, 3)
+		require.Equal(t, model.RoleAssistant, result[0].Role)
+		require.Contains(t, result[1].Content, "some summary")
+		require.Contains(t, result[1].Content, "current user")
+		require.Equal(t, model.RoleTool, result[2].Role)
 	})
 
 	t.Run("req_prefix_ends_with_user_merges_into_prefix_as_fallback", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- prefer merging user-mode session summaries into the first user history/current message when one is available
- keep merging into a trailing prefix user message only as a fallback when there is no user history/current message to attach to
- update tests and docs to describe the refined merge order and clarify the fallback behavior

## Why
User-mode summary injection was checking trailing prefix user messages before the live history/current turn. That could pull summary content into injected-context or few-shot prefix blocks even when a real user turn was already available, which made the placement feel redundant and less intuitive.

## Impact
This keeps summary content attached to the live user turn in the common case while preserving the existing fallback for prompt prefixes that already end with a user message.

## Validation
- `go test ./agent/llmagent ./agent/graphagent ./internal/flow/processor`
