### PR TITLE
openclaw: preserve admin async URLs under proxy subpaths

### DIFF
--- a/openclaw/admin/relative_paths.go
+++ b/openclaw/admin/relative_paths.go
@@ -28,14 +28,29 @@ const (
 	htmlMediaType = "text/html"
 
 	htmlAttrAction     = "action"
+	htmlAttrDataPrefix = "data-"
 	htmlAttrFormAction = "formaction"
 	htmlAttrHref       = "href"
 	htmlAttrSrc        = "src"
+
+	htmlAttrActionSuffix = "-action"
+	htmlAttrHrefSuffix   = "-href"
+	htmlAttrPathSuffix   = "-path"
+	htmlAttrSrcSuffix    = "-src"
+	htmlAttrURLSuffix    = "-url"
 
 	rootPath           = "/"
 	currentPathSegment = "."
 	parentPathSegment  = ".."
 )
+
+var htmlDataReferenceAttrSuffixes = []string{
+	htmlAttrActionSuffix,
+	htmlAttrHrefSuffix,
+	htmlAttrPathSuffix,
+	htmlAttrSrcSuffix,
+	htmlAttrURLSuffix,
+}
 
 // wrapRelativeLinks keeps admin navigation working when the
 // service is exposed behind a reverse-proxy subpath.
@@ -193,15 +208,32 @@ func rewriteHTMLReferences(node *html.Node, requestPath string) {
 }
 
 func isHTMLReferenceAttr(key string) bool {
-	switch strings.ToLower(strings.TrimSpace(key)) {
+	normalized := strings.ToLower(strings.TrimSpace(key))
+	switch normalized {
 	case htmlAttrAction,
 		htmlAttrFormAction,
 		htmlAttrHref,
 		htmlAttrSrc:
 		return true
 	default:
+		return isHTMLDataReferenceAttr(normalized)
+	}
+}
+
+func isHTMLDataReferenceAttr(key string) bool {
+	if !strings.HasPrefix(key, htmlAttrDataPrefix) {
 		return false
 	}
+	for _, suffix := range htmlDataReferenceAttrSuffixes {
+		if !strings.HasSuffix(key, suffix) {
+			continue
+		}
+		if len(key) <= len(htmlAttrDataPrefix)+len(suffix) {
+			return false
+		}
+		return true
+	}
+	return false
 }
 
 func relativeRequestReference(requestPath string, rawTarget string) string {

--- a/openclaw/admin/service.go
+++ b/openclaw/admin/service.go
@@ -4972,17 +4972,33 @@ const adminPageHTML = `<!doctype html>
     </section>
     {{end}}
   <script>
+    const resolveRequestURL = (reference) => {
+      const trimmed = typeof reference === "string"
+        ? reference.trim()
+        : "";
+      if (!trimmed) {
+        return null;
+      }
+      try {
+        return new URL(trimmed, window.location.href);
+      } catch (_) {
+        return null;
+      }
+    };
+
     (function () {
       const root = document.querySelector("[data-page-stale-root]");
       if (!root) return;
 
-      const statePath = root.getAttribute("data-page-state-path") || "";
+      const stateURL = resolveRequestURL(
+        root.getAttribute("data-page-state-path") || ""
+      );
       const initialToken =
         root.getAttribute("data-page-state-token") || "";
       const intervalValue = Number(
         root.getAttribute("data-page-refresh-interval") || "0"
       );
-      if (!statePath || !initialToken || intervalValue <= 0) {
+      if (!stateURL || !initialToken || intervalValue <= 0) {
         return;
       }
 
@@ -4994,7 +5010,7 @@ const adminPageHTML = `<!doctype html>
           return;
         }
         try {
-          const response = await fetch(statePath, {
+          const response = await fetch(stateURL.toString(), {
             headers: { Accept: "application/json" },
           });
           if (!response.ok) {
@@ -5409,9 +5425,13 @@ const adminPageHTML = `<!doctype html>
       };
 
       const fetchHistory = async (root, cursor) => {
-        const path = root.getAttribute("data-chat-history-path") || "";
         const chatID = root.getAttribute("data-chat-id") || "";
-        const url = new URL(path, window.location.origin);
+        const url = resolveRequestURL(
+          root.getAttribute("data-chat-history-path") || ""
+        );
+        if (!url) {
+          throw new Error(fallbackHistoryError);
+        }
         url.searchParams.set("chat_id", chatID);
         if (cursor) {
           url.searchParams.set("cursor", cursor);

--- a/openclaw/admin/service_test.go
+++ b/openclaw/admin/service_test.go
@@ -2014,7 +2014,13 @@ func TestService_ChatsPageAndJSON(t *testing.T) {
 	require.Contains(t, body, "href=\"identity#identity-global\"")
 	require.Contains(t, body, "Alice Chen (alice)")
 	require.Contains(t, body, "data-chat-history-root")
-	require.Contains(t, body, routeChatHistoryJSON)
+	require.Contains(
+		t,
+		body,
+		`data-chat-history-path="api/chats/history"`,
+	)
+	require.Contains(t, body, "window.location.href")
+	require.NotContains(t, body, "window.location.origin")
 	require.Contains(
 		t,
 		body,
@@ -4496,6 +4502,9 @@ func TestRewriteHTMLBody(t *testing.T) {
 	body := []byte(`
 <html><body>
 <a href="/skills" data-path="/skills">Skills</a>
+<div
+  data-page-state-path="/api/page/state?view=overview"
+  data-chat-history-path="/api/chats/history"></div>
 <form action="/api/skills/refresh">
 <button formaction="/api/cron/jobs/run">Run</button>
 </form>
@@ -4525,6 +4534,16 @@ func TestRewriteHTMLBody(t *testing.T) {
 		`src="uploads/file?path=clip.mp4"`,
 	)
 	require.Contains(t, string(got), `data-path="/skills"`)
+	require.Contains(
+		t,
+		string(got),
+		`data-page-state-path="api/page/state?view=overview"`,
+	)
+	require.Contains(
+		t,
+		string(got),
+		`data-chat-history-path="api/chats/history"`,
+	)
 }
 
 func TestRewriteHTMLBodySkipsNonHTML(t *testing.T) {


### PR DESCRIPTION
## Summary
- rewrite URL-carrying admin `data-*` attributes into page-relative paths when the admin UI is served behind a reverse-proxy subpath
- resolve async admin requests against the current page URL instead of the site origin so rewritten history and page-state endpoints keep the proxy prefix
- add regression coverage for the rewritten custom attributes and the chats page script

## Root cause
The admin HTML rewriter only adjusted `href`/`src`/`action`-style attributes. The chats page stores its history endpoint in `data-chat-history-path`, and the history loader resolved that attribute with `window.location.origin`. Behind a proxy subpath, the browser therefore requested `/api/chats/history` at the site root instead of the prefixed admin route, and the UI surfaced the nginx 404 HTML as plain text.

## Validation
- `cd openclaw && go test ./admin`
- `cd openclaw && go test ./...`
