### PR TITLE
event: clone applied surface ids in execution trace steps

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -225,9 +225,10 @@ func cloneExecutionTraceStep(step trace.Step) trace.Step {
 			[]string(nil),
 			step.PredecessorStepIDs...,
 		),
-		Input:  cloneExecutionTraceSnapshot(step.Input),
-		Output: cloneExecutionTraceSnapshot(step.Output),
-		Error:  step.Error,
+		AppliedSurfaceIDs: append([]string(nil), step.AppliedSurfaceIDs...),
+		Input:             cloneExecutionTraceSnapshot(step.Input),
+		Output:            cloneExecutionTraceSnapshot(step.Output),
+		Error:             step.Error,
 	}
 }
 


### PR DESCRIPTION
This PR updates execution trace step cloning to copy AppliedSurfaceIDs so cloned event payloads preserve applied surface information instead of dropping it.