### PR TITLE
processor: preserve batched tool call state delta

### DIFF
--- a/internal/flow/processor/functioncall.go
+++ b/internal/flow/processor/functioncall.go
@@ -72,6 +72,8 @@ type toolEventStateDelta struct {
 	choice model.Choice
 }
 
+type resolvedToolContextKey struct{}
+
 // toolResult holds the result of a single tool execution.
 type toolResult struct {
 	index      int
@@ -450,8 +452,6 @@ func (p *FunctionCallResponseProcessor) executeSingleToolCallSequentialResult(
 	if err == nil {
 		stateDelta = p.buildToolEventStateDelta(
 			ctx,
-			tools,
-			toolCall.Function.Name,
 			modifiedArgs,
 			choices,
 		)
@@ -667,8 +667,6 @@ func (p *FunctionCallResponseProcessor) runParallelToolCall(
 	}
 	stateDelta := p.buildToolEventStateDelta(
 		ctx,
-		tools,
-		tc.Function.Name,
 		modifiedArgs,
 		choices,
 	)
@@ -817,15 +815,13 @@ func (p *FunctionCallResponseProcessor) annotateSkipSummarization(
 
 func (p *FunctionCallResponseProcessor) buildToolEventStateDelta(
 	ctx context.Context,
-	tools map[string]tool.Tool,
-	toolName string,
 	args []byte,
 	choices []model.Choice,
 ) *toolEventStateDelta {
 	if len(choices) == 0 || hasSyntheticStateOnlyToolChoice(ctx) {
 		return nil
 	}
-	tl, ok := tools[toolName]
+	tl, ok := resolvedToolFromContext(ctx)
 	if !ok {
 		return nil
 	}
@@ -849,11 +845,32 @@ func newStateDeltaInvocationView(
 	return view
 }
 
+func withResolvedToolContext(
+	ctx context.Context,
+	tl tool.Tool,
+) context.Context {
+	if ctx == nil || tl == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, resolvedToolContextKey{}, tl)
+}
+
+func resolvedToolFromContext(ctx context.Context) (tool.Tool, bool) {
+	if ctx == nil {
+		return nil, false
+	}
+	tl, ok := ctx.Value(resolvedToolContextKey{}).(tool.Tool)
+	return tl, ok
+}
+
 func (p *FunctionCallResponseProcessor) attachStateDeltaToToolResults(
 	invocation *agent.Invocation,
 	results []toolResult,
 ) []*event.Event {
-	stateDeltaInv := newStateDeltaInvocationView(invocation)
+	var (
+		stateDeltaInv     *agent.Invocation
+		pendingStateDelta []*event.Event
+	)
 	events := make([]*event.Event, 0, len(results))
 	for i := 0; i < len(results); i++ {
 		result := results[i]
@@ -861,6 +878,16 @@ func (p *FunctionCallResponseProcessor) attachStateDeltaToToolResults(
 			continue
 		}
 		if result.stateDelta != nil {
+			if stateDeltaInv == nil {
+				stateDeltaInv = newStateDeltaInvocationView(invocation)
+				if stateDeltaInv != nil && stateDeltaInv.Session != nil {
+					for j := 0; j < len(pendingStateDelta); j++ {
+						stateDeltaInv.Session.ApplyEventStateDelta(
+							pendingStateDelta[j],
+						)
+					}
+				}
+			}
 			p.attachStateDelta(
 				stateDeltaInv,
 				result.stateDelta.tool,
@@ -873,6 +900,11 @@ func (p *FunctionCallResponseProcessor) attachStateDeltaToToolResults(
 			stateDeltaInv.Session != nil &&
 			len(result.event.StateDelta) > 0 {
 			stateDeltaInv.Session.ApplyEventStateDelta(result.event)
+		} else if len(result.event.StateDelta) > 0 {
+			pendingStateDelta = append(
+				pendingStateDelta,
+				result.event,
+			)
 		}
 		events = append(events, result.event)
 	}
@@ -986,6 +1018,7 @@ func (p *FunctionCallResponseProcessor) executeToolCall(
 		tl,
 		eventChan,
 	)
+	ctx = withResolvedToolContext(ctx, tl)
 	// Only return error when it's a stop error
 	if err != nil {
 		if _, ok := agent.AsStopError(err); ok {

--- a/internal/flow/processor/functioncall.go
+++ b/internal/flow/processor/functioncall.go
@@ -66,11 +66,18 @@ type streamInnerPreference interface {
 	StreamInner() bool
 }
 
+type toolEventStateDelta struct {
+	tool   tool.Tool
+	args   []byte
+	choice model.Choice
+}
+
 // toolResult holds the result of a single tool execution.
 type toolResult struct {
-	index int
-	event *event.Event
-	err   error
+	index      int
+	event      *event.Event
+	err        error
+	stateDelta *toolEventStateDelta
 }
 
 // Default message used when transferring to a sub-agent without an explicit message.
@@ -326,18 +333,22 @@ func (p *FunctionCallResponseProcessor) handleFunctionCalls(
 		return p.executeToolCallsInParallel(ctx, invocation, llmResponse, toolCalls, tools, eventChan)
 	}
 
-	var toolCallResponsesEvents []*event.Event
+	toolResults := make([]toolResult, 0, len(toolCalls))
 	for i, tc := range toolCalls {
-		toolEvent, err := p.executeSingleToolCallSequential(
+		result, err := p.executeSingleToolCallSequentialResult(
 			ctx, invocation, llmResponse, tools, eventChan, i, tc,
 		)
 		if err != nil {
 			return nil, err
 		}
-		if toolEvent != nil {
-			toolCallResponsesEvents = append(toolCallResponsesEvents, toolEvent)
+		if result.event != nil {
+			toolResults = append(toolResults, result)
 		}
 	}
+	toolCallResponsesEvents := p.attachStateDeltaToToolResults(
+		invocation,
+		toolResults,
+	)
 
 	if len(toolCallResponsesEvents) == 0 &&
 		invocation != nil &&
@@ -367,6 +378,37 @@ func (p *FunctionCallResponseProcessor) executeSingleToolCallSequential(
 	index int,
 	toolCall model.ToolCall,
 ) (*event.Event, error) {
+	result, err := p.executeSingleToolCallSequentialResult(
+		ctx,
+		invocation,
+		llmResponse,
+		tools,
+		eventChan,
+		index,
+		toolCall,
+	)
+	if result.event == nil {
+		return nil, err
+	}
+	toolEvents := p.attachStateDeltaToToolResults(
+		invocation,
+		[]toolResult{result},
+	)
+	if len(toolEvents) == 0 {
+		return nil, err
+	}
+	return toolEvents[0], err
+}
+
+func (p *FunctionCallResponseProcessor) executeSingleToolCallSequentialResult(
+	ctx context.Context,
+	invocation *agent.Invocation,
+	llmResponse *model.Response,
+	tools map[string]tool.Tool,
+	eventChan chan<- *event.Event,
+	index int,
+	toolCall model.ToolCall,
+) (toolResult, error) {
 	ctx, span, startedSpan := itrace.StartSpan(ctx, invocation, itelemetry.NewExecuteToolSpanName(toolCall.Function.Name))
 	if startedSpan {
 		defer span.End()
@@ -388,7 +430,7 @@ func (p *FunctionCallResponseProcessor) executeSingleToolCallSequential(
 			choices = []model.Choice{*choice}
 		} else {
 			// Return critical errors (e.g., stop errors) immediately
-			return nil, err
+			return toolResult{}, err
 		}
 	}
 	toolEvent := p.buildToolCallResponseEvent(
@@ -401,31 +443,25 @@ func (p *FunctionCallResponseProcessor) executeSingleToolCallSequential(
 		skipSummarization,
 	)
 	if toolEvent == nil {
-		return nil, nil
+		return toolResult{index: index}, nil
 	}
 	decl := p.lookupDeclaration(tools, toolCall.Function.Name)
+	var stateDelta *toolEventStateDelta
+	if err == nil {
+		stateDelta = p.buildToolEventStateDelta(
+			ctx,
+			tools,
+			toolCall.Function.Name,
+			modifiedArgs,
+			choices,
+		)
+	}
 
 	var (
 		sess      = &session.Session{}
 		modelName string
 		agentName string
 	)
-	// Attach state delta if the tool provides it.
-	if err == nil && len(choices) > 0 &&
-		!hasSyntheticStateOnlyToolChoice(ctx) {
-		if tl, ok := tools[toolCall.Function.Name]; ok {
-			// Use the first choice as the canonical tool result for state
-			// delta.
-			p.attachStateDelta(
-				invocation,
-				tl,
-				modifiedArgs,
-				&choices[0],
-				toolEvent,
-			)
-		}
-	}
-
 	if invocation != nil {
 		if invocation.Session != nil {
 			sess = invocation.Session
@@ -450,7 +486,11 @@ func (p *FunctionCallResponseProcessor) executeSingleToolCallSequential(
 		AgentName:        agentName,
 		Error:            err,
 	}, time.Since(startTime))
-	return toolEvent, nil
+	return toolResult{
+		index:      index,
+		event:      toolEvent,
+		stateDelta: stateDelta,
+	}, nil
 }
 
 // executeToolCallsInParallel runs multiple tool calls concurrently and merges
@@ -481,10 +521,10 @@ func (p *FunctionCallResponseProcessor) executeToolCallsInParallel(
 		close(done)
 	}()
 
-	toolCallResponsesEvents, err := p.collectParallelToolResults(
+	toolResults, err := p.collectParallelToolResults(
 		ctx, resultChan, len(toolCalls),
 	)
-	if len(toolCallResponsesEvents) == 0 &&
+	if len(toolResults) == 0 &&
 		invocation != nil &&
 		invocation.RunOptions.ToolExecutionFilter != nil {
 		filter := invocation.RunOptions.ToolExecutionFilter
@@ -495,6 +535,10 @@ func (p *FunctionCallResponseProcessor) executeToolCallsInParallel(
 			}
 		}
 	}
+	toolCallResponsesEvents := p.attachStateDeltaToToolResults(
+		invocation,
+		toolResults,
+	)
 	mergedEvent := p.buildMergedParallelEvent(
 		ctx, invocation, llmResponse, tools, toolCalls, toolCallResponsesEvents,
 	)
@@ -621,19 +665,13 @@ func (p *FunctionCallResponseProcessor) runParallelToolCall(
 			agentName = invocation.AgentName
 		}
 	}
-	// Attach state delta if the tool provides it.
-	if len(choices) > 0 && !hasSyntheticStateOnlyToolChoice(ctx) {
-		if tl, ok := tools[tc.Function.Name]; ok {
-			// Use the first choice as the canonical tool result for state delta.
-			p.attachStateDelta(
-				invocation,
-				tl,
-				modifiedArgs,
-				&choices[0],
-				toolCallResponseEvent,
-			)
-		}
-	}
+	stateDelta := p.buildToolEventStateDelta(
+		ctx,
+		tools,
+		tc.Function.Name,
+		modifiedArgs,
+		choices,
+	)
 	if startedSpan {
 		itelemetry.TraceToolCall(span, sess, decl, modifiedArgs, toolCallResponseEvent, err)
 	}
@@ -648,7 +686,11 @@ func (p *FunctionCallResponseProcessor) runParallelToolCall(
 	}, time.Since(startTime))
 	// Send result back to aggregator.
 	p.sendToolResult(
-		ctx, resultChan, toolResult{index: index, event: toolCallResponseEvent},
+		ctx, resultChan, toolResult{
+			index:      index,
+			event:      toolCallResponseEvent,
+			stateDelta: stateDelta,
+		},
 	)
 }
 
@@ -771,6 +813,70 @@ func (p *FunctionCallResponseProcessor) annotateSkipSummarization(
 	if dynamic || toolPrefersSkipSummarization(tl) {
 		markSkipSummarization(ev)
 	}
+}
+
+func (p *FunctionCallResponseProcessor) buildToolEventStateDelta(
+	ctx context.Context,
+	tools map[string]tool.Tool,
+	toolName string,
+	args []byte,
+	choices []model.Choice,
+) *toolEventStateDelta {
+	if len(choices) == 0 || hasSyntheticStateOnlyToolChoice(ctx) {
+		return nil
+	}
+	tl, ok := tools[toolName]
+	if !ok {
+		return nil
+	}
+	return &toolEventStateDelta{
+		tool:   tl,
+		args:   args,
+		choice: choices[0],
+	}
+}
+
+func newStateDeltaInvocationView(
+	invocation *agent.Invocation,
+) *agent.Invocation {
+	if invocation == nil {
+		return nil
+	}
+	view := invocation.View()
+	if invocation.Session != nil {
+		view.Session = invocation.Session.Clone()
+	}
+	return view
+}
+
+func (p *FunctionCallResponseProcessor) attachStateDeltaToToolResults(
+	invocation *agent.Invocation,
+	results []toolResult,
+) []*event.Event {
+	stateDeltaInv := newStateDeltaInvocationView(invocation)
+	events := make([]*event.Event, 0, len(results))
+	for i := 0; i < len(results); i++ {
+		result := results[i]
+		if result.event == nil {
+			continue
+		}
+		if result.stateDelta != nil {
+			p.attachStateDelta(
+				stateDeltaInv,
+				result.stateDelta.tool,
+				result.stateDelta.args,
+				&result.stateDelta.choice,
+				result.event,
+			)
+		}
+		if stateDeltaInv != nil &&
+			stateDeltaInv.Session != nil &&
+			len(result.event.StateDelta) > 0 {
+			stateDeltaInv.Session.ApplyEventStateDelta(result.event)
+		}
+		events = append(events, result.event)
+	}
+	return events
 }
 
 // lookupDeclaration returns a declaration or a safe placeholder.
@@ -1098,18 +1204,18 @@ func (p *FunctionCallResponseProcessor) collectParallelToolResults(
 	ctx context.Context,
 	resultChan <-chan toolResult,
 	toolCallsCount int,
-) ([]*event.Event, error) {
-	results := make([]*event.Event, toolCallsCount)
+) ([]toolResult, error) {
+	results := make([]toolResult, toolCallsCount)
 	var err error
 	for {
 		select {
 		case result, ok := <-resultChan:
 			if !ok {
 				// Channel closed, all results received.
-				return p.filterNilEvents(results), err
+				return p.filterNilToolResults(results), err
 			}
 			if result.index >= 0 && result.index < len(results) {
-				results[result.index] = result.event
+				results[result.index] = result
 				if err == nil && result.err != nil {
 					err = result.err
 				}
@@ -1127,7 +1233,7 @@ func (p *FunctionCallResponseProcessor) collectParallelToolResults(
 				ctx,
 				"Context cancelled while waiting for tool results",
 			)
-			return p.filterNilEvents(results), nil
+			return p.filterNilToolResults(results), nil
 		}
 	}
 }
@@ -1850,14 +1956,16 @@ func marshalChunkToText(content any) string {
 	}
 }
 
-// filterNilEvents filters out nil events from a slice of events while preserving order.
+// filterNilToolResults filters out nil events while preserving order.
 // Pre-allocates capacity to avoid multiple memory allocations.
-func (p *FunctionCallResponseProcessor) filterNilEvents(results []*event.Event) []*event.Event {
+func (p *FunctionCallResponseProcessor) filterNilToolResults(
+	results []toolResult,
+) []toolResult {
 	// Pre-allocate with capacity to reduce allocations
-	filtered := make([]*event.Event, 0, len(results))
-	for _, event := range results {
-		if event != nil {
-			filtered = append(filtered, event)
+	filtered := make([]toolResult, 0, len(results))
+	for _, result := range results {
+		if result.event != nil {
+			filtered = append(filtered, result)
 		}
 	}
 	return filtered

--- a/internal/flow/processor/functioncall_test.go
+++ b/internal/flow/processor/functioncall_test.go
@@ -34,10 +34,12 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/plugin"
 	"trpc.group/trpc-go/trpc-agent-go/session"
+	skillstate "trpc.group/trpc-go/trpc-agent-go/skill"
 	"trpc.group/trpc-go/trpc-agent-go/telemetry/trace"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 	agenttool "trpc.group/trpc-go/trpc-agent-go/tool/agent"
 	"trpc.group/trpc-go/trpc-agent-go/tool/function"
+	skilltool "trpc.group/trpc-go/trpc-agent-go/tool/skill"
 	"trpc.group/trpc-go/trpc-agent-go/tool/transfer"
 )
 
@@ -99,6 +101,25 @@ type mockCallableTool struct {
 func (m *mockCallableTool) Declaration() *tool.Declaration { return m.declaration }
 func (m *mockCallableTool) Call(ctx context.Context, args []byte) (any, error) {
 	return m.callFn(ctx, args)
+}
+
+type delayedLoadTool struct {
+	*skilltool.LoadTool
+	delays map[string]time.Duration
+}
+
+func (t *delayedLoadTool) Call(
+	ctx context.Context,
+	args []byte,
+) (any, error) {
+	var in struct {
+		Skill string `json:"skill"`
+	}
+	_ = json.Unmarshal(args, &in)
+	if delay := t.delays[in.Skill]; delay > 0 {
+		time.Sleep(delay)
+	}
+	return t.LoadTool.Call(ctx, args)
 }
 
 type mockCallbackCompatibleResult struct {
@@ -333,6 +354,136 @@ func TestFunctionCallResponseProcessor_AttachStateDelta(t *testing.T) {
 	}
 	p.attachStateDelta(inv, tl2, args, choice, ev2)
 	require.Equal(t, []byte(deltaVal2), ev2.StateDelta[deltaKey2])
+}
+
+func marshalSkillLoadArgs(
+	t *testing.T,
+	skillName string,
+) []byte {
+	t.Helper()
+	args, err := json.Marshal(map[string]string{
+		"skill": skillName,
+	})
+	require.NoError(t, err)
+	return args
+}
+
+func newSkillLoadToolCall(
+	t *testing.T,
+	id string,
+	skillName string,
+) model.ToolCall {
+	t.Helper()
+	return model.ToolCall{
+		ID: id,
+		Function: model.FunctionDefinitionParam{
+			Name:      "skill_load",
+			Arguments: marshalSkillLoadArgs(t, skillName),
+		},
+	}
+}
+
+func newToolCallResponseWithCalls(
+	toolCalls []model.ToolCall,
+) *model.Response {
+	return &model.Response{
+		Model: "mock-model",
+		Choices: []model.Choice{{
+			Message: model.Message{
+				Role:      model.RoleAssistant,
+				ToolCalls: toolCalls,
+			},
+		}},
+	}
+}
+
+func TestHandleFunctionCalls_SequentialUsesMergedInvocationStateDelta(
+	t *testing.T,
+) {
+	const agentName = "tester"
+	loadTool := skilltool.NewLoadTool(nil)
+	tools := map[string]tool.Tool{
+		loadTool.Declaration().Name: loadTool,
+	}
+	inv := &agent.Invocation{
+		AgentName: agentName,
+		Session: &session.Session{
+			State: session.StateMap{
+				skillstate.LoadedOrderKey(agentName): []byte(
+					`["a","b","c","d"]`,
+				),
+			},
+		},
+	}
+	toolCalls := []model.ToolCall{
+		newSkillLoadToolCall(t, "call-1", "a"),
+		newSkillLoadToolCall(t, "call-2", "b"),
+	}
+
+	ev, err := NewFunctionCallResponseProcessor(
+		false,
+		nil,
+	).handleFunctionCalls(
+		context.Background(),
+		inv,
+		newToolCallResponseWithCalls(toolCalls),
+		tools,
+		nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, ev)
+	require.Equal(
+		t,
+		`["c","d","a","b"]`,
+		string(ev.StateDelta[skillstate.LoadedOrderKey(agentName)]),
+	)
+}
+
+func TestHandleFunctionCalls_ParallelUsesMergedInvocationStateDelta(
+	t *testing.T,
+) {
+	const agentName = "tester"
+	loadTool := &delayedLoadTool{
+		LoadTool: skilltool.NewLoadTool(nil),
+		delays: map[string]time.Duration{
+			"a": 50 * time.Millisecond,
+		},
+	}
+	tools := map[string]tool.Tool{
+		loadTool.Declaration().Name: loadTool,
+	}
+	inv := &agent.Invocation{
+		AgentName: agentName,
+		Session: &session.Session{
+			State: session.StateMap{
+				skillstate.LoadedOrderKey(agentName): []byte(
+					`["a","b","c","d"]`,
+				),
+			},
+		},
+	}
+	toolCalls := []model.ToolCall{
+		newSkillLoadToolCall(t, "call-1", "a"),
+		newSkillLoadToolCall(t, "call-2", "b"),
+	}
+
+	ev, err := NewFunctionCallResponseProcessor(
+		true,
+		nil,
+	).handleFunctionCalls(
+		context.Background(),
+		inv,
+		newToolCallResponseWithCalls(toolCalls),
+		tools,
+		nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, ev)
+	require.Equal(
+		t,
+		`["c","d","a","b"]`,
+		string(ev.StateDelta[skillstate.LoadedOrderKey(agentName)]),
+	)
 }
 
 func TestExecuteToolCall(t *testing.T) {

--- a/internal/flow/processor/functioncall_test.go
+++ b/internal/flow/processor/functioncall_test.go
@@ -117,7 +117,11 @@ func (t *delayedLoadTool) Call(
 	}
 	_ = json.Unmarshal(args, &in)
 	if delay := t.delays[in.Skill]; delay > 0 {
-		time.Sleep(delay)
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
 	}
 	return t.LoadTool.Call(ctx, args)
 }
@@ -225,6 +229,7 @@ func TestExecuteToolCallsInParallel_DisableTracingSkipsSpanCreation(t *testing.T
 
 type mockInvocationStateDeltaTool struct {
 	declaration *tool.Declaration
+	callFn      func(context.Context, []byte) (any, error)
 	delta       map[string][]byte
 }
 
@@ -235,6 +240,16 @@ func (m *mockInvocationStateDeltaTool) Declaration() *tool.Declaration {
 	return &tool.Declaration{Name: "mock"}
 }
 
+func (m *mockInvocationStateDeltaTool) Call(
+	ctx context.Context,
+	args []byte,
+) (any, error) {
+	if m.callFn != nil {
+		return m.callFn(ctx, args)
+	}
+	return map[string]any{"ok": true}, nil
+}
+
 func (m *mockInvocationStateDeltaTool) StateDeltaForInvocation(
 	_ *agent.Invocation,
 	_ string,
@@ -242,6 +257,44 @@ func (m *mockInvocationStateDeltaTool) StateDeltaForInvocation(
 	_ []byte,
 ) map[string][]byte {
 	return m.delta
+}
+
+type sessionReadingStateDeltaTool struct {
+	declaration *tool.Declaration
+	readKey     string
+	writeKey    string
+}
+
+func (t *sessionReadingStateDeltaTool) Declaration() *tool.Declaration {
+	if t.declaration != nil {
+		return t.declaration
+	}
+	return &tool.Declaration{Name: "session-reading"}
+}
+
+func (t *sessionReadingStateDeltaTool) Call(
+	context.Context,
+	[]byte,
+) (any, error) {
+	return map[string]any{"ok": true}, nil
+}
+
+func (t *sessionReadingStateDeltaTool) StateDeltaForInvocation(
+	inv *agent.Invocation,
+	_ string,
+	_ []byte,
+	_ []byte,
+) map[string][]byte {
+	if inv == nil || inv.Session == nil {
+		return nil
+	}
+	value, ok := inv.Session.GetState(t.readKey)
+	if !ok {
+		return nil
+	}
+	return map[string][]byte{
+		t.writeKey: append([]byte(nil), value...),
+	}
 }
 
 type mockStateDeltaTool struct {
@@ -315,6 +368,64 @@ func TestExecuteToolCall_MapsSubAgentToTransfer(t *testing.T) {
 	assert.Equal(t, "What's the weather like in Tokyo?", got.Message)
 }
 
+func TestExecuteSingleToolCallSequential_AttachesMappedToolStateDelta(
+	t *testing.T,
+) {
+	ctx := context.Background()
+	p := NewFunctionCallResponseProcessor(false, nil)
+	inv := &agent.Invocation{
+		InvocationID: "inv-map-delta",
+		AgentName:    "coordinator",
+		Agent: &mockTransferAgent{
+			subAgents: []agent.Agent{
+				&mockTransferSubAgent{
+					info: &mockTransferAgentInfo{name: "weather-agent"},
+				},
+			},
+		},
+	}
+	tc := model.ToolCall{
+		ID: "call-1",
+		Function: model.FunctionDefinitionParam{
+			Name:      "weather-agent",
+			Arguments: []byte(`{"message":"weather"}`),
+		},
+	}
+	rsp := &model.Response{
+		Model: "mock-model",
+		Choices: []model.Choice{{
+			Message: model.Message{
+				Role:      model.RoleAssistant,
+				ToolCalls: []model.ToolCall{tc},
+			},
+		}},
+	}
+	const mappedStateKey = "mapped-state"
+	tools := map[string]tool.Tool{
+		transfer.TransferToolName: &mockInvocationStateDeltaTool{
+			declaration: &tool.Declaration{
+				Name: transfer.TransferToolName,
+			},
+			delta: map[string][]byte{
+				mappedStateKey: []byte("1"),
+			},
+		},
+	}
+
+	ev, err := p.executeSingleToolCallSequential(
+		ctx,
+		inv,
+		rsp,
+		tools,
+		nil,
+		0,
+		tc,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, ev)
+	require.Equal(t, []byte("1"), ev.StateDelta[mappedStateKey])
+}
+
 func TestFunctionCallResponseProcessor_AttachStateDelta(t *testing.T) {
 	const (
 		deltaKey1 = "k1"
@@ -354,6 +465,53 @@ func TestFunctionCallResponseProcessor_AttachStateDelta(t *testing.T) {
 	}
 	p.attachStateDelta(inv, tl2, args, choice, ev2)
 	require.Equal(t, []byte(deltaVal2), ev2.StateDelta[deltaKey2])
+}
+
+func TestAttachStateDeltaToToolResults_ReplaysPendingStateDeltas(
+	t *testing.T,
+) {
+	const (
+		readKey  = "existing"
+		writeKey = "copied"
+	)
+	p := &FunctionCallResponseProcessor{}
+	inv := &agent.Invocation{
+		AgentName: "tester",
+		Session:   &session.Session{State: session.StateMap{}},
+	}
+	choice := model.Choice{
+		Message: model.Message{
+			ToolID:  "call-2",
+			Content: `{"ok":true}`,
+			Role:    model.RoleTool,
+		},
+	}
+	results := []toolResult{
+		{
+			index: 0,
+			event: &event.Event{
+				StateDelta: map[string][]byte{
+					readKey: []byte("v1"),
+				},
+			},
+		},
+		{
+			index: 1,
+			event: &event.Event{},
+			stateDelta: &toolEventStateDelta{
+				tool: &sessionReadingStateDeltaTool{
+					readKey:  readKey,
+					writeKey: writeKey,
+				},
+				args:   []byte(`{}`),
+				choice: choice,
+			},
+		},
+	}
+
+	events := p.attachStateDeltaToToolResults(inv, results)
+	require.Len(t, events, 2)
+	require.Equal(t, []byte("v1"), events[1].StateDelta[writeKey])
 }
 
 func marshalSkillLoadArgs(


### PR DESCRIPTION
## Summary
- preserve invocation-aware state delta evaluation across multiple tool calls in one assistant response by replaying earlier deltas on a cloned session view
- keep sequential and parallel tool-call paths consistent so merged tool responses keep the latest logical state instead of the last stale snapshot
- add regressions for batched `skill_load` calls in both sequential and parallel execution paths

## Root cause
`StateDeltaForInvocation` previously evaluated each tool call against the original `inv.Session`. When one assistant response contained multiple tool calls that touched the same state key, later deltas ignored earlier updates and the merged response kept a stale last-write-wins snapshot.

## Testing
- `go test ./internal/flow/processor`
- `go test ./internal/flow/processor -run 'TestHandleFunctionCalls_(Sequential|Parallel)UsesMergedInvocationStateDelta|TestSkillsRequestProcessor_MaxLoadedSkills_(SelectDocsTouchesSkill|ToolResultMode_EvictsOldest|UsesStoredOrder)|TestKeepMostRecentSkills_UsesStoredOrder|TestLoadedSkillOrder_FallsBackFromInvalidStateToEvents'`
- `go test ./tool/skill -run 'TestLoadTool_Call_ValidatesAndDelta|TestAppendLoadedOrderStateDelta|TestSelectDocsTool_ReplaceAndAll'`