### PR TITLE
{model/hedge, docs, examples}: add hedge model

### DIFF
--- a/docs/mkdocs/en/model.md
+++ b/docs/mkdocs/en/model.md
@@ -2410,3 +2410,90 @@ if err != nil {
 - Switching is allowed only before the first non-error chunk is received.
 - If the current candidate returns an `error` directly before that point, or returns an error response with `Response.Error`, the wrapper continues with the next candidate.
 - Once any non-error chunk has been returned to the caller, later streaming failures are surfaced directly instead of replaying the request on the backup candidate.
+
+## Model Hedge
+
+`model/hedge` provides a wrapper for hedging the time to first meaningful response. It starts the primary candidate immediately, then launches later candidates according to the configured hedge delay. If all currently active candidates have already failed, it launches the next candidate early. The first candidate that produces a meaningful response becomes the winner, and the remaining candidates are canceled.
+
+**Quick Start:**
+
+```go
+import (
+    "trpc.group/trpc-go/trpc-agent-go/model/hedge"
+    "trpc.group/trpc-go/trpc-agent-go/model/openai"
+)
+
+primary := openai.New(
+    "gpt-4o-mini",
+    openai.WithBaseURL("https://api.openai.com/v1"),
+)
+backup := openai.New(
+    "deepseek-chat",
+    openai.WithBaseURL("https://api.deepseek.com/v1"),
+)
+
+llm, err := hedge.New(
+    hedge.WithName("chat-hedge"),
+    hedge.WithCandidates(primary, backup),
+)
+if err != nil {
+    return err
+}
+```
+
+`hedge.New(...)` also returns a regular `model.Model`, so it can be passed directly to places that accept `model.Model`, such as `llmagent.WithModel(...)`. This quick start uses the package default delay. Use `WithDelay(...)` or `WithDelays(...)` when you need explicit launch scheduling. For a complete example, see [examples/model/hedge](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/model/hedge).
+
+**Scheduling And Commit Rules**:
+
+- The first candidate always starts immediately when the request begins.
+- `WithDelay(...)` defines one fixed interval between successive hedge launches, while `WithDelays(...)` can specify explicit launch offsets for candidates `1..n`.
+- If all currently active candidates have already failed and there are still candidates that have not started, the wrapper launches the next candidate immediately instead of waiting for the timer.
+- Only the first candidate that starts producing meaningful content becomes the winner. Empty or metadata-only responses do not win.
+- Once a winner has been committed, the other candidates are canceled and only the winner's stream is forwarded to the caller.
+
+**Configuration Examples**:
+
+The following snippets show only the scheduling differences.
+
+```go
+llm, err := hedge.New(
+    hedge.WithCandidates(primary, backupA, backupB),
+    hedge.WithDelay(100*time.Millisecond),
+)
+```
+
+This configuration means:
+
+- `candidate[0]` starts at `0ms`.
+- `candidate[1]` starts at `100ms`.
+- `candidate[2]` starts at `200ms`.
+
+```go
+llm, err := hedge.New(
+    hedge.WithCandidates(primary, backupA, backupB),
+    hedge.WithDelays(80*time.Millisecond, 250*time.Millisecond),
+)
+```
+
+This configuration means:
+
+- `candidate[0]` starts at `0ms`.
+- `candidate[1]` starts at `80ms`.
+- `candidate[2]` starts at `250ms`.
+
+`WithDelays(...)` uses absolute launch offsets from request start, not incremental gaps relative to the previous candidate.
+
+```go
+llm, err := hedge.New(
+    hedge.WithCandidates(primary, backupA, backupB),
+    hedge.WithDelays(0, 0),
+)
+```
+
+This configuration means:
+
+- `candidate[0]` starts at `0ms`.
+- `candidate[1]` starts at `0ms`.
+- `candidate[2]` starts at `0ms`.
+
+This is the all-at-once case where every candidate launches immediately when the request begins. In fixed-interval form, the same setup can be written as `WithDelay(0)`.

--- a/docs/mkdocs/zh/model.md
+++ b/docs/mkdocs/zh/model.md
@@ -2401,3 +2401,90 @@ if err != nil {
 - 只有在收到首个非错误 chunk 之前，才允许从当前候选模型切换到下一个候选模型。
 - 如果当前候选模型在此之前直接返回 `error`，或返回带 `Response.Error` 的错误响应，就会继续尝试下一个候选模型。
 - 一旦已经向调用方返回过任意非错误 chunk，后续即使流式过程中再出错，也不会重放到备模型，而是直接将错误返回给调用方。
+
+## 模型对冲（Hedge）
+
+`model/hedge` 提供了一个用于对冲首 token 尾延迟的模型包装器。它会先启动主候选，再按配置的 hedge delay 逐步补发后续候选；如果当前已启动候选都已经失败，则会提前拉起下一个候选。谁先返回首个有意义响应，谁就成为本次请求的胜者，其余候选会被取消。
+
+**快速开始：**
+
+```go
+import (
+    "trpc.group/trpc-go/trpc-agent-go/model/hedge"
+    "trpc.group/trpc-go/trpc-agent-go/model/openai"
+)
+
+primary := openai.New(
+    "gpt-4o-mini",
+    openai.WithBaseURL("https://api.openai.com/v1"),
+)
+backup := openai.New(
+    "deepseek-chat",
+    openai.WithBaseURL("https://api.deepseek.com/v1"),
+)
+
+llm, err := hedge.New(
+    hedge.WithName("chat-hedge"),
+    hedge.WithCandidates(primary, backup),
+)
+if err != nil {
+    return err
+}
+```
+
+`hedge.New(...)` 同样返回普通的 `model.Model`，可以直接传给 `llmagent.WithModel(...)` 等接受 `model.Model` 的位置使用。上面这段代码使用包默认 delay；如果要显式控制补发时序，可继续使用 `WithDelay(...)` 或 `WithDelays(...)`。完整示例见 [examples/model/hedge](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/model/hedge)。
+
+**调度与提交规则：**
+
+- 第一个候选总是在请求开始时立即启动。
+- `WithDelay(...)` 表示相邻 hedge 候选的固定补发间隔；`WithDelays(...)` 可显式指定候选 `1..n` 的启动偏移。
+- 如果当前所有已启动候选都已经失败，且仍有未启动候选，包装器会立即拉起下一个候选，而不是继续等待定时器。
+- 只有真正开始产出有效内容的候选才会成为胜者；只返回空内容或元数据的响应不会抢占胜者。
+- 一旦已经提交胜者，其他候选会被取消，后续只继续向调用方转发胜者的流。
+
+**配置示例：**
+
+下面的片段只展示调度配置差异。
+
+```go
+llm, err := hedge.New(
+    hedge.WithCandidates(primary, backupA, backupB),
+    hedge.WithDelay(100*time.Millisecond),
+)
+```
+
+上面这段配置表示：
+
+- `candidate[0]` 在 `0ms` 启动。
+- `candidate[1]` 在 `100ms` 启动。
+- `candidate[2]` 在 `200ms` 启动。
+
+```go
+llm, err := hedge.New(
+    hedge.WithCandidates(primary, backupA, backupB),
+    hedge.WithDelays(80*time.Millisecond, 250*time.Millisecond),
+)
+```
+
+上面这段配置表示：
+
+- `candidate[0]` 在 `0ms` 启动。
+- `candidate[1]` 在 `80ms` 启动。
+- `candidate[2]` 在 `250ms` 启动。
+
+这里 `WithDelays(...)` 传入的是相对请求开始时刻的绝对启动偏移，不是相对上一个候选的增量间隔。
+
+```go
+llm, err := hedge.New(
+    hedge.WithCandidates(primary, backupA, backupB),
+    hedge.WithDelays(0, 0),
+)
+```
+
+上面这段配置表示：
+
+- `candidate[0]` 在 `0ms` 启动。
+- `candidate[1]` 在 `0ms` 启动。
+- `candidate[2]` 在 `0ms` 启动。
+
+这相当于所有候选在请求开始时立即并发发起；如果是固定间隔模式，也可以写成 `WithDelay(0)`。

--- a/examples/model/README.md
+++ b/examples/model/README.md
@@ -15,6 +15,7 @@ See also the focused sub-examples in this directory:
 - `retry/` for SDK-level retry configuration.
 - `switch/` for runtime model switching.
 - `failover/` for primary/backup model failover before the first non-error chunk.
+- `hedge/` for delayed or failure-triggered hedge requests across multiple candidates.
 
 ## Key Features
 

--- a/examples/model/hedge/README.md
+++ b/examples/model/hedge/README.md
@@ -1,0 +1,114 @@
+# Model Hedge with LLMAgent and Runner
+
+This example demonstrates how to use `model/hedge` behind `llmagent` and `runner`.
+
+The primary provider uses the official OpenAI endpoint, and the backup provider uses DeepSeek. The example keeps the hedge logic at the model layer, then plugs that wrapped model into a normal multi-turn chat stack built with `LLMAgent` and `Runner`.
+
+## What This Example Shows
+
+- A hedged model chain created with `hedge.New(...)`.
+- A normal `llmagent.New(...)` setup using the hedge model as its single LLM.
+- A `runner.NewRunner(...)` chat loop with in-memory session storage.
+- Interactive multi-turn chat without any mock provider or fake transport.
+
+## Hedge Rule
+
+The wrapper behaves as follows:
+
+1. It launches the primary candidate immediately.
+2. It launches the next candidate after the configured hedge delay, or earlier when all active candidates have already failed.
+3. It commits the first candidate that produces a meaningful non-error response.
+4. Once a winner is committed, it cancels the other candidates and keeps forwarding only the winner's stream.
+
+## Environment Variables
+
+The example expects separate credentials for the two providers:
+
+| Variable | Description |
+| --- | --- |
+| `OPENAI_API_KEY` | API key for the primary OpenAI endpoint. |
+| `DEEPSEEK_API_KEY` | API key for the backup DeepSeek endpoint. |
+
+The example passes explicit base URLs in code:
+
+- Primary: `https://api.openai.com/v1`
+- Backup: `https://api.deepseek.com/v1`
+
+## Running The Example
+
+```bash
+export OPENAI_API_KEY="your-openai-key"
+export DEEPSEEK_API_KEY="your-deepseek-key"
+
+cd examples/model/hedge
+go run . \
+  -primary-model gpt-4o-mini \
+  -backup-model deepseek-chat \
+  -hedge-delay=100ms \
+  -streaming=true
+```
+
+## Available Flags
+
+| Flag | Description | Default |
+| --- | --- | --- |
+| `-primary-model` | Primary model name. | `gpt-4o-mini` |
+| `-backup-model` | Backup model name. | `deepseek-chat` |
+| `-primary-base-url` | Primary model base URL. | `https://api.openai.com/v1` |
+| `-backup-base-url` | Backup model base URL. | `https://api.deepseek.com/v1` |
+| `-hedge-delay` | Delay before launching the next hedge candidate. | `100ms` |
+| `-streaming` | Enables streaming responses. | `true` |
+
+## Chat Commands
+
+- `/new` starts a fresh session.
+- `/exit` ends the conversation.
+
+## Core Setup
+
+```go
+primary := openai.New(
+    "gpt-4o-mini",
+    openai.WithBaseURL("https://api.openai.com/v1"),
+)
+backup := openai.New(
+    "deepseek-chat",
+    openai.WithBaseURL("https://api.deepseek.com/v1"),
+)
+
+llm, err := hedge.New(
+    hedge.WithName("hedge-chat-model"),
+    hedge.WithCandidates(primary, backup),
+    hedge.WithDelay(100*time.Millisecond),
+)
+if err != nil {
+    return err
+}
+
+agentInstance := llmagent.New(
+    "hedge-chat-agent",
+    llmagent.WithModel(llm),
+    llmagent.WithGenerationConfig(model.GenerationConfig{Stream: true}),
+)
+
+r := runner.NewRunner(
+    "hedge-chat-demo",
+    agentInstance,
+    runner.WithSessionService(sessioninmemory.NewSessionService()),
+)
+```
+
+## Design Notes
+
+- The request is cloned per candidate, so provider-side request mutation on one candidate does not leak into another candidate.
+- Setting `-hedge-delay=0` makes the example launch both candidates immediately, which matches an all-at-once race.
+- The example uses the normal `LLMAgent + Runner` path, so the hedge model can be adopted without changing higher-level agent orchestration code.
+
+## Verification
+
+Build the example directly:
+
+```bash
+cd examples
+go build ./model/hedge
+```

--- a/examples/model/hedge/agent.go
+++ b/examples/model/hedge/agent.go
@@ -1,0 +1,42 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+func newHedgeAgent(config appConfig) (*llmagent.LLMAgent, error) {
+	hedgeModel, err := newHedgeModel(config)
+	if err != nil {
+		return nil, err
+	}
+	genConfig := model.GenerationConfig{
+		MaxTokens:   intPtr(1200),
+		Temperature: floatPtr(0.7),
+		Stream:      config.streaming,
+	}
+	return llmagent.New(
+		agentName,
+		llmagent.WithModel(hedgeModel),
+		llmagent.WithDescription("A chat assistant backed by a hedged primary and backup model."),
+		llmagent.WithInstruction("You are a concise and reliable assistant. Answer clearly and directly."),
+		llmagent.WithGenerationConfig(genConfig),
+	), nil
+}
+
+func intPtr(value int) *int {
+	return &value
+}
+
+func floatPtr(value float64) *float64 {
+	return &value
+}

--- a/examples/model/hedge/chat.go
+++ b/examples/model/hedge/chat.go
@@ -1,0 +1,108 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+	sessioninmemory "trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+)
+
+type hedgeChat struct {
+	config    appConfig
+	runner    runner.Runner
+	userID    string
+	sessionID string
+}
+
+func (c *hedgeChat) run() error {
+	ctx := context.Background()
+	if err := c.setup(ctx); err != nil {
+		return fmt.Errorf("setup failed: %w", err)
+	}
+	defer c.runner.Close()
+	return c.startChat(ctx)
+}
+
+func (c *hedgeChat) setup(_ context.Context) error {
+	agentInstance, err := newHedgeAgent(c.config)
+	if err != nil {
+		return err
+	}
+	c.runner = runner.NewRunner(
+		appName,
+		agentInstance,
+		runner.WithSessionService(sessioninmemory.NewSessionService()),
+	)
+	c.userID = "demo-user"
+	c.sessionID = newSessionID()
+	c.printBanner()
+	return nil
+}
+
+func (c *hedgeChat) startChat(ctx context.Context) error {
+	scanner := bufio.NewScanner(os.Stdin)
+	printCommands()
+	for {
+		fmt.Print("👤 You: ")
+		if !scanner.Scan() {
+			break
+		}
+		userInput := strings.TrimSpace(scanner.Text())
+		if userInput == "" {
+			continue
+		}
+		switch strings.ToLower(userInput) {
+		case "/new":
+			c.startNewSession()
+			continue
+		case "/exit":
+			fmt.Println("👋 Goodbye!")
+			return nil
+		}
+		if err := c.processMessage(ctx, userInput); err != nil {
+			fmt.Printf("❌ Error: %v\n", err)
+		}
+		fmt.Println()
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("input scanner error: %w", err)
+	}
+	return nil
+}
+
+func (c *hedgeChat) startNewSession() {
+	c.sessionID = newSessionID()
+	fmt.Printf("🆕 New session: %s\n\n", c.sessionID)
+}
+
+func (c *hedgeChat) processMessage(ctx context.Context, userMessage string) error {
+	eventChan, err := c.runner.Run(
+		ctx,
+		c.userID,
+		c.sessionID,
+		model.NewUserMessage(userMessage),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to run hedge agent: %w", err)
+	}
+	return c.processResponse(eventChan)
+}
+
+func newSessionID() string {
+	return fmt.Sprintf("hedge-session-%d", time.Now().UnixNano())
+}

--- a/examples/model/hedge/main.go
+++ b/examples/model/hedge/main.go
@@ -1,0 +1,59 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package main demonstrates hedged model requests with LLMAgent and Runner.
+package main
+
+import (
+	"flag"
+	"log"
+	"time"
+)
+
+const (
+	appName               = "hedge-chat-demo"
+	agentName             = "hedge-chat-agent"
+	defaultPrimaryModel   = "gpt-4o-mini"
+	defaultBackupModel    = "deepseek-chat"
+	defaultPrimaryBaseURL = "https://api.openai.com/v1"
+	defaultBackupBaseURL  = "https://api.deepseek.com/v1"
+	defaultHedgeDelay     = 100 * time.Millisecond
+)
+
+func main() {
+	primaryModelName := flag.String("primary-model", defaultPrimaryModel, "Primary model name.")
+	backupModelName := flag.String("backup-model", defaultBackupModel, "Backup model name.")
+	primaryBaseURL := flag.String("primary-base-url", defaultPrimaryBaseURL, "Primary model base URL.")
+	backupBaseURL := flag.String("backup-base-url", defaultBackupBaseURL, "Backup model base URL.")
+	hedgeDelay := flag.Duration("hedge-delay", defaultHedgeDelay, "Delay before launching the next hedge candidate.")
+	streaming := flag.Bool("streaming", true, "Enable streaming mode for responses.")
+	flag.Parse()
+	chat := &hedgeChat{
+		config: appConfig{
+			primaryModelName: *primaryModelName,
+			backupModelName:  *backupModelName,
+			primaryBaseURL:   *primaryBaseURL,
+			backupBaseURL:    *backupBaseURL,
+			hedgeDelay:       *hedgeDelay,
+			streaming:        *streaming,
+		},
+	}
+	if err := chat.run(); err != nil {
+		log.Fatalf("Chat failed: %v", err)
+	}
+}
+
+type appConfig struct {
+	primaryModelName string
+	backupModelName  string
+	primaryBaseURL   string
+	backupBaseURL    string
+	hedgeDelay       time.Duration
+	streaming        bool
+}

--- a/examples/model/hedge/model.go
+++ b/examples/model/hedge/model.go
@@ -1,0 +1,32 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/model/hedge"
+	"trpc.group/trpc-go/trpc-agent-go/model/openai"
+)
+
+func newHedgeModel(config appConfig) (model.Model, error) {
+	primary := openai.New(
+		config.primaryModelName,
+		openai.WithBaseURL(config.primaryBaseURL),
+	)
+	backup := openai.New(
+		config.backupModelName,
+		openai.WithBaseURL(config.backupBaseURL),
+	)
+	return hedge.New(
+		hedge.WithName("hedge-chat-model"),
+		hedge.WithCandidates(primary, backup),
+		hedge.WithDelay(config.hedgeDelay),
+	)
+}

--- a/examples/model/hedge/print.go
+++ b/examples/model/hedge/print.go
@@ -70,7 +70,7 @@ func (c *hedgeChat) processResponse(eventChan <-chan *event.Event) error {
 }
 
 func (c *hedgeChat) extractContent(choice model.Choice) string {
-	if c.config.streaming {
+	if choice.Delta.Content != "" {
 		return choice.Delta.Content
 	}
 	return choice.Message.Content

--- a/examples/model/hedge/print.go
+++ b/examples/model/hedge/print.go
@@ -1,0 +1,77 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+func (c *hedgeChat) printBanner() {
+	fmt.Printf("🚀 Model hedge chat with LLMAgent and Runner\n")
+	fmt.Printf("Primary model: %s (%s)\n", c.config.primaryModelName, c.config.primaryBaseURL)
+	fmt.Printf("Backup model: %s (%s)\n", c.config.backupModelName, c.config.backupBaseURL)
+	fmt.Printf("Hedge delay: %s\n", c.config.hedgeDelay)
+	fmt.Printf("Streaming: %t\n", c.config.streaming)
+	fmt.Printf("Hedge policy: launch the primary immediately, then hedge backups on delay or early failure.\n")
+	fmt.Println(strings.Repeat("=", 50))
+	fmt.Printf("✅ Chat ready! Session: %s\n\n", c.sessionID)
+}
+
+func printCommands() {
+	fmt.Println("💡 Commands:")
+	fmt.Println("   /new      - Start a new session")
+	fmt.Println("   /exit     - End the conversation")
+	fmt.Println()
+}
+
+func (c *hedgeChat) processResponse(eventChan <-chan *event.Event) error {
+	fmt.Print("🤖 Assistant: ")
+	var output strings.Builder
+	for evt := range eventChan {
+		if evt == nil {
+			continue
+		}
+		if evt.Error != nil {
+			fmt.Printf("\n❌ Error: %s\n", evt.Error.Message)
+			return nil
+		}
+		if len(evt.Choices) == 0 {
+			if evt.Done {
+				break
+			}
+			continue
+		}
+		content := c.extractContent(evt.Choices[0])
+		if content != "" {
+			fmt.Print(content)
+			output.WriteString(content)
+		}
+		if evt.Done {
+			break
+		}
+	}
+	if output.Len() > 0 {
+		fmt.Println()
+	} else {
+		fmt.Println("(empty response)")
+	}
+	return nil
+}
+
+func (c *hedgeChat) extractContent(choice model.Choice) string {
+	if c.config.streaming {
+		return choice.Delta.Content
+	}
+	return choice.Message.Content
+}

--- a/model/hedge/failure.go
+++ b/model/hedge/failure.go
@@ -1,0 +1,101 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package hedge
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+const completedWithoutMeaningfulResponse = "completed without meaningful response"
+
+type failureError struct {
+	failures []failureRecord
+}
+
+type failureRecord struct {
+	candidate string
+	message   string
+	errType   string
+}
+
+func newFailureError(failures []failureRecord) error {
+	return &failureError{failures: append([]failureRecord(nil), failures...)}
+}
+
+func (e *failureError) Error() string {
+	return buildFailureMessage(e.failures)
+}
+
+func buildFailureMessage(failures []failureRecord) string {
+	parts := make([]string, 0, len(failures))
+	for _, failure := range failures {
+		if failure.candidate == "" {
+			parts = append(parts, failure.message)
+			continue
+		}
+		parts = append(
+			parts,
+			fmt.Sprintf(
+				"candidate model %q failed before winner selection: %s",
+				failure.candidate,
+				failure.message,
+			),
+		)
+	}
+	return strings.Join(parts, "; ")
+}
+
+func failuresFromError(err error, fallback []failureRecord) []failureRecord {
+	var wrapped *failureError
+	if errors.As(err, &wrapped) && wrapped != nil {
+		return append([]failureRecord(nil), wrapped.failures...)
+	}
+	return appendFailure(fallback, "", err.Error(), "")
+}
+
+func appendFailure(
+	failures []failureRecord,
+	candidateName string,
+	message string,
+	errType string,
+) []failureRecord {
+	next := append([]failureRecord(nil), failures...)
+	next = append(next, failureRecord{
+		candidate: candidateName,
+		message:   message,
+		errType:   errType,
+	})
+	return next
+}
+
+func buildFailureResponse(failures []failureRecord) *model.Response {
+	return &model.Response{
+		Error: &model.ResponseError{
+			Message: buildFailureMessage(failures),
+			Type:    failureResponseType(failures),
+		},
+		Timestamp: time.Now(),
+		Done:      true,
+	}
+}
+
+func failureResponseType(failures []failureRecord) string {
+	for i := len(failures) - 1; i >= 0; i-- {
+		if failures[i].errType != "" {
+			return failures[i].errType
+		}
+	}
+	return model.ErrorTypeAPIError
+}

--- a/model/hedge/hedge.go
+++ b/model/hedge/hedge.go
@@ -181,7 +181,13 @@ func (r *hedgeRun) run() {
 }
 
 func (r *hedgeRun) advance(now time.Time) bool {
+	if r.drainReadyEvents() {
+		return true
+	}
 	r.launchReadyAttempts(now)
+	if r.drainReadyEvents() {
+		return true
+	}
 	if r.winnerIndex == -1 && r.activeCount == 0 && r.nextLaunchIndex >= len(r.hedge.candidates) {
 		if len(r.failures) == 0 {
 			return true
@@ -191,6 +197,19 @@ func (r *hedgeRun) advance(now time.Time) bool {
 	}
 	r.updateLaunchTimer(now)
 	return false
+}
+
+func (r *hedgeRun) drainReadyEvents() bool {
+	for {
+		select {
+		case event := <-r.eventChan:
+			if r.handleEvent(event) {
+				return true
+			}
+		default:
+			return false
+		}
+	}
 }
 
 func (r *hedgeRun) wait() bool {

--- a/model/hedge/hedge.go
+++ b/model/hedge/hedge.go
@@ -1,0 +1,528 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package hedge provides a model.Model wrapper that launches hedge requests
+// across candidates and commits the first meaningful response.
+package hedge
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+type hedgeModel struct {
+	candidates    []model.Model
+	name          string
+	launchOffsets []time.Duration
+}
+
+type attempt struct {
+	index     int
+	candidate model.Model
+	cancel    context.CancelFunc
+}
+
+type attemptEvent struct {
+	index    int
+	response *model.Response
+	failure  *failureRecord
+	finished bool
+}
+
+type hedgeRun struct {
+	hedge           *hedgeModel
+	request         *model.Request
+	yield           func(*model.Response) bool
+	ctx             context.Context
+	cancel          context.CancelFunc
+	attempts        []*attempt
+	failures        []failureRecord
+	eventChan       chan attemptEvent
+	start           time.Time
+	nextLaunchIndex int
+	activeCount     int
+	winnerIndex     int
+	launchTimer     *time.Timer
+	launchTimerChan <-chan time.Time
+}
+
+// New creates a hedge model wrapper.
+func New(opt ...Option) (model.Model, error) {
+	opts := newOptions(opt...)
+	if len(opts.candidates) == 0 {
+		return nil, errors.New("hedge: at least one candidate model is required")
+	}
+	candidates := make([]model.Model, 0, len(opts.candidates))
+	for i, candidate := range opts.candidates {
+		if candidate == nil {
+			return nil, fmt.Errorf("hedge: candidate model at index %d is nil", i)
+		}
+		candidates = append(candidates, candidate)
+	}
+	launchOffsets, err := resolveLaunchOffsets(len(candidates), &opts)
+	if err != nil {
+		return nil, err
+	}
+	name := opts.name
+	if name == "" {
+		name = candidates[0].Info().Name
+	}
+	return &hedgeModel{
+		candidates:    candidates,
+		name:          name,
+		launchOffsets: launchOffsets,
+	}, nil
+}
+
+// Info returns the logical hedge model info.
+func (m *hedgeModel) Info() model.Info {
+	return model.Info{Name: m.name}
+}
+
+// GenerateContent implements the model.Model interface.
+func (m *hedgeModel) GenerateContent(
+	ctx context.Context,
+	request *model.Request,
+) (<-chan *model.Response, error) {
+	seq, err := m.GenerateContentIter(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+	responseChan := make(chan *model.Response, 1)
+	go func() {
+		defer close(responseChan)
+		seq(func(resp *model.Response) bool {
+			if resp == nil {
+				return true
+			}
+			select {
+			case responseChan <- resp.Clone():
+				return true
+			case <-ctx.Done():
+				return false
+			}
+		})
+	}()
+	return responseChan, nil
+}
+
+// GenerateContentIter implements the model.IterModel interface.
+func (m *hedgeModel) GenerateContentIter(
+	ctx context.Context,
+	request *model.Request,
+) (model.Seq[*model.Response], error) {
+	if request == nil {
+		return nil, errors.New("request cannot be nil")
+	}
+	return func(yield func(*model.Response) bool) {
+		m.runHedge(ctx, request, yield)
+	}, nil
+}
+
+func (m *hedgeModel) runHedge(
+	ctx context.Context,
+	request *model.Request,
+	yield func(*model.Response) bool,
+) {
+	run := newHedgeRun(ctx, m, request, yield)
+	defer run.close()
+	run.run()
+}
+
+func newHedgeRun(
+	ctx context.Context,
+	hedge *hedgeModel,
+	request *model.Request,
+	yield func(*model.Response) bool,
+) *hedgeRun {
+	runCtx, cancel := context.WithCancel(ctx)
+	return &hedgeRun{
+		hedge:       hedge,
+		request:     request,
+		yield:       yield,
+		ctx:         runCtx,
+		cancel:      cancel,
+		attempts:    make([]*attempt, len(hedge.candidates)),
+		failures:    make([]failureRecord, 0, len(hedge.candidates)),
+		eventChan:   make(chan attemptEvent, len(hedge.candidates)),
+		start:       time.Now(),
+		winnerIndex: -1,
+	}
+}
+
+func (r *hedgeRun) close() {
+	r.stopLaunchTimer()
+	r.cancel()
+}
+
+func (r *hedgeRun) run() {
+	r.launchAttempt(0)
+	r.nextLaunchIndex = 1
+	for {
+		if r.advance(time.Now()) {
+			return
+		}
+		if r.wait() {
+			return
+		}
+	}
+}
+
+func (r *hedgeRun) advance(now time.Time) bool {
+	r.launchReadyAttempts(now)
+	if r.winnerIndex == -1 && r.activeCount == 0 && r.nextLaunchIndex >= len(r.hedge.candidates) {
+		if len(r.failures) == 0 {
+			return true
+		}
+		r.yield(buildFailureResponse(r.failures))
+		return true
+	}
+	r.updateLaunchTimer(now)
+	return false
+}
+
+func (r *hedgeRun) wait() bool {
+	select {
+	case <-r.ctx.Done():
+		r.stopLaunchTimer()
+		return true
+	case <-r.launchTimerChan:
+		r.stopLaunchTimer()
+		return false
+	case event := <-r.eventChan:
+		return r.handleEvent(event)
+	}
+}
+
+func (r *hedgeRun) handleEvent(event attemptEvent) bool {
+	if r.winnerIndex == -1 {
+		if event.response != nil {
+			if !isWinningResponse(event.response) {
+				return false
+			}
+			r.winnerIndex = event.index
+			r.cancelLosers(event.index)
+			r.stopLaunchTimer()
+			if r.yield(event.response) {
+				return false
+			}
+			r.cancel()
+			return true
+		}
+		if event.failure != nil {
+			r.activeCount--
+			r.failures = append(r.failures, *event.failure)
+			return false
+		}
+		if event.finished {
+			r.activeCount--
+		}
+		return false
+	}
+	if event.index != r.winnerIndex {
+		return false
+	}
+	if event.response != nil {
+		if r.yield(event.response) {
+			return false
+		}
+		r.cancel()
+		return true
+	}
+	return event.failure != nil || event.finished
+}
+
+func (r *hedgeRun) launchReadyAttempts(now time.Time) {
+	if r.winnerIndex != -1 {
+		return
+	}
+	r.launchDueAttempts(now)
+	for r.activeCount == 0 && r.nextLaunchIndex < len(r.hedge.candidates) {
+		r.launchAttempt(r.nextLaunchIndex)
+		r.nextLaunchIndex++
+		r.launchDueAttempts(time.Now())
+	}
+}
+
+func (r *hedgeRun) launchDueAttempts(now time.Time) {
+	elapsed := now.Sub(r.start)
+	for r.nextLaunchIndex < len(r.hedge.launchOffsets) &&
+		r.hedge.launchOffsets[r.nextLaunchIndex] <= elapsed {
+		r.launchAttempt(r.nextLaunchIndex)
+		r.nextLaunchIndex++
+	}
+}
+
+func (r *hedgeRun) launchAttempt(index int) {
+	candidate := r.hedge.candidates[index]
+	candidateRequest, err := cloneRequest(r.request)
+	if err != nil {
+		r.failures = appendFailure(
+			r.failures,
+			candidate.Info().Name,
+			err.Error(),
+			"",
+		)
+		return
+	}
+	attemptCtx, attemptCancel := context.WithCancel(r.ctx)
+	seq, err := sequenceForCandidate(
+		attemptCtx,
+		candidate,
+		candidateRequest,
+	)
+	if err != nil {
+		attemptCancel()
+		r.failures = appendFailure(
+			r.failures,
+			candidate.Info().Name,
+			err.Error(),
+			"",
+		)
+		return
+	}
+	activeAttempt := &attempt{
+		index:     index,
+		candidate: candidate,
+		cancel:    attemptCancel,
+	}
+	r.attempts[index] = activeAttempt
+	r.activeCount++
+	go runAttempt(attemptCtx, activeAttempt, seq, r.eventChan)
+}
+
+func (r *hedgeRun) updateLaunchTimer(now time.Time) {
+	r.stopLaunchTimer()
+	if r.winnerIndex != -1 || r.nextLaunchIndex >= len(r.hedge.launchOffsets) {
+		return
+	}
+	delay := r.hedge.launchOffsets[r.nextLaunchIndex] - now.Sub(r.start)
+	if delay < 0 {
+		delay = 0
+	}
+	r.launchTimer = time.NewTimer(delay)
+	r.launchTimerChan = r.launchTimer.C
+}
+
+func (r *hedgeRun) stopLaunchTimer() {
+	if r.launchTimer == nil {
+		return
+	}
+	if !r.launchTimer.Stop() {
+		select {
+		case <-r.launchTimer.C:
+		default:
+		}
+	}
+	r.launchTimer = nil
+	r.launchTimerChan = nil
+}
+
+func (r *hedgeRun) cancelLosers(winner int) {
+	for i, activeAttempt := range r.attempts {
+		if activeAttempt == nil || i == winner {
+			continue
+		}
+		activeAttempt.cancel()
+	}
+}
+
+func runAttempt(
+	ctx context.Context,
+	activeAttempt *attempt,
+	seq model.Seq[*model.Response],
+	eventChan chan<- attemptEvent,
+) {
+	sawMeaningful := false
+	var terminalFailure *failureRecord
+	seq(func(resp *model.Response) bool {
+		if resp == nil {
+			return true
+		}
+		cloned := resp.Clone()
+		if isWinningResponse(cloned) {
+			sawMeaningful = true
+		}
+		if !sendAttemptEvent(ctx, eventChan, attemptEvent{
+			index:    activeAttempt.index,
+			response: cloned,
+		}) {
+			return false
+		}
+		if !hasHedgeResponseError(cloned) {
+			return true
+		}
+		terminalFailure = &failureRecord{
+			candidate: activeAttempt.candidate.Info().Name,
+			message:   responseErrorMessage(cloned.Error),
+			errType:   cloned.Error.Type,
+		}
+		return false
+	})
+	if ctx.Err() != nil {
+		return
+	}
+	if terminalFailure != nil {
+		sendAttemptEvent(ctx, eventChan, attemptEvent{
+			index:   activeAttempt.index,
+			failure: terminalFailure,
+		})
+		return
+	}
+	if !sawMeaningful {
+		sendAttemptEvent(ctx, eventChan, attemptEvent{
+			index: activeAttempt.index,
+			failure: &failureRecord{
+				candidate: activeAttempt.candidate.Info().Name,
+				message:   completedWithoutMeaningfulResponse,
+			},
+		})
+		return
+	}
+	sendAttemptEvent(ctx, eventChan, attemptEvent{
+		index:    activeAttempt.index,
+		finished: true,
+	})
+}
+
+func sendAttemptEvent(
+	ctx context.Context,
+	eventChan chan<- attemptEvent,
+	event attemptEvent,
+) bool {
+	select {
+	case eventChan <- event:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func resolveLaunchOffsets(candidateCount int, opts *options) ([]time.Duration, error) {
+	launchOffsets := make([]time.Duration, candidateCount)
+	if len(opts.delays) > 0 {
+		if len(opts.delays) != candidateCount-1 {
+			return nil, fmt.Errorf(
+				"hedge: expected %d explicit delays, got %d",
+				candidateCount-1,
+				len(opts.delays),
+			)
+		}
+		prev := time.Duration(0)
+		for i, delay := range opts.delays {
+			if delay < 0 {
+				return nil, fmt.Errorf("hedge: delay at index %d cannot be negative", i)
+			}
+			if i > 0 && delay < prev {
+				return nil, fmt.Errorf("hedge: delays must be non-decreasing")
+			}
+			launchOffsets[i+1] = delay
+			prev = delay
+		}
+		return launchOffsets, nil
+	}
+	delay := opts.delay
+	if delay < 0 {
+		return nil, errors.New("hedge: delay cannot be negative")
+	}
+	for i := 1; i < candidateCount; i++ {
+		launchOffsets[i] = time.Duration(i) * delay
+	}
+	return launchOffsets, nil
+}
+
+func sequenceForCandidate(
+	ctx context.Context,
+	candidate model.Model,
+	request *model.Request,
+) (model.Seq[*model.Response], error) {
+	if iterModel, ok := candidate.(model.IterModel); ok {
+		seq, err := iterModel.GenerateContentIter(ctx, request)
+		if err != nil {
+			return nil, err
+		}
+		if seq == nil {
+			return nil, fmt.Errorf("candidate model %q returned nil response sequence", candidate.Info().Name)
+		}
+		return seq, nil
+	}
+	responseChan, err := candidate.GenerateContent(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+	if responseChan == nil {
+		return nil, fmt.Errorf("candidate model %q returned nil response channel", candidate.Info().Name)
+	}
+	return func(yield func(*model.Response) bool) {
+		for response := range responseChan {
+			if !yield(response) {
+				return
+			}
+		}
+	}, nil
+}
+
+func cloneRequest(request *model.Request) (*model.Request, error) {
+	payload, err := json.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+	var cloned model.Request
+	if err := json.Unmarshal(payload, &cloned); err != nil {
+		return nil, fmt.Errorf("unmarshal request: %w", err)
+	}
+	if len(request.Tools) > 0 {
+		cloned.Tools = make(map[string]tool.Tool, len(request.Tools))
+		for name, toolImpl := range request.Tools {
+			cloned.Tools[name] = toolImpl
+		}
+	}
+	return &cloned, nil
+}
+
+func hasHedgeResponseError(response *model.Response) bool {
+	if response == nil || response.Error == nil {
+		return false
+	}
+	return response.Error.Message != "" ||
+		response.Error.Type != "" ||
+		response.Error.Param != nil ||
+		response.Error.Code != nil
+}
+
+func isWinningResponse(response *model.Response) bool {
+	return response != nil &&
+		!hasHedgeResponseError(response) &&
+		response.IsValidContent()
+}
+
+func responseErrorMessage(responseError *model.ResponseError) string {
+	if responseError == nil {
+		return "unknown response error"
+	}
+	if responseError.Message != "" {
+		return responseError.Message
+	}
+	if responseError.Type != "" {
+		return responseError.Type
+	}
+	if responseError.Code != nil && *responseError.Code != "" {
+		return *responseError.Code
+	}
+	if responseError.Param != nil && *responseError.Param != "" {
+		return *responseError.Param
+	}
+	return "unknown response error"
+}

--- a/model/hedge/hedge.go
+++ b/model/hedge/hedge.go
@@ -412,7 +412,7 @@ func sendAttemptEvent(
 
 func resolveLaunchOffsets(candidateCount int, opts *options) ([]time.Duration, error) {
 	launchOffsets := make([]time.Duration, candidateCount)
-	if len(opts.delays) > 0 {
+	if opts.delays != nil {
 		if len(opts.delays) != candidateCount-1 {
 			return nil, fmt.Errorf(
 				"hedge: expected %d explicit delays, got %d",
@@ -466,9 +466,17 @@ func sequenceForCandidate(
 		return nil, fmt.Errorf("candidate model %q returned nil response channel", candidate.Info().Name)
 	}
 	return func(yield func(*model.Response) bool) {
-		for response := range responseChan {
-			if !yield(response) {
+		for {
+			select {
+			case <-ctx.Done():
 				return
+			case response, ok := <-responseChan:
+				if !ok {
+					return
+				}
+				if !yield(response) {
+					return
+				}
 			}
 		}
 	}, nil

--- a/model/hedge/hedge_test.go
+++ b/model/hedge/hedge_test.go
@@ -129,6 +129,35 @@ func TestGenerateContentUsesNonIterCandidate(t *testing.T) {
 	assert.Equal(t, "hello from channel", responses[0].Choices[0].Message.Content)
 }
 
+func TestGenerateContentIterReturnsErrorForNilRequest(t *testing.T) {
+	llm, err := New(WithCandidates(&scriptedIterModel{name: "primary"}))
+	require.NoError(t, err)
+	iterModel, ok := llm.(model.IterModel)
+	require.True(t, ok)
+	seq, err := iterModel.GenerateContentIter(context.Background(), nil)
+	require.Error(t, err)
+	assert.EqualError(t, err, "request cannot be nil")
+	assert.Nil(t, seq)
+}
+
+func TestGenerateContentStopsWhenContextCanceled(t *testing.T) {
+	llm, err := New(WithCandidates(&scriptedIterModel{
+		name:       "primary",
+		startDelay: 50 * time.Millisecond,
+		responses: []*model.Response{
+			assistantResponse("late response", true),
+		},
+	}))
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	responseChan, err := llm.GenerateContent(ctx, &model.Request{
+		Messages: []model.Message{model.NewUserMessage("hello")},
+	})
+	require.NoError(t, err)
+	cancel()
+	assert.Empty(t, collectResponsesFromChannel(responseChan))
+}
+
 func TestHedgeDelayLaunchesNextCandidateAfterTimer(t *testing.T) {
 	primaryStarted := make(chan struct{})
 	primaryStopped := make(chan struct{})
@@ -354,6 +383,188 @@ func TestBuildFailureMessageIncludesWinnerSelectionWording(t *testing.T) {
 	assert.True(t, strings.Contains(message, "fallback preparation failed"))
 }
 
+func TestFailureHelpersPreserveFailureRecords(t *testing.T) {
+	records := []failureRecord{
+		{candidate: "primary", message: "primary failed", errType: model.ErrorTypeAPIError},
+	}
+	err := newFailureError(records)
+	require.EqualError(t, err, `candidate model "primary" failed before winner selection: primary failed`)
+	assert.Equal(t, records, failuresFromError(err, nil))
+	fallback := failuresFromError(errors.New("prepare failed"), nil)
+	require.Len(t, fallback, 1)
+	assert.Equal(t, "prepare failed", fallback[0].message)
+	assert.Equal(t, "", fallback[0].candidate)
+}
+
+func TestBuildFailureResponseUsesDefaultErrorType(t *testing.T) {
+	response := buildFailureResponse([]failureRecord{{candidate: "primary", message: "primary failed"}})
+	require.NotNil(t, response.Error)
+	assert.Equal(t, model.ErrorTypeAPIError, response.Error.Type)
+}
+
+func TestLaunchAttemptRecordsCloneFailure(t *testing.T) {
+	runCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	candidate := &scriptedIterModel{name: "primary"}
+	run := &hedgeRun{
+		hedge: &hedgeModel{
+			candidates: []model.Model{candidate},
+		},
+		request: &model.Request{
+			StructuredOutput: &model.StructuredOutput{
+				Type: model.StructuredOutputJSONSchema,
+				JSONSchema: &model.JSONSchemaConfig{
+					Name: "answer",
+					Schema: map[string]any{
+						"unsupported": func() {},
+					},
+				},
+			},
+		},
+		yield:       func(*model.Response) bool { return true },
+		ctx:         runCtx,
+		cancel:      cancel,
+		attempts:    make([]*attempt, 1),
+		failures:    make([]failureRecord, 0, 1),
+		eventChan:   make(chan attemptEvent, 1),
+		winnerIndex: -1,
+	}
+	run.launchAttempt(0)
+	require.Len(t, run.failures, 1)
+	assert.Equal(t, "primary", run.failures[0].candidate)
+	assert.Contains(t, run.failures[0].message, "marshal request")
+	assert.Equal(t, 0, run.activeCount)
+}
+
+func TestSequenceForCandidateReturnsErrorForNilResults(t *testing.T) {
+	request := &model.Request{
+		Messages: []model.Message{model.NewUserMessage("hello")},
+	}
+	seq, err := sequenceForCandidate(context.Background(), &nilIterModel{name: "iter-primary"}, request)
+	require.Error(t, err)
+	assert.EqualError(t, err, `candidate model "iter-primary" returned nil response sequence`)
+	assert.Nil(t, seq)
+	seq, err = sequenceForCandidate(context.Background(), &nilChannelModel{name: "channel-primary"}, request)
+	require.Error(t, err)
+	assert.EqualError(t, err, `candidate model "channel-primary" returned nil response channel`)
+	assert.Nil(t, seq)
+}
+
+func TestCloneRequestReturnsMarshalError(t *testing.T) {
+	request := &model.Request{
+		StructuredOutput: &model.StructuredOutput{
+			Type: model.StructuredOutputJSONSchema,
+			JSONSchema: &model.JSONSchemaConfig{
+				Name: "answer",
+				Schema: map[string]any{
+					"unsupported": func() {},
+				},
+			},
+		},
+	}
+	cloned, err := cloneRequest(request)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "marshal request")
+	assert.Nil(t, cloned)
+}
+
+func TestResponseErrorMessageBranches(t *testing.T) {
+	code := "bad-request"
+	param := "temperature"
+	assert.Equal(t, "unknown response error", responseErrorMessage(nil))
+	assert.Equal(t, "rate limit", responseErrorMessage(&model.ResponseError{Message: "rate limit"}))
+	assert.Equal(t, model.ErrorTypeAPIError, responseErrorMessage(&model.ResponseError{Type: model.ErrorTypeAPIError}))
+	assert.Equal(t, code, responseErrorMessage(&model.ResponseError{Code: &code}))
+	assert.Equal(t, param, responseErrorMessage(&model.ResponseError{Param: &param}))
+	assert.Equal(t, "unknown response error", responseErrorMessage(&model.ResponseError{}))
+}
+
+func TestSendAttemptEventReturnsFalseWhenContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	assert.False(t, sendAttemptEvent(ctx, make(chan attemptEvent), attemptEvent{}))
+}
+
+func TestWaitReturnsForContextAndTimer(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	run := &hedgeRun{
+		ctx:         ctx,
+		cancel:      func() {},
+		winnerIndex: -1,
+	}
+	assert.True(t, run.wait())
+	run = &hedgeRun{
+		ctx:         context.Background(),
+		cancel:      func() {},
+		winnerIndex: -1,
+	}
+	run.launchTimer = time.NewTimer(0)
+	run.launchTimerChan = run.launchTimer.C
+	assert.False(t, run.wait())
+	assert.Nil(t, run.launchTimer)
+	assert.Nil(t, run.launchTimerChan)
+}
+
+func TestHandleEventStateTransitions(t *testing.T) {
+	t.Run("select winner and cancel losers", func(t *testing.T) {
+		loserCanceled := false
+		run := &hedgeRun{
+			yield: func(*model.Response) bool {
+				return true
+			},
+			cancel: func() {},
+			attempts: []*attempt{
+				{index: 0, cancel: func() {}},
+				{index: 1, cancel: func() { loserCanceled = true }},
+			},
+			winnerIndex: -1,
+		}
+		done := run.handleEvent(attemptEvent{
+			index:    0,
+			response: assistantResponse("winner", true),
+		})
+		assert.False(t, done)
+		assert.Equal(t, 0, run.winnerIndex)
+		assert.True(t, loserCanceled)
+	})
+	t.Run("record pre-winner failure", func(t *testing.T) {
+		run := &hedgeRun{
+			yield: func(*model.Response) bool {
+				return true
+			},
+			cancel:      func() {},
+			activeCount: 1,
+			failures:    make([]failureRecord, 0, 1),
+			winnerIndex: -1,
+		}
+		done := run.handleEvent(attemptEvent{
+			index:   0,
+			failure: &failureRecord{candidate: "primary", message: "primary failed"},
+		})
+		assert.False(t, done)
+		assert.Equal(t, 0, run.activeCount)
+		require.Len(t, run.failures, 1)
+		assert.Equal(t, "primary failed", run.failures[0].message)
+	})
+	t.Run("stop when winner stream is rejected", func(t *testing.T) {
+		canceled := false
+		run := &hedgeRun{
+			yield: func(*model.Response) bool {
+				return false
+			},
+			cancel:      func() { canceled = true },
+			winnerIndex: 0,
+		}
+		done := run.handleEvent(attemptEvent{
+			index:    0,
+			response: partialResponse("winner"),
+		})
+		assert.True(t, done)
+		assert.True(t, canceled)
+	})
+}
+
 type scriptedIterModel struct {
 	name                string
 	startupErr          error
@@ -415,6 +626,30 @@ func (m *scriptedIterModel) Info() model.Info {
 	return model.Info{Name: m.name}
 }
 
+type nilIterModel struct {
+	name string
+}
+
+func (m *nilIterModel) GenerateContent(
+	ctx context.Context,
+	request *model.Request,
+) (<-chan *model.Response, error) {
+	ch := make(chan *model.Response)
+	close(ch)
+	return ch, nil
+}
+
+func (m *nilIterModel) GenerateContentIter(
+	ctx context.Context,
+	request *model.Request,
+) (model.Seq[*model.Response], error) {
+	return nil, nil
+}
+
+func (m *nilIterModel) Info() model.Info {
+	return model.Info{Name: m.name}
+}
+
 type scriptedChannelModel struct {
 	name                string
 	responses           []*model.Response
@@ -461,6 +696,21 @@ func (m *scriptedChannelModel) GenerateContent(
 }
 
 func (m *scriptedChannelModel) Info() model.Info {
+	return model.Info{Name: m.name}
+}
+
+type nilChannelModel struct {
+	name string
+}
+
+func (m *nilChannelModel) GenerateContent(
+	ctx context.Context,
+	request *model.Request,
+) (<-chan *model.Response, error) {
+	return nil, nil
+}
+
+func (m *nilChannelModel) Info() model.Info {
 	return model.Info{Name: m.name}
 }
 

--- a/model/hedge/hedge_test.go
+++ b/model/hedge/hedge_test.go
@@ -1,0 +1,562 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package hedge
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+func TestNewReturnsErrorWithoutCandidates(t *testing.T) {
+	llm, err := New()
+	require.Error(t, err)
+	assert.EqualError(t, err, "hedge: at least one candidate model is required")
+	assert.Nil(t, llm)
+}
+
+func TestNewReturnsErrorWithNilCandidate(t *testing.T) {
+	llm, err := New(WithCandidates(nil))
+	require.Error(t, err)
+	assert.EqualError(t, err, "hedge: candidate model at index 0 is nil")
+	assert.Nil(t, llm)
+}
+
+func TestNewReturnsErrorForInvalidDelays(t *testing.T) {
+	primary := &scriptedIterModel{name: "primary"}
+	backup := &scriptedIterModel{name: "backup"}
+	llm, err := New(
+		WithCandidates(primary, backup),
+		WithDelay(-time.Millisecond),
+	)
+	require.Error(t, err)
+	assert.EqualError(t, err, "hedge: delay cannot be negative")
+	assert.Nil(t, llm)
+	llm, err = New(
+		WithCandidates(primary, backup),
+		WithDelays(10*time.Millisecond, 20*time.Millisecond),
+	)
+	require.Error(t, err)
+	assert.EqualError(t, err, "hedge: expected 1 explicit delays, got 2")
+	assert.Nil(t, llm)
+	llm, err = New(
+		WithCandidates(primary, backup, &scriptedIterModel{name: "third"}),
+		WithDelays(20*time.Millisecond, 10*time.Millisecond),
+	)
+	require.Error(t, err)
+	assert.EqualError(t, err, "hedge: delays must be non-decreasing")
+	assert.Nil(t, llm)
+}
+
+func TestInfoUsesConfiguredName(t *testing.T) {
+	llm, err := New(
+		WithCandidates(&scriptedIterModel{name: "primary"}),
+		WithName("hedge-model"),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "hedge-model", llm.Info().Name)
+}
+
+func TestCloneRequestDeepCopiesSerializableFields(t *testing.T) {
+	maxTokens := 128
+	toolImpl := &stubTool{name: "lookup"}
+	request := &model.Request{
+		Messages: []model.Message{
+			model.NewSystemMessage("system"),
+			model.NewUserMessage("user"),
+		},
+		GenerationConfig: model.GenerationConfig{
+			Stream:    true,
+			MaxTokens: &maxTokens,
+		},
+		StructuredOutput: &model.StructuredOutput{
+			Type: model.StructuredOutputJSONSchema,
+			JSONSchema: &model.JSONSchemaConfig{
+				Name:   "answer",
+				Strict: true,
+				Schema: map[string]any{
+					"type": "object",
+				},
+			},
+		},
+		Tools: map[string]tool.Tool{
+			"lookup": toolImpl,
+		},
+	}
+	cloned, err := cloneRequest(request)
+	require.NoError(t, err)
+	require.NotNil(t, cloned)
+	require.NotSame(t, request, cloned)
+	require.NotSame(t, request.StructuredOutput, cloned.StructuredOutput)
+	require.NotSame(t, request.StructuredOutput.JSONSchema, cloned.StructuredOutput.JSONSchema)
+	cloned.Messages[1].Content = "changed"
+	cloned.StructuredOutput.JSONSchema.Name = "changed"
+	cloned.StructuredOutput.JSONSchema.Schema["type"] = "array"
+	cloned.Tools["other"] = stubTool{name: "other"}
+	assert.Equal(t, "user", request.Messages[1].Content)
+	assert.Equal(t, "answer", request.StructuredOutput.JSONSchema.Name)
+	assert.Equal(t, "object", request.StructuredOutput.JSONSchema.Schema["type"])
+	assert.Len(t, request.Tools, 1)
+	assert.Same(t, toolImpl, cloned.Tools["lookup"])
+}
+
+func TestGenerateContentUsesNonIterCandidate(t *testing.T) {
+	llm, err := New(WithCandidates(&scriptedChannelModel{
+		name: "channel-primary",
+		responses: []*model.Response{
+			assistantResponse("hello from channel", true),
+		},
+	}))
+	require.NoError(t, err)
+	responses := collectChannelResponses(t, llm, &model.Request{
+		Messages: []model.Message{model.NewUserMessage("hello")},
+	})
+	require.Len(t, responses, 1)
+	assert.Equal(t, "hello from channel", responses[0].Choices[0].Message.Content)
+}
+
+func TestHedgeDelayLaunchesNextCandidateAfterTimer(t *testing.T) {
+	primaryStarted := make(chan struct{})
+	primaryStopped := make(chan struct{})
+	backupStarted := make(chan struct{})
+	primary := &scriptedIterModel{
+		name:      "primary",
+		started:   primaryStarted,
+		stopped:   primaryStopped,
+		holdAfter: true,
+	}
+	backup := &scriptedIterModel{
+		name:    "backup",
+		started: backupStarted,
+		responses: []*model.Response{
+			assistantResponse("backup wins", true),
+		},
+	}
+	llm, err := New(
+		WithCandidates(primary, backup),
+		WithDelay(40*time.Millisecond),
+	)
+	require.NoError(t, err)
+	responseChan, err := llm.GenerateContent(context.Background(), &model.Request{
+		Messages: []model.Message{model.NewUserMessage("hello")},
+	})
+	require.NoError(t, err)
+	waitForClosed(t, primaryStarted, 100*time.Millisecond)
+	assertNotClosed(t, backupStarted, 15*time.Millisecond)
+	waitForClosed(t, backupStarted, 250*time.Millisecond)
+	responses := collectResponsesFromChannel(responseChan)
+	require.Len(t, responses, 1)
+	assert.Equal(t, "backup wins", responses[0].Choices[0].Message.Content)
+	waitForClosed(t, primaryStopped, 100*time.Millisecond)
+}
+
+func TestExplicitHedgeDelaysLaunchCandidatesAtConfiguredOffsets(t *testing.T) {
+	primaryStarted := make(chan struct{})
+	secondStarted := make(chan struct{})
+	thirdStarted := make(chan struct{})
+	primary := &scriptedIterModel{
+		name:      "primary",
+		started:   primaryStarted,
+		holdAfter: true,
+	}
+	second := &scriptedIterModel{
+		name:      "second",
+		started:   secondStarted,
+		holdAfter: true,
+	}
+	third := &scriptedIterModel{
+		name:    "third",
+		started: thirdStarted,
+		responses: []*model.Response{
+			assistantResponse("third wins", true),
+		},
+	}
+	llm, err := New(
+		WithCandidates(primary, second, third),
+		WithDelays(40*time.Millisecond, 100*time.Millisecond),
+	)
+	require.NoError(t, err)
+	responseChan, err := llm.GenerateContent(context.Background(), &model.Request{
+		Messages: []model.Message{model.NewUserMessage("hello")},
+	})
+	require.NoError(t, err)
+	waitForClosed(t, primaryStarted, 100*time.Millisecond)
+	assertNotClosed(t, secondStarted, 15*time.Millisecond)
+	waitForClosed(t, secondStarted, 200*time.Millisecond)
+	assertNotClosed(t, thirdStarted, 25*time.Millisecond)
+	waitForClosed(t, thirdStarted, 250*time.Millisecond)
+	responses := collectResponsesFromChannel(responseChan)
+	require.Len(t, responses, 1)
+	assert.Equal(t, "third wins", responses[0].Choices[0].Message.Content)
+}
+
+func TestHedgeLaunchesNextCandidateImmediatelyWhenAllActiveAttemptsFail(t *testing.T) {
+	backupStarted := make(chan struct{})
+	primary := &scriptedIterModel{
+		name:       "primary",
+		startupErr: errors.New("primary failed"),
+	}
+	backup := &scriptedIterModel{
+		name:    "backup",
+		started: backupStarted,
+		responses: []*model.Response{
+			assistantResponse("backup wins", true),
+		},
+	}
+	llm, err := New(
+		WithCandidates(primary, backup),
+		WithDelay(500*time.Millisecond),
+	)
+	require.NoError(t, err)
+	responseChan, err := llm.GenerateContent(context.Background(), &model.Request{
+		Messages: []model.Message{model.NewUserMessage("hello")},
+	})
+	require.NoError(t, err)
+	waitForClosed(t, backupStarted, 100*time.Millisecond)
+	responses := collectResponsesFromChannel(responseChan)
+	require.Len(t, responses, 1)
+	assert.Equal(t, "backup wins", responses[0].Choices[0].Message.Content)
+}
+
+func TestMeaningfulWinnerIgnoresEmptyPrelude(t *testing.T) {
+	primaryStopped := make(chan struct{})
+	primary := &scriptedIterModel{
+		name:    "primary",
+		stopped: primaryStopped,
+		responses: []*model.Response{
+			{ID: "prelude", Model: "primary", Done: false},
+		},
+		holdAfter: true,
+	}
+	backup := &scriptedIterModel{
+		name: "backup",
+		responses: []*model.Response{
+			assistantResponse("backup wins", true),
+		},
+	}
+	llm, err := New(
+		WithCandidates(primary, backup),
+		WithDelay(20*time.Millisecond),
+	)
+	require.NoError(t, err)
+	responses := collectChannelResponses(t, llm, &model.Request{
+		Messages: []model.Message{model.NewUserMessage("hello")},
+	})
+	require.Len(t, responses, 1)
+	assert.Equal(t, "backup wins", responses[0].Choices[0].Message.Content)
+	waitForClosed(t, primaryStopped, 100*time.Millisecond)
+}
+
+func TestWinnerErrorIsForwardedAndLosersAreCanceled(t *testing.T) {
+	backupStopped := make(chan struct{})
+	primary := &scriptedIterModel{
+		name: "primary",
+		responses: []*model.Response{
+			partialResponse("hello"),
+			errorResponse("primary stream failed", model.ErrorTypeStreamError),
+		},
+	}
+	backup := &scriptedIterModel{
+		name:      "backup",
+		stopped:   backupStopped,
+		holdAfter: true,
+	}
+	llm, err := New(
+		WithCandidates(primary, backup),
+		WithDelay(0),
+	)
+	require.NoError(t, err)
+	responses := collectChannelResponses(t, llm, &model.Request{
+		Messages: []model.Message{model.NewUserMessage("hello")},
+	})
+	require.Len(t, responses, 2)
+	assert.Equal(t, "hello", responses[0].Choices[0].Delta.Content)
+	require.NotNil(t, responses[1].Error)
+	assert.Equal(t, "primary stream failed", responses[1].Error.Message)
+	waitForClosed(t, backupStopped, 100*time.Millisecond)
+}
+
+func TestAllCandidatesFailReturnsAggregatedFailureResponse(t *testing.T) {
+	primary := &scriptedIterModel{
+		name:       "primary",
+		startupErr: errors.New("dial tcp timeout"),
+	}
+	backup := &scriptedIterModel{
+		name: "backup",
+		responses: []*model.Response{
+			errorResponse("rate limit", model.ErrorTypeAPIError),
+		},
+	}
+	llm, err := New(
+		WithCandidates(primary, backup),
+		WithDelay(0),
+	)
+	require.NoError(t, err)
+	responses := collectChannelResponses(t, llm, &model.Request{
+		Messages: []model.Message{model.NewUserMessage("hello")},
+	})
+	require.Len(t, responses, 1)
+	require.NotNil(t, responses[0].Error)
+	assert.Contains(t, responses[0].Error.Message, `candidate model "primary" failed before winner selection: dial tcp timeout`)
+	assert.Contains(t, responses[0].Error.Message, `candidate model "backup" failed before winner selection: rate limit`)
+	assert.Equal(t, model.ErrorTypeAPIError, responses[0].Error.Type)
+	assert.True(t, responses[0].Done)
+}
+
+func TestRequestIsClonedPerCandidate(t *testing.T) {
+	request := &model.Request{
+		Messages: []model.Message{model.NewUserMessage("original")},
+	}
+	primary := &scriptedIterModel{
+		name: "primary",
+		prepare: func(req *model.Request) {
+			req.Messages[0].Content = "mutated"
+		},
+		startupErr: errors.New("primary failed"),
+	}
+	backup := &scriptedIterModel{
+		name: "backup",
+		responsesForRequest: func(req *model.Request) []*model.Response {
+			return []*model.Response{assistantResponse(req.Messages[0].Content, true)}
+		},
+	}
+	llm, err := New(
+		WithCandidates(primary, backup),
+		WithDelay(500*time.Millisecond),
+	)
+	require.NoError(t, err)
+	responses := collectChannelResponses(t, llm, request)
+	require.Len(t, responses, 1)
+	assert.Equal(t, "original", responses[0].Choices[0].Message.Content)
+	assert.Equal(t, "original", request.Messages[0].Content)
+}
+
+func TestBuildFailureMessageIncludesWinnerSelectionWording(t *testing.T) {
+	message := buildFailureMessage([]failureRecord{
+		{candidate: "primary", message: "primary failed"},
+		{message: "fallback preparation failed"},
+	})
+	assert.True(t, strings.Contains(message, `candidate model "primary" failed before winner selection: primary failed`))
+	assert.True(t, strings.Contains(message, "fallback preparation failed"))
+}
+
+type scriptedIterModel struct {
+	name                string
+	startupErr          error
+	responses           []*model.Response
+	responsesForRequest func(*model.Request) []*model.Response
+	prepare             func(*model.Request)
+	started             chan struct{}
+	stopped             chan struct{}
+	startDelay          time.Duration
+	holdAfter           bool
+}
+
+func (m *scriptedIterModel) GenerateContent(
+	ctx context.Context,
+	request *model.Request,
+) (<-chan *model.Response, error) {
+	ch := make(chan *model.Response)
+	close(ch)
+	return ch, nil
+}
+
+func (m *scriptedIterModel) GenerateContentIter(
+	ctx context.Context,
+	request *model.Request,
+) (model.Seq[*model.Response], error) {
+	if m.prepare != nil {
+		m.prepare(request)
+	}
+	signalClosed(m.started)
+	if m.startupErr != nil {
+		return nil, m.startupErr
+	}
+	responses := m.responses
+	if m.responsesForRequest != nil {
+		responses = m.responsesForRequest(request)
+	}
+	return func(yield func(*model.Response) bool) {
+		defer signalClosed(m.stopped)
+		if m.startDelay > 0 {
+			select {
+			case <-time.After(m.startDelay):
+			case <-ctx.Done():
+				return
+			}
+		}
+		for _, response := range responses {
+			if !yield(response) {
+				return
+			}
+		}
+		if !m.holdAfter {
+			return
+		}
+		<-ctx.Done()
+	}, nil
+}
+
+func (m *scriptedIterModel) Info() model.Info {
+	return model.Info{Name: m.name}
+}
+
+type scriptedChannelModel struct {
+	name                string
+	responses           []*model.Response
+	responsesForRequest func(*model.Request) []*model.Response
+	err                 error
+	prepare             func(*model.Request)
+	started             chan struct{}
+	stopped             chan struct{}
+	holdAfter           bool
+}
+
+func (m *scriptedChannelModel) GenerateContent(
+	ctx context.Context,
+	request *model.Request,
+) (<-chan *model.Response, error) {
+	if m.prepare != nil {
+		m.prepare(request)
+	}
+	signalClosed(m.started)
+	if m.err != nil {
+		return nil, m.err
+	}
+	responses := m.responses
+	if m.responsesForRequest != nil {
+		responses = m.responsesForRequest(request)
+	}
+	ch := make(chan *model.Response, len(responses))
+	go func() {
+		defer close(ch)
+		defer signalClosed(m.stopped)
+		for _, response := range responses {
+			select {
+			case ch <- response:
+			case <-ctx.Done():
+				return
+			}
+		}
+		if !m.holdAfter {
+			return
+		}
+		<-ctx.Done()
+	}()
+	return ch, nil
+}
+
+func (m *scriptedChannelModel) Info() model.Info {
+	return model.Info{Name: m.name}
+}
+
+type stubTool struct {
+	name string
+}
+
+func (t stubTool) Declaration() *tool.Declaration {
+	return &tool.Declaration{Name: t.name}
+}
+
+func assistantResponse(content string, done bool) *model.Response {
+	return &model.Response{
+		Model: "assistant-model",
+		Choices: []model.Choice{
+			{
+				Message: model.Message{
+					Role:    model.RoleAssistant,
+					Content: content,
+				},
+			},
+		},
+		Done: done,
+	}
+}
+
+func partialResponse(content string) *model.Response {
+	return &model.Response{
+		Model: "assistant-model",
+		Choices: []model.Choice{
+			{
+				Delta: model.Message{
+					Role:    model.RoleAssistant,
+					Content: content,
+				},
+			},
+		},
+		IsPartial: true,
+	}
+}
+
+func errorResponse(message string, errType string) *model.Response {
+	return &model.Response{
+		Error: &model.ResponseError{
+			Message: message,
+			Type:    errType,
+		},
+		Model: "assistant-model",
+		Done:  true,
+	}
+}
+
+func collectChannelResponses(
+	t *testing.T,
+	llm model.Model,
+	request *model.Request,
+) []*model.Response {
+	t.Helper()
+	responseChan, err := llm.GenerateContent(context.Background(), request)
+	require.NoError(t, err)
+	return collectResponsesFromChannel(responseChan)
+}
+
+func collectResponsesFromChannel(responseChan <-chan *model.Response) []*model.Response {
+	responses := make([]*model.Response, 0)
+	for response := range responseChan {
+		responses = append(responses, response)
+	}
+	return responses
+}
+
+func waitForClosed(t *testing.T, signal <-chan struct{}, timeout time.Duration) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(timeout):
+		t.Fatalf("timed out waiting for signal after %v", timeout)
+	}
+}
+
+func assertNotClosed(t *testing.T, signal <-chan struct{}, timeout time.Duration) {
+	t.Helper()
+	select {
+	case <-signal:
+		t.Fatalf("signal closed unexpectedly within %v", timeout)
+	case <-time.After(timeout):
+	}
+}
+
+func signalClosed(signal chan struct{}) {
+	if signal == nil {
+		return
+	}
+	select {
+	case <-signal:
+	default:
+		close(signal)
+	}
+}

--- a/model/hedge/hedge_test.go
+++ b/model/hedge/hedge_test.go
@@ -61,6 +61,13 @@ func TestNewReturnsErrorForInvalidDelays(t *testing.T) {
 	assert.EqualError(t, err, "hedge: expected 1 explicit delays, got 0")
 	assert.Nil(t, llm)
 	llm, err = New(
+		WithCandidates(primary, backup),
+		WithDelays(-time.Millisecond),
+	)
+	require.Error(t, err)
+	assert.EqualError(t, err, "hedge: delay at index 0 cannot be negative")
+	assert.Nil(t, llm)
+	llm, err = New(
 		WithCandidates(primary, backup, &scriptedIterModel{name: "third"}),
 		WithDelays(20*time.Millisecond, 10*time.Millisecond),
 	)
@@ -202,16 +209,20 @@ func TestHedgeDelayLaunchesNextCandidateAfterTimer(t *testing.T) {
 
 func TestExplicitHedgeDelaysLaunchCandidatesAtConfiguredOffsets(t *testing.T) {
 	primaryStarted := make(chan struct{})
+	primaryStopped := make(chan struct{})
 	secondStarted := make(chan struct{})
+	secondStopped := make(chan struct{})
 	thirdStarted := make(chan struct{})
 	primary := &scriptedIterModel{
 		name:      "primary",
 		started:   primaryStarted,
+		stopped:   primaryStopped,
 		holdAfter: true,
 	}
 	second := &scriptedIterModel{
 		name:      "second",
 		started:   secondStarted,
+		stopped:   secondStopped,
 		holdAfter: true,
 	}
 	third := &scriptedIterModel{
@@ -238,6 +249,8 @@ func TestExplicitHedgeDelaysLaunchCandidatesAtConfiguredOffsets(t *testing.T) {
 	responses := collectResponsesFromChannel(responseChan)
 	require.Len(t, responses, 1)
 	assert.Equal(t, "third wins", responses[0].Choices[0].Message.Content)
+	waitForClosed(t, primaryStopped, 100*time.Millisecond)
+	waitForClosed(t, secondStopped, 100*time.Millisecond)
 }
 
 func TestHedgeLaunchesNextCandidateImmediatelyWhenAllActiveAttemptsFail(t *testing.T) {

--- a/model/hedge/hedge_test.go
+++ b/model/hedge/hedge_test.go
@@ -603,6 +603,40 @@ func TestHandleEventStateTransitions(t *testing.T) {
 	})
 }
 
+func TestAdvanceProcessesQueuedWinnerBeforeLaunchingDueCandidates(t *testing.T) {
+	runCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	run := &hedgeRun{
+		hedge: &hedgeModel{
+			candidates: []model.Model{
+				&scriptedIterModel{name: "primary"},
+				&scriptedIterModel{name: "backup"},
+			},
+			launchOffsets: []time.Duration{0, 0},
+		},
+		request: &model.Request{
+			Messages: []model.Message{model.NewUserMessage("hello")},
+		},
+		yield:           func(*model.Response) bool { return true },
+		ctx:             runCtx,
+		cancel:          cancel,
+		attempts:        make([]*attempt, 2),
+		failures:        make([]failureRecord, 0, 2),
+		eventChan:       make(chan attemptEvent, 1),
+		nextLaunchIndex: 1,
+		winnerIndex:     -1,
+	}
+	run.eventChan <- attemptEvent{
+		index:    0,
+		response: assistantResponse("winner", true),
+	}
+	done := run.advance(time.Now())
+	assert.False(t, done)
+	assert.Equal(t, 0, run.winnerIndex)
+	assert.Nil(t, run.attempts[1])
+	assert.Equal(t, 1, run.nextLaunchIndex)
+}
+
 type scriptedIterModel struct {
 	name                string
 	startupErr          error

--- a/model/hedge/hedge_test.go
+++ b/model/hedge/hedge_test.go
@@ -54,6 +54,13 @@ func TestNewReturnsErrorForInvalidDelays(t *testing.T) {
 	assert.EqualError(t, err, "hedge: expected 1 explicit delays, got 2")
 	assert.Nil(t, llm)
 	llm, err = New(
+		WithCandidates(primary, backup),
+		WithDelays(),
+	)
+	require.Error(t, err)
+	assert.EqualError(t, err, "hedge: expected 1 explicit delays, got 0")
+	assert.Nil(t, llm)
+	llm, err = New(
 		WithCandidates(primary, backup, &scriptedIterModel{name: "third"}),
 		WithDelays(20*time.Millisecond, 10*time.Millisecond),
 	)
@@ -177,7 +184,7 @@ func TestHedgeDelayLaunchesNextCandidateAfterTimer(t *testing.T) {
 	}
 	llm, err := New(
 		WithCandidates(primary, backup),
-		WithDelay(40*time.Millisecond),
+		WithDelay(80*time.Millisecond),
 	)
 	require.NoError(t, err)
 	responseChan, err := llm.GenerateContent(context.Background(), &model.Request{
@@ -185,8 +192,8 @@ func TestHedgeDelayLaunchesNextCandidateAfterTimer(t *testing.T) {
 	})
 	require.NoError(t, err)
 	waitForClosed(t, primaryStarted, 100*time.Millisecond)
-	assertNotClosed(t, backupStarted, 15*time.Millisecond)
-	waitForClosed(t, backupStarted, 250*time.Millisecond)
+	assertNotClosed(t, backupStarted, 40*time.Millisecond)
+	waitForClosed(t, backupStarted, 300*time.Millisecond)
 	responses := collectResponsesFromChannel(responseChan)
 	require.Len(t, responses, 1)
 	assert.Equal(t, "backup wins", responses[0].Choices[0].Message.Content)
@@ -216,7 +223,7 @@ func TestExplicitHedgeDelaysLaunchCandidatesAtConfiguredOffsets(t *testing.T) {
 	}
 	llm, err := New(
 		WithCandidates(primary, second, third),
-		WithDelays(40*time.Millisecond, 100*time.Millisecond),
+		WithDelays(80*time.Millisecond, 220*time.Millisecond),
 	)
 	require.NoError(t, err)
 	responseChan, err := llm.GenerateContent(context.Background(), &model.Request{
@@ -224,10 +231,10 @@ func TestExplicitHedgeDelaysLaunchCandidatesAtConfiguredOffsets(t *testing.T) {
 	})
 	require.NoError(t, err)
 	waitForClosed(t, primaryStarted, 100*time.Millisecond)
-	assertNotClosed(t, secondStarted, 15*time.Millisecond)
-	waitForClosed(t, secondStarted, 200*time.Millisecond)
-	assertNotClosed(t, thirdStarted, 25*time.Millisecond)
-	waitForClosed(t, thirdStarted, 250*time.Millisecond)
+	assertNotClosed(t, secondStarted, 40*time.Millisecond)
+	waitForClosed(t, secondStarted, 250*time.Millisecond)
+	assertNotClosed(t, thirdStarted, 80*time.Millisecond)
+	waitForClosed(t, thirdStarted, 400*time.Millisecond)
 	responses := collectResponsesFromChannel(responseChan)
 	require.Len(t, responses, 1)
 	assert.Equal(t, "third wins", responses[0].Choices[0].Message.Content)
@@ -448,6 +455,24 @@ func TestSequenceForCandidateReturnsErrorForNilResults(t *testing.T) {
 	require.Error(t, err)
 	assert.EqualError(t, err, `candidate model "channel-primary" returned nil response channel`)
 	assert.Nil(t, seq)
+}
+
+func TestSequenceForCandidateStopsWhenContextCanceledForChannelModel(t *testing.T) {
+	request := &model.Request{
+		Messages: []model.Message{model.NewUserMessage("hello")},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	seq, err := sequenceForCandidate(ctx, &blockingChannelModel{name: "blocking-primary"}, request)
+	require.NoError(t, err)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		seq(func(*model.Response) bool {
+			return true
+		})
+	}()
+	cancel()
+	waitForClosed(t, done, 100*time.Millisecond)
 }
 
 func TestCloneRequestReturnsMarshalError(t *testing.T) {
@@ -711,6 +736,21 @@ func (m *nilChannelModel) GenerateContent(
 }
 
 func (m *nilChannelModel) Info() model.Info {
+	return model.Info{Name: m.name}
+}
+
+type blockingChannelModel struct {
+	name string
+}
+
+func (m *blockingChannelModel) GenerateContent(
+	ctx context.Context,
+	request *model.Request,
+) (<-chan *model.Response, error) {
+	return make(chan *model.Response), nil
+}
+
+func (m *blockingChannelModel) Info() model.Info {
 	return model.Info{Name: m.name}
 }
 

--- a/model/hedge/options.go
+++ b/model/hedge/options.go
@@ -1,0 +1,66 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package hedge
+
+import (
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+const defaultDelay = 100 * time.Millisecond
+
+type options struct {
+	candidates []model.Model
+	name       string
+	delay      time.Duration
+	delays     []time.Duration
+}
+
+func newOptions(opt ...Option) options {
+	opts := options{
+		delay: defaultDelay,
+	}
+	for _, o := range opt {
+		o(&opts)
+	}
+	return opts
+}
+
+// Option configures a hedge model.
+type Option func(*options)
+
+// WithCandidates appends hedge candidates in launch order.
+func WithCandidates(candidates ...model.Model) Option {
+	return func(o *options) {
+		o.candidates = append(o.candidates, candidates...)
+	}
+}
+
+// WithName sets a stable logical model name for the hedge wrapper.
+func WithName(name string) Option {
+	return func(o *options) {
+		o.name = name
+	}
+}
+
+// WithDelay sets a fixed interval between successive hedge launches.
+func WithDelay(delay time.Duration) Option {
+	return func(o *options) {
+		o.delay = delay
+	}
+}
+
+// WithDelays sets absolute launch offsets for candidates[1:].
+func WithDelays(delays ...time.Duration) Option {
+	return func(o *options) {
+		o.delays = append([]time.Duration(nil), delays...)
+	}
+}

--- a/model/hedge/options.go
+++ b/model/hedge/options.go
@@ -38,6 +38,7 @@ func newOptions(opt ...Option) options {
 type Option func(*options)
 
 // WithCandidates appends hedge candidates in launch order.
+// Multiple calls accumulate candidates instead of replacing them.
 func WithCandidates(candidates ...model.Model) Option {
 	return func(o *options) {
 		o.candidates = append(o.candidates, candidates...)
@@ -61,6 +62,7 @@ func WithDelay(delay time.Duration) Option {
 // WithDelays sets absolute launch offsets for candidates[1:].
 func WithDelays(delays ...time.Duration) Option {
 	return func(o *options) {
-		o.delays = append([]time.Duration(nil), delays...)
+		o.delays = make([]time.Duration, len(delays))
+		copy(o.delays, delays)
 	}
 }


### PR DESCRIPTION
Add the new model/hedge wrapper for delay-based hedging across multiple candidates, including early launch when active attempts fail before a winner is chosen, and update the example and model docs to show how to use WithDelay and WithDelays.