### PR TITLE
{internal, telemetry}: preserve structured response errors in telemetry labels

### DIFF
--- a/internal/telemetry/errs_test.go
+++ b/internal/telemetry/errs_test.go
@@ -11,6 +11,7 @@ package telemetry
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"trpc.group/trpc-go/trpc-agent-go/model"
@@ -198,5 +199,19 @@ func TestToErrorType(t *testing.T) {
 				t.Errorf("ToErrorType(%v, %q) = %q, want %q", tt.err, tt.errorType, result, tt.expected)
 			}
 		})
+	}
+}
+
+func TestToErrorType_UsesRealResponseErrorConversion(t *testing.T) {
+	err := fmt.Errorf("wrapped: %w", &model.ResponseError{
+		Message: "rate limit",
+		Type:    model.ErrorTypeAPIError,
+		Code:    strPtr("429"),
+	})
+
+	got := ToErrorType(err, "default_error")
+	want := model.ErrorTypeAPIError + "_429"
+	if got != want {
+		t.Fatalf("ToErrorType(%v, %q) = %q, want %q", err, "default_error", got, want)
 	}
 }

--- a/telemetry/errs/errs.go
+++ b/telemetry/errs/errs.go
@@ -11,10 +11,5 @@ import "trpc.group/trpc-go/trpc-agent-go/model"
 
 // ToResponseError converts an error to a ResponseError.
 var ToResponseError = func(err error) *model.ResponseError {
-	if err == nil {
-		return nil
-	}
-	return &model.ResponseError{
-		Message: err.Error(),
-	}
+	return model.ResponseErrorFromError(err, "")
 }

--- a/telemetry/errs/errs.go
+++ b/telemetry/errs/errs.go
@@ -11,5 +11,10 @@ import "trpc.group/trpc-go/trpc-agent-go/model"
 
 // ToResponseError converts an error to a ResponseError.
 var ToResponseError = func(err error) *model.ResponseError {
-	return model.ResponseErrorFromError(err, "")
+	respErr := model.ResponseErrorFromError(err, "")
+	if respErr == nil {
+		return nil
+	}
+	respErr.Message = err.Error()
+	return respErr
 }

--- a/telemetry/errs/errs_test.go
+++ b/telemetry/errs/errs_test.go
@@ -1,0 +1,41 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package errs
+
+import (
+	"fmt"
+	"testing"
+
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+func TestToResponseError_PreservesOuterMessageAndStructuredFields(t *testing.T) {
+	code := "429"
+	err := fmt.Errorf("request failed: %w", &model.ResponseError{
+		Message: "rate limit",
+		Type:    model.ErrorTypeAPIError,
+		Code:    &code,
+	})
+
+	got := ToResponseError(err)
+	if got == nil {
+		t.Fatal("ToResponseError() returned nil")
+	}
+	if got.Message != err.Error() {
+		t.Fatalf("Message = %q, want %q", got.Message, err.Error())
+	}
+	if got.Type != model.ErrorTypeAPIError {
+		t.Fatalf("Type = %q, want %q", got.Type, model.ErrorTypeAPIError)
+	}
+	if got.Code == nil || *got.Code != code {
+		t.Fatalf("Code = %v, want %q", got.Code, code)
+	}
+}

--- a/telemetry/errs/errs_test.go
+++ b/telemetry/errs/errs_test.go
@@ -17,6 +17,12 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/model"
 )
 
+func TestToResponseError_Nil(t *testing.T) {
+	if got := ToResponseError(nil); got != nil {
+		t.Fatalf("ToResponseError(nil) = %#v, want nil", got)
+	}
+}
+
 func TestToResponseError_PreservesOuterMessageAndStructuredFields(t *testing.T) {
 	code := "429"
 	err := fmt.Errorf("request failed: %w", &model.ResponseError{


### PR DESCRIPTION

Reuse ResponseErrorFromError so telemetry keeps error type and code when converting wrapped errors, and add a regression test for the real conversion path.