### PR TITLE
openclaw/admin: add runtime config page

### DIFF
--- a/openclaw/admin/config_page.go
+++ b/openclaw/admin/config_page.go
@@ -1,0 +1,219 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package admin
+
+import (
+	"net/http"
+	"strings"
+)
+
+const (
+	routeConfigPage  = "/config"
+	routeConfigJSON  = "/api/config"
+	routeConfigSave  = "/api/config/save"
+	routeConfigReset = "/api/config/reset"
+
+	formConfigFieldKey = "field_key"
+	formConfigValue    = "value"
+
+	configInputText   = "text"
+	configInputNumber = "number"
+	configInputSelect = "select"
+
+	configApplyHot        = "hot"
+	configApplyNextTurn   = "next_turn"
+	configApplyRestart    = "restart"
+	configSourceExplicit  = "explicit"
+	configSourceInherited = "inherited"
+)
+
+const pageSummaryConfig = "" +
+	"Edit major runtime config fields, compare the saved config with " +
+	"the current runtime, and reset fields back to inheritance."
+
+const (
+	viewConfig adminView = "config"
+)
+
+type RuntimeConfigProvider interface {
+	RuntimeConfigStatus() (RuntimeConfigStatus, error)
+	SaveRuntimeConfigValue(key string, value string) error
+	ResetRuntimeConfigValue(key string) error
+}
+
+type RuntimeConfigStatus struct {
+	Enabled    bool                   `json:"enabled"`
+	Error      string                 `json:"error,omitempty"`
+	ConfigPath string                 `json:"config_path,omitempty"`
+	Sections   []RuntimeConfigSection `json:"sections,omitempty"`
+}
+
+type RuntimeConfigSection struct {
+	Key     string               `json:"key,omitempty"`
+	Title   string               `json:"title,omitempty"`
+	Summary string               `json:"summary,omitempty"`
+	Fields  []RuntimeConfigField `json:"fields,omitempty"`
+}
+
+type RuntimeConfigField struct {
+	Key                   string                `json:"key,omitempty"`
+	Title                 string                `json:"title,omitempty"`
+	Summary               string                `json:"summary,omitempty"`
+	InputType             string                `json:"input_type,omitempty"`
+	Placeholder           string                `json:"placeholder,omitempty"`
+	ApplyMode             string                `json:"apply_mode,omitempty"`
+	EditorValue           string                `json:"editor_value,omitempty"`
+	ConfiguredValue       string                `json:"configured_value,omitempty"`
+	ConfiguredSourceLabel string                `json:"configured_source_label,omitempty"`
+	ConfiguredSource      string                `json:"configured_source,omitempty"`
+	RuntimeValue          string                `json:"runtime_value,omitempty"`
+	RuntimeSourceLabel    string                `json:"runtime_source_label,omitempty"`
+	PendingRestart        bool                  `json:"pending_restart"`
+	Resettable            bool                  `json:"resettable"`
+	Options               []RuntimeConfigOption `json:"options,omitempty"`
+}
+
+type RuntimeConfigOption struct {
+	Value string `json:"value,omitempty"`
+	Label string `json:"label,omitempty"`
+}
+
+func (s *Service) runtimeConfigStatus() RuntimeConfigStatus {
+	if s == nil || s.cfg.RuntimeConfig == nil {
+		return RuntimeConfigStatus{}
+	}
+	status, err := s.cfg.RuntimeConfig.RuntimeConfigStatus()
+	if err != nil {
+		return RuntimeConfigStatus{
+			Enabled: true,
+			Error:   strings.TrimSpace(err.Error()),
+		}
+	}
+	status.Enabled = true
+	return status
+}
+
+func (s *Service) handleConfigPage(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	s.renderPage(w, r, viewConfig)
+}
+
+func (s *Service) handleConfigJSON(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	writeJSON(w, http.StatusOK, s.runtimeConfigStatus())
+}
+
+func (s *Service) handleSaveRuntimeConfig(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	returnTo := strings.TrimSpace(r.FormValue(formReturnTo))
+	if s.cfg.RuntimeConfig == nil {
+		s.redirectWithMessageAt(
+			w,
+			r,
+			queryError,
+			"runtime config provider is not available",
+			returnTo,
+		)
+		return
+	}
+	key := strings.TrimSpace(r.FormValue(formConfigFieldKey))
+	if key == "" {
+		s.redirectWithMessageAt(
+			w,
+			r,
+			queryError,
+			"config field is required",
+			returnTo,
+		)
+		return
+	}
+	value := strings.TrimSpace(r.FormValue(formConfigValue))
+	if err := s.cfg.RuntimeConfig.SaveRuntimeConfigValue(key, value); err != nil {
+		s.redirectWithMessageAt(
+			w,
+			r,
+			queryError,
+			err.Error(),
+			returnTo,
+		)
+		return
+	}
+	s.redirectWithMessageAt(
+		w,
+		r,
+		queryNotice,
+		"Saved config field. Restart the runtime to apply "+
+			"restart-bound changes.",
+		returnTo,
+	)
+}
+
+func (s *Service) handleResetRuntimeConfig(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	returnTo := strings.TrimSpace(r.FormValue(formReturnTo))
+	if s.cfg.RuntimeConfig == nil {
+		s.redirectWithMessageAt(
+			w,
+			r,
+			queryError,
+			"runtime config provider is not available",
+			returnTo,
+		)
+		return
+	}
+	key := strings.TrimSpace(r.FormValue(formConfigFieldKey))
+	if key == "" {
+		s.redirectWithMessageAt(
+			w,
+			r,
+			queryError,
+			"config field is required",
+			returnTo,
+		)
+		return
+	}
+	if err := s.cfg.RuntimeConfig.ResetRuntimeConfigValue(key); err != nil {
+		s.redirectWithMessageAt(
+			w,
+			r,
+			queryError,
+			err.Error(),
+			returnTo,
+		)
+		return
+	}
+	s.redirectWithMessageAt(
+		w,
+		r,
+		queryNotice,
+		"Reset config field to inherited behavior.",
+		returnTo,
+	)
+}

--- a/openclaw/admin/config_page.go
+++ b/openclaw/admin/config_page.go
@@ -86,10 +86,11 @@ type RuntimeConfigOption struct {
 }
 
 func (s *Service) runtimeConfigStatus() RuntimeConfigStatus {
-	if s == nil || s.cfg.RuntimeConfig == nil {
+	provider := s.runtimeConfigProvider()
+	if provider == nil {
 		return RuntimeConfigStatus{}
 	}
-	status, err := s.cfg.RuntimeConfig.RuntimeConfigStatus()
+	status, err := provider.RuntimeConfigStatus()
 	if err != nil {
 		return RuntimeConfigStatus{
 			Enabled: true,
@@ -98,6 +99,17 @@ func (s *Service) runtimeConfigStatus() RuntimeConfigStatus {
 	}
 	status.Enabled = true
 	return status
+}
+
+func (s *Service) runtimeConfigProvider() RuntimeConfigProvider {
+	if s == nil {
+		return nil
+	}
+	return s.runtimeConfig
+}
+
+func (s *Service) hasRuntimeConfigProvider() bool {
+	return s.runtimeConfigProvider() != nil
 }
 
 func (s *Service) handleConfigPage(
@@ -127,7 +139,8 @@ func (s *Service) handleSaveRuntimeConfig(
 		return
 	}
 	returnTo := strings.TrimSpace(r.FormValue(formReturnTo))
-	if s.cfg.RuntimeConfig == nil {
+	provider := s.runtimeConfigProvider()
+	if provider == nil {
 		s.redirectWithMessageAt(
 			w,
 			r,
@@ -149,7 +162,7 @@ func (s *Service) handleSaveRuntimeConfig(
 		return
 	}
 	value := strings.TrimSpace(r.FormValue(formConfigValue))
-	if err := s.cfg.RuntimeConfig.SaveRuntimeConfigValue(key, value); err != nil {
+	if err := provider.SaveRuntimeConfigValue(key, value); err != nil {
 		s.redirectWithMessageAt(
 			w,
 			r,
@@ -178,7 +191,8 @@ func (s *Service) handleResetRuntimeConfig(
 		return
 	}
 	returnTo := strings.TrimSpace(r.FormValue(formReturnTo))
-	if s.cfg.RuntimeConfig == nil {
+	provider := s.runtimeConfigProvider()
+	if provider == nil {
 		s.redirectWithMessageAt(
 			w,
 			r,
@@ -199,7 +213,7 @@ func (s *Service) handleResetRuntimeConfig(
 		)
 		return
 	}
-	if err := s.cfg.RuntimeConfig.ResetRuntimeConfigValue(key); err != nil {
+	if err := provider.ResetRuntimeConfigValue(key); err != nil {
 		s.redirectWithMessageAt(
 			w,
 			r,

--- a/openclaw/admin/config_page_test.go
+++ b/openclaw/admin/config_page_test.go
@@ -121,6 +121,46 @@ func TestServiceHandlerRendersConfigPage(t *testing.T) {
 	require.Contains(t, body, "Pending restart")
 }
 
+func TestServiceHandlerRendersConfigPageRestartCTA(t *testing.T) {
+	t.Parallel()
+
+	svc := New(
+		Config{},
+		WithRuntimeConfigProvider(&stubRuntimeConfigProvider{
+			status: RuntimeConfigStatus{
+				ConfigPath: "/tmp/openclaw.yaml",
+				Sections: []RuntimeConfigSection{{
+					Key:   "skills",
+					Title: "Skills",
+					Fields: []RuntimeConfigField{{
+						Key:            "skills.max_loaded_skills",
+						Title:          "Max Loaded Skills",
+						PendingRestart: true,
+					}},
+				}},
+			},
+		}),
+		WithRuntimeLifecycleProvider(
+			&stubRuntimeLifecycleProvider{},
+		),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, routeConfigPage, nil)
+	rr := httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	body := rr.Body.String()
+	require.Contains(t, body, "Open Runtime Control")
+	require.Contains(t, body, `href="runtime-control"`)
+	require.Contains(t, body, "1 saved field")
+	require.Contains(
+		t,
+		body,
+		"still need a restart before the running runtime will use them.",
+	)
+}
+
 func TestHandleSaveRuntimeConfig(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/admin/config_page_test.go
+++ b/openclaw/admin/config_page_test.go
@@ -10,6 +10,7 @@
 package admin
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -195,6 +196,56 @@ func TestHandleResetRuntimeConfig(t *testing.T) {
 	)
 }
 
+func TestServiceRuntimeConfigStatus_Error(t *testing.T) {
+	t.Parallel()
+
+	svc := New(Config{
+		RuntimeConfig: &stubRuntimeConfigProvider{
+			err: errors.New(" status failed "),
+		},
+	})
+
+	status := svc.runtimeConfigStatus()
+	require.True(t, status.Enabled)
+	require.Equal(t, "status failed", status.Error)
+}
+
+func TestHandleConfigJSON(t *testing.T) {
+	t.Parallel()
+
+	svc := New(Config{
+		RuntimeConfig: &stubRuntimeConfigProvider{
+			status: RuntimeConfigStatus{
+				ConfigPath: "/tmp/openclaw.yaml",
+			},
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, routeConfigJSON, nil)
+	rr := httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var status RuntimeConfigStatus
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &status))
+	require.True(t, status.Enabled)
+	require.Equal(t, "/tmp/openclaw.yaml", status.ConfigPath)
+}
+
+func TestHandleConfigJSON_MethodNotAllowed(t *testing.T) {
+	t.Parallel()
+
+	svc := New(Config{})
+
+	req := httptest.NewRequest(http.MethodPost, routeConfigJSON, nil)
+	rr := httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+	require.Contains(t, rr.Body.String(), "method not allowed")
+}
+
 func TestHandleSaveRuntimeConfig_ProviderError(t *testing.T) {
 	t.Parallel()
 
@@ -225,5 +276,184 @@ func TestHandleSaveRuntimeConfig_ProviderError(t *testing.T) {
 		t,
 		rr.Header().Get("Location"),
 		"config?error=write+failed",
+	)
+}
+
+func TestHandleSaveRuntimeConfig_MethodNotAllowed(t *testing.T) {
+	t.Parallel()
+
+	svc := New(Config{})
+
+	req := httptest.NewRequest(http.MethodGet, routeConfigSave, nil)
+	rr := httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+	require.Contains(t, rr.Body.String(), "method not allowed")
+}
+
+func TestHandleSaveRuntimeConfig_NoProvider(t *testing.T) {
+	t.Parallel()
+
+	svc := New(Config{})
+
+	values := url.Values{
+		formConfigFieldKey: {"skills.max_loaded_skills"},
+		formConfigValue:    {"10"},
+		formReturnPath:     {routeConfigPage},
+	}
+	req := httptest.NewRequest(
+		http.MethodPost,
+		routeConfigSave,
+		strings.NewReader(values.Encode()),
+	)
+	req.Header.Set(
+		"Content-Type",
+		"application/x-www-form-urlencoded",
+	)
+	rr := httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusSeeOther, rr.Code)
+	require.Contains(
+		t,
+		rr.Header().Get("Location"),
+		"config?error=runtime+config+provider+is+not+available",
+	)
+}
+
+func TestHandleSaveRuntimeConfig_MissingField(t *testing.T) {
+	t.Parallel()
+
+	svc := New(Config{
+		RuntimeConfig: &stubRuntimeConfigProvider{},
+	})
+
+	values := url.Values{
+		formConfigValue: {"10"},
+		formReturnPath:  {routeConfigPage},
+	}
+	req := httptest.NewRequest(
+		http.MethodPost,
+		routeConfigSave,
+		strings.NewReader(values.Encode()),
+	)
+	req.Header.Set(
+		"Content-Type",
+		"application/x-www-form-urlencoded",
+	)
+	rr := httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusSeeOther, rr.Code)
+	require.Contains(
+		t,
+		rr.Header().Get("Location"),
+		"config?error=config+field+is+required",
+	)
+}
+
+func TestHandleResetRuntimeConfig_MethodNotAllowed(t *testing.T) {
+	t.Parallel()
+
+	svc := New(Config{})
+
+	req := httptest.NewRequest(http.MethodGet, routeConfigReset, nil)
+	rr := httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+	require.Contains(t, rr.Body.String(), "method not allowed")
+}
+
+func TestHandleResetRuntimeConfig_NoProvider(t *testing.T) {
+	t.Parallel()
+
+	svc := New(Config{})
+
+	values := url.Values{
+		formConfigFieldKey: {"skills.max_loaded_skills"},
+		formReturnPath:     {routeConfigPage},
+	}
+	req := httptest.NewRequest(
+		http.MethodPost,
+		routeConfigReset,
+		strings.NewReader(values.Encode()),
+	)
+	req.Header.Set(
+		"Content-Type",
+		"application/x-www-form-urlencoded",
+	)
+	rr := httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusSeeOther, rr.Code)
+	require.Contains(
+		t,
+		rr.Header().Get("Location"),
+		"config?error=runtime+config+provider+is+not+available",
+	)
+}
+
+func TestHandleResetRuntimeConfig_MissingField(t *testing.T) {
+	t.Parallel()
+
+	svc := New(Config{
+		RuntimeConfig: &stubRuntimeConfigProvider{},
+	})
+
+	values := url.Values{
+		formReturnPath: {routeConfigPage},
+	}
+	req := httptest.NewRequest(
+		http.MethodPost,
+		routeConfigReset,
+		strings.NewReader(values.Encode()),
+	)
+	req.Header.Set(
+		"Content-Type",
+		"application/x-www-form-urlencoded",
+	)
+	rr := httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusSeeOther, rr.Code)
+	require.Contains(
+		t,
+		rr.Header().Get("Location"),
+		"config?error=config+field+is+required",
+	)
+}
+
+func TestHandleResetRuntimeConfig_ProviderError(t *testing.T) {
+	t.Parallel()
+
+	svc := New(Config{
+		RuntimeConfig: &stubRuntimeConfigProvider{
+			resetErr: errors.New("reset failed"),
+		},
+	})
+
+	values := url.Values{
+		formConfigFieldKey: {"skills.max_loaded_skills"},
+		formReturnPath:     {routeConfigPage},
+	}
+	req := httptest.NewRequest(
+		http.MethodPost,
+		routeConfigReset,
+		strings.NewReader(values.Encode()),
+	)
+	req.Header.Set(
+		"Content-Type",
+		"application/x-www-form-urlencoded",
+	)
+	rr := httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusSeeOther, rr.Code)
+	require.Contains(
+		t,
+		rr.Header().Get("Location"),
+		"config?error=reset+failed",
 	)
 }

--- a/openclaw/admin/config_page_test.go
+++ b/openclaw/admin/config_page_test.go
@@ -109,6 +109,8 @@ func TestServiceHandlerRendersConfigPage(t *testing.T) {
 	require.Contains(t, body, "Runtime Config")
 	require.Contains(t, body, "Max Loaded Skills")
 	require.Contains(t, body, "/tmp/openclaw.yaml")
+	require.Contains(t, body, `<details class="config-field"`)
+	require.Contains(t, body, `<summary class="config-field-summary">`)
 	require.Contains(t, body, `action="api/config/save"`)
 	require.Contains(t, body, `formaction="api/config/reset"`)
 	require.Contains(t, body, "Pending restart")

--- a/openclaw/admin/config_page_test.go
+++ b/openclaw/admin/config_page_test.go
@@ -161,6 +161,38 @@ func TestServiceHandlerRendersConfigPageRestartCTA(t *testing.T) {
 	)
 }
 
+func TestServiceHandlerRendersConfigPageRuntimeControlLink(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	svc := New(
+		Config{},
+		WithRuntimeConfigProvider(&stubRuntimeConfigProvider{
+			status: RuntimeConfigStatus{
+				ConfigPath: "/tmp/openclaw.yaml",
+				Sections: []RuntimeConfigSection{{
+					Key:   "skills",
+					Title: "Skills",
+				}},
+			},
+		}),
+		WithRuntimeLifecycleProvider(
+			&stubRuntimeLifecycleProvider{},
+		),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, routeConfigPage, nil)
+	rr := httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	body := rr.Body.String()
+	require.Contains(t, body, "Runtime control")
+	require.Contains(t, body, "Restart and version actions")
+	require.Contains(t, body, "Open Runtime Control")
+}
+
 func TestHandleSaveRuntimeConfig(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/admin/config_page_test.go
+++ b/openclaw/admin/config_page_test.go
@@ -71,8 +71,9 @@ func (p *stubRuntimeConfigProvider) ResetRuntimeConfigValue(
 func TestServiceHandlerRendersConfigPage(t *testing.T) {
 	t.Parallel()
 
-	svc := New(Config{
-		RuntimeConfig: &stubRuntimeConfigProvider{
+	svc := New(
+		Config{},
+		WithRuntimeConfigProvider(&stubRuntimeConfigProvider{
 			status: RuntimeConfigStatus{
 				ConfigPath: "/tmp/openclaw.yaml",
 				Sections: []RuntimeConfigSection{{
@@ -96,8 +97,8 @@ func TestServiceHandlerRendersConfigPage(t *testing.T) {
 					}},
 				}},
 			},
-		},
-	})
+		}),
+	)
 
 	req := httptest.NewRequest(http.MethodGet, routeConfigPage, nil)
 	rr := httptest.NewRecorder()
@@ -117,7 +118,7 @@ func TestHandleSaveRuntimeConfig(t *testing.T) {
 	t.Parallel()
 
 	provider := &stubRuntimeConfigProvider{}
-	svc := New(Config{RuntimeConfig: provider})
+	svc := New(Config{}, WithRuntimeConfigProvider(provider))
 
 	values := url.Values{
 		formConfigFieldKey: {"skills.max_loaded_skills"},
@@ -160,7 +161,7 @@ func TestHandleResetRuntimeConfig(t *testing.T) {
 	t.Parallel()
 
 	provider := &stubRuntimeConfigProvider{}
-	svc := New(Config{RuntimeConfig: provider})
+	svc := New(Config{}, WithRuntimeConfigProvider(provider))
 
 	values := url.Values{
 		formConfigFieldKey: {"skills.max_loaded_skills"},
@@ -199,27 +200,37 @@ func TestHandleResetRuntimeConfig(t *testing.T) {
 func TestServiceRuntimeConfigStatus_Error(t *testing.T) {
 	t.Parallel()
 
-	svc := New(Config{
-		RuntimeConfig: &stubRuntimeConfigProvider{
+	svc := New(
+		Config{},
+		WithRuntimeConfigProvider(&stubRuntimeConfigProvider{
 			err: errors.New(" status failed "),
-		},
-	})
+		}),
+	)
 
 	status := svc.runtimeConfigStatus()
 	require.True(t, status.Enabled)
 	require.Equal(t, "status failed", status.Error)
 }
 
+func TestServiceRuntimeConfigProviderHelpers_NilService(t *testing.T) {
+	t.Parallel()
+
+	var svc *Service
+	require.Nil(t, svc.runtimeConfigProvider())
+	require.False(t, svc.hasRuntimeConfigProvider())
+}
+
 func TestHandleConfigJSON(t *testing.T) {
 	t.Parallel()
 
-	svc := New(Config{
-		RuntimeConfig: &stubRuntimeConfigProvider{
+	svc := New(
+		Config{},
+		WithRuntimeConfigProvider(&stubRuntimeConfigProvider{
 			status: RuntimeConfigStatus{
 				ConfigPath: "/tmp/openclaw.yaml",
 			},
-		},
-	})
+		}),
+	)
 
 	req := httptest.NewRequest(http.MethodGet, routeConfigJSON, nil)
 	rr := httptest.NewRecorder()
@@ -252,7 +263,7 @@ func TestHandleSaveRuntimeConfig_ProviderError(t *testing.T) {
 	provider := &stubRuntimeConfigProvider{
 		saveErr: errors.New("write failed"),
 	}
-	svc := New(Config{RuntimeConfig: provider})
+	svc := New(Config{}, WithRuntimeConfigProvider(provider))
 
 	values := url.Values{
 		formConfigFieldKey: {"skills.max_loaded_skills"},
@@ -325,9 +336,7 @@ func TestHandleSaveRuntimeConfig_NoProvider(t *testing.T) {
 func TestHandleSaveRuntimeConfig_MissingField(t *testing.T) {
 	t.Parallel()
 
-	svc := New(Config{
-		RuntimeConfig: &stubRuntimeConfigProvider{},
-	})
+	svc := New(Config{}, WithRuntimeConfigProvider(&stubRuntimeConfigProvider{}))
 
 	values := url.Values{
 		formConfigValue: {"10"},
@@ -398,9 +407,7 @@ func TestHandleResetRuntimeConfig_NoProvider(t *testing.T) {
 func TestHandleResetRuntimeConfig_MissingField(t *testing.T) {
 	t.Parallel()
 
-	svc := New(Config{
-		RuntimeConfig: &stubRuntimeConfigProvider{},
-	})
+	svc := New(Config{}, WithRuntimeConfigProvider(&stubRuntimeConfigProvider{}))
 
 	values := url.Values{
 		formReturnPath: {routeConfigPage},
@@ -428,11 +435,12 @@ func TestHandleResetRuntimeConfig_MissingField(t *testing.T) {
 func TestHandleResetRuntimeConfig_ProviderError(t *testing.T) {
 	t.Parallel()
 
-	svc := New(Config{
-		RuntimeConfig: &stubRuntimeConfigProvider{
+	svc := New(
+		Config{},
+		WithRuntimeConfigProvider(&stubRuntimeConfigProvider{
 			resetErr: errors.New("reset failed"),
-		},
-	})
+		}),
+	)
 
 	values := url.Values{
 		formConfigFieldKey: {"skills.max_loaded_skills"},

--- a/openclaw/admin/config_page_test.go
+++ b/openclaw/admin/config_page_test.go
@@ -71,6 +71,10 @@ func (p *stubRuntimeConfigProvider) ResetRuntimeConfigValue(
 func TestServiceHandlerRendersConfigPage(t *testing.T) {
 	t.Parallel()
 
+	const malformedSummaryClose = `</div>
+                  </div>
+              </summary>`
+
 	svc := New(
 		Config{},
 		WithRuntimeConfigProvider(&stubRuntimeConfigProvider{
@@ -111,6 +115,7 @@ func TestServiceHandlerRendersConfigPage(t *testing.T) {
 	require.Contains(t, body, "/tmp/openclaw.yaml")
 	require.Contains(t, body, `<details class="config-field"`)
 	require.Contains(t, body, `<summary class="config-field-summary">`)
+	require.NotContains(t, body, malformedSummaryClose)
 	require.Contains(t, body, `action="api/config/save"`)
 	require.Contains(t, body, `formaction="api/config/reset"`)
 	require.Contains(t, body, "Pending restart")

--- a/openclaw/admin/config_page_test.go
+++ b/openclaw/admin/config_page_test.go
@@ -1,0 +1,229 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package admin
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type stubRuntimeConfigProvider struct {
+	status RuntimeConfigStatus
+	err    error
+
+	saveErr    error
+	resetErr   error
+	saveKey    string
+	saveValue  string
+	saveCount  int
+	resetKey   string
+	resetCount int
+}
+
+func (p *stubRuntimeConfigProvider) RuntimeConfigStatus() (
+	RuntimeConfigStatus,
+	error,
+) {
+	if p == nil {
+		return RuntimeConfigStatus{}, nil
+	}
+	return p.status, p.err
+}
+
+func (p *stubRuntimeConfigProvider) SaveRuntimeConfigValue(
+	key string,
+	value string,
+) error {
+	if p == nil {
+		return nil
+	}
+	p.saveCount++
+	p.saveKey = key
+	p.saveValue = value
+	return p.saveErr
+}
+
+func (p *stubRuntimeConfigProvider) ResetRuntimeConfigValue(
+	key string,
+) error {
+	if p == nil {
+		return nil
+	}
+	p.resetCount++
+	p.resetKey = key
+	return p.resetErr
+}
+
+func TestServiceHandlerRendersConfigPage(t *testing.T) {
+	t.Parallel()
+
+	svc := New(Config{
+		RuntimeConfig: &stubRuntimeConfigProvider{
+			status: RuntimeConfigStatus{
+				ConfigPath: "/tmp/openclaw.yaml",
+				Sections: []RuntimeConfigSection{{
+					Key:     "skills",
+					Title:   "Skills",
+					Summary: "Skill loading and fallback policy.",
+					Fields: []RuntimeConfigField{{
+						Key:                   "skills.max_loaded_skills",
+						Title:                 "Max Loaded Skills",
+						Summary:               "Cap the active skill set.",
+						InputType:             configInputNumber,
+						ApplyMode:             configApplyRestart,
+						EditorValue:           "10",
+						ConfiguredValue:       "10",
+						ConfiguredSource:      configSourceExplicit,
+						ConfiguredSourceLabel: "Explicit in config",
+						RuntimeValue:          "6",
+						RuntimeSourceLabel:    "Current runtime",
+						PendingRestart:        true,
+						Resettable:            true,
+					}},
+				}},
+			},
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, routeConfigPage, nil)
+	rr := httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	body := rr.Body.String()
+	require.Contains(t, body, "Runtime Config")
+	require.Contains(t, body, "Max Loaded Skills")
+	require.Contains(t, body, "/tmp/openclaw.yaml")
+	require.Contains(t, body, `action="api/config/save"`)
+	require.Contains(t, body, `formaction="api/config/reset"`)
+	require.Contains(t, body, "Pending restart")
+}
+
+func TestHandleSaveRuntimeConfig(t *testing.T) {
+	t.Parallel()
+
+	provider := &stubRuntimeConfigProvider{}
+	svc := New(Config{RuntimeConfig: provider})
+
+	values := url.Values{
+		formConfigFieldKey: {"skills.max_loaded_skills"},
+		formConfigValue:    {"10"},
+		formReturnPath:     {routeConfigPage},
+		formReturnTo:       {"config-field-skills.max_loaded_skills"},
+	}
+	req := httptest.NewRequest(
+		http.MethodPost,
+		routeConfigSave,
+		strings.NewReader(values.Encode()),
+	)
+	req.Header.Set(
+		"Content-Type",
+		"application/x-www-form-urlencoded",
+	)
+	rr := httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusSeeOther, rr.Code)
+	require.Equal(t, "skills.max_loaded_skills", provider.saveKey)
+	require.Equal(t, "10", provider.saveValue)
+	location := rr.Header().Get("Location")
+	require.Contains(t, location, "config?notice=Saved+config+field.")
+	require.Contains(
+		t,
+		location,
+		"Restart+the+runtime+to+apply+restart-bound+changes.",
+	)
+	require.True(
+		t,
+		strings.HasSuffix(
+			location,
+			"#config-field-skills.max_loaded_skills",
+		),
+	)
+}
+
+func TestHandleResetRuntimeConfig(t *testing.T) {
+	t.Parallel()
+
+	provider := &stubRuntimeConfigProvider{}
+	svc := New(Config{RuntimeConfig: provider})
+
+	values := url.Values{
+		formConfigFieldKey: {"skills.max_loaded_skills"},
+		formReturnPath:     {routeConfigPage},
+		formReturnTo:       {"config-field-skills.max_loaded_skills"},
+	}
+	req := httptest.NewRequest(
+		http.MethodPost,
+		routeConfigReset,
+		strings.NewReader(values.Encode()),
+	)
+	req.Header.Set(
+		"Content-Type",
+		"application/x-www-form-urlencoded",
+	)
+	rr := httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusSeeOther, rr.Code)
+	require.Equal(t, "skills.max_loaded_skills", provider.resetKey)
+	location := rr.Header().Get("Location")
+	require.Contains(
+		t,
+		location,
+		"config?notice=Reset+config+field+to+inherited+behavior.",
+	)
+	require.True(
+		t,
+		strings.HasSuffix(
+			location,
+			"#config-field-skills.max_loaded_skills",
+		),
+	)
+}
+
+func TestHandleSaveRuntimeConfig_ProviderError(t *testing.T) {
+	t.Parallel()
+
+	provider := &stubRuntimeConfigProvider{
+		saveErr: errors.New("write failed"),
+	}
+	svc := New(Config{RuntimeConfig: provider})
+
+	values := url.Values{
+		formConfigFieldKey: {"skills.max_loaded_skills"},
+		formConfigValue:    {"10"},
+		formReturnPath:     {routeConfigPage},
+	}
+	req := httptest.NewRequest(
+		http.MethodPost,
+		routeConfigSave,
+		strings.NewReader(values.Encode()),
+	)
+	req.Header.Set(
+		"Content-Type",
+		"application/x-www-form-urlencoded",
+	)
+	rr := httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusSeeOther, rr.Code)
+	require.Contains(
+		t,
+		rr.Header().Get("Location"),
+		"config?error=write+failed",
+	)
+}

--- a/openclaw/admin/runtime_control.go
+++ b/openclaw/admin/runtime_control.go
@@ -1,0 +1,444 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package admin
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	routeRuntimeControlPage   = "/runtime-control"
+	routeRuntimeControlAction = "/api/runtime/control/action"
+
+	queryRuntimeVersion = "version"
+
+	formRuntimeActionKind    = "kind"
+	formRuntimeActionMode    = "mode"
+	formRuntimeTargetVersion = "target_version"
+
+	runtimeActionRestart = "restart"
+	runtimeActionUpgrade = "upgrade"
+
+	runtimeModeGraceful = "graceful"
+	runtimeModeForce    = "force"
+)
+
+const pageSummaryRuntimeControl = "" +
+	"Request graceful or forced restarts, switch versions, " +
+	"and inspect release notes for the current runtime."
+
+const (
+	viewRuntimeControl adminView = "runtime_control"
+)
+
+type RuntimeLifecycleProvider interface {
+	RuntimeLifecycleStatus() (RuntimeLifecycleStatus, error)
+	RuntimeLifecycleVersions() (RuntimeLifecycleVersionIndex, error)
+	RuntimeLifecycleChangelog(string) (
+		RuntimeLifecycleChangelog,
+		error,
+	)
+	RequestRuntimeLifecycleAction(
+		RuntimeLifecycleActionRequest,
+	) (RuntimeLifecycleActionResult, error)
+}
+
+type RuntimeLifecycleStatus struct {
+	State           string                         `json:"state,omitempty"`
+	CurrentVersion  string                         `json:"current_version,omitempty"`
+	ActiveRequests  int                            `json:"active_requests"`
+	RunningRequests int                            `json:"running_requests"`
+	QueuedRequests  int                            `json:"queued_requests"`
+	Pending         *RuntimeLifecyclePendingAction `json:"pending,omitempty"`
+	UpdatedAt       time.Time                      `json:"updated_at,omitempty"`
+	ExitCode        int                            `json:"exit_code"`
+}
+
+type RuntimeLifecyclePendingAction struct {
+	ID             string    `json:"id,omitempty"`
+	Kind           string    `json:"kind,omitempty"`
+	Mode           string    `json:"mode,omitempty"`
+	TargetVersion  string    `json:"target_version,omitempty"`
+	Actor          string    `json:"actor,omitempty"`
+	Source         string    `json:"source,omitempty"`
+	RequestedAt    time.Time `json:"requested_at,omitempty"`
+	CurrentVersion string    `json:"current_version,omitempty"`
+	Summary        []string  `json:"summary,omitempty"`
+}
+
+type RuntimeLifecycleVersionIndex struct {
+	LatestVersion      string                    `json:"latest_version,omitempty"`
+	MinSupportedTarget string                    `json:"min_supported_target,omitempty"`
+	Versions           []RuntimeLifecycleVersion `json:"versions,omitempty"`
+}
+
+type RuntimeLifecycleVersion struct {
+	Version      string    `json:"version,omitempty"`
+	PublishedAt  time.Time `json:"published_at,omitempty"`
+	InstallURL   string    `json:"install_url,omitempty"`
+	ChangelogURL string    `json:"changelog_url,omitempty"`
+	Notes        []string  `json:"notes,omitempty"`
+}
+
+type RuntimeLifecycleChangelog struct {
+	Version   string   `json:"version,omitempty"`
+	Summary   []string `json:"summary,omitempty"`
+	Changelog string   `json:"changelog,omitempty"`
+}
+
+type RuntimeLifecycleActionRequest struct {
+	Kind          string `json:"kind,omitempty"`
+	Mode          string `json:"mode,omitempty"`
+	TargetVersion string `json:"target_version,omitempty"`
+}
+
+type RuntimeLifecycleActionResult struct {
+	Status  RuntimeLifecycleStatus `json:"status"`
+	Started bool                   `json:"started"`
+}
+
+type RuntimeLifecyclePageStatus struct {
+	Enabled         bool                         `json:"enabled"`
+	Error           string                       `json:"error,omitempty"`
+	Status          RuntimeLifecycleStatus       `json:"status"`
+	Index           RuntimeLifecycleVersionIndex `json:"index"`
+	SelectedVersion string                       `json:"selected_version,omitempty"`
+	Changelog       RuntimeLifecycleChangelog    `json:"changelog"`
+}
+
+func (s *Service) runtimeLifecycleProvider() RuntimeLifecycleProvider {
+	if s == nil {
+		return nil
+	}
+	return s.runtimeLifecycle
+}
+
+func (s *Service) hasRuntimeLifecycleProvider() bool {
+	return s.runtimeLifecycleProvider() != nil
+}
+
+func (s *Service) runtimeLifecycleStatus(
+	r *http.Request,
+) RuntimeLifecyclePageStatus {
+	provider := s.runtimeLifecycleProvider()
+	if provider == nil {
+		return RuntimeLifecyclePageStatus{}
+	}
+
+	status, err := provider.RuntimeLifecycleStatus()
+	if err != nil {
+		return RuntimeLifecyclePageStatus{
+			Enabled: true,
+			Error:   strings.TrimSpace(err.Error()),
+		}
+	}
+
+	state := RuntimeLifecyclePageStatus{
+		Enabled: true,
+		Status:  status,
+	}
+
+	index, err := provider.RuntimeLifecycleVersions()
+	if err != nil {
+		state.Error = strings.TrimSpace(err.Error())
+		return state
+	}
+	state.Index = index
+
+	selected := resolveRuntimeLifecycleSelectedVersion(r, state)
+	state.SelectedVersion = selected
+	if selected == "" {
+		return state
+	}
+
+	changelog, err := provider.RuntimeLifecycleChangelog(selected)
+	if err != nil {
+		state.Error = strings.TrimSpace(err.Error())
+		return state
+	}
+	state.Changelog = changelog
+	return state
+}
+
+func (s *Service) runtimeLifecycleRefreshStatus(
+	r *http.Request,
+) RuntimeLifecyclePageStatus {
+	provider := s.runtimeLifecycleProvider()
+	if provider == nil {
+		return RuntimeLifecyclePageStatus{}
+	}
+
+	status, err := provider.RuntimeLifecycleStatus()
+	if err != nil {
+		return RuntimeLifecyclePageStatus{
+			Enabled: true,
+			Error:   strings.TrimSpace(err.Error()),
+		}
+	}
+
+	return RuntimeLifecyclePageStatus{
+		Enabled:         true,
+		Status:          status,
+		SelectedVersion: resolveRuntimeLifecycleRefreshVersion(r, status),
+	}
+}
+
+func resolveRuntimeLifecycleSelectedVersion(
+	r *http.Request,
+	state RuntimeLifecyclePageStatus,
+) string {
+	if r != nil && r.URL != nil {
+		version := strings.TrimSpace(
+			r.URL.Query().Get(queryRuntimeVersion),
+		)
+		if version != "" {
+			return version
+		}
+	}
+	if state.Status.Pending != nil {
+		version := strings.TrimSpace(
+			state.Status.Pending.TargetVersion,
+		)
+		if version != "" {
+			return version
+		}
+	}
+	version := strings.TrimSpace(state.Index.LatestVersion)
+	if version != "" {
+		return version
+	}
+	return strings.TrimSpace(state.Status.CurrentVersion)
+}
+
+func resolveRuntimeLifecycleRefreshVersion(
+	r *http.Request,
+	status RuntimeLifecycleStatus,
+) string {
+	if r != nil && r.URL != nil {
+		version := strings.TrimSpace(
+			r.URL.Query().Get(queryRuntimeVersion),
+		)
+		if version != "" {
+			return version
+		}
+	}
+	if status.Pending != nil {
+		version := strings.TrimSpace(
+			status.Pending.TargetVersion,
+		)
+		if version != "" {
+			return version
+		}
+	}
+	return strings.TrimSpace(status.CurrentVersion)
+}
+
+func (s *Service) handleRuntimeControlPage(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	s.renderPage(w, r, viewRuntimeControl)
+}
+
+func (s *Service) handleRuntimeControlAction(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	returnTo := strings.TrimSpace(r.FormValue(formReturnTo))
+	provider := s.runtimeLifecycleProvider()
+	if provider == nil {
+		s.redirectRuntimeControlWithMessage(
+			w,
+			r,
+			queryError,
+			"runtime lifecycle provider is not available",
+			"",
+			returnTo,
+		)
+		return
+	}
+
+	req, err := runtimeLifecycleActionRequestFromForm(r)
+	if err != nil {
+		s.redirectRuntimeControlWithMessage(
+			w,
+			r,
+			queryError,
+			err.Error(),
+			"",
+			returnTo,
+		)
+		return
+	}
+
+	if _, err := provider.RequestRuntimeLifecycleAction(req); err != nil {
+		s.redirectRuntimeControlWithMessage(
+			w,
+			r,
+			queryError,
+			err.Error(),
+			req.TargetVersion,
+			returnTo,
+		)
+		return
+	}
+
+	s.redirectRuntimeControlWithMessage(
+		w,
+		r,
+		queryNotice,
+		runtimeLifecycleActionNotice(req),
+		req.TargetVersion,
+		returnTo,
+	)
+}
+
+func (s *Service) redirectRuntimeControlWithMessage(
+	w http.ResponseWriter,
+	r *http.Request,
+	key string,
+	message string,
+	version string,
+	fragment string,
+) {
+	target := &url.URL{
+		Path:     routeRuntimeControlPage,
+		Fragment: strings.TrimSpace(fragment),
+	}
+	values := url.Values{}
+	values.Set(key, message)
+	version = strings.TrimSpace(version)
+	if version != "" {
+		values.Set(queryRuntimeVersion, version)
+	}
+	target.RawQuery = values.Encode()
+	http.Redirect(
+		w,
+		r,
+		target.String(),
+		http.StatusSeeOther,
+	)
+}
+
+func runtimeLifecycleActionRequestFromForm(
+	r *http.Request,
+) (RuntimeLifecycleActionRequest, error) {
+	if r == nil {
+		return RuntimeLifecycleActionRequest{}, errRuntimeActionRequired(
+			"request is required",
+		)
+	}
+	if err := r.ParseForm(); err != nil {
+		return RuntimeLifecycleActionRequest{}, errRuntimeActionRequired(
+			err.Error(),
+		)
+	}
+
+	kind := normalizeRuntimeLifecycleAction(
+		r.FormValue(formRuntimeActionKind),
+	)
+	switch kind {
+	case runtimeActionRestart, runtimeActionUpgrade:
+	default:
+		return RuntimeLifecycleActionRequest{}, errRuntimeActionRequired(
+			"runtime action kind is required",
+		)
+	}
+
+	mode := normalizeRuntimeLifecycleMode(
+		r.FormValue(formRuntimeActionMode),
+	)
+	switch mode {
+	case runtimeModeGraceful, runtimeModeForce:
+	default:
+		return RuntimeLifecycleActionRequest{}, errRuntimeActionRequired(
+			"runtime action mode is required",
+		)
+	}
+
+	req := RuntimeLifecycleActionRequest{
+		Kind: kind,
+		Mode: mode,
+	}
+	if kind == runtimeActionUpgrade {
+		req.TargetVersion = strings.TrimSpace(
+			r.FormValue(formRuntimeTargetVersion),
+		)
+	}
+	return req, nil
+}
+
+func errRuntimeActionRequired(message string) error {
+	return &runtimeLifecycleFormError{
+		Message: strings.TrimSpace(message),
+	}
+}
+
+type runtimeLifecycleFormError struct {
+	Message string
+}
+
+func (e *runtimeLifecycleFormError) Error() string {
+	if e == nil {
+		return "runtime action is invalid"
+	}
+	return e.Message
+}
+
+func normalizeRuntimeLifecycleAction(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case runtimeActionRestart:
+		return runtimeActionRestart
+	case runtimeActionUpgrade:
+		return runtimeActionUpgrade
+	default:
+		return ""
+	}
+}
+
+func normalizeRuntimeLifecycleMode(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case runtimeModeGraceful:
+		return runtimeModeGraceful
+	case runtimeModeForce:
+		return runtimeModeForce
+	default:
+		return ""
+	}
+}
+
+func runtimeLifecycleActionNotice(
+	req RuntimeLifecycleActionRequest,
+) string {
+	mode := "graceful"
+	if req.Mode == runtimeModeForce {
+		mode = "force"
+	}
+	switch req.Kind {
+	case runtimeActionRestart:
+		return "Requested " + mode + " restart."
+	case runtimeActionUpgrade:
+		target := strings.TrimSpace(req.TargetVersion)
+		if target == "" {
+			return "Requested " + mode + " upgrade to latest."
+		}
+		return "Requested " + mode + " switch to " + target + "."
+	default:
+		return "Requested runtime action."
+	}
+}

--- a/openclaw/admin/runtime_control_test.go
+++ b/openclaw/admin/runtime_control_test.go
@@ -1,0 +1,294 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package admin
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type stubRuntimeLifecycleProvider struct {
+	status    RuntimeLifecycleStatus
+	statusErr error
+
+	index    RuntimeLifecycleVersionIndex
+	indexErr error
+
+	changelog    RuntimeLifecycleChangelog
+	changelogErr error
+	changelogFor string
+
+	actionErr   error
+	actionReq   RuntimeLifecycleActionRequest
+	actionCount int
+}
+
+func (p *stubRuntimeLifecycleProvider) RuntimeLifecycleStatus() (
+	RuntimeLifecycleStatus,
+	error,
+) {
+	if p == nil {
+		return RuntimeLifecycleStatus{}, nil
+	}
+	return p.status, p.statusErr
+}
+
+func (p *stubRuntimeLifecycleProvider) RuntimeLifecycleVersions() (
+	RuntimeLifecycleVersionIndex,
+	error,
+) {
+	if p == nil {
+		return RuntimeLifecycleVersionIndex{}, nil
+	}
+	return p.index, p.indexErr
+}
+
+func (p *stubRuntimeLifecycleProvider) RuntimeLifecycleChangelog(
+	version string,
+) (RuntimeLifecycleChangelog, error) {
+	if p == nil {
+		return RuntimeLifecycleChangelog{}, nil
+	}
+	p.changelogFor = strings.TrimSpace(version)
+	return p.changelog, p.changelogErr
+}
+
+func (p *stubRuntimeLifecycleProvider) RequestRuntimeLifecycleAction(
+	req RuntimeLifecycleActionRequest,
+) (RuntimeLifecycleActionResult, error) {
+	if p == nil {
+		return RuntimeLifecycleActionResult{}, nil
+	}
+	p.actionCount++
+	p.actionReq = req
+	return RuntimeLifecycleActionResult{
+		Status:  p.status,
+		Started: p.actionErr == nil,
+	}, p.actionErr
+}
+
+func TestServiceHandlerRendersRuntimeControlPage(t *testing.T) {
+	t.Parallel()
+
+	provider := &stubRuntimeLifecycleProvider{
+		status: RuntimeLifecycleStatus{
+			State:           "idle",
+			CurrentVersion:  "v0.0.70",
+			RunningRequests: 1,
+			QueuedRequests:  2,
+			ExitCode:        75,
+			Pending: &RuntimeLifecyclePendingAction{
+				Kind:          runtimeActionUpgrade,
+				Mode:          runtimeModeGraceful,
+				TargetVersion: "v0.0.71",
+				Summary: []string{
+					"ready to drain",
+				},
+			},
+		},
+		index: RuntimeLifecycleVersionIndex{
+			LatestVersion:      "v0.0.71",
+			MinSupportedTarget: "v0.0.48",
+			Versions: []RuntimeLifecycleVersion{
+				{Version: "v0.0.70"},
+				{Version: "v0.0.71"},
+			},
+		},
+		changelog: RuntimeLifecycleChangelog{
+			Version: "v0.0.71",
+			Summary: []string{
+				"release summary",
+			},
+			Changelog: "line one\nline two",
+		},
+	}
+
+	svc := New(
+		Config{},
+		WithRuntimeLifecycleProvider(provider),
+	)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		routeRuntimeControlPage+"?version=v0.0.71",
+		nil,
+	)
+	rr := httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	body := rr.Body.String()
+	require.Contains(t, body, "Runtime Control")
+	require.Contains(t, body, "Quick Actions")
+	require.Contains(t, body, "Target Version")
+	require.Contains(t, body, "Release Notes")
+	require.Contains(t, body, "Force Upgrade to Latest")
+	require.Contains(t, body, `action="api/runtime/control/action"`)
+	require.Contains(t, body, `href="runtime-control"`)
+	require.Contains(t, body, "v0.0.71")
+	require.Contains(t, body, "release summary")
+	require.Equal(t, "v0.0.71", provider.changelogFor)
+}
+
+func TestServiceOverviewRuntimeControlNavVisibility(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodGet, routeOverview, nil)
+
+	hidden := New(Config{})
+	hiddenRec := httptest.NewRecorder()
+	hidden.Handler().ServeHTTP(hiddenRec, req)
+	require.Equal(t, http.StatusOK, hiddenRec.Code)
+	require.NotContains(
+		t,
+		hiddenRec.Body.String(),
+		`href="runtime-control"`,
+	)
+
+	visible := New(
+		Config{},
+		WithRuntimeLifecycleProvider(
+			&stubRuntimeLifecycleProvider{},
+		),
+	)
+	visibleRec := httptest.NewRecorder()
+	visible.Handler().ServeHTTP(visibleRec, req)
+	require.Equal(t, http.StatusOK, visibleRec.Code)
+	require.Contains(
+		t,
+		visibleRec.Body.String(),
+		`href="runtime-control"`,
+	)
+}
+
+func TestHandleRuntimeControlAction(t *testing.T) {
+	t.Parallel()
+
+	provider := &stubRuntimeLifecycleProvider{}
+	svc := New(
+		Config{},
+		WithRuntimeLifecycleProvider(provider),
+	)
+
+	values := url.Values{
+		formRuntimeActionKind:    {runtimeActionUpgrade},
+		formRuntimeActionMode:    {runtimeModeForce},
+		formRuntimeTargetVersion: {"v0.0.71"},
+		formReturnPath:           {routeRuntimeControlPage},
+		formReturnTo:             {"runtime-control-version"},
+	}
+	req := httptest.NewRequest(
+		http.MethodPost,
+		routeRuntimeControlAction,
+		strings.NewReader(values.Encode()),
+	)
+	req.Header.Set(
+		"Content-Type",
+		"application/x-www-form-urlencoded",
+	)
+	rr := httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusSeeOther, rr.Code)
+	require.Equal(t, 1, provider.actionCount)
+	require.Equal(t, RuntimeLifecycleActionRequest{
+		Kind:          runtimeActionUpgrade,
+		Mode:          runtimeModeForce,
+		TargetVersion: "v0.0.71",
+	}, provider.actionReq)
+	location := rr.Header().Get("Location")
+	require.Contains(
+		t,
+		location,
+		"runtime-control?notice=Requested+force+switch+to+v0.0.71.",
+	)
+	require.True(
+		t,
+		strings.HasSuffix(location, "#runtime-control-version"),
+	)
+}
+
+func TestHandleRuntimeControlActionValidationError(t *testing.T) {
+	t.Parallel()
+
+	svc := New(
+		Config{},
+		WithRuntimeLifecycleProvider(
+			&stubRuntimeLifecycleProvider{},
+		),
+	)
+
+	values := url.Values{
+		formRuntimeActionKind: {"restart"},
+		formReturnPath:        {routeRuntimeControlPage},
+	}
+	req := httptest.NewRequest(
+		http.MethodPost,
+		routeRuntimeControlAction,
+		strings.NewReader(values.Encode()),
+	)
+	req.Header.Set(
+		"Content-Type",
+		"application/x-www-form-urlencoded",
+	)
+	rr := httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusSeeOther, rr.Code)
+	require.Contains(
+		t,
+		rr.Header().Get("Location"),
+		"error=runtime+action+mode+is+required",
+	)
+}
+
+func TestHandleRuntimeControlPageStateJSONUsesLightweightStatus(t *testing.T) {
+	t.Parallel()
+
+	provider := &stubRuntimeLifecycleProvider{
+		status: RuntimeLifecycleStatus{
+			CurrentVersion: "v0.0.70",
+		},
+		index: RuntimeLifecycleVersionIndex{
+			LatestVersion: "v0.0.71",
+		},
+		changelogErr: errors.New("should not fetch changelog"),
+	}
+	svc := New(
+		Config{},
+		WithClock(func() time.Time {
+			return time.Unix(1700000000, 0)
+		}),
+		WithRuntimeLifecycleProvider(provider),
+	)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		routePageStateJSON+"?view="+string(viewRuntimeControl),
+		nil,
+	)
+	rr := httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Empty(t, provider.changelogFor)
+
+	var state pageStateStatus
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &state))
+	require.NotEmpty(t, state.Token)
+}

--- a/openclaw/admin/service.go
+++ b/openclaw/admin/service.go
@@ -626,6 +626,8 @@ type skillInstallView struct {
 type pageData struct {
 	Snapshot          snapshot
 	Config            RuntimeConfigStatus
+	ConfigPending     int
+	ConfigCanRestart  bool
 	RuntimeControl    RuntimeLifecyclePageStatus
 	Prompts           PromptsStatus
 	Identity          IdentityStatus
@@ -1150,19 +1152,21 @@ func (s *Service) renderPage(
 	personas := s.personasStatus()
 	chats := s.chatsStatus()
 	data := pageData{
-		Snapshot:        snapshot,
-		Config:          configStatus,
-		RuntimeControl:  runtimeControl,
-		Prompts:         prompts,
-		Identity:        identity,
-		Personas:        personas,
-		Chats:           chats,
-		ChatHistoryPath: routeChatHistoryJSON,
-		Notice:          strings.TrimSpace(r.URL.Query().Get(queryNotice)),
-		Error:           strings.TrimSpace(r.URL.Query().Get(queryError)),
-		View:            view,
-		PageTitle:       pageTitle(view),
-		PageSummary:     pageSummary(view),
+		Snapshot:         snapshot,
+		Config:           configStatus,
+		ConfigPending:    pendingRestartFields(configStatus),
+		ConfigCanRestart: s.hasRuntimeLifecycleProvider(),
+		RuntimeControl:   runtimeControl,
+		Prompts:          prompts,
+		Identity:         identity,
+		Personas:         personas,
+		Chats:            chats,
+		ChatHistoryPath:  routeChatHistoryJSON,
+		Notice:           strings.TrimSpace(r.URL.Query().Get(queryNotice)),
+		Error:            strings.TrimSpace(r.URL.Query().Get(queryError)),
+		View:             view,
+		PageTitle:        pageTitle(view),
+		PageSummary:      pageSummary(view),
 		NavSections: adminNavSections(
 			view,
 			s.hasRuntimeConfigProvider(),
@@ -1200,6 +1204,18 @@ func (s *Service) renderPage(
 			http.StatusInternalServerError,
 		)
 	}
+}
+
+func pendingRestartFields(status RuntimeConfigStatus) int {
+	count := 0
+	for _, section := range status.Sections {
+		for _, field := range section.Fields {
+			if field.PendingRestart {
+				count++
+			}
+		}
+	}
+	return count
 }
 
 func resolveSelectedChat(
@@ -4214,6 +4230,28 @@ const adminPageHTML = `<!doctype html>
           </div>
         </div>
       </div>
+      {{if gt .ConfigPending 0}}
+      <div class="skills-ops-grid">
+        <div class="skills-op-card">
+          <div class="skills-op-label">Pending restart</div>
+          <div class="skills-op-value">
+            {{.ConfigPending}} saved field{{if ne .ConfigPending 1}}s{{end}}
+            still need a restart before the running runtime will use them.
+          </div>
+          <div class="skills-op-note">
+            Saved config changes are already on disk. The live runtime stays on
+            the previous values until the next restart.
+          </div>
+          {{if .ConfigCanRestart}}
+          <div class="skills-op-actions">
+            <a class="page-refresh-link" href="/runtime-control">
+              Open Runtime Control
+            </a>
+          </div>
+          {{end}}
+        </div>
+      </div>
+      {{end}}
       {{if .Config.Error}}
       <div class="notice err" style="margin-top: 12px;">
         {{.Config.Error}}

--- a/openclaw/admin/service.go
+++ b/openclaw/admin/service.go
@@ -243,6 +243,7 @@ type BrowserManagedService struct {
 type Service struct {
 	cfg               Config
 	runtimeConfig     RuntimeConfigProvider
+	runtimeLifecycle  RuntimeLifecycleProvider
 	now               func() time.Time
 	browserHTTPClient *http.Client
 }
@@ -269,6 +270,16 @@ func WithRuntimeConfigProvider(provider RuntimeConfigProvider) Option {
 	return func(s *Service) {
 		if s != nil {
 			s.runtimeConfig = provider
+		}
+	}
+}
+
+func WithRuntimeLifecycleProvider(
+	provider RuntimeLifecycleProvider,
+) Option {
+	return func(s *Service) {
+		if s != nil {
+			s.runtimeLifecycle = provider
 		}
 	}
 }
@@ -306,6 +317,10 @@ func (s *Service) Handler() http.Handler {
 	mux.HandleFunc(
 		routeConfigPage,
 		wrapRelativeLinksFunc(s.handleConfigPage),
+	)
+	mux.HandleFunc(
+		routeRuntimeControlPage,
+		wrapRelativeLinksFunc(s.handleRuntimeControlPage),
 	)
 	mux.HandleFunc(
 		routePrompts,
@@ -361,6 +376,10 @@ func (s *Service) Handler() http.Handler {
 	mux.HandleFunc(
 		routeConfigReset,
 		wrapRelativeLinksFunc(s.handleResetRuntimeConfig),
+	)
+	mux.HandleFunc(
+		routeRuntimeControlAction,
+		wrapRelativeLinksFunc(s.handleRuntimeControlAction),
 	)
 	mux.HandleFunc(
 		routePromptInlineSave,
@@ -607,6 +626,7 @@ type skillInstallView struct {
 type pageData struct {
 	Snapshot          snapshot
 	Config            RuntimeConfigStatus
+	RuntimeControl    RuntimeLifecyclePageStatus
 	Prompts           PromptsStatus
 	Identity          IdentityStatus
 	Personas          PersonasStatus
@@ -640,6 +660,7 @@ type pageStateStatus struct {
 type pageRefreshInput struct {
 	Snapshot          snapshot
 	Config            RuntimeConfigStatus
+	RuntimeControl    RuntimeLifecyclePageStatus
 	Prompts           PromptsStatus
 	Identity          IdentityStatus
 	Personas          PersonasStatus
@@ -1119,6 +1140,11 @@ func (s *Service) renderPage(
 
 	snapshot := s.snapshotForView(view)
 	configStatus := s.runtimeConfigStatus()
+	runtimeControl := s.runtimeLifecycleStatus(r)
+	refreshRuntimeControl := runtimeControl
+	if view == viewRuntimeControl {
+		refreshRuntimeControl = s.runtimeLifecycleRefreshStatus(r)
+	}
 	prompts := s.promptsStatus()
 	identity := s.identityStatus()
 	personas := s.personasStatus()
@@ -1126,6 +1152,7 @@ func (s *Service) renderPage(
 	data := pageData{
 		Snapshot:        snapshot,
 		Config:          configStatus,
+		RuntimeControl:  runtimeControl,
 		Prompts:         prompts,
 		Identity:        identity,
 		Personas:        personas,
@@ -1136,7 +1163,11 @@ func (s *Service) renderPage(
 		View:            view,
 		PageTitle:       pageTitle(view),
 		PageSummary:     pageSummary(view),
-		NavSections:     adminNavSections(view, s.hasRuntimeConfigProvider()),
+		NavSections: adminNavSections(
+			view,
+			s.hasRuntimeConfigProvider(),
+			s.hasRuntimeLifecycleProvider(),
+		),
 	}
 	if view == viewChats {
 		data.SelectedChat, data.SelectedChatError = resolveSelectedChat(
@@ -1151,6 +1182,7 @@ func (s *Service) renderPage(
 		pageRefreshInput{
 			Snapshot:          snapshot,
 			Config:            configStatus,
+			RuntimeControl:    refreshRuntimeControl,
 			Prompts:           prompts,
 			Identity:          identity,
 			Personas:          personas,
@@ -1293,6 +1325,7 @@ func mergeChatView(
 func adminNavSections(
 	active adminView,
 	showConfig bool,
+	showRuntimeControl bool,
 ) []adminNavSection {
 	controlItems := []adminNavItem{
 		{Label: "Overview", Path: routeOverview},
@@ -1320,11 +1353,7 @@ func adminNavSections(
 		},
 		{
 			Label: "Diagnostics",
-			Items: []adminNavItem{
-				{Label: "Runtime Sessions", Path: routeSessions},
-				{Label: "Debug", Path: routeDebug},
-				{Label: "Browser", Path: routeBrowser},
-			},
+			Items: runtimeDiagnosticsNavItems(showRuntimeControl),
 		},
 	}
 	for i := range sections {
@@ -1336,10 +1365,34 @@ func adminNavSections(
 	return sections
 }
 
+func runtimeDiagnosticsNavItems(
+	showRuntimeControl bool,
+) []adminNavItem {
+	items := []adminNavItem{}
+	if showRuntimeControl {
+		items = append(
+			items,
+			adminNavItem{
+				Label: "Runtime Control",
+				Path:  routeRuntimeControlPage,
+			},
+		)
+	}
+	items = append(
+		items,
+		adminNavItem{Label: "Runtime Sessions", Path: routeSessions},
+		adminNavItem{Label: "Debug", Path: routeDebug},
+		adminNavItem{Label: "Browser", Path: routeBrowser},
+	)
+	return items
+}
+
 func pageTitle(view adminView) string {
 	switch view {
 	case viewConfig:
 		return "Config"
+	case viewRuntimeControl:
+		return "Runtime Control"
 	case viewSkills:
 		return "Skills"
 	case viewPrompts:
@@ -1369,6 +1422,8 @@ func pageSummary(view adminView) string {
 	switch view {
 	case viewConfig:
 		return pageSummaryConfig
+	case viewRuntimeControl:
+		return pageSummaryRuntimeControl
 	case viewSkills:
 		return "Discover installed skills, refresh folders from disk, and manage config-backed enablement."
 	case viewPrompts:
@@ -1398,6 +1453,7 @@ func pageRefreshWatch(view adminView) bool {
 	switch view {
 	case viewOverview,
 		viewConfig,
+		viewRuntimeControl,
 		viewSkills,
 		viewChats,
 		viewMemory,
@@ -1454,6 +1510,14 @@ func pageRefreshStatePath(
 			values.Set(queryChatID, chatID)
 		}
 	}
+	if view == viewRuntimeControl && r != nil && r.URL != nil {
+		version := strings.TrimSpace(
+			r.URL.Query().Get(queryRuntimeVersion),
+		)
+		if version != "" {
+			values.Set(queryRuntimeVersion, version)
+		}
+	}
 	return routePageStateJSON + "?" + values.Encode()
 }
 
@@ -1464,6 +1528,8 @@ func pageRefreshToken(
 	switch view {
 	case viewConfig:
 		return refreshTokenForValue(input.Config)
+	case viewRuntimeControl:
+		return refreshTokenForValue(input.RuntimeControl)
 	case viewPrompts:
 		return refreshTokenForValue(input.Prompts)
 	case viewIdentity:
@@ -1517,6 +1583,11 @@ func (s *Service) pageRefreshInput(
 		Identity: s.identityStatus(),
 		Personas: s.personasStatus(),
 		Chats:    s.chatsStatus(),
+	}
+	if view == viewRuntimeControl {
+		input.RuntimeControl = s.runtimeLifecycleRefreshStatus(r)
+	} else {
+		input.RuntimeControl = s.runtimeLifecycleStatus(r)
 	}
 	if view == viewChats {
 		input.SelectedChat, input.SelectedChatError = resolveSelectedChat(
@@ -1728,6 +1799,8 @@ func navPath(raw string) string {
 		return routeOverview
 	case routeConfigPage:
 		return routeConfigPage
+	case routeRuntimeControlPage:
+		return routeRuntimeControlPage
 	case routeSkillsPage:
 		return routeSkillsPage
 	case routePrompts:
@@ -1759,6 +1832,8 @@ func navViewForPath(path string) adminView {
 		return viewOverview
 	case routeConfigPage:
 		return viewConfig
+	case routeRuntimeControlPage:
+		return viewRuntimeControl
 	case routeSkillsPage:
 		return viewSkills
 	case routePrompts:
@@ -3046,6 +3121,80 @@ const adminPageHTML = `<!doctype html>
     .config-form .subtle {
       margin: 0;
     }
+    .runtime-meta-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 10px 16px;
+      margin-top: 12px;
+    }
+    .runtime-meta-card {
+      border-radius: 14px;
+      background: rgba(243, 238, 231, 0.62);
+      padding: 10px 12px;
+    }
+    .runtime-meta-label {
+      color: var(--muted);
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+    .runtime-meta-value {
+      margin-top: 6px;
+      line-height: 1.5;
+      word-break: break-word;
+    }
+    .runtime-pending {
+      margin-top: 16px;
+      padding-top: 16px;
+      border-top: 1px solid rgba(215, 207, 194, 0.65);
+    }
+    .runtime-pending h3,
+    .runtime-version-card h3,
+    .runtime-changelog-card h3 {
+      margin: 0 0 10px;
+      font-size: 16px;
+    }
+    .runtime-summary-list {
+      margin: 12px 0 0;
+      padding-left: 20px;
+    }
+    .runtime-summary-list li {
+      color: var(--muted);
+    }
+    .runtime-version-form,
+    .runtime-version-view-form {
+      display: grid;
+      gap: 10px;
+      margin-top: 14px;
+    }
+    .runtime-version-form select,
+    .runtime-version-view-form select {
+      min-width: min(100%, 320px);
+      padding: 10px 12px;
+      border-radius: 12px;
+      border: 1px solid var(--line);
+      background: rgba(255, 255, 255, 0.96);
+      color: var(--ink);
+      font: inherit;
+    }
+    .runtime-version-actions {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+    .runtime-changelog {
+      margin-top: 12px;
+      padding: 14px;
+      border-radius: 16px;
+      border: 1px solid rgba(215, 207, 194, 0.85);
+      background: rgba(255, 253, 248, 0.9);
+      white-space: pre-wrap;
+      font-family: "SFMono-Regular", "SFMono-Regular", monospace;
+      line-height: 1.45;
+      max-height: 420px;
+      overflow: auto;
+    }
     .skills-group {
       margin-top: 18px;
     }
@@ -4174,6 +4323,291 @@ const adminPageHTML = `<!doctype html>
       </p>
       {{end}}
     </section>
+    {{end}}
+
+    {{if eq .View "runtime_control"}}
+    {{if .RuntimeControl.Error}}
+    <div class="notice err" style="margin-top: 24px;">
+      {{.RuntimeControl.Error}}
+    </div>
+    {{end}}
+    {{if .RuntimeControl.Enabled}}
+    <section class="panels" style="margin-top: 24px;">
+      <article class="card" id="runtime-control-state">
+        <h2>Runtime State</h2>
+        <p class="subtle">
+          Review the current version, queue depth, and any lifecycle action
+          that is already in flight.
+        </p>
+        <div class="runtime-meta-grid">
+          <div class="runtime-meta-card">
+            <div class="runtime-meta-label">Current Version</div>
+            <div class="runtime-meta-value">
+              {{if .RuntimeControl.Status.CurrentVersion}}
+                <code>{{.RuntimeControl.Status.CurrentVersion}}</code>
+              {{else}}
+                <span class="subtle">-</span>
+              {{end}}
+            </div>
+          </div>
+          <div class="runtime-meta-card">
+            <div class="runtime-meta-label">Latest Version</div>
+            <div class="runtime-meta-value">
+              {{if .RuntimeControl.Index.LatestVersion}}
+                <code>{{.RuntimeControl.Index.LatestVersion}}</code>
+              {{else}}
+                <span class="subtle">Unavailable</span>
+              {{end}}
+            </div>
+          </div>
+          <div class="runtime-meta-card">
+            <div class="runtime-meta-label">State</div>
+            <div class="runtime-meta-value">
+              {{if .RuntimeControl.Status.State}}
+                {{.RuntimeControl.Status.State}}
+              {{else}}
+                <span class="subtle">Unknown</span>
+              {{end}}
+            </div>
+          </div>
+          <div class="runtime-meta-card">
+            <div class="runtime-meta-label">Exit Code</div>
+            <div class="runtime-meta-value">
+              {{.RuntimeControl.Status.ExitCode}}
+            </div>
+          </div>
+          <div class="runtime-meta-card">
+            <div class="runtime-meta-label">Running Requests</div>
+            <div class="runtime-meta-value">
+              {{.RuntimeControl.Status.RunningRequests}}
+            </div>
+          </div>
+          <div class="runtime-meta-card">
+            <div class="runtime-meta-label">Queued Requests</div>
+            <div class="runtime-meta-value">
+              {{.RuntimeControl.Status.QueuedRequests}}
+            </div>
+          </div>
+        </div>
+        {{if .RuntimeControl.Status.Pending}}
+        <div class="runtime-pending">
+          <h3>Pending Action</h3>
+          <dl class="meta">
+            <dt>Kind</dt>
+            <dd>{{.RuntimeControl.Status.Pending.Kind}}</dd>
+            <dt>Mode</dt>
+            <dd>{{.RuntimeControl.Status.Pending.Mode}}</dd>
+            {{if .RuntimeControl.Status.Pending.TargetVersion}}
+            <dt>Target Version</dt>
+            <dd>
+              <code>{{.RuntimeControl.Status.Pending.TargetVersion}}</code>
+            </dd>
+            {{end}}
+            {{if .RuntimeControl.Status.Pending.Actor}}
+            <dt>Actor</dt>
+            <dd>{{.RuntimeControl.Status.Pending.Actor}}</dd>
+            {{end}}
+            {{if .RuntimeControl.Status.Pending.Source}}
+            <dt>Source</dt>
+            <dd>{{.RuntimeControl.Status.Pending.Source}}</dd>
+            {{end}}
+            {{if hasTime .RuntimeControl.Status.Pending.RequestedAt}}
+            <dt>Requested</dt>
+            <dd>{{formatTime .RuntimeControl.Status.Pending.RequestedAt}}</dd>
+            {{end}}
+            {{if hasTime .RuntimeControl.Status.UpdatedAt}}
+            <dt>Updated</dt>
+            <dd>{{formatTime .RuntimeControl.Status.UpdatedAt}}</dd>
+            {{end}}
+          </dl>
+          {{if .RuntimeControl.Status.Pending.Summary}}
+          <ul class="runtime-summary-list">
+            {{range .RuntimeControl.Status.Pending.Summary}}
+            <li>{{.}}</li>
+            {{end}}
+          </ul>
+          {{end}}
+        </div>
+        {{else}}
+        <p class="subtle" style="margin-top: 14px;">
+          No restart or version switch is currently pending.
+        </p>
+        {{end}}
+      </article>
+
+      <article class="card" id="runtime-control-quick-actions">
+        <h2>Quick Actions</h2>
+        <p class="subtle">
+          These controls line up with the runtime lifecycle card behavior:
+          graceful actions wait for in-flight work, forced actions exit after
+          the forced-shutdown window.
+        </p>
+        <div class="skills-ops-grid">
+          <div class="skills-op-card">
+            <div class="skills-op-label">Restart</div>
+            <div class="skills-op-value">Graceful restart</div>
+            <div class="skills-op-note">
+              Stop admitting new work, drain active requests, and then restart.
+            </div>
+            <div class="skills-op-actions">
+              <form method="post" action="/api/runtime/control/action">
+                <input type="hidden" name="kind" value="restart">
+                <input type="hidden" name="mode" value="graceful">
+                <input type="hidden" name="return_path" value="/runtime-control">
+                <input type="hidden" name="return_to" value="runtime-control-quick-actions">
+                <button type="submit">Graceful Restart</button>
+              </form>
+            </div>
+          </div>
+          <div class="skills-op-card">
+            <div class="skills-op-label">Restart</div>
+            <div class="skills-op-value">Force restart</div>
+            <div class="skills-op-note">
+              Request a restart and exit once the forced shutdown timeout lands.
+            </div>
+            <div class="skills-op-actions">
+              <form method="post" action="/api/runtime/control/action">
+                <input type="hidden" name="kind" value="restart">
+                <input type="hidden" name="mode" value="force">
+                <input type="hidden" name="return_path" value="/runtime-control">
+                <input type="hidden" name="return_to" value="runtime-control-quick-actions">
+                <button class="warn" type="submit">Force Restart</button>
+              </form>
+            </div>
+          </div>
+          <div class="skills-op-card">
+            <div class="skills-op-label">Upgrade</div>
+            <div class="skills-op-value">Latest version</div>
+            <div class="skills-op-note">
+              Ask the runtime to switch to the latest published release.
+            </div>
+            <div class="skills-op-actions">
+              <form method="post" action="/api/runtime/control/action">
+                <input type="hidden" name="kind" value="upgrade">
+                <input type="hidden" name="mode" value="graceful">
+                <input type="hidden" name="return_path" value="/runtime-control">
+                <input type="hidden" name="return_to" value="runtime-control-quick-actions">
+                <button type="submit">Upgrade to Latest</button>
+              </form>
+            </div>
+          </div>
+          <div class="skills-op-card">
+            <div class="skills-op-label">Upgrade</div>
+            <div class="skills-op-value">Force latest upgrade</div>
+            <div class="skills-op-note">
+              Request the latest version and force the handoff after the drain
+              window ends.
+            </div>
+            <div class="skills-op-actions">
+              <form method="post" action="/api/runtime/control/action">
+                <input type="hidden" name="kind" value="upgrade">
+                <input type="hidden" name="mode" value="force">
+                <input type="hidden" name="return_path" value="/runtime-control">
+                <input type="hidden" name="return_to" value="runtime-control-quick-actions">
+                <button class="warn" type="submit">Force Upgrade to Latest</button>
+              </form>
+            </div>
+          </div>
+        </div>
+      </article>
+    </section>
+
+    <section class="panels" style="margin-top: 16px;">
+      <article class="card runtime-version-card" id="runtime-control-version">
+        <h2>Target Version</h2>
+        <p class="subtle">
+          Pick a release to inspect notes or request a direct switch to that
+          version.
+        </p>
+        {{if .RuntimeControl.Index.MinSupportedTarget}}
+        <p class="subtle">
+          Minimum supported target:
+          <code>{{.RuntimeControl.Index.MinSupportedTarget}}</code>
+        </p>
+        {{end}}
+        {{if .RuntimeControl.Index.Versions}}
+        <form method="get" action="/runtime-control" class="runtime-version-view-form">
+          <select name="version">
+            {{range .RuntimeControl.Index.Versions}}
+            <option value="{{.Version}}" {{if eq $.RuntimeControl.SelectedVersion .Version}}selected{{end}}>
+              {{.Version}}
+            </option>
+            {{end}}
+          </select>
+          <div class="runtime-version-actions">
+            <button class="secondary" type="submit">View Release Notes</button>
+          </div>
+        </form>
+        <form method="post" action="/api/runtime/control/action" class="runtime-version-form">
+          <input type="hidden" name="kind" value="upgrade">
+          <input type="hidden" name="return_path" value="/runtime-control">
+          <input type="hidden" name="return_to" value="runtime-control-version">
+          <select name="target_version">
+            {{range .RuntimeControl.Index.Versions}}
+            <option value="{{.Version}}" {{if eq $.RuntimeControl.SelectedVersion .Version}}selected{{end}}>
+              {{.Version}}
+            </option>
+            {{end}}
+          </select>
+          <div class="runtime-version-actions">
+            <button type="submit" name="mode" value="graceful">
+              Switch Gracefully
+            </button>
+            <button class="warn" type="submit" name="mode" value="force">
+              Switch Forcefully
+            </button>
+          </div>
+        </form>
+        {{else}}
+        <p class="subtle" style="margin-top: 14px;">
+          No published versions are available from the configured release
+          source.
+        </p>
+        {{end}}
+      </article>
+
+      <article class="card runtime-changelog-card" id="runtime-control-changelog">
+        <h2>Release Notes</h2>
+        {{if .RuntimeControl.Changelog.Version}}
+        <p class="subtle">
+          Notes for <code>{{.RuntimeControl.Changelog.Version}}</code>.
+        </p>
+        {{else if .RuntimeControl.SelectedVersion}}
+        <p class="subtle">
+          Notes for <code>{{.RuntimeControl.SelectedVersion}}</code> are not
+          available yet.
+        </p>
+        {{else}}
+        <p class="subtle">
+          Pick a version to inspect release notes.
+        </p>
+        {{end}}
+        {{if .RuntimeControl.Changelog.Summary}}
+        <ul class="runtime-summary-list">
+          {{range .RuntimeControl.Changelog.Summary}}
+          <li>{{.}}</li>
+          {{end}}
+        </ul>
+        {{end}}
+        {{if .RuntimeControl.Changelog.Changelog}}
+        <div class="runtime-changelog">
+          {{.RuntimeControl.Changelog.Changelog}}
+        </div>
+        {{else}}
+        <p class="subtle" style="margin-top: 14px;">
+          The selected version does not currently have release notes.
+        </p>
+        {{end}}
+      </article>
+    </section>
+    {{else if not .RuntimeControl.Error}}
+    <section class="card" style="margin-top: 24px;">
+      <h2>Runtime Control</h2>
+      <p class="subtle">
+        Runtime lifecycle controls are not available for this runtime.
+      </p>
+    </section>
+    {{end}}
     {{end}}
 
     {{if eq .View "skills"}}

--- a/openclaw/admin/service.go
+++ b/openclaw/admin/service.go
@@ -4099,7 +4099,6 @@ const adminPageHTML = `<!doctype html>
                     {{end}}
                   </div>
                 </div>
-                  </div>
               </summary>
               <div class="config-field-detail">
                 <div class="config-meta">

--- a/openclaw/admin/service.go
+++ b/openclaw/admin/service.go
@@ -168,6 +168,7 @@ type Config struct {
 	Channels      []string
 	GatewayRoutes Routes
 	Skills        SkillsStatusProvider
+	RuntimeConfig RuntimeConfigProvider
 	Prompts       PromptsProvider
 	Identity      IdentityProvider
 	Personas      PersonasProvider
@@ -295,6 +296,10 @@ func (s *Service) Handler() http.Handler {
 		wrapRelativeLinksFunc(s.handleSkillsPage),
 	)
 	mux.HandleFunc(
+		routeConfigPage,
+		wrapRelativeLinksFunc(s.handleConfigPage),
+	)
+	mux.HandleFunc(
 		routePrompts,
 		wrapRelativeLinksFunc(s.handlePromptsPage),
 	)
@@ -333,6 +338,7 @@ func (s *Service) Handler() http.Handler {
 	mux.HandleFunc(routeStatusJSON, s.handleStatusJSON)
 	mux.HandleFunc(routePageStateJSON, s.handlePageStateJSON)
 	mux.HandleFunc(routeSkillsJSON, s.handleSkillsJSON)
+	mux.HandleFunc(routeConfigJSON, s.handleConfigJSON)
 	mux.HandleFunc(routePromptsJSON, s.handlePromptsJSON)
 	mux.HandleFunc(routeIdentityJSON, s.handleIdentityJSON)
 	mux.HandleFunc(routePersonasJSON, s.handlePersonasJSON)
@@ -340,6 +346,14 @@ func (s *Service) Handler() http.Handler {
 	mux.HandleFunc(routeChatHistoryJSON, s.handleChatHistoryJSON)
 	mux.HandleFunc(routeMemoryFilesJSON, s.handleMemoryFilesJSON)
 	mux.HandleFunc(routeMemoryFile, s.handleMemoryFile)
+	mux.HandleFunc(
+		routeConfigSave,
+		wrapRelativeLinksFunc(s.handleSaveRuntimeConfig),
+	)
+	mux.HandleFunc(
+		routeConfigReset,
+		wrapRelativeLinksFunc(s.handleResetRuntimeConfig),
+	)
 	mux.HandleFunc(
 		routePromptInlineSave,
 		wrapRelativeLinksFunc(s.handleSavePromptInline),
@@ -584,6 +598,7 @@ type skillInstallView struct {
 
 type pageData struct {
 	Snapshot          snapshot
+	Config            RuntimeConfigStatus
 	Prompts           PromptsStatus
 	Identity          IdentityStatus
 	Personas          PersonasStatus
@@ -616,6 +631,7 @@ type pageStateStatus struct {
 
 type pageRefreshInput struct {
 	Snapshot          snapshot
+	Config            RuntimeConfigStatus
 	Prompts           PromptsStatus
 	Identity          IdentityStatus
 	Personas          PersonasStatus
@@ -691,6 +707,7 @@ func (s *Service) snapshotForView(view adminView) snapshot {
 	switch view {
 	case viewSkills:
 		out.Skills = s.skillsStatus()
+	case viewConfig:
 	case viewMemory:
 		out.Memory = s.memoryStatus()
 	case viewAutomation:
@@ -1093,12 +1110,14 @@ func (s *Service) renderPage(
 	}
 
 	snapshot := s.snapshotForView(view)
+	configStatus := s.runtimeConfigStatus()
 	prompts := s.promptsStatus()
 	identity := s.identityStatus()
 	personas := s.personasStatus()
 	chats := s.chatsStatus()
 	data := pageData{
 		Snapshot:        snapshot,
+		Config:          configStatus,
 		Prompts:         prompts,
 		Identity:        identity,
 		Personas:        personas,
@@ -1123,6 +1142,7 @@ func (s *Service) renderPage(
 		view,
 		pageRefreshInput{
 			Snapshot:          snapshot,
+			Config:            configStatus,
 			Prompts:           prompts,
 			Identity:          identity,
 			Personas:          personas,
@@ -1268,6 +1288,7 @@ func adminNavSections(active adminView) []adminNavSection {
 			Label: "Control",
 			Items: []adminNavItem{
 				{Label: "Overview", Path: routeOverview},
+				{Label: "Config", Path: routeConfigPage},
 				{Label: "Skills", Path: routeSkillsPage},
 				{Label: "Prompts", Path: routePrompts},
 				{Label: "Identity", Path: routeIdentity},
@@ -1297,6 +1318,8 @@ func adminNavSections(active adminView) []adminNavSection {
 
 func pageTitle(view adminView) string {
 	switch view {
+	case viewConfig:
+		return "Config"
 	case viewSkills:
 		return "Skills"
 	case viewPrompts:
@@ -1324,6 +1347,8 @@ func pageTitle(view adminView) string {
 
 func pageSummary(view adminView) string {
 	switch view {
+	case viewConfig:
+		return pageSummaryConfig
 	case viewSkills:
 		return "Discover installed skills, refresh folders from disk, and manage config-backed enablement."
 	case viewPrompts:
@@ -1352,6 +1377,7 @@ func pageSummary(view adminView) string {
 func pageRefreshWatch(view adminView) bool {
 	switch view {
 	case viewOverview,
+		viewConfig,
 		viewSkills,
 		viewChats,
 		viewMemory,
@@ -1416,6 +1442,8 @@ func pageRefreshToken(
 	input pageRefreshInput,
 ) string {
 	switch view {
+	case viewConfig:
+		return refreshTokenForValue(input.Config)
 	case viewPrompts:
 		return refreshTokenForValue(input.Prompts)
 	case viewIdentity:
@@ -1464,6 +1492,7 @@ func (s *Service) pageRefreshInput(
 ) pageRefreshInput {
 	input := pageRefreshInput{
 		Snapshot: s.snapshotForView(view),
+		Config:   s.runtimeConfigStatus(),
 		Prompts:  s.promptsStatus(),
 		Identity: s.identityStatus(),
 		Personas: s.personasStatus(),
@@ -1677,6 +1706,8 @@ func navPath(raw string) string {
 	switch strings.TrimSpace(raw) {
 	case routeIndex, routeOverview:
 		return routeOverview
+	case routeConfigPage:
+		return routeConfigPage
 	case routeSkillsPage:
 		return routeSkillsPage
 	case routePrompts:
@@ -1706,6 +1737,8 @@ func navViewForPath(path string) adminView {
 	switch strings.TrimSpace(path) {
 	case routeIndex, routeOverview:
 		return viewOverview
+	case routeConfigPage:
+		return viewConfig
 	case routeSkillsPage:
 		return viewSkills
 	case routePrompts:
@@ -2876,6 +2909,106 @@ const adminPageHTML = `<!doctype html>
       padding: 7px 12px;
       font-size: 14px;
     }
+    .config-sections {
+      display: grid;
+      gap: 18px;
+      margin-top: 16px;
+    }
+    .config-section-card {
+      border: 1px solid var(--line);
+      border-radius: 18px;
+      padding: 18px;
+      background: rgba(255, 253, 248, 0.8);
+      box-shadow: 0 10px 24px rgba(35, 29, 22, 0.04);
+    }
+    .config-field-list {
+      display: grid;
+      gap: 14px;
+      margin-top: 14px;
+    }
+    .config-field {
+      border: 1px solid rgba(215, 207, 194, 0.9);
+      border-radius: 16px;
+      padding: 14px 16px;
+      background: rgba(255, 252, 247, 0.94);
+    }
+    .config-field-top {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 12px;
+    }
+    .config-field-title {
+      margin: 0;
+      font-size: 18px;
+    }
+    .config-badges {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+    .config-badge {
+      border-radius: 999px;
+      border: 1px solid rgba(15, 111, 97, 0.18);
+      background: rgba(15, 111, 97, 0.08);
+      color: var(--accent);
+      padding: 4px 10px;
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+    .config-badge.warn {
+      border-color: rgba(154, 47, 47, 0.18);
+      background: rgba(154, 47, 47, 0.08);
+      color: var(--warn);
+    }
+    .config-meta {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 10px 16px;
+      margin-top: 12px;
+    }
+    .config-meta-block {
+      border-radius: 14px;
+      background: rgba(243, 238, 231, 0.62);
+      padding: 10px 12px;
+    }
+    .config-meta-label {
+      color: var(--muted);
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+    .config-meta-value {
+      margin-top: 6px;
+      line-height: 1.5;
+      word-break: break-word;
+    }
+    .config-form {
+      display: grid;
+      gap: 10px;
+      margin-top: 14px;
+    }
+    .config-form-row {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+    .config-form input,
+    .config-form select {
+      min-width: min(100%, 320px);
+      padding: 10px 12px;
+      border-radius: 12px;
+      border: 1px solid var(--line);
+      background: rgba(255, 255, 255, 0.96);
+      color: var(--ink);
+      font: inherit;
+    }
+    .config-form .subtle {
+      margin: 0;
+    }
     .skills-group {
       margin-top: 18px;
     }
@@ -3857,6 +3990,148 @@ const adminPageHTML = `<!doctype html>
           <dd><a href="/browser">Browser</a></dd>
         </dl>
       </article>
+    </section>
+    {{end}}
+
+    {{if eq .View "config"}}
+    <section class="card" style="margin-top: 24px;" id="config-admin">
+      <div class="skills-header">
+        <div class="skills-header-copy">
+          <h2>Runtime Config</h2>
+          <p class="skills-lead">
+            This page writes directly to the main runtime config file and keeps
+            unset fields distinct from explicit values.
+          </p>
+        </div>
+      </div>
+      <div class="skills-ops-grid">
+        <div class="skills-op-card">
+          <div class="skills-op-label">Config file</div>
+          <div class="skills-op-value">
+            {{if .Config.ConfigPath}}
+              <code>{{.Config.ConfigPath}}</code>
+            {{else}}
+              Runtime config path is not available
+            {{end}}
+          </div>
+          <div class="skills-op-note">
+            Reset deletes the YAML key so the runtime falls back to inherited
+            behavior.
+          </div>
+        </div>
+        <div class="skills-op-card">
+          <div class="skills-op-label">Apply model</div>
+          <div class="skills-op-value">Restart required by default</div>
+          <div class="skills-op-note">
+            The current runtime stays unchanged until you restart, so this page
+            shows both the saved config and the live runtime side by side.
+          </div>
+        </div>
+      </div>
+      {{if .Config.Error}}
+      <div class="notice err" style="margin-top: 12px;">
+        {{.Config.Error}}
+      </div>
+      {{end}}
+      {{if .Config.Sections}}
+      <div class="config-sections">
+        {{range .Config.Sections}}
+        <section class="config-section-card" id="config-section-{{.Key}}">
+          <h3>{{.Title}}</h3>
+          {{if .Summary}}
+          <p class="subtle">{{.Summary}}</p>
+          {{end}}
+          <div class="config-field-list">
+            {{range .Fields}}
+            <article class="config-field" id="config-field-{{.Key}}">
+              {{$field := .}}
+              <div class="config-field-top">
+                <div>
+                  <h4 class="config-field-title">{{.Title}}</h4>
+                  {{if .Summary}}
+                  <p class="subtle">{{.Summary}}</p>
+                  {{end}}
+                </div>
+                <div class="config-badges">
+                  <span class="config-badge">
+                    {{if eq .ApplyMode "hot"}}Hot apply{{else if eq .ApplyMode "next_turn"}}Next turn{{else}}Restart{{end}}
+                  </span>
+                  {{if .PendingRestart}}
+                  <span class="config-badge warn">Pending restart</span>
+                  {{end}}
+                </div>
+              </div>
+              <div class="config-meta">
+                <div class="config-meta-block">
+                  <div class="config-meta-label">Configured</div>
+                  <div class="config-meta-value">
+                    {{if eq .ConfiguredSource "explicit"}}
+                      {{if .ConfiguredValue}}<code>{{.ConfiguredValue}}</code>{{else}}<code>(empty)</code>{{end}}
+                    {{else}}
+                      <span class="subtle">Inherited</span>
+                    {{end}}
+                  </div>
+                  {{if .ConfiguredSourceLabel}}
+                  <div class="subtle">{{.ConfiguredSourceLabel}}</div>
+                  {{end}}
+                </div>
+                <div class="config-meta-block">
+                  <div class="config-meta-label">Current runtime</div>
+                  <div class="config-meta-value">
+                    {{if .RuntimeValue}}<code>{{.RuntimeValue}}</code>{{else}}<span class="subtle">-</span>{{end}}
+                  </div>
+                  {{if .RuntimeSourceLabel}}
+                  <div class="subtle">{{.RuntimeSourceLabel}}</div>
+                  {{end}}
+                </div>
+              </div>
+              <form method="post" action="/api/config/save" class="config-form">
+                <input type="hidden" name="field_key" value="{{.Key}}">
+                <input type="hidden" name="return_to" value="config-field-{{.Key}}">
+                <input type="hidden" name="return_path" value="/config">
+                {{if eq .InputType "select"}}
+                <select name="value">
+                  {{range $field.Options}}
+                  <option value="{{.Value}}" {{if eq $field.EditorValue .Value}}selected{{end}}>
+                    {{.Label}}
+                  </option>
+                  {{end}}
+                </select>
+                {{else if eq .InputType "number"}}
+                <input
+                  type="number"
+                  name="value"
+                  value="{{.EditorValue}}"
+                  {{if .Placeholder}}placeholder="{{.Placeholder}}"{{end}}
+                >
+                {{else}}
+                <input
+                  type="text"
+                  name="value"
+                  value="{{.EditorValue}}"
+                  {{if .Placeholder}}placeholder="{{.Placeholder}}"{{end}}
+                >
+                {{end}}
+                <div class="config-form-row">
+                  <button type="submit">Save</button>
+                  {{if .Resettable}}
+                  <button class="secondary" type="submit" formaction="/api/config/reset">
+                    Reset
+                  </button>
+                  {{end}}
+                </div>
+              </form>
+            </article>
+            {{end}}
+          </div>
+        </section>
+        {{end}}
+      </div>
+      {{else if not .Config.Error}}
+      <p class="subtle" style="margin-top: 12px;">
+        Runtime config editing is not available for this runtime.
+      </p>
+      {{end}}
     </section>
     {{end}}
 

--- a/openclaw/admin/service.go
+++ b/openclaw/admin/service.go
@@ -4229,6 +4229,21 @@ const adminPageHTML = `<!doctype html>
             shows both the saved config and the live runtime side by side.
           </div>
         </div>
+        {{if .ConfigCanRestart}}
+        <div class="skills-op-card">
+          <div class="skills-op-label">Runtime control</div>
+          <div class="skills-op-value">Restart and version actions</div>
+          <div class="skills-op-note">
+            Use the runtime controls page for graceful restarts, forced
+            restarts, and target-version actions.
+          </div>
+          <div class="skills-op-actions">
+            <a class="page-refresh-link" href="/runtime-control">
+              Open Runtime Control
+            </a>
+          </div>
+        </div>
+        {{end}}
       </div>
       {{if gt .ConfigPending 0}}
       <div class="skills-ops-grid">

--- a/openclaw/admin/service.go
+++ b/openclaw/admin/service.go
@@ -168,7 +168,6 @@ type Config struct {
 	Channels      []string
 	GatewayRoutes Routes
 	Skills        SkillsStatusProvider
-	RuntimeConfig RuntimeConfigProvider
 	Prompts       PromptsProvider
 	Identity      IdentityProvider
 	Personas      PersonasProvider
@@ -243,6 +242,7 @@ type BrowserManagedService struct {
 
 type Service struct {
 	cfg               Config
+	runtimeConfig     RuntimeConfigProvider
 	now               func() time.Time
 	browserHTTPClient *http.Client
 }
@@ -261,6 +261,14 @@ func WithBrowserHTTPClient(client *http.Client) Option {
 	return func(s *Service) {
 		if s != nil && client != nil {
 			s.browserHTTPClient = client
+		}
+	}
+}
+
+func WithRuntimeConfigProvider(provider RuntimeConfigProvider) Option {
+	return func(s *Service) {
+		if s != nil {
+			s.runtimeConfig = provider
 		}
 	}
 }
@@ -1128,7 +1136,7 @@ func (s *Service) renderPage(
 		View:            view,
 		PageTitle:       pageTitle(view),
 		PageSummary:     pageSummary(view),
-		NavSections:     adminNavSections(view),
+		NavSections:     adminNavSections(view, s.hasRuntimeConfigProvider()),
 	}
 	if view == viewChats {
 		data.SelectedChat, data.SelectedChatError = resolveSelectedChat(
@@ -1282,21 +1290,33 @@ func mergeChatView(
 	return merged
 }
 
-func adminNavSections(active adminView) []adminNavSection {
+func adminNavSections(
+	active adminView,
+	showConfig bool,
+) []adminNavSection {
+	controlItems := []adminNavItem{
+		{Label: "Overview", Path: routeOverview},
+	}
+	if showConfig {
+		controlItems = append(
+			controlItems,
+			adminNavItem{Label: "Config", Path: routeConfigPage},
+		)
+	}
+	controlItems = append(
+		controlItems,
+		adminNavItem{Label: "Skills", Path: routeSkillsPage},
+		adminNavItem{Label: "Prompts", Path: routePrompts},
+		adminNavItem{Label: "Identity", Path: routeIdentity},
+		adminNavItem{Label: "Personas", Path: routePersonas},
+		adminNavItem{Label: "Chats", Path: routeChats},
+		adminNavItem{Label: "Memory", Path: routeMemory},
+		adminNavItem{Label: "Automation", Path: routeAutomation},
+	)
 	sections := []adminNavSection{
 		{
 			Label: "Control",
-			Items: []adminNavItem{
-				{Label: "Overview", Path: routeOverview},
-				{Label: "Config", Path: routeConfigPage},
-				{Label: "Skills", Path: routeSkillsPage},
-				{Label: "Prompts", Path: routePrompts},
-				{Label: "Identity", Path: routeIdentity},
-				{Label: "Personas", Path: routePersonas},
-				{Label: "Chats", Path: routeChats},
-				{Label: "Memory", Path: routeMemory},
-				{Label: "Automation", Path: routeAutomation},
-			},
+			Items: controlItems,
 		},
 		{
 			Label: "Diagnostics",

--- a/openclaw/admin/service.go
+++ b/openclaw/admin/service.go
@@ -2949,8 +2949,25 @@ const adminPageHTML = `<!doctype html>
     .config-field {
       border: 1px solid rgba(215, 207, 194, 0.9);
       border-radius: 16px;
-      padding: 14px 16px;
       background: rgba(255, 252, 247, 0.94);
+      overflow: hidden;
+      transition: box-shadow 140ms ease, border-color 140ms ease;
+    }
+    .config-field[open] {
+      border-color: rgba(15, 111, 97, 0.28);
+      box-shadow: 0 14px 28px rgba(35, 29, 22, 0.08);
+    }
+    .config-field summary {
+      list-style: none;
+      cursor: pointer;
+      padding: 14px 16px;
+    }
+    .config-field summary::-webkit-details-marker {
+      display: none;
+    }
+    .config-field-detail {
+      padding: 0 16px 16px;
+      border-top: 1px solid rgba(215, 207, 194, 0.65);
     }
     .config-field-top {
       display: flex;
@@ -4063,85 +4080,90 @@ const adminPageHTML = `<!doctype html>
           {{end}}
           <div class="config-field-list">
             {{range .Fields}}
-            <article class="config-field" id="config-field-{{.Key}}">
+            <details class="config-field" id="config-field-{{.Key}}">
               {{$field := .}}
-              <div class="config-field-top">
-                <div>
-                  <h4 class="config-field-title">{{.Title}}</h4>
-                  {{if .Summary}}
-                  <p class="subtle">{{.Summary}}</p>
-                  {{end}}
-                </div>
-                <div class="config-badges">
-                  <span class="config-badge">
-                    {{if eq .ApplyMode "hot"}}Hot apply{{else if eq .ApplyMode "next_turn"}}Next turn{{else}}Restart{{end}}
-                  </span>
-                  {{if .PendingRestart}}
-                  <span class="config-badge warn">Pending restart</span>
-                  {{end}}
-                </div>
-              </div>
-              <div class="config-meta">
-                <div class="config-meta-block">
-                  <div class="config-meta-label">Configured</div>
-                  <div class="config-meta-value">
-                    {{if eq .ConfiguredSource "explicit"}}
-                      {{if .ConfiguredValue}}<code>{{.ConfiguredValue}}</code>{{else}}<code>(empty)</code>{{end}}
-                    {{else}}
-                      <span class="subtle">Inherited</span>
+              <summary class="config-field-summary">
+                <div class="config-field-top">
+                  <div>
+                    <h4 class="config-field-title">{{.Title}}</h4>
+                    {{if .Summary}}
+                    <p class="subtle">{{.Summary}}</p>
                     {{end}}
                   </div>
-                  {{if .ConfiguredSourceLabel}}
-                  <div class="subtle">{{.ConfiguredSourceLabel}}</div>
-                  {{end}}
-                </div>
-                <div class="config-meta-block">
-                  <div class="config-meta-label">Current runtime</div>
-                  <div class="config-meta-value">
-                    {{if .RuntimeValue}}<code>{{.RuntimeValue}}</code>{{else}}<span class="subtle">-</span>{{end}}
+                  <div class="config-badges">
+                    <span class="config-badge">
+                      {{if eq .ApplyMode "hot"}}Hot apply{{else if eq .ApplyMode "next_turn"}}Next turn{{else}}Restart{{end}}
+                    </span>
+                    {{if .PendingRestart}}
+                    <span class="config-badge warn">Pending restart</span>
+                    {{end}}
                   </div>
-                  {{if .RuntimeSourceLabel}}
-                  <div class="subtle">{{.RuntimeSourceLabel}}</div>
-                  {{end}}
                 </div>
+                  </div>
+              </summary>
+              <div class="config-field-detail">
+                <div class="config-meta">
+                  <div class="config-meta-block">
+                    <div class="config-meta-label">Configured</div>
+                    <div class="config-meta-value">
+                      {{if eq .ConfiguredSource "explicit"}}
+                        {{if .ConfiguredValue}}<code>{{.ConfiguredValue}}</code>{{else}}<code>(empty)</code>{{end}}
+                      {{else}}
+                        <span class="subtle">Inherited</span>
+                      {{end}}
+                    </div>
+                    {{if .ConfiguredSourceLabel}}
+                    <div class="subtle">{{.ConfiguredSourceLabel}}</div>
+                    {{end}}
+                  </div>
+                  <div class="config-meta-block">
+                    <div class="config-meta-label">Current runtime</div>
+                    <div class="config-meta-value">
+                      {{if .RuntimeValue}}<code>{{.RuntimeValue}}</code>{{else}}<span class="subtle">-</span>{{end}}
+                    </div>
+                    {{if .RuntimeSourceLabel}}
+                    <div class="subtle">{{.RuntimeSourceLabel}}</div>
+                    {{end}}
+                  </div>
+                </div>
+                <form method="post" action="/api/config/save" class="config-form">
+                  <input type="hidden" name="field_key" value="{{.Key}}">
+                  <input type="hidden" name="return_to" value="config-field-{{.Key}}">
+                  <input type="hidden" name="return_path" value="/config">
+                  {{if eq .InputType "select"}}
+                  <select name="value">
+                    {{range $field.Options}}
+                    <option value="{{.Value}}" {{if eq $field.EditorValue .Value}}selected{{end}}>
+                      {{.Label}}
+                    </option>
+                    {{end}}
+                  </select>
+                  {{else if eq .InputType "number"}}
+                  <input
+                    type="number"
+                    name="value"
+                    value="{{.EditorValue}}"
+                    {{if .Placeholder}}placeholder="{{.Placeholder}}"{{end}}
+                  >
+                  {{else}}
+                  <input
+                    type="text"
+                    name="value"
+                    value="{{.EditorValue}}"
+                    {{if .Placeholder}}placeholder="{{.Placeholder}}"{{end}}
+                  >
+                  {{end}}
+                  <div class="config-form-row">
+                    <button type="submit">Save</button>
+                    {{if .Resettable}}
+                    <button class="secondary" type="submit" formaction="/api/config/reset">
+                      Reset
+                    </button>
+                    {{end}}
+                  </div>
+                </form>
               </div>
-              <form method="post" action="/api/config/save" class="config-form">
-                <input type="hidden" name="field_key" value="{{.Key}}">
-                <input type="hidden" name="return_to" value="config-field-{{.Key}}">
-                <input type="hidden" name="return_path" value="/config">
-                {{if eq .InputType "select"}}
-                <select name="value">
-                  {{range $field.Options}}
-                  <option value="{{.Value}}" {{if eq $field.EditorValue .Value}}selected{{end}}>
-                    {{.Label}}
-                  </option>
-                  {{end}}
-                </select>
-                {{else if eq .InputType "number"}}
-                <input
-                  type="number"
-                  name="value"
-                  value="{{.EditorValue}}"
-                  {{if .Placeholder}}placeholder="{{.Placeholder}}"{{end}}
-                >
-                {{else}}
-                <input
-                  type="text"
-                  name="value"
-                  value="{{.EditorValue}}"
-                  {{if .Placeholder}}placeholder="{{.Placeholder}}"{{end}}
-                >
-                {{end}}
-                <div class="config-form-row">
-                  <button type="submit">Save</button>
-                  {{if .Resettable}}
-                  <button class="secondary" type="submit" formaction="/api/config/reset">
-                    Reset
-                  </button>
-                  {{end}}
-                </div>
-              </form>
-            </article>
+            </details>
             {{end}}
           </div>
         </section>
@@ -5489,6 +5511,28 @@ const adminPageHTML = `<!doctype html>
       });
       refresh();
       restoreScrollPosition();
+    })();
+
+    (function () {
+      const revealHashDetails = () => {
+        if (!window.location.hash) {
+          return;
+        }
+        const target = document.querySelector(window.location.hash);
+        if (!target) {
+          return;
+        }
+        const disclosure = target.matches("details")
+          ? target
+          : target.closest("details");
+        if (!disclosure) {
+          return;
+        }
+        disclosure.open = true;
+      };
+
+      window.addEventListener("hashchange", revealHashDetails);
+      revealHashDetails();
     })();
 
     (function () {

--- a/openclaw/admin/service_test.go
+++ b/openclaw/admin/service_test.go
@@ -1063,6 +1063,31 @@ func TestServiceHandlerRendersAdminPages(t *testing.T) {
 	}
 }
 
+func TestServiceOverviewConfigNavVisibility(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodGet, routeOverview, nil)
+
+	hidden := New(Config{})
+	hiddenRec := httptest.NewRecorder()
+	hidden.Handler().ServeHTTP(hiddenRec, req)
+	require.Equal(t, http.StatusOK, hiddenRec.Code)
+	require.NotContains(t, hiddenRec.Body.String(), `href="config"`)
+
+	visible := New(
+		Config{},
+		WithRuntimeConfigProvider(&stubRuntimeConfigProvider{
+			status: RuntimeConfigStatus{
+				ConfigPath: "/tmp/openclaw.yaml",
+			},
+		}),
+	)
+	visibleRec := httptest.NewRecorder()
+	visible.Handler().ServeHTTP(visibleRec, req)
+	require.Equal(t, http.StatusOK, visibleRec.Code)
+	require.Contains(t, visibleRec.Body.String(), `href="config"`)
+}
+
 func TestServiceRenderPageRejectsNonGET(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/app/admin_runtime_config.go
+++ b/openclaw/app/admin_runtime_config.go
@@ -1,0 +1,1048 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package app
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/admin"
+)
+
+const (
+	adminRuntimeConfigInputText   = "text"
+	adminRuntimeConfigInputNumber = "number"
+	adminRuntimeConfigInputSelect = "select"
+
+	adminRuntimeConfigApplyRestart = "restart"
+
+	adminRuntimeConfigSourceExplicit  = "explicit"
+	adminRuntimeConfigSourceInherited = "inherited"
+
+	adminRuntimeConfigConfiguredExplicit  = "Explicit in config"
+	adminRuntimeConfigConfiguredInherited = "Inherited from current runtime"
+	adminRuntimeConfigRuntimeSourceLabel  = "Current runtime"
+
+	adminRuntimeConfigValueString = "string"
+	adminRuntimeConfigValueInt    = "int"
+	adminRuntimeConfigValueBool   = "bool"
+)
+
+var runtimeAdminOptionsStore sync.Map
+
+type adminRuntimeConfigProvider struct {
+	configPath string
+	opts       runOptions
+}
+
+type adminRuntimeConfigKeyRef struct {
+	Preferred string
+	Aliases   []string
+}
+
+type adminRuntimeConfigSectionSpec struct {
+	Key     string
+	Title   string
+	Summary string
+	Fields  []adminRuntimeConfigFieldSpec
+}
+
+type adminRuntimeConfigFieldSpec struct {
+	Key         string
+	Title       string
+	Summary     string
+	InputType   string
+	Placeholder string
+	ApplyMode   string
+	ValueType   string
+	Path        []adminRuntimeConfigKeyRef
+	Options     []admin.RuntimeConfigOption
+	Runtime     func(runOptions) string
+}
+
+type adminRuntimeConfiguredValue struct {
+	Value    string
+	Explicit bool
+}
+
+func buildAdminRuntimeConfigProvider(
+	opts runOptions,
+) admin.RuntimeConfigProvider {
+	path := strings.TrimSpace(opts.ConfigPath)
+	if path == "" {
+		return nil
+	}
+	return &adminRuntimeConfigProvider{
+		configPath: path,
+		opts:       opts,
+	}
+}
+
+func buildAdminOptions(opts runOptions) []admin.Option {
+	provider := buildAdminRuntimeConfigProvider(opts)
+	if provider == nil {
+		return nil
+	}
+	return []admin.Option{
+		admin.WithRuntimeConfigProvider(provider),
+	}
+}
+
+func runtimeAdminOptions(rt *Runtime) []admin.Option {
+	if rt == nil {
+		return nil
+	}
+	raw, ok := runtimeAdminOptionsStore.Load(rt)
+	if !ok {
+		return nil
+	}
+	options, ok := raw.([]admin.Option)
+	if !ok || len(options) == 0 {
+		return nil
+	}
+	return append([]admin.Option(nil), options...)
+}
+
+func setRuntimeAdminOptions(rt *Runtime, opts []admin.Option) {
+	if rt == nil {
+		return
+	}
+	if len(opts) == 0 {
+		runtimeAdminOptionsStore.Delete(rt)
+		return
+	}
+	runtimeAdminOptionsStore.Store(rt, append([]admin.Option(nil), opts...))
+}
+
+func clearRuntimeAdminOptions(rt *Runtime) {
+	if rt == nil {
+		return
+	}
+	runtimeAdminOptionsStore.Delete(rt)
+}
+
+func (p *adminRuntimeConfigProvider) RuntimeConfigStatus() (
+	admin.RuntimeConfigStatus,
+	error,
+) {
+	if p == nil || strings.TrimSpace(p.configPath) == "" {
+		return admin.RuntimeConfigStatus{}, nil
+	}
+
+	root, err := adminRuntimeConfigRootFromPath(p.configPath)
+	if err != nil {
+		return admin.RuntimeConfigStatus{}, err
+	}
+
+	status := admin.RuntimeConfigStatus{
+		Enabled:    true,
+		ConfigPath: strings.TrimSpace(p.configPath),
+		Sections: make(
+			[]admin.RuntimeConfigSection,
+			0,
+			len(adminRuntimeConfigSectionSpecs()),
+		),
+	}
+	for _, section := range adminRuntimeConfigSectionSpecs() {
+		view := admin.RuntimeConfigSection{
+			Key:     section.Key,
+			Title:   section.Title,
+			Summary: section.Summary,
+			Fields: make(
+				[]admin.RuntimeConfigField,
+				0,
+				len(section.Fields),
+			),
+		}
+		for _, field := range section.Fields {
+			configured := adminRuntimeConfiguredFieldValue(
+				root,
+				field.Path,
+			)
+			runtimeValue := strings.TrimSpace(field.Runtime(p.opts))
+			nextValue := runtimeValue
+			editorValue := runtimeValue
+			if configured.Explicit {
+				editorValue = configured.Value
+				nextValue = adminRuntimeComparableConfiguredValue(
+					field,
+					configured.Value,
+				)
+			}
+			view.Fields = append(view.Fields, admin.RuntimeConfigField{
+				Key:                   field.Key,
+				Title:                 field.Title,
+				Summary:               field.Summary,
+				InputType:             field.InputType,
+				Placeholder:           field.Placeholder,
+				ApplyMode:             field.ApplyMode,
+				EditorValue:           editorValue,
+				ConfiguredValue:       configured.Value,
+				ConfiguredSource:      adminRuntimeConfiguredSource(configured.Explicit),
+				ConfiguredSourceLabel: adminRuntimeConfiguredLabel(configured.Explicit),
+				RuntimeValue:          runtimeValue,
+				RuntimeSourceLabel:    adminRuntimeConfigRuntimeSourceLabel,
+				PendingRestart:        strings.TrimSpace(nextValue) != runtimeValue,
+				Resettable:            configured.Explicit,
+				Options: append(
+					[]admin.RuntimeConfigOption(nil),
+					field.Options...,
+				),
+			})
+		}
+		status.Sections = append(status.Sections, view)
+	}
+	return status, nil
+}
+
+func (p *adminRuntimeConfigProvider) SaveRuntimeConfigValue(
+	key string,
+	value string,
+) error {
+	if p == nil || strings.TrimSpace(p.configPath) == "" {
+		return fmt.Errorf("runtime config is not available")
+	}
+	spec, ok := adminRuntimeConfigFieldSpecByKey(key)
+	if !ok {
+		return fmt.Errorf("unknown runtime config field")
+	}
+
+	doc, root, err := adminRuntimeConfigDocumentFromPath(p.configPath)
+	if err != nil {
+		return err
+	}
+	parent, err := adminRuntimeEnsureFieldParent(root, spec.Path)
+	if err != nil {
+		return err
+	}
+	if err := adminRuntimeSetFieldValue(parent, spec, value); err != nil {
+		return err
+	}
+	return writeConfigDocument(p.configPath, &doc)
+}
+
+func (p *adminRuntimeConfigProvider) ResetRuntimeConfigValue(
+	key string,
+) error {
+	if p == nil || strings.TrimSpace(p.configPath) == "" {
+		return fmt.Errorf("runtime config is not available")
+	}
+	spec, ok := adminRuntimeConfigFieldSpecByKey(key)
+	if !ok {
+		return fmt.Errorf("unknown runtime config field")
+	}
+
+	doc, root, err := adminRuntimeConfigDocumentFromPath(p.configPath)
+	if err != nil {
+		return err
+	}
+	adminRuntimeDeleteField(root, spec.Path)
+	return writeConfigDocument(p.configPath, &doc)
+}
+
+func adminRuntimeConfigSectionSpecs() []adminRuntimeConfigSectionSpec {
+	return []adminRuntimeConfigSectionSpec{
+		{
+			Key:     "admin",
+			Title:   "Admin",
+			Summary: "Admin server listen settings and safety toggles.",
+			Fields: []adminRuntimeConfigFieldSpec{
+				adminRuntimeBoolField(
+					"admin.enabled",
+					"Enabled",
+					"Turn the admin surface on or off.",
+					[]adminRuntimeConfigKeyRef{
+						adminRuntimeKey("admin"),
+						adminRuntimeKey("enabled"),
+					},
+					func(opts runOptions) string {
+						return strconv.FormatBool(opts.AdminEnabled)
+					},
+				),
+				adminRuntimeTextField(
+					"admin.addr",
+					"Address",
+					"Primary listen address for the admin server.",
+					defaultAdminAddr,
+					[]adminRuntimeConfigKeyRef{
+						adminRuntimeKey("admin"),
+						adminRuntimeKey("addr"),
+					},
+					func(opts runOptions) string {
+						return strings.TrimSpace(opts.AdminAddr)
+					},
+				),
+				adminRuntimeBoolField(
+					"admin.auto_port",
+					"Auto Port",
+					"Search nearby ports when the preferred one is busy.",
+					[]adminRuntimeConfigKeyRef{
+						adminRuntimeKey("admin"),
+						adminRuntimeKey("auto_port"),
+					},
+					func(opts runOptions) string {
+						return strconv.FormatBool(opts.AdminAutoPort)
+					},
+				),
+			},
+		},
+		{
+			Key:     "model",
+			Title:   "Model",
+			Summary: "Core model routing and OpenAI compatibility mode.",
+			Fields: []adminRuntimeConfigFieldSpec{
+				adminRuntimeSelectField(
+					"model.mode",
+					"Mode",
+					"Backend provider family for the runtime.",
+					[]adminRuntimeConfigKeyRef{
+						adminRuntimeKey("model"),
+						adminRuntimeKey("mode"),
+					},
+					func(opts runOptions) string {
+						return strings.TrimSpace(opts.ModelMode)
+					},
+					"mock",
+					"openai",
+				),
+				adminRuntimeTextField(
+					"model.base_url",
+					"Base URL",
+					"Custom OpenAI-compatible endpoint override.",
+					"",
+					[]adminRuntimeConfigKeyRef{
+						adminRuntimeKey("model"),
+						adminRuntimeKey("base_url"),
+					},
+					func(opts runOptions) string {
+						return strings.TrimSpace(opts.OpenAIBaseURL)
+					},
+				),
+				adminRuntimeSelectField(
+					"model.openai_variant",
+					"OpenAI Variant",
+					"Dialect hint for compatible providers.",
+					[]adminRuntimeConfigKeyRef{
+						adminRuntimeKey("model"),
+						adminRuntimeKey("openai_variant"),
+					},
+					func(opts runOptions) string {
+						return strings.TrimSpace(opts.OpenAIVariant)
+					},
+					"auto",
+					"openai",
+					"deepseek",
+					"qwen",
+					"hunyuan",
+				),
+			},
+		},
+		{
+			Key:     "skills",
+			Title:   "Skills",
+			Summary: "Skill watch mode, load policy, and retention settings.",
+			Fields: []adminRuntimeConfigFieldSpec{
+				adminRuntimeBoolField(
+					"skills.watch",
+					"Watch",
+					"Reload local skill folders when files change.",
+					[]adminRuntimeConfigKeyRef{
+						adminRuntimeKey("skills"),
+						adminRuntimeKey("watch"),
+					},
+					func(opts runOptions) string {
+						return strconv.FormatBool(opts.SkillsWatch)
+					},
+				),
+				adminRuntimeBoolField(
+					"skills.watch_bundled",
+					"Watch Bundled",
+					"Watch bundled skill directories as well.",
+					[]adminRuntimeConfigKeyRef{
+						adminRuntimeKey("skills"),
+						adminRuntimeKey("watch_bundled"),
+					},
+					func(opts runOptions) string {
+						return strconv.FormatBool(opts.SkillsWatchBundled)
+					},
+				),
+				adminRuntimeNumberField(
+					"skills.watch_debounce_ms",
+					"Watch Debounce (ms)",
+					"Delay before a burst of file changes reloads skills.",
+					[]adminRuntimeConfigKeyRef{
+						adminRuntimeKey("skills"),
+						adminRuntimeKey("watch_debounce_ms"),
+					},
+					func(opts runOptions) string {
+						return strconv.Itoa(
+							int(opts.SkillsWatchDebounce / time.Millisecond),
+						)
+					},
+				),
+				adminRuntimeSelectField(
+					"skills.load_mode",
+					"Load Mode",
+					"How long a loaded skill stays active.",
+					[]adminRuntimeConfigKeyRef{
+						adminRuntimeKey("skills"),
+						adminRuntimeKey("load_mode"),
+					},
+					func(opts runOptions) string {
+						return strings.TrimSpace(opts.SkillsLoadMode)
+					},
+					"once",
+					"turn",
+					"session",
+				),
+				adminRuntimeNumberField(
+					"skills.max_loaded_skills",
+					"Max Loaded Skills",
+					"Keep only the most recent loaded skills active.",
+					[]adminRuntimeConfigKeyRef{
+						adminRuntimeKey("skills"),
+						adminRuntimeKey("max_loaded_skills"),
+					},
+					func(opts runOptions) string {
+						return strconv.Itoa(opts.SkillsMaxLoaded)
+					},
+				),
+				adminRuntimeBoolField(
+					"skills.loaded_content_in_tool_results",
+					"Loaded Content In Tool Results",
+					"Store loaded skill text in tool results instead of only in system context.",
+					[]adminRuntimeConfigKeyRef{
+						adminRuntimeKey("skills"),
+						adminRuntimeKey("loaded_content_in_tool_results"),
+					},
+					func(opts runOptions) string {
+						return strconv.FormatBool(opts.SkillsToolResults)
+					},
+				),
+				adminRuntimeBoolField(
+					"skills.skip_fallback_on_session_summary",
+					"Skip Fallback On Summary",
+					"Do not re-inject loaded skill context when session summary is present.",
+					[]adminRuntimeConfigKeyRef{
+						adminRuntimeKey("skills"),
+						adminRuntimeKey("skip_fallback_on_session_summary"),
+					},
+					func(opts runOptions) string {
+						return strconv.FormatBool(opts.SkillsSkipFallback)
+					},
+				),
+			},
+		},
+		{
+			Key:     "tools",
+			Title:   "Tools",
+			Summary: "High-level runtime tool toggles.",
+			Fields: []adminRuntimeConfigFieldSpec{
+				adminRuntimeBoolField(
+					"tools.enable_local_exec",
+					"Enable Local Exec",
+					"Expose the local execution tool.",
+					[]adminRuntimeConfigKeyRef{
+						adminRuntimeKey("tools"),
+						adminRuntimeKey("enable_local_exec"),
+					},
+					func(opts runOptions) string {
+						return strconv.FormatBool(opts.EnableLocalExec)
+					},
+				),
+				adminRuntimeBoolField(
+					"tools.enable_openclaw_tools",
+					"Enable OpenClaw Tools",
+					"Expose host-side OpenClaw runtime tools.",
+					[]adminRuntimeConfigKeyRef{
+						adminRuntimeKey("tools"),
+						adminRuntimeKey("enable_openclaw_tools"),
+					},
+					func(opts runOptions) string {
+						return strconv.FormatBool(opts.EnableOpenClawTools)
+					},
+				),
+				adminRuntimeBoolField(
+					"tools.enable_parallel_tools",
+					"Enable Parallel Tools",
+					"Allow the runtime to issue compatible tool calls in parallel.",
+					[]adminRuntimeConfigKeyRef{
+						adminRuntimeKey("tools"),
+						adminRuntimeKey("enable_parallel_tools"),
+					},
+					func(opts runOptions) string {
+						return strconv.FormatBool(opts.EnableParallelTools)
+					},
+				),
+				adminRuntimeBoolField(
+					"tools.refresh_toolsets_on_run",
+					"Refresh Toolsets On Run",
+					"Refresh the toolset registry before each run.",
+					[]adminRuntimeConfigKeyRef{
+						adminRuntimeKey("tools"),
+						adminRuntimeKey("refresh_toolsets_on_run"),
+					},
+					func(opts runOptions) string {
+						return strconv.FormatBool(opts.RefreshToolSetsOnRun)
+					},
+				),
+			},
+		},
+		{
+			Key:     "storage",
+			Title:   "Storage",
+			Summary: "Primary session and memory backend selection.",
+			Fields: []adminRuntimeConfigFieldSpec{
+				adminRuntimeSelectField(
+					"session.backend",
+					"Session Backend",
+					"Conversation session storage backend.",
+					[]adminRuntimeConfigKeyRef{
+						adminRuntimeKey("session"),
+						adminRuntimeKey("backend"),
+					},
+					func(opts runOptions) string {
+						return strings.TrimSpace(opts.SessionBackend)
+					},
+					sessionBackendInMemory,
+					sessionBackendRedis,
+					sessionBackendSQLite,
+					sessionBackendMySQL,
+					sessionBackendPostgres,
+					sessionBackendClickHouse,
+				),
+				adminRuntimeSelectField(
+					"memory.backend",
+					"Memory Backend",
+					"Primary memory backend used by the runtime.",
+					[]adminRuntimeConfigKeyRef{
+						adminRuntimeKey("memory"),
+						adminRuntimeKey("backend"),
+					},
+					func(opts runOptions) string {
+						return strings.TrimSpace(opts.MemoryBackend)
+					},
+					memoryBackendFile,
+					memoryBackendInMemory,
+					memoryBackendRedis,
+					memoryBackendSQLite,
+					memoryBackendSQLiteVec,
+					memoryBackendMySQL,
+					memoryBackendPostgres,
+					memoryBackendPGVector,
+				),
+			},
+		},
+	}
+}
+
+func adminRuntimeBoolField(
+	key string,
+	title string,
+	summary string,
+	path []adminRuntimeConfigKeyRef,
+	runtime func(runOptions) string,
+) adminRuntimeConfigFieldSpec {
+	return adminRuntimeConfigFieldSpec{
+		Key:       key,
+		Title:     title,
+		Summary:   summary,
+		InputType: adminRuntimeConfigInputSelect,
+		ApplyMode: adminRuntimeConfigApplyRestart,
+		ValueType: adminRuntimeConfigValueBool,
+		Path:      path,
+		Options: []admin.RuntimeConfigOption{
+			{Value: "true", Label: "true"},
+			{Value: "false", Label: "false"},
+		},
+		Runtime: runtime,
+	}
+}
+
+func adminRuntimeNumberField(
+	key string,
+	title string,
+	summary string,
+	path []adminRuntimeConfigKeyRef,
+	runtime func(runOptions) string,
+) adminRuntimeConfigFieldSpec {
+	return adminRuntimeConfigFieldSpec{
+		Key:       key,
+		Title:     title,
+		Summary:   summary,
+		InputType: adminRuntimeConfigInputNumber,
+		ApplyMode: adminRuntimeConfigApplyRestart,
+		ValueType: adminRuntimeConfigValueInt,
+		Path:      path,
+		Runtime:   runtime,
+	}
+}
+
+func adminRuntimeTextField(
+	key string,
+	title string,
+	summary string,
+	placeholder string,
+	path []adminRuntimeConfigKeyRef,
+	runtime func(runOptions) string,
+) adminRuntimeConfigFieldSpec {
+	return adminRuntimeConfigFieldSpec{
+		Key:         key,
+		Title:       title,
+		Summary:     summary,
+		InputType:   adminRuntimeConfigInputText,
+		Placeholder: placeholder,
+		ApplyMode:   adminRuntimeConfigApplyRestart,
+		ValueType:   adminRuntimeConfigValueString,
+		Path:        path,
+		Runtime:     runtime,
+	}
+}
+
+func adminRuntimeSelectField(
+	key string,
+	title string,
+	summary string,
+	path []adminRuntimeConfigKeyRef,
+	runtime func(runOptions) string,
+	options ...string,
+) adminRuntimeConfigFieldSpec {
+	return adminRuntimeConfigFieldSpec{
+		Key:       key,
+		Title:     title,
+		Summary:   summary,
+		InputType: adminRuntimeConfigInputSelect,
+		ApplyMode: adminRuntimeConfigApplyRestart,
+		ValueType: adminRuntimeConfigValueString,
+		Path:      path,
+		Options:   adminRuntimeStringOptions(options...),
+		Runtime:   runtime,
+	}
+}
+
+func adminRuntimeStringOptions(
+	values ...string,
+) []admin.RuntimeConfigOption {
+	out := make([]admin.RuntimeConfigOption, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		out = append(out, admin.RuntimeConfigOption{
+			Value: value,
+			Label: value,
+		})
+	}
+	return out
+}
+
+func adminRuntimeConfiguredSource(explicit bool) string {
+	if explicit {
+		return adminRuntimeConfigSourceExplicit
+	}
+	return adminRuntimeConfigSourceInherited
+}
+
+func adminRuntimeConfiguredLabel(explicit bool) string {
+	if explicit {
+		return adminRuntimeConfigConfiguredExplicit
+	}
+	return adminRuntimeConfigConfiguredInherited
+}
+
+func adminRuntimeComparableConfiguredValue(
+	spec adminRuntimeConfigFieldSpec,
+	value string,
+) string {
+	value = strings.TrimSpace(os.ExpandEnv(value))
+	switch spec.ValueType {
+	case adminRuntimeConfigValueBool:
+		parsed, err := strconv.ParseBool(value)
+		if err != nil {
+			return value
+		}
+		return strconv.FormatBool(parsed)
+	case adminRuntimeConfigValueInt:
+		parsed, err := strconv.Atoi(value)
+		if err != nil {
+			return value
+		}
+		return strconv.Itoa(parsed)
+	default:
+		return value
+	}
+}
+
+func adminRuntimeConfigFieldSpecByKey(
+	key string,
+) (adminRuntimeConfigFieldSpec, bool) {
+	key = strings.TrimSpace(key)
+	for _, section := range adminRuntimeConfigSectionSpecs() {
+		for _, field := range section.Fields {
+			if field.Key == key {
+				return field, true
+			}
+		}
+	}
+	return adminRuntimeConfigFieldSpec{}, false
+}
+
+func adminRuntimeConfigRootFromPath(
+	path string,
+) (*yaml.Node, error) {
+	_, root, err := adminRuntimeConfigDocumentFromPath(path)
+	return root, err
+}
+
+func adminRuntimeConfigDocumentFromPath(
+	path string,
+) (yaml.Node, *yaml.Node, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return yaml.Node{}, nil, fmt.Errorf("runtime config path is empty")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return yaml.Node{}, nil, fmt.Errorf("read config: %w", err)
+	}
+	doc, err := decodeConfigDocument(data)
+	if err != nil {
+		return yaml.Node{}, nil, fmt.Errorf("decode config: %w", err)
+	}
+	root, err := ensureDocumentMapping(&doc)
+	if err != nil {
+		return yaml.Node{}, nil, fmt.Errorf("config root: %w", err)
+	}
+	return doc, root, nil
+}
+
+func adminRuntimeConfiguredFieldValue(
+	root *yaml.Node,
+	path []adminRuntimeConfigKeyRef,
+) adminRuntimeConfiguredValue {
+	node := adminRuntimeFieldNode(root, path)
+	if node == nil {
+		return adminRuntimeConfiguredValue{}
+	}
+	return adminRuntimeConfiguredValue{
+		Value:    strings.TrimSpace(node.Value),
+		Explicit: true,
+	}
+}
+
+func adminRuntimeFieldNode(
+	root *yaml.Node,
+	path []adminRuntimeConfigKeyRef,
+) *yaml.Node {
+	parent := adminRuntimeFieldParent(root, path)
+	if parent == nil {
+		return nil
+	}
+	return adminRuntimeLookupMappingValue(parent, path[len(path)-1])
+}
+
+func adminRuntimeFieldParent(
+	root *yaml.Node,
+	path []adminRuntimeConfigKeyRef,
+) *yaml.Node {
+	current := root
+	if current == nil || current.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(path); i++ {
+		current = adminRuntimeLookupMappingValue(current, path[i])
+		if current == nil || current.Kind != yaml.MappingNode {
+			return nil
+		}
+	}
+	return current
+}
+
+func adminRuntimeEnsureFieldParent(
+	root *yaml.Node,
+	path []adminRuntimeConfigKeyRef,
+) (*yaml.Node, error) {
+	current := root
+	if current == nil || current.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("config root is not writable")
+	}
+	for i := 0; i+1 < len(path); i++ {
+		next, err := adminRuntimeEnsureMappingChild(current, path[i])
+		if err != nil {
+			return nil, err
+		}
+		current = next
+	}
+	return current, nil
+}
+
+func adminRuntimeDeleteField(
+	root *yaml.Node,
+	path []adminRuntimeConfigKeyRef,
+) {
+	parent := adminRuntimeFieldParent(root, path)
+	if parent == nil {
+		return
+	}
+	adminRuntimeDeleteMappingValue(parent, path[len(path)-1])
+}
+
+func adminRuntimeSetFieldValue(
+	parent *yaml.Node,
+	spec adminRuntimeConfigFieldSpec,
+	raw string,
+) error {
+	raw = strings.TrimSpace(raw)
+	if spec.InputType == adminRuntimeConfigInputSelect &&
+		!adminRuntimeOptionValueAllowed(raw, spec.Options) {
+		return fmt.Errorf("invalid config value")
+	}
+	switch spec.ValueType {
+	case adminRuntimeConfigValueBool:
+		value, err := strconv.ParseBool(raw)
+		if err != nil {
+			return fmt.Errorf("config: value must be true or false")
+		}
+		return adminRuntimeSetMappingBool(parent, spec.Path[len(spec.Path)-1], value)
+	case adminRuntimeConfigValueInt:
+		value, err := strconv.Atoi(raw)
+		if err != nil {
+			return fmt.Errorf("config: value must be an integer")
+		}
+		return adminRuntimeSetMappingInt(parent, spec.Path[len(spec.Path)-1], value)
+	default:
+		if raw == "" {
+			return fmt.Errorf("config: value is required; use Reset to inherit")
+		}
+		return adminRuntimeSetMappingString(parent, spec.Path[len(spec.Path)-1], raw)
+	}
+}
+
+func adminRuntimeOptionValueAllowed(
+	value string,
+	options []admin.RuntimeConfigOption,
+) bool {
+	if len(options) == 0 {
+		return true
+	}
+	for _, option := range options {
+		if strings.TrimSpace(option.Value) == value {
+			return true
+		}
+	}
+	return false
+}
+
+func adminRuntimeSetMappingBool(
+	parent *yaml.Node,
+	key adminRuntimeConfigKeyRef,
+	value bool,
+) error {
+	boolValue := "false"
+	if value {
+		boolValue = "true"
+	}
+	return adminRuntimeSetScalarValue(parent, key, "!!bool", boolValue)
+}
+
+func adminRuntimeSetMappingInt(
+	parent *yaml.Node,
+	key adminRuntimeConfigKeyRef,
+	value int,
+) error {
+	return adminRuntimeSetScalarValue(
+		parent,
+		key,
+		"!!int",
+		strconv.Itoa(value),
+	)
+}
+
+func adminRuntimeSetMappingString(
+	parent *yaml.Node,
+	key adminRuntimeConfigKeyRef,
+	value string,
+) error {
+	return adminRuntimeSetScalarValue(parent, key, "!!str", value)
+}
+
+func adminRuntimeSetScalarValue(
+	parent *yaml.Node,
+	key adminRuntimeConfigKeyRef,
+	tag string,
+	value string,
+) error {
+	if parent == nil {
+		return fmt.Errorf("mapping node is required")
+	}
+	if parent.Kind != yaml.MappingNode {
+		return fmt.Errorf("expected mapping node")
+	}
+
+	for i := 0; i+1 < len(parent.Content); i += 2 {
+		keyNode := parent.Content[i]
+		if !adminRuntimeKeyMatches(keyNode, key) {
+			continue
+		}
+		valueNode := parent.Content[i+1]
+		if valueNode == nil {
+			valueNode = &yaml.Node{}
+			parent.Content[i+1] = valueNode
+		}
+		if valueNode.Kind != 0 && valueNode.Kind != yaml.ScalarNode {
+			return fmt.Errorf("expected scalar node")
+		}
+		valueNode.Kind = yaml.ScalarNode
+		valueNode.Tag = tag
+		valueNode.Value = value
+		return nil
+	}
+
+	parent.Content = append(
+		parent.Content,
+		&yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Tag:   "!!str",
+			Value: adminRuntimePreferredKey(key),
+		},
+		&yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Tag:   tag,
+			Value: value,
+		},
+	)
+	return nil
+}
+
+func adminRuntimeEnsureMappingChild(
+	parent *yaml.Node,
+	key adminRuntimeConfigKeyRef,
+) (*yaml.Node, error) {
+	if parent == nil {
+		return nil, fmt.Errorf("mapping node is required")
+	}
+	if parent.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("expected mapping node")
+	}
+
+	for i := 0; i+1 < len(parent.Content); i += 2 {
+		keyNode := parent.Content[i]
+		if !adminRuntimeKeyMatches(keyNode, key) {
+			continue
+		}
+		valueNode := parent.Content[i+1]
+		if valueNode == nil {
+			valueNode = &yaml.Node{
+				Kind: yaml.MappingNode,
+				Tag:  "!!map",
+			}
+			parent.Content[i+1] = valueNode
+		}
+		if valueNode.Kind != yaml.MappingNode {
+			return nil, fmt.Errorf("expected mapping node")
+		}
+		return valueNode, nil
+	}
+
+	keyNode := &yaml.Node{
+		Kind:  yaml.ScalarNode,
+		Tag:   "!!str",
+		Value: adminRuntimePreferredKey(key),
+	}
+	valueNode := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Tag:  "!!map",
+	}
+	parent.Content = append(parent.Content, keyNode, valueNode)
+	return valueNode, nil
+}
+
+func adminRuntimeLookupMappingValue(
+	parent *yaml.Node,
+	key adminRuntimeConfigKeyRef,
+) *yaml.Node {
+	if parent == nil || parent.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(parent.Content); i += 2 {
+		if adminRuntimeKeyMatches(parent.Content[i], key) {
+			return parent.Content[i+1]
+		}
+	}
+	return nil
+}
+
+func adminRuntimeDeleteMappingValue(
+	parent *yaml.Node,
+	key adminRuntimeConfigKeyRef,
+) {
+	if parent == nil || parent.Kind != yaml.MappingNode {
+		return
+	}
+	for i := 0; i+1 < len(parent.Content); i += 2 {
+		if !adminRuntimeKeyMatches(parent.Content[i], key) {
+			continue
+		}
+		parent.Content = append(parent.Content[:i], parent.Content[i+2:]...)
+		return
+	}
+}
+
+func adminRuntimeKey(
+	preferred string,
+	aliases ...string,
+) adminRuntimeConfigKeyRef {
+	return adminRuntimeConfigKeyRef{
+		Preferred: strings.TrimSpace(preferred),
+		Aliases:   append([]string(nil), aliases...),
+	}
+}
+
+func adminRuntimePreferredKey(key adminRuntimeConfigKeyRef) string {
+	if strings.TrimSpace(key.Preferred) != "" {
+		return strings.TrimSpace(key.Preferred)
+	}
+	for _, alias := range key.Aliases {
+		alias = strings.TrimSpace(alias)
+		if alias != "" {
+			return alias
+		}
+	}
+	return ""
+}
+
+func adminRuntimeKeyMatches(
+	node *yaml.Node,
+	key adminRuntimeConfigKeyRef,
+) bool {
+	if node == nil {
+		return false
+	}
+	value := strings.TrimSpace(node.Value)
+	if value == "" {
+		return false
+	}
+	if value == strings.TrimSpace(key.Preferred) {
+		return true
+	}
+	for _, alias := range key.Aliases {
+		if value == strings.TrimSpace(alias) {
+			return true
+		}
+	}
+	return false
+}

--- a/openclaw/app/admin_runtime_config.go
+++ b/openclaw/app/admin_runtime_config.go
@@ -43,6 +43,9 @@ const (
 
 var runtimeAdminOptionsStore sync.Map
 
+// AdminSourceConfigPathEnvName overrides the writable admin config file path.
+const AdminSourceConfigPathEnvName = "TRPC_CLAW_ADMIN_SOURCE_CONFIG_PATH"
+
 type adminRuntimeConfigProvider struct {
 	configPath string
 	opts       runOptions
@@ -81,7 +84,7 @@ type adminRuntimeConfiguredValue struct {
 func buildAdminRuntimeConfigProvider(
 	opts runOptions,
 ) admin.RuntimeConfigProvider {
-	path := strings.TrimSpace(opts.ConfigPath)
+	path := adminWritableConfigPath(opts.ConfigPath)
 	if path == "" {
 		return nil
 	}
@@ -89,6 +92,16 @@ func buildAdminRuntimeConfigProvider(
 		configPath: path,
 		opts:       opts,
 	}
+}
+
+func adminWritableConfigPath(configPath string) string {
+	override := strings.TrimSpace(
+		os.Getenv(AdminSourceConfigPathEnvName),
+	)
+	if override != "" {
+		return override
+	}
+	return strings.TrimSpace(configPath)
 }
 
 func buildAdminOptions(opts runOptions) []admin.Option {

--- a/openclaw/app/admin_runtime_config_test.go
+++ b/openclaw/app/admin_runtime_config_test.go
@@ -1,0 +1,712 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package app
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/admin"
+)
+
+func TestBuildAdminOptions_WiresRuntimeConfigProvider(t *testing.T) {
+	t.Parallel()
+
+	cfgPath := writeAdminRuntimeConfigTestFile(t, "")
+	opts := adminRuntimeConfigTestOptions(cfgPath)
+	svc := admin.New(
+		buildAdminConfig(
+			opts,
+			agentTypeLLM,
+			"instance-1",
+			admin.LangfuseStatus{},
+			t.TempDir(),
+			t.TempDir(),
+			time.Unix(0, 0),
+			nil,
+			admin.Routes{},
+			nil,
+			nil,
+			nil,
+			nil,
+			"127.0.0.1:8081",
+			"http://127.0.0.1:8081",
+			nil,
+			nil,
+			nil,
+			nil,
+		),
+		buildAdminOptions(opts)...,
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+	rr := httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var status admin.RuntimeConfigStatus
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &status))
+	require.True(t, status.Enabled)
+	require.Equal(t, cfgPath, status.ConfigPath)
+	require.NotEmpty(t, status.Sections)
+}
+
+func TestBuildAdminOptions_WithoutConfigPath(t *testing.T) {
+	t.Parallel()
+
+	opts := adminRuntimeConfigTestOptions("")
+	svc := admin.New(
+		buildAdminConfig(
+			opts,
+			agentTypeLLM,
+			"instance-1",
+			admin.LangfuseStatus{},
+			t.TempDir(),
+			t.TempDir(),
+			time.Unix(0, 0),
+			nil,
+			admin.Routes{},
+			nil,
+			nil,
+			nil,
+			nil,
+			"127.0.0.1:8081",
+			"http://127.0.0.1:8081",
+			nil,
+			nil,
+			nil,
+			nil,
+		),
+		buildAdminOptions(opts)...,
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/overview", nil)
+	rr := httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.NotContains(t, rr.Body.String(), `href="config"`)
+}
+
+func TestAdminRuntimeConfigProvider_StatusSaveReset(t *testing.T) {
+	t.Parallel()
+
+	cfgPath := writeAdminRuntimeConfigTestFile(
+		t,
+		"skills:\n  max_loaded_skills: 4\n",
+	)
+	opts := adminRuntimeConfigTestOptions(cfgPath)
+	opts.SkillsMaxLoaded = 4
+
+	provider, ok := buildAdminRuntimeConfigProvider(opts).(*adminRuntimeConfigProvider)
+	require.True(t, ok)
+
+	status, err := provider.RuntimeConfigStatus()
+	require.NoError(t, err)
+	field := findAdminRuntimeConfigField(
+		t,
+		status,
+		"skills.max_loaded_skills",
+	)
+	require.Equal(t, "4", field.ConfiguredValue)
+	require.Equal(t, "explicit", field.ConfiguredSource)
+	require.Equal(t, "4", field.RuntimeValue)
+	require.False(t, field.PendingRestart)
+	require.True(t, field.Resettable)
+
+	require.NoError(t, provider.SaveRuntimeConfigValue(
+		"skills.max_loaded_skills",
+		"10",
+	))
+
+	data, err := os.ReadFile(cfgPath)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "max_loaded_skills: 10")
+
+	status, err = provider.RuntimeConfigStatus()
+	require.NoError(t, err)
+	field = findAdminRuntimeConfigField(
+		t,
+		status,
+		"skills.max_loaded_skills",
+	)
+	require.Equal(t, "10", field.ConfiguredValue)
+	require.Equal(t, "4", field.RuntimeValue)
+	require.True(t, field.PendingRestart)
+
+	require.NoError(t, provider.ResetRuntimeConfigValue(
+		"skills.max_loaded_skills",
+	))
+
+	data, err = os.ReadFile(cfgPath)
+	require.NoError(t, err)
+	require.NotContains(t, string(data), "max_loaded_skills")
+
+	status, err = provider.RuntimeConfigStatus()
+	require.NoError(t, err)
+	field = findAdminRuntimeConfigField(
+		t,
+		status,
+		"skills.max_loaded_skills",
+	)
+	require.Empty(t, field.ConfiguredValue)
+	require.Equal(t, "inherited", field.ConfiguredSource)
+	require.False(t, field.PendingRestart)
+	require.False(t, field.Resettable)
+}
+
+func TestAdminRuntimeConfigProvider_SaveBoolFieldCreatesConfig(t *testing.T) {
+	t.Parallel()
+
+	cfgPath := filepath.Join(t.TempDir(), "openclaw.yaml")
+	opts := adminRuntimeConfigTestOptions(cfgPath)
+	provider, ok := buildAdminRuntimeConfigProvider(opts).(*adminRuntimeConfigProvider)
+	require.True(t, ok)
+
+	require.NoError(t, provider.SaveRuntimeConfigValue(
+		"admin.auto_port",
+		"false",
+	))
+
+	data, err := os.ReadFile(cfgPath)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "admin:")
+	require.Contains(t, string(data), "auto_port: false")
+}
+
+func TestAdminRuntimeConfigProvider_SaveStringFieldAndEnvExpansion(
+	t *testing.T,
+) {
+	t.Setenv("OPENCLAW_TEST_BASE_URL", "https://runtime.example")
+	cfgPath := writeAdminRuntimeConfigTestFile(
+		t,
+		"model:\n  base_url: ${OPENCLAW_TEST_BASE_URL}\n",
+	)
+	opts := adminRuntimeConfigTestOptions(cfgPath)
+	opts.OpenAIBaseURL = "https://runtime.example"
+	provider, ok := buildAdminRuntimeConfigProvider(opts).(*adminRuntimeConfigProvider)
+	require.True(t, ok)
+
+	status, err := provider.RuntimeConfigStatus()
+	require.NoError(t, err)
+	field := findAdminRuntimeConfigField(
+		t,
+		status,
+		"model.base_url",
+	)
+	require.Equal(t, "${OPENCLAW_TEST_BASE_URL}", field.ConfiguredValue)
+	require.False(t, field.PendingRestart)
+
+	require.NoError(t, provider.SaveRuntimeConfigValue(
+		"model.base_url",
+		"https://override.example",
+	))
+	data, err := os.ReadFile(cfgPath)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "base_url: https://override.example")
+}
+
+func TestAdminRuntimeConfigProvider_ErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	var nilProvider *adminRuntimeConfigProvider
+	status, err := nilProvider.RuntimeConfigStatus()
+	require.NoError(t, err)
+	require.Equal(t, admin.RuntimeConfigStatus{}, status)
+	require.Error(t, nilProvider.SaveRuntimeConfigValue("admin.auto_port", "true"))
+	require.Error(t, nilProvider.ResetRuntimeConfigValue("admin.auto_port"))
+
+	cfgPath := writeAdminRuntimeConfigTestFile(t, "")
+	opts := adminRuntimeConfigTestOptions(cfgPath)
+	provider, ok := buildAdminRuntimeConfigProvider(opts).(*adminRuntimeConfigProvider)
+	require.True(t, ok)
+
+	require.Error(t, provider.SaveRuntimeConfigValue("missing", "value"))
+	require.Error(t, provider.ResetRuntimeConfigValue("missing"))
+	require.Error(t, provider.SaveRuntimeConfigValue("admin.auto_port", "maybe"))
+	require.Error(t, provider.SaveRuntimeConfigValue("skills.max_loaded_skills", "nan"))
+	require.Error(t, provider.SaveRuntimeConfigValue("skills.load_mode", "invalid"))
+
+	badPath := writeAdminRuntimeConfigTestFile(
+		t,
+		"first: 1\n---\nsecond: 2\n",
+	)
+	badProvider, ok := buildAdminRuntimeConfigProvider(
+		adminRuntimeConfigTestOptions(badPath),
+	).(*adminRuntimeConfigProvider)
+	require.True(t, ok)
+	_, err = badProvider.RuntimeConfigStatus()
+	require.Error(t, err)
+	require.Error(t, badProvider.SaveRuntimeConfigValue("admin.addr", "x"))
+	require.Error(t, badProvider.ResetRuntimeConfigValue("admin.addr"))
+}
+
+func TestAdminRuntimeConfigHelpers(t *testing.T) {
+	t.Parallel()
+
+	spec, ok := adminRuntimeConfigFieldSpecByKey("missing")
+	require.False(t, ok)
+	require.Equal(t, adminRuntimeConfigFieldSpec{}, spec)
+	require.Equal(t, "", adminRuntimePreferredKey(adminRuntimeKey("")))
+
+	require.Equal(
+		t,
+		"true",
+		adminRuntimeComparableConfiguredValue(
+			adminRuntimeConfigFieldSpec{ValueType: adminRuntimeConfigValueBool},
+			"true",
+		),
+	)
+	require.Equal(
+		t,
+		"12",
+		adminRuntimeComparableConfiguredValue(
+			adminRuntimeConfigFieldSpec{ValueType: adminRuntimeConfigValueInt},
+			"12",
+		),
+	)
+	require.Equal(
+		t,
+		"bad-bool",
+		adminRuntimeComparableConfiguredValue(
+			adminRuntimeConfigFieldSpec{ValueType: adminRuntimeConfigValueBool},
+			"bad-bool",
+		),
+	)
+	require.Equal(
+		t,
+		"bad-int",
+		adminRuntimeComparableConfiguredValue(
+			adminRuntimeConfigFieldSpec{ValueType: adminRuntimeConfigValueInt},
+			"bad-int",
+		),
+	)
+	require.Equal(
+		t,
+		os.ExpandEnv("$HOME/bin"),
+		adminRuntimeComparableConfiguredValue(
+			adminRuntimeConfigFieldSpec{ValueType: adminRuntimeConfigValueString},
+			"$HOME/bin",
+		),
+	)
+
+	require.True(t, adminRuntimeOptionValueAllowed("turn", nil))
+	require.False(
+		t,
+		adminRuntimeOptionValueAllowed(
+			"bad",
+			[]admin.RuntimeConfigOption{{Value: "turn"}},
+		),
+	)
+
+	require.Equal(
+		t,
+		"fallback",
+		adminRuntimePreferredKey(adminRuntimeKey("", "fallback")),
+	)
+	require.True(
+		t,
+		adminRuntimeKeyMatches(
+			&yaml.Node{Value: "alias"},
+			adminRuntimeKey("preferred", "alias"),
+		),
+	)
+	require.False(t, adminRuntimeKeyMatches(nil, adminRuntimeKey("preferred")))
+	require.False(
+		t,
+		adminRuntimeKeyMatches(
+			&yaml.Node{Value: "other"},
+			adminRuntimeKey("preferred", "alias"),
+		),
+	)
+
+	_, _, err := adminRuntimeConfigDocumentFromPath("")
+	require.Error(t, err)
+	doc, rootDoc, err := adminRuntimeConfigDocumentFromPath(
+		filepath.Join(t.TempDir(), "missing.yaml"),
+	)
+	require.NoError(t, err)
+	require.Equal(t, yaml.DocumentNode, doc.Kind)
+	require.NotNil(t, rootDoc)
+
+	parent := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	require.NoError(t, adminRuntimeSetMappingBool(
+		parent,
+		adminRuntimeKey("enabled"),
+		true,
+	))
+	require.NoError(t, adminRuntimeSetMappingString(
+		parent,
+		adminRuntimeKey("base_url"),
+		"https://example.test",
+	))
+	require.Equal(
+		t,
+		"https://example.test",
+		adminRuntimeLookupMappingValue(parent, adminRuntimeKey("base_url")).Value,
+	)
+	require.NoError(t, adminRuntimeSetMappingString(
+		parent,
+		adminRuntimeKey("base_url"),
+		"https://updated.example",
+	))
+	require.Equal(
+		t,
+		"https://updated.example",
+		adminRuntimeLookupMappingValue(parent, adminRuntimeKey("base_url")).Value,
+	)
+	require.NoError(t, adminRuntimeSetMappingInt(
+		parent,
+		adminRuntimeKey("max_loaded_skills"),
+		8,
+	))
+	require.Equal(
+		t,
+		"8",
+		adminRuntimeLookupMappingValue(
+			parent,
+			adminRuntimeKey("max_loaded_skills"),
+		).Value,
+	)
+	require.Error(
+		t,
+		adminRuntimeSetMappingString(
+			&yaml.Node{Kind: yaml.SequenceNode},
+			adminRuntimeKey("broken"),
+			"value",
+		),
+	)
+	require.Error(
+		t,
+		adminRuntimeSetScalarValue(
+			nil,
+			adminRuntimeKey("broken"),
+			"!!str",
+			"value",
+		),
+	)
+	_, err = adminRuntimeEnsureMappingChild(nil, adminRuntimeKey("skills"))
+	require.Error(t, err)
+	_, err = adminRuntimeEnsureMappingChild(
+		&yaml.Node{Kind: yaml.SequenceNode},
+		adminRuntimeKey("skills"),
+	)
+	require.Error(t, err)
+	child, err := adminRuntimeEnsureMappingChild(
+		parent,
+		adminRuntimeKey("settings"),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, child)
+	child, err = adminRuntimeEnsureMappingChild(
+		parent,
+		adminRuntimeKey("settings"),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, child)
+	parentWithNilChild := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Tag:  "!!map",
+		Content: []*yaml.Node{
+			{Kind: yaml.ScalarNode, Tag: "!!str", Value: "empty"},
+			nil,
+		},
+	}
+	child, err = adminRuntimeEnsureMappingChild(
+		parentWithNilChild,
+		adminRuntimeKey("empty"),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, child)
+	adminRuntimeDeleteMappingValue(parent, adminRuntimeKey("missing"))
+	adminRuntimeDeleteMappingValue(parent, adminRuntimeKey("settings"))
+	require.Nil(
+		t,
+		adminRuntimeLookupMappingValue(parent, adminRuntimeKey("settings")),
+	)
+
+	root := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	fieldPath := []adminRuntimeConfigKeyRef{
+		adminRuntimeKey("skills"),
+		adminRuntimeKey("max_loaded_skills"),
+	}
+	fieldParent, err := adminRuntimeEnsureFieldParent(root, fieldPath)
+	require.NoError(t, err)
+	require.Error(t, adminRuntimeSetFieldValue(
+		fieldParent,
+		adminRuntimeConfigFieldSpec{
+			Key:       "skills.mode",
+			InputType: adminRuntimeConfigInputText,
+			ValueType: adminRuntimeConfigValueString,
+			Path: []adminRuntimeConfigKeyRef{
+				adminRuntimeKey("skills"),
+				adminRuntimeKey("mode"),
+			},
+		},
+		"",
+	))
+	require.NoError(t, adminRuntimeSetFieldValue(
+		fieldParent,
+		adminRuntimeConfigFieldSpec{
+			Key:       "skills.max_loaded_skills",
+			InputType: adminRuntimeConfigInputNumber,
+			ValueType: adminRuntimeConfigValueInt,
+			Path:      fieldPath,
+		},
+		"6",
+	))
+	require.Equal(
+		t,
+		"6",
+		adminRuntimeFieldNode(root, fieldPath).Value,
+	)
+	modePath := []adminRuntimeConfigKeyRef{
+		adminRuntimeKey("skills"),
+		adminRuntimeKey("load_mode"),
+	}
+	modeParent, err := adminRuntimeEnsureFieldParent(root, modePath)
+	require.NoError(t, err)
+	require.NoError(t, adminRuntimeSetFieldValue(
+		modeParent,
+		adminRuntimeConfigFieldSpec{
+			Key:       "skills.load_mode",
+			InputType: adminRuntimeConfigInputSelect,
+			ValueType: adminRuntimeConfigValueString,
+			Path:      modePath,
+			Options:   []admin.RuntimeConfigOption{{Value: "turn"}},
+		},
+		"turn",
+	))
+	require.Equal(t, "turn", adminRuntimeFieldNode(root, modePath).Value)
+	adminRuntimeDeleteField(root, fieldPath)
+	require.Nil(t, adminRuntimeFieldNode(root, fieldPath))
+	adminRuntimeDeleteField(root, modePath)
+	adminRuntimeDeleteField(root, []adminRuntimeConfigKeyRef{
+		adminRuntimeKey("missing"),
+		adminRuntimeKey("field"),
+	})
+	require.Nil(
+		t,
+		adminRuntimeFieldParent(
+			&yaml.Node{Kind: yaml.SequenceNode},
+			fieldPath,
+		),
+	)
+	_, err = adminRuntimeEnsureFieldParent(
+		&yaml.Node{Kind: yaml.SequenceNode},
+		fieldPath,
+	)
+	require.Error(t, err)
+	_, err = adminRuntimeEnsureFieldParent(
+		&yaml.Node{
+			Kind: yaml.MappingNode,
+			Tag:  "!!map",
+			Content: []*yaml.Node{
+				{Kind: yaml.ScalarNode, Tag: "!!str", Value: "skills"},
+				{Kind: yaml.ScalarNode, Tag: "!!str", Value: "bad"},
+			},
+		},
+		fieldPath,
+	)
+	require.Error(t, err)
+}
+
+func TestAdminRuntimeConfigHelperErrorBranches(t *testing.T) {
+	t.Parallel()
+
+	badPath := writeAdminRuntimeConfigTestFile(
+		t,
+		"first: 1\n---\nsecond: 2\n",
+	)
+	_, _, err := adminRuntimeConfigDocumentFromPath(badPath)
+	require.Error(t, err)
+
+	provider := &adminRuntimeConfigProvider{}
+	require.Error(t, provider.SaveRuntimeConfigValue("admin.addr", "x"))
+	require.Error(t, provider.ResetRuntimeConfigValue("admin.addr"))
+
+	_, err = adminRuntimeEnsureFieldParent(nil, []adminRuntimeConfigKeyRef{
+		adminRuntimeKey("skills"),
+		adminRuntimeKey("watch"),
+	})
+	require.Error(t, err)
+
+	badParent := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Tag:  "!!map",
+		Content: []*yaml.Node{
+			{Kind: yaml.ScalarNode, Tag: "!!str", Value: "skills"},
+			{Kind: yaml.ScalarNode, Tag: "!!str", Value: "not-a-map"},
+		},
+	}
+	_, err = adminRuntimeEnsureMappingChild(
+		badParent,
+		adminRuntimeKey("skills"),
+	)
+	require.Error(t, err)
+
+	require.Nil(
+		t,
+		adminRuntimeLookupMappingValue(
+			&yaml.Node{Kind: yaml.SequenceNode},
+			adminRuntimeKey("skills"),
+		),
+	)
+	adminRuntimeDeleteMappingValue(
+		&yaml.Node{Kind: yaml.SequenceNode},
+		adminRuntimeKey("skills"),
+	)
+
+	require.Error(
+		t,
+		adminRuntimeSetMappingBool(nil, adminRuntimeKey("enabled"), true),
+	)
+	require.Error(
+		t,
+		adminRuntimeSetScalarValue(
+			&yaml.Node{Kind: yaml.MappingNode, Tag: "!!map", Content: []*yaml.Node{
+				{Kind: yaml.ScalarNode, Tag: "!!str", Value: "enabled"},
+				{Kind: yaml.SequenceNode},
+			}},
+			adminRuntimeKey("enabled"),
+			"!!bool",
+			"true",
+		),
+	)
+	require.False(
+		t,
+		adminRuntimeKeyMatches(&yaml.Node{Value: ""}, adminRuntimeKey("enabled")),
+	)
+	require.Equal(
+		t,
+		1,
+		len(adminRuntimeStringOptions("", "turn")),
+	)
+
+	boolPath := []adminRuntimeConfigKeyRef{
+		adminRuntimeKey("admin"),
+		adminRuntimeKey("enabled"),
+	}
+	root := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	parent, err := adminRuntimeEnsureFieldParent(root, boolPath)
+	require.NoError(t, err)
+	require.NoError(t, adminRuntimeSetFieldValue(
+		parent,
+		adminRuntimeConfigFieldSpec{
+			Key:       "admin.enabled",
+			InputType: adminRuntimeConfigInputSelect,
+			ValueType: adminRuntimeConfigValueBool,
+			Path:      boolPath,
+			Options: []admin.RuntimeConfigOption{
+				{Value: "true"},
+				{Value: "false"},
+			},
+		},
+		"true",
+	))
+	require.Equal(t, "true", adminRuntimeFieldNode(root, boolPath).Value)
+
+}
+
+func TestRuntimeAdminOptionsHelpers(t *testing.T) {
+	t.Parallel()
+
+	var nilRuntime *Runtime
+	require.Nil(t, runtimeAdminOptions(nilRuntime))
+	setRuntimeAdminOptions(nilRuntime, buildAdminOptions(runOptions{}))
+	clearRuntimeAdminOptions(nilRuntime)
+
+	rt := &Runtime{}
+	require.Nil(t, runtimeAdminOptions(rt))
+
+	runtimeAdminOptionsStore.Store(rt, "bad")
+	require.Nil(t, runtimeAdminOptions(rt))
+
+	runtimeAdminOptionsStore.Store(rt, []admin.Option{})
+	require.Nil(t, runtimeAdminOptions(rt))
+
+	opts := buildAdminOptions(
+		adminRuntimeConfigTestOptions(
+			writeAdminRuntimeConfigTestFile(t, ""),
+		),
+	)
+	setRuntimeAdminOptions(rt, opts)
+	got := runtimeAdminOptions(rt)
+	require.Len(t, got, len(opts))
+	require.NotNil(t, got[0])
+	clearRuntimeAdminOptions(rt)
+	require.Nil(t, runtimeAdminOptions(rt))
+
+	setRuntimeAdminOptions(rt, nil)
+	require.Nil(t, runtimeAdminOptions(rt))
+}
+
+func adminRuntimeConfigTestOptions(configPath string) runOptions {
+	return runOptions{
+		ConfigPath:           strings.TrimSpace(configPath),
+		AdminEnabled:         true,
+		AdminAddr:            defaultAdminAddr,
+		AdminAutoPort:        defaultAdminAutoPort,
+		ModelMode:            modeOpenAI,
+		OpenAIVariant:        defaultOpenAIVariant,
+		SkillsWatch:          true,
+		SkillsWatchDebounce:  defaultSkillsWatchDebounce,
+		SkillsLoadMode:       defaultSkillsLoadMode,
+		SkillsMaxLoaded:      0,
+		SkillsToolResults:    true,
+		SkillsSkipFallback:   true,
+		SessionBackend:       sessionBackendInMemory,
+		MemoryBackend:        memoryBackendInMemory,
+		EnableOpenClawTools:  true,
+		EnableParallelTools:  false,
+		RefreshToolSetsOnRun: false,
+	}
+}
+
+func writeAdminRuntimeConfigTestFile(
+	t *testing.T,
+	body string,
+) string {
+	t.Helper()
+
+	cfgPath := filepath.Join(t.TempDir(), "openclaw.yaml")
+	require.NoError(t, os.WriteFile(
+		cfgPath,
+		[]byte(body),
+		0o600,
+	))
+	return cfgPath
+}
+
+func findAdminRuntimeConfigField(
+	t *testing.T,
+	status admin.RuntimeConfigStatus,
+	key string,
+) admin.RuntimeConfigField {
+	t.Helper()
+
+	for _, section := range status.Sections {
+		for _, field := range section.Fields {
+			if field.Key == key {
+				return field
+			}
+		}
+	}
+	t.Fatalf("runtime config field %q not found", key)
+	return admin.RuntimeConfigField{}
+}

--- a/openclaw/app/admin_runtime_config_test.go
+++ b/openclaw/app/admin_runtime_config_test.go
@@ -67,6 +67,43 @@ func TestBuildAdminOptions_WiresRuntimeConfigProvider(t *testing.T) {
 	require.NotEmpty(t, status.Sections)
 }
 
+func TestBuildAdminOptions_UsesAdminSourceConfigPathEnv(t *testing.T) {
+	sourcePath := writeAdminRuntimeConfigTestFile(
+		t,
+		"skills:\n  max_loaded_skills: 3\n",
+	)
+	runtimePath := writeAdminRuntimeConfigTestFile(
+		t,
+		"skills:\n  max_loaded_skills: 7\n",
+	)
+	t.Setenv(AdminSourceConfigPathEnvName, sourcePath)
+
+	opts := adminRuntimeConfigTestOptions(runtimePath)
+	opts.SkillsMaxLoaded = 7
+
+	provider, ok := buildAdminRuntimeConfigProvider(
+		opts,
+	).(*adminRuntimeConfigProvider)
+	require.True(t, ok)
+
+	status, err := provider.RuntimeConfigStatus()
+	require.NoError(t, err)
+	require.Equal(t, sourcePath, status.ConfigPath)
+
+	require.NoError(t, provider.SaveRuntimeConfigValue(
+		"skills.max_loaded_skills",
+		"10",
+	))
+
+	sourceData, err := os.ReadFile(sourcePath)
+	require.NoError(t, err)
+	require.Contains(t, string(sourceData), "max_loaded_skills: 10")
+
+	runtimeData, err := os.ReadFile(runtimePath)
+	require.NoError(t, err)
+	require.Contains(t, string(runtimeData), "max_loaded_skills: 7")
+}
+
 func TestBuildAdminOptions_WithoutConfigPath(t *testing.T) {
 	t.Parallel()
 
@@ -597,7 +634,6 @@ func TestAdminRuntimeConfigHelperErrorBranches(t *testing.T) {
 		1,
 		len(adminRuntimeStringOptions("", "turn")),
 	)
-
 	boolPath := []adminRuntimeConfigKeyRef{
 		adminRuntimeKey("admin"),
 		adminRuntimeKey("enabled"),
@@ -621,6 +657,21 @@ func TestAdminRuntimeConfigHelperErrorBranches(t *testing.T) {
 	))
 	require.Equal(t, "true", adminRuntimeFieldNode(root, boolPath).Value)
 
+}
+
+func TestAdminWritableConfigPath(t *testing.T) {
+	t.Setenv(AdminSourceConfigPathEnvName, "  /tmp/source.yaml ")
+	require.Equal(
+		t,
+		"/tmp/source.yaml",
+		adminWritableConfigPath("/tmp/runtime.yaml"),
+	)
+	t.Setenv(AdminSourceConfigPathEnvName, " ")
+	require.Equal(
+		t,
+		"/tmp/runtime.yaml",
+		adminWritableConfigPath(" /tmp/runtime.yaml "),
+	)
 }
 
 func TestRuntimeAdminOptionsHelpers(t *testing.T) {

--- a/openclaw/app/admin_server.go
+++ b/openclaw/app/admin_server.go
@@ -307,7 +307,7 @@ func buildAdminSkillsProvider(
 		StateDir:        stateDir,
 	}
 	return &adminSkillsProvider{
-		configPath:   strings.TrimSpace(opts.ConfigPath),
+		configPath:   adminWritableConfigPath(opts.ConfigPath),
 		repo:         repo,
 		watch:        watch,
 		roots:        resolveSkillRoots(cwd, cfg),

--- a/openclaw/app/admin_skills_config_test.go
+++ b/openclaw/app/admin_skills_config_test.go
@@ -289,6 +289,41 @@ description: "Probe weather prerequisites"
 	require.False(t, provider.SkillsRefreshable())
 }
 
+func TestBuildAdminSkillsProvider_UsesAdminSourceConfigPathEnv(t *testing.T) {
+	sourcePath := filepath.Join(t.TempDir(), "openclaw.yaml")
+	require.NoError(t, os.WriteFile(
+		sourcePath,
+		[]byte("app_name: source\n"),
+		0o600,
+	))
+	runtimePath := filepath.Join(t.TempDir(), "runtime.yaml")
+	require.NoError(t, os.WriteFile(
+		runtimePath,
+		[]byte("app_name: runtime\n"),
+		0o600,
+	))
+	t.Setenv(AdminSourceConfigPathEnvName, sourcePath)
+
+	provider, ok := buildAdminSkillsProvider(
+		runOptions{ConfigPath: runtimePath},
+		t.TempDir(),
+		nil,
+		nil,
+	).(*adminSkillsProvider)
+	require.True(t, ok)
+	require.Equal(t, sourcePath, provider.SkillsConfigPath())
+
+	require.NoError(t, provider.SetSkillEnabled("weather-api", false))
+
+	sourceBody, err := os.ReadFile(sourcePath)
+	require.NoError(t, err)
+	require.Contains(t, string(sourceBody), "weather-api:")
+
+	runtimeBody, err := os.ReadFile(runtimePath)
+	require.NoError(t, err)
+	require.NotContains(t, string(runtimeBody), "weather-api:")
+}
+
 func TestAdminSkillsProviderSetSkillEnabled_ErrorPaths(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -565,6 +565,31 @@ func (r *Runtime) ConfigureAdmin(
 	r.applyAdminConfig(cfg)
 }
 
+// AddAdminOptions appends runtime-scoped admin options without changing
+// Runtime's exported struct layout.
+func (r *Runtime) AddAdminOptions(opts ...admin.Option) {
+	if r == nil || len(opts) == 0 {
+		return
+	}
+
+	filtered := make([]admin.Option, 0, len(opts))
+	filtered = append(filtered, runtimeAdminOptions(r)...)
+	for _, opt := range opts {
+		if opt != nil {
+			filtered = append(filtered, opt)
+		}
+	}
+	if len(filtered) == 0 {
+		return
+	}
+
+	setRuntimeAdminOptions(r, filtered)
+	if r.adminCfg == nil {
+		return
+	}
+	r.applyAdminConfig(*r.adminCfg)
+}
+
 func (r *Runtime) applyAdminConfig(cfg admin.Config) {
 	if r == nil {
 		return

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -570,7 +570,7 @@ func (r *Runtime) applyAdminConfig(cfg admin.Config) {
 		return
 	}
 	r.adminCfg = &cfg
-	r.Admin.Handler = admin.New(cfg).Handler()
+	r.Admin.Handler = admin.New(cfg, runtimeAdminOptions(r)...).Handler()
 	r.Admin.Addr = strings.TrimSpace(cfg.AdminAddr)
 	r.Admin.URL = strings.TrimSpace(cfg.AdminURL)
 }
@@ -1047,6 +1047,7 @@ func NewRuntime(
 			fileMemoryStore,
 			rt.SessionService(),
 		)
+		setRuntimeAdminOptions(rt, buildAdminOptions(opts))
 		rt.applyAdminConfig(adminCfg)
 	}
 
@@ -1083,6 +1084,7 @@ func (r *Runtime) Close() error {
 	if err := shutdownTelemetry(r.telemetryShutdown); err != nil {
 		errs = append(errs, err)
 	}
+	clearRuntimeAdminOptions(r)
 	return errors.Join(errs...)
 }
 
@@ -1506,32 +1508,35 @@ func run(ctx context.Context, args []string) error {
 				Err:  err,
 			}
 		}
-		adminSvc := admin.New(buildAdminConfig(
-			opts,
-			agentType,
-			instanceID,
-			langfuseStatus,
-			resolvedStateDir,
-			debugDir,
-			startedAt,
-			channels,
-			admin.Routes{
-				HealthPath:   gwSrv.HealthPath(),
-				MessagesPath: gwSrv.MessagesPath(),
-				StatusPath:   gwSrv.StatusPath(),
-				CancelPath:   gwSrv.CancelPath(),
-			},
-			cronSvc,
-			openClawTools.execMgr,
-			promptController,
-			browserServerSup,
-			adminBinding.addr,
-			adminBinding.url,
-			skillsRepo,
-			skillsWatch,
-			fileMemoryStore,
-			bridgedSessionSvc,
-		))
+		adminSvc := admin.New(
+			buildAdminConfig(
+				opts,
+				agentType,
+				instanceID,
+				langfuseStatus,
+				resolvedStateDir,
+				debugDir,
+				startedAt,
+				channels,
+				admin.Routes{
+					HealthPath:   gwSrv.HealthPath(),
+					MessagesPath: gwSrv.MessagesPath(),
+					StatusPath:   gwSrv.StatusPath(),
+					CancelPath:   gwSrv.CancelPath(),
+				},
+				cronSvc,
+				openClawTools.execMgr,
+				promptController,
+				browserServerSup,
+				adminBinding.addr,
+				adminBinding.url,
+				skillsRepo,
+				skillsWatch,
+				fileMemoryStore,
+				bridgedSessionSvc,
+			),
+			buildAdminOptions(opts)...,
+		)
 		adminSrv = &http.Server{
 			Handler:           adminSvc.Handler(),
 			ReadHeaderTimeout: 5 * time.Second,

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -357,6 +357,33 @@ func TestRuntimeConfigureAdmin(t *testing.T) {
 	require.NotNil(t, rt.adminCfg.Prompts)
 }
 
+func TestRuntimeConfigureAdminPreservesRuntimeConfigProvider(t *testing.T) {
+	t.Parallel()
+
+	cfgPath := writeAdminRuntimeConfigTestFile(t, "")
+	opts := adminRuntimeConfigTestOptions(cfgPath)
+	rt := &Runtime{
+		adminCfg: &admin.Config{
+			AdminAddr: "127.0.0.1:8081",
+			AdminURL:  "http://127.0.0.1:8081",
+		},
+	}
+	setRuntimeAdminOptions(rt, buildAdminOptions(opts))
+	t.Cleanup(func() {
+		clearRuntimeAdminOptions(rt)
+	})
+
+	rt.ConfigureAdmin(func(cfg *admin.Config) {
+		cfg.Prompts = stubAdminPromptsProvider{}
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+	rr := httptest.NewRecorder()
+	rt.Admin.Handler.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), cfgPath)
+}
+
 func TestRuntimeConfigureAdminNoAdminConfig(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -70,6 +70,10 @@ type stubRuntimeAgent struct{}
 
 type stubAdminPromptsProvider struct{}
 
+type stubAdminRuntimeLifecycleProvider struct {
+	status admin.RuntimeLifecycleStatus
+}
+
 func (stubRuntimeAgent) Run(
 	context.Context,
 	*agent.Invocation,
@@ -125,6 +129,35 @@ func (stubAdminPromptsProvider) DeletePromptFile(
 	string,
 ) error {
 	return nil
+}
+
+func (p stubAdminRuntimeLifecycleProvider) RuntimeLifecycleStatus() (
+	admin.RuntimeLifecycleStatus,
+	error,
+) {
+	return p.status, nil
+}
+
+func (stubAdminRuntimeLifecycleProvider) RuntimeLifecycleVersions() (
+	admin.RuntimeLifecycleVersionIndex,
+	error,
+) {
+	return admin.RuntimeLifecycleVersionIndex{}, nil
+}
+
+func (stubAdminRuntimeLifecycleProvider) RuntimeLifecycleChangelog(
+	string,
+) (admin.RuntimeLifecycleChangelog, error) {
+	return admin.RuntimeLifecycleChangelog{}, nil
+}
+
+func (p stubAdminRuntimeLifecycleProvider) RequestRuntimeLifecycleAction(
+	admin.RuntimeLifecycleActionRequest,
+) (admin.RuntimeLifecycleActionResult, error) {
+	return admin.RuntimeLifecycleActionResult{
+		Status:  p.status,
+		Started: true,
+	}, nil
 }
 
 func (stubRuntimeAgent) Info() agent.Info {
@@ -384,6 +417,44 @@ func TestRuntimeConfigureAdminPreservesRuntimeConfigProvider(t *testing.T) {
 	require.Contains(t, rr.Body.String(), cfgPath)
 }
 
+func TestRuntimeAddAdminOptionsPreservesExistingProviders(t *testing.T) {
+	t.Parallel()
+
+	cfgPath := writeAdminRuntimeConfigTestFile(t, "")
+	opts := adminRuntimeConfigTestOptions(cfgPath)
+	rt := &Runtime{
+		adminCfg: &admin.Config{
+			AdminAddr: "127.0.0.1:8081",
+			AdminURL:  "http://127.0.0.1:8081",
+		},
+	}
+	setRuntimeAdminOptions(rt, buildAdminOptions(opts))
+	t.Cleanup(func() {
+		clearRuntimeAdminOptions(rt)
+	})
+
+	rt.AddAdminOptions(admin.WithRuntimeLifecycleProvider(
+		stubAdminRuntimeLifecycleProvider{
+			status: admin.RuntimeLifecycleStatus{
+				CurrentVersion: "v0.0.70",
+			},
+		},
+	))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+	rr := httptest.NewRecorder()
+	rt.Admin.Handler.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), cfgPath)
+
+	req = httptest.NewRequest(http.MethodGet, "/runtime-control", nil)
+	rr = httptest.NewRecorder()
+	rt.Admin.Handler.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), "Runtime Control")
+	require.Contains(t, rr.Body.String(), "v0.0.70")
+}
+
 func TestRuntimeConfigureAdminNoAdminConfig(t *testing.T) {
 	t.Parallel()
 
@@ -391,6 +462,7 @@ func TestRuntimeConfigureAdminNoAdminConfig(t *testing.T) {
 	rt.ConfigureAdmin(func(cfg *admin.Config) {
 		cfg.AppName = "ignored"
 	})
+	rt.AddAdminOptions(nil)
 	require.Nil(t, rt.adminCfg)
 	require.Empty(t, rt.Admin)
 


### PR DESCRIPTION
## Summary
- add an admin Config page for major runtime settings
- expose provider-driven config status plus save/reset APIs
- keep runtime-specific editing logic outside the shared admin package

## Why
OpenClaw already supports prompt and skill management in Admin, but the
main runtime YAML still has to be edited by hand for common operational
switches. This adds a generic config-management surface that local
runtimes can implement without hardcoding OpenClaw details into the
shared admin UI.

## Impact
- users can inspect configured vs effective runtime values in Admin
- runtimes can mark fields as restart-required and surface pending
  restart state
- no behavior changes unless a runtime opts into the new provider

## Validation
- go test ./admin
