### PR TITLE
tool/webfetch/httpfetch: add WithTimeout option

### DIFF
--- a/tool/webfetch/httpfetch/fetch.go
+++ b/tool/webfetch/httpfetch/fetch.go
@@ -37,6 +37,8 @@ type Option func(*config)
 
 type config struct {
 	httpClient            *http.Client
+	timeout               time.Duration
+	timeoutSet            bool
 	maxContentLength      int
 	maxTotalContentLength int
 	allowedDomains        []string
@@ -83,6 +85,21 @@ func WithBlockedDomains(domains []string) Option {
 	}
 }
 
+// WithTimeout sets the HTTP request timeout. When combined with WithHTTPClient,
+// the custom client's Transport/Proxy/Jar settings are preserved via shallow
+// copy - the caller's original *http.Client is never mutated.
+// Passing 0 explicitly disables the default 30s timeout (Go http.Client
+// treats Timeout==0 as "no timeout"). Negative values are ignored.
+func WithTimeout(timeout time.Duration) Option {
+	return func(cfg *config) {
+		if timeout < 0 {
+			return
+		}
+		cfg.timeout = timeout
+		cfg.timeoutSet = true
+	}
+}
+
 // fetchRequest is the input for the tool.
 type fetchRequest struct {
 	URLS []string `json:"urls" jsonschema:"description=The list of URLs to fetch content from"`
@@ -102,6 +119,22 @@ type resultItem struct {
 	Error        string `json:"error,omitempty"`
 }
 
+// resolveHTTPClient builds the final *http.Client from config, applying
+// nil fallback and timeout override via shallow copy - the caller's
+// original client is never mutated.
+func resolveHTTPClient(cfg *config) *http.Client {
+	client := cfg.httpClient
+	if client == nil {
+		client = &http.Client{Timeout: defaultTimeout}
+	}
+	if cfg.timeoutSet {
+		cloned := *client
+		cloned.Timeout = cfg.timeout
+		client = &cloned
+	}
+	return client
+}
+
 // NewTool creates the web-fetch tool.
 func NewTool(opts ...Option) tool.CallableTool {
 	cfg := &config{
@@ -111,8 +144,10 @@ func NewTool(opts ...Option) tool.CallableTool {
 		opt(cfg)
 	}
 
+	client := resolveHTTPClient(cfg)
+
 	t := &webFetchTool{
-		client:                cfg.httpClient,
+		client:                client,
 		maxContentLength:      cfg.maxContentLength,
 		maxTotalContentLength: cfg.maxTotalContentLength,
 	}

--- a/tool/webfetch/httpfetch/fetch_test.go
+++ b/tool/webfetch/httpfetch/fetch_test.go
@@ -17,6 +17,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -681,4 +682,80 @@ func TestTruncateString_ExactLength(t *testing.T) {
 	// Test when string length equals limit
 	assert.Equal(t, "hello", truncateString("hello", 5))
 	assert.Equal(t, "hello", truncateString("hello", 10))
+}
+
+// applyOpts builds a config and calls the production resolveHTTPClient,
+// so tests exercise the same code path as NewTool.
+func applyOpts(opts ...Option) *http.Client {
+	cfg := &config{
+		httpClient: &http.Client{Timeout: defaultTimeout},
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	return resolveHTTPClient(cfg)
+}
+
+func TestWithTimeout_Standalone(t *testing.T) {
+	client := applyOpts(WithTimeout(60 * time.Second))
+	assert.Equal(t, 60*time.Second, client.Timeout)
+}
+
+func TestWithTimeout_DoesNotMutateOriginalClient(t *testing.T) {
+	original := &http.Client{
+		Timeout:   10 * time.Second,
+		Transport: http.DefaultTransport,
+	}
+
+	client := applyOpts(WithHTTPClient(original), WithTimeout(99*time.Second))
+
+	assert.Equal(t, 99*time.Second, client.Timeout)
+	assert.Equal(t, 10*time.Second, original.Timeout, "original client timeout must not be mutated")
+	assert.Equal(t, http.DefaultTransport, original.Transport, "original client transport must be preserved")
+}
+
+func TestWithTimeout_PreservesCustomTransport(t *testing.T) {
+	customTransport := &http.Transport{MaxIdleConns: 42}
+	original := &http.Client{
+		Timeout:   5 * time.Second,
+		Transport: customTransport,
+	}
+
+	client := applyOpts(WithHTTPClient(original), WithTimeout(120*time.Second))
+
+	assert.Equal(t, 120*time.Second, client.Timeout)
+	assert.Equal(t, customTransport, client.Transport, "custom transport must be preserved after WithTimeout")
+}
+
+func TestWithTimeout_ZeroDisablesDefault(t *testing.T) {
+	client := applyOpts(WithTimeout(0))
+	assert.Equal(t, time.Duration(0), client.Timeout, "WithTimeout(0) should disable default timeout")
+}
+
+func TestWithTimeout_NegativeIgnored(t *testing.T) {
+	client := applyOpts(WithTimeout(-1 * time.Second))
+	assert.Equal(t, defaultTimeout, client.Timeout, "negative timeout should be ignored, keeping default")
+}
+
+func TestWithHTTPClient_NilFallsBackToDefault(t *testing.T) {
+	client := applyOpts(WithHTTPClient(nil))
+	assert.NotNil(t, client)
+	assert.Equal(t, defaultTimeout, client.Timeout)
+}
+
+func TestWithHTTPClient_NilPlusTimeout(t *testing.T) {
+	client := applyOpts(WithHTTPClient(nil), WithTimeout(45*time.Second))
+	assert.NotNil(t, client)
+	assert.Equal(t, 45*time.Second, client.Timeout)
+}
+
+func TestWithTimeout_OrderIndependent(t *testing.T) {
+	custom := &http.Client{Timeout: 5 * time.Second, Transport: http.DefaultTransport}
+
+	client1 := applyOpts(WithHTTPClient(custom), WithTimeout(60*time.Second))
+	client2 := applyOpts(WithTimeout(60*time.Second), WithHTTPClient(custom))
+
+	assert.Equal(t, 60*time.Second, client1.Timeout)
+	assert.Equal(t, 60*time.Second, client2.Timeout)
+	assert.Equal(t, 5*time.Second, custom.Timeout, "original must not be mutated regardless of order")
 }


### PR DESCRIPTION
Add a convenience WithTimeout(d time.Duration) option so callers can override the default 30s HTTP timeout without constructing a full http.Client. The implementation uses a shallow copy of the client to avoid mutating a shared *http.Client passed via WithHTTPClient, making it safe to combine with custom Transport/Proxy settings in any order.

WithTimeout(0) explicitly disables the timeout; negative values are ignored.