### PR TITLE
tool/mcpbroker: add server description to mcp_list_servers

### DIFF
--- a/docs/mkdocs/en/tool.md
+++ b/docs/mkdocs/en/tool.md
@@ -813,10 +813,11 @@ import (
 broker := mcpbroker.New(
     mcpbroker.WithServers(map[string]mcp.ConnectionConfig{
         "local_stdio_code": {
-            Transport: "stdio",
-            Command:   "go",
-            Args:      []string{"run", "./stdio_server/main.go"},
-            Timeout:   10 * time.Second,
+            Transport:   "stdio",
+            Command:     "go",
+            Args:        []string{"run", "./stdio_server/main.go"},
+            Timeout:     10 * time.Second,
+            Description: "Project management, documentation, and calendar tools.",
         },
     }),
     mcpbroker.WithAllowAdHocHTTP(true),
@@ -828,6 +829,34 @@ agent := llmagent.New(
     llmagent.WithTools(broker.Tools()),
 )
 ```
+
+#### Server Description
+
+The `Description` field on `ConnectionConfig` provides a capability
+summary for the MCP server, helping the model decide which server to
+explore at the `mcp_list_servers` stage. The output includes the
+description:
+
+```json
+{
+  "servers": [
+    {
+      "name": "local_stdio_code",
+      "transport": "stdio",
+      "description": "Project management, documentation, and calendar tools."
+    }
+  ]
+}
+```
+
+This is analogous to the `description` field on an OpenAI tool namespace:
+the model can read it at the `mcp_list_servers` step and decide which
+server to explore next, without needing to `mcp_list_tools` every server
+one by one. The more servers you have, or the less self-explanatory the
+server names are, the more valuable this description becomes.
+
+The field is optional. When omitted, the output simply does not include
+a `description` property, and existing behavior is unchanged.
 
 Today `mcpbroker` is a **tool-layer integration**. Unlike `Skill`, it
 does not automatically inject routing guidance into the system prompt.

--- a/docs/mkdocs/zh/tool.md
+++ b/docs/mkdocs/zh/tool.md
@@ -802,10 +802,11 @@ import (
 broker := mcpbroker.New(
     mcpbroker.WithServers(map[string]mcp.ConnectionConfig{
         "local_stdio_code": {
-            Transport: "stdio",
-            Command:   "go",
-            Args:      []string{"run", "./stdio_server/main.go"},
-            Timeout:   10 * time.Second,
+            Transport:   "stdio",
+            Command:     "go",
+            Args:        []string{"run", "./stdio_server/main.go"},
+            Timeout:     10 * time.Second,
+            Description: "Project management, documentation, and calendar tools.",
         },
     }),
     mcpbroker.WithAllowAdHocHTTP(true),
@@ -817,6 +818,32 @@ agent := llmagent.New(
     llmagent.WithTools(broker.Tools()),
 )
 ```
+
+#### Server Description（服务描述）
+
+`ConnectionConfig` 上的 `Description` 字段为 MCP server 提供一段能力摘要，
+帮助模型在 `mcp_list_servers` 阶段判断该去哪个 server 探索。
+`mcp_list_servers` 的返回值会包含这个 description：
+
+```json
+{
+  "servers": [
+    {
+      "name": "local_stdio_code",
+      "transport": "stdio",
+      "description": "Project management, documentation, and calendar tools."
+    }
+  ]
+}
+```
+
+这类似于 OpenAI tool namespace 的 `description`：模型在第一步
+`mcp_list_servers` 时就能根据描述决定"去哪个 server 看"，而不需要
+逐个 `mcp_list_tools` 试探。server 数量越多、名字越不直观时，
+description 的价值越大。
+
+这个字段是可选的。如果不填，输出中不会出现 `description`，对现有行为
+没有任何影响。
 
 当前 `mcpbroker` 是**工具层接入**，不会像 `Skill` 那样自动向
 `System Prompt` 注入策略提示。如果你希望模型更稳定地理解：

--- a/examples/mcpbroker/basic/main.go
+++ b/examples/mcpbroker/basic/main.go
@@ -197,10 +197,11 @@ func (c *mcpBrokerChat) buildBrokerOptions(serverPath string) (
 		mcpbroker.WithAllowAdHocHTTP(true),
 		mcpbroker.WithServers(map[string]mcpcfg.ConnectionConfig{
 			"local_stdio_code": {
-				Transport: "stdio",
-				Command:   "go",
-				Args:      []string{"run", serverPath},
-				Timeout:   10 * time.Second,
+				Transport:   "stdio",
+				Command:     "go",
+				Args:        []string{"run", serverPath},
+				Timeout:     10 * time.Second,
+				Description: "Project management, documentation, calendar, and meeting tools for the local workspace.",
 			},
 		}),
 	}

--- a/tool/mcp/config.go
+++ b/tool/mcp/config.go
@@ -70,6 +70,11 @@ type ConnectionConfig struct {
 	// Common configuration.
 	Timeout time.Duration `json:"timeout,omitempty"`
 
+	// Description provides a capability summary of this MCP server.
+	// When set, mcpbroker exposes it in mcp_list_servers so the model can
+	// decide which server to explore without listing every tool first.
+	Description string `json:"description,omitempty"`
+
 	// Advanced configuration.
 	ClientInfo mcp.Implementation `json:"client_info,omitempty"`
 }

--- a/tool/mcpbroker/broker.go
+++ b/tool/mcpbroker/broker.go
@@ -255,8 +255,9 @@ func (b *Broker) listServers(ctx context.Context, _ listServersInput) (listServe
 	output := listServersOutput{Servers: make([]listServersServer, 0, len(servers))}
 	for _, server := range servers {
 		output.Servers = append(output.Servers, listServersServer{
-			Name:      server.Name,
-			Transport: server.Config.Transport,
+			Name:        server.Name,
+			Transport:   server.Config.Transport,
+			Description: server.Config.Description,
 		})
 	}
 	return output, nil

--- a/tool/mcpbroker/broker_test.go
+++ b/tool/mcpbroker/broker_test.go
@@ -225,6 +225,34 @@ func TestListServers_ReturnsConfiguredServers(t *testing.T) {
 
 	require.Equal(t, "from_code", output.Servers[0].Name)
 	require.Equal(t, "stdio", output.Servers[0].Transport)
+	require.Empty(t, output.Servers[0].Description)
+}
+
+func TestListServers_ReturnsDescription(t *testing.T) {
+	broker := New(
+		WithServers(map[string]legacymcp.ConnectionConfig{
+			"crm": {
+				ServerURL:   "https://crm.example.com/mcp",
+				Description: "CRM tools for customer lookup and order management.",
+			},
+			"code": {
+				Command: "go",
+				Args:    []string{"run", "./server"},
+			},
+		}),
+	)
+
+	output, err := broker.listServers(context.Background(), listServersInput{})
+	require.NoError(t, err)
+	require.Len(t, output.Servers, 2)
+
+	serverByName := make(map[string]listServersServer, len(output.Servers))
+	for _, s := range output.Servers {
+		serverByName[s.Name] = s
+	}
+
+	require.Equal(t, "CRM tools for customer lookup and order management.", serverByName["crm"].Description)
+	require.Empty(t, serverByName["code"].Description)
 }
 
 func TestResolveNamedServers_TrimsNamesAndRejectsCollisions(t *testing.T) {

--- a/tool/mcpbroker/config.go
+++ b/tool/mcpbroker/config.go
@@ -94,13 +94,14 @@ func normalizeConnectionConfig(cfg mcpcfg.ConnectionConfig, adHoc bool) (mcpcfg.
 	}
 
 	return mcpcfg.ConnectionConfig{
-		Transport:  transport,
-		ServerURL:  serverURL,
-		Headers:    cloneStringMap(cfg.Headers),
-		Command:    command,
-		Args:       cloneStringSlice(cfg.Args),
-		Timeout:    cfg.Timeout,
-		ClientInfo: cfg.ClientInfo,
+		Transport:   transport,
+		ServerURL:   serverURL,
+		Headers:     cloneStringMap(cfg.Headers),
+		Command:     command,
+		Args:        cloneStringSlice(cfg.Args),
+		Timeout:     cfg.Timeout,
+		Description: strings.TrimSpace(cfg.Description),
+		ClientInfo:  cfg.ClientInfo,
 	}, kind, nil
 }
 

--- a/tool/mcpbroker/tools.go
+++ b/tool/mcpbroker/tools.go
@@ -28,8 +28,9 @@ type listServersOutput struct {
 }
 
 type listServersServer struct {
-	Name      string `json:"name"`
-	Transport string `json:"transport"`
+	Name        string `json:"name"`
+	Transport   string `json:"transport"`
+	Description string `json:"description,omitempty"`
 }
 
 type listToolsInput struct {
@@ -89,7 +90,7 @@ func newBrokerTools(b *Broker) []tool.Tool {
 		function.NewFunctionTool(
 			b.listServers,
 			function.WithName(listServersToolName),
-			function.WithDescription("List named MCP servers already configured for this broker. Use this first when you expect the platform to have preconfigured MCP connections. This tool only returns named broker servers; it does not inspect arbitrary URLs."),
+			function.WithDescription("List named MCP servers already configured for this broker. Use this first when you expect the platform to have preconfigured MCP connections. When configured, server descriptions help choose which server to inspect next. This tool only returns named broker servers; it does not inspect arbitrary URLs."),
 			function.WithInputSchema(emptyObjectSchema()),
 			function.WithOutputSchema(listServersOutputSchema()),
 		),
@@ -415,8 +416,9 @@ func listServersOutputSchema() *tool.Schema {
 					AdditionalProperties: false,
 					Required:             []string{"name", "transport"},
 					Properties: map[string]*tool.Schema{
-						"name":      {Type: "string", Description: "Configured server name."},
-						"transport": {Type: "string", Description: "Resolved MCP transport."},
+						"name":        {Type: "string", Description: "Configured server name."},
+						"transport":   {Type: "string", Description: "Resolved MCP transport."},
+						"description": {Type: "string", Description: "Capability summary of the server. Use this to decide which server to explore next. Present only when configured."},
 					},
 				},
 			},


### PR DESCRIPTION
MCP servers in mcpbroker act as tool namespaces, but mcp_list_servers only returned name and transport, forcing the model to list_tools on every server to understand what it offers.

Add an optional Description field to mcp.ConnectionConfig so users can provide a human-readable summary when configuring named servers. The broker propagates it through normalization (with TrimSpace) and exposes it in the mcp_list_servers output, letting the model route to the right server without extra discovery round-trips.