### PR TITLE
examples: split sqlitevec example implementations

### DIFF
--- a/examples/knowledge/go.mod
+++ b/examples/knowledge/go.mod
@@ -6,7 +6,6 @@ replace (
 	trpc.group/trpc-go/trpc-agent-go => ../../
 	trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader/pdf => ../../knowledge/document/reader/pdf
 	trpc.group/trpc-go/trpc-agent-go/knowledge/embedder/gemini => ../../knowledge/embedder/gemini
-	trpc.group/trpc-go/trpc-agent-go/knowledge/extractor/docling => ../../knowledge/extractor/docling
 	trpc.group/trpc-go/trpc-agent-go/knowledge/ocr/tesseract => ../../knowledge/ocr/tesseract
 	trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/elasticsearch => ../../knowledge/vectorstore/elasticsearch
 	trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/milvus => ../../knowledge/vectorstore/milvus
@@ -20,7 +19,7 @@ replace (
 )
 
 require (
-	trpc.group/trpc-go/trpc-agent-go v0.6.0
+	trpc.group/trpc-go/trpc-agent-go v1.8.2-0.20260415014524-d83a248b0ea1
 	trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader/pdf v0.5.0
 	trpc.group/trpc-go/trpc-agent-go/knowledge/ocr/tesseract v0.0.0-20251203120347-0b4d62cb115d
 	trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/elasticsearch v0.2.1

--- a/examples/knowledge/sqlitevec_store_impl.go
+++ b/examples/knowledge/sqlitevec_store_impl.go
@@ -1,0 +1,44 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+//go:build cgo && sqliteveccgo
+
+package util
+
+import (
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore"
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/sqlitevec"
+)
+
+const (
+	sqliteVecDSNEnvKey           = "SQLITEVEC_DSN"
+	defaultSQLiteVecDSN          = "file:knowledge.sqlite?_busy_timeout=5000"
+	sqliteVecTableEnvKey         = "SQLITEVEC_TABLE"
+	defaultSQLiteVecTable        = "knowledge_documents"
+	sqliteVecMetadataTableEnvKey = "SQLITEVEC_METADATA_TABLE"
+	defaultSQLiteVecMetadata     = "knowledge_document_meta"
+)
+
+func newSQLiteVecStore() (vectorstore.VectorStore, error) {
+	dsn := GetEnvOrDefault(sqliteVecDSNEnvKey, defaultSQLiteVecDSN)
+	table := GetEnvOrDefault(
+		sqliteVecTableEnvKey,
+		defaultSQLiteVecTable,
+	)
+	metaTable := GetEnvOrDefault(
+		sqliteVecMetadataTableEnvKey,
+		defaultSQLiteVecMetadata,
+	)
+
+	return sqlitevec.New(
+		sqlitevec.WithDSN(dsn),
+		sqlitevec.WithTableName(table),
+		sqlitevec.WithMetadataTableName(metaTable),
+	)
+}

--- a/examples/knowledge/sqlitevec_store_stub.go
+++ b/examples/knowledge/sqlitevec_store_stub.go
@@ -1,0 +1,27 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+//go:build !cgo || !sqliteveccgo
+
+package util
+
+import (
+	"errors"
+
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore"
+)
+
+const sqliteVecUnavailableMessage = "" +
+	"sqlitevec is unavailable in this build; use " +
+	"CGO_ENABLED=1 with -tags sqliteveccgo on " +
+	"a system with sqlite3 development headers"
+
+func newSQLiteVecStore() (vectorstore.VectorStore, error) {
+	return nil, errors.New(sqliteVecUnavailableMessage)
+}

--- a/examples/knowledge/util.go
+++ b/examples/knowledge/util.go
@@ -34,7 +34,6 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/inmemory"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/milvus"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/pgvector"
-	"trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/sqlitevec"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/tcvector"
 )
 
@@ -69,18 +68,6 @@ func NewVectorStoreByType(storeType VectorStoreType) (vectorstore.VectorStore, e
 	default:
 		return inmemory.New(), nil
 	}
-}
-
-func newSQLiteVecStore() (vectorstore.VectorStore, error) {
-	dsn := GetEnvOrDefault("SQLITEVEC_DSN", "file:knowledge.sqlite?_busy_timeout=5000")
-	table := GetEnvOrDefault("SQLITEVEC_TABLE", "knowledge_documents")
-	metaTable := GetEnvOrDefault("SQLITEVEC_METADATA_TABLE", "knowledge_document_meta")
-
-	return sqlitevec.New(
-		sqlitevec.WithDSN(dsn),
-		sqlitevec.WithTableName(table),
-		sqlitevec.WithMetadataTableName(metaTable),
-	)
 }
 
 func newPGVectorStore() (vectorstore.VectorStore, error) {

--- a/examples/memory/sqlitevec_memory_impl.go
+++ b/examples/memory/sqlitevec_memory_impl.go
@@ -1,0 +1,78 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+//go:build cgo && sqliteveccgo
+
+package util
+
+import (
+	"database/sql"
+
+	openaiembedder "trpc.group/trpc-go/trpc-agent-go/knowledge/embedder/openai"
+	"trpc.group/trpc-go/trpc-agent-go/memory"
+	memorysqlitevec "trpc.group/trpc-go/trpc-agent-go/memory/sqlitevec"
+)
+
+func newSQLiteVecMemoryService(
+	cfg MemoryServiceConfig,
+) (memory.Service, error) {
+	dsn := GetEnvOrDefault(
+		sqliteVecMemoryDSNEnvKey,
+		defaultSQLiteVecMemoryDBDSN,
+	)
+	db, err := sql.Open(sqliteDriverName, dsn)
+	if err != nil {
+		return nil, err
+	}
+	db.SetMaxOpenConns(defaultSQLiteMaxOpenConns)
+	db.SetMaxIdleConns(defaultSQLiteMaxIdleConns)
+
+	embedderModel := GetEnvOrDefault(
+		sqliteVecEmbedderModelEnvKey,
+		openaiembedder.DefaultModel,
+	)
+	emb := newOpenAIEmbedder(embedderModel)
+
+	opts := []memorysqlitevec.ServiceOpt{
+		memorysqlitevec.WithEmbedder(emb),
+		memorysqlitevec.WithSoftDelete(cfg.SoftDelete),
+	}
+
+	if cfg.Extractor != nil {
+		opts = append(opts, memorysqlitevec.WithExtractor(cfg.Extractor))
+		if cfg.AsyncMemoryNum > 0 {
+			opts = append(
+				opts,
+				memorysqlitevec.WithAsyncMemoryNum(cfg.AsyncMemoryNum),
+			)
+		}
+		if cfg.MemoryQueueSize > 0 {
+			opts = append(
+				opts,
+				memorysqlitevec.WithMemoryQueueSize(cfg.MemoryQueueSize),
+			)
+		}
+		if cfg.MemoryJobTimeout > 0 {
+			opts = append(
+				opts,
+				memorysqlitevec.WithMemoryJobTimeout(
+					cfg.MemoryJobTimeout,
+				),
+			)
+		}
+	}
+
+	svc, err := memorysqlitevec.NewService(db, opts...)
+	if err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+
+	return svc, nil
+}

--- a/examples/memory/sqlitevec_memory_stub.go
+++ b/examples/memory/sqlitevec_memory_stub.go
@@ -1,0 +1,30 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+//go:build !cgo || !sqliteveccgo
+
+package util
+
+import (
+	"errors"
+
+	"trpc.group/trpc-go/trpc-agent-go/memory"
+)
+
+const sqliteVecMemoryUnavailableMessage = "" +
+	"sqlitevec memory is unavailable in this build; use " +
+	"CGO_ENABLED=1 with -tags sqliteveccgo on " +
+	"a system with sqlite3 development headers"
+
+func newSQLiteVecMemoryService(
+	cfg MemoryServiceConfig,
+) (memory.Service, error) {
+	_ = cfg
+	return nil, errors.New(sqliteVecMemoryUnavailableMessage)
+}

--- a/examples/memory/util.go
+++ b/examples/memory/util.go
@@ -28,7 +28,6 @@ import (
 	memorypostgres "trpc.group/trpc-go/trpc-agent-go/memory/postgres"
 	memoryredis "trpc.group/trpc-go/trpc-agent-go/memory/redis"
 	memorysqlite "trpc.group/trpc-go/trpc-agent-go/memory/sqlite"
-	memorysqlitevec "trpc.group/trpc-go/trpc-agent-go/memory/sqlitevec"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/model/openai"
 	"trpc.group/trpc-go/trpc-agent-go/runner"
@@ -219,60 +218,6 @@ func newOpenAIEmbedder(defaultModel string) *openaiembedder.Embedder {
 	}
 
 	return openaiembedder.New(opts...)
-}
-
-func newSQLiteVecMemoryService(cfg MemoryServiceConfig) (memory.Service, error) {
-	dsn := GetEnvOrDefault(
-		sqliteVecMemoryDSNEnvKey,
-		defaultSQLiteVecMemoryDBDSN,
-	)
-	db, err := sql.Open(sqliteDriverName, dsn)
-	if err != nil {
-		return nil, err
-	}
-	db.SetMaxOpenConns(defaultSQLiteMaxOpenConns)
-	db.SetMaxIdleConns(defaultSQLiteMaxIdleConns)
-
-	embedderModel := GetEnvOrDefault(
-		sqliteVecEmbedderModelEnvKey,
-		openaiembedder.DefaultModel,
-	)
-	emb := newOpenAIEmbedder(embedderModel)
-
-	opts := []memorysqlitevec.ServiceOpt{
-		memorysqlitevec.WithEmbedder(emb),
-		memorysqlitevec.WithSoftDelete(cfg.SoftDelete),
-	}
-
-	if cfg.Extractor != nil {
-		opts = append(opts, memorysqlitevec.WithExtractor(cfg.Extractor))
-		if cfg.AsyncMemoryNum > 0 {
-			opts = append(
-				opts,
-				memorysqlitevec.WithAsyncMemoryNum(cfg.AsyncMemoryNum),
-			)
-		}
-		if cfg.MemoryQueueSize > 0 {
-			opts = append(
-				opts,
-				memorysqlitevec.WithMemoryQueueSize(cfg.MemoryQueueSize),
-			)
-		}
-		if cfg.MemoryJobTimeout > 0 {
-			opts = append(
-				opts,
-				memorysqlitevec.WithMemoryJobTimeout(cfg.MemoryJobTimeout),
-			)
-		}
-	}
-
-	svc, err := memorysqlitevec.NewService(db, opts...)
-	if err != nil {
-		_ = db.Close()
-		return nil, err
-	}
-
-	return svc, nil
 }
 
 // newInMemoryMemoryService creates an in-memory memory service.


### PR DESCRIPTION
This moves the sqlitevec implementations in the knowledge and memory examples into CGO-gated source files and updates the knowledge example module requirement so synced downstream copies can resolve extractor imports without colliding with existing sqlitevec stub files.