### PR TITLE
model/openai: detect embedded error in HTTP 200 responses from non-standard providers

### DIFF
--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -2228,6 +2228,17 @@ func (m *Model) handleNonStreamingResponseWithEmitter(
 		})
 		return
 	}
+	// Some OpenAI-compatible providers return HTTP 200 with an error body
+	// instead of a proper 4xx/5xx status code. The SDK does not treat these
+	// as errors because it only inspects the HTTP status. However the error
+	// payload is still preserved in ChatCompletion.JSON.ExtraFields["error"].
+	// Detect this case and convert it into an explicit error response so that
+	// downstream consumers see a clear failure instead of an empty completion
+	// that can cause silent infinite loops in the agent flow.
+	if resp := extractEmbeddedErrorResponse(chatCompletion); resp != nil {
+		emit(resp)
+		return
+	}
 	// Call response callback on successful completion.
 	m.runChatResponseCallback(ctx, &chatRequest, chatCompletion)
 	emit(m.createResponseFromCompletion(chatCompletion))
@@ -2612,4 +2623,106 @@ func (m *Model) DownloadFile(
 		mime = "application/octet-stream"
 	}
 	return data, mime, nil
+}
+
+// extractEmbeddedErrorResponse detects an error payload hidden inside an
+// otherwise "successful" ChatCompletion. Some OpenAI-compatible providers
+// return HTTP 200 with a JSON body like:
+//
+//	{"error": {"message": "...", "type": "...", "code": "..."}}
+//
+// The OpenAI SDK only checks HTTP status codes for errors, so it silently
+// parses this into an empty ChatCompletion. The error object ends up in
+// ChatCompletion.JSON.ExtraFields["error"] because "error" is not a
+// recognized field in the ChatCompletion schema.
+//
+// This function checks for that specific condition and, when found, returns
+// a model.Response with the original error information restored.
+// Returns nil when no embedded error is detected.
+func extractEmbeddedErrorResponse(cc *openai.ChatCompletion) *model.Response {
+	if cc == nil {
+		return nil
+	}
+	// Only inspect ExtraFields when the completion is empty (no choices).
+	// A completion with valid choices is never treated as an error, even if
+	// the provider happens to include extra fields named "error".
+	if len(cc.Choices) > 0 {
+		return nil
+	}
+	errField, ok := cc.JSON.ExtraFields["error"]
+	if !ok {
+		return nil
+	}
+	// Parse the raw error JSON to extract message and type.
+	// Use Raw() instead of Valid() because the SDK may mark non-schema
+	// object fields as "invalid" status even though the content is present.
+	raw := errField.Raw()
+	if raw == "" || raw == "null" {
+		return nil
+	}
+	var errBody struct {
+		Message string          `json:"message"`
+		Type    string          `json:"type"`
+		Code    json.RawMessage `json:"code"`
+		Param   json.RawMessage `json:"param"`
+	}
+	if err := json.Unmarshal([]byte(raw), &errBody); err != nil {
+		// ExtraFields["error"] exists but is not a recognizable error object;
+		// leave it for the normal completion path.
+		return nil
+	}
+	if errBody.Message == "" && errBody.Type == "" {
+		return nil
+	}
+	errMsg := errBody.Message
+	if errMsg == "" {
+		errMsg = "OpenAI-compatible API returned an embedded error in HTTP 200 response"
+	}
+	log.Debugf("OpenAI-compatible API returned HTTP 200 with embedded error (type=%s)", errBody.Type)
+	respErr := &model.ResponseError{
+		Message: errMsg,
+		Type:    model.ErrorTypeAPIError,
+	}
+	if code := normalizeEmbeddedErrorCode(errBody.Code); code != "" {
+		respErr.Code = &code
+	}
+	if p := normalizeEmbeddedErrorString(errBody.Param); p != "" {
+		respErr.Param = &p
+	}
+	return &model.Response{
+		Error:     respErr,
+		Timestamp: time.Now(),
+		Done:      true,
+	}
+}
+
+// normalizeEmbeddedErrorString extracts a JSON string value.
+// Returns "" for absent, null, or non-string values.
+func normalizeEmbeddedErrorString(raw json.RawMessage) string {
+	if len(raw) == 0 || string(raw) == "null" {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	return ""
+}
+
+// normalizeEmbeddedErrorCode converts a JSON code value (string, number, or
+// null) into a string suitable for model.ResponseError.Code.
+// Returns "" when the value is absent, null, or unparsable.
+func normalizeEmbeddedErrorCode(raw json.RawMessage) string {
+	if s := normalizeEmbeddedErrorString(raw); s != "" {
+		return s
+	}
+	if len(raw) == 0 || string(raw) == "null" {
+		return ""
+	}
+	// Try number (some providers return numeric codes).
+	var n json.Number
+	if err := json.Unmarshal(raw, &n); err == nil {
+		return n.String()
+	}
+	return ""
 }

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -7515,3 +7515,266 @@ func TestChatRequestCallbackSynchronous(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractEmbeddedErrorResponse(t *testing.T) {
+	mustCompletion := func(t *testing.T, raw string) *openaigo.ChatCompletion {
+		t.Helper()
+		var cc openaigo.ChatCompletion
+		require.NoError(t, cc.UnmarshalJSON([]byte(raw)))
+		return &cc
+	}
+
+	tests := []struct {
+		name        string
+		completion  *openaigo.ChatCompletion
+		wantNil     bool
+		wantMessage string
+		wantType    string
+		wantCode    string
+		wantParam   string
+	}{
+		{
+			name:       "nil completion",
+			completion: nil,
+			wantNil:    true,
+		},
+		{
+			name: "normal completion with choices",
+			completion: mustCompletion(t, `{
+				"id": "chatcmpl-123",
+				"object": "chat.completion",
+				"choices": [{"index": 0, "message": {"role": "assistant", "content": "hello"}, "finish_reason": "stop"}],
+				"model": "gpt-4"
+			}`),
+			wantNil: true,
+		},
+		{
+			name: "normal completion with choices and extra error field is not treated as error",
+			completion: mustCompletion(t, `{
+				"id": "chatcmpl-123",
+				"object": "chat.completion",
+				"choices": [{"index": 0, "message": {"role": "assistant", "content": "hello"}, "finish_reason": "stop"}],
+				"model": "gpt-4",
+				"error": {"message": "some warning", "type": "info"}
+			}`),
+			wantNil: true,
+		},
+		{
+			name:       "empty completion without error field",
+			completion: mustCompletion(t, `{}`),
+			wantNil:    true,
+		},
+		{
+			name: "empty completion with embedded error",
+			completion: mustCompletion(t, `{
+				"error": {
+					"message": "When using tool_choice, 'tools' must be set.",
+					"type": "invalid_request_error",
+					"code": "validation_error"
+				}
+			}`),
+			wantNil:     false,
+			wantMessage: "When using tool_choice, 'tools' must be set.",
+			wantType:    model.ErrorTypeAPIError,
+			wantCode:    "validation_error",
+		},
+		{
+			name: "empty completion with embedded error containing ret_code",
+			completion: mustCompletion(t, `{
+				"error": {
+					"message": "API key exceeded rate limit",
+					"type": "requestAuthError",
+					"code": "rate_limited",
+					"ret_code": -2000
+				}
+			}`),
+			wantNil:     false,
+			wantMessage: "API key exceeded rate limit",
+			wantType:    model.ErrorTypeAPIError,
+			wantCode:    "rate_limited",
+		},
+		{
+			name: "empty completion with error message only, type defaults to api_error",
+			completion: mustCompletion(t, `{
+				"error": {"message": "something went wrong"}
+			}`),
+			wantNil:     false,
+			wantMessage: "something went wrong",
+			wantType:    model.ErrorTypeAPIError,
+		},
+		{
+			name: "empty completion with embedded error where code is a number",
+			completion: mustCompletion(t, `{
+				"error": {
+					"message": "rate limit",
+					"type": "requestAuthError",
+					"code": -2000
+				}
+			}`),
+			wantNil:     false,
+			wantMessage: "rate limit",
+			wantType:    model.ErrorTypeAPIError,
+			wantCode:    "-2000",
+		},
+		{
+			name: "empty completion with embedded error containing param",
+			completion: mustCompletion(t, `{
+				"error": {
+					"message": "invalid parameter",
+					"type": "invalid_request_error",
+					"param": "tool_choice"
+				}
+			}`),
+			wantNil:     false,
+			wantMessage: "invalid parameter",
+			wantType:    model.ErrorTypeAPIError,
+			wantParam:   "tool_choice",
+		},
+		{
+			name: "empty completion with error field that is not a valid object",
+			completion: mustCompletion(t, `{
+				"error": "plain string error"
+			}`),
+			wantNil: true,
+		},
+		{
+			name: "empty completion with error field that is null",
+			completion: mustCompletion(t, `{
+				"error": null
+			}`),
+			wantNil: true,
+		},
+		{
+			name: "empty completion with error object but empty message and type",
+			completion: mustCompletion(t, `{
+				"error": {"code": "unknown"}
+			}`),
+			wantNil: true,
+		},
+		{
+			name: "empty completion with type only and no message falls back to generic message",
+			completion: mustCompletion(t, `{
+				"error": {"type": "server_error"}
+			}`),
+			wantNil:     false,
+			wantMessage: "OpenAI-compatible API returned an embedded error in HTTP 200 response",
+			wantType:    model.ErrorTypeAPIError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := extractEmbeddedErrorResponse(tt.completion)
+			if tt.wantNil {
+				assert.Nil(t, resp, "expected nil response")
+				return
+			}
+			require.NotNil(t, resp, "expected non-nil error response")
+			require.NotNil(t, resp.Error, "expected Error field")
+			assert.Equal(t, tt.wantMessage, resp.Error.Message)
+			assert.Equal(t, tt.wantType, resp.Error.Type)
+			assert.True(t, resp.Done, "error response must be Done")
+			if tt.wantCode != "" {
+				require.NotNil(t, resp.Error.Code, "expected Code field")
+				assert.Equal(t, tt.wantCode, *resp.Error.Code)
+			}
+			if tt.wantParam != "" {
+				require.NotNil(t, resp.Error.Param, "expected Param field")
+				assert.Equal(t, tt.wantParam, *resp.Error.Param)
+			}
+		})
+	}
+}
+
+func TestModel_GenerateContent_EmbeddedErrorHTTP200(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/chat/completions") {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		// Simulate a provider returning HTTP 200 with an error body.
+		fmt.Fprint(w, `{
+			"error": {
+				"message": "When using tool_choice, 'tools' must be set.",
+				"type": "invalid_request_error",
+				"ret_code": -1000
+			}
+		}`)
+	}))
+	defer server.Close()
+
+	m := New("test-model",
+		WithBaseURL(server.URL),
+		WithAPIKey("test-key"),
+	)
+
+	req := &model.Request{
+		Messages: []model.Message{
+			model.NewUserMessage("hello"),
+		},
+		GenerationConfig: model.GenerationConfig{Stream: false},
+	}
+
+	ch, err := m.GenerateContent(context.Background(), req)
+	require.NoError(t, err)
+
+	var responses []*model.Response
+	for resp := range ch {
+		responses = append(responses, resp)
+	}
+
+	require.Len(t, responses, 1, "expected exactly one response")
+	resp := responses[0]
+	require.NotNil(t, resp.Error, "response must carry an error")
+	assert.Equal(t, "When using tool_choice, 'tools' must be set.", resp.Error.Message)
+	assert.Equal(t, model.ErrorTypeAPIError, resp.Error.Type)
+	assert.True(t, resp.Done)
+	assert.Empty(t, resp.Choices, "error response should have no choices")
+}
+
+func TestModel_GenerateContentIter_EmbeddedErrorHTTP200(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/chat/completions") {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+			"error": {
+				"message": "rate limit exceeded",
+				"type": "requestAuthError",
+				"ret_code": -2000
+			}
+		}`)
+	}))
+	defer server.Close()
+
+	m := New("test-model",
+		WithBaseURL(server.URL),
+		WithAPIKey("test-key"),
+	)
+
+	req := &model.Request{
+		Messages: []model.Message{
+			model.NewUserMessage("hello"),
+		},
+		GenerationConfig: model.GenerationConfig{Stream: false},
+	}
+
+	seq, err := m.GenerateContentIter(context.Background(), req)
+	require.NoError(t, err)
+
+	var responses []*model.Response
+	seq(func(resp *model.Response) bool {
+		responses = append(responses, resp)
+		return true
+	})
+
+	require.Len(t, responses, 1)
+	resp := responses[0]
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, "rate limit exceeded", resp.Error.Message)
+	assert.Equal(t, model.ErrorTypeAPIError, resp.Error.Type)
+	assert.True(t, resp.Done)
+}


### PR DESCRIPTION
Some OpenAI-compatible providers return HTTP 200 with an error payload in the response body instead of a proper 4xx/5xx status code. The OpenAI SDK only inspects HTTP status codes, so it silently parses these into empty ChatCompletion objects (no choices, no error). This causes the agent flow loop to retry indefinitely since IsFinalResponse() does not consider an empty completion as terminal.

Add extractEmbeddedErrorResponse to detect when a ChatCompletion has no choices but carries an "error" object in JSON.ExtraFields. When found, the original error message/type/code/param are restored into a model.ResponseError, allowing the normal error handling pipeline to surface the failure to users.

The detection is gated behind len(cc.Choices) == 0 to avoid false positives on normal completions that happen to include extra fields. Code and param use json.RawMessage with best-effort normalization to tolerate type mismatches (e.g. numeric code) without blocking core message/type recovery.