### PR TITLE
examples/a2ui: stabilize sbti runtime flow

### DIFF
--- a/examples/a2ui/client/client.js
+++ b/examples/a2ui/client/client.js
@@ -1373,7 +1373,7 @@ function normalizeContextValue(surfaceId, rawValue, dataContextPath = "/") {
       if (resolved === undefined) {
         return null;
       }
-      return projectActionContextValue(normalizeContextValue(surfaceId, resolved, dataContextPath));
+      return normalizeContextValue(surfaceId, resolved, dataContextPath);
     }
     if (typeof rawValue.literalString === "string") {
       return rawValue.literalString;
@@ -1549,6 +1549,15 @@ function buildUserActionPayload(surfaceId, sourceComponentId, action, dataContex
   const actionName = isObject(action) && typeof action.name === "string" && action.name.trim()
     ? action.name.trim()
     : "unknown";
+  const context = extractActionContext(normalizedSurfaceId, isObject(action) ? action.context : undefined, dataContextPath);
+  if (actionName === "submit_test") {
+    if (Object.prototype.hasOwnProperty.call(context, "questions")) {
+      context.questions = projectActionContextValue(context.questions);
+    }
+    if (Object.prototype.hasOwnProperty.call(context, "special")) {
+      context.special = projectActionContextValue(context.special);
+    }
+  }
   return {
     userAction: {
       name: actionName,
@@ -1557,7 +1566,7 @@ function buildUserActionPayload(surfaceId, sourceComponentId, action, dataContex
         ? action.sourceComponentId.trim()
         : sourceComponentId,
       timestamp: new Date().toISOString(),
-      context: extractActionContext(normalizedSurfaceId, isObject(action) ? action.context : undefined, dataContextPath),
+      context,
     },
   };
 }

--- a/examples/a2ui/client/client.js
+++ b/examples/a2ui/client/client.js
@@ -272,7 +272,7 @@ function parseDataModelValue(rawValue) {
       if (!isObject(entry) || typeof entry.key !== "string") {
         return;
       }
-      result[entry.key] = parseDataModelValue(entry.value);
+      result[entry.key] = parseDataModelValue(entry.value !== undefined ? entry.value : entry);
     });
     return result;
   }
@@ -417,6 +417,17 @@ function parseAguiEvent(rawEvent) {
 }
 
 function extractRawPayload(rawEvent) {
+  if (typeof rawEvent === "string") {
+    const trimmed = rawEvent.trim();
+    if (trimmed) {
+      try {
+        return extractRawPayload(JSON.parse(trimmed));
+      } catch {
+        return rawEvent;
+      }
+    }
+    return rawEvent;
+  }
   if (!isObject(rawEvent)) {
     return rawEvent;
   }
@@ -1362,7 +1373,7 @@ function normalizeContextValue(surfaceId, rawValue, dataContextPath = "/") {
       if (resolved === undefined) {
         return null;
       }
-      return normalizeContextValue(surfaceId, resolved, dataContextPath);
+      return projectActionContextValue(normalizeContextValue(surfaceId, resolved, dataContextPath));
     }
     if (typeof rawValue.literalString === "string") {
       return rawValue.literalString;
@@ -1380,6 +1391,32 @@ function normalizeContextValue(surfaceId, rawValue, dataContextPath = "/") {
     return normalized;
   }
   return String(rawValue);
+}
+
+function projectActionContextValue(value) {
+  if (value === null || value === undefined) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => projectActionContextValue(item));
+  }
+  if (!isObject(value)) {
+    return value;
+  }
+  if (Object.prototype.hasOwnProperty.call(value, "selected")) {
+    return { selected: projectActionContextValue(value.selected) };
+  }
+  if (Object.prototype.hasOwnProperty.call(value, "value")) {
+    return { value: projectActionContextValue(value.value) };
+  }
+  if (Object.prototype.hasOwnProperty.call(value, "checked")) {
+    return { checked: projectActionContextValue(value.checked) };
+  }
+  const projected = {};
+  Object.keys(value).forEach((key) => {
+    projected[key] = projectActionContextValue(value[key]);
+  });
+  return projected;
 }
 
 function clearLogs() {

--- a/examples/a2ui/server/sbti/agent.go
+++ b/examples/a2ui/server/sbti/agent.go
@@ -66,10 +66,8 @@ func buildGraph() (*graph.Graph, error) {
 
 func buildDirectorAgent(schema map[string]any) agent.Agent {
 	generationConfig := model.GenerationConfig{
-		MaxTokens:       intPtr(16384),
-		Temperature:     floatPtr(1.0),
-		ReasoningEffort: stringPtr("medium"),
-		Stream:          *isStream,
+		MaxTokens: intPtr(16384),
+		Stream:    *isStream,
 	}
 	return llmagent.New(
 		directorAgentName,
@@ -88,10 +86,8 @@ func localDirectorInstructionText() string {
 
 func buildRendererAgent() agent.Agent {
 	generationConfig := model.GenerationConfig{
-		MaxTokens:       intPtr(32768),
-		Temperature:     floatPtr(1.0),
-		ReasoningEffort: stringPtr("medium"),
-		Stream:          *isStream,
+		MaxTokens: intPtr(32768),
+		Stream:    *isStream,
 	}
 	return llmagent.New(
 		rendererAgentName,
@@ -116,13 +112,5 @@ func directorOutputSchemaMap() (map[string]any, error) {
 }
 
 func intPtr(v int) *int {
-	return &v
-}
-
-func floatPtr(v float64) *float64 {
-	return &v
-}
-
-func stringPtr(v string) *string {
 	return &v
 }

--- a/examples/a2ui/server/sbti/assets/director_instruction.txt
+++ b/examples/a2ui/server/sbti/assets/director_instruction.txt
@@ -7,7 +7,6 @@ The quiz_state field is the only contract consumed by the downstream renderer ag
 Input rules:
 - The latest user turn may be plain text or a JSON string that contains userAction.
 - The quiz is a single-page local form.
-- If recent history contains an earlier valid director JSON object whose top-level field director_output_version equals sbti_v2, use its quiz_state.answers as the baseline answer state before applying the latest action.
 - When the latest userAction.name is submit_test, reconstruct the full answer state from nested userAction.context.questions and userAction.context.special objects.
 - submit_test action.context must carry exactly two top-level fields: questions and special.
 - questions must be an object keyed by q1 through q30, and each question item must include selected.
@@ -19,6 +18,7 @@ Input rules:
 - If the latest plain text clearly asks to restart or reset, reset every answer to empty.
 - If the latest plain text starts or continues the test without a usable userAction payload, start from empty.
 - If submit_test arrives without usable nested questions and special objects in action.context, treat every answer as empty and keep quiz mode with a short notice.
+- Ignore prior assistant output when reconstructing quiz state. Only the latest user turn decides whether the state starts empty, resets, or comes from submit_test payload.
 State rules:
 - Keep the official question content and the official scoring logic.
 - Do not randomize question order.
@@ -35,8 +35,6 @@ Action rules:
 - If submit_test arrives before every required answer is present, stay in quiz mode and set a prominent notice.
 - restart_test resets the test to the initial empty state.
 - After restart_test, the quiz must return to the same official full 32-question copy as a fresh start. Never replace official prompts or option labels with placeholders.
-- If the test is already completed, only restart_test may leave result mode.
-- If a non-restart action arrives after completion, keep result mode and set a short notice.
 Scoring rules:
 - Each main question belongs to one dimension.
 - Main-question selected option values are 1, 2, or 3.
@@ -64,7 +62,9 @@ Output rules:
 - drink_gate_q1 values must be 1, 2, 3, 4, or an empty string.
 - drink_gate_q2 values must be 1, 2, or an empty string.
 - Keep quiz copy concise and lively.
-- quiz_state.title, quiz_state.description, and quiz_state.notice must already be final Chinese copy for rendering.
+- In quiz mode, quiz_state.title must always be exactly SBTI 32题人格测试.
+- In quiz mode, quiz_state.description must always be exactly 30道主题 + 2道小彩蛋。按直觉选，别想太多。
+- quiz_state.notice must already be final Chinese copy for rendering.
 - In quiz mode, result.code, result.title, result.tagline, result.match_summary, result.image_url, and result.description must be empty strings.
 - In quiz mode, result.dimension_portraits must be an empty array.
 - In result mode, locate the official fixed type profile whose code equals the primary result code.

--- a/examples/a2ui/server/sbti/assets/renderer_instruction.txt
+++ b/examples/a2ui/server/sbti/assets/renderer_instruction.txt
@@ -46,11 +46,13 @@ Quiz mode rules:
 - Quiz option changes must stay local and must not create a network request.
 - The quiz footer renders only submit_test and restart_test.
 - The submit_test button must use action name submit_test.
+- The submit_test button label must be exactly 提交测试.
 - submit_test action.context must include exactly two top-level keys: questions and special.
 - questions must use one path reference to /session/content/questions.
 - special must use one path reference to /session/content/special.
 - Do not flatten submit_test answers into 32 separate context entries.
 - The restart_test button must use action name restart_test.
+- In quiz mode, the restart_test button label must be exactly 重新开始.
 - If quiz_state.notice is empty, still render noticeText from the bound path and do not invent fallback copy.
 Result mode rules:
 - In result mode, use dataModelUpdate to write title, tagline, match_summary, image_url, and description into /session/result.
@@ -72,4 +74,5 @@ Result mode rules:
 - dimensionLevel must read level from the current template item.
 - dimensionDescription must read description from the current template item.
 - For result screens, use only restart_test as the footer action.
+- In result mode, the restart_test button label must be exactly 重新开始.
 - Keep surfaceId fixed as sbti-main.


### PR DESCRIPTION
This updates the SBTI A2UI example to make the browser flow more deterministic by removing the explicit reasoning-effort override, fixing the quiz and restart copy used by the renderer, tightening the director state reconstruction rules, and reducing the demo client's action-context payload to the fields the server actually consumes.