### PR TITLE
model/openai: preserve mixed reasoning chunks in accumulator

### DIFF
--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -1402,13 +1402,18 @@ func stripReasoningFromChunkForAccumulator(
 
 // hasAccumulatorPayloadBeyondReasoning reports whether the stripped chunk still
 // contains payload the SDK accumulator must keep, such as content, refusal,
-// tool calls, or usage. Pure reasoning-only chunks intentionally keep the old
-// behavior and stay out of the accumulator.
+// tool calls, finish reasons, or usage. Pure reasoning-only chunks
+// intentionally keep the old behavior and stay out of the accumulator.
 func hasAccumulatorPayloadBeyondReasoning(
 	chunk openai.ChatCompletionChunk,
 ) bool {
 	if len(chunk.Choices) > 0 {
-		delta := chunk.Choices[0].Delta
+		choice := chunk.Choices[0]
+		if choice.FinishReason != "" {
+			return true
+		}
+
+		delta := choice.Delta
 		if delta.JSON.Content.Valid() || delta.JSON.Refusal.Valid() {
 			return true
 		}

--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -1300,8 +1300,9 @@ func (m *Model) handleStreamingResponseWithEmitter(
 		// Track ID -> Index mapping when ID is present (first chunk of each tool call).
 		m.updateToolCallIndexMapping(chunk, idToIndexMap)
 
-		// Accumulate chunk for correctness (tool call deltas are assembled later),
-		// but skip chunks with reasoning content that would cause the SDK accumulator to panic.
+		// Accumulate chunk for correctness. When a chunk mixes reasoning with
+		// content or tool-call deltas, strip only the reasoning metadata before
+		// passing it to the SDK accumulator.
 		m.accumulateChunk(chunk, &acc, &reasoningBuf)
 
 		// Suppress chunks that carry no meaningful visible delta (including
@@ -1365,6 +1366,60 @@ func sanitizeChunkForAccumulator(chunk openai.ChatCompletionChunk) openai.ChatCo
 	sanitized.Choices[0].Delta.JSON.ToolCalls = respjson.Field{}
 
 	return sanitized
+}
+
+// stripReasoningFromChunkForAccumulator returns a defensive copy of the chunk
+// with reasoning-only ExtraFields removed from the first choice delta. This
+// lets the upstream accumulator keep non-reasoning payloads from mixed chunks
+// without mutating the original chunk.
+func stripReasoningFromChunkForAccumulator(
+	chunk openai.ChatCompletionChunk,
+) (openai.ChatCompletionChunk, bool) {
+	if len(chunk.Choices) == 0 {
+		return chunk, false
+	}
+
+	extraFields := chunk.Choices[0].Delta.JSON.ExtraFields
+	if extractReasoningContent(extraFields) == "" {
+		return chunk, false
+	}
+
+	stripped := chunk
+	stripped.Choices = make([]openai.ChatCompletionChunkChoice, len(chunk.Choices))
+	copy(stripped.Choices, chunk.Choices)
+	stripped.Choices[0].Delta.JSON.ExtraFields =
+		cloneRespJSONFieldMap(extraFields)
+	delete(
+		stripped.Choices[0].Delta.JSON.ExtraFields,
+		model.ReasoningContentKey,
+	)
+	delete(
+		stripped.Choices[0].Delta.JSON.ExtraFields,
+		model.ReasoningContentKeyAlt,
+	)
+	return stripped, true
+}
+
+// hasAccumulatorPayloadBeyondReasoning reports whether the stripped chunk still
+// contains payload the SDK accumulator must keep, such as content, refusal,
+// tool calls, or usage. Pure reasoning-only chunks intentionally keep the old
+// behavior and stay out of the accumulator.
+func hasAccumulatorPayloadBeyondReasoning(
+	chunk openai.ChatCompletionChunk,
+) bool {
+	if len(chunk.Choices) > 0 {
+		delta := chunk.Choices[0].Delta
+		if delta.JSON.Content.Valid() || delta.JSON.Refusal.Valid() {
+			return true
+		}
+		if len(delta.ToolCalls) > 0 {
+			return true
+		}
+	}
+
+	return chunk.Usage.CompletionTokens > 0 ||
+		chunk.Usage.PromptTokens > 0 ||
+		chunk.Usage.TotalTokens > 0
 }
 
 type toolCallIndexState struct {
@@ -1574,19 +1629,28 @@ func applyOpenAISDKTokenDetailsAccumulationFix(
 	acc.Usage.PromptTokensDetails.CachedTokens += chunk.Usage.PromptTokensDetails.CachedTokens
 }
 
-// accumulateChunk accumulates the chunk into the accumulator and reasoning buffer.
+// accumulateChunk accumulates non-reasoning deltas into the SDK accumulator and
+// always appends reasoning deltas to the reasoning buffer.
 func (m *Model) accumulateChunk(
 	chunk openai.ChatCompletionChunk,
 	acc *openai.ChatCompletionAccumulator,
 	reasoningBuf *bytes.Buffer,
 ) {
-	// Always accumulate for correctness (tool call deltas are assembled later),
-	// but skip chunks with reasoning content that would cause the SDK accumulator to panic.
-	if !m.hasReasoningContent(chunk.Choices) {
+	chunkForAccumulator := chunk
+	shouldAccumulate := true
+	if strippedChunk, stripped := stripReasoningFromChunkForAccumulator(chunk); stripped {
+		if hasAccumulatorPayloadBeyondReasoning(strippedChunk) {
+			chunkForAccumulator = strippedChunk
+		} else {
+			shouldAccumulate = false
+		}
+	}
+
+	if shouldAccumulate {
 		// Sanitize chunks before feeding them into the upstream accumulator to
 		// avoid known panics when JSON.ToolCalls is marked present but the
 		// typed ToolCalls slice is empty, especially on finish_reason chunks.
-		sanitizedChunk := sanitizeChunkForAccumulator(chunk)
+		sanitizedChunk := sanitizeChunkForAccumulator(chunkForAccumulator)
 		if acc.AddChunk(sanitizedChunk) {
 			applyOpenAISDKTokenDetailsAccumulationFix(acc, chunk)
 		}

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -2383,11 +2383,12 @@ func stringPtr(s string) *string {
 func TestModel_GenerateContent_StreamingBatchProcessing(t *testing.T) {
 	// Test cases covering different streaming scenarios.
 	tests := []struct {
-		name          string
-		chunks        []string
-		expectedTool  string
-		expectedArgs  string
-		expectedCount int
+		name           string
+		chunks         []string
+		expectedTool   string
+		expectedArgs   string
+		expectedCount  int
+		expectedReason string
 	}{
 		{
 			name: "Normal_Sandwich_Mode", // Normal "sandwich" mode: content does not exist in tool call chunks {0}.
@@ -2410,6 +2411,17 @@ func TestModel_GenerateContent_StreamingBatchProcessing(t *testing.T) {
 			expectedTool:  "calculate",
 			expectedArgs:  `{"expr":"2+2"}`,
 			expectedCount: 1,
+		},
+		{
+			name: "Reasoning_ToolCalls_SameChunk",
+			chunks: []string{
+				`data: {"id":"test","object":"chat.completion.chunk","created":1699200000,"model":"gpt-3.5-turbo","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"tool planning","tool_calls":[{"index":0,"id":"call_reasoning","type":"function","function":{"name":"lookup_weather","arguments":"{\"city\":\"Shenzhen\"}"}}]},"finish_reason":null}]}`,
+				`data: {"id":"test","object":"chat.completion.chunk","created":1699200000,"model":"gpt-3.5-turbo","choices":[{"index":0,"delta":{"content":""},"finish_reason":"tool_calls"}]}`,
+			},
+			expectedTool:   "lookup_weather",
+			expectedArgs:   `{"city":"Shenzhen"}`,
+			expectedCount:  1,
+			expectedReason: "tool planning",
 		},
 		{
 			name: "Multiple_ToolCalls_Sandwich", // multiple tool calls in normal mode.
@@ -2537,6 +2549,14 @@ func TestModel_GenerateContent_StreamingBatchProcessing(t *testing.T) {
 				assert.Equalf(t, tt.expectedArgs, string(tc.Function.Arguments), "Expected args '%s', got '%s'", tt.expectedArgs, string(tc.Function.Arguments))
 				// Verify Done=false for tool call responses.
 				assert.Falsef(t, toolCallResponse.Done, "Tool call response should have Done=false")
+			}
+
+			if tt.expectedReason != "" {
+				assert.Equal(
+					t,
+					tt.expectedReason,
+					toolCallResponse.Choices[0].Message.ReasoningContent,
+				)
 			}
 
 			// Special verification for ID_Index_Mapping_Verification test case.
@@ -5125,6 +5145,39 @@ func TestSanitizeChunkForAccumulator_NoFinishReason(t *testing.T) {
 	assert.Len(t, sanitized.Choices[0].Delta.ToolCalls, 0)
 }
 
+func TestStripReasoningFromChunkForAccumulator(t *testing.T) {
+	chunk := parseChunkWithExtraFields(t, `{
+		"id": "test",
+		"object": "chat.completion.chunk",
+		"created": 1699200000,
+		"model": "gpt-3.5-turbo",
+		"choices": [
+			{
+				"index": 0,
+				"delta": {
+					"content": "hello",
+					"reasoning_content": "plan"
+				}
+			}
+		]
+	}`)
+
+	stripped, ok := stripReasoningFromChunkForAccumulator(chunk)
+
+	require.True(t, ok)
+	require.Len(t, stripped.Choices, 1)
+	assert.Equal(t, "hello", stripped.Choices[0].Delta.Content)
+	assert.Empty(
+		t,
+		extractReasoningContent(stripped.Choices[0].Delta.JSON.ExtraFields),
+	)
+	assert.Equal(
+		t,
+		"plan",
+		extractReasoningContent(chunk.Choices[0].Delta.JSON.ExtraFields),
+	)
+}
+
 // TestStreamingCallbackIntegration tests the integration of streaming callbacks.
 func TestStreamingCallbackIntegration(t *testing.T) {
 	t.Run("streaming with chat stream complete callback", func(t *testing.T) {
@@ -5340,6 +5393,15 @@ func TestStreamingCallbackIntegration(t *testing.T) {
 			}
 		}
 		assert.True(t, hasReasoning, "expected at least one response to contain reasoning content")
+		require.NotEmpty(t, responses)
+		finalResp := responses[len(responses)-1]
+		require.True(t, finalResp.Done)
+		require.Len(t, finalResp.Choices, 1)
+		assert.Equal(
+			t,
+			"I think the answer is 42.",
+			finalResp.Choices[0].Message.Content,
+		)
 	})
 
 	t.Run("streaming with malformed reasoning content", func(t *testing.T) {
@@ -6709,11 +6771,11 @@ func TestModel_accumulateChunk(t *testing.T) {
 		assert.Equal(t, "", reasoningBuf.String())
 	})
 
-	t.Run("skip chunk with reasoning content", func(t *testing.T) {
+	t.Run("skip pure reasoning-only chunk", func(t *testing.T) {
 		chunk := parseChunkWithExtraFields(t, `{
-			"id": "test-id",
-			"object": "chat.completion.chunk",
-			"created": 1699200000,
+				"id": "test-id",
+				"object": "chat.completion.chunk",
+				"created": 1699200000,
 			"model": "test-model",
 			"choices": [{
 				"index": 0,
@@ -6729,6 +6791,72 @@ func TestModel_accumulateChunk(t *testing.T) {
 
 		assert.Equal(t, "First reasoning", reasoningBuf.String())
 		assert.Empty(t, acc.Choices)
+	})
+
+	t.Run("accumulate chunk with reasoning and content", func(t *testing.T) {
+		chunk := parseChunkWithExtraFields(t, `{
+				"id": "test-id",
+				"object": "chat.completion.chunk",
+				"created": 1699200000,
+				"model": "test-model",
+				"choices": [{
+					"index": 0,
+					"delta": {
+						"content": "Hello",
+						"reasoning_content": "plan"
+					}
+				}]
+			}`)
+		acc := openai.ChatCompletionAccumulator{}
+		var reasoningBuf bytes.Buffer
+
+		m.accumulateChunk(chunk, &acc, &reasoningBuf)
+
+		require.Len(t, acc.Choices, 1)
+		assert.Equal(t, "Hello", acc.Choices[0].Message.Content)
+		assert.Equal(t, "plan", reasoningBuf.String())
+	})
+
+	t.Run("accumulate chunk with reasoning and tool calls", func(t *testing.T) {
+		chunk := parseChunkWithExtraFields(t, `{
+				"id": "test-id",
+				"object": "chat.completion.chunk",
+				"created": 1699200000,
+				"model": "test-model",
+				"choices": [{
+					"index": 0,
+					"delta": {
+						"reasoning_content": "tool planning",
+						"tool_calls": [{
+							"index": 0,
+							"id": "call_123",
+							"type": "function",
+							"function": {
+								"name": "lookup_weather",
+								"arguments": "{\"city\":\"Shenzhen\"}"
+							}
+						}]
+					}
+				}]
+			}`)
+		acc := openai.ChatCompletionAccumulator{}
+		var reasoningBuf bytes.Buffer
+
+		m.accumulateChunk(chunk, &acc, &reasoningBuf)
+
+		require.Len(t, acc.Choices, 1)
+		require.Len(t, acc.Choices[0].Message.ToolCalls, 1)
+		assert.Equal(
+			t,
+			"lookup_weather",
+			acc.Choices[0].Message.ToolCalls[0].Function.Name,
+		)
+		assert.Equal(
+			t,
+			`{"city":"Shenzhen"}`,
+			acc.Choices[0].Message.ToolCalls[0].Function.Arguments,
+		)
+		assert.Equal(t, "tool planning", reasoningBuf.String())
 	})
 
 	t.Run("accumulate with custom usage function", func(t *testing.T) {

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -3168,6 +3168,8 @@ func TestModel_GenerateContent_Streaming_FinalReasoningAggregated(t *testing.T) 
 	got := final.Choices[0].Message.ReasoningContent
 	want := "First second final"
 	assert.Equalf(t, want, got, "final ReasoningContent mismatch: got %q want %q", got, want)
+	require.NotNil(t, final.Choices[0].FinishReason)
+	assert.Equal(t, "stop", *final.Choices[0].FinishReason)
 	assert.Truef(t, final.Done, "expected final.Done == true")
 	assert.Falsef(t, final.IsPartial, "expected final.IsPartial == false")
 }
@@ -6857,6 +6859,30 @@ func TestModel_accumulateChunk(t *testing.T) {
 			acc.Choices[0].Message.ToolCalls[0].Function.Arguments,
 		)
 		assert.Equal(t, "tool planning", reasoningBuf.String())
+	})
+
+	t.Run("accumulate chunk with reasoning and finish reason", func(t *testing.T) {
+		chunk := parseChunkWithExtraFields(t, `{
+				"id": "test-id",
+				"object": "chat.completion.chunk",
+				"created": 1699200000,
+				"model": "test-model",
+				"choices": [{
+					"index": 0,
+					"delta": {
+						"reasoning_content": "final step"
+					},
+					"finish_reason": "stop"
+				}]
+			}`)
+		acc := openai.ChatCompletionAccumulator{}
+		var reasoningBuf bytes.Buffer
+
+		m.accumulateChunk(chunk, &acc, &reasoningBuf)
+
+		require.Len(t, acc.Choices, 1)
+		assert.Equal(t, "stop", acc.Choices[0].FinishReason)
+		assert.Equal(t, "final step", reasoningBuf.String())
 	})
 
 	t.Run("accumulate with custom usage function", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- strip only reasoning metadata before feeding mixed streaming chunks into the OpenAI SDK accumulator
- keep pure reasoning-only chunks on the old path while preserving content/tool-call deltas and reasoning aggregation
- add regressions for reasoning+content and reasoning+tool_call chunks plus the mixed tool-call streaming path

## Testing
- go test ./model/openai
- go test ./model/openai -run 'TestStripReasoningFromChunkForAccumulator|TestModel_accumulateChunk|TestModel_GenerateContent_StreamingBatchProcessing|TestModel_GenerateContent_WithReasoningContent|TestModel_GenerateContent_Streaming_FinalReasoningAggregated|TestSanitizeChunkForAccumulator_FinishReasonToolCalls|TestSanitizeChunkForAccumulator_NoFinishReason'

## Notes
- repo-wide `go test ./...` still hits two unrelated existing failures in `codeexecutor/local` and `telemetry/langfuse/config`
