### PR TITLE
model/openai: add reasoning content backfill option

### DIFF
--- a/model/openai/batch.go
+++ b/model/openai/batch.go
@@ -197,11 +197,56 @@ func (m *Model) generateBatchJSONL(requests []*BatchRequestInput) ([]byte, error
 		if r.Body.Model == "" {
 			r.Body.Model = m.name
 		}
-		if err := enc.Encode(r); err != nil {
+		payload, err := m.batchRequestPayload(r)
+		if err != nil {
+			return nil, err
+		}
+		if err := enc.Encode(payload); err != nil {
 			return nil, fmt.Errorf("failed to encode jsonl line: %w", err)
 		}
 	}
 	return buf.Bytes(), nil
+}
+
+func (m *Model) batchRequestPayload(
+	r *BatchRequestInput,
+) (any, error) {
+	if !m.reasoningContentBackfill {
+		return r, nil
+	}
+
+	rawRequest, err := json.Marshal(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal batch request: %w", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(rawRequest, &payload); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal batch request: %w", err)
+	}
+
+	body, ok := payload["body"].(map[string]any)
+	if !ok {
+		return payload, nil
+	}
+	messageValues, ok := body["messages"].([]any)
+	if !ok {
+		return payload, nil
+	}
+
+	for idx, msg := range r.Body.Messages {
+		if idx >= len(messageValues) ||
+			!m.shouldBackfillReasoningContent(msg) {
+			continue
+		}
+		messageValue, ok := messageValues[idx].(map[string]any)
+		if !ok {
+			continue
+		}
+		messageValue[model.ReasoningContentKey] = msg.ReasoningContent
+	}
+
+	return payload, nil
 }
 
 // RetrieveBatch retrieves a batch job by ID.

--- a/model/openai/batch.go
+++ b/model/openai/batch.go
@@ -197,10 +197,7 @@ func (m *Model) generateBatchJSONL(requests []*BatchRequestInput) ([]byte, error
 		if r.Body.Model == "" {
 			r.Body.Model = m.name
 		}
-		payload, err := m.batchRequestPayload(r)
-		if err != nil {
-			return nil, err
-		}
+		payload := m.batchRequestPayload(r)
 		if err := enc.Encode(payload); err != nil {
 			return nil, fmt.Errorf("failed to encode jsonl line: %w", err)
 		}
@@ -210,43 +207,66 @@ func (m *Model) generateBatchJSONL(requests []*BatchRequestInput) ([]byte, error
 
 func (m *Model) batchRequestPayload(
 	r *BatchRequestInput,
-) (any, error) {
-	if !m.reasoningContentBackfill {
-		return r, nil
+) batchRequestPayload {
+	messages := make([]batchMessagePayload, len(r.Body.Messages))
+	for i, msg := range r.Body.Messages {
+		messages[i] = m.newBatchMessagePayload(msg)
 	}
 
-	rawRequest, err := json.Marshal(r)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal batch request: %w", err)
+	return batchRequestPayload{
+		CustomID: r.CustomID,
+		Method:   r.Method,
+		URL:      r.URL,
+		Body: batchRequestBodyPayload{
+			Messages:         messages,
+			GenerationConfig: r.Body.GenerationConfig,
+			StructuredOutput: r.Body.StructuredOutput,
+			Model:            r.Body.Model,
+		},
 	}
+}
 
-	var payload map[string]any
-	if err := json.Unmarshal(rawRequest, &payload); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal batch request: %w", err)
+func (m *Model) newBatchMessagePayload(
+	msg model.Message,
+) batchMessagePayload {
+	payload := batchMessagePayload{
+		Role:         msg.Role,
+		Content:      msg.Content,
+		ContentParts: msg.ContentParts,
+		ToolID:       msg.ToolID,
+		ToolName:     msg.ToolName,
+		ToolCalls:    msg.ToolCalls,
 	}
+	if msg.ReasoningContent != "" ||
+		m.shouldBackfillReasoningContent(msg) {
+		reasoningContent := msg.ReasoningContent
+		payload.ReasoningContent = &reasoningContent
+	}
+	return payload
+}
 
-	body, ok := payload["body"].(map[string]any)
-	if !ok {
-		return payload, nil
-	}
-	messageValues, ok := body["messages"].([]any)
-	if !ok {
-		return payload, nil
-	}
+type batchRequestPayload struct {
+	CustomID string                  `json:"custom_id"`
+	Method   string                  `json:"method"`
+	URL      string                  `json:"url"`
+	Body     batchRequestBodyPayload `json:"body"`
+}
 
-	for idx, msg := range r.Body.Messages {
-		if idx >= len(messageValues) ||
-			!m.shouldBackfillReasoningContent(msg) {
-			continue
-		}
-		messageValue, ok := messageValues[idx].(map[string]any)
-		if !ok {
-			continue
-		}
-		messageValue[model.ReasoningContentKey] = msg.ReasoningContent
-	}
+type batchRequestBodyPayload struct {
+	Messages         []batchMessagePayload   `json:"messages"`
+	GenerationConfig model.GenerationConfig  `json:"generation_config,omitempty"`
+	StructuredOutput *model.StructuredOutput `json:"structured_output,omitempty"`
+	Model            string                  `json:"model"`
+}
 
-	return payload, nil
+type batchMessagePayload struct {
+	Role             model.Role          `json:"role"`
+	Content          string              `json:"content,omitempty"`
+	ContentParts     []model.ContentPart `json:"content_parts,omitempty"`
+	ToolID           string              `json:"tool_id,omitempty"`
+	ToolName         string              `json:"tool_name,omitempty"`
+	ToolCalls        []model.ToolCall    `json:"tool_calls,omitempty"`
+	ReasoningContent *string             `json:"reasoning_content,omitempty"`
 }
 
 // RetrieveBatch retrieves a batch job by ID.

--- a/model/openai/batch_test.go
+++ b/model/openai/batch_test.go
@@ -346,6 +346,7 @@ func TestGenerateBatchJSONL_ReasoningContentBackfill(t *testing.T) {
 	const toolCallID = "call-backfill"
 	const toolName = "calculator"
 	const toolArgs = `{"expression":"2+2"}`
+	const reasoningContent = "I should call the calculator."
 
 	requests := []*BatchRequestInput{
 		{
@@ -418,6 +419,55 @@ func TestGenerateBatchJSONL_ReasoningContentBackfill(t *testing.T) {
 			_, ok := message[model.ReasoningContentKey]
 			assert.False(t, ok)
 		})
+
+	t.Run("preserves non-empty reasoning_content", func(t *testing.T) {
+		requests := []*BatchRequestInput{
+			{
+				CustomID: customID,
+				Body: BatchRequest{
+					Request: model.Request{
+						Messages: []model.Message{
+							{
+								Role:             model.RoleAssistant,
+								Content:          "Calling a tool.",
+								ReasoningContent: reasoningContent,
+								ToolCalls: []model.ToolCall{
+									{
+										ID:   toolCallID,
+										Type: "function",
+										Function: model.FunctionDefinitionParam{
+											Name:      toolName,
+											Arguments: []byte(toolArgs),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		m := New("default-model")
+
+		jsonlData, err := m.generateBatchJSONL(requests)
+		require.NoError(t, err)
+
+		lines := strings.Split(strings.TrimSpace(string(jsonlData)), "\n")
+		require.Len(t, lines, 1)
+
+		var decoded map[string]any
+		err = json.Unmarshal([]byte(lines[0]), &decoded)
+		require.NoError(t, err)
+
+		body := decoded["body"].(map[string]any)
+		messages := body["messages"].([]any)
+		message := messages[0].(map[string]any)
+
+		reasoningValue, ok := message[model.ReasoningContentKey]
+		require.True(t, ok)
+		assert.Equal(t, reasoningContent, reasoningValue)
+	})
 }
 
 func TestBatchRequestOutput_JSON(t *testing.T) {

--- a/model/openai/batch_test.go
+++ b/model/openai/batch_test.go
@@ -341,6 +341,85 @@ func TestGenerateBatchJSONL(t *testing.T) {
 	}
 }
 
+func TestGenerateBatchJSONL_ReasoningContentBackfill(t *testing.T) {
+	const customID = "tool-call"
+	const toolCallID = "call-backfill"
+	const toolName = "calculator"
+	const toolArgs = `{"expression":"2+2"}`
+
+	requests := []*BatchRequestInput{
+		{
+			CustomID: customID,
+			Body: BatchRequest{
+				Request: model.Request{
+					Messages: []model.Message{
+						{
+							Role:    model.RoleAssistant,
+							Content: "Calling a tool.",
+							ToolCalls: []model.ToolCall{
+								{
+									ID:   toolCallID,
+									Type: "function",
+									Function: model.FunctionDefinitionParam{
+										Name:      toolName,
+										Arguments: []byte(toolArgs),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("backfills empty reasoning_content when enabled",
+		func(t *testing.T) {
+			m := New("default-model",
+				WithReasoningContentBackfill(true))
+
+			jsonlData, err := m.generateBatchJSONL(requests)
+			require.NoError(t, err)
+
+			lines := strings.Split(strings.TrimSpace(string(jsonlData)), "\n")
+			require.Len(t, lines, 1)
+
+			var decoded map[string]any
+			err = json.Unmarshal([]byte(lines[0]), &decoded)
+			require.NoError(t, err)
+
+			body := decoded["body"].(map[string]any)
+			messages := body["messages"].([]any)
+			message := messages[0].(map[string]any)
+
+			reasoningValue, ok := message[model.ReasoningContentKey]
+			require.True(t, ok)
+			assert.Equal(t, "", reasoningValue)
+		})
+
+	t.Run("keeps reasoning_content absent when disabled",
+		func(t *testing.T) {
+			m := New("default-model")
+
+			jsonlData, err := m.generateBatchJSONL(requests)
+			require.NoError(t, err)
+
+			lines := strings.Split(strings.TrimSpace(string(jsonlData)), "\n")
+			require.Len(t, lines, 1)
+
+			var decoded map[string]any
+			err = json.Unmarshal([]byte(lines[0]), &decoded)
+			require.NoError(t, err)
+
+			body := decoded["body"].(map[string]any)
+			messages := body["messages"].([]any)
+			message := messages[0].(map[string]any)
+
+			_, ok := message[model.ReasoningContentKey]
+			assert.False(t, ok)
+		})
+}
+
 func TestBatchRequestOutput_JSON(t *testing.T) {
 	t.Run("successful response", func(t *testing.T) {
 		in := &BatchRequestOutput{

--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -656,6 +656,10 @@ func (m *Model) buildThinkingOption(request *model.Request) []openaiopt.RequestO
 	return opts
 }
 
+// shouldBackfillReasoningContent reports whether replay should emit
+// model.ReasoningContentKey as an empty string for assistant tool-call
+// messages. Some providers require the key to be present during tool-call
+// replay even when no reasoning text was returned.
 func (m *Model) shouldBackfillReasoningContent(
 	msg model.Message,
 ) bool {

--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -231,6 +231,7 @@ type Model struct {
 	extraFields                map[string]any
 	variant                    Variant
 	variantConfig              variantConfig
+	reasoningContentBackfill   bool
 	batchCompletionWindow      openai.BatchNewParamsCompletionWindow
 	batchMetadata              map[string]string
 	batchBaseURL               string
@@ -310,6 +311,7 @@ func New(name string, opts ...Option) *Model {
 		extraFields:                o.ExtraFields,
 		variant:                    o.Variant,
 		variantConfig:              variantConfigs[o.Variant],
+		reasoningContentBackfill:   o.ReasoningContentBackfill,
 		batchCompletionWindow:      o.BatchCompletionWindow,
 		batchMetadata:              o.BatchMetadata,
 		batchBaseURL:               o.BatchBaseURL,
@@ -654,6 +656,14 @@ func (m *Model) buildThinkingOption(request *model.Request) []openaiopt.RequestO
 	return opts
 }
 
+func (m *Model) shouldBackfillReasoningContent(
+	msg model.Message,
+) bool {
+	return m.reasoningContentBackfill &&
+		msg.ReasoningContent == "" &&
+		len(msg.ToolCalls) > 0
+}
+
 // convertMessages converts our Message format to OpenAI's format.
 func (m *Model) convertMessages(messages []model.Message) []openai.ChatCompletionMessageParamUnion {
 	result := make([]openai.ChatCompletionMessageParamUnion, len(messages))
@@ -685,7 +695,8 @@ func (m *Model) convertMessages(messages []model.Message) []openai.ChatCompletio
 			}
 			// Pass reasoning_content to API if present (required by DeepSeek for
 			// tool call scenarios within the same request turn).
-			if msg.ReasoningContent != "" {
+			if msg.ReasoningContent != "" ||
+				m.shouldBackfillReasoningContent(msg) {
 				assistantMsg.SetExtraFields(map[string]any{
 					model.ReasoningContentKey: msg.ReasoningContent,
 				})

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -764,6 +764,45 @@ func TestModel_convertMessages_ReasoningContent(t *testing.T) {
 			assert.Equal(t, "", reasoningValue)
 		})
 
+	t.Run("assistant tool call is not backfilled by default",
+		func(t *testing.T) {
+			msgs := []model.Message{
+				{
+					Role:    model.RoleAssistant,
+					Content: "Calling a tool.",
+					ToolCalls: []model.ToolCall{
+						{
+							ID:   "call-default-off",
+							Type: "function",
+							Function: model.FunctionDefinitionParam{
+								Name:      "calculator",
+								Arguments: []byte(`{"expression":"2+2"}`),
+							},
+						},
+					},
+				},
+			}
+
+			converted := New("dummy-model").convertMessages(msgs)
+			require.Len(t, converted, 1)
+			require.NotNil(t, converted[0].OfAssistant)
+
+			data, err := json.Marshal(converted[0].OfAssistant)
+			require.NoError(t, err)
+
+			var parsed map[string]any
+			err = json.Unmarshal(data, &parsed)
+			require.NoError(t, err)
+
+			_, ok := parsed[model.ReasoningContentKey]
+			assert.False(
+				t,
+				ok,
+				"reasoning_content should stay absent when backfill "+
+					"is disabled",
+			)
+		})
+
 	t.Run("assistant message without tool calls is not backfilled",
 		func(t *testing.T) {
 			msgs := []model.Message{

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -721,6 +721,80 @@ func TestModel_convertMessages_ReasoningContent(t *testing.T) {
 		assert.False(t, ok, "reasoning_content should NOT be present when empty")
 	})
 
+	t.Run("assistant tool call backfills empty reasoning_content",
+		func(t *testing.T) {
+			msgs := []model.Message{
+				{
+					Role:    model.RoleAssistant,
+					Content: "Calling a tool.",
+					ToolCalls: []model.ToolCall{
+						{
+							ID:   "call-backfill",
+							Type: "function",
+							Function: model.FunctionDefinitionParam{
+								Name:      "calculator",
+								Arguments: []byte(`{"expression":"2+2"}`),
+							},
+						},
+					},
+				},
+			}
+
+			converted := New(
+				"dummy-model",
+				WithReasoningContentBackfill(true),
+			).convertMessages(msgs)
+			require.Len(t, converted, 1)
+			require.NotNil(t, converted[0].OfAssistant)
+
+			data, err := json.Marshal(converted[0].OfAssistant)
+			require.NoError(t, err)
+
+			var parsed map[string]any
+			err = json.Unmarshal(data, &parsed)
+			require.NoError(t, err)
+
+			reasoningValue, ok := parsed[model.ReasoningContentKey]
+			require.True(
+				t,
+				ok,
+				"reasoning_content should be present when backfill "+
+					"is enabled",
+			)
+			assert.Equal(t, "", reasoningValue)
+		})
+
+	t.Run("assistant message without tool calls is not backfilled",
+		func(t *testing.T) {
+			msgs := []model.Message{
+				{
+					Role:    model.RoleAssistant,
+					Content: "Simple response without tool calls.",
+				},
+			}
+
+			converted := New(
+				"dummy-model",
+				WithReasoningContentBackfill(true),
+			).convertMessages(msgs)
+			require.Len(t, converted, 1)
+			require.NotNil(t, converted[0].OfAssistant)
+
+			data, err := json.Marshal(converted[0].OfAssistant)
+			require.NoError(t, err)
+
+			var parsed map[string]any
+			err = json.Unmarshal(data, &parsed)
+			require.NoError(t, err)
+
+			_, ok := parsed[model.ReasoningContentKey]
+			assert.False(
+				t,
+				ok,
+				"reasoning_content should stay absent without tool calls",
+			)
+		})
+
 	t.Run("assistant message with tool calls and reasoning_content", func(t *testing.T) {
 		msgs := []model.Message{
 			{

--- a/model/openai/options.go
+++ b/model/openai/options.go
@@ -112,8 +112,13 @@ type options struct {
 	// chunks from the provider will be forwarded via
 	// Response.Choices[].Delta.ToolCalls instead of being
 	// suppressed until the final aggregated response.
-	ShowToolCallDelta    bool
-	accumulateChunkUsage AccumulateChunkUsage
+	ShowToolCallDelta bool
+	// ReasoningContentBackfill controls whether assistant
+	// tool-call messages should replay an empty
+	// reasoning_content field when the message has no
+	// reasoning text.
+	ReasoningContentBackfill bool
+	accumulateChunkUsage     AccumulateChunkUsage
 	// OptimizeForCache controls whether to optimize message structure for prompt caching.
 	// When enabled, system messages will be moved to the front to improve cache hit rates.
 	// OpenAI's prompt caching is automatic and doesn't require explicit cache control,
@@ -214,6 +219,15 @@ func WithChatChunkCallback(fn ChatChunkCallbackFunc) Option {
 func WithChatStreamCompleteCallback(fn ChatStreamCompleteCallbackFunc) Option {
 	return func(opts *options) {
 		opts.ChatStreamCompleteCallback = fn
+	}
+}
+
+// WithReasoningContentBackfill enables replay-time
+// reasoning_content backfill for assistant tool-call
+// messages that have no reasoning text.
+func WithReasoningContentBackfill(enabled bool) Option {
+	return func(opts *options) {
+		opts.ReasoningContentBackfill = enabled
 	}
 }
 


### PR DESCRIPTION
## Summary

- add an opt-in OpenAI option to backfill an empty reasoning_content field for assistant tool-call message replay
- keep the default replay behavior unchanged unless the option is enabled
- add tests covering assistant tool-call backfill and the non-tool-call case
