### PR TITLE
openclaw: improve runtime path diagnostics

### DIFF
--- a/openclaw/admin/config_page.go
+++ b/openclaw/admin/config_page.go
@@ -23,9 +23,10 @@ const (
 	formConfigFieldKey = "field_key"
 	formConfigValue    = "value"
 
-	configInputText   = "text"
-	configInputNumber = "number"
-	configInputSelect = "select"
+	configInputText     = "text"
+	configInputNumber   = "number"
+	configInputSelect   = "select"
+	configInputReadOnly = "readonly"
 
 	configApplyHot        = "hot"
 	configApplyNextTurn   = "next_turn"

--- a/openclaw/admin/config_page_test.go
+++ b/openclaw/admin/config_page_test.go
@@ -154,11 +154,7 @@ func TestServiceHandlerRendersReadOnlyConfigField(t *testing.T) {
 	require.Equal(t, http.StatusOK, rr.Code)
 	body := rr.Body.String()
 	require.Contains(t, body, "Read-only runtime diagnostics.")
-	require.NotContains(
-		t,
-		body,
-		`action="api/config/save" class="config-form"`,
-	)
+	require.NotContains(t, body, `class="config-form"`)
 	require.Contains(t, body, "Effective PATH")
 }
 

--- a/openclaw/admin/config_page_test.go
+++ b/openclaw/admin/config_page_test.go
@@ -121,6 +121,47 @@ func TestServiceHandlerRendersConfigPage(t *testing.T) {
 	require.Contains(t, body, "Pending restart")
 }
 
+func TestServiceHandlerRendersReadOnlyConfigField(t *testing.T) {
+	t.Parallel()
+
+	svc := New(
+		Config{},
+		WithRuntimeConfigProvider(&stubRuntimeConfigProvider{
+			status: RuntimeConfigStatus{
+				ConfigPath: "/tmp/openclaw.yaml",
+				Sections: []RuntimeConfigSection{{
+					Key:   "runtime",
+					Title: "Runtime",
+					Fields: []RuntimeConfigField{{
+						Key:                "runtime.effective_path",
+						Title:              "Effective PATH",
+						Summary:            "Read-only path diagnostics.",
+						InputType:          configInputReadOnly,
+						ApplyMode:          configApplyHot,
+						EditorValue:        "/usr/local/bin:/usr/bin",
+						RuntimeValue:       "/usr/local/bin:/usr/bin",
+						RuntimeSourceLabel: "Current process PATH.",
+					}},
+				}},
+			},
+		}),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, routeConfigPage, nil)
+	rr := httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	body := rr.Body.String()
+	require.Contains(t, body, "Read-only runtime diagnostics.")
+	require.NotContains(
+		t,
+		body,
+		`action="api/config/save" class="config-form"`,
+	)
+	require.Contains(t, body, "Effective PATH")
+}
+
 func TestServiceHandlerRendersConfigPageRestartCTA(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/admin/service.go
+++ b/openclaw/admin/service.go
@@ -4327,6 +4327,11 @@ const adminPageHTML = `<!doctype html>
                     {{end}}
                   </div>
                 </div>
+                {{if eq .InputType "readonly"}}
+                <p class="subtle" style="margin-top: 12px;">
+                  Read-only runtime diagnostics.
+                </p>
+                {{else}}
                 <form method="post" action="/api/config/save" class="config-form">
                   <input type="hidden" name="field_key" value="{{.Key}}">
                   <input type="hidden" name="return_to" value="config-field-{{.Key}}">
@@ -4363,6 +4368,7 @@ const adminPageHTML = `<!doctype html>
                     {{end}}
                   </div>
                 </form>
+                {{end}}
               </div>
             </details>
             {{end}}

--- a/openclaw/internal/skills/repository.go
+++ b/openclaw/internal/skills/repository.go
@@ -29,17 +29,21 @@ import (
 )
 
 const (
-	skillsPathEnvName      = "PATH"
-	skillsExtraPathEnvName = "TRPC_CLAW_EXTRA_PATH_DIRS"
+	skillsPathEnvName = "PATH"
+
+	skillsBinPathFixHint = "" +
+		"move the binary into an existing PATH dir or restart " +
+		"openclaw with PATH including its directory"
+	skillsAnyBinPathFixHint = "" +
+		"install one of these binaries into an existing PATH " +
+		"dir or restart openclaw with PATH including its " +
+		"directory"
 
 	missingBinsReasonFormat = "" +
-		"missing bins: %s; searched PATH dirs: %s; fix: move " +
-		"the binary into an existing PATH dir or add its " +
-		"directory to %s"
+		"missing bins: %s; searched PATH dirs: %s; fix: %s"
 	missingAnyBinsReasonFormat = "" +
 		"missing anyBins (need one): %s; searched PATH dirs: %s; " +
-		"fix: install one of these binaries into an existing " +
-		"PATH dir or add its directory to %s"
+		"fix: %s"
 
 	emptySkillsSearchDirs = "(empty)"
 )
@@ -574,7 +578,7 @@ func evaluateRequiredBins(bins []string) string {
 		missingBinsReasonFormat,
 		strings.Join(missing, ", "),
 		formatSkillsSearchDirs(),
-		skillsExtraPathEnvName,
+		skillsBinPathFixHint,
 	)
 }
 
@@ -599,7 +603,7 @@ func evaluateRequiredAnyBins(bins []string) string {
 		missingAnyBinsReasonFormat,
 		strings.Join(any, ", "),
 		formatSkillsSearchDirs(),
-		skillsExtraPathEnvName,
+		skillsAnyBinPathFixHint,
 	)
 }
 

--- a/openclaw/internal/skills/repository.go
+++ b/openclaw/internal/skills/repository.go
@@ -28,6 +28,22 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/deps"
 )
 
+const (
+	skillsPathEnvName      = "PATH"
+	skillsExtraPathEnvName = "TRPC_CLAW_EXTRA_PATH_DIRS"
+
+	missingBinsReasonFormat = "" +
+		"missing bins: %s; searched PATH dirs: %s; fix: move " +
+		"the binary into an existing PATH dir or add its " +
+		"directory to %s"
+	missingAnyBinsReasonFormat = "" +
+		"missing anyBins (need one): %s; searched PATH dirs: %s; " +
+		"fix: install one of these binaries into an existing " +
+		"PATH dir or add its directory to %s"
+
+	emptySkillsSearchDirs = "(empty)"
+)
+
 type SkillConfig struct {
 	Enabled *bool
 	APIKey  string
@@ -555,8 +571,10 @@ func evaluateRequiredBins(bins []string) string {
 		return ""
 	}
 	return fmt.Sprintf(
-		"missing bins: %s",
+		missingBinsReasonFormat,
 		strings.Join(missing, ", "),
+		formatSkillsSearchDirs(),
+		skillsExtraPathEnvName,
 	)
 }
 
@@ -578,9 +596,27 @@ func evaluateRequiredAnyBins(bins []string) string {
 		}
 	}
 	return fmt.Sprintf(
-		"missing anyBins (need one): %s",
+		missingAnyBinsReasonFormat,
 		strings.Join(any, ", "),
+		formatSkillsSearchDirs(),
+		skillsExtraPathEnvName,
 	)
+}
+
+func formatSkillsSearchDirs() string {
+	parts := filepath.SplitList(os.Getenv(skillsPathEnvName))
+	out := make([]string, 0, len(parts))
+	for _, entry := range parts {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		out = append(out, entry)
+	}
+	if len(out) == 0 {
+		return emptySkillsSearchDirs
+	}
+	return strings.Join(out, ", ")
 }
 
 func evaluateRequiredEnv(

--- a/openclaw/internal/skills/repository_test.go
+++ b/openclaw/internal/skills/repository_test.go
@@ -981,9 +981,8 @@ x
 }
 
 func TestListTool_ReturnsDisabledSkillsWithReasons(t *testing.T) {
-	t.Parallel()
-
 	root := t.TempDir()
+	t.Setenv(skillsPathEnvName, "/usr/local/bin:/usr/bin")
 	writeSkill(t, root, "ok", `---
 name: ok
 description: ok
@@ -1021,6 +1020,16 @@ metadata:
 	require.True(t, byName["ok"].Enabled)
 	require.False(t, byName["needsbin"].Enabled)
 	require.Contains(t, byName["needsbin"].Reason, "missing bins")
+	require.Contains(
+		t,
+		byName["needsbin"].Reason,
+		"searched PATH dirs: /usr/local/bin, /usr/bin",
+	)
+	require.Contains(
+		t,
+		byName["needsbin"].Reason,
+		skillsExtraPathEnvName,
+	)
 }
 
 func TestListTool_Declaration(t *testing.T) {

--- a/openclaw/internal/skills/repository_test.go
+++ b/openclaw/internal/skills/repository_test.go
@@ -1028,7 +1028,42 @@ metadata:
 	require.Contains(
 		t,
 		byName["needsbin"].Reason,
-		skillsExtraPathEnvName,
+		skillsBinPathFixHint,
+	)
+}
+
+func TestListTool_ReturnsDisabledSkillsWithEmptySearchDirs(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(skillsPathEnvName, string(os.PathListSeparator))
+	writeSkill(t, root, "needseither", `---
+name: needseither
+description: needs any bin
+metadata:
+  { "openclaw": { "requires": { "anyBins": ["missing_a", "missing_b"] } } }
+---
+
+# needseither
+`)
+
+	repo, err := NewRepository([]string{root})
+	require.NoError(t, err)
+
+	lt := NewListTool(repo)
+	gotAny, err := lt.Call(context.Background(), []byte(`{}`))
+	require.NoError(t, err)
+
+	got, ok := gotAny.(listOutput)
+	require.True(t, ok)
+	require.Len(t, got.Skills, 1)
+	require.Contains(
+		t,
+		got.Skills[0].Reason,
+		"searched PATH dirs: "+emptySkillsSearchDirs,
+	)
+	require.Contains(
+		t,
+		got.Skills[0].Reason,
+		skillsAnyBinPathFixHint,
 	)
 }
 

--- a/openclaw/internal/skills/status.go
+++ b/openclaw/internal/skills/status.go
@@ -21,6 +21,21 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/skill"
 )
 
+const (
+	statusInstallKindPathHint = "path_hint"
+
+	statusInstallIDExtraPath = "path-hint-extra-path-dirs"
+	statusInstallIDMovePath  = "path-hint-existing-path"
+
+	statusInstallLabelExtraPath = "" +
+		"Add the binary directory to TRPC_CLAW_EXTRA_PATH_DIRS " +
+		"in Admin > Config > Runtime Environment"
+	statusInstallLabelMovePath = "" +
+		"Move the binary into one of the existing PATH " +
+		"directories shown in Admin > Config > Runtime " +
+		"Environment"
+)
+
 type StatusRequirements struct {
 	OS      []string `json:"os,omitempty"`
 	Bins    []string `json:"bins,omitempty"`
@@ -151,7 +166,10 @@ func (r *Repository) statusEntryForSummary(
 	entry.Homepage = strings.TrimSpace(meta.Homepage)
 	entry.Requirements = requiredStatus(meta)
 	entry.Missing = missingStatus(meta, r.configKeys, cfg)
-	entry.Install = normalizeStatusInstall(meta.Install)
+	entry.Install = appendRuntimePathInstallHints(
+		entry.Missing,
+		normalizeStatusInstall(meta.Install),
+	)
 	return entry
 }
 
@@ -345,6 +363,53 @@ func normalizeStatusInstall(
 	if len(out) == 0 {
 		return nil
 	}
+	return out
+}
+
+func appendRuntimePathInstallHints(
+	missing StatusRequirements,
+	options []StatusInstallOption,
+) []StatusInstallOption {
+	if len(missingStatusBins(missing)) == 0 {
+		return options
+	}
+	out := append([]StatusInstallOption(nil), options...)
+	if !statusInstallOptionExists(out, statusInstallIDExtraPath) {
+		out = append(out, StatusInstallOption{
+			ID:    statusInstallIDExtraPath,
+			Kind:  statusInstallKindPathHint,
+			Label: statusInstallLabelExtraPath,
+		})
+	}
+	if !statusInstallOptionExists(out, statusInstallIDMovePath) {
+		out = append(out, StatusInstallOption{
+			ID:    statusInstallIDMovePath,
+			Kind:  statusInstallKindPathHint,
+			Label: statusInstallLabelMovePath,
+		})
+	}
+	return out
+}
+
+func statusInstallOptionExists(
+	options []StatusInstallOption,
+	id string,
+) bool {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return false
+	}
+	for _, option := range options {
+		if strings.TrimSpace(option.ID) == id {
+			return true
+		}
+	}
+	return false
+}
+
+func missingStatusBins(missing StatusRequirements) []string {
+	out := append([]string(nil), missing.Bins...)
+	out = append(out, missing.AnyBins...)
 	return out
 }
 

--- a/openclaw/internal/skills/status.go
+++ b/openclaw/internal/skills/status.go
@@ -24,16 +24,15 @@ import (
 const (
 	statusInstallKindPathHint = "path_hint"
 
-	statusInstallIDExtraPath = "path-hint-extra-path-dirs"
-	statusInstallIDMovePath  = "path-hint-existing-path"
+	statusInstallIDRestartPath = "path-hint-restart-with-path"
+	statusInstallIDMovePath    = "path-hint-existing-path"
 
-	statusInstallLabelExtraPath = "" +
-		"Add the binary directory to TRPC_CLAW_EXTRA_PATH_DIRS " +
-		"in Admin > Config > Runtime Environment"
+	statusInstallLabelRestartPath = "" +
+		"Restart openclaw after updating PATH to include " +
+		"the binary directory"
 	statusInstallLabelMovePath = "" +
 		"Move the binary into one of the existing PATH " +
-		"directories shown in Admin > Config > Runtime " +
-		"Environment"
+		"directories"
 )
 
 type StatusRequirements struct {
@@ -374,11 +373,11 @@ func appendRuntimePathInstallHints(
 		return options
 	}
 	out := append([]StatusInstallOption(nil), options...)
-	if !statusInstallOptionExists(out, statusInstallIDExtraPath) {
+	if !statusInstallOptionExists(out, statusInstallIDRestartPath) {
 		out = append(out, StatusInstallOption{
-			ID:    statusInstallIDExtraPath,
+			ID:    statusInstallIDRestartPath,
 			Kind:  statusInstallKindPathHint,
-			Label: statusInstallLabelExtraPath,
+			Label: statusInstallLabelRestartPath,
 		})
 	}
 	if !statusInstallOptionExists(out, statusInstallIDMovePath) {

--- a/openclaw/internal/skills/status_test.go
+++ b/openclaw/internal/skills/status_test.go
@@ -60,7 +60,7 @@ metadata:
 	require.Equal(t, "OPENAI_API_KEY", entry.PrimaryEnv)
 	require.Equal(t, "https://example.com/weather", entry.Homepage)
 	require.Len(t, entry.Install, 2)
-	require.Equal(t, statusInstallIDExtraPath, entry.Install[0].ID)
+	require.Equal(t, statusInstallIDRestartPath, entry.Install[0].ID)
 	require.Equal(t, statusInstallIDMovePath, entry.Install[1].ID)
 }
 
@@ -239,9 +239,9 @@ func TestStatusHelpers_MissingRequirementsAndInstallers(t *testing.T) {
 		t,
 		[]StatusInstallOption{
 			{
-				ID:    statusInstallIDExtraPath,
+				ID:    statusInstallIDRestartPath,
 				Kind:  statusInstallKindPathHint,
-				Label: statusInstallLabelExtraPath,
+				Label: statusInstallLabelRestartPath,
 			},
 			{
 				ID:    statusInstallIDMovePath,
@@ -251,6 +251,24 @@ func TestStatusHelpers_MissingRequirementsAndInstallers(t *testing.T) {
 		},
 		pathHints,
 	)
+
+	existingHints := appendRuntimePathInstallHints(
+		StatusRequirements{
+			AnyBins: []string{"missing-bin"},
+		},
+		[]StatusInstallOption{
+			{
+				ID:   statusInstallIDRestartPath,
+				Kind: statusInstallKindPathHint,
+			},
+			{
+				ID:   statusInstallIDMovePath,
+				Kind: statusInstallKindPathHint,
+			},
+		},
+	)
+	require.Len(t, existingHints, 2)
+	require.False(t, statusInstallOptionExists(existingHints, ""))
 }
 
 func TestStatusHelpers_SourceAndConfigResolution(t *testing.T) {

--- a/openclaw/internal/skills/status_test.go
+++ b/openclaw/internal/skills/status_test.go
@@ -59,6 +59,9 @@ metadata:
 	require.Equal(t, []string{"channels.telegram.token"}, entry.Missing.Config)
 	require.Equal(t, "OPENAI_API_KEY", entry.PrimaryEnv)
 	require.Equal(t, "https://example.com/weather", entry.Homepage)
+	require.Len(t, entry.Install, 2)
+	require.Equal(t, statusInstallIDExtraPath, entry.Install[0].ID)
+	require.Equal(t, statusInstallIDMovePath, entry.Install[1].ID)
 }
 
 func TestBuildStatus_HonorsDisabledConfigAndPrimaryAPIKey(t *testing.T) {
@@ -225,6 +228,29 @@ func TestStatusHelpers_MissingRequirementsAndInstallers(t *testing.T) {
 	)
 	require.Equal(t, []string{"tool"}, options[5].Bins)
 	require.Nil(t, normalizeStatusInstall([]openClawInstallEntry{{Kind: ""}}))
+
+	pathHints := appendRuntimePathInstallHints(
+		StatusRequirements{
+			Bins: []string{"missing-bin"},
+		},
+		nil,
+	)
+	require.Equal(
+		t,
+		[]StatusInstallOption{
+			{
+				ID:    statusInstallIDExtraPath,
+				Kind:  statusInstallKindPathHint,
+				Label: statusInstallLabelExtraPath,
+			},
+			{
+				ID:    statusInstallIDMovePath,
+				Kind:  statusInstallKindPathHint,
+				Label: statusInstallLabelMovePath,
+			},
+		},
+		pathHints,
+	)
 }
 
 func TestStatusHelpers_SourceAndConfigResolution(t *testing.T) {


### PR DESCRIPTION
## Summary
- add read-only runtime diagnostics rendering for admin config fields
- include searched PATH directories and fix guidance in missing-bin skill reasons
- add runtime PATH setup hints to skill status installers

## Why
The current runtime PATH behavior is hard to understand when a binary is installed outside the existing search path. Users can see that a skill is missing a binary, but they cannot see where the runtime searched or what the safe fix is.

## Impact
This makes missing dependency diagnostics actionable without changing runtime execution semantics. Admin pages can surface read-only path diagnostics cleanly, and missing-bin status now points users to either an existing PATH directory or `TRPC_CLAW_EXTRA_PATH_DIRS`.

## Root cause
Dependency checks only reported the missing binary name. They did not expose the searched PATH directories or any structured guidance for how to make a newly installed binary visible to the runtime.

## Validation
- `go test ./admin ./internal/skills`
