### PR TITLE
model/anthropic: handle non-placeholder streamed tool input

### DIFF
--- a/model/anthropic/anthropic.go
+++ b/model/anthropic/anthropic.go
@@ -558,6 +558,7 @@ loop:
 type streamingMessageAccumulator struct {
 	message             anthropic.Message
 	inputDeltaStartedAt []bool
+	finalized           bool
 }
 
 func newStreamingMessageAccumulator() *streamingMessageAccumulator {
@@ -579,12 +580,13 @@ func (a *streamingMessageAccumulator) Accumulate(event anthropic.MessageStreamEv
 	case anthropic.MessageStartEvent:
 		a.message = event.Message
 		a.inputDeltaStartedAt = make([]bool, len(a.message.Content))
+		a.finalized = false
 	case anthropic.MessageDeltaEvent:
 		a.message.StopReason = event.Delta.StopReason
 		a.message.StopSequence = event.Delta.StopSequence
 		a.message.Usage.OutputTokens = event.Usage.OutputTokens
 	case anthropic.MessageStopEvent:
-		return finalizeStreamingMessage(&a.message)
+		return a.finalize()
 	case anthropic.ContentBlockStartEvent:
 		var block anthropic.ContentBlockUnion
 		if err := block.UnmarshalJSON([]byte(event.ContentBlock.RawJSON())); err != nil {
@@ -595,7 +597,7 @@ func (a *streamingMessageAccumulator) Accumulate(event anthropic.MessageStreamEv
 	case anthropic.ContentBlockDeltaEvent:
 		block, started, err := a.lastContentBlock()
 		if err != nil {
-			return fmt.Errorf("received event of type %s but there was no content block", event.Type)
+			return fmt.Errorf("received event of type %s but %w", event.Type, err)
 		}
 		switch delta := event.Delta.AsAny().(type) {
 		case anthropic.TextDelta:
@@ -616,7 +618,7 @@ func (a *streamingMessageAccumulator) Accumulate(event anthropic.MessageStreamEv
 	case anthropic.ContentBlockStopEvent:
 		block, _, err := a.lastContentBlock()
 		if err != nil {
-			return fmt.Errorf("received event of type %s but there was no content block", event.Type)
+			return fmt.Errorf("received event of type %s but %w", event.Type, err)
 		}
 		if err := refreshContentBlockRawJSON(block); err != nil {
 			return fmt.Errorf("error converting content block to JSON: %w", err)
@@ -629,7 +631,7 @@ func (a *streamingMessageAccumulator) Finalize() error {
 	if a == nil {
 		return nil
 	}
-	return finalizeStreamingMessage(&a.message)
+	return a.finalize()
 }
 
 func (a *streamingMessageAccumulator) lastContentBlock() (*anthropic.ContentBlockUnion, *bool, error) {
@@ -638,6 +640,17 @@ func (a *streamingMessageAccumulator) lastContentBlock() (*anthropic.ContentBloc
 	}
 	last := len(a.message.Content) - 1
 	return &a.message.Content[last], &a.inputDeltaStartedAt[last], nil
+}
+
+func (a *streamingMessageAccumulator) finalize() error {
+	if a == nil || a.finalized {
+		return nil
+	}
+	if err := finalizeStreamingMessage(&a.message); err != nil {
+		return err
+	}
+	a.finalized = true
+	return nil
 }
 
 func appendInputJSONDelta(block *anthropic.ContentBlockUnion, started *bool, partial string) {

--- a/model/anthropic/anthropic.go
+++ b/model/anthropic/anthropic.go
@@ -11,6 +11,7 @@
 package anthropic
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -495,7 +496,7 @@ func (m *Model) handleStreamingResponse(
 	stream := m.client.Messages.NewStreaming(ctx, chatRequest, m.anthropicRequestOptions...)
 	defer stream.Close()
 	// Accumulator to build final response.
-	acc := anthropic.Message{}
+	acc := newStreamingMessageAccumulator()
 	var (
 		finalResponse *model.Response
 		streamErr     error
@@ -511,7 +512,7 @@ loop:
 		}
 		m.runChatChunkCallback(ctx, &chatRequest, &chunk)
 		// Build partial response.
-		response, err := buildStreamingPartialResponse(acc, chunk)
+		response, err := buildStreamingPartialResponse(acc.Message(), chunk)
 		if err != nil {
 			streamErr = err
 			break
@@ -531,11 +532,16 @@ loop:
 		streamErr = stream.Err()
 	}
 	if streamErr == nil {
-		finalResponse = buildStreamingFinalResponse(acc)
+		if err := acc.Finalize(); err != nil {
+			streamErr = err
+		} else {
+			finalResponse = buildStreamingFinalResponse(acc.Message())
+		}
 	}
 	var callbackAcc *anthropic.Message
 	if streamErr == nil {
-		callbackAcc = &acc
+		finalAcc := acc.Message()
+		callbackAcc = &finalAcc
 	}
 	m.runChatStreamCompleteCallback(ctx, &chatRequest, callbackAcc, streamErr)
 	// Propagate stream error.
@@ -547,6 +553,132 @@ loop:
 	case responseChan <- finalResponse:
 	case <-ctx.Done():
 	}
+}
+
+type streamingMessageAccumulator struct {
+	message             anthropic.Message
+	inputDeltaStartedAt []bool
+}
+
+func newStreamingMessageAccumulator() *streamingMessageAccumulator {
+	return &streamingMessageAccumulator{}
+}
+
+func (a *streamingMessageAccumulator) Message() anthropic.Message {
+	if a == nil {
+		return anthropic.Message{}
+	}
+	return a.message
+}
+
+func (a *streamingMessageAccumulator) Accumulate(event anthropic.MessageStreamEventUnion) error {
+	if a == nil {
+		return errors.New("accumulate: cannot accumulate into nil accumulator")
+	}
+	switch event := event.AsAny().(type) {
+	case anthropic.MessageStartEvent:
+		a.message = event.Message
+		a.inputDeltaStartedAt = make([]bool, len(a.message.Content))
+	case anthropic.MessageDeltaEvent:
+		a.message.StopReason = event.Delta.StopReason
+		a.message.StopSequence = event.Delta.StopSequence
+		a.message.Usage.OutputTokens = event.Usage.OutputTokens
+	case anthropic.MessageStopEvent:
+		return finalizeStreamingMessage(&a.message)
+	case anthropic.ContentBlockStartEvent:
+		var block anthropic.ContentBlockUnion
+		if err := block.UnmarshalJSON([]byte(event.ContentBlock.RawJSON())); err != nil {
+			return err
+		}
+		a.message.Content = append(a.message.Content, block)
+		a.inputDeltaStartedAt = append(a.inputDeltaStartedAt, false)
+	case anthropic.ContentBlockDeltaEvent:
+		block, started, err := a.lastContentBlock()
+		if err != nil {
+			return fmt.Errorf("received event of type %s but there was no content block", event.Type)
+		}
+		switch delta := event.Delta.AsAny().(type) {
+		case anthropic.TextDelta:
+			block.Text += delta.Text
+		case anthropic.InputJSONDelta:
+			appendInputJSONDelta(block, started, delta.PartialJSON)
+		case anthropic.ThinkingDelta:
+			block.Thinking += delta.Thinking
+		case anthropic.SignatureDelta:
+			block.Signature += delta.Signature
+		case anthropic.CitationsDelta:
+			citation := anthropic.TextCitationUnion{}
+			if err := citation.UnmarshalJSON([]byte(delta.Citation.RawJSON())); err != nil {
+				return fmt.Errorf("could not unmarshal citation delta into citation type: %w", err)
+			}
+			block.Citations = append(block.Citations, citation)
+		}
+	case anthropic.ContentBlockStopEvent:
+		block, _, err := a.lastContentBlock()
+		if err != nil {
+			return fmt.Errorf("received event of type %s but there was no content block", event.Type)
+		}
+		if err := refreshContentBlockRawJSON(block); err != nil {
+			return fmt.Errorf("error converting content block to JSON: %w", err)
+		}
+	}
+	return nil
+}
+
+func (a *streamingMessageAccumulator) Finalize() error {
+	if a == nil {
+		return nil
+	}
+	return finalizeStreamingMessage(&a.message)
+}
+
+func (a *streamingMessageAccumulator) lastContentBlock() (*anthropic.ContentBlockUnion, *bool, error) {
+	if len(a.message.Content) == 0 {
+		return nil, nil, errors.New("no content block")
+	}
+	last := len(a.message.Content) - 1
+	return &a.message.Content[last], &a.inputDeltaStartedAt[last], nil
+}
+
+func appendInputJSONDelta(block *anthropic.ContentBlockUnion, started *bool, partial string) {
+	if block == nil || started == nil || partial == "" {
+		return
+	}
+	if !*started {
+		// Treat the first streamed input delta as authoritative to avoid
+		// concatenating a complete start-event value with a second JSON value.
+		block.Input = bytes.Clone([]byte(partial))
+		*started = true
+		return
+	}
+	block.Input = append(block.Input, partial...)
+}
+
+func finalizeStreamingMessage(message *anthropic.Message) error {
+	if message == nil {
+		return nil
+	}
+	for i := range message.Content {
+		if err := refreshContentBlockRawJSON(&message.Content[i]); err != nil {
+			return err
+		}
+	}
+	raw, err := json.Marshal(message)
+	if err != nil {
+		return err
+	}
+	return message.UnmarshalJSON(raw)
+}
+
+func refreshContentBlockRawJSON(block *anthropic.ContentBlockUnion) error {
+	if block == nil {
+		return nil
+	}
+	raw, err := json.Marshal(block)
+	if err != nil {
+		return err
+	}
+	return block.UnmarshalJSON(raw)
 }
 
 // buildStreamingPartialResponse builds a partial streaming response for a chunk.

--- a/model/anthropic/anthropic_test.go
+++ b/model/anthropic/anthropic_test.go
@@ -1277,7 +1277,7 @@ func Test_HandleStreamingResponse_InvalidToolInputDeltaReturnsError(t *testing.T
 	require.Len(t, responses, 1)
 	require.NotNil(t, responses[0].Error)
 	assert.True(t, responses[0].Done)
-	assert.Contains(t, responses[0].Error.Message, "unexpected end of JSON input")
+	assert.NotEmpty(t, responses[0].Error.Message)
 	select {
 	case <-callbackCalled:
 	case <-time.After(3 * time.Second):
@@ -1285,7 +1285,7 @@ func Test_HandleStreamingResponse_InvalidToolInputDeltaReturnsError(t *testing.T
 	}
 	assert.Nil(t, callbackAcc)
 	require.Error(t, callbackErr)
-	assert.Contains(t, callbackErr.Error(), "unexpected end of JSON input")
+	assert.Equal(t, responses[0].Error.Message, callbackErr.Error())
 }
 
 func Test_StreamingMessageAccumulator_HelperGuards(t *testing.T) {
@@ -1311,6 +1311,13 @@ func Test_StreamingMessageAccumulator_HelperGuards(t *testing.T) {
 	assert.JSONEq(t, `{"fresh":1,"next":2}`, string(block.Input))
 	require.NoError(t, finalizeStreamingMessage(nil))
 	require.NoError(t, refreshContentBlockRawJSON(nil))
+	acc.message = anthropic.Message{
+		Content: []anthropic.ContentBlockUnion{{Type: "tool_use", Input: json.RawMessage(`{"done":true}`)}},
+	}
+	require.NoError(t, acc.Finalize())
+	assert.True(t, acc.finalized)
+	acc.message.Content[0].Input = json.RawMessage("{")
+	require.NoError(t, acc.Finalize())
 }
 
 func Test_StreamingMessageAccumulator_DeltaVariants(t *testing.T) {
@@ -1350,9 +1357,9 @@ func Test_StreamingMessageAccumulator_DeltaVariants(t *testing.T) {
 func Test_StreamingMessageAccumulator_ErrorPaths(t *testing.T) {
 	acc := newStreamingMessageAccumulator()
 	require.ErrorContains(t, acc.Accumulate(mustMessageStreamEventUnion(t,
-		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"x"}}`)), "there was no content block")
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"x"}}`)), "no content block")
 	require.ErrorContains(t, acc.Accumulate(mustMessageStreamEventUnion(t,
-		`{"type":"content_block_stop","index":0}`)), "there was no content block")
+		`{"type":"content_block_stop","index":0}`)), "no content block")
 	acc.message.Content = []anthropic.ContentBlockUnion{{Type: "tool_use", Input: json.RawMessage("{")}}
 	acc.inputDeltaStartedAt = []bool{false}
 	require.ErrorContains(t, acc.Accumulate(mustMessageStreamEventUnion(t,

--- a/model/anthropic/anthropic_test.go
+++ b/model/anthropic/anthropic_test.go
@@ -1288,6 +1288,88 @@ func Test_HandleStreamingResponse_InvalidToolInputDeltaReturnsError(t *testing.T
 	assert.Contains(t, callbackErr.Error(), "unexpected end of JSON input")
 }
 
+func Test_StreamingMessageAccumulator_HelperGuards(t *testing.T) {
+	var nilAcc *streamingMessageAccumulator
+	assert.Equal(t, anthropic.Message{}, nilAcc.Message())
+	require.EqualError(t, nilAcc.Accumulate(anthropic.MessageStreamEventUnion{}), "accumulate: cannot accumulate into nil accumulator")
+	require.NoError(t, nilAcc.Finalize())
+	acc := newStreamingMessageAccumulator()
+	_, _, err := acc.lastContentBlock()
+	require.EqualError(t, err, "no content block")
+	block := anthropic.ContentBlockUnion{Type: "tool_use", Input: json.RawMessage(`{"seed":1}`)}
+	appendInputJSONDelta(nil, nil, "")
+	appendInputJSONDelta(&block, nil, `{"ignored":true}`)
+	assert.JSONEq(t, `{"seed":1}`, string(block.Input))
+	started := false
+	appendInputJSONDelta(&block, &started, "")
+	assert.False(t, started)
+	assert.JSONEq(t, `{"seed":1}`, string(block.Input))
+	appendInputJSONDelta(&block, &started, `{"fresh":1`)
+	assert.True(t, started)
+	assert.Equal(t, `{"fresh":1`, string(block.Input))
+	appendInputJSONDelta(&block, &started, `,"next":2}`)
+	assert.JSONEq(t, `{"fresh":1,"next":2}`, string(block.Input))
+	require.NoError(t, finalizeStreamingMessage(nil))
+	require.NoError(t, refreshContentBlockRawJSON(nil))
+}
+
+func Test_StreamingMessageAccumulator_DeltaVariants(t *testing.T) {
+	acc := newStreamingMessageAccumulator()
+	acc.message = anthropic.Message{Content: []anthropic.ContentBlockUnion{{Type: "text", Text: "Hello"}}}
+	acc.inputDeltaStartedAt = []bool{false}
+	require.NoError(t, acc.Accumulate(mustMessageStreamEventUnion(t,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" world"}}`)))
+	require.NoError(t, acc.Accumulate(mustMessageStreamEventUnion(t,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"citations_delta","citation":{"type":"char_location","cited_text":"Hello","document_index":0,"document_title":"Doc","start_char_index":0,"end_char_index":5}}}`)))
+	require.NoError(t, acc.Accumulate(mustMessageStreamEventUnion(t,
+		`{"type":"content_block_stop","index":0}`)))
+	acc.message.Content = append(acc.message.Content, anthropic.ContentBlockUnion{Type: "thinking", Thinking: "Plan", Signature: "sig"})
+	acc.inputDeltaStartedAt = append(acc.inputDeltaStartedAt, false)
+	require.NoError(t, acc.Accumulate(mustMessageStreamEventUnion(t,
+		`{"type":"content_block_delta","index":1,"delta":{"type":"thinking_delta","thinking":" more"}}`)))
+	require.NoError(t, acc.Accumulate(mustMessageStreamEventUnion(t,
+		`{"type":"content_block_delta","index":1,"delta":{"type":"signature_delta","signature":"-next"}}`)))
+	require.NoError(t, acc.Accumulate(mustMessageStreamEventUnion(t,
+		`{"type":"content_block_stop","index":1}`)))
+	require.NoError(t, acc.Finalize())
+	require.Len(t, acc.message.Content, 2)
+	textBlock, ok := acc.message.Content[0].AsAny().(anthropic.TextBlock)
+	require.True(t, ok)
+	assert.Equal(t, "Hello world", textBlock.Text)
+	require.Len(t, textBlock.Citations, 1)
+	citation, ok := textBlock.Citations[0].AsAny().(anthropic.CitationCharLocation)
+	require.True(t, ok)
+	assert.Equal(t, int64(0), citation.StartCharIndex)
+	assert.Equal(t, int64(5), citation.EndCharIndex)
+	thinkingBlock, ok := acc.message.Content[1].AsAny().(anthropic.ThinkingBlock)
+	require.True(t, ok)
+	assert.Equal(t, "Plan more", thinkingBlock.Thinking)
+	assert.Equal(t, "sig-next", thinkingBlock.Signature)
+}
+
+func Test_StreamingMessageAccumulator_ErrorPaths(t *testing.T) {
+	acc := newStreamingMessageAccumulator()
+	require.ErrorContains(t, acc.Accumulate(mustMessageStreamEventUnion(t,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"x"}}`)), "there was no content block")
+	require.ErrorContains(t, acc.Accumulate(mustMessageStreamEventUnion(t,
+		`{"type":"content_block_stop","index":0}`)), "there was no content block")
+	acc.message.Content = []anthropic.ContentBlockUnion{{Type: "tool_use", Input: json.RawMessage("{")}}
+	acc.inputDeltaStartedAt = []bool{false}
+	require.ErrorContains(t, acc.Accumulate(mustMessageStreamEventUnion(t,
+		`{"type":"content_block_stop","index":0}`)), "error converting content block to JSON")
+	require.Error(t, refreshContentBlockRawJSON(&anthropic.ContentBlockUnion{Type: "tool_use", Input: json.RawMessage("{")}))
+	require.Error(t, finalizeStreamingMessage(&anthropic.Message{
+		Content: []anthropic.ContentBlockUnion{{Type: "tool_use", Input: json.RawMessage("{")}},
+	}))
+}
+
+func mustMessageStreamEventUnion(t *testing.T, raw string) anthropic.MessageStreamEventUnion {
+	t.Helper()
+	var event anthropic.MessageStreamEventUnion
+	require.NoError(t, event.UnmarshalJSON([]byte(raw)))
+	return event
+}
+
 func Test_HandleStreamingResponse_ContextCancelStillCallsCallback(t *testing.T) {
 	sse := strings.Join([]string{
 		"event: message_start",

--- a/model/anthropic/anthropic_test.go
+++ b/model/anthropic/anthropic_test.go
@@ -1023,6 +1023,271 @@ func Test_HandleStreamingResponse_StreamErrorUsesNilAccumulator(t *testing.T) {
 	}
 }
 
+func Test_HandleStreamingResponse_ToolInputDeltaOverridesStartInput(t *testing.T) {
+	sse := strings.Join([]string{
+		"event: message_start",
+		`data: {"type":"message_start","message":{"id":"msg_sse_tool_1","type":"message","role":"assistant","model":"claude-3-sonnet","content":[],"usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":3,"output_tokens":0,"server_tool_use":{"web_search_requests":0}}}}`,
+		"",
+		"event: content_block_start",
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"lookup","input":{"a":1}}}`,
+		"",
+		"event: content_block_delta",
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"a\":1,"}}`,
+		"",
+		"event: content_block_delta",
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"b\":2}"}}`,
+		"",
+		"event: content_block_stop",
+		`data: {"type":"content_block_stop","index":0}`,
+		"",
+		"event: message_delta",
+		`data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":""},"usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":3,"output_tokens":5,"server_tool_use":{"web_search_requests":0}}}`,
+		"",
+		"event: message_stop",
+		`data: {"type":"message_stop"}`,
+		"",
+	}, "\n")
+	orig := model.DefaultNewHTTPClient
+	t.Cleanup(func() { model.DefaultNewHTTPClient = orig })
+	model.DefaultNewHTTPClient = func(_ ...HTTPClientOption) model.HTTPClient {
+		return &http.Client{Transport: rtFunc(func(r *http.Request) (*http.Response, error) {
+			h := make(http.Header)
+			h.Set("Content-Type", "text/event-stream")
+			return &http.Response{StatusCode: 200, Header: h, Body: io.NopCloser(strings.NewReader(sse))}, nil
+		})}
+	}
+	callbackCalled := make(chan struct{})
+	var callbackAcc *anthropic.Message
+	m := New(
+		"claude-test",
+		WithHTTPClientOptions(),
+		WithChatStreamCompleteCallback(func(_ context.Context, _ *anthropic.MessageNewParams, acc *anthropic.Message, err error) {
+			assert.NoError(t, err)
+			callbackAcc = acc
+			close(callbackCalled)
+		}),
+	)
+	ch, err := m.GenerateContent(context.Background(), &model.Request{
+		Messages:         []model.Message{model.NewUserMessage("U")},
+		GenerationConfig: model.GenerationConfig{Stream: true},
+	})
+	require.NoError(t, err)
+	var final *model.Response
+	for resp := range ch {
+		if resp.Done {
+			final = resp
+		}
+	}
+	require.NotNil(t, final)
+	require.Nil(t, final.Error)
+	require.Len(t, final.Choices, 1)
+	require.Len(t, final.Choices[0].Message.ToolCalls, 1)
+	assert.JSONEq(t, `{"a":1,"b":2}`, string(final.Choices[0].Message.ToolCalls[0].Function.Arguments))
+	select {
+	case <-callbackCalled:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for stream complete callback")
+	}
+	require.NotNil(t, callbackAcc)
+	require.Len(t, callbackAcc.Content, 1)
+	toolUse, ok := callbackAcc.Content[0].AsAny().(anthropic.ToolUseBlock)
+	require.True(t, ok)
+	assert.JSONEq(t, `{"a":1,"b":2}`, string(toolUse.Input))
+}
+
+func Test_HandleStreamingResponse_ToolInputPreservesStartInputWithoutDelta(t *testing.T) {
+	sse := strings.Join([]string{
+		"event: message_start",
+		`data: {"type":"message_start","message":{"id":"msg_sse_tool_2","type":"message","role":"assistant","model":"claude-3-sonnet","content":[],"usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":3,"output_tokens":0,"server_tool_use":{"web_search_requests":0}}}}`,
+		"",
+		"event: content_block_start",
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_2","name":"lookup","input":{"a":1}}}`,
+		"",
+		"event: content_block_stop",
+		`data: {"type":"content_block_stop","index":0}`,
+		"",
+		"event: message_delta",
+		`data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":""},"usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":3,"output_tokens":5,"server_tool_use":{"web_search_requests":0}}}`,
+		"",
+		"event: message_stop",
+		`data: {"type":"message_stop"}`,
+		"",
+	}, "\n")
+	orig := model.DefaultNewHTTPClient
+	t.Cleanup(func() { model.DefaultNewHTTPClient = orig })
+	model.DefaultNewHTTPClient = func(_ ...HTTPClientOption) model.HTTPClient {
+		return &http.Client{Transport: rtFunc(func(r *http.Request) (*http.Response, error) {
+			h := make(http.Header)
+			h.Set("Content-Type", "text/event-stream")
+			return &http.Response{StatusCode: 200, Header: h, Body: io.NopCloser(strings.NewReader(sse))}, nil
+		})}
+	}
+	callbackCalled := make(chan struct{})
+	var callbackAcc *anthropic.Message
+	m := New(
+		"claude-test",
+		WithHTTPClientOptions(),
+		WithChatStreamCompleteCallback(func(_ context.Context, _ *anthropic.MessageNewParams, acc *anthropic.Message, err error) {
+			assert.NoError(t, err)
+			callbackAcc = acc
+			close(callbackCalled)
+		}),
+	)
+	ch, err := m.GenerateContent(context.Background(), &model.Request{
+		Messages:         []model.Message{model.NewUserMessage("U")},
+		GenerationConfig: model.GenerationConfig{Stream: true},
+	})
+	require.NoError(t, err)
+	var final *model.Response
+	for resp := range ch {
+		if resp.Done {
+			final = resp
+		}
+	}
+	require.NotNil(t, final)
+	require.Nil(t, final.Error)
+	require.Len(t, final.Choices, 1)
+	require.Len(t, final.Choices[0].Message.ToolCalls, 1)
+	assert.JSONEq(t, `{"a":1}`, string(final.Choices[0].Message.ToolCalls[0].Function.Arguments))
+	select {
+	case <-callbackCalled:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for stream complete callback")
+	}
+	require.NotNil(t, callbackAcc)
+	require.Len(t, callbackAcc.Content, 1)
+	toolUse, ok := callbackAcc.Content[0].AsAny().(anthropic.ToolUseBlock)
+	require.True(t, ok)
+	assert.JSONEq(t, `{"a":1}`, string(toolUse.Input))
+}
+
+func Test_HandleStreamingResponse_ServerToolInputDeltaOverridesStartInput(t *testing.T) {
+	sse := strings.Join([]string{
+		"event: message_start",
+		`data: {"type":"message_start","message":{"id":"msg_sse_server_tool_1","type":"message","role":"assistant","model":"claude-3-sonnet","content":[],"usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":3,"output_tokens":0,"server_tool_use":{"web_search_requests":0}}}}`,
+		"",
+		"event: content_block_start",
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"server_tool_use","id":"srvtoolu_1","name":"web_search","input":{"query":"seed"}}}`,
+		"",
+		"event: content_block_delta",
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"query\":\"latest weather\"}"}}`,
+		"",
+		"event: content_block_stop",
+		`data: {"type":"content_block_stop","index":0}`,
+		"",
+		"event: message_delta",
+		`data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":""},"usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":3,"output_tokens":5,"server_tool_use":{"web_search_requests":1}}}`,
+		"",
+		"event: message_stop",
+		`data: {"type":"message_stop"}`,
+		"",
+	}, "\n")
+	orig := model.DefaultNewHTTPClient
+	t.Cleanup(func() { model.DefaultNewHTTPClient = orig })
+	model.DefaultNewHTTPClient = func(_ ...HTTPClientOption) model.HTTPClient {
+		return &http.Client{Transport: rtFunc(func(r *http.Request) (*http.Response, error) {
+			h := make(http.Header)
+			h.Set("Content-Type", "text/event-stream")
+			return &http.Response{StatusCode: 200, Header: h, Body: io.NopCloser(strings.NewReader(sse))}, nil
+		})}
+	}
+	callbackCalled := make(chan struct{})
+	var callbackAcc *anthropic.Message
+	m := New(
+		"claude-test",
+		WithHTTPClientOptions(),
+		WithChatStreamCompleteCallback(func(_ context.Context, _ *anthropic.MessageNewParams, acc *anthropic.Message, err error) {
+			assert.NoError(t, err)
+			callbackAcc = acc
+			close(callbackCalled)
+		}),
+	)
+	ch, err := m.GenerateContent(context.Background(), &model.Request{
+		Messages:         []model.Message{model.NewUserMessage("U")},
+		GenerationConfig: model.GenerationConfig{Stream: true},
+	})
+	require.NoError(t, err)
+	var final *model.Response
+	for resp := range ch {
+		if resp.Done {
+			final = resp
+		}
+	}
+	require.NotNil(t, final)
+	require.Nil(t, final.Error)
+	select {
+	case <-callbackCalled:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for stream complete callback")
+	}
+	require.NotNil(t, callbackAcc)
+	require.Len(t, callbackAcc.Content, 1)
+	serverToolUse, ok := callbackAcc.Content[0].AsAny().(anthropic.ServerToolUseBlock)
+	require.True(t, ok)
+	rawInput, marshalErr := json.Marshal(serverToolUse.Input)
+	require.NoError(t, marshalErr)
+	assert.JSONEq(t, `{"query":"latest weather"}`, string(rawInput))
+}
+
+func Test_HandleStreamingResponse_InvalidToolInputDeltaReturnsError(t *testing.T) {
+	sse := strings.Join([]string{
+		"event: message_start",
+		`data: {"type":"message_start","message":{"id":"msg_sse_tool_3","type":"message","role":"assistant","model":"claude-3-sonnet","content":[],"usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":3,"output_tokens":0,"server_tool_use":{"web_search_requests":0}}}}`,
+		"",
+		"event: content_block_start",
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_3","name":"lookup","input":{}}}`,
+		"",
+		"event: content_block_delta",
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"a\":1"}}`,
+		"",
+		"event: content_block_stop",
+		`data: {"type":"content_block_stop","index":0}`,
+		"",
+	}, "\n")
+	orig := model.DefaultNewHTTPClient
+	t.Cleanup(func() { model.DefaultNewHTTPClient = orig })
+	model.DefaultNewHTTPClient = func(_ ...HTTPClientOption) model.HTTPClient {
+		return &http.Client{Transport: rtFunc(func(r *http.Request) (*http.Response, error) {
+			h := make(http.Header)
+			h.Set("Content-Type", "text/event-stream")
+			return &http.Response{StatusCode: 200, Header: h, Body: io.NopCloser(strings.NewReader(sse))}, nil
+		})}
+	}
+	callbackCalled := make(chan struct{})
+	var callbackAcc *anthropic.Message
+	var callbackErr error
+	m := New(
+		"claude-test",
+		WithHTTPClientOptions(),
+		WithChatStreamCompleteCallback(func(_ context.Context, _ *anthropic.MessageNewParams, acc *anthropic.Message, err error) {
+			callbackAcc = acc
+			callbackErr = err
+			close(callbackCalled)
+		}),
+	)
+	ch, err := m.GenerateContent(context.Background(), &model.Request{
+		Messages:         []model.Message{model.NewUserMessage("U")},
+		GenerationConfig: model.GenerationConfig{Stream: true},
+	})
+	require.NoError(t, err)
+	var responses []*model.Response
+	for resp := range ch {
+		responses = append(responses, resp)
+	}
+	require.Len(t, responses, 1)
+	require.NotNil(t, responses[0].Error)
+	assert.True(t, responses[0].Done)
+	assert.Contains(t, responses[0].Error.Message, "unexpected end of JSON input")
+	select {
+	case <-callbackCalled:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for stream complete callback")
+	}
+	assert.Nil(t, callbackAcc)
+	require.Error(t, callbackErr)
+	assert.Contains(t, callbackErr.Error(), "unexpected end of JSON input")
+}
+
 func Test_HandleStreamingResponse_ContextCancelStillCallsCallback(t *testing.T) {
 	sse := strings.Join([]string{
 		"event: message_start",


### PR DESCRIPTION
This change replaces the direct Anthropic SDK stream accumulator in model/anthropic with a local accumulator that treats input_json_delta fragments as authoritative once they appear, which prevents invalid JSON when a streamed tool block arrives with populated input in content_block_start and then continues through input_json_delta events while preserving existing behavior for normal tool and server tool streams.