### PR TITLE
openclaw: add configurable skill tool profiles

### DIFF
--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -261,6 +261,14 @@ func buildRequestProcessorsWithAgent(a *LLMAgent, options *Options) []flow.Reque
 	// deciding on tool calls.
 	skillFlags := mustResolveSkillToolFlags(options)
 	var skillsOpts []processor.SkillsRequestProcessorOption
+	if options.skillsCapabilityGuidance != nil {
+		skillsOpts = append(
+			skillsOpts,
+			processor.WithSkillsCapabilityGuidance(
+				*options.skillsCapabilityGuidance,
+			),
+		)
+	}
 	if options.skillsToolingGuidance != nil {
 		skillsOpts = append(
 			skillsOpts,
@@ -278,6 +286,9 @@ func buildRequestProcessorsWithAgent(a *LLMAgent, options *Options) []flow.Reque
 		processor.WithSkillToolFlags(skillFlags),
 		processor.WithSkillToolFlagsResolver(
 			a.skillToolFlagsForInvocation,
+		),
+		processor.WithSkillsDirectoryHints(
+			options.skillsDirectoryHints,
 		),
 	)
 	if options.MaxLoadedSkills > 0 {
@@ -420,6 +431,9 @@ func appendSkillsToolResultProcessor(a *LLMAgent, options *Options, requestProce
 			),
 			processor.WithSkillsToolResultLoadMode(
 				options.SkillLoadMode,
+			),
+			processor.WithSkillsToolResultDirectoryHints(
+				options.skillsDirectoryHints,
 			),
 			processor.WithSkipSkillsFallbackOnSessionSummary(
 				options.SkipSkillsFallbackOnSessionSummary,

--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -698,9 +698,18 @@ func appendSkillToolsWithRepoAndFlags(
 		return allTools
 	}
 	if skillFlags.Load {
+		loadOpts := []toolskill.LoadToolOption{}
+		if options.skillLoadToolDescription != nil {
+			loadOpts = append(
+				loadOpts,
+				toolskill.WithLoadToolDescription(
+					*options.skillLoadToolDescription,
+				),
+			)
+		}
 		allTools = append(
 			allTools,
-			toolskill.NewLoadTool(repo),
+			toolskill.NewLoadTool(repo, loadOpts...),
 		)
 	}
 	if skillFlags.SelectDocs {

--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -709,7 +709,10 @@ func appendSkillToolsWithRepoAndFlags(
 		}
 		allTools = append(
 			allTools,
-			toolskill.NewLoadTool(repo, loadOpts...),
+			toolskill.NewLoadToolWithOptions(
+				repo,
+				loadOpts...,
+			),
 		)
 	}
 	if skillFlags.SelectDocs {

--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -817,8 +817,8 @@ func appendWorkspaceExecTool(
 	return appendWorkspaceExecToolWithExecutor(
 		allTools,
 		exec,
-		codeExecutorSupportsWorkspaceExec(exec),
-		codeExecutorSupportsWorkspaceExecSessions(exec),
+		executorSupportsWorkspaceExec(options),
+		executorSupportsWorkspaceExecSessions(options),
 		reg,
 		inv,
 	)
@@ -975,7 +975,7 @@ func codeExecutorSupportsInteractive(exec codeexecutor.CodeExecutor) bool {
 // not fall back to the local engine because that would silently move
 // commands onto the agent host instead of the configured executor.
 func executorSupportsWorkspaceExec(options *Options) bool {
-	if options == nil {
+	if !workspaceExecSurfaceEnabled(options) {
 		return false
 	}
 	return codeExecutorSupportsWorkspaceExec(options.codeExecutor)
@@ -999,10 +999,20 @@ func codeExecutorSupportsWorkspaceExec(exec codeexecutor.CodeExecutor) bool {
 // executorSupportsWorkspaceExecSessions reports whether workspace_exec can
 // expose interactive session helpers such as workspace_write_stdin.
 func executorSupportsWorkspaceExecSessions(options *Options) bool {
-	if options == nil {
+	if !workspaceExecSurfaceEnabled(options) {
 		return false
 	}
 	return codeExecutorSupportsWorkspaceExecSessions(options.codeExecutor)
+}
+
+func workspaceExecSurfaceEnabled(options *Options) bool {
+	if options == nil {
+		return false
+	}
+	if options.workspaceExecSurfaceEnabled == nil {
+		return true
+	}
+	return *options.workspaceExecSurfaceEnabled
 }
 
 func codeExecutorSupportsWorkspaceExecSessions(

--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -269,6 +269,14 @@ func buildRequestProcessorsWithAgent(a *LLMAgent, options *Options) []flow.Reque
 			),
 		)
 	}
+	if options.skillsProtocolGuidance != nil {
+		skillsOpts = append(
+			skillsOpts,
+			processor.WithSkillsProtocolGuidance(
+				*options.skillsProtocolGuidance,
+			),
+		)
+	}
 	if options.skillsToolingGuidance != nil {
 		skillsOpts = append(
 			skillsOpts,
@@ -289,6 +297,9 @@ func buildRequestProcessorsWithAgent(a *LLMAgent, options *Options) []flow.Reque
 		),
 		processor.WithSkillsDirectoryHints(
 			options.skillsDirectoryHints,
+		),
+		processor.WithSkillsFilePathHints(
+			options.skillsFilePathHints,
 		),
 	)
 	if options.MaxLoadedSkills > 0 {
@@ -434,6 +445,9 @@ func appendSkillsToolResultProcessor(a *LLMAgent, options *Options, requestProce
 			),
 			processor.WithSkillsToolResultDirectoryHints(
 				options.skillsDirectoryHints,
+			),
+			processor.WithSkillsToolResultFilePathHints(
+				options.skillsFilePathHints,
 			),
 			processor.WithSkipSkillsFallbackOnSessionSummary(
 				options.SkipSkillsFallbackOnSessionSummary,

--- a/agent/llmagent/llm_agent_skill_test.go
+++ b/agent/llmagent/llm_agent_skill_test.go
@@ -866,6 +866,45 @@ func TestLLMAgent_WithSkillsDirectoryHints_WiresPrompt(t *testing.T) {
 	require.Contains(t, sys, "(dir: [s1]/echoer)")
 }
 
+func TestLLMAgent_WithSkillsFilePathHints_WiresPrompt(t *testing.T) {
+	root := createTestSkill(t)
+	repo, err := skill.NewFSRepository(root)
+	require.NoError(t, err)
+
+	opts := &Options{}
+	WithSkills(repo)(opts)
+	WithSkillsFilePathHints(true)(opts)
+	WithSkillToolProfile(SkillToolProfileKnowledgeOnly)(opts)
+	WithSkillsCapabilityGuidance("")(opts)
+	WithSkillsToolingGuidance("")(opts)
+
+	procs := buildRequestProcessors("tester", opts)
+	inv := &agent.Invocation{
+		InvocationID: "inv1",
+		AgentName:    "tester",
+		Message:      model.NewUserMessage("u"),
+		Session:      &session.Session{},
+	}
+	req := &model.Request{}
+	for _, p := range procs {
+		p.ProcessRequest(context.Background(), inv, req, nil)
+	}
+
+	var sys string
+	for _, msg := range req.Messages {
+		if msg.Role != model.RoleSystem {
+			continue
+		}
+		if strings.Contains(msg.Content, skillsOverviewHeader) {
+			sys = msg.Content
+			break
+		}
+	}
+	require.NotEmpty(t, sys)
+	require.Contains(t, sys, skillRootsHeader)
+	require.Contains(t, sys, "(file: [s1]/echoer/"+skill.SkillFile+")")
+}
+
 func TestLLMAgent_WithSkillsCapabilityGuidance_WiresPrompt(t *testing.T) {
 	root := createTestSkill(t)
 	repo, err := skill.NewFSRepository(root)
@@ -906,6 +945,50 @@ func TestLLMAgent_WithSkillsCapabilityGuidance_WiresPrompt(t *testing.T) {
 		sys,
 		"Built-in skill execution tools are unavailable",
 	)
+}
+
+func TestLLMAgent_WithSkillsProtocolGuidance_WiresPrompt(t *testing.T) {
+	root := createTestSkill(t)
+	repo, err := skill.NewFSRepository(root)
+	require.NoError(t, err)
+
+	opts := &Options{}
+	WithSkills(repo)(opts)
+	WithSkillToolProfile(SkillToolProfileKnowledgeOnly)(opts)
+	WithSkillsProtocolGuidance(
+		"Use the matching skill before answering.",
+	)(opts)
+
+	procs := buildRequestProcessors("tester", opts)
+	inv := &agent.Invocation{
+		InvocationID: "inv1",
+		AgentName:    "tester",
+		Message:      model.NewUserMessage("u"),
+		Session:      &session.Session{},
+	}
+	req := &model.Request{}
+	for _, p := range procs {
+		p.ProcessRequest(context.Background(), inv, req, nil)
+	}
+
+	var sys string
+	for _, msg := range req.Messages {
+		if msg.Role != model.RoleSystem {
+			continue
+		}
+		if strings.Contains(msg.Content, skillsOverviewHeader) {
+			sys = msg.Content
+			break
+		}
+	}
+	require.NotEmpty(t, sys)
+	require.Contains(
+		t,
+		sys,
+		"Use the matching skill before answering.",
+	)
+	require.NotContains(t, sys, skillsCapabilityHeader)
+	require.NotContains(t, sys, skillsToolingGuidanceHeader)
 }
 
 func TestLLMAgent_WithAllowedSkillTools_LoadOnly_WiresPrompt(

--- a/agent/llmagent/llm_agent_skill_test.go
+++ b/agent/llmagent/llm_agent_skill_test.go
@@ -143,6 +143,26 @@ func TestLLMAgent_WorkspaceExecSessionToolsRegisteredForInteractiveExecutor(
 	require.True(t, names["workspace_kill_session"])
 }
 
+func TestLLMAgent_WorkspaceExecSurfaceDisabledForExplicitExecutor(
+	t *testing.T,
+) {
+	a := New(
+		"tester",
+		WithCodeExecutor(&interactiveStubExec{}),
+		WithWorkspaceExecSurfaceEnabled(false),
+	)
+	names := make(map[string]bool)
+	for _, tl := range a.Tools() {
+		if d := tl.Declaration(); d != nil {
+			names[d.Name] = true
+		}
+	}
+
+	require.False(t, names["workspace_exec"])
+	require.False(t, names["workspace_write_stdin"])
+	require.False(t, names["workspace_kill_session"])
+}
+
 func TestLLMAgent_WorkspaceExecDeclarationOmitsSessionFieldsForNonInteractiveExecutor(
 	t *testing.T,
 ) {
@@ -1577,6 +1597,14 @@ func TestExecutorSupportsWorkspaceExec(t *testing.T) {
 	}
 }
 
+func TestExecutorSupportsWorkspaceExecDisabledByOption(t *testing.T) {
+	opts := &Options{
+		codeExecutor: &stubExec{},
+	}
+	WithWorkspaceExecSurfaceEnabled(false)(opts)
+	require.False(t, executorSupportsWorkspaceExec(opts))
+}
+
 func TestExecutorSupportsWorkspaceExecSessions(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -1615,6 +1643,16 @@ func TestExecutorSupportsWorkspaceExecSessions(t *testing.T) {
 			require.Equal(t, tt.want, executorSupportsWorkspaceExecSessions(opts))
 		})
 	}
+}
+
+func TestExecutorSupportsWorkspaceExecSessionsDisabledByOption(
+	t *testing.T,
+) {
+	opts := &Options{
+		codeExecutor: &interactiveStubExec{},
+	}
+	WithWorkspaceExecSurfaceEnabled(false)(opts)
+	require.False(t, executorSupportsWorkspaceExecSessions(opts))
 }
 
 func TestLLMAgent_GuidanceOmitsExecForNonInteractiveExecutor(t *testing.T) {
@@ -1750,6 +1788,27 @@ func TestLLMAgent_WorkspaceExecGuidanceWithoutSkillsRepo(t *testing.T) {
 	require.NotContains(t, sys, "skills/")
 	require.NotContains(t, sys, "workspace_write_stdin")
 	require.NotContains(t, sys, skillsOverviewHeader)
+}
+
+func TestLLMAgent_WorkspaceExecGuidanceDisabledByOption(t *testing.T) {
+	opts := &Options{}
+	WithCodeExecutor(&interactiveStubExec{})(opts)
+	WithWorkspaceExecSurfaceEnabled(false)(opts)
+
+	procs := buildRequestProcessors("tester", opts)
+	inv := &agent.Invocation{
+		InvocationID: "inv1",
+		AgentName:    "tester",
+		Message:      model.NewUserMessage("u"),
+		Session:      &session.Session{},
+	}
+	req := &model.Request{}
+	for _, p := range procs {
+		p.ProcessRequest(context.Background(), inv, req, nil)
+	}
+
+	sys := findSystemMessageContaining(req, workspaceExecGuidanceHeader)
+	require.Empty(t, sys)
 }
 
 func TestLLMAgent_WorkspaceExecGuidanceIncludesSaveArtifactWhenAvailable(

--- a/agent/llmagent/llm_agent_skill_test.go
+++ b/agent/llmagent/llm_agent_skill_test.go
@@ -987,6 +987,11 @@ func TestLLMAgent_WithSkillsProtocolGuidance_WiresPrompt(t *testing.T) {
 		sys,
 		"Use the matching skill before answering.",
 	)
+	require.Less(
+		t,
+		strings.Index(sys, "Use the matching skill before answering."),
+		strings.Index(sys, skillsOverviewHeader),
+	)
 	require.NotContains(t, sys, skillsCapabilityHeader)
 	require.NotContains(t, sys, skillsToolingGuidanceHeader)
 }

--- a/agent/llmagent/llm_agent_skill_test.go
+++ b/agent/llmagent/llm_agent_skill_test.go
@@ -40,6 +40,7 @@ const (
 	skillsOverviewHeader        = "Available skills:"
 	skillsCapabilityHeader      = "Skill tool availability:"
 	skillsToolingGuidanceHeader = "Tooling and workspace guidance:"
+	skillRootsHeader            = "Skill roots:"
 	workspaceExecGuidanceHeader = "Executor workspace guidance:"
 )
 
@@ -824,6 +825,87 @@ func TestLLMAgent_WithSkillToolProfile_KnowledgeOnly_GuidanceDisabled(
 	require.NotEmpty(t, sys)
 	require.NotContains(t, sys, skillsCapabilityHeader)
 	require.NotContains(t, sys, skillsToolingGuidanceHeader)
+}
+
+func TestLLMAgent_WithSkillsDirectoryHints_WiresPrompt(t *testing.T) {
+	root := createTestSkill(t)
+	repo, err := skill.NewFSRepository(root)
+	require.NoError(t, err)
+
+	opts := &Options{}
+	WithSkills(repo)(opts)
+	WithSkillsDirectoryHints(true)(opts)
+	WithSkillToolProfile(SkillToolProfileKnowledgeOnly)(opts)
+	WithSkillsCapabilityGuidance("")(opts)
+	WithSkillsToolingGuidance("")(opts)
+
+	procs := buildRequestProcessors("tester", opts)
+	inv := &agent.Invocation{
+		InvocationID: "inv1",
+		AgentName:    "tester",
+		Message:      model.NewUserMessage("u"),
+		Session:      &session.Session{},
+	}
+	req := &model.Request{}
+	for _, p := range procs {
+		p.ProcessRequest(context.Background(), inv, req, nil)
+	}
+
+	var sys string
+	for _, msg := range req.Messages {
+		if msg.Role != model.RoleSystem {
+			continue
+		}
+		if strings.Contains(msg.Content, skillsOverviewHeader) {
+			sys = msg.Content
+			break
+		}
+	}
+	require.NotEmpty(t, sys)
+	require.Contains(t, sys, skillRootsHeader)
+	require.Contains(t, sys, "(dir: [s1]/echoer)")
+}
+
+func TestLLMAgent_WithSkillsCapabilityGuidance_WiresPrompt(t *testing.T) {
+	root := createTestSkill(t)
+	repo, err := skill.NewFSRepository(root)
+	require.NoError(t, err)
+
+	opts := &Options{}
+	WithSkills(repo)(opts)
+	WithSkillToolProfile(SkillToolProfileKnowledgeOnly)(opts)
+	WithSkillsCapabilityGuidance("Use skills as directory bundles.")(opts)
+	WithSkillsToolingGuidance("")(opts)
+
+	procs := buildRequestProcessors("tester", opts)
+	inv := &agent.Invocation{
+		InvocationID: "inv1",
+		AgentName:    "tester",
+		Message:      model.NewUserMessage("u"),
+		Session:      &session.Session{},
+	}
+	req := &model.Request{}
+	for _, p := range procs {
+		p.ProcessRequest(context.Background(), inv, req, nil)
+	}
+
+	var sys string
+	for _, msg := range req.Messages {
+		if msg.Role != model.RoleSystem {
+			continue
+		}
+		if strings.Contains(msg.Content, skillsOverviewHeader) {
+			sys = msg.Content
+			break
+		}
+	}
+	require.NotEmpty(t, sys)
+	require.Contains(t, sys, "Use skills as directory bundles.")
+	require.NotContains(
+		t,
+		sys,
+		"Built-in skill execution tools are unavailable",
+	)
 }
 
 func TestLLMAgent_WithAllowedSkillTools_LoadOnly_WiresPrompt(

--- a/agent/llmagent/llm_agent_skill_test.go
+++ b/agent/llmagent/llm_agent_skill_test.go
@@ -1250,6 +1250,27 @@ func TestLLMAgent_WithSkillFilter_WiresOption(t *testing.T) {
 	require.NotNil(t, opts.skillFilter)
 }
 
+func TestLLMAgent_WithSkillLoadToolDescription_WiresTool(
+	t *testing.T,
+) {
+	root := createTestSkill(t)
+	repo, err := skill.NewFSRepository(root)
+	require.NoError(t, err)
+
+	const description = "Always load the matching skill first."
+
+	agt := New(
+		"tester",
+		WithSkills(repo),
+		WithSkillLoadToolDescription(description),
+	)
+	tl := findTool(agt.Tools(), "skill_load")
+	require.NotNil(t, tl)
+	decl := tl.Declaration()
+	require.NotNil(t, decl)
+	require.Equal(t, description, decl.Description)
+}
+
 func TestLLMAgent_WithSkillsLoadedContentInToolResults_WiresProcessor(
 	t *testing.T,
 ) {

--- a/agent/llmagent/option.go
+++ b/agent/llmagent/option.go
@@ -202,6 +202,12 @@ type Options struct {
 	// ChannelBufferSize is the buffer size for event channels (default: 256).
 	ChannelBufferSize int
 	codeExecutor      codeexecutor.CodeExecutor
+	// workspaceExecSurfaceEnabled controls whether generic workspace
+	// execution tools such as workspace_exec are exposed to the model
+	// when a code executor is available.
+	//
+	// Default: true.
+	workspaceExecSurfaceEnabled *bool
 	// EnableCodeExecutionResponseProcessor controls whether the agent
 	// auto-executes fenced code blocks from model responses.
 	//
@@ -621,6 +627,22 @@ func WithChannelBufferSize(size int) Option {
 func WithCodeExecutor(ce codeexecutor.CodeExecutor) Option {
 	return func(opts *Options) {
 		opts.codeExecutor = ce
+	}
+}
+
+// WithWorkspaceExecSurfaceEnabled controls whether generic workspace
+// execution tools are exposed to the model when a code executor is
+// available.
+//
+// This does not disable the configured code executor itself; it only
+// suppresses model-visible workspace tools such as workspace_exec and
+// its session helpers.
+//
+// Default: true.
+func WithWorkspaceExecSurfaceEnabled(enable bool) Option {
+	return func(opts *Options) {
+		value := enable
+		opts.workspaceExecSurfaceEnabled = &value
 	}
 }
 

--- a/agent/llmagent/option.go
+++ b/agent/llmagent/option.go
@@ -399,11 +399,17 @@ type Options struct {
 	// skillsCapabilityGuidance overrides the built-in skill capability
 	// disclosure block.
 	skillsCapabilityGuidance *string
+	// skillsProtocolGuidance overrides the full built-in skill protocol
+	// text appended after the overview.
+	skillsProtocolGuidance *string
 	// skillsToolingGuidance overrides the built-in skills guidance block.
 	skillsToolingGuidance *string
 	// skillsDirectoryHints exposes skill directory locators in prompt
 	// materialization when enabled.
 	skillsDirectoryHints bool
+	// skillsFilePathHints exposes SKILL.md file locators in prompt
+	// materialization when enabled.
+	skillsFilePathHints bool
 	// skillRunAllowedCommands restricts skill_run to allowlisted commands.
 	skillRunAllowedCommands []string
 	// skillRunDeniedCommands rejects denylisted commands for skill_run.
@@ -777,6 +783,23 @@ func WithSkillsCapabilityGuidance(
 	}
 }
 
+// WithSkillsProtocolGuidance overrides the full skill protocol text
+// appended after the skills overview.
+//
+// Behavior:
+//   - Not configured: use the built-in capability/tooling guidance flow.
+//   - Configured with empty string: omit all built-in skill guidance.
+//   - Configured with non-empty string: append the provided text and skip
+//     the built-in capability/tooling guidance blocks.
+func WithSkillsProtocolGuidance(
+	guidance string,
+) Option {
+	return func(opts *Options) {
+		text := guidance
+		opts.skillsProtocolGuidance = &text
+	}
+}
+
 // WithSkillsDirectoryHints exposes skill directory locators in the skills
 // overview and in loaded skill materialization.
 //
@@ -784,6 +807,16 @@ func WithSkillsCapabilityGuidance(
 func WithSkillsDirectoryHints(enable bool) Option {
 	return func(opts *Options) {
 		opts.skillsDirectoryHints = enable
+	}
+}
+
+// WithSkillsFilePathHints exposes SKILL.md file locators in the skills
+// overview and in loaded skill materialization.
+//
+// Default: false.
+func WithSkillsFilePathHints(enable bool) Option {
+	return func(opts *Options) {
+		opts.skillsFilePathHints = enable
 	}
 }
 

--- a/agent/llmagent/option.go
+++ b/agent/llmagent/option.go
@@ -396,8 +396,14 @@ type Options struct {
 	// allowedSkillTools, when non-nil, overrides skillToolProfile and limits
 	// the final built-in skill tool registration set to this explicit allowlist.
 	allowedSkillTools []string
+	// skillsCapabilityGuidance overrides the built-in skill capability
+	// disclosure block.
+	skillsCapabilityGuidance *string
 	// skillsToolingGuidance overrides the built-in skills guidance block.
 	skillsToolingGuidance *string
+	// skillsDirectoryHints exposes skill directory locators in prompt
+	// materialization when enabled.
+	skillsDirectoryHints bool
 	// skillRunAllowedCommands restricts skill_run to allowlisted commands.
 	skillRunAllowedCommands []string
 	// skillRunDeniedCommands rejects denylisted commands for skill_run.
@@ -752,6 +758,32 @@ func WithSkillsToolingGuidance(
 	return func(opts *Options) {
 		text := guidance
 		opts.skillsToolingGuidance = &text
+	}
+}
+
+// WithSkillsCapabilityGuidance overrides the capability disclosure block
+// appended to the skills overview.
+//
+// Behavior:
+//   - Not configured: use the built-in default disclosure.
+//   - Configured with empty string: omit the capability block.
+//   - Configured with non-empty string: append the provided text.
+func WithSkillsCapabilityGuidance(
+	guidance string,
+) Option {
+	return func(opts *Options) {
+		text := guidance
+		opts.skillsCapabilityGuidance = &text
+	}
+}
+
+// WithSkillsDirectoryHints exposes skill directory locators in the skills
+// overview and in loaded skill materialization.
+//
+// Default: false.
+func WithSkillsDirectoryHints(enable bool) Option {
+	return func(opts *Options) {
+		opts.skillsDirectoryHints = enable
 	}
 }
 

--- a/agent/llmagent/option.go
+++ b/agent/llmagent/option.go
@@ -410,6 +410,9 @@ type Options struct {
 	// skillsFilePathHints exposes SKILL.md file locators in prompt
 	// materialization when enabled.
 	skillsFilePathHints bool
+	// skillLoadToolDescription overrides the built-in skill_load tool
+	// description when non-nil.
+	skillLoadToolDescription *string
 	// skillRunAllowedCommands restricts skill_run to allowlisted commands.
 	skillRunAllowedCommands []string
 	// skillRunDeniedCommands rejects denylisted commands for skill_run.
@@ -817,6 +820,22 @@ func WithSkillsDirectoryHints(enable bool) Option {
 func WithSkillsFilePathHints(enable bool) Option {
 	return func(opts *Options) {
 		opts.skillsFilePathHints = enable
+	}
+}
+
+// WithSkillLoadToolDescription overrides the skill_load tool
+// description.
+//
+// Behavior:
+//   - Not configured: use the built-in default description.
+//   - Configured with empty string: set an empty description.
+//   - Configured with non-empty string: use the provided text.
+func WithSkillLoadToolDescription(
+	description string,
+) Option {
+	return func(opts *Options) {
+		text := description
+		opts.skillLoadToolDescription = &text
 	}
 }
 

--- a/agent/llmagent/option_test.go
+++ b/agent/llmagent/option_test.go
@@ -250,6 +250,30 @@ func TestWithSkillsLoadedContentInToolResults(t *testing.T) {
 	require.True(t, b.option.SkillsLoadedContentInToolResults)
 }
 
+func TestWithSkillsDirectoryHints(t *testing.T) {
+	a := New("test-agent")
+	require.False(t, a.option.skillsDirectoryHints)
+
+	b := New("test-agent", WithSkillsDirectoryHints(true))
+	require.True(t, b.option.skillsDirectoryHints)
+}
+
+func TestWithSkillsCapabilityGuidance(t *testing.T) {
+	a := New("test-agent")
+	require.Nil(t, a.option.skillsCapabilityGuidance)
+
+	b := New(
+		"test-agent",
+		WithSkillsCapabilityGuidance("Use directory bundles."),
+	)
+	require.NotNil(t, b.option.skillsCapabilityGuidance)
+	require.Equal(
+		t,
+		"Use directory bundles.",
+		*b.option.skillsCapabilityGuidance,
+	)
+}
+
 func TestWithSkillFilter(t *testing.T) {
 	a := New("test-agent")
 	require.Nil(t, a.option.skillFilter)

--- a/agent/llmagent/option_test.go
+++ b/agent/llmagent/option_test.go
@@ -258,6 +258,14 @@ func TestWithSkillsDirectoryHints(t *testing.T) {
 	require.True(t, b.option.skillsDirectoryHints)
 }
 
+func TestWithSkillsFilePathHints(t *testing.T) {
+	a := New("test-agent")
+	require.False(t, a.option.skillsFilePathHints)
+
+	b := New("test-agent", WithSkillsFilePathHints(true))
+	require.True(t, b.option.skillsFilePathHints)
+}
+
 func TestWithSkillsCapabilityGuidance(t *testing.T) {
 	a := New("test-agent")
 	require.Nil(t, a.option.skillsCapabilityGuidance)
@@ -271,6 +279,22 @@ func TestWithSkillsCapabilityGuidance(t *testing.T) {
 		t,
 		"Use directory bundles.",
 		*b.option.skillsCapabilityGuidance,
+	)
+}
+
+func TestWithSkillsProtocolGuidance(t *testing.T) {
+	a := New("test-agent")
+	require.Nil(t, a.option.skillsProtocolGuidance)
+
+	b := New(
+		"test-agent",
+		WithSkillsProtocolGuidance("Always load SKILL.md first."),
+	)
+	require.NotNil(t, b.option.skillsProtocolGuidance)
+	require.Equal(
+		t,
+		"Always load SKILL.md first.",
+		*b.option.skillsProtocolGuidance,
 	)
 }
 

--- a/agent/llmagent/option_test.go
+++ b/agent/llmagent/option_test.go
@@ -280,6 +280,19 @@ func TestWithSkillLoadToolDescription(t *testing.T) {
 	require.Equal(t, description, *b.option.skillLoadToolDescription)
 }
 
+func TestWithWorkspaceExecSurfaceEnabled(t *testing.T) {
+	a := New("test-agent")
+	require.Nil(t, a.option.workspaceExecSurfaceEnabled)
+	require.True(t, workspaceExecSurfaceEnabled(&a.option))
+
+	b := New(
+		"test-agent",
+		WithWorkspaceExecSurfaceEnabled(false),
+	)
+	require.NotNil(t, b.option.workspaceExecSurfaceEnabled)
+	require.False(t, *b.option.workspaceExecSurfaceEnabled)
+}
+
 func TestWithSkillsCapabilityGuidance(t *testing.T) {
 	a := New("test-agent")
 	require.Nil(t, a.option.skillsCapabilityGuidance)

--- a/agent/llmagent/option_test.go
+++ b/agent/llmagent/option_test.go
@@ -266,6 +266,20 @@ func TestWithSkillsFilePathHints(t *testing.T) {
 	require.True(t, b.option.skillsFilePathHints)
 }
 
+func TestWithSkillLoadToolDescription(t *testing.T) {
+	a := New("test-agent")
+	require.Nil(t, a.option.skillLoadToolDescription)
+
+	const description = "Load the matching skill before answering."
+
+	b := New(
+		"test-agent",
+		WithSkillLoadToolDescription(description),
+	)
+	require.NotNil(t, b.option.skillLoadToolDescription)
+	require.Equal(t, description, *b.option.skillLoadToolDescription)
+}
+
 func TestWithSkillsCapabilityGuidance(t *testing.T) {
 	a := New("test-agent")
 	require.Nil(t, a.option.skillsCapabilityGuidance)

--- a/agent/llmagent/surface_runtime.go
+++ b/agent/llmagent/surface_runtime.go
@@ -97,13 +97,33 @@ func (a *LLMAgent) codeExecutorForInvocation(
 func (a *LLMAgent) supportsWorkspaceExecForInvocation(
 	inv *agent.Invocation,
 ) bool {
+	if a == nil {
+		return false
+	}
+	a.mu.RLock()
+	options := a.option
+	a.mu.RUnlock()
+	if !workspaceExecSurfaceEnabled(&options) {
+		return false
+	}
 	return codeExecutorSupportsWorkspaceExec(a.codeExecutorForInvocation(inv))
 }
 
 func (a *LLMAgent) supportsWorkspaceExecSessionsForInvocation(
 	inv *agent.Invocation,
 ) bool {
-	return codeExecutorSupportsWorkspaceExecSessions(a.codeExecutorForInvocation(inv))
+	if a == nil {
+		return false
+	}
+	a.mu.RLock()
+	options := a.option
+	a.mu.RUnlock()
+	if !workspaceExecSurfaceEnabled(&options) {
+		return false
+	}
+	return codeExecutorSupportsWorkspaceExecSessions(
+		a.codeExecutorForInvocation(inv),
+	)
 }
 
 func (a *LLMAgent) skillToolFlagsForInvocation(
@@ -175,17 +195,21 @@ func (a *LLMAgent) InvocationToolSurface(
 
 	effectiveSkills := a.skillRepositoryForInvocation(inv)
 	effectiveExec := a.codeExecutorForInvocation(inv)
+	workspaceExecEnabled := workspaceExecSurfaceEnabled(&options) &&
+		codeExecutorSupportsWorkspaceExec(effectiveExec)
+	workspaceExecSessions := workspaceExecEnabled &&
+		codeExecutorSupportsWorkspaceExecSessions(effectiveExec)
 	var workspaceRegistry *codeexecutor.WorkspaceRegistry
 	if effectiveSkills != nil && effectiveExec != nil {
 		workspaceRegistry = buildWorkspaceRegistry()
-	} else if codeExecutorSupportsWorkspaceExec(effectiveExec) {
+	} else if workspaceExecEnabled {
 		workspaceRegistry = buildWorkspaceRegistry()
 	}
 	allTools = appendWorkspaceExecToolWithExecutor(
 		allTools,
 		effectiveExec,
-		codeExecutorSupportsWorkspaceExec(effectiveExec),
-		codeExecutorSupportsWorkspaceExecSessions(effectiveExec),
+		workspaceExecEnabled,
+		workspaceExecSessions,
 		workspaceRegistry,
 		inv,
 	)

--- a/agent/llmagent/surface_runtime_test.go
+++ b/agent/llmagent/surface_runtime_test.go
@@ -515,6 +515,29 @@ func TestLLMAgent_Run_SurfacePatch_AddsSkillsWithoutStaticRepository(t *testing.
 	require.Contains(t, m.got.Tools, "workspace_exec")
 }
 
+func TestLLMAgent_InvocationToolSurface_HidesWorkspaceExecWhenDisabled(
+	t *testing.T,
+) {
+	agt := New(
+		"test-agent",
+		WithModel(newDummyModel()),
+		WithCodeExecutor(&interactiveStubExec{}),
+		WithWorkspaceExecSurfaceEnabled(false),
+	)
+
+	tools, _ := agt.InvocationToolSurface(
+		context.Background(),
+		agent.NewInvocation(
+			agent.WithInvocationMessage(model.NewUserMessage("hi")),
+			agent.WithInvocationSession(&session.Session{}),
+		),
+	)
+
+	require.Nil(t, findTool(tools, "workspace_exec"))
+	require.Nil(t, findTool(tools, "workspace_write_stdin"))
+	require.Nil(t, findTool(tools, "workspace_kill_session"))
+}
+
 func TestLLMAgent_SurfaceRuntimeHelpers_NilAgentBranches(t *testing.T) {
 	var agt *LLMAgent
 	require.Nil(t, agt.codeExecutorForInvocation(nil))

--- a/agent/llmagent/surface_runtime_test.go
+++ b/agent/llmagent/surface_runtime_test.go
@@ -541,6 +541,8 @@ func TestLLMAgent_InvocationToolSurface_HidesWorkspaceExecWhenDisabled(
 func TestLLMAgent_SurfaceRuntimeHelpers_NilAgentBranches(t *testing.T) {
 	var agt *LLMAgent
 	require.Nil(t, agt.codeExecutorForInvocation(nil))
+	require.False(t, agt.supportsWorkspaceExecForInvocation(nil))
+	require.False(t, agt.supportsWorkspaceExecSessionsForInvocation(nil))
 	flags := agt.skillToolFlagsForInvocation(nil)
 	require.False(t, flags.Load)
 	require.False(t, flags.SelectDocs)
@@ -550,6 +552,30 @@ func TestLLMAgent_SurfaceRuntimeHelpers_NilAgentBranches(t *testing.T) {
 	require.False(t, flags.WriteStdin)
 	require.False(t, flags.PollSession)
 	require.False(t, flags.KillSession)
+}
+
+func TestLLMAgent_SurfaceRuntimeHelpers_WorkspaceExecOptionRespected(
+	t *testing.T,
+) {
+	disabled := New(
+		"test-agent",
+		WithModel(newDummyModel()),
+		WithCodeExecutor(&interactiveStubExec{}),
+		WithWorkspaceExecSurfaceEnabled(false),
+	)
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(&session.Session{}),
+	)
+	require.False(t, disabled.supportsWorkspaceExecForInvocation(inv))
+	require.False(t, disabled.supportsWorkspaceExecSessionsForInvocation(inv))
+
+	enabled := New(
+		"test-agent",
+		WithModel(newDummyModel()),
+		WithCodeExecutor(&interactiveStubExec{}),
+	)
+	require.True(t, enabled.supportsWorkspaceExecForInvocation(inv))
+	require.True(t, enabled.supportsWorkspaceExecSessionsForInvocation(inv))
 }
 
 func TestLLMAgent_AppendSkillToolsWithRepo_UsesResolvedFlags(t *testing.T) {

--- a/internal/flow/processor/skills.go
+++ b/internal/flow/processor/skills.go
@@ -742,26 +742,43 @@ func (p *SkillsRequestProcessor) injectOverview(
 		return
 	}
 	var b strings.Builder
-	b.WriteString(skillsOverviewHeader)
-	b.WriteString("\n")
-	if p.directoryHints || p.filePathHints {
-		if rootsText := buildSkillRootsText(repo); rootsText != "" {
-			b.WriteString(rootsText)
-		}
-	}
-	for _, s := range sums {
-		line := fmt.Sprintf(
-			"- %s: %s%s\n",
-			s.Name,
-			s.Description,
-			p.skillOverviewSuffix(ctx, repo, s.Name),
-		)
-		b.WriteString(line)
-	}
 	flags := p.toolFlagsForInvocation(inv)
 	if protocol := p.protocolGuidanceText(flags); protocol != "" {
 		b.WriteString(protocol)
+		b.WriteString("\n")
+		b.WriteString(skillsOverviewHeader)
+		b.WriteString("\n")
+		if p.directoryHints || p.filePathHints {
+			if rootsText := buildSkillRootsText(repo); rootsText != "" {
+				b.WriteString(rootsText)
+			}
+		}
+		for _, s := range sums {
+			line := fmt.Sprintf(
+				"- %s: %s%s\n",
+				s.Name,
+				s.Description,
+				p.skillOverviewSuffix(ctx, repo, s.Name),
+			)
+			b.WriteString(line)
+		}
 	} else {
+		b.WriteString(skillsOverviewHeader)
+		b.WriteString("\n")
+		if p.directoryHints || p.filePathHints {
+			if rootsText := buildSkillRootsText(repo); rootsText != "" {
+				b.WriteString(rootsText)
+			}
+		}
+		for _, s := range sums {
+			line := fmt.Sprintf(
+				"- %s: %s%s\n",
+				s.Name,
+				s.Description,
+				p.skillOverviewSuffix(ctx, repo, s.Name),
+			)
+			b.WriteString(line)
+		}
 		if capability := p.capabilityGuidanceText(flags); capability != "" {
 			b.WriteString(capability)
 		}
@@ -775,7 +792,13 @@ func (p *SkillsRequestProcessor) injectOverview(
 	if idx >= 0 {
 		sys := &req.Messages[idx]
 		if !strings.Contains(sys.Content, skillsOverviewHeader) {
-			if sys.Content != "" {
+			if p.protocolGuidanceText(flags) != "" {
+				if sys.Content != "" {
+					sys.Content = overview + "\n\n" + sys.Content
+				} else {
+					sys.Content = overview
+				}
+			} else if sys.Content != "" {
 				sys.Content += "\n\n" + overview
 			} else {
 				sys.Content = overview

--- a/internal/flow/processor/skills.go
+++ b/internal/flow/processor/skills.go
@@ -35,6 +35,7 @@ const (
 
 	skillRootsHeader = "Skill roots:"
 	skillDirLabel    = "Skill dir: "
+	skillFileLabel   = "Skill file: "
 
 	// SkillLoadModeOnce injects loaded skill content for the next model
 	// request, then offloads it from session state.
@@ -52,6 +53,7 @@ const (
 
 type skillsRequestProcessorOptions struct {
 	capabilityGuidance *string
+	protocolGuidance   *string
 	toolingGuidance    *string
 	loadMode           string
 	toolResultMode     bool
@@ -63,6 +65,7 @@ type skillsRequestProcessorOptions struct {
 	execToolsDisabled  bool
 	repoResolver       func(*agent.Invocation) skill.Repository
 	directoryHints     bool
+	filePathHints      bool
 }
 
 // SkillsRequestProcessorOption configures SkillsRequestProcessor.
@@ -111,6 +114,23 @@ func WithSkillsCapabilityGuidance(
 	return func(o *skillsRequestProcessorOptions) {
 		text := guidance
 		o.capabilityGuidance = &text
+	}
+}
+
+// WithSkillsProtocolGuidance overrides the full skill protocol block
+// appended after the skills overview.
+//
+// Behavior:
+//   - Not configured: use the built-in capability/tooling guidance flow.
+//   - Configured with empty string: omit all built-in skill guidance.
+//   - Configured with non-empty string: append the provided text and skip
+//     the built-in capability/tooling guidance blocks.
+func WithSkillsProtocolGuidance(
+	guidance string,
+) SkillsRequestProcessorOption {
+	return func(o *skillsRequestProcessorOptions) {
+		text := guidance
+		o.protocolGuidance = &text
 	}
 }
 
@@ -199,6 +219,16 @@ func WithSkillsDirectoryHints(
 	}
 }
 
+// WithSkillsFilePathHints exposes SKILL.md file locators in the skills
+// overview and in loaded skill materialization.
+func WithSkillsFilePathHints(
+	enable bool,
+) SkillsRequestProcessorOption {
+	return func(o *skillsRequestProcessorOptions) {
+		o.filePathHints = enable
+	}
+}
+
 // SkillsRequestProcessor injects skill overviews and loaded contents.
 //
 // Behavior:
@@ -214,6 +244,7 @@ type SkillsRequestProcessor struct {
 	repo               skill.Repository
 	repoResolver       func(*agent.Invocation) skill.Repository
 	capabilityGuidance *string
+	protocolGuidance   *string
 	toolingGuidance    *string
 	loadMode           string
 	toolResultMode     bool
@@ -221,6 +252,7 @@ type SkillsRequestProcessor struct {
 	toolFlags          skillprofile.Flags
 	toolFlagsResolver  func(*agent.Invocation) skillprofile.Flags
 	directoryHints     bool
+	filePathHints      bool
 }
 
 const (
@@ -255,6 +287,7 @@ func NewSkillsRequestProcessor(
 		repo:               repo,
 		repoResolver:       options.repoResolver,
 		capabilityGuidance: options.capabilityGuidance,
+		protocolGuidance:   options.protocolGuidance,
 		toolingGuidance:    options.toolingGuidance,
 		loadMode:           normalizeSkillLoadMode(options.loadMode),
 		toolResultMode:     options.toolResultMode,
@@ -262,6 +295,7 @@ func NewSkillsRequestProcessor(
 		toolFlags:          flags,
 		toolFlagsResolver:  options.toolFlagsResolver,
 		directoryHints:     options.directoryHints,
+		filePathHints:      options.filePathHints,
 	}
 }
 
@@ -329,13 +363,7 @@ func (p *SkillsRequestProcessor) ProcessRequest(
 			lb.WriteString("\n[Loaded] ")
 			lb.WriteString(name)
 			lb.WriteString("\n")
-			if p.directoryHints {
-				if dir := skillDirectoryText(ctx, repo, name); dir != "" {
-					lb.WriteString(skillDirLabel)
-					lb.WriteString(dir)
-					lb.WriteString("\n")
-				}
-			}
+			p.appendSkillPathHints(&lb, ctx, repo, name)
 			lb.WriteString("\n")
 			lb.WriteString(sk.Body)
 			lb.WriteString("\n")
@@ -716,7 +744,7 @@ func (p *SkillsRequestProcessor) injectOverview(
 	var b strings.Builder
 	b.WriteString(skillsOverviewHeader)
 	b.WriteString("\n")
-	if p.directoryHints {
+	if p.directoryHints || p.filePathHints {
 		if rootsText := buildSkillRootsText(repo); rootsText != "" {
 			b.WriteString(rootsText)
 		}
@@ -726,16 +754,20 @@ func (p *SkillsRequestProcessor) injectOverview(
 			"- %s: %s%s\n",
 			s.Name,
 			s.Description,
-			p.skillDirectorySuffix(ctx, repo, s.Name),
+			p.skillOverviewSuffix(ctx, repo, s.Name),
 		)
 		b.WriteString(line)
 	}
 	flags := p.toolFlagsForInvocation(inv)
-	if capability := p.capabilityGuidanceText(flags); capability != "" {
-		b.WriteString(capability)
-	}
-	if guidance := p.toolingGuidanceText(flags); guidance != "" {
-		b.WriteString(guidance)
+	if protocol := p.protocolGuidanceText(flags); protocol != "" {
+		b.WriteString(protocol)
+	} else {
+		if capability := p.capabilityGuidanceText(flags); capability != "" {
+			b.WriteString(capability)
+		}
+		if guidance := p.toolingGuidanceText(flags); guidance != "" {
+			b.WriteString(guidance)
+		}
 	}
 	overview := b.String()
 
@@ -763,6 +795,16 @@ func (p *SkillsRequestProcessor) toolFlagsForInvocation(
 		return p.toolFlagsResolver(inv)
 	}
 	return p.toolFlags
+}
+
+func (p *SkillsRequestProcessor) protocolGuidanceText(
+	flags skillprofile.Flags,
+) string {
+	if p.protocolGuidance == nil {
+		return ""
+	}
+	_ = flags
+	return normalizeGuidance(*p.protocolGuidance)
 }
 
 func (p *SkillsRequestProcessor) toolingGuidanceText(
@@ -1067,19 +1109,24 @@ func skillRootAliases(repo skill.Repository) []skillRootAlias {
 	return aliases
 }
 
-func (p *SkillsRequestProcessor) skillDirectorySuffix(
+func (p *SkillsRequestProcessor) skillOverviewSuffix(
 	ctx context.Context,
 	repo skill.Repository,
 	name string,
 ) string {
-	if !p.directoryHints {
-		return ""
+	if p.filePathHints {
+		locator := skillFileLocator(ctx, repo, name)
+		if locator != "" {
+			return " (file: " + locator + ")"
+		}
 	}
-	locator := skillDirectoryLocator(ctx, repo, name)
-	if locator == "" {
-		return ""
+	if p.directoryHints {
+		locator := skillDirectoryLocator(ctx, repo, name)
+		if locator != "" {
+			return " (dir: " + locator + ")"
+		}
 	}
-	return " (dir: " + locator + ")"
+	return ""
 }
 
 func skillDirectoryLocator(
@@ -1092,7 +1139,7 @@ func skillDirectoryLocator(
 		return ""
 	}
 	for _, item := range skillRootAliases(repo) {
-		rel, ok := relativeSkillDir(item.root, dir)
+		rel, ok := relativeSkillPath(item.root, dir)
 		if !ok {
 			continue
 		}
@@ -1102,6 +1149,28 @@ func skillDirectoryLocator(
 		return "[" + item.alias + "]/" + rel
 	}
 	return dir
+}
+
+func skillFileLocator(
+	ctx context.Context,
+	repo skill.Repository,
+	name string,
+) string {
+	path := skillFileText(ctx, repo, name)
+	if path == "" {
+		return ""
+	}
+	for _, item := range skillRootAliases(repo) {
+		rel, ok := relativeSkillPath(item.root, path)
+		if !ok {
+			continue
+		}
+		if rel == "" {
+			return "[" + item.alias + "]"
+		}
+		return "[" + item.alias + "]/" + rel
+	}
+	return path
 }
 
 func skillDirectoryText(
@@ -1120,8 +1189,25 @@ func skillDirectoryText(
 	return filepath.ToSlash(dir)
 }
 
-func relativeSkillDir(root string, dir string) (string, bool) {
-	rel, err := filepath.Rel(root, dir)
+func skillFileText(
+	ctx context.Context,
+	repo skill.Repository,
+	name string,
+) string {
+	dir := skillDirectoryText(ctx, repo, name)
+	if dir == "" {
+		return ""
+	}
+	path := filepath.Join(dir, skill.SkillFile)
+	path = filepath.Clean(strings.TrimSpace(path))
+	if path == "" {
+		return ""
+	}
+	return filepath.ToSlash(path)
+}
+
+func relativeSkillPath(root string, path string) (string, bool) {
+	rel, err := filepath.Rel(root, path)
 	if err != nil {
 		return "", false
 	}
@@ -1133,6 +1219,31 @@ func relativeSkillDir(root string, dir string) (string, bool) {
 		return "", true
 	}
 	return filepath.ToSlash(rel), true
+}
+
+func (p *SkillsRequestProcessor) appendSkillPathHints(
+	b *strings.Builder,
+	ctx context.Context,
+	repo skill.Repository,
+	name string,
+) {
+	if b == nil {
+		return
+	}
+	if p.directoryHints {
+		if dir := skillDirectoryText(ctx, repo, name); dir != "" {
+			b.WriteString(skillDirLabel)
+			b.WriteString(dir)
+			b.WriteString("\n")
+		}
+	}
+	if p.filePathHints {
+		if path := skillFileText(ctx, repo, name); path != "" {
+			b.WriteString(skillFileLabel)
+			b.WriteString(path)
+			b.WriteString("\n")
+		}
+	}
 }
 
 func appendKnowledgeGuidance(

--- a/internal/flow/processor/skills.go
+++ b/internal/flow/processor/skills.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -32,6 +33,9 @@ const (
 
 	skillsToolingGuidanceHeader = "Tooling and workspace guidance:"
 
+	skillRootsHeader = "Skill roots:"
+	skillDirLabel    = "Skill dir: "
+
 	// SkillLoadModeOnce injects loaded skill content for the next model
 	// request, then offloads it from session state.
 	SkillLoadModeOnce = "once"
@@ -47,16 +51,18 @@ const (
 )
 
 type skillsRequestProcessorOptions struct {
-	toolingGuidance   *string
-	loadMode          string
-	toolResultMode    bool
-	maxLoadedSkills   int
-	toolProfile       string
-	toolFlags         skillprofile.Flags
-	toolFlagsResolver func(*agent.Invocation) skillprofile.Flags
-	hasToolFlags      bool
-	execToolsDisabled bool
-	repoResolver      func(*agent.Invocation) skill.Repository
+	capabilityGuidance *string
+	toolingGuidance    *string
+	loadMode           string
+	toolResultMode     bool
+	maxLoadedSkills    int
+	toolProfile        string
+	toolFlags          skillprofile.Flags
+	toolFlagsResolver  func(*agent.Invocation) skillprofile.Flags
+	hasToolFlags       bool
+	execToolsDisabled  bool
+	repoResolver       func(*agent.Invocation) skill.Repository
+	directoryHints     bool
 }
 
 // SkillsRequestProcessorOption configures SkillsRequestProcessor.
@@ -89,6 +95,22 @@ func WithSkillsToolingGuidance(
 	return func(o *skillsRequestProcessorOptions) {
 		text := guidance
 		o.toolingGuidance = &text
+	}
+}
+
+// WithSkillsCapabilityGuidance overrides the capability disclosure block
+// appended to the skills overview.
+//
+// Behavior:
+//   - Not configured: use the built-in default disclosure.
+//   - Configured with empty string: omit the capability block.
+//   - Configured with non-empty string: append the provided text.
+func WithSkillsCapabilityGuidance(
+	guidance string,
+) SkillsRequestProcessorOption {
+	return func(o *skillsRequestProcessorOptions) {
+		text := guidance
+		o.capabilityGuidance = &text
 	}
 }
 
@@ -167,6 +189,16 @@ func WithMaxLoadedSkills(max int) SkillsRequestProcessorOption {
 	}
 }
 
+// WithSkillsDirectoryHints exposes skill directory locators in the skills
+// overview and in loaded skill materialization.
+func WithSkillsDirectoryHints(
+	enable bool,
+) SkillsRequestProcessorOption {
+	return func(o *skillsRequestProcessorOptions) {
+		o.directoryHints = enable
+	}
+}
+
 // SkillsRequestProcessor injects skill overviews and loaded contents.
 //
 // Behavior:
@@ -179,14 +211,16 @@ func WithMaxLoadedSkills(max int) SkillsRequestProcessorOption {
 //   - skill.DocsKey(agentName, skillName) ->
 //     "*" or JSON array of file names.
 type SkillsRequestProcessor struct {
-	repo              skill.Repository
-	repoResolver      func(*agent.Invocation) skill.Repository
-	toolingGuidance   *string
-	loadMode          string
-	toolResultMode    bool
-	maxLoadedSkills   int
-	toolFlags         skillprofile.Flags
-	toolFlagsResolver func(*agent.Invocation) skillprofile.Flags
+	repo               skill.Repository
+	repoResolver       func(*agent.Invocation) skill.Repository
+	capabilityGuidance *string
+	toolingGuidance    *string
+	loadMode           string
+	toolResultMode     bool
+	maxLoadedSkills    int
+	toolFlags          skillprofile.Flags
+	toolFlagsResolver  func(*agent.Invocation) skillprofile.Flags
+	directoryHints     bool
 }
 
 const (
@@ -218,14 +252,16 @@ func NewSkillsRequestProcessor(
 		flags = flags.WithoutInteractiveExecution()
 	}
 	return &SkillsRequestProcessor{
-		repo:              repo,
-		repoResolver:      options.repoResolver,
-		toolingGuidance:   options.toolingGuidance,
-		loadMode:          normalizeSkillLoadMode(options.loadMode),
-		toolResultMode:    options.toolResultMode,
-		maxLoadedSkills:   options.maxLoadedSkills,
-		toolFlags:         flags,
-		toolFlagsResolver: options.toolFlagsResolver,
+		repo:               repo,
+		repoResolver:       options.repoResolver,
+		capabilityGuidance: options.capabilityGuidance,
+		toolingGuidance:    options.toolingGuidance,
+		loadMode:           normalizeSkillLoadMode(options.loadMode),
+		toolResultMode:     options.toolResultMode,
+		maxLoadedSkills:    options.maxLoadedSkills,
+		toolFlags:          flags,
+		toolFlagsResolver:  options.toolFlagsResolver,
+		directoryHints:     options.directoryHints,
 	}
 }
 
@@ -292,7 +328,15 @@ func (p *SkillsRequestProcessor) ProcessRequest(
 		if sk.Body != "" {
 			lb.WriteString("\n[Loaded] ")
 			lb.WriteString(name)
-			lb.WriteString("\n\n")
+			lb.WriteString("\n")
+			if p.directoryHints {
+				if dir := skillDirectoryText(ctx, repo, name); dir != "" {
+					lb.WriteString(skillDirLabel)
+					lb.WriteString(dir)
+					lb.WriteString("\n")
+				}
+			}
+			lb.WriteString("\n")
 			lb.WriteString(sk.Body)
 			lb.WriteString("\n")
 		}
@@ -672,8 +716,18 @@ func (p *SkillsRequestProcessor) injectOverview(
 	var b strings.Builder
 	b.WriteString(skillsOverviewHeader)
 	b.WriteString("\n")
+	if p.directoryHints {
+		if rootsText := buildSkillRootsText(repo); rootsText != "" {
+			b.WriteString(rootsText)
+		}
+	}
 	for _, s := range sums {
-		line := fmt.Sprintf("- %s: %s\n", s.Name, s.Description)
+		line := fmt.Sprintf(
+			"- %s: %s%s\n",
+			s.Name,
+			s.Description,
+			p.skillDirectorySuffix(ctx, repo, s.Name),
+		)
 		b.WriteString(line)
 	}
 	flags := p.toolFlagsForInvocation(inv)
@@ -723,6 +777,9 @@ func (p *SkillsRequestProcessor) toolingGuidanceText(
 func (p *SkillsRequestProcessor) capabilityGuidanceText(
 	flags skillprofile.Flags,
 ) string {
+	if p.capabilityGuidance != nil {
+		return normalizeGuidance(*p.capabilityGuidance)
+	}
 	if p.toolingGuidance != nil && *p.toolingGuidance == "" {
 		return ""
 	}
@@ -957,6 +1014,125 @@ func defaultFullToolingAndWorkspaceGuidance(flags skillprofile.Flags) string {
 	b.WriteString("rather than inventing shell syntax or command ")
 	b.WriteString("arguments.\n")
 	return b.String()
+}
+
+type skillRootAlias struct {
+	alias string
+	root  string
+}
+
+func buildSkillRootsText(repo skill.Repository) string {
+	aliases := skillRootAliases(repo)
+	if len(aliases) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(skillRootsHeader)
+	b.WriteString("\n")
+	for _, item := range aliases {
+		b.WriteString("- [")
+		b.WriteString(item.alias)
+		b.WriteString("]=")
+		b.WriteString(item.root)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func skillRootAliases(repo skill.Repository) []skillRootAlias {
+	rooted, ok := repo.(skill.RootedRepository)
+	if !ok || rooted == nil {
+		return nil
+	}
+	roots := rooted.Roots()
+	if len(roots) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(roots))
+	aliases := make([]skillRootAlias, 0, len(roots))
+	for _, root := range roots {
+		root = filepath.Clean(strings.TrimSpace(root))
+		if root == "" {
+			continue
+		}
+		if _, ok := seen[root]; ok {
+			continue
+		}
+		seen[root] = struct{}{}
+		aliases = append(aliases, skillRootAlias{
+			alias: fmt.Sprintf("s%d", len(aliases)+1),
+			root:  root,
+		})
+	}
+	return aliases
+}
+
+func (p *SkillsRequestProcessor) skillDirectorySuffix(
+	ctx context.Context,
+	repo skill.Repository,
+	name string,
+) string {
+	if !p.directoryHints {
+		return ""
+	}
+	locator := skillDirectoryLocator(ctx, repo, name)
+	if locator == "" {
+		return ""
+	}
+	return " (dir: " + locator + ")"
+}
+
+func skillDirectoryLocator(
+	ctx context.Context,
+	repo skill.Repository,
+	name string,
+) string {
+	dir := skillDirectoryText(ctx, repo, name)
+	if dir == "" {
+		return ""
+	}
+	for _, item := range skillRootAliases(repo) {
+		rel, ok := relativeSkillDir(item.root, dir)
+		if !ok {
+			continue
+		}
+		if rel == "" {
+			return "[" + item.alias + "]"
+		}
+		return "[" + item.alias + "]/" + rel
+	}
+	return dir
+}
+
+func skillDirectoryText(
+	ctx context.Context,
+	repo skill.Repository,
+	name string,
+) string {
+	dir, err := skill.PathForContext(ctx, repo, name)
+	if err != nil {
+		return ""
+	}
+	dir = filepath.Clean(strings.TrimSpace(dir))
+	if dir == "" {
+		return ""
+	}
+	return filepath.ToSlash(dir)
+}
+
+func relativeSkillDir(root string, dir string) (string, bool) {
+	rel, err := filepath.Rel(root, dir)
+	if err != nil {
+		return "", false
+	}
+	rel = filepath.Clean(rel)
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	if rel == "." {
+		return "", true
+	}
+	return filepath.ToSlash(rel), true
 }
 
 func appendKnowledgeGuidance(

--- a/internal/flow/processor/skills_test.go
+++ b/internal/flow/processor/skills_test.go
@@ -26,8 +26,10 @@ import (
 )
 
 type mockRepo struct {
-	sums []skill.Summary
-	full map[string]*skill.Skill
+	sums  []skill.Summary
+	full  map[string]*skill.Skill
+	paths map[string]string
+	roots []string
 }
 
 func (m *mockRepo) Summaries() []skill.Summary { return m.sums }
@@ -37,7 +39,16 @@ func (m *mockRepo) Get(name string) (*skill.Skill, error) {
 	}
 	return nil, nil
 }
-func (m *mockRepo) Path(name string) (string, error) { return "", nil }
+func (m *mockRepo) Path(name string) (string, error) {
+	if dir, ok := m.paths[name]; ok {
+		return dir, nil
+	}
+	return "", nil
+}
+
+func (m *mockRepo) Roots() []string {
+	return append([]string(nil), m.roots...)
+}
 
 func TestSkillsRequestProcessor_ProcessRequest_OverviewAndDocs(
 	t *testing.T,
@@ -221,6 +232,78 @@ func TestSkillsRequestProcessor_ToolingGuidance_Disabled(t *testing.T) {
 	require.Contains(t, sys, skillsOverviewHeader)
 	require.NotContains(t, sys, skillsCapabilityHeader)
 	require.NotContains(t, sys, skillsToolingGuidanceHeader)
+}
+
+func TestSkillsRequestProcessor_DirectoryHints(t *testing.T) {
+	repo := &mockRepo{
+		sums: []skill.Summary{{Name: "calc", Description: "math ops"}},
+		full: map[string]*skill.Skill{
+			"calc": {
+				Summary: skill.Summary{Name: "calc"},
+				Body:    "Calc body",
+			},
+		},
+		paths: map[string]string{
+			"calc": "/tmp/skills/local/calc",
+		},
+		roots: []string{"/tmp/skills/local"},
+	}
+
+	inv := &agent.Invocation{
+		InvocationID: "inv1",
+		AgentName:    "tester",
+		Session: &session.Session{
+			State: session.StateMap{
+				skill.LoadedKey("tester", "calc"): []byte("1"),
+			},
+		},
+	}
+
+	req := &model.Request{
+		Messages: []model.Message{
+			model.NewSystemMessage("sys"),
+		},
+	}
+
+	p := NewSkillsRequestProcessor(
+		repo,
+		WithSkillLoadMode(SkillLoadModeSession),
+		WithSkillsDirectoryHints(true),
+		WithSkillsCapabilityGuidance(""),
+		WithSkillsToolingGuidance(""),
+	)
+	p.ProcessRequest(context.Background(), inv, req, nil)
+
+	sys := req.Messages[0].Content
+	require.Contains(t, sys, skillRootsHeader)
+	require.Contains(t, sys, "- [s1]=/tmp/skills/local")
+	require.Contains(t, sys, "- calc: math ops (dir: [s1]/calc)")
+	require.Contains(t, sys, "[Loaded] calc")
+	require.Contains(t, sys, skillDirLabel+"/tmp/skills/local/calc")
+}
+
+func TestSkillsRequestProcessor_CapabilityGuidanceOverride(t *testing.T) {
+	repo := &mockRepo{
+		sums: []skill.Summary{{Name: "x", Description: "d"}},
+		full: map[string]*skill.Skill{},
+	}
+	inv := &agent.Invocation{Session: &session.Session{}}
+	req := &model.Request{Messages: nil}
+	p := NewSkillsRequestProcessor(
+		repo,
+		WithSkillToolProfile(skillprofile.KnowledgeOnly),
+		WithSkillsCapabilityGuidance("Use skills as directory bundles."),
+		WithSkillsToolingGuidance(""),
+	)
+	p.ProcessRequest(context.Background(), inv, req, nil)
+
+	sys := req.Messages[0].Content
+	require.Contains(t, sys, "Use skills as directory bundles.")
+	require.NotContains(
+		t,
+		sys,
+		"Built-in skill execution tools are unavailable",
+	)
 }
 
 func TestSkillsRequestProcessor_ExecToolsDisabled(t *testing.T) {
@@ -1553,6 +1636,53 @@ func TestSkillsToolResultRequestProcessor_FallbackSystemMessageAdded(
 			continue
 		}
 		require.NotContains(t, m.Content, skillsLoadedContextHeader)
+	}
+}
+
+func TestSkillsToolResultRequestProcessor_DirectoryHints(t *testing.T) {
+	repo := &mockRepo{
+		sums: []skill.Summary{{Name: "calc", Description: "math"}},
+		full: map[string]*skill.Skill{
+			"calc": {Summary: skill.Summary{Name: "calc"}, Body: "B"},
+		},
+		paths: map[string]string{
+			"calc": "/tmp/skills/local/calc",
+		},
+	}
+
+	inv := &agent.Invocation{
+		InvocationID: "inv1",
+		AgentName:    "tester",
+		Session: &session.Session{
+			State: session.StateMap{
+				skill.LoadedKey("tester", "calc"): []byte("1"),
+			},
+		},
+	}
+
+	req := &model.Request{
+		Messages: []model.Message{
+			model.NewSystemMessage("sys"),
+			model.NewUserMessage("u"),
+		},
+	}
+
+	p := NewSkillsToolResultRequestProcessor(
+		repo,
+		WithSkillsToolResultLoadMode(SkillLoadModeSession),
+		WithSkillsToolResultDirectoryHints(true),
+	)
+	p.ProcessRequest(context.Background(), inv, req, nil)
+
+	for _, m := range req.Messages {
+		if m.Role != model.RoleSystem {
+			continue
+		}
+		if !strings.Contains(m.Content, skillsLoadedContextHeader) {
+			continue
+		}
+		require.Contains(t, m.Content, "[Loaded] calc")
+		require.Contains(t, m.Content, skillDirLabel+"/tmp/skills/local/calc")
 	}
 }
 

--- a/internal/flow/processor/skills_test.go
+++ b/internal/flow/processor/skills_test.go
@@ -282,6 +282,53 @@ func TestSkillsRequestProcessor_DirectoryHints(t *testing.T) {
 	require.Contains(t, sys, skillDirLabel+"/tmp/skills/local/calc")
 }
 
+func TestSkillsRequestProcessor_FilePathHints(t *testing.T) {
+	repo := &mockRepo{
+		sums: []skill.Summary{{Name: "calc", Description: "math ops"}},
+		full: map[string]*skill.Skill{
+			"calc": {Summary: skill.Summary{Name: "calc"}, Body: "Calc body"},
+		},
+		paths: map[string]string{
+			"calc": "/tmp/skills/local/calc",
+		},
+		roots: []string{"/tmp/skills/local"},
+	}
+	inv := &agent.Invocation{
+		AgentName: "tester",
+		Session: &session.Session{
+			State: session.StateMap{
+				skill.LoadedKey("tester", "calc"): []byte("1"),
+			},
+		},
+	}
+	req := &model.Request{
+		Messages: []model.Message{
+			model.NewSystemMessage("sys"),
+		},
+	}
+	p := NewSkillsRequestProcessor(
+		repo,
+		WithSkillLoadMode(SkillLoadModeSession),
+		WithSkillsFilePathHints(true),
+		WithSkillsCapabilityGuidance(""),
+		WithSkillsToolingGuidance(""),
+	)
+	p.ProcessRequest(context.Background(), inv, req, nil)
+
+	sys := req.Messages[0].Content
+	require.Contains(t, sys, skillRootsHeader)
+	require.Contains(
+		t,
+		sys,
+		"- calc: math ops (file: [s1]/calc/"+skill.SkillFile+")",
+	)
+	require.Contains(
+		t,
+		sys,
+		skillFileLabel+"/tmp/skills/local/calc/"+skill.SkillFile,
+	)
+}
+
 func TestSkillsRequestProcessor_CapabilityGuidanceOverride(t *testing.T) {
 	repo := &mockRepo{
 		sums: []skill.Summary{{Name: "x", Description: "d"}},
@@ -304,6 +351,32 @@ func TestSkillsRequestProcessor_CapabilityGuidanceOverride(t *testing.T) {
 		sys,
 		"Built-in skill execution tools are unavailable",
 	)
+}
+
+func TestSkillsRequestProcessor_ProtocolGuidanceOverride(t *testing.T) {
+	repo := &mockRepo{
+		sums: []skill.Summary{{Name: "x", Description: "d"}},
+		full: map[string]*skill.Skill{},
+	}
+	inv := &agent.Invocation{Session: &session.Session{}}
+	req := &model.Request{Messages: nil}
+	p := NewSkillsRequestProcessor(
+		repo,
+		WithSkillToolProfile(skillprofile.KnowledgeOnly),
+		WithSkillsProtocolGuidance(
+			"Always load SKILL.md before answering.",
+		),
+	)
+	p.ProcessRequest(context.Background(), inv, req, nil)
+
+	sys := req.Messages[0].Content
+	require.Contains(
+		t,
+		sys,
+		"Always load SKILL.md before answering.",
+	)
+	require.NotContains(t, sys, skillsCapabilityHeader)
+	require.NotContains(t, sys, skillsToolingGuidanceHeader)
 }
 
 func TestSkillsRequestProcessor_ExecToolsDisabled(t *testing.T) {
@@ -1683,6 +1756,53 @@ func TestSkillsToolResultRequestProcessor_DirectoryHints(t *testing.T) {
 		}
 		require.Contains(t, m.Content, "[Loaded] calc")
 		require.Contains(t, m.Content, skillDirLabel+"/tmp/skills/local/calc")
+	}
+}
+
+func TestSkillsToolResultRequestProcessor_FilePathHints(t *testing.T) {
+	repo := &mockRepo{
+		sums: []skill.Summary{{Name: "calc", Description: "math"}},
+		full: map[string]*skill.Skill{
+			"calc": {Summary: skill.Summary{Name: "calc"}, Body: "B"},
+		},
+		paths: map[string]string{
+			"calc": "/tmp/skills/local/calc",
+		},
+	}
+	inv := &agent.Invocation{
+		InvocationID: "inv1",
+		AgentName:    "tester",
+		Session: &session.Session{
+			State: session.StateMap{
+				skill.LoadedKey("tester", "calc"): []byte("1"),
+			},
+		},
+	}
+	req := &model.Request{
+		Messages: []model.Message{
+			model.NewSystemMessage("sys"),
+			model.NewUserMessage("u"),
+		},
+	}
+	p := NewSkillsToolResultRequestProcessor(
+		repo,
+		WithSkillsToolResultLoadMode(SkillLoadModeSession),
+		WithSkillsToolResultFilePathHints(true),
+	)
+	p.ProcessRequest(context.Background(), inv, req, nil)
+
+	for _, m := range req.Messages {
+		if m.Role != model.RoleSystem {
+			continue
+		}
+		if !strings.Contains(m.Content, skillsLoadedContextHeader) {
+			continue
+		}
+		require.Contains(
+			t,
+			m.Content,
+			skillFileLabel+"/tmp/skills/local/calc/"+skill.SkillFile,
+		)
 	}
 }
 

--- a/internal/flow/processor/skills_test.go
+++ b/internal/flow/processor/skills_test.go
@@ -375,6 +375,11 @@ func TestSkillsRequestProcessor_ProtocolGuidanceOverride(t *testing.T) {
 		sys,
 		"Always load SKILL.md before answering.",
 	)
+	require.Less(
+		t,
+		strings.Index(sys, "Always load SKILL.md before answering."),
+		strings.Index(sys, skillsOverviewHeader),
+	)
 	require.NotContains(t, sys, skillsCapabilityHeader)
 	require.NotContains(t, sys, skillsToolingGuidanceHeader)
 }

--- a/internal/flow/processor/skills_test.go
+++ b/internal/flow/processor/skills_test.go
@@ -30,6 +30,7 @@ type mockRepo struct {
 	full  map[string]*skill.Skill
 	paths map[string]string
 	roots []string
+	errs  map[string]error
 }
 
 func (m *mockRepo) Summaries() []skill.Summary { return m.sums }
@@ -40,6 +41,9 @@ func (m *mockRepo) Get(name string) (*skill.Skill, error) {
 	return nil, nil
 }
 func (m *mockRepo) Path(name string) (string, error) {
+	if err, ok := m.errs[name]; ok {
+		return "", err
+	}
 	if dir, ok := m.paths[name]; ok {
 		return dir, nil
 	}
@@ -327,6 +331,181 @@ func TestSkillsRequestProcessor_FilePathHints(t *testing.T) {
 		sys,
 		skillFileLabel+"/tmp/skills/local/calc/"+skill.SkillFile,
 	)
+}
+
+func TestSkillsRequestProcessor_RepositoryResolverAndHints(t *testing.T) {
+	resolvedRepo := &mockRepo{
+		sums: []skill.Summary{{Name: "calc", Description: "math ops"}},
+		full: map[string]*skill.Skill{
+			"calc": {
+				Summary: skill.Summary{Name: "calc"},
+				Body:    "Calc body",
+			},
+		},
+		paths: map[string]string{
+			"calc": "/tmp/skills/local/calc",
+		},
+		roots: []string{
+			"/tmp/skills/local",
+			"/tmp/skills/local",
+		},
+	}
+	inv := &agent.Invocation{
+		AgentName: "tester",
+		Session: &session.Session{
+			State: session.StateMap{
+				skill.LoadedKey("tester", "calc"): []byte("1"),
+			},
+		},
+	}
+	req := &model.Request{
+		Messages: []model.Message{
+			model.NewSystemMessage("sys"),
+		},
+	}
+	p := NewSkillsRequestProcessor(
+		nil,
+		WithSkillsRepositoryResolver(
+			func(*agent.Invocation) skill.Repository { return resolvedRepo },
+		),
+		WithSkillsDirectoryHints(true),
+		WithSkillsFilePathHints(true),
+		WithSkillsCapabilityGuidance(""),
+		WithSkillsToolingGuidance(""),
+	)
+	require.Same(t, resolvedRepo, p.repositoryForInvocation(inv))
+	p.ProcessRequest(context.Background(), inv, req, nil)
+
+	sys := req.Messages[0].Content
+	require.Contains(t, sys, skillRootsHeader)
+	require.Contains(t, sys, "- [s1]=/tmp/skills/local")
+	require.NotContains(t, sys, "- [s2]=/tmp/skills/local")
+	require.Contains(
+		t,
+		sys,
+		"- calc: math ops (file: [s1]/calc/"+skill.SkillFile+")",
+	)
+}
+
+func TestSkillPathHelpers(t *testing.T) {
+	repo := &mockRepo{
+		paths: map[string]string{
+			"calc":  "/tmp/skills/local/calc",
+			"root":  "/tmp/skills/local",
+			"other": "/var/tmp/other",
+		},
+		roots: []string{
+			" /tmp/skills/local ",
+			"/tmp/skills/local",
+		},
+		errs: map[string]error{
+			"bad":     context.DeadlineExceeded,
+			"missing": context.Canceled,
+		},
+	}
+
+	t.Run("root aliases dedupe and clean", func(t *testing.T) {
+		aliases := skillRootAliases(repo)
+		require.Equal(
+			t,
+			[]skillRootAlias{{
+				alias: "s1",
+				root:  "/tmp/skills/local",
+			}},
+			aliases,
+		)
+		text := buildSkillRootsText(repo)
+		require.Contains(t, text, skillRootsHeader)
+		require.Contains(t, text, "- [s1]=/tmp/skills/local")
+	})
+
+	t.Run("locators prefer aliases and fall back", func(t *testing.T) {
+		ctx := context.Background()
+		require.Equal(
+			t,
+			"[s1]/calc",
+			skillDirectoryLocator(ctx, repo, "calc"),
+		)
+		require.Equal(
+			t,
+			"[s1]/calc/"+skill.SkillFile,
+			skillFileLocator(ctx, repo, "calc"),
+		)
+		require.Equal(
+			t,
+			"[s1]",
+			skillDirectoryLocator(ctx, repo, "root"),
+		)
+		require.Equal(
+			t,
+			"[s1]/"+skill.SkillFile,
+			skillFileLocator(ctx, repo, "root"),
+		)
+		require.Equal(
+			t,
+			"/var/tmp/other",
+			skillDirectoryLocator(ctx, repo, "other"),
+		)
+		require.Equal(
+			t,
+			"/var/tmp/other/"+skill.SkillFile,
+			skillFileLocator(ctx, repo, "other"),
+		)
+		require.Empty(t, skillDirectoryLocator(ctx, repo, "bad"))
+		require.Empty(t, skillFileLocator(ctx, repo, "missing"))
+	})
+
+	t.Run("relative path accepts root and rejects escapes", func(t *testing.T) {
+		rel, ok := relativeSkillPath("/tmp/skills", "/tmp/skills")
+		require.True(t, ok)
+		require.Empty(t, rel)
+
+		rel, ok = relativeSkillPath(
+			"/tmp/skills",
+			"/tmp/skills/local/calc",
+		)
+		require.True(t, ok)
+		require.Equal(t, "local/calc", rel)
+
+		rel, ok = relativeSkillPath("/tmp/skills", "/tmp/other")
+		require.False(t, ok)
+		require.Empty(t, rel)
+	})
+
+	t.Run("overview suffix and path hints honor configured fields", func(t *testing.T) {
+		ctx := context.Background()
+		dirOnly := &SkillsRequestProcessor{directoryHints: true}
+		fileOnly := &SkillsRequestProcessor{filePathHints: true}
+		require.Equal(
+			t,
+			" (dir: [s1]/calc)",
+			dirOnly.skillOverviewSuffix(ctx, repo, "calc"),
+		)
+		require.Equal(
+			t,
+			" (file: [s1]/calc/"+skill.SkillFile+")",
+			fileOnly.skillOverviewSuffix(ctx, repo, "calc"),
+		)
+
+		var b strings.Builder
+		fileAndDir := &SkillsRequestProcessor{
+			directoryHints: true,
+			filePathHints:  true,
+		}
+		fileAndDir.appendSkillPathHints(&b, ctx, repo, "calc")
+		require.Contains(
+			t,
+			b.String(),
+			skillDirLabel+"/tmp/skills/local/calc",
+		)
+		require.Contains(
+			t,
+			b.String(),
+			skillFileLabel+"/tmp/skills/local/calc/"+skill.SkillFile,
+		)
+
+		fileAndDir.appendSkillPathHints(nil, ctx, repo, "calc")
+	})
 }
 
 func TestSkillsRequestProcessor_CapabilityGuidanceOverride(t *testing.T) {
@@ -2242,6 +2421,12 @@ func TestSkillsToolResultRequestProcessor_RebuildRequestForContextCompaction(
 	loaded, ok := inv.Session.GetState(skill.LoadedKey("tester", "calc"))
 	require.True(t, ok)
 	require.Equal(t, []byte("1"), loaded)
+
+	t.Run("nil inputs are ignored", func(t *testing.T) {
+		p := NewSkillsToolResultRequestProcessor(repo)
+		p.RebuildRequestForContextCompaction(context.Background(), nil, req)
+		p.RebuildRequestForContextCompaction(context.Background(), inv, nil)
+	})
 }
 
 func TestHasSessionSummary(t *testing.T) {

--- a/internal/flow/processor/skills_tool_result.go
+++ b/internal/flow/processor/skills_tool_result.go
@@ -34,6 +34,7 @@ type skillsToolResultProcessorOptions struct {
 	loadMode                     string
 	skipFallbackOnSessionSummary bool
 	repoResolver                 func(*agent.Invocation) skill.Repository
+	directoryHints               bool
 }
 
 // SkillsToolResultRequestProcessorOption configures
@@ -79,6 +80,16 @@ func WithSkillsToolResultRepositoryResolver(
 	}
 }
 
+// WithSkillsToolResultDirectoryHints exposes skill directory locators in
+// loaded skill materialization.
+func WithSkillsToolResultDirectoryHints(
+	enable bool,
+) SkillsToolResultRequestProcessorOption {
+	return func(o *skillsToolResultProcessorOptions) {
+		o.directoryHints = enable
+	}
+}
+
 // SkillsToolResultRequestProcessor materializes loaded skill content
 // into tool result messages (skill_load / skill_select_docs) when
 // possible.
@@ -96,6 +107,7 @@ type SkillsToolResultRequestProcessor struct {
 	loadMode     string
 
 	skipFallbackOnSessionSummary bool
+	directoryHints               bool
 }
 
 // NewSkillsToolResultRequestProcessor creates a processor instance.
@@ -117,6 +129,7 @@ func NewSkillsToolResultRequestProcessor(
 		repoResolver:                 options.repoResolver,
 		loadMode:                     normalizeSkillLoadMode(options.loadMode),
 		skipFallbackOnSessionSummary: options.skipFallbackOnSessionSummary,
+		directoryHints:               options.directoryHints,
 	}
 }
 
@@ -393,7 +406,15 @@ func (p *SkillsToolResultRequestProcessor) buildToolResultContent(
 	if strings.TrimSpace(sk.Body) != "" {
 		b.WriteString("[Loaded] ")
 		b.WriteString(skillName)
-		b.WriteString("\n\n")
+		b.WriteString("\n")
+		if p.directoryHints {
+			if dir := skillDirectoryText(ctx, repo, skillName); dir != "" {
+				b.WriteString(skillDirLabel)
+				b.WriteString(dir)
+				b.WriteString("\n")
+			}
+		}
+		b.WriteString("\n")
 		b.WriteString(sk.Body)
 		b.WriteString("\n")
 	}
@@ -509,7 +530,15 @@ func (p *SkillsToolResultRequestProcessor) buildFallbackSystemContent(
 		if strings.TrimSpace(sk.Body) != "" {
 			b.WriteString("\n[Loaded] ")
 			b.WriteString(name)
-			b.WriteString("\n\n")
+			b.WriteString("\n")
+			if p.directoryHints {
+				if dir := skillDirectoryText(ctx, repo, name); dir != "" {
+					b.WriteString(skillDirLabel)
+					b.WriteString(dir)
+					b.WriteString("\n")
+				}
+			}
+			b.WriteString("\n")
 			b.WriteString(sk.Body)
 			b.WriteString("\n")
 			appended = true

--- a/internal/flow/processor/skills_tool_result.go
+++ b/internal/flow/processor/skills_tool_result.go
@@ -35,6 +35,7 @@ type skillsToolResultProcessorOptions struct {
 	skipFallbackOnSessionSummary bool
 	repoResolver                 func(*agent.Invocation) skill.Repository
 	directoryHints               bool
+	filePathHints                bool
 }
 
 // SkillsToolResultRequestProcessorOption configures
@@ -90,6 +91,16 @@ func WithSkillsToolResultDirectoryHints(
 	}
 }
 
+// WithSkillsToolResultFilePathHints exposes SKILL.md file paths in loaded
+// skill materialization.
+func WithSkillsToolResultFilePathHints(
+	enable bool,
+) SkillsToolResultRequestProcessorOption {
+	return func(o *skillsToolResultProcessorOptions) {
+		o.filePathHints = enable
+	}
+}
+
 // SkillsToolResultRequestProcessor materializes loaded skill content
 // into tool result messages (skill_load / skill_select_docs) when
 // possible.
@@ -108,6 +119,7 @@ type SkillsToolResultRequestProcessor struct {
 
 	skipFallbackOnSessionSummary bool
 	directoryHints               bool
+	filePathHints                bool
 }
 
 // NewSkillsToolResultRequestProcessor creates a processor instance.
@@ -130,6 +142,7 @@ func NewSkillsToolResultRequestProcessor(
 		loadMode:                     normalizeSkillLoadMode(options.loadMode),
 		skipFallbackOnSessionSummary: options.skipFallbackOnSessionSummary,
 		directoryHints:               options.directoryHints,
+		filePathHints:                options.filePathHints,
 	}
 }
 
@@ -407,13 +420,7 @@ func (p *SkillsToolResultRequestProcessor) buildToolResultContent(
 		b.WriteString("[Loaded] ")
 		b.WriteString(skillName)
 		b.WriteString("\n")
-		if p.directoryHints {
-			if dir := skillDirectoryText(ctx, repo, skillName); dir != "" {
-				b.WriteString(skillDirLabel)
-				b.WriteString(dir)
-				b.WriteString("\n")
-			}
-		}
+		p.appendSkillPathHints(&b, ctx, repo, skillName)
 		b.WriteString("\n")
 		b.WriteString(sk.Body)
 		b.WriteString("\n")
@@ -531,13 +538,7 @@ func (p *SkillsToolResultRequestProcessor) buildFallbackSystemContent(
 			b.WriteString("\n[Loaded] ")
 			b.WriteString(name)
 			b.WriteString("\n")
-			if p.directoryHints {
-				if dir := skillDirectoryText(ctx, repo, name); dir != "" {
-					b.WriteString(skillDirLabel)
-					b.WriteString(dir)
-					b.WriteString("\n")
-				}
-			}
+			p.appendSkillPathHints(&b, ctx, repo, name)
 			b.WriteString("\n")
 			b.WriteString(sk.Body)
 			b.WriteString("\n")
@@ -562,6 +563,31 @@ func (p *SkillsToolResultRequestProcessor) buildFallbackSystemContent(
 		return ""
 	}
 	return strings.TrimSpace(b.String())
+}
+
+func (p *SkillsToolResultRequestProcessor) appendSkillPathHints(
+	b *strings.Builder,
+	ctx context.Context,
+	repo skill.Repository,
+	name string,
+) {
+	if b == nil {
+		return
+	}
+	if p.directoryHints {
+		if dir := skillDirectoryText(ctx, repo, name); dir != "" {
+			b.WriteString(skillDirLabel)
+			b.WriteString(dir)
+			b.WriteString("\n")
+		}
+	}
+	if p.filePathHints {
+		if path := skillFileText(ctx, repo, name); path != "" {
+			b.WriteString(skillFileLabel)
+			b.WriteString(path)
+			b.WriteString("\n")
+		}
+	}
 }
 
 func (p *SkillsToolResultRequestProcessor) upsertLoadedContextMessage(

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -1163,6 +1163,7 @@ skills:
   watch: true
   watch_bundled: false
   watch_debounce_ms: 250
+  tool_profile: "full" # full|knowledge_only
   load_mode: "turn" # once|turn|session
   loaded_content_in_tool_results: true
   max_loaded_skills: 0
@@ -1183,6 +1184,12 @@ skills:
 OpenClaw defaults to materializing loaded skill bodies/docs into tool
 result messages. This keeps the system prompt more stable while still
 letting `SkillLoadMode` control how long loaded skill state survives.
+
+`tool_profile: "knowledge_only"` keeps `skill_load`,
+`skill_list_docs`, and `skill_select_docs`, while hiding execution
+tools such as `skill_run`. This is useful when you want skills to
+provide guidance and supporting docs but keep actual execution on the
+normal runtime tool surface.
 
 When `skills.watch` is enabled, changes under local filesystem skill
 roots are picked up automatically after the watch debounce fires.

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -1163,7 +1163,7 @@ skills:
   watch: true
   watch_bundled: false
   watch_debounce_ms: 250
-  tool_profile: "full" # full|knowledge_only
+  tool_profile: "knowledge_only" # knowledge_only|full
   load_mode: "turn" # once|turn|session
   loaded_content_in_tool_results: true
   max_loaded_skills: 0
@@ -1185,11 +1185,14 @@ OpenClaw defaults to materializing loaded skill bodies/docs into tool
 result messages. This keeps the system prompt more stable while still
 letting `SkillLoadMode` control how long loaded skill state survives.
 
-`tool_profile: "knowledge_only"` keeps `skill_load`,
+`tool_profile: "knowledge_only"` is the default. It keeps `skill_load`,
 `skill_list_docs`, and `skill_select_docs`, while hiding execution
 tools such as `skill_run`. This is useful when you want skills to
 provide guidance and supporting docs but keep actual execution on the
 normal runtime tool surface.
+
+Use `tool_profile: "full"` only when you explicitly want the built-in
+skill execution tools to be visible to the model.
 
 When `skills.watch` is enabled, changes under local filesystem skill
 roots are picked up automatically after the watch debounce fires.

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -279,6 +279,9 @@ tools:
   # When enabled and the model returns multiple tool calls in one step,
   # OpenClaw executes them concurrently.
   enable_parallel_tools: true
+  # Optional: override the built-in OpenClaw tooling guidance prompt.
+  # Leave unset to use the built-in default, or set to "" to disable it.
+  openclaw_tooling_guidance: ""
   providers:
     - type: "browser"
       name: "browser-runtime"

--- a/openclaw/README.zh_CN.md
+++ b/openclaw/README.zh_CN.md
@@ -1059,6 +1059,7 @@ skills:
   # 可选：限制默认启用的内置技能。
   # 仅适用于 ./openclaw/skills 下的内置技能。
   allowBundled: ["gh-issues", "notion"]
+  tool_profile: "full" # full|knowledge_only
   load_mode: "turn" # once|turn|session
   loaded_content_in_tool_results: true
   max_loaded_skills: 0
@@ -1079,6 +1080,11 @@ skills:
 OpenClaw 默认将加载的技能正文/文档物化到 tool result 消息中。
 这样可以保持 system prompt 更稳定，同时仍允许 `SkillLoadMode`
 控制加载的技能状态的存活时间。
+
+将 `tool_profile` 设为 `"knowledge_only"` 时，会保留
+`skill_load`、`skill_list_docs`、`skill_select_docs`，但隐藏
+`skill_run` 这类执行工具。适合让技能只提供说明和补充文档，
+实际执行仍统一走常规 runtime tool 表面。
 
 内置技能指导默认更面向运行时：agent 在有技能自带脚本时优先使用，
 并可以使用最小的只读探测（如 `--help` 或 `--version`）来验证外部 CLI

--- a/openclaw/README.zh_CN.md
+++ b/openclaw/README.zh_CN.md
@@ -1059,7 +1059,7 @@ skills:
   # 可选：限制默认启用的内置技能。
   # 仅适用于 ./openclaw/skills 下的内置技能。
   allowBundled: ["gh-issues", "notion"]
-  tool_profile: "full" # full|knowledge_only
+  tool_profile: "knowledge_only" # knowledge_only|full
   load_mode: "turn" # once|turn|session
   loaded_content_in_tool_results: true
   max_loaded_skills: 0
@@ -1081,10 +1081,13 @@ OpenClaw 默认将加载的技能正文/文档物化到 tool result 消息中。
 这样可以保持 system prompt 更稳定，同时仍允许 `SkillLoadMode`
 控制加载的技能状态的存活时间。
 
-将 `tool_profile` 设为 `"knowledge_only"` 时，会保留
+`"knowledge_only"` 现在是默认值。它会保留
 `skill_load`、`skill_list_docs`、`skill_select_docs`，但隐藏
 `skill_run` 这类执行工具。适合让技能只提供说明和补充文档，
 实际执行仍统一走常规 runtime tool 表面。
+
+只有在你明确希望把内置的 skill 执行工具也暴露给模型时，
+才需要改成 `tool_profile: "full"`。
 
 内置技能指导默认更面向运行时：agent 在有技能自带脚本时优先使用，
 并可以使用最小的只读探测（如 `--help` 或 `--version`）来验证外部 CLI

--- a/openclaw/README.zh_CN.md
+++ b/openclaw/README.zh_CN.md
@@ -268,6 +268,9 @@ tools:
   # 启用后，当模型在一个步骤中返回多个 tool call 时，
   # OpenClaw 会并发执行它们。
   enable_parallel_tools: true
+  # 可选：覆盖内置的 OpenClaw tooling guidance 提示词。
+  # 不设置时使用内置默认值，设为 "" 可禁用它。
+  openclaw_tooling_guidance: ""
   providers:
     - type: "browser"
       name: "browser-runtime"

--- a/openclaw/app/admin_runtime_config.go
+++ b/openclaw/app/admin_runtime_config.go
@@ -19,6 +19,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"trpc.group/trpc-go/trpc-agent-go/internal/skillprofile"
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/admin"
 )
 
@@ -405,6 +406,22 @@ func adminRuntimeConfigSectionSpecs() []adminRuntimeConfigSectionSpec {
 							int(opts.SkillsWatchDebounce / time.Millisecond),
 						)
 					},
+				),
+				adminRuntimeSelectField(
+					"skills.tool_profile",
+					"Tool Profile",
+					"Which built-in skill tools are exposed.",
+					[]adminRuntimeConfigKeyRef{
+						adminRuntimeKey("skills"),
+						adminRuntimeKey("tool_profile"),
+					},
+					func(opts runOptions) string {
+						return strings.TrimSpace(
+							opts.SkillsToolProfile,
+						)
+					},
+					skillprofile.Full,
+					skillprofile.KnowledgeOnly,
 				),
 				adminRuntimeSelectField(
 					"skills.load_mode",

--- a/openclaw/app/admin_runtime_config.go
+++ b/openclaw/app/admin_runtime_config.go
@@ -420,8 +420,8 @@ func adminRuntimeConfigSectionSpecs() []adminRuntimeConfigSectionSpec {
 							opts.SkillsToolProfile,
 						)
 					},
-					skillprofile.Full,
 					skillprofile.KnowledgeOnly,
+					skillprofile.Full,
 				),
 				adminRuntimeSelectField(
 					"skills.load_mode",

--- a/openclaw/app/admin_runtime_config.go
+++ b/openclaw/app/admin_runtime_config.go
@@ -413,7 +413,7 @@ func adminRuntimeConfigSectionSpecs() []adminRuntimeConfigSectionSpec {
 					"Which built-in skill tools are exposed.",
 					[]adminRuntimeConfigKeyRef{
 						adminRuntimeKey("skills"),
-						adminRuntimeKey("tool_profile"),
+						adminRuntimeKey("tool_profile", "toolProfile"),
 					},
 					func(opts runOptions) string {
 						return strings.TrimSpace(

--- a/openclaw/app/admin_runtime_config.go
+++ b/openclaw/app/admin_runtime_config.go
@@ -505,6 +505,27 @@ func adminRuntimeConfigSectionSpecs() []adminRuntimeConfigSectionSpec {
 						return strconv.FormatBool(opts.EnableOpenClawTools)
 					},
 				),
+				adminRuntimeTextField(
+					"tools.openclaw_tooling_guidance",
+					"OpenClaw Tooling Guidance",
+					"Override or disable the built-in OpenClaw tooling guidance. Leave unset to use the built-in default, or set an empty string to disable injection.",
+					"",
+					[]adminRuntimeConfigKeyRef{
+						adminRuntimeKey("tools"),
+						adminRuntimeKey(
+							"openclaw_tooling_guidance",
+							"openClawToolingGuidance",
+						),
+					},
+					func(opts runOptions) string {
+						if opts.OpenClawToolingGuide != nil {
+							return *opts.OpenClawToolingGuide
+						}
+						return strings.TrimSpace(
+							openClawToolingGuidance,
+						)
+					},
+				),
 				adminRuntimeBoolField(
 					"tools.enable_parallel_tools",
 					"Enable Parallel Tools",

--- a/openclaw/app/admin_runtime_config_test.go
+++ b/openclaw/app/admin_runtime_config_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
+	"trpc.group/trpc-go/trpc-agent-go/internal/skillprofile"
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/admin"
 )
 
@@ -277,6 +278,7 @@ func TestAdminRuntimeConfigProvider_ErrorPaths(t *testing.T) {
 	require.Error(t, provider.ResetRuntimeConfigValue("missing"))
 	require.Error(t, provider.SaveRuntimeConfigValue("admin.auto_port", "maybe"))
 	require.Error(t, provider.SaveRuntimeConfigValue("skills.max_loaded_skills", "nan"))
+	require.Error(t, provider.SaveRuntimeConfigValue("skills.tool_profile", "invalid"))
 	require.Error(t, provider.SaveRuntimeConfigValue("skills.load_mode", "invalid"))
 
 	badPath := writeAdminRuntimeConfigTestFile(
@@ -717,6 +719,7 @@ func adminRuntimeConfigTestOptions(configPath string) runOptions {
 		OpenAIVariant:        defaultOpenAIVariant,
 		SkillsWatch:          true,
 		SkillsWatchDebounce:  defaultSkillsWatchDebounce,
+		SkillsToolProfile:    defaultSkillsToolProfile,
 		SkillsLoadMode:       defaultSkillsLoadMode,
 		SkillsMaxLoaded:      0,
 		SkillsToolResults:    true,
@@ -760,4 +763,48 @@ func findAdminRuntimeConfigField(
 	}
 	t.Fatalf("runtime config field %q not found", key)
 	return admin.RuntimeConfigField{}
+}
+
+func TestBuildAdminOptions_ExposesSkillsToolProfileField(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	cfgPath := writeAdminRuntimeConfigTestFile(
+		t,
+		"skills:\n  tool_profile: knowledge_only\n",
+	)
+	opts := adminRuntimeConfigTestOptions(cfgPath)
+	opts.SkillsToolProfile = skillprofile.KnowledgeOnly
+
+	provider, ok := buildAdminRuntimeConfigProvider(
+		opts,
+	).(*adminRuntimeConfigProvider)
+	require.True(t, ok)
+
+	status, err := provider.RuntimeConfigStatus()
+	require.NoError(t, err)
+	field := findAdminRuntimeConfigField(
+		t,
+		status,
+		"skills.tool_profile",
+	)
+	require.Equal(t, skillprofile.KnowledgeOnly, field.RuntimeValue)
+	require.Equal(
+		t,
+		skillprofile.KnowledgeOnly,
+		field.ConfiguredValue,
+	)
+	require.Equal(
+		t,
+		adminRuntimeConfigInputSelect,
+		field.InputType,
+	)
+	require.Len(t, field.Options, 2)
+	require.Equal(t, skillprofile.Full, field.Options[0].Value)
+	require.Equal(
+		t,
+		skillprofile.KnowledgeOnly,
+		field.Options[1].Value,
+	)
 }

--- a/openclaw/app/admin_runtime_config_test.go
+++ b/openclaw/app/admin_runtime_config_test.go
@@ -801,10 +801,14 @@ func TestBuildAdminOptions_ExposesSkillsToolProfileField(
 		field.InputType,
 	)
 	require.Len(t, field.Options, 2)
-	require.Equal(t, skillprofile.Full, field.Options[0].Value)
 	require.Equal(
 		t,
 		skillprofile.KnowledgeOnly,
+		field.Options[0].Value,
+	)
+	require.Equal(
+		t,
+		skillprofile.Full,
 		field.Options[1].Value,
 	)
 }

--- a/openclaw/app/admin_runtime_config_test.go
+++ b/openclaw/app/admin_runtime_config_test.go
@@ -772,7 +772,7 @@ func TestBuildAdminOptions_ExposesSkillsToolProfileField(
 
 	cfgPath := writeAdminRuntimeConfigTestFile(
 		t,
-		"skills:\n  tool_profile: knowledge_only\n",
+		"skills:\n  toolProfile: knowledge_only\n",
 	)
 	opts := adminRuntimeConfigTestOptions(cfgPath)
 	opts.SkillsToolProfile = skillprofile.KnowledgeOnly

--- a/openclaw/app/admin_runtime_config_test.go
+++ b/openclaw/app/admin_runtime_config_test.go
@@ -812,3 +812,37 @@ func TestBuildAdminOptions_ExposesSkillsToolProfileField(
 		field.Options[1].Value,
 	)
 }
+
+func TestBuildAdminOptions_ExposesOpenClawToolingGuidanceField(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	cfgPath := writeAdminRuntimeConfigTestFile(
+		t,
+		"tools:\n  openclaw_tooling_guidance: \"\"\n",
+	)
+	opts := adminRuntimeConfigTestOptions(cfgPath)
+	guide := ""
+	opts.OpenClawToolingGuide = &guide
+
+	provider, ok := buildAdminRuntimeConfigProvider(
+		opts,
+	).(*adminRuntimeConfigProvider)
+	require.True(t, ok)
+
+	status, err := provider.RuntimeConfigStatus()
+	require.NoError(t, err)
+	field := findAdminRuntimeConfigField(
+		t,
+		status,
+		"tools.openclaw_tooling_guidance",
+	)
+	require.Equal(t, "", field.RuntimeValue)
+	require.Equal(t, "", field.ConfiguredValue)
+	require.Equal(
+		t,
+		adminRuntimeConfigInputText,
+		field.InputType,
+	)
+}

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -112,11 +112,11 @@ const (
 		"OPENCLAW_LAST_UPLOAD_MIME, and " +
 		"OPENCLAW_MEMORY_FILE, " +
 		"OPENCLAW_RECENT_UPLOADS_JSON instead of guessing " +
-		"attachment paths. When a user follows " +
-		"up about 'the PDF/audio/video I just sent', assume they " +
-		"mean the recent upload already present in this chat unless " +
-		"the reference is genuinely ambiguous. Match by media kind " +
-		"first: prefer OPENCLAW_LAST_PDF_PATH, " +
+		"attachment paths. When a user follows up about a " +
+		"recent upload in the current chat, assume they mean " +
+		"that existing upload unless the reference is " +
+		"genuinely ambiguous. Match by media kind first: " +
+		"prefer OPENCLAW_LAST_PDF_PATH, " +
 		"OPENCLAW_LAST_AUDIO_PATH, OPENCLAW_LAST_VIDEO_PATH, or " +
 		"OPENCLAW_LAST_IMAGE_PATH when the request clearly targets " +
 		"one of those kinds. Telegram voice notes count as audio, " +
@@ -127,18 +127,17 @@ const (
 		"the default target unless they clearly ask for something " +
 		"else. Do not ask the user to re-upload a file or provide " +
 		"a local path when the recent upload context already lists " +
-		"a matching upload for this chat. If the user asks you to " +
-		"'send it back', '发给我', " +
-		"'回传', or similar, send the derived files directly in " +
-		"the current chat with message instead of asking which " +
-		"channel or delivery method to use. For exec_command, do " +
+		"a matching upload for this chat. If the user wants a " +
+		"derived file sent back in the current chat, send it with " +
+		"message instead of asking which channel or delivery " +
+		"method to use. For exec_command, do " +
 		"not assume skill workspace paths like work/inputs. Do not " +
 		"expose local host paths to the user; when acknowledging a " +
 		"new upload, refer to it only by filename and media kind, " +
-		"not by OPENCLAW_* vars or a machine path. If Telegram gives " +
-		"you an opaque placeholder filename like file_11.oga, avoid " +
-		"surfacing that raw placeholder to the user unless they " +
-		"explicitly ask for the exact filename. Refer to uploads " +
+		"not by OPENCLAW_* vars or a machine path. If the channel " +
+		"gives you an opaque placeholder filename, avoid surfacing " +
+		"that raw placeholder to the user unless they explicitly " +
+		"ask for the exact filename. Refer to uploads " +
 		"and generated files by user-facing filenames, and use " +
 		"OPENCLAW_LAST_*_NAME instead of basename(" +
 		"OPENCLAW_LAST_*_PATH) when deriving output filenames, " +

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -847,9 +847,10 @@ func NewRuntime(
 			StateDir:            resolvedStateDir,
 			MemoryFileStore:     fileMemoryStore,
 
-			EnableLocalExec:     opts.EnableLocalExec,
-			EnableOpenClawTools: opts.EnableOpenClawTools,
-			EnableParallelTools: opts.EnableParallelTools,
+			EnableLocalExec:      opts.EnableLocalExec,
+			EnableOpenClawTools:  opts.EnableOpenClawTools,
+			OpenClawToolingGuide: opts.OpenClawToolingGuide,
+			EnableParallelTools:  opts.EnableParallelTools,
 
 			ToolProviders: opts.ToolProviders,
 			ToolSets:      opts.ToolSets,
@@ -2081,9 +2082,11 @@ func newAgent(
 		instruction = defaultAgentInstruction
 	}
 	if cfg.EnableOpenClawTools {
-		instruction = strings.TrimSpace(
-			instruction + "\n\n" + buildOpenClawToolingGuidance(cfg),
-		)
+		if guidance := buildOpenClawToolingGuidance(cfg); strings.TrimSpace(guidance) != "" {
+			instruction = strings.TrimSpace(
+				instruction + "\n\n" + guidance,
+			)
+		}
 	}
 	knowledgeTools, err := buildKnowledgeTools(cfg.KnowledgesConfig)
 	if err != nil {
@@ -2202,7 +2205,9 @@ func newAgent(
 }
 
 func buildOpenClawToolingGuidance(cfg agentConfig) string {
-	_ = cfg
+	if cfg.OpenClawToolingGuide != nil {
+		return strings.TrimSpace(*cfg.OpenClawToolingGuide)
+	}
 	return strings.TrimSpace(openClawToolingGuidance)
 }
 
@@ -2406,8 +2411,9 @@ type agentConfig struct {
 
 	EnableLocalExec bool
 
-	EnableOpenClawTools bool
-	EnableParallelTools bool
+	EnableOpenClawTools  bool
+	OpenClawToolingGuide *string
+	EnableParallelTools  bool
 
 	ToolProviders []pluginSpec
 

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -89,26 +89,32 @@ const (
 	defaultAgentName        = "assistant"
 	defaultAgentInstruction = "You are a helpful assistant. " +
 		"Keep replies concise."
-	openClawSkillsGuidance = "Treat the skill overview as an index " +
-		"of skill directories. When a skill looks relevant, " +
-		"call skill_load promptly so SKILL.md is in context " +
-		"before giving precise guidance or acting on the " +
-		"workflow. After loading a skill, inspect only the " +
-		"supporting docs, scripts, assets, examples, or " +
-		"templates you still need from that skill's " +
-		"directory. Follow the loaded skill instructions " +
-		"and bundled resources to complete the task, and " +
-		"reuse bundled scripts or templates when they " +
-		"already fit. Do not invent commands, flags, auth " +
-		"steps, file layouts, or release procedures from a " +
-		"short summary or partial memory alone. If a " +
-		"needed detail is missing, read the relevant skill " +
-		"files first and keep exploring nearby runtime " +
-		"facts, retries, and recovery paths before asking " +
-		"for more input. If completion still depends on an " +
-		"external input you cannot derive locally, state " +
-		"the exact missing piece tersely and keep the " +
-		"answer factual."
+	openClawSkillsGuidance = "Treat the skill overview as the " +
+		"skills available in this session. Each entry " +
+		"includes a path to that skill's SKILL.md on disk. " +
+		"If the user names a skill, names a slash command, " +
+		"or the task clearly matches a skill description, " +
+		"you must use that skill in the same turn. Never " +
+		"say that you could read or load a matching skill " +
+		"later without actually doing it first. Load " +
+		"SKILL.md before giving substantive guidance or " +
+		"acting on the workflow. When SKILL.md references " +
+		"relative paths, resolve them from the skill " +
+		"directory first. Read only the supporting docs, " +
+		"scripts, assets, examples, or templates you still " +
+		"need. Reuse bundled scripts, templates, and assets " +
+		"when they already fit. If multiple skills match, " +
+		"use the smallest set that covers the task. Keep " +
+		"context small and avoid bulk-loading docs. Do not " +
+		"invent commands, flags, auth steps, file layouts, " +
+		"or workflows from a short summary or partial " +
+		"memory. Keep exploring nearby runtime facts, " +
+		"retries, and recovery paths yourself before asking " +
+		"for more input. If a matching skill is missing, " +
+		"unreadable, or still lacks a required external " +
+		"input after reasonable local exploration, state " +
+		"the issue briefly and continue with the best " +
+		"fallback."
 	openClawToolingGuidance = "For common PDF, DOCX, text, CSV, " +
 		"and spreadsheet uploads already in the chat, prefer " +
 		"read_document or read_spreadsheet before falling back " +
@@ -2176,8 +2182,8 @@ func newAgent(
 		llmagent.WithSkillToolProfile(
 			llmagent.SkillToolProfile(cfg.SkillsToolProfile),
 		),
+		llmagent.WithSkillsFilePathHints(true),
 		llmagent.WithSkillsDirectoryHints(true),
-		llmagent.WithSkillsCapabilityGuidance(""),
 		llmagent.WithSkillLoadMode(cfg.SkillsLoadMode),
 		llmagent.WithSkillsLoadedContentInToolResults(
 			cfg.SkillsToolResults,
@@ -2185,7 +2191,7 @@ func newAgent(
 		llmagent.WithSkipSkillsFallbackOnSessionSummary(
 			cfg.SkillsSkipFallback,
 		),
-		llmagent.WithSkillsToolingGuidance(
+		llmagent.WithSkillsProtocolGuidance(
 			buildOpenClawSkillsGuidance(cfg),
 		),
 	)

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -89,7 +89,7 @@ const (
 	defaultAgentName        = "assistant"
 	defaultAgentInstruction = "You are a helpful assistant. " +
 		"Keep replies concise."
-	openClawSkillsGuidance = "Treat the skill overview as the " +
+	openClawSkillsGuidance = "Treat the skill overview below as the " +
 		"skills available in this session. Each entry " +
 		"includes a path to that skill's SKILL.md on disk. " +
 		"This is a blocking requirement for matching " +
@@ -103,8 +103,12 @@ const (
 		"unless you already called `skill_load` for it in " +
 		"this turn. Never say that you could read or load " +
 		"a matching skill later without actually doing it " +
-		"first. Load `SKILL.md` before giving substantive " +
-		"guidance or acting on the workflow. When " +
+		"first. Do not answer a matching skill task from " +
+		"the short summary, prior knowledge, or partial " +
+		"memory. Even if you think you already know the " +
+		"answer, load `SKILL.md` first. Load `SKILL.md` " +
+		"before giving substantive guidance or acting on " +
+		"the workflow. When " +
 		"`SKILL.md` references " +
 		"relative paths, resolve them from the skill " +
 		"directory first. Read only the supporting docs, " +

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -92,13 +92,20 @@ const (
 	openClawSkillsGuidance = "Treat the skill overview as the " +
 		"skills available in this session. Each entry " +
 		"includes a path to that skill's SKILL.md on disk. " +
+		"This is a blocking requirement for matching " +
+		"skills. " +
 		"If the user names a skill, names a slash command, " +
 		"or the task clearly matches a skill description, " +
-		"you must use that skill in the same turn. Never " +
-		"say that you could read or load a matching skill " +
-		"later without actually doing it first. Load " +
-		"SKILL.md before giving substantive guidance or " +
-		"acting on the workflow. When SKILL.md references " +
+		"you must use that skill in the same turn. Call " +
+		"`skill_load` for that skill before generating " +
+		"any other response about the task. Never mention " +
+		"reading, loading, or using a matching skill " +
+		"unless you already called `skill_load` for it in " +
+		"this turn. Never say that you could read or load " +
+		"a matching skill later without actually doing it " +
+		"first. Load `SKILL.md` before giving substantive " +
+		"guidance or acting on the workflow. When " +
+		"`SKILL.md` references " +
 		"relative paths, resolve them from the skill " +
 		"directory first. Read only the supporting docs, " +
 		"scripts, assets, examples, or templates you still " +

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -103,9 +103,12 @@ const (
 		"steps, file layouts, or release procedures from a " +
 		"short summary or partial memory alone. If a " +
 		"needed detail is missing, read the relevant skill " +
-		"files first. Only describe a blocker when a real " +
-		"missing permission, credential, network path, or " +
-		"runtime tool prevents completion."
+		"files first and keep exploring nearby runtime " +
+		"facts, retries, and recovery paths before asking " +
+		"for more input. If completion still depends on an " +
+		"external input you cannot derive locally, state " +
+		"the exact missing piece tersely and keep the " +
+		"answer factual."
 	openClawToolingGuidance = "For common PDF, DOCX, text, CSV, " +
 		"and spreadsheet uploads already in the chat, prefer " +
 		"read_document or read_spreadsheet before falling back " +

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -841,6 +841,7 @@ func NewRuntime(
 			SkillsWatch:         opts.SkillsWatch,
 			SkillsWatchBundled:  opts.SkillsWatchBundled,
 			SkillsWatchDebounce: opts.SkillsWatchDebounce,
+			SkillsToolProfile:   opts.SkillsToolProfile,
 			SkillsLoadMode:      opts.SkillsLoadMode,
 			SkillsMaxLoaded:     opts.SkillsMaxLoaded,
 			SkillsToolResults:   opts.SkillsToolResults,
@@ -1312,6 +1313,7 @@ func run(ctx context.Context, args []string) error {
 			SkillsWatch:         opts.SkillsWatch,
 			SkillsWatchBundled:  opts.SkillsWatchBundled,
 			SkillsWatchDebounce: opts.SkillsWatchDebounce,
+			SkillsToolProfile:   opts.SkillsToolProfile,
 			SkillsLoadMode:      opts.SkillsLoadMode,
 			SkillsMaxLoaded:     opts.SkillsMaxLoaded,
 			SkillsToolResults:   opts.SkillsToolResults,
@@ -2152,6 +2154,9 @@ func newAgent(
 	opts = append(opts, llmagent.WithSkills(repo))
 	opts = append(
 		opts,
+		llmagent.WithSkillToolProfile(
+			llmagent.SkillToolProfile(cfg.SkillsToolProfile),
+		),
 		llmagent.WithSkillLoadMode(cfg.SkillsLoadMode),
 		llmagent.WithSkillsLoadedContentInToolResults(
 			cfg.SkillsToolResults,
@@ -2386,6 +2391,7 @@ type agentConfig struct {
 	SkillsWatch         bool
 	SkillsWatchBundled  bool
 	SkillsWatchDebounce time.Duration
+	SkillsToolProfile   string
 	SkillsLoadMode      string
 	SkillsMaxLoaded     int
 	SkillsToolResults   bool

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -126,6 +126,15 @@ const (
 		"input after reasonable local exploration, state " +
 		"the issue briefly and continue with the best " +
 		"fallback."
+	openClawSkillLoadToolDescription = "Load a skill body and optional " +
+		"docs. This is a blocking requirement when the user " +
+		"names a listed skill, names a slash command, or the " +
+		"task clearly matches a listed skill description. " +
+		"Call this tool before any other substantive response " +
+		"about that task. Do not answer from a short skill " +
+		"summary, prior knowledge, or partial memory when a " +
+		"matching skill exists. Load `SKILL.md` first, then " +
+		"load only the extra docs you still need."
 	openClawToolingGuidance = "For common PDF, DOCX, text, CSV, " +
 		"and spreadsheet uploads already in the chat, prefer " +
 		"read_document or read_spreadsheet before falling back " +
@@ -2198,6 +2207,9 @@ func newAgent(
 		llmagent.WithSkillLoadMode(cfg.SkillsLoadMode),
 		llmagent.WithSkillsLoadedContentInToolResults(
 			cfg.SkillsToolResults,
+		),
+		llmagent.WithSkillLoadToolDescription(
+			openClawSkillLoadToolDescription,
 		),
 		llmagent.WithSkipSkillsFallbackOnSessionSummary(
 			cfg.SkillsSkipFallback,

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -40,6 +40,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/agent/claudecode"
 	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
 	localexec "trpc.group/trpc-go/trpc-agent-go/codeexecutor/local"
+	"trpc.group/trpc-go/trpc-agent-go/internal/skillprofile"
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/memory"
 	"trpc.group/trpc-go/trpc-agent-go/model"
@@ -89,6 +90,8 @@ const (
 	defaultAgentName        = "assistant"
 	defaultAgentInstruction = "You are a helpful assistant. " +
 		"Keep replies concise."
+	openClawSkillRunGuidance = "Use skill_run only for skill " +
+		"workspace workflows."
 
 	openClawToolingGuidance = "For general local shell work, use " +
 		"read_document or read_spreadsheet first for common PDF, " +
@@ -202,8 +205,7 @@ const (
 		"scheduling request. Prefer concise, outcome-oriented " +
 		"tasks over brittle shell transcripts unless exact " +
 		"commands are truly required. Use cron for future or " +
-		"recurring work. " +
-		"Use skill_run only for skill workspace workflows."
+		"recurring work."
 
 	browserToolingGuidance = "For real browser automation, use " +
 		"browser. Prefer browser snapshot plus act for page " +
@@ -2086,7 +2088,7 @@ func newAgent(
 	}
 	if cfg.EnableOpenClawTools {
 		instruction = strings.TrimSpace(
-			instruction + "\n\n" + openClawToolingGuidance,
+			instruction + "\n\n" + buildOpenClawToolingGuidance(cfg),
 		)
 	}
 	knowledgeTools, err := buildKnowledgeTools(cfg.KnowledgesConfig)
@@ -2203,6 +2205,19 @@ func newAgent(
 	opts = append(opts, llmagent.WithToolCallbacks(callbacks))
 
 	return llmagent.New(defaultAgentName, opts...), repo, nil
+}
+
+func buildOpenClawToolingGuidance(cfg agentConfig) string {
+	guidance := strings.TrimSpace(openClawToolingGuidance)
+	if skillprofile.IsKnowledgeOnly(cfg.SkillsToolProfile) {
+		return guidance
+	}
+	if guidance == "" {
+		return openClawSkillRunGuidance
+	}
+	return strings.TrimSpace(
+		guidance + " " + openClawSkillRunGuidance,
+	)
 }
 
 func hasToolNamed(tools []tool.Tool, name string) bool {

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -40,7 +40,6 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/agent/claudecode"
 	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
 	localexec "trpc.group/trpc-go/trpc-agent-go/codeexecutor/local"
-	"trpc.group/trpc-go/trpc-agent-go/internal/skillprofile"
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/memory"
 	"trpc.group/trpc-go/trpc-agent-go/model"
@@ -90,14 +89,10 @@ const (
 	defaultAgentName        = "assistant"
 	defaultAgentInstruction = "You are a helpful assistant. " +
 		"Keep replies concise."
-	openClawSkillRunGuidance = "Use skill_run only for skill " +
-		"workspace workflows."
-
-	openClawToolingGuidance = "For general local shell work, use " +
-		"read_document or read_spreadsheet first for common PDF, " +
-		"DOCX, text, CSV, and spreadsheet uploads already in the " +
-		"chat. Only fall back to " +
-		"exec_command when those tools cannot satisfy the task. " +
+	openClawToolingGuidance = "For common PDF, DOCX, text, CSV, " +
+		"and spreadsheet uploads already in the chat, prefer " +
+		"read_document or read_spreadsheet before falling back " +
+		"to exec_command. " +
 		"For questions about the active chat history, recent " +
 		"turns, or who said something in the current session, use " +
 		"conversation_history before searching long-term memory. " +
@@ -105,9 +100,9 @@ const (
 		"available in the current session. " +
 		"Do not call exec_command just to print OPENCLAW_* upload " +
 		"vars or inspect recent upload metadata when a matching " +
-		"chat file is already available. For general local shell " +
-		"work, use " +
-		"exec_command. For interactive follow-up input, use " +
+		"chat file is already available. For other general local " +
+		"shell work, use exec_command. For interactive follow-up " +
+		"input, use " +
 		"write_stdin and kill_session when needed. Use message " +
 		"to send to the current chat or an explicit target. " +
 		"Chat uploads are saved to stable host paths. For host " +
@@ -2208,13 +2203,8 @@ func newAgent(
 }
 
 func buildOpenClawToolingGuidance(cfg agentConfig) string {
-	guidance := strings.TrimSpace(openClawToolingGuidance)
-	if skillprofile.IsKnowledgeOnly(cfg.SkillsToolProfile) {
-		return guidance
-	}
-	return strings.TrimSpace(
-		guidance + " " + openClawSkillRunGuidance,
-	)
+	_ = cfg
+	return strings.TrimSpace(openClawToolingGuidance)
 }
 
 func hasToolNamed(tools []tool.Tool, name string) bool {

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -99,7 +99,9 @@ const (
 		"you must use that skill in the same turn. Start " +
 		"with one brief user-visible preamble about the " +
 		"immediate next step, then call `skill_load` for " +
-		"that skill right away. That preamble may " +
+		"that skill right away in the same turn. That " +
+		"brief preamble is part of acting immediately, " +
+		"not a pause to ask what to do next. That preamble may " +
 		"announce the immediate task, but do not use it " +
 		"for substantive guidance, capability " +
 		"disclaimers, or explanations about which " +
@@ -138,13 +140,18 @@ const (
 		"docs. This is a blocking requirement when the user " +
 		"names a listed skill, names a slash command, or the " +
 		"task clearly matches a listed skill description. " +
-		"A brief preamble that announces the immediate next " +
-		"step is allowed, but call this tool before any " +
-		"substantive guidance about that task. Do not answer " +
-		"from a short skill summary, prior knowledge, or " +
-		"partial memory when a matching skill exists. Load " +
-		"`SKILL.md` first, then load only the extra docs " +
-		"you still need."
+		"Before the first matching load, start with one " +
+		"brief user-visible preamble that says which skill " +
+		"or skill docs you are reading next, then call this " +
+		"tool right away in the same turn. Do not pause " +
+		"after that preamble to ask what to do next. Do " +
+		"not use that preamble for " +
+		"capability disclaimers, implementation-split " +
+		"explanations, or substantive guidance about the " +
+		"task. Do not answer from a short skill summary, " +
+		"prior knowledge, or partial memory when a matching " +
+		"skill exists. Load `SKILL.md` first, then load " +
+		"only the extra docs you still need."
 	openClawToolingGuidance = "For common PDF, DOCX, text, CSV, " +
 		"and spreadsheet uploads already in the chat, prefer " +
 		"read_document or read_spreadsheet before falling back " +
@@ -2221,6 +2228,7 @@ func newAgent(
 		llmagent.WithSkillLoadToolDescription(
 			openClawSkillLoadToolDescription,
 		),
+		llmagent.WithWorkspaceExecSurfaceEnabled(false),
 		llmagent.WithSkipSkillsFallbackOnSessionSummary(
 			cfg.SkillsSkipFallback,
 		),

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -89,6 +89,23 @@ const (
 	defaultAgentName        = "assistant"
 	defaultAgentInstruction = "You are a helpful assistant. " +
 		"Keep replies concise."
+	openClawSkillsGuidance = "Treat the skill overview as an index " +
+		"of skill directories. When a skill looks relevant, " +
+		"call skill_load promptly so SKILL.md is in context " +
+		"before giving precise guidance or acting on the " +
+		"workflow. After loading a skill, inspect only the " +
+		"supporting docs, scripts, assets, examples, or " +
+		"templates you still need from that skill's " +
+		"directory. Follow the loaded skill instructions " +
+		"and bundled resources to complete the task, and " +
+		"reuse bundled scripts or templates when they " +
+		"already fit. Do not invent commands, flags, auth " +
+		"steps, file layouts, or release procedures from a " +
+		"short summary or partial memory alone. If a " +
+		"needed detail is missing, read the relevant skill " +
+		"files first. Only describe a blocker when a real " +
+		"missing permission, credential, network path, or " +
+		"runtime tool prevents completion."
 	openClawToolingGuidance = "For common PDF, DOCX, text, CSV, " +
 		"and spreadsheet uploads already in the chat, prefer " +
 		"read_document or read_spreadsheet before falling back " +
@@ -2156,6 +2173,8 @@ func newAgent(
 		llmagent.WithSkillToolProfile(
 			llmagent.SkillToolProfile(cfg.SkillsToolProfile),
 		),
+		llmagent.WithSkillsDirectoryHints(true),
+		llmagent.WithSkillsCapabilityGuidance(""),
 		llmagent.WithSkillLoadMode(cfg.SkillsLoadMode),
 		llmagent.WithSkillsLoadedContentInToolResults(
 			cfg.SkillsToolResults,
@@ -2163,19 +2182,14 @@ func newAgent(
 		llmagent.WithSkipSkillsFallbackOnSessionSummary(
 			cfg.SkillsSkipFallback,
 		),
+		llmagent.WithSkillsToolingGuidance(
+			buildOpenClawSkillsGuidance(cfg),
+		),
 	)
 	if cfg.SkillsMaxLoaded > 0 {
 		opts = append(
 			opts,
 			llmagent.WithMaxLoadedSkills(cfg.SkillsMaxLoaded),
-		)
-	}
-	if cfg.SkillsToolingGuide != nil {
-		opts = append(
-			opts,
-			llmagent.WithSkillsToolingGuidance(
-				*cfg.SkillsToolingGuide,
-			),
 		)
 	}
 	if len(tools) > 0 {
@@ -2209,6 +2223,13 @@ func buildOpenClawToolingGuidance(cfg agentConfig) string {
 		return strings.TrimSpace(*cfg.OpenClawToolingGuide)
 	}
 	return strings.TrimSpace(openClawToolingGuidance)
+}
+
+func buildOpenClawSkillsGuidance(cfg agentConfig) string {
+	if cfg.SkillsToolingGuide != nil {
+		return strings.TrimSpace(*cfg.SkillsToolingGuide)
+	}
+	return strings.TrimSpace(openClawSkillsGuidance)
 }
 
 func hasToolNamed(tools []tool.Tool, name string) bool {

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -96,9 +96,14 @@ const (
 		"skills. " +
 		"If the user names a skill, names a slash command, " +
 		"or the task clearly matches a skill description, " +
-		"you must use that skill in the same turn. Call " +
-		"`skill_load` for that skill before generating " +
-		"any other response about the task. Never mention " +
+		"you must use that skill in the same turn. Start " +
+		"with one brief user-visible preamble about the " +
+		"immediate next step, then call `skill_load` for " +
+		"that skill right away. That preamble may " +
+		"announce the immediate task, but do not use it " +
+		"for substantive guidance, capability " +
+		"disclaimers, or explanations about which " +
+		"subsystem loads versus runs the skill. Never mention " +
 		"reading, loading, or using a matching skill " +
 		"unless you already called `skill_load` for it in " +
 		"this turn. Never say that you could read or load " +
@@ -113,7 +118,10 @@ const (
 		"relative paths, resolve them from the skill " +
 		"directory first. Read only the supporting docs, " +
 		"scripts, assets, examples, or templates you still " +
-		"need. Reuse bundled scripts, templates, and assets " +
+		"need. Do not respond with capability disclaimers " +
+		"such as `I can read the skill` when you can load " +
+		"it now. Announce the next step briefly and do it. " +
+		"Reuse bundled scripts, templates, and assets " +
 		"when they already fit. If multiple skills match, " +
 		"use the smallest set that covers the task. Keep " +
 		"context small and avoid bulk-loading docs. Do not " +
@@ -130,11 +138,13 @@ const (
 		"docs. This is a blocking requirement when the user " +
 		"names a listed skill, names a slash command, or the " +
 		"task clearly matches a listed skill description. " +
-		"Call this tool before any other substantive response " +
-		"about that task. Do not answer from a short skill " +
-		"summary, prior knowledge, or partial memory when a " +
-		"matching skill exists. Load `SKILL.md` first, then " +
-		"load only the extra docs you still need."
+		"A brief preamble that announces the immediate next " +
+		"step is allowed, but call this tool before any " +
+		"substantive guidance about that task. Do not answer " +
+		"from a short skill summary, prior knowledge, or " +
+		"partial memory when a matching skill exists. Load " +
+		"`SKILL.md` first, then load only the extra docs " +
+		"you still need."
 	openClawToolingGuidance = "For common PDF, DOCX, text, CSV, " +
 		"and spreadsheet uploads already in the chat, prefer " +
 		"read_document or read_spreadsheet before falling back " +

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -2212,9 +2212,6 @@ func buildOpenClawToolingGuidance(cfg agentConfig) string {
 	if skillprofile.IsKnowledgeOnly(cfg.SkillsToolProfile) {
 		return guidance
 	}
-	if guidance == "" {
-		return openClawSkillRunGuidance
-	}
 	return strings.TrimSpace(
 		guidance + " " + openClawSkillRunGuidance,
 	)

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -1669,7 +1669,7 @@ func TestNewAgent_KnowledgeOnlyProfileHidesSkillRun(t *testing.T) {
 	)
 }
 
-func TestNewAgent_KnowledgeOnlyProfileOmitsSkillRunGuidance(
+func TestNewAgent_KnowledgeOnlyProfileUsesToolingGuidance(
 	t *testing.T,
 ) {
 	t.Parallel()
@@ -1696,11 +1696,6 @@ func TestNewAgent_KnowledgeOnlyProfileOmitsSkillRunGuidance(
 		&session.Session{},
 	)
 	content := joinAllMessageContent(req)
-	require.NotContains(
-		t,
-		content,
-		openClawSkillRunGuidance,
-	)
 	require.Contains(
 		t,
 		content,
@@ -1708,7 +1703,7 @@ func TestNewAgent_KnowledgeOnlyProfileOmitsSkillRunGuidance(
 	)
 }
 
-func TestNewAgent_FullProfileIncludesSkillRunGuidance(t *testing.T) {
+func TestNewAgent_FullProfileUsesToolingGuidance(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
@@ -1749,7 +1744,6 @@ func TestNewAgent_FullProfileIncludesSkillRunGuidance(t *testing.T) {
 				content,
 				strings.TrimSpace(openClawToolingGuidance),
 			)
-			require.Contains(t, content, openClawSkillRunGuidance)
 		})
 	}
 }

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -35,6 +35,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/agent/claudecode"
 	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
 	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/internal/skillprofile"
 	"trpc.group/trpc-go/trpc-agent-go/memory"
 	meminmemory "trpc.group/trpc-go/trpc-agent-go/memory/inmemory"
 	"trpc.group/trpc-go/trpc-agent-go/model"
@@ -1605,6 +1606,29 @@ func TestNewAgent_SkillsToolResults_ConfigApplied(t *testing.T) {
 	sys := joinSystemMessages(req)
 	require.Contains(t, sys, "Loaded skill context:")
 	require.Contains(t, sys, "[Loaded] echoer")
+}
+
+func TestNewAgent_KnowledgeOnlyProfileHidesSkillRun(t *testing.T) {
+	t.Parallel()
+
+	root := createAppTestSkill(t)
+	mdl := &captureRequestModel{}
+	agt, _, err := newAgent(mdl, agentConfig{
+		AppName:           "demo",
+		SkillsRoot:        root,
+		StateDir:          t.TempDir(),
+		SkillsToolProfile: skillprofile.KnowledgeOnly,
+	}, nil, nil)
+	require.NoError(t, err)
+
+	require.NotNil(
+		t,
+		findToolDeclaration(agt.Tools(), skillprofile.ToolLoad),
+	)
+	require.Nil(
+		t,
+		findToolDeclaration(agt.Tools(), skillprofile.ToolRun),
+	)
 }
 
 func TestRun_HTTPListenErrorPath(t *testing.T) {

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -1446,6 +1446,12 @@ func TestNewAgent_SkillsPrompt_DefaultsApplied(t *testing.T) {
 		sys,
 		"Treat the skill overview as an index of skill directories.",
 	)
+	require.Contains(
+		t,
+		sys,
+		"keep exploring nearby runtime facts, retries, "+
+			"and recovery paths",
+	)
 	require.Contains(t, sys, "(dir: ")
 	require.NotContains(t, sys, "Skill tool availability:")
 	require.NotContains(
@@ -1453,6 +1459,7 @@ func TestNewAgent_SkillsPrompt_DefaultsApplied(t *testing.T) {
 		sys,
 		"Built-in skill execution tools are unavailable",
 	)
+	require.NotContains(t, sys, "Only describe a blocker")
 }
 
 func TestNewAgent_BrowserToolingGuidance_Applied(t *testing.T) {

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -1459,8 +1459,9 @@ func TestNewAgent_SkillsPrompt_DefaultsApplied(t *testing.T) {
 	require.Contains(
 		t,
 		sys,
-		"Call `skill_load` for that skill before generating "+
-			"any other response about the task.",
+		"Start with one brief user-visible preamble "+
+			"about the immediate next step, then call "+
+			"`skill_load` for that skill right away.",
 	)
 	require.Contains(
 		t,
@@ -1810,7 +1811,7 @@ func TestNewAgent_KnowledgeOnlyProfileHidesSkillRun(t *testing.T) {
 		t,
 		findToolDeclaration(agt.Tools(), skillprofile.ToolLoad).
 			Description,
-		"Call this tool before any other substantive response",
+		"A brief preamble that announces the immediate next",
 	)
 }
 

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -1806,6 +1806,12 @@ func TestNewAgent_KnowledgeOnlyProfileHidesSkillRun(t *testing.T) {
 		t,
 		findToolDeclaration(agt.Tools(), skillprofile.ToolKillSession),
 	)
+	require.Contains(
+		t,
+		findToolDeclaration(agt.Tools(), skillprofile.ToolLoad).
+			Description,
+		"Call this tool before any other substantive response",
+	)
 }
 
 func TestNewAgent_KnowledgeOnlyProfileUsesToolingGuidance(

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -1498,6 +1498,69 @@ func TestNewAgent_BrowserToolingGuidance_FromToolProvider(
 	)
 }
 
+func TestNewAgent_OpenClawToolingGuidance_OverrideApplied(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	root := createAppTestSkill(t)
+	mdl := &captureRequestModel{}
+	guide := "Use internal runtime guidance only."
+	agt, _, err := newAgent(mdl, agentConfig{
+		AppName:              "demo",
+		SkillsRoot:           root,
+		StateDir:             t.TempDir(),
+		EnableOpenClawTools:  true,
+		OpenClawToolingGuide: &guide,
+	}, nil, nil)
+	require.NoError(t, err)
+
+	req := runAgentAndCapture(
+		t,
+		agt,
+		mdl,
+		&session.Session{},
+	)
+	content := joinAllMessageContent(req)
+	require.Contains(t, content, guide)
+	require.NotContains(
+		t,
+		content,
+		strings.TrimSpace(openClawToolingGuidance),
+	)
+}
+
+func TestNewAgent_OpenClawToolingGuidance_EmptyDisables(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	root := createAppTestSkill(t)
+	mdl := &captureRequestModel{}
+	guide := ""
+	agt, _, err := newAgent(mdl, agentConfig{
+		AppName:              "demo",
+		SkillsRoot:           root,
+		StateDir:             t.TempDir(),
+		EnableOpenClawTools:  true,
+		OpenClawToolingGuide: &guide,
+	}, nil, nil)
+	require.NoError(t, err)
+
+	req := runAgentAndCapture(
+		t,
+		agt,
+		mdl,
+		&session.Session{},
+	)
+	content := joinAllMessageContent(req)
+	require.NotContains(
+		t,
+		content,
+		strings.TrimSpace(openClawToolingGuidance),
+	)
+}
+
 func TestNewAgent_DefaultGenerationConfigStreams(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -1477,6 +1477,12 @@ func TestNewAgent_SkillsPrompt_DefaultsApplied(t *testing.T) {
 	require.Contains(
 		t,
 		sys,
+		"Do not answer a matching skill task from the short "+
+			"summary, prior knowledge, or partial memory.",
+	)
+	require.Contains(
+		t,
+		sys,
 		"Keep exploring nearby runtime facts, retries, "+
 			"and recovery paths",
 	)

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -261,6 +261,9 @@ func joinAllMessageContent(req *model.Request) string {
 	}
 	parts := make([]string, 0, len(req.Messages))
 	for _, msg := range req.Messages {
+		if msg.Role == model.RoleUser {
+			continue
+		}
 		parts = append(parts, msg.Content)
 	}
 	return strings.Join(parts, "\n\n")

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -1454,7 +1454,25 @@ func TestNewAgent_SkillsPrompt_DefaultsApplied(t *testing.T) {
 	require.Contains(
 		t,
 		sys,
+		"This is a blocking requirement for matching skills.",
+	)
+	require.Contains(
+		t,
+		sys,
+		"Call `skill_load` for that skill before generating "+
+			"any other response about the task.",
+	)
+	require.Contains(
+		t,
+		sys,
 		"Never say that you could read or load a matching skill later",
+	)
+	require.Contains(
+		t,
+		sys,
+		"Never mention reading, loading, or using a matching "+
+			"skill unless you already called `skill_load` for "+
+			"it in this turn.",
 	)
 	require.Contains(
 		t,

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -1688,11 +1688,46 @@ func TestNewAgent_KnowledgeOnlyProfileOmitsSkillRunGuidance(
 		mdl,
 		&session.Session{},
 	)
+	content := joinAllMessageContent(req)
 	require.NotContains(
 		t,
-		joinAllMessageContent(req),
+		content,
 		openClawSkillRunGuidance,
 	)
+	require.Contains(
+		t,
+		content,
+		strings.TrimSpace(openClawToolingGuidance),
+	)
+}
+
+func TestNewAgent_FullProfileIncludesSkillRunGuidance(t *testing.T) {
+	t.Parallel()
+
+	root := createAppTestSkill(t)
+	mdl := &captureRequestModel{}
+	agt, _, err := newAgent(mdl, agentConfig{
+		AppName:             "demo",
+		SkillsRoot:          root,
+		StateDir:            t.TempDir(),
+		SkillsToolProfile:   skillprofile.Full,
+		EnableOpenClawTools: true,
+	}, nil, nil)
+	require.NoError(t, err)
+
+	req := runAgentAndCapture(
+		t,
+		agt,
+		mdl,
+		&session.Session{},
+	)
+	content := joinAllMessageContent(req)
+	require.Contains(
+		t,
+		content,
+		strings.TrimSpace(openClawToolingGuidance),
+	)
+	require.Contains(t, content, openClawSkillRunGuidance)
 }
 
 func TestRun_HTTPListenErrorPath(t *testing.T) {

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -1715,7 +1715,7 @@ func TestNewAgent_FullProfileUsesToolingGuidance(t *testing.T) {
 			profile: skillprofile.Full,
 		},
 		{
-			name:    "zero-value profile defaults to full",
+			name:    "zero-value profile defaults to knowledge-only",
 			profile: "",
 		},
 	}

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -1418,6 +1418,41 @@ func TestNewAgent_SkillsToolingGuidance_ConfigApplied(t *testing.T) {
 		sys,
 		"Tooling and workspace guidance:",
 	)
+	require.NotContains(t, sys, "Skill tool availability:")
+}
+
+func TestNewAgent_SkillsPrompt_DefaultsApplied(t *testing.T) {
+	t.Parallel()
+
+	root := createAppTestSkill(t)
+	mdl := &captureRequestModel{}
+	agt, _, err := newAgent(mdl, agentConfig{
+		AppName:    "demo",
+		SkillsRoot: root,
+		StateDir:   t.TempDir(),
+	}, nil, nil)
+	require.NoError(t, err)
+
+	req := runAgentAndCapture(
+		t,
+		agt,
+		mdl,
+		&session.Session{},
+	)
+	sys := joinSystemMessages(req)
+	require.Contains(t, sys, "Available skills:")
+	require.Contains(
+		t,
+		sys,
+		"Treat the skill overview as an index of skill directories.",
+	)
+	require.Contains(t, sys, "(dir: ")
+	require.NotContains(t, sys, "Skill tool availability:")
+	require.NotContains(
+		t,
+		sys,
+		"Built-in skill execution tools are unavailable",
+	)
 }
 
 func TestNewAgent_BrowserToolingGuidance_Applied(t *testing.T) {

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -1461,7 +1461,12 @@ func TestNewAgent_SkillsPrompt_DefaultsApplied(t *testing.T) {
 		sys,
 		"Start with one brief user-visible preamble "+
 			"about the immediate next step, then call "+
-			"`skill_load` for that skill right away.",
+			"`skill_load` for that skill right away",
+	)
+	require.Contains(
+		t,
+		sys,
+		"not a pause to ask what to do next",
 	)
 	require.Contains(
 		t,
@@ -1495,6 +1500,32 @@ func TestNewAgent_SkillsPrompt_DefaultsApplied(t *testing.T) {
 	require.NotContains(t, sys, "Skill tool availability:")
 	require.NotContains(t, sys, "Built-in skill execution tools are unavailable")
 	require.NotContains(t, sys, "Only describe a blocker")
+}
+
+func TestNewAgent_LocalExecKeepsExecCommandButOmitsWorkspaceExec(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	root := createAppTestSkill(t)
+	agt, _, err := newAgent(&captureRequestModel{}, agentConfig{
+		AppName:         "demo",
+		SkillsRoot:      root,
+		StateDir:        t.TempDir(),
+		EnableLocalExec: true,
+	}, nil, nil)
+	require.NoError(t, err)
+
+	names := make(map[string]bool)
+	for _, tl := range agt.Tools() {
+		if decl := tl.Declaration(); decl != nil {
+			names[decl.Name] = true
+		}
+	}
+
+	require.False(t, names["workspace_exec"])
+	require.False(t, names["workspace_write_stdin"])
+	require.False(t, names["workspace_kill_session"])
 }
 
 func TestNewAgent_BrowserToolingGuidance_Applied(t *testing.T) {
@@ -1811,7 +1842,8 @@ func TestNewAgent_KnowledgeOnlyProfileHidesSkillRun(t *testing.T) {
 		t,
 		findToolDeclaration(agt.Tools(), skillprofile.ToolLoad).
 			Description,
-		"A brief preamble that announces the immediate next",
+		"Before the first matching load, start with one "+
+			"brief user-visible preamble",
 	)
 }
 

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -1681,6 +1681,10 @@ func TestNewAgent_KnowledgeOnlyProfileOmitsSkillRunGuidance(
 		EnableOpenClawTools: true,
 	}, nil, nil)
 	require.NoError(t, err)
+	require.Nil(
+		t,
+		findToolDeclaration(agt.Tools(), skillprofile.ToolRun),
+	)
 
 	req := runAgentAndCapture(
 		t,
@@ -1704,30 +1708,47 @@ func TestNewAgent_KnowledgeOnlyProfileOmitsSkillRunGuidance(
 func TestNewAgent_FullProfileIncludesSkillRunGuidance(t *testing.T) {
 	t.Parallel()
 
-	root := createAppTestSkill(t)
-	mdl := &captureRequestModel{}
-	agt, _, err := newAgent(mdl, agentConfig{
-		AppName:             "demo",
-		SkillsRoot:          root,
-		StateDir:            t.TempDir(),
-		SkillsToolProfile:   skillprofile.Full,
-		EnableOpenClawTools: true,
-	}, nil, nil)
-	require.NoError(t, err)
+	testCases := []struct {
+		name    string
+		profile string
+	}{
+		{
+			name:    "explicit full profile",
+			profile: skillprofile.Full,
+		},
+		{
+			name:    "zero-value profile defaults to full",
+			profile: "",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := createAppTestSkill(t)
+			mdl := &captureRequestModel{}
+			agt, _, err := newAgent(mdl, agentConfig{
+				AppName:             "demo",
+				SkillsRoot:          root,
+				StateDir:            t.TempDir(),
+				SkillsToolProfile:   tc.profile,
+				EnableOpenClawTools: true,
+			}, nil, nil)
+			require.NoError(t, err)
 
-	req := runAgentAndCapture(
-		t,
-		agt,
-		mdl,
-		&session.Session{},
-	)
-	content := joinAllMessageContent(req)
-	require.Contains(
-		t,
-		content,
-		strings.TrimSpace(openClawToolingGuidance),
-	)
-	require.Contains(t, content, openClawSkillRunGuidance)
+			req := runAgentAndCapture(
+				t,
+				agt,
+				mdl,
+				&session.Session{},
+			)
+			content := joinAllMessageContent(req)
+			require.Contains(
+				t,
+				content,
+				strings.TrimSpace(openClawToolingGuidance),
+			)
+			require.Contains(t, content, openClawSkillRunGuidance)
+		})
+	}
 }
 
 func TestRun_HTTPListenErrorPath(t *testing.T) {

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -255,6 +255,17 @@ func joinSystemMessages(req *model.Request) string {
 	return strings.Join(parts, "\n\n")
 }
 
+func joinAllMessageContent(req *model.Request) string {
+	if req == nil {
+		return ""
+	}
+	parts := make([]string, 0, len(req.Messages))
+	for _, msg := range req.Messages {
+		parts = append(parts, msg.Content)
+	}
+	return strings.Join(parts, "\n\n")
+}
+
 func TestRuntimePromptControllerUpdatesAgentPrompts(
 	t *testing.T,
 ) {
@@ -1625,9 +1636,62 @@ func TestNewAgent_KnowledgeOnlyProfileHidesSkillRun(t *testing.T) {
 		t,
 		findToolDeclaration(agt.Tools(), skillprofile.ToolLoad),
 	)
+	require.NotNil(
+		t,
+		findToolDeclaration(agt.Tools(), skillprofile.ToolListDocs),
+	)
+	require.NotNil(
+		t,
+		findToolDeclaration(agt.Tools(), skillprofile.ToolSelectDocs),
+	)
 	require.Nil(
 		t,
 		findToolDeclaration(agt.Tools(), skillprofile.ToolRun),
+	)
+	require.Nil(
+		t,
+		findToolDeclaration(agt.Tools(), skillprofile.ToolExec),
+	)
+	require.Nil(
+		t,
+		findToolDeclaration(agt.Tools(), skillprofile.ToolWriteStdin),
+	)
+	require.Nil(
+		t,
+		findToolDeclaration(agt.Tools(), skillprofile.ToolPollSession),
+	)
+	require.Nil(
+		t,
+		findToolDeclaration(agt.Tools(), skillprofile.ToolKillSession),
+	)
+}
+
+func TestNewAgent_KnowledgeOnlyProfileOmitsSkillRunGuidance(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	root := createAppTestSkill(t)
+	mdl := &captureRequestModel{}
+	agt, _, err := newAgent(mdl, agentConfig{
+		AppName:             "demo",
+		SkillsRoot:          root,
+		StateDir:            t.TempDir(),
+		SkillsToolProfile:   skillprofile.KnowledgeOnly,
+		EnableOpenClawTools: true,
+	}, nil, nil)
+	require.NoError(t, err)
+
+	req := runAgentAndCapture(
+		t,
+		agt,
+		mdl,
+		&session.Session{},
+	)
+	require.NotContains(
+		t,
+		joinAllMessageContent(req),
+		openClawSkillRunGuidance,
 	)
 }
 

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -1416,7 +1416,7 @@ func TestNewAgent_SkillsToolingGuidance_ConfigApplied(t *testing.T) {
 	require.NotContains(
 		t,
 		sys,
-		"Tooling and workspace guidance:",
+		"Each entry includes a path to that skill's SKILL.md on disk.",
 	)
 	require.NotContains(t, sys, "Skill tool availability:")
 }
@@ -1444,21 +1444,31 @@ func TestNewAgent_SkillsPrompt_DefaultsApplied(t *testing.T) {
 	require.Contains(
 		t,
 		sys,
-		"Treat the skill overview as an index of skill directories.",
+		"Each entry includes a path to that skill's SKILL.md on disk.",
 	)
 	require.Contains(
 		t,
 		sys,
-		"keep exploring nearby runtime facts, retries, "+
-			"and recovery paths",
+		"you must use that skill in the same turn.",
 	)
-	require.Contains(t, sys, "(dir: ")
-	require.NotContains(t, sys, "Skill tool availability:")
-	require.NotContains(
+	require.Contains(
 		t,
 		sys,
-		"Built-in skill execution tools are unavailable",
+		"Never say that you could read or load a matching skill later",
 	)
+	require.Contains(
+		t,
+		sys,
+		"Keep exploring nearby runtime facts, retries, "+
+			"and recovery paths",
+	)
+	require.Contains(
+		t,
+		sys,
+		"echoer/"+skill.SkillFile,
+	)
+	require.NotContains(t, sys, "Skill tool availability:")
+	require.NotContains(t, sys, "Built-in skill execution tools are unavailable")
 	require.NotContains(t, sys, "Only describe a blocker")
 }
 

--- a/openclaw/app/run_options.go
+++ b/openclaw/app/run_options.go
@@ -233,9 +233,10 @@ type runOptions struct {
 	SessionSummaryMaxWords            int
 	SessionSummaryApproxRunesPerToken float64
 
-	EnableLocalExec     bool
-	EnableOpenClawTools bool
-	EnableParallelTools bool
+	EnableLocalExec      bool
+	EnableOpenClawTools  bool
+	OpenClawToolingGuide *string
+	EnableParallelTools  bool
 
 	enableOpenClawToolsExplicit bool
 
@@ -1082,10 +1083,12 @@ type skillEntryConfig struct {
 }
 
 type toolsConfig struct {
-	EnableLocalExec      *bool `yaml:"enable_local_exec,omitempty"`
-	EnableOpenClawTools  *bool `yaml:"enable_openclaw_tools,omitempty"`
-	EnableParallelTools  *bool `yaml:"enable_parallel_tools,omitempty"`
-	RefreshToolSetsOnRun *bool `yaml:"refresh_toolsets_on_run,omitempty"`
+	EnableLocalExec           *bool   `yaml:"enable_local_exec,omitempty"`
+	EnableOpenClawTools       *bool   `yaml:"enable_openclaw_tools,omitempty"`
+	OpenClawToolingGuide      *string `yaml:"openclaw_tooling_guidance,omitempty"`
+	OpenClawToolingGuideCamel *string `yaml:"openClawToolingGuidance,omitempty"`
+	EnableParallelTools       *bool   `yaml:"enable_parallel_tools,omitempty"`
+	RefreshToolSetsOnRun      *bool   `yaml:"refresh_toolsets_on_run,omitempty"`
 
 	Providers []filePluginSpec `yaml:"providers,omitempty"`
 	ToolSets  []filePluginSpec `yaml:"toolsets,omitempty"`
@@ -1607,6 +1610,10 @@ func (cfg *fileConfig) apply(
 					*cfg.Tools.EnableOpenClawTools
 			}
 		}
+		opts.OpenClawToolingGuide = firstStringPtr(
+			cfg.Tools.OpenClawToolingGuide,
+			cfg.Tools.OpenClawToolingGuideCamel,
+		)
 		if cfg.Tools.EnableParallelTools != nil &&
 			!flagWasSet(set, flagEnableParallelTools) {
 			opts.EnableParallelTools = *cfg.Tools.EnableParallelTools

--- a/openclaw/app/run_options.go
+++ b/openclaw/app/run_options.go
@@ -25,6 +25,7 @@ import (
 
 	ia2a "trpc.group/trpc-go/trpc-agent-go/internal/a2a"
 	"trpc.group/trpc-go/trpc-agent-go/internal/flow/processor"
+	"trpc.group/trpc-go/trpc-agent-go/internal/skillprofile"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	ocskills "trpc.group/trpc-go/trpc-agent-go/openclaw/internal/skills"
 )
@@ -62,6 +63,7 @@ const (
 
 	defaultSessionSummaryEventThreshold = 20
 	defaultSkillsLoadMode               = "turn"
+	defaultSkillsToolProfile            = skillprofile.Full
 	defaultSkillsWatchDebounce          = 250 * time.Millisecond
 
 	flagAddSessionSummary                             = "add-session-summary"
@@ -93,6 +95,7 @@ const (
 	flagSkillsWatch         = "skills-watch"
 	flagSkillsWatchBundled  = "skills-watch-bundled"
 	flagSkillsWatchDebounce = "skills-watch-debounce"
+	flagSkillsToolProfile   = "skills-tool-profile"
 	flagSkillsLoadMode      = "skills-load-mode"
 	flagSkillsMaxLoaded     = "skills-max-loaded"
 	flagSkillsToolResults   = "skills-loaded-content-in-tool-results"
@@ -185,6 +188,7 @@ type runOptions struct {
 	SkillsWatch         bool
 	SkillsWatchBundled  bool
 	SkillsWatchDebounce time.Duration
+	SkillsToolProfile   string
 	SkillsLoadMode      string
 	SkillsMaxLoaded     int
 	SkillsToolResults   bool
@@ -261,6 +265,7 @@ func parseRunOptions(args []string) (runOptions, error) {
 
 		SkillsWatch:         true,
 		SkillsWatchDebounce: defaultSkillsWatchDebounce,
+		SkillsToolProfile:   defaultSkillsToolProfile,
 		SkillsLoadMode:      defaultSkillsLoadMode,
 		SkillsToolResults:   true,
 		SkillsSkipFallback:  true,
@@ -592,6 +597,12 @@ func parseRunOptions(args []string) (runOptions, error) {
 		"Also watch bundled skills roots for local changes",
 	)
 	fs.StringVar(
+		&opts.SkillsToolProfile,
+		flagSkillsToolProfile,
+		defaultSkillsToolProfile,
+		"Built-in skill tool profile: full|knowledge_only",
+	)
+	fs.StringVar(
 		&opts.SkillsLoadMode,
 		flagSkillsLoadMode,
 		defaultSkillsLoadMode,
@@ -845,7 +856,7 @@ func parseRunOptions(args []string) (runOptions, error) {
 
 	if err := finalizeRunOptions(&opts); err != nil {
 		return runOptions{}, &exitError{
-			Code: loadModeExitCode(setFlags),
+			Code: skillsOptionExitCode(setFlags),
 			Err:  err,
 		}
 	}
@@ -1046,6 +1057,8 @@ type skillsConfig struct {
 	WatchBundledCamel  *bool    `yaml:"watchBundled,omitempty"`
 	WatchDebounceMS    *int     `yaml:"watch_debounce_ms,omitempty"`
 	WatchDebounceCamel *int     `yaml:"watchDebounceMs,omitempty"`
+	ToolProfile        *string  `yaml:"tool_profile,omitempty"`
+	ToolProfileCamel   *string  `yaml:"toolProfile,omitempty"`
 	LoadMode           *string  `yaml:"load_mode,omitempty"`
 	LoadModeCamel      *string  `yaml:"loadMode,omitempty"`
 	MaxLoadedSkills    *int     `yaml:"max_loaded_skills,omitempty"`
@@ -1539,6 +1552,14 @@ func (cfg *fileConfig) apply(
 				cfg.Skills.Entries,
 			)
 		}
+		toolProfile := firstStringPtr(
+			cfg.Skills.ToolProfile,
+			cfg.Skills.ToolProfileCamel,
+		)
+		if toolProfile != nil &&
+			!flagWasSet(set, flagSkillsToolProfile) {
+			opts.SkillsToolProfile = strings.TrimSpace(*toolProfile)
+		}
 		loadMode := firstStringPtr(
 			cfg.Skills.LoadMode,
 			cfg.Skills.LoadModeCamel,
@@ -1992,8 +2013,9 @@ func flagWasSet(set map[string]struct{}, name string) bool {
 	return ok
 }
 
-func loadModeExitCode(set map[string]struct{}) int {
-	if flagWasSet(set, flagSkillsLoadMode) {
+func skillsOptionExitCode(set map[string]struct{}) int {
+	if flagWasSet(set, flagSkillsToolProfile) ||
+		flagWasSet(set, flagSkillsLoadMode) {
 		return 2
 	}
 	return 1
@@ -2003,6 +2025,11 @@ func finalizeRunOptions(opts *runOptions) error {
 	if opts == nil {
 		return nil
 	}
+	profile, err := normalizeSkillsToolProfile(opts.SkillsToolProfile)
+	if err != nil {
+		return err
+	}
+	opts.SkillsToolProfile = profile
 	mode, err := normalizeSkillsLoadMode(opts.SkillsLoadMode)
 	if err != nil {
 		return err
@@ -2052,6 +2079,23 @@ func normalizeA2AHost(raw string) string {
 		return ""
 	}
 	return ia2a.NormalizeURL(host)
+}
+
+func normalizeSkillsToolProfile(raw string) (string, error) {
+	profile := strings.ToLower(strings.TrimSpace(raw))
+	if profile == "" {
+		return defaultSkillsToolProfile, nil
+	}
+	switch profile {
+	case skillprofile.Full, skillprofile.KnowledgeOnly:
+		return profile, nil
+	default:
+		return "", fmt.Errorf(
+			"invalid skills tool profile %q: "+
+				"want full|knowledge_only",
+			raw,
+		)
+	}
 }
 
 func normalizeSkillsLoadMode(raw string) (string, error) {

--- a/openclaw/app/run_options.go
+++ b/openclaw/app/run_options.go
@@ -63,7 +63,7 @@ const (
 
 	defaultSessionSummaryEventThreshold = 20
 	defaultSkillsLoadMode               = "turn"
-	defaultSkillsToolProfile            = skillprofile.Full
+	defaultSkillsToolProfile            = skillprofile.KnowledgeOnly
 	defaultSkillsWatchDebounce          = 250 * time.Millisecond
 
 	flagAddSessionSummary                             = "add-session-summary"

--- a/openclaw/app/run_options_test.go
+++ b/openclaw/app/run_options_test.go
@@ -1103,6 +1103,24 @@ func TestParseRunOptions_SkillsToolProfile_InvalidFails(
 	require.Equal(t, 2, exitErr.Code)
 }
 
+func TestParseRunOptions_SkillsToolProfile_ConfigInvalidFails(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	cfgPath := writeTempConfig(t, `
+skills:
+  tool_profile: "bad"
+`)
+
+	_, err := parseRunOptions([]string{"-config", cfgPath})
+	require.Error(t, err)
+
+	var exitErr *exitError
+	require.True(t, errors.As(err, &exitErr))
+	require.Equal(t, 1, exitErr.Code)
+}
+
 func TestParseRunOptions_AdminDefaults(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/app/run_options_test.go
+++ b/openclaw/app/run_options_test.go
@@ -1103,6 +1103,18 @@ func TestParseRunOptions_SkillsToolProfile_InvalidFails(
 	require.Equal(t, 2, exitErr.Code)
 }
 
+func TestParseRunOptions_SkillsToolProfile_FullAccepted(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	opts, err := parseRunOptions([]string{
+		"-skills-tool-profile", "FULL",
+	})
+	require.NoError(t, err)
+	require.Equal(t, skillprofile.Full, opts.SkillsToolProfile)
+}
+
 func TestParseRunOptions_SkillsToolProfile_ConfigInvalidFails(
 	t *testing.T,
 ) {
@@ -1119,6 +1131,26 @@ skills:
 	var exitErr *exitError
 	require.True(t, errors.As(err, &exitErr))
 	require.Equal(t, 1, exitErr.Code)
+}
+
+func TestSkillsOptionExitCode(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(
+		t,
+		2,
+		skillsOptionExitCode(map[string]struct{}{
+			flagSkillsToolProfile: {},
+		}),
+	)
+	require.Equal(
+		t,
+		2,
+		skillsOptionExitCode(map[string]struct{}{
+			flagSkillsLoadMode: {},
+		}),
+	)
+	require.Equal(t, 1, skillsOptionExitCode(map[string]struct{}{}))
 }
 
 func TestParseRunOptions_AdminDefaults(t *testing.T) {

--- a/openclaw/app/run_options_test.go
+++ b/openclaw/app/run_options_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
+	"trpc.group/trpc-go/trpc-agent-go/internal/skillprofile"
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/registry"
 )
 
@@ -608,6 +609,7 @@ skills:
   watch: false
   watch_bundled: true
   watch_debounce_ms: 125
+  tool_profile: "knowledge_only"
   load_mode: "session"
   max_loaded_skills: 3
   loaded_content_in_tool_results: false
@@ -750,6 +752,11 @@ memory:
 	require.False(t, opts.SkillsWatch)
 	require.True(t, opts.SkillsWatchBundled)
 	require.Equal(t, 125*time.Millisecond, opts.SkillsWatchDebounce)
+	require.Equal(
+		t,
+		skillprofile.KnowledgeOnly,
+		opts.SkillsToolProfile,
+	)
 	require.Equal(t, "session", opts.SkillsLoadMode)
 	require.Equal(t, 3, opts.SkillsMaxLoaded)
 	require.False(t, opts.SkillsToolResults)
@@ -1056,6 +1063,11 @@ func TestParseRunOptions_SkillsDefaults(t *testing.T) {
 		defaultSkillsWatchDebounce,
 		opts.SkillsWatchDebounce,
 	)
+	require.Equal(
+		t,
+		defaultSkillsToolProfile,
+		opts.SkillsToolProfile,
+	)
 	require.Equal(t, defaultSkillsLoadMode, opts.SkillsLoadMode)
 	require.True(t, opts.SkillsToolResults)
 	require.True(t, opts.SkillsSkipFallback)
@@ -1068,6 +1080,21 @@ func TestParseRunOptions_SkillsLoadMode_InvalidFails(t *testing.T) {
 
 	_, err := parseRunOptions([]string{
 		"-skills-load-mode", "bad",
+	})
+	require.Error(t, err)
+
+	var exitErr *exitError
+	require.True(t, errors.As(err, &exitErr))
+	require.Equal(t, 2, exitErr.Code)
+}
+
+func TestParseRunOptions_SkillsToolProfile_InvalidFails(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	_, err := parseRunOptions([]string{
+		"-skills-tool-profile", "bad",
 	})
 	require.Error(t, err)
 

--- a/openclaw/app/run_options_test.go
+++ b/openclaw/app/run_options_test.go
@@ -630,6 +630,7 @@ skills:
 tools:
   enable_local_exec: true
   enable_openclaw_tools: true
+  openclaw_tooling_guidance: ""
   enable_parallel_tools: true
   refresh_toolsets_on_run: true
   providers:
@@ -785,6 +786,8 @@ memory:
 
 	require.True(t, opts.EnableLocalExec)
 	require.True(t, opts.EnableOpenClawTools)
+	require.NotNil(t, opts.OpenClawToolingGuide)
+	require.Equal(t, "", *opts.OpenClawToolingGuide)
 	require.True(t, opts.EnableParallelTools)
 	require.True(t, opts.RefreshToolSetsOnRun)
 

--- a/skill/context_repository.go
+++ b/skill/context_repository.go
@@ -131,6 +131,18 @@ func (r *filteredRepository) Path(name string) (string, error) {
 	return r.base.Path(name)
 }
 
+// Roots exposes the underlying repository roots when available.
+func (r *filteredRepository) Roots() []string {
+	if r == nil || r.base == nil {
+		return nil
+	}
+	rooted, ok := r.base.(RootedRepository)
+	if !ok || rooted == nil {
+		return nil
+	}
+	return rooted.Roots()
+}
+
 func (r *filteredRepository) SummariesForContext(
 	ctx context.Context,
 ) []Summary {

--- a/skill/context_repository_test.go
+++ b/skill/context_repository_test.go
@@ -27,6 +27,11 @@ type visibilityTestRepo struct {
 	env       map[string]map[string]string
 }
 
+type rootedVisibilityTestRepo struct {
+	*visibilityTestRepo
+	roots []string
+}
+
 func (r *visibilityTestRepo) Summaries() []rootskill.Summary {
 	out := make([]rootskill.Summary, len(r.summaries))
 	copy(out, r.summaries)
@@ -55,6 +60,10 @@ func (r *visibilityTestRepo) SkillRunEnv(
 		return env, nil
 	}
 	return nil, fmt.Errorf("skill %q not found", skillName)
+}
+
+func (r *rootedVisibilityTestRepo) Roots() []string {
+	return append([]string(nil), r.roots...)
 }
 
 func testRuntimeStateContext(userID string) context.Context {
@@ -207,6 +216,46 @@ func TestFilteredRepository_DelegatesPlainRepositoryMethods(t *testing.T) {
 	path, err := repo.Path("alpha")
 	require.NoError(t, err)
 	require.Equal(t, "/skills/alpha", path)
+}
+
+func TestFilteredRepository_RootsDelegatesWhenAvailable(t *testing.T) {
+	base := &rootedVisibilityTestRepo{
+		visibilityTestRepo: &visibilityTestRepo{
+			summaries: []rootskill.Summary{
+				{Name: "alpha", Description: "A"},
+			},
+			skills: map[string]*rootskill.Skill{
+				"alpha": {
+					Summary: rootskill.Summary{Name: "alpha"},
+					Body:    "alpha body",
+				},
+			},
+			paths: map[string]string{"alpha": "/skills/alpha"},
+		},
+		roots: []string{"/skills", "/more-skills"},
+	}
+
+	repo := rootskill.NewFilteredRepository(
+		base,
+		func(context.Context, rootskill.Summary) bool { return true },
+	)
+	rooted, ok := repo.(interface{ Roots() []string })
+	require.True(t, ok)
+	require.Equal(t, []string{"/skills", "/more-skills"}, rooted.Roots())
+
+	got := rooted.Roots()
+	got[0] = "mutated"
+	require.Equal(t, []string{"/skills", "/more-skills"}, rooted.Roots())
+}
+
+func TestFilteredRepository_RootsNilWithoutRootedBase(t *testing.T) {
+	repo := rootskill.NewFilteredRepository(
+		&visibilityTestRepo{},
+		func(context.Context, rootskill.Summary) bool { return true },
+	)
+	rooted, ok := repo.(interface{ Roots() []string })
+	require.True(t, ok)
+	require.Nil(t, rooted.Roots())
 }
 
 func TestNewFilteredRepository_NilBaseReturnsNil(t *testing.T) {

--- a/skill/repository.go
+++ b/skill/repository.go
@@ -70,6 +70,13 @@ type Repository interface {
 	Path(name string) (string, error)
 }
 
+// RootedRepository optionally exposes the configured skill roots.
+// Runtimes can use this to render compact directory locators in prompts.
+type RootedRepository interface {
+	Repository
+	Roots() []string
+}
+
 // RefreshableRepository can rescan its backing skill sources.
 type RefreshableRepository interface {
 	Repository
@@ -128,6 +135,13 @@ func (r *FSRepository) Path(name string) (string, error) {
 		return "", fmt.Errorf("skill %q not found", name)
 	}
 	return dir, nil
+}
+
+// Roots returns the configured filesystem roots.
+func (r *FSRepository) Roots() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return append([]string(nil), r.roots...)
 }
 
 func scanRoots(roots []string) (map[string]string, error) {

--- a/skill/repository.go
+++ b/skill/repository.go
@@ -35,6 +35,10 @@ import (
 // skillFile is the canonical skill definition filename.
 const skillFile = "SKILL.md"
 
+// SkillFile is the canonical skill definition filename exposed for
+// prompt rendering and other callers that need the on-disk path.
+const SkillFile = skillFile
+
 // EnvSkillsRoot is the environment variable name that points to the
 // skills repository root directory used by examples and runtimes.
 // Defining it here avoids repeated string literals across the codebase.

--- a/skill/repository_test.go
+++ b/skill/repository_test.go
@@ -181,6 +181,24 @@ func TestFSRepository_Path_WithSymlinkRoot(t *testing.T) {
 	require.Equal(t, want, got)
 }
 
+func TestFSRepository_RootsReturnsCopyAndSkillFileConstant(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	writeSkill(t, root, "alpha")
+
+	repo, err := NewFSRepository("", root)
+	require.NoError(t, err)
+
+	require.Equal(t, skillFile, SkillFile)
+
+	roots := repo.Roots()
+	require.Equal(t, []string{root}, roots)
+
+	roots[0] = "mutated"
+	require.Equal(t, []string{root}, repo.Roots())
+}
+
 func TestFSRepository_Summaries_And_Get_WithDocs(t *testing.T) {
 	root := t.TempDir()
 	sdir := writeSkill(t, root, "one")

--- a/tool/skill/load.go
+++ b/tool/skill/load.go
@@ -31,12 +31,51 @@ type stateDeltaProvider interface {
 // LoadTool enables loading a skill into session state.
 // It produces deltas under prefixes defined by skill package.
 type LoadTool struct {
-	repo skill.Repository
+	repo        skill.Repository
+	description string
+}
+
+const defaultLoadToolDescription = "Load a skill body and optional docs. " +
+	"Prefer progressive disclosure: load SKILL.md first, " +
+	"then load only needed docs. " +
+	"Safe to call multiple times to add or replace docs. " +
+	"Do not call this to list skills; names and descriptions " +
+	"are already in context. Use when a task needs a skill's " +
+	"SKILL.md body and selected docs in context."
+
+type loadToolOptions struct {
+	description string
+}
+
+// LoadToolOption configures LoadTool.
+type LoadToolOption func(*loadToolOptions)
+
+// WithLoadToolDescription overrides the skill_load tool description.
+func WithLoadToolDescription(
+	description string,
+) LoadToolOption {
+	return func(o *loadToolOptions) {
+		o.description = description
+	}
 }
 
 // NewLoadTool creates a new LoadTool.
-func NewLoadTool(repo skill.Repository) *LoadTool {
-	return &LoadTool{repo: repo}
+func NewLoadTool(
+	repo skill.Repository,
+	opts ...LoadToolOption,
+) *LoadTool {
+	options := loadToolOptions{
+		description: defaultLoadToolDescription,
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&options)
+		}
+	}
+	return &LoadTool{
+		repo:        repo,
+		description: options.description,
+	}
 }
 
 // loadInput is the schema for skill_load.
@@ -49,14 +88,8 @@ type loadInput struct {
 // Declaration implements tool.Tool.
 func (t *LoadTool) Declaration() *tool.Declaration {
 	return &tool.Declaration{
-		Name: "skill_load",
-		Description: "Load a skill body and optional docs. " +
-			"Prefer progressive disclosure: load SKILL.md first, " +
-			"then load only needed docs. " +
-			"Safe to call multiple times to add or replace docs. " +
-			"Do not call this to list skills; names and descriptions " +
-			"are already in context. Use when a task needs a skill's " +
-			"SKILL.md body and selected docs in context.",
+		Name:        "skill_load",
+		Description: t.description,
 		InputSchema: &tool.Schema{
 			Type:        "object",
 			Description: "Load skill input",

--- a/tool/skill/load.go
+++ b/tool/skill/load.go
@@ -60,7 +60,12 @@ func WithLoadToolDescription(
 }
 
 // NewLoadTool creates a new LoadTool.
-func NewLoadTool(
+func NewLoadTool(repo skill.Repository) *LoadTool {
+	return NewLoadToolWithOptions(repo)
+}
+
+// NewLoadToolWithOptions creates a new LoadTool with optional overrides.
+func NewLoadToolWithOptions(
 	repo skill.Repository,
 	opts ...LoadToolOption,
 ) *LoadTool {

--- a/tool/skill/load_test.go
+++ b/tool/skill/load_test.go
@@ -112,7 +112,10 @@ func TestLoadTool_Declaration(t *testing.T) {
 func TestLoadTool_DeclarationOverride(t *testing.T) {
 	const description = "Always load the matching skill first."
 
-	lt := NewLoadTool(nil, WithLoadToolDescription(description))
+	lt := NewLoadToolWithOptions(
+		nil,
+		WithLoadToolDescription(description),
+	)
 	d := lt.Declaration()
 	require.Equal(t, description, d.Description)
 }

--- a/tool/skill/load_test.go
+++ b/tool/skill/load_test.go
@@ -104,8 +104,17 @@ func TestLoadTool_Declaration(t *testing.T) {
 	lt := NewLoadTool(nil)
 	d := lt.Declaration()
 	require.Equal(t, "skill_load", d.Name)
+	require.Equal(t, defaultLoadToolDescription, d.Description)
 	require.NotNil(t, d.InputSchema)
 	require.NotNil(t, d.OutputSchema)
+}
+
+func TestLoadTool_DeclarationOverride(t *testing.T) {
+	const description = "Always load the matching skill first."
+
+	lt := NewLoadTool(nil, WithLoadToolDescription(description))
+	d := lt.Declaration()
+	require.Equal(t, description, d.Description)
 }
 
 func TestLoadTool_StateDelta_InvalidArgs(t *testing.T) {


### PR DESCRIPTION
## Summary
- add an explicit `skills.tool_profile` config surface in `openclaw/app`
- thread the selected profile into agent construction and admin runtime config
- add `tools.openclaw_tooling_guidance` so downstream runtimes can override or disable the built-in OpenClaw tooling guidance without disabling the actual OpenClaw tools
- document the new guidance override behavior and cover the new behavior with tests

## Testing
- `cd openclaw && go test ./app`
- `cd openclaw && go test ./...`