### PR TITLE
[gemini][chore] Make gemini-embedding-001 as default embedding model

### DIFF
--- a/knowledge/embedder/gemini/gemini.go
+++ b/knowledge/embedder/gemini/gemini.go
@@ -30,7 +30,7 @@ var _ embedder.Embedder = (*Embedder)(nil)
 
 const (
 	// DefaultModel is the default Gemini embedding model.
-	DefaultModel = ModelGeminiEmbeddingExp0307
+	DefaultModel = ModelGeminiEmbedding001
 	// DefaultDimensions is the default embedding dimension.
 	DefaultDimensions = 1536
 	// DefaultTaskType is the default task type.


### PR DESCRIPTION
- gemini-embedding-001 is replacing  gemini-embedding-exp-03-07 
- Ref: https://ai.google.dev/gemini-api/docs/deprecations