### PR TITLE
session/redis: avoid KEEPTTL in hashidx Lua scripts

### DIFF
--- a/session/redis/internal/hashidx/lua.go
+++ b/session/redis/internal/hashidx/lua.go
@@ -54,6 +54,14 @@ local ttl = tonumber(ARGV[4])
 -- Use a simple placeholder string, then replace its quoted JSON form with null after encoding.
 local nilSentinel = "__TRPC_AGENT_GO_NULL__"
 
+local function setPreserveTTL(key, value)
+    local ttlMs = redis.call('PTTL', key)
+    redis.call('SET', key, value)
+    if ttlMs > 0 then
+        redis.call('PEXPIRE', key, ttlMs)
+    end
+end
+
 local metaJSON = redis.call('GET', sessionMetaKey)
 if not metaJSON then
     return 0
@@ -86,7 +94,7 @@ encodedMeta = string.gsub(encodedMeta, '"' .. nilSentinel .. '"', 'null')
 if ttl > 0 then
     redis.call('SET', sessionMetaKey, encodedMeta, 'EX', ttl)
 else
-    redis.call('SET', sessionMetaKey, encodedMeta, 'KEEPTTL')
+    setPreserveTTL(sessionMetaKey, encodedMeta)
 end
 
 return 1
@@ -106,6 +114,14 @@ local eventJSON = ARGV[2]
 local timestamp = tonumber(ARGV[3])
 local ttl = tonumber(ARGV[4])
 local shouldStoreEvent = tonumber(ARGV[5]) == 1
+
+local function setPreserveTTL(key, value)
+    local ttlMs = redis.call('PTTL', key)
+    redis.call('SET', key, value)
+    if ttlMs > 0 then
+        redis.call('PEXPIRE', key, ttlMs)
+    end
+end
 
 -- 1. Check session meta exists first to avoid orphan events
 local metaJSON = redis.call('GET', sessionMetaKey)
@@ -130,7 +146,11 @@ if stateDelta and next(stateDelta) ~= nil then
     for k, v in pairs(stateDelta) do
         meta.state[k] = v
     end
-    redis.call('SET', sessionMetaKey, cjson.encode(meta), 'KEEPTTL')
+    if ttl > 0 then
+        redis.call('SET', sessionMetaKey, cjson.encode(meta))
+    else
+        setPreserveTTL(sessionMetaKey, cjson.encode(meta))
+    end
 end
 
 -- 4. Refresh TTL on event data keys
@@ -187,6 +207,14 @@ local fk = ARGV[1]
 local newSum = cjson.decode(ARGV[2])
 local ttl = tonumber(ARGV[3])
 
+local function setPreserveTTL(key, value)
+    local ttlMs = redis.call('PTTL', key)
+    redis.call('SET', key, value)
+    if ttlMs > 0 then
+        redis.call('PEXPIRE', key, ttlMs)
+    end
+end
+
 local cur = redis.call('GET', sumKey)
 if not cur or cur == '' then
     local m = {}
@@ -207,7 +235,7 @@ local new_ts = newSum and newSum['updated_at'] or nil
 
 if not old or (old_ts and new_ts and old_ts <= new_ts) then
     map[fk] = newSum
-    redis.call('SET', sumKey, cjson.encode(map), 'KEEPTTL')
+    setPreserveTTL(sumKey, cjson.encode(map))
     return 1
 end
 return 0
@@ -391,6 +419,14 @@ local ts = tonumber(ARGV[2])
 local ttl = tonumber(ARGV[3])
 local tracksVal = ARGV[4]
 
+local function setPreserveTTL(key, value)
+    local ttlMs = redis.call('PTTL', key)
+    redis.call('SET', key, value)
+    if ttlMs > 0 then
+        redis.call('PEXPIRE', key, ttlMs)
+    end
+end
+
 -- Check session exists and read meta
 local metaJSON = redis.call('GET', metaKey)
 if not metaJSON then
@@ -410,7 +446,7 @@ if not meta.state or type(meta.state) ~= 'table' then
     meta.state = {}
 end
 meta.state['tracks'] = tracksVal
-redis.call('SET', metaKey, cjson.encode(meta), 'KEEPTTL')
+setPreserveTTL(metaKey, cjson.encode(meta))
 
 -- Refresh TTL for track data keys
 if ttl > 0 then

--- a/session/redis/internal/hashidx/session_test.go
+++ b/session/redis/internal/hashidx/session_test.go
@@ -261,6 +261,44 @@ func TestClient_AppendEvent(t *testing.T) {
 	})
 }
 
+func TestClient_AppendEvent_PreservesExistingTTLWithoutRefresh(t *testing.T) {
+	mr, rdb := setupMiniredis(t)
+	createCfg := defaultConfig()
+	createCfg.SessionTTL = 10 * time.Second
+	createClient := NewClient(rdb, createCfg)
+
+	appendCfg := createCfg
+	appendCfg.SessionTTL = 0
+	appendClient := NewClient(rdb, appendCfg)
+
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "ae-ttl"}
+
+	_, err := createClient.CreateSession(ctx, key, nil)
+	require.NoError(t, err)
+
+	metaKey := createClient.keys.SessionMetaKey(key)
+	assert.Equal(t, 10*time.Second, mr.TTL(metaKey))
+
+	mr.FastForward(4 * time.Second)
+
+	err = appendClient.AppendEvent(ctx, key, &event.Event{
+		ID:        "evt-ttl",
+		Timestamp: time.Now(),
+		StateDelta: session.StateMap{
+			"k": []byte("v"),
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 6*time.Second, mr.TTL(metaKey))
+
+	sess, err := createClient.GetSession(ctx, key, 0, time.Time{})
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Equal(t, []byte("v"), sess.State["k"])
+}
+
 func TestClient_DeleteSession(t *testing.T) {
 	_, rdb := setupMiniredis(t)
 	c := NewClient(rdb, defaultConfig())

--- a/session/redis/internal/hashidx/state_test.go
+++ b/session/redis/internal/hashidx/state_test.go
@@ -57,6 +57,39 @@ func TestClient_UpdateSessionState(t *testing.T) {
 	})
 }
 
+func TestClient_UpdateSessionState_PreservesExistingTTLWithoutRefresh(t *testing.T) {
+	mr, rdb := setupMiniredis(t)
+	createCfg := defaultConfig()
+	createCfg.SessionTTL = 10 * time.Second
+	createClient := NewClient(rdb, createCfg)
+
+	updateCfg := createCfg
+	updateCfg.SessionTTL = 0
+	updateClient := NewClient(rdb, updateCfg)
+
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "uss-ttl"}
+
+	_, err := createClient.CreateSession(ctx, key, session.StateMap{"existing": []byte("v1")})
+	require.NoError(t, err)
+
+	metaKey := createClient.keys.SessionMetaKey(key)
+	assert.Equal(t, 10*time.Second, mr.TTL(metaKey))
+
+	mr.FastForward(4 * time.Second)
+
+	err = updateClient.UpdateSessionState(ctx, key, session.StateMap{"new": []byte("v2")})
+	require.NoError(t, err)
+
+	assert.Equal(t, 6*time.Second, mr.TTL(metaKey))
+
+	sess, err := createClient.GetSession(ctx, key, 0, time.Time{})
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Equal(t, []byte("v1"), sess.State["existing"])
+	assert.Equal(t, []byte("v2"), sess.State["new"])
+}
+
 func TestClient_UpdateAppState(t *testing.T) {
 	_, rdb := setupMiniredis(t)
 	c := NewClient(rdb, defaultConfig())

--- a/session/redis/internal/hashidx/summary_test.go
+++ b/session/redis/internal/hashidx/summary_test.go
@@ -83,3 +83,35 @@ func TestClient_GetSummary(t *testing.T) {
 		assert.Nil(t, result)
 	})
 }
+
+func TestClient_CreateSummary_PreservesExistingTTLOnUpdate(t *testing.T) {
+	mr, rdb := setupMiniredis(t)
+	cfg := defaultConfig()
+	cfg.SessionTTL = 10 * time.Second
+	c := NewClient(rdb, cfg)
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "sum-ttl"}
+
+	first := time.Now().UTC()
+	require.NoError(t, c.CreateSummary(ctx, key, "all", &session.Summary{
+		Summary:   "first",
+		UpdatedAt: first,
+	}, cfg.SessionTTL))
+
+	sumKey := c.keys.SummaryKey(key)
+	assert.Equal(t, 10*time.Second, mr.TTL(sumKey))
+
+	mr.FastForward(4 * time.Second)
+
+	require.NoError(t, c.CreateSummary(ctx, key, "all", &session.Summary{
+		Summary:   "second",
+		UpdatedAt: first.Add(time.Second),
+	}, cfg.SessionTTL))
+
+	assert.Equal(t, 6*time.Second, mr.TTL(sumKey))
+
+	result, err := c.GetSummary(ctx, key)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "second", result["all"].Summary)
+}

--- a/session/redis/internal/hashidx/track_test.go
+++ b/session/redis/internal/hashidx/track_test.go
@@ -66,6 +66,44 @@ func TestClient_AppendTrackEvent(t *testing.T) {
 	})
 }
 
+func TestClient_AppendTrackEvent_PreservesExistingTTLWithoutRefresh(t *testing.T) {
+	mr, rdb := setupMiniredis(t)
+	createCfg := defaultConfig()
+	createCfg.SessionTTL = 10 * time.Second
+	createClient := NewClient(rdb, createCfg)
+
+	appendCfg := createCfg
+	appendCfg.SessionTTL = 0
+	appendClient := NewClient(rdb, appendCfg)
+
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "trk-ttl"}
+
+	_, err := createClient.CreateSession(ctx, key, nil)
+	require.NoError(t, err)
+
+	metaKey := createClient.keys.SessionMetaKey(key)
+	assert.Equal(t, 10*time.Second, mr.TTL(metaKey))
+
+	mr.FastForward(4 * time.Second)
+
+	tracksJSON, err := json.Marshal([]string{"alpha"})
+	require.NoError(t, err)
+
+	err = appendClient.AppendTrackEvent(ctx, key, &session.TrackEvent{
+		Track:     "alpha",
+		Payload:   json.RawMessage(`"payload"`),
+		Timestamp: time.Now(),
+	}, tracksJSON)
+	require.NoError(t, err)
+
+	assert.Equal(t, 6*time.Second, mr.TTL(metaKey))
+
+	tracks, err := createClient.ListTracksForSession(ctx, key)
+	require.NoError(t, err)
+	assert.Contains(t, tracks, session.Track("alpha"))
+}
+
 func TestClient_GetTrackEvents(t *testing.T) {
 	_, rdb := setupMiniredis(t)
 	c := NewClient(rdb, defaultConfig())


### PR DESCRIPTION
## Summary
- replace `SET ... KEEPTTL` in hashidx Lua scripts with a Redis-version-compatible TTL preservation helper
- keep summary, session state, append-event, and track-event write semantics unchanged while avoiding syntax errors on older Redis deployments
- add hashidx regression tests covering summary and session-meta TTL preservation during updates

## Validation
- `cd session/redis && go test ./...`

## Notes
- this change only touches the hashidx path
- the zset path is unchanged because it does not use `KEEPTTL` in its summary persistence flow