### PR TITLE
model/openai: preserve terminal streaming responses

### DIFF
--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -30,7 +30,6 @@ import (
 	openai "github.com/openai/openai-go"
 	openaiopt "github.com/openai/openai-go/option"
 	"github.com/openai/openai-go/packages/respjson"
-	"github.com/openai/openai-go/packages/ssestream"
 	"github.com/openai/openai-go/shared"
 	"trpc.group/trpc-go/trpc-agent-go/internal/fileref"
 	"trpc.group/trpc-go/trpc-agent-go/log"
@@ -1355,10 +1354,31 @@ func (m *Model) handleStreamingResponseWithEmitter(
 		}
 	}
 
-	// Call the stream complete callback before the final response is emitted.
-	m.handleStreamCompleteCallback(ctx, chatRequest, acc, stream.Err())
+	streamErr := normalizeTerminalStreamError(stream.Err(), acc)
 
-	m.emitStreamingFinalResponse(ctx, stream, acc, idToIndexMap, extraFieldsMap, reasoningBuf.String(), emit)
+	// Call the stream complete callback before the final response is emitted.
+	m.handleStreamCompleteCallback(ctx, chatRequest, acc, streamErr)
+
+	m.emitStreamingFinalResponse(ctx, streamErr, acc, idToIndexMap, extraFieldsMap, reasoningBuf.String(), emit)
+}
+
+func normalizeTerminalStreamError(
+	streamErr error,
+	acc openai.ChatCompletionAccumulator,
+) error {
+	if streamErr == nil || !hasTerminalFinishReason(acc) {
+		return streamErr
+	}
+	return nil
+}
+
+func hasTerminalFinishReason(acc openai.ChatCompletionAccumulator) bool {
+	for _, choice := range acc.Choices {
+		if choice.FinishReason != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // sanitizeChunkForAccumulator returns a defensive copy of the given chunk that
@@ -2131,14 +2151,14 @@ func toolCallDeltaIndexPointer(toolCall openai.ChatCompletionChunkChoiceDeltaToo
 // emitStreamingFinalResponse emits the final response with accumulated data.
 func (m *Model) emitStreamingFinalResponse(
 	ctx context.Context,
-	stream *ssestream.Stream[openai.ChatCompletionChunk],
+	streamErr error,
 	acc openai.ChatCompletionAccumulator,
 	idToIndexMap map[string]int,
 	extraFieldsMap map[string]map[string]any,
 	aggregatedReasoning string,
 	emit responseEmitter,
 ) {
-	if stream.Err() == nil {
+	if streamErr == nil {
 		// Check accumulated tool calls (batch processing after streaming is complete).
 		var hasToolCall bool
 		var accumulatedToolCalls []model.ToolCall
@@ -2176,7 +2196,7 @@ func (m *Model) emitStreamingFinalResponse(
 	// Send error response.
 	emit(&model.Response{
 		Error: &model.ResponseError{
-			Message: stream.Err().Error(),
+			Message: streamErr.Error(),
 			Type:    model.ErrorTypeStreamError,
 		},
 		Timestamp: time.Now(),

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -2515,6 +2515,19 @@ func TestModel_GenerateContent_StreamingBatchProcessing(t *testing.T) {
 			expectedCount: 1,
 		},
 		{
+			name: "Terminal_ToolCall_With_PostTerminal_Error", // Some compatible providers emit an error after terminal finish_reason.
+			chunks: []string{
+				`data: {"id":"test","object":"chat.completion.chunk","created":1699200000,"model":"gpt-3.5-turbo","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}],"usage":{"completion_tokens":1,"prompt_tokens":10,"total_tokens":11}}`,
+				`data: {"id":"test","object":"chat.completion.chunk","created":1699200000,"model":"gpt-3.5-turbo","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_789","type":"function","function":{"name":"search","arguments":"{\"query\":\"city novel\"}"}}]},"finish_reason":null}],"usage":{"completion_tokens":12,"prompt_tokens":10,"total_tokens":22}}`,
+				`data: {"id":"test","object":"chat.completion.chunk","created":1699200000,"model":"gpt-3.5-turbo","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],"usage":{"completion_tokens":14,"prompt_tokens":10,"total_tokens":24}}`,
+				`data: {"id":"test","object":"chat.completion.chunk","created":1699200000,"model":"gpt-3.5-turbo","choices":[],"usage":{"completion_tokens":14,"prompt_tokens":10,"total_tokens":24}}`,
+				`data: {"error":{"message":"list index out of range","type":"BadRequestError","param":null,"code":400}}`,
+			},
+			expectedTool:  "search",
+			expectedArgs:  `{"query":"city novel"}`,
+			expectedCount: 1,
+		},
+		{
 			name: "Abnormal_Mixed_Mode", // other "mixed" mode: content exists in tool call chunks {3 ""}.
 			chunks: []string{
 				`data: {"id":"test","object":"chat.completion.chunk","created":1699200000,"model":"gpt-3.5-turbo","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}`,


### PR DESCRIPTION
## Summary
- preserve accumulated OpenAI-compatible streaming responses once a terminal `finish_reason` has been received
- prevent provider tail errors, such as missing `data: [DONE]` or post-terminal SSE error frames, from replacing a completed response with `stream_error`
- add regression coverage for a terminal streamed tool call followed by a provider error frame

## Why
Some OpenAI-compatible providers can emit a complete streamed response, including `finish_reason` and a final usage chunk, then close without the standard `data: [DONE]` sentinel or append an error frame such as `list index out of range`. The upstream SDK reports that tail condition as a stream error, which previously discarded already accumulated tool calls.

## Impact
- completed streamed tool calls continue through normal tool execution even if the provider reports an error after the terminal chunk
- streams that fail before any terminal `finish_reason` are still surfaced as `stream_error`, preserving existing failure semantics

## Validation
- `go test ./model/openai`