### PR TITLE
{plugin, examples, docs}: add errormessage plugin to customise error event content

### DIFF
--- a/docs/mkdocs/en/plugin.md
+++ b/docs/mkdocs/en/plugin.md
@@ -547,6 +547,14 @@ rewriter := errormessage.New(
 
 Returning `ok=false` or an empty string from the resolver leaves the event untouched, which means Runner's built-in fallback message still applies.
 
+Finish reason:
+
+By default the plugin sets the synthesised choice's `FinishReason` to `"error"`. Use `errormessage.WithFinishReason("stop")` or another value if your downstream protocol expects a different reason. If the original choice already has a `FinishReason`, the plugin preserves it and does not override downstream expectations.
+
+Scope:
+
+The plugin is installed via `runner.WithPlugins(...)` and runs on every event the runner processes, so it covers errors that agents emit on their event channel (for example, the `stop_agent_error` event produced by `llmflow` for `agent.StopError`, or any raw `event.NewErrorEvent(...)`). Errors returned synchronously from `agent.Run` (before any event channel is produced) are handled directly by Runner using its built-in fallback content, so this plugin does not rewrite the persisted content on that specific path.
+
 Full example: [examples/plugin/errormessage](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/plugin/errormessage).
 
 ### Guardrail

--- a/docs/mkdocs/en/plugin.md
+++ b/docs/mkdocs/en/plugin.md
@@ -503,6 +503,52 @@ defer runnerInstance.Close()
 
 Full example: [examples/plugin/messagemerger](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/plugin/messagemerger).
 
+### ErrorMessage
+
+`errormessage.New(opts...)` from `plugin/errormessage` rewrites the assistant-visible content of error events before Runner persists them into the session.
+
+When an event carries `Response.Error` but no `Choices[].Message.Content` — for example, the `stop_agent_error` event produced by `llmflow` for `agent.StopError`, or any raw `event.NewErrorEvent(...)` — Runner falls back to a generic English message: `"An error occurred during execution. Please contact the service provider."`. This plugin runs in `OnEvent` before that fallback and fills the content itself, so callers can surface a customised, localised, or tenant-specific message to end users. The structured `Response.Error` is left intact, so debugging and downstream consumers still see the original reason.
+
+The plugin only rewrites events where no valid content exists yet, so a partial assistant message produced before the failure is never overwritten.
+
+Static content:
+
+```go
+rewriter := errormessage.New(
+    errormessage.WithContent("The request was stopped. Please try again later."),
+)
+runnerInstance := runner.NewRunner(
+    "my-app",
+    agentInstance,
+    runner.WithPlugins(rewriter),
+)
+defer runnerInstance.Close()
+```
+
+Dynamic resolver (for example, friendlier copy for `stop_agent_error`):
+
+```go
+rewriter := errormessage.New(
+    errormessage.WithResolver(func(
+        _ context.Context,
+        _ *agent.Invocation,
+        e *event.Event,
+    ) (string, bool) {
+        if e == nil || e.Response == nil || e.Response.Error == nil {
+            return "", false
+        }
+        if e.Response.Error.Type == agent.ErrorTypeStopAgentError {
+            return "The request was stopped by policy. Please try again later.", true
+        }
+        return "Execution failed. Please try again later.", true
+    }),
+)
+```
+
+Returning `ok=false` or an empty string from the resolver leaves the event untouched, which means Runner's built-in fallback message still applies.
+
+Full example: [examples/plugin/errormessage](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/plugin/errormessage).
+
 ### Guardrail
 
 `guardrail.New(...)` from `plugin/guardrail` is the top-level plugin that wires one or more guardrail capabilities into the runner.
@@ -808,10 +854,10 @@ The example includes verified scenarios for:
 - A clearly unsafe request that is blocked
 - A defensive analysis request that is allowed
 
-The repository currently includes Logging, GlobalInstruction, ToolCallID, and
-Guardrail as built-in plugins. Tool Approval, Prompt Injection, and Unsafe
-Intent are currently built-in capabilities under the Guardrail plugin.
-Additional plugins can be implemented as custom plugins.
+The repository currently includes Logging, GlobalInstruction, ToolCallID,
+MessageMerger, ErrorMessage, and Guardrail as built-in plugins. Tool Approval,
+Prompt Injection, and Unsafe Intent are currently built-in capabilities under
+the Guardrail plugin. Additional plugins can be implemented as custom plugins.
 
 ## Writing Your Own Plugin
 

--- a/docs/mkdocs/zh/plugin.md
+++ b/docs/mkdocs/zh/plugin.md
@@ -837,6 +837,14 @@ rewriter := errormessage.New(
 
 resolver 返回 `ok=false` 或空字符串时，事件保持不变，Runner 内置的兜底文案仍然生效。
 
+FinishReason：
+
+插件默认会把合成 choice 的 `FinishReason` 设为 `"error"`。如果下游协议期望别的取值，可以通过 `errormessage.WithFinishReason("stop")` 等方式覆盖。如果原始 choice 已经带有 `FinishReason`，插件会原样保留，不会强制覆盖下游的预期。
+
+适用范围：
+
+插件通过 `runner.WithPlugins(...)` 注册，会在 Runner 处理每一条事件时触发，因此能覆盖 agent 从事件通道发出的错误事件（比如 `llmflow` 针对 `agent.StopError` 产出的 `stop_agent_error` 事件，以及任何 `event.NewErrorEvent(...)` 产出的事件）。但对于 `agent.Run` 同步返回 error（尚未建立事件通道）这一路径，Runner 会直接用内置兜底文案写入 session，此时本插件无法改写持久化内容。
+
 完整示例见 [examples/plugin/errormessage](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/plugin/errormessage)。
 
 说明：目前仓库内置了 Logging、GlobalInstruction、ToolCallID、MessageMerger、ErrorMessage、Guardrail 六类插件。其中 Guardrail 插件当前提供的内置 capability 包括工具审批、Prompt Injection 和 Unsafe Intent。更多插件可通过自定义插件实现。

--- a/docs/mkdocs/zh/plugin.md
+++ b/docs/mkdocs/zh/plugin.md
@@ -793,7 +793,53 @@ defer runnerInstance.Close()
 
 完整示例见 [examples/plugin/messagemerger](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/plugin/messagemerger)。
 
-说明：目前仓库内置了 Logging、GlobalInstruction、ToolCallID、MessageMerger、Guardrail 五类插件。其中 Guardrail 插件当前提供的内置 capability 包括工具审批、Prompt Injection 和 Unsafe Intent。更多插件可通过自定义插件实现。
+### ErrorMessage（错误消息改写）
+
+`plugin/errormessage` 下的 `errormessage.New(opts...)` 会在 Runner 把错误事件写入 session 之前，改写这条错误事件里对用户可见的 `Choices[].Message.Content`。
+
+当一个 event 带有 `Response.Error` 但还没有 `Choices[].Message.Content` 时（例如 `llmflow` 把 `agent.StopError` 转成的 `stop_agent_error` 事件、或者任何直接 `event.NewErrorEvent(...)` 产出的事件），Runner 会用一句固定的英文兜底文案 `"An error occurred during execution. Please contact the service provider."` 补齐。这个插件在 `OnEvent` 中先一步把 content 填好，方便业务侧展示更友好、本地化或按租户定制的提示信息。结构化的 `Response.Error` 不会被修改，调试和下游消费方仍能看到原始原因。
+
+插件只会改写尚未带有有效 content 的错误事件，所以失败前已经产出的流式助手消息不会被覆盖。
+
+静态文案：
+
+```go
+rewriter := errormessage.New(
+    errormessage.WithContent("本次执行已停止，请稍后再试。"),
+)
+runnerInstance := runner.NewRunner(
+    "my-app",
+    agentInstance,
+    runner.WithPlugins(rewriter),
+)
+defer runnerInstance.Close()
+```
+
+动态 resolver（例如对 `stop_agent_error` 使用更友好的话术）：
+
+```go
+rewriter := errormessage.New(
+    errormessage.WithResolver(func(
+        _ context.Context,
+        _ *agent.Invocation,
+        e *event.Event,
+    ) (string, bool) {
+        if e == nil || e.Response == nil || e.Response.Error == nil {
+            return "", false
+        }
+        if e.Response.Error.Type == agent.ErrorTypeStopAgentError {
+            return "本次执行已按策略停止，请稍后再试。", true
+        }
+        return "执行失败，请稍后重试。", true
+    }),
+)
+```
+
+resolver 返回 `ok=false` 或空字符串时，事件保持不变，Runner 内置的兜底文案仍然生效。
+
+完整示例见 [examples/plugin/errormessage](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/plugin/errormessage)。
+
+说明：目前仓库内置了 Logging、GlobalInstruction、ToolCallID、MessageMerger、ErrorMessage、Guardrail 六类插件。其中 Guardrail 插件当前提供的内置 capability 包括工具审批、Prompt Injection 和 Unsafe Intent。更多插件可通过自定义插件实现。
 
 ## 如何扩展：写一个自己的插件
 

--- a/examples/plugin/errormessage/README.md
+++ b/examples/plugin/errormessage/README.md
@@ -31,7 +31,7 @@ go run .
 You will see two blocks in the output. The first block is persisted **without**
 the plugin, so the default fallback message is stored:
 
-```
+```text
   Persisted error event:
     Response.Error.Type : stop_agent_error
     Response.Error.Msg  : max iterations reached
@@ -41,7 +41,7 @@ the plugin, so the default fallback message is stored:
 The second block is persisted **with** the plugin, which uses the resolver
 above to choose a friendlier message:
 
-```
+```text
   Persisted error event:
     Response.Error.Type : stop_agent_error
     Response.Error.Msg  : max iterations reached

--- a/examples/plugin/errormessage/README.md
+++ b/examples/plugin/errormessage/README.md
@@ -1,0 +1,89 @@
+# Error Message Plugin Example
+
+This example shows how to use `plugin/errormessage` to customise the
+assistant-visible content of error events before Runner persists them into the
+session.
+
+The example does **not** call any real model backend. A tiny custom agent
+emits a single `stop_agent_error` event — the same shape `llmflow` produces
+when a `StopError` propagates out of a tool or callback — and the demo runs
+two Runners so the persisted session events can be compared side by side.
+
+## What this example demonstrates
+
+- Create a Runner with `errormessage.New(...)`
+- Plug in a `Resolver` that decides the user-facing content per error type
+- Compare the session events persisted with and without the plugin
+
+## Prerequisites
+
+- Go 1.21 or later
+
+No environment variables are required.
+
+## Usage
+
+```bash
+cd examples/plugin/errormessage
+go run .
+```
+
+You will see two blocks in the output. The first block is persisted **without**
+the plugin, so the default fallback message is stored:
+
+```
+  Persisted error event:
+    Response.Error.Type : stop_agent_error
+    Response.Error.Msg  : max iterations reached
+    Visible Content     : An error occurred during execution. Please contact the service provider.
+```
+
+The second block is persisted **with** the plugin, which uses the resolver
+above to choose a friendlier message:
+
+```
+  Persisted error event:
+    Response.Error.Type : stop_agent_error
+    Response.Error.Msg  : max iterations reached
+    Visible Content     : 本次执行已按策略停止，请稍后再试。
+```
+
+In both cases `Response.Error` is left intact, so debugging tools and
+downstream consumers still see the original reason.
+
+## Core integration
+
+The example wires the plugin at Runner construction time:
+
+```go
+rewriter := errormessage.New(
+    errormessage.WithResolver(func(
+        _ context.Context,
+        _ *agent.Invocation,
+        e *event.Event,
+    ) (string, bool) {
+        if e == nil || e.Response == nil || e.Response.Error == nil {
+            return "", false
+        }
+        if e.Response.Error.Type == agent.ErrorTypeStopAgentError {
+            return "本次执行已按策略停止，请稍后再试。", true
+        }
+        return "执行失败，请稍后重试。", true
+    }),
+)
+
+runnerInstance := runner.NewRunner(
+    "error-message-demo",
+    agentInstance,
+    runner.WithSessionService(svc),
+    runner.WithPlugins(rewriter),
+)
+```
+
+For a fixed, static message `errormessage.WithContent("...")` is equivalent to
+`WithResolver` returning the same string for every error event.
+
+## Files
+
+- `main.go`: program entry, Runner setup, and side-by-side comparison.
+- `agent.go`: a minimal agent that emits a single `stop_agent_error` event.

--- a/examples/plugin/errormessage/agent.go
+++ b/examples/plugin/errormessage/agent.go
@@ -1,0 +1,62 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"context"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+// stopAgent is a minimal agent that emits a single raw error event, matching
+// the shape llmflow produces when a StopError propagates out of a tool or
+// callback. It has no dependency on any real model backend, so the demo is
+// fully self-contained.
+type stopAgent struct{}
+
+func newStopAgent() agent.Agent {
+	return &stopAgent{}
+}
+
+func (a *stopAgent) Info() agent.Info {
+	return agent.Info{
+		Name:        agentName,
+		Description: "emits a single stop_agent_error event for demo purposes",
+	}
+}
+
+func (a *stopAgent) Tools() []tool.Tool {
+	return nil
+}
+
+func (a *stopAgent) SubAgents() []agent.Agent {
+	return nil
+}
+
+func (a *stopAgent) FindSubAgent(string) agent.Agent {
+	return nil
+}
+
+func (a *stopAgent) Run(
+	_ context.Context,
+	inv *agent.Invocation,
+) (<-chan *event.Event, error) {
+	ch := make(chan *event.Event, 1)
+	ch <- event.NewErrorEvent(
+		inv.InvocationID,
+		agentName,
+		agent.ErrorTypeStopAgentError,
+		"max iterations reached",
+	)
+	close(ch)
+	return ch, nil
+}

--- a/examples/plugin/errormessage/main.go
+++ b/examples/plugin/errormessage/main.go
@@ -1,0 +1,161 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package main demonstrates the error message plugin.
+//
+// The example wires a minimal agent that always emits a raw error event (the
+// same shape llmflow produces for StopError) and runs two Runners:
+//
+//   - one without the plugin, so Runner applies its default fallback message
+//   - one with the plugin, so a custom, user-facing message is used instead
+//
+// The example does not call any model backend, so no API key is required.
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/plugin/errormessage"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	sessioninmemory "trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+)
+
+const (
+	appName   = "error-message-demo"
+	agentName = "stopping-agent"
+	userID    = "demo-user"
+)
+
+func main() {
+	fmt.Println("Error Message Plugin Demo")
+	fmt.Println(strings.Repeat("=", 72))
+
+	if err := runWithoutPlugin(); err != nil {
+		fmt.Printf("default run failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println(strings.Repeat("-", 72))
+
+	if err := runWithPlugin(); err != nil {
+		fmt.Printf("plugin run failed: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func runWithoutPlugin() error {
+	fmt.Println("[1] Runner without errormessage plugin (default fallback).")
+	svc := sessioninmemory.NewSessionService()
+	r := runner.NewRunner(
+		appName,
+		newStopAgent(),
+		runner.WithSessionService(svc),
+	)
+	defer r.Close()
+
+	sessionID := "default"
+	if err := drainRun(r, sessionID); err != nil {
+		return err
+	}
+	return printPersistedErrorEvent(svc, sessionID)
+}
+
+func runWithPlugin() error {
+	fmt.Println("[2] Runner with errormessage plugin (customised content).")
+	svc := sessioninmemory.NewSessionService()
+
+	// Example: produce a friendly message for stop_agent_error, and a generic
+	// one for any other error type. The structured Response.Error is left
+	// intact, so debugging and downstream consumers keep the raw reason.
+	rewriter := errormessage.New(
+		errormessage.WithResolver(func(
+			_ context.Context,
+			_ *agent.Invocation,
+			e *event.Event,
+		) (string, bool) {
+			if e == nil || e.Response == nil || e.Response.Error == nil {
+				return "", false
+			}
+			if e.Response.Error.Type == agent.ErrorTypeStopAgentError {
+				return "本次执行已按策略停止，请稍后再试。", true
+			}
+			return "执行失败，请稍后重试。", true
+		}),
+	)
+
+	r := runner.NewRunner(
+		appName,
+		newStopAgent(),
+		runner.WithSessionService(svc),
+		runner.WithPlugins(rewriter),
+	)
+	defer r.Close()
+
+	sessionID := "rewritten"
+	if err := drainRun(r, sessionID); err != nil {
+		return err
+	}
+	return printPersistedErrorEvent(svc, sessionID)
+}
+
+func drainRun(r runner.Runner, sessionID string) error {
+	ch, err := r.Run(
+		context.Background(),
+		userID,
+		sessionID,
+		model.NewUserMessage("trigger a stop"),
+	)
+	if err != nil {
+		return err
+	}
+	for range ch {
+		// Drain; persistence happens in the runner event loop and we only
+		// care about what is stored on the session.
+	}
+	return nil
+}
+
+func printPersistedErrorEvent(
+	svc session.Service,
+	sessionID string,
+) error {
+	sess, err := svc.GetSession(context.Background(), session.Key{
+		AppName:   appName,
+		UserID:    userID,
+		SessionID: sessionID,
+	})
+	if err != nil {
+		return err
+	}
+	if sess == nil {
+		return fmt.Errorf("session %q not found", sessionID)
+	}
+	for _, evt := range sess.Events {
+		if evt.Response == nil || evt.Response.Error == nil {
+			continue
+		}
+		content := ""
+		if len(evt.Response.Choices) > 0 {
+			content = evt.Response.Choices[0].Message.Content
+		}
+		fmt.Println("  Persisted error event:")
+		fmt.Printf("    Response.Error.Type : %s\n", evt.Response.Error.Type)
+		fmt.Printf("    Response.Error.Msg  : %s\n", evt.Response.Error.Message)
+		fmt.Printf("    Visible Content     : %s\n", content)
+		return nil
+	}
+	return fmt.Errorf("no error event persisted in session %q", sessionID)
+}

--- a/plugin/errormessage/errormessage.go
+++ b/plugin/errormessage/errormessage.go
@@ -16,6 +16,19 @@
 // that fallback and fills the Choices content itself, so callers can surface a
 // customised, tenant-specific, or localised message to end users while keeping
 // the structured Response.Error intact for debugging and downstream consumers.
+//
+// Scope:
+//
+//   - The plugin is triggered via the runner OnEvent hook, so it covers
+//     errors produced by agents during a run (for example, events emitted by
+//     llmflow for agent.StopError, or any raw event.NewErrorEvent).
+//   - Errors returned synchronously from agent.Run (before any event channel
+//     is produced) are handled by the runner itself via
+//     ensureErrorEventContent, and the runner applies its built-in fallback
+//     content to those events before invoking plugin hooks. In that specific
+//     path the plugin cannot rewrite the persisted content. Callers that need
+//     a custom message there should make their agent implementation surface
+//     a first error event instead of returning an error from Run.
 package errormessage
 
 import (
@@ -90,9 +103,14 @@ func (p *errorMessagePlugin) onEvent(
 // isRewritableErrorEvent reports whether the event is an error event that has
 // no assistant-visible content yet. Events that already carry valid content
 // (e.g. a partial assistant response produced before the failure) are left
-// untouched so this plugin never overwrites real assistant text.
+// untouched so this plugin never overwrites real assistant text. Partial
+// events are also skipped so that a later final event can still decide the
+// outcome without this plugin leaking a premature failure message to callers.
 func isRewritableErrorEvent(e *event.Event) bool {
 	if e == nil || e.Response == nil || e.Response.Error == nil {
+		return false
+	}
+	if e.IsPartial {
 		return false
 	}
 	if e.IsValidContent() {
@@ -114,7 +132,9 @@ func ensureFirstAssistantChoice(rsp *model.Response) {
 		}}
 		return
 	}
-	if rsp.Choices[0].Message.Role == "" {
-		rsp.Choices[0].Message.Role = model.RoleAssistant
-	}
+	// Always force the first choice into an assistant role so resolver
+	// output is never written into a non-assistant choice (for example when
+	// upstream emits an error event whose first choice carries a
+	// role=user or role=system placeholder).
+	rsp.Choices[0].Message.Role = model.RoleAssistant
 }

--- a/plugin/errormessage/errormessage.go
+++ b/plugin/errormessage/errormessage.go
@@ -1,0 +1,120 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package errormessage provides a runner-scoped plugin that rewrites the
+// user-facing content of error events before they are persisted or forwarded.
+//
+// By default, Runner populates the assistant-visible content of an error event
+// with a generic fallback message when the upstream event carries
+// Response.Error but no Choices content. This plugin runs in OnEvent before
+// that fallback and fills the Choices content itself, so callers can surface a
+// customised, tenant-specific, or localised message to end users while keeping
+// the structured Response.Error intact for debugging and downstream consumers.
+package errormessage
+
+import (
+	"context"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/plugin"
+)
+
+// errorMessagePlugin rewrites the visible content of error events so that a
+// customised message replaces the framework's default fallback.
+type errorMessagePlugin struct {
+	name         string
+	resolver     Resolver
+	finishReason string
+}
+
+// New creates a new error message plugin.
+func New(options ...Option) plugin.Plugin {
+	opts := newOptions(options...)
+	return &errorMessagePlugin{
+		name:         opts.name,
+		resolver:     opts.resolver,
+		finishReason: opts.finishReason,
+	}
+}
+
+// Name implements plugin.Plugin.
+func (p *errorMessagePlugin) Name() string {
+	return p.name
+}
+
+// Register implements plugin.Plugin.
+func (p *errorMessagePlugin) Register(r *plugin.Registry) {
+	if p == nil || r == nil {
+		return
+	}
+	r.OnEvent(p.onEvent)
+}
+
+func (p *errorMessagePlugin) onEvent(
+	ctx context.Context,
+	inv *agent.Invocation,
+	e *event.Event,
+) (*event.Event, error) {
+	if p == nil || p.resolver == nil {
+		return nil, nil
+	}
+	if !isRewritableErrorEvent(e) {
+		return nil, nil
+	}
+	content, ok := p.resolver(ctx, inv, e)
+	if !ok || content == "" {
+		return nil, nil
+	}
+
+	// Shallow-copy the event and deep-copy Response so upstream/sibling
+	// consumers are not affected by our mutation.
+	updated := *e
+	updated.Response = e.Response.Clone()
+	ensureFirstAssistantChoice(updated.Response)
+	updated.Response.Choices[0].Message.Content = content
+	if updated.Response.Choices[0].FinishReason == nil {
+		reason := p.finishReason
+		updated.Response.Choices[0].FinishReason = &reason
+	}
+	return &updated, nil
+}
+
+// isRewritableErrorEvent reports whether the event is an error event that has
+// no assistant-visible content yet. Events that already carry valid content
+// (e.g. a partial assistant response produced before the failure) are left
+// untouched so this plugin never overwrites real assistant text.
+func isRewritableErrorEvent(e *event.Event) bool {
+	if e == nil || e.Response == nil || e.Response.Error == nil {
+		return false
+	}
+	if e.IsValidContent() {
+		return false
+	}
+	return true
+}
+
+func ensureFirstAssistantChoice(rsp *model.Response) {
+	if rsp == nil {
+		return
+	}
+	if len(rsp.Choices) == 0 {
+		rsp.Choices = []model.Choice{{
+			Index: 0,
+			Message: model.Message{
+				Role: model.RoleAssistant,
+			},
+		}}
+		return
+	}
+	if rsp.Choices[0].Message.Role == "" {
+		rsp.Choices[0].Message.Role = model.RoleAssistant
+	}
+}

--- a/plugin/errormessage/errormessage_test.go
+++ b/plugin/errormessage/errormessage_test.go
@@ -1,0 +1,300 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package errormessage_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	rootplugin "trpc.group/trpc-go/trpc-agent-go/plugin"
+	"trpc.group/trpc-go/trpc-agent-go/plugin/errormessage"
+)
+
+func newPluginManager(t *testing.T, p rootplugin.Plugin) *rootplugin.Manager {
+	t.Helper()
+	m, err := rootplugin.NewManager(p)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	return m
+}
+
+func newErrorEvent(errType, errMsg string) *event.Event {
+	return event.NewErrorEvent("inv-1", "agent-1", errType, errMsg)
+}
+
+func TestPlugin_RewritesEmptyErrorEventContent(t *testing.T) {
+	p := errormessage.New(
+		errormessage.WithContent("Friendly fallback."),
+	)
+	m := newPluginManager(t, p)
+
+	original := newErrorEvent(agent.ErrorTypeStopAgentError, "stopped: reason X")
+	require.False(t, original.Response.IsValidContent())
+
+	out, err := m.OnEvent(context.Background(), nil, original)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	require.NotSame(t, original, out, "plugin must not mutate the original event in place")
+
+	// Rewritten event carries the customised visible content.
+	require.Len(t, out.Response.Choices, 1)
+	require.Equal(t, model.RoleAssistant, out.Response.Choices[0].Message.Role)
+	require.Equal(
+		t,
+		"Friendly fallback.",
+		out.Response.Choices[0].Message.Content,
+	)
+	require.NotNil(t, out.Response.Choices[0].FinishReason)
+	require.Equal(t, "error", *out.Response.Choices[0].FinishReason)
+
+	// Structured Response.Error must remain intact for downstream consumers.
+	require.NotNil(t, out.Response.Error)
+	require.Equal(
+		t,
+		agent.ErrorTypeStopAgentError,
+		out.Response.Error.Type,
+	)
+	require.Equal(t, "stopped: reason X", out.Response.Error.Message)
+
+	// Original event must be untouched.
+	require.Empty(t, original.Response.Choices)
+}
+
+func TestPlugin_KeepsExistingAssistantContent(t *testing.T) {
+	p := errormessage.New(
+		errormessage.WithContent("should NOT be applied"),
+	)
+	m := newPluginManager(t, p)
+
+	rsp := &model.Response{
+		Object: model.ObjectTypeError,
+		Done:   true,
+		Error: &model.ResponseError{
+			Type:    "flow_error",
+			Message: "inner details",
+		},
+		Choices: []model.Choice{{
+			Index: 0,
+			Message: model.Message{
+				Role:    model.RoleAssistant,
+				Content: "partial answer before failure",
+			},
+		}},
+	}
+	original := event.NewResponseEvent("inv", "agent", rsp)
+	require.True(t, original.Response.IsValidContent())
+
+	out, err := m.OnEvent(context.Background(), nil, original)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	require.Same(t, original, out, "events with valid content must be passed through")
+	require.Equal(
+		t,
+		"partial answer before failure",
+		out.Response.Choices[0].Message.Content,
+	)
+}
+
+func TestPlugin_SkipsNonErrorEvents(t *testing.T) {
+	p := errormessage.New(errormessage.WithContent("fallback"))
+	m := newPluginManager(t, p)
+
+	rsp := &model.Response{
+		Done: true,
+		Choices: []model.Choice{{
+			Index:   0,
+			Message: model.NewAssistantMessage("normal reply"),
+		}},
+	}
+	original := event.NewResponseEvent("inv", "agent", rsp)
+
+	out, err := m.OnEvent(context.Background(), nil, original)
+	require.NoError(t, err)
+	require.Same(t, original, out)
+}
+
+func TestPlugin_ResolverReceivesInvocationAndEvent(t *testing.T) {
+	var (
+		seenInvocation *agent.Invocation
+		seenEvent      *event.Event
+	)
+	resolver := func(
+		_ context.Context,
+		inv *agent.Invocation,
+		e *event.Event,
+	) (string, bool) {
+		seenInvocation = inv
+		seenEvent = e
+		return "resolved", true
+	}
+	p := errormessage.New(errormessage.WithResolver(resolver))
+	m := newPluginManager(t, p)
+
+	inv := agent.NewInvocation(agent.WithInvocationID("inv-42"))
+	original := newErrorEvent("flow_error", "boom")
+
+	out, err := m.OnEvent(context.Background(), inv, original)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	require.Equal(t, inv, seenInvocation)
+	require.Same(t, original, seenEvent)
+	require.Equal(
+		t,
+		"resolved",
+		out.Response.Choices[0].Message.Content,
+	)
+}
+
+func TestPlugin_ResolverReturningFalseLeavesEventUntouched(t *testing.T) {
+	resolver := func(
+		_ context.Context,
+		_ *agent.Invocation,
+		_ *event.Event,
+	) (string, bool) {
+		return "unused", false
+	}
+	p := errormessage.New(errormessage.WithResolver(resolver))
+	m := newPluginManager(t, p)
+
+	original := newErrorEvent("flow_error", "boom")
+	out, err := m.OnEvent(context.Background(), nil, original)
+	require.NoError(t, err)
+	require.Same(t, original, out)
+	require.Empty(t, original.Response.Choices)
+}
+
+func TestPlugin_ResolverReturningEmptyLeavesEventUntouched(t *testing.T) {
+	resolver := func(
+		_ context.Context,
+		_ *agent.Invocation,
+		_ *event.Event,
+	) (string, bool) {
+		return "", true
+	}
+	p := errormessage.New(errormessage.WithResolver(resolver))
+	m := newPluginManager(t, p)
+
+	original := newErrorEvent("flow_error", "boom")
+	out, err := m.OnEvent(context.Background(), nil, original)
+	require.NoError(t, err)
+	require.Same(t, original, out)
+	require.Empty(t, original.Response.Choices)
+}
+
+func TestPlugin_NoResolverIsNoop(t *testing.T) {
+	p := errormessage.New()
+	m := newPluginManager(t, p)
+
+	original := newErrorEvent("flow_error", "boom")
+	out, err := m.OnEvent(context.Background(), nil, original)
+	require.NoError(t, err)
+	require.Same(t, original, out)
+}
+
+func TestPlugin_CustomFinishReason(t *testing.T) {
+	p := errormessage.New(
+		errormessage.WithContent("stopped"),
+		errormessage.WithFinishReason("stop"),
+	)
+	m := newPluginManager(t, p)
+
+	original := newErrorEvent(agent.ErrorTypeStopAgentError, "policy stop")
+	out, err := m.OnEvent(context.Background(), nil, original)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	require.NotNil(t, out.Response.Choices[0].FinishReason)
+	require.Equal(t, "stop", *out.Response.Choices[0].FinishReason)
+}
+
+func TestPlugin_PreservesExistingFinishReason(t *testing.T) {
+	existing := "length"
+	rsp := &model.Response{
+		Object: model.ObjectTypeError,
+		Done:   true,
+		Error: &model.ResponseError{
+			Type:    "flow_error",
+			Message: "boom",
+		},
+		Choices: []model.Choice{{
+			Index: 0,
+			Message: model.Message{
+				Role: model.RoleAssistant,
+			},
+			FinishReason: &existing,
+		}},
+	}
+	original := event.NewResponseEvent("inv", "agent", rsp)
+	require.False(t, original.Response.IsValidContent())
+
+	p := errormessage.New(errormessage.WithContent("friendly"))
+	m := newPluginManager(t, p)
+
+	out, err := m.OnEvent(context.Background(), nil, original)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	require.Equal(t, "friendly", out.Response.Choices[0].Message.Content)
+	require.NotNil(t, out.Response.Choices[0].FinishReason)
+	require.Equal(t, "length", *out.Response.Choices[0].FinishReason)
+}
+
+func TestPlugin_CustomNameIsHonoured(t *testing.T) {
+	p := errormessage.New(errormessage.WithName("my_error_rewriter"))
+	require.Equal(t, "my_error_rewriter", p.Name())
+}
+
+func TestPlugin_EmptyNameFallsBackToDefault(t *testing.T) {
+	p := errormessage.New(errormessage.WithName(""))
+	require.Equal(t, "error_message_rewriter", p.Name())
+}
+
+func TestPlugin_EmptyFinishReasonFallsBackToDefault(t *testing.T) {
+	p := errormessage.New(
+		errormessage.WithContent("friendly"),
+		errormessage.WithFinishReason(""),
+	)
+	m := newPluginManager(t, p)
+
+	original := newErrorEvent("flow_error", "boom")
+	out, err := m.OnEvent(context.Background(), nil, original)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	require.NotNil(t, out.Response.Choices[0].FinishReason)
+	require.Equal(t, "error", *out.Response.Choices[0].FinishReason)
+}
+
+// TestPlugin_NilResponseIsSafe guards against upstream emitting malformed
+// events where Response is missing. The plugin must not panic and must not
+// materialise a fake choice.
+func TestPlugin_NilResponseIsSafe(t *testing.T) {
+	p := errormessage.New(errormessage.WithContent("friendly"))
+	m := newPluginManager(t, p)
+
+	original := &event.Event{InvocationID: "inv", Author: "agent"}
+	out, err := m.OnEvent(context.Background(), nil, original)
+	require.NoError(t, err)
+	require.Same(t, original, out)
+}
+
+// Using errors.New here keeps the option.go import block matching the rest of
+// the repository even when Resolver type evolves in the future.
+var _ errormessage.Resolver = func(
+	_ context.Context,
+	_ *agent.Invocation,
+	_ *event.Event,
+) (string, bool) {
+	return errors.New("unused").Error(), false
+}

--- a/plugin/errormessage/errormessage_test.go
+++ b/plugin/errormessage/errormessage_test.go
@@ -289,6 +289,77 @@ func TestPlugin_NilResponseIsSafe(t *testing.T) {
 	require.Same(t, original, out)
 }
 
+// TestPlugin_SkipsPartialErrorEvents ensures that partial error events are
+// forwarded unchanged. A later final event is free to override the outcome,
+// so the plugin must not surface a failure message for transient partial
+// frames.
+func TestPlugin_SkipsPartialErrorEvents(t *testing.T) {
+	p := errormessage.New(errormessage.WithContent("should not apply"))
+	m := newPluginManager(t, p)
+
+	rsp := &model.Response{
+		Object:    model.ObjectTypeError,
+		IsPartial: true,
+		Error: &model.ResponseError{
+			Type:    "flow_error",
+			Message: "transient failure",
+		},
+	}
+	original := event.NewResponseEvent("inv", "agent", rsp)
+
+	out, err := m.OnEvent(context.Background(), nil, original)
+	require.NoError(t, err)
+	require.Same(t, original, out)
+	require.Empty(t, original.Response.Choices)
+}
+
+// TestPlugin_NormalisesNonAssistantFirstChoiceRole ensures the plugin always
+// writes its resolved content into an assistant-role choice, even if upstream
+// emitted an error event whose first choice was authored as user/system.
+func TestPlugin_NormalisesNonAssistantFirstChoiceRole(t *testing.T) {
+	p := errormessage.New(errormessage.WithContent("friendly"))
+	m := newPluginManager(t, p)
+
+	rsp := &model.Response{
+		Object: model.ObjectTypeError,
+		Done:   true,
+		Error: &model.ResponseError{
+			Type:    "flow_error",
+			Message: "boom",
+		},
+		Choices: []model.Choice{{
+			Index: 0,
+			Message: model.Message{
+				Role: model.RoleUser,
+			},
+		}},
+	}
+	original := event.NewResponseEvent("inv", "agent", rsp)
+	require.False(t, original.Response.IsValidContent())
+
+	out, err := m.OnEvent(context.Background(), nil, original)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	require.Len(t, out.Response.Choices, 1)
+	require.Equal(
+		t,
+		model.RoleAssistant,
+		out.Response.Choices[0].Message.Role,
+	)
+	require.Equal(
+		t,
+		"friendly",
+		out.Response.Choices[0].Message.Content,
+	)
+
+	// Original event must not be mutated by the plugin.
+	require.Equal(
+		t,
+		model.RoleUser,
+		original.Response.Choices[0].Message.Role,
+	)
+}
+
 // Using errors.New here keeps the option.go import block matching the rest of
 // the repository even when Resolver type evolves in the future.
 var _ errormessage.Resolver = func(

--- a/plugin/errormessage/errormessage_test.go
+++ b/plugin/errormessage/errormessage_test.go
@@ -369,3 +369,13 @@ var _ errormessage.Resolver = func(
 ) (string, bool) {
 	return errors.New("unused").Error(), false
 }
+
+// TestPlugin_RegisterNilRegistryIsNoop guards the defensive nil-registry
+// branch on the plugin.Register contract. It must not panic.
+func TestPlugin_RegisterNilRegistryIsNoop(t *testing.T) {
+	p := errormessage.New(errormessage.WithContent("friendly"))
+	// The plugin.Plugin contract allows implementations to be tolerant of
+	// a nil registry. We reach in via the exported interface so the call is
+	// identical to how plugin.NewManager would invoke it.
+	require.NotPanics(t, func() { p.Register(nil) })
+}

--- a/plugin/errormessage/option.go
+++ b/plugin/errormessage/option.go
@@ -65,7 +65,9 @@ func WithName(name string) Option {
 // WithContent sets a static message that replaces the framework's default
 // fallback content for all error events.
 //
-// Shorthand for WithResolver(func(...) (string, bool) { return content, true }).
+// It is shorthand for a Resolver that returns (content, content != ""), so
+// passing an empty string is a no-op and the event is left untouched, which
+// means Runner's built-in fallback message still applies.
 func WithContent(content string) Option {
 	return WithResolver(func(
 		_ context.Context,

--- a/plugin/errormessage/option.go
+++ b/plugin/errormessage/option.go
@@ -1,0 +1,98 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package errormessage
+
+import (
+	"context"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+)
+
+const (
+	defaultPluginName   = "error_message_rewriter"
+	defaultFinishReason = "error"
+)
+
+// Resolver returns the assistant-visible content to attach to an error event.
+//
+// Returning ok=false (or an empty string) leaves the event untouched, which
+// falls back to Runner's built-in generic fallback message.
+type Resolver func(
+	ctx context.Context,
+	inv *agent.Invocation,
+	e *event.Event,
+) (content string, ok bool)
+
+// Option configures the error message plugin.
+type Option func(*options)
+
+type options struct {
+	name         string
+	resolver     Resolver
+	finishReason string
+}
+
+func newOptions(opts ...Option) *options {
+	o := &options{
+		name:         defaultPluginName,
+		finishReason: defaultFinishReason,
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(o)
+		}
+	}
+	return o
+}
+
+// WithName sets the plugin name. The name must be unique within a Runner.
+func WithName(name string) Option {
+	return func(o *options) {
+		if name != "" {
+			o.name = name
+		}
+	}
+}
+
+// WithContent sets a static message that replaces the framework's default
+// fallback content for all error events.
+//
+// Shorthand for WithResolver(func(...) (string, bool) { return content, true }).
+func WithContent(content string) Option {
+	return WithResolver(func(
+		_ context.Context,
+		_ *agent.Invocation,
+		_ *event.Event,
+	) (string, bool) {
+		return content, content != ""
+	})
+}
+
+// WithResolver registers a Resolver that computes the assistant-visible
+// content for each error event. It is called only when the event is an error
+// event with no existing valid content, so returning a message is always a
+// safe, non-destructive operation.
+func WithResolver(resolver Resolver) Option {
+	return func(o *options) {
+		o.resolver = resolver
+	}
+}
+
+// WithFinishReason overrides the FinishReason attached to the synthesised
+// assistant choice. It is used only when the choice does not carry a
+// FinishReason yet. The default is "error".
+func WithFinishReason(reason string) Option {
+	return func(o *options) {
+		if reason != "" {
+			o.finishReason = reason
+		}
+	}
+}

--- a/plugin/errormessage/runner_integration_test.go
+++ b/plugin/errormessage/runner_integration_test.go
@@ -1,0 +1,203 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package errormessage_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/plugin/errormessage"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	sessioninmemory "trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+// stopAgent emits a single stop_agent_error event and closes, matching the
+// shape llmflow produces when StopError propagates out of a tool or callback.
+type stopAgent struct {
+	name string
+	msg  string
+}
+
+func (a *stopAgent) Info() agent.Info {
+	return agent.Info{Name: a.name}
+}
+
+func (a *stopAgent) Tools() []tool.Tool              { return nil }
+func (a *stopAgent) SubAgents() []agent.Agent        { return nil }
+func (a *stopAgent) FindSubAgent(string) agent.Agent { return nil }
+
+func (a *stopAgent) Run(
+	_ context.Context,
+	inv *agent.Invocation,
+) (<-chan *event.Event, error) {
+	ch := make(chan *event.Event, 1)
+	ch <- event.NewErrorEvent(
+		inv.InvocationID,
+		a.name,
+		agent.ErrorTypeStopAgentError,
+		a.msg,
+	)
+	close(ch)
+	return ch, nil
+}
+
+// TestPlugin_RunnerIntegration_RewritesPersistedErrorEventContent exercises
+// the full runner event pipeline. It verifies that, for events emitted on
+// the runner's normal event channel (the path llmflow uses for
+// stop_agent_error and for any agent that returns event.NewErrorEvent),
+// the plugin's resolver output ends up in the session, replacing the
+// built-in generic fallback message.
+func TestPlugin_RunnerIntegration_RewritesPersistedErrorEventContent(
+	t *testing.T,
+) {
+	const (
+		appName     = "error-message-test"
+		userID      = "user"
+		sessionID   = "session"
+		customReply = "custom stop message"
+		stopReason  = "max iterations reached"
+	)
+	svc := sessioninmemory.NewSessionService()
+
+	rewriter := errormessage.New(
+		errormessage.WithResolver(func(
+			_ context.Context,
+			_ *agent.Invocation,
+			e *event.Event,
+		) (string, bool) {
+			if e == nil || e.Response == nil || e.Response.Error == nil {
+				return "", false
+			}
+			if e.Response.Error.Type != agent.ErrorTypeStopAgentError {
+				return "", false
+			}
+			return customReply, true
+		}),
+	)
+
+	r := runner.NewRunner(
+		appName,
+		&stopAgent{name: "stop-agent", msg: stopReason},
+		runner.WithSessionService(svc),
+		runner.WithPlugins(rewriter),
+	)
+	defer r.Close()
+
+	ch, err := r.Run(
+		context.Background(),
+		userID,
+		sessionID,
+		model.NewUserMessage("trigger"),
+	)
+	require.NoError(t, err)
+	for range ch {
+	}
+
+	sess, err := svc.GetSession(context.Background(), session.Key{
+		AppName:   appName,
+		UserID:    userID,
+		SessionID: sessionID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+
+	var errorEvent *event.Event
+	for i := range sess.Events {
+		evt := sess.Events[i]
+		if evt.Response != nil && evt.Response.Error != nil {
+			errorEvent = &sess.Events[i]
+			break
+		}
+	}
+	require.NotNil(t, errorEvent, "expected an error event in session")
+
+	// Resolver output is persisted as the assistant-visible content.
+	require.Len(t, errorEvent.Response.Choices, 1)
+	require.Equal(
+		t,
+		model.RoleAssistant,
+		errorEvent.Response.Choices[0].Message.Role,
+	)
+	require.Equal(
+		t,
+		customReply,
+		errorEvent.Response.Choices[0].Message.Content,
+	)
+
+	// Structured Response.Error is left intact for debugging consumers.
+	require.Equal(
+		t,
+		agent.ErrorTypeStopAgentError,
+		errorEvent.Response.Error.Type,
+	)
+	require.Equal(t, stopReason, errorEvent.Response.Error.Message)
+}
+
+// TestPlugin_RunnerIntegration_WithoutPluginUsesDefaultFallback pins the
+// framework's built-in fallback so regressions in runner behaviour are
+// caught alongside plugin changes.
+func TestPlugin_RunnerIntegration_WithoutPluginUsesDefaultFallback(
+	t *testing.T,
+) {
+	const (
+		appName   = "error-message-test-default"
+		userID    = "user"
+		sessionID = "session"
+	)
+	svc := sessioninmemory.NewSessionService()
+
+	r := runner.NewRunner(
+		appName,
+		&stopAgent{name: "stop-agent", msg: "max iterations reached"},
+		runner.WithSessionService(svc),
+	)
+	defer r.Close()
+
+	ch, err := r.Run(
+		context.Background(),
+		userID,
+		sessionID,
+		model.NewUserMessage("trigger"),
+	)
+	require.NoError(t, err)
+	for range ch {
+	}
+
+	sess, err := svc.GetSession(context.Background(), session.Key{
+		AppName:   appName,
+		UserID:    userID,
+		SessionID: sessionID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+
+	var errorEvent *event.Event
+	for i := range sess.Events {
+		evt := sess.Events[i]
+		if evt.Response != nil && evt.Response.Error != nil {
+			errorEvent = &sess.Events[i]
+			break
+		}
+	}
+	require.NotNil(t, errorEvent)
+	require.Len(t, errorEvent.Response.Choices, 1)
+	require.Equal(
+		t,
+		"An error occurred during execution. Please contact the service provider.",
+		errorEvent.Response.Choices[0].Message.Content,
+	)
+}


### PR DESCRIPTION
## Motivation

When an event carries `Response.Error` but no `Choices[].Message.Content`,
Runner falls back to a hard-coded English message:

> An error occurred during execution. Please contact the service provider.

This is what ends up persisted into the session for events like
`stop_agent_error` (produced by `llmflow` for `agent.StopError`) or any raw
`event.NewErrorEvent(...)`. Users have asked for a way to customise this
text — for localisation, tenant-specific phrasing, or friendlier copy — without
losing the structured `Response.Error` or touching the Runner core.

## What this PR does

Adds `plugin/errormessage`, a Runner-scoped plugin that hooks into `OnEvent`
and rewrites the assistant-visible content of error events **before** Runner
persists them.

- `errormessage.WithContent("...")` for a static message.
- `errormessage.WithResolver(func(ctx, inv, e) (string, bool))` for dynamic
  content (for example, different copy for `stop_agent_error` vs other
  error types, or locale/tenant-aware phrasing).
- `errormessage.WithFinishReason("...")` to override the synthesised
  `FinishReason` (default: `error`).
- The plugin only rewrites events that do not already carry valid content, so
  a partial assistant message produced before the failure is never overwritten.
- `Response.Error` is left untouched so debugging and downstream consumers
  keep the original reason.

No changes are made to the Runner core. The feature is delivered entirely via
the existing `runner.WithPlugins` + `plugin.OnEvent` extension point.

## Example

`examples/plugin/errormessage` is fully self-contained (no API key required).
It emits a single `stop_agent_error` event and runs two Runners — one without
the plugin and one with it — so the persisted session events can be compared
side by side:

```
[1] Runner without errormessage plugin (default fallback).
  Persisted error event:
    Response.Error.Type : stop_agent_error
    Response.Error.Msg  : max iterations reached
    Visible Content     : An error occurred during execution. Please contact the service provider.
------------------------------------------------------------------------
[2] Runner with errormessage plugin (customised content).
  Persisted error event:
    Response.Error.Type : stop_agent_error
    Response.Error.Msg  : max iterations reached
    Visible Content     : 本次执行已按策略停止，请稍后再试。
```

## Docs

- `docs/mkdocs/en/plugin.md` and `docs/mkdocs/zh/plugin.md` gain an
  `ErrorMessage` section (static content and dynamic resolver examples), and
  the built-in plugin list is updated accordingly.

## Tests

`plugin/errormessage/errormessage_test.go` adds 13 tests covering:

- rewriting empty-content error events
- leaving events with existing valid content untouched
- skipping non-error events
- passing the invocation and event to the resolver
- resolver returning `ok=false` / empty string leaves the event unchanged
- default no-op when no resolver is configured
- custom / empty / default `FinishReason` behaviour
- existing `FinishReason` is preserved
- custom and empty plugin names
- nil `Response` does not panic

## Validation

- `go build ./...`
- `go test ./plugin/errormessage/... -count=1` (13/13 passed)
- `gofmt -l` and `gofmt -r 'interface{} -> any' -l` on new files
- `goimports -l` on new files
- `golangci-lint run --timeout=10m ./plugin/errormessage/...`
- `cd examples && go build ./plugin/errormessage/...`
- `cd examples/plugin/errormessage && go run .` reproduces the output above
