### PR TITLE
{tool/todo, examples/todo}: add todo_write tool for multi-step plan tracking

### DIFF
--- a/docs/mkdocs/en/tool.md
+++ b/docs/mkdocs/en/tool.md
@@ -605,6 +605,100 @@ The main `tool/claudecode` options focus on working directory, read-only mode, a
 
 `WithBaseDir` defines the working scope for `Read`, `Write`, `Edit`, `Glob`, and `Grep`, and also determines the default working directory for `Bash`. When read-only mode is enabled, the toolset keeps only read, search, command, and web capabilities. When read-only mode is disabled, it also exposes `Write`, `Edit`, and `NotebookEdit`.
 
+### Todo Tool
+
+The Todo tool gives an Agent a structured, persistent checklist for multi-step work. The model calls `todo_write` to publish or update its current plan; the list is persisted on the session, surfaced to the frontend in the tool result, and (by default) followed by a short nudge that reminds the model to keep marking items as it goes.
+
+Reach for it when:
+
+- the task spans several non-trivial steps and the model tends to drop one;
+- the user (or a downstream UI) needs visible progress while the agent works;
+- the same conversation may pause for input and later pick the plan back up.
+
+#### Basic Usage
+
+```go
+import (
+    "trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+    "trpc.group/trpc-go/trpc-agent-go/tool"
+    "trpc.group/trpc-go/trpc-agent-go/tool/todo"
+)
+
+todoTool := todo.New()
+
+agent := llmagent.New("todo-assistant",
+    llmagent.WithModel(model),
+    llmagent.WithInstruction(todo.DefaultToolPrompt),
+    llmagent.WithTools([]tool.Tool{todoTool}),
+)
+```
+
+`todo.DefaultToolPrompt` is a ready-made system-instruction snippet that teaches the model when to call `todo_write` and how to phrase items. You can replace it with your own copy; the runtime checks below stay the same.
+
+#### Tool Result
+
+`todo_write` returns a structured result instead of free-form text, so any caller — terminal, AG-UI, a custom HTTP frontend — can render the same data without parsing prose:
+
+```go
+type Output struct {
+    Message  string `json:"message"`             // default nudge + hook output
+    Todos    []Item `json:"todos"`               // current list after this write
+    OldTodos []Item `json:"oldTodos,omitempty"`  // list before this write
+}
+```
+
+`Todos` and `OldTodos` ride directly on the tool-result event, so an AG-UI client (or any frontend that consumes `tool_call_result`) can decode them and render both the new state and the diff without going back to the session store. The terminal demo in `examples/todo/` inlines a small ASCII formatter; rich frontends are free to render the same structured data in whatever style fits.
+
+#### Cross-turn Persistence and Branch Isolation
+
+Each write is published as a session state delta, so the list survives across `Runner.Run` calls and across processes when the session service is durable.
+
+The list is keyed by `Invocation.Branch`, which defaults to the agent's name when no explicit branch has been set (so a sub-agent or agent-tool reads and writes its own list and never overwrites the parent's plan). For the basic wiring above (`llmagent.New("todo-assistant", ...)`) the canonical read is therefore:
+
+```go
+items, err := todo.GetTodos(sess, "todo-assistant") // the agent name
+// items == nil + err == nil → no list yet
+// len(items) == 0           → list explicitly cleared
+```
+
+If you have configured a custom branch (for example via `WithInvocationBranch`, or by running this Agent as a sub-agent of a parent), pass that branch value instead. An empty `branch` only reads the top-level slot when `Invocation.Branch` was explicitly set to `""`.
+
+#### Input Validation
+
+Every call is validated against the rules below; if any rule fails the call is rejected and the session state is not modified:
+
+- The `todos` field is **required** and must be an array. A missing field or a literal `null` is rejected — it is _not_ silently treated as "clear all". To clear the list, send `{"todos": []}`.
+- Every item must carry a non-empty `content`, a non-empty `activeForm`, and a valid `status` (`pending` / `in_progress` / `completed`).
+- **At most one** item may be `in_progress` at a time.
+- `content` strings must be unique across the list (exact match — no trim / case-fold / unicode normalisation).
+
+Stylistic guidance — for example "keep exactly one item `in_progress` while actively working", item phrasing, or when `todo_write` is worth a call — lives in `todo.DefaultToolPrompt` rather than in these checks, so you can adjust the prompt for your domain or model family without changing the tool.
+
+#### Customization
+
+```go
+todoTool := todo.New(
+    // Persist the list under a different state-key namespace. The
+    // default already isolates by branch, so most users do not need
+    // this.
+    todo.WithStateKeyPrefix("temp:plan"),
+    // By default the list is cleared once every item is completed,
+    // so the next planning cycle starts from scratch. Set false to
+    // keep the completed items visible.
+    todo.WithClearOnAllDone(false),
+    // Replace the default "after each write" nudge string.
+    todo.WithNudgeMessage("Keep going; mark items as you finish them."),
+    // Append extra guidance derived from the diff between the
+    // previous list and the one just submitted (custom prompts,
+    // telemetry, metrics, ...). Hooks are expected to be read-only.
+    todo.WithNudgeHook(func(ctx context.Context, oldTodos, submitted []todo.Item) string {
+        return ""
+    }),
+)
+```
+
+A complete runnable demo, including the multi-turn pause/resume scenario and an ASCII renderer, lives in [`examples/todo/`](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/todo).
+
 ## MCP Tools
 
 MCP (Model Context Protocol) is an open protocol that standardizes how applications provide context to LLMs. MCP tools are based on JSON-RPC 2.0 and provide standardized integration with external services for Agents.

--- a/docs/mkdocs/zh/tool.md
+++ b/docs/mkdocs/zh/tool.md
@@ -598,6 +598,97 @@ agent := llmagent.New(
 
 `WithBaseDir` 定义了 `Read`、`Write`、`Edit`、`Glob`、`Grep` 等文件相关工具的工作范围，也决定了 `Bash` 的默认执行目录。启用只读模式后，工具集只保留读取、检索、命令执行和 Web 相关能力；关闭只读模式后，会额外暴露 `Write`、`Edit` 与 `NotebookEdit`。
 
+### Todo 工具
+
+Todo 工具为 Agent 提供一份结构化、可跨轮持久化的任务清单。模型通过 `todo_write` 发布或更新当前计划；清单会被持久化到 session、随 tool result 事件返回给前端，并在每次写入后默认追加一段简短提示，督促模型边推进边更新状态。
+
+适合下面这些场景：
+
+- 任务跨多个非平凡步骤，模型容易漏掉某一步；
+- 用户或下游 UI 需要在 Agent 工作过程中看到可见的进度；
+- 同一会话可能中途暂停（例如向用户追问信息），后续再续上原计划继续推进。
+
+#### 基础用法
+
+```go
+import (
+    "trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+    "trpc.group/trpc-go/trpc-agent-go/tool"
+    "trpc.group/trpc-go/trpc-agent-go/tool/todo"
+)
+
+todoTool := todo.New()
+
+agent := llmagent.New("todo-assistant",
+    llmagent.WithModel(model),
+    llmagent.WithInstruction(todo.DefaultToolPrompt),
+    llmagent.WithTools([]tool.Tool{todoTool}),
+)
+```
+
+`todo.DefaultToolPrompt` 是开箱即用的 system instruction 片段，告诉模型何时调用 `todo_write` 以及如何撰写条目；你也可以替换成自己的版本，下文的运行时校验规则不受影响。
+
+#### 工具返回结构
+
+`todo_write` 返回的是结构化结果而不是自由文本，因此终端、AG-UI、自研 HTTP 前端等任何调用方都可以直接消费：
+
+```go
+type Output struct {
+    Message  string `json:"message"`             // 默认 nudge + hook 输出
+    Todos    []Item `json:"todos"`               // 本次写入后的当前清单
+    OldTodos []Item `json:"oldTodos,omitempty"`  // 本次写入前的清单
+}
+```
+
+`Todos` 和 `OldTodos` 会直接挂在 tool result 事件上，AG-UI 客户端（或任何消费 `tool_call_result` 的前端）解码后即可渲染最新状态和 diff，不需要回查 session。`examples/todo/` 中的终端示例内联了一个小型 ASCII 格式化函数；富前端可以按自己的风格渲染同一份结构化数据。
+
+#### 跨轮持久化与 Branch 隔离
+
+每次写入都会作为 session state delta 发布，因此清单可以跨 `Runner.Run` 调用持久化；当后端 session service 是持久化实现时，跨进程同样有效。
+
+清单按 `Invocation.Branch` 分键存储；当调用方没有显式设置 branch 时，框架会自动把它补成该 Agent 的名称（因此子 Agent 或 agent-tool 会读写自己的清单，不会覆盖父 Agent 的计划）。对应上面的基础接入（`llmagent.New("todo-assistant", ...)`），服务端读取应当写成：
+
+```go
+items, err := todo.GetTodos(sess, "todo-assistant") // 即 agent 名称
+// items == nil + err == nil → 还没有清单
+// len(items) == 0           → 清单已被显式清空
+```
+
+如果你配置了自定义 branch（例如通过 `WithInvocationBranch`，或把当前 Agent 作为子 Agent 运行在父 Agent 下），就传入对应的 branch 值。只有当 `Invocation.Branch` 被显式置为 `""` 时，传空字符串才会命中顶层槽位。
+
+#### 输入校验
+
+每次调用都会经过下面这组检查；任意一条不满足都会让本次调用直接失败，session 状态不会被修改：
+
+- `todos` 字段**必填**且必须是数组。缺失字段或字面量 `null` 会被直接拒绝，**不会**被当作"清空全部"。要清空清单请显式发送 `{"todos": []}`。
+- 每个条目必须包含非空的 `content`、非空的 `activeForm`，以及合法的 `status`（`pending` / `in_progress` / `completed`）。
+- 同一时刻**最多一个**条目处于 `in_progress`。
+- `content` 在清单内必须唯一（精确字符串匹配，不做 trim / 大小写归一 / Unicode 归一）。
+
+风格性建议——例如"实际工作期间始终恰好一个 `in_progress`"、条目措辞、何时值得调用 `todo_write` 等——放在 `todo.DefaultToolPrompt` 里，不在上述检查中强制；因此你可以根据自身业务或所用模型族调整 prompt，不需要改工具。
+
+#### 自定义
+
+```go
+todoTool := todo.New(
+    // 把清单存到自定义 state-key 命名空间下；默认布局已经按 branch
+    // 隔离，大多数场景不需要改这个。
+    todo.WithStateKeyPrefix("temp:plan"),
+    // 默认情况下，所有条目变成 completed 后清单会被清空，让下一轮
+    // 规划从零开始。设为 false 可以保留已完成条目。
+    todo.WithClearOnAllDone(false),
+    // 替换每次写入后默认追加的 nudge 文案。
+    todo.WithNudgeMessage("继续推进；完成一项就更新一项。"),
+    // 根据本次提交的清单和上一份清单的 diff 追加额外提示
+    // (例如自定义 prompt、埋点、指标计算)。Hook 期望是只读的。
+    todo.WithNudgeHook(func(ctx context.Context, oldTodos, submitted []todo.Item) string {
+        return ""
+    }),
+)
+```
+
+完整可运行示例（包含多轮暂停/续接场景与 ASCII 渲染器）见 [`examples/todo/`](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/todo)。
+
 ## MCP Tools 协议工具
 
 MCP（Model Context Protocol）是一个开放协议，标准化了应用程序向 LLM 提供上下文的方式。MCP 工具基于 JSON-RPC 2.0 协议，为 Agent 提供了与外部服务的标准化集成能力。

--- a/examples/todo/README.md
+++ b/examples/todo/README.md
@@ -227,9 +227,14 @@ All of these boil down to "the list must still be there next time
   the same thing:
   - **Hard tool contract (enforced in code, tool call fails on
     violation):**
-    - The `todos` field is required (JSON-schema level). Items are
-      validated only when present, and an empty list is accepted —
-      see the note right after this block on why.
+    - The `todos` field is required and must be an array. A missing
+      field or an explicit `null` is rejected at the runtime edge —
+      not silently treated as "clear all". The legitimate clear
+      gesture is an explicit empty array, `{"todos": []}`. This
+      asymmetry is on purpose: a destructive operation should require
+      an explicit token, so that an upstream provider, retry
+      middleware, or hand-rolled caller that accidentally drops the
+      field cannot wipe a session's plan in one shot.
     - Every item must carry a non-empty `content`, a non-empty
       `activeForm`, and a valid `status`
       (`pending` / `in_progress` / `completed`).
@@ -239,11 +244,13 @@ All of these boil down to "the list must still be there next time
       to avoid silently merging items the model meant to keep
       distinct).
 
-  Why an empty list is allowed: the tool is also the legitimate way
-  to _clear_ a checklist (e.g. after all items completed under
-  `WithClearOnAllDone(false)`, or when a plan is abandoned and
-  replaced). Rejecting `[]` would force callers to invent a separate
-  clear path just to satisfy the validator.
+  Why explicit `[]` is the only clear path: the tool _is_ the
+  legitimate way to clear a checklist (e.g. after all items
+  completed under `WithClearOnAllDone(false)`, or when a plan is
+  abandoned and replaced), but only when the caller explicitly says
+  so. Forcing the empty-array spelling preserves the symmetry the
+  schema declares (`required: ["todos"]`, type: array) and matches
+  how the same shape is enforced for any structured tool input.
   - **Prompt-only guidance (the model is encouraged to follow, but
     the tool will not reject it):** keeping exactly one item
     `in_progress` while actively working, not leaving stale

--- a/examples/todo/README.md
+++ b/examples/todo/README.md
@@ -85,7 +85,7 @@ Interactive commands inside the chat:
 
 ## Example output
 
-```
+```text
 You (seed): Plan 3 small steps with todo_write: 1) greet, 2) define dark mode in 1 sentence, 3) suggest 2 CSS variables. Then execute them one by one, updating the list each time.
 Assistant:   [tool-call] todo_write {"todos":[
   {"content":"Greet the user","activeForm":"Greeting the user","status":"in_progress"},
@@ -124,7 +124,7 @@ Seed prompt (shortened):
 
 ### Turn 1 — partial progress, then pause
 
-```
+```text
 You (seed): I'm writing a 3-section blog post ... ASK ME ... then STOP.
 Assistant:
   [tool-call] todo_write { ... Intro in_progress, Main Body pending, Conclusion pending ... }
@@ -157,7 +157,7 @@ Main Body item truly in `in_progress`.
 
 ### Turn 2 — user answers, agent resumes from the same list
 
-```
+```text
 You: Autumn vibes, 2 candles, warm yellow lighting
 Assistant:
   [tool-call] todo_write { ... Main Body completed, Conclusion in_progress ... }

--- a/examples/todo/README.md
+++ b/examples/todo/README.md
@@ -1,0 +1,274 @@
+# Todo Tool Demo
+
+A minimal multi-turn chat that exercises the `tool/todo` package end to end.
+
+The agent is given a single tool — `todo_write` — and a system instruction
+that explains when and how to use it. After every assistant turn the
+example reads the checklist out of the session store and prints it in
+the terminal, so you can watch the plan evolve turn by turn.
+
+## What this demo shows
+
+- Registering `todo.New()` as a plain LLM tool.
+- Persisting the checklist through the tool's `StateDeltaForInvocation`
+  hook, so it survives across `Runner.Run` invocations.
+- Two ways of consuming the list:
+  - in-stream, decoding `todo.Output` from each tool-result event
+    (what a cloud/AG-UI frontend will do);
+  - end-of-turn, reading the canonical state with `todo.GetTodos` and
+    rendering it via this demo's local `formatTodos` helper (what a
+    REST endpoint or audit job would do).
+- Attaching a custom `NudgeHook` — in this example, a reminder to
+  summarise the outcome once every task is completed.
+
+## Prerequisites
+
+- Go 1.21 or later
+- Valid OpenAI API key (or a compatible endpoint)
+
+## Environment Variables
+
+| Variable          | Description                                    | Default Value               |
+| ----------------- | ---------------------------------------------- | --------------------------- |
+| `OPENAI_API_KEY`  | API key for the model service                  | ``                          |
+| `OPENAI_BASE_URL` | Base URL for the model API endpoint            | `https://api.openai.com/v1` |
+
+## Command Line Arguments
+
+| Argument     | Description                                           | Default Value   |
+| ------------ | ----------------------------------------------------- | --------------- |
+| `-model`     | Name of the model to use (any OpenAI-compatible id)   | `deepseek-chat` |
+| `-variant`   | Variant passed to the OpenAI provider                 | `openai`        |
+| `-streaming` | Enable streaming mode for responses                   | `true`          |
+| `-seed`      | Optional first user message; auto-starts the chat     | ``              |
+
+## Usage
+
+### Basic Chat
+
+```bash
+cd examples/todo
+export OPENAI_API_KEY="your-api-key-here"
+go run .
+```
+
+### Custom Model
+
+```bash
+export OPENAI_API_KEY="your-api-key"
+go run . -model gpt-4o
+```
+
+### Auto-start with a Seed Prompt
+
+```bash
+go run . -streaming=false \
+  -seed "Plan 3 small steps with todo_write: 1) greet, 2) define dark mode in one sentence, 3) suggest 2 CSS variables. Execute one by one, updating the checklist each time."
+```
+
+### Response Modes
+
+Choose between streaming and non-streaming responses:
+
+```bash
+# Default streaming mode (real-time character output)
+go run .
+
+# Non-streaming mode (complete response at once)
+go run . -streaming=false
+```
+
+Interactive commands inside the chat:
+
+- `/list` – print the current checklist on demand.
+- `/exit` – leave the chat.
+
+## Example output
+
+```
+You (seed): Plan 3 small steps with todo_write: 1) greet, 2) define dark mode in 1 sentence, 3) suggest 2 CSS variables. Then execute them one by one, updating the list each time.
+Assistant:   [tool-call] todo_write {"todos":[
+  {"content":"Greet the user","activeForm":"Greeting the user","status":"in_progress"},
+  {"content":"Define dark mode in 1 sentence","activeForm":"...","status":"pending"},
+  {"content":"Suggest 2 CSS variables","activeForm":"...","status":"pending"}
+]}
+  [tool-result] {"message":"Todos have been modified successfully. ..."}
+  ... (three more tool-calls as the model flips each step to completed) ...
+  [tool-result] {"message":"Todos have been modified successfully. ...
+
+Reminder: all tasks are marked completed. Before finishing, briefly summarise the outcome for the user."}
+
+A: All steps completed! I've greeted you, defined dark mode as a color scheme using light elements on dark backgrounds, and suggested two CSS variables: `--background-color` and `--text-color`.
+
+----- Current checklist -----
+- [x] Greet the user
+- [x] Define dark mode in 1 sentence
+- [x] Suggest 2 CSS variables
+-----------------------------
+```
+
+## Multi-turn: pause, ask, resume
+
+Real agents often need to stop mid-plan to ask the user something — a
+permission, a preference, a missing fact — and then pick up exactly
+where they left off. The todo tool is designed for this: the checklist
+survives across `Runner.Run` invocations, and the tool reports the
+pre-write list as `oldTodos` so downstream consumers can render a
+precise diff.
+
+Seed prompt (shortened):
+
+> Plan a 3-section blog post (Intro, Main Body, Conclusion). Mark Intro
+> in_progress, write it, flip to completed and Main Body to in_progress.
+> **Before writing the Main Body, ASK me for the mood I want and STOP.**
+
+### Turn 1 — partial progress, then pause
+
+```
+You (seed): I'm writing a 3-section blog post ... ASK ME ... then STOP.
+Assistant:
+  [tool-call] todo_write { ... Intro in_progress, Main Body pending, Conclusion pending ... }
+  [tool-result decoded] 3 todos (was 0)
+    - [in_progress] Write Intro paragraph
+    - [pending]     Write Main Body section
+    - [pending]     Write Conclusion paragraph
+
+  ... (Intro paragraph streamed as plain text) ...
+
+  [tool-call] todo_write { ... Intro completed, Main Body in_progress ... }
+  [tool-result decoded] 3 todos (was 3)
+    - [completed]   Write Intro paragraph
+    - [in_progress] Write Main Body section
+    - [pending]     Write Conclusion paragraph
+
+A: Before I write the Main Body section, what mood/aesthetic would you
+   like for it?
+
+----- Current checklist -----
+- [x] Write Intro paragraph
+- [>] Write Main Body section
+- [ ] Write Conclusion paragraph
+-----------------------------
+```
+
+The end-of-turn block is printed by `printTodos()` reading session
+state via `todo.GetTodos(sess, agentName)`. Turn 1 ends with the
+Main Body item truly in `in_progress`.
+
+### Turn 2 — user answers, agent resumes from the same list
+
+```
+You: Autumn vibes, 2 candles, warm yellow lighting
+Assistant:
+  [tool-call] todo_write { ... Main Body completed, Conclusion in_progress ... }
+  [tool-result raw] {
+    "message":"Todos have been modified successfully. ...",
+    "todos":    [ ... Intro done, Main Body done, Conclusion in_progress ... ],
+    "oldTodos": [
+      {"content":"Write Intro paragraph",      "status":"completed"},
+      {"content":"Write Main Body section",    "status":"in_progress"},
+      {"content":"Write Conclusion paragraph", "status":"pending"}
+    ]
+  }
+  [tool-result decoded] 3 todos (was 3)
+    - [completed]   Write Intro paragraph
+    - [completed]   Write Main Body section
+    - [in_progress] Write Conclusion paragraph
+
+  ... (Main Body paragraph streamed; then todo_write flipping Conclusion to completed) ...
+
+A: All three sections of your blog post are complete! ...
+
+----- Current checklist -----
+- [x] Write Intro paragraph
+- [x] Write Main Body section
+- [x] Write Conclusion paragraph
+-----------------------------
+```
+
+The `oldTodos` field on the very first tool-result of Turn 2 is **byte-
+identical to the final state of Turn 1**. That proves two independent
+pieces of the plumbing:
+
+1. `StateDeltaForInvocation` flushed Turn 1's list into the canonical
+   session store at the end of the previous run.
+2. On Turn 2, the tool's `Call()` re-read that persisted state (via
+   `readTodos(sess, key)`) to compute the diff — the agent did not
+   re-plan from scratch, nor did it invent a new list.
+
+Real-world analogues where this matters:
+
+- The agent needs a credential / permission and pauses for approval.
+- Two valid implementation paths exist; the agent asks the user to
+  choose.
+- A destructive operation is about to run; the agent stops for
+  confirmation.
+- The user explicitly batches work: "do the first three steps now,
+  I'll come back for the rest later."
+- The user closes the browser and resumes tomorrow on the same
+  session ID.
+
+All of these boil down to "the list must still be there next time
+`Runner.Run` is called" — which is exactly what this demo verifies.
+
+## Notes
+
+- **Branch scoping.** The tool writes to the key
+  `temp:todos[:<branch>]`. When the branch field of the invocation is
+  empty it defaults to the agent's name, so this demo reads back with
+  `todo.GetTodos(sess, agentName)`.
+- **Clear-on-all-done.** By default the tool wipes the list once every
+  item is completed (so a new planning cycle starts from scratch). The
+  demo passes `todo.WithClearOnAllDone(false)` to keep the completed
+  items visible in the final render.
+- **Tool contract vs. prompt guidance — know the boundary.** The
+  default prompt (`todo.DefaultToolPrompt`) and the runtime validator
+  (`validateTodos`) talk about overlapping concerns, but they are not
+  the same thing:
+  - **Hard tool contract (enforced in code, tool call fails on
+    violation):**
+    - The `todos` field is required (JSON-schema level). Items are
+      validated only when present, and an empty list is accepted —
+      see the note right after this block on why.
+    - Every item must carry a non-empty `content`, a non-empty
+      `activeForm`, and a valid `status`
+      (`pending` / `in_progress` / `completed`).
+    - **At most one** item may be `in_progress` at a time.
+    - `content` strings must be unique across the list (exact string
+      match — no trim / case-fold / unicode-normalisation on purpose,
+      to avoid silently merging items the model meant to keep
+      distinct).
+
+  Why an empty list is allowed: the tool is also the legitimate way
+  to _clear_ a checklist (e.g. after all items completed under
+  `WithClearOnAllDone(false)`, or when a plan is abandoned and
+  replaced). Rejecting `[]` would force callers to invent a separate
+  clear path just to satisfy the validator.
+  - **Prompt-only guidance (the model is encouraged to follow, but
+    the tool will not reject it):** keeping exactly one item
+    `in_progress` while actively working, not leaving stale
+    `in_progress` items across turns, avoiding multi-step work that
+    never produces a checklist, tone/phrasing of `activeForm`, and
+    the few-shot examples about when `todo_write` is worth the call.
+
+  The split is intentional: the contract stays small so it never
+  fights a well-behaved agent, while the prompt can evolve with
+  taste and model-family idiosyncrasies without touching the tool
+  schema. If you ever find yourself wanting to enforce more in code
+  (e.g. "exactly one in_progress when the list is non-empty"), do
+  it by adding a validator, not by rewriting the prompt: keep the
+  two layers distinguishable.
+
+## Where to look next
+
+- `tool/todo/todo.go` – the `Tool` implementation, default nudge, and
+  the `StateDeltaForInvocation` hook that persists the list.
+- `tool/todo/options.go` – `WithNudgeHook`, `WithStateKeyPrefix`,
+  `WithClearOnAllDone`, etc.
+- `tool/todo/helpers.go` – `GetTodos` / `GetTodosWithPrefix` for
+  server-side reads of the current list. The package ships no
+  pretty-printer on purpose: terminal demos like this one inline a
+  small ASCII formatter (`formatTodos` in `main.go`), rich frontends
+  render `Output.Todos` in their own native style.
+- `tool/todo/prompt.go` – `DefaultToolPrompt` injected into the system
+  instruction of this demo.

--- a/examples/todo/main.go
+++ b/examples/todo/main.go
@@ -1,0 +1,329 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+// Package main demonstrates the todo_write tool.
+//
+// After each assistant turn the current checklist is read from the
+// session state and pretty-printed to the terminal so you can see how
+// the agent plans, updates status, and eventually finishes a multi-step
+// task.
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/model/openai"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	sessioninmemory "trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+	"trpc.group/trpc-go/trpc-agent-go/tool/todo"
+)
+
+var (
+	modelName = flag.String("model", "deepseek-chat", "Name of the model to use (any OpenAI-compatible identifier)")
+	streaming = flag.Bool("streaming", true, "Enable streaming mode for responses")
+	variant   = flag.String("variant", "openai", "Variant passed to the OpenAI provider")
+	seed      = flag.String("seed", "", "Optional first user message; if set, the chat auto-starts with it")
+)
+
+const (
+	appName   = "todo-demo"
+	agentName = "todo-assistant"
+)
+
+func main() {
+	flag.Parse()
+
+	fmt.Println("Todo tool demo: plan + track multi-step work")
+	fmt.Printf("Model:     %s (variant=%s)\n", *modelName, *variant)
+	fmt.Printf("Streaming: %t\n", *streaming)
+	fmt.Println("Commands:  /exit to quit, /list to print the current checklist")
+	fmt.Println(strings.Repeat("=", 60))
+
+	c := &chat{modelName: *modelName, streaming: *streaming, variant: *variant}
+	if err := c.run(); err != nil {
+		log.Fatalf("chat failed: %v", err)
+	}
+}
+
+// chat wraps the runner, session service and conversation loop.
+type chat struct {
+	modelName string
+	streaming bool
+	variant   string
+
+	runner    runner.Runner
+	sessSvc   session.Service
+	userID    string
+	sessionID string
+}
+
+func (c *chat) run() error {
+	ctx := context.Background()
+	if err := c.setup(); err != nil {
+		return fmt.Errorf("setup: %w", err)
+	}
+	defer c.runner.Close()
+
+	if *seed != "" {
+		fmt.Printf("You (seed): %s\n", *seed)
+		if err := c.processMessage(ctx, *seed); err != nil {
+			fmt.Printf("Error: %v\n", err)
+		}
+		fmt.Println()
+		c.printTodos()
+	}
+	return c.startChat(ctx)
+}
+
+func (c *chat) setup() error {
+	modelInstance := openai.New(c.modelName, openai.WithVariant(openai.Variant(c.variant)))
+	c.sessSvc = sessioninmemory.NewSessionService()
+
+	// Build the todo tool. The verification nudge hook demonstrates how
+	// to attach an extra policy reminder without touching the tool core:
+	// when the model closes out 3+ tasks all-at-once we remind it to do
+	// a verification pass before declaring success.
+	todoTool := todo.New(
+		// Keep the final "all completed" state visible in the demo.
+		// The default behavior (true) clears the list to signal a
+		// fresh planning session next time.
+		todo.WithClearOnAllDone(false),
+		todo.WithNudgeHook(func(_ context.Context, _, newList []todo.Item) string {
+			if len(newList) < 3 {
+				return ""
+			}
+			allDone := true
+			for _, it := range newList {
+				if it.Status != todo.StatusCompleted {
+					allDone = false
+					break
+				}
+			}
+			if !allDone {
+				return ""
+			}
+			return "Reminder: all tasks are marked completed. " +
+				"Before finishing, briefly summarise the outcome for the user."
+		}),
+	)
+
+	instruction := "You are a careful assistant. When a user asks you to do " +
+		"anything with more than 2 steps, call the todo_write tool to plan " +
+		"first, then work the items one by one, flipping status as you go.\n\n" +
+		todo.DefaultToolPrompt
+
+	llmAgent := llmagent.New(
+		agentName,
+		llmagent.WithModel(modelInstance),
+		llmagent.WithDescription("Demo agent that uses todo_write to plan and track work."),
+		llmagent.WithInstruction(instruction),
+		llmagent.WithGenerationConfig(model.GenerationConfig{
+			MaxTokens: intPtr(8000),
+			Stream:    c.streaming,
+		}),
+		llmagent.WithTools([]tool.Tool{todoTool}),
+	)
+
+	c.runner = runner.NewRunner(appName, llmAgent, runner.WithSessionService(c.sessSvc))
+	c.userID = "demo-user"
+	c.sessionID = fmt.Sprintf("demo-session-%d", time.Now().Unix())
+
+	fmt.Printf("Ready. Session: %s\n\n", c.sessionID)
+	return nil
+}
+
+func (c *chat) startChat(ctx context.Context) error {
+	scanner := bufio.NewScanner(os.Stdin)
+	for {
+		fmt.Print("You: ")
+		if !scanner.Scan() {
+			break
+		}
+		line := strings.TrimSpace(scanner.Text())
+		switch line {
+		case "":
+			continue
+		case "/exit":
+			fmt.Println("bye")
+			return nil
+		case "/list":
+			c.printTodos()
+			continue
+		}
+		if err := c.processMessage(ctx, line); err != nil {
+			fmt.Printf("Error: %v\n", err)
+		}
+		fmt.Println()
+		c.printTodos()
+	}
+	return scanner.Err()
+}
+
+func (c *chat) processMessage(ctx context.Context, msg string) error {
+	reqID := uuid.New().String()
+	eventChan, err := c.runner.Run(
+		ctx, c.userID, c.sessionID, model.NewUserMessage(msg),
+		agent.WithRequestID(reqID),
+	)
+	if err != nil {
+		return err
+	}
+	return c.processResponse(eventChan)
+}
+
+// processResponse renders the stream: tool calls, tool responses and
+// assistant text are each formatted distinctly so the checklist updates
+// are easy to spot.
+func (c *chat) processResponse(eventChan <-chan *event.Event) error {
+	fmt.Print("Assistant: ")
+	var assistantStarted bool
+	var toolCallsPrinted bool
+
+	for evt := range eventChan {
+		if evt.Error != nil {
+			fmt.Printf("\n[error] %s\n", evt.Error.Message)
+			continue
+		}
+		if evt.Response == nil || len(evt.Response.Choices) == 0 {
+			continue
+		}
+		ch := evt.Response.Choices[0]
+
+		// Tool calls - always show the arguments so you can watch the
+		// model write the checklist.
+		if len(ch.Message.ToolCalls) > 0 {
+			if assistantStarted {
+				fmt.Println()
+			}
+			for _, tc := range ch.Message.ToolCalls {
+				fmt.Printf("  [tool-call] %s %s\n", tc.Function.Name, string(tc.Function.Arguments))
+			}
+			toolCallsPrinted = true
+			continue
+		}
+
+		// Tool responses. We render two views side-by-side to show
+		// both consumption patterns a real deployment will use:
+		//
+		//   1. The raw JSON — what the LLM sees (includes the nudge).
+		//   2. A decoded todo.Output — what a cloud frontend (AG-UI,
+		//      Web UI, etc.) consumes directly from the event stream,
+		//      without any extra session fetch.
+		if ch.Message.Role == model.RoleTool && ch.Message.ToolID != "" {
+			raw := strings.TrimSpace(ch.Message.Content)
+			fmt.Printf("  [tool-result raw ] %s\n", raw)
+			var out todo.Output
+			if err := json.Unmarshal([]byte(raw), &out); err == nil {
+				fmt.Printf("  [tool-result decoded] %d todos (was %d)\n",
+					len(out.Todos), len(out.OldTodos))
+				for _, it := range out.Todos {
+					fmt.Printf("    - [%s] %s\n", it.Status, it.Content)
+				}
+			}
+			continue
+		}
+
+		// Assistant text (streaming delta or full).
+		text := ch.Delta.Content
+		if !c.streaming {
+			text = ch.Message.Content
+		}
+		if text == "" {
+			continue
+		}
+		if !assistantStarted {
+			if toolCallsPrinted {
+				fmt.Print("\nAssistant: ")
+			}
+			assistantStarted = true
+		}
+		fmt.Print(text)
+
+		if evt.IsFinalResponse() {
+			fmt.Println()
+		}
+	}
+	return nil
+}
+
+// printTodos reads the current checklist from the session at the end of
+// a turn and renders it as ASCII.
+//
+// Two consumption patterns exist and this demo shows both:
+//
+//  1. In-stream, structured: decode todo.Output from the tool-result
+//     event (see processResponse above). This is what a cloud
+//     frontend (AG-UI, WebSocket UI, etc.) will use — no extra fetch.
+//  2. End-of-turn, canonical: read the session and call todo.GetTodos.
+//     This is what a REST endpoint or an audit job would use when it
+//     only needs the current state, not the change stream.
+func (c *chat) printTodos() {
+	sess, err := c.sessSvc.GetSession(context.Background(), session.Key{
+		AppName:   appName,
+		UserID:    c.userID,
+		SessionID: c.sessionID,
+	})
+	if err != nil || sess == nil {
+		return
+	}
+	// The tool writes under a branch-scoped key. A single-agent setup
+	// uses the agent name as the branch (see agent.Invocation.Branch).
+	items, err := todo.GetTodos(sess, agentName)
+	if err != nil {
+		fmt.Printf("[todo] decode error: %v\n", err)
+		return
+	}
+	fmt.Println("----- Current checklist -----")
+	fmt.Println(formatTodos(items))
+	fmt.Println("-----------------------------")
+}
+
+// formatTodos is a tiny ASCII pretty-printer local to this demo. Rich
+// frontends (AG-UI, web UIs, etc.) should render todo.Item directly in
+// their own native style instead of reusing a fixed string like this.
+func formatTodos(todos []todo.Item) string {
+	if len(todos) == 0 {
+		return "(no todos)"
+	}
+	glyph := func(s todo.Status) string {
+		switch s {
+		case todo.StatusCompleted:
+			return "[x]"
+		case todo.StatusInProgress:
+			return "[>]"
+		default:
+			return "[ ]"
+		}
+	}
+	var b strings.Builder
+	for i, it := range todos {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		fmt.Fprintf(&b, "- %s %s", glyph(it.Status), it.Content)
+	}
+	return b.String()
+}
+
+func intPtr(i int) *int { return &i }

--- a/tool/todo/helpers.go
+++ b/tool/todo/helpers.go
@@ -66,8 +66,10 @@ func GetTodosWithPrefix(sess *session.Session, prefix, branch string) ([]Item, e
 }
 
 // readTodos is the package-internal variant of GetTodosWithPrefix that
-// accepts a pre-computed state key. Errors from decoding are swallowed
-// so that a poisoned state entry cannot break the next write.
+// accepts a pre-computed state key. A poisoned state entry surfaces as
+// a decode error and is the caller's responsibility to discard —
+// Call() does this with `oldTodos, _ = readTodos(...)` so that a
+// single bad write cannot stop the next one from landing.
 func readTodos(sess *session.Session, key string) ([]Item, error) {
 	if sess == nil {
 		return nil, nil

--- a/tool/todo/helpers.go
+++ b/tool/todo/helpers.go
@@ -50,6 +50,11 @@ func GetTodos(sess *session.Session, branch string) ([]Item, error) {
 // GetTodosWithPrefix is the advanced form of GetTodos that honours a
 // custom state key prefix (see WithStateKeyPrefix). Return semantics
 // match GetTodos.
+//
+// An empty prefix is treated as a request for the default layout and
+// falls back to DefaultStateKeyPrefix — it is never read as a literal
+// empty-prefix state key. Pass a concrete value if you need a custom
+// layout, or use GetTodos if you do not.
 func GetTodosWithPrefix(sess *session.Session, prefix, branch string) ([]Item, error) {
 	if sess == nil {
 		return nil, nil

--- a/tool/todo/helpers.go
+++ b/tool/todo/helpers.go
@@ -1,0 +1,84 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package todo
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+// stateKey builds the session.State key used to persist the checklist
+// for the given branch. An empty branch yields just the prefix, which
+// is the main (parent) agent's list.
+//
+// Each branch of an agent tree owns an independent list automatically,
+// so parent and child agents never clobber each other's checklists.
+//
+// The key layout is a package-internal detail. External readers should
+// use GetTodos; they do not need to know how keys are assembled.
+func stateKey(prefix, branch string) string {
+	if prefix == "" {
+		prefix = DefaultStateKeyPrefix
+	}
+	if branch == "" {
+		return prefix
+	}
+	return prefix + ":" + branch
+}
+
+// GetTodos loads the current checklist for the given branch from the
+// session. The returned slice may be nil (no list written yet, empty
+// session, or the list was cleared after all items completed) or a
+// populated slice decoded from state; callers should rely on len()
+// instead of a nil check. An error is only returned if stored data
+// is present but corrupt.
+//
+// Use the empty string for branch to read the main agent's list.
+func GetTodos(sess *session.Session, branch string) ([]Item, error) {
+	return GetTodosWithPrefix(sess, DefaultStateKeyPrefix, branch)
+}
+
+// GetTodosWithPrefix is the advanced form of GetTodos that honours a
+// custom state key prefix (see WithStateKeyPrefix). Return semantics
+// match GetTodos.
+func GetTodosWithPrefix(sess *session.Session, prefix, branch string) ([]Item, error) {
+	if sess == nil {
+		return nil, nil
+	}
+	raw, ok := sess.GetState(stateKey(prefix, branch))
+	if !ok || len(raw) == 0 {
+		return nil, nil
+	}
+	var out []Item
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("todo: decode state: %w", err)
+	}
+	return out, nil
+}
+
+// readTodos is the package-internal variant of GetTodosWithPrefix that
+// accepts a pre-computed state key. Errors from decoding are swallowed
+// so that a poisoned state entry cannot break the next write.
+func readTodos(sess *session.Session, key string) ([]Item, error) {
+	if sess == nil {
+		return nil, nil
+	}
+	raw, ok := sess.GetState(key)
+	if !ok || len(raw) == 0 {
+		return nil, nil
+	}
+	var out []Item
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/tool/todo/options.go
+++ b/tool/todo/options.go
@@ -1,0 +1,124 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package todo
+
+import "context"
+
+// NudgeHook is an optional policy callback invoked after the state
+// has been persisted but before the tool returns. Any non-empty string
+// it returns is appended to the final tool message, giving the model
+// additional structured guidance for the next step.
+//
+// Arguments:
+//
+//   - oldTodos is the list as it was before this write, decoded from
+//     the session. Empty on the very first write of a session.
+//   - submitted is the list the LLM just wrote, exactly as produced
+//     (pre-normalisation). In particular, when WithClearOnAllDone is
+//     enabled and every item is completed, the tool will persist an
+//     empty list and expose Output.Todos as empty, but the hook still
+//     receives the all-completed list here so it can react to that
+//     exact transition (the default demo uses this to ask the model
+//     to summarise when all tasks are done).
+//
+// Typical uses:
+//
+//   - verification reminders (e.g. "You just closed 3+ tasks without a
+//     verification step; call the verifier before summarising.")
+//   - loop detection ("The last 5 updates only flipped the same task
+//     back and forth; consider replanning.")
+//   - token budget warnings.
+//
+// Hooks MUST be side-effect free with respect to the checklist itself.
+// Mutating oldTodos or submitted is not supported.
+type NudgeHook func(ctx context.Context, oldTodos, submitted []Item) string
+
+// options holds the configurable knobs of the Tool.
+type options struct {
+	toolName       string
+	description    string
+	defaultNudge   string
+	stateKeyPrefix string
+	clearOnAllDone bool
+	nudgeHooks     []NudgeHook
+}
+
+func defaultOptions() options {
+	return options{
+		toolName:       DefaultToolName,
+		description:    DefaultToolDescription,
+		defaultNudge:   DefaultNudgeMessage,
+		stateKeyPrefix: DefaultStateKeyPrefix,
+		clearOnAllDone: true,
+	}
+}
+
+// Option configures a Tool.
+type Option func(*options)
+
+// WithToolName overrides the registered tool name.
+//
+// Must match ^[a-zA-Z0-9_-]+$ for maximum LLM-provider compatibility.
+func WithToolName(name string) Option {
+	return func(o *options) {
+		if name != "" {
+			o.toolName = name
+		}
+	}
+}
+
+// WithDescription overrides the short description exposed to the model.
+// For the long usage prompt, inject it via the agent's system instruction
+// (see todo.DefaultToolPrompt for a ready-to-use text).
+func WithDescription(desc string) Option {
+	return func(o *options) {
+		if desc != "" {
+			o.description = desc
+		}
+	}
+}
+
+// WithNudgeMessage overrides the default reminder appended to every tool
+// result. Set to "" to disable the default nudge (hooks still run).
+func WithNudgeMessage(msg string) Option {
+	return func(o *options) {
+		o.defaultNudge = msg
+	}
+}
+
+// WithStateKeyPrefix overrides the session.State key prefix used for
+// persistence. The final key is "<prefix>[:<branch>]".
+func WithStateKeyPrefix(prefix string) Option {
+	return func(o *options) {
+		if prefix != "" {
+			o.stateKeyPrefix = prefix
+		}
+	}
+}
+
+// WithClearOnAllDone controls whether the list is cleared once every
+// item reaches "completed". Enabled by default to avoid unbounded
+// context growth. Disable it if you want completed items to persist
+// (e.g. for UI history).
+func WithClearOnAllDone(clear bool) Option {
+	return func(o *options) {
+		o.clearOnAllDone = clear
+	}
+}
+
+// WithNudgeHook registers an additional policy hook. Hooks run in the
+// order they are registered, after the default nudge message.
+func WithNudgeHook(hook NudgeHook) Option {
+	return func(o *options) {
+		if hook != nil {
+			o.nudgeHooks = append(o.nudgeHooks, hook)
+		}
+	}
+}

--- a/tool/todo/prompt.go
+++ b/tool/todo/prompt.go
@@ -1,0 +1,76 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package todo
+
+// DefaultToolDescription is the short one-line description surfaced in
+// the tool declaration. It is what most LLM providers feed directly into
+// the function-calling prompt.
+const DefaultToolDescription = "Maintain a structured todo list for the current session. " +
+	"Call this proactively to plan, track and report progress on multi-step tasks. " +
+	"Each call replaces the entire list; at most one task may be 'in_progress' at any time."
+
+// DefaultToolPrompt is a long-form usage guide for the todo tool,
+// intended to be concatenated into an agent's system instruction.
+// It tells the model *when* and *how* to use the tool - the short
+// Description alone is often not enough to produce disciplined usage.
+const DefaultToolPrompt = `## Todo list tool
+
+You have access to a todo_write tool to create and manage a structured
+task list for the current session. Use it proactively to plan and track
+complex work and to show progress to the user.
+
+### When to use
+
+Use the tool when:
+1. A task requires 3 or more distinct steps.
+2. The user provides multiple tasks (numbered or comma-separated).
+3. The user explicitly asks for a checklist.
+4. You receive new instructions that must be captured as follow-up work.
+5. You start working on a task - mark it as in_progress BEFORE beginning.
+6. You finish a task - mark it completed and add any follow-ups discovered.
+
+Skip the tool when:
+- There is only a single, straightforward step.
+- The task is trivial or purely conversational.
+
+### Task states
+
+Each item has three fields:
+
+- content:    imperative form, e.g. "Run tests".
+- activeForm: present-continuous form, e.g. "Running tests".
+- status:     one of pending | in_progress | completed.
+
+Rules:
+- At most ONE task may be in_progress at any time. Keep exactly one
+  in_progress while you are actively working the plan; zero is only
+  acceptable when the list has just been drafted, everything is
+  completed, or you are between batches.
+- Mark a task completed IMMEDIATELY after finishing; do not batch completions.
+- Only mark completed when the task is FULLY done. If blocked, keep it
+  in_progress and add a new task describing what must be resolved.
+- Each call replaces the ENTIRE list. Send the full updated list every time.
+- Content must be unique across the list; do not duplicate tasks.
+- Remove tasks that are no longer relevant instead of leaving them stale.
+
+### Example
+
+User: "Add a dark-mode toggle and make sure tests pass."
+
+First call:
+  todo_write({todos: [
+    {content: "Add dark-mode toggle component",    activeForm: "Adding dark-mode toggle component",    status: "in_progress"},
+    {content: "Wire theme state into app context", activeForm: "Wiring theme state into app context", status: "pending"},
+    {content: "Update styles for dark theme",      activeForm: "Updating styles for dark theme",      status: "pending"},
+    {content: "Run test suite and fix failures",   activeForm: "Running test suite and fixing failures", status: "pending"},
+  ]})
+
+After completing the first item, call again with the first task marked
+completed and the next one flipped to in_progress.`

--- a/tool/todo/todo.go
+++ b/tool/todo/todo.go
@@ -267,9 +267,12 @@ func (t *Tool) Call(ctx context.Context, jsonArgs []byte) (any, error) {
 	key := stateKey(t.opts.stateKeyPrefix, branch)
 
 	// Compute next list. All-done => clear to avoid unbounded growth.
+	// Normalise the cleared list to an empty (non-nil) slice so that
+	// the marshalled Output.Todos and the persisted state both emit
+	// `[]` rather than `null`, matching the declared output schema.
 	newTodos := in.Todos
 	if t.opts.clearOnAllDone && allCompleted(newTodos) {
-		newTodos = nil
+		newTodos = []Item{}
 	}
 
 	// Read old list (best-effort) and persist new list.

--- a/tool/todo/todo.go
+++ b/tool/todo/todo.go
@@ -1,0 +1,407 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+// Package todo provides a session-scoped todo-list tool that lets an LLM
+// agent plan, track and report multi-step work inside a single conversation.
+//
+// The tool stores the current checklist as ephemeral session state and, on
+// every call, returns a short "continue using the list" nudge so that the
+// model is reminded to keep the plan up to date. Key design choices:
+//
+//   - Storage goes through session.State (the temp: prefix), so every
+//     write lives with the session and disappears when the session ends.
+//   - Sub-agent isolation is achieved via Invocation.Branch (each branch
+//     keeps its own checklist, so parent and child agents do not step on
+//     each other).
+//   - Behaviour hooks (NudgeHook) let callers attach policies such as
+//     verification reminders, loop detection or token budget warnings
+//     without modifying the tool itself.
+//
+// Typical use:
+//
+//	todoTool := todo.New()
+//	agent := llmagent.New("assistant",
+//	    llmagent.WithTools([]tool.Tool{todoTool}),
+//	)
+//
+// Public surface:
+//
+//   - todo.New / todo.Option — construct and configure the tool.
+//   - todo.Tool — CallableTool implementation (plug into llmagent).
+//   - todo.Item / todo.Status / todo.Output — structured types that
+//     show up in tool-call results; frontends (e.g. AG-UI) consume
+//     these directly and never need to parse raw session state.
+//   - todo.GetTodos / todo.GetTodosWithPrefix — read the current list
+//     from a session (server-side integrations, REST endpoints, etc).
+//
+// The package deliberately does NOT ship a text/ASCII pretty-printer.
+// Presentation is the caller's concern: a CLI prints plain text, a web
+// UI paints rich components, an AG-UI frontend renders its own cards.
+// See examples/todo for a minimal terminal-style formatter.
+//
+// The session key layout is also NOT part of the public API: any code
+// that needs to read the list should go through GetTodos.
+package todo
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+// Default configuration constants.
+const (
+	// DefaultToolName is the default registered name of the todo tool.
+	// It is intentionally snake_case to satisfy strict LLM tool-naming
+	// rules enforced by some providers (e.g. Kimi / DeepSeek require
+	// ^[a-zA-Z0-9_-]+$).
+	DefaultToolName = "todo_write"
+
+	// DefaultStateKeyPrefix is the session.State key prefix used to persist
+	// the current list. The final key is "temp:todos[:<branch>]" so that:
+	//   - the temp: prefix marks it as session-scoped ephemeral state;
+	//   - child agents isolated by Branch get their own list automatically.
+	DefaultStateKeyPrefix = "temp:todos"
+
+	// DefaultNudgeMessage is the fixed reminder returned after every update.
+	// Keeping this message in the tool response (rather than only in the
+	// system prompt) materially improves the model's follow-through on
+	// long multi-step tasks.
+	DefaultNudgeMessage = "Todos have been modified successfully. " +
+		"Ensure that you continue to use the todo list to track your progress. " +
+		"Please proceed with the current tasks if applicable."
+)
+
+// Status is the life-cycle state of a single todo item.
+type Status string
+
+// Valid todo statuses.
+const (
+	StatusPending    Status = "pending"
+	StatusInProgress Status = "in_progress"
+	StatusCompleted  Status = "completed"
+)
+
+// IsValid reports whether the status is one of the three accepted values.
+func (s Status) IsValid() bool {
+	switch s {
+	case StatusPending, StatusInProgress, StatusCompleted:
+		return true
+	default:
+		return false
+	}
+}
+
+// Item is one entry in the checklist.
+//
+// Content and ActiveForm are both required:
+//   - Content is the imperative form, used by the model for planning
+//     ("Run tests", "Fix auth bug").
+//   - ActiveForm is the present-continuous form, intended for UI spinners
+//     or status lines ("Running tests", "Fixing auth bug").
+type Item struct {
+	Content    string `json:"content"    description:"Imperative description of the task, e.g. 'Run tests'"`
+	ActiveForm string `json:"activeForm" description:"Present-continuous form shown while the task is running, e.g. 'Running tests'"`
+	Status     Status `json:"status"     jsonschema:"enum=pending,enum=in_progress,enum=completed" description:"One of: pending | in_progress | completed"`
+}
+
+// writeInput is the LLM-facing input for a single tool call.
+// The entire previous list is replaced by Todos on every call; callers do
+// not send diffs.
+type writeInput struct {
+	Todos []Item `json:"todos" description:"The complete, updated todo list. Replaces the previous list entirely."`
+}
+
+// Output is the structured result of a tool call. It serves two
+// audiences simultaneously:
+//
+//   - The LLM sees it (serialized as JSON) as the tool response, where
+//     Message acts as a nudge to keep it on plan.
+//   - External consumers (server-side code, AG-UI frontends, logs)
+//     consume Todos and OldTodos directly from the tool-result event
+//     without having to fetch the session store or parse StateDelta.
+//
+// The list itself is small and echoing it costs few tokens; in exchange
+// every event consumer gets the current state inline and can render
+// a diff against OldTodos when desired.
+type Output struct {
+	// Message is the guidance text the model sees in the tool response.
+	Message string `json:"message"`
+	// Todos is the checklist after this write. When the tool clears the
+	// list (see WithClearOnAllDone) this is empty.
+	Todos []Item `json:"todos"`
+	// OldTodos is the checklist as it was before this write. It is
+	// omitted on the very first call of a session and whenever no prior
+	// state exists.
+	OldTodos []Item `json:"oldTodos,omitempty"`
+}
+
+// Tool is a CallableTool implementation of the todo-list writer.
+type Tool struct {
+	opts options
+}
+
+// Ensure interface satisfaction at compile time.
+var _ tool.CallableTool = (*Tool)(nil)
+
+// New constructs a Tool with the provided options. All options are
+// independent; any that is not supplied falls back to a sensible default.
+func New(opts ...Option) *Tool {
+	o := defaultOptions()
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&o)
+		}
+	}
+	return &Tool{opts: o}
+}
+
+// Declaration implements tool.Tool.
+func (t *Tool) Declaration() *tool.Declaration {
+	// Build an explicit schema so that the item sub-schema, enum and
+	// descriptions are stable regardless of reflection quirks.
+	itemSchema := &tool.Schema{
+		Type: "object",
+		Properties: map[string]*tool.Schema{
+			"content": {
+				Type:        "string",
+				Description: "Imperative description of the task, e.g. 'Run tests'.",
+			},
+			"activeForm": {
+				Type:        "string",
+				Description: "Present-continuous form shown while the task is running, e.g. 'Running tests'.",
+			},
+			"status": {
+				Type:        "string",
+				Description: "Task status. One of: pending | in_progress | completed.",
+				Enum: []any{
+					string(StatusPending),
+					string(StatusInProgress),
+					string(StatusCompleted),
+				},
+			},
+		},
+		Required: []string{"content", "activeForm", "status"},
+	}
+
+	input := &tool.Schema{
+		Type: "object",
+		Properties: map[string]*tool.Schema{
+			"todos": {
+				Type:        "array",
+				Description: "The complete, updated todo list. Replaces the previous list entirely.",
+				Items:       itemSchema,
+			},
+		},
+		Required: []string{"todos"},
+	}
+
+	output := &tool.Schema{
+		Type: "object",
+		Properties: map[string]*tool.Schema{
+			"message": {
+				Type:        "string",
+				Description: "Guidance for the next step.",
+			},
+			"todos": {
+				Type:        "array",
+				Description: "The checklist after this write.",
+				Items:       itemSchema,
+			},
+			"oldTodos": {
+				Type:        "array",
+				Description: "The checklist before this write (omitted on first write).",
+				Items:       itemSchema,
+			},
+		},
+	}
+
+	return &tool.Declaration{
+		Name:         t.opts.toolName,
+		Description:  t.opts.description,
+		InputSchema:  input,
+		OutputSchema: output,
+	}
+}
+
+// Call implements tool.CallableTool.
+//
+// Behaviour:
+//  1. Parse and validate the new list.
+//  2. Resolve the storage key for the current branch.
+//  3. If every item is completed, clear the list (prevents completed
+//     items from piling up in context across turns).
+//  4. Persist the new list on the Session's in-memory State.
+//  5. Run any configured NudgeHook to append extra guidance strings.
+//  6. Return {message: "...default nudge... + hook output"}.
+//
+// An error is returned only for malformed input; operational failures
+// (missing invocation / session) degrade gracefully into a tool-side
+// message so that a misconfigured agent still gets feedback from the
+// model instead of a hard stop.
+func (t *Tool) Call(ctx context.Context, jsonArgs []byte) (any, error) {
+	var in writeInput
+	if err := json.Unmarshal(jsonArgs, &in); err != nil {
+		return nil, fmt.Errorf("todo_write: invalid arguments: %w", err)
+	}
+	if err := validateTodos(in.Todos); err != nil {
+		return nil, fmt.Errorf("todo_write: %w", err)
+	}
+
+	// Resolve scope. Without an invocation we still accept the call so
+	// that tests and single-shot usage work, but we report it clearly.
+	inv, _ := agent.InvocationFromContext(ctx)
+	branch := ""
+	if inv != nil {
+		branch = inv.Branch
+	}
+	key := stateKey(t.opts.stateKeyPrefix, branch)
+
+	// Compute next list. All-done => clear to avoid unbounded growth.
+	newTodos := in.Todos
+	if t.opts.clearOnAllDone && allCompleted(newTodos) {
+		newTodos = nil
+	}
+
+	// Read old list (best-effort) and persist new list.
+	var oldTodos []Item
+	if inv != nil && inv.Session != nil {
+		oldTodos, _ = readTodos(inv.Session, key)
+		encoded, err := json.Marshal(newTodos)
+		if err != nil {
+			return nil, fmt.Errorf("todo_write: encode state: %w", err)
+		}
+		inv.Session.SetState(key, encoded)
+	}
+
+	// Compose message: default nudge + hooks.
+	msg := t.opts.defaultNudge
+	for _, hook := range t.opts.nudgeHooks {
+		if hook == nil {
+			continue
+		}
+		if extra := hook(ctx, oldTodos, in.Todos); extra != "" {
+			msg += "\n\n" + extra
+		}
+	}
+
+	return Output{
+		Message:  msg,
+		Todos:    newTodos,
+		OldTodos: oldTodos,
+	}, nil
+}
+
+// StateDeltaForInvocation publishes the new checklist as a session
+// state delta so the session service persists it beyond the current
+// invocation. The in-run SetState above keeps reads fast within a
+// single Run; this method keeps the canonical store in sync so the
+// list survives across turns (and shows up when external code calls
+// session.Service.GetSession).
+//
+// It is discovered by the function-call response processor via duck
+// typing and is safe to call with zero or nil arguments.
+func (t *Tool) StateDeltaForInvocation(
+	inv *agent.Invocation,
+	_ string,
+	args []byte,
+	_ []byte,
+) map[string][]byte {
+	var in writeInput
+	if err := json.Unmarshal(args, &in); err != nil {
+		return nil
+	}
+	if err := validateTodos(in.Todos); err != nil {
+		return nil
+	}
+	branch := ""
+	if inv != nil {
+		branch = inv.Branch
+	}
+	key := stateKey(t.opts.stateKeyPrefix, branch)
+
+	newTodos := in.Todos
+	if t.opts.clearOnAllDone && allCompleted(newTodos) {
+		newTodos = nil
+	}
+	encoded, err := json.Marshal(newTodos)
+	if err != nil {
+		return nil
+	}
+	return map[string][]byte{key: encoded}
+}
+
+// validateTodos checks the list against the tool's structural contract.
+//
+// The rules enforced here are the ones a healthy agent cannot violate
+// by accident; stylistic guidance ("prefer exactly one in_progress
+// while actively working", item ordering, etc.) stays in the prompt.
+//
+// Enforced:
+//
+//  1. Per-item: content and activeForm are non-empty, status is one of
+//     pending | in_progress | completed.
+//  2. At most one item is in_progress. Two or more in_progress items
+//     almost always mean the model has lost track of what it is doing;
+//     zero in_progress is legal (pure planning, batch-flip interlude,
+//     all-completed terminal state).
+//  3. Content is unique across the list. Duplicate content is a
+//     strong signal of double-tracking / copy-paste accidents.
+func validateTodos(todos []Item) error {
+	var inProgress int
+	seen := make(map[string]int, len(todos))
+	for i, it := range todos {
+		if it.Content == "" {
+			return fmt.Errorf("todos[%d].content must not be empty", i)
+		}
+		if it.ActiveForm == "" {
+			return fmt.Errorf("todos[%d].activeForm must not be empty", i)
+		}
+		if !it.Status.IsValid() {
+			return fmt.Errorf(
+				"todos[%d].status %q is invalid (want pending|in_progress|completed)",
+				i, it.Status,
+			)
+		}
+		if it.Status == StatusInProgress {
+			inProgress++
+			if inProgress > 1 {
+				return fmt.Errorf(
+					"at most one item may be in_progress, got multiple (first at todos[%d])",
+					i,
+				)
+			}
+		}
+		if prev, ok := seen[it.Content]; ok {
+			return fmt.Errorf(
+				"todos[%d].content %q duplicates todos[%d].content",
+				i, it.Content, prev,
+			)
+		}
+		seen[it.Content] = i
+	}
+	return nil
+}
+
+// allCompleted returns true if every item is in completed state.
+// An empty slice is not treated as all-completed (nothing to clear).
+func allCompleted(todos []Item) bool {
+	if len(todos) == 0 {
+		return false
+	}
+	for _, it := range todos {
+		if it.Status != StatusCompleted {
+			return false
+		}
+	}
+	return true
+}

--- a/tool/todo/todo.go
+++ b/tool/todo/todo.go
@@ -319,6 +319,12 @@ func (t *Tool) StateDeltaForInvocation(
 	args []byte,
 	_ []byte,
 ) map[string][]byte {
+	// The function-call response processor only reaches here after
+	// Call() has already returned successfully, so args is guaranteed
+	// to decode and validate. We re-check defensively and silently
+	// drop the delta on mismatch: if this path ever fires it indicates
+	// a framework-level bug, and corrupting the canonical session
+	// store is strictly worse than losing one turn of persistence.
 	var in writeInput
 	if err := json.Unmarshal(args, &in); err != nil {
 		return nil
@@ -332,9 +338,13 @@ func (t *Tool) StateDeltaForInvocation(
 	}
 	key := stateKey(t.opts.stateKeyPrefix, branch)
 
+	// Mirror the clear-on-all-done normalisation performed by Call():
+	// an empty (non-nil) slice so that the persisted state serialises
+	// to []  - keeping the in-run SetState and the canonical store
+	// byte-identical regardless of backend (inmemory, Redis, ...).
 	newTodos := in.Todos
 	if t.opts.clearOnAllDone && allCompleted(newTodos) {
-		newTodos = nil
+		newTodos = []Item{}
 	}
 	encoded, err := json.Marshal(newTodos)
 	if err != nil {

--- a/tool/todo/todo.go
+++ b/tool/todo/todo.go
@@ -253,6 +253,16 @@ func (t *Tool) Call(ctx context.Context, jsonArgs []byte) (any, error) {
 	if err := json.Unmarshal(jsonArgs, &in); err != nil {
 		return nil, fmt.Errorf("todo_write: invalid arguments: %w", err)
 	}
+	// `{"todos": null}` and a missing `todos` field both unmarshal to a
+	// nil slice. Treat them as an explicit empty list so that the tool
+	// never serialises `null` for a field declared as an array in both
+	// the input and the output schema. Semantically this matches the
+	// "submit an empty list" convention callers can already use to
+	// clear the checklist, and keeps the two persistence layers
+	// (Session.SetState + StateDelta) byte-identical.
+	if in.Todos == nil {
+		in.Todos = []Item{}
+	}
 	if err := validateTodos(in.Todos); err != nil {
 		return nil, fmt.Errorf("todo_write: %w", err)
 	}
@@ -286,21 +296,30 @@ func (t *Tool) Call(ctx context.Context, jsonArgs []byte) (any, error) {
 		inv.Session.SetState(key, encoded)
 	}
 
+	// Snapshot the returned lists up front: the persisted state was
+	// marshalled above, so even if a misbehaving hook mutates the
+	// slices it receives, our Output and the canonical store stay in
+	// sync. The contract on NudgeHook (see options.go) already says
+	// hooks must be read-only; these clones are belt-and-braces so a
+	// buggy hook cannot silently corrupt the tool's response.
+	outputTodos := cloneItems(newTodos)
+	outputOldTodos := cloneItems(oldTodos)
+
 	// Compose message: default nudge + hooks.
 	msg := t.opts.defaultNudge
 	for _, hook := range t.opts.nudgeHooks {
 		if hook == nil {
 			continue
 		}
-		if extra := hook(ctx, oldTodos, in.Todos); extra != "" {
+		if extra := hook(ctx, cloneItems(oldTodos), cloneItems(in.Todos)); extra != "" {
 			msg += "\n\n" + extra
 		}
 	}
 
 	return Output{
 		Message:  msg,
-		Todos:    newTodos,
-		OldTodos: oldTodos,
+		Todos:    outputTodos,
+		OldTodos: outputOldTodos,
 	}, nil
 }
 
@@ -328,6 +347,14 @@ func (t *Tool) StateDeltaForInvocation(
 	var in writeInput
 	if err := json.Unmarshal(args, &in); err != nil {
 		return nil
+	}
+	// Mirror Call(): coerce a missing/null todos field to an empty
+	// slice so the canonical delta stays a JSON array. Call() has
+	// already done the same on its own path, this keeps the two
+	// persistence layers byte-identical even if an arg array was
+	// rewritten between Call and StateDeltaForInvocation.
+	if in.Todos == nil {
+		in.Todos = []Item{}
 	}
 	if err := validateTodos(in.Todos); err != nil {
 		return nil
@@ -417,4 +444,20 @@ func allCompleted(todos []Item) bool {
 		}
 	}
 	return true
+}
+
+// cloneItems returns a fresh []Item with the same contents as items.
+// A nil input maps to a nil output so that optional-empty semantics
+// ("first call, no OldTodos") continue to marshal as an omitted
+// field rather than `[]`.
+//
+// Item has only scalar fields, so a shallow copy is sufficient to
+// isolate callers from each other.
+func cloneItems(items []Item) []Item {
+	if items == nil {
+		return nil
+	}
+	out := make([]Item, len(items))
+	copy(out, items)
+	return out
 }

--- a/tool/todo/todo.go
+++ b/tool/todo/todo.go
@@ -50,6 +50,7 @@
 package todo
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -249,21 +250,8 @@ func (t *Tool) Declaration() *tool.Declaration {
 // message so that a misconfigured agent still gets feedback from the
 // model instead of a hard stop.
 func (t *Tool) Call(ctx context.Context, jsonArgs []byte) (any, error) {
-	var in writeInput
-	if err := json.Unmarshal(jsonArgs, &in); err != nil {
-		return nil, fmt.Errorf("todo_write: invalid arguments: %w", err)
-	}
-	// `{"todos": null}` and a missing `todos` field both unmarshal to a
-	// nil slice. Treat them as an explicit empty list so that the tool
-	// never serialises `null` for a field declared as an array in both
-	// the input and the output schema. Semantically this matches the
-	// "submit an empty list" convention callers can already use to
-	// clear the checklist, and keeps the two persistence layers
-	// (Session.SetState + StateDelta) byte-identical.
-	if in.Todos == nil {
-		in.Todos = []Item{}
-	}
-	if err := validateTodos(in.Todos); err != nil {
+	in, err := decodeWriteInput(jsonArgs)
+	if err != nil {
 		return nil, fmt.Errorf("todo_write: %w", err)
 	}
 
@@ -344,19 +332,8 @@ func (t *Tool) StateDeltaForInvocation(
 	// drop the delta on mismatch: if this path ever fires it indicates
 	// a framework-level bug, and corrupting the canonical session
 	// store is strictly worse than losing one turn of persistence.
-	var in writeInput
-	if err := json.Unmarshal(args, &in); err != nil {
-		return nil
-	}
-	// Mirror Call(): coerce a missing/null todos field to an empty
-	// slice so the canonical delta stays a JSON array. Call() has
-	// already done the same on its own path, this keeps the two
-	// persistence layers byte-identical even if an arg array was
-	// rewritten between Call and StateDeltaForInvocation.
-	if in.Todos == nil {
-		in.Todos = []Item{}
-	}
-	if err := validateTodos(in.Todos); err != nil {
+	in, err := decodeWriteInput(args)
+	if err != nil {
 		return nil
 	}
 	branch := ""
@@ -378,6 +355,59 @@ func (t *Tool) StateDeltaForInvocation(
 		return nil
 	}
 	return map[string][]byte{key: encoded}
+}
+
+// decodeWriteInput parses the raw tool arguments into a writeInput,
+// rejecting structurally legal but semantically destructive shapes
+// before any persistence happens.
+//
+// Specifically: a missing `todos` field and `{"todos": null}` both
+// unmarshal to a nil slice and would otherwise round-trip through
+// validateTodos as "empty list = clear all". We refuse them at the
+// edge so that an upstream provider, retry middleware, or hand-rolled
+// caller that accidentally drops the field cannot wipe a session's
+// plan in one shot. The legitimate clear gesture is an explicit empty
+// array (`{"todos": []}`); making the destructive path require an
+// explicit token preserves the symmetry the JSON schema declares
+// (`required: ["todos"]`, type: array) and matches how the same shape
+// is enforced for any structured tool input.
+//
+// The helper is shared between Call() and StateDeltaForInvocation()
+// so the two persistence layers cannot drift on whether to accept a
+// given payload.
+func decodeWriteInput(jsonArgs []byte) (writeInput, error) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(jsonArgs, &raw); err != nil {
+		return writeInput{}, fmt.Errorf("invalid arguments: %w", err)
+	}
+	todosRaw, ok := raw["todos"]
+	if !ok {
+		return writeInput{}, fmt.Errorf(
+			"todos field is required and must be an array " +
+				"(use [] to clear the checklist)",
+		)
+	}
+	if bytes.Equal(bytes.TrimSpace(todosRaw), []byte("null")) {
+		return writeInput{}, fmt.Errorf(
+			"todos must be an array, got null " +
+				"(use [] to clear the checklist)",
+		)
+	}
+	var todos []Item
+	if err := json.Unmarshal(todosRaw, &todos); err != nil {
+		return writeInput{}, fmt.Errorf("todos must be an array: %w", err)
+	}
+	if todos == nil {
+		// json.Unmarshal of `[]` produces a non-nil empty slice;
+		// any other shape that survives the checks above and still
+		// yields nil is treated as the same kind of structural mishap
+		// the explicit checks above are there to catch.
+		todos = []Item{}
+	}
+	if err := validateTodos(todos); err != nil {
+		return writeInput{}, err
+	}
+	return writeInput{Todos: todos}, nil
 }
 
 // validateTodos checks the list against the tool's structural contract.

--- a/tool/todo/todo_test.go
+++ b/tool/todo/todo_test.go
@@ -133,12 +133,36 @@ func TestCall_ClearOnAllDone(t *testing.T) {
 		{Content: "a", ActiveForm: "Aing", Status: StatusCompleted},
 		{Content: "b", ActiveForm: "Bing", Status: StatusCompleted},
 	}})
-	if _, err := tl.Call(ctx, args); err != nil {
+	raw, err := tl.Call(ctx, args)
+	if err != nil {
 		t.Fatalf("Call: %v", err)
 	}
 	got, _ := GetTodos(sess, "")
 	if len(got) != 0 {
 		t.Fatalf("expected empty list after all-done clear, got %#v", got)
+	}
+
+	// Regression guard: the cleared list must marshal to "todos": [],
+	// not "todos": null. Output.Todos has no omitempty and the
+	// declared output schema says the field is an array, so emitting
+	// null here would break schema-aware LLMs and AG-UI-style
+	// frontends that call .length / .map directly on the field.
+	out, ok := raw.(Output)
+	if !ok {
+		t.Fatalf("Call returned unexpected type %T", raw)
+	}
+	if out.Todos == nil {
+		t.Fatalf("Output.Todos must be non-nil after clear, got nil")
+	}
+	encoded, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("marshal Output: %v", err)
+	}
+	if !strings.Contains(string(encoded), `"todos":[]`) {
+		t.Fatalf("expected marshalled output to contain \"todos\":[], got %s", encoded)
+	}
+	if strings.Contains(string(encoded), `"todos":null`) {
+		t.Fatalf("output must not emit \"todos\":null, got %s", encoded)
 	}
 
 	// With clear disabled, items should be retained.

--- a/tool/todo/todo_test.go
+++ b/tool/todo/todo_test.go
@@ -177,6 +177,36 @@ func TestCall_ClearOnAllDone(t *testing.T) {
 	}
 }
 
+// TestStateDeltaForInvocation_ClearOnAllDone guards against the
+// canonical session store receiving "null" bytes when clear-on-all-done
+// fires. Call() persists `[]` via SetState, and StateDeltaForInvocation
+// must publish a matching delta so every backend (inmemory, Redis, ...)
+// converges on the same on-disk shape.
+func TestStateDeltaForInvocation_ClearOnAllDone(t *testing.T) {
+	tl := New()
+	inv := &agent.Invocation{AgentName: "tester", Session: session.NewSession("app", "user", "sid")}
+
+	args, err := json.Marshal(writeInput{Todos: []Item{
+		{Content: "a", ActiveForm: "Aing", Status: StatusCompleted},
+		{Content: "b", ActiveForm: "Bing", Status: StatusCompleted},
+	}})
+	if err != nil {
+		t.Fatalf("marshal args: %v", err)
+	}
+
+	delta := tl.StateDeltaForInvocation(inv, "", args, nil)
+	if delta == nil {
+		t.Fatalf("expected non-nil state delta")
+	}
+	encoded, ok := delta[stateKey(DefaultStateKeyPrefix, "")]
+	if !ok {
+		t.Fatalf("state delta missing default key, got %v", delta)
+	}
+	if string(encoded) != `[]` {
+		t.Fatalf("expected cleared state to encode as `[]`, got %q", encoded)
+	}
+}
+
 func TestCall_NudgeHook(t *testing.T) {
 	ctx, _ := newTestCtx("")
 	called := false

--- a/tool/todo/todo_test.go
+++ b/tool/todo/todo_test.go
@@ -1,0 +1,350 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package todo
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+// newTestCtx builds a context wired with a fresh Invocation + Session for
+// the given branch. Returning both lets tests inspect persisted state.
+func newTestCtx(branch string) (context.Context, *session.Session) {
+	sess := session.NewSession("app", "user", "sid")
+	inv := &agent.Invocation{
+		AgentName: "tester",
+		Branch:    branch,
+		Session:   sess,
+	}
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+	return ctx, sess
+}
+
+func mustMarshal(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}
+
+func TestDeclaration_DefaultsAndOverrides(t *testing.T) {
+	tl := New()
+	d := tl.Declaration()
+	if d.Name != DefaultToolName {
+		t.Fatalf("default name: got %q want %q", d.Name, DefaultToolName)
+	}
+	if d.InputSchema == nil || d.InputSchema.Properties["todos"] == nil {
+		t.Fatalf("missing todos input schema: %#v", d.InputSchema)
+	}
+	items := d.InputSchema.Properties["todos"]
+	if items.Type != "array" || items.Items == nil {
+		t.Fatalf("todos must be array with items, got %#v", items)
+	}
+	status := items.Items.Properties["status"]
+	if status == nil || len(status.Enum) != 3 {
+		t.Fatalf("status enum should have 3 values, got %#v", status)
+	}
+
+	custom := New(
+		WithToolName("plan_write"),
+		WithDescription("alt desc"),
+	)
+	cd := custom.Declaration()
+	if cd.Name != "plan_write" || cd.Description != "alt desc" {
+		t.Fatalf("overrides not applied: %#v", cd)
+	}
+}
+
+func TestCall_WritesState_AndReturnsNudge(t *testing.T) {
+	ctx, sess := newTestCtx("")
+	tl := New()
+
+	args := mustMarshal(t, writeInput{Todos: []Item{
+		{Content: "Scan repo", ActiveForm: "Scanning repo", Status: StatusInProgress},
+		{Content: "Write tests", ActiveForm: "Writing tests", Status: StatusPending},
+	}})
+	res, err := tl.Call(ctx, args)
+	if err != nil {
+		t.Fatalf("Call err: %v", err)
+	}
+	out, ok := res.(Output)
+	if !ok {
+		t.Fatalf("expected Output, got %T", res)
+	}
+	if !strings.Contains(out.Message, "continue to use the todo list") {
+		t.Fatalf("default nudge missing in %q", out.Message)
+	}
+
+	got, err := GetTodos(sess, "")
+	if err != nil {
+		t.Fatalf("GetTodos: %v", err)
+	}
+	if len(got) != 2 || got[0].Status != StatusInProgress || got[1].Content != "Write tests" {
+		t.Fatalf("state did not persist correctly: %#v", got)
+	}
+}
+
+func TestCall_BranchIsolation(t *testing.T) {
+	sess := session.NewSession("app", "user", "sid")
+
+	runOn := func(branch string, todos []Item) {
+		inv := &agent.Invocation{Branch: branch, Session: sess}
+		ctx := agent.NewInvocationContext(context.Background(), inv)
+		args := mustMarshal(t, writeInput{Todos: todos})
+		if _, err := New().Call(ctx, args); err != nil {
+			t.Fatalf("Call(%s): %v", branch, err)
+		}
+	}
+
+	runOn("", []Item{{Content: "parent task", ActiveForm: "parenting", Status: StatusPending}})
+	runOn("sub", []Item{
+		{Content: "child task", ActiveForm: "childing", Status: StatusInProgress},
+	})
+
+	parent, _ := GetTodos(sess, "")
+	child, _ := GetTodos(sess, "sub")
+	if len(parent) != 1 || parent[0].Content != "parent task" {
+		t.Fatalf("parent list wrong: %#v", parent)
+	}
+	if len(child) != 1 || child[0].Content != "child task" {
+		t.Fatalf("child list wrong: %#v", child)
+	}
+}
+
+func TestCall_ClearOnAllDone(t *testing.T) {
+	ctx, sess := newTestCtx("")
+	tl := New()
+
+	args := mustMarshal(t, writeInput{Todos: []Item{
+		{Content: "a", ActiveForm: "Aing", Status: StatusCompleted},
+		{Content: "b", ActiveForm: "Bing", Status: StatusCompleted},
+	}})
+	if _, err := tl.Call(ctx, args); err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	got, _ := GetTodos(sess, "")
+	if len(got) != 0 {
+		t.Fatalf("expected empty list after all-done clear, got %#v", got)
+	}
+
+	// With clear disabled, items should be retained.
+	ctx2, sess2 := newTestCtx("")
+	tl2 := New(WithClearOnAllDone(false))
+	if _, err := tl2.Call(ctx2, args); err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	got2, _ := GetTodos(sess2, "")
+	if len(got2) != 2 {
+		t.Fatalf("expected retained list, got %#v", got2)
+	}
+}
+
+func TestCall_NudgeHook(t *testing.T) {
+	ctx, _ := newTestCtx("")
+	called := false
+	hook := func(_ context.Context, old, newT []Item) string {
+		called = true
+		if len(old) != 0 {
+			t.Fatalf("first call old should be empty, got %d", len(old))
+		}
+		if len(newT) != 1 {
+			t.Fatalf("newT should have 1 item, got %d", len(newT))
+		}
+		return "EXTRA_HINT"
+	}
+	tl := New(WithNudgeHook(hook))
+	args := mustMarshal(t, writeInput{Todos: []Item{
+		{Content: "x", ActiveForm: "Xing", Status: StatusPending},
+	}})
+	res, err := tl.Call(ctx, args)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if !called {
+		t.Fatalf("hook not called")
+	}
+	if !strings.Contains(res.(Output).Message, "EXTRA_HINT") {
+		t.Fatalf("hook output not appended: %q", res.(Output).Message)
+	}
+}
+
+func TestCall_HookReceivesOldList(t *testing.T) {
+	ctx, _ := newTestCtx("")
+	var gotOld []Item
+	hook := func(_ context.Context, old, _ []Item) string {
+		gotOld = append(gotOld, old...)
+		return ""
+	}
+	tl := New(WithNudgeHook(hook))
+
+	// First write establishes state.
+	_, err := tl.Call(ctx, mustMarshal(t, writeInput{Todos: []Item{
+		{Content: "first", ActiveForm: "firsting", Status: StatusPending},
+	}}))
+	if err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if len(gotOld) != 0 {
+		t.Fatalf("first call old should be empty, got %#v", gotOld)
+	}
+
+	// Second write: hook should see the previous list.
+	_, err = tl.Call(ctx, mustMarshal(t, writeInput{Todos: []Item{
+		{Content: "first", ActiveForm: "firsting", Status: StatusInProgress},
+	}}))
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if len(gotOld) != 1 || gotOld[0].Content != "first" {
+		t.Fatalf("hook did not receive old list: %#v", gotOld)
+	}
+}
+
+func TestCall_ValidatesInput(t *testing.T) {
+	ctx, _ := newTestCtx("")
+	tl := New()
+
+	cases := []struct {
+		name string
+		in   writeInput
+	}{
+		{"empty content", writeInput{Todos: []Item{{Content: "", ActiveForm: "X", Status: StatusPending}}}},
+		{"empty activeForm", writeInput{Todos: []Item{{Content: "A", ActiveForm: "", Status: StatusPending}}}},
+		{"bad status", writeInput{Todos: []Item{{Content: "A", ActiveForm: "X", Status: Status("other")}}}},
+		{"multiple in_progress", writeInput{Todos: []Item{
+			{Content: "A", ActiveForm: "Doing A", Status: StatusInProgress},
+			{Content: "B", ActiveForm: "Doing B", Status: StatusInProgress},
+		}}},
+		{"duplicate content", writeInput{Todos: []Item{
+			{Content: "A", ActiveForm: "Doing A", Status: StatusInProgress},
+			{Content: "A", ActiveForm: "Doing A again", Status: StatusPending},
+		}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tl.Call(ctx, mustMarshal(t, tc.in))
+			if err == nil {
+				t.Fatalf("expected validation error")
+			}
+		})
+	}
+}
+
+func TestCall_MalformedJSON(t *testing.T) {
+	ctx, _ := newTestCtx("")
+	tl := New()
+	if _, err := tl.Call(ctx, []byte("{not json")); err == nil {
+		t.Fatalf("expected json error")
+	}
+}
+
+func TestCall_NoInvocationContext(t *testing.T) {
+	// Without an invocation the tool must still answer (with the nudge)
+	// but cannot persist state. Useful for smoke tests and SDK demos.
+	tl := New()
+	args := mustMarshal(t, writeInput{Todos: []Item{
+		{Content: "x", ActiveForm: "X", Status: StatusPending},
+	}})
+	res, err := tl.Call(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Call without invocation: %v", err)
+	}
+	if !strings.Contains(res.(Output).Message, "continue to use the todo list") {
+		t.Fatalf("expected nudge message, got %q", res.(Output).Message)
+	}
+}
+
+func TestStateKey(t *testing.T) {
+	cases := []struct {
+		prefix, branch, want string
+	}{
+		{"", "", DefaultStateKeyPrefix},
+		{"", "sub", DefaultStateKeyPrefix + ":sub"},
+		{"custom", "", "custom"},
+		{"custom", "b1", "custom:b1"},
+	}
+	for _, tc := range cases {
+		if got := stateKey(tc.prefix, tc.branch); got != tc.want {
+			t.Errorf("stateKey(%q,%q) = %q, want %q", tc.prefix, tc.branch, got, tc.want)
+		}
+	}
+}
+
+func TestGetTodos_NilAndEmpty(t *testing.T) {
+	if items, err := GetTodos(nil, ""); err != nil || items != nil {
+		t.Fatalf("nil session should return (nil,nil), got (%v,%v)", items, err)
+	}
+	sess := session.NewSession("a", "u", "s")
+	items, err := GetTodos(sess, "")
+	if err != nil || items != nil {
+		t.Fatalf("empty session should return (nil,nil), got (%v,%v)", items, err)
+	}
+}
+
+func TestGetTodos_CorruptState(t *testing.T) {
+	sess := session.NewSession("a", "u", "s")
+	sess.SetState(stateKey(DefaultStateKeyPrefix, ""), []byte("not-json"))
+	if _, err := GetTodos(sess, ""); err == nil {
+		t.Fatalf("expected decode error on corrupt state")
+	}
+}
+
+func TestStatus_IsValid(t *testing.T) {
+	for _, s := range []Status{StatusPending, StatusInProgress, StatusCompleted} {
+		if !s.IsValid() {
+			t.Errorf("%q should be valid", s)
+		}
+	}
+	if Status("done").IsValid() {
+		t.Errorf("'done' should be invalid")
+	}
+}
+
+func TestAllCompleted(t *testing.T) {
+	if allCompleted(nil) {
+		t.Errorf("empty should not be all-completed")
+	}
+	if allCompleted([]Item{{Status: StatusCompleted}, {Status: StatusPending}}) {
+		t.Errorf("mixed should not be all-completed")
+	}
+	if !allCompleted([]Item{{Status: StatusCompleted}, {Status: StatusCompleted}}) {
+		t.Errorf("all done should return true")
+	}
+}
+
+func TestWithNudgeMessage_Empty(t *testing.T) {
+	ctx, _ := newTestCtx("")
+	// Disable default nudge; hook provides the only text.
+	tl := New(
+		WithNudgeMessage(""),
+		WithNudgeHook(func(_ context.Context, _, _ []Item) string { return "ONLY_HOOK" }),
+	)
+	args := mustMarshal(t, writeInput{Todos: []Item{
+		{Content: "x", ActiveForm: "X", Status: StatusPending},
+	}})
+	res, err := tl.Call(ctx, args)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	msg := res.(Output).Message
+	if strings.Contains(msg, "continue to use the todo list") {
+		t.Fatalf("default nudge should be disabled, got %q", msg)
+	}
+	if !strings.Contains(msg, "ONLY_HOOK") {
+		t.Fatalf("hook output missing: %q", msg)
+	}
+}

--- a/tool/todo/todo_test.go
+++ b/tool/todo/todo_test.go
@@ -380,6 +380,130 @@ func TestAllCompleted(t *testing.T) {
 	}
 }
 
+// TestCall_NormalisesNullAndMissingTodos guards the second entry path
+// for the "todos must never marshal to null" contract: the one where
+// the LLM sends `{"todos": null}` or omits the field entirely. A plain
+// json.Unmarshal leaves Todos nil, which would then round-trip through
+// validation (empty list is legal) and marshal back to "null". Both
+// Call() and StateDeltaForInvocation() must coerce nil -> []Item{} so
+// that Output.Todos and the persisted state stay consistent with the
+// declared array schema.
+func TestCall_NormalisesNullAndMissingTodos(t *testing.T) {
+	inputs := map[string][]byte{
+		"null_todos":    []byte(`{"todos": null}`),
+		"missing_field": []byte(`{}`),
+	}
+	for name, args := range inputs {
+		t.Run(name, func(t *testing.T) {
+			ctx, sess := newTestCtx("")
+			tl := New()
+
+			res, err := tl.Call(ctx, args)
+			if err != nil {
+				t.Fatalf("Call: %v", err)
+			}
+			out, ok := res.(Output)
+			if !ok {
+				t.Fatalf("unexpected result type: %T", res)
+			}
+			if out.Todos == nil {
+				t.Fatalf("Output.Todos must be non-nil, got nil")
+			}
+			if len(out.Todos) != 0 {
+				t.Fatalf("Output.Todos must be empty, got %#v", out.Todos)
+			}
+			blob, err := json.Marshal(out)
+			if err != nil {
+				t.Fatalf("marshal Output: %v", err)
+			}
+			if !strings.Contains(string(blob), `"todos":[]`) {
+				t.Fatalf("Output should serialise todos as [], got %s", blob)
+			}
+			if strings.Contains(string(blob), `"todos":null`) {
+				t.Fatalf("Output still serialises todos as null: %s", blob)
+			}
+			// Persisted state (in-run SetState) must also be the []
+			// encoding, not null.
+			key := stateKey(DefaultStateKeyPrefix, "")
+			raw, ok := sess.GetState(key)
+			if !ok {
+				t.Fatalf("expected persisted state at %q", key)
+			}
+			if string(raw) != "[]" {
+				t.Fatalf("persisted state = %q, want %q", raw, "[]")
+			}
+
+			// Canonical state delta must match (not "null").
+			inv, _ := agent.InvocationFromContext(ctx)
+			delta := tl.StateDeltaForInvocation(inv, "", args, nil)
+			deltaRaw, ok := delta[key]
+			if !ok {
+				t.Fatalf("StateDeltaForInvocation missing key %q", key)
+			}
+			if string(deltaRaw) != "[]" {
+				t.Fatalf("state delta = %q, want %q", deltaRaw, "[]")
+			}
+		})
+	}
+}
+
+// TestCall_HookMutationsDoNotCorruptSnapshot verifies that a
+// misbehaving NudgeHook cannot affect the returned Output or the
+// persisted state. Hooks declare themselves read-only (see
+// options.go), but the framework defends against contract violations
+// via shallow clones so a buggy hook only hurts itself.
+func TestCall_HookMutationsDoNotCorruptSnapshot(t *testing.T) {
+	ctx, sess := newTestCtx("")
+
+	// Seed an initial list so OldTodos is non-empty on the next call.
+	seedTool := New()
+	_, err := seedTool.Call(ctx, mustMarshal(t, writeInput{Todos: []Item{
+		{Content: "Alpha", ActiveForm: "Doing Alpha", Status: StatusPending},
+	}}))
+	if err != nil {
+		t.Fatalf("seed Call: %v", err)
+	}
+
+	tl := New(WithNudgeHook(func(_ context.Context, oldTodos, submitted []Item) string {
+		// Malicious hook: clobber both slices in place.
+		for i := range oldTodos {
+			oldTodos[i].Content = "MUTATED_OLD"
+		}
+		for i := range submitted {
+			submitted[i].Content = "MUTATED_NEW"
+		}
+		return "ack"
+	}))
+
+	args := mustMarshal(t, writeInput{Todos: []Item{
+		{Content: "Beta", ActiveForm: "Doing Beta", Status: StatusInProgress},
+	}})
+	res, err := tl.Call(ctx, args)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	out := res.(Output)
+
+	if len(out.Todos) != 1 || out.Todos[0].Content != "Beta" {
+		t.Fatalf("Output.Todos corrupted by hook: %#v", out.Todos)
+	}
+	if len(out.OldTodos) != 1 || out.OldTodos[0].Content != "Alpha" {
+		t.Fatalf("Output.OldTodos corrupted by hook: %#v", out.OldTodos)
+	}
+
+	// Persisted state must also still reflect the submitted "Beta",
+	// since the clone happens before any hook runs.
+	key := stateKey(DefaultStateKeyPrefix, "")
+	raw, _ := sess.GetState(key)
+	var persisted []Item
+	if err := json.Unmarshal(raw, &persisted); err != nil {
+		t.Fatalf("decode persisted state: %v", err)
+	}
+	if len(persisted) != 1 || persisted[0].Content != "Beta" {
+		t.Fatalf("persisted state corrupted by hook: %#v", persisted)
+	}
+}
+
 func TestWithNudgeMessage_Empty(t *testing.T) {
 	ctx, _ := newTestCtx("")
 	// Disable default nudge; hook provides the only text.

--- a/tool/todo/todo_test.go
+++ b/tool/todo/todo_test.go
@@ -380,15 +380,17 @@ func TestAllCompleted(t *testing.T) {
 	}
 }
 
-// TestCall_NormalisesNullAndMissingTodos guards the second entry path
-// for the "todos must never marshal to null" contract: the one where
-// the LLM sends `{"todos": null}` or omits the field entirely. A plain
-// json.Unmarshal leaves Todos nil, which would then round-trip through
-// validation (empty list is legal) and marshal back to "null". Both
-// Call() and StateDeltaForInvocation() must coerce nil -> []Item{} so
-// that Output.Todos and the persisted state stay consistent with the
-// declared array schema.
-func TestCall_NormalisesNullAndMissingTodos(t *testing.T) {
+// TestCall_RejectsNullAndMissingTodos pins down the strict-input
+// contract: a missing `todos` field or `{"todos": null}` payload is
+// refused at the edge instead of being silently treated as "clear all".
+// The destructive shape (wipe the entire checklist) must be reachable
+// only via an explicit empty array, see
+// TestCall_AcceptsExplicitEmptyArrayClear.
+//
+// Beyond the error path we also verify that the rejection is total:
+// no in-run state was written, no canonical state delta is published,
+// and any pre-existing list in the session is left intact.
+func TestCall_RejectsNullAndMissingTodos(t *testing.T) {
 	inputs := map[string][]byte{
 		"null_todos":    []byte(`{"todos": null}`),
 		"missing_field": []byte(`{}`),
@@ -398,52 +400,110 @@ func TestCall_NormalisesNullAndMissingTodos(t *testing.T) {
 			ctx, sess := newTestCtx("")
 			tl := New()
 
-			res, err := tl.Call(ctx, args)
-			if err != nil {
-				t.Fatalf("Call: %v", err)
+			// Seed a real plan so we can prove the rejection does
+			// not collateral-damage prior state.
+			seedArgs := mustMarshal(t, writeInput{Todos: []Item{
+				{Content: "Keep me", ActiveForm: "Keeping me", Status: StatusInProgress},
+			}})
+			if _, err := tl.Call(ctx, seedArgs); err != nil {
+				t.Fatalf("seed Call: %v", err)
 			}
-			out, ok := res.(Output)
-			if !ok {
-				t.Fatalf("unexpected result type: %T", res)
-			}
-			if out.Todos == nil {
-				t.Fatalf("Output.Todos must be non-nil, got nil")
-			}
-			if len(out.Todos) != 0 {
-				t.Fatalf("Output.Todos must be empty, got %#v", out.Todos)
-			}
-			blob, err := json.Marshal(out)
-			if err != nil {
-				t.Fatalf("marshal Output: %v", err)
-			}
-			if !strings.Contains(string(blob), `"todos":[]`) {
-				t.Fatalf("Output should serialise todos as [], got %s", blob)
-			}
-			if strings.Contains(string(blob), `"todos":null`) {
-				t.Fatalf("Output still serialises todos as null: %s", blob)
-			}
-			// Persisted state (in-run SetState) must also be the []
-			// encoding, not null.
 			key := stateKey(DefaultStateKeyPrefix, "")
-			raw, ok := sess.GetState(key)
+			before, ok := sess.GetState(key)
 			if !ok {
-				t.Fatalf("expected persisted state at %q", key)
-			}
-			if string(raw) != "[]" {
-				t.Fatalf("persisted state = %q, want %q", raw, "[]")
+				t.Fatalf("seed state missing at %q", key)
 			}
 
-			// Canonical state delta must match (not "null").
-			inv, _ := agent.InvocationFromContext(ctx)
-			delta := tl.StateDeltaForInvocation(inv, "", args, nil)
-			deltaRaw, ok := delta[key]
-			if !ok {
-				t.Fatalf("StateDeltaForInvocation missing key %q", key)
+			res, err := tl.Call(ctx, args)
+			if err == nil {
+				t.Fatalf("Call(%s) must reject, got Output=%#v", name, res)
 			}
-			if string(deltaRaw) != "[]" {
-				t.Fatalf("state delta = %q, want %q", deltaRaw, "[]")
+			if !strings.Contains(err.Error(), "todos") {
+				t.Fatalf("error must mention todos field, got %v", err)
+			}
+
+			after, ok := sess.GetState(key)
+			if !ok {
+				t.Fatalf("session state vanished after rejection")
+			}
+			if string(after) != string(before) {
+				t.Fatalf("session state mutated by a rejected call:\n  before=%s\n  after =%s",
+					before, after)
+			}
+
+			// The canonical state delta must also be empty: a
+			// rejected call must not publish anything.
+			inv, _ := agent.InvocationFromContext(ctx)
+			if delta := tl.StateDeltaForInvocation(inv, "", args, nil); delta != nil {
+				t.Fatalf("StateDeltaForInvocation must drop rejected input, got %v", delta)
 			}
 		})
+	}
+}
+
+// TestCall_AcceptsExplicitEmptyArrayClear documents the only
+// supported clear gesture: an explicit empty array. Compared with
+// TestCall_RejectsNullAndMissingTodos this is the symmetric "yes"
+// case — the destructive operation is reachable, but only when the
+// caller spells it out.
+func TestCall_AcceptsExplicitEmptyArrayClear(t *testing.T) {
+	ctx, sess := newTestCtx("")
+	tl := New()
+
+	// Seed a real plan first.
+	seedArgs := mustMarshal(t, writeInput{Todos: []Item{
+		{Content: "First", ActiveForm: "Doing first", Status: StatusInProgress},
+	}})
+	if _, err := tl.Call(ctx, seedArgs); err != nil {
+		t.Fatalf("seed Call: %v", err)
+	}
+
+	res, err := tl.Call(ctx, []byte(`{"todos": []}`))
+	if err != nil {
+		t.Fatalf("Call with explicit []: %v", err)
+	}
+	out, ok := res.(Output)
+	if !ok {
+		t.Fatalf("unexpected result type: %T", res)
+	}
+	if out.Todos == nil {
+		t.Fatalf("Output.Todos must be non-nil empty, got nil")
+	}
+	if len(out.Todos) != 0 {
+		t.Fatalf("Output.Todos must be empty, got %#v", out.Todos)
+	}
+	if len(out.OldTodos) != 1 || out.OldTodos[0].Content != "First" {
+		t.Fatalf("Output.OldTodos should reflect prior state, got %#v", out.OldTodos)
+	}
+
+	blob, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("marshal Output: %v", err)
+	}
+	if !strings.Contains(string(blob), `"todos":[]`) {
+		t.Fatalf("Output must serialise todos as [], got %s", blob)
+	}
+	if strings.Contains(string(blob), `"todos":null`) {
+		t.Fatalf("Output must not serialise todos as null: %s", blob)
+	}
+
+	key := stateKey(DefaultStateKeyPrefix, "")
+	raw, ok := sess.GetState(key)
+	if !ok {
+		t.Fatalf("expected persisted state at %q", key)
+	}
+	if string(raw) != "[]" {
+		t.Fatalf("persisted state = %q, want %q", raw, "[]")
+	}
+
+	inv, _ := agent.InvocationFromContext(ctx)
+	delta := tl.StateDeltaForInvocation(inv, "", []byte(`{"todos": []}`), nil)
+	deltaRaw, ok := delta[key]
+	if !ok {
+		t.Fatalf("StateDeltaForInvocation missing key %q", key)
+	}
+	if string(deltaRaw) != "[]" {
+		t.Fatalf("state delta = %q, want %q", deltaRaw, "[]")
 	}
 }
 


### PR DESCRIPTION
## Summary
- add tool/todo, a CallableTool that lets the LLM declare and update a multi-step checklist (content / activeForm / status) in one call
- persist the checklist through StateDeltaForInvocation so it survives across Runner.Run invocations; scope it automatically by Invocation.Branch so parent and child agents never clobber each other
- surface structured data directly in the tool result (Output.Todos / Output.OldTodos) for in-stream consumption by frontends such as AG-UI, and expose todo.GetTodos / todo.GetTodosWithPrefix for server-side snapshot reads
- ship todo.DefaultToolPrompt for the agent's system instruction and a pluggable NudgeHook mechanism for policy callbacks
- enforce a small hard contract in validateTodos (at-most-one in_progress, unique content, valid status / non-empty fields); all other discipline stays in the prompt
- add examples/todo with a multi-turn chat demo, a pause / ask / resume scenario, and both consumption patterns (decoding Output from the tool event vs. reading session state with GetTodos)