### PR TITLE
{agent,processor,openclaw,docs}: gate oversized tool result truncation behind EnableContextCompaction

### DIFF
--- a/agent/graphagent/option.go
+++ b/agent/graphagent/option.go
@@ -136,8 +136,12 @@ type Options struct {
 	ContextCompactionKeepRecentRequests int
 	// ContextCompactionOversizedToolResultMaxTokens sets the token threshold
 	// above which any tool result (including from the current request) is
-	// truncated using head+tail preservation. Fires regardless of
-	// EnableContextCompaction. 0 disables it.
+	// truncated using head+tail preservation. Like Pass 1, this also requires
+	// EnableContextCompaction=true to take effect; it will not fire when
+	// context compaction is disabled, even if a positive threshold is
+	// configured. 0 disables it regardless of EnableContextCompaction.
+	// Default is 0; the recommended value to pass when opting in is
+	// processor.DefaultContextCompactionOversizedToolResultMaxTokens (8192).
 	ContextCompactionOversizedToolResultMaxTokens int
 	// summaryFormatter allows custom formatting of session summary content.
 	// When nil (default), uses default formatSummaryContent function.
@@ -169,10 +173,15 @@ type Options struct {
 
 var (
 	defaultOptions = Options{
-		ChannelBufferSize:                             defaultChannelBufferSize,
-		ContextCompactionToolResultMaxTokens:          processor.DefaultContextCompactionToolResultMaxTokens,
-		ContextCompactionKeepRecentRequests:           processor.DefaultContextCompactionKeepRecentRequests,
-		ContextCompactionOversizedToolResultMaxTokens: processor.DefaultContextCompactionOversizedToolResultMaxTokens,
+		ChannelBufferSize:                    defaultChannelBufferSize,
+		ContextCompactionToolResultMaxTokens: processor.DefaultContextCompactionToolResultMaxTokens,
+		ContextCompactionKeepRecentRequests:  processor.DefaultContextCompactionKeepRecentRequests,
+		// Pass 2 is opt-in. Defaulting to 0 keeps EnableContextCompaction=false
+		// truly equivalent to "framework does not modify tool results". Users
+		// who want the head+tail truncation safety net should explicitly call
+		// WithContextCompactionOversizedToolResultMaxTokens (the recommended
+		// value is processor.DefaultContextCompactionOversizedToolResultMaxTokens).
+		ContextCompactionOversizedToolResultMaxTokens: 0,
 	}
 )
 
@@ -300,7 +309,13 @@ func WithContextCompactionKeepRecentRequests(n int) Option {
 
 // WithContextCompactionOversizedToolResultMaxTokens sets the token threshold
 // above which any tool result (including from the current request) is truncated
-// using head+tail preservation. Fires regardless of EnableContextCompaction.
+// using head+tail preservation. Like Pass 1, this requires
+// WithEnableContextCompaction(true) to take effect; the framework will not
+// modify tool results when context compaction is disabled, even if a positive
+// threshold is configured here. 0 disables it regardless of
+// EnableContextCompaction. The default is 0; the recommended value to pass
+// when opting in is processor.DefaultContextCompactionOversizedToolResultMaxTokens
+// (8192).
 func WithContextCompactionOversizedToolResultMaxTokens(tokens int) Option {
 	return func(opts *Options) {
 		if tokens >= 0 {

--- a/agent/llmagent/option.go
+++ b/agent/llmagent/option.go
@@ -150,11 +150,16 @@ var (
 
 		SkipSkillsFallbackOnSessionSummary: true,
 
-		EnableContextCompaction:                       false,
-		ContextCompactionThresholdRatio:               0.7,
-		ContextCompactionToolResultMaxTokens:          processor.DefaultContextCompactionToolResultMaxTokens,
-		ContextCompactionKeepRecentRequests:           processor.DefaultContextCompactionKeepRecentRequests,
-		ContextCompactionOversizedToolResultMaxTokens: processor.DefaultContextCompactionOversizedToolResultMaxTokens,
+		EnableContextCompaction:              false,
+		ContextCompactionThresholdRatio:      0.7,
+		ContextCompactionToolResultMaxTokens: processor.DefaultContextCompactionToolResultMaxTokens,
+		ContextCompactionKeepRecentRequests:  processor.DefaultContextCompactionKeepRecentRequests,
+		// Pass 2 is opt-in. Defaulting to 0 keeps EnableContextCompaction=false
+		// truly equivalent to "framework does not modify tool results". Users
+		// who want the head+tail truncation safety net should explicitly call
+		// WithContextCompactionOversizedToolResultMaxTokens (the recommended
+		// value is processor.DefaultContextCompactionOversizedToolResultMaxTokens).
+		ContextCompactionOversizedToolResultMaxTokens: 0,
 
 		skillRunRequireSkillLoaded: true,
 	}
@@ -301,8 +306,12 @@ type Options struct {
 	ContextCompactionKeepRecentRequests int
 	// ContextCompactionOversizedToolResultMaxTokens sets the token threshold
 	// above which any tool result (including from the current request) is
-	// truncated using head+tail preservation. This fires regardless of
-	// EnableContextCompaction. 0 disables it.
+	// truncated using head+tail preservation. Like Pass 1, this also requires
+	// EnableContextCompaction=true to take effect; it will not fire when
+	// context compaction is disabled, even if a positive threshold is
+	// configured. 0 disables it regardless of EnableContextCompaction.
+	// Default is 0; the recommended value to pass when opting in is
+	// processor.DefaultContextCompactionOversizedToolResultMaxTokens (8192).
 	ContextCompactionOversizedToolResultMaxTokens int
 	// summaryFormatter allows custom formatting of session summary content.
 	// When nil (default), uses the default formatSummaryContent function.
@@ -1199,8 +1208,13 @@ func WithContextCompactionKeepRecentRequests(n int) Option {
 
 // WithContextCompactionOversizedToolResultMaxTokens sets the token threshold
 // above which any tool result (including from the current request) is truncated
-// using head+tail preservation. This fires regardless of
-// EnableContextCompaction. 0 disables it.
+// using head+tail preservation. Like Pass 1, this requires
+// WithEnableContextCompaction(true) to take effect; the framework will not
+// modify tool results when context compaction is disabled, even if a positive
+// threshold is configured here. 0 disables it regardless of
+// EnableContextCompaction. The default is 0; the recommended value to pass
+// when opting in is processor.DefaultContextCompactionOversizedToolResultMaxTokens
+// (8192).
 func WithContextCompactionOversizedToolResultMaxTokens(tokens int) Option {
 	return func(opts *Options) {
 		if tokens >= 0 {

--- a/docs/mkdocs/en/session.md
+++ b/docs/mkdocs/en/session.md
@@ -1788,8 +1788,8 @@ The framework provides two distinct modes for managing conversation context sent
 When `WithEnableContextCompaction(true)` is enabled, the framework adds a lightweight Phase 1 compaction pass before the LLM call:
 
 - **Pass 1** — Historical tool results from older requests that exceed `ContextCompactionToolResultMaxTokens` (default 1024 tokens) are replaced with a placeholder while keeping `ToolID` and `ToolName`.
-- **Pass 2** — Any single tool result (including the current request) exceeding `ContextCompactionOversizedToolResultMaxTokens` (default 8192 tokens) is truncated using head+tail preservation with a `[...N characters truncated...]` marker. Pass 2 fires independently of `EnableContextCompaction`.
-- The latest `ContextCompactionKeepRecentRequests` completed requests are exempt from Pass 1 (but not Pass 2).
+- **Pass 2** — Any single tool result (including the current request) exceeding `ContextCompactionOversizedToolResultMaxTokens` is truncated using head+tail preservation with a `[...N characters truncated...]` marker. **Disabled by default (value `0`)** — you must explicitly call `WithContextCompactionOversizedToolResultMaxTokens(...)` and keep `WithEnableContextCompaction(true)` for Pass 2 to fire (recommended opt-in value: 8192 tokens).
+- The latest `ContextCompactionKeepRecentRequests` completed requests are exempt from Pass 1 (but if Pass 2 is opted into, they remain subject to Pass 2 truncation).
 - If `WithAddSessionSummary(true)` is also enabled and the rebuilt request still approaches the model context window, the framework performs one synchronous `CreateSessionSummary(...)` retry before calling the model.
 - Model-layer token tailoring remains the final fallback.
 
@@ -1811,7 +1811,7 @@ llmAgent := llmagent.New(
 - No summary is prepended.
 - Only the **most recent `MaxHistoryRuns` conversation turns** are included.
 - When `MaxHistoryRuns=0` (default), no limit is applied and all history is included.
-- If `WithEnableContextCompaction(true)` is enabled, oversized tool results in older retained requests can still be compacted (Pass 1) and extremely large tool results in any request can be head+tail truncated (Pass 2) during request projection.
+- If `WithEnableContextCompaction(true)` is enabled, oversized tool results in older retained requests can still be compacted (Pass 1). If you additionally call `WithContextCompactionOversizedToolResultMaxTokens(8192)` (or another positive value), extremely large tool results in any request will be head+tail truncated (Pass 2). Both passes require the `EnableContextCompaction=true` master switch.
 - The pre-LLM synchronous summary retry is disabled in this mode.
 - Use this mode for short sessions or when you want direct control over context window size.
 

--- a/docs/mkdocs/en/session/index.md
+++ b/docs/mkdocs/en/session/index.md
@@ -80,8 +80,9 @@ func main() {
         llmagent.WithAddSessionSummary(true),
         // Optional: compact oversized historical tool results before the LLM call
         // WithAddSessionSummary(true) additionally enables one sync summary retry when needed
-        llmagent.WithEnableContextCompaction(true),
+        llmagent.WithEnableContextCompaction(true), // master switch for both Pass 1 and Pass 2
         llmagent.WithContextCompactionToolResultMaxTokens(1024),  // old tool results → placeholder
+        // Pass 2 is disabled by default; opt in with a positive threshold (recommended: 8192)
         llmagent.WithContextCompactionOversizedToolResultMaxTokens(8192),  // any huge result → head+tail truncation
         llmagent.WithContextCompactionKeepRecentRequests(1),
         // Note: WithAddSessionSummary(true) ignores WithMaxHistoryRuns

--- a/docs/mkdocs/en/session/summary.md
+++ b/docs/mkdocs/en/session/summary.md
@@ -708,7 +708,7 @@ When `WithEnableContextCompaction(true)` is enabled, the framework adds two comp
 - The current request and the latest `ContextCompactionKeepRecentRequests` completed requests are never affected
 - This cleans up accumulated long tool outputs from earlier conversation turns
 
-**Pass 2 — Oversized tool result truncation** (`ContextCompactionOversizedToolResultMaxTokens`, default 8192 tokens):
+**Pass 2 — Oversized tool result truncation** (`ContextCompactionOversizedToolResultMaxTokens`, **default 0 / disabled**):
 
 - Applies to **all** tool results including the current request
 - Tool results exceeding this threshold are truncated using head+tail preservation: the beginning and end of the content are kept, with a `[...N characters truncated...]` marker in the middle
@@ -716,9 +716,7 @@ When `WithEnableContextCompaction(true)` is enabled, the framework adds two comp
 
 The two passes have different roles: Pass 1 aggressively cleans old history (low threshold, full replacement); Pass 2 is a high-threshold guard that only kicks in for extreme cases but protects the current request too.
 
-Additionally:
-
-Pass 2 fires regardless of `EnableContextCompaction`; it only requires `ContextCompactionOversizedToolResultMaxTokens > 0`.
+Pass 2 is disabled by default (`0`). It only fires when both (1) `WithEnableContextCompaction(true)` is set and (2) `ContextCompactionOversizedToolResultMaxTokens > 0` (recommended opt-in value: `8192`, exposed as the constant `processor.DefaultContextCompactionOversizedToolResultMaxTokens`). This guarantees that `EnableContextCompaction=false` always means "the framework will not modify any tool result".
 
 Additionally:
 
@@ -773,7 +771,7 @@ llmagent.WithMaxHistoryRuns(10)
 - No summary message added
 - Only includes the most recent `MaxHistoryRuns` conversation turns
 - `MaxHistoryRuns=0` means no limit, includes all history
-- If `WithEnableContextCompaction(true)` is enabled, oversized tool results in older retained requests can still be compacted during request projection; additionally, extremely large tool results in any request (including the current one) will be head+tail truncated whenever `ContextCompactionOversizedToolResultMaxTokens > 0` (this fires even without `EnableContextCompaction`)
+- If `WithEnableContextCompaction(true)` is enabled, oversized tool results in older retained requests can still be compacted during request projection (Pass 1). If you also explicitly set `WithContextCompactionOversizedToolResultMaxTokens(8192)` (or another positive value), extremely large tool results in any request (including the current one) will be head+tail truncated (Pass 2). Both passes require the `EnableContextCompaction=true` master switch.
 - The pre-LLM synchronous summary retry is disabled in this mode
 
 **Context structure**:
@@ -800,7 +798,7 @@ llmagent.WithMaxHistoryRuns(10)
 
 If your long sessions frequently contain large tool outputs such as search results, logs, or code scan output, enable `EnableContextCompaction=true`. Pair it with `AddSessionSummary=true` when you also want the pre-LLM synchronous summary retry.
 
-> **Tip**: If your agent uses tools like `web_fetch` that can return extremely large results in a single call, `ContextCompactionOversizedToolResultMaxTokens` is particularly valuable — it prevents a single tool result from consuming the entire context window, even when that result belongs to the current (protected) request. It fires independently of `EnableContextCompaction`.
+> **Tip**: If your agent uses tools like `web_fetch` that can return extremely large results in a single call, `ContextCompactionOversizedToolResultMaxTokens` is particularly valuable — it prevents a single tool result from consuming the entire context window, even when that result belongs to the current (protected) request. It is **disabled by default**; opt in by enabling `WithEnableContextCompaction(true)` and passing a positive threshold (recommended: `8192`).
 
 ## Summary Format Customization
 

--- a/docs/mkdocs/zh/session.md
+++ b/docs/mkdocs/zh/session.md
@@ -1873,8 +1873,8 @@ llmagent.WithAddSessionSummary(true)
 当开启 `WithEnableContextCompaction(true)` 时，框架会在真正调用模型前执行两遍压缩：
 
 - **Pass 1** — 旧 request 中超过 `ContextCompactionToolResultMaxTokens`（默认 1024 tokens）的 tool result 整体替换为占位符，保留 `ToolID` 和 `ToolName`
-- **Pass 2** — 任意 request（包括当前 request）中超过 `ContextCompactionOversizedToolResultMaxTokens`（默认 8192 tokens）的单个 tool result，使用首尾保留策略截断，中间插入 `[...N characters truncated...]` 标记。Pass 2 独立于 `EnableContextCompaction`，只要设置了值就会生效
-- 最近 `ContextCompactionKeepRecentRequests` 个已完成 request 不受 Pass 1 影响（但 Pass 2 仍会生效）
+- **Pass 2** — 任意 request（包括当前 request）中超过 `ContextCompactionOversizedToolResultMaxTokens` 的单个 tool result，使用首尾保留策略截断，中间插入 `[...N characters truncated...]` 标记。**默认值为 0（关闭）**，需要显式调用 `WithContextCompactionOversizedToolResultMaxTokens(...)` 并保持 `WithEnableContextCompaction(true)` 才会生效（推荐值 8192 tokens）
+- 最近 `ContextCompactionKeepRecentRequests` 个已完成 request 不受 Pass 1 影响（如果同时开启了 Pass 2，仍会受 Pass 2 截断）
 - 如果同时开启了 `WithAddSessionSummary(true)`，并且压完后请求仍接近 context window，会在 LLM 调用前同步执行一次 `CreateSessionSummary(...)` 并重建 request
 - 模型层的 token tailoring 仍然作为最后兜底
 
@@ -1920,7 +1920,7 @@ llmagent.WithMaxHistoryRuns(10)  // 限制历史轮次
 - 不添加摘要消息
 - 只包含最近 `MaxHistoryRuns` 轮对话
 - `MaxHistoryRuns=0` 时不限制，包含所有历史
-- 如果开启 `WithEnableContextCompaction(true)`，旧 request 中超长 tool result 仍可在 request projection 阶段被压缩（Pass 1），同时任意 request 中的超大 tool result 也会被首尾保留截断（Pass 2）
+- 如果开启 `WithEnableContextCompaction(true)`，旧 request 中超长 tool result 会在 request projection 阶段被压缩（Pass 1）；如果同时显式设置 `WithContextCompactionOversizedToolResultMaxTokens(8192)`（或其他正值），任意 request 中的超大 tool result 也会被首尾保留截断（Pass 2）
 - 这个模式下不会触发 pre-LLM 的同步摘要重试
 
 **上下文结构：**

--- a/docs/mkdocs/zh/session.md
+++ b/docs/mkdocs/zh/session.md
@@ -1870,7 +1870,7 @@ llmagent.WithAddSessionSummary(true)
 
 **可选：Prompt 侧上下文压缩**
 
-当开启 `WithEnableContextCompaction(true)` 时，框架会在真正调用模型前执行两遍压缩：
+当开启 `WithEnableContextCompaction(true)` 时，框架会在真正调用模型前执行 Pass 1 压缩；如果同时显式配置正数的 `ContextCompactionOversizedToolResultMaxTokens`，还会执行 Pass 2：
 
 - **Pass 1** — 旧 request 中超过 `ContextCompactionToolResultMaxTokens`（默认 1024 tokens）的 tool result 整体替换为占位符，保留 `ToolID` 和 `ToolName`
 - **Pass 2** — 任意 request（包括当前 request）中超过 `ContextCompactionOversizedToolResultMaxTokens` 的单个 tool result，使用首尾保留策略截断，中间插入 `[...N characters truncated...]` 标记。**默认值为 0（关闭）**，需要显式调用 `WithContextCompactionOversizedToolResultMaxTokens(...)` 并保持 `WithEnableContextCompaction(true)` 才会生效（推荐值 8192 tokens）

--- a/docs/mkdocs/zh/session/index.md
+++ b/docs/mkdocs/zh/session/index.md
@@ -78,9 +78,10 @@ func main() {
         llmagent.WithModel(llm),
         llmagent.WithInstruction("你是一个智能助手"),
         llmagent.WithAddSessionSummary(true), // 可选：启用摘要注入到上下文
-        llmagent.WithEnableContextCompaction(true), // 可选：压缩历史超长 tool result
+        llmagent.WithEnableContextCompaction(true), // 可选：压缩历史超长 tool result（Pass 1 + Pass 2 的总开关）
         // 配合 WithAddSessionSummary(true) 时，还会在必要时多一次同步摘要重试
         llmagent.WithContextCompactionToolResultMaxTokens(1024),  // 旧 tool result → 占位符
+        // Pass 2 默认关闭，需要显式设置一个正阈值才会生效（推荐 8192）
         llmagent.WithContextCompactionOversizedToolResultMaxTokens(8192),  // 超大 result → 首尾保留截断
         llmagent.WithContextCompactionKeepRecentRequests(1),
         // 注意：WithAddSessionSummary(true) 时会忽略 WithMaxHistoryRuns 配置

--- a/docs/mkdocs/zh/session/summary.md
+++ b/docs/mkdocs/zh/session/summary.md
@@ -711,7 +711,7 @@ agent := llmagent.New(
 - 当前 request 和最近 `ContextCompactionKeepRecentRequests` 个已完成 request 不受影响
 - 适合清理已不重要的历史工具输出
 
-**Pass 2 — 超大 tool result 截断**（`ContextCompactionOversizedToolResultMaxTokens`，默认 8192 tokens）：
+**Pass 2 — 超大 tool result 截断**（`ContextCompactionOversizedToolResultMaxTokens`，**默认 0 / 关闭**）：
 
 - 作用于**所有 tool result，包括当前 request 的**
 - 超过阈值的 tool result 会使用首尾保留策略截断：保留内容的开头和结尾，中间插入 `[...N characters truncated...]` 标记
@@ -719,7 +719,7 @@ agent := llmagent.New(
 
 两遍压缩的定位不同：Pass 1 低阈值、全量替换，激进清理旧历史；Pass 2 高阈值、只在极端情况触发，但能保护当前 request。
 
-Pass 2 独立于 `EnableContextCompaction`，只要 `ContextCompactionOversizedToolResultMaxTokens > 0` 就会生效。
+Pass 2 默认是关闭的（`0`），需要满足两个条件才会生效：(1) `WithEnableContextCompaction(true)` 总开关已打开；(2) `ContextCompactionOversizedToolResultMaxTokens > 0`（推荐显式传入 `8192`，可读取常量 `processor.DefaultContextCompactionOversizedToolResultMaxTokens`）。这样 `EnableContextCompaction=false` 在语义上始终等于"框架不会修改任何 tool result"。
 
 此外：
 
@@ -774,7 +774,7 @@ llmagent.WithMaxHistoryRuns(10)  // 限制历史轮次
 - 不添加摘要消息
 - 只包含最近 `MaxHistoryRuns` 轮对话
 - `MaxHistoryRuns=0` 时不限制，包含所有历史
-- 如果开启 `WithEnableContextCompaction(true)`，保留下来的旧 request 中超长 `tool result` 仍可在 request projection 阶段被压缩；此外只要 `ContextCompactionOversizedToolResultMaxTokens > 0`（即使未开启 `EnableContextCompaction`），任意 request 中的超大 tool result 也会被首尾保留截断
+- 如果开启 `WithEnableContextCompaction(true)`，保留下来的旧 request 中超长 `tool result` 会在 request projection 阶段被压缩（Pass 1）；如果同时显式设置 `WithContextCompactionOversizedToolResultMaxTokens(8192)`（或其他正值），任意 request 中的超大 tool result 会被首尾保留截断（Pass 2）。两者都需要 `EnableContextCompaction=true` 总开关
 - 这个模式下不会触发 pre-LLM 的同步摘要重试
 
 **上下文结构**：
@@ -801,7 +801,7 @@ llmagent.WithMaxHistoryRuns(10)  // 限制历史轮次
 
 如果你的长会话里经常出现搜索结果、日志、代码扫描输出这类长 `tool result`，建议开启 `EnableContextCompaction=true`。如果你还希望在接近 context window 时多一次同步摘要兜底，再配合 `AddSessionSummary=true` 一起使用。
 
-> **提示**：如果你的 agent 使用了 `web_fetch` 等可能单次返回超大结果的工具，`ContextCompactionOversizedToolResultMaxTokens` 尤为重要——它能防止单个 tool result 吃光整个 context window，即使该 result 属于当前正在处理的（受保护的）request。它独立于 `EnableContextCompaction`，默认开启。
+> **提示**：如果你的 agent 使用了 `web_fetch` 等可能单次返回超大结果的工具，`ContextCompactionOversizedToolResultMaxTokens` 尤为重要——它能防止单个 tool result 吃光整个 context window，即使该 result 属于当前正在处理的（受保护的）request。它**默认关闭**，需要显式开启 `WithEnableContextCompaction(true)` 并设置一个正阈值（推荐 `8192`）才会生效。
 
 ## 摘要格式自定义
 

--- a/internal/flow/processor/content.go
+++ b/internal/flow/processor/content.go
@@ -1400,7 +1400,8 @@ func (p *ContentRequestProcessor) projectMessagesForEvent(
 func (p *ContentRequestProcessor) truncateOversizedToolResultMessages(
 	messages []model.Message,
 ) []model.Message {
-	if p.ContextCompactionConfig.OversizedToolResultMaxTokens <= 0 {
+	if !p.ContextCompactionConfig.Enabled ||
+		p.ContextCompactionConfig.OversizedToolResultMaxTokens <= 0 {
 		return messages
 	}
 

--- a/internal/flow/processor/content.go
+++ b/internal/flow/processor/content.go
@@ -380,8 +380,9 @@ func WithContextCompactionToolResultMaxTokens(tokens int) ContentOption {
 
 // WithContextCompactionOversizedToolResultMaxTokens sets the token threshold
 // above which any tool result (including from the current request) is truncated
-// using head+tail preservation. This safety net fires regardless of whether
-// EnableContextCompaction is set.
+// using head+tail preservation. Like Pass 1, this requires
+// EnableContextCompaction=true to take effect, so EnableContextCompaction=false
+// guarantees the framework will not modify tool results.
 func WithContextCompactionOversizedToolResultMaxTokens(tokens int) ContentOption {
 	return func(p *ContentRequestProcessor) {
 		p.ContextCompactionConfig.OversizedToolResultMaxTokens = tokens
@@ -436,9 +437,12 @@ func NewContentRequestProcessor(opts ...ContentOption) *ContentRequestProcessor 
 		PreloadSessionRecall:           0,
 		PreloadSessionRecallSearchMode: session.SearchModeHybrid,
 		ContextCompactionConfig: ContextCompactionConfig{
-			KeepRecentRequests:           DefaultContextCompactionKeepRecentRequests,
-			ToolResultMaxTokens:          DefaultContextCompactionToolResultMaxTokens,
-			OversizedToolResultMaxTokens: DefaultContextCompactionOversizedToolResultMaxTokens,
+			KeepRecentRequests:  DefaultContextCompactionKeepRecentRequests,
+			ToolResultMaxTokens: DefaultContextCompactionToolResultMaxTokens,
+			// Pass 2 is opt-in: callers must explicitly set a positive value
+			// AND enable context compaction. Defaulting to 0 keeps the
+			// processor from silently rewriting tool results.
+			OversizedToolResultMaxTokens: 0,
 		},
 	}
 

--- a/internal/flow/processor/content_test.go
+++ b/internal/flow/processor/content_test.go
@@ -1628,9 +1628,10 @@ func TestNewContentRequestProcessor(t *testing.T) {
 		PreloadMemory:                  0, // Default to disable preloading.
 		PreloadSessionRecallSearchMode: session.SearchModeHybrid,
 		ContextCompactionConfig: ContextCompactionConfig{
-			KeepRecentRequests:           DefaultContextCompactionKeepRecentRequests,
-			ToolResultMaxTokens:          DefaultContextCompactionToolResultMaxTokens,
-			OversizedToolResultMaxTokens: DefaultContextCompactionOversizedToolResultMaxTokens,
+			KeepRecentRequests:  DefaultContextCompactionKeepRecentRequests,
+			ToolResultMaxTokens: DefaultContextCompactionToolResultMaxTokens,
+			// Pass 2 is opt-in; see WithContextCompactionOversizedToolResultMaxTokens.
+			OversizedToolResultMaxTokens: 0,
 		},
 	}
 

--- a/internal/flow/processor/content_test.go
+++ b/internal/flow/processor/content_test.go
@@ -2543,6 +2543,79 @@ func TestContentRequestProcessor_IncludeContentsNoneTruncatesOversizedToolResult
 	require.True(t, strings.HasSuffix(req.Messages[2].Content, "-TAIL"))
 }
 
+// TestContentRequestProcessor_IncludeContentsNoneRequiresEnabledForOversizedTruncation
+// asserts that the include_contents=none path leaves oversized tool results
+// untouched when EnableContextCompaction is false, even if a positive
+// OversizedToolResultMaxTokens threshold is configured.
+func TestContentRequestProcessor_IncludeContentsNoneRequiresEnabledForOversizedTruncation(t *testing.T) {
+	p := NewContentRequestProcessor(
+		WithContextCompactionOversizedToolResultMaxTokens(32),
+	)
+
+	original := "HEAD-" + strings.Repeat("middle-", 400) + "-TAIL"
+	sess := &session.Session{
+		EventMu: sync.RWMutex{},
+		Events: []event.Event{
+			{
+				Author:       "assistant",
+				RequestID:    "req-1",
+				InvocationID: "inv-1",
+				Response: &model.Response{
+					Choices: []model.Choice{
+						{
+							Message: model.Message{
+								Role: model.RoleAssistant,
+								ToolCalls: []model.ToolCall{
+									{
+										ID: "call-1",
+										Function: model.FunctionDefinitionParam{
+											Name:      "fetch",
+											Arguments: []byte(`{}`),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Author:       "tool",
+				RequestID:    "req-1",
+				InvocationID: "inv-1",
+				Response: &model.Response{
+					Object: model.ObjectTypeToolResponse,
+					Choices: []model.Choice{
+						{
+							Message: model.NewToolMessage("call-1", "fetch", original),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationID("inv-1"),
+		agent.WithInvocationMessage(model.NewUserMessage("current")),
+		agent.WithInvocationRunOptions(agent.RunOptions{
+			RequestID: "req-1",
+			RuntimeState: map[string]any{
+				"include_contents": "none",
+			},
+		}),
+	)
+
+	req := &model.Request{}
+	p.ProcessRequest(context.Background(), inv, req, nil)
+
+	require.Len(t, req.Messages, 3)
+	require.Equal(t, model.RoleTool, req.Messages[2].Role)
+	require.Equal(t, original, req.Messages[2].Content)
+	require.NotContains(t, req.Messages[2].Content, "[... ")
+}
+
 func TestContentRequestProcessor_getFilterIncrementMessages(t *testing.T) {
 	baseTime := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
 

--- a/internal/flow/processor/context_compact.go
+++ b/internal/flow/processor/context_compact.go
@@ -26,11 +26,16 @@ const (
 	// placeholder.
 	DefaultContextCompactionToolResultMaxTokens = 1024
 
-	// DefaultContextCompactionOversizedToolResultMaxTokens is the token
-	// threshold above which ANY tool result (including current request) is
-	// truncated to head+tail. This is the safety net for tool results so
-	// large they alone could overflow the context window (e.g. web_fetch
-	// returning 800K+ chars).
+	// DefaultContextCompactionOversizedToolResultMaxTokens is the recommended
+	// token threshold above which ANY tool result (including current request)
+	// is truncated to head+tail when Pass 2 is opted into.
+	//
+	// NOTE: this constant is only the suggested value to pass to
+	// WithContextCompactionOversizedToolResultMaxTokens; it is NOT applied
+	// automatically. Pass 2 only runs when both EnableContextCompaction is
+	// true and the threshold is greater than 0. The default for the option
+	// itself is 0 (disabled) so that EnableContextCompaction=false truly
+	// means "framework will not modify tool results".
 	DefaultContextCompactionOversizedToolResultMaxTokens = 8192
 
 	historicalToolResultPlaceholder = "Historical tool result omitted to save context."
@@ -44,8 +49,9 @@ type ContextCompactionConfig struct {
 	ToolResultMaxTokens int
 	// OversizedToolResultMaxTokens is the token threshold above which any tool
 	// result (including current-request results) is truncated using head+tail
-	// preservation. This safety net fires regardless of the Enabled flag.
-	// 0 disables it.
+	// preservation. Like Pass 1, this also requires Enabled=true; it will not
+	// fire when context compaction is turned off, even if a positive threshold
+	// is configured. 0 disables it regardless of Enabled.
 	OversizedToolResultMaxTokens int
 }
 
@@ -84,7 +90,7 @@ func compactIncrementEvents(
 	}
 
 	pass1Active := cfg.Enabled && cfg.ToolResultMaxTokens > 0
-	pass2Active := cfg.OversizedToolResultMaxTokens > 0
+	pass2Active := cfg.Enabled && cfg.OversizedToolResultMaxTokens > 0
 	if !pass1Active && !pass2Active {
 		return events, ContextCompactionStats{}
 	}
@@ -112,7 +118,9 @@ func compactIncrementEvents(
 	}
 
 	// Pass 2: oversized tool results (including current request) → head+tail
-	// truncation. This safety net fires independently of EnableContextCompaction.
+	// truncation. Gated on EnableContextCompaction together with Pass 1, so
+	// the framework never silently rewrites tool results when context
+	// compaction is disabled.
 	if pass2Active {
 		passEvents, passStats := applyOversizedToolResultPass(
 			ctx,

--- a/internal/flow/processor/context_compact_test.go
+++ b/internal/flow/processor/context_compact_test.go
@@ -332,6 +332,42 @@ func TestCompactIncrementEvents_Pass2WorksWithoutPass1Context(t *testing.T) {
 	require.Greater(t, stats.EstimatedTokensSaved, 0)
 }
 
+// TestCompactIncrementEvents_Pass2RequiresEnabled documents that Pass 2 is
+// gated on the EnableContextCompaction master switch. When Enabled=false the
+// framework must not modify tool results, even when a positive
+// OversizedToolResultMaxTokens is configured.
+func TestCompactIncrementEvents_Pass2RequiresEnabled(t *testing.T) {
+	content := "HEAD-" + strings.Repeat("middle-", 400) + "-TAIL"
+	evt := event.Event{
+		RequestID:    "req-current",
+		InvocationID: "inv-current",
+		FilterKey:    "test-agent",
+		Response: &model.Response{
+			Done: true,
+			Choices: []model.Choice{{
+				Message: model.NewToolMessage("tool-call-current", "worker", content),
+			}},
+		},
+	}
+
+	compacted, stats := compactIncrementEvents(
+		context.Background(),
+		[]event.Event{evt},
+		"req-current",
+		"inv-current",
+		ContextCompactionConfig{
+			Enabled:                      false,
+			OversizedToolResultMaxTokens: 32,
+		},
+	)
+
+	require.Len(t, compacted, 1)
+	require.Equal(t, content, compacted[0].Response.Choices[0].Message.Content,
+		"Pass 2 must not modify tool results when EnableContextCompaction is off")
+	require.Zero(t, stats.ToolResultsCompacted)
+	require.Zero(t, stats.EstimatedTokensSaved)
+}
+
 func TestTruncateOversizedToolResultMessage_PreservesContentParts(t *testing.T) {
 	partText := "structured payload"
 	msg := model.Message{

--- a/openclaw/app/run_options.go
+++ b/openclaw/app/run_options.go
@@ -24,7 +24,6 @@ import (
 	"gopkg.in/yaml.v3"
 
 	ia2a "trpc.group/trpc-go/trpc-agent-go/internal/a2a"
-	"trpc.group/trpc-go/trpc-agent-go/internal/flow/processor"
 	"trpc.group/trpc-go/trpc-agent-go/internal/skillprofile"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	ocskills "trpc.group/trpc-go/trpc-agent-go/openclaw/internal/skills"
@@ -378,8 +377,10 @@ func parseRunOptions(args []string) (runOptions, error) {
 	fs.IntVar(
 		&opts.ContextCompactionOversizedToolResultMaxTokens,
 		flagContextCompactionOversizedToolResultMaxTokens,
-		processor.DefaultContextCompactionOversizedToolResultMaxTokens,
-		"Truncate oversized tool results with head+tail preservation (0=disable)",
+		0,
+		"Truncate oversized tool results with head+tail preservation when "+
+			"context compaction is enabled (0=disable; recommended opt-in "+
+			"value is 8192). Requires --enable-context-compaction.",
 	)
 	fs.IntVar(
 		&opts.MaxHistoryRuns,


### PR DESCRIPTION
## Summary
- gate Pass 2 (oversized tool result head+tail truncation) on `EnableContextCompaction` so the framework no longer silently rewrites tool results when context compaction is disabled
- change `ContextCompactionOversizedToolResultMaxTokens` default from `8192` to `0` across `llmagent`, `graphagent`, the content processor and the OpenClaw flag, making Pass 2 strictly opt-in
- document the new gating in zh/en `session.md`, `session/summary.md` and `session/index.md`, and add unit coverage asserting Pass 2 stays inert when `Enabled=false`

## Why

Before this change, Pass 2 was active whenever `OversizedToolResultMaxTokens > 0`, completely independent of `EnableContextCompaction`. Combined with the 8192-token default value introduced in #1574, that meant any tool result larger than ~32K characters was silently truncated even when callers had `EnableContextCompaction=false`. This violated the natural "off means off" reading of the compaction switch and could surprise agents that legitimately need full tool outputs (RAG search, large diff/log readers, etc.).

After this change, Pass 2 follows the same opt-in shape as Pass 1: both require `EnableContextCompaction=true`, and Pass 2 additionally requires an explicitly configured positive `OversizedToolResultMaxTokens`. The recommended opt-in value remains `8192`, exposed as `processor.DefaultContextCompactionOversizedToolResultMaxTokens`.

## Behavior change

This is a user-visible behavior change for callers that already shipped on `v1.8.0` / `v1.8.1`, where Pass 2 was on by default. To preserve the old behavior, callers should explicitly set:

```go
llmagent.WithEnableContextCompaction(true)
llmagent.WithContextCompactionOversizedToolResultMaxTokens(
    processor.DefaultContextCompactionOversizedToolResultMaxTokens,
)
```

Most callers will benefit from the new opt-in default — the framework will no longer silently truncate tool results unless asked.

## Test plan
- [x] `go test ./internal/flow/processor ./agent/llmagent ./agent/graphagent`
- [x] `cd openclaw && go test ./app`
- [x] `golangci-lint run --timeout=5m ./internal/flow/processor/... ./agent/llmagent/... ./agent/graphagent/...`
- [x] `goimports -l` / `gofmt -l` clean on touched files