### PR TITLE
openclaw/admin: improve memory admin editing flow

### DIFF
--- a/openclaw/admin/memory.go
+++ b/openclaw/admin/memory.go
@@ -10,6 +10,7 @@
 package admin
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/base64"
 	"errors"
@@ -39,6 +40,33 @@ type MemoryFileStore interface {
 	ReadFile(path string, maxBytes int) (string, error)
 }
 
+type MemoryUserLabelResolver interface {
+	ResolveMemoryUserLabel(appName string, userID string) string
+}
+
+type MemoryUserLabelResolverFunc func(
+	appName string,
+	userID string,
+) string
+
+func (f MemoryUserLabelResolverFunc) ResolveMemoryUserLabel(
+	appName string,
+	userID string,
+) string {
+	if f == nil {
+		return ""
+	}
+	return f(appName, userID)
+}
+
+type memoryFileSaver interface {
+	SaveResolvedMemoryFile(
+		ctx context.Context,
+		path string,
+		content string,
+	) error
+}
+
 type memoryStatus struct {
 	Enabled      bool             `json:"enabled"`
 	FileEnabled  bool             `json:"file_enabled"`
@@ -54,6 +82,7 @@ type memoryStatus struct {
 type memoryFileView struct {
 	AppName      string    `json:"app_name,omitempty"`
 	UserID       string    `json:"user_id,omitempty"`
+	UserLabel    string    `json:"user_label,omitempty"`
 	RelativePath string    `json:"relative_path,omitempty"`
 	Path         string    `json:"path,omitempty"`
 	OpenURL      string    `json:"open_url,omitempty"`
@@ -68,6 +97,7 @@ type memoryFileView struct {
 type memoryFileDetail struct {
 	AppName      string    `json:"app_name,omitempty"`
 	UserID       string    `json:"user_id,omitempty"`
+	UserLabel    string    `json:"user_label,omitempty"`
 	RelativePath string    `json:"relative_path,omitempty"`
 	OpenURL      string    `json:"open_url,omitempty"`
 	LoadURL      string    `json:"load_url,omitempty"`
@@ -104,7 +134,11 @@ func (s *Service) memoryStatusWithFiles(includeFiles bool) memoryStatus {
 	out.FileEnabled = true
 	out.Root = root
 
-	files, err := memoryFileViews(s.cfg.MemoryFiles, includeFiles)
+	files, err := memoryFileViewsWithResolver(
+		s.cfg.MemoryFiles,
+		s.cfg.MemoryUserLabels,
+		includeFiles,
+	)
 	if err != nil {
 		out.Error = err.Error()
 		return out
@@ -143,6 +177,14 @@ func configuredMemoryRoot(
 
 func memoryFileViews(
 	store MemoryFileStore,
+	includePreview bool,
+) ([]memoryFileView, error) {
+	return memoryFileViewsWithResolver(store, nil, includePreview)
+}
+
+func memoryFileViewsWithResolver(
+	store MemoryFileStore,
+	resolver MemoryUserLabelResolver,
 	includePreview bool,
 ) ([]memoryFileView, error) {
 	root, configured, err := configuredMemoryRoot(store)
@@ -198,9 +240,15 @@ func memoryFileViews(
 			}
 			appName := decodeMemoryPathPart(appDir.Name())
 			userID := decodeMemoryPathPart(userDir.Name())
+			userLabel := resolveMemoryUserLabel(
+				resolver,
+				appName,
+				userID,
+			)
 			files = append(files, memoryFileView{
 				AppName:      appName,
 				UserID:       userID,
+				UserLabel:    userLabel,
 				RelativePath: rel,
 				Path:         filePath,
 				OpenURL: routeMemoryFile + "?" + url.Values{
@@ -213,6 +261,7 @@ func memoryFileViews(
 				SearchValue: buildMemorySearchValue(
 					appName,
 					userID,
+					userLabel,
 					rel,
 					preview,
 				),
@@ -292,18 +341,12 @@ func resolveMemoryFile(root string, relPath string) (string, error) {
 	if root == "" {
 		return "", fmt.Errorf("memory file store is not configured")
 	}
-	clean := filepath.Clean(filepath.FromSlash(strings.TrimSpace(relPath)))
-	if clean == "." || clean == "" {
-		return "", fmt.Errorf("memory file path is required")
-	}
-	if filepath.IsAbs(clean) || strings.HasPrefix(clean, "..") {
-		return "", fmt.Errorf("invalid memory file path")
-	}
-	if filepath.Base(clean) != memoryFileName {
-		return "", fmt.Errorf("unsupported memory file: %s", clean)
+	clean, err := normalizeMemoryRelativePath(relPath)
+	if err != nil {
+		return "", err
 	}
 
-	candidate := filepath.Join(root, clean)
+	candidate := filepath.Join(root, filepath.FromSlash(clean))
 	absRoot, err := filepath.Abs(root)
 	if err != nil {
 		return "", fmt.Errorf("resolve memory root: %w", err)
@@ -353,11 +396,42 @@ func resolveMemoryFile(root string, relPath string) (string, error) {
 	return absResolved, nil
 }
 
+func normalizeMemoryRelativePath(relPath string) (string, error) {
+	clean := filepath.Clean(
+		filepath.FromSlash(strings.TrimSpace(relPath)),
+	)
+	if clean == "." || clean == "" {
+		return "", fmt.Errorf("memory file path is required")
+	}
+	parentPrefix := ".." + string(filepath.Separator)
+	if filepath.IsAbs(clean) ||
+		clean == ".." ||
+		strings.HasPrefix(clean, parentPrefix) {
+		return "", fmt.Errorf("invalid memory file path")
+	}
+	if filepath.Base(clean) != memoryFileName {
+		return "", fmt.Errorf("unsupported memory file: %s", clean)
+	}
+	return filepath.ToSlash(clean), nil
+}
+
 func readMemoryFileDetail(
 	root string,
 	relPath string,
 ) (memoryFileDetail, error) {
-	filePath, err := resolveMemoryFile(root, relPath)
+	return readMemoryFileDetailWithResolver(root, relPath, nil)
+}
+
+func readMemoryFileDetailWithResolver(
+	root string,
+	relPath string,
+	resolver MemoryUserLabelResolver,
+) (memoryFileDetail, error) {
+	cleanRelPath, err := normalizeMemoryRelativePath(relPath)
+	if err != nil {
+		return memoryFileDetail{}, err
+	}
+	filePath, err := resolveMemoryFile(root, cleanRelPath)
 	if err != nil {
 		return memoryFileDetail{}, err
 	}
@@ -375,24 +449,18 @@ func readMemoryFileDetail(
 			err,
 		)
 	}
-	rel, err := filepath.Rel(root, filePath)
-	if err != nil {
-		return memoryFileDetail{}, fmt.Errorf(
-			"relativize memory file: %w",
-			err,
-		)
-	}
-	rel = filepath.ToSlash(rel)
-	appName, userID := memoryScopeFromRelativePath(rel)
+	appName, userID := memoryScopeFromRelativePath(cleanRelPath)
+	userLabel := resolveMemoryUserLabel(resolver, appName, userID)
 	return memoryFileDetail{
 		AppName:      appName,
 		UserID:       userID,
-		RelativePath: rel,
+		UserLabel:    userLabel,
+		RelativePath: cleanRelPath,
 		OpenURL: routeMemoryFile + "?" + url.Values{
-			queryPath: {rel},
+			queryPath: {cleanRelPath},
 		}.Encode(),
 		LoadURL: routeMemoryFileAPI + "?" + url.Values{
-			queryPath: {rel},
+			queryPath: {cleanRelPath},
 		}.Encode(),
 		Content:    string(raw),
 		SizeBytes:  info.Size(),
@@ -401,13 +469,21 @@ func readMemoryFileDetail(
 }
 
 func saveMemoryFile(
-	root string,
+	ctx context.Context,
+	store MemoryFileStore,
 	relPath string,
 	content string,
 ) error {
+	root, configured, err := configuredMemoryRoot(store)
+	if err != nil || !configured {
+		return fmt.Errorf("memory file store is not configured")
+	}
 	filePath, err := resolveMemoryFile(root, relPath)
 	if err != nil {
 		return err
+	}
+	if saver, ok := store.(memoryFileSaver); ok {
+		return saver.SaveResolvedMemoryFile(ctx, filePath, content)
 	}
 	return writeMemoryFileAtomic(filePath, []byte(content))
 }
@@ -427,6 +503,7 @@ func memoryScopeFromRelativePath(relPath string) (string, string) {
 func buildMemorySearchValue(
 	appName string,
 	userID string,
+	userLabel string,
 	relPath string,
 	preview string,
 ) string {
@@ -434,11 +511,29 @@ func buildMemorySearchValue(
 		[]string{
 			strings.TrimSpace(appName),
 			strings.TrimSpace(userID),
+			strings.TrimSpace(userLabel),
 			strings.TrimSpace(relPath),
 			strings.TrimSpace(preview),
 		},
 		" ",
 	)
+}
+
+func resolveMemoryUserLabel(
+	resolver MemoryUserLabelResolver,
+	appName string,
+	userID string,
+) string {
+	if resolver == nil {
+		return ""
+	}
+	label := strings.TrimSpace(
+		resolver.ResolveMemoryUserLabel(appName, userID),
+	)
+	if label == "" || label == strings.TrimSpace(userID) {
+		return ""
+	}
+	return label
 }
 
 func memoryCardID(relPath string) string {

--- a/openclaw/admin/memory.go
+++ b/openclaw/admin/memory.go
@@ -10,6 +10,7 @@
 package admin
 
 import (
+	"crypto/sha256"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -27,6 +28,10 @@ const (
 	maxMemoryFilePreviewBytes = 4 * 1024
 	maxMemoryFilePreviewRunes = 220
 	maxMemoryPreviewLines     = 3
+
+	memoryCardIDPrefix      = "memory-file-"
+	memoryFilePerm          = 0o600
+	memoryTempPatternSuffix = ".tmp-*"
 )
 
 type MemoryFileStore interface {
@@ -52,7 +57,21 @@ type memoryFileView struct {
 	RelativePath string    `json:"relative_path,omitempty"`
 	Path         string    `json:"path,omitempty"`
 	OpenURL      string    `json:"open_url,omitempty"`
+	LoadURL      string    `json:"load_url,omitempty"`
+	CardID       string    `json:"card_id,omitempty"`
+	SearchValue  string    `json:"search_value,omitempty"`
 	Preview      string    `json:"preview,omitempty"`
+	SizeBytes    int64     `json:"size_bytes"`
+	ModifiedAt   time.Time `json:"modified_at"`
+}
+
+type memoryFileDetail struct {
+	AppName      string    `json:"app_name,omitempty"`
+	UserID       string    `json:"user_id,omitempty"`
+	RelativePath string    `json:"relative_path,omitempty"`
+	OpenURL      string    `json:"open_url,omitempty"`
+	LoadURL      string    `json:"load_url,omitempty"`
+	Content      string    `json:"content,omitempty"`
 	SizeBytes    int64     `json:"size_bytes"`
 	ModifiedAt   time.Time `json:"modified_at"`
 }
@@ -177,14 +196,26 @@ func memoryFileViews(
 					maxMemoryFilePreviewBytes,
 				)
 			}
+			appName := decodeMemoryPathPart(appDir.Name())
+			userID := decodeMemoryPathPart(userDir.Name())
 			files = append(files, memoryFileView{
-				AppName:      decodeMemoryPathPart(appDir.Name()),
-				UserID:       decodeMemoryPathPart(userDir.Name()),
+				AppName:      appName,
+				UserID:       userID,
 				RelativePath: rel,
 				Path:         filePath,
 				OpenURL: routeMemoryFile + "?" + url.Values{
 					queryPath: {rel},
 				}.Encode(),
+				LoadURL: routeMemoryFileAPI + "?" + url.Values{
+					queryPath: {rel},
+				}.Encode(),
+				CardID: memoryCardID(rel),
+				SearchValue: buildMemorySearchValue(
+					appName,
+					userID,
+					rel,
+					preview,
+				),
 				Preview: summarizeMemoryPreview(
 					preview,
 					maxMemoryPreviewLines,
@@ -320,4 +351,143 @@ func resolveMemoryFile(root string, relPath string) (string, error) {
 		return "", fmt.Errorf("memory path is a directory")
 	}
 	return absResolved, nil
+}
+
+func readMemoryFileDetail(
+	root string,
+	relPath string,
+) (memoryFileDetail, error) {
+	filePath, err := resolveMemoryFile(root, relPath)
+	if err != nil {
+		return memoryFileDetail{}, err
+	}
+	raw, err := os.ReadFile(filePath)
+	if err != nil {
+		return memoryFileDetail{}, fmt.Errorf(
+			"read memory file: %w",
+			err,
+		)
+	}
+	info, err := os.Stat(filePath)
+	if err != nil {
+		return memoryFileDetail{}, fmt.Errorf(
+			"stat memory file: %w",
+			err,
+		)
+	}
+	rel, err := filepath.Rel(root, filePath)
+	if err != nil {
+		return memoryFileDetail{}, fmt.Errorf(
+			"relativize memory file: %w",
+			err,
+		)
+	}
+	rel = filepath.ToSlash(rel)
+	appName, userID := memoryScopeFromRelativePath(rel)
+	return memoryFileDetail{
+		AppName:      appName,
+		UserID:       userID,
+		RelativePath: rel,
+		OpenURL: routeMemoryFile + "?" + url.Values{
+			queryPath: {rel},
+		}.Encode(),
+		LoadURL: routeMemoryFileAPI + "?" + url.Values{
+			queryPath: {rel},
+		}.Encode(),
+		Content:    string(raw),
+		SizeBytes:  info.Size(),
+		ModifiedAt: info.ModTime(),
+	}, nil
+}
+
+func saveMemoryFile(
+	root string,
+	relPath string,
+	content string,
+) error {
+	filePath, err := resolveMemoryFile(root, relPath)
+	if err != nil {
+		return err
+	}
+	return writeMemoryFileAtomic(filePath, []byte(content))
+}
+
+func memoryScopeFromRelativePath(relPath string) (string, string) {
+	parts := strings.Split(
+		filepath.ToSlash(strings.TrimSpace(relPath)),
+		"/",
+	)
+	if len(parts) < 3 {
+		return "", ""
+	}
+	return decodeMemoryPathPart(parts[0]),
+		decodeMemoryPathPart(parts[1])
+}
+
+func buildMemorySearchValue(
+	appName string,
+	userID string,
+	relPath string,
+	preview string,
+) string {
+	return strings.Join(
+		[]string{
+			strings.TrimSpace(appName),
+			strings.TrimSpace(userID),
+			strings.TrimSpace(relPath),
+			strings.TrimSpace(preview),
+		},
+		" ",
+	)
+}
+
+func memoryCardID(relPath string) string {
+	trimmed := strings.TrimSpace(relPath)
+	if trimmed == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(trimmed))
+	return fmt.Sprintf(
+		"%s%x",
+		memoryCardIDPrefix,
+		sum[:6],
+	)
+}
+
+func writeMemoryFileAtomic(path string, data []byte) error {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return fmt.Errorf("memory file path is required")
+	}
+	dir := filepath.Dir(path)
+	file, err := os.CreateTemp(
+		dir,
+		filepath.Base(path)+memoryTempPatternSuffix,
+	)
+	if err != nil {
+		return fmt.Errorf("create temp memory file: %w", err)
+	}
+	tempPath := file.Name()
+	removeTemp := true
+	defer func() {
+		_ = file.Close()
+		if removeTemp {
+			_ = os.Remove(tempPath)
+		}
+	}()
+
+	if _, err := file.Write(data); err != nil {
+		return fmt.Errorf("write temp memory file: %w", err)
+	}
+	if err := file.Chmod(memoryFilePerm); err != nil {
+		return fmt.Errorf("chmod temp memory file: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close temp memory file: %w", err)
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return fmt.Errorf("replace memory file: %w", err)
+	}
+	removeTemp = false
+	return nil
 }

--- a/openclaw/admin/memory_test.go
+++ b/openclaw/admin/memory_test.go
@@ -201,6 +201,10 @@ func TestMemoryFileViews_CoversFilesystemVariants(t *testing.T) {
 	require.Equal(t, userBlank, views[2].UserID)
 	require.Equal(t, "demo", views[2].AppName)
 	require.Contains(t, views[2].OpenURL, routeMemoryFile+"?path=")
+	require.Contains(t, views[2].LoadURL, routeMemoryFileAPI+"?path=")
+	require.NotEmpty(t, views[0].CardID)
+	require.Contains(t, views[0].SearchValue, "openclaw")
+	require.Contains(t, views[0].SearchValue, "alice")
 }
 
 func TestMemoryFileViews_SortsByModifiedAtAppAndUser(t *testing.T) {
@@ -338,4 +342,50 @@ func TestResolveMemoryFile_RejectsSymlinkEscapes(t *testing.T) {
 
 	_, err := resolveMemoryFile(root, "app/user/MEMORY.md")
 	require.ErrorContains(t, err, "memory file escapes memory root")
+}
+
+func TestReadMemoryFileDetailPreservesExactContent(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	appDir := base64.RawURLEncoding.EncodeToString([]byte("app"))
+	userDir := base64.RawURLEncoding.EncodeToString([]byte("user"))
+	dir := filepath.Join(root, appDir, userDir)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	body := "# Memory\n\n- first line\n- second line\n"
+	require.NoError(
+		t,
+		os.WriteFile(filepath.Join(dir, memoryFileName), []byte(body), 0o600),
+	)
+
+	detail, err := readMemoryFileDetail(
+		root,
+		appDir+"/"+userDir+"/MEMORY.md",
+	)
+	require.NoError(t, err)
+	require.Equal(t, body, detail.Content)
+	require.Equal(t, "app", detail.AppName)
+	require.Equal(t, "user", detail.UserID)
+	require.Contains(t, detail.OpenURL, routeMemoryFile+"?path=")
+	require.Contains(t, detail.LoadURL, routeMemoryFileAPI+"?path=")
+}
+
+func TestSaveMemoryFileWritesExactContent(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	dir := filepath.Join(root, "app", "user")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	path := filepath.Join(dir, memoryFileName)
+	require.NoError(t, os.WriteFile(path, []byte("old"), 0o600))
+
+	next := "# Memory\n\n- updated\n"
+	require.NoError(t, saveMemoryFile(root, "app/user/MEMORY.md", next))
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, next, string(raw))
+
+	err = saveMemoryFile(root, "../MEMORY.md", "bad")
+	require.ErrorContains(t, err, "invalid memory file path")
 }

--- a/openclaw/admin/memory_test.go
+++ b/openclaw/admin/memory_test.go
@@ -10,10 +10,12 @@
 package admin
 
 import (
+	"context"
 	"encoding/base64"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -28,6 +30,13 @@ type memoryStoreStub struct {
 	readCount *atomic.Int32
 }
 
+type memoryStoreSaverStub struct {
+	root         string
+	savedPath    string
+	savedContent string
+	saveCount    int
+}
+
 func (s memoryStoreStub) Root() string {
 	return s.root
 }
@@ -37,6 +46,31 @@ func (s memoryStoreStub) ReadFile(string, int) (string, error) {
 		s.readCount.Add(1)
 	}
 	return "", nil
+}
+
+func (s *memoryStoreSaverStub) Root() string {
+	if s == nil {
+		return ""
+	}
+	return s.root
+}
+
+func (s *memoryStoreSaverStub) ReadFile(string, int) (string, error) {
+	return "", nil
+}
+
+func (s *memoryStoreSaverStub) SaveResolvedMemoryFile(
+	_ context.Context,
+	path string,
+	content string,
+) error {
+	if s == nil {
+		return nil
+	}
+	s.saveCount++
+	s.savedPath = path
+	s.savedContent = content
+	return nil
 }
 
 func TestMemoryStatusWithFiles_ReportsStoreErrors(t *testing.T) {
@@ -207,6 +241,53 @@ func TestMemoryFileViews_CoversFilesystemVariants(t *testing.T) {
 	require.Contains(t, views[0].SearchValue, "alice")
 }
 
+func TestMemoryFileViewsWithResolver_AddsUserLabel(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	store, err := memoryfile.NewStore(root)
+	require.NoError(t, err)
+
+	appDir := base64.RawURLEncoding.EncodeToString([]byte("openclaw"))
+	userDir := base64.RawURLEncoding.EncodeToString(
+		[]byte("wecom:dm:T00320026A"),
+	)
+	dir := filepath.Join(root, appDir, userDir)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(
+		t,
+		os.WriteFile(
+			filepath.Join(dir, memoryFileName),
+			[]byte("# Memory\n\n- note\n"),
+			0o600,
+		),
+	)
+
+	views, err := memoryFileViewsWithResolver(
+		store,
+		MemoryUserLabelResolverFunc(
+			func(appName string, userID string) string {
+				require.Equal(t, "openclaw", appName)
+				require.Equal(t, "wecom:dm:T00320026A", userID)
+				return "RTX wineguo (Guo Qizhou)"
+			},
+		),
+		true,
+	)
+	require.NoError(t, err)
+	require.Len(t, views, 1)
+	require.Equal(
+		t,
+		"RTX wineguo (Guo Qizhou)",
+		views[0].UserLabel,
+	)
+	require.Contains(
+		t,
+		views[0].SearchValue,
+		"RTX wineguo (Guo Qizhou)",
+	)
+}
+
 func TestMemoryFileViews_SortsByModifiedAtAppAndUser(t *testing.T) {
 	t.Parallel()
 
@@ -366,8 +447,78 @@ func TestReadMemoryFileDetailPreservesExactContent(t *testing.T) {
 	require.Equal(t, body, detail.Content)
 	require.Equal(t, "app", detail.AppName)
 	require.Equal(t, "user", detail.UserID)
+	require.Equal(t, appDir+"/"+userDir+"/"+memoryFileName, detail.RelativePath)
 	require.Contains(t, detail.OpenURL, routeMemoryFile+"?path=")
 	require.Contains(t, detail.LoadURL, routeMemoryFileAPI+"?path=")
+}
+
+func TestReadMemoryFileDetailWithResolver_AddsUserLabel(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	appDir := base64.RawURLEncoding.EncodeToString([]byte("app"))
+	userDir := base64.RawURLEncoding.EncodeToString(
+		[]byte("wecom:dm:T00320026A"),
+	)
+	dir := filepath.Join(root, appDir, userDir)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(
+		t,
+		os.WriteFile(
+			filepath.Join(dir, memoryFileName),
+			[]byte("# Memory\n"),
+			0o600,
+		),
+	)
+
+	detail, err := readMemoryFileDetailWithResolver(
+		root,
+		appDir+"/"+userDir+"/"+memoryFileName,
+		MemoryUserLabelResolverFunc(
+			func(appName string, userID string) string {
+				require.Equal(t, "app", appName)
+				require.Equal(t, "wecom:dm:T00320026A", userID)
+				return "RTX wineguo (Guo Qizhou)"
+			},
+		),
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		"RTX wineguo (Guo Qizhou)",
+		detail.UserLabel,
+	)
+}
+
+func TestReadMemoryFileDetailKeepsRequestedRelativePath(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink permissions are not reliable on windows")
+	}
+
+	realRoot := t.TempDir()
+	linkRoot := filepath.Join(t.TempDir(), "memory-link")
+	require.NoError(t, os.Symlink(realRoot, linkRoot))
+
+	appDir := base64.RawURLEncoding.EncodeToString([]byte("app"))
+	userDir := base64.RawURLEncoding.EncodeToString([]byte("user"))
+	relPath := appDir + "/" + userDir + "/" + memoryFileName
+	dir := filepath.Join(realRoot, appDir, userDir)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(
+		t,
+		os.WriteFile(
+			filepath.Join(dir, memoryFileName),
+			[]byte("# Memory\n\n- line\n"),
+			0o600,
+		),
+	)
+
+	detail, err := readMemoryFileDetail(linkRoot, relPath)
+	require.NoError(t, err)
+	require.Equal(t, relPath, detail.RelativePath)
+	require.NotContains(t, detail.RelativePath, "..")
 }
 
 func TestReadMemoryFileDetailReadError(t *testing.T) {
@@ -398,20 +549,62 @@ func TestSaveMemoryFileWritesExactContent(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
-	dir := filepath.Join(root, "app", "user")
-	require.NoError(t, os.MkdirAll(dir, 0o755))
-	path := filepath.Join(dir, memoryFileName)
+	store, err := memoryfile.NewStore(root)
+	require.NoError(t, err)
+
+	path, err := store.MemoryPath("app", "user")
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
 	require.NoError(t, os.WriteFile(path, []byte("old"), 0o600))
 
 	next := "# Memory\n\n- updated\n"
-	require.NoError(t, saveMemoryFile(root, "app/user/MEMORY.md", next))
+	relPath := filepath.ToSlash(strings.TrimPrefix(path, root+string(os.PathSeparator)))
+	require.NoError(
+		t,
+		saveMemoryFile(
+			context.Background(),
+			store,
+			relPath,
+			next,
+		),
+	)
 
 	raw, err := os.ReadFile(path)
 	require.NoError(t, err)
 	require.Equal(t, next, string(raw))
 
-	err = saveMemoryFile(root, "../MEMORY.md", "bad")
+	err = saveMemoryFile(
+		context.Background(),
+		store,
+		"../MEMORY.md",
+		"bad",
+	)
 	require.ErrorContains(t, err, "invalid memory file path")
+}
+
+func TestSaveMemoryFileUsesStoreSaver(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	dir := filepath.Join(root, "app", "user")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	path := filepath.Join(dir, memoryFileName)
+	require.NoError(t, os.WriteFile(path, []byte("old"), 0o600))
+
+	store := &memoryStoreSaverStub{root: root}
+	next := "# Memory\n\n- updated\n"
+	require.NoError(
+		t,
+		saveMemoryFile(
+			context.Background(),
+			store,
+			"app/user/MEMORY.md",
+			next,
+		),
+	)
+	require.Equal(t, 1, store.saveCount)
+	require.Equal(t, path, store.savedPath)
+	require.Equal(t, next, store.savedContent)
 }
 
 func TestMemoryHelpers_HandleShortAndEmptyInput(t *testing.T) {

--- a/openclaw/admin/memory_test.go
+++ b/openclaw/admin/memory_test.go
@@ -370,6 +370,30 @@ func TestReadMemoryFileDetailPreservesExactContent(t *testing.T) {
 	require.Contains(t, detail.LoadURL, routeMemoryFileAPI+"?path=")
 }
 
+func TestReadMemoryFileDetailReadError(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("permission-denied file reads are not reliable on windows")
+	}
+
+	root := t.TempDir()
+	appDir := base64.RawURLEncoding.EncodeToString([]byte("app"))
+	userDir := base64.RawURLEncoding.EncodeToString([]byte("user"))
+	dir := filepath.Join(root, appDir, userDir)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+
+	path := filepath.Join(dir, memoryFileName)
+	require.NoError(t, os.WriteFile(path, []byte("secret"), 0o600))
+	require.NoError(t, os.Chmod(path, 0))
+	t.Cleanup(func() {
+		_ = os.Chmod(path, 0o600)
+	})
+
+	_, err := readMemoryFileDetail(root, appDir+"/"+userDir+"/"+memoryFileName)
+	require.ErrorContains(t, err, "read memory file")
+}
+
 func TestSaveMemoryFileWritesExactContent(t *testing.T) {
 	t.Parallel()
 
@@ -388,4 +412,26 @@ func TestSaveMemoryFileWritesExactContent(t *testing.T) {
 
 	err = saveMemoryFile(root, "../MEMORY.md", "bad")
 	require.ErrorContains(t, err, "invalid memory file path")
+}
+
+func TestMemoryHelpers_HandleShortAndEmptyInput(t *testing.T) {
+	t.Parallel()
+
+	appName, userID := memoryScopeFromRelativePath(memoryFileName)
+	require.Empty(t, appName)
+	require.Empty(t, userID)
+	require.Empty(t, memoryCardID(""))
+}
+
+func TestWriteMemoryFileAtomic_ValidatesPathAndDirectory(t *testing.T) {
+	t.Parallel()
+
+	err := writeMemoryFileAtomic("", []byte("data"))
+	require.ErrorContains(t, err, "memory file path is required")
+
+	err = writeMemoryFileAtomic(
+		filepath.Join(t.TempDir(), "missing", memoryFileName),
+		[]byte("data"),
+	)
+	require.ErrorContains(t, err, "create temp memory file")
 }

--- a/openclaw/admin/service.go
+++ b/openclaw/admin/service.go
@@ -49,6 +49,7 @@ const (
 	routeSkillsRefresh     = "/api/skills/refresh"
 	routeSkillToggle       = "/api/skills/toggle"
 	routeMemoryFilesJSON   = "/api/memory/files"
+	routeMemoryFileAPI     = "/api/memory/file"
 	routeMemoryFile        = "/memory/file"
 	routeJobsJSON          = "/api/cron/jobs"
 	routeJobRun            = "/api/cron/jobs/run"
@@ -368,6 +369,10 @@ func (s *Service) Handler() http.Handler {
 	mux.HandleFunc(routeChatsJSON, s.handleChatsJSON)
 	mux.HandleFunc(routeChatHistoryJSON, s.handleChatHistoryJSON)
 	mux.HandleFunc(routeMemoryFilesJSON, s.handleMemoryFilesJSON)
+	mux.HandleFunc(
+		routeMemoryFileAPI,
+		wrapRelativeLinksFunc(s.handleMemoryFileAPI),
+	)
 	mux.HandleFunc(routeMemoryFile, s.handleMemoryFile)
 	mux.HandleFunc(
 		routeConfigSave,
@@ -1451,7 +1456,8 @@ func pageSummary(view adminView) string {
 	case viewChats:
 		return pageSummaryChats
 	case viewMemory:
-		return "Inspect durable memory storage, file-backed MEMORY.md scopes, and memory inventory."
+		return "Inspect durable memory storage, expand file-backed " +
+			"MEMORY.md scopes, and edit full files in place."
 	case viewAutomation:
 		return "Inspect scheduled jobs, trigger one-off runs, and clear automation state."
 	case viewSessions:
@@ -1665,6 +1671,96 @@ func (s *Service) handleMemoryFilesJSON(
 		return
 	}
 	writeJSON(w, http.StatusOK, s.memoryStatus())
+}
+
+func (s *Service) handleMemoryFileAPI(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	switch r.Method {
+	case http.MethodGet:
+		s.handleMemoryFileJSON(w, r)
+	case http.MethodPost:
+		s.handleSaveMemoryFile(w, r)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *Service) handleMemoryFileJSON(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	root, configured, err := configuredMemoryRoot(s.cfg.MemoryFiles)
+	if err != nil || !configured {
+		http.Error(
+			w,
+			"memory file store is not configured",
+			http.StatusNotFound,
+		)
+		return
+	}
+	detail, err := readMemoryFileDetail(
+		root,
+		strings.TrimSpace(r.URL.Query().Get(queryPath)),
+	)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	writeJSON(w, http.StatusOK, detail)
+}
+
+func (s *Service) handleSaveMemoryFile(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	root, configured, err := configuredMemoryRoot(s.cfg.MemoryFiles)
+	if err != nil || !configured {
+		http.Error(
+			w,
+			"memory file store is not configured",
+			http.StatusNotFound,
+		)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	returnTo := strings.TrimSpace(r.FormValue(formReturnTo))
+	path := strings.TrimSpace(r.FormValue(queryPath))
+	if path == "" {
+		s.redirectWithMessageAt(
+			w,
+			r,
+			queryError,
+			"path is required",
+			returnTo,
+		)
+		return
+	}
+	if err := saveMemoryFile(
+		root,
+		path,
+		r.FormValue(formPromptContent),
+	); err != nil {
+		s.redirectWithMessageAt(
+			w,
+			r,
+			queryError,
+			err.Error(),
+			returnTo,
+		)
+		return
+	}
+	s.redirectWithMessageAt(
+		w,
+		r,
+		queryNotice,
+		"Saved memory file.",
+		returnTo,
+	)
 }
 
 func (s *Service) handleMemoryFile(
@@ -3527,6 +3623,57 @@ const adminPageHTML = `<!doctype html>
       font-weight: 700;
       white-space: nowrap;
     }
+    .memory-list {
+      display: grid;
+      gap: 14px;
+      margin-top: 16px;
+    }
+    .memory-card-head {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      gap: 14px;
+      align-items: flex-start;
+    }
+    .memory-card-meta {
+      display: grid;
+      gap: 6px;
+      color: var(--muted);
+      font-size: 0.9rem;
+      text-align: right;
+      white-space: nowrap;
+    }
+    .memory-path {
+      margin-top: 8px;
+      color: var(--muted);
+      overflow-wrap: anywhere;
+    }
+    .memory-card-toolbar {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      gap: 10px 14px;
+      align-items: center;
+      margin-bottom: 12px;
+    }
+    .memory-editor-form {
+      margin-top: 12px;
+    }
+    .memory-editor-form textarea {
+      width: 100%;
+      min-height: 240px;
+      margin-top: 8px;
+      font: inherit;
+      resize: vertical;
+    }
+    .memory-editor-status {
+      margin-top: 8px;
+      color: var(--muted);
+      font-size: 0.92rem;
+    }
+    .memory-editor-status.error {
+      color: #b6544d;
+    }
     .chat-list {
       display: grid;
       gap: 14px;
@@ -5072,56 +5219,105 @@ const adminPageHTML = `<!doctype html>
             <input
               id="memory-search"
               type="search"
-              placeholder="Search users or memory content"
+              placeholder="Search app, user, path, or preview"
               data-memory-search
             >
           </div>
         </div>
       </div>
-      <table>
-        <thead>
-          <tr>
-            <th>Scope</th>
-            <th>Preview</th>
-            <th>File</th>
-            <th>Size</th>
-            <th>Modified</th>
-          </tr>
-        </thead>
-        <tbody>
-          {{range .Snapshot.Memory.Files}}
-          <tr
-            data-memory-row
-            data-memory-app="{{.AppName}}"
-            data-memory-user="{{.UserID}}"
-            data-memory-search="{{.UserID}} {{.Preview}}"
-          >
-            <td>
-              <div class="memory-scope">
-                <span>app <code>{{.AppName}}</code></span>
-                <span>user <code>{{.UserID}}</code></span>
+      <div class="memory-list">
+        {{range .Snapshot.Memory.Files}}
+        <details
+          class="card prompt-detail"
+          id="{{.CardID}}"
+          data-memory-card
+          data-memory-path="{{.RelativePath}}"
+          data-memory-load-url="{{.LoadURL}}"
+          data-memory-search="{{.SearchValue}}"
+        >
+          <summary>
+            <div class="memory-card-head">
+              <div>
+                <div class="memory-scope">
+                  <span>app <code>{{.AppName}}</code></span>
+                  <span>user <code>{{.UserID}}</code></span>
+                </div>
+                <div class="memory-path">
+                  <code>{{.RelativePath}}</code>
+                </div>
+                <p class="subtle prompt-detail-hint">
+                  {{if .Preview}}
+                    {{.Preview}}
+                  {{else}}
+                    No visible memory content yet.
+                  {{end}}
+                </p>
               </div>
-            </td>
-            <td>
-              {{if .Preview}}
-              <div class="memory-preview">{{.Preview}}</div>
-              {{else}}
-              <span class="subtle">empty</span>
-              {{end}}
-            </td>
-            <td>
-              <a href="{{.OpenURL}}" target="_blank" rel="noopener noreferrer">
-                open
+              <div class="memory-card-meta">
+                <span>{{.SizeBytes}} bytes</span>
+                <span>{{formatTime .ModifiedAt}}</span>
+              </div>
+            </div>
+          </summary>
+          <div class="prompt-detail-body">
+            <div class="memory-card-toolbar">
+              <div class="subtle">
+                Edit the full <code>MEMORY.md</code> file for this scope.
+              </div>
+              <a
+                href="{{.OpenURL}}"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Open Raw File
               </a>
-              <br>
-              <code>{{.RelativePath}}</code>
-            </td>
-            <td>{{.SizeBytes}}</td>
-            <td>{{formatTime .ModifiedAt}}</td>
-          </tr>
-          {{end}}
-        </tbody>
-      </table>
+            </div>
+            <form
+              class="memory-editor-form"
+              method="post"
+              action="/api/memory/file"
+              data-memory-form
+            >
+              <input type="hidden" name="path" value="{{.RelativePath}}">
+              <input type="hidden" name="return_path" value="/memory">
+              <input type="hidden" name="return_to" value="{{.CardID}}">
+              <label for="editor-{{.CardID}}">
+                Full file content
+              </label>
+              <textarea
+                id="editor-{{.CardID}}"
+                name="content"
+                data-memory-editor
+                placeholder="Open this scope to load MEMORY.md"
+                disabled
+              ></textarea>
+              <div class="memory-editor-status" data-memory-status>
+                Open this scope to load its full file.
+              </div>
+              <div
+                class="notice err"
+                style="margin-top: 12px;"
+                data-memory-error
+                hidden
+              ></div>
+              <div class="actions" style="margin-top: 12px;">
+                <button type="submit" data-memory-save disabled>
+                  Save File
+                </button>
+                <button
+                  class="secondary"
+                  type="button"
+                  data-memory-reset
+                  disabled
+                >
+                  Revert
+                </button>
+              </div>
+            </form>
+          </div>
+        </details>
+        {{end}}
+      </div>
       <p class="empty" data-memory-empty hidden>No matching memory files.</p>
       {{else if not .Snapshot.Memory.Error}}
       <p class="empty">
@@ -6382,26 +6578,185 @@ const adminPageHTML = `<!doctype html>
       const search = root.querySelector("[data-memory-search]");
       const shown = root.querySelector("[data-memory-shown]");
       const empty = document.querySelector("[data-memory-empty]");
-      const rows = Array.from(document.querySelectorAll("[data-memory-row]"));
+      const cards = Array.from(
+        document.querySelectorAll("[data-memory-card]")
+      );
 
-      const matches = (row) => {
-        const needle = (search && search.value ? search.value : "").trim().toLowerCase();
+      const readControls = (card) => ({
+        editor: card.querySelector("[data-memory-editor]"),
+        save: card.querySelector("[data-memory-save]"),
+        reset: card.querySelector("[data-memory-reset]"),
+        error: card.querySelector("[data-memory-error]"),
+        status: card.querySelector("[data-memory-status]"),
+      });
+
+      const setStatus = (card, message, isError) => {
+        const status = readControls(card).status;
+        if (!status) return;
+        status.textContent = message;
+        status.classList.toggle("error", Boolean(isError));
+      };
+
+      const clearError = (card) => {
+        const error = readControls(card).error;
+        if (!error) return;
+        error.hidden = true;
+        error.textContent = "";
+      };
+
+      const showError = (card, message) => {
+        const error = readControls(card).error;
+        if (!error) return;
+        error.hidden = false;
+        error.textContent = message;
+        setStatus(card, message, true);
+      };
+
+      const updateDirtyState = (card) => {
+        const controls = readControls(card);
+        const editor = controls.editor;
+        if (!editor) return;
+        const original = editor.dataset.original || "";
+        const loaded = card.dataset.memoryLoaded === "true";
+        const dirty = !editor.disabled && editor.value !== original;
+        if (controls.save) {
+          controls.save.disabled = editor.disabled || !dirty;
+        }
+        if (controls.reset) {
+          controls.reset.disabled = editor.disabled || !dirty;
+        }
+        if (editor.disabled) {
+          setStatus(
+            card,
+            "Open this scope to load its full file.",
+            false
+          );
+          return;
+        }
+        if (dirty) {
+          setStatus(card, "Unsaved changes.", false);
+          return;
+        }
+        if (loaded) {
+          setStatus(
+            card,
+            "Loaded from disk. Edit the file to enable save.",
+            false
+          );
+        }
+      };
+
+      const loadCard = async (card) => {
+        if (
+          card.dataset.memoryLoaded === "true" ||
+          card.dataset.memoryLoading === "true"
+        ) {
+          updateDirtyState(card);
+          return;
+        }
+        const controls = readControls(card);
+        const editor = controls.editor;
+        card.dataset.memoryLoading = "true";
+        clearError(card);
+        setStatus(card, "Loading full file...", false);
+        if (editor) {
+          editor.disabled = true;
+        }
+        if (controls.save) {
+          controls.save.disabled = true;
+        }
+        if (controls.reset) {
+          controls.reset.disabled = true;
+        }
+        try {
+          const url = resolveRequestURL(
+            card.getAttribute("data-memory-load-url") || ""
+          );
+          if (!url) {
+            throw new Error("memory file endpoint is unavailable");
+          }
+          const response = await fetch(url.toString(), {
+            headers: { Accept: "application/json" },
+          });
+          if (!response.ok) {
+            const text = (await response.text()).trim();
+            throw new Error(text || "failed to load memory file");
+          }
+          const payload = await response.json();
+          const content =
+            typeof payload.content === "string" ? payload.content : "";
+          if (editor) {
+            editor.value = content;
+            editor.dataset.original = content;
+            editor.disabled = false;
+          }
+          card.dataset.memoryLoaded = "true";
+          updateDirtyState(card);
+        } catch (err) {
+          showError(
+            card,
+            err && typeof err.message === "string"
+              ? err.message
+              : "failed to load memory file"
+          );
+        } finally {
+          delete card.dataset.memoryLoading;
+        }
+      };
+
+      const matches = (card) => {
+        const needle =
+          (search && search.value ? search.value : "")
+            .trim()
+            .toLowerCase();
         if (!needle) return true;
-        const haystack = (row.getAttribute("data-memory-search") || "").toLowerCase();
+        const haystack = (
+          card.getAttribute("data-memory-search") || ""
+        ).toLowerCase();
         if (haystack.indexOf(needle) === -1) return false;
         return true;
       };
 
       const refresh = () => {
         let visibleCount = 0;
-        rows.forEach((row) => {
-          const visible = matches(row);
-          row.hidden = !visible;
+        cards.forEach((card) => {
+          const visible = matches(card);
+          card.hidden = !visible;
           if (visible) visibleCount += 1;
         });
         if (shown) shown.textContent = String(visibleCount);
         if (empty) empty.hidden = visibleCount !== 0;
       };
+
+      cards.forEach((card) => {
+        const disclosure = card.matches("details")
+          ? card
+          : card.closest("details");
+        const controls = readControls(card);
+        if (controls.editor) {
+          controls.editor.addEventListener("input", () => {
+            updateDirtyState(card);
+          });
+        }
+        if (controls.reset) {
+          controls.reset.addEventListener("click", () => {
+            if (!controls.editor) return;
+            controls.editor.value =
+              controls.editor.dataset.original || "";
+            updateDirtyState(card);
+          });
+        }
+        if (disclosure) {
+          disclosure.addEventListener("toggle", () => {
+            if (disclosure.open) {
+              loadCard(card);
+            }
+          });
+          if (disclosure.open) {
+            loadCard(card);
+          }
+        }
+      });
 
       if (search) {
         search.addEventListener("input", refresh);

--- a/openclaw/admin/service.go
+++ b/openclaw/admin/service.go
@@ -166,15 +166,16 @@ type Config struct {
 	StateDir string
 	DebugDir string
 
-	Channels      []string
-	GatewayRoutes Routes
-	Skills        SkillsStatusProvider
-	Prompts       PromptsProvider
-	Identity      IdentityProvider
-	Personas      PersonasProvider
-	Chats         ChatsProvider
-	MemoryFiles   MemoryFileStore
-	Browser       BrowserConfig
+	Channels         []string
+	GatewayRoutes    Routes
+	Skills           SkillsStatusProvider
+	Prompts          PromptsProvider
+	Identity         IdentityProvider
+	Personas         PersonasProvider
+	Chats            ChatsProvider
+	MemoryFiles      MemoryFileStore
+	MemoryUserLabels MemoryUserLabelResolver
+	Browser          BrowserConfig
 
 	Cron *cron.Service
 	Exec *octool.Manager
@@ -1700,9 +1701,10 @@ func (s *Service) handleMemoryFileJSON(
 		)
 		return
 	}
-	detail, err := readMemoryFileDetail(
+	detail, err := readMemoryFileDetailWithResolver(
 		root,
 		strings.TrimSpace(r.URL.Query().Get(queryPath)),
+		s.cfg.MemoryUserLabels,
 	)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -1715,7 +1717,7 @@ func (s *Service) handleSaveMemoryFile(
 	w http.ResponseWriter,
 	r *http.Request,
 ) {
-	root, configured, err := configuredMemoryRoot(s.cfg.MemoryFiles)
+	_, configured, err := configuredMemoryRoot(s.cfg.MemoryFiles)
 	if err != nil || !configured {
 		http.Error(
 			w,
@@ -1741,7 +1743,8 @@ func (s *Service) handleSaveMemoryFile(
 		return
 	}
 	if err := saveMemoryFile(
-		root,
+		r.Context(),
+		s.cfg.MemoryFiles,
 		path,
 		r.FormValue(formPromptContent),
 	); err != nil {
@@ -3578,6 +3581,11 @@ const adminPageHTML = `<!doctype html>
       display: grid;
       gap: 4px;
     }
+    .memory-user-label {
+      color: var(--muted);
+      font-size: 0.92rem;
+      font-weight: 700;
+    }
     .memory-controls {
       margin: 18px 0 12px;
     }
@@ -5240,7 +5248,12 @@ const adminPageHTML = `<!doctype html>
               <div>
                 <div class="memory-scope">
                   <span>app <code>{{.AppName}}</code></span>
-                  <span>user <code>{{.UserID}}</code></span>
+                  <span>
+                    user <code>{{.UserID}}</code>
+                    {{if .UserLabel}}
+                    <span class="memory-user-label">{{.UserLabel}}</span>
+                    {{end}}
+                  </span>
                 </div>
                 <div class="memory-path">
                   <code>{{.RelativePath}}</code>

--- a/openclaw/admin/service_test.go
+++ b/openclaw/admin/service_test.go
@@ -699,11 +699,13 @@ func TestServiceHandlerRendersMemoryInventory(t *testing.T) {
 	require.Contains(t, body, `href="memory/file?path=`)
 	require.Contains(t, body, `data-memory-root`)
 	require.Contains(t, body, `data-memory-search`)
-	require.Contains(t, body, `data-memory-row`)
-	require.Contains(t, body, `data-memory-app="openclaw"`)
-	require.Contains(t, body, `data-memory-user="alice"`)
-	require.Contains(t, body, `data-memory-search="alice`)
-	require.Contains(t, body, "Search users or memory content")
+	require.Contains(t, body, `data-memory-card`)
+	require.Contains(t, body, `data-memory-path=`)
+	require.Contains(t, body, `data-memory-load-url=`)
+	require.Contains(t, body, `data-memory-editor`)
+	require.Contains(t, body, "Search app, user, path, or preview")
+	require.Contains(t, body, "Edit the full")
+	require.Contains(t, body, "Open Raw File")
 }
 
 func TestServiceHandlerRendersMemoryInventory_FileBackendUnconfigured(t *testing.T) {
@@ -767,6 +769,138 @@ func TestServiceMemoryFilesJSONEndpoint_MethodNotAllowed(t *testing.T) {
 	svc.Handler().ServeHTTP(rr, req)
 
 	require.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+}
+
+func TestServiceMemoryFileAPIEndpoint(t *testing.T) {
+	t.Parallel()
+
+	root, err := memoryfile.DefaultRoot(t.TempDir())
+	require.NoError(t, err)
+	store, err := memoryfile.NewStore(root)
+	require.NoError(t, err)
+	_, err = store.UpdateMemory(
+		context.Background(),
+		"openclaw",
+		"alice",
+		func(string) (string, error) {
+			return "# Memory\n\n- Alice prefers concise updates.\n", nil
+		},
+	)
+	require.NoError(t, err)
+
+	svc := New(Config{
+		MemoryBackend: "file",
+		MemoryFiles:   store,
+	})
+	status := svc.memoryStatus()
+	require.Len(t, status.Files, 1)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		routeMemoryFileAPI+"?path="+url.QueryEscape(
+			status.Files[0].RelativePath,
+		),
+		nil,
+	)
+	rr := httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	var detail memoryFileDetail
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &detail))
+	require.Equal(t, "openclaw", detail.AppName)
+	require.Equal(t, "alice", detail.UserID)
+	require.Equal(
+		t,
+		"# Memory\n\n- Alice prefers concise updates.\n",
+		detail.Content,
+	)
+}
+
+func TestServiceMemoryFileAPIEndpoint_Save(t *testing.T) {
+	t.Parallel()
+
+	root, err := memoryfile.DefaultRoot(t.TempDir())
+	require.NoError(t, err)
+	store, err := memoryfile.NewStore(root)
+	require.NoError(t, err)
+	_, err = store.UpdateMemory(
+		context.Background(),
+		"openclaw",
+		"alice",
+		func(string) (string, error) {
+			return "# Memory\n\n- before\n", nil
+		},
+	)
+	require.NoError(t, err)
+
+	svc := New(Config{
+		MemoryBackend: "file",
+		MemoryFiles:   store,
+	})
+	status := svc.memoryStatus()
+	require.Len(t, status.Files, 1)
+
+	form := url.Values{
+		queryPath:         {status.Files[0].RelativePath},
+		formPromptContent: {"# Memory\n\n- after\n"},
+		formReturnPath:    {routeMemory},
+		formReturnTo:      {status.Files[0].CardID},
+	}
+	req := httptest.NewRequest(
+		http.MethodPost,
+		routeMemoryFileAPI,
+		strings.NewReader(form.Encode()),
+	)
+	req.Header.Set(
+		"Content-Type",
+		"application/x-www-form-urlencoded",
+	)
+	rr := httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusSeeOther, rr.Code)
+	require.Contains(t, rr.Header().Get("Location"), "Saved+memory+file.")
+	require.Contains(
+		t,
+		rr.Header().Get("Location"),
+		"#"+status.Files[0].CardID,
+	)
+
+	raw, err := os.ReadFile(status.Files[0].Path)
+	require.NoError(t, err)
+	require.Equal(t, "# Memory\n\n- after\n", string(raw))
+}
+
+func TestServiceMemoryFileAPIEndpoint_MethodAndPathValidation(t *testing.T) {
+	t.Parallel()
+
+	root, err := memoryfile.DefaultRoot(t.TempDir())
+	require.NoError(t, err)
+	store, err := memoryfile.NewStore(root)
+	require.NoError(t, err)
+
+	svc := New(Config{
+		MemoryBackend: "file",
+		MemoryFiles:   store,
+	})
+
+	req := httptest.NewRequest(http.MethodDelete, routeMemoryFileAPI, nil)
+	rr := httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rr, req)
+	require.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+
+	req = httptest.NewRequest(
+		http.MethodGet,
+		routeMemoryFileAPI+"?path="+url.QueryEscape(
+			filepath.Join(root, "app", "user", "MEMORY.md"),
+		),
+		nil,
+	)
+	rr = httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rr, req)
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Contains(t, rr.Body.String(), "invalid memory file path")
 }
 
 func TestServiceMemoryFileEndpoint(t *testing.T) {
@@ -1019,7 +1153,7 @@ func TestServiceHandlerRendersAdminPages(t *testing.T) {
 			name:    "memory",
 			path:    routeMemory,
 			title:   "Memory",
-			summary: "Inspect durable memory storage, file-backed MEMORY.md scopes, and memory inventory.",
+			summary: "Inspect durable memory storage, expand file-backed MEMORY.md scopes, and edit full files in place.",
 		},
 		{
 			name:    "automation",
@@ -1436,7 +1570,7 @@ func TestAdminHelpers_PageMetadataAndNavigation(t *testing.T) {
 			path:    routeMemory,
 			view:    viewMemory,
 			title:   "Memory",
-			summary: "Inspect durable memory storage, file-backed MEMORY.md scopes, and memory inventory.",
+			summary: "Inspect durable memory storage, expand file-backed MEMORY.md scopes, and edit full files in place.",
 		},
 		{
 			path:    routeAutomation,

--- a/openclaw/admin/service_test.go
+++ b/openclaw/admin/service_test.go
@@ -683,6 +683,17 @@ func TestServiceHandlerRendersMemoryInventory(t *testing.T) {
 	svc := New(Config{
 		MemoryBackend: "file",
 		MemoryFiles:   store,
+		MemoryUserLabels: MemoryUserLabelResolverFunc(
+			func(appName string, userID string) string {
+				if appName != "openclaw" {
+					return ""
+				}
+				if userID != "alice" {
+					return ""
+				}
+				return "RTX alice.dev (Alice Chen)"
+			},
+		),
 	})
 
 	req := httptest.NewRequest(http.MethodGet, routeMemory, nil)
@@ -694,6 +705,7 @@ func TestServiceHandlerRendersMemoryInventory(t *testing.T) {
 	require.Contains(t, body, "Memory Files")
 	require.Contains(t, body, "openclaw")
 	require.Contains(t, body, "alice")
+	require.Contains(t, body, "RTX alice.dev (Alice Chen)")
 	require.Contains(t, body, "Alice prefers concise updates.")
 	require.Contains(t, body, `href="api/memory/files"`)
 	require.Contains(t, body, `href="memory/file?path=`)
@@ -747,6 +759,14 @@ func TestServiceMemoryFilesJSONEndpoint(t *testing.T) {
 	svc := New(Config{
 		MemoryBackend: "file",
 		MemoryFiles:   store,
+		MemoryUserLabels: MemoryUserLabelResolverFunc(
+			func(appName string, userID string) string {
+				if appName == "openclaw" && userID == "alice" {
+					return "RTX alice.dev (Alice Chen)"
+				}
+				return ""
+			},
+		),
 	})
 
 	req := httptest.NewRequest(http.MethodGet, routeMemoryFilesJSON, nil)
@@ -758,6 +778,11 @@ func TestServiceMemoryFilesJSONEndpoint(t *testing.T) {
 	require.Contains(t, body, `"file_count": 1`)
 	require.Contains(t, body, `"app_name": "openclaw"`)
 	require.Contains(t, body, `"user_id": "alice"`)
+	require.Contains(
+		t,
+		body,
+		`"user_label": "RTX alice.dev (Alice Chen)"`,
+	)
 }
 
 func TestServiceMemoryFilesJSONEndpoint_MethodNotAllowed(t *testing.T) {
@@ -791,6 +816,14 @@ func TestServiceMemoryFileAPIEndpoint(t *testing.T) {
 	svc := New(Config{
 		MemoryBackend: "file",
 		MemoryFiles:   store,
+		MemoryUserLabels: MemoryUserLabelResolverFunc(
+			func(appName string, userID string) string {
+				if appName == "openclaw" && userID == "alice" {
+					return "RTX alice.dev (Alice Chen)"
+				}
+				return ""
+			},
+		),
 	})
 	status := svc.memoryStatus()
 	require.Len(t, status.Files, 1)
@@ -810,6 +843,11 @@ func TestServiceMemoryFileAPIEndpoint(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &detail))
 	require.Equal(t, "openclaw", detail.AppName)
 	require.Equal(t, "alice", detail.UserID)
+	require.Equal(
+		t,
+		"RTX alice.dev (Alice Chen)",
+		detail.UserLabel,
+	)
 	require.Equal(
 		t,
 		"# Memory\n\n- Alice prefers concise updates.\n",
@@ -878,10 +916,15 @@ func TestServiceMemoryFileAPIEndpoint_Save(t *testing.T) {
 	svc.Handler().ServeHTTP(rr, req)
 
 	require.Equal(t, http.StatusSeeOther, rr.Code)
-	require.Contains(t, rr.Header().Get("Location"), "Saved+memory+file.")
+	assertRedirectQueryValue(
+		t,
+		rr.Header().Get(headerLocation),
+		queryNotice,
+		"Saved memory file.",
+	)
 	require.Contains(
 		t,
-		rr.Header().Get("Location"),
+		rr.Header().Get(headerLocation),
 		"#"+status.Files[0].CardID,
 	)
 
@@ -933,7 +976,12 @@ func TestServiceMemoryFileAPIEndpoint_SaveValidation(t *testing.T) {
 	rr = httptest.NewRecorder()
 	svc.Handler().ServeHTTP(rr, req)
 	require.Equal(t, http.StatusSeeOther, rr.Code)
-	require.Contains(t, rr.Header().Get("Location"), "path+is+required")
+	assertRedirectQueryValue(
+		t,
+		rr.Header().Get(headerLocation),
+		queryError,
+		"path is required",
+	)
 
 	form = url.Values{
 		queryPath:         {"/tmp/not-memory-file"},
@@ -953,10 +1001,11 @@ func TestServiceMemoryFileAPIEndpoint_SaveValidation(t *testing.T) {
 	rr = httptest.NewRecorder()
 	svc.Handler().ServeHTTP(rr, req)
 	require.Equal(t, http.StatusSeeOther, rr.Code)
-	require.Contains(
+	assertRedirectQueryValue(
 		t,
-		rr.Header().Get("Location"),
-		"invalid+memory+file+path",
+		rr.Header().Get(headerLocation),
+		queryError,
+		"invalid memory file path",
 	)
 }
 
@@ -3495,6 +3544,19 @@ func TestSkillInstallViewsFromStatus_TrimsValues(t *testing.T) {
 		out,
 	)
 	require.Nil(t, skillInstallViewsFromStatus(nil))
+}
+
+func assertRedirectQueryValue(
+	t *testing.T,
+	location string,
+	key string,
+	want string,
+) {
+	t.Helper()
+
+	target, err := url.Parse(location)
+	require.NoError(t, err)
+	require.Equal(t, want, target.Query().Get(key))
 }
 
 func TestServiceToggleSkillEndpointRequiresConfigPath(t *testing.T) {

--- a/openclaw/admin/service_test.go
+++ b/openclaw/admin/service_test.go
@@ -817,6 +817,24 @@ func TestServiceMemoryFileAPIEndpoint(t *testing.T) {
 	)
 }
 
+func TestServiceMemoryFileAPIEndpoint_UnconfiguredStore(t *testing.T) {
+	t.Parallel()
+
+	svc := New(Config{MemoryBackend: "file"})
+
+	req := httptest.NewRequest(http.MethodGet, routeMemoryFileAPI, nil)
+	rr := httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rr, req)
+	require.Equal(t, http.StatusNotFound, rr.Code)
+	require.Contains(t, rr.Body.String(), "not configured")
+
+	req = httptest.NewRequest(http.MethodPost, routeMemoryFileAPI, nil)
+	rr = httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rr, req)
+	require.Equal(t, http.StatusNotFound, rr.Code)
+	require.Contains(t, rr.Body.String(), "not configured")
+}
+
 func TestServiceMemoryFileAPIEndpoint_Save(t *testing.T) {
 	t.Parallel()
 
@@ -870,6 +888,76 @@ func TestServiceMemoryFileAPIEndpoint_Save(t *testing.T) {
 	raw, err := os.ReadFile(status.Files[0].Path)
 	require.NoError(t, err)
 	require.Equal(t, "# Memory\n\n- after\n", string(raw))
+}
+
+func TestServiceMemoryFileAPIEndpoint_SaveValidation(t *testing.T) {
+	t.Parallel()
+
+	root, err := memoryfile.DefaultRoot(t.TempDir())
+	require.NoError(t, err)
+	store, err := memoryfile.NewStore(root)
+	require.NoError(t, err)
+
+	svc := New(Config{
+		MemoryBackend: "file",
+		MemoryFiles:   store,
+	})
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		routeMemoryFileAPI,
+		strings.NewReader("%zz"),
+	)
+	req.Header.Set(
+		"Content-Type",
+		"application/x-www-form-urlencoded",
+	)
+	rr := httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rr, req)
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+
+	form := url.Values{
+		formPromptContent: {"# Memory\n\n- after\n"},
+		formReturnPath:    {routeMemory},
+		formReturnTo:      {"memory-file-demo"},
+	}
+	req = httptest.NewRequest(
+		http.MethodPost,
+		routeMemoryFileAPI,
+		strings.NewReader(form.Encode()),
+	)
+	req.Header.Set(
+		"Content-Type",
+		"application/x-www-form-urlencoded",
+	)
+	rr = httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rr, req)
+	require.Equal(t, http.StatusSeeOther, rr.Code)
+	require.Contains(t, rr.Header().Get("Location"), "path+is+required")
+
+	form = url.Values{
+		queryPath:         {"/tmp/not-memory-file"},
+		formPromptContent: {"# Memory\n\n- after\n"},
+		formReturnPath:    {routeMemory},
+		formReturnTo:      {"memory-file-demo"},
+	}
+	req = httptest.NewRequest(
+		http.MethodPost,
+		routeMemoryFileAPI,
+		strings.NewReader(form.Encode()),
+	)
+	req.Header.Set(
+		"Content-Type",
+		"application/x-www-form-urlencoded",
+	)
+	rr = httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rr, req)
+	require.Equal(t, http.StatusSeeOther, rr.Code)
+	require.Contains(
+		t,
+		rr.Header().Get("Location"),
+		"invalid+memory+file+path",
+	)
 }
 
 func TestServiceMemoryFileAPIEndpoint_MethodAndPathValidation(t *testing.T) {

--- a/openclaw/internal/memoryfile/store.go
+++ b/openclaw/internal/memoryfile/store.go
@@ -157,6 +157,36 @@ func (s *Store) UpdateMemory(
 	return path, nil
 }
 
+// SaveResolvedMemoryFile writes a validated file path while holding the
+// same store lock used by logical memory updates.
+func (s *Store) SaveResolvedMemoryFile(
+	ctx context.Context,
+	path string,
+	content string,
+) error {
+	if s == nil {
+		return errors.New("memoryfile: nil store")
+	}
+	if err := contextErr(ctx); err != nil {
+		return err
+	}
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return errors.New("memoryfile: empty file path")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := contextErr(ctx); err != nil {
+		return err
+	}
+	if !fileExists(path) {
+		return os.ErrNotExist
+	}
+	return writeFileAtomic(path, []byte(content))
+}
+
 func (s *Store) ReadFile(path string, maxBytes int) (string, error) {
 	if s == nil {
 		return "", errors.New("memoryfile: nil store")

--- a/openclaw/internal/memoryfile/store_test.go
+++ b/openclaw/internal/memoryfile/store_test.go
@@ -594,6 +594,58 @@ func TestStoreUpdateMemory_WriteErrorReturnsError(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestStoreSaveResolvedMemoryFileWritesContent(t *testing.T) {
+	t.Parallel()
+
+	root, err := DefaultRoot(t.TempDir())
+	require.NoError(t, err)
+	store, err := NewStore(root)
+	require.NoError(t, err)
+
+	path, err := store.MemoryPath("demo-app", "u1")
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), dirPerm))
+	require.NoError(t, os.WriteFile(path, []byte("original"), filePerm))
+
+	err = store.SaveResolvedMemoryFile(
+		context.Background(),
+		path,
+		"updated",
+	)
+	require.NoError(t, err)
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, "updated", string(raw))
+}
+
+func TestStoreSaveResolvedMemoryFileValidatesInputs(t *testing.T) {
+	t.Parallel()
+
+	var nilStore *Store
+	err := nilStore.SaveResolvedMemoryFile(
+		context.Background(),
+		"/tmp/memory/MEMORY.md",
+		"updated",
+	)
+	require.Error(t, err)
+
+	root, err := DefaultRoot(t.TempDir())
+	require.NoError(t, err)
+	store, err := NewStore(root)
+	require.NoError(t, err)
+
+	err = store.SaveResolvedMemoryFile(context.Background(), " ", "updated")
+	require.Error(t, err)
+
+	err = store.SaveResolvedMemoryFile(
+		context.Background(),
+		filepath.Join(root, "missing", memoryFileName),
+		"updated",
+	)
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
 func TestWriteFileAtomic_EmptyPathReturnsError(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What changed

This updates the openclaw `Memory` admin page from a read-only inventory table to an inline editing surface for file-backed `MEMORY.md` scopes.

The change adds:

- expandable memory cards that reuse the existing prompt-style disclosure pattern
- on-demand full file loading for a selected memory scope
- in-page full-file editing with save and revert actions
- broader client-side search over app, user, path, and preview text
- a JSON memory file API plus safe save helpers guarded by the existing path checks

## Why

The previous page was optimized for inspection rather than management.
Users could only see a short preview and then jump out to a raw file view, which made memory editing hard to discover and inconvenient in practice.

## Impact

- file-backed memory is much easier to browse and edit in admin
- the existing raw file endpoint remains compatible for direct open / download flows
- `MemoryFileStore` compatibility is preserved because the new editing path is implemented without widening the existing interface

## Root cause

The old implementation treated memory as a table of previews instead of a working surface.
That left no direct full-file edit path, no fold / expand detail flow, and a very narrow search index.

## Validation

- `go test ./admin` from `openclaw/` in `../github/trpc-agent-go`
- `go test trpc.group/trpc-go/trpc-agent-go/openclaw/admin` from the inner repo after local replace
- `go build ./cmd/openclaw` from the inner repo after local replace
