### PR TITLE
{knowledge, session}: fix embedding dimensions for text-embedding-v4

### DIFF
--- a/knowledge/embedder/openai/openai.go
+++ b/knowledge/embedder/openai/openai.go
@@ -50,8 +50,15 @@ const (
 	// EncodingFormatBase64 represents the base64 encoding format.
 	EncodingFormatBase64 = "base64"
 
-	// Model prefix for text-embedding-3 series.
-	textEmbedding3Prefix = "text-embedding-3"
+	// textEmbedding3Prefix marks the text-embedding-3 model family
+	// (text-embedding-3-small, text-embedding-3-large, ...). The trailing
+	// hyphen is required so unrelated ids like text-embedding-30 or
+	// text-embedding-3rd-party do not accidentally inherit the legacy
+	// default-dimensions forwarding behavior. Members of this family have
+	// always received the configured dimensions (with a 1536 default) and
+	// we keep that default forwarding to preserve the existing wire
+	// behavior for callers that never set WithDimensions.
+	textEmbedding3Prefix = "text-embedding-3-"
 )
 
 // defaultRetryBackoff is the default backoff durations for retry attempts.
@@ -64,9 +71,14 @@ var defaultRetryBackoff = []time.Duration{
 
 // Embedder implements the embedder.Embedder interface for OpenAI API.
 type Embedder struct {
-	client         openai.Client
-	model          string
-	dimensions     int
+	client     openai.Client
+	model      string
+	dimensions int
+	// dimensionsSet indicates whether dimensions was explicitly configured
+	// via WithDimensions. When set, the value is forwarded to the API for
+	// any model; when unset, see the WithDimensions godoc for which models
+	// still receive the historical default.
+	dimensionsSet  bool
 	encodingFormat string
 	user           string
 	apiKey         string
@@ -90,10 +102,20 @@ func WithModel(model string) Option {
 }
 
 // WithDimensions sets the number of dimensions for the embedding.
-// Only works with text-embedding-3 and later models.
+//
+// When set, the value is forwarded as-is to the embeddings endpoint
+// regardless of the model id. The caller is responsible for picking a
+// value the configured model supports (e.g. text-embedding-3-*, or
+// text-embedding-v3/v4 on DashScope-compatible gateways).
+//
+// When not set, the request includes dimensions only for the
+// text-embedding-3-* family (defaulting to DefaultDimensions=1536, which
+// preserves the existing wire behavior); for any other model the
+// parameter is omitted so the model's server-side default is used.
 func WithDimensions(dimensions int) Option {
 	return func(e *Embedder) {
 		e.dimensions = dimensions
+		e.dimensionsSet = true
 	}
 }
 
@@ -330,8 +352,12 @@ func (e *Embedder) response(ctx context.Context, text string) (rsp *openai.Creat
 		request.User = openai.String(e.user)
 	}
 
-	// Set dimensions for text-embedding-3 models.
-	if isTextEmbedding3Model(e.model) {
+	// Forward dimensions when the caller explicitly configured it (any
+	// model), or implicitly for the text-embedding-3-* family to keep
+	// the historical default. For other models we omit the parameter so
+	// the server-side default applies and gateways/models that reject
+	// the field keep working.
+	if e.dimensionsSet || isTextEmbedding3Model(e.model) {
 		request.Dimensions = openai.Int(int64(e.dimensions))
 	}
 
@@ -344,12 +370,19 @@ func (e *Embedder) response(ctx context.Context, text string) (rsp *openai.Creat
 }
 
 // GetDimensions implements the embedder.Embedder interface.
-// It returns the number of dimensions in the embedding vectors.
+//
+// It returns the configured dimensions value (DefaultDimensions when the
+// caller never invoked WithDimensions). For non text-embedding-3-* models
+// where dimensions was not explicitly configured, the API may return a
+// different vector size; in that case prefer calling WithDimensions to
+// keep this method consistent with the wire response.
 func (e *Embedder) GetDimensions() int {
 	return e.dimensions
 }
 
-// isTextEmbedding3Model checks if the model is a text-embedding-3 series model.
+// isTextEmbedding3Model reports whether the model belongs to the
+// text-embedding-3 family that historically received the configured
+// dimensions value (defaulting to 1536) on every request.
 func isTextEmbedding3Model(model string) bool {
 	return strings.HasPrefix(model, textEmbedding3Prefix)
 }

--- a/knowledge/embedder/openai/openai_test.go
+++ b/knowledge/embedder/openai/openai_test.go
@@ -142,23 +142,132 @@ func TestGetDimensions(t *testing.T) {
 	}
 }
 
-// TestIsTextEmbedding3Model tests the helper function.
-func TestIsTextEmbedding3Model(t *testing.T) {
+// TestRequestDimensionsForwarding verifies how the dimensions parameter is
+// forwarded to the embeddings API:
+//
+//   - Explicit WithDimensions: always forwarded for any model id (this is the
+//     regression test for issue #1664, where dimensions configured for
+//     text-embedding-v4 on a DashScope-compatible gateway was silently dropped).
+//   - Implicit (no WithDimensions) on the text-embedding-3-* family: the
+//     historical default (DefaultDimensions=1536) is forwarded to preserve the
+//     existing wire contract for callers who already provisioned downstream
+//     stores against that default.
+//   - Implicit on any other model: the parameter is omitted so the model's
+//     server-side default is used and gateways/models that reject the field
+//     keep working.
+func TestRequestDimensionsForwarding(t *testing.T) {
 	tests := []struct {
-		model    string
-		expected bool
+		name           string
+		opts           []Option
+		wantDimensions int64 // 0 means "must be omitted"
 	}{
-		{ModelTextEmbedding3Small, true},
-		{ModelTextEmbedding3Large, true},
-		{ModelTextEmbeddingAda002, false},
-		{"text-davinci-003", false},
-		{"", false},
+		{
+			name:           "explicit dimensions on text-embedding-3-small",
+			opts:           []Option{WithModel(ModelTextEmbedding3Small), WithDimensions(256)},
+			wantDimensions: 256,
+		},
+		{
+			name:           "explicit dimensions on text-embedding-v4",
+			opts:           []Option{WithModel("text-embedding-v4"), WithDimensions(1536)},
+			wantDimensions: 1536,
+		},
+		{
+			name:           "implicit dimensions on text-embedding-3-small (legacy default)",
+			opts:           []Option{WithModel(ModelTextEmbedding3Small)},
+			wantDimensions: int64(DefaultDimensions),
+		},
+		{
+			name:           "implicit dimensions on text-embedding-3-large (legacy default)",
+			opts:           []Option{WithModel(ModelTextEmbedding3Large)},
+			wantDimensions: int64(DefaultDimensions),
+		},
+		{
+			name:           "no explicit dimensions on ada-002 (model rejects param)",
+			opts:           []Option{WithModel(ModelTextEmbeddingAda002)},
+			wantDimensions: 0,
+		},
+		{
+			name:           "no explicit dimensions on text-embedding-v4",
+			opts:           []Option{WithModel("text-embedding-v4")},
+			wantDimensions: 0,
+		},
+		{
+			name:           "no explicit dimensions on custom OpenAI-compatible model",
+			opts:           []Option{WithModel("custom-embedder")},
+			wantDimensions: 0,
+		},
+		{
+			// Guard against the text-embedding-3 prefix accidentally
+			// matching unrelated ids that share the leading characters.
+			name:           "no explicit dimensions on text-embedding-30 (prefix-collision guard)",
+			opts:           []Option{WithModel("text-embedding-30")},
+			wantDimensions: 0,
+		},
+		{
+			name:           "no explicit dimensions on text-embedding-3rd-party (prefix-collision guard)",
+			opts:           []Option{WithModel("text-embedding-3rd-party")},
+			wantDimensions: 0,
+		},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.model, func(t *testing.T) {
-			if got := isTextEmbedding3Model(tt.model); got != tt.expected {
-				t.Errorf("isTextEmbedding3Model(%s) = %v, want %v", tt.model, got, tt.expected)
+		t.Run(tt.name, func(t *testing.T) {
+			// captured is written by the handler goroutine and read by the
+			// test goroutine after GetEmbedding returns. The HTTP round trip
+			// provides the happens-before edge, so a plain shared variable
+			// is safe; decode errors are surfaced via decodeErr instead of
+			// t.Fatalf, since t.Fatalf from a non-test goroutine only exits
+			// that goroutine and would leave the test running with bad data.
+			var (
+				captured  map[string]any
+				decodeErr error
+			)
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if !strings.HasSuffix(r.URL.Path, "/embeddings") {
+					http.Error(w, "not found", http.StatusNotFound)
+					return
+				}
+				if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+					decodeErr = err
+					http.Error(w, "bad request", http.StatusBadRequest)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"object": "list",
+					"data": []map[string]any{
+						{"object": "embedding", "index": 0, "embedding": []float64{0.1}},
+					},
+					"usage": map[string]any{"prompt_tokens": 1, "total_tokens": 1},
+				})
+			}))
+			defer srv.Close()
+
+			opts := append([]Option{WithBaseURL(srv.URL), WithAPIKey("dummy")}, tt.opts...)
+			emb := New(opts...)
+			if _, err := emb.GetEmbedding(context.Background(), "hello"); err != nil {
+				t.Fatalf("GetEmbedding err: %v", err)
+			}
+			if decodeErr != nil {
+				t.Fatalf("decode request body: %v", decodeErr)
+			}
+
+			got, present := captured["dimensions"]
+			if tt.wantDimensions == 0 {
+				if present {
+					t.Fatalf("dimensions should not be sent, but got %v", got)
+				}
+				return
+			}
+			if !present {
+				t.Fatalf("dimensions=%d expected in request, but absent", tt.wantDimensions)
+			}
+			gotF, ok := got.(float64)
+			if !ok {
+				t.Fatalf("dimensions field is not numeric: %T (%v)", got, got)
+			}
+			if int64(gotF) != tt.wantDimensions {
+				t.Errorf("dimensions = %v, want %d", got, tt.wantDimensions)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Forward the configured `dimensions` parameter to the embeddings API for **any** model id whenever the caller explicitly invoked `WithDimensions(...)`. Previously the framework only forwarded it for the `text-embedding-3-*` family, so values like `1536` configured for `text-embedding-v4` on DashScope-compatible gateways were silently dropped.
- Preserve the historical implicit default (`DefaultDimensions=1536`) for the `text-embedding-3-*` family when the caller did not call `WithDimensions`. This keeps wire compatibility for existing schemas (e.g. pgvector indices) provisioned against the old default — see CodeRabbit's regression note about `text-embedding-3-large`.
- For every other model id, omit the parameter when it was not explicitly configured, so the model's server-side default applies and gateways/models that reject the field keep working (also flagged by CodeRabbit as a wire-compatibility concern).

## Behavior matrix

| Model | `WithDimensions(N)` | Sent to API | Notes |
|-------|---------------------|-------------|-------|
| `text-embedding-3-small` (default) | not set | `dimensions=1536` | unchanged from before |
| `text-embedding-3-large` | not set | `dimensions=1536` | unchanged from before |
| `text-embedding-3-*` | set to `N` | `dimensions=N` | unchanged from before |
| `text-embedding-v4` (DashScope) | set to `1536` | `dimensions=1536` | **fix for #1664** (was: silently dropped) |
| `text-embedding-v3` / `v4` | not set | omitted | server-side default (1024) |
| `text-embedding-ada-002` | not set | omitted | unchanged from before |
| custom OpenAI-compatible model | not set | omitted | unchanged from before |
| any model | set to `N` | `dimensions=N` | new pass-through |

## Root cause
The OpenAI-compatible embedder gated the `dimensions` request field on a `text-embedding-3-*` prefix check, so `WithDimensions(...)` was a no-op for any other model id, including DashScope-compatible models such as `text-embedding-v4`. Server returned its 1024-dim default and the configured pgvector index (1536) rejected writes with `expected 1536 dimensions, not 1024`.

## Fix
Track whether `WithDimensions` was explicitly invoked via a private `dimensionsSet` flag, and emit the request field iff `dimensionsSet || isTextEmbedding3Model(model)`. The single remaining model-family check exists solely to preserve the long-standing implicit default for `text-embedding-3-*`; the new explicit-opt-in path is fully model-agnostic.

## Notes for callers
`GetDimensions()` still returns the configured value (defaulting to `DefaultDimensions=1536`), unchanged. For non `text-embedding-3-*` models where dimensions is not explicitly configured, the API may return a different vector size (e.g. 1024 for `text-embedding-v3/v4`); in that case `WithDimensions(...)` should be called so `GetDimensions()` and downstream stores stay aligned.

## Testing
- `go test ./...` (root module — 11083 passed)
- `cd session/pgvector && go test ./...` (317 passed)
- `cd openclaw && go test ./...` (2088 passed)
- New table-driven test `TestRequestDimensionsForwarding` captures the actual HTTP request body and asserts the dimensions field is present/absent and equal to the expected value across the matrix above.

Closes #1664