### PR TITLE
agui: expose source metadata for frontend event grouping

### DIFF
--- a/docs/mkdocs/en/agui.md
+++ b/docs/mkdocs/en/agui.md
@@ -388,6 +388,61 @@ For example, when using React Planner, if you want to apply different custom eve
 
 You can find the complete code example in [examples/agui/server/react](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/server/react).
 
+### Expose source metadata for frontend grouping
+
+When you enable inner Agent streaming, the frontend often needs to know
+which translated AG-UI event came from which sub-agent so it can group tool
+calls, tool results, and text output together.
+
+Use `agui.WithEventSourceMetadataEnabled(true)` to attach compact source
+metadata from the original `trpc-agent-go` event into the translated AG-UI
+event's `rawEvent` field:
+
+```go
+server, err := agui.New(
+    runner,
+    agui.WithEventSourceMetadataEnabled(true),
+)
+```
+
+The same switch is also available at lower layers if you build the stack
+manually:
+
+- `aguirunner.WithEventSourceMetadataEnabled(true)`
+- `translator.WithEventSourceMetadataEnabled(true)`
+
+After enabling it, translated AG-UI events such as `TOOL_CALL_START`,
+`TOOL_CALL_ARGS`, `TOOL_CALL_END`, `TOOL_CALL_RESULT`, text events, and
+activity events will carry a `rawEvent` object similar to:
+
+```json
+{
+  "rawEvent": {
+    "eventId": "evt-tool-call",
+    "author": "member-a",
+    "invocationId": "inv-1",
+    "parentInvocationId": "parent-1",
+    "branch": "root.member-a"
+  }
+}
+```
+
+Recommended frontend usage:
+
+- Group by `rawEvent.author` when you want a stable "which agent emitted
+  this" label.
+- Group by `rawEvent.branch` when you want one concrete sub-agent execution
+  block per run, even if the same agent name appears multiple times.
+- Keep `rawEvent.invocationId` if you need a unique execution key but do not
+  want to expose the full branch string in UI state.
+
+Compatibility notes:
+
+- The option is disabled by default.
+- Enabling it is additive only: it does not change event ordering, message
+  IDs, tool call IDs, or existing payload fields.
+- Existing clients that ignore `rawEvent` continue to work unchanged.
+
 ### Thinking content
 
 AG-UI uses `REASONING_*` events to carry model thinking content, making it easier for the frontend to display the thinking process before the final answer. For more details, see the official AG-UI docs: [Reasoning](https://docs.ag-ui.com/concepts/reasoning). A typical event sequence is as follows:

--- a/docs/mkdocs/en/agui.md
+++ b/docs/mkdocs/en/agui.md
@@ -427,6 +427,36 @@ activity events will carry a `rawEvent` object similar to:
 }
 ```
 
+`rawEvent` is optional. It only appears on AG-UI events produced by the
+AG-UI translator or the AG-UI messages snapshot builder, and it is omitted
+when the framework has no non-empty source metadata to expose.
+
+On the `/history` route, the `MESSAGES_SNAPSHOT` event uses `rawEvent` as a
+source index instead of a single-event payload:
+
+```json
+{
+  "rawEvent": {
+    "messages": {
+      "assistant-1": {
+        "eventId": "evt-assistant",
+        "author": "member-a",
+        "invocationId": "inv-1",
+        "branch": "root.member-a"
+      }
+    },
+    "toolCalls": {
+      "tool-call-1": {
+        "eventId": "evt-tool-call",
+        "author": "member-a",
+        "invocationId": "inv-1",
+        "branch": "root.member-a"
+      }
+    }
+  }
+}
+```
+
 Recommended frontend usage:
 
 - Group by `rawEvent.author` when you want a stable "which agent emitted
@@ -435,6 +465,9 @@ Recommended frontend usage:
   block per run, even if the same agent name appears multiple times.
 - Keep `rawEvent.invocationId` if you need a unique execution key but do not
   want to expose the full branch string in UI state.
+- When restoring history from `MESSAGES_SNAPSHOT`, read
+  `rawEvent.toolCalls[toolCallId]` or `rawEvent.messages[messageId]` to
+  rebuild the same grouping state before the live stream resumes.
 
 Compatibility notes:
 

--- a/docs/mkdocs/zh/agui.md
+++ b/docs/mkdocs/zh/agui.md
@@ -385,6 +385,59 @@ server, _ := agui.New(runner, agui.WithAGUIRunnerOptions(aguirunner.WithTranslat
 
 完整的代码示例可以参考 [examples/agui/server/react](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/server/react)。
 
+### 暴露 source 元数据供前端分组
+
+开启子 Agent 的流式透传后，前端经常需要知道某条 AG-UI 事件到底来自
+哪个 sub-agent，才能把 tool call、tool result 和文本输出按同一个成员
+归到一起展示。
+
+可以通过 `agui.WithEventSourceMetadataEnabled(true)`，把原始
+`trpc-agent-go` 事件里的精简 source 信息挂到翻译后的 AG-UI 事件
+`rawEvent` 字段中：
+
+```go
+server, err := agui.New(
+    runner,
+    agui.WithEventSourceMetadataEnabled(true),
+)
+```
+
+如果你不是直接用 `agui.New`，而是手动组装各层，也可以在更底层开启：
+
+- `aguirunner.WithEventSourceMetadataEnabled(true)`
+- `translator.WithEventSourceMetadataEnabled(true)`
+
+开启后，像 `TOOL_CALL_START`、`TOOL_CALL_ARGS`、`TOOL_CALL_END`、
+`TOOL_CALL_RESULT`、文本事件以及 activity 事件，都会携带类似下面的
+`rawEvent`：
+
+```json
+{
+  "rawEvent": {
+    "eventId": "evt-tool-call",
+    "author": "member-a",
+    "invocationId": "inv-1",
+    "parentInvocationId": "parent-1",
+    "branch": "root.member-a"
+  }
+}
+```
+
+前端推荐这样使用：
+
+- 想按“这是哪个 Agent 发的”分组时，用 `rawEvent.author`。
+- 想按“这一次具体的 sub-agent 执行块”分组时，用 `rawEvent.branch`。
+  这样即使同名 Agent 在一次 run 中被调用多次，也不会混在一起。
+- 如果你需要唯一执行键，但不想直接把 branch 暴露到 UI 状态里，可以
+  使用 `rawEvent.invocationId`。
+
+兼容性说明：
+
+- 该能力默认关闭。
+- 开启后只是增量增加 `rawEvent`，不会改动原有事件顺序、messageId、
+  toolCallId，也不会改变现有字段语义。
+- 现有前端如果忽略 `rawEvent`，行为保持不变。
+
 ### 思考内容
 
 AG-UI 通过`REASONING_*` 事件承载模型思考内容，便于前端在正文回复之前展示思考过程，详细可参考 [AG-UI Reasoning](https://docs.ag-ui.com/concepts/reasoning)。典型事件序列如下：

--- a/docs/mkdocs/zh/agui.md
+++ b/docs/mkdocs/zh/agui.md
@@ -423,6 +423,36 @@ server, err := agui.New(
 }
 ```
 
+`rawEvent` 是可选字段。它只会出现在 AG-UI translator 或消息快照构建
+器生成的 AG-UI 事件上；如果当前事件没有可暴露的非空 source 元数据，
+就不会携带这个字段。
+
+在 `/history` 路由上，`MESSAGES_SNAPSHOT` 的 `rawEvent` 不是单条事件
+source，而是一份 source 索引：
+
+```json
+{
+  "rawEvent": {
+    "messages": {
+      "assistant-1": {
+        "eventId": "evt-assistant",
+        "author": "member-a",
+        "invocationId": "inv-1",
+        "branch": "root.member-a"
+      }
+    },
+    "toolCalls": {
+      "tool-call-1": {
+        "eventId": "evt-tool-call",
+        "author": "member-a",
+        "invocationId": "inv-1",
+        "branch": "root.member-a"
+      }
+    }
+  }
+}
+```
+
 前端推荐这样使用：
 
 - 想按“这是哪个 Agent 发的”分组时，用 `rawEvent.author`。
@@ -430,6 +460,9 @@ server, err := agui.New(
   这样即使同名 Agent 在一次 run 中被调用多次，也不会混在一起。
 - 如果你需要唯一执行键，但不想直接把 branch 暴露到 UI 状态里，可以
   使用 `rawEvent.invocationId`。
+- 如果你是在恢复 `MESSAGES_SNAPSHOT` 历史消息，可以读取
+  `rawEvent.toolCalls[toolCallId]` 或 `rawEvent.messages[messageId]`，
+  用同一套规则还原前端分组状态。
 
 兼容性说明：
 

--- a/examples/agui/server/default/README.md
+++ b/examples/agui/server/default/README.md
@@ -18,3 +18,30 @@ The server prints startup logs showing the bound address.
 ```
 2025-09-26T10:28:46+08:00       INFO    default/main.go:60      AG-UI: serving agent "agui-agent" on http://127.0.0.1:8080/agui
 ```
+
+## Frontend grouping
+
+If your frontend needs to group streamed tool calls by sub-agent, enable
+source metadata on the server:
+
+```go
+server, err := agui.New(
+    runner,
+    agui.WithEventSourceMetadataEnabled(true),
+)
+```
+
+When enabled, translated AG-UI events carry a compact `rawEvent` object.
+Typical fields include:
+
+- `author`: the agent that emitted the original event
+- `invocationId`: the concrete invocation that produced the event
+- `parentInvocationId`: the parent invocation when the event came from a
+  nested sub-agent
+- `branch`: the execution branch, useful when the same agent runs multiple
+  times in one request
+
+Recommended grouping strategy:
+
+- Use `rawEvent.author` to show one bucket per agent name.
+- Use `rawEvent.branch` to show one bucket per concrete sub-agent execution.

--- a/examples/agui/server/default/README.md
+++ b/examples/agui/server/default/README.md
@@ -34,12 +34,17 @@ server, err := agui.New(
 When enabled, translated AG-UI events carry a compact `rawEvent` object.
 Typical fields include:
 
+- `eventId`: the original `trpc-agent-go` event identifier
 - `author`: the agent that emitted the original event
 - `invocationId`: the concrete invocation that produced the event
 - `parentInvocationId`: the parent invocation when the event came from a
   nested sub-agent
 - `branch`: the execution branch, useful when the same agent runs multiple
   times in one request
+
+`rawEvent` is optional. It only appears on AG-UI events produced by the
+AG-UI translator or the AG-UI message snapshot builder, and it is omitted
+when the framework has no non-empty source metadata to expose.
 
 Recommended grouping strategy:
 

--- a/server/agui/internal/source/metadata.go
+++ b/server/agui/internal/source/metadata.go
@@ -167,7 +167,7 @@ func fromEventOverride(ev *agentevent.Event) (Metadata, bool) {
 	}
 	var metadata Metadata
 	if err := json.Unmarshal(raw, &metadata); err != nil {
-		return Metadata{}, true
+		return Metadata{}, false
 	}
 	return metadata, true
 }

--- a/server/agui/internal/source/metadata.go
+++ b/server/agui/internal/source/metadata.go
@@ -222,7 +222,9 @@ func recordSnapshotMetadata(
 		toolCalls[e.ToolCallID] = metadata
 	case *aguievents.ToolCallResultEvent:
 		messages[e.MessageID] = metadata
-		toolCalls[e.ToolCallID] = metadata
+		if _, exists := toolCalls[e.ToolCallID]; !exists {
+			toolCalls[e.ToolCallID] = metadata
+		}
 	case *aguievents.ActivitySnapshotEvent:
 		messages[e.MessageID] = metadata
 	case *aguievents.ActivityDeltaEvent:

--- a/server/agui/internal/source/metadata.go
+++ b/server/agui/internal/source/metadata.go
@@ -1,0 +1,246 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package source provides shared helpers for AG-UI source metadata.
+package source
+
+import (
+	"encoding/json"
+
+	aguievents "github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/events"
+	agentevent "trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+const (
+	// ExtensionKey stores an AG-UI source metadata override on an agent event.
+	ExtensionKey = "server.agui.source_metadata.v1"
+)
+
+// Metadata is the compact source metadata exposed to AG-UI consumers.
+type Metadata struct {
+	EventID            string `json:"eventId,omitempty"`
+	Author             string `json:"author,omitempty"`
+	InvocationID       string `json:"invocationId,omitempty"`
+	ParentInvocationID string `json:"parentInvocationId,omitempty"`
+	Branch             string `json:"branch,omitempty"`
+}
+
+// SnapshotMetadata indexes source metadata for messages snapshot payloads.
+type SnapshotMetadata struct {
+	Messages  map[string]Metadata `json:"messages,omitempty"`
+	ToolCalls map[string]Metadata `json:"toolCalls,omitempty"`
+}
+
+// IsZero reports whether the metadata is empty.
+func (m Metadata) IsZero() bool {
+	return m == (Metadata{})
+}
+
+// IsZero reports whether the snapshot metadata is empty.
+func (m SnapshotMetadata) IsZero() bool {
+	return len(m.Messages) == 0 && len(m.ToolCalls) == 0
+}
+
+// FromEvent resolves source metadata from an agent event.
+//
+// If the event carries an explicit override in Extensions, the override takes
+// precedence. A zero-value override intentionally suppresses metadata export.
+func FromEvent(ev *agentevent.Event) (Metadata, bool) {
+	if ev == nil {
+		return Metadata{}, false
+	}
+	if metadata, ok := fromEventOverride(ev); ok {
+		return metadata, !metadata.IsZero()
+	}
+	metadata := Metadata{
+		EventID:            ev.ID,
+		Author:             ev.Author,
+		InvocationID:       ev.InvocationID,
+		ParentInvocationID: ev.ParentInvocationID,
+		Branch:             ev.Branch,
+	}
+	return metadata, !metadata.IsZero()
+}
+
+// SetEventOverride stores an explicit source metadata override on the event.
+func SetEventOverride(
+	ev *agentevent.Event,
+	metadata Metadata,
+) error {
+	if ev == nil {
+		return nil
+	}
+	raw, err := json.Marshal(metadata)
+	if err != nil {
+		return err
+	}
+	if ev.Extensions == nil {
+		ev.Extensions = make(map[string]json.RawMessage)
+	}
+	ev.Extensions[ExtensionKey] = raw
+	return nil
+}
+
+// FromRawEvent extracts source metadata from an AG-UI rawEvent payload.
+func FromRawEvent(raw any) (Metadata, bool) {
+	switch v := raw.(type) {
+	case nil:
+		return Metadata{}, false
+	case Metadata:
+		return v, !v.IsZero()
+	case *Metadata:
+		if v == nil {
+			return Metadata{}, false
+		}
+		return *v, !v.IsZero()
+	case map[string]any:
+		metadata := Metadata{
+			EventID:            stringFromMap(v, "eventId"),
+			Author:             stringFromMap(v, "author"),
+			InvocationID:       stringFromMap(v, "invocationId"),
+			ParentInvocationID: stringFromMap(v, "parentInvocationId"),
+			Branch:             stringFromMap(v, "branch"),
+		}
+		return metadata, !metadata.IsZero()
+	default:
+		rawJSON, err := json.Marshal(raw)
+		if err != nil {
+			return Metadata{}, false
+		}
+		var metadata Metadata
+		if err := json.Unmarshal(rawJSON, &metadata); err != nil {
+			return Metadata{}, false
+		}
+		return metadata, !metadata.IsZero()
+	}
+}
+
+// BuildSnapshotMetadata derives message and tool-call source indexes from
+// persisted AG-UI track events.
+func BuildSnapshotMetadata(events []session.TrackEvent) SnapshotMetadata {
+	metadata := SnapshotMetadata{
+		Messages:  make(map[string]Metadata),
+		ToolCalls: make(map[string]Metadata),
+	}
+	for _, trackEvent := range events {
+		if len(trackEvent.Payload) == 0 {
+			continue
+		}
+		evt, err := aguievents.EventFromJSON(trackEvent.Payload)
+		if err != nil || evt == nil {
+			continue
+		}
+		base := evt.GetBaseEvent()
+		if base == nil {
+			continue
+		}
+		sourceMetadata, ok := FromRawEvent(base.RawEvent)
+		if !ok {
+			continue
+		}
+		recordSnapshotMetadata(metadata.Messages, metadata.ToolCalls,
+			evt, sourceMetadata)
+	}
+	if len(metadata.Messages) == 0 {
+		metadata.Messages = nil
+	}
+	if len(metadata.ToolCalls) == 0 {
+		metadata.ToolCalls = nil
+	}
+	return metadata
+}
+
+func fromEventOverride(ev *agentevent.Event) (Metadata, bool) {
+	if ev == nil || len(ev.Extensions) == 0 {
+		return Metadata{}, false
+	}
+	raw, ok := ev.Extensions[ExtensionKey]
+	if !ok {
+		return Metadata{}, false
+	}
+	var metadata Metadata
+	if err := json.Unmarshal(raw, &metadata); err != nil {
+		return Metadata{}, true
+	}
+	return metadata, true
+}
+
+func stringFromMap(values map[string]any, key string) string {
+	value, ok := values[key]
+	if !ok {
+		return ""
+	}
+	text, ok := value.(string)
+	if !ok {
+		return ""
+	}
+	return text
+}
+
+func recordSnapshotMetadata(
+	messages map[string]Metadata,
+	toolCalls map[string]Metadata,
+	event aguievents.Event,
+	metadata Metadata,
+) {
+	switch e := event.(type) {
+	case *aguievents.TextMessageStartEvent:
+		messages[e.MessageID] = metadata
+	case *aguievents.TextMessageContentEvent:
+		messages[e.MessageID] = metadata
+	case *aguievents.TextMessageEndEvent:
+		messages[e.MessageID] = metadata
+	case *aguievents.TextMessageChunkEvent:
+		if e.MessageID != nil && *e.MessageID != "" {
+			messages[*e.MessageID] = metadata
+		}
+	case *aguievents.ReasoningMessageStartEvent:
+		messages[e.MessageID] = metadata
+	case *aguievents.ReasoningMessageContentEvent:
+		messages[e.MessageID] = metadata
+	case *aguievents.ReasoningMessageEndEvent:
+		messages[e.MessageID] = metadata
+	case *aguievents.ReasoningMessageChunkEvent:
+		if e.MessageID != nil && *e.MessageID != "" {
+			messages[*e.MessageID] = metadata
+		}
+	case *aguievents.ToolCallStartEvent:
+		toolCalls[e.ToolCallID] = metadata
+		if e.ParentMessageID != nil && *e.ParentMessageID != "" {
+			messages[*e.ParentMessageID] = metadata
+		}
+	case *aguievents.ToolCallArgsEvent:
+		toolCalls[e.ToolCallID] = metadata
+	case *aguievents.ToolCallEndEvent:
+		toolCalls[e.ToolCallID] = metadata
+	case *aguievents.ToolCallResultEvent:
+		messages[e.MessageID] = metadata
+		toolCalls[e.ToolCallID] = metadata
+	case *aguievents.ActivitySnapshotEvent:
+		messages[e.MessageID] = metadata
+	case *aguievents.ActivityDeltaEvent:
+		messages[e.MessageID] = metadata
+	case *aguievents.StepStartedEvent:
+		messages[e.ID()] = metadata
+	case *aguievents.StepFinishedEvent:
+		messages[e.ID()] = metadata
+	case *aguievents.StateSnapshotEvent:
+		messages[e.ID()] = metadata
+	case *aguievents.StateDeltaEvent:
+		messages[e.ID()] = metadata
+	case *aguievents.MessagesSnapshotEvent:
+		messages[e.ID()] = metadata
+	case *aguievents.CustomEvent:
+		messages[e.ID()] = metadata
+	case *aguievents.RawEvent:
+		messages[e.ID()] = metadata
+	default:
+	}
+}

--- a/server/agui/internal/source/metadata_test.go
+++ b/server/agui/internal/source/metadata_test.go
@@ -14,12 +14,63 @@ import (
 	"testing"
 
 	aguievents "github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/events"
+	aguitypes "github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	agentevent "trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 )
+
+const (
+	testAuthor             = "member-a"
+	testInvocationID       = "inv-1"
+	testParentInvocationID = "parent-1"
+	testBranch             = "root.member-a"
+	testMessageID          = "msg-1"
+	testParentMessageID    = "assistant-1"
+	testToolCallID         = "call-1"
+)
+
+func TestMetadataIsZero(t *testing.T) {
+	assert.True(t, Metadata{}.IsZero())
+	assert.False(t, testMetadata("evt-1").IsZero())
+}
+
+func TestSnapshotMetadataIsZero(t *testing.T) {
+	assert.True(t, SnapshotMetadata{}.IsZero())
+	assert.False(t, SnapshotMetadata{
+		Messages: map[string]Metadata{
+			testMessageID: testMetadata("evt-1"),
+		},
+	}.IsZero())
+}
+
+func TestFromEventHandlesNilAndMissingOverride(t *testing.T) {
+	metadata, ok := FromEvent(nil)
+	assert.False(t, ok)
+	assert.Equal(t, Metadata{}, metadata)
+
+	ev := agentevent.NewResponseEvent(
+		testInvocationID,
+		testAuthor,
+		&model.Response{},
+	)
+	ev.ID = "evt-1"
+	ev.ParentInvocationID = testParentInvocationID
+	ev.Branch = testBranch
+	ev.Extensions = map[string]json.RawMessage{
+		"other": json.RawMessage(`{"author":"ignored"}`),
+	}
+
+	metadata, ok = FromEvent(ev)
+	require.True(t, ok)
+	assert.Equal(t, testMetadata("evt-1"), metadata)
+}
+
+func TestSetEventOverrideHandlesNilEvent(t *testing.T) {
+	assert.NoError(t, SetEventOverride(nil, testMetadata("evt-1")))
+}
 
 func TestFromEventUsesEventFields(t *testing.T) {
 	metadata, ok := FromEvent(&agentevent.Event{
@@ -70,6 +121,38 @@ func TestFromEventMalformedOverrideFallsBackToFields(t *testing.T) {
 	}, metadata)
 }
 
+func TestFromRawEventSupportsDirectMetadataValues(t *testing.T) {
+	want := testMetadata("evt-1")
+
+	metadata, ok := FromRawEvent(want)
+	require.True(t, ok)
+	assert.Equal(t, want, metadata)
+
+	metadata, ok = FromRawEvent(&want)
+	require.True(t, ok)
+	assert.Equal(t, want, metadata)
+}
+
+func TestFromRawEventRejectsUnsupportedValues(t *testing.T) {
+	metadata, ok := FromRawEvent((*Metadata)(nil))
+	assert.False(t, ok)
+	assert.Equal(t, Metadata{}, metadata)
+
+	metadata, ok = FromRawEvent(map[string]any{
+		"author": true,
+	})
+	assert.False(t, ok)
+	assert.Equal(t, Metadata{}, metadata)
+
+	metadata, ok = FromRawEvent("invalid")
+	assert.False(t, ok)
+	assert.Equal(t, Metadata{}, metadata)
+
+	metadata, ok = FromRawEvent(func() {})
+	assert.False(t, ok)
+	assert.Equal(t, Metadata{}, metadata)
+}
+
 func TestFromRawEventSupportsMapPayload(t *testing.T) {
 	metadata, ok := FromRawEvent(map[string]any{
 		"eventId":            "evt-1",
@@ -86,6 +169,310 @@ func TestFromRawEventSupportsMapPayload(t *testing.T) {
 		ParentInvocationID: "parent-1",
 		Branch:             "root.member-a",
 	}, metadata)
+}
+
+func TestRecordSnapshotMetadataIndexesSupportedEvents(t *testing.T) {
+	metadata := testMetadata("evt-1")
+	messageID := testMessageID
+	role := "assistant"
+	textDelta := "delta"
+	reasoningDelta := "trace"
+
+	stepStarted := aguievents.NewStepStartedEvent("step-1")
+	stepFinished := aguievents.NewStepFinishedEvent("step-1")
+	stateSnapshot := aguievents.NewStateSnapshotEvent(map[string]any{
+		"foo": "bar",
+	})
+	stateDelta := aguievents.NewStateDeltaEvent(
+		[]aguievents.JSONPatchOperation{{
+			Op:    "add",
+			Path:  "/foo",
+			Value: "bar",
+		}},
+	)
+	messagesSnapshot := aguievents.NewMessagesSnapshotEvent(
+		[]aguievents.Message{{
+			ID:   testMessageID,
+			Role: aguitypes.RoleAssistant,
+		}},
+	)
+	customEvent := aguievents.NewCustomEvent("custom")
+	rawEvent := aguievents.NewRawEvent(map[string]any{
+		"foo": "bar",
+	})
+	runStarted := aguievents.NewRunStartedEvent("thread", "run")
+
+	tests := []struct {
+		name          string
+		event         aguievents.Event
+		wantMessages  map[string]Metadata
+		wantToolCalls map[string]Metadata
+	}{
+		{
+			name: "text start",
+			event: aguievents.NewTextMessageStartEvent(
+				testMessageID,
+			),
+			wantMessages: map[string]Metadata{
+				testMessageID: metadata,
+			},
+		},
+		{
+			name: "text content",
+			event: aguievents.NewTextMessageContentEvent(
+				testMessageID,
+				textDelta,
+			),
+			wantMessages: map[string]Metadata{
+				testMessageID: metadata,
+			},
+		},
+		{
+			name: "text end",
+			event: aguievents.NewTextMessageEndEvent(
+				testMessageID,
+			),
+			wantMessages: map[string]Metadata{
+				testMessageID: metadata,
+			},
+		},
+		{
+			name: "text chunk",
+			event: aguievents.NewTextMessageChunkEvent(
+				&messageID,
+				&role,
+				&textDelta,
+			),
+			wantMessages: map[string]Metadata{
+				testMessageID: metadata,
+			},
+		},
+		{
+			name: "reasoning start",
+			event: aguievents.NewReasoningMessageStartEvent(
+				testMessageID,
+				role,
+			),
+			wantMessages: map[string]Metadata{
+				testMessageID: metadata,
+			},
+		},
+		{
+			name: "reasoning content",
+			event: aguievents.NewReasoningMessageContentEvent(
+				testMessageID,
+				reasoningDelta,
+			),
+			wantMessages: map[string]Metadata{
+				testMessageID: metadata,
+			},
+		},
+		{
+			name: "reasoning end",
+			event: aguievents.NewReasoningMessageEndEvent(
+				testMessageID,
+			),
+			wantMessages: map[string]Metadata{
+				testMessageID: metadata,
+			},
+		},
+		{
+			name: "reasoning chunk",
+			event: aguievents.NewReasoningMessageChunkEvent(
+				&messageID,
+				&reasoningDelta,
+			),
+			wantMessages: map[string]Metadata{
+				testMessageID: metadata,
+			},
+		},
+		{
+			name: "tool call start",
+			event: aguievents.NewToolCallStartEvent(
+				testToolCallID,
+				"search",
+				aguievents.WithParentMessageID(
+					testParentMessageID,
+				),
+			),
+			wantMessages: map[string]Metadata{
+				testParentMessageID: metadata,
+			},
+			wantToolCalls: map[string]Metadata{
+				testToolCallID: metadata,
+			},
+		},
+		{
+			name: "tool call args",
+			event: aguievents.NewToolCallArgsEvent(
+				testToolCallID,
+				textDelta,
+			),
+			wantToolCalls: map[string]Metadata{
+				testToolCallID: metadata,
+			},
+		},
+		{
+			name: "tool call end",
+			event: aguievents.NewToolCallEndEvent(
+				testToolCallID,
+			),
+			wantToolCalls: map[string]Metadata{
+				testToolCallID: metadata,
+			},
+		},
+		{
+			name: "activity snapshot",
+			event: aguievents.NewActivitySnapshotEvent(
+				testMessageID,
+				"status",
+				map[string]any{"state": "running"},
+			),
+			wantMessages: map[string]Metadata{
+				testMessageID: metadata,
+			},
+		},
+		{
+			name: "activity delta",
+			event: aguievents.NewActivityDeltaEvent(
+				testMessageID,
+				"status",
+				[]aguievents.JSONPatchOperation{{
+					Op:    "replace",
+					Path:  "/state",
+					Value: "done",
+				}},
+			),
+			wantMessages: map[string]Metadata{
+				testMessageID: metadata,
+			},
+		},
+		{
+			name:  "step started",
+			event: stepStarted,
+			wantMessages: map[string]Metadata{
+				stepStarted.ID(): metadata,
+			},
+		},
+		{
+			name:  "step finished",
+			event: stepFinished,
+			wantMessages: map[string]Metadata{
+				stepFinished.ID(): metadata,
+			},
+		},
+		{
+			name:  "state snapshot",
+			event: stateSnapshot,
+			wantMessages: map[string]Metadata{
+				stateSnapshot.ID(): metadata,
+			},
+		},
+		{
+			name:  "state delta",
+			event: stateDelta,
+			wantMessages: map[string]Metadata{
+				stateDelta.ID(): metadata,
+			},
+		},
+		{
+			name:  "messages snapshot",
+			event: messagesSnapshot,
+			wantMessages: map[string]Metadata{
+				messagesSnapshot.ID(): metadata,
+			},
+		},
+		{
+			name:  "custom event",
+			event: customEvent,
+			wantMessages: map[string]Metadata{
+				customEvent.ID(): metadata,
+			},
+		},
+		{
+			name:  "raw event",
+			event: rawEvent,
+			wantMessages: map[string]Metadata{
+				rawEvent.ID(): metadata,
+			},
+		},
+		{
+			name:  "unsupported event",
+			event: runStarted,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			messages := make(map[string]Metadata)
+			toolCalls := make(map[string]Metadata)
+
+			recordSnapshotMetadata(
+				messages,
+				toolCalls,
+				tt.event,
+				metadata,
+			)
+
+			if tt.wantMessages == nil {
+				assert.Empty(t, messages)
+			} else {
+				assert.Equal(t, tt.wantMessages, messages)
+			}
+			if tt.wantToolCalls == nil {
+				assert.Empty(t, toolCalls)
+			} else {
+				assert.Equal(t, tt.wantToolCalls, toolCalls)
+			}
+		})
+	}
+}
+
+func TestRecordSnapshotMetadataSkipsChunkEventsWithoutMessageID(
+	t *testing.T,
+) {
+	metadata := testMetadata("evt-1")
+	messageID := ""
+	role := "assistant"
+	textDelta := "delta"
+	reasoningDelta := "trace"
+
+	tests := []aguievents.Event{
+		aguievents.NewTextMessageChunkEvent(
+			&messageID,
+			&role,
+			&textDelta,
+		),
+		aguievents.NewReasoningMessageChunkEvent(
+			&messageID,
+			&reasoningDelta,
+		),
+		aguievents.NewToolCallStartEvent(
+			testToolCallID,
+			"search",
+		),
+	}
+
+	for _, event := range tests {
+		messages := make(map[string]Metadata)
+		toolCalls := make(map[string]Metadata)
+
+		recordSnapshotMetadata(
+			messages,
+			toolCalls,
+			event,
+			metadata,
+		)
+
+		assert.Empty(t, messages)
+		if _, ok := event.(*aguievents.ToolCallStartEvent); ok {
+			assert.Equal(t, map[string]Metadata{
+				testToolCallID: metadata,
+			}, toolCalls)
+			continue
+		}
+		assert.Empty(t, toolCalls)
+	}
 }
 
 func TestBuildSnapshotMetadataIndexesMessagesAndToolCalls(t *testing.T) {
@@ -170,6 +557,16 @@ func TestBuildSnapshotMetadataFallsBackToToolResultSource(t *testing.T) {
 			"call-1": toolMetadata,
 		},
 	}, metadata)
+}
+
+func testMetadata(eventID string) Metadata {
+	return Metadata{
+		EventID:            eventID,
+		Author:             testAuthor,
+		InvocationID:       testInvocationID,
+		ParentInvocationID: testParentInvocationID,
+		Branch:             testBranch,
+	}
 }
 
 func newTrackEvent(t *testing.T, event aguievents.Event) session.TrackEvent {

--- a/server/agui/internal/source/metadata_test.go
+++ b/server/agui/internal/source/metadata_test.go
@@ -70,7 +70,7 @@ func TestFromRawEventSupportsMapPayload(t *testing.T) {
 
 func TestBuildSnapshotMetadataIndexesMessagesAndToolCalls(t *testing.T) {
 	assistantMetadata := Metadata{
-		EventID:      "evt-assistant",
+		EventID:      "evt-tool-call",
 		Author:       "member-a",
 		InvocationID: "inv-assistant",
 		Branch:       "root.member-a",
@@ -108,7 +108,7 @@ func TestBuildSnapshotMetadataIndexesMessagesAndToolCalls(t *testing.T) {
 			"tool-msg-1":  toolMetadata,
 		},
 		ToolCalls: map[string]Metadata{
-			"call-1": toolMetadata,
+			"call-1": assistantMetadata,
 		},
 	}, metadata)
 }
@@ -120,6 +120,36 @@ func TestBuildSnapshotMetadataIgnoresInvalidEntries(t *testing.T) {
 		newTrackEvent(t, aguievents.NewRunFinishedEvent("thread", "run")),
 	})
 	assert.True(t, metadata.IsZero())
+}
+
+func TestBuildSnapshotMetadataFallsBackToToolResultSource(t *testing.T) {
+	toolMetadata := Metadata{
+		EventID:      "evt-tool-result",
+		Author:       "member-a",
+		InvocationID: "inv-tool",
+		Branch:       "root.member-a",
+	}
+
+	trackEvents := []session.TrackEvent{
+		newTrackEvent(t, withRawEvent(
+			aguievents.NewToolCallResultEvent(
+				"tool-msg-1",
+				"call-1",
+				"done",
+			),
+			toolMetadata,
+		)),
+	}
+
+	metadata := BuildSnapshotMetadata(trackEvents)
+	assert.Equal(t, SnapshotMetadata{
+		Messages: map[string]Metadata{
+			"tool-msg-1": toolMetadata,
+		},
+		ToolCalls: map[string]Metadata{
+			"call-1": toolMetadata,
+		},
+	}, metadata)
 }
 
 func newTrackEvent(t *testing.T, event aguievents.Event) session.TrackEvent {

--- a/server/agui/internal/source/metadata_test.go
+++ b/server/agui/internal/source/metadata_test.go
@@ -1,0 +1,139 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package source
+
+import (
+	"encoding/json"
+	"testing"
+
+	aguievents "github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/events"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	agentevent "trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+func TestFromEventUsesEventFields(t *testing.T) {
+	metadata, ok := FromEvent(&agentevent.Event{
+		ID:                 "evt-1",
+		Author:             "member-a",
+		InvocationID:       "inv-1",
+		ParentInvocationID: "parent-1",
+		Branch:             "root.member-a",
+	})
+	require.True(t, ok)
+	assert.Equal(t, Metadata{
+		EventID:            "evt-1",
+		Author:             "member-a",
+		InvocationID:       "inv-1",
+		ParentInvocationID: "parent-1",
+		Branch:             "root.member-a",
+	}, metadata)
+}
+
+func TestFromEventOverrideSuppressesFallback(t *testing.T) {
+	ev := agentevent.NewResponseEvent("inv-1", "agui.runner", &model.Response{})
+	ev.ID = "evt-1"
+
+	require.NoError(t, SetEventOverride(ev, Metadata{}))
+
+	metadata, ok := FromEvent(ev)
+	assert.False(t, ok)
+	assert.Equal(t, Metadata{}, metadata)
+}
+
+func TestFromRawEventSupportsMapPayload(t *testing.T) {
+	metadata, ok := FromRawEvent(map[string]any{
+		"eventId":            "evt-1",
+		"author":             "member-a",
+		"invocationId":       "inv-1",
+		"parentInvocationId": "parent-1",
+		"branch":             "root.member-a",
+	})
+	require.True(t, ok)
+	assert.Equal(t, Metadata{
+		EventID:            "evt-1",
+		Author:             "member-a",
+		InvocationID:       "inv-1",
+		ParentInvocationID: "parent-1",
+		Branch:             "root.member-a",
+	}, metadata)
+}
+
+func TestBuildSnapshotMetadataIndexesMessagesAndToolCalls(t *testing.T) {
+	assistantMetadata := Metadata{
+		EventID:      "evt-assistant",
+		Author:       "member-a",
+		InvocationID: "inv-assistant",
+		Branch:       "root.member-a",
+	}
+	toolMetadata := Metadata{
+		EventID:      "evt-tool-result",
+		Author:       "member-a",
+		InvocationID: "inv-tool",
+		Branch:       "root.member-a",
+	}
+
+	trackEvents := []session.TrackEvent{
+		newTrackEvent(t, withRawEvent(
+			aguievents.NewToolCallStartEvent(
+				"call-1",
+				"search",
+				aguievents.WithParentMessageID("assistant-1"),
+			),
+			assistantMetadata,
+		)),
+		newTrackEvent(t, withRawEvent(
+			aguievents.NewToolCallResultEvent(
+				"tool-msg-1",
+				"call-1",
+				"done",
+			),
+			toolMetadata,
+		)),
+	}
+
+	metadata := BuildSnapshotMetadata(trackEvents)
+	assert.Equal(t, SnapshotMetadata{
+		Messages: map[string]Metadata{
+			"assistant-1": assistantMetadata,
+			"tool-msg-1":  toolMetadata,
+		},
+		ToolCalls: map[string]Metadata{
+			"call-1": toolMetadata,
+		},
+	}, metadata)
+}
+
+func TestBuildSnapshotMetadataIgnoresInvalidEntries(t *testing.T) {
+	metadata := BuildSnapshotMetadata([]session.TrackEvent{
+		{},
+		{Payload: []byte("{")},
+		newTrackEvent(t, aguievents.NewRunFinishedEvent("thread", "run")),
+	})
+	assert.True(t, metadata.IsZero())
+}
+
+func newTrackEvent(t *testing.T, event aguievents.Event) session.TrackEvent {
+	t.Helper()
+
+	payload, err := json.Marshal(event)
+	require.NoError(t, err)
+	return session.TrackEvent{Payload: payload}
+}
+
+func withRawEvent(
+	event aguievents.Event,
+	metadata Metadata,
+) aguievents.Event {
+	event.GetBaseEvent().RawEvent = metadata
+	return event
+}

--- a/server/agui/internal/source/metadata_test.go
+++ b/server/agui/internal/source/metadata_test.go
@@ -50,6 +50,26 @@ func TestFromEventOverrideSuppressesFallback(t *testing.T) {
 	assert.Equal(t, Metadata{}, metadata)
 }
 
+func TestFromEventMalformedOverrideFallsBackToFields(t *testing.T) {
+	ev := agentevent.NewResponseEvent("inv-1", "member-a", &model.Response{})
+	ev.ID = "evt-1"
+	ev.ParentInvocationID = "parent-1"
+	ev.Branch = "root.member-a"
+	ev.Extensions = map[string]json.RawMessage{
+		ExtensionKey: json.RawMessage("{"),
+	}
+
+	metadata, ok := FromEvent(ev)
+	require.True(t, ok)
+	assert.Equal(t, Metadata{
+		EventID:            "evt-1",
+		Author:             "member-a",
+		InvocationID:       "inv-1",
+		ParentInvocationID: "parent-1",
+		Branch:             "root.member-a",
+	}, metadata)
+}
+
 func TestFromRawEventSupportsMapPayload(t *testing.T) {
 	metadata, ok := FromRawEvent(map[string]any{
 		"eventId":            "evt-1",

--- a/server/agui/options.go
+++ b/server/agui/options.go
@@ -163,6 +163,17 @@ func WithReasoningContentEnabled(enabled bool) Option {
 	}
 }
 
+// WithEventSourceMetadataEnabled controls whether translated AG-UI events
+// include source metadata from the original trpc-agent-go event in rawEvent.
+func WithEventSourceMetadataEnabled(enabled bool) Option {
+	return func(o *options) {
+		o.aguiRunnerOptions = append(
+			o.aguiRunnerOptions,
+			aguirunner.WithEventSourceMetadataEnabled(enabled),
+		)
+	}
+}
+
 // WithToolResultInputTranslationEnabled controls whether echoed tool-result inputs pass through the AG-UI translator.
 func WithToolResultInputTranslationEnabled(enabled bool) Option {
 	return func(o *options) {

--- a/server/agui/options_test.go
+++ b/server/agui/options_test.go
@@ -118,6 +118,12 @@ func TestWithReasoningContentEnabled(t *testing.T) {
 	assert.True(t, ro.ReasoningContentEnabled)
 }
 
+func TestWithEventSourceMetadataEnabled(t *testing.T) {
+	opts := newOptions(WithEventSourceMetadataEnabled(true))
+	ro := aguirunner.NewOptions(opts.aguiRunnerOptions...)
+	assert.True(t, ro.EventSourceMetadataEnabled)
+}
+
 func TestWithToolResultInputTranslationEnabled(t *testing.T) {
 	opts := newOptions(WithToolResultInputTranslationEnabled(true))
 	ro := aguirunner.NewOptions(opts.aguiRunnerOptions...)

--- a/server/agui/runner/messagessnapshot.go
+++ b/server/agui/runner/messagessnapshot.go
@@ -20,6 +20,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/internal/reduce"
+	"trpc.group/trpc-go/trpc-agent-go/server/agui/internal/source"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 )
 
@@ -132,7 +133,14 @@ func (r *runner) getMessagesSnapshotEvent(ctx context.Context,
 	if err != nil {
 		err = fmt.Errorf("reduce track events: %w", err)
 	}
-	return aguievents.NewMessagesSnapshotEvent(messages), trackEvents, err
+	event := aguievents.NewMessagesSnapshotEvent(messages)
+	if r.eventSourceMetadataEnabled {
+		metadata := source.BuildSnapshotMetadata(trackEvents.Events)
+		if !metadata.IsZero() {
+			event.GetBaseEvent().RawEvent = metadata
+		}
+	}
+	return event, trackEvents, err
 }
 
 func (r *runner) messagesSnapshotFollow(

--- a/server/agui/runner/messagessnapshot_test.go
+++ b/server/agui/runner/messagessnapshot_test.go
@@ -205,7 +205,7 @@ func TestMessagesSnapshotAttachesSourceMetadataIndex(t *testing.T) {
 			"tool-msg-1":  toolMetadata,
 		},
 		ToolCalls: map[string]source.Metadata{
-			"tool-call-1": toolMetadata,
+			"tool-call-1": assistantMetadata,
 		},
 	}, got)
 }

--- a/server/agui/runner/messagessnapshot_test.go
+++ b/server/agui/runner/messagessnapshot_test.go
@@ -25,6 +25,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
+	"trpc.group/trpc-go/trpc-agent-go/server/agui/internal/source"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/internal/track"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/translator"
 	"trpc.group/trpc-go/trpc-agent-go/session"
@@ -135,6 +136,78 @@ func TestMessagesSnapshotHappyPath(t *testing.T) {
 	assert.Equal(t, "tool-call-1", snapshot.Messages[2].ToolCallID)
 
 	require.IsType(t, (*aguievents.RunFinishedEvent)(nil), collected[2])
+}
+
+func TestMessagesSnapshotAttachesSourceMetadataIndex(t *testing.T) {
+	assistantMetadata := source.Metadata{
+		EventID:      "evt-assistant",
+		Author:       "member-a",
+		InvocationID: "inv-assistant",
+		Branch:       "root.member-a",
+	}
+	toolMetadata := source.Metadata{
+		EventID:      "evt-tool-result",
+		Author:       "member-a",
+		InvocationID: "inv-tool",
+		Branch:       "root.member-a",
+	}
+	svc := &testSessionService{
+		trackEvents: []session.TrackEvent{
+			newTrackEvent(t, withSnapshotRawEvent(
+				aguievents.NewToolCallStartEvent(
+					"tool-call-1",
+					"calc",
+					aguievents.WithParentMessageID("assistant-1"),
+				),
+				assistantMetadata,
+			)),
+			newTrackEvent(t, withSnapshotRawEvent(
+				aguievents.NewToolCallEndEvent("tool-call-1"),
+				assistantMetadata,
+			)),
+			newTrackEvent(t, withSnapshotRawEvent(
+				aguievents.NewToolCallResultEvent(
+					"tool-msg-1",
+					"tool-call-1",
+					"42",
+				),
+				toolMetadata,
+			)),
+		},
+	}
+	tracker, err := track.New(svc)
+	require.NoError(t, err)
+	r := &runner{
+		runner:                     noopBaseRunner{},
+		userIDResolver:             NewOptions().UserIDResolver,
+		runAgentInputHook:          NewOptions().RunAgentInputHook,
+		appName:                    "demo",
+		tracker:                    tracker,
+		eventSourceMetadataEnabled: true,
+	}
+
+	stream, err := r.MessagesSnapshot(
+		context.Background(),
+		&adapter.RunAgentInput{ThreadID: "thread", RunID: "run"},
+	)
+	require.NoError(t, err)
+
+	collected := collectAGUIEvents(t, stream)
+	require.Len(t, collected, 3)
+
+	snapshot, ok := collected[1].(*aguievents.MessagesSnapshotEvent)
+	require.True(t, ok)
+	got, ok := snapshot.GetBaseEvent().RawEvent.(source.SnapshotMetadata)
+	require.True(t, ok)
+	assert.Equal(t, source.SnapshotMetadata{
+		Messages: map[string]source.Metadata{
+			"assistant-1": assistantMetadata,
+			"tool-msg-1":  toolMetadata,
+		},
+		ToolCalls: map[string]source.Metadata{
+			"tool-call-1": toolMetadata,
+		},
+	}, got)
 }
 
 func TestMessagesSnapshotUsesResolvedAppName(t *testing.T) {
@@ -910,6 +983,14 @@ func collectAGUIEvents(t *testing.T, ch <-chan aguievents.Event) []aguievents.Ev
 		events = append(events, evt)
 	}
 	return events
+}
+
+func withSnapshotRawEvent(
+	event aguievents.Event,
+	metadata source.Metadata,
+) aguievents.Event {
+	event.GetBaseEvent().RawEvent = metadata
+	return event
 }
 
 func newTrackEvent(t *testing.T, evt aguievents.Event) session.TrackEvent {

--- a/server/agui/runner/options.go
+++ b/server/agui/runner/options.go
@@ -29,6 +29,7 @@ const (
 	defaultGraphNodeInterruptActivityEnabled      = false
 	defaultGraphNodeInterruptActivityTopLevelOnly = false
 	defaultReasoningContentEnabled                = false
+	defaultEventSourceMetadataEnabled             = false
 	defaultToolResultInputTranslationEnabled      = false
 	defaultStreamingToolResultActivityEnabled     = false
 )
@@ -57,6 +58,7 @@ type Options struct {
 	GraphNodeInterruptActivityEnabled      bool                  // GraphNodeInterruptActivityEnabled enables graph interrupt activity events.
 	GraphNodeInterruptActivityTopLevelOnly bool                  // GraphNodeInterruptActivityTopLevelOnly drops nested graph interrupt activity events.
 	ReasoningContentEnabled                bool                  // ReasoningContentEnabled controls whether reasoning content events are emitted.
+	EventSourceMetadataEnabled             bool                  // EventSourceMetadataEnabled attaches original trpc-agent-go source metadata to translated AG-UI events.
 	ToolResultInputTranslationEnabled      bool                  // ToolResultInputTranslationEnabled controls whether tool-result inputs are translated before emission.
 	StreamingToolResultActivityEnabled     bool                  // StreamingToolResultActivityEnabled rewrites partial tool results as activity events.
 }
@@ -79,6 +81,7 @@ func NewOptions(opt ...Option) *Options {
 		GraphNodeInterruptActivityEnabled:      defaultGraphNodeInterruptActivityEnabled,
 		GraphNodeInterruptActivityTopLevelOnly: defaultGraphNodeInterruptActivityTopLevelOnly,
 		ReasoningContentEnabled:                defaultReasoningContentEnabled,
+		EventSourceMetadataEnabled:             defaultEventSourceMetadataEnabled,
 		ToolResultInputTranslationEnabled:      defaultToolResultInputTranslationEnabled,
 		StreamingToolResultActivityEnabled:     defaultStreamingToolResultActivityEnabled,
 	}
@@ -262,6 +265,14 @@ func WithGraphNodeInterruptActivityTopLevelOnly(enabled bool) Option {
 func WithReasoningContentEnabled(enabled bool) Option {
 	return func(o *Options) {
 		o.ReasoningContentEnabled = enabled
+	}
+}
+
+// WithEventSourceMetadataEnabled controls whether translated AG-UI events
+// carry source metadata from the original trpc-agent-go event in rawEvent.
+func WithEventSourceMetadataEnabled(enabled bool) Option {
+	return func(o *Options) {
+		o.EventSourceMetadataEnabled = enabled
 	}
 }
 

--- a/server/agui/runner/options_test.go
+++ b/server/agui/runner/options_test.go
@@ -77,6 +77,7 @@ func TestNewOptionsDefaults(t *testing.T) {
 	assert.False(t, opts.GraphNodeInterruptActivityEnabled)
 	assert.False(t, opts.GraphNodeInterruptActivityTopLevelOnly)
 	assert.False(t, opts.ReasoningContentEnabled)
+	assert.False(t, opts.EventSourceMetadataEnabled)
 	assert.False(t, opts.ToolResultInputTranslationEnabled)
 	assert.False(t, opts.StreamingToolResultActivityEnabled)
 }
@@ -136,6 +137,11 @@ func TestWithGraphNodeInterruptActivityTopLevelOnly(t *testing.T) {
 func TestWithReasoningContentEnabled(t *testing.T) {
 	opts := NewOptions(WithReasoningContentEnabled(true))
 	assert.True(t, opts.ReasoningContentEnabled)
+}
+
+func TestWithEventSourceMetadataEnabled(t *testing.T) {
+	opts := NewOptions(WithEventSourceMetadataEnabled(true))
+	assert.True(t, opts.EventSourceMetadataEnabled)
 }
 
 func TestWithToolResultInputTranslationEnabled(t *testing.T) {

--- a/server/agui/runner/runner.go
+++ b/server/agui/runner/runner.go
@@ -79,6 +79,7 @@ func New(r trunner.Runner, opt ...Option) Runner {
 		graphNodeInterruptActivityEnabled:      opts.GraphNodeInterruptActivityEnabled,
 		graphNodeInterruptActivityTopLevelOnly: opts.GraphNodeInterruptActivityTopLevelOnly,
 		reasoningContentEnabled:                opts.ReasoningContentEnabled,
+		eventSourceMetadataEnabled:             opts.EventSourceMetadataEnabled,
 		userIDResolver:                         opts.UserIDResolver,
 		translateCallbacks:                     opts.TranslateCallbacks,
 		runAgentInputHook:                      opts.RunAgentInputHook,
@@ -109,6 +110,7 @@ type runner struct {
 	graphNodeInterruptActivityEnabled      bool
 	graphNodeInterruptActivityTopLevelOnly bool
 	reasoningContentEnabled                bool
+	eventSourceMetadataEnabled             bool
 	userIDResolver                         UserIDResolver
 	translateCallbacks                     *translator.Callbacks
 	runAgentInputHook                      RunAgentInputHook
@@ -250,6 +252,7 @@ func (r *runner) Run(ctx context.Context, runAgentInput *adapter.RunAgentInput) 
 		translator.WithGraphNodeInterruptActivityEnabled(r.graphNodeInterruptActivityEnabled),
 		translator.WithGraphNodeInterruptActivityTopLevelOnly(r.graphNodeInterruptActivityTopLevelOnly),
 		translator.WithReasoningContentEnabled(r.reasoningContentEnabled),
+		translator.WithEventSourceMetadataEnabled(r.eventSourceMetadataEnabled),
 		translator.WithStreamingToolResultActivityEnabled(r.streamingToolResultActivityEnabled),
 	)
 	if err != nil {

--- a/server/agui/runner/runner.go
+++ b/server/agui/runner/runner.go
@@ -558,7 +558,9 @@ func (r *runner) emitToolResultEvent(ctx context.Context, events chan<- aguieven
 		messageID = msg.ToolID
 	}
 	if r.toolResultInputTranslationEnabled {
-		return r.handleAgentEvent(ctx, events, input, newToolResultInputEvent(messageID, msg))
+		event := newToolResultInputEvent(messageID, msg)
+		r.attachToolResultInputSourceMetadata(ctx, input.key, event, msg.ToolID)
+		return r.handleAgentEvent(ctx, events, input, event)
 	}
 	toolResultEvent := aguievents.NewToolCallResultEvent(messageID, msg.ToolID, msg.Content)
 	return r.emitEvent(ctx, events, toolResultEvent, input)

--- a/server/agui/runner/runner_test.go
+++ b/server/agui/runner/runner_test.go
@@ -57,10 +57,115 @@ func TestNew(t *testing.T) {
 	assert.NotNil(t, runner.runOptionResolver)
 	assert.False(t, runner.toolResultInputTranslationEnabled)
 	assert.False(t, runner.streamingToolResultActivityEnabled)
+	assert.False(t, runner.eventSourceMetadataEnabled)
 	userID, err := runner.userIDResolver(context.Background(),
 		&adapter.RunAgentInput{ThreadID: "thread", RunID: "run"})
 	assert.NoError(t, err)
 	assert.Equal(t, "user", userID)
+}
+
+func TestRunEventSourceMetadataEnabledAttachesRawEvent(t *testing.T) {
+	agentEvents := make(chan *agentevent.Event, 3)
+	agentEvents <- &agentevent.Event{
+		ID:                 "evt-tool-call",
+		Author:             "member-a",
+		InvocationID:       "inv-1",
+		ParentInvocationID: "parent-1",
+		Branch:             "root.member-a",
+		Response: &model.Response{
+			ID:     "msg-tool-call",
+			Object: model.ObjectTypeChatCompletion,
+			Choices: []model.Choice{{
+				Message: model.Message{
+					Role: model.RoleAssistant,
+					ToolCalls: []model.ToolCall{{
+						ID:   "call-1",
+						Type: "function",
+						Function: model.FunctionDefinitionParam{
+							Name:      "search",
+							Arguments: []byte(`{"q":"agent"}`),
+						},
+					}},
+				},
+			}},
+		},
+	}
+	agentEvents <- &agentevent.Event{
+		ID:                 "evt-tool-result",
+		Author:             "member-a",
+		InvocationID:       "inv-1",
+		ParentInvocationID: "parent-1",
+		Branch:             "root.member-a",
+		Response: &model.Response{
+			Object: model.ObjectTypeToolResponse,
+			Choices: []model.Choice{{
+				Message: model.Message{
+					Role:    model.RoleTool,
+					ToolID:  "call-1",
+					Content: "done",
+				},
+			}},
+		},
+	}
+	agentEvents <- &agentevent.Event{
+		Response: &model.Response{
+			Object: model.ObjectTypeRunnerCompletion,
+			Done:   true,
+		},
+	}
+	close(agentEvents)
+
+	underlying := &fakeRunner{
+		run: func(ctx context.Context,
+			userID, sessionID string,
+			message model.Message,
+			_ ...agent.RunOption) (<-chan *agentevent.Event, error) {
+			return agentEvents, nil
+		},
+	}
+	rr, ok := New(
+		underlying,
+		WithEventSourceMetadataEnabled(true),
+	).(*runner)
+	require.True(t, ok)
+
+	eventsCh, err := rr.Run(context.Background(), &adapter.RunAgentInput{
+		ThreadID: "thread",
+		RunID:    "run",
+		Messages: []types.Message{{Role: types.RoleUser, Content: "hi"}},
+	})
+	require.NoError(t, err)
+
+	evts := collectEvents(t, eventsCh)
+	require.Len(t, evts, 6)
+
+	want := map[string]any{
+		"eventId":            "evt-tool-call",
+		"author":             "member-a",
+		"invocationId":       "inv-1",
+		"parentInvocationId": "parent-1",
+		"branch":             "root.member-a",
+	}
+	for _, idx := range []int{1, 2, 3} {
+		payload, marshalErr := json.Marshal(evts[idx].GetBaseEvent().RawEvent)
+		require.NoError(t, marshalErr)
+		var decoded map[string]any
+		require.NoError(t, json.Unmarshal(payload, &decoded))
+		assert.Equal(t, want, decoded)
+	}
+
+	payload, err := json.Marshal(evts[1])
+	require.NoError(t, err)
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(payload, &decoded))
+	assert.Equal(t, want, decoded["rawEvent"])
+
+	resultPayload, err := json.Marshal(evts[4].GetBaseEvent().RawEvent)
+	require.NoError(t, err)
+	var resultDecoded map[string]any
+	require.NoError(t, json.Unmarshal(resultPayload, &resultDecoded))
+	assert.Equal(t, "evt-tool-result", resultDecoded["eventId"])
+	assert.Equal(t, "member-a", resultDecoded["author"])
 }
 
 func TestRunEmitsGraphNodeStartActivityWhenEnabled(t *testing.T) {

--- a/server/agui/runner/source_metadata.go
+++ b/server/agui/runner/source_metadata.go
@@ -1,0 +1,120 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package runner
+
+import (
+	"context"
+
+	aguievents "github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/events"
+	agentevent "trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/log"
+	"trpc.group/trpc-go/trpc-agent-go/server/agui/internal/source"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+func (r *runner) attachToolResultInputSourceMetadata(
+	ctx context.Context,
+	key session.Key,
+	event *agentevent.Event,
+	toolCallID string,
+) {
+	if !r.eventSourceMetadataEnabled || event == nil {
+		return
+	}
+	metadata, ok, err := r.lookupToolCallSourceMetadata(ctx, key, toolCallID)
+	if err != nil {
+		log.WarnfContext(
+			ctx,
+			"agui source metadata: lookup tool call %s: %v",
+			toolCallID,
+			err,
+		)
+	}
+	if !ok {
+		metadata = source.Metadata{}
+	}
+	if err := source.SetEventOverride(event, metadata); err != nil {
+		log.WarnfContext(
+			ctx,
+			"agui source metadata: override tool call %s: %v",
+			toolCallID,
+			err,
+		)
+	}
+}
+
+func (r *runner) lookupToolCallSourceMetadata(
+	ctx context.Context,
+	key session.Key,
+	toolCallID string,
+) (source.Metadata, bool, error) {
+	if r == nil ||
+		r.tracker == nil ||
+		toolCallID == "" {
+		return source.Metadata{}, false, nil
+	}
+	trackEvents, err := r.tracker.GetEvents(ctx, key)
+	if err != nil {
+		return source.Metadata{}, false, err
+	}
+	if trackEvents == nil || len(trackEvents.Events) == 0 {
+		return source.Metadata{}, false, nil
+	}
+	for i := len(trackEvents.Events) - 1; i >= 0; i-- {
+		metadata, ok := toolCallSourceMetadata(
+			trackEvents.Events[i].Payload,
+			toolCallID,
+		)
+		if ok {
+			return metadata, true, nil
+		}
+	}
+	return source.Metadata{}, false, nil
+}
+
+func toolCallSourceMetadata(
+	payload []byte,
+	toolCallID string,
+) (source.Metadata, bool) {
+	if len(payload) == 0 || toolCallID == "" {
+		return source.Metadata{}, false
+	}
+	event, err := aguievents.EventFromJSON(payload)
+	if err != nil || event == nil {
+		return source.Metadata{}, false
+	}
+	base := event.GetBaseEvent()
+	if base == nil {
+		return source.Metadata{}, false
+	}
+	metadata, ok := source.FromRawEvent(base.RawEvent)
+	if !ok || !matchesToolCallID(event, toolCallID) {
+		return source.Metadata{}, false
+	}
+	return metadata, true
+}
+
+func matchesToolCallID(
+	event aguievents.Event,
+	toolCallID string,
+) bool {
+	switch e := event.(type) {
+	case *aguievents.ToolCallStartEvent:
+		return e.ToolCallID == toolCallID
+	case *aguievents.ToolCallArgsEvent:
+		return e.ToolCallID == toolCallID
+	case *aguievents.ToolCallEndEvent:
+		return e.ToolCallID == toolCallID
+	case *aguievents.ToolCallResultEvent:
+		return e.ToolCallID == toolCallID
+	default:
+		return false
+	}
+}

--- a/server/agui/runner/source_metadata_test.go
+++ b/server/agui/runner/source_metadata_test.go
@@ -1,0 +1,179 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	aguievents "github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/events"
+	"github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	agentevent "trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
+	"trpc.group/trpc-go/trpc-agent-go/server/agui/internal/source"
+	tracksvc "trpc.group/trpc-go/trpc-agent-go/server/agui/internal/track"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+)
+
+func TestToolCallSourceMetadataMatchesTrackedToolCall(t *testing.T) {
+	metadata := source.Metadata{
+		EventID:      "evt-tool-call",
+		Author:       "member-a",
+		InvocationID: "inv-1",
+		Branch:       "root.member-a",
+	}
+	payload, err := json.Marshal(withTrackedRawEvent(
+		aguievents.NewToolCallStartEvent(
+			"call-1",
+			"search",
+			aguievents.WithParentMessageID("assistant-1"),
+		),
+		metadata,
+	))
+	require.NoError(t, err)
+
+	got, ok := toolCallSourceMetadata(payload, "call-1")
+	require.True(t, ok)
+	assert.Equal(t, metadata, got)
+}
+
+func TestToolCallSourceMetadataRejectsInvalidPayloads(t *testing.T) {
+	_, ok := toolCallSourceMetadata(nil, "call-1")
+	assert.False(t, ok)
+
+	_, ok = toolCallSourceMetadata([]byte("{"), "call-1")
+	assert.False(t, ok)
+
+	payload, err := json.Marshal(withTrackedRawEvent(
+		aguievents.NewRunFinishedEvent("thread", "run"),
+		source.Metadata{Author: "member-a"},
+	))
+	require.NoError(t, err)
+
+	_, ok = toolCallSourceMetadata(payload, "call-1")
+	assert.False(t, ok)
+}
+
+func TestRunToolResultInputTranslationReusesTrackedSourceMetadata(
+	t *testing.T,
+) {
+	ctx := context.Background()
+	svc := inmemory.NewSessionService()
+	tracker, err := tracksvc.New(svc)
+	require.NoError(t, err)
+	key := session.Key{
+		AppName:   "demo",
+		UserID:    "user",
+		SessionID: "thread",
+	}
+	want := source.Metadata{
+		EventID:      "evt-tool-call",
+		Author:       "member-a",
+		InvocationID: "inv-1",
+		Branch:       "root.member-a",
+	}
+	require.NoError(t, tracker.AppendEvent(ctx, key, withTrackedRawEvent(
+		aguievents.NewToolCallStartEvent(
+			"call-1",
+			"calculator",
+			aguievents.WithParentMessageID("assistant-1"),
+		),
+		want,
+	)))
+
+	rr, ok := New(
+		&fakeRunner{
+			run: func(context.Context, string, string, model.Message,
+				...agent.RunOption) (<-chan *agentevent.Event, error) {
+				ch := make(chan *agentevent.Event)
+				close(ch)
+				return ch, nil
+			},
+		},
+		WithAppName("demo"),
+		WithSessionService(svc),
+		WithEventSourceMetadataEnabled(true),
+		WithToolResultInputTranslationEnabled(true),
+	).(*runner)
+	require.True(t, ok)
+
+	eventsCh, err := rr.Run(ctx, &adapter.RunAgentInput{
+		ThreadID: "thread",
+		RunID:    "run",
+		Messages: []types.Message{{
+			ID:         "tool-msg-1",
+			Role:       types.RoleTool,
+			Content:    "done",
+			Name:       "calculator",
+			ToolCallID: "call-1",
+		}},
+	})
+	require.NoError(t, err)
+
+	events := collectEvents(t, eventsCh)
+	require.Len(t, events, 2)
+	result, ok := events[1].(*aguievents.ToolCallResultEvent)
+	require.True(t, ok)
+	got, ok := result.GetBaseEvent().RawEvent.(source.Metadata)
+	require.True(t, ok)
+	assert.Equal(t, want, got)
+}
+
+func TestRunToolResultInputTranslationSuppressesSyntheticSourceMetadata(
+	t *testing.T,
+) {
+	rr, ok := New(
+		&fakeRunner{
+			run: func(context.Context, string, string, model.Message,
+				...agent.RunOption) (<-chan *agentevent.Event, error) {
+				ch := make(chan *agentevent.Event)
+				close(ch)
+				return ch, nil
+			},
+		},
+		WithAppName("demo"),
+		WithEventSourceMetadataEnabled(true),
+		WithToolResultInputTranslationEnabled(true),
+	).(*runner)
+	require.True(t, ok)
+
+	eventsCh, err := rr.Run(context.Background(), &adapter.RunAgentInput{
+		ThreadID: "thread",
+		RunID:    "run",
+		Messages: []types.Message{{
+			ID:         "tool-msg-1",
+			Role:       types.RoleTool,
+			Content:    "done",
+			Name:       "calculator",
+			ToolCallID: "call-1",
+		}},
+	})
+	require.NoError(t, err)
+
+	events := collectEvents(t, eventsCh)
+	require.Len(t, events, 2)
+	result, ok := events[1].(*aguievents.ToolCallResultEvent)
+	require.True(t, ok)
+	assert.Nil(t, result.GetBaseEvent().RawEvent)
+}
+
+func withTrackedRawEvent(
+	event aguievents.Event,
+	metadata source.Metadata,
+) aguievents.Event {
+	event.GetBaseEvent().RawEvent = metadata
+	return event
+}

--- a/server/agui/runner/source_metadata_test.go
+++ b/server/agui/runner/source_metadata_test.go
@@ -12,6 +12,7 @@ package runner
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	aguievents "github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/events"
@@ -26,6 +27,15 @@ import (
 	tracksvc "trpc.group/trpc-go/trpc-agent-go/server/agui/internal/track"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	"trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+)
+
+const (
+	runnerAppName   = "demo"
+	runnerThreadID  = "thread"
+	runnerUserID    = "user"
+	runnerToolCall  = "call-1"
+	runnerToolName  = "calculator"
+	runnerMessageID = "tool-msg-1"
 )
 
 func TestToolCallSourceMetadataMatchesTrackedToolCall(t *testing.T) {
@@ -50,6 +60,28 @@ func TestToolCallSourceMetadataMatchesTrackedToolCall(t *testing.T) {
 	assert.Equal(t, metadata, got)
 }
 
+func TestToolCallSourceMetadataRejectsMissingRawEventAndMismatches(
+	t *testing.T,
+) {
+	payload, err := json.Marshal(aguievents.NewToolCallStartEvent(
+		runnerToolCall,
+		runnerToolName,
+	))
+	require.NoError(t, err)
+
+	_, ok := toolCallSourceMetadata(payload, runnerToolCall)
+	assert.False(t, ok)
+
+	payload, err = json.Marshal(withTrackedRawEvent(
+		aguievents.NewToolCallEndEvent(runnerToolCall),
+		source.Metadata{Author: "member-a"},
+	))
+	require.NoError(t, err)
+
+	_, ok = toolCallSourceMetadata(payload, "other")
+	assert.False(t, ok)
+}
+
 func TestToolCallSourceMetadataRejectsInvalidPayloads(t *testing.T) {
 	_, ok := toolCallSourceMetadata(nil, "call-1")
 	assert.False(t, ok)
@@ -65,6 +97,325 @@ func TestToolCallSourceMetadataRejectsInvalidPayloads(t *testing.T) {
 
 	_, ok = toolCallSourceMetadata(payload, "call-1")
 	assert.False(t, ok)
+}
+
+func TestMatchesToolCallID(t *testing.T) {
+	tests := []struct {
+		name   string
+		event  aguievents.Event
+		want   bool
+		target string
+	}{
+		{
+			name: "tool call start",
+			event: aguievents.NewToolCallStartEvent(
+				runnerToolCall,
+				runnerToolName,
+			),
+			target: runnerToolCall,
+			want:   true,
+		},
+		{
+			name: "tool call args",
+			event: aguievents.NewToolCallArgsEvent(
+				runnerToolCall,
+				"{}",
+			),
+			target: runnerToolCall,
+			want:   true,
+		},
+		{
+			name: "tool call end",
+			event: aguievents.NewToolCallEndEvent(
+				runnerToolCall,
+			),
+			target: runnerToolCall,
+			want:   true,
+		},
+		{
+			name: "tool call result",
+			event: aguievents.NewToolCallResultEvent(
+				runnerMessageID,
+				runnerToolCall,
+				"done",
+			),
+			target: runnerToolCall,
+			want:   true,
+		},
+		{
+			name: "non tool event",
+			event: aguievents.NewRunStartedEvent(
+				runnerThreadID,
+				"run",
+			),
+			target: runnerToolCall,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(
+				t,
+				tt.want,
+				matchesToolCallID(tt.event, tt.target),
+			)
+		})
+	}
+}
+
+func TestLookupToolCallSourceMetadataGuardClauses(t *testing.T) {
+	ctx := context.Background()
+	key := session.Key{
+		AppName:   runnerAppName,
+		UserID:    runnerUserID,
+		SessionID: runnerThreadID,
+	}
+
+	var nilRunner *runner
+	metadata, ok, err := nilRunner.lookupToolCallSourceMetadata(
+		ctx,
+		key,
+		runnerToolCall,
+	)
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Equal(t, source.Metadata{}, metadata)
+
+	rr := &runner{}
+	metadata, ok, err = rr.lookupToolCallSourceMetadata(
+		ctx,
+		key,
+		runnerToolCall,
+	)
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Equal(t, source.Metadata{}, metadata)
+
+	rr.tracker = &staticTrackEventsTracker{}
+	metadata, ok, err = rr.lookupToolCallSourceMetadata(
+		ctx,
+		key,
+		"",
+	)
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Equal(t, source.Metadata{}, metadata)
+}
+
+func TestLookupToolCallSourceMetadataHandlesTrackerResponses(t *testing.T) {
+	ctx := context.Background()
+	key := session.Key{
+		AppName:   runnerAppName,
+		UserID:    runnerUserID,
+		SessionID: runnerThreadID,
+	}
+	want := source.Metadata{
+		EventID:      "evt-new",
+		Author:       "member-a",
+		InvocationID: "inv-2",
+		Branch:       "root.member-a",
+	}
+	older := source.Metadata{
+		EventID:      "evt-old",
+		Author:       "member-a",
+		InvocationID: "inv-1",
+		Branch:       "root.member-a",
+	}
+
+	rr := &runner{
+		tracker: &staticTrackEventsTracker{
+			events: &session.TrackEvents{Events: []session.TrackEvent{
+				newTrackedTrackEvent(t, withTrackedRawEvent(
+					aguievents.NewToolCallStartEvent(
+						runnerToolCall,
+						runnerToolName,
+					),
+					older,
+				)),
+				newTrackedTrackEvent(t, withTrackedRawEvent(
+					aguievents.NewToolCallArgsEvent(
+						"other",
+						"{}",
+					),
+					source.Metadata{Author: "ignored"},
+				)),
+				newTrackedTrackEvent(t, withTrackedRawEvent(
+					aguievents.NewToolCallEndEvent(
+						runnerToolCall,
+					),
+					want,
+				)),
+			}},
+		},
+	}
+
+	got, ok, err := rr.lookupToolCallSourceMetadata(
+		ctx,
+		key,
+		runnerToolCall,
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, want, got)
+}
+
+func TestLookupToolCallSourceMetadataHandlesMissAndError(t *testing.T) {
+	ctx := context.Background()
+	key := session.Key{
+		AppName:   runnerAppName,
+		UserID:    runnerUserID,
+		SessionID: runnerThreadID,
+	}
+
+	rr := &runner{tracker: &staticTrackEventsTracker{}}
+	metadata, ok, err := rr.lookupToolCallSourceMetadata(
+		ctx,
+		key,
+		runnerToolCall,
+	)
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Equal(t, source.Metadata{}, metadata)
+
+	rr.tracker = &staticTrackEventsTracker{
+		events: &session.TrackEvents{},
+	}
+	metadata, ok, err = rr.lookupToolCallSourceMetadata(
+		ctx,
+		key,
+		runnerToolCall,
+	)
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Equal(t, source.Metadata{}, metadata)
+
+	rr.tracker = &getEventsErrorTracker{
+		err: errors.New("boom"),
+	}
+	metadata, ok, err = rr.lookupToolCallSourceMetadata(
+		ctx,
+		key,
+		runnerToolCall,
+	)
+	require.Error(t, err)
+	assert.False(t, ok)
+	assert.Equal(t, source.Metadata{}, metadata)
+}
+
+func TestAttachToolResultInputSourceMetadata(t *testing.T) {
+	ctx := context.Background()
+	key := session.Key{
+		AppName:   runnerAppName,
+		UserID:    runnerUserID,
+		SessionID: runnerThreadID,
+	}
+
+	t.Run("disabled runner leaves event untouched", func(t *testing.T) {
+		ev := agentevent.NewResponseEvent(
+			"inv-1",
+			toolResultInputEventAuthor,
+			&model.Response{},
+		)
+		rr := &runner{}
+
+		rr.attachToolResultInputSourceMetadata(
+			ctx,
+			key,
+			ev,
+			runnerToolCall,
+		)
+
+		assert.Nil(t, ev.Extensions)
+	})
+
+	t.Run("missing source stores zero override", func(t *testing.T) {
+		ev := agentevent.NewResponseEvent(
+			"inv-1",
+			toolResultInputEventAuthor,
+			&model.Response{},
+		)
+		rr := &runner{
+			eventSourceMetadataEnabled: true,
+			tracker:                    &staticTrackEventsTracker{},
+		}
+
+		rr.attachToolResultInputSourceMetadata(
+			ctx,
+			key,
+			ev,
+			runnerToolCall,
+		)
+
+		metadata, ok := source.FromEvent(ev)
+		assert.False(t, ok)
+		assert.Equal(t, source.Metadata{}, metadata)
+	})
+
+	t.Run("lookup hit reuses tracked metadata", func(t *testing.T) {
+		want := source.Metadata{
+			EventID:      "evt-tool-call",
+			Author:       "member-a",
+			InvocationID: "inv-1",
+			Branch:       "root.member-a",
+		}
+		ev := agentevent.NewResponseEvent(
+			"inv-1",
+			toolResultInputEventAuthor,
+			&model.Response{},
+		)
+		rr := &runner{
+			eventSourceMetadataEnabled: true,
+			tracker: &staticTrackEventsTracker{
+				events: &session.TrackEvents{
+					Events: []session.TrackEvent{
+						newTrackedTrackEvent(t, withTrackedRawEvent(
+							aguievents.NewToolCallStartEvent(
+								runnerToolCall,
+								runnerToolName,
+							),
+							want,
+						)),
+					},
+				},
+			},
+		}
+
+		rr.attachToolResultInputSourceMetadata(
+			ctx,
+			key,
+			ev,
+			runnerToolCall,
+		)
+
+		metadata, ok := source.FromEvent(ev)
+		require.True(t, ok)
+		assert.Equal(t, want, metadata)
+	})
+
+	t.Run("lookup error still suppresses fallback", func(t *testing.T) {
+		ev := agentevent.NewResponseEvent(
+			"inv-1",
+			toolResultInputEventAuthor,
+			&model.Response{},
+		)
+		rr := &runner{
+			eventSourceMetadataEnabled: true,
+			tracker: &getEventsErrorTracker{
+				err: errors.New("boom"),
+			},
+		}
+
+		rr.attachToolResultInputSourceMetadata(
+			ctx,
+			key,
+			ev,
+			runnerToolCall,
+		)
+
+		metadata, ok := source.FromEvent(ev)
+		assert.False(t, ok)
+		assert.Equal(t, source.Metadata{}, metadata)
+	})
 }
 
 func TestRunToolResultInputTranslationReusesTrackedSourceMetadata(
@@ -168,6 +519,71 @@ func TestRunToolResultInputTranslationSuppressesSyntheticSourceMetadata(
 	result, ok := events[1].(*aguievents.ToolCallResultEvent)
 	require.True(t, ok)
 	assert.Nil(t, result.GetBaseEvent().RawEvent)
+}
+
+type staticTrackEventsTracker struct {
+	events *session.TrackEvents
+}
+
+func (s *staticTrackEventsTracker) AppendEvent(
+	context.Context,
+	session.Key,
+	aguievents.Event,
+) error {
+	return nil
+}
+
+func (s *staticTrackEventsTracker) GetEvents(
+	context.Context,
+	session.Key,
+	...session.Option,
+) (*session.TrackEvents, error) {
+	return s.events, nil
+}
+
+func (s *staticTrackEventsTracker) Flush(
+	context.Context,
+	session.Key,
+) error {
+	return nil
+}
+
+type getEventsErrorTracker struct {
+	err error
+}
+
+func (g *getEventsErrorTracker) AppendEvent(
+	context.Context,
+	session.Key,
+	aguievents.Event,
+) error {
+	return nil
+}
+
+func (g *getEventsErrorTracker) GetEvents(
+	context.Context,
+	session.Key,
+	...session.Option,
+) (*session.TrackEvents, error) {
+	return nil, g.err
+}
+
+func (g *getEventsErrorTracker) Flush(
+	context.Context,
+	session.Key,
+) error {
+	return nil
+}
+
+func newTrackedTrackEvent(
+	t *testing.T,
+	event aguievents.Event,
+) session.TrackEvent {
+	t.Helper()
+
+	payload, err := json.Marshal(event)
+	require.NoError(t, err)
+	return session.TrackEvent{Payload: payload}
 }
 
 func withTrackedRawEvent(

--- a/server/agui/translator/options.go
+++ b/server/agui/translator/options.go
@@ -15,6 +15,7 @@ type options struct {
 	graphNodeInterruptActivityEnabled      bool // graphNodeInterruptActivityEnabled enables graph interrupt activity events.
 	graphNodeInterruptActivityTopLevelOnly bool // graphNodeInterruptActivityTopLevelOnly drops nested graph interrupt activity events.
 	reasoningContentEnabled                bool // reasoningContentEnabled controls whether reasoning content events are emitted.
+	eventSourceMetadataEnabled             bool // eventSourceMetadataEnabled attaches trpc-agent-go source metadata to translated AG-UI events.
 	streamingToolResultActivityEnabled     bool // streamingToolResultActivityEnabled rewrites partial tool results as activity events.
 }
 
@@ -58,6 +59,15 @@ func WithGraphNodeInterruptActivityTopLevelOnly(enabled bool) Option {
 func WithReasoningContentEnabled(enabled bool) Option {
 	return func(o *options) {
 		o.reasoningContentEnabled = enabled
+	}
+}
+
+// WithEventSourceMetadataEnabled controls whether the translator attaches
+// source metadata from the original trpc-agent-go event to each translated
+// AG-UI event via the AG-UI event's rawEvent field.
+func WithEventSourceMetadataEnabled(enabled bool) Option {
+	return func(o *options) {
+		o.eventSourceMetadataEnabled = enabled
 	}
 }
 

--- a/server/agui/translator/translator.go
+++ b/server/agui/translator/translator.go
@@ -26,6 +26,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
+	"trpc.group/trpc-go/trpc-agent-go/server/agui/internal/source"
 	aguitool "trpc.group/trpc-go/trpc-agent-go/server/agui/internal/tool"
 	"trpc.group/trpc-go/trpc-agent-go/skill"
 )
@@ -95,14 +96,6 @@ type translator struct {
 	eventSourceMetadataEnabled             bool
 	streamingToolResultActivityEnabled     bool
 	streamingToolResultContent             map[string]string
-}
-
-type eventSourceMetadata struct {
-	EventID            string `json:"eventId,omitempty"`
-	Author             string `json:"author,omitempty"`
-	InvocationID       string `json:"invocationId,omitempty"`
-	ParentInvocationID string `json:"parentInvocationId,omitempty"`
-	Branch             string `json:"branch,omitempty"`
 }
 
 const skillRunArtifactsStateKey = skill.StateKeyArtifacts
@@ -227,7 +220,8 @@ func (t *translator) finalizeEvents(
 		len(events) == 0 {
 		return events
 	}
-	metadata, ok := newEventSourceMetadata(src)
+	// A zero-value override intentionally suppresses rawEvent export.
+	metadata, ok := source.FromEvent(src)
 	if !ok {
 		return events
 	}
@@ -242,25 +236,6 @@ func (t *translator) finalizeEvents(
 		base.RawEvent = metadata
 	}
 	return events
-}
-
-func newEventSourceMetadata(
-	ev *agentevent.Event,
-) (eventSourceMetadata, bool) {
-	if ev == nil {
-		return eventSourceMetadata{}, false
-	}
-	metadata := eventSourceMetadata{
-		EventID:            ev.ID,
-		Author:             ev.Author,
-		InvocationID:       ev.InvocationID,
-		ParentInvocationID: ev.ParentInvocationID,
-		Branch:             ev.Branch,
-	}
-	if metadata == (eventSourceMetadata{}) {
-		return eventSourceMetadata{}, false
-	}
-	return metadata, true
 }
 
 type artifactRef struct {

--- a/server/agui/translator/translator.go
+++ b/server/agui/translator/translator.go
@@ -72,6 +72,7 @@ func New(ctx context.Context, threadID, runID string, opts ...Option) (Translato
 		graphNodeInterruptActivityEnabled:      options.graphNodeInterruptActivityEnabled,
 		graphNodeInterruptActivityTopLevelOnly: options.graphNodeInterruptActivityTopLevelOnly,
 		reasoningContentEnabled:                options.reasoningContentEnabled,
+		eventSourceMetadataEnabled:             options.eventSourceMetadataEnabled,
 		streamingToolResultActivityEnabled:     options.streamingToolResultActivityEnabled,
 		streamingToolResultContent:             make(map[string]string),
 	}, nil
@@ -91,8 +92,17 @@ type translator struct {
 	graphNodeInterruptActivityEnabled      bool
 	graphNodeInterruptActivityTopLevelOnly bool
 	reasoningContentEnabled                bool
+	eventSourceMetadataEnabled             bool
 	streamingToolResultActivityEnabled     bool
 	streamingToolResultContent             map[string]string
+}
+
+type eventSourceMetadata struct {
+	EventID            string `json:"eventId,omitempty"`
+	Author             string `json:"author,omitempty"`
+	InvocationID       string `json:"invocationId,omitempty"`
+	ParentInvocationID string `json:"parentInvocationId,omitempty"`
+	Branch             string `json:"branch,omitempty"`
 }
 
 const skillRunArtifactsStateKey = skill.StateKeyArtifacts
@@ -127,14 +137,14 @@ func (t *translator) Translate(ctx context.Context, event *agentevent.Event) ([]
 	rsp := event.Response
 	if rsp == nil {
 		if len(events) > 0 || hasGraphDelta {
-			return events, nil
+			return t.finalizeEvents(event, events), nil
 		}
 		return nil, errors.New("event response is nil")
 	}
 	if rsp.Error != nil {
 		log.Errorf("agui: threadID: %s, runID: %s, error in response: %v", t.threadID, t.runID, rsp.Error)
 		events = append(events, aguievents.NewRunErrorEvent(rsp.Error.Message, aguievents.WithRunID(t.runID)))
-		return events, nil
+		return t.finalizeEvents(event, events), nil
 	}
 	if rsp.Object == model.ObjectTypeChatCompletionChunk || rsp.Object == model.ObjectTypeChatCompletion {
 		if t.reasoningContentEnabled {
@@ -183,7 +193,7 @@ func (t *translator) Translate(ctx context.Context, event *agentevent.Event) ([]
 		events = append(events, finalizationEvents...)
 		events = append(events, aguievents.NewRunFinishedEvent(t.threadID, t.runID))
 	}
-	return events, nil
+	return t.finalizeEvents(event, events), nil
 }
 
 // PostRunFinalizationEvents closes any active reasoning or text streams after a run ends.
@@ -206,6 +216,51 @@ func (t *translator) PostRunFinalizationEvents(context.Context) ([]aguievents.Ev
 		t.receivingMessage = false
 	}
 	return events, nil
+}
+
+func (t *translator) finalizeEvents(
+	src *agentevent.Event,
+	events []aguievents.Event,
+) []aguievents.Event {
+	if t == nil ||
+		!t.eventSourceMetadataEnabled ||
+		len(events) == 0 {
+		return events
+	}
+	metadata, ok := newEventSourceMetadata(src)
+	if !ok {
+		return events
+	}
+	for _, evt := range events {
+		if evt == nil {
+			continue
+		}
+		base := evt.GetBaseEvent()
+		if base == nil || base.RawEvent != nil {
+			continue
+		}
+		base.RawEvent = metadata
+	}
+	return events
+}
+
+func newEventSourceMetadata(
+	ev *agentevent.Event,
+) (eventSourceMetadata, bool) {
+	if ev == nil {
+		return eventSourceMetadata{}, false
+	}
+	metadata := eventSourceMetadata{
+		EventID:            ev.ID,
+		Author:             ev.Author,
+		InvocationID:       ev.InvocationID,
+		ParentInvocationID: ev.ParentInvocationID,
+		Branch:             ev.Branch,
+	}
+	if metadata == (eventSourceMetadata{}) {
+		return eventSourceMetadata{}, false
+	}
+	return metadata, true
 }
 
 type artifactRef struct {

--- a/server/agui/translator/translator_test.go
+++ b/server/agui/translator/translator_test.go
@@ -288,6 +288,20 @@ func TestFinalizeEventsHandlesNilInputs(t *testing.T) {
 	result = translator.finalizeEvents(nil, events)
 	assert.Equal(t, events, result)
 	assert.Nil(t, events[2].GetBaseEvent().RawEvent)
+
+	src := &agentevent.Event{Author: "member-a"}
+	events = []aguievents.Event{
+		nil,
+		stubEventWithNilBase{},
+		aguievents.NewRunStartedEvent("thread", "run"),
+	}
+	result = translator.finalizeEvents(src, events)
+	assert.Equal(t, events, result)
+	assert.Nil(t, events[0])
+
+	got, ok := events[2].GetBaseEvent().RawEvent.(source.Metadata)
+	require.True(t, ok)
+	assert.Equal(t, source.Metadata{Author: "member-a"}, got)
 }
 
 type stubEventWithNilBase struct{}

--- a/server/agui/translator/translator_test.go
+++ b/server/agui/translator/translator_test.go
@@ -19,11 +19,13 @@ import (
 	aguievents "github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/events"
 	aguitypes "github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
 	agentevent "trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/graph"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	trunner "trpc.group/trpc-go/trpc-agent-go/runner"
+	"trpc.group/trpc-go/trpc-agent-go/server/agui/internal/source"
 	aguitool "trpc.group/trpc-go/trpc-agent-go/server/agui/internal/tool"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
@@ -214,7 +216,7 @@ func TestTranslateAttachesEventSourceMetadataWhenEnabled(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, events, 3)
 
-	want := eventSourceMetadata{
+	want := source.Metadata{
 		EventID:            "evt-1",
 		Author:             "member-a",
 		InvocationID:       "inv-1",
@@ -222,7 +224,7 @@ func TestTranslateAttachesEventSourceMetadataWhenEnabled(t *testing.T) {
 		Branch:             "root.member-a",
 	}
 	for _, evt := range events {
-		got, ok := evt.GetBaseEvent().RawEvent.(eventSourceMetadata)
+		got, ok := evt.GetBaseEvent().RawEvent.(source.Metadata)
 		assert.True(t, ok)
 		assert.Equal(t, want, got)
 	}
@@ -233,6 +235,80 @@ func TestTranslateAttachesEventSourceMetadataWhenEnabled(t *testing.T) {
 	assert.Contains(t, string(payload), `"author":"member-a"`)
 	assert.Contains(t, string(payload), `"invocationId":"inv-1"`)
 }
+
+func TestFinalizeEventsSkipsExistingRawEvent(t *testing.T) {
+	translator := &translator{eventSourceMetadataEnabled: true}
+	existing := map[string]any{"keep": true}
+	event := aguievents.NewRunStartedEvent("thread", "run")
+	event.GetBaseEvent().RawEvent = existing
+
+	events := translator.finalizeEvents(
+		&agentevent.Event{Author: "member-a"},
+		[]aguievents.Event{event},
+	)
+	require.Len(t, events, 1)
+	assert.Equal(t, existing, events[0].GetBaseEvent().RawEvent)
+}
+
+func TestFinalizeEventsSuppressesZeroOverride(t *testing.T) {
+	translator := &translator{eventSourceMetadataEnabled: true}
+	src := agentevent.NewResponseEvent("inv-1", "agui.runner", &model.Response{})
+	require.NoError(t, source.SetEventOverride(src, source.Metadata{}))
+
+	events := translator.finalizeEvents(
+		src,
+		[]aguievents.Event{
+			aguievents.NewRunStartedEvent("thread", "run"),
+		},
+	)
+	require.Len(t, events, 1)
+	assert.Nil(t, events[0].GetBaseEvent().RawEvent)
+}
+
+func TestFinalizeEventsHandlesNilInputs(t *testing.T) {
+	var nilTranslator *translator
+	assert.Nil(t, nilTranslator.finalizeEvents(nil, nil))
+
+	translator := &translator{}
+	assert.Nil(t, translator.finalizeEvents(nil, nil))
+
+	events := []aguievents.Event{nil}
+	result := translator.finalizeEvents(
+		&agentevent.Event{Author: "member-a"},
+		events,
+	)
+	assert.Equal(t, events, result)
+
+	translator.eventSourceMetadataEnabled = true
+	events = []aguievents.Event{
+		nil,
+		stubEventWithNilBase{},
+		aguievents.NewRunStartedEvent("thread", "run"),
+	}
+	result = translator.finalizeEvents(nil, events)
+	assert.Equal(t, events, result)
+	assert.Nil(t, events[2].GetBaseEvent().RawEvent)
+}
+
+type stubEventWithNilBase struct{}
+
+func (stubEventWithNilBase) Type() aguievents.EventType {
+	return aguievents.EventTypeRunStarted
+}
+
+func (stubEventWithNilBase) Timestamp() *int64 { return nil }
+
+func (stubEventWithNilBase) SetTimestamp(int64) {}
+
+func (stubEventWithNilBase) ThreadID() string { return "" }
+
+func (stubEventWithNilBase) RunID() string { return "" }
+
+func (stubEventWithNilBase) Validate() error { return nil }
+
+func (stubEventWithNilBase) ToJSON() ([]byte, error) { return nil, nil }
+
+func (stubEventWithNilBase) GetBaseEvent() *aguievents.BaseEvent { return nil }
 
 func TestTextMessageEventStreamingAndCompletion(t *testing.T) {
 	translator := newTranslatorImplForTest(t)

--- a/server/agui/translator/translator_test.go
+++ b/server/agui/translator/translator_test.go
@@ -144,6 +144,96 @@ func TestTranslateErrorResponse(t *testing.T) {
 	assert.Equal(t, "run", runErr.RunID())
 }
 
+func TestTranslateEventSourceMetadataDisabledByDefault(t *testing.T) {
+	translator := newTranslatorForTest(t)
+	if translator == nil {
+		return
+	}
+	rsp := &model.Response{
+		ID:     "msg-1",
+		Object: model.ObjectTypeChatCompletionChunk,
+		Choices: []model.Choice{{
+			Delta: model.Message{
+				Role:    model.RoleAssistant,
+				Content: "Hello",
+			},
+		}},
+	}
+	events, err := translator.Translate(
+		context.Background(),
+		&agentevent.Event{
+			ID:           "evt-1",
+			Author:       "member-a",
+			InvocationID: "inv-1",
+			Response:     rsp,
+		},
+	)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, events)
+	for _, evt := range events {
+		assert.Nil(t, evt.GetBaseEvent().RawEvent)
+	}
+}
+
+func TestTranslateAttachesEventSourceMetadataWhenEnabled(t *testing.T) {
+	translator := newTranslatorForTest(
+		t,
+		WithEventSourceMetadataEnabled(true),
+	)
+	if translator == nil {
+		return
+	}
+	rsp := &model.Response{
+		ID:     "msg-1",
+		Object: model.ObjectTypeChatCompletion,
+		Choices: []model.Choice{{
+			Message: model.Message{
+				Role: model.RoleAssistant,
+				ToolCalls: []model.ToolCall{{
+					ID:   "call-1",
+					Type: "function",
+					Function: model.FunctionDefinitionParam{
+						Name:      "search",
+						Arguments: []byte(`{"q":"agent"}`),
+					},
+				}},
+			},
+		}},
+	}
+	events, err := translator.Translate(
+		context.Background(),
+		&agentevent.Event{
+			ID:                 "evt-1",
+			Author:             "member-a",
+			InvocationID:       "inv-1",
+			ParentInvocationID: "parent-1",
+			Branch:             "root.member-a",
+			Response:           rsp,
+		},
+	)
+	assert.NoError(t, err)
+	assert.Len(t, events, 3)
+
+	want := eventSourceMetadata{
+		EventID:            "evt-1",
+		Author:             "member-a",
+		InvocationID:       "inv-1",
+		ParentInvocationID: "parent-1",
+		Branch:             "root.member-a",
+	}
+	for _, evt := range events {
+		got, ok := evt.GetBaseEvent().RawEvent.(eventSourceMetadata)
+		assert.True(t, ok)
+		assert.Equal(t, want, got)
+	}
+
+	payload, err := json.Marshal(events[0])
+	assert.NoError(t, err)
+	assert.Contains(t, string(payload), `"rawEvent":`)
+	assert.Contains(t, string(payload), `"author":"member-a"`)
+	assert.Contains(t, string(payload), `"invocationId":"inv-1"`)
+}
+
 func TestTextMessageEventStreamingAndCompletion(t *testing.T) {
 	translator := newTranslatorImplForTest(t)
 	if translator == nil {


### PR DESCRIPTION
## What changed
- add an opt-in AG-UI option to attach source metadata to translated events through `rawEvent`
- thread the option through `agui`, `aguirunner`, and `translator`
- add translator and runner tests covering default-off behavior and enabled metadata emission
- document how frontends can group sub-agent tool calls by `author`, `branch`, and `invocationId`

## Why
Frontends that stream multi-agent output can already receive translated AG-UI tool events, but they cannot reliably tell which sub-agent produced each tool call or tool result. The raw `trpc-agent-go` event already carries this information; the AG-UI layer was dropping it.

## Impact
- fully backward compatible: the option is disabled by default
- existing clients remain unchanged unless they opt in
- opt-in clients can group tool calls and related output by sub-agent without changing event ordering or existing IDs

## Validation
- `cd server/agui && go test ./...`
- `cd examples/agui && go test ./...`
- `mkdocs build --strict -f docs/mkdocs.yml`
