### PR TITLE
tool/agent: fix flaky flush-signal race in agent_tool tests

### DIFF
--- a/tool/agent/agent_tool_test.go
+++ b/tool/agent/agent_tool_test.go
@@ -3433,9 +3433,13 @@ func TestTool_Call_WithParentInvocation_RunError(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to run agent")
 
+	// Block until the flush goroutine signals completion. The send happens
+	// after close(req.ACK), which is what unblocks at.Call; under CI load
+	// the goroutine can be descheduled between those two steps, so a
+	// non-blocking check here is racy. The ctx deadline bounds the wait.
 	select {
 	case <-flushed:
-	default:
+	case <-time.After(time.Second):
 		t.Fatalf("expected flush to be triggered")
 	}
 }
@@ -3472,9 +3476,12 @@ func TestTool_Call_WithParentInvocation_FlushesAndCompletes(t *testing.T) {
 	require.True(t, strings.HasPrefix(resStr, "parent-agent/"+a.name+"-"))
 	require.Equal(t, a.seen, resStr)
 
+	// See TestTool_Call_WithParentInvocation_RunError: the non-blocking
+	// select was racy because the helper goroutine may still be between
+	// close(req.ACK) and the send on flushed when at.Call returns.
 	select {
 	case <-flushed:
-	default:
+	case <-time.After(time.Second):
 		t.Fatalf("expected flush to be triggered")
 	}
 }


### PR DESCRIPTION
## Summary

`TestTool_Call_WithParentInvocation_RunError` (and the identical pattern
in `TestTool_Call_WithParentInvocation_FlushesAndCompletes`) is
intermittently flaky on CI.

### Root cause

Both tests spin up a helper goroutine that reads a `FlushRequest`,
closes `req.ACK`, then sends on a buffered `flushed` channel. The test
main goroutine then runs `at.Call(...)` and, after it returns, uses a
non-blocking `select { case <-flushed: default: t.Fatalf(...) }` to
assert the flush was observed.

The race is that `close(req.ACK)` is what unblocks `flush.Invoke` inside
`at.Call`. So by the time `at.Call` returns, the helper goroutine may
still be between `close(req.ACK)` and its send on `flushed` — the test
then races the helper's send against its own assertion.

I verified this is the real race by inserting a 2ms `time.Sleep`
between `close(req.ACK)` and the send on `flushed`: the test then
fails 100% of runs under `-race`, exactly matching the CI symptom.

### Fix

Replace the non-blocking `select`+`default` with a blocking receive
bounded by a 1s timeout — the idiomatic Go pattern for "wait for a
background goroutine to signal completion". Same change applied to
both tests; production code in `agent_tool.go` is untouched.

## Test plan

- [x] With the fix + injected 2ms delay reproducer, the test now passes
  50/50 runs under `-race`.
- [x] `go test -run TestTool_Call_WithParentInvocation -race -count=500`
  passes cleanly.
- [x] Full package: `go test ./tool/agent/... -race -count=5` passes.
- [x] No lint errors.