### PR TITLE
openclaw: add subagent runtime

### DIFF
--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -1592,6 +1592,12 @@ func run(ctx context.Context, args []string) error {
 		cronRunner  runner.Runner
 		subagentSvc *subagentrun.Service
 	)
+	var cleanupSubagent func()
+	defer func() {
+		if cleanupSubagent != nil {
+			cleanupSubagent()
+		}
+	}()
 	if openClawTools.router != nil {
 		for _, ch := range channels {
 			openClawTools.router.Register(ch)
@@ -1639,6 +1645,13 @@ func run(ctx context.Context, args []string) error {
 		}
 		openClawTools.subagentTools.SetService(subagentSvc)
 		subagentSvc.Start(runCtx)
+		cleanupSubagent = func() {
+			openClawTools.subagentTools.SetService(nil)
+			if subagentSvc != nil {
+				_ = subagentSvc.Close()
+				subagentSvc = nil
+			}
+		}
 	}
 
 	if opts.AdminEnabled {
@@ -1749,7 +1762,10 @@ func run(ctx context.Context, args []string) error {
 		_ = cronSvc.Close()
 	}
 	if subagentSvc != nil {
+		openClawTools.subagentTools.SetService(nil)
+		cleanupSubagent = nil
 		_ = subagentSvc.Close()
+		subagentSvc = nil
 	}
 	if cronRunner != nil {
 		_ = cronRunner.Close()

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -45,6 +45,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/model/openai"
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/conversation"
+	publicsubagent "trpc.group/trpc-go/trpc-agent-go/openclaw/subagent"
 	"trpc.group/trpc-go/trpc-agent-go/runner"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	sessioninmemory "trpc.group/trpc-go/trpc-agent-go/session/inmemory"
@@ -64,6 +65,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/outbound"
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/persona"
 	ocskills "trpc.group/trpc-go/trpc-agent-go/openclaw/internal/skills"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/subagentrun"
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/uploads"
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/registry"
 )
@@ -175,7 +177,12 @@ const (
 		"OPENCLAW_LAST_UPLOAD_MIME, and " +
 		"OPENCLAW_MEMORY_FILE, " +
 		"OPENCLAW_RECENT_UPLOADS_JSON instead of guessing " +
-		"attachment paths. When a user follows up about a " +
+		"attachment paths. For long-running work, independent " +
+		"verification, or background work that can continue after " +
+		"this turn, use subagents_spawn. Do not use background " +
+		"subagents for small, tightly-coupled steps, and do not " +
+		"spawn nested subagents. " +
+		"When a user follows up about a " +
 		"recent upload in the current chat, assume they mean " +
 		"that existing upload unless the reference is " +
 		"genuinely ambiguous. Match by media kind first: " +
@@ -185,8 +192,8 @@ const (
 		"one of those kinds. Telegram voice notes count as audio, " +
 		"video notes count as video, and documents with image/audio/" +
 		"video MIME types still count as that media kind. If the " +
-		"user replies " +
-		"to an earlier media message, treat that replied media as " +
+		"user replies to an earlier media message, treat that " +
+		"replied media as " +
 		"the default target unless they clearly ask for something " +
 		"else. Do not ask the user to re-upload a file or provide " +
 		"a local path when the recent upload context already lists " +
@@ -532,12 +539,14 @@ type Runtime struct {
 	adminCfg *admin.Config
 	appName  string
 	session  session.Service
+	subagent publicsubagent.Service
 
 	runner            runner.Runner
 	cronRunner        closeFunc
 	sessionSvc        closeFunc
 	memorySvc         closeFunc
 	cronSvc           closeFunc
+	subagentSvc       closeFunc
 	skillsWatch       closeFunc
 	toolSets          []tool.ToolSet
 	telemetryShutdown func(context.Context) error
@@ -611,6 +620,13 @@ func (r *Runtime) SessionService() session.Service {
 		return nil
 	}
 	return r.session
+}
+
+func (r *Runtime) SubagentService() publicsubagent.Service {
+	if r == nil {
+		return nil
+	}
+	return r.subagent
 }
 
 func (r *Runtime) ConfigureAdmin(
@@ -1071,8 +1087,9 @@ func NewRuntime(
 	}
 
 	var (
-		cronSvc    *cron.Service
-		cronRunner runner.Runner
+		cronSvc     *cron.Service
+		cronRunner  runner.Runner
+		subagentSvc *subagentrun.Service
 	)
 	if openClawTools.router != nil {
 		for _, ch := range rt.Channels {
@@ -1103,6 +1120,22 @@ func NewRuntime(
 		cronSvc.Start(ctx)
 		rt.cronSvc = cronSvc
 		rt.cronRunner = cronRunner
+
+		subagentSvc, err = subagentrun.NewService(
+			resolvedStateDir,
+			r,
+			openClawTools.router,
+		)
+		if err != nil {
+			return nil, &exitError{
+				Code: 1,
+				Err:  fmt.Errorf("create subagent service failed: %w", err),
+			}
+		}
+		openClawTools.subagentTools.SetService(subagentSvc)
+		subagentSvc.Start(ctx)
+		rt.subagent = subagentSvc
+		rt.subagentSvc = subagentSvc
 	}
 
 	if opts.AdminEnabled {
@@ -1152,6 +1185,9 @@ func (r *Runtime) Close() error {
 	}
 	if r.cronRunner != nil {
 		_ = r.cronRunner.Close()
+	}
+	if r.subagentSvc != nil {
+		_ = r.subagentSvc.Close()
 	}
 	if r.skillsWatch != nil {
 		if err := r.skillsWatch.Close(); err != nil {
@@ -1552,8 +1588,9 @@ func run(ctx context.Context, args []string) error {
 	}
 
 	var (
-		cronSvc    *cron.Service
-		cronRunner runner.Runner
+		cronSvc     *cron.Service
+		cronRunner  runner.Runner
+		subagentSvc *subagentrun.Service
 	)
 	if openClawTools.router != nil {
 		for _, ch := range channels {
@@ -1582,6 +1619,26 @@ func run(ctx context.Context, args []string) error {
 		openClawTools.cronTool.SetService(cronSvc)
 		gw.SetCronService(cronSvc)
 		cronSvc.Start(runCtx)
+
+		subagentSvc, err = subagentrun.NewService(
+			resolvedStateDir,
+			r,
+			openClawTools.router,
+		)
+		if err != nil {
+			if cronSvc != nil {
+				_ = cronSvc.Close()
+			}
+			if cronRunner != nil {
+				_ = cronRunner.Close()
+			}
+			return &exitError{
+				Code: 1,
+				Err:  fmt.Errorf("create subagent service failed: %w", err),
+			}
+		}
+		openClawTools.subagentTools.SetService(subagentSvc)
+		subagentSvc.Start(runCtx)
 	}
 
 	if opts.AdminEnabled {
@@ -1690,6 +1747,9 @@ func run(ctx context.Context, args []string) error {
 	}
 	if cronSvc != nil {
 		_ = cronSvc.Close()
+	}
+	if subagentSvc != nil {
+		_ = subagentSvc.Close()
 	}
 	if cronRunner != nil {
 		_ = cronRunner.Close()
@@ -2494,11 +2554,12 @@ type agentConfig struct {
 }
 
 type openClawToolsBundle struct {
-	tools    []tool.Tool
-	execMgr  *octool.Manager
-	router   *outbound.Router
-	cronTool *cron.Tool
-	deps     *deps.Report
+	tools         []tool.Tool
+	execMgr       *octool.Manager
+	router        *outbound.Router
+	cronTool      *cron.Tool
+	subagentTools subagentrun.Tools
+	deps          *deps.Report
 }
 
 type runtimeStores struct {
@@ -2568,6 +2629,7 @@ func buildOpenClawTools(
 	)
 	router := outbound.NewRouter()
 	cronTool := cron.NewTool(nil)
+	subagentTools := subagentrun.NewTools(nil)
 	var depsReport *deps.Report
 	if sources, err := deps.SourcesForProfiles(deps.DefaultProfiles()); err ==
 		nil {
@@ -2595,12 +2657,14 @@ func buildOpenClawTools(
 		outbound.NewTool(router),
 		cronTool,
 	}
+	tools = append(tools, subagentTools.All()...)
 	return openClawToolsBundle{
-		tools:    tools,
-		execMgr:  mgr,
-		router:   router,
-		cronTool: cronTool,
-		deps:     depsReport,
+		tools:         tools,
+		execMgr:       mgr,
+		router:        router,
+		cronTool:      cronTool,
+		subagentTools: subagentTools,
+		deps:          depsReport,
 	}
 }
 

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -612,6 +612,49 @@ func TestBuildOpenClawTools_IncludesConversationHistoryTool(
 	)
 }
 
+func TestBuildOpenClawTools_IncludesSubagentTools(t *testing.T) {
+	t.Parallel()
+
+	bundle := buildOpenClawTools(true, t.TempDir(), nil, nil)
+	require.NotNil(
+		t,
+		findToolDeclaration(bundle.tools, "subagents_spawn"),
+	)
+	require.NotNil(
+		t,
+		findToolDeclaration(bundle.tools, "subagents_list"),
+	)
+	require.NotNil(
+		t,
+		findToolDeclaration(bundle.tools, "subagents_get"),
+	)
+	require.NotNil(
+		t,
+		findToolDeclaration(bundle.tools, "subagents_cancel"),
+	)
+	require.NotNil(
+		t,
+		findToolDeclaration(bundle.tools, "sessions_spawn"),
+	)
+}
+
+func TestNewRuntime_ExposesSubagentService(t *testing.T) {
+	t.Parallel()
+
+	rt, err := NewRuntime(context.Background(), []string{
+		"-mode", modeMock,
+		"-state-dir", t.TempDir(),
+		"-skills-root", t.TempDir(),
+		"-enable-openclaw-tools",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = rt.Close()
+	})
+
+	require.NotNil(t, rt.SubagentService())
+}
+
 func TestNewRuntimeStores_CreatesAllStores(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -636,6 +636,18 @@ func TestBuildOpenClawTools_IncludesSubagentTools(t *testing.T) {
 		t,
 		findToolDeclaration(bundle.tools, "sessions_spawn"),
 	)
+	require.NotNil(
+		t,
+		findToolDeclaration(bundle.tools, "sessions_list"),
+	)
+	require.NotNil(
+		t,
+		findToolDeclaration(bundle.tools, "sessions_get"),
+	)
+	require.NotNil(
+		t,
+		findToolDeclaration(bundle.tools, "sessions_cancel"),
+	)
 }
 
 func TestNewRuntime_ExposesSubagentService(t *testing.T) {

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -655,6 +655,13 @@ func TestNewRuntime_ExposesSubagentService(t *testing.T) {
 	require.NotNil(t, rt.SubagentService())
 }
 
+func TestRuntimeSubagentServiceNilReceiver(t *testing.T) {
+	t.Parallel()
+
+	var rt *Runtime
+	require.Nil(t, rt.SubagentService())
+}
+
 func TestNewRuntimeStores_CreatesAllStores(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/internal/subagentrun/service.go
+++ b/openclaw/internal/subagentrun/service.go
@@ -1,0 +1,624 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package subagentrun
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/log"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/outbound"
+	publicsubagent "trpc.group/trpc-go/trpc-agent-go/openclaw/subagent"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+)
+
+type Service struct {
+	path   string
+	runner runner.Runner
+	router *outbound.Router
+
+	clock func() time.Time
+
+	mu      sync.Mutex
+	runs    map[string]*runRecord
+	running map[string]*runningRun
+
+	persistMu sync.Mutex
+
+	startOnce sync.Once
+	baseCtx   context.Context
+	cancel    context.CancelFunc
+	wg        sync.WaitGroup
+}
+
+type runningRun struct {
+	cancel          context.CancelFunc
+	skipNotify      bool
+	cancelRequested bool
+	childSession    string
+	requestID       string
+	startedAt       time.Time
+}
+
+func NewService(
+	stateDir string,
+	r runner.Runner,
+	router *outbound.Router,
+) (*Service, error) {
+	if strings.TrimSpace(stateDir) == "" {
+		return nil, fmt.Errorf("subagent: empty state dir")
+	}
+	if r == nil {
+		return nil, fmt.Errorf("subagent: nil runner")
+	}
+
+	path := filepath.Join(
+		strings.TrimSpace(stateDir),
+		subagentDirName,
+		subagentRunsFileName,
+	)
+	runs, err := loadRuns(path)
+	if err != nil {
+		return nil, err
+	}
+
+	svc := &Service{
+		path:    path,
+		runner:  r,
+		router:  router,
+		clock:   time.Now,
+		runs:    runs,
+		running: make(map[string]*runningRun),
+	}
+	if normalizeLoadedRuns(svc.runs, svc.clock()) {
+		if err := svc.persist(); err != nil {
+			return nil, err
+		}
+	}
+	return svc, nil
+}
+
+func (s *Service) Start(ctx context.Context) {
+	if s == nil {
+		return
+	}
+	s.startOnce.Do(func() {
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		s.baseCtx, s.cancel = context.WithCancel(ctx)
+	})
+}
+
+func (s *Service) Close() error {
+	if s == nil {
+		return nil
+	}
+	if s.cancel != nil {
+		s.cancel()
+	}
+	s.stopAllRunning()
+	s.wg.Wait()
+	return s.persist()
+}
+
+func (s *Service) Spawn(
+	ctx context.Context,
+	req SpawnRequest,
+) (publicsubagent.Run, error) {
+	if s == nil {
+		return publicsubagent.Run{}, fmt.Errorf("subagent: nil service")
+	}
+	if s.baseCtx == nil {
+		return publicsubagent.Run{}, fmt.Errorf("subagent: not started")
+	}
+
+	ownerUserID := strings.TrimSpace(req.OwnerUserID)
+	parentSessionID := strings.TrimSpace(req.ParentSessionID)
+	task := strings.TrimSpace(req.Task)
+	if ownerUserID == "" {
+		return publicsubagent.Run{}, fmt.Errorf("subagent: empty owner")
+	}
+	if parentSessionID == "" {
+		return publicsubagent.Run{}, fmt.Errorf(
+			"subagent: empty parent session id",
+		)
+	}
+	if task == "" {
+		return publicsubagent.Run{}, fmt.Errorf("subagent: empty task")
+	}
+
+	now := s.clock()
+	record := &runRecord{
+		Run: publicsubagent.Run{
+			ID:              uuid.NewString(),
+			ParentSessionID: parentSessionID,
+			Task:            task,
+			Status:          publicsubagent.StatusQueued,
+			CreatedAt:       now,
+			UpdatedAt:       now,
+		},
+		OwnerUserID: ownerUserID,
+		Delivery:    req.Delivery,
+	}
+
+	s.mu.Lock()
+	s.runs[record.ID] = record
+	s.mu.Unlock()
+	if err := s.persist(); err != nil {
+		s.mu.Lock()
+		delete(s.runs, record.ID)
+		s.mu.Unlock()
+		return publicsubagent.Run{}, err
+	}
+
+	s.wg.Add(1)
+	go func(
+		parent context.Context,
+		runID string,
+		timeoutSeconds int,
+	) {
+		defer s.wg.Done()
+		s.execute(parent, runID, timeoutSeconds)
+	}(s.baseCtx, record.ID, req.TimeoutSeconds)
+
+	return record.publicView(), nil
+}
+
+func (s *Service) ListForUser(
+	userID string,
+	filter publicsubagent.ListFilter,
+) []publicsubagent.Run {
+	if s == nil {
+		return nil
+	}
+	userID = strings.TrimSpace(userID)
+	parentSessionID := strings.TrimSpace(filter.ParentSessionID)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	runs := make([]publicsubagent.Run, 0, len(s.runs))
+	for _, item := range s.runs {
+		if item == nil || item.OwnerUserID != userID {
+			continue
+		}
+		if parentSessionID != "" &&
+			item.ParentSessionID != parentSessionID {
+			continue
+		}
+		runs = append(runs, item.publicView())
+	}
+	sort.Slice(runs, func(i int, j int) bool {
+		return runs[i].UpdatedAt.After(runs[j].UpdatedAt)
+	})
+	return runs
+}
+
+func (s *Service) GetForUser(
+	userID string,
+	runID string,
+) (*publicsubagent.Run, error) {
+	record, err := s.runForUser(userID, runID)
+	if err != nil {
+		return nil, err
+	}
+	view := record.publicView()
+	return &view, nil
+}
+
+func (s *Service) CancelForUser(
+	userID string,
+	runID string,
+) (*publicsubagent.Run, bool, error) {
+	record, err := s.runForUser(userID, runID)
+	if err != nil {
+		return nil, false, err
+	}
+
+	s.mu.Lock()
+	current := s.runs[record.ID]
+	if current == nil {
+		s.mu.Unlock()
+		return nil, false, publicsubagent.ErrRunNotFound
+	}
+	if current.Status.IsTerminal() {
+		view := current.publicView()
+		s.mu.Unlock()
+		return &view, false, nil
+	}
+
+	now := s.clock()
+	current.Status = publicsubagent.StatusCanceled
+	current.Error = ""
+	current.Summary = summarizeResult("canceled")
+	current.UpdatedAt = now
+	current.FinishedAt = cloneTime(now)
+
+	if running := s.running[current.ID]; running != nil {
+		running.skipNotify = true
+		running.cancelRequested = true
+		if running.cancel != nil {
+			running.cancel()
+		}
+	}
+	view := current.publicView()
+	s.mu.Unlock()
+
+	if err := s.persist(); err != nil {
+		return nil, false, err
+	}
+	return &view, true, nil
+}
+
+func (s *Service) execute(
+	parent context.Context,
+	runID string,
+	timeoutSeconds int,
+) {
+	record, runCtx, started, err := s.markRunning(
+		parent,
+		runID,
+		timeoutSeconds,
+	)
+	if err != nil {
+		return
+	}
+
+	result := replyAccumulator{}
+	runErr := s.runChild(runCtx, record, started, &result)
+	output := sanitizeStoredResult(result.text)
+	s.finishRun(runID, output, runErr)
+}
+
+func (s *Service) runChild(
+	ctx context.Context,
+	record *runRecord,
+	started runningRun,
+	result *replyAccumulator,
+) error {
+	if record == nil {
+		return fmt.Errorf("subagent: nil run record")
+	}
+	runtimeState := map[string]any{
+		runtimeStateSubagentRun:      true,
+		runtimeStateSubagentRunID:    record.ID,
+		runtimeStateSubagentParentID: record.ParentSessionID,
+	}
+	if record.Delivery.Channel != "" && record.Delivery.Target != "" {
+		targetState := outbound.RuntimeStateForTarget(
+			outbound.DeliveryTarget{
+				Channel: record.Delivery.Channel,
+				Target:  record.Delivery.Target,
+			},
+		)
+		for key, value := range targetState {
+			runtimeState[key] = value
+		}
+	}
+
+	runOpts := []agent.RunOption{
+		agent.WithRequestID(started.requestID),
+		agent.WithRuntimeState(runtimeState),
+		agent.WithInjectedContextMessages([]model.Message{
+			model.NewSystemMessage(subagentRunPrompt),
+		}),
+	}
+
+	events, err := s.runner.Run(
+		ctx,
+		record.OwnerUserID,
+		started.childSession,
+		model.NewUserMessage(record.Task),
+		runOpts...,
+	)
+	if err != nil {
+		return err
+	}
+	for evt := range events {
+		result.consume(evt)
+	}
+	return result.err
+}
+
+func (s *Service) markRunning(
+	parent context.Context,
+	runID string,
+	timeoutSeconds int,
+) (*runRecord, context.Context, runningRun, error) {
+	s.mu.Lock()
+	record := s.runs[strings.TrimSpace(runID)]
+	if record == nil {
+		s.mu.Unlock()
+		return nil, nil, runningRun{}, publicsubagent.ErrRunNotFound
+	}
+	if record.Status == publicsubagent.StatusCanceled {
+		s.mu.Unlock()
+		return nil, nil, runningRun{}, fmt.Errorf(
+			"subagent: run canceled before start",
+		)
+	}
+
+	now := s.clock()
+	started := runningRun{
+		startedAt:    now,
+		childSession: newChildSessionID(record.ID, now),
+		requestID:    newRequestID(record.ID, now),
+	}
+
+	runCtx := parent
+	if runCtx == nil {
+		runCtx = context.Background()
+	}
+	if timeoutSeconds > 0 {
+		timeoutCtx, cancel := context.WithTimeout(
+			runCtx,
+			time.Duration(timeoutSeconds)*time.Second,
+		)
+		runCtx = timeoutCtx
+		started.cancel = cancel
+	} else {
+		nextCtx, cancel := context.WithCancel(runCtx)
+		runCtx = nextCtx
+		started.cancel = cancel
+	}
+
+	record.Status = publicsubagent.StatusRunning
+	record.ChildSessionID = started.childSession
+	record.UpdatedAt = now
+	record.StartedAt = cloneTime(now)
+	record.FinishedAt = nil
+	record.Error = ""
+	record.Summary = ""
+	record.Result = ""
+
+	s.running[record.ID] = &runningRun{
+		cancel:       started.cancel,
+		childSession: started.childSession,
+		requestID:    started.requestID,
+		startedAt:    started.startedAt,
+	}
+	clone := record.clone()
+	s.mu.Unlock()
+
+	if err := s.persist(); err != nil {
+		if started.cancel != nil {
+			started.cancel()
+		}
+		s.mu.Lock()
+		delete(s.running, runID)
+		if current := s.runs[runID]; current != nil {
+			current.Status = publicsubagent.StatusFailed
+			current.Error = err.Error()
+			current.Summary = summarizeResult(current.Error)
+			current.UpdatedAt = now
+			current.FinishedAt = cloneTime(now)
+		}
+		s.mu.Unlock()
+		return nil, nil, runningRun{}, err
+	}
+	return clone, runCtx, started, nil
+}
+
+func (s *Service) finishRun(
+	runID string,
+	output string,
+	runErr error,
+) {
+	s.mu.Lock()
+	record := s.runs[runID]
+	if record == nil {
+		delete(s.running, runID)
+		s.mu.Unlock()
+		return
+	}
+	now := s.clock()
+	running := s.running[runID]
+	delete(s.running, runID)
+
+	record.Result = output
+	record.UpdatedAt = now
+	record.FinishedAt = cloneTime(now)
+
+	switch {
+	case running != nil && running.cancelRequested:
+		record.Status = publicsubagent.StatusCanceled
+		record.Error = ""
+		record.Summary = summarizeResult("canceled")
+	case errors.Is(runErr, context.Canceled):
+		record.Status = publicsubagent.StatusCanceled
+		record.Error = ""
+		record.Summary = summarizeResult("canceled")
+	case runErr != nil:
+		record.Status = publicsubagent.StatusFailed
+		record.Error = runErr.Error()
+		record.Summary = summarizeResult(record.Error)
+	default:
+		record.Status = publicsubagent.StatusCompleted
+		record.Error = ""
+		record.Summary = summarizeResult(output)
+	}
+	clone := record.clone()
+	notify := running != nil &&
+		!running.skipNotify &&
+		record.Status != publicsubagent.StatusCanceled
+	s.mu.Unlock()
+
+	if err := s.persist(); err != nil {
+		log.Warnf("subagent: persist run %s failed: %v", runID, err)
+	}
+	if notify {
+		s.notifyCompletion(clone)
+	}
+}
+
+func (s *Service) notifyCompletion(record *runRecord) {
+	if s == nil || s.router == nil || record == nil {
+		return
+	}
+	if strings.TrimSpace(record.Delivery.Channel) == "" ||
+		strings.TrimSpace(record.Delivery.Target) == "" {
+		return
+	}
+	message := formatNotification(record)
+	if strings.TrimSpace(message) == "" {
+		return
+	}
+	err := s.router.SendText(
+		context.Background(),
+		outbound.DeliveryTarget{
+			Channel: record.Delivery.Channel,
+			Target:  record.Delivery.Target,
+		},
+		message,
+	)
+	if err != nil {
+		log.Warnf(
+			"subagent: notify run %s failed: %v",
+			record.ID,
+			err,
+		)
+	}
+}
+
+func formatNotification(record *runRecord) string {
+	if record == nil {
+		return ""
+	}
+	var prefix string
+	switch record.Status {
+	case publicsubagent.StatusCompleted:
+		prefix = notificationPrefixCompleted
+	case publicsubagent.StatusFailed:
+		prefix = notificationPrefixFailed
+	case publicsubagent.StatusCanceled:
+		prefix = notificationPrefixCanceled
+	default:
+		return ""
+	}
+
+	lines := []string{
+		fmt.Sprintf("%s #%s", prefix, record.ID),
+	}
+	if summary := strings.TrimSpace(record.Summary); summary != "" {
+		lines = append(lines, summary)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (s *Service) runForUser(
+	userID string,
+	runID string,
+) (*runRecord, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	record := s.runs[strings.TrimSpace(runID)]
+	if record == nil ||
+		record.OwnerUserID != strings.TrimSpace(userID) {
+		return nil, publicsubagent.ErrRunNotFound
+	}
+	return record.clone(), nil
+}
+
+func (s *Service) stopAllRunning() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for id, running := range s.running {
+		if running == nil {
+			delete(s.running, id)
+			continue
+		}
+		running.skipNotify = true
+		running.cancelRequested = true
+		if running.cancel != nil {
+			running.cancel()
+		}
+	}
+}
+
+func (s *Service) persist() error {
+	if s == nil {
+		return nil
+	}
+	s.persistMu.Lock()
+	defer s.persistMu.Unlock()
+
+	s.mu.Lock()
+	runs := make(map[string]*runRecord, len(s.runs))
+	for id, item := range s.runs {
+		runs[id] = item.clone()
+	}
+	s.mu.Unlock()
+	return saveRuns(s.path, runs)
+}
+
+type replyAccumulator struct {
+	text     string
+	builder  strings.Builder
+	seenFull bool
+	err      error
+}
+
+func (a *replyAccumulator) consume(evt *event.Event) {
+	if evt == nil {
+		return
+	}
+	if evt.Error != nil {
+		a.err = errors.New(evt.Error.Message)
+		return
+	}
+	if evt.Response == nil {
+		return
+	}
+	switch evt.Object {
+	case model.ObjectTypeChatCompletion:
+		a.consumeFull(evt.Response)
+	case model.ObjectTypeChatCompletionChunk:
+		a.consumeDelta(evt.Response)
+	}
+}
+
+func (a *replyAccumulator) consumeFull(rsp *model.Response) {
+	if rsp == nil || len(rsp.Choices) == 0 {
+		return
+	}
+	content := rsp.Choices[0].Message.Content
+	if content == "" {
+		return
+	}
+	a.text = content
+	a.seenFull = true
+}
+
+func (a *replyAccumulator) consumeDelta(rsp *model.Response) {
+	if rsp == nil || a.seenFull {
+		return
+	}
+	for _, choice := range rsp.Choices {
+		if choice.Delta.Content == "" {
+			continue
+		}
+		a.builder.WriteString(choice.Delta.Content)
+	}
+	a.text = a.builder.String()
+}

--- a/openclaw/internal/subagentrun/service.go
+++ b/openclaw/internal/subagentrun/service.go
@@ -169,6 +169,7 @@ func (s *Service) Spawn(
 		s.mu.Unlock()
 		return publicsubagent.Run{}, err
 	}
+	view := record.publicView()
 
 	s.wg.Add(1)
 	go func(
@@ -180,7 +181,7 @@ func (s *Service) Spawn(
 		s.execute(parent, runID, timeoutSeconds)
 	}(s.baseCtx, record.ID, req.TimeoutSeconds)
 
-	return record.publicView(), nil
+	return view, nil
 }
 
 func (s *Service) ListForUser(
@@ -281,6 +282,9 @@ func (s *Service) execute(
 	)
 	if err != nil {
 		return
+	}
+	if started.cancel != nil {
+		defer started.cancel()
 	}
 
 	result := replyAccumulator{}
@@ -482,8 +486,17 @@ func (s *Service) notifyCompletion(record *runRecord) {
 	if strings.TrimSpace(message) == "" {
 		return
 	}
+	notifyCtx := s.baseCtx
+	if notifyCtx == nil {
+		notifyCtx = context.Background()
+	}
+	notifyCtx, cancel := context.WithTimeout(
+		notifyCtx,
+		defaultNotifyTimeout,
+	)
+	defer cancel()
 	err := s.router.SendText(
-		context.Background(),
+		notifyCtx,
 		outbound.DeliveryTarget{
 			Channel: record.Delivery.Channel,
 			Target:  record.Delivery.Target,
@@ -518,10 +531,26 @@ func formatNotification(record *runRecord) string {
 	lines := []string{
 		fmt.Sprintf("%s #%s", prefix, record.ID),
 	}
-	if summary := strings.TrimSpace(record.Summary); summary != "" {
-		lines = append(lines, summary)
+	if detail := notificationDetail(record); detail != "" {
+		lines = append(lines, detail)
 	}
 	return strings.Join(lines, "\n")
+}
+
+func notificationDetail(record *runRecord) string {
+	if record == nil {
+		return ""
+	}
+	if record.Status == publicsubagent.StatusCompleted {
+		result := strings.TrimSpace(record.Result)
+		if result != "" {
+			return result
+		}
+	}
+	if summary := strings.TrimSpace(record.Summary); summary != "" {
+		return summary
+	}
+	return strings.TrimSpace(record.Error)
 }
 
 func (s *Service) runForUser(

--- a/openclaw/internal/subagentrun/service_test.go
+++ b/openclaw/internal/subagentrun/service_test.go
@@ -12,6 +12,7 @@ package subagentrun
 import (
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -606,4 +607,111 @@ func TestServiceNotifyCompletionToleratesSenderError(t *testing.T) {
 			Status: publicsubagent.StatusCompleted,
 		},
 	})
+}
+
+func TestServiceErrorBranches(t *testing.T) {
+	t.Parallel()
+
+	var nilSvc *Service
+	_, err := nilSvc.Spawn(context.Background(), SpawnRequest{})
+	require.ErrorContains(t, err, "nil service")
+	require.Nil(t, nilSvc.ListForUser("user-a", publicsubagent.ListFilter{}))
+
+	svc := &Service{
+		path:    t.TempDir(),
+		clock:   time.Now,
+		runs:    make(map[string]*runRecord),
+		running: make(map[string]*runningRun),
+	}
+
+	_, _, _, err = svc.markRunning(nil, "missing", 0)
+	require.ErrorIs(t, err, publicsubagent.ErrRunNotFound)
+
+	svc.runs["run-canceled"] = &runRecord{
+		Run: publicsubagent.Run{
+			ID:     "run-canceled",
+			Status: publicsubagent.StatusCanceled,
+		},
+	}
+	_, _, _, err = svc.markRunning(nil, "run-canceled", 0)
+	require.ErrorContains(t, err, "run canceled before start")
+
+	badPath := filepath.Join(t.TempDir(), "runs-dir")
+	require.NoError(t, os.MkdirAll(badPath, 0o700))
+	svc.path = badPath
+	svc.runs["run-persist"] = &runRecord{
+		Run: publicsubagent.Run{
+			ID:        "run-persist",
+			Status:    publicsubagent.StatusQueued,
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		},
+		OwnerUserID: "user-a",
+	}
+	_, _, _, err = svc.markRunning(nil, "run-persist", 0)
+	require.Error(t, err)
+	run, getErr := svc.GetForUser("user-a", "run-persist")
+	require.NoError(t, getErr)
+	require.Equal(t, publicsubagent.StatusFailed, run.Status)
+
+	require.ErrorContains(
+		t,
+		svc.runChild(context.Background(), nil, runningRun{}, &replyAccumulator{}),
+		"nil run record",
+	)
+
+	svc.finishRun("missing", "", nil)
+
+	canceled := false
+	svc.running = map[string]*runningRun{
+		"nil-entry": nil,
+		"active": {
+			cancel: func() {
+				canceled = true
+			},
+		},
+	}
+	svc.stopAllRunning()
+	require.True(t, canceled)
+	require.NotNil(t, svc.running["active"])
+	require.True(t, svc.running["active"].cancelRequested)
+}
+
+func TestReplyAccumulatorNoOpBranches(t *testing.T) {
+	t.Parallel()
+
+	var acc replyAccumulator
+	acc.consume(nil)
+	acc.consume(&event.Event{
+		Response: &model.Response{},
+	})
+	acc.consume(&event.Event{
+		Response: &model.Response{
+			Error: &model.ResponseError{Message: "event failed"},
+		},
+	})
+	require.ErrorContains(t, acc.err, "event failed")
+
+	acc = replyAccumulator{}
+	acc.consumeFull(nil)
+	acc.consumeFull(&model.Response{})
+	acc.consumeFull(&model.Response{
+		Choices: []model.Choice{{}},
+	})
+	require.Empty(t, acc.text)
+
+	acc.consumeDelta(nil)
+	acc.seenFull = true
+	acc.consumeDelta(&model.Response{
+		Choices: []model.Choice{{
+			Delta: model.Message{Content: "ignored"},
+		}},
+	})
+	require.Empty(t, acc.text)
+
+	acc = replyAccumulator{}
+	acc.consumeDelta(&model.Response{
+		Choices: []model.Choice{{}},
+	})
+	require.Empty(t, acc.text)
 }

--- a/openclaw/internal/subagentrun/service_test.go
+++ b/openclaw/internal/subagentrun/service_test.go
@@ -1,0 +1,609 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package subagentrun
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/outbound"
+	publicsubagent "trpc.group/trpc-go/trpc-agent-go/openclaw/subagent"
+)
+
+type captureRunner struct {
+	mu        sync.Mutex
+	userID    string
+	sessionID string
+	message   model.Message
+	runOpts   agent.RunOptions
+	reply     string
+	runErr    error
+}
+
+func (r *captureRunner) Run(
+	ctx context.Context,
+	userID string,
+	sessionID string,
+	message model.Message,
+	opts ...agent.RunOption,
+) (<-chan *event.Event, error) {
+	r.mu.Lock()
+	r.userID = userID
+	r.sessionID = sessionID
+	r.message = message
+	var runOpts agent.RunOptions
+	for _, opt := range opts {
+		opt(&runOpts)
+	}
+	r.runOpts = runOpts
+	reply := r.reply
+	runErr := r.runErr
+	r.mu.Unlock()
+
+	if runErr != nil {
+		return nil, runErr
+	}
+
+	ch := make(chan *event.Event, 1)
+	ch <- &event.Event{
+		Response: &model.Response{
+			Object: model.ObjectTypeChatCompletion,
+			Choices: []model.Choice{{
+				Message: model.NewAssistantMessage(reply),
+			}},
+		},
+	}
+	close(ch)
+	return ch, nil
+}
+
+func (r *captureRunner) Close() error {
+	return nil
+}
+
+type blockingRunner struct {
+	started chan struct{}
+	once    sync.Once
+}
+
+func (r *blockingRunner) Run(
+	ctx context.Context,
+	userID string,
+	sessionID string,
+	message model.Message,
+	opts ...agent.RunOption,
+) (<-chan *event.Event, error) {
+	r.once.Do(func() {
+		close(r.started)
+	})
+
+	ch := make(chan *event.Event)
+	go func() {
+		defer close(ch)
+		<-ctx.Done()
+	}()
+	return ch, nil
+}
+
+func (r *blockingRunner) Close() error {
+	return nil
+}
+
+type stubSender struct {
+	mu      sync.Mutex
+	target  string
+	text    string
+	sendErr error
+}
+
+func (s *stubSender) ID() string {
+	return "telegram"
+}
+
+func (s *stubSender) Run(ctx context.Context) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (s *stubSender) SendText(
+	ctx context.Context,
+	target string,
+	text string,
+) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.target = target
+	s.text = text
+	return s.sendErr
+}
+
+func (s *stubSender) snapshot() (string, string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.target, s.text
+}
+
+func TestServiceSpawnCompletesRunAndNotifies(t *testing.T) {
+	t.Parallel()
+
+	router := outbound.NewRouter()
+	sender := &stubSender{}
+	router.RegisterSender(sender)
+
+	runner := &captureRunner{reply: "finished delegated work"}
+	svc, err := NewService(t.TempDir(), runner, router)
+	require.NoError(t, err)
+	svc.Start(context.Background())
+	t.Cleanup(func() {
+		require.NoError(t, svc.Close())
+	})
+
+	run, err := svc.Spawn(context.Background(), SpawnRequest{
+		OwnerUserID:     "telegram:user",
+		ParentSessionID: "telegram:dm:100",
+		Task:            "check the incident timeline",
+		TimeoutSeconds:  30,
+		Delivery: deliveryTarget{
+			Channel: "telegram",
+			Target:  "100",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, publicsubagent.StatusQueued, run.Status)
+
+	require.Eventually(t, func() bool {
+		current, getErr := svc.GetForUser("telegram:user", run.ID)
+		if getErr != nil || current == nil {
+			return false
+		}
+		return current.Status == publicsubagent.StatusCompleted
+	}, time.Second, 10*time.Millisecond)
+
+	current, err := svc.GetForUser("telegram:user", run.ID)
+	require.NoError(t, err)
+	require.Equal(t, publicsubagent.StatusCompleted, current.Status)
+	require.Equal(t, "finished delegated work", current.Result)
+	require.Equal(t, "finished delegated work", current.Summary)
+	require.NotEmpty(t, current.ChildSessionID)
+
+	runs := svc.ListForUser("telegram:user", publicsubagent.ListFilter{
+		ParentSessionID: "telegram:dm:100",
+	})
+	require.Len(t, runs, 1)
+	require.Equal(t, run.ID, runs[0].ID)
+
+	runner.mu.Lock()
+	require.Equal(t, "telegram:user", runner.userID)
+	require.Equal(t, "check the incident timeline", runner.message.Content)
+	require.True(
+		t,
+		strings.HasPrefix(runner.sessionID, subagentSessionPrefix),
+	)
+	require.Equal(
+		t,
+		true,
+		runner.runOpts.RuntimeState[runtimeStateSubagentRun],
+	)
+	require.Equal(
+		t,
+		run.ID,
+		runner.runOpts.RuntimeState[runtimeStateSubagentRunID],
+	)
+	require.Equal(
+		t,
+		"telegram:dm:100",
+		runner.runOpts.RuntimeState[runtimeStateSubagentParentID],
+	)
+	require.Equal(
+		t,
+		"telegram",
+		runner.runOpts.RuntimeState["openclaw.delivery.channel"],
+	)
+	require.Equal(
+		t,
+		"100",
+		runner.runOpts.RuntimeState["openclaw.delivery.target"],
+	)
+	require.Len(t, runner.runOpts.InjectedContextMessages, 1)
+	require.Equal(
+		t,
+		subagentRunPrompt,
+		runner.runOpts.InjectedContextMessages[0].Content,
+	)
+	runner.mu.Unlock()
+
+	require.Eventually(t, func() bool {
+		target, text := sender.snapshot()
+		return target == "100" &&
+			strings.Contains(text, notificationPrefixCompleted) &&
+			strings.Contains(text, run.ID)
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestServiceCancelForUser(t *testing.T) {
+	t.Parallel()
+
+	router := outbound.NewRouter()
+	sender := &stubSender{}
+	router.RegisterSender(sender)
+
+	runner := &blockingRunner{started: make(chan struct{})}
+	svc, err := NewService(t.TempDir(), runner, router)
+	require.NoError(t, err)
+	svc.Start(context.Background())
+	t.Cleanup(func() {
+		require.NoError(t, svc.Close())
+	})
+
+	run, err := svc.Spawn(context.Background(), SpawnRequest{
+		OwnerUserID:     "user-a",
+		ParentSessionID: "session-a",
+		Task:            "wait for cancel",
+		Delivery: deliveryTarget{
+			Channel: "telegram",
+			Target:  "900",
+		},
+	})
+	require.NoError(t, err)
+
+	select {
+	case <-runner.started:
+	case <-time.After(time.Second):
+		t.Fatal("subagent run did not start in time")
+	}
+
+	canceled, changed, err := svc.CancelForUser("user-a", run.ID)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Equal(t, publicsubagent.StatusCanceled, canceled.Status)
+
+	require.Eventually(t, func() bool {
+		current, getErr := svc.GetForUser("user-a", run.ID)
+		if getErr != nil || current == nil {
+			return false
+		}
+		return current.Status == publicsubagent.StatusCanceled
+	}, time.Second, 10*time.Millisecond)
+
+	_, text := sender.snapshot()
+	require.Empty(t, text)
+}
+
+func TestServiceListForUserScopesByOwnerAndParent(t *testing.T) {
+	t.Parallel()
+
+	runner := &captureRunner{reply: "ok"}
+	svc, err := NewService(t.TempDir(), runner, nil)
+	require.NoError(t, err)
+	svc.Start(context.Background())
+	t.Cleanup(func() {
+		require.NoError(t, svc.Close())
+	})
+
+	first, err := svc.Spawn(context.Background(), SpawnRequest{
+		OwnerUserID:     "user-a",
+		ParentSessionID: "parent-a",
+		Task:            "first",
+	})
+	require.NoError(t, err)
+	_, err = svc.Spawn(context.Background(), SpawnRequest{
+		OwnerUserID:     "user-a",
+		ParentSessionID: "parent-b",
+		Task:            "second",
+	})
+	require.NoError(t, err)
+	_, err = svc.Spawn(context.Background(), SpawnRequest{
+		OwnerUserID:     "user-b",
+		ParentSessionID: "parent-a",
+		Task:            "third",
+	})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return len(svc.ListForUser("user-a", publicsubagent.ListFilter{})) == 2
+	}, time.Second, 10*time.Millisecond)
+
+	filtered := svc.ListForUser("user-a", publicsubagent.ListFilter{
+		ParentSessionID: "parent-a",
+	})
+	require.Len(t, filtered, 1)
+	require.Equal(t, first.ID, filtered[0].ID)
+}
+
+func TestNewServiceMarksInterruptedRunsFailed(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	startedAt := time.Now().Add(-time.Minute)
+	path := filepath.Join(
+		dir,
+		subagentDirName,
+		subagentRunsFileName,
+	)
+	runs := map[string]*runRecord{
+		"run-1": {
+			Run: publicsubagent.Run{
+				ID:              "run-1",
+				ParentSessionID: "parent",
+				Task:            "resume me",
+				Status:          publicsubagent.StatusRunning,
+				CreatedAt:       startedAt,
+				UpdatedAt:       startedAt,
+				StartedAt:       cloneTime(startedAt),
+			},
+			OwnerUserID: "user-a",
+		},
+	}
+	require.NoError(t, saveRuns(path, runs))
+
+	svc, err := NewService(dir, &captureRunner{reply: "ok"}, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, svc.Close())
+	})
+
+	run, err := svc.GetForUser("user-a", "run-1")
+	require.NoError(t, err)
+	require.Equal(t, publicsubagent.StatusFailed, run.Status)
+	require.Contains(t, run.Error, "previous runtime restart")
+}
+
+func TestNewServiceValidatesInput(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewService("", &captureRunner{reply: "ok"}, nil)
+	require.ErrorContains(t, err, "empty state dir")
+
+	_, err = NewService(t.TempDir(), nil, nil)
+	require.ErrorContains(t, err, "nil runner")
+}
+
+func TestFormatNotification(t *testing.T) {
+	t.Parallel()
+
+	record := &runRecord{
+		Run: publicsubagent.Run{
+			ID:      "run-1",
+			Status:  publicsubagent.StatusCompleted,
+			Summary: "finished",
+		},
+	}
+	require.Contains(t, formatNotification(record), notificationPrefixCompleted)
+
+	record.Status = publicsubagent.StatusFailed
+	record.Summary = "boom"
+	require.Contains(t, formatNotification(record), notificationPrefixFailed)
+
+	record.Status = publicsubagent.StatusCanceled
+	require.Contains(t, formatNotification(record), notificationPrefixCanceled)
+
+	record.Status = publicsubagent.StatusQueued
+	require.Empty(t, formatNotification(record))
+}
+
+func TestReplyAccumulatorConsumeDeltaAndError(t *testing.T) {
+	t.Parallel()
+
+	var acc replyAccumulator
+	acc.consume(&event.Event{
+		Response: &model.Response{
+			Object: model.ObjectTypeChatCompletionChunk,
+			Choices: []model.Choice{{
+				Delta: model.Message{Content: "hello "},
+			}},
+		},
+	})
+	acc.consume(&event.Event{
+		Response: &model.Response{
+			Object: model.ObjectTypeChatCompletionChunk,
+			Choices: []model.Choice{{
+				Delta: model.Message{Content: "world"},
+			}},
+		},
+	})
+	require.Equal(t, "hello world", acc.text)
+
+	acc.consume(&event.Event{
+		Response: &model.Response{
+			Error: &model.ResponseError{
+				Message: "stream failed",
+			},
+		},
+	})
+	require.ErrorContains(t, acc.err, "stream failed")
+}
+
+func TestServiceSpawnValidation(t *testing.T) {
+	t.Parallel()
+
+	svc, err := NewService(t.TempDir(), &captureRunner{reply: "ok"}, nil)
+	require.NoError(t, err)
+
+	_, err = svc.Spawn(context.Background(), SpawnRequest{})
+	require.ErrorContains(t, err, "not started")
+
+	svc.Start(context.Background())
+
+	_, err = svc.Spawn(context.Background(), SpawnRequest{
+		ParentSessionID: "session-a",
+		Task:            "task",
+	})
+	require.ErrorContains(t, err, "empty owner")
+
+	_, err = svc.Spawn(context.Background(), SpawnRequest{
+		OwnerUserID: "user-a",
+		Task:        "task",
+	})
+	require.ErrorContains(t, err, "empty parent session id")
+
+	_, err = svc.Spawn(context.Background(), SpawnRequest{
+		OwnerUserID:     "user-a",
+		ParentSessionID: "session-a",
+	})
+	require.ErrorContains(t, err, "empty task")
+}
+
+func TestServiceRunFailureMarksRunFailed(t *testing.T) {
+	t.Parallel()
+
+	router := outbound.NewRouter()
+	sender := &stubSender{}
+	router.RegisterSender(sender)
+
+	runner := &captureRunner{runErr: errors.New("runner boom")}
+	svc, err := NewService(t.TempDir(), runner, router)
+	require.NoError(t, err)
+	svc.Start(context.Background())
+	t.Cleanup(func() {
+		require.NoError(t, svc.Close())
+	})
+
+	run, err := svc.Spawn(context.Background(), SpawnRequest{
+		OwnerUserID:     "user-a",
+		ParentSessionID: "session-a",
+		Task:            "fail this run",
+		Delivery: deliveryTarget{
+			Channel: "telegram",
+			Target:  "100",
+		},
+	})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		current, getErr := svc.GetForUser("user-a", run.ID)
+		if getErr != nil || current == nil {
+			return false
+		}
+		return current.Status == publicsubagent.StatusFailed
+	}, time.Second, 10*time.Millisecond)
+
+	current, err := svc.GetForUser("user-a", run.ID)
+	require.NoError(t, err)
+	require.Equal(t, publicsubagent.StatusFailed, current.Status)
+	require.Contains(t, current.Error, "runner boom")
+
+	require.Eventually(t, func() bool {
+		_, text := sender.snapshot()
+		return strings.Contains(text, notificationPrefixFailed)
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestServiceHelperPaths(t *testing.T) {
+	t.Parallel()
+
+	var nilSvc *Service
+	nilSvc.Start(nil)
+	require.NoError(t, nilSvc.Close())
+	require.NoError(t, nilSvc.persist())
+
+	svc, err := NewService(t.TempDir(), &captureRunner{reply: "ok"}, nil)
+	require.NoError(t, err)
+	svc.Start(nil)
+	t.Cleanup(func() {
+		require.NoError(t, svc.Close())
+	})
+
+	_, err = svc.GetForUser("user-a", "missing")
+	require.ErrorIs(t, err, publicsubagent.ErrRunNotFound)
+
+	_, _, err = svc.CancelForUser("user-a", "missing")
+	require.ErrorIs(t, err, publicsubagent.ErrRunNotFound)
+
+	require.Empty(t, formatNotification(nil))
+}
+
+func TestServiceFinishRunCanceledPaths(t *testing.T) {
+	t.Parallel()
+
+	svc, err := NewService(t.TempDir(), &captureRunner{reply: "ok"}, nil)
+	require.NoError(t, err)
+
+	now := time.Now()
+	svc.clock = func() time.Time {
+		return now
+	}
+
+	svc.runs["run-1"] = &runRecord{
+		Run: publicsubagent.Run{
+			ID:        "run-1",
+			Status:    publicsubagent.StatusRunning,
+			CreatedAt: now,
+			UpdatedAt: now,
+		},
+		OwnerUserID: "user-a",
+	}
+	svc.running["run-1"] = &runningRun{cancelRequested: true}
+	svc.finishRun("run-1", "ignored", nil)
+
+	run, err := svc.GetForUser("user-a", "run-1")
+	require.NoError(t, err)
+	require.Equal(t, publicsubagent.StatusCanceled, run.Status)
+	require.Equal(t, "canceled", run.Summary)
+
+	svc.runs["run-2"] = &runRecord{
+		Run: publicsubagent.Run{
+			ID:        "run-2",
+			Status:    publicsubagent.StatusRunning,
+			CreatedAt: now,
+			UpdatedAt: now,
+		},
+		OwnerUserID: "user-a",
+	}
+	svc.running["run-2"] = &runningRun{}
+	svc.finishRun("run-2", "", context.Canceled)
+
+	run, err = svc.GetForUser("user-a", "run-2")
+	require.NoError(t, err)
+	require.Equal(t, publicsubagent.StatusCanceled, run.Status)
+}
+
+func TestServiceNotifyCompletionToleratesSenderError(t *testing.T) {
+	t.Parallel()
+
+	router := outbound.NewRouter()
+	sender := &stubSender{sendErr: errors.New("send failed")}
+	router.RegisterSender(sender)
+
+	svc, err := NewService(t.TempDir(), &captureRunner{reply: "ok"}, router)
+	require.NoError(t, err)
+
+	svc.notifyCompletion(&runRecord{
+		Run: publicsubagent.Run{
+			ID:      "run-1",
+			Status:  publicsubagent.StatusCompleted,
+			Summary: "done",
+		},
+		Delivery: deliveryTarget{
+			Channel: "telegram",
+			Target:  "42",
+		},
+	})
+
+	target, text := sender.snapshot()
+	require.Equal(t, "42", target)
+	require.Contains(t, text, "run-1")
+
+	svc.notifyCompletion(&runRecord{
+		Run: publicsubagent.Run{
+			ID:     "run-2",
+			Status: publicsubagent.StatusCompleted,
+		},
+	})
+}

--- a/openclaw/internal/subagentrun/service_test.go
+++ b/openclaw/internal/subagentrun/service_test.go
@@ -383,10 +383,13 @@ func TestFormatNotification(t *testing.T) {
 		Run: publicsubagent.Run{
 			ID:      "run-1",
 			Status:  publicsubagent.StatusCompleted,
-			Summary: "finished",
+			Result:  "full result",
+			Summary: "summary only",
 		},
 	}
 	require.Contains(t, formatNotification(record), notificationPrefixCompleted)
+	require.Contains(t, formatNotification(record), "full result")
+	require.NotContains(t, formatNotification(record), "summary only")
 
 	record.Status = publicsubagent.StatusFailed
 	record.Summary = "boom"
@@ -510,13 +513,13 @@ func TestServiceHelperPaths(t *testing.T) {
 	t.Parallel()
 
 	var nilSvc *Service
-	nilSvc.Start(nil)
+	nilSvc.Start(context.Background())
 	require.NoError(t, nilSvc.Close())
 	require.NoError(t, nilSvc.persist())
 
 	svc, err := NewService(t.TempDir(), &captureRunner{reply: "ok"}, nil)
 	require.NoError(t, err)
-	svc.Start(nil)
+	svc.Start(context.Background())
 	t.Cleanup(func() {
 		require.NoError(t, svc.Close())
 	})
@@ -624,7 +627,11 @@ func TestServiceErrorBranches(t *testing.T) {
 		running: make(map[string]*runningRun),
 	}
 
-	_, _, _, err = svc.markRunning(nil, "missing", 0)
+	_, _, _, err = svc.markRunning(
+		context.Background(),
+		"missing",
+		0,
+	)
 	require.ErrorIs(t, err, publicsubagent.ErrRunNotFound)
 
 	svc.runs["run-canceled"] = &runRecord{
@@ -633,7 +640,11 @@ func TestServiceErrorBranches(t *testing.T) {
 			Status: publicsubagent.StatusCanceled,
 		},
 	}
-	_, _, _, err = svc.markRunning(nil, "run-canceled", 0)
+	_, _, _, err = svc.markRunning(
+		context.Background(),
+		"run-canceled",
+		0,
+	)
 	require.ErrorContains(t, err, "run canceled before start")
 
 	badPath := filepath.Join(t.TempDir(), "runs-dir")
@@ -648,7 +659,11 @@ func TestServiceErrorBranches(t *testing.T) {
 		},
 		OwnerUserID: "user-a",
 	}
-	_, _, _, err = svc.markRunning(nil, "run-persist", 0)
+	_, _, _, err = svc.markRunning(
+		context.Background(),
+		"run-persist",
+		0,
+	)
 	require.Error(t, err)
 	run, getErr := svc.GetForUser("user-a", "run-persist")
 	require.NoError(t, getErr)

--- a/openclaw/internal/subagentrun/store.go
+++ b/openclaw/internal/subagentrun/store.go
@@ -1,0 +1,118 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package subagentrun
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	publicsubagent "trpc.group/trpc-go/trpc-agent-go/openclaw/subagent"
+)
+
+const (
+	storeVersion = 1
+
+	storeDirPerm  = 0o700
+	storeFilePerm = 0o600
+)
+
+func loadRuns(path string) (map[string]*runRecord, error) {
+	path = filepath.Clean(path)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]*runRecord{}, nil
+		}
+		return nil, err
+	}
+
+	var file storeFile
+	if err := json.Unmarshal(data, &file); err != nil {
+		return nil, err
+	}
+	if file.Version != 0 && file.Version != storeVersion {
+		return nil, fmt.Errorf(
+			"subagent: unsupported store version: %d",
+			file.Version,
+		)
+	}
+
+	runs := make(map[string]*runRecord, len(file.Runs))
+	for _, item := range file.Runs {
+		record := item
+		if record.ID == "" {
+			continue
+		}
+		runs[record.ID] = record.clone()
+	}
+	return runs, nil
+}
+
+func saveRuns(path string, runs map[string]*runRecord) error {
+	path = filepath.Clean(path)
+	if err := os.MkdirAll(filepath.Dir(path), storeDirPerm); err != nil {
+		return err
+	}
+
+	items := make([]runRecord, 0, len(runs))
+	for _, item := range runs {
+		if item == nil || item.ID == "" {
+			continue
+		}
+		items = append(items, *item.clone())
+	}
+	sort.Slice(items, func(i int, j int) bool {
+		return items[i].CreatedAt.Before(items[j].CreatedAt)
+	})
+
+	file := storeFile{
+		Version: storeVersion,
+		Runs:    items,
+	}
+	data, err := json.MarshalIndent(file, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, storeFilePerm); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+
+func normalizeLoadedRuns(
+	runs map[string]*runRecord,
+	now time.Time,
+) bool {
+	changed := false
+	for _, run := range runs {
+		if run == nil || run.Status.IsTerminal() {
+			continue
+		}
+		run.Status = publicsubagent.StatusFailed
+		run.Error = "interrupted by previous runtime restart"
+		run.UpdatedAt = now
+		run.FinishedAt = cloneTime(now)
+		run.Summary = summarizeResult(run.Error)
+		changed = true
+	}
+	return changed
+}
+
+func cloneTime(value time.Time) *time.Time {
+	copied := value
+	return &copied
+}

--- a/openclaw/internal/subagentrun/store_test.go
+++ b/openclaw/internal/subagentrun/store_test.go
@@ -84,3 +84,51 @@ func TestStoreAndTypeHelpers(t *testing.T) {
 	require.Equal(t, "ab", truncateRunes("abcd", 2))
 	require.Equal(t, "abc", truncateRunes("abc", 8))
 }
+
+func TestStoreErrorBranches(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	_, err := loadRuns(dir)
+	require.Error(t, err)
+
+	badJSONPath := filepath.Join(t.TempDir(), subagentRunsFileName)
+	require.NoError(t, os.WriteFile(badJSONPath, []byte("{"), 0o600))
+	_, err = loadRuns(badJSONPath)
+	require.Error(t, err)
+
+	skippedPath := filepath.Join(t.TempDir(), subagentRunsFileName)
+	require.NoError(t, os.WriteFile(
+		skippedPath,
+		[]byte(`{"runs":[{"id":""},{"id":"run-3","status":"queued"}]}`),
+		0o600,
+	))
+	loaded, err := loadRuns(skippedPath)
+	require.NoError(t, err)
+	require.Len(t, loaded, 1)
+
+	blockedParent := filepath.Join(t.TempDir(), "blocked")
+	require.NoError(t, os.WriteFile(blockedParent, []byte("x"), 0o600))
+	err = saveRuns(filepath.Join(blockedParent, subagentRunsFileName), nil)
+	require.Error(t, err)
+
+	err = saveRuns(filepath.Join(t.TempDir(), subagentRunsFileName), map[string]*runRecord{
+		"nil": nil,
+		"empty": {
+			Run: publicsubagent.Run{},
+		},
+	})
+	require.NoError(t, err)
+
+	now := time.Now()
+	changed := normalizeLoadedRuns(map[string]*runRecord{
+		"nil": nil,
+		"done": {
+			Run: publicsubagent.Run{
+				ID:     "done",
+				Status: publicsubagent.StatusCompleted,
+			},
+		},
+	}, now)
+	require.False(t, changed)
+}

--- a/openclaw/internal/subagentrun/store_test.go
+++ b/openclaw/internal/subagentrun/store_test.go
@@ -1,0 +1,86 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package subagentrun
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	publicsubagent "trpc.group/trpc-go/trpc-agent-go/openclaw/subagent"
+)
+
+func TestLoadRunsRejectsUnsupportedVersion(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), subagentRunsFileName)
+	require.NoError(
+		t,
+		os.WriteFile(path, []byte(`{"version":999}`), 0o600),
+	)
+
+	_, err := loadRuns(path)
+	require.ErrorContains(t, err, "unsupported store version")
+}
+
+func TestSaveRunsAndLoadRunsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), subagentRunsFileName)
+	now := time.Now()
+	runs := map[string]*runRecord{
+		"run-1": {
+			Run: publicsubagent.Run{
+				ID:        "run-1",
+				Status:    publicsubagent.StatusCompleted,
+				CreatedAt: now,
+				UpdatedAt: now,
+			},
+			OwnerUserID: "user-a",
+		},
+	}
+	require.NoError(t, saveRuns(path, runs))
+
+	loaded, err := loadRuns(path)
+	require.NoError(t, err)
+	require.Len(t, loaded, 1)
+	require.Equal(t, "user-a", loaded["run-1"].OwnerUserID)
+}
+
+func TestStoreAndTypeHelpers(t *testing.T) {
+	t.Parallel()
+
+	loaded, err := loadRuns(filepath.Join(t.TempDir(), "missing.json"))
+	require.NoError(t, err)
+	require.Empty(t, loaded)
+
+	var nilRecord *runRecord
+	require.Equal(t, publicsubagent.Run{}, nilRecord.publicView())
+
+	startedAt := time.Now()
+	record := &runRecord{
+		Run: publicsubagent.Run{
+			ID:        "run-2",
+			CreatedAt: startedAt,
+			UpdatedAt: startedAt,
+			StartedAt: cloneTime(startedAt),
+		},
+	}
+	cloned := record.clone()
+	require.Equal(t, record.ID, cloned.ID)
+	require.NotSame(t, record.StartedAt, cloned.StartedAt)
+
+	require.Equal(t, "trimmed", truncateRunes(" trimmed ", 0))
+	require.Equal(t, "ab", truncateRunes("abcd", 2))
+	require.Equal(t, "abc", truncateRunes("abc", 8))
+}

--- a/openclaw/internal/subagentrun/tool.go
+++ b/openclaw/internal/subagentrun/tool.go
@@ -275,10 +275,16 @@ func (t *spawnTool) Call(
 	if err != nil {
 		return nil, err
 	}
-	delivery, _ := outbound.ResolveTarget(
+	delivery, err := outbound.ResolveTarget(
 		ctx,
 		outbound.DeliveryTarget{},
 	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"subagent: resolve delivery target: %w",
+			err,
+		)
+	}
 
 	run, err := t.svc.Spawn(ctx, SpawnRequest{
 		OwnerUserID:     userID,

--- a/openclaw/internal/subagentrun/tool.go
+++ b/openclaw/internal/subagentrun/tool.go
@@ -1,0 +1,472 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package subagentrun
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/outbound"
+	publicsubagent "trpc.group/trpc-go/trpc-agent-go/openclaw/subagent"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+const (
+	toolSubagentsSpawn  = "subagents_spawn"
+	toolSubagentsList   = "subagents_list"
+	toolSubagentsGet    = "subagents_get"
+	toolSubagentsCancel = "subagents_cancel"
+
+	toolSessionsSpawn  = "sessions_spawn"
+	toolSessionsList   = "sessions_list"
+	toolSessionsGet    = "sessions_get"
+	toolSessionsCancel = "sessions_cancel"
+
+	argTask           = "task"
+	argID             = "id"
+	argTimeoutSeconds = "timeout_seconds"
+
+	schemaTypeInteger = "integer"
+	schemaTypeObject  = "object"
+	schemaTypeString  = "string"
+)
+
+type Tools struct {
+	spawn       *spawnTool
+	list        *listTool
+	get         *getTool
+	cancel      *cancelTool
+	spawnAlias  *spawnTool
+	listAlias   *listTool
+	getAlias    *getTool
+	cancelAlias *cancelTool
+}
+
+func NewTools(svc *Service) Tools {
+	return Tools{
+		spawn:       newSpawnTool(toolSubagentsSpawn, false, svc),
+		list:        newListTool(toolSubagentsList, false, svc),
+		get:         newGetTool(toolSubagentsGet, false, svc),
+		cancel:      newCancelTool(toolSubagentsCancel, false, svc),
+		spawnAlias:  newSpawnTool(toolSessionsSpawn, true, svc),
+		listAlias:   newListTool(toolSessionsList, true, svc),
+		getAlias:    newGetTool(toolSessionsGet, true, svc),
+		cancelAlias: newCancelTool(toolSessionsCancel, true, svc),
+	}
+}
+
+func (t *Tools) SetService(svc *Service) {
+	if t == nil {
+		return
+	}
+	for _, item := range []*ServiceAwareTool{
+		t.spawn.base(),
+		t.list.base(),
+		t.get.base(),
+		t.cancel.base(),
+		t.spawnAlias.base(),
+		t.listAlias.base(),
+		t.getAlias.base(),
+		t.cancelAlias.base(),
+	} {
+		if item == nil {
+			continue
+		}
+		item.svc = svc
+	}
+}
+
+func (t *Tools) All() []tool.Tool {
+	if t == nil {
+		return nil
+	}
+	return []tool.Tool{
+		t.spawn,
+		t.list,
+		t.get,
+		t.cancel,
+		t.spawnAlias,
+		t.listAlias,
+		t.getAlias,
+		t.cancelAlias,
+	}
+}
+
+type ServiceAwareTool struct {
+	name        string
+	compatAlias bool
+	svc         *Service
+}
+
+type spawnTool struct {
+	ServiceAwareTool
+}
+
+type listTool struct {
+	ServiceAwareTool
+}
+
+type getTool struct {
+	ServiceAwareTool
+}
+
+type cancelTool struct {
+	ServiceAwareTool
+}
+
+type spawnInput struct {
+	Task           string `json:"task"`
+	TimeoutSeconds int    `json:"timeout_seconds"`
+}
+
+type runIDInput struct {
+	ID string `json:"id"`
+}
+
+type listResult struct {
+	Runs []publicsubagent.Run `json:"runs,omitempty"`
+}
+
+func newSpawnTool(
+	name string,
+	compatAlias bool,
+	svc *Service,
+) *spawnTool {
+	return &spawnTool{
+		ServiceAwareTool: ServiceAwareTool{
+			name:        name,
+			compatAlias: compatAlias,
+			svc:         svc,
+		},
+	}
+}
+
+func newListTool(
+	name string,
+	compatAlias bool,
+	svc *Service,
+) *listTool {
+	return &listTool{
+		ServiceAwareTool: ServiceAwareTool{
+			name:        name,
+			compatAlias: compatAlias,
+			svc:         svc,
+		},
+	}
+}
+
+func newGetTool(
+	name string,
+	compatAlias bool,
+	svc *Service,
+) *getTool {
+	return &getTool{
+		ServiceAwareTool: ServiceAwareTool{
+			name:        name,
+			compatAlias: compatAlias,
+			svc:         svc,
+		},
+	}
+}
+
+func newCancelTool(
+	name string,
+	compatAlias bool,
+	svc *Service,
+) *cancelTool {
+	return &cancelTool{
+		ServiceAwareTool: ServiceAwareTool{
+			name:        name,
+			compatAlias: compatAlias,
+			svc:         svc,
+		},
+	}
+}
+
+func (t *spawnTool) base() *ServiceAwareTool {
+	if t == nil {
+		return nil
+	}
+	return &t.ServiceAwareTool
+}
+
+func (t *listTool) base() *ServiceAwareTool {
+	if t == nil {
+		return nil
+	}
+	return &t.ServiceAwareTool
+}
+
+func (t *getTool) base() *ServiceAwareTool {
+	if t == nil {
+		return nil
+	}
+	return &t.ServiceAwareTool
+}
+
+func (t *cancelTool) base() *ServiceAwareTool {
+	if t == nil {
+		return nil
+	}
+	return &t.ServiceAwareTool
+}
+
+func (t *spawnTool) Declaration() *tool.Declaration {
+	description := "Spawn one background subagent for the current " +
+		"session. Use this for long-running work, parallelizable " +
+		"work, or independent verification. It returns " +
+		"immediately with a run id."
+	if t.compatAlias {
+		description = "Compatibility alias for " +
+			toolSubagentsSpawn + ". " + description
+	}
+	return &tool.Declaration{
+		Name:        t.name,
+		Description: description,
+		InputSchema: &tool.Schema{
+			Type:     schemaTypeObject,
+			Required: []string{argTask},
+			Properties: map[string]*tool.Schema{
+				argTask: {
+					Type: schemaTypeString,
+					Description: "Delegated task for the " +
+						"background subagent.",
+				},
+				argTimeoutSeconds: {
+					Type: schemaTypeInteger,
+					Description: "Optional timeout in " +
+						"seconds for the delegated run.",
+				},
+			},
+		},
+	}
+}
+
+func (t *spawnTool) Call(
+	ctx context.Context,
+	args []byte,
+) (any, error) {
+	if t == nil || t.svc == nil {
+		return nil, fmt.Errorf("subagent: service unavailable")
+	}
+	if isNestedSubagent(ctx) {
+		return nil, fmt.Errorf(
+			"subagent: nested subagent spawn is not supported",
+		)
+	}
+
+	var in spawnInput
+	if err := json.Unmarshal(args, &in); err != nil {
+		return nil, err
+	}
+
+	userID, sess, err := currentContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	delivery, _ := outbound.ResolveTarget(
+		ctx,
+		outbound.DeliveryTarget{},
+	)
+
+	run, err := t.svc.Spawn(ctx, SpawnRequest{
+		OwnerUserID:     userID,
+		ParentSessionID: sess.ID,
+		Task:            in.Task,
+		TimeoutSeconds:  in.TimeoutSeconds,
+		Delivery: deliveryTarget{
+			Channel: delivery.Channel,
+			Target:  delivery.Target,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return run, nil
+}
+
+func (t *listTool) Declaration() *tool.Declaration {
+	description := "List background subagents created from the " +
+		"current session."
+	if t.compatAlias {
+		description = "Compatibility alias for " +
+			toolSubagentsList + ". " + description
+	}
+	return &tool.Declaration{
+		Name:        t.name,
+		Description: description,
+		InputSchema: &tool.Schema{
+			Type: schemaTypeObject,
+		},
+	}
+}
+
+func (t *listTool) Call(
+	ctx context.Context,
+	args []byte,
+) (any, error) {
+	if t == nil || t.svc == nil {
+		return nil, fmt.Errorf("subagent: service unavailable")
+	}
+	if len(args) > 0 && strings.TrimSpace(string(args)) != "" &&
+		strings.TrimSpace(string(args)) != "{}" {
+		var ignored map[string]any
+		if err := json.Unmarshal(args, &ignored); err != nil {
+			return nil, err
+		}
+	}
+
+	userID, sess, err := currentContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return listResult{
+		Runs: t.svc.ListForUser(
+			userID,
+			publicsubagent.ListFilter{
+				ParentSessionID: sess.ID,
+			},
+		),
+	}, nil
+}
+
+func (t *getTool) Declaration() *tool.Declaration {
+	description := "Get the latest status and result for one " +
+		"background subagent run."
+	if t.compatAlias {
+		description = "Compatibility alias for " +
+			toolSubagentsGet + ". " + description
+	}
+	return &tool.Declaration{
+		Name:        t.name,
+		Description: description,
+		InputSchema: &tool.Schema{
+			Type:     schemaTypeObject,
+			Required: []string{argID},
+			Properties: map[string]*tool.Schema{
+				argID: {
+					Type: schemaTypeString,
+					Description: "Subagent run id returned by " +
+						"spawn.",
+				},
+			},
+		},
+	}
+}
+
+func (t *getTool) Call(
+	ctx context.Context,
+	args []byte,
+) (any, error) {
+	if t == nil || t.svc == nil {
+		return nil, fmt.Errorf("subagent: service unavailable")
+	}
+	runID, userID, err := decodeRunIDArgs(ctx, args)
+	if err != nil {
+		return nil, err
+	}
+	return t.svc.GetForUser(userID, runID)
+}
+
+func (t *cancelTool) Declaration() *tool.Declaration {
+	description := "Cancel one background subagent run. This is " +
+		"best-effort."
+	if t.compatAlias {
+		description = "Compatibility alias for " +
+			toolSubagentsCancel + ". " + description
+	}
+	return &tool.Declaration{
+		Name:        t.name,
+		Description: description,
+		InputSchema: &tool.Schema{
+			Type:     schemaTypeObject,
+			Required: []string{argID},
+			Properties: map[string]*tool.Schema{
+				argID: {
+					Type: schemaTypeString,
+					Description: "Subagent run id returned by " +
+						"spawn.",
+				},
+			},
+		},
+	}
+}
+
+func (t *cancelTool) Call(
+	ctx context.Context,
+	args []byte,
+) (any, error) {
+	if t == nil || t.svc == nil {
+		return nil, fmt.Errorf("subagent: service unavailable")
+	}
+	runID, userID, err := decodeRunIDArgs(ctx, args)
+	if err != nil {
+		return nil, err
+	}
+	run, _, err := t.svc.CancelForUser(userID, runID)
+	if err != nil {
+		return nil, err
+	}
+	return run, nil
+}
+
+func decodeRunIDArgs(
+	ctx context.Context,
+	args []byte,
+) (string, string, error) {
+	var in runIDInput
+	if err := json.Unmarshal(args, &in); err != nil {
+		return "", "", err
+	}
+	userID, _, err := currentContext(ctx)
+	if err != nil {
+		return "", "", err
+	}
+	runID := strings.TrimSpace(in.ID)
+	if runID == "" {
+		return "", "", fmt.Errorf("subagent: empty run id")
+	}
+	return runID, userID, nil
+}
+
+func currentContext(
+	ctx context.Context,
+) (string, *session.Session, error) {
+	inv, ok := agent.InvocationFromContext(ctx)
+	if !ok || inv == nil || inv.Session == nil {
+		return "", nil, fmt.Errorf(
+			"subagent: current session context is unavailable",
+		)
+	}
+	userID := strings.TrimSpace(inv.Session.UserID)
+	if userID == "" {
+		return "", nil, fmt.Errorf(
+			"subagent: current user id is unavailable",
+		)
+	}
+	if strings.TrimSpace(inv.Session.ID) == "" {
+		return "", nil, fmt.Errorf(
+			"subagent: current session id is unavailable",
+		)
+	}
+	return userID, inv.Session, nil
+}
+
+func isNestedSubagent(ctx context.Context) bool {
+	nested, ok := agent.GetRuntimeStateValueFromContext[bool](
+		ctx,
+		runtimeStateSubagentRun,
+	)
+	return ok && nested
+}

--- a/openclaw/internal/subagentrun/tool_test.go
+++ b/openclaw/internal/subagentrun/tool_test.go
@@ -261,6 +261,10 @@ func TestToolAdditionalErrorPaths(t *testing.T) {
 
 	_, err = tools.cancel.Call(ctx, []byte(`{"id":"missing"}`))
 	require.ErrorIs(t, err, publicsubagent.ErrRunNotFound)
+
+	badCtx := newInvocationContext("user-a", "session-a", nil)
+	_, err = tools.spawn.Call(badCtx, []byte(`{"task":"demo"}`))
+	require.ErrorContains(t, err, "resolve delivery target")
 }
 
 func newInvocationContext(

--- a/openclaw/internal/subagentrun/tool_test.go
+++ b/openclaw/internal/subagentrun/tool_test.go
@@ -213,6 +213,7 @@ func TestToolAdditionalErrorPaths(t *testing.T) {
 
 	var nilTools *Tools
 	require.Nil(t, nilTools.All())
+	nilTools.SetService(nil)
 
 	var nilSpawn *spawnTool
 	var nilList *listTool
@@ -245,6 +246,21 @@ func TestToolAdditionalErrorPaths(t *testing.T) {
 
 	_, err = tools.cancel.Call(ctx, []byte(`{invalid`))
 	require.Error(t, err)
+
+	_, err = tools.spawn.Call(ctx, []byte(`{invalid`))
+	require.Error(t, err)
+
+	_, err = tools.spawn.Call(context.Background(), []byte(`{"task":"demo"}`))
+	require.ErrorContains(t, err, "current session context is unavailable")
+
+	_, err = tools.list.Call(context.Background(), nil)
+	require.ErrorContains(t, err, "current session context is unavailable")
+
+	_, err = tools.get.Call(context.Background(), []byte(`{"id":"run-1"}`))
+	require.ErrorContains(t, err, "current session context is unavailable")
+
+	_, err = tools.cancel.Call(ctx, []byte(`{"id":"missing"}`))
+	require.ErrorIs(t, err, publicsubagent.ErrRunNotFound)
 }
 
 func newInvocationContext(

--- a/openclaw/internal/subagentrun/tool_test.go
+++ b/openclaw/internal/subagentrun/tool_test.go
@@ -1,0 +1,264 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package subagentrun
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	publicsubagent "trpc.group/trpc-go/trpc-agent-go/openclaw/subagent"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+func TestToolsSpawnListGetCancel(t *testing.T) {
+	t.Parallel()
+
+	runner := &blockingRunner{started: make(chan struct{})}
+	svc, err := NewService(t.TempDir(), runner, nil)
+	require.NoError(t, err)
+	svc.Start(context.Background())
+	t.Cleanup(func() {
+		require.NoError(t, svc.Close())
+	})
+
+	tools := NewTools(svc)
+	ctx := newInvocationContext(
+		"telegram:user",
+		"telegram:dm:321",
+		nil,
+	)
+
+	spawnedAny, err := tools.spawn.Call(
+		ctx,
+		[]byte(`{"task":"review the patch","timeout_seconds":5}`),
+	)
+	require.NoError(t, err)
+
+	spawned := spawnedAny.(publicsubagent.Run)
+	require.Equal(t, "telegram:dm:321", spawned.ParentSessionID)
+	require.Equal(t, publicsubagent.StatusQueued, spawned.Status)
+
+	select {
+	case <-runner.started:
+	case <-time.After(time.Second):
+		t.Fatal("subagent run did not start in time")
+	}
+
+	listedAny, err := tools.list.Call(ctx, nil)
+	require.NoError(t, err)
+	listed := listedAny.(listResult)
+	require.Len(t, listed.Runs, 1)
+	require.Equal(t, spawned.ID, listed.Runs[0].ID)
+
+	getArgs := []byte(`{"id":"` + spawned.ID + `"}`)
+	gotAny, err := tools.get.Call(ctx, getArgs)
+	require.NoError(t, err)
+	got := gotAny.(*publicsubagent.Run)
+	require.Equal(t, spawned.ID, got.ID)
+
+	canceledAny, err := tools.cancel.Call(ctx, getArgs)
+	require.NoError(t, err)
+	canceled := canceledAny.(*publicsubagent.Run)
+	require.Equal(t, publicsubagent.StatusCanceled, canceled.Status)
+
+	listedAny, err = tools.listAlias.Call(ctx, []byte(`{}`))
+	require.NoError(t, err)
+	listed = listedAny.(listResult)
+	require.Len(t, listed.Runs, 1)
+}
+
+func TestSpawnToolRejectsNestedSubagent(t *testing.T) {
+	t.Parallel()
+
+	runner := &captureRunner{reply: "ok"}
+	svc, err := NewService(t.TempDir(), runner, nil)
+	require.NoError(t, err)
+	svc.Start(context.Background())
+	t.Cleanup(func() {
+		require.NoError(t, svc.Close())
+	})
+
+	tools := NewTools(svc)
+	ctx := newInvocationContext(
+		"user-a",
+		"session-a",
+		map[string]any{runtimeStateSubagentRun: true},
+	)
+
+	_, err = tools.spawn.Call(ctx, []byte(`{"task":"nested"}`))
+	require.ErrorContains(
+		t,
+		err,
+		"nested subagent spawn is not supported",
+	)
+}
+
+func TestCurrentContextRequiresInvocation(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := currentContext(context.Background())
+	require.ErrorContains(t, err, "current session context is unavailable")
+}
+
+func TestToolsAllAndDeclarations(t *testing.T) {
+	t.Parallel()
+
+	tools := NewTools(nil)
+	all := tools.All()
+	require.Len(t, all, 8)
+
+	svc := &Service{}
+	tools.SetService(svc)
+	for _, item := range all {
+		require.NotNil(t, item.Declaration())
+	}
+	require.Contains(
+		t,
+		tools.spawnAlias.Declaration().Description,
+		toolSubagentsSpawn,
+	)
+	require.Contains(
+		t,
+		tools.listAlias.Declaration().Description,
+		toolSubagentsList,
+	)
+	require.Contains(
+		t,
+		tools.getAlias.Declaration().Description,
+		toolSubagentsGet,
+	)
+	require.Contains(
+		t,
+		tools.cancelAlias.Declaration().Description,
+		toolSubagentsCancel,
+	)
+}
+
+func TestDecodeRunIDArgsRequiresID(t *testing.T) {
+	t.Parallel()
+
+	ctx := newInvocationContext("user-a", "session-a", nil)
+	_, _, err := decodeRunIDArgs(ctx, []byte(`{"id":" "}`))
+	require.ErrorContains(t, err, "empty run id")
+}
+
+func TestToolsRequireConfiguredService(t *testing.T) {
+	t.Parallel()
+
+	tools := NewTools(nil)
+	ctx := newInvocationContext("user-a", "session-a", nil)
+
+	_, err := tools.spawn.Call(ctx, []byte(`{"task":"demo"}`))
+	require.ErrorContains(t, err, "service unavailable")
+
+	_, err = tools.list.Call(ctx, nil)
+	require.ErrorContains(t, err, "service unavailable")
+}
+
+func TestListToolRejectsInvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	svc, err := NewService(t.TempDir(), &captureRunner{reply: "ok"}, nil)
+	require.NoError(t, err)
+	svc.Start(context.Background())
+	t.Cleanup(func() {
+		require.NoError(t, svc.Close())
+	})
+
+	tools := NewTools(svc)
+	ctx := newInvocationContext("user-a", "session-a", nil)
+	_, err = tools.list.Call(ctx, []byte(`{invalid`))
+	require.Error(t, err)
+}
+
+func TestCurrentContextRequiresUserAndSessionFields(t *testing.T) {
+	t.Parallel()
+
+	ctx := agent.NewInvocationContext(
+		context.Background(),
+		agent.NewInvocation(
+			agent.WithInvocationSession(
+				session.NewSession("app", "", "session-a"),
+			),
+		),
+	)
+	_, _, err := currentContext(ctx)
+	require.ErrorContains(t, err, "current user id is unavailable")
+
+	ctx = agent.NewInvocationContext(
+		context.Background(),
+		agent.NewInvocation(
+			agent.WithInvocationSession(
+				session.NewSession("app", "user-a", ""),
+			),
+		),
+	)
+	_, _, err = currentContext(ctx)
+	require.ErrorContains(t, err, "current session id is unavailable")
+}
+
+func TestToolAdditionalErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	var nilTools *Tools
+	require.Nil(t, nilTools.All())
+
+	var nilSpawn *spawnTool
+	var nilList *listTool
+	var nilGet *getTool
+	var nilCancel *cancelTool
+	require.Nil(t, nilSpawn.base())
+	require.Nil(t, nilList.base())
+	require.Nil(t, nilGet.base())
+	require.Nil(t, nilCancel.base())
+
+	tools := NewTools(nil)
+	ctx := newInvocationContext("user-a", "session-a", nil)
+
+	_, err := tools.get.Call(ctx, []byte(`{"id":"run-1"}`))
+	require.ErrorContains(t, err, "service unavailable")
+
+	_, err = tools.cancel.Call(ctx, []byte(`{"id":"run-1"}`))
+	require.ErrorContains(t, err, "service unavailable")
+
+	svc, err := NewService(t.TempDir(), &captureRunner{reply: "ok"}, nil)
+	require.NoError(t, err)
+	svc.Start(context.Background())
+	t.Cleanup(func() {
+		require.NoError(t, svc.Close())
+	})
+	tools.SetService(svc)
+
+	_, err = tools.get.Call(ctx, []byte(`{invalid`))
+	require.Error(t, err)
+
+	_, err = tools.cancel.Call(ctx, []byte(`{invalid`))
+	require.Error(t, err)
+}
+
+func newInvocationContext(
+	userID string,
+	sessionID string,
+	runtimeState map[string]any,
+) context.Context {
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(
+			session.NewSession("app", userID, sessionID),
+		),
+		agent.WithInvocationRunOptions(agent.RunOptions{
+			RuntimeState: runtimeState,
+		}),
+	)
+	return agent.NewInvocationContext(context.Background(), inv)
+}

--- a/openclaw/internal/subagentrun/types.go
+++ b/openclaw/internal/subagentrun/types.go
@@ -1,0 +1,128 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package subagentrun
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	publicsubagent "trpc.group/trpc-go/trpc-agent-go/openclaw/subagent"
+)
+
+const (
+	subagentDirName       = "subagents"
+	subagentRunsFileName  = "runs.json"
+	subagentSessionPrefix = "subagent:"
+	subagentRequestPrefix = "subagent:"
+
+	runtimeStateSubagentRun      = "openclaw.subagent.run"
+	runtimeStateSubagentRunID    = "openclaw.subagent.run_id"
+	runtimeStateSubagentParentID = "openclaw.subagent.parent_session_id"
+
+	defaultStoredResultRunes  = 4000
+	defaultStoredSummaryRunes = 240
+
+	notificationPrefixCompleted = "✅ subagent 已完成"
+	notificationPrefixFailed    = "⚠️ subagent 失败"
+	notificationPrefixCanceled  = "🛑 subagent 已取消"
+
+	subagentRunPrompt = "You are running as an OpenClaw background " +
+		"subagent. Complete the delegated task once. The parent " +
+		"chat will receive your final result automatically. Keep " +
+		"the result concise and action-oriented. Do not spawn more " +
+		"subagents from inside this subagent."
+)
+
+type deliveryTarget struct {
+	Channel string `json:"channel,omitempty"`
+	Target  string `json:"target,omitempty"`
+}
+
+type runRecord struct {
+	publicsubagent.Run
+
+	OwnerUserID string         `json:"owner_user_id,omitempty"`
+	Delivery    deliveryTarget `json:"delivery,omitempty"`
+}
+
+type storeFile struct {
+	Version int         `json:"version"`
+	Runs    []runRecord `json:"runs,omitempty"`
+}
+
+type SpawnRequest struct {
+	OwnerUserID     string
+	ParentSessionID string
+	Task            string
+	TimeoutSeconds  int
+	Delivery        deliveryTarget
+}
+
+func (r *runRecord) clone() *runRecord {
+	if r == nil {
+		return nil
+	}
+	out := *r
+	if r.StartedAt != nil {
+		startedAt := *r.StartedAt
+		out.StartedAt = &startedAt
+	}
+	if r.FinishedAt != nil {
+		finishedAt := *r.FinishedAt
+		out.FinishedAt = &finishedAt
+	}
+	return &out
+}
+
+func (r *runRecord) publicView() publicsubagent.Run {
+	if r == nil {
+		return publicsubagent.Run{}
+	}
+	return r.Run
+}
+
+func newChildSessionID(runID string, now time.Time) string {
+	return fmt.Sprintf(
+		"%s%s:%d",
+		subagentSessionPrefix,
+		strings.TrimSpace(runID),
+		now.UnixNano(),
+	)
+}
+
+func newRequestID(runID string, now time.Time) string {
+	return fmt.Sprintf(
+		"%s%s:%d",
+		subagentRequestPrefix,
+		strings.TrimSpace(runID),
+		now.UnixNano(),
+	)
+}
+
+func sanitizeStoredResult(text string) string {
+	return truncateRunes(text, defaultStoredResultRunes)
+}
+
+func summarizeResult(text string) string {
+	return truncateRunes(text, defaultStoredSummaryRunes)
+}
+
+func truncateRunes(text string, limit int) string {
+	trimmed := strings.TrimSpace(text)
+	if limit <= 0 {
+		return trimmed
+	}
+	runes := []rune(trimmed)
+	if len(runes) <= limit {
+		return trimmed
+	}
+	return string(runes[:limit])
+}

--- a/openclaw/internal/subagentrun/types.go
+++ b/openclaw/internal/subagentrun/types.go
@@ -29,6 +29,7 @@ const (
 
 	defaultStoredResultRunes  = 4000
 	defaultStoredSummaryRunes = 240
+	defaultNotifyTimeout      = 15 * time.Second
 
 	notificationPrefixCompleted = "✅ subagent 已完成"
 	notificationPrefixFailed    = "⚠️ subagent 失败"

--- a/openclaw/subagent/subagent.go
+++ b/openclaw/subagent/subagent.go
@@ -1,0 +1,66 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package subagent exposes the public control-plane view for OpenClaw
+// background subagents.
+package subagent
+
+import (
+	"errors"
+	"time"
+)
+
+var ErrRunNotFound = errors.New("subagent: run not found")
+
+type Status string
+
+const (
+	StatusQueued    Status = "queued"
+	StatusRunning   Status = "running"
+	StatusCompleted Status = "completed"
+	StatusFailed    Status = "failed"
+	StatusCanceled  Status = "canceled"
+)
+
+type Run struct {
+	ID              string     `json:"id,omitempty"`
+	ParentSessionID string     `json:"parent_session_id,omitempty"`
+	ChildSessionID  string     `json:"child_session_id,omitempty"`
+	Task            string     `json:"task,omitempty"`
+	Status          Status     `json:"status,omitempty"`
+	Summary         string     `json:"summary,omitempty"`
+	Result          string     `json:"result,omitempty"`
+	Error           string     `json:"error,omitempty"`
+	CreatedAt       time.Time  `json:"created_at"`
+	UpdatedAt       time.Time  `json:"updated_at"`
+	StartedAt       *time.Time `json:"started_at,omitempty"`
+	FinishedAt      *time.Time `json:"finished_at,omitempty"`
+}
+
+type ListFilter struct {
+	ParentSessionID string
+}
+
+type Service interface {
+	ListForUser(userID string, filter ListFilter) []Run
+	GetForUser(userID string, runID string) (*Run, error)
+	CancelForUser(
+		userID string,
+		runID string,
+	) (*Run, bool, error)
+}
+
+func (s Status) IsTerminal() bool {
+	switch s {
+	case StatusCompleted, StatusFailed, StatusCanceled:
+		return true
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
## Summary
- add a minimal OpenClaw subagent runtime with persistent run storage
- expose subagent spawn/list/get/cancel tools plus compatibility aliases
- wire the runtime into OpenClaw app startup and shutdown, with tests

## Testing
- go test ./internal/subagentrun ./app
- go test -coverprofile=/tmp/subagent_public.out ./internal/subagentrun && go tool cover -func=/tmp/subagent_public.out