### PR TITLE
session/mysql: snapshot async-persist events before enqueue

### DIFF
--- a/session/mysql/service.go
+++ b/session/mysql/service.go
@@ -705,8 +705,10 @@ func (s *Service) appendEventInternal(
 	key session.Key,
 	opts ...session.Option,
 ) error {
+	storedEvent := snapshotEvent(e)
+
 	// update user session with the given event
-	sess.UpdateUserSession(e, opts...)
+	sess.UpdateUserSession(storedEvent, opts...)
 
 	// persist event to MySQL asynchronously
 	if s.opts.enableAsyncPersist {
@@ -729,14 +731,14 @@ func (s *Service) appendEventInternal(
 		// Hash key to determine which worker channel to use
 		index := sess.Hash % len(s.eventPairChans)
 		select {
-		case s.eventPairChans[index] <- &sessionEventPair{key: key, event: e}:
+		case s.eventPairChans[index] <- &sessionEventPair{key: key, event: storedEvent}:
 		case <-ctx.Done():
 			return ctx.Err()
 		}
 		return nil
 	}
 
-	if err := s.addEvent(ctx, key, e); err != nil {
+	if err := s.addEvent(ctx, key, storedEvent); err != nil {
 		return fmt.Errorf("mysql session service append event failed: %w", err)
 	}
 
@@ -750,6 +752,8 @@ func (s *Service) AppendTrackEvent(
 	trackEvent *session.TrackEvent,
 	opts ...session.Option,
 ) error {
+	storedTrackEvent := snapshotTrackEvent(trackEvent)
+
 	key := session.Key{
 		AppName:   sess.AppName,
 		UserID:    sess.UserID,
@@ -758,7 +762,7 @@ func (s *Service) AppendTrackEvent(
 	if err := key.CheckSessionKey(); err != nil {
 		return err
 	}
-	if err := sess.AppendTrackEvent(trackEvent, opts...); err != nil {
+	if err := sess.AppendTrackEvent(storedTrackEvent, opts...); err != nil {
 		return fmt.Errorf("mysql session service append track event failed: %w", err)
 	}
 
@@ -775,14 +779,14 @@ func (s *Service) AppendTrackEvent(
 
 		index := sess.Hash % len(s.trackEventChans)
 		select {
-		case s.trackEventChans[index] <- &trackEventPair{key: key, event: trackEvent}:
+		case s.trackEventChans[index] <- &trackEventPair{key: key, event: storedTrackEvent}:
 		case <-ctx.Done():
 			return ctx.Err()
 		}
 		return nil
 	}
 
-	if err := s.addTrackEvent(ctx, key, trackEvent); err != nil {
+	if err := s.addTrackEvent(ctx, key, storedTrackEvent); err != nil {
 		return fmt.Errorf("mysql session service append track event failed: %w", err)
 	}
 	return nil

--- a/session/mysql/service_test.go
+++ b/session/mysql/service_test.go
@@ -3475,6 +3475,127 @@ func TestAppendEventInternal_AsyncPersistEnqueue(t *testing.T) {
 	}
 }
 
+func TestAppendEventInternal_AsyncPersistEnqueueSnapshotsNestedMessageData(t *testing.T) {
+	db, _, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db, WithEnableAsyncPersist(true))
+	s.eventPairChans = []chan *sessionEventPair{
+		make(chan *sessionEventPair, 1),
+	}
+
+	ctx := context.Background()
+	key := session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "sess",
+	}
+	sess := session.NewSession(key.AppName, key.UserID, key.SessionID)
+	sess.Hash = 0
+
+	messageText := "before-text"
+	deltaText := "before-delta"
+	toolIndex := 0
+	finishReason := "stop"
+	evt := event.New("inv-1", "author")
+	evt.Response = &model.Response{
+		Object: model.ObjectTypeChatCompletion,
+		Done:   true,
+		Choices: []model.Choice{
+			{
+				Index: 0,
+				Message: model.Message{
+					Role:    model.RoleAssistant,
+					Content: "{\"insight_text\":\"before\"}",
+					ContentParts: []model.ContentPart{
+						{
+							Type: model.ContentTypeText,
+							Text: &messageText,
+						},
+						{
+							Type: model.ContentTypeFile,
+							File: &model.File{
+								Name:     "payload.json",
+								Data:     []byte("before-file"),
+								MimeType: "application/json",
+							},
+						},
+					},
+					ToolCalls: []model.ToolCall{
+						{
+							Type: "function",
+							Function: model.FunctionDefinitionParam{
+								Name:      "test_tool",
+								Arguments: []byte(`{"stage":"before"}`),
+							},
+							Index: &toolIndex,
+							ExtraFields: map[string]any{
+								"nested": []any{
+									map[string]any{
+										"phase": "before",
+									},
+								},
+							},
+						},
+					},
+				},
+				Delta: model.Message{
+					Role: model.RoleAssistant,
+					ContentParts: []model.ContentPart{
+						{
+							Type: model.ContentTypeText,
+							Text: &deltaText,
+						},
+					},
+				},
+				FinishReason: &finishReason,
+			},
+		},
+	}
+
+	err = s.appendEventInternal(ctx, sess, evt, key)
+	require.NoError(t, err)
+
+	evt.Response.Choices[0].Message.Content = "{\"insight_text\":\"after\"}"
+	*evt.Response.Choices[0].Message.ContentParts[0].Text = "after-text"
+	evt.Response.Choices[0].Message.ContentParts[1].File.Data[0] = 'A'
+	evt.Response.Choices[0].Message.ToolCalls[0].Function.Arguments[10] = 'a'
+	*evt.Response.Choices[0].Message.ToolCalls[0].Index = 3
+	evt.Response.Choices[0].Message.ToolCalls[0].ExtraFields["nested"].([]any)[0].(map[string]any)["phase"] = "after"
+	*evt.Response.Choices[0].Delta.ContentParts[0].Text = "after-delta"
+	*evt.Response.Choices[0].FinishReason = "length"
+
+	select {
+	case pair := <-s.eventPairChans[0]:
+		require.NotNil(t, pair)
+		require.NotNil(t, pair.event)
+		require.NotNil(t, pair.event.Response)
+		require.Len(t, pair.event.Response.Choices, 1)
+
+		choice := pair.event.Response.Choices[0]
+		assert.Equal(t, "{\"insight_text\":\"before\"}", choice.Message.Content)
+		require.Len(t, choice.Message.ContentParts, 2)
+		require.NotNil(t, choice.Message.ContentParts[0].Text)
+		assert.Equal(t, "before-text", *choice.Message.ContentParts[0].Text)
+		require.NotNil(t, choice.Message.ContentParts[1].File)
+		assert.Equal(t, []byte("before-file"), choice.Message.ContentParts[1].File.Data)
+		require.Len(t, choice.Message.ToolCalls, 1)
+		assert.Equal(t, []byte(`{"stage":"before"}`), choice.Message.ToolCalls[0].Function.Arguments)
+		require.NotNil(t, choice.Message.ToolCalls[0].Index)
+		assert.Equal(t, 0, *choice.Message.ToolCalls[0].Index)
+		nested := choice.Message.ToolCalls[0].ExtraFields["nested"].([]any)
+		assert.Equal(t, "before", nested[0].(map[string]any)["phase"])
+		require.Len(t, choice.Delta.ContentParts, 1)
+		require.NotNil(t, choice.Delta.ContentParts[0].Text)
+		assert.Equal(t, "before-delta", *choice.Delta.ContentParts[0].Text)
+		require.NotNil(t, choice.FinishReason)
+		assert.Equal(t, "stop", *choice.FinishReason)
+	default:
+		t.Fatal("expected event to be enqueued")
+	}
+}
+
 func TestAppendTrackEvent_AsyncPersistEnqueueSnapshotsPayload(t *testing.T) {
 	db, _, err := sqlmock.New()
 	require.NoError(t, err)

--- a/session/mysql/service_test.go
+++ b/session/mysql/service_test.go
@@ -3443,17 +3443,71 @@ func TestAppendEventInternal_AsyncPersistEnqueue(t *testing.T) {
 	sess.Hash = 0
 
 	evt := event.New("inv-1", "author")
+	evt.Response = &model.Response{
+		Object: model.ObjectTypeChatCompletion,
+		Done:   true,
+		Choices: []model.Choice{
+			{
+				Index: 0,
+				Message: model.Message{
+					Role:    model.RoleAssistant,
+					Content: "{\"insight_text\":\"before\"}",
+				},
+			},
+		},
+	}
 
 	err = s.appendEventInternal(ctx, sess, evt, key)
 	require.NoError(t, err)
+
+	evt.Response.Choices[0].Message.Content = "{\"insight_text\":\"after\"}"
 
 	select {
 	case pair := <-s.eventPairChans[0]:
 		require.NotNil(t, pair)
 		assert.Equal(t, key, pair.key)
-		assert.Equal(t, evt, pair.event)
+		require.NotSame(t, evt, pair.event)
+		require.NotNil(t, pair.event.Response)
+		require.Len(t, pair.event.Response.Choices, 1)
+		assert.Equal(t, "{\"insight_text\":\"before\"}", pair.event.Response.Choices[0].Message.Content)
 	default:
 		t.Fatal("expected event to be enqueued")
+	}
+}
+
+func TestAppendTrackEvent_AsyncPersistEnqueueSnapshotsPayload(t *testing.T) {
+	db, _, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db, WithEnableAsyncPersist(true))
+	s.trackEventChans = []chan *trackEventPair{
+		make(chan *trackEventPair, 1),
+	}
+
+	ctx := context.Background()
+	sess := session.NewSession("app", "user", "sess")
+	sess.Hash = 0
+
+	trackEvent := &session.TrackEvent{
+		Track:     "agui",
+		Payload:   json.RawMessage(`{"delta":"before"}`),
+		Timestamp: time.Now(),
+	}
+
+	err = s.AppendTrackEvent(ctx, sess, trackEvent)
+	require.NoError(t, err)
+
+	copy(trackEvent.Payload, []byte(`{"delta":"after "}`))
+
+	select {
+	case pair := <-s.trackEventChans[0]:
+		require.NotNil(t, pair)
+		require.NotNil(t, pair.event)
+		require.NotSame(t, trackEvent, pair.event)
+		assert.Equal(t, json.RawMessage(`{"delta":"before"}`), pair.event.Payload)
+	default:
+		t.Fatal("expected track event to be enqueued")
 	}
 }
 

--- a/session/mysql/snapshot.go
+++ b/session/mysql/snapshot.go
@@ -1,0 +1,78 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package mysql
+
+import (
+	"encoding/json"
+
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+func snapshotEvent(e *event.Event) *event.Event {
+	if e == nil {
+		return nil
+	}
+
+	snap := *e
+	if e.Response != nil {
+		snap.Response = e.Response.Clone()
+	}
+	if e.LongRunningToolIDs != nil {
+		snap.LongRunningToolIDs = make(map[string]struct{}, len(e.LongRunningToolIDs))
+		for k := range e.LongRunningToolIDs {
+			snap.LongRunningToolIDs[k] = struct{}{}
+		}
+	}
+	if e.StateDelta != nil {
+		snap.StateDelta = make(map[string][]byte, len(e.StateDelta))
+		for k, v := range e.StateDelta {
+			if v == nil {
+				snap.StateDelta[k] = nil
+				continue
+			}
+			copied := make([]byte, len(v))
+			copy(copied, v)
+			snap.StateDelta[k] = copied
+		}
+	}
+	if e.Extensions != nil {
+		snap.Extensions = make(map[string]json.RawMessage, len(e.Extensions))
+		for k, v := range e.Extensions {
+			if v == nil {
+				snap.Extensions[k] = nil
+				continue
+			}
+			copied := make([]byte, len(v))
+			copy(copied, v)
+			snap.Extensions[k] = copied
+		}
+	}
+	if e.Actions != nil {
+		snap.Actions = &event.EventActions{
+			SkipSummarization: e.Actions.SkipSummarization,
+		}
+	}
+	snap.StructuredOutput = nil
+	snap.ExecutionTrace = nil
+	return &snap
+}
+
+func snapshotTrackEvent(trackEvent *session.TrackEvent) *session.TrackEvent {
+	if trackEvent == nil {
+		return nil
+	}
+
+	snap := *trackEvent
+	if trackEvent.Payload != nil {
+		snap.Payload = make(json.RawMessage, len(trackEvent.Payload))
+		copy(snap.Payload, trackEvent.Payload)
+	}
+	return &snap
+}

--- a/session/mysql/snapshot.go
+++ b/session/mysql/snapshot.go
@@ -10,6 +10,7 @@ package mysql
 
 import (
 	"encoding/json"
+	"reflect"
 
 	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/model"
@@ -163,19 +164,86 @@ func snapshotFunctionDefinitionParam(param model.FunctionDefinitionParam) model.
 }
 
 func snapshotExtraFields(extraFields map[string]any) map[string]any {
-	payload, err := json.Marshal(extraFields)
-	if err == nil {
-		var snap map[string]any
-		if err := json.Unmarshal(payload, &snap); err == nil {
-			return snap
-		}
-	}
-
 	snap := make(map[string]any, len(extraFields))
 	for k, v := range extraFields {
-		snap[k] = v
+		snap[k] = snapshotDynamicValue(v)
 	}
 	return snap
+}
+
+func snapshotDynamicValue(value any) any {
+	if value == nil {
+		return nil
+	}
+	return snapshotReflectValue(reflect.ValueOf(value)).Interface()
+}
+
+func snapshotReflectValue(value reflect.Value) reflect.Value {
+	if !value.IsValid() {
+		return value
+	}
+
+	switch value.Kind() {
+	case reflect.Interface:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		cloned := snapshotReflectValue(value.Elem())
+		result := reflect.New(value.Type()).Elem()
+		result.Set(cloned)
+		return result
+	case reflect.Pointer:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		cloned := reflect.New(value.Type().Elem())
+		cloned.Elem().Set(snapshotReflectValue(value.Elem()))
+		return cloned
+	case reflect.Slice:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		cloned := reflect.MakeSlice(value.Type(), value.Len(), value.Len())
+		if value.Type().Elem().Kind() == reflect.Uint8 {
+			reflect.Copy(cloned, value)
+			return cloned
+		}
+		for i := 0; i < value.Len(); i++ {
+			cloned.Index(i).Set(snapshotReflectValue(value.Index(i)))
+		}
+		return cloned
+	case reflect.Array:
+		cloned := reflect.New(value.Type()).Elem()
+		for i := 0; i < value.Len(); i++ {
+			cloned.Index(i).Set(snapshotReflectValue(value.Index(i)))
+		}
+		return cloned
+	case reflect.Map:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		cloned := reflect.MakeMapWithSize(value.Type(), value.Len())
+		iter := value.MapRange()
+		for iter.Next() {
+			cloned.SetMapIndex(iter.Key(), snapshotReflectValue(iter.Value()))
+		}
+		return cloned
+	case reflect.Struct:
+		cloned := reflect.New(value.Type()).Elem()
+		cloned.Set(value)
+		for i := 0; i < value.NumField(); i++ {
+			if !cloned.Field(i).CanSet() {
+				continue
+			}
+			switch value.Field(i).Kind() {
+			case reflect.Interface, reflect.Pointer, reflect.Slice, reflect.Array, reflect.Map, reflect.Struct:
+				cloned.Field(i).Set(snapshotReflectValue(value.Field(i)))
+			}
+		}
+		return cloned
+	default:
+		return value
+	}
 }
 
 func snapshotTrackEvent(trackEvent *session.TrackEvent) *session.TrackEvent {

--- a/session/mysql/snapshot.go
+++ b/session/mysql/snapshot.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 
 	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 )
 
@@ -22,7 +23,7 @@ func snapshotEvent(e *event.Event) *event.Event {
 
 	snap := *e
 	if e.Response != nil {
-		snap.Response = e.Response.Clone()
+		snap.Response = snapshotResponse(e.Response)
 	}
 	if e.LongRunningToolIDs != nil {
 		snap.LongRunningToolIDs = make(map[string]struct{}, len(e.LongRunningToolIDs))
@@ -62,6 +63,119 @@ func snapshotEvent(e *event.Event) *event.Event {
 	snap.StructuredOutput = nil
 	snap.ExecutionTrace = nil
 	return &snap
+}
+
+func snapshotResponse(rsp *model.Response) *model.Response {
+	if rsp == nil {
+		return nil
+	}
+
+	snap := rsp.Clone()
+	if len(rsp.Choices) == 0 {
+		return snap
+	}
+
+	snap.Choices = make([]model.Choice, len(rsp.Choices))
+	for i := range rsp.Choices {
+		snap.Choices[i] = snapshotChoice(rsp.Choices[i])
+	}
+	return snap
+}
+
+func snapshotChoice(choice model.Choice) model.Choice {
+	snap := choice
+	snap.Message = snapshotMessage(choice.Message)
+	snap.Delta = snapshotMessage(choice.Delta)
+	if choice.FinishReason != nil {
+		finishReason := *choice.FinishReason
+		snap.FinishReason = &finishReason
+	}
+	return snap
+}
+
+func snapshotMessage(msg model.Message) model.Message {
+	snap := msg
+	if len(msg.ContentParts) > 0 {
+		snap.ContentParts = make([]model.ContentPart, len(msg.ContentParts))
+		for i := range msg.ContentParts {
+			snap.ContentParts[i] = snapshotContentPart(msg.ContentParts[i])
+		}
+	}
+	if len(msg.ToolCalls) > 0 {
+		snap.ToolCalls = make([]model.ToolCall, len(msg.ToolCalls))
+		for i := range msg.ToolCalls {
+			snap.ToolCalls[i] = snapshotToolCall(msg.ToolCalls[i])
+		}
+	}
+	return snap
+}
+
+func snapshotContentPart(part model.ContentPart) model.ContentPart {
+	snap := part
+	if part.Text != nil {
+		text := *part.Text
+		snap.Text = &text
+	}
+	if part.Image != nil {
+		snap.Image = &model.Image{
+			URL:    part.Image.URL,
+			Data:   append([]byte(nil), part.Image.Data...),
+			Detail: part.Image.Detail,
+			Format: part.Image.Format,
+		}
+	}
+	if part.Audio != nil {
+		snap.Audio = &model.Audio{
+			Data:   append([]byte(nil), part.Audio.Data...),
+			Format: part.Audio.Format,
+		}
+	}
+	if part.File != nil {
+		snap.File = &model.File{
+			Name:     part.File.Name,
+			Data:     append([]byte(nil), part.File.Data...),
+			FileID:   part.File.FileID,
+			MimeType: part.File.MimeType,
+		}
+	}
+	return snap
+}
+
+func snapshotToolCall(toolCall model.ToolCall) model.ToolCall {
+	snap := toolCall
+	snap.Function = snapshotFunctionDefinitionParam(toolCall.Function)
+	if toolCall.Index != nil {
+		index := *toolCall.Index
+		snap.Index = &index
+	}
+	if toolCall.ExtraFields != nil {
+		snap.ExtraFields = snapshotExtraFields(toolCall.ExtraFields)
+	}
+	return snap
+}
+
+func snapshotFunctionDefinitionParam(param model.FunctionDefinitionParam) model.FunctionDefinitionParam {
+	snap := param
+	if param.Arguments != nil {
+		snap.Arguments = append([]byte(nil), param.Arguments...)
+	}
+	return snap
+}
+
+func snapshotExtraFields(extraFields map[string]any) map[string]any {
+	payload, err := json.Marshal(extraFields)
+	if err == nil {
+		var snap map[string]any
+		if err := json.Unmarshal(payload, &snap); err == nil {
+			return snap
+		}
+	}
+
+	snap := make(map[string]any, len(extraFields))
+	for k, v := range extraFields {
+		snap[k] = v
+	}
+	return snap
 }
 
 func snapshotTrackEvent(trackEvent *session.TrackEvent) *session.TrackEvent {

--- a/session/mysql/snapshot_test.go
+++ b/session/mysql/snapshot_test.go
@@ -1,0 +1,190 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package mysql
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/agent/trace"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+type extraFieldsValueHolder struct {
+	Values []string
+}
+
+type extraFieldsPointerHolder struct {
+	Value string
+}
+
+func TestSnapshotExtraFields_PreservesTypesAndDeepCopies(t *testing.T) {
+	currentTime := time.Date(2026, time.April, 23, 10, 0, 0, 0, time.UTC)
+	structValue := extraFieldsValueHolder{Values: []string{"before"}}
+	structPointer := &extraFieldsPointerHolder{Value: "before"}
+
+	extraFields := map[string]any{
+		"int64":      int64(7),
+		"time":       currentTime,
+		"slice":      []int{1, 2},
+		"array":      [2]string{"a", "b"},
+		"nested_map": map[string]any{"count": int64(1)},
+		"struct":     structValue,
+		"struct_ptr": structPointer,
+		"raw":        json.RawMessage(`{"ok":true}`),
+	}
+
+	snap := snapshotExtraFields(extraFields)
+
+	extraFields["slice"].([]int)[0] = 9
+	extraFields["nested_map"].(map[string]any)["count"] = int64(2)
+	extraFields["struct"].(extraFieldsValueHolder).Values[0] = "after"
+	extraFields["struct_ptr"].(*extraFieldsPointerHolder).Value = "after"
+	extraFields["raw"].(json.RawMessage)[2] = 'x'
+
+	require.NotNil(t, snap)
+	assert.IsType(t, int64(0), snap["int64"])
+	assert.Equal(t, int64(7), snap["int64"])
+	assert.IsType(t, time.Time{}, snap["time"])
+	assert.Equal(t, currentTime, snap["time"])
+	assert.Equal(t, []int{1, 2}, snap["slice"])
+	assert.Equal(t, [2]string{"a", "b"}, snap["array"])
+	assert.Equal(t, int64(1), snap["nested_map"].(map[string]any)["count"])
+	assert.Equal(t, []string{"before"}, snap["struct"].(extraFieldsValueHolder).Values)
+	assert.Equal(t, "before", snap["struct_ptr"].(*extraFieldsPointerHolder).Value)
+	assert.NotSame(t, structPointer, snap["struct_ptr"])
+	assert.Equal(t, json.RawMessage(`{"ok":true}`), snap["raw"])
+}
+
+func TestSnapshotContentPart_ClonesBinaryPayloads(t *testing.T) {
+	imageData := []byte{1, 2, 3}
+	audioData := []byte{4, 5, 6}
+	fileData := []byte("before-file")
+
+	imagePart := model.ContentPart{
+		Type: model.ContentTypeImage,
+		Image: &model.Image{
+			URL:    "https://example.com/image.png",
+			Data:   imageData,
+			Detail: "high",
+			Format: "png",
+		},
+	}
+	audioPart := model.ContentPart{
+		Type: model.ContentTypeAudio,
+		Audio: &model.Audio{
+			Data:   audioData,
+			Format: "wav",
+		},
+	}
+	filePart := model.ContentPart{
+		Type: model.ContentTypeFile,
+		File: &model.File{
+			Name:     "payload.json",
+			Data:     fileData,
+			FileID:   "file-1",
+			MimeType: "application/json",
+		},
+	}
+
+	imageSnap := snapshotContentPart(imagePart)
+	audioSnap := snapshotContentPart(audioPart)
+	fileSnap := snapshotContentPart(filePart)
+
+	imagePart.Image.Data[0] = 9
+	audioPart.Audio.Data[0] = 8
+	filePart.File.Data[0] = 'A'
+
+	require.NotNil(t, imageSnap.Image)
+	require.NotNil(t, audioSnap.Audio)
+	require.NotNil(t, fileSnap.File)
+	assert.Equal(t, []byte{1, 2, 3}, imageSnap.Image.Data)
+	assert.Equal(t, []byte{4, 5, 6}, audioSnap.Audio.Data)
+	assert.Equal(t, []byte("before-file"), fileSnap.File.Data)
+}
+
+func TestSnapshotEvent_DeepCopiesAndClearsInMemoryFields(t *testing.T) {
+	text := "before-text"
+	evt := event.New("inv-1", "author")
+	evt.Response = &model.Response{
+		Object: model.ObjectTypeChatCompletion,
+		Choices: []model.Choice{
+			{
+				Message: model.Message{
+					Role: model.RoleAssistant,
+					ContentParts: []model.ContentPart{
+						{
+							Type: model.ContentTypeText,
+							Text: &text,
+						},
+					},
+				},
+			},
+		},
+	}
+	evt.LongRunningToolIDs = map[string]struct{}{"tool-1": {}}
+	evt.StateDelta = map[string][]byte{"state": []byte("before"), "nil": nil}
+	evt.Extensions = map[string]json.RawMessage{
+		"meta": json.RawMessage(`{"key":"before"}`),
+		"nil":  nil,
+	}
+	evt.Actions = &event.EventActions{SkipSummarization: true}
+	evt.StructuredOutput = map[string]string{"drop": "me"}
+	evt.ExecutionTrace = &trace.Trace{
+		RootAgentName:    "root",
+		RootInvocationID: "inv-1",
+		SessionID:        "sess-1",
+	}
+
+	snap := snapshotEvent(evt)
+
+	require.NotNil(t, snap)
+	evt.LongRunningToolIDs["tool-2"] = struct{}{}
+	evt.StateDelta["state"][0] = 'A'
+	evt.Extensions["meta"][8] = 'A'
+	*evt.Response.Choices[0].Message.ContentParts[0].Text = "after-text"
+
+	assert.Nil(t, snap.StructuredOutput)
+	assert.Nil(t, snap.ExecutionTrace)
+	assert.Len(t, snap.LongRunningToolIDs, 1)
+	assert.Equal(t, []byte("before"), snap.StateDelta["state"])
+	assert.Nil(t, snap.StateDelta["nil"])
+	assert.Equal(t, json.RawMessage(`{"key":"before"}`), snap.Extensions["meta"])
+	assert.Nil(t, snap.Extensions["nil"])
+	require.NotNil(t, snap.Actions)
+	assert.True(t, snap.Actions.SkipSummarization)
+	require.Len(t, snap.Response.Choices, 1)
+	require.Len(t, snap.Response.Choices[0].Message.ContentParts, 1)
+	require.NotNil(t, snap.Response.Choices[0].Message.ContentParts[0].Text)
+	assert.Equal(t, "before-text", *snap.Response.Choices[0].Message.ContentParts[0].Text)
+}
+
+func TestSnapshotHelpers_HandleNilAndEmptyValues(t *testing.T) {
+	assert.Nil(t, snapshotEvent(nil))
+	assert.Nil(t, snapshotResponse(nil))
+	assert.Nil(t, snapshotTrackEvent(nil))
+
+	emptyResponse := &model.Response{ID: "rsp-1"}
+	responseSnap := snapshotResponse(emptyResponse)
+	require.NotNil(t, responseSnap)
+	assert.Empty(t, responseSnap.Choices)
+
+	trackEvent := &session.TrackEvent{
+		Track:     "agui",
+		Timestamp: time.Now(),
+	}
+	trackSnap := snapshotTrackEvent(trackEvent)
+	require.NotNil(t, trackSnap)
+	assert.Nil(t, trackSnap.Payload)
+}


### PR DESCRIPTION
## Summary
- Preserve normal delta content on streaming chunks that also carry reasoning_content.
- Keep reasoning_content aggregation unchanged while feeding visible content/tool-call deltas into the accumulator.
- Add coverage for final content matching streamed partial content when the first content chunk is `{`.

## Validation
- go test ./model/openai
- go test ./...