### PR TITLE
tool/workspaceexec: add workspace-scoped file tools sharing workspace_exec state

### DIFF
--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -332,6 +332,9 @@ func buildRequestProcessorsWithAgent(a *LLMAgent, options *Options) []flow.Reque
 		processor.WithWorkspaceExecSessionsResolver(
 			a.supportsWorkspaceExecSessionsForInvocation,
 		),
+		processor.WithWorkspaceFileToolsEnabledResolver(
+			a.supportsWorkspaceFileToolsForInvocation,
+		),
 		processor.WithWorkspaceExecSkillsRepositoryResolver(
 			a.skillRepositoryForInvocation,
 		),
@@ -613,7 +616,8 @@ func registerTools(options *Options) ([]tool.Tool, map[string]bool) {
 			workspaceRegistry = buildWorkspaceRegistry()
 		}
 		runTool = buildSkillRunTool(options, workspaceRegistry)
-	} else if executorSupportsWorkspaceExec(options) {
+	} else if executorSupportsWorkspaceExec(options) ||
+		executorSupportsWorkspaceFileTools(options) {
 		workspaceRegistry = buildWorkspaceRegistry()
 	}
 	allTools = appendWorkspaceExecTool(
@@ -862,6 +866,7 @@ func appendWorkspaceExecTool(
 		exec,
 		executorSupportsWorkspaceExec(options),
 		executorSupportsWorkspaceExecSessions(options),
+		executorSupportsWorkspaceFileTools(options),
 		reg,
 		inv,
 		options,
@@ -884,12 +889,13 @@ func appendWorkspaceExecToolWithExecutor(
 	exec codeexecutor.CodeExecutor,
 	enabled bool,
 	sessional bool,
+	fileToolsEnabled bool,
 	reg *codeexecutor.WorkspaceRegistry,
 	inv *agent.Invocation,
 	options *Options,
 	loadedSkillsRepo skill.Repository,
 ) []tool.Tool {
-	if !enabled {
+	if !enabled && !fileToolsEnabled {
 		return allTools
 	}
 	toolOpts := []func(*toolworkspaceexec.ExecTool){
@@ -900,21 +906,29 @@ func appendWorkspaceExecToolWithExecutor(
 		workspacePrepOptions(options, loadedSkillsRepo)...,
 	)
 	execTool := toolworkspaceexec.NewExecTool(exec, toolOpts...)
-	allTools = append(
-		allTools,
-		execTool,
-	)
-	if toolworkspaceexec.SupportsArtifactSave(inv) {
-		allTools = append(
-			allTools,
-			toolworkspaceexec.NewSaveArtifactTool(execTool),
-		)
+	if enabled {
+		allTools = append(allTools, execTool)
+		if toolworkspaceexec.SupportsArtifactSave(inv) {
+			allTools = append(
+				allTools,
+				toolworkspaceexec.NewSaveArtifactTool(execTool),
+			)
+		}
+		if sessional {
+			allTools = append(
+				allTools,
+				toolworkspaceexec.NewWriteStdinTool(execTool),
+				toolworkspaceexec.NewKillSessionTool(execTool),
+			)
+		}
 	}
-	if sessional {
+	if fileToolsEnabled {
 		allTools = append(
 			allTools,
-			toolworkspaceexec.NewWriteStdinTool(execTool),
-			toolworkspaceexec.NewKillSessionTool(execTool),
+			toolworkspaceexec.NewFileTools(
+				execTool,
+				toolworkspaceexec.FileToolsOptions{},
+			)...,
 		)
 	}
 	return allTools
@@ -1109,6 +1123,29 @@ func workspaceExecSurfaceEnabled(options *Options) bool {
 		return true
 	}
 	return *options.workspaceExecSurfaceEnabled
+}
+
+// workspaceFileToolsEnabled reports whether the caller has opted in
+// to the workspace file-tool surface. Unlike workspaceExecSurface
+// Enabled, the default is false: file tools must be explicitly
+// requested so the model surface does not change for existing
+// callers when they pick up this package.
+func workspaceFileToolsEnabled(options *Options) bool {
+	if options == nil || options.workspaceFileToolsEnabled == nil {
+		return false
+	}
+	return *options.workspaceFileToolsEnabled
+}
+
+// executorSupportsWorkspaceFileTools mirrors
+// executorSupportsWorkspaceExec for the file-tool surface: the tools
+// require the same live-engine-backed executor, plus the explicit
+// opt-in described on WithWorkspaceFileToolsEnabled.
+func executorSupportsWorkspaceFileTools(options *Options) bool {
+	if !workspaceFileToolsEnabled(options) {
+		return false
+	}
+	return codeExecutorSupportsWorkspaceExec(options.codeExecutor)
 }
 
 func codeExecutorSupportsWorkspaceExecSessions(

--- a/agent/llmagent/llm_agent_skill_test.go
+++ b/agent/llmagent/llm_agent_skill_test.go
@@ -1836,7 +1836,7 @@ func TestLLMAgent_WorkspaceExecGuidanceWithoutSkillsRepo(t *testing.T) {
 	sys := findSystemMessageContaining(req, workspaceExecGuidanceHeader)
 	require.NotEmpty(t, sys)
 	require.Contains(t, sys, "default general shell runner")
-	require.Contains(t, sys, "workspace is its scope, not its capability limit")
+	require.Contains(t, sys, "workspace is their scope, not their capability limit")
 	require.Contains(t, sys, "Prefer work/, out/, and runs/")
 	require.Contains(t, sys, "verify first before claiming the limitation")
 	require.NotContains(t, sys, "workspace_save_artifact")

--- a/agent/llmagent/option.go
+++ b/agent/llmagent/option.go
@@ -208,6 +208,20 @@ type Options struct {
 	//
 	// Default: true.
 	workspaceExecSurfaceEnabled *bool
+	// workspaceFileToolsEnabled controls whether the dedicated
+	// workspace file tools (workspace_read_file, workspace_list_dir,
+	// workspace_search_file, workspace_search_content,
+	// workspace_write_file, workspace_replace_content) are exposed to
+	// the model when a code executor is available.
+	//
+	// This switch is independent of workspaceExecSurfaceEnabled: file
+	// tools can be enabled without workspace_exec and vice versa.
+	// When both are enabled the two surfaces share the same ExecTool
+	// so that file tools observe the same prepared workspace
+	// workspace_exec would see on the next call.
+	//
+	// Default: false (no file tools are exposed by default).
+	workspaceFileToolsEnabled *bool
 	// EnableCodeExecutionResponseProcessor controls whether the agent
 	// auto-executes fenced code blocks from model responses.
 	//
@@ -674,6 +688,33 @@ func WithWorkspaceExecSurfaceEnabled(enable bool) Option {
 	return func(opts *Options) {
 		value := enable
 		opts.workspaceExecSurfaceEnabled = &value
+	}
+}
+
+// WithWorkspaceFileToolsEnabled controls whether the dedicated
+// workspace file tools (workspace_read_file, workspace_list_dir,
+// workspace_search_file, workspace_search_content,
+// workspace_write_file, workspace_replace_content) are exposed to
+// the model.
+//
+// The file tools are a thin, purpose-built layer over the same
+// executor workspace that workspace_exec uses, and they are always
+// safe to combine with WithWorkspaceExecSurfaceEnabled. Typical
+// configurations:
+//
+//   - exec on, file tools on   — full surface, recommended when the
+//     model should both run commands and manipulate files directly.
+//   - exec on, file tools off  — default; file operations must go
+//     through shell commands.
+//   - exec off, file tools on  — constrained surface that lets the
+//     model inspect and edit files without being able to run
+//     arbitrary commands.
+//
+// Default: false.
+func WithWorkspaceFileToolsEnabled(enable bool) Option {
+	return func(opts *Options) {
+		value := enable
+		opts.workspaceFileToolsEnabled = &value
 	}
 }
 

--- a/agent/llmagent/option_test.go
+++ b/agent/llmagent/option_test.go
@@ -293,6 +293,25 @@ func TestWithWorkspaceExecSurfaceEnabled(t *testing.T) {
 	require.False(t, *b.option.workspaceExecSurfaceEnabled)
 }
 
+func TestWithWorkspaceFileToolsEnabled(t *testing.T) {
+	// Default is opt-out: no file tools unless the caller asks.
+	a := New("test-agent")
+	require.Nil(t, a.option.workspaceFileToolsEnabled)
+	require.False(t, workspaceFileToolsEnabled(&a.option))
+
+	// Explicit true stores *bool(true).
+	b := New("test-agent", WithWorkspaceFileToolsEnabled(true))
+	require.NotNil(t, b.option.workspaceFileToolsEnabled)
+	require.True(t, *b.option.workspaceFileToolsEnabled)
+	require.True(t, workspaceFileToolsEnabled(&b.option))
+
+	// Explicit false stores *bool(false); the helper must respect it.
+	c := New("test-agent", WithWorkspaceFileToolsEnabled(false))
+	require.NotNil(t, c.option.workspaceFileToolsEnabled)
+	require.False(t, *c.option.workspaceFileToolsEnabled)
+	require.False(t, workspaceFileToolsEnabled(&c.option))
+}
+
 func TestWithSkillsCapabilityGuidance(t *testing.T) {
 	a := New("test-agent")
 	require.Nil(t, a.option.skillsCapabilityGuidance)

--- a/agent/llmagent/surface_runtime.go
+++ b/agent/llmagent/surface_runtime.go
@@ -126,6 +126,30 @@ func (a *LLMAgent) supportsWorkspaceExecSessionsForInvocation(
 	)
 }
 
+// supportsWorkspaceFileToolsForInvocation mirrors the toolset wiring
+// logic in InvocationToolSurface/appendWorkspaceExecToolWithExecutor
+// so the request processor can emit workspace file-tool guidance
+// exactly when the matching tools will be registered for this
+// invocation. It returns true only when the caller opted into
+// WithWorkspaceFileToolsEnabled and the active executor can host the
+// shared workspace the tools rely on.
+func (a *LLMAgent) supportsWorkspaceFileToolsForInvocation(
+	inv *agent.Invocation,
+) bool {
+	if a == nil {
+		return false
+	}
+	a.mu.RLock()
+	options := a.option
+	a.mu.RUnlock()
+	if !workspaceFileToolsEnabled(&options) {
+		return false
+	}
+	return codeExecutorSupportsWorkspaceExec(
+		a.codeExecutorForInvocation(inv),
+	)
+}
+
 func (a *LLMAgent) skillToolFlagsForInvocation(
 	inv *agent.Invocation,
 ) skillprofile.Flags {
@@ -199,10 +223,12 @@ func (a *LLMAgent) InvocationToolSurface(
 		codeExecutorSupportsWorkspaceExec(effectiveExec)
 	workspaceExecSessions := workspaceExecEnabled &&
 		codeExecutorSupportsWorkspaceExecSessions(effectiveExec)
+	workspaceFileToolsActive := workspaceFileToolsEnabled(&options) &&
+		codeExecutorSupportsWorkspaceExec(effectiveExec)
 	var workspaceRegistry *codeexecutor.WorkspaceRegistry
 	if effectiveSkills != nil && effectiveExec != nil {
 		workspaceRegistry = buildWorkspaceRegistry()
-	} else if workspaceExecEnabled {
+	} else if workspaceExecEnabled || workspaceFileToolsActive {
 		workspaceRegistry = buildWorkspaceRegistry()
 	}
 	// Pass effectiveSkills so workspace_exec's loaded-skills
@@ -217,6 +243,7 @@ func (a *LLMAgent) InvocationToolSurface(
 		effectiveExec,
 		workspaceExecEnabled,
 		workspaceExecSessions,
+		workspaceFileToolsActive,
 		workspaceRegistry,
 		inv,
 		&options,

--- a/agent/llmagent/surface_runtime_test.go
+++ b/agent/llmagent/surface_runtime_test.go
@@ -538,6 +538,104 @@ func TestLLMAgent_InvocationToolSurface_HidesWorkspaceExecWhenDisabled(
 	require.Nil(t, findTool(tools, "workspace_kill_session"))
 }
 
+// The workspace file tools are opt-in: asserting the *absence* of
+// the surface when the caller leaves the option at its default
+// protects against accidentally expanding the default surface in
+// future refactors.
+func TestLLMAgent_InvocationToolSurface_FileToolsDisabledByDefault(
+	t *testing.T,
+) {
+	agt := New(
+		"test-agent",
+		WithModel(newDummyModel()),
+		WithCodeExecutor(&interactiveStubExec{}),
+	)
+	tools, _ := agt.InvocationToolSurface(
+		context.Background(),
+		agent.NewInvocation(
+			agent.WithInvocationMessage(model.NewUserMessage("hi")),
+			agent.WithInvocationSession(&session.Session{}),
+		),
+	)
+	// workspace_exec is still on (its own default is true) but the
+	// file tools must stay off until the caller asks for them.
+	require.NotNil(t, findTool(tools, "workspace_exec"))
+	for _, name := range []string{
+		"workspace_read_file",
+		"workspace_list_dir",
+		"workspace_search_file",
+		"workspace_search_content",
+		"workspace_write_file",
+		"workspace_replace_content",
+	} {
+		require.Nil(
+			t, findTool(tools, name),
+			"file tool %q should be hidden by default", name,
+		)
+	}
+}
+
+// When WithWorkspaceFileToolsEnabled(true) is combined with the
+// default exec surface, every file tool must be registered alongside
+// workspace_exec so the model can pick the best tool for each job.
+func TestLLMAgent_InvocationToolSurface_FileToolsEnabledRegistersAll(
+	t *testing.T,
+) {
+	agt := New(
+		"test-agent",
+		WithModel(newDummyModel()),
+		WithCodeExecutor(&interactiveStubExec{}),
+		WithWorkspaceFileToolsEnabled(true),
+	)
+	tools, _ := agt.InvocationToolSurface(
+		context.Background(),
+		agent.NewInvocation(
+			agent.WithInvocationMessage(model.NewUserMessage("hi")),
+			agent.WithInvocationSession(&session.Session{}),
+		),
+	)
+	require.NotNil(t, findTool(tools, "workspace_exec"))
+	for _, name := range []string{
+		"workspace_read_file",
+		"workspace_list_dir",
+		"workspace_search_file",
+		"workspace_search_content",
+		"workspace_write_file",
+		"workspace_replace_content",
+	} {
+		require.NotNil(
+			t, findTool(tools, name),
+			"file tool %q should be registered", name,
+		)
+	}
+}
+
+// File-tools-only mode exercises the path where exec is disabled but
+// file tools are still opted in. This is the third supported
+// configuration called out in WithWorkspaceFileToolsEnabled's godoc.
+func TestLLMAgent_InvocationToolSurface_FileToolsOnlyWhenExecDisabled(
+	t *testing.T,
+) {
+	agt := New(
+		"test-agent",
+		WithModel(newDummyModel()),
+		WithCodeExecutor(&interactiveStubExec{}),
+		WithWorkspaceExecSurfaceEnabled(false),
+		WithWorkspaceFileToolsEnabled(true),
+	)
+	tools, _ := agt.InvocationToolSurface(
+		context.Background(),
+		agent.NewInvocation(
+			agent.WithInvocationMessage(model.NewUserMessage("hi")),
+			agent.WithInvocationSession(&session.Session{}),
+		),
+	)
+	require.Nil(t, findTool(tools, "workspace_exec"))
+	require.Nil(t, findTool(tools, "workspace_write_stdin"))
+	require.NotNil(t, findTool(tools, "workspace_read_file"))
+	require.NotNil(t, findTool(tools, "workspace_write_file"))
+}
+
 func TestLLMAgent_SurfaceRuntimeHelpers_NilAgentBranches(t *testing.T) {
 	var agt *LLMAgent
 	require.Nil(t, agt.codeExecutorForInvocation(nil))
@@ -552,6 +650,41 @@ func TestLLMAgent_SurfaceRuntimeHelpers_NilAgentBranches(t *testing.T) {
 	require.False(t, flags.WriteStdin)
 	require.False(t, flags.PollSession)
 	require.False(t, flags.KillSession)
+}
+
+// supportsWorkspaceFileToolsForInvocation is the resolver the
+// workspace request processor reads to decide whether to emit
+// file-tools guidance. Guarantee it tracks both the opt-in and the
+// executor's ability to host a shared workspace so the guidance
+// cannot drift from the actual tool surface.
+func TestLLMAgent_SurfaceRuntimeHelpers_FileToolsResolverRespectsOptionAndExecutor(
+	t *testing.T,
+) {
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(&session.Session{}),
+	)
+
+	disabled := New(
+		"test-agent",
+		WithModel(newDummyModel()),
+		WithCodeExecutor(&interactiveStubExec{}),
+	)
+	require.False(t, disabled.supportsWorkspaceFileToolsForInvocation(inv))
+
+	enabled := New(
+		"test-agent",
+		WithModel(newDummyModel()),
+		WithCodeExecutor(&interactiveStubExec{}),
+		WithWorkspaceFileToolsEnabled(true),
+	)
+	require.True(t, enabled.supportsWorkspaceFileToolsForInvocation(inv))
+
+	noExec := New(
+		"test-agent",
+		WithModel(newDummyModel()),
+		WithWorkspaceFileToolsEnabled(true),
+	)
+	require.False(t, noExec.supportsWorkspaceFileToolsForInvocation(inv))
 }
 
 func TestLLMAgent_SurfaceRuntimeHelpers_WorkspaceExecOptionRespected(

--- a/internal/flow/processor/workspaceexec.go
+++ b/internal/flow/processor/workspaceexec.go
@@ -25,11 +25,12 @@ const (
 )
 
 type workspaceExecRequestProcessorOptions struct {
-	sessionTools     bool
-	hasSkillsRepo    bool
-	repoResolver     func(*agent.Invocation) skill.Repository
-	enabledResolver  func(*agent.Invocation) bool
-	sessionsResolver func(*agent.Invocation) bool
+	sessionTools      bool
+	hasSkillsRepo     bool
+	repoResolver      func(*agent.Invocation) skill.Repository
+	enabledResolver   func(*agent.Invocation) bool
+	sessionsResolver  func(*agent.Invocation) bool
+	fileToolsResolver func(*agent.Invocation) bool
 }
 
 // WorkspaceExecRequestProcessorOption configures
@@ -64,6 +65,25 @@ func WithWorkspaceExecSessionsResolver(
 	}
 }
 
+// WithWorkspaceFileToolsEnabledResolver sets an invocation-aware
+// resolver that reports whether the workspace file tools
+// (workspace_read_file, workspace_list_dir, workspace_search_file,
+// workspace_search_content, workspace_write_file,
+// workspace_replace_content) are exposed for this invocation. When
+// it returns true the processor appends a file-tool guidance block
+// to the workspace system prompt so the model prefers the dedicated
+// tools over running raw shell commands via workspace_exec. The
+// resolver is independent of WithWorkspaceExecEnabledResolver so it
+// works in the "file-tools-only" configuration described by
+// llmagent.WithWorkspaceFileToolsEnabled.
+func WithWorkspaceFileToolsEnabledResolver(
+	resolver func(*agent.Invocation) bool,
+) WorkspaceExecRequestProcessorOption {
+	return func(o *workspaceExecRequestProcessorOptions) {
+		o.fileToolsResolver = resolver
+	}
+}
+
 // WithWorkspaceExecSkillsRepo indicates that skills are configured, so the
 // workspace guidance can mention existing paths under skills/.
 func WithWorkspaceExecSkillsRepo() WorkspaceExecRequestProcessorOption {
@@ -82,13 +102,17 @@ func WithWorkspaceExecSkillsRepositoryResolver(
 }
 
 // WorkspaceExecRequestProcessor injects system guidance for executor-side
-// workspace_exec tools independently of skills repo wiring.
+// workspace_exec and workspace file tools independently of skills
+// repo wiring. The processor emits guidance when either surface is
+// active for the invocation; the shared preamble steers the model
+// toward workspace-aware tools regardless of which half is on.
 type WorkspaceExecRequestProcessor struct {
-	sessionTools     bool
-	staticSkillsRepo bool
-	repoResolver     func(*agent.Invocation) skill.Repository
-	enabledResolver  func(*agent.Invocation) bool
-	sessionsResolver func(*agent.Invocation) bool
+	sessionTools      bool
+	staticSkillsRepo  bool
+	repoResolver      func(*agent.Invocation) skill.Repository
+	enabledResolver   func(*agent.Invocation) bool
+	sessionsResolver  func(*agent.Invocation) bool
+	fileToolsResolver func(*agent.Invocation) bool
 }
 
 // NewWorkspaceExecRequestProcessor creates a new
@@ -104,11 +128,12 @@ func NewWorkspaceExecRequestProcessor(
 		opt(&options)
 	}
 	return &WorkspaceExecRequestProcessor{
-		sessionTools:     options.sessionTools,
-		staticSkillsRepo: options.hasSkillsRepo,
-		repoResolver:     options.repoResolver,
-		enabledResolver:  options.enabledResolver,
-		sessionsResolver: options.sessionsResolver,
+		sessionTools:      options.sessionTools,
+		staticSkillsRepo:  options.hasSkillsRepo,
+		repoResolver:      options.repoResolver,
+		enabledResolver:   options.enabledResolver,
+		sessionsResolver:  options.sessionsResolver,
+		fileToolsResolver: options.fileToolsResolver,
 	}
 }
 
@@ -157,36 +182,75 @@ func (p *WorkspaceExecRequestProcessor) ProcessRequest(
 func (p *WorkspaceExecRequestProcessor) guidanceText(
 	inv *agent.Invocation,
 ) string {
-	if !p.enabledForInvocation(inv) {
+	execOn := p.execEnabledForInvocation(inv)
+	fileToolsOn := p.fileToolsEnabledForInvocation(inv)
+	if !execOn && !fileToolsOn {
 		return ""
 	}
 	var b strings.Builder
 	b.WriteString(workspaceExecGuidanceHeader)
 	b.WriteString("\n")
-	b.WriteString("- Treat workspace_exec as the default general shell ")
-	b.WriteString("runner for shared executor-side work. It runs inside ")
-	b.WriteString("the current executor workspace, not on the agent ")
-	b.WriteString("host; workspace is its scope, not its capability ")
-	b.WriteString("limit.\n")
-	b.WriteString("- workspace_exec starts at the workspace root by ")
-	b.WriteString("default. Prefer work/, out/, and runs/ for shared ")
-	b.WriteString("executor-side work, and treat cwd as a ")
-	b.WriteString("workspace-relative path.\n")
+	b.WriteString("- The executor workspace is the shared working ")
+	b.WriteString("directory for this invocation. Every workspace_* ")
+	b.WriteString("tool operates inside that workspace, not on the ")
+	b.WriteString("agent host; workspace is their scope, not their ")
+	b.WriteString("capability limit.\n")
+	b.WriteString("- Prefer work/, out/, and runs/ for shared ")
+	b.WriteString("executor-side work, and treat any workspace-tool ")
+	b.WriteString("path or cwd as a workspace-relative path rooted at ")
+	b.WriteString("the workspace root.\n")
 	b.WriteString("- Conversation file inputs that are attached to the ")
 	b.WriteString("current request or visible session are staged ")
-	b.WriteString("automatically under work/inputs before ")
-	b.WriteString("workspace_exec runs.\n")
-	b.WriteString("- Network access depends on the current executor ")
-	b.WriteString("environment. If you need a network command such as ")
-	b.WriteString("curl, use a small bounded command to verify whether ")
-	b.WriteString("that environment allows it.\n")
-	b.WriteString("- When a limitation depends on the executor ")
-	b.WriteString("environment and a small bounded command can verify ")
-	b.WriteString("it, verify first before claiming the limitation. ")
-	b.WriteString("This applies to checks such as command ")
-	b.WriteString("availability, file presence, or access to a known ")
-	b.WriteString("URL.\n")
-	if toolworkspaceexec.SupportsArtifactSave(inv) {
+	b.WriteString("automatically under work/inputs before any ")
+	b.WriteString("workspace tool runs; do not recreate them.\n")
+	if execOn {
+		b.WriteString("- Treat workspace_exec as the default general ")
+		b.WriteString("shell runner for shared executor-side work. It ")
+		b.WriteString("starts at the workspace root by default.\n")
+		b.WriteString("- Network access depends on the current executor ")
+		b.WriteString("environment. If you need a network command such ")
+		b.WriteString("as curl, use a small bounded command to verify ")
+		b.WriteString("whether that environment allows it.\n")
+		b.WriteString("- When a limitation depends on the executor ")
+		b.WriteString("environment and a small bounded command can ")
+		b.WriteString("verify it, verify first before claiming the ")
+		b.WriteString("limitation. This applies to checks such as ")
+		b.WriteString("command availability, file presence, or access ")
+		b.WriteString("to a known URL.\n")
+	}
+	if fileToolsOn {
+		if execOn {
+			b.WriteString("- Prefer the dedicated workspace file tools ")
+			b.WriteString("over ad-hoc shell commands when the task is ")
+			b.WriteString("a plain file operation: workspace_read_file ")
+			b.WriteString("to read text, workspace_list_dir to list a ")
+			b.WriteString("directory, workspace_search_file to find ")
+			b.WriteString("files by glob, and workspace_search_content ")
+			b.WriteString("to grep file contents. Reserve workspace_exec ")
+			b.WriteString("for commands that need a real shell.\n")
+		} else {
+			b.WriteString("- Use workspace_read_file, ")
+			b.WriteString("workspace_list_dir, workspace_search_file, ")
+			b.WriteString("and workspace_search_content to explore ")
+			b.WriteString("and read files inside the workspace.\n")
+		}
+		b.WriteString("- Use workspace_write_file to create or ")
+		b.WriteString("overwrite files, and workspace_replace_content ")
+		b.WriteString("to edit existing files in place. Both refuse ")
+		b.WriteString("to modify framework-managed paths: ")
+		b.WriteString("work/inputs/** (staged conversation inputs), ")
+		b.WriteString("skills/** (skill working copies), and any ")
+		b.WriteString("paths declared as bootstrap file targets. ")
+		b.WriteString("Reach those indirectly (for example copy to ")
+		b.WriteString("work/ first) instead of writing them.\n")
+		b.WriteString("- Respect the truncated / files_partial flags ")
+		b.WriteString("on workspace_search_* and workspace_read_file ")
+		b.WriteString("results: when they are set the result is ")
+		b.WriteString("incomplete, so narrow the scope or raise the ")
+		b.WriteString("limits (max_bytes, max_results, max_matches) ")
+		b.WriteString("before concluding.\n")
+	}
+	if execOn && toolworkspaceexec.SupportsArtifactSave(inv) {
 		b.WriteString("- Use workspace_save_artifact only when you ")
 		b.WriteString("need a stable artifact reference for an already ")
 		b.WriteString("existing file in work/, out/, or runs/. ")
@@ -197,15 +261,18 @@ func (p *WorkspaceExecRequestProcessor) guidanceText(
 		b.WriteString("only after skill_load <name>: that call ")
 		b.WriteString("materializes the writable skill working copy ")
 		b.WriteString("and turns skills/<name>/ into a real directory ")
-		b.WriteString("you can run commands from. After loading, set ")
-		b.WriteString("cwd to skills/<name> for workspace_exec and ")
-		b.WriteString("run the scripts referenced in that SKILL.md ")
-		b.WriteString("(for example, the Examples section). Without ")
-		b.WriteString("a prior skill_load, paths under skills/ are ")
-		b.WriteString("not staged and workspace_exec will not see ")
-		b.WriteString("them.\n")
+		b.WriteString("you can run commands from.")
+		if execOn {
+			b.WriteString(" After loading, set cwd to skills/<name> ")
+			b.WriteString("for workspace_exec and run the scripts ")
+			b.WriteString("referenced in that SKILL.md (for example, ")
+			b.WriteString("the Examples section).")
+		}
+		b.WriteString(" Without a prior skill_load, paths under ")
+		b.WriteString("skills/ are not staged and workspace tools will ")
+		b.WriteString("not see them.\n")
 	}
-	if p.sessionToolsForInvocation(inv) {
+	if execOn && p.sessionToolsForInvocation(inv) {
 		b.WriteString("- When workspace_exec starts a command that keeps ")
 		b.WriteString("running or waits for stdin, continue with ")
 		b.WriteString("workspace_write_stdin. When chars is empty, ")
@@ -220,13 +287,22 @@ func (p *WorkspaceExecRequestProcessor) guidanceText(
 	return b.String()
 }
 
-func (p *WorkspaceExecRequestProcessor) enabledForInvocation(
+func (p *WorkspaceExecRequestProcessor) execEnabledForInvocation(
 	inv *agent.Invocation,
 ) bool {
 	if p.enabledResolver != nil {
 		return p.enabledResolver(inv)
 	}
 	return true
+}
+
+func (p *WorkspaceExecRequestProcessor) fileToolsEnabledForInvocation(
+	inv *agent.Invocation,
+) bool {
+	if p.fileToolsResolver != nil {
+		return p.fileToolsResolver(inv)
+	}
+	return false
 }
 
 func (p *WorkspaceExecRequestProcessor) sessionToolsForInvocation(

--- a/internal/flow/processor/workspaceexec_test.go
+++ b/internal/flow/processor/workspaceexec_test.go
@@ -55,7 +55,7 @@ func TestWorkspaceExecRequestProcessor_ProcessRequest_NoSkillsRepo(
 	sys := req.Messages[0].Content
 	require.Contains(t, sys, workspaceExecGuidanceHeader)
 	require.Contains(t, sys, "default general shell runner")
-	require.Contains(t, sys, "workspace is its scope, not its capability limit")
+	require.Contains(t, sys, "workspace is their scope, not their capability limit")
 	require.Contains(t, sys, "Prefer work/, out/, and runs/")
 	require.Contains(t, sys, "staged automatically under work/inputs")
 	require.Contains(t, sys, "Network access depends on the current executor environment")
@@ -97,7 +97,7 @@ func TestWorkspaceExecRequestProcessor_ProcessRequest_InteractiveWithSkillsRepo(
 	require.Contains(t, sys, "base")
 	require.Contains(t, sys, workspaceExecGuidanceHeader)
 	require.Contains(t, sys, "default general shell runner")
-	require.Contains(t, sys, "workspace is its scope, not its capability limit")
+	require.Contains(t, sys, "workspace is their scope, not their capability limit")
 	require.Contains(t, sys, "staged automatically under work/inputs")
 	require.Contains(t, sys, "Network access depends on the current executor environment")
 	require.Contains(t, sys, "verify first before claiming the limitation")
@@ -176,6 +176,99 @@ func TestWorkspaceExecRequestProcessor_ProcessRequest_DisabledByResolver(
 			func(*agent.Invocation) bool {
 				return false
 			},
+		),
+	)
+	req := &model.Request{}
+
+	p.ProcessRequest(
+		context.Background(),
+		&agent.Invocation{AgentName: "tester"},
+		req,
+		nil,
+	)
+
+	require.Empty(t, req.Messages)
+}
+
+func TestWorkspaceExecRequestProcessor_FileToolsOnly_EmitsFileToolGuidance(
+	t *testing.T,
+) {
+	// File-tools-only mode: exec disabled, filetools enabled. The
+	// processor must still emit a guidance block that names the
+	// workspace file tools so the model knows they exist. Without
+	// this, the filetools surface ships silently and the model
+	// falls back to shell-style reasoning it does not actually have.
+	p := NewWorkspaceExecRequestProcessor(
+		WithWorkspaceExecEnabledResolver(
+			func(*agent.Invocation) bool { return false },
+		),
+		WithWorkspaceFileToolsEnabledResolver(
+			func(*agent.Invocation) bool { return true },
+		),
+	)
+	req := &model.Request{}
+
+	p.ProcessRequest(
+		context.Background(),
+		&agent.Invocation{AgentName: "tester"},
+		req,
+		nil,
+	)
+
+	require.NotEmpty(t, req.Messages)
+	sys := req.Messages[0].Content
+	require.Contains(t, sys, workspaceExecGuidanceHeader)
+	require.Contains(t, sys, "workspace_read_file")
+	require.Contains(t, sys, "workspace_list_dir")
+	require.Contains(t, sys, "workspace_search_file")
+	require.Contains(t, sys, "workspace_search_content")
+	require.Contains(t, sys, "workspace_write_file")
+	require.Contains(t, sys, "workspace_replace_content")
+	require.Contains(t, sys, "work/inputs/**")
+	require.Contains(t, sys, "files_partial")
+	// No exec-only phrases should leak in.
+	require.NotContains(t, sys, "default general shell runner")
+	require.NotContains(t, sys, "Network access depends on the current executor environment")
+	require.NotContains(t, sys, "workspace_save_artifact")
+}
+
+func TestWorkspaceExecRequestProcessor_ExecAndFileToolsCombined(
+	t *testing.T,
+) {
+	p := NewWorkspaceExecRequestProcessor(
+		WithWorkspaceFileToolsEnabledResolver(
+			func(*agent.Invocation) bool { return true },
+		),
+	)
+	req := &model.Request{}
+
+	p.ProcessRequest(
+		context.Background(),
+		&agent.Invocation{AgentName: "tester"},
+		req,
+		nil,
+	)
+
+	require.NotEmpty(t, req.Messages)
+	sys := req.Messages[0].Content
+	require.Contains(t, sys, "default general shell runner")
+	require.Contains(t, sys, "Prefer the dedicated workspace file tools")
+	require.Contains(t, sys, "workspace_read_file")
+	require.Contains(t, sys, "workspace_replace_content")
+}
+
+func TestWorkspaceExecRequestProcessor_ProcessRequest_DisabledWhenAllOff(
+	t *testing.T,
+) {
+	// Both resolvers report false: the processor should stay silent
+	// instead of emitting workspace guidance for a surface the model
+	// cannot actually use.
+	p := NewWorkspaceExecRequestProcessor(
+		WithWorkspaceExecEnabledResolver(
+			func(*agent.Invocation) bool { return false },
+		),
+		WithWorkspaceFileToolsEnabledResolver(
+			func(*agent.Invocation) bool { return false },
 		),
 	)
 	req := &model.Request{}

--- a/tool/workspaceexec/file_backend.go
+++ b/tool/workspaceexec/file_backend.go
@@ -1,0 +1,780 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package workspaceexec
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"path"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	ds "github.com/bmatcuk/doublestar/v4"
+
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
+)
+
+// File-tool constants.
+const (
+	// defaultFileToolMaxBytes caps the number of bytes any single
+	// read/replace operation may pull back from the workspace. The
+	// local backend's Collect imposes its own 4 MiB ceiling; this
+	// further trims the model-visible payload to something that fits
+	// comfortably in a single tool response.
+	defaultFileToolMaxBytes int64 = 1 << 20 // 1 MiB
+
+	// defaultFileToolMode is the POSIX mode applied when writing text
+	// files. Matches codeexecutor.DefaultScriptFileMode so that
+	// bootstrap-written and tool-written files are indistinguishable.
+	defaultFileToolMode uint32 = codeexecutor.DefaultScriptFileMode
+
+	// fileBackendShellTimeout bounds shell-driven metadata operations
+	// (list / search / exists). Metadata shells must always finish
+	// quickly; a timeout prevents a broken executor from stalling the
+	// tool call indefinitely.
+	fileBackendShellTimeout = 20 * time.Second
+
+	// maxListingEntriesDefault caps the number of entries returned
+	// by a recursive listing. Trees larger than this are truncated;
+	// the caller surfaces the truncation through the tool output.
+	maxListingEntriesDefault = 5000
+)
+
+// maxListingEntriesOverride is a test-only hook. When non-zero it
+// replaces maxListingEntriesDefault so tests can exercise the
+// truncation path without seeding 5000+ entries. Production code
+// leaves this at zero.
+var maxListingEntriesOverride = 0
+
+// Shell output markers. Using four-letter all-caps sentinels keeps
+// them distinguishable from ordinary file names while being short
+// enough to emit comfortably from portable sh.
+const (
+	wsOutEntryPrefix = "ENTRY\t"
+	wsOutNotFound    = "__NOT_FOUND__"
+	wsOutNotDir      = "__NOT_DIR__"
+	wsOutExistsYes   = "YES"
+	wsOutExistsNo    = "NO"
+)
+
+// Shell exit codes used by metadata scripts to signal structured
+// errors. Any exit code from Runner().RunProgram that is not 0 and
+// not listed here is treated as an opaque backend error.
+const (
+	exitNotFound = 10
+	exitNotDir   = 11
+)
+
+// dirEntry describes a single listing entry produced by the
+// workspace-side shell script.
+type dirEntry struct {
+	Name string
+	Type string // "file" | "dir" | "symlink" | "other"
+	Size int64
+}
+
+// notFoundError signals that a workspace path does not exist.
+type notFoundError struct{ Path string }
+
+func (e notFoundError) Error() string {
+	return fmt.Sprintf("workspace path not found: %s", e.Path)
+}
+
+func isNotFound(err error) bool {
+	var n notFoundError
+	return errors.As(err, &n)
+}
+
+// notDirError signals that a workspace path exists but is not a
+// directory (relevant only to list operations).
+type notDirError struct{ Path string }
+
+func (e notDirError) Error() string {
+	return fmt.Sprintf("workspace path is not a directory: %s", e.Path)
+}
+
+func isNotDir(err error) bool {
+	var n notDirError
+	return errors.As(err, &n)
+}
+
+// notTextError signals that a file's bytes are not safe to surface
+// as UTF-8 text (e.g. binary content or invalid encoding).
+type notTextError struct{ Path string }
+
+func (e notTextError) Error() string {
+	return fmt.Sprintf("file is not valid UTF-8 text: %s", e.Path)
+}
+
+func isNotText(err error) bool {
+	var n notTextError
+	return errors.As(err, &n)
+}
+
+// readFileLimited reads a workspace-relative file using
+// Engine.FS().Collect and caps the result at maxBytes. The returned
+// truncated flag is true when either the backend or this helper
+// truncated the file.
+func readFileLimited(
+	ctx context.Context,
+	eng codeexecutor.Engine,
+	ws codeexecutor.Workspace,
+	rel string,
+	maxBytes int64,
+) (data []byte, sizeBytes int64, truncated bool, err error) {
+	if eng == nil || eng.FS() == nil {
+		return nil, 0, false, errors.New(
+			"executor does not provide a live filesystem",
+		)
+	}
+	if maxBytes <= 0 {
+		maxBytes = defaultFileToolMaxBytes
+	}
+	files, err := eng.FS().Collect(ctx, ws, []string{rel})
+	if err != nil {
+		return nil, 0, false, err
+	}
+	if len(files) == 0 {
+		return nil, 0, false, notFoundError{Path: rel}
+	}
+	f := files[0]
+	content := []byte(f.Content)
+	if int64(len(content)) > maxBytes {
+		content = content[:maxBytes]
+		return content, f.SizeBytes, true, nil
+	}
+	return content, f.SizeBytes, f.Truncated, nil
+}
+
+// writeFileBytes writes data into the workspace at rel using
+// Engine.FS().PutFiles. When mode is zero the default script file
+// mode is used.
+func writeFileBytes(
+	ctx context.Context,
+	eng codeexecutor.Engine,
+	ws codeexecutor.Workspace,
+	rel string,
+	data []byte,
+	mode uint32,
+) error {
+	if eng == nil || eng.FS() == nil {
+		return errors.New("executor does not provide a live filesystem")
+	}
+	if mode == 0 {
+		mode = defaultFileToolMode
+	}
+	return eng.FS().PutFiles(ctx, ws, []codeexecutor.PutFile{{
+		Path:    rel,
+		Content: data,
+		Mode:    mode,
+	}})
+}
+
+// workspacePathExists reports whether rel exists inside the live
+// workspace. It drives a minimal shell test so that both local and
+// container backends answer consistently, regardless of which
+// filesystem view the model has.
+func workspacePathExists(
+	ctx context.Context,
+	eng codeexecutor.Engine,
+	ws codeexecutor.Workspace,
+	rel string,
+) (bool, error) {
+	if eng == nil || eng.Runner() == nil {
+		return false, errors.New(
+			"executor does not provide a live runner",
+		)
+	}
+	script := `if [ -e "$1" ]; then echo ` + wsOutExistsYes +
+		`; else echo ` + wsOutExistsNo + `; fi`
+	rr, err := eng.Runner().RunProgram(ctx, ws, codeexecutor.RunProgramSpec{
+		Cmd:     "sh",
+		Args:    []string{"-c", script, "sh", rel},
+		Timeout: fileBackendShellTimeout,
+	})
+	if err != nil {
+		return false, err
+	}
+	if rr.ExitCode != 0 {
+		return false, fmt.Errorf(
+			"workspace exists check failed (exit %d): %s",
+			rr.ExitCode, strings.TrimSpace(rr.Stderr),
+		)
+	}
+	out := strings.TrimSpace(rr.Stdout)
+	switch out {
+	case wsOutExistsYes:
+		return true, nil
+	case wsOutExistsNo:
+		return false, nil
+	default:
+		return false, fmt.Errorf(
+			"unexpected workspace exists output: %q", out,
+		)
+	}
+}
+
+// listDirEntries returns the immediate children of the workspace
+// directory at rel. The rel="." form lists the workspace root. The
+// returned truncated flag is true when the underlying shell
+// produced more than maxListingEntries rows and the slice had to be
+// clipped; callers should plumb this flag into their tool output so
+// the model knows the listing is partial.
+func listDirEntries(
+	ctx context.Context,
+	eng codeexecutor.Engine,
+	ws codeexecutor.Workspace,
+	rel string,
+) ([]dirEntry, bool, error) {
+	return runListingScript(ctx, eng, ws, rel, buildListScript(false))
+}
+
+// listTreeAll returns a depth-first listing of every file and
+// directory under rel. It returns (entries, truncated, error) where
+// truncated is true when the walk had to be clipped at
+// maxListingEntries.
+func listTreeAll(
+	ctx context.Context,
+	eng codeexecutor.Engine,
+	ws codeexecutor.Workspace,
+	rel string,
+) ([]dirEntry, bool, error) {
+	return runListingScript(ctx, eng, ws, rel, buildListScript(true))
+}
+
+// buildListScript constructs the portable /bin/sh listing helper.
+// The script accepts the workspace-relative target as $1 and emits
+//
+//	ENTRY\t<type>\t<size>\t<path>\n
+//
+// lines on stdout, or one of the __NOT_FOUND__/__NOT_DIR__ markers
+// on stderr. Separate markers let the Go side translate backend
+// errors into typed Go errors without parsing localized OS text.
+func buildListScript(recursive bool) string {
+	depth := "-maxdepth 1"
+	if recursive {
+		depth = ""
+	}
+	return fmt.Sprintf(`
+set -u
+TARGET="$1"
+if [ ! -e "$TARGET" ]; then
+    printf '%%s\n' "%s" 1>&2
+    exit %d
+fi
+if [ ! -d "$TARGET" ]; then
+    printf '%%s\n' "%s" 1>&2
+    exit %d
+fi
+cd "$TARGET" || exit 1
+find . -mindepth 1 %s -print 2>/dev/null | LC_ALL=C sort | while IFS= read -r p; do
+    p="${p#./}"
+    if [ -L "$p" ]; then
+        t=symlink; s=0
+    elif [ -d "$p" ]; then
+        t=dir; s=0
+    elif [ -f "$p" ]; then
+        t=file
+        s=$(wc -c < "$p" 2>/dev/null | tr -d ' \t\n')
+        [ -z "$s" ] && s=0
+    else
+        t=other; s=0
+    fi
+    printf 'ENTRY\t%%s\t%%s\t%%s\n' "$t" "$s" "$p"
+done
+`, wsOutNotFound, exitNotFound, wsOutNotDir, exitNotDir, depth)
+}
+
+func runListingScript(
+	ctx context.Context,
+	eng codeexecutor.Engine,
+	ws codeexecutor.Workspace,
+	rel string,
+	script string,
+) ([]dirEntry, bool, error) {
+	if eng == nil || eng.Runner() == nil {
+		return nil, false, errors.New(
+			"executor does not provide a live runner",
+		)
+	}
+	rr, err := eng.Runner().RunProgram(ctx, ws, codeexecutor.RunProgramSpec{
+		Cmd:     "sh",
+		Args:    []string{"-c", script, "sh", rel},
+		Timeout: fileBackendShellTimeout,
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	if rr.ExitCode != 0 {
+		return nil, false, translateListingError(rel, rr)
+	}
+	entries, err := parseListingStdout(rr.Stdout)
+	if err != nil {
+		return nil, false, err
+	}
+	truncated := false
+	limit := maxListingEntriesDefault
+	if maxListingEntriesOverride > 0 {
+		limit = maxListingEntriesOverride
+	}
+	if len(entries) > limit {
+		entries = entries[:limit]
+		truncated = true
+	}
+	return entries, truncated, nil
+}
+
+func translateListingError(rel string, rr codeexecutor.RunResult) error {
+	stderr := rr.Stderr
+	switch rr.ExitCode {
+	case exitNotFound:
+		return notFoundError{Path: rel}
+	case exitNotDir:
+		return notDirError{Path: rel}
+	}
+	if strings.Contains(stderr, wsOutNotFound) {
+		return notFoundError{Path: rel}
+	}
+	if strings.Contains(stderr, wsOutNotDir) {
+		return notDirError{Path: rel}
+	}
+	trimmed := strings.TrimSpace(stderr)
+	if trimmed == "" {
+		trimmed = strings.TrimSpace(rr.Stdout)
+	}
+	return fmt.Errorf(
+		"workspace listing failed (exit %d): %s", rr.ExitCode, trimmed,
+	)
+}
+
+// parseListingStdout converts the ENTRY\t<type>\t<size>\t<path>
+// lines emitted by buildListScript into dirEntry values. Malformed
+// lines are skipped rather than aborting the whole call; the shell
+// script only emits well-formed lines, so malformed lines indicate a
+// genuinely hostile environment that we would rather tolerate than
+// amplify.
+func parseListingStdout(stdout string) ([]dirEntry, error) {
+	scanner := bufio.NewScanner(strings.NewReader(stdout))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	var entries []dirEntry
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, wsOutEntryPrefix) {
+			continue
+		}
+		body := strings.TrimPrefix(line, wsOutEntryPrefix)
+		parts := strings.SplitN(body, "\t", 3)
+		if len(parts) != 3 {
+			continue
+		}
+		size, err := strconv.ParseInt(parts[1], 10, 64)
+		if err != nil {
+			size = 0
+		}
+		name := parts[2]
+		if name == "" {
+			continue
+		}
+		entries = append(entries, dirEntry{
+			Name: name,
+			Type: parts[0],
+			Size: size,
+		})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("parse workspace listing: %w", err)
+	}
+	return entries, nil
+}
+
+// validateTextBytes checks that data is plausibly human-readable
+// UTF-8 text. It rejects invalid UTF-8 and any occurrence of a NUL
+// byte, which is the cheapest reliable signal that a file is
+// binary.
+func validateTextBytes(data []byte, rel string) error {
+	if bytes.IndexByte(data, 0) >= 0 {
+		return notTextError{Path: rel}
+	}
+	if !utf8.Valid(data) {
+		return notTextError{Path: rel}
+	}
+	return nil
+}
+
+// validateTextString is a convenience wrapper for callers that
+// already hold the content as a string.
+func validateTextString(s, rel string) error {
+	return validateTextBytes([]byte(s), rel)
+}
+
+// detectTextMIME returns a best-effort MIME type for textual data
+// that has already passed validateTextBytes. The caller owns the
+// filename because that is the strongest hint for hand-rolled
+// extensions such as .md / .go.
+func detectTextMIME(data []byte, rel string) string {
+	if mime := mimeFromExt(rel); mime != "" {
+		return mime
+	}
+	if mime := http.DetectContentType(data); mime != "" {
+		return mime
+	}
+	return "text/plain; charset=utf-8"
+}
+
+func mimeFromExt(rel string) string {
+	lower := strings.ToLower(rel)
+	switch {
+	case strings.HasSuffix(lower, ".md"):
+		return "text/markdown; charset=utf-8"
+	case strings.HasSuffix(lower, ".json"):
+		return "application/json"
+	case strings.HasSuffix(lower, ".yaml"), strings.HasSuffix(lower, ".yml"):
+		return "application/yaml"
+	case strings.HasSuffix(lower, ".go"):
+		return "text/x-go; charset=utf-8"
+	case strings.HasSuffix(lower, ".py"):
+		return "text/x-python; charset=utf-8"
+	case strings.HasSuffix(lower, ".sh"):
+		return "application/x-sh"
+	case strings.HasSuffix(lower, ".txt"), strings.HasSuffix(lower, ".log"):
+		return "text/plain; charset=utf-8"
+	}
+	return ""
+}
+
+// sliceTextByLines extracts a 1-indexed, inclusive [startLine,
+// endLine] window from s. When startLine is zero or negative the
+// window starts at line 1; when endLine is zero or exceeds the line
+// count it runs to the end of the file. The returned window is
+// normalized so that startLine/endLine reflect the true slice
+// boundaries.
+func sliceTextByLines(
+	s string, startLine, endLine int,
+) (body string, start, end, total int) {
+	total = countLines(s)
+	if total == 0 {
+		return "", 1, 0, 0
+	}
+	start = startLine
+	if start <= 0 {
+		start = 1
+	}
+	if start > total {
+		return "", total + 1, total, total
+	}
+	end = endLine
+	if end <= 0 || end > total {
+		end = total
+	}
+	if end < start {
+		end = start
+	}
+	lines := splitLinesPreserving(s)
+	body = strings.Join(lines[start-1:end], "\n")
+	return body, start, end, total
+}
+
+func countLines(s string) int {
+	if s == "" {
+		return 0
+	}
+	n := strings.Count(s, "\n")
+	if !strings.HasSuffix(s, "\n") {
+		n++
+	}
+	return n
+}
+
+func splitLinesPreserving(s string) []string {
+	if s == "" {
+		return nil
+	}
+	trimmed := strings.TrimSuffix(s, "\n")
+	return strings.Split(trimmed, "\n")
+}
+
+// compileContentRegex compiles the regex supplied by the model. The
+// caller toggles case insensitivity explicitly (workspace_search_
+// content exposes it as a separate boolean) so compileContentRegex
+// handles it via the (?i) inline flag to keep the API simple.
+func compileContentRegex(pattern string, caseInsensitive bool) (*regexp.Regexp, error) {
+	if strings.TrimSpace(pattern) == "" {
+		return nil, errors.New("pattern must not be empty")
+	}
+	src := pattern
+	if caseInsensitive && !strings.HasPrefix(pattern, "(?i)") {
+		src = "(?i)" + pattern
+	}
+	rx, err := regexp.Compile(src)
+	if err != nil {
+		return nil, fmt.Errorf("invalid regex: %w", err)
+	}
+	return rx, nil
+}
+
+// contentHit captures a single matching line inside a file.
+type contentHit struct {
+	Line    int    `json:"line"`
+	Preview string `json:"preview"`
+}
+
+// scanContentLines walks s line-by-line and returns at most
+// maxMatches hits. previewMax trims long lines so that the tool
+// response remains bounded even on pathological inputs.
+func scanContentLines(
+	rx *regexp.Regexp, s string, maxMatches, previewMax int,
+) []contentHit {
+	if maxMatches <= 0 {
+		maxMatches = 50
+	}
+	if previewMax <= 0 {
+		previewMax = 240
+	}
+	var hits []contentHit
+	lineNo := 0
+	for _, line := range splitLinesPreserving(s) {
+		lineNo++
+		if !rx.MatchString(line) {
+			continue
+		}
+		preview := line
+		if len(preview) > previewMax {
+			preview = preview[:previewMax] + "..."
+		}
+		hits = append(hits, contentHit{Line: lineNo, Preview: preview})
+		if len(hits) >= maxMatches {
+			break
+		}
+	}
+	return hits
+}
+
+// matchGlob reports whether name matches pattern using doublestar
+// semantics (supports ** and ? in addition to *). A pattern of ""
+// matches any name, mirroring the convention used by tool/file.
+func matchGlob(pattern, name string) bool {
+	if strings.TrimSpace(pattern) == "" {
+		return true
+	}
+	ok, err := ds.Match(pattern, name)
+	if err != nil {
+		return false
+	}
+	return ok
+}
+
+// -----------------------------------------------------------------------------
+// Workspace-relative path helpers.
+// -----------------------------------------------------------------------------
+
+// cleanWorkspaceRelPath normalizes a workspace-relative file path
+// supplied by the model. It enforces the same "stay inside the
+// workspace" invariants used elsewhere in this package:
+//
+//   - backslashes are converted to forward slashes;
+//   - $WORKSPACE_DIR / $WORK_DIR / $SKILLS_DIR / $OUTPUT_DIR /
+//     $RUN_DIR prefixes are rewritten via NormalizeGlobs;
+//   - absolute paths (with or without env expansion) must resolve to
+//     one of the allowed workspace roots;
+//   - the path must not contain glob metacharacters;
+//   - the path must not walk outside the workspace (..);
+//   - when allowEmpty is false, "" and "." are rejected.
+//
+// On success the returned value is either "." or a clean, forward-
+// slash, workspace-relative path without a leading ".".
+func cleanWorkspaceRelPath(raw string, allowEmpty bool) (string, error) {
+	s := strings.TrimSpace(raw)
+	s = strings.ReplaceAll(s, "\\", "/")
+	if s == "" {
+		if allowEmpty {
+			return ".", nil
+		}
+		return "", errors.New("path must not be empty")
+	}
+	if hasGlobMeta(s) {
+		return "", errors.New("path must not contain glob patterns")
+	}
+	if isWorkspaceEnvPath(s) {
+		out := codeexecutor.NormalizeGlobs([]string{s})
+		if len(out) == 0 {
+			return "", fmt.Errorf("invalid path: %q", raw)
+		}
+		s = out[0]
+	}
+	if strings.HasPrefix(s, "/") {
+		rel := strings.TrimPrefix(path.Clean(s), "/")
+		if rel == "" || rel == "." {
+			if allowEmpty {
+				return ".", nil
+			}
+			return "", errors.New("path must not resolve to workspace root")
+		}
+		if !isAllowedWorkspacePath(rel) {
+			return "", fmt.Errorf(
+				"path must stay under workspace roots such as work/, out/, runs/, or skills/: %q",
+				raw,
+			)
+		}
+		return rel, nil
+	}
+	rel := path.Clean(s)
+	if rel == "." {
+		if allowEmpty {
+			return ".", nil
+		}
+		return "", errors.New("path must not resolve to workspace root")
+	}
+	if rel == ".." || strings.HasPrefix(rel, "../") {
+		return "", errors.New("path must stay within the workspace")
+	}
+	if !isAllowedWorkspacePath(rel) {
+		return "", fmt.Errorf(
+			"path must stay under workspace roots such as work/, out/, runs/, or skills/: %q",
+			raw,
+		)
+	}
+	return rel, nil
+}
+
+// isBuiltInProtectedWorkspacePath reports whether rel is owned by a
+// framework-managed subtree that file tools must not overwrite:
+//
+//   - work/inputs/**: conversation-file staging area (reconciler-
+//     authoritative);
+//   - skills/**: skill working copies staged by skill_load +
+//     LoadedSkillsProvider.
+//
+// These checks are purely syntactic; callers that need to protect
+// WorkspaceBootstrapSpec.Files targets should call
+// (*ExecTool).isBootstrapProtectedPath in addition to this helper.
+func isBuiltInProtectedWorkspacePath(rel string) bool {
+	clean := path.Clean(rel)
+	if clean == "" || clean == "." {
+		return false
+	}
+	if clean == "work/inputs" || strings.HasPrefix(clean, "work/inputs/") {
+		return true
+	}
+	if clean == codeexecutor.DirSkills ||
+		strings.HasPrefix(clean, codeexecutor.DirSkills+"/") {
+		return true
+	}
+	return false
+}
+
+// -----------------------------------------------------------------------------
+// ExecTool support hooks used by file tools.
+//
+// These methods let every file tool share exactly one "prepare the
+// workspace" code path and one bootstrap-target registry, so file
+// tools and workspace_exec never see different views of the shared
+// workspace state.
+// -----------------------------------------------------------------------------
+
+// prepareForFileTool brings the shared executor workspace to the
+// desired state that workspace_exec would have observed at the same
+// moment, and returns the live engine plus workspace handle. File
+// tools call this helper instead of reimplementing the "liveEngine
+// -> CreateWorkspace -> reconcile" sequence, ensuring that file
+// tools and workspace_exec always see the same conversation inputs,
+// bootstrap files, and loaded skills.
+func (t *ExecTool) prepareForFileTool(
+	ctx context.Context,
+) (codeexecutor.Engine, codeexecutor.Workspace, error) {
+	if t == nil {
+		return nil, codeexecutor.Workspace{}, errors.New(
+			"workspace file tools are not configured",
+		)
+	}
+	eng, err := t.liveEngine()
+	if err != nil {
+		return nil, codeexecutor.Workspace{}, err
+	}
+	if t.resolver == nil {
+		return nil, codeexecutor.Workspace{}, errors.New(
+			"workspace file tools require a workspace resolver",
+		)
+	}
+	ws, err := t.resolver.CreateWorkspace(ctx, eng, "workspace")
+	if err != nil {
+		return nil, codeexecutor.Workspace{}, err
+	}
+	if err := t.reconcileWorkspace(ctx, eng, ws); err != nil {
+		return nil, codeexecutor.Workspace{}, err
+	}
+	return eng, ws, nil
+}
+
+// registerBootstrapFileTargets records the workspace-relative Target
+// of every WorkspaceFile declared via WithWorkspaceBootstrap. File
+// tools consult this set when validating writes so that declarative
+// bootstrap outputs cannot be silently mutated or replaced by the
+// model.
+//
+// The method tolerates arbitrary user input: targets that fail
+// cleanWorkspaceRelPath are dropped (they will be rejected at
+// reconcile-time anyway and would never match a live write path).
+func (t *ExecTool) registerBootstrapFileTargets(
+	spec codeexecutor.WorkspaceBootstrapSpec,
+) {
+	if t == nil || len(spec.Files) == 0 {
+		return
+	}
+	seen := make(map[string]struct{}, len(t.bootstrapFileTargets))
+	for _, existing := range t.bootstrapFileTargets {
+		seen[existing] = struct{}{}
+	}
+	for _, f := range spec.Files {
+		rel, err := cleanWorkspaceRelPath(f.Target, false)
+		if err != nil {
+			continue
+		}
+		if _, ok := seen[rel]; ok {
+			continue
+		}
+		seen[rel] = struct{}{}
+		t.bootstrapFileTargets = append(t.bootstrapFileTargets, rel)
+	}
+	sort.Strings(t.bootstrapFileTargets)
+}
+
+// isBootstrapProtectedPath reports whether rel collides with a
+// bootstrap-managed file target. A path is protected when it matches
+// a target exactly or when it lives beneath a target that is itself
+// a directory prefix of another protected path.
+//
+// The lookup is O(len(targets)); bootstrap specs are expected to
+// hold tens of entries at most, so linear scanning is adequate.
+func (t *ExecTool) isBootstrapProtectedPath(rel string) bool {
+	if t == nil || len(t.bootstrapFileTargets) == 0 {
+		return false
+	}
+	clean := path.Clean(rel)
+	if clean == "" || clean == "." {
+		return false
+	}
+	for _, target := range t.bootstrapFileTargets {
+		if clean == target {
+			return true
+		}
+		if strings.HasPrefix(clean, target+"/") {
+			return true
+		}
+	}
+	return false
+}

--- a/tool/workspaceexec/file_tools.go
+++ b/tool/workspaceexec/file_tools.go
@@ -1,0 +1,1058 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package workspaceexec
+
+// Workspace file tools.
+//
+// This file hosts every workspace-scoped file tool built on top of
+// ExecTool: read, list, search-by-name, search-by-content, write, and
+// replace. They are grouped here instead of being split across six
+// per-tool files because they share the same skeleton
+// (input/output/Declaration/Call), the same backend helpers in
+// file_backend.go, and the same NewFileTools constructor. Keeping
+// them in one place makes it easier to audit tool surface parity
+// with tool/file and to reason about write-protection invariants
+// (work/inputs/**, skills/**, bootstrap targets) as a whole.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path"
+	"regexp"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+// -----------------------------------------------------------------------------
+// File tool set (constructor + options).
+// -----------------------------------------------------------------------------
+
+// FileToolsOptions selectively disables individual file tools when
+// the caller does not want to expose the full set. The zero value
+// enables all six tools, which is the recommended configuration for
+// llmagent callers. Each Disable* switch is expressed explicitly
+// (rather than via a bitmask) so that the API stays
+// self-documenting.
+type FileToolsOptions struct {
+	DisableReadFile       bool
+	DisableListDir        bool
+	DisableSearchFile     bool
+	DisableSearchContent  bool
+	DisableWriteFile      bool
+	DisableReplaceContent bool
+}
+
+// NewFileTools constructs the set of workspace file tools bound to
+// the provided ExecTool. File tools share the same executor,
+// workspace resolver, and reconciler wiring as workspace_exec, so
+// they always observe a workspace that has already been converged
+// to the desired state.
+//
+// The returned slice is freshly allocated on every call so callers
+// can safely append it to their own tool list.
+func NewFileTools(exec *ExecTool, opts FileToolsOptions) []tool.Tool {
+	if exec == nil {
+		return nil
+	}
+	tools := make([]tool.Tool, 0, 6)
+	if !opts.DisableReadFile {
+		tools = append(tools, newReadFileTool(exec))
+	}
+	if !opts.DisableListDir {
+		tools = append(tools, newListDirTool(exec))
+	}
+	if !opts.DisableSearchFile {
+		tools = append(tools, newSearchFileTool(exec))
+	}
+	if !opts.DisableSearchContent {
+		tools = append(tools, newSearchContentTool(exec))
+	}
+	if !opts.DisableWriteFile {
+		tools = append(tools, newWriteFileTool(exec))
+	}
+	if !opts.DisableReplaceContent {
+		tools = append(tools, newReplaceContentTool(exec))
+	}
+	return tools
+}
+
+// -----------------------------------------------------------------------------
+// workspace_read_file
+// -----------------------------------------------------------------------------
+
+// readFileTool reads a text file from the shared executor workspace.
+// It is the file-tool analogue of `cat <file>` but adds line
+// windowing, size capping, and UTF-8 validation so the model always
+// receives a well-formed textual payload.
+type readFileTool struct {
+	exec *ExecTool
+}
+
+// newReadFileTool constructs the tool bound to an existing ExecTool.
+// ExecTool owns the workspace resolver and reconciler so file tools
+// always operate on the same workspace snapshot as workspace_exec.
+func newReadFileTool(exec *ExecTool) *readFileTool {
+	return &readFileTool{exec: exec}
+}
+
+type readFileInput struct {
+	Path      string `json:"path"`
+	StartLine int    `json:"start_line,omitempty"`
+	NumLines  int    `json:"num_lines,omitempty"`
+	MaxBytes  int64  `json:"max_bytes,omitempty"`
+}
+
+type readFileOutput struct {
+	Path       string `json:"path"`
+	Contents   string `json:"contents"`
+	MIMEType   string `json:"mime_type"`
+	SizeBytes  int64  `json:"size_bytes"`
+	Truncated  bool   `json:"truncated"`
+	StartLine  int    `json:"start_line"`
+	EndLine    int    `json:"end_line"`
+	TotalLines int    `json:"total_lines"`
+}
+
+// Declaration describes the tool schema.
+func (t *readFileTool) Declaration() *tool.Declaration {
+	return &tool.Declaration{
+		Name: "workspace_read_file",
+		Description: "Read a UTF-8 text file from the shared executor " +
+			"workspace. Prefer this tool over `cat` via workspace_exec: " +
+			"it enforces a size cap, validates UTF-8, and supports line " +
+			"windows via start_line and num_lines. Binary files are " +
+			"rejected with a clear error.",
+		InputSchema: &tool.Schema{
+			Type:     "object",
+			Required: []string{"path"},
+			Properties: map[string]*tool.Schema{
+				"path": {
+					Type:        "string",
+					Description: "Workspace-relative file path (for example work/main.py).",
+				},
+				"start_line": {
+					Type:        "integer",
+					Description: "Optional 1-based line to start reading from.",
+				},
+				"num_lines": {
+					Type:        "integer",
+					Description: "Optional maximum number of lines to return. Defaults to all remaining lines.",
+				},
+				"max_bytes": {
+					Type:        "integer",
+					Description: "Maximum number of bytes to read from the file. Defaults to 1048576 (1 MiB).",
+				},
+			},
+		},
+		OutputSchema: &tool.Schema{
+			Type: "object",
+			Properties: map[string]*tool.Schema{
+				"path":        {Type: "string"},
+				"contents":    {Type: "string", Description: "Selected text window."},
+				"mime_type":   {Type: "string"},
+				"size_bytes":  {Type: "integer", Description: "Full file size in bytes."},
+				"truncated":   {Type: "boolean", Description: "True when the tool returned fewer bytes than the file contains."},
+				"start_line":  {Type: "integer"},
+				"end_line":    {Type: "integer"},
+				"total_lines": {Type: "integer"},
+			},
+		},
+	}
+}
+
+// Call executes the read operation and returns the selected window.
+func (t *readFileTool) Call(ctx context.Context, args []byte) (any, error) {
+	if t == nil || t.exec == nil {
+		return nil, errors.New("workspace_read_file is not configured")
+	}
+	var in readFileInput
+	if err := json.Unmarshal(args, &in); err != nil {
+		return nil, fmt.Errorf("invalid args: %w", err)
+	}
+	rel, err := cleanWorkspaceRelPath(in.Path, false)
+	if err != nil {
+		return nil, err
+	}
+	eng, ws, err := t.exec.prepareForFileTool(ctx)
+	if err != nil {
+		return nil, err
+	}
+	data, size, truncated, err := readFileLimited(
+		ctx, eng, ws, rel, in.MaxBytes,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateTextBytes(data, rel); err != nil {
+		return nil, err
+	}
+	body, start, end, total := sliceTextByLines(
+		string(data), in.StartLine, limitWindowEnd(in.StartLine, in.NumLines),
+	)
+	return readFileOutput{
+		Path:       rel,
+		Contents:   body,
+		MIMEType:   detectTextMIME(data, rel),
+		SizeBytes:  size,
+		Truncated:  truncated,
+		StartLine:  start,
+		EndLine:    end,
+		TotalLines: total,
+	}, nil
+}
+
+// limitWindowEnd converts a (start_line, num_lines) pair into the
+// inclusive endLine expected by sliceTextByLines. Zero or negative
+// limits mean "read to end of file", which is signaled to
+// sliceTextByLines by passing zero.
+func limitWindowEnd(startLine, numLines int) int {
+	if numLines <= 0 {
+		return 0
+	}
+	start := startLine
+	if start <= 0 {
+		start = 1
+	}
+	return start + numLines - 1
+}
+
+// -----------------------------------------------------------------------------
+// workspace_list_dir
+// -----------------------------------------------------------------------------
+
+// listDirTool enumerates the direct children of a workspace
+// directory. It is the file-tool analogue of `ls -la <dir>` but
+// returns structured entries.
+type listDirTool struct {
+	exec *ExecTool
+}
+
+// newListDirTool constructs the tool bound to an existing ExecTool.
+func newListDirTool(exec *ExecTool) *listDirTool {
+	return &listDirTool{exec: exec}
+}
+
+type listDirInput struct {
+	Path string `json:"path,omitempty"`
+}
+
+type listDirEntryOut struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+	Size int64  `json:"size"`
+}
+
+type listDirOutput struct {
+	Path      string            `json:"path"`
+	Entries   []listDirEntryOut `json:"entries"`
+	Truncated bool              `json:"truncated"`
+}
+
+// Declaration describes the tool schema.
+func (t *listDirTool) Declaration() *tool.Declaration {
+	return &tool.Declaration{
+		Name: "workspace_list_dir",
+		Description: "List the direct children of a workspace directory. " +
+			"Prefer this tool over `ls` via workspace_exec: it returns " +
+			"structured entries with type and size and works consistently " +
+			"across local and container executors. Use workspace_search_file " +
+			"for recursive discovery.",
+		InputSchema: &tool.Schema{
+			Type: "object",
+			Properties: map[string]*tool.Schema{
+				"path": {
+					Type: "string",
+					Description: "Workspace-relative directory path. " +
+						"Defaults to the workspace root.",
+				},
+			},
+		},
+		OutputSchema: &tool.Schema{
+			Type: "object",
+			Properties: map[string]*tool.Schema{
+				"path": {Type: "string"},
+				"entries": {
+					Type: "array",
+					Items: &tool.Schema{
+						Type: "object",
+						Properties: map[string]*tool.Schema{
+							"name": {Type: "string"},
+							"type": {Type: "string", Description: "file, dir, symlink, or other."},
+							"size": {Type: "integer"},
+						},
+					},
+				},
+				"truncated": {Type: "boolean"},
+			},
+		},
+	}
+}
+
+// Call executes the listing.
+func (t *listDirTool) Call(ctx context.Context, args []byte) (any, error) {
+	if t == nil || t.exec == nil {
+		return nil, errors.New("workspace_list_dir is not configured")
+	}
+	var in listDirInput
+	if len(args) > 0 {
+		if err := json.Unmarshal(args, &in); err != nil {
+			return nil, fmt.Errorf("invalid args: %w", err)
+		}
+	}
+	rel, err := cleanWorkspaceRelPath(in.Path, true)
+	if err != nil {
+		return nil, err
+	}
+	eng, ws, err := t.exec.prepareForFileTool(ctx)
+	if err != nil {
+		return nil, err
+	}
+	entries, truncated, err := listDirEntries(ctx, eng, ws, rel)
+	if err != nil {
+		return nil, err
+	}
+	out := listDirOutput{
+		Path:      rel,
+		Entries:   make([]listDirEntryOut, 0, len(entries)),
+		Truncated: truncated,
+	}
+	for _, e := range entries {
+		out.Entries = append(out.Entries, listDirEntryOut{
+			Name: e.Name,
+			Type: e.Type,
+			Size: e.Size,
+		})
+	}
+	return out, nil
+}
+
+// -----------------------------------------------------------------------------
+// workspace_search_file
+// -----------------------------------------------------------------------------
+
+// searchFileTool recursively searches the workspace for files whose
+// paths match a doublestar glob. It is the file-tool analogue of
+// `find . -name ...` and avoids the fragility of parsing shell
+// output from a generic find invocation.
+type searchFileTool struct {
+	exec *ExecTool
+}
+
+// newSearchFileTool constructs the tool bound to an existing ExecTool.
+func newSearchFileTool(exec *ExecTool) *searchFileTool {
+	return &searchFileTool{exec: exec}
+}
+
+type searchFileInput struct {
+	Path       string `json:"path,omitempty"`
+	Pattern    string `json:"pattern"`
+	MaxResults int    `json:"max_results,omitempty"`
+	FilesOnly  bool   `json:"files_only,omitempty"`
+}
+
+type searchFileMatch struct {
+	Path string `json:"path"`
+	Type string `json:"type"`
+	Size int64  `json:"size"`
+}
+
+type searchFileOutput struct {
+	Root      string            `json:"root"`
+	Matches   []searchFileMatch `json:"matches"`
+	Truncated bool              `json:"truncated"`
+}
+
+// Declaration describes the tool schema.
+func (t *searchFileTool) Declaration() *tool.Declaration {
+	return &tool.Declaration{
+		Name: "workspace_search_file",
+		Description: "Recursively find workspace files whose path matches " +
+			"a doublestar glob pattern. Use ** to match across directory " +
+			"levels, for example '**/*.go' or 'work/**/input*.csv'. " +
+			"Prefer this tool over `find` via workspace_exec because it " +
+			"returns structured results and works consistently across " +
+			"backends.",
+		InputSchema: &tool.Schema{
+			Type:     "object",
+			Required: []string{"pattern"},
+			Properties: map[string]*tool.Schema{
+				"path": {
+					Type: "string",
+					Description: "Workspace-relative directory to search. " +
+						"Defaults to the workspace root.",
+				},
+				"pattern": {
+					Type:        "string",
+					Description: "Doublestar glob pattern matched against the path relative to `path`.",
+				},
+				"files_only": {
+					Type:        "boolean",
+					Description: "When true, directory entries are filtered out.",
+				},
+				"max_results": {
+					Type:        "integer",
+					Description: "Maximum number of matches to return. Defaults to 200.",
+				},
+			},
+		},
+		OutputSchema: &tool.Schema{
+			Type: "object",
+			Properties: map[string]*tool.Schema{
+				"root": {Type: "string"},
+				"matches": {
+					Type: "array",
+					Items: &tool.Schema{
+						Type: "object",
+						Properties: map[string]*tool.Schema{
+							"path": {Type: "string"},
+							"type": {Type: "string"},
+							"size": {Type: "integer"},
+						},
+					},
+				},
+				"truncated": {Type: "boolean"},
+			},
+		},
+	}
+}
+
+// Call executes the recursive search.
+func (t *searchFileTool) Call(ctx context.Context, args []byte) (any, error) {
+	if t == nil || t.exec == nil {
+		return nil, errors.New("workspace_search_file is not configured")
+	}
+	var in searchFileInput
+	if err := json.Unmarshal(args, &in); err != nil {
+		return nil, fmt.Errorf("invalid args: %w", err)
+	}
+	if strings.TrimSpace(in.Pattern) == "" {
+		return nil, errors.New("pattern is required")
+	}
+	root, err := cleanWorkspaceRelPath(in.Path, true)
+	if err != nil {
+		return nil, err
+	}
+	eng, ws, err := t.exec.prepareForFileTool(ctx)
+	if err != nil {
+		return nil, err
+	}
+	entries, treeTruncated, err := listTreeAll(ctx, eng, ws, root)
+	if err != nil {
+		return nil, err
+	}
+	limit := in.MaxResults
+	if limit <= 0 {
+		limit = 200
+	}
+	out := searchFileOutput{
+		Root:    root,
+		Matches: []searchFileMatch{},
+		// Propagate tree-walk truncation up-front: even when
+		// max_results does not fire, the results may be incomplete
+		// because the directory walk itself was clipped at
+		// maxListingEntries. Pre-setting this flag keeps the model
+		// honest about the possibility.
+		Truncated: treeTruncated,
+	}
+	for _, e := range entries {
+		if in.FilesOnly && e.Type != "file" {
+			continue
+		}
+		if !matchGlob(in.Pattern, e.Name) {
+			continue
+		}
+		full := e.Name
+		if root != "." {
+			full = path.Join(root, e.Name)
+		}
+		out.Matches = append(out.Matches, searchFileMatch{
+			Path: full,
+			Type: e.Type,
+			Size: e.Size,
+		})
+		if len(out.Matches) >= limit {
+			out.Truncated = true
+			break
+		}
+	}
+	return out, nil
+}
+
+// -----------------------------------------------------------------------------
+// workspace_search_content
+// -----------------------------------------------------------------------------
+
+// searchContentTool scans workspace files for a regex and returns
+// matching line previews. It is the file-tool analogue of
+// `grep -rn` and removes the need for the model to write brittle
+// grep invocations.
+type searchContentTool struct {
+	exec *ExecTool
+}
+
+// newSearchContentTool constructs the tool bound to an existing ExecTool.
+func newSearchContentTool(exec *ExecTool) *searchContentTool {
+	return &searchContentTool{exec: exec}
+}
+
+type searchContentInput struct {
+	Path            string `json:"path,omitempty"`
+	Pattern         string `json:"pattern"`
+	CaseInsensitive bool   `json:"case_insensitive,omitempty"`
+	FileGlob        string `json:"file_glob,omitempty"`
+	MaxMatches      int    `json:"max_matches,omitempty"`
+	MaxFiles        int    `json:"max_files,omitempty"`
+	MaxBytes        int64  `json:"max_bytes,omitempty"`
+}
+
+type searchContentMatch struct {
+	Path    string `json:"path"`
+	Line    int    `json:"line"`
+	Preview string `json:"preview"`
+}
+
+type searchContentOutput struct {
+	Root         string               `json:"root"`
+	Matches      []searchContentMatch `json:"matches"`
+	FilesScanned int                  `json:"files_scanned"`
+	FilesSkipped int                  `json:"files_skipped"`
+	FilesPartial int                  `json:"files_partial"`
+	Truncated    bool                 `json:"truncated"`
+}
+
+// Declaration describes the tool schema.
+func (t *searchContentTool) Declaration() *tool.Declaration {
+	return &tool.Declaration{
+		Name: "workspace_search_content",
+		Description: "Search the contents of UTF-8 text files in the " +
+			"workspace for a regular expression and return matching lines. " +
+			"Use file_glob to restrict the search to specific files, for " +
+			"example '**/*.go' or 'work/**/*.csv'. Prefer this tool over " +
+			"`grep` via workspace_exec because it handles text validation, " +
+			"result capping, and binary-file skipping for you.",
+		InputSchema: &tool.Schema{
+			Type:     "object",
+			Required: []string{"pattern"},
+			Properties: map[string]*tool.Schema{
+				"path": {
+					Type:        "string",
+					Description: "Workspace-relative directory to search. Defaults to the workspace root.",
+				},
+				"pattern":          {Type: "string", Description: "RE2 regular expression."},
+				"case_insensitive": {Type: "boolean", Description: "When true, the regex is matched case-insensitively."},
+				"file_glob": {
+					Type:        "string",
+					Description: "Optional doublestar glob that matching file paths must satisfy.",
+				},
+				"max_matches": {Type: "integer", Description: "Maximum number of matches across all files. Defaults to 100."},
+				"max_files":   {Type: "integer", Description: "Maximum number of files to inspect. Defaults to 200."},
+				"max_bytes":   {Type: "integer", Description: "Maximum number of bytes to read per file. Defaults to 1048576 (1 MiB)."},
+			},
+		},
+		OutputSchema: &tool.Schema{
+			Type: "object",
+			Properties: map[string]*tool.Schema{
+				"root": {Type: "string"},
+				"matches": {
+					Type: "array",
+					Items: &tool.Schema{
+						Type: "object",
+						Properties: map[string]*tool.Schema{
+							"path":    {Type: "string"},
+							"line":    {Type: "integer"},
+							"preview": {Type: "string"},
+						},
+					},
+				},
+				"files_scanned": {Type: "integer"},
+				"files_skipped": {Type: "integer", Description: "Number of files skipped because they were not UTF-8 text or could not be read."},
+				"files_partial": {Type: "integer", Description: "Number of files scanned only up to max_bytes; their matches beyond that offset are not reported."},
+				"truncated":     {Type: "boolean", Description: "True when any of the result limits fired, the tree walk was clipped, or at least one file was only scanned partially."},
+			},
+		},
+	}
+}
+
+// Call executes the recursive content search.
+func (t *searchContentTool) Call(ctx context.Context, args []byte) (any, error) {
+	if t == nil || t.exec == nil {
+		return nil, errors.New("workspace_search_content is not configured")
+	}
+	var in searchContentInput
+	if err := json.Unmarshal(args, &in); err != nil {
+		return nil, fmt.Errorf("invalid args: %w", err)
+	}
+	if strings.TrimSpace(in.Pattern) == "" {
+		return nil, errors.New("pattern is required")
+	}
+	rx, err := compileContentRegex(in.Pattern, in.CaseInsensitive)
+	if err != nil {
+		return nil, err
+	}
+	root, err := cleanWorkspaceRelPath(in.Path, true)
+	if err != nil {
+		return nil, err
+	}
+	eng, ws, err := t.exec.prepareForFileTool(ctx)
+	if err != nil {
+		return nil, err
+	}
+	entries, treeTruncated, err := listTreeAll(ctx, eng, ws, root)
+	if err != nil {
+		return nil, err
+	}
+	maxMatches := in.MaxMatches
+	if maxMatches <= 0 {
+		maxMatches = 100
+	}
+	maxFiles := in.MaxFiles
+	if maxFiles <= 0 {
+		maxFiles = 200
+	}
+	maxBytes := in.MaxBytes
+	if maxBytes <= 0 {
+		maxBytes = defaultFileToolMaxBytes
+	}
+	out := searchContentOutput{
+		Root:      root,
+		Matches:   []searchContentMatch{},
+		Truncated: treeTruncated,
+	}
+	for _, e := range entries {
+		if e.Type != "file" {
+			continue
+		}
+		if in.FileGlob != "" && !matchGlob(in.FileGlob, e.Name) {
+			continue
+		}
+		if out.FilesScanned >= maxFiles {
+			out.Truncated = true
+			break
+		}
+		full := e.Name
+		if root != "." {
+			full = path.Join(root, e.Name)
+		}
+		data, _, fileTruncated, err := readFileLimited(
+			ctx, eng, ws, full, maxBytes,
+		)
+		if err != nil {
+			out.FilesSkipped++
+			continue
+		}
+		if err := validateTextBytes(data, full); err != nil {
+			out.FilesSkipped++
+			continue
+		}
+		out.FilesScanned++
+		if fileTruncated {
+			// The file exceeded max_bytes; we are about to scan only
+			// the prefix. Book-keep the partial scan so the caller
+			// knows the match list is incomplete for this file, and
+			// mark the overall response truncated so downstream
+			// reasoning does not treat a clean result as proof of
+			// absence.
+			out.FilesPartial++
+			out.Truncated = true
+		}
+		remaining := maxMatches - len(out.Matches)
+		if remaining <= 0 {
+			out.Truncated = true
+			break
+		}
+		hits := scanContentLines(rx, string(data), remaining, 240)
+		for _, h := range hits {
+			out.Matches = append(out.Matches, searchContentMatch{
+				Path:    full,
+				Line:    h.Line,
+				Preview: h.Preview,
+			})
+		}
+		if len(out.Matches) >= maxMatches {
+			out.Truncated = true
+			break
+		}
+	}
+	return out, nil
+}
+
+// -----------------------------------------------------------------------------
+// workspace_write_file
+// -----------------------------------------------------------------------------
+
+// writeFileTool creates or overwrites a UTF-8 text file inside the
+// workspace. It is the file-tool analogue of `printf ... > file` and
+// enforces two invariants that the shell form does not:
+//
+//  1. The target must not resolve to a framework-managed path such
+//     as work/inputs/**, skills/**, or a WorkspaceBootstrapSpec.Files
+//     target. These paths are owned by the reconciler and must not be
+//     mutated out of band.
+//  2. Unless overwrite=true, an existing file is preserved. This
+//     matches the "read-before-edit" semantics that other agent
+//     ecosystems expose and prevents silent loss of prior state.
+type writeFileTool struct {
+	exec *ExecTool
+}
+
+// newWriteFileTool constructs the tool bound to an existing ExecTool.
+func newWriteFileTool(exec *ExecTool) *writeFileTool {
+	return &writeFileTool{exec: exec}
+}
+
+type writeFileInput struct {
+	Path      string `json:"path"`
+	Contents  string `json:"contents"`
+	Overwrite bool   `json:"overwrite,omitempty"`
+	Mode      uint32 `json:"mode,omitempty"`
+}
+
+type writeFileOutput struct {
+	Path         string `json:"path"`
+	BytesWritten int    `json:"bytes_written"`
+	Overwritten  bool   `json:"overwritten"`
+	MIMEType     string `json:"mime_type"`
+}
+
+// Declaration describes the tool schema.
+func (t *writeFileTool) Declaration() *tool.Declaration {
+	return writeFileDeclaration()
+}
+
+// writeFileDeclaration is factored into a helper so the tool schema
+// can be reused by external wiring (for example, prompt generation)
+// without invoking the tool itself.
+func writeFileDeclaration() *tool.Declaration {
+	return &tool.Declaration{
+		Name: "workspace_write_file",
+		Description: "Create or overwrite a UTF-8 text file in the " +
+			"shared executor workspace. Refuses to write into framework-" +
+			"managed paths (work/inputs/**, skills/**, or declared " +
+			"bootstrap file targets) and refuses to overwrite an existing " +
+			"file unless overwrite=true.",
+		InputSchema: &tool.Schema{
+			Type:     "object",
+			Required: []string{"path", "contents"},
+			Properties: map[string]*tool.Schema{
+				"path": {
+					Type:        "string",
+					Description: "Workspace-relative file path.",
+				},
+				"contents": {
+					Type:        "string",
+					Description: "File contents as UTF-8 text.",
+				},
+				"overwrite": {
+					Type:        "boolean",
+					Description: "When true, replaces the file if it already exists.",
+				},
+				"mode": {
+					Type:        "integer",
+					Description: "Optional POSIX mode (for example 420 for 0644). Defaults to 0644.",
+				},
+			},
+		},
+		OutputSchema: &tool.Schema{
+			Type: "object",
+			Properties: map[string]*tool.Schema{
+				"path":          {Type: "string"},
+				"bytes_written": {Type: "integer"},
+				"overwritten":   {Type: "boolean"},
+				"mime_type":     {Type: "string"},
+			},
+		},
+	}
+}
+
+// Call executes the write.
+func (t *writeFileTool) Call(ctx context.Context, args []byte) (any, error) {
+	if t == nil || t.exec == nil {
+		return nil, errors.New("workspace_write_file is not configured")
+	}
+	var in writeFileInput
+	if err := json.Unmarshal(args, &in); err != nil {
+		return nil, fmt.Errorf("invalid args: %w", err)
+	}
+	rel, err := cleanWorkspaceRelPath(in.Path, false)
+	if err != nil {
+		return nil, err
+	}
+	if isBuiltInProtectedWorkspacePath(rel) || t.exec.isBootstrapProtectedPath(rel) {
+		return nil, fmt.Errorf(
+			"path %q is managed by the framework and cannot be written through workspace_write_file",
+			rel,
+		)
+	}
+	data := []byte(in.Contents)
+	if err := validateTextBytes(data, rel); err != nil {
+		return nil, err
+	}
+	eng, ws, err := t.exec.prepareForFileTool(ctx)
+	if err != nil {
+		return nil, err
+	}
+	exists, err := workspacePathExists(ctx, eng, ws, rel)
+	if err != nil {
+		return nil, err
+	}
+	if exists && !in.Overwrite {
+		return nil, fmt.Errorf(
+			"file already exists and overwrite=false: %s", rel,
+		)
+	}
+	mode := in.Mode
+	if mode == 0 {
+		mode = defaultFileToolMode
+	}
+	if err := writeFileBytes(ctx, eng, ws, rel, data, mode); err != nil {
+		return nil, err
+	}
+	return writeFileOutput{
+		Path:         rel,
+		BytesWritten: len(data),
+		Overwritten:  exists,
+		MIMEType:     detectTextMIME(data, rel),
+	}, nil
+}
+
+// -----------------------------------------------------------------------------
+// workspace_replace_content
+// -----------------------------------------------------------------------------
+
+// replaceContentTool performs an in-place text substitution on a
+// workspace file. It is the file-tool analogue of
+// `sed -i 's/old/new/'` but:
+//
+//  - keeps substitution literal by default (no accidental regex
+//    meta interpretation);
+//  - requires the file to already contain the search string:
+//    missing matches surface as an explicit error so the model
+//    cannot mistake a silent no-match for a successful edit. This
+//    is stricter than tool/file.replace_content (which reports
+//    "not found" via message + nil error); workspace_replace_content
+//    deliberately diverges here because the shared workspace edit
+//    loop is less forgiving of no-op "successes";
+//  - treats old_string == new_string as a success no-op, matching
+//    tool/file.replace_content;
+//  - refuses to modify framework-managed paths.
+type replaceContentTool struct {
+	exec *ExecTool
+}
+
+// newReplaceContentTool constructs the tool bound to an existing ExecTool.
+func newReplaceContentTool(exec *ExecTool) *replaceContentTool {
+	return &replaceContentTool{exec: exec}
+}
+
+type replaceContentInput struct {
+	Path            string `json:"path"`
+	OldString       string `json:"old_string"`
+	NewString       string `json:"new_string"`
+	NumReplacements int    `json:"num_replacements,omitempty"`
+	Regex           bool   `json:"regex,omitempty"`
+	CaseInsensitive bool   `json:"case_insensitive,omitempty"`
+	MaxBytes        int64  `json:"max_bytes,omitempty"`
+}
+
+type replaceContentOutput struct {
+	Path            string `json:"path"`
+	NumReplacements int    `json:"num_replacements"`
+	TotalMatches    int    `json:"total_matches"`
+	BytesWritten    int    `json:"bytes_written"`
+}
+
+// Declaration describes the tool schema.
+func (t *replaceContentTool) Declaration() *tool.Declaration {
+	return &tool.Declaration{
+		Name: "workspace_replace_content",
+		Description: "Replace text inside a workspace file in place. " +
+			"By default performs a literal, single-occurrence replacement; " +
+			"set regex=true to interpret old_string as an RE2 pattern and " +
+			"num_replacements<0 to replace every occurrence. Refuses to " +
+			"modify framework-managed paths (work/inputs/**, skills/**, " +
+			"and declared bootstrap file targets).",
+		InputSchema: &tool.Schema{
+			Type:     "object",
+			Required: []string{"path", "old_string", "new_string"},
+			Properties: map[string]*tool.Schema{
+				"path":             {Type: "string", Description: "Workspace-relative file path."},
+				"old_string":       {Type: "string", Description: "Literal text to find, or RE2 pattern when regex=true."},
+				"new_string":       {Type: "string", Description: "Replacement text."},
+				"num_replacements": {Type: "integer", Description: "Optional replacement limit; 0 means 1 and negative means replace all matches."},
+				"regex":            {Type: "boolean", Description: "When true, interpret `old_string` as an RE2 regex."},
+				"case_insensitive": {Type: "boolean", Description: "When true combined with regex, matching is case-insensitive."},
+				"max_bytes":        {Type: "integer", Description: "Maximum bytes to read when loading the file. Defaults to 1048576 (1 MiB)."},
+			},
+		},
+		OutputSchema: &tool.Schema{
+			Type: "object",
+			Properties: map[string]*tool.Schema{
+				"path":             {Type: "string"},
+				"num_replacements": {Type: "integer", Description: "Number of occurrences actually replaced."},
+				"total_matches":    {Type: "integer", Description: "Number of occurrences of old_string found in the file."},
+				"bytes_written":    {Type: "integer"},
+			},
+		},
+	}
+}
+
+// Call executes the substitution.
+func (t *replaceContentTool) Call(ctx context.Context, args []byte) (any, error) {
+	if t == nil || t.exec == nil {
+		return nil, errors.New("workspace_replace_content is not configured")
+	}
+	var in replaceContentInput
+	if err := json.Unmarshal(args, &in); err != nil {
+		return nil, fmt.Errorf("invalid args: %w", err)
+	}
+	if in.OldString == "" {
+		return nil, errors.New("old_string must not be empty")
+	}
+	rel, err := cleanWorkspaceRelPath(in.Path, false)
+	if err != nil {
+		return nil, err
+	}
+	if isBuiltInProtectedWorkspacePath(rel) || t.exec.isBootstrapProtectedPath(rel) {
+		return nil, fmt.Errorf(
+			"path %q is managed by the framework and cannot be written through workspace_replace_content",
+			rel,
+		)
+	}
+	if in.OldString == in.NewString {
+		// Parity with tool/file.replace_content: a rewrite that
+		// would produce identical content is reported as a
+		// successful no-op instead of an error. We still validate
+		// the path above so obviously bad calls do not get a
+		// misleading success.
+		return replaceContentOutput{Path: rel}, nil
+	}
+	eng, ws, err := t.exec.prepareForFileTool(ctx)
+	if err != nil {
+		return nil, err
+	}
+	data, _, truncated, err := readFileLimited(ctx, eng, ws, rel, in.MaxBytes)
+	if err != nil {
+		return nil, err
+	}
+	if truncated {
+		return nil, fmt.Errorf(
+			"file %q exceeds the configured max_bytes and cannot be safely replaced",
+			rel,
+		)
+	}
+	if err := validateTextBytes(data, rel); err != nil {
+		return nil, err
+	}
+	updated, applied, total, err := applyReplacement(string(data), in)
+	if err != nil {
+		return nil, err
+	}
+	if total == 0 {
+		return nil, fmt.Errorf(
+			"no occurrences of the search pattern were found in %s", rel,
+		)
+	}
+	if err := writeFileBytes(
+		ctx, eng, ws, rel, []byte(updated), defaultFileToolMode,
+	); err != nil {
+		return nil, err
+	}
+	return replaceContentOutput{
+		Path:            rel,
+		NumReplacements: applied,
+		TotalMatches:    total,
+		BytesWritten:    len(updated),
+	}, nil
+}
+
+// applyReplacement performs the literal or regex-based substitution
+// and returns the updated content, the number of replacements
+// actually applied, and the total number of matches found. The
+// num_replacements input is interpreted the same way the existing
+// tool/file.replace_content does: 0 means 1, and any negative value
+// means "replace every occurrence". Positive values are clamped to
+// the total match count so the caller always learns the real
+// upper bound.
+func applyReplacement(
+	src string, in replaceContentInput,
+) (string, int, int, error) {
+	limit := in.NumReplacements
+	if limit == 0 {
+		limit = 1
+	}
+
+	if in.Regex {
+		rx, err := compileContentRegex(in.OldString, in.CaseInsensitive)
+		if err != nil {
+			return "", 0, 0, err
+		}
+		all := rx.FindAllStringIndex(src, -1)
+		total := len(all)
+		if total == 0 {
+			return src, 0, 0, nil
+		}
+		if limit < 0 || limit > total {
+			limit = total
+		}
+		if limit == total {
+			return rx.ReplaceAllString(src, in.NewString), limit, total, nil
+		}
+		var b strings.Builder
+		b.Grow(len(src))
+		prev := 0
+		for i := 0; i < limit; i++ {
+			loc := all[i]
+			b.WriteString(src[prev:loc[0]])
+			match := src[loc[0]:loc[1]]
+			b.WriteString(rx.ReplaceAllString(match, in.NewString))
+			prev = loc[1]
+		}
+		b.WriteString(src[prev:])
+		return b.String(), limit, total, nil
+	}
+
+	if in.CaseInsensitive {
+		rx := regexp.MustCompile("(?i)" + regexp.QuoteMeta(in.OldString))
+		all := rx.FindAllStringIndex(src, -1)
+		total := len(all)
+		if total == 0 {
+			return src, 0, 0, nil
+		}
+		if limit < 0 || limit > total {
+			limit = total
+		}
+		if limit == total {
+			return rx.ReplaceAllLiteralString(src, in.NewString), limit, total, nil
+		}
+		var b strings.Builder
+		b.Grow(len(src))
+		prev := 0
+		for i := 0; i < limit; i++ {
+			loc := all[i]
+			b.WriteString(src[prev:loc[0]])
+			b.WriteString(in.NewString)
+			prev = loc[1]
+		}
+		b.WriteString(src[prev:])
+		return b.String(), limit, total, nil
+	}
+
+	total := strings.Count(src, in.OldString)
+	if total == 0 {
+		return src, 0, 0, nil
+	}
+	if limit < 0 || limit > total {
+		limit = total
+	}
+	return strings.Replace(src, in.OldString, in.NewString, limit), limit, total, nil
+}

--- a/tool/workspaceexec/file_tools_test.go
+++ b/tool/workspaceexec/file_tools_test.go
@@ -1,0 +1,499 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package workspaceexec
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
+	localexec "trpc.group/trpc-go/trpc-agent-go/codeexecutor/local"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+// callAs marshals the input struct to JSON and invokes the tool
+// Call method. All workspace file tools share the same JSON-driven
+// contract so a single helper is enough.
+func callAs(t *testing.T, tl tool.CallableTool, in any) any {
+	t.Helper()
+	enc, err := json.Marshal(in)
+	require.NoError(t, err)
+	res, err := tl.Call(context.Background(), enc)
+	require.NoError(t, err)
+	return res
+}
+
+// callErr is the negative-path counterpart to callAs. It asserts
+// the Call returned an error so tests can focus on the message text
+// rather than repeating the err!=nil boilerplate.
+func callErr(t *testing.T, tl tool.CallableTool, in any) error {
+	t.Helper()
+	enc, err := json.Marshal(in)
+	require.NoError(t, err)
+	_, callError := tl.Call(context.Background(), enc)
+	require.Error(t, callError)
+	return callError
+}
+
+// seedWorkspace materializes a handful of files inside the shared
+// executor workspace using the same PutFiles path that file tools
+// exercise. Seeding through the engine (rather than reaching into
+// ws.Path) keeps the tests honest about the production API surface.
+func seedWorkspace(
+	t *testing.T,
+	exec *ExecTool,
+	files map[string]string,
+) (codeexecutor.Engine, codeexecutor.Workspace) {
+	t.Helper()
+	eng, ws, err := exec.prepareForFileTool(context.Background())
+	require.NoError(t, err)
+	puts := make([]codeexecutor.PutFile, 0, len(files))
+	for p, c := range files {
+		puts = append(puts, codeexecutor.PutFile{
+			Path:    p,
+			Content: []byte(c),
+			Mode:    0o644,
+		})
+	}
+	require.NoError(t, eng.FS().PutFiles(context.Background(), ws, puts))
+	return eng, ws
+}
+
+func newExecToolForFileTests(t *testing.T) *ExecTool {
+	t.Helper()
+	return NewExecTool(localexec.New())
+}
+
+// ------- ReadFile -------
+
+func TestReadFileTool_ReadsWholeFile(t *testing.T) {
+	exec := newExecToolForFileTests(t)
+	seedWorkspace(t, exec, map[string]string{
+		"work/hello.txt": "line1\nline2\nline3\n",
+	})
+
+	tl := newReadFileTool(exec)
+	res := callAs(t, tl, readFileInput{Path: "work/hello.txt"}).(readFileOutput)
+
+	require.Equal(t, "work/hello.txt", res.Path)
+	require.Equal(t, "line1\nline2\nline3", res.Contents)
+	require.Equal(t, 3, res.TotalLines)
+	require.Equal(t, 1, res.StartLine)
+	require.Equal(t, 3, res.EndLine)
+	require.False(t, res.Truncated)
+}
+
+func TestReadFileTool_LineWindow(t *testing.T) {
+	exec := newExecToolForFileTests(t)
+	seedWorkspace(t, exec, map[string]string{
+		"work/hello.txt": "l1\nl2\nl3\nl4\nl5\n",
+	})
+
+	tl := newReadFileTool(exec)
+	res := callAs(t, tl, readFileInput{
+		Path: "work/hello.txt", StartLine: 2, NumLines: 2,
+	}).(readFileOutput)
+
+	require.Equal(t, "l2\nl3", res.Contents)
+	require.Equal(t, 2, res.StartLine)
+	require.Equal(t, 3, res.EndLine)
+	require.Equal(t, 5, res.TotalLines)
+}
+
+func TestReadFileTool_MissingPath(t *testing.T) {
+	exec := newExecToolForFileTests(t)
+	tl := newReadFileTool(exec)
+	err := callErr(t, tl, readFileInput{Path: "work/does-not-exist.txt"})
+	require.Contains(t, err.Error(), "not found")
+}
+
+func TestReadFileTool_RejectsBinary(t *testing.T) {
+	exec := newExecToolForFileTests(t)
+	seedWorkspace(t, exec, map[string]string{
+		"work/bin.dat": "okay\x00trailer",
+	})
+	tl := newReadFileTool(exec)
+	err := callErr(t, tl, readFileInput{Path: "work/bin.dat"})
+	require.Contains(t, err.Error(), "not valid UTF-8 text")
+}
+
+// ------- ListDir -------
+
+func TestListDirTool_DirectChildrenOnly(t *testing.T) {
+	exec := newExecToolForFileTests(t)
+	seedWorkspace(t, exec, map[string]string{
+		"work/a.txt":       "a",
+		"work/nested/b.txt": "bb",
+	})
+
+	tl := newListDirTool(exec)
+	res := callAs(t, tl, listDirInput{Path: "work"}).(listDirOutput)
+
+	names := map[string]string{}
+	for _, e := range res.Entries {
+		names[e.Name] = e.Type
+	}
+	require.Equal(t, "file", names["a.txt"])
+	require.Equal(t, "dir", names["nested"])
+	require.NotContains(t, names, "b.txt")
+}
+
+func TestListDirTool_NotDir(t *testing.T) {
+	exec := newExecToolForFileTests(t)
+	seedWorkspace(t, exec, map[string]string{"work/file.txt": "x"})
+	tl := newListDirTool(exec)
+	err := callErr(t, tl, listDirInput{Path: "work/file.txt"})
+	require.Contains(t, err.Error(), "not a directory")
+}
+
+// ------- SearchFile -------
+
+func TestSearchFileTool_GlobMatch(t *testing.T) {
+	exec := newExecToolForFileTests(t)
+	seedWorkspace(t, exec, map[string]string{
+		"work/a.go":       "package a",
+		"work/b.py":       "print(1)",
+		"work/inner/c.go": "package c",
+	})
+
+	tl := newSearchFileTool(exec)
+	res := callAs(t, tl, searchFileInput{
+		Path: "work", Pattern: "**/*.go", FilesOnly: true,
+	}).(searchFileOutput)
+
+	paths := make(map[string]bool)
+	for _, m := range res.Matches {
+		paths[m.Path] = true
+	}
+	require.True(t, paths["work/a.go"])
+	require.True(t, paths["work/inner/c.go"])
+	require.False(t, paths["work/b.py"])
+}
+
+// TestSearchFileTool_PropagatesTreeTruncation exercises the
+// listTreeAll truncation signal. Lowering the tree cap by hand
+// (rather than generating >5000 entries) keeps the test fast while
+// still proving that Search* propagates the flag instead of
+// dropping it inside the backend.
+func TestSearchFileTool_PropagatesTreeTruncation(t *testing.T) {
+	orig := maxListingEntriesOverride
+	maxListingEntriesOverride = 3
+	t.Cleanup(func() { maxListingEntriesOverride = orig })
+
+	exec := newExecToolForFileTests(t)
+	seedWorkspace(t, exec, map[string]string{
+		"work/a.txt": "1",
+		"work/b.txt": "2",
+		"work/c.txt": "3",
+		"work/d.txt": "4",
+		"work/e.txt": "5",
+	})
+
+	tl := newSearchFileTool(exec)
+	res := callAs(t, tl, searchFileInput{
+		Path: "work", Pattern: "*", FilesOnly: true,
+		MaxResults: 100,
+	}).(searchFileOutput)
+	require.True(t, res.Truncated)
+}
+
+// ------- SearchContent -------
+
+func TestSearchContentTool_RegexMatch(t *testing.T) {
+	exec := newExecToolForFileTests(t)
+	seedWorkspace(t, exec, map[string]string{
+		"work/a.txt": "hello world\nfoo bar\nHELLO AGAIN\n",
+		"work/b.txt": "no relevant content\n",
+	})
+
+	tl := newSearchContentTool(exec)
+	res := callAs(t, tl, searchContentInput{
+		Path: "work", Pattern: "hello", CaseInsensitive: true,
+	}).(searchContentOutput)
+
+	require.GreaterOrEqual(t, len(res.Matches), 2)
+	var linesA []int
+	for _, m := range res.Matches {
+		if m.Path == "work/a.txt" {
+			linesA = append(linesA, m.Line)
+		}
+	}
+	require.Equal(t, []int{1, 3}, linesA)
+}
+
+func TestSearchContentTool_RestrictedByFileGlob(t *testing.T) {
+	exec := newExecToolForFileTests(t)
+	seedWorkspace(t, exec, map[string]string{
+		"work/a.txt": "keyword\n",
+		"work/a.go":  "keyword\n",
+	})
+	tl := newSearchContentTool(exec)
+	res := callAs(t, tl, searchContentInput{
+		Path: "work", Pattern: "keyword", FileGlob: "*.go",
+	}).(searchContentOutput)
+	require.Len(t, res.Matches, 1)
+	require.Equal(t, "work/a.go", res.Matches[0].Path)
+}
+
+// TestSearchContentTool_PartialFileFlagged pins down the
+// files_partial / truncated behavior added so the model is told
+// when a file was only scanned up to max_bytes. Without this flag
+// an empty result set would be indistinguishable from the file
+// having no matches below the byte cap.
+func TestSearchContentTool_PartialFileFlagged(t *testing.T) {
+	exec := newExecToolForFileTests(t)
+	var big strings.Builder
+	for i := 0; i < 10; i++ {
+		big.WriteString("filler line nothing here\n")
+	}
+	big.WriteString("NEEDLE line at the end\n")
+	seedWorkspace(t, exec, map[string]string{
+		"work/big.txt": big.String(),
+	})
+	tl := newSearchContentTool(exec)
+	res := callAs(t, tl, searchContentInput{
+		Path:     "work",
+		Pattern:  "NEEDLE",
+		MaxBytes: 32, // Force the read to stop inside the prefix.
+	}).(searchContentOutput)
+	require.Equal(t, 1, res.FilesScanned)
+	require.Equal(t, 1, res.FilesPartial)
+	require.True(t, res.Truncated)
+	require.Empty(t, res.Matches)
+}
+
+// ------- WriteFile -------
+
+func TestWriteFileTool_CreatesAndRefusesOverwrite(t *testing.T) {
+	exec := newExecToolForFileTests(t)
+	// Prime the workspace so PutFiles root exists even if nothing
+	// was seeded.
+	_, _, err := exec.prepareForFileTool(context.Background())
+	require.NoError(t, err)
+
+	tl := newWriteFileTool(exec)
+	res := callAs(t, tl, writeFileInput{
+		Path: "work/note.txt", Contents: "hi\n",
+	}).(writeFileOutput)
+	require.Equal(t, 3, res.BytesWritten)
+	require.False(t, res.Overwritten)
+
+	// Second write without overwrite must fail.
+	err = callErr(t, tl, writeFileInput{
+		Path: "work/note.txt", Contents: "again\n",
+	})
+	require.Contains(t, err.Error(), "already exists")
+
+	// With overwrite=true it should succeed and report overwritten.
+	res = callAs(t, tl, writeFileInput{
+		Path: "work/note.txt", Contents: "again\n", Overwrite: true,
+	}).(writeFileOutput)
+	require.True(t, res.Overwritten)
+}
+
+func TestWriteFileTool_RejectsProtectedPaths(t *testing.T) {
+	exec := newExecToolForFileTests(t)
+	_, _, err := exec.prepareForFileTool(context.Background())
+	require.NoError(t, err)
+
+	tl := newWriteFileTool(exec)
+	err = callErr(t, tl, writeFileInput{
+		Path: "work/inputs/evil.txt", Contents: "x",
+	})
+	require.Contains(t, err.Error(), "managed by the framework")
+
+	err = callErr(t, tl, writeFileInput{
+		Path: "skills/evil/SKILL.md", Contents: "x",
+	})
+	require.Contains(t, err.Error(), "managed by the framework")
+}
+
+func TestWriteFileTool_RejectsBootstrapTargets(t *testing.T) {
+	exec := NewExecTool(
+		localexec.New(),
+		WithWorkspaceBootstrap(codeexecutor.WorkspaceBootstrapSpec{
+			Files: []codeexecutor.WorkspaceFile{
+				{Target: "work/config.json", Content: []byte("{}")},
+			},
+		}),
+	)
+	_, _, err := exec.prepareForFileTool(context.Background())
+	require.NoError(t, err)
+
+	tl := newWriteFileTool(exec)
+	err = callErr(t, tl, writeFileInput{
+		Path: "work/config.json", Contents: "{}", Overwrite: true,
+	})
+	require.Contains(t, err.Error(), "managed by the framework")
+}
+
+// ------- ReplaceContent -------
+
+func TestReplaceContentTool_LiteralFirstOccurrence(t *testing.T) {
+	exec := newExecToolForFileTests(t)
+	seedWorkspace(t, exec, map[string]string{
+		"work/note.txt": "alpha beta alpha",
+	})
+	tl := newReplaceContentTool(exec)
+	res := callAs(t, tl, replaceContentInput{
+		Path: "work/note.txt", OldString: "alpha", NewString: "gamma",
+	}).(replaceContentOutput)
+	require.Equal(t, 1, res.NumReplacements)
+	require.Equal(t, 2, res.TotalMatches)
+
+	rd := callAs(
+		t, newReadFileTool(exec),
+		readFileInput{Path: "work/note.txt"},
+	).(readFileOutput)
+	require.Equal(t, "gamma beta alpha", rd.Contents)
+}
+
+func TestReplaceContentTool_RegexReplaceAll(t *testing.T) {
+	exec := newExecToolForFileTests(t)
+	seedWorkspace(t, exec, map[string]string{
+		"work/note.txt": "foo1 foo2 foo3",
+	})
+	tl := newReplaceContentTool(exec)
+	res := callAs(t, tl, replaceContentInput{
+		Path: "work/note.txt", OldString: `foo\d`, NewString: "X",
+		Regex: true, NumReplacements: -1,
+	}).(replaceContentOutput)
+	require.Equal(t, 3, res.NumReplacements)
+	require.Equal(t, 3, res.TotalMatches)
+}
+
+func TestReplaceContentTool_LiteralReplaceAll(t *testing.T) {
+	exec := newExecToolForFileTests(t)
+	seedWorkspace(t, exec, map[string]string{
+		"work/note.txt": "a b a b a",
+	})
+	tl := newReplaceContentTool(exec)
+	res := callAs(t, tl, replaceContentInput{
+		Path:            "work/note.txt",
+		OldString:       "a",
+		NewString:       "Z",
+		NumReplacements: -1,
+	}).(replaceContentOutput)
+	require.Equal(t, 3, res.NumReplacements)
+	require.Equal(t, 3, res.TotalMatches)
+	rd := callAs(
+		t, newReadFileTool(exec),
+		readFileInput{Path: "work/note.txt"},
+	).(readFileOutput)
+	require.Equal(t, "Z b Z b Z", rd.Contents)
+}
+
+func TestReplaceContentTool_LimitedReplacements(t *testing.T) {
+	exec := newExecToolForFileTests(t)
+	seedWorkspace(t, exec, map[string]string{
+		"work/note.txt": "a b a b a",
+	})
+	tl := newReplaceContentTool(exec)
+	res := callAs(t, tl, replaceContentInput{
+		Path:            "work/note.txt",
+		OldString:       "a",
+		NewString:       "Z",
+		NumReplacements: 2,
+	}).(replaceContentOutput)
+	require.Equal(t, 2, res.NumReplacements)
+	require.Equal(t, 3, res.TotalMatches)
+}
+
+// TestReplaceContentTool_OldEqualsNewIsNoOp pins down the tool/file
+// parity: when old_string == new_string the tool must succeed with
+// zero replacements instead of surfacing an error. The file must be
+// left untouched.
+func TestReplaceContentTool_OldEqualsNewIsNoOp(t *testing.T) {
+	exec := newExecToolForFileTests(t)
+	seedWorkspace(t, exec, map[string]string{
+		"work/note.txt": "alpha beta",
+	})
+	tl := newReplaceContentTool(exec)
+	res := callAs(t, tl, replaceContentInput{
+		Path: "work/note.txt", OldString: "alpha", NewString: "alpha",
+	}).(replaceContentOutput)
+	require.Equal(t, "work/note.txt", res.Path)
+	require.Equal(t, 0, res.NumReplacements)
+	require.Equal(t, 0, res.TotalMatches)
+	require.Equal(t, 0, res.BytesWritten)
+
+	rd := callAs(
+		t, newReadFileTool(exec),
+		readFileInput{Path: "work/note.txt"},
+	).(readFileOutput)
+	require.Equal(t, "alpha beta", rd.Contents)
+}
+
+func TestReplaceContentTool_NoMatchFails(t *testing.T) {
+	exec := newExecToolForFileTests(t)
+	seedWorkspace(t, exec, map[string]string{"work/note.txt": "abc"})
+	tl := newReplaceContentTool(exec)
+	err := callErr(t, tl, replaceContentInput{
+		Path: "work/note.txt", OldString: "zz", NewString: "yy",
+	})
+	require.Contains(t, err.Error(), "no occurrences")
+}
+
+func TestReplaceContentTool_ProtectedPath(t *testing.T) {
+	exec := newExecToolForFileTests(t)
+	tl := newReplaceContentTool(exec)
+	err := callErr(t, tl, replaceContentInput{
+		Path: "skills/foo/SKILL.md", OldString: "a", NewString: "b",
+	})
+	require.Contains(t, err.Error(), "managed by the framework")
+}
+
+// ------- NewFileTools + FileToolsOptions -------
+
+func TestNewFileTools_DefaultRegistersAll(t *testing.T) {
+	exec := newExecToolForFileTests(t)
+	tools := NewFileTools(exec, FileToolsOptions{})
+	names := map[string]bool{}
+	for _, tl := range tools {
+		if d := tl.Declaration(); d != nil {
+			names[d.Name] = true
+		}
+	}
+	for _, want := range []string{
+		"workspace_read_file",
+		"workspace_list_dir",
+		"workspace_search_file",
+		"workspace_search_content",
+		"workspace_write_file",
+		"workspace_replace_content",
+	} {
+		require.True(t, names[want], "missing tool %s", want)
+	}
+}
+
+func TestNewFileTools_DisableFlags(t *testing.T) {
+	exec := newExecToolForFileTests(t)
+	tools := NewFileTools(exec, FileToolsOptions{
+		DisableWriteFile:      true,
+		DisableReplaceContent: true,
+	})
+	names := map[string]bool{}
+	for _, tl := range tools {
+		if d := tl.Declaration(); d != nil {
+			names[d.Name] = true
+		}
+	}
+	require.False(t, names["workspace_write_file"])
+	require.False(t, names["workspace_replace_content"])
+	require.True(t, names["workspace_read_file"])
+}
+
+func TestNewFileTools_NilExecReturnsNil(t *testing.T) {
+	require.Nil(t, NewFileTools(nil, FileToolsOptions{}))
+}

--- a/tool/workspaceexec/workspace_exec.go
+++ b/tool/workspaceexec/workspace_exec.go
@@ -54,6 +54,12 @@ type ExecTool struct {
 	reconciler             workspaceprep.Reconciler
 	conversationFilesWired bool
 
+	// bootstrapFileTargets lists the workspace-relative Target paths
+	// declared by every WithWorkspaceBootstrap call. File tools read
+	// this set to reject writes that would collide with declarative
+	// bootstrap outputs managed by the reconciler.
+	bootstrapFileTargets []string
+
 	mu       sync.Mutex
 	sessions map[string]*execSession
 	ttl      time.Duration
@@ -202,6 +208,7 @@ func WithWorkspaceBootstrap(
 	}
 	return func(t *ExecTool) {
 		t.addPreparer(provider)
+		t.registerBootstrapFileTargets(spec)
 	}
 }
 


### PR DESCRIPTION
Introduce six file tools (workspace_read_file, workspace_list_dir, workspace_search_file, workspace_search_content, workspace_write_file, workspace_replace_content) that operate on the same invocation-scoped workspace as workspace_exec. They reuse the WorkspaceRegistry, resolver, and reconcile layer added in #1660, and refuse to write framework-managed paths (work/inputs/**, skills/**, and WorkspaceBootstrapSpec.Files targets).

Expose them through an opt-in llmagent.WithWorkspaceFileToolsEnabled option. Extend WorkspaceExecRequestProcessor to compose exec and filetools guidance so both surfaces receive consistent instructions, including write-protection and truncation semantics.