### PR TITLE
server/evaluation: add metric routes and split resource handlers

### DIFF
--- a/examples/evaluation/server/main.go
+++ b/examples/evaluation/server/main.go
@@ -65,6 +65,7 @@ func main() {
 		sevaluation.WithBasePath(*basePath),
 		sevaluation.WithAgentEvaluator(agentEvaluator),
 		sevaluation.WithEvalSetManager(evalSetManager),
+		sevaluation.WithMetricManager(metricManager),
 		sevaluation.WithEvalResultManager(evalResultManager),
 	)
 	if err != nil {

--- a/server/evaluation/langfuse/handler_test.go
+++ b/server/evaluation/langfuse/handler_test.go
@@ -1452,6 +1452,7 @@ func TestHandlerRegisterRoutesMountsUnderEvaluationBasePath(t *testing.T) {
 		serverevaluation.WithAppName("demo-app"),
 		serverevaluation.WithAgentEvaluator(agentEvaluator),
 		serverevaluation.WithEvalSetManager(evalSetManager),
+		serverevaluation.WithMetricManager(newTestMetricManager(t)),
 		serverevaluation.WithEvalResultManager(resultManager),
 		serverevaluation.WithRouteRegistrar(handler),
 	)

--- a/server/evaluation/metrics.go
+++ b/server/evaluation/metrics.go
@@ -1,0 +1,250 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package evaluation
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
+)
+
+func (s *Server) handleMetrics(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions {
+		s.handleCORS(w)
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		s.handleListMetrics(w, r)
+	case http.MethodPost:
+		s.handleCreateMetric(w, r)
+	default:
+		w.Header().Set(headerAllow, strings.Join([]string{http.MethodGet, http.MethodPost}, ", "))
+		s.respondJSON(w, r, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+	}
+}
+
+func (s *Server) handleMetricByName(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions {
+		s.handleCORS(w)
+		return
+	}
+	metricName := strings.TrimSpace(r.PathValue("metricName"))
+	if metricName == "" {
+		s.respondJSON(w, r, http.StatusNotFound, map[string]string{"error": "not found"})
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		s.handleGetMetric(w, r, metricName)
+	case http.MethodPut:
+		s.handleUpdateMetric(w, r, metricName)
+	case http.MethodDelete:
+		s.handleDeleteMetric(w, r, metricName)
+	default:
+		w.Header().Set(headerAllow, strings.Join([]string{http.MethodGet, http.MethodPut, http.MethodDelete}, ", "))
+		s.respondJSON(w, r, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+	}
+}
+
+func (s *Server) handleListMetrics(w http.ResponseWriter, r *http.Request) {
+	setID, ok := s.readRequiredMetricSetID(w, r)
+	if !ok {
+		return
+	}
+	metrics, err := s.listMetrics(r.Context(), setID)
+	if err != nil {
+		s.respondStatusError(w, r, err)
+		return
+	}
+	s.respondJSON(w, r, http.StatusOK, &ListMetricsResponse{
+		Metrics: metrics,
+	})
+}
+
+func (s *Server) listMetrics(ctx context.Context, setID string) ([]*metric.EvalMetric, error) {
+	ids, err := s.metricManager.List(ctx, s.appName, setID)
+	if err != nil {
+		return nil, err
+	}
+	metrics := make([]*metric.EvalMetric, 0, len(ids))
+	for _, id := range ids {
+		evalMetric, err := s.metricManager.Get(ctx, s.appName, setID, id)
+		if err != nil {
+			return nil, err
+		}
+		metrics = append(metrics, evalMetric)
+	}
+	return metrics, nil
+}
+
+func (s *Server) handleCreateMetric(w http.ResponseWriter, r *http.Request) {
+	req, err := s.decodeCreateMetricRequest(w, r)
+	if err != nil {
+		return
+	}
+	existing, err := s.metricManager.Get(r.Context(), s.appName, req.SetID, req.Metric.MetricName)
+	switch {
+	case err == nil && existing != nil:
+		s.respondJSON(w, r, http.StatusConflict, map[string]string{"error": "already exists"})
+		return
+	case err != nil && !errors.Is(err, os.ErrNotExist):
+		s.respondStatusError(w, r, err)
+		return
+	}
+	if err := s.metricManager.Add(r.Context(), s.appName, req.SetID, req.Metric); err != nil {
+		existing, getErr := s.metricManager.Get(r.Context(), s.appName, req.SetID, req.Metric.MetricName)
+		if getErr == nil && existing != nil {
+			s.respondJSON(w, r, http.StatusConflict, map[string]string{"error": "already exists"})
+			return
+		}
+		s.respondStatusError(w, r, err)
+		return
+	}
+	evalMetric, err := s.metricManager.Get(r.Context(), s.appName, req.SetID, req.Metric.MetricName)
+	if err != nil {
+		s.respondStatusError(w, r, err)
+		return
+	}
+	s.respondJSON(w, r, http.StatusCreated, &MetricResponse{
+		Metric: evalMetric,
+	})
+}
+
+func (s *Server) handleGetMetric(w http.ResponseWriter, r *http.Request, metricName string) {
+	setID, ok := s.readRequiredMetricSetID(w, r)
+	if !ok {
+		return
+	}
+	evalMetric, err := s.metricManager.Get(r.Context(), s.appName, setID, metricName)
+	if err != nil {
+		s.respondStatusError(w, r, err)
+		return
+	}
+	s.respondJSON(w, r, http.StatusOK, &MetricResponse{
+		Metric: evalMetric,
+	})
+}
+
+func (s *Server) handleUpdateMetric(w http.ResponseWriter, r *http.Request, metricName string) {
+	req, err := s.decodeUpdateMetricRequest(w, r, metricName)
+	if err != nil {
+		return
+	}
+	if err := s.metricManager.Update(r.Context(), s.appName, req.SetID, req.Metric); err != nil {
+		s.respondStatusError(w, r, err)
+		return
+	}
+	evalMetric, err := s.metricManager.Get(r.Context(), s.appName, req.SetID, metricName)
+	if err != nil {
+		s.respondStatusError(w, r, err)
+		return
+	}
+	s.respondJSON(w, r, http.StatusOK, &MetricResponse{
+		Metric: evalMetric,
+	})
+}
+
+func (s *Server) handleDeleteMetric(w http.ResponseWriter, r *http.Request, metricName string) {
+	setID, ok := s.readRequiredMetricSetID(w, r)
+	if !ok {
+		return
+	}
+	if err := s.metricManager.Delete(r.Context(), s.appName, setID, metricName); err != nil {
+		s.respondStatusError(w, r, err)
+		return
+	}
+	w.Header().Set(headerAccessControlOrigin, "*")
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) readRequiredMetricSetID(w http.ResponseWriter, r *http.Request) (string, bool) {
+	setID := strings.TrimSpace(r.URL.Query().Get("setId"))
+	if setID == "" {
+		s.respondJSON(w, r, http.StatusBadRequest, map[string]string{"error": "setId must not be empty"})
+		return "", false
+	}
+	return setID, true
+}
+
+func (s *Server) decodeCreateMetricRequest(w http.ResponseWriter, r *http.Request) (*CreateMetricRequest, error) {
+	var req CreateMetricRequest
+	if err := s.decodeJSONRequestBody(w, r, &req); err != nil {
+		return nil, err
+	}
+	if err := validateCreateMetricRequest(&req); err != nil {
+		s.respondJSON(w, r, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return nil, err
+	}
+	return &req, nil
+}
+
+func (s *Server) decodeUpdateMetricRequest(w http.ResponseWriter, r *http.Request, metricName string) (*UpdateMetricRequest, error) {
+	var req UpdateMetricRequest
+	if err := s.decodeJSONRequestBody(w, r, &req); err != nil {
+		return nil, err
+	}
+	if err := applyMetricNameFromPath(req.Metric, metricName); err != nil {
+		s.respondJSON(w, r, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return nil, err
+	}
+	if err := validateUpdateMetricRequest(&req); err != nil {
+		s.respondJSON(w, r, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return nil, err
+	}
+	return &req, nil
+}
+
+func validateCreateMetricRequest(req *CreateMetricRequest) error {
+	if req == nil {
+		return errors.New("request must not be nil")
+	}
+	return validateMetricPayload(&req.SetID, req.Metric)
+}
+
+func validateUpdateMetricRequest(req *UpdateMetricRequest) error {
+	if req == nil {
+		return errors.New("request must not be nil")
+	}
+	return validateMetricPayload(&req.SetID, req.Metric)
+}
+
+func validateMetricPayload(setID *string, evalMetric *metric.EvalMetric) error {
+	*setID = strings.TrimSpace(*setID)
+	if *setID == "" {
+		return errors.New("setId must not be empty")
+	}
+	if evalMetric == nil {
+		return errors.New("metric must not be nil")
+	}
+	evalMetric.MetricName = strings.TrimSpace(evalMetric.MetricName)
+	if evalMetric.MetricName == "" {
+		return errors.New("metric.metricName must not be empty")
+	}
+	return nil
+}
+
+func applyMetricNameFromPath(evalMetric *metric.EvalMetric, metricName string) error {
+	if evalMetric == nil {
+		return nil
+	}
+	bodyMetricName := strings.TrimSpace(evalMetric.MetricName)
+	if bodyMetricName == "" {
+		evalMetric.MetricName = metricName
+		return nil
+	}
+	if bodyMetricName != metricName {
+		return errors.New("metric.metricName must match path metricName when provided")
+	}
+	return nil
+}

--- a/server/evaluation/openapi.yaml
+++ b/server/evaluation/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: Evaluation Server API
   version: 1.0.0
-  description: HTTP API for listing evaluation sets, running evaluations, and retrieving evaluation results.
+  description: HTTP API for listing evaluation sets, managing evaluation metrics, running evaluations, and retrieving evaluation results.
 servers:
   - url: "{basePath}"
     variables:
@@ -35,6 +35,104 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetSetResponse"
+        "404":
+          $ref: "#/components/responses/ErrorResponse"
+        "500":
+          $ref: "#/components/responses/ErrorResponse"
+  /metrics:
+    get:
+      operationId: listMetrics
+      summary: List evaluation metrics
+      parameters:
+        - $ref: "#/components/parameters/MetricSetID"
+      responses:
+        "200":
+          description: Evaluation metrics were returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListMetricsResponse"
+        "400":
+          $ref: "#/components/responses/ErrorResponse"
+        "500":
+          $ref: "#/components/responses/ErrorResponse"
+    post:
+      operationId: createMetric
+      summary: Create an evaluation metric
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateMetricRequest"
+      responses:
+        "201":
+          description: Evaluation metric was created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MetricResponse"
+        "400":
+          $ref: "#/components/responses/ErrorResponse"
+        "409":
+          $ref: "#/components/responses/ErrorResponse"
+        "500":
+          $ref: "#/components/responses/ErrorResponse"
+  /metrics/{metricName}:
+    get:
+      operationId: getMetric
+      summary: Get an evaluation metric
+      parameters:
+        - $ref: "#/components/parameters/MetricName"
+        - $ref: "#/components/parameters/MetricSetID"
+      responses:
+        "200":
+          description: Evaluation metric detail was returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MetricResponse"
+        "400":
+          $ref: "#/components/responses/ErrorResponse"
+        "404":
+          $ref: "#/components/responses/ErrorResponse"
+        "500":
+          $ref: "#/components/responses/ErrorResponse"
+    put:
+      operationId: updateMetric
+      summary: Update an evaluation metric
+      parameters:
+        - $ref: "#/components/parameters/MetricName"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateMetricRequest"
+      responses:
+        "200":
+          description: Evaluation metric was updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MetricResponse"
+        "400":
+          $ref: "#/components/responses/ErrorResponse"
+        "404":
+          $ref: "#/components/responses/ErrorResponse"
+        "500":
+          $ref: "#/components/responses/ErrorResponse"
+    delete:
+      operationId: deleteMetric
+      summary: Delete an evaluation metric
+      parameters:
+        - $ref: "#/components/parameters/MetricName"
+        - $ref: "#/components/parameters/MetricSetID"
+      responses:
+        "204":
+          description: Evaluation metric was deleted successfully.
+        "400":
+          $ref: "#/components/responses/ErrorResponse"
         "404":
           $ref: "#/components/responses/ErrorResponse"
         "500":
@@ -106,6 +204,18 @@ components:
       required: true
       schema:
         type: string
+    MetricSetID:
+      name: setId
+      in: query
+      required: true
+      schema:
+        type: string
+    MetricName:
+      name: metricName
+      in: path
+      required: true
+      schema:
+        type: string
     ResultSetID:
       name: setId
       in: query
@@ -157,6 +267,42 @@ components:
       properties:
         set:
           $ref: "#/components/schemas/EvalSet"
+      additionalProperties: false
+    CreateMetricRequest:
+      type: object
+      properties:
+        setId:
+          type: string
+        metric:
+          $ref: "#/components/schemas/EvalMetric"
+      required:
+        - setId
+        - metric
+      additionalProperties: false
+    UpdateMetricRequest:
+      type: object
+      properties:
+        setId:
+          type: string
+        metric:
+          $ref: "#/components/schemas/EvalMetric"
+      required:
+        - setId
+        - metric
+      additionalProperties: false
+    ListMetricsResponse:
+      type: object
+      properties:
+        metrics:
+          type: array
+          items:
+            $ref: "#/components/schemas/EvalMetric"
+      additionalProperties: false
+    MetricResponse:
+      type: object
+      properties:
+        metric:
+          $ref: "#/components/schemas/EvalMetric"
       additionalProperties: false
     CreateRunResponse:
       type: object
@@ -211,6 +357,16 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/EvalMetricResult"
+    EvalMetric:
+      type: object
+      properties:
+        metricName:
+          type: string
+        threshold:
+          type: number
+        criterion:
+          type: object
+          additionalProperties: true
     EvalSet:
       type: object
       properties:

--- a/server/evaluation/options.go
+++ b/server/evaluation/options.go
@@ -15,11 +15,13 @@ import (
 	coreevaluation "trpc.group/trpc-go/trpc-agent-go/evaluation"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
 )
 
 const (
 	defaultBasePath    = "/evaluation"
 	defaultSetsPath    = "/sets"
+	defaultMetricsPath = "/metrics"
 	defaultRunsPath    = "/runs"
 	defaultResultsPath = "/results"
 )
@@ -31,11 +33,13 @@ type options struct {
 	appName           string
 	basePath          string
 	setsPath          string
+	metricsPath       string
 	runsPath          string
 	resultsPath       string
 	timeout           time.Duration
 	agentEvaluator    coreevaluation.AgentEvaluator
 	evalSetManager    evalset.Manager
+	metricManager     metric.Manager
 	evalResultManager evalresult.Manager
 	routeRegistrars   []RouteRegistrar
 }
@@ -44,6 +48,7 @@ func newOptions(opt ...Option) *options {
 	opts := &options{
 		basePath:    defaultBasePath,
 		setsPath:    defaultSetsPath,
+		metricsPath: defaultMetricsPath,
 		runsPath:    defaultRunsPath,
 		resultsPath: defaultResultsPath,
 	}
@@ -71,6 +76,13 @@ func WithBasePath(path string) Option {
 func WithSetsPath(path string) Option {
 	return func(opts *options) {
 		opts.setsPath = path
+	}
+}
+
+// WithMetricsPath sets the metrics collection path relative to BasePath.
+func WithMetricsPath(path string) Option {
+	return func(opts *options) {
+		opts.metricsPath = path
 	}
 }
 
@@ -103,13 +115,23 @@ func WithAgentEvaluator(agentEvaluator coreevaluation.AgentEvaluator) Option {
 }
 
 // WithEvalSetManager sets the eval set manager used by the evaluation server.
+// When omitted, set routes are not registered.
 func WithEvalSetManager(manager evalset.Manager) Option {
 	return func(opts *options) {
 		opts.evalSetManager = manager
 	}
 }
 
+// WithMetricManager sets the metric manager used by the evaluation server.
+// When omitted, metric routes are not registered.
+func WithMetricManager(manager metric.Manager) Option {
+	return func(opts *options) {
+		opts.metricManager = manager
+	}
+}
+
 // WithEvalResultManager sets the eval result manager used by the evaluation server.
+// When omitted, result routes are not registered.
 func WithEvalResultManager(manager evalresult.Manager) Option {
 	return func(opts *options) {
 		opts.evalResultManager = manager

--- a/server/evaluation/results.go
+++ b/server/evaluation/results.go
@@ -1,0 +1,86 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package evaluation
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
+)
+
+func (s *Server) handleResults(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions {
+		s.handleCORS(w)
+		return
+	}
+	if r.Method != http.MethodGet {
+		w.Header().Set(headerAllow, http.MethodGet)
+		s.respondJSON(w, r, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+	filterSetID := readSetIDFilter(r)
+	results, err := s.listEvalResults(r.Context(), filterSetID)
+	if err != nil {
+		s.respondStatusError(w, r, err)
+		return
+	}
+	s.respondJSON(w, r, http.StatusOK, &ListResultsResponse{
+		Results: results,
+	})
+}
+
+func (s *Server) handleResultByID(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions {
+		s.handleCORS(w)
+		return
+	}
+	if r.Method != http.MethodGet {
+		w.Header().Set(headerAllow, http.MethodGet)
+		s.respondJSON(w, r, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+	id := strings.TrimSpace(r.PathValue("resultId"))
+	if id == "" {
+		s.respondJSON(w, r, http.StatusNotFound, map[string]string{"error": "not found"})
+		return
+	}
+	result, err := s.evalResultManager.Get(r.Context(), s.appName, id)
+	if err != nil {
+		s.respondStatusError(w, r, err)
+		return
+	}
+	s.respondJSON(w, r, http.StatusOK, &GetResultResponse{
+		Result: result,
+	})
+}
+
+func (s *Server) listEvalResults(ctx context.Context, filterSetID string) ([]*evalresult.EvalSetResult, error) {
+	ids, err := s.evalResultManager.List(ctx, s.appName)
+	if err != nil {
+		return nil, err
+	}
+	results := make([]*evalresult.EvalSetResult, 0, len(ids))
+	for _, id := range ids {
+		result, err := s.evalResultManager.Get(ctx, s.appName, id)
+		if err != nil {
+			return nil, err
+		}
+		if filterSetID != "" && result.EvalSetID != filterSetID {
+			continue
+		}
+		results = append(results, result)
+	}
+	return results, nil
+}
+
+func readSetIDFilter(r *http.Request) string {
+	return strings.TrimSpace(r.URL.Query().Get("setId"))
+}

--- a/server/evaluation/runs.go
+++ b/server/evaluation/runs.go
@@ -1,0 +1,81 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package evaluation
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+
+	coreevaluation "trpc.group/trpc-go/trpc-agent-go/evaluation"
+)
+
+func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions {
+		s.handleCORS(w)
+		return
+	}
+	if r.Method != http.MethodPost {
+		w.Header().Set(headerAllow, http.MethodPost)
+		s.respondJSON(w, r, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+	s.handleCreateRun(w, r)
+}
+
+func (s *Server) handleCreateRun(w http.ResponseWriter, r *http.Request) {
+	req, err := s.decodeRunEvaluationRequest(w, r)
+	if err != nil {
+		return
+	}
+	ctx, cancel := newExecutionContext(r.Context(), s.timeout)
+	defer cancel()
+	result, err := s.runEvaluation(ctx, req)
+	if err != nil {
+		s.respondStatusError(w, r, err)
+		return
+	}
+	s.respondJSON(w, r, http.StatusCreated, &CreateRunResponse{
+		EvaluationResult: result,
+	})
+}
+
+func (s *Server) runEvaluation(ctx context.Context, req *RunEvaluationRequest) (*coreevaluation.EvaluationResult, error) {
+	evalOpts := make([]coreevaluation.Option, 0, 1)
+	if req.NumRuns != nil {
+		evalOpts = append(evalOpts, coreevaluation.WithNumRuns(*req.NumRuns))
+	}
+	return s.agentEvaluator.Evaluate(ctx, req.SetID, evalOpts...)
+}
+
+func (s *Server) decodeRunEvaluationRequest(w http.ResponseWriter, r *http.Request) (*RunEvaluationRequest, error) {
+	var req RunEvaluationRequest
+	if err := s.decodeJSONRequestBody(w, r, &req); err != nil {
+		return nil, err
+	}
+	if err := validateRunEvaluationRequest(&req); err != nil {
+		s.respondJSON(w, r, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return nil, err
+	}
+	return &req, nil
+}
+
+func validateRunEvaluationRequest(req *RunEvaluationRequest) error {
+	if req == nil {
+		return errors.New("request must not be nil")
+	}
+	if strings.TrimSpace(req.SetID) == "" {
+		return errors.New("setId must not be empty")
+	}
+	if req.NumRuns != nil && *req.NumRuns <= 0 {
+		return errors.New("numRuns must be greater than 0 when provided")
+	}
+	return nil
+}

--- a/server/evaluation/runs.go
+++ b/server/evaluation/runs.go
@@ -71,7 +71,8 @@ func validateRunEvaluationRequest(req *RunEvaluationRequest) error {
 	if req == nil {
 		return errors.New("request must not be nil")
 	}
-	if strings.TrimSpace(req.SetID) == "" {
+	req.SetID = strings.TrimSpace(req.SetID)
+	if req.SetID == "" {
 		return errors.New("setId must not be empty")
 	}
 	if req.NumRuns != nil && *req.NumRuns <= 0 {

--- a/server/evaluation/server.go
+++ b/server/evaluation/server.go
@@ -24,6 +24,7 @@ import (
 	coreevaluation "trpc.group/trpc-go/trpc-agent-go/evaluation"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
 	"trpc.group/trpc-go/trpc-agent-go/log"
 )
 
@@ -42,11 +43,13 @@ type Server struct {
 	appName           string
 	basePath          string
 	setsPath          string
+	metricsPath       string
 	runsPath          string
 	resultsPath       string
 	timeout           time.Duration
 	agentEvaluator    coreevaluation.AgentEvaluator
 	evalSetManager    evalset.Manager
+	metricManager     metric.Manager
 	evalResultManager evalresult.Manager
 	routeRegistrars   []RouteRegistrar
 	handler           http.Handler
@@ -61,16 +64,14 @@ func New(opts ...Option) (*Server, error) {
 	if options.agentEvaluator == nil {
 		return nil, errors.New("evaluation server: agent evaluator must not be nil")
 	}
-	if options.evalSetManager == nil {
-		return nil, errors.New("evaluation server: eval set manager must not be nil")
-	}
-	if options.evalResultManager == nil {
-		return nil, errors.New("evaluation server: eval result manager must not be nil")
-	}
 	basePath := normalizeBasePath(options.basePath)
 	setsPath, err := joinURLPath(basePath, options.setsPath)
 	if err != nil {
 		return nil, fmt.Errorf("evaluation server: join sets path: %w", err)
+	}
+	metricsPath, err := joinURLPath(basePath, options.metricsPath)
+	if err != nil {
+		return nil, fmt.Errorf("evaluation server: join metrics path: %w", err)
 	}
 	runsPath, err := joinURLPath(basePath, options.runsPath)
 	if err != nil {
@@ -84,11 +85,13 @@ func New(opts ...Option) (*Server, error) {
 		appName:           options.appName,
 		basePath:          basePath,
 		setsPath:          setsPath,
+		metricsPath:       metricsPath,
 		runsPath:          runsPath,
 		resultsPath:       resultsPath,
 		timeout:           options.timeout,
 		agentEvaluator:    options.agentEvaluator,
 		evalSetManager:    options.evalSetManager,
+		metricManager:     options.metricManager,
 		evalResultManager: options.evalResultManager,
 		routeRegistrars:   append([]RouteRegistrar(nil), options.routeRegistrars...),
 	}
@@ -113,6 +116,11 @@ func (s *Server) SetsPath() string {
 	return s.setsPath
 }
 
+// MetricsPath returns the metrics collection endpoint path.
+func (s *Server) MetricsPath() string {
+	return s.metricsPath
+}
+
 // RunsPath returns the runs collection endpoint path.
 func (s *Server) RunsPath() string {
 	return s.runsPath
@@ -130,19 +138,30 @@ func (s *Server) Close() error {
 
 func (s *Server) setupHandler() error {
 	mux := http.NewServeMux()
-	// Register collection and item routes for evaluation sets.
-	mux.HandleFunc(s.setsPath, s.handleSets)
-	mux.HandleFunc(s.setsPath+"/{$}", s.redirectTrailingSlashToCanonicalPath)
-	mux.HandleFunc(s.setsPath+"/{setId}", s.handleSetByID)
-	mux.HandleFunc(s.setsPath+"/{setId}/{$}", s.redirectTrailingSlashToCanonicalPath)
+	if s.evalSetManager != nil {
+		// Register collection and item routes for evaluation sets.
+		mux.HandleFunc(s.setsPath, s.handleSets)
+		mux.HandleFunc(s.setsPath+"/{$}", s.redirectTrailingSlashToCanonicalPath)
+		mux.HandleFunc(s.setsPath+"/{setId}", s.handleSetByID)
+		mux.HandleFunc(s.setsPath+"/{setId}/{$}", s.redirectTrailingSlashToCanonicalPath)
+	}
+	if s.metricManager != nil {
+		// Register collection and item routes for evaluation metrics.
+		mux.HandleFunc(s.metricsPath, s.handleMetrics)
+		mux.HandleFunc(s.metricsPath+"/{$}", s.redirectTrailingSlashToCanonicalPath)
+		mux.HandleFunc(s.metricsPath+"/{metricName}", s.handleMetricByName)
+		mux.HandleFunc(s.metricsPath+"/{metricName}/{$}", s.redirectTrailingSlashToCanonicalPath)
+	}
 	// Register collection and item routes for evaluation runs.
 	mux.HandleFunc(s.runsPath, s.handleRuns)
 	mux.HandleFunc(s.runsPath+"/{$}", s.redirectTrailingSlashToCanonicalPath)
-	// Register collection and item routes for evaluation results.
-	mux.HandleFunc(s.resultsPath, s.handleResults)
-	mux.HandleFunc(s.resultsPath+"/{$}", s.redirectTrailingSlashToCanonicalPath)
-	mux.HandleFunc(s.resultsPath+"/{resultId}", s.handleResultByID)
-	mux.HandleFunc(s.resultsPath+"/{resultId}/{$}", s.redirectTrailingSlashToCanonicalPath)
+	if s.evalResultManager != nil {
+		// Register collection and item routes for evaluation results.
+		mux.HandleFunc(s.resultsPath, s.handleResults)
+		mux.HandleFunc(s.resultsPath+"/{$}", s.redirectTrailingSlashToCanonicalPath)
+		mux.HandleFunc(s.resultsPath+"/{resultId}", s.handleResultByID)
+		mux.HandleFunc(s.resultsPath+"/{resultId}/{$}", s.redirectTrailingSlashToCanonicalPath)
+	}
 	for _, registrar := range s.routeRegistrars {
 		if err := registrar.RegisterRoutes(mux, s); err != nil {
 			return fmt.Errorf("evaluation server: register extra routes: %w", err)
@@ -167,173 +186,9 @@ func joinURLPath(basePath, child string) (string, error) {
 	return url.JoinPath(basePath, child)
 }
 
-func (s *Server) handleSets(w http.ResponseWriter, r *http.Request) {
-	if r.Method == http.MethodOptions {
-		s.handleCORS(w)
-		return
-	}
-	if r.Method != http.MethodGet {
-		w.Header().Set(headerAllow, http.MethodGet)
-		s.respondJSON(w, r, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
-		return
-	}
-	sets, err := s.listEvalSets(r.Context())
-	if err != nil {
-		s.respondStatusError(w, r, err)
-		return
-	}
-	s.respondJSON(w, r, http.StatusOK, &ListSetsResponse{
-		Sets: sets,
-	})
-}
-
-func (s *Server) handleSetByID(w http.ResponseWriter, r *http.Request) {
-	if r.Method == http.MethodOptions {
-		s.handleCORS(w)
-		return
-	}
-	if r.Method != http.MethodGet {
-		w.Header().Set(headerAllow, http.MethodGet)
-		s.respondJSON(w, r, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
-		return
-	}
-	id := strings.TrimSpace(r.PathValue("setId"))
-	if id == "" {
-		s.respondJSON(w, r, http.StatusNotFound, map[string]string{"error": "not found"})
-		return
-	}
-	set, err := s.evalSetManager.Get(r.Context(), s.appName, id)
-	if err != nil {
-		s.respondStatusError(w, r, err)
-		return
-	}
-	s.respondJSON(w, r, http.StatusOK, &GetSetResponse{
-		Set: set,
-	})
-}
-
-func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
-	if r.Method == http.MethodOptions {
-		s.handleCORS(w)
-		return
-	}
-	if r.Method != http.MethodPost {
-		w.Header().Set(headerAllow, http.MethodPost)
-		s.respondJSON(w, r, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
-		return
-	}
-	s.handleCreateRun(w, r)
-}
-
-func (s *Server) handleCreateRun(w http.ResponseWriter, r *http.Request) {
-	req, err := s.decodeRunEvaluationRequest(w, r)
-	if err != nil {
-		return
-	}
-	ctx, cancel := newExecutionContext(r.Context(), s.timeout)
-	defer cancel()
-	result, err := s.runEvaluation(ctx, req)
-	if err != nil {
-		s.respondStatusError(w, r, err)
-		return
-	}
-	s.respondJSON(w, r, http.StatusCreated, &CreateRunResponse{
-		EvaluationResult: result,
-	})
-}
-
-func (s *Server) handleResults(w http.ResponseWriter, r *http.Request) {
-	if r.Method == http.MethodOptions {
-		s.handleCORS(w)
-		return
-	}
-	if r.Method != http.MethodGet {
-		w.Header().Set(headerAllow, http.MethodGet)
-		s.respondJSON(w, r, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
-		return
-	}
-	filterSetID := readSetIDFilter(r)
-	results, err := s.listEvalResults(r.Context(), filterSetID)
-	if err != nil {
-		s.respondStatusError(w, r, err)
-		return
-	}
-	s.respondJSON(w, r, http.StatusOK, &ListResultsResponse{
-		Results: results,
-	})
-}
-
-func (s *Server) handleResultByID(w http.ResponseWriter, r *http.Request) {
-	if r.Method == http.MethodOptions {
-		s.handleCORS(w)
-		return
-	}
-	if r.Method != http.MethodGet {
-		w.Header().Set(headerAllow, http.MethodGet)
-		s.respondJSON(w, r, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
-		return
-	}
-	id := strings.TrimSpace(r.PathValue("resultId"))
-	if id == "" {
-		s.respondJSON(w, r, http.StatusNotFound, map[string]string{"error": "not found"})
-		return
-	}
-	result, err := s.evalResultManager.Get(r.Context(), s.appName, id)
-	if err != nil {
-		s.respondStatusError(w, r, err)
-		return
-	}
-	s.respondJSON(w, r, http.StatusOK, &GetResultResponse{
-		Result: result,
-	})
-}
-
-func (s *Server) listEvalSets(ctx context.Context) ([]*evalset.EvalSet, error) {
-	ids, err := s.evalSetManager.List(ctx, s.appName)
-	if err != nil {
-		return nil, err
-	}
-	sets := make([]*evalset.EvalSet, 0, len(ids))
-	for _, id := range ids {
-		set, err := s.evalSetManager.Get(ctx, s.appName, id)
-		if err != nil {
-			return nil, err
-		}
-		sets = append(sets, set)
-	}
-	return sets, nil
-}
-
-func (s *Server) listEvalResults(ctx context.Context, filterSetID string) ([]*evalresult.EvalSetResult, error) {
-	ids, err := s.evalResultManager.List(ctx, s.appName)
-	if err != nil {
-		return nil, err
-	}
-	results := make([]*evalresult.EvalSetResult, 0, len(ids))
-	for _, id := range ids {
-		result, err := s.evalResultManager.Get(ctx, s.appName, id)
-		if err != nil {
-			return nil, err
-		}
-		if filterSetID != "" && result.EvalSetID != filterSetID {
-			continue
-		}
-		results = append(results, result)
-	}
-	return results, nil
-}
-
-func (s *Server) runEvaluation(ctx context.Context, req *RunEvaluationRequest) (*coreevaluation.EvaluationResult, error) {
-	evalOpts := make([]coreevaluation.Option, 0, 1)
-	if req.NumRuns != nil {
-		evalOpts = append(evalOpts, coreevaluation.WithNumRuns(*req.NumRuns))
-	}
-	return s.agentEvaluator.Evaluate(ctx, req.SetID, evalOpts...)
-}
-
 func (s *Server) handleCORS(w http.ResponseWriter) {
 	w.Header().Set(headerAccessControlOrigin, "*")
-	w.Header().Set(headerAccessControlMethods, strings.Join([]string{http.MethodGet, http.MethodPost, http.MethodOptions}, ", "))
+	w.Header().Set(headerAccessControlMethods, strings.Join([]string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodOptions}, ", "))
 	w.Header().Set(headerAccessControlHeaders, "Content-Type")
 	w.WriteHeader(http.StatusNoContent)
 }
@@ -412,14 +267,13 @@ func newExecutionContext(ctx context.Context, timeout time.Duration) (context.Co
 	return context.WithCancel(ctx)
 }
 
-func (s *Server) decodeRunEvaluationRequest(w http.ResponseWriter, r *http.Request) (*RunEvaluationRequest, error) {
+func (s *Server) decodeJSONRequestBody(w http.ResponseWriter, r *http.Request, dst any) error {
 	defer r.Body.Close()
-	var req RunEvaluationRequest
 	decoder := json.NewDecoder(r.Body)
 	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&req); err != nil {
+	if err := decoder.Decode(dst); err != nil {
 		s.respondJSON(w, r, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("invalid request body: %v", err)})
-		return nil, err
+		return err
 	}
 	extraErr := decoder.Decode(&struct{}{})
 	if extraErr != io.EOF {
@@ -427,24 +281,7 @@ func (s *Server) decodeRunEvaluationRequest(w http.ResponseWriter, r *http.Reque
 		if extraErr == nil {
 			extraErr = errors.New("request body must contain a single JSON object")
 		}
-		return nil, extraErr
-	}
-	if err := validateRunEvaluationRequest(&req); err != nil {
-		s.respondJSON(w, r, http.StatusBadRequest, map[string]string{"error": err.Error()})
-		return nil, err
-	}
-	return &req, nil
-}
-
-func validateRunEvaluationRequest(req *RunEvaluationRequest) error {
-	if req == nil {
-		return errors.New("request must not be nil")
-	}
-	if strings.TrimSpace(req.SetID) == "" {
-		return errors.New("setId must not be empty")
-	}
-	if req.NumRuns != nil && *req.NumRuns <= 0 {
-		return errors.New("numRuns must be greater than 0 when provided")
+		return extraErr
 	}
 	return nil
 }
@@ -460,8 +297,4 @@ func errorMessageFromError(err error) string {
 		return "not found"
 	}
 	return "internal server error"
-}
-
-func readSetIDFilter(r *http.Request) string {
-	return strings.TrimSpace(r.URL.Query().Get("setId"))
 }

--- a/server/evaluation/server_test.go
+++ b/server/evaluation/server_test.go
@@ -25,6 +25,7 @@ import (
 	coreevaluation "trpc.group/trpc-go/trpc-agent-go/evaluation"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/status"
 	agentlog "trpc.group/trpc-go/trpc-agent-go/log"
 )
@@ -158,6 +159,57 @@ func (f *fakeEvalResultManager) Close() error {
 	return nil
 }
 
+type fakeMetricManager struct {
+	list   func(ctx context.Context, appName, evalSetID string) ([]string, error)
+	get    func(ctx context.Context, appName, evalSetID, metricName string) (*metric.EvalMetric, error)
+	add    func(ctx context.Context, appName, evalSetID string, evalMetric *metric.EvalMetric) error
+	delete func(ctx context.Context, appName, evalSetID, metricName string) error
+	update func(ctx context.Context, appName, evalSetID string, evalMetric *metric.EvalMetric) error
+	close  func() error
+}
+
+func (f *fakeMetricManager) List(ctx context.Context, appName, evalSetID string) ([]string, error) {
+	if f.list != nil {
+		return f.list(ctx, appName, evalSetID)
+	}
+	return nil, errors.New("list is not configured")
+}
+
+func (f *fakeMetricManager) Get(ctx context.Context, appName, evalSetID, metricName string) (*metric.EvalMetric, error) {
+	if f.get != nil {
+		return f.get(ctx, appName, evalSetID, metricName)
+	}
+	return nil, errors.New("get is not configured")
+}
+
+func (f *fakeMetricManager) Add(ctx context.Context, appName, evalSetID string, evalMetric *metric.EvalMetric) error {
+	if f.add != nil {
+		return f.add(ctx, appName, evalSetID, evalMetric)
+	}
+	return errors.New("add is not configured")
+}
+
+func (f *fakeMetricManager) Delete(ctx context.Context, appName, evalSetID, metricName string) error {
+	if f.delete != nil {
+		return f.delete(ctx, appName, evalSetID, metricName)
+	}
+	return errors.New("delete is not configured")
+}
+
+func (f *fakeMetricManager) Update(ctx context.Context, appName, evalSetID string, evalMetric *metric.EvalMetric) error {
+	if f.update != nil {
+		return f.update(ctx, appName, evalSetID, evalMetric)
+	}
+	return errors.New("update is not configured")
+}
+
+func (f *fakeMetricManager) Close() error {
+	if f.close != nil {
+		return f.close()
+	}
+	return nil
+}
+
 type failingResponseWriter struct {
 	header     http.Header
 	statusCode int
@@ -240,6 +292,13 @@ func newTestEvalResult(evalSetResultID, evalSetID string, numRuns int) *evalresu
 	}
 }
 
+func newTestMetric(metricName string, threshold float64) *metric.EvalMetric {
+	return &metric.EvalMetric{
+		MetricName: metricName,
+		Threshold:  threshold,
+	}
+}
+
 func intPtr(v int) *int {
 	return &v
 }
@@ -270,6 +329,23 @@ func newTestServer(t *testing.T, opts ...Option) *Server {
 				return newTestEvalSet(evalSetID), nil
 			},
 		}),
+		WithMetricManager(&fakeMetricManager{
+			list: func(ctx context.Context, appName, evalSetID string) ([]string, error) {
+				return []string{}, nil
+			},
+			get: func(ctx context.Context, appName, evalSetID, metricName string) (*metric.EvalMetric, error) {
+				return newTestMetric(metricName, 1), nil
+			},
+			add: func(ctx context.Context, appName, evalSetID string, evalMetric *metric.EvalMetric) error {
+				return nil
+			},
+			update: func(ctx context.Context, appName, evalSetID string, evalMetric *metric.EvalMetric) error {
+				return nil
+			},
+			delete: func(ctx context.Context, appName, evalSetID, metricName string) error {
+				return nil
+			},
+		}),
 		WithEvalResultManager(&fakeEvalResultManager{
 			list: func(ctx context.Context, appName string) ([]string, error) {
 				return []string{}, nil
@@ -289,6 +365,7 @@ func TestNewValidation(t *testing.T) {
 	_, err := New(
 		WithAppName("demo-app"),
 		WithEvalSetManager(&fakeEvalSetManager{}),
+		WithMetricManager(&fakeMetricManager{}),
 		WithEvalResultManager(&fakeEvalResultManager{}),
 	)
 	require.Error(t, err)
@@ -300,11 +377,13 @@ func TestNewCustomPaths(t *testing.T) {
 		WithBasePath("/api/evaluation"),
 		WithRunsPath("/executions"),
 		WithSetsPath("/datasets"),
+		WithMetricsPath("/quality-metrics"),
 		WithResultsPath("/outputs"),
 	)
 	assert.Equal(t, "/api/evaluation", srv.BasePath())
 	assert.Equal(t, "/api/evaluation/executions", srv.RunsPath())
 	assert.Equal(t, "/api/evaluation/datasets", srv.SetsPath())
+	assert.Equal(t, "/api/evaluation/quality-metrics", srv.MetricsPath())
 	assert.Equal(t, "/api/evaluation/outputs", srv.ResultsPath())
 }
 
@@ -326,6 +405,7 @@ func TestNewPropagatesRouteRegistrarError(t *testing.T) {
 		WithAppName("demo-app"),
 		WithAgentEvaluator(&fakeAgentEvaluator{}),
 		WithEvalSetManager(&fakeEvalSetManager{}),
+		WithMetricManager(&fakeMetricManager{}),
 		WithEvalResultManager(&fakeEvalResultManager{}),
 		WithRouteRegistrar(&stubRouteRegistrar{register: func(mux *http.ServeMux, server *Server) error {
 			return errors.New("register failed")
@@ -340,6 +420,7 @@ func TestDefaultPathsAreRESTful(t *testing.T) {
 	srv := newTestServer(t)
 	assert.Equal(t, "/evaluation", srv.BasePath())
 	assert.Equal(t, "/evaluation/sets", srv.SetsPath())
+	assert.Equal(t, "/evaluation/metrics", srv.MetricsPath())
 	assert.Equal(t, "/evaluation/runs", srv.RunsPath())
 	assert.Equal(t, "/evaluation/results", srv.ResultsPath())
 }
@@ -349,28 +430,11 @@ func TestNewRejectsInvalidConfigAndNormalizesBasePath(t *testing.T) {
 		_, err := New(
 			WithAgentEvaluator(&fakeAgentEvaluator{}),
 			WithEvalSetManager(&fakeEvalSetManager{}),
+			WithMetricManager(&fakeMetricManager{}),
 			WithEvalResultManager(&fakeEvalResultManager{}),
 		)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "app name")
-	})
-	t.Run("missing eval set manager", func(t *testing.T) {
-		_, err := New(
-			WithAppName("demo-app"),
-			WithAgentEvaluator(&fakeAgentEvaluator{}),
-			WithEvalResultManager(&fakeEvalResultManager{}),
-		)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "eval set manager")
-	})
-	t.Run("missing eval result manager", func(t *testing.T) {
-		_, err := New(
-			WithAppName("demo-app"),
-			WithAgentEvaluator(&fakeAgentEvaluator{}),
-			WithEvalSetManager(&fakeEvalSetManager{}),
-		)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "eval result manager")
 	})
 	t.Run("normalize relative base path", func(t *testing.T) {
 		srv := newTestServer(t, WithBasePath("evaluation/"))
@@ -380,6 +444,120 @@ func TestNewRejectsInvalidConfigAndNormalizesBasePath(t *testing.T) {
 		srv := newTestServer(t, WithBasePath(" "))
 		assert.Equal(t, "/evaluation", srv.BasePath())
 	})
+}
+
+func TestNewAllowsNilMetricManagerAndSkipsMetricRoutes(t *testing.T) {
+	srv, err := New(
+		WithAppName("demo-app"),
+		WithAgentEvaluator(&fakeAgentEvaluator{
+			evaluate: func(ctx context.Context, evalSetID string, opt ...coreevaluation.Option) (*coreevaluation.EvaluationResult, error) {
+				return newTestEvaluationResult(evalSetID, "result-default", 1, time.Second), nil
+			},
+		}),
+		WithEvalSetManager(&fakeEvalSetManager{
+			list: func(ctx context.Context, appName string) ([]string, error) {
+				return []string{}, nil
+			},
+			get: func(ctx context.Context, appName, evalSetID string) (*evalset.EvalSet, error) {
+				return newTestEvalSet(evalSetID), nil
+			},
+		}),
+		WithEvalResultManager(&fakeEvalResultManager{
+			list: func(ctx context.Context, appName string) ([]string, error) {
+				return []string{}, nil
+			},
+			get: func(ctx context.Context, appName, evalSetResultID string) (*evalresult.EvalSetResult, error) {
+				return newTestEvalResult(evalSetResultID, "math-basic", 1), nil
+			},
+		}),
+	)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodGet, srv.MetricsPath()+"?setId=math-basic", nil)
+	recorder := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusNotFound, recorder.Code)
+}
+
+func TestNewAllowsNilEvalSetManagerAndSkipsSetRoutes(t *testing.T) {
+	srv, err := New(
+		WithAppName("demo-app"),
+		WithAgentEvaluator(&fakeAgentEvaluator{
+			evaluate: func(ctx context.Context, evalSetID string, opt ...coreevaluation.Option) (*coreevaluation.EvaluationResult, error) {
+				return newTestEvaluationResult(evalSetID, "result-default", 1, time.Second), nil
+			},
+		}),
+		WithMetricManager(&fakeMetricManager{
+			list: func(ctx context.Context, appName, evalSetID string) ([]string, error) {
+				return []string{}, nil
+			},
+			get: func(ctx context.Context, appName, evalSetID, metricName string) (*metric.EvalMetric, error) {
+				return newTestMetric(metricName, 1), nil
+			},
+			add: func(ctx context.Context, appName, evalSetID string, evalMetric *metric.EvalMetric) error {
+				return nil
+			},
+			update: func(ctx context.Context, appName, evalSetID string, evalMetric *metric.EvalMetric) error {
+				return nil
+			},
+			delete: func(ctx context.Context, appName, evalSetID, metricName string) error {
+				return nil
+			},
+		}),
+		WithEvalResultManager(&fakeEvalResultManager{
+			list: func(ctx context.Context, appName string) ([]string, error) {
+				return []string{}, nil
+			},
+			get: func(ctx context.Context, appName, evalSetResultID string) (*evalresult.EvalSetResult, error) {
+				return newTestEvalResult(evalSetResultID, "math-basic", 1), nil
+			},
+		}),
+	)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodGet, srv.SetsPath(), nil)
+	recorder := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusNotFound, recorder.Code)
+}
+
+func TestNewAllowsNilEvalResultManagerAndSkipsResultRoutes(t *testing.T) {
+	srv, err := New(
+		WithAppName("demo-app"),
+		WithAgentEvaluator(&fakeAgentEvaluator{
+			evaluate: func(ctx context.Context, evalSetID string, opt ...coreevaluation.Option) (*coreevaluation.EvaluationResult, error) {
+				return newTestEvaluationResult(evalSetID, "result-default", 1, time.Second), nil
+			},
+		}),
+		WithEvalSetManager(&fakeEvalSetManager{
+			list: func(ctx context.Context, appName string) ([]string, error) {
+				return []string{}, nil
+			},
+			get: func(ctx context.Context, appName, evalSetID string) (*evalset.EvalSet, error) {
+				return newTestEvalSet(evalSetID), nil
+			},
+		}),
+		WithMetricManager(&fakeMetricManager{
+			list: func(ctx context.Context, appName, evalSetID string) ([]string, error) {
+				return []string{}, nil
+			},
+			get: func(ctx context.Context, appName, evalSetID, metricName string) (*metric.EvalMetric, error) {
+				return newTestMetric(metricName, 1), nil
+			},
+			add: func(ctx context.Context, appName, evalSetID string, evalMetric *metric.EvalMetric) error {
+				return nil
+			},
+			update: func(ctx context.Context, appName, evalSetID string, evalMetric *metric.EvalMetric) error {
+				return nil
+			},
+			delete: func(ctx context.Context, appName, evalSetID, metricName string) error {
+				return nil
+			},
+		}),
+	)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodGet, srv.ResultsPath(), nil)
+	recorder := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusNotFound, recorder.Code)
 }
 
 func TestCloseReturnsNil(t *testing.T) {
@@ -494,6 +672,8 @@ func TestHandleOptionsRequests(t *testing.T) {
 	}{
 		{name: "sets", path: srv.SetsPath()},
 		{name: "set detail", path: srv.SetsPath() + "/math-basic"},
+		{name: "metrics", path: srv.MetricsPath()},
+		{name: "metric detail", path: srv.MetricsPath() + "/accuracy?setId=math-basic"},
 		{name: "runs", path: srv.RunsPath()},
 		{name: "runs trailing slash", path: srv.RunsPath() + "/"},
 		{name: "results", path: srv.ResultsPath()},
@@ -506,7 +686,7 @@ func TestHandleOptionsRequests(t *testing.T) {
 			srv.Handler().ServeHTTP(recorder, req)
 			require.Equal(t, http.StatusNoContent, recorder.Code)
 			assert.Equal(t, "*", recorder.Header().Get("Access-Control-Allow-Origin"))
-			assert.Equal(t, "GET, POST, OPTIONS", recorder.Header().Get("Access-Control-Allow-Methods"))
+			assert.Equal(t, "GET, POST, PUT, DELETE, OPTIONS", recorder.Header().Get("Access-Control-Allow-Methods"))
 			assert.Equal(t, "Content-Type", recorder.Header().Get("Access-Control-Allow-Headers"))
 		})
 	}
@@ -640,6 +820,410 @@ func TestHandleSetErrorsAndMethods(t *testing.T) {
 			},
 		}))
 		req := httptest.NewRequest(http.MethodGet, srv.SetsPath()+"/missing", nil)
+		recorder := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusNotFound, recorder.Code)
+		assert.JSONEq(t, `{"error":"not found"}`, recorder.Body.String())
+	})
+}
+
+func TestHandleMetricQueries(t *testing.T) {
+	srv := newTestServer(t, WithMetricManager(&fakeMetricManager{
+		list: func(ctx context.Context, appName, evalSetID string) ([]string, error) {
+			return []string{"accuracy", "groundedness"}, nil
+		},
+		get: func(ctx context.Context, appName, evalSetID, metricName string) (*metric.EvalMetric, error) {
+			switch metricName {
+			case "groundedness":
+				return newTestMetric("groundedness", 0.9), nil
+			default:
+				return newTestMetric(metricName, 0.8), nil
+			}
+		},
+	}))
+	t.Run("list", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, srv.MetricsPath()+"?setId=math-basic", nil)
+		recorder := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusOK, recorder.Code)
+		var resp ListMetricsResponse
+		require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &resp))
+		require.Len(t, resp.Metrics, 2)
+		assert.Equal(t, "accuracy", resp.Metrics[0].MetricName)
+		assert.Equal(t, 0.8, resp.Metrics[0].Threshold)
+		assert.Equal(t, "groundedness", resp.Metrics[1].MetricName)
+	})
+	t.Run("list redirects trailing slash", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, srv.MetricsPath()+"/?setId=math-basic", nil)
+		recorder := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusPermanentRedirect, recorder.Code)
+		assert.Equal(t, srv.MetricsPath()+"?setId=math-basic", recorder.Header().Get("Location"))
+	})
+	t.Run("detail", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, srv.MetricsPath()+"/accuracy?setId=math-basic", nil)
+		recorder := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusOK, recorder.Code)
+		var resp MetricResponse
+		require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &resp))
+		require.NotNil(t, resp.Metric)
+		assert.Equal(t, "accuracy", resp.Metric.MetricName)
+		assert.Equal(t, 0.8, resp.Metric.Threshold)
+	})
+	t.Run("detail redirects trailing slash", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, srv.MetricsPath()+"/accuracy/?setId=math-basic", nil)
+		recorder := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusPermanentRedirect, recorder.Code)
+		assert.Equal(t, srv.MetricsPath()+"/accuracy?setId=math-basic", recorder.Header().Get("Location"))
+	})
+	t.Run("detail with escaped slash", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, srv.MetricsPath()+"/acc%2Furacy?setId=math-basic", nil)
+		recorder := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusOK, recorder.Code)
+		var resp MetricResponse
+		require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &resp))
+		require.NotNil(t, resp.Metric)
+		assert.Equal(t, "acc/uracy", resp.Metric.MetricName)
+	})
+	t.Run("detail rejects additional segments", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, srv.MetricsPath()+"/accuracy/extra?setId=math-basic", nil)
+		recorder := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusNotFound, recorder.Code)
+	})
+}
+
+func TestHandleMetricWrites(t *testing.T) {
+	t.Run("create", func(t *testing.T) {
+		var gotSetID string
+		var gotMetric *metric.EvalMetric
+		getCalls := 0
+		srv := newTestServer(t, WithMetricManager(&fakeMetricManager{
+			add: func(ctx context.Context, appName, evalSetID string, evalMetric *metric.EvalMetric) error {
+				gotSetID = evalSetID
+				gotMetric = evalMetric
+				return nil
+			},
+			get: func(ctx context.Context, appName, evalSetID, metricName string) (*metric.EvalMetric, error) {
+				getCalls++
+				if getCalls == 1 {
+					return nil, os.ErrNotExist
+				}
+				return newTestMetric(metricName, 0.75), nil
+			},
+			list: func(ctx context.Context, appName, evalSetID string) ([]string, error) {
+				return []string{}, nil
+			},
+			update: func(ctx context.Context, appName, evalSetID string, evalMetric *metric.EvalMetric) error {
+				return nil
+			},
+			delete: func(ctx context.Context, appName, evalSetID, metricName string) error {
+				return nil
+			},
+		}))
+		req := httptest.NewRequest(http.MethodPost, srv.MetricsPath(), bytes.NewBufferString(`{"setId":"math-basic","metric":{"metricName":"accuracy","threshold":0.75}}`))
+		recorder := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusCreated, recorder.Code)
+		require.NotNil(t, gotMetric)
+		assert.Equal(t, "math-basic", gotSetID)
+		assert.Equal(t, "accuracy", gotMetric.MetricName)
+		assert.Equal(t, 0.75, gotMetric.Threshold)
+		assert.Equal(t, 2, getCalls)
+		var resp MetricResponse
+		require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &resp))
+		require.NotNil(t, resp.Metric)
+		assert.Equal(t, "accuracy", resp.Metric.MetricName)
+	})
+	t.Run("update fills metric name from path", func(t *testing.T) {
+		var gotMetric *metric.EvalMetric
+		srv := newTestServer(t, WithMetricManager(&fakeMetricManager{
+			list: func(ctx context.Context, appName, evalSetID string) ([]string, error) {
+				return []string{}, nil
+			},
+			get: func(ctx context.Context, appName, evalSetID, metricName string) (*metric.EvalMetric, error) {
+				return newTestMetric(metricName, 0.91), nil
+			},
+			add: func(ctx context.Context, appName, evalSetID string, evalMetric *metric.EvalMetric) error {
+				return nil
+			},
+			update: func(ctx context.Context, appName, evalSetID string, evalMetric *metric.EvalMetric) error {
+				gotMetric = evalMetric
+				return nil
+			},
+			delete: func(ctx context.Context, appName, evalSetID, metricName string) error {
+				return nil
+			},
+		}))
+		req := httptest.NewRequest(http.MethodPut, srv.MetricsPath()+"/accuracy", bytes.NewBufferString(`{"setId":"math-basic","metric":{"threshold":0.91}}`))
+		recorder := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusOK, recorder.Code)
+		require.NotNil(t, gotMetric)
+		assert.Equal(t, "accuracy", gotMetric.MetricName)
+		assert.Equal(t, 0.91, gotMetric.Threshold)
+		var resp MetricResponse
+		require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &resp))
+		require.NotNil(t, resp.Metric)
+		assert.Equal(t, "accuracy", resp.Metric.MetricName)
+		assert.Equal(t, 0.91, resp.Metric.Threshold)
+	})
+	t.Run("delete", func(t *testing.T) {
+		var gotSetID string
+		var gotMetricName string
+		srv := newTestServer(t, WithMetricManager(&fakeMetricManager{
+			list: func(ctx context.Context, appName, evalSetID string) ([]string, error) {
+				return []string{}, nil
+			},
+			get: func(ctx context.Context, appName, evalSetID, metricName string) (*metric.EvalMetric, error) {
+				return newTestMetric(metricName, 1), nil
+			},
+			add: func(ctx context.Context, appName, evalSetID string, evalMetric *metric.EvalMetric) error {
+				return nil
+			},
+			update: func(ctx context.Context, appName, evalSetID string, evalMetric *metric.EvalMetric) error {
+				return nil
+			},
+			delete: func(ctx context.Context, appName, evalSetID, metricName string) error {
+				gotSetID = evalSetID
+				gotMetricName = metricName
+				return nil
+			},
+		}))
+		req := httptest.NewRequest(http.MethodDelete, srv.MetricsPath()+"/accuracy?setId=math-basic", nil)
+		recorder := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusNoContent, recorder.Code)
+		assert.Equal(t, "math-basic", gotSetID)
+		assert.Equal(t, "accuracy", gotMetricName)
+		assert.Empty(t, recorder.Body.String())
+	})
+}
+
+func TestHandleMetricErrorsAndMethods(t *testing.T) {
+	t.Run("collection rejects unsupported method", func(t *testing.T) {
+		srv := newTestServer(t)
+		req := httptest.NewRequest(http.MethodPut, srv.MetricsPath(), nil)
+		recorder := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusMethodNotAllowed, recorder.Code)
+		assert.Equal(t, "GET, POST", recorder.Header().Get("Allow"))
+	})
+	t.Run("item rejects unsupported method", func(t *testing.T) {
+		srv := newTestServer(t)
+		req := httptest.NewRequest(http.MethodPost, srv.MetricsPath()+"/accuracy?setId=math-basic", nil)
+		recorder := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusMethodNotAllowed, recorder.Code)
+		assert.Equal(t, "GET, PUT, DELETE", recorder.Header().Get("Allow"))
+	})
+	t.Run("list requires set id", func(t *testing.T) {
+		srv := newTestServer(t)
+		req := httptest.NewRequest(http.MethodGet, srv.MetricsPath(), nil)
+		recorder := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.JSONEq(t, `{"error":"setId must not be empty"}`, recorder.Body.String())
+	})
+	t.Run("list returns internal error when list fails", func(t *testing.T) {
+		srv := newTestServer(t, WithMetricManager(&fakeMetricManager{
+			list: func(ctx context.Context, appName, evalSetID string) ([]string, error) {
+				return nil, errors.New("list failed")
+			},
+			get: func(ctx context.Context, appName, evalSetID, metricName string) (*metric.EvalMetric, error) {
+				return newTestMetric(metricName, 1), nil
+			},
+			add: func(ctx context.Context, appName, evalSetID string, evalMetric *metric.EvalMetric) error {
+				return nil
+			},
+			update: func(ctx context.Context, appName, evalSetID string, evalMetric *metric.EvalMetric) error {
+				return nil
+			},
+			delete: func(ctx context.Context, appName, evalSetID, metricName string) error {
+				return nil
+			},
+		}))
+		req := httptest.NewRequest(http.MethodGet, srv.MetricsPath()+"?setId=math-basic", nil)
+		recorder := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusInternalServerError, recorder.Code)
+		assert.JSONEq(t, `{"error":"internal server error"}`, recorder.Body.String())
+	})
+	t.Run("detail requires set id", func(t *testing.T) {
+		srv := newTestServer(t)
+		req := httptest.NewRequest(http.MethodGet, srv.MetricsPath()+"/accuracy", nil)
+		recorder := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.JSONEq(t, `{"error":"setId must not be empty"}`, recorder.Body.String())
+	})
+	t.Run("detail rejects blank metric name", func(t *testing.T) {
+		srv := newTestServer(t)
+		req := httptest.NewRequest(http.MethodGet, srv.MetricsPath()+"/%20?setId=math-basic", nil)
+		recorder := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusNotFound, recorder.Code)
+		assert.JSONEq(t, `{"error":"not found"}`, recorder.Body.String())
+	})
+	t.Run("detail returns not found", func(t *testing.T) {
+		srv := newTestServer(t, WithMetricManager(&fakeMetricManager{
+			list: func(ctx context.Context, appName, evalSetID string) ([]string, error) {
+				return []string{}, nil
+			},
+			get: func(ctx context.Context, appName, evalSetID, metricName string) (*metric.EvalMetric, error) {
+				return nil, os.ErrNotExist
+			},
+			add: func(ctx context.Context, appName, evalSetID string, evalMetric *metric.EvalMetric) error {
+				return nil
+			},
+			update: func(ctx context.Context, appName, evalSetID string, evalMetric *metric.EvalMetric) error {
+				return nil
+			},
+			delete: func(ctx context.Context, appName, evalSetID, metricName string) error {
+				return nil
+			},
+		}))
+		req := httptest.NewRequest(http.MethodGet, srv.MetricsPath()+"/missing?setId=math-basic", nil)
+		recorder := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusNotFound, recorder.Code)
+		assert.JSONEq(t, `{"error":"not found"}`, recorder.Body.String())
+	})
+	t.Run("create rejects unknown fields", func(t *testing.T) {
+		srv := newTestServer(t)
+		req := httptest.NewRequest(http.MethodPost, srv.MetricsPath(), bytes.NewBufferString(`{"setId":"math-basic","unexpected":true}`))
+		recorder := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), "unknown field")
+	})
+	t.Run("create validates metric payload", func(t *testing.T) {
+		srv := newTestServer(t)
+		req := httptest.NewRequest(http.MethodPost, srv.MetricsPath(), bytes.NewBufferString(`{"setId":"math-basic"}`))
+		recorder := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.JSONEq(t, `{"error":"metric must not be nil"}`, recorder.Body.String())
+	})
+	t.Run("create returns conflict when metric exists", func(t *testing.T) {
+		addCalled := false
+		srv := newTestServer(t, WithMetricManager(&fakeMetricManager{
+			list: func(ctx context.Context, appName, evalSetID string) ([]string, error) {
+				return []string{}, nil
+			},
+			get: func(ctx context.Context, appName, evalSetID, metricName string) (*metric.EvalMetric, error) {
+				return newTestMetric(metricName, 1), nil
+			},
+			add: func(ctx context.Context, appName, evalSetID string, evalMetric *metric.EvalMetric) error {
+				addCalled = true
+				return nil
+			},
+			update: func(ctx context.Context, appName, evalSetID string, evalMetric *metric.EvalMetric) error {
+				return nil
+			},
+			delete: func(ctx context.Context, appName, evalSetID, metricName string) error {
+				return nil
+			},
+		}))
+		req := httptest.NewRequest(http.MethodPost, srv.MetricsPath(), bytes.NewBufferString(`{"setId":"math-basic","metric":{"metricName":"accuracy","threshold":0.8}}`))
+		recorder := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusConflict, recorder.Code)
+		assert.JSONEq(t, `{"error":"already exists"}`, recorder.Body.String())
+		assert.False(t, addCalled)
+	})
+	t.Run("create returns conflict when add loses race", func(t *testing.T) {
+		getCalls := 0
+		srv := newTestServer(t, WithMetricManager(&fakeMetricManager{
+			list: func(ctx context.Context, appName, evalSetID string) ([]string, error) {
+				return []string{}, nil
+			},
+			get: func(ctx context.Context, appName, evalSetID, metricName string) (*metric.EvalMetric, error) {
+				getCalls++
+				if getCalls == 1 {
+					return nil, os.ErrNotExist
+				}
+				return newTestMetric(metricName, 1), nil
+			},
+			add: func(ctx context.Context, appName, evalSetID string, evalMetric *metric.EvalMetric) error {
+				return errors.New("duplicate key")
+			},
+			update: func(ctx context.Context, appName, evalSetID string, evalMetric *metric.EvalMetric) error {
+				return nil
+			},
+			delete: func(ctx context.Context, appName, evalSetID, metricName string) error {
+				return nil
+			},
+		}))
+		req := httptest.NewRequest(http.MethodPost, srv.MetricsPath(), bytes.NewBufferString(`{"setId":"math-basic","metric":{"metricName":"accuracy","threshold":0.8}}`))
+		recorder := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusConflict, recorder.Code)
+		assert.JSONEq(t, `{"error":"already exists"}`, recorder.Body.String())
+		assert.Equal(t, 2, getCalls)
+	})
+	t.Run("update rejects mismatched metric name", func(t *testing.T) {
+		srv := newTestServer(t)
+		req := httptest.NewRequest(http.MethodPut, srv.MetricsPath()+"/accuracy", bytes.NewBufferString(`{"setId":"math-basic","metric":{"metricName":"groundedness","threshold":0.8}}`))
+		recorder := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.JSONEq(t, `{"error":"metric.metricName must match path metricName when provided"}`, recorder.Body.String())
+	})
+	t.Run("update returns not found", func(t *testing.T) {
+		srv := newTestServer(t, WithMetricManager(&fakeMetricManager{
+			list: func(ctx context.Context, appName, evalSetID string) ([]string, error) {
+				return []string{}, nil
+			},
+			get: func(ctx context.Context, appName, evalSetID, metricName string) (*metric.EvalMetric, error) {
+				return nil, os.ErrNotExist
+			},
+			add: func(ctx context.Context, appName, evalSetID string, evalMetric *metric.EvalMetric) error {
+				return nil
+			},
+			update: func(ctx context.Context, appName, evalSetID string, evalMetric *metric.EvalMetric) error {
+				return os.ErrNotExist
+			},
+			delete: func(ctx context.Context, appName, evalSetID, metricName string) error {
+				return nil
+			},
+		}))
+		req := httptest.NewRequest(http.MethodPut, srv.MetricsPath()+"/accuracy", bytes.NewBufferString(`{"setId":"math-basic","metric":{"threshold":0.8}}`))
+		recorder := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusNotFound, recorder.Code)
+		assert.JSONEq(t, `{"error":"not found"}`, recorder.Body.String())
+	})
+	t.Run("delete requires set id", func(t *testing.T) {
+		srv := newTestServer(t)
+		req := httptest.NewRequest(http.MethodDelete, srv.MetricsPath()+"/accuracy", nil)
+		recorder := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.JSONEq(t, `{"error":"setId must not be empty"}`, recorder.Body.String())
+	})
+	t.Run("delete returns not found", func(t *testing.T) {
+		srv := newTestServer(t, WithMetricManager(&fakeMetricManager{
+			list: func(ctx context.Context, appName, evalSetID string) ([]string, error) {
+				return []string{}, nil
+			},
+			get: func(ctx context.Context, appName, evalSetID, metricName string) (*metric.EvalMetric, error) {
+				return newTestMetric(metricName, 1), nil
+			},
+			add: func(ctx context.Context, appName, evalSetID string, evalMetric *metric.EvalMetric) error {
+				return nil
+			},
+			update: func(ctx context.Context, appName, evalSetID string, evalMetric *metric.EvalMetric) error {
+				return nil
+			},
+			delete: func(ctx context.Context, appName, evalSetID, metricName string) error {
+				return os.ErrNotExist
+			},
+		}))
+		req := httptest.NewRequest(http.MethodDelete, srv.MetricsPath()+"/accuracy?setId=math-basic", nil)
 		recorder := httptest.NewRecorder()
 		srv.Handler().ServeHTTP(recorder, req)
 		require.Equal(t, http.StatusNotFound, recorder.Code)
@@ -902,4 +1486,47 @@ func TestValidateRunEvaluationRequest(t *testing.T) {
 	require.EqualError(t, validateRunEvaluationRequest(&RunEvaluationRequest{SetID: "   "}), "setId must not be empty")
 	require.EqualError(t, validateRunEvaluationRequest(&RunEvaluationRequest{SetID: "math-basic", NumRuns: intPtr(-1)}), "numRuns must be greater than 0 when provided")
 	assert.NoError(t, validateRunEvaluationRequest(&RunEvaluationRequest{SetID: "math-basic"}))
+}
+
+func TestValidateCreateMetricRequest(t *testing.T) {
+	require.EqualError(t, validateCreateMetricRequest(nil), "request must not be nil")
+	require.EqualError(t, validateCreateMetricRequest(&CreateMetricRequest{SetID: "   "}), "setId must not be empty")
+	require.EqualError(t, validateCreateMetricRequest(&CreateMetricRequest{SetID: "math-basic"}), "metric must not be nil")
+	require.EqualError(t, validateCreateMetricRequest(&CreateMetricRequest{
+		SetID:  "math-basic",
+		Metric: &metric.EvalMetric{MetricName: "   "},
+	}), "metric.metricName must not be empty")
+	req := &CreateMetricRequest{
+		SetID:  " math-basic ",
+		Metric: &metric.EvalMetric{MetricName: " accuracy ", Threshold: 0.8},
+	}
+	require.NoError(t, validateCreateMetricRequest(req))
+	assert.Equal(t, "math-basic", req.SetID)
+	assert.Equal(t, "accuracy", req.Metric.MetricName)
+}
+
+func TestValidateUpdateMetricRequest(t *testing.T) {
+	require.EqualError(t, validateUpdateMetricRequest(nil), "request must not be nil")
+	require.EqualError(t, validateUpdateMetricRequest(&UpdateMetricRequest{SetID: "   "}), "setId must not be empty")
+	require.EqualError(t, validateUpdateMetricRequest(&UpdateMetricRequest{SetID: "math-basic"}), "metric must not be nil")
+	require.EqualError(t, validateUpdateMetricRequest(&UpdateMetricRequest{
+		SetID:  "math-basic",
+		Metric: &metric.EvalMetric{MetricName: "   "},
+	}), "metric.metricName must not be empty")
+	req := &UpdateMetricRequest{
+		SetID:  " math-basic ",
+		Metric: &metric.EvalMetric{MetricName: " accuracy ", Threshold: 0.8},
+	}
+	require.NoError(t, validateUpdateMetricRequest(req))
+	assert.Equal(t, "math-basic", req.SetID)
+	assert.Equal(t, "accuracy", req.Metric.MetricName)
+}
+
+func TestApplyMetricNameFromPath(t *testing.T) {
+	require.NoError(t, applyMetricNameFromPath(nil, "accuracy"))
+	evalMetric := &metric.EvalMetric{}
+	require.NoError(t, applyMetricNameFromPath(evalMetric, "accuracy"))
+	assert.Equal(t, "accuracy", evalMetric.MetricName)
+	require.NoError(t, applyMetricNameFromPath(&metric.EvalMetric{MetricName: "accuracy"}, "accuracy"))
+	require.EqualError(t, applyMetricNameFromPath(&metric.EvalMetric{MetricName: "groundedness"}, "accuracy"), "metric.metricName must match path metricName when provided")
 }

--- a/server/evaluation/server_test.go
+++ b/server/evaluation/server_test.go
@@ -651,6 +651,21 @@ func TestHandleCreateRunTimeoutReturnsGatewayTimeout(t *testing.T) {
 	assert.JSONEq(t, `{"error":"evaluation timed out"}`, recorder.Body.String())
 }
 
+func TestHandleCreateRunTrimsSetIDBeforeEvaluate(t *testing.T) {
+	var gotSetID string
+	srv := newTestServer(t, WithAgentEvaluator(&fakeAgentEvaluator{
+		evaluate: func(ctx context.Context, evalSetID string, opt ...coreevaluation.Option) (*coreevaluation.EvaluationResult, error) {
+			gotSetID = evalSetID
+			return newTestEvaluationResult(evalSetID, "result-default", 1, time.Second), nil
+		},
+	}))
+	req := httptest.NewRequest(http.MethodPost, srv.RunsPath(), bytes.NewBufferString(`{"setId":" math-basic "}`))
+	recorder := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(recorder, req)
+	require.Equal(t, http.StatusCreated, recorder.Code)
+	assert.Equal(t, "math-basic", gotSetID)
+}
+
 func TestHandleRunsRejectsReadRequests(t *testing.T) {
 	srv := newTestServer(t)
 	req := httptest.NewRequest(http.MethodGet, srv.RunsPath(), nil)
@@ -1485,7 +1500,9 @@ func TestValidateRunEvaluationRequest(t *testing.T) {
 	require.EqualError(t, validateRunEvaluationRequest(nil), "request must not be nil")
 	require.EqualError(t, validateRunEvaluationRequest(&RunEvaluationRequest{SetID: "   "}), "setId must not be empty")
 	require.EqualError(t, validateRunEvaluationRequest(&RunEvaluationRequest{SetID: "math-basic", NumRuns: intPtr(-1)}), "numRuns must be greater than 0 when provided")
-	assert.NoError(t, validateRunEvaluationRequest(&RunEvaluationRequest{SetID: "math-basic"}))
+	req := &RunEvaluationRequest{SetID: " math-basic "}
+	require.NoError(t, validateRunEvaluationRequest(req))
+	assert.Equal(t, "math-basic", req.SetID)
 }
 
 func TestValidateCreateMetricRequest(t *testing.T) {

--- a/server/evaluation/sets.go
+++ b/server/evaluation/sets.go
@@ -1,0 +1,78 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package evaluation
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
+)
+
+func (s *Server) handleSets(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions {
+		s.handleCORS(w)
+		return
+	}
+	if r.Method != http.MethodGet {
+		w.Header().Set(headerAllow, http.MethodGet)
+		s.respondJSON(w, r, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+	sets, err := s.listEvalSets(r.Context())
+	if err != nil {
+		s.respondStatusError(w, r, err)
+		return
+	}
+	s.respondJSON(w, r, http.StatusOK, &ListSetsResponse{
+		Sets: sets,
+	})
+}
+
+func (s *Server) handleSetByID(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions {
+		s.handleCORS(w)
+		return
+	}
+	if r.Method != http.MethodGet {
+		w.Header().Set(headerAllow, http.MethodGet)
+		s.respondJSON(w, r, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+	id := strings.TrimSpace(r.PathValue("setId"))
+	if id == "" {
+		s.respondJSON(w, r, http.StatusNotFound, map[string]string{"error": "not found"})
+		return
+	}
+	set, err := s.evalSetManager.Get(r.Context(), s.appName, id)
+	if err != nil {
+		s.respondStatusError(w, r, err)
+		return
+	}
+	s.respondJSON(w, r, http.StatusOK, &GetSetResponse{
+		Set: set,
+	})
+}
+
+func (s *Server) listEvalSets(ctx context.Context) ([]*evalset.EvalSet, error) {
+	ids, err := s.evalSetManager.List(ctx, s.appName)
+	if err != nil {
+		return nil, err
+	}
+	sets := make([]*evalset.EvalSet, 0, len(ids))
+	for _, id := range ids {
+		set, err := s.evalSetManager.Get(ctx, s.appName, id)
+		if err != nil {
+			return nil, err
+		}
+		sets = append(sets, set)
+	}
+	return sets, nil
+}

--- a/server/evaluation/types.go
+++ b/server/evaluation/types.go
@@ -12,6 +12,7 @@ import (
 	coreevaluation "trpc.group/trpc-go/trpc-agent-go/evaluation"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
 )
 
 // RunEvaluationRequest represents the request payload for creating an evaluation run.
@@ -28,6 +29,28 @@ type ListSetsResponse struct {
 // GetSetResponse represents the response payload for getting a set.
 type GetSetResponse struct {
 	Set *evalset.EvalSet `json:"set,omitempty"`
+}
+
+// CreateMetricRequest represents the request payload for creating a metric.
+type CreateMetricRequest struct {
+	SetID  string             `json:"setId,omitempty"`
+	Metric *metric.EvalMetric `json:"metric,omitempty"`
+}
+
+// UpdateMetricRequest represents the request payload for updating a metric.
+type UpdateMetricRequest struct {
+	SetID  string             `json:"setId,omitempty"`
+	Metric *metric.EvalMetric `json:"metric,omitempty"`
+}
+
+// ListMetricsResponse represents the response payload for listing metrics.
+type ListMetricsResponse struct {
+	Metrics []*metric.EvalMetric `json:"metrics,omitempty"`
+}
+
+// MetricResponse represents the response payload for getting or writing a metric.
+type MetricResponse struct {
+	Metric *metric.EvalMetric `json:"metric,omitempty"`
 }
 
 // CreateRunResponse represents the response payload for creating a run.


### PR DESCRIPTION
Add top-level metric endpoints to the evaluation server, move set/result/run/metric handlers into resource-specific files, keep set/metric/result routes optional when their managers are not configured, and update the OpenAPI schema and example wiring to match the new metric request and response types.