### PR TITLE
runner: support one-shot await_user_reply routing

### DIFF
--- a/agent/await_user_reply.go
+++ b/agent/await_user_reply.go
@@ -1,0 +1,169 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package agent
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/log"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+const (
+	awaitUserReplyInvocationStateKey = "__await_user_reply_route__"
+	awaitUserReplySessionStateKey    = "__trpc_agent_await_user_reply_route__"
+	awaitUserReplyEventExtensionKey  = "trpc_agent.await_user_reply_route"
+)
+
+// AwaitUserReplyRoute describes which agent should receive the next user turn.
+//
+// Runner consumes this route once when await-user-reply routing is enabled.
+type AwaitUserReplyRoute struct {
+	// AgentName is the target agent that should resume on the next user turn.
+	AgentName string `json:"agent_name"`
+}
+
+// MarkAwaitingUserReply marks the current invocation so its next terminal
+// response persists a one-shot "resume here on the next user reply" route.
+func MarkAwaitingUserReply(inv *Invocation) error {
+	if inv == nil {
+		return errors.New("invocation is nil")
+	}
+	route, err := normalizeAwaitUserReplyRoute(
+		AwaitUserReplyRoute{AgentName: inv.AgentName},
+	)
+	if err != nil {
+		return err
+	}
+	inv.SetState(awaitUserReplyInvocationStateKey, route)
+	return nil
+}
+
+// CurrentAwaitUserReplyRoute returns the route currently staged on an
+// invocation by MarkAwaitingUserReply.
+func CurrentAwaitUserReplyRoute(
+	inv *Invocation,
+) (AwaitUserReplyRoute, bool) {
+	route, ok := GetStateValue[AwaitUserReplyRoute](
+		inv,
+		awaitUserReplyInvocationStateKey,
+	)
+	if !ok {
+		return AwaitUserReplyRoute{}, false
+	}
+	normalized, err := normalizeAwaitUserReplyRoute(route)
+	if err != nil {
+		return AwaitUserReplyRoute{}, false
+	}
+	return normalized, true
+}
+
+// PendingAwaitUserReplyRoute reads a persisted next-user-turn route from the
+// session state.
+func PendingAwaitUserReplyRoute(
+	sess *session.Session,
+) (AwaitUserReplyRoute, bool, error) {
+	if sess == nil {
+		return AwaitUserReplyRoute{}, false, nil
+	}
+	raw, ok := sess.GetState(awaitUserReplySessionStateKey)
+	if !ok || len(raw) == 0 {
+		return AwaitUserReplyRoute{}, false, nil
+	}
+	var route AwaitUserReplyRoute
+	if err := json.Unmarshal(raw, &route); err != nil {
+		return AwaitUserReplyRoute{}, false, err
+	}
+	normalized, err := normalizeAwaitUserReplyRoute(route)
+	if err != nil {
+		return AwaitUserReplyRoute{}, false, err
+	}
+	return normalized, true, nil
+}
+
+// ClearAwaitUserReplyRouteState returns the session update that clears the
+// pending next-user-turn route.
+func ClearAwaitUserReplyRouteState() session.StateMap {
+	return session.StateMap{
+		awaitUserReplySessionStateKey: nil,
+	}
+}
+
+// State encodes the route into session state.
+func (r AwaitUserReplyRoute) State() (session.StateMap, error) {
+	normalized, err := normalizeAwaitUserReplyRoute(r)
+	if err != nil {
+		return nil, err
+	}
+	raw, err := json.Marshal(normalized)
+	if err != nil {
+		return nil, err
+	}
+	return session.StateMap{
+		awaitUserReplySessionStateKey: raw,
+	}, nil
+}
+
+// AttachEvent stores the route in one event's state delta and extensions.
+func (r AwaitUserReplyRoute) AttachEvent(evt *event.Event) error {
+	if evt == nil {
+		return nil
+	}
+	state, err := r.State()
+	if err != nil {
+		return err
+	}
+	if evt.StateDelta == nil {
+		evt.StateDelta = make(map[string][]byte, len(state))
+	}
+	for key, value := range state {
+		evt.StateDelta[key] = value
+	}
+	return event.SetExtension(
+		evt,
+		awaitUserReplyEventExtensionKey,
+		r,
+	)
+}
+
+func attachAwaitUserReplyRoute(inv *Invocation, evt *event.Event) {
+	if inv == nil || evt == nil || evt.Response == nil {
+		return
+	}
+	if evt.Response.IsPartial || !evt.Response.Done || evt.IsError() {
+		return
+	}
+	route, ok := CurrentAwaitUserReplyRoute(inv)
+	if !ok {
+		return
+	}
+	if err := route.AttachEvent(evt); err != nil {
+		log.Warnf(
+			"attach await_user_reply route failed for agent %q: %v",
+			inv.AgentName,
+			err,
+		)
+	}
+}
+
+func normalizeAwaitUserReplyRoute(
+	route AwaitUserReplyRoute,
+) (AwaitUserReplyRoute, error) {
+	route.AgentName = strings.TrimSpace(route.AgentName)
+	if route.AgentName == "" {
+		return AwaitUserReplyRoute{}, errors.New(
+			"await_user_reply requires a non-empty agent name",
+		)
+	}
+	return route, nil
+}

--- a/agent/await_user_reply.go
+++ b/agent/await_user_reply.go
@@ -23,14 +23,19 @@ const (
 	awaitUserReplyInvocationStateKey = "__await_user_reply_route__"
 	awaitUserReplySessionStateKey    = "__trpc_agent_await_user_reply_route__"
 	awaitUserReplyEventExtensionKey  = "trpc_agent.await_user_reply_route"
+	awaitUserReplyRootLookupStateKey = "__await_user_reply_root_lookup__"
 )
 
-// AwaitUserReplyRoute describes which agent should receive the next user turn.
+// AwaitUserReplyRoute describes the target of the next user turn.
 //
 // Runner consumes this route once when await-user-reply routing is enabled.
 type AwaitUserReplyRoute struct {
 	// AgentName is the target agent that should resume on the next user turn.
 	AgentName string `json:"agent_name"`
+	// LookupPath is the stable agent path Runner uses to resolve the target.
+	// The first segment is the root agent lookup key. Remaining segments are
+	// sub-agent names along the invocation branch.
+	LookupPath string `json:"lookup_path,omitempty"`
 }
 
 // MarkAwaitingUserReply marks the current invocation so its next terminal
@@ -40,7 +45,10 @@ func MarkAwaitingUserReply(inv *Invocation) error {
 		return errors.New("invocation is nil")
 	}
 	route, err := normalizeAwaitUserReplyRoute(
-		AwaitUserReplyRoute{AgentName: inv.AgentName},
+		AwaitUserReplyRoute{
+			AgentName:  inv.AgentName,
+			LookupPath: buildAwaitUserReplyLookupPath(inv),
+		},
 	)
 	if err != nil {
 		return err
@@ -89,6 +97,20 @@ func PendingAwaitUserReplyRoute(
 		return AwaitUserReplyRoute{}, false, err
 	}
 	return normalized, true, nil
+}
+
+// SetAwaitUserReplyRootLookupName stores the stable root lookup key used to
+// resume the current invocation branch on the next user turn.
+func SetAwaitUserReplyRootLookupName(inv *Invocation, name string) {
+	if inv == nil {
+		return
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		inv.DeleteState(awaitUserReplyRootLookupStateKey)
+		return
+	}
+	inv.SetState(awaitUserReplyRootLookupStateKey, name)
 }
 
 // ClearAwaitUserReplyRouteState returns the session update that clears the
@@ -160,10 +182,65 @@ func normalizeAwaitUserReplyRoute(
 	route AwaitUserReplyRoute,
 ) (AwaitUserReplyRoute, error) {
 	route.AgentName = strings.TrimSpace(route.AgentName)
+	route.LookupPath = normalizeAwaitUserReplyPath(route.LookupPath)
+	if route.LookupPath == "" {
+		route.LookupPath = route.AgentName
+	}
 	if route.AgentName == "" {
+		segments := splitAwaitUserReplyPath(route.LookupPath)
+		if len(segments) > 0 {
+			route.AgentName = segments[len(segments)-1]
+		}
+	}
+	if route.AgentName == "" || route.LookupPath == "" {
 		return AwaitUserReplyRoute{}, errors.New(
-			"await_user_reply requires a non-empty agent name",
+			"await_user_reply requires a non-empty agent target",
 		)
 	}
 	return route, nil
+}
+
+func buildAwaitUserReplyLookupPath(inv *Invocation) string {
+	if inv == nil {
+		return ""
+	}
+	branch := normalizeAwaitUserReplyPath(inv.Branch)
+	if branch == "" {
+		branch = strings.TrimSpace(inv.AgentName)
+	}
+	rootLookupName, _ := GetStateValue[string](
+		inv,
+		awaitUserReplyRootLookupStateKey,
+	)
+	rootLookupName = strings.TrimSpace(rootLookupName)
+	if rootLookupName == "" {
+		return branch
+	}
+	segments := splitAwaitUserReplyPath(branch)
+	if len(segments) == 0 {
+		return rootLookupName
+	}
+	segments[0] = rootLookupName
+	return strings.Join(segments, BranchDelimiter)
+}
+
+func normalizeAwaitUserReplyPath(path string) string {
+	segments := splitAwaitUserReplyPath(path)
+	if len(segments) == 0 {
+		return ""
+	}
+	return strings.Join(segments, BranchDelimiter)
+}
+
+func splitAwaitUserReplyPath(path string) []string {
+	parts := strings.Split(path, BranchDelimiter)
+	segments := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		segments = append(segments, part)
+	}
+	return segments
 }

--- a/agent/await_user_reply.go
+++ b/agent/await_user_reply.go
@@ -141,7 +141,11 @@ func (r AwaitUserReplyRoute) AttachEvent(evt *event.Event) error {
 	if evt == nil {
 		return nil
 	}
-	state, err := r.State()
+	normalized, err := normalizeAwaitUserReplyRoute(r)
+	if err != nil {
+		return err
+	}
+	state, err := normalized.State()
 	if err != nil {
 		return err
 	}
@@ -154,7 +158,7 @@ func (r AwaitUserReplyRoute) AttachEvent(evt *event.Event) error {
 	return event.SetExtension(
 		evt,
 		awaitUserReplyEventExtensionKey,
-		r,
+		normalized,
 	)
 }
 
@@ -163,6 +167,10 @@ func attachAwaitUserReplyRoute(inv *Invocation, evt *event.Event) {
 		return
 	}
 	if evt.Response.IsPartial || !evt.Response.Done || evt.IsError() {
+		return
+	}
+	if !evt.Response.IsFinalResponse() ||
+		evt.Response.IsToolResultResponse() {
 		return
 	}
 	route, ok := CurrentAwaitUserReplyRoute(inv)

--- a/agent/await_user_reply_test.go
+++ b/agent/await_user_reply_test.go
@@ -235,3 +235,187 @@ func TestPendingAwaitUserReplyRoute_InvalidState(t *testing.T) {
 	require.False(t, ok)
 	require.Error(t, err)
 }
+
+func TestCurrentAwaitUserReplyRoute_InvalidRoute(t *testing.T) {
+	inv := &Invocation{}
+	inv.SetState(
+		awaitUserReplyInvocationStateKey,
+		AwaitUserReplyRoute{},
+	)
+
+	_, ok := CurrentAwaitUserReplyRoute(inv)
+	require.False(t, ok)
+}
+
+func TestPendingAwaitUserReplyRoute_EdgeCases(t *testing.T) {
+	t.Run("nil session", func(t *testing.T) {
+		_, ok, err := PendingAwaitUserReplyRoute(nil)
+		require.NoError(t, err)
+		require.False(t, ok)
+	})
+
+	t.Run("missing state", func(t *testing.T) {
+		sess := session.NewSession("app", "user", "sess")
+
+		_, ok, err := PendingAwaitUserReplyRoute(sess)
+		require.NoError(t, err)
+		require.False(t, ok)
+	})
+
+	t.Run("invalid normalized route", func(t *testing.T) {
+		sess := session.NewSession(
+			"app",
+			"user",
+			"sess",
+			session.WithSessionState(session.StateMap{
+				awaitUserReplySessionStateKey: []byte(
+					`{"agent_name":" "}`,
+				),
+			}),
+		)
+
+		_, ok, err := PendingAwaitUserReplyRoute(sess)
+		require.False(t, ok)
+		require.Error(t, err)
+	})
+}
+
+func TestSetAwaitUserReplyRootLookupName_ClearsState(t *testing.T) {
+	inv := &Invocation{}
+
+	SetAwaitUserReplyRootLookupName(inv, " coordinator ")
+	rootName, ok := GetStateValue[string](
+		inv,
+		awaitUserReplyRootLookupStateKey,
+	)
+	require.True(t, ok)
+	require.Equal(t, "coordinator", rootName)
+
+	SetAwaitUserReplyRootLookupName(inv, " ")
+	_, ok = GetStateValue[string](inv, awaitUserReplyRootLookupStateKey)
+	require.False(t, ok)
+
+	SetAwaitUserReplyRootLookupName(nil, "coordinator")
+}
+
+func TestClearAwaitUserReplyRouteState(t *testing.T) {
+	state := ClearAwaitUserReplyRouteState()
+	value, ok := state[awaitUserReplySessionStateKey]
+	require.True(t, ok)
+	require.Nil(t, value)
+}
+
+func TestAwaitUserReplyRoute_StateAndAttachEventErrors(t *testing.T) {
+	_, err := (AwaitUserReplyRoute{}).State()
+	require.Error(t, err)
+
+	require.NoError(t, (AwaitUserReplyRoute{}).AttachEvent(nil))
+
+	evt := event.NewResponseEvent(
+		"inv-1",
+		"clarifier",
+		&model.Response{
+			Done: true,
+			Choices: []model.Choice{{
+				Index: 0,
+				Message: model.Message{
+					Role:    model.RoleAssistant,
+					Content: "Please share your city.",
+				},
+			}},
+		},
+	)
+	err = (AwaitUserReplyRoute{}).AttachEvent(evt)
+	require.Error(t, err)
+}
+
+func TestAwaitUserReplyRoute_StateInfersAgentNameFromPath(t *testing.T) {
+	state, err := (AwaitUserReplyRoute{
+		LookupPath: "parent/clarifier",
+	}).State()
+	require.NoError(t, err)
+
+	sess := session.NewSession(
+		"app",
+		"user",
+		"sess",
+		session.WithSessionState(state),
+	)
+	route, ok, routeErr := PendingAwaitUserReplyRoute(sess)
+	require.NoError(t, routeErr)
+	require.True(t, ok)
+	require.Equal(t, "clarifier", route.AgentName)
+}
+
+func TestBuildAwaitUserReplyLookupPath(t *testing.T) {
+	require.Empty(t, buildAwaitUserReplyLookupPath(nil))
+
+	inv := &Invocation{}
+	SetAwaitUserReplyRootLookupName(inv, "coordinator")
+	require.Equal(
+		t,
+		"coordinator",
+		buildAwaitUserReplyLookupPath(inv),
+	)
+
+	inv.AgentName = "clarifier"
+	inv.Branch = " runtime-root / clarifier "
+	require.Equal(
+		t,
+		"coordinator/clarifier",
+		buildAwaitUserReplyLookupPath(inv),
+	)
+}
+
+func TestAttachAwaitUserReplyRoute_WithoutPendingRoute(t *testing.T) {
+	inv := &Invocation{AgentName: "clarifier"}
+	evt := event.NewResponseEvent(
+		"inv-1",
+		"clarifier",
+		&model.Response{
+			Done: true,
+			Choices: []model.Choice{{
+				Index: 0,
+				Message: model.Message{
+					Role:    model.RoleAssistant,
+					Content: "Please share your city.",
+				},
+			}},
+		},
+	)
+
+	attachAwaitUserReplyRoute(inv, evt)
+
+	sess := session.NewSession("app", "user", "sess")
+	sess.ApplyEventStateDelta(evt)
+	_, ok, err := PendingAwaitUserReplyRoute(sess)
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func TestAwaitUserReplyRoute_AttachEventPreservesStateDelta(t *testing.T) {
+	evt := event.NewResponseEvent(
+		"inv-1",
+		"clarifier",
+		&model.Response{
+			Done: true,
+			Choices: []model.Choice{{
+				Index: 0,
+				Message: model.Message{
+					Role:    model.RoleAssistant,
+					Content: "Need your city.",
+				},
+			}},
+		},
+	)
+	evt.StateDelta = session.StateMap{
+		"existing": []byte("value"),
+	}
+
+	err := (AwaitUserReplyRoute{
+		AgentName: "clarifier",
+	}).AttachEvent(evt)
+	require.NoError(t, err)
+	require.Contains(t, evt.StateDelta, "existing")
+	require.Contains(t, evt.StateDelta, awaitUserReplySessionStateKey)
+}

--- a/agent/await_user_reply_test.go
+++ b/agent/await_user_reply_test.go
@@ -114,14 +114,9 @@ func TestAwaitUserReplyRoute_AttachEventNormalizesExtension(t *testing.T) {
 	require.Equal(t, "coordinator/clarifier", ext.LookupPath)
 }
 
-func TestMarkAwaitingUserReply_InvalidInvocation(t *testing.T) {
-	t.Run("nil invocation", func(t *testing.T) {
-		require.Error(t, MarkAwaitingUserReply(nil))
-	})
-
-	t.Run("empty agent name", func(t *testing.T) {
-		require.Error(t, MarkAwaitingUserReply(&Invocation{}))
-	})
+func TestMarkAwaitingUserReply_EmptyAgentName(t *testing.T) {
+	require.Error(t, MarkAwaitingUserReply(nil))
+	require.Error(t, MarkAwaitingUserReply(&Invocation{}))
 }
 
 func TestMarkAwaitingUserReply_UsesBranchPath(t *testing.T) {

--- a/agent/await_user_reply_test.go
+++ b/agent/await_user_reply_test.go
@@ -23,8 +23,10 @@ import (
 func TestMarkAwaitingUserReply_AttachesToFinalEvent(t *testing.T) {
 	inv := &Invocation{
 		AgentName:    "clarifier",
+		Branch:       "runtime-root/clarifier",
 		InvocationID: "inv-1",
 	}
+	SetAwaitUserReplyRootLookupName(inv, "coordinator")
 	require.NoError(t, MarkAwaitingUserReply(inv))
 
 	ch := make(chan *event.Event, 1)
@@ -59,6 +61,7 @@ func TestMarkAwaitingUserReply_AttachesToFinalEvent(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ok)
 	require.Equal(t, "clarifier", route.AgentName)
+	require.Equal(t, "coordinator/clarifier", route.LookupPath)
 
 	ext, ok, err := event.GetExtension[AwaitUserReplyRoute](
 		evt,
@@ -67,11 +70,26 @@ func TestMarkAwaitingUserReply_AttachesToFinalEvent(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ok)
 	require.Equal(t, "clarifier", ext.AgentName)
+	require.Equal(t, "coordinator/clarifier", ext.LookupPath)
 }
 
 func TestMarkAwaitingUserReply_EmptyAgentName(t *testing.T) {
 	err := MarkAwaitingUserReply(&Invocation{})
 	require.Error(t, err)
+}
+
+func TestMarkAwaitingUserReply_UsesBranchPath(t *testing.T) {
+	inv := &Invocation{
+		AgentName: "clarifier",
+		Branch:    "parent/clarifier",
+	}
+
+	require.NoError(t, MarkAwaitingUserReply(inv))
+
+	route, ok := CurrentAwaitUserReplyRoute(inv)
+	require.True(t, ok)
+	require.Equal(t, "clarifier", route.AgentName)
+	require.Equal(t, "parent/clarifier", route.LookupPath)
 }
 
 func TestPendingAwaitUserReplyRoute_InvalidState(t *testing.T) {

--- a/agent/await_user_reply_test.go
+++ b/agent/await_user_reply_test.go
@@ -73,6 +73,47 @@ func TestMarkAwaitingUserReply_AttachesToFinalEvent(t *testing.T) {
 	require.Equal(t, "coordinator/clarifier", ext.LookupPath)
 }
 
+func TestAwaitUserReplyRoute_AttachEventNormalizesExtension(t *testing.T) {
+	evt := event.NewResponseEvent(
+		"inv-1",
+		"clarifier",
+		&model.Response{
+			Done: true,
+			Choices: []model.Choice{{
+				Index: 0,
+				Message: model.Message{
+					Role:    model.RoleAssistant,
+					Content: "Need your phone number.",
+				},
+			}},
+		},
+	)
+
+	err := (AwaitUserReplyRoute{
+		AgentName:  " clarifier ",
+		LookupPath: " coordinator / clarifier ",
+	}).AttachEvent(evt)
+	require.NoError(t, err)
+
+	sess := session.NewSession("app", "user", "sess")
+	sess.ApplyEventStateDelta(evt)
+
+	route, ok, err := PendingAwaitUserReplyRoute(sess)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "clarifier", route.AgentName)
+	require.Equal(t, "coordinator/clarifier", route.LookupPath)
+
+	ext, ok, err := event.GetExtension[AwaitUserReplyRoute](
+		evt,
+		awaitUserReplyEventExtensionKey,
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "clarifier", ext.AgentName)
+	require.Equal(t, "coordinator/clarifier", ext.LookupPath)
+}
+
 func TestMarkAwaitingUserReply_EmptyAgentName(t *testing.T) {
 	err := MarkAwaitingUserReply(&Invocation{})
 	require.Error(t, err)
@@ -90,6 +131,99 @@ func TestMarkAwaitingUserReply_UsesBranchPath(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "clarifier", route.AgentName)
 	require.Equal(t, "parent/clarifier", route.LookupPath)
+}
+
+func TestMarkAwaitingUserReply_DoesNotAttachToPartialEvent(t *testing.T) {
+	inv := &Invocation{
+		AgentName:    "clarifier",
+		InvocationID: "inv-partial",
+	}
+	require.NoError(t, MarkAwaitingUserReply(inv))
+
+	ch := make(chan *event.Event, 1)
+	err := EmitEvent(
+		context.Background(),
+		inv,
+		ch,
+		event.NewResponseEvent(
+			"inv-partial",
+			"clarifier",
+			&model.Response{
+				Done: false,
+				Choices: []model.Choice{{
+					Index: 0,
+					Message: model.Message{
+						Role:    model.RoleAssistant,
+						Content: "thinking...",
+					},
+				}},
+			},
+		),
+	)
+	require.NoError(t, err)
+	close(ch)
+
+	evt := <-ch
+	sess := session.NewSession("app", "user", "sess")
+	sess.ApplyEventStateDelta(evt)
+
+	_, ok, err := PendingAwaitUserReplyRoute(sess)
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	_, ok, err = event.GetExtension[AwaitUserReplyRoute](
+		evt,
+		awaitUserReplyEventExtensionKey,
+	)
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func TestMarkAwaitingUserReply_DoesNotAttachToToolResult(t *testing.T) {
+	inv := &Invocation{
+		AgentName:    "clarifier",
+		InvocationID: "inv-tool-result",
+	}
+	require.NoError(t, MarkAwaitingUserReply(inv))
+
+	ch := make(chan *event.Event, 1)
+	err := EmitEvent(
+		context.Background(),
+		inv,
+		ch,
+		event.NewResponseEvent(
+			"inv-tool-result",
+			"clarifier",
+			&model.Response{
+				Done: true,
+				Choices: []model.Choice{{
+					Index: 0,
+					Message: model.Message{
+						Role:    model.RoleTool,
+						ToolID:  "call-1",
+						Content: "ok",
+					},
+				}},
+			},
+		),
+	)
+	require.NoError(t, err)
+	close(ch)
+
+	evt := <-ch
+	sess := session.NewSession("app", "user", "sess")
+	sess.ApplyEventStateDelta(evt)
+
+	_, ok, err := PendingAwaitUserReplyRoute(sess)
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	_, ok, err = event.GetExtension[AwaitUserReplyRoute](
+		evt,
+		awaitUserReplyEventExtensionKey,
+	)
+	require.NoError(t, err)
+	require.False(t, ok)
 }
 
 func TestPendingAwaitUserReplyRoute_InvalidState(t *testing.T) {

--- a/agent/await_user_reply_test.go
+++ b/agent/await_user_reply_test.go
@@ -114,9 +114,14 @@ func TestAwaitUserReplyRoute_AttachEventNormalizesExtension(t *testing.T) {
 	require.Equal(t, "coordinator/clarifier", ext.LookupPath)
 }
 
-func TestMarkAwaitingUserReply_EmptyAgentName(t *testing.T) {
-	err := MarkAwaitingUserReply(&Invocation{})
-	require.Error(t, err)
+func TestMarkAwaitingUserReply_InvalidInvocation(t *testing.T) {
+	t.Run("nil invocation", func(t *testing.T) {
+		require.Error(t, MarkAwaitingUserReply(nil))
+	})
+
+	t.Run("empty agent name", func(t *testing.T) {
+		require.Error(t, MarkAwaitingUserReply(&Invocation{}))
+	})
 }
 
 func TestMarkAwaitingUserReply_UsesBranchPath(t *testing.T) {

--- a/agent/await_user_reply_test.go
+++ b/agent/await_user_reply_test.go
@@ -1,0 +1,84 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+func TestMarkAwaitingUserReply_AttachesToFinalEvent(t *testing.T) {
+	inv := &Invocation{
+		AgentName:    "clarifier",
+		InvocationID: "inv-1",
+	}
+	require.NoError(t, MarkAwaitingUserReply(inv))
+
+	ch := make(chan *event.Event, 1)
+	err := EmitEvent(
+		context.Background(),
+		inv,
+		ch,
+		event.NewResponseEvent(
+			"inv-1",
+			"clarifier",
+			&model.Response{
+				Done: true,
+				Choices: []model.Choice{{
+					Index: 0,
+					Message: model.Message{
+						Role:    model.RoleAssistant,
+						Content: "Please provide your account id.",
+					},
+				}},
+			},
+		),
+	)
+	require.NoError(t, err)
+	close(ch)
+
+	evt := <-ch
+	require.NotNil(t, evt)
+
+	sess := session.NewSession("app", "user", "sess")
+	sess.ApplyEventStateDelta(evt)
+	route, ok, err := PendingAwaitUserReplyRoute(sess)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "clarifier", route.AgentName)
+
+	ext, ok, err := event.GetExtension[AwaitUserReplyRoute](
+		evt,
+		awaitUserReplyEventExtensionKey,
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "clarifier", ext.AgentName)
+}
+
+func TestMarkAwaitingUserReply_EmptyAgentName(t *testing.T) {
+	err := MarkAwaitingUserReply(&Invocation{})
+	require.Error(t, err)
+}
+
+func TestPendingAwaitUserReplyRoute_InvalidState(t *testing.T) {
+	sess := session.NewSession("app", "user", "sess")
+	sess.SetState(awaitUserReplySessionStateKey, []byte("{"))
+
+	_, ok, err := PendingAwaitUserReplyRoute(sess)
+	require.False(t, ok)
+	require.Error(t, err)
+}

--- a/agent/await_user_reply_test.go
+++ b/agent/await_user_reply_test.go
@@ -149,7 +149,8 @@ func TestMarkAwaitingUserReply_DoesNotAttachToPartialEvent(t *testing.T) {
 			"inv-partial",
 			"clarifier",
 			&model.Response{
-				Done: false,
+				Done:      false,
+				IsPartial: true,
 				Choices: []model.Choice{{
 					Index: 0,
 					Message: model.Message{

--- a/agent/invocation.go
+++ b/agent/invocation.go
@@ -1294,6 +1294,7 @@ func EmitEvent(ctx context.Context, inv *Invocation, ch chan<- *event.Event,
 	if ch == nil || e == nil {
 		return nil
 	}
+	attachAwaitUserReplyRoute(inv, e)
 	InjectIntoEvent(inv, e)
 	var agentName, requestID string
 	if inv != nil {

--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -40,6 +40,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/skill"
 	semconvtrace "trpc.group/trpc-go/trpc-agent-go/telemetry/semconv/trace"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
+	toolawaitreply "trpc.group/trpc-go/trpc-agent-go/tool/awaitreply"
 	toolskill "trpc.group/trpc-go/trpc-agent-go/tool/skill"
 	"trpc.group/trpc-go/trpc-agent-go/tool/transfer"
 	toolworkspaceexec "trpc.group/trpc-go/trpc-agent-go/tool/workspaceexec"
@@ -1514,6 +1515,10 @@ func (a *LLMAgent) getAllToolsLockedWithContext(
 		}
 	}
 
+	if a.option.EnableAwaitUserReplyTool {
+		base = append(base, toolawaitreply.New())
+	}
+
 	if len(a.subAgents) == 0 {
 		return base
 	}
@@ -1576,6 +1581,7 @@ func (a *LLMAgent) FindSubAgent(name string) agent.Agent {
 //   - knowledge_search / agentic_knowledge_search (auto-added when
 //     WithKnowledge is set)
 //   - transfer_to_agent (auto-added when WithSubAgents is set)
+//   - await_user_reply (auto-added when WithAwaitUserReplyTool(true))
 //
 // This method is used by the tool filtering logic to distinguish user
 // tools from framework tools.
@@ -1598,7 +1604,8 @@ func (a *LLMAgent) UserTools() []tool.Tool {
 	// When ToolSets are refreshed on each run, user tools include:
 	//   - Tools from WithTools (tracked in userToolNames)
 	//   - Tools coming from ToolSets (wrapped as NamedTool).
-	// Framework tools (knowledge_search, transfer_to_agent, etc.)
+	// Framework tools (knowledge_search, transfer_to_agent,
+	// await_user_reply, etc.)
 	// remain excluded.
 	allTools := a.getAllToolsLocked()
 	userTools := make([]tool.Tool, 0, len(allTools))

--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -80,6 +80,10 @@ type LLMAgent struct {
 	option               Options
 }
 
+const invalidOutputSchemaAwaitUserReply = "" +
+	"Invalid LLMAgent configuration: if output_schema is set, " +
+	"await_user_reply must be disabled"
+
 // New creates a new LLMAgent with the given options.
 func New(name string, opts ...Option) *LLMAgent {
 	options := defaultOptions
@@ -93,6 +97,9 @@ func New(name string, opts ...Option) *LLMAgent {
 
 	// Validate output_schema configuration before registering tools.
 	if options.OutputSchema != nil {
+		if options.EnableAwaitUserReplyTool {
+			panic(invalidOutputSchemaAwaitUserReply)
+		}
 		if len(options.Tools) > 0 || len(options.ToolSets) > 0 {
 			panic("Invalid LLMAgent configuration: if output_schema is set, tools and toolSets must be empty")
 		}

--- a/agent/llmagent/llm_agent_test.go
+++ b/agent/llmagent/llm_agent_test.go
@@ -979,6 +979,18 @@ func TestLLMAgent_New_WithOutputSchema_InvalidCombos(t *testing.T) {
 			},
 		)
 	})
+
+	t.Run("with await_user_reply", func(t *testing.T) {
+		require.PanicsWithValue(t,
+			invalidOutputSchemaAwaitUserReply,
+			func() {
+				_ = New("test",
+					WithOutputSchema(schema),
+					WithAwaitUserReplyTool(true),
+				)
+			},
+		)
+	})
 }
 
 func TestLLMAgent_New_WithStructuredOutputJSONSchema_AllowsTools(t *testing.T) {

--- a/agent/llmagent/llm_agent_tools_test.go
+++ b/agent/llmagent/llm_agent_tools_test.go
@@ -130,6 +130,27 @@ func TestLLMAgent_Tools_IncludesAwaitUserReplyWhenEnabled(t *testing.T) {
 	}
 }
 
+func TestLLMAgent_FilterTools_PreservesAwaitUserReply(t *testing.T) {
+	agt := New(
+		"main",
+		WithAwaitUserReplyTool(true),
+		WithToolFilter(func(context.Context, tool.Tool) bool {
+			return false
+		}),
+	)
+
+	filtered := agt.FilterTools(context.Background())
+	for _, tl := range filtered {
+		if tl.Declaration().Name == testAwaitReplyToolName {
+			return
+		}
+	}
+
+	t.Fatalf(
+		"expected await_user_reply to be preserved by runtime filtering",
+	)
+}
+
 func TestLLMAgent_UserTools(t *testing.T) {
 	// Create agent with user tools, toolsets, knowledge, and subagents
 	userTool1 := dummyTool{

--- a/agent/llmagent/llm_agent_tools_test.go
+++ b/agent/llmagent/llm_agent_tools_test.go
@@ -317,6 +317,7 @@ func TestLLMAgent_RefreshToolSetsOnRun(t *testing.T) {
 		WithTools([]tool.Tool{staticTool}),
 		WithToolSets([]tool.ToolSet{dyn}),
 		WithRefreshToolSetsOnRun(true),
+		WithAwaitUserReplyTool(true),
 	)
 
 	toolsV1 := agent.Tools()

--- a/agent/llmagent/llm_agent_tools_test.go
+++ b/agent/llmagent/llm_agent_tools_test.go
@@ -35,6 +35,7 @@ const (
 	testSubAgentName          = "sub-agent"
 	testToolNameWithCtx       = "tool_with_ctx"
 	testToolNameWithoutCtx    = "tool_without_ctx"
+	testAwaitReplyToolName    = "await_user_reply"
 )
 
 // minimalKnowledge implements knowledge.Knowledge with no-op behaviors for unit tests.
@@ -113,6 +114,22 @@ func TestLLMAgent_Tools_IncludesTransferWhenSubAgents(t *testing.T) {
 	}
 }
 
+func TestLLMAgent_Tools_IncludesAwaitUserReplyWhenEnabled(t *testing.T) {
+	agt := New("main", WithAwaitUserReplyTool(true))
+
+	ts := agt.Tools()
+	found := false
+	for _, tl := range ts {
+		if tl.Declaration().Name == testAwaitReplyToolName {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected await_user_reply tool when enabled")
+	}
+}
+
 func TestLLMAgent_UserTools(t *testing.T) {
 	// Create agent with user tools, toolsets, knowledge, and subagents
 	userTool1 := dummyTool{
@@ -130,6 +147,7 @@ func TestLLMAgent_UserTools(t *testing.T) {
 		WithToolSets([]tool.ToolSet{toolSet}),
 		WithKnowledge(kb),
 		WithSubAgents([]agent.Agent{subAgent}),
+		WithAwaitUserReplyTool(true),
 	)
 
 	// Get all tools
@@ -170,7 +188,9 @@ func TestLLMAgent_UserTools(t *testing.T) {
 	// Verify that framework tools are NOT in user tools
 	for _, tool := range userTools {
 		name := tool.Declaration().Name
-		if name == testKnowledgeToolName || name == testTransferToolName {
+		if name == testKnowledgeToolName ||
+			name == testTransferToolName ||
+			name == testAwaitReplyToolName {
 			t.Errorf("framework tool %s should not be in user tools", name)
 		}
 	}
@@ -184,6 +204,7 @@ func TestLLMAgent_UserTools_EmptyCase(t *testing.T) {
 	agent := New("test-agent",
 		WithKnowledge(kb),
 		WithSubAgents([]agent.Agent{subAgent}),
+		WithAwaitUserReplyTool(true),
 	)
 
 	// Get user tools - should be empty
@@ -198,17 +219,21 @@ func TestLLMAgent_UserTools_EmptyCase(t *testing.T) {
 
 	foundKnowledge := false
 	foundTransfer := false
+	foundAwaitReply := false
 	for _, tool := range allTools {
 		switch tool.Declaration().Name {
 		case testKnowledgeToolName:
 			foundKnowledge = true
 		case testTransferToolName:
 			foundTransfer = true
+		case testAwaitReplyToolName:
+			foundAwaitReply = true
 		}
 	}
 
-	if !foundKnowledge || !foundTransfer {
-		t.Errorf("framework tools should be in all tools even when no user tools")
+	if !foundKnowledge || !foundTransfer || !foundAwaitReply {
+		t.Errorf("framework tools should be in all tools even when " +
+			"no user tools")
 	}
 }
 
@@ -322,7 +347,9 @@ func TestLLMAgent_RefreshToolSetsOnRun(t *testing.T) {
 	userTools := agent.UserTools()
 	for _, tl := range userTools {
 		name := tl.Declaration().Name
-		if name == "knowledge_search" || name == "transfer_to_agent" {
+		if name == "knowledge_search" ||
+			name == "transfer_to_agent" ||
+			name == testAwaitReplyToolName {
 			t.Fatalf(
 				"framework tool %s should not appear in user tools",
 				name,

--- a/agent/llmagent/option.go
+++ b/agent/llmagent/option.go
@@ -236,6 +236,10 @@ type Options struct {
 	Planner planner.Planner
 	// SubAgents is the list of sub-agents available to the agent.
 	SubAgents []agent.Agent
+	// EnableAwaitUserReplyTool adds the await_user_reply framework tool.
+	// When enabled, the model can explicitly mark that the next user turn
+	// should resume at this agent.
+	EnableAwaitUserReplyTool bool
 	// AgentCallbacks contains callbacks for agent operations.
 	AgentCallbacks *agent.Callbacks
 	// ModelCallbacks contains callbacks for model operations.
@@ -1343,6 +1347,14 @@ func WithEventMessageProjector(
 ) Option {
 	return func(opts *Options) {
 		opts.EventMessageProjector = projector
+	}
+}
+
+// WithAwaitUserReplyTool controls whether the await_user_reply framework tool
+// is exposed to the model.
+func WithAwaitUserReplyTool(enabled bool) Option {
+	return func(opts *Options) {
+		opts.EnableAwaitUserReplyTool = enabled
 	}
 }
 

--- a/agent/llmagent/surface_runtime.go
+++ b/agent/llmagent/surface_runtime.go
@@ -21,6 +21,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/skill"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
+	toolawaitreply "trpc.group/trpc-go/trpc-agent-go/tool/awaitreply"
 	"trpc.group/trpc-go/trpc-agent-go/tool/transfer"
 )
 
@@ -234,6 +235,9 @@ func (a *LLMAgent) InvocationToolSurface(
 			effectiveExec,
 		),
 	)
+	if options.EnableAwaitUserReplyTool {
+		allTools = append(allTools, toolawaitreply.New())
+	}
 	if len(subAgents) == 0 {
 		return allTools, userToolNames
 	}

--- a/docs/mkdocs/en/multiagent.md
+++ b/docs/mkdocs/en/multiagent.md
@@ -684,12 +684,20 @@ r := runner.NewRunner(
 // Turn 2 (same session):
 // user: "+1-555-0101"
 // Runner resumes directly at profile-agent for this turn.
-_, _ = r.Run(
+events, err := r.Run(
     context.Background(),
     "user-1",
     "session-1",
     model.NewUserMessage("+1-555-0101"),
 )
+if err != nil {
+    // handle error
+}
+for evt := range events {
+    if evt.IsRunnerCompletion() {
+        break
+    }
+}
 ```
 
 Important behavior:

--- a/docs/mkdocs/en/multiagent.md
+++ b/docs/mkdocs/en/multiagent.md
@@ -20,6 +20,7 @@ The Multi-Agent System is built on the SubAgent concept, implementing various co
 
 - **Agent Tool (AgentTool)** - Wraps Agents as tools for other Agents to call
 - **Agent Transfer** - Implements task delegation between Agents through the `transfer_to_agent` tool
+- **Await User Reply Routing** - Lets an Agent explicitly claim the next user turn when it needs follow-up information
 - **Team** - A high-level wrapper for coordinator teams and swarm-style handoffs (`team` package)
 
 ## SubAgent Basics
@@ -607,6 +608,103 @@ Compound Interest Calculation Result:
 - Term: 8 years
 - Result: $7,969.24 (interest approximately $2,969.24)
 ```
+
+#### Follow-Up Questions Across Turns
+
+`transfer_to_agent` solves **who handles the current run**. It does not, by
+itself, tell `Runner` who should handle the **next user message**.
+
+That becomes visible when a SubAgent asks a clarifying question:
+
+1. The coordinator transfers to a SubAgent.
+2. The SubAgent asks the user for missing information.
+3. The user replies in a later request.
+4. By default, `Runner` starts from its normal entry Agent again.
+
+The clean solution is to make this routing **explicit** and **one-shot**:
+
+- Enable `runner.WithAwaitUserReplyRouting(true)` on the Runner.
+- Enable `llmagent.WithAwaitUserReplyTool(true)` on any Agent that may ask the
+  user for follow-up data.
+- In that Agent's instruction, tell the model to call `await_user_reply`
+  immediately before it asks the user for missing information.
+
+```go
+import (
+    "context"
+
+    "trpc.group/trpc-go/trpc-agent-go/agent"
+    "trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+    "trpc.group/trpc-go/trpc-agent-go/model"
+    "trpc.group/trpc-go/trpc-agent-go/runner"
+    "trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+profileAgent := llmagent.New(
+    "profile-agent",
+    llmagent.WithModel(modelInstance),
+    llmagent.WithDescription(
+        "Collects and updates customer profile information.",
+    ),
+    llmagent.WithInstruction(`
+You update customer profiles.
+
+If any required field is missing:
+1. call await_user_reply
+2. ask one clear question to the user
+3. stop and wait for the next user message
+
+When all required fields are present, call update_profile.
+`),
+    llmagent.WithAwaitUserReplyTool(true),
+    llmagent.WithTools([]tool.Tool{updateProfileTool}),
+)
+
+coordinatorAgent := llmagent.New(
+    "coordinator-agent",
+    llmagent.WithModel(modelInstance),
+    llmagent.WithInstruction(`
+Delegate profile-update requests to profile-agent.
+Do not collect profile fields yourself.
+`),
+    llmagent.WithSubAgents([]agent.Agent{profileAgent}),
+)
+
+r := runner.NewRunner(
+    "crm-app",
+    coordinatorAgent,
+    runner.WithAwaitUserReplyRouting(true),
+)
+
+// Turn 1:
+// user: "Update my profile."
+// coordinator-agent -> transfer_to_agent(profile-agent)
+// profile-agent -> await_user_reply + "What phone number should I save?"
+
+// Turn 2 (same session):
+// user: "+1-555-0101"
+// Runner resumes directly at profile-agent for this turn.
+_, _ = r.Run(
+    context.Background(),
+    "user-1",
+    "session-1",
+    model.NewUserMessage("+1-555-0101"),
+)
+```
+
+Important behavior:
+
+- The route is consumed once. After the next user turn starts, it is cleared.
+- Explicit `agent.WithAgent(...)` or `agent.WithAgentByName(...)` still wins.
+- If the target Agent was removed, or the name is no longer uniquely
+  resolvable, `Runner` falls back to its default entry Agent and clears the
+  stale route.
+- `Runner` can resolve uniquely named nested SubAgents automatically, so you do
+  not need to register every SubAgent separately in the common
+  coordinator-plus-SubAgents setup.
+
+For custom Agents that do not use `LLMAgent`, see the `runner` guide for the
+low-level `agent.MarkAwaitingUserReply(...)` API.
 
 ## Environment Variable Configuration
 

--- a/docs/mkdocs/en/multiagent.md
+++ b/docs/mkdocs/en/multiagent.md
@@ -696,10 +696,9 @@ Important behavior:
 
 - The route is consumed once. After the next user turn starts, it is cleared.
 - Explicit `agent.WithAgent(...)` or `agent.WithAgentByName(...)` still wins.
-- If the target Agent was removed, or the name is no longer uniquely
-  resolvable, `Runner` falls back to its default entry Agent and clears the
-  stale route.
-- `Runner` can resolve uniquely named nested SubAgents automatically, so you do
+- If the target Agent path is no longer valid, `Runner` falls back to its
+  default entry Agent and clears the stale route.
+- `Runner` restores nested SubAgents by their full agent-chain path, so you do
   not need to register every SubAgent separately in the common
   coordinator-plus-SubAgents setup.
 

--- a/docs/mkdocs/en/runner.md
+++ b/docs/mkdocs/en/runner.md
@@ -231,6 +231,105 @@ Recommended patterns:
 This boundary is especially important when using MCP ToolSets. See the
 ToolSet lifecycle notes in the `tool` documentation for more details.
 
+### Resume the Next User Turn at a Specific Agent
+
+In a multi-Agent conversation, a transferred SubAgent may ask the user for
+missing information. The next request is a brand-new `Runner.Run(...)` call, so
+`Runner` needs an explicit signal if that next user message should resume at
+the same Agent instead of the normal entry Agent.
+
+Enable the one-shot route consumer on Runner:
+
+```go
+r := runner.NewRunner(
+    "crm-app",
+    coordinatorAgent,
+    runner.WithAwaitUserReplyRouting(true),
+)
+```
+
+There are two ways to produce that route:
+
+1. `LLMAgent`: enable `llmagent.WithAwaitUserReplyTool(true)` and instruct the
+   model to call `await_user_reply` immediately before it asks the user for
+   missing information.
+2. Custom Agent implementations: call `agent.MarkAwaitingUserReply(invocation)`
+   before you emit the final clarifying question event.
+
+#### Low-Level Example for a Custom Agent
+
+```go
+type clarifierAgent struct{}
+
+func (a *clarifierAgent) Run(
+    ctx context.Context,
+    inv *agent.Invocation,
+) (<-chan *event.Event, error) {
+    ch := make(chan *event.Event, 1)
+    go func() {
+        defer close(ch)
+
+        if missingPhoneNumber(inv.Message) {
+            _ = agent.MarkAwaitingUserReply(inv)
+            _ = agent.EmitEvent(
+                ctx,
+                inv,
+                ch,
+                event.NewResponseEvent(
+                    inv.InvocationID,
+                    inv.AgentName,
+                    &model.Response{
+                        Done: true,
+                        Choices: []model.Choice{{
+                            Index: 0,
+                            Message: model.Message{
+                                Role:    model.RoleAssistant,
+                                Content: "What phone number should I save?",
+                            },
+                        }},
+                    },
+                ),
+            )
+            return
+        }
+
+        _ = agent.EmitEvent(
+            ctx,
+            inv,
+            ch,
+            event.NewResponseEvent(
+                inv.InvocationID,
+                inv.AgentName,
+                &model.Response{
+                    Done: true,
+                    Choices: []model.Choice{{
+                        Index: 0,
+                        Message: model.Message{
+                            Role:    model.RoleAssistant,
+                            Content: "Profile updated.",
+                        },
+                    }},
+                },
+            ),
+        )
+    }()
+    return ch, nil
+}
+```
+
+Behavior summary:
+
+- The route is stored in session state, not by mutating message roles.
+- It is consumed once, right before the next user turn starts.
+- `agent.WithAgent(...)` and `agent.WithAgentByName(...)` still take
+  precedence.
+- If the recorded Agent no longer exists, or its name is no longer uniquely
+  resolvable, Runner clears the stale route and falls back to the default
+  entry Agent.
+- Runner can resolve uniquely named nested SubAgents automatically, so the
+  common `coordinator + WithSubAgents(...)` setup works without extra manual
+  registration.
+
 ### 🔌 Plugins
 
 Runner plugins are global, runner-scoped hooks. Register plugins once and they

--- a/docs/mkdocs/en/runner.md
+++ b/docs/mkdocs/en/runner.md
@@ -319,16 +319,26 @@ func (a *clarifierAgent) Run(
 
 Behavior summary:
 
-- The route is stored in session state, not by mutating message roles.
+- The route is stored in session state as a stable agent path, not by
+  mutating message roles.
 - It is consumed once, right before the next user turn starts.
 - `agent.WithAgent(...)` and `agent.WithAgentByName(...)` still take
   precedence.
-- If the recorded Agent no longer exists, or its name is no longer uniquely
-  resolvable, Runner clears the stale route and falls back to the default
-  entry Agent.
-- Runner can resolve uniquely named nested SubAgents automatically, so the
-  common `coordinator + WithSubAgents(...)` setup works without extra manual
-  registration.
+- If the recorded Agent path no longer exists, Runner clears the stale route
+  and falls back to the default entry Agent.
+- Nested SubAgents are resumed by their full invocation path, so the common
+  `coordinator + WithSubAgents(...)` setup works without manually registering
+  every child Agent.
+
+Advanced note:
+
+- The built-in `Runner` records the stable root lookup key automatically,
+  including `AgentFactory` cases where the runtime `Info().Name` differs from
+  the registered factory name.
+- If you build and run invocations manually outside `Runner`, and the stable
+  root lookup key is different from `inv.AgentName`, call
+  `agent.SetAwaitUserReplyRootLookupName(inv, rootLookupName)` before the
+  Agent emits its final clarifying reply.
 
 ### 🔌 Plugins
 

--- a/docs/mkdocs/en/team.md
+++ b/docs/mkdocs/en/team.md
@@ -390,6 +390,14 @@ Agent that produced the last reply (until another `transfer_to_agent` happens).
 This feature is implemented via session state, so you must reuse the same
 session across requests.
 
+This is different from `await_user_reply` plus
+`runner.WithAwaitUserReplyRouting(true)`:
+
+- `WithCrossRequestTransfer(true)` is a Swarm-specific owner model. The active
+  member keeps owning future user turns until another transfer happens.
+- `await_user_reply` is a one-shot route. It is consumed by exactly one future
+  user turn and then cleared automatically.
+
 ### Dynamic members (runtime)
 
 In long-running services, the set of available Swarm members may change over

--- a/docs/mkdocs/en/tool.md
+++ b/docs/mkdocs/en/tool.md
@@ -1542,7 +1542,7 @@ Agent.
 Use it together with `runner.WithAwaitUserReplyRouting(true)`:
 
 ```go
-agent := llmagent.New("profile-agent",
+profileAgent := llmagent.New("profile-agent",
     llmagent.WithAwaitUserReplyTool(true),
     llmagent.WithInstruction(`
 If you must ask the user for a missing field, call await_user_reply
@@ -1552,7 +1552,7 @@ immediately before your question.
 
 r := runner.NewRunner(
     "crm-app",
-    coordinatorAgent,
+    profileAgent,
     runner.WithAwaitUserReplyRouting(true),
 )
 ```

--- a/docs/mkdocs/en/tool.md
+++ b/docs/mkdocs/en/tool.md
@@ -1252,7 +1252,7 @@ apply to all agents
 
 - 🎯 **Per-Run Control**: Independent configuration per invocation, no Agent modification needed
 - 💰 **Cost Optimization**: Reduce tool descriptions sent to LLM, lowering token costs
-- 🛡️ **Smart Protection**: Framework tools (`transfer_to_agent`, `knowledge_search`) automatically preserved, never filtered
+- 🛡️ **Smart Protection**: Framework tools (`transfer_to_agent`, `knowledge_search`, optional `await_user_reply`) automatically preserved, never filtered
 - 🔧 **Flexible Customization**: Support for built-in filters and custom FilterFunc
 
 #### Tool Search (Automatic Tool Selection)
@@ -1502,7 +1502,7 @@ The framework automatically distinguishes **user tools** from **framework tools*
 | Tool Category       | Includes                                                                                                                      | Filtered?                         |
 | ------------------- | ----------------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
 | **User Tools**      | Tools registered via `WithTools`<br>Tools registered via `WithToolSets`                                                       | ✅ Subject to filtering           |
-| **Framework Tools** | `transfer_to_agent` (multi-Agent coordination)<br>`knowledge_search` (knowledge base retrieval)<br>`agentic_knowledge_search` | ❌ Never filtered, auto-preserved |
+| **Framework Tools** | `transfer_to_agent` (multi-Agent coordination)<br>`knowledge_search` (knowledge base retrieval)<br>`agentic_knowledge_search`<br>`await_user_reply` (one-shot follow-up routing, when enabled) | ❌ Never filtered, auto-preserved |
 
 **Example:**
 
@@ -1515,6 +1515,7 @@ agent := llmagent.New("assistant",
     }),
     llmagent.WithSubAgents([]agent.Agent{subAgent1, subAgent2}), // Auto-adds transfer_to_agent
     llmagent.WithKnowledge(kb),                                   // Auto-adds knowledge_search
+    llmagent.WithAwaitUserReplyTool(true),                        // Auto-adds await_user_reply
 )
 
 // Runtime filtering: only allow calculator
@@ -1528,7 +1529,36 @@ runner.Run(ctx, userID, sessionID, message,
 // ❌ textTool          - User tool, filtered out
 // ✅ transfer_to_agent - Framework tool, auto-preserved
 // ✅ knowledge_search  - Framework tool, auto-preserved
+// ✅ await_user_reply  - Framework tool, auto-preserved
 ```
+
+#### `await_user_reply` for Follow-Up Turns
+
+`await_user_reply` is an optional framework tool. Enable it with
+`llmagent.WithAwaitUserReplyTool(true)` when an Agent may ask the user for
+missing information and you want the next user message to resume at that same
+Agent.
+
+Use it together with `runner.WithAwaitUserReplyRouting(true)`:
+
+```go
+agent := llmagent.New("profile-agent",
+    llmagent.WithAwaitUserReplyTool(true),
+    llmagent.WithInstruction(`
+If you must ask the user for a missing field, call await_user_reply
+immediately before your question.
+`),
+)
+
+r := runner.NewRunner(
+    "crm-app",
+    coordinatorAgent,
+    runner.WithAwaitUserReplyRouting(true),
+)
+```
+
+The route is one-shot: Runner consumes it on the next user turn and then clears
+it automatically.
 
 #### Important Notes
 
@@ -1683,7 +1713,9 @@ if !removed {
 Runtime ToolSet updates integrate seamlessly with the **tool filtering** logic described earlier:
 
 - Tools coming from `WithTools` or any ToolSet (including dynamically added ones) are treated as **user tools** and are subject to `WithToolFilter` and per‑run filters.
-- Framework tools such as `transfer_to_agent`, `knowledge_search`, and `agentic_knowledge_search` remain **never filtered** and are always available.
+- Framework tools such as `transfer_to_agent`, `knowledge_search`,
+  `agentic_knowledge_search`, and optional `await_user_reply` remain
+  **never filtered** and are always available.
 
 #### Tool Call Arguments Auto Repair
 

--- a/docs/mkdocs/zh/multiagent.md
+++ b/docs/mkdocs/zh/multiagent.md
@@ -678,12 +678,20 @@ r := runner.NewRunner(
 // 第 2 轮（同一个 session）：
 // user: "+1-555-0101"
 // Runner 这一轮会直接从 profile-agent 开始。
-_, _ = r.Run(
+events, err := r.Run(
     context.Background(),
     "user-1",
     "session-1",
     model.NewUserMessage("+1-555-0101"),
 )
+if err != nil {
+    // handle error
+}
+for evt := range events {
+    if evt.IsRunnerCompletion() {
+        break
+    }
+}
 ```
 
 这套能力的行为边界：

--- a/docs/mkdocs/zh/multiagent.md
+++ b/docs/mkdocs/zh/multiagent.md
@@ -691,11 +691,10 @@ _, _ = r.Run(
 - 这条路由只消费一次；下一条用户消息开始时就会被清掉
 - 显式指定的 `agent.WithAgent(...)` 或 `agent.WithAgentByName(...)`
   仍然优先
-- 如果目标 Agent 已被移除，或者这个名字已经无法唯一解析，
-  `Runner` 会回退到默认入口 Agent，并清理掉脏路由
+- 如果目标 Agent 路径已经失效，`Runner` 会回退到默认入口 Agent，
+  并清理掉脏路由
 - 对最常见的 “coordinator + WithSubAgents” 结构，`Runner`
-  可以自动解析唯一命名的嵌套 SubAgent，不需要你把每个 SubAgent
-  再额外注册一遍
+  会按完整的 Agent 链路径恢复，不需要你把每个 SubAgent 再额外注册一遍
 
 如果你不是用 `LLMAgent`，而是自己实现 `agent.Agent`，请看 `runner`
 文档里的底层 API：`agent.MarkAwaitingUserReply(...)`。

--- a/docs/mkdocs/zh/multiagent.md
+++ b/docs/mkdocs/zh/multiagent.md
@@ -20,6 +20,7 @@
 
 - **Agent 工具 (AgentTool)** - 将 Agent 包装成工具，供其他 Agent 调用
 - **Agent 委托 (Agent Transfer)** - 通过 `transfer_to_agent` 工具实现 Agent 间的任务委托
+- **等待用户回复路由** - 让 Agent 在需要补充信息时显式接管下一条用户消息
 - **Team** - 更高层的团队编排封装，支持协调者团队与 Swarm（见 `team` 包）
 
 ## SubAgent 基础
@@ -603,6 +604,101 @@ func refreshSubAgents(ctx context.Context, ag agent.Agent) error {
 - 期限：8年
 - 结果：$7,969.24（利息约$2,969.24）
 ```
+
+#### 跨轮追问用户
+
+`transfer_to_agent` 解决的是 **当前这一轮由谁处理**。它本身并不会告诉
+`Runner`：**下一条用户消息** 应该继续交给谁。
+
+当 SubAgent 发起追问时，这个问题就会暴露出来：
+
+1. coordinator transfer 给某个 SubAgent
+2. SubAgent 向用户追问缺失信息
+3. 用户在下一次请求里补充信息
+4. 默认情况下，`Runner` 还是会从常规入口 Agent 开始
+
+更干净的做法是把这件事做成 **显式**、**一次性** 的路由：
+
+- 在 Runner 上开启 `runner.WithAwaitUserReplyRouting(true)`
+- 对可能追问用户的 Agent，开启
+  `llmagent.WithAwaitUserReplyTool(true)`
+- 在这些 Agent 的 instruction 里明确要求模型：如果要向用户补字段，
+  先调用 `await_user_reply`，再发出追问
+
+```go
+import (
+    "context"
+
+    "trpc.group/trpc-go/trpc-agent-go/agent"
+    "trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+    "trpc.group/trpc-go/trpc-agent-go/model"
+    "trpc.group/trpc-go/trpc-agent-go/runner"
+    "trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+profileAgent := llmagent.New(
+    "profile-agent",
+    llmagent.WithModel(modelInstance),
+    llmagent.WithDescription("负责采集并更新客户资料。"),
+    llmagent.WithInstruction(`
+你负责更新客户资料。
+
+如果缺少必要字段：
+1. 先调用 await_user_reply
+2. 再向用户提出一个明确的问题
+3. 然后等待下一条用户消息
+
+字段齐全后，再调用 update_profile。
+`),
+    llmagent.WithAwaitUserReplyTool(true),
+    llmagent.WithTools([]tool.Tool{updateProfileTool}),
+)
+
+coordinatorAgent := llmagent.New(
+    "coordinator-agent",
+    llmagent.WithModel(modelInstance),
+    llmagent.WithInstruction(`
+用户要更新资料时，直接 transfer 给 profile-agent。
+不要自己收集资料字段。
+`),
+    llmagent.WithSubAgents([]agent.Agent{profileAgent}),
+)
+
+r := runner.NewRunner(
+    "crm-app",
+    coordinatorAgent,
+    runner.WithAwaitUserReplyRouting(true),
+)
+
+// 第 1 轮：
+// user: "帮我更新资料"
+// coordinator-agent -> transfer_to_agent(profile-agent)
+// profile-agent -> await_user_reply + "请问要保存的手机号是多少？"
+
+// 第 2 轮（同一个 session）：
+// user: "+1-555-0101"
+// Runner 这一轮会直接从 profile-agent 开始。
+_, _ = r.Run(
+    context.Background(),
+    "user-1",
+    "session-1",
+    model.NewUserMessage("+1-555-0101"),
+)
+```
+
+这套能力的行为边界：
+
+- 这条路由只消费一次；下一条用户消息开始时就会被清掉
+- 显式指定的 `agent.WithAgent(...)` 或 `agent.WithAgentByName(...)`
+  仍然优先
+- 如果目标 Agent 已被移除，或者这个名字已经无法唯一解析，
+  `Runner` 会回退到默认入口 Agent，并清理掉脏路由
+- 对最常见的 “coordinator + WithSubAgents” 结构，`Runner`
+  可以自动解析唯一命名的嵌套 SubAgent，不需要你把每个 SubAgent
+  再额外注册一遍
+
+如果你不是用 `LLMAgent`，而是自己实现 `agent.Agent`，请看 `runner`
+文档里的底层 API：`agent.MarkAwaitingUserReply(...)`。
 
 ## 环境变量配置
 

--- a/docs/mkdocs/zh/runner.md
+++ b/docs/mkdocs/zh/runner.md
@@ -311,13 +311,22 @@ func (a *clarifierAgent) Run(
 
 这套能力的行为总结：
 
-- 路由存放在 session state 中，而不是去修改 message role
+- 路由会以稳定的 Agent 路径形式存放在 session state 中，而不是去修改
+  message role
 - 它只消费一次，在下一条用户消息开始前就会被清掉
 - `agent.WithAgent(...)` 和 `agent.WithAgentByName(...)` 仍然优先
-- 如果记录的 Agent 已不存在，或者名字已无法唯一解析，Runner 会清理掉
-  脏路由，并回退到默认入口 Agent
-- 对常见的 `coordinator + WithSubAgents(...)` 结构，Runner 可以自动解析
-  唯一命名的嵌套 SubAgent，不需要额外手工注册
+- 如果记录的 Agent 路径已经失效，Runner 会清理掉脏路由，并回退到
+  默认入口 Agent
+- 对常见的 `coordinator + WithSubAgents(...)` 结构，Runner 会按完整的
+  Agent 链路径恢复，不需要额外手工注册每个子 Agent
+
+进阶说明：
+
+- 内建 `Runner` 会自动记录稳定的根 Agent lookup key，包括
+  `AgentFactory` 返回的运行时 `Info().Name` 与注册名不一致的场景。
+- 如果你是在 `Runner` 之外手工构造并运行 Invocation，而且稳定的根
+  lookup key 和 `inv.AgentName` 不一致，请在 Agent 发出最终追问前先调
+  一次 `agent.SetAwaitUserReplyRootLookupName(inv, rootLookupName)`。
 
 ### 🔌 插件
 

--- a/docs/mkdocs/zh/runner.md
+++ b/docs/mkdocs/zh/runner.md
@@ -225,6 +225,100 @@ _ = err
 这类边界在使用 MCP ToolSet 时尤其常见，详细说明可继续参考
 `tool` 文档中的 ToolSet 生命周期章节。
 
+### 让下一条用户消息继续回到某个 Agent
+
+在多 Agent 对话里，transfer 过去的 SubAgent 可能会向用户补问信息。下一次
+请求本质上是一次全新的 `Runner.Run(...)`，因此如果你希望下一条用户消息
+继续回到刚才那个 Agent，就必须给 Runner 一个显式信号。
+
+先在 Runner 上开启一次性路由消费能力：
+
+```go
+r := runner.NewRunner(
+    "crm-app",
+    coordinatorAgent,
+    runner.WithAwaitUserReplyRouting(true),
+)
+```
+
+然后有两种方式可以产出这条路由：
+
+1. `LLMAgent`：开启 `llmagent.WithAwaitUserReplyTool(true)`，并在
+   instruction 里要求模型在追问用户前先调用 `await_user_reply`
+2. 自定义 Agent：在发出最终追问事件前，手动调用
+   `agent.MarkAwaitingUserReply(invocation)`
+
+#### 自定义 Agent 的底层示例
+
+```go
+type clarifierAgent struct{}
+
+func (a *clarifierAgent) Run(
+    ctx context.Context,
+    inv *agent.Invocation,
+) (<-chan *event.Event, error) {
+    ch := make(chan *event.Event, 1)
+    go func() {
+        defer close(ch)
+
+        if missingPhoneNumber(inv.Message) {
+            _ = agent.MarkAwaitingUserReply(inv)
+            _ = agent.EmitEvent(
+                ctx,
+                inv,
+                ch,
+                event.NewResponseEvent(
+                    inv.InvocationID,
+                    inv.AgentName,
+                    &model.Response{
+                        Done: true,
+                        Choices: []model.Choice{{
+                            Index: 0,
+                            Message: model.Message{
+                                Role:    model.RoleAssistant,
+                                Content: "请问要保存的手机号是多少？",
+                            },
+                        }},
+                    },
+                ),
+            )
+            return
+        }
+
+        _ = agent.EmitEvent(
+            ctx,
+            inv,
+            ch,
+            event.NewResponseEvent(
+                inv.InvocationID,
+                inv.AgentName,
+                &model.Response{
+                    Done: true,
+                    Choices: []model.Choice{{
+                        Index: 0,
+                        Message: model.Message{
+                            Role:    model.RoleAssistant,
+                            Content: "资料已更新。",
+                        },
+                    }},
+                },
+            ),
+        )
+    }()
+    return ch, nil
+}
+```
+
+这套能力的行为总结：
+
+- 路由存放在 session state 中，而不是去修改 message role
+- 它只消费一次，在下一条用户消息开始前就会被清掉
+- `agent.WithAgent(...)` 和 `agent.WithAgentByName(...)` 仍然优先
+- 如果记录的 Agent 已不存在，或者名字已无法唯一解析，Runner 会清理掉
+  脏路由，并回退到默认入口 Agent
+- 对常见的 `coordinator + WithSubAgents(...)` 结构，Runner 可以自动解析
+  唯一命名的嵌套 SubAgent，不需要额外手工注册
+
 ### 🔌 插件
 
 Runner 插件是一类全局、Runner 作用域的 Hook（钩子）。只需要在创建 Runner 时

--- a/docs/mkdocs/zh/team.md
+++ b/docs/mkdocs/zh/team.md
@@ -362,6 +362,12 @@ tm, err := team.NewSwarm(
 下一条用户输入将从该成员开始（直到再次发生 `transfer_to_agent`）。该能力通过
 Session State 实现，因此需要复用同一个 session。
 
+它和 `await_user_reply + runner.WithAwaitUserReplyRouting(true)` 的语义不同：
+
+- `WithCrossRequestTransfer(true)` 是 Swarm 专属的 owner 语义。只要没有新的
+  transfer，后续用户消息都会继续落到当前 active member。
+- `await_user_reply` 是一次性路由。它只消费下一条用户消息，消费后会自动清掉。
+
 ### 动态成员（运行时增删）
 
 在长时间运行的服务中，Swarm 的成员列表可能会变化（例如远程 Agent

--- a/docs/mkdocs/zh/tool.md
+++ b/docs/mkdocs/zh/tool.md
@@ -1210,7 +1210,7 @@ toolSet := mcp.NewMCPToolSet(
 
 - 🎯 **Per-Run 控制**：每次调用独立配置，不影响 Agent 定义
 - 💰 **成本优化**：减少发送给 LLM 的工具描述，降低 token 消耗
-- 🛡️ **智能保护**：框架工具（`transfer_to_agent`、`knowledge_search`、可选的 `await_user_reply`）自动保留，永不被过滤
+- 🛡️ **智能保护**：框架工具（`transfer_to_agent`、`knowledge_search`、`agentic_knowledge_search`、可选的 `await_user_reply`）自动保留，永不被过滤
 - 🔧 **灵活定制**：支持内置过滤器和自定义 FilterFunc
 
 #### Tool Search（自动工具筛选）

--- a/docs/mkdocs/zh/tool.md
+++ b/docs/mkdocs/zh/tool.md
@@ -1210,7 +1210,7 @@ toolSet := mcp.NewMCPToolSet(
 
 - 🎯 **Per-Run 控制**：每次调用独立配置，不影响 Agent 定义
 - 💰 **成本优化**：减少发送给 LLM 的工具描述，降低 token 消耗
-- 🛡️ **智能保护**：框架工具（`transfer_to_agent`、`knowledge_search`）自动保留，永不被过滤
+- 🛡️ **智能保护**：框架工具（`transfer_to_agent`、`knowledge_search`、可选的 `await_user_reply`）自动保留，永不被过滤
 - 🔧 **灵活定制**：支持内置过滤器和自定义 FilterFunc
 
 #### Tool Search（自动工具筛选）
@@ -1466,7 +1466,7 @@ eventChan, err := runner.Run(ctx, userID, sessionID, message,
 | 工具分类     | 包含的工具                                                                                             | 是否被过滤            |
 | ------------ | ------------------------------------------------------------------------------------------------------ | --------------------- |
 | **用户工具** | 通过 `WithTools` 注册的工具<br>通过 `WithToolSets` 注册的工具                                          | ✅ 受过滤控制         |
-| **框架工具** | `transfer_to_agent`（多 Agent 协调）<br>`knowledge_search`（知识库检索）<br>`agentic_knowledge_search` | ❌ 永不过滤，自动保留 |
+| **框架工具** | `transfer_to_agent`（多 Agent 协调）<br>`knowledge_search`（知识库检索）<br>`agentic_knowledge_search`<br>`await_user_reply`（开启后的一次性追问路由） | ❌ 永不过滤，自动保留 |
 
 **示例：**
 
@@ -1479,6 +1479,7 @@ agent := llmagent.New("assistant",
     }),
     llmagent.WithSubAgents([]agent.Agent{subAgent1, subAgent2}), // 自动添加 transfer_to_agent
     llmagent.WithKnowledge(kb),                                   // 自动添加 knowledge_search
+    llmagent.WithAwaitUserReplyTool(true),                        // 自动添加 await_user_reply
 )
 
 // 运行时过滤：只允许 calculator
@@ -1492,7 +1493,34 @@ runner.Run(ctx, userID, sessionID, message,
 // ❌ textTool          - 用户工具，被过滤
 // ✅ transfer_to_agent - 框架工具，自动保留
 // ✅ knowledge_search  - 框架工具，自动保留
+// ✅ await_user_reply  - 框架工具，自动保留
 ```
+
+#### 用 `await_user_reply` 处理跨轮追问
+
+`await_user_reply` 是一个可选框架工具。当某个 Agent 可能向用户补问信息，并且
+你希望下一条用户消息继续回到这个 Agent 时，可以开启
+`llmagent.WithAwaitUserReplyTool(true)`。
+
+它需要和 `runner.WithAwaitUserReplyRouting(true)` 搭配使用：
+
+```go
+agent := llmagent.New("profile-agent",
+    llmagent.WithAwaitUserReplyTool(true),
+    llmagent.WithInstruction(`
+如果你必须向用户补一个缺失字段，先调用 await_user_reply，
+再提出问题。
+`),
+)
+
+r := runner.NewRunner(
+    "crm-app",
+    coordinatorAgent,
+    runner.WithAwaitUserReplyRouting(true),
+)
+```
+
+这条路由是一次性的：Runner 会在下一条用户消息到来时消费它，然后自动清掉。
 
 #### 注意事项
 
@@ -1640,7 +1668,9 @@ if !removed {
 运行时 ToolSet 更新会自动与前文的**工具过滤机制**协同工作：
 
 - 通过 `WithTools` 和所有 ToolSet（包括动态添加的 ToolSet）注册的工具都视为**用户工具**，会受到 `WithToolFilter` 以及每次调用的运行时过滤控制。
-- 框架工具（`transfer_to_agent`、`knowledge_search`、`agentic_knowledge_search`）仍然**永远不被过滤**，始终对 Agent 可用。
+- 框架工具（`transfer_to_agent`、`knowledge_search`、
+  `agentic_knowledge_search`、可选的 `await_user_reply`）仍然
+  **永远不被过滤**，始终对 Agent 可用。
 
 #### Tool Call 参数自动修复
 

--- a/docs/mkdocs/zh/tool.md
+++ b/docs/mkdocs/zh/tool.md
@@ -1505,7 +1505,7 @@ runner.Run(ctx, userID, sessionID, message,
 它需要和 `runner.WithAwaitUserReplyRouting(true)` 搭配使用：
 
 ```go
-agent := llmagent.New("profile-agent",
+profileAgent := llmagent.New("profile-agent",
     llmagent.WithAwaitUserReplyTool(true),
     llmagent.WithInstruction(`
 如果你必须向用户补一个缺失字段，先调用 await_user_reply，
@@ -1515,7 +1515,7 @@ agent := llmagent.New("profile-agent",
 
 r := runner.NewRunner(
     "crm-app",
-    coordinatorAgent,
+    profileAgent,
     runner.WithAwaitUserReplyRouting(true),
 )
 ```

--- a/runner/agent_lookup.go
+++ b/runner/agent_lookup.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
-	"trpc.group/trpc-go/trpc-agent-go/telemetry/appid"
 )
 
 func (r *runner) loadRegisteredAgent(
@@ -70,9 +69,7 @@ func (r *runner) resolveAwaitUserReplyRoute(
 		}
 	}
 
-	selected := r.wrapSelectedAgent(current)
-	appid.RegisterRunner(r.appName, selected.Info().Name)
-	return selected, rootName, true, nil
+	return current, rootName, true, nil
 }
 
 func splitAgentPath(path string) []string {

--- a/runner/agent_lookup.go
+++ b/runner/agent_lookup.go
@@ -1,0 +1,147 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package runner
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/telemetry/appid"
+)
+
+func (r *runner) lookupNamedAgent(
+	ctx context.Context,
+	agentName string,
+	ro agent.RunOptions,
+) (agent.Agent, bool, error) {
+	if ag, ok := r.agents[agentName]; ok && ag != nil {
+		selected := r.wrapSelectedAgent(ag)
+		appid.RegisterRunner(r.appName, selected.Info().Name)
+		return selected, true, nil
+	}
+	if factory, ok := r.agentFactories[agentName]; ok && factory != nil {
+		created, err := factory(ctx, ro)
+		if err != nil {
+			return nil, false, fmt.Errorf("runner: agent factory: %w", err)
+		}
+		if created == nil {
+			return nil, false, fmt.Errorf(
+				"runner: agent factory returned nil",
+			)
+		}
+		selected := r.wrapSelectedAgent(created)
+		appid.RegisterRunner(r.appName, selected.Info().Name)
+		return selected, true, nil
+	}
+	ag, ok := findUniqueNestedAgent(r.agents, agentName)
+	if !ok || ag == nil {
+		return nil, false, nil
+	}
+	selected := r.wrapSelectedAgent(ag)
+	appid.RegisterRunner(r.appName, selected.Info().Name)
+	return selected, true, nil
+}
+
+func findUniqueNestedAgent(
+	roots map[string]agent.Agent,
+	targetName string,
+) (agent.Agent, bool) {
+	if targetName == "" || len(roots) == 0 {
+		return nil, false
+	}
+	var found agent.Agent
+	visited := make(map[uintptr]struct{})
+	for _, root := range roots {
+		candidate, matched, ambiguous := findAgentInTree(
+			root,
+			targetName,
+			visited,
+		)
+		if ambiguous {
+			return nil, false
+		}
+		if !matched {
+			continue
+		}
+		if found != nil {
+			return nil, false
+		}
+		found = candidate
+	}
+	return found, found != nil
+}
+
+func findAgentInTree(
+	root agent.Agent,
+	targetName string,
+	visited map[uintptr]struct{},
+) (agent.Agent, bool, bool) {
+	if root == nil {
+		return nil, false, false
+	}
+	rootID, ok := comparableAgentID(root)
+	if ok {
+		if _, seen := visited[rootID]; seen {
+			return nil, false, false
+		}
+		visited[rootID] = struct{}{}
+	}
+
+	var found agent.Agent
+	for _, sub := range root.SubAgents() {
+		if sub == nil {
+			continue
+		}
+		if sub.Info().Name == targetName {
+			if found != nil {
+				return nil, false, true
+			}
+			found = sub
+		}
+		nested, matched, ambiguous := findAgentInTree(
+			sub,
+			targetName,
+			visited,
+		)
+		if ambiguous {
+			return nil, false, true
+		}
+		if matched {
+			if found != nil {
+				return nil, false, true
+			}
+			found = nested
+		}
+	}
+	return found, found != nil, false
+}
+
+func comparableAgentID(ag agent.Agent) (uintptr, bool) {
+	if ag == nil {
+		return 0, false
+	}
+	value := reflect.ValueOf(ag)
+	switch value.Kind() {
+	case reflect.Chan,
+		reflect.Func,
+		reflect.Map,
+		reflect.Pointer,
+		reflect.Slice,
+		reflect.UnsafePointer:
+		if value.IsNil() {
+			return 0, false
+		}
+		return value.Pointer(), true
+	default:
+		return 0, false
+	}
+}

--- a/runner/agent_lookup.go
+++ b/runner/agent_lookup.go
@@ -12,21 +12,19 @@ package runner
 import (
 	"context"
 	"fmt"
-	"reflect"
+	"strings"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/telemetry/appid"
 )
 
-func (r *runner) lookupNamedAgent(
+func (r *runner) loadRegisteredAgent(
 	ctx context.Context,
 	agentName string,
 	ro agent.RunOptions,
 ) (agent.Agent, bool, error) {
 	if ag, ok := r.agents[agentName]; ok && ag != nil {
-		selected := r.wrapSelectedAgent(ag)
-		appid.RegisterRunner(r.appName, selected.Info().Name)
-		return selected, true, nil
+		return ag, true, nil
 	}
 	if factory, ok := r.agentFactories[agentName]; ok && factory != nil {
 		created, err := factory(ctx, ro)
@@ -38,110 +36,54 @@ func (r *runner) lookupNamedAgent(
 				"runner: agent factory returned nil",
 			)
 		}
-		selected := r.wrapSelectedAgent(created)
-		appid.RegisterRunner(r.appName, selected.Info().Name)
-		return selected, true, nil
+		return created, true, nil
 	}
-	ag, ok := findUniqueNestedAgent(r.agents, agentName)
-	if !ok || ag == nil {
-		return nil, false, nil
+	return nil, false, nil
+}
+
+func (r *runner) resolveAwaitUserReplyRoute(
+	ctx context.Context,
+	route agent.AwaitUserReplyRoute,
+	ro agent.RunOptions,
+) (agent.Agent, string, bool, error) {
+	if r == nil {
+		return nil, "", false, nil
 	}
-	selected := r.wrapSelectedAgent(ag)
+	segments := splitAgentPath(route.LookupPath)
+	if len(segments) == 0 {
+		return nil, "", false, nil
+	}
+
+	rootName := segments[0]
+	current, ok, err := r.loadRegisteredAgent(ctx, rootName, ro)
+	if err != nil {
+		return nil, "", false, err
+	}
+	if !ok || current == nil {
+		return nil, "", false, nil
+	}
+
+	for _, segment := range segments[1:] {
+		current = current.FindSubAgent(segment)
+		if current == nil {
+			return nil, "", false, nil
+		}
+	}
+
+	selected := r.wrapSelectedAgent(current)
 	appid.RegisterRunner(r.appName, selected.Info().Name)
-	return selected, true, nil
+	return selected, rootName, true, nil
 }
 
-func findUniqueNestedAgent(
-	roots map[string]agent.Agent,
-	targetName string,
-) (agent.Agent, bool) {
-	if targetName == "" || len(roots) == 0 {
-		return nil, false
-	}
-	var found agent.Agent
-	visited := make(map[uintptr]struct{})
-	for _, root := range roots {
-		candidate, matched, ambiguous := findAgentInTree(
-			root,
-			targetName,
-			visited,
-		)
-		if ambiguous {
-			return nil, false
-		}
-		if !matched {
+func splitAgentPath(path string) []string {
+	parts := strings.Split(path, agent.BranchDelimiter)
+	segments := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
 			continue
 		}
-		if found != nil {
-			return nil, false
-		}
-		found = candidate
+		segments = append(segments, part)
 	}
-	return found, found != nil
-}
-
-func findAgentInTree(
-	root agent.Agent,
-	targetName string,
-	visited map[uintptr]struct{},
-) (agent.Agent, bool, bool) {
-	if root == nil {
-		return nil, false, false
-	}
-	rootID, ok := comparableAgentID(root)
-	if ok {
-		if _, seen := visited[rootID]; seen {
-			return nil, false, false
-		}
-		visited[rootID] = struct{}{}
-	}
-
-	var found agent.Agent
-	for _, sub := range root.SubAgents() {
-		if sub == nil {
-			continue
-		}
-		if sub.Info().Name == targetName {
-			if found != nil {
-				return nil, false, true
-			}
-			found = sub
-		}
-		nested, matched, ambiguous := findAgentInTree(
-			sub,
-			targetName,
-			visited,
-		)
-		if ambiguous {
-			return nil, false, true
-		}
-		if matched {
-			if found != nil {
-				return nil, false, true
-			}
-			found = nested
-		}
-	}
-	return found, found != nil, false
-}
-
-func comparableAgentID(ag agent.Agent) (uintptr, bool) {
-	if ag == nil {
-		return 0, false
-	}
-	value := reflect.ValueOf(ag)
-	switch value.Kind() {
-	case reflect.Chan,
-		reflect.Func,
-		reflect.Map,
-		reflect.Pointer,
-		reflect.Slice,
-		reflect.UnsafePointer:
-		if value.IsNil() {
-			return 0, false
-		}
-		return value.Pointer(), true
-	default:
-		return 0, false
-	}
+	return segments
 }

--- a/runner/await_user_reply.go
+++ b/runner/await_user_reply.go
@@ -29,11 +29,16 @@ func (r *runner) applyAwaitUserReplyRoute(
 	if r == nil || !r.awaitUserReplyRouting {
 		return ro, "", nil
 	}
-	if ro.Agent != nil || ro.AgentByName != "" {
-		return ro, "", nil
-	}
 	if message.Role != model.RoleUser {
 		return ro, "", nil
+	}
+	if ro.Agent != nil || ro.AgentByName != "" {
+		return r.clearOverriddenAwaitUserReplyRoute(
+			ctx,
+			key,
+			sess,
+			ro,
+		)
 	}
 
 	route, ok, err := agent.PendingAwaitUserReplyRoute(sess)
@@ -79,6 +84,35 @@ func (r *runner) applyAwaitUserReplyRoute(
 	}
 	ro.Agent = selected
 	return ro, rootName, nil
+}
+
+func (r *runner) clearOverriddenAwaitUserReplyRoute(
+	ctx context.Context,
+	key session.Key,
+	sess *session.Session,
+	ro agent.RunOptions,
+) (agent.RunOptions, string, error) {
+	_, ok, err := agent.PendingAwaitUserReplyRoute(sess)
+	if err != nil {
+		if clearErr := r.clearAwaitUserReplyRoute(ctx, key, sess); clearErr != nil {
+			return ro, "", fmt.Errorf(
+				"runner: clear invalid await_user_reply route: %w",
+				clearErr,
+			)
+		}
+		log.Warnf("runner: ignore invalid await_user_reply route: %v", err)
+		return ro, "", nil
+	}
+	if !ok {
+		return ro, "", nil
+	}
+	if err := r.clearAwaitUserReplyRoute(ctx, key, sess); err != nil {
+		return ro, "", fmt.Errorf(
+			"runner: clear overridden await_user_reply route: %w",
+			err,
+		)
+	}
+	return ro, "", nil
 }
 
 func (r *runner) clearAwaitUserReplyRoute(

--- a/runner/await_user_reply.go
+++ b/runner/await_user_reply.go
@@ -1,0 +1,109 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package runner
+
+import (
+	"context"
+	"fmt"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/log"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+func (r *runner) applyAwaitUserReplyRoute(
+	ctx context.Context,
+	key session.Key,
+	sess *session.Session,
+	message model.Message,
+	ro agent.RunOptions,
+) (agent.RunOptions, error) {
+	if r == nil || !r.awaitUserReplyRouting {
+		return ro, nil
+	}
+	if ro.Agent != nil || ro.AgentByName != "" {
+		return ro, nil
+	}
+	if message.Role != model.RoleUser {
+		return ro, nil
+	}
+
+	route, ok, err := agent.PendingAwaitUserReplyRoute(sess)
+	if err != nil {
+		if clearErr := r.clearAwaitUserReplyRoute(ctx, key, sess); clearErr != nil {
+			return ro, fmt.Errorf(
+				"runner: clear invalid await_user_reply route: %w",
+				clearErr,
+			)
+		}
+		log.Warnf("runner: ignore invalid await_user_reply route: %v", err)
+		return ro, nil
+	}
+	if !ok {
+		return ro, nil
+	}
+	if !r.canResolveAgent(route.AgentName) {
+		if clearErr := r.clearAwaitUserReplyRoute(ctx, key, sess); clearErr != nil {
+			return ro, fmt.Errorf(
+				"runner: clear stale await_user_reply route: %w",
+				clearErr,
+			)
+		}
+		log.Warnf(
+			"runner: ignore stale await_user_reply route for agent %q",
+			route.AgentName,
+		)
+		return ro, nil
+	}
+	if err := r.clearAwaitUserReplyRoute(ctx, key, sess); err != nil {
+		return ro, fmt.Errorf(
+			"runner: consume await_user_reply route: %w",
+			err,
+		)
+	}
+	ro.AgentByName = route.AgentName
+	return ro, nil
+}
+
+func (r *runner) clearAwaitUserReplyRoute(
+	ctx context.Context,
+	key session.Key,
+	sess *session.Session,
+) error {
+	if r == nil || r.sessionService == nil {
+		return nil
+	}
+	state := agent.ClearAwaitUserReplyRouteState()
+	if err := r.sessionService.UpdateSessionState(ctx, key, state); err != nil {
+		return err
+	}
+	if sess == nil {
+		return nil
+	}
+	for stateKey := range state {
+		sess.SetState(stateKey, nil)
+	}
+	return nil
+}
+
+func (r *runner) canResolveAgent(name string) bool {
+	if r == nil || name == "" {
+		return false
+	}
+	if ag, ok := r.agents[name]; ok && ag != nil {
+		return true
+	}
+	if factory, ok := r.agentFactories[name]; ok && factory != nil {
+		return true
+	}
+	_, ok := findUniqueNestedAgent(r.agents, name)
+	return ok
+}

--- a/runner/await_user_reply.go
+++ b/runner/await_user_reply.go
@@ -25,52 +25,60 @@ func (r *runner) applyAwaitUserReplyRoute(
 	sess *session.Session,
 	message model.Message,
 	ro agent.RunOptions,
-) (agent.RunOptions, error) {
+) (agent.RunOptions, string, error) {
 	if r == nil || !r.awaitUserReplyRouting {
-		return ro, nil
+		return ro, "", nil
 	}
 	if ro.Agent != nil || ro.AgentByName != "" {
-		return ro, nil
+		return ro, "", nil
 	}
 	if message.Role != model.RoleUser {
-		return ro, nil
+		return ro, "", nil
 	}
 
 	route, ok, err := agent.PendingAwaitUserReplyRoute(sess)
 	if err != nil {
 		if clearErr := r.clearAwaitUserReplyRoute(ctx, key, sess); clearErr != nil {
-			return ro, fmt.Errorf(
+			return ro, "", fmt.Errorf(
 				"runner: clear invalid await_user_reply route: %w",
 				clearErr,
 			)
 		}
 		log.Warnf("runner: ignore invalid await_user_reply route: %v", err)
-		return ro, nil
+		return ro, "", nil
 	}
 	if !ok {
-		return ro, nil
+		return ro, "", nil
 	}
-	if !r.canResolveAgent(route.AgentName) {
+	selected, rootName, ok, err := r.resolveAwaitUserReplyRoute(
+		ctx,
+		route,
+		ro,
+	)
+	if err != nil {
+		return ro, "", err
+	}
+	if !ok {
 		if clearErr := r.clearAwaitUserReplyRoute(ctx, key, sess); clearErr != nil {
-			return ro, fmt.Errorf(
+			return ro, "", fmt.Errorf(
 				"runner: clear stale await_user_reply route: %w",
 				clearErr,
 			)
 		}
 		log.Warnf(
-			"runner: ignore stale await_user_reply route for agent %q",
-			route.AgentName,
+			"runner: ignore stale await_user_reply route for path %q",
+			route.LookupPath,
 		)
-		return ro, nil
+		return ro, "", nil
 	}
 	if err := r.clearAwaitUserReplyRoute(ctx, key, sess); err != nil {
-		return ro, fmt.Errorf(
+		return ro, "", fmt.Errorf(
 			"runner: consume await_user_reply route: %w",
 			err,
 		)
 	}
-	ro.AgentByName = route.AgentName
-	return ro, nil
+	ro.Agent = selected
+	return ro, rootName, nil
 }
 
 func (r *runner) clearAwaitUserReplyRoute(
@@ -92,18 +100,4 @@ func (r *runner) clearAwaitUserReplyRoute(
 		sess.SetState(stateKey, nil)
 	}
 	return nil
-}
-
-func (r *runner) canResolveAgent(name string) bool {
-	if r == nil || name == "" {
-		return false
-	}
-	if ag, ok := r.agents[name]; ok && ag != nil {
-		return true
-	}
-	if factory, ok := r.agentFactories[name]; ok && factory != nil {
-		return true
-	}
-	_, ok := findUniqueNestedAgent(r.agents, name)
-	return ok
 }

--- a/runner/await_user_reply_test.go
+++ b/runner/await_user_reply_test.go
@@ -409,3 +409,28 @@ func TestRunner_Run_AwaitUserReplyRoutingResolvesFactorySubAgentPath(
 	require.Equal(t, 1, factoryCalls)
 	require.Equal(t, 1, child.calls)
 }
+
+func TestRunner_ResolveAwaitUserReplyRoute_ReturnsRawAgent(t *testing.T) {
+	child := &awaitReplyTrackingAgent{name: "child"}
+	parent := &awaitReplyTrackingAgent{
+		name:      "parent",
+		subAgents: []agent.Agent{child},
+	}
+	r := &runner{
+		agents:         map[string]agent.Agent{"parent": parent},
+		agentFactories: map[string]AgentFactory{},
+	}
+
+	got, rootName, ok, err := r.resolveAwaitUserReplyRoute(
+		context.Background(),
+		agent.AwaitUserReplyRoute{
+			AgentName:  "child",
+			LookupPath: "parent/child",
+		},
+		agent.RunOptions{},
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "parent", rootName)
+	require.Same(t, child, got)
+}

--- a/runner/await_user_reply_test.go
+++ b/runner/await_user_reply_test.go
@@ -26,6 +26,7 @@ import (
 type awaitReplyTrackingAgent struct {
 	name      string
 	subAgents []agent.Agent
+	markAwait bool
 	calls     int
 }
 
@@ -58,6 +59,9 @@ func (a *awaitReplyTrackingAgent) Run(
 	ch := make(chan *event.Event, 1)
 	go func() {
 		defer close(ch)
+		if a.markAwait {
+			_ = agent.MarkAwaitingUserReply(inv)
+		}
 		_ = agent.EmitEvent(
 			ctx,
 			inv,
@@ -173,6 +177,7 @@ func TestRunner_Run_AwaitUserReplyRoutingExplicitAgentWins(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ok)
 	require.Equal(t, "child", route.AgentName)
+	require.Equal(t, "child", route.LookupPath)
 }
 
 func TestRunner_Run_AwaitUserReplyRoutingFallsBackWhenMissing(t *testing.T) {
@@ -218,7 +223,7 @@ func TestRunner_Run_AwaitUserReplyRoutingFallsBackWhenMissing(t *testing.T) {
 	require.False(t, ok)
 }
 
-func TestRunner_Run_AwaitUserReplyRoutingResolvesNestedSubAgent(t *testing.T) {
+func TestRunner_Run_AwaitUserReplyRoutingResolvesNestedPath(t *testing.T) {
 	ctx := context.Background()
 	svc := sessioninmemory.NewSessionService()
 	key := session.Key{
@@ -227,21 +232,24 @@ func TestRunner_Run_AwaitUserReplyRoutingResolvesNestedSubAgent(t *testing.T) {
 		SessionID: "sess-nested",
 	}
 	state, err := (agent.AwaitUserReplyRoute{
-		AgentName: "child",
+		AgentName:  "child",
+		LookupPath: "parent/child",
 	}).State()
 	require.NoError(t, err)
 	_, err = svc.CreateSession(ctx, key, state)
 	require.NoError(t, err)
 
-	child := &awaitReplyTrackingAgent{name: "child"}
+	nestedChild := &awaitReplyTrackingAgent{name: "child"}
 	parent := &awaitReplyTrackingAgent{
 		name:      "parent",
-		subAgents: []agent.Agent{child},
+		subAgents: []agent.Agent{nestedChild},
 	}
+	topLevelChild := &awaitReplyTrackingAgent{name: "child"}
 	r := NewRunner(
 		"app",
 		parent,
 		WithSessionService(svc),
+		WithAgent("child", topLevelChild),
 		WithAwaitUserReplyRouting(true),
 	)
 
@@ -257,5 +265,103 @@ func TestRunner_Run_AwaitUserReplyRoutingResolvesNestedSubAgent(t *testing.T) {
 	}
 
 	require.Equal(t, 0, parent.calls)
+	require.Equal(t, 1, nestedChild.calls)
+	require.Equal(t, 0, topLevelChild.calls)
+}
+
+func TestRunner_Run_AwaitUserReplyRoutingPersistsFactoryLookupPath(
+	t *testing.T,
+) {
+	ctx := context.Background()
+	svc := sessioninmemory.NewSessionService()
+	r := NewRunnerWithAgentFactory(
+		"app",
+		"coordinator",
+		func(
+			_ context.Context,
+			_ agent.RunOptions,
+		) (agent.Agent, error) {
+			return &awaitReplyTrackingAgent{
+				name:      "runtime-root",
+				markAwait: true,
+			}, nil
+		},
+		WithSessionService(svc),
+		WithAwaitUserReplyRouting(true),
+	)
+
+	eventCh, err := r.Run(
+		ctx,
+		"user",
+		"sess-factory-root",
+		model.NewUserMessage("first turn"),
+		agent.WithRequestID("req-await-factory-root"),
+	)
+	require.NoError(t, err)
+	for range eventCh {
+	}
+
+	sess, err := svc.GetSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "sess-factory-root",
+	})
+	require.NoError(t, err)
+	route, ok, err := agent.PendingAwaitUserReplyRoute(sess)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "runtime-root", route.AgentName)
+	require.Equal(t, "coordinator", route.LookupPath)
+}
+
+func TestRunner_Run_AwaitUserReplyRoutingResolvesFactorySubAgentPath(
+	t *testing.T,
+) {
+	ctx := context.Background()
+	svc := sessioninmemory.NewSessionService()
+	key := session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "sess-factory-nested",
+	}
+	state, err := (agent.AwaitUserReplyRoute{
+		AgentName:  "child",
+		LookupPath: "coordinator/child",
+	}).State()
+	require.NoError(t, err)
+	_, err = svc.CreateSession(ctx, key, state)
+	require.NoError(t, err)
+
+	child := &awaitReplyTrackingAgent{name: "child"}
+	factoryCalls := 0
+	r := NewRunnerWithAgentFactory(
+		"app",
+		"coordinator",
+		func(
+			_ context.Context,
+			_ agent.RunOptions,
+		) (agent.Agent, error) {
+			factoryCalls++
+			return &awaitReplyTrackingAgent{
+				name:      "runtime-root",
+				subAgents: []agent.Agent{child},
+			}, nil
+		},
+		WithSessionService(svc),
+		WithAwaitUserReplyRouting(true),
+	)
+
+	eventCh, err := r.Run(
+		ctx,
+		key.UserID,
+		key.SessionID,
+		model.NewUserMessage("follow up"),
+		agent.WithRequestID("req-await-factory-nested"),
+	)
+	require.NoError(t, err)
+	for range eventCh {
+	}
+
+	require.Equal(t, 1, factoryCalls)
 	require.Equal(t, 1, child.calls)
 }

--- a/runner/await_user_reply_test.go
+++ b/runner/await_user_reply_test.go
@@ -1,0 +1,261 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package runner
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	sessioninmemory "trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+type awaitReplyTrackingAgent struct {
+	name      string
+	subAgents []agent.Agent
+	calls     int
+}
+
+func (a *awaitReplyTrackingAgent) Info() agent.Info {
+	return agent.Info{Name: a.name}
+}
+
+func (a *awaitReplyTrackingAgent) SubAgents() []agent.Agent {
+	return a.subAgents
+}
+
+func (a *awaitReplyTrackingAgent) FindSubAgent(name string) agent.Agent {
+	for _, sub := range a.subAgents {
+		if sub != nil && sub.Info().Name == name {
+			return sub
+		}
+	}
+	return nil
+}
+
+func (a *awaitReplyTrackingAgent) Tools() []tool.Tool {
+	return nil
+}
+
+func (a *awaitReplyTrackingAgent) Run(
+	ctx context.Context,
+	inv *agent.Invocation,
+) (<-chan *event.Event, error) {
+	a.calls++
+	ch := make(chan *event.Event, 1)
+	go func() {
+		defer close(ch)
+		_ = agent.EmitEvent(
+			ctx,
+			inv,
+			ch,
+			event.NewResponseEvent(
+				inv.InvocationID,
+				a.name,
+				&model.Response{
+					Done: true,
+					Choices: []model.Choice{{
+						Index: 0,
+						Message: model.Message{
+							Role:    model.RoleAssistant,
+							Content: a.name,
+						},
+					}},
+				},
+			),
+		)
+	}()
+	return ch, nil
+}
+
+func TestRunner_Run_AwaitUserReplyRoutingConsumesRoute(t *testing.T) {
+	ctx := context.Background()
+	svc := sessioninmemory.NewSessionService()
+	key := session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "sess",
+	}
+	state, err := (agent.AwaitUserReplyRoute{
+		AgentName: "child",
+	}).State()
+	require.NoError(t, err)
+	_, err = svc.CreateSession(ctx, key, state)
+	require.NoError(t, err)
+
+	parent := &awaitReplyTrackingAgent{name: "parent"}
+	child := &awaitReplyTrackingAgent{name: "child"}
+	r := NewRunner(
+		"app",
+		parent,
+		WithSessionService(svc),
+		WithAgent("child", child),
+		WithAwaitUserReplyRouting(true),
+	)
+
+	eventCh, err := r.Run(
+		ctx,
+		key.UserID,
+		key.SessionID,
+		model.NewUserMessage("follow up"),
+		agent.WithRequestID("req-await-consume"),
+	)
+	require.NoError(t, err)
+	for range eventCh {
+	}
+
+	require.Equal(t, 0, parent.calls)
+	require.Equal(t, 1, child.calls)
+
+	sess, err := svc.GetSession(ctx, key)
+	require.NoError(t, err)
+	_, ok, err := agent.PendingAwaitUserReplyRoute(sess)
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func TestRunner_Run_AwaitUserReplyRoutingExplicitAgentWins(t *testing.T) {
+	ctx := context.Background()
+	svc := sessioninmemory.NewSessionService()
+	key := session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "sess-explicit",
+	}
+	state, err := (agent.AwaitUserReplyRoute{
+		AgentName: "child",
+	}).State()
+	require.NoError(t, err)
+	_, err = svc.CreateSession(ctx, key, state)
+	require.NoError(t, err)
+
+	parent := &awaitReplyTrackingAgent{name: "parent"}
+	child := &awaitReplyTrackingAgent{name: "child"}
+	r := NewRunner(
+		"app",
+		parent,
+		WithSessionService(svc),
+		WithAgent("child", child),
+		WithAwaitUserReplyRouting(true),
+	)
+
+	eventCh, err := r.Run(
+		ctx,
+		key.UserID,
+		key.SessionID,
+		model.NewUserMessage("follow up"),
+		agent.WithRequestID("req-await-explicit"),
+		agent.WithAgentByName("parent"),
+	)
+	require.NoError(t, err)
+	for range eventCh {
+	}
+
+	require.Equal(t, 1, parent.calls)
+	require.Equal(t, 0, child.calls)
+
+	sess, err := svc.GetSession(ctx, key)
+	require.NoError(t, err)
+	route, ok, err := agent.PendingAwaitUserReplyRoute(sess)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "child", route.AgentName)
+}
+
+func TestRunner_Run_AwaitUserReplyRoutingFallsBackWhenMissing(t *testing.T) {
+	ctx := context.Background()
+	svc := sessioninmemory.NewSessionService()
+	key := session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "sess-missing",
+	}
+	state, err := (agent.AwaitUserReplyRoute{
+		AgentName: "missing",
+	}).State()
+	require.NoError(t, err)
+	_, err = svc.CreateSession(ctx, key, state)
+	require.NoError(t, err)
+
+	parent := &awaitReplyTrackingAgent{name: "parent"}
+	r := NewRunner(
+		"app",
+		parent,
+		WithSessionService(svc),
+		WithAwaitUserReplyRouting(true),
+	)
+
+	eventCh, err := r.Run(
+		ctx,
+		key.UserID,
+		key.SessionID,
+		model.NewUserMessage("follow up"),
+		agent.WithRequestID("req-await-missing"),
+	)
+	require.NoError(t, err)
+	for range eventCh {
+	}
+
+	require.Equal(t, 1, parent.calls)
+
+	sess, err := svc.GetSession(ctx, key)
+	require.NoError(t, err)
+	_, ok, err := agent.PendingAwaitUserReplyRoute(sess)
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func TestRunner_Run_AwaitUserReplyRoutingResolvesNestedSubAgent(t *testing.T) {
+	ctx := context.Background()
+	svc := sessioninmemory.NewSessionService()
+	key := session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "sess-nested",
+	}
+	state, err := (agent.AwaitUserReplyRoute{
+		AgentName: "child",
+	}).State()
+	require.NoError(t, err)
+	_, err = svc.CreateSession(ctx, key, state)
+	require.NoError(t, err)
+
+	child := &awaitReplyTrackingAgent{name: "child"}
+	parent := &awaitReplyTrackingAgent{
+		name:      "parent",
+		subAgents: []agent.Agent{child},
+	}
+	r := NewRunner(
+		"app",
+		parent,
+		WithSessionService(svc),
+		WithAwaitUserReplyRouting(true),
+	)
+
+	eventCh, err := r.Run(
+		ctx,
+		key.UserID,
+		key.SessionID,
+		model.NewUserMessage("follow up"),
+		agent.WithRequestID("req-await-nested"),
+	)
+	require.NoError(t, err)
+	for range eventCh {
+	}
+
+	require.Equal(t, 0, parent.calls)
+	require.Equal(t, 1, child.calls)
+}

--- a/runner/await_user_reply_test.go
+++ b/runner/await_user_reply_test.go
@@ -131,6 +131,52 @@ func TestRunner_Run_AwaitUserReplyRoutingConsumesRoute(t *testing.T) {
 	require.False(t, ok)
 }
 
+func TestRunner_Run_AwaitUserReplyRoutingDisabledByDefault(t *testing.T) {
+	ctx := context.Background()
+	svc := sessioninmemory.NewSessionService()
+	key := session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "sess-disabled",
+	}
+	state, err := (agent.AwaitUserReplyRoute{
+		AgentName: "child",
+	}).State()
+	require.NoError(t, err)
+	_, err = svc.CreateSession(ctx, key, state)
+	require.NoError(t, err)
+
+	parent := &awaitReplyTrackingAgent{name: "parent"}
+	child := &awaitReplyTrackingAgent{name: "child"}
+	r := NewRunner(
+		"app",
+		parent,
+		WithSessionService(svc),
+		WithAgent("child", child),
+	)
+
+	eventCh, err := r.Run(
+		ctx,
+		key.UserID,
+		key.SessionID,
+		model.NewUserMessage("follow up"),
+		agent.WithRequestID("req-await-disabled"),
+	)
+	require.NoError(t, err)
+	for range eventCh {
+	}
+
+	require.Equal(t, 1, parent.calls)
+	require.Equal(t, 0, child.calls)
+
+	sess, err := svc.GetSession(ctx, key)
+	require.NoError(t, err)
+	route, ok, err := agent.PendingAwaitUserReplyRoute(sess)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "child", route.AgentName)
+}
+
 func TestRunner_Run_AwaitUserReplyRoutingExplicitAgentWins(t *testing.T) {
 	ctx := context.Background()
 	svc := sessioninmemory.NewSessionService()
@@ -173,11 +219,9 @@ func TestRunner_Run_AwaitUserReplyRoutingExplicitAgentWins(t *testing.T) {
 
 	sess, err := svc.GetSession(ctx, key)
 	require.NoError(t, err)
-	route, ok, err := agent.PendingAwaitUserReplyRoute(sess)
+	_, ok, err := agent.PendingAwaitUserReplyRoute(sess)
 	require.NoError(t, err)
-	require.True(t, ok)
-	require.Equal(t, "child", route.AgentName)
-	require.Equal(t, "child", route.LookupPath)
+	require.False(t, ok)
 }
 
 func TestRunner_Run_AwaitUserReplyRoutingFallsBackWhenMissing(t *testing.T) {

--- a/runner/await_user_reply_test.go
+++ b/runner/await_user_reply_test.go
@@ -11,6 +11,7 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -22,6 +23,29 @@ import (
 	sessioninmemory "trpc.group/trpc-go/trpc-agent-go/session/inmemory"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
+
+type awaitReplyUpdateCall struct {
+	key   session.Key
+	state session.StateMap
+}
+
+type awaitReplySessionService struct {
+	*mockSessionService
+	updateCalls []awaitReplyUpdateCall
+	updateErr   error
+}
+
+func (s *awaitReplySessionService) UpdateSessionState(
+	ctx context.Context,
+	key session.Key,
+	state session.StateMap,
+) error {
+	s.updateCalls = append(
+		s.updateCalls,
+		awaitReplyUpdateCall{key: key, state: state},
+	)
+	return s.updateErr
+}
 
 type awaitReplyTrackingAgent struct {
 	name      string
@@ -433,4 +457,457 @@ func TestRunner_ResolveAwaitUserReplyRoute_ReturnsRawAgent(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "parent", rootName)
 	require.Same(t, child, got)
+}
+
+func TestRunner_ApplyAwaitUserReplyRoute_EdgeCases(t *testing.T) {
+	ctx := context.Background()
+	key := session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "sess",
+	}
+	userMessage := model.NewUserMessage("follow up")
+
+	t.Run("disabled", func(t *testing.T) {
+		r := &runner{}
+
+		got, rootName, err := r.applyAwaitUserReplyRoute(
+			ctx,
+			key,
+			nil,
+			userMessage,
+			agent.RunOptions{},
+		)
+		require.NoError(t, err)
+		require.Empty(t, rootName)
+		require.Nil(t, got.Agent)
+		require.Empty(t, got.AgentByName)
+	})
+
+	t.Run("non user message", func(t *testing.T) {
+		r := &runner{awaitUserReplyRouting: true}
+
+		got, rootName, err := r.applyAwaitUserReplyRoute(
+			ctx,
+			key,
+			nil,
+			model.Message{Role: model.RoleAssistant},
+			agent.RunOptions{},
+		)
+		require.NoError(t, err)
+		require.Empty(t, rootName)
+		require.Nil(t, got.Agent)
+	})
+
+	t.Run("no pending route", func(t *testing.T) {
+		r := &runner{awaitUserReplyRouting: true}
+		sess := session.NewSession("app", "user", "sess")
+
+		got, rootName, err := r.applyAwaitUserReplyRoute(
+			ctx,
+			key,
+			sess,
+			userMessage,
+			agent.RunOptions{},
+		)
+		require.NoError(t, err)
+		require.Empty(t, rootName)
+		require.Nil(t, got.Agent)
+	})
+
+	t.Run("invalid route clear error", func(t *testing.T) {
+		svc := &awaitReplySessionService{
+			mockSessionService: &mockSessionService{},
+			updateErr:          errors.New("clear failed"),
+		}
+		r := &runner{
+			awaitUserReplyRouting: true,
+			sessionService:        svc,
+		}
+		sess := session.NewSession(
+			"app",
+			"user",
+			"sess",
+			session.WithSessionState(session.StateMap{
+				"__trpc_agent_await_user_reply_route__": []byte("{"),
+			}),
+		)
+
+		_, _, err := r.applyAwaitUserReplyRoute(
+			ctx,
+			key,
+			sess,
+			userMessage,
+			agent.RunOptions{},
+		)
+		require.ErrorContains(
+			t,
+			err,
+			"clear invalid await_user_reply route",
+		)
+	})
+
+	t.Run("invalid route clears state", func(t *testing.T) {
+		svc := &awaitReplySessionService{
+			mockSessionService: &mockSessionService{},
+		}
+		r := &runner{
+			awaitUserReplyRouting: true,
+			sessionService:        svc,
+		}
+		sess := session.NewSession(
+			"app",
+			"user",
+			"sess",
+			session.WithSessionState(session.StateMap{
+				"__trpc_agent_await_user_reply_route__": []byte("{"),
+			}),
+		)
+
+		got, rootName, err := r.applyAwaitUserReplyRoute(
+			ctx,
+			key,
+			sess,
+			userMessage,
+			agent.RunOptions{},
+		)
+		require.NoError(t, err)
+		require.Empty(t, rootName)
+		require.Nil(t, got.Agent)
+		require.Len(t, svc.updateCalls, 1)
+	})
+
+	t.Run("stale route clear error", func(t *testing.T) {
+		state, err := (agent.AwaitUserReplyRoute{
+			AgentName: "missing",
+		}).State()
+		require.NoError(t, err)
+
+		svc := &awaitReplySessionService{
+			mockSessionService: &mockSessionService{},
+			updateErr:          errors.New("clear failed"),
+		}
+		r := &runner{
+			awaitUserReplyRouting: true,
+			sessionService:        svc,
+		}
+		sess := session.NewSession(
+			"app",
+			"user",
+			"sess",
+			session.WithSessionState(state),
+		)
+
+		_, _, err = r.applyAwaitUserReplyRoute(
+			ctx,
+			key,
+			sess,
+			userMessage,
+			agent.RunOptions{},
+		)
+		require.ErrorContains(
+			t,
+			err,
+			"clear stale await_user_reply route",
+		)
+	})
+
+	t.Run("resolve error", func(t *testing.T) {
+		state, err := (agent.AwaitUserReplyRoute{
+			AgentName: "child",
+		}).State()
+		require.NoError(t, err)
+
+		r := &runner{
+			awaitUserReplyRouting: true,
+			agentFactories: map[string]AgentFactory{
+				"child": func(
+					context.Context,
+					agent.RunOptions,
+				) (agent.Agent, error) {
+					return nil, errors.New("factory failed")
+				},
+			},
+		}
+		sess := session.NewSession(
+			"app",
+			"user",
+			"sess",
+			session.WithSessionState(state),
+		)
+
+		_, _, err = r.applyAwaitUserReplyRoute(
+			ctx,
+			key,
+			sess,
+			userMessage,
+			agent.RunOptions{},
+		)
+		require.ErrorContains(t, err, "factory failed")
+	})
+}
+
+func TestRunner_ClearOverriddenAwaitUserReplyRoute_EdgeCases(t *testing.T) {
+	ctx := context.Background()
+	key := session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "sess",
+	}
+	ro := agent.RunOptions{AgentByName: "parent"}
+
+	t.Run("no pending route", func(t *testing.T) {
+		svc := &awaitReplySessionService{
+			mockSessionService: &mockSessionService{},
+		}
+		r := &runner{sessionService: svc}
+		sess := session.NewSession("app", "user", "sess")
+
+		got, rootName, err := r.clearOverriddenAwaitUserReplyRoute(
+			ctx,
+			key,
+			sess,
+			ro,
+		)
+		require.NoError(t, err)
+		require.Empty(t, rootName)
+		require.Equal(t, ro.AgentByName, got.AgentByName)
+		require.Empty(t, svc.updateCalls)
+	})
+
+	t.Run("invalid route clears state", func(t *testing.T) {
+		svc := &awaitReplySessionService{
+			mockSessionService: &mockSessionService{},
+		}
+		r := &runner{sessionService: svc}
+		sess := session.NewSession(
+			"app",
+			"user",
+			"sess",
+			session.WithSessionState(session.StateMap{
+				"__trpc_agent_await_user_reply_route__": []byte("{"),
+			}),
+		)
+
+		_, _, err := r.clearOverriddenAwaitUserReplyRoute(
+			ctx,
+			key,
+			sess,
+			ro,
+		)
+		require.NoError(t, err)
+		require.Len(t, svc.updateCalls, 1)
+
+		_, ok, routeErr := agent.PendingAwaitUserReplyRoute(sess)
+		require.NoError(t, routeErr)
+		require.False(t, ok)
+	})
+
+	t.Run("clear error", func(t *testing.T) {
+		state, err := (agent.AwaitUserReplyRoute{
+			AgentName: "child",
+		}).State()
+		require.NoError(t, err)
+
+		svc := &awaitReplySessionService{
+			mockSessionService: &mockSessionService{},
+			updateErr:          errors.New("clear failed"),
+		}
+		r := &runner{sessionService: svc}
+		sess := session.NewSession(
+			"app",
+			"user",
+			"sess",
+			session.WithSessionState(state),
+		)
+
+		_, _, err = r.clearOverriddenAwaitUserReplyRoute(
+			ctx,
+			key,
+			sess,
+			ro,
+		)
+		require.ErrorContains(
+			t,
+			err,
+			"clear overridden await_user_reply route",
+		)
+	})
+}
+
+func TestRunner_ClearAwaitUserReplyRoute_EdgeCases(t *testing.T) {
+	ctx := context.Background()
+	key := session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "sess",
+	}
+
+	t.Run("nil runner", func(t *testing.T) {
+		var r *runner
+		require.NoError(t, r.clearAwaitUserReplyRoute(ctx, key, nil))
+	})
+
+	t.Run("nil session service", func(t *testing.T) {
+		r := &runner{}
+		require.NoError(t, r.clearAwaitUserReplyRoute(ctx, key, nil))
+	})
+
+	t.Run("nil session", func(t *testing.T) {
+		svc := &awaitReplySessionService{
+			mockSessionService: &mockSessionService{},
+		}
+		r := &runner{sessionService: svc}
+
+		err := r.clearAwaitUserReplyRoute(ctx, key, nil)
+		require.NoError(t, err)
+		require.Len(t, svc.updateCalls, 1)
+		require.Equal(t, key, svc.updateCalls[0].key)
+	})
+
+	t.Run("updates in memory session", func(t *testing.T) {
+		state, err := (agent.AwaitUserReplyRoute{
+			AgentName: "child",
+		}).State()
+		require.NoError(t, err)
+
+		svc := &awaitReplySessionService{
+			mockSessionService: &mockSessionService{},
+		}
+		r := &runner{sessionService: svc}
+		sess := session.NewSession(
+			"app",
+			"user",
+			"sess",
+			session.WithSessionState(state),
+		)
+
+		err = r.clearAwaitUserReplyRoute(ctx, key, sess)
+		require.NoError(t, err)
+		require.Len(t, svc.updateCalls, 1)
+
+		_, ok, routeErr := agent.PendingAwaitUserReplyRoute(sess)
+		require.NoError(t, routeErr)
+		require.False(t, ok)
+	})
+}
+
+func TestRunner_ResolveAwaitUserReplyRoute_EdgeCases(t *testing.T) {
+	ctx := context.Background()
+	ro := agent.RunOptions{}
+
+	t.Run("nil runner", func(t *testing.T) {
+		var r *runner
+
+		got, rootName, ok, err := r.resolveAwaitUserReplyRoute(
+			ctx,
+			agent.AwaitUserReplyRoute{LookupPath: "root"},
+			ro,
+		)
+		require.NoError(t, err)
+		require.False(t, ok)
+		require.Empty(t, rootName)
+		require.Nil(t, got)
+	})
+
+	t.Run("empty path", func(t *testing.T) {
+		r := &runner{}
+
+		got, rootName, ok, err := r.resolveAwaitUserReplyRoute(
+			ctx,
+			agent.AwaitUserReplyRoute{},
+			ro,
+		)
+		require.NoError(t, err)
+		require.False(t, ok)
+		require.Empty(t, rootName)
+		require.Nil(t, got)
+	})
+
+	t.Run("missing root", func(t *testing.T) {
+		r := &runner{
+			agents:         map[string]agent.Agent{},
+			agentFactories: map[string]AgentFactory{},
+		}
+
+		got, rootName, ok, err := r.resolveAwaitUserReplyRoute(
+			ctx,
+			agent.AwaitUserReplyRoute{LookupPath: "missing"},
+			ro,
+		)
+		require.NoError(t, err)
+		require.False(t, ok)
+		require.Empty(t, rootName)
+		require.Nil(t, got)
+	})
+
+	t.Run("missing nested sub agent", func(t *testing.T) {
+		parent := &awaitReplyTrackingAgent{name: "parent"}
+		r := &runner{
+			agents: map[string]agent.Agent{"parent": parent},
+		}
+
+		got, rootName, ok, err := r.resolveAwaitUserReplyRoute(
+			ctx,
+			agent.AwaitUserReplyRoute{
+				LookupPath: "parent/child",
+			},
+			ro,
+		)
+		require.NoError(t, err)
+		require.False(t, ok)
+		require.Empty(t, rootName)
+		require.Nil(t, got)
+	})
+
+	t.Run("factory error", func(t *testing.T) {
+		r := &runner{
+			agentFactories: map[string]AgentFactory{
+				"factory": func(
+					context.Context,
+					agent.RunOptions,
+				) (agent.Agent, error) {
+					return nil, errors.New("factory failed")
+				},
+			},
+		}
+
+		got, rootName, ok, err := r.resolveAwaitUserReplyRoute(
+			ctx,
+			agent.AwaitUserReplyRoute{LookupPath: "factory"},
+			ro,
+		)
+		require.ErrorContains(t, err, "factory failed")
+		require.False(t, ok)
+		require.Empty(t, rootName)
+		require.Nil(t, got)
+	})
+
+	t.Run("factory returned nil", func(t *testing.T) {
+		r := &runner{
+			agentFactories: map[string]AgentFactory{
+				"factory": func(
+					context.Context,
+					agent.RunOptions,
+				) (agent.Agent, error) {
+					return nil, nil
+				},
+			},
+		}
+
+		got, rootName, ok, err := r.resolveAwaitUserReplyRoute(
+			ctx,
+			agent.AwaitUserReplyRoute{LookupPath: "factory"},
+			ro,
+		)
+		require.ErrorContains(t, err, "returned nil")
+		require.False(t, ok)
+		require.Empty(t, rootName)
+		require.Nil(t, got)
+	})
+}
+
+func TestSplitAgentPath_TrimsEmptySegments(t *testing.T) {
+	got := splitAgentPath(" / root // child / ")
+	require.Equal(t, []string{"root", "child"}, got)
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -135,6 +135,22 @@ func WithPlugins(plugins ...plugin.Plugin) Option {
 	}
 }
 
+// WithAwaitUserReplyRouting enables one-shot next-user-turn routing from
+// session state produced by agent.MarkAwaitingUserReply or the
+// await_user_reply framework tool.
+//
+// When enabled, Runner checks session state before each user turn. If the
+// previous turn persisted an await-user-reply route, Runner consumes that
+// route once and starts the new run from the recorded agent instead of the
+// default agent.
+//
+// Default: false.
+func WithAwaitUserReplyRouting(enabled bool) Option {
+	return func(opts *Options) {
+		opts.awaitUserReplyRouting = enabled
+	}
+}
+
 // Runner is the interface for running agents.
 type Runner interface {
 	Run(
@@ -207,16 +223,17 @@ type RunStatus struct {
 
 // runner runs agents.
 type runner struct {
-	appName          string
-	defaultAgentName string
-	agents           map[string]agent.Agent
-	agentFactories   map[string]AgentFactory
-	sessionService   session.Service
-	memoryService    memory.Service
-	ingestor         session.Ingestor
-	artifactService  artifact.Service
-	pluginManager    agent.PluginManager
-	ralphLoop        *RalphLoopConfig
+	appName               string
+	defaultAgentName      string
+	agents                map[string]agent.Agent
+	agentFactories        map[string]AgentFactory
+	sessionService        session.Service
+	memoryService         memory.Service
+	ingestor              session.Ingestor
+	artifactService       artifact.Service
+	pluginManager         agent.PluginManager
+	ralphLoop             *RalphLoopConfig
+	awaitUserReplyRouting bool
 
 	// Resource management fields.
 	ownedSessionService bool      // Indicates if sessionService was created by this runner.
@@ -236,14 +253,15 @@ type runHandle struct {
 
 // Options is the options for the Runner.
 type Options struct {
-	sessionService  session.Service
-	memoryService   memory.Service
-	ingestor        session.Ingestor
-	artifactService artifact.Service
-	agents          map[string]agent.Agent
-	agentFactories  map[string]AgentFactory
-	plugins         []plugin.Plugin
-	ralphLoop       *RalphLoopConfig
+	sessionService        session.Service
+	memoryService         memory.Service
+	ingestor              session.Ingestor
+	artifactService       artifact.Service
+	agents                map[string]agent.Agent
+	agentFactories        map[string]AgentFactory
+	plugins               []plugin.Plugin
+	ralphLoop             *RalphLoopConfig
+	awaitUserReplyRouting bool
 }
 
 // newOptions creates a new Options.
@@ -283,17 +301,18 @@ func NewRunner(appName string, ag agent.Agent, opts ...Option) Runner {
 		appid.RegisterRunner(appName, a.Info().Name)
 	}
 	return &runner{
-		appName:             appName,
-		defaultAgentName:    ag.Info().Name,
-		agents:              agents,
-		agentFactories:      options.agentFactories,
-		sessionService:      options.sessionService,
-		memoryService:       options.memoryService,
-		ingestor:            options.ingestor,
-		artifactService:     options.artifactService,
-		pluginManager:       pm,
-		ralphLoop:           options.ralphLoop,
-		ownedSessionService: ownedSessionService,
+		appName:               appName,
+		defaultAgentName:      ag.Info().Name,
+		agents:                agents,
+		agentFactories:        options.agentFactories,
+		sessionService:        options.sessionService,
+		memoryService:         options.memoryService,
+		ingestor:              options.ingestor,
+		artifactService:       options.artifactService,
+		pluginManager:         pm,
+		ralphLoop:             options.ralphLoop,
+		awaitUserReplyRouting: options.awaitUserReplyRouting,
+		ownedSessionService:   ownedSessionService,
 	}
 }
 
@@ -334,17 +353,18 @@ func NewRunnerWithAgentFactory(
 	}
 
 	return &runner{
-		appName:             appName,
-		defaultAgentName:    defaultAgentName,
-		agents:              options.agents,
-		agentFactories:      options.agentFactories,
-		sessionService:      options.sessionService,
-		memoryService:       options.memoryService,
-		ingestor:            options.ingestor,
-		artifactService:     options.artifactService,
-		pluginManager:       pm,
-		ralphLoop:           options.ralphLoop,
-		ownedSessionService: ownedSessionService,
+		appName:               appName,
+		defaultAgentName:      defaultAgentName,
+		agents:                options.agents,
+		agentFactories:        options.agentFactories,
+		sessionService:        options.sessionService,
+		memoryService:         options.memoryService,
+		ingestor:              options.ingestor,
+		artifactService:       options.artifactService,
+		pluginManager:         pm,
+		ralphLoop:             options.ralphLoop,
+		awaitUserReplyRouting: options.awaitUserReplyRouting,
+		ownedSessionService:   ownedSessionService,
 	}
 }
 
@@ -434,6 +454,18 @@ func (r *runner) Run(
 	}
 
 	sess, err := r.getOrCreateSession(execCtx, sessionKey)
+	if err != nil {
+		execCancel()
+		return nil, err
+	}
+
+	ro, err = r.applyAwaitUserReplyRoute(
+		execCtx,
+		sessionKey,
+		sess,
+		message,
+		ro,
+	)
 	if err != nil {
 		execCancel()
 		return nil, err
@@ -761,19 +793,9 @@ func (r *runner) selectAgent(
 		agentName = ro.AgentByName
 	}
 
-	if ag, ok := r.agents[agentName]; ok && ag != nil {
-		return r.wrapSelectedAgent(ag), nil
-	}
-	if factory, ok := r.agentFactories[agentName]; ok && factory != nil {
-		created, err := factory(ctx, ro)
-		if err != nil {
-			return nil, fmt.Errorf("runner: agent factory: %w", err)
-		}
-		if created == nil {
-			return nil, fmt.Errorf("runner: agent factory returned nil")
-		}
-		selected := r.wrapSelectedAgent(created)
-		appid.RegisterRunner(r.appName, selected.Info().Name)
+	if selected, ok, err := r.lookupNamedAgent(ctx, agentName, ro); err != nil {
+		return nil, err
+	} else if ok {
 		return selected, nil
 	}
 	return nil, fmt.Errorf("runner: agent %q not found", agentName)

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -459,7 +459,7 @@ func (r *runner) Run(
 		return nil, err
 	}
 
-	ro, err = r.applyAwaitUserReplyRoute(
+	ro, awaitUserReplyRootName, err := r.applyAwaitUserReplyRoute(
 		execCtx,
 		sessionKey,
 		sess,
@@ -495,6 +495,15 @@ func (r *runner) Run(
 		agent.WithInvocationEventFilterKey(eventFilterKey),
 		agent.WithInvocationPlugins(r.pluginManager),
 	)
+	if rootLookupName := r.selectedRootLookupName(
+		ro,
+		awaitUserReplyRootName,
+	); rootLookupName != "" {
+		agent.SetAwaitUserReplyRootLookupName(
+			invocation,
+			rootLookupName,
+		)
+	}
 
 	queuedUserMessages := steer.NewQueue()
 	steer.Attach(invocation, queuedUserMessages)
@@ -793,12 +802,30 @@ func (r *runner) selectAgent(
 		agentName = ro.AgentByName
 	}
 
-	if selected, ok, err := r.lookupNamedAgent(ctx, agentName, ro); err != nil {
+	if ag, ok, err := r.loadRegisteredAgent(ctx, agentName, ro); err != nil {
 		return nil, err
 	} else if ok {
+		selected := r.wrapSelectedAgent(ag)
+		appid.RegisterRunner(r.appName, selected.Info().Name)
 		return selected, nil
 	}
 	return nil, fmt.Errorf("runner: agent %q not found", agentName)
+}
+
+func (r *runner) selectedRootLookupName(
+	ro agent.RunOptions,
+	awaitUserReplyRootName string,
+) string {
+	if awaitUserReplyRootName != "" {
+		return awaitUserReplyRootName
+	}
+	if ro.Agent != nil {
+		return ""
+	}
+	if ro.AgentByName != "" {
+		return ro.AgentByName
+	}
+	return r.defaultAgentName
 }
 
 func (r *runner) wrapSelectedAgent(ag agent.Agent) agent.Agent {

--- a/tool/awaitreply/await_reply_tool.go
+++ b/tool/awaitreply/await_reply_tool.go
@@ -1,0 +1,96 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package awaitreply provides the await_user_reply framework tool.
+package awaitreply
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+const (
+	// ToolName is the await_user_reply framework tool name.
+	ToolName = "await_user_reply"
+)
+
+// Request is the request payload for await_user_reply.
+type Request struct{}
+
+// Response is the tool response payload for await_user_reply.
+type Response struct {
+	// Success indicates whether the route was recorded successfully.
+	Success bool `json:"success"`
+	// Message describes the result.
+	Message string `json:"message"`
+	// AgentName is the agent that will receive the next user turn.
+	AgentName string `json:"agent_name,omitempty"`
+}
+
+// Tool marks the current agent as waiting for the next user reply.
+type Tool struct{}
+
+// New creates a new await_user_reply tool.
+func New() *Tool {
+	return &Tool{}
+}
+
+// Declaration implements tool.Tool.
+func (t *Tool) Declaration() *tool.Declaration {
+	return &tool.Declaration{
+		Name: ToolName,
+		Description: "Mark that the next user message in this session " +
+			"should resume at the current agent. Use this right " +
+			"before asking the user for missing information.",
+		InputSchema: &tool.Schema{
+			Type:       "object",
+			Properties: map[string]*tool.Schema{},
+		},
+	}
+}
+
+// Call implements tool.CallableTool.
+func (t *Tool) Call(ctx context.Context, jsonArgs []byte) (any, error) {
+	if len(bytes.TrimSpace(jsonArgs)) > 0 {
+		var req Request
+		if err := json.Unmarshal(jsonArgs, &req); err != nil {
+			return Response{
+				Success: false,
+				Message: fmt.Sprintf(
+					"invalid request format: %v",
+					err,
+				),
+			}, nil
+		}
+	}
+
+	invocation, ok := agent.InvocationFromContext(ctx)
+	if !ok || invocation == nil {
+		return Response{
+			Success: false,
+			Message: "await_user_reply requires an invocation context",
+		}, nil
+	}
+	if err := agent.MarkAwaitingUserReply(invocation); err != nil {
+		return Response{
+			Success: false,
+			Message: err.Error(),
+		}, nil
+	}
+	return Response{
+		Success:   true,
+		Message:   "The next user message will resume at this agent.",
+		AgentName: invocation.AgentName,
+	}, nil
+}

--- a/tool/awaitreply/await_reply_tool_test.go
+++ b/tool/awaitreply/await_reply_tool_test.go
@@ -18,6 +18,17 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 )
 
+func TestTool_Declaration(t *testing.T) {
+	tl := New()
+
+	decl := tl.Declaration()
+	require.NotNil(t, decl)
+	require.Equal(t, ToolName, decl.Name)
+	require.NotNil(t, decl.InputSchema)
+	require.Equal(t, "object", decl.InputSchema.Type)
+	require.Empty(t, decl.InputSchema.Properties)
+}
+
 func TestTool_CallMarksInvocation(t *testing.T) {
 	tl := New()
 	inv := &agent.Invocation{AgentName: "clarifier"}
@@ -63,4 +74,18 @@ func TestTool_CallInvalidJSON(t *testing.T) {
 
 	_, ok = agent.CurrentAwaitUserReplyRoute(inv)
 	require.False(t, ok)
+}
+
+func TestTool_CallInvalidInvocation(t *testing.T) {
+	tl := New()
+	inv := &agent.Invocation{}
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+
+	got, err := tl.Call(ctx, []byte(`{}`))
+	require.NoError(t, err)
+
+	resp, ok := got.(Response)
+	require.True(t, ok)
+	require.False(t, resp.Success)
+	require.Contains(t, resp.Message, "non-empty agent target")
 }

--- a/tool/awaitreply/await_reply_tool_test.go
+++ b/tool/awaitreply/await_reply_tool_test.go
@@ -1,0 +1,63 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package awaitreply
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+)
+
+func TestTool_CallMarksInvocation(t *testing.T) {
+	tl := New()
+	inv := &agent.Invocation{AgentName: "clarifier"}
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+
+	got, err := tl.Call(ctx, []byte(`{}`))
+	require.NoError(t, err)
+
+	resp, ok := got.(Response)
+	require.True(t, ok)
+	require.True(t, resp.Success)
+	require.Equal(t, "clarifier", resp.AgentName)
+
+	route, ok := agent.CurrentAwaitUserReplyRoute(inv)
+	require.True(t, ok)
+	require.Equal(t, "clarifier", route.AgentName)
+}
+
+func TestTool_CallWithoutInvocationContext(t *testing.T) {
+	tl := New()
+
+	got, err := tl.Call(context.Background(), []byte(`{}`))
+	require.NoError(t, err)
+
+	resp, ok := got.(Response)
+	require.True(t, ok)
+	require.False(t, resp.Success)
+	require.Contains(t, resp.Message, "invocation context")
+}
+
+func TestTool_CallInvalidJSON(t *testing.T) {
+	tl := New()
+	inv := &agent.Invocation{AgentName: "clarifier"}
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+
+	got, err := tl.Call(ctx, []byte(`{`))
+	require.NoError(t, err)
+
+	resp, ok := got.(Response)
+	require.True(t, ok)
+	require.False(t, resp.Success)
+	require.Contains(t, resp.Message, "invalid request format")
+}

--- a/tool/awaitreply/await_reply_tool_test.go
+++ b/tool/awaitreply/await_reply_tool_test.go
@@ -60,4 +60,7 @@ func TestTool_CallInvalidJSON(t *testing.T) {
 	require.True(t, ok)
 	require.False(t, resp.Success)
 	require.Contains(t, resp.Message, "invalid request format")
+
+	_, ok = agent.CurrentAwaitUserReplyRoute(inv)
+	require.False(t, ok)
 }


### PR DESCRIPTION
## Summary
- add a one-shot `await_user_reply` routing mechanism so the next user turn can resume at the agent that asked a follow-up question
- keep ordinary `transfer_to_agent` behavior unchanged by default; routing only changes when `runner.WithAwaitUserReplyRouting(true)` is enabled
- document the feature in English and Chinese across `multiagent`, `runner`, `tool`, and `team`

## Why
A common multi-turn transfer flow is:
1. the coordinator transfers to a subagent
2. the subagent asks the user for missing information
3. the user replies in the next request

Before this change, the next request still started from the runner's normal entry agent. Session history alone did not provide a first-class, framework-level way to say "the next user turn should resume at this subagent".

## What Changed
- add `agent.MarkAwaitingUserReply(...)` plus session/event encoding helpers
- persist the one-shot follow-up route on the agent's final event instead of mutating `model.Message.Role`
- add `runner.WithAwaitUserReplyRouting(true)` so `Runner` consumes that route once on the next user turn
- allow `Runner` to resolve uniquely named nested subagents automatically, so the common coordinator + `WithSubAgents(...)` setup works without separately registering every child
- add optional `llmagent.WithAwaitUserReplyTool(true)` which exposes the framework tool `await_user_reply`
- add unit tests for the new agent helpers, runner routing, nested subagent resolution, and tool surface behavior
- add detailed EN/ZH docs and examples

## Compatibility Notes
This patch is intentionally compatibility-first:
- default behavior is unchanged; if `runner.WithAwaitUserReplyRouting(true)` is not enabled, ordinary transfer flows behave exactly as before
- `await_user_reply` is opt-in; agents do not get the new framework tool unless `llmagent.WithAwaitUserReplyTool(true)` is enabled
- routing is one-shot; it is consumed by exactly one future user turn and then cleared automatically
- explicit per-run overrides still win: `agent.WithAgent(...)` and `agent.WithAgentByName(...)` take precedence
- if the recorded agent is missing or no longer uniquely resolvable, `Runner` clears the stale route and falls back to the default entry agent instead of hard-failing the conversation
- this does not change Swarm semantics; `team.WithCrossRequestTransfer(true)` remains the sticky owner model, while `await_user_reply` is a one-shot resume path

## Verification
Passed locally:
- `go test ./agent ./agent/llmagent ./tool/awaitreply ./runner ./internal/flow/processor`
- `go test ./runner -run AwaitUserReply -v`

Additional local note:
- `go test ./...` hit two environment-dependent failures unrelated to this diff in my workspace:
  - `codeexecutor/local`: shell startup banner leaked into a workspace runtime test
  - `telemetry/langfuse/config`: local env vars made a default-env test fail

I will keep watching the PR CI and fix any real regressions until it is green.