### PR TITLE
runner: fix WithMessages user message dedupe

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -2118,7 +2118,7 @@ func shouldAppendUserMessage(message model.Message, seed []model.Message) bool {
 	}
 	// Only a trailing seeded user turn can cover the incoming user message.
 	for i := len(seed) - 1; i >= 0; i-- {
-		if !model.HasPayload(seed[i]) || seed[i].Role == model.RoleSystem {
+		if (!model.HasPayload(seed[i]) && len(seed[i].ToolCalls) == 0) || seed[i].Role == model.RoleSystem {
 			continue
 		}
 		if seed[i].Role != model.RoleUser {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -575,11 +575,14 @@ func (r *runner) seedSessionHistory(
 	invocation *agent.Invocation,
 	ag agent.Agent,
 	ro agent.RunOptions,
-) error {
+) (bool, error) {
 	if len(ro.Messages) == 0 || sess.GetEventCount() != 0 {
-		return nil
+		return false, nil
 	}
-	return r.appendMessagesAsSessionEvents(ctx, sess, invocation, ag, ro.Messages)
+	if err := r.appendMessagesAsSessionEvents(ctx, sess, invocation, ag, ro.Messages); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // appendSessionMessages persists messages into the session transcript in the
@@ -631,8 +634,12 @@ func (r *runner) appendIncomingMessage(
 	invocation *agent.Invocation,
 	message model.Message,
 	ro agent.RunOptions,
+	historySeeded bool,
 ) error {
-	if !model.HasPayload(message) || !shouldAppendUserMessage(message, ro.Messages) {
+	if !model.HasPayload(message) {
+		return nil
+	}
+	if historySeeded && !shouldAppendUserMessage(message, ro.Messages) {
 		return nil
 	}
 	evt := event.NewResponseEvent(
@@ -2083,10 +2090,11 @@ func (r *runner) persistCurrentTurnMessages(
 	ro agent.RunOptions,
 ) error {
 	if ro.UserMessageRewriter == nil {
-		if err := r.seedSessionHistory(ctx, sess, invocation, ag, ro); err != nil {
+		historySeeded, err := r.seedSessionHistory(ctx, sess, invocation, ag, ro)
+		if err != nil {
 			return err
 		}
-		return r.appendIncomingMessage(ctx, sess, invocation, message, ro)
+		return r.appendIncomingMessage(ctx, sess, invocation, message, ro, historySeeded)
 	}
 	if sess.GetEventCount() == 0 {
 		initialMessages := mergeCurrentTurnMessagesIntoSeed(
@@ -2108,9 +2116,13 @@ func shouldAppendUserMessage(message model.Message, seed []model.Message) bool {
 	if message.Role != model.RoleUser {
 		return true
 	}
+	// Only a trailing seeded user turn can cover the incoming user message.
 	for i := len(seed) - 1; i >= 0; i-- {
-		if seed[i].Role != model.RoleUser {
+		if !model.HasPayload(seed[i]) || seed[i].Role == model.RoleSystem {
 			continue
+		}
+		if seed[i].Role != model.RoleUser {
+			return true
 		}
 		return !model.MessagesEqual(seed[i], message)
 	}

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -1785,6 +1785,23 @@ func TestShouldAppendUserMessage_Cases(t *testing.T) {
 			model.NewAssistantMessage("a"),
 		},
 	))
+	require.True(t, shouldAppendUserMessage(
+		model.NewUserMessage("u"),
+		[]model.Message{
+			model.NewUserMessage("u"),
+			{
+				Role: model.RoleAssistant,
+				ToolCalls: []model.ToolCall{{
+					Type: "function",
+					ID:   "call_1",
+					Function: model.FunctionDefinitionParam{
+						Name:      "lookup",
+						Arguments: []byte(`{"q":"u"}`),
+					},
+				}},
+			},
+		},
+	))
 }
 
 func TestRunner_Run_EmptyIncomingMessagePreservesSeedHistory(t *testing.T) {

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -1686,6 +1686,107 @@ func TestRunner_AppendsDifferentUserAfterSeed(t *testing.T) {
 	}
 }
 
+func TestRunner_AppendsSameUserWhenSeedEndsWithAssistant(t *testing.T) {
+	sessionService := sessioninmemory.NewSessionService()
+	mockAgent := &mockAgent{name: "test-agent"}
+	runner := NewRunner("test-app", mockAgent, WithSessionService(sessionService))
+
+	ctx := context.Background()
+	userID := "seed-user3"
+	sessionID := "seed-session3"
+	seedHistory := []model.Message{
+		model.NewUserMessage("hello"),
+		model.NewAssistantMessage("prev reply"),
+	}
+
+	eventCh, err := runner.Run(
+		ctx,
+		userID,
+		sessionID,
+		model.NewUserMessage("hello"),
+		agent.WithMessages(seedHistory),
+	)
+	require.NoError(t, err)
+	for range eventCh {
+		// drain channel
+	}
+
+	sess, err := sessionService.GetSession(ctx, session.Key{AppName: "test-app", UserID: userID, SessionID: sessionID})
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Len(t, sess.Events, 4)
+	require.Equal(t, authorUser, sess.Events[0].Author)
+	require.Equal(t, "test-agent", sess.Events[1].Author)
+	require.Equal(t, authorUser, sess.Events[2].Author)
+	require.Equal(t, "hello", sess.Events[2].Response.Choices[0].Message.Content)
+}
+
+func TestRunner_AppendsSameUserWhenSessionAlreadyExists(t *testing.T) {
+	sessionService := sessioninmemory.NewSessionService()
+	mockAgent := &mockAgent{name: "test-agent"}
+	runner := NewRunner("test-app", mockAgent, WithSessionService(sessionService))
+
+	ctx := context.Background()
+	userID := "existing-user"
+	sessionID := "existing-session"
+	message := model.NewUserMessage("hello")
+
+	eventCh, err := runner.Run(ctx, userID, sessionID, message)
+	require.NoError(t, err)
+	for range eventCh {
+		// drain channel
+	}
+
+	eventCh, err = runner.Run(
+		ctx,
+		userID,
+		sessionID,
+		message,
+		agent.WithMessages([]model.Message{model.NewUserMessage("hello")}),
+	)
+	require.NoError(t, err)
+	for range eventCh {
+		// drain channel
+	}
+
+	sess, err := sessionService.GetSession(ctx, session.Key{AppName: "test-app", UserID: userID, SessionID: sessionID})
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Len(t, sess.Events, 4)
+
+	userCount := 0
+	for _, e := range sess.Events {
+		if e.Author == authorUser {
+			userCount++
+		}
+	}
+	require.Equal(t, 2, userCount)
+	require.Equal(t, authorUser, sess.Events[2].Author)
+	require.Equal(t, "hello", sess.Events[2].Response.Choices[0].Message.Content)
+}
+
+func TestShouldAppendUserMessage_Cases(t *testing.T) {
+	require.True(t, shouldAppendUserMessage(
+		model.NewAssistantMessage("a"),
+		[]model.Message{model.NewUserMessage("u")},
+	))
+	require.True(t, shouldAppendUserMessage(
+		model.NewUserMessage("u"),
+		[]model.Message{model.NewSystemMessage("s"), model.NewAssistantMessage("a")},
+	))
+	require.False(t, shouldAppendUserMessage(
+		model.NewUserMessage("u"),
+		[]model.Message{model.NewUserMessage("u")},
+	))
+	require.True(t, shouldAppendUserMessage(
+		model.NewUserMessage("u"),
+		[]model.Message{
+			model.NewUserMessage("u"),
+			model.NewAssistantMessage("a"),
+		},
+	))
+}
+
 func TestRunner_Run_EmptyIncomingMessagePreservesSeedHistory(t *testing.T) {
 	sessionService := sessioninmemory.NewSessionService()
 	mockAgent := &mockAgent{name: "test-agent"}


### PR DESCRIPTION
## Summary

- Persist the incoming user message when `WithMessages` is provided for an existing session.
- Only skip the incoming user message when newly seeded history already ends with the same user turn.
- Treat trailing assistant tool calls as a real turn boundary so the next identical user input is not deduped against an older seed message.

## Tests

- `go test ./runner`
