### PR TITLE
internal/flow/processor: preserve tool round results on continuation

### DIFF
--- a/internal/flow/processor/content.go
+++ b/internal/flow/processor/content.go
@@ -1794,13 +1794,16 @@ func (p *ContentRequestProcessor) rearrangeLatestFuncResp(
 
 	// Look for corresponding function call event.
 	functionCallEventIdx := -1
+	var functionCallIDs []string
 	for i := len(events) - 2; i >= 0; i-- {
 		evt := &events[i]
 		if evt.IsToolCallResponse() {
-			functionCallIDs := toMap(evt.GetToolCallIDs())
+			callIDs := evt.GetToolCallIDs()
+			functionCallIDSet := toMap(callIDs)
 			for _, responseID := range functionResponseIDs {
-				if functionCallIDs[responseID] {
+				if functionCallIDSet[responseID] {
 					functionCallEventIdx = i
+					functionCallIDs = callIDs
 					break
 				}
 			}
@@ -1820,8 +1823,8 @@ func (p *ContentRequestProcessor) rearrangeLatestFuncResp(
 		evt := &events[i]
 		if evt.IsToolResultResponse() {
 			responseIDs := toMap(evt.GetToolResultIDs())
-			for _, responseID := range functionResponseIDs {
-				if responseIDs[responseID] {
+			for _, callID := range functionCallIDs {
+				if responseIDs[callID] {
 					functionResponseEvents = append(functionResponseEvents, *evt)
 					break
 				}

--- a/internal/flow/processor/content_merge_test.go
+++ b/internal/flow/processor/content_merge_test.go
@@ -150,8 +150,8 @@ func Test_rearrangeLatestFuncResp_MergesBetweenCallAndLatest(t *testing.T) {
 	assert.Len(t, out, 2)
 	assert.True(t, out[0].IsToolCallResponse(), "first should remain the tool call")
 	assert.True(t, out[1].IsToolResultResponse(), "second should be merged tool result")
-	assert.ElementsMatch(t, []string{"b"}, out[1].GetToolResultIDs())
-	assert.Len(t, out[1].Response.Choices, 1, "merged choices should contain latest event results only")
+	assert.ElementsMatch(t, []string{"a", "b"}, out[1].GetToolResultIDs())
+	assert.Len(t, out[1].Response.Choices, 2, "merged choices should contain all matched results from the tool-call round")
 }
 
 func Test_rearrangeLatestFuncResp_NoMatchingCall_ReturnsOriginal(t *testing.T) {

--- a/internal/flow/processor/content_test.go
+++ b/internal/flow/processor/content_test.go
@@ -3668,6 +3668,89 @@ func TestContentRequestProcessor_getIncrementMessages_SummaryPreservesToolState(
 	}
 }
 
+func TestContentRequestProcessor_getIncrementMessages_MixedToolContinuationPreservesRoundResults(t *testing.T) {
+	baseTime := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	userMsg := model.NewUserMessage("Please calculate 17 + 25 and ask external_note for topic mixed-tools-demo.")
+	toolCallMsg := model.Message{
+		Role: model.RoleAssistant,
+		ToolCalls: []model.ToolCall{
+			{
+				Type: "function",
+				ID:   "call_calc",
+				Function: model.FunctionDefinitionParam{
+					Name:      "calculator",
+					Arguments: []byte(`{"a":17,"b":25,"operation":"add"}`),
+				},
+			},
+			{
+				Type: "function",
+				ID:   "call_external",
+				Function: model.FunctionDefinitionParam{
+					Name:      "external_note",
+					Arguments: []byte(`{"topic":"mixed-tools-demo"}`),
+				},
+			},
+		},
+	}
+	calculatorResult := model.Message{
+		Role:     model.RoleTool,
+		ToolID:   "call_calc",
+		ToolName: "calculator",
+		Content:  `{"result":42}`,
+	}
+	externalResult := model.Message{
+		Role:     model.RoleTool,
+		ToolID:   "call_external",
+		ToolName: "external_note",
+		Content:  "verified-by-caller",
+	}
+	createEvent := func(requestID, invocationID, author string, ts time.Time, msg model.Message, object string) event.Event {
+		return event.Event{
+			Author:       author,
+			RequestID:    requestID,
+			InvocationID: invocationID,
+			Timestamp:    ts,
+			Version:      event.CurrentVersion,
+			FilterKey:    "test-filter",
+			Response: &model.Response{
+				Done:    true,
+				Object:  object,
+				Choices: []model.Choice{{Index: 0, Message: msg}},
+			},
+		}
+	}
+	sess := &session.Session{
+		EventMu: sync.RWMutex{},
+		Events: []event.Event{
+			createEvent("req1", "inv1", "user", baseTime, userMsg, ""),
+			createEvent("req1", "inv1", "test-agent", baseTime.Add(time.Second), toolCallMsg, ""),
+			createEvent("req1", "inv1", "test-agent", baseTime.Add(2*time.Second), calculatorResult, model.ObjectTypeToolResponse),
+			createEvent("req2", "inv2", "test-agent", baseTime.Add(3*time.Second), externalResult, model.ObjectTypeToolResponse),
+		},
+	}
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationID("inv2"),
+		agent.WithInvocationMessage(externalResult),
+		agent.WithInvocationRunOptions(agent.RunOptions{RequestID: "req2"}),
+		agent.WithInvocationEventFilterKey("test-filter"),
+	)
+	inv.AgentName = "test-agent"
+	p := NewContentRequestProcessor()
+	messages := p.getIncrementMessages(inv, time.Time{})
+	require.Len(t, messages, 4)
+	require.True(t, model.MessagesEqual(userMsg, messages[0]))
+	require.Equal(t, model.RoleAssistant, messages[1].Role)
+	require.Len(t, messages[1].ToolCalls, 2)
+	assert.ElementsMatch(t, []string{"call_calc", "call_external"}, []string{messages[1].ToolCalls[0].ID, messages[1].ToolCalls[1].ID})
+	require.Equal(t, model.RoleTool, messages[2].Role)
+	require.Equal(t, "call_calc", messages[2].ToolID)
+	require.Equal(t, `{"result":42}`, messages[2].Content)
+	require.Equal(t, model.RoleTool, messages[3].Role)
+	require.Equal(t, "call_external", messages[3].ToolID)
+	require.Equal(t, "verified-by-caller", messages[3].Content)
+}
+
 func TestInsertInvocationMessage(t *testing.T) {
 	createInvocation := func(id, requestID, content string) *agent.Invocation {
 		return &agent.Invocation{
@@ -4209,6 +4292,84 @@ func TestContentRequestProcessor_getCurrentInvocationMessages_IsolatedSubagent(t
 
 	assert.True(t, hasToolCall, "should include tool call message")
 	assert.True(t, hasToolResult, "should include tool result message")
+}
+
+func TestContentRequestProcessor_getCurrentInvocationMessages_MixedToolContinuationPreservesRoundResults(t *testing.T) {
+	baseTime := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	createEvent := func(requestID string, ts time.Time, msg model.Message, object string) event.Event {
+		return event.Event{
+			Author:       "subagent",
+			RequestID:    requestID,
+			InvocationID: "subagent_inv",
+			Timestamp:    ts,
+			Version:      event.CurrentVersion,
+			Response: &model.Response{
+				Done:    true,
+				Object:  object,
+				Choices: []model.Choice{{Index: 0, Message: msg}},
+			},
+		}
+	}
+	toolCallMsg := model.Message{
+		Role: model.RoleAssistant,
+		ToolCalls: []model.ToolCall{
+			{
+				Type: "function",
+				ID:   "call_calc",
+				Function: model.FunctionDefinitionParam{
+					Name:      "calculator",
+					Arguments: []byte(`{"a":17,"b":25,"operation":"add"}`),
+				},
+			},
+			{
+				Type: "function",
+				ID:   "call_external",
+				Function: model.FunctionDefinitionParam{
+					Name:      "external_note",
+					Arguments: []byte(`{"topic":"mixed-tools-demo"}`),
+				},
+			},
+		},
+	}
+	calculatorResult := model.Message{
+		Role:     model.RoleTool,
+		ToolID:   "call_calc",
+		ToolName: "calculator",
+		Content:  `{"result":42}`,
+	}
+	externalResult := model.Message{
+		Role:     model.RoleTool,
+		ToolID:   "call_external",
+		ToolName: "external_note",
+		Content:  "verified-by-caller",
+	}
+	sess := &session.Session{
+		EventMu: sync.RWMutex{},
+		Events: []event.Event{
+			createEvent("req1", baseTime, toolCallMsg, ""),
+			createEvent("req1", baseTime.Add(time.Second), calculatorResult, model.ObjectTypeToolResponse),
+			createEvent("req2", baseTime.Add(2*time.Second), model.Message{Role: model.RoleAssistant, Content: "waiting for external tool"}, ""),
+			createEvent("req2", baseTime.Add(3*time.Second), externalResult, model.ObjectTypeToolResponse),
+		},
+	}
+	inv := &agent.Invocation{
+		InvocationID: "subagent_inv",
+		AgentName:    "subagent",
+		Session:      sess,
+	}
+	inv.RunOptions.RequestID = "req2"
+	p := NewContentRequestProcessor()
+	messages := p.getCurrentInvocationMessages(inv)
+	require.Len(t, messages, 3)
+	require.Equal(t, model.RoleAssistant, messages[0].Role)
+	require.Len(t, messages[0].ToolCalls, 2)
+	assert.ElementsMatch(t, []string{"call_calc", "call_external"}, []string{messages[0].ToolCalls[0].ID, messages[0].ToolCalls[1].ID})
+	require.Equal(t, model.RoleTool, messages[1].Role)
+	require.Equal(t, "call_calc", messages[1].ToolID)
+	require.Equal(t, `{"result":42}`, messages[1].Content)
+	require.Equal(t, model.RoleTool, messages[2].Role)
+	require.Equal(t, "call_external", messages[2].ToolID)
+	require.Equal(t, "verified-by-caller", messages[2].Content)
 }
 
 func TestContentRequestProcessor_getCurrentInvocationMessages_ReasoningContentDiscardPreviousTurns(t *testing.T) {


### PR DESCRIPTION
This updates continuation history reconstruction to keep all matched tool results from the same assistant tool-call round instead of only the latest result, so mixed internal and external tool flows do not orphan sibling tool calls when a deferred tool result arrives in a later request.