### PR TITLE
{memory,session}: stop response collection on context cancel

### DIFF
--- a/memory/extractor/memory.go
+++ b/memory/extractor/memory.go
@@ -142,12 +142,12 @@ func (e *memoryExtractor) Extract(
 			return nil, fmt.Errorf("model call failed: %w", err)
 		}
 	}
-
-	// Parse tool calls into operations.
-	var ops []*Operation
 	if rspChan == nil {
 		return nil, errors.New("model returned nil response channel")
 	}
+
+	// Parse tool calls into operations.
+	var ops []*Operation
 	for {
 		select {
 		case <-ctx.Done():

--- a/memory/extractor/memory.go
+++ b/memory/extractor/memory.go
@@ -145,31 +145,41 @@ func (e *memoryExtractor) Extract(
 
 	// Parse tool calls into operations.
 	var ops []*Operation
-	for rsp := range rspChan {
-		ctx, rsp, err = e.runAfterModelCallbacks(ctx, req, rsp)
-		if err != nil {
-			return nil, err
-		}
-		if rsp == nil {
-			continue
-		}
-		if rsp.Error != nil {
-			return nil, fmt.Errorf("model error: %s", rsp.Error.Message)
-		}
-		if len(rsp.Choices) == 0 {
-			continue
-		}
-		// Choices are alternative candidates rather than cumulative
-		// tool-call batches, so only the selected primary choice
-		// should be converted into operations.
-		for _, call := range rsp.Choices[0].Message.ToolCalls {
-			op := e.parseToolCall(ctx, call)
-			if op != nil {
-				ops = append(ops, op)
+	if rspChan == nil {
+		return nil, errors.New("model returned nil response channel")
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("memory extraction canceled: %w", ctx.Err())
+		case rsp, ok := <-rspChan:
+			if !ok {
+				return ops, nil
+			}
+			ctx, rsp, err = e.runAfterModelCallbacks(ctx, req, rsp)
+			if err != nil {
+				return nil, err
+			}
+			if rsp == nil {
+				continue
+			}
+			if rsp.Error != nil {
+				return nil, fmt.Errorf("model error: %s", rsp.Error.Message)
+			}
+			if len(rsp.Choices) == 0 {
+				continue
+			}
+			// Choices are alternative candidates rather than cumulative
+			// tool-call batches, so only the selected primary choice
+			// should be converted into operations.
+			for _, call := range rsp.Choices[0].Message.ToolCalls {
+				op := e.parseToolCall(ctx, call)
+				if op != nil {
+					ops = append(ops, op)
+				}
 			}
 		}
 	}
-	return ops, nil
 }
 
 // SetPrompt updates the extractor's prompt dynamically.

--- a/memory/extractor/memory_test.go
+++ b/memory/extractor/memory_test.go
@@ -53,6 +53,21 @@ func (m *mockModel) Info() model.Info {
 	return model.Info{Name: m.name}
 }
 
+type blockingModel struct {
+	name string
+}
+
+func (m *blockingModel) GenerateContent(
+	ctx context.Context,
+	request *model.Request,
+) (<-chan *model.Response, error) {
+	return make(chan *model.Response), nil
+}
+
+func (m *blockingModel) Info() model.Info {
+	return model.Info{Name: m.name}
+}
+
 // newMockModelWithToolCalls creates a mock model that returns tool calls.
 func newMockModelWithToolCalls(toolCalls []model.ToolCall) *mockModel {
 	return &mockModel{
@@ -150,6 +165,23 @@ func TestExtractor_Extract_ModelError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "model call failed")
 	assert.Nil(t, ops)
+}
+
+func TestExtractor_Extract_ContextTimeoutWhileWaitingForResponse(t *testing.T) {
+	e := NewExtractor(&blockingModel{name: "blocking-model"})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	ops, err := e.Extract(ctx, []model.Message{
+		model.NewUserMessage("remember that I like coffee"),
+	}, nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "context deadline exceeded")
+	assert.Nil(t, ops)
+	assert.Less(t, time.Since(start), 500*time.Millisecond)
 }
 
 func TestExtractor_Extract_ResponseError(t *testing.T) {

--- a/memory/extractor/memory_test.go
+++ b/memory/extractor/memory_test.go
@@ -68,6 +68,21 @@ func (m *blockingModel) Info() model.Info {
 	return model.Info{Name: m.name}
 }
 
+type nilChannelModel struct {
+	name string
+}
+
+func (m *nilChannelModel) GenerateContent(
+	ctx context.Context,
+	request *model.Request,
+) (<-chan *model.Response, error) {
+	return nil, nil
+}
+
+func (m *nilChannelModel) Info() model.Info {
+	return model.Info{Name: m.name}
+}
+
 // newMockModelWithToolCalls creates a mock model that returns tool calls.
 func newMockModelWithToolCalls(toolCalls []model.ToolCall) *mockModel {
 	return &mockModel{
@@ -164,6 +179,18 @@ func TestExtractor_Extract_ModelError(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "model call failed")
+	assert.Nil(t, ops)
+}
+
+func TestExtractor_Extract_NilResponseChannel(t *testing.T) {
+	e := NewExtractor(&nilChannelModel{name: "nil-channel"})
+
+	ops, err := e.Extract(context.Background(), []model.Message{
+		model.NewUserMessage("remember that I like tea"),
+	}, nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "model returned nil response channel")
 	assert.Nil(t, ops)
 }
 

--- a/memory/extractor/memory_test.go
+++ b/memory/extractor/memory_test.go
@@ -61,6 +61,7 @@ func (m *blockingModel) GenerateContent(
 	ctx context.Context,
 	request *model.Request,
 ) (<-chan *model.Response, error) {
+	// The channel is intentionally never closed to exercise context timeout handling.
 	return make(chan *model.Response), nil
 }
 
@@ -206,7 +207,7 @@ func TestExtractor_Extract_ContextTimeoutWhileWaitingForResponse(t *testing.T) {
 	}, nil)
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "context deadline exceeded")
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
 	assert.Nil(t, ops)
 	assert.Less(t, time.Since(start), 500*time.Millisecond)
 }

--- a/session/summary/summarizer.go
+++ b/session/summary/summarizer.go
@@ -10,6 +10,7 @@ package summary
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -845,43 +846,54 @@ func (s *sessionSummarizer) collectSummaryFromResponses(
 	trackResponse func(resp *model.Response),
 	ensureTimingInfo func(resp *model.Response),
 ) (context.Context, string, *model.Response, error) {
+	if responseChan == nil {
+		return ctx, "", nil, errors.New("model returned nil response channel")
+	}
+
 	var (
 		summary   strings.Builder
 		finalResp *model.Response
 	)
 
-	for response := range responseChan {
-		if trackResponse != nil {
-			trackResponse(response)
-		}
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx, "", finalResp, fmt.Errorf("summary response collection canceled: %w", ctx.Err())
+		case response, ok := <-responseChan:
+			if !ok {
+				summaryText := strings.TrimSpace(summary.String())
+				return ctx, summaryText, finalResp, nil
+			}
+			if trackResponse != nil {
+				trackResponse(response)
+			}
 
-		var err error
-		ctx, response, err = s.runAfterModelCallbacks(ctx, request, response)
-		if err != nil {
-			return ctx, "", finalResp, err
-		}
-		if ensureTimingInfo != nil {
-			ensureTimingInfo(response)
-		}
-		if response == nil {
-			continue
-		}
-		finalResp = response
+			var err error
+			ctx, response, err = s.runAfterModelCallbacks(ctx, request, response)
+			if err != nil {
+				return ctx, "", finalResp, err
+			}
+			if ensureTimingInfo != nil {
+				ensureTimingInfo(response)
+			}
+			if response == nil {
+				continue
+			}
+			finalResp = response
 
-		if response.Error != nil {
-			return ctx, "", finalResp, formatResponseError(response.Error)
-		}
-		if len(response.Choices) > 0 {
-			content := response.Choices[0].Message.Content
-			if content != "" {
-				summary.WriteString(content)
+			if response.Error != nil {
+				return ctx, "", finalResp, formatResponseError(response.Error)
+			}
+			if len(response.Choices) > 0 {
+				content := response.Choices[0].Message.Content
+				if content != "" {
+					summary.WriteString(content)
+				}
+			}
+			if response.Done {
+				summaryText := strings.TrimSpace(summary.String())
+				return ctx, summaryText, finalResp, nil
 			}
 		}
-		if response.Done {
-			break
-		}
 	}
-
-	summaryText := strings.TrimSpace(summary.String())
-	return ctx, summaryText, finalResp, nil
 }

--- a/session/summary/summarizer_test.go
+++ b/session/summary/summarizer_test.go
@@ -433,6 +433,27 @@ func TestSessionSummarizer_GenerateSummary_EmptyResponse(t *testing.T) {
 	assert.Contains(t, err.Error(), "generated empty summary")
 }
 
+func TestSessionSummarizer_Summarize_ContextTimeoutWhileWaitingForResponse(t *testing.T) {
+	s := NewSummarizer(&blockingResponseModel{})
+	sess := &session.Session{
+		ID: "timeout",
+		Events: []event.Event{{
+			Author:    "user",
+			Response:  &model.Response{Choices: []model.Choice{{Message: model.Message{Content: "test"}}}},
+			Timestamp: time.Now(),
+		}},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := s.Summarize(ctx, sess)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "context deadline exceeded")
+	assert.Less(t, time.Since(start), 500*time.Millisecond)
+}
+
 func TestSessionSummarizer_ShouldSummarize_EmptyEvents(t *testing.T) {
 	s := NewSummarizer(&fakeModel{}, WithEventThreshold(10))
 	sess := &session.Session{Events: []event.Event{}}
@@ -909,6 +930,15 @@ func (e *emptyResponseModel) GenerateContent(ctx context.Context, req *model.Req
 	ch <- &model.Response{Done: true, Choices: []model.Choice{{Message: model.Message{Content: ""}}}}
 	close(ch)
 	return ch, nil
+}
+
+// blockingResponseModel simulates a non-cooperative provider that neither
+// sends a response nor closes the response channel after ctx cancellation.
+type blockingResponseModel struct{}
+
+func (b *blockingResponseModel) Info() model.Info { return model.Info{Name: "blocking-response"} }
+func (b *blockingResponseModel) GenerateContent(ctx context.Context, req *model.Request) (<-chan *model.Response, error) {
+	return make(chan *model.Response), nil
 }
 
 func TestFormatResponseError(t *testing.T) {

--- a/session/summary/summarizer_test.go
+++ b/session/summary/summarizer_test.go
@@ -380,6 +380,21 @@ func TestSessionSummarizer_GenerateSummary_ModelError(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to generate summary")
 }
 
+func TestSessionSummarizer_GenerateSummary_NilResponseChannel(t *testing.T) {
+	s := NewSummarizer(&nilResponseChannelModel{})
+
+	sess := &session.Session{
+		ID: "test-nil-channel",
+		Events: []event.Event{
+			{Response: &model.Response{Choices: []model.Choice{{Message: model.Message{Content: "test"}}}}, Timestamp: time.Now()},
+		},
+	}
+
+	_, err := s.Summarize(context.Background(), sess)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "model returned nil response channel")
+}
+
 func TestSessionSummarizer_GenerateSummary_ResponseError(t *testing.T) {
 	responseErrorModel := &responseErrorModel{}
 	s := NewSummarizer(responseErrorModel)
@@ -939,6 +954,16 @@ type blockingResponseModel struct{}
 func (b *blockingResponseModel) Info() model.Info { return model.Info{Name: "blocking-response"} }
 func (b *blockingResponseModel) GenerateContent(ctx context.Context, req *model.Request) (<-chan *model.Response, error) {
 	return make(chan *model.Response), nil
+}
+
+type nilResponseChannelModel struct{}
+
+func (n *nilResponseChannelModel) Info() model.Info {
+	return model.Info{Name: "nil-response-channel"}
+}
+
+func (n *nilResponseChannelModel) GenerateContent(ctx context.Context, req *model.Request) (<-chan *model.Response, error) {
+	return nil, nil
 }
 
 func TestFormatResponseError(t *testing.T) {

--- a/session/summary/summarizer_test.go
+++ b/session/summary/summarizer_test.go
@@ -465,7 +465,7 @@ func TestSessionSummarizer_Summarize_ContextTimeoutWhileWaitingForResponse(t *te
 	start := time.Now()
 	_, err := s.Summarize(ctx, sess)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "context deadline exceeded")
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
 	assert.Less(t, time.Since(start), 500*time.Millisecond)
 }
 
@@ -953,6 +953,7 @@ type blockingResponseModel struct{}
 
 func (b *blockingResponseModel) Info() model.Info { return model.Info{Name: "blocking-response"} }
 func (b *blockingResponseModel) GenerateContent(ctx context.Context, req *model.Request) (<-chan *model.Response, error) {
+	// The channel is intentionally never closed to exercise context timeout handling.
 	return make(chan *model.Response), nil
 }
 


### PR DESCRIPTION
## Summary
- Stop session summary and memory extraction response collection when the request context is canceled.
- Add regression coverage for non-cooperative model response channels that never send or close.

## Test plan
- go test ./memory/extractor -run TestExtractor_Extract_ContextTimeoutWhileWaitingForResponse -count=1 -timeout=2s
- go test ./session/summary -run TestSessionSummarizer_Summarize_ContextTimeoutWhileWaitingForResponse -count=1 -timeout=2s
- go test ./session/... ./memory/... -count=1