### PR TITLE
a2a: pass context to response rewriter

### DIFF
--- a/docs/mkdocs/en/a2a.md
+++ b/docs/mkdocs/en/a2a.md
@@ -375,12 +375,15 @@ server-generated events that are not part of your public A2A contract.
 The rewriter sees the final unary result after server-side aggregation. In
 streaming mode, it sees every outbound streaming result, including converted
 agent events, task status updates, final artifact updates, structured task
-errors, and messages returned by the error handler.
+errors, and messages returned by the error handler. The request context is
+passed to each rewrite call so you can use request-scoped values in logs.
 
 Returning `nil` from the rewriter drops that outbound result.
 
 ```go
 import (
+	"context"
+
 	"trpc.group/trpc-go/trpc-a2a-go/protocol"
 	a2aserver "trpc.group/trpc-go/trpc-agent-go/server/a2a"
 )
@@ -389,13 +392,13 @@ server, _ := a2aserver.New(
 	a2aserver.WithHost("localhost:8080"),
 	a2aserver.WithAgent(agent, true),
 	a2aserver.WithResponseRewriter(a2aserver.ResponseRewriterFuncs{
-		Unary: func(result protocol.UnaryMessageResult) protocol.UnaryMessageResult {
+		Unary: func(ctx context.Context, result protocol.UnaryMessageResult) protocol.UnaryMessageResult {
 			if msg, ok := result.(*protocol.Message); ok {
 				delete(msg.Metadata, "debug_trace")
 			}
 			return result
 		},
-		Streaming: func(result protocol.StreamingMessageResult) protocol.StreamingMessageResult {
+		Streaming: func(ctx context.Context, result protocol.StreamingMessageResult) protocol.StreamingMessageResult {
 			if msg, ok := result.(*protocol.Message); ok {
 				delete(msg.Metadata, "debug_trace")
 			}

--- a/docs/mkdocs/zh/a2a.md
+++ b/docs/mkdocs/zh/a2a.md
@@ -363,12 +363,14 @@ server, _ := a2aserver.New(
 `WithResponseRewriter` 允许服务端在 A2A 结果返回给调用方、或发送给流式订阅者之前做最后一次改写。
 典型用途包括隐藏内部 metadata、删除调试字段，或丢弃不希望暴露到公开 A2A 协议面的服务端事件。
 
-对于 unary 响应，rewriter 看到的是服务端聚合后的最终结果。对于 streaming 响应，rewriter 会看到每一个即将发送的出站结果，包括转换后的 agent 事件、task 状态更新、final artifact、结构化 task error，以及 `ErrorHandler` 返回的消息。
+对于 unary 响应，rewriter 看到的是服务端聚合后的最终结果。对于 streaming 响应，rewriter 会看到每一个即将发送的出站结果，包括转换后的 agent 事件、task 状态更新、final artifact、结构化 task error，以及 `ErrorHandler` 返回的消息。每次 rewrite 都会收到本次请求的 context，方便读取请求级日志字段。
 
 rewriter 返回 `nil` 表示丢弃该出站结果。
 
 ```go
 import (
+	"context"
+
 	"trpc.group/trpc-go/trpc-a2a-go/protocol"
 	a2aserver "trpc.group/trpc-go/trpc-agent-go/server/a2a"
 )
@@ -377,13 +379,13 @@ server, _ := a2aserver.New(
 	a2aserver.WithHost("localhost:8080"),
 	a2aserver.WithAgent(agent, true),
 	a2aserver.WithResponseRewriter(a2aserver.ResponseRewriterFuncs{
-		Unary: func(result protocol.UnaryMessageResult) protocol.UnaryMessageResult {
+		Unary: func(ctx context.Context, result protocol.UnaryMessageResult) protocol.UnaryMessageResult {
 			if msg, ok := result.(*protocol.Message); ok {
 				delete(msg.Metadata, "debug_trace")
 			}
 			return result
 		},
-		Streaming: func(result protocol.StreamingMessageResult) protocol.StreamingMessageResult {
+		Streaming: func(ctx context.Context, result protocol.StreamingMessageResult) protocol.StreamingMessageResult {
 			if msg, ok := result.(*protocol.Message); ok {
 				delete(msg.Metadata, "debug_trace")
 			}

--- a/server/a2a/server.go
+++ b/server/a2a/server.go
@@ -458,7 +458,7 @@ func (m *messageProcessor) handleError(
 	}
 
 	if streaming {
-		rewritten := m.rewriteStreamingResult(errMsg)
+		rewritten := m.rewriteStreamingResult(ctx, errMsg)
 		if rewritten == nil {
 			return droppedStreamingMessageProcessingResult(), nil
 		}
@@ -466,7 +466,7 @@ func (m *messageProcessor) handleError(
 		return &taskmanager.MessageProcessingResult{StreamingEvents: subscriber}, nil
 	}
 
-	rewritten := m.rewriteUnaryResult(errMsg)
+	rewritten := m.rewriteUnaryResult(ctx, errMsg)
 	if rewritten == nil {
 		return droppedUnaryMessageProcessingResult(), nil
 	}
@@ -496,7 +496,7 @@ func (m *messageProcessor) handleStreamingProcessingError(
 		log.WarnfContext(ctx, "handle streaming processing error: %v", err)
 		return err
 	}
-	rewritten := m.rewriteStreamingResult(errMsg)
+	rewritten := m.rewriteStreamingResult(ctx, errMsg)
 
 	if rewritten == nil {
 		return nil
@@ -905,7 +905,7 @@ func (m *messageProcessor) sendStreamingResult(
 	result protocol.StreamingMessageResult,
 	errorMessage string,
 ) error {
-	rewritten := m.rewriteStreamingResult(result)
+	rewritten := m.rewriteStreamingResult(ctx, result)
 	if rewritten == nil {
 		return nil
 	}
@@ -986,7 +986,7 @@ func (m *messageProcessor) processBatchStreamingEvents(
 				true,
 			)
 			statusEvent.Metadata = task.Metadata
-			rewritten := m.rewriteStreamingResult(&statusEvent)
+			rewritten := m.rewriteStreamingResult(ctx, &statusEvent)
 			if rewritten == nil {
 				if terminalTaskError != nil {
 					*terminalTaskError = true
@@ -1027,7 +1027,7 @@ func (m *messageProcessor) processBatchStreamingEvents(
 		if err != nil {
 			return false, fmt.Errorf("failed to convert event to A2A message: %w", err)
 		}
-		convertedResult = m.rewriteStreamingResult(convertedResult)
+		convertedResult = m.rewriteStreamingResult(ctx, convertedResult)
 
 		if m.debugLogging {
 			a2aMsgJson, _ := json.Marshal(convertedResult)
@@ -1099,7 +1099,7 @@ func (m *messageProcessor) processMessage(
 				a2aMsg.MessageID,
 				time.Now().UnixNano(),
 			)
-			rewritten := m.rewriteUnaryResult(buildStructuredFailureTask(
+			rewritten := m.rewriteUnaryResult(ctx, buildStructuredFailureTask(
 				taskID,
 				ctxID,
 				messages,
@@ -1148,7 +1148,7 @@ func (m *messageProcessor) processMessage(
 	}
 	result := buildMessageProcessingResult(a2aMsg, ctxID, messages)
 	if result != nil && result.Result != nil {
-		rewritten := m.rewriteUnaryResult(result.Result)
+		rewritten := m.rewriteUnaryResult(ctx, result.Result)
 		if rewritten == nil {
 			return droppedUnaryMessageProcessingResult(), nil
 		}
@@ -1361,13 +1361,14 @@ func (m *messageProcessor) addTaskMetadata(event *protocol.TaskStatusUpdateEvent
 }
 
 func (m *messageProcessor) rewriteStreamingResult(
+	ctx context.Context,
 	result protocol.StreamingMessageResult,
 ) protocol.StreamingMessageResult {
 	if result == nil {
 		return nil
 	}
 	if m.responseRewriter != nil {
-		result = m.responseRewriter.RewriteStreaming(result)
+		result = m.responseRewriter.RewriteStreaming(ctx, result)
 	}
 	if result == nil {
 		return nil
@@ -1376,13 +1377,14 @@ func (m *messageProcessor) rewriteStreamingResult(
 }
 
 func (m *messageProcessor) rewriteUnaryResult(
+	ctx context.Context,
 	result protocol.UnaryMessageResult,
 ) protocol.UnaryMessageResult {
 	if result == nil {
 		return nil
 	}
 	if m.responseRewriter != nil {
-		result = m.responseRewriter.RewriteUnary(result)
+		result = m.responseRewriter.RewriteUnary(ctx, result)
 	}
 	if result == nil {
 		return nil

--- a/server/a2a/server_option.go
+++ b/server/a2a/server_option.go
@@ -66,40 +66,42 @@ type TaskManagerBuilder func(processor taskmanager.MessageProcessor) taskmanager
 // ResponseRewriter rewrites outbound A2A responses before they are returned or
 // sent to the remote peer.
 //
-// RewriteUnary receives the final unary result after server-side aggregation of
-// converted events. It rewrites what the caller will actually receive, rather
-// than every intermediate converter output.
+// RewriteUnary receives the request context and final unary result after
+// server-side aggregation of converted events. It rewrites what the caller will
+// actually receive, rather than every intermediate converter output.
 //
 // Returning nil drops the outbound result.
 type ResponseRewriter interface {
-	RewriteUnary(result protocol.UnaryMessageResult) protocol.UnaryMessageResult
-	RewriteStreaming(result protocol.StreamingMessageResult) protocol.StreamingMessageResult
+	RewriteUnary(ctx context.Context, result protocol.UnaryMessageResult) protocol.UnaryMessageResult
+	RewriteStreaming(ctx context.Context, result protocol.StreamingMessageResult) protocol.StreamingMessageResult
 }
 
 // ResponseRewriterFuncs adapts plain functions into a ResponseRewriter.
 type ResponseRewriterFuncs struct {
-	Unary     func(result protocol.UnaryMessageResult) protocol.UnaryMessageResult
-	Streaming func(result protocol.StreamingMessageResult) protocol.StreamingMessageResult
+	Unary     func(ctx context.Context, result protocol.UnaryMessageResult) protocol.UnaryMessageResult
+	Streaming func(ctx context.Context, result protocol.StreamingMessageResult) protocol.StreamingMessageResult
 }
 
 // RewriteUnary implements ResponseRewriter.
 func (f ResponseRewriterFuncs) RewriteUnary(
+	ctx context.Context,
 	result protocol.UnaryMessageResult,
 ) protocol.UnaryMessageResult {
 	if f.Unary == nil {
 		return result
 	}
-	return f.Unary(result)
+	return f.Unary(ctx, result)
 }
 
 // RewriteStreaming implements ResponseRewriter.
 func (f ResponseRewriterFuncs) RewriteStreaming(
+	ctx context.Context,
 	result protocol.StreamingMessageResult,
 ) protocol.StreamingMessageResult {
 	if f.Streaming == nil {
 		return result
 	}
-	return f.Streaming(result)
+	return f.Streaming(ctx, result)
 }
 
 // EventToA2APartMapper converts an agent event into additional A2A parts.
@@ -360,7 +362,8 @@ func WithGraphEventObjectAllowlist(objectTypes ...string) Option {
 //
 // For unary responses, the rewriter sees the final result returned by the A2A
 // server after it aggregates converted events. For streaming responses, it sees
-// each outbound streaming event immediately before send.
+// each outbound streaming event immediately before send. The request context is
+// passed through so rewriters can use request-scoped values for logging.
 //
 // Returning nil drops the outbound result.
 func WithResponseRewriter(rewriter ResponseRewriter) Option {

--- a/server/a2a/server_option_test.go
+++ b/server/a2a/server_option_test.go
@@ -379,8 +379,38 @@ func TestResponseRewriterFuncs_Defaults(t *testing.T) {
 		},
 	}
 
-	assert.Same(t, unary, rewriter.RewriteUnary(unary))
-	assert.Same(t, streaming, rewriter.RewriteStreaming(streaming))
+	assert.Same(t, unary, rewriter.RewriteUnary(context.Background(), unary))
+	assert.Same(t, streaming, rewriter.RewriteStreaming(context.Background(), streaming))
+}
+
+func TestResponseRewriterFuncs_Context(t *testing.T) {
+	type contextKey struct{}
+	ctx := context.WithValue(context.Background(), contextKey{}, "trace-1")
+	unary := &protocol.Message{
+		Role:  protocol.MessageRoleAgent,
+		Parts: []protocol.Part{protocol.NewTextPart("unary")},
+	}
+	streaming := &protocol.TaskStatusUpdateEvent{
+		TaskID:    "task",
+		ContextID: "ctx",
+		Status: protocol.TaskStatus{
+			State: protocol.TaskStateCompleted,
+		},
+	}
+
+	rewriter := ResponseRewriterFuncs{
+		Unary: func(ctx context.Context, result protocol.UnaryMessageResult) protocol.UnaryMessageResult {
+			assert.Equal(t, "trace-1", ctx.Value(contextKey{}))
+			return result
+		},
+		Streaming: func(ctx context.Context, result protocol.StreamingMessageResult) protocol.StreamingMessageResult {
+			assert.Equal(t, "trace-1", ctx.Value(contextKey{}))
+			return result
+		},
+	}
+
+	assert.Same(t, unary, rewriter.RewriteUnary(ctx, unary))
+	assert.Same(t, streaming, rewriter.RewriteStreaming(ctx, streaming))
 }
 
 func TestWithOptions(t *testing.T) {

--- a/server/a2a/server_test.go
+++ b/server/a2a/server_test.go
@@ -763,7 +763,7 @@ func TestMessageProcessor_HandleError(t *testing.T) {
 func TestMessageProcessor_HandleError_ResponseRewriter(t *testing.T) {
 	proc := &messageProcessor{
 		responseRewriter: ResponseRewriterFuncs{
-			Unary: func(result protocol.UnaryMessageResult) protocol.UnaryMessageResult {
+			Unary: func(ctx context.Context, result protocol.UnaryMessageResult) protocol.UnaryMessageResult {
 				msg, ok := result.(*protocol.Message)
 				if !ok {
 					return result
@@ -795,7 +795,7 @@ func TestMessageProcessor_HandleError_ResponseRewriter(t *testing.T) {
 func TestMessageProcessor_HandleError_ResponseRewriter_DropUnaryResult(t *testing.T) {
 	proc := &messageProcessor{
 		responseRewriter: ResponseRewriterFuncs{
-			Unary: func(result protocol.UnaryMessageResult) protocol.UnaryMessageResult {
+			Unary: func(ctx context.Context, result protocol.UnaryMessageResult) protocol.UnaryMessageResult {
 				return nil
 			},
 		},
@@ -816,7 +816,7 @@ func TestMessageProcessor_HandleError_ResponseRewriter_DropUnaryResult(t *testin
 func TestMessageProcessor_HandleStreamingProcessingError_ResponseRewriter(t *testing.T) {
 	proc := &messageProcessor{
 		responseRewriter: ResponseRewriterFuncs{
-			Streaming: func(result protocol.StreamingMessageResult) protocol.StreamingMessageResult {
+			Streaming: func(ctx context.Context, result protocol.StreamingMessageResult) protocol.StreamingMessageResult {
 				msg, ok := result.(*protocol.Message)
 				if !ok {
 					return result
@@ -858,6 +858,7 @@ func TestMessageProcessor_HandleStreamingProcessingError_ResponseRewriter_DropRe
 	proc := &messageProcessor{
 		responseRewriter: ResponseRewriterFuncs{
 			Streaming: func(
+				ctx context.Context,
 				result protocol.StreamingMessageResult,
 			) protocol.StreamingMessageResult {
 				return nil
@@ -897,7 +898,7 @@ func TestMessageProcessor_HandleStreamingProcessingError_ResponseRewriter_DropRe
 func TestMessageProcessor_HandleError_ResponseRewriter_DropStreamingResult(t *testing.T) {
 	proc := &messageProcessor{
 		responseRewriter: ResponseRewriterFuncs{
-			Streaming: func(result protocol.StreamingMessageResult) protocol.StreamingMessageResult {
+			Streaming: func(ctx context.Context, result protocol.StreamingMessageResult) protocol.StreamingMessageResult {
 				return nil
 			},
 		},
@@ -4070,6 +4071,7 @@ func TestMessageProcessor_ProcessMessage_StructuredTaskError_ResponseRewriterDro
 		structuredTaskErrors: true,
 		responseRewriter: ResponseRewriterFuncs{
 			Unary: func(
+				ctx context.Context,
 				result protocol.UnaryMessageResult,
 			) protocol.UnaryMessageResult {
 				return nil
@@ -4281,6 +4283,7 @@ func TestMessageProcessor_ProcessBatchStreamingEvents_DropStructuredTaskError(
 		structuredTaskErrors: true,
 		responseRewriter: ResponseRewriterFuncs{
 			Streaming: func(
+				ctx context.Context,
 				result protocol.StreamingMessageResult,
 			) protocol.StreamingMessageResult {
 				return nil
@@ -4337,6 +4340,7 @@ func TestProcessAgentStreamingEvents_ResponseRewriterDropsCompletionEvents(
 	proc := createTestMessageProcessor()
 	proc.responseRewriter = ResponseRewriterFuncs{
 		Streaming: func(
+			ctx context.Context,
 			result protocol.StreamingMessageResult,
 		) protocol.StreamingMessageResult {
 			switch v := result.(type) {
@@ -4994,8 +4998,8 @@ func TestCloneStateDeltaBytes(t *testing.T) {
 func TestNormalizeResponseResults(t *testing.T) {
 	t.Run("nil inputs", func(t *testing.T) {
 		proc := &messageProcessor{}
-		assert.Nil(t, proc.rewriteUnaryResult(nil))
-		assert.Nil(t, proc.rewriteStreamingResult(nil))
+		assert.Nil(t, proc.rewriteUnaryResult(context.Background(), nil))
+		assert.Nil(t, proc.rewriteStreamingResult(context.Background(), nil))
 		assert.Nil(t, normalizeProtocolMessage(nil))
 		assert.Nil(t, normalizeTask(nil))
 		assert.Nil(t, normalizeTaskArtifactUpdateEvent(nil))
@@ -5077,6 +5081,37 @@ func TestNormalizeResponseResults(t *testing.T) {
 	})
 }
 
+func TestMessageProcessor_ResponseRewriterReceivesContext(t *testing.T) {
+	type contextKey struct{}
+	ctx := context.WithValue(context.Background(), contextKey{}, "trace-1")
+	unary := &protocol.Message{
+		Role:  protocol.MessageRoleAgent,
+		Parts: []protocol.Part{protocol.NewTextPart("unary")},
+	}
+	streaming := &protocol.TaskStatusUpdateEvent{
+		TaskID:    "task",
+		ContextID: "ctx",
+		Status: protocol.TaskStatus{
+			State: protocol.TaskStateCompleted,
+		},
+	}
+	proc := &messageProcessor{
+		responseRewriter: ResponseRewriterFuncs{
+			Unary: func(ctx context.Context, result protocol.UnaryMessageResult) protocol.UnaryMessageResult {
+				assert.Equal(t, "trace-1", ctx.Value(contextKey{}))
+				return result
+			},
+			Streaming: func(ctx context.Context, result protocol.StreamingMessageResult) protocol.StreamingMessageResult {
+				assert.Equal(t, "trace-1", ctx.Value(contextKey{}))
+				return result
+			},
+		},
+	}
+
+	assert.Same(t, unary, proc.rewriteUnaryResult(ctx, unary))
+	assert.Same(t, streaming, proc.rewriteStreamingResult(ctx, streaming))
+}
+
 // TestMessageProcessor_ProcessMessage_NoPartsCollected tests handling when no parts are collected
 func TestMessageProcessor_ProcessMessage_NoPartsCollected(t *testing.T) {
 	ctxID := "ctx"
@@ -5133,6 +5168,7 @@ func TestMessageProcessor_ProcessMessage_ResponseRewriterDropFinalResult(
 	processor := &messageProcessor{
 		responseRewriter: ResponseRewriterFuncs{
 			Unary: func(
+				ctx context.Context,
 				result protocol.UnaryMessageResult,
 			) protocol.UnaryMessageResult {
 				return nil
@@ -5440,7 +5476,7 @@ func TestMessageProcessor_ProcessMessage_SkipsRunnerCompletion(t *testing.T) {
 		processor := &messageProcessor{
 			debugLogging: false,
 			responseRewriter: ResponseRewriterFuncs{
-				Unary: func(result protocol.UnaryMessageResult) protocol.UnaryMessageResult {
+				Unary: func(ctx context.Context, result protocol.UnaryMessageResult) protocol.UnaryMessageResult {
 					msg, ok := result.(*protocol.Message)
 					if !ok {
 						return result
@@ -5505,7 +5541,7 @@ func TestMessageProcessor_ProcessMessage_SkipsRunnerCompletion(t *testing.T) {
 		processor := &messageProcessor{
 			debugLogging: false,
 			responseRewriter: ResponseRewriterFuncs{
-				Unary: func(result protocol.UnaryMessageResult) protocol.UnaryMessageResult {
+				Unary: func(ctx context.Context, result protocol.UnaryMessageResult) protocol.UnaryMessageResult {
 					rewriteCallCount++
 					msg, ok := result.(*protocol.Message)
 					if !ok {
@@ -5553,7 +5589,7 @@ func TestMessageProcessor_ProcessMessage_SkipsRunnerCompletion(t *testing.T) {
 		processor := &messageProcessor{
 			debugLogging: false,
 			responseRewriter: ResponseRewriterFuncs{
-				Unary: func(result protocol.UnaryMessageResult) protocol.UnaryMessageResult {
+				Unary: func(ctx context.Context, result protocol.UnaryMessageResult) protocol.UnaryMessageResult {
 					msg, ok := result.(*protocol.Message)
 					if !ok {
 						return result


### PR DESCRIPTION
## Summary

- add request context to `ResponseRewriter` and `ResponseRewriterFuncs` callbacks
- pass the active request context through all unary and streaming response rewrite paths
- update A2A docs and add regression coverage for context propagation

## Tests

- `go test ./server/a2a -count=1`
- `go test ./...` (fails in unrelated existing skill/workspace-related packages: `agent/llmagent`, `internal/skillstage`, `internal/workspaceprep`, `tool/file`, `tool/skill`, `tool/workspaceexec`)
