### PR TITLE
model/openai: adapt DeepSeek structured output

### DIFF
--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -578,15 +578,22 @@ func (m *Model) buildChatRequest(request *model.Request) (*openai.ChatCompletion
 		request.StructuredOutput.Type == model.StructuredOutputJSONSchema &&
 		request.StructuredOutput.JSONSchema != nil {
 		js := request.StructuredOutput.JSONSchema
-		chatRequest.ResponseFormat = openai.ChatCompletionNewParamsResponseFormatUnion{
-			OfJSONSchema: &shared.ResponseFormatJSONSchemaParam{
-				JSONSchema: shared.ResponseFormatJSONSchemaJSONSchemaParam{
-					Name:        js.Name,
-					Schema:      js.Schema,
-					Strict:      openai.Bool(js.Strict),
-					Description: openai.String(js.Description),
+		if m.variant == VariantDeepSeek {
+			jsonObject := shared.NewResponseFormatJSONObjectParam()
+			chatRequest.ResponseFormat = openai.ChatCompletionNewParamsResponseFormatUnion{
+				OfJSONObject: &jsonObject,
+			}
+		} else {
+			chatRequest.ResponseFormat = openai.ChatCompletionNewParamsResponseFormatUnion{
+				OfJSONSchema: &shared.ResponseFormatJSONSchemaParam{
+					JSONSchema: shared.ResponseFormatJSONSchemaJSONSchemaParam{
+						Name:        js.Name,
+						Schema:      js.Schema,
+						Strict:      openai.Bool(js.Strict),
+						Description: openai.String(js.Description),
+					},
 				},
-			},
+			}
 		}
 		if len(request.Tools) > 0 {
 			// Parallel tool calls can interfere with strict JSON schema

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -3917,9 +3917,11 @@ func TestBuildChatRequest_EdgeCases(t *testing.T) {
 		}
 
 		chatReq, _ := deepSeekModel.buildChatRequest(req)
-		assert.NotNil(t, chatReq.ResponseFormat.OfJSONObject)
-		assert.Nil(t, chatReq.ResponseFormat.OfJSONSchema)
-		assert.Equal(t, "json_object", *chatReq.ResponseFormat.GetType())
+		require.NotNil(t, chatReq.ResponseFormat.OfJSONObject)
+		require.Nil(t, chatReq.ResponseFormat.OfJSONSchema)
+		typePtr := chatReq.ResponseFormat.GetType()
+		require.NotNil(t, typePtr)
+		assert.Equal(t, "json_object", *typePtr)
 	})
 }
 

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -3889,6 +3889,38 @@ func TestBuildChatRequest_EdgeCases(t *testing.T) {
 		}
 		assert.False(t, chatReq.ParallelToolCalls.Value)
 	})
+
+	t.Run("DeepSeek structured output uses json object response format", func(t *testing.T) {
+		deepSeekModel := New(
+			"deepseek-v4-flash",
+			WithAPIKey("test-key"),
+			WithVariant(VariantDeepSeek),
+		)
+		req := &model.Request{
+			Messages: []model.Message{
+				model.NewUserMessage("Return JSON with an ok field."),
+			},
+			StructuredOutput: &model.StructuredOutput{
+				Type: model.StructuredOutputJSONSchema,
+				JSONSchema: &model.JSONSchemaConfig{
+					Name: "output",
+					Schema: map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"ok": map[string]any{"type": "boolean"},
+						},
+						"required": []string{"ok"},
+					},
+					Strict: true,
+				},
+			},
+		}
+
+		chatReq, _ := deepSeekModel.buildChatRequest(req)
+		assert.NotNil(t, chatReq.ResponseFormat.OfJSONObject)
+		assert.Nil(t, chatReq.ResponseFormat.OfJSONSchema)
+		assert.Equal(t, "json_object", *chatReq.ResponseFormat.GetType())
+	})
 }
 
 // TestConvertUserMessageContent_WithImage tests image content conversion.


### PR DESCRIPTION
## Summary
- Send DeepSeek structured output requests as `response_format: {\"type\": \"json_object\"}` because DeepSeek v4 rejects OpenAI `json_schema` response formats.
- Preserve the existing OpenAI JSON schema path for non-DeepSeek variants.
- Add a focused unit test that verifies DeepSeek uses the JSON object response format.

## Test plan
- `go test ./model/openai -run 'TestBuildChatRequest_EdgeCases/DeepSeek_structured_output_uses_json_object_response_format' -count=1`
- `go test ./model/openai -count=1`
