### PR TITLE
model: expose reasoning token usage

### DIFF
--- a/model/callbacks_test.go
+++ b/model/callbacks_test.go
@@ -184,12 +184,8 @@ func TestCallbacksChainRegistration(t *testing.T) {
 		})
 
 	// Verify that both callbacks were registered.
-	if len(callbacks.BeforeModel) != 1 {
-		t.Errorf("Expected 1 before model callback, got %d", len(callbacks.BeforeModel))
-	}
-	if len(callbacks.AfterModel) != 1 {
-		t.Errorf("Expected 1 after model callback, got %d", len(callbacks.AfterModel))
-	}
+	require.Len(t, callbacks.BeforeModel, 1)
+	require.Len(t, callbacks.AfterModel, 1)
 }
 
 // TestCallbacks_BeforeModel_WithError tests error handling in before model callbacks.

--- a/model/http_client_test.go
+++ b/model/http_client_test.go
@@ -13,14 +13,15 @@ package model
 import (
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDefaultNewHTTPClient(t *testing.T) {
 	client := DefaultNewHTTPClient()
 
-	if client == nil {
-		t.Error("Expected non-nil HTTP client, got nil")
-	}
+	require.NotNil(t, client)
 }
 
 func TestDefaultNewHTTPClient_WithOptions(t *testing.T) {
@@ -31,30 +32,20 @@ func TestDefaultNewHTTPClient_WithOptions(t *testing.T) {
 		WithHTTPClientTransport(customTransport),
 	)
 
-	if client == nil {
-		t.Error("Expected non-nil HTTP client, got nil")
-	}
+	require.NotNil(t, client)
 
-	if httpClient, ok := client.(*http.Client); ok {
-		if httpClient.Transport != customTransport {
-			t.Error("Custom transport was not set correctly")
-		}
-	} else {
-		t.Error("Returned client is not of type *http.Client")
-	}
+	httpClient, ok := client.(*http.Client)
+	require.True(t, ok)
+	assert.Same(t, customTransport, httpClient.Transport)
 }
 
 func TestDefaultNewHTTPClient_NoOptions(t *testing.T) {
 	client := DefaultNewHTTPClient()
 
-	if client == nil {
-		t.Error("Expected non-nil HTTP client, got nil")
-	}
+	require.NotNil(t, client)
 
 	if httpClient, ok := client.(*http.Client); ok {
-		if httpClient.Transport != nil {
-			t.Error("Expected nil transport for default client")
-		}
+		assert.Nil(t, httpClient.Transport)
 	}
 }
 
@@ -63,9 +54,7 @@ func TestWithHTTPClientName(t *testing.T) {
 
 	WithHTTPClientName("test-name")(options)
 
-	if options.Name != "test-name" {
-		t.Errorf("Expected name 'test-name', got '%s'", options.Name)
-	}
+	assert.Equal(t, "test-name", options.Name)
 }
 
 func TestWithHTTPClientTransport(t *testing.T) {
@@ -74,9 +63,7 @@ func TestWithHTTPClientTransport(t *testing.T) {
 
 	WithHTTPClientTransport(customTransport)(options)
 
-	if options.Transport != customTransport {
-		t.Error("Custom transport was not set correctly in options")
-	}
+	assert.Same(t, customTransport, options.Transport)
 }
 
 func TestHTTPClientOptions_Merge(t *testing.T) {
@@ -86,13 +73,8 @@ func TestHTTPClientOptions_Merge(t *testing.T) {
 	WithHTTPClientName("merged-client")(options)
 	WithHTTPClientTransport(customTransport)(options)
 
-	if options.Name != "merged-client" {
-		t.Errorf("Expected name 'merged-client', got '%s'", options.Name)
-	}
-
-	if options.Transport != customTransport {
-		t.Error("Custom transport was not set correctly after merge")
-	}
+	assert.Equal(t, "merged-client", options.Name)
+	assert.Same(t, customTransport, options.Transport)
 }
 
 func TestHTTPClientInterface(t *testing.T) {
@@ -105,9 +87,7 @@ func TestHTTPClientNewFunc(t *testing.T) {
 	}
 
 	client := newFunc()
-	if client == nil {
-		t.Error("HTTPClientNewFunc should return a non-nil client")
-	}
+	require.NotNil(t, client)
 }
 
 func TestDefaultImplementationCompleteness(t *testing.T) {
@@ -122,32 +102,21 @@ func TestDefaultImplementationCompleteness(t *testing.T) {
 		opt(options)
 	}
 
-	if options.Name != "complete-test" {
-		t.Errorf("Expected name 'complete-test', got '%s'", options.Name)
-	}
-
-	if options.Transport != http.DefaultTransport {
-		t.Error("Expected default transport to be set")
-	}
+	assert.Equal(t, "complete-test", options.Name)
+	assert.Same(t, http.DefaultTransport, options.Transport)
 }
 
 func TestEdgeCases(t *testing.T) {
 	options := &HTTPClientOptions{}
 	WithHTTPClientName("")(options)
-	if options.Name != "" {
-		t.Error("Expected empty name to be set")
-	}
+	assert.Empty(t, options.Name)
 
 	options = &HTTPClientOptions{}
 	WithHTTPClientTransport(nil)(options)
-	if options.Transport != nil {
-		t.Error("Expected nil transport to be set")
-	}
+	assert.Nil(t, options.Transport)
 
 	client := DefaultNewHTTPClient()
-	if client == nil {
-		t.Error("Client should be created even with no options")
-	}
+	require.NotNil(t, client)
 }
 
 func TestMultipleOptionApplications(t *testing.T) {
@@ -157,7 +126,5 @@ func TestMultipleOptionApplications(t *testing.T) {
 	WithHTTPClientName("second")(options)
 	WithHTTPClientName("third")(options)
 
-	if options.Name != "third" {
-		t.Errorf("Expected last applied name 'third', got '%s'", options.Name)
-	}
+	assert.Equal(t, "third", options.Name)
 }

--- a/model/message_compare_test.go
+++ b/model/message_compare_test.go
@@ -11,83 +11,61 @@ package model
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestMessagesEqual_Simple(t *testing.T) {
 	a := NewUserMessage("hello")
 	b := NewUserMessage("hello")
-	if !MessagesEqual(a, b) {
-		t.Fatalf("expected equal for identical user messages")
-	}
+	require.True(t, MessagesEqual(a, b), "expected equal for identical user messages")
 
 	c := NewAssistantMessage("hello")
-	if MessagesEqual(a, c) {
-		t.Fatalf("expected not equal when roles differ")
-	}
+	require.False(t, MessagesEqual(a, c), "expected not equal when roles differ")
 
 	d := NewUserMessage("hello!")
-	if MessagesEqual(a, d) {
-		t.Fatalf("expected not equal when content differs")
-	}
+	require.False(t, MessagesEqual(a, d), "expected not equal when content differs")
 }
 
 func TestMessagesEqual_ContentParts(t *testing.T) {
 	text := "part"
 	m1 := Message{Role: RoleUser, Content: "", ContentParts: []ContentPart{{Type: ContentTypeText, Text: &text}}}
 	m2 := Message{Role: RoleUser, Content: "", ContentParts: []ContentPart{{Type: ContentTypeText, Text: &text}}}
-	if !MessagesEqual(m1, m2) {
-		t.Fatalf("expected equal when content parts match")
-	}
+	require.True(t, MessagesEqual(m1, m2), "expected equal when content parts match")
 
 	diff := "part2"
 	m3 := Message{Role: RoleUser, Content: "", ContentParts: []ContentPart{{Type: ContentTypeText, Text: &diff}}}
-	if MessagesEqual(m1, m3) {
-		t.Fatalf("expected not equal when content parts differ")
-	}
+	require.False(t, MessagesEqual(m1, m3), "expected not equal when content parts differ")
 }
 
 func TestMessagesEqual_ToolFields(t *testing.T) {
 	// Tool result comparison
 	toolMsg1 := Message{Role: RoleTool, ToolID: "call_1", ToolName: "fn", Content: "res"}
 	toolMsg2 := Message{Role: RoleTool, ToolID: "call_1", ToolName: "fn", Content: "res"}
-	if !MessagesEqual(toolMsg1, toolMsg2) {
-		t.Fatalf("expected equal tool result messages")
-	}
+	require.True(t, MessagesEqual(toolMsg1, toolMsg2), "expected equal tool result messages")
 	toolMsg3 := Message{Role: RoleTool, ToolID: "call_2", ToolName: "fn", Content: "res"}
-	if MessagesEqual(toolMsg1, toolMsg3) {
-		t.Fatalf("expected not equal when tool id differs")
-	}
+	require.False(t, MessagesEqual(toolMsg1, toolMsg3), "expected not equal when tool id differs")
 
 	// Tool calls comparison
 	args1 := []byte(`{"x":1}`)
 	args2 := []byte(`{"x":2}`)
 	callMsg1 := Message{Role: RoleAssistant, ToolCalls: []ToolCall{{Type: "function", ID: "t1", Function: FunctionDefinitionParam{Name: "echo", Arguments: args1}}}}
 	callMsg2 := Message{Role: RoleAssistant, ToolCalls: []ToolCall{{Type: "function", ID: "t1", Function: FunctionDefinitionParam{Name: "echo", Arguments: args1}}}}
-	if !MessagesEqual(callMsg1, callMsg2) {
-		t.Fatalf("expected equal tool call messages")
-	}
+	require.True(t, MessagesEqual(callMsg1, callMsg2), "expected equal tool call messages")
 	callMsg3 := Message{Role: RoleAssistant, ToolCalls: []ToolCall{{Type: "function", ID: "t1", Function: FunctionDefinitionParam{Name: "echo", Arguments: args2}}}}
-	if MessagesEqual(callMsg1, callMsg3) {
-		t.Fatalf("expected not equal when tool call args differ")
-	}
+	require.False(t, MessagesEqual(callMsg1, callMsg3), "expected not equal when tool call args differ")
 }
 
 func TestMessagesEqual_ReasoningContent(t *testing.T) {
 	a := Message{Role: RoleAssistant, Content: "ok", ReasoningContent: "think1"}
 	b := Message{Role: RoleAssistant, Content: "ok", ReasoningContent: "think1"}
-	if !MessagesEqual(a, b) {
-		t.Fatalf("expected equal when reasoning content same")
-	}
+	require.True(t, MessagesEqual(a, b), "expected equal when reasoning content same")
 	c := Message{Role: RoleAssistant, Content: "ok", ReasoningContent: "think2"}
-	if MessagesEqual(a, c) {
-		t.Fatalf("expected not equal when reasoning content differs")
-	}
+	require.False(t, MessagesEqual(a, c), "expected not equal when reasoning content differs")
 }
 
 func TestMessagesEqual_ToolNameDiffers(t *testing.T) {
 	a := Message{Role: RoleTool, ToolID: "1", ToolName: "fn1", Content: "res"}
 	b := Message{Role: RoleTool, ToolID: "1", ToolName: "fn2", Content: "res"}
-	if MessagesEqual(a, b) {
-		t.Fatalf("expected not equal when tool name differs")
-	}
+	require.False(t, MessagesEqual(a, b), "expected not equal when tool name differs")
 }

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -13,6 +13,8 @@ import (
 	"context"
 	"errors"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // TestModelInterface tests the Model interface definition.
@@ -28,12 +30,8 @@ func TestModelInterface(t *testing.T) {
 	ctx := context.Background()
 	responseChan, err := mock.GenerateContent(ctx, nil)
 
-	if err == nil {
-		t.Error("Model.GenerateContent() with nil request should return error")
-	}
-	if responseChan != nil {
-		t.Error("Model.GenerateContent() with nil request should return nil channel")
-	}
+	require.Error(t, err)
+	require.Nil(t, responseChan)
 }
 
 // mockModel is a simple mock implementation for testing the interface.

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -4088,11 +4088,17 @@ func TestInverseOPENAISKDAddChunkUsage(t *testing.T) {
 			PromptTokens:     100,
 			CompletionTokens: 50,
 			TotalTokens:      150,
+			CompletionTokensDetails: model.CompletionTokensDetails{
+				ReasoningTokens: 12,
+			},
 		}
 		delta := model.Usage{
 			PromptTokens:     10,
 			CompletionTokens: 5,
 			TotalTokens:      15,
+			CompletionTokensDetails: model.CompletionTokensDetails{
+				ReasoningTokens: 2,
+			},
 		}
 
 		result := inverseOpenAISDKAddChunkUsage(currentUsage, delta)
@@ -4100,6 +4106,7 @@ func TestInverseOPENAISKDAddChunkUsage(t *testing.T) {
 		assert.Equal(t, 90, result.PromptTokens, "expected prompt tokens to be 90 (100 - 10)")
 		assert.Equal(t, 45, result.CompletionTokens, "expected completion tokens to be 45 (50 - 5)")
 		assert.Equal(t, 135, result.TotalTokens, "expected total tokens to be 135 (150 - 15)")
+		assert.Equal(t, 10, result.CompletionTokensDetails.ReasoningTokens, "expected reasoning tokens to be 10 (12 - 2)")
 	})
 
 	t.Run("handles zero delta", func(t *testing.T) {
@@ -4151,6 +4158,9 @@ func TestModelUsageToCompletionUsage(t *testing.T) {
 			PromptTokensDetails: model.PromptTokensDetails{
 				CachedTokens: 20,
 			},
+			CompletionTokensDetails: model.CompletionTokensDetails{
+				ReasoningTokens: 15,
+			},
 		}
 
 		result := modelUsageToCompletionUsage(modelUsage)
@@ -4159,6 +4169,7 @@ func TestModelUsageToCompletionUsage(t *testing.T) {
 		assert.Equal(t, int64(50), result.CompletionTokens, "expected completion tokens to be 50")
 		assert.Equal(t, int64(150), result.TotalTokens, "expected total tokens to be 150")
 		assert.Equal(t, int64(20), result.PromptTokensDetails.CachedTokens, "expected cached tokens to be 20")
+		assert.Equal(t, int64(15), result.CompletionTokensDetails.ReasoningTokens, "expected reasoning tokens to be 15")
 	})
 
 	t.Run("converts zero values", func(t *testing.T) {
@@ -4169,6 +4180,9 @@ func TestModelUsageToCompletionUsage(t *testing.T) {
 			PromptTokensDetails: model.PromptTokensDetails{
 				CachedTokens: 0,
 			},
+			CompletionTokensDetails: model.CompletionTokensDetails{
+				ReasoningTokens: 0,
+			},
 		}
 
 		result := modelUsageToCompletionUsage(modelUsage)
@@ -4177,6 +4191,7 @@ func TestModelUsageToCompletionUsage(t *testing.T) {
 		assert.Equal(t, int64(0), result.CompletionTokens, "expected completion tokens to be 0")
 		assert.Equal(t, int64(0), result.TotalTokens, "expected total tokens to be 0")
 		assert.Equal(t, int64(0), result.PromptTokensDetails.CachedTokens, "expected cached tokens to be 0")
+		assert.Equal(t, int64(0), result.CompletionTokensDetails.ReasoningTokens, "expected reasoning tokens to be 0")
 	})
 
 	t.Run("roundtrip conversion", func(t *testing.T) {
@@ -4186,6 +4201,9 @@ func TestModelUsageToCompletionUsage(t *testing.T) {
 			TotalTokens:      579,
 			PromptTokensDetails: model.PromptTokensDetails{
 				CachedTokens: 78,
+			},
+			CompletionTokensDetails: model.CompletionTokensDetails{
+				ReasoningTokens: 90,
 			},
 		}
 
@@ -4197,6 +4215,7 @@ func TestModelUsageToCompletionUsage(t *testing.T) {
 		assert.Equal(t, originalUsage.CompletionTokens, backToModel.CompletionTokens, "expected completion tokens to match after roundtrip")
 		assert.Equal(t, originalUsage.TotalTokens, backToModel.TotalTokens, "expected total tokens to match after roundtrip")
 		assert.Equal(t, originalUsage.PromptTokensDetails.CachedTokens, backToModel.PromptTokensDetails.CachedTokens, "expected cached tokens to match after roundtrip")
+		assert.Equal(t, originalUsage.CompletionTokensDetails.ReasoningTokens, backToModel.CompletionTokensDetails.ReasoningTokens, "expected reasoning tokens to match after roundtrip")
 	})
 }
 
@@ -4210,6 +4229,9 @@ func TestCompletionUsageToModelUsage(t *testing.T) {
 			PromptTokensDetails: openai.CompletionUsagePromptTokensDetails{
 				CachedTokens: int64(30),
 			},
+			CompletionTokensDetails: openai.CompletionUsageCompletionTokensDetails{
+				ReasoningTokens: int64(25),
+			},
 		}
 
 		result := completionUsageToModelUsage(openaiUsage)
@@ -4218,6 +4240,7 @@ func TestCompletionUsageToModelUsage(t *testing.T) {
 		assert.Equal(t, 75, result.CompletionTokens, "expected completion tokens to be 75")
 		assert.Equal(t, 275, result.TotalTokens, "expected total tokens to be 275")
 		assert.Equal(t, 30, result.PromptTokensDetails.CachedTokens, "expected cached tokens to be 30")
+		assert.Equal(t, 25, result.CompletionTokensDetails.ReasoningTokens, "expected reasoning tokens to be 25")
 	})
 
 	t.Run("converts zero values", func(t *testing.T) {
@@ -4228,6 +4251,9 @@ func TestCompletionUsageToModelUsage(t *testing.T) {
 			PromptTokensDetails: openai.CompletionUsagePromptTokensDetails{
 				CachedTokens: int64(0),
 			},
+			CompletionTokensDetails: openai.CompletionUsageCompletionTokensDetails{
+				ReasoningTokens: int64(0),
+			},
 		}
 
 		result := completionUsageToModelUsage(openaiUsage)
@@ -4236,6 +4262,7 @@ func TestCompletionUsageToModelUsage(t *testing.T) {
 		assert.Equal(t, 0, result.CompletionTokens, "expected completion tokens to be 0")
 		assert.Equal(t, 0, result.TotalTokens, "expected total tokens to be 0")
 		assert.Equal(t, 0, result.PromptTokensDetails.CachedTokens, "expected cached tokens to be 0")
+		assert.Equal(t, 0, result.CompletionTokensDetails.ReasoningTokens, "expected reasoning tokens to be 0")
 	})
 }
 

--- a/model/openai/options.go
+++ b/model/openai/options.go
@@ -373,6 +373,9 @@ func inverseOpenAISDKAddChunkUsage(u model.Usage, delta model.Usage) model.Usage
 		PromptTokensDetails: model.PromptTokensDetails{
 			CachedTokens: int(u.PromptTokensDetails.CachedTokens - delta.PromptTokensDetails.CachedTokens),
 		},
+		CompletionTokensDetails: model.CompletionTokensDetails{
+			ReasoningTokens: int(u.CompletionTokensDetails.ReasoningTokens - delta.CompletionTokensDetails.ReasoningTokens),
+		},
 	}
 }
 
@@ -385,6 +388,9 @@ func completionUsageToModelUsage(usage openai.CompletionUsage) model.Usage {
 		PromptTokensDetails: model.PromptTokensDetails{
 			CachedTokens: int(usage.PromptTokensDetails.CachedTokens),
 		},
+		CompletionTokensDetails: model.CompletionTokensDetails{
+			ReasoningTokens: int(usage.CompletionTokensDetails.ReasoningTokens),
+		},
 	}
 }
 
@@ -396,6 +402,9 @@ func modelUsageToCompletionUsage(usage model.Usage) openai.CompletionUsage {
 		TotalTokens:      int64(usage.TotalTokens),
 		PromptTokensDetails: openai.CompletionUsagePromptTokensDetails{
 			CachedTokens: int64(usage.PromptTokensDetails.CachedTokens),
+		},
+		CompletionTokensDetails: openai.CompletionUsageCompletionTokensDetails{
+			ReasoningTokens: int64(usage.CompletionTokensDetails.ReasoningTokens),
 		},
 	}
 }

--- a/model/response.go
+++ b/model/response.go
@@ -96,6 +96,9 @@ type Usage struct {
 	// PromptTokensDetails is the details of the prompt tokens.
 	PromptTokensDetails PromptTokensDetails `json:"prompt_tokens_details"`
 
+	// CompletionTokensDetails is the details of the completion tokens.
+	CompletionTokensDetails CompletionTokensDetails `json:"completion_tokens_details"`
+
 	// TimingInfo contains detailed timing information for token generation.
 	TimingInfo *TimingInfo `json:"timing_info,omitempty"`
 }
@@ -108,6 +111,12 @@ type PromptTokensDetails struct {
 	CacheCreationTokens int `json:"cache_creation_tokens,omitempty"`
 	// CacheReadTokens is the number of tokens read from cache (Anthropic).
 	CacheReadTokens int `json:"cache_read_tokens,omitempty"`
+}
+
+// CompletionTokensDetails is the details of the completion tokens.
+type CompletionTokensDetails struct {
+	// ReasoningTokens is the number of tokens generated for reasoning.
+	ReasoningTokens int `json:"reasoning_tokens,omitempty"`
 }
 
 // Response is the response from the model.
@@ -175,10 +184,11 @@ func (rsp *Response) Clone() *Response {
 	copy(clone.Choices, rsp.Choices)
 	if rsp.Usage != nil {
 		clone.Usage = &Usage{
-			PromptTokens:        rsp.Usage.PromptTokens,
-			CompletionTokens:    rsp.Usage.CompletionTokens,
-			TotalTokens:         rsp.Usage.TotalTokens,
-			PromptTokensDetails: rsp.Usage.PromptTokensDetails,
+			PromptTokens:            rsp.Usage.PromptTokens,
+			CompletionTokens:        rsp.Usage.CompletionTokens,
+			TotalTokens:             rsp.Usage.TotalTokens,
+			PromptTokensDetails:     rsp.Usage.PromptTokensDetails,
+			CompletionTokensDetails: rsp.Usage.CompletionTokensDetails,
 		}
 		// Deep copy TimingInfo if present
 		if rsp.Usage.TimingInfo != nil {

--- a/model/response.go
+++ b/model/response.go
@@ -114,6 +114,9 @@ type PromptTokensDetails struct {
 }
 
 // CompletionTokensDetails is the details of the completion tokens.
+// It intentionally exposes reasoning tokens first; other OpenAI SDK completion
+// detail fields such as audio tokens and prediction token counters are deferred
+// until the model package has provider-agnostic semantics for them.
 type CompletionTokensDetails struct {
 	// ReasoningTokens is the number of tokens generated for reasoning.
 	ReasoningTokens int `json:"reasoning_tokens,omitempty"`

--- a/model/response_test.go
+++ b/model/response_test.go
@@ -172,7 +172,10 @@ func TestCompletionTokensDetails_Structure(t *testing.T) {
 	details := CompletionTokensDetails{
 		ReasoningTokens: 100,
 	}
-	assert.GreaterOrEqual(t, details.ReasoningTokens, 0)
+	assert.Equal(t, 100, details.ReasoningTokens)
+
+	zero := CompletionTokensDetails{}
+	assert.Equal(t, 0, zero.ReasoningTokens)
 }
 
 func TestUsage_WithPromptTokensDetails(t *testing.T) {

--- a/model/response_test.go
+++ b/model/response_test.go
@@ -11,9 +11,11 @@ package model
 
 import (
 	"errors"
-	"reflect"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type typedCodedError struct{}
@@ -89,9 +91,7 @@ func TestErrorTypeConstants(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.constant != tt.expected {
-				t.Errorf("Error constant = %v, want %v", tt.constant, tt.expected)
-			}
+			assert.Equal(t, tt.expected, tt.constant)
 		})
 	}
 }
@@ -111,18 +111,11 @@ func TestChoice_Structure(t *testing.T) {
 		FinishReason: &finishReason,
 	}
 
-	if choice.Index != 0 {
-		t.Errorf("Choice.Index = %v, want %v", choice.Index, 0)
-	}
-	if choice.Message.Role != RoleAssistant {
-		t.Errorf("Choice.Message.Role = %v, want %v", choice.Message.Role, RoleAssistant)
-	}
-	if choice.Delta.Content != "Streaming content" {
-		t.Errorf("Choice.Delta.Content = %v, want %v", choice.Delta.Content, "Streaming content")
-	}
-	if *choice.FinishReason != "stop" {
-		t.Errorf("Choice.FinishReason = %v, want %v", *choice.FinishReason, "stop")
-	}
+	assert.Equal(t, 0, choice.Index)
+	assert.Equal(t, RoleAssistant, choice.Message.Role)
+	assert.Equal(t, "Streaming content", choice.Delta.Content)
+	require.NotNil(t, choice.FinishReason)
+	assert.Equal(t, "stop", *choice.FinishReason)
 }
 
 func TestUsage_Structure(t *testing.T) {
@@ -132,15 +125,9 @@ func TestUsage_Structure(t *testing.T) {
 		TotalTokens:      30,
 	}
 
-	if usage.PromptTokens != 10 {
-		t.Errorf("Usage.PromptTokens = %v, want %v", usage.PromptTokens, 10)
-	}
-	if usage.CompletionTokens != 20 {
-		t.Errorf("Usage.CompletionTokens = %v, want %v", usage.CompletionTokens, 20)
-	}
-	if usage.TotalTokens != 30 {
-		t.Errorf("Usage.TotalTokens = %v, want %v", usage.TotalTokens, 30)
-	}
+	assert.Equal(t, 10, usage.PromptTokens)
+	assert.Equal(t, 20, usage.CompletionTokens)
+	assert.Equal(t, 30, usage.TotalTokens)
 }
 
 func TestPromptTokensDetails_Structure(t *testing.T) {
@@ -174,15 +161,9 @@ func TestPromptTokensDetails_Structure(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.details.CachedTokens < 0 {
-				t.Errorf("CachedTokens should not be negative: %v", tt.details.CachedTokens)
-			}
-			if tt.details.CacheCreationTokens < 0 {
-				t.Errorf("CacheCreationTokens should not be negative: %v", tt.details.CacheCreationTokens)
-			}
-			if tt.details.CacheReadTokens < 0 {
-				t.Errorf("CacheReadTokens should not be negative: %v", tt.details.CacheReadTokens)
-			}
+			assert.GreaterOrEqual(t, tt.details.CachedTokens, 0)
+			assert.GreaterOrEqual(t, tt.details.CacheCreationTokens, 0)
+			assert.GreaterOrEqual(t, tt.details.CacheReadTokens, 0)
 		})
 	}
 }
@@ -191,9 +172,7 @@ func TestCompletionTokensDetails_Structure(t *testing.T) {
 	details := CompletionTokensDetails{
 		ReasoningTokens: 100,
 	}
-	if details.ReasoningTokens < 0 {
-		t.Errorf("ReasoningTokens should not be negative: %v", details.ReasoningTokens)
-	}
+	assert.GreaterOrEqual(t, details.ReasoningTokens, 0)
 }
 
 func TestUsage_WithPromptTokensDetails(t *testing.T) {
@@ -241,16 +220,10 @@ func TestUsage_WithPromptTokensDetails(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Verify basic usage fields
-			if tt.usage.TotalTokens != tt.usage.PromptTokens+tt.usage.CompletionTokens {
-				t.Errorf("TotalTokens mismatch: got %v, want %v",
-					tt.usage.TotalTokens, tt.usage.PromptTokens+tt.usage.CompletionTokens)
-			}
+			assert.Equal(t, tt.usage.PromptTokens+tt.usage.CompletionTokens, tt.usage.TotalTokens)
 
 			// Verify cache tokens don't exceed prompt tokens
-			if tt.usage.PromptTokensDetails.CachedTokens > tt.usage.PromptTokens {
-				t.Errorf("CachedTokens (%v) should not exceed PromptTokens (%v)",
-					tt.usage.PromptTokensDetails.CachedTokens, tt.usage.PromptTokens)
-			}
+			assert.LessOrEqual(t, tt.usage.PromptTokensDetails.CachedTokens, tt.usage.PromptTokens)
 		})
 	}
 }
@@ -283,27 +256,15 @@ func TestResponse_Structure(t *testing.T) {
 		Done:              true,
 	}
 
-	if response.ID != "chatcmpl-123" {
-		t.Errorf("Response.ID = %v, want %v", response.ID, "chatcmpl-123")
-	}
-	if response.Object != "chat.completion" {
-		t.Errorf("Response.Object = %v, want %v", response.Object, "chat.completion")
-	}
-	if response.Model != "gpt-3.5-turbo" {
-		t.Errorf("Response.Model = %v, want %v", response.Model, "gpt-3.5-turbo")
-	}
-	if len(response.Choices) != 1 {
-		t.Errorf("Response.Choices length = %v, want %v", len(response.Choices), 1)
-	}
-	if response.Usage.TotalTokens != 15 {
-		t.Errorf("Response.Usage.TotalTokens = %v, want %v", response.Usage.TotalTokens, 15)
-	}
-	if *response.SystemFingerprint != "fp_test_123" {
-		t.Errorf("Response.SystemFingerprint = %v, want %v", *response.SystemFingerprint, "fp_test_123")
-	}
-	if !response.Done {
-		t.Errorf("Response.Done = %v, want %v", response.Done, true)
-	}
+	assert.Equal(t, "chatcmpl-123", response.ID)
+	assert.Equal(t, "chat.completion", response.Object)
+	assert.Equal(t, "gpt-3.5-turbo", response.Model)
+	assert.Len(t, response.Choices, 1)
+	require.NotNil(t, response.Usage)
+	assert.Equal(t, 15, response.Usage.TotalTokens)
+	require.NotNil(t, response.SystemFingerprint)
+	assert.Equal(t, "fp_test_123", *response.SystemFingerprint)
+	assert.True(t, response.Done)
 }
 
 func TestResponseError_Structure(t *testing.T) {
@@ -317,31 +278,21 @@ func TestResponseError_Structure(t *testing.T) {
 		Code:    &code,
 	}
 
-	if err.Message != "Invalid parameter value" {
-		t.Errorf("ResponseError.Message = %v, want %v", err.Message, "Invalid parameter value")
-	}
-	if err.Type != ErrorTypeAPIError {
-		t.Errorf("ResponseError.Type = %v, want %v", err.Type, ErrorTypeAPIError)
-	}
-	if *err.Param != "max_tokens" {
-		t.Errorf("ResponseError.Param = %v, want %v", *err.Param, "max_tokens")
-	}
-	if *err.Code != "invalid_value" {
-		t.Errorf("ResponseError.Code = %v, want %v", *err.Code, "invalid_value")
-	}
+	assert.Equal(t, "Invalid parameter value", err.Message)
+	assert.Equal(t, ErrorTypeAPIError, err.Type)
+	require.NotNil(t, err.Param)
+	assert.Equal(t, "max_tokens", *err.Param)
+	require.NotNil(t, err.Code)
+	assert.Equal(t, "invalid_value", *err.Code)
 }
 
 func TestResponseError_ImplementsError(t *testing.T) {
 	var respErr *ResponseError
-	if respErr.Error() != "" {
-		t.Errorf("(*ResponseError)(nil).Error() = %q, want %q", respErr.Error(), "")
-	}
+	assert.Empty(t, respErr.Error())
 
 	respErr = &ResponseError{Message: "boom"}
 	var err error = respErr
-	if err.Error() != "boom" {
-		t.Errorf("error.Error() = %q, want %q", err.Error(), "boom")
-	}
+	assert.Equal(t, "boom", err.Error())
 }
 
 func TestResponseErrorFromError_PreservesTypeAndCode(t *testing.T) {
@@ -353,18 +304,11 @@ func TestResponseErrorFromError_PreservesTypeAndCode(t *testing.T) {
 	}
 
 	got := ResponseErrorFromError(in, ErrorTypeFlowError)
-	if got == nil {
-		t.Fatal("ResponseErrorFromError() returned nil")
-	}
-	if got.Type != "biz_error" {
-		t.Errorf("Type = %q, want %q", got.Type, "biz_error")
-	}
-	if got.Code == nil || *got.Code != "E42" {
-		t.Errorf("Code = %v, want %q", got.Code, "E42")
-	}
-	if got.Message != "bad" {
-		t.Errorf("Message = %q, want %q", got.Message, "bad")
-	}
+	require.NotNil(t, got)
+	assert.Equal(t, "biz_error", got.Type)
+	require.NotNil(t, got.Code)
+	assert.Equal(t, "E42", *got.Code)
+	assert.Equal(t, "bad", got.Message)
 }
 
 func TestResponseErrorFromError_ExtractsTypeAndCode(t *testing.T) {
@@ -372,83 +316,54 @@ func TestResponseErrorFromError_ExtractsTypeAndCode(t *testing.T) {
 	err = errors.Join(err, typedCodedError{})
 
 	got := ResponseErrorFromError(err, ErrorTypeFlowError)
-	if got == nil {
-		t.Fatal("ResponseErrorFromError() returned nil")
-	}
-	if got.Type != typedCodedErrType {
-		t.Errorf("Type = %q, want %q", got.Type, typedCodedErrType)
-	}
-	if got.Code == nil || *got.Code != typedCodedErrCodeStr {
-		t.Errorf("Code = %v, want %q", got.Code, typedCodedErrCodeStr)
-	}
-	if got.Message == "" {
-		t.Error("Message should not be empty")
-	}
+	require.NotNil(t, got)
+	assert.Equal(t, typedCodedErrType, got.Type)
+	require.NotNil(t, got.Code)
+	assert.Equal(t, typedCodedErrCodeStr, *got.Code)
+	assert.NotEmpty(t, got.Message)
 }
 
 func TestResponseErrorFromError_Nil(t *testing.T) {
 	got := ResponseErrorFromError(nil, ErrorTypeFlowError)
-	if got != nil {
-		t.Fatalf("ResponseErrorFromError(nil) = %#v, want nil", got)
-	}
+	require.Nil(t, got)
 }
 
 func TestResponseErrorFromError_FallbackTypeAndNoCode(t *testing.T) {
 	err := errors.New("boom")
 
 	got := ResponseErrorFromError(err, ErrorTypeFlowError)
-	if got == nil {
-		t.Fatal("ResponseErrorFromError() returned nil")
-	}
-	if got.Type != ErrorTypeFlowError {
-		t.Errorf("Type = %q, want %q", got.Type, ErrorTypeFlowError)
-	}
-	if got.Code != nil {
-		t.Errorf("Code = %v, want nil", got.Code)
-	}
-	if got.Message != "boom" {
-		t.Errorf("Message = %q, want %q", got.Message, "boom")
-	}
+	require.NotNil(t, got)
+	assert.Equal(t, ErrorTypeFlowError, got.Type)
+	assert.Nil(t, got.Code)
+	assert.Equal(t, "boom", got.Message)
 }
 
 func TestResponseErrorFromError_UsesErrorCodeMethod(t *testing.T) {
 	got := ResponseErrorFromError(errorCodeStringError{}, ErrorTypeFlowError)
-	if got == nil {
-		t.Fatal("ResponseErrorFromError() returned nil")
-	}
-	if got.Code == nil || *got.Code != errorCodeStringErrCode {
-		t.Errorf("Code = %v, want %q", got.Code, errorCodeStringErrCode)
-	}
+	require.NotNil(t, got)
+	require.NotNil(t, got.Code)
+	assert.Equal(t, errorCodeStringErrCode, *got.Code)
 }
 
 func TestResponseErrorFromError_UsesCodeStringMethod(t *testing.T) {
 	got := ResponseErrorFromError(codeStringError{}, ErrorTypeFlowError)
-	if got == nil {
-		t.Fatal("ResponseErrorFromError() returned nil")
-	}
-	if got.Code == nil || *got.Code != codeStringErrCode {
-		t.Errorf("Code = %v, want %q", got.Code, codeStringErrCode)
-	}
+	require.NotNil(t, got)
+	require.NotNil(t, got.Code)
+	assert.Equal(t, codeStringErrCode, *got.Code)
 }
 
 func TestResponseErrorFromError_UsesCodeInt32Method(t *testing.T) {
 	got := ResponseErrorFromError(codeInt32Error{}, ErrorTypeFlowError)
-	if got == nil {
-		t.Fatal("ResponseErrorFromError() returned nil")
-	}
-	if got.Code == nil || *got.Code != codeInt32ErrCodeStr {
-		t.Errorf("Code = %v, want %q", got.Code, codeInt32ErrCodeStr)
-	}
+	require.NotNil(t, got)
+	require.NotNil(t, got.Code)
+	assert.Equal(t, codeInt32ErrCodeStr, *got.Code)
 }
 
 func TestResponseErrorFromError_UsesCodeInt64Method(t *testing.T) {
 	got := ResponseErrorFromError(codeInt64Error{}, ErrorTypeFlowError)
-	if got == nil {
-		t.Fatal("ResponseErrorFromError() returned nil")
-	}
-	if got.Code == nil || *got.Code != codeInt64ErrCodeStr {
-		t.Errorf("Code = %v, want %q", got.Code, codeInt64ErrCodeStr)
-	}
+	require.NotNil(t, got)
+	require.NotNil(t, got.Code)
+	assert.Equal(t, codeInt64ErrCodeStr, *got.Code)
 }
 
 func TestResponse_WithError(t *testing.T) {
@@ -463,16 +378,9 @@ func TestResponse_WithError(t *testing.T) {
 		Done:      true,
 	}
 
-	if response.Error == nil {
-		t.Error("Response.Error should not be nil")
-		return
-	}
-	if response.Error.Message != "API error occurred" {
-		t.Errorf("Response.Error.Message = %v, want %v", response.Error.Message, "API error occurred")
-	}
-	if response.Error.Type != ErrorTypeStreamError {
-		t.Errorf("Response.Error.Type = %v, want %v", response.Error.Type, ErrorTypeStreamError)
-	}
+	require.NotNil(t, response.Error)
+	assert.Equal(t, "API error occurred", response.Error.Message)
+	assert.Equal(t, ErrorTypeStreamError, response.Error.Type)
 }
 
 func TestResponse_StreamingResponse(t *testing.T) {
@@ -497,15 +405,10 @@ func TestResponse_StreamingResponse(t *testing.T) {
 		Done:      false,
 	}
 
-	if streamChunk.Object != "chat.completion.chunk" {
-		t.Errorf("Stream chunk Object = %v, want %v", streamChunk.Object, "chat.completion.chunk")
-	}
-	if streamChunk.Choices[0].Delta.Content != "partial " {
-		t.Errorf("Stream chunk Delta.Content = %v, want %v", streamChunk.Choices[0].Delta.Content, "partial ")
-	}
-	if streamChunk.Done {
-		t.Errorf("Stream chunk Done = %v, want %v", streamChunk.Done, false)
-	}
+	assert.Equal(t, "chat.completion.chunk", streamChunk.Object)
+	require.NotEmpty(t, streamChunk.Choices)
+	assert.Equal(t, "partial ", streamChunk.Choices[0].Delta.Content)
+	assert.False(t, streamChunk.Done)
 }
 
 func TestResponse_EmptyChoices(t *testing.T) {
@@ -515,9 +418,7 @@ func TestResponse_EmptyChoices(t *testing.T) {
 		Done:    true,
 	}
 
-	if len(response.Choices) != 0 {
-		t.Errorf("Empty response Choices length = %v, want %v", len(response.Choices), 0)
-	}
+	assert.Empty(t, response.Choices)
 }
 
 func TestResponse_MultipleChoices(t *testing.T) {
@@ -542,18 +443,10 @@ func TestResponse_MultipleChoices(t *testing.T) {
 		Done: true,
 	}
 
-	if len(response.Choices) != 2 {
-		t.Errorf("Multiple choices length = %v, want %v", len(response.Choices), 2)
-	}
-	if response.Choices[0].Index != 0 {
-		t.Errorf("First choice index = %v, want %v", response.Choices[0].Index, 0)
-	}
-	if response.Choices[1].Index != 1 {
-		t.Errorf("Second choice index = %v, want %v", response.Choices[1].Index, 1)
-	}
-	if response.Choices[1].Message.Content != "Second choice" {
-		t.Errorf("Second choice content = %v, want %v", response.Choices[1].Message.Content, "Second choice")
-	}
+	require.Len(t, response.Choices, 2)
+	assert.Equal(t, 0, response.Choices[0].Index)
+	assert.Equal(t, 1, response.Choices[1].Index)
+	assert.Equal(t, "Second choice", response.Choices[1].Message.Content)
 }
 
 func TestResponse_IsValidContent(t *testing.T) {
@@ -684,9 +577,7 @@ func TestResponse_IsValidContent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.rsp.IsValidContent(); got != tt.want {
-				t.Errorf("IsValidContent() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, tt.rsp.IsValidContent())
 		})
 	}
 }
@@ -748,9 +639,7 @@ func TestResponse_IsToolResultResponse(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.rsp.IsToolResultResponse()
-			if got != tt.expected {
-				t.Errorf("IsToolResultResponse() = %v, want %v", got, tt.expected)
-			}
+			assert.Equal(t, tt.expected, got)
 		})
 	}
 }
@@ -821,9 +710,7 @@ func TestResponse_GetToolCallIDs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.rsp.GetToolCallIDs()
-			if !reflect.DeepEqual(got, tt.expected) {
-				t.Errorf("GetToolCallIDs() = %v, want %v", got, tt.expected)
-			}
+			assert.Equal(t, tt.expected, got)
 		})
 	}
 }
@@ -898,9 +785,7 @@ func TestResponse_GetToolResultIDs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.rsp.GetToolResultIDs()
-			if !reflect.DeepEqual(got, tt.expected) {
-				t.Errorf("GetToolResultIDs() = %v, want %v", got, tt.expected)
-			}
+			assert.Equal(t, tt.expected, got)
 		})
 	}
 }
@@ -961,9 +846,7 @@ func TestResponse_IsFinalResponse(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.rsp.IsFinalResponse()
-			if got != tt.expected {
-				t.Errorf("IsFinalResponse() = %v, want %v", got, tt.expected)
-			}
+			assert.Equal(t, tt.expected, got)
 		})
 	}
 }
@@ -1077,98 +960,59 @@ func TestResponse_Clone(t *testing.T) {
 
 			// Test nil case
 			if tt.response == nil {
-				if clone != nil {
-					t.Errorf("Clone of nil should return nil, got %v", clone)
-				}
+				assert.Nil(t, clone)
 				return
 			}
 
 			// Verify it's a different object
-			if tt.response == clone {
-				t.Error("Clone should return a different object")
-			}
+			require.NotSame(t, tt.response, clone)
 
 			// Verify all fields are equal
-			if clone.ID != tt.response.ID {
-				t.Errorf("ID mismatch: got %v, want %v", clone.ID, tt.response.ID)
-			}
-			if clone.Object != tt.response.Object {
-				t.Errorf("Object mismatch: got %v, want %v", clone.Object, tt.response.Object)
-			}
-			if clone.Created != tt.response.Created {
-				t.Errorf("Created mismatch: got %v, want %v", clone.Created, tt.response.Created)
-			}
-			if clone.Model != tt.response.Model {
-				t.Errorf("Model mismatch: got %v, want %v", clone.Model, tt.response.Model)
-			}
+			assert.Equal(t, tt.response.ID, clone.ID)
+			assert.Equal(t, tt.response.Object, clone.Object)
+			assert.Equal(t, tt.response.Created, clone.Created)
+			assert.Equal(t, tt.response.Model, clone.Model)
 
 			// Verify Choices is a deep copy
-			if len(clone.Choices) != len(tt.response.Choices) {
-				t.Errorf("Choices length mismatch: got %v, want %v", len(clone.Choices), len(tt.response.Choices))
-			}
-			if len(clone.Choices) > 0 && &clone.Choices[0] == &tt.response.Choices[0] {
-				t.Error("Choices should be deep copied")
+			require.Len(t, clone.Choices, len(tt.response.Choices))
+			if len(clone.Choices) > 0 {
+				assert.NotSame(t, &tt.response.Choices[0], &clone.Choices[0])
 			}
 			for i := range clone.Choices {
-				if !reflect.DeepEqual(clone.Choices[i], tt.response.Choices[i]) {
-					t.Errorf("Choice %d mismatch: got %+v, want %+v", i, clone.Choices[i], tt.response.Choices[i])
-				}
+				assert.Equal(t, tt.response.Choices[i], clone.Choices[i])
 			}
 
 			// Verify Usage is deep copied
 			if tt.response.Usage != nil {
-				if clone.Usage == nil {
-					t.Error("Usage should be copied")
-				} else {
-					if clone.Usage == tt.response.Usage {
-						t.Error("Usage should be deep copied")
-					}
-					if !reflect.DeepEqual(clone.Usage, tt.response.Usage) {
-						t.Errorf("Usage mismatch: got %+v, want %+v", clone.Usage, tt.response.Usage)
-					}
-				}
-			} else if clone.Usage != nil {
-				t.Error("Usage should be nil")
+				require.NotNil(t, clone.Usage)
+				assert.NotSame(t, tt.response.Usage, clone.Usage)
+				assert.Equal(t, tt.response.Usage, clone.Usage)
+			} else {
+				assert.Nil(t, clone.Usage)
 			}
 
 			// Verify Error is deep copied
 			if tt.response.Error != nil {
-				if clone.Error == nil {
-					t.Error("Error should be copied")
-				} else {
-					if clone.Error == tt.response.Error {
-						t.Error("Error should be deep copied")
-					}
-					if !reflect.DeepEqual(clone.Error, tt.response.Error) {
-						t.Errorf("Error mismatch: got %+v, want %+v", clone.Error, tt.response.Error)
-					}
-				}
-			} else if clone.Error != nil {
-				t.Error("Error should be nil")
+				require.NotNil(t, clone.Error)
+				assert.NotSame(t, tt.response.Error, clone.Error)
+				assert.Equal(t, tt.response.Error, clone.Error)
+			} else {
+				assert.Nil(t, clone.Error)
 			}
 
 			// Verify SystemFingerprint is deep copied
 			if tt.response.SystemFingerprint != nil {
-				if clone.SystemFingerprint == nil {
-					t.Error("SystemFingerprint should be copied")
-				} else {
-					if clone.SystemFingerprint == tt.response.SystemFingerprint {
-						t.Error("SystemFingerprint should be deep copied")
-					}
-					if *clone.SystemFingerprint != *tt.response.SystemFingerprint {
-						t.Errorf("SystemFingerprint mismatch: got %v, want %v", *clone.SystemFingerprint, *tt.response.SystemFingerprint)
-					}
-				}
-			} else if clone.SystemFingerprint != nil {
-				t.Error("SystemFingerprint should be nil")
+				require.NotNil(t, clone.SystemFingerprint)
+				assert.NotSame(t, tt.response.SystemFingerprint, clone.SystemFingerprint)
+				assert.Equal(t, *tt.response.SystemFingerprint, *clone.SystemFingerprint)
+			} else {
+				assert.Nil(t, clone.SystemFingerprint)
 			}
 
 			// Verify modifying clone doesn't affect original
 			if len(clone.Choices) > 0 {
 				clone.Choices[0].Message.Content = "Modified"
-				if tt.response.Choices[0].Message.Content == "Modified" {
-					t.Error("Modifying clone should not affect original")
-				}
+				assert.NotEqual(t, "Modified", tt.response.Choices[0].Message.Content)
 			}
 		})
 	}
@@ -1241,9 +1085,7 @@ func TestResponse_IsToolCallResponse(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.rsp.IsToolCallResponse()
-			if got != tt.expected {
-				t.Errorf("IsToolCallResponse() = %v, want %v", got, tt.expected)
-			}
+			assert.Equal(t, tt.expected, got)
 		})
 	}
 }
@@ -1273,9 +1115,7 @@ func TestResponse_IsPartialResponse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.rsp.IsPartial != tt.expected {
-				t.Errorf("IsPartial = %v, want %v", tt.rsp.IsPartial, tt.expected)
-			}
+			assert.Equal(t, tt.expected, tt.rsp.IsPartial)
 		})
 	}
 }
@@ -1366,9 +1206,7 @@ func TestObjectTypeConstants(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.constant != tt.expected {
-				t.Errorf("Constant = %v, want %v", tt.constant, tt.expected)
-			}
+			assert.Equal(t, tt.expected, tt.constant)
 		})
 	}
 }
@@ -1466,9 +1304,7 @@ func TestResponse_IsUserMessage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := tt.rsp.IsUserMessage()
-			if result != tt.expected {
-				t.Errorf("IsUserMessage() = %v, want %v", result, tt.expected)
-			}
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/model/response_test.go
+++ b/model/response_test.go
@@ -187,6 +187,15 @@ func TestPromptTokensDetails_Structure(t *testing.T) {
 	}
 }
 
+func TestCompletionTokensDetails_Structure(t *testing.T) {
+	details := CompletionTokensDetails{
+		ReasoningTokens: 100,
+	}
+	if details.ReasoningTokens < 0 {
+		t.Errorf("ReasoningTokens should not be negative: %v", details.ReasoningTokens)
+	}
+}
+
 func TestUsage_WithPromptTokensDetails(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
## Summary
- Add `CompletionTokensDetails` to model usage and map OpenAI SDK reasoning token usage through conversions.
- Simplify root `model` package tests with testify assertions while preserving existing coverage.

## Test plan
- `go test ./model/openai ./model`
- Live compatibility checked earlier against DeepSeek v4, proxy `deepseek-v3.2`, and proxy `gpt-5.2`.

## Reference
- https://api-docs.deepseek.com/zh-cn/api/create-chat-completion
- https://developers.openai.com/api/reference/resources/completions
