### PR TITLE
tool/agent: add final-only response mode

### DIFF
--- a/docs/mkdocs/en/multiagent.md
+++ b/docs/mkdocs/en/multiagent.md
@@ -379,6 +379,8 @@ agentTool := agenttool.NewTool(
     agenttool.WithSkipSummarization(false),
     // Enable inner forwarding: stream child Agent events inline to the parent
     agenttool.WithStreamInner(true),
+    // Return only the child Agent's final assistant message as the tool result.
+    agenttool.WithResponseMode(agenttool.ResponseModeFinalOnly),
 )
 
 // Use Agent tool in main Agent.
@@ -465,6 +467,15 @@ if ev.Response != nil && ev.Object == model.ObjectTypeToolResponse {
   assistant text when inner streaming is enabled
 - `WithInnerTextMode(agenttool.InnerTextModeExclude)`: keep inner
   progress events, but suppress forwarded child assistant text
+- `WithResponseMode(agenttool.ResponseModeDefault)`: default compatibility mode;
+  concatenate child assistant messages into the tool result
+- `WithResponseMode(agenttool.ResponseModeFinalOnly)`: return only the last
+  complete child assistant message as the tool result
+
+Use `ResponseModeFinalOnly` when the child Agent is a context-isolated worker
+and the parent Agent should only consume its final answer. Use
+`InnerTextModeExclude` separately when you also want to hide child assistant
+text from the streamed UI.
 
 ### Agent Transfer
 

--- a/docs/mkdocs/en/tool.md
+++ b/docs/mkdocs/en/tool.md
@@ -1121,6 +1121,8 @@ mathTool := agenttool.NewTool(
     agenttool.WithStreamInner(true),
     // hide child assistant prose while still forwarding inner tool progress.
     agenttool.WithInnerTextMode(agenttool.InnerTextModeExclude),
+    // return only the child Agent's final assistant message as the tool result.
+    agenttool.WithResponseMode(agenttool.ResponseModeFinalOnly),
 )
 
 // 3) Use in parent Agent
@@ -1160,6 +1162,57 @@ if ev.Author != parentName && ev.Response != nil &&
 }
 ```
 
+### Tool Result Response Modes
+
+AgentTool always executes the child Agent as an event stream. The response mode
+only controls the value returned to the parent Agent as the tool result. It does
+not change child session storage, event filter keys, or inner streaming.
+
+By default, AgentTool preserves its legacy behavior: every non-empty assistant
+message emitted by the child Agent is appended into one tool-result string.
+This is useful for compatibility, but it can be surprising for long-running
+child Agents that emit progress, drafts, or intermediate assistant messages.
+Those intermediate assistant messages can become part of the parent Agent's
+`tool.response`.
+
+Use `WithResponseMode(agenttool.ResponseModeFinalOnly)` when the child Agent is
+used as an isolated worker and the parent Agent should only see the child's
+final answer:
+
+```go
+childTool := agenttool.NewTool(
+    childAgent,
+    agenttool.WithResponseMode(agenttool.ResponseModeFinalOnly),
+)
+```
+
+In final-only mode, AgentTool:
+
+- ignores partial assistant chunks
+- ignores non-assistant messages, empty assistant messages, and tool messages
+- returns the last complete child assistant message
+- returns an empty string when the child Agent completes without a complete
+  assistant message
+- still returns child Agent errors as `agent error: ...`
+
+This is different from `WithSkipSummarization(true)`. `WithSkipSummarization`
+controls whether the parent flow performs an extra outer summarization call
+after the tool response. `WithResponseMode` controls what the tool response
+contains in the first place.
+
+Example with both settings:
+
+```go
+childTool := agenttool.NewTool(
+    childAgent,
+    // Keep the child Agent's chain-of-work out of the tool result.
+    agenttool.WithResponseMode(agenttool.ResponseModeFinalOnly),
+    // End the parent turn after tool.response instead of asking the parent
+    // model to summarize the result again.
+    agenttool.WithSkipSummarization(true),
+)
+```
+
 ### Options
 
 - WithSkipSummarization(bool):
@@ -1180,6 +1233,13 @@ if ev.Author != parentName && ev.Response != nil &&
     keeping inner tool calls, tool completions, and the aggregated final tool
     response
 
+- WithResponseMode(ResponseMode):
+
+  - `ResponseModeDefault` (default): keep legacy concatenation of child
+    assistant messages into the tool result
+  - `ResponseModeFinalOnly`: return only the last complete child assistant
+    message as the tool result
+
 - WithHistoryScope(HistoryScope):
   - `HistoryScopeIsolated` (default): Keep the child Agent fully isolated; it only sees the current tool arguments (no inherited history).
   - `HistoryScopeParentBranch`: Inherit parent conversation history by using a hierarchical filter key `parent/child-uuid`. This allows the content processor to include parent events via prefix matching while keeping child events isolated under a sub-branch. Typical use cases: “edit/optimize/continue previous output”.
@@ -1192,6 +1252,7 @@ child := agenttool.NewTool(
     agenttool.WithSkipSummarization(false),
     agenttool.WithStreamInner(true),
     agenttool.WithInnerTextMode(agenttool.InnerTextModeExclude),
+    agenttool.WithResponseMode(agenttool.ResponseModeFinalOnly),
     agenttool.WithHistoryScope(agenttool.HistoryScopeParentBranch),
 )
 ```
@@ -1204,6 +1265,10 @@ child := agenttool.NewTool(
   `WithInnerTextMode(agenttool.InnerTextModeExclude)` when users should see
   inner progress without seeing duplicated child prose
 - Model compatibility: Some providers require a tool message after tool_calls; AgentTool automatically supplies the aggregated content
+- Child context isolation and tool-result shaping are separate concerns.
+  `WithHistoryScope(agenttool.HistoryScopeIsolated)` controls what the child
+  can read. `WithResponseMode(agenttool.ResponseModeFinalOnly)` controls what
+  the parent receives as the tool result.
 - `WithSkipSummarization(true)` only skips the extra outer summarization LLM call. It does not make `tool.response` a final assistant response; keep consuming until `runner.completion` if you need the real terminal signal
 
 ## Tool Integration and Usage

--- a/docs/mkdocs/zh/multiagent.md
+++ b/docs/mkdocs/zh/multiagent.md
@@ -380,6 +380,8 @@ agentTool := agenttool.NewTool(
     agenttool.WithSkipSummarization(false),
     // 开启转发：把子 Agent 的流式事件内联到父流程
     agenttool.WithStreamInner(true),
+    // 工具结果只返回子 Agent 最后一条完整 assistant 消息
+    agenttool.WithResponseMode(agenttool.ResponseModeFinalOnly),
 )
 
 // 在主 Agent 中使用 Agent 工具
@@ -463,6 +465,12 @@ if ev.Response != nil && ev.Object == model.ObjectTypeToolResponse {
 - `WithStreamInner(false)`：按普通可调用工具处理，不转发内部流
 - `WithInnerTextMode(agenttool.InnerTextModeInclude)`：启用内部转发时，继续展示子 Agent 的 assistant 文本
 - `WithInnerTextMode(agenttool.InnerTextModeExclude)`：保留内部进度事件，但不再转发子 Agent 的 assistant 正文
+- `WithResponseMode(agenttool.ResponseModeDefault)`：默认兼容模式，把子 Agent 的 assistant 消息拼接成工具结果
+- `WithResponseMode(agenttool.ResponseModeFinalOnly)`：只把子 Agent 最后一条完整 assistant 消息作为工具结果返回
+
+当子 Agent 是一个上下文隔离的独立工作者，而父 Agent 只应该消费它的最终答案时，
+使用 `ResponseModeFinalOnly`。如果还希望在流式 UI 中隐藏子 Agent 的正文，
+再单独组合 `InnerTextModeExclude`。
 
 ### Agent 委托 (Agent Transfer)
 

--- a/docs/mkdocs/zh/tool.md
+++ b/docs/mkdocs/zh/tool.md
@@ -1099,6 +1099,7 @@ mathTool := agenttool.NewTool(
     agenttool.WithSkipSummarization(false), // 可选，默认 false，当设置为 true 时会跳过外层模型总结，在 tool.response 后直接结束本轮
     agenttool.WithStreamInner(true),        // 开启：把子 Agent 的流式事件转发给父流程
     agenttool.WithInnerTextMode(agenttool.InnerTextModeExclude), // 隐藏子 Agent 正文，仅保留内部进度
+    agenttool.WithResponseMode(agenttool.ResponseModeFinalOnly),  // 工具结果只返回子 Agent 最后一条完整 assistant 消息
 )
 
 // 3) 在父 Agent 中使用该工具
@@ -1136,6 +1137,51 @@ if ev.Author != parentName && ev.Response != nil &&
 }
 ```
 
+### 工具结果响应模式
+
+AgentTool 内部始终是以事件流的形式运行子 Agent。响应模式只控制
+AgentTool 最终作为“工具结果”返回给父 Agent 的内容；它不会改变
+子 Agent 的 session 写入、事件过滤键，也不会改变内部流式转发行为。
+
+默认情况下，AgentTool 保持历史兼容行为：子 Agent 产生的每一条非空
+assistant 消息都会被追加到同一个工具结果字符串里。这个行为对存量调用方最安全，
+但长任务子 Agent 往往会输出进度、草稿或中间结论，这些中间 assistant 内容也会
+进入父 Agent 看到的 `tool.response`。
+
+当子 Agent 的目标是“隔离上下文、独立完成任务、只把最终答案交给父 Agent”
+时，可以使用 `WithResponseMode(agenttool.ResponseModeFinalOnly)`：
+
+```go
+childTool := agenttool.NewTool(
+    childAgent,
+    agenttool.WithResponseMode(agenttool.ResponseModeFinalOnly),
+)
+```
+
+在 final-only 模式下，AgentTool 会：
+
+- 忽略 partial assistant 增量
+- 忽略非 assistant 消息、空 assistant 消息以及 tool 消息
+- 返回子 Agent 最后一条完整 assistant 消息
+- 如果子 Agent 结束时没有完整 assistant 消息，则返回空字符串
+- 子 Agent 报错时仍返回 `agent error: ...`
+
+它和 `WithSkipSummarization(true)` 不是一回事。`WithSkipSummarization`
+控制的是父流程拿到工具响应后，是否再调用一次外层模型做总结；
+`WithResponseMode` 控制的是工具响应本身应该包含哪些子 Agent 内容。
+
+组合示例：
+
+```go
+childTool := agenttool.NewTool(
+    childAgent,
+    // 不把子 Agent 的中间推理/进度 assistant 文本拼进工具结果。
+    agenttool.WithResponseMode(agenttool.ResponseModeFinalOnly),
+    // 父流程拿到 tool.response 后直接结束本轮，不再额外总结。
+    agenttool.WithSkipSummarization(true),
+)
+```
+
 ### 选项说明
 
 - WithSkipSummarization(bool)：
@@ -1153,6 +1199,11 @@ if ev.Author != parentName && ev.Response != nil &&
   - `InnerTextModeInclude`：实际默认行为，开启内部转发时继续展示子 Agent 的 assistant 文本
   - `InnerTextModeExclude`：隐藏子 Agent 的 assistant 文本，但继续保留内部 tool call、tool.done，以及聚合后的最终工具响应
 
+- WithResponseMode(ResponseMode)：
+
+  - `ResponseModeDefault`（默认）：保持历史兼容行为，把子 Agent 的 assistant 消息拼接成工具结果
+  - `ResponseModeFinalOnly`：只把子 Agent 最后一条完整 assistant 消息作为工具结果返回
+
 - WithHistoryScope(HistoryScope)：
   - `HistoryScopeIsolated`（默认）：保持子调用完全隔离，只读取本次工具参数（不继承父历史）。
   - `HistoryScopeParentBranch`：通过分层过滤键 `父键/子名-UUID（Universally Unique Identifier，通用唯一识别码）` 继承父会话历史；内容处理器会基于前缀匹配纳入父事件，同时子事件仍写入独立子分支。典型场景：基于上一轮产出进行“编辑/优化/续写”。
@@ -1165,6 +1216,7 @@ child := agenttool.NewTool(
     agenttool.WithSkipSummarization(false),
     agenttool.WithStreamInner(true),
     agenttool.WithInnerTextMode(agenttool.InnerTextModeExclude),
+    agenttool.WithResponseMode(agenttool.ResponseModeFinalOnly),
     agenttool.WithHistoryScope(agenttool.HistoryScopeParentBranch),
 )
 ```
@@ -1175,6 +1227,9 @@ child := agenttool.NewTool(
 - 内容去重：如果已转发子 Agent 的增量内容，默认不要再把最终 `tool.response` 的聚合内容打印出来
 - “只看进度”体验：当你希望用户看到内部进度、但不想重复看到子 Agent 正文时，可组合使用 `WithStreamInner(true)` 和 `WithInnerTextMode(agenttool.InnerTextModeExclude)`
 - 模型兼容性：一些模型要求工具调用后必须跟随工具消息，AgentTool 已自动填充聚合后的工具内容满足此要求
+- 子 Agent 上下文隔离和工具结果裁剪是两件事：
+  `WithHistoryScope(agenttool.HistoryScopeIsolated)` 控制子 Agent 能读到什么；
+  `WithResponseMode(agenttool.ResponseModeFinalOnly)` 控制父 Agent 作为工具结果收到什么。
 - `WithSkipSummarization(true)` 只会跳过额外的外层总结型 LLM 调用，不会把 `tool.response` 变成 assistant final response；如果你需要真正的终止信号，仍应持续消费到 `runner.completion`
 
 ## 工具集成与使用

--- a/examples/agenttool/README.md
+++ b/examples/agenttool/README.md
@@ -35,13 +35,14 @@ Agent tools provide a way to wrap any agent as a tool that can be called by othe
 
 ## Command Line Arguments
 
-| Argument      | Description                                     | Default Value   |
-| ------------- | ----------------------------------------------- | --------------- |
-| `-model`      | Name of the model to use                        | `deepseek-chat` |
-| `-show-inner` | Show inner agent deltas streamed by AgentTool   | `true`          |
-| `-inner-text` | Inner text mode: `include` or `exclude`         | `include`       |
-| `-show-tool`  | Show tool.response deltas/finals in transcript  | `false`         |
-| `-debug`      | Prefix streamed lines with author for debugging | `false`         |
+| Argument         | Description                                           | Default Value   |
+| ---------------- | ----------------------------------------------------- | --------------- |
+| `-model`         | Name of the model to use                              | `deepseek-chat` |
+| `-show-inner`    | Show inner agent deltas streamed by AgentTool         | `true`          |
+| `-inner-text`    | Inner text mode: `include` or `exclude`               | `include`       |
+| `-response-mode` | Tool result mode: `default` or `final-only`           | `default`       |
+| `-show-tool`     | Show tool.response deltas/finals in transcript        | `false`         |
+| `-debug`         | Prefix streamed lines with author for debugging       | `false`         |
 
 ## Usage
 
@@ -68,6 +69,8 @@ This example exposes three visibility controls:
 - `-inner-text`: whether forwarded inner assistant text is visible
 - `-show-tool`: whether the example prints the aggregated final
   `tool.response`
+- `-response-mode`: which child assistant messages become the tool result
+  consumed by the parent agent
 
 The flags map directly to the AgentTool configuration:
 
@@ -77,6 +80,7 @@ agentTool := agenttool.NewTool(
     agenttool.WithSkipSummarization(true),
     agenttool.WithStreamInner(showInner),
     agenttool.WithInnerTextMode(innerTextMode),
+    agenttool.WithResponseMode(responseMode),
 )
 ```
 
@@ -129,6 +133,31 @@ You will see:
 - tool response output if `-show-tool=true`
 - no forwarded inner events
 
+### Final-Only Tool Result
+
+```bash
+go run . -response-mode=final-only -show-tool=true
+```
+
+Use this when the child agent is doing its own multi-step work and the parent
+agent should only receive the child agent's final answer as the tool result.
+
+The default response mode preserves compatibility by concatenating child
+assistant messages into the tool result. That means progress-like assistant
+messages, drafts, and the final assistant message may all appear in the final
+`tool.response`. `final-only` changes only the tool result: it ignores partial
+assistant chunks and returns the last complete child assistant message.
+
+This is separate from `-inner-text`. For example:
+
+```bash
+go run . -show-inner=true -inner-text=exclude \
+  -response-mode=final-only -show-tool=true
+```
+
+This combination keeps child tool progress visible, hides streamed child prose,
+and gives the parent agent only the child agent's final answer.
+
 ## Implemented Tools
 
 The example includes two types of tools:
@@ -169,6 +198,12 @@ Chat Assistant (Main Agent)
 3. **Tool Integration**: The agent tool is added to the main agent's tool list
 4. **Delegation**: When the main agent encounters tasks that match the specialized agent's expertise, it delegates to the agent tool
 5. **Response Processing**: The agent tool executes the specialized agent and returns the result. When the agent tool streams, you will receive `tool.response` events with partial chunks.
+
+By default, AgentTool builds its callable result by aggregating child assistant
+messages. This preserves older behavior. When you configure
+`agenttool.WithResponseMode(agenttool.ResponseModeFinalOnly)`, AgentTool still
+runs the same child agent, but only the last complete child assistant message is
+returned as the tool result.
 
 ## Tool Calling Process
 
@@ -272,6 +307,7 @@ agentTool := agenttool.NewTool(
     agenttool.WithSkipSummarization(true),
     agenttool.WithStreamInner(*showInner),
     agenttool.WithInnerTextMode(innerTextMode),
+    agenttool.WithResponseMode(responseMode),
 )
 ```
 
@@ -324,9 +360,15 @@ This lets the agent tool stream results progressively while keeping the main con
 - `-inner-text=include` shows the child agent's prose as it streams.
 - `-inner-text=exclude` hides child prose but still lets you keep tool
   progress and the aggregated final `tool.response`.
-- The framework always emits a final non-partial `tool.response` with merged
-  content for session history and provider compliance. The example hides it
-  unless `-show-tool` is set.
+- `-response-mode=default` preserves compatibility by concatenating child
+  assistant messages into the tool result.
+- `-response-mode=final-only` returns only the child agent's last complete
+  assistant message as the tool result.
+- The framework always emits a final non-partial `tool.response` for session
+  history and provider compliance. In `default` mode, that tool response uses
+  merged child content. In `final-only` mode, it uses only the child agent's
+  last complete assistant message. The example hides it unless `-show-tool` is
+  set.
 
 Examples:
 
@@ -337,6 +379,9 @@ go run . -model gpt-4o-mini
 # Show progress only, then render the aggregated tool response
 go run . -show-inner -inner-text=exclude -show-tool
 
+# Return only the child agent's final answer as the tool result
+go run . -response-mode=final-only -show-tool
+
 # Hide all inner events and only print tool outputs
 go run . -show-inner=false -show-tool
 ```
@@ -344,8 +389,8 @@ go run . -show-inner=false -show-tool
 Notes:
 
 - Even when inner deltas are streamed, the framework does not forward the child
-  agent's final full message again. That content is merged into the final
-  `tool.response`.
+  agent's final full message again. The selected response mode controls what is
+  written into the final `tool.response`.
 - If you choose `-inner-text=exclude` and also keep `-show-tool=false`, you
   will only see progress markers. That is expected: the child prose is hidden,
   and the example is also choosing not to print the final tool message.

--- a/examples/agenttool/main.go
+++ b/examples/agenttool/main.go
@@ -1,5 +1,6 @@
 //
-// Tencent is pleased to support the open source community by making trpc-agent-go available.
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
 //
 // Copyright (C) 2025 Tencent.  All rights reserved.
 //
@@ -34,6 +35,8 @@ import (
 const (
 	defaultModelName     = "deepseek-chat"
 	defaultInnerTextMode = string(agenttool.InnerTextModeInclude)
+	responseModeDefault  = "default"
+	responseModeFinal    = "final-only"
 )
 
 var (
@@ -62,6 +65,11 @@ var (
 		defaultInnerTextMode,
 		"Inner text mode: include or exclude",
 	)
+	toolResponseMode = flag.String(
+		"response-mode",
+		responseModeDefault,
+		"AgentTool response mode: default or final-only",
+	)
 )
 
 func main() {
@@ -72,11 +80,16 @@ func main() {
 	if err != nil {
 		log.Fatalf("invalid -inner-text: %v", err)
 	}
+	responseMode, err := parseResponseMode(*toolResponseMode)
+	if err != nil {
+		log.Fatalf("invalid -response-mode: %v", err)
+	}
 
 	fmt.Printf("🚀 Agent Tool Example\n")
 	fmt.Printf("Model: %s\n", *modelName)
 	fmt.Printf("Show inner: %t\n", *showInner)
 	fmt.Printf("Inner text mode: %s\n", mode)
+	fmt.Printf("Response mode: %s\n", responseModeName(responseMode))
 	fmt.Printf("Show tool: %t\n", *showTool)
 	fmt.Printf("Available tools: current_time, math-specialist(agent_tool)\n")
 	fmt.Println(strings.Repeat("=", 50))
@@ -88,6 +101,7 @@ func main() {
 		showTool:      *showTool,
 		showInner:     *showInner,
 		innerTextMode: mode,
+		responseMode:  responseMode,
 	}
 
 	if err := chat.run(); err != nil {
@@ -107,6 +121,7 @@ type agentToolChat struct {
 	showTool      bool
 	showInner     bool
 	innerTextMode agenttool.InnerTextMode
+	responseMode  agenttool.ResponseMode
 }
 
 // run starts the interactive chat session.
@@ -134,18 +149,26 @@ func (c *agentToolChat) setup(_ context.Context) error {
 	calculatorTool := function.NewFunctionTool(
 		c.calculate,
 		function.WithName("calculator"),
-		function.WithDescription("Perform basic mathematical calculations (add, subtract, multiply, divide)"),
+		function.WithDescription(
+			"Perform basic mathematical calculations",
+		),
 	)
 
 	// Create a specialized agent for math operations.
 	mathAgent := llmagent.New(
 		"math-specialist",
 		llmagent.WithModel(modelInstance),
-		llmagent.WithDescription("A specialized agent for mathematical operations and calculations"),
-		llmagent.WithInstruction("You are a math specialist. Focus on mathematical operations, "+
-			"calculations, and numerical reasoning. When you receive a calculation request, "+
-			"use your calculator tool to compute the result, then provide a clear, natural language response "+
-			"explaining the calculation and result. Always explain what you calculated and present the answer clearly."),
+		llmagent.WithDescription(
+			"A specialized agent for mathematical operations",
+		),
+		llmagent.WithInstruction(
+			"You are a math specialist. Focus on mathematical "+
+				"operations, calculations, and numerical reasoning. "+
+				"When you receive a calculation request, use your "+
+				"calculator tool to compute the result, then provide "+
+				"a clear, natural language response explaining the "+
+				"calculation and result.",
+		),
 		llmagent.WithGenerationConfig(model.GenerationConfig{
 			MaxTokens:   intPtr(1000),
 			Temperature: floatPtr(0.3),
@@ -168,7 +191,9 @@ func (c *agentToolChat) setup(_ context.Context) error {
 	timeTool := function.NewFunctionTool(
 		c.getCurrentTime,
 		function.WithName("current_time"),
-		function.WithDescription("Get the current time and date for a specific timezone"),
+		function.WithDescription(
+			"Get the current time and date for a specific timezone",
+		),
 	)
 
 	// Create agent tool that wraps the math specialist agent.
@@ -179,6 +204,7 @@ func (c *agentToolChat) setup(_ context.Context) error {
 		agenttool.WithSkipSummarization(true),
 		agenttool.WithStreamInner(c.showInner),
 		agenttool.WithInnerTextMode(c.innerTextMode),
+		agenttool.WithResponseMode(c.responseMode),
 	)
 
 	// Create LLM agent with tools including the agent tool.
@@ -192,11 +218,17 @@ func (c *agentToolChat) setup(_ context.Context) error {
 	llmAgent := llmagent.New(
 		c.agentName,
 		llmagent.WithModel(modelInstance),
-		llmagent.WithDescription("A helpful AI assistant with time tools and agent tools"),
-		llmagent.WithInstruction("Use tools when appropriate for time queries or "+
-			"mathematical operations. For any math calculations, always use the math-specialist agent tool. "+
-			"After receiving the math-specialist's response, present the result clearly to the user. "+
-			"Be helpful and conversational."),
+		llmagent.WithDescription(
+			"A helpful AI assistant with time tools and agent tools",
+		),
+		llmagent.WithInstruction(
+			"Use tools when appropriate for time queries or "+
+				"mathematical operations. For any math calculations, "+
+				"always use the math-specialist agent tool. After "+
+				"receiving the math-specialist's response, present "+
+				"the result clearly to the user. Be helpful and "+
+				"conversational.",
+		),
 		llmagent.WithGenerationConfig(genConfig),
 		llmagent.WithTools([]tool.Tool{timeTool, agentTool}),
 	)
@@ -269,7 +301,10 @@ func (c *agentToolChat) startChat(ctx context.Context) error {
 }
 
 // processMessage handles a single message exchange.
-func (c *agentToolChat) processMessage(ctx context.Context, userMessage string) error {
+func (c *agentToolChat) processMessage(
+	ctx context.Context,
+	userMessage string,
+) error {
 	message := model.NewUserMessage(userMessage)
 
 	// Run the agent through the runner.
@@ -282,8 +317,10 @@ func (c *agentToolChat) processMessage(ctx context.Context, userMessage string) 
 	return c.processStreamingResponse(eventChan)
 }
 
-// processStreamingResponse handles the streaming response with tool call visualization.
-func (c *agentToolChat) processStreamingResponse(eventChan <-chan *event.Event) error {
+// processStreamingResponse handles streaming with tool call visualization.
+func (c *agentToolChat) processStreamingResponse(
+	eventChan <-chan *event.Event,
+) error {
 	fmt.Print("🤖 Assistant: ")
 
 	var (
@@ -301,8 +338,12 @@ func (c *agentToolChat) processStreamingResponse(eventChan <-chan *event.Event) 
 	return nil
 }
 
-// handleEvent processes a single event and returns true if the event was handled.
-func (c *agentToolChat) handleEvent(ev *event.Event, assistantStarted *bool, fullContent *strings.Builder) bool {
+// handleEvent processes one event and returns true when it was handled.
+func (c *agentToolChat) handleEvent(
+	ev *event.Event,
+	assistantStarted *bool,
+	fullContent *strings.Builder,
+) bool {
 	// Handle errors
 	if ev.Error != nil {
 		fmt.Printf("\n❌ Error: %s\n", ev.Error.Message)
@@ -333,7 +374,10 @@ func (c *agentToolChat) handleEvent(ev *event.Event, assistantStarted *bool, ful
 }
 
 // handleToolCalls processes tool call events.
-func (c *agentToolChat) handleToolCalls(ev *event.Event, assistantStarted *bool) bool {
+func (c *agentToolChat) handleToolCalls(
+	ev *event.Event,
+	assistantStarted *bool,
+) bool {
 	if ev.Response == nil || len(ev.Response.Choices) == 0 {
 		return false
 	}
@@ -359,7 +403,10 @@ func (c *agentToolChat) handleToolCalls(ev *event.Event, assistantStarted *bool)
 
 // handleInnerAgentStreaming processes inner agent streaming events.
 func (c *agentToolChat) handleInnerAgentStreaming(ev *event.Event) bool {
-	if !c.showInner || ev.Author == c.agentName || ev.Response == nil || len(ev.Response.Choices) == 0 {
+	if !c.showInner ||
+		ev.Author == c.agentName ||
+		ev.Response == nil ||
+		len(ev.Response.Choices) == 0 {
 		return false
 	}
 
@@ -376,8 +423,14 @@ func (c *agentToolChat) handleInnerAgentStreaming(ev *event.Event) bool {
 }
 
 // handleAssistantStreaming processes outer assistant streaming events.
-func (c *agentToolChat) handleAssistantStreaming(ev *event.Event, assistantStarted *bool, fullContent *strings.Builder) bool {
-	if ev.Author != c.agentName || ev.Response == nil || len(ev.Response.Choices) == 0 {
+func (c *agentToolChat) handleAssistantStreaming(
+	ev *event.Event,
+	assistantStarted *bool,
+	fullContent *strings.Builder,
+) bool {
+	if ev.Author != c.agentName ||
+		ev.Response == nil ||
+		len(ev.Response.Choices) == 0 {
 		return false
 	}
 
@@ -397,13 +450,15 @@ func (c *agentToolChat) handleAssistantStreaming(ev *event.Event, assistantStart
 
 // handleToolResponses processes tool response events.
 func (c *agentToolChat) handleToolResponses(ev *event.Event) bool {
-	if ev.Response == nil || ev.Object != model.ObjectTypeToolResponse || len(ev.Response.Choices) == 0 {
+	if ev.Response == nil ||
+		ev.Object != model.ObjectTypeToolResponse ||
+		len(ev.Response.Choices) == 0 {
 		return false
 	}
 
 	ch := ev.Response.Choices[0]
 	if ch.Delta.Content != "" {
-		// Partial tool delta - only show if not already shown via inner streaming
+		// Partial tool delta; only show if inner streaming is hidden.
 		if c.showTool && !c.showInner {
 			fmt.Printf("\n🛠️  tool> %s", ch.Delta.Content)
 		}
@@ -413,7 +468,11 @@ func (c *agentToolChat) handleToolResponses(ev *event.Event) bool {
 	if ch.Message.Content != "" {
 		// Final tool message - show detailed response
 		if c.showTool {
-			fmt.Printf("\n✅ Tool response (ID: %s): %s\n", ch.Message.ToolID, strings.TrimSpace(ch.Message.Content))
+			fmt.Printf(
+				"\n✅ Tool response (ID: %s): %s\n",
+				ch.Message.ToolID,
+				strings.TrimSpace(ch.Message.Content),
+			)
 		} else {
 			fmt.Printf("\n✅ Tool execution completed.\n")
 		}
@@ -439,5 +498,26 @@ func parseInnerTextMode(mode string) (agenttool.InnerTextMode, error) {
 		return agenttool.InnerTextModeExclude, nil
 	default:
 		return "", fmt.Errorf("unsupported mode %q", mode)
+	}
+}
+
+func parseResponseMode(mode string) (agenttool.ResponseMode, error) {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "", responseModeDefault:
+		return agenttool.ResponseModeDefault, nil
+	case responseModeFinal:
+		return agenttool.ResponseModeFinalOnly, nil
+	default:
+		return agenttool.ResponseModeDefault,
+			fmt.Errorf("unsupported response mode %q", mode)
+	}
+}
+
+func responseModeName(mode agenttool.ResponseMode) string {
+	switch mode {
+	case agenttool.ResponseModeFinalOnly:
+		return responseModeFinal
+	default:
+		return responseModeDefault
 	}
 }

--- a/tool/agent/agent_tool.go
+++ b/tool/agent/agent_tool.go
@@ -40,6 +40,7 @@ type Tool struct {
 	innerTextMode          InnerTextMode
 	structuredStreamErrors bool
 	historyScope           HistoryScope
+	responseMode           ResponseMode
 	name                   string
 	description            string
 	inputSchema            *tool.Schema
@@ -56,6 +57,7 @@ type agentToolOptions struct {
 	innerTextMode          InnerTextMode
 	structuredStreamErrors bool
 	historyScope           HistoryScope
+	responseMode           ResponseMode
 	description            *string
 }
 
@@ -74,6 +76,30 @@ const (
 	// still aggregating that text into the final tool response.
 	InnerTextModeExclude = tool.InnerTextModeExclude
 )
+
+// ResponseMode controls which child assistant text AgentTool returns as the tool
+// result. It does not change session event mirroring or inner streaming
+// behavior.
+type ResponseMode int
+
+const (
+	// ResponseModeDefault preserves the legacy assistant-content
+	// concatenation behavior.
+	ResponseModeDefault ResponseMode = iota
+
+	// ResponseModeFinalOnly returns only the last complete assistant message
+	// emitted by the child agent. If none is emitted, the tool result is
+	// an empty string.
+	ResponseModeFinalOnly
+)
+
+// WithResponseMode sets how AgentTool builds the tool result from child agent
+// events.
+func WithResponseMode(mode ResponseMode) Option {
+	return func(opts *agentToolOptions) {
+		opts.responseMode = mode
+	}
+}
 
 // WithSkipSummarization sets whether to skip summarization of the agent output.
 func WithSkipSummarization(skip bool) Option {
@@ -199,6 +225,7 @@ func NewTool(agent agent.Agent, opts ...Option) *Tool {
 		innerTextMode:          tool.NormalizeInnerTextMode(options.innerTextMode),
 		structuredStreamErrors: options.structuredStreamErrors,
 		historyScope:           options.historyScope,
+		responseMode:           normalizeResponseMode(options.responseMode),
 		name:                   info.Name,
 		description:            description,
 		inputSchema:            inputSchema,
@@ -704,6 +731,9 @@ func (at *Tool) buildChildFilterKey(parentInv *agent.Invocation) string {
 // collectResponse collects and concatenates assistant messages from the event
 // channel, returning the complete response text.
 func (at *Tool) collectResponse(inv *agent.Invocation, evCh <-chan *event.Event) (string, error) {
+	if at.responseMode == ResponseModeFinalOnly {
+		return collectFinalResponse(evCh)
+	}
 	if !shouldRewriteCallableCompletion(inv) {
 		return collectLegacyResponse(evCh)
 	}
@@ -746,6 +776,27 @@ func (at *Tool) collectResponse(inv *agent.Invocation, evCh <-chan *event.Event)
 	return response.String(), nil
 }
 
+// collectFinalResponse returns the last complete child assistant message. If no
+// complete assistant message is emitted, it returns an empty string and nil
+// error.
+func collectFinalResponse(evCh <-chan *event.Event) (string, error) {
+	var finalResponse string
+	for ev := range evCh {
+		if ev == nil {
+			continue
+		}
+		if ev.Error != nil {
+			return "", fmt.Errorf("agent error: %s", ev.Error.Message)
+		}
+		content, ok := assistantMessageContent(ev)
+		if !ok || ev.IsPartial {
+			continue
+		}
+		finalResponse = content
+	}
+	return finalResponse, nil
+}
+
 // collectLegacyResponse preserves the pre-#1365 concatenation semantics for the
 // default callable path. It applies a narrow fix for issue #1640 by skipping a
 // trailing graph-completion snapshot event that re-emits the same non-partial
@@ -785,6 +836,18 @@ func shouldRewriteCallableCompletion(inv *agent.Invocation) bool {
 	return inv != nil && agent.IsGraphCompletionEventDisabled(inv)
 }
 
+func normalizeResponseMode(mode ResponseMode) ResponseMode {
+	switch mode {
+	case ResponseModeDefault:
+		return ResponseModeDefault
+	case ResponseModeFinalOnly:
+		return mode
+	default:
+		log.Debugf("AgentTool: unknown response mode %d, using default", mode)
+		return ResponseModeDefault
+	}
+}
+
 // StreamableCall executes the agent tool with streaming support and returns a stream reader.
 // It runs the wrapped agent and forwards its streaming text output as chunks.
 // The returned chunks' Content are plain strings representing incremental text.
@@ -803,6 +866,7 @@ type streamCompletionState struct {
 	sawGraphCompletionSnapshot bool
 	lastAssistantResponseID    string
 	lastAssistantContent       string
+	finalOnlyResult            string
 	overrideResult             string
 }
 
@@ -882,6 +946,7 @@ func (at *Tool) forwardSubInvocationStream(
 			at.completeSuppressedBarrierStreamEvent(ctx, subInv, ev, &state)
 			continue
 		}
+		at.updateFinalOnlyStreamResult(ev, &state)
 		if agent.IsGraphCompletionEventDisabled(subInv) &&
 			isGraphCompletionSnapshotEvent(ev) {
 			if emitFinalResultChunk {
@@ -928,10 +993,28 @@ func (at *Tool) forwardSubInvocationStream(
 		at.flushPendingVisibleCompletionForSession(ctx, subInv, &state)
 	}
 	if emitFinalResultChunk {
+		if at.responseMode == ResponseModeFinalOnly {
+			at.emitFinalOnlyResultChunk(&state, writer)
+			return
+		}
 		at.emitPendingCompletionChunk(&state, writer)
 		return
 	}
 	at.emitPendingVisibleCompletionEvent(&state, writer)
+}
+
+func (at *Tool) updateFinalOnlyStreamResult(
+	ev *event.Event,
+	state *streamCompletionState,
+) {
+	if state == nil {
+		return
+	}
+	content, ok := assistantMessageContent(ev)
+	if !ok || ev.IsPartial {
+		return
+	}
+	state.finalOnlyResult = content
 }
 
 func (at *Tool) capturePendingVisibleCompletion(
@@ -1126,6 +1209,28 @@ func (at *Tool) emitPendingCompletionChunk(
 	_ = writer.Send(tool.StreamChunk{
 		Content: content,
 	}, nil)
+}
+
+func (at *Tool) emitFinalOnlyResultChunk(
+	state *streamCompletionState,
+	writer *tool.StreamWriter,
+) {
+	result := ""
+	var stateDelta map[string][]byte
+	if state != nil {
+		result = state.finalOnlyResult
+		if state.pendingCompletionChunk != nil {
+			stateDelta = state.pendingCompletionChunk.StateDelta
+		}
+	}
+	var content any = tool.FinalResultChunk{Result: result}
+	if len(stateDelta) > 0 {
+		content = tool.FinalResultStateChunk{
+			Result:     result,
+			StateDelta: cloneStateDelta(stateDelta),
+		}
+	}
+	_ = writer.Send(tool.StreamChunk{Content: content}, nil)
 }
 
 func (at *Tool) streamFromFallbackRunner(

--- a/tool/agent/agent_tool_test.go
+++ b/tool/agent/agent_tool_test.go
@@ -668,6 +668,43 @@ func TestTool_Call_DisableGraphCompletionEvent_PrefersAfterCallbackCustomRespons
 	require.Equal(t, "after callback", resultText)
 }
 
+func TestTool_Call_DisableGraphCompletionEvent_FinalOnlyPrefersAfterCallback(
+	t *testing.T,
+) {
+	const afterCallbackText = "after callback"
+
+	ga := newGraphAgentWithAfterCallback(
+		t,
+		graph.State{graph.StateKeyLastResponse: "child-final"},
+		&model.Response{
+			Object: "after.custom",
+			Done:   true,
+			Choices: []model.Choice{{
+				Message: model.NewAssistantMessage(afterCallbackText),
+			}},
+		},
+	)
+	at := NewTool(
+		ga,
+		WithHistoryScope(HistoryScopeParentBranch),
+		WithResponseMode(ResponseModeFinalOnly),
+	)
+	parent := agent.NewInvocation(
+		agent.WithInvocationSession(
+			session.NewSession("app", "user", "session"),
+		),
+		agent.WithInvocationRunOptions(agent.NewRunOptions(
+			agent.WithDisableGraphCompletionEvent(true),
+		)),
+	)
+	ctx := agent.NewInvocationContext(context.Background(), parent)
+	result, err := at.Call(ctx, []byte(`{"request":"ignored"}`))
+	require.NoError(t, err)
+	resultText, ok := result.(string)
+	require.True(t, ok)
+	require.Equal(t, afterCallbackText, resultText)
+}
+
 func TestTool_Call_DisableGraphCompletionEvent_PreservesFinalTextInSharedSession(t *testing.T) {
 	sg := graph.NewStateGraph(graph.MessagesStateSchema())
 	sg.AddNode("done", func(ctx context.Context, state graph.State) (any, error) {
@@ -810,6 +847,135 @@ func TestTool_Call_VisibleCompletionSnapshot_PreservesLegacyConcatenation(t *tes
 	require.Equal(t, "draftchild-finalchild-final", resultText)
 }
 
+func TestTool_Call_FinalOnlyResponseMode_ReturnsLastMessage(t *testing.T) {
+	at := NewTool(
+		&assistantThenVisibleCompletionAgent{name: "visible-agent"},
+		WithResponseMode(ResponseModeFinalOnly),
+	)
+	parent := agent.NewInvocation(
+		agent.WithInvocationSession(
+			session.NewSession("app", "user", "session"),
+		),
+	)
+	ctx := agent.NewInvocationContext(context.Background(), parent)
+
+	result, err := at.Call(ctx, []byte(`{"request":"ignored"}`))
+	require.NoError(t, err)
+	resultText, ok := result.(string)
+	require.True(t, ok)
+	require.Equal(t, "child-final", resultText)
+}
+
+func TestTool_Call_FinalOnlyResponseMode_PropagatesAgentError(
+	t *testing.T,
+) {
+	at := NewTool(
+		&visibleCompletionThenErrorAgent{
+			name: "visible-completion-then-error-agent",
+		},
+		WithResponseMode(ResponseModeFinalOnly),
+	)
+	parent := agent.NewInvocation(
+		agent.WithInvocationSession(
+			session.NewSession("app", "user", "session"),
+		),
+	)
+	ctx := agent.NewInvocationContext(context.Background(), parent)
+
+	_, err := at.Call(ctx, []byte(`{"request":"ignored"}`))
+	require.ErrorContains(t, err, "agent error:")
+}
+
+func TestCollectFinalResponse_SkipsNilEvents(t *testing.T) {
+	const finalContent = "final"
+
+	t.Run("skips nil events", func(t *testing.T) {
+		ch := make(chan *event.Event, 2)
+		ch <- nil
+		ch <- event.NewResponseEvent(
+			"invocation",
+			"author",
+			&model.Response{
+				Done: true,
+				Choices: []model.Choice{{
+					Message: model.NewAssistantMessage(finalContent),
+				}},
+			},
+		)
+		close(ch)
+
+		result, err := collectFinalResponse(ch)
+		require.NoError(t, err)
+		require.Equal(t, finalContent, result)
+	})
+
+	t.Run("skips guarded events and returns last complete", func(t *testing.T) {
+		const (
+			firstContent   = "first"
+			partialContent = "partial"
+			toolContent    = "tool"
+			lastContent    = "last"
+		)
+
+		ch := make(chan *event.Event, 5)
+		ch <- &event.Event{
+			Response: &model.Response{
+				IsPartial: true,
+				Choices: []model.Choice{{
+					Message: model.NewAssistantMessage(partialContent),
+				}},
+			},
+		}
+		ch <- event.NewResponseEvent(
+			"invocation",
+			"author",
+			&model.Response{
+				Choices: []model.Choice{{
+					Message: model.Message{
+						Role:    model.RoleTool,
+						Content: toolContent,
+					},
+				}},
+			},
+		)
+		ch <- event.NewResponseEvent(
+			"invocation",
+			"author",
+			&model.Response{
+				Done: true,
+				Choices: []model.Choice{{
+					Message: model.NewAssistantMessage(""),
+				}},
+			},
+		)
+		ch <- event.NewResponseEvent(
+			"invocation",
+			"author",
+			&model.Response{
+				Done: true,
+				Choices: []model.Choice{{
+					Message: model.NewAssistantMessage(firstContent),
+				}},
+			},
+		)
+		ch <- event.NewResponseEvent(
+			"invocation",
+			"author",
+			&model.Response{
+				Done: true,
+				Choices: []model.Choice{{
+					Message: model.NewAssistantMessage(lastContent),
+				}},
+			},
+		)
+		close(ch)
+
+		result, err := collectFinalResponse(ch)
+		require.NoError(t, err)
+		require.Equal(t, lastContent, result)
+	})
+}
+
 func TestTool_DefaultSkipSummarization(t *testing.T) {
 	mockAgent := &mockAgent{
 		name:        "test-agent",
@@ -834,6 +1000,25 @@ func TestTool_WithSkipSummarization(t *testing.T) {
 	if !agentTool.skipSummarization {
 		t.Error("Expected skip summarization to be true")
 	}
+}
+
+func TestTool_WithResponseMode(t *testing.T) {
+	mockAgent := &mockAgent{
+		name:        "test-agent",
+		description: "A test agent for testing",
+	}
+
+	defaultTool := NewTool(mockAgent)
+	require.Equal(t, ResponseModeDefault, defaultTool.responseMode)
+
+	finalOnlyTool := NewTool(
+		mockAgent,
+		WithResponseMode(ResponseModeFinalOnly),
+	)
+	require.Equal(t, ResponseModeFinalOnly, finalOnlyTool.responseMode)
+
+	invalidTool := NewTool(mockAgent, WithResponseMode(ResponseMode(99)))
+	require.Equal(t, ResponseModeDefault, invalidTool.responseMode)
 }
 
 // streamingMockAgent streams a few delta events then a final full message.
@@ -2506,6 +2691,73 @@ func TestTool_StreamableCall_DisableGraphCompletionEvent_WithFinalResultChunks_K
 		require.Equal(t, []byte(`"child-final"`), finalChunk.StateDelta[graph.StateKeyLastResponse])
 	}
 	require.Equal(t, "child-final", finalResult)
+}
+
+func TestTool_StreamableCall_FinalOnlyResponseMode_ReturnsLastMessage(
+	t *testing.T,
+) {
+	at := NewTool(
+		&assistantThenVisibleCompletionAgent{name: "visible-agent"},
+		WithStreamInner(true),
+		WithResponseMode(ResponseModeFinalOnly),
+	)
+	parent := agent.NewInvocation(
+		agent.WithInvocationSession(
+			session.NewSession("app", "user", "session"),
+		),
+	)
+	ctx := agent.NewInvocationContext(context.Background(), parent)
+	reader, err := at.StreamableCall(
+		tool.WithFinalResultChunks(ctx),
+		[]byte(`{"request":"ignored"}`),
+	)
+	require.NoError(t, err)
+	defer reader.Close()
+
+	var finalResult any
+	for {
+		chunk, recvErr := reader.Recv()
+		if recvErr == io.EOF {
+			break
+		}
+		require.NoError(t, recvErr)
+		if _, ok := chunk.Content.(*event.Event); ok {
+			continue
+		}
+		finalResult = requireFinalChunkView(t, chunk.Content).Result
+	}
+	require.Equal(t, "child-final", finalResult)
+}
+
+func TestTool_EmitFinalOnlyResultChunk_PreservesStateDelta(t *testing.T) {
+	const finalResult = "final-only"
+
+	at := NewTool(&mockAgent{name: "test-agent", description: "test"})
+	stream := tool.NewStream(1)
+	state := &streamCompletionState{
+		finalOnlyResult: finalResult,
+		pendingCompletionChunk: &pendingFinalResultChunk{
+			StateDelta: map[string][]byte{
+				graphStateKey: []byte(graphStateValue),
+			},
+		},
+	}
+
+	at.emitFinalOnlyResultChunk(state, stream.Writer)
+	stream.Writer.Close()
+
+	chunk, err := stream.Reader.Recv()
+	require.NoError(t, err)
+	finalChunk := requireFinalChunkView(t, chunk.Content)
+	require.Equal(t, finalResult, finalChunk.Result)
+	require.Equal(
+		t,
+		[]byte(graphStateValue),
+		finalChunk.StateDelta[graphStateKey],
+	)
+
+	_, err = stream.Reader.Recv()
+	require.ErrorIs(t, err, io.EOF)
 }
 
 func TestTool_StreamableCall_DisableGraphCompletionEvent_DefaultsToVisibleCompletionEvents(t *testing.T) {


### PR DESCRIPTION
## Summary
- add an opt-in AgentTool response mode for returning only the child agent final assistant message
- apply the response mode to both callable and streamed final tool results while preserving legacy concatenation by default
- document response-mode semantics in English and Chinese AgentTool docs
- add an `examples/agenttool` flag and README guidance for `default` vs `final-only`
- cover callable and streamable final-only behavior in AgentTool tests

## Tests
- go test -count=1 ./tool/agent ./internal/flow/processor
- go test -count=1 -cover ./tool/agent ./internal/flow/processor
- (cd examples && go test -count=1 ./agenttool)
- python -m mkdocs build -f docs/mkdocs.yml
