### PR TITLE
{server/agui, docs, examples}: add SSE heartbeat keepalive

### DIFF
--- a/docs/mkdocs/en/agui.md
+++ b/docs/mkdocs/en/agui.md
@@ -277,6 +277,20 @@ type PostRunFinalizingTranslator interface {
 
 ## Advanced Usage
 
+### SSE heartbeat keepalive
+
+In some deployment environments, a gateway, load balancer, or browser may close an SSE connection when no data is written for a long time. If your Agent run can spend long periods without emitting events, enable transport-level heartbeats with `agui.WithHeartbeatInterval(d)`:
+
+```go
+server, err := agui.New(
+    runner,
+    agui.WithPath("/agui"),
+    agui.WithHeartbeatInterval(15*time.Second),
+)
+```
+
+The server writes SSE comment frames (`:\n\n`) at the configured interval to keep the connection active. Heartbeats are disabled by default, and non-positive intervals keep them disabled.
+
 ### Custom transport
 
 The AG-UI specification does not enforce a transport. The framework uses SSE by default, but you can implement the `service.Service` interface to switch to WebSocket or any other transport:

--- a/docs/mkdocs/zh/agui.md
+++ b/docs/mkdocs/zh/agui.md
@@ -277,6 +277,20 @@ type PostRunFinalizingTranslator interface {
 
 ## 进阶用法
 
+### SSE 心跳保活
+
+在一些部署环境中，网关、负载均衡或浏览器可能会关闭长时间没有数据写入的 SSE 连接。如果你的 Agent 运行过程中可能出现较长时间没有事件输出的情况，可以通过 `agui.WithHeartbeatInterval(d)` 开启传输层心跳：
+
+```go
+server, err := agui.New(
+    runner,
+    agui.WithPath("/agui"),
+    agui.WithHeartbeatInterval(15*time.Second),
+)
+```
+
+服务端会按配置间隔写入 SSE comment 帧 `:\n\n`，用于保持连接活跃。该能力默认关闭，传入小于等于 0 的间隔表示关闭。
+
 ### 自定义通信协议
 
 AG-UI 协议未强制规定通信协议，框架使用 SSE 作为 AG-UI 的默认通信协议，如果希望改用 WebSocket 等其他协议，可以实现 `service.Service` 接口：

--- a/examples/agui/server/README.md
+++ b/examples/agui/server/README.md
@@ -10,6 +10,7 @@ This directory shows AG-UI servers that can talk to the AG-UI client examples.
 - [`finishresult/`](finishresult/) – Demonstrates populating `RUN_FINISHED.result` by wrapping the default translator.
 - [`externaltool/`](externaltool/) – Demonstrates a two-call external tool workflow (`role=user` then `role=tool`) backed by `GraphAgent` interrupts.
 - [`streamtool/`](streamtool/) – Demonstrates a minimal `StreamableTool` that uses `agui.WithStreamingToolResultActivityEnabled(true)` to stream tool progress as `ACTIVITY_SNAPSHOT` / `ACTIVITY_DELTA` while preserving a final `TOOL_CALL_RESULT`.
+- [`heartbeat/`](heartbeat/) – Demonstrates SSE heartbeat keepalive frames with `agui.WithHeartbeatInterval`.
 - [`graph/`](graph/) – Demonstrates graph node start activity events via `ACTIVITY_DELTA`.
 - [`react/`](react/) – The server showcases how React planner tags are streamed as custom AG-UI events.
 - [`langfuse/`](langfuse/) – This example shows how AG-UI Server customizes reporting through TranslateCallback and connects to the langfuse observability platform.

--- a/examples/agui/server/heartbeat/README.md
+++ b/examples/agui/server/heartbeat/README.md
@@ -1,0 +1,78 @@
+# Heartbeat AG-UI Server
+
+This example demonstrates SSE heartbeat keepalive frames for AG-UI.
+
+It wires `agui.WithHeartbeatInterval` into a regular AG-UI server backed by a real `LLMAgent`, an OpenAI-compatible model, and a real `FunctionTool`. The agent is instructed to call `wait_before_answer` before answering. While that tool is waiting, the server keeps the SSE connection active by writing heartbeat comment frames.
+
+## What This Example Shows
+
+- `agui.WithHeartbeatInterval(d)` on the default SSE transport.
+- SSE comment frames (`:\n\n`) emitted while the run is active and no AG-UI event is ready.
+- A normal AG-UI event stream before and after the tool quiet period.
+- A real model-driven tool call through `function.NewFunctionTool`.
+
+## Run
+
+From the `examples/agui` module:
+
+```bash
+export OPENAI_API_KEY="your-api-key"
+export OPENAI_BASE_URL="https://your-openai-compatible-base-url"
+
+go run ./server/heartbeat \
+  -model deepseek-v3.2 \
+  -address 127.0.0.1:8080 \
+  -path /agui \
+  -heartbeat 1s \
+  -wait 5s
+```
+
+The server exposes:
+
+- chat endpoint: `http://127.0.0.1:8080/agui`
+
+## Try It
+
+Inspect the raw SSE stream with `curl`:
+
+```bash
+curl -N http://127.0.0.1:8080/agui \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "threadId": "heartbeat-demo",
+    "runId": "heartbeat-run-1",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Wait before answering, then say hello."
+      }
+    ]
+  }'
+```
+
+In the raw output, heartbeat frames appear between normal `data:` frames while the run is active. A stream that includes the waiting tool looks like:
+
+```text
+data: {"type":"RUN_STARTED",...}
+...
+data: {"type":"TOOL_CALL_START",...}
+data: {"type":"TOOL_CALL_ARGS",...}
+data: {"type":"TOOL_CALL_END",...}
+:
+
+:
+
+data: {"type":"TOOL_CALL_RESULT",...}
+...
+data: {"type":"TEXT_MESSAGE_START",...}
+data: {"type":"TEXT_MESSAGE_CONTENT",...}
+data: {"type":"TEXT_MESSAGE_END",...}
+data: {"type":"RUN_FINISHED",...}
+```
+
+The `:` lines are heartbeat frames from the SSE transport.
+
+## Options
+
+- `-heartbeat`: heartbeat interval. `0` disables heartbeat frames.
+- `-wait`: quiet period inside the `wait_before_answer` tool.

--- a/examples/agui/server/heartbeat/agent.go
+++ b/examples/agui/server/heartbeat/agent.go
@@ -1,0 +1,37 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/model/openai"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+const agentName = "agui-heartbeat-agent"
+
+func newAgent(
+	modelName string,
+	generationConfig model.GenerationConfig,
+	quietPeriod time.Duration,
+) *llmagent.LLMAgent {
+	waitTool := newWaitTool(quietPeriod)
+	return llmagent.New(
+		agentName,
+		llmagent.WithModel(openai.New(modelName)),
+		llmagent.WithGenerationConfig(generationConfig),
+		llmagent.WithInstruction("You are a concise assistant. "+
+			"Start every user request by calling wait_before_answer exactly once. "+
+			"After the tool result confirms that the quiet period has completed, answer the user."),
+		llmagent.WithTools([]tool.Tool{waitTool}),
+	)
+}

--- a/examples/agui/server/heartbeat/agui.go
+++ b/examples/agui/server/heartbeat/agui.go
@@ -1,0 +1,57 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"net/http"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/log"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+	"trpc.group/trpc-go/trpc-agent-go/server/agui"
+)
+
+const appName = "agui-heartbeat-demo"
+
+type serverConfig struct {
+	ModelName         string
+	GenerationConfig  model.GenerationConfig
+	WaitDuration      time.Duration
+	Address           string
+	Path              string
+	HeartbeatInterval time.Duration
+}
+
+func runServer(cfg serverConfig) {
+	agent := newAgent(cfg.ModelName, cfg.GenerationConfig, cfg.WaitDuration)
+	run := runner.NewRunner(appName, agent)
+	defer run.Close()
+	server, err := agui.New(
+		run,
+		agui.WithPath(cfg.Path),
+		agui.WithHeartbeatInterval(cfg.HeartbeatInterval),
+	)
+	if err != nil {
+		log.Fatalf("create AG-UI server failed: %v", err)
+	}
+	log.Infof("AG-UI: serving agent %q on http://%s%s", agent.Info().Name, cfg.Address, cfg.Path)
+	log.Infof("AG-UI: SSE heartbeat interval: %s", durationLabel(cfg.HeartbeatInterval))
+	log.Infof("AG-UI: tool quiet period: %s", cfg.WaitDuration)
+	if err := http.ListenAndServe(cfg.Address, server.Handler()); err != nil {
+		log.Fatalf("server stopped with error: %v", err)
+	}
+}
+
+func durationLabel(d time.Duration) string {
+	if d <= 0 {
+		return "disabled"
+	}
+	return d.String()
+}

--- a/examples/agui/server/heartbeat/main.go
+++ b/examples/agui/server/heartbeat/main.go
@@ -1,0 +1,51 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package main demonstrates AG-UI SSE heartbeat keepalive frames.
+package main
+
+import (
+	"flag"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+var (
+	modelName         = flag.String("model", "deepseek-v3.2", "OpenAI-compatible model name.")
+	isStream          = flag.Bool("stream", true, "Whether to stream the model response.")
+	address           = flag.String("address", "127.0.0.1:8080", "Listen address.")
+	path              = flag.String("path", "/agui", "HTTP path.")
+	heartbeatInterval = flag.Duration("heartbeat", time.Second, "SSE heartbeat interval. Set 0 to disable.")
+	waitDuration      = flag.Duration("wait", 5*time.Second, "Duration of the tool quiet period.")
+)
+
+func main() {
+	flag.Parse()
+	generationConfig := model.GenerationConfig{
+		MaxTokens:   intPtr(768),
+		Temperature: floatPtr(0.1),
+		Stream:      *isStream,
+	}
+	runServer(serverConfig{
+		ModelName:         *modelName,
+		GenerationConfig:  generationConfig,
+		WaitDuration:      *waitDuration,
+		Address:           *address,
+		Path:              *path,
+		HeartbeatInterval: *heartbeatInterval,
+	})
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func floatPtr(f float64) *float64 {
+	return &f
+}

--- a/examples/agui/server/heartbeat/tool.go
+++ b/examples/agui/server/heartbeat/tool.go
@@ -1,0 +1,58 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"context"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+	"trpc.group/trpc-go/trpc-agent-go/tool/function"
+)
+
+const waitToolName = "wait_before_answer"
+
+type waitBeforeAnswerArgs struct {
+	Reason string `json:"reason,omitempty" description:"Short reason for waiting before answering."`
+}
+
+type waitBeforeAnswerResult struct {
+	WaitedMS int64  `json:"waited_ms"`
+	Message  string `json:"message"`
+}
+
+func newWaitTool(quietPeriod time.Duration) tool.Tool {
+	return function.NewFunctionTool(
+		func(ctx context.Context, _ waitBeforeAnswerArgs) (waitBeforeAnswerResult, error) {
+			if err := sleepWithContext(ctx, quietPeriod); err != nil {
+				return waitBeforeAnswerResult{}, err
+			}
+			return waitBeforeAnswerResult{
+				WaitedMS: quietPeriod.Milliseconds(),
+				Message:  "Quiet period completed.",
+			}, nil
+		},
+		function.WithName(waitToolName),
+		function.WithDescription("Wait for the server-configured quiet period before the assistant answers."),
+	)
+}
+
+func sleepWithContext(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return ctx.Err()
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/server/agui/agui.go
+++ b/server/agui/agui.go
@@ -64,7 +64,10 @@ func newService(runner runner.Runner, opts *options) (service.Service, error) {
 	if err != nil {
 		return nil, fmt.Errorf("agui: url join chat path: %w", err)
 	}
-	serviceOpts := []service.Option{service.WithPath(chatPath)}
+	serviceOpts := []service.Option{
+		service.WithPath(chatPath),
+		service.WithHeartbeatInterval(opts.heartbeatInterval),
+	}
 	if opts.cancelEnabled {
 		cancelPath, err := joinURLPath(opts.basePath, opts.cancelPath)
 		if err != nil {

--- a/server/agui/agui_test.go
+++ b/server/agui/agui_test.go
@@ -16,6 +16,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"trpc.group/trpc-go/trpc-agent-go/agent"
@@ -214,6 +215,24 @@ func TestNewCancelEnabledWiresServiceOptions(t *testing.T) {
 	assert.Equal(t, "/api/chat", captured.Path)
 	assert.True(t, captured.CancelEnabled)
 	assert.Equal(t, "/api/cancel", captured.CancelPath)
+}
+
+func TestNewHeartbeatIntervalWiresServiceOptions(t *testing.T) {
+	agent := &mockAgent{info: agent.Info{Name: "demo"}}
+	r := runner.NewRunner(agent.Info().Name, agent)
+	var captured *service.Options
+	customFactory := func(_ aguirunner.Runner, opt ...service.Option) service.Service {
+		captured = service.NewOptions(opt...)
+		return dummyAGUIService{}
+	}
+	srv, err := New(r,
+		WithHeartbeatInterval(2*time.Second),
+		WithServiceFactory(customFactory),
+	)
+	assert.NoError(t, err)
+	assert.NotNil(t, srv)
+	assert.NotNil(t, captured)
+	assert.Equal(t, 2*time.Second, captured.HeartbeatInterval)
 }
 
 func TestPathDefault(t *testing.T) {

--- a/server/agui/options.go
+++ b/server/agui/options.go
@@ -38,6 +38,7 @@ type options struct {
 	messagesSnapshotEnabled bool
 	cancelPath              string
 	cancelEnabled           bool
+	heartbeatInterval       time.Duration
 	appName                 string
 	sessionService          session.Service
 }
@@ -132,6 +133,13 @@ func WithFlushInterval(d time.Duration) Option {
 func WithPostRunFinalizationTimeout(d time.Duration) Option {
 	return func(o *options) {
 		o.aguiRunnerOptions = append(o.aguiRunnerOptions, aguirunner.WithPostRunFinalizationTimeout(d))
+	}
+}
+
+// WithHeartbeatInterval sets how often the SSE transport sends heartbeat frames.
+func WithHeartbeatInterval(d time.Duration) Option {
+	return func(o *options) {
+		o.heartbeatInterval = d
 	}
 }
 

--- a/server/agui/options_test.go
+++ b/server/agui/options_test.go
@@ -94,6 +94,11 @@ func TestWithPostRunFinalizationTimeout(t *testing.T) {
 	assert.Equal(t, 2*time.Second, ro.PostRunFinalizationTimeout)
 }
 
+func TestWithHeartbeatInterval(t *testing.T) {
+	opts := newOptions(WithHeartbeatInterval(2 * time.Second))
+	assert.Equal(t, 2*time.Second, opts.heartbeatInterval)
+}
+
 func TestWithGraphNodeLifecycleActivityEnabled(t *testing.T) {
 	opts := newOptions(WithGraphNodeLifecycleActivityEnabled(true))
 	ro := aguirunner.NewOptions(opts.aguiRunnerOptions...)

--- a/server/agui/service/options.go
+++ b/server/agui/service/options.go
@@ -9,6 +9,8 @@
 
 package service
 
+import "time"
+
 const (
 	// defaultPath is the default path for the AG-UI service.
 	defaultPath = "/"
@@ -20,12 +22,13 @@ const (
 
 // Options holds the options for an AG-UI transport implementation.
 type Options struct {
-	AppName                 string // AppName is the name of the application.
-	Path                    string // Path is the request URL path served by the handler.
-	MessagesSnapshotEnabled bool   // MessagesSnapshotEnabled enables the messages snapshot handler.
-	MessagesSnapshotPath    string // MessagesSnapshotPath is the HTTP path for the messages snapshot handler.
-	CancelEnabled           bool   // CancelEnabled enables the cancel handler.
-	CancelPath              string // CancelPath is the HTTP path for the cancel handler.
+	AppName                 string        // AppName is the name of the application.
+	Path                    string        // Path is the request URL path served by the handler.
+	MessagesSnapshotEnabled bool          // MessagesSnapshotEnabled enables the messages snapshot handler.
+	MessagesSnapshotPath    string        // MessagesSnapshotPath is the HTTP path for the messages snapshot handler.
+	CancelEnabled           bool          // CancelEnabled enables the cancel handler.
+	CancelPath              string        // CancelPath is the HTTP path for the cancel handler.
+	HeartbeatInterval       time.Duration // HeartbeatInterval controls how often heartbeat frames are sent.
 }
 
 // NewOptions creates a new options instance.
@@ -81,5 +84,12 @@ func WithCancelEnabled(e bool) Option {
 func WithCancelPath(p string) Option {
 	return func(s *Options) {
 		s.CancelPath = p
+	}
+}
+
+// WithHeartbeatInterval sets how often the transport sends heartbeat frames.
+func WithHeartbeatInterval(d time.Duration) Option {
+	return func(s *Options) {
+		s.HeartbeatInterval = d
 	}
 }

--- a/server/agui/service/options_test.go
+++ b/server/agui/service/options_test.go
@@ -11,6 +11,7 @@ package service
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -51,4 +52,11 @@ func TestWithCancelEnabled(t *testing.T) {
 	opts := NewOptions(WithCancelEnabled(true))
 	assert.True(t, opts.CancelEnabled)
 	assert.Equal(t, "/cancel", opts.CancelPath)
+}
+
+func TestWithHeartbeatInterval(t *testing.T) {
+	opts := NewOptions()
+	assert.Zero(t, opts.HeartbeatInterval)
+	opts = NewOptions(WithHeartbeatInterval(2 * time.Second))
+	assert.Equal(t, 2*time.Second, opts.HeartbeatInterval)
 }

--- a/server/agui/service/sse/sse.go
+++ b/server/agui/service/sse/sse.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"time"
 
 	aguievents "github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/events"
 	aguisse "github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/encoding/sse"
@@ -35,6 +36,7 @@ type sse struct {
 	handler                 http.Handler
 	messagesSnapshotEnabled bool
 	cancelEnabled           bool
+	heartbeatInterval       time.Duration
 }
 
 // New creates a new SSE service.
@@ -48,6 +50,7 @@ func New(runner aguirunner.Runner, opt ...service.Option) service.Service {
 		writer:                  aguisse.NewSSEWriter(),
 		messagesSnapshotEnabled: opts.MessagesSnapshotEnabled,
 		cancelEnabled:           opts.CancelEnabled,
+		heartbeatInterval:       opts.HeartbeatInterval,
 	}
 	h := http.NewServeMux()
 	h.HandleFunc(s.path, s.handle)
@@ -243,6 +246,12 @@ func (s *sse) handleEvents(
 	events <-chan aguievents.Event,
 	drain bool,
 ) error {
+	var heartbeat <-chan time.Time
+	if s.heartbeatInterval > 0 {
+		ticker := time.NewTicker(s.heartbeatInterval)
+		defer ticker.Stop()
+		heartbeat = ticker.C
+	}
 	for {
 		select {
 		case <-ctx.Done():
@@ -250,6 +259,13 @@ func (s *sse) handleEvents(
 				go drainEvents(events)
 			}
 			return nil
+		case <-heartbeat:
+			if err := writeHeartbeat(w); err != nil {
+				if drain {
+					go drainEvents(events)
+				}
+				return err
+			}
 		case evt, ok := <-events:
 			if !ok {
 				return nil
@@ -262,6 +278,16 @@ func (s *sse) handleEvents(
 			}
 		}
 	}
+}
+
+func writeHeartbeat(w http.ResponseWriter) error {
+	if _, err := w.Write([]byte(":\n\n")); err != nil {
+		return err
+	}
+	if flusher, ok := w.(interface{ Flush() }); ok {
+		flusher.Flush()
+	}
+	return nil
 }
 
 // handleCancel cancels a running run identified by the request payload.

--- a/server/agui/service/sse/sse_test.go
+++ b/server/agui/service/sse/sse_test.go
@@ -132,6 +132,42 @@ func TestHandleSuccess(t *testing.T) {
 	assert.Equal(t, 1, runner.calls)
 }
 
+func TestHandleEventsHeartbeatDisabledByDefault(t *testing.T) {
+	eventsCh := make(chan aguievents.Event)
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		close(eventsCh)
+	}()
+	srv := &sse{writer: aguisse.NewSSEWriter()}
+	rr := httptest.NewRecorder()
+	err := srv.handleEvents(context.Background(), rr, eventsCh, false)
+	assert.NoError(t, err)
+	assert.Empty(t, rr.Body.String())
+}
+
+func TestHandleEventsHeartbeatWritesCommentFrame(t *testing.T) {
+	eventsCh := make(chan aguievents.Event)
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		close(eventsCh)
+	}()
+	srv := &sse{writer: aguisse.NewSSEWriter(), heartbeatInterval: 5 * time.Millisecond}
+	rr := httptest.NewRecorder()
+	err := srv.handleEvents(context.Background(), rr, eventsCh, false)
+	assert.NoError(t, err)
+	body := rr.Body.String()
+	assert.Contains(t, body, ":\n\n")
+	assert.NotContains(t, body, `"type"`)
+}
+
+func TestHandleEventsHeartbeatWriteError(t *testing.T) {
+	eventsCh := make(chan aguievents.Event)
+	srv := &sse{writer: aguisse.NewSSEWriter(), heartbeatInterval: 5 * time.Millisecond}
+	errWriter := newErrorResponseWriter(errors.New("write failure"))
+	err := srv.handleEvents(context.Background(), errWriter, eventsCh, false)
+	assert.ErrorContains(t, err, "write failure")
+}
+
 func TestHandleWriteEventError(t *testing.T) {
 	eventsCh := make(chan aguievents.Event, 1)
 	eventsCh <- aguievents.NewRunStartedEvent("thread", "run")


### PR DESCRIPTION
Add an optional AG-UI SSE heartbeat interval that writes transport-level comment frames while a run is active and no AG-UI event is ready. The change wires the option through the public AG-UI server and SSE service layers, documents the advanced usage in English and Chinese, and adds a runnable heartbeat server example backed by a real LLMAgent and function tool.