### PR TITLE
model/openai: preserve zero tool call delta index

### DIFF
--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -2084,11 +2084,6 @@ func (m *Model) createPartialResponse(chunk openai.ChatCompletionChunk) *model.R
 				[]model.ToolCall, 0,
 				len(chunk.Choices[0].Delta.ToolCalls))
 			for _, toolCall := range chunk.Choices[0].Delta.ToolCalls {
-				var indexPtr *int
-				if toolCall.Index != 0 {
-					index := int(toolCall.Index)
-					indexPtr = &index
-				}
 				toolCalls = append(toolCalls, model.ToolCall{
 					Type: string(toolCall.Type),
 					Function: model.FunctionDefinitionParam{
@@ -2096,7 +2091,7 @@ func (m *Model) createPartialResponse(chunk openai.ChatCompletionChunk) *model.R
 						Arguments: []byte(toolCall.Function.Arguments),
 					},
 					ID:    toolCall.ID,
-					Index: indexPtr,
+					Index: toolCallDeltaIndexPointer(toolCall),
 				})
 			}
 		}
@@ -2116,6 +2111,14 @@ func (m *Model) createPartialResponse(chunk openai.ChatCompletionChunk) *model.R
 	}
 
 	return response
+}
+
+func toolCallDeltaIndexPointer(toolCall openai.ChatCompletionChunkChoiceDeltaToolCall) *int {
+	if toolCall.Index == 0 && !toolCall.JSON.Index.Valid() {
+		return nil
+	}
+	index := int(toolCall.Index)
+	return &index
 }
 
 // emitStreamingFinalResponse emits the final response with accumulated data.

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -5062,6 +5062,80 @@ func TestEmptyChunkHandling(t *testing.T) {
 		assert.Equal(t, "{\"content\":\"partial\"}",
 			string(tc.Function.Arguments))
 	})
+
+	t.Run("createPartialResponse preserves tool call index zero", func(t *testing.T) {
+		mWithToolDelta := &Model{
+			showToolCallDelta: true,
+		}
+		chunk := parseChunkWithExtraFields(t, `{
+			"id": "chunk-tool-zero",
+			"model": "test-model",
+			"choices": [{
+				"delta": {
+					"tool_calls": [{
+						"index": 0,
+						"id": "call-zero",
+						"type": "function",
+						"function": {
+							"name": "generate_document",
+							"arguments": "{\"content\":\"partial\"}"
+						}
+					}]
+				}
+			}]
+		}`)
+
+		response := mWithToolDelta.createPartialResponse(chunk)
+		require.NotNil(t, response)
+		require.Len(t, response.Choices, 1)
+		deltaMsg := response.Choices[0].Delta
+		require.Len(t, deltaMsg.ToolCalls, 1)
+		tc := deltaMsg.ToolCalls[0]
+		require.NotNil(t, tc.Index)
+		assert.Equal(t, 0, *tc.Index)
+		assert.Equal(t, "call-zero", tc.ID)
+		assert.Equal(t, "generate_document", tc.Function.Name)
+		assert.Equal(t, "{\"content\":\"partial\"}",
+			string(tc.Function.Arguments))
+	})
+
+	t.Run("createPartialResponse keeps omitted tool call index nil", func(t *testing.T) {
+		mWithToolDelta := &Model{
+			showToolCallDelta: true,
+		}
+		chunk := openai.ChatCompletionChunk{
+			ID:    "chunk-tool-no-index",
+			Model: "test-model",
+			Choices: []openai.ChatCompletionChunkChoice{
+				{
+					Delta: openai.ChatCompletionChunkChoiceDelta{
+						ToolCalls: []openai.ChatCompletionChunkChoiceDeltaToolCall{
+							{
+								ID:   "call-no-index",
+								Type: "function",
+								Function: openai.ChatCompletionChunkChoiceDeltaToolCallFunction{
+									Name:      "generate_document",
+									Arguments: "{\"content\":\"partial\"}",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		response := mWithToolDelta.createPartialResponse(chunk)
+		require.NotNil(t, response)
+		require.Len(t, response.Choices, 1)
+		deltaMsg := response.Choices[0].Delta
+		require.Len(t, deltaMsg.ToolCalls, 1)
+		tc := deltaMsg.ToolCalls[0]
+		assert.Nil(t, tc.Index)
+		assert.Equal(t, "call-no-index", tc.ID)
+		assert.Equal(t, "generate_document", tc.Function.Name)
+		assert.Equal(t, "{\"content\":\"partial\"}",
+			string(tc.Function.Arguments))
+	})
 }
 
 // TestCreateFinalResponseFinishReason verifies that finish reasons from the


### PR DESCRIPTION
Preserve explicit zero-valued tool call delta indices when mapping OpenAI streaming chunks into model.ToolCall. The OpenAI adapter already promises that WithShowToolCallDelta forwards tool call identity fields for callers that stitch argument fragments together; this change uses the SDK JSON field metadata to distinguish an omitted index from a valid index: 0.