### PR TITLE
{server/agui, docs}: add run lifecycle events to message snapshots

### DIFF
--- a/docs/mkdocs/en/agui.md
+++ b/docs/mkdocs/en/agui.md
@@ -837,6 +837,65 @@ server, err := agui.New(
 
 If more complex aggregation strategies are required, you can implement `aggregator.Aggregator` and inject it through a custom factory. Note that although an aggregator is created separately for each session, avoiding cross-session state management and concurrency handling, the aggregation methods themselves may still be called concurrently, so concurrency must still be handled properly.
 
+### Run Lifecycle Events in Message Snapshots
+
+Top-level events returned by the message snapshot route describe the lifecycle of the current snapshot request. On success, the sequence is:
+
+`RUN_STARTED → MESSAGES_SNAPSHOT → RUN_FINISHED`
+
+By default, `MESSAGES_SNAPSHOT.messages` contains conversation messages and displayable activity messages reconstructed from the historical AG-UI track. It does not include persisted historical `RUN_STARTED`, `RUN_FINISHED`, or `RUN_ERROR` events.
+
+To preserve historical run lifecycle state in message snapshots, enable `agui.WithMessagesSnapshotRunLifecycleEventsEnabled(true)`:
+
+```go
+server, err := agui.New(
+    runner,
+    agui.WithAppName(appName),
+    agui.WithSessionService(sessionService),
+    agui.WithMessagesSnapshotEnabled(true),
+    agui.WithMessagesSnapshotRunLifecycleEventsEnabled(true),
+)
+```
+
+When enabled, historical `RUN_STARTED`, `RUN_FINISHED`, and `RUN_ERROR` events are included in `MESSAGES_SNAPSHOT.messages` as messages whose `role` is `activity`. Event semantics are determined by their layer:
+
+- messages inside `MESSAGES_SNAPSHOT.messages` whose `role` is `activity` and whose `activityType` is `RUN_*` represent persisted run lifecycle events from the historical conversation;
+- top-level `RUN_STARTED`, `RUN_FINISHED`, or `RUN_ERROR` emitted by the message snapshot route represents the current snapshot request lifecycle or load failure.
+
+With this option enabled, historical `RUN_*` messages inside `MESSAGES_SNAPSHOT` have the following shape:
+
+```json
+{
+  "type": "MESSAGES_SNAPSHOT",
+  "messages": [
+    {
+      "id": "event-id-1",
+      "role": "activity",
+      "activityType": "RUN_STARTED",
+      "content": {
+        "threadId": "thread-1",
+        "runId": "run-1"
+      }
+    },
+    {
+      "id": "event-id-2",
+      "role": "assistant",
+      "content": "hello"
+    },
+    {
+      "id": "event-id-3",
+      "role": "activity",
+      "activityType": "RUN_ERROR",
+      "content": {
+        "runId": "run-1",
+        "message": "model call failed",
+        "code": "MODEL_ERROR"
+      }
+    }
+  ]
+}
+```
+
 ### Message Snapshot Continuation
 
 By default, `/history` (the message snapshot route) returns a one-shot snapshot and closes the connection immediately. When a user refreshes or reconnects in the middle of a real-time conversation (run), or opens the page in a new tab, the snapshot alone may not cover the events that continue to be produced after the snapshot boundary. If you want to keep streaming subsequent AG-UI events after the snapshot, enable message snapshot continuation.

--- a/docs/mkdocs/zh/agui.md
+++ b/docs/mkdocs/zh/agui.md
@@ -833,6 +833,65 @@ server, err := agui.New(
 
 如果需要更复杂的聚合策略，可以实现 `aggregator.Aggregator` 并通过自定义工厂注入。需要注意的是，虽然每个会话都会单独创建一个聚合器，省去了跨会话的状态维护和并发处理，但聚合方法本身仍有可能被并发调用，因此仍需妥善处理并发。
 
+### 消息快照中的 run 生命周期事件
+
+消息快照路由返回的顶层事件用于描述本次快照请求的生命周期，成功时事件序列为：
+
+`RUN_STARTED → MESSAGES_SNAPSHOT → RUN_FINISHED`
+
+默认情况下，`MESSAGES_SNAPSHOT.messages` 仅包含由历史 AG-UI track 还原出的对话消息和可展示 activity，不包含已持久化的历史 `RUN_STARTED`、`RUN_FINISHED`、`RUN_ERROR`。
+
+若需要在消息快照中保留历史 run 的生命周期状态，可以启用 `agui.WithMessagesSnapshotRunLifecycleEventsEnabled(true)`：
+
+```go
+server, err := agui.New(
+    runner,
+    agui.WithAppName(appName),
+    agui.WithSessionService(sessionService),
+    agui.WithMessagesSnapshotEnabled(true),
+    agui.WithMessagesSnapshotRunLifecycleEventsEnabled(true),
+)
+```
+
+启用后，历史 `RUN_STARTED`、`RUN_FINISHED`、`RUN_ERROR` 会写入 `MESSAGES_SNAPSHOT.messages`，消息的 `role` 为 `activity`。事件语义按所在层级区分：
+
+- `MESSAGES_SNAPSHOT.messages` 中 `role` 为 `activity`、`activityType` 为 `RUN_*` 的消息表示历史会话中已持久化的 run 生命周期事件；
+- 消息快照路由顶层返回的 `RUN_STARTED`、`RUN_FINISHED`、`RUN_ERROR` 表示本次快照请求的生命周期或加载错误。
+
+开启后，`MESSAGES_SNAPSHOT` 中的历史 `RUN_*` 消息形态如下：
+
+```json
+{
+  "type": "MESSAGES_SNAPSHOT",
+  "messages": [
+    {
+      "id": "event-id-1",
+      "role": "activity",
+      "activityType": "RUN_STARTED",
+      "content": {
+        "threadId": "thread-1",
+        "runId": "run-1"
+      }
+    },
+    {
+      "id": "event-id-2",
+      "role": "assistant",
+      "content": "hello"
+    },
+    {
+      "id": "event-id-3",
+      "role": "activity",
+      "activityType": "RUN_ERROR",
+      "content": {
+        "runId": "run-1",
+        "message": "model call failed",
+        "code": "MODEL_ERROR"
+      }
+    }
+  ]
+}
+```
+
 ### 消息快照续传
 
 默认情况下，消息快照路由只返回一次性快照并立即结束连接。当用户在一次实时对话的中途刷新或重连时，仅靠快照可能无法覆盖快照边界之后继续产生的事件。如需在快照之后继续流式接收后续 AG-UI 事件，需要使用消息快照续传功能。

--- a/server/agui/internal/reduce/options.go
+++ b/server/agui/internal/reduce/options.go
@@ -1,0 +1,25 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package reduce
+
+// Option configures how AG-UI track events are reduced into snapshot messages.
+type Option func(*options)
+
+type options struct {
+	includeRunLifecycleEvents bool
+}
+
+// WithRunLifecycleEvents controls whether RUN_* lifecycle events are included in the
+// message snapshot as activity messages.
+func WithRunLifecycleEvents(include bool) Option {
+	return func(o *options) {
+		o.includeRunLifecycleEvents = include
+	}
+}

--- a/server/agui/internal/reduce/reduce.go
+++ b/server/agui/internal/reduce/reduce.go
@@ -24,13 +24,14 @@ import (
 
 // reducer reduces the AG-UI track events into message snapshots.
 type reducer struct {
-	appName              string
-	userID               string
-	texts                map[string]*textState
-	reasonings           map[string]*reasoningState
-	lastReasoningChunkID string
-	toolCalls            map[string]*toolCallState
-	messages             []*aguievents.Message
+	appName                   string
+	userID                    string
+	includeRunLifecycleEvents bool
+	texts                     map[string]*textState
+	reasonings                map[string]*reasoningState
+	lastReasoningChunkID      string
+	toolCalls                 map[string]*toolCallState
+	messages                  []*aguievents.Message
 }
 
 // textPhase is the phase of the text message.
@@ -86,8 +87,12 @@ type toolCallState struct {
 
 // Reduce reduces the AG-UI track events into message snapshots.
 // In order to fetch the history messages as much as possible, still return the messages even if there is an error.
-func Reduce(appName, userID string, events []session.TrackEvent) ([]aguievents.Message, error) {
-	r := new(appName, userID)
+func Reduce(appName, userID string, events []session.TrackEvent, opt ...Option) ([]aguievents.Message, error) {
+	opts := options{}
+	for _, o := range opt {
+		o(&opts)
+	}
+	r := new(appName, userID, opts)
 	var err error
 	for _, trackEvent := range events {
 		if err = r.reduce(trackEvent); err != nil {
@@ -109,14 +114,15 @@ func Reduce(appName, userID string, events []session.TrackEvent) ([]aguievents.M
 }
 
 // new creates a new reducer.
-func new(appName, userID string) *reducer {
+func new(appName, userID string, opts options) *reducer {
 	return &reducer{
-		appName:    appName,
-		userID:     userID,
-		texts:      make(map[string]*textState),
-		reasonings: make(map[string]*reasoningState),
-		toolCalls:  make(map[string]*toolCallState),
-		messages:   make([]*aguievents.Message, 0),
+		appName:                   appName,
+		userID:                    userID,
+		includeRunLifecycleEvents: opts.includeRunLifecycleEvents,
+		texts:                     make(map[string]*textState),
+		reasonings:                make(map[string]*reasoningState),
+		toolCalls:                 make(map[string]*toolCallState),
+		messages:                  make([]*aguievents.Message, 0),
 	}
 }
 
@@ -134,6 +140,12 @@ func (r *reducer) reduce(trackEvent session.TrackEvent) error {
 
 func (r *reducer) reduceEvent(evt aguievents.Event) error {
 	switch e := evt.(type) {
+	case *aguievents.RunStartedEvent:
+		return r.handleRunStarted(e)
+	case *aguievents.RunFinishedEvent:
+		return r.handleRunFinished(e)
+	case *aguievents.RunErrorEvent:
+		return r.handleRunError(e)
 	case *aguievents.TextMessageStartEvent:
 		return r.handleTextStart(e)
 	case *aguievents.TextMessageContentEvent:
@@ -256,6 +268,59 @@ func (r *reducer) sanitizeSnapshotMessage(message *aguievents.Message) *aguieven
 	empty := ""
 	cloned.Content = &empty
 	return &cloned
+}
+
+func (r *reducer) handleRunStarted(e *aguievents.RunStartedEvent) error {
+	if !r.includeRunLifecycleEvents {
+		return nil
+	}
+	content := map[string]any{
+		"threadId": e.ThreadID(),
+		"runId":    e.RunID(),
+	}
+	r.appendRunActivity(e, content)
+	return nil
+}
+
+func (r *reducer) handleRunFinished(e *aguievents.RunFinishedEvent) error {
+	if !r.includeRunLifecycleEvents {
+		return nil
+	}
+	content := map[string]any{
+		"threadId": e.ThreadID(),
+		"runId":    e.RunID(),
+	}
+	if e.Result != nil {
+		content["result"] = e.Result
+	}
+	r.appendRunActivity(e, content)
+	return nil
+}
+
+func (r *reducer) handleRunError(e *aguievents.RunErrorEvent) error {
+	if !r.includeRunLifecycleEvents {
+		return nil
+	}
+	content := map[string]any{
+		"message": e.Message,
+	}
+	if e.RunID() != "" {
+		content["runId"] = e.RunID()
+	}
+	if e.Code != nil {
+		content["code"] = *e.Code
+	}
+	r.appendRunActivity(e, content)
+	return nil
+}
+
+func (r *reducer) appendRunActivity(e aguievents.Event, content map[string]any) {
+	r.messages = append(r.messages, &aguievents.Message{
+		ID:           e.GetBaseEvent().ID(),
+		Role:         types.RoleActivity,
+		ActivityType: string(e.Type()),
+		Content:      content,
+	})
 }
 
 // handleTextStart handles the text message start event.

--- a/server/agui/internal/reduce/reduce_test.go
+++ b/server/agui/internal/reduce/reduce_test.go
@@ -186,7 +186,7 @@ func TestHandleUserMessageCustomEventErrors(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := new(testAppName, testUserID)
+			r := new(testAppName, testUserID, options{})
 			err := r.reduceEvent(tt.event)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.want)
@@ -540,7 +540,7 @@ func TestHandleTextChunkSuccess(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := new(testAppName, testUserID)
+			r := new(testAppName, testUserID, options{})
 			require.NoError(t, r.handleTextChunk(tt.chunk))
 			require.Len(t, r.messages, 1)
 			msg := r.messages[0]
@@ -568,14 +568,14 @@ func stringPtr(s string) *string {
 func TestHandleTextChunkErrors(t *testing.T) {
 	t.Run("missing id", func(t *testing.T) {
 		chunk := aguievents.NewTextMessageChunkEvent(stringPtr(""), stringPtr("assistant"), stringPtr(""))
-		r := new(testAppName, testUserID)
+		r := new(testAppName, testUserID, options{})
 		err := r.handleTextChunk(chunk)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "text message chunk missing id")
 	})
 	t.Run("duplicate id", func(t *testing.T) {
 		chunk := aguievents.NewTextMessageChunkEvent(stringPtr("msg-1"), stringPtr("assistant"), stringPtr(""))
-		r := new(testAppName, testUserID)
+		r := new(testAppName, testUserID, options{})
 		require.NoError(t, r.handleTextChunk(chunk))
 		err := r.handleTextChunk(chunk)
 		require.Error(t, err)
@@ -583,7 +583,7 @@ func TestHandleTextChunkErrors(t *testing.T) {
 	})
 	t.Run("unsupported role", func(t *testing.T) {
 		chunk := aguievents.NewTextMessageChunkEvent(stringPtr("msg-3"), stringPtr("tool"), stringPtr(""))
-		r := new(testAppName, testUserID)
+		r := new(testAppName, testUserID, options{})
 		err := r.handleTextChunk(chunk)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unsupported role: tool")
@@ -592,7 +592,7 @@ func TestHandleTextChunkErrors(t *testing.T) {
 		chunk := aguievents.NewTextMessageChunkEvent(stringPtr(""), stringPtr("assistant"), stringPtr(""))
 		empty := ""
 		chunk.MessageID = &empty
-		r := new(testAppName, testUserID)
+		r := new(testAppName, testUserID, options{})
 		err := r.handleTextChunk(chunk)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "text message chunk missing id")
@@ -600,7 +600,7 @@ func TestHandleTextChunkErrors(t *testing.T) {
 }
 
 func TestReduceEventDispatchesChunk(t *testing.T) {
-	r := new(testAppName, testUserID)
+	r := new(testAppName, testUserID, options{})
 	chunk := aguievents.NewTextMessageChunkEvent(stringPtr("msg-1"), stringPtr("assistant"), stringPtr("hi"))
 	require.NoError(t, r.reduceEvent(chunk))
 	require.Len(t, r.messages, 1)
@@ -1009,11 +1009,52 @@ func TestReduceInvalidPayload(t *testing.T) {
 	assertReduceError(t, []session.TrackEvent{event}, "unmarshal track event payload")
 }
 
-func TestReduceIgnoresUnknownEvents(t *testing.T) {
+func TestReduceOmitsRunEventsByDefault(t *testing.T) {
 	events := trackEventsFrom(aguievents.NewRunStartedEvent("thread", "run"))
 	msgs, err := Reduce(testAppName, testUserID, events)
 	require.NoError(t, err)
 	assert.Empty(t, msgs)
+}
+
+func TestReduceIncludesRunEventsWhenEnabled(t *testing.T) {
+	events := trackEventsFrom(
+		aguievents.NewRunStartedEvent("thread-1", "run-1"),
+		aguievents.NewRunFinishedEventWithOptions(
+			"thread-1",
+			"run-1",
+			aguievents.WithResult("ok"),
+		),
+		aguievents.NewRunErrorEvent(
+			"boom",
+			aguievents.WithRunID("run-2"),
+			aguievents.WithErrorCode("E_RUN"),
+		),
+	)
+
+	msgs, err := Reduce(testAppName, testUserID, events, WithRunLifecycleEvents(true))
+	require.NoError(t, err)
+	require.Len(t, msgs, 3)
+
+	started := msgs[0]
+	assert.Equal(t, types.RoleActivity, started.Role)
+	assert.Equal(t, string(aguievents.EventTypeRunStarted), started.ActivityType)
+	startedContent, ok := started.ContentActivity()
+	require.True(t, ok)
+	assert.Equal(t, map[string]any{"threadId": "thread-1", "runId": "run-1"}, startedContent)
+
+	finished := msgs[1]
+	assert.Equal(t, types.RoleActivity, finished.Role)
+	assert.Equal(t, string(aguievents.EventTypeRunFinished), finished.ActivityType)
+	finishedContent, ok := finished.ContentActivity()
+	require.True(t, ok)
+	assert.Equal(t, map[string]any{"threadId": "thread-1", "runId": "run-1", "result": "ok"}, finishedContent)
+
+	runErr := msgs[2]
+	assert.Equal(t, types.RoleActivity, runErr.Role)
+	assert.Equal(t, string(aguievents.EventTypeRunError), runErr.ActivityType)
+	errContent, ok := runErr.ContentActivity()
+	require.True(t, ok)
+	assert.Equal(t, map[string]any{"message": "boom", "runId": "run-2", "code": "E_RUN"}, errContent)
 }
 
 func TestHandleActivityAllCases(t *testing.T) {
@@ -1139,7 +1180,7 @@ func TestHandleActivityAllCases(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := new(testAppName, testUserID)
+			r := new(testAppName, testUserID, options{})
 			require.NoError(t, r.handleActivity(tt.event))
 			require.Len(t, r.messages, tt.wantCount)
 			if tt.wantCount == 0 {
@@ -1158,7 +1199,7 @@ func TestHandleActivityAllCases(t *testing.T) {
 }
 
 func TestHandleToolEndMissingParent(t *testing.T) {
-	r := new(testAppName, testUserID)
+	r := new(testAppName, testUserID, options{})
 	r.toolCalls["tool-call-1"] = &toolCallState{
 		messageID: "ghost-parent",
 		phase:     toolAwaitingArgs,

--- a/server/agui/internal/source/metadata.go
+++ b/server/agui/internal/source/metadata.go
@@ -239,6 +239,12 @@ func recordSnapshotMetadata(
 		messages[e.ID()] = metadata
 	case *aguievents.MessagesSnapshotEvent:
 		messages[e.ID()] = metadata
+	case *aguievents.RunStartedEvent:
+		messages[e.ID()] = metadata
+	case *aguievents.RunFinishedEvent:
+		messages[e.ID()] = metadata
+	case *aguievents.RunErrorEvent:
+		messages[e.ID()] = metadata
 	case *aguievents.CustomEvent:
 		messages[e.ID()] = metadata
 	case *aguievents.RawEvent:

--- a/server/agui/internal/source/metadata_test.go
+++ b/server/agui/internal/source/metadata_test.go
@@ -196,11 +196,13 @@ func TestRecordSnapshotMetadataIndexesSupportedEvents(t *testing.T) {
 			Role: aguitypes.RoleAssistant,
 		}},
 	)
+	runStarted := aguievents.NewRunStartedEvent("thread", "run")
+	runFinished := aguievents.NewRunFinishedEvent("thread", "run")
+	runError := aguievents.NewRunErrorEvent("boom")
 	customEvent := aguievents.NewCustomEvent("custom")
 	rawEvent := aguievents.NewRawEvent(map[string]any{
 		"foo": "bar",
 	})
-	runStarted := aguievents.NewRunStartedEvent("thread", "run")
 
 	tests := []struct {
 		name          string
@@ -383,6 +385,27 @@ func TestRecordSnapshotMetadataIndexesSupportedEvents(t *testing.T) {
 			},
 		},
 		{
+			name:  "run started",
+			event: runStarted,
+			wantMessages: map[string]Metadata{
+				runStarted.ID(): metadata,
+			},
+		},
+		{
+			name:  "run finished",
+			event: runFinished,
+			wantMessages: map[string]Metadata{
+				runFinished.ID(): metadata,
+			},
+		},
+		{
+			name:  "run error",
+			event: runError,
+			wantMessages: map[string]Metadata{
+				runError.ID(): metadata,
+			},
+		},
+		{
 			name:  "custom event",
 			event: customEvent,
 			wantMessages: map[string]Metadata{
@@ -395,10 +418,6 @@ func TestRecordSnapshotMetadataIndexesSupportedEvents(t *testing.T) {
 			wantMessages: map[string]Metadata{
 				rawEvent.ID(): metadata,
 			},
-		},
-		{
-			name:  "unsupported event",
-			event: runStarted,
 		},
 	}
 

--- a/server/agui/options.go
+++ b/server/agui/options.go
@@ -218,6 +218,14 @@ func WithMessagesSnapshotFollowMaxDuration(d time.Duration) Option {
 	}
 }
 
+// WithMessagesSnapshotRunLifecycleEventsEnabled controls whether persisted RUN_* events
+// are included as activity messages in MESSAGES_SNAPSHOT.
+func WithMessagesSnapshotRunLifecycleEventsEnabled(enabled bool) Option {
+	return func(o *options) {
+		o.aguiRunnerOptions = append(o.aguiRunnerOptions, aguirunner.WithMessagesSnapshotRunLifecycleEventsEnabled(enabled))
+	}
+}
+
 // WithAppName sets the app name.
 func WithAppName(n string) Option {
 	return func(o *options) {

--- a/server/agui/options_test.go
+++ b/server/agui/options_test.go
@@ -148,6 +148,12 @@ func TestWithMessagesSnapshotFollowMaxDuration(t *testing.T) {
 	assert.Equal(t, 2*time.Second, ro.MessagesSnapshotFollowMaxDuration)
 }
 
+func TestWithMessagesSnapshotRunLifecycleEventsEnabled(t *testing.T) {
+	opts := newOptions(WithMessagesSnapshotRunLifecycleEventsEnabled(true))
+	ro := aguirunner.NewOptions(opts.aguiRunnerOptions...)
+	assert.True(t, ro.MessagesSnapshotRunLifecycleEventsEnabled)
+}
+
 func TestWithCancelEnabled(t *testing.T) {
 	opts := newOptions(WithCancelEnabled(true))
 	assert.True(t, opts.cancelEnabled)

--- a/server/agui/runner/messagessnapshot.go
+++ b/server/agui/runner/messagessnapshot.go
@@ -129,7 +129,12 @@ func (r *runner) getMessagesSnapshotEvent(ctx context.Context,
 	if err != nil {
 		return nil, nil, fmt.Errorf("get track events: %w", err)
 	}
-	messages, err := reduce.Reduce(sessionKey.AppName, sessionKey.UserID, trackEvents.Events)
+	messages, err := reduce.Reduce(
+		sessionKey.AppName,
+		sessionKey.UserID,
+		trackEvents.Events,
+		reduce.WithRunLifecycleEvents(r.messagesSnapshotRunLifecycleEventsEnabled),
+	)
 	if err != nil {
 		err = fmt.Errorf("reduce track events: %w", err)
 	}

--- a/server/agui/runner/messagessnapshot_test.go
+++ b/server/agui/runner/messagessnapshot_test.go
@@ -138,6 +138,107 @@ func TestMessagesSnapshotHappyPath(t *testing.T) {
 	require.IsType(t, (*aguievents.RunFinishedEvent)(nil), collected[2])
 }
 
+func TestMessagesSnapshotIncludesRunEventsWhenEnabled(t *testing.T) {
+	svc := &testSessionService{
+		trackEvents: []session.TrackEvent{
+			newTrackEvent(t, aguievents.NewRunStartedEvent("thread", "real-run-1")),
+			newTrackEvent(t, aguievents.NewTextMessageStartEvent("assistant-1", aguievents.WithRole("assistant"))),
+			newTrackEvent(t, aguievents.NewTextMessageContentEvent("assistant-1", "hello")),
+			newTrackEvent(t, aguievents.NewTextMessageEndEvent("assistant-1")),
+			newTrackEvent(t, aguievents.NewRunFinishedEventWithOptions(
+				"thread",
+				"real-run-1",
+				aguievents.WithResult("ok"),
+			)),
+			newTrackEvent(t, aguievents.NewRunErrorEvent(
+				"boom",
+				aguievents.WithRunID("real-run-2"),
+				aguievents.WithErrorCode("E_RUN"),
+			)),
+		},
+	}
+	tracker, err := track.New(svc)
+	require.NoError(t, err)
+	r := &runner{
+		runner:            noopBaseRunner{},
+		userIDResolver:    NewOptions().UserIDResolver,
+		runAgentInputHook: NewOptions().RunAgentInputHook,
+		appName:           "demo",
+		tracker:           tracker,
+		messagesSnapshotRunLifecycleEventsEnabled: true,
+	}
+
+	stream, err := r.MessagesSnapshot(
+		context.Background(),
+		&adapter.RunAgentInput{ThreadID: "thread", RunID: "history-run"},
+	)
+	require.NoError(t, err)
+
+	collected := collectAGUIEvents(t, stream)
+	require.Len(t, collected, 3)
+	require.IsType(t, (*aguievents.RunStartedEvent)(nil), collected[0])
+	snapshot, ok := collected[1].(*aguievents.MessagesSnapshotEvent)
+	require.True(t, ok)
+	require.Len(t, snapshot.Messages, 4)
+	require.IsType(t, (*aguievents.RunFinishedEvent)(nil), collected[2])
+
+	assert.Equal(t, types.RoleActivity, snapshot.Messages[0].Role)
+	assert.Equal(t, string(aguievents.EventTypeRunStarted), snapshot.Messages[0].ActivityType)
+	startedContent, ok := snapshot.Messages[0].ContentActivity()
+	require.True(t, ok)
+	assert.Equal(t, map[string]any{"threadId": "thread", "runId": "real-run-1"}, startedContent)
+
+	assert.Equal(t, types.RoleAssistant, snapshot.Messages[1].Role)
+	content, ok := snapshot.Messages[1].ContentString()
+	require.True(t, ok)
+	assert.Equal(t, "hello", content)
+
+	assert.Equal(t, types.RoleActivity, snapshot.Messages[2].Role)
+	assert.Equal(t, string(aguievents.EventTypeRunFinished), snapshot.Messages[2].ActivityType)
+	finishedContent, ok := snapshot.Messages[2].ContentActivity()
+	require.True(t, ok)
+	assert.Equal(t, map[string]any{"threadId": "thread", "runId": "real-run-1", "result": "ok"}, finishedContent)
+
+	assert.Equal(t, types.RoleActivity, snapshot.Messages[3].Role)
+	assert.Equal(t, string(aguievents.EventTypeRunError), snapshot.Messages[3].ActivityType)
+	errContent, ok := snapshot.Messages[3].ContentActivity()
+	require.True(t, ok)
+	assert.Equal(t, map[string]any{"message": "boom", "runId": "real-run-2", "code": "E_RUN"}, errContent)
+}
+
+func TestMessagesSnapshotOmitsRunEventsByDefault(t *testing.T) {
+	svc := &testSessionService{
+		trackEvents: []session.TrackEvent{
+			newTrackEvent(t, aguievents.NewRunStartedEvent("thread", "real-run")),
+			newTrackEvent(t, aguievents.NewRunFinishedEvent("thread", "real-run")),
+			newTrackEvent(t, aguievents.NewRunErrorEvent("boom", aguievents.WithRunID("real-run"))),
+		},
+	}
+	tracker, err := track.New(svc)
+	require.NoError(t, err)
+	r := &runner{
+		runner:            noopBaseRunner{},
+		userIDResolver:    NewOptions().UserIDResolver,
+		runAgentInputHook: NewOptions().RunAgentInputHook,
+		appName:           "demo",
+		tracker:           tracker,
+	}
+
+	stream, err := r.MessagesSnapshot(
+		context.Background(),
+		&adapter.RunAgentInput{ThreadID: "thread", RunID: "history-run"},
+	)
+	require.NoError(t, err)
+
+	collected := collectAGUIEvents(t, stream)
+	require.Len(t, collected, 3)
+	require.IsType(t, (*aguievents.RunStartedEvent)(nil), collected[0])
+	snapshot, ok := collected[1].(*aguievents.MessagesSnapshotEvent)
+	require.True(t, ok)
+	assert.Empty(t, snapshot.Messages)
+	require.IsType(t, (*aguievents.RunFinishedEvent)(nil), collected[2])
+}
+
 func TestMessagesSnapshotAttachesSourceMetadataIndex(t *testing.T) {
 	assistantMetadata := source.Metadata{
 		EventID:      "evt-assistant",

--- a/server/agui/runner/options.go
+++ b/server/agui/runner/options.go
@@ -36,31 +36,32 @@ const (
 
 // Options holds the options for the runner.
 type Options struct {
-	TranslatorFactory                      TranslatorFactory     // TranslatorFactory creates a translator for an AG-UI run.
-	UserIDResolver                         UserIDResolver        // UserIDResolver derives the user identifier for an AG-UI run.
-	TranslateCallbacks                     *translator.Callbacks // TranslateCallbacks translates the run events to AG-UI events.
-	RunAgentInputHook                      RunAgentInputHook     // RunAgentInputHook allows modifying the run input before processing.
-	AppName                                string                // AppName is the name of the application.
-	AppNameResolver                        AppNameResolver       // AppNameResolver derives the app name for an AG-UI run.
-	SessionService                         session.Service       // SessionService is the session service.
-	StateResolver                          StateResolver         // StateResolver resolves runtime state for an AG-UI run.
-	RunOptionResolver                      RunOptionResolver     // RunOptionResolver resolves the runner options for an AG-UI run.
-	AggregatorFactory                      aggregator.Factory    // AggregatorFactory builds an aggregator for each run.
-	AggregationOption                      []aggregator.Option   // AggregationOption is the aggregation options for each run.
-	FlushInterval                          time.Duration         // FlushInterval controls how often buffered AG-UI events are flushed for a session.
-	MessagesSnapshotFollowEnabled          bool                  // MessagesSnapshotFollowEnabled enables tailing persisted AG-UI track events after MESSAGES_SNAPSHOT.
-	MessagesSnapshotFollowMaxDuration      time.Duration         // MessagesSnapshotFollowMaxDuration bounds how long tailing can run before emitting RUN_ERROR.
-	StartSpan                              StartSpan             // StartSpan starts a span for an AG-UI run.
-	PostRunFinalizationTimeout             time.Duration         // PostRunFinalizationTimeout bounds how long post-run finalization is allowed to take.
-	Timeout                                time.Duration         // Timeout controls how long a run is allowed to execute.
-	CancelOnContextDoneEnabled             bool                  // CancelOnContextDoneEnabled cancels the run when the parent context is done.
-	GraphNodeLifecycleActivityEnabled      bool                  // GraphNodeLifecycleActivityEnabled enables graph node lifecycle activity events.
-	GraphNodeInterruptActivityEnabled      bool                  // GraphNodeInterruptActivityEnabled enables graph interrupt activity events.
-	GraphNodeInterruptActivityTopLevelOnly bool                  // GraphNodeInterruptActivityTopLevelOnly drops nested graph interrupt activity events.
-	ReasoningContentEnabled                bool                  // ReasoningContentEnabled controls whether reasoning content events are emitted.
-	EventSourceMetadataEnabled             bool                  // EventSourceMetadataEnabled attaches original trpc-agent-go source metadata to translated AG-UI events.
-	ToolResultInputTranslationEnabled      bool                  // ToolResultInputTranslationEnabled controls whether tool-result inputs are translated before emission.
-	StreamingToolResultActivityEnabled     bool                  // StreamingToolResultActivityEnabled rewrites partial tool results as activity events.
+	TranslatorFactory                         TranslatorFactory     // TranslatorFactory creates a translator for an AG-UI run.
+	UserIDResolver                            UserIDResolver        // UserIDResolver derives the user identifier for an AG-UI run.
+	TranslateCallbacks                        *translator.Callbacks // TranslateCallbacks translates the run events to AG-UI events.
+	RunAgentInputHook                         RunAgentInputHook     // RunAgentInputHook allows modifying the run input before processing.
+	AppName                                   string                // AppName is the name of the application.
+	AppNameResolver                           AppNameResolver       // AppNameResolver derives the app name for an AG-UI run.
+	SessionService                            session.Service       // SessionService is the session service.
+	StateResolver                             StateResolver         // StateResolver resolves runtime state for an AG-UI run.
+	RunOptionResolver                         RunOptionResolver     // RunOptionResolver resolves the runner options for an AG-UI run.
+	AggregatorFactory                         aggregator.Factory    // AggregatorFactory builds an aggregator for each run.
+	AggregationOption                         []aggregator.Option   // AggregationOption is the aggregation options for each run.
+	FlushInterval                             time.Duration         // FlushInterval controls how often buffered AG-UI events are flushed for a session.
+	MessagesSnapshotFollowEnabled             bool                  // MessagesSnapshotFollowEnabled enables tailing persisted AG-UI track events after MESSAGES_SNAPSHOT.
+	MessagesSnapshotFollowMaxDuration         time.Duration         // MessagesSnapshotFollowMaxDuration bounds how long tailing can run before emitting RUN_ERROR.
+	MessagesSnapshotRunLifecycleEventsEnabled bool                  // MessagesSnapshotRunLifecycleEventsEnabled includes persisted RUN_* events as activity messages in MESSAGES_SNAPSHOT.
+	StartSpan                                 StartSpan             // StartSpan starts a span for an AG-UI run.
+	PostRunFinalizationTimeout                time.Duration         // PostRunFinalizationTimeout bounds how long post-run finalization is allowed to take.
+	Timeout                                   time.Duration         // Timeout controls how long a run is allowed to execute.
+	CancelOnContextDoneEnabled                bool                  // CancelOnContextDoneEnabled cancels the run when the parent context is done.
+	GraphNodeLifecycleActivityEnabled         bool                  // GraphNodeLifecycleActivityEnabled enables graph node lifecycle activity events.
+	GraphNodeInterruptActivityEnabled         bool                  // GraphNodeInterruptActivityEnabled enables graph interrupt activity events.
+	GraphNodeInterruptActivityTopLevelOnly    bool                  // GraphNodeInterruptActivityTopLevelOnly drops nested graph interrupt activity events.
+	ReasoningContentEnabled                   bool                  // ReasoningContentEnabled controls whether reasoning content events are emitted.
+	EventSourceMetadataEnabled                bool                  // EventSourceMetadataEnabled attaches original trpc-agent-go source metadata to translated AG-UI events.
+	ToolResultInputTranslationEnabled         bool                  // ToolResultInputTranslationEnabled controls whether tool-result inputs are translated before emission.
+	StreamingToolResultActivityEnabled        bool                  // StreamingToolResultActivityEnabled rewrites partial tool results as activity events.
 }
 
 // NewOptions creates a new options instance.
@@ -196,6 +197,14 @@ func WithMessagesSnapshotFollowEnabled(enabled bool) Option {
 func WithMessagesSnapshotFollowMaxDuration(d time.Duration) Option {
 	return func(o *Options) {
 		o.MessagesSnapshotFollowMaxDuration = d
+	}
+}
+
+// WithMessagesSnapshotRunLifecycleEventsEnabled controls whether persisted RUN_* events
+// are included as activity messages in MESSAGES_SNAPSHOT.
+func WithMessagesSnapshotRunLifecycleEventsEnabled(enabled bool) Option {
+	return func(o *Options) {
+		o.MessagesSnapshotRunLifecycleEventsEnabled = enabled
 	}
 }
 

--- a/server/agui/runner/options_test.go
+++ b/server/agui/runner/options_test.go
@@ -80,6 +80,7 @@ func TestNewOptionsDefaults(t *testing.T) {
 	assert.False(t, opts.EventSourceMetadataEnabled)
 	assert.False(t, opts.ToolResultInputTranslationEnabled)
 	assert.False(t, opts.StreamingToolResultActivityEnabled)
+	assert.False(t, opts.MessagesSnapshotRunLifecycleEventsEnabled)
 }
 
 func TestWithUserIDResolver(t *testing.T) {
@@ -152,6 +153,11 @@ func TestWithToolResultInputTranslationEnabled(t *testing.T) {
 func TestWithStreamingToolResultActivityEnabled(t *testing.T) {
 	opts := NewOptions(WithStreamingToolResultActivityEnabled(true))
 	assert.True(t, opts.StreamingToolResultActivityEnabled)
+}
+
+func TestWithMessagesSnapshotRunLifecycleEventsEnabled(t *testing.T) {
+	opts := NewOptions(WithMessagesSnapshotRunLifecycleEventsEnabled(true))
+	assert.True(t, opts.MessagesSnapshotRunLifecycleEventsEnabled)
 }
 
 func TestWithPostRunFinalizationTimeout(t *testing.T) {

--- a/server/agui/runner/runner.go
+++ b/server/agui/runner/runner.go
@@ -94,40 +94,42 @@ func New(r trunner.Runner, opt ...Option) Runner {
 		cancelOnContextDoneEnabled:             opts.CancelOnContextDoneEnabled,
 		messagesSnapshotFollowEnabled:          opts.MessagesSnapshotFollowEnabled,
 		messagesSnapshotFollowMaxDuration:      opts.MessagesSnapshotFollowMaxDuration,
-		toolResultInputTranslationEnabled:      opts.ToolResultInputTranslationEnabled,
-		streamingToolResultActivityEnabled:     opts.StreamingToolResultActivityEnabled,
+		messagesSnapshotRunLifecycleEventsEnabled: opts.MessagesSnapshotRunLifecycleEventsEnabled,
+		toolResultInputTranslationEnabled:         opts.ToolResultInputTranslationEnabled,
+		streamingToolResultActivityEnabled:        opts.StreamingToolResultActivityEnabled,
 	}
 	return run
 }
 
 // runner is the default implementation of the Runner.
 type runner struct {
-	appName                                string
-	appNameResolver                        AppNameResolver
-	runner                                 trunner.Runner
-	translatorFactory                      TranslatorFactory
-	graphNodeLifecycleActivityEnabled      bool
-	graphNodeInterruptActivityEnabled      bool
-	graphNodeInterruptActivityTopLevelOnly bool
-	reasoningContentEnabled                bool
-	eventSourceMetadataEnabled             bool
-	userIDResolver                         UserIDResolver
-	translateCallbacks                     *translator.Callbacks
-	runAgentInputHook                      RunAgentInputHook
-	stateResolver                          StateResolver
-	runOptionResolver                      RunOptionResolver
-	tracker                                track.Tracker
-	runningMu                              sync.Mutex
-	running                                map[session.Key]*sessionContext
-	startSpan                              StartSpan
-	flushInterval                          time.Duration
-	postRunFinalizationTimeout             time.Duration
-	timeout                                time.Duration
-	cancelOnContextDoneEnabled             bool
-	messagesSnapshotFollowEnabled          bool
-	messagesSnapshotFollowMaxDuration      time.Duration
-	toolResultInputTranslationEnabled      bool
-	streamingToolResultActivityEnabled     bool
+	appName                                   string
+	appNameResolver                           AppNameResolver
+	runner                                    trunner.Runner
+	translatorFactory                         TranslatorFactory
+	graphNodeLifecycleActivityEnabled         bool
+	graphNodeInterruptActivityEnabled         bool
+	graphNodeInterruptActivityTopLevelOnly    bool
+	reasoningContentEnabled                   bool
+	eventSourceMetadataEnabled                bool
+	userIDResolver                            UserIDResolver
+	translateCallbacks                        *translator.Callbacks
+	runAgentInputHook                         RunAgentInputHook
+	stateResolver                             StateResolver
+	runOptionResolver                         RunOptionResolver
+	tracker                                   track.Tracker
+	runningMu                                 sync.Mutex
+	running                                   map[session.Key]*sessionContext
+	startSpan                                 StartSpan
+	flushInterval                             time.Duration
+	postRunFinalizationTimeout                time.Duration
+	timeout                                   time.Duration
+	cancelOnContextDoneEnabled                bool
+	messagesSnapshotFollowEnabled             bool
+	messagesSnapshotFollowMaxDuration         time.Duration
+	messagesSnapshotRunLifecycleEventsEnabled bool
+	toolResultInputTranslationEnabled         bool
+	streamingToolResultActivityEnabled        bool
 }
 
 type sessionContext struct {


### PR DESCRIPTION
Adds an opt-in AG-UI message snapshot setting that restores persisted RUN_STARTED, RUN_FINISHED, and RUN_ERROR lifecycle events as activity messages inside MESSAGES_SNAPSHOT.messages, while keeping the snapshot route top-level RUN_* events scoped to the current history request. Updates reducer and runner configuration plumbing plus AG-UI documentation to describe the event layering and message shape.