### PR TITLE
openclaw: tighten autonomy prompts

### DIFF
--- a/openclaw/app/agent_prompts_test.go
+++ b/openclaw/app/agent_prompts_test.go
@@ -24,6 +24,16 @@ func TestResolveAgentPrompts_DefaultInstruction(t *testing.T) {
 	prompts, err := resolveAgentPromptsForDir(runOptions{}, t.TempDir())
 	require.NoError(t, err)
 	require.Equal(t, defaultAgentInstruction, prompts.Instruction)
+	require.Contains(
+		t,
+		prompts.Instruction,
+		"A preamble-only response such as `I will ...`",
+	)
+	require.Contains(
+		t,
+		prompts.Instruction,
+		"produce the requested content in the same turn",
+	)
 	require.Empty(t, prompts.SystemPrompt)
 }
 

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -88,9 +88,40 @@ const (
 
 	defaultDebugRecorderDir = "debug"
 
-	defaultAgentName        = "assistant"
+	defaultAgentName = "assistant"
+
+	preambleOnlyFinalAnswerRule = "A preamble-only response such as " +
+		"`I will ...`, `I'll ...`, `我先...`, or " +
+		"`接下来...` is not a valid final answer. If " +
+		"tool work is needed, the same assistant message " +
+		"must include the tool call; if no tool is needed, " +
+		"return the requested content or completed result " +
+		"instead of an announcement. "
+	substantiveSameTurnRule = "For writing, summarization, " +
+		"recommendation, explanation, or analysis tasks, " +
+		"produce the requested content in the same turn. "
+	artifactCompletionRule = "For requests to create, write, send, " +
+		"publish, upload, schedule, or update an artifact " +
+		"or external resource, the turn is not complete " +
+		"until you have performed the action and returned " +
+		"the resulting link, id, file marker, or exact " +
+		"blocker after recovery."
+	skillPreambleOnlyRule = "A preamble-only skill response is " +
+		"invalid. "
+	skillSameTurnToolRule = "If you say you will read, load, " +
+		"use, write, create, send, or publish through a " +
+		"skill, the same assistant message must include " +
+		"the required tool call. Do not stop after " +
+		"announcing the skill-backed next step. "
+
 	defaultAgentInstruction = "You are a helpful assistant. " +
-		"Keep replies concise."
+		"Keep replies concise, but make each reply " +
+		"substantive enough to complete the user's request. " +
+		"Act without asking for confirmation when the next " +
+		"step is clearly in scope, cheap, and reversible. " +
+		preambleOnlyFinalAnswerRule +
+		substantiveSameTurnRule +
+		artifactCompletionRule
 	openClawSkillsGuidance = "Treat the skill overview below as the " +
 		"skills available in this session. Each entry " +
 		"includes a path to that skill's SKILL.md on disk. " +
@@ -104,6 +135,10 @@ const (
 		"that skill right away in the same turn. That " +
 		"brief preamble is part of acting immediately, " +
 		"not a pause to ask what to do next. That preamble may " +
+		"not be the whole reply. " +
+		skillPreambleOnlyRule +
+		skillSameTurnToolRule +
+		"That preamble may " +
 		"announce the immediate task, but do not use it " +
 		"for substantive guidance, capability " +
 		"disclaimers, or explanations about which " +
@@ -146,8 +181,12 @@ const (
 		"brief user-visible preamble that says which skill " +
 		"or skill docs you are reading next, then call this " +
 		"tool right away in the same turn. Do not pause " +
-		"after that preamble to ask what to do next. Do " +
-		"not use that preamble for " +
+		"after that preamble to ask what to do next, and do " +
+		"not send the preamble as the whole reply. " +
+		skillPreambleOnlyRule +
+		skillSameTurnToolRule +
+		"Do not " +
+		"use that preamble for " +
 		"capability disclaimers, implementation-split " +
 		"explanations, or substantive guidance about the " +
 		"task. Do not answer from a short skill summary, " +
@@ -170,6 +209,9 @@ const (
 		"input, use " +
 		"write_stdin and kill_session when needed. Use message " +
 		"to send to the current chat or an explicit target. " +
+		artifactCompletionRule + " " +
+		"Use the available tool path to complete the request " +
+		"in this turn. " +
 		"Chat uploads are saved to stable host paths. For host " +
 		"commands, prefer OPENCLAW_LAST_UPLOAD_PATH or " +
 		"OPENCLAW_SESSION_UPLOADS_DIR, OPENCLAW_LAST_UPLOAD_HOST_REF, " +

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -580,6 +580,11 @@ func TestBuildOpenClawTools_HidesMemoryFileEnvWithoutFileBackend(t *testing.T) {
 	bundle := buildOpenClawTools(true, t.TempDir(), nil, nil)
 	decl := findToolDeclaration(bundle.tools, "exec_command")
 	require.NotNil(t, decl)
+	require.Contains(
+		t,
+		decl.Description,
+		"same assistant message must call exec_command",
+	)
 	require.NotContains(t, decl.Description, "OPENCLAW_MEMORY_FILE")
 }
 
@@ -595,6 +600,11 @@ func TestBuildOpenClawTools_ExposesMemoryFileEnvForFileBackend(t *testing.T) {
 	decl := findToolDeclaration(bundle.tools, "exec_command")
 	require.NotNil(t, decl)
 	require.Contains(t, decl.Description, "OPENCLAW_MEMORY_FILE")
+	require.Contains(
+		t,
+		decl.Description,
+		"same assistant message must call exec_command",
+	)
 }
 
 func TestBuildOpenClawTools_IncludesConversationHistoryTool(
@@ -1546,6 +1556,17 @@ func TestNewAgent_SkillsPrompt_DefaultsApplied(t *testing.T) {
 	require.Contains(
 		t,
 		sys,
+		"A preamble-only skill response is invalid",
+	)
+	require.Contains(
+		t,
+		sys,
+		"Do not stop after announcing the skill-backed "+
+			"next step",
+	)
+	require.Contains(
+		t,
+		sys,
 		"Never say that you could read or load a matching skill later",
 	)
 	require.Contains(
@@ -1920,6 +1941,13 @@ func TestNewAgent_KnowledgeOnlyProfileHidesSkillRun(t *testing.T) {
 		"Before the first matching load, start with one "+
 			"brief user-visible preamble",
 	)
+	require.Contains(
+		t,
+		findToolDeclaration(agt.Tools(), skillprofile.ToolLoad).
+			Description,
+		"same assistant message must include the required "+
+			"tool call",
+	)
 }
 
 func TestNewAgent_KnowledgeOnlyProfileUsesToolingGuidance(
@@ -1996,6 +2024,11 @@ func TestNewAgent_FullProfileUsesToolingGuidance(t *testing.T) {
 				t,
 				content,
 				strings.TrimSpace(openClawToolingGuidance),
+			)
+			require.Contains(
+				t,
+				content,
+				artifactCompletionRule,
 			)
 		})
 	}

--- a/openclaw/internal/cron/service.go
+++ b/openclaw/internal/cron/service.go
@@ -47,7 +47,10 @@ const (
 		"Do not use message unless you need an additional " +
 		"side message beyond the final result. The final " +
 		"answer will be delivered automatically to the job " +
-		"target. Do not ask for confirmation unless blocked."
+		"target. Do not ask for confirmation unless blocked. " +
+		"Do not return only a statement of what you will do; " +
+		"perform the scheduled task and report the result or " +
+		"the exact blocker."
 
 	scheduledRunMessagePrefix = "Execute the following existing " +
 		"scheduled job once now. Ignore any wording about " +

--- a/openclaw/internal/cron/service_test.go
+++ b/openclaw/internal/cron/service_test.go
@@ -1223,6 +1223,21 @@ func TestServiceNormalizeAndAccumulatorHelpers(t *testing.T) {
 	)
 }
 
+func TestRunContextPromptRequiresScheduledExecution(t *testing.T) {
+	t.Parallel()
+
+	require.Contains(
+		t,
+		runContextPrompt,
+		"Do not return only a statement of what you will do",
+	)
+	require.Contains(
+		t,
+		runContextPrompt,
+		"perform the scheduled task and report the result",
+	)
+}
+
 func waitFor(t *testing.T, fn func() bool) {
 	t.Helper()
 

--- a/openclaw/internal/octool/tools.go
+++ b/openclaw/internal/octool/tools.go
@@ -193,6 +193,9 @@ func execToolDescription(hasMemoryFile bool) string {
 	parts := []string{
 		"Execute a host shell command. Use this for general local shell work.",
 		"Interactive commands can continue with write_stdin.",
+		"If you say you will run, inspect, create, write, or verify " +
+			"something with host shell work, the same assistant " +
+			"message must call exec_command or the required tool.",
 		"Protected shell and credential paths may be blocked by policy.",
 		"Sensitive env values may be redacted from returned output.",
 		"Do not use this just to inspect a PDF or spreadsheet already " +

--- a/openclaw/internal/persona/store.go
+++ b/openclaw/internal/persona/store.go
@@ -39,6 +39,11 @@ const (
 	PresetConcise    = "concise"
 	PresetCoach      = "coach"
 	PresetCreative   = "creative"
+
+	personaTaskCompletionPrompt = " Keep this persona subordinate to " +
+		"task completion. Do not answer only with what you will " +
+		"do next when the requested content or action can be " +
+		"completed now."
 )
 
 var ErrUnknownPreset = errors.New("persona: unknown preset")
@@ -65,7 +70,7 @@ var presetList = []Preset{
 			"flirting is fine when the user's tone welcomes it. " +
 			"Stay respectful, emotionally grounded, and honest. " +
 			"Do not claim real-world exclusivity, dependency, or " +
-			"obligations.",
+			"obligations." + personaTaskCompletionPrompt,
 	},
 	{
 		ID:          PresetConcise,
@@ -73,7 +78,8 @@ var presetList = []Preset{
 		Description: "Direct, brief, and action-first replies.",
 		Prompt: "Be direct, brief, and low-friction. Lead with the " +
 			"answer or concrete action. Keep wording tight unless " +
-			"the user explicitly asks for depth.",
+			"the user explicitly asks for depth." +
+			personaTaskCompletionPrompt,
 	},
 	{
 		ID:          PresetCoach,
@@ -82,7 +88,7 @@ var presetList = []Preset{
 		Prompt: "Act like a pragmatic coach. Give clear structure, " +
 			"challenge vague thinking, and convert goals into " +
 			"concrete next steps. Stay supportive but do not " +
-			"sugarcoat tradeoffs.",
+			"sugarcoat tradeoffs." + personaTaskCompletionPrompt,
 	},
 	{
 		ID:          PresetCreative,
@@ -90,7 +96,7 @@ var presetList = []Preset{
 		Description: "More imaginative, vivid, and idea-rich.",
 		Prompt: "Lean imaginative, vivid, and idea-rich. Offer " +
 			"varied angles, names, examples, and alternatives " +
-			"when it helps the task.",
+			"when it helps the task." + personaTaskCompletionPrompt,
 	},
 }
 

--- a/openclaw/internal/persona/store_test.go
+++ b/openclaw/internal/persona/store_test.go
@@ -24,6 +24,21 @@ func TestLookup(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, PresetGirlfriend, preset.ID)
 
+	for _, id := range []string{
+		PresetGirlfriend,
+		PresetConcise,
+		PresetCoach,
+		PresetCreative,
+	} {
+		preset, ok := Lookup(id)
+		require.True(t, ok)
+		require.Contains(
+			t,
+			preset.Prompt,
+			"Do not answer only with what you will do next",
+		)
+	}
+
 	preset, ok = Lookup("")
 	require.True(t, ok)
 	require.Equal(t, PresetDefault, preset.ID)

--- a/openclaw/internal/subagentrun/service_test.go
+++ b/openclaw/internal/subagentrun/service_test.go
@@ -228,6 +228,11 @@ func TestServiceSpawnCompletesRunAndNotifies(t *testing.T) {
 		subagentRunPrompt,
 		runner.runOpts.InjectedContextMessages[0].Content,
 	)
+	require.Contains(
+		t,
+		runner.runOpts.InjectedContextMessages[0].Content,
+		"Do not return only a statement of what you will do",
+	)
 	runner.mu.Unlock()
 
 	require.Eventually(t, func() bool {

--- a/openclaw/internal/subagentrun/types.go
+++ b/openclaw/internal/subagentrun/types.go
@@ -38,8 +38,10 @@ const (
 	subagentRunPrompt = "You are running as an OpenClaw background " +
 		"subagent. Complete the delegated task once. The parent " +
 		"chat will receive your final result automatically. Keep " +
-		"the result concise and action-oriented. Do not spawn more " +
-		"subagents from inside this subagent."
+		"the result concise and action-oriented. Do not return " +
+		"only a statement of what you will do; complete the " +
+		"task and report the result or exact blocker. Do not " +
+		"spawn more subagents from inside this subagent."
 )
 
 type deliveryTarget struct {


### PR DESCRIPTION
### Summary
- tighten OpenClaw-specific autonomy prompts so preamble-only replies are not treated as completed answers
- require OpenClaw skill/tool-backed write, send, publish, scheduled, background, and host-exec actions to either complete in the same turn or report an exact blocker
- update OpenClaw prompt tests for app, persona, cron, subagent, and exec tool guidance

### Scope
- intentionally leaves shared trpc-agent-go planner/react, LLMAgent, and internal flow processor defaults unchanged to avoid compatibility risk for existing non-OpenClaw users

### Tests
- `go test ./app ./internal/cron ./internal/octool ./internal/persona ./internal/subagentrun` from the `openclaw` module
