### PR TITLE
flow/processor: preserve compacted tool-call reasoning

### DIFF
--- a/internal/flow/processor/content.go
+++ b/internal/flow/processor/content.go
@@ -1001,10 +1001,11 @@ func compactedCurrentInvocationMessage(
 	switch {
 	case len(msg.ToolCalls) > 0:
 		return model.Message{
-			Role:         msg.Role,
-			Content:      msg.Content,
-			ContentParts: msg.ContentParts,
-			ToolCalls:    msg.ToolCalls,
+			Role:             msg.Role,
+			Content:          msg.Content,
+			ContentParts:     msg.ContentParts,
+			ReasoningContent: msg.ReasoningContent,
+			ToolCalls:        msg.ToolCalls,
 		}, true
 	case msg.Role == model.RoleTool && msg.ToolID != "":
 		return model.Message{

--- a/internal/flow/processor/content_test.go
+++ b/internal/flow/processor/content_test.go
@@ -3618,8 +3618,9 @@ func TestContentRequestProcessor_getIncrementMessages_SummaryPreservesToolState(
 	baseTime := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
 	userMsg := model.NewUserMessage("run the task")
 	toolCall1 := model.Message{
-		Role:    model.RoleAssistant,
-		Content: "Starting with step 1.",
+		Role:             model.RoleAssistant,
+		Content:          "Starting with step 1.",
+		ReasoningContent: "Need to execute step 1 before continuing.",
 		ToolCalls: []model.ToolCall{{
 			Type: "function",
 			ID:   "call_1",
@@ -3731,6 +3732,7 @@ func TestContentRequestProcessor_getIncrementMessages_SummaryPreservesToolState(
 	if assert.Len(t, messages, 5) {
 		assert.True(t, model.MessagesEqual(userMsg, messages[0]))
 		assert.Equal(t, toolCall1.Content, messages[1].Content)
+		assert.Equal(t, toolCall1.ReasoningContent, messages[1].ReasoningContent)
 		assert.Equal(t, toolCall1.ToolCalls, messages[1].ToolCalls)
 		assert.Equal(t, model.RoleTool, messages[2].Role)
 		assert.Equal(t, toolResult1.ToolID, messages[2].ToolID)


### PR DESCRIPTION
## Summary
- preserve `ReasoningContent` when same-turn summary compaction keeps assistant tool-call messages for replay
- extend processor coverage to assert compacted tool-call messages still retain reasoning content
- verify DeepSeek thinking-mode tool loops no longer fail with missing `reasoning_content` errors after compaction

## Test plan
- [x] `go test ./internal/flow/processor`
- [x] `cd examples && go run ./summary/toolcalls -model "$MODEL_NAME" -sync-summary-intra-run -steps 3 -wait-sec 2`
- [x] `cd examples && go run ./summary/toolcalls -model "$MODEL_NAME" -steps 5 -wait-sec 2`