### PR TITLE
session: add noop session service

### DIFF
--- a/examples/session/simple/README.md
+++ b/examples/session/simple/README.md
@@ -7,7 +7,7 @@ This example demonstrates advanced session management capabilities using the `Ru
 This implementation highlights the power of session management in conversational AI:
 
 - **Multiple Sessions**: Create and switch between multiple independent conversation contexts
-- **Persistent Storage**: Support for SQLite, Redis, PostgreSQL, pgvector, MySQL, and ClickHouse backends
+- **Storage Options**: Support for no-op, in-memory, SQLite, Redis, PostgreSQL, pgvector, MySQL, and ClickHouse backends
 - **Session Discovery**: List and switch between existing sessions
 
 
@@ -18,7 +18,7 @@ This implementation highlights the power of session management in conversational
 - **Session Listing**: View all active sessions with `/sessions`
 - **History Recap**: Ask the agent to summarize conversation with `/history`
 - **Semantic Recall**: Use `/search <query>` when the backend implements `session.SearchableService`
-- **Backend Flexibility**: Choose from in-memory, SQLite, Redis, PostgreSQL, pgvector, MySQL, or ClickHouse storage
+- **Backend Flexibility**: Choose from no-op, in-memory, SQLite, Redis, PostgreSQL, pgvector, MySQL, or ClickHouse storage
 - **Context Preservation**: Each session maintains independent conversation history
 - **Langfuse Tracing**: Optional OpenTelemetry tracing for Redis session operations via Langfuse
 
@@ -98,13 +98,13 @@ Optional dedicated embedding credentials:
 | Argument           | Description                                         | Default Value    |
 | ------------------ | --------------------------------------------------- | ---------------- |
 | `-model`           | Name of the model to use                            | `MODEL_NAME` env var |
-| `-session`         | Session backend: inmemory/sqlite/redis/postgres/pgvector/mysql/clickhouse | `redis` |
+| `-session`         | Session backend: noop/inmemory/sqlite/redis/postgres/pgvector/mysql/clickhouse | `redis` |
 | `-streaming`       | Enable streaming mode for responses                 | `true`           |
 | `-event-limit`     | Maximum number of events to store per session       | `1000`           |
 | `-session-ttl`     | Session time-to-live duration                       | `10s`            |
 | `-search-topk`     | Maximum recalled events shown by `/search`          | `5`              |
 | `-debug`           | Enable debug mode to print session events           | `true`           |
-| `-enable-trace`    | Enable Langfuse tracing for session operations      | `true`           |
+| `-enable-trace`    | Enable Langfuse tracing for session operations      | `false`          |
 
 ## Usage
 
@@ -115,6 +115,17 @@ cd examples/session/simple
 export OPENAI_API_KEY="your-api-key-here"
 export OPENAI_BASE_URL="https://api.openai.com/v1"
 go run . -session inmemory
+```
+
+### With No-Op Backend
+
+Use the no-op backend when you want runner/session integration without
+persisting conversation history between turns:
+
+```bash
+export OPENAI_API_KEY="your-api-key-here"
+export OPENAI_BASE_URL="https://api.openai.com/v1"
+go run . -session noop
 ```
 
 ### Custom Event Limit and Session TTL
@@ -238,12 +249,7 @@ export LANGFUSE_SECRET_KEY="sk-lf-..."
 export LANGFUSE_PUBLIC_KEY="pk-lf-..."
 export LANGFUSE_HOST="localhost:3000"
 export LANGFUSE_INSECURE="true"
-go run . -session redis -enable-trace
-```
-
-To disable tracing:
-```bash
-go run . -session redis -enable-trace=false
+go run . -session redis -enable-trace=true
 ```
 
 ## Session Commands

--- a/examples/session/simple/main.go
+++ b/examples/session/simple/main.go
@@ -15,6 +15,7 @@
 // Usage:
 //
 //	go run main.go -session=inmemory
+//	go run main.go -session=noop
 //	go run main.go -session=sqlite
 //	go run main.go -session=redis
 //	go run main.go -session=postgres
@@ -102,7 +103,7 @@ var (
 	sessServiceName = flag.String(
 		"session",
 		"redis",
-		"Name of the session service to use, inmemory / "+
+		"Name of the session service to use, inmemory / noop / "+
 			"sqlite / redis / postgres / pgvector / mysql / clickhouse",
 	)
 	streaming = flag.Bool(
@@ -133,7 +134,7 @@ var (
 	)
 	enableTrace = flag.Bool(
 		"enable-trace",
-		true,
+		false,
 		"Enable Langfuse tracing for session operations. "+
 			"Requires LANGFUSE_SECRET_KEY, LANGFUSE_PUBLIC_KEY, LANGFUSE_HOST env vars.",
 	)
@@ -191,6 +192,7 @@ type multiTurnChat struct {
 	searchable     session.SearchableService
 	userID         string
 	sessionID      string
+	debugPersisted bool
 }
 
 // run starts the interactive chat session.
@@ -227,6 +229,7 @@ func (c *multiTurnChat) setup(_ context.Context) error {
 	if searchable, ok := sessionService.(session.SearchableService); ok {
 		c.searchable = searchable
 	}
+	c.debugPersisted = sessionType != util.SessionNoop
 
 	modelInstance := openai.New(c.modelName)
 
@@ -326,7 +329,7 @@ func (c *multiTurnChat) startChat(ctx context.Context) error {
 		}
 
 		// Print session events in debug mode.
-		if *debugMode {
+		if *debugMode && c.debugPersisted {
 			if err := util.PrintSessionEvents(
 				ctx,
 				c.sessionService,

--- a/examples/session/util.go
+++ b/examples/session/util.go
@@ -33,6 +33,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/session/clickhouse"
 	sessioninmemory "trpc.group/trpc-go/trpc-agent-go/session/inmemory"
 	"trpc.group/trpc-go/trpc-agent-go/session/mysql"
+	sessionnoop "trpc.group/trpc-go/trpc-agent-go/session/noop"
 	sessionpgvector "trpc.group/trpc-go/trpc-agent-go/session/pgvector"
 	"trpc.group/trpc-go/trpc-agent-go/session/postgres"
 	"trpc.group/trpc-go/trpc-agent-go/session/redis"
@@ -46,6 +47,7 @@ type SessionType string
 // Session type constants.
 const (
 	SessionInMemory   SessionType = "inmemory"
+	SessionNoop       SessionType = "noop"
 	SessionSQLite     SessionType = "sqlite"
 	SessionRedis      SessionType = "redis"
 	SessionPostgres   SessionType = "postgres"
@@ -67,7 +69,7 @@ type SessionServiceConfig struct {
 // type.
 //
 // Parameters:
-//   - sessionType: one of inmemory, sqlite, redis, postgres, pgvector,
+//   - sessionType: one of inmemory, noop, sqlite, redis, postgres, pgvector,
 //     mysql, clickhouse
 //   - cfg: session service configuration (eventLimit, ttl, hooks)
 //
@@ -100,6 +102,8 @@ func NewSessionServiceByType(
 		return newMySQLSessionService(cfg)
 	case SessionClickHouse:
 		return newClickHouseSessionService(cfg)
+	case SessionNoop:
+		return sessionnoop.NewService(), nil
 	case SessionInMemory:
 		fallthrough
 	default:

--- a/session/noop/runner_test.go
+++ b/session/noop/runner_test.go
@@ -1,0 +1,155 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package noop
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/chainagent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/graphagent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/graph"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+func TestRunnerWithNoopSessionService_GraphSeesCurrentUserMessage(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	const userMessage = "hello graph"
+	ag := newGraphHistoryCheckAgent(t, "graph", userMessage)
+	svc := NewService()
+	r := runner.NewRunner("app", ag, runner.WithSessionService(svc))
+	t.Cleanup(func() { require.NoError(t, r.Close()) })
+
+	events, err := r.Run(ctx, "user", "session", model.NewUserMessage(userMessage))
+	require.NoError(t, err)
+	requireNoRunError(t, events)
+
+	stored, err := svc.GetSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "session",
+	})
+	require.NoError(t, err)
+	require.Nil(t, stored)
+}
+
+func TestRunnerWithNoopSessionService_ChainGraphSeesUpstreamHistory(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	const upstreamMessage = "from upstream agent"
+	graphChild := newGraphHistoryCheckAgent(t, "graph-child", upstreamMessage)
+	chain := chainagent.New(
+		"chain-parent",
+		chainagent.WithSubAgents([]agent.Agent{
+			&staticResponseAgent{name: "upstream", content: upstreamMessage},
+			graphChild,
+		}),
+	)
+
+	r := runner.NewRunner("app", chain, runner.WithSessionService(NewService()))
+	t.Cleanup(func() { require.NoError(t, r.Close()) })
+
+	events, err := r.Run(ctx, "user", "session", model.NewUserMessage("start"))
+	require.NoError(t, err)
+	requireNoRunError(t, events)
+}
+
+func newGraphHistoryCheckAgent(t *testing.T, name string, want string) agent.Agent {
+	t.Helper()
+	compiled, err := graph.NewStateGraph(graph.MessagesStateSchema()).
+		AddNode("check", func(_ context.Context, state graph.State) (any, error) {
+			raw, ok := state[graph.StateKeyMessages]
+			if !ok {
+				return nil, fmt.Errorf("messages not found")
+			}
+			messages, ok := raw.([]model.Message)
+			if !ok {
+				return nil, fmt.Errorf("messages has type %T", raw)
+			}
+			for _, msg := range messages {
+				if strings.Contains(msg.Content, want) {
+					return graph.State{
+						graph.StateKeyLastResponse: "ok",
+					}, nil
+				}
+			}
+			return nil, fmt.Errorf("message containing %q not found", want)
+		}).
+		SetEntryPoint("check").
+		SetFinishPoint("check").
+		Compile()
+	require.NoError(t, err)
+
+	ag, err := graphagent.New(name, compiled)
+	require.NoError(t, err)
+	return ag
+}
+
+type staticResponseAgent struct {
+	name    string
+	content string
+}
+
+func (a *staticResponseAgent) Info() agent.Info {
+	return agent.Info{Name: a.name}
+}
+
+func (a *staticResponseAgent) SubAgents() []agent.Agent {
+	return nil
+}
+
+func (a *staticResponseAgent) FindSubAgent(string) agent.Agent {
+	return nil
+}
+
+func (a *staticResponseAgent) Tools() []tool.Tool {
+	return nil
+}
+
+func (a *staticResponseAgent) Run(ctx context.Context, inv *agent.Invocation) (<-chan *event.Event, error) {
+	events := make(chan *event.Event, 1)
+	go func() {
+		defer close(events)
+		resp := &model.Response{
+			Choices: []model.Choice{{
+				Message: model.NewAssistantMessage(a.content),
+			}},
+		}
+		_ = agent.EmitEvent(ctx, inv, events, event.NewResponseEvent(inv.InvocationID, a.name, resp))
+	}()
+	return events, nil
+}
+
+func requireNoRunError(t *testing.T, events <-chan *event.Event) {
+	t.Helper()
+	var completion *event.Event
+	for evt := range events {
+		require.NotNil(t, evt)
+		if evt.Error != nil {
+			t.Fatalf("unexpected run error: %s", evt.Error.Message)
+		}
+		if evt.IsRunnerCompletion() {
+			completion = evt
+		}
+	}
+	require.NotNil(t, completion)
+}

--- a/session/noop/service.go
+++ b/session/noop/service.go
@@ -1,0 +1,242 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+// Package noop provides a session service that keeps no persisted state.
+package noop
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+var (
+	_ session.Service      = (*Service)(nil)
+	_ session.TrackService = (*Service)(nil)
+)
+
+// Service implements session.Service without storing sessions or state.
+type Service struct{}
+
+// NewService creates a new no-op session service.
+func NewService() *Service {
+	return &Service{}
+}
+
+// CreateSession creates a transient session and does not persist it.
+func (s *Service) CreateSession(
+	ctx context.Context,
+	key session.Key,
+	state session.StateMap,
+	opts ...session.Option,
+) (*session.Session, error) {
+	if err := key.CheckUserKey(); err != nil {
+		return nil, err
+	}
+	if key.SessionID == "" {
+		key.SessionID = uuid.NewString()
+	}
+	sess := session.NewSession(key.AppName, key.UserID, key.SessionID)
+	for k, v := range state {
+		sess.SetState(k, v)
+	}
+	return sess, nil
+}
+
+// GetSession always returns nil after validating the key and options.
+func (s *Service) GetSession(
+	ctx context.Context,
+	key session.Key,
+	opts ...session.Option,
+) (*session.Session, error) {
+	if err := key.CheckSessionKey(); err != nil {
+		return nil, err
+	}
+	opt := applyOptions(opts...)
+	if err := session.ValidateGetSessionOptions(opt, false); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+// ListSessions always returns an empty list after validating the key and options.
+func (s *Service) ListSessions(
+	ctx context.Context,
+	userKey session.UserKey,
+	opts ...session.Option,
+) ([]*session.Session, error) {
+	if err := userKey.CheckUserKey(); err != nil {
+		return nil, err
+	}
+	opt := applyOptions(opts...)
+	if err := session.ValidateListSessionsOptions(opt); err != nil {
+		return nil, err
+	}
+	return []*session.Session{}, nil
+}
+
+// DeleteSession validates the key and does not persist any deletion.
+func (s *Service) DeleteSession(
+	ctx context.Context,
+	key session.Key,
+	opts ...session.Option,
+) error {
+	return key.CheckSessionKey()
+}
+
+// UpdateAppState validates the app name and drops the state update.
+func (s *Service) UpdateAppState(ctx context.Context, appName string, state session.StateMap) error {
+	if appName == "" {
+		return session.ErrAppNameRequired
+	}
+	return nil
+}
+
+// DeleteAppState validates the app name and drops the delete request.
+func (s *Service) DeleteAppState(ctx context.Context, appName string, key string) error {
+	if appName == "" {
+		return session.ErrAppNameRequired
+	}
+	return nil
+}
+
+// ListAppStates validates the app name and returns an empty state map.
+func (s *Service) ListAppStates(ctx context.Context, appName string) (session.StateMap, error) {
+	if appName == "" {
+		return nil, session.ErrAppNameRequired
+	}
+	return session.StateMap{}, nil
+}
+
+// UpdateUserState validates the user key and drops the state update.
+func (s *Service) UpdateUserState(
+	ctx context.Context,
+	userKey session.UserKey,
+	state session.StateMap,
+) error {
+	if err := userKey.CheckUserKey(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ListUserStates validates the user key and returns an empty state map.
+func (s *Service) ListUserStates(
+	ctx context.Context,
+	userKey session.UserKey,
+) (session.StateMap, error) {
+	if err := userKey.CheckUserKey(); err != nil {
+		return nil, err
+	}
+	return session.StateMap{}, nil
+}
+
+// DeleteUserState validates the user key and drops the delete request.
+func (s *Service) DeleteUserState(ctx context.Context, userKey session.UserKey, key string) error {
+	return userKey.CheckUserKey()
+}
+
+// UpdateSessionState validates the session key and drops the state update.
+func (s *Service) UpdateSessionState(
+	ctx context.Context,
+	key session.Key,
+	state session.StateMap,
+) error {
+	if err := key.CheckSessionKey(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// AppendEvent updates the transient session object and does not persist the event.
+func (s *Service) AppendEvent(
+	ctx context.Context,
+	sess *session.Session,
+	evt *event.Event,
+	opts ...session.Option,
+) error {
+	if sess == nil {
+		return session.ErrNilSession
+	}
+	key := session.Key{AppName: sess.AppName, UserID: sess.UserID, SessionID: sess.ID}
+	if err := key.CheckSessionKey(); err != nil {
+		return err
+	}
+	sess.UpdateUserSession(evt, opts...)
+	return nil
+}
+
+// AppendTrackEvent updates the transient session object and does not persist the event.
+func (s *Service) AppendTrackEvent(
+	ctx context.Context,
+	sess *session.Session,
+	trackEvent *session.TrackEvent,
+	opts ...session.Option,
+) error {
+	if sess == nil {
+		return session.ErrNilSession
+	}
+	key := session.Key{AppName: sess.AppName, UserID: sess.UserID, SessionID: sess.ID}
+	if err := key.CheckSessionKey(); err != nil {
+		return err
+	}
+	return sess.AppendTrackEvent(trackEvent, opts...)
+}
+
+// CreateSessionSummary is a no-op.
+func (s *Service) CreateSessionSummary(
+	ctx context.Context,
+	sess *session.Session,
+	filterKey string,
+	force bool,
+) error {
+	if sess == nil {
+		return session.ErrNilSession
+	}
+	key := session.Key{AppName: sess.AppName, UserID: sess.UserID, SessionID: sess.ID}
+	return key.CheckSessionKey()
+}
+
+// EnqueueSummaryJob is a no-op.
+func (s *Service) EnqueueSummaryJob(
+	ctx context.Context,
+	sess *session.Session,
+	filterKey string,
+	force bool,
+) error {
+	if sess == nil {
+		return session.ErrNilSession
+	}
+	key := session.Key{AppName: sess.AppName, UserID: sess.UserID, SessionID: sess.ID}
+	return key.CheckSessionKey()
+}
+
+// GetSessionSummaryText always reports that no summary exists.
+func (s *Service) GetSessionSummaryText(
+	ctx context.Context,
+	sess *session.Session,
+	opts ...session.SummaryOption,
+) (string, bool) {
+	return "", false
+}
+
+// Close closes the no-op service.
+func (s *Service) Close() error {
+	return nil
+}
+
+func applyOptions(opts ...session.Option) *session.Options {
+	opt := &session.Options{}
+	for _, o := range opts {
+		o(opt)
+	}
+	return opt
+}

--- a/session/noop/service_test.go
+++ b/session/noop/service_test.go
@@ -176,3 +176,93 @@ func TestValidation(t *testing.T) {
 	require.ErrorIs(t, svc.CreateSessionSummary(ctx, nil, "", false), session.ErrNilSession)
 	require.ErrorIs(t, svc.EnqueueSummaryJob(ctx, nil, "", false), session.ErrNilSession)
 }
+
+func TestNoopStateMethodsValidateKeys(t *testing.T) {
+	ctx := context.Background()
+	svc := NewService()
+
+	require.NoError(t, svc.DeleteSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "session",
+	}))
+	require.ErrorIs(t,
+		svc.DeleteSession(ctx, session.Key{AppName: "app", UserID: "user"}),
+		session.ErrSessionIDRequired,
+	)
+
+	require.ErrorIs(t,
+		svc.UpdateAppState(ctx, "", session.StateMap{"k": []byte("v")}),
+		session.ErrAppNameRequired,
+	)
+	require.NoError(t, svc.DeleteAppState(ctx, "app", "k"))
+	require.ErrorIs(t,
+		svc.DeleteAppState(ctx, "", "k"),
+		session.ErrAppNameRequired,
+	)
+	_, err := svc.ListAppStates(ctx, "")
+	require.ErrorIs(t, err, session.ErrAppNameRequired)
+
+	userKey := session.UserKey{AppName: "app", UserID: "user"}
+	require.NoError(t, svc.DeleteUserState(ctx, userKey, "k"))
+	require.ErrorIs(t,
+		svc.DeleteUserState(ctx, session.UserKey{AppName: "app"}, "k"),
+		session.ErrUserIDRequired,
+	)
+	require.ErrorIs(t,
+		svc.UpdateUserState(ctx, session.UserKey{UserID: "user"}, session.StateMap{}),
+		session.ErrAppNameRequired,
+	)
+	_, err = svc.ListUserStates(ctx, session.UserKey{AppName: "app"})
+	require.ErrorIs(t, err, session.ErrUserIDRequired)
+
+	require.ErrorIs(t,
+		svc.UpdateSessionState(ctx, session.Key{
+			AppName: "app",
+			UserID:  "user",
+		}, session.StateMap{}),
+		session.ErrSessionIDRequired,
+	)
+}
+
+func TestNoopEventAndSummaryMethodsValidateSessions(t *testing.T) {
+	ctx := context.Background()
+	svc := NewService()
+
+	invalidSession := session.NewSession("", "user", "session")
+	require.ErrorIs(t,
+		svc.AppendEvent(ctx, invalidSession, nil),
+		session.ErrAppNameRequired,
+	)
+	require.ErrorIs(t,
+		svc.AppendTrackEvent(ctx, invalidSession, &session.TrackEvent{Track: "trace"}),
+		session.ErrAppNameRequired,
+	)
+	require.ErrorIs(t,
+		svc.CreateSessionSummary(ctx, invalidSession, "", false),
+		session.ErrAppNameRequired,
+	)
+	require.ErrorIs(t,
+		svc.EnqueueSummaryJob(ctx, invalidSession, "", false),
+		session.ErrAppNameRequired,
+	)
+
+	validSession := session.NewSession("app", "user", "session")
+	require.NoError(t, svc.CreateSessionSummary(ctx, validSession, "", false))
+	require.NoError(t, svc.EnqueueSummaryJob(ctx, validSession, "", false))
+
+	text, ok := svc.GetSessionSummaryText(ctx, validSession, session.WithSummaryFilterKey("filter"))
+	assert.Empty(t, text)
+	assert.False(t, ok)
+	require.NoError(t, svc.Close())
+}
+
+func TestAppendTrackEventPropagatesTransientSessionError(t *testing.T) {
+	ctx := context.Background()
+	svc := NewService()
+	sess := session.NewSession("app", "user", "session")
+
+	err := svc.AppendTrackEvent(ctx, sess, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "track event is nil")
+}

--- a/session/noop/service_test.go
+++ b/session/noop/service_test.go
@@ -1,0 +1,178 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package noop
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+func TestServiceImplementsInterfaces(t *testing.T) {
+	var _ session.Service = NewService()
+	var _ session.TrackService = NewService()
+}
+
+func TestCreateSessionReturnsTransientSession(t *testing.T) {
+	svc := NewService()
+	state := session.StateMap{"k": []byte("v")}
+
+	sess, err := svc.CreateSession(context.Background(), session.Key{
+		AppName: "app",
+		UserID:  "user",
+	}, state)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.NotEmpty(t, sess.ID)
+
+	got, ok := sess.GetState("k")
+	require.True(t, ok)
+	assert.Equal(t, []byte("v"), got)
+
+	state["k"][0] = 'x'
+	got, ok = sess.GetState("k")
+	require.True(t, ok)
+	assert.Equal(t, []byte("v"), got)
+}
+
+func TestServiceDoesNotPersistSessionsOrState(t *testing.T) {
+	ctx := context.Background()
+	svc := NewService()
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "session"}
+
+	sess, err := svc.CreateSession(ctx, key, session.StateMap{"k": []byte("v")})
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+
+	got, err := svc.GetSession(ctx, key)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+
+	sessions, err := svc.ListSessions(ctx, session.UserKey{AppName: "app", UserID: "user"})
+	require.NoError(t, err)
+	assert.Empty(t, sessions)
+
+	require.NoError(t, svc.UpdateAppState(ctx, "app", session.StateMap{"app": []byte("v")}))
+	appState, err := svc.ListAppStates(ctx, "app")
+	require.NoError(t, err)
+	assert.Empty(t, appState)
+
+	require.NoError(t, svc.UpdateUserState(ctx, session.UserKey{AppName: "app", UserID: "user"}, session.StateMap{"user": []byte("v")}))
+	userState, err := svc.ListUserStates(ctx, session.UserKey{AppName: "app", UserID: "user"})
+	require.NoError(t, err)
+	assert.Empty(t, userState)
+}
+
+func TestAppendEventUpdatesOnlyTransientSession(t *testing.T) {
+	ctx := context.Background()
+	svc := NewService()
+	sess := session.NewSession("app", "user", "session")
+	evt := event.NewResponseEvent(
+		"invocation",
+		"author",
+		&model.Response{
+			Choices: []model.Choice{{
+				Message: model.Message{
+					Role:    model.RoleUser,
+					Content: "hello",
+				},
+			}},
+		},
+	)
+	evt.StateDelta = session.StateMap{"answer": []byte("42")}
+
+	err := svc.AppendEvent(ctx, sess, evt)
+	require.NoError(t, err)
+	assert.Equal(t, 1, sess.GetEventCount())
+	got, ok := sess.GetState("answer")
+	require.True(t, ok)
+	assert.Equal(t, []byte("42"), got)
+
+	stored, err := svc.GetSession(ctx, session.Key{
+		AppName:   sess.AppName,
+		UserID:    sess.UserID,
+		SessionID: sess.ID,
+	})
+	require.NoError(t, err)
+	assert.Nil(t, stored)
+}
+
+func TestAppendTrackEventUpdatesOnlyTransientSession(t *testing.T) {
+	ctx := context.Background()
+	svc := NewService()
+	sess := session.NewSession("app", "user", "session")
+
+	err := svc.AppendTrackEvent(ctx, sess, &session.TrackEvent{
+		Track:   "trace",
+		Payload: []byte(`{"ok":true}`),
+	})
+	require.NoError(t, err)
+
+	events, err := sess.GetTrackEvents("trace")
+	require.NoError(t, err)
+	require.Len(t, events.Events, 1)
+	assert.JSONEq(t, `{"ok":true}`, string(events.Events[0].Payload))
+
+	stored, err := svc.GetSession(ctx, session.Key{
+		AppName:   sess.AppName,
+		UserID:    sess.UserID,
+		SessionID: sess.ID,
+	})
+	require.NoError(t, err)
+	assert.Nil(t, stored)
+}
+
+func TestValidation(t *testing.T) {
+	ctx := context.Background()
+	svc := NewService()
+
+	_, err := svc.CreateSession(ctx, session.Key{UserID: "user"}, nil)
+	require.ErrorIs(t, err, session.ErrAppNameRequired)
+
+	_, err = svc.GetSession(ctx, session.Key{AppName: "app", UserID: "user"})
+	require.ErrorIs(t, err, session.ErrSessionIDRequired)
+
+	_, err = svc.GetSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "session",
+	}, session.WithGetSessionEventPage(0, 1))
+	require.ErrorIs(t, err, session.ErrEventPageUnsupported)
+
+	_, err = svc.ListSessions(ctx, session.UserKey{
+		AppName: "app",
+		UserID:  "user",
+	}, session.WithGetSessionEventPage(0, 1))
+	require.ErrorIs(t, err, session.ErrEventPageOnlyForGetSession)
+
+	err = svc.UpdateUserState(ctx, session.UserKey{AppName: "app", UserID: "user"}, session.StateMap{
+		session.StateTempPrefix + "k": []byte("v"),
+	})
+	require.NoError(t, err)
+
+	err = svc.UpdateSessionState(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "session",
+	}, session.StateMap{
+		session.StateUserPrefix + "k": []byte("v"),
+	})
+	require.NoError(t, err)
+
+	require.ErrorIs(t, svc.AppendEvent(ctx, nil, nil), session.ErrNilSession)
+	require.ErrorIs(t, svc.AppendTrackEvent(ctx, nil, nil), session.ErrNilSession)
+	require.ErrorIs(t, svc.CreateSessionSummary(ctx, nil, "", false), session.ErrNilSession)
+	require.ErrorIs(t, svc.EnqueueSummaryJob(ctx, nil, "", false), session.ErrNilSession)
+}


### PR DESCRIPTION
## Summary

Adds a `session/noop` package that implements `session.Service` without persisting sessions or state. The service still returns a transient session from `CreateSession` and updates the in-flight session in `AppendEvent` and `AppendTrackEvent`, so a single runner execution can continue to use session history and state deltas while storage remains disabled.

## Impact

This is useful for callers that want normal runner, graph, and multi-agent execution without retaining session data across requests. Cross-request features that depend on persisted sessions, such as restored history, summaries, AG-UI snapshots, or swarm cross-request transfer state, intentionally remain unavailable with the noop backend.

## Validation

- `go test ./session/noop -count=1`
- `go test ./session/...`
- `go test ./runner`

A full `go test ./...` was also attempted and failed in existing skill/workspace-related packages unrelated to this change: `agent/llmagent`, `internal/skillstage`, `internal/workspaceprep`, `tool/file`, `tool/skill`, and `tool/workspaceexec`.