### PR TITLE
docs: clarify context-reduction mechanisms in session management

### DIFF
--- a/docs/mkdocs/en/session.md
+++ b/docs/mkdocs/en/session.md
@@ -1789,12 +1789,13 @@ First, separate the three context-reduction mechanisms:
 | Context compaction | Agent prompt assembly | Does not call an LLM or drop whole turns; it only rewrites `tool result` content | Clean up large search results, logs, web fetches, and similar tool outputs |
 | Token tailoring | Model provider | Drops or keeps message rounds by token budget immediately before the provider call | Final fallback to keep the request within the context window |
 
-In call order, the agent assembles the prompt, injects summary when configured,
-and optionally compacts `tool result` content. If needed, the flow may refresh
-the summary once and rebuild the request. Finally, model-layer token tailoring
-trims the message list. Context compaction shrinks tool-output payloads inside
-messages, token tailoring drops message rounds, and summary creates a semantic
-replacement for historical context.
+In call order, the agent assembles the prompt, injects summary when
+`WithAddSessionSummary(true)` is enabled, and optionally compacts `tool result`
+content. If summary injection is enabled and the request still approaches the
+context window, the flow may refresh the summary once and rebuild the request.
+Finally, model-layer token tailoring trims the message list. Context compaction
+shrinks tool-output payloads inside messages, token tailoring drops message
+rounds, and summary creates a semantic replacement for historical context.
 
 **Mode 1: With Summary (`WithAddSessionSummary(true)`)**
 

--- a/docs/mkdocs/en/session.md
+++ b/docs/mkdocs/en/session.md
@@ -1781,6 +1781,21 @@ eventChan, err := runner.Run(ctx, userID, sessionID, userMessage)
 
 The framework provides two distinct modes for managing conversation context sent to the LLM:
 
+First, separate the three context-reduction mechanisms:
+
+| Mechanism | Layer | What changes | Typical use |
+| --- | --- | --- | --- |
+| Summary | Session Service + prompt assembly | Uses an LLM to create a persisted historical summary. With `WithAddSessionSummary(true)`, the request injects that summary and appends only incremental events after the summary point | Preserve semantic continuity in long sessions |
+| Context compaction | Agent prompt assembly | Does not call an LLM or drop whole turns; it only rewrites `tool result` content | Clean up large search results, logs, web fetches, and similar tool outputs |
+| Token tailoring | Model provider | Drops or keeps message rounds by token budget immediately before the provider call | Final fallback to keep the request within the context window |
+
+In call order, the agent assembles the prompt, injects summary when configured,
+and optionally compacts `tool result` content. If needed, the flow may refresh
+the summary once and rebuild the request. Finally, model-layer token tailoring
+trims the message list. Context compaction shrinks tool-output payloads inside
+messages, token tailoring drops message rounds, and summary creates a semantic
+replacement for historical context.
+
 **Mode 1: With Summary (`WithAddSessionSummary(true)`)**
 
 - The session summary is merged into the existing system message when one is already present, or prepended as a new system message when none exists.
@@ -1788,9 +1803,20 @@ The framework provides two distinct modes for managing conversation context sent
 - This ensures complete context: condensed history (summary) + all new conversations since summarization.
 - `WithMaxHistoryRuns` is **ignored** in this mode.
 
-**Optional: Prompt-side context compaction**
+**Context compaction details**
 
-When `WithEnableContextCompaction(true)` is enabled, the framework adds a lightweight Phase 1 compaction pass before the LLM call:
+Context compaction is not another name for summary, and it is not token
+tailoring. It only targets `tool result` content, which is the part most likely
+to grow unexpectedly. It does not summarize ordinary user/assistant messages
+with an LLM, and it does not discard complete message rounds the way token
+tailoring may.
+
+> **Naming note**: "compaction" in `WithEnableContextCompaction(true)` means
+> prompt-side tool result compaction/pruning. Semantic summaries are still
+> controlled by `WithAddSessionSummary(true)` and the configured session
+> summarizer.
+
+When `WithEnableContextCompaction(true)` is enabled, the framework adds prompt-side compaction before the LLM call:
 
 - **Pass 1** — Historical tool results from older requests that exceed `ContextCompactionToolResultMaxTokens` (default 1024 tokens) are replaced with a placeholder while keeping `ToolID` and `ToolName`.
 - **Pass 2** — Any single tool result (including the current request) exceeding `ContextCompactionOversizedToolResultMaxTokens` is truncated using head+tail preservation with a `[...N characters truncated...]` marker. **Disabled by default (value `0`)** — you must explicitly call `WithContextCompactionOversizedToolResultMaxTokens(...)` and keep `WithEnableContextCompaction(true)` for Pass 2 to fire (recommended opt-in value: 8192 tokens).
@@ -1803,7 +1829,7 @@ llmAgent := llmagent.New(
     "my-agent",
     llmagent.WithModel(summaryModel),
     llmagent.WithAddSessionSummary(true),
-    llmagent.WithEnableContextCompaction(true),
+    llmagent.WithEnableContextCompaction(true), // only shrinks tool results; does not generate a summary
     llmagent.WithContextCompactionThresholdRatio(0.7),
     llmagent.WithContextCompactionToolResultMaxTokens(1024),  // Pass 1: old tool results → placeholder
     llmagent.WithContextCompactionOversizedToolResultMaxTokens(8192),  // Pass 2: any huge result → head+tail

--- a/docs/mkdocs/en/session/index.md
+++ b/docs/mkdocs/en/session/index.md
@@ -78,8 +78,9 @@ func main() {
         llmagent.WithModel(llm),
         llmagent.WithInstruction("You are a helpful assistant"),
         llmagent.WithAddSessionSummary(true),
-        // Optional: compact oversized historical tool results before the LLM call
-        // WithAddSessionSummary(true) additionally enables one sync summary retry when needed
+        // Optional: shrink tool-result payloads before the LLM call; this does not generate a summary.
+        // This is separate from session summary and model token tailoring.
+        // WithAddSessionSummary(true) additionally enables one sync summary retry when needed.
         llmagent.WithEnableContextCompaction(true), // master switch for both Pass 1 and Pass 2
         llmagent.WithContextCompactionToolResultMaxTokens(1024),  // old tool results → placeholder
         // Pass 2 is disabled by default; opt in with a positive threshold (recommended: 8192)

--- a/docs/mkdocs/en/session/summary.md
+++ b/docs/mkdocs/en/session/summary.md
@@ -623,7 +623,7 @@ Before choosing a mode, distinguish the three context-reduction mechanisms:
 | --- | --- | --- | --- |
 | Summary | Session Service + prompt assembly | Uses an LLM to create a persisted summary of historical events. With `WithAddSessionSummary(true)`, the request injects that summary and appends only incremental events after the summary point | Preserve semantic continuity in long sessions while avoiding repeated full-history prompts |
 | Context compaction | Agent prompt assembly | Does not call an LLM and does not drop whole turns. It only rewrites `tool result` content during request projection, such as replacing old results with placeholders or truncating oversized results with head+tail preservation | Keep the conversation structure and active tool chain while shrinking large tool outputs |
-| Token tailoring | Model provider | Drops or keeps message rounds according to a token budget right before the provider call. The default strategy preserves system messages and the latest turn | Final fallback to keep the request within the model context window |
+| Token tailoring | Model provider | Drops or keeps message rounds according to a token budget right before the provider call. The default strategy tries to preserve system messages and the latest turn, but preservation is still limited by the available budget | Final fallback to keep the request within the model context window |
 
 The normal call path is: the agent assembles the prompt, injects the summary when
 configured, and optionally compacts `tool result` content. If summary injection is

--- a/docs/mkdocs/en/session/summary.md
+++ b/docs/mkdocs/en/session/summary.md
@@ -617,6 +617,24 @@ err := sessionService.CreateSessionSummary(
 
 The framework provides two modes for managing conversation context sent to the LLM:
 
+Before choosing a mode, distinguish the three context-reduction mechanisms:
+
+| Mechanism | Layer | What changes | Typical use |
+| --- | --- | --- | --- |
+| Summary | Session Service + prompt assembly | Uses an LLM to create a persisted summary of historical events. With `WithAddSessionSummary(true)`, the request injects that summary and appends only incremental events after the summary point | Preserve semantic continuity in long sessions while avoiding repeated full-history prompts |
+| Context compaction | Agent prompt assembly | Does not call an LLM and does not drop whole turns. It only rewrites `tool result` content during request projection, such as replacing old results with placeholders or truncating oversized results with head+tail preservation | Keep the conversation structure and active tool chain while shrinking large tool outputs |
+| Token tailoring | Model provider | Drops or keeps message rounds according to a token budget right before the provider call. The default strategy preserves system messages and the latest turn | Final fallback to keep the request within the model context window |
+
+The normal call path is: the agent assembles the prompt, injects the summary when
+configured, and optionally compacts `tool result` content. If summary injection is
+enabled and the compacted request still approaches the context window, the flow
+may synchronously refresh the summary once and rebuild the request before the LLM
+call. Finally, model-layer token tailoring trims the message list by budget. In
+short, context compaction and token tailoring can both reduce prompt size, but
+compaction shrinks tool-output payloads inside messages, while tailoring drops
+message rounds. Summary is different again: it creates a semantic replacement for
+historical context.
+
 ### Mode 1: Enable Summary Injection (Recommended)
 
 ```go
@@ -700,7 +718,18 @@ When the first history message is not a user role, the summary is a standalone u
 
 > **Tip**: For very long conversations (hundreds of turns) where you want old summaries to naturally age out (replaced by newer summaries), use `SessionSummaryInjectionUser` mode.
 
-**Optional: Prompt-side context compaction**
+#### Context Compaction Details
+
+Context compaction is not another name for summary, and it is not token
+tailoring. It only targets `tool result` content, which is the part most likely
+to grow unexpectedly. It does not summarize ordinary user/assistant messages
+with an LLM, and it does not discard complete message rounds the way token
+tailoring may.
+
+> **Naming note**: "compaction" in `WithEnableContextCompaction(true)` means
+> prompt-side tool result compaction/pruning. Semantic summaries are still
+> controlled by `WithAddSessionSummary(true)` and the configured session
+> summarizer.
 
 When `WithEnableContextCompaction(true)` is enabled, the framework adds two compaction passes before the LLM call:
 
@@ -730,7 +759,7 @@ agent := llmagent.New(
     "my-agent",
     llmagent.WithModel(modelInstance),
     llmagent.WithAddSessionSummary(true),
-    llmagent.WithEnableContextCompaction(true),
+    llmagent.WithEnableContextCompaction(true), // only shrinks tool results; does not generate a summary
     llmagent.WithContextCompactionThresholdRatio(0.7),
     llmagent.WithContextCompactionToolResultMaxTokens(1024),  // Pass 1: old tool results → placeholder
     llmagent.WithContextCompactionOversizedToolResultMaxTokens(8192),  // Pass 2: any huge result → head+tail

--- a/docs/mkdocs/zh/session.md
+++ b/docs/mkdocs/zh/session.md
@@ -1870,10 +1870,11 @@ err := sessionService.CreateSessionSummary(
 | Context compaction | Agent prompt assembly | 不调用 LLM、不删整轮消息，只改写 `tool result` 内容 | 清理搜索结果、日志、网页抓取等超长工具输出 |
 | Token tailoring | Model provider | 模型调用前按 token budget 删除或保留消息轮次 | 最后一层兜底，保证请求落入 context window |
 
-调用顺序上，agent 先组装 prompt、注入 summary、按需压缩 `tool result`；
-必要时再同步刷新一次 summary 并重建请求；最后由模型层 token tailoring
-裁剪消息列表。context compaction 缩小消息内部的工具输出，token tailoring
-删减消息轮次，summary 则用新的语义摘要替代一段历史。
+调用顺序上，agent 先组装 prompt；如果启用了 `WithAddSessionSummary(true)`，
+则注入 summary；随后按需压缩 `tool result`。如果开启了摘要注入且请求仍接近
+context window，必要时再同步刷新一次 summary 并重建请求；最后由模型层
+token tailoring 裁剪消息列表。context compaction 缩小消息内部的工具输出，
+token tailoring 删减消息轮次，summary 则用新的语义摘要替代一段历史。
 
 #### 模式 1：启用摘要注入（推荐）
 

--- a/docs/mkdocs/zh/session.md
+++ b/docs/mkdocs/zh/session.md
@@ -1862,6 +1862,19 @@ err := sessionService.CreateSessionSummary(
 
 框架提供两种模式来管理发送给 LLM 的对话上下文：
 
+先区分三类上下文减载机制：
+
+| 机制 | 所在层 | 改动对象 | 典型用途 |
+| --- | --- | --- | --- |
+| Summary | Session Service + prompt assembly | 用 LLM 生成可持久化历史摘要；开启 `WithAddSessionSummary(true)` 后，请求中注入摘要，并只拼接摘要时间点之后的增量事件 | 长会话保留语义连续性 |
+| Context compaction | Agent prompt assembly | 不调用 LLM、不删整轮消息，只改写 `tool result` 内容 | 清理搜索结果、日志、网页抓取等超长工具输出 |
+| Token tailoring | Model provider | 模型调用前按 token budget 删除或保留消息轮次 | 最后一层兜底，保证请求落入 context window |
+
+调用顺序上，agent 先组装 prompt、注入 summary、按需压缩 `tool result`；
+必要时再同步刷新一次 summary 并重建请求；最后由模型层 token tailoring
+裁剪消息列表。context compaction 缩小消息内部的工具输出，token tailoring
+删减消息轮次，summary 则用新的语义摘要替代一段历史。
+
 #### 模式 1：启用摘要注入（推荐）
 
 ```go
@@ -1875,7 +1888,15 @@ llmagent.WithAddSessionSummary(true)
 - 保证完整上下文：浓缩历史 + 完整新对话
 - **`WithMaxHistoryRuns` 参数被忽略**
 
-**可选：Prompt 侧上下文压缩**
+**Context compaction 细节**
+
+Context compaction 不是 summary 的同义词，也不是 token tailoring。它只处理
+`tool result` 这种容易异常膨胀的内容，不会把普通 user/assistant 消息做
+LLM 摘要，也不会像 token tailoring 那样直接丢弃完整消息轮次。
+
+> **命名说明**：`WithEnableContextCompaction(true)` 中的 "compaction"
+> 指 prompt-side tool result compaction/pruning；如果需要语义摘要，仍然由
+> `WithAddSessionSummary(true)` 和会话摘要器负责。
 
 当开启 `WithEnableContextCompaction(true)` 时，框架会在真正调用模型前执行 Pass 1 压缩；如果同时显式配置正数的 `ContextCompactionOversizedToolResultMaxTokens`，还会执行 Pass 2：
 
@@ -1890,7 +1911,7 @@ agent := llmagent.New(
     "my-agent",
     llmagent.WithModel(modelInstance),
     llmagent.WithAddSessionSummary(true),
-    llmagent.WithEnableContextCompaction(true),
+    llmagent.WithEnableContextCompaction(true), // 只压 tool result，不生成摘要
     llmagent.WithContextCompactionThresholdRatio(0.7),
     llmagent.WithContextCompactionToolResultMaxTokens(1024),  // Pass 1: 旧 tool result → 占位符
     llmagent.WithContextCompactionOversizedToolResultMaxTokens(8192),  // Pass 2: 任意超大 result → 首尾保留截断

--- a/docs/mkdocs/zh/session/index.md
+++ b/docs/mkdocs/zh/session/index.md
@@ -78,7 +78,8 @@ func main() {
         llmagent.WithModel(llm),
         llmagent.WithInstruction("你是一个智能助手"),
         llmagent.WithAddSessionSummary(true), // 可选：启用摘要注入到上下文
-        llmagent.WithEnableContextCompaction(true), // 可选：压缩历史超长 tool result（Pass 1 + Pass 2 的总开关）
+        // 可选：只压缩 tool result 内容，不生成摘要；和 session summary / token tailoring 分层独立
+        llmagent.WithEnableContextCompaction(true), // Pass 1 + Pass 2 的总开关
         // 配合 WithAddSessionSummary(true) 时，还会在必要时多一次同步摘要重试
         llmagent.WithContextCompactionToolResultMaxTokens(1024),  // 旧 tool result → 占位符
         // Pass 2 默认关闭，需要显式设置一个正阈值才会生效（推荐 8192）

--- a/docs/mkdocs/zh/session/summary.md
+++ b/docs/mkdocs/zh/session/summary.md
@@ -626,14 +626,15 @@ err := sessionService.CreateSessionSummary(
 | --- | --- | --- | --- |
 | Summary | Session Service + prompt assembly | 用 LLM 将历史事件生成可持久化摘要；开启 `WithAddSessionSummary(true)` 后，请求中注入摘要，并只拼接摘要时间点之后的增量事件 | 长会话保留语义连续性，减少反复发送完整历史 |
 | Context compaction | Agent prompt assembly | 不调用 LLM，不删除整轮消息；只在请求投影阶段改写 `tool result` 内容，例如旧结果替换为占位符、超大结果首尾保留截断 | 工具输出很长，但希望尽量保留对话结构和当前轮工具链路 |
-| Token tailoring | Model provider | 模型调用前按 token budget 删除或保留消息轮次，默认策略会保留系统消息和最新轮次 | 最后一层兜底，保证请求落入模型 context window |
+| Token tailoring | Model provider | 模型调用前按 token budget 删除或保留消息轮次，默认策略会尽量保留系统消息和最新轮次，但最终仍受可用预算约束 | 最后一层兜底，保证请求落入模型 context window |
 
-正常调用链路大致是：先由 agent 组装 prompt，并按需注入 summary、压缩
-`tool result`；如果开启了 summary 且压完后仍接近 context window，会在
-LLM 调用前同步尝试刷新一次 summary 并重建请求；最后模型层的 token
-tailoring 再按预算裁剪消息列表。也就是说，context compaction 和 token
-tailoring 都能减少 prompt 体积，但前者缩小消息内部的工具输出，后者删减
-消息轮次；summary 则是用新的语义摘要替代一段历史。
+正常调用链路大致是：先由 agent 组装 prompt；如果启用了
+`WithAddSessionSummary(true)`，则注入 summary；随后按需压缩 `tool result`。
+如果开启了摘要注入且压完后仍接近 context window，会在 LLM 调用前同步尝试
+刷新一次 summary 并重建请求；最后模型层的 token tailoring 再按预算裁剪
+消息列表。也就是说，context compaction 和 token tailoring 都能减少 prompt
+体积，但前者缩小消息内部的工具输出，后者删减消息轮次；summary 则是用新的
+语义摘要替代一段历史。
 
 ### 模式 1：启用摘要注入（推荐）
 

--- a/docs/mkdocs/zh/session/summary.md
+++ b/docs/mkdocs/zh/session/summary.md
@@ -620,6 +620,21 @@ err := sessionService.CreateSessionSummary(
 
 框架提供两种模式来管理发送给 LLM 的对话上下文：
 
+在选择模式前，先区分三类上下文减载机制：
+
+| 机制 | 所在层 | 改动对象 | 典型用途 |
+| --- | --- | --- | --- |
+| Summary | Session Service + prompt assembly | 用 LLM 将历史事件生成可持久化摘要；开启 `WithAddSessionSummary(true)` 后，请求中注入摘要，并只拼接摘要时间点之后的增量事件 | 长会话保留语义连续性，减少反复发送完整历史 |
+| Context compaction | Agent prompt assembly | 不调用 LLM，不删除整轮消息；只在请求投影阶段改写 `tool result` 内容，例如旧结果替换为占位符、超大结果首尾保留截断 | 工具输出很长，但希望尽量保留对话结构和当前轮工具链路 |
+| Token tailoring | Model provider | 模型调用前按 token budget 删除或保留消息轮次，默认策略会保留系统消息和最新轮次 | 最后一层兜底，保证请求落入模型 context window |
+
+正常调用链路大致是：先由 agent 组装 prompt，并按需注入 summary、压缩
+`tool result`；如果开启了 summary 且压完后仍接近 context window，会在
+LLM 调用前同步尝试刷新一次 summary 并重建请求；最后模型层的 token
+tailoring 再按预算裁剪消息列表。也就是说，context compaction 和 token
+tailoring 都能减少 prompt 体积，但前者缩小消息内部的工具输出，后者删减
+消息轮次；summary 则是用新的语义摘要替代一段历史。
+
 ### 模式 1：启用摘要注入（推荐）
 
 ```go
@@ -703,7 +718,15 @@ agent := llmagent.New(
 
 > **提示**：如果你的场景是超长对话（数百轮），且希望旧摘要能被自然淘汰（被新的摘要替代），建议使用 `SessionSummaryInjectionUser` 模式。
 
-**可选：Prompt 侧上下文压缩**
+#### Context Compaction 细节
+
+Context compaction 不是 summary 的同义词，也不是 token tailoring。它只处理
+`tool result` 这种容易异常膨胀的内容，不会把普通 user/assistant 消息做
+LLM 摘要，也不会像 token tailoring 那样直接丢弃完整消息轮次。
+
+> **命名说明**：`WithEnableContextCompaction(true)` 中的 "compaction"
+> 指 prompt-side tool result compaction/pruning；如果需要语义摘要，仍然由
+> `WithAddSessionSummary(true)` 和会话摘要器负责。
 
 当开启 `WithEnableContextCompaction(true)` 时，框架会在真正调用模型前执行两遍压缩：
 
@@ -733,7 +756,7 @@ agent := llmagent.New(
     "my-agent",
     llmagent.WithModel(modelInstance),
     llmagent.WithAddSessionSummary(true),
-    llmagent.WithEnableContextCompaction(true),
+    llmagent.WithEnableContextCompaction(true), // 只压 tool result，不生成摘要
     llmagent.WithContextCompactionThresholdRatio(0.7),
     llmagent.WithContextCompactionToolResultMaxTokens(1024),  // Pass 1: 旧 tool result → 占位符
     llmagent.WithContextCompactionOversizedToolResultMaxTokens(8192),  // Pass 2: 任意超大 result → 首尾保留截断


### PR DESCRIPTION
Enhances documentation by detailing the three distinct context-reduction mechanisms: Summary, Context Compaction, and Token Tailoring. Each mechanism's purpose, usage, and operational layers are clearly defined to improve understanding of their roles in managing conversation context for LLM interactions. Additionally, clarifications on the functionality of context compaction and its separation from summary generation are included, ensuring users can effectively utilize these features.