### PR TITLE
openclaw: tighten post-tool autonomy prompt

### DIFF
--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -106,6 +106,39 @@ const (
 		"until you have performed the action and returned " +
 		"the resulting link, id, file marker, or exact " +
 		"blocker after recovery."
+	openClawPostToolPrompt = "[OpenClaw Tool Result Prompt] " +
+		"Treat tool results as mid-task state, not as " +
+		"permission to stop. Compare the latest tool result " +
+		"with the user's original/current request and keep " +
+		"working autonomously until the requested content, " +
+		"artifact, or external action is complete or blocked. " +
+		"If the request is complete, return the concrete " +
+		"user-facing result: link, id, file marker, sent " +
+		"status, created document title, scheduled job id, " +
+		"or the exact blocker. If work is still needed and " +
+		"an available tool can advance, verify, or recover " +
+		"the task, call that tool in the same assistant turn. " +
+		"Do not answer only with what you will do next. Do " +
+		"not stop at a plan, progress note, or tool-result " +
+		"summary when a next tool call is available. Do not " +
+		"ask for confirmation for an in-scope next step unless " +
+		"it is destructive, expensive, or genuinely ambiguous. " +
+		"Do not claim that a document, message, upload, " +
+		"schedule, file, wiki page, or external resource was " +
+		"created, sent, written, published, or updated unless " +
+		"the latest tool result proves it. If a tool failed " +
+		"or returned a partial result, recover with available " +
+		"tools when there is a clear path: corrected " +
+		"parameters, canonical ids, alternate lookup, retry, " +
+		"or verification. Only return a blocker when no safe " +
+		"next step remains. For files and media, return " +
+		"`MEDIA:` or `MEDIA_DIR:` lines only after the " +
+		"file or directory exists and is intended to be " +
+		"sent. For docs and iWiki, return the link, id, " +
+		"or title when available. " +
+		"Keep final answers concise and user-facing; avoid " +
+		"exposing tool/source/process details unless they are " +
+		"the exact result or blocker."
 	skillPreambleOnlyRule = "A preamble-only skill response is " +
 		"invalid. "
 	skillSameTurnToolRule = "If you say you will read, load, " +
@@ -2330,6 +2363,7 @@ func newAgent(
 			conversation.ProjectEventMessage,
 		),
 		llmagent.WithEnableParallelTools(cfg.EnableParallelTools),
+		llmagent.WithPostToolPrompt(openClawPostToolPrompt),
 	}
 	opts = append(opts, llmagent.WithSkills(repo))
 	opts = append(

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -224,6 +224,17 @@ func runAgentAndCapture(
 		agent.WithInvocationMessage(model.NewUserMessage("hi")),
 		agent.WithInvocationSession(sess),
 	)
+	return runInvocationAndCapture(t, agt, mdl, inv)
+}
+
+func runInvocationAndCapture(
+	t *testing.T,
+	agt agent.Agent,
+	mdl *captureRequestModel,
+	inv *agent.Invocation,
+) *model.Request {
+	t.Helper()
+
 	ch, err := agt.Run(context.Background(), inv)
 	require.NoError(t, err)
 	for evt := range ch {
@@ -1596,6 +1607,124 @@ func TestNewAgent_SkillsPrompt_DefaultsApplied(t *testing.T) {
 	require.NotContains(t, sys, "Skill tool availability:")
 	require.NotContains(t, sys, "Built-in skill execution tools are unavailable")
 	require.NotContains(t, sys, "Only describe a blocker")
+}
+
+func TestNewAgent_OpenClawPostToolPrompt_AppliedAfterToolResult(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	const (
+		userRequest = "write meeting notes to iWiki"
+		toolCallID  = "call_write_iwiki"
+		toolName    = "write_iwiki"
+		toolResult  = `{"status":"created","url":"https://iwiki.example/doc"}`
+	)
+
+	root := createAppTestSkill(t)
+	mdl := &captureRequestModel{}
+	agt, _, err := newAgent(mdl, agentConfig{
+		AppName:    "demo",
+		SkillsRoot: root,
+		StateDir:   t.TempDir(),
+	}, nil, nil)
+	require.NoError(t, err)
+
+	userMsg := model.NewUserMessage(userRequest)
+	inv := agent.NewInvocation(agent.WithInvocationMessage(userMsg))
+	sess := session.NewSession("demo", "user", "sess")
+	sess.Events = []event.Event{
+		*event.NewResponseEvent(
+			inv.InvocationID,
+			"user",
+			&model.Response{
+				Choices: []model.Choice{{
+					Message: userMsg,
+				}},
+			},
+		),
+		*event.NewResponseEvent(
+			inv.InvocationID,
+			defaultAgentName,
+			&model.Response{
+				Choices: []model.Choice{{
+					Message: model.Message{
+						Role: model.RoleAssistant,
+						ToolCalls: []model.ToolCall{{
+							Type: "function",
+							ID:   toolCallID,
+							Function: model.FunctionDefinitionParam{
+								Name: toolName,
+								Arguments: []byte(
+									`{"title":"notes"}`,
+								),
+							},
+						}},
+					},
+				}},
+			},
+		),
+		*event.NewResponseEvent(
+			inv.InvocationID,
+			defaultAgentName,
+			&model.Response{
+				Object: model.ObjectTypeToolResponse,
+				Choices: []model.Choice{{
+					Message: model.NewToolMessage(
+						toolCallID,
+						toolName,
+						toolResult,
+					),
+				}},
+			},
+		),
+	}
+	inv.Session = sess
+
+	req := runInvocationAndCapture(t, agt, mdl, inv)
+	system := joinSystemMessages(req)
+	require.Contains(t, system, openClawPostToolPrompt)
+	require.Contains(t, system, "same assistant turn")
+	require.Contains(
+		t,
+		system,
+		"Do not answer only with what you will do next.",
+	)
+	require.Contains(t, system, "Do not claim that a document")
+	require.Contains(
+		t,
+		system,
+		"Only return a blocker when no safe next step remains.",
+	)
+	require.Contains(t, system, "return `MEDIA:` or `MEDIA_DIR:` lines")
+	require.NotContains(t, system, "WECOM_FILE")
+	require.NotContains(t, system, "WECOM_MEDIA")
+	require.Contains(t, system, "For docs and iWiki")
+	require.NotContains(t, system, "Final Answer Requirement:")
+}
+
+func TestNewAgent_OpenClawPostToolPrompt_NotAppliedWithoutToolResult(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	root := createAppTestSkill(t)
+	mdl := &captureRequestModel{}
+	agt, _, err := newAgent(mdl, agentConfig{
+		AppName:    "demo",
+		SkillsRoot: root,
+		StateDir:   t.TempDir(),
+	}, nil, nil)
+	require.NoError(t, err)
+
+	req := runAgentAndCapture(
+		t,
+		agt,
+		mdl,
+		session.NewSession("demo", "user", "sess"),
+	)
+	system := joinSystemMessages(req)
+	require.NotContains(t, system, openClawPostToolPrompt)
 }
 
 func TestNewAgent_LocalExecKeepsExecCommandButOmitsWorkspaceExec(


### PR DESCRIPTION
## Summary

- add an OpenClaw-specific post-tool prompt that keeps driving tool-backed work until the requested artifact/action is complete or exactly blocked
- wire the prompt through `llmagent.WithPostToolPrompt` only for OpenClaw, leaving shared defaults unchanged
- add OpenClaw app tests for post-tool injection and non-injection on normal first requests

## Tests

- `git diff --check`
- `go test ./app ./internal/cron ./internal/octool ./internal/persona ./internal/subagentrun` from `openclaw/`
