### PR TITLE
{model/anthropic, docs}: add streamed tool call argument deltas

### DIFF
--- a/docs/mkdocs/en/model.md
+++ b/docs/mkdocs/en/model.md
@@ -2289,7 +2289,37 @@ model := anthropic.New("claude-3-5-sonnet",
 )
 ```
 
-For detailed explanations of the token calculation formula, tailoring strategy, and custom strategy implementation, please refer to [Token Tailoring under OpenAI Model](#3-token-tailoring).
+For detailed explanations of the token calculation formula, tailoring strategy, and custom strategy implementation, please refer to [Token Tailoring under OpenAI Model](#7-token-tailoring).
+
+#### 5. Streaming Tool Call Deltas: ShowToolCallDelta
+
+By default, the Anthropic adapter accumulates tool-call arguments internally and returns the complete arguments once the model finishes the tool call, through `Response.Choices[0].Message.ToolCalls` in the final response.
+
+`WithShowToolCallDelta` exposes Anthropic `input_json_delta` chunks during streaming. Enable this option when tool arguments are long, or when the frontend needs to display argument generation progress:
+
+```go
+llm := anthropic.New(
+    "claude-sonnet-4-0",
+    anthropic.WithShowToolCallDelta(true),
+)
+```
+
+When `WithShowToolCallDelta(true)` is enabled:
+
+- Streaming responses may include `Response.Choices[0].Delta.ToolCalls`.
+- `Delta.ToolCalls[*].Function.Arguments` is the newly produced argument string fragment, and is usually not complete JSON.
+- `Delta.ToolCalls[*].ID` and `Index` can be used to join fragments for the same tool call.
+- The final response still returns the complete tool call in `Response.Choices[0].Message.ToolCalls`, so existing tool execution logic can continue to use the final response unchanged.
+
+Typical handling pattern:
+
+1. Read `Response.Choices[0].Delta.ToolCalls[*].Function.Arguments` on each
+   partial response.
+2. Group chunks by tool call `ID` or `Index`, and append the `Arguments`
+   fragments in order.
+3. Treat the accumulated value as the tool argument JSON. For progressive
+   rendering, render the string as it grows and unmarshal it only after it
+   becomes valid JSON.
 
 ## Provider
 

--- a/docs/mkdocs/zh/model.md
+++ b/docs/mkdocs/zh/model.md
@@ -2275,7 +2275,34 @@ model := anthropic.New("claude-3-5-sonnet",
 )
 ```
 
-关于 Token 计算公式、裁剪策略和自定义策略的详细说明，请参考 [OpenAI Model 的 Token 裁剪部分](#6-token-裁剪token-tailoring)。
+关于 Token 计算公式、裁剪策略和自定义策略的详细说明，请参考 [OpenAI Model 的 Token 裁剪部分](#7-token-token-tailoring)。
+
+#### 5. 流式工具调用增量：ShowToolCallDelta
+
+默认情况下，Anthropic 适配层会先在内部累积工具调用参数，等模型完成这次工具调用后，再通过最终响应的 `Response.Choices[0].Message.ToolCalls` 一次性返回完整参数。
+
+`WithShowToolCallDelta` 用于在流式阶段透出 Anthropic 的 `input_json_delta` 分片。工具参数较长，或前端需要展示参数生成过程时，可以开启这个选项：
+
+```go
+llm := anthropic.New(
+    "claude-sonnet-4-0",
+    anthropic.WithShowToolCallDelta(true),
+)
+```
+
+当启用 `WithShowToolCallDelta(true)` 时：
+
+- 流式响应中会出现 `Response.Choices[0].Delta.ToolCalls`；
+- `Delta.ToolCalls[*].Function.Arguments` 是本次新增的参数字符串片段，通常不是完整 JSON；
+- `Delta.ToolCalls[*].ID` 和 `Index` 可用于把同一个工具调用的多个片段串起来；
+- 最终响应仍然会在 `Response.Choices[0].Message.ToolCalls` 中返回完整工具调用，原有工具执行链路可以继续复用。
+
+典型处理方式：
+
+1. 在每个部分响应中读取
+   `Response.Choices[0].Delta.ToolCalls[*].Function.Arguments`；
+2. 按工具调用 `ID` 或 `Index` 分组，并按顺序追加 `Arguments` 片段；
+3. 将累积后的字符串作为 JSON 参数处理；边生成边展示的场景可以先按字符串渲染，等它构成合法 JSON 后再反序列化。
 
 ## Provider
 

--- a/model/anthropic/anthropic.go
+++ b/model/anthropic/anthropic.go
@@ -68,6 +68,7 @@ type Model struct {
 	cacheSystemPrompt bool
 	cacheTools        bool
 	cacheMessages     bool
+	showToolCallDelta bool
 }
 
 // New creates a new Anthropic model adapter.
@@ -116,6 +117,7 @@ func New(name string, opts ...Option) *Model {
 		cacheSystemPrompt:          o.cacheSystemPrompt,
 		cacheTools:                 o.cacheTools,
 		cacheMessages:              o.cacheMessages,
+		showToolCallDelta:          o.showToolCallDelta,
 	}
 }
 
@@ -586,7 +588,7 @@ loop:
 		}
 		m.runChatChunkCallback(ctx, &chatRequest, &chunk)
 		// Build partial response.
-		response, err := buildStreamingPartialResponse(acc.Message(), chunk)
+		response, err := buildStreamingPartialResponse(acc.Message(), chunk, m.showToolCallDelta)
 		if err != nil {
 			streamErr = err
 			break
@@ -771,7 +773,8 @@ func refreshContentBlockRawJSON(block *anthropic.ContentBlockUnion) error {
 // buildStreamingPartialResponse builds a partial streaming response for a chunk.
 // Returns nil if the chunk should be skipped.
 func buildStreamingPartialResponse(acc anthropic.Message,
-	chunk anthropic.MessageStreamEventUnion) (*model.Response, error) {
+	chunk anthropic.MessageStreamEventUnion,
+	showToolCallDelta bool) (*model.Response, error) {
 	now := time.Now()
 	response := &model.Response{
 		ID:        acc.ID,
@@ -801,6 +804,17 @@ func buildStreamingPartialResponse(acc anthropic.Message,
 				return nil, nil
 			}
 			response.Choices[0].Delta.ReasoningContent = delta.Thinking
+		case anthropic.InputJSONDelta:
+			if !showToolCallDelta || delta.PartialJSON == "" {
+				return nil, nil
+			}
+			block, index, ok := streamingToolCallTarget(acc, event.Index)
+			if !ok {
+				return nil, nil
+			}
+			response.Choices[0].Delta.ToolCalls = []model.ToolCall{
+				buildStreamingToolCallDelta(block, index, delta.PartialJSON),
+			}
 		default:
 			return nil, nil
 		}
@@ -814,6 +828,41 @@ func buildStreamingPartialResponse(acc anthropic.Message,
 		return nil, nil
 	}
 	return response, nil
+}
+
+func buildStreamingToolCallDelta(
+	block anthropic.ToolUseBlock,
+	index int,
+	partialJSON string,
+) model.ToolCall {
+	return model.ToolCall{
+		Index: &index,
+		ID:    block.ID,
+		Type:  functionToolType,
+		Function: model.FunctionDefinitionParam{
+			Name:      block.Name,
+			Arguments: []byte(partialJSON),
+		},
+	}
+}
+
+func streamingToolCallTarget(acc anthropic.Message, contentBlockIndex int64) (anthropic.ToolUseBlock, int, bool) {
+	index := int(contentBlockIndex)
+	if index < 0 || index >= len(acc.Content) {
+		return anthropic.ToolUseBlock{}, 0, false
+	}
+	toolCallIndex := 0
+	for i := 0; i <= index; i++ {
+		block, ok := acc.Content[i].AsAny().(anthropic.ToolUseBlock)
+		if !ok {
+			continue
+		}
+		if i == index {
+			return block, toolCallIndex, true
+		}
+		toolCallIndex++
+	}
+	return anthropic.ToolUseBlock{}, 0, false
 }
 
 // buildStreamingFinalResponse builds a final streaming response from the accumulator.

--- a/model/anthropic/anthropic_test.go
+++ b/model/anthropic/anthropic_test.go
@@ -631,54 +631,104 @@ func Test_buildStreamingPartialResponse_TextAndThinkingAndStop(t *testing.T) {
 
 	// Text delta empty -> skip.
 	e1 := anthropicStreamEvent("content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":""}}`)
-	resp, err := buildStreamingPartialResponse(acc, e1)
+	resp, err := buildStreamingPartialResponse(acc, e1, false)
 	assert.NoError(t, err)
 	assert.Nil(t, resp)
 
 	// Text delta non-empty -> content delta.
 	e2 := anthropicStreamEvent("content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"abc"}}`)
-	resp, err = buildStreamingPartialResponse(acc, e2)
+	resp, err = buildStreamingPartialResponse(acc, e2, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, "abc", resp.Choices[0].Delta.Content)
 
 	// Thinking delta non-empty -> reasoning delta.
 	e3 := anthropicStreamEvent("content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"think"}}`)
-	resp, err = buildStreamingPartialResponse(acc, e3)
+	resp, err = buildStreamingPartialResponse(acc, e3, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, "think", resp.Choices[0].Delta.ReasoningContent)
 
 	// Message delta with stop_reason -> finish reason set.
 	e4 := anthropicStreamEvent("message_delta", `{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":""},"usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":0,"output_tokens":0,"server_tool_use":{"web_search_requests":0}}}`)
-	resp, err = buildStreamingPartialResponse(acc, e4)
+	resp, err = buildStreamingPartialResponse(acc, e4, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.NotNil(t, resp.Choices[0].FinishReason)
 
 	// Unknown type should be skipped.
 	e5 := anthropicStreamEvent("unknown", `{"type":"unknown"}`)
-	resp, err = buildStreamingPartialResponse(acc, e5)
+	resp, err = buildStreamingPartialResponse(acc, e5, false)
 	assert.NoError(t, err)
 	assert.Nil(t, resp)
 
 	// Content block delta with input_json_delta should be skipped.
 	e6 := anthropicStreamEvent("content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{}"}}`)
-	resp, err = buildStreamingPartialResponse(acc, e6)
+	acc.Content = []anthropic.ContentBlockUnion{
+		anthropicContentUnion("tool_use", `{"type":"tool_use","id":"id1","name":"fn","input":{}}`),
+	}
+	resp, err = buildStreamingPartialResponse(acc, e6, false)
+	assert.NoError(t, err)
+	assert.Nil(t, resp)
+
+	// Content block delta with input_json_delta should be emitted when enabled.
+	resp, err = buildStreamingPartialResponse(acc, e6, true)
+	assert.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Len(t, resp.Choices[0].Delta.ToolCalls, 1)
+	assert.Equal(t, "id1", resp.Choices[0].Delta.ToolCalls[0].ID)
+	assert.Equal(t, "fn", resp.Choices[0].Delta.ToolCalls[0].Function.Name)
+	assert.Equal(t, "{}", string(resp.Choices[0].Delta.ToolCalls[0].Function.Arguments))
+	require.NotNil(t, resp.Choices[0].Delta.ToolCalls[0].Index)
+	assert.Equal(t, 0, *resp.Choices[0].Delta.ToolCalls[0].Index)
+
+	// Input JSON delta without a resolved tool_use block should be skipped.
+	acc.Content = []anthropic.ContentBlockUnion{
+		anthropicContentUnion("text", `{"type":"text","text":"not a tool"}`),
+	}
+	resp, err = buildStreamingPartialResponse(acc, e6, true)
+	assert.NoError(t, err)
+	assert.Nil(t, resp)
+	e6OutOfRange := anthropicStreamEvent("content_block_delta", `{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{}"}}`)
+	resp, err = buildStreamingPartialResponse(acc, e6OutOfRange, true)
 	assert.NoError(t, err)
 	assert.Nil(t, resp)
 
 	// Thinking delta empty should be skipped.
 	e7 := anthropicStreamEvent("content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":""}}`)
-	resp, err = buildStreamingPartialResponse(acc, e7)
+	resp, err = buildStreamingPartialResponse(acc, e7, false)
 	assert.NoError(t, err)
 	assert.Nil(t, resp)
 
 	// Message delta with empty stop_reason should be skipped.
 	e8 := anthropicStreamEvent("message_delta", `{"type":"message_delta","delta":{"stop_reason":"","stop_sequence":""},"usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":0,"output_tokens":0,"server_tool_use":{"web_search_requests":0}}}`)
-	resp, err = buildStreamingPartialResponse(acc, e8)
+	resp, err = buildStreamingPartialResponse(acc, e8, false)
 	assert.NoError(t, err)
 	assert.Nil(t, resp)
+}
+
+func Test_buildStreamingPartialResponse_ToolCallDeltaIndexUsesToolCallOrdinal(t *testing.T) {
+	acc := anthropic.Message{
+		ID:    "acc1",
+		Model: anthropic.Model("claude-test"),
+		Content: []anthropic.ContentBlockUnion{
+			anthropicContentUnion("text", `{"type":"text","text":"before"}`),
+			anthropicContentUnion("tool_use", `{"type":"tool_use","id":"id1","name":"fn","input":{}}`),
+		},
+	}
+	event := anthropicStreamEvent(
+		"content_block_delta",
+		`{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"a\":1}"}}`,
+	)
+	resp, err := buildStreamingPartialResponse(acc, event, true)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Len(t, resp.Choices[0].Delta.ToolCalls, 1)
+	require.NotNil(t, resp.Choices[0].Delta.ToolCalls[0].Index)
+	assert.Equal(t, 0, *resp.Choices[0].Delta.ToolCalls[0].Index)
+	assert.Equal(t, "id1", resp.Choices[0].Delta.ToolCalls[0].ID)
+	assert.Equal(t, "fn", resp.Choices[0].Delta.ToolCalls[0].Function.Name)
+	assert.Equal(t, `{"a":1}`, string(resp.Choices[0].Delta.ToolCalls[0].Function.Arguments))
 }
 
 func Test_buildStreamingFinalResponse_Aggregation(t *testing.T) {
@@ -1212,6 +1262,7 @@ func Test_HandleStreamingResponse_ToolInputDeltaOverridesStartInput(t *testing.T
 	m := New(
 		"claude-test",
 		WithHTTPClientOptions(),
+		WithShowToolCallDelta(true),
 		WithChatStreamCompleteCallback(func(_ context.Context, _ *anthropic.MessageNewParams, acc *anthropic.Message, err error) {
 			assert.NoError(t, err)
 			callbackAcc = acc
@@ -1224,11 +1275,20 @@ func Test_HandleStreamingResponse_ToolInputDeltaOverridesStartInput(t *testing.T
 	})
 	require.NoError(t, err)
 	var final *model.Response
+	var toolCallDeltas []model.ToolCall
 	for resp := range ch {
+		if len(resp.Choices) > 0 {
+			toolCallDeltas = append(toolCallDeltas, resp.Choices[0].Delta.ToolCalls...)
+		}
 		if resp.Done {
 			final = resp
 		}
 	}
+	require.Len(t, toolCallDeltas, 2)
+	assert.Equal(t, "toolu_1", toolCallDeltas[0].ID)
+	assert.Equal(t, "lookup", toolCallDeltas[0].Function.Name)
+	assert.Equal(t, `{"a":1,`, string(toolCallDeltas[0].Function.Arguments))
+	assert.Equal(t, `"b":2}`, string(toolCallDeltas[1].Function.Arguments))
 	require.NotNil(t, final)
 	require.Nil(t, final.Error)
 	require.Len(t, final.Choices, 1)
@@ -1244,6 +1304,63 @@ func Test_HandleStreamingResponse_ToolInputDeltaOverridesStartInput(t *testing.T
 	toolUse, ok := callbackAcc.Content[0].AsAny().(anthropic.ToolUseBlock)
 	require.True(t, ok)
 	assert.JSONEq(t, `{"a":1,"b":2}`, string(toolUse.Input))
+}
+
+func Test_HandleStreamingResponse_ToolInputDeltaHiddenByDefault(t *testing.T) {
+	sse := strings.Join([]string{
+		"event: message_start",
+		`data: {"type":"message_start","message":{"id":"msg_sse_tool_1","type":"message","role":"assistant","model":"claude-3-sonnet","content":[],"usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":3,"output_tokens":0,"server_tool_use":{"web_search_requests":0}}}}`,
+		"",
+		"event: content_block_start",
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"lookup","input":{"a":1}}}`,
+		"",
+		"event: content_block_delta",
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"a\":1,"}}`,
+		"",
+		"event: content_block_delta",
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"b\":2}"}}`,
+		"",
+		"event: content_block_stop",
+		`data: {"type":"content_block_stop","index":0}`,
+		"",
+		"event: message_delta",
+		`data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":""},"usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":3,"output_tokens":5,"server_tool_use":{"web_search_requests":0}}}`,
+		"",
+		"event: message_stop",
+		`data: {"type":"message_stop"}`,
+		"",
+	}, "\n")
+	orig := model.DefaultNewHTTPClient
+	t.Cleanup(func() { model.DefaultNewHTTPClient = orig })
+	model.DefaultNewHTTPClient = func(_ ...HTTPClientOption) model.HTTPClient {
+		return &http.Client{Transport: rtFunc(func(r *http.Request) (*http.Response, error) {
+			h := make(http.Header)
+			h.Set("Content-Type", "text/event-stream")
+			return &http.Response{StatusCode: 200, Header: h, Body: io.NopCloser(strings.NewReader(sse))}, nil
+		})}
+	}
+	m := New("claude-test", WithHTTPClientOptions())
+	ch, err := m.GenerateContent(context.Background(), &model.Request{
+		Messages:         []model.Message{model.NewUserMessage("U")},
+		GenerationConfig: model.GenerationConfig{Stream: true},
+	})
+	require.NoError(t, err)
+	var final *model.Response
+	var toolCallDeltas []model.ToolCall
+	for resp := range ch {
+		if len(resp.Choices) > 0 {
+			toolCallDeltas = append(toolCallDeltas, resp.Choices[0].Delta.ToolCalls...)
+		}
+		if resp.Done {
+			final = resp
+		}
+	}
+	assert.Empty(t, toolCallDeltas)
+	require.NotNil(t, final)
+	require.Nil(t, final.Error)
+	require.Len(t, final.Choices, 1)
+	require.Len(t, final.Choices[0].Message.ToolCalls, 1)
+	assert.JSONEq(t, `{"a":1,"b":2}`, string(final.Choices[0].Message.ToolCalls[0].Function.Arguments))
 }
 
 func Test_HandleStreamingResponse_ToolInputPreservesStartInputWithoutDelta(t *testing.T) {

--- a/model/anthropic/options.go
+++ b/model/anthropic/options.go
@@ -97,6 +97,9 @@ type options struct {
 	// When enabled, cache control will be applied to the last assistant message
 	// to maximize cache reuse in subsequent turns.
 	cacheMessages bool
+	// showToolCallDelta controls whether to expose tool call argument deltas in
+	// streaming responses.
+	showToolCallDelta bool
 }
 
 var (
@@ -203,6 +206,16 @@ func WithChatChunkCallback(fn ChatChunkCallbackFunc) Option {
 func WithChatStreamCompleteCallback(fn ChatStreamCompleteCallbackFunc) Option {
 	return func(opts *options) {
 		opts.chatStreamCompleteCallback = fn
+	}
+}
+
+// WithShowToolCallDelta controls whether to expose tool call argument deltas in
+// streaming responses. When enabled, input_json_delta chunks from Anthropic will
+// be forwarded via Response.Choices[].Delta.ToolCalls so callers can reconstruct
+// arguments incrementally.
+func WithShowToolCallDelta(show bool) Option {
+	return func(opts *options) {
+		opts.showToolCallDelta = show
 	}
 }
 

--- a/model/anthropic/options_test.go
+++ b/model/anthropic/options_test.go
@@ -147,3 +147,13 @@ func TestWithTokenCounter_Nil(t *testing.T) {
 	WithTokenCounter(nil)(&opt)
 	assert.NotNil(t, opt.tokenCounter, "tokenCounter is nil")
 }
+
+func TestWithShowToolCallDelta(t *testing.T) {
+	opt := defaultOptions
+	WithShowToolCallDelta(true)(&opt)
+	assert.True(t, opt.showToolCallDelta)
+
+	opt = defaultOptions
+	WithShowToolCallDelta(false)(&opt)
+	assert.False(t, opt.showToolCallDelta)
+}


### PR DESCRIPTION
Adds an opt-in Anthropic model option that forwards streamed input_json_delta tool argument chunks through Delta.ToolCalls while preserving the existing final aggregated Message.ToolCalls behavior, and documents how to consume those partial arguments.