### PR TITLE
WIP: openclaw: add scoped MCP registry tools

### DIFF
--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -337,6 +337,15 @@ const (
 		"at that exact path. Prefer already installed local tools " +
 		"for OCR, PDF, audio, image, and video work before " +
 		"trying package installs or long downloads. " +
+		"When the user asks whether an MCP server exists, " +
+		"lists MCP capability, or configures an MCP endpoint, " +
+		"use mcp_registry_list or mcp_registry_add when those " +
+		"tools are available before saying no MCP is configured. " +
+		"After adding an MCP registry entry, inspect it with " +
+		"mcp_list_tools before using mcp_call. Do not hand-write " +
+		"mcporter config files when registry tools are available, " +
+		"and never expose MCP tokens, API keys, cookies, or " +
+		"authorization headers in replies. " +
 		"When creating a cron job from chat, omit channel and " +
 		"target to send results back to the current chat by " +
 		"default. When adding cron jobs, write the stored task " +

--- a/openclaw/app/mcp_registry_provider.go
+++ b/openclaw/app/mcp_registry_provider.go
@@ -1,0 +1,70 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package app
+
+import (
+	"context"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/mcpregistry"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/registry"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+	"trpc.group/trpc-go/trpc-agent-go/tool/mcp"
+	"trpc.group/trpc-go/trpc-agent-go/tool/mcpbroker"
+)
+
+const toolProviderMCPRegistry = "mcp_registry"
+
+type mcpRegistryProviderConfig struct {
+	Dir            string `yaml:"dir,omitempty"`
+	AllowAdHocHTTP bool   `yaml:"allow_adhoc_http,omitempty"`
+}
+
+func init() {
+	must(registry.RegisterToolProvider(
+		toolProviderMCPRegistry,
+		newMCPRegistryTools,
+	))
+}
+
+func newMCPRegistryTools(
+	deps registry.ToolProviderDeps,
+	spec registry.PluginSpec,
+) ([]tool.Tool, error) {
+	var cfg mcpRegistryProviderConfig
+	if err := registry.DecodeStrict(spec.Config, &cfg); err != nil {
+		return nil, err
+	}
+
+	dir := strings.TrimSpace(cfg.Dir)
+	if dir == "" {
+		dir = mcpregistry.DefaultDir(deps.StateDir)
+	}
+	store := mcpregistry.NewFileStore(dir)
+	broker := mcpbroker.New(
+		mcpbroker.WithAllowAdHocHTTP(cfg.AllowAdHocHTTP),
+		mcpbroker.WithServerResolver(func(
+			ctx context.Context,
+		) (map[string]mcp.ConnectionConfig, error) {
+			runtime, err := mcpregistry.RuntimeContextFromContext(
+				ctx,
+				deps.AppName,
+			)
+			if err != nil {
+				return nil, err
+			}
+			return store.ServerConfigs(ctx, runtime)
+		}),
+	)
+
+	tools := mcpregistry.NewTools(store, deps.AppName)
+	tools = append(tools, broker.Tools()...)
+	return tools, nil
+}

--- a/openclaw/app/tooling_builtins_test.go
+++ b/openclaw/app/tooling_builtins_test.go
@@ -113,6 +113,31 @@ profiles:
 	require.Equal(t, "browser", tools[0].Declaration().Name)
 }
 
+func TestNewMCPRegistryTools_Succeeds(t *testing.T) {
+	t.Parallel()
+
+	cfg := yamlNode(t, `
+allow_adhoc_http: true
+`)
+	tools, err := newMCPRegistryTools(
+		registry.ToolProviderDeps{
+			AppName:  "app",
+			StateDir: t.TempDir(),
+		},
+		registry.PluginSpec{Config: cfg},
+	)
+	require.NoError(t, err)
+
+	names := make(map[string]bool, len(tools))
+	for _, tl := range tools {
+		names[tl.Declaration().Name] = true
+	}
+	require.True(t, names["mcp_registry_add"])
+	require.True(t, names["mcp_registry_list"])
+	require.True(t, names["mcp_list_servers"])
+	require.True(t, names["mcp_call"])
+}
+
 func TestNewBrowserTools_ErrorPaths(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/app/tooling_builtins_test.go
+++ b/openclaw/app/tooling_builtins_test.go
@@ -192,6 +192,8 @@ func TestNewMCPRegistryTools_CallsRegistryAndBroker(t *testing.T) {
 	listJSON, err := json.Marshal(listOut)
 	require.NoError(t, err)
 	require.Contains(t, string(listJSON), "docs")
+	require.NotContains(t, string(listJSON), "secret")
+	require.NotContains(t, string(listJSON), "token=")
 }
 
 func TestNewBrowserTools_ErrorPaths(t *testing.T) {

--- a/openclaw/app/tooling_builtins_test.go
+++ b/openclaw/app/tooling_builtins_test.go
@@ -11,6 +11,7 @@ package app
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -21,11 +22,17 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/conversation"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/mcpregistry"
+	"trpc.group/trpc-go/trpc-agent-go/session"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 	"trpc.group/trpc-go/trpc-agent-go/tool/mcp"
 
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/registry"
 )
+
+const appMCPListServersTool = "mcp_list_servers"
 
 func TestNewHTTPWebFetchTools_RequiresAllowlist(t *testing.T) {
 	t.Parallel()
@@ -136,6 +143,55 @@ allow_adhoc_http: true
 	require.True(t, names["mcp_registry_list"])
 	require.True(t, names["mcp_list_servers"])
 	require.True(t, names["mcp_call"])
+}
+
+func TestNewMCPRegistryTools_InvalidConfigFails(t *testing.T) {
+	t.Parallel()
+
+	_, err := newMCPRegistryTools(
+		registry.ToolProviderDeps{},
+		registry.PluginSpec{
+			Config: yamlNode(t, "unknown_field: true\n"),
+		},
+	)
+	require.Error(t, err)
+}
+
+func TestNewMCPRegistryTools_CallsRegistryAndBroker(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfg := yamlNode(
+		t,
+		"dir: \""+dir+"\"\nallow_adhoc_http: true\n",
+	)
+	tools, err := newMCPRegistryTools(
+		registry.ToolProviderDeps{
+			AppName:  "app",
+			StateDir: t.TempDir(),
+		},
+		registry.PluginSpec{Config: cfg},
+	)
+	require.NoError(t, err)
+
+	ctx := mcpRegistryInvocationContext("app")
+	addTool := callableToolByName(t, tools, mcpregistry.ToolAdd)
+	addOut, err := addTool.Call(ctx, []byte(
+		`{"name":"docs","scope":"chat",`+
+			`"server_url":"https://example.com/mcp?token=secret"}`,
+	))
+	require.NoError(t, err)
+	addJSON, err := json.Marshal(addOut)
+	require.NoError(t, err)
+	require.Contains(t, string(addJSON), "docs")
+	require.NotContains(t, string(addJSON), "secret")
+
+	listTool := callableToolByName(t, tools, appMCPListServersTool)
+	listOut, err := listTool.Call(ctx, []byte(`{}`))
+	require.NoError(t, err)
+	listJSON, err := json.Marshal(listOut)
+	require.NoError(t, err)
+	require.Contains(t, string(listJSON), "docs")
 }
 
 func TestNewBrowserTools_ErrorPaths(t *testing.T) {
@@ -661,6 +717,44 @@ func toolNames(tools []tool.Tool) map[string]struct{} {
 		out[t.Declaration().Name] = struct{}{}
 	}
 	return out
+}
+
+func callableToolByName(
+	t *testing.T,
+	tools []tool.Tool,
+	name string,
+) tool.CallableTool {
+	t.Helper()
+
+	for _, tl := range tools {
+		if tl.Declaration().Name != name {
+			continue
+		}
+		callable, ok := tl.(tool.CallableTool)
+		require.True(t, ok)
+		return callable
+	}
+	t.Fatalf("tool %q not found", name)
+	return nil
+}
+
+func mcpRegistryInvocationContext(appName string) context.Context {
+	inv := &agent.Invocation{
+		Session: &session.Session{
+			AppName: appName,
+			ID:      "session-1",
+			UserID:  "user-1",
+		},
+		RunOptions: agent.RunOptions{
+			RuntimeState: conversation.RuntimeState(
+				conversation.Annotation{
+					StorageUserID: "chat-storage-1",
+					ChatID:        "chat-1",
+				},
+			),
+		},
+	}
+	return agent.NewInvocationContext(context.Background(), inv)
 }
 
 func indentYAML(body string, spaces int) string {

--- a/openclaw/conversation/annotation.go
+++ b/openclaw/conversation/annotation.go
@@ -20,6 +20,7 @@ import (
 type Annotation struct {
 	HistoryMode   string            `json:"history_mode,omitempty"`
 	StorageUserID string            `json:"storage_user_id,omitempty"`
+	ChatID        string            `json:"chat_id,omitempty"`
 	ActorID       string            `json:"actor_id,omitempty"`
 	ActorLabel    string            `json:"actor_label,omitempty"`
 	ActorLabels   map[string]string `json:"actor_labels,omitempty"`
@@ -153,6 +154,7 @@ func decodeAnnotation(
 func isZeroRuntimeAnnotation(annotation Annotation) bool {
 	return strings.TrimSpace(annotation.HistoryMode) == "" &&
 		strings.TrimSpace(annotation.StorageUserID) == "" &&
+		strings.TrimSpace(annotation.ChatID) == "" &&
 		strings.TrimSpace(annotation.ActorID) == "" &&
 		strings.TrimSpace(annotation.ActorLabel) == "" &&
 		len(annotation.ActorLabels) == 0 &&
@@ -166,6 +168,7 @@ func normalizeAnnotation(annotation Annotation) Annotation {
 	annotation.StorageUserID = strings.TrimSpace(
 		annotation.StorageUserID,
 	)
+	annotation.ChatID = strings.TrimSpace(annotation.ChatID)
 	annotation.ActorID = strings.TrimSpace(annotation.ActorID)
 	annotation.ActorLabel = strings.TrimSpace(
 		annotation.ActorLabel,

--- a/openclaw/mcpregistry/context.go
+++ b/openclaw/mcpregistry/context.go
@@ -1,0 +1,48 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package mcpregistry
+
+import (
+	"context"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/conversation"
+)
+
+// RuntimeContextFromContext extracts MCP scope context from the current
+// agent invocation.
+func RuntimeContextFromContext(
+	ctx context.Context,
+	fallbackAppName string,
+) (RuntimeContext, error) {
+	inv, ok := agent.InvocationFromContext(ctx)
+	if !ok || inv == nil || inv.Session == nil {
+		return RuntimeContext{}, errRegistryContextUnavailable
+	}
+
+	runtime := RuntimeContext{
+		AppName:   strings.TrimSpace(inv.Session.AppName),
+		SessionID: strings.TrimSpace(inv.Session.ID),
+		UserID:    strings.TrimSpace(inv.Session.UserID),
+	}
+	if runtime.AppName == "" {
+		runtime.AppName = strings.TrimSpace(fallbackAppName)
+	}
+
+	annotation, ok := conversation.AnnotationFromRuntimeState(
+		inv.RunOptions.RuntimeState,
+	)
+	if ok {
+		runtime.StorageUserID = strings.TrimSpace(annotation.StorageUserID)
+		runtime.ChatID = strings.TrimSpace(annotation.ChatID)
+	}
+	return runtime, nil
+}

--- a/openclaw/mcpregistry/store.go
+++ b/openclaw/mcpregistry/store.go
@@ -1,0 +1,745 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package mcpregistry stores scoped MCP server registrations for OpenClaw.
+package mcpregistry
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/tool/mcp"
+)
+
+const (
+	// ScopeSession makes one MCP server visible only to the current session.
+	ScopeSession Scope = "session"
+	// ScopeChat makes one MCP server visible in the current chat container.
+	ScopeChat Scope = "chat"
+	// ScopeUser makes one MCP server visible to the current actor.
+	ScopeUser Scope = "user"
+	// ScopeWorkspace makes one MCP server visible to the current workspace.
+	ScopeWorkspace Scope = "workspace"
+	// ScopeGlobal makes one MCP server visible to the whole OpenClaw instance.
+	ScopeGlobal Scope = "global"
+
+	defaultRegistryFileName = "registry.json"
+	defaultSecretsFileName  = "secrets.json"
+
+	secretRedaction = "***"
+
+	scopeKeyGlobal = "global"
+
+	transportStdio      = "stdio"
+	transportSSE        = "sse"
+	transportStreamable = "streamable"
+	transportHTTP       = "http"
+	transportHTTPAlt    = "streamable_http"
+)
+
+var (
+	errRegistryContextUnavailable = errors.New(
+		"mcp registry context is unavailable",
+	)
+	errRegistryEntryNotFound = errors.New("mcp registry entry not found")
+)
+
+var sensitiveHeaderNames = map[string]struct{}{
+	"authorization":       {},
+	"cookie":              {},
+	"proxy-authorization": {},
+	"set-cookie":          {},
+	"x-api-key":           {},
+}
+
+var sensitiveQueryHints = []string{
+	"api_key",
+	"apikey",
+	"auth",
+	"credential",
+	"key",
+	"password",
+	"secret",
+	"token",
+}
+
+// Scope identifies where one MCP server registration is visible.
+type Scope string
+
+// RuntimeContext describes the current OpenClaw turn for scope resolution.
+type RuntimeContext struct {
+	AppName       string
+	SessionID     string
+	UserID        string
+	StorageUserID string
+	ChatID        string
+	WorkspaceID   string
+}
+
+// Entry is one persisted MCP server registration.
+type Entry struct {
+	ID                 string               `json:"id"`
+	Name               string               `json:"name"`
+	Scope              Scope                `json:"scope"`
+	ScopeKey           string               `json:"scope_key"`
+	Description        string               `json:"description,omitempty"`
+	Connection         mcp.ConnectionConfig `json:"connection"`
+	HasSensitiveValues bool                 `json:"has_sensitive_values"`
+	CreatedAt          time.Time            `json:"created_at"`
+	UpdatedAt          time.Time            `json:"updated_at"`
+}
+
+// EntryView is the safe model-facing view of one registry entry.
+type EntryView struct {
+	Name               string `json:"name"`
+	Scope              Scope  `json:"scope"`
+	Description        string `json:"description,omitempty"`
+	Selector           string `json:"selector"`
+	QualifiedSelector  string `json:"qualified_selector"`
+	Transport          string `json:"transport"`
+	ServerURL          string `json:"server_url,omitempty"`
+	Command            string `json:"command,omitempty"`
+	HasSensitiveValues bool   `json:"has_sensitive_values"`
+	UpdatedAt          string `json:"updated_at,omitempty"`
+}
+
+// UpsertRequest stores one MCP server registration.
+type UpsertRequest struct {
+	Context     RuntimeContext
+	Name        string
+	Scope       Scope
+	Description string
+	Connection  mcp.ConnectionConfig
+	UpdateOnly  bool
+	AllowUpdate bool
+}
+
+// DeleteRequest removes one MCP server registration from the current scope.
+type DeleteRequest struct {
+	Context RuntimeContext
+	Name    string
+	Scope   Scope
+}
+
+// FileStore persists registry metadata and raw sensitive connection values.
+type FileStore struct {
+	mu           sync.Mutex
+	registryPath string
+	secretsPath  string
+	now          func() time.Time
+}
+
+type registryState struct {
+	Entries []Entry `json:"entries"`
+}
+
+type secretState struct {
+	Connections map[string]mcp.ConnectionConfig `json:"connections,omitempty"`
+}
+
+// DefaultDir returns the default registry directory under stateDir.
+func DefaultDir(stateDir string) string {
+	return filepath.Join(strings.TrimSpace(stateDir), "mcp")
+}
+
+// NewFileStore creates a JSON-backed MCP registry store.
+func NewFileStore(dir string) *FileStore {
+	dir = strings.TrimSpace(dir)
+	return &FileStore{
+		registryPath: filepath.Join(dir, defaultRegistryFileName),
+		secretsPath:  filepath.Join(dir, defaultSecretsFileName),
+		now:          time.Now,
+	}
+}
+
+// Upsert creates or updates one scoped MCP server registration.
+func (s *FileStore) Upsert(
+	ctx context.Context,
+	req UpsertRequest,
+) (EntryView, error) {
+	if s == nil {
+		return EntryView{}, errors.New("mcp registry store is nil")
+	}
+	name, err := normalizeName(req.Name)
+	if err != nil {
+		return EntryView{}, err
+	}
+	scope, scopeKey, err := resolveScope(req.Scope, req.Context)
+	if err != nil {
+		return EntryView{}, err
+	}
+	conn, err := normalizeConnection(req.Connection)
+	if err != nil {
+		return EntryView{}, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	state, secrets, err := s.loadLocked(ctx)
+	if err != nil {
+		return EntryView{}, err
+	}
+
+	now := s.now().UTC()
+	id := entryID(scope, scopeKey, name)
+	index := findEntryIndex(state.Entries, id)
+	if req.UpdateOnly && index < 0 {
+		return EntryView{}, fmt.Errorf(
+			"mcp_registry_update: %w: %s",
+			errRegistryEntryNotFound,
+			name,
+		)
+	}
+	if !req.AllowUpdate && !req.UpdateOnly && index >= 0 {
+		return EntryView{}, fmt.Errorf(
+			"mcp_registry_add: entry already exists; use update: %s",
+			name,
+		)
+	}
+
+	safeConn, hasSensitive := redactConnection(conn)
+	entry := Entry{
+		ID:                 id,
+		Name:               name,
+		Scope:              scope,
+		ScopeKey:           scopeKey,
+		Description:        strings.TrimSpace(req.Description),
+		Connection:         safeConn,
+		HasSensitiveValues: hasSensitive,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+	if index >= 0 {
+		entry.CreatedAt = state.Entries[index].CreatedAt
+		state.Entries[index] = entry
+	} else {
+		state.Entries = append(state.Entries, entry)
+	}
+	if hasSensitive {
+		if secrets.Connections == nil {
+			secrets.Connections = make(map[string]mcp.ConnectionConfig)
+		}
+		secrets.Connections[id] = conn
+	} else if secrets.Connections != nil {
+		delete(secrets.Connections, id)
+	}
+
+	if err := s.saveLocked(ctx, state, secrets); err != nil {
+		return EntryView{}, err
+	}
+	return viewForEntry(entry, entry.Name), nil
+}
+
+// Delete removes one scoped MCP server registration.
+func (s *FileStore) Delete(
+	ctx context.Context,
+	req DeleteRequest,
+) (bool, error) {
+	if s == nil {
+		return false, errors.New("mcp registry store is nil")
+	}
+	name, err := normalizeName(req.Name)
+	if err != nil {
+		return false, err
+	}
+	scope, scopeKey, err := resolveScope(req.Scope, req.Context)
+	if err != nil {
+		return false, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	state, secrets, err := s.loadLocked(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	id := entryID(scope, scopeKey, name)
+	index := findEntryIndex(state.Entries, id)
+	if index < 0 {
+		return false, nil
+	}
+	state.Entries = append(state.Entries[:index], state.Entries[index+1:]...)
+	if secrets.Connections != nil {
+		delete(secrets.Connections, id)
+	}
+	return true, s.saveLocked(ctx, state, secrets)
+}
+
+// List returns the MCP registrations visible to the current context.
+func (s *FileStore) List(
+	ctx context.Context,
+	runtime RuntimeContext,
+) ([]EntryView, error) {
+	entries, _, err := s.accessibleEntries(ctx, runtime)
+	if err != nil {
+		return nil, err
+	}
+	aliases := aliasMap(entries)
+	views := make([]EntryView, 0, len(entries))
+	for _, entry := range entries {
+		views = append(views, viewForEntry(entry, aliases[entry.ID]))
+	}
+	return views, nil
+}
+
+// ServerConfigs returns broker-ready MCP servers visible to the context.
+func (s *FileStore) ServerConfigs(
+	ctx context.Context,
+	runtime RuntimeContext,
+) (map[string]mcp.ConnectionConfig, error) {
+	entries, secrets, err := s.accessibleEntries(ctx, runtime)
+	if err != nil {
+		return nil, err
+	}
+	if len(entries) == 0 {
+		return nil, nil
+	}
+
+	aliases := aliasMap(entries)
+	out := make(map[string]mcp.ConnectionConfig, len(entries)*2)
+	for _, entry := range entries {
+		conn := entry.Connection
+		if raw, ok := secrets.Connections[entry.ID]; ok {
+			conn = raw
+		}
+		conn.Description = descriptionWithScope(
+			entry.Description,
+			entry.Scope,
+		)
+		out[qualifiedName(entry)] = conn
+		if alias := aliases[entry.ID]; alias == entry.Name {
+			out[alias] = conn
+		}
+	}
+	return out, nil
+}
+
+func (s *FileStore) accessibleEntries(
+	ctx context.Context,
+	runtime RuntimeContext,
+) ([]Entry, secretState, error) {
+	if s == nil {
+		return nil, secretState{}, errors.New("mcp registry store is nil")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	state, secrets, err := s.loadLocked(ctx)
+	if err != nil {
+		return nil, secretState{}, err
+	}
+	entries := make([]Entry, 0, len(state.Entries))
+	for _, entry := range state.Entries {
+		if isEntryVisible(entry, runtime) {
+			entries = append(entries, entry)
+		}
+	}
+	sortEntries(entries)
+	return entries, secrets, nil
+}
+
+func (s *FileStore) loadLocked(
+	ctx context.Context,
+) (registryState, secretState, error) {
+	if err := ctx.Err(); err != nil {
+		return registryState{}, secretState{}, err
+	}
+	state, err := readJSONFile[registryState](s.registryPath)
+	if err != nil {
+		return registryState{}, secretState{}, err
+	}
+	secrets, err := readJSONFile[secretState](s.secretsPath)
+	if err != nil {
+		return registryState{}, secretState{}, err
+	}
+	if secrets.Connections == nil {
+		secrets.Connections = make(map[string]mcp.ConnectionConfig)
+	}
+	return state, secrets, nil
+}
+
+func (s *FileStore) saveLocked(
+	ctx context.Context,
+	state registryState,
+	secrets secretState,
+) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	sortEntries(state.Entries)
+	if err := writeJSONFile(s.registryPath, state, 0o600); err != nil {
+		return err
+	}
+	if len(secrets.Connections) == 0 {
+		return removeIfExists(s.secretsPath)
+	}
+	return writeJSONFile(s.secretsPath, secrets, 0o600)
+}
+
+func readJSONFile[T any](path string) (T, error) {
+	var out T
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return out, nil
+		}
+		return out, err
+	}
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return out, nil
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		return out, err
+	}
+	return out, nil
+}
+
+func writeJSONFile(path string, value any, perm os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return os.WriteFile(path, data, perm)
+}
+
+func removeIfExists(path string) error {
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
+func resolveScope(
+	scope Scope,
+	runtime RuntimeContext,
+) (Scope, string, error) {
+	if strings.TrimSpace(string(scope)) == "" {
+		scope = ScopeSession
+	}
+	scope = Scope(strings.ToLower(strings.TrimSpace(string(scope))))
+	switch scope {
+	case ScopeSession:
+		return requireScopeKey(scope, runtime.SessionID)
+	case ScopeChat:
+		if strings.TrimSpace(runtime.ChatID) != "" {
+			return scope, strings.TrimSpace(runtime.ChatID), nil
+		}
+		return requireScopeKey(scope, runtime.StorageUserID)
+	case ScopeUser:
+		return requireScopeKey(scope, runtime.UserID)
+	case ScopeWorkspace:
+		return requireScopeKey(scope, runtime.WorkspaceID)
+	case ScopeGlobal:
+		return scope, scopeKeyGlobal, nil
+	default:
+		return "", "", fmt.Errorf("unsupported mcp registry scope: %s", scope)
+	}
+}
+
+func requireScopeKey(scope Scope, value string) (Scope, string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", "", fmt.Errorf(
+			"%w for %s scope",
+			errRegistryContextUnavailable,
+			scope,
+		)
+	}
+	return scope, value, nil
+}
+
+func normalizeName(name string) (string, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", errors.New("mcp registry name is required")
+	}
+	if strings.ContainsAny(name, "\r\n\t") {
+		return "", fmt.Errorf("mcp registry name contains whitespace: %q", name)
+	}
+	return name, nil
+}
+
+func normalizeConnection(
+	cfg mcp.ConnectionConfig,
+) (mcp.ConnectionConfig, error) {
+	command := strings.TrimSpace(cfg.Command)
+	serverURL := strings.TrimSpace(cfg.ServerURL)
+	transport := normalizeTransport(cfg.Transport, command, serverURL)
+	if cfg.Timeout < 0 {
+		return mcp.ConnectionConfig{}, errors.New("timeout must be non-negative")
+	}
+	switch transport {
+	case transportStdio:
+		if command == "" {
+			return mcp.ConnectionConfig{}, errors.New("stdio MCP requires command")
+		}
+		if serverURL != "" {
+			return mcp.ConnectionConfig{}, errors.New(
+				"stdio MCP cannot use server_url",
+			)
+		}
+		if len(cfg.Headers) > 0 {
+			return mcp.ConnectionConfig{}, errors.New("stdio MCP cannot use headers")
+		}
+	case transportSSE, transportStreamable:
+		if serverURL == "" {
+			return mcp.ConnectionConfig{}, errors.New("HTTP MCP requires server_url")
+		}
+		parsed, err := url.Parse(serverURL)
+		if err != nil {
+			return mcp.ConnectionConfig{}, err
+		}
+		if parsed.Scheme != "http" && parsed.Scheme != "https" {
+			return mcp.ConnectionConfig{}, errors.New(
+				"HTTP MCP requires http or https URL",
+			)
+		}
+		if strings.TrimSpace(parsed.Host) == "" {
+			return mcp.ConnectionConfig{}, errors.New("HTTP MCP requires URL host")
+		}
+		if command != "" {
+			return mcp.ConnectionConfig{}, errors.New("HTTP MCP cannot use command")
+		}
+	default:
+		return mcp.ConnectionConfig{}, fmt.Errorf(
+			"unsupported MCP transport: %s",
+			cfg.Transport,
+		)
+	}
+	return mcp.ConnectionConfig{
+		Transport:   transport,
+		ServerURL:   serverURL,
+		Headers:     cloneStringMap(cfg.Headers),
+		Command:     command,
+		Args:        cloneStringSlice(cfg.Args),
+		Timeout:     cfg.Timeout,
+		Description: strings.TrimSpace(cfg.Description),
+		ClientInfo:  cfg.ClientInfo,
+	}, nil
+}
+
+func normalizeTransport(raw string, command string, serverURL string) string {
+	value := strings.ToLower(strings.TrimSpace(raw))
+	switch value {
+	case "":
+		if command != "" {
+			return transportStdio
+		}
+		if serverURL != "" {
+			return transportStreamable
+		}
+		return ""
+	case transportHTTP, transportHTTPAlt:
+		return transportStreamable
+	default:
+		return value
+	}
+}
+
+func redactConnection(cfg mcp.ConnectionConfig) (mcp.ConnectionConfig, bool) {
+	out := cfg
+	out.Headers = cloneStringMap(cfg.Headers)
+	out.Args = cloneStringSlice(cfg.Args)
+	hasSensitive := false
+	if out.ServerURL != "" {
+		redactedURL, ok := redactURL(out.ServerURL)
+		out.ServerURL = redactedURL
+		hasSensitive = hasSensitive || ok
+	}
+	for key := range out.Headers {
+		if isSensitiveHeader(key) {
+			out.Headers[key] = secretRedaction
+			hasSensitive = true
+		}
+	}
+	return out, hasSensitive
+}
+
+func redactURL(raw string) (string, bool) {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return raw, false
+	}
+	query := parsed.Query()
+	changed := false
+	for key := range query {
+		if isSensitiveQueryKey(key) {
+			query.Set(key, secretRedaction)
+			changed = true
+		}
+	}
+	if !changed {
+		return raw, false
+	}
+	parsed.RawQuery = query.Encode()
+	return parsed.String(), true
+}
+
+func isSensitiveHeader(name string) bool {
+	_, ok := sensitiveHeaderNames[strings.ToLower(strings.TrimSpace(name))]
+	return ok
+}
+
+func isSensitiveQueryKey(key string) bool {
+	key = strings.ToLower(strings.TrimSpace(key))
+	for _, hint := range sensitiveQueryHints {
+		if key == hint || strings.Contains(key, hint) {
+			return true
+		}
+	}
+	return false
+}
+
+func entryID(scope Scope, key string, name string) string {
+	sum := sha256.Sum256([]byte(
+		string(scope) + "\x00" + key + "\x00" + name,
+	))
+	return hex.EncodeToString(sum[:])[:16]
+}
+
+func findEntryIndex(entries []Entry, id string) int {
+	for i := range entries {
+		if entries[i].ID == id {
+			return i
+		}
+	}
+	return -1
+}
+
+func isEntryVisible(entry Entry, runtime RuntimeContext) bool {
+	switch entry.Scope {
+	case ScopeSession:
+		return entry.ScopeKey == strings.TrimSpace(runtime.SessionID)
+	case ScopeChat:
+		chatID := strings.TrimSpace(runtime.ChatID)
+		storageUserID := strings.TrimSpace(runtime.StorageUserID)
+		return entry.ScopeKey == chatID || entry.ScopeKey == storageUserID
+	case ScopeUser:
+		return entry.ScopeKey == strings.TrimSpace(runtime.UserID)
+	case ScopeWorkspace:
+		return entry.ScopeKey == strings.TrimSpace(runtime.WorkspaceID)
+	case ScopeGlobal:
+		return entry.ScopeKey == scopeKeyGlobal
+	default:
+		return false
+	}
+}
+
+func aliasMap(entries []Entry) map[string]string {
+	out := make(map[string]string, len(entries))
+	bareOwners := make(map[string]Entry, len(entries))
+	for _, entry := range entries {
+		owner, ok := bareOwners[entry.Name]
+		if !ok || scopeRank(entry.Scope) < scopeRank(owner.Scope) {
+			bareOwners[entry.Name] = entry
+		}
+		out[entry.ID] = qualifiedName(entry)
+	}
+	for _, entry := range bareOwners {
+		out[entry.ID] = entry.Name
+	}
+	return out
+}
+
+func viewForEntry(entry Entry, selector string) EntryView {
+	return EntryView{
+		Name:               entry.Name,
+		Scope:              entry.Scope,
+		Description:        entry.Description,
+		Selector:           selector,
+		QualifiedSelector:  qualifiedName(entry),
+		Transport:          entry.Connection.Transport,
+		ServerURL:          entry.Connection.ServerURL,
+		Command:            entry.Connection.Command,
+		HasSensitiveValues: entry.HasSensitiveValues,
+		UpdatedAt:          entry.UpdatedAt.Format(time.RFC3339),
+	}
+}
+
+func qualifiedName(entry Entry) string {
+	return string(entry.Scope) + ":" + entry.Name
+}
+
+func descriptionWithScope(description string, scope Scope) string {
+	description = strings.TrimSpace(description)
+	if description == "" {
+		return "MCP server registered in " + string(scope) + " scope."
+	}
+	return description + " Scope: " + string(scope) + "."
+}
+
+func sortEntries(entries []Entry) {
+	sort.Slice(entries, func(i, j int) bool {
+		left := entries[i]
+		right := entries[j]
+		if scopeRank(left.Scope) != scopeRank(right.Scope) {
+			return scopeRank(left.Scope) < scopeRank(right.Scope)
+		}
+		if left.Name != right.Name {
+			return left.Name < right.Name
+		}
+		return left.ScopeKey < right.ScopeKey
+	})
+}
+
+func scopeRank(scope Scope) int {
+	switch scope {
+	case ScopeSession:
+		return 0
+	case ScopeChat:
+		return 1
+	case ScopeUser:
+		return 2
+	case ScopeWorkspace:
+		return 3
+	case ScopeGlobal:
+		return 4
+	default:
+		return 9
+	}
+}
+
+func cloneStringMap(input map[string]string) map[string]string {
+	if input == nil {
+		return nil
+	}
+	out := make(map[string]string, len(input))
+	for key, value := range input {
+		out[key] = value
+	}
+	return out
+}
+
+func cloneStringSlice(input []string) []string {
+	if input == nil {
+		return nil
+	}
+	out := make([]string, len(input))
+	copy(out, input)
+	return out
+}

--- a/openclaw/mcpregistry/store.go
+++ b/openclaw/mcpregistry/store.go
@@ -122,13 +122,19 @@ type EntryView struct {
 
 // UpsertRequest stores one MCP server registration.
 type UpsertRequest struct {
-	Context     RuntimeContext
-	Name        string
-	Scope       Scope
-	Description string
-	Connection  mcp.ConnectionConfig
-	UpdateOnly  bool
-	AllowUpdate bool
+	Context          RuntimeContext
+	Name             string
+	Scope            Scope
+	Description      string
+	Connection       mcp.ConnectionConfig
+	ClearServerURL   bool
+	ClearHeaders     bool
+	ClearCommand     bool
+	ClearArgs        bool
+	ClearTimeout     bool
+	ClearDescription bool
+	UpdateOnly       bool
+	AllowUpdate      bool
 }
 
 // DeleteRequest removes one MCP server registration from the current scope.
@@ -217,8 +223,9 @@ func (s *FileStore) Upsert(
 		conn = mergeConnection(
 			rawConnectionForEntry(existing, secrets),
 			conn,
+			req,
 		)
-		if description == "" {
+		if description == "" && !req.ClearDescription {
 			description = existing.Description
 		}
 	}
@@ -622,6 +629,7 @@ func rawConnectionForEntry(
 func mergeConnection(
 	base mcp.ConnectionConfig,
 	update mcp.ConnectionConfig,
+	req UpsertRequest,
 ) mcp.ConnectionConfig {
 	out := mcp.ConnectionConfig{
 		Transport:   base.Transport,
@@ -632,6 +640,24 @@ func mergeConnection(
 		Timeout:     base.Timeout,
 		Description: base.Description,
 		ClientInfo:  base.ClientInfo,
+	}
+	if req.ClearServerURL {
+		out.ServerURL = ""
+	}
+	if req.ClearHeaders {
+		out.Headers = nil
+	}
+	if req.ClearCommand {
+		out.Command = ""
+	}
+	if req.ClearArgs {
+		out.Args = nil
+	}
+	if req.ClearTimeout {
+		out.Timeout = 0
+	}
+	if req.ClearDescription {
+		out.Description = ""
 	}
 	if strings.TrimSpace(update.Transport) != "" {
 		out.Transport = update.Transport

--- a/openclaw/mcpregistry/store.go
+++ b/openclaw/mcpregistry/store.go
@@ -267,17 +267,17 @@ func (s *FileStore) Upsert(
 func (s *FileStore) Delete(
 	ctx context.Context,
 	req DeleteRequest,
-) (bool, error) {
+) (bool, Scope, error) {
 	if s == nil {
-		return false, errors.New("mcp registry store is nil")
+		return false, "", errors.New("mcp registry store is nil")
 	}
 	name, err := normalizeName(req.Name)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 	scope, scopeKey, err := resolveScope(req.Scope, req.Context)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 
 	s.mu.Lock()
@@ -285,19 +285,19 @@ func (s *FileStore) Delete(
 
 	state, secrets, err := s.loadLocked(ctx)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 
 	id := entryID(scope, scopeKey, name)
 	index := findEntryIndex(state.Entries, id)
 	if index < 0 {
-		return false, nil
+		return false, scope, nil
 	}
 	state.Entries = append(state.Entries[:index], state.Entries[index+1:]...)
 	if secrets.Connections != nil {
 		delete(secrets.Connections, id)
 	}
-	return true, s.saveLocked(ctx, state, secrets)
+	return true, scope, s.saveLocked(ctx, state, secrets)
 }
 
 // List returns the MCP registrations visible to the current context.
@@ -370,6 +370,7 @@ func (s *FileStore) accessibleEntries(
 			entries = append(entries, entry)
 		}
 	}
+	entries = preferExactChatEntries(entries, runtime)
 	sortEntries(entries)
 	return entries, secrets, nil
 }
@@ -403,13 +404,16 @@ func (s *FileStore) saveLocked(
 		return err
 	}
 	sortEntries(state.Entries)
-	if err := writeJSONFile(s.registryPath, state, 0o600); err != nil {
-		return err
-	}
 	if len(secrets.Connections) == 0 {
+		if err := writeJSONFile(s.registryPath, state, 0o600); err != nil {
+			return err
+		}
 		return removeIfExists(s.secretsPath)
 	}
-	return writeJSONFile(s.secretsPath, secrets, 0o600)
+	if err := writeJSONFile(s.secretsPath, secrets, 0o600); err != nil {
+		return err
+	}
+	return writeJSONFile(s.registryPath, state, 0o600)
 }
 
 func readJSONFile[T any](path string) (T, error) {
@@ -431,15 +435,42 @@ func readJSONFile[T any](path string) (T, error) {
 }
 
 func writeJSONFile(path string, value any, perm os.FileMode) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-		return err
-	}
 	data, err := json.MarshalIndent(value, "", "  ")
 	if err != nil {
 		return err
 	}
 	data = append(data, '\n')
-	return os.WriteFile(path, data, perm)
+	return writeFileAtomically(path, data, perm)
+}
+
+func writeFileAtomically(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	file, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tempPath := file.Name()
+	closed := false
+	defer func() {
+		if !closed {
+			_ = file.Close()
+		}
+		_ = os.Remove(tempPath)
+	}()
+	if _, err := file.Write(data); err != nil {
+		return err
+	}
+	if err := file.Chmod(perm); err != nil {
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	closed = true
+	return os.Rename(tempPath, path)
 }
 
 func removeIfExists(path string) error {
@@ -780,6 +811,38 @@ func isEntryVisible(entry Entry, runtime RuntimeContext) bool {
 	default:
 		return false
 	}
+}
+
+func preferExactChatEntries(
+	entries []Entry,
+	runtime RuntimeContext,
+) []Entry {
+	chatID := strings.TrimSpace(runtime.ChatID)
+	storageUserID := strings.TrimSpace(runtime.StorageUserID)
+	if chatID == "" || storageUserID == "" || chatID == storageUserID {
+		return entries
+	}
+
+	exactNames := make(map[string]struct{})
+	for _, entry := range entries {
+		if entry.Scope == ScopeChat && entry.ScopeKey == chatID {
+			exactNames[entry.Name] = struct{}{}
+		}
+	}
+	if len(exactNames) == 0 {
+		return entries
+	}
+
+	out := entries[:0]
+	for _, entry := range entries {
+		if entry.Scope == ScopeChat && entry.ScopeKey == storageUserID {
+			if _, ok := exactNames[entry.Name]; ok {
+				continue
+			}
+		}
+		out = append(out, entry)
+	}
+	return out
 }
 
 func aliasMap(entries []Entry) map[string]string {

--- a/openclaw/mcpregistry/store.go
+++ b/openclaw/mcpregistry/store.go
@@ -185,11 +185,6 @@ func (s *FileStore) Upsert(
 	if err != nil {
 		return EntryView{}, err
 	}
-	conn, err := normalizeConnection(req.Connection)
-	if err != nil {
-		return EntryView{}, err
-	}
-
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -215,13 +210,33 @@ func (s *FileStore) Upsert(
 		)
 	}
 
+	description := strings.TrimSpace(req.Description)
+	conn := req.Connection
+	if req.UpdateOnly && index >= 0 {
+		existing := state.Entries[index]
+		conn = mergeConnection(
+			rawConnectionForEntry(existing, secrets),
+			conn,
+		)
+		if description == "" {
+			description = existing.Description
+		}
+	}
+	if strings.TrimSpace(conn.Description) == "" {
+		conn.Description = description
+	}
+	conn, err = normalizeConnection(conn)
+	if err != nil {
+		return EntryView{}, err
+	}
+
 	safeConn, hasSensitive := redactConnection(conn)
 	entry := Entry{
 		ID:                 id,
 		Name:               name,
 		Scope:              scope,
 		ScopeKey:           scopeKey,
-		Description:        strings.TrimSpace(req.Description),
+		Description:        description,
 		Connection:         safeConn,
 		HasSensitiveValues: hasSensitive,
 		CreatedAt:          now,
@@ -561,6 +576,62 @@ func normalizeTransport(raw string, command string, serverURL string) string {
 	}
 }
 
+func rawConnectionForEntry(
+	entry Entry,
+	secrets secretState,
+) mcp.ConnectionConfig {
+	if secrets.Connections != nil {
+		if raw, ok := secrets.Connections[entry.ID]; ok {
+			return raw
+		}
+	}
+	return entry.Connection
+}
+
+func mergeConnection(
+	base mcp.ConnectionConfig,
+	update mcp.ConnectionConfig,
+) mcp.ConnectionConfig {
+	out := mcp.ConnectionConfig{
+		Transport:   base.Transport,
+		ServerURL:   base.ServerURL,
+		Headers:     cloneStringMap(base.Headers),
+		Command:     base.Command,
+		Args:        cloneStringSlice(base.Args),
+		Timeout:     base.Timeout,
+		Description: base.Description,
+		ClientInfo:  base.ClientInfo,
+	}
+	if strings.TrimSpace(update.Transport) != "" {
+		out.Transport = update.Transport
+	}
+	if strings.TrimSpace(update.ServerURL) != "" {
+		out.ServerURL = update.ServerURL
+	}
+	if update.Headers != nil {
+		out.Headers = cloneStringMap(update.Headers)
+	}
+	if strings.TrimSpace(update.Command) != "" {
+		out.Command = update.Command
+	}
+	if update.Args != nil {
+		out.Args = cloneStringSlice(update.Args)
+	}
+	if update.Timeout != 0 {
+		out.Timeout = update.Timeout
+	}
+	if strings.TrimSpace(update.Description) != "" {
+		out.Description = update.Description
+	}
+	if strings.TrimSpace(update.ClientInfo.Name) != "" {
+		out.ClientInfo.Name = update.ClientInfo.Name
+	}
+	if strings.TrimSpace(update.ClientInfo.Version) != "" {
+		out.ClientInfo.Version = update.ClientInfo.Version
+	}
+	return out
+}
+
 func redactConnection(cfg mcp.ConnectionConfig) (mcp.ConnectionConfig, bool) {
 	out := cfg
 	out.Headers = cloneStringMap(cfg.Headers)
@@ -577,6 +648,9 @@ func redactConnection(cfg mcp.ConnectionConfig) (mcp.ConnectionConfig, bool) {
 			hasSensitive = true
 		}
 	}
+	args, ok := redactArgs(out.Args)
+	out.Args = args
+	hasSensitive = hasSensitive || ok
 	return out, hasSensitive
 }
 
@@ -613,6 +687,64 @@ func isSensitiveQueryKey(key string) bool {
 		}
 	}
 	return false
+}
+
+func redactArgs(args []string) ([]string, bool) {
+	out := cloneStringSlice(args)
+	changed := false
+	redactNext := false
+	for i, arg := range out {
+		if redactNext {
+			out[i] = secretRedaction
+			changed = true
+			redactNext = false
+			continue
+		}
+		redacted, ok := redactArg(arg)
+		if ok {
+			out[i] = redacted
+			changed = true
+			continue
+		}
+		if isSensitiveArgName(arg) {
+			redactNext = true
+		}
+	}
+	return out, changed
+}
+
+func redactArg(arg string) (string, bool) {
+	if redactedURL, ok := redactURL(arg); ok {
+		return redactedURL, true
+	}
+	for _, sep := range []string{"=", ":"} {
+		index := strings.Index(arg, sep)
+		if index < 0 {
+			continue
+		}
+		key := strings.TrimSpace(arg[:index])
+		value := strings.TrimSpace(arg[index+len(sep):])
+		if isSensitiveArgName(key) ||
+			isSensitiveArgName(valueKey(value)) {
+			return arg[:index+len(sep)] + secretRedaction, true
+		}
+	}
+	return arg, false
+}
+
+func valueKey(value string) string {
+	for _, sep := range []string{":", "="} {
+		index := strings.Index(value, sep)
+		if index >= 0 {
+			return value[:index]
+		}
+	}
+	return value
+}
+
+func isSensitiveArgName(name string) bool {
+	name = strings.TrimLeft(strings.ToLower(strings.TrimSpace(name)), "-")
+	return isSensitiveHeader(name) || isSensitiveQueryKey(name)
 }
 
 func entryID(scope Scope, key string, name string) string {

--- a/openclaw/mcpregistry/store.go
+++ b/openclaw/mcpregistry/store.go
@@ -42,6 +42,7 @@ const (
 
 	defaultRegistryFileName = "registry.json"
 	defaultSecretsFileName  = "secrets.json"
+	defaultStateFileName    = "state.json"
 
 	secretRedaction = "***"
 
@@ -147,9 +148,15 @@ type DeleteRequest struct {
 // FileStore persists registry metadata and raw sensitive connection values.
 type FileStore struct {
 	mu           sync.Mutex
+	statePath    string
 	registryPath string
 	secretsPath  string
 	now          func() time.Time
+}
+
+type persistedState struct {
+	Registry registryState `json:"registry"`
+	Secrets  secretState   `json:"secrets"`
 }
 
 type registryState struct {
@@ -169,6 +176,7 @@ func DefaultDir(stateDir string) string {
 func NewFileStore(dir string) *FileStore {
 	dir = strings.TrimSpace(dir)
 	return &FileStore{
+		statePath:    filepath.Join(dir, defaultStateFileName),
 		registryPath: filepath.Join(dir, defaultRegistryFileName),
 		secretsPath:  filepath.Join(dir, defaultSecretsFileName),
 		now:          time.Now,
@@ -267,7 +275,8 @@ func (s *FileStore) Upsert(
 	if err := s.saveLocked(ctx, state, secrets); err != nil {
 		return EntryView{}, err
 	}
-	return viewForEntry(entry, entry.Name), nil
+	selector := selectorForEntry(state.Entries, req.Context, entry)
+	return viewForEntry(entry, selector), nil
 }
 
 // Delete removes one scoped MCP server registration.
@@ -388,6 +397,15 @@ func (s *FileStore) loadLocked(
 	if err := ctx.Err(); err != nil {
 		return registryState{}, secretState{}, err
 	}
+	persisted, ok, err := readPersistedStateFile(s.statePath)
+	if err != nil {
+		return registryState{}, secretState{}, err
+	}
+	if ok {
+		state, secrets := normalizePersistedState(persisted)
+		return state, secrets, nil
+	}
+
 	state, err := readJSONFile[registryState](s.registryPath)
 	if err != nil {
 		return registryState{}, secretState{}, err
@@ -396,10 +414,11 @@ func (s *FileStore) loadLocked(
 	if err != nil {
 		return registryState{}, secretState{}, err
 	}
-	if secrets.Connections == nil {
-		secrets.Connections = make(map[string]mcp.ConnectionConfig)
-	}
-	return state, secrets, nil
+	state, normalizedSecrets := normalizePersistedState(persistedState{
+		Registry: state,
+		Secrets:  secrets,
+	})
+	return state, normalizedSecrets, nil
 }
 
 func (s *FileStore) saveLocked(
@@ -412,15 +431,46 @@ func (s *FileStore) saveLocked(
 	}
 	sortEntries(state.Entries)
 	if len(secrets.Connections) == 0 {
-		if err := writeJSONFile(s.registryPath, state, 0o600); err != nil {
-			return err
-		}
-		return removeIfExists(s.secretsPath)
+		secrets.Connections = nil
 	}
-	if err := writeJSONFile(s.secretsPath, secrets, 0o600); err != nil {
+	if err := writeJSONFile(s.statePath, persistedState{
+		Registry: state,
+		Secrets:  secrets,
+	}, 0o600); err != nil {
 		return err
 	}
-	return writeJSONFile(s.registryPath, state, 0o600)
+	if err := removeIfExists(s.registryPath); err != nil {
+		return err
+	}
+	return removeIfExists(s.secretsPath)
+}
+
+func normalizePersistedState(
+	persisted persistedState,
+) (registryState, secretState) {
+	secrets := persisted.Secrets
+	if secrets.Connections == nil {
+		secrets.Connections = make(map[string]mcp.ConnectionConfig)
+	}
+	return persisted.Registry, secrets
+}
+
+func readPersistedStateFile(path string) (persistedState, bool, error) {
+	var out persistedState
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return out, false, nil
+		}
+		return out, false, err
+	}
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return out, true, nil
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		return out, false, err
+	}
+	return out, true, nil
 }
 
 func readJSONFile[T any](path string) (T, error) {
@@ -716,8 +766,12 @@ func redactURL(raw string) (string, bool) {
 	if err != nil {
 		return raw, false
 	}
-	query := parsed.Query()
 	changed := false
+	if parsed.User != nil {
+		parsed.User = url.User(secretRedaction)
+		changed = true
+	}
+	query := parsed.Query()
 	for key := range query {
 		if isSensitiveQueryKey(key) {
 			query.Set(key, secretRedaction)
@@ -885,6 +939,26 @@ func aliasMap(entries []Entry) map[string]string {
 		out[entry.ID] = entry.Name
 	}
 	return out
+}
+
+func selectorForEntry(
+	entries []Entry,
+	runtime RuntimeContext,
+	entry Entry,
+) string {
+	visible := make([]Entry, 0, len(entries))
+	for _, candidate := range entries {
+		if isEntryVisible(candidate, runtime) {
+			visible = append(visible, candidate)
+		}
+	}
+	visible = preferExactChatEntries(visible, runtime)
+	sortEntries(visible)
+	aliases := aliasMap(visible)
+	if selector := aliases[entry.ID]; selector != "" {
+		return selector
+	}
+	return qualifiedName(entry)
 }
 
 func viewForEntry(entry Entry, selector string) EntryView {

--- a/openclaw/mcpregistry/store_test.go
+++ b/openclaw/mcpregistry/store_test.go
@@ -11,10 +11,12 @@ package mcpregistry
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -45,7 +47,7 @@ func TestFileStore_RedactsSensitiveValuesAndResolvesRawConfig(t *testing.T) {
 		Description: "Docs MCP",
 		Connection: mcp.ConnectionConfig{
 			Transport: "streamable_http",
-			ServerURL: "https://example.com/mcp?apikey=secret&plain=ok",
+			ServerURL: "https://user:pass@example.com/mcp?apikey=secret&plain=ok",
 			Headers: map[string]string{
 				"Authorization": "Bearer secret",
 				"X-Trace":       "trace",
@@ -57,25 +59,30 @@ func TestFileStore_RedactsSensitiveValuesAndResolvesRawConfig(t *testing.T) {
 	require.Equal(t, "docs", view.Selector)
 	require.True(t, view.HasSensitiveValues)
 	require.NotContains(t, view.ServerURL, "secret")
+	require.NotContains(t, view.ServerURL, "user")
+	require.NotContains(t, view.ServerURL, "pass")
 
-	registryBytes, err := os.ReadFile(
-		filepath.Join(dir, defaultRegistryFileName),
+	persisted, ok, err := readPersistedStateFile(
+		filepath.Join(dir, defaultStateFileName),
 	)
 	require.NoError(t, err)
-	require.NotContains(t, string(registryBytes), "Bearer secret")
-	require.NotContains(t, string(registryBytes), "apikey=secret")
+	require.True(t, ok)
+	require.Len(t, persisted.Registry.Entries, 1)
+	entry := persisted.Registry.Entries[0]
+	require.NotContains(t, entry.Connection.ServerURL, "apikey=secret")
+	require.NotContains(t, entry.Connection.ServerURL, "user")
+	require.NotContains(t, entry.Connection.ServerURL, "pass")
+	require.Equal(t, secretRedaction, entry.Connection.Headers["Authorization"])
 
-	secretsBytes, err := os.ReadFile(
-		filepath.Join(dir, defaultSecretsFileName),
-	)
-	require.NoError(t, err)
-	require.Contains(t, string(secretsBytes), "Bearer secret")
+	raw := persisted.Secrets.Connections[entry.ID]
+	require.Equal(t, "Bearer secret", raw.Headers["Authorization"])
+	require.Contains(t, raw.ServerURL, "user:pass")
 
 	servers, err := store.ServerConfigs(context.Background(), runtime)
 	require.NoError(t, err)
 	require.Contains(t, servers, "docs")
 	require.Contains(t, servers, "chat:docs")
-	require.Equal(t, "https://example.com/mcp?apikey=secret&plain=ok",
+	require.Equal(t, "https://user:pass@example.com/mcp?apikey=secret&plain=ok",
 		servers["docs"].ServerURL)
 	require.Equal(t, "Bearer secret", servers["docs"].Headers["Authorization"])
 }
@@ -107,9 +114,13 @@ func TestFileStore_RedactsSensitiveStdioArgs(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	registryBytes, err := os.ReadFile(
-		filepath.Join(dir, defaultRegistryFileName),
+	persisted, ok, err := readPersistedStateFile(
+		filepath.Join(dir, defaultStateFileName),
 	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, persisted.Registry.Entries, 1)
+	registryBytes, err := json.Marshal(persisted.Registry)
 	require.NoError(t, err)
 	registryText := string(registryBytes)
 	require.NotContains(t, registryText, "arg-secret")
@@ -309,6 +320,89 @@ func TestFileStore_DeleteRemovesEntryAndSecret(t *testing.T) {
 
 	_, err = os.Stat(filepath.Join(dir, defaultSecretsFileName))
 	require.True(t, os.IsNotExist(err))
+
+	persisted, ok, err := readPersistedStateFile(
+		filepath.Join(dir, defaultStateFileName),
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Empty(t, persisted.Registry.Entries)
+	require.Empty(t, persisted.Secrets.Connections)
+}
+
+func TestFileStore_LoadsLegacySplitFiles(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	store := NewFileStore(dir)
+	runtime := testRuntimeContext()
+	id := entryID(ScopeSession, runtime.SessionID, "docs")
+	now := time.Now()
+	require.NoError(t, writeJSONFile(
+		filepath.Join(dir, defaultRegistryFileName),
+		registryState{Entries: []Entry{{
+			ID:                 id,
+			Name:               "docs",
+			Scope:              ScopeSession,
+			ScopeKey:           runtime.SessionID,
+			Connection:         mcp.ConnectionConfig{ServerURL: secretRedaction},
+			HasSensitiveValues: true,
+			CreatedAt:          now,
+			UpdatedAt:          now,
+		}}},
+		0o600,
+	))
+	require.NoError(t, writeJSONFile(
+		filepath.Join(dir, defaultSecretsFileName),
+		secretState{Connections: map[string]mcp.ConnectionConfig{
+			id: {ServerURL: "https://example.com/mcp?token=secret"},
+		}},
+		0o600,
+	))
+
+	servers, err := store.ServerConfigs(context.Background(), runtime)
+	require.NoError(t, err)
+	require.Equal(t, "https://example.com/mcp?token=secret",
+		servers["docs"].ServerURL)
+}
+
+func TestFileStore_UpsertReturnsQualifiedSelectorWhenBareNameIsShadowed(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	store := NewFileStore(t.TempDir())
+	runtime := testRuntimeContext()
+	_, err := store.Upsert(context.Background(), UpsertRequest{
+		Context: runtime,
+		Name:    "docs",
+		Scope:   ScopeSession,
+		Connection: mcp.ConnectionConfig{
+			ServerURL: "https://session.example.com/mcp",
+		},
+	})
+	require.NoError(t, err)
+
+	view, err := store.Upsert(context.Background(), UpsertRequest{
+		Context: runtime,
+		Name:    "docs",
+		Scope:   ScopeGlobal,
+		Connection: mcp.ConnectionConfig{
+			ServerURL: "https://global.example.com/mcp",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "global:docs", view.Selector)
+	require.Equal(t, "global:docs", view.QualifiedSelector)
+
+	views, err := store.List(context.Background(), runtime)
+	require.NoError(t, err)
+	viewsByScope := make(map[Scope]EntryView, len(views))
+	for _, candidate := range views {
+		viewsByScope[candidate.Scope] = candidate
+	}
+	require.Equal(t, "docs", viewsByScope[ScopeSession].Selector)
+	require.Equal(t, "global:docs", viewsByScope[ScopeGlobal].Selector)
 }
 
 func TestFileStore_ExactChatEntryOverridesStorageFallback(t *testing.T) {

--- a/openclaw/mcpregistry/store_test.go
+++ b/openclaw/mcpregistry/store_test.go
@@ -1,0 +1,203 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package mcpregistry
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/conversation"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/tool/mcp"
+)
+
+const (
+	testAppName   = "app"
+	testSessionID = "sess-1"
+	testUserID    = "user-1"
+	testChatID    = "chat-1"
+)
+
+func TestFileStore_RedactsSensitiveValuesAndResolvesRawConfig(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	store := NewFileStore(dir)
+	runtime := testRuntimeContext()
+
+	view, err := store.Upsert(context.Background(), UpsertRequest{
+		Context:     runtime,
+		Name:        "docs",
+		Scope:       ScopeChat,
+		Description: "Docs MCP",
+		Connection: mcp.ConnectionConfig{
+			Transport: "streamable_http",
+			ServerURL: "https://example.com/mcp?apikey=secret&plain=ok",
+			Headers: map[string]string{
+				"Authorization": "Bearer secret",
+				"X-Trace":       "trace",
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, ScopeChat, view.Scope)
+	require.Equal(t, "docs", view.Selector)
+	require.True(t, view.HasSensitiveValues)
+	require.NotContains(t, view.ServerURL, "secret")
+
+	registryBytes, err := os.ReadFile(
+		filepath.Join(dir, defaultRegistryFileName),
+	)
+	require.NoError(t, err)
+	require.NotContains(t, string(registryBytes), "Bearer secret")
+	require.NotContains(t, string(registryBytes), "apikey=secret")
+
+	secretsBytes, err := os.ReadFile(
+		filepath.Join(dir, defaultSecretsFileName),
+	)
+	require.NoError(t, err)
+	require.Contains(t, string(secretsBytes), "Bearer secret")
+
+	servers, err := store.ServerConfigs(context.Background(), runtime)
+	require.NoError(t, err)
+	require.Contains(t, servers, "docs")
+	require.Contains(t, servers, "chat:docs")
+	require.Equal(t, "https://example.com/mcp?apikey=secret&plain=ok",
+		servers["docs"].ServerURL)
+	require.Equal(t, "Bearer secret", servers["docs"].Headers["Authorization"])
+}
+
+func TestFileStore_ScopeVisibilityAndAliasPrecedence(t *testing.T) {
+	t.Parallel()
+
+	store := NewFileStore(t.TempDir())
+	runtime := testRuntimeContext()
+	_, err := store.Upsert(context.Background(), UpsertRequest{
+		Context: runtime,
+		Name:    "docs",
+		Scope:   ScopeGlobal,
+		Connection: mcp.ConnectionConfig{
+			ServerURL: "https://global.example.com/mcp",
+		},
+	})
+	require.NoError(t, err)
+	_, err = store.Upsert(context.Background(), UpsertRequest{
+		Context: runtime,
+		Name:    "docs",
+		Scope:   ScopeChat,
+		Connection: mcp.ConnectionConfig{
+			ServerURL: "https://chat.example.com/mcp",
+		},
+	})
+	require.NoError(t, err)
+
+	servers, err := store.ServerConfigs(context.Background(), runtime)
+	require.NoError(t, err)
+	require.Equal(t, "https://chat.example.com/mcp", servers["docs"].ServerURL)
+	require.Equal(t,
+		"https://global.example.com/mcp",
+		servers["global:docs"].ServerURL)
+
+	otherRuntime := runtime
+	otherRuntime.ChatID = "other-chat"
+	otherRuntime.StorageUserID = "other-chat"
+	servers, err = store.ServerConfigs(context.Background(), otherRuntime)
+	require.NoError(t, err)
+	require.Equal(t, "https://global.example.com/mcp", servers["docs"].ServerURL)
+	require.NotContains(t, servers, "chat:docs")
+}
+
+func TestRuntimeContextFromContext_UsesConversationAnnotation(t *testing.T) {
+	t.Parallel()
+
+	ctx := testInvocationContext()
+	runtime, err := RuntimeContextFromContext(ctx, "fallback")
+	require.NoError(t, err)
+	require.Equal(t, testAppName, runtime.AppName)
+	require.Equal(t, testSessionID, runtime.SessionID)
+	require.Equal(t, testUserID, runtime.UserID)
+	require.Equal(t, testChatID, runtime.ChatID)
+	require.Equal(t, "chat-storage", runtime.StorageUserID)
+}
+
+func TestFileStore_DeleteRemovesEntryAndSecret(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	store := NewFileStore(dir)
+	runtime := testRuntimeContext()
+	_, err := store.Upsert(context.Background(), UpsertRequest{
+		Context: runtime,
+		Name:    "docs",
+		Scope:   ScopeSession,
+		Connection: mcp.ConnectionConfig{
+			ServerURL: "https://example.com/mcp?token=secret",
+		},
+	})
+	require.NoError(t, err)
+
+	removed, err := store.Delete(context.Background(), DeleteRequest{
+		Context: runtime,
+		Name:    "docs",
+		Scope:   ScopeSession,
+	})
+	require.NoError(t, err)
+	require.True(t, removed)
+
+	servers, err := store.ServerConfigs(context.Background(), runtime)
+	require.NoError(t, err)
+	require.Empty(t, servers)
+
+	_, err = os.Stat(filepath.Join(dir, defaultSecretsFileName))
+	require.True(t, os.IsNotExist(err))
+}
+
+func testRuntimeContext() RuntimeContext {
+	return RuntimeContext{
+		AppName:       testAppName,
+		SessionID:     testSessionID,
+		UserID:        testUserID,
+		StorageUserID: "chat-storage",
+		ChatID:        testChatID,
+	}
+}
+
+func testInvocationContext() context.Context {
+	inv := &agent.Invocation{
+		Session: &session.Session{
+			AppName: testAppName,
+			ID:      testSessionID,
+			UserID:  testUserID,
+		},
+		RunOptions: agent.RunOptions{
+			RuntimeState: conversation.RuntimeState(
+				conversation.Annotation{
+					StorageUserID: "chat-storage",
+					ChatID:        testChatID,
+				},
+			),
+		},
+	}
+	return agent.NewInvocationContext(context.Background(), inv)
+}
+
+func TestNormalizeNameRejectsControlWhitespace(t *testing.T) {
+	t.Parallel()
+
+	_, err := normalizeName("bad\nname")
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), "whitespace"))
+}

--- a/openclaw/mcpregistry/store_test.go
+++ b/openclaw/mcpregistry/store_test.go
@@ -163,6 +163,48 @@ func TestFileStore_UpdateMergesExistingConnection(t *testing.T) {
 	require.Equal(t, "Bearer secret", servers["docs"].Headers["Authorization"])
 }
 
+func TestFileStore_UpdateCanClearFieldsForTransportChange(t *testing.T) {
+	t.Parallel()
+
+	store := NewFileStore(t.TempDir())
+	runtime := testRuntimeContext()
+	_, err := store.Upsert(context.Background(), UpsertRequest{
+		Context: runtime,
+		Name:    "docs",
+		Scope:   ScopeSession,
+		Connection: mcp.ConnectionConfig{
+			Transport: "streamable_http",
+			ServerURL: "https://example.com/mcp",
+			Headers: map[string]string{
+				"Authorization": "Bearer secret",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = store.Upsert(context.Background(), UpsertRequest{
+		Context:        runtime,
+		Name:           "docs",
+		Scope:          ScopeSession,
+		UpdateOnly:     true,
+		ClearServerURL: true,
+		ClearHeaders:   true,
+		Connection: mcp.ConnectionConfig{
+			Transport: "stdio",
+			Command:   "mcporter",
+			Args:      []string{"serve"},
+		},
+	})
+	require.NoError(t, err)
+
+	servers, err := store.ServerConfigs(context.Background(), runtime)
+	require.NoError(t, err)
+	require.Equal(t, "stdio", servers["docs"].Transport)
+	require.Equal(t, "mcporter", servers["docs"].Command)
+	require.Empty(t, servers["docs"].ServerURL)
+	require.Empty(t, servers["docs"].Headers)
+}
+
 func TestFileStore_ScopeVisibilityAndAliasPrecedence(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/mcpregistry/store_test.go
+++ b/openclaw/mcpregistry/store_test.go
@@ -232,13 +232,14 @@ func TestFileStore_DeleteRemovesEntryAndSecret(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	removed, err := store.Delete(context.Background(), DeleteRequest{
+	removed, scope, err := store.Delete(context.Background(), DeleteRequest{
 		Context: runtime,
 		Name:    "docs",
 		Scope:   ScopeSession,
 	})
 	require.NoError(t, err)
 	require.True(t, removed)
+	require.Equal(t, ScopeSession, scope)
 
 	servers, err := store.ServerConfigs(context.Background(), runtime)
 	require.NoError(t, err)
@@ -246,6 +247,41 @@ func TestFileStore_DeleteRemovesEntryAndSecret(t *testing.T) {
 
 	_, err = os.Stat(filepath.Join(dir, defaultSecretsFileName))
 	require.True(t, os.IsNotExist(err))
+}
+
+func TestFileStore_ExactChatEntryOverridesStorageFallback(t *testing.T) {
+	t.Parallel()
+
+	store := NewFileStore(t.TempDir())
+	runtime := testRuntimeContext()
+	fallbackRuntime := runtime
+	fallbackRuntime.ChatID = ""
+	_, err := store.Upsert(context.Background(), UpsertRequest{
+		Context: fallbackRuntime,
+		Name:    "docs",
+		Scope:   ScopeChat,
+		Connection: mcp.ConnectionConfig{
+			ServerURL: "https://fallback.example.com/mcp",
+		},
+	})
+	require.NoError(t, err)
+	_, err = store.Upsert(context.Background(), UpsertRequest{
+		Context: runtime,
+		Name:    "docs",
+		Scope:   ScopeChat,
+		Connection: mcp.ConnectionConfig{
+			ServerURL: "https://chat.example.com/mcp",
+		},
+	})
+	require.NoError(t, err)
+
+	servers, err := store.ServerConfigs(context.Background(), runtime)
+	require.NoError(t, err)
+	require.Equal(t, "https://chat.example.com/mcp", servers["docs"].ServerURL)
+	require.Equal(t,
+		"https://chat.example.com/mcp",
+		servers["chat:docs"].ServerURL)
+	require.NotContains(t, servers["chat:docs"].ServerURL, "fallback")
 }
 
 func testRuntimeContext() RuntimeContext {

--- a/openclaw/mcpregistry/store_test.go
+++ b/openclaw/mcpregistry/store_test.go
@@ -80,6 +80,89 @@ func TestFileStore_RedactsSensitiveValuesAndResolvesRawConfig(t *testing.T) {
 	require.Equal(t, "Bearer secret", servers["docs"].Headers["Authorization"])
 }
 
+func TestFileStore_RedactsSensitiveStdioArgs(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	store := NewFileStore(dir)
+	runtime := testRuntimeContext()
+
+	_, err := store.Upsert(context.Background(), UpsertRequest{
+		Context: runtime,
+		Name:    "docs",
+		Scope:   ScopeSession,
+		Connection: mcp.ConnectionConfig{
+			Transport: "stdio",
+			Command:   "mcporter",
+			Args: []string{
+				"--token",
+				"arg-secret",
+				"--api-key=inline-secret",
+				"--header=Authorization: Bearer header-secret",
+				"https://example.com/mcp?token=url-secret",
+				"--plain",
+				"ok",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	registryBytes, err := os.ReadFile(
+		filepath.Join(dir, defaultRegistryFileName),
+	)
+	require.NoError(t, err)
+	registryText := string(registryBytes)
+	require.NotContains(t, registryText, "arg-secret")
+	require.NotContains(t, registryText, "inline-secret")
+	require.NotContains(t, registryText, "header-secret")
+	require.NotContains(t, registryText, "url-secret")
+	require.Contains(t, registryText, secretRedaction)
+
+	servers, err := store.ServerConfigs(context.Background(), runtime)
+	require.NoError(t, err)
+	require.Equal(t, "arg-secret", servers["docs"].Args[1])
+	require.Equal(t, "--api-key=inline-secret", servers["docs"].Args[2])
+}
+
+func TestFileStore_UpdateMergesExistingConnection(t *testing.T) {
+	t.Parallel()
+
+	store := NewFileStore(t.TempDir())
+	runtime := testRuntimeContext()
+	_, err := store.Upsert(context.Background(), UpsertRequest{
+		Context:     runtime,
+		Name:        "docs",
+		Scope:       ScopeChat,
+		Description: "old docs",
+		Connection: mcp.ConnectionConfig{
+			Transport: "streamable_http",
+			ServerURL: "https://example.com/mcp?token=secret",
+			Headers: map[string]string{
+				"Authorization": "Bearer secret",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	view, err := store.Upsert(context.Background(), UpsertRequest{
+		Context:     runtime,
+		Name:        "docs",
+		Scope:       ScopeChat,
+		Description: "new docs",
+		UpdateOnly:  true,
+		Connection:  mcp.ConnectionConfig{},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "new docs", view.Description)
+	require.True(t, view.HasSensitiveValues)
+
+	servers, err := store.ServerConfigs(context.Background(), runtime)
+	require.NoError(t, err)
+	require.Equal(t, "https://example.com/mcp?token=secret",
+		servers["docs"].ServerURL)
+	require.Equal(t, "Bearer secret", servers["docs"].Headers["Authorization"])
+}
+
 func TestFileStore_ScopeVisibilityAndAliasPrecedence(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/mcpregistry/store_test.go
+++ b/openclaw/mcpregistry/store_test.go
@@ -258,6 +258,26 @@ func TestRuntimeContextFromContext_UsesConversationAnnotation(t *testing.T) {
 	require.Equal(t, "chat-storage", runtime.StorageUserID)
 }
 
+func TestRuntimeContextFromContext_UsesFallbackAppName(t *testing.T) {
+	t.Parallel()
+
+	inv := &agent.Invocation{
+		Session: &session.Session{
+			ID:     testSessionID,
+			UserID: testUserID,
+		},
+	}
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+
+	runtime, err := RuntimeContextFromContext(ctx, testAppName)
+	require.NoError(t, err)
+	require.Equal(t, testAppName, runtime.AppName)
+	require.Equal(t, testSessionID, runtime.SessionID)
+	require.Equal(t, testUserID, runtime.UserID)
+	require.Empty(t, runtime.StorageUserID)
+	require.Empty(t, runtime.ChatID)
+}
+
 func TestFileStore_DeleteRemovesEntryAndSecret(t *testing.T) {
 	t.Parallel()
 
@@ -324,6 +344,162 @@ func TestFileStore_ExactChatEntryOverridesStorageFallback(t *testing.T) {
 		"https://chat.example.com/mcp",
 		servers["chat:docs"].ServerURL)
 	require.NotContains(t, servers["chat:docs"].ServerURL, "fallback")
+}
+
+func TestFileStore_DefaultDirUsesStateDir(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, filepath.Join("/state", "mcp"), DefaultDir("/state"))
+	require.Equal(t, filepath.Join("mcp"), DefaultDir(" "))
+}
+
+func TestFileStore_ListReturnsVisibleScopedViews(t *testing.T) {
+	t.Parallel()
+
+	store := NewFileStore(t.TempDir())
+	runtime := testRuntimeContext()
+	runtime.WorkspaceID = "workspace-1"
+
+	for _, item := range []struct {
+		name  string
+		scope Scope
+		url   string
+	}{
+		{
+			name:  "session-docs",
+			scope: ScopeSession,
+			url:   "https://session.example.com/mcp",
+		},
+		{
+			name:  "user-docs",
+			scope: ScopeUser,
+			url:   "https://user.example.com/mcp",
+		},
+		{
+			name:  "workspace-docs",
+			scope: ScopeWorkspace,
+			url:   "https://workspace.example.com/mcp",
+		},
+		{
+			name:  "global-docs",
+			scope: ScopeGlobal,
+			url:   "https://global.example.com/mcp",
+		},
+	} {
+		_, err := store.Upsert(context.Background(), UpsertRequest{
+			Context: runtime,
+			Name:    item.name,
+			Scope:   item.scope,
+			Connection: mcp.ConnectionConfig{
+				ServerURL: item.url,
+			},
+		})
+		require.NoError(t, err)
+	}
+
+	views, err := store.List(context.Background(), runtime)
+	require.NoError(t, err)
+	require.Len(t, views, 4)
+	require.Equal(t, ScopeSession, views[0].Scope)
+	require.Equal(t, ScopeGlobal, views[3].Scope)
+
+	otherRuntime := runtime
+	otherRuntime.SessionID = "session-2"
+	otherRuntime.UserID = "user-2"
+	otherRuntime.ChatID = "chat-2"
+	otherRuntime.StorageUserID = "chat-storage-2"
+
+	views, err = store.List(context.Background(), otherRuntime)
+	require.NoError(t, err)
+	require.Len(t, views, 2)
+	require.Equal(t, ScopeWorkspace, views[0].Scope)
+	require.Equal(t, ScopeGlobal, views[1].Scope)
+}
+
+func TestFileStore_ValidationErrors(t *testing.T) {
+	t.Parallel()
+
+	store := NewFileStore(t.TempDir())
+	runtime := testRuntimeContext()
+
+	_, err := store.Upsert(context.Background(), UpsertRequest{
+		Context: RuntimeContext{},
+		Name:    "docs",
+		Scope:   ScopeSession,
+		Connection: mcp.ConnectionConfig{
+			ServerURL: "https://example.com/mcp",
+		},
+	})
+	require.ErrorIs(t, err, errRegistryContextUnavailable)
+
+	_, err = store.Upsert(context.Background(), UpsertRequest{
+		Context: runtime,
+		Name:    "docs",
+		Scope:   Scope("bad"),
+		Connection: mcp.ConnectionConfig{
+			ServerURL: "https://example.com/mcp",
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported mcp registry scope")
+
+	_, err = store.Upsert(context.Background(), UpsertRequest{
+		Context: runtime,
+		Name:    "docs",
+		Scope:   ScopeWorkspace,
+		Connection: mcp.ConnectionConfig{
+			ServerURL: "https://example.com/mcp",
+		},
+	})
+	require.ErrorIs(t, err, errRegistryContextUnavailable)
+
+	_, err = store.Upsert(context.Background(), UpsertRequest{
+		Context: runtime,
+		Name:    "docs",
+		Connection: mcp.ConnectionConfig{
+			Transport: transportStdio,
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "stdio MCP requires command")
+
+	_, err = store.Upsert(context.Background(), UpsertRequest{
+		Context: runtime,
+		Name:    "docs",
+		Connection: mcp.ConnectionConfig{
+			Transport: transportStreamable,
+			ServerURL: "file:///tmp/mcp",
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "http or https")
+
+	_, err = store.Upsert(context.Background(), UpsertRequest{
+		Context: runtime,
+		Name:    "docs",
+		Connection: mcp.ConnectionConfig{
+			Transport: transportStreamable,
+			ServerURL: "https://example.com/mcp",
+			Command:   "mcporter",
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "HTTP MCP cannot use command")
+}
+
+func TestFileStore_ReadJSONFileHandlesEmptyAndInvalidFiles(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "state.json")
+	require.NoError(t, os.WriteFile(path, []byte(" \n"), 0o600))
+
+	state, err := readJSONFile[registryState](path)
+	require.NoError(t, err)
+	require.Empty(t, state.Entries)
+
+	require.NoError(t, os.WriteFile(path, []byte("{"), 0o600))
+	_, err = readJSONFile[registryState](path)
+	require.Error(t, err)
 }
 
 func testRuntimeContext() RuntimeContext {

--- a/openclaw/mcpregistry/tools.go
+++ b/openclaw/mcpregistry/tools.go
@@ -34,16 +34,22 @@ type registryTools struct {
 }
 
 type upsertInput struct {
-	Name        string            `json:"name"`
-	Scope       string            `json:"scope,omitempty"`
-	Description string            `json:"description,omitempty"`
-	Transport   string            `json:"transport,omitempty"`
-	ServerURL   string            `json:"server_url,omitempty"`
-	Headers     map[string]string `json:"headers,omitempty"`
-	Command     string            `json:"command,omitempty"`
-	Args        []string          `json:"args,omitempty"`
-	TimeoutMS   int64             `json:"timeout_ms,omitempty"`
-	AllowUpdate bool              `json:"allow_update,omitempty"`
+	Name             string            `json:"name"`
+	Scope            string            `json:"scope,omitempty"`
+	Description      string            `json:"description,omitempty"`
+	Transport        string            `json:"transport,omitempty"`
+	ServerURL        string            `json:"server_url,omitempty"`
+	Headers          map[string]string `json:"headers,omitempty"`
+	Command          string            `json:"command,omitempty"`
+	Args             []string          `json:"args,omitempty"`
+	TimeoutMS        int64             `json:"timeout_ms,omitempty"`
+	ClearServerURL   bool              `json:"clear_server_url,omitempty"`
+	ClearHeaders     bool              `json:"clear_headers,omitempty"`
+	ClearCommand     bool              `json:"clear_command,omitempty"`
+	ClearArgs        bool              `json:"clear_args,omitempty"`
+	ClearTimeout     bool              `json:"clear_timeout,omitempty"`
+	ClearDescription bool              `json:"clear_description,omitempty"`
+	AllowUpdate      bool              `json:"allow_update,omitempty"`
 }
 
 type removeInput struct {
@@ -144,13 +150,19 @@ func (t registryTools) upsert(
 		Description: input.Description,
 	}
 	return t.store.Upsert(ctx, UpsertRequest{
-		Context:     runtime,
-		Name:        input.Name,
-		Scope:       Scope(input.Scope),
-		Description: input.Description,
-		Connection:  conn,
-		UpdateOnly:  updateOnly,
-		AllowUpdate: input.AllowUpdate,
+		Context:          runtime,
+		Name:             input.Name,
+		Scope:            Scope(input.Scope),
+		Description:      input.Description,
+		Connection:       conn,
+		ClearServerURL:   input.ClearServerURL,
+		ClearHeaders:     input.ClearHeaders,
+		ClearCommand:     input.ClearCommand,
+		ClearArgs:        input.ClearArgs,
+		ClearTimeout:     input.ClearTimeout,
+		ClearDescription: input.ClearDescription,
+		UpdateOnly:       updateOnly,
+		AllowUpdate:      input.AllowUpdate,
 	})
 }
 
@@ -245,7 +257,9 @@ const addToolDescription = "" +
 const updateToolDescription = "" +
 	"Update an existing MCP registry entry in the selected scope. Use this " +
 	"when the user changes the URL, token, headers, command, or " +
-	"description of an already configured MCP server. Never echo secrets."
+	"description of an already configured MCP server. For transport changes, " +
+	"use clear_server_url/clear_headers/clear_command/clear_args to remove " +
+	"fields from the previous transport. Never echo secrets."
 
 const removeToolDescription = "" +
 	"Remove an MCP registry entry from the selected scope. Default scope is " +

--- a/openclaw/mcpregistry/tools.go
+++ b/openclaw/mcpregistry/tools.go
@@ -162,7 +162,7 @@ func (t registryTools) remove(
 	if err != nil {
 		return removeOutput{}, err
 	}
-	removed, err := t.store.Delete(ctx, DeleteRequest{
+	removed, scope, err := t.store.Delete(ctx, DeleteRequest{
 		Context: runtime,
 		Name:    input.Name,
 		Scope:   Scope(input.Scope),
@@ -173,7 +173,7 @@ func (t registryTools) remove(
 	return removeOutput{
 		Removed: removed,
 		Name:    strings.TrimSpace(input.Name),
-		Scope:   strings.TrimSpace(input.Scope),
+		Scope:   string(scope),
 	}, nil
 }
 

--- a/openclaw/mcpregistry/tools.go
+++ b/openclaw/mcpregistry/tools.go
@@ -1,0 +1,263 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package mcpregistry
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+	"trpc.group/trpc-go/trpc-agent-go/tool/function"
+	"trpc.group/trpc-go/trpc-agent-go/tool/mcp"
+)
+
+const (
+	ToolAdd    = "mcp_registry_add"
+	ToolUpdate = "mcp_registry_update"
+	ToolRemove = "mcp_registry_remove"
+	ToolList   = "mcp_registry_list"
+	ToolTest   = "mcp_registry_test"
+)
+
+type registryTools struct {
+	store   *FileStore
+	appName string
+}
+
+type upsertInput struct {
+	Name        string            `json:"name"`
+	Scope       string            `json:"scope,omitempty"`
+	Description string            `json:"description,omitempty"`
+	Transport   string            `json:"transport,omitempty"`
+	ServerURL   string            `json:"server_url,omitempty"`
+	Headers     map[string]string `json:"headers,omitempty"`
+	Command     string            `json:"command,omitempty"`
+	Args        []string          `json:"args,omitempty"`
+	TimeoutMS   int64             `json:"timeout_ms,omitempty"`
+	AllowUpdate bool              `json:"allow_update,omitempty"`
+}
+
+type removeInput struct {
+	Name  string `json:"name"`
+	Scope string `json:"scope,omitempty"`
+}
+
+type listInput struct{}
+
+type listOutput struct {
+	Servers []EntryView `json:"servers"`
+}
+
+type testInput struct {
+	Name  string `json:"name"`
+	Scope string `json:"scope,omitempty"`
+}
+
+type testOutput struct {
+	Accessible        bool   `json:"accessible"`
+	Selector          string `json:"selector,omitempty"`
+	QualifiedSelector string `json:"qualified_selector,omitempty"`
+	Message           string `json:"message"`
+}
+
+type removeOutput struct {
+	Removed bool   `json:"removed"`
+	Name    string `json:"name"`
+	Scope   string `json:"scope,omitempty"`
+}
+
+// NewTools creates registry management tools backed by store.
+func NewTools(store *FileStore, appName string) []tool.Tool {
+	tools := registryTools{
+		store:   store,
+		appName: strings.TrimSpace(appName),
+	}
+	return []tool.Tool{
+		function.NewFunctionTool(
+			tools.add,
+			function.WithName(ToolAdd),
+			function.WithDescription(addToolDescription),
+		),
+		function.NewFunctionTool(
+			tools.update,
+			function.WithName(ToolUpdate),
+			function.WithDescription(updateToolDescription),
+		),
+		function.NewFunctionTool(
+			tools.remove,
+			function.WithName(ToolRemove),
+			function.WithDescription(removeToolDescription),
+		),
+		function.NewFunctionTool(
+			tools.list,
+			function.WithName(ToolList),
+			function.WithDescription(listToolDescription),
+		),
+		function.NewFunctionTool(
+			tools.test,
+			function.WithName(ToolTest),
+			function.WithDescription(testToolDescription),
+		),
+	}
+}
+
+func (t registryTools) add(
+	ctx context.Context,
+	input upsertInput,
+) (EntryView, error) {
+	return t.upsert(ctx, input, false)
+}
+
+func (t registryTools) update(
+	ctx context.Context,
+	input upsertInput,
+) (EntryView, error) {
+	input.AllowUpdate = true
+	return t.upsert(ctx, input, true)
+}
+
+func (t registryTools) upsert(
+	ctx context.Context,
+	input upsertInput,
+	updateOnly bool,
+) (EntryView, error) {
+	runtime, err := RuntimeContextFromContext(ctx, t.appName)
+	if err != nil {
+		return EntryView{}, err
+	}
+	conn := mcp.ConnectionConfig{
+		Transport:   input.Transport,
+		ServerURL:   input.ServerURL,
+		Headers:     input.Headers,
+		Command:     input.Command,
+		Args:        input.Args,
+		Timeout:     time.Duration(input.TimeoutMS) * time.Millisecond,
+		Description: input.Description,
+	}
+	return t.store.Upsert(ctx, UpsertRequest{
+		Context:     runtime,
+		Name:        input.Name,
+		Scope:       Scope(input.Scope),
+		Description: input.Description,
+		Connection:  conn,
+		UpdateOnly:  updateOnly,
+		AllowUpdate: input.AllowUpdate,
+	})
+}
+
+func (t registryTools) remove(
+	ctx context.Context,
+	input removeInput,
+) (removeOutput, error) {
+	runtime, err := RuntimeContextFromContext(ctx, t.appName)
+	if err != nil {
+		return removeOutput{}, err
+	}
+	removed, err := t.store.Delete(ctx, DeleteRequest{
+		Context: runtime,
+		Name:    input.Name,
+		Scope:   Scope(input.Scope),
+	})
+	if err != nil {
+		return removeOutput{}, err
+	}
+	return removeOutput{
+		Removed: removed,
+		Name:    strings.TrimSpace(input.Name),
+		Scope:   strings.TrimSpace(input.Scope),
+	}, nil
+}
+
+func (t registryTools) list(
+	ctx context.Context,
+	_ listInput,
+) (listOutput, error) {
+	runtime, err := RuntimeContextFromContext(ctx, t.appName)
+	if err != nil {
+		return listOutput{}, err
+	}
+	servers, err := t.store.List(ctx, runtime)
+	if err != nil {
+		return listOutput{}, err
+	}
+	return listOutput{Servers: servers}, nil
+}
+
+func (t registryTools) test(
+	ctx context.Context,
+	input testInput,
+) (testOutput, error) {
+	name, err := normalizeName(input.Name)
+	if err != nil {
+		return testOutput{}, err
+	}
+	runtime, err := RuntimeContextFromContext(ctx, t.appName)
+	if err != nil {
+		return testOutput{}, err
+	}
+	servers, err := t.store.List(ctx, runtime)
+	if err != nil {
+		return testOutput{}, err
+	}
+	scope := Scope(strings.ToLower(strings.TrimSpace(input.Scope)))
+	for _, server := range servers {
+		if server.Name != name {
+			continue
+		}
+		if scope != "" && server.Scope != scope {
+			continue
+		}
+		return testOutput{
+			Accessible:        true,
+			Selector:          server.Selector,
+			QualifiedSelector: server.QualifiedSelector,
+			Message: "Registry entry is visible. Use mcp_list_tools " +
+				"with selector to test the live MCP connection.",
+		}, nil
+	}
+	return testOutput{
+		Accessible: false,
+		Message: fmt.Sprintf(
+			"MCP registry entry %q is not visible in this turn",
+			name,
+		),
+	}, nil
+}
+
+const addToolDescription = "" +
+	"Persist an MCP server for future turns. Use this when the user asks " +
+	"to configure, remember, add, or persist an MCP connection. Default " +
+	"scope is session, so /new or another chat will not inherit it. Use " +
+	"scope=chat only when the user wants the current chat or group to " +
+	"share it. Use scope=user for the current actor across chats. Use " +
+	"scope=global only for an explicit instance-wide admin-style request. " +
+	"Never echo secrets after calling this tool."
+
+const updateToolDescription = "" +
+	"Update an existing MCP registry entry in the selected scope. Use this " +
+	"when the user changes the URL, token, headers, command, or " +
+	"description of an already configured MCP server. Never echo secrets."
+
+const removeToolDescription = "" +
+	"Remove an MCP registry entry from the selected scope. Default scope is " +
+	"session. Use this when the user asks to forget, remove, clear, or " +
+	"delete a configured MCP server."
+
+const listToolDescription = "" +
+	"List MCP registry entries visible to the current turn. Use this " +
+	"before saying no MCP server is configured. Returned URLs and headers " +
+	"are safe views with sensitive values redacted."
+
+const testToolDescription = "" +
+	"Check whether a named MCP registry entry is visible in the current " +
+	"turn and return the selector to use with mcp_list_tools. This tool " +
+	"does not expose secrets."

--- a/openclaw/mcpregistry/tools_test.go
+++ b/openclaw/mcpregistry/tools_test.go
@@ -1,0 +1,161 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package mcpregistry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testDocsName        = "docs"
+	testDocsDescription = "Docs MCP"
+	testDocsURL         = "https://example.com/mcp?token=secret"
+	testUpdatedDocsDesc = "Updated docs"
+	testRegistryCommand = "mcporter"
+)
+
+func TestNewTools_ReturnsRegistryManagementTools(t *testing.T) {
+	t.Parallel()
+
+	tools := NewTools(NewFileStore(t.TempDir()), " "+testAppName+" ")
+	names := make(map[string]struct{}, len(tools))
+	for _, tl := range tools {
+		names[tl.Declaration().Name] = struct{}{}
+	}
+
+	require.Contains(t, names, ToolAdd)
+	require.Contains(t, names, ToolUpdate)
+	require.Contains(t, names, ToolRemove)
+	require.Contains(t, names, ToolList)
+	require.Contains(t, names, ToolTest)
+}
+
+func TestRegistryTools_ManageVisibleEntries(t *testing.T) {
+	t.Parallel()
+
+	tools := registryTools{
+		store:   NewFileStore(t.TempDir()),
+		appName: testAppName,
+	}
+	ctx := testInvocationContext()
+
+	added, err := tools.add(ctx, upsertInput{
+		Name:        testDocsName,
+		Scope:       string(ScopeChat),
+		Description: testDocsDescription,
+		ServerURL:   testDocsURL,
+		Headers: map[string]string{
+			"Authorization": "Bearer secret",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, ScopeChat, added.Scope)
+	require.Equal(t, testDocsName, added.Selector)
+	require.Equal(t, testDocsDescription, added.Description)
+	require.True(t, added.HasSensitiveValues)
+	require.NotContains(t, added.ServerURL, "secret")
+
+	listed, err := tools.list(ctx, listInput{})
+	require.NoError(t, err)
+	require.Len(t, listed.Servers, 1)
+	require.Equal(t, testDocsName, listed.Servers[0].Name)
+
+	visible, err := tools.test(ctx, testInput{Name: testDocsName})
+	require.NoError(t, err)
+	require.True(t, visible.Accessible)
+	require.Equal(t, testDocsName, visible.Selector)
+	require.Contains(t, visible.Message, "mcp_list_tools")
+
+	notInUserScope, err := tools.test(ctx, testInput{
+		Name:  testDocsName,
+		Scope: string(ScopeUser),
+	})
+	require.NoError(t, err)
+	require.False(t, notInUserScope.Accessible)
+
+	updated, err := tools.update(ctx, upsertInput{
+		Name:             testDocsName,
+		Scope:            string(ScopeChat),
+		Description:      testUpdatedDocsDesc,
+		Transport:        transportStdio,
+		Command:          testRegistryCommand,
+		Args:             []string{"serve"},
+		TimeoutMS:        1000,
+		ClearServerURL:   true,
+		ClearHeaders:     true,
+		ClearDescription: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, testRegistryCommand, updated.Command)
+	require.Equal(t, transportStdio, updated.Transport)
+	require.Equal(t, testUpdatedDocsDesc, updated.Description)
+	require.False(t, updated.HasSensitiveValues)
+
+	removed, err := tools.remove(ctx, removeInput{
+		Name:  testDocsName,
+		Scope: string(ScopeChat),
+	})
+	require.NoError(t, err)
+	require.True(t, removed.Removed)
+	require.Equal(t, testDocsName, removed.Name)
+	require.Equal(t, string(ScopeChat), removed.Scope)
+
+	missing, err := tools.test(ctx, testInput{Name: testDocsName})
+	require.NoError(t, err)
+	require.False(t, missing.Accessible)
+}
+
+func TestRegistryTools_ErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	tools := registryTools{
+		store:   NewFileStore(t.TempDir()),
+		appName: testAppName,
+	}
+	ctx := testInvocationContext()
+
+	_, err := tools.list(context.Background(), listInput{})
+	require.ErrorIs(t, err, errRegistryContextUnavailable)
+
+	_, err = tools.add(context.Background(), upsertInput{
+		Name:      testDocsName,
+		ServerURL: "https://example.com/mcp",
+	})
+	require.ErrorIs(t, err, errRegistryContextUnavailable)
+
+	_, err = tools.remove(context.Background(), removeInput{
+		Name: testDocsName,
+	})
+	require.ErrorIs(t, err, errRegistryContextUnavailable)
+
+	_, err = tools.test(context.Background(), testInput{
+		Name: testDocsName,
+	})
+	require.ErrorIs(t, err, errRegistryContextUnavailable)
+
+	_, err = tools.add(ctx, upsertInput{Name: testDocsName})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported MCP transport")
+
+	_, err = tools.update(ctx, upsertInput{
+		Name:      testDocsName,
+		ServerURL: "https://example.com/mcp",
+	})
+	require.ErrorIs(t, err, errRegistryEntryNotFound)
+
+	_, err = tools.remove(ctx, removeInput{Name: "bad\nname"})
+	require.Error(t, err)
+
+	_, err = tools.test(ctx, testInput{Name: "bad\nname"})
+	require.Error(t, err)
+}

--- a/openclaw/mcpregistry/tools_test.go
+++ b/openclaw/mcpregistry/tools_test.go
@@ -84,16 +84,15 @@ func TestRegistryTools_ManageVisibleEntries(t *testing.T) {
 	require.False(t, notInUserScope.Accessible)
 
 	updated, err := tools.update(ctx, upsertInput{
-		Name:             testDocsName,
-		Scope:            string(ScopeChat),
-		Description:      testUpdatedDocsDesc,
-		Transport:        transportStdio,
-		Command:          testRegistryCommand,
-		Args:             []string{"serve"},
-		TimeoutMS:        1000,
-		ClearServerURL:   true,
-		ClearHeaders:     true,
-		ClearDescription: true,
+		Name:           testDocsName,
+		Scope:          string(ScopeChat),
+		Description:    testUpdatedDocsDesc,
+		Transport:      transportStdio,
+		Command:        testRegistryCommand,
+		Args:           []string{"serve"},
+		TimeoutMS:      1000,
+		ClearServerURL: true,
+		ClearHeaders:   true,
 	})
 	require.NoError(t, err)
 	require.Equal(t, testRegistryCommand, updated.Command)

--- a/openclaw/skills/mcporter/SKILL.md
+++ b/openclaw/skills/mcporter/SKILL.md
@@ -26,6 +26,13 @@ metadata:
 
 Use `mcporter` to work with MCP servers directly.
 
+In OpenClaw, if `mcp_registry_add`, `mcp_registry_list`,
+`mcp_list_tools`, and `mcp_call` are available, prefer those runtime tools
+for user-configured MCP servers. Use `mcporter` as a fallback when the
+runtime registry tools are unavailable or when the user explicitly asks for
+mcporter CLI/config work. Never echo MCP tokens, API keys, cookies, or auth
+headers back to the user.
+
 Quick start
 
 - `mcporter list`

--- a/tool/mcpbroker/broker.go
+++ b/tool/mcpbroker/broker.go
@@ -29,7 +29,8 @@ const (
 )
 
 const (
-	originCode = "code"
+	originCode     = "code"
+	originResolver = "resolver"
 )
 
 const (
@@ -55,11 +56,17 @@ type Option func(*brokerOptions)
 
 type brokerOptions struct {
 	servers                     map[string]mcpcfg.ConnectionConfig
+	serverResolver              ServerResolver
 	allowAdHocHTTP              bool
 	adhocSensitiveHeaderDenyset map[string]struct{}
 	httpHeaderInjector          HTTPHeaderInjector
 	errorInterceptor            ErrorInterceptor
 }
+
+// ServerResolver resolves named MCP servers for the current tool call.
+type ServerResolver func(
+	context.Context,
+) (map[string]mcpcfg.ConnectionConfig, error)
 
 // HTTPHeaderInjector resolves per-run HTTP headers for MCP requests.
 type HTTPHeaderInjector func(context.Context, *HeaderInjectRequest) (map[string]string, error)
@@ -129,6 +136,15 @@ func WithServers(servers map[string]mcpcfg.ConnectionConfig) Option {
 	}
 }
 
+// WithServerResolver adds named MCP server configurations resolved at
+// tool-call time. This is useful when the visible MCP servers depend on the
+// current user, chat, session, or workspace.
+func WithServerResolver(resolver ServerResolver) Option {
+	return func(opts *brokerOptions) {
+		opts.serverResolver = resolver
+	}
+}
+
 // WithAllowAdHocHTTP controls whether ad-hoc HTTP MCP targets are allowed.
 func WithAllowAdHocHTTP(enabled bool) Option {
 	return func(opts *brokerOptions) {
@@ -182,7 +198,17 @@ type namedServer struct {
 	Config     mcpcfg.ConnectionConfig
 }
 
-func (b *Broker) resolveNamedServers() ([]namedServer, map[string]namedServer, error) {
+func (b *Broker) resolveNamedServers() (
+	[]namedServer,
+	map[string]namedServer,
+	error,
+) {
+	return b.resolveNamedServersWithContext(context.Background())
+}
+
+func (b *Broker) resolveNamedServersWithContext(
+	ctx context.Context,
+) ([]namedServer, map[string]namedServer, error) {
 	merged := make(map[string]namedServer, len(b.options.servers))
 	for name, cfg := range b.options.servers {
 		server, serverErr := normalizeNamedServer(name, cfg, originCode)
@@ -190,9 +216,35 @@ func (b *Broker) resolveNamedServers() ([]namedServer, map[string]namedServer, e
 			return nil, nil, serverErr
 		}
 		if _, exists := merged[server.Name]; exists {
-			return nil, nil, fmt.Errorf("duplicate MCP server name after normalization: %s", server.Name)
+			return nil, nil, fmt.Errorf(
+				"duplicate MCP server name after normalization: %s",
+				server.Name,
+			)
 		}
 		merged[server.Name] = server
+	}
+	if b.options.serverResolver != nil {
+		servers, err := b.options.serverResolver(ctx)
+		if err != nil {
+			return nil, nil, err
+		}
+		for name, cfg := range servers {
+			server, serverErr := normalizeNamedServer(
+				name,
+				cfg,
+				originResolver,
+			)
+			if serverErr != nil {
+				return nil, nil, serverErr
+			}
+			if _, exists := merged[server.Name]; exists {
+				return nil, nil, fmt.Errorf(
+					"duplicate MCP server name after normalization: %s",
+					server.Name,
+				)
+			}
+			merged[server.Name] = server
+		}
 	}
 
 	list := make([]namedServer, 0, len(merged))
@@ -207,6 +259,13 @@ func (b *Broker) resolveNamedServers() ([]namedServer, map[string]namedServer, e
 }
 
 func (b *Broker) resolveTarget(input targetInput) (resolvedTarget, error) {
+	return b.resolveTargetWithContext(context.Background(), input)
+}
+
+func (b *Broker) resolveTargetWithContext(
+	ctx context.Context,
+	input targetInput,
+) (resolvedTarget, error) {
 	serverName := strings.TrimSpace(input.ServerName)
 	urlValue := strings.TrimSpace(input.URL)
 
@@ -215,7 +274,7 @@ func (b *Broker) resolveTarget(input targetInput) (resolvedTarget, error) {
 	}
 
 	if serverName != "" {
-		_, merged, err := b.resolveNamedServers()
+		_, merged, err := b.resolveNamedServersWithContext(ctx)
 		if err != nil {
 			return resolvedTarget{}, err
 		}
@@ -247,7 +306,7 @@ func (b *Broker) resolveTarget(input targetInput) (resolvedTarget, error) {
 }
 
 func (b *Broker) listServers(ctx context.Context, _ listServersInput) (listServersOutput, error) {
-	servers, _, err := b.resolveNamedServers()
+	servers, _, err := b.resolveNamedServersWithContext(ctx)
 	if err != nil {
 		return listServersOutput{}, err
 	}
@@ -264,6 +323,7 @@ func (b *Broker) listServers(ctx context.Context, _ listServersInput) (listServe
 }
 
 func (b *Broker) resolveListSelector(
+	ctx context.Context,
 	selector string,
 	transport string,
 	headers map[string]string,
@@ -274,7 +334,7 @@ func (b *Broker) resolveListSelector(
 	}
 
 	if looksLikeHTTPSelector(selector) {
-		target, err := b.resolveTarget(targetInput{
+		target, err := b.resolveTargetWithContext(ctx, targetInput{
 			URL:       selector,
 			Transport: transport,
 			Headers:   headers,
@@ -285,7 +345,7 @@ func (b *Broker) resolveListSelector(
 		return target, selector, nil
 	}
 
-	target, err := b.resolveTarget(targetInput{
+	target, err := b.resolveTargetWithContext(ctx, targetInput{
 		ServerName: selector,
 		Transport:  transport,
 		Headers:    headers,
@@ -297,6 +357,7 @@ func (b *Broker) resolveListSelector(
 }
 
 func (b *Broker) resolveCallSelector(
+	ctx context.Context,
 	selector string,
 	transport string,
 	headers map[string]string,
@@ -311,7 +372,7 @@ func (b *Broker) resolveCallSelector(
 		if err != nil {
 			return resolvedTarget{}, "", "", err
 		}
-		target, targetErr := b.resolveTarget(targetInput{
+		target, targetErr := b.resolveTargetWithContext(ctx, targetInput{
 			URL:       baseURL,
 			Transport: transport,
 			Headers:   headers,
@@ -322,11 +383,14 @@ func (b *Broker) resolveCallSelector(
 		return target, baseURL, toolName, nil
 	}
 
-	serverName, toolName, err := b.splitNamedToolSelector(selector)
+	serverName, toolName, err := b.splitNamedToolSelectorWithContext(
+		ctx,
+		selector,
+	)
 	if err != nil {
 		return resolvedTarget{}, "", "", err
 	}
-	target, targetErr := b.resolveTarget(targetInput{
+	target, targetErr := b.resolveTargetWithContext(ctx, targetInput{
 		ServerName: serverName,
 		Transport:  transport,
 		Headers:    headers,
@@ -338,12 +402,19 @@ func (b *Broker) resolveCallSelector(
 }
 
 func (b *Broker) splitNamedToolSelector(selector string) (string, string, error) {
+	return b.splitNamedToolSelectorWithContext(context.Background(), selector)
+}
+
+func (b *Broker) splitNamedToolSelectorWithContext(
+	ctx context.Context,
+	selector string,
+) (string, string, error) {
 	selector = strings.TrimSpace(selector)
 	if selector == "" {
 		return "", "", fmt.Errorf("selector is required")
 	}
 
-	_, merged, err := b.resolveNamedServers()
+	_, merged, err := b.resolveNamedServersWithContext(ctx)
 	if err != nil {
 		return "", "", err
 	}

--- a/tool/mcpbroker/broker.go
+++ b/tool/mcpbroker/broker.go
@@ -274,20 +274,13 @@ func (b *Broker) resolveTargetWithContext(
 	}
 
 	if serverName != "" {
-		_, merged, err := b.resolveNamedServersWithContext(ctx)
+		_, merged, err := b.resolveNamedServersWithContext(
+			ctx,
+		)
 		if err != nil {
 			return resolvedTarget{}, err
 		}
-		server, ok := merged[serverName]
-		if !ok {
-			return resolvedTarget{}, fmt.Errorf("unknown MCP server: %s", serverName)
-		}
-		return resolvedTarget{
-			Name:       server.Name,
-			Origin:     server.Origin,
-			TargetType: server.TargetType,
-			Config:     server.Config,
-		}, nil
+		return resolveNamedTarget(serverName, merged)
 	}
 
 	if !b.options.allowAdHocHTTP {
@@ -383,22 +376,40 @@ func (b *Broker) resolveCallSelector(
 		return target, baseURL, toolName, nil
 	}
 
-	serverName, toolName, err := b.splitNamedToolSelectorWithContext(
-		ctx,
+	_, merged, err := b.resolveNamedServersWithContext(ctx)
+	if err != nil {
+		return resolvedTarget{}, "", "", err
+	}
+
+	serverName, toolName, err := splitNamedToolSelectorFromServers(
+		merged,
 		selector,
 	)
 	if err != nil {
 		return resolvedTarget{}, "", "", err
 	}
-	target, targetErr := b.resolveTargetWithContext(ctx, targetInput{
-		ServerName: serverName,
-		Transport:  transport,
-		Headers:    headers,
-	})
+	target, targetErr := resolveNamedTarget(serverName, merged)
 	if targetErr != nil {
 		return resolvedTarget{}, "", "", targetErr
 	}
 	return target, serverName, toolName, nil
+}
+
+func resolveNamedTarget(
+	serverName string,
+	merged map[string]namedServer,
+) (resolvedTarget, error) {
+	serverName = strings.TrimSpace(serverName)
+	server, ok := merged[serverName]
+	if !ok {
+		return resolvedTarget{}, fmt.Errorf("unknown MCP server: %s", serverName)
+	}
+	return resolvedTarget{
+		Name:       server.Name,
+		Origin:     server.Origin,
+		TargetType: server.TargetType,
+		Config:     server.Config,
+	}, nil
 }
 
 func (b *Broker) splitNamedToolSelector(selector string) (string, string, error) {
@@ -409,14 +420,23 @@ func (b *Broker) splitNamedToolSelectorWithContext(
 	ctx context.Context,
 	selector string,
 ) (string, string, error) {
-	selector = strings.TrimSpace(selector)
-	if selector == "" {
-		return "", "", fmt.Errorf("selector is required")
-	}
-
 	_, merged, err := b.resolveNamedServersWithContext(ctx)
 	if err != nil {
 		return "", "", err
+	}
+	return splitNamedToolSelectorFromServers(
+		merged,
+		selector,
+	)
+}
+
+func splitNamedToolSelectorFromServers(
+	merged map[string]namedServer,
+	selector string,
+) (string, string, error) {
+	selector = strings.TrimSpace(selector)
+	if selector == "" {
+		return "", "", fmt.Errorf("selector is required")
 	}
 
 	bestName := ""

--- a/tool/mcpbroker/broker_test.go
+++ b/tool/mcpbroker/broker_test.go
@@ -262,6 +262,36 @@ func TestListServers_UsesContextServerResolver(t *testing.T) {
 	require.Equal(t, "https://example.com/mcp", target.Config.ServerURL)
 }
 
+func TestResolveCallSelector_UsesOneResolverSnapshot(t *testing.T) {
+	t.Parallel()
+
+	callCount := 0
+	broker := New(
+		WithServerResolver(func(
+			context.Context,
+		) (map[string]legacymcp.ConnectionConfig, error) {
+			callCount++
+			return map[string]legacymcp.ConnectionConfig{
+				"docs": {
+					ServerURL: "https://example.com/mcp",
+				},
+			}, nil
+		}),
+	)
+
+	target, serverName, toolName, err := broker.resolveCallSelector(
+		context.Background(),
+		"docs.search",
+		"",
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, "docs", serverName)
+	require.Equal(t, "search", toolName)
+	require.Equal(t, "https://example.com/mcp", target.Config.ServerURL)
+	require.Equal(t, 1, callCount)
+}
+
 func TestResolveNamedServers_ServerResolverErrors(t *testing.T) {
 	broker := New(
 		WithServerResolver(func(

--- a/tool/mcpbroker/broker_test.go
+++ b/tool/mcpbroker/broker_test.go
@@ -228,6 +228,40 @@ func TestListServers_ReturnsConfiguredServers(t *testing.T) {
 	require.Empty(t, output.Servers[0].Description)
 }
 
+func TestListServers_UsesContextServerResolver(t *testing.T) {
+	type ctxKey struct{}
+
+	broker := New(
+		WithServerResolver(func(
+			ctx context.Context,
+		) (map[string]legacymcp.ConnectionConfig, error) {
+			baseURL, _ := ctx.Value(ctxKey{}).(string)
+			return map[string]legacymcp.ConnectionConfig{
+				"from_context": {
+					ServerURL: baseURL,
+				},
+			}, nil
+		}),
+	)
+
+	ctx := context.WithValue(
+		context.Background(),
+		ctxKey{},
+		"https://example.com/mcp",
+	)
+	output, err := broker.listServers(ctx, listServersInput{})
+	require.NoError(t, err)
+	require.Len(t, output.Servers, 1)
+	require.Equal(t, "from_context", output.Servers[0].Name)
+
+	target, err := broker.resolveTargetWithContext(
+		ctx,
+		targetInput{ServerName: "from_context"},
+	)
+	require.NoError(t, err)
+	require.Equal(t, "https://example.com/mcp", target.Config.ServerURL)
+}
+
 func TestListServers_ReturnsDescription(t *testing.T) {
 	broker := New(
 		WithServers(map[string]legacymcp.ConnectionConfig{

--- a/tool/mcpbroker/broker_test.go
+++ b/tool/mcpbroker/broker_test.go
@@ -262,6 +262,43 @@ func TestListServers_UsesContextServerResolver(t *testing.T) {
 	require.Equal(t, "https://example.com/mcp", target.Config.ServerURL)
 }
 
+func TestResolveNamedServers_ServerResolverErrors(t *testing.T) {
+	broker := New(
+		WithServerResolver(func(
+			context.Context,
+		) (map[string]legacymcp.ConnectionConfig, error) {
+			return nil, fmt.Errorf("resolver failed")
+		}),
+	)
+
+	_, _, err := broker.resolveNamedServersWithContext(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "resolver failed")
+}
+
+func TestResolveNamedServers_ServerResolverRejectsDuplicates(t *testing.T) {
+	broker := New(
+		WithServers(map[string]legacymcp.ConnectionConfig{
+			"dup": {
+				Command: "go",
+			},
+		}),
+		WithServerResolver(func(
+			context.Context,
+		) (map[string]legacymcp.ConnectionConfig, error) {
+			return map[string]legacymcp.ConnectionConfig{
+				" dup ": {
+					Command: "go",
+				},
+			}, nil
+		}),
+	)
+
+	_, _, err := broker.resolveNamedServersWithContext(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duplicate MCP server name")
+}
+
 func TestListServers_ReturnsDescription(t *testing.T) {
 	broker := New(
 		WithServers(map[string]legacymcp.ConnectionConfig{

--- a/tool/mcpbroker/tools.go
+++ b/tool/mcpbroker/tools.go
@@ -119,7 +119,12 @@ func newBrokerTools(b *Broker) []tool.Tool {
 }
 
 func (b *Broker) listTools(ctx context.Context, input listToolsInput) (listToolsOutput, error) {
-	target, selectorPrefix, err := b.resolveListSelector(input.Selector, input.Transport, input.Headers)
+	target, selectorPrefix, err := b.resolveListSelector(
+		ctx,
+		input.Selector,
+		input.Transport,
+		input.Headers,
+	)
 	if err != nil {
 		return listToolsOutput{}, err
 	}
@@ -175,7 +180,12 @@ func (b *Broker) inspectTools(ctx context.Context, input inspectToolsInput) (ins
 		return inspectToolsOutput{}, fmt.Errorf("tools is required and must contain at least one tool name")
 	}
 
-	target, selectorPrefix, err := b.resolveListSelector(input.Selector, input.Transport, input.Headers)
+	target, selectorPrefix, err := b.resolveListSelector(
+		ctx,
+		input.Selector,
+		input.Transport,
+		input.Headers,
+	)
 	if err != nil {
 		return inspectToolsOutput{}, err
 	}
@@ -236,7 +246,12 @@ func (b *Broker) callTool(ctx context.Context, input callToolInput) (callToolOut
 		return callToolOutput{}, fmt.Errorf("arguments is required; pass {} when the MCP tool takes no parameters")
 	}
 
-	target, _, toolName, err := b.resolveCallSelector(input.Selector, input.Transport, input.Headers)
+	target, _, toolName, err := b.resolveCallSelector(
+		ctx,
+		input.Selector,
+		input.Transport,
+		input.Headers,
+	)
 	if err != nil {
 		return callToolOutput{}, err
 	}


### PR DESCRIPTION
## Summary
- add an OpenClaw MCP registry provider with scoped session/chat/user/workspace/global storage
- expose registry management tools alongside broker discovery/call tools
- add context-aware MCP broker server resolution and secret redaction for persisted MCP configs

## Tests
- `go test ./tool/mcpbroker`
- `(cd openclaw && go test ./mcpregistry ./app ./conversation)`