### PR TITLE
test: close mcpbroker HTTP test connections

### DIFF
--- a/tool/mcpbroker/broker_test.go
+++ b/tool/mcpbroker/broker_test.go
@@ -176,6 +176,7 @@ func startBrokerHTTPServerWithOptions(t *testing.T, opts brokerHTTPServerOptions
 }
 
 func (s *brokerHTTPServer) Close() {
+	s.server.CloseClientConnections()
 	s.server.Close()
 }
 


### PR DESCRIPTION
## Summary

Fixes a flaky `tool/mcpbroker` test shutdown path by closing active client connections before waiting for the `httptest.Server` to close.

## Root Cause

`trpc-mcp-go` streamable HTTP clients can leave a GET SSE connection active briefly after the one-shot client is closed. In CI, `httptest.Server.Close()` can start waiting before the SSE handler observes cancellation, causing the root-module `go test` job to hang until the 10 minute timeout.

Observed failure on PR #1714:

```text
httptest.Server blocked in Close after 5 seconds, waiting for connections
panic: test timed out after 10m0s
running tests:
  TestAdHocHTTPServer_ListToolsAndCallTool
```

## Change

The mcpbroker test helper now calls `CloseClientConnections()` before `Close()` so long-lived test HTTP/SSE connections are force-closed during test cleanup.

## Validation

```bash
go test -coverprofile=/tmp/mcpbroker-coverage-full-main.out ./tool/mcpbroker -count=1 -timeout=120s
go test -coverprofile=/tmp/mcpbroker-coverage-target-main.out ./tool/mcpbroker -run '^TestAdHocHTTPServer_ListToolsAndCallTool$' -count=20 -timeout=120s
```
