### PR TITLE
openclaw: prefer private MCP configs over env vars

### DIFF
--- a/openclaw/skills/mcporter/SKILL.md
+++ b/openclaw/skills/mcporter/SKILL.md
@@ -40,10 +40,27 @@ Skill-first MCP shape
 - `references/`: schemas, API notes, or longer operation guides.
 - `scripts/`: wrappers for fragile multi-step calls or post-processing.
 
-Keep raw secrets out of the skill. Prefer environment variables, token helper
-commands, OAuth login state, or platform-managed credentials. If `mcp.json`
-uses a token, reference it by environment variable instead of copying the
-token value into the file.
+Credential handling
+
+- Keep shared, bundled, published, or repo-tracked skills free of raw secrets.
+  Reference environment variables, token helper commands, OAuth login state,
+  runtime config, or platform-managed credentials instead.
+- If the user explicitly provides a complete private MCP config or a
+  credential-bearing endpoint and asks to keep or use it, save it in a local
+  private config file such as skill-local `mcp.json` in a writable
+  user-managed skill root, or a dedicated user-managed private mcporter config
+  file. Keep it non-shared and excluded from source control and packaging. Set
+  file permissions to `0600` when possible. Do not ask the user to re-enter the
+  same value as an environment variable, and do not edit shell startup or
+  trusted env files just to persist it. Do not echo the secret value back in
+  CLI output, logs, or errors; redact or omit token and secret fields from
+  displayed tool results.
+- For bot-global OpenClaw MCP capabilities, prefer a local skill plus
+  skill-local `mcp.json`. Use `mcporter --config path/to/skill/mcp.json ...`
+  as the durable command path. Treat `~/.mcporter/mcporter.json` as an
+  interoperability copy when useful, not as the capability boundary. The
+  credential-bearing source of truth for a durable skill run is the explicit
+  `--config` file you pass.
 
 For a durable MCP skill, first inspect the server schema:
 
@@ -88,5 +105,7 @@ Codegen
 
 Notes
 
-- Config default: `./config/mcporter.json` (override with `--config`).
+- Prefer explicit `--config` for skills. mcporter can also use its default
+  project or user config paths for local ad-hoc CLI work, but shared or
+  packaged skills and automation should always pass an explicit `--config`.
 - Prefer `--output json` for machine-readable results.

--- a/openclaw/skills/skill-creator/SKILL.md
+++ b/openclaw/skills/skill-creator/SKILL.md
@@ -364,7 +364,9 @@ If you used `--examples`, delete any placeholder files that are not needed for t
 
 Write `SKILL.md` as the operating contract for the durable capability. It should explain when the capability applies, the smallest reliable workflow for using it, the important constraints, and the recovery paths that keep future runs moving.
 
-For tool, API, CLI, or MCP integrations, keep the skill as the user-facing capability boundary. Put the invocation recipe, schema lookup command, examples, and domain-specific constraints in the skill. Keep secrets out of the skill; reference environment variables, runtime config, auth helpers, or platform-managed credentials instead.
+For tool, API, CLI, or MCP integrations, keep the skill as the user-facing capability boundary. Put the invocation recipe, schema lookup command, examples, and domain-specific constraints in the skill. Keep shared, bundled, published, or repo-tracked skills free of raw secrets; reference environment variables, runtime config, auth helpers, or platform-managed credentials instead.
+
+If the user explicitly provides a complete private config or credential-bearing endpoint for a local runtime capability, store it in a local private config file such as skill-local `mcp.json` in a writable user-managed skill root, or another dedicated private config path, rather than asking the user to re-enter the same value as an environment variable. Keep that file non-shared, excluded from source control and packaging, and outside repo-tracked skill artifacts. Use restrictive file permissions when possible, do not edit shell startup or trusted env files just to persist it, do not echo secret values back, and keep the skill instructions focused on when and how to use that config.
 
 When the user asks for a capability with contextual limits such as "only for this team", "only in this project", "only when I ask", or "only for these chats", capture those limits in clear natural language in the skill. Treat these limits as behavioral guidance for the model, not as a hard security boundary.
 


### PR DESCRIPTION
## Summary
- clarify that user-provided private MCP configs should be saved as local private config files instead of forcing env vars
- steer bot-global MCP capabilities toward local skills plus skill-local `mcp.json`
- keep shared, bundled, published, or repo-tracked skills secret-free while preserving local private config usability

## Tests
- `go test ./cmd/openclaw` (from `openclaw/`)