### PR TITLE
openclaw: improve stream progress visibility

### DIFF
--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -4039,7 +4039,9 @@ func TestInProcGatewayClient_StreamMessageWithOptions_ProgressAfterText(
 	require.Equal(t, gwproto.StreamEventTypeMessageDelta, events[2].Type)
 	require.Equal(t, firstDelta, events[2].Delta)
 	require.Equal(t, gwproto.StreamEventTypeRunProgress, events[3].Type)
-	require.Equal(t, "Running demo_tool", events[3].Summary)
+	require.Equal(t, "Running local tool", events[3].Summary)
+	require.Equal(t, "demo_tool", events[3].ToolName)
+	require.Equal(t, gwproto.StreamToolStatusRunning, events[3].ToolStatus)
 	require.Equal(t, gwproto.StreamEventTypeRunProgress, events[4].Type)
 	require.Equal(t, gwproto.StreamProgressStageSummarizing, events[4].Stage)
 }

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -3968,6 +3968,82 @@ func TestInProcGatewayClient_StreamMessage_StatusError(t *testing.T) {
 	)
 }
 
+func TestInProcGatewayClient_StreamMessageWithOptions_ProgressAfterText(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	const firstDelta = "checking "
+
+	srv, err := gateway.New(&inProcGWTestRunner{
+		events: []*event.Event{
+			{
+				Response: &model.Response{
+					Object: model.ObjectTypeChatCompletionChunk,
+					Choices: []model.Choice{{
+						Delta: model.Message{Content: firstDelta},
+					}},
+				},
+			},
+			{
+				Response: &model.Response{
+					Object: model.ObjectTypeChatCompletion,
+					Choices: []model.Choice{{
+						Message: model.Message{
+							ToolCalls: []model.ToolCall{{
+								Type: "function",
+								Function: model.FunctionDefinitionParam{
+									Name: "demo_tool",
+								},
+							}},
+						},
+					}},
+				},
+			},
+			{
+				Response: &model.Response{
+					Object: model.ObjectTypeToolResponse,
+				},
+			},
+			{
+				Response: &model.Response{
+					Object: model.ObjectTypeChatCompletion,
+					Choices: []model.Choice{{
+						Message: model.NewAssistantMessage("done"),
+					}},
+					Done: true,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	c := newInProcGatewayClient(srv, appName, nil, nil, "")
+	stream, err := c.StreamMessageWithOptions(
+		context.Background(),
+		gwclient.MessageRequest{
+			From: "u1",
+			Text: "hi",
+		},
+		&gwclient.MessageStreamOptions{
+			ProgressAfterTextDelta: true,
+		},
+	)
+	require.NoError(t, err)
+
+	var events []gwclient.StreamEvent
+	for evt := range stream {
+		events = append(events, evt)
+	}
+	require.Len(t, events, 7)
+	require.Equal(t, gwproto.StreamEventTypeMessageDelta, events[2].Type)
+	require.Equal(t, firstDelta, events[2].Delta)
+	require.Equal(t, gwproto.StreamEventTypeRunProgress, events[3].Type)
+	require.Equal(t, "Running demo_tool", events[3].Summary)
+	require.Equal(t, gwproto.StreamEventTypeRunProgress, events[4].Type)
+	require.Equal(t, gwproto.StreamProgressStageSummarizing, events[4].Stage)
+}
+
 func TestInProcGatewayClient_NilServerFails(t *testing.T) {
 	t.Parallel()
 
@@ -5143,6 +5219,7 @@ type inProcGWTestRunner struct {
 	reply     string
 	requestID string
 	usage     *model.Usage
+	events    []*event.Event
 }
 
 func (r *inProcGWTestRunner) Run(
@@ -5152,6 +5229,15 @@ func (r *inProcGWTestRunner) Run(
 	_ model.Message,
 	_ ...agent.RunOption,
 ) (<-chan *event.Event, error) {
+	if len(r.events) > 0 {
+		ch := make(chan *event.Event, len(r.events))
+		for _, evt := range r.events {
+			ch <- evt
+		}
+		close(ch)
+		return ch, nil
+	}
+
 	reply := r.reply
 	if reply == "" {
 		reply = "ok"

--- a/openclaw/app/inproc_gateway_client.go
+++ b/openclaw/app/inproc_gateway_client.go
@@ -135,11 +135,23 @@ func (c *inProcGatewayClient) StreamMessage(
 	ctx context.Context,
 	req gwclient.MessageRequest,
 ) (<-chan gwclient.StreamEvent, error) {
+	return c.StreamMessageWithOptions(ctx, req, nil)
+}
+
+func (c *inProcGatewayClient) StreamMessageWithOptions(
+	ctx context.Context,
+	req gwclient.MessageRequest,
+	opts *gwclient.MessageStreamOptions,
+) (<-chan gwclient.StreamEvent, error) {
 	if c == nil || c.srv == nil {
 		return nil, errors.New(errNilGatewayServer)
 	}
 
-	stream, apiErr, status := c.srv.StreamMessage(ctx, req)
+	stream, apiErr, status := c.srv.StreamMessageWithOptions(
+		ctx,
+		req,
+		opts,
+	)
 	if err := errorForGWStatus(status, apiErr); err != nil {
 		return nil, err
 	}

--- a/openclaw/gwclient/client.go
+++ b/openclaw/gwclient/client.go
@@ -81,6 +81,9 @@ func NewWithStreamPath(
 // MessageRequest matches the gateway /messages JSON payload.
 type MessageRequest = gwproto.MessageRequest
 
+// MessageStreamOptions controls optional streaming behaviors.
+type MessageStreamOptions = gwproto.MessageStreamOptions
+
 // StreamEvent matches the gateway streaming event payload.
 type StreamEvent = gwproto.StreamEvent
 

--- a/openclaw/gwclient/client_test.go
+++ b/openclaw/gwclient/client_test.go
@@ -446,6 +446,169 @@ func TestClient_StreamMessage_Success(t *testing.T) {
 	require.Equal(t, "req-1", events[4].RequestID)
 }
 
+func TestClient_StreamMessageWithOptions_EncodesOptions(t *testing.T) {
+	t.Parallel()
+
+	type capturedStreamRequest struct {
+		body map[string]any
+		err  error
+	}
+	resultCh := make(chan capturedStreamRequest, 1)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		data, err := io.ReadAll(r.Body)
+		var body map[string]any
+		if err == nil {
+			err = json.Unmarshal(data, &body)
+		}
+
+		w.Header().Set(headerContentType, gwproto.SSEContentType)
+		_, writeErr := io.WriteString(
+			w,
+			"data: {\"type\":\"run.completed\"}\n\n",
+		)
+		if err == nil {
+			err = writeErr
+		}
+		resultCh <- capturedStreamRequest{
+			body: body,
+			err:  err,
+		}
+	})
+
+	cli, err := New(handler, "/v1/gateway/messages", "/cancel")
+	require.NoError(t, err)
+
+	stream, err := cli.StreamMessageWithOptions(
+		context.Background(),
+		MessageRequest{
+			From: "u1",
+			Text: "hello",
+		},
+		&MessageStreamOptions{
+			ProgressAfterTextDelta: true,
+		},
+	)
+	require.NoError(t, err)
+
+	events := collectClientStreamEvents(t, stream)
+	require.Len(t, events, 1)
+	require.Equal(
+		t,
+		gwproto.StreamEventTypeRunCompleted,
+		events[0].Type,
+	)
+
+	var captured capturedStreamRequest
+	select {
+	case captured = <-resultCh:
+	default:
+		t.Fatal("missing captured request body")
+	}
+	require.NoError(t, captured.err)
+	body := captured.body
+	require.Equal(t, "u1", body["from"])
+	streamOptions, ok := body["stream_options"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(
+		t,
+		true,
+		streamOptions["progress_after_text_delta"],
+	)
+}
+
+func TestClient_StreamMessageWithOptions_EnablesGatewayProgressAfterDelta(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	const firstDelta = "checking "
+
+	srv, err := gateway.New(&staticRunner{
+		events: []*event.Event{
+			{
+				Response: &model.Response{
+					Object: model.ObjectTypeChatCompletionChunk,
+					Choices: []model.Choice{{
+						Delta: model.Message{
+							Content: firstDelta,
+						},
+					}},
+				},
+			},
+			{
+				Response: &model.Response{
+					Object: model.ObjectTypeChatCompletion,
+					Choices: []model.Choice{{
+						Message: model.Message{
+							ToolCalls: []model.ToolCall{{
+								Type: "function",
+								Function: model.FunctionDefinitionParam{
+									Name: "demo_tool",
+								},
+							}},
+						},
+					}},
+				},
+			},
+			{
+				Response: &model.Response{
+					Object: model.ObjectTypeToolResponse,
+				},
+			},
+			{
+				Response: &model.Response{
+					Object: model.ObjectTypeChatCompletion,
+					Choices: []model.Choice{{
+						Message: model.NewAssistantMessage("done"),
+					}},
+					Done: true,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	cli, err := New(srv.Handler(), srv.MessagesPath(), srv.CancelPath())
+	require.NoError(t, err)
+
+	stream, err := cli.StreamMessageWithOptions(
+		context.Background(),
+		MessageRequest{
+			From: "u1",
+			Text: "hello",
+		},
+		&MessageStreamOptions{
+			ProgressAfterTextDelta: true,
+		},
+	)
+	require.NoError(t, err)
+
+	events := collectClientStreamEvents(t, stream)
+	require.Len(t, events, 7)
+	require.Equal(
+		t,
+		gwproto.StreamEventTypeMessageDelta,
+		events[2].Type,
+	)
+	require.Equal(t, firstDelta, events[2].Delta)
+	require.Equal(
+		t,
+		gwproto.StreamEventTypeRunProgress,
+		events[3].Type,
+	)
+	require.Equal(t, "Running demo_tool", events[3].Summary)
+	require.Equal(
+		t,
+		gwproto.StreamEventTypeRunProgress,
+		events[4].Type,
+	)
+	require.Equal(
+		t,
+		gwproto.StreamProgressStageSummarizing,
+		events[4].Stage,
+	)
+}
+
 func TestClient_StreamMessage_StatusError(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/gwclient/client_test.go
+++ b/openclaw/gwclient/client_test.go
@@ -542,6 +542,7 @@ func TestClient_StreamMessageWithOptions_EnablesGatewayProgressAfterDelta(
 						Message: model.Message{
 							ToolCalls: []model.ToolCall{{
 								Type: "function",
+								ID:   "call-demo",
 								Function: model.FunctionDefinitionParam{
 									Name: "demo_tool",
 								},
@@ -553,6 +554,13 @@ func TestClient_StreamMessageWithOptions_EnablesGatewayProgressAfterDelta(
 			{
 				Response: &model.Response{
 					Object: model.ObjectTypeToolResponse,
+					Choices: []model.Choice{{
+						Message: model.Message{
+							Role:     model.RoleTool,
+							ToolID:   "call-demo",
+							ToolName: "demo_tool",
+						},
+					}},
 				},
 			},
 			{
@@ -596,7 +604,10 @@ func TestClient_StreamMessageWithOptions_EnablesGatewayProgressAfterDelta(
 		gwproto.StreamEventTypeRunProgress,
 		events[3].Type,
 	)
-	require.Equal(t, "Running demo_tool", events[3].Summary)
+	require.Equal(t, "Running local tool", events[3].Summary)
+	require.Equal(t, "demo_tool", events[3].ToolName)
+	require.Equal(t, "call-demo", events[3].ToolCallID)
+	require.Equal(t, gwproto.StreamToolStatusRunning, events[3].ToolStatus)
 	require.Equal(
 		t,
 		gwproto.StreamEventTypeRunProgress,
@@ -607,6 +618,9 @@ func TestClient_StreamMessageWithOptions_EnablesGatewayProgressAfterDelta(
 		gwproto.StreamProgressStageSummarizing,
 		events[4].Stage,
 	)
+	require.Equal(t, "demo_tool", events[4].ToolName)
+	require.Equal(t, "call-demo", events[4].ToolCallID)
+	require.Equal(t, gwproto.StreamToolStatusCompleted, events[4].ToolStatus)
 }
 
 func TestClient_StreamMessage_StatusError(t *testing.T) {
@@ -823,12 +837,19 @@ func TestParseSSEStream_EventFallbackAndErrors(t *testing.T) {
 		context.Background(),
 		bytes.NewBufferString(
 			"event: run.progress\n"+
-				"data: {\"summary\":\"Preparing\"}\n\n",
+				"data: {\"summary\":\"Preparing\","+
+				"\"tool_name\":\"kb_search\","+
+				"\"tool_call_id\":\"call-1\","+
+				"\"tool_status\":\"running\"}\n\n",
 		),
 		out,
 	)
 	require.NoError(t, err)
-	require.Equal(t, gwproto.StreamEventTypeRunProgress, (<-out).Type)
+	evt := <-out
+	require.Equal(t, gwproto.StreamEventTypeRunProgress, evt.Type)
+	require.Equal(t, "kb_search", evt.ToolName)
+	require.Equal(t, "call-1", evt.ToolCallID)
+	require.Equal(t, gwproto.StreamToolStatusRunning, evt.ToolStatus)
 
 	err = parseSSEStream(
 		context.Background(),

--- a/openclaw/gwclient/stream.go
+++ b/openclaw/gwclient/stream.go
@@ -29,11 +29,32 @@ func (c *Client) StreamMessage(
 	ctx context.Context,
 	req MessageRequest,
 ) (<-chan StreamEvent, error) {
+	return c.streamMessage(ctx, req, nil)
+}
+
+// StreamMessageWithOptions sends one streaming message with opt-in
+// streaming behavior controls.
+func (c *Client) StreamMessageWithOptions(
+	ctx context.Context,
+	req MessageRequest,
+	opts *MessageStreamOptions,
+) (<-chan StreamEvent, error) {
+	return c.streamMessage(ctx, req, opts)
+}
+
+func (c *Client) streamMessage(
+	ctx context.Context,
+	req MessageRequest,
+	opts *MessageStreamOptions,
+) (<-chan StreamEvent, error) {
 	if strings.TrimSpace(c.streamPath) == "" {
 		return nil, errors.New("gwclient: empty stream path")
 	}
 
-	body, err := json.Marshal(req)
+	body, err := json.Marshal(streamMessageRequest{
+		MessageRequest: req,
+		StreamOptions:  opts,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("gwclient: marshal request: %w", err)
 	}
@@ -99,6 +120,11 @@ func (c *Client) StreamMessage(
 	}()
 
 	return out, nil
+}
+
+type streamMessageRequest struct {
+	MessageRequest
+	StreamOptions *MessageStreamOptions `json:"stream_options,omitempty"`
 }
 
 func streamStatusError(status int, body []byte) error {

--- a/openclaw/gwproto/types.go
+++ b/openclaw/gwproto/types.go
@@ -82,6 +82,9 @@ type StreamEventType string
 // StreamProgressStage identifies one high-level run progress stage.
 type StreamProgressStage string
 
+// StreamToolStatus identifies the visible lifecycle of one tool call.
+type StreamToolStatus string
+
 const (
 	// MessagesStreamSuffix is the default suffix for stream routes.
 	MessagesStreamSuffix = ":stream"
@@ -133,6 +136,11 @@ const (
 	StreamProgressStageRunningTool StreamProgressStage = "running_tool"
 	// StreamProgressStageSummarizing marks post-tool answer generation.
 	StreamProgressStageSummarizing StreamProgressStage = "summarizing"
+
+	// StreamToolStatusRunning marks a tool call that has started.
+	StreamToolStatusRunning StreamToolStatus = "running"
+	// StreamToolStatusCompleted marks a tool call result that returned.
+	StreamToolStatusCompleted StreamToolStatus = "completed"
 )
 
 // StreamEvent is one gateway streaming event payload.
@@ -142,14 +150,17 @@ type StreamEvent struct {
 	SessionID string `json:"session_id,omitempty"`
 	RequestID string `json:"request_id,omitempty"`
 
-	Delta     string              `json:"delta,omitempty"`
-	Reply     string              `json:"reply,omitempty"`
-	Stage     StreamProgressStage `json:"stage,omitempty"`
-	Summary   string              `json:"summary,omitempty"`
-	ElapsedMS int64               `json:"elapsed_ms,omitempty"`
-	Usage     *Usage              `json:"usage,omitempty"`
-	Ignored   bool                `json:"ignored,omitempty"`
-	Error     *APIError           `json:"error,omitempty"`
+	Delta      string              `json:"delta,omitempty"`
+	Reply      string              `json:"reply,omitempty"`
+	Stage      StreamProgressStage `json:"stage,omitempty"`
+	Summary    string              `json:"summary,omitempty"`
+	ToolName   string              `json:"tool_name,omitempty"`
+	ToolCallID string              `json:"tool_call_id,omitempty"`
+	ToolStatus StreamToolStatus    `json:"tool_status,omitempty"`
+	ElapsedMS  int64               `json:"elapsed_ms,omitempty"`
+	Usage      *Usage              `json:"usage,omitempty"`
+	Ignored    bool                `json:"ignored,omitempty"`
+	Error      *APIError           `json:"error,omitempty"`
 }
 
 // ContentPartType is the type discriminator for ContentPart.

--- a/openclaw/gwproto/types.go
+++ b/openclaw/gwproto/types.go
@@ -39,6 +39,13 @@ type MessageRequest struct {
 	Extensions map[string]json.RawMessage `json:"extensions,omitempty"`
 }
 
+// MessageStreamOptions controls optional streaming behaviors.
+type MessageStreamOptions struct {
+	// ProgressAfterTextDelta lets opt-in clients receive run.progress
+	// events after the first message.delta event has started.
+	ProgressAfterTextDelta bool `json:"progress_after_text_delta,omitempty"`
+}
+
 // APIError matches gateway error payloads.
 type APIError struct {
 	Type    string `json:"type"`

--- a/openclaw/internal/gateway/process.go
+++ b/openclaw/internal/gateway/process.go
@@ -31,6 +31,7 @@ type preparedMessageRun struct {
 	requestSystemPrompt string
 	inbound             InboundMessage
 	userMsg             model.Message
+	streamOptions       *gwproto.MessageStreamOptions
 	extensions          map[string]json.RawMessage
 }
 
@@ -88,6 +89,7 @@ func (s *Server) ProcessMessage(
 	prepared, earlyRsp, earlyStatus := s.prepareMessageRun(
 		ctx,
 		req,
+		nil,
 		trace,
 	)
 	if earlyRsp != nil {
@@ -177,6 +179,7 @@ func (s *Server) ProcessMessage(
 func (s *Server) prepareMessageRun(
 	ctx context.Context,
 	req gwproto.MessageRequest,
+	opts *gwproto.MessageStreamOptions,
 	trace *debugrecorder.Trace,
 ) (preparedMessageRun, *gwproto.MessageResponse, int) {
 	userMsg, mentionText, err := s.normalizeUserMessage(ctx, req)
@@ -262,8 +265,19 @@ func (s *Server) prepareMessageRun(
 		requestSystemPrompt: strings.TrimSpace(req.RequestSystemPrompt),
 		inbound:             msg,
 		userMsg:             userMsg,
+		streamOptions:       cloneStreamOptions(opts),
 		extensions:          cloneExtensions(req.Extensions),
 	}, nil, http.StatusOK
+}
+
+func cloneStreamOptions(
+	src *gwproto.MessageStreamOptions,
+) *gwproto.MessageStreamOptions {
+	if src == nil {
+		return nil
+	}
+	cloned := *src
+	return &cloned
 }
 
 func cloneExtensions(

--- a/openclaw/internal/gateway/server_test.go
+++ b/openclaw/internal/gateway/server_test.go
@@ -4566,6 +4566,51 @@ func TestServer_HandleMessagesStream_Success(t *testing.T) {
 	require.Contains(t, rr.Body.String(), `"reply":"ok"`)
 }
 
+func TestServer_HandleMessagesStream_ProgressAfterTextDeltaOption(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	const (
+		firstDelta = "checking "
+		replyText  = "done"
+		requestID  = "req-1"
+	)
+
+	srv, err := New(&staticRunner{
+		events: progressAfterDeltaEvents(
+			firstDelta,
+			replyText,
+			requestID,
+		),
+	})
+	require.NoError(t, err)
+
+	reqBody, err := json.Marshal(map[string]any{
+		"from": "u1",
+		"text": "hello",
+		"stream_options": map[string]bool{
+			"progress_after_text_delta": true,
+		},
+	})
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(
+		http.MethodPost,
+		srv.MessagesStreamPath(),
+		bytes.NewReader(reqBody),
+	)
+	srv.Handler().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), "event: message.delta")
+	require.Contains(t, rr.Body.String(), `"tool_name":"`+
+		streamToolReadDocument+`"`)
+	require.Contains(t, rr.Body.String(), `"tool_status":"`+
+		string(gwproto.StreamToolStatusCompleted)+`"`)
+}
+
 func TestServer_HandleMessagesStream_ErrorPaths(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/internal/gateway/server_test.go
+++ b/openclaw/internal/gateway/server_test.go
@@ -3757,8 +3757,9 @@ func TestServer_StreamMessage_ProgressStages(t *testing.T) {
 						Message: model.Message{
 							ToolCalls: []model.ToolCall{{
 								Type: "function",
+								ID:   testReadDocumentToolCallID,
 								Function: model.FunctionDefinitionParam{
-									Name: "read_document",
+									Name: streamToolReadDocument,
 									Arguments: []byte(
 										`{"page":2}`,
 									),
@@ -3771,6 +3772,13 @@ func TestServer_StreamMessage_ProgressStages(t *testing.T) {
 			{
 				Response: &model.Response{
 					Object: model.ObjectTypeToolResponse,
+					Choices: []model.Choice{{
+						Message: model.Message{
+							Role:     model.RoleTool,
+							ToolID:   testReadDocumentToolCallID,
+							ToolName: streamToolReadDocument,
+						},
+					}},
 				},
 			},
 			{
@@ -3827,6 +3835,13 @@ func TestServer_StreamMessage_ProgressStages(t *testing.T) {
 		events[2].Stage,
 	)
 	require.Equal(t, "Reading document page 2", events[2].Summary)
+	require.Equal(t, streamToolReadDocument, events[2].ToolName)
+	require.Equal(t, testReadDocumentToolCallID, events[2].ToolCallID)
+	require.Equal(
+		t,
+		gwproto.StreamToolStatusRunning,
+		events[2].ToolStatus,
+	)
 	require.Equal(
 		t,
 		gwproto.StreamEventTypeRunProgress,
@@ -3838,6 +3853,13 @@ func TestServer_StreamMessage_ProgressStages(t *testing.T) {
 		events[3].Stage,
 	)
 	require.Equal(t, progressSummaryAnswering, events[3].Summary)
+	require.Equal(t, streamToolReadDocument, events[3].ToolName)
+	require.Equal(t, testReadDocumentToolCallID, events[3].ToolCallID)
+	require.Equal(
+		t,
+		gwproto.StreamToolStatusCompleted,
+		events[3].ToolStatus,
+	)
 	require.Equal(
 		t,
 		gwproto.StreamEventTypeMessageDelta,
@@ -3905,6 +3927,13 @@ func TestServer_StreamMessage_ProgressAfterTextDelta(t *testing.T) {
 		events[3].Stage,
 	)
 	require.Equal(t, "Reading document page 2", events[3].Summary)
+	require.Equal(t, streamToolReadDocument, events[3].ToolName)
+	require.Equal(t, testReadDocumentToolCallID, events[3].ToolCallID)
+	require.Equal(
+		t,
+		gwproto.StreamToolStatusRunning,
+		events[3].ToolStatus,
+	)
 	require.Equal(t, gwproto.StreamEventTypeRunProgress, events[4].Type)
 	require.Equal(
 		t,
@@ -3912,6 +3941,13 @@ func TestServer_StreamMessage_ProgressAfterTextDelta(t *testing.T) {
 		events[4].Stage,
 	)
 	require.Equal(t, progressSummaryAnswering, events[4].Summary)
+	require.Equal(t, streamToolReadDocument, events[4].ToolName)
+	require.Equal(t, testReadDocumentToolCallID, events[4].ToolCallID)
+	require.Equal(
+		t,
+		gwproto.StreamToolStatusCompleted,
+		events[4].ToolStatus,
+	)
 	require.Equal(
 		t,
 		gwproto.StreamEventTypeMessageCompleted,
@@ -4033,6 +4069,8 @@ func TestServer_StreamMessage_EmptyOptionsKeepDefaultProgressOrder(
 	)
 }
 
+const testReadDocumentToolCallID = "call-read-document"
+
 func progressAfterDeltaEvents(
 	firstDelta string,
 	replyText string,
@@ -4056,6 +4094,7 @@ func progressAfterDeltaEvents(
 					Message: model.Message{
 						ToolCalls: []model.ToolCall{{
 							Type: "function",
+							ID:   testReadDocumentToolCallID,
 							Function: model.FunctionDefinitionParam{
 								Name: streamToolReadDocument,
 								Arguments: []byte(
@@ -4070,6 +4109,13 @@ func progressAfterDeltaEvents(
 		{
 			Response: &model.Response{
 				Object: model.ObjectTypeToolResponse,
+				Choices: []model.Choice{{
+					Message: model.Message{
+						Role:     model.RoleTool,
+						ToolID:   testReadDocumentToolCallID,
+						ToolName: streamToolReadDocument,
+					},
+				}},
 			},
 		},
 		{
@@ -4107,6 +4153,7 @@ func TestStreamProgressHelpers(t *testing.T) {
 			Choices: []model.Choice{{
 				Message: model.Message{
 					ToolCalls: []model.ToolCall{{
+						ID: testReadDocumentToolCallID,
 						Function: model.FunctionDefinitionParam{
 							Name:      streamToolReadDocument,
 							Arguments: []byte(`{"page":2}`),
@@ -4123,10 +4170,24 @@ func TestStreamProgressHelpers(t *testing.T) {
 		update.stage,
 	)
 	require.Equal(t, "Reading document page 2", update.summary)
+	require.Equal(t, streamToolReadDocument, update.toolName)
+	require.Equal(t, testReadDocumentToolCallID, update.toolCallID)
+	require.Equal(
+		t,
+		gwproto.StreamToolStatusRunning,
+		update.toolStatus,
+	)
 
 	update, ok = progressUpdateFromRunnerEvent(&event.Event{
 		Response: &model.Response{
 			Object: model.ObjectTypeToolResponse,
+			Choices: []model.Choice{{
+				Message: model.Message{
+					Role:     model.RoleTool,
+					ToolID:   testReadDocumentToolCallID,
+					ToolName: streamToolReadDocument,
+				},
+			}},
 		},
 	})
 	require.True(t, ok)
@@ -4136,12 +4197,20 @@ func TestStreamProgressHelpers(t *testing.T) {
 		update.stage,
 	)
 	require.Equal(t, progressSummaryAnswering, update.summary)
+	require.Equal(t, streamToolReadDocument, update.toolName)
+	require.Equal(t, testReadDocumentToolCallID, update.toolCallID)
+	require.Equal(
+		t,
+		gwproto.StreamToolStatusCompleted,
+		update.toolStatus,
+	)
 }
 
 func TestToolCallProgressSummaries(t *testing.T) {
 	t.Parallel()
 
 	update, ok := progressFromToolCall(model.ToolCall{
+		ID: testReadDocumentToolCallID,
 		Function: model.FunctionDefinitionParam{
 			Name:      streamToolReadSheet,
 			Arguments: []byte(`{"start_row":2,"end_row":4}`),
@@ -4154,6 +4223,13 @@ func TestToolCallProgressSummaries(t *testing.T) {
 		update.stage,
 	)
 	require.Equal(t, "Reading spreadsheet rows 2-4", update.summary)
+	require.Equal(t, streamToolReadSheet, update.toolName)
+	require.Equal(t, testReadDocumentToolCallID, update.toolCallID)
+	require.Equal(
+		t,
+		gwproto.StreamToolStatusRunning,
+		update.toolStatus,
+	)
 
 	update, ok = progressFromToolCall(model.ToolCall{
 		Function: model.FunctionDefinitionParam{
@@ -4193,7 +4269,8 @@ func TestToolCallProgressSummaries(t *testing.T) {
 		},
 	})
 	require.True(t, ok)
-	require.Equal(t, "Running custom_tool", update.summary)
+	require.Equal(t, progressSummaryTool, update.summary)
+	require.Equal(t, "custom_tool", update.toolName)
 
 	_, ok = progressFromToolCall(model.ToolCall{})
 	require.False(t, ok)
@@ -4234,16 +4311,20 @@ func TestSendProgressUpdateAndHelpers(t *testing.T) {
 		out,
 		run,
 		state,
-		gwproto.StreamProgressStagePreparing,
-		progressSummaryPrepare,
+		progressUpdate{
+			stage:   gwproto.StreamProgressStagePreparing,
+			summary: progressSummaryPrepare,
+		},
 	))
 	require.True(t, sendProgressUpdate(
 		ctx,
 		out,
 		run,
 		state,
-		gwproto.StreamProgressStagePreparing,
-		progressSummaryPrepare,
+		progressUpdate{
+			stage:   gwproto.StreamProgressStagePreparing,
+			summary: progressSummaryPrepare,
+		},
 	))
 	require.Len(t, out, 1)
 	evt := <-out
@@ -4262,8 +4343,10 @@ func TestSendProgressUpdateAndHelpers(t *testing.T) {
 		make(chan gwproto.StreamEvent),
 		run,
 		&progressState{startedAt: time.Now()},
-		gwproto.StreamProgressStagePreparing,
-		progressSummaryPrepare,
+		progressUpdate{
+			stage:   gwproto.StreamProgressStagePreparing,
+			summary: progressSummaryPrepare,
+		},
 	))
 
 	collected := collectGatewayStreamEvents(

--- a/openclaw/internal/gateway/server_test.go
+++ b/openclaw/internal/gateway/server_test.go
@@ -3857,6 +3857,244 @@ func TestServer_StreamMessage_ProgressStages(t *testing.T) {
 	)
 }
 
+func TestServer_StreamMessage_ProgressAfterTextDelta(t *testing.T) {
+	t.Parallel()
+
+	const (
+		firstDelta = "checking "
+		replyText  = "done"
+		requestID  = "req-1"
+	)
+
+	srv, err := New(&staticRunner{
+		events: progressAfterDeltaEvents(
+			firstDelta,
+			replyText,
+			requestID,
+		),
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(
+		context.Background(),
+		testTimeout,
+	)
+	defer cancel()
+
+	stream, apiErr, status := srv.StreamMessageWithOptions(
+		ctx,
+		gwproto.MessageRequest{
+			From: "u1",
+			Text: "hello",
+		},
+		progressAfterMessageDeltaOptions(),
+	)
+	require.Nil(t, apiErr)
+	require.Equal(t, http.StatusOK, status)
+
+	events := collectGatewayStreamEvents(t, stream)
+	require.Len(t, events, 7)
+	require.Equal(t, gwproto.StreamEventTypeRunStarted, events[0].Type)
+	require.Equal(t, gwproto.StreamEventTypeRunProgress, events[1].Type)
+	require.Equal(t, gwproto.StreamEventTypeMessageDelta, events[2].Type)
+	require.Equal(t, firstDelta, events[2].Delta)
+	require.Equal(t, gwproto.StreamEventTypeRunProgress, events[3].Type)
+	require.Equal(
+		t,
+		gwproto.StreamProgressStageReadingDocument,
+		events[3].Stage,
+	)
+	require.Equal(t, "Reading document page 2", events[3].Summary)
+	require.Equal(t, gwproto.StreamEventTypeRunProgress, events[4].Type)
+	require.Equal(
+		t,
+		gwproto.StreamProgressStageSummarizing,
+		events[4].Stage,
+	)
+	require.Equal(t, progressSummaryAnswering, events[4].Summary)
+	require.Equal(
+		t,
+		gwproto.StreamEventTypeMessageCompleted,
+		events[5].Type,
+	)
+	require.Equal(t, replyText, events[5].Reply)
+	require.Equal(
+		t,
+		gwproto.StreamEventTypeRunCompleted,
+		events[6].Type,
+	)
+}
+
+func TestServer_StreamMessage_DefaultProgressStopsAfterDelta(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	const (
+		firstDelta = "checking "
+		replyText  = "done"
+		requestID  = "req-1"
+	)
+
+	srv, err := New(&staticRunner{
+		events: progressAfterDeltaEvents(
+			firstDelta,
+			replyText,
+			requestID,
+		),
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(
+		context.Background(),
+		testTimeout,
+	)
+	defer cancel()
+
+	stream, apiErr, status := srv.StreamMessage(ctx, gwproto.MessageRequest{
+		From: "u1",
+		Text: "hello",
+	})
+	require.Nil(t, apiErr)
+	require.Equal(t, http.StatusOK, status)
+
+	events := collectGatewayStreamEvents(t, stream)
+	require.Len(t, events, 5)
+	require.Equal(t, gwproto.StreamEventTypeRunStarted, events[0].Type)
+	require.Equal(t, gwproto.StreamEventTypeRunProgress, events[1].Type)
+	require.Equal(t, gwproto.StreamEventTypeMessageDelta, events[2].Type)
+	require.Equal(t, firstDelta, events[2].Delta)
+	require.Equal(
+		t,
+		gwproto.StreamEventTypeMessageCompleted,
+		events[3].Type,
+	)
+	require.Equal(t, replyText, events[3].Reply)
+	require.Equal(
+		t,
+		gwproto.StreamEventTypeRunCompleted,
+		events[4].Type,
+	)
+}
+
+func TestServer_StreamMessage_EmptyOptionsKeepDefaultProgressOrder(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	const (
+		firstDelta = "checking "
+		replyText  = "done"
+		requestID  = "req-1"
+	)
+
+	srv, err := New(&staticRunner{
+		events: progressAfterDeltaEvents(
+			firstDelta,
+			replyText,
+			requestID,
+		),
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(
+		context.Background(),
+		testTimeout,
+	)
+	defer cancel()
+
+	stream, apiErr, status := srv.StreamMessageWithOptions(
+		ctx,
+		gwproto.MessageRequest{
+			From: "u1",
+			Text: "hello",
+		},
+		&gwproto.MessageStreamOptions{},
+	)
+	require.Nil(t, apiErr)
+	require.Equal(t, http.StatusOK, status)
+
+	events := collectGatewayStreamEvents(t, stream)
+	require.Len(t, events, 5)
+	require.Equal(t, gwproto.StreamEventTypeRunStarted, events[0].Type)
+	require.Equal(t, gwproto.StreamEventTypeRunProgress, events[1].Type)
+	require.Equal(t, gwproto.StreamEventTypeMessageDelta, events[2].Type)
+	require.Equal(t, firstDelta, events[2].Delta)
+	require.Equal(
+		t,
+		gwproto.StreamEventTypeMessageCompleted,
+		events[3].Type,
+	)
+	require.Equal(t, replyText, events[3].Reply)
+	require.Equal(
+		t,
+		gwproto.StreamEventTypeRunCompleted,
+		events[4].Type,
+	)
+}
+
+func progressAfterDeltaEvents(
+	firstDelta string,
+	replyText string,
+	requestID string,
+) []*event.Event {
+	return []*event.Event{
+		{
+			Response: &model.Response{
+				Object: model.ObjectTypeChatCompletionChunk,
+				Choices: []model.Choice{{
+					Delta: model.Message{
+						Content: firstDelta,
+					},
+				}},
+			},
+		},
+		{
+			Response: &model.Response{
+				Object: model.ObjectTypeChatCompletion,
+				Choices: []model.Choice{{
+					Message: model.Message{
+						ToolCalls: []model.ToolCall{{
+							Type: "function",
+							Function: model.FunctionDefinitionParam{
+								Name: streamToolReadDocument,
+								Arguments: []byte(
+									`{"page":2}`,
+								),
+							},
+						}},
+					},
+				}},
+			},
+		},
+		{
+			Response: &model.Response{
+				Object: model.ObjectTypeToolResponse,
+			},
+		},
+		{
+			Response: &model.Response{
+				Object: model.ObjectTypeChatCompletion,
+				Choices: []model.Choice{
+					{
+						Message: model.NewAssistantMessage(
+							replyText,
+						),
+					},
+				},
+				Done: true,
+			},
+			RequestID: requestID,
+		},
+	}
+}
+
+func progressAfterMessageDeltaOptions() *gwproto.MessageStreamOptions {
+	return &gwproto.MessageStreamOptions{
+		ProgressAfterTextDelta: true,
+	}
+}
+
 func TestStreamProgressHelpers(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/internal/gateway/stream.go
+++ b/openclaw/internal/gateway/stream.go
@@ -57,9 +57,12 @@ type streamOutcome struct {
 }
 
 type progressState struct {
-	startedAt time.Time
-	stage     gwproto.StreamProgressStage
-	summary   string
+	startedAt  time.Time
+	stage      gwproto.StreamProgressStage
+	summary    string
+	toolName   string
+	toolCallID string
+	toolStatus gwproto.StreamToolStatus
 }
 
 // StreamMessage processes a request and returns a stream of gateway
@@ -288,8 +291,10 @@ func (s *Server) streamLocked(
 		out,
 		run,
 		&progress,
-		gwproto.StreamProgressStagePreparing,
-		progressSummaryPrepare,
+		progressUpdate{
+			stage:   gwproto.StreamProgressStagePreparing,
+			summary: progressSummaryPrepare,
+		},
 	) {
 		return streamOutcome{
 			status: traceStatusError,
@@ -342,8 +347,7 @@ func (s *Server) streamLocked(
 				out,
 				run,
 				&progress,
-				update.stage,
-				update.summary,
+				update,
 			) {
 				return streamOutcome{
 					status: traceStatusError,
@@ -582,8 +586,11 @@ func sendStreamEvent(
 }
 
 type progressUpdate struct {
-	stage   gwproto.StreamProgressStage
-	summary string
+	stage      gwproto.StreamProgressStage
+	summary    string
+	toolName   string
+	toolCallID string
+	toolStatus gwproto.StreamToolStatus
 }
 
 func progressUpdateFromRunnerEvent(
@@ -600,10 +607,7 @@ func progressUpdateFromRunnerEvent(
 		return progressFromToolCall(toolCall)
 	}
 	if evt.Object == model.ObjectTypeToolResponse {
-		return progressUpdate{
-			stage:   gwproto.StreamProgressStageSummarizing,
-			summary: progressSummaryAnswering,
-		}, true
+		return progressFromToolResult(evt.Response), true
 	}
 	return progressUpdate{}, false
 }
@@ -623,35 +627,71 @@ func firstToolCall(rsp *model.Response) (model.ToolCall, bool) {
 	return model.ToolCall{}, false
 }
 
+func firstToolResult(rsp *model.Response) (model.Message, bool) {
+	if rsp == nil {
+		return model.Message{}, false
+	}
+	for _, choice := range rsp.Choices {
+		if choice.Message.ToolID != "" || choice.Message.ToolName != "" {
+			return choice.Message, true
+		}
+		if choice.Delta.ToolID != "" || choice.Delta.ToolName != "" {
+			return choice.Delta, true
+		}
+	}
+	return model.Message{}, false
+}
+
 func progressFromToolCall(
 	toolCall model.ToolCall,
 ) (progressUpdate, bool) {
 	name := strings.TrimSpace(toolCall.Function.Name)
+	update := progressUpdate{
+		toolName:   name,
+		toolCallID: strings.TrimSpace(toolCall.ID),
+		toolStatus: gwproto.StreamToolStatusRunning,
+	}
 	switch name {
 	case streamToolReadDocument:
-		return progressUpdate{
-			stage:   gwproto.StreamProgressStageReadingDocument,
-			summary: readDocumentProgressSummary(toolCall),
-		}, true
+		update.stage = gwproto.StreamProgressStageReadingDocument
+		update.summary = readDocumentProgressSummary(toolCall)
+		return update, true
 	case streamToolReadSheet:
-		return progressUpdate{
-			stage:   gwproto.StreamProgressStageReadingSpreadsheet,
-			summary: readSpreadsheetProgressSummary(toolCall),
-		}, true
+		update.stage = gwproto.StreamProgressStageReadingSpreadsheet
+		update.summary = readSpreadsheetProgressSummary(toolCall)
+		return update, true
 	case streamToolExecCommand:
-		return progressUpdate{
-			stage:   gwproto.StreamProgressStageRunningTool,
-			summary: execCommandProgressSummary(toolCall),
-		}, true
+		update.stage = gwproto.StreamProgressStageRunningTool
+		update.summary = execCommandProgressSummary(toolCall)
+		return update, true
 	default:
 		if name == "" {
 			return progressUpdate{}, false
 		}
-		return progressUpdate{
-			stage:   gwproto.StreamProgressStageRunningTool,
-			summary: "Running " + name,
-		}, true
+		update.stage = gwproto.StreamProgressStageRunningTool
+		update.summary = progressSummaryTool
+		return update, true
 	}
+}
+
+func progressFromToolResult(rsp *model.Response) progressUpdate {
+	update := progressUpdate{
+		stage:   gwproto.StreamProgressStageSummarizing,
+		summary: progressSummaryAnswering,
+	}
+	if rsp == nil || rsp.IsPartial {
+		return update
+	}
+	msg, ok := firstToolResult(rsp)
+	if !ok {
+		return update
+	}
+	update.toolName = strings.TrimSpace(msg.ToolName)
+	update.toolCallID = strings.TrimSpace(msg.ToolID)
+	if update.toolName != "" || update.toolCallID != "" {
+		update.toolStatus = gwproto.StreamToolStatusCompleted
+	}
+	return update
 }
 
 func execCommandProgressSummary(toolCall model.ToolCall) string {
@@ -764,24 +804,33 @@ func sendProgressUpdate(
 	out chan<- gwproto.StreamEvent,
 	run preparedMessageRun,
 	state *progressState,
-	stage gwproto.StreamProgressStage,
-	summary string,
+	update progressUpdate,
 ) bool {
-	if state == nil || stage == "" {
+	if state == nil || update.stage == "" {
 		return true
 	}
-	if state.stage == stage && state.summary == summary {
+	if state.stage == update.stage &&
+		state.summary == update.summary &&
+		state.toolName == update.toolName &&
+		state.toolCallID == update.toolCallID &&
+		state.toolStatus == update.toolStatus {
 		return true
 	}
-	state.stage = stage
-	state.summary = summary
+	state.stage = update.stage
+	state.summary = update.summary
+	state.toolName = update.toolName
+	state.toolCallID = update.toolCallID
+	state.toolStatus = update.toolStatus
 	return sendStreamEvent(ctx, out, gwproto.StreamEvent{
-		Type:      gwproto.StreamEventTypeRunProgress,
-		SessionID: run.sessionID,
-		RequestID: run.requestID,
-		Stage:     stage,
-		Summary:   summary,
-		ElapsedMS: time.Since(state.startedAt).Milliseconds(),
+		Type:       gwproto.StreamEventTypeRunProgress,
+		SessionID:  run.sessionID,
+		RequestID:  run.requestID,
+		Stage:      update.stage,
+		Summary:    update.summary,
+		ToolName:   update.toolName,
+		ToolCallID: update.toolCallID,
+		ToolStatus: update.toolStatus,
+		ElapsedMS:  time.Since(state.startedAt).Milliseconds(),
 	})
 }
 

--- a/openclaw/internal/gateway/stream.go
+++ b/openclaw/internal/gateway/stream.go
@@ -68,6 +68,24 @@ func (s *Server) StreamMessage(
 	ctx context.Context,
 	req gwproto.MessageRequest,
 ) (<-chan gwproto.StreamEvent, *gwproto.APIError, int) {
+	return s.streamMessage(ctx, req, nil)
+}
+
+// StreamMessageWithOptions processes a request with opt-in stream behavior
+// controls and returns a stream of gateway events.
+func (s *Server) StreamMessageWithOptions(
+	ctx context.Context,
+	req gwproto.MessageRequest,
+	opts *gwproto.MessageStreamOptions,
+) (<-chan gwproto.StreamEvent, *gwproto.APIError, int) {
+	return s.streamMessage(ctx, req, opts)
+}
+
+func (s *Server) streamMessage(
+	ctx context.Context,
+	req gwproto.MessageRequest,
+	opts *gwproto.MessageStreamOptions,
+) (<-chan gwproto.StreamEvent, *gwproto.APIError, int) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -93,6 +111,7 @@ func (s *Server) StreamMessage(
 	prepared, earlyRsp, earlyStatus := s.prepareMessageRun(
 		ctx,
 		req,
+		opts,
 		trace,
 	)
 	if earlyRsp != nil {
@@ -172,7 +191,7 @@ func (s *Server) handleMessagesStream(
 		return
 	}
 
-	var req gwproto.MessageRequest
+	var req streamMessageRequest
 	if err := s.decodeJSON(r, &req); err != nil {
 		s.writeError(w, gwproto.APIError{
 			Type:    errTypeInvalidRequest,
@@ -181,7 +200,11 @@ func (s *Server) handleMessagesStream(
 		return
 	}
 
-	events, apiErr, status := s.StreamMessage(r.Context(), req)
+	events, apiErr, status := s.streamMessage(
+		r.Context(),
+		req.MessageRequest,
+		req.StreamOptions,
+	)
 	if apiErr != nil {
 		s.writeError(w, *apiErr, status)
 		return
@@ -198,6 +221,11 @@ func (s *Server) handleMessagesStream(
 			return
 		}
 	}
+}
+
+type streamMessageRequest struct {
+	gwproto.MessageRequest
+	StreamOptions *gwproto.MessageStreamOptions `json:"stream_options,omitempty"`
 }
 
 func writeSSEEvent(
@@ -307,20 +335,19 @@ func (s *Server) streamLocked(
 			continue
 		}
 
-		if !sentText {
-			if update, ok := progressUpdateFromRunnerEvent(evt); ok {
-				if !sendProgressUpdate(
-					ctx,
-					out,
-					run,
-					&progress,
-					update.stage,
-					update.summary,
-				) {
-					return streamOutcome{
-						status: traceStatusError,
-						errMsg: contextErrMessage(ctx),
-					}
+		if update, ok := progressUpdateFromRunnerEvent(evt); ok &&
+			shouldSendProgressForEvent(run.streamOptions, sentText) {
+			if !sendProgressUpdate(
+				ctx,
+				out,
+				run,
+				&progress,
+				update.stage,
+				update.summary,
+			) {
+				return streamOutcome{
+					status: traceStatusError,
+					errMsg: contextErrMessage(ctx),
 				}
 			}
 		}
@@ -529,6 +556,16 @@ func (s *Server) streamLocked(
 		}
 	}
 	return streamOutcome{status: traceStatusOK}
+}
+
+func shouldSendProgressForEvent(
+	opts *gwproto.MessageStreamOptions,
+	sentText bool,
+) bool {
+	if !sentText {
+		return true
+	}
+	return opts != nil && opts.ProgressAfterTextDelta
 }
 
 func sendStreamEvent(

--- a/tool/claudecode/claudecode_test.go
+++ b/tool/claudecode/claudecode_test.go
@@ -1955,8 +1955,14 @@ func TestGrepHelpersCoverRemainingFallbackAndRipgrepBranches(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "files_with_matches", fallbackOut.Mode)
 	require.Len(t, fallbackOut.Filenames, 1)
+	rgPath := writeExecutableFile(
+		t,
+		dir,
+		"fake-rg.sh",
+		"#!/bin/sh\nprintf 'main.go:1:alpha\\nmain.go:2:beta\\n'\n",
+	)
 	restore := withRipgrepForTest(func(string) (string, error) {
-		return writeExecutableFile(t, dir, "fake-rg.sh", "#!/bin/sh\nprintf 'main.go:1:alpha\\nmain.go:2:beta\\n'\n"), nil
+		return rgPath, nil
 	})
 	ripgrepContentOut, handled, err := runRipgrepCommand(context.Background(), dir, ".", grepInput{
 		Pattern:    "alpha",
@@ -1967,15 +1973,27 @@ func TestGrepHelpersCoverRemainingFallbackAndRipgrepBranches(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "content", ripgrepContentOut.Mode)
 	require.Contains(t, ripgrepContentOut.Content, "main.go:1:alpha")
+	rgEmptyPath := writeExecutableFile(
+		t,
+		dir,
+		"fake-rg-empty.sh",
+		"#!/bin/sh\nexit 1\n",
+	)
 	restore = withRipgrepForTest(func(string) (string, error) {
-		return writeExecutableFile(t, dir, "fake-rg-empty.sh", "#!/bin/sh\nexit 1\n"), nil
+		return rgEmptyPath, nil
 	})
 	lines, err := execRipgrep(context.Background(), dir, "alpha")
 	restore()
 	require.NoError(t, err)
 	require.Empty(t, lines)
+	rgErrorPath := writeExecutableFile(
+		t,
+		dir,
+		"fake-rg-error.sh",
+		"#!/bin/sh\nexit 2\n",
+	)
 	restore = withRipgrepForTest(func(string) (string, error) {
-		return writeExecutableFile(t, dir, "fake-rg-error.sh", "#!/bin/sh\nexit 2\n"), nil
+		return rgErrorPath, nil
 	})
 	_, err = execRipgrep(context.Background(), dir, "alpha")
 	restore()


### PR DESCRIPTION
## Summary
- keep opt-in gateway progress visible after text streaming starts
- expose structured tool progress metadata in gateway stream events
- avoid encoding tool names only inside human summary text

## Tests
- go test ./gwproto ./gwclient ./internal/gateway