### PR TITLE
examples/knowledge: bump trpc-agent-go module version

### DIFF
--- a/examples/knowledge/go.mod
+++ b/examples/knowledge/go.mod
@@ -20,7 +20,7 @@ replace (
 
 require (
 	github.com/getkin/kin-openapi v0.124.0
-	trpc.group/trpc-go/trpc-agent-go v1.8.2-0.20260415014524-d83a248b0ea1
+	trpc.group/trpc-go/trpc-agent-go v1.8.2-0.20260429121222-b41f42aefbc5
 	trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader/pdf v0.5.0
 	trpc.group/trpc-go/trpc-agent-go/knowledge/ocr/tesseract v0.0.0-20251203120347-0b4d62cb115d
 	trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/elasticsearch v0.2.1


### PR DESCRIPTION
## Summary
- bump examples/knowledge's trpc-agent-go requirement to the commit that introduced the code-search/repo APIs used by the examples

## Testing
- cd examples/knowledge && go test ./...
- .github/scripts/check-go-mod-version.sh
- .github/scripts/check-go-mod-tidy.sh