### PR TITLE
model/openai: backfill reasoning content for assistant history

### DIFF
--- a/model/openai/batch_test.go
+++ b/model/openai/batch_test.go
@@ -398,6 +398,45 @@ func TestGenerateBatchJSONL_ReasoningContentBackfill(t *testing.T) {
 			assert.Equal(t, "", reasoningValue)
 		})
 
+	t.Run("backfills assistant content message when enabled",
+		func(t *testing.T) {
+			requests := []*BatchRequestInput{
+				{
+					CustomID: customID,
+					Body: BatchRequest{
+						Request: model.Request{
+							Messages: []model.Message{
+								{
+									Role:    model.RoleAssistant,
+									Content: "Final answer without reasoning.",
+								},
+							},
+						},
+					},
+				},
+			}
+			m := New("default-model",
+				WithReasoningContentBackfill(true))
+
+			jsonlData, err := m.generateBatchJSONL(requests)
+			require.NoError(t, err)
+
+			lines := strings.Split(strings.TrimSpace(string(jsonlData)), "\n")
+			require.Len(t, lines, 1)
+
+			var decoded map[string]any
+			err = json.Unmarshal([]byte(lines[0]), &decoded)
+			require.NoError(t, err)
+
+			body := decoded["body"].(map[string]any)
+			messages := body["messages"].([]any)
+			message := messages[0].(map[string]any)
+
+			reasoningValue, ok := message[model.ReasoningContentKey]
+			require.True(t, ok)
+			assert.Equal(t, "", reasoningValue)
+		})
+
 	t.Run("keeps reasoning_content absent when disabled",
 		func(t *testing.T) {
 			m := New("default-model")

--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -673,15 +673,16 @@ func (m *Model) buildThinkingOption(request *model.Request) []openaiopt.RequestO
 }
 
 // shouldBackfillReasoningContent reports whether replay should emit
-// model.ReasoningContentKey as an empty string for assistant tool-call
-// messages. Some providers require the key to be present during tool-call
-// replay even when no reasoning text was returned.
+// model.ReasoningContentKey as an empty string for assistant messages. Some
+// providers require the key to be present for every assistant message in
+// thinking mode even when no reasoning text was returned.
 func (m *Model) shouldBackfillReasoningContent(
 	msg model.Message,
 ) bool {
 	return m.reasoningContentBackfill &&
+		msg.Role == model.RoleAssistant &&
 		msg.ReasoningContent == "" &&
-		len(msg.ToolCalls) > 0
+		(msg.Content != "" || len(msg.ContentParts) > 0 || len(msg.ToolCalls) > 0)
 }
 
 // convertMessages converts our Message format to OpenAI's format.
@@ -713,8 +714,8 @@ func (m *Model) convertMessages(messages []model.Message) []openai.ChatCompletio
 				Content:   m.convertAssistantMessageContent(msg),
 				ToolCalls: m.convertToolCalls(msg.ToolCalls),
 			}
-			// Pass reasoning_content to API if present (required by DeepSeek for
-			// tool-call replay across current and later request turns).
+			// Pass reasoning_content to API if present, or when provider replay
+			// requires the field for assistant history in thinking mode.
 			if msg.ReasoningContent != "" ||
 				m.shouldBackfillReasoningContent(msg) {
 				assistantMsg.SetExtraFields(map[string]any{

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -803,7 +803,7 @@ func TestModel_convertMessages_ReasoningContent(t *testing.T) {
 			)
 		})
 
-	t.Run("assistant message without tool calls is not backfilled",
+	t.Run("assistant message without tool calls backfills empty reasoning_content",
 		func(t *testing.T) {
 			msgs := []model.Message{
 				{
@@ -826,12 +826,14 @@ func TestModel_convertMessages_ReasoningContent(t *testing.T) {
 			err = json.Unmarshal(data, &parsed)
 			require.NoError(t, err)
 
-			_, ok := parsed[model.ReasoningContentKey]
-			assert.False(
+			reasoningValue, ok := parsed[model.ReasoningContentKey]
+			require.True(
 				t,
 				ok,
-				"reasoning_content should stay absent without tool calls",
+				"reasoning_content should be present when backfill "+
+					"is enabled",
 			)
+			assert.Equal(t, "", reasoningValue)
 		})
 
 	t.Run("assistant message with tool calls and reasoning_content", func(t *testing.T) {

--- a/model/openai/options.go
+++ b/model/openai/options.go
@@ -113,9 +113,8 @@ type options struct {
 	// Response.Choices[].Delta.ToolCalls instead of being
 	// suppressed until the final aggregated response.
 	ShowToolCallDelta bool
-	// ReasoningContentBackfill controls whether assistant
-	// tool-call messages should replay an empty
-	// reasoning_content field when the message has no
+	// ReasoningContentBackfill controls whether assistant messages should
+	// replay an empty reasoning_content field when the message has no
 	// reasoning text.
 	ReasoningContentBackfill bool
 	accumulateChunkUsage     AccumulateChunkUsage
@@ -222,9 +221,8 @@ func WithChatStreamCompleteCallback(fn ChatStreamCompleteCallbackFunc) Option {
 	}
 }
 
-// WithReasoningContentBackfill enables replay-time
-// reasoning_content backfill for assistant tool-call
-// messages that have no reasoning text.
+// WithReasoningContentBackfill enables replay-time reasoning_content backfill
+// for assistant messages that have no reasoning text.
 func WithReasoningContentBackfill(enabled bool) Option {
 	return func(opts *options) {
 		opts.ReasoningContentBackfill = enabled


### PR DESCRIPTION
## What changed

- Extend `openai.WithReasoningContentBackfill(true)` so empty `reasoning_content` is replayed for assistant history messages, not only assistant tool-call messages.
- Keep the behavior opt-in and preserve existing non-empty `reasoning_content` values.
- Add coverage for normal assistant messages in both chat request conversion and batch JSONL generation.

## Why

DeepSeek v4 thinking mode can reject follow-up requests after a model switch when previous assistant messages do not include the `reasoning_content` field. The previous backfill only covered assistant messages with tool calls, so a final assistant reply after tool execution could still miss the field and trigger a 400 response.

## Validation

- `go test ./model/openai -count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reasoning content backfill logic for assistant messages in thinking mode to properly handle cases where reasoning content is empty.
  * Clarified and expanded when empty reasoning content fields are inserted during message serialization.

* **Tests**
  * Added new test case to verify reasoning content backfill behavior for assistant messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->