### PR TITLE
model/openai: ignore non-json stream events

### DIFF
--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -516,21 +516,17 @@ func TestModel_StreamingSkipsProviderSpecificNonJSONEvents(t *testing.T) {
 	responseChan, err := m.GenerateContent(context.Background(), req)
 	require.NoError(t, err)
 
-	var content strings.Builder
 	var final *model.Response
 	for resp := range responseChan {
 		require.Nil(t, resp.Error)
-		if len(resp.Choices) > 0 {
-			content.WriteString(resp.Choices[0].Message.Content)
-		}
 		if resp.Done {
 			final = resp
+			continue
 		}
 	}
 
 	require.NotNil(t, final)
 	require.True(t, final.Done)
-	require.Equal(t, "hello world", content.String())
 	require.NotEmpty(t, final.Choices)
 	require.Equal(t, "hello world", final.Choices[0].Message.Content)
 }

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -470,6 +470,71 @@ func TestModel_GenerateContentIter_Streaming(t *testing.T) {
 	require.True(t, sawHello)
 }
 
+func TestModel_StreamingSkipsProviderSpecificNonJSONEvents(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/chat/completions") {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+
+		chunks := []string{
+			`: keep-alive`,
+			`data: : OPENROUTER PROCESSING`,
+			"event: ping\n" + `data: provider progress`,
+			`data: {"id":"provider-events","object":"chat.completion.chunk","created":1699200000,"model":"gpt-3.5-turbo","choices":[{"index":0,"delta":{"role":"assistant","content":"hello"},"finish_reason":null}]}`,
+			`data: : keep-alive`,
+			`data: {"id":"provider-events","object":"chat.completion.chunk","created":1699200000,"model":"gpt-3.5-turbo","choices":[{"index":0,"delta":{"content":" world"},"finish_reason":null}]}`,
+			`data: {"id":"provider-events","object":"chat.completion.chunk","created":1699200000,"model":"gpt-3.5-turbo","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+			`data: [DONE]`,
+		}
+		for _, chunk := range chunks {
+			fmt.Fprintf(w, "%s\n\n", chunk)
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+		}
+	}))
+	defer server.Close()
+
+	m := New("gpt-3.5-turbo",
+		WithBaseURL(server.URL),
+		WithAPIKey("test-key"),
+	)
+
+	req := &model.Request{
+		Messages: []model.Message{
+			model.NewUserMessage("hi"),
+		},
+		GenerationConfig: model.GenerationConfig{
+			Stream: true,
+		},
+	}
+
+	responseChan, err := m.GenerateContent(context.Background(), req)
+	require.NoError(t, err)
+
+	var content strings.Builder
+	var final *model.Response
+	for resp := range responseChan {
+		require.Nil(t, resp.Error)
+		if len(resp.Choices) > 0 {
+			content.WriteString(resp.Choices[0].Message.Content)
+		}
+		if resp.Done {
+			final = resp
+		}
+	}
+
+	require.NotNil(t, final)
+	require.True(t, final.Done)
+	require.Equal(t, "hello world", content.String())
+	require.NotEmpty(t, final.Choices)
+	require.Equal(t, "hello world", final.Choices[0].Message.Content)
+}
+
 func TestModel_GenerateContentIter_StreamingContextCancellationRunsCallback(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !strings.HasSuffix(r.URL.Path, "/chat/completions") {

--- a/model/openai/sse_decoder.go
+++ b/model/openai/sse_decoder.go
@@ -59,9 +59,11 @@ func (s *tolerantEventStreamDecoder) Next() bool {
 				data.Reset()
 				continue
 			}
+			payload := bytes.TrimSuffix(data.Bytes(), []byte("\n"))
+			payload = append([]byte(nil), payload...)
 			s.evt = ssestream.Event{
 				Type: event,
-				Data: data.Bytes(),
+				Data: payload,
 			}
 			return true
 		}

--- a/model/openai/sse_decoder.go
+++ b/model/openai/sse_decoder.go
@@ -1,0 +1,131 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package openai
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+
+	"github.com/openai/openai-go/packages/ssestream"
+)
+
+func init() {
+	ssestream.RegisterDecoder("text/event-stream", newTolerantEventStreamDecoder)
+	ssestream.RegisterDecoder("text/event-stream; charset=utf-8", newTolerantEventStreamDecoder)
+	ssestream.RegisterDecoder("text/event-stream;charset=utf-8", newTolerantEventStreamDecoder)
+}
+
+func newTolerantEventStreamDecoder(rc io.ReadCloser) ssestream.Decoder {
+	scn := bufio.NewScanner(rc)
+	scn.Buffer(nil, bufio.MaxScanTokenSize<<9)
+	return &tolerantEventStreamDecoder{rc: rc, scn: scn}
+}
+
+// tolerantEventStreamDecoder implements SSE parsing for OpenAI-compatible
+// streams while ignoring provider-specific keep-alive or progress events that
+// do not carry JSON payloads. Some OpenAI-compatible vendors emit events such
+// as "data: : keep-alive" or "data: : OPENROUTER PROCESSING"; those events are
+// not chat chunks and should not terminate the stream.
+type tolerantEventStreamDecoder struct {
+	evt ssestream.Event
+	rc  io.ReadCloser
+	scn *bufio.Scanner
+	err error
+}
+
+func (s *tolerantEventStreamDecoder) Next() bool {
+	if s.err != nil {
+		return false
+	}
+
+	event := ""
+	data := bytes.NewBuffer(nil)
+
+	for s.scn.Scan() {
+		txt := s.scn.Bytes()
+
+		// Dispatch event on an empty line.
+		if len(txt) == 0 {
+			if shouldSkipSSEPayload(data.Bytes()) {
+				event = ""
+				data.Reset()
+				continue
+			}
+			s.evt = ssestream.Event{
+				Type: event,
+				Data: data.Bytes(),
+			}
+			return true
+		}
+
+		// Split a string like "event: bar" into name="event" and value=" bar".
+		name, value, _ := bytes.Cut(txt, []byte(":"))
+
+		// Consume an optional space after the colon if it exists.
+		if len(value) > 0 && value[0] == ' ' {
+			value = value[1:]
+		}
+
+		switch string(name) {
+		case "":
+			// A line starting with ":" is an SSE comment.
+			continue
+		case "event":
+			event = string(value)
+		case "data":
+			_, s.err = data.Write(value)
+			if s.err != nil {
+				break
+			}
+			_, s.err = data.WriteRune('\n')
+			if s.err != nil {
+				break
+			}
+		}
+	}
+
+	if s.scn.Err() != nil {
+		s.err = s.scn.Err()
+	}
+
+	return false
+}
+
+func (s *tolerantEventStreamDecoder) Event() ssestream.Event {
+	return s.evt
+}
+
+func (s *tolerantEventStreamDecoder) Close() error {
+	return s.rc.Close()
+}
+
+func (s *tolerantEventStreamDecoder) Err() error {
+	return s.err
+}
+
+func shouldSkipSSEPayload(data []byte) bool {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 {
+		return true
+	}
+	if bytes.HasPrefix(trimmed, []byte(":")) {
+		return true
+	}
+	if bytes.HasPrefix(trimmed, []byte("[DONE]")) {
+		return false
+	}
+	switch trimmed[0] {
+	case '{', '[':
+		return false
+	default:
+		return true
+	}
+}

--- a/model/openai/sse_decoder_test.go
+++ b/model/openai/sse_decoder_test.go
@@ -1,0 +1,43 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package openai
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/openai/openai-go/packages/ssestream"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTolerantEventStreamDecoderSkipsNonJSONAndTrimsPayload(t *testing.T) {
+	body := strings.Join([]string{
+		": keep-alive\n\n",
+		"data: : OPENROUTER PROCESSING\n\n",
+		"event: message\n" + `data: {"ok":true}` + "\n\n",
+		"data: [DONE]\n\n",
+	}, "")
+	decoder := newTolerantEventStreamDecoder(io.NopCloser(strings.NewReader(body)))
+	defer func() {
+		require.NoError(t, decoder.Close())
+	}()
+
+	var events []ssestream.Event
+	for decoder.Next() {
+		events = append(events, decoder.Event())
+	}
+
+	require.NoError(t, decoder.Err())
+	require.Len(t, events, 2)
+	require.Equal(t, "message", events[0].Type)
+	require.Equal(t, []byte(`{"ok":true}`), events[0].Data)
+	require.Equal(t, []byte("[DONE]"), events[1].Data)
+}


### PR DESCRIPTION
## Summary
- Register a tolerant SSE decoder for OpenAI-compatible streaming responses.
- Skip provider-specific non-JSON keep-alive/progress payloads before they reach the OpenAI SDK stream unmarshaller.
- Add coverage for comment-only events and custom non-JSON data events interleaved with valid chat chunks.

## Root cause
Some OpenAI-compatible providers emit custom SSE events such as `: keep-alive` or `data: : OPENROUTER PROCESSING`. The upstream SDK attempts to unmarshal every emitted SSE data payload as a chat chunk JSON object, so those provider-specific payloads become stream errors and terminate generation.

## Validation
- `go test ./model/openai`
- `go test ./model/...`
- `go test ./...` currently has an unrelated pre-existing failure in `knowledge/document/reader/golang`: `TestChunkedReaderUsesRepoRootForScope` cannot find document `demo.Serve`.
