### PR TITLE
.github: add external module consumption checks

### DIFF
--- a/.github/scripts/check-external-consumer.sh
+++ b/.github/scripts/check-external-consumer.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script verifies that packages from published modules can be imported by
+# an external consumer against the current repository snapshot.
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+cd "${repo_root}"
+
+tmp_root="$(mktemp -d)"
+trap 'chmod -R u+w "${tmp_root}" >/dev/null 2>&1 || true; rm -rf "${tmp_root}"' EXIT
+
+# The consumer check intentionally uses the non-CGO build path so CI does not
+# depend on system SQLite libraries.
+export CGO_ENABLED=0
+
+declare -a requested_modules=()
+declare -a repository_modules=()
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--module)
+			if [[ $# -lt 2 ]]; then
+				echo "missing value for --module" >&2
+				exit 2
+			fi
+			requested_modules+=("$2")
+			shift 2
+			;;
+		*)
+			echo "unknown argument: $1" >&2
+			exit 2
+			;;
+	esac
+done
+
+is_do_not_use_module() {
+	local mod_file="$1"
+	head -n 5 "${mod_file}" | grep -q "DO NOT USE!"
+}
+
+normalize_module_file() {
+	local module="$1"
+	local normalized="${module#./}"
+	normalized="./${normalized}"
+	if [[ ! -f "${normalized}" ]]; then
+		echo "module file not found: ${module}" >&2
+		return 2
+	fi
+	printf '%s\n' "${normalized}"
+}
+
+discover_modules() {
+	local -n modules_ref="$1"
+	local mod_file
+	modules_ref=()
+	if (( ${#requested_modules[@]} > 0 )); then
+		for mod_file in "${requested_modules[@]}"; do
+			modules_ref+=("$(normalize_module_file "${mod_file}")")
+		done
+		return 0
+	fi
+	while IFS= read -r -d '' mod_file; do
+		if is_do_not_use_module "${mod_file}"; then
+			continue
+		fi
+		modules_ref+=("${mod_file}")
+	done < <(find . -name "go.mod" \
+		-not -path "./.resource/*" \
+		-not -path "./docs/*" \
+		-not -path "./examples/*" \
+		-not -path "./test/*" \
+		-print0 | sort -z)
+}
+
+discover_repository_modules() {
+	local -n modules_ref="$1"
+	local mod_file mod_dir
+	modules_ref=()
+	while IFS= read -r -d '' mod_file; do
+		if is_do_not_use_module "${mod_file}"; then
+			continue
+		fi
+		mod_dir="$(cd "$(dirname "${mod_file}")" && pwd)"
+		modules_ref+=("${mod_dir}/go.mod")
+	done < <(find . -name "go.mod" \
+		-not -path "./.resource/*" \
+		-not -path "./docs/*" \
+		-not -path "./examples/*" \
+		-not -path "./test/*" \
+		-print0 | sort -z)
+}
+
+module_readable_name() {
+	local mod_file="$1"
+	local mod_dir rel_dir
+	mod_dir="$(dirname "${mod_file}")"
+	rel_dir="${mod_dir#./}"
+	if [[ -z "${rel_dir}" || "${rel_dir}" == "." ]]; then
+		printf 'root\n'
+		return 0
+	fi
+	printf '%s\n' "${rel_dir}"
+}
+
+is_external_importable_path() {
+	local import_path="$1"
+	[[ "${import_path}" != */internal ]] && [[ "${import_path}" != */internal/* ]]
+}
+
+list_importable_packages() {
+	local mod_dir="$1"
+	local output_file="$2"
+	local package_list import_path package_name go_files cgo_files
+	package_list="$(mktemp "${tmp_root}/packages.XXXXXX")"
+	if ! (cd "${mod_dir}" && go list -f '{{.ImportPath}}{{"\t"}}{{.Name}}{{"\t"}}{{len .GoFiles}}{{"\t"}}{{len .CgoFiles}}' ./...) >"${package_list}"; then
+		return 1
+	fi
+	: >"${output_file}"
+	while IFS=$'\t' read -r import_path package_name go_files cgo_files; do
+		if [[ -z "${import_path}" || -z "${package_name}" ]]; then
+			continue
+		fi
+		if (( go_files == 0 && cgo_files == 0 )); then
+			continue
+		fi
+		if [[ "${package_name}" == "main" ]]; then
+			continue
+		fi
+		if ! is_external_importable_path "${import_path}"; then
+			continue
+		fi
+		printf '%s\n' "${import_path}" >>"${output_file}"
+	done <"${package_list}"
+}
+
+write_consumer_test() {
+	local package_file="$1"
+	local output_file="$2"
+	{
+		printf 'package consumer\n\n'
+		printf 'import (\n'
+		while IFS= read -r import_path; do
+			printf '\t_ "%s"\n' "${import_path}"
+		done <"${package_file}"
+		printf ')\n'
+	} >"${output_file}"
+}
+
+add_repository_replaces() {
+	local mod_file mod_dir module_path
+	for mod_file in "${repository_modules[@]}"; do
+		mod_dir="$(cd "$(dirname "${mod_file}")" && pwd)"
+		module_path="$(cd "${mod_dir}" && go list -m -f '{{.Path}}')"
+		go mod edit -replace "${module_path}=${mod_dir}"
+	done
+}
+
+check_module_as_external_consumer() {
+	local mod_file="$1"
+	local mod_dir module_path readable package_file consumer_dir status
+	mod_dir="$(cd "$(dirname "${mod_file}")" && pwd)"
+	readable="$(module_readable_name "${mod_file}")"
+	module_path="$(cd "${mod_dir}" && go list -m -f '{{.Path}}')"
+
+	echo "::group::External consumer: ${readable}"
+	echo "module path: ${module_path}"
+	echo "module dir: ${mod_dir}"
+
+	package_file="$(mktemp "${tmp_root}/importable-packages.XXXXXX")"
+	if ! list_importable_packages "${mod_dir}" "${package_file}"; then
+		echo "::error::Failed to list packages for ${readable}."
+		echo "::endgroup::"
+		return 1
+	fi
+	if [[ ! -s "${package_file}" ]]; then
+		echo "No external importable packages found, skipping ${readable}."
+		echo "::endgroup::"
+		return 0
+	fi
+
+	echo "Importable packages:"
+	sed 's/^/  - /' "${package_file}"
+
+	consumer_dir="$(mktemp -d "${tmp_root}/consumer.XXXXXX")"
+	status=0
+	(
+		cd "${consumer_dir}"
+		go mod init example.com/trpc-agent-go-external-consumer
+		add_repository_replaces
+		write_consumer_test "${package_file}" "${consumer_dir}/consumer_test.go"
+		go mod tidy
+		go test ./...
+	) || status=$?
+
+	echo "::endgroup::"
+	return "${status}"
+}
+
+main() {
+	local -a modules=()
+	discover_modules modules
+	discover_repository_modules repository_modules
+	if (( ${#modules[@]} == 0 )); then
+		echo "no go.mod files found." >&2
+		return 2
+	fi
+	if (( ${#repository_modules[@]} == 0 )); then
+		echo "no repository go.mod files found." >&2
+		return 2
+	fi
+	local -a failed_modules=()
+	local mod_file
+	for mod_file in "${modules[@]}"; do
+		if is_do_not_use_module "${mod_file}"; then
+			echo "Skipping $(module_readable_name "${mod_file}"): marked as DO NOT USE."
+			continue
+		fi
+		if ! check_module_as_external_consumer "${mod_file}"; then
+			failed_modules+=("$(module_readable_name "${mod_file}")")
+		fi
+	done
+	if (( ${#failed_modules[@]} > 0 )); then
+		echo "::group::External consumer check summary"
+		echo "External consumer check failed for modules:"
+		local module_name
+		for module_name in "${failed_modules[@]}"; do
+			echo "  - ${module_name}"
+		done
+		echo "::endgroup::"
+		return 1
+	fi
+}
+
+main "$@"

--- a/.github/scripts/check-external-consumer.sh
+++ b/.github/scripts/check-external-consumer.sh
@@ -121,7 +121,7 @@ list_importable_packages() {
 		if [[ -z "${import_path}" || -z "${package_name}" ]]; then
 			continue
 		fi
-		if (( go_files == 0 && cgo_files == 0 )); then
+		if (( go_files == 0 )); then
 			continue
 		fi
 		if [[ "${package_name}" == "main" ]]; then

--- a/.github/scripts/check-go-mod-version.sh
+++ b/.github/scripts/check-go-mod-version.sh
@@ -41,35 +41,39 @@ fi
 # Detect if this is a fork and try to fetch upstream tags.
 skip_tag_validation=false
 origin_url="$(git config --get remote.origin.url 2>/dev/null || true)"
-
-if [[ "${origin_url}" != *"${root_module}"* ]]; then
-  echo "Detected fork repository (module: ${root_module}, origin: ${origin_url})"
-  
-  # Try to infer upstream URL from module path.
-  upstream_url=""
-  if [[ "${root_module}" == trpc.group/* ]]; then
-    repo_path="${root_module#trpc.group/}"
-    if [[ "${repo_path}" == trpc-go/* ]]; then
-      repo_path="trpc-group/${repo_path#trpc-go/}"
-    fi
-    upstream_url="https://github.com/${repo_path}.git"
-  elif [[ "${root_module}" == github.com/* ]]; then
-    repo_path="${root_module#github.com/}"
-    upstream_url="https://github.com/${repo_path}.git"
+canonical_repo_path=""
+if [[ "${root_module}" == trpc.group/* ]]; then
+  repo_path="${root_module#trpc.group/}"
+  if [[ "${repo_path}" =~ ^(.+)/v([2-9][0-9]*)$ ]]; then
+    repo_path="${BASH_REMATCH[1]}"
   fi
-  
-  if [ -n "${upstream_url}" ]; then
-    echo "Attempting to fetch tags from upstream: ${upstream_url}"
-    if git fetch "${upstream_url}" "+refs/tags/*:refs/tags/*" 2>/dev/null; then
-      echo "Successfully fetched upstream tags"
-    else
-      echo "::warning::Failed to fetch upstream tags, will skip tag validation"
-      skip_tag_validation=true
-    fi
+  if [[ "${repo_path}" == trpc-go/* ]]; then
+    repo_path="trpc-group/${repo_path#trpc-go/}"
+  fi
+  canonical_repo_path="${repo_path}"
+elif [[ "${root_module}" == github.com/* ]]; then
+  repo_path="${root_module#github.com/}"
+  if [[ "${repo_path}" =~ ^(.+)/v([2-9][0-9]*)$ ]]; then
+    repo_path="${BASH_REMATCH[1]}"
+  fi
+  canonical_repo_path="${repo_path}"
+fi
+
+if [[ -n "${canonical_repo_path}" && "${origin_url}" != *"${canonical_repo_path}"* ]]; then
+  echo "Detected fork repository (module: ${root_module}, origin: ${origin_url})"
+
+  upstream_url="https://github.com/${canonical_repo_path}.git"
+  echo "Attempting to fetch tags from upstream: ${upstream_url}"
+  if git fetch "${upstream_url}" "+refs/tags/*:refs/tags/*" 2>/dev/null; then
+    echo "Successfully fetched upstream tags"
   else
-    echo "::warning::Cannot infer upstream URL, will skip tag validation"
+    echo "::warning::Failed to fetch upstream tags, will skip tag validation"
     skip_tag_validation=true
   fi
+elif [[ -z "${canonical_repo_path}" && "${origin_url}" != *"${root_module}"* ]]; then
+  echo "Detected fork repository (module: ${root_module}, origin: ${origin_url})"
+  echo "::warning::Cannot infer upstream URL, will skip tag validation"
+  skip_tag_validation=true
 fi
 
 if [ "${skip_tag_validation}" = true ]; then
@@ -198,7 +202,7 @@ for go_mod in "${go_mod_files[@]}"; do
     dep_ver="${req#* }"
     is_repo_module_path "${dep_path}" || continue
 
-    line_number="$(grep -nF "${dep_path}" "${go_mod}" | head -n1 | cut -d: -f1)"
+    line_number="$(grep -nF "${dep_path}" "${go_mod}" | head -n1 | cut -d: -f1 || true)"
     [ -z "${line_number}" ] && line_number=1
 
     if ! validate_resolvable_version "${rel_path}" "${line_number}" "${dep_path}" "${dep_ver}"; then

--- a/.github/scripts/check-go-mod-version.sh
+++ b/.github/scripts/check-go-mod-version.sh
@@ -91,6 +91,12 @@ while IFS= read -r tag; do
     continue
   fi
   module_tags["${mod_path}"]+="${ver} "
+  if [[ "${ver}" =~ ^v([2-9][0-9]*)\. ]]; then
+    major_suffix="/v${BASH_REMATCH[1]}"
+    if [[ "${mod_path}" != *"${major_suffix}" ]]; then
+      module_tags["${mod_path}${major_suffix}"]+="${ver} "
+    fi
+  fi
 done < <(git tag)
 
 zero_placeholder="v0.0.0-00010101000000-000000000000"

--- a/.github/scripts/check-go-mod-version.sh
+++ b/.github/scripts/check-go-mod-version.sh
@@ -143,8 +143,14 @@ validate_resolvable_version() {
   local line_number="$2"
   local dep_path="$3"
   local dep_ver="$4"
+  local resolver_dir="${tmp_dir}/resolver"
 
-  if go mod download -json "${dep_path}@${dep_ver}" >/dev/null 2>&1; then
+  mkdir -p "${resolver_dir}"
+  if [ ! -f "${resolver_dir}/go.mod" ]; then
+    (cd "${resolver_dir}" && GOWORK=off go mod init example.com/module-version-check >/dev/null 2>&1)
+  fi
+
+  if (cd "${resolver_dir}" && GOWORK=off go mod download -json "${dep_path}@${dep_ver}" >/dev/null 2>&1); then
     return 0
   fi
 

--- a/.github/scripts/check-go-mod-version.sh
+++ b/.github/scripts/check-go-mod-version.sh
@@ -202,7 +202,7 @@ for go_mod in "${go_mod_files[@]}"; do
     dep_ver="${req#* }"
     is_repo_module_path "${dep_path}" || continue
 
-    line_number="$(grep -nF "${dep_path}" "${go_mod}" | head -n1 | cut -d: -f1 || true)"
+    line_number="$(awk -v dep_path="${dep_path}" '($1 == "require" && $2 == dep_path) || ($1 == dep_path) { print NR; exit }' "${go_mod}")"
     [ -z "${line_number}" ] && line_number=1
 
     if ! validate_resolvable_version "${rel_path}" "${line_number}" "${dep_path}" "${dep_ver}"; then

--- a/.github/scripts/check-go-mod-version.sh
+++ b/.github/scripts/check-go-mod-version.sh
@@ -162,6 +162,30 @@ validate_resolvable_version() {
   return 1
 }
 
+require_line_number() {
+  local go_mod="$1"
+  local dep_path="$2"
+
+  awk -v dep_path="${dep_path}" '
+    $1 == "require" && $2 == dep_path {
+      print NR
+      exit
+    }
+    $1 == "require" && $2 == "(" {
+      in_require = 1
+      next
+    }
+    in_require && $1 == ")" {
+      in_require = 0
+      next
+    }
+    in_require && $1 == dep_path {
+      print NR
+      exit
+    }
+  ' "${go_mod}"
+}
+
 for go_mod in "${go_mod_files[@]}"; do
   rel_path="${go_mod#./}"
   mod_dir="$(dirname "${go_mod}")"
@@ -202,7 +226,7 @@ for go_mod in "${go_mod_files[@]}"; do
     dep_ver="${req#* }"
     is_repo_module_path "${dep_path}" || continue
 
-    line_number="$(awk -v dep_path="${dep_path}" '($1 == "require" && $2 == dep_path) || ($1 == dep_path) { print NR; exit }' "${go_mod}")"
+    line_number="$(require_line_number "${go_mod}" "${dep_path}")"
     [ -z "${line_number}" ] && line_number=1
 
     if ! validate_resolvable_version "${rel_path}" "${line_number}" "${dep_path}" "${dep_ver}"; then

--- a/.github/scripts/check-go-mod-version.sh
+++ b/.github/scripts/check-go-mod-version.sh
@@ -5,10 +5,37 @@ set -euo pipefail
 
 echo "::group::Checking go.mod for forbidden version string and invalid tags"
 
+declare -a requested_modules=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --module)
+      if [[ $# -lt 2 ]]; then
+        echo "missing value for --module" >&2
+        exit 2
+      fi
+      requested_modules+=("$2")
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
 root_module="$(go list -m -f '{{.Path}}' 2>/dev/null || awk '/^module / {print $2; exit}' go.mod)"
 if [ -z "${root_module}" ]; then
   echo "::error::Unable to determine root module path."
   exit 1
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'chmod -R u+w "${tmp_dir}" >/dev/null 2>&1 || true; rm -rf "${tmp_dir}"' EXIT
+export GOMODCACHE="${tmp_dir}/gomodcache"
+if [ -n "${GOFLAGS:-}" ]; then
+  export GOFLAGS="${GOFLAGS} -modcacherw"
+else
+  export GOFLAGS="-modcacherw"
 fi
 
 # Detect if this is a fork and try to fetch upstream tags.
@@ -22,6 +49,9 @@ if [[ "${origin_url}" != *"${root_module}"* ]]; then
   upstream_url=""
   if [[ "${root_module}" == trpc.group/* ]]; then
     repo_path="${root_module#trpc.group/}"
+    if [[ "${repo_path}" == trpc-go/* ]]; then
+      repo_path="trpc-group/${repo_path#trpc-go/}"
+    fi
     upstream_url="https://github.com/${repo_path}.git"
   elif [[ "${root_module}" == github.com/* ]]; then
     repo_path="${root_module#github.com/}"
@@ -30,15 +60,10 @@ if [[ "${origin_url}" != *"${root_module}"* ]]; then
   
   if [ -n "${upstream_url}" ]; then
     echo "Attempting to fetch tags from upstream: ${upstream_url}"
-    if git remote add upstream "${upstream_url}" 2>/dev/null || true; then
-      if git fetch upstream --tags 2>/dev/null; then
-        echo "Successfully fetched upstream tags"
-      else
-        echo "::warning::Failed to fetch upstream tags, will skip tag validation"
-        skip_tag_validation=true
-      fi
+    if git fetch "${upstream_url}" "+refs/tags/*:refs/tags/*" 2>/dev/null; then
+      echo "Successfully fetched upstream tags"
     else
-      echo "::warning::Failed to add upstream remote, will skip tag validation"
+      echo "::warning::Failed to fetch upstream tags, will skip tag validation"
       skip_tag_validation=true
     fi
   else
@@ -72,7 +97,26 @@ zero_placeholder="v0.0.0-00010101000000-000000000000"
 plain_zero_regex='v0\.0\.0(?!-)'
 pseudo_regex='^v[0-9]+\.[0-9]+\.[0-9]+.*-0?\.?[0-9]{14}-[a-f0-9]{12,40}$'
 
-mapfile -d '' go_mod_files < <(find . -name "go.mod" -print0 | sort -z)
+go_mod_files=()
+if [ "${#requested_modules[@]}" -gt 0 ]; then
+  for module in "${requested_modules[@]}"; do
+    normalized="${module#./}"
+    normalized="./${normalized}"
+    if [ ! -f "${normalized}" ]; then
+      echo "::error::Module file not found: ${module}"
+      echo "::endgroup::"
+      exit 2
+    fi
+    go_mod_files+=("${normalized}")
+  done
+else
+  mapfile -d '' go_mod_files < <(find . -name "go.mod" \
+    -not -path "./.resource/*" \
+    -not -path "./docs/*" \
+    -not -path "./examples/*" \
+    -not -path "./test/*" \
+    -print0 | sort -z)
+fi
 
 if [ "${#go_mod_files[@]}" -eq 0 ]; then
   echo "No go.mod files found, skipping check."
@@ -82,6 +126,25 @@ fi
 
 has_error=false
 flagged_files=()
+
+is_repo_module_path() {
+  local dep_path="$1"
+  [[ "${dep_path}" == "${root_module}" || "${dep_path}" == "${root_module}/"* ]]
+}
+
+validate_resolvable_version() {
+  local rel_path="$1"
+  local line_number="$2"
+  local dep_path="$3"
+  local dep_ver="$4"
+
+  if go mod download -json "${dep_path}@${dep_ver}" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  echo "::error file=${rel_path},line=${line_number}::Version '${dep_ver}' for module '${dep_path}' cannot be resolved by go mod download."
+  return 1
+}
 
 for go_mod in "${go_mod_files[@]}"; do
   rel_path="${go_mod#./}"
@@ -121,7 +184,15 @@ for go_mod in "${go_mod_files[@]}"; do
     [ -z "${req}" ] && continue
     dep_path="${req%% *}"
     dep_ver="${req#* }"
-    [[ "${dep_path}" != ${root_module}* ]] && continue
+    is_repo_module_path "${dep_path}" || continue
+
+    line_number="$(grep -nF "${dep_path}" "${go_mod}" | head -n1 | cut -d: -f1)"
+    [ -z "${line_number}" ] && line_number=1
+
+    if ! validate_resolvable_version "${rel_path}" "${line_number}" "${dep_path}" "${dep_ver}"; then
+      has_error=true
+      has_match=true
+    fi
 
     # Skip tag validation if requested.
     if [ "${skip_tag_validation}" = "true" ]; then
@@ -129,8 +200,6 @@ for go_mod in "${go_mod_files[@]}"; do
     fi
 
     tags="${module_tags[$dep_path]:-}"
-    line_number="$(grep -nF "${dep_path}" "${go_mod}" | head -n1 | cut -d: -f1)"
-    [ -z "${line_number}" ] && line_number=1
 
     version_ok=false
 

--- a/.github/workflows/prc.yml
+++ b/.github/workflows/prc.yml
@@ -238,6 +238,21 @@ jobs:
       - name: Check go.mod and go.sum are tidy
         shell: bash
         run: bash .github/scripts/check-go-mod-tidy.sh
+  check-external-consumer:
+    name: check external consumer (${{ matrix.module }})
+    runs-on: ubuntu-latest
+    needs: discover-go-modules
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.discover-go-modules.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "${{ env.ROOT_GO_VERSION }}"
+      - name: Check module as an external consumer
+        shell: bash
+        run: bash .github/scripts/check-external-consumer.sh --module "${{ matrix.module }}"
   check-examples:
     name: check examples (${{ matrix.shard_label }})
     runs-on: ubuntu-latest

--- a/artifact/s3/go.mod
+++ b/artifact/s3/go.mod
@@ -10,7 +10,7 @@ replace (
 require (
 	github.com/stretchr/testify v1.11.1
 	trpc.group/trpc-go/trpc-agent-go v0.8.0
-	trpc.group/trpc-go/trpc-agent-go/storage/s3 v1.1.2-0.20260108033914-7a20241f1ad5
+	trpc.group/trpc-go/trpc-agent-go/storage/s3 v1.8.0
 )
 
 require (

--- a/openclaw/go.mod
+++ b/openclaw/go.mod
@@ -50,30 +50,30 @@ require (
 	golang.org/x/net v0.49.0
 	gopkg.in/yaml.v3 v3.0.1
 	trpc.group/trpc-go/trpc-a2a-go v0.2.5
-	trpc.group/trpc-go/trpc-agent-go v1.6.1-0.20260311094958-7b74ee59e339
-	trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/elasticsearch v1.6.1-0.20260311094958-7b74ee59e339
-	trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/pgvector v1.6.1-0.20260311094958-7b74ee59e339
-	trpc.group/trpc-go/trpc-agent-go/memory/mysql v1.5.0
-	trpc.group/trpc-go/trpc-agent-go/memory/pgvector v0.0.0-20260226120000-4e084c8c87d8
-	trpc.group/trpc-go/trpc-agent-go/memory/postgres v1.5.0
-	trpc.group/trpc-go/trpc-agent-go/memory/redis v0.2.0
-	trpc.group/trpc-go/trpc-agent-go/memory/sqlite v1.5.0
-	trpc.group/trpc-go/trpc-agent-go/memory/sqlitevec v1.5.0
-	trpc.group/trpc-go/trpc-agent-go/session/clickhouse v1.5.0
-	trpc.group/trpc-go/trpc-agent-go/session/mysql v1.5.0
-	trpc.group/trpc-go/trpc-agent-go/session/postgres v1.5.0
-	trpc.group/trpc-go/trpc-agent-go/session/redis v0.0.3
-	trpc.group/trpc-go/trpc-agent-go/session/sqlite v1.5.0
-	trpc.group/trpc-go/trpc-agent-go/storage/clickhouse v1.5.0
-	trpc.group/trpc-go/trpc-agent-go/storage/mysql v1.5.0
-	trpc.group/trpc-go/trpc-agent-go/storage/postgres v1.5.0
-	trpc.group/trpc-go/trpc-agent-go/storage/redis v0.2.0
-	trpc.group/trpc-go/trpc-agent-go/tool/arxivsearch v1.5.0
-	trpc.group/trpc-go/trpc-agent-go/tool/email v1.5.0
-	trpc.group/trpc-go/trpc-agent-go/tool/google v1.5.0
-	trpc.group/trpc-go/trpc-agent-go/tool/openapi v1.5.0
-	trpc.group/trpc-go/trpc-agent-go/tool/webfetch/httpfetch v1.5.0
-	trpc.group/trpc-go/trpc-agent-go/tool/wikipedia v0.0.0-20260226120000-4e084c8c87d8
+	trpc.group/trpc-go/trpc-agent-go v1.8.0
+	trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/elasticsearch v1.8.0
+	trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/pgvector v1.8.0
+	trpc.group/trpc-go/trpc-agent-go/memory/mysql v1.8.0
+	trpc.group/trpc-go/trpc-agent-go/memory/pgvector v1.8.0
+	trpc.group/trpc-go/trpc-agent-go/memory/postgres v1.8.0
+	trpc.group/trpc-go/trpc-agent-go/memory/redis v1.8.0
+	trpc.group/trpc-go/trpc-agent-go/memory/sqlite v1.8.0
+	trpc.group/trpc-go/trpc-agent-go/memory/sqlitevec v1.8.0
+	trpc.group/trpc-go/trpc-agent-go/session/clickhouse v1.8.0
+	trpc.group/trpc-go/trpc-agent-go/session/mysql v1.8.0
+	trpc.group/trpc-go/trpc-agent-go/session/postgres v1.8.0
+	trpc.group/trpc-go/trpc-agent-go/session/redis v1.8.0
+	trpc.group/trpc-go/trpc-agent-go/session/sqlite v1.8.0
+	trpc.group/trpc-go/trpc-agent-go/storage/clickhouse v1.8.0
+	trpc.group/trpc-go/trpc-agent-go/storage/mysql v1.8.0
+	trpc.group/trpc-go/trpc-agent-go/storage/postgres v1.8.0
+	trpc.group/trpc-go/trpc-agent-go/storage/redis v1.8.0
+	trpc.group/trpc-go/trpc-agent-go/tool/arxivsearch v1.8.0
+	trpc.group/trpc-go/trpc-agent-go/tool/email v1.8.0
+	trpc.group/trpc-go/trpc-agent-go/tool/google v1.8.0
+	trpc.group/trpc-go/trpc-agent-go/tool/openapi v1.8.0
+	trpc.group/trpc-go/trpc-agent-go/tool/webfetch/httpfetch v1.8.0
+	trpc.group/trpc-go/trpc-agent-go/tool/wikipedia v1.8.0
 	trpc.group/trpc-go/trpc-mcp-go v0.0.10
 )
 


### PR DESCRIPTION
This change strengthens CI for multi-module publishing by checking that intra-repository module requirements are resolvable through the public module system and by importing buildable packages from each module through a temporary external consumer against the current repository snapshot. It also avoids repository-local replace directives masking missing published module versions and runs the consumer check with CGO disabled so the pipeline does not depend on system SQLite libraries.