### PR TITLE
model: expose timing info to callbacks

### DIFF
--- a/graph/state_graph.go
+++ b/graph/state_graph.go
@@ -34,6 +34,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/graph/internal/channel"
 	"trpc.group/trpc-go/trpc-agent-go/internal/jsonrepair"
 	promptstate "trpc.group/trpc-go/trpc-agent-go/internal/prompt/adapter/state"
+	"trpc.group/trpc-go/trpc-agent-go/internal/responseusage"
 	istructure "trpc.group/trpc-go/trpc-agent-go/internal/structure"
 	itelemetry "trpc.group/trpc-go/trpc-agent-go/internal/telemetry"
 	itool "trpc.group/trpc-go/trpc-agent-go/internal/tool"
@@ -1639,7 +1640,7 @@ type modelResponseConfig struct {
 	Invocation       *agent.Invocation
 	StableInvocation *agent.Invocation
 	Tracker          *itelemetry.ChatMetricsTracker
-	PartialUsage     *partialUsageState
+	PartialUsage     *responseusage.PartialState
 	ModelCallbacks   *model.Callbacks
 	EventChan        chan<- *event.Event
 	InvocationID     string
@@ -1878,7 +1879,7 @@ func processModelResponse(ctx context.Context, config modelResponseConfig) (cont
 	if config.Tracker != nil {
 		config.Tracker.SetInvocationState(currentInvocation, timingInfo)
 	}
-	callbackTimingAttachment := attachResponseUsageTimingForCallback(
+	callbackTimingAttachment := responseusage.AttachTimingForCallback(
 		config.Response,
 		timingInfo,
 		config.PartialUsage,
@@ -1899,7 +1900,7 @@ func processModelResponse(ctx context.Context, config modelResponseConfig) (cont
 	}
 	responseReplaced := false
 	if pluginOverride {
-		callbackTimingAttachment.restore()
+		callbackTimingAttachment.Restore()
 		config.Response = customResponse
 		args.Response = config.Response
 		responseReplaced = true
@@ -1916,7 +1917,7 @@ func processModelResponse(ctx context.Context, config modelResponseConfig) (cont
 			return ctx, nil, err
 		}
 		if customResponse != nil {
-			callbackTimingAttachment.restore()
+			callbackTimingAttachment.Restore()
 			config.Response = customResponse
 			responseReplaced = true
 		}
@@ -1926,10 +1927,10 @@ func processModelResponse(ctx context.Context, config modelResponseConfig) (cont
 	if config.Tracker != nil {
 		config.Tracker.SetInvocationState(currentInvocation, timingInfo)
 	}
-	if !responseReplaced && timingInfo != callbackTimingAttachment.attachedTimingInfo {
-		callbackTimingAttachment.restore()
+	if !responseReplaced {
+		callbackTimingAttachment.RestoreIfTimingInfoChanged(timingInfo)
 	}
-	attachResponseUsageTiming(config.Response, timingInfo, config.PartialUsage)
+	responseusage.AttachTiming(config.Response, timingInfo, config.PartialUsage)
 	eventInvocation := config.StableInvocation
 	if eventInvocation == nil {
 		eventInvocation = config.Invocation
@@ -4369,104 +4370,6 @@ func trackModelResponseTelemetry(
 	tracker.TrackResponse(response)
 }
 
-type partialUsageState struct {
-	usage      *model.Usage
-	timingInfo *model.TimingInfo
-}
-
-type responseUsageTimingAttachment struct {
-	response           *model.Response
-	usage              *model.Usage
-	timingInfo         *model.TimingInfo
-	attachedUsage      *model.Usage
-	attachedTimingInfo *model.TimingInfo
-	createdUsage       bool
-}
-
-func attachResponseUsageTimingForCallback(
-	response *model.Response,
-	timingInfo *model.TimingInfo,
-	partialUsageState *partialUsageState,
-) responseUsageTimingAttachment {
-	attachment := responseUsageTimingAttachment{response: response}
-	if response != nil {
-		attachment.usage = response.Usage
-		if response.Usage != nil {
-			attachment.timingInfo = response.Usage.TimingInfo
-		}
-	}
-	attachResponseUsageTiming(response, timingInfo, partialUsageState)
-	if response != nil {
-		attachment.attachedUsage = response.Usage
-		if response.Usage != nil {
-			attachment.attachedTimingInfo = response.Usage.TimingInfo
-		}
-		attachment.createdUsage = attachment.usage == nil && response.Usage != nil
-	}
-	return attachment
-}
-
-func (a responseUsageTimingAttachment) restore() {
-	if a.response == nil || a.response.Usage == nil {
-		return
-	}
-	if a.createdUsage {
-		if a.response.Usage != a.attachedUsage {
-			return
-		}
-		if usageOnlyHasTimingInfo(a.response.Usage) {
-			a.response.Usage = nil
-			return
-		}
-		if a.response.Usage.TimingInfo == a.attachedTimingInfo {
-			a.response.Usage.TimingInfo = nil
-		}
-		return
-	}
-	if a.response.Usage == a.usage &&
-		a.response.Usage.TimingInfo == a.attachedTimingInfo {
-		a.response.Usage.TimingInfo = a.timingInfo
-	}
-}
-
-func usageOnlyHasTimingInfo(usage *model.Usage) bool {
-	if usage == nil {
-		return true
-	}
-	return usage.PromptTokens == 0 &&
-		usage.CompletionTokens == 0 &&
-		usage.TotalTokens == 0 &&
-		usage.PromptTokensDetails == (model.PromptTokensDetails{}) &&
-		usage.CompletionTokensDetails == (model.CompletionTokensDetails{})
-}
-
-func attachResponseUsageTiming(
-	response *model.Response,
-	timingInfo *model.TimingInfo,
-	partialUsageState *partialUsageState,
-) {
-	if response == nil || timingInfo == nil {
-		return
-	}
-	if response.Usage == nil {
-		if response.IsPartial {
-			if partialUsageState == nil {
-				response.Usage = &model.Usage{}
-			} else {
-				if partialUsageState.usage == nil ||
-					partialUsageState.timingInfo != timingInfo {
-					partialUsageState.usage = &model.Usage{}
-					partialUsageState.timingInfo = timingInfo
-				}
-				response.Usage = partialUsageState.usage
-			}
-		} else {
-			response.Usage = &model.Usage{}
-		}
-	}
-	response.Usage.TimingInfo = timingInfo
-}
-
 func responseUsageTimingInfo(invocation *agent.Invocation) *model.TimingInfo {
 	if invocation == nil || invocation.RunOptions.DisableResponseUsageTracking {
 		return nil
@@ -4556,7 +4459,7 @@ type modelResponseProcessor struct {
 	invocation                     *agent.Invocation
 	tracker                        *itelemetry.ChatMetricsTracker
 	timingInfo                     *model.TimingInfo
-	partialUsageState              partialUsageState
+	partialUsageState              responseusage.PartialState
 	tap                            *modelDeltaStreamTap
 	reusableEvents                 []event.Event
 	reusableEventIdx               int
@@ -4829,7 +4732,7 @@ func (p *modelResponseProcessor) handleResponse(response *model.Response) (bool,
 	p.finalResponse = response
 	reusableEvent := nextReusableModelEvent(p.reusableEvents, &p.reusableEventIdx)
 	if p.fastResponsePath {
-		attachResponseUsageTiming(response, p.timingInfo, &p.partialUsageState)
+		responseusage.AttachTiming(response, p.timingInfo, &p.partialUsageState)
 		lastEvent, err := emitFastModelResponseEvent(
 			p.ctx,
 			p.stableInvocation,

--- a/graph/state_graph.go
+++ b/graph/state_graph.go
@@ -1873,6 +1873,16 @@ func shouldEmitModelResponseEvent(
 
 // processModelResponse processes a single model response.
 func processModelResponse(ctx context.Context, config modelResponseConfig) (context.Context, *event.Event, error) {
+	currentInvocation := invocationFromContextOrDefault(ctx, config.Invocation)
+	timingInfo := responseUsageTimingInfo(currentInvocation)
+	if config.Tracker != nil {
+		config.Tracker.SetInvocationState(currentInvocation, timingInfo)
+	}
+	callbackTimingAttachment := attachResponseUsageTimingForCallback(
+		config.Response,
+		timingInfo,
+		config.PartialUsage,
+	)
 	args := &model.AfterModelArgs{
 		Request:  config.Request,
 		Response: config.Response,
@@ -1887,9 +1897,12 @@ func processModelResponse(ctx context.Context, config modelResponseConfig) (cont
 	if err != nil {
 		return ctx, nil, err
 	}
+	responseReplaced := false
 	if pluginOverride {
+		callbackTimingAttachment.restore()
 		config.Response = customResponse
 		args.Response = config.Response
+		responseReplaced = true
 	}
 
 	if !pluginOverride {
@@ -1903,13 +1916,18 @@ func processModelResponse(ctx context.Context, config modelResponseConfig) (cont
 			return ctx, nil, err
 		}
 		if customResponse != nil {
+			callbackTimingAttachment.restore()
 			config.Response = customResponse
+			responseReplaced = true
 		}
 	}
-	currentInvocation := invocationFromContextOrDefault(ctx, config.Invocation)
-	timingInfo := responseUsageTimingInfo(currentInvocation)
+	currentInvocation = invocationFromContextOrDefault(ctx, config.Invocation)
+	timingInfo = responseUsageTimingInfo(currentInvocation)
 	if config.Tracker != nil {
 		config.Tracker.SetInvocationState(currentInvocation, timingInfo)
+	}
+	if !responseReplaced && timingInfo != callbackTimingAttachment.attachedTimingInfo {
+		callbackTimingAttachment.restore()
 	}
 	attachResponseUsageTiming(config.Response, timingInfo, config.PartialUsage)
 	eventInvocation := config.StableInvocation
@@ -4354,6 +4372,72 @@ func trackModelResponseTelemetry(
 type partialUsageState struct {
 	usage      *model.Usage
 	timingInfo *model.TimingInfo
+}
+
+type responseUsageTimingAttachment struct {
+	response           *model.Response
+	usage              *model.Usage
+	timingInfo         *model.TimingInfo
+	attachedUsage      *model.Usage
+	attachedTimingInfo *model.TimingInfo
+	createdUsage       bool
+}
+
+func attachResponseUsageTimingForCallback(
+	response *model.Response,
+	timingInfo *model.TimingInfo,
+	partialUsageState *partialUsageState,
+) responseUsageTimingAttachment {
+	attachment := responseUsageTimingAttachment{response: response}
+	if response != nil {
+		attachment.usage = response.Usage
+		if response.Usage != nil {
+			attachment.timingInfo = response.Usage.TimingInfo
+		}
+	}
+	attachResponseUsageTiming(response, timingInfo, partialUsageState)
+	if response != nil {
+		attachment.attachedUsage = response.Usage
+		if response.Usage != nil {
+			attachment.attachedTimingInfo = response.Usage.TimingInfo
+		}
+		attachment.createdUsage = attachment.usage == nil && response.Usage != nil
+	}
+	return attachment
+}
+
+func (a responseUsageTimingAttachment) restore() {
+	if a.response == nil || a.response.Usage == nil {
+		return
+	}
+	if a.createdUsage {
+		if a.response.Usage != a.attachedUsage {
+			return
+		}
+		if usageOnlyHasTimingInfo(a.response.Usage) {
+			a.response.Usage = nil
+			return
+		}
+		if a.response.Usage.TimingInfo == a.attachedTimingInfo {
+			a.response.Usage.TimingInfo = nil
+		}
+		return
+	}
+	if a.response.Usage == a.usage &&
+		a.response.Usage.TimingInfo == a.attachedTimingInfo {
+		a.response.Usage.TimingInfo = a.timingInfo
+	}
+}
+
+func usageOnlyHasTimingInfo(usage *model.Usage) bool {
+	if usage == nil {
+		return true
+	}
+	return usage.PromptTokens == 0 &&
+		usage.CompletionTokens == 0 &&
+		usage.TotalTokens == 0 &&
+		usage.PromptTokensDetails == (model.PromptTokensDetails{}) &&
+		usage.CompletionTokensDetails == (model.CompletionTokensDetails{})
 }
 
 func attachResponseUsageTiming(

--- a/graph/state_graph_additional_test.go
+++ b/graph/state_graph_additional_test.go
@@ -1431,6 +1431,47 @@ func TestExecuteModelAndProcessResponses_UsesUpdatedInvocationForMetricsMetadata
 	require.True(t, resourceMetricsContainAttribute(rm, semconvtrace.KeyTRPCAgentGoAppName, updatedInvocation.Session.AppName))
 }
 
+func TestExecuteModelAndProcessResponses_AttachesTimingInfoBeforeAfterModelCallbacks(t *testing.T) {
+	baseInvocation := agent.NewInvocation(
+		agent.WithInvocationID("inv-callback-timing"),
+	)
+	response := &model.Response{
+		Choices: []model.Choice{
+			{Message: model.NewAssistantMessage("done")},
+		},
+	}
+	var callbackTimingInfo *model.TimingInfo
+	callbacks := model.NewCallbacks().RegisterAfterModel(
+		func(ctx context.Context, args *model.AfterModelArgs) (*model.AfterModelResult, error) {
+			require.NotNil(t, args.Response)
+			require.NotNil(t, args.Response.Usage)
+			require.NotNil(t, args.Response.Usage.TimingInfo)
+			require.NotZero(t, args.Response.Usage.TimingInfo.FirstTokenDuration)
+			callbackTimingInfo = args.Response.Usage.TimingInfo
+			return &model.AfterModelResult{}, nil
+		},
+	)
+	resp, err := executeModelAndProcessResponses(
+		agent.NewInvocationContext(context.Background(), baseInvocation),
+		modelExecutionConfig{
+			Invocation:     baseInvocation,
+			ModelCallbacks: callbacks,
+			LLMModel: &multiResponseModel{
+				responses: []*model.Response{response},
+				delay:     time.Millisecond,
+			},
+			Request:      &model.Request{},
+			InvocationID: baseInvocation.InvocationID,
+			Span:         noop.Span{},
+			NodeID:       "llm",
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, response.Usage)
+	require.Same(t, callbackTimingInfo, response.Usage.TimingInfo)
+}
+
 func TestExecuteModelAndProcessResponses_UsesUpdatedInvocationForResponseUsageTimingOnSingleChunk(t *testing.T) {
 	baseInvocation := agent.NewInvocation(
 		agent.WithInvocationID("inv-base-single-usage"),

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -573,6 +573,11 @@ func (f *Flow) processStreamingResponses(
 			response,
 			tracker,
 		)
+		callbackTimingAttachment := attachResponseUsageTimingForCallback(
+			response,
+			timingInfo,
+			&partialUsageState,
+		)
 		eventInvocation := invocation
 		if eventInvocation == nil {
 			eventInvocation = currentInvocation
@@ -591,7 +596,9 @@ func (f *Flow) processStreamingResponses(
 			return false
 		}
 		ctx = updatedCtx
-		if customResp != nil {
+		responseReplaced := customResp != nil
+		if responseReplaced {
+			callbackTimingAttachment.restore()
 			response = customResp
 		}
 		currentInvocation = invocationFromContextOrDefault(
@@ -601,6 +608,9 @@ func (f *Flow) processStreamingResponses(
 		timingInfo = responseUsageTimingInfo(currentInvocation)
 		if tracker != nil {
 			tracker.SetInvocationState(currentInvocation, timingInfo)
+		}
+		if !responseReplaced && timingInfo != callbackTimingAttachment.attachedTimingInfo {
+			callbackTimingAttachment.restore()
 		}
 		attachResponseUsageTiming(response, timingInfo, &partialUsageState)
 		// Repair tool call arguments in place when needed.
@@ -740,6 +750,72 @@ func trackModelResponseTelemetry(
 		return
 	}
 	tracker.TrackResponse(response)
+}
+
+type responseUsageTimingAttachment struct {
+	response           *model.Response
+	usage              *model.Usage
+	timingInfo         *model.TimingInfo
+	attachedUsage      *model.Usage
+	attachedTimingInfo *model.TimingInfo
+	createdUsage       bool
+}
+
+func attachResponseUsageTimingForCallback(
+	response *model.Response,
+	timingInfo *model.TimingInfo,
+	partialUsageState *partialUsageState,
+) responseUsageTimingAttachment {
+	attachment := responseUsageTimingAttachment{response: response}
+	if response != nil {
+		attachment.usage = response.Usage
+		if response.Usage != nil {
+			attachment.timingInfo = response.Usage.TimingInfo
+		}
+	}
+	attachResponseUsageTiming(response, timingInfo, partialUsageState)
+	if response != nil {
+		attachment.attachedUsage = response.Usage
+		if response.Usage != nil {
+			attachment.attachedTimingInfo = response.Usage.TimingInfo
+		}
+		attachment.createdUsage = attachment.usage == nil && response.Usage != nil
+	}
+	return attachment
+}
+
+func (a responseUsageTimingAttachment) restore() {
+	if a.response == nil || a.response.Usage == nil {
+		return
+	}
+	if a.createdUsage {
+		if a.response.Usage != a.attachedUsage {
+			return
+		}
+		if usageOnlyHasTimingInfo(a.response.Usage) {
+			a.response.Usage = nil
+			return
+		}
+		if a.response.Usage.TimingInfo == a.attachedTimingInfo {
+			a.response.Usage.TimingInfo = nil
+		}
+		return
+	}
+	if a.response.Usage == a.usage &&
+		a.response.Usage.TimingInfo == a.attachedTimingInfo {
+		a.response.Usage.TimingInfo = a.timingInfo
+	}
+}
+
+func usageOnlyHasTimingInfo(usage *model.Usage) bool {
+	if usage == nil {
+		return true
+	}
+	return usage.PromptTokens == 0 &&
+		usage.CompletionTokens == 0 &&
+		usage.TotalTokens == 0 &&
+		usage.PromptTokensDetails == (model.PromptTokensDetails{}) &&
+		usage.CompletionTokensDetails == (model.CompletionTokensDetails{})
 }
 
 func attachResponseUsageTiming(

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -27,6 +27,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/internal/flow"
 	"trpc.group/trpc-go/trpc-agent-go/internal/flow/processor"
 	"trpc.group/trpc-go/trpc-agent-go/internal/jsonrepair"
+	"trpc.group/trpc-go/trpc-agent-go/internal/responseusage"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/steer"
 	itelemetry "trpc.group/trpc-go/trpc-agent-go/internal/telemetry"
 	"trpc.group/trpc-go/trpc-agent-go/internal/toolcall"
@@ -525,11 +526,6 @@ func (f *Flow) runOneStep(
 }
 
 // processStreamingResponses handles the streaming response processing logic.
-type partialUsageState struct {
-	usage      *model.Usage
-	timingInfo *model.TimingInfo
-}
-
 func (f *Flow) processStreamingResponses(
 	ctx context.Context,
 	invocation *agent.Invocation,
@@ -546,7 +542,7 @@ func (f *Flow) processStreamingResponses(
 	}
 	var tracker *itelemetry.ChatMetricsTracker
 	var timingInfo *model.TimingInfo
-	var partialUsageState partialUsageState
+	var partialUsageState responseusage.PartialState
 	if metricsInvocation != nil {
 		timingInfo = responseUsageTimingInfo(currentInvocation)
 		tracker = itelemetry.NewChatMetricsTracker(
@@ -573,7 +569,7 @@ func (f *Flow) processStreamingResponses(
 			response,
 			tracker,
 		)
-		callbackTimingAttachment := attachResponseUsageTimingForCallback(
+		callbackTimingAttachment := responseusage.AttachTimingForCallback(
 			response,
 			timingInfo,
 			&partialUsageState,
@@ -598,7 +594,7 @@ func (f *Flow) processStreamingResponses(
 		ctx = updatedCtx
 		responseReplaced := customResp != nil
 		if responseReplaced {
-			callbackTimingAttachment.restore()
+			callbackTimingAttachment.Restore()
 			response = customResp
 		}
 		currentInvocation = invocationFromContextOrDefault(
@@ -609,10 +605,10 @@ func (f *Flow) processStreamingResponses(
 		if tracker != nil {
 			tracker.SetInvocationState(currentInvocation, timingInfo)
 		}
-		if !responseReplaced && timingInfo != callbackTimingAttachment.attachedTimingInfo {
-			callbackTimingAttachment.restore()
+		if !responseReplaced {
+			callbackTimingAttachment.RestoreIfTimingInfoChanged(timingInfo)
 		}
-		attachResponseUsageTiming(response, timingInfo, &partialUsageState)
+		responseusage.AttachTiming(response, timingInfo, &partialUsageState)
 		// Repair tool call arguments in place when needed.
 		if currentInvocation != nil &&
 			jsonrepair.IsToolCallArgumentsJSONRepairEnabled(currentInvocation) {
@@ -750,99 +746,6 @@ func trackModelResponseTelemetry(
 		return
 	}
 	tracker.TrackResponse(response)
-}
-
-type responseUsageTimingAttachment struct {
-	response           *model.Response
-	usage              *model.Usage
-	timingInfo         *model.TimingInfo
-	attachedUsage      *model.Usage
-	attachedTimingInfo *model.TimingInfo
-	createdUsage       bool
-}
-
-func attachResponseUsageTimingForCallback(
-	response *model.Response,
-	timingInfo *model.TimingInfo,
-	partialUsageState *partialUsageState,
-) responseUsageTimingAttachment {
-	attachment := responseUsageTimingAttachment{response: response}
-	if response != nil {
-		attachment.usage = response.Usage
-		if response.Usage != nil {
-			attachment.timingInfo = response.Usage.TimingInfo
-		}
-	}
-	attachResponseUsageTiming(response, timingInfo, partialUsageState)
-	if response != nil {
-		attachment.attachedUsage = response.Usage
-		if response.Usage != nil {
-			attachment.attachedTimingInfo = response.Usage.TimingInfo
-		}
-		attachment.createdUsage = attachment.usage == nil && response.Usage != nil
-	}
-	return attachment
-}
-
-func (a responseUsageTimingAttachment) restore() {
-	if a.response == nil || a.response.Usage == nil {
-		return
-	}
-	if a.createdUsage {
-		if a.response.Usage != a.attachedUsage {
-			return
-		}
-		if usageOnlyHasTimingInfo(a.response.Usage) {
-			a.response.Usage = nil
-			return
-		}
-		if a.response.Usage.TimingInfo == a.attachedTimingInfo {
-			a.response.Usage.TimingInfo = nil
-		}
-		return
-	}
-	if a.response.Usage == a.usage &&
-		a.response.Usage.TimingInfo == a.attachedTimingInfo {
-		a.response.Usage.TimingInfo = a.timingInfo
-	}
-}
-
-func usageOnlyHasTimingInfo(usage *model.Usage) bool {
-	if usage == nil {
-		return true
-	}
-	return usage.PromptTokens == 0 &&
-		usage.CompletionTokens == 0 &&
-		usage.TotalTokens == 0 &&
-		usage.PromptTokensDetails == (model.PromptTokensDetails{}) &&
-		usage.CompletionTokensDetails == (model.CompletionTokensDetails{})
-}
-
-func attachResponseUsageTiming(
-	response *model.Response,
-	timingInfo *model.TimingInfo,
-	partialUsageState *partialUsageState,
-) {
-	if response == nil || timingInfo == nil {
-		return
-	}
-	if response.Usage == nil {
-		if response.IsPartial {
-			if partialUsageState == nil {
-				response.Usage = &model.Usage{}
-			} else {
-				if partialUsageState.usage == nil ||
-					partialUsageState.timingInfo != timingInfo {
-					partialUsageState.usage = &model.Usage{}
-					partialUsageState.timingInfo = timingInfo
-				}
-				response.Usage = partialUsageState.usage
-			}
-		} else {
-			response.Usage = &model.Usage{}
-		}
-	}
-	response.Usage.TimingInfo = timingInfo
 }
 
 func responseUsageTimingInfo(invocation *agent.Invocation) *model.TimingInfo {

--- a/internal/flow/llmflow/llmflow_test.go
+++ b/internal/flow/llmflow/llmflow_test.go
@@ -951,6 +951,54 @@ func TestProcessStreamingResponses_UsesUpdatedInvocationForResponseUsageTiming(t
 	require.Nil(t, response2.Usage)
 }
 
+func TestProcessStreamingResponses_AttachesTimingInfoBeforeAfterModelCallbacks(t *testing.T) {
+	var callbackTimingInfo *model.TimingInfo
+	f := New(nil, nil, Options{
+		ModelCallbacks: model.NewCallbacks().RegisterAfterModel(
+			func(ctx context.Context, args *model.AfterModelArgs) (*model.AfterModelResult, error) {
+				require.NotNil(t, args.Response)
+				require.NotNil(t, args.Response.Usage)
+				require.NotNil(t, args.Response.Usage.TimingInfo)
+				require.NotZero(t, args.Response.Usage.TimingInfo.FirstTokenDuration)
+				callbackTimingInfo = args.Response.Usage.TimingInfo
+				return &model.AfterModelResult{}, nil
+			},
+		),
+	})
+	invocation := agent.NewInvocation(
+		agent.WithInvocationID("inv-callback-timing"),
+	)
+	response := &model.Response{
+		Choices: []model.Choice{
+			{Message: model.NewAssistantMessage("done")},
+		},
+	}
+	responseSeq := func(yield func(*model.Response) bool) {
+		time.Sleep(time.Millisecond)
+		yield(response)
+	}
+	eventChan := make(chan *event.Event, 10)
+	tracer := oteltrace.NewNoopTracerProvider().Tracer("t")
+	ctx, span := tracer.Start(
+		agent.NewInvocationContext(context.Background(), invocation),
+		"s",
+	)
+	defer span.End()
+	lastEvent, err := f.processStreamingResponses(
+		ctx,
+		invocation,
+		&model.Request{},
+		responseSeq,
+		eventChan,
+		span,
+		true,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, lastEvent)
+	require.NotNil(t, response.Usage)
+	require.Same(t, callbackTimingInfo, response.Usage.TimingInfo)
+}
+
 func TestProcessStreamingResponses_UsesUpdatedInvocationForResponseUsageTimingOnSingleChunk(t *testing.T) {
 	updatedInvocation := agent.NewInvocation(
 		agent.WithInvocationID("inv-updated-single-usage"),

--- a/internal/responseusage/timing.go
+++ b/internal/responseusage/timing.go
@@ -1,0 +1,123 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+// Package responseusage provides helpers for attaching response usage metadata.
+package responseusage
+
+import "trpc.group/trpc-go/trpc-agent-go/model"
+
+// PartialState stores reusable usage state for partial responses.
+type PartialState struct {
+	usage      *model.Usage
+	timingInfo *model.TimingInfo
+}
+
+// TimingAttachment records a temporary TimingInfo attachment.
+type TimingAttachment struct {
+	response           *model.Response
+	usage              *model.Usage
+	timingInfo         *model.TimingInfo
+	attachedUsage      *model.Usage
+	attachedTimingInfo *model.TimingInfo
+	createdUsage       bool
+}
+
+// AttachTimingForCallback attaches TimingInfo before callbacks and returns a restorer.
+func AttachTimingForCallback(
+	response *model.Response,
+	timingInfo *model.TimingInfo,
+	partialState *PartialState,
+) TimingAttachment {
+	attachment := TimingAttachment{response: response}
+	if response != nil {
+		attachment.usage = response.Usage
+		if response.Usage != nil {
+			attachment.timingInfo = response.Usage.TimingInfo
+		}
+	}
+	AttachTiming(response, timingInfo, partialState)
+	if response != nil {
+		attachment.attachedUsage = response.Usage
+		if response.Usage != nil {
+			attachment.attachedTimingInfo = response.Usage.TimingInfo
+		}
+		attachment.createdUsage = attachment.usage == nil && response.Usage != nil
+	}
+	return attachment
+}
+
+// RestoreIfTimingInfoChanged restores the temporary attachment if the target TimingInfo changed.
+func (a TimingAttachment) RestoreIfTimingInfoChanged(timingInfo *model.TimingInfo) {
+	if timingInfo != a.attachedTimingInfo {
+		a.Restore()
+	}
+}
+
+// Restore removes the temporary attachment if it is still unchanged.
+func (a TimingAttachment) Restore() {
+	if a.response == nil || a.response.Usage == nil {
+		return
+	}
+	if a.createdUsage {
+		if a.response.Usage != a.attachedUsage {
+			return
+		}
+		if usageOnlyHasTimingInfo(a.response.Usage) {
+			a.response.Usage = nil
+			return
+		}
+		if a.response.Usage.TimingInfo == a.attachedTimingInfo {
+			a.response.Usage.TimingInfo = nil
+		}
+		return
+	}
+	if a.response.Usage == a.usage &&
+		a.response.Usage.TimingInfo == a.attachedTimingInfo {
+		a.response.Usage.TimingInfo = a.timingInfo
+	}
+}
+
+func usageOnlyHasTimingInfo(usage *model.Usage) bool {
+	if usage == nil {
+		return true
+	}
+	return usage.PromptTokens == 0 &&
+		usage.CompletionTokens == 0 &&
+		usage.TotalTokens == 0 &&
+		usage.PromptTokensDetails == (model.PromptTokensDetails{}) &&
+		usage.CompletionTokensDetails == (model.CompletionTokensDetails{})
+}
+
+// AttachTiming attaches TimingInfo to response usage.
+func AttachTiming(
+	response *model.Response,
+	timingInfo *model.TimingInfo,
+	partialState *PartialState,
+) {
+	if response == nil || timingInfo == nil {
+		return
+	}
+	if response.Usage == nil {
+		if response.IsPartial {
+			if partialState == nil {
+				response.Usage = &model.Usage{}
+			} else {
+				if partialState.usage == nil ||
+					partialState.timingInfo != timingInfo {
+					partialState.usage = &model.Usage{}
+					partialState.timingInfo = timingInfo
+				}
+				response.Usage = partialState.usage
+			}
+		} else {
+			response.Usage = &model.Usage{}
+		}
+	}
+	response.Usage.TimingInfo = timingInfo
+}

--- a/internal/responseusage/timing.go
+++ b/internal/responseusage/timing.go
@@ -87,11 +87,9 @@ func usageOnlyHasTimingInfo(usage *model.Usage) bool {
 	if usage == nil {
 		return true
 	}
-	return usage.PromptTokens == 0 &&
-		usage.CompletionTokens == 0 &&
-		usage.TotalTokens == 0 &&
-		usage.PromptTokensDetails == (model.PromptTokensDetails{}) &&
-		usage.CompletionTokensDetails == (model.CompletionTokensDetails{})
+	withoutTiming := *usage
+	withoutTiming.TimingInfo = nil
+	return withoutTiming == model.Usage{}
 }
 
 // AttachTiming attaches TimingInfo to response usage.

--- a/internal/responseusage/timing.go
+++ b/internal/responseusage/timing.go
@@ -26,6 +26,7 @@ type TimingAttachment struct {
 	attachedUsage      *model.Usage
 	attachedTimingInfo *model.TimingInfo
 	createdUsage       bool
+	reusedUsage        bool
 }
 
 // AttachTimingForCallback attaches TimingInfo before callbacks and returns a restorer.
@@ -40,6 +41,11 @@ func AttachTimingForCallback(
 		if response.Usage != nil {
 			attachment.timingInfo = response.Usage.TimingInfo
 		}
+		attachment.reusedUsage = response.Usage == nil &&
+			response.IsPartial &&
+			partialState != nil &&
+			partialState.usage != nil &&
+			partialState.timingInfo == timingInfo
 	}
 	AttachTiming(response, timingInfo, partialState)
 	if response != nil {
@@ -47,7 +53,9 @@ func AttachTimingForCallback(
 		if response.Usage != nil {
 			attachment.attachedTimingInfo = response.Usage.TimingInfo
 		}
-		attachment.createdUsage = attachment.usage == nil && response.Usage != nil
+		attachment.createdUsage = attachment.usage == nil &&
+			response.Usage != nil &&
+			!attachment.reusedUsage
 	}
 	return attachment
 }
@@ -74,6 +82,12 @@ func (a TimingAttachment) Restore() {
 		}
 		if a.response.Usage.TimingInfo == a.attachedTimingInfo {
 			a.response.Usage.TimingInfo = nil
+		}
+		return
+	}
+	if a.reusedUsage {
+		if a.response.Usage == a.attachedUsage {
+			a.response.Usage = a.usage
 		}
 		return
 	}

--- a/internal/responseusage/timing_test.go
+++ b/internal/responseusage/timing_test.go
@@ -58,6 +58,25 @@ func TestTimingAttachment_RestoreIfTimingInfoChanged(t *testing.T) {
 	require.Nil(t, response.Usage)
 }
 
+func TestTimingAttachment_RestoreDetachesReusedPartialUsage(t *testing.T) {
+	timing := &model.TimingInfo{FirstTokenDuration: time.Millisecond}
+	var state PartialState
+	first := &model.Response{IsPartial: true}
+	second := &model.Response{IsPartial: true}
+
+	AttachTiming(first, timing, &state)
+	first.Usage.PromptTokens = 10
+	attachment := AttachTimingForCallback(second, timing, &state)
+	require.Same(t, first.Usage, second.Usage)
+
+	attachment.RestoreIfTimingInfoChanged(nil)
+
+	require.Nil(t, second.Usage)
+	require.NotNil(t, first.Usage)
+	require.Equal(t, 10, first.Usage.PromptTokens)
+	require.Same(t, timing, first.Usage.TimingInfo)
+}
+
 func TestTimingAttachment_RestoreKeepsCallbackMutatedUsage(t *testing.T) {
 	timing := &model.TimingInfo{FirstTokenDuration: time.Millisecond}
 	response := &model.Response{}

--- a/internal/responseusage/timing_test.go
+++ b/internal/responseusage/timing_test.go
@@ -63,11 +63,11 @@ func TestTimingAttachment_RestoreKeepsCallbackMutatedUsage(t *testing.T) {
 	response := &model.Response{}
 
 	attachment := AttachTimingForCallback(response, timing, nil)
-	response.Usage.PromptTokens = 10
+	response.Usage.PromptTokensDetails.CachedTokens = 10
 	attachment.Restore()
 
 	require.NotNil(t, response.Usage)
-	require.Equal(t, 10, response.Usage.PromptTokens)
+	require.Equal(t, 10, response.Usage.PromptTokensDetails.CachedTokens)
 	require.Nil(t, response.Usage.TimingInfo)
 }
 

--- a/internal/responseusage/timing_test.go
+++ b/internal/responseusage/timing_test.go
@@ -1,0 +1,124 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package responseusage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+func TestAttachTimingForCallback_CreatesUsageAndRestores(t *testing.T) {
+	timing := &model.TimingInfo{FirstTokenDuration: time.Millisecond}
+	response := &model.Response{}
+
+	attachment := AttachTimingForCallback(response, timing, nil)
+	require.NotNil(t, response.Usage)
+	require.Same(t, timing, response.Usage.TimingInfo)
+
+	attachment.Restore()
+	require.Nil(t, response.Usage)
+}
+
+func TestAttachTimingForCallback_RestoresExistingTimingInfo(t *testing.T) {
+	oldTiming := &model.TimingInfo{FirstTokenDuration: time.Millisecond}
+	newTiming := &model.TimingInfo{FirstTokenDuration: 2 * time.Millisecond}
+	usage := &model.Usage{PromptTokens: 1, TimingInfo: oldTiming}
+	response := &model.Response{Usage: usage}
+
+	attachment := AttachTimingForCallback(response, newTiming, nil)
+	require.Same(t, usage, response.Usage)
+	require.Same(t, newTiming, response.Usage.TimingInfo)
+
+	attachment.Restore()
+	require.Same(t, usage, response.Usage)
+	require.Same(t, oldTiming, response.Usage.TimingInfo)
+}
+
+func TestTimingAttachment_RestoreIfTimingInfoChanged(t *testing.T) {
+	timing := &model.TimingInfo{FirstTokenDuration: time.Millisecond}
+	updatedTiming := &model.TimingInfo{FirstTokenDuration: 2 * time.Millisecond}
+	response := &model.Response{}
+
+	attachment := AttachTimingForCallback(response, timing, nil)
+	attachment.RestoreIfTimingInfoChanged(timing)
+	require.NotNil(t, response.Usage)
+	require.Same(t, timing, response.Usage.TimingInfo)
+
+	attachment.RestoreIfTimingInfoChanged(updatedTiming)
+	require.Nil(t, response.Usage)
+}
+
+func TestTimingAttachment_RestoreKeepsCallbackMutatedUsage(t *testing.T) {
+	timing := &model.TimingInfo{FirstTokenDuration: time.Millisecond}
+	response := &model.Response{}
+
+	attachment := AttachTimingForCallback(response, timing, nil)
+	response.Usage.PromptTokens = 10
+	attachment.Restore()
+
+	require.NotNil(t, response.Usage)
+	require.Equal(t, 10, response.Usage.PromptTokens)
+	require.Nil(t, response.Usage.TimingInfo)
+}
+
+func TestTimingAttachment_RestoreIgnoresReplacedUsage(t *testing.T) {
+	timing := &model.TimingInfo{FirstTokenDuration: time.Millisecond}
+	response := &model.Response{}
+
+	attachment := AttachTimingForCallback(response, timing, nil)
+	replacedUsage := &model.Usage{PromptTokens: 10}
+	response.Usage = replacedUsage
+	attachment.Restore()
+
+	require.Same(t, replacedUsage, response.Usage)
+	require.Nil(t, response.Usage.TimingInfo)
+}
+
+func TestAttachTiming_ReusesPartialUsageForSameTimingInfo(t *testing.T) {
+	timing := &model.TimingInfo{FirstTokenDuration: time.Millisecond}
+	var state PartialState
+	first := &model.Response{IsPartial: true}
+	second := &model.Response{IsPartial: true}
+
+	AttachTiming(first, timing, &state)
+	AttachTiming(second, timing, &state)
+
+	require.NotNil(t, first.Usage)
+	require.Same(t, first.Usage, second.Usage)
+	require.Same(t, timing, first.Usage.TimingInfo)
+}
+
+func TestAttachTiming_UsesNewPartialUsageForDifferentTimingInfo(t *testing.T) {
+	firstTiming := &model.TimingInfo{FirstTokenDuration: time.Millisecond}
+	secondTiming := &model.TimingInfo{FirstTokenDuration: 2 * time.Millisecond}
+	var state PartialState
+	first := &model.Response{IsPartial: true}
+	second := &model.Response{IsPartial: true}
+
+	AttachTiming(first, firstTiming, &state)
+	AttachTiming(second, secondTiming, &state)
+
+	require.NotNil(t, first.Usage)
+	require.NotNil(t, second.Usage)
+	require.NotSame(t, first.Usage, second.Usage)
+	require.Same(t, firstTiming, first.Usage.TimingInfo)
+	require.Same(t, secondTiming, second.Usage.TimingInfo)
+}
+
+func TestAttachTiming_NoopsOnNilResponseOrTimingInfo(t *testing.T) {
+	AttachTiming(nil, &model.TimingInfo{}, nil)
+
+	response := &model.Response{}
+	AttachTiming(response, nil, nil)
+	require.Nil(t, response.Usage)
+}


### PR DESCRIPTION
## Summary
- Attach response `TimingInfo` before after-model callbacks so callbacks can read TTFT immediately.
- Restore temporary timing attachment when callbacks replace responses or disable response usage tracking via updated invocation.
- Share response timing attachment logic through an internal helper and cover both llmflow and graph paths with regression tests.

## Tests
- `go test ./internal/responseusage ./internal/flow/llmflow ./graph -count=1`