### PR TITLE
WIP: openclaw localized stream display projector

### DIFF
--- a/openclaw/gwclient/client_test.go
+++ b/openclaw/gwclient/client_test.go
@@ -545,6 +545,10 @@ func TestClient_StreamMessageWithOptions_EnablesGatewayProgressAfterDelta(
 								ID:   "call-demo",
 								Function: model.FunctionDefinitionParam{
 									Name: "demo_tool",
+									Arguments: []byte(
+										`{"query":"hello",` +
+											`"api_key":"hidden"}`,
+									),
 								},
 							}},
 						},
@@ -607,6 +611,17 @@ func TestClient_StreamMessageWithOptions_EnablesGatewayProgressAfterDelta(
 	require.Equal(t, "Running local tool", events[3].Summary)
 	require.Equal(t, "demo_tool", events[3].ToolName)
 	require.Equal(t, "call-demo", events[3].ToolCallID)
+	require.Equal(
+		t,
+		`{"api_key":"[redacted]","query":"hello"}`,
+		events[3].ToolArguments,
+	)
+	require.Len(t, events[3].ToolCalls, 1)
+	require.Equal(
+		t,
+		events[3].ToolArguments,
+		events[3].ToolCalls[0].Function.Arguments,
+	)
 	require.Equal(t, gwproto.StreamToolStatusRunning, events[3].ToolStatus)
 	require.Equal(
 		t,
@@ -840,6 +855,7 @@ func TestParseSSEStream_EventFallbackAndErrors(t *testing.T) {
 				"data: {\"summary\":\"Preparing\","+
 				"\"tool_name\":\"kb_search\","+
 				"\"tool_call_id\":\"call-1\","+
+				"\"tool_arguments\":\"{\\\"query\\\":\\\"hello\\\"}\","+
 				"\"tool_status\":\"running\"}\n\n",
 		),
 		out,
@@ -849,6 +865,7 @@ func TestParseSSEStream_EventFallbackAndErrors(t *testing.T) {
 	require.Equal(t, gwproto.StreamEventTypeRunProgress, evt.Type)
 	require.Equal(t, "kb_search", evt.ToolName)
 	require.Equal(t, "call-1", evt.ToolCallID)
+	require.Equal(t, `{"query":"hello"}`, evt.ToolArguments)
 	require.Equal(t, gwproto.StreamToolStatusRunning, evt.ToolStatus)
 
 	err = parseSSEStream(

--- a/openclaw/gwproto/types.go
+++ b/openclaw/gwproto/types.go
@@ -131,7 +131,9 @@ const (
 	// StreamProgressStageReadingDocument marks document extraction.
 	StreamProgressStageReadingDocument StreamProgressStage = "reading_document"
 	// StreamProgressStageReadingSpreadsheet marks tabular extraction.
-	StreamProgressStageReadingSpreadsheet StreamProgressStage = "reading_spreadsheet"
+	StreamProgressStageReadingSpreadsheet = StreamProgressStage(
+		"reading_spreadsheet",
+	)
 	// StreamProgressStageRunningTool marks a generic tool run.
 	StreamProgressStageRunningTool StreamProgressStage = "running_tool"
 	// StreamProgressStageSummarizing marks post-tool answer generation.
@@ -156,11 +158,31 @@ type StreamEvent struct {
 	Summary    string              `json:"summary,omitempty"`
 	ToolName   string              `json:"tool_name,omitempty"`
 	ToolCallID string              `json:"tool_call_id,omitempty"`
-	ToolStatus StreamToolStatus    `json:"tool_status,omitempty"`
-	ElapsedMS  int64               `json:"elapsed_ms,omitempty"`
-	Usage      *Usage              `json:"usage,omitempty"`
-	Ignored    bool                `json:"ignored,omitempty"`
-	Error      *APIError           `json:"error,omitempty"`
+	// ToolArguments is a compact, redacted argument summary for display.
+	ToolArguments string           `json:"tool_arguments,omitempty"`
+	ToolCalls     []StreamToolCall `json:"tool_calls,omitempty"`
+	ToolStatus    StreamToolStatus `json:"tool_status,omitempty"`
+	ElapsedMS     int64            `json:"elapsed_ms,omitempty"`
+	Usage         *Usage           `json:"usage,omitempty"`
+	Ignored       bool             `json:"ignored,omitempty"`
+	Error         *APIError        `json:"error,omitempty"`
+}
+
+// StreamToolCall describes one tool call inside a progress event.
+type StreamToolCall struct {
+	ID            string                  `json:"id,omitempty"`
+	ToolCallID    string                  `json:"tool_call_id,omitempty"`
+	Name          string                  `json:"name,omitempty"`
+	ToolName      string                  `json:"tool_name,omitempty"`
+	Arguments     string                  `json:"arguments,omitempty"`
+	ToolArguments string                  `json:"tool_arguments,omitempty"`
+	Function      *StreamToolCallFunction `json:"function,omitempty"`
+}
+
+// StreamToolCallFunction describes function-style tool call metadata.
+type StreamToolCallFunction struct {
+	Name      string `json:"name,omitempty"`
+	Arguments string `json:"arguments,omitempty"`
 }
 
 // ContentPartType is the type discriminator for ContentPart.

--- a/openclaw/internal/gateway/server_test.go
+++ b/openclaw/internal/gateway/server_test.go
@@ -4395,6 +4395,21 @@ func TestSummarizeToolArgumentsRedactsAndTruncates(t *testing.T) {
 	)
 	require.Empty(t, summarizeToolArguments([]byte(`{}`)))
 	require.Equal(t, "plain text", summarizeToolArguments([]byte("plain text")))
+	require.Equal(
+		t,
+		toolArgumentRedacted,
+		summarizeToolArguments([]byte(`{"api_key":"secret`)),
+	)
+	require.Equal(
+		t,
+		`{"query":"trpc`,
+		summarizeToolArguments([]byte(`{"query":"trpc`)),
+	)
+	require.Equal(
+		t,
+		`{"apiKey":"[redacted]"}`,
+		summarizeToolArguments([]byte(`{"apiKey":"hidden"}`)),
+	)
 }
 
 func TestSendProgressUpdateAndHelpers(t *testing.T) {

--- a/openclaw/internal/gateway/server_test.go
+++ b/openclaw/internal/gateway/server_test.go
@@ -557,7 +557,9 @@ func TestServerUploadContextMessages_UsesStorageUserOverride(t *testing.T) {
 	require.Contains(t, msgs[0].Content, "clip.mp4 [video]")
 }
 
-func TestServerInjectedContextMessages_IncludePersonaAndUploads(t *testing.T) {
+func TestServerInjectedContextMessages_IncludePersonaAndUploads(
+	t *testing.T,
+) {
 	t.Parallel()
 
 	stateDir := t.TempDir()
@@ -718,7 +720,7 @@ func TestServerInjectedContextMessages_IncludeMemoryFiles(t *testing.T) {
 	require.Contains(t, msgs[2].Content, recentUploadContextHeader)
 }
 
-func TestServerInjectedContextMessages_UsesLayeredMemoryAndStorageScopedUploads(
+func TestServerInjectedContextMessages_LayeredMemoryAndScopedUploads(
 	t *testing.T,
 ) {
 	t.Parallel()
@@ -739,7 +741,11 @@ func TestServerInjectedContextMessages_UsesLayeredMemoryAndStorageScopedUploads(
 	require.NoError(t, err)
 	require.NoError(
 		t,
-		os.WriteFile(memoryPath, []byte("## Preferences\n\n- Remember my name."), 0o600),
+		os.WriteFile(
+			memoryPath,
+			[]byte("## Preferences\n\n- Remember my name."),
+			0o600,
+		),
 	)
 
 	otherMemoryPath, err := memoryStore.EnsureMemory(
@@ -750,7 +756,11 @@ func TestServerInjectedContextMessages_UsesLayeredMemoryAndStorageScopedUploads(
 	require.NoError(t, err)
 	require.NoError(
 		t,
-		os.WriteFile(otherMemoryPath, []byte("## Preferences\n\n- Chat rule."), 0o600),
+		os.WriteFile(
+			otherMemoryPath,
+			[]byte("## Preferences\n\n- Chat rule."),
+			0o600,
+		),
 	)
 
 	_, err = uploadStore.Save(
@@ -790,7 +800,9 @@ func TestServerInjectedContextMessages_UsesLayeredMemoryAndStorageScopedUploads(
 	require.Contains(t, msgs[2].Content, "clip.mp4 [video]")
 }
 
-func TestServerInjectedContextMessages_CanceledContextSkipsMemoryFiles(t *testing.T) {
+func TestServerInjectedContextMessages_CanceledContextSkipsMemoryFiles(
+	t *testing.T,
+) {
 	t.Parallel()
 
 	root, err := memoryfile.DefaultRoot(t.TempDir())
@@ -814,7 +826,9 @@ func TestServerInjectedContextMessages_CanceledContextSkipsMemoryFiles(t *testin
 	require.Empty(t, msgs)
 }
 
-func TestServerInjectedContextMessages_EmptyAppNameSkipsMemoryFiles(t *testing.T) {
+func TestServerInjectedContextMessages_EmptyAppNameSkipsMemoryFiles(
+	t *testing.T,
+) {
 	t.Parallel()
 
 	root, err := memoryfile.DefaultRoot(t.TempDir())
@@ -836,7 +850,9 @@ func TestServerInjectedContextMessages_EmptyAppNameSkipsMemoryFiles(t *testing.T
 	require.Empty(t, msgs)
 }
 
-func TestServerInjectedContextMessages_EmptyUserIDSkipsMemoryFiles(t *testing.T) {
+func TestServerInjectedContextMessages_EmptyUserIDSkipsMemoryFiles(
+	t *testing.T,
+) {
 	t.Parallel()
 
 	root, err := memoryfile.DefaultRoot(t.TempDir())
@@ -858,7 +874,9 @@ func TestServerInjectedContextMessages_EmptyUserIDSkipsMemoryFiles(t *testing.T)
 	require.Empty(t, msgs)
 }
 
-func TestServerInjectedContextMessages_EmptyMemoryFileSkipsMessage(t *testing.T) {
+func TestServerInjectedContextMessages_EmptyMemoryFileSkipsMessage(
+	t *testing.T,
+) {
 	t.Parallel()
 
 	root, err := memoryfile.DefaultRoot(t.TempDir())
@@ -3837,6 +3855,13 @@ func TestServer_StreamMessage_ProgressStages(t *testing.T) {
 	require.Equal(t, "Reading document page 2", events[2].Summary)
 	require.Equal(t, streamToolReadDocument, events[2].ToolName)
 	require.Equal(t, testReadDocumentToolCallID, events[2].ToolCallID)
+	require.Equal(t, `{"page":2}`, events[2].ToolArguments)
+	require.Len(t, events[2].ToolCalls, 1)
+	require.Equal(
+		t,
+		events[2].ToolArguments,
+		events[2].ToolCalls[0].Function.Arguments,
+	)
 	require.Equal(
 		t,
 		gwproto.StreamToolStatusRunning,
@@ -4172,6 +4197,13 @@ func TestStreamProgressHelpers(t *testing.T) {
 	require.Equal(t, "Reading document page 2", update.summary)
 	require.Equal(t, streamToolReadDocument, update.toolName)
 	require.Equal(t, testReadDocumentToolCallID, update.toolCallID)
+	require.Equal(t, `{"page":2}`, update.toolArguments)
+	require.Len(t, update.toolCalls, 1)
+	require.Equal(
+		t,
+		update.toolArguments,
+		update.toolCalls[0].Function.Arguments,
+	)
 	require.Equal(
 		t,
 		gwproto.StreamToolStatusRunning,
@@ -4225,6 +4257,7 @@ func TestToolCallProgressSummaries(t *testing.T) {
 	require.Equal(t, "Reading spreadsheet rows 2-4", update.summary)
 	require.Equal(t, streamToolReadSheet, update.toolName)
 	require.Equal(t, testReadDocumentToolCallID, update.toolCallID)
+	require.Equal(t, `{"end_row":4,"start_row":2}`, update.toolArguments)
 	require.Equal(
 		t,
 		gwproto.StreamToolStatusRunning,
@@ -4233,8 +4266,10 @@ func TestToolCallProgressSummaries(t *testing.T) {
 
 	update, ok = progressFromToolCall(model.ToolCall{
 		Function: model.FunctionDefinitionParam{
-			Name:      streamToolExecCommand,
-			Arguments: []byte(`{"command":"go test ./..."}`),
+			Name: streamToolExecCommand,
+			Arguments: []byte(
+				`{"command":"go test ./...","token":"hidden"}`,
+			),
 		},
 	})
 	require.True(t, ok)
@@ -4244,6 +4279,11 @@ func TestToolCallProgressSummaries(t *testing.T) {
 		update.stage,
 	)
 	require.Equal(t, progressSummaryGoTest, update.summary)
+	require.Equal(
+		t,
+		`{"command":"go test ./...","token":"[redacted]"}`,
+		update.toolArguments,
+	)
 
 	update, ok = progressFromToolCall(model.ToolCall{
 		Function: model.FunctionDefinitionParam{
@@ -4293,6 +4333,68 @@ func TestToolCallProgressSummaries(t *testing.T) {
 			},
 		}),
 	)
+}
+
+func TestProgressUpdateFromRunnerEventKeepsAllToolCalls(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	update, ok := progressUpdateFromRunnerEvent(&event.Event{
+		Response: &model.Response{
+			Choices: []model.Choice{{
+				Message: model.Message{
+					ToolCalls: []model.ToolCall{
+						{
+							ID: "call_search",
+							Function: model.FunctionDefinitionParam{
+								Name:      "duckduckgo_search",
+								Arguments: []byte(`{"query":"repo"}`),
+							},
+						},
+						{
+							ID: "call_wiki",
+							Function: model.FunctionDefinitionParam{
+								Name: "wiki_wikipedia_search",
+								Arguments: []byte(
+									`{"query":"repo","limit":5}`,
+								),
+							},
+						},
+					},
+				},
+			}},
+		},
+	})
+	require.True(t, ok)
+	require.Equal(t, "duckduckgo_search", update.toolName)
+	require.Equal(t, "call_search", update.toolCallID)
+	require.Len(t, update.toolCalls, 2)
+	require.Equal(
+		t,
+		`{"query":"repo"}`,
+		update.toolCalls[0].Function.Arguments,
+	)
+	require.Equal(
+		t,
+		`{"limit":5,"query":"repo"}`,
+		update.toolCalls[1].Function.Arguments,
+	)
+}
+
+func TestSummarizeToolArgumentsRedactsAndTruncates(t *testing.T) {
+	t.Parallel()
+
+	detail := summarizeToolArguments([]byte(
+		`{"command":"git status","password":"hidden"}`,
+	))
+	require.Equal(
+		t,
+		`{"command":"git status","password":"[redacted]"}`,
+		detail,
+	)
+	require.Empty(t, summarizeToolArguments([]byte(`{}`)))
+	require.Equal(t, "plain text", summarizeToolArguments([]byte("plain text")))
 }
 
 func TestSendProgressUpdateAndHelpers(t *testing.T) {

--- a/openclaw/internal/gateway/stream.go
+++ b/openclaw/internal/gateway/stream.go
@@ -57,12 +57,14 @@ type streamOutcome struct {
 }
 
 type progressState struct {
-	startedAt  time.Time
-	stage      gwproto.StreamProgressStage
-	summary    string
-	toolName   string
-	toolCallID string
-	toolStatus gwproto.StreamToolStatus
+	startedAt     time.Time
+	stage         gwproto.StreamProgressStage
+	summary       string
+	toolName      string
+	toolCallID    string
+	toolArguments string
+	toolCallsKey  string
+	toolStatus    gwproto.StreamToolStatus
 }
 
 // StreamMessage processes a request and returns a stream of gateway
@@ -586,11 +588,13 @@ func sendStreamEvent(
 }
 
 type progressUpdate struct {
-	stage      gwproto.StreamProgressStage
-	summary    string
-	toolName   string
-	toolCallID string
-	toolStatus gwproto.StreamToolStatus
+	stage         gwproto.StreamProgressStage
+	summary       string
+	toolName      string
+	toolCallID    string
+	toolArguments string
+	toolCalls     []gwproto.StreamToolCall
+	toolStatus    gwproto.StreamToolStatus
 }
 
 func progressUpdateFromRunnerEvent(
@@ -600,11 +604,20 @@ func progressUpdateFromRunnerEvent(
 		return progressUpdate{}, false
 	}
 	if evt.Response.IsToolCallResponse() {
-		toolCall, ok := firstToolCall(evt.Response)
+		toolCalls := toolCallsFromResponse(evt.Response)
+		if len(toolCalls) == 0 {
+			return progressUpdate{}, false
+		}
+		toolCall, ok := firstToolCallFromList(toolCalls)
 		if !ok {
 			return progressUpdate{}, false
 		}
-		return progressFromToolCall(toolCall)
+		update, ok := progressFromToolCall(toolCall)
+		if !ok {
+			return progressUpdate{}, false
+		}
+		update.toolCalls = streamToolCallsFromModel(toolCalls)
+		return update, true
 	}
 	if evt.Object == model.ObjectTypeToolResponse {
 		return progressFromToolResult(evt.Response), true
@@ -613,15 +626,31 @@ func progressUpdateFromRunnerEvent(
 }
 
 func firstToolCall(rsp *model.Response) (model.ToolCall, bool) {
+	return firstToolCallFromList(toolCallsFromResponse(rsp))
+}
+
+func toolCallsFromResponse(rsp *model.Response) []model.ToolCall {
 	if rsp == nil {
-		return model.ToolCall{}, false
+		return nil
 	}
 	for _, choice := range rsp.Choices {
 		if len(choice.Message.ToolCalls) > 0 {
-			return choice.Message.ToolCalls[0], true
+			return choice.Message.ToolCalls
 		}
 		if len(choice.Delta.ToolCalls) > 0 {
-			return choice.Delta.ToolCalls[0], true
+			return choice.Delta.ToolCalls
+		}
+	}
+	return nil
+}
+
+func firstToolCallFromList(
+	toolCalls []model.ToolCall,
+) (model.ToolCall, bool) {
+	for _, toolCall := range toolCalls {
+		if strings.TrimSpace(toolCall.ID) != "" ||
+			strings.TrimSpace(toolCall.Function.Name) != "" {
+			return toolCall, true
 		}
 	}
 	return model.ToolCall{}, false
@@ -649,6 +678,9 @@ func progressFromToolCall(
 	update := progressUpdate{
 		toolName:   name,
 		toolCallID: strings.TrimSpace(toolCall.ID),
+		toolArguments: summarizeToolArguments(
+			toolCall.Function.Arguments,
+		),
 		toolStatus: gwproto.StreamToolStatusRunning,
 	}
 	switch name {
@@ -672,6 +704,38 @@ func progressFromToolCall(
 		update.summary = progressSummaryTool
 		return update, true
 	}
+}
+
+func streamToolCallsFromModel(
+	toolCalls []model.ToolCall,
+) []gwproto.StreamToolCall {
+	if len(toolCalls) == 0 {
+		return nil
+	}
+	calls := make([]gwproto.StreamToolCall, 0, len(toolCalls))
+	for _, toolCall := range toolCalls {
+		name := strings.TrimSpace(toolCall.Function.Name)
+		id := strings.TrimSpace(toolCall.ID)
+		if name == "" && id == "" {
+			continue
+		}
+		arguments := summarizeToolArguments(
+			toolCall.Function.Arguments,
+		)
+		calls = append(calls, gwproto.StreamToolCall{
+			ID:            id,
+			ToolCallID:    id,
+			Name:          name,
+			ToolName:      name,
+			Arguments:     arguments,
+			ToolArguments: arguments,
+			Function: &gwproto.StreamToolCallFunction{
+				Name:      name,
+				Arguments: arguments,
+			},
+		})
+	}
+	return calls
 }
 
 func progressFromToolResult(rsp *model.Response) progressUpdate {
@@ -809,10 +873,13 @@ func sendProgressUpdate(
 	if state == nil || update.stage == "" {
 		return true
 	}
+	toolCallsKey := streamToolCallsKey(update.toolCalls)
 	if state.stage == update.stage &&
 		state.summary == update.summary &&
 		state.toolName == update.toolName &&
 		state.toolCallID == update.toolCallID &&
+		state.toolArguments == update.toolArguments &&
+		state.toolCallsKey == toolCallsKey &&
 		state.toolStatus == update.toolStatus {
 		return true
 	}
@@ -820,18 +887,33 @@ func sendProgressUpdate(
 	state.summary = update.summary
 	state.toolName = update.toolName
 	state.toolCallID = update.toolCallID
+	state.toolArguments = update.toolArguments
+	state.toolCallsKey = toolCallsKey
 	state.toolStatus = update.toolStatus
 	return sendStreamEvent(ctx, out, gwproto.StreamEvent{
-		Type:       gwproto.StreamEventTypeRunProgress,
-		SessionID:  run.sessionID,
-		RequestID:  run.requestID,
-		Stage:      update.stage,
-		Summary:    update.summary,
-		ToolName:   update.toolName,
-		ToolCallID: update.toolCallID,
-		ToolStatus: update.toolStatus,
-		ElapsedMS:  time.Since(state.startedAt).Milliseconds(),
+		Type:          gwproto.StreamEventTypeRunProgress,
+		SessionID:     run.sessionID,
+		RequestID:     run.requestID,
+		Stage:         update.stage,
+		Summary:       update.summary,
+		ToolName:      update.toolName,
+		ToolCallID:    update.toolCallID,
+		ToolArguments: update.toolArguments,
+		ToolCalls:     update.toolCalls,
+		ToolStatus:    update.toolStatus,
+		ElapsedMS:     time.Since(state.startedAt).Milliseconds(),
 	})
+}
+
+func streamToolCallsKey(toolCalls []gwproto.StreamToolCall) string {
+	if len(toolCalls) == 0 {
+		return ""
+	}
+	body, err := json.Marshal(toolCalls)
+	if err != nil {
+		return ""
+	}
+	return string(body)
 }
 
 func singleStreamEvents(

--- a/openclaw/internal/gateway/tool_arguments.go
+++ b/openclaw/internal/gateway/tool_arguments.go
@@ -1,0 +1,185 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package gateway
+
+import (
+	"encoding/json"
+	"io"
+	"sort"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	toolArgumentMaxRunes       = 180
+	toolArgumentStringMaxRunes = 80
+	toolArgumentMaxDepth       = 3
+	toolArgumentMaxItems       = 6
+	toolArgumentRedacted       = "[redacted]"
+	toolArgumentOmitted        = "..."
+
+	toolArgumentKeyAccessKey     = "access_key"
+	toolArgumentKeyAPIKey        = "api_key"
+	toolArgumentKeyAuthorization = "authorization"
+	toolArgumentKeyCookie        = "cookie"
+	toolArgumentKeyCredential    = "credential"
+	toolArgumentKeyPasswd        = "passwd"
+	toolArgumentKeyPassword      = "password"
+	toolArgumentKeyPrivateKey    = "private_key"
+	toolArgumentKeySecret        = "secret"
+	toolArgumentKeyToken         = "token"
+)
+
+var sensitiveToolArgumentKeys = [...]string{
+	toolArgumentKeyAccessKey,
+	toolArgumentKeyAPIKey,
+	toolArgumentKeyAuthorization,
+	toolArgumentKeyCookie,
+	toolArgumentKeyCredential,
+	toolArgumentKeyPasswd,
+	toolArgumentKeyPassword,
+	toolArgumentKeyPrivateKey,
+	toolArgumentKeySecret,
+	toolArgumentKeyToken,
+}
+
+func summarizeToolArguments(raw []byte) string {
+	text := strings.TrimSpace(string(raw))
+	if text == "" {
+		return ""
+	}
+	value, ok := parseToolArgumentJSON(text)
+	if !ok {
+		return truncateToolArgumentRunes(text, toolArgumentMaxRunes)
+	}
+	if isEmptyToolArgumentValue(value) {
+		return ""
+	}
+	sanitized := sanitizeToolArgumentValue(value, 0)
+	body, err := json.Marshal(sanitized)
+	if err != nil {
+		return truncateToolArgumentRunes(text, toolArgumentMaxRunes)
+	}
+	return truncateToolArgumentRunes(string(body), toolArgumentMaxRunes)
+}
+
+func parseToolArgumentJSON(text string) (any, bool) {
+	decoder := json.NewDecoder(strings.NewReader(text))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, false
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		return nil, false
+	}
+	return value, true
+}
+
+func sanitizeToolArgumentValue(value any, depth int) any {
+	if depth >= toolArgumentMaxDepth {
+		return toolArgumentOmitted
+	}
+	switch typed := value.(type) {
+	case map[string]any:
+		return sanitizeToolArgumentMap(typed, depth)
+	case []any:
+		return sanitizeToolArgumentList(typed, depth)
+	case string:
+		return truncateToolArgumentRunes(
+			typed,
+			toolArgumentStringMaxRunes,
+		)
+	default:
+		return typed
+	}
+}
+
+func sanitizeToolArgumentMap(
+	value map[string]any,
+	depth int,
+) map[string]any {
+	keys := make([]string, 0, len(value))
+	for key := range value {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	if len(keys) > toolArgumentMaxItems {
+		keys = keys[:toolArgumentMaxItems]
+	}
+	sanitized := make(map[string]any, len(keys))
+	for _, key := range keys {
+		if isSensitiveToolArgumentKey(key) {
+			sanitized[key] = toolArgumentRedacted
+			continue
+		}
+		sanitized[key] = sanitizeToolArgumentValue(
+			value[key],
+			depth+1,
+		)
+	}
+	return sanitized
+}
+
+func sanitizeToolArgumentList(value []any, depth int) []any {
+	if len(value) > toolArgumentMaxItems {
+		value = value[:toolArgumentMaxItems]
+	}
+	sanitized := make([]any, 0, len(value))
+	for _, item := range value {
+		sanitized = append(
+			sanitized,
+			sanitizeToolArgumentValue(item, depth+1),
+		)
+	}
+	return sanitized
+}
+
+func isSensitiveToolArgumentKey(key string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(key))
+	normalized = strings.ReplaceAll(normalized, "-", "_")
+	for _, sensitive := range sensitiveToolArgumentKeys {
+		if strings.Contains(normalized, sensitive) {
+			return true
+		}
+	}
+	return false
+}
+
+func isEmptyToolArgumentValue(value any) bool {
+	switch typed := value.(type) {
+	case nil:
+		return true
+	case string:
+		return strings.TrimSpace(typed) == ""
+	case map[string]any:
+		return len(typed) == 0
+	case []any:
+		return len(typed) == 0
+	default:
+		return false
+	}
+}
+
+func truncateToolArgumentRunes(text string, maxRunes int) string {
+	text = strings.TrimSpace(text)
+	if maxRunes <= 0 || utf8.RuneCountInString(text) <= maxRunes {
+		return text
+	}
+	runes := []rune(text)
+	suffixRunes := []rune(toolArgumentOmitted)
+	if maxRunes <= len(suffixRunes) {
+		return string(runes[:maxRunes])
+	}
+	return strings.TrimSpace(
+		string(runes[:maxRunes-len(suffixRunes)]),
+	) + toolArgumentOmitted
+}

--- a/openclaw/internal/gateway/tool_arguments.go
+++ b/openclaw/internal/gateway/tool_arguments.go
@@ -57,7 +57,7 @@ func summarizeToolArguments(raw []byte) string {
 	}
 	value, ok := parseToolArgumentJSON(text)
 	if !ok {
-		return truncateToolArgumentRunes(text, toolArgumentMaxRunes)
+		return summarizeRawToolArgumentText(text)
 	}
 	if isEmptyToolArgumentValue(value) {
 		return ""
@@ -65,9 +65,16 @@ func summarizeToolArguments(raw []byte) string {
 	sanitized := sanitizeToolArgumentValue(value, 0)
 	body, err := json.Marshal(sanitized)
 	if err != nil {
-		return truncateToolArgumentRunes(text, toolArgumentMaxRunes)
+		return summarizeRawToolArgumentText(text)
 	}
 	return truncateToolArgumentRunes(string(body), toolArgumentMaxRunes)
+}
+
+func summarizeRawToolArgumentText(text string) string {
+	if containsSensitiveToolArgumentKey(text) {
+		return toolArgumentRedacted
+	}
+	return truncateToolArgumentRunes(text, toolArgumentMaxRunes)
 }
 
 func parseToolArgumentJSON(text string) (any, bool) {
@@ -144,14 +151,39 @@ func sanitizeToolArgumentList(value []any, depth int) []any {
 }
 
 func isSensitiveToolArgumentKey(key string) bool {
-	normalized := strings.ToLower(strings.TrimSpace(key))
-	normalized = strings.ReplaceAll(normalized, "-", "_")
+	normalized := canonicalToolArgumentKey(key)
 	for _, sensitive := range sensitiveToolArgumentKeys {
-		if strings.Contains(normalized, sensitive) {
+		if strings.Contains(
+			normalized,
+			canonicalToolArgumentKey(sensitive),
+		) {
 			return true
 		}
 	}
 	return false
+}
+
+func containsSensitiveToolArgumentKey(text string) bool {
+	normalized := canonicalToolArgumentKey(text)
+	for _, sensitive := range sensitiveToolArgumentKeys {
+		if strings.Contains(
+			normalized,
+			canonicalToolArgumentKey(sensitive),
+		) {
+			return true
+		}
+	}
+	return false
+}
+
+func canonicalToolArgumentKey(text string) string {
+	var builder strings.Builder
+	for _, r := range strings.ToLower(text) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			builder.WriteRune(r)
+		}
+	}
+	return builder.String()
 }
 
 func isEmptyToolArgumentValue(value any) bool {

--- a/openclaw/streamdisplay/display.go
+++ b/openclaw/streamdisplay/display.go
@@ -87,6 +87,7 @@ type Labels struct {
 	Explored          string
 	Writing           string
 	Wrote             string
+	Detail            string
 	Answer            string
 	Canceled          string
 	Ignored           string
@@ -110,6 +111,7 @@ type ToolUpdate struct {
 	Kind   ItemKind
 	Status ItemStatus
 	Text   string
+	Detail string
 }
 
 // Projector stores display state for one stream.
@@ -136,6 +138,7 @@ type Item struct {
 	Status ItemStatus
 	Name   string
 	Text   string
+	Detail string
 }
 
 // Snapshot is an immutable display view.
@@ -456,6 +459,9 @@ func mergeLabels(base Labels, override Labels) Labels {
 	if override.Wrote != "" {
 		base.Wrote = override.Wrote
 	}
+	if override.Detail != "" {
+		base.Detail = override.Detail
+	}
 	if override.Answer != "" {
 		base.Answer = override.Answer
 	}
@@ -484,6 +490,7 @@ func englishLabels() Labels {
 		Explored:          "Explored",
 		Writing:           "Writing",
 		Wrote:             "Wrote",
+		Detail:            "Args",
 		Answer:            "Answer",
 		Canceled:          "Canceled",
 		Ignored:           "Ignored",
@@ -504,6 +511,7 @@ func chineseLabels() Labels {
 		Explored:          "已查看",
 		Writing:           "正在写入",
 		Wrote:             "已写入",
+		Detail:            "参数",
 		Answer:            "回答",
 		Canceled:          "已取消",
 		Ignored:           "已忽略",
@@ -587,6 +595,7 @@ func toolItem(update ToolUpdate) Item {
 		Status: normalizeItemStatus(update.Status),
 		Name:   name,
 		Text:   strings.TrimSpace(update.Text),
+		Detail: strings.TrimSpace(update.Detail),
 	}
 }
 
@@ -649,6 +658,10 @@ func updateItem(existing *Item, next Item) bool {
 		existing.Text = next.Text
 		changed = true
 	}
+	if next.Detail != "" && existing.Detail != next.Detail {
+		existing.Detail = next.Detail
+		changed = true
+	}
 	return changed
 }
 
@@ -665,10 +678,15 @@ func renderItem(item Item, labels Labels, maxTextRunes int) string {
 		return ""
 	}
 	text := truncateRunes(strings.TrimSpace(item.Text), maxTextRunes)
-	if text == "" || text == item.Name {
-		return bulletPrefix + head
+	detail := truncateRunes(strings.TrimSpace(item.Detail), maxTextRunes)
+	lines := []string{bulletPrefix + head}
+	if detail != "" {
+		lines = append(lines, childPrefix+labels.Detail+": "+detail)
 	}
-	return bulletPrefix + head + "\n" + childPrefix + text
+	if text != "" && text != item.Name && text != detail {
+		lines = append(lines, childPrefix+text)
+	}
+	return strings.Join(lines, "\n")
 }
 
 func itemHead(item Item, labels Labels) string {

--- a/openclaw/streamdisplay/display.go
+++ b/openclaw/streamdisplay/display.go
@@ -1,0 +1,733 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package streamdisplay projects stream activity into localized transcript
+// snapshots for chat surfaces.
+package streamdisplay
+
+import (
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	defaultMaxItems     = 6
+	defaultMaxTextRunes = 320
+	truncatedSuffix     = "..."
+	sectionSep          = "\n\n"
+	bulletPrefix        = "- "
+	childPrefix         = "  - "
+
+	progressItemID     = "progress"
+	publicLanePrefix   = "public"
+	reasoningLaneID    = "reasoning"
+	toolItemIDPrefix   = "tool:"
+	languageChinese    = "zh"
+	languageChineseAlt = "cn"
+	languageEnglish    = "en"
+)
+
+// Language identifies a built-in display language.
+type Language string
+
+const (
+	// LanguageEnglish renders English labels.
+	LanguageEnglish Language = languageEnglish
+	// LanguageChinese renders Simplified Chinese labels.
+	LanguageChinese Language = languageChinese
+)
+
+// ItemKind describes the visible item category.
+type ItemKind string
+
+const (
+	// ItemKindStatus is a general progress item.
+	ItemKindStatus ItemKind = "status"
+	// ItemKindReasoning is a reasoning or thought item.
+	ItemKindReasoning ItemKind = "reasoning"
+	// ItemKindTool is a generic tool item.
+	ItemKindTool ItemKind = "tool"
+	// ItemKindCommand is a local command item.
+	ItemKindCommand ItemKind = "command"
+	// ItemKindExplore is a workspace read, list, or search item.
+	ItemKindExplore ItemKind = "explore"
+	// ItemKindWrite is a workspace write or patch item.
+	ItemKindWrite ItemKind = "write"
+)
+
+// ItemStatus describes the visible lifecycle of one item.
+type ItemStatus string
+
+const (
+	// ItemStatusRunning marks an active item.
+	ItemStatusRunning ItemStatus = "running"
+	// ItemStatusCompleted marks a completed item.
+	ItemStatusCompleted ItemStatus = "completed"
+	// ItemStatusFailed marks a failed item.
+	ItemStatusFailed ItemStatus = "failed"
+)
+
+// Labels contains localized display strings.
+type Labels struct {
+	Working           string
+	ThinkingRunning   string
+	ThinkingCompleted string
+	Calling           string
+	Called            string
+	Running           string
+	Ran               string
+	Exploring         string
+	Explored          string
+	Writing           string
+	Wrote             string
+	Answer            string
+	Canceled          string
+	Ignored           string
+	Failed            string
+}
+
+// Options controls projection and rendering.
+type Options struct {
+	Language       string
+	Labels         Labels
+	ShowReasoning  bool
+	MaxItems       int
+	MaxTextRunes   int
+	HideAnswerHead bool
+}
+
+// ToolUpdate describes one tool call lifecycle update.
+type ToolUpdate struct {
+	ID     string
+	Name   string
+	Kind   ItemKind
+	Status ItemStatus
+	Text   string
+}
+
+// Projector stores display state for one stream.
+type Projector struct {
+	opts           Options
+	items          []Item
+	itemIndex      map[string]int
+	answer         strings.Builder
+	answerComplete string
+	status         string
+	errText        string
+	done           bool
+	canceled       bool
+	ignored        bool
+	failed         bool
+	public         textLane
+	reasoning      textLane
+}
+
+// Item is one visible transcript item.
+type Item struct {
+	ID     string
+	Kind   ItemKind
+	Status ItemStatus
+	Name   string
+	Text   string
+}
+
+// Snapshot is an immutable display view.
+type Snapshot struct {
+	Items    []Item
+	Answer   string
+	Status   string
+	Error    string
+	Done     bool
+	Canceled bool
+	Ignored  bool
+	Failed   bool
+	Options  Options
+}
+
+type textLane struct {
+	prefix   string
+	kind     ItemKind
+	next     int
+	activeID string
+	pending  strings.Builder
+}
+
+// NewProjector creates a projector with normalized options.
+func NewProjector(opts Options) *Projector {
+	return &Projector{
+		opts:      normalizeOptions(opts),
+		itemIndex: make(map[string]int),
+		public:    newTextLane(publicLanePrefix, ItemKindStatus),
+		reasoning: newTextLane(reasoningLaneID, ItemKindReasoning),
+	}
+}
+
+// NormalizeLanguage maps locale names and aliases to supported languages.
+func NormalizeLanguage(language string) Language {
+	normalized := strings.ToLower(strings.TrimSpace(language))
+	switch {
+	case normalized == "":
+		return LanguageEnglish
+	case strings.HasPrefix(normalized, languageChinese):
+		return LanguageChinese
+	case strings.HasPrefix(normalized, languageChineseAlt):
+		return LanguageChinese
+	case strings.HasPrefix(normalized, languageEnglish):
+		return LanguageEnglish
+	default:
+		return LanguageEnglish
+	}
+}
+
+// ApplyStatus records a fallback status line for otherwise empty snapshots.
+func (p *Projector) ApplyStatus(text string) bool {
+	if p == nil {
+		return false
+	}
+	text = strings.TrimSpace(text)
+	if text == "" || p.status == text {
+		return false
+	}
+	p.status = text
+	return true
+}
+
+// ApplyProgress records a visible high-level progress item.
+func (p *Projector) ApplyProgress(text string) bool {
+	if p == nil {
+		return false
+	}
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return false
+	}
+	changed := p.ApplyStatus(text)
+	return p.upsertItem(Item{
+		ID:     progressItemID,
+		Kind:   ItemKindStatus,
+		Status: ItemStatusRunning,
+		Text:   text,
+	}) || changed
+}
+
+// ApplyTool records one tool call lifecycle update.
+func (p *Projector) ApplyTool(update ToolUpdate) bool {
+	if p == nil {
+		return false
+	}
+	item := toolItem(update)
+	if item.ID == "" {
+		return false
+	}
+	return p.upsertItem(item)
+}
+
+// ApplyPublicDelta appends incremental public progress text.
+func (p *Projector) ApplyPublicDelta(delta string) bool {
+	if p == nil {
+		return false
+	}
+	return p.applyLaneDelta(&p.public, delta)
+}
+
+// ApplyPublicCompleted commits public progress text as a completed item.
+func (p *Projector) ApplyPublicCompleted(text string) bool {
+	if p == nil {
+		return false
+	}
+	return p.applyLaneCompleted(&p.public, text)
+}
+
+// ApplyReasoningDelta appends incremental reasoning text when enabled.
+func (p *Projector) ApplyReasoningDelta(delta string) bool {
+	if p == nil || !p.opts.ShowReasoning {
+		return false
+	}
+	return p.applyLaneDelta(&p.reasoning, delta)
+}
+
+// ApplyReasoningCompleted commits reasoning text when enabled.
+func (p *Projector) ApplyReasoningCompleted(text string) bool {
+	if p == nil || !p.opts.ShowReasoning {
+		return false
+	}
+	return p.applyLaneCompleted(&p.reasoning, text)
+}
+
+// ApplyAnswerDelta appends incremental answer text.
+func (p *Projector) ApplyAnswerDelta(delta string) bool {
+	if p == nil || delta == "" {
+		return false
+	}
+	p.answer.WriteString(delta)
+	return true
+}
+
+// ApplyAnswerCompleted records the final answer text.
+func (p *Projector) ApplyAnswerCompleted(text string) bool {
+	if p == nil {
+		return false
+	}
+	text = strings.TrimSpace(text)
+	if text == "" || p.answerComplete == text {
+		return false
+	}
+	p.answerComplete = text
+	return true
+}
+
+// Complete marks the stream as successfully completed.
+func (p *Projector) Complete() bool {
+	if p == nil || p.done {
+		return false
+	}
+	p.done = true
+	return true
+}
+
+// Cancel marks the stream as canceled.
+func (p *Projector) Cancel() bool {
+	if p == nil {
+		return false
+	}
+	changed := !p.done || !p.canceled
+	p.done = true
+	p.canceled = true
+	return changed
+}
+
+// Ignore marks the stream as ignored.
+func (p *Projector) Ignore() bool {
+	if p == nil {
+		return false
+	}
+	changed := !p.done || !p.ignored
+	p.done = true
+	p.ignored = true
+	return changed
+}
+
+// Fail marks the stream as failed.
+func (p *Projector) Fail(message string) bool {
+	if p == nil {
+		return false
+	}
+	message = strings.TrimSpace(message)
+	changed := !p.done || p.errText != message
+	p.done = true
+	p.failed = true
+	p.errText = message
+	return changed
+}
+
+// Snapshot returns the current display snapshot.
+func (p *Projector) Snapshot() Snapshot {
+	if p == nil {
+		return Snapshot{Options: normalizeOptions(Options{})}
+	}
+	items := make([]Item, len(p.items))
+	copy(items, p.items)
+	answer := p.answerComplete
+	if answer == "" {
+		answer = p.answer.String()
+	}
+	return Snapshot{
+		Items:    items,
+		Answer:   strings.TrimSpace(answer),
+		Status:   strings.TrimSpace(p.status),
+		Error:    strings.TrimSpace(p.errText),
+		Done:     p.done,
+		Canceled: p.canceled,
+		Ignored:  p.ignored,
+		Failed:   p.failed,
+		Options:  p.opts,
+	}
+}
+
+// HasContent reports whether the projector currently renders visible text.
+func (p *Projector) HasContent() bool {
+	if p == nil {
+		return false
+	}
+	return Render(p.Snapshot()) != ""
+}
+
+// Render renders a snapshot into Markdown-like plain text.
+func Render(snapshot Snapshot) string {
+	opts := normalizeOptions(snapshot.Options)
+	labels := opts.Labels
+	maxTextRunes := opts.MaxTextRunes
+
+	parts := make([]string, 0, len(snapshot.Items)+2)
+	for _, item := range limitedItems(snapshot.Items, opts.MaxItems) {
+		rendered := renderItem(item, labels, maxTextRunes)
+		if rendered != "" {
+			parts = append(parts, rendered)
+		}
+	}
+
+	if snapshot.Failed || snapshot.Error != "" {
+		parts = append(parts, errorText(labels, snapshot.Error, maxTextRunes))
+	} else if snapshot.Canceled {
+		parts = append(parts, labels.Canceled)
+	} else if snapshot.Ignored {
+		parts = append(parts, labels.Ignored)
+	}
+
+	answer := strings.TrimSpace(snapshot.Answer)
+	if answer != "" {
+		answer = truncateRunes(answer, maxTextRunes)
+		if !opts.HideAnswerHead {
+			answer = labels.Answer + "\n" + answer
+		}
+		parts = append(parts, answer)
+	} else if snapshot.Status != "" && len(parts) == 0 {
+		parts = append(
+			parts,
+			labels.Working+": "+
+				truncateRunes(snapshot.Status, maxTextRunes),
+		)
+	}
+
+	return strings.TrimSpace(strings.Join(parts, sectionSep))
+}
+
+func normalizeOptions(opts Options) Options {
+	if opts.MaxItems <= 0 {
+		opts.MaxItems = defaultMaxItems
+	}
+	if opts.MaxTextRunes <= 0 {
+		opts.MaxTextRunes = defaultMaxTextRunes
+	}
+	opts.Labels = mergeLabels(
+		baseLabelsForLanguage(opts.Language),
+		opts.Labels,
+	)
+	return opts
+}
+
+func baseLabelsForLanguage(language string) Labels {
+	switch NormalizeLanguage(language) {
+	case LanguageChinese:
+		return chineseLabels()
+	default:
+		return englishLabels()
+	}
+}
+
+func mergeLabels(base Labels, override Labels) Labels {
+	if override.Working != "" {
+		base.Working = override.Working
+	}
+	if override.ThinkingRunning != "" {
+		base.ThinkingRunning = override.ThinkingRunning
+	}
+	if override.ThinkingCompleted != "" {
+		base.ThinkingCompleted = override.ThinkingCompleted
+	}
+	if override.Calling != "" {
+		base.Calling = override.Calling
+	}
+	if override.Called != "" {
+		base.Called = override.Called
+	}
+	if override.Running != "" {
+		base.Running = override.Running
+	}
+	if override.Ran != "" {
+		base.Ran = override.Ran
+	}
+	if override.Exploring != "" {
+		base.Exploring = override.Exploring
+	}
+	if override.Explored != "" {
+		base.Explored = override.Explored
+	}
+	if override.Writing != "" {
+		base.Writing = override.Writing
+	}
+	if override.Wrote != "" {
+		base.Wrote = override.Wrote
+	}
+	if override.Answer != "" {
+		base.Answer = override.Answer
+	}
+	if override.Canceled != "" {
+		base.Canceled = override.Canceled
+	}
+	if override.Ignored != "" {
+		base.Ignored = override.Ignored
+	}
+	if override.Failed != "" {
+		base.Failed = override.Failed
+	}
+	return base
+}
+
+func englishLabels() Labels {
+	return Labels{
+		Working:           "Working",
+		ThinkingRunning:   "Thinking",
+		ThinkingCompleted: "Thought",
+		Calling:           "Calling",
+		Called:            "Called",
+		Running:           "Running",
+		Ran:               "Ran",
+		Exploring:         "Exploring",
+		Explored:          "Explored",
+		Writing:           "Writing",
+		Wrote:             "Wrote",
+		Answer:            "Answer",
+		Canceled:          "Canceled",
+		Ignored:           "Ignored",
+		Failed:            "Failed",
+	}
+}
+
+func chineseLabels() Labels {
+	return Labels{
+		Working:           "处理中",
+		ThinkingRunning:   "思考中",
+		ThinkingCompleted: "思考",
+		Calling:           "正在调用",
+		Called:            "已调用",
+		Running:           "正在执行",
+		Ran:               "已执行",
+		Exploring:         "正在查看",
+		Explored:          "已查看",
+		Writing:           "正在写入",
+		Wrote:             "已写入",
+		Answer:            "回答",
+		Canceled:          "已取消",
+		Ignored:           "已忽略",
+		Failed:            "失败",
+	}
+}
+
+func newTextLane(prefix string, kind ItemKind) textLane {
+	return textLane{
+		prefix: prefix,
+		kind:   kind,
+	}
+}
+
+func (p *Projector) applyLaneDelta(
+	lane *textLane,
+	delta string,
+) bool {
+	if lane == nil || delta == "" {
+		return false
+	}
+	lane.pending.WriteString(delta)
+	if strings.TrimSpace(lane.pending.String()) == "" {
+		return false
+	}
+	return p.upsertItem(Item{
+		ID:     lane.ensureActiveID(),
+		Kind:   lane.kind,
+		Status: ItemStatusRunning,
+		Text:   lane.pending.String(),
+	})
+}
+
+func (p *Projector) applyLaneCompleted(
+	lane *textLane,
+	text string,
+) bool {
+	if lane == nil {
+		return false
+	}
+	text = strings.TrimSpace(text)
+	if text == "" {
+		text = strings.TrimSpace(lane.pending.String())
+	}
+	if text == "" {
+		return false
+	}
+	changed := p.upsertItem(Item{
+		ID:     lane.ensureActiveID(),
+		Kind:   lane.kind,
+		Status: ItemStatusCompleted,
+		Text:   text,
+	})
+	lane.clearActive()
+	return changed
+}
+
+func (l *textLane) ensureActiveID() string {
+	if l.activeID != "" {
+		return l.activeID
+	}
+	l.next++
+	l.activeID = l.prefix + ":" + strconv.Itoa(l.next)
+	return l.activeID
+}
+
+func (l *textLane) clearActive() {
+	l.activeID = ""
+	l.pending.Reset()
+}
+
+func toolItem(update ToolUpdate) Item {
+	name := strings.TrimSpace(update.Name)
+	id := strings.TrimSpace(update.ID)
+	if id == "" && name != "" {
+		id = toolItemIDPrefix + name
+	}
+	return Item{
+		ID:     id,
+		Kind:   normalizeItemKind(update.Kind),
+		Status: normalizeItemStatus(update.Status),
+		Name:   name,
+		Text:   strings.TrimSpace(update.Text),
+	}
+}
+
+func normalizeItemKind(kind ItemKind) ItemKind {
+	switch kind {
+	case ItemKindStatus,
+		ItemKindReasoning,
+		ItemKindTool,
+		ItemKindCommand,
+		ItemKindExplore,
+		ItemKindWrite:
+		return kind
+	default:
+		return ItemKindTool
+	}
+}
+
+func normalizeItemStatus(status ItemStatus) ItemStatus {
+	switch status {
+	case ItemStatusRunning,
+		ItemStatusCompleted,
+		ItemStatusFailed:
+		return status
+	default:
+		return ItemStatusRunning
+	}
+}
+
+func (p *Projector) upsertItem(item Item) bool {
+	item.ID = strings.TrimSpace(item.ID)
+	if item.ID == "" {
+		return false
+	}
+	if idx, ok := p.itemIndex[item.ID]; ok {
+		return updateItem(&p.items[idx], item)
+	}
+	p.itemIndex[item.ID] = len(p.items)
+	p.items = append(p.items, item)
+	return true
+}
+
+func updateItem(existing *Item, next Item) bool {
+	if existing == nil {
+		return false
+	}
+	changed := false
+	if next.Kind != "" && existing.Kind != next.Kind {
+		existing.Kind = next.Kind
+		changed = true
+	}
+	if next.Status != "" && existing.Status != next.Status {
+		existing.Status = next.Status
+		changed = true
+	}
+	if next.Name != "" && existing.Name != next.Name {
+		existing.Name = next.Name
+		changed = true
+	}
+	if next.Text != "" && existing.Text != next.Text {
+		existing.Text = next.Text
+		changed = true
+	}
+	return changed
+}
+
+func limitedItems(items []Item, limit int) []Item {
+	if limit <= 0 || len(items) <= limit {
+		return items
+	}
+	return items[len(items)-limit:]
+}
+
+func renderItem(item Item, labels Labels, maxTextRunes int) string {
+	head := itemHead(item, labels)
+	if head == "" {
+		return ""
+	}
+	text := truncateRunes(strings.TrimSpace(item.Text), maxTextRunes)
+	if text == "" || text == item.Name {
+		return bulletPrefix + head
+	}
+	return bulletPrefix + head + "\n" + childPrefix + text
+}
+
+func itemHead(item Item, labels Labels) string {
+	if item.Status == ItemStatusFailed {
+		return namedHead(labels.Failed, item.Name)
+	}
+	switch item.Kind {
+	case ItemKindReasoning:
+		if item.Status == ItemStatusCompleted {
+			return labels.ThinkingCompleted
+		}
+		return labels.ThinkingRunning
+	case ItemKindCommand:
+		return lifecycleHead(item, labels.Running, labels.Ran)
+	case ItemKindExplore:
+		return lifecycleHead(item, labels.Exploring, labels.Explored)
+	case ItemKindWrite:
+		return lifecycleHead(item, labels.Writing, labels.Wrote)
+	case ItemKindStatus:
+		return labels.Working
+	default:
+		return lifecycleHead(item, labels.Calling, labels.Called)
+	}
+}
+
+func lifecycleHead(item Item, running, completed string) string {
+	if item.Status == ItemStatusCompleted {
+		return namedHead(completed, item.Name)
+	}
+	return namedHead(running, item.Name)
+}
+
+func namedHead(label, name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return label
+	}
+	return label + " " + name
+}
+
+func errorText(labels Labels, text string, maxTextRunes int) string {
+	text = truncateRunes(text, maxTextRunes)
+	if text == "" {
+		return labels.Failed
+	}
+	return labels.Failed + ": " + text
+}
+
+func truncateRunes(text string, maxRunes int) string {
+	text = strings.TrimSpace(text)
+	if maxRunes <= 0 || utf8.RuneCountInString(text) <= maxRunes {
+		return text
+	}
+	runes := []rune(text)
+	suffixRunes := []rune(truncatedSuffix)
+	if maxRunes <= len(suffixRunes) {
+		return string(runes[:maxRunes])
+	}
+	return strings.TrimSpace(
+		string(runes[:maxRunes-len(suffixRunes)]),
+	) + truncatedSuffix
+}

--- a/openclaw/streamdisplay/display_test.go
+++ b/openclaw/streamdisplay/display_test.go
@@ -69,6 +69,7 @@ func TestProjectorRendersEnglishToolLifecycle(t *testing.T) {
 		Kind:   ItemKindCommand,
 		Status: ItemStatusRunning,
 		Text:   "Running git command",
+		Detail: `{"command":"git status"}`,
 	}))
 	require.True(t, projector.ApplyTool(ToolUpdate{
 		ID:     "call_1",
@@ -85,6 +86,7 @@ func TestProjectorRendersEnglishToolLifecycle(t *testing.T) {
 	require.Equal(
 		t,
 		"- Ran exec_command\n"+
+			"  - Args: {\"command\":\"git status\"}\n"+
 			"  - Preparing final answer\n\n"+
 			"Answer\n"+
 			"done",
@@ -108,6 +110,7 @@ func TestProjectorRendersChineseLabels(t *testing.T) {
 		Kind:   ItemKindExplore,
 		Status: ItemStatusRunning,
 		Text:   "Scanning files",
+		Detail: `{"query":"*.go"}`,
 	}))
 
 	rendered := Render(projector.Snapshot())
@@ -116,6 +119,7 @@ func TestProjectorRendersChineseLabels(t *testing.T) {
 		"- 思考\n"+
 			"  - 先检查上下文\n\n"+
 			"- 正在查看 fs_search\n"+
+			"  - 参数: {\"query\":\"*.go\"}\n"+
 			"  - Scanning files",
 		rendered,
 	)

--- a/openclaw/streamdisplay/display_test.go
+++ b/openclaw/streamdisplay/display_test.go
@@ -1,0 +1,347 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package streamdisplay
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeLanguage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		language string
+		want     Language
+	}{
+		{
+			name:     "empty defaults to english",
+			language: "",
+			want:     LanguageEnglish,
+		},
+		{
+			name:     "english locale",
+			language: "en-US",
+			want:     LanguageEnglish,
+		},
+		{
+			name:     "chinese locale",
+			language: "zh-CN",
+			want:     LanguageChinese,
+		},
+		{
+			name:     "cn alias",
+			language: "cn",
+			want:     LanguageChinese,
+		},
+		{
+			name:     "unknown falls back",
+			language: "fr",
+			want:     LanguageEnglish,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.want, NormalizeLanguage(tt.language))
+		})
+	}
+}
+
+func TestProjectorRendersEnglishToolLifecycle(t *testing.T) {
+	t.Parallel()
+
+	projector := NewProjector(Options{Language: "en"})
+	require.True(t, projector.ApplyTool(ToolUpdate{
+		ID:     "call_1",
+		Name:   "exec_command",
+		Kind:   ItemKindCommand,
+		Status: ItemStatusRunning,
+		Text:   "Running git command",
+	}))
+	require.True(t, projector.ApplyTool(ToolUpdate{
+		ID:     "call_1",
+		Name:   "exec_command",
+		Kind:   ItemKindCommand,
+		Status: ItemStatusCompleted,
+		Text:   "Preparing final answer",
+	}))
+	require.True(t, projector.ApplyAnswerDelta("do"))
+	require.True(t, projector.ApplyAnswerDelta("ne"))
+	require.True(t, projector.ApplyAnswerCompleted("done"))
+
+	rendered := Render(projector.Snapshot())
+	require.Equal(
+		t,
+		"- Ran exec_command\n"+
+			"  - Preparing final answer\n\n"+
+			"Answer\n"+
+			"done",
+		rendered,
+	)
+}
+
+func TestProjectorRendersChineseLabels(t *testing.T) {
+	t.Parallel()
+
+	projector := NewProjector(Options{
+		Language:      "zh-CN",
+		ShowReasoning: true,
+	})
+	require.True(t, projector.ApplyReasoningDelta("先检查"))
+	require.True(t, projector.ApplyReasoningDelta("上下文"))
+	require.True(t, projector.ApplyReasoningCompleted(""))
+	require.True(t, projector.ApplyTool(ToolUpdate{
+		ID:     "call_2",
+		Name:   "fs_search",
+		Kind:   ItemKindExplore,
+		Status: ItemStatusRunning,
+		Text:   "Scanning files",
+	}))
+
+	rendered := Render(projector.Snapshot())
+	require.Equal(
+		t,
+		"- 思考\n"+
+			"  - 先检查上下文\n\n"+
+			"- 正在查看 fs_search\n"+
+			"  - Scanning files",
+		rendered,
+	)
+}
+
+func TestProjectorHidesReasoningByDefault(t *testing.T) {
+	t.Parallel()
+
+	projector := NewProjector(Options{})
+	require.False(t, projector.ApplyReasoningDelta("internal reasoning"))
+	require.False(t, projector.ApplyReasoningCompleted("done"))
+	require.Empty(t, Render(projector.Snapshot()))
+}
+
+func TestProjectorAllowsCustomLabels(t *testing.T) {
+	t.Parallel()
+
+	projector := NewProjector(Options{
+		Labels: Labels{
+			Working: "Busy",
+			Answer:  "Result",
+		},
+	})
+	require.True(t, projector.ApplyStatus("Preparing request"))
+	require.Equal(
+		t,
+		"Busy: Preparing request",
+		Render(projector.Snapshot()),
+	)
+	require.True(t, projector.ApplyAnswerCompleted("ok"))
+
+	require.Equal(
+		t,
+		"Result\nok",
+		Render(projector.Snapshot()),
+	)
+}
+
+func TestProjectorAppendsPublicDeltasAndCompletions(t *testing.T) {
+	t.Parallel()
+
+	projector := NewProjector(Options{})
+	require.True(t, projector.ApplyPublicDelta("checking"))
+	require.True(t, projector.ApplyPublicDelta(" "))
+	require.True(t, projector.ApplyPublicDelta("repo"))
+	require.Equal(
+		t,
+		"- Working\n  - checking repo",
+		Render(projector.Snapshot()),
+	)
+	require.True(t, projector.ApplyPublicCompleted(""))
+	require.True(t, projector.ApplyPublicCompleted("reading files"))
+
+	require.Equal(
+		t,
+		"- Working\n"+
+			"  - checking repo\n\n"+
+			"- Working\n"+
+			"  - reading files",
+		Render(projector.Snapshot()),
+	)
+}
+
+func TestProjectorKeepsWhitespaceOnlyDeltas(t *testing.T) {
+	t.Parallel()
+
+	projector := NewProjector(Options{
+		ShowReasoning: true,
+	})
+	require.False(t, projector.ApplyPublicDelta(" "))
+	require.True(t, projector.ApplyPublicDelta("hello"))
+	require.True(t, projector.ApplyPublicDelta(" "))
+	require.True(t, projector.ApplyPublicDelta("world"))
+	require.False(t, projector.ApplyReasoningDelta("\n"))
+	require.True(t, projector.ApplyReasoningDelta("think"))
+	require.True(t, projector.ApplyReasoningDelta(" "))
+	require.True(t, projector.ApplyReasoningDelta("more"))
+
+	require.Equal(
+		t,
+		"- Working\n"+
+			"  - hello world\n\n"+
+			"- Thinking\n"+
+			"  - think more",
+		Render(projector.Snapshot()),
+	)
+}
+
+func TestProjectorRendersTerminalStates(t *testing.T) {
+	t.Parallel()
+
+	completed := NewProjector(Options{})
+	require.True(t, completed.Complete())
+	require.False(t, completed.Complete())
+
+	canceled := NewProjector(Options{})
+	require.True(t, canceled.Cancel())
+	require.False(t, canceled.Cancel())
+	require.Equal(t, "Canceled", Render(canceled.Snapshot()))
+
+	ignored := NewProjector(Options{})
+	require.True(t, ignored.Ignore())
+	require.False(t, ignored.Ignore())
+	require.Equal(t, "Ignored", Render(ignored.Snapshot()))
+
+	failed := NewProjector(Options{})
+	require.True(t, failed.Fail("network down"))
+	require.False(t, failed.Fail("network down"))
+	require.Equal(t, "Failed: network down", Render(failed.Snapshot()))
+
+	emptyFailed := NewProjector(Options{})
+	require.True(t, emptyFailed.Fail(""))
+	require.Equal(t, "Failed", Render(emptyFailed.Snapshot()))
+}
+
+func TestProjectorRendersFailedTool(t *testing.T) {
+	t.Parallel()
+
+	projector := NewProjector(Options{})
+	require.True(t, projector.ApplyTool(ToolUpdate{
+		Name:   "exec_command",
+		Kind:   ItemKindCommand,
+		Status: ItemStatusFailed,
+		Text:   "exit status 1",
+	}))
+
+	require.Equal(
+		t,
+		"- Failed exec_command\n  - exit status 1",
+		Render(projector.Snapshot()),
+	)
+}
+
+func TestProjectorNormalizesToolUpdate(t *testing.T) {
+	t.Parallel()
+
+	projector := NewProjector(Options{})
+	require.False(t, projector.ApplyTool(ToolUpdate{}))
+	require.True(t, projector.ApplyTool(ToolUpdate{
+		ID:     "call_1",
+		Name:   "custom_tool",
+		Kind:   ItemKind("unknown"),
+		Status: ItemStatus("unknown"),
+		Text:   "custom_tool",
+	}))
+
+	require.Equal(t, "- Calling custom_tool", Render(projector.Snapshot()))
+}
+
+func TestProjectorUpdatesExistingToolFields(t *testing.T) {
+	t.Parallel()
+
+	projector := NewProjector(Options{})
+	require.True(t, projector.ApplyTool(ToolUpdate{
+		ID:     "call_1",
+		Name:   "custom_tool",
+		Kind:   ItemKindTool,
+		Status: ItemStatusRunning,
+		Text:   "starting",
+	}))
+	require.True(t, projector.ApplyTool(ToolUpdate{
+		ID:     "call_1",
+		Name:   "exec_command",
+		Kind:   ItemKindCommand,
+		Status: ItemStatusCompleted,
+		Text:   "done",
+	}))
+
+	require.Equal(
+		t,
+		"- Ran exec_command\n  - done",
+		Render(projector.Snapshot()),
+	)
+}
+
+func TestProjectorEmptyInputsDoNotChangeSnapshot(t *testing.T) {
+	t.Parallel()
+
+	projector := NewProjector(Options{})
+	require.False(t, projector.ApplyStatus(""))
+	require.False(t, projector.ApplyProgress(""))
+	require.False(t, projector.ApplyPublicDelta(" "))
+	require.False(t, projector.ApplyPublicCompleted(""))
+	require.False(t, projector.ApplyAnswerDelta(""))
+	require.False(t, projector.ApplyAnswerCompleted(""))
+	require.False(t, projector.HasContent())
+	require.False(t, (*Projector)(nil).HasContent())
+	require.Equal(
+		t,
+		Snapshot{Options: normalizeOptions(Options{})},
+		nilSnapshot(),
+	)
+}
+
+func TestProjectorSnapshotIsImmutable(t *testing.T) {
+	t.Parallel()
+
+	labels := Labels{Working: "Busy"}
+	projector := NewProjector(Options{Labels: labels})
+	labels.Working = "Changed"
+	require.True(t, projector.ApplyProgress("checking"))
+
+	snapshot := projector.Snapshot()
+	require.Equal(t, "- Busy\n  - checking", Render(snapshot))
+	snapshot.Items[0].Text = "mutated"
+	require.Equal(
+		t,
+		"- Busy\n  - checking",
+		Render(projector.Snapshot()),
+	)
+}
+
+func TestRenderTruncatesLongTextAndLimitsItems(t *testing.T) {
+	t.Parallel()
+
+	projector := NewProjector(Options{
+		MaxItems:     1,
+		MaxTextRunes: 8,
+	})
+	require.True(t, projector.ApplyPublicCompleted("first"))
+	require.True(t, projector.ApplyPublicCompleted("abcdefghijklmnop"))
+
+	require.Equal(t, "- Working\n  - abcde...", Render(projector.Snapshot()))
+}
+
+func nilSnapshot() Snapshot {
+	var projector *Projector
+	return projector.Snapshot()
+}

--- a/openclaw/streamdisplay/gwproto.go
+++ b/openclaw/streamdisplay/gwproto.go
@@ -1,0 +1,124 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package streamdisplay
+
+import (
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/gwproto"
+)
+
+const (
+	toolExecCommand = "exec_command"
+	toolReadFile    = "fs_read_file"
+	toolSaveFile    = "fs_save_file"
+	toolListDir     = "fs_list_dir"
+	toolSearch      = "fs_search"
+	toolApplyPatch  = "apply_patch"
+)
+
+// Apply consumes one gateway stream event. It returns true when the rendered
+// snapshot may have changed.
+func (p *Projector) Apply(evt gwproto.StreamEvent) bool {
+	return ApplyStreamEvent(p, evt)
+}
+
+// ApplyStreamEvent projects one gwproto stream event into a Projector.
+func ApplyStreamEvent(
+	projector *Projector,
+	evt gwproto.StreamEvent,
+) bool {
+	if projector == nil {
+		return false
+	}
+	switch evt.Type {
+	case gwproto.StreamEventTypeRunStarted:
+		return projector.ApplyStatus(evt.Summary)
+	case gwproto.StreamEventTypeRunProgress:
+		return applyStreamProgress(projector, evt)
+	case gwproto.StreamEventTypePublicDelta:
+		return projector.ApplyPublicDelta(evt.Delta)
+	case gwproto.StreamEventTypePublicCompleted:
+		return projector.ApplyPublicCompleted(evt.Reply)
+	case gwproto.StreamEventTypeThoughtDelta:
+		return projector.ApplyReasoningDelta(evt.Delta)
+	case gwproto.StreamEventTypeThoughtCompleted:
+		return projector.ApplyReasoningCompleted(evt.Reply)
+	case gwproto.StreamEventTypeMessageDelta:
+		return projector.ApplyAnswerDelta(evt.Delta)
+	case gwproto.StreamEventTypeMessageCompleted:
+		return projector.ApplyAnswerCompleted(evt.Reply)
+	case gwproto.StreamEventTypeRunCompleted:
+		return projector.Complete()
+	case gwproto.StreamEventTypeRunCanceled:
+		return projector.Cancel()
+	case gwproto.StreamEventTypeRunIgnored:
+		return projector.Ignore()
+	case gwproto.StreamEventTypeRunError:
+		return projector.Fail(streamErrorText(evt))
+	default:
+		return false
+	}
+}
+
+func applyStreamProgress(
+	projector *Projector,
+	evt gwproto.StreamEvent,
+) bool {
+	toolName := strings.TrimSpace(evt.ToolName)
+	toolCallID := strings.TrimSpace(evt.ToolCallID)
+	if toolName == "" && toolCallID == "" {
+		return projector.ApplyProgress(evt.Summary)
+	}
+	return projector.ApplyTool(ToolUpdate{
+		ID:     toolCallID,
+		Name:   toolName,
+		Kind:   streamToolKind(evt.Stage, toolName),
+		Status: streamItemStatus(evt.ToolStatus),
+		Text:   evt.Summary,
+	})
+}
+
+func streamToolKind(
+	stage gwproto.StreamProgressStage,
+	toolName string,
+) ItemKind {
+	switch strings.TrimSpace(toolName) {
+	case toolExecCommand:
+		return ItemKindCommand
+	case toolReadFile, toolListDir, toolSearch:
+		return ItemKindExplore
+	case toolSaveFile, toolApplyPatch:
+		return ItemKindWrite
+	}
+	switch stage {
+	case gwproto.StreamProgressStageReadingDocument,
+		gwproto.StreamProgressStageReadingSpreadsheet:
+		return ItemKindExplore
+	default:
+		return ItemKindTool
+	}
+}
+
+func streamItemStatus(status gwproto.StreamToolStatus) ItemStatus {
+	switch status {
+	case gwproto.StreamToolStatusCompleted:
+		return ItemStatusCompleted
+	default:
+		return ItemStatusRunning
+	}
+}
+
+func streamErrorText(evt gwproto.StreamEvent) string {
+	if evt.Error == nil {
+		return ""
+	}
+	return evt.Error.Message
+}

--- a/openclaw/streamdisplay/gwproto.go
+++ b/openclaw/streamdisplay/gwproto.go
@@ -72,6 +72,9 @@ func applyStreamProgress(
 	projector *Projector,
 	evt gwproto.StreamEvent,
 ) bool {
+	if len(evt.ToolCalls) > 0 {
+		return applyStreamToolCalls(projector, evt)
+	}
 	toolName := strings.TrimSpace(evt.ToolName)
 	toolCallID := strings.TrimSpace(evt.ToolCallID)
 	if toolName == "" && toolCallID == "" {
@@ -83,7 +86,74 @@ func applyStreamProgress(
 		Kind:   streamToolKind(evt.Stage, toolName),
 		Status: streamItemStatus(evt.ToolStatus),
 		Text:   evt.Summary,
+		Detail: strings.TrimSpace(evt.ToolArguments),
 	})
+}
+
+func applyStreamToolCalls(
+	projector *Projector,
+	evt gwproto.StreamEvent,
+) bool {
+	changed := false
+	for _, call := range evt.ToolCalls {
+		update, ok := streamToolUpdateFromCall(evt, call)
+		if ok {
+			changed = projector.ApplyTool(update) || changed
+		}
+	}
+	return changed
+}
+
+func streamToolUpdateFromCall(
+	evt gwproto.StreamEvent,
+	call gwproto.StreamToolCall,
+) (ToolUpdate, bool) {
+	toolName := streamToolCallName(call)
+	toolCallID := streamToolCallID(call)
+	if toolName == "" && toolCallID == "" {
+		return ToolUpdate{}, false
+	}
+	return ToolUpdate{
+		ID:     toolCallID,
+		Name:   toolName,
+		Kind:   streamToolKind(evt.Stage, toolName),
+		Status: streamItemStatus(evt.ToolStatus),
+		Text:   evt.Summary,
+		Detail: streamToolCallDetail(call),
+	}, true
+}
+
+func streamToolCallName(call gwproto.StreamToolCall) string {
+	if name := strings.TrimSpace(call.ToolName); name != "" {
+		return name
+	}
+	if name := strings.TrimSpace(call.Name); name != "" {
+		return name
+	}
+	if call.Function == nil {
+		return ""
+	}
+	return strings.TrimSpace(call.Function.Name)
+}
+
+func streamToolCallID(call gwproto.StreamToolCall) string {
+	if id := strings.TrimSpace(call.ToolCallID); id != "" {
+		return id
+	}
+	return strings.TrimSpace(call.ID)
+}
+
+func streamToolCallDetail(call gwproto.StreamToolCall) string {
+	if detail := strings.TrimSpace(call.ToolArguments); detail != "" {
+		return detail
+	}
+	if detail := strings.TrimSpace(call.Arguments); detail != "" {
+		return detail
+	}
+	if call.Function == nil {
+		return ""
+	}
+	return strings.TrimSpace(call.Function.Arguments)
 }
 
 func streamToolKind(

--- a/openclaw/streamdisplay/gwproto_test.go
+++ b/openclaw/streamdisplay/gwproto_test.go
@@ -1,0 +1,211 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package streamdisplay
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/gwproto"
+)
+
+func TestApplyStreamEventProjectsToolLifecycle(t *testing.T) {
+	t.Parallel()
+
+	projector := NewProjector(Options{Language: "en"})
+	require.True(t, projector.Apply(gwproto.StreamEvent{
+		Type:       gwproto.StreamEventTypeRunProgress,
+		Summary:    "Running git command",
+		ToolName:   toolExecCommand,
+		ToolCallID: "call_1",
+		ToolStatus: gwproto.StreamToolStatusRunning,
+	}))
+	require.True(t, projector.Apply(gwproto.StreamEvent{
+		Type:       gwproto.StreamEventTypeRunProgress,
+		Summary:    "Preparing final answer",
+		ToolName:   toolExecCommand,
+		ToolCallID: "call_1",
+		ToolStatus: gwproto.StreamToolStatusCompleted,
+	}))
+
+	require.Equal(
+		t,
+		"- Ran exec_command\n  - Preparing final answer",
+		Render(projector.Snapshot()),
+	)
+}
+
+func TestApplyStreamEventHandlesDeltasAndIgnored(t *testing.T) {
+	t.Parallel()
+
+	projector := NewProjector(Options{})
+	require.True(t, ApplyStreamEvent(projector, gwproto.StreamEvent{
+		Type:  gwproto.StreamEventTypePublicDelta,
+		Delta: "Checking ",
+	}))
+	require.True(t, ApplyStreamEvent(projector, gwproto.StreamEvent{
+		Type:  gwproto.StreamEventTypePublicDelta,
+		Delta: "repo",
+	}))
+	require.True(t, ApplyStreamEvent(projector, gwproto.StreamEvent{
+		Type: gwproto.StreamEventTypePublicCompleted,
+	}))
+	require.True(t, ApplyStreamEvent(projector, gwproto.StreamEvent{
+		Type: gwproto.StreamEventTypeRunIgnored,
+	}))
+
+	require.Equal(
+		t,
+		"- Working\n"+
+			"  - Checking repo\n\n"+
+			"Ignored",
+		Render(projector.Snapshot()),
+	)
+}
+
+func TestApplyStreamEventClassifiesToolKinds(t *testing.T) {
+	t.Parallel()
+
+	projector := NewProjector(Options{Language: "en"})
+	require.True(t, projector.Apply(gwproto.StreamEvent{
+		Type:       gwproto.StreamEventTypeRunProgress,
+		ToolName:   toolSaveFile,
+		ToolCallID: "save",
+		ToolStatus: gwproto.StreamToolStatusCompleted,
+	}))
+	require.True(t, projector.Apply(gwproto.StreamEvent{
+		Type:       gwproto.StreamEventTypeRunProgress,
+		ToolName:   toolApplyPatch,
+		ToolCallID: "patch",
+		ToolStatus: gwproto.StreamToolStatusRunning,
+	}))
+	require.True(t, projector.Apply(gwproto.StreamEvent{
+		Type:    gwproto.StreamEventTypeRunProgress,
+		Stage:   gwproto.StreamProgressStageReadingDocument,
+		Summary: "Reading document",
+	}))
+	require.True(t, projector.Apply(gwproto.StreamEvent{
+		Type:  gwproto.StreamEventTypeRunError,
+		Error: &gwproto.APIError{Message: "tool failed"},
+	}))
+
+	rendered := Render(projector.Snapshot())
+	require.Contains(t, rendered, "- Wrote fs_save_file")
+	require.Contains(t, rendered, "- Writing apply_patch")
+	require.Contains(t, rendered, "- Working")
+	require.Contains(t, rendered, "Failed: tool failed")
+}
+
+func TestApplyStreamEventProjectsAllEventTypes(t *testing.T) {
+	t.Parallel()
+
+	projector := NewProjector(Options{
+		ShowReasoning: true,
+	})
+	require.False(t, ApplyStreamEvent(nil, gwproto.StreamEvent{
+		Type: gwproto.StreamEventTypeRunStarted,
+	}))
+	require.True(t, ApplyStreamEvent(projector, gwproto.StreamEvent{
+		Type:    gwproto.StreamEventTypeRunStarted,
+		Summary: "Preparing",
+	}))
+	require.True(t, ApplyStreamEvent(projector, gwproto.StreamEvent{
+		Type:  gwproto.StreamEventTypeThoughtDelta,
+		Delta: "think",
+	}))
+	require.True(t, ApplyStreamEvent(projector, gwproto.StreamEvent{
+		Type:  gwproto.StreamEventTypeThoughtCompleted,
+		Reply: "thought",
+	}))
+	require.True(t, ApplyStreamEvent(projector, gwproto.StreamEvent{
+		Type:  gwproto.StreamEventTypeMessageDelta,
+		Delta: "he",
+	}))
+	require.True(t, ApplyStreamEvent(projector, gwproto.StreamEvent{
+		Type:  gwproto.StreamEventTypeMessageDelta,
+		Delta: "llo",
+	}))
+	require.True(t, ApplyStreamEvent(projector, gwproto.StreamEvent{
+		Type:  gwproto.StreamEventTypeMessageCompleted,
+		Reply: "hello",
+	}))
+	require.True(t, ApplyStreamEvent(projector, gwproto.StreamEvent{
+		Type: gwproto.StreamEventTypeRunCompleted,
+	}))
+	require.False(t, ApplyStreamEvent(projector, gwproto.StreamEvent{
+		Type: gwproto.StreamEventType("unknown"),
+	}))
+
+	rendered := Render(projector.Snapshot())
+	require.Contains(t, rendered, "Thought")
+	require.Contains(t, rendered, "Answer\nhello")
+}
+
+func TestApplyStreamEventProjectsTerminalFallbacks(t *testing.T) {
+	t.Parallel()
+
+	canceled := NewProjector(Options{})
+	require.True(t, ApplyStreamEvent(canceled, gwproto.StreamEvent{
+		Type: gwproto.StreamEventTypeRunCanceled,
+	}))
+	require.Equal(t, "Canceled", Render(canceled.Snapshot()))
+
+	failed := NewProjector(Options{})
+	require.True(t, ApplyStreamEvent(failed, gwproto.StreamEvent{
+		Type: gwproto.StreamEventTypeRunError,
+	}))
+	require.Equal(t, "Failed", Render(failed.Snapshot()))
+}
+
+func TestApplyStreamEventClassifiesProtocolStages(t *testing.T) {
+	t.Parallel()
+
+	projector := NewProjector(Options{})
+	require.True(t, projector.Apply(gwproto.StreamEvent{
+		Type:       gwproto.StreamEventTypeRunProgress,
+		Summary:    "read",
+		ToolName:   toolReadFile,
+		ToolCallID: "read",
+	}))
+	require.True(t, projector.Apply(gwproto.StreamEvent{
+		Type:       gwproto.StreamEventTypeRunProgress,
+		Summary:    "list",
+		ToolName:   toolListDir,
+		ToolCallID: "list",
+	}))
+	require.True(t, projector.Apply(gwproto.StreamEvent{
+		Type:       gwproto.StreamEventTypeRunProgress,
+		Summary:    "search",
+		ToolName:   toolSearch,
+		ToolCallID: "search",
+	}))
+	require.True(t, projector.Apply(gwproto.StreamEvent{
+		Type:    gwproto.StreamEventTypeRunProgress,
+		Stage:   gwproto.StreamProgressStageReadingSpreadsheet,
+		Summary: "sheet",
+	}))
+
+	rendered := Render(projector.Snapshot())
+	require.Contains(t, rendered, "Exploring fs_read_file")
+	require.Contains(t, rendered, "Exploring fs_list_dir")
+	require.Contains(t, rendered, "Exploring fs_search")
+	require.Contains(t, rendered, "Working")
+}
+
+func TestNilProjectorApplyDoesNotChange(t *testing.T) {
+	t.Parallel()
+
+	var projector *Projector
+	require.False(t, projector.Apply(gwproto.StreamEvent{
+		Type: gwproto.StreamEventTypeRunStarted,
+	}))
+	require.Empty(t, Render(projector.Snapshot()))
+}

--- a/openclaw/streamdisplay/gwproto_test.go
+++ b/openclaw/streamdisplay/gwproto_test.go
@@ -22,11 +22,12 @@ func TestApplyStreamEventProjectsToolLifecycle(t *testing.T) {
 
 	projector := NewProjector(Options{Language: "en"})
 	require.True(t, projector.Apply(gwproto.StreamEvent{
-		Type:       gwproto.StreamEventTypeRunProgress,
-		Summary:    "Running git command",
-		ToolName:   toolExecCommand,
-		ToolCallID: "call_1",
-		ToolStatus: gwproto.StreamToolStatusRunning,
+		Type:          gwproto.StreamEventTypeRunProgress,
+		Summary:       "Running git command",
+		ToolName:      toolExecCommand,
+		ToolCallID:    "call_1",
+		ToolArguments: `{"command":"git status"}`,
+		ToolStatus:    gwproto.StreamToolStatusRunning,
 	}))
 	require.True(t, projector.Apply(gwproto.StreamEvent{
 		Type:       gwproto.StreamEventTypeRunProgress,
@@ -38,9 +39,42 @@ func TestApplyStreamEventProjectsToolLifecycle(t *testing.T) {
 
 	require.Equal(
 		t,
-		"- Ran exec_command\n  - Preparing final answer",
+		"- Ran exec_command\n"+
+			"  - Args: {\"command\":\"git status\"}\n"+
+			"  - Preparing final answer",
 		Render(projector.Snapshot()),
 	)
+}
+
+func TestApplyStreamEventProjectsNestedToolCalls(t *testing.T) {
+	t.Parallel()
+
+	projector := NewProjector(Options{Language: "en"})
+	require.True(t, projector.Apply(gwproto.StreamEvent{
+		Type:       gwproto.StreamEventTypeRunProgress,
+		Summary:    "Running local tools",
+		ToolStatus: gwproto.StreamToolStatusRunning,
+		ToolCalls: []gwproto.StreamToolCall{
+			{
+				ID: "call_read",
+				Function: &gwproto.StreamToolCallFunction{
+					Name:      toolReadFile,
+					Arguments: `{"path":"README.md"}`,
+				},
+			},
+			{
+				ToolCallID:    "call_patch",
+				ToolName:      toolApplyPatch,
+				ToolArguments: `{"patch":"*** Begin Patch"}`,
+			},
+		},
+	}))
+
+	rendered := Render(projector.Snapshot())
+	require.Contains(t, rendered, "- Exploring fs_read_file")
+	require.Contains(t, rendered, `"path":"README.md"`)
+	require.Contains(t, rendered, "- Writing apply_patch")
+	require.Contains(t, rendered, `"patch":"*** Begin Patch"`)
 }
 
 func TestApplyStreamEventHandlesDeltasAndIgnored(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add `openclaw/streamdisplay`, a reusable localized projector for stream display snapshots.
- Split the core projector from the `gwproto` adapter so render state is not tied to transport structs.
- Surface tool-call names and compact redacted argument summaries in `run.progress` events, including multi-tool-call responses.
- Render tool argument details as localized `Args` / `参数` child lines while preserving tool lifecycle status.

## Design Notes

- `Projector` exposes explicit methods such as `ApplyTool`, `ApplyPublicDelta`, `ApplyAnswerCompleted`, and terminal state methods.
- `gwproto.go` is the protocol adapter; it maps stream stages/tool status into display item kinds and statuses.
- Reasoning is hidden by default and only appears when `ShowReasoning` is enabled.
- Tool arguments are summarized generically from JSON, with sensitive keys such as tokens, passwords, cookies, API keys, and credentials redacted before they enter stream events.
- Partial or malformed tool argument fragments are conservatively redacted when they mention a sensitive key, so streaming deltas do not expose half-written secrets.
- Snapshots copy item and option state so callers cannot mutate projector render output by changing a previous snapshot.

## Validation

- `cd openclaw && go test ./streamdisplay ./gwclient ./internal/gateway`
- `cd openclaw && go test ./...`
