### PR TITLE
tool/mcpbroker: harden ClientOptionsProvider hot path

### DIFF
--- a/tool/mcpbroker/broker.go
+++ b/tool/mcpbroker/broker.go
@@ -12,6 +12,7 @@ package mcpbroker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"sort"
@@ -21,6 +22,13 @@ import (
 	mcpcfg "trpc.group/trpc-go/trpc-agent-go/tool/mcp"
 	tmcp "trpc.group/trpc-go/trpc-mcp-go"
 )
+
+// ErrClientOptionsProviderPanicked is the sentinel returned (wrapped via fmt.Errorf %w) when a
+// ClientOptionsProvider panics. The broker recovers the panic so it never unwinds through
+// trpc-mcp-go internals; callers can detect this case with errors.Is for observability or to
+// fall back to default options. The recovered panic value is included in the wrapped error
+// message via %v.
+var ErrClientOptionsProviderPanicked = errors.New("ClientOptionsProvider panicked")
 
 const (
 	listServersToolName  = "mcp_list_servers"
@@ -80,11 +88,39 @@ type brokerOptions struct {
 }
 
 // ClientOptionsProvider supplies extra trpc-mcp-go client options after the broker has resolved
-// the target and merged injected HTTP headers. Returning (nil, nil) applies no extra options.
+// the target and merged injected HTTP headers, but before the underlying MCP client is created.
+// Returning (nil, nil) applies no extra options.
+//
+// # Trust boundary
+//
+// The provider is host-trusted code registered via WithClientOptionsProvider; it is not
+// model-controlled or end-user-controlled input. The broker therefore does NOT subject the
+// returned options to the ad-hoc header denylist or any other sanitisation. By design, the
+// provider can override Authorization or any other header previously set by
+// WithHTTPHeaderInjector - hosts rely on this for service-account auth, request signing, and
+// audit hooks. The flip side is that a provider that accidentally shadows the injector's
+// Authorization is a host bug, not a framework vulnerability.
+//
+// # Failure modes
+//
+//   - If the provider returns an error, the broker aborts before establishing the MCP connection.
+//   - If the provider panics, the broker recovers and surfaces an error wrapping
+//     ErrClientOptionsProviderPanicked (use errors.Is to detect this case) instead of unwinding
+//     through trpc-mcp-go internals.
+//   - nil entries inside the returned ClientOptions.HTTP / .Stdio slices are silently filtered out
+//     so a conditional option builder that yields nil does not crash trpc-mcp-go.
+//
+// # Caveats
+//
+// HTTP-layer retries (e.g. tmcp.WithRetry) configured here are not aware of MCP-level side
+// effects. Retrying tools/call automatically can cause duplicated side effects; hosts that need
+// retry semantics for tool calls should implement them above the broker, gated by idempotency.
 type ClientOptionsProvider func(context.Context, *ClientOptionsRequest) (*ClientOptions, error)
 
 // ClientOptionsRequest is the broker-side context passed to ClientOptionsProvider before creating
-// the underlying MCP client. Config is a defensive clone of the final ConnectionConfig for this call.
+// the underlying MCP client. Config is a defensive clone of the final ConnectionConfig for this
+// call (see cloneConnectionConfig); mutations to Config (including its Headers map and Args slice)
+// do not propagate back to the broker or the actual request.
 type ClientOptionsRequest struct {
 	Selector   string
 	ServerName string
@@ -100,8 +136,12 @@ type ClientOptionsRequest struct {
 }
 
 // ClientOptions carries optional HTTP and stdio client options. HTTP applies to SSE and streamable
-// transports; Stdio applies to stdio transports. Default broker headers are applied first; options
-// here follow and may override or extend behavior (see trpc-mcp-go ClientOption / StdioClientOption).
+// transports; Stdio applies to stdio transports.
+//
+// Default broker headers are applied first; options here follow and may override or extend
+// behavior intentionally (see trpc-mcp-go ClientOption / StdioClientOption). For example, a host
+// can use tmcp.WithHTTPBeforeRequest to rewrite an Authorization header set earlier by
+// WithHTTPHeaderInjector. nil entries in HTTP / Stdio are filtered out before being applied.
 type ClientOptions struct {
 	HTTP  []tmcp.ClientOption
 	Stdio []tmcp.StdioClientOption
@@ -210,8 +250,9 @@ func WithHTTPHeaderInjector(fn HTTPHeaderInjector) Option {
 }
 
 // WithClientOptionsProvider registers a hook that returns extra trpc-mcp-go client options after
-// resolveTarget and WithHTTPHeaderInjector. Use this for URL policy, auditing, retries, custom HTTP
-// clients, or stdio options without adding parallel WithX hooks for each concern.
+// resolveTarget and WithHTTPHeaderInjector. Use this for URL policy, auditing, custom HTTP
+// clients, or stdio options without adding parallel WithX hooks for each concern. See
+// ClientOptionsProvider for the trust boundary, failure modes, and the HTTP-retry caveat.
 func WithClientOptionsProvider(fn ClientOptionsProvider) Option {
 	return func(opts *brokerOptions) {
 		opts.clientOptionsProvider = fn

--- a/tool/mcpbroker/broker_test.go
+++ b/tool/mcpbroker/broker_test.go
@@ -925,6 +925,56 @@ func TestClientOptionsProvider_ErrorStopsBeforeConnect(t *testing.T) {
 	require.Equal(t, 0, server.MethodCount("initialize"), "provider error must abort before MCP initialize")
 }
 
+func TestClientOptionsProvider_PanicIsRecoveredAsError(t *testing.T) {
+	server := startBrokerHTTPServer(t)
+	defer server.Close()
+
+	broker := New(
+		WithAllowAdHocHTTP(true),
+		WithClientOptionsProvider(func(ctx context.Context, req *ClientOptionsRequest) (*ClientOptions, error) {
+			panic("provider blew up")
+		}),
+	)
+
+	_, err := broker.listTools(context.Background(), listToolsInput{Selector: server.URL})
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrClientOptionsProviderPanicked,
+		"panic must surface as an error wrapping the sentinel for errors.Is detection")
+	require.Contains(t, err.Error(), "provider blew up",
+		"recovered panic value must be preserved in the error message")
+	require.Equal(t, 0, server.MethodCount("initialize"),
+		"panicking provider must abort before MCP initialize")
+}
+
+func TestClientOptionsProvider_NilOptionEntriesAreFilteredOut(t *testing.T) {
+	server := startBrokerHTTPServer(t)
+	defer server.Close()
+
+	var beforeRequestCalled bool
+
+	broker := New(
+		WithAllowAdHocHTTP(true),
+		WithClientOptionsProvider(func(ctx context.Context, req *ClientOptionsRequest) (*ClientOptions, error) {
+			return &ClientOptions{
+				HTTP: []tmcp.ClientOption{
+					nil,
+					tmcp.WithHTTPBeforeRequest(func(ctx context.Context, httpReq *http.Request) error {
+						beforeRequestCalled = true
+						return nil
+					}),
+					nil,
+				},
+			}, nil
+		}),
+	)
+
+	output, err := broker.listTools(context.Background(), listToolsInput{Selector: server.URL})
+	require.NoError(t, err, "nil entries in HTTP options must not crash trpc-mcp-go")
+	require.Len(t, output.Tools, 2)
+	require.True(t, beforeRequestCalled,
+		"non-nil HTTP option must still execute after nil filtering")
+}
+
 func TestNamedHTTPServer_HeaderInjectorCanonicalizesOverrides(t *testing.T) {
 	server := startBrokerHTTPServerWithOptions(t, brokerHTTPServerOptions{
 		RequiredAuth: "Bearer injected-token",

--- a/tool/mcpbroker/client.go
+++ b/tool/mcpbroker/client.go
@@ -221,14 +221,65 @@ func (b *Broker) resolveClientOptions(
 		Config:     cloneConnectionConfig(cfg),
 	}
 
-	out, err := b.options.clientOptionsProvider(ctx, req)
+	out, err := invokeClientOptionsProvider(ctx, b.options.clientOptionsProvider, req)
 	if err != nil {
 		return nil, nil, err
 	}
 	if out == nil {
 		return nil, nil, nil
 	}
-	return out.HTTP, out.Stdio, nil
+	return filterNilClientOptions(out.HTTP), filterNilStdioClientOptions(out.Stdio), nil
+}
+
+// invokeClientOptionsProvider runs the host-supplied provider with a panic guard so a
+// misbehaving hook surfaces as an error wrapping ErrClientOptionsProviderPanicked instead
+// of crashing the agent. The provider runs on the hot path of every list/inspect/call
+// invocation; recover() here is cheap insurance against host bugs that would otherwise
+// unwind through trpc-mcp-go internals.
+func invokeClientOptionsProvider(
+	ctx context.Context,
+	fn ClientOptionsProvider,
+	req *ClientOptionsRequest,
+) (out *ClientOptions, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			out = nil
+			err = fmt.Errorf("%w: %v", ErrClientOptionsProviderPanicked, r)
+		}
+	}()
+	return fn(ctx, req)
+}
+
+// filterNilClientOptions drops nil entries so trpc-mcp-go's option application loop never
+// invokes a nil ClientOption (which would panic). Hosts often build options conditionally,
+// so tolerating sparse slices keeps the contract forgiving.
+func filterNilClientOptions(opts []tmcp.ClientOption) []tmcp.ClientOption {
+	if len(opts) == 0 {
+		return nil
+	}
+	result := make([]tmcp.ClientOption, 0, len(opts))
+	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
+		result = append(result, opt)
+	}
+	return result
+}
+
+// filterNilStdioClientOptions mirrors filterNilClientOptions for the stdio transport.
+func filterNilStdioClientOptions(opts []tmcp.StdioClientOption) []tmcp.StdioClientOption {
+	if len(opts) == 0 {
+		return nil
+	}
+	result := make([]tmcp.StdioClientOption, 0, len(opts))
+	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
+		result = append(result, opt)
+	}
+	return result
 }
 
 func createClient(cfg mcpcfg.ConnectionConfig, extraHTTP []tmcp.ClientOption, extraStdio []tmcp.StdioClientOption) (tmcp.Connector, error) {

--- a/tool/mcpbroker/config.go
+++ b/tool/mcpbroker/config.go
@@ -136,6 +136,11 @@ func normalizeTransport(raw string, hasCommand, hasURL, adHoc bool) (string, tra
 	}
 }
 
+// cloneConnectionConfig returns a defensive copy of cfg. Scalar fields are duplicated by Go
+// value semantics; the Headers map and Args slice are deep-cloned via cloneStringMap and
+// cloneStringSlice. Mutations to the returned config (including its Headers / Args) therefore
+// do not propagate back to the source. Callers that hand the clone to external callbacks (such
+// as ClientOptionsProvider) rely on this contract.
 func cloneConnectionConfig(cfg mcpcfg.ConnectionConfig) mcpcfg.ConnectionConfig {
 	cfg.Headers = cloneStringMap(cfg.Headers)
 	cfg.Args = cloneStringSlice(cfg.Args)


### PR DESCRIPTION
The provider runs on every list/inspect/call invocation, but a misbehaving host hook would previously panic through trpc-mcp-go internals or feed nil ClientOption entries into the option-application loop and crash NewClient.