### PR TITLE
model: support request extra fields

### DIFF
--- a/agent/invocation.go
+++ b/agent/invocation.go
@@ -241,6 +241,23 @@ func WithRuntimeState(state map[string]any) RunOption {
 	}
 }
 
+// WithModelRequestExtraFields merges provider-specific top-level fields into
+// each model request created during this run. Request-level fields take
+// precedence over model-level extra fields in adapters that support merging.
+func WithModelRequestExtraFields(fields map[string]any) RunOption {
+	return func(opts *RunOptions) {
+		if len(fields) == 0 {
+			return
+		}
+		if opts.ModelRequestExtraFields == nil {
+			opts.ModelRequestExtraFields = make(map[string]any, len(fields))
+		}
+		for key, value := range fields {
+			opts.ModelRequestExtraFields[key] = value
+		}
+	}
+}
+
 // MergeRuntimeState merges runtime state into existing RunOptions state.
 //
 // When a key already exists, the new value replaces the old one.
@@ -989,6 +1006,13 @@ type RunOptions struct {
 	// The agent will look up the model by name from its registered models.
 	// If both Model and ModelName are set, Model takes precedence.
 	ModelName string
+
+	// ModelRequestExtraFields contains provider-specific top-level request body
+	// fields for model calls made during this run.
+	//
+	// Adapters that support extra fields merge these with model-level extra
+	// fields, with these request-level values taking precedence.
+	ModelRequestExtraFields map[string]any
 
 	// CodeExecutor is the code executor to use for this specific run.
 	// If set, it temporarily overrides the agent's default code executor for

--- a/agent/invocation_options_test.go
+++ b/agent/invocation_options_test.go
@@ -25,6 +25,27 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
 
+func TestWithModelRequestExtraFields(t *testing.T) {
+	opts := &RunOptions{}
+	fields := map[string]any{
+		"prompt_cache_key": "cache-1",
+	}
+
+	WithModelRequestExtraFields(fields)(opts)
+	fields["prompt_cache_key"] = "changed"
+
+	require.NotNil(t, opts.ModelRequestExtraFields)
+	assert.Equal(t, "cache-1", opts.ModelRequestExtraFields["prompt_cache_key"])
+
+	WithModelRequestExtraFields(map[string]any{
+		"prompt_cache_key": "cache-2",
+		"tenant":           "tenant-a",
+	})(opts)
+
+	assert.Equal(t, "cache-2", opts.ModelRequestExtraFields["prompt_cache_key"])
+	assert.Equal(t, "tenant-a", opts.ModelRequestExtraFields["tenant"])
+}
+
 func TestWithInvocationBranch(t *testing.T) {
 	inv := NewInvocation(
 		WithInvocationBranch("test-branch"),

--- a/graph/state_graph.go
+++ b/graph/state_graph.go
@@ -1394,6 +1394,17 @@ func applyInvocationRequestOverrides(
 	if invocation.RunOptions.Stream != nil {
 		request.GenerationConfig.Stream = *invocation.RunOptions.Stream
 	}
+	if len(invocation.RunOptions.ModelRequestExtraFields) > 0 {
+		if request.ExtraFields == nil {
+			request.ExtraFields = make(
+				map[string]any,
+				len(invocation.RunOptions.ModelRequestExtraFields),
+			)
+		}
+		for key, value := range invocation.RunOptions.ModelRequestExtraFields {
+			request.ExtraFields[key] = value
+		}
+	}
 }
 
 func extractModelResponseSummary(result any) (string, string) {

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -1049,6 +1049,12 @@ func cloneRequestForContextCompaction(req *model.Request) *model.Request {
 	cloned.StructuredOutput = cloneStructuredOutputForContextCompaction(
 		req.StructuredOutput,
 	)
+	if req.ExtraFields != nil {
+		cloned.ExtraFields = make(map[string]any, len(req.ExtraFields))
+		for key, value := range req.ExtraFields {
+			cloned.ExtraFields[key] = value
+		}
+	}
 	if req.Tools != nil {
 		cloned.Tools = make(map[string]tool.Tool, len(req.Tools))
 		for name, t := range req.Tools {

--- a/internal/flow/processor/basic.go
+++ b/internal/flow/processor/basic.go
@@ -82,6 +82,17 @@ func (p *BasicRequestProcessor) ProcessRequest(
 	if invocation.RunOptions.Stream != nil {
 		req.GenerationConfig.Stream = *invocation.RunOptions.Stream
 	}
+	if len(invocation.RunOptions.ModelRequestExtraFields) > 0 {
+		if req.ExtraFields == nil {
+			req.ExtraFields = make(
+				map[string]any,
+				len(invocation.RunOptions.ModelRequestExtraFields),
+			)
+		}
+		for key, value := range invocation.RunOptions.ModelRequestExtraFields {
+			req.ExtraFields[key] = value
+		}
+	}
 
 	// Propagate structured output from invocation to request if present.
 	if invocation.StructuredOutput != nil {

--- a/internal/flow/processor/basic_test.go
+++ b/internal/flow/processor/basic_test.go
@@ -114,6 +114,35 @@ func TestBasicReqProc_ProcessReq(t *testing.T) {
 	}
 }
 
+func TestBasicReqProc_ModelRequestExtraFields(t *testing.T) {
+	fields := map[string]any{
+		"prompt_cache_key": "cache-1",
+	}
+	req := &model.Request{}
+	inv := &agent.Invocation{
+		AgentName:    "test-agent",
+		InvocationID: "test-123",
+		RunOptions: agent.RunOptions{
+			ModelRequestExtraFields: fields,
+		},
+	}
+
+	NewBasicRequestProcessor().ProcessRequest(
+		context.Background(),
+		inv,
+		req,
+		make(chan *event.Event, 1),
+	)
+	fields["prompt_cache_key"] = "changed"
+
+	if req.ExtraFields["prompt_cache_key"] != "cache-1" {
+		t.Fatalf(
+			"ProcessRequest() got extra field %v, want cache-1",
+			req.ExtraFields["prompt_cache_key"],
+		)
+	}
+}
+
 // Helper functions for test data
 func intPtr(i int) *int {
 	return &i

--- a/model/failover/failover.go
+++ b/model/failover/failover.go
@@ -235,6 +235,12 @@ func cloneRequest(request *model.Request) (*model.Request, error) {
 	if err := json.Unmarshal(payload, &cloned); err != nil {
 		return nil, fmt.Errorf("unmarshal request: %w", err)
 	}
+	if len(request.ExtraFields) > 0 {
+		cloned.ExtraFields = make(map[string]any, len(request.ExtraFields))
+		for key, value := range request.ExtraFields {
+			cloned.ExtraFields[key] = value
+		}
+	}
 	if len(request.Tools) > 0 {
 		cloned.Tools = make(map[string]tool.Tool, len(request.Tools))
 		for name, toolImpl := range request.Tools {

--- a/model/failover/failover_test.go
+++ b/model/failover/failover_test.go
@@ -77,6 +77,9 @@ func TestCloneRequestDeepCopiesSerializableFields(t *testing.T) {
 				},
 			},
 		},
+		ExtraFields: map[string]any{
+			"prompt_cache_key": "cache-1",
+		},
 		Tools: map[string]tool.Tool{
 			"lookup": toolImpl,
 		},
@@ -90,8 +93,10 @@ func TestCloneRequestDeepCopiesSerializableFields(t *testing.T) {
 	cloned.Messages[1].Content = "changed"
 	cloned.StructuredOutput.JSONSchema.Name = "changed"
 	cloned.StructuredOutput.JSONSchema.Schema["type"] = "array"
+	cloned.ExtraFields["prompt_cache_key"] = "changed"
 	cloned.Tools["other"] = stubTool{name: "other"}
 	assert.Equal(t, "user", request.Messages[1].Content)
+	assert.Equal(t, "cache-1", request.ExtraFields["prompt_cache_key"])
 	assert.Equal(t, "answer", request.StructuredOutput.JSONSchema.Name)
 	assert.Equal(t, "object", request.StructuredOutput.JSONSchema.Schema["type"])
 	assert.Len(t, request.Tools, 1)

--- a/model/hedge/hedge.go
+++ b/model/hedge/hedge.go
@@ -510,6 +510,12 @@ func cloneRequest(request *model.Request) (*model.Request, error) {
 	if err := json.Unmarshal(payload, &cloned); err != nil {
 		return nil, fmt.Errorf("unmarshal request: %w", err)
 	}
+	if len(request.ExtraFields) > 0 {
+		cloned.ExtraFields = make(map[string]any, len(request.ExtraFields))
+		for key, value := range request.ExtraFields {
+			cloned.ExtraFields[key] = value
+		}
+	}
 	if len(request.Tools) > 0 {
 		cloned.Tools = make(map[string]tool.Tool, len(request.Tools))
 		for name, toolImpl := range request.Tools {

--- a/model/hedge/hedge_test.go
+++ b/model/hedge/hedge_test.go
@@ -107,6 +107,9 @@ func TestCloneRequestDeepCopiesSerializableFields(t *testing.T) {
 				},
 			},
 		},
+		ExtraFields: map[string]any{
+			"prompt_cache_key": "cache-1",
+		},
 		Tools: map[string]tool.Tool{
 			"lookup": toolImpl,
 		},
@@ -120,8 +123,10 @@ func TestCloneRequestDeepCopiesSerializableFields(t *testing.T) {
 	cloned.Messages[1].Content = "changed"
 	cloned.StructuredOutput.JSONSchema.Name = "changed"
 	cloned.StructuredOutput.JSONSchema.Schema["type"] = "array"
+	cloned.ExtraFields["prompt_cache_key"] = "changed"
 	cloned.Tools["other"] = stubTool{name: "other"}
 	assert.Equal(t, "user", request.Messages[1].Content)
+	assert.Equal(t, "cache-1", request.ExtraFields["prompt_cache_key"])
 	assert.Equal(t, "answer", request.StructuredOutput.JSONSchema.Name)
 	assert.Equal(t, "object", request.StructuredOutput.JSONSchema.Schema["type"])
 	assert.Len(t, request.Tools, 1)

--- a/model/huggingface/converter.go
+++ b/model/huggingface/converter.go
@@ -32,6 +32,10 @@ func (m *Model) convertRequest(req *model.Request) (*ChatCompletionRequest, erro
 		ExtraFields:      make(map[string]any),
 	}
 
+	for key, value := range req.ExtraFields {
+		hfReq.ExtraFields[key] = value
+	}
+
 	// Convert messages.
 	for _, msg := range req.Messages {
 		hfMsg, err := convertMessage(msg)

--- a/model/huggingface/huggingface_test.go
+++ b/model/huggingface/huggingface_test.go
@@ -3602,8 +3602,9 @@ func TestGenerateContent_WithExtraFields(t *testing.T) {
 		var req map[string]any
 		json.NewDecoder(r.Body).Decode(&req)
 
-		// Verify extra fields are present
-		assert.Equal(t, "custom_value", req["custom_field"])
+		// Verify extra fields are present and request-level fields take precedence.
+		assert.Equal(t, "request_value", req["custom_field"])
+		assert.Equal(t, "cache-1", req["prompt_cache_key"])
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(ChatCompletionResponse{
@@ -3638,6 +3639,10 @@ func TestGenerateContent_WithExtraFields(t *testing.T) {
 	request := &model.Request{
 		Messages: []model.Message{
 			{Role: "user", Content: "Hello"},
+		},
+		ExtraFields: map[string]any{
+			"custom_field":     "request_value",
+			"prompt_cache_key": "cache-1",
 		},
 	}
 

--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -639,8 +639,12 @@ func (m *Model) buildChatRequest(request *model.Request) (*openai.ChatCompletion
 		chatRequest.ReasoningEffort = shared.ReasoningEffort(*request.ReasoningEffort)
 	}
 	opts := m.buildThinkingOption(request)
-	// Add extra fields to the request
+	// Add model-level extra fields to the request.
 	for key, value := range m.extraFields {
+		opts = append(opts, openaiopt.WithJSONSet(key, value))
+	}
+	// Add request-level extra fields after model-level fields so they take precedence.
+	for key, value := range request.ExtraFields {
 		opts = append(opts, openaiopt.WithJSONSet(key, value))
 	}
 

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -4567,12 +4567,60 @@ func TestBuildChatRequest_WithExtraFields(t *testing.T) {
 			model.NewUserMessage("test"),
 		},
 		GenerationConfig: model.GenerationConfig{},
+		ExtraFields: map[string]any{
+			"prompt_cache_key": "cache-1",
+		},
 	}
 
 	chatReq, reqOpts := m.buildChatRequest(req)
 	assert.Equal(t, "gpt-3.5-turbo", chatReq.Model, "expected model to be gpt-3.5-turbo")
-	// Extra fields should be included in reqOpts
-	assert.NotEmpty(t, reqOpts, "expected request options to be present")
+	// Extra fields should be included in reqOpts.
+	assert.Len(t, reqOpts, 3, "expected model and request extra fields to be present")
+}
+
+func TestModel_GenerateContent_RequestExtraFieldsOverrideModelExtraFields(t *testing.T) {
+	var captured map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/chat/completions") {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&captured))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-test",
+			"object":"chat.completion",
+			"created":123,
+			"model":"gpt-3.5-turbo",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]
+		}`))
+	}))
+	defer server.Close()
+
+	m := New(
+		"gpt-3.5-turbo",
+		WithBaseURL(server.URL),
+		WithAPIKey("test-key"),
+		WithExtraFields(map[string]any{
+			"model_field":      "model_value",
+			"prompt_cache_key": "model-cache",
+		}),
+	)
+	req := &model.Request{
+		Messages: []model.Message{model.NewUserMessage("test")},
+		ExtraFields: map[string]any{
+			"prompt_cache_key": "request-cache",
+		},
+	}
+
+	responseChan, err := m.GenerateContent(context.Background(), req)
+	require.NoError(t, err)
+	for range responseChan {
+	}
+
+	require.NotNil(t, captured)
+	assert.Equal(t, "model_value", captured["model_field"])
+	assert.Equal(t, "request-cache", captured["prompt_cache_key"])
 }
 
 // TestNew_WithAllOptions tests creating a model with all available options.

--- a/model/request.go
+++ b/model/request.go
@@ -451,6 +451,11 @@ type Request struct {
 	// JSON formatting. This field is optional and provider-agnostic.
 	StructuredOutput *StructuredOutput `json:"structured_output,omitempty"`
 
+	// ExtraFields stores provider-specific top-level request body fields.
+	// Model adapters merge these with model-level extra fields when supported;
+	// request-level values take precedence.
+	ExtraFields map[string]any `json:"-"`
+
 	Tools map[string]tool.Tool `json:"-"` // Tools are not serialized, handled separately
 }
 


### PR DESCRIPTION
## Summary
- add request-scoped model extra fields to RunOptions and model.Request
- pass extra fields through LLM, graph, failover, and hedge request paths
- merge request-level extra fields in OpenAI-compatible adapters with request values taking precedence

## Tests
- go test ./model/failover ./model/hedge ./agent ./internal/flow/processor ./internal/flow/llmflow ./graph ./model/openai ./model/huggingface