### PR TITLE
codeexecutor/workspaceio: add Workspace facade for in-process file & exec ops

### DIFF
--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -1466,13 +1466,23 @@ func (a *LLMAgent) setupInvocation(invocation *agent.Invocation) {
 // the same invocation workspace as workspace_exec. The helper is a
 // no-op when the agent has no code executor configured.
 func (a *LLMAgent) withWorkspace(ctx context.Context) context.Context {
-	if a == nil || a.codeExecutor == nil {
+	if a == nil {
+		return ctx
+	}
+	// a.codeExecutor / a.workspaceRegistry can be mutated under a.mu
+	// by tool refresh paths (refreshToolsLocked → workspaceRegistryForKeyLocked);
+	// snapshot under RLock to avoid a data race with concurrent Run().
+	a.mu.RLock()
+	exec := a.codeExecutor
+	reg := a.workspaceRegistry
+	a.mu.RUnlock()
+	if exec == nil {
 		return ctx
 	}
 	if _, ok := workspaceio.WorkspaceFromContext(ctx); ok {
 		return ctx
 	}
-	ws := workspaceio.New(a.codeExecutor, a.workspaceRegistry)
+	ws := workspaceio.New(exec, reg)
 	return workspaceio.WithWorkspace(ctx, ws)
 }
 

--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -1256,6 +1256,29 @@ func codeExecutorSupportsWorkspaceExec(exec codeexecutor.CodeExecutor) bool {
 	return eng.Manager() != nil && eng.FS() != nil && eng.Runner() != nil
 }
 
+// codeExecutorHasLiveWorkspace reports whether exec exposes an Engine
+// with Manager + FS — enough to drive Workspace.Collect / PutFiles /
+// StageInputs / SaveArtifact. Looser than
+// codeExecutorSupportsWorkspaceExec, which additionally requires
+// Runner for the workspace_exec LLM tool. Workspace.RunProgram still
+// surfaces a targeted "no program runner" error when Runner is nil,
+// so executors that intentionally omit ProgramRunner can keep the
+// other facade methods usable from callbacks.
+func codeExecutorHasLiveWorkspace(exec codeexecutor.CodeExecutor) bool {
+	if exec == nil {
+		return false
+	}
+	ep, ok := exec.(codeexecutor.EngineProvider)
+	if !ok || ep == nil {
+		return false
+	}
+	eng := ep.Engine()
+	if eng == nil {
+		return false
+	}
+	return eng.Manager() != nil && eng.FS() != nil
+}
+
 // executorSupportsWorkspaceExecSessions reports whether workspace_exec can
 // expose interactive session helpers such as workspace_write_stdin.
 func executorSupportsWorkspaceExecSessions(options *Options) bool {
@@ -1483,7 +1506,12 @@ func (a *LLMAgent) withWorkspace(
 		return ctx
 	}
 	exec := a.codeExecutorForInvocation(inv)
-	if !codeExecutorSupportsWorkspaceExec(exec) {
+	// Gate on "live workspace" (Manager + FS) rather than
+	// "workspace_exec" (Manager + FS + Runner). Executors that
+	// intentionally omit ProgramRunner can still serve Collect /
+	// PutFiles / StageInputs / SaveArtifact through the facade;
+	// RunProgram itself returns a targeted error when Runner is nil.
+	if !codeExecutorHasLiveWorkspace(exec) {
 		return ctx
 	}
 	reg := a.workspaceRegistryForInvocation(inv, exec)

--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -24,6 +24,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
 	localexec "trpc.group/trpc-go/trpc-agent-go/codeexecutor/local"
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor/workspaceio"
 	"trpc.group/trpc-go/trpc-agent-go/event"
 	iagent "trpc.group/trpc-go/trpc-agent-go/internal/agent"
 	"trpc.group/trpc-go/trpc-agent-go/internal/flow"
@@ -1293,6 +1294,7 @@ func codeExecutorSupportsWorkspaceExecSessions(
 // It executes the LLM agent flow and returns a channel of events.
 func (a *LLMAgent) Run(ctx context.Context, invocation *agent.Invocation) (e <-chan *event.Event, err error) {
 	a.setupInvocation(invocation)
+	ctx = a.withWorkspace(ctx)
 	ctx, span, startedSpan := itrace.StartSpan(
 		ctx,
 		invocation,
@@ -1457,6 +1459,21 @@ func (a *LLMAgent) setupInvocation(invocation *agent.Invocation) {
 	// treat them as "no limit", preserving existing behavior.
 	invocation.MaxLLMCalls = a.option.MaxLLMCalls
 	invocation.MaxToolIterations = a.option.MaxToolIterations
+}
+
+// withWorkspace installs a workspaceio.Workspace into ctx so that
+// AgentCallbacks (BeforeAgent/AfterAgent/BeforeTool/AfterTool) observe
+// the same invocation workspace as workspace_exec. The helper is a
+// no-op when the agent has no code executor configured.
+func (a *LLMAgent) withWorkspace(ctx context.Context) context.Context {
+	if a == nil || a.codeExecutor == nil {
+		return ctx
+	}
+	if _, ok := workspaceio.WorkspaceFromContext(ctx); ok {
+		return ctx
+	}
+	ws := workspaceio.New(a.codeExecutor, a.workspaceRegistry)
+	return workspaceio.WithWorkspace(ctx, ws)
 }
 
 // wrapEventChannel wraps the event channel to apply after agent callbacks.

--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -1294,7 +1294,7 @@ func codeExecutorSupportsWorkspaceExecSessions(
 // It executes the LLM agent flow and returns a channel of events.
 func (a *LLMAgent) Run(ctx context.Context, invocation *agent.Invocation) (e <-chan *event.Event, err error) {
 	a.setupInvocation(invocation)
-	ctx = a.withWorkspace(ctx)
+	ctx = a.withWorkspace(ctx, invocation)
 	ctx, span, startedSpan := itrace.StartSpan(
 		ctx,
 		invocation,
@@ -1463,25 +1463,30 @@ func (a *LLMAgent) setupInvocation(invocation *agent.Invocation) {
 
 // withWorkspace installs a workspaceio.Workspace into ctx so that
 // AgentCallbacks (BeforeAgent/AfterAgent/BeforeTool/AfterTool) observe
-// the same invocation workspace as workspace_exec. The helper is a
-// no-op when the agent has no code executor configured.
-func (a *LLMAgent) withWorkspace(ctx context.Context) context.Context {
+// the same invocation workspace as workspace_exec.
+//
+// The helper resolves the effective executor and registry the same
+// way InvocationToolSurface does — honoring an invocation-scoped
+// RunOptions.CodeExecutor override and only installing a facade when
+// the executor actually supports workspace execution. This keeps the
+// callback view and the workspace_exec tool view in lockstep across
+// run-options overrides; otherwise callbacks could read or write a
+// stale executor while the LLM tool uses the override.
+func (a *LLMAgent) withWorkspace(
+	ctx context.Context,
+	inv *agent.Invocation,
+) context.Context {
 	if a == nil {
-		return ctx
-	}
-	// a.codeExecutor / a.workspaceRegistry can be mutated under a.mu
-	// by tool refresh paths (refreshToolsLocked → workspaceRegistryForKeyLocked);
-	// snapshot under RLock to avoid a data race with concurrent Run().
-	a.mu.RLock()
-	exec := a.codeExecutor
-	reg := a.workspaceRegistry
-	a.mu.RUnlock()
-	if exec == nil {
 		return ctx
 	}
 	if _, ok := workspaceio.WorkspaceFromContext(ctx); ok {
 		return ctx
 	}
+	exec := a.codeExecutorForInvocation(inv)
+	if !codeExecutorSupportsWorkspaceExec(exec) {
+		return ctx
+	}
+	reg := a.workspaceRegistryForInvocation(inv, exec)
 	ws := workspaceio.New(exec, reg)
 	return workspaceio.WithWorkspace(ctx, ws)
 }

--- a/agent/llmagent/workspace_io_test.go
+++ b/agent/llmagent/workspace_io_test.go
@@ -63,6 +63,47 @@ func TestLLMAgent_Run_InstallsWorkspaceInContext(t *testing.T) {
 	require.NotNil(t, captured)
 }
 
+// TestLLMAgent_Run_PreservesExistingWorkspaceInContext verifies the
+// short-circuit branch in withWorkspace: when ctx already carries a
+// Workspace (e.g. installed by an outer agent in a composition), Run
+// must not overwrite it with a fresh facade.
+func TestLLMAgent_Run_PreservesExistingWorkspaceInContext(t *testing.T) {
+	exec := localexec.New()
+	existing := workspaceio.New(exec, nil)
+
+	var captured *workspaceio.Workspace
+	var captureOK bool
+	cb := agent.NewCallbacks()
+	cb.RegisterBeforeAgent(func(ctx context.Context, args *agent.BeforeAgentArgs) (*agent.BeforeAgentResult, error) {
+		captured, captureOK = workspaceio.WorkspaceFromContext(ctx)
+		return nil, nil
+	})
+
+	a := New("agent",
+		WithCodeExecutor(exec),
+		WithAgentCallbacks(cb),
+	)
+	a.flow = &mockFlow{done: true}
+
+	inv := agent.NewInvocation(
+		agent.WithInvocationID("inv-preserve-ws"),
+		agent.WithInvocationMessage(model.NewUserMessage("hi")),
+		agent.WithInvocationSession(&session.Session{
+			ID: "s1", AppName: "app", UserID: "user",
+		}),
+	)
+
+	ctx := workspaceio.WithWorkspace(context.Background(), existing)
+	events, err := a.Run(ctx, inv)
+	require.NoError(t, err)
+	for range events {
+	}
+
+	require.True(t, captureOK, "BeforeAgent should still see a Workspace")
+	require.Same(t, existing, captured,
+		"withWorkspace must not overwrite an already-installed Workspace")
+}
+
 func TestLLMAgent_Run_WithoutCodeExecutor_NoWorkspaceInContext(t *testing.T) {
 	var captureOK bool
 

--- a/agent/llmagent/workspace_io_test.go
+++ b/agent/llmagent/workspace_io_test.go
@@ -105,10 +105,16 @@ func TestLLMAgent_Run_PreservesExistingWorkspaceInContext(t *testing.T) {
 }
 
 func TestLLMAgent_Run_WithoutCodeExecutor_NoWorkspaceInContext(t *testing.T) {
+	// captureOK defaults to false, so require.False alone would also pass
+	// if the callback never ran. Pin "callback was invoked" explicitly via
+	// `called` so the negative assertion can't quietly turn into a no-op
+	// after future refactors of LLMAgent.Run.
+	var called bool
 	var captureOK bool
 
 	cb := agent.NewCallbacks()
 	cb.RegisterBeforeAgent(func(ctx context.Context, args *agent.BeforeAgentArgs) (*agent.BeforeAgentResult, error) {
+		called = true
 		_, captureOK = workspaceio.WorkspaceFromContext(ctx)
 		return nil, nil
 	})
@@ -129,5 +135,6 @@ func TestLLMAgent_Run_WithoutCodeExecutor_NoWorkspaceInContext(t *testing.T) {
 	for range events {
 	}
 
+	require.True(t, called, "BeforeAgent callback must run for the negative assertion below to be meaningful")
 	require.False(t, captureOK, "no Workspace should be installed when no executor is configured")
 }

--- a/agent/llmagent/workspace_io_test.go
+++ b/agent/llmagent/workspace_io_test.go
@@ -1,0 +1,92 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package llmagent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	localexec "trpc.group/trpc-go/trpc-agent-go/codeexecutor/local"
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor/workspaceio"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+// TestLLMAgent_Run_InstallsWorkspaceInContext verifies that callbacks
+// receive a ready-to-use Workspace via WorkspaceFromContext when the
+// agent is configured with a CodeExecutor. This is the only integration
+// guarantee llmagent makes around the facade; sink composition,
+// truncation, and budget policy are the caller's responsibility.
+func TestLLMAgent_Run_InstallsWorkspaceInContext(t *testing.T) {
+	exec := localexec.New()
+
+	var captured *workspaceio.Workspace
+	var captureOK bool
+
+	cb := agent.NewCallbacks()
+	cb.RegisterBeforeAgent(func(ctx context.Context, args *agent.BeforeAgentArgs) (*agent.BeforeAgentResult, error) {
+		captured, captureOK = workspaceio.WorkspaceFromContext(ctx)
+		return nil, nil
+	})
+
+	a := New("agent",
+		WithCodeExecutor(exec),
+		WithAgentCallbacks(cb),
+	)
+	a.flow = &mockFlow{done: true}
+
+	inv := agent.NewInvocation(
+		agent.WithInvocationID("inv-wsio-ctx"),
+		agent.WithInvocationMessage(model.NewUserMessage("hi")),
+		agent.WithInvocationSession(&session.Session{
+			ID: "s1", AppName: "app", UserID: "user",
+		}),
+	)
+
+	events, err := a.Run(context.Background(), inv)
+	require.NoError(t, err)
+	for range events {
+	}
+
+	require.True(t, captureOK, "WorkspaceFromContext should resolve when WithCodeExecutor is configured")
+	require.NotNil(t, captured)
+}
+
+func TestLLMAgent_Run_WithoutCodeExecutor_NoWorkspaceInContext(t *testing.T) {
+	var captureOK bool
+
+	cb := agent.NewCallbacks()
+	cb.RegisterBeforeAgent(func(ctx context.Context, args *agent.BeforeAgentArgs) (*agent.BeforeAgentResult, error) {
+		_, captureOK = workspaceio.WorkspaceFromContext(ctx)
+		return nil, nil
+	})
+
+	a := New("agent", WithAgentCallbacks(cb))
+	a.flow = &mockFlow{done: true}
+
+	inv := agent.NewInvocation(
+		agent.WithInvocationID("inv-noexec"),
+		agent.WithInvocationMessage(model.NewUserMessage("hi")),
+		agent.WithInvocationSession(&session.Session{
+			ID: "s1", AppName: "app", UserID: "user",
+		}),
+	)
+
+	events, err := a.Run(context.Background(), inv)
+	require.NoError(t, err)
+	for range events {
+	}
+
+	require.False(t, captureOK, "no Workspace should be installed when no executor is configured")
+}

--- a/agent/llmagent/workspace_io_test.go
+++ b/agent/llmagent/workspace_io_test.go
@@ -17,11 +17,31 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
 	localexec "trpc.group/trpc-go/trpc-agent-go/codeexecutor/local"
 	"trpc.group/trpc-go/trpc-agent-go/codeexecutor/workspaceio"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 )
+
+// liveButNoRunnerExec implements codeexecutor.CodeExecutor +
+// EngineProvider with FS + Manager but Runner=nil — mirroring real
+// executors that intentionally omit ProgramRunner.
+type liveButNoRunnerExec struct {
+	eng codeexecutor.Engine
+}
+
+func (l *liveButNoRunnerExec) ExecuteCode(
+	context.Context, codeexecutor.CodeExecutionInput,
+) (codeexecutor.CodeExecutionResult, error) {
+	return codeexecutor.CodeExecutionResult{}, nil
+}
+
+func (l *liveButNoRunnerExec) CodeBlockDelimiter() codeexecutor.CodeBlockDelimiter {
+	return codeexecutor.CodeBlockDelimiter{}
+}
+
+func (l *liveButNoRunnerExec) Engine() codeexecutor.Engine { return l.eng }
 
 // TestLLMAgent_Run_InstallsWorkspaceInContext verifies that callbacks
 // receive a ready-to-use Workspace via WorkspaceFromContext when the
@@ -102,6 +122,46 @@ func TestLLMAgent_Run_PreservesExistingWorkspaceInContext(t *testing.T) {
 	require.True(t, captureOK, "BeforeAgent should still see a Workspace")
 	require.Same(t, existing, captured,
 		"withWorkspace must not overwrite an already-installed Workspace")
+}
+
+// TestLLMAgent_Run_InstallsWorkspaceWhenRunnerNil pins withWorkspace's
+// gate at "live workspace" (FS + Manager) rather than "workspace_exec"
+// (FS + Manager + Runner). Executors that legitimately omit
+// ProgramRunner can still serve Collect / PutFiles / StageInputs /
+// SaveArtifact through the callback-side facade; RunProgram itself
+// surfaces a targeted error when Runner is nil.
+func TestLLMAgent_Run_InstallsWorkspaceWhenRunnerNil(t *testing.T) {
+	rt := localexec.NewRuntime("")
+	eng := codeexecutor.NewEngine(rt, rt, nil) // Manager + FS but no Runner
+	exec := &liveButNoRunnerExec{eng: eng}
+
+	var called, captureOK bool
+	cb := agent.NewCallbacks()
+	cb.RegisterBeforeAgent(func(ctx context.Context, args *agent.BeforeAgentArgs) (*agent.BeforeAgentResult, error) {
+		called = true
+		_, captureOK = workspaceio.WorkspaceFromContext(ctx)
+		return nil, nil
+	})
+
+	a := New("agent", WithCodeExecutor(exec), WithAgentCallbacks(cb))
+	a.flow = &mockFlow{done: true}
+
+	inv := agent.NewInvocation(
+		agent.WithInvocationID("inv-norunner"),
+		agent.WithInvocationMessage(model.NewUserMessage("hi")),
+		agent.WithInvocationSession(&session.Session{
+			ID: "s1", AppName: "app", UserID: "user",
+		}),
+	)
+
+	events, err := a.Run(context.Background(), inv)
+	require.NoError(t, err)
+	for range events {
+	}
+
+	require.True(t, called, "BeforeAgent must have run")
+	require.True(t, captureOK,
+		"withWorkspace must accept FS+Manager-only executors; RunProgram surfaces a targeted error when Runner is nil")
 }
 
 // TestLLMAgent_Run_HonorsRunOptionsCodeExecutorForWorkspace pins the

--- a/agent/llmagent/workspace_io_test.go
+++ b/agent/llmagent/workspace_io_test.go
@@ -104,6 +104,47 @@ func TestLLMAgent_Run_PreservesExistingWorkspaceInContext(t *testing.T) {
 		"withWorkspace must not overwrite an already-installed Workspace")
 }
 
+// TestLLMAgent_Run_HonorsRunOptionsCodeExecutorForWorkspace pins the
+// contract that withWorkspace resolves the *effective* executor via
+// codeExecutorForInvocation — same as workspace_exec / skill_run.
+// Pre-fix, withWorkspace read a.codeExecutor unconditionally so when
+// the executor only came from RunOptions, callbacks saw no Workspace
+// even though the LLM tools used the override. Now they stay in sync.
+func TestLLMAgent_Run_HonorsRunOptionsCodeExecutorForWorkspace(t *testing.T) {
+	runExec := localexec.New()
+
+	var called, captureOK bool
+	cb := agent.NewCallbacks()
+	cb.RegisterBeforeAgent(func(ctx context.Context, args *agent.BeforeAgentArgs) (*agent.BeforeAgentResult, error) {
+		called = true
+		_, captureOK = workspaceio.WorkspaceFromContext(ctx)
+		return nil, nil
+	})
+
+	a := New("agent", WithAgentCallbacks(cb)) // no WithCodeExecutor
+	a.flow = &mockFlow{done: true}
+
+	inv := agent.NewInvocation(
+		agent.WithInvocationID("inv-runopts"),
+		agent.WithInvocationMessage(model.NewUserMessage("hi")),
+		agent.WithInvocationSession(&session.Session{
+			ID: "s1", AppName: "app", UserID: "user",
+		}),
+		agent.WithInvocationRunOptions(agent.NewRunOptions(
+			agent.WithCodeExecutor(runExec),
+		)),
+	)
+
+	events, err := a.Run(context.Background(), inv)
+	require.NoError(t, err)
+	for range events {
+	}
+
+	require.True(t, called, "BeforeAgent must have run")
+	require.True(t, captureOK,
+		"withWorkspace must honor RunOptions.CodeExecutor for installing the facade")
+}
+
 func TestLLMAgent_Run_WithoutCodeExecutor_NoWorkspaceInContext(t *testing.T) {
 	// captureOK defaults to false, so require.False alone would also pass
 	// if the callback never ran. Pin "callback was invoked" explicitly via

--- a/codeexecutor/workspaceio/context.go
+++ b/codeexecutor/workspaceio/context.go
@@ -1,0 +1,41 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package workspaceio
+
+import "context"
+
+type workspaceCtxKey struct{}
+
+// WithWorkspace binds w to ctx so callbacks down the chain can resolve
+// it via WorkspaceFromContext. Returns ctx unchanged when w is nil so
+// callers don't accidentally mask "no executor configured" with a
+// non-nil sentinel.
+func WithWorkspace(ctx context.Context, w *Workspace) context.Context {
+	if ctx == nil || w == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, workspaceCtxKey{}, w)
+}
+
+// WorkspaceFromContext returns the Workspace previously bound via
+// WithWorkspace. The boolean return is false when no Workspace was
+// installed for the current invocation, allowing callers to gracefully
+// fall back when the agent has no code executor configured.
+func WorkspaceFromContext(ctx context.Context) (*Workspace, bool) {
+	if ctx == nil {
+		return nil, false
+	}
+	w, ok := ctx.Value(workspaceCtxKey{}).(*Workspace)
+	if !ok || w == nil {
+		return nil, false
+	}
+	return w, true
+}

--- a/codeexecutor/workspaceio/workspace_io.go
+++ b/codeexecutor/workspaceio/workspace_io.go
@@ -264,7 +264,12 @@ func (w *Workspace) SaveArtifact(
 		Save:          true,
 		Inline:        false,
 	})
-	if err != nil {
+	// ErrPartialOutputCommit means the artifact already landed in the
+	// service but some non-fatal post-commit work failed (e.g. cleanup
+	// or secondary inline read). Mirror tool/workspaceexec.SaveArtifact
+	// and continue so the caller still gets the persisted ref. Any
+	// other error is fatal.
+	if err != nil && !errors.Is(err, codeexecutor.ErrPartialOutputCommit) {
 		return nil, err
 	}
 	if len(manifest.Files) == 0 {
@@ -296,6 +301,11 @@ func (w *Workspace) SaveArtifact(
 
 // StageInputs maps external inputs (artifact://, host://, workspace://,
 // skill://) into the workspace using the engine's StageInputs primitive.
+//
+// The artifact service and session metadata are forwarded through ctx
+// (matching SaveArtifact) so artifact:// inputs can resolve against the
+// invocation's artifact service. When the invocation does not carry
+// that info ctx is forwarded unchanged.
 func (w *Workspace) StageInputs(
 	ctx context.Context,
 	specs []codeexecutor.InputSpec,
@@ -306,11 +316,12 @@ func (w *Workspace) StageInputs(
 	if len(specs) == 0 {
 		return nil
 	}
-	eng, ws, err := w.bindWorkspace(ctx)
+	ctxIO := workspacefacade.WithArtifactContext(ctx)
+	eng, ws, err := w.bindWorkspace(ctxIO)
 	if err != nil {
 		return err
 	}
-	return eng.FS().StageInputs(ctx, ws, specs)
+	return eng.FS().StageInputs(ctxIO, ws, specs)
 }
 
 // RunProgram executes a program inside the current invocation's
@@ -319,11 +330,12 @@ func (w *Workspace) StageInputs(
 //
 // The returned error is non-nil only for framework-level failures
 // (no executor configured, backend rejection, launch error, internal
-// timeout). A non-zero exit code is signaled via RunResult.ExitCode
-// and is NOT an error — callers inspect ExitCode / TimedOut on the
-// returned RunResult and decide whether to fail, retry, or accept the
-// outcome themselves. This matches the convention used by Go's
-// os/exec.Cmd.Run and by the workspace_exec LLM tool.
+// timeout, or an out-of-workspace Cwd). A non-zero exit code is
+// signaled via RunResult.ExitCode and is NOT an error — callers
+// inspect ExitCode / TimedOut on the returned RunResult and decide
+// whether to fail, retry, or accept the outcome themselves. This
+// matches the convention used by Go's os/exec.Cmd.Run and by the
+// workspace_exec LLM tool.
 func (w *Workspace) RunProgram(
 	ctx context.Context,
 	spec codeexecutor.RunProgramSpec,
@@ -333,6 +345,17 @@ func (w *Workspace) RunProgram(
 			"workspaceio: workspace is nil",
 		)
 	}
+	// Normalize Cwd through the same containment policy used by the
+	// workspace_exec LLM tool so the godoc claim "cannot escape the
+	// workspace" is actually enforced, not left to each backend. The
+	// local runtime in particular happily joins ws.Path with
+	// filepath.Clean(spec.Cwd) and would otherwise let "../.." run
+	// outside the workspace.
+	cwd, err := workspacefacade.NormalizeWorkspaceCWD(spec.Cwd)
+	if err != nil {
+		return codeexecutor.RunResult{}, err
+	}
+	spec.Cwd = cwd
 	eng, ws, err := w.bindWorkspace(ctx)
 	if err != nil {
 		return codeexecutor.RunResult{}, err

--- a/codeexecutor/workspaceio/workspace_io.go
+++ b/codeexecutor/workspaceio/workspace_io.go
@@ -177,7 +177,7 @@ func (w *Workspace) Collect(
 		return nil, errors.New("workspaceio: workspace is nil")
 	}
 	if len(patterns) == 0 {
-		return nil, nil
+		return []*File{}, nil
 	}
 	eng, ws, err := w.bindWorkspace(ctx)
 	if err != nil {

--- a/codeexecutor/workspaceio/workspace_io.go
+++ b/codeexecutor/workspaceio/workspace_io.go
@@ -1,0 +1,386 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+// Package workspaceio exposes Workspace, a thin Go-facing facade over
+// codeexecutor.WorkspaceFS + ProgramRunner bound to the current
+// invocation's workspace. It is the entry point business code uses
+// from agent callbacks (and custom tools) to read, write, persist,
+// stage, and run programs against workspace files without taking a
+// dependency on a specific executor backend.
+//
+// Naming note: the package is workspaceio because the project's
+// existing convention is workspace<action-class> (workspaceinput,
+// workspaceprep, workspacesession, workspacefacade, workspaceexec);
+// the type is Workspace because industry sandbox SDKs (E2B / Modal /
+// Daytona / Vercel) all reserve the resource name for the
+// behavior-bearing handle. codeexecutor.Workspace (descriptor) and
+// workspaceio.Workspace (facade) coexist permanently — the descriptor
+// type is a v1-published value object that cannot be renamed under
+// Go module compatibility rules. The two types are disambiguated by
+// import path; business code rarely references both in the same file.
+package workspaceio
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
+	"trpc.group/trpc-go/trpc-agent-go/internal/fileref"
+	"trpc.group/trpc-go/trpc-agent-go/internal/workspacefacade"
+	"trpc.group/trpc-go/trpc-agent-go/internal/workspacesession"
+)
+
+// File is an in-memory snapshot of a workspace file produced by
+// Workspace.Collect. It mirrors the fields of codeexecutor.File but
+// uses []byte for Data so callers can mutate it freely. Truncated
+// reports whether the backend hit its internal read cap; the framework
+// does not act on it — callers should check the flag themselves and
+// decide whether to retry, fail, or accept the partial bytes.
+type File struct {
+	Path      string
+	Data      []byte
+	MIMEType  string
+	SizeBytes int64
+	Truncated bool
+}
+
+// ArtifactRef describes a workspace file that has been persisted via
+// Workspace.SaveArtifact. Field names mirror the workspace_save_artifact
+// LLM tool output schema so callers can move between the two without a
+// translation layer.
+type ArtifactRef struct {
+	// SavedAs is the artifact key returned by the artifact service.
+	SavedAs   string
+	Version   int
+	Ref       string
+	MIMEType  string
+	SizeBytes int64
+	// Path is the workspace-relative source path that was persisted.
+	Path string
+}
+
+// Workspace is a thin facade over codeexecutor.WorkspaceFS plus
+// ProgramRunner, bound to the current invocation's workspace. Use
+// WorkspaceFromContext from inside agent callbacks (BeforeAgent /
+// AfterAgent / BeforeTool / AfterTool / BeforeModel / AfterModel /
+// your own tool's Run) to obtain one; tests can also construct one
+// directly via New.
+//
+// The methods are deliberately thin pass-throughs to the underlying
+// codeexecutor backend — the framework does not impose extra budgets,
+// truncation policies, or batch loops on top. Callers that want those
+// policies write them in the callback.
+//
+// Type shape:
+//
+// Workspace is intentionally a concrete type rather than an interface.
+// Backend variation lives one layer below at codeexecutor.WorkspaceFS
+// and codeexecutor.ProgramRunner; Workspace is a single user-facing
+// facade on top of any engine. Promoting it to an interface should
+// wait until a second user-facing implementation actually exists (for
+// example, a remote workspace client speaking RPC instead of going
+// through Engine).
+//
+// The zero value is not usable; obtain a *Workspace via
+// WorkspaceFromContext (or New from tests / framework wiring).
+//
+// Concurrency:
+//
+// Workspace has no internal locking. The struct simply forwards each
+// call to the underlying codeexecutor backend, so concurrent callers
+// inherit whatever guarantees that backend offers. The framework does
+// not standardize those guarantees; in practice callbacks should
+// serialize their workspace operations when ordering matters (a
+// PutFiles followed by a Collect against the same path is the
+// canonical example).
+//
+// Scope and backend caveats:
+//
+//   - Workspace always operates on the current invocation's workspace.
+//     Path arguments are interpreted relative to the workspace root
+//     (or to the workspace ${WORK} / ${OUT} / ${RUNS} env paths).
+//     Workspace never reaches outside the workspace, never touches
+//     the skill / profile store, and never references arbitrary
+//     remote filesystems.
+//   - Whether two nodes can read the same workspace depends entirely
+//     on the executor backend. local/container executors are
+//     single-node by construction; pcg123 + CFS can persist if the
+//     backend is configured to share the same workspace id, and
+//     cube-style sandboxes depend on whether the runtime exposes a
+//     stable workspace handle. Mirror state into your own shared store
+//     from a callback when you need cross-node visibility.
+type Workspace struct {
+	exec     codeexecutor.CodeExecutor
+	resolver *workspacesession.Resolver
+}
+
+// New creates a Workspace backed by exec. When reg is nil the
+// Workspace allocates a private workspace registry; pass the agent's
+// shared registry to reuse the same invocation workspace as
+// workspace_exec.
+//
+// Returns nil when exec is nil so callers can detect "no executor
+// configured" without a panic.
+func New(
+	exec codeexecutor.CodeExecutor,
+	reg *codeexecutor.WorkspaceRegistry,
+) *Workspace {
+	if exec == nil {
+		return nil
+	}
+	return &Workspace{
+		exec:     exec,
+		resolver: workspacesession.NewResolver(exec, reg),
+	}
+}
+
+// SaveArtifactOptions controls Workspace.SaveArtifact behavior.
+type SaveArtifactOptions struct {
+	MaxBytes int64
+}
+
+// SaveArtifactOption mutates SaveArtifactOptions.
+type SaveArtifactOption func(*SaveArtifactOptions)
+
+// WithSaveArtifactMaxBytes caps the size of files persisted via
+// SaveArtifact. The cap is forwarded to the backend's
+// CollectOutputs(MaxFileBytes/MaxTotalBytes) so it gates the read
+// itself, not just a post-check. Files larger than this cap are
+// rejected by the backend.
+func WithSaveArtifactMaxBytes(n int64) SaveArtifactOption {
+	return func(o *SaveArtifactOptions) { o.MaxBytes = n }
+}
+
+// Collect reads every workspace file that matches one of the supplied
+// patterns and returns them as Files. Pattern syntax is identical to
+// codeexecutor.WorkspaceFS.Collect (e.g. "skills/echoer/SKILL.md",
+// "skills/*/SKILL.md", "out/**/*.json"); a single literal path is a
+// valid pattern. An empty pattern list returns an empty slice.
+//
+// Collect does not enforce any per-file or aggregate budget — callers
+// that need one apply it on the returned slice. Each file's Truncated
+// flag is preserved from the backend.
+func (w *Workspace) Collect(
+	ctx context.Context,
+	patterns ...string,
+) ([]*File, error) {
+	if w == nil {
+		return nil, errors.New("workspaceio: workspace is nil")
+	}
+	if len(patterns) == 0 {
+		return nil, nil
+	}
+	eng, ws, err := w.bindWorkspace(ctx)
+	if err != nil {
+		return nil, err
+	}
+	raw, err := eng.FS().Collect(ctx, ws, patterns)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*File, len(raw))
+	for i := range raw {
+		out[i] = toFile(raw[i])
+	}
+	return out, nil
+}
+
+// PutFiles writes a batch of workspace files in one engine call. Each
+// PutFile carries its own path / content / mode; parent directories
+// are created automatically by the engine. An empty list is a no-op.
+//
+// Single-file writes use the same entry point — pass one PutFile.
+// When PutFile.Mode is 0 the local backend falls back to its default
+// mode (0o644); use codeexecutor.DefaultScriptFileMode (0o644) or
+// codeexecutor.DefaultExecFileMode (0o755) when you want to be
+// explicit.
+func (w *Workspace) PutFiles(
+	ctx context.Context,
+	files ...codeexecutor.PutFile,
+) error {
+	if w == nil {
+		return errors.New("workspaceio: workspace is nil")
+	}
+	if len(files) == 0 {
+		return nil
+	}
+	eng, ws, err := w.bindWorkspace(ctx)
+	if err != nil {
+		return err
+	}
+	return eng.FS().PutFiles(ctx, ws, files)
+}
+
+// SaveArtifact persists an existing workspace file as an artifact via
+// the invocation's artifact service. The path must reference a real
+// file inside one of the publish-allowed workspace roots
+// (work/, out/, runs/).
+func (w *Workspace) SaveArtifact(
+	ctx context.Context,
+	relPath string,
+	opts ...SaveArtifactOption,
+) (*ArtifactRef, error) {
+	if w == nil {
+		return nil, errors.New("workspaceio: workspace is nil")
+	}
+	rel, err := workspacefacade.NormalizeArtifactPath(relPath)
+	if err != nil {
+		return nil, err
+	}
+	if reason := workspacefacade.ArtifactSaveSkipReason(ctx); reason != "" {
+		return nil, fmt.Errorf(
+			"workspaceio: artifact persistence requires artifact service and session: %s",
+			reason,
+		)
+	}
+	cfg := SaveArtifactOptions{MaxBytes: workspacefacade.DefaultArtifactMaxBytes}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+	if cfg.MaxBytes <= 0 {
+		cfg.MaxBytes = workspacefacade.DefaultArtifactMaxBytes
+	}
+	ctxIO := workspacefacade.WithArtifactContext(ctx)
+	eng, ws, err := w.bindWorkspace(ctxIO)
+	if err != nil {
+		return nil, err
+	}
+	manifest, err := eng.FS().CollectOutputs(ctxIO, ws, codeexecutor.OutputSpec{
+		Globs:         []string{rel},
+		MaxFiles:      1,
+		MaxFileBytes:  cfg.MaxBytes,
+		MaxTotalBytes: cfg.MaxBytes,
+		Save:          true,
+		Inline:        false,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(manifest.Files) == 0 {
+		return nil, fmt.Errorf(
+			"workspaceio: artifact file not found: %s", rel,
+		)
+	}
+	if len(manifest.Files) > 1 {
+		return nil, fmt.Errorf(
+			"workspaceio: artifact path matched %d files: %s",
+			len(manifest.Files), rel,
+		)
+	}
+	ref := manifest.Files[0]
+	if ref.SavedAs == "" {
+		return nil, fmt.Errorf(
+			"workspaceio: artifact was not persisted: %s", rel,
+		)
+	}
+	return &ArtifactRef{
+		SavedAs:   ref.SavedAs,
+		Version:   ref.Version,
+		Ref:       fileref.ArtifactPrefix + ref.SavedAs + "@" + strconv.Itoa(ref.Version),
+		MIMEType:  ref.MIMEType,
+		SizeBytes: ref.SizeBytes,
+		Path:      rel,
+	}, nil
+}
+
+// StageInputs maps external inputs (artifact://, host://, workspace://,
+// skill://) into the workspace using the engine's StageInputs primitive.
+func (w *Workspace) StageInputs(
+	ctx context.Context,
+	specs []codeexecutor.InputSpec,
+) error {
+	if w == nil {
+		return errors.New("workspaceio: workspace is nil")
+	}
+	if len(specs) == 0 {
+		return nil
+	}
+	eng, ws, err := w.bindWorkspace(ctx)
+	if err != nil {
+		return err
+	}
+	return eng.FS().StageInputs(ctx, ws, specs)
+}
+
+// RunProgram executes a program inside the current invocation's
+// workspace via the engine's ProgramRunner. spec.Cwd is interpreted
+// relative to the workspace root and cannot escape it.
+//
+// The returned error is non-nil only for framework-level failures
+// (no executor configured, backend rejection, launch error, internal
+// timeout). A non-zero exit code is signaled via RunResult.ExitCode
+// and is NOT an error — callers inspect ExitCode / TimedOut on the
+// returned RunResult and decide whether to fail, retry, or accept the
+// outcome themselves. This matches the convention used by Go's
+// os/exec.Cmd.Run and by the workspace_exec LLM tool.
+func (w *Workspace) RunProgram(
+	ctx context.Context,
+	spec codeexecutor.RunProgramSpec,
+) (codeexecutor.RunResult, error) {
+	if w == nil {
+		return codeexecutor.RunResult{}, errors.New(
+			"workspaceio: workspace is nil",
+		)
+	}
+	eng, ws, err := w.bindWorkspace(ctx)
+	if err != nil {
+		return codeexecutor.RunResult{}, err
+	}
+	runner := eng.Runner()
+	if runner == nil {
+		return codeexecutor.RunResult{}, errors.New(
+			"workspaceio: executor does not expose a program runner",
+		)
+	}
+	return runner.RunProgram(ctx, ws, spec)
+}
+
+// bindWorkspace resolves the engine and acquires the invocation workspace.
+func (w *Workspace) bindWorkspace(
+	ctx context.Context,
+) (codeexecutor.Engine, codeexecutor.Workspace, error) {
+	if w == nil || w.resolver == nil {
+		return nil, codeexecutor.Workspace{}, errors.New(
+			"workspaceio: workspace is not initialized",
+		)
+	}
+	eng := w.resolver.EnsureEngine()
+	if eng == nil || eng.FS() == nil || eng.Manager() == nil {
+		return nil, codeexecutor.Workspace{}, errors.New(
+			"workspaceio: executor does not expose a live workspace engine",
+		)
+	}
+	ws, err := w.resolver.CreateWorkspace(ctx, eng, "workspace")
+	if err != nil {
+		return nil, codeexecutor.Workspace{}, err
+	}
+	return eng, ws, nil
+}
+
+// toFile converts a codeexecutor.File into the public File type.
+// The Truncated flag is forwarded as-is so callers can decide whether
+// to retry, fail, or accept the partial bytes.
+func toFile(in codeexecutor.File) *File {
+	size := in.SizeBytes
+	if size <= 0 {
+		size = int64(len(in.Content))
+	}
+	return &File{
+		Path:      in.Name,
+		Data:      []byte(in.Content),
+		MIMEType:  in.MIMEType,
+		SizeBytes: size,
+		Truncated: in.Truncated,
+	}
+}

--- a/codeexecutor/workspaceio/workspace_io_test.go
+++ b/codeexecutor/workspaceio/workspace_io_test.go
@@ -401,6 +401,140 @@ func TestRunProgram_RunnerNil(t *testing.T) {
 	require.Contains(t, err.Error(), "does not expose a program runner")
 }
 
+// stubFSExec implements codeexecutor.CodeExecutor + EngineProvider with
+// a caller-supplied Engine. Used to inject FS doubles below.
+type stubFSExec struct {
+	eng codeexecutor.Engine
+}
+
+func (s *stubFSExec) ExecuteCode(
+	context.Context, codeexecutor.CodeExecutionInput,
+) (codeexecutor.CodeExecutionResult, error) {
+	return codeexecutor.CodeExecutionResult{}, nil
+}
+
+func (s *stubFSExec) CodeBlockDelimiter() codeexecutor.CodeBlockDelimiter {
+	return codeexecutor.CodeBlockDelimiter{}
+}
+
+func (s *stubFSExec) Engine() codeexecutor.Engine { return s.eng }
+
+// partialCommitFS layers ErrPartialOutputCommit on top of a real
+// CollectOutputs response so the SaveArtifact "ignore partial commit
+// when artifact landed" branch can be exercised without reaching for a
+// backend that emits the error organically.
+type partialCommitFS struct {
+	codeexecutor.WorkspaceFS
+}
+
+func (p *partialCommitFS) CollectOutputs(
+	ctx context.Context,
+	ws codeexecutor.Workspace,
+	spec codeexecutor.OutputSpec,
+) (codeexecutor.OutputManifest, error) {
+	m, err := p.WorkspaceFS.CollectOutputs(ctx, ws, spec)
+	if err != nil {
+		return m, err
+	}
+	return m, codeexecutor.ErrPartialOutputCommit
+}
+
+// TestSaveArtifact_PartialCommitStillReturnsRef pins the contract that
+// ErrPartialOutputCommit is non-fatal: the artifact has already been
+// persisted and callers must still receive the ref. Mirrors the same
+// concession in tool/workspaceexec.SaveArtifactTool.Call.
+func TestSaveArtifact_PartialCommitStillReturnsRef(t *testing.T) {
+	rt := localexec.NewRuntime("")
+	fs := &partialCommitFS{WorkspaceFS: rt}
+	eng := codeexecutor.NewEngine(rt, fs, rt)
+	exec := &stubFSExec{eng: eng}
+
+	ws := New(exec, codeexecutor.NewWorkspaceRegistry())
+	svc := inmemory.NewService()
+	inv := agent.NewInvocation(
+		agent.WithInvocationMessage(model.NewUserMessage("hi")),
+		agent.WithInvocationSession(&session.Session{
+			ID: "sess-partial", AppName: "app", UserID: "user",
+		}),
+		agent.WithInvocationArtifactService(svc),
+	)
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+
+	require.NoError(t, ws.PutFiles(ctx, codeexecutor.PutFile{
+		Path: "out/done.txt", Content: []byte("ok"),
+	}))
+
+	ref, err := ws.SaveArtifact(ctx, "out/done.txt")
+	require.NoError(t, err,
+		"ErrPartialOutputCommit must not bubble up when the artifact has landed")
+	require.NotNil(t, ref)
+	require.Equal(t, "out/done.txt", ref.Path)
+	require.NotEmpty(t, ref.SavedAs)
+}
+
+// captureCtxStageFS snapshots the ctx that StageInputs receives without
+// touching the inner backend, so the test can pin "artifact service /
+// session info is forwarded to the backend".
+type captureCtxStageFS struct {
+	codeexecutor.WorkspaceFS
+	gotCtx context.Context
+}
+
+func (c *captureCtxStageFS) StageInputs(
+	ctx context.Context,
+	_ codeexecutor.Workspace,
+	_ []codeexecutor.InputSpec,
+) error {
+	c.gotCtx = ctx
+	return nil
+}
+
+// TestStageInputs_ForwardsArtifactContext pins the contract that
+// StageInputs prepares ctx with the invocation's artifact service /
+// session info, matching what SaveArtifact already does. Without this,
+// `artifact://` inputs can't resolve even though workspace acquisition
+// silently used them earlier in the same call.
+func TestStageInputs_ForwardsArtifactContext(t *testing.T) {
+	rt := localexec.NewRuntime("")
+	fs := &captureCtxStageFS{WorkspaceFS: rt}
+	eng := codeexecutor.NewEngine(rt, fs, rt)
+	exec := &stubFSExec{eng: eng}
+
+	ws := New(exec, codeexecutor.NewWorkspaceRegistry())
+	svc := inmemory.NewService()
+	inv := agent.NewInvocation(
+		agent.WithInvocationMessage(model.NewUserMessage("hi")),
+		agent.WithInvocationSession(&session.Session{
+			ID: "sess-stage", AppName: "app", UserID: "user",
+		}),
+		agent.WithInvocationArtifactService(svc),
+	)
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+
+	require.NoError(t, ws.StageInputs(ctx, []codeexecutor.InputSpec{
+		{From: "artifact://placeholder@1", To: "in/placeholder"},
+	}))
+	require.NotNil(t, fs.gotCtx, "FS.StageInputs must have been called")
+	gotSvc, ok := codeexecutor.ArtifactServiceFromContext(fs.gotCtx)
+	require.True(t, ok,
+		"ctx forwarded to backend StageInputs must carry artifact service")
+	require.Same(t, artifact.Service(svc), gotSvc)
+}
+
+// TestRunProgram_RejectsCwdEscape pins the godoc claim that spec.Cwd
+// cannot escape the workspace. The local runtime in particular joins
+// ws.Path with filepath.Clean(spec.Cwd) verbatim and would otherwise
+// honor "../..".
+func TestRunProgram_RejectsCwdEscape(t *testing.T) {
+	ws, ctx, _, _ := newHarness(t)
+	_, err := ws.RunProgram(ctx, codeexecutor.RunProgramSpec{
+		Cmd: "true",
+		Cwd: "../etc",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cwd must stay within the workspace")
+}
+
 // TestWithSaveArtifactMaxBytes_Applies verifies the option is wired
 // to SaveArtifactOptions.MaxBytes. The option is otherwise applied
 // inside an internal flow; checking the struct directly is the

--- a/codeexecutor/workspaceio/workspace_io_test.go
+++ b/codeexecutor/workspaceio/workspace_io_test.go
@@ -103,11 +103,16 @@ func TestCollect_ReturnsMatchingFiles(t *testing.T) {
 	}, paths)
 }
 
-func TestCollect_EmptyPatternsIsNil(t *testing.T) {
+// TestCollect_EmptyPatternsReturnsEmptySlice pins the documented contract
+// in workspace_io.go: "An empty pattern list returns an empty slice."
+// Returning nil would force callers to special-case the no-pattern path
+// and disagrees with the godoc.
+func TestCollect_EmptyPatternsReturnsEmptySlice(t *testing.T) {
 	ws, ctx, _, _ := newHarness(t)
 	got, err := ws.Collect(ctx)
 	require.NoError(t, err)
-	require.Nil(t, got)
+	require.NotNil(t, got, "Collect must return a non-nil empty slice for empty patterns")
+	require.Empty(t, got)
 }
 
 func TestPutFiles_BatchWrite(t *testing.T) {

--- a/codeexecutor/workspaceio/workspace_io_test.go
+++ b/codeexecutor/workspaceio/workspace_io_test.go
@@ -1,0 +1,419 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package workspaceio
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/artifact"
+	"trpc.group/trpc-go/trpc-agent-go/artifact/inmemory"
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
+	localexec "trpc.group/trpc-go/trpc-agent-go/codeexecutor/local"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+func newHarness(t *testing.T) (*Workspace, context.Context, *agent.Invocation, *inmemory.Service) {
+	t.Helper()
+	exec := localexec.New()
+	reg := codeexecutor.NewWorkspaceRegistry()
+	svc := inmemory.NewService()
+	inv := agent.NewInvocation(
+		agent.WithInvocationMessage(model.NewUserMessage("hi")),
+		agent.WithInvocationSession(&session.Session{
+			ID:      "sess-wsio",
+			AppName: "app",
+			UserID:  "user",
+		}),
+		agent.WithInvocationArtifactService(svc),
+	)
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+	return New(exec, reg), ctx, inv, svc
+}
+
+func TestNew_NilExecReturnsNil(t *testing.T) {
+	require.Nil(t, New(nil, nil))
+}
+
+func TestPutAndCollect(t *testing.T) {
+	ws, ctx, _, _ := newHarness(t)
+	require.NotNil(t, ws)
+
+	require.NoError(t, ws.PutFiles(ctx, codeexecutor.PutFile{
+		Path:    "work/notes.txt",
+		Content: []byte("hello world"),
+	}))
+
+	got, err := ws.Collect(ctx, "work/notes.txt")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, "work/notes.txt", got[0].Path)
+	require.Equal(t, []byte("hello world"), got[0].Data)
+	require.False(t, got[0].Truncated)
+	require.EqualValues(t, len("hello world"), got[0].SizeBytes)
+}
+
+// TestCollect_ForwardsTruncated verifies that the facade reports the
+// backend's Truncated flag verbatim — it is the caller's responsibility
+// to decide whether a truncated read is acceptable.
+func TestCollect_ForwardsTruncated(t *testing.T) {
+	got := toFile(codeexecutor.File{
+		Name:      "skills/echoer/SKILL.md",
+		Content:   "abc",
+		SizeBytes: 8 * 1024 * 1024,
+		Truncated: true,
+	})
+	require.True(t, got.Truncated)
+	require.Equal(t, []byte("abc"), got.Data)
+	require.EqualValues(t, 8*1024*1024, got.SizeBytes)
+}
+
+func TestCollect_ReturnsMatchingFiles(t *testing.T) {
+	ws, ctx, _, _ := newHarness(t)
+	require.NoError(t, ws.PutFiles(ctx,
+		codeexecutor.PutFile{Path: "skills/echoer/SKILL.md", Content: []byte("# Echoer")},
+		codeexecutor.PutFile{Path: "skills/greeter/SKILL.md", Content: []byte("# Greeter")},
+		codeexecutor.PutFile{Path: "skills/scratch/notes.txt", Content: []byte("ignored")},
+	))
+
+	got, err := ws.Collect(ctx, "skills/*/SKILL.md")
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	paths := []string{got[0].Path, got[1].Path}
+	sort.Strings(paths)
+	require.Equal(t, []string{
+		"skills/echoer/SKILL.md",
+		"skills/greeter/SKILL.md",
+	}, paths)
+}
+
+func TestCollect_EmptyPatternsIsNil(t *testing.T) {
+	ws, ctx, _, _ := newHarness(t)
+	got, err := ws.Collect(ctx)
+	require.NoError(t, err)
+	require.Nil(t, got)
+}
+
+func TestPutFiles_BatchWrite(t *testing.T) {
+	ws, ctx, _, _ := newHarness(t)
+
+	require.NoError(t, ws.PutFiles(ctx,
+		codeexecutor.PutFile{Path: "work/a.txt", Content: []byte("alpha")},
+		codeexecutor.PutFile{Path: "work/b.txt", Content: []byte("beta")},
+	))
+
+	got, err := ws.Collect(ctx, "work/a.txt", "work/b.txt")
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	byPath := map[string][]byte{}
+	for _, f := range got {
+		byPath[f.Path] = f.Data
+	}
+	require.Equal(t, []byte("alpha"), byPath["work/a.txt"])
+	require.Equal(t, []byte("beta"), byPath["work/b.txt"])
+}
+
+func TestPutFiles_EmptyIsNoOp(t *testing.T) {
+	ws, ctx, _, _ := newHarness(t)
+	require.NoError(t, ws.PutFiles(ctx))
+}
+
+func TestSaveArtifact_PersistsExistingFile(t *testing.T) {
+	ws, ctx, _, svc := newHarness(t)
+	data := []byte("artifact-payload")
+	require.NoError(t, ws.PutFiles(ctx, codeexecutor.PutFile{
+		Path:    "out/site.zip",
+		Content: data,
+	}))
+
+	ref, err := ws.SaveArtifact(ctx, "out/site.zip")
+	require.NoError(t, err)
+	require.Equal(t, "out/site.zip", ref.SavedAs)
+	require.Equal(t, "out/site.zip", ref.Path)
+	require.Equal(t, 0, ref.Version)
+	require.Equal(t, "artifact://out/site.zip@0", ref.Ref)
+	require.EqualValues(t, len(data), ref.SizeBytes)
+
+	loaded, err := svc.LoadArtifact(ctx, artifact.SessionInfo{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "sess-wsio",
+	}, "out/site.zip", nil)
+	require.NoError(t, err)
+	require.Equal(t, data, loaded.Data)
+}
+
+func TestSaveArtifact_RejectsSkillsPath(t *testing.T) {
+	ws, ctx, _, _ := newHarness(t)
+	_, err := ws.SaveArtifact(ctx, "skills/demo/SKILL.md")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "supported artifact roots")
+}
+
+func TestSaveArtifact_RequiresArtifactService(t *testing.T) {
+	exec := localexec.New()
+	ws := New(exec, nil)
+	inv := agent.NewInvocation(
+		agent.WithInvocationMessage(model.NewUserMessage("hi")),
+		agent.WithInvocationSession(&session.Session{
+			ID: "sess", AppName: "app", UserID: "user",
+		}),
+	)
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+	_, err := ws.SaveArtifact(ctx, "out/site.zip")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "artifact service")
+}
+
+func TestStageInputs_HostScheme(t *testing.T) {
+	ws, ctx, _, _ := newHarness(t)
+	srcDir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(srcDir, "a.txt"), []byte("from-host"), 0o644,
+	))
+
+	err := ws.StageInputs(ctx, []codeexecutor.InputSpec{{
+		From: "host://" + srcDir,
+		To:   "work/inputs/a.txt",
+	}})
+	require.NoError(t, err)
+
+	got, err := ws.Collect(ctx, "work/inputs/a.txt")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, []byte("from-host"), got[0].Data)
+}
+
+// TestRunProgram_EchoesStdout verifies that RunProgram forwards a
+// successful command's stdout and zero exit code through the facade.
+func TestRunProgram_EchoesStdout(t *testing.T) {
+	ws, ctx, _, _ := newHarness(t)
+
+	res, err := ws.RunProgram(ctx, codeexecutor.RunProgramSpec{
+		Cmd:  "sh",
+		Args: []string{"-c", "printf hello"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 0, res.ExitCode)
+	require.Equal(t, "hello", res.Stdout)
+	require.False(t, res.TimedOut)
+}
+
+// TestRunProgram_NonZeroExitIsNotError verifies the documented contract:
+// non-zero exit codes are signalled via RunResult, not via error.
+func TestRunProgram_NonZeroExitIsNotError(t *testing.T) {
+	ws, ctx, _, _ := newHarness(t)
+
+	res, err := ws.RunProgram(ctx, codeexecutor.RunProgramSpec{
+		Cmd:  "sh",
+		Args: []string{"-c", "exit 7"},
+	})
+	require.NoError(t, err, "non-zero exit must not be a framework error")
+	require.Equal(t, 7, res.ExitCode)
+	require.False(t, res.TimedOut)
+}
+
+func TestContextRoundTrip(t *testing.T) {
+	ws, ctx, _, _ := newHarness(t)
+
+	got, ok := WorkspaceFromContext(ctx)
+	require.False(t, ok)
+	require.Nil(t, got)
+
+	bound := WithWorkspace(ctx, ws)
+	got, ok = WorkspaceFromContext(bound)
+	require.True(t, ok)
+	require.Same(t, ws, got)
+}
+
+func TestContextNilNoOp(t *testing.T) {
+	ctx := context.Background()
+	out := WithWorkspace(ctx, nil)
+	got, ok := WorkspaceFromContext(out)
+	require.False(t, ok)
+	require.Nil(t, got)
+}
+
+// TestContextNilContextHandled covers the (ctx == nil) guard on both
+// helpers — defensive but cheap.
+func TestContextNilContextHandled(t *testing.T) {
+	require.Nil(t, WithWorkspace(nil, &Workspace{}))
+	got, ok := WorkspaceFromContext(nil)
+	require.False(t, ok)
+	require.Nil(t, got)
+}
+
+// TestNilReceiver_AllMethodsErrorOnNilFacade verifies that every
+// public method on *Workspace tolerates a nil receiver and returns a
+// uniform "workspace is nil" error rather than panicking.
+func TestNilReceiver_AllMethodsErrorOnNilFacade(t *testing.T) {
+	var w *Workspace
+	ctx := context.Background()
+
+	_, err := w.Collect(ctx, "x")
+	require.ErrorContains(t, err, "workspace is nil")
+
+	require.ErrorContains(t,
+		w.PutFiles(ctx, codeexecutor.PutFile{
+			Path:    "a.txt",
+			Content: []byte("x"),
+		}),
+		"workspace is nil")
+
+	_, err = w.SaveArtifact(ctx, "out/x")
+	require.ErrorContains(t, err, "workspace is nil")
+
+	require.ErrorContains(t,
+		w.StageInputs(ctx, []codeexecutor.InputSpec{{
+			From: "host:///nope", To: "x",
+		}}),
+		"workspace is nil")
+
+	_, err = w.RunProgram(ctx, codeexecutor.RunProgramSpec{Cmd: "true"})
+	require.ErrorContains(t, err, "workspace is nil")
+}
+
+// TestUninitialized_BindWorkspace covers the (resolver == nil) guard
+// in bindWorkspace via a zero-value *Workspace. Methods reach the
+// guard rather than touching any backend.
+func TestUninitialized_BindWorkspace(t *testing.T) {
+	w := &Workspace{} // resolver is nil
+	ctx := context.Background()
+
+	_, err := w.Collect(ctx, "x")
+	require.ErrorContains(t, err, "workspace is not initialized")
+
+	require.ErrorContains(t,
+		w.PutFiles(ctx, codeexecutor.PutFile{
+			Path:    "a.txt",
+			Content: []byte("x"),
+		}),
+		"workspace is not initialized")
+
+	require.ErrorContains(t,
+		w.StageInputs(ctx, []codeexecutor.InputSpec{{
+			From: "host:///nope", To: "x",
+		}}),
+		"workspace is not initialized")
+
+	_, err = w.RunProgram(ctx, codeexecutor.RunProgramSpec{Cmd: "true"})
+	require.ErrorContains(t, err, "workspace is not initialized")
+}
+
+// TestSaveArtifact_NoInvocationInContext exercises the
+// SaveReasonNoInvocation branch — a freshly constructed *Workspace
+// with no invocation on ctx.
+func TestSaveArtifact_NoInvocationInContext(t *testing.T) {
+	exec := localexec.New()
+	ws := New(exec, nil)
+	_, err := ws.SaveArtifact(context.Background(), "out/missing.zip")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invocation is missing")
+}
+
+// TestSaveArtifact_FileNotFound exercises the manifest.Files == 0
+// branch — the path is publish-allowed but the file does not exist.
+func TestSaveArtifact_FileNotFound(t *testing.T) {
+	ws, ctx, _, _ := newHarness(t)
+	_, err := ws.SaveArtifact(ctx, "out/never-written.zip")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "artifact file not found")
+}
+
+// TestSaveArtifact_MaxBytesZeroFallsBackToDefault verifies that
+// WithSaveArtifactMaxBytes(0) is treated as "use the framework
+// default" rather than rejecting the call outright.
+func TestSaveArtifact_MaxBytesZeroFallsBackToDefault(t *testing.T) {
+	ws, ctx, _, _ := newHarness(t)
+	require.NoError(t, ws.PutFiles(ctx, codeexecutor.PutFile{
+		Path:    "out/small.txt",
+		Content: []byte("ok"),
+	}))
+
+	ref, err := ws.SaveArtifact(ctx, "out/small.txt",
+		WithSaveArtifactMaxBytes(0))
+	require.NoError(t, err)
+	require.Equal(t, "out/small.txt", ref.SavedAs)
+}
+
+// nilRunnerExec implements codeexecutor.CodeExecutor and
+// EngineProvider, exposing an engine whose Runner() is nil. It is
+// the minimum surface needed to drive Workspace.RunProgram into its
+// "no program runner" branch without leaning on any production
+// backend's behavior.
+type nilRunnerExec struct {
+	eng codeexecutor.Engine
+}
+
+func (f *nilRunnerExec) ExecuteCode(
+	context.Context, codeexecutor.CodeExecutionInput,
+) (codeexecutor.CodeExecutionResult, error) {
+	return codeexecutor.CodeExecutionResult{}, nil
+}
+
+func (f *nilRunnerExec) CodeBlockDelimiter() codeexecutor.CodeBlockDelimiter {
+	return codeexecutor.CodeBlockDelimiter{}
+}
+
+func (f *nilRunnerExec) Engine() codeexecutor.Engine { return f.eng }
+
+// TestRunProgram_RunnerNil covers the "executor does not expose a
+// program runner" branch. We wire a real local FS+Manager so
+// bindWorkspace succeeds, then drop the Runner.
+func TestRunProgram_RunnerNil(t *testing.T) {
+	rt := localexec.NewRuntime("")
+	eng := codeexecutor.NewEngine(rt, rt, nil) // runner = nil
+	exec := &nilRunnerExec{eng: eng}
+
+	ws := New(exec, codeexecutor.NewWorkspaceRegistry())
+	inv := agent.NewInvocation(
+		agent.WithInvocationMessage(model.NewUserMessage("hi")),
+		agent.WithInvocationSession(&session.Session{
+			ID: "sess", AppName: "app", UserID: "user",
+		}),
+	)
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+
+	_, err := ws.RunProgram(ctx, codeexecutor.RunProgramSpec{Cmd: "true"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not expose a program runner")
+}
+
+// TestWithSaveArtifactMaxBytes_Applies verifies the option is wired
+// to SaveArtifactOptions.MaxBytes. The option is otherwise applied
+// inside an internal flow; checking the struct directly is the
+// cheapest way to pin the contract.
+func TestWithSaveArtifactMaxBytes_Applies(t *testing.T) {
+	cfg := SaveArtifactOptions{}
+	WithSaveArtifactMaxBytes(1234)(&cfg)
+	require.EqualValues(t, 1234, cfg.MaxBytes)
+}
+
+// TestToFile_SizeFallback covers the size<=0 fallback in toFile that
+// re-derives SizeBytes from Content when the backend left it unset.
+func TestToFile_SizeFallback(t *testing.T) {
+	got := toFile(codeexecutor.File{
+		Name:    "work/a.txt",
+		Content: "abc",
+	})
+	require.EqualValues(t, 3, got.SizeBytes)
+	require.Equal(t, []byte("abc"), got.Data)
+	require.False(t, got.Truncated)
+}

--- a/docs/mkdocs/en/codeexecutor.md
+++ b/docs/mkdocs/en/codeexecutor.md
@@ -145,6 +145,28 @@ Common paths:
 - write intermediate files to `work/`
 - write result files to `out/`
 
+## What Persists Across Turns
+
+There are two important cases:
+
+- the request lands on the same physical workspace
+- the request lands on a fresh workspace
+
+In the same physical workspace:
+
+- files in `work/` and `out/` are usually still available
+- result files can often be read again directly
+
+In a fresh workspace:
+
+- conversation file inputs can usually be re-staged from visible message
+  history
+- old `out/**` files are not restored automatically
+- old `work/**` files should not be assumed to exist
+
+If a file must survive beyond a fresh workspace, store it as an artifact or
+persist it explicitly in your application layer.
+
 ## Where Uploaded Files Appear
 
 On execution paths that support conversation-file auto-staging, the framework
@@ -184,7 +206,7 @@ msg.AddFileIDWithName("artifact://uploads/report.pdf@1", "report.pdf")
 Before execution, the framework resolves that reference and writes the file
 under `work/inputs/`.
 
-## Example: Upload to Artifact First
+### End-to-end example: upload first, stage at execution time
 
 This example shows the full flow for uploading a file first and letting the
 executor stage it automatically later:
@@ -282,6 +304,18 @@ Requirement:
 Otherwise the framework will not find the artifact when resolving the
 `artifact://...` reference.
 
+## Provider File IDs vs Artifact References
+
+Some providers support native `file_id` values. Whether those IDs can be
+downloaded back by the executor depends on the model integration.
+
+If executor-side access must be reliable, prefer:
+
+- `artifact://...`
+
+This path is managed by the framework's artifact service and does not depend on
+provider-specific file download support.
+
 ## How Tools Usually Use These Files
 
 When your Agent exposes workspace tools such as `workspace_exec`, the common
@@ -361,39 +395,299 @@ need to duplicate skill sources in init hook `Inputs`; init hooks cover
 session-independent files and setup commands you want present before any tool
 run.
 
-## What Persists Across Turns
+## Accessing the Workspace From Application Code
 
-There are two important cases:
+The model drives the workspace through `workspace_exec`. Application
+code sometimes needs to read what the agent just produced — mirroring
+files at agreed paths into a profile store from `AfterAgent`, or
+harvesting intermediate output of a specific tool from `AfterTool`;
+some scenarios also need to run a command from a callback for
+validation or post-processing.
 
-- the request lands on the same physical workspace
-- the request lands on a fresh workspace
+`codeexecutor/workspaceio` exposes a single facade, `Workspace`. Once
+`WithCodeExecutor(...)` is configured, `LLMAgent.Run` installs it into
+`ctx` at entry, so any callback or tool that receives a `ctx` can
+resolve it — `BeforeAgent` / `AfterAgent` / `BeforeTool` / `AfterTool`
+/ `BeforeModel` / `AfterModel` / your own tool's `Run`.
 
-In the same physical workspace:
+It is a thin wrapper over `codeexecutor.WorkspaceFS` plus
+`ProgramRunner`: the framework does not enforce truncation, volume,
+atomicity, or non-zero-exit handling for you. How to validate after a
+read, when to refuse on overflow, what to do when a command exits
+non-zero — that all lives in your callback. See *Caller-owned policy*
+below.
 
-- files in `work/` and `out/` are usually still available
-- result files can often be read again directly
+> **About the name collision with `codeexecutor.Workspace`:** the
+> latter is a v1-published workspace descriptor (`{ID, Path}`, no
+> methods); this section's `Workspace` is the facade. The two are
+> disambiguated by import path; business code rarely references both
+> in the same file. When it does, use an import alias:
+>
+> ```go
+> import (
+>     "trpc.group/trpc-go/trpc-agent-go/codeexecutor"
+>     wsio "trpc.group/trpc-go/trpc-agent-go/codeexecutor/workspaceio"
+> )
+> ```
 
-In a fresh workspace:
+### Read and write inside callbacks
 
-- conversation file inputs can usually be re-staged from visible message
-  history
-- old `out/**` files are not restored automatically
-- old `work/**` files should not be assumed to exist
+There are two recommended use patterns for `Workspace`:
 
-If a file must survive beyond a fresh workspace, store it as an artifact or
-persist it explicitly in your application layer.
+- **`AfterAgent`**: when the whole turn is done, mirror the artifacts
+  at agreed paths (`skills/*/SKILL.md`, `out/report.pdf`, ...) back
+  into your own store. Skip on failure since the workspace state
+  cannot be trusted.
+- **`AfterTool` gated on `args.ToolName`**: when you only care about
+  the artifacts produced by a specific tool (for example, mirroring
+  files written by `workspace_exec`, or harvesting intermediate output
+  of a custom skill tool), filter by tool name first so unrelated tool
+  calls do not trigger a `Collect`.
 
-## Provider File IDs vs Artifact References
+`myStore.Save(...)` and `mirror(ctx, files)` in the snippets below are
+interfaces you implement; the docs do not pin their signatures.
 
-Some providers support native `file_id` values. Whether those IDs can be
-downloaded back by the executor depends on the model integration.
+```go
+import (
+    "trpc.group/trpc-go/trpc-agent-go/agent"
+    "trpc.group/trpc-go/trpc-agent-go/codeexecutor/workspaceio"
+    "trpc.group/trpc-go/trpc-agent-go/tool"
+)
 
-If executor-side access must be reliable, prefer:
+agentCB := agent.NewCallbacks()
+agentCB.RegisterAfterAgent(func(ctx context.Context, args *agent.AfterAgentArgs) (*agent.AfterAgentResult, error) {
+    if args.Error != nil {
+        return nil, nil // workspace state is unreliable on failure
+    }
+    ws, ok := workspaceio.WorkspaceFromContext(ctx)
+    if !ok {
+        return nil, nil
+    }
+    files, err := ws.Collect(ctx, "skills/*/SKILL.md")
+    if err != nil {
+        return nil, err
+    }
+    for _, f := range files {
+        if f.Truncated {
+            return nil, fmt.Errorf("%s was truncated by the backend", f.Path)
+        }
+        if err := myStore.Save(ctx, args.Invocation, f); err != nil {
+            return nil, err
+        }
+    }
+    return nil, nil
+})
 
-- `artifact://...`
+toolCB := tool.NewCallbacks()
+toolCB.RegisterAfterTool(func(ctx context.Context, args *tool.AfterToolArgs) (*tool.AfterToolResult, error) {
+    // Only mirror after the target tool finishes; avoids scanning the
+    // workspace after every unrelated tool call.
+    if args.ToolName != "workspace_exec" {
+        return nil, nil
+    }
+    ws, ok := workspaceio.WorkspaceFromContext(ctx)
+    if !ok {
+        return nil, nil
+    }
+    files, err := ws.Collect(ctx, "out/**/*.json")
+    if err != nil {
+        return nil, err
+    }
+    return nil, mirror(ctx, files)
+})
 
-This path is managed by the framework's artifact service and does not depend on
-provider-specific file download support.
+agent := llmagent.New("demo",
+    llmagent.WithCodeExecutor(local.New()),
+    llmagent.WithAgentCallbacks(agentCB),
+    llmagent.WithToolCallbacks(toolCB),
+)
+```
+
+> Avoid using `BeforeAgent` + `PutFiles` to project external profile
+> or skill files into the workspace. That is workspace-initialization
+> work and belongs in `codeexecutor.WorkspaceInitHook` (see the
+> *Workspace init hooks* section above — use `InputSpec` with
+> `skill://` / `artifact://` / `host://` schemes to stage everything
+> at workspace creation time). `Workspace` exists for "read what the
+> agent produced", "promote a workspace file to an artifact", and
+> "run a one-off command for validation/post-processing", not for the
+> initialization path.
+
+### Available methods (every `path` is relative to the workspace root)
+
+- `Collect(ctx, patterns...)` — read every file matching one of the
+  patterns, returning `[]*File` (`Path`, `Data`, `MIMEType`,
+  `SizeBytes`, `Truncated`). Pattern syntax matches
+  `codeexecutor.WorkspaceFS.Collect` exactly: a literal path
+  (`skills/echoer/SKILL.md`), a wildcard (`out/*.json`), or a recursive
+  glob (`runs/**/result.md`). Single-file reads use the same entry
+  point — pass a literal pattern and take `result[0]`.
+- `PutFiles(ctx, files...)` — write 1..N `codeexecutor.PutFile`
+  values; parent directories are created automatically. Single-file
+  writes use the same entry point (pass one `PutFile`).
+  `PutFile.Mode == 0` falls back to the backend default (0o644 on
+  local); use `codeexecutor.DefaultExecFileMode` when you need 0o755.
+- `SaveArtifact(ctx, relPath, opts...)` — persist a workspace file as
+  an artifact (the `Runner` must be configured with an
+  `artifact.Service`); returns `*ArtifactRef`.
+- `StageInputs(ctx, specs)` — batch-stage external inputs identified
+  by `artifact://`, `host://`, `workspace://`, or `skill://` URIs.
+- `RunProgram(ctx, spec)` — run a program inside the workspace
+  (`spec.Cwd` is interpreted relative to the workspace root and
+  cannot escape it); returns `codeexecutor.RunResult` (`Stdout`,
+  `Stderr`, `ExitCode`, `Duration`, `TimedOut`). **A non-zero exit
+  code is NOT an error**, matching Go's `os/exec` convention — the
+  caller inspects `RunResult.ExitCode` / `TimedOut` and decides
+  whether to fail, retry, or accept. The returned `error` is reserved
+  for framework-level failures (no executor configured, backend
+  rejection, launch failure, internal timeout).
+
+`Workspace` has no internal locking; serialize calls yourself when
+ordering matters.
+
+### How to fill `Cmd` / `Args` in `RunProgram`
+
+`Cmd` is the executable name (**no shell parsing**); `Args` is the
+argument list. The `workspace_exec` LLM tool goes through the same
+`ProgramRunner.RunProgram` underneath — two patterns cover most needs.
+
+**Run a shell one-liner** (identical to how `workspace_exec` runs LLM
+commands):
+
+```go
+res, err := ws.RunProgram(ctx, codeexecutor.RunProgramSpec{
+    Cmd:     "sh",
+    Args:    []string{"-lc", "ls -la work && cat out/report.md"},
+    Cwd:     "",                  // empty == workspace root
+    Timeout: 30 * time.Second,
+})
+if err != nil {
+    return err
+}
+if res.ExitCode != 0 || res.TimedOut {
+    return fmt.Errorf("post-check failed: exit=%d timed_out=%v: %s",
+        res.ExitCode, res.TimedOut, res.Stderr)
+}
+```
+
+**Invoke a program directly** (no shell — zero argument escaping,
+more deterministic):
+
+```go
+res, err := ws.RunProgram(ctx, codeexecutor.RunProgramSpec{
+    Cmd:  "go",
+    Args: []string{"vet", "./..."},
+    Cwd:  "work",                 // run inside ${WORK}
+    Env:  map[string]string{"GOFLAGS": "-count=1"}, // appended/overridden, not a replacement
+})
+```
+
+Other fields:
+
+- `Stdin` — string piped to the process stdin once at startup, then
+  closed; use the `workspace_exec` LLM tool (or your own session) for
+  interactive programs.
+- `Timeout` — wall-clock timeout for the single run; on hit
+  `RunResult.TimedOut = true` while `error` stays `nil`.
+- `Env` — appended to / overriding environment variables; the
+  workspace already injects `${WORK}` / `${OUT}` / `${RUNS}` /
+  `${WORKSPACE_DIR}`, which you can reference directly in `Args`.
+
+### `*File`: what a read returns
+
+`Collect` returns a backend-agnostic snapshot per file:
+
+```go
+type File struct {
+    Path      string // workspace-relative, e.g. "skills/echoer/SKILL.md"
+    Data      []byte // copied bytes; callers may mutate
+    MIMEType  string // backend-detected; empty when the backend did not set it
+    SizeBytes int64  // actual file size; may exceed len(Data) when Truncated
+    Truncated bool   // backend hit its read cap; the framework does not error
+}
+```
+
+Two real uses:
+
+- **Mirror to external storage**: `os.WriteFile(dst, f.Data, 0o644)` /
+  `s3.PutObject(key, bytes.NewReader(f.Data))`. `f.Path` doubles as
+  the destination key or sub-path.
+- **Structural validation**: `bytes.Contains(f.Data, []byte("# "))`,
+  `yaml.Unmarshal(f.Data, &frontmatter)`, schema checks — fail
+  fast before mirroring.
+
+### `*ArtifactRef` + `WithSaveArtifactMaxBytes`: expose workspace output to later turns
+
+Use `SaveArtifact` when the model wrote something to `out/` (a
+generated PDF, a synthesized dataset, a training checkpoint, ...) and
+later turns need to reference it. The returned `ArtifactRef` mirrors
+the `workspace_save_artifact` LLM tool's output schema:
+
+```go
+ref, err := ws.SaveArtifact(ctx, "out/report.pdf",
+    workspaceio.WithSaveArtifactMaxBytes(8 * 1024 * 1024))
+if err != nil {
+    return err
+}
+
+// ref.Ref       == "artifact://out/report.pdf@3"  // pre-formatted reference
+// ref.SavedAs   == "out/report.pdf"               // artifact key
+// ref.Version   == 3
+// ref.SizeBytes == 4_812_345
+
+// Stash the reference in session state so the next turn's prompt can
+// quote ref.Ref directly.
+args.Invocation.Session.AppendStateValue("last_report", ref.Ref)
+```
+
+`WithSaveArtifactMaxBytes` is enforced at the backend's **read step**,
+not as a post-check — read-and-discard is avoided and overflow fails
+fast. Typical reasons to set it:
+
+- **The output may be large** (datasets, model weights, video) — set
+  8 MiB / 32 MiB so the backend fails fast instead of pushing GiB
+  through the artifact service.
+- **Compliance / audit boundaries** — pinning the per-artifact size
+  protects against runaway agents producing oversized outputs.
+
+The default cap is `64 MiB`, which covers most documents and small
+datasets, so most callers never need this option.
+
+### Caller-owned policy
+
+The framework does not make these choices for you; write each one in
+your callback as needed.
+
+**What to do with the bytes you just read**
+
+- *Mirror on failure?* Default: the example bails on
+  `args.Error != nil` — workspace state is unreliable in that case.
+  Drop the early return when you want post-mortem snapshots.
+- *Single file truncated?* Default: backends cap individual reads at
+  a few MiB and return `File.Truncated = true` on overflow; `Collect`
+  forwards the flag and does **not** error. Add
+  `if f.Truncated { return error }` for strict semantics.
+- *Too many / too large in aggregate?* Default: `Collect` caps neither
+  count nor total bytes. Apply your own check on `len(files)` /
+  summed `SizeBytes` and refuse when over budget.
+- *Non-zero exit from `RunProgram`?* Default: surfaced via
+  `RunResult.ExitCode` / `TimedOut`, **not** via error. Treat non-zero
+  exits as failures yourself with
+  `if res.ExitCode != 0 { return error }`.
+
+**Writing into your own store**
+
+- *Need all-or-nothing?* `Collect` followed by a `Save` loop is **not
+  transactional**. Stage to a temp prefix and rename, or use a
+  transactional store.
+
+**What happens when the callback returns an error**
+
+- Returning a non-`nil` error from `AfterAgent` / `AfterTool` **aborts
+  the current invocation**. Log-and-swallow if flush should be
+  best-effort.
+
+End-to-end example: [examples/workspace_io](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/workspace_io).
 
 ## Environment Variables
 

--- a/docs/mkdocs/zh/codeexecutor.md
+++ b/docs/mkdocs/zh/codeexecutor.md
@@ -142,6 +142,27 @@ agent := llmagent.New(
 - 写中间文件：`work/`
 - 写结果文件：`out/`
 
+## 哪些文件会保留
+
+通常有两类情况：
+
+- 仍然命中同一个物理 workspace
+- 后续换成了一个新的 workspace
+
+在同一个物理 workspace 中：
+
+- `work/`、`out/` 里的文件通常还能继续用
+- 之前写出的结果文件可以直接再次读取
+
+如果换成了新的 workspace：
+
+- 用户会话里的文件输入通常可以根据消息历史重新放回 `work/inputs/`
+- 旧的 `out/**` 不会自动恢复
+- 旧的 `work/**` 也不应该假设还能继续存在
+
+如果你需要跨新 workspace 稳定复用某个文件，建议把它保存为 artifact，
+或者让业务层自己管理持久化。
+
 ## 用户上传的文件会出现在哪里
 
 在支持会话文件自动 stage 的执行路径里，框架会在执行前把这些文件物化到：
@@ -178,7 +199,7 @@ msg.AddFileIDWithName("artifact://uploads/report.pdf@1", "report.pdf")
 
 执行前，框架会解析这个引用，并把文件写到 `work/inputs/` 下。
 
-## 示例：先上传 artifact，再交给执行环境
+### 完整示例：先上传，再交给执行环境
 
 下面的示例演示“先上传，再执行时自动 stage”的完整链路：
 
@@ -274,6 +295,17 @@ func main() {
 
 否则执行前解析 `artifact://...` 时，找不到对应 artifact。
 
+## provider 文件 ID 与 artifact 引用的区别
+
+有些模型厂商支持原生 `file_id`。这类 ID 能不能在执行器侧重新读取，取决于
+具体模型实现是否支持下载。
+
+如果你希望文件能稳定地被执行器读取，通常更建议使用：
+
+- `artifact://...`
+
+因为这条链路由框架自己的 artifact service 管理，不依赖模型厂商的文件下载能力。
+
 ## 与工作区工具的配合
 
 暴露 `workspace_exec` 一类工作区工具后，常见使用方式如下：
@@ -351,37 +383,272 @@ init hook 不会在磁盘文件变化后自动按文件再执行。
 写入 `skills/<name>`。不必在 init hook 的 `Inputs` 里重复声明技能来源；init hook 负责
 与会话无关、且希望在任意工具运行前就位的那份固定物料与初始化命令。
 
-## 哪些文件会保留
+## 应用代码访问 workspace
 
-通常有两类情况：
+模型通过 `workspace_exec` 操作 workspace；**应用代码**有时也需要从
+agent 跑完后的 workspace 里读出东西——例如 `AfterAgent` 把约定路径
+下的产物回写到自己的 profile store，或者 `AfterTool` 把某次工具产
+生的中间文件镜像出去；某些场景下还会需要在 callback 里直接跑一条
+命令做校验或后处理。
 
-- 仍然命中同一个物理 workspace
-- 后续换成了一个新的 workspace
+`codeexecutor/workspaceio` 提供 facade `Workspace`。在
+`WithCodeExecutor(...)` 配过的前提下，`LLMAgent.Run` 入口就把它注入
+ctx，**任何**带 ctx 的钩子点都能直接拿到——`BeforeAgent` /
+`AfterAgent` / `BeforeTool` / `AfterTool` / `BeforeModel` /
+`AfterModel` / 你自己实现的工具内部均可。
 
-在同一个物理 workspace 中：
+它是 `codeexecutor.WorkspaceFS` + `ProgramRunner` 的薄封装：截断、
+总量、原子性、非零 exit code 这类策略框架不替你做主——读完之后怎么
+校验、超限怎么拒绝、命令失败怎么处理，都在 callback 里按需写。详
+见后文 *调用方负责的策略*。
 
-- `work/`、`out/` 里的文件通常还能继续用
-- 之前写出的结果文件可以直接再次读取
+> **关于 `codeexecutor.Workspace` 和 `workspaceio.Workspace` 同名**
+> ：前者是 v1 起公开的 workspace descriptor（`{ID, Path}`，无方法），
+> 后者是本节的 facade。两者通过 import path 区分，编译器零歧义；
+> 业务代码极少同行引用 descriptor。如确需同时 import：
+>
+> ```go
+> import (
+>     "trpc.group/trpc-go/trpc-agent-go/codeexecutor"
+>     wsio "trpc.group/trpc-go/trpc-agent-go/codeexecutor/workspaceio"
+> )
+> ```
 
-如果换成了新的 workspace：
+### 在 callback 里读写
 
-- 用户会话里的文件输入通常可以根据消息历史重新放回 `work/inputs/`
-- 旧的 `out/**` 不会自动恢复
-- 旧的 `work/**` 也不应该假设还能继续存在
+`Workspace` 主要的两类用法：
 
-如果你需要跨新 workspace 稳定复用某个文件，建议把它保存为 artifact，
-或者让业务层自己管理持久化。
+- **`AfterAgent`**：本轮跑完，把约定路径下的产物
+  （`skills/*/SKILL.md`、`out/report.pdf` 等）整体回写到自己的 store。
+  失败时 workspace 状态不可信，跳过。
+- **`AfterTool` + `args.ToolName` 特判**：只关心某个工具产生的产物
+  时（`workspace_exec` 跑完后镜像它写出的文件、某个自定义 skill 工
+  具结束后取中间结果），按工具名过滤再读，避免每次工具调用都触发
+  一次 `Collect`。
 
-## provider 文件 ID 与 artifact 引用的区别
+下面示例里 `myStore.Save(...)` 和 `mirror(ctx, files)` 是你自己实现
+的接口——文档不绑死它们的签名，按你的存储形态自己定。
 
-有些模型厂商支持原生 `file_id`。这类 ID 能不能在执行器侧重新读取，取决于
-具体模型实现是否支持下载。
+```go
+import (
+    "trpc.group/trpc-go/trpc-agent-go/agent"
+    "trpc.group/trpc-go/trpc-agent-go/codeexecutor/workspaceio"
+    "trpc.group/trpc-go/trpc-agent-go/tool"
+)
 
-如果你希望文件能稳定地被执行器读取，通常更建议使用：
+agentCB := agent.NewCallbacks()
+agentCB.RegisterAfterAgent(func(ctx context.Context, args *agent.AfterAgentArgs) (*agent.AfterAgentResult, error) {
+    if args.Error != nil {
+        return nil, nil // 失败时 workspace 状态不可信，跳过镜像
+    }
+    ws, ok := workspaceio.WorkspaceFromContext(ctx)
+    if !ok {
+        return nil, nil
+    }
+    files, err := ws.Collect(ctx, "skills/*/SKILL.md")
+    if err != nil {
+        return nil, err
+    }
+    for _, f := range files {
+        if f.Truncated {
+            return nil, fmt.Errorf("%s 被 backend 截断", f.Path)
+        }
+        if err := myStore.Save(ctx, args.Invocation, f); err != nil {
+            return nil, err
+        }
+    }
+    return nil, nil
+})
 
-- `artifact://...`
+toolCB := tool.NewCallbacks()
+toolCB.RegisterAfterTool(func(ctx context.Context, args *tool.AfterToolArgs) (*tool.AfterToolResult, error) {
+    // 只在目标工具结束后镜像，避免对每个工具调用都全量扫 workspace。
+    if args.ToolName != "workspace_exec" {
+        return nil, nil
+    }
+    ws, ok := workspaceio.WorkspaceFromContext(ctx)
+    if !ok {
+        return nil, nil
+    }
+    files, err := ws.Collect(ctx, "out/**/*.json")
+    if err != nil {
+        return nil, err
+    }
+    return nil, mirror(ctx, files)
+})
 
-因为这条链路由框架自己的 artifact service 管理，不依赖模型厂商的文件下载能力。
+agent := llmagent.New("demo",
+    llmagent.WithCodeExecutor(local.New()),
+    llmagent.WithAgentCallbacks(agentCB),
+    llmagent.WithToolCallbacks(toolCB),
+)
+```
+
+> 不建议在 `BeforeAgent` 里用 `PutFiles` 把外部 profile / skill 文
+> 件投影进 workspace ——那是「workspace 初始化」职责，应当走
+> `codeexecutor.WorkspaceInitHook`（见前文 *Workspace init hooks*
+> 章节，用 `InputSpec` 配合 `skill://` / `artifact://` / `host://`
+> 等 scheme 在工作区创建时一次完成），而不是借 `Workspace` 在
+> callback 里偷做。`Workspace` 的设计点是「读出 agent 跑出来的东
+> 西」「把 workspace 文件转成 artifact」「在 callback 里跑一条命
+> 令做校验/后处理」，不是为初始化路径服务的。
+
+### 可用方法（`path` 一律相对 workspace 根）
+
+- `Collect(ctx, patterns...)` — 按模式批量读，返回 `[]*File`（`Path` /
+  `Data` / `MIMEType` / `SizeBytes` / `Truncated`）。模式语法与
+  `codeexecutor.WorkspaceFS.Collect` 一致：字面量路径
+  （`skills/echoer/SKILL.md`）、通配（`out/*.json`、`runs/**/result.md`）
+  都是合法 pattern。单文件读也用这个入口（传字面量 pattern，取
+  `result[0]`）。
+- `PutFiles(ctx, files...)` — 写入 1～N 份 `codeexecutor.PutFile`，
+  自动建父目录。单文件写也用这个入口（传一个 `PutFile`）。
+  `PutFile.Mode == 0` 时回落到 backend 默认（local 是 0o644）；要
+  0o755 用 `codeexecutor.DefaultExecFileMode`。
+- `SaveArtifact(ctx, relPath, opts...)` — 把 workspace 文件持久化为
+  artifact（需要 Runner 配 `artifact.Service`），返回 `*ArtifactRef`。
+- `StageInputs(ctx, specs)` — 按 `artifact://` / `host://` /
+  `workspace://` / `skill://` 把外部输入拉进 workspace。
+- `RunProgram(ctx, spec)` — 在 workspace 里跑一条命令（`spec.Cwd` 相
+  对 workspace 根，不能越界），返回 `codeexecutor.RunResult`
+  （`Stdout` / `Stderr` / `ExitCode` / `Duration` / `TimedOut`）。
+  **非零 exit code 不是 error**，按 Go `os/exec` 惯例通过
+  `RunResult.ExitCode` 报告——调用方自己看 `ExitCode` / `TimedOut`
+  决定怎么处理。`error` 仅在「框架层失败」时返回（没配 executor、
+  backend 拒绝、launch 失败、内部超时）。
+
+`Workspace` 没有内部锁，并发使用要自行串行化。
+
+### `RunProgram` 怎么写 `Cmd` / `Args`
+
+`Cmd` 是可执行文件名（**不走 shell 解析**），`Args` 是传给它的参数
+列表。`workspace_exec` LLM 工具底层也是同一条 `ProgramRunner.RunProgram`
+路径——两种形态够用。
+
+**跑一行 shell**（跟 `workspace_exec` 接收 LLM 命令时完全一致）：
+
+```go
+res, err := ws.RunProgram(ctx, codeexecutor.RunProgramSpec{
+    Cmd:     "sh",
+    Args:    []string{"-lc", "ls -la work && cat out/report.md"},
+    Cwd:     "",                  // 留空就是 workspace 根
+    Timeout: 30 * time.Second,
+})
+if err != nil {
+    return err
+}
+if res.ExitCode != 0 || res.TimedOut {
+    return fmt.Errorf("post-check failed: exit=%d timed_out=%v: %s",
+        res.ExitCode, res.TimedOut, res.Stderr)
+}
+```
+
+**直接跑某个程序**（不开 shell，参数零转义、更可控）：
+
+```go
+res, err := ws.RunProgram(ctx, codeexecutor.RunProgramSpec{
+    Cmd:  "go",
+    Args: []string{"vet", "./..."},
+    Cwd:  "work",                 // 在 ${WORK} 下执行
+    Env:  map[string]string{"GOFLAGS": "-count=1"}, // 追加/覆盖，不替换整个 env
+})
+```
+
+其余字段：
+
+- `Stdin` — 字符串，启动后由框架喂给 stdin，跑完即关；跑交互式程序请用
+  `workspace_exec` LLM 工具或自己起 session。
+- `Timeout` — 单次执行墙钟超时；超时后 `RunResult.TimedOut = true`，
+  `error` 仍为 `nil`。
+- `Env` — 追加/覆盖一组环境变量；workspace 已注入 `${WORK}` / `${OUT}`
+  / `${RUNS}` / `${WORKSPACE_DIR}` 这几个根目录路径，可在 `Args` 里直
+  接引用。
+
+### `*File`：读出来的文件长什么样
+
+`Collect` 返回的 `*File` 是后端无关的快照：
+
+```go
+type File struct {
+    Path      string // workspace 相对路径，例如 "skills/echoer/SKILL.md"
+    Data      []byte // 拷贝过的字节，调用方可随意 mutate
+    MIMEType  string // 后端检测的 MIME；空表示后端没填
+    SizeBytes int64  // 文件实际大小；可能 > len(Data) 当 Truncated=true
+    Truncated bool   // 后端读到内部上限被截断；框架不会因此报错
+}
+```
+
+实际用法就两类：
+
+- **Mirror 到外部存储**：`os.WriteFile(dst, f.Data, 0o644)` /
+  `s3.PutObject(key, bytes.NewReader(f.Data))`；`f.Path` 直接当目标
+  key / 子路径。
+- **结构性校验**：`bytes.Contains(f.Data, []byte("# "))`、
+  `yaml.Unmarshal(f.Data, &frontmatter)` 之类，校验失败就拒绝镜像。
+
+### `*ArtifactRef` + `WithSaveArtifactMaxBytes`：把 workspace 产物公开给后续轮次
+
+`SaveArtifact` 适用于"模型这一轮在 `out/` 写出了一份要被后面引用的
+产物（生成的 PDF、合成数据集、训练 checkpoint ...）"。返回的
+`ArtifactRef` 字段名和 LLM 工具 `workspace_save_artifact` 输出一致：
+
+```go
+ref, err := ws.SaveArtifact(ctx, "out/report.pdf",
+    workspaceio.WithSaveArtifactMaxBytes(8 * 1024 * 1024))
+if err != nil {
+    return err
+}
+
+// ref.Ref       == "artifact://out/report.pdf@3"  // 拼好的引用串
+// ref.SavedAs   == "out/report.pdf"               // artifact key
+// ref.Version   == 3
+// ref.SizeBytes == 4_812_345
+
+// 把引用回写到 session state，让下一轮的 prompt 可以直接用 ref.Ref
+args.Invocation.Session.AppendStateValue("last_report", ref.Ref)
+```
+
+`WithSaveArtifactMaxBytes` 在后端**读取阶段**就生效（不是读完再判长
+度），超限直接报错——比"读出来再丢弃"省内存、也能更早失败。典型
+场景：
+
+- **可能过大的产物**（生成的数据集、模型权重、视频）— 设 8 MiB /
+  32 MiB 让后端早失败，不要把 GiB 级数据塞进 artifact service。
+- **审计 / 合规边界** — 把"单 artifact 体量"钉死成业务约束，防止
+  agent 出 bug 产生超大产物。
+
+不传时默认 `64 MiB`，够大多数文档 / 小数据，一般场景不用关心。
+
+### 调用方负责的策略
+
+框架不替你做主，下面这些都在你的 callback 里自己写。
+
+**读到内容后怎么处理**
+
+- *失败时是否镜像？* 默认行为：示例 `args.Error != nil` 时直接
+  `return`——workspace 在失败时状态不可信。**要事故快照**就反过来，
+  错误也照镜。
+- *单文件被截断了怎么办？* 默认行为：backend 单文件读有内部上限
+  （一般几 MiB），命中后置 `File.Truncated = true` 并照常返回，**不**
+  自动报错。**要严格语义**自己加 `if f.Truncated { return error }`。
+- *扫出来太多 / 太大怎么办？* 默认行为：`Collect` 不限返回数量、
+  也不限总字节。**要预算**就在结果上 `len(files)` / 累加
+  `SizeBytes` 自己卡，超了拒绝。
+- *`RunProgram` 退出码非零怎么办？* 默认行为：通过 `RunResult.ExitCode`
+  / `TimedOut` 报告，**不**作为 error 返回。要把非零 exit 当失败处
+  理就自己 `if res.ExitCode != 0 { return error }`。
+
+**写到自己的 store 时**
+
+- *需要 all-or-nothing？* `Collect` + 循环 `Save` **不是事务**。要原
+  子性就先写临时位置最后 rename，或用支持事务的存储。
+
+**callback 返回 error 会发生什么**
+
+- 从 `AfterAgent` / `AfterTool` 返回非 `nil` 会**终止当前 invocation**。
+  flush 想做 best-effort 的话自己 log 后吞掉。
+
+完整可运行示例：[examples/workspace_io](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/workspace_io)。
 
 ## 环境变量与执行环境
 

--- a/examples/workspace_io/README.md
+++ b/examples/workspace_io/README.md
@@ -62,7 +62,7 @@ go run . \
 
 Expected output (abridged):
 
-```
+```text
 Workspace I/O demo
 - model:        deepseek-v4-flash
 - skill store:  /abs/path/to/examples/workspace_io/skills_store
@@ -84,7 +84,11 @@ Skill store after invocation:
 cb.RegisterAfterAgent(func(
     ctx context.Context, args *agent.AfterAgentArgs,
 ) (*agent.AfterAgentResult, error) {
-    ws, _ := workspaceio.WorkspaceFromContext(ctx)
+    ws, ok := workspaceio.WorkspaceFromContext(ctx)
+    if !ok {
+        // No code executor configured for this agent — nothing to mirror.
+        return nil, nil
+    }
     files, err := ws.Collect(ctx, "skills/*/SKILL.md")
     if err != nil {
         return nil, err

--- a/examples/workspace_io/README.md
+++ b/examples/workspace_io/README.md
@@ -1,0 +1,163 @@
+# Workspace I/O Example
+
+This example shows how to mirror files out of an `LLMAgent` workspace
+into a caller-managed store after the invocation finishes.
+
+The whole pattern is `Collect` + a sink loop, written from a regular
+`AgentCallbacks`. The framework does not bake the timing, error type,
+or budget into a sugar option — the caller writes them where they
+make sense.
+
+| API | Used for |
+| --- | --- |
+| `workspaceio.WorkspaceFromContext(ctx)` | Resolves the per-invocation workspace facade from any callback context. |
+| `ws.PutFiles(ctx, files...)` | Write one or many files into the workspace. The example calls it from `BeforeAgent` only to keep the demo self-contained; production code should stage external profile / skill files via `codeexecutor.WorkspaceInitHook` + `InputSpec` instead — see the *codeexecutor* docs. |
+| `ws.Collect(ctx, patterns...)` | Enumerate workspace files after the run; returns `[]*workspaceio.File` with `Truncated` preserved. Same pattern syntax as `codeexecutor.WorkspaceFS.Collect`; pass a literal path to read a single file and take `result[0]`. |
+| `ws.SaveArtifact(ctx, relPath)` | Persist an existing workspace file (under `work/`, `out/`, or `runs/`) as an artifact when later turns need to reference it. |
+| `ws.RunProgram(ctx, spec)` | Run a program inside the current invocation's workspace and inspect `RunResult` (stdout/stderr/exit code/timed out). Mirrors what the `workspace_exec` LLM tool gives the model. |
+
+The example uses `LocalCodeExecutor` so it runs end-to-end without
+Docker or a remote sandbox. The "user-level skill store" is just a
+host directory under `./skills_store`. Production deployments swap
+`directorySink` for whatever storage backend they use.
+
+## What the example does
+
+1. Configures an `LLMAgent` with `WithCodeExecutor(localexec.New())`.
+2. In `BeforeAgent`, resolves `Workspace` from `ctx` and pre-populates
+   the workspace with two `SKILL.md` files
+   (`skills/echoer/SKILL.md`, `skills/greeter/SKILL.md`).
+   *Demo-only convenience*: writing into the workspace from
+   `BeforeAgent` keeps this single-file example runnable without
+   external storage. In production the same projection belongs in
+   `codeexecutor.WorkspaceInitHook` (see the *codeexecutor* docs); the
+   read-side patterns shown below — `Collect` + sink — apply unchanged.
+3. Runs a trivial prompt against the configured model.
+4. In `AfterAgent`, calls `ws.Collect(ctx, "skills/*/SKILL.md")` and
+   loops over the result, validating each file and handing it to a
+   `directorySink`.
+5. `directorySink.Save` writes
+   `skills_store/<userID>/<workspace path>` on disk.
+6. Prints what landed in the store.
+
+## Prerequisites
+
+- Go 1.21 or later.
+- A reachable model endpoint (the example uses the OpenAI Go SDK,
+  which honors `OPENAI_API_KEY` and `OPENAI_BASE_URL`).
+
+## Run
+
+```bash
+export OPENAI_API_KEY="..."
+# Optionally point to an OpenAI-compatible endpoint:
+# export OPENAI_BASE_URL="https://api.deepseek.com/v1"
+
+cd examples/workspace_io
+go run . \
+  -model deepseek-v4-flash \
+  -store ./skills_store \
+  -prompt "Say a short hello so I can verify the agent finished."
+```
+
+Expected output (abridged):
+
+```
+Workspace I/O demo
+- model:        deepseek-v4-flash
+- skill store:  /abs/path/to/examples/workspace_io/skills_store
+============================================================
+seeded workspace file: skills/echoer/SKILL.md (38 bytes)
+seeded workspace file: skills/greeter/SKILL.md (37 bytes)
+[assistant] Hello!
+mirrored skills/echoer/SKILL.md -> .../skills_store/demo-user/skills/echoer/SKILL.md (38 bytes)
+mirrored skills/greeter/SKILL.md -> .../skills_store/demo-user/skills/greeter/SKILL.md (37 bytes)
+------------------------------------------------------------
+Skill store after invocation:
+- demo-user/skills/echoer/SKILL.md  (38 bytes)
+- demo-user/skills/greeter/SKILL.md (37 bytes)
+```
+
+## The wiring in three lines
+
+```go
+cb.RegisterAfterAgent(func(
+    ctx context.Context, args *agent.AfterAgentArgs,
+) (*agent.AfterAgentResult, error) {
+    ws, _ := workspaceio.WorkspaceFromContext(ctx)
+    files, err := ws.Collect(ctx, "skills/*/SKILL.md")
+    if err != nil {
+        return nil, err
+    }
+    for _, f := range files {
+        if err := sink.Save(ctx, args.Invocation, f); err != nil {
+            return nil, err
+        }
+    }
+    return nil, nil
+})
+```
+
+Returning the error from `AfterAgent` makes the failure visible to
+the caller. Log-and-swallow if you want flush to be best-effort.
+
+## Adapting the example to your stack
+
+- Replace `directorySink` with anything; the file is just `*workspaceio.File`
+  (`Path`, `Data`, `MIMEType`, `SizeBytes`, `Truncated`). Wire it to
+  a database, object store, HTTP service, etc.
+- Tighten or relax the matched paths by changing the `Collect`
+  patterns. They use the same syntax as
+  `codeexecutor.WorkspaceFS.Collect` (e.g. `out/*.json`,
+  `runs/**/result.md`).
+- Validate before sinking. The example checks for a markdown heading;
+  swap in YAML frontmatter parsing, schema checks, etc.
+- Move the same loop into `AfterTool` (filtered by tool name) if you
+  want to mirror state after every `workspace_exec` instead of after
+  the whole invocation.
+
+## Caller-owned policy
+
+The framework keeps `Workspace` deliberately thin. A few things you
+should think through and code yourself:
+
+- **Skip on failure.** The example bails out when `args.Error != nil`
+  because the workspace state is unreliable in that case. If you want
+  partial state for post-mortem, drop the early return.
+- **Truncation.** `ws.Collect` forwards the `File.Truncated` flag
+  from the backend (which caps individual reads at a few MiB). If you
+  do not want to silently mirror half of a `SKILL.md`, check the flag
+  — see `mirrorSkillsAfterAgent` in `main.go`.
+- **Volume.** A glob like `skills/**` can drag tens of MiB of
+  intermediate scratch state into your sink. Keep patterns specific,
+  cap on `len(files)` / sum of `SizeBytes`, or both.
+- **Atomicity.** `Collect` then `Save` in a loop is not transactional.
+  If you need all-or-nothing semantics, stage to a temp directory and
+  rename, or use a transactional store.
+- **Non-zero exit codes from `RunProgram`.** A non-zero `ExitCode` is
+  reported via `RunResult`, not via error — match Go's `os/exec`
+  convention. Inspect `result.ExitCode` / `result.TimedOut` and decide
+  whether to fail, retry, or accept the outcome.
+
+## Multi-node caveat
+
+`workspaceio.Workspace` is backend-agnostic but only addresses the
+*current invocation's* workspace. Whether two nodes can see the same
+workspace depends on the executor:
+
+- `local` / `container` are single-node by construction.
+- `pcg123` + CFS can persist when the deployment shares the workspace id.
+- Cube-style remote sandboxes depend on whether the runtime exposes a
+  stable handle.
+
+The pattern shown here — sinking into a caller-managed store after the
+run — is how you get cross-node visibility regardless of backend.
+
+## Where to look in the framework
+
+- `codeexecutor/workspaceio/workspace_io.go` — `Workspace`,
+  `Collect`, `PutFiles`, `SaveArtifact`, `StageInputs`, `RunProgram`.
+- `codeexecutor/workspaceio/context.go` — `WithWorkspace`,
+  `WorkspaceFromContext`.
+- `agent/llmagent/llm_agent.go` — installs the `Workspace` into the
+  invocation context whenever `WithCodeExecutor` is configured.

--- a/examples/workspace_io/main.go
+++ b/examples/workspace_io/main.go
@@ -1,0 +1,266 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+// Package main demonstrates how to mirror workspace files into a
+// caller-managed store after an LLMAgent invocation, using nothing but
+// codeexecutor/workspaceio.Workspace and a regular AgentCallbacks.
+//
+// LLMAgent does not ship a dedicated post-invocation flush option —
+// the framework leaves the timing, error type, and budget choices to
+// the caller. The pattern shown here is just:
+//
+//  1. Resolve Workspace from ctx.
+//  2. Call ws.Collect to enumerate matched files.
+//  3. Loop and pass each *workspaceio.File to your sink.
+//
+// LocalCodeExecutor keeps the example fully self-contained (no Docker,
+// no remote sandbox); the "user-level skill store" is a host directory
+// under ./skills_store. Real deployments would replace `directorySink`
+// with a database / object store / HTTP service.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
+	localexec "trpc.group/trpc-go/trpc-agent-go/codeexecutor/local"
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor/workspaceio"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/model/openai"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+)
+
+var (
+	modelName = flag.String("model", "deepseek-v4-flash", "Name of the model to use")
+	storeDir  = flag.String("store", "./skills_store",
+		"Host directory used as the user-level skill store")
+	prompt = flag.String(
+		"prompt",
+		"Say a short hello so I can verify the agent finished.",
+		"User prompt sent to the agent",
+	)
+)
+
+func main() {
+	flag.Parse()
+
+	absStore, err := filepath.Abs(*storeDir)
+	if err != nil {
+		log.Fatalf("resolve store dir: %v", err)
+	}
+	if err := os.MkdirAll(absStore, 0o755); err != nil {
+		log.Fatalf("create store dir: %v", err)
+	}
+
+	fmt.Printf("Workspace I/O demo\n")
+	fmt.Printf("- model:        %s\n", *modelName)
+	fmt.Printf("- skill store:  %s\n", absStore)
+	fmt.Println(strings.Repeat("=", 60))
+
+	sink := newDirectorySink(absStore)
+
+	cb := agent.NewCallbacks()
+	cb.RegisterBeforeAgent(seedWorkspaceProfile)
+	cb.RegisterAfterAgent(mirrorSkillsAfterAgent(sink))
+
+	a := llmagent.New(
+		"workspace-flush-demo",
+		llmagent.WithModel(openai.New(*modelName)),
+		llmagent.WithDescription(
+			"Demonstrates programmatic workspaceio.Workspace usage.",
+		),
+		llmagent.WithInstruction(
+			"You are a helpful assistant. Keep replies short.",
+		),
+		// LocalCodeExecutor gives every invocation its own work/ root.
+		// Any backend (container, pcg123 NFS, cube) would work the
+		// same way through codeexecutor.Engine.
+		llmagent.WithCodeExecutor(localexec.New()),
+		llmagent.WithAgentCallbacks(cb),
+	)
+
+	r := runner.NewRunner("workspace-flush-demo-app", a)
+	defer r.Close()
+
+	ctx := context.Background()
+	events, err := r.Run(
+		ctx, "demo-user", "demo-session",
+		model.NewUserMessage(*prompt),
+	)
+	if err != nil {
+		log.Fatalf("run agent: %v", err)
+	}
+	drainEvents(events)
+
+	fmt.Println(strings.Repeat("-", 60))
+	fmt.Println("Skill store after invocation:")
+	listStore(absStore)
+}
+
+// seedWorkspaceProfile pre-populates the workspace with two SKILL.md
+// files, simulating an agent that loaded a user profile from somewhere
+// and projected it into the workspace before the model runs.
+func seedWorkspaceProfile(
+	ctx context.Context,
+	args *agent.BeforeAgentArgs,
+) (*agent.BeforeAgentResult, error) {
+	ws, ok := workspaceio.WorkspaceFromContext(ctx)
+	if !ok {
+		log.Printf(
+			"Workspace not available; check that " +
+				"WithCodeExecutor is configured",
+		)
+		return nil, nil
+	}
+	skills := []codeexecutor.PutFile{
+		{
+			Path:    "skills/echoer/SKILL.md",
+			Content: []byte("# Echoer\n\nReplies with the same text.\n"),
+		},
+		{
+			Path:    "skills/greeter/SKILL.md",
+			Content: []byte("# Greeter\n\nGreets the user politely.\n"),
+		},
+	}
+	if err := ws.PutFiles(ctx, skills...); err != nil {
+		return nil, fmt.Errorf("seed workspace skills: %w", err)
+	}
+	for _, f := range skills {
+		log.Printf("seeded workspace file: %s (%d bytes)", f.Path, len(f.Content))
+	}
+	return nil, nil
+}
+
+// mirrorSkillsAfterAgent returns an AfterAgent callback that copies
+// every skills/*/SKILL.md from the workspace into sink. The whole
+// pattern is a single Collect plus a sink loop — there is no framework
+// helper involved on purpose.
+func mirrorSkillsAfterAgent(sink *directorySink) agent.AfterAgentCallbackStructured {
+	return func(
+		ctx context.Context, args *agent.AfterAgentArgs,
+	) (*agent.AfterAgentResult, error) {
+		// Skip mirroring when the agent itself failed; the workspace
+		// state is unreliable in that case.
+		if args.Error != nil {
+			return nil, nil
+		}
+		ws, ok := workspaceio.WorkspaceFromContext(ctx)
+		if !ok {
+			return nil, nil
+		}
+		files, err := ws.Collect(ctx, "skills/*/SKILL.md")
+		if err != nil {
+			return nil, fmt.Errorf("collect skills: %w", err)
+		}
+		for _, f := range files {
+			if f.Truncated {
+				return nil, fmt.Errorf(
+					"%s was truncated by the executor (size=%d)",
+					f.Path, f.SizeBytes,
+				)
+			}
+			if err := validateSkillMarkdown(f); err != nil {
+				return nil, err
+			}
+			if err := sink.Save(ctx, args.Invocation, f); err != nil {
+				return nil, fmt.Errorf("sink %s: %w", f.Path, err)
+			}
+		}
+		return nil, nil
+	}
+}
+
+// validateSkillMarkdown rejects empty or heading-less SKILL.md files.
+// A real validator would parse YAML frontmatter, check for required
+// headings, etc.
+func validateSkillMarkdown(file *workspaceio.File) error {
+	if len(file.Data) == 0 {
+		return fmt.Errorf("%s is empty", file.Path)
+	}
+	if !strings.Contains(string(file.Data), "#") {
+		return fmt.Errorf("%s has no markdown heading", file.Path)
+	}
+	return nil
+}
+
+// directorySink persists each mirrored workspace file under root/<userID>/<path>,
+// preserving the workspace-relative directory structure.
+type directorySink struct {
+	root string
+}
+
+func newDirectorySink(root string) *directorySink { return &directorySink{root: root} }
+
+func (s *directorySink) Save(
+	_ context.Context,
+	inv *agent.Invocation,
+	file *workspaceio.File,
+) error {
+	userID := "anonymous"
+	if inv != nil && inv.Session != nil {
+		userID = inv.Session.UserID
+	}
+	dst := filepath.Join(s.root, userID, file.Path)
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(dst, file.Data, 0o644); err != nil {
+		return err
+	}
+	log.Printf("mirrored %s -> %s (%d bytes)", file.Path, dst, len(file.Data))
+	return nil
+}
+
+func drainEvents(events <-chan *event.Event) {
+	for ev := range events {
+		if ev.Error != nil {
+			log.Printf("agent error: %s", ev.Error.Message)
+		}
+		if len(ev.Response.Choices) > 0 {
+			c := ev.Response.Choices[0]
+			if c.Message.Content != "" {
+				fmt.Printf("[assistant] %s\n", c.Message.Content)
+			}
+		}
+		if ev.Done {
+			return
+		}
+	}
+}
+
+func listStore(root string) {
+	err := filepath.WalkDir(root, func(p string, _ os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		info, err := os.Stat(p)
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel, _ := filepath.Rel(root, p)
+		fmt.Printf("- %s (%d bytes)\n", rel, info.Size())
+		return nil
+	})
+	if err != nil {
+		log.Printf("walk store: %v", err)
+	}
+}

--- a/examples/workspace_io/main.go
+++ b/examples/workspace_io/main.go
@@ -216,7 +216,16 @@ func (s *directorySink) Save(
 	if inv != nil && inv.Session != nil {
 		userID = inv.Session.UserID
 	}
-	dst := filepath.Join(s.root, userID, file.Path)
+	// Refuse to write outside s.root. file.Path comes from a workspace
+	// collector and should already be workspace-relative, but this example
+	// is copy-paste fodder — keep the containment check explicit so user
+	// code stays safe by default. filepath.IsLocal (Go 1.20+) rejects
+	// absolute paths, "..", and Windows UNC/volume escapes in one shot.
+	rel := filepath.Join(userID, file.Path)
+	if !filepath.IsLocal(rel) {
+		return fmt.Errorf("directorySink: refusing to write outside sink root: %q", rel)
+	}
+	dst := filepath.Join(s.root, rel)
 	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
 		return err
 	}

--- a/internal/workspacefacade/artifact.go
+++ b/internal/workspacefacade/artifact.go
@@ -31,12 +31,12 @@ const (
 	SaveReasonNoSessionIDs = "session app/user/session IDs are missing"
 )
 
-// ArtifactSaveSkipReason returns a non-empty string explaining why the
-// current invocation cannot persist artifacts, or "" when persistence
-// is supported.
-func ArtifactSaveSkipReason(ctx context.Context) string {
-	inv, ok := agent.InvocationFromContext(ctx)
-	if !ok || inv == nil {
+// ArtifactSaveSkipReasonInv is the single source of truth for "can this
+// invocation persist artifacts?". ArtifactSaveSkipReason, WithArtifactContext
+// and tool/workspaceexec.SupportsArtifactSave all forward to this helper so
+// the predicate stays consistent across the codebase.
+func ArtifactSaveSkipReasonInv(inv *agent.Invocation) string {
+	if inv == nil {
 		return SaveReasonNoInvocation
 	}
 	if inv.ArtifactService == nil {
@@ -51,20 +51,32 @@ func ArtifactSaveSkipReason(ctx context.Context) string {
 	return ""
 }
 
+// ArtifactSaveSkipReason returns a non-empty string explaining why the
+// current invocation cannot persist artifacts, or "" when persistence
+// is supported.
+func ArtifactSaveSkipReason(ctx context.Context) string {
+	inv, ok := agent.InvocationFromContext(ctx)
+	if !ok {
+		return SaveReasonNoInvocation
+	}
+	return ArtifactSaveSkipReasonInv(inv)
+}
+
 // WithArtifactContext copies the invocation's artifact service and
 // session info onto ctx so codeexecutor backends can persist files.
-// When the invocation does not carry that info, ctx is returned as-is.
+// Injection is gated on the same completeness check as
+// ArtifactSaveSkipReason — if any prerequisite is missing, ctx is
+// returned as-is so backends never receive a half-populated session.
 func WithArtifactContext(ctx context.Context) context.Context {
-	ctxIO := ctx
-	if inv, ok := agent.InvocationFromContext(ctx); ok &&
-		inv != nil && inv.ArtifactService != nil &&
-		inv.Session != nil {
-		ctxIO = codeexecutor.WithArtifactService(ctxIO, inv.ArtifactService)
-		ctxIO = codeexecutor.WithArtifactSession(ctxIO, artifact.SessionInfo{
-			AppName:   inv.Session.AppName,
-			UserID:    inv.Session.UserID,
-			SessionID: inv.Session.ID,
-		})
+	inv, ok := agent.InvocationFromContext(ctx)
+	if !ok || ArtifactSaveSkipReasonInv(inv) != "" {
+		return ctx
 	}
+	ctxIO := codeexecutor.WithArtifactService(ctx, inv.ArtifactService)
+	ctxIO = codeexecutor.WithArtifactSession(ctxIO, artifact.SessionInfo{
+		AppName:   inv.Session.AppName,
+		UserID:    inv.Session.UserID,
+		SessionID: inv.Session.ID,
+	})
 	return ctxIO
 }

--- a/internal/workspacefacade/artifact.go
+++ b/internal/workspacefacade/artifact.go
@@ -1,0 +1,70 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package workspacefacade
+
+import (
+	"context"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/artifact"
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
+)
+
+// DefaultArtifactMaxBytes is the default per-file cap for artifact
+// publishing flows when the caller does not provide one.
+const DefaultArtifactMaxBytes int64 = 64 * 1024 * 1024
+
+// Reasons returned by ArtifactSaveSkipReason; an empty string means
+// the current invocation can persist artifacts.
+const (
+	SaveReasonNoInvocation = "invocation is missing from context"
+	SaveReasonNoService    = "artifact service is not configured"
+	SaveReasonNoSession    = "session is missing from invocation"
+	SaveReasonNoSessionIDs = "session app/user/session IDs are missing"
+)
+
+// ArtifactSaveSkipReason returns a non-empty string explaining why the
+// current invocation cannot persist artifacts, or "" when persistence
+// is supported.
+func ArtifactSaveSkipReason(ctx context.Context) string {
+	inv, ok := agent.InvocationFromContext(ctx)
+	if !ok || inv == nil {
+		return SaveReasonNoInvocation
+	}
+	if inv.ArtifactService == nil {
+		return SaveReasonNoService
+	}
+	if inv.Session == nil {
+		return SaveReasonNoSession
+	}
+	if inv.Session.AppName == "" || inv.Session.UserID == "" || inv.Session.ID == "" {
+		return SaveReasonNoSessionIDs
+	}
+	return ""
+}
+
+// WithArtifactContext copies the invocation's artifact service and
+// session info onto ctx so codeexecutor backends can persist files.
+// When the invocation does not carry that info, ctx is returned as-is.
+func WithArtifactContext(ctx context.Context) context.Context {
+	ctxIO := ctx
+	if inv, ok := agent.InvocationFromContext(ctx); ok &&
+		inv != nil && inv.ArtifactService != nil &&
+		inv.Session != nil {
+		ctxIO = codeexecutor.WithArtifactService(ctxIO, inv.ArtifactService)
+		ctxIO = codeexecutor.WithArtifactSession(ctxIO, artifact.SessionInfo{
+			AppName:   inv.Session.AppName,
+			UserID:    inv.Session.UserID,
+			SessionID: inv.Session.ID,
+		})
+	}
+	return ctxIO
+}

--- a/internal/workspacefacade/artifact_test.go
+++ b/internal/workspacefacade/artifact_test.go
@@ -1,0 +1,81 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package workspacefacade
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/artifact/inmemory"
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+func TestArtifactSaveSkipReason(t *testing.T) {
+	require.Equal(t, SaveReasonNoInvocation, ArtifactSaveSkipReason(context.Background()))
+
+	noSvc := agent.NewInvocationContext(context.Background(), agent.NewInvocation(
+		agent.WithInvocationMessage(model.NewUserMessage("hi")),
+		agent.WithInvocationSession(&session.Session{
+			ID:      "sess",
+			AppName: "app",
+			UserID:  "user",
+		}),
+	))
+	require.Equal(t, SaveReasonNoService, ArtifactSaveSkipReason(noSvc))
+
+	noSession := agent.NewInvocationContext(context.Background(), agent.NewInvocation(
+		agent.WithInvocationMessage(model.NewUserMessage("hi")),
+		agent.WithInvocationArtifactService(inmemory.NewService()),
+	))
+	require.Equal(t, SaveReasonNoSession, ArtifactSaveSkipReason(noSession))
+
+	incompleteSession := agent.NewInvocationContext(context.Background(), agent.NewInvocation(
+		agent.WithInvocationMessage(model.NewUserMessage("hi")),
+		agent.WithInvocationArtifactService(inmemory.NewService()),
+		agent.WithInvocationSession(&session.Session{ID: "sess"}),
+	))
+	require.Equal(t, SaveReasonNoSessionIDs, ArtifactSaveSkipReason(incompleteSession))
+
+	complete := agent.NewInvocationContext(context.Background(), agent.NewInvocation(
+		agent.WithInvocationMessage(model.NewUserMessage("hi")),
+		agent.WithInvocationArtifactService(inmemory.NewService()),
+		agent.WithInvocationSession(&session.Session{
+			ID:      "sess",
+			AppName: "app",
+			UserID:  "user",
+		}),
+	))
+	require.Equal(t, "", ArtifactSaveSkipReason(complete))
+}
+
+func TestWithArtifactContext(t *testing.T) {
+	inv := agent.NewInvocation(
+		agent.WithInvocationMessage(model.NewUserMessage("hi")),
+		agent.WithInvocationArtifactService(inmemory.NewService()),
+		agent.WithInvocationSession(&session.Session{
+			ID:      "sess",
+			AppName: "app",
+			UserID:  "user",
+		}),
+	)
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+
+	out := WithArtifactContext(ctx)
+	_, ok := codeexecutor.ArtifactServiceFromContext(out)
+	require.True(t, ok)
+	_, err := codeexecutor.SaveArtifactHelper(out, "out/site.zip", []byte("payload"), "text/plain")
+	require.NoError(t, err)
+}

--- a/internal/workspacefacade/paths.go
+++ b/internal/workspacefacade/paths.go
@@ -1,0 +1,123 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+// Package workspacefacade hosts implementation primitives shared by the
+// codeexecutor/workspaceio facade and the tool/workspaceexec LLM tools.
+// Nothing in this package is part of the public API.
+package workspacefacade
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
+)
+
+// HasGlobMeta reports whether s contains any glob metacharacter.
+func HasGlobMeta(s string) bool {
+	return strings.ContainsAny(s, "*?[")
+}
+
+// IsWorkspaceEnvPath reports whether s starts with a recognized
+// workspace env-prefixed path such as $WORK_DIR/... or
+// ${SKILLS_DIR}/....
+func IsWorkspaceEnvPath(s string) bool {
+	return hasEnvPrefix(s, codeexecutor.WorkspaceEnvDirKey) ||
+		hasEnvPrefix(s, codeexecutor.EnvSkillsDir) ||
+		hasEnvPrefix(s, codeexecutor.EnvWorkDir) ||
+		hasEnvPrefix(s, codeexecutor.EnvOutputDir) ||
+		hasEnvPrefix(s, codeexecutor.EnvRunDir)
+}
+
+// NormalizeArtifactPath validates a single-file path used by artifact
+// publishing entry points (workspace_save_artifact LLM tool and
+// Workspace.SaveArtifact). Globs and parent traversal are rejected.
+// The returned path is always workspace-relative, clean, and confirmed
+// to live under one of the supported publish roots (work/, out/,
+// runs/).
+func NormalizeArtifactPath(raw string) (string, error) {
+	s := strings.TrimSpace(raw)
+	s = strings.ReplaceAll(s, "\\", "/")
+	if s == "" {
+		return "", errors.New("path is required")
+	}
+	if HasGlobMeta(s) {
+		return "", errors.New("path must not contain glob patterns")
+	}
+	if IsWorkspaceEnvPath(s) {
+		out := codeexecutor.NormalizeGlobs([]string{s})
+		if len(out) == 0 {
+			return "", errors.New("invalid path")
+		}
+		s = out[0]
+	}
+	if strings.HasPrefix(s, "/") {
+		rel := strings.TrimPrefix(path.Clean(s), "/")
+		if rel == "" || rel == "." {
+			return "", errors.New("path must point to a file inside the workspace")
+		}
+		if !IsAllowedPublishArtifactPath(rel) {
+			return "", fmt.Errorf(
+				"path must stay under supported artifact roots such as work/, out/, or runs/: %q",
+				raw,
+			)
+		}
+		return rel, nil
+	}
+	rel := path.Clean(s)
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, "../") {
+		return "", errors.New("path must stay within the workspace")
+	}
+	if !IsAllowedPublishArtifactPath(rel) {
+		return "", fmt.Errorf(
+			"path must stay under supported artifact roots such as work/, out/, or runs/: %q",
+			raw,
+		)
+	}
+	return rel, nil
+}
+
+// IsAllowedPublishArtifactPath reports whether rel resolves to a
+// workspace path under work/, out/, or runs/.
+func IsAllowedPublishArtifactPath(rel string) bool {
+	switch {
+	case rel == codeexecutor.DirWork || strings.HasPrefix(rel, codeexecutor.DirWork+"/"):
+		return true
+	case rel == codeexecutor.DirOut || strings.HasPrefix(rel, codeexecutor.DirOut+"/"):
+		return true
+	case rel == codeexecutor.DirRuns || strings.HasPrefix(rel, codeexecutor.DirRuns+"/"):
+		return true
+	default:
+		return false
+	}
+}
+
+const (
+	envVarPrefix = "$"
+	envVarLBrace = "${"
+	envVarRBrace = "}"
+)
+
+// hasEnvPrefix reports whether s starts with an env reference such as
+// $name or ${name} followed by either nothing or a path separator.
+func hasEnvPrefix(s, name string) bool {
+	if strings.HasPrefix(s, envVarPrefix+name) {
+		tail := s[len(envVarPrefix+name):]
+		return tail == "" || strings.HasPrefix(tail, "/") || strings.HasPrefix(tail, "\\")
+	}
+	prefix := envVarLBrace + name + envVarRBrace
+	if strings.HasPrefix(s, prefix) {
+		tail := s[len(prefix):]
+		return tail == "" || strings.HasPrefix(tail, "/") || strings.HasPrefix(tail, "\\")
+	}
+	return false
+}

--- a/internal/workspacefacade/paths.go
+++ b/internal/workspacefacade/paths.go
@@ -101,6 +101,85 @@ func IsAllowedPublishArtifactPath(rel string) bool {
 	}
 }
 
+// IsAllowedWorkspaceRoot reports whether rel resolves to one of the
+// workspace roots reachable for read/write/exec operations
+// (skills/, work/, out/, runs/). Looser than
+// IsAllowedPublishArtifactPath, which excludes skills/ because artifact
+// publishing must not target skill assets.
+func IsAllowedWorkspaceRoot(rel string) bool {
+	switch {
+	case rel == codeexecutor.DirSkills || strings.HasPrefix(rel, codeexecutor.DirSkills+"/"):
+		return true
+	case rel == codeexecutor.DirWork || strings.HasPrefix(rel, codeexecutor.DirWork+"/"):
+		return true
+	case rel == codeexecutor.DirOut || strings.HasPrefix(rel, codeexecutor.DirOut+"/"):
+		return true
+	case rel == codeexecutor.DirRuns || strings.HasPrefix(rel, codeexecutor.DirRuns+"/"):
+		return true
+	default:
+		return false
+	}
+}
+
+// NormalizeWorkspaceCWD canonicalises a working-directory string for
+// program execution against the current invocation's workspace. It is
+// the single source of truth for "is this Cwd safe?" — both the
+// workspace_exec LLM tool and Workspace.RunProgram forward to it so a
+// single rule set governs Cwd containment.
+//
+// Behavior:
+//   - empty / whitespace-only returns ".", meaning workspace root.
+//   - glob metacharacters are rejected.
+//   - $WORK / $OUT / $RUNS / $SKILLS env-prefixed paths are expanded
+//     to their workspace-relative form via codeexecutor.NormalizeGlobs.
+//   - absolute paths (leading "/") are stripped to workspace-relative
+//     and then checked against IsAllowedWorkspaceRoot.
+//   - relative paths that traverse out of the workspace ("..", "../*")
+//     are rejected outright.
+//   - any other relative path must resolve under
+//     IsAllowedWorkspaceRoot (skills/, work/, out/, runs/).
+func NormalizeWorkspaceCWD(raw string) (string, error) {
+	s := strings.TrimSpace(raw)
+	s = strings.ReplaceAll(s, "\\", "/")
+	if s == "" {
+		return ".", nil
+	}
+	if HasGlobMeta(s) {
+		return "", errors.New("cwd must not contain glob patterns")
+	}
+	if IsWorkspaceEnvPath(s) {
+		out := codeexecutor.NormalizeGlobs([]string{s})
+		if len(out) == 0 {
+			return "", errors.New("invalid cwd")
+		}
+		s = out[0]
+	}
+	if strings.HasPrefix(s, "/") {
+		rel := strings.TrimPrefix(path.Clean(s), "/")
+		if rel == "" || rel == "." {
+			return ".", nil
+		}
+		if !IsAllowedWorkspaceRoot(rel) {
+			return "", fmt.Errorf("cwd must stay under workspace roots: %q", raw)
+		}
+		return rel, nil
+	}
+	rel := path.Clean(s)
+	if rel == "." {
+		return ".", nil
+	}
+	if rel == ".." || strings.HasPrefix(rel, "../") {
+		return "", errors.New("cwd must stay within the workspace")
+	}
+	if !IsAllowedWorkspaceRoot(rel) {
+		return "", fmt.Errorf(
+			"cwd must stay under supported workspace roots such as work/, out/, or runs/: %q",
+			raw,
+		)
+	}
+	return rel, nil
+}
+
 const (
 	envVarPrefix = "$"
 	envVarLBrace = "${"

--- a/internal/workspacefacade/paths_test.go
+++ b/internal/workspacefacade/paths_test.go
@@ -16,6 +16,57 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestIsAllowedWorkspaceRoot(t *testing.T) {
+	// Looser than IsAllowedPublishArtifactPath — also accepts skills/.
+	require.True(t, IsAllowedWorkspaceRoot("skills"))
+	require.True(t, IsAllowedWorkspaceRoot("skills/echoer"))
+	require.True(t, IsAllowedWorkspaceRoot("work"))
+	require.True(t, IsAllowedWorkspaceRoot("work/x.txt"))
+	require.True(t, IsAllowedWorkspaceRoot("out/done.bin"))
+	require.True(t, IsAllowedWorkspaceRoot("runs/foo/bar"))
+	require.False(t, IsAllowedWorkspaceRoot(""))
+	require.False(t, IsAllowedWorkspaceRoot("etc/passwd"))
+	require.False(t, IsAllowedWorkspaceRoot("workspaces"))
+}
+
+func TestNormalizeWorkspaceCWD(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr string
+	}{
+		{name: "empty becomes root", in: "", want: "."},
+		{name: "whitespace becomes root", in: "   ", want: "."},
+		{name: "dot stays root", in: ".", want: "."},
+		{name: "work root", in: "work", want: "work"},
+		{name: "nested out path", in: "out/sub/file", want: "out/sub/file"},
+		{name: "windows separators", in: "work\\sub", want: "work/sub"},
+		{name: "absolute to work", in: "/work/x", want: "work/x"},
+		{name: "absolute root collapses", in: "/", want: "."},
+		{name: "env-prefixed path expands", in: "${WORK_DIR}/x", want: "work/x"},
+
+		{name: "rejects glob", in: "work/*.txt", wantErr: "glob"},
+		{name: "rejects parent escape", in: "..", wantErr: "stay within"},
+		{name: "rejects parent prefix escape", in: "../etc", wantErr: "stay within"},
+		{name: "rejects disallowed root", in: "etc/passwd", wantErr: "workspace roots"},
+		{name: "rejects absolute disallowed root", in: "/etc/passwd", wantErr: "workspace roots"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := NormalizeWorkspaceCWD(tc.in)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
 func TestHasGlobMeta(t *testing.T) {
 	require.False(t, HasGlobMeta(""))
 	require.False(t, HasGlobMeta("work/demo.txt"))

--- a/internal/workspacefacade/paths_test.go
+++ b/internal/workspacefacade/paths_test.go
@@ -1,0 +1,67 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package workspacefacade
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHasGlobMeta(t *testing.T) {
+	require.False(t, HasGlobMeta(""))
+	require.False(t, HasGlobMeta("work/demo.txt"))
+	require.True(t, HasGlobMeta("work/*.txt"))
+	require.True(t, HasGlobMeta("work/?.txt"))
+	require.True(t, HasGlobMeta("work/[abc].txt"))
+}
+
+func TestIsWorkspaceEnvPath(t *testing.T) {
+	require.True(t, IsWorkspaceEnvPath("$WORK_DIR/demo"))
+	require.True(t, IsWorkspaceEnvPath("${OUTPUT_DIR}/demo"))
+	require.True(t, IsWorkspaceEnvPath("${SKILLS_DIR}/demo"))
+	require.False(t, IsWorkspaceEnvPath("$OUTPUT_DIR_demo"))
+	require.False(t, IsWorkspaceEnvPath("/tmp/demo"))
+	require.False(t, IsWorkspaceEnvPath(""))
+}
+
+func TestNormalizeArtifactPath(t *testing.T) {
+	rel, err := NormalizeArtifactPath("/out/site.zip")
+	require.NoError(t, err)
+	require.Equal(t, "out/site.zip", rel)
+
+	rel, err = NormalizeArtifactPath("${OUTPUT_DIR}/site.zip")
+	require.NoError(t, err)
+	require.Equal(t, "out/site.zip", rel)
+
+	_, err = NormalizeArtifactPath("")
+	require.Error(t, err)
+
+	_, err = NormalizeArtifactPath("/")
+	require.Error(t, err)
+
+	_, err = NormalizeArtifactPath("../site.zip")
+	require.Error(t, err)
+
+	_, err = NormalizeArtifactPath("tmp/site.zip")
+	require.Error(t, err)
+
+	_, err = NormalizeArtifactPath("work/*.txt")
+	require.Error(t, err)
+}
+
+func TestIsAllowedPublishArtifactPath(t *testing.T) {
+	require.True(t, IsAllowedPublishArtifactPath("work/demo"))
+	require.True(t, IsAllowedPublishArtifactPath("out/demo"))
+	require.True(t, IsAllowedPublishArtifactPath("runs/demo"))
+	require.False(t, IsAllowedPublishArtifactPath("skills/demo"))
+	require.False(t, IsAllowedPublishArtifactPath("tmp/demo"))
+}

--- a/tool/workspaceexec/save_artifact.go
+++ b/tool/workspaceexec/save_artifact.go
@@ -14,18 +14,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"path"
 	"strings"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
-	"trpc.group/trpc-go/trpc-agent-go/artifact"
 	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
 	"trpc.group/trpc-go/trpc-agent-go/internal/fileref"
+	"trpc.group/trpc-go/trpc-agent-go/internal/workspacefacade"
 	"trpc.group/trpc-go/trpc-agent-go/skill"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
-
-const defaultWorkspaceArtifactMaxBytes = 64 * 1024 * 1024
 
 // SaveArtifactTool persists an existing workspace file as an artifact.
 type SaveArtifactTool struct {
@@ -108,18 +105,18 @@ func (t *SaveArtifactTool) Call(
 	if err := json.Unmarshal(input, &in); err != nil {
 		return nil, err
 	}
-	rel, err := normalizeArtifactPath(in.Path)
+	rel, err := workspacefacade.NormalizeArtifactPath(in.Path)
 	if err != nil {
 		return nil, err
 	}
-	reason := artifactSaveSkipReason(ctx)
+	reason := workspacefacade.ArtifactSaveSkipReason(ctx)
 	if reason != "" {
 		return nil, fmt.Errorf(
 			"workspace_save_artifact requires artifact service and session info: %s",
 			reason,
 		)
 	}
-	ctxIO := withArtifactContext(ctx)
+	ctxIO := workspacefacade.WithArtifactContext(ctx)
 	eng, err := t.exec.liveEngine()
 	if err != nil {
 		return nil, err
@@ -131,8 +128,8 @@ func (t *SaveArtifactTool) Call(
 	manifest, err := eng.FS().CollectOutputs(ctxIO, ws, codeexecutor.OutputSpec{
 		Globs:         []string{rel},
 		MaxFiles:      1,
-		MaxFileBytes:  defaultWorkspaceArtifactMaxBytes,
-		MaxTotalBytes: defaultWorkspaceArtifactMaxBytes,
+		MaxFileBytes:  workspacefacade.DefaultArtifactMaxBytes,
+		MaxTotalBytes: workspacefacade.DefaultArtifactMaxBytes,
 		Save:          true,
 		Inline:        false,
 	})
@@ -202,13 +199,6 @@ func (t *SaveArtifactTool) StateDelta(
 	}
 }
 
-const (
-	saveReasonNoInvocation = "invocation is missing from context"
-	saveReasonNoService    = "artifact service is not configured"
-	saveReasonNoSession    = "session is missing from invocation"
-	saveReasonNoSessionIDs = "session app/user/session IDs are missing"
-)
-
 // SupportsArtifactSave reports whether the current invocation can
 // persist artifacts for workspace tools.
 func SupportsArtifactSave(inv *agent.Invocation) bool {
@@ -220,93 +210,6 @@ func SupportsArtifactSave(inv *agent.Invocation) bool {
 		return false
 	}
 	return true
-}
-
-func artifactSaveSkipReason(ctx context.Context) string {
-	inv, ok := agent.InvocationFromContext(ctx)
-	if !ok || inv == nil {
-		return saveReasonNoInvocation
-	}
-	if inv.ArtifactService == nil {
-		return saveReasonNoService
-	}
-	if inv.Session == nil {
-		return saveReasonNoSession
-	}
-	if !SupportsArtifactSave(inv) {
-		return saveReasonNoSessionIDs
-	}
-	return ""
-}
-
-func withArtifactContext(ctx context.Context) context.Context {
-	ctxIO := ctx
-	if inv, ok := agent.InvocationFromContext(ctx); ok &&
-		inv != nil && inv.ArtifactService != nil &&
-		inv.Session != nil {
-		ctxIO = codeexecutor.WithArtifactService(ctxIO, inv.ArtifactService)
-		ctxIO = codeexecutor.WithArtifactSession(ctxIO, artifact.SessionInfo{
-			AppName:   inv.Session.AppName,
-			UserID:    inv.Session.UserID,
-			SessionID: inv.Session.ID,
-		})
-	}
-	return ctxIO
-}
-
-func normalizeArtifactPath(raw string) (string, error) {
-	s := strings.TrimSpace(raw)
-	s = strings.ReplaceAll(s, "\\", "/")
-	if s == "" {
-		return "", errors.New("path is required")
-	}
-	if hasGlobMeta(s) {
-		return "", errors.New("path must not contain glob patterns")
-	}
-	if isWorkspaceEnvPath(s) {
-		out := codeexecutor.NormalizeGlobs([]string{s})
-		if len(out) == 0 {
-			return "", errors.New("invalid path")
-		}
-		s = out[0]
-	}
-	if strings.HasPrefix(s, "/") {
-		rel := strings.TrimPrefix(path.Clean(s), "/")
-		if rel == "" || rel == "." {
-			return "", errors.New("path must point to a file inside the workspace")
-		}
-		if !isAllowedPublishArtifactPath(rel) {
-			return "", fmt.Errorf(
-				"path must stay under supported artifact roots such as work/, out/, or runs/: %q",
-				raw,
-			)
-		}
-		return rel, nil
-	}
-	rel := path.Clean(s)
-	if rel == "." || rel == ".." || strings.HasPrefix(rel, "../") {
-		return "", errors.New("path must stay within the workspace")
-	}
-	if !isAllowedPublishArtifactPath(rel) {
-		return "", fmt.Errorf(
-			"path must stay under supported artifact roots such as work/, out/, or runs/: %q",
-			raw,
-		)
-	}
-	return rel, nil
-}
-
-func isAllowedPublishArtifactPath(rel string) bool {
-	switch {
-	case rel == codeexecutor.DirWork || strings.HasPrefix(rel, codeexecutor.DirWork+"/"):
-		return true
-	case rel == codeexecutor.DirOut || strings.HasPrefix(rel, codeexecutor.DirOut+"/"):
-		return true
-	case rel == codeexecutor.DirRuns || strings.HasPrefix(rel, codeexecutor.DirRuns+"/"):
-		return true
-	default:
-		return false
-	}
 }
 
 var _ tool.Tool = (*SaveArtifactTool)(nil)

--- a/tool/workspaceexec/save_artifact.go
+++ b/tool/workspaceexec/save_artifact.go
@@ -200,16 +200,11 @@ func (t *SaveArtifactTool) StateDelta(
 }
 
 // SupportsArtifactSave reports whether the current invocation can
-// persist artifacts for workspace tools.
+// persist artifacts for workspace tools. It forwards to
+// workspacefacade.ArtifactSaveSkipReasonInv so the predicate stays in
+// sync with workspacefacade.ArtifactSaveSkipReason (used by Call).
 func SupportsArtifactSave(inv *agent.Invocation) bool {
-	if inv == nil || inv.ArtifactService == nil || inv.Session == nil {
-		return false
-	}
-	if inv.Session.AppName == "" || inv.Session.UserID == "" ||
-		inv.Session.ID == "" {
-		return false
-	}
-	return true
+	return workspacefacade.ArtifactSaveSkipReasonInv(inv) == ""
 }
 
 var _ tool.Tool = (*SaveArtifactTool)(nil)

--- a/tool/workspaceexec/save_artifact_test.go
+++ b/tool/workspaceexec/save_artifact_test.go
@@ -375,6 +375,8 @@ func TestSaveArtifactTool_SupportsArtifactSave_Negatives(t *testing.T) {
 		})},
 	}
 	for _, tc := range cases {
+		tc := tc // Go 1.21 range-var scoping: rebind for safety against
+		// future t.Parallel() calls. Cheap defensive write.
 		t.Run(tc.name, func(t *testing.T) {
 			require.False(t, SupportsArtifactSave(tc.inv))
 		})

--- a/tool/workspaceexec/save_artifact_test.go
+++ b/tool/workspaceexec/save_artifact_test.go
@@ -332,6 +332,55 @@ func TestSaveArtifactTool_SupportsArtifactSave(t *testing.T) {
 	require.True(t, SupportsArtifactSave(inv))
 }
 
+// TestSaveArtifactTool_SupportsArtifactSave_Negatives directly pins the
+// false branches of SupportsArtifactSave. Call's tests exercise the same
+// preconditions through workspacefacade.ArtifactSaveSkipReason, but the
+// exported helper is a public contract on its own and deserves direct
+// coverage so refactors can't silently drift the predicate.
+func TestSaveArtifactTool_SupportsArtifactSave_Negatives(t *testing.T) {
+	svc := inmemory.NewService()
+	mkInv := func(mutate func(b *agent.Invocation)) *agent.Invocation {
+		inv := agent.NewInvocation(
+			agent.WithInvocationMessage(model.NewUserMessage("hi")),
+			agent.WithInvocationSession(&session.Session{
+				ID:      "sess",
+				AppName: "app",
+				UserID:  "user",
+			}),
+			agent.WithInvocationArtifactService(svc),
+		)
+		if mutate != nil {
+			mutate(inv)
+		}
+		return inv
+	}
+
+	cases := []struct {
+		name string
+		inv  *agent.Invocation
+	}{
+		{"nil invocation", nil},
+		{"missing artifact service", mkInv(func(b *agent.Invocation) {
+			b.ArtifactService = nil
+		})},
+		{"nil session", mkInv(func(b *agent.Invocation) { b.Session = nil })},
+		{"empty app name", mkInv(func(b *agent.Invocation) {
+			b.Session.AppName = ""
+		})},
+		{"empty user id", mkInv(func(b *agent.Invocation) {
+			b.Session.UserID = ""
+		})},
+		{"empty session id", mkInv(func(b *agent.Invocation) {
+			b.Session.ID = ""
+		})},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.False(t, SupportsArtifactSave(tc.inv))
+		})
+	}
+}
+
 func saveArtifactContext() context.Context {
 	svc := inmemory.NewService()
 	inv := agent.NewInvocation(

--- a/tool/workspaceexec/save_artifact_test.go
+++ b/tool/workspaceexec/save_artifact_test.go
@@ -24,6 +24,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/artifact/inmemory"
 	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
 	localexec "trpc.group/trpc-go/trpc-agent-go/codeexecutor/local"
+	"trpc.group/trpc-go/trpc-agent-go/internal/workspacefacade"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	"trpc.group/trpc-go/trpc-agent-go/skill"
@@ -175,7 +176,7 @@ func TestSaveArtifactTool_RequiresInvocationContext(t *testing.T) {
 
 	_, err = tl.Call(context.Background(), enc)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), saveReasonNoInvocation)
+	require.Contains(t, err.Error(), workspacefacade.SaveReasonNoInvocation)
 }
 
 func TestSaveArtifactTool_RequiresCompleteSessionIDs(t *testing.T) {
@@ -193,35 +194,7 @@ func TestSaveArtifactTool_RequiresCompleteSessionIDs(t *testing.T) {
 
 	_, err = tl.Call(ctx, enc)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), saveReasonNoSessionIDs)
-}
-
-func TestSaveArtifactTool_NormalizesPathVariants(t *testing.T) {
-	rel, err := normalizeArtifactPath("/out/site.zip")
-	require.NoError(t, err)
-	require.Equal(t, "out/site.zip", rel)
-
-	rel, err = normalizeArtifactPath("${OUTPUT_DIR}/site.zip")
-	require.NoError(t, err)
-	require.Equal(t, "out/site.zip", rel)
-}
-
-func TestSaveArtifactTool_NormalizePathValidation(t *testing.T) {
-	_, err := normalizeArtifactPath("")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "path is required")
-
-	_, err = normalizeArtifactPath("/")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "inside the workspace")
-
-	_, err = normalizeArtifactPath("../site.zip")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "stay within the workspace")
-
-	_, err = normalizeArtifactPath("tmp/site.zip")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "supported artifact roots")
+	require.Contains(t, err.Error(), workspacefacade.SaveReasonNoSessionIDs)
 }
 
 func TestSaveArtifactTool_RejectsMissingFile(t *testing.T) {
@@ -352,43 +325,11 @@ func TestSaveArtifactTool_StateDeltaFallbacks(t *testing.T) {
 	require.Nil(t, tl.StateDelta("call-4", nil, []byte(`{"saved_as":"out/site.zip","version":-1}`)))
 }
 
-func TestSaveArtifactTool_ArtifactContextHelpers(t *testing.T) {
-	require.Equal(t, saveReasonNoInvocation, artifactSaveSkipReason(context.Background()))
-
-	noSvc := agent.NewInvocationContext(context.Background(), agent.NewInvocation(
-		agent.WithInvocationMessage(model.NewUserMessage("hi")),
-		agent.WithInvocationSession(&session.Session{
-			ID:      "sess",
-			AppName: "app",
-			UserID:  "user",
-		}),
-	))
-	require.Equal(t, saveReasonNoService, artifactSaveSkipReason(noSvc))
-
-	noSession := agent.NewInvocationContext(context.Background(), agent.NewInvocation(
-		agent.WithInvocationMessage(model.NewUserMessage("hi")),
-		agent.WithInvocationArtifactService(inmemory.NewService()),
-	))
-	require.Equal(t, saveReasonNoSession, artifactSaveSkipReason(noSession))
-
-	incompleteSession := agent.NewInvocationContext(context.Background(), agent.NewInvocation(
-		agent.WithInvocationMessage(model.NewUserMessage("hi")),
-		agent.WithInvocationArtifactService(inmemory.NewService()),
-		agent.WithInvocationSession(&session.Session{ID: "sess"}),
-	))
-	require.Equal(t, saveReasonNoSessionIDs, artifactSaveSkipReason(incompleteSession))
-
+func TestSaveArtifactTool_SupportsArtifactSave(t *testing.T) {
 	ctx := saveArtifactContext()
-	require.Equal(t, "", artifactSaveSkipReason(ctx))
 	inv, ok := agent.InvocationFromContext(ctx)
 	require.True(t, ok)
 	require.True(t, SupportsArtifactSave(inv))
-
-	ctx = withArtifactContext(ctx)
-	_, ok = codeexecutor.ArtifactServiceFromContext(ctx)
-	require.True(t, ok)
-	_, err := codeexecutor.SaveArtifactHelper(ctx, "out/site.zip", []byte("payload"), "text/plain")
-	require.NoError(t, err)
 }
 
 func saveArtifactContext() context.Context {

--- a/tool/workspaceexec/workspace_exec.go
+++ b/tool/workspaceexec/workspace_exec.go
@@ -16,7 +16,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"path"
 	"strings"
 	"sync"
 	"time"
@@ -800,46 +799,11 @@ func (t *ExecTool) markSessionFinalized(sess *execSession) {
 	sess.exitedAt = now
 }
 
+// normalizeCWD forwards to workspacefacade.NormalizeWorkspaceCWD so the
+// LLM workspace_exec tool and Workspace.RunProgram share one canonical
+// containment policy. Keep the wrapper for the existing call sites.
 func normalizeCWD(raw string) (string, error) {
-	s := strings.TrimSpace(raw)
-	s = strings.ReplaceAll(s, "\\", "/")
-	if s == "" {
-		return ".", nil
-	}
-	if workspacefacade.HasGlobMeta(s) {
-		return "", errors.New("cwd must not contain glob patterns")
-	}
-	if workspacefacade.IsWorkspaceEnvPath(s) {
-		out := codeexecutor.NormalizeGlobs([]string{s})
-		if len(out) == 0 {
-			return "", errors.New("invalid cwd")
-		}
-		s = out[0]
-	}
-	if strings.HasPrefix(s, "/") {
-		rel := strings.TrimPrefix(path.Clean(s), "/")
-		if rel == "" || rel == "." {
-			return ".", nil
-		}
-		if !isAllowedWorkspacePath(rel) {
-			return "", fmt.Errorf("cwd must stay under workspace roots: %q", raw)
-		}
-		return rel, nil
-	}
-	rel := path.Clean(s)
-	if rel == "." {
-		return ".", nil
-	}
-	if rel == ".." || strings.HasPrefix(rel, "../") {
-		return "", errors.New("cwd must stay within the workspace")
-	}
-	if !isAllowedWorkspacePath(rel) {
-		return "", fmt.Errorf(
-			"cwd must stay under supported workspace roots such as work/, out/, or runs/: %q",
-			raw,
-		)
-	}
-	return rel, nil
+	return workspacefacade.NormalizeWorkspaceCWD(raw)
 }
 
 func supportsInteractiveSessions(exec codeexecutor.CodeExecutor) bool {
@@ -968,19 +932,12 @@ func intPtrValue(v int) *int {
 	return &v
 }
 
+// isAllowedWorkspacePath forwards to
+// workspacefacade.IsAllowedWorkspaceRoot. Kept as a package-private
+// alias for the few remaining call sites; new code should call the
+// facade helper directly.
 func isAllowedWorkspacePath(rel string) bool {
-	switch {
-	case rel == codeexecutor.DirSkills || strings.HasPrefix(rel, codeexecutor.DirSkills+"/"):
-		return true
-	case rel == codeexecutor.DirWork || strings.HasPrefix(rel, codeexecutor.DirWork+"/"):
-		return true
-	case rel == codeexecutor.DirOut || strings.HasPrefix(rel, codeexecutor.DirOut+"/"):
-		return true
-	case rel == codeexecutor.DirRuns || strings.HasPrefix(rel, codeexecutor.DirRuns+"/"):
-		return true
-	default:
-		return false
-	}
+	return workspacefacade.IsAllowedWorkspaceRoot(rel)
 }
 
 var _ tool.Tool = (*ExecTool)(nil)

--- a/tool/workspaceexec/workspace_exec.go
+++ b/tool/workspaceexec/workspace_exec.go
@@ -24,6 +24,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
 	"trpc.group/trpc-go/trpc-agent-go/internal/programsession"
+	"trpc.group/trpc-go/trpc-agent-go/internal/workspacefacade"
 	"trpc.group/trpc-go/trpc-agent-go/internal/workspaceinput"
 	"trpc.group/trpc-go/trpc-agent-go/internal/workspaceprep"
 	"trpc.group/trpc-go/trpc-agent-go/internal/workspacesession"
@@ -805,10 +806,10 @@ func normalizeCWD(raw string) (string, error) {
 	if s == "" {
 		return ".", nil
 	}
-	if hasGlobMeta(s) {
+	if workspacefacade.HasGlobMeta(s) {
 		return "", errors.New("cwd must not contain glob patterns")
 	}
-	if isWorkspaceEnvPath(s) {
+	if workspacefacade.IsWorkspaceEnvPath(s) {
 		out := codeexecutor.NormalizeGlobs([]string{s})
 		if len(out) == 0 {
 			return "", errors.New("invalid cwd")
@@ -885,10 +886,6 @@ func pollOutput(sessionID string, poll codeexecutor.ProgramPoll) execOutput {
 		out.SessionID = sessionID
 	}
 	return out
-}
-
-func hasGlobMeta(s string) bool {
-	return strings.ContainsAny(s, "*?[")
 }
 
 func execTimeout(raw int) time.Duration {
@@ -969,33 +966,6 @@ func firstNonEmpty(values ...string) string {
 
 func intPtrValue(v int) *int {
 	return &v
-}
-
-const (
-	envVarPrefix = "$"
-	envVarLBrace = "${"
-	envVarRBrace = "}"
-)
-
-func hasEnvPrefix(s string, name string) bool {
-	if strings.HasPrefix(s, envVarPrefix+name) {
-		tail := s[len(envVarPrefix+name):]
-		return tail == "" || strings.HasPrefix(tail, "/") || strings.HasPrefix(tail, "\\")
-	}
-	prefix := envVarLBrace + name + envVarRBrace
-	if strings.HasPrefix(s, prefix) {
-		tail := s[len(prefix):]
-		return tail == "" || strings.HasPrefix(tail, "/") || strings.HasPrefix(tail, "\\")
-	}
-	return false
-}
-
-func isWorkspaceEnvPath(s string) bool {
-	return hasEnvPrefix(s, codeexecutor.WorkspaceEnvDirKey) ||
-		hasEnvPrefix(s, codeexecutor.EnvSkillsDir) ||
-		hasEnvPrefix(s, codeexecutor.EnvWorkDir) ||
-		hasEnvPrefix(s, codeexecutor.EnvOutputDir) ||
-		hasEnvPrefix(s, codeexecutor.EnvRunDir)
 }
 
 func isAllowedWorkspacePath(rel string) bool {

--- a/tool/workspaceexec/workspace_exec_test.go
+++ b/tool/workspaceexec/workspace_exec_test.go
@@ -457,14 +457,6 @@ func TestExecTool_HelperFunctions(t *testing.T) {
 	require.Equal(t, "", firstNonEmpty("", "   "))
 	require.Equal(t, "abc", firstNonEmpty("", " abc "))
 
-	require.True(t, hasEnvPrefix("$WORK_DIR/demo", codeexecutor.EnvWorkDir))
-	require.True(t, hasEnvPrefix("${OUTPUT_DIR}/demo", codeexecutor.EnvOutputDir))
-	require.False(t, hasEnvPrefix("$OUTPUT_DIR_demo", codeexecutor.EnvOutputDir))
-
-	require.True(t, isWorkspaceEnvPath("$WORK_DIR/demo"))
-	require.True(t, isWorkspaceEnvPath("${SKILLS_DIR}/demo"))
-	require.False(t, isWorkspaceEnvPath("/tmp/demo"))
-
 	require.True(t, isAllowedWorkspacePath("skills/demo"))
 	require.True(t, isAllowedWorkspacePath("work/demo"))
 	require.True(t, isAllowedWorkspacePath("out/demo"))


### PR DESCRIPTION
## Summary

Add `codeexecutor/workspaceio.Workspace` — a thin, backend-agnostic facade so application code (callbacks, sinks, profile-projection code) can read, write, persist, stage, and run programs against the current invocation's workspace from any context, without depending on the specific code executor backend (local / container / pcg123 / cube …).