### PR TITLE
claw: refactor knowledge config to unified provider pattern

### DIFF
--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -264,15 +264,16 @@ model:
 # This only configures the embedder and vector store. Content loading
 # can be triggered separately at runtime.
 knowledges:
-  entries:
+  providers:
     - name: "docs"
-      embedder:
-        type: "openai"
-        model: "text-embedding-3-small"
-        dimensions: 1536
-      vector_store:
-        type: "inmemory"
-        max_results: 5
+      max_results: 5
+      config:
+        embedder:
+          type: "openai"
+          model: "text-embedding-3-small"
+          dimensions: 1536
+        vector_store:
+          type: "inmemory"
 
 tools:
   # Optional; default is serial execution.
@@ -332,21 +333,22 @@ Notes:
 
   ```yaml
   knowledges:
-    entries:
+    providers:
       - name: "trpc_agent_go"
-        embedder:
-          type: "openai"
-          model: "text-embedding-3-small"
-          base_url: "${OPENAI_BASE_URL}"
-          api_key: "${OPENAI_API_KEY}"
-          dimensions: 1536
-        vector_store:
-          type: "pgvector"
-          url: "postgres://postgres:${PGPASSWORD}@localhost:5432/vectordb?sslmode=disable"
-          table: "trpc_agent_go"
-          index_dimension: 1536
-          enable_tsvector: true
-          max_results: 5
+        max_results: 5
+        config:
+          embedder:
+            type: "openai"
+            model: "text-embedding-3-small"
+            base_url: "${OPENAI_BASE_URL}"
+            api_key: "${OPENAI_API_KEY}"
+            dimensions: 1536
+          vector_store:
+            type: "pgvector"
+            url: "postgres://postgres:${PGPASSWORD}@localhost:5432/vectordb?sslmode=disable"
+            table: "trpc_agent_go"
+            index_dimension: 1536
+            enable_tsvector: true
   ```
 
   Use identifier-safe table names such as `trpc_agent_go`; do not use raw

--- a/openclaw/README.zh_CN.md
+++ b/openclaw/README.zh_CN.md
@@ -253,15 +253,16 @@ model:
 # 可选：knowledge 后端，用于 knowledge search tools。
 # 这里只配置 embedder 和 vector store，知识内容加载需要在运行时单独触发。
 knowledges:
-  entries:
+  providers:
     - name: "docs"
-      embedder:
-        type: "openai"
-        model: "text-embedding-3-small"
-        dimensions: 1536
-      vector_store:
-        type: "inmemory"
-        max_results: 5
+      max_results: 5
+      config:
+        embedder:
+          type: "openai"
+          model: "text-embedding-3-small"
+          dimensions: 1536
+        vector_store:
+          type: "inmemory"
 
 tools:
   # 可选；默认为串行执行。
@@ -321,21 +322,22 @@ go run ./cmd/openclaw -config ./openclaw.yaml
 
   ```yaml
   knowledges:
-    entries:
+    providers:
       - name: "trpc_agent_go"
-        embedder:
-          type: "openai"
-          model: "text-embedding-3-small"
-          base_url: "${OPENAI_BASE_URL}"
-          api_key: "${OPENAI_API_KEY}"
-          dimensions: 1536
-        vector_store:
-          type: "pgvector"
-          url: "postgres://postgres:${PGPASSWORD}@localhost:5432/vectordb?sslmode=disable"
-          table: "trpc_agent_go"
-          index_dimension: 1536
-          enable_tsvector: true
-          max_results: 5
+        max_results: 5
+        config:
+          embedder:
+            type: "openai"
+            model: "text-embedding-3-small"
+            base_url: "${OPENAI_BASE_URL}"
+            api_key: "${OPENAI_API_KEY}"
+            dimensions: 1536
+          vector_store:
+            type: "pgvector"
+            url: "postgres://postgres:${PGPASSWORD}@localhost:5432/vectordb?sslmode=disable"
+            table: "trpc_agent_go"
+            index_dimension: 1536
+            enable_tsvector: true
   ```
 
   表名建议使用 `trpc_agent_go` 这类安全标识符，不要直接用

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -34,8 +34,6 @@ import (
 	"syscall"
 	"time"
 
-	"gopkg.in/yaml.v3"
-
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/agent/claudecode"
 	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
@@ -2324,7 +2322,9 @@ func newAgent(
 			)
 		}
 	}
-	knowledgeTools, err := buildKnowledgeTools(cfg.KnowledgesConfig)
+	knowledgeTools, err := buildKnowledgeTools(
+		cfg.KnowledgesConfig,
+	)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -2648,7 +2648,7 @@ type agentConfig struct {
 	SkillsToolResults   bool
 	SkillsSkipFallback  bool
 	SkillsToolingGuide  *string
-	KnowledgesConfig    map[string]*yaml.Node
+	KnowledgesConfig    []knowledgeEntry
 
 	StateDir string
 

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -2520,8 +2520,8 @@ func TestValidateAgentRunOptions(t *testing.T) {
 			name:      "knowledges",
 			agentType: agentTypeClaudeCode,
 			opts: runOptions{
-				KnowledgesConfig: map[string]*yaml.Node{
-					"docs": yamlNode(t, `
+				KnowledgesConfig: []knowledgeEntry{
+					builtinKnowledgeEntry(t, "docs", `
 vector_store:
   type: inmemory
 `),

--- a/openclaw/app/builtins.go
+++ b/openclaw/app/builtins.go
@@ -73,6 +73,11 @@ func init() {
 		memoryBackendPGVector,
 		newPGVectorMemoryBackend,
 	))
+
+	must(registry.RegisterKnowledgeProvider(
+		"builtin",
+		newBuiltinKnowledge,
+	))
 }
 
 func must(err error) {

--- a/openclaw/app/knowledge_tools.go
+++ b/openclaw/app/knowledge_tools.go
@@ -29,13 +29,17 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/registry"
 )
 
-type knowledgeToolsBundle struct {
-	tools []tool.Tool
+// knowledgeEntry is the parsed intermediate representation of a knowledge
+// provider configuration.
+type knowledgeEntry struct {
+	Type       string
+	Name       string
+	MaxResults int
+	Config     *yaml.Node
 }
 
-type knowledgeDependencyConfig struct {
-	Embedder    *rawKnowledgeComponent `yaml:"embedder,omitempty"`
-	VectorStore *rawKnowledgeComponent `yaml:"vector_store,omitempty"`
+type knowledgeToolsBundle struct {
+	tools []tool.Tool
 }
 
 type rawKnowledgeComponent struct {
@@ -47,47 +51,97 @@ func (r *rawKnowledgeComponent) UnmarshalYAML(node *yaml.Node) error {
 	return nil
 }
 
-func buildKnowledgeTools(
-	configs map[string]*yaml.Node,
-) (*knowledgeToolsBundle, error) {
-	if len(configs) == 0 {
-		return nil, nil
-	}
+// builtinKnowledgeConfig is the config schema for the "builtin" knowledge
+// provider (embedder + vector_store).
+type builtinKnowledgeConfig struct {
+	Embedder    *rawKnowledgeComponent `yaml:"embedder,omitempty"`
+	VectorStore *rawKnowledgeComponent `yaml:"vector_store,omitempty"`
+}
 
-	knowledges, err := buildKnowledgeBases(configs)
+func newBuiltinKnowledge(
+	_ registry.KnowledgeProviderDeps,
+	spec registry.PluginSpec,
+) (knowledge.Knowledge, error) {
+	var cfg builtinKnowledgeConfig
+	if err := registry.DecodeStrict(spec.Config, &cfg); err != nil {
+		return nil, fmt.Errorf("decode failed: %w", err)
+	}
+	emb, err := buildKnowledgeEmbedder(cfg.Embedder)
 	if err != nil {
 		return nil, err
 	}
-	if len(knowledges) == 0 {
+	store, err := buildKnowledgeVectorStore(cfg.VectorStore, emb)
+	if err != nil {
+		return nil, err
+	}
+	return knowledge.New(
+		knowledge.WithEmbedder(emb),
+		knowledge.WithVectorStore(store),
+	), nil
+}
+
+func buildKnowledgeTools(
+	entries []knowledgeEntry,
+) (*knowledgeToolsBundle, error) {
+	if len(entries) == 0 {
 		return nil, nil
 	}
 
-	names := sortedKnowledgeNames(knowledges)
-	if len(names) == 1 {
-		maxResults, err := knowledgeToolMaxResults(configs[names[0]])
+	type knowledgeWithMaxResults struct {
+		kb         knowledge.Knowledge
+		maxResults int
+	}
+	knowledges := make(map[string]*knowledgeWithMaxResults, len(entries))
+	for _, entry := range entries {
+		f, ok := registry.LookupKnowledgeProvider(entry.Type)
+		if !ok {
+			return nil, fmt.Errorf(
+				"unsupported knowledge provider type: %s",
+				entry.Type,
+			)
+		}
+		kb, err := f(registry.KnowledgeProviderDeps{}, registry.PluginSpec{
+			Type:   entry.Type,
+			Name:   entry.Name,
+			Config: entry.Config,
+		})
 		if err != nil {
 			return nil, fmt.Errorf(
-				"knowledge %q tool config invalid: %w",
-				names[0],
+				"knowledge %q config invalid: %w",
+				entry.Name,
 				err,
 			)
 		}
+		knowledges[entry.Name] = &knowledgeWithMaxResults{
+			kb:         kb,
+			maxResults: entry.MaxResults,
+		}
+	}
+
+	names := make([]string, 0, len(knowledges))
+	for name := range knowledges {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	if len(names) == 1 {
+		entry := knowledges[names[0]]
 		toolOpts := []knowledgetool.Option{
 			knowledgetool.WithToolName("knowledge_search"),
 			knowledgetool.WithToolDescription(
 				"Search for relevant information in the knowledge base.",
 			),
 		}
-		if maxResults > 0 {
+		if entry.maxResults > 0 {
 			toolOpts = append(
 				toolOpts,
-				knowledgetool.WithMaxResults(maxResults),
+				knowledgetool.WithMaxResults(entry.maxResults),
 			)
 		}
 		return &knowledgeToolsBundle{
 			tools: []tool.Tool{
 				knowledgetool.NewKnowledgeSearchTool(
-					knowledges[names[0]],
+					entry.kb,
 					toolOpts...,
 				),
 			},
@@ -107,14 +161,7 @@ func buildKnowledgeTools(
 			)
 		}
 		seenToolNames[toolName] = name
-		maxResults, err := knowledgeToolMaxResults(configs[name])
-		if err != nil {
-			return nil, fmt.Errorf(
-				"knowledge %q tool config invalid: %w",
-				name,
-				err,
-			)
-		}
+		entry := knowledges[name]
 		toolOpts := []knowledgetool.Option{
 			knowledgetool.WithToolName(toolName),
 			knowledgetool.WithToolDescription(
@@ -124,78 +171,20 @@ func buildKnowledgeTools(
 				),
 			),
 		}
-		if maxResults > 0 {
+		if entry.maxResults > 0 {
 			toolOpts = append(
 				toolOpts,
-				knowledgetool.WithMaxResults(maxResults),
+				knowledgetool.WithMaxResults(entry.maxResults),
 			)
 		}
 		tools = append(tools, knowledgetool.NewAgenticFilterSearchTool(
-			knowledges[name],
+			entry.kb,
 			nil,
 			toolOpts...,
 		))
 	}
 
 	return &knowledgeToolsBundle{tools: tools}, nil
-}
-
-func buildKnowledgeBases(
-	configs map[string]*yaml.Node,
-) (map[string]knowledge.Knowledge, error) {
-	if len(configs) == 0 {
-		return nil, nil
-	}
-
-	out := make(map[string]knowledge.Knowledge, len(configs))
-	for rawName, node := range configs {
-		name := strings.TrimSpace(rawName)
-		if name == "" || node == nil {
-			continue
-		}
-
-		kb, err := buildKnowledgeBase(node)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"knowledge %q config invalid: %w",
-				name,
-				err,
-			)
-		}
-		out[name] = kb
-	}
-
-	if len(out) == 0 {
-		return nil, nil
-	}
-	return out, nil
-}
-
-func buildKnowledgeBase(
-	node *yaml.Node,
-) (knowledge.Knowledge, error) {
-	if node == nil {
-		return nil, nil
-	}
-
-	var cfg knowledgeDependencyConfig
-	if err := registry.DecodeStrict(node, &cfg); err != nil {
-		return nil, fmt.Errorf("decode failed: %w", err)
-	}
-
-	emb, err := buildKnowledgeEmbedder(cfg.Embedder)
-	if err != nil {
-		return nil, err
-	}
-	store, err := buildKnowledgeVectorStore(cfg.VectorStore, emb)
-	if err != nil {
-		return nil, err
-	}
-
-	return knowledge.New(
-		knowledge.WithEmbedder(emb),
-		knowledge.WithVectorStore(store),
-	), nil
 }
 
 type knowledgeTypeConfig struct {
@@ -434,71 +423,6 @@ func knowledgeEmbedderDimensions(e embedder.Embedder) int {
 		return 0
 	}
 	return e.GetDimensions()
-}
-
-func knowledgeToolMaxResults(node *yaml.Node) (int, error) {
-	if node == nil {
-		return 0, nil
-	}
-
-	var cfg knowledgeDependencyConfig
-	if err := registry.DecodeStrict(node, &cfg); err != nil {
-		return 0, fmt.Errorf("decode failed: %w", err)
-	}
-	return knowledgeVectorStoreMaxResults(cfg.VectorStore)
-}
-
-func knowledgeVectorStoreMaxResults(
-	cfg *rawKnowledgeComponent,
-) (int, error) {
-	if cfg == nil || cfg.Node == nil {
-		return 0, nil
-	}
-
-	typeName, err := knowledgeComponentType(cfg.Node)
-	if err != nil {
-		return 0, fmt.Errorf("vector_store type invalid: %w", err)
-	}
-	switch typeName {
-	case "", "inmemory":
-		var c inmemoryKnowledgeVectorStoreConfig
-		if err := registry.DecodeStrict(cfg.Node, &c); err != nil {
-			return 0, err
-		}
-		return positiveIntValue(c.MaxResults), nil
-	case "pgvector":
-		var c pgvectorKnowledgeVectorStoreConfig
-		if err := registry.DecodeStrict(cfg.Node, &c); err != nil {
-			return 0, err
-		}
-		return positiveIntValue(c.MaxResults), nil
-	case "elasticsearch":
-		var c elasticsearchKnowledgeVectorStoreConfig
-		if err := registry.DecodeStrict(cfg.Node, &c); err != nil {
-			return 0, err
-		}
-		return positiveIntValue(c.MaxResults), nil
-	default:
-		return 0, fmt.Errorf("unsupported vector_store.type: %s", typeName)
-	}
-}
-
-func positiveIntValue(v *int) int {
-	if v == nil || *v <= 0 {
-		return 0
-	}
-	return *v
-}
-
-func sortedKnowledgeNames(
-	knowledges map[string]knowledge.Knowledge,
-) []string {
-	names := make([]string, 0, len(knowledges))
-	for name := range knowledges {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	return names
 }
 
 func knowledgeToolName(name string) string {

--- a/openclaw/app/knowledge_tools_test.go
+++ b/openclaw/app/knowledge_tools_test.go
@@ -11,17 +11,50 @@ package app
 
 import (
 	"compress/gzip"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
+	"trpc.group/trpc-go/trpc-agent-go/knowledge"
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/document"
 	openaiembedder "trpc.group/trpc-go/trpc-agent-go/knowledge/embedder/openai"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/registry"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
+
+type providerKnowledge struct{}
+
+func (providerKnowledge) Search(
+	context.Context,
+	*knowledge.SearchRequest,
+) (*knowledge.SearchResult, error) {
+	doc := &document.Document{Content: "provider result"}
+	return &knowledge.SearchResult{
+		Document: doc,
+		Score:    1,
+		Text:     doc.Content,
+		Documents: []*knowledge.Result{{
+			Document: doc,
+			Score:    1,
+		}},
+	}, nil
+}
+
+func builtinKnowledgeEntry(t *testing.T, name, configYAML string) knowledgeEntry {
+	t.Helper()
+	return knowledgeEntry{
+		Type:   "builtin",
+		Name:   name,
+		Config: yamlNode(t, configYAML),
+	}
+}
 
 func TestRawKnowledgeComponentUnmarshalYAML_StoresNode(t *testing.T) {
 	t.Parallel()
@@ -40,8 +73,8 @@ embedder:
 func TestBuildKnowledgeTools_SingleKnowledgeUsesGenericTool(t *testing.T) {
 	t.Parallel()
 
-	bundle, err := buildKnowledgeTools(map[string]*yaml.Node{
-		"docs": yamlNode(t, `
+	bundle, err := buildKnowledgeTools([]knowledgeEntry{
+		builtinKnowledgeEntry(t, "docs", `
 embedder:
   type: openai
 vector_store:
@@ -57,15 +90,13 @@ vector_store:
 func TestBuildKnowledgeTools_MultipleKnowledgesCreateNamedTools(t *testing.T) {
 	t.Parallel()
 
-	bundle, err := buildKnowledgeTools(map[string]*yaml.Node{
-		"Docs KB": yamlNode(t, `
+	inmemory := `
 vector_store:
   type: inmemory
-`),
-		"FAQ": yamlNode(t, `
-vector_store:
-  type: inmemory
-`),
+`
+	bundle, err := buildKnowledgeTools([]knowledgeEntry{
+		builtinKnowledgeEntry(t, "Docs KB", inmemory),
+		builtinKnowledgeEntry(t, "FAQ", inmemory),
 	})
 	require.NoError(t, err)
 	require.NotNil(t, bundle)
@@ -77,15 +108,13 @@ vector_store:
 func TestBuildKnowledgeTools_RejectsCollidingToolNames(t *testing.T) {
 	t.Parallel()
 
-	_, err := buildKnowledgeTools(map[string]*yaml.Node{
-		"Docs KB": yamlNode(t, `
+	inmemory := `
 vector_store:
   type: inmemory
-`),
-		"Docs-KB": yamlNode(t, `
-vector_store:
-  type: inmemory
-`),
+`
+	_, err := buildKnowledgeTools([]knowledgeEntry{
+		builtinKnowledgeEntry(t, "Docs KB", inmemory),
+		builtinKnowledgeEntry(t, "Docs-KB", inmemory),
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "knowledge tool name collision")
@@ -94,8 +123,8 @@ vector_store:
 func TestBuildKnowledgeTools_InvalidConfigFails(t *testing.T) {
 	t.Parallel()
 
-	_, err := buildKnowledgeTools(map[string]*yaml.Node{
-		"docs": yamlNode(t, `
+	_, err := buildKnowledgeTools([]knowledgeEntry{
+		builtinKnowledgeEntry(t, "docs", `
 vector_store:
   type: nope
 `),
@@ -104,17 +133,69 @@ vector_store:
 	require.Contains(t, err.Error(), "unsupported vector_store.type")
 }
 
+func TestBuildKnowledgeTools_ProviderKnowledge(t *testing.T) {
+	providerType := fmt.Sprintf(
+		"test_provider_%d",
+		time.Now().UnixNano(),
+	)
+	var gotSpec registry.PluginSpec
+	require.NoError(t, registry.RegisterKnowledgeProvider(
+		providerType,
+		func(
+			_ registry.KnowledgeProviderDeps,
+			spec registry.PluginSpec,
+		) (knowledge.Knowledge, error) {
+			gotSpec = spec
+			return providerKnowledge{}, nil
+		},
+	))
+
+	bundle, err := buildKnowledgeTools([]knowledgeEntry{
+		{
+			Type:       providerType,
+			Name:       "docs",
+			MaxResults: 7,
+			Config: yamlNode(t, `
+endpoint: http://127.0.0.1:8080
+`),
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, bundle)
+	require.Len(t, bundle.tools, 1)
+	require.Equal(t, "knowledge_search", bundle.tools[0].Declaration().Name)
+	require.Equal(t, providerType, gotSpec.Type)
+	require.Equal(t, "docs", gotSpec.Name)
+	require.NotNil(t, gotSpec.Config)
+	require.Equal(t, "http://127.0.0.1:8080", mappingValue(gotSpec.Config, "endpoint").Value)
+
+	callable, ok := bundle.tools[0].(tool.CallableTool)
+	require.True(t, ok)
+	res, err := callable.Call(
+		context.Background(),
+		[]byte(`{"query":"hello"}`),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+}
+
+func TestBuildKnowledgeTools_ProviderRequiresRegisteredType(t *testing.T) {
+	t.Parallel()
+
+	_, err := buildKnowledgeTools([]knowledgeEntry{
+		{
+			Type: "missing_provider",
+			Name: "docs",
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported knowledge provider type")
+}
+
 func TestBuildKnowledgeTools_EmptyConfigsReturnNil(t *testing.T) {
 	t.Parallel()
 
 	bundle, err := buildKnowledgeTools(nil)
-	require.NoError(t, err)
-	require.Nil(t, bundle)
-
-	bundle, err = buildKnowledgeTools(map[string]*yaml.Node{
-		" ":    yamlNode(t, `vector_store: {type: inmemory}`),
-		"docs": nil,
-	})
 	require.NoError(t, err)
 	require.Nil(t, bundle)
 }
@@ -122,8 +203,8 @@ func TestBuildKnowledgeTools_EmptyConfigsReturnNil(t *testing.T) {
 func TestBuildKnowledgeTools_EmbedderDefaultsToOpenAI(t *testing.T) {
 	t.Parallel()
 
-	bundle, err := buildKnowledgeTools(map[string]*yaml.Node{
-		"docs": yamlNode(t, `
+	bundle, err := buildKnowledgeTools([]knowledgeEntry{
+		builtinKnowledgeEntry(t, "docs", `
 embedder:
   model: text-embedding-3-small
 vector_store:
@@ -136,16 +217,15 @@ vector_store:
 	require.Equal(t, "knowledge_search", bundle.tools[0].Declaration().Name)
 }
 
-func TestBuildKnowledgeTools_SingleKnowledgeUsesGenericToolNameWithMaxResultsConfig(t *testing.T) {
+func TestBuildKnowledgeTools_SingleKnowledgeUsesGenericToolNameWithMaxResults(t *testing.T) {
 	t.Parallel()
 
-	bundle, err := buildKnowledgeTools(map[string]*yaml.Node{
-		"docs": yamlNode(t, `
+	entry := builtinKnowledgeEntry(t, "docs", `
 vector_store:
   type: inmemory
-  max_results: 3
-`),
-	})
+`)
+	entry.MaxResults = 3
+	bundle, err := buildKnowledgeTools([]knowledgeEntry{entry})
 	require.NoError(t, err)
 	require.NotNil(t, bundle)
 	require.Len(t, bundle.tools, 1)
@@ -155,8 +235,8 @@ vector_store:
 func TestBuildKnowledgeTools_VectorStoreUsesTypeSpecificValidation(t *testing.T) {
 	t.Parallel()
 
-	_, err := buildKnowledgeTools(map[string]*yaml.Node{
-		"docs": yamlNode(t, `
+	_, err := buildKnowledgeTools([]knowledgeEntry{
+		builtinKnowledgeEntry(t, "docs", `
 vector_store:
   type: inmemory
   addresses:
@@ -170,8 +250,8 @@ vector_store:
 func TestBuildKnowledgeTools_VectorStoreTypeIsRequired(t *testing.T) {
 	t.Parallel()
 
-	_, err := buildKnowledgeTools(map[string]*yaml.Node{
-		"docs": yamlNode(t, `
+	_, err := buildKnowledgeTools([]knowledgeEntry{
+		builtinKnowledgeEntry(t, "docs", `
 vector_store:
   max_results: 5
 `),
@@ -180,55 +260,37 @@ vector_store:
 	require.Contains(t, err.Error(), "vector_store.type is required")
 }
 
-func TestBuildKnowledgeBases_TrimsNamesAndSkipsEmptyEntries(t *testing.T) {
+func TestNewBuiltinKnowledge_RequiresVectorStore(t *testing.T) {
 	t.Parallel()
 
-	knowledges, err := buildKnowledgeBases(map[string]*yaml.Node{
-		" docs ": yamlNode(t, `
-vector_store:
-  type: inmemory
+	_, err := newBuiltinKnowledge(
+		registry.KnowledgeProviderDeps{},
+		registry.PluginSpec{
+			Config: yamlNode(t, `
+embedder:
+  type: openai
 `),
-		"": yamlNode(t, `
-vector_store:
-  type: inmemory
-`),
-		"nil": nil,
-	})
-	require.NoError(t, err)
-	require.Len(t, knowledges, 1)
-	require.Contains(t, knowledges, "docs")
+		},
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "vector_store is required")
 }
 
-func TestBuildKnowledgeBase_NilNodeReturnsNil(t *testing.T) {
+func TestNewBuiltinKnowledge_DecodeStrictFailure(t *testing.T) {
 	t.Parallel()
 
-	kb, err := buildKnowledgeBase(nil)
-	require.NoError(t, err)
-	require.Nil(t, kb)
-}
-
-func TestBuildKnowledgeBase_DecodeStrictFailure(t *testing.T) {
-	t.Parallel()
-
-	_, err := buildKnowledgeBase(yamlNode(t, `
+	_, err := newBuiltinKnowledge(
+		registry.KnowledgeProviderDeps{},
+		registry.PluginSpec{
+			Config: yamlNode(t, `
 unexpected: true
 vector_store:
   type: inmemory
-`))
+`),
+		},
+	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "decode failed")
-	require.Contains(t, err.Error(), "field unexpected not found")
-}
-
-func TestBuildKnowledgeBase_RequiresVectorStore(t *testing.T) {
-	t.Parallel()
-
-	_, err := buildKnowledgeBase(yamlNode(t, `
-embedder:
-  type: openai
-`))
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "vector_store is required")
 }
 
 func TestBuildKnowledgeEmbedder_UnsupportedTypeFails(t *testing.T) {
@@ -423,19 +485,6 @@ dimensions: 384
 	require.Equal(t, 384, knowledgeEmbedderDimensions(emb))
 }
 
-func TestKnowledgeToolMaxResults_ReadsVectorStoreConfig(t *testing.T) {
-	t.Parallel()
-
-	maxResults, err := knowledgeToolMaxResults(yamlNode(t, `
-vector_store:
-  type: pgvector
-  url: postgres://user:pass@127.0.0.1:5432/dbname?sslmode=disable
-  max_results: 6
-`))
-	require.NoError(t, err)
-	require.Equal(t, 6, maxResults)
-}
-
 func TestBuildKnowledgeVectorStore_ElasticsearchBuildsSuccessfully(t *testing.T) {
 	t.Parallel()
 
@@ -608,8 +657,8 @@ func TestNewAgent_KnowledgeConfigRegistersSearchTool(t *testing.T) {
 		SkillsRoot:   t.TempDir(),
 		StateDir:     t.TempDir(),
 		SystemPrompt: "sys",
-		KnowledgesConfig: map[string]*yaml.Node{
-			"docs": yamlNode(t, `
+		KnowledgesConfig: []knowledgeEntry{
+			builtinKnowledgeEntry(t, "docs", `
 vector_store:
   type: inmemory
 `),
@@ -624,20 +673,18 @@ vector_store:
 func TestNewAgent_MultipleKnowledgeConfigsRegisterNamedTools(t *testing.T) {
 	t.Parallel()
 
+	inmemory := `
+vector_store:
+  type: inmemory
+`
 	mdl := &captureRequestModel{}
 	agt, _, err := newAgent(mdl, agentConfig{
 		AppName:    "demo",
 		SkillsRoot: t.TempDir(),
 		StateDir:   t.TempDir(),
-		KnowledgesConfig: map[string]*yaml.Node{
-			"docs": yamlNode(t, `
-vector_store:
-  type: inmemory
-`),
-			"faq": yamlNode(t, `
-vector_store:
-  type: inmemory
-`),
+		KnowledgesConfig: []knowledgeEntry{
+			builtinKnowledgeEntry(t, "docs", inmemory),
+			builtinKnowledgeEntry(t, "faq", inmemory),
 		},
 	}, nil, nil)
 	require.NoError(t, err)
@@ -654,8 +701,8 @@ func TestNewAgent_InvalidKnowledgeConfigReturnsError(t *testing.T) {
 		AppName:    "demo",
 		SkillsRoot: t.TempDir(),
 		StateDir:   t.TempDir(),
-		KnowledgesConfig: map[string]*yaml.Node{
-			"docs": yamlNode(t, `
+		KnowledgesConfig: []knowledgeEntry{
+			builtinKnowledgeEntry(t, "docs", `
 unexpected: true
 vector_store:
   type: inmemory

--- a/openclaw/app/run_options.go
+++ b/openclaw/app/run_options.go
@@ -1112,6 +1112,12 @@ type memoryConfig struct {
 
 type knowledgesConfig struct {
 	Providers []knowledgeProviderConfig `yaml:"providers,omitempty"`
+
+	// Entries is the deprecated field name (pre-v0.0.4). Kept here so
+	// that KnownFields(true) does not reject it with a confusing
+	// "field entries not found" error; instead we return a clear
+	// migration message in fileConfig.apply.
+	Entries []rawYAMLNode `yaml:"entries,omitempty"`
 }
 
 type knowledgeProviderConfig struct {
@@ -1473,6 +1479,14 @@ func (cfg *fileConfig) apply(
 		}
 	}
 	if cfg.Knowledges != nil {
+		if len(cfg.Knowledges.Entries) > 0 {
+			return fmt.Errorf(
+				"knowledges.entries is no longer supported; " +
+					"rename it to knowledges.providers and wrap " +
+					"embedder/vector_store under a 'config' key " +
+					"(see README for the new format)",
+			)
+		}
 		knowledges, err := convertKnowledgeConfigs(cfg.Knowledges.Providers)
 		if err != nil {
 			return err

--- a/openclaw/app/run_options.go
+++ b/openclaw/app/run_options.go
@@ -178,7 +178,7 @@ type runOptions struct {
 	OpenAIBaseURL       string
 	GenerationConfig    *model.GenerationConfig
 	ModelConfig         *yaml.Node
-	KnowledgesConfig    map[string]*yaml.Node
+	KnowledgesConfig    []knowledgeEntry
 	SkillsRoot          string
 	SkillsExtraDir      string
 	SkillsDebug         bool
@@ -1111,13 +1111,14 @@ type memoryConfig struct {
 }
 
 type knowledgesConfig struct {
-	Entries []knowledgeEntryConfig `yaml:"entries,omitempty"`
+	Providers []knowledgeProviderConfig `yaml:"providers,omitempty"`
 }
 
-type knowledgeEntryConfig struct {
-	Name        string       `yaml:"name,omitempty"`
-	Embedder    *rawYAMLNode `yaml:"embedder,omitempty"`
-	VectorStore *rawYAMLNode `yaml:"vector_store,omitempty"`
+type knowledgeProviderConfig struct {
+	Type       string       `yaml:"type,omitempty"`
+	Name       string       `yaml:"name,omitempty"`
+	MaxResults *int         `yaml:"max_results,omitempty"`
+	Config     *rawYAMLNode `yaml:"config,omitempty"`
 }
 
 type pluginSpec struct {
@@ -1472,7 +1473,7 @@ func (cfg *fileConfig) apply(
 		}
 	}
 	if cfg.Knowledges != nil {
-		knowledges, err := convertKnowledgeConfigs(cfg.Knowledges.Entries)
+		knowledges, err := convertKnowledgeConfigs(cfg.Knowledges.Providers)
 		if err != nil {
 			return err
 		}
@@ -1867,72 +1868,56 @@ func convertSkillConfigs(
 }
 
 func convertKnowledgeConfigs(
-	entries []knowledgeEntryConfig,
-) (map[string]*yaml.Node, error) {
-	if len(entries) == 0 {
+	providers []knowledgeProviderConfig,
+) ([]knowledgeEntry, error) {
+	if len(providers) == 0 {
 		return nil, nil
 	}
 
-	out := make(map[string]*yaml.Node, len(entries))
-	for i := range entries {
-		entry := entries[i]
-		name := strings.TrimSpace(entry.Name)
+	seen := make(map[string]bool, len(providers))
+	out := make([]knowledgeEntry, 0, len(providers))
+
+	for i, p := range providers {
+		name := strings.TrimSpace(p.Name)
 		if name == "" {
-			return nil, fmt.Errorf("knowledges.entries[%d].name is empty", i)
+			return nil, fmt.Errorf(
+				"knowledges.providers[%d].name is empty", i,
+			)
 		}
-		if _, exists := out[name]; exists {
-			return nil, fmt.Errorf("duplicate knowledge name: %s", name)
+		if seen[name] {
+			return nil, fmt.Errorf(
+				"duplicate knowledge name: %s", name,
+			)
+		}
+		seen[name] = true
+
+		typeName := strings.ToLower(strings.TrimSpace(p.Type))
+		if typeName == "" {
+			typeName = "builtin"
 		}
 
-		node := &yaml.Node{
-			Kind: yaml.MappingNode,
-			Tag:  "!!map",
+		var maxResults int
+		if p.MaxResults != nil && *p.MaxResults > 0 {
+			maxResults = *p.MaxResults
 		}
-		if entry.Embedder != nil && entry.Embedder.Node != nil {
-			node.Content = append(
-				node.Content,
-				&yaml.Node{
-					Kind:  yaml.ScalarNode,
-					Tag:   "!!str",
-					Value: "embedder",
-				},
-				cloneYAMLNode(entry.Embedder.Node),
-			)
+
+		var config *yaml.Node
+		if p.Config != nil {
+			config = p.Config.Node
 		}
-		if entry.VectorStore != nil && entry.VectorStore.Node != nil {
-			node.Content = append(
-				node.Content,
-				&yaml.Node{
-					Kind:  yaml.ScalarNode,
-					Tag:   "!!str",
-					Value: "vector_store",
-				},
-				cloneYAMLNode(entry.VectorStore.Node),
-			)
-		}
-		if len(node.Content) == 0 {
-			continue
-		}
-		out[name] = node
+
+		out = append(out, knowledgeEntry{
+			Type:       typeName,
+			Name:       name,
+			MaxResults: maxResults,
+			Config:     config,
+		})
 	}
+
 	if len(out) == 0 {
 		return nil, nil
 	}
 	return out, nil
-}
-
-func cloneYAMLNode(node *yaml.Node) *yaml.Node {
-	if node == nil {
-		return nil
-	}
-	cloned := *node
-	if len(node.Content) > 0 {
-		cloned.Content = make([]*yaml.Node, 0, len(node.Content))
-		for _, child := range node.Content {
-			cloned.Content = append(cloned.Content, cloneYAMLNode(child))
-		}
-	}
-	return &cloned
 }
 
 func applySessionSummary(

--- a/openclaw/app/run_options_test.go
+++ b/openclaw/app/run_options_test.go
@@ -1014,6 +1014,28 @@ func TestConvertKnowledgeConfigs_EmptyProvidersReturnNil(t *testing.T) {
 	require.Nil(t, configs)
 }
 
+func TestParseRunOptions_KnowledgesLegacyEntriesReturnsHelpfulError(t *testing.T) {
+	t.Parallel()
+
+	cfgPath := writeTempConfig(t, `
+knowledges:
+  entries:
+    - name: "docs"
+      embedder:
+        type: "openai"
+      vector_store:
+        type: "inmemory"
+`)
+
+	_, err := parseRunOptions([]string{"-config", cfgPath})
+	require.Error(t, err)
+	var exitErr *exitError
+	require.True(t, errors.As(err, &exitErr))
+	require.Equal(t, 1, exitErr.Code)
+	require.Contains(t, err.Error(), "knowledges.entries is no longer supported")
+	require.Contains(t, err.Error(), "knowledges.providers")
+}
+
 func TestParseRunOptions_DebugRecorder_ConfigApplied(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/app/run_options_test.go
+++ b/openclaw/app/run_options_test.go
@@ -913,36 +913,65 @@ skills:
 	require.Equal(t, "b,c", opts.SkillsAllowBundled)
 }
 
-func TestParseRunOptions_KnowledgesEntriesConfig(t *testing.T) {
+func TestParseRunOptions_KnowledgesProvidersConfig(t *testing.T) {
 	t.Parallel()
 
 	cfgPath := writeTempConfig(t, `
 knowledges:
-  entries:
+  providers:
     - name: "docs"
-      embedder:
-        type: "openai"
-        model: "text-embedding-3-small"
-      vector_store:
-        type: "inmemory"
-        max_results: 5
+      max_results: 5
+      config:
+        embedder:
+          type: "openai"
+          model: "text-embedding-3-small"
+        vector_store:
+          type: "inmemory"
 `)
 
 	opts, err := parseRunOptions([]string{"-config", cfgPath})
 	require.NoError(t, err)
 	require.Len(t, opts.KnowledgesConfig, 1)
-	require.Contains(t, opts.KnowledgesConfig, "docs")
-	require.NotNil(t, opts.KnowledgesConfig["docs"])
+	require.Equal(t, "docs", opts.KnowledgesConfig[0].Name)
+	require.Equal(t, "builtin", opts.KnowledgesConfig[0].Type)
+	require.Equal(t, 5, opts.KnowledgesConfig[0].MaxResults)
 }
 
-func TestParseRunOptions_KnowledgesEntriesRequireName(t *testing.T) {
+func TestParseRunOptions_KnowledgesProvidersExternalConfig(t *testing.T) {
 	t.Parallel()
 
 	cfgPath := writeTempConfig(t, `
 knowledges:
-  entries:
-    - vector_store:
-        type: "inmemory"
+  providers:
+    - type: "lingshan"
+      name: "lingshan"
+      max_results: 5
+      config:
+        knowledge_base_id: "kb1"
+        service_name: "trpc.test.knowledge.lingshan"
+`)
+
+	opts, err := parseRunOptions([]string{"-config", cfgPath})
+	require.NoError(t, err)
+	require.Len(t, opts.KnowledgesConfig, 1)
+	entry := opts.KnowledgesConfig[0]
+	require.Equal(t, "lingshan", entry.Type)
+	require.Equal(t, "lingshan", entry.Name)
+	require.Equal(t, 5, entry.MaxResults)
+	require.NotNil(t, entry.Config)
+	require.Equal(t, "kb1", mappingValue(entry.Config, "knowledge_base_id").Value)
+	require.Equal(t, "trpc.test.knowledge.lingshan", mappingValue(entry.Config, "service_name").Value)
+}
+
+func TestParseRunOptions_KnowledgesProvidersRequireName(t *testing.T) {
+	t.Parallel()
+
+	cfgPath := writeTempConfig(t, `
+knowledges:
+  providers:
+    - config:
+        vector_store:
+          type: "inmemory"
 `)
 
 	_, err := parseRunOptions([]string{"-config", cfgPath})
@@ -950,21 +979,23 @@ knowledges:
 	var exitErr *exitError
 	require.True(t, errors.As(err, &exitErr))
 	require.Equal(t, 1, exitErr.Code)
-	require.Contains(t, err.Error(), "knowledges.entries[0].name is empty")
+	require.Contains(t, err.Error(), "knowledges.providers[0].name is empty")
 }
 
-func TestParseRunOptions_KnowledgesEntriesRejectDuplicateNames(t *testing.T) {
+func TestParseRunOptions_KnowledgesProvidersRejectDuplicateNames(t *testing.T) {
 	t.Parallel()
 
 	cfgPath := writeTempConfig(t, `
 knowledges:
-  entries:
+  providers:
     - name: "docs"
-      vector_store:
-        type: "inmemory"
+      config:
+        vector_store:
+          type: "inmemory"
     - name: "docs"
-      vector_store:
-        type: "inmemory"
+      config:
+        vector_store:
+          type: "inmemory"
 `)
 
 	_, err := parseRunOptions([]string{"-config", cfgPath})
@@ -975,65 +1006,12 @@ knowledges:
 	require.Contains(t, err.Error(), "duplicate knowledge name: docs")
 }
 
-func TestConvertKnowledgeConfigs_SkipsEntriesWithoutComponents(t *testing.T) {
-	t.Parallel()
-
-	configs, err := convertKnowledgeConfigs([]knowledgeEntryConfig{
-		{Name: "empty"},
-		{
-			Name: "docs",
-			VectorStore: &rawYAMLNode{Node: yamlNode(t, `
-type: inmemory
-max_results: 5
-`)},
-		},
-	})
-	require.NoError(t, err)
-	require.Len(t, configs, 1)
-	require.NotContains(t, configs, "empty")
-	require.Contains(t, configs, "docs")
-}
-
-func TestConvertKnowledgeConfigs_EmptyEntriesReturnNil(t *testing.T) {
+func TestConvertKnowledgeConfigs_EmptyProvidersReturnNil(t *testing.T) {
 	t.Parallel()
 
 	configs, err := convertKnowledgeConfigs(nil)
 	require.NoError(t, err)
 	require.Nil(t, configs)
-}
-
-func TestConvertKnowledgeConfigs_ClonesNestedNodes(t *testing.T) {
-	t.Parallel()
-
-	embedderNode := yamlNode(t, `
-type: openai
-model: text-embedding-3-small
-`)
-	vectorStoreNode := yamlNode(t, `
-type: inmemory
-max_results: 5
-`)
-
-	configs, err := convertKnowledgeConfigs([]knowledgeEntryConfig{{
-		Name:        "docs",
-		Embedder:    &rawYAMLNode{Node: embedderNode},
-		VectorStore: &rawYAMLNode{Node: vectorStoreNode},
-	}})
-	require.NoError(t, err)
-
-	mappingValue(embedderNode, "model").Value = "mutated-model"
-	mappingValue(vectorStoreNode, "max_results").Value = "99"
-
-	gotEmbedder := mappingValue(configs["docs"], "embedder")
-	gotVectorStore := mappingValue(configs["docs"], "vector_store")
-	require.Equal(t, "text-embedding-3-small", mappingValue(gotEmbedder, "model").Value)
-	require.Equal(t, "5", mappingValue(gotVectorStore, "max_results").Value)
-}
-
-func TestCloneYAMLNode_NilReturnsNil(t *testing.T) {
-	t.Parallel()
-
-	require.Nil(t, cloneYAMLNode(nil))
 }
 
 func TestParseRunOptions_DebugRecorder_ConfigApplied(t *testing.T) {

--- a/openclaw/registry/registry.go
+++ b/openclaw/registry/registry.go
@@ -34,6 +34,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"trpc.group/trpc-go/trpc-agent-go/knowledge"
 	"trpc.group/trpc-go/trpc-agent-go/memory"
 	memextractor "trpc.group/trpc-go/trpc-agent-go/memory/extractor"
 	"trpc.group/trpc-go/trpc-agent-go/model"
@@ -154,6 +155,16 @@ type MemoryBackendFactory func(
 	spec MemoryBackendSpec,
 ) (memory.Service, error)
 
+// KnowledgeProviderDeps are dependencies passed to knowledge provider
+// factories.
+type KnowledgeProviderDeps struct{}
+
+// KnowledgeProviderFactory creates a knowledge implementation from config.
+type KnowledgeProviderFactory func(
+	deps KnowledgeProviderDeps,
+	spec PluginSpec,
+) (knowledge.Knowledge, error)
+
 // ToolProviderDeps are dependencies passed to tool provider factories.
 type ToolProviderDeps struct {
 	Model    model.Model
@@ -197,12 +208,13 @@ type ModelFactory func(spec ModelSpec) (model.Model, error)
 var (
 	mu sync.RWMutex
 
-	channelFactories = map[string]ChannelFactory{}
-	sessionFactories = map[string]SessionBackendFactory{}
-	memoryFactories  = map[string]MemoryBackendFactory{}
-	toolFactories    = map[string]ToolProviderFactory{}
-	toolSetFactories = map[string]ToolSetProviderFactory{}
-	modelFactories   = map[string]ModelFactory{}
+	channelFactories   = map[string]ChannelFactory{}
+	sessionFactories   = map[string]SessionBackendFactory{}
+	memoryFactories    = map[string]MemoryBackendFactory{}
+	knowledgeFactories = map[string]KnowledgeProviderFactory{}
+	toolFactories      = map[string]ToolProviderFactory{}
+	toolSetFactories   = map[string]ToolSetProviderFactory{}
+	modelFactories     = map[string]ModelFactory{}
 )
 
 // RegisterChannel registers a channel factory under typeName.
@@ -298,6 +310,46 @@ func LookupMemoryBackend(typeName string) (MemoryBackendFactory, bool) {
 	defer mu.RUnlock()
 	name := normalizeType(typeName)
 	f, ok := memoryFactories[name]
+	return f, ok
+}
+
+// RegisterKnowledgeProvider registers a knowledge provider factory under
+// typeName.
+func RegisterKnowledgeProvider(
+	typeName string,
+	f KnowledgeProviderFactory,
+) error {
+	name, err := validateType("knowledge provider", typeName)
+	if err != nil {
+		return err
+	}
+	if f == nil {
+		return fmt.Errorf(
+			"registry: knowledge provider factory is nil: %s",
+			name,
+		)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if _, ok := knowledgeFactories[name]; ok {
+		return fmt.Errorf(
+			"registry: knowledge provider already registered: %s",
+			name,
+		)
+	}
+	knowledgeFactories[name] = f
+	return nil
+}
+
+// LookupKnowledgeProvider returns a knowledge provider factory by typeName.
+func LookupKnowledgeProvider(
+	typeName string,
+) (KnowledgeProviderFactory, bool) {
+	mu.RLock()
+	defer mu.RUnlock()
+	name := normalizeType(typeName)
+	f, ok := knowledgeFactories[name]
 	return f, ok
 }
 
@@ -424,6 +476,8 @@ func Types(kind string) []string {
 		keys = mapKeys(sessionFactories)
 	case "memory backend":
 		keys = mapKeys(memoryFactories)
+	case "knowledge provider":
+		keys = mapKeys(knowledgeFactories)
 	case "tool provider":
 		keys = mapKeys(toolFactories)
 	case "toolset provider":

--- a/openclaw/registry/registry_test.go
+++ b/openclaw/registry/registry_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
+	"trpc.group/trpc-go/trpc-agent-go/knowledge"
 	"trpc.group/trpc-go/trpc-agent-go/memory"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
@@ -45,6 +46,7 @@ func resetForTest(t *testing.T) {
 	channelFactories = map[string]ChannelFactory{}
 	sessionFactories = map[string]SessionBackendFactory{}
 	memoryFactories = map[string]MemoryBackendFactory{}
+	knowledgeFactories = map[string]KnowledgeProviderFactory{}
 	toolFactories = map[string]ToolProviderFactory{}
 	toolSetFactories = map[string]ToolSetProviderFactory{}
 	modelFactories = map[string]ModelFactory{}
@@ -183,6 +185,27 @@ func TestRegisterAndLookup_MoreKinds(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, memoryCalled)
 
+	knowledgeCalled := false
+	require.NoError(t, RegisterKnowledgeProvider(
+		"knowledge",
+		func(
+			_ KnowledgeProviderDeps,
+			_ PluginSpec,
+		) (knowledge.Knowledge, error) {
+			knowledgeCalled = true
+			return nil, nil
+		},
+	))
+
+	knowledgeFactory, ok := LookupKnowledgeProvider("knowledge")
+	require.True(t, ok)
+	_, err = knowledgeFactory(
+		KnowledgeProviderDeps{},
+		PluginSpec{},
+	)
+	require.NoError(t, err)
+	require.True(t, knowledgeCalled)
+
 	providerCalled := false
 	require.NoError(t, RegisterToolProvider(
 		"p",
@@ -211,6 +234,42 @@ func TestRegisterToolProvider_DuplicateFails(t *testing.T) {
 	require.Error(t, RegisterToolProvider(
 		"p",
 		func(ToolProviderDeps, PluginSpec) ([]tool.Tool, error) {
+			return nil, nil
+		},
+	))
+}
+
+func TestRegisterKnowledgeProvider_ValidatesInputs(t *testing.T) {
+	resetForTest(t)
+
+	require.Error(t, RegisterKnowledgeProvider(
+		"",
+		func(
+			KnowledgeProviderDeps,
+			PluginSpec,
+		) (knowledge.Knowledge, error) {
+			return nil, nil
+		},
+	))
+
+	var nilFactory KnowledgeProviderFactory
+	require.Error(t, RegisterKnowledgeProvider("knowledge", nilFactory))
+
+	require.NoError(t, RegisterKnowledgeProvider(
+		"knowledge",
+		func(
+			KnowledgeProviderDeps,
+			PluginSpec,
+		) (knowledge.Knowledge, error) {
+			return nil, nil
+		},
+	))
+	require.Error(t, RegisterKnowledgeProvider(
+		"knowledge",
+		func(
+			KnowledgeProviderDeps,
+			PluginSpec,
+		) (knowledge.Knowledge, error) {
 			return nil, nil
 		},
 	))
@@ -248,6 +307,27 @@ func TestTypes(t *testing.T) {
 	))
 
 	require.Equal(t, []string{"a", "b"}, Types("toolset provider"))
+
+	require.NoError(t, RegisterKnowledgeProvider(
+		"b",
+		func(
+			_ KnowledgeProviderDeps,
+			_ PluginSpec,
+		) (knowledge.Knowledge, error) {
+			return nil, nil
+		},
+	))
+	require.NoError(t, RegisterKnowledgeProvider(
+		"a",
+		func(
+			_ KnowledgeProviderDeps,
+			_ PluginSpec,
+		) (knowledge.Knowledge, error) {
+			return nil, nil
+		},
+	))
+
+	require.Equal(t, []string{"a", "b"}, Types("knowledge provider"))
 
 	require.Nil(t, Types("unknown kind"))
 }


### PR DESCRIPTION
## Summary

Refactor the OpenClaw knowledge configuration while user adoption is still low, aligning it with the consistent `type + name + config` provider pattern used by tools, session, and memory.

- **Rename `knowledges.entries` to `knowledges.providers`** with a `type + name + max_results + config` structure, matching `tools.providers` / `session` / `memory` conventions
- **Register built-in `embedder + vector_store` as a `"builtin"` knowledge provider** in the registry, so all knowledge backends go through the same factory mechanism
- **Add `KnowledgeProviderFactory` / `RegisterKnowledgeProvider`** to the registry, enabling third-party knowledge providers to be plugged in
- **Reuse `PluginSpec`** instead of a dedicated `KnowledgeProviderSpec`, keeping the registry interface minimal
- **Default `type` to `"builtin"`** when omitted, reducing migration friction
- **Add friendly runtime error** for users still on the old `knowledges.entries` format, with clear migration instructions instead of a confusing YAML parse error
- **Remove dead code**: `positiveIntValue`, `cloneYAMLNode`, `sortedKnowledgeNames`, `knowledgeToolMaxResults`, `knowledgeVectorStoreMaxResults`

### Why now?

OpenClaw is pre-v1 with a small user base. Unifying the knowledge config before wider adoption avoids a more painful migration later and makes the YAML schema consistent across all pluggable components.

### Breaking Change

`knowledges.entries` is replaced by `knowledges.providers`. Old configs will get a clear error message pointing to the new format.

**Before:**
```yaml
knowledges:
  entries:
    - name: "docs"
      embedder:
        type: "openai"
      vector_store:
        type: "inmemory"
        max_results: 5
```

**After:**
```yaml
knowledges:
  providers:
    - name: "docs"
      max_results: 5
      config:
        embedder:
          type: "openai"
        vector_store:
          type: "inmemory"
```

## Test plan

- [x] `cd openclaw && go test ./registry/...`
- [x] `cd openclaw && go test ./app/...`
- [x] Legacy `knowledges.entries` config triggers helpful migration error
- [x] Custom knowledge provider registration and lookup works end-to-end
- [x] Single / multiple knowledge tools created correctly
- [x] README (en/zh) examples updated to new format