### PR TITLE
evaluation/mysql: bind JSON payloads as text

### DIFF
--- a/evaluation/evalresult/mysql/mysql.go
+++ b/evaluation/evalresult/mysql/mysql.go
@@ -98,7 +98,7 @@ func (m *manager) Save(ctx context.Context, appName string, evalSetResult *evalr
 		if err != nil {
 			return "", fmt.Errorf("marshal summary: %w", err)
 		}
-		summaryPayload = summaryBytes
+		summaryPayload = string(summaryBytes)
 	}
 	query := fmt.Sprintf(
 		`INSERT INTO %s (app_name, eval_set_result_id, eval_set_id, eval_set_result_name, eval_case_results, summary)
@@ -111,7 +111,7 @@ func (m *manager) Save(ctx context.Context, appName string, evalSetResult *evalr
 		   updated_at = CURRENT_TIMESTAMP(6)`,
 		m.tables.EvalSetResults,
 	)
-	if _, err := m.db.Exec(ctx, query, appName, evalSetResultID, evalSetResult.EvalSetID, evalSetResultName, casePayload, summaryPayload); err != nil {
+	if _, err := m.db.Exec(ctx, query, appName, evalSetResultID, evalSetResult.EvalSetID, evalSetResultName, string(casePayload), summaryPayload); err != nil {
 		return "", fmt.Errorf("store eval set result %s.%s: %w", appName, evalSetResultID, err)
 	}
 	return evalSetResultID, nil

--- a/evaluation/evalresult/mysql/mysql_test.go
+++ b/evaluation/evalresult/mysql/mysql_test.go
@@ -152,7 +152,7 @@ func TestSave_GeneratesDefaultsAndStores(t *testing.T) {
 
 	pattern := fmt.Sprintf(`(?s)INSERT INTO %s.*ON DUPLICATE KEY UPDATE`, regexp.QuoteMeta(m.tables.EvalSetResults))
 	mock.ExpectExec(pattern).
-		WithArgs("app", sqlmock.AnyArg(), "set", sqlmock.AnyArg(), sqlmock.AnyArg(), nil).
+		WithArgs("app", sqlmock.AnyArg(), "set", sqlmock.AnyArg(), "[]", nil).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	id, err := m.Save(ctx, "app", &evalresult.EvalSetResult{EvalSetID: "set"})
@@ -160,7 +160,7 @@ func TestSave_GeneratesDefaultsAndStores(t *testing.T) {
 	assert.True(t, strings.HasPrefix(id, "app_set_"))
 
 	mock.ExpectExec(pattern).
-		WithArgs("app", "rid", "set", "rname", sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WithArgs("app", "rid", "set", "rname", "[]", `{"numRuns":1}`).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	id, err = m.Save(ctx, "app", &evalresult.EvalSetResult{

--- a/evaluation/evalset/mysql/mysql.go
+++ b/evaluation/evalset/mysql/mysql.go
@@ -304,7 +304,7 @@ func (m *manager) AddCase(ctx context.Context, appName, evalSetID string, evalCa
 		"INSERT INTO %s (app_name, eval_set_id, eval_id, eval_mode, eval_case) VALUES (?, ?, ?, ?, ?)",
 		m.tables.EvalCases,
 	)
-	if _, err := m.db.Exec(ctx, query, appName, evalSetID, cloned.EvalID, cloned.EvalMode, payload); err != nil {
+	if _, err := m.db.Exec(ctx, query, appName, evalSetID, cloned.EvalID, cloned.EvalMode, string(payload)); err != nil {
 		if mysqldb.IsDuplicateEntry(err) {
 			return fmt.Errorf("eval case %s.%s.%s already exists", appName, evalSetID, cloned.EvalID)
 		}
@@ -338,7 +338,7 @@ func (m *manager) UpdateCase(ctx context.Context, appName, evalSetID string, eva
 		"UPDATE %s SET eval_mode = ?, eval_case = ?, updated_at = CURRENT_TIMESTAMP(6) WHERE app_name = ? AND eval_set_id = ? AND eval_id = ?",
 		m.tables.EvalCases,
 	)
-	res, err := m.db.Exec(ctx, query, evalCase.EvalMode, payload, appName, evalSetID, evalCase.EvalID)
+	res, err := m.db.Exec(ctx, query, evalCase.EvalMode, string(payload), appName, evalSetID, evalCase.EvalID)
 	if err != nil {
 		return fmt.Errorf("update eval case %s.%s.%s: %w", appName, evalSetID, evalCase.EvalID, err)
 	}

--- a/evaluation/evalset/mysql/mysql_test.go
+++ b/evaluation/evalset/mysql/mysql_test.go
@@ -35,17 +35,12 @@ type evalCasePayloadMatcher struct {
 }
 
 func (m evalCasePayloadMatcher) Match(v driver.Value) bool {
-	var payload []byte
-	switch typed := v.(type) {
-	case []byte:
-		payload = typed
-	case string:
-		payload = []byte(typed)
-	default:
+	payload, ok := v.(string)
+	if !ok {
 		return false
 	}
 	var c evalset.EvalCase
-	if err := json.Unmarshal(payload, &c); err != nil {
+	if err := json.Unmarshal([]byte(payload), &c); err != nil {
 		return false
 	}
 	if c.EvalID != "case" {
@@ -445,7 +440,7 @@ func TestCaseCRUD(t *testing.T) {
 		m.tables.EvalCases,
 	)
 	mock.ExpectExec(regexp.QuoteMeta(updateSQL)).
-		WithArgs("", sqlmock.AnyArg(), "app", "set", "case").
+		WithArgs("", `{"evalId":"case"}`, "app", "set", "case").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	err = m.UpdateCase(ctx, "app", "set", &evalset.EvalCase{EvalID: "case"})

--- a/evaluation/metric/mysql/mysql.go
+++ b/evaluation/metric/mysql/mysql.go
@@ -142,7 +142,7 @@ func (m *manager) Add(ctx context.Context, appName, evalSetID string, metricInpu
 		"INSERT INTO %s (app_name, eval_set_id, metric_name, metric) VALUES (?, ?, ?, ?)",
 		m.tables.Metrics,
 	)
-	if _, err := m.db.Exec(ctx, query, appName, evalSetID, metricInput.MetricName, payload); err != nil {
+	if _, err := m.db.Exec(ctx, query, appName, evalSetID, metricInput.MetricName, string(payload)); err != nil {
 		if mysqldb.IsDuplicateEntry(err) {
 			return fmt.Errorf("metric %s.%s.%s already exists", appName, evalSetID, metricInput.MetricName)
 		}
@@ -202,7 +202,7 @@ func (m *manager) Update(ctx context.Context, appName, evalSetID string, metricI
 		"UPDATE %s SET metric = ?, updated_at = CURRENT_TIMESTAMP(6) WHERE app_name = ? AND eval_set_id = ? AND metric_name = ?",
 		m.tables.Metrics,
 	)
-	res, err := m.db.Exec(ctx, query, payload, appName, evalSetID, metricInput.MetricName)
+	res, err := m.db.Exec(ctx, query, string(payload), appName, evalSetID, metricInput.MetricName)
 	if err != nil {
 		return fmt.Errorf("update metric %s.%s.%s: %w", appName, evalSetID, metricInput.MetricName, err)
 	}

--- a/evaluation/metric/mysql/mysql_test.go
+++ b/evaluation/metric/mysql/mysql_test.go
@@ -242,7 +242,7 @@ func TestGet_Add_Update_Delete(t *testing.T) {
 		m.tables.Metrics,
 	)
 	mock.ExpectExec(regexp.QuoteMeta(addSQL)).
-		WithArgs("app", "set", "m1", sqlmock.AnyArg()).
+		WithArgs("app", "set", "m1", `{"metricName":"m1","threshold":0.5}`).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	err = m.Add(ctx, "app", "set", &metric.EvalMetric{MetricName: "m1", Threshold: 0.5})
@@ -253,7 +253,7 @@ func TestGet_Add_Update_Delete(t *testing.T) {
 		m.tables.Metrics,
 	)
 	mock.ExpectExec(regexp.QuoteMeta(updateSQL)).
-		WithArgs(sqlmock.AnyArg(), "app", "set", "m1").
+		WithArgs(`{"metricName":"m1","threshold":0.7}`, "app", "set", "m1").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	err = m.Update(ctx, "app", "set", &metric.EvalMetric{MetricName: "m1", Threshold: 0.7})

--- a/evaluation/workflow/promptiter/store/mysql/mysql.go
+++ b/evaluation/workflow/promptiter/store/mysql/mysql.go
@@ -66,7 +66,8 @@ func (s *mysqlStore) Create(ctx context.Context, run *engine.RunResult) error {
 		"INSERT INTO %s (run_id, status, run_result) VALUES (?, ?, ?)",
 		s.tableName,
 	)
-	if _, err := s.db.Exec(ctx, query, run.ID, string(run.Status), payload); err != nil {
+	// Pass JSON as a UTF-8 string so the driver does not bind []byte as BINARY (MySQL JSON rejects binary charset).
+	if _, err := s.db.Exec(ctx, query, run.ID, string(run.Status), string(payload)); err != nil {
 		if mysqldb.IsDuplicateEntry(err) {
 			return fmt.Errorf("run %q already exists", run.ID)
 		}
@@ -117,7 +118,7 @@ func (s *mysqlStore) Update(ctx context.Context, run *engine.RunResult) error {
 		"UPDATE %s SET status = ?, run_result = ?, updated_at = CURRENT_TIMESTAMP(6) WHERE run_id = ?",
 		s.tableName,
 	)
-	result, err := s.db.Exec(ctx, query, string(run.Status), payload, run.ID)
+	result, err := s.db.Exec(ctx, query, string(run.Status), string(payload), run.ID)
 	if err != nil {
 		return fmt.Errorf("update run %q: %w", run.ID, err)
 	}


### PR DESCRIPTION
MySQL-backed evaluation stores write marshaled JSON into JSON columns, but passing json.Marshal output as []byte can be bound as a binary value and rejected by MySQL JSON handling. This change binds those payloads as UTF-8 strings while preserving the existing JSON content and read paths.