### PR TITLE
openclaw: add knowledge description field and use AgenticFilterSearchTool

### DIFF
--- a/openclaw/app/knowledge_tools.go
+++ b/openclaw/app/knowledge_tools.go
@@ -32,10 +32,11 @@ import (
 // knowledgeEntry is the parsed intermediate representation of a knowledge
 // provider configuration.
 type knowledgeEntry struct {
-	Type       string
-	Name       string
-	MaxResults int
-	Config     *yaml.Node
+	Type        string
+	Name        string
+	Description string
+	MaxResults  int
+	Config      *yaml.Node
 }
 
 type knowledgeToolsBundle struct {
@@ -87,11 +88,12 @@ func buildKnowledgeTools(
 		return nil, nil
 	}
 
-	type knowledgeWithMaxResults struct {
-		kb         knowledge.Knowledge
-		maxResults int
+	type resolvedKnowledge struct {
+		kb          knowledge.Knowledge
+		description string
+		maxResults  int
 	}
-	knowledges := make(map[string]*knowledgeWithMaxResults, len(entries))
+	knowledges := make(map[string]*resolvedKnowledge, len(entries))
 	for _, entry := range entries {
 		f, ok := registry.LookupKnowledgeProvider(entry.Type)
 		if !ok {
@@ -112,9 +114,10 @@ func buildKnowledgeTools(
 				err,
 			)
 		}
-		knowledges[entry.Name] = &knowledgeWithMaxResults{
-			kb:         kb,
-			maxResults: entry.MaxResults,
+		knowledges[entry.Name] = &resolvedKnowledge{
+			kb:          kb,
+			description: entry.Description,
+			maxResults:  entry.MaxResults,
 		}
 	}
 
@@ -126,11 +129,13 @@ func buildKnowledgeTools(
 
 	if len(names) == 1 {
 		entry := knowledges[names[0]]
+		desc := entry.description
+		if desc == "" {
+			desc = "Search for relevant information in the knowledge base."
+		}
 		toolOpts := []knowledgetool.Option{
 			knowledgetool.WithToolName("knowledge_search"),
-			knowledgetool.WithToolDescription(
-				"Search for relevant information in the knowledge base.",
-			),
+			knowledgetool.WithToolDescription(desc),
 		}
 		if entry.maxResults > 0 {
 			toolOpts = append(
@@ -162,14 +167,16 @@ func buildKnowledgeTools(
 		}
 		seenToolNames[toolName] = name
 		entry := knowledges[name]
+		desc := entry.description
+		if desc == "" {
+			desc = fmt.Sprintf(
+				"Search for relevant information in the %q knowledge base.",
+				name,
+			)
+		}
 		toolOpts := []knowledgetool.Option{
 			knowledgetool.WithToolName(toolName),
-			knowledgetool.WithToolDescription(
-				fmt.Sprintf(
-					"Search for relevant information in the %q knowledge base.",
-					name,
-				),
-			),
+			knowledgetool.WithToolDescription(desc),
 		}
 		if entry.maxResults > 0 {
 			toolOpts = append(

--- a/openclaw/app/knowledge_tools.go
+++ b/openclaw/app/knowledge_tools.go
@@ -145,8 +145,9 @@ func buildKnowledgeTools(
 		}
 		return &knowledgeToolsBundle{
 			tools: []tool.Tool{
-				knowledgetool.NewKnowledgeSearchTool(
+				knowledgetool.NewAgenticFilterSearchTool(
 					entry.kb,
+					nil,
 					toolOpts...,
 				),
 			},

--- a/openclaw/app/knowledge_tools_test.go
+++ b/openclaw/app/knowledge_tools_test.go
@@ -232,6 +232,49 @@ vector_store:
 	require.Equal(t, "knowledge_search", bundle.tools[0].Declaration().Name)
 }
 
+func TestBuildKnowledgeTools_SingleKnowledgeCustomDescription(t *testing.T) {
+	t.Parallel()
+
+	entry := builtinKnowledgeEntry(t, "docs", `
+vector_store:
+  type: inmemory
+`)
+	entry.Description = "Search the trpc-agent-go documentation including API reference and design docs."
+	bundle, err := buildKnowledgeTools([]knowledgeEntry{entry})
+	require.NoError(t, err)
+	require.NotNil(t, bundle)
+	require.Len(t, bundle.tools, 1)
+	require.Equal(t, "knowledge_search", bundle.tools[0].Declaration().Name)
+	require.Equal(t,
+		"Search the trpc-agent-go documentation including API reference and design docs.",
+		bundle.tools[0].Declaration().Description,
+	)
+}
+
+func TestBuildKnowledgeTools_MultipleKnowledgesCustomDescription(t *testing.T) {
+	t.Parallel()
+
+	inmemory := `
+vector_store:
+  type: inmemory
+`
+	docs := builtinKnowledgeEntry(t, "docs", inmemory)
+	docs.Description = "Framework documentation and design docs."
+	faq := builtinKnowledgeEntry(t, "faq", inmemory)
+	bundle, err := buildKnowledgeTools([]knowledgeEntry{docs, faq})
+	require.NoError(t, err)
+	require.NotNil(t, bundle)
+	require.Len(t, bundle.tools, 2)
+	require.Equal(t,
+		"Framework documentation and design docs.",
+		bundle.tools[0].Declaration().Description,
+	)
+	require.Contains(t,
+		bundle.tools[1].Declaration().Description,
+		`"faq"`,
+	)
+}
+
 func TestBuildKnowledgeTools_VectorStoreUsesTypeSpecificValidation(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/app/run_options.go
+++ b/openclaw/app/run_options.go
@@ -1121,10 +1121,11 @@ type knowledgesConfig struct {
 }
 
 type knowledgeProviderConfig struct {
-	Type       string       `yaml:"type,omitempty"`
-	Name       string       `yaml:"name,omitempty"`
-	MaxResults *int         `yaml:"max_results,omitempty"`
-	Config     *rawYAMLNode `yaml:"config,omitempty"`
+	Type        string       `yaml:"type,omitempty"`
+	Name        string       `yaml:"name,omitempty"`
+	Description string       `yaml:"description,omitempty"`
+	MaxResults  *int         `yaml:"max_results,omitempty"`
+	Config      *rawYAMLNode `yaml:"config,omitempty"`
 }
 
 type pluginSpec struct {
@@ -1921,10 +1922,11 @@ func convertKnowledgeConfigs(
 		}
 
 		out = append(out, knowledgeEntry{
-			Type:       typeName,
-			Name:       name,
-			MaxResults: maxResults,
-			Config:     config,
+			Type:        typeName,
+			Name:        name,
+			Description: strings.TrimSpace(p.Description),
+			MaxResults:  maxResults,
+			Config:      config,
 		})
 	}
 

--- a/openclaw/app/run_options_test.go
+++ b/openclaw/app/run_options_test.go
@@ -937,6 +937,30 @@ knowledges:
 	require.Equal(t, 5, opts.KnowledgesConfig[0].MaxResults)
 }
 
+func TestParseRunOptions_KnowledgesProvidersWithDescription(t *testing.T) {
+	t.Parallel()
+
+	cfgPath := writeTempConfig(t, `
+knowledges:
+  providers:
+    - name: "docs"
+      description: "Framework docs and API reference"
+      max_results: 5
+      config:
+        vector_store:
+          type: "inmemory"
+`)
+
+	opts, err := parseRunOptions([]string{"-config", cfgPath})
+	require.NoError(t, err)
+	require.Len(t, opts.KnowledgesConfig, 1)
+	require.Equal(t, "docs", opts.KnowledgesConfig[0].Name)
+	require.Equal(t,
+		"Framework docs and API reference",
+		opts.KnowledgesConfig[0].Description,
+	)
+}
+
 func TestParseRunOptions_KnowledgesProvidersExternalConfig(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Add a configurable `description` field to knowledge provider config, allowing users to customize the tool description sent to the LLM via YAML. This helps the LLM understand what content each knowledge base contains.
- Switch single-knowledge-base path from `NewKnowledgeSearchTool` to `NewAgenticFilterSearchTool`, so the LLM has access to the `filter` parameter in the tool schema (consistent with multi-knowledge path).

**WIP**: Follow-up work planned to add default metadata filter guidance in tool description when `agenticFilterInfo` is nil, so the LLM knows it can use metadata from search results to construct filters.

## Changes

1. `knowledgeProviderConfig` / `knowledgeEntry`: add `Description` field
2. `buildKnowledgeTools`: prioritize custom description for tool description; fallback to default
3. `buildKnowledgeTools`: use `NewAgenticFilterSearchTool` for both single and multi knowledge base scenarios
4. Tests: add 3 new test cases covering description parsing and tool description behavior

## YAML config example

```yaml
knowledges:
  providers:
    - name: "docs"
      description: "Search the trpc-agent-go documentation including API reference and design docs."
      max_results: 5
      config:
        vector_store:
          type: "inmemory"
```

## Test plan

- [x] `go test ./openclaw/app/... -run TestBuildKnowledgeTools` — all 12 tests pass
- [x] `go test ./openclaw/app/... -run TestParseRunOptions_KnowledgesProviders` — all pass
- [ ] Follow-up: add default metadata filter guidance for nil agenticFilterInfo


Made with [Cursor](https://cursor.com)