### PR TITLE
knowledge/tool: add default metadata filter guidance for agentic search

### DIFF
--- a/knowledge/tool/searchtool.go
+++ b/knowledge/tool/searchtool.go
@@ -30,6 +30,56 @@ const (
 	defaultMaxResults        = 10
 	defaultMinScore          = 0.0
 	agenticFilterPromptIntro = "You are a helpful assistant that can search for relevant information in the knowledge base."
+
+	// metadataFilterHint is appended to the tool description when no explicit
+	// agenticFilterInfo is provided. It teaches the LLM that metadata fields
+	// from search results can be used to construct filter conditions.
+	metadataFilterHint = `Each search result contains two types of filterable fields:
+
+  1. Document text — shown as "text" in results, but use field name
+     "content" when constructing filters. Use the "like" operator for
+     substring matching against the original document content.
+
+  2. "metadata.*" — structured metadata fields. Keys in results appear
+     without prefix (e.g. "source", "topic"), but when constructing
+     filters, prefix them with "metadata." (e.g. "metadata.source").
+
+You can use these field names and values from previous search results
+to construct filter conditions for more precise subsequent searches.
+
+Example — given a search result like:
+  {
+    "text": "Graph state is the core mechanism...",
+    "metadata": {"source": "docs/graph.md", "topic": "architecture"},
+    "score": 0.87
+  }
+
+  Filter by document text (use "content" as field name, not "text"):
+    {"field": "content", "operator": "like", "value": "graph state"}
+
+  Filter by metadata (note the "metadata." prefix):
+    {"field": "metadata.topic", "operator": "eq", "value": "architecture"}
+
+  Filter by metadata (multiple values):
+    {"field": "metadata.topic", "operator": "in", "value": ["architecture", "api"]}
+
+  Combine content and metadata:
+    {"operator": "and", "value": [
+      {"field": "content", "operator": "like", "value": "graph state"},
+      {"field": "metadata.source", "operator": "eq", "value": "docs/graph.md"}
+    ]}
+
+Available operators:
+  eq, ne, gt, gte, lt, lte, in, not in, like, not like, between, and, or
+
+Usage modes:
+  - query + filter: use together for semantic search narrowed by metadata constraints.
+  - filter only: omit query and use filter alone for pure metadata-based retrieval.
+  - query only: omit filter for standard semantic search.
+  At least one of query or filter must be provided.
+
+Note:
+  For logical operators (and/or), use "value" to specify an array of sub-conditions.`
 )
 
 // KnowledgeSearchRequest represents the input for the knowledge search tool.
@@ -318,19 +368,17 @@ func composeAgenticToolDescription(toolDescription, filterInfo string) string {
 	toolDescription = strings.TrimSpace(toolDescription)
 	filterInfo = strings.TrimSpace(filterInfo)
 
-	switch {
-	case toolDescription == "":
-		return filterInfo
-	case filterInfo == "":
-		return toolDescription
+	base := toolDescription
+	if base == "" {
+		base = agenticFilterPromptIntro
 	}
 
 	filterAppendix := strings.TrimSpace(strings.TrimPrefix(filterInfo, agenticFilterPromptIntro))
 	if filterAppendix == "" {
-		return toolDescription
+		filterAppendix = metadataFilterHint
 	}
 
-	return fmt.Sprintf("%s\n\n== FILTER GUIDANCE ==\n\n%s", toolDescription, filterAppendix)
+	return fmt.Sprintf("%s\n\n== FILTER GUIDANCE ==\n\n%s", base, filterAppendix)
 }
 
 // applyPostProcessor runs the optional ResultPostProcessor on resp. Passing a

--- a/knowledge/tool/searchtool.go
+++ b/knowledge/tool/searchtool.go
@@ -54,8 +54,9 @@ Example — given a search result like:
     "score": 0.87
   }
 
-  Filter by document text (use "content" as field name, not "text"):
-    {"field": "content", "operator": "like", "value": "graph state"}
+  Filter by document text (use "content" as field name, not "text";
+  use %% wildcards for substring matching):
+    {"field": "content", "operator": "like", "value": "%graph state%"}
 
   Filter by metadata (note the "metadata." prefix):
     {"field": "metadata.topic", "operator": "eq", "value": "architecture"}
@@ -65,7 +66,7 @@ Example — given a search result like:
 
   Combine content and metadata:
     {"operator": "and", "value": [
-      {"field": "content", "operator": "like", "value": "graph state"},
+      {"field": "content", "operator": "like", "value": "%graph state%"},
       {"field": "metadata.source", "operator": "eq", "value": "docs/graph.md"}
     ]}
 

--- a/knowledge/tool/searchtool_test.go
+++ b/knowledge/tool/searchtool_test.go
@@ -582,6 +582,60 @@ func TestGenerateAgenticFilterPrompt(t *testing.T) {
 	})
 }
 
+func TestComposeAgenticToolDescription(t *testing.T) {
+	t.Parallel()
+
+	sampleFilterInfo := generateAgenticFilterPrompt(map[string][]any{
+		"metadata.topic": {"architecture", "api"},
+	})
+
+	t.Run("with description and filterInfo", func(t *testing.T) {
+		desc := composeAgenticToolDescription("Search docs.", sampleFilterInfo)
+		require.Contains(t, desc, "Search docs.")
+		require.Contains(t, desc, "== FILTER GUIDANCE ==")
+		require.Contains(t, desc, "metadata.topic")
+		require.NotContains(t, desc, metadataFilterHint)
+	})
+
+	t.Run("with description and nil filterInfo", func(t *testing.T) {
+		nilFilterInfo := generateAgenticFilterPrompt(nil)
+		desc := composeAgenticToolDescription("Search docs.", nilFilterInfo)
+		require.Contains(t, desc, "Search docs.")
+		require.Contains(t, desc, "== FILTER GUIDANCE ==")
+		require.Contains(t, desc, metadataFilterHint)
+		require.Contains(t, desc, `"content"`)
+		require.Contains(t, desc, `"metadata.*"`)
+		require.Contains(t, desc, `"like"`)
+	})
+
+	t.Run("no description with filterInfo", func(t *testing.T) {
+		desc := composeAgenticToolDescription("", sampleFilterInfo)
+		require.Contains(t, desc, agenticFilterPromptIntro)
+		require.Contains(t, desc, "== FILTER GUIDANCE ==")
+		require.Contains(t, desc, "metadata.topic")
+		require.NotContains(t, desc, metadataFilterHint)
+	})
+
+	t.Run("no description and nil filterInfo", func(t *testing.T) {
+		nilFilterInfo := generateAgenticFilterPrompt(nil)
+		desc := composeAgenticToolDescription("", nilFilterInfo)
+		require.Contains(t, desc, agenticFilterPromptIntro)
+		require.Contains(t, desc, "== FILTER GUIDANCE ==")
+		require.Contains(t, desc, metadataFilterHint)
+	})
+
+	t.Run("metadata filter hint contains content and metadata examples", func(t *testing.T) {
+		require.Contains(t, metadataFilterHint, `"content"`)
+		require.Contains(t, metadataFilterHint, `"metadata.*"`)
+		require.Contains(t, metadataFilterHint, `metadata.topic`)
+		require.Contains(t, metadataFilterHint, `metadata.source`)
+		require.Contains(t, metadataFilterHint, `"like"`)
+		require.Contains(t, metadataFilterHint, `"eq"`)
+		require.Contains(t, metadataFilterHint, `"in"`)
+		require.Contains(t, metadataFilterHint, `"and"`)
+	})
+}
+
 func TestAgenticFilterSearchToolWithAdvancedFilter(t *testing.T) {
 	t.Run("successful search with simple filter", func(t *testing.T) {
 		kb := stubKnowledge{


### PR DESCRIPTION
## Summary

When `agenticFilterInfo` is nil (no pre-declared filterable fields), `composeAgenticToolDescription` now appends a generic metadata filter guidance to the tool description instead of producing no filter guidance at all.

This teaches the LLM two types of filterable fields from search results:

1. **`content`** — document raw text, use `like` operator for substring matching
2. **`metadata.*`** — structured metadata fields from results (keys appear without prefix in results but require `metadata.` prefix in filter field names)

The guidance includes concrete examples showing how to construct filters based on actual search results, enabling the LLM to discover filterable fields autonomously without the developer pre-declaring them.

## Changes

- `knowledge/tool/searchtool.go`:
  - Add `metadataFilterHint` constant with content/metadata filter examples
  - Modify `composeAgenticToolDescription`: when `filterAppendix` is empty (nil agenticFilterInfo), fall back to `metadataFilterHint` instead of returning description without guidance
  - Always output `base + FILTER GUIDANCE` format for consistent behavior

- `knowledge/tool/searchtool_test.go`:
  - Add `TestComposeAgenticToolDescription` with 5 sub-tests covering all 4 input combinations plus hint content validation

## Test plan

- [x] `go test ./knowledge/tool/... -count=1` — all tests pass
- [x] New `TestComposeAgenticToolDescription` covers:
  - desc + filterInfo → uses provided filterInfo
  - desc + nil filterInfo → uses metadataFilterHint
  - no desc + filterInfo → uses agenticFilterPromptIntro as base
  - no desc + nil filterInfo → uses both defaults
  - hint contains content/metadata examples with correct operators


Made with [Cursor](https://cursor.com)