### PR TITLE
examples: add graph RAG code search demo and viewer

### DIFF
--- a/examples/knowledge/features/code_context_engine/mcp/server.go
+++ b/examples/knowledge/features/code_context_engine/mcp/server.go
@@ -29,6 +29,7 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	util "trpc.group/trpc-go/trpc-agent-go/examples/knowledge"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge"
+	_ "trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader/golang"
 	openaiembedder "trpc.group/trpc-go/trpc-agent-go/knowledge/embedder/openai"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/searchfilter"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/source"

--- a/examples/knowledge/features/graphrag/README.md
+++ b/examples/knowledge/features/graphrag/README.md
@@ -1,0 +1,249 @@
+# GraphRAG Code Chat
+
+Ask a codebase question, let the agent find the right symbols, then traverse the call graph instead of guessing from keyword hits.
+
+This example indexes the `trpc-go` repository into:
+
+- Apache AGE for code graph nodes and edges.
+- pgvector for semantic seed search.
+- A chat agent with `code_graph_search`, `code_graph_traverse`, and `code_graph_find_paths`.
+
+It is useful for questions where plain vector search usually stops too early:
+
+- "Where is this mechanism configured?"
+- "How does this request flow from client to server?"
+- "Which functions participate in this error handling path?"
+- "What is connected to this symbol, and why?"
+
+## What It Shows
+
+The case demonstrates a GraphRAG workflow over real Go code:
+
+1. Search the codebase semantically to find likely seed symbols.
+2. Resolve those results to stable graph node IDs.
+3. Traverse callers, callees, or dependency edges around those symbols.
+4. Answer with concrete files, functions, and graph evidence.
+
+Compared with a normal RAG example, this one can move from a fuzzy question like "timeout propagation" to specific code such as:
+
+- `client.client.Invoke`
+- `codec.msg.WithRequestTimeout`
+- `server.service.handle`
+- `server.mayConvert2FullLinkTimeout`
+- `server.mayConvert2NormalTimeout`
+
+## Demo Case: Timeout Propagation in tRPC-Go
+
+Start the chat with existing indexed data:
+
+```bash
+cd examples/knowledge/features/graphrag
+go run . -recreate=false
+```
+
+Example startup:
+
+```text
+GraphRAG Chat Demo
+Model: claude-4-5-sonnet-20250929
+Streaming: true
+==================================================
+Embedding: server:277357 (1024 dimensions)
+Skipped graph source loading; using existing AGE graph and pgvector data
+
+Chat ready. Session: graph-demo-session-1777467345
+Type '/exit' to end the conversation.
+Try: Find code related to client RPC invocation in trpc-go, traverse its callees, and explain the nearby call graph.
+==================================================
+```
+
+Ask:
+
+```text
+Help me check the timeout propagation chain in trpc-go.
+```
+
+The agent first searches for timeout-related seed code:
+
+```text
+Tool calls (2):
+  [1] code_graph_search
+      query: timeout propagation context deadline
+      filter:
+        metadata.trpc_ast_repo_name = trpc-go
+        metadata.trpc_ast_scope = code
+
+  [2] code_graph_search
+      query: WithTimeout SetTimeout timeout handling
+      filter:
+        metadata.trpc_ast_repo_name = trpc-go
+        metadata.trpc_ast_scope = code
+        metadata.trpc_ast_type in [Function, Method]
+```
+
+Typical results include:
+
+```text
+documents: 3
+  [1] server.WithTimeout
+      file: trpc-go server/options.go:226-231
+      sig: func WithTimeout(t time.Duration) Option
+
+  [2] client.WithTimeout
+      file: trpc-go client/options.go:317-322
+      sig: func WithTimeout(t time.Duration) Option
+```
+
+Then it narrows to server and client timeout handling:
+
+```text
+Tool calls:
+  code_graph_search query="timeout request handling context"
+  code_graph_search query="client timeout context deadline"
+```
+
+The relevant seed symbols become:
+
+```text
+server.Options
+server.WithDisableRequestTimeout
+client.BackendConfig
+client.client.Invoke
+server.mayConvert2NormalTimeout
+server.mayConvert2FullLinkTimeout
+```
+
+After that, the agent uses graph traversal to inspect the actual call neighborhood:
+
+```text
+Tool calls:
+  code_graph_traverse
+      direction: out
+      edge_types: [CALLS]
+      max_depth: 2
+      start_ids: [node:...]
+```
+
+Example graph result:
+
+```text
+nodes: 21
+  [1] Invoke
+      full: trpc.group/trpc-go/trpc-go/client.client.Invoke
+      file: trpc-go client/client.go:55-99
+
+  [2] fixFilters
+      full: trpc.group/trpc-go/trpc-go/client.client.fixFilters
+      file: trpc-go client/client.go:206-218
+
+edges: 21
+  [1] CALLS: client.client.Invoke -> client.client.getOptions
+  [2] CALLS: client.client.Invoke -> client.client.updateMsg
+  ... more edges omitted
+```
+
+The final answer can explain the propagation chain with concrete code anchors:
+
+```text
+client.client.Invoke
+  -> applies client timeout with context.WithTimeout
+  -> writes remaining deadline into msg.WithRequestTimeout
+  -> protocol encoding carries RequestTimeout
+
+codec.msg.WithRequestTimeout / RequestTimeout
+  -> stores timeout on the framework message
+
+server.service.handle
+  -> reads msg.RequestTimeout
+  -> compares upstream timeout with server Options.Timeout
+  -> applies the smaller timeout using context.WithTimeout
+
+server.mayConvert2FullLinkTimeout / mayConvert2NormalTimeout
+  -> maps timeout errors to full-link or normal server timeout codes
+```
+
+Good follow-up questions:
+
+```text
+如何在trpc-go中配置超时时间？
+trpc-go超时时间的默认值是多少？
+除了超时，trpc-go还有哪些常见的错误和异常情况？
+```
+
+These work well because the first question asks for configuration symbols, the second forces the agent to inspect defaults, and the third expands from timeout errors to the surrounding error taxonomy.
+
+## Run From Scratch
+
+Set model and embedding options:
+
+```bash
+export OPENAI_API_KEY=sk-xxxx
+export OPENAI_BASE_URL=https://api.openai.com/v1
+export MODEL_NAME=claude-4-5-sonnet-20250929
+export EMBEDDING_MODEL=server:277357
+export EMBEDDING_DIMENSION=1024
+```
+
+Set AGE and pgvector. `AGE_DSN` and `PGVECTOR_DSN` can override the individual fields.
+
+```bash
+export AGE_HOST=127.0.0.1
+export AGE_PORT=5432
+export AGE_USER=root
+export AGE_PASSWORD=123
+export AGE_DATABASE=contextengine
+export AGE_GRAPH_NAME=knowledge_graph
+
+export PGVECTOR_HOST=127.0.0.1
+export PGVECTOR_PORT=5432
+export PGVECTOR_USER=root
+export PGVECTOR_PASSWORD=123
+export PGVECTOR_DATABASE=contextengine
+export PGVECTOR_TABLE=trpc_agent_go_graph
+```
+
+Load or reload the repository graph and vector seed index:
+
+```bash
+go run . -recreate=true
+```
+
+Reuse existing AGE and pgvector data:
+
+```bash
+go run . -recreate=false
+```
+
+## Useful Flags
+
+```bash
+go run . \
+  -recreate=false \
+  -streaming=true \
+  -model=claude-4-5-sonnet-20250929 \
+  -embedding-model=server:277357 \
+  -embedding-dimension=1024
+```
+
+Key flags:
+
+- `-recreate=true`: drop and rebuild the AGE graph and pgvector table.
+- `-recreate=false`: skip loading and use existing indexed data.
+- `-query="..."`: run one initial question before entering interactive chat.
+- `-progress-step=100`: control graph loading progress logs.
+
+## Graph Viewer
+
+The viewer is in [viewer](./viewer). It reads the same AGE graph and shows a lightweight UI for inspecting nodes, edges, content, and metadata.
+
+```bash
+go run ./viewer -addr=0.0.0.0:3012
+```
+
+Open:
+
+```text
+http://127.0.0.1:3012
+```
+
+For remote access, bind to `0.0.0.0` and use the machine IP.

--- a/examples/knowledge/features/graphrag/README.md
+++ b/examples/knowledge/features/graphrag/README.md
@@ -46,7 +46,6 @@ Example startup:
 ```text
 GraphRAG Chat Demo
 Model: claude-4-5-sonnet-20250929
-Streaming: true
 ==================================================
 Embedding: server:277357 (1024 dimensions)
 Skipped graph source loading; using existing AGE graph and pgvector data
@@ -219,7 +218,6 @@ go run . -recreate=false
 ```bash
 go run . \
   -recreate=false \
-  -streaming=true \
   -model=claude-4-5-sonnet-20250929 \
   -embedding-model=server:277357 \
   -embedding-dimension=1024
@@ -231,6 +229,7 @@ Key flags:
 - `-recreate=false`: skip loading and use existing indexed data.
 - `-query="..."`: run one initial question before entering interactive chat.
 - `-progress-step=100`: control graph loading progress logs.
+- `-debug-file=trace.jsonl`: write a JSONL tool trace.
 
 ## Graph Viewer
 

--- a/examples/knowledge/features/graphrag/main.go
+++ b/examples/knowledge/features/graphrag/main.go
@@ -8,7 +8,7 @@
 //
 
 // Package main demonstrates GraphRAG over repository code in a multi-turn chat.
-// It loads the trpc-agent-go repository through repo source, wires graph search,
+// It loads the trpc-go repository through repo source, wires graph search,
 // traversal, and path tools into an LLM agent, and prints tool calls and
 // tool responses during the conversation.
 //
@@ -76,10 +76,10 @@ import (
 )
 
 var (
-	defaultRepoURL = "https://github.com/trpc-group/trpc-agent-go"
-	defaultQuery   = "Find code related to agent execution in trpc-agent-go, traverse its callees, and explain the nearby call graph."
+	defaultRepoURL = "https://github.com/trpc-group/trpc-go"
+	defaultQuery   = "Find code related to client RPC invocation in trpc-go, traverse its callees, and explain the nearby call graph."
 	query          = flag.String("query", "", "Optional initial query to ask before entering chat")
-	modelName      = flag.String("model", util.GetEnvOrDefault("MODEL_NAME", "deepseek-v3,2"), "Model to use")
+	modelName      = flag.String("model", util.GetEnvOrDefault("MODEL_NAME", "deepseek-chat"), "Model to use")
 	embeddingModel = flag.String("embedding-model", util.GetEnvOrDefault("EMBEDDING_MODEL", "server:277357"), "Embedding model to use")
 	embeddingDim   = flag.Int("embedding-dimension", defaultEmbeddingDimension(), "Embedding dimension; <=0 probes once")
 	recreate       = flag.Bool("recreate", false, "Drop pgvector table and reload graph source; false reuses existing graph/vector data")
@@ -145,8 +145,8 @@ func main() {
 	graphToolSet := knowledgetool.NewCodeGraphSearchTool(
 		kb,
 		knowledgetool.WithCodeSearchRepoInfos([]knowledgetool.CodeRepoInfo{{
-			Name:        "trpc-agent-go",
-			Description: "The tRPC-Agent-Go framework repository used to demonstrate graph RAG over repo source.",
+			Name:        "trpc-go",
+			Description: "The tRPC-Go framework repository used to demonstrate graph RAG over repo source.",
 		}}),
 		knowledgetool.WithCodeSearchMaxResults(3),
 	)
@@ -185,7 +185,8 @@ func main() {
 	if strings.TrimSpace(*query) != "" {
 		fmt.Printf("\nInitial query: %s\n", *query)
 		if err := runTurn(ctx, r, "graph-demo-user", sessionID, *query, trace); err != nil {
-			log.Fatalf("run initial query: %v", err)
+			fmt.Printf("run initial query failed: %v\n", err)
+			return
 		}
 		fmt.Println()
 	}
@@ -321,21 +322,21 @@ func (s timedGraphSource) ReadGraph(ctx context.Context, opts ...source.ReadGrap
 	return data, nil
 }
 
-// loadGraphSource loads the trpc-agent-go repo into the graph knowledge base.
+// loadGraphSource loads the trpc-go repo into the graph knowledge base.
 func loadGraphSource(ctx context.Context, kb *knowledge.BuiltinGraphKnowledge) error {
 	repoSrc := repo.New(
 		repo.WithRepository(repo.Repository{
 			URL:         defaultRepoURL,
-			RepoName:    "trpc-agent-go",
+			RepoName:    "trpc-go",
 			RepoURL:     defaultRepoURL,
-			Description: "The tRPC-Agent-Go framework repository used to demonstrate graph RAG over repo source.",
+			Description: "The tRPC-Go framework repository used to demonstrate graph RAG over repo source.",
 		}),
-		repo.WithName("trpc-agent-go Repository"),
+		repo.WithName("trpc-go Repository"),
 		repo.WithFileExtensions([]string{".go"}),
 	)
 	err := kb.LoadGraphSource(
 		ctx,
-		timedGraphSource{name: "trpc-agent-go Repository", src: repoSrc},
+		timedGraphSource{name: "trpc-go Repository", src: repoSrc},
 		knowledge.WithGraphLoadProgress(true),
 		knowledge.WithGraphLoadProgressStepSize(*progressStep),
 		knowledge.WithGraphLoadConcurrency(knowledge.GraphLoadConcurrency{

--- a/examples/knowledge/features/graphrag/main.go
+++ b/examples/knowledge/features/graphrag/main.go
@@ -1,0 +1,561 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+// Package main demonstrates GraphRAG over repository code in a multi-turn chat.
+// It loads the trpc-agent-go repository through repo source, wires graph search,
+// traversal, and path tools into an LLM agent, and prints tool calls and
+// tool responses during the conversation.
+//
+// Required environment variables:
+//   - OPENAI_API_KEY: Your OpenAI API key for the chat model and embeddings.
+//   - OPENAI_BASE_URL: (Optional) Custom OpenAI API endpoint.
+//   - MODEL_NAME: (Optional) Model name to use, defaults to deepseek-chat.
+//   - EMBEDDING_MODEL: (Optional) Embedding model, defaults to server:277357.
+//   - EMBEDDING_DIMENSION: (Optional) Embedding dimension. If unset, the example probes once.
+//   - AGE_DSN: (Optional) PostgreSQL DSN for Apache AGE, highest priority.
+//   - AGE_HOST: (Optional) PostgreSQL host for Apache AGE, defaults to 127.0.0.1.
+//   - AGE_PORT: (Optional) PostgreSQL port for Apache AGE, defaults to 5432.
+//   - AGE_USER: (Optional) PostgreSQL user for Apache AGE, defaults to root.
+//   - AGE_PASSWORD: (Optional) PostgreSQL password for Apache AGE, defaults to 123.
+//   - AGE_DATABASE: (Optional) PostgreSQL database for Apache AGE, defaults to contextengine.
+//   - AGE_GRAPH_NAME: (Optional) Apache AGE graph name, defaults to knowledge_graph.
+//   - PGVECTOR_DSN: (Optional) PostgreSQL DSN for pgvector, highest priority.
+//   - PGVECTOR_HOST: (Optional) PostgreSQL host for pgvector, defaults to 127.0.0.1.
+//   - PGVECTOR_PORT: (Optional) PostgreSQL port for pgvector, defaults to 5432.
+//   - PGVECTOR_USER: (Optional) PostgreSQL user for pgvector, defaults to root.
+//   - PGVECTOR_PASSWORD: (Optional) PostgreSQL password for pgvector, defaults to 123.
+//   - PGVECTOR_DATABASE: (Optional) PostgreSQL database for pgvector, defaults to contextengine.
+//   - PGVECTOR_TABLE: (Optional) PostgreSQL pgvector table, defaults to trpc_agent_go_graph.
+//
+// Example usage:
+//
+//	export OPENAI_API_KEY=sk-xxxx
+//	export OPENAI_BASE_URL=https://api.openai.com/v1
+//	export MODEL_NAME=deepseek-chat
+//	go run ./features/graphrag
+package main
+
+import (
+	"bufio"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	util "trpc.group/trpc-go/trpc-agent-go/examples/knowledge"
+	"trpc.group/trpc-go/trpc-agent-go/knowledge"
+	_ "trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader/golang"
+	openaiembedder "trpc.group/trpc-go/trpc-agent-go/knowledge/embedder/openai"
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/graph"
+	agegraphstore "trpc.group/trpc-go/trpc-agent-go/knowledge/graphstore/age"
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/source"
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/source/repo"
+	knowledgetool "trpc.group/trpc-go/trpc-agent-go/knowledge/tool"
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/pgvector"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	openaimodel "trpc.group/trpc-go/trpc-agent-go/model/openai"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+	sessioninmemory "trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+	"trpc.group/trpc-go/trpc-agent-go/storage/postgres"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+var (
+	defaultRepoURL = "https://github.com/trpc-group/trpc-agent-go"
+	defaultQuery   = "Find code related to agent execution in trpc-agent-go, traverse its callees, and explain the nearby call graph."
+	query          = flag.String("query", "", "Optional initial query to ask before entering chat")
+	modelName      = flag.String("model", util.GetEnvOrDefault("MODEL_NAME", "deepseek-v3,2"), "Model to use")
+	embeddingModel = flag.String("embedding-model", util.GetEnvOrDefault("EMBEDDING_MODEL", "server:277357"), "Embedding model to use")
+	embeddingDim   = flag.Int("embedding-dimension", defaultEmbeddingDimension(), "Embedding dimension; <=0 probes once")
+	recreate       = flag.Bool("recreate", false, "Drop pgvector table and reload graph source; false reuses existing graph/vector data")
+	progressStep   = flag.Int("progress-step", 1000, "Graph seed indexing progress step")
+	debugFile      = flag.String("debug-file", "", "Write JSONL tool trace to this file when set")
+)
+
+func main() {
+	flag.Parse()
+	ctx := context.Background()
+
+	fmt.Println("GraphRAG Chat Demo")
+	fmt.Printf("Model: %s\n", *modelName)
+	fmt.Println(strings.Repeat("=", 50))
+
+	ageDSN, ageGraphName := ageConfig()
+	if *recreate {
+		if err := dropAGEGraph(ctx, ageDSN, ageGraphName); err != nil {
+			log.Fatalf("drop AGE graph: %v", err)
+		}
+		fmt.Printf("Dropped AGE graph: %s\n", ageGraphName)
+	}
+
+	graphStore, err := newAGEGraphStore()
+	if err != nil {
+		log.Fatalf("create AGE graph store: %v", err)
+	}
+	defer graphStore.Close()
+
+	embedder, resolvedDimension, err := setupEmbedder(ctx)
+	if err != nil {
+		log.Fatalf("setup embedder: %v", err)
+	}
+	fmt.Printf("Embedding: %s (%d dimensions)\n", *embeddingModel, resolvedDimension)
+
+	vectorDSN, vectorTable := pgVectorConfig()
+	if *recreate {
+		if err := dropPGVectorTable(ctx, vectorDSN, vectorTable); err != nil {
+			log.Fatalf("drop pgvector table: %v", err)
+		}
+		fmt.Printf("Dropped pgvector table: %s\n", vectorTable)
+	}
+
+	vectorStore, err := newVectorStore(vectorDSN, vectorTable, resolvedDimension)
+	if err != nil {
+		log.Fatalf("create vector store: %v", err)
+	}
+	defer vectorStore.Close()
+
+	kb := knowledge.NewGraphKnowledge(
+		knowledge.WithGraphStore(graphStore),
+		knowledge.WithGraphVectorStore(vectorStore),
+		knowledge.WithGraphEmbedder(embedder),
+	)
+	if *recreate {
+		if err := loadGraphSource(ctx, kb); err != nil {
+			log.Fatalf("load graph from repo source: %v", err)
+		}
+	} else {
+		fmt.Println("Skipped graph source loading; using existing AGE graph and pgvector data")
+	}
+
+	graphToolSet := knowledgetool.NewCodeGraphSearchTool(
+		kb,
+		knowledgetool.WithCodeSearchRepoInfos([]knowledgetool.CodeRepoInfo{{
+			Name:        "trpc-agent-go",
+			Description: "The tRPC-Agent-Go framework repository used to demonstrate graph RAG over repo source.",
+		}}),
+		knowledgetool.WithCodeSearchMaxResults(3),
+	)
+
+	llmAgent := llmagent.New(
+		"graph-knowledge-assistant",
+		llmagent.WithModel(openaimodel.New(*modelName)),
+		llmagent.WithInstruction(graphAgentInstruction()),
+		llmagent.WithGenerationConfig(model.GenerationConfig{Stream: true}),
+		llmagent.WithToolSets([]tool.ToolSet{graphToolSet}),
+	)
+
+	r := runner.NewRunner(
+		"graph-knowledge-chat",
+		llmAgent,
+		runner.WithSessionService(sessioninmemory.NewSessionService()),
+	)
+	defer r.Close()
+
+	var trace *jsonlTrace
+	if *debugFile != "" {
+		trace, err = newJSONLTrace(*debugFile)
+		if err != nil {
+			log.Fatalf("open debug file: %v", err)
+		}
+		defer trace.Close()
+		fmt.Printf("Debug trace: %s\n", *debugFile)
+	}
+
+	sessionID := fmt.Sprintf("graph-demo-session-%d", time.Now().Unix())
+	fmt.Printf("\nChat ready. Session: %s\n", sessionID)
+	fmt.Printf("Type '/exit' to end the conversation.\n")
+	fmt.Printf("Try: %s\n", defaultQuery)
+	fmt.Println(strings.Repeat("=", 50))
+
+	if strings.TrimSpace(*query) != "" {
+		fmt.Printf("\nInitial query: %s\n", *query)
+		if err := runTurn(ctx, r, "graph-demo-user", sessionID, *query, trace); err != nil {
+			log.Fatalf("run initial query: %v", err)
+		}
+		fmt.Println()
+	}
+
+	scanner := bufio.NewScanner(os.Stdin)
+	for {
+		fmt.Print("You: ")
+		if !scanner.Scan() {
+			break
+		}
+		userInput := strings.TrimSpace(scanner.Text())
+		if userInput == "" {
+			continue
+		}
+		if userInput == "/exit" || userInput == "/quit" {
+			fmt.Println("Done.")
+			return
+		}
+		if err := runTurn(ctx, r, "graph-demo-user", sessionID, userInput, trace); err != nil {
+			fmt.Printf("Error: %v\n", err)
+		}
+		fmt.Println()
+	}
+	if err := scanner.Err(); err != nil {
+		log.Fatalf("input scanner: %v", err)
+	}
+}
+
+// runTurn sends one user message and prints the streamed response with tool activity.
+func runTurn(ctx context.Context, r runner.Runner, userID, sessionID, userMessage string, trace *jsonlTrace) error {
+	trace.write("user_message", map[string]any{"message": userMessage})
+
+	eventChan, err := r.Run(ctx, userID, sessionID, model.NewUserMessage(userMessage))
+	if err != nil {
+		return fmt.Errorf("run agent: %w", err)
+	}
+
+	fmt.Print("Assistant: ")
+	assistantStarted := true
+	toolCallsDetected := false
+
+	for evt := range eventChan {
+		if evt == nil {
+			continue
+		}
+		if evt.Error != nil {
+			fmt.Printf("\nEvent error: %s\n", evt.Error.Message)
+			continue
+		}
+		if evt.Response == nil || len(evt.Response.Choices) == 0 {
+			continue
+		}
+
+		for ci, choice := range evt.Response.Choices {
+			if len(choice.Message.ToolCalls) > 0 {
+				toolCallsDetected = true
+				if assistantStarted {
+					fmt.Println()
+				}
+				fmt.Println()
+				fmt.Printf("Tool calls (%d):\n", len(choice.Message.ToolCalls))
+				for i, call := range choice.Message.ToolCalls {
+					fmt.Printf("  [%d] %s id=%s\n", i+1, call.Function.Name, call.ID)
+					if len(call.Function.Arguments) > 0 {
+						fmt.Println("      args:")
+						fmt.Println(indentBlock(formatToolArguments(string(call.Function.Arguments)), "        "))
+					}
+					trace.write("tool_call", map[string]any{
+						"tool_name": call.Function.Name,
+						"tool_id":   call.ID,
+						"arguments": decodeJSONValue(string(call.Function.Arguments)),
+					})
+				}
+				fmt.Println("Executing tools...")
+				fmt.Println()
+				assistantStarted = false
+				continue
+			}
+
+			if choice.Message.Role == model.RoleTool && choice.Message.ToolID != "" {
+				fmt.Printf("Tool result: %s id=%s\n", choice.Message.ToolName, choice.Message.ToolID)
+				fmt.Println(formatToolResponse(choice.Message.Content))
+				fmt.Println()
+				trace.write("tool_result", map[string]any{
+					"tool_name": choice.Message.ToolName,
+					"tool_id":   choice.Message.ToolID,
+					"result":    decodeJSONValue(choice.Message.Content),
+				})
+				assistantStarted = false
+				continue
+			}
+
+			if ci > 0 {
+				continue
+			}
+			content := choice.Delta.Content
+			if content == "" {
+				content = choice.Message.Content
+			}
+			if content != "" {
+				if !assistantStarted {
+					if toolCallsDetected {
+						fmt.Print("Assistant: ")
+					}
+					assistantStarted = true
+				}
+				fmt.Print(content)
+			}
+		}
+		if evt.IsFinalResponse() {
+			fmt.Println()
+			break
+		}
+	}
+	return nil
+}
+
+// timedGraphSource wraps a GraphSource and logs parse timing.
+type timedGraphSource struct {
+	name string
+	src  source.GraphSource
+}
+
+func (s timedGraphSource) ReadGraph(ctx context.Context, opts ...source.ReadGraphOption) (*graph.Data, error) {
+	start := time.Now()
+	data, err := s.src.ReadGraph(ctx, opts...)
+	elapsed := time.Since(start).Truncate(time.Millisecond)
+	if err != nil {
+		fmt.Printf("Graph source parse failed: %s | elapsed=%s\n", s.name, elapsed)
+		return nil, err
+	}
+	fmt.Printf("Graph source parsed: %s | nodes=%d edges=%d elapsed=%s\n", s.name, len(data.Nodes), len(data.Edges), elapsed)
+	return data, nil
+}
+
+// loadGraphSource loads the trpc-agent-go repo into the graph knowledge base.
+func loadGraphSource(ctx context.Context, kb *knowledge.BuiltinGraphKnowledge) error {
+	repoSrc := repo.New(
+		repo.WithRepository(repo.Repository{
+			URL:         defaultRepoURL,
+			RepoName:    "trpc-agent-go",
+			RepoURL:     defaultRepoURL,
+			Description: "The tRPC-Agent-Go framework repository used to demonstrate graph RAG over repo source.",
+		}),
+		repo.WithName("trpc-agent-go Repository"),
+		repo.WithFileExtensions([]string{".go"}),
+	)
+	err := kb.LoadGraphSource(
+		ctx,
+		timedGraphSource{name: "trpc-agent-go Repository", src: repoSrc},
+		knowledge.WithGraphLoadProgress(true),
+		knowledge.WithGraphLoadProgressStepSize(*progressStep),
+		knowledge.WithGraphLoadConcurrency(knowledge.GraphLoadConcurrency{
+			AddNodeRoutines:   200,
+			AddEdgeRoutines:   200,
+			EmbeddingRoutines: 10,
+		}),
+		knowledge.WithGraphLoadReadGraphOpts(source.WithReadGraphParseConcurrency(300)),
+	)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Loaded graph from repo source: %s\n", defaultRepoURL)
+	return nil
+}
+
+// jsonlTrace appends JSON lines to a file for debugging tool activity.
+// A nil receiver is safe to call on all methods.
+type jsonlTrace struct {
+	file    *os.File
+	encoder *json.Encoder
+}
+
+func newJSONLTrace(path string) (*jsonlTrace, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		return nil, err
+	}
+	return &jsonlTrace{file: f, encoder: json.NewEncoder(f)}, nil
+}
+
+func (t *jsonlTrace) write(kind string, fields map[string]any) {
+	if t == nil {
+		return
+	}
+	fields["kind"] = kind
+	fields["timestamp"] = time.Now().Format(time.RFC3339Nano)
+	if err := t.encoder.Encode(fields); err != nil {
+		log.Printf("write debug trace: %v", err)
+	}
+}
+
+func decodeJSONValue(raw string) any {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	var value any
+	decoder := json.NewDecoder(strings.NewReader(raw))
+	decoder.UseNumber()
+	if err := decoder.Decode(&value); err != nil {
+		return raw
+	}
+	return value
+}
+
+func (t *jsonlTrace) Close() error {
+	if t == nil || t.file == nil {
+		return nil
+	}
+	return t.file.Close()
+}
+
+func setupEmbedder(ctx context.Context) (*openaiembedder.Embedder, int, error) {
+	opts := []openaiembedder.Option{
+		openaiembedder.WithModel(*embeddingModel),
+		openaiembedder.WithMaxRetries(20),
+	}
+	if *embeddingDim > 0 {
+		opts = append(opts, openaiembedder.WithDimensions(*embeddingDim))
+	}
+	e := openaiembedder.New(opts...)
+	if *embeddingDim > 0 {
+		return e, *embeddingDim, nil
+	}
+	vec, err := e.GetEmbedding(ctx, "dimension probe")
+	if err != nil {
+		return nil, 0, err
+	}
+	if len(vec) == 0 {
+		return nil, 0, fmt.Errorf("embedding probe returned empty vector")
+	}
+	dim := len(vec)
+	return openaiembedder.New(append(opts, openaiembedder.WithDimensions(dim))...), dim, nil
+}
+
+func defaultEmbeddingDimension() int {
+	value, err := strconv.Atoi(strings.TrimSpace(util.GetEnvOrDefault("EMBEDDING_DIMENSION", "0")))
+	if err != nil {
+		return 0
+	}
+	return value
+}
+
+func newAGEGraphStore() (*agegraphstore.Store, error) {
+	dsn, graphName := ageConfig()
+	return agegraphstore.New(
+		agegraphstore.WithClientDSN(dsn),
+		agegraphstore.WithGraphName(graphName),
+	)
+}
+
+func ageConfig() (string, string) {
+	host := util.GetEnvOrDefault("AGE_HOST", "127.0.0.1")
+	port := util.GetEnvOrDefault("AGE_PORT", "5432")
+	user := util.GetEnvOrDefault("AGE_USER", "root")
+	password := util.GetEnvOrDefault("AGE_PASSWORD", "123")
+	database := util.GetEnvOrDefault("AGE_DATABASE", "contextengine")
+	graphName := util.GetEnvOrDefault("AGE_GRAPH_NAME", "knowledge_graph")
+	dsn := strings.TrimSpace(util.GetEnvOrDefault("AGE_DSN", ""))
+	if dsn == "" {
+		dsn = (&url.URL{
+			Scheme:   "postgres",
+			User:     url.UserPassword(user, password),
+			Host:     net.JoinHostPort(host, port),
+			Path:     database,
+			RawQuery: "sslmode=disable",
+		}).String()
+	}
+	return dsn, graphName
+}
+
+func pgVectorConfig() (string, string) {
+	host := util.GetEnvOrDefault("PGVECTOR_HOST", "127.0.0.1")
+	port := util.GetEnvOrDefault("PGVECTOR_PORT", "5432")
+	user := util.GetEnvOrDefault("PGVECTOR_USER", "root")
+	password := util.GetEnvOrDefault("PGVECTOR_PASSWORD", "123")
+	database := util.GetEnvOrDefault("PGVECTOR_DATABASE", "contextengine")
+	table := util.GetEnvOrDefault("PGVECTOR_TABLE", "trpc_agent_go_graph")
+	dsn := strings.TrimSpace(util.GetEnvOrDefault("PGVECTOR_DSN", ""))
+	if dsn == "" {
+		dsn = (&url.URL{
+			Scheme:   "postgres",
+			User:     url.UserPassword(user, password),
+			Host:     net.JoinHostPort(host, port),
+			Path:     database,
+			RawQuery: "sslmode=disable",
+		}).String()
+	}
+	return dsn, table
+}
+
+func dropPGVectorTable(ctx context.Context, dsn, table string) error {
+	client, err := postgres.GetClientBuilder()(ctx, postgres.WithClientConnString(dsn))
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+	_, err = client.ExecContext(ctx, "DROP TABLE IF EXISTS "+quoteQualifiedIdentifier(table)+" CASCADE")
+	return err
+}
+
+func dropAGEGraph(ctx context.Context, dsn, graphName string) error {
+	client, err := postgres.GetClientBuilder()(ctx, postgres.WithClientConnString(dsn))
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+	if _, err := client.ExecContext(ctx, "CREATE EXTENSION IF NOT EXISTS age"); err != nil {
+		return err
+	}
+	var exists bool
+	if err := client.Query(ctx, func(rows *sql.Rows) error {
+		if rows.Next() {
+			return rows.Scan(&exists)
+		}
+		return nil
+	}, "SELECT EXISTS(SELECT 1 FROM ag_catalog.ag_graph WHERE name = $1)", graphName); err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+	if _, err := client.ExecContext(ctx, "LOAD 'age'"); err != nil {
+		return err
+	}
+	if _, err := client.ExecContext(ctx, "SET search_path = ag_catalog, public"); err != nil {
+		return err
+	}
+	_, err = client.ExecContext(ctx, "SELECT ag_catalog.drop_graph($1, true)", graphName)
+	return err
+}
+
+func quoteQualifiedIdentifier(identifier string) string {
+	parts := strings.Split(identifier, ".")
+	for i, part := range parts {
+		parts[i] = `"` + strings.ReplaceAll(part, `"`, `""`) + `"`
+	}
+	return strings.Join(parts, ".")
+}
+
+func newVectorStore(dsn, table string, indexDimension int) (*pgvector.VectorStore, error) {
+	return pgvector.New(
+		pgvector.WithPGVectorClientDSN(dsn),
+		pgvector.WithTable(table),
+		pgvector.WithIndexDimension(indexDimension),
+	)
+}
+
+func graphAgentInstruction() string {
+	return strings.Join([]string{
+		"You are a code graph assistant.",
+		"Use code_graph_search only to find seed code graph nodes and collect their graph node IDs.",
+		"For mechanism, architecture, flow, lifecycle, or implementation questions, do not answer from search results alone: after finding a relevant seed node ID, call code_graph_traverse at least once.",
+		"Do not repeat near-identical code_graph_search calls after useful results or duplicate-result messages; traverse a known candidate or answer from gathered evidence.",
+		"",
+		"== code_graph_traverse usage ==",
+		"code_graph_traverse requires start_ids — graph node IDs returned by code_graph_search. It has NO query or filter parameter. Always pass IDs, not names or package paths.",
+		"Workflow: (1) call code_graph_search to find relevant symbols and collect their 'id' fields, (2) pass those IDs as start_ids to code_graph_traverse.",
+		"IMPORTANT: as soon as code_graph_search returns a relevant interface or type node ID, immediately call code_graph_traverse with IMPLEMENTS/METHOD/FIELD edges. Do NOT keep calling code_graph_search to enumerate package members — traverse does that in one call.",
+		"To find all implementations of an interface: search for the interface → get its ID → traverse with edge_types [\"IMPLEMENTS\"], direction \"in\", max_depth 1.",
+		"To find callers of a function: traverse direction \"in\", edge_types [\"CALLS\"], max_depth 1.",
+		"To find callees of a function: traverse direction \"out\", edge_types [\"CALLS\"], max_depth 1.",
+		"To inspect a type's methods or fields: traverse direction \"out\", edge_types [\"METHOD\"] or [\"FIELD\"], max_depth 1.",
+		"",
+		"== code_graph_find_paths usage ==",
+		"Use code_graph_find_paths when the user asks how two specific code entities are connected.",
+		"Before calling code_graph_find_paths, resolve both endpoints with code_graph_search and pass the returned graph node IDs as from_id and to_id.",
+		"",
+		"Keep tool use concise: usually 1-2 seed searches plus 1-2 targeted traversals are enough before answering.",
+		"Ground the final answer in the returned node names and edge directions.",
+	}, "\n")
+}

--- a/examples/knowledge/features/graphrag/output.go
+++ b/examples/knowledge/features/graphrag/output.go
@@ -1,0 +1,406 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const (
+	maxPrintedToolItems = 2
+	maxPrintedTextRunes = 120
+	maxPrintedCodeRunes = 360
+)
+
+func formatToolResponse(content string) string {
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return "<empty>"
+	}
+	var payload any
+	if err := json.Unmarshal([]byte(content), &payload); err != nil {
+		return compactPreview(content, maxPrintedTextRunes*2)
+	}
+	if summary, ok := renderToolSummary(payload); ok {
+		return summary
+	}
+	truncateToolPayload(payload)
+	truncateLongStrings(payload)
+	pretty, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return compactPreview(content, maxPrintedTextRunes*2)
+	}
+	return string(pretty)
+}
+
+func formatToolArguments(content string) string {
+	content = strings.TrimSpace(content)
+	var payload any
+	if err := json.Unmarshal([]byte(content), &payload); err != nil {
+		return content
+	}
+	pretty, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return content
+	}
+	return string(pretty)
+}
+
+func renderToolSummary(payload any) (string, bool) {
+	obj, ok := payload.(map[string]any)
+	if !ok {
+		return "", false
+	}
+	var b strings.Builder
+	rendered := false
+	if documents, ok := obj["documents"].([]any); ok {
+		renderDocuments(&b, documents)
+		rendered = true
+	}
+	if nodes, ok := obj["nodes"].([]any); ok {
+		renderNodes(&b, nodes)
+		rendered = true
+	}
+	if edges, ok := obj["edges"].([]any); ok {
+		renderEdges(&b, edges)
+		rendered = true
+	}
+	if paths, ok := obj["paths"].([]any); ok {
+		renderPaths(&b, paths)
+		rendered = true
+	}
+	if !rendered {
+		return "", false
+	}
+	if message := stringValue(obj, "message"); message != "" {
+		fmt.Fprintf(&b, "message: %s\n", compactPreview(message, maxPrintedTextRunes*2))
+	}
+	if truncated := stringValue(obj, "truncated"); truncated != "" {
+		fmt.Fprintf(&b, "truncated: %s\n", truncated)
+	}
+	return strings.TrimRight(b.String(), "\n"), true
+}
+
+func renderDocuments(b *strings.Builder, documents []any) {
+	fmt.Fprintf(b, "documents: %d\n", len(documents))
+	for i, item := range firstToolItems(documents) {
+		doc, ok := item.(map[string]any)
+		if !ok {
+			fmt.Fprintf(b, "  [%d] %s\n", i+1, compactPreview(item, maxPrintedTextRunes))
+			continue
+		}
+		metadata, _ := doc["metadata"].(map[string]any)
+		title := firstNonEmpty(
+			stringValue(metadata, "trpc_ast_name"),
+			stringValue(metadata, "trpc_ast_full_name"),
+			stringValue(metadata, "name"),
+			stringValue(metadata, "full_name"),
+		)
+		if title == "" {
+			title = "document"
+		}
+		score := numberValue(doc, "score")
+		if score != "" {
+			fmt.Fprintf(b, "  [%d] %s score=%s\n", i+1, title, score)
+		} else {
+			fmt.Fprintf(b, "  [%d] %s\n", i+1, title)
+		}
+		if fullName := stringValue(metadata, "trpc_ast_full_name"); fullName != "" && fullName != title {
+			fmt.Fprintf(b, "      full: %s\n", compactPreview(fullName, maxPrintedTextRunes*2))
+		}
+		if location := metadataLocation(metadata); location != "" {
+			fmt.Fprintf(b, "      file: %s\n", location)
+		}
+		if signature := stringValue(metadata, "trpc_ast_signature"); signature != "" {
+			fmt.Fprintf(b, "      sig: %s\n", compactPreview(signature, maxPrintedTextRunes*2))
+		}
+		if i == 0 {
+			if text := codePreview(doc["text"]); text != "" {
+				fmt.Fprintf(b, "      code:\n%s\n", indentBlock(text, "        "))
+			}
+			continue
+		}
+		if text := compactPreview(doc["text"], maxPrintedTextRunes); text != "" {
+			fmt.Fprintf(b, "      code: %s\n", text)
+		}
+	}
+	renderOmitted(b, len(documents), "document")
+}
+
+func renderNodes(b *strings.Builder, nodes []any) {
+	fmt.Fprintf(b, "nodes: %d\n", len(nodes))
+	for i, item := range firstToolItems(nodes) {
+		node, ok := item.(map[string]any)
+		if !ok {
+			fmt.Fprintf(b, "  [%d] %s\n", i+1, compactPreview(item, maxPrintedTextRunes))
+			continue
+		}
+		metadata, _ := node["metadata"].(map[string]any)
+		title := firstNonEmpty(
+			stringValue(node, "name"),
+			stringValue(metadata, "trpc_ast_name"),
+			stringValue(metadata, "trpc_ast_full_name"),
+			stringValue(node, "id"),
+		)
+		fmt.Fprintf(b, "  [%d] %s\n", i+1, compactPreview(title, maxPrintedTextRunes))
+		if fullName := stringValue(metadata, "trpc_ast_full_name"); fullName != "" && fullName != title {
+			fmt.Fprintf(b, "      full: %s\n", compactPreview(fullName, maxPrintedTextRunes*2))
+		}
+		if location := metadataLocation(metadata); location != "" {
+			fmt.Fprintf(b, "      file: %s\n", location)
+		}
+		if i == 0 {
+			if content := codePreview(node["content"]); content != "" {
+				fmt.Fprintf(b, "      content:\n%s\n", indentBlock(content, "        "))
+			}
+			continue
+		}
+		if content := compactPreview(node["content"], maxPrintedTextRunes); content != "" {
+			fmt.Fprintf(b, "      content: %s\n", content)
+		}
+	}
+	renderOmitted(b, len(nodes), "node")
+}
+
+func renderEdges(b *strings.Builder, edges []any) {
+	fmt.Fprintf(b, "edges: %d\n", len(edges))
+	for i, item := range firstToolItems(edges) {
+		edge, ok := item.(map[string]any)
+		if !ok {
+			fmt.Fprintf(b, "  [%d] %s\n", i+1, compactPreview(item, maxPrintedTextRunes))
+			continue
+		}
+		edgeType := firstNonEmpty(stringValue(edge, "type"), stringValue(edge, "label"), stringValue(edge, "name"))
+		if edgeType == "" {
+			edgeType = "edge"
+		}
+		from := firstNonEmpty(stringValue(edge, "from_id"), stringValue(edge, "from"), stringValue(edge, "source"))
+		to := firstNonEmpty(stringValue(edge, "to_id"), stringValue(edge, "to"), stringValue(edge, "target"))
+		fmt.Fprintf(b, "  [%d] %s: %s -> %s\n", i+1, compactPreview(edgeType, 80), compactPreview(from, 120), compactPreview(to, 120))
+	}
+	renderOmitted(b, len(edges), "edge")
+}
+
+func renderPaths(b *strings.Builder, paths []any) {
+	fmt.Fprintf(b, "paths: %d\n", len(paths))
+	for i, item := range firstToolItems(paths) {
+		path, ok := item.(map[string]any)
+		if !ok {
+			fmt.Fprintf(b, "  [%d] %s\n", i+1, compactPreview(item, maxPrintedTextRunes))
+			continue
+		}
+		nodes, _ := path["nodes"].([]any)
+		edges, _ := path["edges"].([]any)
+		fmt.Fprintf(b, "  [%d] nodes=%d edges=%d\n", i+1, len(nodes), len(edges))
+		if nodeLine := compactGraphNodeLine(nodes); nodeLine != "" {
+			fmt.Fprintf(b, "      nodes: %s\n", nodeLine)
+		}
+		if edgeLine := compactGraphEdgeLine(edges); edgeLine != "" {
+			fmt.Fprintf(b, "      edges: %s\n", edgeLine)
+		}
+	}
+	renderOmitted(b, len(paths), "path")
+}
+
+func truncateToolPayload(payload any) {
+	obj, ok := payload.(map[string]any)
+	if !ok {
+		return
+	}
+	truncateToolArray(obj, "documents", "document")
+	truncateToolArray(obj, "nodes", "node")
+	truncateToolArray(obj, "edges", "edge")
+	truncateToolArray(obj, "paths", "path")
+}
+
+func truncateToolArray(obj map[string]any, key, label string) {
+	items, ok := obj[key].([]any)
+	if !ok || len(items) <= maxPrintedToolItems {
+		return
+	}
+	omitted := len(items) - maxPrintedToolItems
+	truncated := append([]any(nil), items[:maxPrintedToolItems]...)
+	truncated = append(truncated, map[string]any{
+		"omitted": fmt.Sprintf("... %d more %s(s) omitted", omitted, label),
+	})
+	obj[key] = truncated
+}
+
+func truncateLongStrings(payload any) {
+	switch v := payload.(type) {
+	case map[string]any:
+		for key, value := range v {
+			if text, ok := value.(string); ok {
+				v[key] = compactPreview(text, maxPrintedTextRunes)
+				continue
+			}
+			truncateLongStrings(value)
+		}
+	case []any:
+		for _, item := range v {
+			truncateLongStrings(item)
+		}
+	}
+}
+
+func firstToolItems(items []any) []any {
+	if len(items) <= maxPrintedToolItems {
+		return items
+	}
+	return items[:maxPrintedToolItems]
+}
+
+func renderOmitted(b *strings.Builder, total int, label string) {
+	if omitted := total - maxPrintedToolItems; omitted > 0 {
+		fmt.Fprintf(b, "  ... %d more %s(s) omitted\n", omitted, label)
+	}
+}
+
+func compactGraphNodeLine(nodes []any) string {
+	names := make([]string, 0, len(firstToolItems(nodes)))
+	for _, item := range firstToolItems(nodes) {
+		node, ok := item.(map[string]any)
+		if !ok {
+			names = append(names, compactPreview(item, 80))
+			continue
+		}
+		metadata, _ := node["metadata"].(map[string]any)
+		names = append(names, compactPreview(firstNonEmpty(
+			stringValue(node, "name"),
+			stringValue(metadata, "trpc_ast_name"),
+			stringValue(node, "id"),
+		), 80))
+	}
+	if omitted := len(nodes) - maxPrintedToolItems; omitted > 0 {
+		names = append(names, fmt.Sprintf("... %d more", omitted))
+	}
+	return strings.Join(names, " -> ")
+}
+
+func compactGraphEdgeLine(edges []any) string {
+	types := make([]string, 0, len(firstToolItems(edges)))
+	for _, item := range firstToolItems(edges) {
+		edge, ok := item.(map[string]any)
+		if !ok {
+			types = append(types, compactPreview(item, 60))
+			continue
+		}
+		types = append(types, compactPreview(firstNonEmpty(
+			stringValue(edge, "type"),
+			stringValue(edge, "label"),
+			stringValue(edge, "name"),
+		), 60))
+	}
+	if omitted := len(edges) - maxPrintedToolItems; omitted > 0 {
+		types = append(types, fmt.Sprintf("... %d more", omitted))
+	}
+	return strings.Join(types, " -> ")
+}
+
+func metadataLocation(metadata map[string]any) string {
+	if len(metadata) == 0 {
+		return ""
+	}
+	file := firstNonEmpty(stringValue(metadata, "trpc_ast_file_path"), stringValue(metadata, "file_path"))
+	repo := firstNonEmpty(stringValue(metadata, "trpc_ast_repo_name"), stringValue(metadata, "repo_name"))
+	start := stringValue(metadata, "trpc_ast_line_start")
+	end := stringValue(metadata, "trpc_ast_line_end")
+	location := file
+	if file != "" && start != "" && end != "" {
+		location = fmt.Sprintf("%s:%s-%s", file, start, end)
+	} else if file != "" && start != "" {
+		location = fmt.Sprintf("%s:%s", file, start)
+	}
+	if repo != "" && location != "" {
+		return fmt.Sprintf("%s %s", repo, location)
+	}
+	return firstNonEmpty(location, repo)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func stringValue(obj map[string]any, key string) string {
+	if obj == nil {
+		return ""
+	}
+	switch value := obj[key].(type) {
+	case string:
+		return value
+	case json.Number:
+		return value.String()
+	case float64:
+		return strconv.FormatFloat(value, 'f', -1, 64)
+	case bool:
+		return strconv.FormatBool(value)
+	case nil:
+		return ""
+	default:
+		return fmt.Sprint(value)
+	}
+}
+
+func numberValue(obj map[string]any, key string) string {
+	if obj == nil {
+		return ""
+	}
+	switch value := obj[key].(type) {
+	case float64:
+		return strconv.FormatFloat(value, 'f', 3, 64)
+	case json.Number:
+		return value.String()
+	case string:
+		return value
+	default:
+		return ""
+	}
+}
+
+func compactPreview(value any, limit int) string {
+	text := strings.TrimSpace(fmt.Sprint(value))
+	if text == "" || text == "<nil>" {
+		return ""
+	}
+	text = strings.Join(strings.Fields(text), " ")
+	runes := []rune(text)
+	if len(runes) <= limit {
+		return text
+	}
+	return string(runes[:limit]) + "..."
+}
+
+func codePreview(value any) string {
+	text := strings.TrimSpace(fmt.Sprint(value))
+	if text == "" || text == "<nil>" {
+		return ""
+	}
+	runes := []rune(text)
+	if len(runes) <= maxPrintedCodeRunes {
+		return text
+	}
+	return string(runes[:maxPrintedCodeRunes]) + "\n..."
+}
+
+func indentBlock(text, prefix string) string {
+	lines := strings.Split(strings.TrimRight(text, "\n"), "\n")
+	for i, line := range lines {
+		lines[i] = prefix + line
+	}
+	return strings.Join(lines, "\n")
+}

--- a/examples/knowledge/features/graphrag/viewer/README.md
+++ b/examples/knowledge/features/graphrag/viewer/README.md
@@ -1,0 +1,54 @@
+# GraphRAG Viewer
+
+This component starts a small local web UI for inspecting the Apache AGE graph created by the GraphRAG example.
+
+It is intended for local debugging only. The backend serves a static page and exposes read-only graph APIs backed by AGE queries.
+
+## Run
+
+From `examples/knowledge`:
+
+```bash
+go run ./features/graphrag/viewer
+```
+
+Default URL:
+
+```text
+http://127.0.0.1:3012
+```
+
+## Configuration
+
+The viewer uses the same AGE database settings as the GraphRAG chat example:
+
+```bash
+export AGE_HOST=127.0.0.1
+export AGE_PORT=5432
+export AGE_USER=root
+export AGE_PASSWORD=123
+export AGE_DATABASE=contextengine
+export AGE_GRAPH_NAME=knowledge_graph
+```
+
+`AGE_DSN` can be used to override the individual database fields.
+
+Runtime flags:
+
+```bash
+go run ./features/graphrag/viewer \
+  -addr=127.0.0.1:3012 \
+  -graph=knowledge_graph \
+  -node-limit=100 \
+  -edge-limit=1000
+```
+
+The page also lets you change node and edge limits before loading graph data.
+
+The metadata filter accepts `key=value` patterns. The value side supports `*` as a wildcard, for example:
+
+```text
+trpc_ast_package=knowledge*
+trpc_ast_file_path=*graph*
+trpc_ast_type=Method
+```

--- a/examples/knowledge/features/graphrag/viewer/index.html
+++ b/examples/knowledge/features/graphrag/viewer/index.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>AGE Graph Viewer - developed by tRPC</title>
   <link rel="preconnect" href="https://unpkg.com">
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <script src="https://unpkg.com/vis-network@9.1.9/standalone/umd/vis-network.min.js"></script>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+  <script src="https://unpkg.com/vis-network@9.1.9/standalone/umd/vis-network.min.js" integrity="sha384-yxKDWWf0wwdUj/gPeuL11czrnKFQROnLgY8ll7En9NYoXibgg3C6NK/UDHNtUgWJ" crossorigin="anonymous"></script>
   <style>
     :root {
       color-scheme: light;
@@ -569,6 +569,7 @@
     }
 
     let debounceTimer = null;
+    let graphLoadController = null;
     function debounceLoad() {
       clearTimeout(debounceTimer);
       debounceTimer = setTimeout(() => loadGraph(true), 350);
@@ -611,6 +612,9 @@
 
     // ── graph loading ────────────────────────────────────────────────────────
     async function loadGraph(replace) {
+      if (graphLoadController) graphLoadController.abort();
+      const controller = new AbortController();
+      graphLoadController = controller;
       setLoading("Loading…");
       loadEl.disabled = true;
       try {
@@ -625,18 +629,22 @@
         if (edgeTypeEl.value.trim()) {
           params.set("edge_type", edgeTypeEl.value.trim());
         }
-        const response = await fetch(`/api/graph?${params}`);
+        const response = await fetch(`/api/graph?${params}`, { signal: controller.signal });
         if (!response.ok) throw new Error(await response.text());
         const graph = await response.json();
+        if (controller !== graphLoadController) return;
         applyGraph(graph, replace);
         resetHighlights();
         const msg = graph.message ? ` · ${graph.message}` : "";
         setStatus(`${nodeDS.length} node(s) · ${edgeDS.length} edge(s)${msg}`, false);
       } catch (err) {
+        if (err.name === "AbortError") return;
         setStatus(err.message || String(err), true);
       } finally {
-        loadEl.disabled = false;
-        clearLoading();
+        if (controller === graphLoadController) {
+          loadEl.disabled = false;
+          clearLoading();
+        }
       }
     }
 

--- a/examples/knowledge/features/graphrag/viewer/index.html
+++ b/examples/knowledge/features/graphrag/viewer/index.html
@@ -1,0 +1,921 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>AGE Graph Viewer - developed by tRPC</title>
+  <link rel="preconnect" href="https://unpkg.com">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <script src="https://unpkg.com/vis-network@9.1.9/standalone/umd/vis-network.min.js"></script>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f6f7f9;
+      --panel: #ffffff;
+      --line: #d8dde6;
+      --text: #20242a;
+      --muted: #68707d;
+      --accent: #176b87;
+      --accent-2: #2d7d46;
+      --danger: #aa3f3f;
+      --code: #f0f3f7;
+    }
+
+    * { box-sizing: border-box; }
+
+    html, body {
+      height: 100%;
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      color: var(--text);
+      background: var(--bg);
+    }
+
+    body {
+      display: grid;
+      grid-template-rows: auto auto minmax(0, 1fr);
+    }
+
+    header {
+      display: grid;
+      grid-template-columns: minmax(180px, 260px) minmax(0, 1fr) minmax(120px, auto);
+      align-items: center;
+      gap: 14px;
+      padding: 8px 14px;
+      border-bottom: 1px solid var(--line);
+      background: var(--panel);
+    }
+
+    h1 {
+      display: flex;
+      flex-direction: column;
+      gap: 1px;
+      margin: 0;
+      font-size: 17px;
+      font-weight: 650;
+      letter-spacing: 0;
+      white-space: nowrap;
+    }
+
+    h1 small {
+      font-size: 11px;
+      font-weight: 500;
+      color: var(--muted);
+    }
+
+    input, button, select {
+      height: 36px;
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      background: #fff;
+      color: var(--text);
+      font: inherit;
+    }
+
+    .form-control, .form-select, .btn {
+      height: 36px;
+      min-height: 36px;
+      font-size: 13px;
+      line-height: 1.2;
+    }
+
+    .form-label {
+      margin-bottom: 3px;
+    }
+
+    input {
+      width: 100%;
+      padding: 0 10px;
+    }
+
+    input[type="number"] { min-width: 0; }
+
+    button {
+      padding: 0 13px;
+      cursor: pointer;
+      font-weight: 600;
+    }
+
+    button.primary {
+      border-color: var(--accent);
+      background: var(--accent);
+      color: #fff;
+    }
+
+    .btn-primary {
+      --bs-btn-bg: var(--accent);
+      --bs-btn-border-color: var(--accent);
+      --bs-btn-hover-bg: #12576e;
+      --bs-btn-hover-border-color: #12576e;
+      --bs-btn-active-bg: #104d62;
+      --bs-btn-active-border-color: #104d62;
+    }
+
+    button.secondary {
+      border-color: var(--accent);
+      color: var(--accent);
+      background: #fff;
+    }
+
+    .btn-outline-secondary {
+      --bs-btn-color: var(--accent);
+      --bs-btn-border-color: var(--accent);
+      --bs-btn-hover-bg: #eef7fb;
+      --bs-btn-hover-border-color: var(--accent);
+      --bs-btn-hover-color: var(--accent);
+      --bs-btn-active-bg: #dceff5;
+      --bs-btn-active-border-color: var(--accent);
+      --bs-btn-active-color: var(--accent);
+    }
+
+    button:disabled {
+      cursor: wait;
+      opacity: .68;
+    }
+
+    .filter-controls {
+      width: 100%;
+      min-width: 0;
+    }
+
+    .filter-controls.row {
+      margin-left: 0;
+      margin-right: 0;
+    }
+
+    .limit-input {
+      width: 88px;
+    }
+
+    .tools {
+      display: grid;
+      grid-template-columns: minmax(260px, 0.85fr) minmax(420px, 1.15fr);
+      align-items: center;
+      gap: 18px;
+      padding: 8px 14px;
+      border-bottom: 1px solid var(--line);
+      background: #fbfcfd;
+    }
+
+    .tool-group {
+      display: grid;
+      align-items: center;
+      gap: 10px;
+      min-width: 0;
+    }
+
+    .tool-group.search-loaded {
+      grid-template-columns: auto minmax(180px, 1fr) auto;
+    }
+
+    .tool-group.find-path {
+      grid-template-columns: auto minmax(170px, 1fr) minmax(170px, 1fr) auto;
+      padding-left: 18px;
+      border-left: 1px solid var(--line);
+    }
+
+    .tool-label {
+      color: var(--muted);
+      font-size: 12px;
+      font-weight: 700;
+      text-transform: uppercase;
+    }
+
+    .field { min-width: 0; }
+
+    .field label {
+      color: var(--muted);
+      font-size: 10px;
+      font-weight: 700;
+      line-height: 1;
+      text-transform: uppercase;
+    }
+
+    main {
+      min-height: 0;
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 380px;
+      position: relative;
+    }
+
+    #network {
+      min-width: 0;
+      min-height: 0;
+      background: #fbfcfd;
+    }
+
+    /* Loading overlay on the graph canvas */
+    #loading-overlay {
+      display: none;
+      position: absolute;
+      inset: 0 380px 0 0;
+      background: rgba(251,252,253,0.75);
+      align-items: center;
+      justify-content: center;
+      font-size: 14px;
+      color: var(--muted);
+      z-index: 10;
+    }
+    #loading-overlay.visible { display: flex; }
+    .spinner {
+      width: 22px; height: 22px;
+      border: 3px solid var(--line);
+      border-top-color: var(--accent);
+      border-radius: 50%;
+      animation: spin 0.7s linear infinite;
+      margin-right: 10px;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+
+    aside {
+      min-width: 0;
+      min-height: 0;
+      display: grid;
+      grid-template-rows: auto auto minmax(0, 1fr);
+      border-left: 1px solid var(--line);
+      background: var(--panel);
+    }
+
+    .stats {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 1px;
+      border-bottom: 1px solid var(--line);
+      background: var(--line);
+    }
+
+    .stat {
+      padding: 12px;
+      background: var(--panel);
+    }
+
+    .stat strong {
+      display: block;
+      font-size: 20px;
+      line-height: 1.1;
+    }
+
+    .stat span {
+      display: block;
+      margin-top: 4px;
+      color: var(--muted);
+      font-size: 12px;
+    }
+
+    .summary {
+      max-height: 170px;
+      overflow: auto;
+      border-bottom: 1px solid var(--line);
+    }
+
+    .summary-row {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 8px;
+      padding: 8px 12px;
+      border-bottom: 1px solid #edf0f4;
+      font-size: 12px;
+    }
+
+    .summary-row code {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      color: var(--muted);
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    }
+
+    .summary-row b {
+      color: var(--accent-2);
+      font-weight: 700;
+    }
+
+    .details {
+      min-height: 0;
+      overflow: auto;
+      padding: 14px;
+    }
+
+    .details h2 {
+      margin: 0 0 4px;
+      font-size: 18px;
+      line-height: 1.25;
+      letter-spacing: 0;
+      overflow-wrap: anywhere;
+    }
+
+    .muted {
+      color: var(--muted);
+      font-size: 12px;
+      overflow-wrap: anywhere;
+    }
+
+    .pill-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      margin: 12px 0;
+    }
+
+    .pill {
+      padding: 3px 7px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: #f8fafc;
+      color: var(--muted);
+      font-size: 12px;
+    }
+
+    pre {
+      margin: 10px 0 0;
+      padding: 10px;
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      background: var(--code);
+      overflow: auto;
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+      font-size: 12px;
+      line-height: 1.45;
+    }
+
+    .section-title {
+      margin-top: 16px;
+      color: var(--muted);
+      font-size: 12px;
+      font-weight: 700;
+      text-transform: uppercase;
+    }
+
+    .expand-btn {
+      margin-top: 14px;
+      width: 100%;
+      height: 32px;
+      font-size: 12px;
+      border-color: var(--accent);
+      color: var(--accent);
+      background: #fff;
+    }
+
+    .expand-btn:hover { background: #eef7fb; }
+
+    .status {
+      min-width: 140px;
+      color: var(--muted);
+      font-size: 12px;
+      text-align: right;
+    }
+
+    .status.error { color: var(--danger); }
+
+    @media (max-width: 900px) {
+      body { grid-template-rows: auto auto minmax(0, 1fr); }
+      header, .tools, .tool-group.search-loaded, .tool-group.find-path {
+        grid-template-columns: 1fr;
+      }
+      .tool-group.find-path {
+        padding-left: 0;
+        padding-top: 8px;
+        border-left: 0;
+        border-top: 1px solid var(--line);
+      }
+      main {
+        grid-template-columns: 1fr;
+        grid-template-rows: minmax(360px, 1fr) 360px;
+      }
+      #loading-overlay { inset: 0 0 360px 0; }
+      aside {
+        border-left: 0;
+        border-top: 1px solid var(--line);
+      }
+      .status { text-align: left; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>
+      <span>AGE Graph Viewer</span>
+      <small>double-click node to expand edges<br>developed by tRPC</small>
+    </h1>
+    <div class="filter-controls row g-2 align-items-end">
+      <div class="col-auto">
+        <div class="tool-label mb-1">Load / Filter</div>
+      </div>
+      <div class="field col-12 col-lg-2">
+        <label class="form-label" for="query-field">Field</label>
+        <select id="query-field" class="form-select form-select-sm" title="Field to search">
+          <optgroup label="Node fields">
+            <option value="name">name</option>
+            <option value="id">id (source key)</option>
+          </optgroup>
+          <optgroup label="Metadata — identity">
+            <option value="metadata.trpc_ast_name">trpc_ast_name</option>
+            <option value="metadata.trpc_ast_full_name">trpc_ast_full_name</option>
+            <option value="metadata.trpc_ast_signature">trpc_ast_signature</option>
+          </optgroup>
+          <optgroup label="Metadata — location">
+            <option value="metadata.trpc_ast_package">trpc_ast_package</option>
+            <option value="metadata.trpc_ast_file_path">trpc_ast_file_path</option>
+          </optgroup>
+          <optgroup label="Metadata — type / scope">
+            <option value="metadata.trpc_ast_type">trpc_ast_type</option>
+            <option value="metadata.trpc_ast_scope">trpc_ast_scope</option>
+          </optgroup>
+          <optgroup label="Content (slow)">
+            <option value="content">content</option>
+            <option value="metadata.trpc_ast_comment">trpc_ast_comment</option>
+          </optgroup>
+        </select>
+      </div>
+      <div class="field col-12 col-lg">
+        <label class="form-label" for="query">Value</label>
+        <input id="query" class="form-control form-control-sm" type="search" placeholder="Substring to match (case-insensitive)" autocomplete="off">
+      </div>
+      <div class="field col-6 col-lg-auto">
+        <label class="form-label" for="node-limit">Nodes</label>
+        <input id="node-limit" class="form-control form-control-sm limit-input" type="number" min="1" max="5000" value="100" title="Node limit">
+      </div>
+      <div class="field col-6 col-lg-auto">
+        <label class="form-label" for="edge-limit">Edges</label>
+        <input id="edge-limit" class="form-control form-control-sm limit-input" type="number" min="1" max="20000" value="1000" title="Edge limit">
+      </div>
+      <div class="field col-12 col-lg-2">
+        <label class="form-label" for="edge-type">Edge Type</label>
+        <select id="edge-type" class="form-select form-select-sm" title="Edge type">
+          <option value="">All edges</option>
+        </select>
+      </div>
+      <div class="col-12 col-lg-auto">
+        <button id="load" class="btn btn-primary btn-sm w-100" type="button">Load</button>
+      </div>
+    </div>
+    <div id="status" class="status">Ready</div>
+  </header>
+  <section class="tools">
+    <div class="tool-group search-loaded">
+      <div class="tool-label">Search Loaded Graph</div>
+      <input id="current-search" class="form-control form-control-sm" type="search" placeholder="Node name, id, content, or metadata" autocomplete="off">
+      <button id="clear-current-search" class="btn btn-outline-secondary btn-sm" type="button">Clear</button>
+    </div>
+    <div class="tool-group find-path">
+      <div class="tool-label">Find Path</div>
+      <input id="path-from" class="form-control form-control-sm" type="search" placeholder="From Node ID" autocomplete="off">
+      <input id="path-to" class="form-control form-control-sm" type="search" placeholder="To Node ID" autocomplete="off">
+      <button id="find-path" class="btn btn-outline-secondary btn-sm" type="button">Find</button>
+    </div>
+  </section>
+  <main>
+    <div id="network"></div>
+    <div id="loading-overlay">
+      <div class="spinner"></div>
+      <span id="loading-text">Loading…</span>
+    </div>
+    <aside>
+      <div class="stats">
+        <div class="stat"><strong id="node-count">0</strong><span>Nodes</span></div>
+        <div class="stat"><strong id="edge-count">0</strong><span>Edges</span></div>
+      </div>
+      <div id="summary" class="summary"></div>
+      <div id="details" class="details">
+        <h2>No node selected</h2>
+        <div class="muted">Click a node to inspect. Double-click to expand neighbours.</div>
+      </div>
+    </aside>
+  </main>
+  <script>
+    // ── vis-network setup ───────────────────────────────────────────────────
+    const nodeDS = new vis.DataSet();
+    const edgeDS = new vis.DataSet();
+    const detailsByVisID = new Map();   // vis internal id → node object
+    const detailsByPropID = new Map();  // node.properties.id → node object
+
+    const kindColors = {
+      Function:  { background: "#e8f4ff", border: "#176b87" },
+      Method:    { background: "#ddeeff", border: "#0d4f66" },
+      Struct:    { background: "#edfaed", border: "#2d7d46" },
+      Interface: { background: "#fffbe8", border: "#a07a20" },
+      Package:   { background: "#f3eeff", border: "#6b42b8" },
+      Variable:  { background: "#fff0f0", border: "#aa4444" },
+      Alias:     { background: "#f5f5f5", border: "#888" },
+      Service:   { background: "#e8f4ff", border: "#176b87" },
+      RPC:       { background: "#edfaed", border: "#2d7d46" },
+      Message:   { background: "#fffbe8", border: "#a07a20" },
+    };
+
+    function nodeColor(kind) {
+      return kindColors[kind] || { background: "#ffffff", border: "#97a3b3" };
+    }
+
+    const network = new vis.Network(
+      document.getElementById("network"),
+      { nodes: nodeDS, edges: edgeDS },
+      {
+        autoResize: true,
+        interaction: { hover: true, multiselect: false, navigationButtons: true },
+        physics: {
+          stabilization: { iterations: 120 },
+          barnesHut: { gravitationalConstant: -5200, springLength: 160, springConstant: 0.035 }
+        },
+        nodes: {
+          shape: "dot",
+          size: 18,
+          borderWidth: 2,
+          font: { size: 13, face: "-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif", color: "#20242a" }
+        },
+        edges: {
+          arrows: { to: { enabled: true, scaleFactor: 0.65 } },
+          color: { color: "#97a3b3", highlight: "#176b87" },
+          font: { size: 11, align: "middle", color: "#68707d", strokeWidth: 3, strokeColor: "#ffffff" },
+          smooth: { type: "dynamic" }
+        }
+      }
+    );
+
+    // ── element refs ────────────────────────────────────────────────────────
+    const statusEl    = document.getElementById("status");
+    const queryEl     = document.getElementById("query");
+    const queryFieldEl = document.getElementById("query-field");
+    const nodeLimitEl = document.getElementById("node-limit");
+    const edgeLimitEl = document.getElementById("edge-limit");
+    const edgeTypeEl  = document.getElementById("edge-type");
+    const currentSearchEl = document.getElementById("current-search");
+    const clearCurrentSearchEl = document.getElementById("clear-current-search");
+    const pathFromEl = document.getElementById("path-from");
+    const pathToEl   = document.getElementById("path-to");
+    const findPathEl = document.getElementById("find-path");
+    const loadEl      = document.getElementById("load");
+    const detailsEl   = document.getElementById("details");
+    const overlayEl   = document.getElementById("loading-overlay");
+    const loadingText = document.getElementById("loading-text");
+
+    // ── events ──────────────────────────────────────────────────────────────
+    const slowFields = new Set(["content", "metadata.trpc_ast_comment"]);
+    const metadataSlowFields = new Set([
+      "metadata.trpc_ast_package", "metadata.trpc_ast_file_path",
+      "metadata.trpc_ast_full_name", "metadata.trpc_ast_signature",
+      "metadata.trpc_ast_scope", "metadata.trpc_ast_name",
+    ]);
+
+    function updateQueryPlaceholder() {
+      const f = queryFieldEl.value;
+      if (slowFields.has(f)) {
+        queryEl.placeholder = "Substring to match — full text scan, may be slow";
+      } else if (metadataSlowFields.has(f)) {
+        queryEl.placeholder = "Substring to match — JSON metadata scan, may be slow";
+      } else {
+        queryEl.placeholder = "Substring to match (case-insensitive)";
+      }
+    }
+
+    let debounceTimer = null;
+    function debounceLoad() {
+      clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(() => loadGraph(true), 350);
+    }
+
+    loadEl.addEventListener("click", () => loadGraph(true));
+    queryEl.addEventListener("keydown", e => { if (e.key === "Enter") { clearTimeout(debounceTimer); loadGraph(true); } });
+    queryEl.addEventListener("input", debounceLoad);
+    queryFieldEl.addEventListener("change", () => {
+      updateQueryPlaceholder();
+      if (queryEl.value.trim()) loadGraph(true);
+    });
+    edgeTypeEl.addEventListener("change", () => loadGraph(true));
+    currentSearchEl.addEventListener("input", () => searchCurrentGraph(currentSearchEl.value));
+    clearCurrentSearchEl.addEventListener("click", () => {
+      currentSearchEl.value = "";
+      resetHighlights();
+      setStatus(`${nodeDS.length} node(s) · ${edgeDS.length} edge(s)`, false);
+    });
+    findPathEl.addEventListener("click", findPath);
+    for (const el of [pathFromEl, pathToEl]) {
+      el.addEventListener("keydown", e => {
+        if (e.key === "Enter") findPath();
+      });
+    }
+    updateQueryPlaceholder();
+
+    network.on("click", params => {
+      if (!params.nodes.length) return;
+      renderDetails(detailsByVisID.get(params.nodes[0]));
+    });
+
+    network.on("doubleClick", async params => {
+      if (!params.nodes.length) return;
+      const nodeData = detailsByVisID.get(params.nodes[0]);
+      const propID = nodeData?.properties?.id;
+      if (!propID) return;
+      await expandNeighbors(propID);
+    });
+
+    // ── graph loading ────────────────────────────────────────────────────────
+    async function loadGraph(replace) {
+      setLoading("Loading…");
+      loadEl.disabled = true;
+      try {
+        const params = new URLSearchParams({
+          node_limit: boundedNumber(nodeLimitEl.value, 100, 1, 5000),
+          edge_limit: boundedNumber(edgeLimitEl.value, 1000, 1, 20000)
+        });
+        if (queryEl.value.trim()) {
+          params.set("query", queryEl.value.trim());
+          params.set("query_field", queryFieldEl.value);
+        }
+        if (edgeTypeEl.value.trim()) {
+          params.set("edge_type", edgeTypeEl.value.trim());
+        }
+        const response = await fetch(`/api/graph?${params}`);
+        if (!response.ok) throw new Error(await response.text());
+        const graph = await response.json();
+        applyGraph(graph, replace);
+        resetHighlights();
+        const msg = graph.message ? ` · ${graph.message}` : "";
+        setStatus(`${nodeDS.length} node(s) · ${edgeDS.length} edge(s)${msg}`, false);
+      } catch (err) {
+        setStatus(err.message || String(err), true);
+      } finally {
+        loadEl.disabled = false;
+        clearLoading();
+      }
+    }
+
+    async function expandNeighbors(propID) {
+      setLoading("Expanding…");
+      try {
+        const params = new URLSearchParams({
+          id: propID,
+          depth: 1,
+          node_limit: boundedNumber(nodeLimitEl.value, 100, 1, 5000),
+          edge_limit: 200
+        });
+        if (edgeTypeEl.value.trim()) {
+          params.set("edge_type", edgeTypeEl.value.trim());
+        }
+        const response = await fetch(`/api/neighbors?${params}`);
+        if (!response.ok) throw new Error(await response.text());
+        const graph = await response.json();
+        applyGraph(graph, false);   // incremental merge
+        setStatus(`${nodeDS.length} node(s) · ${edgeDS.length} edge(s)`, false);
+      } catch (err) {
+        setStatus(err.message || String(err), true);
+      } finally {
+        clearLoading();
+      }
+    }
+
+    async function findPath() {
+      const fromID = pathFromEl.value.trim();
+      const toID = pathToEl.value.trim();
+      if (!fromID || !toID) {
+        setStatus("from/to Node ID are required", true);
+        return;
+      }
+      setLoading("Finding path…");
+      findPathEl.disabled = true;
+      try {
+        const params = new URLSearchParams({ from_id: fromID, to_id: toID });
+        const response = await fetch(`/api/path?${params}`);
+        if (!response.ok) throw new Error(await response.text());
+        const graph = await response.json();
+        applyGraph(graph, false);
+        highlightPath(graph);
+        const msg = graph.message ? ` · ${graph.message}` : "";
+        setStatus(`${nodeDS.length} node(s) · ${edgeDS.length} edge(s)${msg}`, false);
+      } catch (err) {
+        setStatus(err.message || String(err), true);
+      } finally {
+        findPathEl.disabled = false;
+        clearLoading();
+      }
+    }
+
+    // ── incremental graph merge ──────────────────────────────────────────────
+    function applyGraph(graph, replace) {
+      if (replace) {
+        detailsByVisID.clear();
+        detailsByPropID.clear();
+        nodeDS.clear();
+        edgeDS.clear();
+      }
+
+      const addNodes = [];
+      const addEdges = [];
+
+      for (const n of (graph.nodes || [])) {
+        if (nodeDS.get(n.id) != null) continue;   // already present
+        const col = nodeColor(n.kind);
+        detailsByVisID.set(n.id, n);
+        if (n.properties?.id) detailsByPropID.set(n.properties.id, n);
+        addNodes.push({
+          id:    n.id,
+          label: n.name || n.label || n.id,
+          title: n.kind || n.label || "",
+          color: nodeColorConfig(col)
+        });
+      }
+
+      for (const e of (graph.edges || [])) {
+        if (edgeDS.get(e.id) != null) continue;
+        addEdges.push({ id: e.id, from: e.from, to: e.to, label: e.label, color: "#97a3b3", width: 1 });
+      }
+
+      nodeDS.add(addNodes);
+      edgeDS.add(addEdges);
+
+      document.getElementById("node-count").textContent = String(nodeDS.length);
+      document.getElementById("edge-count").textContent = String(edgeDS.length);
+
+      if (replace && nodeDS.length > 0) {
+        network.fit({ animation: { duration: 250, easingFunction: "easeInOutQuad" } });
+      }
+    }
+
+    function searchCurrentGraph(value) {
+      const needle = value.trim().toLowerCase();
+      resetHighlights();
+      if (!needle) {
+        setStatus(`${nodeDS.length} node(s) · ${edgeDS.length} edge(s)`, false);
+        return;
+      }
+      const matched = [];
+      for (const node of detailsByVisID.values()) {
+        if (!currentGraphText(node).includes(needle)) continue;
+        matched.push(node.id);
+      }
+      nodeDS.update(matched.map(id => ({
+        id,
+        borderWidth: 4,
+        color: { background: "#fff3b0", border: "#b7791f", highlight: { background: "#fff3b0", border: "#b7791f" } }
+      })));
+      if (matched.length > 0) {
+        network.selectNodes(matched);
+        network.fit({ nodes: matched, animation: { duration: 250, easingFunction: "easeInOutQuad" } });
+      }
+      setStatus(`${matched.length} match(es) in current graph`, false);
+    }
+
+    function currentGraphText(node) {
+      return [
+        node.id,
+        node.name,
+        node.kind,
+        node.label,
+        node.content,
+        node.properties?.id,
+        JSON.stringify(node.properties?.metadata || {})
+      ].filter(Boolean).join("\n").toLowerCase();
+    }
+
+    function highlightPath(graph) {
+      resetHighlights();
+      const nodeIDs = (graph.nodes || []).map(n => n.id);
+      const edgeIDs = (graph.edges || []).map(e => e.id);
+      nodeDS.update(nodeIDs.map(id => ({
+        id,
+        borderWidth: 4,
+        color: { background: "#e9f9ef", border: "#1f8f4d", highlight: { background: "#e9f9ef", border: "#1f8f4d" } }
+      })));
+      edgeDS.update(edgeIDs.map(id => ({ id, color: "#1f8f4d", width: 4 })));
+      if (nodeIDs.length > 0) {
+        network.selectNodes(nodeIDs);
+        network.fit({ nodes: nodeIDs, animation: { duration: 250, easingFunction: "easeInOutQuad" } });
+      }
+    }
+
+    function resetHighlights() {
+      const nodes = [];
+      for (const node of detailsByVisID.values()) {
+        const col = nodeColor(node.kind);
+        nodes.push({ id: node.id, borderWidth: 2, color: nodeColorConfig(col) });
+      }
+      if (nodes.length > 0) nodeDS.update(nodes);
+      const edges = edgeDS.getIds().map(id => ({ id, color: "#97a3b3", width: 1 }));
+      if (edges.length > 0) edgeDS.update(edges);
+      network.unselectAll();
+    }
+
+    function nodeColorConfig(col) {
+      return {
+        background: col.background,
+        border: col.border,
+        highlight: { background: col.background, border: col.border }
+      };
+    }
+
+    // ── summary ──────────────────────────────────────────────────────────────
+    async function loadSummary() {
+      try {
+        const response = await fetch("/api/summary");
+        if (!response.ok) return;
+        const rows = await response.json();
+        renderSummary(rows);
+        renderEdgeTypeOptions(rows);
+      } catch (err) {
+        console.warn("summary load failed:", err);
+      }
+    }
+
+    function renderEdgeTypeOptions(rows) {
+      const selected = edgeTypeEl.value;
+      const labels = Array.from(new Set((rows || []).map(row => row.edge_label).filter(Boolean))).sort();
+      edgeTypeEl.innerHTML = "";
+      const all = document.createElement("option");
+      all.value = "";
+      all.textContent = "All edges";
+      edgeTypeEl.appendChild(all);
+      for (const label of labels) {
+        const option = document.createElement("option");
+        option.value = label;
+        option.textContent = label;
+        edgeTypeEl.appendChild(option);
+      }
+      edgeTypeEl.value = labels.includes(selected) ? selected : "";
+    }
+
+    function renderSummary(rows) {
+      const container = document.getElementById("summary");
+      container.innerHTML = "";
+      for (const row of (rows || [])) {
+        const item = document.createElement("div");
+        item.className = "summary-row";
+        const code = document.createElement("code");
+        code.textContent = `${row.from_label} - ${row.edge_label} -> ${row.to_label}`;
+        const count = document.createElement("b");
+        count.textContent = row.count;
+        item.append(code, count);
+        container.appendChild(item);
+      }
+    }
+
+    // ── detail panel ─────────────────────────────────────────────────────────
+    function renderDetails(node) {
+      if (!node) return;
+      const metadata = (node.properties && node.properties.metadata) || {};
+      const propID   = node.properties?.id || "";
+      detailsEl.innerHTML = "";
+
+      const title = document.createElement("h2");
+      title.textContent = node.name || propID || node.id;
+
+      const pills = document.createElement("div");
+      pills.className = "pill-row";
+      for (const value of [node.label, node.kind, metadata.trpc_ast_package, metadata.trpc_ast_file_path].filter(Boolean)) {
+        const pill = document.createElement("span");
+        pill.className = "pill";
+        pill.textContent = String(value);
+        pills.appendChild(pill);
+      }
+
+      detailsEl.append(title, pills);
+      if (propID) appendSection("Node ID", propID);
+      appendSection("Name", node.name || "");
+      appendSection("Content", node.content || "");
+      appendSection("Metadata", JSON.stringify(metadata, null, 2));
+
+      if (propID) {
+        const btn = document.createElement("button");
+        btn.className = "expand-btn";
+        btn.textContent = "Expand neighbours (double-click also works)";
+        btn.addEventListener("click", () => expandNeighbors(propID));
+        detailsEl.appendChild(btn);
+      }
+    }
+
+    function appendSection(title, content) {
+      if (!content) return;
+      const label = document.createElement("div");
+      label.className = "section-title";
+      label.textContent = title;
+      const pre = document.createElement("pre");
+      pre.textContent = content;
+      detailsEl.append(label, pre);
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+    function setLoading(msg) {
+      loadingText.textContent = msg;
+      overlayEl.classList.add("visible");
+    }
+
+    function clearLoading() {
+      overlayEl.classList.remove("visible");
+    }
+
+    function setStatus(message, isError) {
+      statusEl.textContent = message;
+      statusEl.classList.toggle("error", Boolean(isError));
+    }
+
+    function boundedNumber(value, fallback, min, max) {
+      const parsed = Number.parseInt(value, 10);
+      if (!Number.isFinite(parsed)) return String(fallback);
+      return String(Math.min(Math.max(parsed, min), max));
+    }
+
+    // ── init ──────────────────────────────────────────────────────────────────
+    loadSummary();
+    loadGraph(true);
+  </script>
+</body>
+</html>

--- a/examples/knowledge/features/graphrag/viewer/index.html
+++ b/examples/knowledge/features/graphrag/viewer/index.html
@@ -653,7 +653,6 @@
       try {
         const params = new URLSearchParams({
           id: propID,
-          depth: 1,
           node_limit: boundedNumber(nodeLimitEl.value, 100, 1, 5000),
           edge_limit: 200
         });

--- a/examples/knowledge/features/graphrag/viewer/main.go
+++ b/examples/knowledge/features/graphrag/viewer/main.go
@@ -226,7 +226,6 @@ func (s *server) handleGraph(w http.ResponseWriter, r *http.Request) {
 // Query params:
 //
 //	id        – required; the node's "id" property value
-//	depth     – optional; traversal depth (1-3, default 1)
 //	edge_type – optional; comma-separated edge labels to include (all if empty)
 //	node_limit / edge_limit – same semantics as /api/graph
 func (s *server) handleNeighbors(w http.ResponseWriter, r *http.Request) {
@@ -236,12 +235,11 @@ func (s *server) handleNeighbors(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "id is required", http.StatusBadRequest)
 		return
 	}
-	depth := queryInt(r, "depth", 1, 3)
 	maxNodes := queryInt(r, "node_limit", *nodeLimit, 5000)
 	maxEdges := queryInt(r, "edge_limit", *edgeLimit, 20000)
 	edgeTypes := parseCommaList(r.URL.Query().Get("edge_type"))
 
-	result, err := s.loadNeighbors(ctx, nodeID, depth, edgeTypes, maxNodes, maxEdges)
+	result, err := s.loadNeighbors(ctx, nodeID, edgeTypes, maxNodes, maxEdges)
 	if err != nil {
 		writeError(w, err)
 		return
@@ -320,7 +318,6 @@ func (s *server) findPath(ctx context.Context, fromID, toID string) (*graphRespo
 func (s *server) loadNeighbors(
 	ctx context.Context,
 	nodeID string,
-	depth int,
 	edgeTypes []string,
 	maxNodes, maxEdges int,
 ) (*graphResponse, error) {
@@ -329,14 +326,13 @@ func (s *server) loadNeighbors(
 	seenEdges := make(map[string]struct{})
 
 	where := ""
-	if edgeFilter := buildEdgeTypeFilter("last(r)", edgeTypes); edgeFilter != "" {
+	if edgeFilter := buildEdgeTypeFilter("r", edgeTypes); edgeFilter != "" {
 		where = " WHERE " + edgeFilter
 	}
 
-	// Use variable-length path so depth > 1 works with a single query.
 	cypher := fmt.Sprintf(
-		`MATCH (n:Node {id: %s})-[r*1..%d]-(m:Node)%s RETURN n, last(r), m LIMIT %d`,
-		cypherString(nodeID), depth, where, maxEdges,
+		`MATCH (n:Node {id: %s})-[r]-(m:Node)%s RETURN n, r, m LIMIT %d`,
+		cypherString(nodeID), where, maxEdges,
 	)
 	conn, err := s.ageConn(ctx)
 	if err != nil {
@@ -462,8 +458,9 @@ func (s *server) loadDefaultGraph(
 ) (*graphResponse, error) {
 	var conditions []string
 	if metadata != "" {
-		f := buildMetadataFilter("n", metadata)
-		conditions = append(conditions, "("+f+" OR "+strings.Replace(f, "n.", "m.", 1)+")")
+		nFilter := buildMetadataFilter("n", metadata)
+		mFilter := buildMetadataFilter("m", metadata)
+		conditions = append(conditions, "("+nFilter+" OR "+mFilter+")")
 	}
 	if edgeFilter := buildEdgeTypeFilter("r", edgeTypes); edgeFilter != "" {
 		conditions = append(conditions, edgeFilter)

--- a/examples/knowledge/features/graphrag/viewer/main.go
+++ b/examples/knowledge/features/graphrag/viewer/main.go
@@ -1,0 +1,934 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+// Package main starts a small Apache AGE graph viewer for the GraphRAG example.
+package main
+
+import (
+	"context"
+	"database/sql"
+	"embed"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/fs"
+	"log"
+	"net"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+	util "trpc.group/trpc-go/trpc-agent-go/examples/knowledge"
+)
+
+//go:embed index.html
+var content embed.FS
+
+var (
+	addr          = flag.String("addr", util.GetEnvOrDefault("GRAPH_VIEWER_ADDR", "127.0.0.1:3012"), "HTTP listen address")
+	graphName     = flag.String("graph", util.GetEnvOrDefault("AGE_GRAPH_NAME", "knowledge_graph"), "Apache AGE graph name")
+	nodeLimit     = flag.Int("node-limit", 100, "Default node limit")
+	edgeLimit     = flag.Int("edge-limit", 1000, "Default edge limit")
+	seedLimit     = flag.Int("seed-limit", 12, "Search seed node limit")
+	searchTimeout = flag.Duration("search-timeout", 8*time.Second, "Statement timeout for seed search queries")
+)
+
+const ageSessionSQL = `LOAD 'age'; SET search_path = ag_catalog, "$user", public`
+
+// maxPoolConns is the connection pool size. Each connection initialises an AGE
+// session independently.
+const maxPoolConns = 4
+
+type server struct {
+	db        *sql.DB
+	graphName string
+}
+
+type graphResponse struct {
+	Nodes   []node `json:"nodes"`
+	Edges   []edge `json:"edges"`
+	Message string `json:"message,omitempty"`
+}
+
+type node struct {
+	ID         string         `json:"id"`
+	Label      string         `json:"label"`
+	Name       string         `json:"name"`
+	Kind       string         `json:"kind,omitempty"`
+	Content    string         `json:"content"`
+	Properties map[string]any `json:"properties"`
+}
+
+type edge struct {
+	ID         string         `json:"id"`
+	From       string         `json:"from"`
+	To         string         `json:"to"`
+	Label      string         `json:"label"`
+	Properties map[string]any `json:"properties,omitempty"`
+}
+
+type vertexValue struct {
+	ID         json.Number    `json:"id"`
+	Label      string         `json:"label"`
+	Properties map[string]any `json:"properties"`
+}
+
+type edgeValue struct {
+	ID         json.Number    `json:"id"`
+	Label      string         `json:"label"`
+	StartID    json.Number    `json:"start_id"`
+	EndID      json.Number    `json:"end_id"`
+	Properties map[string]any `json:"properties"`
+}
+
+type edgeSummary struct {
+	FromLabel string `json:"from_label"`
+	EdgeLabel string `json:"edge_label"`
+	ToLabel   string `json:"to_label"`
+	Count     string `json:"count"`
+}
+
+func main() {
+	flag.Parse()
+
+	db, err := openDB(context.Background(), ageDSN())
+	if err != nil {
+		log.Fatalf("open AGE database: %v", err)
+	}
+	defer db.Close()
+
+	s := &server{
+		db:        db,
+		graphName: *graphName,
+	}
+	mux := http.NewServeMux()
+	static, err := fs.Sub(content, ".")
+	if err != nil {
+		log.Fatalf("prepare static files: %v", err)
+	}
+	mux.Handle("/", http.FileServer(http.FS(static)))
+	mux.HandleFunc("/api/graph", s.handleGraph)
+	mux.HandleFunc("/api/neighbors", s.handleNeighbors)
+	mux.HandleFunc("/api/path", s.handlePath)
+	mux.HandleFunc("/api/summary", s.handleSummary)
+	mux.HandleFunc("/api/health", s.handleHealth)
+
+	log.Printf("AGE graph viewer listening on http://%s", *addr)
+	log.Printf("Graph: %s", *graphName)
+	if err := http.ListenAndServe(*addr, mux); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func ageDSN() string {
+	dsn := strings.TrimSpace(util.GetEnvOrDefault("AGE_DSN", ""))
+	if dsn != "" {
+		return dsn
+	}
+	host := util.GetEnvOrDefault("AGE_HOST", "127.0.0.1")
+	port := util.GetEnvOrDefault("AGE_PORT", "5432")
+	user := util.GetEnvOrDefault("AGE_USER", "root")
+	password := util.GetEnvOrDefault("AGE_PASSWORD", "123")
+	database := util.GetEnvOrDefault("AGE_DATABASE", "contextengine")
+	return (&url.URL{
+		Scheme:   "postgres",
+		User:     url.UserPassword(user, password),
+		Host:     net.JoinHostPort(host, port),
+		Path:     database,
+		RawQuery: "sslmode=disable",
+	}).String()
+}
+
+func openDB(ctx context.Context, dsn string) (*sql.DB, error) {
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		return nil, err
+	}
+	db.SetMaxOpenConns(maxPoolConns)
+	db.SetMaxIdleConns(maxPoolConns)
+	db.SetConnMaxLifetime(30 * time.Minute)
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return db, nil
+}
+
+// ageConn acquires a connection from the pool and initialises an AGE session on
+// it. The session SET is idempotent so running it on every checkout is safe and
+// keeps the pool transparent to callers.
+func (s *server) ageConn(ctx context.Context) (*sql.Conn, error) {
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := conn.ExecContext(ctx, ageSessionSQL); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	return conn, nil
+}
+
+func (s *server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, map[string]string{"status": "ok", "graph": s.graphName})
+}
+
+func (s *server) handleGraph(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	maxNodes := queryInt(r, "node_limit", *nodeLimit, 5000)
+	maxEdges := queryInt(r, "edge_limit", *edgeLimit, 20000)
+	query := strings.TrimSpace(r.URL.Query().Get("query"))
+	queryField := strings.TrimSpace(r.URL.Query().Get("query_field"))
+	metadata := strings.TrimSpace(r.URL.Query().Get("metadata"))
+	edgeTypes := parseCommaList(r.URL.Query().Get("edge_type"))
+	if query != "" && strings.HasPrefix(queryField, "metadata.") {
+		metadata = appendMetadataFilter(metadata, strings.TrimPrefix(queryField, "metadata."), query)
+		query = ""
+		queryField = ""
+	}
+
+	result, err := s.loadGraph(ctx, query, queryField, metadata, edgeTypes, maxNodes, maxEdges)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, result)
+}
+
+// handleNeighbors returns the immediate neighbours of a node identified by its
+// graph node ID property, not the AGE internal numeric id.
+//
+// Query params:
+//
+//	id        – required; the node's "id" property value
+//	depth     – optional; traversal depth (1-3, default 1)
+//	edge_type – optional; comma-separated edge labels to include (all if empty)
+//	node_limit / edge_limit – same semantics as /api/graph
+func (s *server) handleNeighbors(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	nodeID := strings.TrimSpace(r.URL.Query().Get("id"))
+	if nodeID == "" {
+		http.Error(w, "id is required", http.StatusBadRequest)
+		return
+	}
+	depth := queryInt(r, "depth", 1, 3)
+	maxNodes := queryInt(r, "node_limit", *nodeLimit, 5000)
+	maxEdges := queryInt(r, "edge_limit", *edgeLimit, 20000)
+	edgeTypes := parseCommaList(r.URL.Query().Get("edge_type"))
+
+	result, err := s.loadNeighbors(ctx, nodeID, depth, edgeTypes, maxNodes, maxEdges)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, result)
+}
+
+func (s *server) handlePath(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	fromID := strings.TrimSpace(r.URL.Query().Get("from_id"))
+	toID := strings.TrimSpace(r.URL.Query().Get("to_id"))
+	if fromID == "" || toID == "" {
+		http.Error(w, "from_id and to_id are required", http.StatusBadRequest)
+		return
+	}
+	result, err := s.findPath(ctx, fromID, toID)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, result)
+}
+
+func (s *server) findPath(ctx context.Context, fromID, toID string) (*graphResponse, error) {
+	const maxDepth = 4
+	result := &graphResponse{}
+	seenNodes := make(map[string]struct{})
+	seenEdges := make(map[string]struct{})
+	cypher := fmt.Sprintf(
+		`MATCH p = (from:Node {id: %s})-[r*1..%d]-(to:Node {id: %s}) RETURN nodes(p), relationships(p) LIMIT 1`,
+		cypherString(fromID), maxDepth, cypherString(toID),
+	)
+	conn, err := s.ageConn(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+	timeoutMS := int(searchTimeout.Milliseconds())
+	if _, err := conn.ExecContext(ctx, fmt.Sprintf("SET statement_timeout = %d", timeoutMS)); err != nil {
+		return nil, err
+	}
+	rows, err := conn.QueryContext(ctx, s.cypherSQL(cypher, "nodes agtype, edges agtype"))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var rawNodes, rawEdges string
+		if err := rows.Scan(&rawNodes, &rawEdges); err != nil {
+			return nil, err
+		}
+		nodes, err := parseVertexList(rawNodes)
+		if err != nil {
+			return nil, err
+		}
+		edges, err := parseEdgeList(rawEdges)
+		if err != nil {
+			return nil, err
+		}
+		for _, n := range nodes {
+			addNode(result, seenNodes, n, len(nodes))
+		}
+		for _, e := range edges {
+			addEdge(result, seenEdges, e)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if len(result.Nodes) == 0 {
+		result.Message = "path not found"
+	}
+	return result, nil
+}
+
+func (s *server) loadNeighbors(
+	ctx context.Context,
+	nodeID string,
+	depth int,
+	edgeTypes []string,
+	maxNodes, maxEdges int,
+) (*graphResponse, error) {
+	result := &graphResponse{}
+	seenNodes := make(map[string]struct{})
+	seenEdges := make(map[string]struct{})
+
+	where := ""
+	if edgeFilter := buildEdgeTypeFilter("last(r)", edgeTypes); edgeFilter != "" {
+		where = " WHERE " + edgeFilter
+	}
+
+	// Use variable-length path so depth > 1 works with a single query.
+	cypher := fmt.Sprintf(
+		`MATCH (n:Node {id: %s})-[r*1..%d]-(m:Node)%s RETURN n, last(r), m LIMIT %d`,
+		cypherString(nodeID), depth, where, maxEdges,
+	)
+	conn, err := s.ageConn(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+	timeoutMS := int(searchTimeout.Milliseconds())
+	if _, err := conn.ExecContext(ctx, fmt.Sprintf("SET statement_timeout = %d", timeoutMS)); err != nil {
+		return nil, err
+	}
+	rows, err := conn.QueryContext(ctx, s.cypherSQL(cypher, "n agtype, r agtype, m agtype"))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var rawN, rawR, rawM string
+		if err := rows.Scan(&rawN, &rawR, &rawM); err != nil {
+			return nil, err
+		}
+		n, err := parseVertex(rawN)
+		if err != nil {
+			return nil, err
+		}
+		r, err := parseEdge(rawR)
+		if err != nil {
+			return nil, err
+		}
+		m, err := parseVertex(rawM)
+		if err != nil {
+			return nil, err
+		}
+		if len(result.Edges) >= maxEdges {
+			break
+		}
+		if !canAddTriple(seenNodes, n, m, maxNodes) {
+			continue
+		}
+		addNode(result, seenNodes, n, maxNodes)
+		addNode(result, seenNodes, m, maxNodes)
+		addEdge(result, seenEdges, r)
+	}
+	return result, rows.Err()
+}
+
+func (s *server) loadGraph(ctx context.Context, query, queryField, metadata string, edgeTypes []string, maxNodes, maxEdges int) (*graphResponse, error) {
+	result := &graphResponse{}
+	seenNodes := make(map[string]struct{})
+	seenEdges := make(map[string]struct{})
+	if query == "" {
+		return s.loadDefaultGraph(ctx, result, seenNodes, seenEdges, metadata, edgeTypes, maxNodes, maxEdges)
+	}
+
+	seeds, err := s.searchSeeds(ctx, query, queryField, metadata, maxNodes)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(seeds))
+	for _, seed := range seeds {
+		addNode(result, seenNodes, seed, maxNodes)
+		if id, ok := stringProperty(seed.Properties, "id"); ok {
+			ids = append(ids, id)
+		}
+	}
+	if len(ids) == 0 {
+		return result, nil
+	}
+	if err := s.loadSeedEdges(ctx, ids, metadata, edgeTypes, result, seenNodes, seenEdges, maxNodes, maxEdges); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (s *server) loadSeedEdges(
+	ctx context.Context,
+	ids []string,
+	metadata string,
+	edgeTypes []string,
+	result *graphResponse,
+	seenNodes map[string]struct{},
+	seenEdges map[string]struct{},
+	maxNodes int,
+	maxEdges int,
+) error {
+	const chunkSize = 20
+	for start := 0; start < len(ids) && len(result.Edges) < maxEdges; start += chunkSize {
+		end := start + chunkSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		conditions := []string{fmt.Sprintf("n.id IN [%s]", cypherStringList(ids[start:end]))}
+		if metadata != "" {
+			conditions = append(conditions, buildMetadataFilter("n", metadata))
+		}
+		if edgeFilter := buildEdgeTypeFilter("last(r)", edgeTypes); edgeFilter != "" {
+			conditions = append(conditions, edgeFilter)
+		}
+		// AGE plans plain -[r]- expansion poorly with property-filtered seeds.
+		// A one-hop variable-length path keeps this path consistent with /api/neighbors
+		// and avoids statement timeouts on package-level filters.
+		cypher := fmt.Sprintf(
+			`MATCH (n:Node)-[r*1..1]-(m:Node) WHERE %s RETURN n, last(r), m LIMIT %d`,
+			strings.Join(conditions, " AND "),
+			maxEdges-len(result.Edges),
+		)
+		if err := s.queryTriples(ctx, cypher, result, seenNodes, seenEdges, maxNodes, maxEdges); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *server) loadDefaultGraph(
+	ctx context.Context,
+	result *graphResponse,
+	seenNodes map[string]struct{},
+	seenEdges map[string]struct{},
+	metadata string,
+	edgeTypes []string,
+	maxNodes int,
+	maxEdges int,
+) (*graphResponse, error) {
+	var conditions []string
+	if metadata != "" {
+		f := buildMetadataFilter("n", metadata)
+		conditions = append(conditions, "("+f+" OR "+strings.Replace(f, "n.", "m.", 1)+")")
+	}
+	if edgeFilter := buildEdgeTypeFilter("r", edgeTypes); edgeFilter != "" {
+		conditions = append(conditions, edgeFilter)
+	}
+	where := ""
+	if len(conditions) > 0 {
+		where = " WHERE " + strings.Join(conditions, " AND ")
+	}
+	cypher := fmt.Sprintf(`MATCH (n:Node)-[r]->(m:Node)%s RETURN n, r, m LIMIT %d`, where, maxEdges)
+	if err := s.queryTriples(ctx, cypher, result, seenNodes, seenEdges, maxNodes, maxEdges); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// searchSeeds finds seed nodes matching query on the specified field.
+// queryField can be "id", "name", "content", or "metadata.<key>".
+// An empty queryField defaults to searching only the "name" field.
+// The match is case-insensitive substring (CONTAINS).
+// Content/comment fields use a smaller limit to avoid slow full-scan queries.
+func (s *server) searchSeeds(ctx context.Context, query, queryField, metadata string, maxNodes int) ([]vertexValue, error) {
+	needle := cypherString(strings.ToLower(query))
+	var where string
+	limit := *seedLimit
+	switch {
+	case queryField == "id":
+		where = fmt.Sprintf(`toLower(toString(n.id)) CONTAINS %s`, needle)
+	case queryField == "content":
+		where = fmt.Sprintf(`toLower(toString(n.content)) CONTAINS %s`, needle)
+		if limit > 5 {
+			limit = 5
+		}
+	case strings.HasPrefix(queryField, "metadata."):
+		metaKey := strings.TrimPrefix(queryField, "metadata.")
+		where = fmt.Sprintf(`toLower(toString(n.metadata[%s])) CONTAINS %s`, cypherString(metaKey), needle)
+		limit = maxNodes
+		// comment is also a large text field
+		if metaKey == "trpc_ast_comment" && limit > 5 {
+			limit = 5
+		}
+	default:
+		// "name" or unspecified
+		where = fmt.Sprintf(`toLower(toString(n.name)) CONTAINS %s`, needle)
+	}
+	if metadata != "" {
+		where = "(" + where + ") AND " + buildMetadataFilter("n", metadata)
+	}
+	cypher := fmt.Sprintf(`MATCH (n:Node) WHERE %s RETURN n LIMIT %d`, where, limit)
+
+	conn, err := s.ageConn(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+	timeoutMS := int(searchTimeout.Milliseconds())
+	if _, err := conn.ExecContext(ctx, fmt.Sprintf("SET statement_timeout = %d", timeoutMS)); err != nil {
+		return nil, err
+	}
+	rows, err := conn.QueryContext(ctx, s.cypherSQL(cypher, "n agtype"))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var seeds []vertexValue
+	for rows.Next() {
+		var raw string
+		if err := rows.Scan(&raw); err != nil {
+			return nil, err
+		}
+		v, err := parseVertex(raw)
+		if err != nil {
+			return nil, err
+		}
+		seeds = append(seeds, v)
+	}
+	return seeds, rows.Err()
+}
+
+func (s *server) queryTriples(ctx context.Context, cypher string, result *graphResponse, seenNodes map[string]struct{}, seenEdges map[string]struct{}, maxNodes, maxEdges int) error {
+	conn, err := s.ageConn(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	timeoutMS := int(searchTimeout.Milliseconds())
+	if _, err := conn.ExecContext(ctx, fmt.Sprintf("SET statement_timeout = %d", timeoutMS)); err != nil {
+		return err
+	}
+	rows, err := conn.QueryContext(ctx, s.cypherSQL(cypher, "n agtype, r agtype, m agtype"))
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var rawN, rawR, rawM string
+		if err := rows.Scan(&rawN, &rawR, &rawM); err != nil {
+			return err
+		}
+		n, err := parseVertex(rawN)
+		if err != nil {
+			return err
+		}
+		r, err := parseEdge(rawR)
+		if err != nil {
+			return err
+		}
+		m, err := parseVertex(rawM)
+		if err != nil {
+			return err
+		}
+		if len(result.Edges) >= maxEdges {
+			return nil
+		}
+		if !canAddTriple(seenNodes, n, m, maxNodes) {
+			continue
+		}
+		addNode(result, seenNodes, n, maxNodes)
+		addNode(result, seenNodes, m, maxNodes)
+		addEdge(result, seenEdges, r)
+	}
+	return rows.Err()
+}
+
+func (s *server) handleSummary(w http.ResponseWriter, r *http.Request) {
+	cypher := `MATCH (a)-[r]->(b) RETURN label(a), label(r), label(b), count(r) ORDER BY count(r) DESC`
+	conn, err := s.ageConn(r.Context())
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	defer conn.Close()
+	rows, err := conn.QueryContext(r.Context(), s.cypherSQL(cypher, "from_label agtype, edge_label agtype, to_label agtype, edge_count agtype"))
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	defer rows.Close()
+
+	var summaries []edgeSummary
+	for rows.Next() {
+		var fromLabel, edgeLabel, toLabel, count string
+		if err := rows.Scan(&fromLabel, &edgeLabel, &toLabel, &count); err != nil {
+			writeError(w, err)
+			return
+		}
+		summaries = append(summaries, edgeSummary{
+			FromLabel: trimAgtypeString(fromLabel),
+			EdgeLabel: trimAgtypeString(edgeLabel),
+			ToLabel:   trimAgtypeString(toLabel),
+			Count:     trimAgtypeString(count),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, summaries)
+}
+
+func (s *server) cypherSQL(cypher, columns string) string {
+	return fmt.Sprintf("SELECT * FROM cypher(%s, %s) AS (%s)", sqlString(s.graphName), dollarQuote(cypher), columns)
+}
+
+func canAddTriple(seen map[string]struct{}, from, to vertexValue, maxNodes int) bool {
+	needed := 0
+	if _, ok := seen[from.ID.String()]; !ok {
+		needed++
+	}
+	if _, ok := seen[to.ID.String()]; !ok && to.ID.String() != from.ID.String() {
+		needed++
+	}
+	return len(seen)+needed <= maxNodes
+}
+
+func addNode(result *graphResponse, seen map[string]struct{}, v vertexValue, maxNodes int) {
+	id := v.ID.String()
+	if _, ok := seen[id]; ok {
+		return
+	}
+	if len(seen) >= maxNodes {
+		return
+	}
+	seen[id] = struct{}{}
+	name, _ := stringProperty(v.Properties, "name")
+	content, _ := stringProperty(v.Properties, "content")
+	kind := metadataKind(v.Properties)
+	if name == "" {
+		name = v.Label + " " + id
+	}
+	result.Nodes = append(result.Nodes, node{
+		ID:         id,
+		Label:      v.Label,
+		Name:       name,
+		Kind:       kind,
+		Content:    content,
+		Properties: v.Properties,
+	})
+}
+
+func addEdge(result *graphResponse, seen map[string]struct{}, e edgeValue) {
+	id := e.ID.String()
+	if _, ok := seen[id]; ok {
+		return
+	}
+	seen[id] = struct{}{}
+	result.Edges = append(result.Edges, edge{
+		ID:         id,
+		From:       e.StartID.String(),
+		To:         e.EndID.String(),
+		Label:      e.Label,
+		Properties: e.Properties,
+	})
+}
+
+func parseVertex(raw string) (vertexValue, error) {
+	var v vertexValue
+	if err := decodeAgtype(raw, "::vertex", &v); err != nil {
+		return vertexValue{}, err
+	}
+	if v.Properties == nil {
+		v.Properties = map[string]any{}
+	}
+	return v, nil
+}
+
+func parseEdge(raw string) (edgeValue, error) {
+	var e edgeValue
+	if err := decodeAgtype(raw, "::edge", &e); err != nil {
+		return edgeValue{}, err
+	}
+	if e.Properties == nil {
+		e.Properties = map[string]any{}
+	}
+	return e, nil
+}
+
+func parseVertexList(raw string) ([]vertexValue, error) {
+	var nodes []vertexValue
+	if err := decodeAgtypeList(raw, &nodes); err != nil {
+		return nil, err
+	}
+	for i := range nodes {
+		if nodes[i].Properties == nil {
+			nodes[i].Properties = map[string]any{}
+		}
+	}
+	return nodes, nil
+}
+
+func parseEdgeList(raw string) ([]edgeValue, error) {
+	var edges []edgeValue
+	if err := decodeAgtypeList(raw, &edges); err != nil {
+		return nil, err
+	}
+	for i := range edges {
+		if edges[i].Properties == nil {
+			edges[i].Properties = map[string]any{}
+		}
+	}
+	return edges, nil
+}
+
+func decodeAgtype(raw, suffix string, dst any) error {
+	raw = strings.TrimSpace(raw)
+	raw = strings.TrimSuffix(raw, suffix)
+	decoder := json.NewDecoder(strings.NewReader(raw))
+	decoder.UseNumber()
+	if err := decoder.Decode(dst); err != nil {
+		return fmt.Errorf("decode agtype %q: %w", raw, err)
+	}
+	return nil
+}
+
+func decodeAgtypeList(raw string, dst any) error {
+	raw = strings.TrimSpace(raw)
+	raw = strings.TrimSuffix(raw, "::agtype")
+	raw = strings.ReplaceAll(raw, "::vertex", "")
+	raw = strings.ReplaceAll(raw, "::edge", "")
+	decoder := json.NewDecoder(strings.NewReader(raw))
+	decoder.UseNumber()
+	if err := decoder.Decode(dst); err != nil {
+		return fmt.Errorf("decode agtype list %q: %w", raw, err)
+	}
+	return nil
+}
+
+func stringProperty(properties map[string]any, key string) (string, bool) {
+	value, ok := properties[key]
+	if !ok || value == nil {
+		return "", false
+	}
+	switch v := value.(type) {
+	case string:
+		return v, true
+	case json.Number:
+		return v.String(), true
+	default:
+		return fmt.Sprint(v), true
+	}
+}
+
+func metadataKind(properties map[string]any) string {
+	raw, ok := properties["metadata"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	for _, key := range []string{"trpc_ast_type", "trpc_ast_scope"} {
+		if value, ok := stringProperty(raw, key); ok && value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+// buildMetadataFilter builds a Cypher WHERE clause fragment for metadata filtering.
+// Supports multiple AND-combined conditions separated by ";", and per-condition
+// key=value glob matching. Examples:
+//
+//	"trpc_ast_type=Method"
+//	"trpc_ast_package=knowledge*;trpc_ast_type=Function"
+//	"client"  (full-metadata substring match)
+func buildMetadataFilter(variable, pattern string) string {
+	parts := splitConditions(pattern)
+	clauses := make([]string, 0, len(parts))
+	for _, part := range parts {
+		clauses = append(clauses, cypherMetadataMatches(variable, part))
+	}
+	if len(clauses) == 1 {
+		return clauses[0]
+	}
+	return "(" + strings.Join(clauses, " AND ") + ")"
+}
+
+func appendMetadataFilter(existing, key, value string) string {
+	filter := strings.TrimSpace(key) + "=" + strings.TrimSpace(value)
+	if strings.TrimSpace(existing) == "" {
+		return filter
+	}
+	return existing + ";" + filter
+}
+
+func buildEdgeTypeFilter(edgeExpr string, edgeTypes []string) string {
+	if len(edgeTypes) == 0 {
+		return ""
+	}
+	quoted := make([]string, 0, len(edgeTypes))
+	for _, t := range edgeTypes {
+		if t != "" {
+			quoted = append(quoted, cypherString(t))
+		}
+	}
+	if len(quoted) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("label(%s) IN [%s]", edgeExpr, strings.Join(quoted, ", "))
+}
+
+// splitConditions splits a metadata filter string on ";" into individual conditions.
+func splitConditions(pattern string) []string {
+	raw := strings.Split(pattern, ";")
+	out := make([]string, 0, len(raw))
+	for _, s := range raw {
+		if s = strings.TrimSpace(s); s != "" {
+			out = append(out, s)
+		}
+	}
+	if len(out) == 0 {
+		return []string{pattern}
+	}
+	return out
+}
+
+func cypherMetadataMatches(variable, pattern string) string {
+	key, value, ok := splitMetadataPattern(pattern)
+	if ok {
+		return fmt.Sprintf("toLower(toString(%s.metadata[%s])) =~ %s",
+			variable, cypherString(key), cypherString(metadataGlobRegex(value)))
+	}
+	return fmt.Sprintf("toLower(toString(%s.metadata)) =~ %s", variable, cypherString(metadataGlobRegex(pattern)))
+}
+
+func splitMetadataPattern(pattern string) (string, string, bool) {
+	key, value, ok := strings.Cut(pattern, "=")
+	if !ok {
+		return "", "", false
+	}
+	key = strings.TrimSpace(key)
+	value = strings.TrimSpace(value)
+	if key == "" || value == "" {
+		return "", "", false
+	}
+	return key, value, true
+}
+
+func metadataGlobRegex(pattern string) string {
+	pattern = strings.ToLower(strings.TrimSpace(pattern))
+	var builder strings.Builder
+	builder.WriteString(".*")
+	wrotePart := false
+	for _, part := range strings.Split(pattern, "*") {
+		if part == "" {
+			continue
+		}
+		builder.WriteString(regexp.QuoteMeta(part))
+		builder.WriteString(".*")
+		wrotePart = true
+	}
+	if !wrotePart {
+		return ".*"
+	}
+	return builder.String()
+}
+
+func cypherString(value string) string {
+	value = strings.ReplaceAll(value, `\`, `\\`)
+	value = strings.ReplaceAll(value, `'`, `\'`)
+	return "'" + value + "'"
+}
+
+func cypherStringList(values []string) string {
+	parts := make([]string, 0, len(values))
+	for _, value := range values {
+		parts = append(parts, cypherString(value))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func sqlString(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
+}
+
+func dollarQuote(value string) string {
+	tag := "$cypher$"
+	if !strings.Contains(value, tag) {
+		return tag + value + tag
+	}
+	return "$cypher_query$" + value + "$cypher_query$"
+}
+
+func trimAgtypeString(value string) string {
+	value = strings.TrimSpace(value)
+	value = strings.Trim(value, `"`)
+	return value
+}
+
+func queryInt(r *http.Request, key string, fallback, max int) int {
+	raw := strings.TrimSpace(r.URL.Query().Get(key))
+	if raw == "" {
+		return fallback
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil || value <= 0 {
+		return fallback
+	}
+	if value > max {
+		return max
+	}
+	return value
+}
+
+func parseCommaList(s string) []string {
+	var out []string
+	for _, part := range strings.Split(s, ",") {
+		if part = strings.TrimSpace(part); part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+func writeJSON(w http.ResponseWriter, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		log.Printf("write response: %v", err)
+	}
+}
+
+func writeError(w http.ResponseWriter, err error) {
+	log.Printf("request error: %v", err)
+	http.Error(w, err.Error(), http.StatusInternalServerError)
+}

--- a/examples/knowledge/features/graphrag/viewer/main.go
+++ b/examples/knowledge/features/graphrag/viewer/main.go
@@ -43,7 +43,10 @@ var (
 	searchTimeout = flag.Duration("search-timeout", 8*time.Second, "Statement timeout for seed search queries")
 )
 
-const ageSessionSQL = `LOAD 'age'; SET search_path = ag_catalog, "$user", public`
+const (
+	ageLoadSQL       = `LOAD 'age'`
+	ageSearchPathSQL = `SET search_path = ag_catalog, "$user", public`
+)
 
 // maxPoolConns is the connection pool size. Each connection initialises an AGE
 // session independently.
@@ -125,7 +128,15 @@ func main() {
 
 	log.Printf("AGE graph viewer listening on http://%s", *addr)
 	log.Printf("Graph: %s", *graphName)
-	if err := http.ListenAndServe(*addr, mux); err != nil {
+	srv := &http.Server{
+		Addr:              *addr,
+		Handler:           mux,
+		ReadHeaderTimeout: *searchTimeout,
+		ReadTimeout:       *searchTimeout,
+		WriteTimeout:      *searchTimeout,
+		IdleTimeout:       time.Minute,
+	}
+	if err := srv.ListenAndServe(); err != nil {
 		log.Fatal(err)
 	}
 }
@@ -172,7 +183,11 @@ func (s *server) ageConn(ctx context.Context) (*sql.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	if _, err := conn.ExecContext(ctx, ageSessionSQL); err != nil {
+	if _, err := conn.ExecContext(ctx, ageLoadSQL); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	if _, err := conn.ExecContext(ctx, ageSearchPathSQL); err != nil {
 		_ = conn.Close()
 		return nil, err
 	}
@@ -883,11 +898,12 @@ func sqlString(value string) string {
 }
 
 func dollarQuote(value string) string {
-	tag := "$cypher$"
-	if !strings.Contains(value, tag) {
-		return tag + value + tag
+	for _, tag := range []string{"$cypher$", "$cypher_query$", "$cypher_q1$", "$cypher_q2$"} {
+		if !strings.Contains(value, tag) {
+			return tag + value + tag
+		}
 	}
-	return "$cypher_query$" + value + "$cypher_query$"
+	return "$cypher_q3$" + value + "$cypher_q3$"
 }
 
 func trimAgtypeString(value string) string {

--- a/examples/knowledge/go.mod
+++ b/examples/knowledge/go.mod
@@ -6,6 +6,7 @@ replace (
 	trpc.group/trpc-go/trpc-agent-go => ../../
 	trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader/pdf => ../../knowledge/document/reader/pdf
 	trpc.group/trpc-go/trpc-agent-go/knowledge/embedder/gemini => ../../knowledge/embedder/gemini
+	trpc.group/trpc-go/trpc-agent-go/knowledge/graphstore/age => ../../knowledge/graphstore/age
 	trpc.group/trpc-go/trpc-agent-go/knowledge/ocr/tesseract => ../../knowledge/ocr/tesseract
 	trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/elasticsearch => ../../knowledge/vectorstore/elasticsearch
 	trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/milvus => ../../knowledge/vectorstore/milvus
@@ -20,16 +21,21 @@ replace (
 
 require (
 	github.com/getkin/kin-openapi v0.124.0
+	github.com/jackc/pgx/v5 v5.7.2
 	trpc.group/trpc-go/trpc-agent-go v1.8.2-0.20260429121222-b41f42aefbc5
 	trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader/pdf v0.5.0
+	trpc.group/trpc-go/trpc-agent-go/knowledge/graphstore/age v0.0.1-0.20260429130101-b1f1d9f169f0
 	trpc.group/trpc-go/trpc-agent-go/knowledge/ocr/tesseract v0.0.0-20251203120347-0b4d62cb115d
 	trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/elasticsearch v0.2.1
 	trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/milvus v0.8.1-0.20251222024650-ea147adf3d21
 	trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/pgvector v0.2.0
 	trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/sqlitevec v0.0.0-20260327150826-d407bd208503
 	trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/tcvector v0.2.0
+	trpc.group/trpc-go/trpc-agent-go/storage/postgres v0.0.0-20251126064502-c8c2594d2519
 	trpc.group/trpc-go/trpc-mcp-go v0.0.10
 )
+
+require github.com/google/uuid v1.6.0 // indirect
 
 require (
 	github.com/asg017/sqlite-vec-go-bindings v0.1.6 // indirect
@@ -70,7 +76,6 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.1.2 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
@@ -82,7 +87,6 @@ require (
 	github.com/invopop/yaml v0.2.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/pgx/v5 v5.7.2 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jonboulle/clockwork v0.2.2 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
@@ -172,11 +176,13 @@ require (
 	golang.org/x/crypto v0.43.0 // indirect
 	golang.org/x/exp v0.0.0-20250218142911-aa4b98e5adaa // indirect
 	golang.org/x/image v0.32.0 // indirect
+	golang.org/x/mod v0.28.0 // indirect
 	golang.org/x/net v0.45.0 // indirect
 	golang.org/x/sync v0.17.0 // indirect
 	golang.org/x/sys v0.37.0 // indirect
 	golang.org/x/text v0.30.0 // indirect
 	golang.org/x/time v0.10.0 // indirect
+	golang.org/x/tools v0.37.0 // indirect
 	google.golang.org/genproto v0.0.0-20250303144028-a0af3efb3deb // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250324211829-b45e905df463 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250707201910-8d1bb00bc6a7 // indirect
@@ -189,8 +195,10 @@ require (
 	k8s.io/apimachinery v0.32.3 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 	trpc.group/trpc-go/trpc-a2a-go v0.2.5 // indirect
+	trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader/golang v0.0.1-0.20260429130101-b1f1d9f169f0
 	trpc.group/trpc-go/trpc-agent-go/storage/elasticsearch v0.2.0 // indirect
 	trpc.group/trpc-go/trpc-agent-go/storage/milvus v0.8.0 // indirect
-	trpc.group/trpc-go/trpc-agent-go/storage/postgres v0.0.0-20251126064502-c8c2594d2519 // indirect
 	trpc.group/trpc-go/trpc-agent-go/storage/tcvector v0.0.4 // indirect
 )
+
+replace trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader/golang => ../../knowledge/document/reader/golang

--- a/examples/knowledge/go.mod
+++ b/examples/knowledge/go.mod
@@ -4,6 +4,7 @@ go 1.24.6
 
 replace (
 	trpc.group/trpc-go/trpc-agent-go => ../../
+	trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader/golang => ../../knowledge/document/reader/golang
 	trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader/pdf => ../../knowledge/document/reader/pdf
 	trpc.group/trpc-go/trpc-agent-go/knowledge/embedder/gemini => ../../knowledge/embedder/gemini
 	trpc.group/trpc-go/trpc-agent-go/knowledge/graphstore/age => ../../knowledge/graphstore/age
@@ -23,6 +24,7 @@ require (
 	github.com/getkin/kin-openapi v0.124.0
 	github.com/jackc/pgx/v5 v5.7.2
 	trpc.group/trpc-go/trpc-agent-go v1.8.2-0.20260429121222-b41f42aefbc5
+	trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader/golang v0.0.1-0.20260429130101-b1f1d9f169f0
 	trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader/pdf v0.5.0
 	trpc.group/trpc-go/trpc-agent-go/knowledge/graphstore/age v0.0.1-0.20260429130101-b1f1d9f169f0
 	trpc.group/trpc-go/trpc-agent-go/knowledge/ocr/tesseract v0.0.0-20251203120347-0b4d62cb115d
@@ -195,10 +197,7 @@ require (
 	k8s.io/apimachinery v0.32.3 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 	trpc.group/trpc-go/trpc-a2a-go v0.2.5 // indirect
-	trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader/golang v0.0.1-0.20260429130101-b1f1d9f169f0
 	trpc.group/trpc-go/trpc-agent-go/storage/elasticsearch v0.2.0 // indirect
 	trpc.group/trpc-go/trpc-agent-go/storage/milvus v0.8.0 // indirect
 	trpc.group/trpc-go/trpc-agent-go/storage/tcvector v0.0.4 // indirect
 )
-
-replace trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader/golang => ../../knowledge/document/reader/golang

--- a/examples/knowledge/go.sum
+++ b/examples/knowledge/go.sum
@@ -774,6 +774,8 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.28.0 h1:gQBtGhjxykdjY9YhZpSlZIsbnaE2+PgjfLWUQTnoZ1U=
+golang.org/x/mod v0.28.0/go.mod h1:yfB/L0NOf/kmEbXjzCPOx1iK1fRutOydrCMsqRhEBxI=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -911,6 +913,8 @@ golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.37.0 h1:DVSRzp7FwePZW356yEAChSdNcQo6Nsp+fex1SUW09lE=
+golang.org/x/tools v0.37.0/go.mod h1:MBN5QPQtLMHVdvsbtarmTNukZDdgwdwlO5qGacAzF0w=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/examples/knowledge/sources/ast/main.go
+++ b/examples/knowledge/sources/ast/main.go
@@ -27,6 +27,7 @@ import (
 	util "trpc.group/trpc-go/trpc-agent-go/examples/knowledge"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/document"
+	_ "trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader/golang"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/embedder"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/embedder/openai"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/source"


### PR DESCRIPTION
## Summary

- Add a complete `graphrag` example under `examples/knowledge/features/graphrag/` demonstrating interactive CLI chat with code graph search tools (search, traverse, find_paths)
- Add JSONL tool chain trace recording for debugging LLM tool usage
- Add a standalone HTML viewer and Go server (`viewer/`) for visualizing tool call traces
- Bump `examples/knowledge/go.mod` dependencies for graph knowledge support

Split from #1731 to reduce PR size.

## Test plan

- [ ] `cd examples/knowledge && go build ./features/graphrag/...`
- [ ] `cd examples/knowledge && go build ./features/graphrag/viewer/...`
- [ ] Verify `check-examples.sh` passes


Made with [Cursor](https://cursor.com)