### PR TITLE
{agent, graph, runner}: align graph agent child surface roots

### DIFF
--- a/agent/chainagent/chain_agent.go
+++ b/agent/chainagent/chain_agent.go
@@ -60,13 +60,20 @@ func (a *ChainAgent) createSubAgentInvocation(
 	subAgent agent.Agent,
 	baseInvocation *agent.Invocation,
 	nodeID string,
+	surfaceRootNodeID string,
 	entryPredecessors []string,
 ) *agent.Invocation {
-	return baseInvocation.Clone(
+	opts := []agent.InvocationOptions{
 		agent.WithInvocationAgent(subAgent),
 		agent.WithInvocationTraceNodeID(nodeID),
 		agent.WithInvocationEntryPredecessorStepIDs(entryPredecessors),
-	)
+	}
+	if surfaceRootNodeID != "" {
+		opts = append(opts, func(inv *agent.Invocation) {
+			agent.SetInvocationSurfaceRootNodeID(inv, surfaceRootNodeID)
+		})
+	}
+	return baseInvocation.Clone(opts...)
 }
 
 // Run implements the agent.Agent interface.
@@ -210,6 +217,7 @@ func (a *ChainAgent) executeSubAgents(
 	tokenUsage := &itelemetry.TokenUsage{}
 	var fullRespEvent *event.Event
 	pathAllocator := istructure.NewPathAllocator(agent.InvocationTraceNodeID(invocation))
+	surfacePathAllocator := istructure.NewPathAllocator(agent.InvocationSurfaceRootNodeID(invocation))
 	predecessors := agent.NextExecutionTracePredecessors(invocation)
 	visibleCtx := graph.WithoutGraphCompletionCapture(ctx)
 	for _, subAgent := range a.subAgents {
@@ -218,6 +226,7 @@ func (a *ChainAgent) executeSubAgents(
 			subAgent,
 			invocation,
 			pathAllocator.Next(subAgent.Info().Name),
+			surfacePathAllocator.Next(subAgent.Info().Name),
 			predecessors,
 		)
 

--- a/agent/chainagent/chain_agent_test.go
+++ b/agent/chainagent/chain_agent_test.go
@@ -563,9 +563,11 @@ func TestCreateSubAgentInvocation(t *testing.T) {
 	require.Equal(t, "root", base.GetEventFilterKey())
 
 	sub := &mockMinimalAgent{name: "child"}
-	inv := parent.createSubAgentInvocation(sub, base, "", nil)
+	inv := parent.createSubAgentInvocation(sub, base, "parent/child", "surface/child", nil)
 
 	require.Equal(t, "child", inv.AgentName)
+	require.Equal(t, "parent/child", agent.InvocationTraceNodeID(inv))
+	require.Equal(t, "surface/child", agent.InvocationSurfaceRootNodeID(inv))
 	require.Equal(t, "root", base.GetEventFilterKey())
 	// Ensure original invocation not mutated.
 	require.Equal(t, "parent"+agent.BranchDelimiter+"child", inv.Branch)

--- a/agent/cycleagent/cycle_agent.go
+++ b/agent/cycleagent/cycle_agent.go
@@ -60,13 +60,20 @@ func (a *CycleAgent) createSubAgentInvocation(
 	subAgent agent.Agent,
 	baseInvocation *agent.Invocation,
 	nodeID string,
+	surfaceRootNodeID string,
 	entryPredecessors []string,
 ) *agent.Invocation {
-	return baseInvocation.Clone(
+	opts := []agent.InvocationOptions{
 		agent.WithInvocationAgent(subAgent),
 		agent.WithInvocationTraceNodeID(nodeID),
 		agent.WithInvocationEntryPredecessorStepIDs(entryPredecessors),
-	)
+	}
+	if surfaceRootNodeID != "" {
+		opts = append(opts, func(inv *agent.Invocation) {
+			agent.SetInvocationSurfaceRootNodeID(inv, surfaceRootNodeID)
+		})
+	}
+	return baseInvocation.Clone(opts...)
 }
 
 // shouldEscalate checks if an event indicates escalation using injectable logic.
@@ -169,12 +176,19 @@ func (a *CycleAgent) runSubAgent(
 	subAgent agent.Agent,
 	invocation *agent.Invocation,
 	nodeID string,
+	surfaceRootNodeID string,
 	entryPredecessors []string,
 	eventChan chan<- *event.Event,
 	fullRespEvent **event.Event,
 ) (*agent.Invocation, bool) {
 	// Create a proper invocation for the sub-agent with correct attribution.
-	subInvocation := a.createSubAgentInvocation(subAgent, invocation, nodeID, entryPredecessors)
+	subInvocation := a.createSubAgentInvocation(
+		subAgent,
+		invocation,
+		nodeID,
+		surfaceRootNodeID,
+		entryPredecessors,
+	)
 
 	// Reset invocation information in context
 	subAgentCtx := graph.WithGraphCompletionCapture(
@@ -257,6 +271,7 @@ func (a *CycleAgent) runSubAgentsLoop(
 	fullRespEvent **event.Event,
 ) ([]string, bool) {
 	pathAllocator := istructure.NewPathAllocator(agent.InvocationTraceNodeID(invocation))
+	surfacePathAllocator := istructure.NewPathAllocator(agent.InvocationSurfaceRootNodeID(invocation))
 	currentPredecessors := entryPredecessors
 	for _, subAgent := range a.subAgents {
 		// Check if context was cancelled.
@@ -270,6 +285,7 @@ func (a *CycleAgent) runSubAgentsLoop(
 			subAgent,
 			invocation,
 			pathAllocator.Next(subAgent.Info().Name),
+			surfacePathAllocator.Next(subAgent.Info().Name),
 			currentPredecessors,
 			eventChan,
 			fullRespEvent,

--- a/agent/cycleagent/cycle_agent_test.go
+++ b/agent/cycleagent/cycle_agent_test.go
@@ -728,9 +728,11 @@ func TestCycleAgent_CreateSubAgentInvoke(t *testing.T) {
 	base := agent.NewInvocation(agent.WithInvocationAgent(parent))
 	child := &noopAgent{name: "child"}
 
-	inv := parent.createSubAgentInvocation(child, base, "", nil)
+	inv := parent.createSubAgentInvocation(child, base, "parent/child", "surface/child", nil)
 
 	require.Equal(t, "child", inv.AgentName)
+	require.Equal(t, "parent/child", agent.InvocationTraceNodeID(inv))
+	require.Equal(t, "surface/child", agent.InvocationSurfaceRootNodeID(inv))
 	// Branch should stay unchanged when base.Branch non-empty.
 	require.Equal(t, "parent"+agent.BranchDelimiter+"child", inv.Branch)
 	// Ensure TransferInfo cleared.

--- a/agent/graphagent/structure_export.go
+++ b/agent/graphagent/structure_export.go
@@ -91,20 +91,27 @@ func (ga *GraphAgent) Export(
 		if err != nil {
 			return nil, err
 		}
-		mountPath := istructure.JoinNodeID(nodePath, childAgent.Info().Name)
-		rebased, err := istructure.RebaseSnapshot(childSnapshot, mountPath)
+		rebased, err := istructure.RebaseSnapshot(childSnapshot, nodePath)
 		if err != nil {
 			return nil, err
 		}
-		snapshot.Nodes = append(snapshot.Nodes, rebased.Nodes...)
-		snapshot.Edges = append(snapshot.Edges, rebased.Edges...)
-		snapshot.Surfaces = append(snapshot.Surfaces, rebased.Surfaces...)
-		snapshot.Edges = append(snapshot.Edges, structure.Edge{
-			FromNodeID: nodePath,
-			ToNodeID:   rebased.EntryNodeID,
-		})
+		appendAgentNodeChildSnapshot(snapshot, rebased)
 	}
 	return snapshot, nil
+}
+
+func appendAgentNodeChildSnapshot(
+	snapshot *structure.Snapshot,
+	rebased *structure.Snapshot,
+) {
+	for _, childNode := range rebased.Nodes {
+		if childNode.NodeID == rebased.EntryNodeID {
+			continue
+		}
+		snapshot.Nodes = append(snapshot.Nodes, childNode)
+	}
+	snapshot.Edges = append(snapshot.Edges, rebased.Edges...)
+	snapshot.Surfaces = append(snapshot.Surfaces, rebased.Surfaces...)
 }
 
 func nodeKindFromGraphNodeType(nodeType graph.NodeType) structure.NodeKind {

--- a/agent/graphagent/structure_export_test.go
+++ b/agent/graphagent/structure_export_test.go
@@ -213,7 +213,7 @@ func TestExport_GraphAgent_ToolNodeSurface(t *testing.T) {
 	})
 }
 
-func TestExport_GraphAgent_AgentNodeRecursesIntoChild(t *testing.T) {
+func TestExport_GraphAgent_AgentNodeMergesChildRootSurfaces(t *testing.T) {
 	compiled := graph.NewStateGraph(graph.NewStateSchema()).
 		AddAgentNode("researcher").
 		SetEntryPoint("researcher").
@@ -222,7 +222,6 @@ func TestExport_GraphAgent_AgentNodeRecursesIntoChild(t *testing.T) {
 	child := llmagent.New("researcher")
 	ag, err := New("assistant", compiled, WithSubAgents([]agent.Agent{child}))
 	require.NoError(t, err)
-
 	snapshot, err := structure.Export(context.Background(), ag)
 	require.NoError(t, err)
 	assertGraphSnapshotEqual(t, snapshot, &structure.Snapshot{
@@ -230,24 +229,83 @@ func TestExport_GraphAgent_AgentNodeRecursesIntoChild(t *testing.T) {
 		Nodes: []structure.Node{
 			{NodeID: "assistant", Kind: structure.NodeKindAgent, Name: "assistant"},
 			{NodeID: "assistant/researcher", Kind: structure.NodeKindAgent, Name: "researcher"},
-			{NodeID: "assistant/researcher/researcher", Kind: structure.NodeKindLLM, Name: "researcher"},
 		},
 		Edges: []structure.Edge{
 			{FromNodeID: "assistant", ToNodeID: "assistant/researcher"},
-			{FromNodeID: "assistant/researcher", ToNodeID: "assistant/researcher/researcher"},
 		},
 		Surfaces: []structure.Surface{
 			{
-				SurfaceID: "assistant/researcher/researcher#global_instruction",
-				NodeID:    "assistant/researcher/researcher",
+				SurfaceID: "assistant/researcher#global_instruction",
+				NodeID:    "assistant/researcher",
 				Type:      structure.SurfaceTypeGlobalInstruction,
 				Value:     structure.SurfaceValue{Text: stringPtr("")},
 			},
 			{
-				SurfaceID: "assistant/researcher/researcher#instruction",
-				NodeID:    "assistant/researcher/researcher",
+				SurfaceID: "assistant/researcher#instruction",
+				NodeID:    "assistant/researcher",
 				Type:      structure.SurfaceTypeInstruction,
 				Value:     structure.SurfaceValue{Text: stringPtr("")},
+			},
+		},
+	})
+}
+
+func TestExport_GraphAgent_AgentNodeMountsChildGraphInternals(t *testing.T) {
+	childCompiled := graph.NewStateGraph(graph.NewStateSchema()).
+		AddLLMNode("plan", &structureMockModel{name: "plan-model"}, "plan", nil).
+		AddLLMNode("write", &structureMockModel{name: "write-model"}, "write", nil).
+		SetEntryPoint("plan").
+		AddEdge("plan", "write").
+		SetFinishPoint("write").
+		MustCompile()
+	child, err := New("research_flow", childCompiled)
+	require.NoError(t, err)
+	compiled := graph.NewStateGraph(graph.NewStateSchema()).
+		AddAgentNode("research_flow").
+		SetEntryPoint("research_flow").
+		SetFinishPoint("research_flow").
+		MustCompile()
+	ag, err := New("assistant", compiled, WithSubAgents([]agent.Agent{child}))
+	require.NoError(t, err)
+	snapshot, err := structure.Export(context.Background(), ag)
+	require.NoError(t, err)
+	assertGraphSnapshotEqual(t, snapshot, &structure.Snapshot{
+		EntryNodeID: "assistant",
+		Nodes: []structure.Node{
+			{NodeID: "assistant", Kind: structure.NodeKindAgent, Name: "assistant"},
+			{NodeID: "assistant/research_flow", Kind: structure.NodeKindAgent, Name: "research_flow"},
+			{NodeID: "assistant/research_flow/plan", Kind: structure.NodeKindLLM, Name: "plan"},
+			{NodeID: "assistant/research_flow/write", Kind: structure.NodeKindLLM, Name: "write"},
+		},
+		Edges: []structure.Edge{
+			{FromNodeID: "assistant", ToNodeID: "assistant/research_flow"},
+			{FromNodeID: "assistant/research_flow", ToNodeID: "assistant/research_flow/plan"},
+			{FromNodeID: "assistant/research_flow/plan", ToNodeID: "assistant/research_flow/write"},
+		},
+		Surfaces: []structure.Surface{
+			{
+				SurfaceID: "assistant/research_flow/plan#instruction",
+				NodeID:    "assistant/research_flow/plan",
+				Type:      structure.SurfaceTypeInstruction,
+				Value:     structure.SurfaceValue{Text: stringPtr("plan")},
+			},
+			{
+				SurfaceID: "assistant/research_flow/plan#model",
+				NodeID:    "assistant/research_flow/plan",
+				Type:      structure.SurfaceTypeModel,
+				Value:     structure.SurfaceValue{Model: &structure.ModelRef{Name: "plan-model"}},
+			},
+			{
+				SurfaceID: "assistant/research_flow/write#instruction",
+				NodeID:    "assistant/research_flow/write",
+				Type:      structure.SurfaceTypeInstruction,
+				Value:     structure.SurfaceValue{Text: stringPtr("write")},
+			},
+			{
+				SurfaceID: "assistant/research_flow/write#model",
+				NodeID:    "assistant/research_flow/write",
+				Type:      structure.SurfaceTypeModel,
+				Value:     structure.SurfaceValue{Model: &structure.ModelRef{Name: "write-model"}},
 			},
 		},
 	})

--- a/agent/parallelagent/parallel_agent.go
+++ b/agent/parallelagent/parallel_agent.go
@@ -66,6 +66,7 @@ func (a *ParallelAgent) createBranchInvocation(
 	subAgent agent.Agent,
 	baseInvocation *agent.Invocation,
 	nodeID string,
+	surfaceRootNodeID string,
 	entryPredecessors []string,
 ) *agent.Invocation {
 	// Create unique invocation ID for this branch.
@@ -76,12 +77,18 @@ func (a *ParallelAgent) createBranchInvocation(
 		eventFilterKey += agent.EventFilterKeyDelimiter + subAgent.Info().Name
 	}
 
-	return baseInvocation.Clone(
+	opts := []agent.InvocationOptions{
 		agent.WithInvocationAgent(subAgent),
 		agent.WithInvocationEventFilterKey(eventFilterKey),
 		agent.WithInvocationTraceNodeID(nodeID),
 		agent.WithInvocationEntryPredecessorStepIDs(entryPredecessors),
-	)
+	}
+	if surfaceRootNodeID != "" {
+		opts = append(opts, func(inv *agent.Invocation) {
+			agent.SetInvocationSurfaceRootNodeID(inv, surfaceRootNodeID)
+		})
+	}
+	return baseInvocation.Clone(opts...)
 }
 
 // setupInvocation prepares the invocation for execution.
@@ -142,13 +149,15 @@ func (a *ParallelAgent) startSubAgents(
 	var wg sync.WaitGroup
 	eventStreams := make([]subAgentEventStream, len(a.subAgents))
 	pathAllocator := istructure.NewPathAllocator(agent.InvocationTraceNodeID(invocation))
+	surfacePathAllocator := istructure.NewPathAllocator(agent.InvocationSurfaceRootNodeID(invocation))
 	entryPredecessors := agent.NextExecutionTracePredecessors(invocation)
 
 	for i, subAgent := range a.subAgents {
 		childNodeID := pathAllocator.Next(subAgent.Info().Name)
+		childSurfaceRootNodeID := surfacePathAllocator.Next(subAgent.Info().Name)
 		wg.Add(1)
 		runCtx := agent.CloneContext(ctx)
-		go func(ctx context.Context, idx int, sa agent.Agent, nodeID string) {
+		go func(ctx context.Context, idx int, sa agent.Agent, nodeID string, surfaceRootNodeID string) {
 			defer wg.Done()
 			// Recover from panics in sub-agent execution to prevent
 			// the whole service from crashing.
@@ -169,7 +178,13 @@ func (a *ParallelAgent) startSubAgents(
 			}()
 
 			// Create branch invocation for this sub-agent.
-			branchInvocation := a.createBranchInvocation(sa, invocation, nodeID, entryPredecessors)
+			branchInvocation := a.createBranchInvocation(
+				sa,
+				invocation,
+				nodeID,
+				surfaceRootNodeID,
+				entryPredecessors,
+			)
 
 			// Reset invocation information in context
 			branchAgentCtx := graph.WithGraphCompletionCapture(
@@ -197,7 +212,7 @@ func (a *ParallelAgent) startSubAgents(
 				author: branchInvocation.AgentName,
 				ch:     subEventChan,
 			}
-		}(runCtx, i, subAgent, childNodeID)
+		}(runCtx, i, subAgent, childNodeID, childSurfaceRootNodeID)
 	}
 
 	// Wait for all sub-agents to start.

--- a/agent/parallelagent/parallel_agent_test.go
+++ b/agent/parallelagent/parallel_agent_test.go
@@ -204,7 +204,13 @@ func TestParallelAgent_BranchInvoke(t *testing.T) {
 	)
 
 	subAgent := &mockAgent{name: "agent-1", eventCount: 1}
-	branchInvocation := parallelAgent.createBranchInvocation(subAgent, baseInvocation, "", nil)
+	branchInvocation := parallelAgent.createBranchInvocation(
+		subAgent,
+		baseInvocation,
+		"test-parallel/agent-1",
+		"surface/agent-1",
+		nil,
+	)
 
 	require.Equal(t, "test-parallel", baseInvocation.GetEventFilterKey())
 	// Verify branch has different ID.
@@ -212,6 +218,8 @@ func TestParallelAgent_BranchInvoke(t *testing.T) {
 	// Verify agent is set.
 	require.NotNil(t, branchInvocation.Agent)
 	require.Equal(t, subAgent.Info().Name, branchInvocation.Agent.Info().Name)
+	require.Equal(t, "test-parallel/agent-1", agent.InvocationTraceNodeID(branchInvocation))
+	require.Equal(t, "surface/agent-1", agent.InvocationSurfaceRootNodeID(branchInvocation))
 	require.Equal(t, "test-parallel/agent-1", branchInvocation.GetEventFilterKey())
 }
 

--- a/graph/state_graph.go
+++ b/graph/state_graph.go
@@ -3577,7 +3577,7 @@ func buildAgentInvocationWithStateScopeAndInputKey(
 		if traceNodeID := buildAgentNodeTraceNodeID(parentInvocation, nodeID); traceNodeID != "" {
 			invocationOpts = append(invocationOpts, agent.WithInvocationTraceNodeID(traceNodeID))
 		}
-		if surfaceRootNodeID := buildAgentNodeSurfaceRoot(parentInvocation, nodeID, targetAgent); surfaceRootNodeID != "" {
+		if surfaceRootNodeID := buildAgentNodeSurfaceRoot(parentInvocation, nodeID); surfaceRootNodeID != "" {
 			invocationOpts = append(invocationOpts, func(inv *agent.Invocation) {
 				agent.SetInvocationSurfaceRootNodeID(inv, surfaceRootNodeID)
 			})
@@ -3649,7 +3649,6 @@ func buildAgentNodeTraceNodeID(
 func buildAgentNodeSurfaceRoot(
 	parentInvocation *agent.Invocation,
 	nodeID string,
-	targetAgent agent.Agent,
 ) string {
 	if parentInvocation == nil {
 		return ""
@@ -3658,10 +3657,7 @@ func buildAgentNodeSurfaceRoot(
 	if nodeID != "" {
 		baseNodeID = istructure.JoinNodeID(baseNodeID, nodeID)
 	}
-	if targetAgent == nil || targetAgent.Info().Name == "" {
-		return baseNodeID
-	}
-	return istructure.JoinNodeID(baseNodeID, targetAgent.Info().Name)
+	return baseNodeID
 }
 
 const (

--- a/graph/state_graph_additional_test.go
+++ b/graph/state_graph_additional_test.go
@@ -3269,7 +3269,7 @@ func TestBuildAgentInvocationWithStateAndScope_PropagatesExecutionTraceMetadata(
 	require.Equal(t, "parent/delegate", agent.InvocationTraceNodeID(inv))
 	require.Equal(
 		t,
-		"parent/delegate/child",
+		"parent/delegate",
 		agent.InvocationSurfaceRootNodeID(inv),
 	)
 	require.Equal(t, []string{rootStepID}, agent.NextExecutionTracePredecessors(inv))
@@ -3301,7 +3301,7 @@ func TestBuildAgentInvocationWithStateAndScope_PreservesMountedSurfaceRoot(
 	require.Equal(t, "trace-parent/delegate", agent.InvocationTraceNodeID(inv))
 	require.Equal(
 		t,
-		"workflow/parent/delegate/child",
+		"workflow/parent/delegate",
 		agent.InvocationSurfaceRootNodeID(inv),
 	)
 }

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -7625,7 +7625,7 @@ func TestRunner_Run_WithSurfacePatchForNode_AppliesGraphChildAgentPatch(
 		t,
 		snapshot,
 		"researcher",
-		structure.NodeKindLLM,
+		structure.NodeKindAgent,
 	)
 	var patch agent.SurfacePatch
 	patch.SetInstruction("child patched instruction")
@@ -7652,6 +7652,222 @@ func TestRunner_Run_WithSurfacePatchForNode_AppliesGraphChildAgentPatch(
 		firstSystemMessageContent(childPatched.LatestRequest().messages),
 		"child patched instruction",
 	)
+}
+
+func TestRunner_Run_WithSurfacePatchForNode_AppliesNestedGraphChildLLMPatch(
+	t *testing.T,
+) {
+	childStatic := &scriptedSurfaceModel{
+		name:      "nested-graph-child-static",
+		responses: []model.Message{model.NewAssistantMessage("child static")},
+	}
+	childPatched := &scriptedSurfaceModel{
+		name:      "nested-graph-child-patched",
+		responses: []model.Message{model.NewAssistantMessage("child patched")},
+	}
+	childCompiled := graph.NewStateGraph(graph.MessagesStateSchema()).
+		AddLLMNode(
+			"plan",
+			childStatic,
+			"nested child static instruction",
+			nil,
+		).
+		SetEntryPoint("plan").
+		SetFinishPoint("plan").
+		MustCompile()
+	child, err := graphagent.New("research_flow", childCompiled)
+	require.NoError(t, err)
+	parentCompiled := graph.NewStateGraph(graph.MessagesStateSchema()).
+		AddAgentNode("research_flow").
+		SetEntryPoint("research_flow").
+		SetFinishPoint("research_flow").
+		MustCompile()
+	parent, err := graphagent.New(
+		"assistant",
+		parentCompiled,
+		graphagent.WithSubAgents([]agent.Agent{child}),
+	)
+	require.NoError(t, err)
+	snapshot := mustExportSnapshot(t, parent)
+	planNodeID := requireNodeIDByNameAndKind(
+		t,
+		snapshot,
+		"plan",
+		structure.NodeKindLLM,
+	)
+	require.Equal(t, "assistant/research_flow/plan", planNodeID)
+	var patch agent.SurfacePatch
+	patch.SetInstruction("nested child patched instruction")
+	patch.SetModel(childPatched)
+	r := NewRunner(
+		"app",
+		parent,
+		WithSessionService(sessioninmemory.NewSessionService()),
+	)
+	eventCh, err := r.Run(
+		context.Background(),
+		"user-nested-graph-child",
+		"session-nested-graph-child",
+		model.NewUserMessage("nested graph child input"),
+		agent.WithSurfacePatchForNode(planNodeID, patch),
+	)
+	require.NoError(t, err)
+	completion := collectRunnerCompletionEvent(t, eventCh)
+	require.NotNil(t, completion.Response)
+	require.Zero(t, childStatic.RequestCount())
+	require.Equal(t, 1, childPatched.RequestCount())
+	system := firstSystemMessageContent(childPatched.LatestRequest().messages)
+	require.Contains(t, system, "nested child patched instruction")
+	require.NotContains(t, system, "nested child static instruction")
+}
+
+func TestRunner_Run_WithSurfacePatchForNode_AppliesNestedGraphAgentNodePatch(
+	t *testing.T,
+) {
+	reviewerStatic := &scriptedSurfaceModel{
+		name:      "nested-agent-node-static",
+		responses: []model.Message{model.NewAssistantMessage("reviewer static")},
+	}
+	reviewerPatched := &scriptedSurfaceModel{
+		name:      "nested-agent-node-patched",
+		responses: []model.Message{model.NewAssistantMessage("reviewer patched")},
+	}
+	reviewer := llmagent.New(
+		"reviewer",
+		llmagent.WithModel(reviewerStatic),
+		llmagent.WithInstruction("nested reviewer static instruction"),
+	)
+	childCompiled := graph.NewStateGraph(graph.MessagesStateSchema()).
+		AddAgentNode("reviewer").
+		SetEntryPoint("reviewer").
+		SetFinishPoint("reviewer").
+		MustCompile()
+	child, err := graphagent.New(
+		"research_flow",
+		childCompiled,
+		graphagent.WithSubAgents([]agent.Agent{reviewer}),
+	)
+	require.NoError(t, err)
+	parentCompiled := graph.NewStateGraph(graph.MessagesStateSchema()).
+		AddAgentNode("research_flow").
+		SetEntryPoint("research_flow").
+		SetFinishPoint("research_flow").
+		MustCompile()
+	parent, err := graphagent.New(
+		"assistant",
+		parentCompiled,
+		graphagent.WithSubAgents([]agent.Agent{child}),
+	)
+	require.NoError(t, err)
+	snapshot := mustExportSnapshot(t, parent)
+	reviewerNodeID := requireNodeIDByNameAndKind(
+		t,
+		snapshot,
+		"reviewer",
+		structure.NodeKindAgent,
+	)
+	require.Equal(t, "assistant/research_flow/reviewer", reviewerNodeID)
+	var patch agent.SurfacePatch
+	patch.SetInstruction("nested reviewer patched instruction")
+	patch.SetModel(reviewerPatched)
+	r := NewRunner(
+		"app",
+		parent,
+		WithSessionService(sessioninmemory.NewSessionService()),
+	)
+	eventCh, err := r.Run(
+		context.Background(),
+		"user-nested-agent-node",
+		"session-nested-agent-node",
+		model.NewUserMessage("nested agent node input"),
+		agent.WithSurfacePatchForNode(reviewerNodeID, patch),
+	)
+	require.NoError(t, err)
+	completion := collectRunnerCompletionEvent(t, eventCh)
+	require.NotNil(t, completion.Response)
+	require.Zero(t, reviewerStatic.RequestCount())
+	require.Equal(t, 1, reviewerPatched.RequestCount())
+	system := firstSystemMessageContent(reviewerPatched.LatestRequest().messages)
+	require.Contains(t, system, "nested reviewer patched instruction")
+	require.NotContains(t, system, "nested reviewer static instruction")
+}
+
+func TestRunner_Run_WithSurfacePatchForNode_AppliesGraphCompositeChildPatch(
+	t *testing.T,
+) {
+	plannerStatic := &scriptedSurfaceModel{
+		name:      "graph-composite-planner-static",
+		responses: []model.Message{model.NewAssistantMessage("planner static")},
+	}
+	plannerPatched := &scriptedSurfaceModel{
+		name:      "graph-composite-planner-patched",
+		responses: []model.Message{model.NewAssistantMessage("planner patched")},
+	}
+	writerStatic := &scriptedSurfaceModel{
+		name:      "graph-composite-writer-static",
+		responses: []model.Message{model.NewAssistantMessage("writer static")},
+	}
+	pipeline := chainagent.New(
+		"pipeline",
+		chainagent.WithSubAgents([]agent.Agent{
+			llmagent.New(
+				"planner",
+				llmagent.WithModel(plannerStatic),
+				llmagent.WithInstruction("planner static instruction"),
+			),
+			llmagent.New(
+				"writer",
+				llmagent.WithModel(writerStatic),
+				llmagent.WithInstruction("writer static instruction"),
+			),
+		}),
+	)
+	parentCompiled := graph.NewStateGraph(graph.MessagesStateSchema()).
+		AddAgentNode("pipeline").
+		SetEntryPoint("pipeline").
+		SetFinishPoint("pipeline").
+		MustCompile()
+	parent, err := graphagent.New(
+		"assistant",
+		parentCompiled,
+		graphagent.WithSubAgents([]agent.Agent{pipeline}),
+	)
+	require.NoError(t, err)
+	snapshot := mustExportSnapshot(t, parent)
+	plannerNodeID := requireNodeIDByNameAndKind(
+		t,
+		snapshot,
+		"planner",
+		structure.NodeKindLLM,
+	)
+	require.Equal(t, "assistant/pipeline/planner", plannerNodeID)
+	var patch agent.SurfacePatch
+	patch.SetInstruction("planner patched instruction")
+	patch.SetModel(plannerPatched)
+	r := NewRunner(
+		"app",
+		parent,
+		WithSessionService(sessioninmemory.NewSessionService()),
+	)
+	eventCh, err := r.Run(
+		context.Background(),
+		"user-graph-composite",
+		"session-graph-composite",
+		model.NewUserMessage("graph composite input"),
+		agent.WithSurfacePatchForNode(plannerNodeID, patch),
+	)
+	require.NoError(t, err)
+	completion := collectRunnerCompletionEvent(t, eventCh)
+	require.NotNil(t, completion.Response)
+	require.Zero(t, plannerStatic.RequestCount())
+	require.Equal(t, 1, plannerPatched.RequestCount())
+	require.Equal(t, 1, writerStatic.RequestCount())
+	plannerSystem := firstSystemMessageContent(plannerPatched.LatestRequest().messages)
+	require.Contains(t, plannerSystem, "planner patched instruction")
+	require.NotContains(t, plannerSystem, "planner static instruction")
+	writerSystem := firstSystemMessageContent(writerStatic.LatestRequest().messages)
+	require.Contains(t, writerSystem, "writer static instruction")
+	require.NotContains(t, writerSystem, "planner patched instruction")
 }
 
 func TestRunner_GraphChildAgentNode_PersistedRunnerCompletionDoesNotReplayIntoNextTurnHistory(


### PR DESCRIPTION
This change mounts GraphAgent child root surfaces directly on their AgentNode paths, updates child invocation surface roots to match exported node IDs, and propagates mounted surface roots through chain, parallel, and cycle agents so nested surface patches resolve consistently.