### PR TITLE
agent: preserve custom state in invocation views

### DIFF
--- a/agent/invocation.go
+++ b/agent/invocation.go
@@ -10,10 +10,13 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"math/big"
 	"reflect"
+	"strings"
 	"sync"
 	"time"
 
@@ -1230,7 +1233,7 @@ func (inv *Invocation) View(invocationOpts ...InvocationOptions) *Invocation {
 			inv.entryPredecessorStepIDs,
 		),
 		traceNodeID:        inv.traceNodeID,
-		state:              inv.cloneState(),
+		state:              inv.cloneViewState(),
 		MaxLLMCalls:        inv.MaxLLMCalls,
 		MaxToolIterations:  inv.MaxToolIterations,
 		timingInfo:         inv.timingInfo,
@@ -1278,36 +1281,321 @@ func (inv *Invocation) SyncView(view *Invocation) {
 	inv.llmCallCount = view.llmCallCount
 	inv.toolIterationCount = view.toolIterationCount
 	inv.stateMu.Lock()
-	inv.state = view.cloneState()
+	inv.state = view.cloneViewState()
 	inv.stateMu.Unlock()
 }
 
 func (inv *Invocation) cloneState() map[string]any {
-	if inv == nil || inv.state == nil {
+	return inv.cloneStateByFilter(isCloneStateKey, keepStateValue)
+}
+
+func (inv *Invocation) cloneViewState() map[string]any {
+	return inv.cloneStateByFilter(includeAllStateKeys, cloneViewStateValue)
+}
+
+func (inv *Invocation) cloneStateByFilter(
+	include func(string) bool,
+	cloneValue func(string, any) any,
+) map[string]any {
+	if inv == nil {
 		return nil
 	}
 	inv.stateMu.RLock()
 	defer inv.stateMu.RUnlock()
-	copied := make(map[string]any)
-	if holder, ok := inv.state[flusherStateKey]; ok {
-		copied[flusherStateKey] = holder
+	if inv.state == nil {
+		return nil
 	}
-	if barrier, ok := inv.state[barrierStateKey]; ok {
-		copied[barrierStateKey] = barrier
-	}
-	if holder, ok := inv.state[appenderStateKey]; ok {
-		copied[appenderStateKey] = holder
-	}
-	if hub, ok := inv.state[streamHubStateKey]; ok {
-		copied[streamHubStateKey] = hub
-	}
-	if nodeID, ok := inv.state[surfaceRootNodeIDStateKey]; ok {
-		copied[surfaceRootNodeIDStateKey] = nodeID
-	}
-	if rootNodeID, ok := inv.state[teamMemberTraceRootStateKey]; ok {
-		copied[teamMemberTraceRootStateKey] = rootNodeID
+	copied := make(map[string]any, len(inv.state))
+	for key, value := range inv.state {
+		if !include(key) {
+			continue
+		}
+		copied[key] = cloneValue(key, value)
 	}
 	return copied
+}
+
+func includeAllStateKeys(string) bool {
+	return true
+}
+
+func keepStateValue(_ string, value any) any {
+	return value
+}
+
+func cloneViewStateValue(key string, value any) any {
+	if isCloneStateKey(key) {
+		return value
+	}
+	return cloneStateValue(value)
+}
+
+func isCloneStateKey(key string) bool {
+	switch key {
+	case flusherStateKey,
+		barrierStateKey,
+		appenderStateKey,
+		streamHubStateKey,
+		surfaceRootNodeIDStateKey,
+		teamMemberTraceRootStateKey:
+		return true
+	default:
+		return false
+	}
+}
+
+// cloneStateValue isolates common mutable custom state for invocation views.
+// Known mutable types such as bytes.Buffer, strings.Builder, and big.Int are
+// copied explicitly. Maps, slices, pointers, arrays, and fully exported
+// structs are cloned recursively. Opaque structs with unexported fields are
+// kept by reference to avoid unsafe copies of no-copy state such as locks.
+func cloneStateValue(value any) any {
+	if value == nil {
+		return nil
+	}
+	cloned, ok := cloneStateReflectValue(
+		reflect.ValueOf(value),
+		map[reflectVisit]reflect.Value{},
+	)
+	if !ok {
+		return value
+	}
+	return cloned.Interface()
+}
+
+type reflectVisit struct {
+	typ      reflect.Type
+	ptr      uintptr
+	length   int
+	capacity int
+}
+
+func cloneStateReflectValue(
+	value reflect.Value,
+	visited map[reflectVisit]reflect.Value,
+) (reflect.Value, bool) {
+	if value.IsValid() && value.CanInterface() {
+		if cloned, ok := cloneKnownStateValue(value.Interface()); ok {
+			return reflect.ValueOf(cloned), true
+		}
+	}
+	switch value.Kind() {
+	case reflect.Interface:
+		if value.IsNil() {
+			return value, true
+		}
+		return cloneStateReflectValue(value.Elem(), visited)
+	case reflect.Pointer:
+		return cloneStatePointerValue(value, visited)
+	case reflect.Map:
+		return cloneStateMapValue(value, visited)
+	case reflect.Slice:
+		return cloneStateSliceValue(value, visited)
+	case reflect.Array:
+		return cloneStateArrayValue(value, visited)
+	case reflect.Struct:
+		return cloneStateStructValue(value, visited)
+	default:
+		return value, true
+	}
+}
+
+func cloneKnownStateValue(value any) (any, bool) {
+	switch v := value.(type) {
+	case *bytes.Buffer:
+		if v == nil {
+			return v, true
+		}
+		return bytes.NewBuffer(cloneBytes(v.Bytes())), true
+	case bytes.Buffer:
+		return *bytes.NewBuffer(cloneBytes(v.Bytes())), true
+	case *strings.Builder:
+		if v == nil {
+			return v, true
+		}
+		var cloned strings.Builder
+		_, _ = cloned.WriteString(v.String())
+		return &cloned, true
+	case *big.Int:
+		if v == nil {
+			return v, true
+		}
+		return new(big.Int).Set(v), true
+	case big.Int:
+		return *new(big.Int).Set(&v), true
+	default:
+		return nil, false
+	}
+}
+
+func cloneBytes(value []byte) []byte {
+	if value == nil {
+		return nil
+	}
+	cloned := make([]byte, len(value))
+	copy(cloned, value)
+	return cloned
+}
+
+func cloneStatePointerValue(
+	value reflect.Value,
+	visited map[reflectVisit]reflect.Value,
+) (reflect.Value, bool) {
+	if value.IsNil() {
+		return value, true
+	}
+	visit := reflectVisit{
+		typ: value.Type(),
+		ptr: value.Pointer(),
+	}
+	if cloned, ok := visited[visit]; ok {
+		return cloned, true
+	}
+	cloned := reflect.New(value.Type().Elem())
+	visited[visit] = cloned
+	elem, ok := cloneStateReflectValue(value.Elem(), visited)
+	if !ok {
+		delete(visited, visit)
+		return value, false
+	}
+	if elem.Type().AssignableTo(cloned.Elem().Type()) {
+		cloned.Elem().Set(elem)
+		return cloneStateAsType(cloned, value.Type())
+	}
+	if elem.Type().ConvertibleTo(cloned.Elem().Type()) {
+		cloned.Elem().Set(elem.Convert(cloned.Elem().Type()))
+		return cloneStateAsType(cloned, value.Type())
+	}
+	return value, false
+}
+
+func cloneStateAsType(
+	value reflect.Value,
+	typ reflect.Type,
+) (reflect.Value, bool) {
+	if value.Type().AssignableTo(typ) {
+		return value, true
+	}
+	if value.Type().ConvertibleTo(typ) {
+		return value.Convert(typ), true
+	}
+	return value, false
+}
+
+func cloneStateMapValue(
+	value reflect.Value,
+	visited map[reflectVisit]reflect.Value,
+) (reflect.Value, bool) {
+	if value.IsNil() {
+		return value, true
+	}
+	visit := reflectVisit{
+		typ: value.Type(),
+		ptr: value.Pointer(),
+	}
+	if cloned, ok := visited[visit]; ok {
+		return cloned, true
+	}
+	cloned := reflect.MakeMapWithSize(value.Type(), value.Len())
+	visited[visit] = cloned
+	iter := value.MapRange()
+	for iter.Next() {
+		// Keep keys unchanged; cloning pointer keys changes lookup identity.
+		cloned.SetMapIndex(
+			iter.Key(),
+			cloneStateElement(iter.Value(), value.Type().Elem(), visited),
+		)
+	}
+	return cloned, true
+}
+
+func cloneStateElement(
+	value reflect.Value,
+	elemType reflect.Type,
+	visited map[reflectVisit]reflect.Value,
+) reflect.Value {
+	cloned, ok := cloneStateReflectValue(value, visited)
+	if !ok {
+		return value
+	}
+	if cloned.Type().AssignableTo(elemType) {
+		return cloned
+	}
+	if cloned.Type().ConvertibleTo(elemType) {
+		return cloned.Convert(elemType)
+	}
+	return value
+}
+
+func cloneStateSliceValue(
+	value reflect.Value,
+	visited map[reflectVisit]reflect.Value,
+) (reflect.Value, bool) {
+	if value.IsNil() {
+		return value, true
+	}
+	visit := reflectVisit{
+		typ:      value.Type(),
+		ptr:      value.Pointer(),
+		length:   value.Len(),
+		capacity: value.Cap(),
+	}
+	if cloned, ok := visited[visit]; ok {
+		return cloned, true
+	}
+	cloned := reflect.MakeSlice(value.Type(), value.Len(), value.Len())
+	visited[visit] = cloned
+	for i := 0; i < value.Len(); i++ {
+		cloned.Index(i).Set(
+			cloneStateElement(
+				value.Index(i),
+				value.Type().Elem(),
+				visited,
+			),
+		)
+	}
+	return cloned, true
+}
+
+func cloneStateArrayValue(
+	value reflect.Value,
+	visited map[reflectVisit]reflect.Value,
+) (reflect.Value, bool) {
+	cloned := reflect.New(value.Type()).Elem()
+	for i := 0; i < value.Len(); i++ {
+		cloned.Index(i).Set(
+			cloneStateElement(
+				value.Index(i),
+				value.Type().Elem(),
+				visited,
+			),
+		)
+	}
+	return cloned, true
+}
+
+func cloneStateStructValue(
+	value reflect.Value,
+	visited map[reflectVisit]reflect.Value,
+) (reflect.Value, bool) {
+	for i := 0; i < value.NumField(); i++ {
+		if value.Type().Field(i).PkgPath != "" {
+			// Opaque structs may carry no-copy state such as locks.
+			return value, false
+		}
+	}
+	cloned := reflect.New(value.Type()).Elem()
+	for i := 0; i < value.NumField(); i++ {
+		target := cloned.Field(i)
+		target.Set(
+			cloneStateElement(
+				value.Field(i),
+				target.Type(),
+				visited,
+			),
+		)
+	}
+	return cloned, true
 }
 
 // GetEventFilterKey get event filter key.

--- a/agent/invocation_test.go
+++ b/agent/invocation_test.go
@@ -10,8 +10,11 @@
 package agent
 
 import (
+	"bytes"
 	"context"
+	"math/big"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -578,6 +581,224 @@ func TestInvocation_cloneState(t *testing.T) {
 		require.NotNil(t, cloned[streamHubStateKey])
 		assert.NotContains(t, cloned, "other")
 	})
+}
+
+func TestInvocation_ViewCopiesCustomState(t *testing.T) {
+	const (
+		customStateKey   = "custom:payload"
+		customStateValue = "business-data"
+		updatedValue     = "updated-data"
+	)
+	inv := NewInvocation()
+	inv.SetState(customStateKey, customStateValue)
+
+	view := inv.View()
+	value, ok := view.GetState(customStateKey)
+	require.True(t, ok)
+	require.Equal(t, customStateValue, value)
+
+	view.SetState(customStateKey, updatedValue)
+	value, ok = inv.GetState(customStateKey)
+	require.True(t, ok)
+	require.Equal(t, customStateValue, value)
+}
+
+func TestInvocation_ViewCopiesMutableCustomState(t *testing.T) {
+	const customStateKey = "custom:payload"
+	inv := NewInvocation()
+	inv.SetState(customStateKey, []byte("abc"))
+
+	view := inv.View()
+	value, ok := view.GetState(customStateKey)
+	require.True(t, ok)
+	viewValue, ok := value.([]byte)
+	require.True(t, ok)
+	viewValue[0] = 'z'
+
+	sourceValue, ok := inv.GetState(customStateKey)
+	require.True(t, ok)
+	require.Equal(t, []byte("abc"), sourceValue)
+}
+
+func TestInvocation_ViewCopiesNestedMutableCustomState(t *testing.T) {
+	const (
+		customMapStateKey   = "custom:map_payload"
+		customPtrStateKey   = "custom:ptr_payload"
+		customCycleStateKey = "custom:cycle_payload"
+	)
+	type customPayload struct {
+		Data []byte
+	}
+	type customNode struct {
+		Data []byte
+		Next *customNode
+	}
+	node := &customNode{Data: []byte("ghi")}
+	node.Next = node
+	inv := NewInvocation()
+	inv.SetState(customMapStateKey, map[string][]byte{
+		"nested": []byte("abc"),
+	})
+	inv.SetState(customPtrStateKey, &customPayload{
+		Data: []byte("def"),
+	})
+	inv.SetState(customCycleStateKey, node)
+
+	view := inv.View()
+	value, ok := view.GetState(customMapStateKey)
+	require.True(t, ok)
+	viewValue, ok := value.(map[string][]byte)
+	require.True(t, ok)
+	viewValue["nested"][0] = 'z'
+	ptrValue, ok := view.GetState(customPtrStateKey)
+	require.True(t, ok)
+	viewPtr, ok := ptrValue.(*customPayload)
+	require.True(t, ok)
+	viewPtr.Data[0] = 'z'
+	cycleValue, ok := view.GetState(customCycleStateKey)
+	require.True(t, ok)
+	viewNode, ok := cycleValue.(*customNode)
+	require.True(t, ok)
+	require.Same(t, viewNode, viewNode.Next)
+	viewNode.Data[0] = 'z'
+
+	sourceValue, ok := inv.GetState(customMapStateKey)
+	require.True(t, ok)
+	sourceMap, ok := sourceValue.(map[string][]byte)
+	require.True(t, ok)
+	require.Equal(t, []byte("abc"), sourceMap["nested"])
+	sourceValue, ok = inv.GetState(customPtrStateKey)
+	require.True(t, ok)
+	sourcePtr, ok := sourceValue.(*customPayload)
+	require.True(t, ok)
+	require.Equal(t, []byte("def"), sourcePtr.Data)
+	sourceValue, ok = inv.GetState(customCycleStateKey)
+	require.True(t, ok)
+	sourceNode, ok := sourceValue.(*customNode)
+	require.True(t, ok)
+	require.Equal(t, []byte("ghi"), sourceNode.Data)
+}
+
+func TestCloneStateValueHandlesEdgeCases(t *testing.T) {
+	type namedString string
+	type customPayload struct {
+		Data []byte
+	}
+	type opaquePayload struct {
+		Data   []byte
+		hidden int
+	}
+	type sharedSlices struct {
+		Short []byte
+		Long  []byte
+	}
+
+	require.Nil(t, cloneStateValue(nil))
+	var nilSlice []byte
+	require.Nil(t, cloneStateValue(nilSlice).([]byte))
+	var nilMap map[string][]byte
+	require.Nil(t, cloneStateValue(nilMap).(map[string][]byte))
+	var nilPtr *customPayload
+	require.Nil(t, cloneStateValue(nilPtr).(*customPayload))
+
+	arr := [1][]byte{[]byte("abc")}
+	clonedArr := cloneStateValue(arr).([1][]byte)
+	clonedArr[0][0] = 'z'
+	require.Equal(t, []byte("abc"), arr[0])
+
+	const (
+		sharedShortData = "ab"
+		sharedLongData  = "abcd"
+	)
+	base := []byte(sharedLongData)
+	shared := sharedSlices{
+		Short: base[:len(sharedShortData)],
+		Long:  base,
+	}
+	clonedShared := cloneStateValue(shared).(sharedSlices)
+	require.Equal(t, []byte(sharedShortData), clonedShared.Short)
+	require.Equal(t, []byte(sharedLongData), clonedShared.Long)
+	clonedShared.Long[0] = 'z'
+	require.Equal(t, []byte(sharedLongData), base)
+	require.Equal(t, []byte(sharedShortData), clonedShared.Short)
+
+	var iface any = []byte("abc")
+	clonedValue, ok := cloneStateReflectValue(
+		reflect.ValueOf(&iface).Elem(),
+		map[reflectVisit]reflect.Value{},
+	)
+	require.True(t, ok)
+	clonedBytes := clonedValue.Interface().([]byte)
+	clonedBytes[0] = 'z'
+	require.Equal(t, []byte("abc"), iface)
+
+	var nilIface any
+	clonedValue, ok = cloneStateReflectValue(
+		reflect.ValueOf(&nilIface).Elem(),
+		map[reflectVisit]reflect.Value{},
+	)
+	require.True(t, ok)
+	require.True(t, clonedValue.IsNil())
+
+	opaque := &opaquePayload{Data: []byte("abc"), hidden: 1}
+	require.Same(t, opaque, cloneStateValue(opaque))
+	opaqueMap := map[string]*opaquePayload{"opaque": opaque}
+	clonedMap := cloneStateValue(opaqueMap).(map[string]*opaquePayload)
+	require.Same(t, opaque, clonedMap["opaque"])
+
+	buffer := bytes.NewBufferString("abc")
+	clonedBuffer := cloneStateValue(buffer).(*bytes.Buffer)
+	clonedBuffer.WriteString("d")
+	require.Equal(t, "abc", buffer.String())
+	bufferValue := *bytes.NewBufferString("efg")
+	clonedBufferValue := cloneStateValue(bufferValue).(bytes.Buffer)
+	clonedBufferValue.WriteString("h")
+	require.Equal(t, "efg", bufferValue.String())
+
+	var builder strings.Builder
+	builder.WriteString("abc")
+	clonedBuilder := cloneStateValue(&builder).(*strings.Builder)
+	clonedBuilder.WriteString("d")
+	require.Equal(t, "abc", builder.String())
+
+	bigValue := big.NewInt(10)
+	clonedBig := cloneStateValue(bigValue).(*big.Int)
+	clonedBig.Add(clonedBig, big.NewInt(1))
+	require.Equal(t, int64(10), bigValue.Int64())
+
+	clonedValue, ok = cloneStateAsType(
+		reflect.ValueOf("named"),
+		reflect.TypeOf(namedString("")),
+	)
+	require.True(t, ok)
+	require.Equal(t, namedString("named"), clonedValue.Interface())
+	_, ok = cloneStateAsType(
+		reflect.ValueOf(struct{}{}),
+		reflect.TypeOf([]byte{}),
+	)
+	require.False(t, ok)
+	element := cloneStateElement(
+		reflect.ValueOf("named"),
+		reflect.TypeOf(namedString("")),
+		map[reflectVisit]reflect.Value{},
+	)
+	require.Equal(t, namedString("named"), element.Interface())
+}
+
+func TestInvocation_SyncViewCopiesCustomState(t *testing.T) {
+	const (
+		customStateKey   = "custom:payload"
+		customStateValue = "business-data"
+	)
+	inv := NewInvocation()
+	view := inv.View()
+	view.SetState(customStateKey, customStateValue)
+
+	inv.SyncView(view)
+
+	value, ok := inv.GetState(customStateKey)
+	require.True(t, ok)
+	require.Equal(t, customStateValue, value)
 }
 
 func TestInvocation_GetEventFilterKey(t *testing.T) {

--- a/internal/flow/processor/functioncall.go
+++ b/internal/flow/processor/functioncall.go
@@ -10,6 +10,7 @@
 package processor
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -71,12 +72,15 @@ type innerTextModePreference interface {
 }
 
 type toolEventStateDelta struct {
-	tool   tool.Tool
-	args   []byte
-	choice model.Choice
+	tool            tool.Tool
+	invocation      *agent.Invocation
+	sessionBaseline session.StateMap
+	args            []byte
+	choice          model.Choice
 }
 
 type resolvedToolContextKey struct{}
+type stateDeltaSessionBaselineContextKey struct{}
 
 // toolResult holds the result of a single tool execution.
 type toolResult struct {
@@ -456,6 +460,7 @@ func (p *FunctionCallResponseProcessor) executeSingleToolCallSequentialResult(
 	if err == nil {
 		stateDelta = p.buildToolEventStateDelta(
 			ctx,
+			invocation,
 			modifiedArgs,
 			choices,
 		)
@@ -513,8 +518,16 @@ func (p *FunctionCallResponseProcessor) executeToolCallsInParallel(
 	for i, tc := range toolCalls {
 		wg.Add(1)
 		runCtx := agent.CloneContext(ctx)
+		runInv := invocation
+		if invocation != nil {
+			runInv = newParallelInvocationView(invocation)
+			if runCtx == nil {
+				runCtx = context.Background()
+			}
+			runCtx = agent.NewInvocationContext(runCtx, runInv)
+		}
 		go p.runParallelToolCall(
-			runCtx, &wg, invocation, llmResponse, tools, eventChan, resultChan, i, tc,
+			runCtx, &wg, runInv, llmResponse, tools, eventChan, resultChan, i, tc,
 		)
 	}
 
@@ -671,6 +684,7 @@ func (p *FunctionCallResponseProcessor) runParallelToolCall(
 	}
 	stateDelta := p.buildToolEventStateDelta(
 		ctx,
+		invocation,
 		modifiedArgs,
 		choices,
 	)
@@ -819,6 +833,7 @@ func (p *FunctionCallResponseProcessor) annotateSkipSummarization(
 
 func (p *FunctionCallResponseProcessor) buildToolEventStateDelta(
 	ctx context.Context,
+	invocation *agent.Invocation,
 	args []byte,
 	choices []model.Choice,
 ) *toolEventStateDelta {
@@ -829,10 +844,128 @@ func (p *FunctionCallResponseProcessor) buildToolEventStateDelta(
 	if !ok {
 		return nil
 	}
+	stateDeltaInv := newStateDeltaSnapshot(ctx, invocation)
 	return &toolEventStateDelta{
-		tool:   tl,
-		args:   args,
-		choice: choices[0],
+		tool:            tl,
+		invocation:      stateDeltaInv,
+		sessionBaseline: stateDeltaSessionBaseline(ctx),
+		args:            args,
+		choice:          choices[0],
+	}
+}
+
+func newStateDeltaSnapshot(
+	ctx context.Context,
+	invocation *agent.Invocation,
+) *agent.Invocation {
+	if ctx == nil {
+		return cloneStateDeltaSession(invocationView(invocation))
+	}
+	ctxInv, hasCtxInv := agent.InvocationFromContext(ctx)
+	if !hasCtxInv || ctxInv == nil {
+		return cloneStateDeltaSession(invocationView(invocation))
+	}
+	if invocation == nil || ctxInv == invocation {
+		return cloneStateDeltaSession(invocationView(ctxInv))
+	}
+	view := ctxInv.View()
+	preserveStateDeltaInvocationDefaults(view, invocation)
+	return cloneStateDeltaSession(view)
+}
+
+func newParallelInvocationView(
+	invocation *agent.Invocation,
+) *agent.Invocation {
+	return cloneStateDeltaSession(invocationView(invocation))
+}
+
+func invocationView(invocation *agent.Invocation) *agent.Invocation {
+	if invocation == nil {
+		return nil
+	}
+	return invocation.View()
+}
+
+func cloneStateDeltaSession(invocation *agent.Invocation) *agent.Invocation {
+	if invocation != nil && invocation.Session != nil {
+		invocation.Session = invocation.Session.Clone()
+	}
+	return invocation
+}
+
+func withStateDeltaSessionBaseline(
+	ctx context.Context,
+	invocation *agent.Invocation,
+) context.Context {
+	if ctx == nil {
+		return nil
+	}
+	var baseline session.StateMap
+	baselineSession := stateDeltaBaselineSession(ctx, invocation)
+	if baselineSession != nil {
+		baseline = baselineSession.SnapshotState()
+	}
+	return context.WithValue(
+		ctx,
+		stateDeltaSessionBaselineContextKey{},
+		baseline,
+	)
+}
+
+func stateDeltaBaselineSession(
+	ctx context.Context,
+	invocation *agent.Invocation,
+) *session.Session {
+	if ctx != nil {
+		if ctxInv, ok := agent.InvocationFromContext(ctx); ok &&
+			ctxInv != nil &&
+			ctxInv.Session != nil {
+			return ctxInv.Session
+		}
+	}
+	if invocation == nil {
+		return nil
+	}
+	return invocation.Session
+}
+
+func stateDeltaSessionBaseline(ctx context.Context) session.StateMap {
+	if ctx == nil {
+		return nil
+	}
+	baseline, _ := ctx.Value(
+		stateDeltaSessionBaselineContextKey{},
+	).(session.StateMap)
+	return baseline
+}
+
+func preserveStateDeltaInvocationDefaults(
+	view *agent.Invocation,
+	base *agent.Invocation,
+) {
+	if view == nil || base == nil {
+		return
+	}
+	view.Agent = base.Agent
+	view.AgentName = base.AgentName
+	view.InvocationID = base.InvocationID
+	view.Branch = base.Branch
+	view.Model = base.Model
+	view.Message = base.Message
+	view.RunOptions = base.RunOptions
+	view.TransferInfo = base.TransferInfo
+	view.Plugins = base.Plugins
+	view.StructuredOutput = base.StructuredOutput
+	view.StructuredOutputType = base.StructuredOutputType
+	view.MemoryService = base.MemoryService
+	view.ArtifactService = base.ArtifactService
+	view.MaxLLMCalls = base.MaxLLMCalls
+	view.MaxToolIterations = base.MaxToolIterations
+	if view.Session == nil {
+		view.Session = base.Session
+	}
+	if view.SessionService == nil {
+		view.SessionService = base.SessionService
 	}
 }
 
@@ -871,10 +1004,7 @@ func (p *FunctionCallResponseProcessor) attachStateDeltaToToolResults(
 	invocation *agent.Invocation,
 	results []toolResult,
 ) []*event.Event {
-	var (
-		stateDeltaInv     *agent.Invocation
-		pendingStateDelta []*event.Event
-	)
+	var priorStateDelta []*event.Event
 	events := make([]*event.Event, 0, len(results))
 	for i := 0; i < len(results); i++ {
 		result := results[i]
@@ -882,15 +1012,16 @@ func (p *FunctionCallResponseProcessor) attachStateDeltaToToolResults(
 			continue
 		}
 		if result.stateDelta != nil {
-			if stateDeltaInv == nil {
-				stateDeltaInv = newStateDeltaInvocationView(invocation)
-				if stateDeltaInv != nil && stateDeltaInv.Session != nil {
-					for j := 0; j < len(pendingStateDelta); j++ {
-						stateDeltaInv.Session.ApplyEventStateDelta(
-							pendingStateDelta[j],
-						)
-					}
-				}
+			stateDeltaInv := stateDeltaInvocationView(
+				invocation,
+				result.stateDelta,
+			)
+			if stateDeltaInv != nil && stateDeltaInv.Session != nil {
+				applyPriorStateDeltas(
+					stateDeltaInv.Session,
+					result.stateDelta.sessionBaseline,
+					priorStateDelta,
+				)
 			}
 			p.attachStateDelta(
 				stateDeltaInv,
@@ -900,19 +1031,74 @@ func (p *FunctionCallResponseProcessor) attachStateDeltaToToolResults(
 				result.event,
 			)
 		}
-		if stateDeltaInv != nil &&
-			stateDeltaInv.Session != nil &&
-			len(result.event.StateDelta) > 0 {
-			stateDeltaInv.Session.ApplyEventStateDelta(result.event)
-		} else if len(result.event.StateDelta) > 0 {
-			pendingStateDelta = append(
-				pendingStateDelta,
+		if len(result.event.StateDelta) > 0 {
+			priorStateDelta = append(
+				priorStateDelta,
 				result.event,
 			)
 		}
 		events = append(events, result.event)
 	}
 	return events
+}
+
+func applyPriorStateDeltas(
+	sess *session.Session,
+	baseline session.StateMap,
+	events []*event.Event,
+) {
+	if sess == nil || len(events) == 0 {
+		return
+	}
+	changed := changedSessionKeys(baseline, sess.SnapshotState())
+	for i := 0; i < len(events); i++ {
+		applyReplayableStateDelta(sess, changed, events[i])
+	}
+}
+
+func changedSessionKeys(
+	baseline session.StateMap,
+	current session.StateMap,
+) map[string]bool {
+	changed := map[string]bool{}
+	for key, currentValue := range current {
+		baselineValue, ok := baseline[key]
+		if !ok || !bytes.Equal(currentValue, baselineValue) {
+			changed[key] = true
+		}
+	}
+	for key := range baseline {
+		if _, ok := current[key]; !ok {
+			changed[key] = true
+		}
+	}
+	return changed
+}
+
+func applyReplayableStateDelta(
+	sess *session.Session,
+	changed map[string]bool,
+	e *event.Event,
+) {
+	if e == nil {
+		return
+	}
+	for key, value := range e.StateDelta {
+		if changed[key] {
+			continue
+		}
+		sess.SetState(key, value)
+	}
+}
+
+func stateDeltaInvocationView(
+	invocation *agent.Invocation,
+	stateDelta *toolEventStateDelta,
+) *agent.Invocation {
+	if stateDelta != nil && stateDelta.invocation != nil {
+		return stateDelta.invocation.View()
+	}
+	return newStateDeltaInvocationView(invocation)
 }
 
 // lookupDeclaration returns a declaration or a safe placeholder.
@@ -1492,6 +1678,7 @@ func (p *FunctionCallResponseProcessor) executeToolWithCallbacks(
 		return ctx, nil, toolCall.Function.Arguments, false, false, err
 	}
 	if customResult != nil {
+		ctx = withStateDeltaSessionBaseline(ctx, invocation)
 		return ctx, customResult, toolCall.Function.Arguments, false,
 			false, nil
 	}
@@ -1503,6 +1690,7 @@ func (p *FunctionCallResponseProcessor) executeToolWithCallbacks(
 	if err != nil {
 		return ctx, nil, toolCall.Function.Arguments, false, false, err
 	}
+	ctx = withStateDeltaSessionBaseline(ctx, invocation)
 	if customResult != nil {
 		return ctx, customResult, toolCall.Function.Arguments, false,
 			false, nil

--- a/internal/flow/processor/functioncall_test.go
+++ b/internal/flow/processor/functioncall_test.go
@@ -297,6 +297,251 @@ func (t *sessionReadingStateDeltaTool) StateDeltaForInvocation(
 	}
 }
 
+type invocationStateRoundTripTool struct {
+	declaration *tool.Declaration
+	stateKey    string
+	stateValue  []byte
+	deltaKey    string
+}
+
+func (t *invocationStateRoundTripTool) Declaration() *tool.Declaration {
+	if t.declaration != nil {
+		return t.declaration
+	}
+	return &tool.Declaration{Name: "invocation-state-round-trip"}
+}
+
+func (t *invocationStateRoundTripTool) Call(
+	ctx context.Context,
+	_ []byte,
+) (any, error) {
+	inv, ok := agent.InvocationFromContext(ctx)
+	if !ok || inv == nil {
+		return false, nil
+	}
+	inv.SetState(t.stateKey, append([]byte(nil), t.stateValue...))
+	return true, nil
+}
+
+func (t *invocationStateRoundTripTool) StateDeltaForInvocation(
+	inv *agent.Invocation,
+	_ string,
+	_ []byte,
+	_ []byte,
+) map[string][]byte {
+	if inv == nil {
+		return nil
+	}
+	value, ok := inv.GetState(t.stateKey)
+	if !ok {
+		return nil
+	}
+	payload, ok := value.([]byte)
+	if !ok {
+		return nil
+	}
+	return map[string][]byte{
+		t.deltaKey: append([]byte(nil), payload...),
+	}
+}
+
+type stateAndSessionDeltaTool struct {
+	declaration *tool.Declaration
+	stateKey    string
+	stateValue  []byte
+	sessionKey  string
+	deltaKey    string
+}
+
+func (t *stateAndSessionDeltaTool) Declaration() *tool.Declaration {
+	if t.declaration != nil {
+		return t.declaration
+	}
+	return &tool.Declaration{Name: "state-and-session"}
+}
+
+func (t *stateAndSessionDeltaTool) Call(
+	ctx context.Context,
+	_ []byte,
+) (any, error) {
+	inv, ok := agent.InvocationFromContext(ctx)
+	if ok && inv != nil {
+		inv.SetState(t.stateKey, append([]byte(nil), t.stateValue...))
+	}
+	return true, nil
+}
+
+func (t *stateAndSessionDeltaTool) StateDeltaForInvocation(
+	inv *agent.Invocation,
+	_ string,
+	_ []byte,
+	_ []byte,
+) map[string][]byte {
+	if inv == nil || inv.Session == nil {
+		return nil
+	}
+	value, ok := inv.GetState(t.stateKey)
+	if !ok {
+		return nil
+	}
+	payload, ok := value.([]byte)
+	if !ok {
+		return nil
+	}
+	sessionValue, ok := inv.Session.GetState(t.sessionKey)
+	if !ok {
+		return nil
+	}
+	delta := append([]byte(nil), payload...)
+	delta = append(delta, ':')
+	delta = append(delta, sessionValue...)
+	return map[string][]byte{t.deltaKey: delta}
+}
+
+type sessionMutatingTool struct {
+	declaration  *tool.Declaration
+	sessionKey   string
+	sessionValue []byte
+}
+
+func (t *sessionMutatingTool) Declaration() *tool.Declaration {
+	if t.declaration != nil {
+		return t.declaration
+	}
+	return &tool.Declaration{Name: "session-mutating"}
+}
+
+func (t *sessionMutatingTool) Call(
+	ctx context.Context,
+	_ []byte,
+) (any, error) {
+	inv, ok := agent.InvocationFromContext(ctx)
+	if ok && inv != nil && inv.Session != nil {
+		inv.Session.SetState(
+			t.sessionKey,
+			append([]byte(nil), t.sessionValue...),
+		)
+	}
+	return true, nil
+}
+
+type sessionMutatingStateDeltaTool struct {
+	declaration  *tool.Declaration
+	sessionKey   string
+	sessionValue []byte
+	deltaKey     string
+}
+
+func (t *sessionMutatingStateDeltaTool) Declaration() *tool.Declaration {
+	if t.declaration != nil {
+		return t.declaration
+	}
+	return &tool.Declaration{Name: "session-mutating-state-delta"}
+}
+
+func (t *sessionMutatingStateDeltaTool) Call(
+	ctx context.Context,
+	_ []byte,
+) (any, error) {
+	inv, ok := agent.InvocationFromContext(ctx)
+	if ok && inv != nil && inv.Session != nil {
+		inv.Session.SetState(
+			t.sessionKey,
+			append([]byte(nil), t.sessionValue...),
+		)
+	}
+	return true, nil
+}
+
+func (t *sessionMutatingStateDeltaTool) StateDeltaForInvocation(
+	inv *agent.Invocation,
+	_ string,
+	_ []byte,
+	_ []byte,
+) map[string][]byte {
+	if inv == nil || inv.Session == nil {
+		return nil
+	}
+	value, ok := inv.Session.GetState(t.sessionKey)
+	if !ok {
+		return nil
+	}
+	return map[string][]byte{
+		t.deltaKey: append([]byte(nil), value...),
+	}
+}
+
+type coordinatedInvocationStateTool struct {
+	declaration      *tool.Declaration
+	stateKey         string
+	stateValue       []byte
+	deltaKey         string
+	waitBeforeWrite  <-chan struct{}
+	wrote            chan<- struct{}
+	waitBeforeReturn <-chan struct{}
+}
+
+func (t *coordinatedInvocationStateTool) Declaration() *tool.Declaration {
+	if t.declaration != nil {
+		return t.declaration
+	}
+	return &tool.Declaration{Name: "coordinated-invocation-state"}
+}
+
+func (t *coordinatedInvocationStateTool) Call(
+	ctx context.Context,
+	_ []byte,
+) (any, error) {
+	if err := waitForTestSignal(ctx, t.waitBeforeWrite); err != nil {
+		return nil, err
+	}
+	inv, ok := agent.InvocationFromContext(ctx)
+	if ok && inv != nil {
+		inv.SetState(t.stateKey, append([]byte(nil), t.stateValue...))
+	}
+	if t.wrote != nil {
+		close(t.wrote)
+	}
+	if err := waitForTestSignal(ctx, t.waitBeforeReturn); err != nil {
+		return nil, err
+	}
+	return true, nil
+}
+
+func (t *coordinatedInvocationStateTool) StateDeltaForInvocation(
+	inv *agent.Invocation,
+	_ string,
+	_ []byte,
+	_ []byte,
+) map[string][]byte {
+	value, ok := inv.GetState(t.stateKey)
+	if !ok {
+		return nil
+	}
+	payload, ok := value.([]byte)
+	if !ok {
+		return nil
+	}
+	return map[string][]byte{
+		t.deltaKey: append([]byte(nil), payload...),
+	}
+}
+
+func waitForTestSignal(ctx context.Context, ch <-chan struct{}) error {
+	if ch == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	select {
+	case <-ch:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 type mockStateDeltaTool struct {
 	declaration *tool.Declaration
 	delta       map[string][]byte
@@ -465,6 +710,760 @@ func TestFunctionCallResponseProcessor_AttachStateDelta(t *testing.T) {
 	}
 	p.attachStateDelta(inv, tl2, args, choice, ev2)
 	require.Equal(t, []byte(deltaVal2), ev2.StateDelta[deltaKey2])
+}
+
+func TestExecuteSingleToolCallSequential_PreservesCustomInvocationState(
+	t *testing.T,
+) {
+	const (
+		agentName       = "tester"
+		toolName        = "stateful"
+		toolCallID      = "call-1"
+		stateKey        = "custom:payload"
+		stateValue      = "business-data"
+		stateDeltaKey   = "business_payload"
+		emptyJSONObject = `{}`
+	)
+	p := NewFunctionCallResponseProcessor(false, nil)
+	inv := &agent.Invocation{AgentName: agentName, Model: &mockModel{}}
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+	rsp := &model.Response{Choices: []model.Choice{{}}}
+	toolCall := model.ToolCall{
+		ID: toolCallID,
+		Function: model.FunctionDefinitionParam{
+			Name:      toolName,
+			Arguments: []byte(emptyJSONObject),
+		},
+	}
+	stateTool := &invocationStateRoundTripTool{
+		declaration: &tool.Declaration{Name: toolName},
+		stateKey:    stateKey,
+		stateValue:  []byte(stateValue),
+		deltaKey:    stateDeltaKey,
+	}
+	tools := map[string]tool.Tool{toolName: stateTool}
+
+	ev, err := p.executeSingleToolCallSequential(
+		ctx,
+		inv,
+		rsp,
+		tools,
+		nil,
+		0,
+		toolCall,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, ev)
+	require.Equal(t, []byte(stateValue), ev.StateDelta[stateDeltaKey])
+}
+
+func TestExecuteSingleToolCallSequential_UsesCallbackInvocationState(
+	t *testing.T,
+) {
+	const (
+		agentName       = "tester"
+		toolName        = "stateful"
+		toolCallID      = "call-1"
+		stateKey        = "custom:payload"
+		stateValue      = "business-data"
+		stateDeltaKey   = "business_payload"
+		emptyJSONObject = `{}`
+	)
+	callbackInv := agent.NewInvocation()
+	callbacks := tool.NewCallbacks()
+	callbacks.RegisterBeforeTool(func(
+		context.Context,
+		*tool.BeforeToolArgs,
+	) (*tool.BeforeToolResult, error) {
+		return &tool.BeforeToolResult{
+			Context: agent.NewInvocationContext(
+				context.Background(),
+				callbackInv,
+			),
+		}, nil
+	})
+	p := NewFunctionCallResponseProcessor(false, callbacks)
+	inv := &agent.Invocation{AgentName: agentName, Model: &mockModel{}}
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+	rsp := &model.Response{Choices: []model.Choice{{}}}
+	toolCall := model.ToolCall{
+		ID: toolCallID,
+		Function: model.FunctionDefinitionParam{
+			Name:      toolName,
+			Arguments: []byte(emptyJSONObject),
+		},
+	}
+	stateTool := &invocationStateRoundTripTool{
+		declaration: &tool.Declaration{Name: toolName},
+		stateKey:    stateKey,
+		stateValue:  []byte(stateValue),
+		deltaKey:    stateDeltaKey,
+	}
+	tools := map[string]tool.Tool{toolName: stateTool}
+
+	ev, err := p.executeSingleToolCallSequential(
+		ctx,
+		inv,
+		rsp,
+		tools,
+		nil,
+		0,
+		toolCall,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, ev)
+	require.Equal(t, []byte(stateValue), ev.StateDelta[stateDeltaKey])
+	_, ok := inv.GetState(stateKey)
+	require.False(t, ok)
+}
+
+func TestExecuteSingleToolCallSequential_CallbackStateKeepsSession(
+	t *testing.T,
+) {
+	const (
+		agentName       = "tester"
+		toolName        = "stateful"
+		toolCallID      = "call-1"
+		stateKey        = "custom:payload"
+		sessionKey      = "session:payload"
+		stateValue      = "business-data"
+		sessionValue    = "session-data"
+		stateDeltaKey   = "business_payload"
+		expectedDelta   = "business-data:session-data"
+		emptyJSONObject = `{}`
+	)
+	callbackInv := agent.NewInvocation()
+	callbacks := tool.NewCallbacks()
+	callbacks.RegisterBeforeTool(func(
+		context.Context,
+		*tool.BeforeToolArgs,
+	) (*tool.BeforeToolResult, error) {
+		return &tool.BeforeToolResult{
+			Context: agent.NewInvocationContext(
+				context.Background(),
+				callbackInv,
+			),
+		}, nil
+	})
+	p := NewFunctionCallResponseProcessor(false, callbacks)
+	inv := &agent.Invocation{
+		AgentName: agentName,
+		Model:     &mockModel{},
+		Session: &session.Session{
+			State: session.StateMap{
+				sessionKey: []byte(sessionValue),
+			},
+		},
+	}
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+	rsp := &model.Response{Choices: []model.Choice{{}}}
+	toolCall := model.ToolCall{
+		ID: toolCallID,
+		Function: model.FunctionDefinitionParam{
+			Name:      toolName,
+			Arguments: []byte(emptyJSONObject),
+		},
+	}
+	stateTool := &stateAndSessionDeltaTool{
+		declaration: &tool.Declaration{Name: toolName},
+		stateKey:    stateKey,
+		stateValue:  []byte(stateValue),
+		sessionKey:  sessionKey,
+		deltaKey:    stateDeltaKey,
+	}
+	tools := map[string]tool.Tool{toolName: stateTool}
+
+	ev, err := p.executeSingleToolCallSequential(
+		ctx,
+		inv,
+		rsp,
+		tools,
+		nil,
+		0,
+		toolCall,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, ev)
+	require.Equal(t, []byte(expectedDelta), ev.StateDelta[stateDeltaKey])
+}
+
+func TestHandleFunctionCalls_SequentialKeepsCallbackSession(t *testing.T) {
+	const (
+		agentName       = "tester"
+		sessionKey      = "session:payload"
+		firstToolName   = "session_first"
+		secondToolName  = "session_second"
+		firstCallID     = "call-1"
+		secondCallID    = "call-2"
+		baseValue       = "base-session"
+		callbackValue   = "callback-session"
+		firstDeltaKey   = "first_payload"
+		secondDeltaKey  = "second_payload"
+		emptyJSONObject = `{}`
+	)
+	callbackInv := agent.NewInvocation(agent.WithInvocationSession(
+		&session.Session{
+			State: session.StateMap{
+				sessionKey: []byte(callbackValue),
+			},
+		},
+	))
+	callbacks := tool.NewCallbacks()
+	callbacks.RegisterBeforeTool(func(
+		ctx context.Context,
+		args *tool.BeforeToolArgs,
+	) (*tool.BeforeToolResult, error) {
+		if args.ToolName != secondToolName {
+			return nil, nil
+		}
+		return &tool.BeforeToolResult{
+			Context: agent.NewInvocationContext(ctx, callbackInv),
+		}, nil
+	})
+	p := NewFunctionCallResponseProcessor(false, callbacks)
+	inv := &agent.Invocation{
+		AgentName: agentName,
+		Model:     &mockModel{},
+		Session: &session.Session{
+			State: session.StateMap{
+				sessionKey: []byte(baseValue),
+			},
+		},
+	}
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+	tools := map[string]tool.Tool{
+		firstToolName: &sessionReadingStateDeltaTool{
+			declaration: &tool.Declaration{Name: firstToolName},
+			readKey:     sessionKey,
+			writeKey:    firstDeltaKey,
+		},
+		secondToolName: &sessionReadingStateDeltaTool{
+			declaration: &tool.Declaration{Name: secondToolName},
+			readKey:     sessionKey,
+			writeKey:    secondDeltaKey,
+		},
+	}
+	toolCalls := []model.ToolCall{
+		{
+			ID: firstCallID,
+			Function: model.FunctionDefinitionParam{
+				Name:      firstToolName,
+				Arguments: []byte(emptyJSONObject),
+			},
+		},
+		{
+			ID: secondCallID,
+			Function: model.FunctionDefinitionParam{
+				Name:      secondToolName,
+				Arguments: []byte(emptyJSONObject),
+			},
+		},
+	}
+
+	ev, err := p.handleFunctionCalls(
+		ctx,
+		inv,
+		newToolCallResponseWithCalls(toolCalls),
+		tools,
+		nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, ev)
+	require.Equal(t, []byte(baseValue), ev.StateDelta[firstDeltaKey])
+	require.Equal(t, []byte(callbackValue), ev.StateDelta[secondDeltaKey])
+}
+
+func TestHandleFunctionCalls_SequentialSnapshotsSession(t *testing.T) {
+	const (
+		agentName       = "tester"
+		sessionKey      = "session:payload"
+		firstToolName   = "session_reader"
+		secondToolName  = "session_writer"
+		firstCallID     = "call-1"
+		secondCallID    = "call-2"
+		initialValue    = "initial-session"
+		laterValue      = "later-session"
+		firstDeltaKey   = "first_payload"
+		emptyJSONObject = `{}`
+	)
+	p := NewFunctionCallResponseProcessor(false, nil)
+	inv := &agent.Invocation{
+		AgentName: agentName,
+		Model:     &mockModel{},
+		Session: &session.Session{
+			State: session.StateMap{
+				sessionKey: []byte(initialValue),
+			},
+		},
+	}
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+	tools := map[string]tool.Tool{
+		firstToolName: &sessionReadingStateDeltaTool{
+			declaration: &tool.Declaration{Name: firstToolName},
+			readKey:     sessionKey,
+			writeKey:    firstDeltaKey,
+		},
+		secondToolName: &sessionMutatingTool{
+			declaration:  &tool.Declaration{Name: secondToolName},
+			sessionKey:   sessionKey,
+			sessionValue: []byte(laterValue),
+		},
+	}
+	toolCalls := []model.ToolCall{
+		{
+			ID: firstCallID,
+			Function: model.FunctionDefinitionParam{
+				Name:      firstToolName,
+				Arguments: []byte(emptyJSONObject),
+			},
+		},
+		{
+			ID: secondCallID,
+			Function: model.FunctionDefinitionParam{
+				Name:      secondToolName,
+				Arguments: []byte(emptyJSONObject),
+			},
+		},
+	}
+
+	ev, err := p.handleFunctionCalls(
+		ctx,
+		inv,
+		newToolCallResponseWithCalls(toolCalls),
+		tools,
+		nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, ev)
+	require.Equal(t, []byte(initialValue), ev.StateDelta[firstDeltaKey])
+}
+
+func TestHandleFunctionCalls_SequentialKeepsCurrentSessionMutation(
+	t *testing.T,
+) {
+	const (
+		agentName       = "tester"
+		sessionKey      = "session:payload"
+		firstToolName   = "session_delta_writer"
+		secondToolName  = "session_direct_writer"
+		firstCallID     = "call-1"
+		secondCallID    = "call-2"
+		initialValue    = "initial-session"
+		priorValue      = "prior-session"
+		currentValue    = "current-session"
+		secondDeltaKey  = "second_payload"
+		emptyJSONObject = `{}`
+	)
+	p := NewFunctionCallResponseProcessor(false, nil)
+	inv := &agent.Invocation{
+		AgentName: agentName,
+		Model:     &mockModel{},
+		Session: &session.Session{
+			State: session.StateMap{
+				sessionKey: []byte(initialValue),
+			},
+		},
+	}
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+	tools := map[string]tool.Tool{
+		firstToolName: &mockInvocationStateDeltaTool{
+			declaration: &tool.Declaration{Name: firstToolName},
+			delta: map[string][]byte{
+				sessionKey: []byte(priorValue),
+			},
+		},
+		secondToolName: &sessionMutatingStateDeltaTool{
+			declaration:  &tool.Declaration{Name: secondToolName},
+			sessionKey:   sessionKey,
+			sessionValue: []byte(currentValue),
+			deltaKey:     secondDeltaKey,
+		},
+	}
+	toolCalls := []model.ToolCall{
+		{
+			ID: firstCallID,
+			Function: model.FunctionDefinitionParam{
+				Name:      firstToolName,
+				Arguments: []byte(emptyJSONObject),
+			},
+		},
+		{
+			ID: secondCallID,
+			Function: model.FunctionDefinitionParam{
+				Name:      secondToolName,
+				Arguments: []byte(emptyJSONObject),
+			},
+		},
+	}
+
+	ev, err := p.handleFunctionCalls(
+		ctx,
+		inv,
+		newToolCallResponseWithCalls(toolCalls),
+		tools,
+		nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, ev)
+	require.Equal(t, []byte(currentValue), ev.StateDelta[secondDeltaKey])
+}
+
+func TestHandleFunctionCalls_SequentialReplaysCallbackSessionDeltas(
+	t *testing.T,
+) {
+	const (
+		agentName       = "tester"
+		sessionKey      = "session:payload"
+		firstToolName   = "session_writer"
+		secondToolName  = "session_reader"
+		firstCallID     = "call-1"
+		secondCallID    = "call-2"
+		initialValue    = "initial-session"
+		updatedValue    = "updated-session"
+		secondDeltaKey  = "second_payload"
+		emptyJSONObject = `{}`
+	)
+	callbackInv := agent.NewInvocation(agent.WithInvocationSession(
+		&session.Session{
+			State: session.StateMap{
+				sessionKey: []byte(initialValue),
+			},
+		},
+	))
+	callbacks := tool.NewCallbacks()
+	callbacks.RegisterBeforeTool(func(
+		ctx context.Context,
+		_ *tool.BeforeToolArgs,
+	) (*tool.BeforeToolResult, error) {
+		return &tool.BeforeToolResult{
+			Context: agent.NewInvocationContext(ctx, callbackInv),
+		}, nil
+	})
+	p := NewFunctionCallResponseProcessor(false, callbacks)
+	inv := &agent.Invocation{
+		AgentName: agentName,
+		Model:     &mockModel{},
+		Session: &session.Session{
+			State: session.StateMap{},
+		},
+	}
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+	tools := map[string]tool.Tool{
+		firstToolName: &mockInvocationStateDeltaTool{
+			declaration: &tool.Declaration{Name: firstToolName},
+			delta: map[string][]byte{
+				sessionKey: []byte(updatedValue),
+			},
+		},
+		secondToolName: &sessionReadingStateDeltaTool{
+			declaration: &tool.Declaration{Name: secondToolName},
+			readKey:     sessionKey,
+			writeKey:    secondDeltaKey,
+		},
+	}
+	toolCalls := []model.ToolCall{
+		{
+			ID: firstCallID,
+			Function: model.FunctionDefinitionParam{
+				Name:      firstToolName,
+				Arguments: []byte(emptyJSONObject),
+			},
+		},
+		{
+			ID: secondCallID,
+			Function: model.FunctionDefinitionParam{
+				Name:      secondToolName,
+				Arguments: []byte(emptyJSONObject),
+			},
+		},
+	}
+
+	ev, err := p.handleFunctionCalls(
+		ctx,
+		inv,
+		newToolCallResponseWithCalls(toolCalls),
+		tools,
+		nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, ev)
+	require.Equal(t, []byte(updatedValue), ev.StateDelta[secondDeltaKey])
+}
+
+func TestHandleFunctionCalls_SequentialReplaysFallbackSessionDeltas(
+	t *testing.T,
+) {
+	const (
+		agentName       = "tester"
+		sessionKey      = "session:payload"
+		firstToolName   = "session_writer"
+		secondToolName  = "session_reader"
+		firstCallID     = "call-1"
+		secondCallID    = "call-2"
+		initialValue    = "initial-session"
+		updatedValue    = "updated-session"
+		secondDeltaKey  = "second_payload"
+		emptyJSONObject = `{}`
+	)
+	callbackInv := agent.NewInvocation()
+	callbacks := tool.NewCallbacks()
+	callbacks.RegisterBeforeTool(func(
+		ctx context.Context,
+		_ *tool.BeforeToolArgs,
+	) (*tool.BeforeToolResult, error) {
+		return &tool.BeforeToolResult{
+			Context: agent.NewInvocationContext(ctx, callbackInv),
+		}, nil
+	})
+	p := NewFunctionCallResponseProcessor(false, callbacks)
+	inv := &agent.Invocation{
+		AgentName: agentName,
+		Model:     &mockModel{},
+		Session: &session.Session{
+			State: session.StateMap{
+				sessionKey: []byte(initialValue),
+			},
+		},
+	}
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+	tools := map[string]tool.Tool{
+		firstToolName: &mockInvocationStateDeltaTool{
+			declaration: &tool.Declaration{Name: firstToolName},
+			delta: map[string][]byte{
+				sessionKey: []byte(updatedValue),
+			},
+		},
+		secondToolName: &sessionReadingStateDeltaTool{
+			declaration: &tool.Declaration{Name: secondToolName},
+			readKey:     sessionKey,
+			writeKey:    secondDeltaKey,
+		},
+	}
+	toolCalls := []model.ToolCall{
+		{
+			ID: firstCallID,
+			Function: model.FunctionDefinitionParam{
+				Name:      firstToolName,
+				Arguments: []byte(emptyJSONObject),
+			},
+		},
+		{
+			ID: secondCallID,
+			Function: model.FunctionDefinitionParam{
+				Name:      secondToolName,
+				Arguments: []byte(emptyJSONObject),
+			},
+		},
+	}
+
+	ev, err := p.handleFunctionCalls(
+		ctx,
+		inv,
+		newToolCallResponseWithCalls(toolCalls),
+		tools,
+		nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, ev)
+	require.Equal(t, []byte(updatedValue), ev.StateDelta[secondDeltaKey])
+}
+
+func TestStateDeltaSessionHelpers_EdgeCases(t *testing.T) {
+	const (
+		baseKey    = "base"
+		removedKey = "removed"
+		changedKey = "changed"
+	)
+	baseInv := &agent.Invocation{
+		Session: &session.Session{
+			State: session.StateMap{
+				baseKey:    []byte("base"),
+				removedKey: []byte("old"),
+				changedKey: []byte("old"),
+			},
+		},
+	}
+	callbackInv := agent.NewInvocation()
+	var ctx context.Context
+	ctx = agent.NewInvocationContext(context.Background(), callbackInv)
+	ctx = withStateDeltaSessionBaseline(ctx, baseInv)
+	require.Equal(
+		t,
+		[]byte("base"),
+		stateDeltaSessionBaseline(ctx)[baseKey],
+	)
+	ctx = withStateDeltaSessionBaseline(context.Background(), baseInv)
+	require.Equal(
+		t,
+		[]byte("base"),
+		stateDeltaSessionBaseline(ctx)[baseKey],
+	)
+	require.Nil(t, stateDeltaSessionBaseline(context.Background()))
+	require.Nil(t, stateDeltaBaselineSession(context.Background(), nil))
+	require.Nil(t, newStateDeltaSnapshot(nil, nil))
+	require.Nil(t, invocationView(nil))
+	preserveStateDeltaInvocationDefaults(nil, baseInv)
+	preserveStateDeltaInvocationDefaults(agent.NewInvocation(), nil)
+
+	current := session.StateMap{
+		baseKey:    []byte("base"),
+		changedKey: []byte("new"),
+	}
+	changed := changedSessionKeys(baseInv.Session.SnapshotState(), current)
+	require.False(t, changed[baseKey])
+	require.True(t, changed[removedKey])
+	require.True(t, changed[changedKey])
+
+	sess := &session.Session{State: session.StateMap{}}
+	applyPriorStateDeltas(nil, nil, nil)
+	applyReplayableStateDelta(sess, map[string]bool{}, nil)
+	applyReplayableStateDelta(
+		sess,
+		map[string]bool{changedKey: true},
+		&event.Event{
+			StateDelta: map[string][]byte{
+				baseKey:    []byte("applied"),
+				changedKey: []byte("skipped"),
+			},
+		},
+	)
+	value, ok := sess.GetState(baseKey)
+	require.True(t, ok)
+	require.Equal(t, []byte("applied"), value)
+	_, ok = sess.GetState(changedKey)
+	require.False(t, ok)
+}
+
+func TestHandleFunctionCalls_SequentialStateSnapshots(t *testing.T) {
+	const (
+		agentName       = "tester"
+		stateKey        = "custom:payload"
+		firstToolName   = "stateful_first"
+		secondToolName  = "stateful_second"
+		firstCallID     = "call-1"
+		secondCallID    = "call-2"
+		firstValue      = "first-data"
+		secondValue     = "second-data"
+		firstDeltaKey   = "first_payload"
+		secondDeltaKey  = "second_payload"
+		emptyJSONObject = `{}`
+	)
+	p := NewFunctionCallResponseProcessor(false, nil)
+	inv := &agent.Invocation{AgentName: agentName, Model: &mockModel{}}
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+	tools := map[string]tool.Tool{
+		firstToolName: &invocationStateRoundTripTool{
+			declaration: &tool.Declaration{Name: firstToolName},
+			stateKey:    stateKey,
+			stateValue:  []byte(firstValue),
+			deltaKey:    firstDeltaKey,
+		},
+		secondToolName: &invocationStateRoundTripTool{
+			declaration: &tool.Declaration{Name: secondToolName},
+			stateKey:    stateKey,
+			stateValue:  []byte(secondValue),
+			deltaKey:    secondDeltaKey,
+		},
+	}
+	toolCalls := []model.ToolCall{
+		{
+			ID: firstCallID,
+			Function: model.FunctionDefinitionParam{
+				Name:      firstToolName,
+				Arguments: []byte(emptyJSONObject),
+			},
+		},
+		{
+			ID: secondCallID,
+			Function: model.FunctionDefinitionParam{
+				Name:      secondToolName,
+				Arguments: []byte(emptyJSONObject),
+			},
+		},
+	}
+
+	ev, err := p.handleFunctionCalls(
+		ctx,
+		inv,
+		newToolCallResponseWithCalls(toolCalls),
+		tools,
+		nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, ev)
+	require.Equal(t, []byte(firstValue), ev.StateDelta[firstDeltaKey])
+	require.Equal(t, []byte(secondValue), ev.StateDelta[secondDeltaKey])
+}
+
+func TestHandleFunctionCalls_ParallelIsolatesInvocationState(t *testing.T) {
+	const (
+		agentName       = "tester"
+		stateKey        = "custom:payload"
+		firstToolName   = "stateful_first"
+		secondToolName  = "stateful_second"
+		firstCallID     = "call-1"
+		secondCallID    = "call-2"
+		firstValue      = "first-data"
+		secondValue     = "second-data"
+		firstDeltaKey   = "first_payload"
+		secondDeltaKey  = "second_payload"
+		emptyJSONObject = `{}`
+	)
+	firstWrote := make(chan struct{})
+	secondWrote := make(chan struct{})
+	p := NewFunctionCallResponseProcessor(true, nil)
+	inv := &agent.Invocation{AgentName: agentName, Model: &mockModel{}}
+	baseCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	ctx := agent.NewInvocationContext(baseCtx, inv)
+	tools := map[string]tool.Tool{
+		firstToolName: &coordinatedInvocationStateTool{
+			declaration:      &tool.Declaration{Name: firstToolName},
+			stateKey:         stateKey,
+			stateValue:       []byte(firstValue),
+			deltaKey:         firstDeltaKey,
+			wrote:            firstWrote,
+			waitBeforeReturn: secondWrote,
+		},
+		secondToolName: &coordinatedInvocationStateTool{
+			declaration:     &tool.Declaration{Name: secondToolName},
+			stateKey:        stateKey,
+			stateValue:      []byte(secondValue),
+			deltaKey:        secondDeltaKey,
+			waitBeforeWrite: firstWrote,
+			wrote:           secondWrote,
+		},
+	}
+	toolCalls := []model.ToolCall{
+		{
+			ID: firstCallID,
+			Function: model.FunctionDefinitionParam{
+				Name:      firstToolName,
+				Arguments: []byte(emptyJSONObject),
+			},
+		},
+		{
+			ID: secondCallID,
+			Function: model.FunctionDefinitionParam{
+				Name:      secondToolName,
+				Arguments: []byte(emptyJSONObject),
+			},
+		},
+	}
+
+	ev, err := p.handleFunctionCalls(
+		ctx,
+		inv,
+		newToolCallResponseWithCalls(toolCalls),
+		tools,
+		nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, ev)
+	require.Equal(t, []byte(firstValue), ev.StateDelta[firstDeltaKey])
+	require.Equal(t, []byte(secondValue), ev.StateDelta[secondDeltaKey])
+	_, ok := inv.GetState(stateKey)
+	require.False(t, ok)
 }
 
 func TestAttachStateDeltaToToolResults_ReplaysPendingStateDeltas(


### PR DESCRIPTION
## Summary
- preserve custom invocation state in isolated `Invocation.View()` snapshots so `StateDeltaForInvocation` can read state written during tool execution
- snapshot invocation and session state per tool result, including callback-replaced invocations and parallel tool calls, before attaching `StateDelta`
- keep `Clone()` behavior on the existing internal-state allowlist while making view-state copies safer for mutable custom maps, slices, pointers, and cycles
- add regression coverage for sequential, callback, session replay, parallel, and nested mutable state cases

## Testing
- `go test ./agent ./internal/flow/processor -count=1`
- `go test -race ./agent ./internal/flow/processor -run 'TestInvocation_View|TestInvocation_SyncView|TestExecuteSingleToolCallSequential|TestHandleFunctionCalls_SequentialSnapshotsSession|TestHandleFunctionCalls_SequentialKeepsCurrentSessionMutation|TestHandleFunctionCalls_SequentialReplaysCallbackSessionDeltas|TestHandleFunctionCalls_SequentialReplaysFallbackSessionDeltas|TestHandleFunctionCalls_SequentialStateSnapshots|TestHandleFunctionCalls_ParallelIsolatesInvocationState|TestHandleFunctionCalls_SequentialKeepsCallbackSession|TestAttachStateDelta' -count=1`
- `go test ./internal/flow/processor -run 'TestHandleFunctionCalls_ParallelIsolatesInvocationState' -count=20`
