### PR TITLE
{flow, toolcall}: keep tool results in matching rounds

### DIFF
--- a/internal/flow/processor/content.go
+++ b/internal/flow/processor/content.go
@@ -1905,25 +1905,10 @@ func (p *ContentRequestProcessor) rearrangeLatestFuncResp(
 func (p *ContentRequestProcessor) rearrangeAsyncFuncRespHist(
 	events []event.Event,
 ) []event.Event {
-	functionCallIDToResponseEventIndex := make(map[string]int)
-
-	// Map function response IDs to event indices.
-	for i, evt := range events {
-		// Create a local copy to avoid implicit memory aliasing.
-		// This bug is fixed in go 1.22.
-		// See: https://tip.golang.org/doc/go1.22#language
-		evt := evt
-
-		if evt.IsToolResultResponse() {
-			responseIDs := evt.GetToolResultIDs()
-			for _, responseID := range responseIDs {
-				functionCallIDToResponseEventIndex[responseID] = i
-			}
-		}
-	}
+	responseEventIndicesByCallEvent := toolResponseIndicesByCallEvent(events)
 
 	var resultEvents []event.Event
-	for _, evt := range events {
+	for i, evt := range events {
 		// Create a local copy to avoid implicit memory aliasing.
 		// This bug is fixed in go 1.22.
 		// See: https://tip.golang.org/doc/go1.22#language
@@ -1934,12 +1919,7 @@ func (p *ContentRequestProcessor) rearrangeAsyncFuncRespHist(
 			continue
 		} else if evt.IsToolCallResponse() {
 			functionCallIDs := evt.GetToolCallIDs()
-			var responseEventIndices []int
-			for _, callID := range functionCallIDs {
-				if idx, exists := functionCallIDToResponseEventIndex[callID]; exists {
-					responseEventIndices = append(responseEventIndices, idx)
-				}
-			}
+			responseEventIndices := responseEventIndicesByCallEvent[i]
 			// When tools run in parallel they commonly return all results inside one response event.
 			// If we pushed the same event once per tool ID, the LLM would see duplicated tool
 			// messages and reject the request. Keep only the first occurrence of each event index
@@ -1979,6 +1959,47 @@ func (p *ContentRequestProcessor) rearrangeAsyncFuncRespHist(
 	return resultEvents
 }
 
+type pendingToolCallRound struct {
+	eventIndex int
+	pendingIDs map[string]struct{}
+}
+
+func toolResponseIndicesByCallEvent(events []event.Event) map[int][]int {
+	responseEventIndicesByCallEvent := make(map[int][]int)
+	var pendingCallRounds []pendingToolCallRound
+	for i, evt := range events {
+		evt := evt
+		if evt.IsToolCallResponse() {
+			ids := evt.GetToolCallIDs()
+			if len(ids) == 0 {
+				continue
+			}
+			pendingCallRounds = append(pendingCallRounds, pendingToolCallRound{
+				eventIndex: i,
+				pendingIDs: toStringSet(ids),
+			})
+			continue
+		}
+		if !evt.IsToolResultResponse() {
+			continue
+		}
+		for _, responseID := range evt.GetToolResultIDs() {
+			for j := len(pendingCallRounds) - 1; j >= 0; j-- {
+				if _, ok := pendingCallRounds[j].pendingIDs[responseID]; !ok {
+					continue
+				}
+				delete(pendingCallRounds[j].pendingIDs, responseID)
+				responseEventIndicesByCallEvent[pendingCallRounds[j].eventIndex] = append(
+					responseEventIndicesByCallEvent[pendingCallRounds[j].eventIndex],
+					i,
+				)
+				break
+			}
+		}
+	}
+	return responseEventIndicesByCallEvent
+}
+
 // mergeFunctionResponseEvents merges a list of function_response events into one event.
 func (p *ContentRequestProcessor) mergeFunctionResponseEvents(
 	functionResponseEvents []event.Event,
@@ -2011,6 +2032,14 @@ func toMap(ids []string) map[string]bool {
 	m := make(map[string]bool)
 	for _, id := range ids {
 		m[id] = true
+	}
+	return m
+}
+
+func toStringSet(ids []string) map[string]struct{} {
+	m := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		m[id] = struct{}{}
 	}
 	return m
 }

--- a/internal/flow/processor/content.go
+++ b/internal/flow/processor/content.go
@@ -1905,7 +1905,7 @@ func (p *ContentRequestProcessor) rearrangeLatestFuncResp(
 func (p *ContentRequestProcessor) rearrangeAsyncFuncRespHist(
 	events []event.Event,
 ) []event.Event {
-	responseEventIndicesByCallEvent := toolResponseIndicesByCallEvent(events)
+	responseMatchesByCallEvent := toolResponseMatchesByCallEvent(events)
 
 	var resultEvents []event.Event
 	for i, evt := range events {
@@ -1918,35 +1918,18 @@ func (p *ContentRequestProcessor) rearrangeAsyncFuncRespHist(
 			// Function response should be handled with function call below.
 			continue
 		} else if evt.IsToolCallResponse() {
-			functionCallIDs := evt.GetToolCallIDs()
-			responseEventIndices := responseEventIndicesByCallEvent[i]
-			// When tools run in parallel they commonly return all results inside one response event.
-			// If we pushed the same event once per tool ID, the LLM would see duplicated tool
-			// messages and reject the request. Keep only the first occurrence of each event index
-			// while preserving their original order.
-			seenIdx := make(map[int]struct{}, len(functionCallIDs))
-			uniqueIndices := responseEventIndices[:0]
-			// Reuse the existing slice to deduplicate in place and maintain the original order.
-			for _, idx := range responseEventIndices {
-				if _, seen := seenIdx[idx]; seen {
-					continue
-				}
-				seenIdx[idx] = struct{}{}
-				uniqueIndices = append(uniqueIndices, idx)
-			}
-			responseEventIndices = uniqueIndices
-
+			responseMatches := responseMatchesByCallEvent[i]
 			resultEvents = append(resultEvents, evt)
 
-			if len(responseEventIndices) == 0 {
+			if len(responseMatches) == 0 {
 				continue
-			} else if len(responseEventIndices) == 1 {
-				resultEvents = append(resultEvents, events[responseEventIndices[0]])
+			} else if len(responseMatches) == 1 {
+				resultEvents = append(resultEvents, filterToolResponseEvent(events, responseMatches[0]))
 			} else {
 				// Merge multiple async function responses.
 				var responseEvents []event.Event
-				for _, idx := range responseEventIndices {
-					responseEvents = append(responseEvents, events[idx])
+				for _, match := range responseMatches {
+					responseEvents = append(responseEvents, filterToolResponseEvent(events, match))
 				}
 				mergedEvent := p.mergeFunctionResponseEvents(responseEvents)
 				resultEvents = append(resultEvents, mergedEvent)
@@ -1964,10 +1947,15 @@ type pendingToolCallRound struct {
 	pendingIDs map[string]struct{}
 }
 
-// toolResponseIndicesByCallEvent matches tool-result events to the nearest
+type matchedToolResponseEvent struct {
+	eventIndex    int
+	choiceIndices []int
+}
+
+// toolResponseMatchesByCallEvent matches tool-result choices to the nearest
 // preceding tool-call round that is still waiting for the result ID.
-func toolResponseIndicesByCallEvent(events []event.Event) map[int][]int {
-	responseEventIndicesByCallEvent := make(map[int][]int)
+func toolResponseMatchesByCallEvent(events []event.Event) map[int][]matchedToolResponseEvent {
+	responseMatchesByCallEvent := make(map[int][]matchedToolResponseEvent)
 	var pendingCallRounds []pendingToolCallRound
 	for i, evt := range events {
 		evt := evt
@@ -1985,21 +1973,68 @@ func toolResponseIndicesByCallEvent(events []event.Event) map[int][]int {
 		if !evt.IsToolResultResponse() {
 			continue
 		}
-		for _, responseID := range evt.GetToolResultIDs() {
+		for choiceIndex, choice := range evt.Response.Choices {
+			responseID := choice.Message.ToolID
+			if responseID == "" {
+				responseID = choice.Delta.ToolID
+			}
+			if responseID == "" {
+				continue
+			}
 			for j := len(pendingCallRounds) - 1; j >= 0; j-- {
 				if _, ok := pendingCallRounds[j].pendingIDs[responseID]; !ok {
 					continue
 				}
 				delete(pendingCallRounds[j].pendingIDs, responseID)
-				responseEventIndicesByCallEvent[pendingCallRounds[j].eventIndex] = append(
-					responseEventIndicesByCallEvent[pendingCallRounds[j].eventIndex],
+				responseMatchesByCallEvent[pendingCallRounds[j].eventIndex] = appendToolResponseChoice(
+					responseMatchesByCallEvent[pendingCallRounds[j].eventIndex],
 					i,
+					choiceIndex,
 				)
 				break
 			}
 		}
 	}
-	return responseEventIndicesByCallEvent
+	return responseMatchesByCallEvent
+}
+
+// appendToolResponseChoice records one matching choice while coalescing choices
+// from the same response event into one match.
+func appendToolResponseChoice(
+	matches []matchedToolResponseEvent,
+	eventIndex int,
+	choiceIndex int,
+) []matchedToolResponseEvent {
+	for i := range matches {
+		if matches[i].eventIndex != eventIndex {
+			continue
+		}
+		matches[i].choiceIndices = append(matches[i].choiceIndices, choiceIndex)
+		return matches
+	}
+	return append(matches, matchedToolResponseEvent{
+		eventIndex:    eventIndex,
+		choiceIndices: []int{choiceIndex},
+	})
+}
+
+// filterToolResponseEvent clones a matched response event with only the tool
+// result choices that belong to the current tool-call round.
+func filterToolResponseEvent(events []event.Event, match matchedToolResponseEvent) event.Event {
+	evt := events[match.eventIndex]
+	if evt.Response == nil || len(match.choiceIndices) == 0 {
+		return evt
+	}
+	response := *evt.Response
+	response.Choices = make([]model.Choice, 0, len(match.choiceIndices))
+	for _, choiceIndex := range match.choiceIndices {
+		if choiceIndex < 0 || choiceIndex >= len(evt.Response.Choices) {
+			continue
+		}
+		response.Choices = append(response.Choices, evt.Response.Choices[choiceIndex])
+	}
+	evt.Response = &response
+	return evt
 }
 
 // mergeFunctionResponseEvents merges a list of function_response events into one event.

--- a/internal/flow/processor/content.go
+++ b/internal/flow/processor/content.go
@@ -1964,6 +1964,8 @@ type pendingToolCallRound struct {
 	pendingIDs map[string]struct{}
 }
 
+// toolResponseIndicesByCallEvent matches tool-result events to the nearest
+// preceding tool-call round that is still waiting for the result ID.
 func toolResponseIndicesByCallEvent(events []event.Event) map[int][]int {
 	responseEventIndicesByCallEvent := make(map[int][]int)
 	var pendingCallRounds []pendingToolCallRound
@@ -2036,6 +2038,7 @@ func toMap(ids []string) map[string]bool {
 	return m
 }
 
+// toStringSet converts IDs to a set for membership checks.
 func toStringSet(ids []string) map[string]struct{} {
 	m := make(map[string]struct{}, len(ids))
 	for _, id := range ids {

--- a/internal/flow/processor/content_merge_test.go
+++ b/internal/flow/processor/content_merge_test.go
@@ -329,3 +329,61 @@ func Test_rearrangeAsyncFuncRespHist_ReusedToolCallIDsStayInTheirRounds(t *testi
 	assert.Equal(t, []string{"shell:49"}, out[3].GetToolResultIDs())
 	assert.Equal(t, "second shell result", out[3].Response.Choices[0].Message.Content)
 }
+
+func Test_rearrangeAsyncFuncRespHist_FiltersMixedResponseEventAcrossRounds(t *testing.T) {
+	p := NewContentRequestProcessor()
+
+	firstCall := event.Event{
+		Author: "assistant",
+		Response: &model.Response{
+			Choices: []model.Choice{
+				{
+					Message: model.Message{
+						Role: model.RoleAssistant,
+						ToolCalls: []model.ToolCall{
+							{ID: "call_first", Function: model.FunctionDefinitionParam{Name: "first_tool"}},
+						},
+					},
+				},
+			},
+		},
+	}
+	secondCall := event.Event{
+		Author: "assistant",
+		Response: &model.Response{
+			Choices: []model.Choice{
+				{
+					Message: model.Message{
+						Role: model.RoleAssistant,
+						ToolCalls: []model.ToolCall{
+							{ID: "call_second", Function: model.FunctionDefinitionParam{Name: "second_tool"}},
+						},
+					},
+				},
+			},
+		},
+	}
+	mixedResult := event.Event{
+		Author: "assistant",
+		Response: &model.Response{
+			Choices: []model.Choice{
+				{Message: model.Message{Role: model.RoleTool, ToolID: "call_first", Content: "first result"}},
+				{Message: model.Message{Role: model.RoleTool, ToolID: "call_second", Content: "second result"}},
+			},
+		},
+	}
+
+	out := p.rearrangeAsyncFuncRespHist([]event.Event{firstCall, secondCall, mixedResult})
+
+	assert.Len(t, out, 4, "mixed tool result event should be split across matching rounds")
+	assert.True(t, out[0].IsToolCallResponse())
+	assert.True(t, out[1].IsToolResultResponse())
+	assert.Equal(t, []string{"call_first"}, out[1].GetToolResultIDs())
+	assert.Len(t, out[1].Response.Choices, 1)
+	assert.Equal(t, "first result", out[1].Response.Choices[0].Message.Content)
+	assert.True(t, out[2].IsToolCallResponse())
+	assert.True(t, out[3].IsToolResultResponse())
+	assert.Equal(t, []string{"call_second"}, out[3].GetToolResultIDs())
+	assert.Len(t, out[3].Response.Choices, 1)
+	assert.Equal(t, "second result", out[3].Response.Choices[0].Message.Content)
+}

--- a/internal/flow/processor/content_merge_test.go
+++ b/internal/flow/processor/content_merge_test.go
@@ -244,3 +244,88 @@ func Test_rearrangeAsyncFuncRespHist_MergesSeparateResponseEvents(t *testing.T) 
 	assert.ElementsMatch(t, []string{"t1", "t2"}, out[1].GetToolResultIDs())
 	assert.Len(t, out[1].Response.Choices, 2)
 }
+
+func Test_rearrangeAsyncFuncRespHist_ReusedToolCallIDsStayInTheirRounds(t *testing.T) {
+	p := NewContentRequestProcessor()
+
+	firstCall := event.Event{
+		Author: "assistant",
+		Response: &model.Response{
+			Choices: []model.Choice{
+				{
+					Message: model.Message{
+						Role: model.RoleAssistant,
+						ToolCalls: []model.ToolCall{
+							{ID: "file_read:47", Function: model.FunctionDefinitionParam{Name: "file_read"}},
+							{ID: "shell:49", Function: model.FunctionDefinitionParam{Name: "shell"}},
+						},
+					},
+				},
+			},
+		},
+	}
+	firstFileResult := event.Event{
+		Author: "assistant",
+		Response: &model.Response{
+			Choices: []model.Choice{
+				{Message: model.Message{Role: model.RoleTool, ToolID: "file_read:47", Content: "file result"}},
+			},
+		},
+	}
+	firstShellResult := event.Event{
+		Author: "assistant",
+		Response: &model.Response{
+			Choices: []model.Choice{
+				{Message: model.Message{Role: model.RoleTool, ToolID: "shell:49", Content: "first shell result"}},
+			},
+		},
+	}
+	secondCall := event.Event{
+		Author: "assistant",
+		Response: &model.Response{
+			Choices: []model.Choice{
+				{
+					Message: model.Message{
+						Role: model.RoleAssistant,
+						ToolCalls: []model.ToolCall{
+							{ID: "shell:49", Function: model.FunctionDefinitionParam{Name: "shell"}},
+						},
+					},
+				},
+			},
+		},
+	}
+	secondShellResult := event.Event{
+		Author: "assistant",
+		Response: &model.Response{
+			Choices: []model.Choice{
+				{Message: model.Message{Role: model.RoleTool, ToolID: "shell:49", Content: "second shell result"}},
+			},
+		},
+	}
+
+	out := p.rearrangeAsyncFuncRespHist([]event.Event{
+		firstCall,
+		firstFileResult,
+		firstShellResult,
+		secondCall,
+		secondShellResult,
+	})
+
+	assert.Len(t, out, 4, "each call round should keep only its own tool result event")
+	assert.True(t, out[0].IsToolCallResponse())
+	assert.True(t, out[1].IsToolResultResponse())
+	assert.ElementsMatch(t, []string{"file_read:47", "shell:49"}, out[1].GetToolResultIDs())
+	assert.Contains(t, []string{
+		out[1].Response.Choices[0].Message.Content,
+		out[1].Response.Choices[1].Message.Content,
+	}, "first shell result")
+	assert.NotContains(t, []string{
+		out[1].Response.Choices[0].Message.Content,
+		out[1].Response.Choices[1].Message.Content,
+	}, "second shell result")
+	assert.True(t, out[2].IsToolCallResponse())
+	assert.True(t, out[3].IsToolResultResponse())
+	assert.Equal(t, []string{"shell:49"}, out[3].GetToolResultIDs())
+	assert.Equal(t, "second shell result", out[3].Response.Choices[0].Message.Content)
+}

--- a/internal/toolcall/sanitize.go
+++ b/internal/toolcall/sanitize.go
@@ -393,12 +393,18 @@ func splitToolResults(toolResults []model.Message, validIDs map[string]struct{},
 		kept:        make([]model.Message, 0, len(toolResults)),
 		invalidByID: make(map[string][]model.Message),
 	}
+	respondedValidIDs := make(map[string]struct{}, len(validIDs))
 	for _, tr := range toolResults {
 		if tr.ToolID == "" {
 			out.orphan = append(out.orphan, tr)
 			continue
 		}
 		if _, ok := validIDs[tr.ToolID]; ok {
+			if _, responded := respondedValidIDs[tr.ToolID]; responded {
+				out.orphan = append(out.orphan, tr)
+				continue
+			}
+			respondedValidIDs[tr.ToolID] = struct{}{}
 			out.kept = append(out.kept, tr)
 			continue
 		}

--- a/internal/toolcall/sanitize_test.go
+++ b/internal/toolcall/sanitize_test.go
@@ -108,6 +108,43 @@ func TestSanitizeMessagesWithTools_PreservesValidToolRound(t *testing.T) {
 	}
 }
 
+func TestSanitizeMessagesWithTools_DowngradesDuplicateToolResult(t *testing.T) {
+	in := []model.Message{
+		{
+			Role: model.RoleAssistant,
+			ToolCalls: []model.ToolCall{
+				{
+					ID: "call_1",
+					Function: model.FunctionDefinitionParam{
+						Name:      "test_tool",
+						Arguments: []byte(`{"a":1}`),
+					},
+				},
+			},
+		},
+		{
+			Role:    model.RoleTool,
+			ToolID:  "call_1",
+			Content: "first result",
+		},
+		{
+			Role:    model.RoleTool,
+			ToolID:  "call_1",
+			Content: "duplicate result",
+		},
+	}
+
+	out := SanitizeMessagesWithTools(in, nil)
+	if assert.Len(t, out, 3) {
+		assert.Equal(t, model.RoleAssistant, out[0].Role)
+		assert.Equal(t, model.RoleTool, out[1].Role)
+		assert.Equal(t, "first result", out[1].Content)
+		assert.Equal(t, model.RoleUser, out[2].Role)
+		assert.Contains(t, out[2].Content, orphanToolResultTag)
+		assert.Contains(t, out[2].Content, "duplicate result")
+	}
+}
+
 func TestSanitizeMessagesWithTools_NormalizesEmptyArgumentsToEmptyObject(t *testing.T) {
 	in := []model.Message{
 		{


### PR DESCRIPTION
## Summary
- Match asynchronous tool results to the nearest pending tool-call round instead of globally by reused tool_call_id.
- Downgrade duplicate tool results in sanitizer so strict chat APIs do not receive orphaned tool messages.
- Add regressions for reused tool IDs across rounds and duplicate tool results.

## Test plan
- go test ./internal/flow/llmflow ./internal/flow/processor ./internal/toolcall