### PR TITLE
agent:  reuse WorkspaceRegistry across invocations to avoid duplicate ws dirs

### DIFF
--- a/agent/llmagent/extras_test.go
+++ b/agent/llmagent/extras_test.go
@@ -78,7 +78,7 @@ func TestRegisterTools_AddsToolSet(t *testing.T) {
 
 	kb := &fakeKnowledge{}
 
-	all, userToolNames := registerTools(&Options{Tools: direct, ToolSets: []tool.ToolSet{ts}, Knowledge: kb})
+	all, userToolNames, _ := registerTools(&Options{Tools: direct, ToolSets: []tool.ToolSet{ts}, Knowledge: kb}, nil)
 
 	// Expect 1 direct + 1 from set + 1 knowledge search tool.
 	require.Equal(t, 3, len(all))

--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -70,6 +70,7 @@ type LLMAgent struct {
 	userToolNames           map[string]bool // Names of tools explicitly registered
 	// via WithTools and WithToolSets.
 	codeExecutor         codeexecutor.CodeExecutor
+	workspaceRegistry    *codeexecutor.WorkspaceRegistry
 	planner              planner.Planner
 	subAgents            []agent.Agent // Sub-agents that can be delegated to
 	agentCallbacks       *agent.Callbacks
@@ -114,7 +115,7 @@ func New(name string, opts ...Option) *LLMAgent {
 
 	// Register tools from both tools and toolsets, including knowledge search tool if provided.
 	// Also track which tools are user-registered (via WithTools) for filtering purposes.
-	tools, userToolNames := registerTools(&options)
+	tools, userToolNames, wsReg := registerTools(&options, nil)
 
 	// Initialize models map and determine the initial model.
 	initialModel, models := initializeModels(&options)
@@ -133,6 +134,7 @@ func New(name string, opts ...Option) *LLMAgent {
 		),
 		genConfig:            options.GenerationConfig,
 		codeExecutor:         options.codeExecutor,
+		workspaceRegistry:    wsReg,
 		tools:                tools,
 		userToolNames:        userToolNames,
 		planner:              options.Planner,
@@ -625,31 +627,61 @@ func initializeModels(options *Options) (model.Model, map[string]model.Model) {
 	return nil, models
 }
 
-func registerTools(options *Options) ([]tool.Tool, map[string]bool) {
+// registerTools assembles the full tool list for an LLMAgent from user-
+// registered tools, knowledge tools, skill tools, and workspace tools.
+//
+// existingReg, when non-nil, is a WorkspaceRegistry carried over from a
+// previous call (e.g. agent construction or tool refresh). Reusing it
+// ensures that successive invocations share the same workspace cache
+// instead of creating duplicate directories. The returned registry
+// should be stored on the agent for future reuse.
+func registerTools(
+	options *Options,
+	existingReg *codeexecutor.WorkspaceRegistry,
+) ([]tool.Tool, map[string]bool, *codeexecutor.WorkspaceRegistry) {
+	// Step 1: collect user-registered tools (WithTools + WithToolSets)
+	// and knowledge search tools.
 	userToolNames := collectUserToolNames(options.Tools)
 	allTools := append([]tool.Tool(nil), options.Tools...)
-	allTools, userToolNames = appendStaticToolSetTools(
-		allTools, userToolNames, options,
-	)
+	allTools, userToolNames = appendStaticToolSetTools(allTools, userToolNames, options)
 	allTools = appendKnowledgeTools(allTools, options)
+
+	// Step 2: determine workspace registry and skill_run tool based on
+	// which capabilities the caller configured.
+	//
+	// Three scenarios:
+	//   a) skills + executor → shared registry for both skill_run and
+	//      workspace_exec; create one only if not inherited.
+	//   b) skills only (no executor) → skill_run gets nil registry and
+	//      builds its own internally; workspace_exec is not wired.
+	//   c) executor only (no skills) → registry for workspace_exec;
+	//      no skill_run needed.
 	var runTool *toolskill.RunTool
-	var workspaceRegistry *codeexecutor.WorkspaceRegistry
+	workspaceRegistry := existingReg
 	if options.skillsRepository != nil {
-		if options.codeExecutor != nil {
+		if options.codeExecutor != nil && workspaceRegistry == nil {
 			workspaceRegistry = buildWorkspaceRegistry()
 		}
 		runTool = buildSkillRunTool(options, workspaceRegistry)
 	} else if executorSupportsWorkspaceExec(options) {
-		workspaceRegistry = buildWorkspaceRegistry()
+		if workspaceRegistry == nil {
+			workspaceRegistry = buildWorkspaceRegistry()
+		}
 	}
+
+	// Step 3: wire workspace_exec (and session companions) when an
+	// executor with EngineProvider is available.
 	allTools = appendWorkspaceExecTool(
 		allTools,
 		options,
 		workspaceRegistry,
 		nil,
 	)
+
+	// Step 4: wire skill tools (skill_load, skill_run, etc.) when a
+	// skill repository is configured.
 	allTools = appendSkillTools(allTools, options, runTool)
-	return allTools, userToolNames
+	return allTools, userToolNames, workspaceRegistry
 }
 
 func collectUserToolNames(tools []tool.Tool) map[string]bool {
@@ -967,6 +999,19 @@ func appendOnDemandSessionTools(
 
 func buildWorkspaceRegistry() *codeexecutor.WorkspaceRegistry {
 	return codeexecutor.NewWorkspaceRegistry()
+}
+
+// ensureWorkspaceRegistry returns the agent-level registry, creating
+// one if it does not yet exist. The registry is stored on the agent so
+// that successive invocations (different rounds) reuse the same
+// instance and do not create duplicate workspace directories.
+func (a *LLMAgent) ensureWorkspaceRegistry() *codeexecutor.WorkspaceRegistry {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.workspaceRegistry == nil {
+		a.workspaceRegistry = codeexecutor.NewWorkspaceRegistry()
+	}
+	return a.workspaceRegistry
 }
 
 // workspacePrepOptions translates llmagent-level workspace options
@@ -1726,9 +1771,14 @@ func (a *LLMAgent) SetSubAgents(subAgents []agent.Agent) {
 // refreshToolsLocked recomputes the aggregated tool list and user tool
 // tracking map from the current options. Caller must hold a.mu.Lock.
 func (a *LLMAgent) refreshToolsLocked() {
-	tools, userToolNames := registerTools(&a.option)
+	tools, userToolNames, reg := registerTools(
+		&a.option, a.workspaceRegistry,
+	)
 	a.tools = tools
 	a.userToolNames = userToolNames
+	if a.workspaceRegistry == nil {
+		a.workspaceRegistry = reg
+	}
 }
 
 // AddToolSet adds or replaces a tool set at runtime in a

--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -71,6 +71,7 @@ type LLMAgent struct {
 	// via WithTools and WithToolSets.
 	codeExecutor         codeexecutor.CodeExecutor
 	workspaceRegistry    *codeexecutor.WorkspaceRegistry
+	workspaceRegistries  map[workspaceRegistryKey]*codeexecutor.WorkspaceRegistry
 	planner              planner.Planner
 	subAgents            []agent.Agent // Sub-agents that can be delegated to
 	agentCallbacks       *agent.Callbacks
@@ -135,6 +136,7 @@ func New(name string, opts ...Option) *LLMAgent {
 		genConfig:            options.GenerationConfig,
 		codeExecutor:         options.codeExecutor,
 		workspaceRegistry:    wsReg,
+		workspaceRegistries:  workspaceRegistryMap(options.codeExecutor, wsReg),
 		tools:                tools,
 		userToolNames:        userToolNames,
 		planner:              options.Planner,
@@ -1001,17 +1003,83 @@ func buildWorkspaceRegistry() *codeexecutor.WorkspaceRegistry {
 	return codeexecutor.NewWorkspaceRegistry()
 }
 
-// ensureWorkspaceRegistry returns the agent-level registry, creating
-// one if it does not yet exist. The registry is stored on the agent so
-// that successive invocations (different rounds) reuse the same
-// instance and do not create duplicate workspace directories.
-func (a *LLMAgent) ensureWorkspaceRegistry() *codeexecutor.WorkspaceRegistry {
+type workspaceRegistryKey struct {
+	exec codeexecutor.CodeExecutor
+}
+
+func workspaceRegistryKeyForExecutor(
+	exec codeexecutor.CodeExecutor,
+) (workspaceRegistryKey, bool) {
+	if exec == nil {
+		return workspaceRegistryKey{}, false
+	}
+	if !reflect.TypeOf(exec).Comparable() {
+		return workspaceRegistryKey{}, false
+	}
+	return workspaceRegistryKey{exec: exec}, true
+}
+
+func workspaceRegistryMap(
+	exec codeexecutor.CodeExecutor,
+	reg *codeexecutor.WorkspaceRegistry,
+) map[workspaceRegistryKey]*codeexecutor.WorkspaceRegistry {
+	if reg == nil {
+		return nil
+	}
+	key, ok := workspaceRegistryKeyForExecutor(exec)
+	if !ok {
+		return nil
+	}
+	return map[workspaceRegistryKey]*codeexecutor.WorkspaceRegistry{
+		key: reg,
+	}
+}
+
+func (a *LLMAgent) ensureWorkspaceRegistryForExecutor(
+	exec codeexecutor.CodeExecutor,
+) (*codeexecutor.WorkspaceRegistry, bool) {
+	key, ok := workspaceRegistryKeyForExecutor(exec)
+	if !ok {
+		return nil, false
+	}
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	if a.workspaceRegistry == nil {
-		a.workspaceRegistry = codeexecutor.NewWorkspaceRegistry()
+	return a.workspaceRegistryForKeyLocked(key), true
+}
+
+func (a *LLMAgent) workspaceRegistryForKeyLocked(
+	key workspaceRegistryKey,
+) *codeexecutor.WorkspaceRegistry {
+	if a.workspaceRegistries == nil {
+		a.workspaceRegistries = make(map[workspaceRegistryKey]*codeexecutor.WorkspaceRegistry)
+		if a.workspaceRegistry != nil {
+			if defaultKey, ok := workspaceRegistryKeyForExecutor(a.codeExecutor); ok {
+				a.workspaceRegistries[defaultKey] = a.workspaceRegistry
+			}
+		}
 	}
-	return a.workspaceRegistry
+	if reg := a.workspaceRegistries[key]; reg != nil {
+		return reg
+	}
+	reg := codeexecutor.NewWorkspaceRegistry()
+	a.workspaceRegistries[key] = reg
+	if a.workspaceRegistry == nil {
+		a.workspaceRegistry = reg
+	}
+	return reg
+}
+
+func (a *LLMAgent) workspaceRegistryForInvocation(
+	inv *agent.Invocation,
+	exec codeexecutor.CodeExecutor,
+) *codeexecutor.WorkspaceRegistry {
+	if inv == nil || inv.Session == nil || inv.Session.ID == "" {
+		return buildWorkspaceRegistry()
+	}
+	if reg, ok := a.ensureWorkspaceRegistryForExecutor(exec); ok {
+		return reg
+	}
+	return buildWorkspaceRegistry()
 }
 
 // workspacePrepOptions translates llmagent-level workspace options
@@ -1771,8 +1839,12 @@ func (a *LLMAgent) SetSubAgents(subAgents []agent.Agent) {
 // refreshToolsLocked recomputes the aggregated tool list and user tool
 // tracking map from the current options. Caller must hold a.mu.Lock.
 func (a *LLMAgent) refreshToolsLocked() {
+	reg := a.workspaceRegistry
+	if key, ok := workspaceRegistryKeyForExecutor(a.option.codeExecutor); ok {
+		reg = a.workspaceRegistryForKeyLocked(key)
+	}
 	tools, userToolNames, reg := registerTools(
-		&a.option, a.workspaceRegistry,
+		&a.option, reg,
 	)
 	a.tools = tools
 	a.userToolNames = userToolNames

--- a/agent/llmagent/llm_agent_skill_test.go
+++ b/agent/llmagent/llm_agent_skill_test.go
@@ -26,6 +26,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/artifact/inmemory"
 	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
+	localexec "trpc.group/trpc-go/trpc-agent-go/codeexecutor/local"
 	"trpc.group/trpc-go/trpc-agent-go/internal/flow/processor"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
@@ -324,6 +325,124 @@ func TestLLMAgent_WorkspaceSaveArtifactOmittedWithoutInvocationCapability(
 	tools, _ := a.InvocationToolSurface(context.Background(), inv)
 	require.NotNil(t, findTool(tools, "workspace_exec"))
 	require.Nil(t, findTool(tools, "workspace_save_artifact"))
+}
+
+func TestLLMAgent_InvocationWorkspaceRegistry_NoSessionIsNotShared(
+	t *testing.T,
+) {
+	a := New("tester", WithCodeExecutor(localexec.New()))
+
+	inv1 := agent.NewInvocation(
+		agent.WithInvocationMessage(model.NewUserMessage("write")),
+	)
+	out := callInvocationWorkspaceExec(
+		t, a, inv1,
+		"mkdir -p out && printf leaked > out/leak.txt",
+	)
+	require.Equal(t, float64(0), out["exit_code"])
+
+	inv2 := agent.NewInvocation(
+		agent.WithInvocationMessage(model.NewUserMessage("read")),
+	)
+	out = callInvocationWorkspaceExec(t, a, inv2, "cat out/leak.txt")
+	require.NotEqual(t, float64(0), out["exit_code"])
+	require.NotContains(t, out["output"], "leaked")
+}
+
+func TestLLMAgent_InvocationWorkspaceRegistry_ReusesSameSessionExecutor(
+	t *testing.T,
+) {
+	a := New("tester", WithCodeExecutor(localexec.New()))
+
+	inv1 := agent.NewInvocation(
+		agent.WithInvocationMessage(model.NewUserMessage("write")),
+		agent.WithInvocationSession(&session.Session{ID: "sess-reuse"}),
+	)
+	out := callInvocationWorkspaceExec(
+		t, a, inv1,
+		"mkdir -p out && printf shared > out/shared.txt",
+	)
+	require.Equal(t, float64(0), out["exit_code"])
+
+	inv2 := agent.NewInvocation(
+		agent.WithInvocationMessage(model.NewUserMessage("read")),
+		agent.WithInvocationSession(&session.Session{ID: "sess-reuse"}),
+	)
+	out = callInvocationWorkspaceExec(t, a, inv2, "cat out/shared.txt")
+	require.Equal(t, float64(0), out["exit_code"])
+	require.Equal(t, "shared", out["output"])
+}
+
+func TestLLMAgent_InvocationWorkspaceRegistry_IsolatedByExecutor(
+	t *testing.T,
+) {
+	defaultExec := localexec.New()
+	overrideExec := localexec.New()
+	a := New("tester", WithCodeExecutor(defaultExec))
+
+	invDefault := agent.NewInvocation(
+		agent.WithInvocationMessage(model.NewUserMessage("default write")),
+		agent.WithInvocationSession(&session.Session{ID: "sess-exec"}),
+	)
+	out := callInvocationWorkspaceExec(
+		t, a, invDefault,
+		"mkdir -p out && printf default > out/default.txt",
+	)
+	require.Equal(t, float64(0), out["exit_code"])
+
+	invOverride := agent.NewInvocation(
+		agent.WithInvocationMessage(model.NewUserMessage("override read")),
+		agent.WithInvocationSession(&session.Session{ID: "sess-exec"}),
+		agent.WithInvocationRunOptions(agent.NewRunOptions(
+			agent.WithCodeExecutor(overrideExec),
+		)),
+	)
+	out = callInvocationWorkspaceExec(t, a, invOverride, "cat out/default.txt")
+	require.NotEqual(t, float64(0), out["exit_code"])
+	require.NotEqual(t, "default", out["output"])
+
+	out = callInvocationWorkspaceExec(
+		t, a, invOverride,
+		"mkdir -p out && printf override > out/override.txt",
+	)
+	require.Equal(t, float64(0), out["exit_code"])
+
+	invOverrideAgain := agent.NewInvocation(
+		agent.WithInvocationMessage(model.NewUserMessage("override read again")),
+		agent.WithInvocationSession(&session.Session{ID: "sess-exec"}),
+		agent.WithInvocationRunOptions(agent.NewRunOptions(
+			agent.WithCodeExecutor(overrideExec),
+		)),
+	)
+	out = callInvocationWorkspaceExec(t, a, invOverrideAgain, "cat out/override.txt")
+	require.Equal(t, float64(0), out["exit_code"])
+	require.Equal(t, "override", out["output"])
+}
+
+func callInvocationWorkspaceExec(
+	t *testing.T,
+	a *LLMAgent,
+	inv *agent.Invocation,
+	command string,
+) map[string]any {
+	t.Helper()
+	tools, _ := a.InvocationToolSurface(context.Background(), inv)
+	tl := findTool(tools, "workspace_exec")
+	require.NotNil(t, tl)
+	args := map[string]any{
+		"command": command,
+		"timeout": 5,
+	}
+	b, err := json.Marshal(args)
+	require.NoError(t, err)
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+	res, err := tl.(tool.CallableTool).Call(ctx, b)
+	require.NoError(t, err)
+	jb, err := json.Marshal(res)
+	require.NoError(t, err)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(jb, &out))
+	return out
 }
 
 func TestLLMAgent_SkillRunUsesDefaultExecutorWhenNoExplicitExecutor(t *testing.T) {

--- a/agent/llmagent/llm_agent_skill_test.go
+++ b/agent/llmagent/llm_agent_skill_test.go
@@ -419,6 +419,94 @@ func TestLLMAgent_InvocationWorkspaceRegistry_IsolatedByExecutor(
 	require.Equal(t, "override", out["output"])
 }
 
+func TestLLMAgent_WorkspaceRegistryKey_NonComparableExecutor(t *testing.T) {
+	exec := nonComparableExec{tags: []string{"slice"}}
+
+	_, ok := workspaceRegistryKeyForExecutor(exec)
+	require.False(t, ok)
+
+	reg := codeexecutor.NewWorkspaceRegistry()
+	require.Nil(t, workspaceRegistryMap(exec, reg))
+
+	a := New("tester")
+	got, ok := a.ensureWorkspaceRegistryForExecutor(exec)
+	require.False(t, ok)
+	require.Nil(t, got)
+}
+
+func TestLLMAgent_WorkspaceRegistryForInvocation_NonComparableExecutorFallback(
+	t *testing.T,
+) {
+	a := New("tester")
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(&session.Session{ID: "sess"}),
+	)
+	exec := nonComparableExec{tags: []string{"slice"}}
+
+	reg1 := a.workspaceRegistryForInvocation(inv, exec)
+	reg2 := a.workspaceRegistryForInvocation(inv, exec)
+
+	require.NotNil(t, reg1)
+	require.NotNil(t, reg2)
+	require.NotSame(t, reg1, reg2)
+}
+
+func TestLLMAgent_WorkspaceRegistryForKeyLocked_InitializesCacheFromDefault(
+	t *testing.T,
+) {
+	exec := &stubExec{}
+	defaultReg := codeexecutor.NewWorkspaceRegistry()
+	a := &LLMAgent{
+		codeExecutor:      exec,
+		workspaceRegistry: defaultReg,
+	}
+	key, ok := workspaceRegistryKeyForExecutor(exec)
+	require.True(t, ok)
+
+	reg := a.workspaceRegistryForKeyLocked(key)
+
+	require.Same(t, defaultReg, reg)
+	require.Same(t, defaultReg, a.workspaceRegistries[key])
+}
+
+func TestLLMAgent_WorkspaceRegistryForKeyLocked_StoresPrimaryRegistry(
+	t *testing.T,
+) {
+	exec := &stubExec{}
+	a := &LLMAgent{}
+	key, ok := workspaceRegistryKeyForExecutor(exec)
+	require.True(t, ok)
+
+	reg := a.workspaceRegistryForKeyLocked(key)
+
+	require.NotNil(t, reg)
+	require.Same(t, reg, a.workspaceRegistry)
+	require.Same(t, reg, a.workspaceRegistries[key])
+}
+
+func TestLLMAgent_RefreshToolsLocked_ReusesExecutorRegistry(t *testing.T) {
+	exec := &stubExec{}
+	a := New("tester", WithCodeExecutor(exec))
+	initialReg := a.workspaceRegistry
+	require.NotNil(t, initialReg)
+
+	a.mu.Lock()
+	a.workspaceRegistries = nil
+	a.refreshToolsLocked()
+	key, ok := workspaceRegistryKeyForExecutor(exec)
+	refreshedReg := a.workspaceRegistry
+	var cachedReg *codeexecutor.WorkspaceRegistry
+	if ok {
+		cachedReg = a.workspaceRegistries[key]
+	}
+	a.mu.Unlock()
+
+	require.True(t, ok)
+	require.Same(t, initialReg, refreshedReg)
+	require.Same(t, initialReg, cachedReg)
+	require.NotNil(t, findTool(a.Tools(), "workspace_exec"))
+}
+
 func callInvocationWorkspaceExec(
 	t *testing.T,
 	a *LLMAgent,
@@ -668,6 +756,25 @@ func (s *stubExec) Engine() codeexecutor.Engine {
 	fs := &stubFS{}
 	rr := &stubRunner{s: s}
 	return codeexecutor.NewEngine(mgr, fs, rr)
+}
+
+type nonComparableExec struct {
+	tags []string
+}
+
+func (n nonComparableExec) ExecuteCode(
+	_ context.Context,
+	_ codeexecutor.CodeExecutionInput,
+) (codeexecutor.CodeExecutionResult, error) {
+	return codeexecutor.CodeExecutionResult{}, nil
+}
+
+func (n nonComparableExec) CodeBlockDelimiter() codeexecutor.CodeBlockDelimiter {
+	return codeexecutor.CodeBlockDelimiter{Start: "```", End: "```"}
+}
+
+func (n nonComparableExec) Engine() codeexecutor.Engine {
+	return codeexecutor.NewEngine(&stubMgr{}, &stubFS{}, &stubRunner{s: &stubExec{}})
 }
 
 type stubMgr struct{}

--- a/agent/llmagent/llm_agent_tools_test.go
+++ b/agent/llmagent/llm_agent_tools_test.go
@@ -76,7 +76,7 @@ func TestRegisterTools_Combinations(t *testing.T) {
 	kb := &minimalKnowledge{}
 
 	// with tools, toolset and knowledge and nil memory.
-	tools, userToolNames := registerTools(&Options{Tools: base, ToolSets: sets, Knowledge: kb})
+	tools, userToolNames, _ := registerTools(&Options{Tools: base, ToolSets: sets, Knowledge: kb}, nil)
 	if len(tools) < 2 {
 		t.Fatalf("expected aggregated tools from base and toolset")
 	}

--- a/agent/llmagent/surface_runtime.go
+++ b/agent/llmagent/surface_runtime.go
@@ -203,9 +203,9 @@ func (a *LLMAgent) InvocationToolSurface(
 		codeExecutorSupportsWorkspaceExecSessions(effectiveExec)
 	var workspaceRegistry *codeexecutor.WorkspaceRegistry
 	if effectiveSkills != nil && effectiveExec != nil {
-		workspaceRegistry = a.ensureWorkspaceRegistry()
+		workspaceRegistry = a.workspaceRegistryForInvocation(inv, effectiveExec)
 	} else if workspaceExecEnabled {
-		workspaceRegistry = a.ensureWorkspaceRegistry()
+		workspaceRegistry = a.workspaceRegistryForInvocation(inv, effectiveExec)
 	}
 	// Pass effectiveSkills so workspace_exec's loaded-skills
 	// reconcile reads the same repository that skill tools and the

--- a/agent/llmagent/surface_runtime.go
+++ b/agent/llmagent/surface_runtime.go
@@ -203,9 +203,9 @@ func (a *LLMAgent) InvocationToolSurface(
 		codeExecutorSupportsWorkspaceExecSessions(effectiveExec)
 	var workspaceRegistry *codeexecutor.WorkspaceRegistry
 	if effectiveSkills != nil && effectiveExec != nil {
-		workspaceRegistry = buildWorkspaceRegistry()
+		workspaceRegistry = a.ensureWorkspaceRegistry()
 	} else if workspaceExecEnabled {
-		workspaceRegistry = buildWorkspaceRegistry()
+		workspaceRegistry = a.ensureWorkspaceRegistry()
 	}
 	// Pass effectiveSkills so workspace_exec's loaded-skills
 	// reconcile reads the same repository that skill tools and the

--- a/internal/workspacesession/resolver.go
+++ b/internal/workspacesession/resolver.go
@@ -70,15 +70,12 @@ func (r *Resolver) CreateWorkspace(
 		reg = codeexecutor.NewWorkspaceRegistry()
 		r.reg = reg
 	}
-	var sid string
+	sid := name
 	if inv, ok := agent.InvocationFromContext(ctx); ok && inv != nil {
 		if inv.Session != nil && inv.Session.ID != "" {
 			sid = inv.Session.ID
 		}
 		ctx = withWorkspaceArtifactContext(ctx, inv)
-	}
-	if sid == "" {
-		return eng.Manager().CreateWorkspace(ctx, name, codeexecutor.WorkspacePolicy{})
 	}
 	return reg.Acquire(ctx, eng.Manager(), sid)
 }

--- a/internal/workspacesession/resolver.go
+++ b/internal/workspacesession/resolver.go
@@ -70,12 +70,15 @@ func (r *Resolver) CreateWorkspace(
 		reg = codeexecutor.NewWorkspaceRegistry()
 		r.reg = reg
 	}
-	sid := name
+	var sid string
 	if inv, ok := agent.InvocationFromContext(ctx); ok && inv != nil {
 		if inv.Session != nil && inv.Session.ID != "" {
 			sid = inv.Session.ID
 		}
 		ctx = withWorkspaceArtifactContext(ctx, inv)
+	}
+	if sid == "" {
+		return eng.Manager().CreateWorkspace(ctx, name, codeexecutor.WorkspacePolicy{})
 	}
 	return reg.Acquire(ctx, eng.Manager(), sid)
 }

--- a/internal/workspacesession/resolver_test.go
+++ b/internal/workspacesession/resolver_test.go
@@ -129,7 +129,7 @@ func TestResolver_EnsureEngine(t *testing.T) {
 	require.NotNil(t, fallback.Runner())
 }
 
-func TestResolver_CreateWorkspace_UsesSessionIDOrFallbackName(t *testing.T) {
+func TestResolver_CreateWorkspace_UsesRegistryOnlyWithSessionID(t *testing.T) {
 	mgr := &resolverStubMgr{}
 	eng := newResolverStubEngine(mgr)
 	r := NewResolver(nil, nil)
@@ -140,11 +140,11 @@ func TestResolver_CreateWorkspace_UsesSessionIDOrFallbackName(t *testing.T) {
 	require.Equal(t, "workspace", ws.ID)
 	require.Equal(t, []string{"workspace"}, mgr.created)
 
-	// Reuse through registry.
+	// No session ID: create a fresh workspace instead of caching "workspace".
 	ws2, err := r.CreateWorkspace(ctx, eng, "workspace")
 	require.NoError(t, err)
 	require.Equal(t, ws, ws2)
-	require.Equal(t, []string{"workspace"}, mgr.created)
+	require.Equal(t, []string{"workspace", "workspace"}, mgr.created)
 
 	inv := agent.NewInvocation()
 	inv.Session = &session.Session{ID: "sess-123"}
@@ -152,7 +152,12 @@ func TestResolver_CreateWorkspace_UsesSessionIDOrFallbackName(t *testing.T) {
 	ws3, err := r.CreateWorkspace(ctx, eng, "ignored-name")
 	require.NoError(t, err)
 	require.Equal(t, "sess-123", ws3.ID)
-	require.Equal(t, []string{"workspace", "sess-123"}, mgr.created)
+	require.Equal(t, []string{"workspace", "workspace", "sess-123"}, mgr.created)
+
+	ws4, err := r.CreateWorkspace(ctx, eng, "ignored-name")
+	require.NoError(t, err)
+	require.Equal(t, ws3, ws4)
+	require.Equal(t, []string{"workspace", "workspace", "sess-123"}, mgr.created)
 }
 
 // artifactProbeManager asserts CreateWorkspace's context can resolve an artifact

--- a/internal/workspacesession/resolver_test.go
+++ b/internal/workspacesession/resolver_test.go
@@ -129,7 +129,7 @@ func TestResolver_EnsureEngine(t *testing.T) {
 	require.NotNil(t, fallback.Runner())
 }
 
-func TestResolver_CreateWorkspace_UsesRegistryOnlyWithSessionID(t *testing.T) {
+func TestResolver_CreateWorkspace_UsesSessionIDOrFallbackName(t *testing.T) {
 	mgr := &resolverStubMgr{}
 	eng := newResolverStubEngine(mgr)
 	r := NewResolver(nil, nil)
@@ -140,11 +140,11 @@ func TestResolver_CreateWorkspace_UsesRegistryOnlyWithSessionID(t *testing.T) {
 	require.Equal(t, "workspace", ws.ID)
 	require.Equal(t, []string{"workspace"}, mgr.created)
 
-	// No session ID: create a fresh workspace instead of caching "workspace".
+	// Reuse through fallback workspace name when no invocation session is present.
 	ws2, err := r.CreateWorkspace(ctx, eng, "workspace")
 	require.NoError(t, err)
 	require.Equal(t, ws, ws2)
-	require.Equal(t, []string{"workspace", "workspace"}, mgr.created)
+	require.Equal(t, []string{"workspace"}, mgr.created)
 
 	inv := agent.NewInvocation()
 	inv.Session = &session.Session{ID: "sess-123"}
@@ -152,12 +152,12 @@ func TestResolver_CreateWorkspace_UsesRegistryOnlyWithSessionID(t *testing.T) {
 	ws3, err := r.CreateWorkspace(ctx, eng, "ignored-name")
 	require.NoError(t, err)
 	require.Equal(t, "sess-123", ws3.ID)
-	require.Equal(t, []string{"workspace", "workspace", "sess-123"}, mgr.created)
+	require.Equal(t, []string{"workspace", "sess-123"}, mgr.created)
 
 	ws4, err := r.CreateWorkspace(ctx, eng, "ignored-name")
 	require.NoError(t, err)
 	require.Equal(t, ws3, ws4)
-	require.Equal(t, []string{"workspace", "workspace", "sess-123"}, mgr.created)
+	require.Equal(t, []string{"workspace", "sess-123"}, mgr.created)
 }
 
 // artifactProbeManager asserts CreateWorkspace's context can resolve an artifact

--- a/openclaw/app/admin_skills_config_test.go
+++ b/openclaw/app/admin_skills_config_test.go
@@ -520,6 +520,7 @@ func TestSetSkillEnabledInConfig_ErrorPathsAndWriteConfigDocument(t *testing.T) 
 	}
 	path = filepath.Join(t.TempDir(), "write.yaml")
 	require.NoError(t, os.WriteFile(path, []byte("app_name: old\n"), 0o644))
+	require.NoError(t, os.Chmod(path, 0o644))
 	require.NoError(t, writeConfigDocument(path, &doc))
 
 	body, err := os.ReadFile(path)

--- a/tool/skill/run_test.go
+++ b/tool/skill/run_test.go
@@ -2848,6 +2848,7 @@ func TestRunTool_StagesUserFileInputs_DedupesAllMetadataInputs(t *testing.T) {
 
 	args1 := runInput{
 		Skill:   testSkillName,
+		Cwd:     "/",
 		Command: "cat work/inputs/" + uploadNotesTxt + " > " + outATxt,
 		Inputs: []codeexecutor.InputSpec{
 			{
@@ -2883,6 +2884,7 @@ func TestRunTool_StagesUserFileInputs_DedupesAllMetadataInputs(t *testing.T) {
 	}, " ")
 	args2 := runInput{
 		Skill:       testSkillName,
+		Cwd:         "/",
 		Command:     cmd2,
 		OutputFiles: []string{outBTxt},
 		Timeout:     timeoutSecSmall,


### PR DESCRIPTION
## Summary

- Promote `WorkspaceRegistry` from a local variable in `registerTools()` to a persistent field on `LLMAgent`, ensuring the same registry instance is reused across agent construction, tool refresh (`refreshToolsLocked`), and runtime tool surface assembly (`InvocationToolSurface`).
- Add `ensureWorkspaceRegistry()` with proper mutex locking for lazy initialization, preventing duplicate workspace directory creation when the same agent is invoked across multiple rounds or when skill auto-loading triggers tool refresh.

## Background

Previously, every call to `registerTools()` and `InvocationToolSurface()` created a new `WorkspaceRegistry`. Since the registry is the deduplication cache keyed by session ID, using a fresh instance on each invocation meant `Acquire()` could never hit a cached workspace — resulting in duplicate `ws_<id>_<timestamp>` directories being created for the same session, causing:
- Loss of workspace state (files, outputs) between rounds
- Unnecessary disk space consumption
- Broken idempotency guarantees of `WorkspaceInitHook` / `WorkspaceBootstrapSpec`

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./agent/llmagent/... -count=1` passes (the only failing test `TestLLMAgent_SkillRun_OutputLimits_Configurable` also fails on `origin/main` — pre-existing flaky test, unrelated to this change)
- [x] Verified `registerTools` signature change is correctly adapted in both test files (`extras_test.go`, `llm_agent_tools_test.go`)

Made with [Cursor](https://cursor.com)