### PR TITLE
{team, internal/flow/processor, docs}: add swarm handoff input builder

### DIFF
--- a/docs/mkdocs/en/team.md
+++ b/docs/mkdocs/en/team.md
@@ -398,6 +398,42 @@ This is different from `await_user_reply` plus
 - `await_user_reply` is a one-shot route. It is consumed by exactly one future
   user turn and then cleared automatically.
 
+### Rewrite handoff input (optional)
+
+By default, when a Swarm member hands off with `transfer_to_agent`, the target member receives the tool call's `message` field as its user input. If your application needs to construct the target member's first input from the original user input, a template, or other context, configure `team.WithSwarmHandoffInputBuilder`:
+
+```go
+tm, err := team.NewSwarm(
+    "support",
+    "main_agent",
+    []agent.Agent{mainAgent, refundAgent},
+    team.WithSwarmHandoffInputBuilder(func(
+        ctx context.Context,
+        args team.SwarmHandoffInputArgs,
+    ) (model.Message, error) {
+        if args.ToAgentName == "refund_agent" {
+            return model.NewUserMessage(
+                "Refund request:\n" + args.RootInput.Content,
+            ), nil
+        }
+        return model.NewUserMessage(args.TransferMessage), nil
+    }),
+)
+if err != nil {
+    panic(err)
+}
+```
+
+`SwarmHandoffInputArgs` provides:
+
+- `FromAgentName`: the member that initiated the handoff.
+- `ToAgentName`: the member that receives the handoff.
+- `RootInput`: the original user input for the current run.
+- `ParentInput`: the current input of the member that initiated the handoff.
+- `TransferMessage`: the `message` field from the `transfer_to_agent` call.
+
+This option only rewrites the target member's current input for this handoff. It does not rewrite the source member's context or prevent the target member from reading existing conversation history.
+
 ### Dynamic members (runtime)
 
 In long-running services, the set of available Swarm members may change over

--- a/docs/mkdocs/zh/team.md
+++ b/docs/mkdocs/zh/team.md
@@ -368,6 +368,42 @@ Session State 实现，因此需要复用同一个 session。
   transfer，后续用户消息都会继续落到当前 active member。
 - `await_user_reply` 是一次性路由。它只消费下一条用户消息，消费后会自动清掉。
 
+### 改写 handoff 输入（可选）
+
+默认情况下，Swarm 成员通过 `transfer_to_agent` 交接时，目标成员收到的用户输入就是工具调用中的 `message` 字段。如果业务希望用原始用户输入、模板或其他上下文重新构造目标成员的首轮输入，可以配置 `team.WithSwarmHandoffInputBuilder`：
+
+```go
+tm, err := team.NewSwarm(
+    "support",
+    "main_agent",
+    []agent.Agent{mainAgent, refundAgent},
+    team.WithSwarmHandoffInputBuilder(func(
+        ctx context.Context,
+        args team.SwarmHandoffInputArgs,
+    ) (model.Message, error) {
+        if args.ToAgentName == "refund_agent" {
+            return model.NewUserMessage(
+                "退款处理请求：\n" + args.RootInput.Content,
+            ), nil
+        }
+        return model.NewUserMessage(args.TransferMessage), nil
+    }),
+)
+if err != nil {
+    panic(err)
+}
+```
+
+`SwarmHandoffInputArgs` 提供以下字段：
+
+- `FromAgentName`：发起 handoff 的成员名。
+- `ToAgentName`：接收 handoff 的成员名。
+- `RootInput`：本轮用户最初输入。
+- `ParentInput`：发起 handoff 的当前成员输入。
+- `TransferMessage`：`transfer_to_agent` 工具调用里携带的 message。
+
+该选项只改写目标成员本次 handoff 的当前输入；不会改写发起方成员的上下文，也不会阻止目标成员读取已有会话历史。
+
 ### 动态成员（运行时增删）
 
 在长时间运行的服务中，Swarm 的成员列表可能会变化（例如远程 Agent

--- a/internal/flow/processor/transfer.go
+++ b/internal/flow/processor/transfer.go
@@ -12,12 +12,14 @@ package processor
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
 	"time"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/event"
 	istructure "trpc.group/trpc-go/trpc-agent-go/internal/structure"
+	itransfer "trpc.group/trpc-go/trpc-agent-go/internal/transfer"
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 )
@@ -72,6 +74,7 @@ func (p *TransferResponseProcessor) ProcessResponse(
 	transferInfo := invocation.TransferInfo
 	targetAgentName := transferInfo.TargetAgentName
 	var nodeTimeout time.Duration
+	var transferCustomizer itransfer.InvocationCustomizer
 
 	// Look up the target agent from the current agent's sub-agents.
 	var targetAgent agent.Agent
@@ -119,8 +122,26 @@ func (p *TransferResponseProcessor) ProcessResponse(
 			return
 		}
 		nodeTimeout = targetTimeout
+		transferCustomizer = transferInvocationCustomizerFor(controller)
 	}
 
+	targetInvocation, targetMessageBeforeCustomize, err := prepareTransferTargetInvocation(
+		ctx,
+		invocation,
+		targetAgent,
+		transferInfo,
+		transferCustomizer,
+	)
+	if err != nil {
+		invocation.TransferInfo = nil
+		agent.EmitEvent(ctx, invocation, ch, event.NewErrorEvent(
+			invocation.InvocationID,
+			invocation.AgentName,
+			model.ErrorTypeFlowError,
+			fmt.Sprintf("Transfer customization rejected: %v", err),
+		))
+		return
+	}
 	// Create transfer event to notify about the handoff.
 	transferEvent := event.New(
 		invocation.InvocationID,
@@ -144,38 +165,16 @@ func (p *TransferResponseProcessor) ProcessResponse(
 			},
 		},
 	}
-
-	// Send transfer event.
+	// Send transfer event after customization succeeds.
 	if err := agent.EmitEvent(ctx, invocation, ch, transferEvent); err != nil {
 		return
 	}
-
-	// Create new invocation for the target agent.
-	// Do NOT propagate EndInvocation from the coordinator.
-	// end_invocation is intended to end the current (parent) invocation
-	// after transfer, not the target agent's invocation.
-	targetInvocation := invocation.Clone(
-		agent.WithInvocationAgent(targetAgent),
-		agent.WithInvocationTraceNodeID(
-			transferTargetTraceNodeID(invocation, targetAgent),
-		),
-		agent.WithInvocationEntryPredecessorStepIDs(
-			agent.NextExecutionTracePredecessors(invocation),
-		),
-		func(inv *agent.Invocation) {
-			if surfaceRootNodeID := transferTargetSurfaceRootNodeID(invocation, targetAgent); surfaceRootNodeID != "" {
-				agent.SetInvocationSurfaceRootNodeID(inv, surfaceRootNodeID)
-			}
-		},
-	)
-
-	// Set the message for the target agent.
-	if transferInfo.Message != "" {
-		targetInvocation.Message = model.Message{
-			Role:    model.RoleUser,
-			Content: transferInfo.Message,
-		}
-		// Always emit a transfer message echo for visibility and traceability.
+	if shouldEmitTransferMessageEcho(
+		transferInfo.Message != "",
+		targetMessageBeforeCustomize,
+		targetInvocation.Message,
+	) {
+		// Emit explicit transfer input for visibility and traceability.
 		// Use tag so UIs can filter internal delegation messages without breaking event alignment.
 		agent.EmitEvent(ctx, targetInvocation, ch, event.NewResponseEvent(
 			targetInvocation.InvocationID,
@@ -249,6 +248,57 @@ func (p *TransferResponseProcessor) ProcessResponse(
 	)
 	invocation.TransferInfo = nil
 	invocation.EndInvocation = p.endInvocationAfterTransfer
+}
+
+func prepareTransferTargetInvocation(
+	ctx context.Context,
+	invocation *agent.Invocation,
+	targetAgent agent.Agent,
+	transferInfo *agent.TransferInfo,
+	customizer itransfer.InvocationCustomizer,
+) (*agent.Invocation, model.Message, error) {
+	// Do NOT propagate EndInvocation from the coordinator.
+	// end_invocation is intended to end the current invocation.
+	targetInvocation := invocation.Clone(
+		agent.WithInvocationAgent(targetAgent),
+		agent.WithInvocationTraceNodeID(
+			transferTargetTraceNodeID(invocation, targetAgent),
+		),
+		agent.WithInvocationEntryPredecessorStepIDs(
+			agent.NextExecutionTracePredecessors(invocation),
+		),
+		func(inv *agent.Invocation) {
+			if surfaceRootNodeID := transferTargetSurfaceRootNodeID(invocation, targetAgent); surfaceRootNodeID != "" {
+				agent.SetInvocationSurfaceRootNodeID(inv, surfaceRootNodeID)
+			}
+		},
+	)
+	if transferInfo.Message != "" {
+		targetInvocation.Message = model.Message{
+			Role:    model.RoleUser,
+			Content: transferInfo.Message,
+		}
+	}
+	beforeCustomize := targetInvocation.Message
+	if customizer == nil {
+		return targetInvocation, beforeCustomize, nil
+	}
+	customizeCtx := itransfer.ContextWithTransferMessage(ctx, transferInfo.Message)
+	if err := customizer.CustomizeTransferInvocation(customizeCtx, invocation, targetInvocation); err != nil {
+		return nil, model.Message{}, err
+	}
+	return targetInvocation, beforeCustomize, nil
+}
+
+func shouldEmitTransferMessageEcho(
+	hasTransferMessage bool,
+	beforeCustomize model.Message,
+	afterCustomize model.Message,
+) bool {
+	if !model.HasPayload(afterCustomize) {
+		return false
+	}
+	return hasTransferMessage || !reflect.DeepEqual(beforeCustomize, afterCustomize)
 }
 
 // saveActiveAgent saves the target agent to session state for Swarm cross-request transfer
@@ -325,4 +375,14 @@ func swarmActiveAgentKey(teamName string) string {
 		return swarmActiveAgentKeyPrefix
 	}
 	return swarmActiveAgentKeyPrefix + teamName
+}
+
+func transferInvocationCustomizerFor(
+	controller agent.TransferController,
+) itransfer.InvocationCustomizer {
+	customizer, ok := controller.(itransfer.InvocationCustomizer)
+	if !ok {
+		return nil
+	}
+	return customizer
 }

--- a/internal/flow/processor/transfer_test.go
+++ b/internal/flow/processor/transfer_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/event"
+	itransfer "trpc.group/trpc-go/trpc-agent-go/internal/transfer"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	"trpc.group/trpc-go/trpc-agent-go/team"
@@ -37,6 +38,8 @@ type mockAgent struct {
 	gotEndInvocation bool
 	gotTraceNodeID   string
 	gotSurfaceRoot   string
+	gotMessage       model.Message
+	invoked          bool
 }
 
 func (m *mockAgent) Info() agent.Info                { return agent.Info{Name: m.name} }
@@ -48,9 +51,11 @@ func (m *mockAgent) Run(ctx context.Context, inv *agent.Invocation) (<-chan *eve
 	go func() {
 		defer close(ch)
 		// Record whether the invocation was incorrectly marked as ended.
+		m.invoked = true
 		m.gotEndInvocation = inv.EndInvocation
 		m.gotTraceNodeID = agent.InvocationTraceNodeID(inv)
 		m.gotSurfaceRoot = agent.InvocationSurfaceRootNodeID(inv)
+		m.gotMessage = inv.Message
 		if m.emit {
 			ch <- event.New(inv.InvocationID, m.name)
 		}
@@ -102,6 +107,62 @@ func TestTransferResponseProc_Successful(t *testing.T) {
 	require.Len(t, evts, 3)
 	require.Equal(t, model.ObjectTypeTransfer, evts[0].Object)
 	require.Equal(t, "child", evts[1].Author)
+}
+
+func TestTransferResponseProc_EmptyMessageDoesNotEchoInheritedInput(t *testing.T) {
+	target := &mockAgent{name: "child"}
+	parent := &parentAgent{child: target}
+	inv := &agent.Invocation{
+		Agent:        parent,
+		AgentName:    "parent",
+		InvocationID: "inv-empty-message",
+		Message:      model.NewUserMessage("original user input"),
+		TransferInfo: &agent.TransferInfo{TargetAgentName: "child"},
+	}
+	rsp := &model.Response{ID: "r-empty-message", Created: time.Now().Unix(), Model: "m"}
+	out := make(chan *event.Event, 10)
+	NewTransferResponseProcessor(true).ProcessResponse(context.Background(), inv, &model.Request{}, rsp, out)
+	close(out)
+	var evts []*event.Event
+	for e := range out {
+		evts = append(evts, e)
+	}
+	require.Len(t, evts, 1)
+	require.Equal(t, model.ObjectTypeTransfer, evts[0].Object)
+	require.Equal(t, model.RoleUser, target.gotMessage.Role)
+	require.Equal(t, "original user input", target.gotMessage.Content)
+}
+
+func TestTransferResponseProc_CustomizerReceivesRawEmptyTransferMessage(t *testing.T) {
+	target := &mockAgent{name: "child"}
+	parent := &parentAgent{child: target}
+	var gotTransferMessage string
+	var gotTransferMessageOK bool
+	inv := &agent.Invocation{
+		Agent:        parent,
+		AgentName:    "parent",
+		InvocationID: "inv-empty-customize",
+		Message:      model.NewUserMessage("original user input"),
+		RunOptions: agent.RunOptions{
+			RuntimeState: map[string]any{
+				agent.RuntimeStateKeyTransferController: customizeTransferController{
+					message:            model.NewUserMessage("custom child input"),
+					transferMessage:    &gotTransferMessage,
+					hasTransferMessage: &gotTransferMessageOK,
+				},
+			},
+		},
+		TransferInfo: &agent.TransferInfo{TargetAgentName: "child"},
+	}
+	rsp := &model.Response{ID: "r-empty-customize", Created: time.Now().Unix(), Model: "m"}
+	out := make(chan *event.Event, 10)
+	NewTransferResponseProcessor(true).ProcessResponse(context.Background(), inv, &model.Request{}, rsp, out)
+	close(out)
+	for range out {
+	}
+	require.True(t, gotTransferMessageOK)
+	require.Empty(t, gotTransferMessage)
+	require.Equal(t, "custom child input", target.gotMessage.Content)
 }
 
 func TestTransferResponseProc_Target404(t *testing.T) {
@@ -313,6 +374,40 @@ func (t timeoutTransferController) OnTransfer(
 	return t.timeout, nil
 }
 
+type customizeTransferController struct {
+	message            model.Message
+	err                error
+	transferMessage    *string
+	hasTransferMessage *bool
+}
+
+func (c customizeTransferController) OnTransfer(
+	context.Context,
+	string,
+	string,
+) (time.Duration, error) {
+	return 0, nil
+}
+
+func (c customizeTransferController) CustomizeTransferInvocation(
+	ctx context.Context,
+	_ *agent.Invocation,
+	target *agent.Invocation,
+) error {
+	transferMessage, ok := itransfer.TransferMessageFromContext(ctx)
+	if c.transferMessage != nil {
+		*c.transferMessage = transferMessage
+	}
+	if c.hasTransferMessage != nil {
+		*c.hasTransferMessage = ok
+	}
+	if c.err != nil {
+		return c.err
+	}
+	target.Message = c.message
+	return nil
+}
+
 type structuredOutputCaptureModel struct {
 	name       string
 	mu         sync.Mutex
@@ -392,6 +487,87 @@ func TestTransferResponseProc_ControllerNodeTimeout(t *testing.T) {
 	for range out {
 	}
 	require.True(t, target.gotDeadline)
+}
+
+func TestTransferResponseProc_CustomizesTargetInvocation(t *testing.T) {
+	target := &mockAgent{name: "child"}
+	parent := &parentAgent{child: target}
+	inv := &agent.Invocation{
+		Agent:        parent,
+		AgentName:    "parent",
+		InvocationID: "inv-customize",
+		RunOptions: agent.RunOptions{
+			RuntimeState: map[string]any{
+				agent.RuntimeStateKeyTransferController: customizeTransferController{
+					message: model.NewUserMessage("custom child input"),
+				},
+			},
+		},
+		TransferInfo: &agent.TransferInfo{TargetAgentName: "child", Message: "parent transfer"},
+	}
+	rsp := &model.Response{ID: "r-customize"}
+	out := make(chan *event.Event, 10)
+	NewTransferResponseProcessor(true).ProcessResponse(
+		context.Background(),
+		inv,
+		&model.Request{},
+		rsp,
+		out,
+	)
+	close(out)
+	var echoedInput string
+	for evt := range out {
+		if evt != nil && evt.Author == "child" && evt.Tag == event.TransferTag && evt.Response != nil {
+			require.NotEmpty(t, evt.Response.Choices)
+			echoedInput = evt.Response.Choices[0].Message.Content
+		}
+	}
+	require.Equal(t, model.RoleUser, target.gotMessage.Role)
+	require.Equal(t, "custom child input", target.gotMessage.Content)
+	require.Equal(t, "custom child input", echoedInput)
+}
+
+func TestTransferResponseProc_CustomizerRejects(t *testing.T) {
+	target := &mockAgent{name: "child"}
+	parent := &parentAgent{child: target}
+	inv := &agent.Invocation{
+		Agent:        parent,
+		AgentName:    "parent",
+		InvocationID: "inv-customize-reject",
+		RunOptions: agent.RunOptions{
+			RuntimeState: map[string]any{
+				agent.RuntimeStateKeyTransferController: customizeTransferController{
+					err: errors.New("custom rejected"),
+				},
+			},
+		},
+		TransferInfo: &agent.TransferInfo{TargetAgentName: "child", Message: "parent transfer"},
+	}
+	rsp := &model.Response{ID: "r-customize-reject"}
+	out := make(chan *event.Event, 10)
+	NewTransferResponseProcessor(true).ProcessResponse(
+		context.Background(),
+		inv,
+		&model.Request{},
+		rsp,
+		out,
+	)
+	close(out)
+	var errorEvent *event.Event
+	var transferEvents int
+	for evt := range out {
+		if evt != nil && evt.Tag == event.TransferTag {
+			transferEvents++
+		}
+		if evt != nil && evt.Error != nil {
+			errorEvent = evt
+		}
+	}
+	require.NotNil(t, errorEvent)
+	require.Contains(t, errorEvent.Error.Message, "custom rejected")
+	require.Zero(t, transferEvents)
+	require.Nil(t, inv.TransferInfo)
+	require.False(t, target.invoked)
 }
 
 func TestTransferResponseProc_PreservesRunStructuredOutput(t *testing.T) {

--- a/internal/transfer/transfer.go
+++ b/internal/transfer/transfer.go
@@ -1,0 +1,40 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+// Package transfer contains internal transfer extension contracts.
+package transfer
+
+import (
+	"context"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+)
+
+type transferMessageContextKey struct{}
+
+// ContextWithTransferMessage returns a context carrying the raw transfer message.
+func ContextWithTransferMessage(ctx context.Context, message string) context.Context {
+	return context.WithValue(ctx, transferMessageContextKey{}, message)
+}
+
+// TransferMessageFromContext returns the raw transfer message carried by ctx.
+func TransferMessageFromContext(ctx context.Context) (string, bool) {
+	message, ok := ctx.Value(transferMessageContextKey{}).(string)
+	return message, ok
+}
+
+// InvocationCustomizer customizes a transfer target invocation before it runs.
+type InvocationCustomizer interface {
+	CustomizeTransferInvocation(
+		ctx context.Context,
+		source *agent.Invocation,
+		target *agent.Invocation,
+	) error
+}

--- a/team/options.go
+++ b/team/options.go
@@ -19,6 +19,7 @@ type options struct {
 	memberTools          memberToolOptions
 	swarm                SwarmConfig
 	crossRequestTransfer bool
+	swarmHandoffInput    SwarmHandoffInputBuilder
 }
 
 // HistoryScope controls whether and how member AgentTools inherit parent
@@ -169,6 +170,26 @@ func WithSwarmConfig(cfg SwarmConfig) Option {
 func WithCrossRequestTransfer(enabled bool) Option {
 	return func(o *options) {
 		o.crossRequestTransfer = enabled
+	}
+}
+
+// WithSwarmHandoffInputBuilder sets the target input builder used by Swarm
+// handoffs.
+//
+// The builder runs after the transfer target invocation is created and after
+// the transfer message is installed as the default target input, but before
+// the target member starts. It can replace that default input with a
+// business-specific message, for example one rendered from the root user input
+// and a template. If the returned message has content but no role, the role is
+// normalized to user.
+//
+// When no builder is configured, the target member receives the
+// transfer_to_agent message as a user message.
+//
+// This only applies to swarm teams.
+func WithSwarmHandoffInputBuilder(builder SwarmHandoffInputBuilder) Option {
+	return func(o *options) {
+		o.swarmHandoffInput = builder
 	}
 }
 

--- a/team/options_test.go
+++ b/team/options_test.go
@@ -1,0 +1,31 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package team
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+func TestWithSwarmHandoffInputBuilder_ConfiguresBuilder(t *testing.T) {
+	inputBuilder := func(context.Context, SwarmHandoffInputArgs) (model.Message, error) {
+		return model.NewUserMessage("input"), nil
+	}
+	opts := defaultOptions("team")
+	WithSwarmHandoffInputBuilder(inputBuilder)(&opts)
+	require.NotNil(t, opts.swarmHandoffInput)
+	msg, err := opts.swarmHandoffInput(context.Background(), SwarmHandoffInputArgs{})
+	require.NoError(t, err)
+	require.Equal(t, "input", msg.Content)
+}

--- a/team/runtime.go
+++ b/team/runtime.go
@@ -17,14 +17,16 @@ import (
 	"time"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
+	itransfer "trpc.group/trpc-go/trpc-agent-go/internal/transfer"
+	"trpc.group/trpc-go/trpc-agent-go/model"
 )
 
 type swarmRuntime struct {
-	mu sync.Mutex
-
-	cfg      SwarmConfig
-	handoffs int
-	recent   []string
+	mu           sync.Mutex
+	cfg          SwarmConfig
+	inputBuilder SwarmHandoffInputBuilder
+	handoffs     int
+	recent       []string
 }
 
 func (sr *swarmRuntime) OnTransfer(
@@ -60,18 +62,85 @@ func (sr *swarmRuntime) OnTransfer(
 	return sr.cfg.NodeTimeout, nil
 }
 
-func ensureSwarmRuntime(inv *agent.Invocation, cfg SwarmConfig) {
+func (sr *swarmRuntime) CustomizeTransferInvocation(
+	ctx context.Context,
+	source *agent.Invocation,
+	target *agent.Invocation,
+) error {
+	if target == nil || sr.inputBuilder == nil {
+		return nil
+	}
+	transferMessage := target.Message.Content
+	if rawTransferMessage, ok := itransfer.TransferMessageFromContext(ctx); ok {
+		transferMessage = rawTransferMessage
+	}
+	msg, err := sr.inputBuilder(ctx, SwarmHandoffInputArgs{
+		FromAgentName:   sourceAgentName(source),
+		ToAgentName:     target.AgentName,
+		RootInput:       rootMessage(source),
+		ParentInput:     sourceMessage(source),
+		TransferMessage: transferMessage,
+	})
+	if err != nil {
+		return err
+	}
+	target.Message = normalizeHandoffInputMessage(msg)
+	return nil
+}
+
+func sourceAgentName(source *agent.Invocation) string {
+	if source == nil {
+		return ""
+	}
+	return source.AgentName
+}
+
+func sourceMessage(source *agent.Invocation) model.Message {
+	if source == nil {
+		return model.Message{}
+	}
+	return source.Message
+}
+
+func rootMessage(source *agent.Invocation) model.Message {
+	msg := sourceMessage(source)
+	for current := source; current != nil; current = current.GetParentInvocation() {
+		if model.HasPayload(current.Message) {
+			msg = current.Message
+		}
+	}
+	return msg
+}
+
+func normalizeHandoffInputMessage(msg model.Message) model.Message {
+	if msg.Role == "" && model.HasPayload(msg) {
+		msg.Role = model.RoleUser
+	}
+	return msg
+}
+
+func ensureSwarmRuntime(
+	inv *agent.Invocation,
+	cfg SwarmConfig,
+	inputBuilder SwarmHandoffInputBuilder,
+) {
 	if inv == nil {
 		return
 	}
-	if inv.RunOptions.RuntimeState == nil {
-		inv.RunOptions.RuntimeState = make(map[string]any)
-	}
-	key := agent.RuntimeStateKeyTransferController
-	if _, ok := inv.RunOptions.RuntimeState[key]; ok {
+	cloneRuntimeStateForSwarm(&inv.RunOptions)
+	runtime := &swarmRuntime{cfg: cfg, inputBuilder: inputBuilder}
+	installSwarmTransferController(&inv.RunOptions, runtime)
+}
+
+func cloneRuntimeStateForSwarm(opts *agent.RunOptions) {
+	if opts == nil {
 		return
 	}
-	inv.RunOptions.RuntimeState[key] = &swarmRuntime{cfg: cfg}
+	cloned := make(map[string]any, len(opts.RuntimeState)+1)
+	for key, value := range opts.RuntimeState {
+		cloned[key] = value
+	}
+	opts.RuntimeState = cloned
 }
 
 var (
@@ -84,4 +153,97 @@ func uniqueCount(values []string) int {
 		seen[v] = struct{}{}
 	}
 	return len(seen)
+}
+
+func installSwarmTransferController(opts *agent.RunOptions, next agent.TransferController) {
+	if opts == nil || next == nil {
+		return
+	}
+	if opts.RuntimeState == nil {
+		opts.RuntimeState = make(map[string]any)
+	}
+	existing, _ := agent.GetRuntimeStateValue[agent.TransferController](
+		opts,
+		agent.RuntimeStateKeyTransferController,
+	)
+	opts.RuntimeState[agent.RuntimeStateKeyTransferController] = composeTransferControllers(
+		stripSwarmTransferControllers(existing),
+		next,
+	)
+}
+
+func stripSwarmTransferControllers(controller agent.TransferController) agent.TransferController {
+	switch c := controller.(type) {
+	case nil:
+		return nil
+	case *swarmRuntime:
+		return nil
+	case chainedTransferController:
+		return composeTransferControllers(
+			stripSwarmTransferControllers(c.first),
+			stripSwarmTransferControllers(c.second),
+		)
+	default:
+		return controller
+	}
+}
+
+func composeTransferControllers(
+	first agent.TransferController,
+	second agent.TransferController,
+) agent.TransferController {
+	if first == nil {
+		return second
+	}
+	if second == nil {
+		return first
+	}
+	return chainedTransferController{first: first, second: second}
+}
+
+type chainedTransferController struct {
+	first  agent.TransferController
+	second agent.TransferController
+}
+
+func (c chainedTransferController) OnTransfer(
+	ctx context.Context,
+	fromAgent string,
+	toAgent string,
+) (time.Duration, error) {
+	firstTimeout, err := c.first.OnTransfer(ctx, fromAgent, toAgent)
+	if err != nil {
+		return 0, err
+	}
+	secondTimeout, err := c.second.OnTransfer(ctx, fromAgent, toAgent)
+	if err != nil {
+		return 0, err
+	}
+	return tighterTimeout(firstTimeout, secondTimeout), nil
+}
+
+func (c chainedTransferController) CustomizeTransferInvocation(
+	ctx context.Context,
+	source *agent.Invocation,
+	target *agent.Invocation,
+) error {
+	if first, ok := c.first.(itransfer.InvocationCustomizer); ok && first != nil {
+		if err := first.CustomizeTransferInvocation(ctx, source, target); err != nil {
+			return err
+		}
+	}
+	if second, ok := c.second.(itransfer.InvocationCustomizer); ok && second != nil {
+		return second.CustomizeTransferInvocation(ctx, source, target)
+	}
+	return nil
+}
+
+func tighterTimeout(a time.Duration, b time.Duration) time.Duration {
+	if a <= 0 {
+		return b
+	}
+	if b <= 0 || a < b {
+		return a
+	}
+	return b
 }

--- a/team/runtime_test.go
+++ b/team/runtime_test.go
@@ -11,10 +11,14 @@ package team
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	itransfer "trpc.group/trpc-go/trpc-agent-go/internal/transfer"
+	"trpc.group/trpc-go/trpc-agent-go/model"
 )
 
 const (
@@ -60,4 +64,317 @@ func TestSwarmRuntime_OnTransfer_ReturnsNodeTimeout(t *testing.T) {
 	got, err := rt.OnTransfer(context.Background(), "a", "b")
 	require.NoError(t, err)
 	require.Equal(t, testTimeout, got)
+}
+
+type composedTransferController struct {
+	transfers  int
+	customized int
+}
+
+func (c *composedTransferController) OnTransfer(
+	context.Context,
+	string,
+	string,
+) (time.Duration, error) {
+	c.transfers++
+	return 2 * testTimeout, nil
+}
+
+func (c *composedTransferController) CustomizeTransferInvocation(
+	_ context.Context,
+	_ *agent.Invocation,
+	target *agent.Invocation,
+) error {
+	c.customized++
+	target.Message = model.NewUserMessage("existing")
+	return nil
+}
+
+func TestEnsureSwarmRuntime_PreservesExistingTransferControllerAndComposesCustomizer(t *testing.T) {
+	existing := &composedTransferController{}
+	inv := agent.NewInvocation(agent.WithInvocationRunOptions(agent.RunOptions{
+		RuntimeState: map[string]any{
+			agent.RuntimeStateKeyTransferController: existing,
+		},
+	}))
+	inputBuilder := func(ctx context.Context, args SwarmHandoffInputArgs) (model.Message, error) {
+		_ = ctx
+		return model.NewUserMessage(args.TransferMessage + "+swarm"), nil
+	}
+	ensureSwarmRuntime(
+		inv,
+		SwarmConfig{NodeTimeout: testTimeout},
+		inputBuilder,
+	)
+	controller, ok := agent.GetRuntimeStateValue[agent.TransferController](
+		&inv.RunOptions,
+		agent.RuntimeStateKeyTransferController,
+	)
+	require.True(t, ok)
+	timeout, err := controller.OnTransfer(context.Background(), "entry", "child")
+	require.NoError(t, err)
+	require.Equal(t, testTimeout, timeout)
+	require.Equal(t, 1, existing.transfers)
+	customizer, ok := controller.(itransfer.InvocationCustomizer)
+	require.True(t, ok)
+	target := agent.NewInvocation(agent.WithInvocationAgent(testAgent{name: "child"}))
+	require.NoError(t, customizer.CustomizeTransferInvocation(context.Background(), inv, target))
+	require.Equal(t, 1, existing.customized)
+	require.Equal(t, "existing+swarm", target.Message.Content)
+}
+
+func TestEnsureSwarmRuntime_IsolatesSharedRuntimeState(t *testing.T) {
+	sharedState := map[string]any{"tenant": "demo"}
+	invA := agent.NewInvocation(agent.WithInvocationRunOptions(agent.RunOptions{
+		RuntimeState: sharedState,
+	}))
+	invB := agent.NewInvocation(agent.WithInvocationRunOptions(agent.RunOptions{
+		RuntimeState: sharedState,
+	}))
+	ensureSwarmRuntime(
+		invA,
+		SwarmConfig{MaxHandoffs: 1},
+		nil,
+	)
+	ensureSwarmRuntime(
+		invB,
+		SwarmConfig{MaxHandoffs: 1},
+		nil,
+	)
+	require.NotContains(t, sharedState, agent.RuntimeStateKeyTransferController)
+	ctrlA, ok := agent.GetRuntimeStateValue[agent.TransferController](
+		&invA.RunOptions,
+		agent.RuntimeStateKeyTransferController,
+	)
+	require.True(t, ok)
+	ctrlB, ok := agent.GetRuntimeStateValue[agent.TransferController](
+		&invB.RunOptions,
+		agent.RuntimeStateKeyTransferController,
+	)
+	require.True(t, ok)
+	_, err := ctrlA.OnTransfer(context.Background(), "entry", "child")
+	require.NoError(t, err)
+	_, err = ctrlA.OnTransfer(context.Background(), "child", "entry")
+	require.Error(t, err)
+	_, err = ctrlB.OnTransfer(context.Background(), "entry", "child")
+	require.NoError(t, err)
+	invA.RunOptions.RuntimeState["branch"] = "a"
+	require.NotContains(t, sharedState, "branch")
+	require.NotContains(t, invB.RunOptions.RuntimeState, "branch")
+}
+
+func TestSwarmRuntime_CustomizeTransferInvocation_BuildsInput(t *testing.T) {
+	source := agent.NewInvocation(
+		agent.WithInvocationAgent(testAgent{name: "parent"}),
+		agent.WithInvocationMessage(model.NewUserMessage("raw user input")),
+	)
+	target := agent.NewInvocation(
+		agent.WithInvocationAgent(testAgent{name: "child"}),
+		agent.WithInvocationID("target-invocation"),
+		agent.WithInvocationMessage(model.NewUserMessage("parent supplied transfer")),
+	)
+	rt := &swarmRuntime{
+		inputBuilder: func(ctx context.Context, args SwarmHandoffInputArgs) (model.Message, error) {
+			require.Equal(t, "parent", args.FromAgentName)
+			require.Equal(t, "child", args.ToAgentName)
+			require.Equal(t, "raw user input", args.RootInput.Content)
+			require.Equal(t, "raw user input", args.ParentInput.Content)
+			require.Equal(t, "parent supplied transfer", args.TransferMessage)
+			_ = ctx
+			return model.Message{Content: "rendered child input"}, nil
+		},
+	}
+	require.NoError(t, rt.CustomizeTransferInvocation(context.Background(), source, target))
+	require.Equal(t, model.RoleUser, target.Message.Role)
+	require.Equal(t, "rendered child input", target.Message.Content)
+}
+
+func TestSwarmRuntime_CustomizeTransferInvocation_UsesRawTransferMessage(t *testing.T) {
+	source := agent.NewInvocation(
+		agent.WithInvocationAgent(testAgent{name: "parent"}),
+		agent.WithInvocationMessage(model.NewUserMessage("original user input")),
+	)
+	target := agent.NewInvocation(
+		agent.WithInvocationAgent(testAgent{name: "child"}),
+		agent.WithInvocationMessage(model.NewUserMessage("original user input")),
+	)
+	rt := &swarmRuntime{
+		inputBuilder: func(ctx context.Context, args SwarmHandoffInputArgs) (model.Message, error) {
+			_ = ctx
+			require.Empty(t, args.TransferMessage)
+			return model.NewUserMessage("custom child input"), nil
+		},
+	}
+	ctx := itransfer.ContextWithTransferMessage(context.Background(), "")
+	require.NoError(t, rt.CustomizeTransferInvocation(ctx, source, target))
+	require.Equal(t, "custom child input", target.Message.Content)
+}
+
+func TestRootMessageUsesRootMostPayload(t *testing.T) {
+	root := agent.NewInvocation(
+		agent.WithInvocationID("root"),
+		agent.WithInvocationMessage(model.NewUserMessage("root input")),
+	)
+	parent := root.Clone(
+		agent.WithInvocationID("parent"),
+		agent.WithInvocationMessage(model.NewUserMessage("parent input")),
+	)
+	child := parent.Clone(
+		agent.WithInvocationID("child"),
+		agent.WithInvocationMessage(model.NewUserMessage("child input")),
+	)
+	require.Equal(t, "root input", rootMessage(child).Content)
+}
+
+func TestSwarmRuntime_CustomizeTransferInvocation_HandlesNilAndBuilderErrors(t *testing.T) {
+	called := false
+	rt := &swarmRuntime{
+		inputBuilder: func(context.Context, SwarmHandoffInputArgs) (model.Message, error) {
+			called = true
+			return model.NewUserMessage("unused"), nil
+		},
+	}
+	require.NoError(t, rt.CustomizeTransferInvocation(context.Background(), nil, nil))
+	require.False(t, called)
+	target := agent.NewInvocation(agent.WithInvocationMessage(model.NewUserMessage("original")))
+	require.NoError(t, (&swarmRuntime{}).CustomizeTransferInvocation(context.Background(), nil, target))
+	require.Equal(t, "original", target.Message.Content)
+	buildErr := errors.New("build failed")
+	rt = &swarmRuntime{
+		inputBuilder: func(ctx context.Context, args SwarmHandoffInputArgs) (model.Message, error) {
+			_ = ctx
+			require.Empty(t, args.FromAgentName)
+			require.Empty(t, args.RootInput.Content)
+			require.Empty(t, args.ParentInput.Content)
+			return model.Message{}, buildErr
+		},
+	}
+	require.ErrorIs(t, rt.CustomizeTransferInvocation(context.Background(), nil, target), buildErr)
+}
+
+func TestRuntimeControllerHelpers_HandleNilAndStripSwarmControllers(t *testing.T) {
+	require.NotPanics(t, func() {
+		ensureSwarmRuntime(nil, SwarmConfig{}, nil)
+	})
+	installSwarmTransferController(nil, &swarmRuntime{})
+	opts := &agent.RunOptions{}
+	installSwarmTransferController(opts, nil)
+	_, ok := agent.GetRuntimeStateValue[agent.TransferController](
+		opts,
+		agent.RuntimeStateKeyTransferController,
+	)
+	require.False(t, ok)
+	existing := &runtimeTestController{timeout: testTimeout}
+	require.Same(t, existing, composeTransferControllers(existing, nil))
+	require.Nil(t, stripSwarmTransferControllers(nil))
+	require.Nil(t, stripSwarmTransferControllers(&swarmRuntime{}))
+	require.Same(t, existing, stripSwarmTransferControllers(existing))
+	chained := chainedTransferController{
+		first:  &swarmRuntime{},
+		second: existing,
+	}
+	require.Same(t, existing, stripSwarmTransferControllers(chained))
+}
+
+func TestChainedTransferController_OnTransfer_PropagatesErrorsAndChoosesTimeout(t *testing.T) {
+	firstErr := errors.New("first transfer failed")
+	second := &runtimeTestController{timeout: testTimeout}
+	_, err := (chainedTransferController{
+		first:  &runtimeTestController{transferErr: firstErr},
+		second: second,
+	}).OnTransfer(context.Background(), "a", "b")
+	require.ErrorIs(t, err, firstErr)
+	require.Zero(t, second.transfers)
+	secondErr := errors.New("second transfer failed")
+	_, err = (chainedTransferController{
+		first:  &runtimeTestController{timeout: 2 * testTimeout},
+		second: &runtimeTestController{transferErr: secondErr},
+	}).OnTransfer(context.Background(), "a", "b")
+	require.ErrorIs(t, err, secondErr)
+	timeout, err := (chainedTransferController{
+		first:  &runtimeTestController{timeout: 2 * testTimeout},
+		second: &runtimeTestController{timeout: testTimeout},
+	}).OnTransfer(context.Background(), "a", "b")
+	require.NoError(t, err)
+	require.Equal(t, testTimeout, timeout)
+}
+
+func TestChainedTransferController_CustomizeTransferInvocation_PropagatesErrorsAndSkipsPlainControllers(t *testing.T) {
+	firstErr := errors.New("first customize failed")
+	second := &runtimeTestController{message: "second"}
+	target := agent.NewInvocation()
+	err := (chainedTransferController{
+		first:  &runtimeTestController{customizeErr: firstErr},
+		second: second,
+	}).CustomizeTransferInvocation(context.Background(), nil, target)
+	require.ErrorIs(t, err, firstErr)
+	require.Zero(t, second.customized)
+	secondErr := errors.New("second customize failed")
+	target = agent.NewInvocation()
+	err = (chainedTransferController{
+		first:  &runtimeTestController{message: "first"},
+		second: &runtimeTestController{customizeErr: secondErr},
+	}).CustomizeTransferInvocation(context.Background(), nil, target)
+	require.ErrorIs(t, err, secondErr)
+	require.Equal(t, "first", target.Message.Content)
+	target = agent.NewInvocation()
+	require.NoError(t, (chainedTransferController{
+		first:  plainTransferController{},
+		second: &runtimeTestController{message: "only customizer"},
+	}).CustomizeTransferInvocation(context.Background(), nil, target))
+	require.Equal(t, "only customizer", target.Message.Content)
+	require.NoError(t, (chainedTransferController{
+		first:  plainTransferController{},
+		second: plainTransferController{},
+	}).CustomizeTransferInvocation(context.Background(), nil, target))
+}
+
+func TestTighterTimeout_SelectsNonZeroMinimum(t *testing.T) {
+	require.Equal(t, 3*time.Second, tighterTimeout(0, 3*time.Second))
+	require.Equal(t, 3*time.Second, tighterTimeout(3*time.Second, 0))
+	require.Equal(t, 2*time.Second, tighterTimeout(2*time.Second, 3*time.Second))
+	require.Equal(t, 2*time.Second, tighterTimeout(3*time.Second, 2*time.Second))
+}
+
+type runtimeTestController struct {
+	timeout      time.Duration
+	transferErr  error
+	customizeErr error
+	message      string
+	transfers    int
+	customized   int
+}
+
+func (c *runtimeTestController) OnTransfer(
+	context.Context,
+	string,
+	string,
+) (time.Duration, error) {
+	c.transfers++
+	return c.timeout, c.transferErr
+}
+
+func (c *runtimeTestController) CustomizeTransferInvocation(
+	_ context.Context,
+	_ *agent.Invocation,
+	target *agent.Invocation,
+) error {
+	c.customized++
+	if c.customizeErr != nil {
+		return c.customizeErr
+	}
+	if c.message != "" {
+		target.Message = model.NewUserMessage(c.message)
+	}
+	return nil
+}
+
+type plainTransferController struct{}
+
+func (plainTransferController) OnTransfer(
+	context.Context,
+	string,
+	string,
+) (time.Duration, error) {
+	return 0, nil
 }

--- a/team/swarm.go
+++ b/team/swarm.go
@@ -9,7 +9,12 @@
 
 package team
 
-import "time"
+import (
+	"context"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
 
 // SwarmConfig defines optional safety limits for swarm-style handoffs.
 //
@@ -31,6 +36,18 @@ type SwarmConfig struct {
 	// A zero value disables this check.
 	RepetitiveHandoffMinUnique int
 }
+
+// SwarmHandoffInputArgs describes one Swarm handoff input rewrite.
+type SwarmHandoffInputArgs struct {
+	FromAgentName   string
+	ToAgentName     string
+	RootInput       model.Message
+	ParentInput     model.Message
+	TransferMessage string
+}
+
+// SwarmHandoffInputBuilder builds the target agent input message for a Swarm handoff.
+type SwarmHandoffInputBuilder func(ctx context.Context, args SwarmHandoffInputArgs) (model.Message, error)
 
 // DefaultSwarmConfig returns conservative defaults that prevent unbounded
 // transfer loops while keeping behavior predictable.

--- a/team/team.go
+++ b/team/team.go
@@ -45,6 +45,7 @@ type Team struct {
 	memberToolSet        tool.ToolSet
 	swarm                SwarmConfig
 	crossRequestTransfer bool
+	swarmHandoffInput    SwarmHandoffInputBuilder
 }
 
 // Mode controls how a Team runs.
@@ -174,6 +175,7 @@ func NewSwarm(
 		memberByName:         memberByName,
 		swarm:                cfg.swarm,
 		crossRequestTransfer: cfg.crossRequestTransfer,
+		swarmHandoffInput:    cfg.swarmHandoffInput,
 	}, nil
 }
 
@@ -271,7 +273,7 @@ func (t *Team) runSwarm(
 		}
 	}
 
-	ensureSwarmRuntime(invocation, t.swarm)
+	ensureSwarmRuntime(invocation, t.swarm, t.swarmHandoffInput)
 	memberPathAllocator := istructure.NewPathAllocator(traceRootNodeID)
 	var memberNodeID string
 	startAgentName := startAgent.Info().Name

--- a/team/team_test.go
+++ b/team/team_test.go
@@ -1564,6 +1564,58 @@ func (m *teamScriptedSurfaceModel) Requests() []*teamSurfaceCapturedRequest {
 	return out
 }
 
+func TestRunnerRun_SwarmHandoffInputBuilder_RewritesTargetInput(t *testing.T) {
+	parentModel := &teamScriptedSurfaceModel{
+		name: "swarm-parent-model",
+		responses: []model.Message{
+			teamToolCallAssistantMessage(
+				transfertool.TransferToolName,
+				`{"agent_name":"child","message":"transfer payload"}`,
+			),
+		},
+	}
+	childModel := &teamScriptedSurfaceModel{
+		name:      "swarm-child-model",
+		responses: []model.Message{model.NewAssistantMessage("child done")},
+	}
+	parent := llmagent.New("parent", llmagent.WithModel(parentModel))
+	child := llmagent.New("child", llmagent.WithModel(childModel))
+	swarm, err := NewSwarm(
+		"support",
+		"parent",
+		[]agent.Agent{parent, child},
+		WithSwarmHandoffInputBuilder(func(ctx context.Context, args SwarmHandoffInputArgs) (model.Message, error) {
+			_ = ctx
+			require.Equal(t, "parent", args.FromAgentName)
+			require.Equal(t, "child", args.ToAgentName)
+			require.Equal(t, "original user input", args.RootInput.Content)
+			require.Equal(t, "transfer payload", args.TransferMessage)
+			return model.NewUserMessage("CUSTOM_CHILD_INPUT: " + args.RootInput.Content), nil
+		}),
+	)
+	require.NoError(t, err)
+	r := runner.NewRunner(
+		"app",
+		swarm,
+		runner.WithSessionService(sessioninmemory.NewSessionService()),
+	)
+	eventCh, err := r.Run(
+		context.Background(),
+		"user-swarm-builder",
+		"session-swarm-builder",
+		model.NewUserMessage("original user input"),
+	)
+	require.NoError(t, err)
+	completion := collectTeamRunnerCompletionEvent(t, eventCh)
+	require.NotNil(t, completion.Response)
+	require.Equal(t, 1, parentModel.RequestCount())
+	require.Equal(t, 1, childModel.RequestCount())
+	require.True(t, teamMessagesContainContent(
+		childModel.LatestRequest().messages,
+		"CUSTOM_CHILD_INPUT: original user input",
+	))
+}
+
 func TestRunnerRun_WithSurfacePatchForNode_AppliesCoordinatorAndMemberPatches(
 	t *testing.T,
 ) {
@@ -1792,6 +1844,15 @@ func teamFirstSystemMessageContent(messages []model.Message) string {
 		}
 	}
 	return ""
+}
+
+func teamMessagesContainContent(messages []model.Message, content string) bool {
+	for _, msg := range messages {
+		if strings.Contains(msg.Content, content) {
+			return true
+		}
+	}
+	return false
 }
 
 func mustExportTeamSnapshot(


### PR DESCRIPTION
Adds a Swarm handoff input builder option so applications can rewrite the target member input from root input, parent input, and transfer message before the transfer target runs, with internal transfer invocation customization plumbing and docs for the new behavior.