### PR TITLE
flow: attach tool call args to tool results

### DIFF
--- a/docs/mkdocs/en/event.md
+++ b/docs/mkdocs/en/event.md
@@ -52,6 +52,9 @@ type Event struct {
     // StateDelta contains state changes to be written to the session.
     StateDelta map[string][]byte `json:"stateDelta,omitempty"`
 
+    // Extensions stores optional event metadata.
+    Extensions map[string]json.RawMessage `json:"extensions,omitempty"`
+
     // StructuredOutput carries a typed, in-memory structured payload (not serialized).
     StructuredOutput any `json:"-"`
 
@@ -417,6 +420,37 @@ if evt.Response != nil && evt.Object == model.ObjectTypeToolResponse && len(evt.
 ```
 
 Tip: For custom events, always use `event.New(...)` with `WithResponse`, `WithBranch`, etc., to ensure IDs and timestamps are set consistently.
+
+### Tool Call Arguments on Tool Responses
+
+Tool response events can carry the final tool-call arguments in
+`Event.Extensions`. This is useful when an event consumer needs to render a
+business-specific display name for a tool result, but that name depends on the
+arguments used for the original tool call.
+
+Use `event.ToolCallArgsExtensionKey` to read a `map[string]string`, where the
+key is the tool call ID and the value is the JSON argument string:
+
+```go
+argsByID, ok, err := event.GetExtension[map[string]string](
+    evt,
+    event.ToolCallArgsExtensionKey,
+)
+if err != nil {
+    // Extension payload had an unexpected shape.
+    return err
+}
+if ok {
+    argsJSON := argsByID[toolCallID]
+    // Use argsJSON to compute a display name, e.g. "Query game time".
+}
+```
+
+The stored arguments are the final arguments used by the framework after
+`BeforeTool` callbacks and argument repair. When parallel tool calls are merged
+into one `tool.response` event, the same extension map can contain entries for
+multiple tool call IDs. Treat this extension as optional so older or custom
+events without it remain compatible.
 
 ### GraphAgent Node-emitted Events (non-LLM output)
 

--- a/docs/mkdocs/zh/event.md
+++ b/docs/mkdocs/zh/event.md
@@ -52,6 +52,9 @@ type Event struct {
     // StateDelta 是需要写入会话状态的增量（例如 Processor 产出的状态变更）
     StateDelta map[string][]byte `json:"stateDelta,omitempty"`
 
+    // Extensions 存放事件上的可选元数据
+    Extensions map[string]json.RawMessage `json:"extensions,omitempty"`
+
     // StructuredOutput 携带类型化的内存内结构化输出，不参与序列化
     StructuredOutput any `json:"-"`
 
@@ -411,6 +414,35 @@ if evt.Response != nil && evt.Object == model.ObjectTypeToolResponse && len(evt.
 ```
 
 提示：自定义事件时，优先使用 `event.New(...)` 搭配 `WithResponse`、`WithBranch` 等，以保证 ID 和时间戳等元数据一致。
+
+### 工具响应中的工具调用参数
+
+工具响应事件可以通过 `Event.Extensions` 携带最终的工具调用参数。这个能力适合
+事件消费方根据工具调用参数计算业务展示名称，例如同一个 `gametime` 工具根据
+`query` 或 `set` 参数显示为“查询游戏时长”或“设置游戏时长”。
+
+使用 `event.ToolCallArgsExtensionKey` 可以读取一个 `map[string]string`，
+其中 key 是 tool call ID，value 是 JSON 参数字符串：
+
+```go
+argsByID, ok, err := event.GetExtension[map[string]string](
+    evt,
+    event.ToolCallArgsExtensionKey,
+)
+if err != nil {
+    // 扩展数据结构不符合预期
+    return err
+}
+if ok {
+    argsJSON := argsByID[toolCallID]
+    // 使用 argsJSON 计算展示名称，例如“查询游戏时长”
+}
+```
+
+这里保存的是框架最终执行工具时使用的参数，已经包含 `BeforeTool` 回调或参数
+修复后的结果。当多个并行工具调用被合并到同一个 `tool.response` 事件时，
+这个扩展 map 中可能同时包含多个 tool call ID。消费方应把该扩展视为可选，
+以兼容旧事件或自定义事件。
 
 ### GraphAgent 节点自定义事件（非 LLM 输出）
 

--- a/event/event.go
+++ b/event/event.go
@@ -52,6 +52,10 @@ const (
 
 	// TransferTag is the tag for transfer event.
 	TransferTag = "transfer"
+
+	// ToolCallArgsExtensionKey stores tool call arguments keyed by tool call ID
+	// on tool result events.
+	ToolCallArgsExtensionKey = "trpc_agent.tool_call_args"
 )
 
 // Event represents an event in conversation between agents and users.

--- a/internal/flow/processor/functioncall.go
+++ b/internal/flow/processor/functioncall.go
@@ -450,6 +450,7 @@ func (p *FunctionCallResponseProcessor) executeSingleToolCallSequentialResult(
 		tools,
 		toolCall,
 		index,
+		modifiedArgs,
 		skipSummarization,
 	)
 	if toolEvent == nil {
@@ -594,6 +595,7 @@ func (p *FunctionCallResponseProcessor) runParallelToolCall(
 			errorEvent := newToolCallResponseEvent(
 				invocation, llmResponse, []model.Choice{*errorChoice},
 			)
+			annotateToolCallArgs(errorEvent, tc, tc.Function.Arguments)
 			if tc.Function.Name == transfer.TransferToolName {
 				errorEvent.Tag = event.TransferTag
 			}
@@ -634,6 +636,7 @@ func (p *FunctionCallResponseProcessor) runParallelToolCall(
 		errorEvent := newToolCallResponseEvent(
 			invocation, llmResponse, []model.Choice{*errorChoice},
 		)
+		annotateToolCallArgs(errorEvent, tc, modifiedArgs)
 		errorEvent = p.decorateToolCallResponseEvent(
 			errorEvent,
 			tools,
@@ -657,6 +660,7 @@ func (p *FunctionCallResponseProcessor) runParallelToolCall(
 		tools,
 		tc,
 		index,
+		modifiedArgs,
 		skipSummarization,
 	)
 	if toolCallResponseEvent == nil {
@@ -717,6 +721,7 @@ func (p *FunctionCallResponseProcessor) buildToolCallResponseEvent(
 	tools map[string]tool.Tool,
 	toolCall model.ToolCall,
 	index int,
+	toolArgs []byte,
 	skipSummarization bool,
 ) *event.Event {
 	if len(choices) == 0 {
@@ -729,6 +734,7 @@ func (p *FunctionCallResponseProcessor) buildToolCallResponseEvent(
 				llmResponse,
 				toolCall,
 				index,
+				toolArgs,
 			),
 			tools,
 			toolCall,
@@ -736,8 +742,10 @@ func (p *FunctionCallResponseProcessor) buildToolCallResponseEvent(
 		)
 	}
 	annotateToolChoicesWithName(choices, toolCall.Function.Name)
+	ev := newToolCallResponseEvent(invocation, llmResponse, choices)
+	annotateToolCallArgs(ev, toolCall, toolArgs)
 	return p.decorateToolCallResponseEvent(
-		newToolCallResponseEvent(invocation, llmResponse, choices),
+		ev,
 		tools,
 		toolCall,
 		skipSummarization,
@@ -751,6 +759,45 @@ func annotateToolChoicesWithName(choices []model.Choice, toolName string) {
 			choices[i].Message.ToolName = toolName
 		}
 	}
+}
+
+func annotateToolCallArgs(
+	ev *event.Event,
+	toolCall model.ToolCall,
+	toolArgs []byte,
+) {
+	if toolArgs == nil {
+		toolArgs = toolCall.Function.Arguments
+	}
+	if err := setToolCallArgs(ev, toolCall.ID, toolArgs); err != nil {
+		log.Warnf("Failed to set tool call args extension: %v", err)
+	}
+}
+
+func setToolCallArgs(
+	ev *event.Event,
+	toolCallID string,
+	toolArgs []byte,
+) error {
+	if ev == nil || toolCallID == "" {
+		return nil
+	}
+	args, _, err := event.GetExtension[map[string]string](
+		ev,
+		event.ToolCallArgsExtensionKey,
+	)
+	if err != nil {
+		return err
+	}
+	if args == nil {
+		args = make(map[string]string)
+	}
+	args[toolCallID] = string(toolArgs)
+	return event.SetExtension(
+		ev,
+		event.ToolCallArgsExtensionKey,
+		args,
+	)
 }
 
 func (p *FunctionCallResponseProcessor) decorateToolCallResponseEvent(
@@ -1137,6 +1184,9 @@ func (p *FunctionCallResponseProcessor) buildMergedParallelEvent(
 			minimal = append(minimal, newMinimalToolChoice(tc, i))
 		}
 		mergedEvent = newToolCallResponseEvent(invocation, llmResponse, minimal)
+		for _, tc := range toolCalls {
+			annotateToolCallArgs(mergedEvent, tc, tc.Function.Arguments)
+		}
 		for _, tc := range toolCalls {
 			if tl, ok := tools[tc.Function.Name]; ok &&
 				toolPrefersSkipSummarization(tl) {
@@ -2239,12 +2289,15 @@ func newMinimalToolCallResponseEvent(
 	functionCallResponse *model.Response,
 	toolCall model.ToolCall,
 	index int,
+	toolArgs []byte,
 ) *event.Event {
-	return newToolCallResponseEvent(
+	ev := newToolCallResponseEvent(
 		invocation,
 		functionCallResponse,
 		[]model.Choice{newMinimalToolChoice(toolCall, index)},
 	)
+	annotateToolCallArgs(ev, toolCall, toolArgs)
+	return ev
 }
 
 func newMinimalToolChoice(
@@ -2272,12 +2325,22 @@ func mergeParallelToolCallResponseEvents(es []*event.Event) *event.Event {
 
 	mergedChoices := collectMergedChoices(es)
 	mergedDelta := collectStateDelta(es)
+	mergedToolArgs := collectToolCallArgs(es)
 	baseEvent := findBaseEvent(es)
 	resp := buildMergedToolResponse(baseEvent, mergedChoices)
 	mergedEvent := buildMergedEvent(baseEvent, resp)
 
 	if len(mergedDelta) > 0 {
 		mergedEvent.StateDelta = mergedDelta
+	}
+	if len(mergedToolArgs) > 0 {
+		if err := event.SetExtension(
+			mergedEvent,
+			event.ToolCallArgsExtensionKey,
+			mergedToolArgs,
+		); err != nil {
+			log.Warnf("Failed to merge tool call args extension: %v", err)
+		}
 	}
 	if shouldSkipSummarization(es) {
 		markSkipSummarization(mergedEvent)
@@ -2316,6 +2379,30 @@ func collectStateDelta(es []*event.Event) map[string][]byte {
 		}
 	}
 	return mergedDelta
+}
+
+func collectToolCallArgs(es []*event.Event) map[string]string {
+	var merged map[string]string
+	for _, e := range es {
+		args, ok, err := event.GetExtension[map[string]string](
+			e,
+			event.ToolCallArgsExtensionKey,
+		)
+		if err != nil {
+			log.Warnf("Failed to decode tool call args extension: %v", err)
+			continue
+		}
+		if !ok || len(args) == 0 {
+			continue
+		}
+		if merged == nil {
+			merged = make(map[string]string)
+		}
+		for toolCallID, toolArgs := range args {
+			merged[toolCallID] = toolArgs
+		}
+	}
+	return merged
 }
 
 // findBaseEvent finds a valid base event for metadata.

--- a/internal/flow/processor/functioncall.go
+++ b/internal/flow/processor/functioncall.go
@@ -81,6 +81,7 @@ type toolEventStateDelta struct {
 
 type resolvedToolContextKey struct{}
 type stateDeltaSessionBaselineContextKey struct{}
+type executingToolArgsContextKey struct{}
 
 // toolResult holds the result of a single tool execution.
 type toolResult struct {
@@ -88,6 +89,7 @@ type toolResult struct {
 	event      *event.Event
 	err        error
 	stateDelta *toolEventStateDelta
+	toolArgs   []byte
 }
 
 // Default message used when transferring to a sub-agent without an explicit message.
@@ -351,9 +353,7 @@ func (p *FunctionCallResponseProcessor) handleFunctionCalls(
 		if err != nil {
 			return nil, err
 		}
-		if result.event != nil {
-			toolResults = append(toolResults, result)
-		}
+		toolResults = append(toolResults, result)
 	}
 	toolCallResponsesEvents := p.attachStateDeltaToToolResults(
 		invocation,
@@ -373,7 +373,8 @@ func (p *FunctionCallResponseProcessor) handleFunctionCalls(
 	}
 
 	mergedEvent := p.buildMergedParallelEvent(
-		ctx, invocation, llmResponse, tools, toolCalls, toolCallResponsesEvents,
+		ctx, invocation, llmResponse, tools, toolCalls, toolResults,
+		toolCallResponsesEvents,
 	)
 	return mergedEvent, nil
 }
@@ -454,7 +455,7 @@ func (p *FunctionCallResponseProcessor) executeSingleToolCallSequentialResult(
 		skipSummarization,
 	)
 	if toolEvent == nil {
-		return toolResult{index: index}, nil
+		return toolResult{index: index, toolArgs: modifiedArgs}, nil
 	}
 	decl := p.lookupDeclaration(tools, toolCall.Function.Name)
 	var stateDelta *toolEventStateDelta
@@ -500,6 +501,7 @@ func (p *FunctionCallResponseProcessor) executeSingleToolCallSequentialResult(
 		index:      index,
 		event:      toolEvent,
 		stateDelta: stateDelta,
+		toolArgs:   modifiedArgs,
 	}, nil
 }
 
@@ -542,7 +544,11 @@ func (p *FunctionCallResponseProcessor) executeToolCallsInParallel(
 	toolResults, err := p.collectParallelToolResults(
 		ctx, resultChan, len(toolCalls),
 	)
-	if len(toolResults) == 0 &&
+	toolCallResponsesEvents := p.attachStateDeltaToToolResults(
+		invocation,
+		toolResults,
+	)
+	if len(toolCallResponsesEvents) == 0 &&
 		invocation != nil &&
 		invocation.RunOptions.ToolExecutionFilter != nil {
 		filter := invocation.RunOptions.ToolExecutionFilter
@@ -553,12 +559,9 @@ func (p *FunctionCallResponseProcessor) executeToolCallsInParallel(
 			}
 		}
 	}
-	toolCallResponsesEvents := p.attachStateDeltaToToolResults(
-		invocation,
-		toolResults,
-	)
 	mergedEvent := p.buildMergedParallelEvent(
-		ctx, invocation, llmResponse, tools, toolCalls, toolCallResponsesEvents,
+		ctx, invocation, llmResponse, tools, toolCalls, toolResults,
+		toolCallResponsesEvents,
 	)
 	return mergedEvent, err
 }
@@ -576,6 +579,11 @@ func (p *FunctionCallResponseProcessor) runParallelToolCall(
 	tc model.ToolCall,
 ) {
 	defer wg.Done()
+	toolArgs := tc.Function.Arguments
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx = context.WithValue(ctx, executingToolArgsContextKey{}, &toolArgs)
 	// Recover from panics to avoid breaking sibling goroutines.
 	defer func() {
 		if r := recover(); r != nil {
@@ -595,11 +603,15 @@ func (p *FunctionCallResponseProcessor) runParallelToolCall(
 			errorEvent := newToolCallResponseEvent(
 				invocation, llmResponse, []model.Choice{*errorChoice},
 			)
-			annotateToolCallArgs(errorEvent, tc, tc.Function.Arguments)
+			annotateToolCallArgs(errorEvent, tc, toolArgs)
 			if tc.Function.Name == transfer.TransferToolName {
 				errorEvent.Tag = event.TransferTag
 			}
-			p.sendToolResult(ctx, resultChan, toolResult{index: index, event: errorEvent})
+			p.sendToolResult(ctx, resultChan, toolResult{
+				index:    index,
+				event:    errorEvent,
+				toolArgs: toolArgs,
+			})
 		}
 	}()
 	// Trace the tool execution for observability.
@@ -618,6 +630,7 @@ func (p *FunctionCallResponseProcessor) runParallelToolCall(
 			index,
 			eventChan,
 		)
+	toolArgs = modifiedArgs
 	// Handle errors based on whether they are ignorable or critical.
 	if err != nil {
 		log.ErrorfContext(
@@ -648,7 +661,12 @@ func (p *FunctionCallResponseProcessor) runParallelToolCall(
 		if !shouldIgnoreError {
 			returnErr = err
 		}
-		p.sendToolResult(ctx, resultChan, toolResult{index: index, event: errorEvent, err: returnErr})
+		p.sendToolResult(ctx, resultChan, toolResult{
+			index:    index,
+			event:    errorEvent,
+			err:      returnErr,
+			toolArgs: modifiedArgs,
+		})
 		return
 	}
 
@@ -664,7 +682,10 @@ func (p *FunctionCallResponseProcessor) runParallelToolCall(
 		skipSummarization,
 	)
 	if toolCallResponseEvent == nil {
-		p.sendToolResult(ctx, resultChan, toolResult{index: index})
+		p.sendToolResult(ctx, resultChan, toolResult{
+			index:    index,
+			toolArgs: modifiedArgs,
+		})
 		return
 	}
 	// Include declaration for telemetry even when tool is missing.
@@ -710,6 +731,7 @@ func (p *FunctionCallResponseProcessor) runParallelToolCall(
 			index:      index,
 			event:      toolCallResponseEvent,
 			stateDelta: stateDelta,
+			toolArgs:   modifiedArgs,
 		},
 	)
 }
@@ -1175,8 +1197,17 @@ func (p *FunctionCallResponseProcessor) buildMergedParallelEvent(
 	llmResponse *model.Response,
 	tools map[string]tool.Tool,
 	toolCalls []model.ToolCall,
+	toolResults []toolResult,
 	toolCallEvents []*event.Event,
 ) *event.Event {
+	toolArgsByIndex := make(map[int][]byte, len(toolResults))
+	for _, result := range toolResults {
+		if result.index >= 0 && result.index < len(toolCalls) &&
+			result.toolArgs != nil {
+			toolArgsByIndex[result.index] = result.toolArgs
+		}
+	}
+
 	var mergedEvent *event.Event
 	if len(toolCallEvents) == 0 {
 		minimal := make([]model.Choice, 0, len(toolCalls))
@@ -1184,9 +1215,6 @@ func (p *FunctionCallResponseProcessor) buildMergedParallelEvent(
 			minimal = append(minimal, newMinimalToolChoice(tc, i))
 		}
 		mergedEvent = newToolCallResponseEvent(invocation, llmResponse, minimal)
-		for _, tc := range toolCalls {
-			annotateToolCallArgs(mergedEvent, tc, tc.Function.Arguments)
-		}
 		for _, tc := range toolCalls {
 			if tl, ok := tools[tc.Function.Name]; ok &&
 				toolPrefersSkipSummarization(tl) {
@@ -1196,6 +1224,9 @@ func (p *FunctionCallResponseProcessor) buildMergedParallelEvent(
 		}
 	} else {
 		mergedEvent = mergeParallelToolCallResponseEvents(toolCallEvents)
+	}
+	for i, tc := range toolCalls {
+		annotateToolCallArgs(mergedEvent, tc, toolArgsByIndex[i])
 	}
 	if len(toolCallEvents) > 1 {
 		_, span, startedSpan := itrace.StartSpan(
@@ -1485,7 +1516,7 @@ func (p *FunctionCallResponseProcessor) collectParallelToolResults(
 		case result, ok := <-resultChan:
 			if !ok {
 				// Channel closed, all results received.
-				return p.filterNilToolResults(results), err
+				return p.compactToolResults(results), err
 			}
 			if result.index >= 0 && result.index < len(results) {
 				results[result.index] = result
@@ -1506,7 +1537,7 @@ func (p *FunctionCallResponseProcessor) collectParallelToolResults(
 				ctx,
 				"Context cancelled while waiting for tool results",
 			)
-			return p.filterNilToolResults(results), nil
+			return p.compactToolResults(results), nil
 		}
 	}
 }
@@ -1717,6 +1748,7 @@ func (p *FunctionCallResponseProcessor) executeToolWithCallbacks(
 	if jsonrepair.IsToolCallArgumentsJSONRepairEnabled(invocation) {
 		jsonrepair.RepairToolCallArgumentsInPlace(ctx, &toolCall)
 	}
+	rememberExecutingToolArgs(ctx, toolCall.Function.Arguments)
 	toolDeclaration := tl.Declaration()
 	ctx, toolCall, customResult, err := p.runBeforeToolPluginCallbacks(
 		ctx,
@@ -1727,6 +1759,7 @@ func (p *FunctionCallResponseProcessor) executeToolWithCallbacks(
 	if err != nil {
 		return ctx, nil, toolCall.Function.Arguments, false, false, err
 	}
+	rememberExecutingToolArgs(ctx, toolCall.Function.Arguments)
 	if customResult != nil {
 		ctx = withStateDeltaSessionBaseline(ctx, invocation)
 		return ctx, customResult, toolCall.Function.Arguments, false,
@@ -1741,6 +1774,7 @@ func (p *FunctionCallResponseProcessor) executeToolWithCallbacks(
 		return ctx, nil, toolCall.Function.Arguments, false, false, err
 	}
 	ctx = withStateDeltaSessionBaseline(ctx, invocation)
+	rememberExecutingToolArgs(ctx, toolCall.Function.Arguments)
 	if customResult != nil {
 		return ctx, customResult, toolCall.Function.Arguments, false,
 			false, nil
@@ -1811,6 +1845,17 @@ func (p *FunctionCallResponseProcessor) executeToolWithCallbacks(
 	}
 	return ctx, toolResult, toolCall.Function.Arguments,
 		suppressDefaultToolMessage, skipSummarization || localSkip, toolErr
+}
+
+func rememberExecutingToolArgs(ctx context.Context, args []byte) {
+	if ctx == nil {
+		return
+	}
+	tracker, ok := ctx.Value(executingToolArgsContextKey{}).(*[]byte)
+	if !ok || tracker == nil {
+		return
+	}
+	*tracker = args
 }
 
 // afterCallbackReplacedResult returns true when the after-tool callback has
@@ -2249,15 +2294,15 @@ func marshalChunkToText(content any) string {
 	}
 }
 
-// filterNilToolResults filters out nil events while preserving order.
-// Pre-allocates capacity to avoid multiple memory allocations.
-func (p *FunctionCallResponseProcessor) filterNilToolResults(
+// compactToolResults keeps received tool results while preserving order.
+// Results without an event may still carry executed args for merged metadata.
+func (p *FunctionCallResponseProcessor) compactToolResults(
 	results []toolResult,
 ) []toolResult {
-	// Pre-allocate with capacity to reduce allocations
 	filtered := make([]toolResult, 0, len(results))
 	for _, result := range results {
-		if result.event != nil {
+		if result.event != nil || result.toolArgs != nil ||
+			result.err != nil || result.stateDelta != nil {
 			filtered = append(filtered, result)
 		}
 	}

--- a/internal/flow/processor/functioncall_test.go
+++ b/internal/flow/processor/functioncall_test.go
@@ -3478,6 +3478,123 @@ func TestRunParallelToolCall_LongRunningToolNoImmediateResult(t *testing.T) {
 	assert.NoError(t, res.err)
 }
 
+func TestRunParallelToolCall_PanicUsesModifiedArgsExtension(t *testing.T) {
+	const (
+		originalArgs = `{"action":"query"}`
+		modifiedArgs = `{"action":"set"}`
+	)
+	callbacks := tool.NewCallbacks()
+	callbacks.RegisterBeforeTool(func(
+		_ context.Context,
+		_ *tool.BeforeToolArgs,
+	) (*tool.BeforeToolResult, error) {
+		return &tool.BeforeToolResult{
+			ModifiedArguments: []byte(modifiedArgs),
+		}, nil
+	})
+	p := NewFunctionCallResponseProcessor(true, callbacks)
+	tools := map[string]tool.Tool{
+		"panic": &mockTool{name: "panic", shouldPanic: true},
+	}
+	tc := model.ToolCall{
+		ID: "call-panic",
+		Function: model.FunctionDefinitionParam{
+			Name:      "panic",
+			Arguments: []byte(originalArgs),
+		},
+	}
+	inv := &agent.Invocation{AgentName: "panic-agent"}
+	llmResp := &model.Response{Model: "mock"}
+	resultChan := make(chan toolResult, 1)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	p.runParallelToolCall(
+		context.Background(),
+		&wg,
+		inv,
+		llmResp,
+		tools,
+		nil,
+		resultChan,
+		0,
+		tc,
+	)
+	wg.Wait()
+	close(resultChan)
+
+	res, ok := <-resultChan
+	require.True(t, ok)
+	require.NotNil(t, res.event)
+	argsByID, found, err := event.GetExtension[map[string]string](
+		res.event,
+		event.ToolCallArgsExtensionKey,
+	)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, modifiedArgs, argsByID["call-panic"])
+}
+
+func TestHandleFunctionCalls_ParallelLongRunningNilResultUsesModifiedArgs(
+	t *testing.T,
+) {
+	callbacks := tool.NewCallbacks()
+	callbacks.RegisterBeforeTool(func(
+		_ context.Context,
+		args *tool.BeforeToolArgs,
+	) (*tool.BeforeToolResult, error) {
+		return &tool.BeforeToolResult{
+			ModifiedArguments: []byte(fmt.Sprintf(
+				`{"call_id":%q,"action":"set"}`,
+				args.ToolCallID,
+			)),
+		}, nil
+	})
+	p := NewFunctionCallResponseProcessor(true, callbacks)
+	tools := map[string]tool.Tool{
+		"long-a": &mockNilLongRunningTool{name: "long-a"},
+		"long-b": &mockNilLongRunningTool{name: "long-b"},
+	}
+	toolCalls := []model.ToolCall{
+		{
+			ID: "call-a",
+			Function: model.FunctionDefinitionParam{
+				Name:      "long-a",
+				Arguments: []byte(`{"action":"query"}`),
+			},
+		},
+		{
+			ID: "call-b",
+			Function: model.FunctionDefinitionParam{
+				Name:      "long-b",
+				Arguments: []byte(`{"action":"query"}`),
+			},
+		},
+	}
+	llmResp := &model.Response{Model: "mock", Choices: []model.Choice{{
+		Message: model.Message{ToolCalls: toolCalls},
+	}}}
+	inv := &agent.Invocation{InvocationID: "inv-long", AgentName: "agent"}
+
+	ev, err := p.handleFunctionCalls(
+		context.Background(),
+		inv,
+		llmResp,
+		tools,
+		nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, ev)
+	argsByID, found, err := event.GetExtension[map[string]string](
+		ev,
+		event.ToolCallArgsExtensionKey,
+	)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, `{"call_id":"call-a","action":"set"}`, argsByID["call-a"])
+	require.Equal(t, `{"call_id":"call-b","action":"set"}`, argsByID["call-b"])
+}
+
 func TestExecuteToolCall_ToolNotFound_ReturnsErrorChoice(t *testing.T) {
 	ctx := context.Background()
 	p := NewFunctionCallResponseProcessor(false, nil)

--- a/internal/flow/processor/functioncall_test.go
+++ b/internal/flow/processor/functioncall_test.go
@@ -180,6 +180,61 @@ func TestExecuteSingleToolCallSequential_DisableTracingSkipsSpanCreation(t *test
 	require.Empty(t, recorder.Ended())
 }
 
+func TestExecuteSingleToolCallSequential_AddsToolCallArgsExtension(t *testing.T) {
+	const (
+		originalArgs = `{"action":"query"}`
+		modifiedArgs = `{"action":"set"}`
+	)
+	callbacks := tool.NewCallbacks()
+	callbacks.RegisterBeforeTool(func(
+		_ context.Context,
+		args *tool.BeforeToolArgs,
+	) (*tool.BeforeToolResult, error) {
+		return &tool.BeforeToolResult{
+			ModifiedArguments: []byte(modifiedArgs),
+		}, nil
+	})
+	p := NewFunctionCallResponseProcessor(false, callbacks)
+	invocation := agent.NewInvocation()
+	invocation.AgentName = "test-agent"
+	response := &model.Response{Model: "mock-model"}
+	toolCall := model.ToolCall{
+		ID: "call-1",
+		Function: model.FunctionDefinitionParam{
+			Name:      "gametime",
+			Arguments: []byte(originalArgs),
+		},
+	}
+	tools := map[string]tool.Tool{
+		"gametime": &mockCallableTool{
+			declaration: &tool.Declaration{Name: "gametime"},
+			callFn: func(_ context.Context, args []byte) (any, error) {
+				require.Equal(t, modifiedArgs, string(args))
+				return "ok", nil
+			},
+		},
+	}
+
+	toolEvent, err := p.executeSingleToolCallSequential(
+		context.Background(),
+		invocation,
+		response,
+		tools,
+		nil,
+		0,
+		toolCall,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, toolEvent)
+	argsByID, ok, err := event.GetExtension[map[string]string](
+		toolEvent,
+		event.ToolCallArgsExtensionKey,
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, modifiedArgs, argsByID["call-1"])
+}
+
 func TestExecuteToolCallsInParallel_DisableTracingSkipsSpanCreation(t *testing.T) {
 	recorder := useSpanRecorder(t)
 	p := NewFunctionCallResponseProcessor(true, nil)
@@ -4950,6 +5005,33 @@ func TestMergeParallelToolCallResponseEvents_MergesStateDelta(t *testing.T) {
 	require.NotNil(t, merged)
 	require.Equal(t, []byte("override"), merged.StateDelta["k1"])
 	require.Equal(t, []byte("v2"), merged.StateDelta["k2"])
+}
+
+func TestMergeParallelToolCallResponseEvents_MergesToolCallArgs(t *testing.T) {
+	e1 := event.New("inv1", "author", event.WithResponse(&model.Response{Model: "m"}))
+	require.NoError(t, event.SetExtension(
+		e1,
+		event.ToolCallArgsExtensionKey,
+		map[string]string{"call-1": `{"action":"query"}`},
+	))
+
+	e2 := event.New("inv2", "author", event.WithResponse(&model.Response{Model: "m"}))
+	require.NoError(t, event.SetExtension(
+		e2,
+		event.ToolCallArgsExtensionKey,
+		map[string]string{"call-2": `{"action":"set"}`},
+	))
+
+	merged := mergeParallelToolCallResponseEvents([]*event.Event{e1, e2})
+	require.NotNil(t, merged)
+	argsByID, ok, err := event.GetExtension[map[string]string](
+		merged,
+		event.ToolCallArgsExtensionKey,
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, `{"action":"query"}`, argsByID["call-1"])
+	require.Equal(t, `{"action":"set"}`, argsByID["call-2"])
 }
 
 func TestMergeParallelToolCallResponseEvents_FallbackWithoutBaseEvent(t *testing.T) {


### PR DESCRIPTION
## Summary
- Attach final tool-call arguments to tool result events through event.Extensions.
- Expose event.ToolCallArgsExtensionKey so consumers can read args by tool call ID using event.GetExtension[map[string]string].
- Merge tool-call args metadata when parallel tool results are collapsed into one event.

## Tests
- go test ./event ./internal/flow/processor -count=1
- go test ./... (fails in unrelated knowledge/document/reader/golang TestChunkedReaderUsesRepoRootForScope: document "demo.Serve" not found; the same focused test fails when rerun alone)
