### PR TITLE
{runner, docs/mkdocs}: add user message rewriter tool transcript coverage

### DIFF
--- a/docs/mkdocs/en/runner.md
+++ b/docs/mkdocs/en/runner.md
@@ -723,8 +723,23 @@ func rewriteUserMessage(
         return []model.Message{args.OriginalMessage}, nil
     }
     if needsContext(raw) {
+        const toolCallID = "call_business_context"
+        businessContext := loadBusinessContext(raw)
         return []model.Message{
             model.NewUserMessage("Please interpret the following request with the business context below."),
+            {
+                Role:    model.RoleAssistant,
+                Content: "I will load the business context before refining the user request.",
+                ToolCalls: []model.ToolCall{{
+                    Type: "function",
+                    ID:   toolCallID,
+                    Function: model.FunctionDefinitionParam{
+                        Name:      "load_business_context",
+                        Arguments: []byte(`{"source":"crm"}`),
+                    },
+                }},
+            },
+            model.NewToolMessage(toolCallID, "load_business_context", businessContext),
             model.NewUserMessage(raw),
         }, nil
     }

--- a/docs/mkdocs/zh/runner.md
+++ b/docs/mkdocs/zh/runner.md
@@ -688,8 +688,23 @@ func rewriteUserMessage(
         return []model.Message{args.OriginalMessage}, nil
     }
     if needsContext(raw) {
+        const toolCallID = "call_business_context"
+        businessContext := loadBusinessContext(raw)
         return []model.Message{
             model.NewUserMessage("请先结合以下业务上下文理解用户问题。"),
+            {
+                Role:    model.RoleAssistant,
+                Content: "我会先读取业务上下文，再整理用户请求。",
+                ToolCalls: []model.ToolCall{{
+                    Type: "function",
+                    ID:   toolCallID,
+                    Function: model.FunctionDefinitionParam{
+                        Name:      "load_business_context",
+                        Arguments: []byte(`{"source":"crm"}`),
+                    },
+                }},
+            },
+            model.NewToolMessage(toolCallID, "load_business_context", businessContext),
             model.NewUserMessage(raw),
         }, nil
     }

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -5705,6 +5705,76 @@ func TestRunner_Run_UserMessageRewriter_RewritesCurrentTurnMessages(t *testing.T
 	require.Equal(t, "rewritten", sess.Events[1].Choices[0].Message.Content)
 }
 
+func TestRunner_Run_UserMessageRewriter_RewritesCurrentTurnToolTranscript(t *testing.T) {
+	toolCall := model.ToolCall{
+		Type: "function",
+		ID:   "call_1",
+		Function: model.FunctionDefinitionParam{
+			Name:      "lookup",
+			Arguments: []byte(`{"query":"hello"}`),
+		},
+	}
+	assistantMessage := model.Message{
+		Role:      model.RoleAssistant,
+		Content:   "calling lookup",
+		ToolCalls: []model.ToolCall{toolCall},
+	}
+	rewritten := []model.Message{
+		model.NewUserMessage("first user"),
+		assistantMessage,
+		model.NewToolMessage("call_1", "lookup", `{"answer":"world"}`),
+		model.NewUserMessage("final user"),
+	}
+	modelStub := &sequentialModel{
+		name: "seq",
+		responses: []*model.Response{{
+			ID:   "resp-1",
+			Done: true,
+			Choices: []model.Choice{{
+				Index:   0,
+				Message: model.NewAssistantMessage("ok"),
+			}},
+		}},
+	}
+	svc := sessioninmemory.NewSessionService()
+	ag := llmagent.New("a", llmagent.WithModel(modelStub))
+	r := NewRunner("app", ag, WithSessionService(svc))
+	ch, err := r.Run(
+		context.Background(),
+		"u",
+		"s",
+		model.NewUserMessage("hello"),
+		agent.WithUserMessageRewriter(func(
+			ctx context.Context,
+			args *agent.UserMessageRewriteArgs,
+		) ([]model.Message, error) {
+			return rewritten, nil
+		}),
+	)
+	require.NoError(t, err)
+	for range ch {
+	}
+	requests := modelStub.Requests()
+	require.Len(t, requests, 1)
+	require.Equal(t, rewritten, requests[0].messages)
+	sess, err := svc.GetSession(
+		context.Background(),
+		session.Key{AppName: "app", UserID: "u", SessionID: "s"},
+	)
+	require.NoError(t, err)
+	require.Len(t, sess.Events, 5)
+	require.Equal(t, model.RoleUser, sess.Events[0].Choices[0].Message.Role)
+	require.Equal(t, model.RoleAssistant, sess.Events[1].Choices[0].Message.Role)
+	require.Equal(t, model.RoleTool, sess.Events[2].Choices[0].Message.Role)
+	require.Equal(t, model.RoleUser, sess.Events[3].Choices[0].Message.Role)
+	require.Equal(t, rewritten, []model.Message{
+		sess.Events[0].Choices[0].Message,
+		sess.Events[1].Choices[0].Message,
+		sess.Events[2].Choices[0].Message,
+		sess.Events[3].Choices[0].Message,
+	})
+}
+
 func TestRunner_Run_UserMessageRewriter_EmptyResultReturnsError(t *testing.T) {
 	svc := sessioninmemory.NewSessionService()
 	r := NewRunner("app", &noOpAgent{name: "a"}, WithSessionService(svc))


### PR DESCRIPTION
Documents UserMessageRewriter with a user/assistant/tool/user rewrite sequence, showing how a synthetic assistant tool call and its tool result can precede the final user request while preserving the rewritten transcript order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated UserMessageRewriter examples in English and Chinese documentation with enhanced workflow demonstrations.

* **Tests**
  * Added test case validating message rewriting functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trpc-group/trpc-agent-go/pull/1784)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->