### PR TITLE
openclaw: stream tool detail

### DIFF
--- a/openclaw/gwclient/client_test.go
+++ b/openclaw/gwclient/client_test.go
@@ -606,6 +606,7 @@ func TestClient_StreamMessageWithOptions_EnablesGatewayProgressAfterDelta(
 	)
 	require.Equal(t, "Running local tool", events[3].Summary)
 	require.Equal(t, "demo_tool", events[3].ToolName)
+	require.Empty(t, events[3].ToolDetail)
 	require.Equal(t, "call-demo", events[3].ToolCallID)
 	require.Equal(t, gwproto.StreamToolStatusRunning, events[3].ToolStatus)
 	require.Equal(
@@ -839,6 +840,7 @@ func TestParseSSEStream_EventFallbackAndErrors(t *testing.T) {
 			"event: run.progress\n"+
 				"data: {\"summary\":\"Preparing\","+
 				"\"tool_name\":\"kb_search\","+
+				"\"tool_detail\":\"query docs\","+
 				"\"tool_call_id\":\"call-1\","+
 				"\"tool_status\":\"running\"}\n\n",
 		),
@@ -848,6 +850,7 @@ func TestParseSSEStream_EventFallbackAndErrors(t *testing.T) {
 	evt := <-out
 	require.Equal(t, gwproto.StreamEventTypeRunProgress, evt.Type)
 	require.Equal(t, "kb_search", evt.ToolName)
+	require.Equal(t, "query docs", evt.ToolDetail)
 	require.Equal(t, "call-1", evt.ToolCallID)
 	require.Equal(t, gwproto.StreamToolStatusRunning, evt.ToolStatus)
 

--- a/openclaw/gwproto/types.go
+++ b/openclaw/gwproto/types.go
@@ -155,6 +155,7 @@ type StreamEvent struct {
 	Stage      StreamProgressStage `json:"stage,omitempty"`
 	Summary    string              `json:"summary,omitempty"`
 	ToolName   string              `json:"tool_name,omitempty"`
+	ToolDetail string              `json:"tool_detail,omitempty"`
 	ToolCallID string              `json:"tool_call_id,omitempty"`
 	ToolStatus StreamToolStatus    `json:"tool_status,omitempty"`
 	ElapsedMS  int64               `json:"elapsed_ms,omitempty"`

--- a/openclaw/internal/gateway/server_test.go
+++ b/openclaw/internal/gateway/server_test.go
@@ -4171,6 +4171,7 @@ func TestStreamProgressHelpers(t *testing.T) {
 	)
 	require.Equal(t, "Reading document page 2", update.summary)
 	require.Equal(t, streamToolReadDocument, update.toolName)
+	require.Equal(t, "page 2", update.toolDetail)
 	require.Equal(t, testReadDocumentToolCallID, update.toolCallID)
 	require.Equal(
 		t,
@@ -4198,6 +4199,7 @@ func TestStreamProgressHelpers(t *testing.T) {
 	)
 	require.Equal(t, progressSummaryAnswering, update.summary)
 	require.Equal(t, streamToolReadDocument, update.toolName)
+	require.Empty(t, update.toolDetail)
 	require.Equal(t, testReadDocumentToolCallID, update.toolCallID)
 	require.Equal(
 		t,
@@ -4224,6 +4226,7 @@ func TestToolCallProgressSummaries(t *testing.T) {
 	)
 	require.Equal(t, "Reading spreadsheet rows 2-4", update.summary)
 	require.Equal(t, streamToolReadSheet, update.toolName)
+	require.Equal(t, "rows 2-4", update.toolDetail)
 	require.Equal(t, testReadDocumentToolCallID, update.toolCallID)
 	require.Equal(
 		t,
@@ -4244,6 +4247,7 @@ func TestToolCallProgressSummaries(t *testing.T) {
 		update.stage,
 	)
 	require.Equal(t, progressSummaryGoTest, update.summary)
+	require.Equal(t, "go test ./...", update.toolDetail)
 
 	update, ok = progressFromToolCall(model.ToolCall{
 		Function: model.FunctionDefinitionParam{
@@ -4253,6 +4257,7 @@ func TestToolCallProgressSummaries(t *testing.T) {
 	})
 	require.True(t, ok)
 	require.Equal(t, progressSummaryGit, update.summary)
+	require.Equal(t, "git status", update.toolDetail)
 
 	update, ok = progressFromToolCall(model.ToolCall{
 		Function: model.FunctionDefinitionParam{
@@ -4262,6 +4267,138 @@ func TestToolCallProgressSummaries(t *testing.T) {
 	})
 	require.True(t, ok)
 	require.Equal(t, progressSummaryInspect, update.summary)
+	require.Equal(t, "rg TODO .", update.toolDetail)
+
+	update, ok = progressFromToolCall(model.ToolCall{
+		Function: model.FunctionDefinitionParam{
+			Name: streamToolExecCommand,
+			Arguments: []byte(
+				`{"command":"bash -lc 'go test ./...'"}`,
+			),
+		},
+	})
+	require.True(t, ok)
+	require.Equal(t, progressSummaryGoTest, update.summary)
+	require.Equal(t, "go test ./...", update.toolDetail)
+
+	update, ok = progressFromToolCall(model.ToolCall{
+		Function: model.FunctionDefinitionParam{
+			Name: streamToolExecCommand,
+			Arguments: []byte(
+				`{"command":"cd repo && GOFLAGS=-count=1 go test ./..."}`,
+			),
+		},
+	})
+	require.True(t, ok)
+	require.Equal(t, progressSummaryGoTest, update.summary)
+	require.Equal(t, "go test ./...", update.toolDetail)
+
+	update, ok = progressFromToolCall(model.ToolCall{
+		Function: model.FunctionDefinitionParam{
+			Name: streamToolExecCommand,
+			Arguments: []byte(
+				`{"command":"make test"}`,
+			),
+		},
+	})
+	require.True(t, ok)
+	require.Equal(t, progressSummaryTool, update.summary)
+	require.Equal(t, "make test", update.toolDetail)
+
+	update, ok = progressFromToolCall(model.ToolCall{
+		Function: model.FunctionDefinitionParam{
+			Name: streamToolExecCommand,
+			Arguments: []byte(
+				`{"command":"gh pr view 123"}`,
+			),
+		},
+	})
+	require.True(t, ok)
+	require.Equal(t, progressSummaryTool, update.summary)
+	require.Equal(t, "gh pr view 123", update.toolDetail)
+
+	update, ok = progressFromToolCall(model.ToolCall{
+		Function: model.FunctionDefinitionParam{
+			Name: streamToolReadFile,
+			Arguments: []byte(
+				`{"path":"/workspace/openclaw/channel/wecom/a.go"}`,
+			),
+		},
+	})
+	require.True(t, ok)
+	require.Equal(t, progressSummaryTool, update.summary)
+	require.Equal(t, ".../channel/wecom/a.go", update.toolDetail)
+
+	update, ok = progressFromToolCall(model.ToolCall{
+		Function: model.FunctionDefinitionParam{
+			Name: streamToolExecCommand,
+			Arguments: []byte(
+				`{"command":"printf %s 'sk-test-secret'"}`,
+			),
+		},
+	})
+	require.True(t, ok)
+	require.Equal(t, "printf", update.toolDetail)
+
+	update, ok = progressFromToolCall(model.ToolCall{
+		Function: model.FunctionDefinitionParam{
+			Name: streamToolExecCommand,
+			Arguments: []byte(
+				`{"command":"go test --token visible ./safe"}`,
+			),
+		},
+	})
+	require.True(t, ok)
+	require.Equal(t, "go test safe", update.toolDetail)
+
+	update, ok = progressFromToolCall(model.ToolCall{
+		Function: model.FunctionDefinitionParam{
+			Name: streamToolExecCommand,
+			Arguments: []byte(
+				`{"command":"rg tokenizer.go ./openclaw"}`,
+			),
+		},
+	})
+	require.True(t, ok)
+	require.Equal(t, "rg tokenizer.go openclaw", update.toolDetail)
+
+	update, ok = progressFromToolCall(model.ToolCall{
+		Function: model.FunctionDefinitionParam{
+			Name: streamToolExecCommand,
+			Arguments: []byte(
+				`{"command":"curl -H 'Authorization: Bearer sk-test' ` +
+					`https://api.example.com/v1?token=x"}`,
+			),
+		},
+	})
+	require.True(t, ok)
+	require.NotContains(t, update.toolDetail, "Authorization")
+	require.NotContains(t, update.toolDetail, "sk-test")
+	require.Equal(t, "curl -H api.example.com/v1", update.toolDetail)
+
+	update, ok = progressFromToolCall(model.ToolCall{
+		Function: model.FunctionDefinitionParam{
+			Name: "browser",
+			Arguments: []byte(
+				`{"action":"navigate","url":"https://example.com/a?token=x"}`,
+			),
+		},
+	})
+	require.True(t, ok)
+	require.Equal(t, progressSummaryTool, update.summary)
+	require.Equal(t, "browser", update.toolName)
+	require.Equal(t, "navigate example.com/a", update.toolDetail)
+
+	update, ok = progressFromToolCall(model.ToolCall{
+		Function: model.FunctionDefinitionParam{
+			Name: "custom_tool",
+			Arguments: []byte(
+				`{"auth_token":"sk-test","path":"tokenizer.go"}`,
+			),
+		},
+	})
+	require.True(t, ok)
+	require.Equal(t, "tokenizer.go", update.toolDetail)
 
 	update, ok = progressFromToolCall(model.ToolCall{
 		Function: model.FunctionDefinitionParam{
@@ -4293,6 +4430,250 @@ func TestToolCallProgressSummaries(t *testing.T) {
 			},
 		}),
 	)
+}
+
+func TestStreamToolDetailHelpers(t *testing.T) {
+	t.Parallel()
+
+	toolCall := func(name, args string) model.ToolCall {
+		return model.ToolCall{
+			Function: model.FunctionDefinitionParam{
+				Name:      name,
+				Arguments: []byte(args),
+			},
+		}
+	}
+	detail := func(name, args string) string {
+		return toolDetailFromToolCall(toolCall(name, args))
+	}
+
+	require.Empty(t, detail(streamToolExecCommand, "{"))
+	require.Empty(t, detail(streamToolReadDocument, "{"))
+	require.Empty(t, detail(streamToolReadSheet, "{"))
+	require.Empty(t, detail("custom_tool", "{"))
+	require.Empty(t, detail(streamToolReadFile, `{}`))
+	require.Empty(t, detail(streamToolSearch, `{}`))
+	_, ok := stringArgFromToolCall(
+		toolCall(streamToolReadFile, "{"),
+		streamToolArgPath,
+	)
+	require.False(t, ok)
+
+	require.Equal(
+		t,
+		".../project/docs/report.pdf page 3",
+		detail(
+			streamToolReadDocument,
+			`{"path":"/workspace/project/docs/report.pdf","page":3}`,
+		),
+	)
+	require.Equal(
+		t,
+		"workspace/data/book.xlsx sheet Data row 7",
+		detail(
+			streamToolReadSheet,
+			`{"path":"/workspace/data/book.xlsx",`+
+				`"sheet":"Data","row":7}`,
+		),
+	)
+	require.Equal(
+		t,
+		"book.xlsx row 3",
+		detail(
+			streamToolReadSheet,
+			`{"path":"book.xlsx","start_row":3}`,
+		),
+	)
+	require.Equal(
+		t,
+		"TODO",
+		detail(streamToolSearch, `{"pattern":"TODO"}`),
+	)
+	require.Equal(
+		t,
+		"same q",
+		detail(
+			"custom_tool",
+			`{"action":"same","operation":"same","query":"q"}`,
+		),
+	)
+	require.Equal(
+		t,
+		"job 123 session abc",
+		detail(
+			"custom_tool",
+			`{"job_id":"123","session_id":"abc"}`,
+		),
+	)
+	require.Equal(
+		t,
+		"safe",
+		detail("custom_tool", `{"id":123,"name":"safe"}`),
+	)
+	require.Equal(
+		t,
+		"github",
+		detail("skill_load", `{"skill":"github"}`),
+	)
+	require.Equal(
+		t,
+		"github refs/api.md",
+		detail(
+			"skill_select_docs",
+			`{"skill":"github","docs":["refs/api.md"]}`,
+		),
+	)
+	require.Equal(
+		t,
+		"github refs/a.md",
+		detail(
+			"skill_select_docs",
+			`{"skill":"github","docs":["refs/a.md","refs/b.md"]}`,
+		),
+	)
+	require.Equal(
+		t,
+		"example.com/a",
+		detail(
+			"web_fetch",
+			`{"urls":["https://example.com/a?token=x"]}`,
+		),
+	)
+	require.Equal(
+		t,
+		"example.com/ok",
+		detail(
+			"web_fetch",
+			`{"urls":["https://sk-secret.example.com",`+
+				`"https://example.com/ok"]}`,
+		),
+	)
+	require.Equal(
+		t,
+		"example.com/a example.com/b",
+		detail(
+			"web_fetch",
+			`{"urls":["https://example.com/a","https://example.com/a",`+
+				`"","https://example.com/b","https://example.com/c"]}`,
+		),
+	)
+	require.Equal(
+		t,
+		"notes/todo.md",
+		detail(
+			"fs_save_file",
+			`{"file_name":"notes/todo.md","contents":"secret"}`,
+		),
+	)
+	require.Equal(
+		t,
+		"preferred.md",
+		detail(
+			"fs_save_file",
+			`{"path":"preferred.md","file_name":"fallback.md"}`,
+		),
+	)
+
+	update, ok := progressFromToolCall(model.ToolCall{
+		Function: model.FunctionDefinitionParam{
+			Name: streamToolSearch,
+			Arguments: []byte(
+				`{"query":"搜索 tokenizer.go"}`,
+			),
+		},
+	})
+	require.True(t, ok)
+	require.Equal(t, "搜索 tokenizer.go", update.toolDetail)
+
+	update, ok = progressFromToolCall(model.ToolCall{
+		Function: model.FunctionDefinitionParam{
+			Name: streamToolExecCommand,
+			Arguments: []byte(
+				`{"command":"sed -n '1,5p' openclaw/channel/wecom/a.go"}`,
+			),
+		},
+	})
+	require.True(t, ok)
+	require.Equal(t, "sed .../channel/wecom/a.go", update.toolDetail)
+
+	update, ok = progressFromToolCall(model.ToolCall{
+		Function: model.FunctionDefinitionParam{
+			Name: streamToolExecCommand,
+			Arguments: []byte(
+				`{"command":"python -m pytest tests/unit"}`,
+			),
+		},
+	})
+	require.True(t, ok)
+	require.Equal(t, progressSummaryPytest, update.summary)
+	require.Equal(t, "pytest tests/unit", update.toolDetail)
+
+	update, ok = progressFromToolCall(model.ToolCall{
+		Function: model.FunctionDefinitionParam{
+			Name: streamToolExecCommand,
+			Arguments: []byte(
+				`{"command":"npm run test --workspace app"}`,
+			),
+		},
+	})
+	require.True(t, ok)
+	require.Equal(t, progressSummaryNPMTest, update.summary)
+	require.Equal(t, "npm run test --workspace app", update.toolDetail)
+
+	require.Equal(
+		t,
+		"printf",
+		shellCommandDetail(`printf 'a;b' && git status`),
+	)
+	require.Equal(t, "git status", shellCommandDetail(`cd repo && git status`))
+	require.Equal(
+		t,
+		"node script.js --env prod",
+		shellCommandDetail(`NODE_ENV=test node script.js --env prod`),
+	)
+	require.Equal(t, "shell loop", shellCommandDetail(`for f in *.go; do`))
+	require.Equal(t, "git status", shellCommandDetail(`; git status`))
+	require.Equal(t, "echo hello world", shellCommandDetail(`echo hello\ world`))
+	require.Equal(t, "ls", shellCommandDetail(`ls -la`))
+	require.Equal(t, "npm", shellCommandDetail(`npm`))
+	require.Equal(t, "pnpm install", shellCommandDetail(`pnpm install`))
+	require.Equal(
+		t,
+		"python script.py --mode test",
+		shellCommandDetail(`python script.py --mode test`),
+	)
+	require.Empty(t, shellCommandDetail(`set -e && export TOKEN=x`))
+	require.Empty(t, shellCommandDetail(`bash`))
+	require.Empty(t, shellCommandDetail(`bash -c`))
+	require.Empty(t, shellCommandDetail(`. env.sh`))
+	require.Empty(t, safeCommandName("sk-secret"))
+	require.Empty(t, safeCommandArgDetail("--count=1"))
+	require.Empty(t, safePathDetail("/"))
+	require.Equal(t, ".", safePathDetail("."))
+	require.Equal(t, "..", safePathDetail(".."))
+	require.Empty(t, safeURLDetail("Bearer abc.def"))
+	require.Equal(t, "api.example.com/v1", safeURLDetail("api.example.com/v1"))
+	require.Empty(t, safeURLDetail("https://sk-secret.example.com"))
+	require.True(t, isSensitiveCommandFlag("--api-key=value"))
+	require.False(t, isSensitiveCommandFlag("--count=1"))
+	require.True(t, isSensitiveCommandKeyToken("Authorization:"))
+	require.False(t, isSensitiveCommandKeyToken("tokenizer.go"))
+	require.True(t, looksSensitiveCommandArg("--token=value"))
+	require.False(t, looksSensitiveCommandArg("--count=1"))
+	require.False(t, isSensitiveToolArgKey(""))
+	require.True(t, isSensitiveToolArgKey("user-key"))
+	require.False(t, looksSensitiveValue(""))
+	require.True(t, looksSensitiveValue("ghp_testtoken"))
+	require.True(t, looksSensitiveValue("tgit_testtoken"))
+	require.False(t, looksLikeJWT("short"))
+	require.False(t, looksLikeJWT("aaaaaaaa.bbbbbbbb"))
+	require.False(t, looksLikeJWT("aaaaaaaa.bbbbbbbb.invalid+part"))
+	require.True(
+		t,
+		looksSensitiveValue("aaaaaaaaaaaa.bbbbbbbbbbbb.cccccccccccc"),
+	)
+	require.True(t, isBase64URLLike("Abc123-_"))
+	require.False(t, isBase64URLLike("abc+def"))
 }
 
 func TestSendProgressUpdateAndHelpers(t *testing.T) {
@@ -4330,6 +4711,24 @@ func TestSendProgressUpdateAndHelpers(t *testing.T) {
 	evt := <-out
 	require.Equal(t, gwproto.StreamEventTypeRunProgress, evt.Type)
 	require.Equal(t, progressSummaryPrepare, evt.Summary)
+
+	require.True(t, sendProgressUpdate(
+		ctx,
+		out,
+		run,
+		state,
+		progressUpdate{
+			stage:      gwproto.StreamProgressStageRunningTool,
+			summary:    progressSummaryGoTest,
+			toolName:   streamToolExecCommand,
+			toolDetail: "go test ./...",
+			toolCallID: "call-1",
+			toolStatus: gwproto.StreamToolStatusRunning,
+		},
+	))
+	evt = <-out
+	require.Equal(t, streamToolExecCommand, evt.ToolName)
+	require.Equal(t, "go test ./...", evt.ToolDetail)
 
 	canceledCtx, cancel := context.WithCancel(ctx)
 	cancel()

--- a/openclaw/internal/gateway/stream.go
+++ b/openclaw/internal/gateway/stream.go
@@ -15,8 +15,11 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
+	"path/filepath"
 	"strings"
 	"time"
+	"unicode"
 
 	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/log"
@@ -31,14 +34,103 @@ const (
 	traceStatusError    = "error"
 	traceStatusCanceled = "canceled"
 
-	streamToolExecCommand    = "exec_command"
-	streamToolReadDocument   = "read_document"
-	streamToolReadSheet      = "read_spreadsheet"
-	streamToolReadFile       = "fs_read_file"
-	streamToolSaveFile       = "fs_save_file"
-	streamToolListDir        = "fs_list_dir"
-	streamToolSearch         = "fs_search"
-	streamToolApplyPatch     = "apply_patch"
+	streamToolExecCommand  = "exec_command"
+	streamToolReadDocument = "read_document"
+	streamToolReadSheet    = "read_spreadsheet"
+	streamToolReadFile     = "fs_read_file"
+	streamToolSaveFile     = "fs_save_file"
+	streamToolListDir      = "fs_list_dir"
+	streamToolSearch       = "fs_search"
+	streamToolApplyPatch   = "apply_patch"
+
+	streamToolArgCommand   = "command"
+	streamToolArgPath      = "path"
+	streamToolArgQuery     = "query"
+	streamToolArgPattern   = "pattern"
+	streamToolArgSkill     = "skill"
+	streamToolArgDocs      = "docs"
+	streamToolArgAction    = "action"
+	streamToolArgOperation = "operation"
+	streamToolArgURL       = "url"
+	streamToolArgURLs      = "urls"
+	streamToolArgFile      = "file"
+	streamToolArgFilePath  = "file_path"
+	streamToolArgFileName  = "file_name"
+	streamToolArgFilename  = "filename"
+	streamToolArgID        = "id"
+	streamToolArgName      = "name"
+	streamToolArgTitle     = "title"
+	streamToolArgTarget    = "target"
+	streamToolArgElement   = "element"
+	streamToolArgSelector  = "selector"
+	streamToolArgRef       = "ref"
+	streamToolArgKey       = "key"
+	streamToolArgJobID     = "job_id"
+	streamToolArgSession   = "session_id"
+	streamToolArgRow       = "row"
+	streamToolArgStartRow  = "start_row"
+	streamToolArgEndRow    = "end_row"
+	streamToolArgSheet     = "sheet"
+
+	streamToolDetailRowsPrefix  = "rows "
+	streamToolDetailRowPrefix   = "row "
+	streamToolDetailPagePrefix  = "page "
+	streamToolDetailSheetPrefix = "sheet "
+	streamToolDetailJobPrefix   = "job "
+	streamToolDetailSessPrefix  = "session "
+	streamToolDetailRefPrefix   = "ref "
+	streamToolDetailKeyPrefix   = "key "
+	streamToolDetailSeparator   = " "
+	streamToolDetailMaxRunes    = 96
+	streamToolDetailMaxParts    = 2
+	streamToolPathEllipsis      = "..."
+	streamToolPathSeparator     = "/"
+
+	streamCommandCD        = "cd"
+	streamCommandSet       = "set"
+	streamCommandExport    = "export"
+	streamCommandSource    = "source"
+	streamCommandDot       = "."
+	streamCommandFor       = "for"
+	streamCommandShellLoop = "shell loop"
+	streamCommandBash      = "bash"
+	streamCommandSh        = "sh"
+	streamCommandZsh       = "zsh"
+	streamCommandGo        = "go"
+	streamCommandGit       = "git"
+	streamCommandRG        = "rg"
+	streamCommandSed       = "sed"
+	streamCommandCat       = "cat"
+	streamCommandHead      = "head"
+	streamCommandTail      = "tail"
+	streamCommandLS        = "ls"
+	streamCommandFind      = "find"
+	streamCommandPytest    = "pytest"
+	streamCommandPython    = "python"
+	streamCommandPython3   = "python3"
+	streamCommandNPM       = "npm"
+	streamCommandPNPM      = "pnpm"
+	streamCommandYarn      = "yarn"
+	streamCommandBun       = "bun"
+
+	streamCommandModuleFlag = "-m"
+	streamCommandShellFlag  = "-c"
+	streamCommandShellLogin = "-lc"
+	streamCommandArgLimit   = 4
+
+	streamSecretToken         = "token"
+	streamSecretSecret        = "secret"
+	streamSecretPassword      = "password"
+	streamSecretAuthorization = "authorization"
+	streamSecretBearer        = "bearer"
+	streamSecretAPIKey        = "api_key"
+	streamSecretAPIKeyFlat    = "apikey"
+	streamSecretCookie        = "cookie"
+	streamSecretKeySuffix     = "_key"
+	streamSecretOpenAIKey     = "sk-"
+	streamSecretGitHubToken   = "ghp_"
+	streamSecretTencentToken  = "tgit_"
+
 	progressSummaryPrepare   = "Preparing request"
 	progressSummaryDoc       = "Reading document"
 	progressSummarySheet     = "Reading spreadsheet"
@@ -61,8 +153,49 @@ type progressState struct {
 	stage      gwproto.StreamProgressStage
 	summary    string
 	toolName   string
+	toolDetail string
 	toolCallID string
 	toolStatus gwproto.StreamToolStatus
+}
+
+type streamToolArgKind int
+
+const (
+	streamToolArgKindText streamToolArgKind = iota
+	streamToolArgKindPath
+	streamToolArgKindURL
+)
+
+type streamToolDetailArg struct {
+	key    string
+	prefix string
+	kind   streamToolArgKind
+}
+
+var streamGenericToolDetailArgs = []streamToolDetailArg{
+	{key: streamToolArgSkill},
+	{key: streamToolArgDocs, kind: streamToolArgKindPath},
+	{key: streamToolArgAction},
+	{key: streamToolArgOperation},
+	{key: streamToolArgQuery},
+	{key: streamToolArgPattern},
+	{key: streamToolArgURL, kind: streamToolArgKindURL},
+	{key: streamToolArgURLs, kind: streamToolArgKindURL},
+	{key: streamToolArgPath, kind: streamToolArgKindPath},
+	{key: streamToolArgFilePath, kind: streamToolArgKindPath},
+	{key: streamToolArgFileName, kind: streamToolArgKindPath},
+	{key: streamToolArgFile, kind: streamToolArgKindPath},
+	{key: streamToolArgFilename, kind: streamToolArgKindPath},
+	{key: streamToolArgID},
+	{key: streamToolArgName},
+	{key: streamToolArgTitle},
+	{key: streamToolArgTarget},
+	{key: streamToolArgElement},
+	{key: streamToolArgSelector},
+	{key: streamToolArgRef, prefix: streamToolDetailRefPrefix},
+	{key: streamToolArgKey, prefix: streamToolDetailKeyPrefix},
+	{key: streamToolArgJobID, prefix: streamToolDetailJobPrefix},
+	{key: streamToolArgSession, prefix: streamToolDetailSessPrefix},
 }
 
 // StreamMessage processes a request and returns a stream of gateway
@@ -589,6 +722,7 @@ type progressUpdate struct {
 	stage      gwproto.StreamProgressStage
 	summary    string
 	toolName   string
+	toolDetail string
 	toolCallID string
 	toolStatus gwproto.StreamToolStatus
 }
@@ -648,6 +782,7 @@ func progressFromToolCall(
 	name := strings.TrimSpace(toolCall.Function.Name)
 	update := progressUpdate{
 		toolName:   name,
+		toolDetail: toolDetailFromToolCall(toolCall),
 		toolCallID: strings.TrimSpace(toolCall.ID),
 		toolStatus: gwproto.StreamToolStatusRunning,
 	}
@@ -694,6 +829,246 @@ func progressFromToolResult(rsp *model.Response) progressUpdate {
 	return update
 }
 
+func toolDetailFromToolCall(toolCall model.ToolCall) string {
+	name := strings.TrimSpace(toolCall.Function.Name)
+	switch name {
+	case streamToolExecCommand:
+		return execCommandToolDetail(toolCall)
+	case streamToolReadDocument:
+		return readDocumentToolDetail(toolCall)
+	case streamToolReadSheet:
+		return readSpreadsheetToolDetail(toolCall)
+	case streamToolReadFile, streamToolSaveFile, streamToolListDir:
+		return toolPathDetail(toolCall)
+	case streamToolSearch:
+		return searchToolDetail(toolCall)
+	default:
+		return genericToolDetail(toolCall)
+	}
+}
+
+func execCommandToolDetail(toolCall model.ToolCall) string {
+	var args struct {
+		Command string `json:"command,omitempty"`
+	}
+	if err := json.Unmarshal(toolCall.Function.Arguments, &args); err != nil {
+		return ""
+	}
+	return sanitizeStreamToolDetail(shellCommandDetail(args.Command))
+}
+
+func readDocumentToolDetail(toolCall model.ToolCall) string {
+	var args struct {
+		Page *int   `json:"page,omitempty"`
+		Path string `json:"path,omitempty"`
+	}
+	if err := json.Unmarshal(toolCall.Function.Arguments, &args); err != nil {
+		return ""
+	}
+	details := make([]string, 0, 2)
+	if path := safePathDetail(args.Path); path != "" {
+		details = append(details, path)
+	}
+	if args.Page != nil && *args.Page > 0 {
+		details = append(
+			details,
+			fmt.Sprintf("%s%d", streamToolDetailPagePrefix, *args.Page),
+		)
+	}
+	return sanitizeStreamToolDetail(
+		strings.Join(details, streamToolDetailSeparator),
+	)
+}
+
+func readSpreadsheetToolDetail(toolCall model.ToolCall) string {
+	var args struct {
+		Path     string `json:"path,omitempty"`
+		Row      *int   `json:"row,omitempty"`
+		StartRow *int   `json:"start_row,omitempty"`
+		EndRow   *int   `json:"end_row,omitempty"`
+		Sheet    string `json:"sheet,omitempty"`
+	}
+	if err := json.Unmarshal(toolCall.Function.Arguments, &args); err != nil {
+		return ""
+	}
+	details := make([]string, 0, 3)
+	if path := safePathDetail(args.Path); path != "" {
+		details = append(details, path)
+	}
+	if sheet := safeDetailToken(args.Sheet); sheet != "" {
+		details = append(details, streamToolDetailSheetPrefix+sheet)
+	}
+	switch {
+	case args.Row != nil && *args.Row > 0:
+		details = append(
+			details,
+			fmt.Sprintf("%s%d", streamToolDetailRowPrefix, *args.Row),
+		)
+	case args.StartRow != nil && *args.StartRow > 0 &&
+		args.EndRow != nil && *args.EndRow >= *args.StartRow:
+		details = append(
+			details,
+			fmt.Sprintf(
+				"%s%d-%d",
+				streamToolDetailRowsPrefix,
+				*args.StartRow,
+				*args.EndRow,
+			),
+		)
+	case args.StartRow != nil && *args.StartRow > 0:
+		details = append(
+			details,
+			fmt.Sprintf("%s%d", streamToolDetailRowPrefix, *args.StartRow),
+		)
+	}
+	return sanitizeStreamToolDetail(
+		strings.Join(details, streamToolDetailSeparator),
+	)
+}
+
+func toolPathDetail(toolCall model.ToolCall) string {
+	for _, key := range []string{
+		streamToolArgPath,
+		streamToolArgFilePath,
+		streamToolArgFileName,
+		streamToolArgFile,
+		streamToolArgFilename,
+	} {
+		path, ok := stringArgFromToolCall(toolCall, key)
+		if ok {
+			return sanitizeStreamToolDetail(safePathDetail(path))
+		}
+	}
+	return ""
+}
+
+func searchToolDetail(toolCall model.ToolCall) string {
+	for _, key := range []string{
+		streamToolArgQuery,
+		streamToolArgPattern,
+	} {
+		if value, ok := stringArgFromToolCall(toolCall, key); ok {
+			return sanitizeStreamToolDetail(safeDetailToken(value))
+		}
+	}
+	return ""
+}
+
+func genericToolDetail(toolCall model.ToolCall) string {
+	args, ok := toolCallArgs(toolCall)
+	if !ok {
+		return ""
+	}
+	parts := make([]string, 0, streamToolDetailMaxParts)
+	for _, candidate := range streamGenericToolDetailArgs {
+		if len(parts) >= streamToolDetailMaxParts {
+			break
+		}
+		for _, value := range stringValuesFromMap(args, candidate.key) {
+			if len(parts) >= streamToolDetailMaxParts {
+				break
+			}
+			detail := toolDetailArgValue(candidate.kind, value)
+			if detail == "" {
+				continue
+			}
+			part := candidate.prefix + detail
+			if containsToolDetailPart(parts, part) {
+				continue
+			}
+			parts = append(parts, part)
+		}
+	}
+	return sanitizeStreamToolDetail(
+		strings.Join(parts, streamToolDetailSeparator),
+	)
+}
+
+func toolDetailArgValue(kind streamToolArgKind, value string) string {
+	switch kind {
+	case streamToolArgKindPath:
+		return safePathDetail(value)
+	case streamToolArgKindURL:
+		return safeURLDetail(value)
+	default:
+		return safeDetailToken(value)
+	}
+}
+
+func containsToolDetailPart(parts []string, part string) bool {
+	for _, existing := range parts {
+		if existing == part {
+			return true
+		}
+	}
+	return false
+}
+
+func stringArgFromToolCall(
+	toolCall model.ToolCall,
+	key string,
+) (string, bool) {
+	args, ok := toolCallArgs(toolCall)
+	if !ok {
+		return "", false
+	}
+	return stringArgFromMap(args, key)
+}
+
+func toolCallArgs(toolCall model.ToolCall) (map[string]any, bool) {
+	var args map[string]any
+	if err := json.Unmarshal(toolCall.Function.Arguments, &args); err != nil {
+		return nil, false
+	}
+	return args, true
+}
+
+func stringArgFromMap(args map[string]any, key string) (string, bool) {
+	values := stringValuesFromMap(args, key)
+	if len(values) == 0 {
+		return "", false
+	}
+	return values[0], true
+}
+
+func stringValuesFromMap(args map[string]any, key string) []string {
+	if isSensitiveToolArgKey(key) {
+		return nil
+	}
+	raw, ok := args[key]
+	if !ok {
+		return nil
+	}
+	switch value := raw.(type) {
+	case string:
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return nil
+		}
+		return []string{value}
+	case []any:
+		return stringValuesFromList(value)
+	default:
+		return nil
+	}
+}
+
+func stringValuesFromList(values []any) []string {
+	out := make([]string, 0, len(values))
+	for _, raw := range values {
+		value, ok := raw.(string)
+		if !ok {
+			continue
+		}
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		out = append(out, value)
+	}
+	return out
+}
+
 func execCommandProgressSummary(toolCall model.ToolCall) string {
 	const defaultSummary = progressSummaryTool
 
@@ -704,7 +1079,7 @@ func execCommandProgressSummary(toolCall model.ToolCall) string {
 		return defaultSummary
 	}
 
-	command := normalizeExecCommand(args.Command)
+	command := normalizeExecCommand(shellCommandDetail(args.Command))
 	switch {
 	case command == "":
 		return defaultSummary
@@ -714,9 +1089,13 @@ func execCommandProgressSummary(toolCall model.ToolCall) string {
 		strings.HasPrefix(command, "python -m pytest"):
 		return progressSummaryPytest
 	case strings.HasPrefix(command, "npm test"),
+		strings.HasPrefix(command, "npm run test"),
 		strings.HasPrefix(command, "pnpm test"),
+		strings.HasPrefix(command, "pnpm run test"),
 		strings.HasPrefix(command, "yarn test"),
-		strings.HasPrefix(command, "bun test"):
+		strings.HasPrefix(command, "yarn run test"),
+		strings.HasPrefix(command, "bun test"),
+		strings.HasPrefix(command, "bun run test"):
 		return progressSummaryNPMTest
 	case strings.HasPrefix(command, "git "):
 		return progressSummaryGit
@@ -748,6 +1127,510 @@ func looksLikeWorkspaceInspection(command string) bool {
 		}
 	}
 	return false
+}
+
+func shellCommandDetail(command string) string {
+	for _, segment := range shellCommandSegments(command) {
+		detail := shellCommandSegmentDetail(segment)
+		if detail != "" {
+			return detail
+		}
+	}
+	return ""
+}
+
+func shellCommandSegments(command string) []string {
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return nil
+	}
+	segments := splitShellSegments(command)
+	return segments
+}
+
+func shellCommandSegmentDetail(segment string) string {
+	fields := cleanCommandFields(segment)
+	fields = trimShellCommandPrefix(fields)
+	if len(fields) == 0 {
+		return ""
+	}
+	command := safeCommandName(fields[0])
+	if command == "" || skipShellSetupCommand(command) {
+		return ""
+	}
+	switch command {
+	case streamCommandFor:
+		return streamCommandShellLoop
+	case streamCommandBash, streamCommandSh, streamCommandZsh:
+		return shellWrapperCommandDetail(fields[1:])
+	case streamCommandGo:
+		return commandWithSafeArgs(
+			command,
+			fields[1:],
+			streamCommandArgLimit,
+		)
+	case streamCommandGit:
+		return commandWithSafeArgs(
+			command,
+			fields[1:],
+			streamCommandArgLimit,
+		)
+	case streamCommandRG:
+		return commandWithSafeArgs(
+			command,
+			fields[1:],
+			streamCommandArgLimit,
+		)
+	case streamCommandSed, streamCommandCat,
+		streamCommandHead, streamCommandTail:
+		return commandWithPathArg(command, fields[1:])
+	case streamCommandLS, streamCommandFind:
+		return commandWithPathArg(command, fields[1:])
+	case streamCommandPytest:
+		return commandWithSafeArgs(
+			command,
+			fields[1:],
+			streamCommandArgLimit,
+		)
+	case streamCommandPython, streamCommandPython3:
+		return pythonCommandDetail(command, fields[1:])
+	case streamCommandNPM, streamCommandPNPM,
+		streamCommandYarn, streamCommandBun:
+		return packageCommandDetail(command, fields[1:])
+	default:
+		return commandWithSafeArgs(
+			command,
+			fields[1:],
+			streamCommandArgLimit,
+		)
+	}
+}
+
+func splitShellSegments(command string) []string {
+	runes := []rune(command)
+	segments := make([]string, 0, 1)
+	var builder strings.Builder
+	var quote rune
+	escaped := false
+	for i := 0; i < len(runes); i++ {
+		char := runes[i]
+		if escaped {
+			builder.WriteRune(char)
+			escaped = false
+			continue
+		}
+		if char == '\\' {
+			builder.WriteRune(char)
+			escaped = true
+			continue
+		}
+		if quote != 0 {
+			if char == quote {
+				quote = 0
+			}
+			builder.WriteRune(char)
+			continue
+		}
+		switch char {
+		case '\'', '"':
+			quote = char
+			builder.WriteRune(char)
+		case '\n', ';', '|':
+			segments = appendShellSegment(segments, builder.String())
+			builder.Reset()
+		case '&':
+			if i+1 < len(runes) && runes[i+1] == '&' {
+				segments = appendShellSegment(segments, builder.String())
+				builder.Reset()
+				i++
+				continue
+			}
+			builder.WriteRune(char)
+		default:
+			builder.WriteRune(char)
+		}
+	}
+	segments = appendShellSegment(segments, builder.String())
+	return segments
+}
+
+func appendShellSegment(segments []string, segment string) []string {
+	if segment = strings.TrimSpace(segment); segment != "" {
+		segments = append(segments, segment)
+	}
+	return segments
+}
+
+func shellFields(segment string) []string {
+	fields := make([]string, 0, 4)
+	var builder strings.Builder
+	var quote rune
+	escaped := false
+	for _, char := range segment {
+		switch {
+		case escaped:
+			builder.WriteRune(char)
+			escaped = false
+		case char == '\\':
+			escaped = true
+		case quote != 0:
+			if char == quote {
+				quote = 0
+				continue
+			}
+			builder.WriteRune(char)
+		case char == '\'' || char == '"':
+			quote = char
+		case unicode.IsSpace(char):
+			fields = appendShellField(fields, builder.String())
+			builder.Reset()
+		default:
+			builder.WriteRune(char)
+		}
+	}
+	fields = appendShellField(fields, builder.String())
+	return fields
+}
+
+func appendShellField(fields []string, field string) []string {
+	if field = strings.TrimSpace(field); field != "" {
+		fields = append(fields, field)
+	}
+	return fields
+}
+
+func trimShellCommandPrefix(fields []string) []string {
+	for len(fields) > 0 {
+		first := strings.TrimSpace(fields[0])
+		switch {
+		case isShellEnvAssignment(first):
+			fields = fields[1:]
+		default:
+			return fields
+		}
+	}
+	return fields
+}
+
+func isShellEnvAssignment(field string) bool {
+	if field == "" || strings.HasPrefix(field, "-") {
+		return false
+	}
+	eq := strings.Index(field, "=")
+	if eq <= 0 {
+		return false
+	}
+	name := field[:eq]
+	for _, char := range name {
+		if char == '_' ||
+			char >= 'a' && char <= 'z' ||
+			char >= 'A' && char <= 'Z' ||
+			char >= '0' && char <= '9' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func cleanCommandFields(segment string) []string {
+	return shellFields(segment)
+}
+
+func safeCommandName(name string) string {
+	name = strings.TrimSpace(filepath.Base(name))
+	name = strings.ToLower(strings.Trim(name, "\"'"))
+	if looksSensitiveValue(name) {
+		return ""
+	}
+	return safeDetailToken(name)
+}
+
+func skipShellSetupCommand(command string) bool {
+	switch command {
+	case streamCommandCD, streamCommandSet, streamCommandExport,
+		streamCommandSource, streamCommandDot:
+		return true
+	default:
+		return false
+	}
+}
+
+func commandWithSafeArgs(
+	command string,
+	args []string,
+	limit int,
+) string {
+	parts := []string{command}
+	skipCount := 0
+	for _, arg := range args {
+		if skipCount > 0 {
+			skipCount--
+			continue
+		}
+		if isSensitiveCommandFlag(arg) {
+			skipCount = 1
+			continue
+		}
+		if isSensitiveCommandKeyToken(arg) {
+			skipCount = 2
+			continue
+		}
+		if len(parts)-1 >= limit {
+			break
+		}
+		if token := safeCommandArgDetail(arg); token != "" {
+			parts = append(parts, token)
+		}
+	}
+	return strings.Join(parts, streamToolDetailSeparator)
+}
+
+func isSensitiveCommandFlag(arg string) bool {
+	arg = strings.TrimSpace(strings.Trim(arg, "\"'"))
+	if !strings.HasPrefix(arg, "-") {
+		return false
+	}
+	flag := strings.TrimLeft(arg, "-")
+	flag, _, _ = strings.Cut(flag, "=")
+	return isSensitiveToolArgKey(flag)
+}
+
+func isSensitiveCommandKeyToken(arg string) bool {
+	arg = strings.TrimSpace(strings.Trim(arg, "\"'"))
+	if !strings.HasSuffix(arg, ":") {
+		return false
+	}
+	key := strings.TrimSuffix(arg, ":")
+	return isSensitiveToolArgKey(key)
+}
+
+func commandWithPathArg(command string, args []string) string {
+	if path := lastSafePathArg(args); path != "" {
+		return strings.Join(
+			[]string{command, path},
+			streamToolDetailSeparator,
+		)
+	}
+	return command
+}
+
+func shellWrapperCommandDetail(args []string) string {
+	for i, arg := range args {
+		switch arg {
+		case streamCommandShellFlag, streamCommandShellLogin:
+			if i+1 >= len(args) {
+				return ""
+			}
+			return shellCommandDetail(strings.Join(args[i+1:], " "))
+		}
+	}
+	return ""
+}
+
+func pythonCommandDetail(command string, args []string) string {
+	if len(args) >= 2 &&
+		args[0] == streamCommandModuleFlag &&
+		args[1] == streamCommandPytest {
+		rest := append([]string{streamCommandPytest}, args[2:]...)
+		return commandWithSafeArgs(
+			streamCommandPytest,
+			rest[1:],
+			streamCommandArgLimit,
+		)
+	}
+	return commandWithSafeArgs(command, args, streamCommandArgLimit)
+}
+
+func packageCommandDetail(command string, args []string) string {
+	if len(args) == 0 {
+		return command
+	}
+	return commandWithSafeArgs(command, args, streamCommandArgLimit)
+}
+
+func safeCommandArgDetail(arg string) string {
+	arg = strings.TrimSpace(strings.Trim(arg, "\"'"))
+	if arg == "" || looksSensitiveCommandArg(arg) {
+		return ""
+	}
+	if strings.HasPrefix(arg, "-") && strings.Contains(arg, "=") {
+		return ""
+	}
+	if strings.Contains(arg, "://") {
+		return safeURLDetail(arg)
+	}
+	if path := safePathDetail(arg); path != "" {
+		return path
+	}
+	return safeDetailToken(arg)
+}
+
+func lastSafePathArg(args []string) string {
+	for i := len(args) - 1; i >= 0; i-- {
+		arg := strings.TrimSpace(args[i])
+		if arg == "" || strings.HasPrefix(arg, "-") {
+			continue
+		}
+		if path := safePathDetail(arg); path != "" {
+			return path
+		}
+	}
+	return ""
+}
+
+func safePathDetail(path string) string {
+	path = strings.TrimSpace(strings.Trim(path, "\"'"))
+	if path == "" || looksSensitiveValue(path) {
+		return ""
+	}
+	if path == "./..." {
+		return path
+	}
+	clean := filepath.ToSlash(filepath.Clean(path))
+	if clean == "." || clean == ".." {
+		return clean
+	}
+	trimmed := strings.Trim(clean, streamToolPathSeparator)
+	if trimmed == "" {
+		return ""
+	}
+	parts := strings.Split(trimmed, streamToolPathSeparator)
+	if len(parts) > 3 {
+		parts = append([]string{streamToolPathEllipsis}, parts[len(parts)-3:]...)
+	}
+	return safeDetailToken(strings.Join(parts, streamToolPathSeparator))
+}
+
+func safeURLDetail(rawURL string) string {
+	rawURL = strings.TrimSpace(strings.Trim(rawURL, "\"'"))
+	if rawURL == "" || looksSensitiveValue(rawURL) {
+		return ""
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed.Host == "" {
+		return safePathDetail(rawURL)
+	}
+	parts := []string{parsed.Host}
+	if path := safePathDetail(parsed.Path); path != "" && path != "." {
+		parts = append(parts, path)
+	}
+	return safeDetailToken(
+		strings.Join(parts, streamToolPathSeparator),
+	)
+}
+
+func safeDetailToken(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" ||
+		len([]rune(value)) > streamToolDetailMaxRunes ||
+		looksSensitiveValue(value) {
+		return ""
+	}
+	for _, char := range value {
+		if isSafeToolDetailRune(char) {
+			continue
+		}
+		return ""
+	}
+	return value
+}
+
+func sanitizeStreamToolDetail(detail string) string {
+	return safeDetailToken(detail)
+}
+
+func isSafeToolDetailRune(char rune) bool {
+	switch {
+	case unicode.IsLetter(char), unicode.IsDigit(char):
+		return true
+	case char == '_', char == '-', char == '.', char == '/',
+		char == ':', char == ' ', char == '*', char == '#',
+		char == '@', char == '[', char == ']':
+		return true
+	default:
+		return false
+	}
+}
+
+func looksSensitiveCommandArg(arg string) bool {
+	if looksSensitiveValue(arg) {
+		return true
+	}
+	if !strings.HasPrefix(arg, "-") || !strings.Contains(arg, "=") {
+		return false
+	}
+	key, _, _ := strings.Cut(strings.TrimLeft(arg, "-"), "=")
+	return isSensitiveToolArgKey(key)
+}
+
+func isSensitiveToolArgKey(key string) bool {
+	key = normalizeSensitiveKey(key)
+	if key == "" {
+		return false
+	}
+	return strings.Contains(key, streamSecretToken) ||
+		strings.Contains(key, streamSecretSecret) ||
+		strings.Contains(key, streamSecretPassword) ||
+		strings.Contains(key, streamSecretAuthorization) ||
+		strings.Contains(key, streamSecretBearer) ||
+		strings.Contains(key, streamSecretAPIKey) ||
+		strings.Contains(key, streamSecretAPIKeyFlat) ||
+		strings.Contains(key, streamSecretCookie) ||
+		strings.HasSuffix(key, streamSecretKeySuffix)
+}
+
+func normalizeSensitiveKey(key string) string {
+	key = strings.ToLower(strings.TrimSpace(key))
+	key = strings.ReplaceAll(key, "-", "_")
+	return key
+}
+
+func looksSensitiveValue(value string) bool {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		return false
+	}
+	return value == streamSecretBearer ||
+		strings.Contains(value, streamSecretBearer) ||
+		strings.HasPrefix(value, streamSecretOpenAIKey) ||
+		strings.HasPrefix(value, streamSecretGitHubToken) ||
+		strings.HasPrefix(value, streamSecretTencentToken) ||
+		looksLikeJWT(value)
+}
+
+func looksLikeJWT(value string) bool {
+	if len(value) < 32 {
+		return false
+	}
+	parts := strings.Split(value, ".")
+	if len(parts) != 3 {
+		return false
+	}
+	for _, part := range parts {
+		if len(part) < 8 || !isBase64URLLike(part) {
+			return false
+		}
+	}
+	return true
+}
+
+func isBase64URLLike(value string) bool {
+	for _, char := range value {
+		switch {
+		case char >= 'a' && char <= 'z':
+			continue
+		case char >= 'A' && char <= 'Z':
+			continue
+		case char >= '0' && char <= '9':
+			continue
+		case char == '-', char == '_':
+			continue
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 func readDocumentProgressSummary(toolCall model.ToolCall) string {
@@ -812,6 +1695,7 @@ func sendProgressUpdate(
 	if state.stage == update.stage &&
 		state.summary == update.summary &&
 		state.toolName == update.toolName &&
+		state.toolDetail == update.toolDetail &&
 		state.toolCallID == update.toolCallID &&
 		state.toolStatus == update.toolStatus {
 		return true
@@ -819,6 +1703,7 @@ func sendProgressUpdate(
 	state.stage = update.stage
 	state.summary = update.summary
 	state.toolName = update.toolName
+	state.toolDetail = update.toolDetail
 	state.toolCallID = update.toolCallID
 	state.toolStatus = update.toolStatus
 	return sendStreamEvent(ctx, out, gwproto.StreamEvent{
@@ -828,6 +1713,7 @@ func sendProgressUpdate(
 		Stage:      update.stage,
 		Summary:    update.summary,
 		ToolName:   update.toolName,
+		ToolDetail: update.toolDetail,
 		ToolCallID: update.toolCallID,
 		ToolStatus: update.toolStatus,
 		ElapsedMS:  time.Since(state.startedAt).Milliseconds(),


### PR DESCRIPTION
## Summary

- add an optional `tool_detail` field to gateway stream progress events
- derive safe, length-limited tool details from structured tool arguments for `exec_command`, document/spreadsheet readers, workspace file tools, search tools, and generic action/path/query/url style tools
- include `tool_detail` in progress de-duplication and client decoding tests

## Why

WeCom native thinking can show that a tool is running, but `exec_command` alone is too vague. The gateway has access to the original tool arguments, so it can produce a sanitized display detail without exposing full commands, outputs, or secrets.

## Safety

The detail builder skips sensitive keys and values, skips values after sensitive flags, strips URL queries, trims long values, keeps only a small character allowlist, and shows shortened path tails instead of full absolute paths.

## Tests

- `go test ./gwproto ./gwclient ./internal/gateway -count=1`
- `go test ./internal/gateway -coverprofile=/tmp/gateway.out -count=1`
- `go test ./...`