### PR TITLE
graph: escape non-JSON tool output in node_responses

### DIFF
--- a/graph/state_graph.go
+++ b/graph/state_graph.go
@@ -2186,6 +2186,19 @@ func NewToolsNodeFunc(tools map[string]tool.Tool, opts ...Option) NodeFunc {
 	return nodeFunc
 }
 
+// toolOutputRawMessageForNodeResponse returns JSON bytes suitable for the
+// "output" field of serialized tool node responses. Valid JSON document
+// fragments are passed through; otherwise content is JSON-string-encoded so
+// json.Marshal of the parent slice never fails or emits invalid JSON.
+func toolOutputRawMessageForNodeResponse(content string) json.RawMessage {
+	output := json.RawMessage(content)
+	if !json.Valid([]byte(content)) {
+		escaped, _ := json.Marshal(content)
+		output = json.RawMessage(escaped)
+	}
+	return output
+}
+
 func newToolsNodeRuntime(
 	tools map[string]tool.Tool,
 	opts ...Option,
@@ -2284,10 +2297,11 @@ func newToolsNodeRuntime(
 
 			responses := make([]toolNodeResponse, 0, len(newMessages))
 			for _, msg := range newMessages {
+				output := toolOutputRawMessageForNodeResponse(msg.Content)
 				responses = append(responses, toolNodeResponse{
 					ToolID:   msg.ToolID,
 					ToolName: msg.ToolName,
-					Output:   json.RawMessage(msg.Content),
+					Output:   output,
 				})
 			}
 

--- a/graph/state_graph_test.go
+++ b/graph/state_graph_test.go
@@ -1203,6 +1203,57 @@ type assertAnError struct{}
 
 func (assertAnError) Error() string { return "boom" }
 
+func TestToolOutputRawMessageForNodeResponse(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		content string
+		want    string // expected JSON text for the output field alone
+	}{
+		{
+			name:    "object_passthrough",
+			content: `{"x":1}`,
+			want:    `{"x":1}`,
+		},
+		{
+			name:    "array_passthrough",
+			content: `[1,2]`,
+			want:    `[1,2]`,
+		},
+		{
+			name:    "plain_text_escaped",
+			content: `not json`,
+			want:    `"not json"`,
+		},
+		{
+			name:    "truncated_object_escaped",
+			content: `{"a":`,
+			want:    `"{\"a\":"`,
+		},
+		{
+			name:    "empty_invalid_then_string",
+			content: "",
+			want:    `""`,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := toolOutputRawMessageForNodeResponse(tc.content)
+			require.True(t, json.Valid(got), "output must be valid JSON: %s", got)
+			require.JSONEq(t, tc.want, string(got))
+
+			wrapped := []map[string]json.RawMessage{{
+				"output": got,
+			}}
+			outer, err := json.Marshal(wrapped)
+			require.NoError(t, err)
+			require.True(t, json.Valid(outer), "wrapped marshal must succeed: %s", outer)
+		})
+	}
+}
+
 func TestNewToolsNodeFunc_WithEnableParallelTools(t *testing.T) {
 	started := make(chan string, 2)
 	allowA, allowB := make(chan struct{}), make(chan struct{})


### PR DESCRIPTION
This change ensures each tool output embedded in serialized `node_responses` is valid JSON: pass through when `msg.Content` is already valid JSON, otherwise JSON-string-encode it so the enclosing `json.Marshal` of the response list cannot emit corrupt JSON.

The logic is extracted to `toolOutputRawMessageForNodeResponse` for direct unit testing (the normal tool execution path always `json.Marshal`s the tool result, so integration tests cannot easily produce invalid JSON content).

**Tests:** `go test ./graph -run TestToolOutputRawMessageForNodeResponse` and full `go test ./graph`.

Made with [Cursor](https://cursor.com)