### PR TITLE
tool/mcpbroker: add WithAdHocHTTPTimeout and document ad-hoc HTTP trust boundary

### DIFF
--- a/tool/mcpbroker/broker.go
+++ b/tool/mcpbroker/broker.go
@@ -7,7 +7,29 @@
 //
 //
 
-// Package mcpbroker provides opt-in MCP discovery/call broker tools.
+// Package mcpbroker provides opt-in MCP discovery/call broker tools
+// (mcp_list_servers, mcp_list_tools, mcp_inspect_tools, mcp_call) that an LLM
+// agent can use to discover and invoke remote MCP servers at runtime.
+//
+// # Untrusted remote content
+//
+// The broker is a passthrough: it forwards remote MCP server output - tool names
+// and descriptions, tool result Content, error messages - verbatim to the model.
+// Remote content is therefore untrusted from the host's perspective and may be
+// crafted to attempt prompt injection, tool-name spoofing, or data exfiltration
+// via the model's tool-use loop. The broker intentionally does not sanitise this
+// content because removing it would also remove the information the agent
+// legitimately needs to reason about the remote server.
+//
+// Hosts that connect to MCP servers outside their trust domain - especially when
+// ad-hoc HTTP is enabled via WithAllowAdHocHTTP - should:
+//
+//   - Constrain which servers or URLs the agent can reach via WithServers,
+//     WithAllowAdHocHTTP, and WithClientOptionsProvider.
+//   - Treat remote tool output Content as untrusted input when composing
+//     downstream prompts and tool chains.
+//   - Use WithErrorInterceptor to redact internal-topology details from MCP
+//     server errors that would otherwise reach the model.
 package mcpbroker
 
 import (
@@ -17,6 +39,7 @@ import (
 	"net/url"
 	"sort"
 	"strings"
+	"time"
 
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 	mcpcfg "trpc.group/trpc-go/trpc-agent-go/tool/mcp"
@@ -81,6 +104,7 @@ type Option func(*brokerOptions)
 type brokerOptions struct {
 	servers                     map[string]mcpcfg.ConnectionConfig
 	allowAdHocHTTP              bool
+	adhocHTTPTimeout            time.Duration
 	adhocSensitiveHeaderDenyset map[string]struct{}
 	httpHeaderInjector          HTTPHeaderInjector
 	clientOptionsProvider       ClientOptionsProvider
@@ -147,10 +171,28 @@ type ClientOptions struct {
 	Stdio []tmcp.StdioClientOption
 }
 
-// HTTPHeaderInjector resolves per-run HTTP headers for MCP requests.
+// HTTPHeaderInjector resolves per-run HTTP headers for MCP requests. The broker
+// calls it after target resolution and before WithClientOptionsProvider, and
+// merges the returned headers into the outgoing request.
+//
+// # Trust BaseURL with care for ad-hoc targets
+//
+// When HeaderInjectRequest.IsAdHoc is true, BaseURL originates from a
+// model-supplied URL and may have been chosen by an attacker via prompt
+// injection. Returning a host secret (OAuth token, session cookie, vendor API
+// key) here without first cross-checking that BaseURL.Host belongs to a trusted
+// destination can exfiltrate that secret to whatever endpoint the model picks.
+// The recommended pattern is:
+//
+//   - For named servers (IsAdHoc == false): inject the secret bound to that
+//     server name.
+//   - For ad-hoc targets (IsAdHoc == true): either skip injection, or only
+//     inject when the parsed BaseURL.Host is on a host-defined allowlist.
 type HTTPHeaderInjector func(context.Context, *HeaderInjectRequest) (map[string]string, error)
 
-// HeaderInjectRequest describes an MCP HTTP request before execution.
+// HeaderInjectRequest describes an MCP HTTP request before execution. IsAdHoc
+// distinguishes trusted named-server targets from model-supplied ad-hoc URLs;
+// see HTTPHeaderInjector for the implications when injecting secrets.
 type HeaderInjectRequest struct {
 	Selector  string
 	BaseURL   string
@@ -216,14 +258,110 @@ func WithServers(servers map[string]mcpcfg.ConnectionConfig) Option {
 }
 
 // WithAllowAdHocHTTP controls whether ad-hoc HTTP MCP targets are allowed.
+//
+// When enabled, mcp_list_tools / mcp_inspect_tools / mcp_call accept model-supplied
+// URLs (selectors that look like an http:// or https:// URL) instead of named
+// servers from WithServers. This is a powerful surface and a risky one: the broker
+// only enforces the http/https scheme and the ad-hoc header denylist (see
+// WithAdHocSensitiveHeaderDenylist); it does NOT validate destination identity,
+// host policy, or reachability.
+//
+// # SSRF risk
+//
+// Without further controls, a sufficiently-instructed model can ask the broker to
+// connect to internal addresses (localhost, link-local, cloud metadata endpoints,
+// intranet services), exfiltrate data to attacker-controlled hosts, or probe
+// internal networks. URL allow/deny policy is the host's responsibility.
+//
+// # Recommended pattern
+//
+// Use WithClientOptionsProvider together with tmcp.WithHTTPBeforeRequest to enforce
+// a per-deployment URL policy. The provider receives
+// ClientOptionsRequest.Origin == OriginAdhoc for model-supplied URLs, so a host can
+// reject or rewrite them before the connection is established.
+//
+// # Hang risk and bounding
+//
+// trpc-mcp-go's underlying http.Client has no built-in request timeout, so an
+// ad-hoc MCP call against a stalled or hostile remote can hang for as long as the
+// caller-supplied context permits. When that context has no deadline (common in
+// long-running agent runs or background jobs), the call can hang indefinitely and
+// occupy a goroutine plus a TCP connection until the OS gives up. Hosts that
+// enable ad-hoc HTTP should bound it explicitly via WithAdHocHTTPTimeout, or via
+// WithClientOptionsProvider for finer-grained per-call policy.
 func WithAllowAdHocHTTP(enabled bool) Option {
 	return func(opts *brokerOptions) {
 		opts.allowAdHocHTTP = enabled
 	}
 }
 
-// WithAdHocSensitiveHeaderDenylist adds case-insensitive denylist header names
-// for ad-hoc HTTP MCP calls.
+// WithAdHocHTTPTimeout sets the upper bound on the total wall-clock time the
+// broker spends on a single ad-hoc HTTP MCP operation (mcp_list_tools,
+// mcp_inspect_tools, or mcp_call). The bound covers Initialize and every MCP
+// RPC the operation issues; the broker wraps the entire operation in
+// context.WithTimeout once, taking whichever deadline is tighter between this
+// value and the caller-supplied context. An ad-hoc target is one resolved
+// from an http/https URL selector rather than a name configured via
+// WithServers.
+//
+// # Why this option is opt-in
+//
+// trpc-mcp-go's underlying http.Client has no built-in request timeout, so an
+// ad-hoc MCP call against a stalled or hostile remote can hang indefinitely
+// when the caller-supplied context has no deadline. Because the appropriate
+// bound is workload-specific (short tool calls might warrant a few seconds;
+// analytical tools may need minutes), the broker exposes this option instead
+// of imposing a framework-wide default that would be wrong for many
+// deployments.
+//
+// # Values
+//
+//   - d > 0: apply d as the per-operation deadline upper bound for ad-hoc
+//     HTTP calls. The clock starts before Initialize and stops after the
+//     last MCP RPC needed for the operation.
+//   - d <= 0: no broker-level deadline (default). The operation then relies
+//     entirely on the caller-supplied context deadline; without one, a
+//     stalled remote can hang the operation indefinitely. Only choose this
+//     when an upstream deadline source is guaranteed.
+//
+// # Scope
+//
+// This option only affects ad-hoc HTTP operations. Named servers configured
+// via WithServers continue to use their own ConnectionConfig.Timeout, which
+// is not modified by this option.
+func WithAdHocHTTPTimeout(d time.Duration) Option {
+	return func(opts *brokerOptions) {
+		if d < 0 {
+			d = 0
+		}
+		opts.adhocHTTPTimeout = d
+	}
+}
+
+// WithAdHocSensitiveHeaderDenylist adds case-insensitive header names that the
+// broker must reject when the model supplies them via the "headers" parameter of
+// mcp_list_tools / mcp_inspect_tools / mcp_call for an ad-hoc HTTP MCP target.
+// Comparison is performed against the lowercase name; entries here extend (never
+// shrink) the built-in default.
+//
+// # Default coverage
+//
+// The built-in default covers the protocol-standard auth headers - Authorization,
+// Proxy-Authorization, Cookie, Set-Cookie - plus X-API-Key, a de-facto industry
+// standard across cloud providers and API gateways. These are intentionally
+// narrow: every host will agree the model should not be able to spell them.
+//
+// # Vendor-specific headers are the host's responsibility
+//
+// Many ecosystems use non-standard token-bearing headers - OpenStack uses
+// X-Auth-Token, AWS uses X-Amz-Security-Token, GitLab uses Private-Token, and
+// many internal systems invent their own. The broker deliberately does NOT add
+// these to the default list. Doing so would silently reject legitimate model
+// traffic in deployments that do not use those vendors, and would create a false
+// sense of safety in deployments that do (an attacker can always rename the
+// exfiltration header). Hosts whose MCP servers - or whose neighbouring services
+// reachable on the same network - rely on such headers should pass them in via
+// this option.
 func WithAdHocSensitiveHeaderDenylist(headers []string) Option {
 	return func(opts *brokerOptions) {
 		if len(headers) == 0 {

--- a/tool/mcpbroker/broker_test.go
+++ b/tool/mcpbroker/broker_test.go
@@ -1485,3 +1485,254 @@ func TestNormalizeConnectionConfigValidation(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "ad-hoc MCP only supports HTTP")
 }
+
+// =============================================================================
+// Ad-hoc HTTP timeout tests (WithAdHocHTTPTimeout)
+// =============================================================================
+
+// startSlowHTTPMCPServer starts a real MCP HTTP server whose `slow_echo` tool
+// sleeps for delay before returning. Callers receive the URL suffix /mcp.
+func startSlowHTTPMCPServer(t *testing.T, delay time.Duration) string {
+	t.Helper()
+	srv := tmcp.NewServer("slow-mcp", "1.0.0", tmcp.WithServerPath("/mcp"))
+	slowTool := tmcp.NewTool(
+		"slow_echo",
+		tmcp.WithDescription("Sleeps then echoes the input."),
+		tmcp.WithString("text", tmcp.Required(), tmcp.Description("Text.")),
+	)
+	srv.RegisterTool(slowTool, func(ctx context.Context, req *tmcp.CallToolRequest) (*tmcp.CallToolResult, error) {
+		select {
+		case <-time.After(delay):
+			text, _ := req.Params.Arguments["text"].(string)
+			return tmcp.NewTextResult("echo: " + text), nil
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	})
+
+	httpSrv := httptest.NewServer(srv.HTTPHandler())
+	t.Cleanup(func() {
+		httpSrv.CloseClientConnections()
+		httpSrv.Close()
+	})
+	return httpSrv.URL + "/mcp"
+}
+
+func TestAdHocHTTPTimeout_BoundsSlowCall(t *testing.T) {
+	url := startSlowHTTPMCPServer(t, 2*time.Second)
+
+	broker := New(
+		WithAllowAdHocHTTP(true),
+		WithAdHocHTTPTimeout(150*time.Millisecond),
+	)
+
+	start := time.Now()
+	_, err := broker.callTool(context.Background(), callToolInput{
+		Selector:  url + "#tool=slow_echo",
+		Arguments: map[string]any{"text": "hi"},
+	})
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "expected deadline exceeded, got nil after %v", elapsed)
+	require.Contains(t, err.Error(), "deadline exceeded",
+		"unexpected error: %v (elapsed=%v)", err, elapsed)
+	require.Less(t, elapsed, 1*time.Second,
+		"expected cut near 150ms, took %v - timeout not enforced for ad-hoc?", elapsed)
+}
+
+func TestAdHocHTTPTimeout_ZeroIsNoOp(t *testing.T) {
+	url := startSlowHTTPMCPServer(t, 300*time.Millisecond)
+
+	broker := New(
+		WithAllowAdHocHTTP(true),
+		WithAdHocHTTPTimeout(0), // explicit no-op
+	)
+
+	start := time.Now()
+	out, err := broker.callTool(context.Background(), callToolInput{
+		Selector:  url + "#tool=slow_echo",
+		Arguments: map[string]any{"text": "hi"},
+	})
+	elapsed := time.Since(start)
+
+	require.NoError(t, err, "expected success with Timeout=0 (elapsed=%v)", elapsed)
+	require.GreaterOrEqual(t, elapsed, 250*time.Millisecond,
+		"call returned too fast (%v); server should have slept ~300ms", elapsed)
+	require.NotEmpty(t, out.Content, "expected non-empty MCP tool content")
+}
+
+func TestAdHocHTTPTimeout_DefaultIsNoBound(t *testing.T) {
+	url := startSlowHTTPMCPServer(t, 300*time.Millisecond)
+
+	broker := New(WithAllowAdHocHTTP(true)) // option not called
+
+	start := time.Now()
+	out, err := broker.callTool(context.Background(), callToolInput{
+		Selector:  url + "#tool=slow_echo",
+		Arguments: map[string]any{"text": "hi"},
+	})
+	elapsed := time.Since(start)
+
+	require.NoError(t, err, "expected success without WithAdHocHTTPTimeout (elapsed=%v)", elapsed)
+	require.GreaterOrEqual(t, elapsed, 250*time.Millisecond,
+		"call returned too fast (%v); server should have slept ~300ms", elapsed)
+	require.NotEmpty(t, out.Content)
+}
+
+func TestAdHocHTTPTimeout_DoesNotAffectNamedServers(t *testing.T) {
+	namedSrv := startBrokerHTTPServer(t)
+	defer namedSrv.Close()
+
+	broker := New(
+		WithAllowAdHocHTTP(true),
+		// Hostile-low ad-hoc timeout. If it leaks into the named path,
+		// the named server listTools call below would fail.
+		WithAdHocHTTPTimeout(1*time.Millisecond),
+		WithServers(map[string]legacymcp.ConnectionConfig{
+			"named": {
+				Transport: "streamable",
+				ServerURL: namedSrv.URL,
+				Timeout:   5 * time.Second,
+			},
+		}),
+	)
+
+	out, err := broker.listTools(context.Background(), listToolsInput{Selector: "named"})
+	require.NoError(t, err,
+		"named-server listTools must not be bounded by WithAdHocHTTPTimeout: %v", err)
+	require.NotEmpty(t, out.Tools)
+}
+
+func TestAdHocHTTPTimeout_NegativeIsClampedToZero(t *testing.T) {
+	broker := New(
+		WithAllowAdHocHTTP(true),
+		WithAdHocHTTPTimeout(-5*time.Second),
+	)
+	require.Equal(t, time.Duration(0), broker.options.adhocHTTPTimeout,
+		"negative values must be clamped to 0 to avoid breaking normalizeConnectionConfig")
+}
+
+// startStagedSlowHTTPMCPServer starts an MCP HTTP server that introduces a
+// per-JSON-RPC-method delay before delegating to the real MCP handler. The
+// delays map keys are JSON-RPC method names (e.g. "tools/list", "tools/call",
+// "initialize"); methods absent from the map respond immediately.
+func startStagedSlowHTTPMCPServer(t *testing.T, delays map[string]time.Duration) string {
+	t.Helper()
+
+	srv := tmcp.NewServer("staged-slow-mcp", "1.0.0", tmcp.WithServerPath("/mcp"))
+	echoTool := tmcp.NewTool(
+		"echo",
+		tmcp.WithDescription("Echo text back."),
+		tmcp.WithString("text", tmcp.Required(), tmcp.Description("Text.")),
+	)
+	srv.RegisterTool(echoTool, func(ctx context.Context, req *tmcp.CallToolRequest) (*tmcp.CallToolResult, error) {
+		text, _ := req.Params.Arguments["text"].(string)
+		return tmcp.NewTextResult("echo: " + text), nil
+	})
+
+	baseHandler := srv.HTTPHandler()
+	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && len(delays) > 0 {
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			r.Body = io.NopCloser(bytes.NewReader(body))
+
+			var rpc struct {
+				Method string `json:"method"`
+			}
+			if err := json.Unmarshal(body, &rpc); err == nil {
+				if delay := delays[rpc.Method]; delay > 0 {
+					select {
+					case <-time.After(delay):
+					case <-r.Context().Done():
+						return
+					}
+				}
+			}
+		}
+		baseHandler.ServeHTTP(w, r)
+	}))
+	t.Cleanup(func() {
+		httpSrv.CloseClientConnections()
+		httpSrv.Close()
+	})
+	return httpSrv.URL + "/mcp"
+}
+
+// TestAdHocHTTPTimeout_BoundsSSEStartup verifies that the timeout reaches the
+// SSE transport, even though trpc-mcp-go's SSE client detaches the long-lived
+// stream context. The startup path (waiting for the "endpoint" event) still
+// observes the caller-supplied ctx deadline, so a stalled SSE endpoint cannot
+// hold the broker call past the configured budget.
+func TestAdHocHTTPTimeout_BoundsSSEStartup(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		// Hold the GET open without ever sending an "endpoint" event.
+		// trpc-mcp-go's SSE client must time out via the broker ctx.
+		<-r.Context().Done()
+	}))
+	t.Cleanup(func() {
+		srv.CloseClientConnections()
+		srv.Close()
+	})
+
+	broker := New(
+		WithAllowAdHocHTTP(true),
+		WithAdHocHTTPTimeout(300*time.Millisecond),
+	)
+
+	start := time.Now()
+	_, err := broker.callTool(context.Background(), callToolInput{
+		Selector:  srv.URL + "/sse#tool=anything",
+		Transport: "sse",
+		Arguments: map[string]any{},
+	})
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "expected timeout error from stalled SSE endpoint")
+	require.Less(t, elapsed, 1*time.Second,
+		"WithAdHocHTTPTimeout must bound SSE ad-hoc operations; took %v", elapsed)
+}
+
+// TestAdHocHTTPTimeout_BoundsTotalOperationAcrossRPCs verifies that the
+// configured timeout bounds the total wall-clock of a single mcp_call
+// operation, not each underlying MCP RPC independently. The mcp_call path
+// issues ListTools (for argument validation) followed by CallTool; if the
+// broker accidentally gave each RPC its own fresh timeout budget, the total
+// elapsed time would exceed the configured upper bound.
+func TestAdHocHTTPTimeout_BoundsTotalOperationAcrossRPCs(t *testing.T) {
+	url := startStagedSlowHTTPMCPServer(t, map[string]time.Duration{
+		"tools/list": 200 * time.Millisecond,
+		"tools/call": 200 * time.Millisecond,
+	})
+
+	broker := New(
+		WithAllowAdHocHTTP(true),
+		WithAdHocHTTPTimeout(300*time.Millisecond),
+	)
+
+	start := time.Now()
+	_, err := broker.callTool(context.Background(), callToolInput{
+		Selector:  url + "#tool=echo",
+		Arguments: map[string]any{"text": "hi"},
+	})
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "expected per-call timeout to fire across ListTools+CallTool")
+	require.Contains(t, err.Error(), "deadline exceeded")
+	require.Less(t, elapsed, 500*time.Millisecond,
+		"per-call budget must bound the total wall-clock across all internal RPCs; got %v", elapsed)
+}

--- a/tool/mcpbroker/client.go
+++ b/tool/mcpbroker/client.go
@@ -65,6 +65,7 @@ func (b *Broker) buildAdHocConfig(input targetInput) (mcpcfg.ConnectionConfig, s
 		Transport: strings.TrimSpace(input.Transport),
 		ServerURL: strings.TrimSpace(input.URL),
 		Headers:   headers,
+		Timeout:   b.options.adhocHTTPTimeout,
 	}, true)
 	if err != nil {
 		return mcpcfg.ConnectionConfig{}, "", err
@@ -351,21 +352,22 @@ func withOneShotClient[T any](
 ) (T, error) {
 	var zero T
 
+	// Per-call deadline: applied once and shared by Initialize and every MCP
+	// RPC issued inside fn. This matches the user-facing contract that
+	// ConnectionConfig.Timeout / WithAdHocHTTPTimeout bound the total
+	// wall-clock time of a single broker operation.
+	ctx, cancel := withTimeoutContext(ctx, cfg.Timeout)
+	defer cancel()
+
 	client, err := createClient(cfg, extraHTTP, extraStdio)
 	if err != nil {
 		return zero, err
 	}
 	defer client.Close()
 
-	initCtx, cancel := withTimeoutContext(ctx, cfg.Timeout)
-	defer cancel()
-
-	if _, err := client.Initialize(initCtx, &tmcp.InitializeRequest{}); err != nil {
+	if _, err := client.Initialize(ctx, &tmcp.InitializeRequest{}); err != nil {
 		return zero, fmt.Errorf("initialize MCP client: %w", err)
 	}
 
-	opCtx, opCancel := withTimeoutContext(ctx, cfg.Timeout)
-	defer opCancel()
-
-	return fn(opCtx, client)
+	return fn(ctx, client)
 }


### PR DESCRIPTION
Add an opt-in per-RPC deadline for ad-hoc HTTP MCP calls and clarify the surrounding trust-boundary godoc.