### PR TITLE
{evaluation, docs, examples/evaluation}: add case-level rubrics

### DIFF
--- a/docs/mkdocs/en/evaluation.md
+++ b/docs/mkdocs/en/evaluation.md
@@ -1589,7 +1589,7 @@ type RubricContent struct {
 
 `rubrics` split a metric into multiple clear-granularity criteria. Each rubric should be independent and directly verifiable from user input and the final answer, which improves judge stability and makes issues easier to locate. `id` is a stable identifier, and `content.text` is the rubric text used by the judge.
 
-`EvalCase.rubrics` adds extra evaluation criteria for a single case. Each rubric targets a configured metric through `metricName`; when that case is evaluated, the framework appends those criteria after the metric's shared rubrics. This affects only the current case and leaves the metric file's global configuration unchanged.
+`EvalCase.rubrics` adds extra evaluation criteria for a single case. Each rubric targets a configured metric through `metricName`; when that case is evaluated, the framework appends those criteria after the metric's shared rubrics. This affects only the current case and leaves the metric file's global configuration unchanged. Rubric `id` values must be unique after merging.
 
 The target metric uses `criterion.llmJudge` to carry the rubric list. Built-in rubric evaluators read the merged criteria, and custom rubric evaluators can read the same field.
 

--- a/docs/mkdocs/en/evaluation.md
+++ b/docs/mkdocs/en/evaluation.md
@@ -559,7 +559,22 @@ type EvalCase struct {
 	ConversationScenario  *ConversationScenario // ConversationScenario is the dynamic user simulation scenario. In default mode it is mutually exclusive with Conversation.
 	ActualConversation    []*Invocation         // ActualConversation is the actual trace in trace mode. It is required in trace mode.
 	SessionInput          *SessionInput         // SessionInput is session initialization info, required.
+	Rubrics               []*EvalCaseRubric     // Rubrics contains case-level rubrics, optional.
 	CreationTimestamp     *epochtime.EpochTime  // CreationTimestamp is the creation timestamp, optional.
+}
+
+// EvalCaseRubric represents a rubric that applies only to one eval case.
+type EvalCaseRubric struct {
+	MetricName  string                 // MetricName identifies the metric instance this rubric augments.
+	ID          string                 // ID uniquely identifies this case-level rubric.
+	Content     *EvalCaseRubricContent // Content contains the judge-readable rubric content.
+	Description string                 // Description stores human-facing context that is not judged by default.
+	Type        string                 // Type classifies the rubric for result inspection.
+}
+
+// EvalCaseRubricContent provides judge-readable content for a case-level rubric.
+type EvalCaseRubricContent struct {
+	Text string // Text is the actual rubric instruction used by rubric evaluators.
 }
 
 // ConversationScenario represents a dynamic user simulation scenario.
@@ -1574,6 +1589,10 @@ type RubricContent struct {
 
 `rubrics` split a metric into multiple clear-granularity criteria. Each rubric should be independent and directly verifiable from user input and the final answer, which improves judge stability and makes issues easier to locate. `id` is a stable identifier, and `content.text` is the rubric text used by the judge.
 
+`EvalCase.rubrics` adds extra evaluation criteria for a single case. Each rubric targets a configured metric through `metricName`; when that case is evaluated, the framework appends those criteria after the metric's shared rubrics. This affects only the current case and leaves the metric file's global configuration unchanged.
+
+The target metric uses `criterion.llmJudge` to carry the rubric list. Built-in rubric evaluators read the merged criteria, and custom rubric evaluators can read the same field.
+
 `template` is used only by `llm_judge_template`. It keeps template-based evaluation focused on cases where the prompt changes while the evaluation orchestration stays the same. Template evaluators do not read `rubrics`; evaluation criteria should be written directly into `template.prompt`.
 
 `template.prompt` uses double-brace template syntax such as `{{question}}` and `{{answer}}`. Every placeholder must be explicitly bound in `variableBindings`. Unbound variables, unknown variables, or binding resolution failures all result in errors.
@@ -1628,6 +1647,38 @@ Below is an example metric configuration that selects `llm_rubric_response` and 
 	}
 ]
 ```
+
+Case-level rubrics are configured directly in `EvalCase.rubrics`, for example:
+
+```json
+{
+	"evalId": "case_compound_profit",
+	"conversation": [
+		{
+			"invocationId": "case_compound_profit-1",
+			"userContent": {
+				"role": "user",
+				"content": "With a principal of 1000 dollars and a compound annual interest rate of 10%, what will the profit be after 30 years?"
+			}
+		}
+	],
+	"rubrics": [
+		{
+			"metricName": "llm_rubric_response",
+			"id": "case:compound-profit",
+			"content": {
+				"text": "For this case, the final answer must distinguish profit from total accumulated amount. A response that only gives the final amount without subtracting the original principal fails this rubric."
+			}
+		}
+	],
+	"sessionInput": {
+		"appName": "rubric-response-app",
+		"userId": "demo-user"
+	}
+}
+```
+
+Here, `metricName` selects the metric that receives the extra criterion. This example appends `case:compound-profit` to the rubrics for `llm_rubric_response`.
 
 Below is an example template metric configuration. It explicitly selects `llm_judge_template` via `evaluatorName`, while keeping `metricName` as the metric instance name in results.
 

--- a/docs/mkdocs/zh/evaluation.md
+++ b/docs/mkdocs/zh/evaluation.md
@@ -558,7 +558,22 @@ type EvalCase struct {
 	ConversationScenario  *ConversationScenario // ConversationScenario 是动态用户模拟场景，默认模式下与 Conversation 二选一
 	ActualConversation    []*Invocation         // ActualConversation 是 Trace 模式下的实际输出轨迹，可选
 	SessionInput          *SessionInput         // SessionInput 是会话初始化信息，必填
+	Rubrics               []*EvalCaseRubric     // Rubrics 是用例级评估细则，可选
 	CreationTimestamp     *epochtime.EpochTime  // CreationTimestamp 是创建时间戳，可选
+}
+
+// EvalCaseRubric 表示只作用于单个评估用例的评估细则
+type EvalCaseRubric struct {
+	MetricName  string                 // MetricName 是该细则补充的指标实例名
+	ID          string                 // ID 是用例级细则的唯一标识
+	Content     *EvalCaseRubricContent // Content 是裁判可读取的细则内容
+	Description string                 // Description 是人类可读说明，默认不参与裁判
+	Type        string                 // Type 是细则类型，用于结果排查
+}
+
+// EvalCaseRubricContent 表示用例级细则的裁判可读内容
+type EvalCaseRubricContent struct {
+	Text string // Text 是 rubric 评估器实际使用的细则文本
 }
 
 // ConversationScenario 表示动态用户模拟场景
@@ -1577,6 +1592,10 @@ type RubricContent struct {
 
 `rubrics` 用于把一个指标拆成多条粒度清晰的评估细则。每条细则尽量保持独立，并能从用户输入与最终回答中直接验证，使裁判判断更稳定，也便于定位问题。`id` 用作稳定标识，`content.text` 是裁判实际执行的细则文本。
 
+`EvalCase.rubrics` 用于给单个用例补充额外评估细则。每条 rubric 通过 `metricName` 指向一个已配置的 metric；评估该 case 时，框架会在该 metric 的公共 rubrics 之后追加这些细则，只影响当前 case，不改变指标文件中的全局配置。
+
+目标 metric 使用 `criterion.llmJudge` 承载 rubric 列表。内置 rubric evaluator 会读取合并后的细则；自定义 rubric evaluator 按同一字段读取即可。
+
 `template` 仅用于 `llm_judge_template`。它将模板化评估限制在“prompt 不同，但评估编排逻辑相同”的场景，不要求框架把所有评估器都表达成模板。模板评估器不读取 `rubrics`，评估标准应直接写入 `template.prompt`。
 
 `template.prompt` 使用双大括号模板语法，例如 `{{question}}`、`{{answer}}`。每个占位符都必须在 `variableBindings` 中显式绑定；未绑定变量、未知变量或绑定解析失败都会直接报错，不存在“可选变量”或空字符串兜底。
@@ -1631,6 +1650,38 @@ type RubricContent struct {
 	}
 ]
 ```
+
+用例级 rubric 可以直接写在 `EvalCase.rubrics` 中，例如：
+
+```json
+{
+	"evalId": "case_compound_profit",
+	"conversation": [
+		{
+			"invocationId": "case_compound_profit-1",
+			"userContent": {
+				"role": "user",
+				"content": "本金 1000 元、年复利 10%、30 年后的利润是多少？"
+			}
+		}
+	],
+	"rubrics": [
+		{
+			"metricName": "llm_rubric_response",
+			"id": "case:compound-profit",
+			"content": {
+				"text": "For this case, the final answer must distinguish profit from total accumulated amount. A response that only gives the final amount without subtracting the original principal fails this rubric."
+			}
+		}
+	],
+	"sessionInput": {
+		"appName": "rubric-response-app",
+		"userId": "demo-user"
+	}
+}
+```
+
+其中 `metricName` 指向要追加细则的 metric。上例会把 `case:compound-profit` 追加到 `llm_rubric_response` 的 rubrics 中。
 
 以下给出一条模板评估指标配置示例，通过 `evaluatorName` 显式选择 `llm_judge_template`，并让 `metricName` 仅作为结果中的指标实例名。
 

--- a/docs/mkdocs/zh/evaluation.md
+++ b/docs/mkdocs/zh/evaluation.md
@@ -1592,7 +1592,7 @@ type RubricContent struct {
 
 `rubrics` 用于把一个指标拆成多条粒度清晰的评估细则。每条细则尽量保持独立，并能从用户输入与最终回答中直接验证，使裁判判断更稳定，也便于定位问题。`id` 用作稳定标识，`content.text` 是裁判实际执行的细则文本。
 
-`EvalCase.rubrics` 用于给单个用例补充额外评估细则。每条 rubric 通过 `metricName` 指向一个已配置的 metric；评估该 case 时，框架会在该 metric 的公共 rubrics 之后追加这些细则，只影响当前 case，不改变指标文件中的全局配置。
+`EvalCase.rubrics` 用于给单个用例补充额外评估细则。每条 rubric 通过 `metricName` 指向一个已配置的 metric；评估该 case 时，框架会在该 metric 的公共 rubrics 之后追加这些细则，只影响当前 case，不改变指标文件中的全局配置。合并后的 rubric `id` 需要保持唯一。
 
 目标 metric 使用 `criterion.llmJudge` 承载 rubric 列表。内置 rubric evaluator 会读取合并后的细则；自定义 rubric evaluator 按同一字段读取即可。
 

--- a/evaluation/evalset/evalcase.go
+++ b/evaluation/evalset/evalcase.go
@@ -42,8 +42,30 @@ type EvalCase struct {
 	ActualConversation []*Invocation `json:"actualConversation,omitempty"`
 	// SessionInput contains initialization data for the session.
 	SessionInput *SessionInput `json:"sessionInput,omitempty"`
+	// Rubrics contains case-level evaluation rubrics bound to metric instances.
+	Rubrics []*EvalCaseRubric `json:"rubrics,omitempty"`
 	// CreationTimestamp when this eval case was created.
 	CreationTimestamp *epochtime.EpochTime `json:"creationTimestamp,omitempty"`
+}
+
+// EvalCaseRubric represents a rubric that applies only to one eval case.
+type EvalCaseRubric struct {
+	// MetricName identifies the metric instance this rubric augments.
+	MetricName string `json:"metricName,omitempty"`
+	// ID uniquely identifies this case-level rubric.
+	ID string `json:"id,omitempty"`
+	// Content contains the judge-readable rubric content.
+	Content *EvalCaseRubricContent `json:"content,omitempty"`
+	// Description stores human-facing context that is not judged by default.
+	Description string `json:"description,omitempty"`
+	// Type classifies the rubric for result inspection.
+	Type string `json:"type,omitempty"`
+}
+
+// EvalCaseRubricContent provides judge-readable content for a case-level rubric.
+type EvalCaseRubricContent struct {
+	// Text is the actual rubric instruction used by rubric evaluators.
+	Text string `json:"text,omitempty"`
 }
 
 // ConversationScenario describes how a simulated user should drive a conversation.

--- a/evaluation/evalset/inmemory/inmemory_test.go
+++ b/evaluation/evalset/inmemory/inmemory_test.go
@@ -58,6 +58,9 @@ func TestManager(t *testing.T) {
 		Conversation: []*evalset.Invocation{
 			{InvocationID: "inv1"},
 		},
+		Rubrics: []*evalset.EvalCaseRubric{
+			{MetricName: "llm_rubric_response", ID: "case:rubric", Content: &evalset.EvalCaseRubricContent{Text: "Case requirement."}},
+		},
 		CreationTimestamp: &epochtime.EpochTime{Time: time.Unix(1700, 0).UTC()},
 	}
 	err = mgr.AddCase(ctx, "app", "set1", caseInput)
@@ -67,15 +70,19 @@ func TestManager(t *testing.T) {
 	assert.Error(t, err)
 
 	caseInput.SessionInput.AppName = "changed"
+	caseInput.Rubrics[0].Content.Text = "mutated"
 
 	storedCase, err := mgr.GetCase(ctx, "app", "set1", "case1")
 	assert.NoError(t, err)
 	assert.Equal(t, "app", storedCase.SessionInput.AppName)
+	assert.Equal(t, "Case requirement.", storedCase.Rubrics[0].Content.Text)
 	storedCase.SessionInput.AppName = "local-mutation"
+	storedCase.Rubrics[0].Content.Text = "local mutation"
 
 	refetchedCase, err := mgr.GetCase(ctx, "app", "set1", "case1")
 	assert.NoError(t, err)
 	assert.Equal(t, "app", refetchedCase.SessionInput.AppName)
+	assert.Equal(t, "Case requirement.", refetchedCase.Rubrics[0].Content.Text)
 	assert.Len(t, refetchedCase.Conversation, 1)
 
 	update := &evalset.EvalCase{
@@ -88,17 +95,22 @@ func TestManager(t *testing.T) {
 			{InvocationID: "inv1"},
 			{InvocationID: "inv2"},
 		},
+		Rubrics: []*evalset.EvalCaseRubric{
+			{MetricName: "llm_rubric_response", ID: "case:updated", Content: &evalset.EvalCaseRubricContent{Text: "Updated case requirement."}},
+		},
 	}
 	err = mgr.UpdateCase(ctx, "app", "set1", update)
 	assert.NoError(t, err)
 
 	update.SessionInput.AppName = "mutated-after-update"
+	update.Rubrics[0].Content.Text = "mutated-after-update"
 
 	updatedCase, err := mgr.GetCase(ctx, "app", "set1", "case1")
 	assert.NoError(t, err)
 	assert.Equal(t, "app-updated", updatedCase.SessionInput.AppName)
 	assert.Equal(t, map[string]any{"level": 2}, updatedCase.SessionInput.State)
 	assert.Len(t, updatedCase.Conversation, 2)
+	assert.Equal(t, "Updated case requirement.", updatedCase.Rubrics[0].Content.Text)
 
 	evalSetAfterUpdate, err := mgr.Get(ctx, "app", "set1")
 	assert.NoError(t, err)

--- a/evaluation/internal/clone/clone_test.go
+++ b/evaluation/internal/clone/clone_test.go
@@ -119,6 +119,22 @@ func TestCloneTemplateVariableHelpersHandleNil(t *testing.T) {
 	assert.Nil(t, cloneTemplateVariableBinding(nil))
 }
 
+func TestCloneEvalCaseRubricsHandlesNilAndEmptyContent(t *testing.T) {
+	got := cloneEvalCaseRubrics([]*evalset.EvalCaseRubric{
+		nil,
+		{
+			MetricName: "llm_rubric_response",
+			ID:         "case:rubric",
+		},
+	})
+	require.Len(t, got, 2)
+	assert.Nil(t, got[0])
+	require.NotNil(t, got[1])
+	assert.Equal(t, "case:rubric", got[1].ID)
+	assert.Nil(t, got[1].Content)
+	assert.Nil(t, cloneEvalCaseRubrics(nil))
+}
+
 func TestCloneEvalMetric_PreservesNilTemplateBinding(t *testing.T) {
 	src := &metric.EvalMetric{
 		MetricName:    "metric-1",

--- a/evaluation/internal/clone/clone_test.go
+++ b/evaluation/internal/clone/clone_test.go
@@ -237,6 +237,15 @@ func TestCloneEvalCase_DeepCopy(t *testing.T) {
 				"bytes": []byte{9, 8, 7},
 			},
 		},
+		Rubrics: []*evalset.EvalCaseRubric{
+			{
+				MetricName:  "llm_rubric_response",
+				ID:          "case:rubric",
+				Description: "case rubric",
+				Type:        "CASE_RUBRIC",
+				Content:     &evalset.EvalCaseRubricContent{Text: "Case-specific requirement."},
+			},
+		},
 		CreationTimestamp: &epochtime.EpochTime{Time: time.Unix(1, 0).UTC()},
 	}
 
@@ -271,6 +280,9 @@ func TestCloneEvalCase_DeepCopy(t *testing.T) {
 
 	dst.SessionInput.State["bytes"].([]byte)[0] = 0
 	assert.Equal(t, byte(9), src.SessionInput.State["bytes"].([]byte)[0])
+
+	dst.Rubrics[0].Content.Text = "changed"
+	assert.Equal(t, "Case-specific requirement.", src.Rubrics[0].Content.Text)
 
 	dst.CreationTimestamp.Time = time.Unix(2, 0).UTC()
 	assert.Equal(t, time.Unix(1, 0).UTC(), src.CreationTimestamp.Time)

--- a/evaluation/internal/clone/evalset.go
+++ b/evaluation/internal/clone/evalset.go
@@ -58,7 +58,31 @@ func CloneEvalCase(src *evalset.EvalCase) (*evalset.EvalCase, error) {
 		return nil, err
 	}
 	copied.SessionInput = sessionInput
+	copied.Rubrics = cloneEvalCaseRubrics(src.Rubrics)
 	return &copied, nil
+}
+
+func cloneEvalCaseRubrics(src []*evalset.EvalCaseRubric) []*evalset.EvalCaseRubric {
+	if src == nil {
+		return nil
+	}
+	copied := make([]*evalset.EvalCaseRubric, len(src))
+	for i := range src {
+		copied[i] = cloneEvalCaseRubric(src[i])
+	}
+	return copied
+}
+
+func cloneEvalCaseRubric(src *evalset.EvalCaseRubric) *evalset.EvalCaseRubric {
+	if src == nil {
+		return nil
+	}
+	copied := *src
+	if src.Content != nil {
+		content := *src.Content
+		copied.Content = &content
+	}
+	return &copied
 }
 
 func cloneInvocations(src []*evalset.Invocation) ([]*evalset.Invocation, error) {

--- a/evaluation/service/local/local.go
+++ b/evaluation/service/local/local.go
@@ -32,6 +32,7 @@ import (
 	istatus "trpc.group/trpc-go/trpc-agent-go/evaluation/internal/status"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion"
+	criterionllm "trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion/llm"
 	metricregistry "trpc.group/trpc-go/trpc-agent-go/evaluation/metric/registry"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/service"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/service/internal/inference"
@@ -408,6 +409,10 @@ func (s *local) evaluatePerCase(ctx context.Context, inferenceResult *service.In
 	if err != nil {
 		return nil, fmt.Errorf("prepare case evaluation inputs (evalCaseID=%s): %w", inferenceResult.EvalCaseID, err)
 	}
+	caseRubricsByMetric, err := buildCaseRubricIndex(inferenceResult.EvalCaseID, evaluateConfig.EvalMetrics, evalCase.Rubrics)
+	if err != nil {
+		return nil, err
+	}
 	// overallMetricResults collects the metric results for the entire eval case.
 	overallMetricResults := make([]*evalresult.EvalMetricResult, 0, len(evaluateConfig.EvalMetrics))
 	perInvocation := make([]*evalresult.EvalMetricResultPerInvocation, len(inputs.actuals))
@@ -419,13 +424,25 @@ func (s *local) evaluatePerCase(ctx context.Context, inferenceResult *service.In
 		}
 	}
 	// Iterate through every configured metric and run the evaluation.
-	for _, evalMetric := range evaluateConfig.EvalMetrics {
-		result, err := s.evaluateMetric(ctx, opts.Registry, evalMetric, inputs.actuals, inputs.expecteds)
+	for _, configuredMetric := range evaluateConfig.EvalMetrics {
+		metricEvaluator, err := lookupMetricEvaluator(opts.Registry, configuredMetric)
 		if err != nil {
 			if errors.Is(err, os.ErrNotExist) {
 				// Skip metrics whose evaluator or artifacts are intentionally absent.
 				continue
 			}
+			return nil, err
+		}
+		evalMetric, err := buildCaseEffectiveMetric(
+			inferenceResult.EvalCaseID,
+			configuredMetric,
+			caseRubricsByMetric[configuredMetric.MetricName],
+		)
+		if err != nil {
+			return nil, err
+		}
+		result, err := metricEvaluator.Evaluate(ctx, inputs.actuals, inputs.expecteds, evalMetric)
+		if err != nil {
 			return nil, fmt.Errorf("run evaluation for metric %s: %w", evalMetric.MetricName, err)
 		}
 		if len(result.PerInvocationResults) != len(perInvocation) {
@@ -495,18 +512,110 @@ func (s *local) evaluatePerCase(ctx context.Context, inferenceResult *service.In
 	}, nil
 }
 
-// evaluateMetric locates the evaluator registered for the metric and runs the evaluation.
-func (s *local) evaluateMetric(ctx context.Context, reg registry.Registry, evalMetric *metric.EvalMetric, actuals, expecteds []*evalset.Invocation) (*evaluator.EvaluateResult, error) {
-	evaluatorName := evalMetric.MetricName
-	if evalMetric.EvaluatorName != "" {
-		evaluatorName = evalMetric.EvaluatorName
-	}
+func lookupMetricEvaluator(reg registry.Registry, evalMetric *metric.EvalMetric) (evaluator.Evaluator, error) {
+	evaluatorName := resolveEvaluatorName(evalMetric)
 	metricEvaluator, err := reg.Get(evaluatorName)
 	if err != nil {
 		return nil, fmt.Errorf("get evaluator for metric %s: %w", evaluatorName, err)
 	}
-	// Run the evaluation on the actual and expected invocations and return the evaluation result.
-	return metricEvaluator.Evaluate(ctx, actuals, expecteds, evalMetric)
+	return metricEvaluator, nil
+}
+
+func buildCaseRubricIndex(
+	evalCaseID string,
+	evalMetrics []*metric.EvalMetric,
+	caseRubrics []*evalset.EvalCaseRubric,
+) (map[string][]*criterionllm.Rubric, error) {
+	if len(caseRubrics) == 0 {
+		return nil, nil
+	}
+	metricNames := make(map[string]struct{}, len(evalMetrics))
+	for _, evalMetric := range evalMetrics {
+		if evalMetric == nil {
+			continue
+		}
+		if strings.TrimSpace(evalMetric.MetricName) == "" {
+			continue
+		}
+		metricNames[evalMetric.MetricName] = struct{}{}
+	}
+	rubricsByMetric := make(map[string][]*criterionllm.Rubric)
+	for i, caseRubric := range caseRubrics {
+		if caseRubric == nil {
+			return nil, fmt.Errorf("case rubric %s[%d]: rubric is nil", evalCaseID, i)
+		}
+		if strings.TrimSpace(caseRubric.MetricName) == "" {
+			return nil, fmt.Errorf("case rubric %s[%d]: metricName is empty", evalCaseID, i)
+		}
+		if caseRubric.Content == nil {
+			return nil, fmt.Errorf("case rubric %s[%d]: content is nil", evalCaseID, i)
+		}
+		text := strings.TrimSpace(caseRubric.Content.Text)
+		if text == "" {
+			return nil, fmt.Errorf("case rubric %s[%d]: content.text is empty", evalCaseID, i)
+		}
+		if _, ok := metricNames[caseRubric.MetricName]; !ok {
+			return nil, fmt.Errorf("case rubric %s[%d]: metric %s not found", evalCaseID, i, caseRubric.MetricName)
+		}
+		id := strings.TrimSpace(caseRubric.ID)
+		if id == "" {
+			id = fmt.Sprintf("case_rubric_%d", i+1)
+		}
+		rubric := &criterionllm.Rubric{
+			ID:          id,
+			Content:     &criterionllm.RubricContent{Text: text},
+			Description: caseRubric.Description,
+			Type:        strings.TrimSpace(caseRubric.Type),
+		}
+		rubricsByMetric[caseRubric.MetricName] = append(rubricsByMetric[caseRubric.MetricName], rubric)
+	}
+	return rubricsByMetric, nil
+}
+
+func buildCaseEffectiveMetric(evalCaseID string, evalMetric *metric.EvalMetric, caseRubrics []*criterionllm.Rubric) (*metric.EvalMetric, error) {
+	if len(caseRubrics) == 0 {
+		return evalMetric, nil
+	}
+	if evalMetric.Criterion == nil || evalMetric.Criterion.LLMJudge == nil {
+		return nil, fmt.Errorf("case rubric %s: metric %s llmJudge criterion is required as rubric container", evalCaseID, evalMetric.MetricName)
+	}
+	effectiveMetric, err := clone.CloneEvalMetric(evalMetric)
+	if err != nil {
+		return nil, fmt.Errorf("clone metric %s for case rubric: %w", evalMetric.MetricName, err)
+	}
+	effectiveMetric.Criterion.LLMJudge.JudgeRunnerOptions = evalMetric.Criterion.LLMJudge.JudgeRunnerOptions
+	if err := appendCaseRubricsToMetric(evalCaseID, effectiveMetric, caseRubrics); err != nil {
+		return nil, err
+	}
+	return effectiveMetric, nil
+}
+
+func appendCaseRubricsToMetric(evalCaseID string, evalMetric *metric.EvalMetric, caseRubrics []*criterionllm.Rubric) error {
+	if len(caseRubrics) == 0 {
+		return nil
+	}
+	seenIDs := make(map[string]struct{}, len(evalMetric.Criterion.LLMJudge.Rubrics)+len(caseRubrics))
+	for _, rubric := range evalMetric.Criterion.LLMJudge.Rubrics {
+		if rubric == nil {
+			continue
+		}
+		id := strings.TrimSpace(rubric.ID)
+		if id == "" {
+			continue
+		}
+		if _, exists := seenIDs[id]; exists {
+			return fmt.Errorf("case rubric %s: duplicate rubric id %s", evalCaseID, id)
+		}
+		seenIDs[id] = struct{}{}
+	}
+	for _, caseRubric := range caseRubrics {
+		if _, exists := seenIDs[caseRubric.ID]; exists {
+			return fmt.Errorf("case rubric %s: duplicate rubric id %s", evalCaseID, caseRubric.ID)
+		}
+		seenIDs[caseRubric.ID] = struct{}{}
+		evalMetric.Criterion.LLMJudge.Rubrics = append(evalMetric.Criterion.LLMJudge.Rubrics, caseRubric)
+	}
+	return nil
 }
 
 type caseEvaluationInputs struct {

--- a/evaluation/service/local/local_test.go
+++ b/evaluation/service/local/local_test.go
@@ -3968,10 +3968,28 @@ func TestBuildCaseRubricIndexValidation(t *testing.T) {
 		wantErr string
 	}{
 		{
+			name:    "nil rubric",
+			metrics: []*metric.EvalMetric{baseMetric()},
+			rubrics: []*evalset.EvalCaseRubric{nil},
+			wantErr: "rubric is nil",
+		},
+		{
+			name:    "empty metric name",
+			metrics: []*metric.EvalMetric{baseMetric()},
+			rubrics: []*evalset.EvalCaseRubric{caseRubric(" ", "case", "Case requirement.")},
+			wantErr: "metricName is empty",
+		},
+		{
 			name:    "missing target metric",
 			metrics: []*metric.EvalMetric{baseMetric()},
 			rubrics: []*evalset.EvalCaseRubric{caseRubric("missing", "case", "Case requirement.")},
 			wantErr: "metric missing not found",
+		},
+		{
+			name:    "no usable metrics",
+			metrics: []*metric.EvalMetric{nil, {}},
+			rubrics: []*evalset.EvalCaseRubric{caseRubric("llm_rubric_response", "case", "Case requirement.")},
+			wantErr: "metric llm_rubric_response not found",
 		},
 		{
 			name:    "empty rubric text",

--- a/evaluation/service/local/local_test.go
+++ b/evaluation/service/local/local_test.go
@@ -123,6 +123,7 @@ type fakeEvaluator struct {
 
 	receivedActuals   []*evalset.Invocation
 	receivedExpecteds []*evalset.Invocation
+	receivedMetric    *metric.EvalMetric
 }
 
 func (f *fakeEvaluator) Name() string {
@@ -139,6 +140,7 @@ func (f *fakeEvaluator) Evaluate(ctx context.Context, actuals, expecteds []*eval
 	}
 	f.receivedActuals = actuals
 	f.receivedExpecteds = expecteds
+	f.receivedMetric = evalMetric
 	return f.result, nil
 }
 
@@ -3735,8 +3737,374 @@ func TestEvaluatePerCaseScenarioRunsConfiguredMetric(t *testing.T) {
 	assert.Len(t, fakeEval.receivedExpecteds, 1)
 }
 
-func TestLocalEvaluateMetricUsesEvaluatorNameWhenPresent(t *testing.T) {
+func TestBuildCaseEffectiveMetricAppendsCaseRubrics(t *testing.T) {
+	judgeRunner := &fakeRunner{}
+	globalMetric := &metric.EvalMetric{
+		MetricName: "llm_rubric_response",
+		Threshold:  1,
+		Criterion: &criterion.Criterion{
+			LLMJudge: &criterionllm.LLMCriterion{
+				JudgeRunnerOptions: &criterionllm.JudgeRunnerOptions{Runner: judgeRunner},
+				Rubrics: []*criterionllm.Rubric{
+					{ID: "global", Content: &criterionllm.RubricContent{Text: "Global requirement."}},
+				},
+			},
+		},
+	}
+	rubricsByMetric, err := buildCaseRubricIndex("case-1", []*metric.EvalMetric{globalMetric}, []*evalset.EvalCaseRubric{
+		{
+			MetricName: "llm_rubric_response",
+			Content:    &evalset.EvalCaseRubricContent{Text: " Case requirement. "},
+		},
+	})
+	assert.NoError(t, err)
+	gotMetric, err := buildCaseEffectiveMetric("case-1", globalMetric, rubricsByMetric["llm_rubric_response"])
+	assert.NoError(t, err)
+	if !assert.NotNil(t, gotMetric) {
+		return
+	}
+	require.NotNil(t, gotMetric.Criterion)
+	require.NotNil(t, gotMetric.Criterion.LLMJudge)
+	require.NotNil(t, gotMetric.Criterion.LLMJudge.JudgeRunnerOptions)
+	assert.Same(t, judgeRunner, gotMetric.Criterion.LLMJudge.JudgeRunnerOptions.Runner)
+	assert.Len(t, globalMetric.Criterion.LLMJudge.Rubrics, 1)
+	if assert.Len(t, gotMetric.Criterion.LLMJudge.Rubrics, 2) {
+		caseRubric := gotMetric.Criterion.LLMJudge.Rubrics[1]
+		assert.Equal(t, "case_rubric_1", caseRubric.ID)
+		assert.Empty(t, caseRubric.Type)
+		assert.Equal(t, "Case requirement.", caseRubric.Content.Text)
+	}
+}
+
+func TestEvaluatePerCaseUsesCaseEffectiveMetric(t *testing.T) {
 	ctx := context.Background()
+	appName := "app"
+	evalSetID := "set"
+	caseID := "case-rubric"
+	mgr := evalsetinmemory.New()
+	_, err := mgr.Create(ctx, appName, evalSetID)
+	assert.NoError(t, err)
+	evalCase := makeEvalCase(appName, caseID, "prompt")
+	evalCase.Rubrics = []*evalset.EvalCaseRubric{
+		{
+			MetricName:  "domain_policy_check",
+			ID:          "case:policy-edge",
+			Description: "Case-specific policy edge.",
+			Type:        "CASE_RUBRIC",
+			Content:     &evalset.EvalCaseRubricContent{Text: "The answer must mention manual review."},
+		},
+	}
+	assert.NoError(t, mgr.AddCase(ctx, appName, evalSetID, evalCase))
+	reg := registry.New()
+	fakeEval := &fakeEvaluator{
+		name: "custom_domain_rubric",
+		result: &evaluator.EvaluateResult{
+			OverallScore:  1,
+			OverallStatus: status.EvalStatusPassed,
+			PerInvocationResults: []*evaluator.PerInvocationResult{
+				{Score: 1, Status: status.EvalStatusPassed},
+			},
+		},
+	}
+	assert.NoError(t, reg.Register(fakeEval.name, fakeEval))
+	svc := newLocalService(t, &fakeRunner{}, mgr, reg, "session-1")
+	configuredMetric := &metric.EvalMetric{
+		MetricName:    "domain_policy_check",
+		EvaluatorName: fakeEval.name,
+		Threshold:     0.5,
+		Criterion: &criterion.Criterion{
+			LLMJudge: &criterionllm.LLMCriterion{
+				Rubrics: []*criterionllm.Rubric{
+					{ID: "global:policy", Content: &criterionllm.RubricContent{Text: "The answer must comply with policy."}},
+				},
+			},
+		},
+	}
+	inferenceResult := makeInferenceResult(appName, evalSetID, caseID, "session-1", []*evalset.Invocation{
+		makeActualInvocation("actual-1", "prompt", "answer"),
+	})
+	result, err := svc.evaluatePerCase(ctx, inferenceResult, &service.EvaluateConfig{
+		EvalMetrics: []*metric.EvalMetric{configuredMetric},
+	}, &service.Options{
+		EvalSetManager: mgr,
+		Registry:       reg,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, status.EvalStatusPassed, result.FinalEvalStatus)
+	assert.Len(t, configuredMetric.Criterion.LLMJudge.Rubrics, 1)
+	require.NotNil(t, fakeEval.receivedMetric)
+	assert.NotSame(t, configuredMetric, fakeEval.receivedMetric)
+	if assert.Len(t, fakeEval.receivedMetric.Criterion.LLMJudge.Rubrics, 2) {
+		assert.Equal(t, "global:policy", fakeEval.receivedMetric.Criterion.LLMJudge.Rubrics[0].ID)
+		assert.Equal(t, "case:policy-edge", fakeEval.receivedMetric.Criterion.LLMJudge.Rubrics[1].ID)
+	}
+	if assert.Len(t, result.OverallEvalMetricResults, 1) {
+		require.NotNil(t, result.OverallEvalMetricResults[0].Criterion)
+		require.NotNil(t, result.OverallEvalMetricResults[0].Criterion.LLMJudge)
+		assert.Len(t, result.OverallEvalMetricResults[0].Criterion.LLMJudge.Rubrics, 2)
+	}
+	if assert.Len(t, result.EvalMetricResultPerInvocation, 1) && assert.Len(t, result.EvalMetricResultPerInvocation[0].EvalMetricResults, 1) {
+		require.NotNil(t, result.EvalMetricResultPerInvocation[0].EvalMetricResults[0].Criterion)
+		require.NotNil(t, result.EvalMetricResultPerInvocation[0].EvalMetricResults[0].Criterion.LLMJudge)
+		assert.Len(t, result.EvalMetricResultPerInvocation[0].EvalMetricResults[0].Criterion.LLMJudge.Rubrics, 2)
+	}
+}
+
+func TestEvaluatePerCaseBindsCaseRubricByMetricNameWhenEvaluatorNameDiffers(t *testing.T) {
+	ctx := context.Background()
+	appName := "app"
+	evalSetID := "set"
+	caseID := "case-custom-metric"
+	mgr := evalsetinmemory.New()
+	_, err := mgr.Create(ctx, appName, evalSetID)
+	assert.NoError(t, err)
+	evalCase := makeEvalCase(appName, caseID, "prompt")
+	evalCase.Rubrics = []*evalset.EvalCaseRubric{
+		{MetricName: "answer_quality", ID: "case:quality", Content: &evalset.EvalCaseRubricContent{Text: "The answer must be concise."}},
+	}
+	assert.NoError(t, mgr.AddCase(ctx, appName, evalSetID, evalCase))
+	reg := registry.New()
+	fakeEval := &fakeEvaluator{
+		name: "llm_rubric_response",
+		result: &evaluator.EvaluateResult{
+			OverallScore:         1,
+			OverallStatus:        status.EvalStatusPassed,
+			PerInvocationResults: []*evaluator.PerInvocationResult{{Score: 1, Status: status.EvalStatusPassed}},
+		},
+	}
+	assert.NoError(t, reg.Register(fakeEval.name, fakeEval))
+	svc := newLocalService(t, &fakeRunner{}, mgr, reg, "session-1")
+	inferenceResult := makeInferenceResult(appName, evalSetID, caseID, "session-1", []*evalset.Invocation{
+		makeActualInvocation("actual-1", "prompt", "answer"),
+	})
+	result, err := svc.evaluatePerCase(ctx, inferenceResult, &service.EvaluateConfig{
+		EvalMetrics: []*metric.EvalMetric{
+			{
+				MetricName:    "answer_quality",
+				EvaluatorName: "llm_rubric_response",
+				Criterion:     &criterion.Criterion{LLMJudge: &criterionllm.LLMCriterion{}},
+			},
+		},
+	}, &service.Options{EvalSetManager: mgr, Registry: reg})
+	assert.NoError(t, err)
+	assert.Equal(t, status.EvalStatusPassed, result.FinalEvalStatus)
+	require.NotNil(t, fakeEval.receivedMetric)
+	if assert.Len(t, fakeEval.receivedMetric.Criterion.LLMJudge.Rubrics, 1) {
+		assert.Equal(t, "case:quality", fakeEval.receivedMetric.Criterion.LLMJudge.Rubrics[0].ID)
+	}
+}
+
+func TestEvaluatePerCaseTemplateEvaluatorKeepsCaseRubricInEffectiveCriterion(t *testing.T) {
+	ctx := context.Background()
+	appName := "app"
+	evalSetID := "set"
+	caseID := "case-template"
+	mgr := evalsetinmemory.New()
+	_, err := mgr.Create(ctx, appName, evalSetID)
+	assert.NoError(t, err)
+	evalCase := makeEvalCase(appName, caseID, "prompt")
+	evalCase.Rubrics = []*evalset.EvalCaseRubric{
+		{MetricName: "llm_rubric_response", ID: "case:template", Content: &evalset.EvalCaseRubricContent{Text: "The answer must mention manual review."}},
+	}
+	assert.NoError(t, mgr.AddCase(ctx, appName, evalSetID, evalCase))
+	reg := registry.New()
+	fakeEval := &fakeEvaluator{
+		name: llmtemplateevaluator.EvaluatorName,
+		result: &evaluator.EvaluateResult{
+			OverallScore:         1,
+			OverallStatus:        status.EvalStatusPassed,
+			PerInvocationResults: []*evaluator.PerInvocationResult{{Score: 1, Status: status.EvalStatusPassed}},
+		},
+	}
+	assert.NoError(t, reg.Register(fakeEval.name, fakeEval))
+	svc := newLocalService(t, &fakeRunner{}, mgr, reg, "session-1")
+	inferenceResult := makeInferenceResult(appName, evalSetID, caseID, "session-1", []*evalset.Invocation{
+		makeActualInvocation("actual-1", "prompt", "answer"),
+	})
+	result, err := svc.evaluatePerCase(ctx, inferenceResult, &service.EvaluateConfig{
+		EvalMetrics: []*metric.EvalMetric{
+			{
+				MetricName:    "llm_rubric_response",
+				EvaluatorName: llmtemplateevaluator.EvaluatorName,
+				Criterion:     &criterion.Criterion{LLMJudge: &criterionllm.LLMCriterion{}},
+			},
+		},
+	}, &service.Options{EvalSetManager: mgr, Registry: reg})
+	assert.NoError(t, err)
+	assert.Equal(t, status.EvalStatusPassed, result.FinalEvalStatus)
+	if assert.Len(t, result.OverallEvalMetricResults, 1) {
+		require.NotNil(t, result.OverallEvalMetricResults[0].Criterion)
+		require.NotNil(t, result.OverallEvalMetricResults[0].Criterion.LLMJudge)
+		if assert.Len(t, result.OverallEvalMetricResults[0].Criterion.LLMJudge.Rubrics, 1) {
+			assert.Equal(t, "case:template", result.OverallEvalMetricResults[0].Criterion.LLMJudge.Rubrics[0].ID)
+		}
+	}
+}
+
+func TestBuildCaseRubricIndexValidation(t *testing.T) {
+	baseMetric := func() *metric.EvalMetric {
+		return &metric.EvalMetric{
+			MetricName: "llm_rubric_response",
+			Criterion: &criterion.Criterion{
+				LLMJudge: &criterionllm.LLMCriterion{
+					Rubrics: []*criterionllm.Rubric{
+						{ID: "global", Content: &criterionllm.RubricContent{Text: "Global requirement."}},
+					},
+				},
+			},
+		}
+	}
+	caseRubric := func(metricName, id, text string) *evalset.EvalCaseRubric {
+		return &evalset.EvalCaseRubric{
+			MetricName: metricName,
+			ID:         id,
+			Content:    &evalset.EvalCaseRubricContent{Text: text},
+		}
+	}
+	tests := []struct {
+		name    string
+		metrics []*metric.EvalMetric
+		rubrics []*evalset.EvalCaseRubric
+		wantErr string
+	}{
+		{
+			name:    "missing target metric",
+			metrics: []*metric.EvalMetric{baseMetric()},
+			rubrics: []*evalset.EvalCaseRubric{caseRubric("missing", "case", "Case requirement.")},
+			wantErr: "metric missing not found",
+		},
+		{
+			name:    "empty rubric text",
+			metrics: []*metric.EvalMetric{baseMetric()},
+			rubrics: []*evalset.EvalCaseRubric{caseRubric("llm_rubric_response", "case", " ")},
+			wantErr: "content.text is empty",
+		},
+		{
+			name:    "nil rubric content",
+			metrics: []*metric.EvalMetric{baseMetric()},
+			rubrics: []*evalset.EvalCaseRubric{{MetricName: "llm_rubric_response"}},
+			wantErr: "content is nil",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := buildCaseRubricIndex("case-1", tc.metrics, tc.rubrics)
+			assert.ErrorContains(t, err, tc.wantErr)
+			assert.Nil(t, got)
+		})
+	}
+}
+
+func TestBuildCaseRubricIndexIgnoresUnrelatedMetricShape(t *testing.T) {
+	got, err := buildCaseRubricIndex("case-1", []*metric.EvalMetric{
+		nil,
+		{},
+		{MetricName: "duplicate"},
+		{MetricName: "duplicate"},
+	}, []*evalset.EvalCaseRubric{
+		{
+			MetricName: "duplicate",
+			ID:         "case",
+			Content:    &evalset.EvalCaseRubricContent{Text: "Case requirement."},
+		},
+	})
+	assert.NoError(t, err)
+	if assert.Len(t, got, 1) {
+		assert.Len(t, got["duplicate"], 1)
+	}
+}
+
+func TestBuildCaseEffectiveMetricValidation(t *testing.T) {
+	originalMetric := &metric.EvalMetric{MetricName: "plain_metric"}
+	got, err := buildCaseEffectiveMetric("case-1", originalMetric, nil)
+	assert.NoError(t, err)
+	assert.Same(t, originalMetric, got)
+	caseRubric := &criterionllm.Rubric{
+		ID:      "global",
+		Content: &criterionllm.RubricContent{Text: "Case requirement."},
+	}
+	_, err = buildCaseEffectiveMetric("case-1", &metric.EvalMetric{MetricName: "llm_rubric_response"}, []*criterionllm.Rubric{caseRubric})
+	assert.ErrorContains(t, err, "llmJudge criterion is required as rubric container")
+	evalMetric := &metric.EvalMetric{
+		MetricName: "llm_rubric_response",
+		Criterion: &criterion.Criterion{
+			LLMJudge: &criterionllm.LLMCriterion{
+				Rubrics: []*criterionllm.Rubric{
+					{ID: "global", Content: &criterionllm.RubricContent{Text: "Global requirement."}},
+				},
+			},
+		},
+	}
+	got, err = buildCaseEffectiveMetric("case-1", evalMetric, []*criterionllm.Rubric{caseRubric})
+	assert.ErrorContains(t, err, "duplicate rubric id global")
+	assert.Nil(t, got)
+}
+
+func TestEvaluatePerCaseSkipsMissingEvaluatorWithCaseRubric(t *testing.T) {
+	ctx := context.Background()
+	appName := "app"
+	evalSetID := "set"
+	caseID := "case-missing-evaluator"
+	mgr := evalsetinmemory.New()
+	_, err := mgr.Create(ctx, appName, evalSetID)
+	assert.NoError(t, err)
+	evalCase := makeEvalCase(appName, caseID, "prompt")
+	evalCase.Rubrics = []*evalset.EvalCaseRubric{
+		{MetricName: "missing_metric", ID: "case:rubric", Content: &evalset.EvalCaseRubricContent{Text: "Case requirement."}},
+	}
+	assert.NoError(t, mgr.AddCase(ctx, appName, evalSetID, evalCase))
+	reg := registry.New()
+	svc := newLocalService(t, &fakeRunner{}, mgr, reg, "session-1")
+	inferenceResult := makeInferenceResult(appName, evalSetID, caseID, "session-1", []*evalset.Invocation{
+		makeActualInvocation("actual-1", "prompt", "answer"),
+	})
+	result, err := svc.evaluatePerCase(ctx, inferenceResult, &service.EvaluateConfig{
+		EvalMetrics: []*metric.EvalMetric{
+			{MetricName: "missing_metric"},
+		},
+	}, &service.Options{
+		EvalSetManager: mgr,
+		Registry:       reg,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, status.EvalStatusNotEvaluated, result.FinalEvalStatus)
+	assert.Empty(t, result.OverallEvalMetricResults)
+	if assert.Len(t, result.EvalMetricResultPerInvocation, 1) {
+		assert.Empty(t, result.EvalMetricResultPerInvocation[0].EvalMetricResults)
+	}
+}
+
+func TestLocalEvaluateCaseRubricValidationFailureReturnsCaseResult(t *testing.T) {
+	ctx := context.Background()
+	appName := "app"
+	evalSetID := "set"
+	caseID := "case-invalid-rubric"
+	mgr := evalsetinmemory.New()
+	_, err := mgr.Create(ctx, appName, evalSetID)
+	assert.NoError(t, err)
+	evalCase := makeEvalCase(appName, caseID, "prompt")
+	evalCase.Rubrics = []*evalset.EvalCaseRubric{
+		{MetricName: "missing_metric", ID: "case:rubric", Content: &evalset.EvalCaseRubricContent{Text: "Case requirement."}},
+	}
+	assert.NoError(t, mgr.AddCase(ctx, appName, evalSetID, evalCase))
+	svc := newLocalService(t, &fakeRunner{}, mgr, registry.New(), "session-1")
+	inferenceResult := makeInferenceResult(appName, evalSetID, caseID, "session-1", []*evalset.Invocation{
+		makeActualInvocation("actual-1", "prompt", "answer"),
+	})
+	result, err := svc.Evaluate(ctx, &service.EvaluateRequest{
+		AppName:          appName,
+		EvalSetID:        evalSetID,
+		InferenceResults: []*service.InferenceResult{inferenceResult},
+		EvaluateConfig:   &service.EvaluateConfig{EvalMetrics: []*metric.EvalMetric{}},
+	})
+	assert.NoError(t, err)
+	if assert.Len(t, result.EvalCaseResults, 1) {
+		assert.Equal(t, status.EvalStatusFailed, result.EvalCaseResults[0].FinalEvalStatus)
+		assert.Contains(t, result.EvalCaseResults[0].ErrorMessage, "metric missing_metric not found")
+	}
+}
+
+func TestLookupMetricEvaluatorUsesEvaluatorNameWhenPresent(t *testing.T) {
 	reg := registry.New()
 	fakeEval := &fakeEvaluator{
 		name: "llm_judge_template",
@@ -3747,20 +4115,14 @@ func TestLocalEvaluateMetricUsesEvaluatorNameWhenPresent(t *testing.T) {
 		},
 	}
 	assert.NoError(t, reg.Register(fakeEval.name, fakeEval))
-	svc := &local{}
-	actuals := []*evalset.Invocation{makeActualInvocation("actual-1", "prompt", "answer")}
-	expecteds := []*evalset.Invocation{makeActualInvocation("expected-1", "prompt", "reference")}
 	evalMetric := &metric.EvalMetric{
 		MetricName:    "answer_quality_against_reference",
 		EvaluatorName: fakeEval.name,
 		Threshold:     0.5,
 	}
-
-	result, err := svc.evaluateMetric(ctx, reg, evalMetric, actuals, expecteds)
+	result, err := lookupMetricEvaluator(reg, evalMetric)
 	assert.NoError(t, err)
-	assert.Equal(t, fakeEval.result, result)
-	assert.Equal(t, actuals, fakeEval.receivedActuals)
-	assert.Equal(t, expecteds, fakeEval.receivedExpecteds)
+	assert.Equal(t, fakeEval, result)
 }
 
 func TestMaterializeResultCriterionInstantiatesTemplatePrompt(t *testing.T) {

--- a/examples/evaluation/llm/caselevelrubric/README.md
+++ b/examples/evaluation/llm/caselevelrubric/README.md
@@ -1,0 +1,62 @@
+# Case-Level Rubric Evaluation Example
+
+This example shows how case-level rubrics work when an eval set uses both a non-rubric evaluator and a rubric-based LLM evaluator.
+
+The eval config contains two metrics:
+
+- `tool_trajectory_avg_score` checks the agent's tool calls.
+- `travel_answer_quality` routes to `llm_rubric_response` and owns the LLM judge rubrics.
+
+The eval case adds one case-level rubric and binds it to `travel_answer_quality`. It does not bind the rubric to the tool trajectory metric, so the tool trajectory metric runs normally while the LLM rubric metric receives the extra case-specific requirement.
+
+## Environment Variables
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `OPENAI_API_KEY` | API key for the agent model (required) | `` |
+| `OPENAI_BASE_URL` | Optional custom endpoint for the agent model | `https://api.openai.com/v1` |
+| `JUDGE_MODEL_API_KEY` | API key for the judge model (required) | `` |
+| `JUDGE_MODEL_BASE_URL` | Optional custom endpoint for the judge model | `https://api.openai.com/v1` |
+
+The metric configuration in `data/` references the judge settings via `${JUDGE_MODEL_API_KEY}` and `${JUDGE_MODEL_BASE_URL}` placeholders.
+
+## Flags
+
+| Flag | Description | Default |
+| --- | --- | --- |
+| `-model` | Model identifier used by the agent | `gpt-5.2` |
+| `-streaming` | Enable streaming responses from the agent | `false` |
+| `-data-dir` | Directory containing `.evalset.json` and `.metrics.json` | `./data` |
+| `-output-dir` | Directory where evaluation results are written | `./output` |
+| `-eval-set` | Evaluation set ID to execute | `case-level-rubric-basic` |
+
+## Run
+
+```bash
+cd examples/evaluation/llm/caselevelrubric
+OPENAI_API_KEY=sk-... \
+JUDGE_MODEL_API_KEY=sk-... \
+go run . \
+  -data-dir "./data" \
+  -output-dir "./output" \
+  -eval-set "case-level-rubric-basic"
+```
+
+## Data Layout
+
+```text
+data/
+└── case-level-rubric-app/
+    ├── case-level-rubric-basic.evalset.json
+    └── case-level-rubric-basic.metrics.json
+```
+
+Key points in the data files:
+
+- `case-level-rubric-basic.metrics.json` defines both `tool_trajectory_avg_score` and `travel_answer_quality`.
+- `travel_answer_quality` sets `evaluatorName` to `llm_rubric_response` and provides `criterion.llmJudge`.
+- The eval case's `rubrics[0].metricName` is `travel_answer_quality`, not `tool_trajectory_avg_score`.
+
+## Expected Behavior
+
+The tool trajectory metric evaluates only tool usage. The case-level rubric is appended only to `travel_answer_quality` and appears in that metric's effective `criterion.llmJudge.rubrics` and rubric scores.

--- a/examples/evaluation/llm/caselevelrubric/README.md
+++ b/examples/evaluation/llm/caselevelrubric/README.md
@@ -60,3 +60,5 @@ Key points in the data files:
 ## Expected Behavior
 
 The tool trajectory metric evaluates only tool usage. The case-level rubric is appended only to `travel_answer_quality` and appears in that metric's effective `criterion.llmJudge.rubrics` and rubric scores.
+
+IDs, timestamps, tool-call details, and LLM wording in the sample output can vary by run and model; the stable expectation is the rubric merge behavior.

--- a/examples/evaluation/llm/caselevelrubric/agent.go
+++ b/examples/evaluation/llm/caselevelrubric/agent.go
@@ -1,0 +1,135 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"context"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/model/openai"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+	"trpc.group/trpc-go/trpc-agent-go/tool/function"
+)
+
+// newTravelAgent builds an agent with weather, news, time, and ticket tools.
+func newTravelAgent(modelName string, stream bool) agent.Agent {
+	weatherTool := function.NewFunctionTool(
+		getWeather,
+		function.WithName("get_weather"),
+		function.WithDescription("Get weather for a city."),
+	)
+	newsTool := function.NewFunctionTool(
+		getNews,
+		function.WithName("get_news"),
+		function.WithDescription("Get safety and event alerts for a city."),
+	)
+	timeTool := function.NewFunctionTool(
+		getTime,
+		function.WithName("get_time"),
+		function.WithDescription("Get the current timestamp."),
+	)
+	ticketTool := function.NewFunctionTool(
+		getTicket,
+		function.WithName("get_ticket"),
+		function.WithDescription("Check ticket availability for a city and time."),
+	)
+	genCfg := model.GenerationConfig{
+		MaxTokens:   intPtr(512),
+		Temperature: floatPtr(0.0),
+		Stream:      stream,
+	}
+	return llmagent.New(
+		"case-level-rubric-agent",
+		llmagent.WithModel(openai.New(modelName)),
+		llmagent.WithTools([]tool.Tool{weatherTool, newsTool, timeTool, ticketTool}),
+		llmagent.WithInstruction(`Always call tools before answering:
+- Use get_weather to fetch city weather.
+- Use get_news to fetch local alerts.
+- Use get_time to get the current timestamp.
+- Use get_ticket with the city and timestamp.
+Finally summarize weather, alerts, ticket status, and a clear travel recommendation in Chinese.`),
+		llmagent.WithDescription("Agent for case-level rubric evaluation."),
+		llmagent.WithGenerationConfig(genCfg),
+	)
+}
+
+type weatherArgs struct {
+	City string `json:"city"`
+}
+
+type weatherResult struct {
+	City      string  `json:"city"`
+	Condition string  `json:"condition"`
+	TempC     float64 `json:"tempC"`
+}
+
+func getWeather(_ context.Context, args weatherArgs) (weatherResult, error) {
+	return weatherResult{
+		City:      args.City,
+		Condition: "sunny",
+		TempC:     26,
+	}, nil
+}
+
+type newsArgs struct {
+	City string `json:"city"`
+}
+
+type newsResult struct {
+	City     string `json:"city"`
+	Headline string `json:"headline"`
+}
+
+func getNews(_ context.Context, args newsArgs) (newsResult, error) {
+	return newsResult{
+		City:     args.City,
+		Headline: "Festival events will be held downtown; traffic disruptions are expected.",
+	}, nil
+}
+
+type timeArgs struct {
+}
+
+type timeResult struct {
+	Timestamp string `json:"timestamp"`
+}
+
+func getTime(_ context.Context, _ timeArgs) (timeResult, error) {
+	return timeResult{Timestamp: time.Now().Format(time.RFC3339)}, nil
+}
+
+type ticketArgs struct {
+	City string `json:"city"`
+	Time string `json:"time"`
+}
+
+type ticketResult struct {
+	City      string `json:"city"`
+	Time      string `json:"time"`
+	SeatsLeft int    `json:"seatsLeft"`
+}
+
+func getTicket(_ context.Context, args ticketArgs) (ticketResult, error) {
+	return ticketResult{
+		City:      args.City,
+		Time:      args.Time,
+		SeatsLeft: 25,
+	}, nil
+}
+
+func intPtr(v int) *int {
+	return &v
+}
+
+func floatPtr(v float64) *float64 {
+	return &v
+}

--- a/examples/evaluation/llm/caselevelrubric/data/case-level-rubric-app/case-level-rubric-basic.evalset.json
+++ b/examples/evaluation/llm/caselevelrubric/data/case-level-rubric-app/case-level-rubric-basic.evalset.json
@@ -1,0 +1,78 @@
+{
+  "evalSetId": "case-level-rubric-basic",
+  "name": "case-level-rubric-basic",
+  "evalCases": [
+    {
+      "evalId": "shanghai_travel_case",
+      "conversation": [
+        {
+          "invocationId": "shanghai_travel_case-1",
+          "userContent": {
+            "role": "user",
+            "content": "I'm traveling to Shanghai tonight. What should I watch out for, and can I still get a ticket?"
+          },
+          "finalResponse": {
+            "role": "assistant",
+            "content": "Shanghai is sunny at 26C. Downtown festival events may cause traffic disruptions. There are 25 tickets left, so tickets are still available. Leave early, plan extra travel time, and buy or reserve the ticket soon."
+          },
+          "tools": [
+            {
+              "id": "tool_use_weather",
+              "name": "get_weather",
+              "arguments": {
+                "city": "Shanghai"
+              },
+              "result": {
+                "city": "Shanghai",
+                "condition": "sunny",
+                "tempC": 26
+              }
+            },
+            {
+              "id": "tool_use_news",
+              "name": "get_news",
+              "arguments": {
+                "city": "Shanghai"
+              },
+              "result": {
+                "city": "Shanghai",
+                "headline": "Festival events will be held downtown; traffic disruptions are expected."
+              }
+            },
+            {
+              "id": "tool_use_time",
+              "name": "get_time",
+              "arguments": {},
+              "result": {}
+            },
+            {
+              "id": "tool_use_ticket",
+              "name": "get_ticket",
+              "arguments": {
+                "city": "Shanghai"
+              },
+              "result": {
+                "city": "Shanghai",
+                "seatsLeft": 25
+              }
+            }
+          ]
+        }
+      ],
+      "rubrics": [
+        {
+          "metricName": "travel_answer_quality",
+          "id": "case:festival-ticket-advice",
+          "description": "This case needs festival traffic and ticket availability advice.",
+          "content": {
+            "text": "For this Shanghai travel case, the final answer must mention festival-related traffic disruption and ticket availability. It should also include at least one concrete action recommendation, such as leaving early, planning extra travel time, reserving, or buying the ticket soon."
+          }
+        }
+      ],
+      "sessionInput": {
+        "appName": "case-level-rubric-app",
+        "userId": "traveler"
+      }
+    }
+  ]
+}

--- a/examples/evaluation/llm/caselevelrubric/data/case-level-rubric-app/case-level-rubric-basic.metrics.json
+++ b/examples/evaluation/llm/caselevelrubric/data/case-level-rubric-app/case-level-rubric-basic.metrics.json
@@ -1,0 +1,75 @@
+[
+  {
+    "metricName": "tool_trajectory_avg_score",
+    "threshold": 1,
+    "criterion": {
+      "toolTrajectory": {
+        "orderSensitive": false,
+        "subsetMatching": false,
+        "defaultStrategy": {
+          "name": {
+            "matchStrategy": "exact"
+          },
+          "arguments": {
+            "matchStrategy": "exact"
+          },
+          "result": {
+            "matchStrategy": "exact"
+          }
+        },
+        "toolStrategy": {
+          "get_time": {
+            "result": {
+              "ignore": true
+            }
+          },
+          "get_ticket": {
+            "arguments": {
+              "ignoreTree": {
+                "time": true
+              },
+              "matchStrategy": "exact"
+            },
+            "result": {
+              "ignoreTree": {
+                "time": true
+              },
+              "matchStrategy": "exact"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "metricName": "travel_answer_quality",
+    "evaluatorName": "llm_rubric_response",
+    "threshold": 0.9,
+    "criterion": {
+      "llmJudge": {
+        "judgeModel": {
+          "providerName": "openai",
+          "modelName": "gpt-5.2",
+          "baseURL": "${JUDGE_MODEL_BASE_URL}",
+          "apiKey": "${JUDGE_MODEL_API_KEY}",
+          "numSamples": 1,
+          "generationConfig": {
+            "max_tokens": 512,
+            "temperature": 0,
+            "stream": false
+          }
+        },
+        "rubrics": [
+          {
+            "id": "global:answer-completeness",
+            "description": "The final answer addresses the travel question.",
+            "type": "FINAL_RESPONSE_QUALITY",
+            "content": {
+              "text": "The final answer should directly answer both parts of the user's question: what to watch out for while traveling to Shanghai and whether a ticket is still available."
+            }
+          }
+        ]
+      }
+    }
+  }
+]

--- a/examples/evaluation/llm/caselevelrubric/main.go
+++ b/examples/evaluation/llm/caselevelrubric/main.go
@@ -1,0 +1,90 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package main runs a local case-level rubric evaluation example.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+
+	"trpc.group/trpc-go/trpc-agent-go/evaluation"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
+	evalresultlocal "trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult/local"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
+	evalsetlocal "trpc.group/trpc-go/trpc-agent-go/evaluation/evalset/local"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/registry"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
+	metriclocal "trpc.group/trpc-go/trpc-agent-go/evaluation/metric/local"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+)
+
+var (
+	dataDir   = flag.String("data-dir", "./data", "Directory containing evaluation set and metric files")
+	outputDir = flag.String("output-dir", "./output", "Directory where evaluation results will be stored")
+	modelName = flag.String("model", "gpt-5.2", "Model to use for evaluation runs")
+	streaming = flag.Bool("streaming", false, "Enable streaming responses from the agent")
+	evalSetID = flag.String("eval-set", "case-level-rubric-basic", "Evaluation set identifier to execute")
+)
+
+const appName = "case-level-rubric-app"
+
+func main() {
+	flag.Parse()
+	ctx := context.Background()
+	run := runner.NewRunner(appName, newTravelAgent(*modelName, *streaming))
+	defer run.Close()
+	evalSetManager := evalsetlocal.New(evalset.WithBaseDir(*dataDir))
+	metricManager := metriclocal.New(metric.WithBaseDir(*dataDir))
+	evalResultManager := evalresultlocal.New(evalresult.WithBaseDir(*outputDir))
+	reg := registry.New()
+	agentEvaluator, err := evaluation.New(
+		appName,
+		run,
+		evaluation.WithEvalSetManager(evalSetManager),
+		evaluation.WithMetricManager(metricManager),
+		evaluation.WithEvalResultManager(evalResultManager),
+		evaluation.WithRegistry(reg),
+	)
+	if err != nil {
+		log.Fatalf("create evaluator: %v", err)
+	}
+	defer func() { agentEvaluator.Close() }()
+	result, err := agentEvaluator.Evaluate(ctx, *evalSetID)
+	if err != nil {
+		log.Fatalf("evaluate: %v", err)
+	}
+	printSummary(result, *outputDir)
+}
+
+func printSummary(result *evaluation.EvaluationResult, outDir string) {
+	fmt.Println("✅ Case-level rubric evaluation completed with local storage")
+	fmt.Printf("App: %s\n", result.AppName)
+	fmt.Printf("Eval Set: %s\n", result.EvalSetID)
+	fmt.Printf("Overall Status: %s\n", result.OverallStatus)
+	runs := 0
+	if len(result.EvalCases) > 0 {
+		runs = len(result.EvalCases[0].EvalCaseResults)
+	}
+	fmt.Printf("Runs: %d\n", runs)
+	for _, caseResult := range result.EvalCases {
+		fmt.Printf("Case %s -> %s\n", caseResult.EvalCaseID, caseResult.OverallStatus)
+		for _, metricResult := range caseResult.MetricResults {
+			fmt.Printf("  Metric %s: score %.2f (threshold %.2f) => %s\n",
+				metricResult.MetricName,
+				metricResult.Score,
+				metricResult.Threshold,
+				metricResult.EvalStatus,
+			)
+		}
+		fmt.Println()
+	}
+	fmt.Printf("Results saved under: %s\n", outDir)
+}

--- a/examples/evaluation/llm/caselevelrubric/main.go
+++ b/examples/evaluation/llm/caselevelrubric/main.go
@@ -69,11 +69,7 @@ func printSummary(result *evaluation.EvaluationResult, outDir string) {
 	fmt.Printf("App: %s\n", result.AppName)
 	fmt.Printf("Eval Set: %s\n", result.EvalSetID)
 	fmt.Printf("Overall Status: %s\n", result.OverallStatus)
-	runs := 0
-	if len(result.EvalCases) > 0 {
-		runs = len(result.EvalCases[0].EvalCaseResults)
-	}
-	fmt.Printf("Runs: %d\n", runs)
+	fmt.Printf("Runs: %d\n", countRuns(result))
 	for _, caseResult := range result.EvalCases {
 		fmt.Printf("Case %s -> %s\n", caseResult.EvalCaseID, caseResult.OverallStatus)
 		for _, metricResult := range caseResult.MetricResults {
@@ -87,4 +83,17 @@ func printSummary(result *evaluation.EvaluationResult, outDir string) {
 		fmt.Println()
 	}
 	fmt.Printf("Results saved under: %s\n", outDir)
+}
+
+func countRuns(result *evaluation.EvaluationResult) int {
+	if result.EvalResult != nil && result.EvalResult.Summary != nil && result.EvalResult.Summary.NumRuns > 0 {
+		return result.EvalResult.Summary.NumRuns
+	}
+	runs := 0
+	for _, caseResult := range result.EvalCases {
+		if len(caseResult.EvalCaseResults) > runs {
+			runs = len(caseResult.EvalCaseResults)
+		}
+	}
+	return runs
 }

--- a/examples/evaluation/llm/caselevelrubric/output/case-level-rubric-app/case-level-rubric-app_case-level-rubric-basic_39aba2cf-ea67-4535-a581-238641acfd5f.evalset_result.json
+++ b/examples/evaluation/llm/caselevelrubric/output/case-level-rubric-app/case-level-rubric-app_case-level-rubric-basic_39aba2cf-ea67-4535-a581-238641acfd5f.evalset_result.json
@@ -1,0 +1,417 @@
+{
+  "evalSetResultId": "case-level-rubric-app_case-level-rubric-basic_39aba2cf-ea67-4535-a581-238641acfd5f",
+  "evalSetResultName": "case-level-rubric-app_case-level-rubric-basic_39aba2cf-ea67-4535-a581-238641acfd5f",
+  "evalSetId": "case-level-rubric-basic",
+  "evalCaseResults": [
+    {
+      "evalSetId": "case-level-rubric-basic",
+      "evalId": "shanghai_travel_case",
+      "runId": 1,
+      "finalEvalStatus": "passed",
+      "overallEvalMetricResults": [
+        {
+          "metricName": "tool_trajectory_avg_score",
+          "score": 1,
+          "evalStatus": "passed",
+          "threshold": 1,
+          "criterion": {
+            "toolTrajectory": {
+              "defaultStrategy": {
+                "name": {
+                  "matchStrategy": "exact"
+                },
+                "arguments": {
+                  "matchStrategy": "exact"
+                },
+                "result": {
+                  "matchStrategy": "exact"
+                }
+              },
+              "toolStrategy": {
+                "get_ticket": {
+                  "arguments": {
+                    "ignoreTree": {
+                      "time": true
+                    },
+                    "matchStrategy": "exact"
+                  },
+                  "result": {
+                    "ignoreTree": {
+                      "time": true
+                    },
+                    "matchStrategy": "exact"
+                  }
+                },
+                "get_time": {
+                  "result": {
+                    "ignore": true
+                  }
+                }
+              }
+            }
+          },
+          "details": {
+            "score": 1
+          }
+        },
+        {
+          "metricName": "travel_answer_quality",
+          "score": 1,
+          "evalStatus": "passed",
+          "threshold": 0.9,
+          "criterion": {
+            "llmJudge": {
+              "rubrics": [
+                {
+                  "id": "global:answer-completeness",
+                  "content": {
+                    "text": "The final answer should directly answer both parts of the user's question: what to watch out for while traveling to Shanghai and whether a ticket is still available."
+                  },
+                  "description": "The final answer addresses the travel question.",
+                  "type": "FINAL_RESPONSE_QUALITY"
+                },
+                {
+                  "id": "case:festival-ticket-advice",
+                  "content": {
+                    "text": "For this Shanghai travel case, the final answer must mention festival-related traffic disruption and ticket availability. It should also include at least one concrete action recommendation, such as leaving early, planning extra travel time, reserving, or buying the ticket soon."
+                  },
+                  "description": "This case needs festival traffic and ticket availability advice."
+                }
+              ],
+              "judgeModel": {
+                "providerName": "openai",
+                "modelName": "gpt-5.2",
+                "baseURL": "${JUDGE_MODEL_BASE_URL}",
+                "numSamples": 1,
+                "generationConfig": {
+                  "max_tokens": 512,
+                  "temperature": 0,
+                  "stream": false
+                }
+              }
+            }
+          },
+          "details": {
+            "reason": "The response explicitly warns about travel issues (festival traffic controls, congestion, reroutes, plus general weather-related precautions) and clearly states that tickets are still available.\nIt mentions festival-related disruption and ticket availability, and provides concrete actions (avoid the core area, allow extra time, leave early, use metro, monitor road closures).",
+            "score": 1,
+            "rubricScores": [
+              {
+                "id": "global:answer-completeness",
+                "reason": "The response explicitly warns about travel issues (festival traffic controls, congestion, reroutes, plus general weather-related precautions) and clearly states that tickets are still available.",
+                "score": 1
+              },
+              {
+                "id": "case:festival-ticket-advice",
+                "reason": "It mentions festival-related disruption and ticket availability, and provides concrete actions (avoid the core area, allow extra time, leave early, use metro, monitor road closures).",
+                "score": 1
+              }
+            ]
+          }
+        }
+      ],
+      "evalMetricResultPerInvocation": [
+        {
+          "actualInvocation": {
+            "invocationId": "b8a938b3-dad9-430d-aeb7-b87ee9c9e748",
+            "userContent": {
+              "role": "user",
+              "content": "I'm traveling to Shanghai tonight. What should I watch out for, and can I still get a ticket?"
+            },
+            "finalResponse": {
+              "role": "assistant",
+              "content": "上海今晚天气：晴，约 26°C。注意防晒、补水，夜间出行可带一件薄外套。  \n\n本地提醒：市中心有节庆活动，预计会有交通管制/拥堵与临时改道；尽量避开核心活动区域，预留更充足的出发与换乘时间。  \n\n票务情况：目前仍有余票，剩余 25 张，今晚出行仍可购票。  \n\n出行建议：可以按计划前往；优先选择地铁等公共交通，若打车请提前出发并关注实时路况与临时封路信息。"
+            },
+            "tools": [
+              {
+                "id": "call_e6fAwty1b2M1FFC2PbidMcan",
+                "name": "get_time",
+                "arguments": {},
+                "result": {
+                  "timestamp": "2026-05-13T13:05:23+08:00"
+                }
+              },
+              {
+                "id": "call_BgFF17fyHIG3jEVwTcRqn6qH",
+                "name": "get_weather",
+                "arguments": {
+                  "city": "Shanghai"
+                },
+                "result": {
+                  "city": "Shanghai",
+                  "condition": "sunny",
+                  "tempC": 26
+                }
+              },
+              {
+                "id": "call_ZH853elmWwBe6cFh6MX5I9mt",
+                "name": "get_news",
+                "arguments": {
+                  "city": "Shanghai"
+                },
+                "result": {
+                  "city": "Shanghai",
+                  "headline": "Festival events will be held downtown; traffic disruptions are expected."
+                }
+              },
+              {
+                "id": "call_DB6e6ucRqVg9Qy9pjspBgM60",
+                "name": "get_ticket",
+                "arguments": {
+                  "city": "Shanghai",
+                  "time": "2026-05-13T13:05:23+08:00"
+                },
+                "result": {
+                  "city": "Shanghai",
+                  "seatsLeft": 25,
+                  "time": "2026-05-13T13:05:23+08:00"
+                }
+              }
+            ]
+          },
+          "expectedInvocation": {
+            "invocationId": "shanghai_travel_case-1",
+            "userContent": {
+              "role": "user",
+              "content": "I'm traveling to Shanghai tonight. What should I watch out for, and can I still get a ticket?"
+            },
+            "finalResponse": {
+              "role": "assistant",
+              "content": "Shanghai is sunny at 26C. Downtown festival events may cause traffic disruptions. There are 25 tickets left, so tickets are still available. Leave early, plan extra travel time, and buy or reserve the ticket soon."
+            },
+            "tools": [
+              {
+                "id": "tool_use_weather",
+                "name": "get_weather",
+                "arguments": {
+                  "city": "Shanghai"
+                },
+                "result": {
+                  "city": "Shanghai",
+                  "condition": "sunny",
+                  "tempC": 26
+                }
+              },
+              {
+                "id": "tool_use_news",
+                "name": "get_news",
+                "arguments": {
+                  "city": "Shanghai"
+                },
+                "result": {
+                  "city": "Shanghai",
+                  "headline": "Festival events will be held downtown; traffic disruptions are expected."
+                }
+              },
+              {
+                "id": "tool_use_time",
+                "name": "get_time",
+                "arguments": {},
+                "result": {}
+              },
+              {
+                "id": "tool_use_ticket",
+                "name": "get_ticket",
+                "arguments": {
+                  "city": "Shanghai"
+                },
+                "result": {
+                  "city": "Shanghai",
+                  "seatsLeft": 25
+                }
+              }
+            ]
+          },
+          "evalMetricResults": [
+            {
+              "metricName": "tool_trajectory_avg_score",
+              "score": 1,
+              "evalStatus": "passed",
+              "threshold": 1,
+              "criterion": {
+                "toolTrajectory": {
+                  "defaultStrategy": {
+                    "name": {
+                      "matchStrategy": "exact"
+                    },
+                    "arguments": {
+                      "matchStrategy": "exact"
+                    },
+                    "result": {
+                      "matchStrategy": "exact"
+                    }
+                  },
+                  "toolStrategy": {
+                    "get_ticket": {
+                      "arguments": {
+                        "ignoreTree": {
+                          "time": true
+                        },
+                        "matchStrategy": "exact"
+                      },
+                      "result": {
+                        "ignoreTree": {
+                          "time": true
+                        },
+                        "matchStrategy": "exact"
+                      }
+                    },
+                    "get_time": {
+                      "result": {
+                        "ignore": true
+                      }
+                    }
+                  }
+                }
+              },
+              "details": {
+                "score": 1
+              }
+            },
+            {
+              "metricName": "travel_answer_quality",
+              "score": 1,
+              "evalStatus": "passed",
+              "threshold": 0.9,
+              "criterion": {
+                "llmJudge": {
+                  "rubrics": [
+                    {
+                      "id": "global:answer-completeness",
+                      "content": {
+                        "text": "The final answer should directly answer both parts of the user's question: what to watch out for while traveling to Shanghai and whether a ticket is still available."
+                      },
+                      "description": "The final answer addresses the travel question.",
+                      "type": "FINAL_RESPONSE_QUALITY"
+                    },
+                    {
+                      "id": "case:festival-ticket-advice",
+                      "content": {
+                        "text": "For this Shanghai travel case, the final answer must mention festival-related traffic disruption and ticket availability. It should also include at least one concrete action recommendation, such as leaving early, planning extra travel time, reserving, or buying the ticket soon."
+                      },
+                      "description": "This case needs festival traffic and ticket availability advice."
+                    }
+                  ],
+                  "judgeModel": {
+                    "providerName": "openai",
+                    "modelName": "gpt-5.2",
+                    "baseURL": "${JUDGE_MODEL_BASE_URL}",
+                    "numSamples": 1,
+                    "generationConfig": {
+                      "max_tokens": 512,
+                      "temperature": 0,
+                      "stream": false
+                    }
+                  }
+                }
+              },
+              "details": {
+                "reason": "The response explicitly warns about travel issues (festival traffic controls, congestion, reroutes, plus general weather-related precautions) and clearly states that tickets are still available.\nIt mentions festival-related disruption and ticket availability, and provides concrete actions (avoid the core area, allow extra time, leave early, use metro, monitor road closures).",
+                "score": 1,
+                "rubricScores": [
+                  {
+                    "id": "global:answer-completeness",
+                    "reason": "The response explicitly warns about travel issues (festival traffic controls, congestion, reroutes, plus general weather-related precautions) and clearly states that tickets are still available.",
+                    "score": 1
+                  },
+                  {
+                    "id": "case:festival-ticket-advice",
+                    "reason": "It mentions festival-related disruption and ticket availability, and provides concrete actions (avoid the core area, allow extra time, leave early, use metro, monitor road closures).",
+                    "score": 1
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "sessionId": "d9fb9cb1-01d2-43c3-8d76-f20362c1ef8c",
+      "userId": "traveler"
+    }
+  ],
+  "summary": {
+    "overallStatus": "passed",
+    "numRuns": 1,
+    "runStatusCounts": {
+      "passed": 1
+    },
+    "runSummaries": [
+      {
+        "runId": 1,
+        "overallStatus": "passed",
+        "caseStatusCounts": {
+          "passed": 1
+        },
+        "metricSummaries": [
+          {
+            "metricName": "tool_trajectory_avg_score",
+            "averageScore": 1,
+            "evalStatus": "passed",
+            "threshold": 1,
+            "statusCounts": {
+              "passed": 1
+            }
+          },
+          {
+            "metricName": "travel_answer_quality",
+            "averageScore": 1,
+            "evalStatus": "passed",
+            "threshold": 0.9,
+            "statusCounts": {
+              "passed": 1
+            }
+          }
+        ]
+      }
+    ],
+    "evalCaseSummaries": [
+      {
+        "evalId": "shanghai_travel_case",
+        "overallStatus": "passed",
+        "runStatusCounts": {
+          "passed": 1
+        },
+        "metricSummaries": [
+          {
+            "metricName": "tool_trajectory_avg_score",
+            "averageScore": 1,
+            "evalStatus": "passed",
+            "threshold": 1,
+            "statusCounts": {
+              "passed": 1
+            }
+          },
+          {
+            "metricName": "travel_answer_quality",
+            "averageScore": 1,
+            "evalStatus": "passed",
+            "threshold": 0.9,
+            "statusCounts": {
+              "passed": 1
+            }
+          }
+        ],
+        "runSummaries": [
+          {
+            "runId": 1,
+            "finalEvalStatus": "passed",
+            "metricResults": [
+              {
+                "metricName": "tool_trajectory_avg_score",
+                "score": 1,
+                "evalStatus": "passed",
+                "threshold": 1
+              },
+              {
+                "metricName": "travel_answer_quality",
+                "score": 1,
+                "evalStatus": "passed",
+                "threshold": 0.9
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "creationTimestamp": 1778648732.6204293
+}


### PR DESCRIPTION
This adds case-level rubrics to evaluation cases, merges metric-scoped case rubrics into LLM judge rubrics at local evaluation time, preserves the effective criterion in evaluation results for traceability, and documents the behavior with a dedicated example that combines a tool trajectory metric with an LLM rubric metric.