### PR TITLE
session/mysql: avoid sort buffer overflow in event queries

### DIFF
--- a/openclaw/app/admin_skills_config_test.go
+++ b/openclaw/app/admin_skills_config_test.go
@@ -520,6 +520,7 @@ func TestSetSkillEnabledInConfig_ErrorPathsAndWriteConfigDocument(t *testing.T) 
 	}
 	path = filepath.Join(t.TempDir(), "write.yaml")
 	require.NoError(t, os.WriteFile(path, []byte("app_name: old\n"), 0o644))
+	require.NoError(t, os.Chmod(path, 0o644))
 	require.NoError(t, writeConfigDocument(path, &doc))
 
 	body, err := os.ReadFile(path)

--- a/session/mysql/service_edge_test.go
+++ b/session/mysql/service_edge_test.go
@@ -86,10 +86,10 @@ func TestGetSession(t *testing.T) {
 			WithArgs(key.AppName, key.UserID, sqlmock.AnyArg()).
 			WillReturnRows(sqlmock.NewRows([]string{"key", "value"}))
 
-		mock.ExpectQuery("SELECT app_name, user_id, session_id, event, created_at FROM").
+		mock.ExpectQuery("SELECT id, app_name, user_id, session_id, event, created_at FROM").
 			WithArgs(key.AppName, key.UserID, key.SessionID).
-			WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}).
-				AddRow("app1", "user1", "session1", []byte("invalid-event-json"), time.Now()))
+			WillReturnRows(sqlmock.NewRows([]string{"id", "app_name", "user_id", "session_id", "event", "created_at"}).
+				AddRow(int64(1), "app1", "user1", "session1", []byte("invalid-event-json"), time.Now()))
 
 		sess, err := s.getSession(context.Background(), key, 0, time.Time{}, nil)
 		assert.Error(t, err)
@@ -151,9 +151,9 @@ func TestGetSession(t *testing.T) {
 			WithArgs(key.AppName, key.UserID, sqlmock.AnyArg()).
 			WillReturnRows(sqlmock.NewRows([]string{"key", "value"}))
 
-		mock.ExpectQuery("SELECT app_name, user_id, session_id, event, created_at FROM").
+		mock.ExpectQuery("SELECT id, app_name, user_id, session_id, event, created_at FROM").
 			WithArgs(key.AppName, key.UserID, key.SessionID).
-			WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}))
+			WillReturnRows(sqlmock.NewRows([]string{"id", "app_name", "user_id", "session_id", "event", "created_at"}))
 
 		// GetSession is a pure read operation - no UPDATE expected.
 		sess, err := s.GetSession(context.Background(), key)
@@ -293,10 +293,10 @@ func TestGetEventsList(t *testing.T) {
 		}
 		createdAts := []time.Time{time.Now().Add(-time.Hour)}
 
-		rows := sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}).
-			AddRow("app1", "user1", "sess1", []byte("invalid-json"), time.Now())
+		rows := sqlmock.NewRows([]string{"id", "app_name", "user_id", "session_id", "event", "created_at"}).
+			AddRow(int64(1), "app1", "user1", "sess1", []byte("invalid-json"), time.Now())
 
-		mock.ExpectQuery("SELECT app_name, user_id, session_id, event, created_at FROM").
+		mock.ExpectQuery("SELECT id, app_name, user_id, session_id, event, created_at FROM").
 			WithArgs("app1", "user1", "sess1").
 			WillReturnRows(rows)
 
@@ -354,12 +354,12 @@ func TestGetEventsList(t *testing.T) {
 		evt3Bytes, _ := json.Marshal(evt3)
 		now := time.Now()
 
-		rows := sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}).
-			AddRow(keys[0].AppName, keys[0].UserID, keys[0].SessionID, evt1Bytes, now).
-			AddRow(keys[0].AppName, keys[0].UserID, keys[0].SessionID, evt2Bytes, now).
-			AddRow(keys[0].AppName, keys[0].UserID, keys[0].SessionID, evt3Bytes, now)
+		rows := sqlmock.NewRows([]string{"id", "app_name", "user_id", "session_id", "event", "created_at"}).
+			AddRow(int64(1), keys[0].AppName, keys[0].UserID, keys[0].SessionID, evt1Bytes, now).
+			AddRow(int64(2), keys[0].AppName, keys[0].UserID, keys[0].SessionID, evt2Bytes, now).
+			AddRow(int64(3), keys[0].AppName, keys[0].UserID, keys[0].SessionID, evt3Bytes, now)
 
-		mock.ExpectQuery("SELECT app_name, user_id, session_id, event, created_at FROM").
+		mock.ExpectQuery("SELECT id, app_name, user_id, session_id, event, created_at FROM").
 			WithArgs(keys[0].AppName, keys[0].UserID, keys[0].SessionID).
 			WillReturnRows(rows)
 
@@ -398,12 +398,12 @@ func TestGetEventsList(t *testing.T) {
 		evt3Bytes, _ := json.Marshal(evt3)
 		now := time.Now()
 
-		rows := sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}).
-			AddRow("app1", "user1", "sess1", evt1Bytes, now).
-			AddRow("app1", "user1", "sess1", evt2Bytes, now).
-			AddRow("app1", "user1", "sess1", evt3Bytes, now)
+		rows := sqlmock.NewRows([]string{"id", "app_name", "user_id", "session_id", "event", "created_at"}).
+			AddRow(int64(1), "app1", "user1", "sess1", evt1Bytes, now).
+			AddRow(int64(2), "app1", "user1", "sess1", evt2Bytes, now).
+			AddRow(int64(3), "app1", "user1", "sess1", evt3Bytes, now)
 
-		mock.ExpectQuery("SELECT app_name, user_id, session_id, event, created_at FROM").
+		mock.ExpectQuery("SELECT id, app_name, user_id, session_id, event, created_at FROM").
 			WithArgs("app1", "user1", "sess1").
 			WillReturnRows(rows)
 
@@ -437,15 +437,22 @@ func TestGetEventsList(t *testing.T) {
 		})
 		evt2Bytes, _ := json.Marshal(evt2)
 		evt3Bytes, _ := json.Marshal(evt3)
-		now := time.Now()
 
-		rows := sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}).
-			AddRow("app1", "user1", "sess1", evt2Bytes, now.Add(-time.Minute)).
-			AddRow("app1", "user1", "sess1", evt3Bytes, now)
-
-		mock.ExpectQuery("SELECT app_name, user_id, session_id, event, created_at FROM").
+		// Phase 1: query IDs only
+		idRows := sqlmock.NewRows([]string{"id"}).
+			AddRow(int64(10)).
+			AddRow(int64(11))
+		mock.ExpectQuery("SELECT id FROM").
 			WithArgs("app1", "user1", "sess1", createdAt, 2, 1).
-			WillReturnRows(rows)
+			WillReturnRows(idRows)
+
+		// Phase 2: fetch events by IDs (ORDER BY id ASC returns in ascending order)
+		eventRows := sqlmock.NewRows([]string{"event"}).
+			AddRow(evt2Bytes).
+			AddRow(evt3Bytes)
+		mock.ExpectQuery("SELECT event FROM").
+			WithArgs(int64(10), int64(11)).
+			WillReturnRows(eventRows)
 
 		result, err := s.getEventsList(
 			context.Background(), keys, createdAts, 0, time.Time{}, &session.EventPage{Offset: 1, Limit: 2},
@@ -467,11 +474,11 @@ func TestGetEventsList(t *testing.T) {
 		keys := []session.Key{
 			{AppName: "app1", UserID: "user1", SessionID: "sess1"},
 		}
-		rows := sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"})
-
-		mock.ExpectQuery("SELECT app_name, user_id, session_id, event, created_at FROM").
+		// Phase 1: query IDs returns empty
+		idRows := sqlmock.NewRows([]string{"id"})
+		mock.ExpectQuery("SELECT id FROM").
 			WithArgs("app1", "user1", "sess1", sqlmock.AnyArg(), 2, 0).
-			WillReturnRows(rows)
+			WillReturnRows(idRows)
 
 		result, err := s.getEventsList(
 			context.Background(), keys, []time.Time{time.Now().Add(-2 * time.Hour)},
@@ -550,12 +557,12 @@ func TestGetEventsList(t *testing.T) {
 		evt3Bytes, _ := json.Marshal(evt3)
 		now := time.Now()
 
-		rows := sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}).
-			AddRow("app1", "user1", "sess1", evt1Bytes, now).
-			AddRow("app1", "user1", "sess1", evt2Bytes, now).
-			AddRow("app1", "user1", "sess1", evt3Bytes, now)
+		rows := sqlmock.NewRows([]string{"id", "app_name", "user_id", "session_id", "event", "created_at"}).
+			AddRow(int64(1), "app1", "user1", "sess1", evt1Bytes, now).
+			AddRow(int64(2), "app1", "user1", "sess1", evt2Bytes, now).
+			AddRow(int64(3), "app1", "user1", "sess1", evt3Bytes, now)
 
-		mock.ExpectQuery("SELECT app_name, user_id, session_id, event, created_at FROM").
+		mock.ExpectQuery("SELECT id, app_name, user_id, session_id, event, created_at FROM").
 			WithArgs("app1", "user1", "sess1").
 			WillReturnRows(rows)
 
@@ -583,7 +590,7 @@ func TestGetEventsList(t *testing.T) {
 		rows := sqlmock.NewRows([]string{"app_name", "user_id"}).
 			AddRow("app1", "user1")
 
-		mock.ExpectQuery("SELECT app_name, user_id, session_id, event, created_at FROM").
+		mock.ExpectQuery("SELECT id, app_name, user_id, session_id, event, created_at FROM").
 			WithArgs("app1", "user1", "sess1").
 			WillReturnRows(rows)
 

--- a/session/mysql/service_edge_test.go
+++ b/session/mysql/service_edge_test.go
@@ -469,6 +469,48 @@ func TestGetEventsList(t *testing.T) {
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 
+	t.Run("WithEventPageSkipsMissingPhase2Rows", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		s := createTestService(t, db)
+		keys := []session.Key{
+			{AppName: "app1", UserID: "user1", SessionID: "sess1"},
+		}
+		createdAt := time.Now().Add(-time.Hour)
+		createdAts := []time.Time{createdAt}
+
+		evt3 := event.NewResponseEvent("inv-3", "author1", &model.Response{
+			Choices: []model.Choice{{Message: model.Message{Role: model.RoleAssistant, Content: "assistant-3"}}},
+		})
+		evt3Bytes, _ := json.Marshal(evt3)
+		older := time.Now().Add(-time.Minute)
+		newer := time.Now()
+
+		idRows := sqlmock.NewRows([]string{"id", "created_at"}).
+			AddRow(int64(10), newer).
+			AddRow(int64(11), older)
+		mock.ExpectQuery("SELECT id, created_at FROM").
+			WithArgs("app1", "user1", "sess1", createdAt, 2, 1).
+			WillReturnRows(idRows)
+
+		eventRows := sqlmock.NewRows([]string{"id", "event"}).
+			AddRow(int64(10), evt3Bytes)
+		mock.ExpectQuery("SELECT id, event FROM").
+			WithArgs(int64(10), int64(11)).
+			WillReturnRows(eventRows)
+
+		result, err := s.getEventsList(
+			context.Background(), keys, createdAts, 0, time.Time{}, &session.EventPage{Offset: 1, Limit: 2},
+		)
+		assert.NoError(t, err)
+		require.Len(t, result, 1)
+		require.Len(t, result[0], 1)
+		assert.Equal(t, "inv-3", result[0][0].InvocationID)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
 	t.Run("WithEventPageUsesTTLLowerBound", func(t *testing.T) {
 		db, mock, err := sqlmock.New()
 		require.NoError(t, err)

--- a/session/mysql/service_edge_test.go
+++ b/session/mysql/service_edge_test.go
@@ -437,20 +437,24 @@ func TestGetEventsList(t *testing.T) {
 		})
 		evt2Bytes, _ := json.Marshal(evt2)
 		evt3Bytes, _ := json.Marshal(evt3)
+		older := time.Now().Add(-time.Minute)
+		newer := time.Now()
 
-		// Phase 1: query IDs only
-		idRows := sqlmock.NewRows([]string{"id"}).
-			AddRow(int64(10)).
-			AddRow(int64(11))
-		mock.ExpectQuery("SELECT id FROM").
+		// Phase 1: query IDs and created_at in descending page order.
+		// id intentionally does not match created_at order.
+		idRows := sqlmock.NewRows([]string{"id", "created_at"}).
+			AddRow(int64(10), newer).
+			AddRow(int64(11), older)
+		mock.ExpectQuery("SELECT id, created_at FROM").
 			WithArgs("app1", "user1", "sess1", createdAt, 2, 1).
 			WillReturnRows(idRows)
 
-		// Phase 2: fetch events by IDs (ORDER BY id ASC returns in ascending order)
-		eventRows := sqlmock.NewRows([]string{"event"}).
-			AddRow(evt2Bytes).
-			AddRow(evt3Bytes)
-		mock.ExpectQuery("SELECT event FROM").
+		// Phase 2: fetch events by IDs. Return order is deliberately not the
+		// desired final order; getPagedEvents must restore it from created_at.
+		eventRows := sqlmock.NewRows([]string{"id", "event"}).
+			AddRow(int64(10), evt3Bytes).
+			AddRow(int64(11), evt2Bytes)
+		mock.ExpectQuery("SELECT id, event FROM").
 			WithArgs(int64(10), int64(11)).
 			WillReturnRows(eventRows)
 
@@ -475,8 +479,8 @@ func TestGetEventsList(t *testing.T) {
 			{AppName: "app1", UserID: "user1", SessionID: "sess1"},
 		}
 		// Phase 1: query IDs returns empty
-		idRows := sqlmock.NewRows([]string{"id"})
-		mock.ExpectQuery("SELECT id FROM").
+		idRows := sqlmock.NewRows([]string{"id", "created_at"})
+		mock.ExpectQuery("SELECT id, created_at FROM").
 			WithArgs("app1", "user1", "sess1", sqlmock.AnyArg(), 2, 0).
 			WillReturnRows(idRows)
 

--- a/session/mysql/service_edge_test.go
+++ b/session/mysql/service_edge_test.go
@@ -417,6 +417,51 @@ func TestGetEventsList(t *testing.T) {
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 
+	t.Run("SortsUnorderedRowsByIDWhenCreatedAtMatches", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		s := createTestService(t, db)
+		keys := []session.Key{
+			{AppName: "app1", UserID: "user1", SessionID: "sess1"},
+		}
+		createdAts := []time.Time{time.Now().Add(-time.Hour)}
+
+		evt1 := event.NewResponseEvent("inv-1", "author1", &model.Response{
+			Choices: []model.Choice{{Message: model.Message{Role: model.RoleUser, Content: "user message"}}},
+		})
+		evt2 := event.NewResponseEvent("inv-2", "author1", &model.Response{
+			Choices: []model.Choice{{Message: model.Message{Role: model.RoleAssistant, Content: "assistant-1"}}},
+		})
+		evt3 := event.NewResponseEvent("inv-3", "author1", &model.Response{
+			Choices: []model.Choice{{Message: model.Message{Role: model.RoleAssistant, Content: "assistant-2"}}},
+		})
+
+		evt1Bytes, _ := json.Marshal(evt1)
+		evt2Bytes, _ := json.Marshal(evt2)
+		evt3Bytes, _ := json.Marshal(evt3)
+		now := time.Now()
+
+		rows := sqlmock.NewRows([]string{"id", "app_name", "user_id", "session_id", "event", "created_at"}).
+			AddRow(int64(3), "app1", "user1", "sess1", evt3Bytes, now).
+			AddRow(int64(2), "app1", "user1", "sess1", evt2Bytes, now).
+			AddRow(int64(1), "app1", "user1", "sess1", evt1Bytes, now)
+
+		mock.ExpectQuery("SELECT id, app_name, user_id, session_id, event, created_at FROM").
+			WithArgs("app1", "user1", "sess1").
+			WillReturnRows(rows)
+
+		result, err := s.getEventsList(context.Background(), keys, createdAts, 0, time.Time{}, nil)
+		assert.NoError(t, err)
+		require.Len(t, result, 1)
+		require.Len(t, result[0], 3)
+		assert.Equal(t, "inv-1", result[0][0].InvocationID)
+		assert.Equal(t, "inv-2", result[0][1].InvocationID)
+		assert.Equal(t, "inv-3", result[0][2].InvocationID)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
 	t.Run("WithEventPage", func(t *testing.T) {
 		db, mock, err := sqlmock.New()
 		require.NoError(t, err)
@@ -466,6 +511,60 @@ func TestGetEventsList(t *testing.T) {
 		require.Len(t, result[0], 2)
 		assert.Equal(t, "inv-2", result[0][0].InvocationID)
 		assert.Equal(t, "inv-3", result[0][1].InvocationID)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("WithEventPageSortsSameCreatedAtByID", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		s := createTestService(t, db)
+		keys := []session.Key{
+			{AppName: "app1", UserID: "user1", SessionID: "sess1"},
+		}
+		createdAt := time.Now().Add(-time.Hour)
+		createdAts := []time.Time{createdAt}
+
+		evt1 := event.NewResponseEvent("inv-1", "author1", &model.Response{
+			Choices: []model.Choice{{Message: model.Message{Role: model.RoleUser, Content: "user-1"}}},
+		})
+		evt2 := event.NewResponseEvent("inv-2", "author1", &model.Response{
+			Choices: []model.Choice{{Message: model.Message{Role: model.RoleAssistant, Content: "assistant-2"}}},
+		})
+		evt3 := event.NewResponseEvent("inv-3", "author1", &model.Response{
+			Choices: []model.Choice{{Message: model.Message{Role: model.RoleAssistant, Content: "assistant-3"}}},
+		})
+		evt1Bytes, _ := json.Marshal(evt1)
+		evt2Bytes, _ := json.Marshal(evt2)
+		evt3Bytes, _ := json.Marshal(evt3)
+		now := time.Now()
+
+		idRows := sqlmock.NewRows([]string{"id", "created_at"}).
+			AddRow(int64(3), now).
+			AddRow(int64(2), now).
+			AddRow(int64(1), now)
+		mock.ExpectQuery("SELECT id, created_at FROM").
+			WithArgs("app1", "user1", "sess1", createdAt, 3, 0).
+			WillReturnRows(idRows)
+
+		eventRows := sqlmock.NewRows([]string{"id", "event"}).
+			AddRow(int64(3), evt3Bytes).
+			AddRow(int64(2), evt2Bytes).
+			AddRow(int64(1), evt1Bytes)
+		mock.ExpectQuery("SELECT id, event FROM").
+			WithArgs(int64(3), int64(2), int64(1)).
+			WillReturnRows(eventRows)
+
+		result, err := s.getEventsList(
+			context.Background(), keys, createdAts, 0, time.Time{}, &session.EventPage{Offset: 0, Limit: 3},
+		)
+		assert.NoError(t, err)
+		require.Len(t, result, 1)
+		require.Len(t, result[0], 3)
+		assert.Equal(t, "inv-1", result[0][0].InvocationID)
+		assert.Equal(t, "inv-2", result[0][1].InvocationID)
+		assert.Equal(t, "inv-3", result[0][2].InvocationID)
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 

--- a/session/mysql/service_helper.go
+++ b/session/mysql/service_helper.go
@@ -14,6 +14,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -546,10 +547,11 @@ func (s *Service) getEventsList(
 		afterTime = time.Now().Add(-s.opts.sessionTTL)
 	}
 
-	query := fmt.Sprintf(`SELECT app_name, user_id, session_id, event, created_at FROM %s
+	// Avoid ORDER BY on large TEXT/JSON columns to prevent sort buffer overflow (MySQL Error 1038).
+	// Sorting is done in Go after loading all events into memory.
+	query := fmt.Sprintf(`SELECT id, app_name, user_id, session_id, event, created_at FROM %s
 		WHERE (app_name, user_id, session_id) IN (%s)
-		AND deleted_at IS NULL
-		ORDER BY app_name, user_id, session_id, created_at ASC, id ASC`,
+		AND deleted_at IS NULL`,
 		s.tableSessionEvents, strings.Join(placeholders, ","))
 
 	sessionCreatedAtMap := make(map[string]time.Time, len(sessionKeys))
@@ -558,13 +560,19 @@ func (s *Service) getEventsList(
 		sessionCreatedAtMap[keyStr] = sessionCreatedAts[i]
 	}
 
-	eventsMap := make(map[string][]event.Event)
+	type eventWithOrder struct {
+		evt       event.Event
+		createdAt time.Time
+		id        int64
+	}
+	eventsMap := make(map[string][]eventWithOrder)
 
 	err := s.mysqlClient.Query(ctx, func(rows *sql.Rows) error {
+		var rowID int64
 		var appName, userID, sessionID string
 		var eventBytes []byte
 		var eventCreatedAt time.Time
-		if err := rows.Scan(&appName, &userID, &sessionID, &eventBytes, &eventCreatedAt); err != nil {
+		if err := rows.Scan(&rowID, &appName, &userID, &sessionID, &eventBytes, &eventCreatedAt); err != nil {
 			return err
 		}
 		keyStr := fmt.Sprintf("%s:%s:%s", appName, userID, sessionID)
@@ -579,7 +587,7 @@ func (s *Service) getEventsList(
 		if err := json.Unmarshal(eventBytes, &evt); err != nil {
 			return fmt.Errorf("unmarshal event failed: %w", err)
 		}
-		eventsMap[keyStr] = append(eventsMap[keyStr], evt)
+		eventsMap[keyStr] = append(eventsMap[keyStr], eventWithOrder{evt: evt, createdAt: eventCreatedAt, id: rowID})
 		return nil
 	}, query, args...)
 
@@ -590,7 +598,17 @@ func (s *Service) getEventsList(
 	result := make([][]event.Event, len(sessionKeys))
 	for i, key := range sessionKeys {
 		keyStr := fmt.Sprintf("%s:%s:%s", key.AppName, key.UserID, key.SessionID)
-		events := eventsMap[keyStr]
+		items := eventsMap[keyStr]
+		sort.Slice(items, func(a, b int) bool {
+			if items[a].createdAt.Equal(items[b].createdAt) {
+				return items[a].id < items[b].id
+			}
+			return items[a].createdAt.Before(items[b].createdAt)
+		})
+		events := make([]event.Event, len(items))
+		for j, item := range items {
+			events[j] = item.evt
+		}
 		sess := session.Session{
 			Events: events,
 		}
@@ -615,42 +633,62 @@ func (s *Service) getPagedEvents(
 		afterTime = sessionCreatedAt
 	}
 
-	query := fmt.Sprintf(`
-		SELECT app_name, user_id, session_id, event, created_at FROM (
-			SELECT app_name, user_id, session_id, event, created_at, id
-			FROM %s
-			WHERE app_name = ? AND user_id = ? AND session_id = ?
-			AND created_at >= ?
-			AND deleted_at IS NULL
-			ORDER BY created_at DESC, id DESC
-			LIMIT ? OFFSET ?
-		) page
-		ORDER BY created_at ASC, id ASC`,
+	// Phase 1: fetch only IDs with ORDER BY + LIMIT/OFFSET.
+	// Sorting lightweight integer rows avoids sort buffer overflow on large event JSON.
+	idsQuery := fmt.Sprintf(`SELECT id FROM %s
+		WHERE app_name = ? AND user_id = ? AND session_id = ?
+		AND created_at >= ?
+		AND deleted_at IS NULL
+		ORDER BY created_at DESC, id DESC
+		LIMIT ? OFFSET ?`,
 		s.tableSessionEvents)
 
-	rowsBySession := make(map[string][]event.Event, 1)
+	var ids []int64
 	err := s.mysqlClient.Query(ctx, func(rows *sql.Rows) error {
-		var appName, userID, sessionID string
-		var eventBytes []byte
-		var eventCreatedAt time.Time
-		if err := rows.Scan(&appName, &userID, &sessionID, &eventBytes, &eventCreatedAt); err != nil {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
 			return err
 		}
-
-		var evt event.Event
-		if err := json.Unmarshal(eventBytes, &evt); err != nil {
-			return fmt.Errorf("unmarshal event failed: %w", err)
-		}
-		keyStr := fmt.Sprintf("%s:%s:%s", appName, userID, sessionID)
-		rowsBySession[keyStr] = append(rowsBySession[keyStr], evt)
+		ids = append(ids, id)
 		return nil
-	}, query, key.AppName, key.UserID, key.SessionID, afterTime, page.Limit, page.Offset)
+	}, idsQuery, key.AppName, key.UserID, key.SessionID, afterTime, page.Limit, page.Offset)
 	if err != nil {
 		return nil, fmt.Errorf("batch get events failed: %w", err)
 	}
 
-	keyStr := fmt.Sprintf("%s:%s:%s", key.AppName, key.UserID, key.SessionID)
-	return [][]event.Event{rowsBySession[keyStr]}, nil
+	if len(ids) == 0 {
+		return [][]event.Event{nil}, nil
+	}
+
+	// Phase 2: fetch full event rows by IDs, ordered by PK (index-ordered scan, no filesort).
+	placeholders := make([]string, len(ids))
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+
+	eventsQuery := fmt.Sprintf(`SELECT event FROM %s WHERE id IN (%s) ORDER BY id ASC`,
+		s.tableSessionEvents, strings.Join(placeholders, ","))
+
+	var events []event.Event
+	err = s.mysqlClient.Query(ctx, func(rows *sql.Rows) error {
+		var eventBytes []byte
+		if err := rows.Scan(&eventBytes); err != nil {
+			return err
+		}
+		var evt event.Event
+		if err := json.Unmarshal(eventBytes, &evt); err != nil {
+			return fmt.Errorf("unmarshal event failed: %w", err)
+		}
+		events = append(events, evt)
+		return nil
+	}, eventsQuery, args...)
+	if err != nil {
+		return nil, fmt.Errorf("batch get events failed: %w", err)
+	}
+
+	return [][]event.Event{events}, nil
 }
 
 // getTrackEvents loads track events for multiple sessions in batch.

--- a/session/mysql/service_helper.go
+++ b/session/mysql/service_helper.go
@@ -547,8 +547,6 @@ func (s *Service) getEventsList(
 		afterTime = time.Now().Add(-s.opts.sessionTTL)
 	}
 
-	// Avoid ORDER BY on large TEXT/JSON columns to prevent sort buffer overflow (MySQL Error 1038).
-	// Sorting is done in Go after loading all events into memory.
 	query := fmt.Sprintf(`SELECT id, app_name, user_id, session_id, event, created_at FROM %s
 		WHERE (app_name, user_id, session_id) IN (%s)
 		AND deleted_at IS NULL`,
@@ -633,9 +631,9 @@ func (s *Service) getPagedEvents(
 		afterTime = sessionCreatedAt
 	}
 
-	// Phase 1: fetch only IDs with ORDER BY + LIMIT/OFFSET.
-	// Sorting lightweight integer rows avoids sort buffer overflow on large event JSON.
-	idsQuery := fmt.Sprintf(`SELECT id FROM %s
+	// Phase 1: fetch only ordering metadata with ORDER BY + LIMIT/OFFSET.
+	// Sorting lightweight rows avoids sort buffer overflow on large event JSON.
+	idsQuery := fmt.Sprintf(`SELECT id, created_at FROM %s
 		WHERE app_name = ? AND user_id = ? AND session_id = ?
 		AND created_at >= ?
 		AND deleted_at IS NULL
@@ -643,51 +641,72 @@ func (s *Service) getPagedEvents(
 		LIMIT ? OFFSET ?`,
 		s.tableSessionEvents)
 
-	var ids []int64
+	type eventRef struct {
+		id        int64
+		createdAt time.Time
+	}
+	var refs []eventRef
 	err := s.mysqlClient.Query(ctx, func(rows *sql.Rows) error {
 		var id int64
-		if err := rows.Scan(&id); err != nil {
+		var createdAt time.Time
+		if err := rows.Scan(&id, &createdAt); err != nil {
 			return err
 		}
-		ids = append(ids, id)
+		refs = append(refs, eventRef{id: id, createdAt: createdAt})
 		return nil
 	}, idsQuery, key.AppName, key.UserID, key.SessionID, afterTime, page.Limit, page.Offset)
 	if err != nil {
 		return nil, fmt.Errorf("batch get events failed: %w", err)
 	}
 
-	if len(ids) == 0 {
+	if len(refs) == 0 {
 		return [][]event.Event{nil}, nil
 	}
 
-	// Phase 2: fetch full event rows by IDs, ordered by PK (index-ordered scan, no filesort).
-	placeholders := make([]string, len(ids))
-	args := make([]any, len(ids))
-	for i, id := range ids {
+	// Phase 2: fetch full event rows by IDs. The final return order is restored
+	// from refs to preserve (created_at ASC, id ASC) semantics.
+	placeholders := make([]string, len(refs))
+	args := make([]any, len(refs))
+	for i, ref := range refs {
 		placeholders[i] = "?"
-		args[i] = id
+		args[i] = ref.id
 	}
 
-	eventsQuery := fmt.Sprintf(`SELECT event FROM %s WHERE id IN (%s) ORDER BY id ASC`,
+	eventsQuery := fmt.Sprintf(`SELECT id, event FROM %s WHERE id IN (%s)`,
 		s.tableSessionEvents, strings.Join(placeholders, ","))
 
-	var events []event.Event
+	eventsByID := make(map[int64]event.Event, len(refs))
 	err = s.mysqlClient.Query(ctx, func(rows *sql.Rows) error {
+		var id int64
 		var eventBytes []byte
-		if err := rows.Scan(&eventBytes); err != nil {
+		if err := rows.Scan(&id, &eventBytes); err != nil {
 			return err
 		}
 		var evt event.Event
 		if err := json.Unmarshal(eventBytes, &evt); err != nil {
 			return fmt.Errorf("unmarshal event failed: %w", err)
 		}
-		events = append(events, evt)
+		eventsByID[id] = evt
 		return nil
 	}, eventsQuery, args...)
 	if err != nil {
 		return nil, fmt.Errorf("batch get events failed: %w", err)
 	}
 
+	sort.Slice(refs, func(i, j int) bool {
+		if refs[i].createdAt.Equal(refs[j].createdAt) {
+			return refs[i].id < refs[j].id
+		}
+		return refs[i].createdAt.Before(refs[j].createdAt)
+	})
+	events := make([]event.Event, 0, len(refs))
+	for _, ref := range refs {
+		evt, ok := eventsByID[ref.id]
+		if !ok {
+			continue
+		}
+		events = append(events, evt)
+	}
 	return [][]event.Event{events}, nil
 }
 

--- a/session/mysql/service_helper.go
+++ b/session/mysql/service_helper.go
@@ -14,7 +14,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -597,11 +597,17 @@ func (s *Service) getEventsList(
 	for i, key := range sessionKeys {
 		keyStr := fmt.Sprintf("%s:%s:%s", key.AppName, key.UserID, key.SessionID)
 		items := eventsMap[keyStr]
-		sort.Slice(items, func(a, b int) bool {
-			if items[a].createdAt.Equal(items[b].createdAt) {
-				return items[a].id < items[b].id
+		slices.SortFunc(items, func(a, b eventWithOrder) int {
+			if cmp := a.createdAt.Compare(b.createdAt); cmp != 0 {
+				return cmp
 			}
-			return items[a].createdAt.Before(items[b].createdAt)
+			if a.id < b.id {
+				return -1
+			}
+			if a.id > b.id {
+				return 1
+			}
+			return 0
 		})
 		events := make([]event.Event, len(items))
 		for j, item := range items {
@@ -693,11 +699,17 @@ func (s *Service) getPagedEvents(
 		return nil, fmt.Errorf("batch get events failed: %w", err)
 	}
 
-	sort.Slice(refs, func(i, j int) bool {
-		if refs[i].createdAt.Equal(refs[j].createdAt) {
-			return refs[i].id < refs[j].id
+	slices.SortFunc(refs, func(a, b eventRef) int {
+		if cmp := a.createdAt.Compare(b.createdAt); cmp != 0 {
+			return cmp
 		}
-		return refs[i].createdAt.Before(refs[j].createdAt)
+		if a.id < b.id {
+			return -1
+		}
+		if a.id > b.id {
+			return 1
+		}
+		return 0
 	})
 	events := make([]event.Event, 0, len(refs))
 	for _, ref := range refs {

--- a/session/mysql/service_helper_test.go
+++ b/session/mysql/service_helper_test.go
@@ -68,9 +68,9 @@ func TestGetSession_Success(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"key", "value"}))
 
 	// Mock: Query events (empty)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, event, created_at FROM")).
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, app_name, user_id, session_id, event, created_at FROM")).
 		WithArgs(key.AppName, key.UserID, key.SessionID).
-		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at", "created_at"}))
+		WillReturnRows(sqlmock.NewRows([]string{"id", "app_name", "user_id", "session_id", "event", "created_at"}))
 
 	sess, err := s.GetSession(ctx, key)
 	require.NoError(t, err)
@@ -163,10 +163,10 @@ func TestGetSession_WithLimit(t *testing.T) {
 	eventBytes, _ := json.Marshal(evt)
 
 	// Mock: Query events with limit
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, event, created_at FROM")).
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, app_name, user_id, session_id, event, created_at FROM")).
 		WithArgs(key.AppName, key.UserID, key.SessionID).
-		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}).
-			AddRow(key.AppName, key.UserID, key.SessionID, eventBytes, time.Now()))
+		WillReturnRows(sqlmock.NewRows([]string{"id", "app_name", "user_id", "session_id", "event", "created_at"}).
+			AddRow(int64(1), key.AppName, key.UserID, key.SessionID, eventBytes, time.Now()))
 
 	// Mock: Batch load summaries with data
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, filter_key, summary, updated_at FROM session_summaries")).
@@ -220,9 +220,9 @@ func TestGetSession_WithTrackEvents(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"key", "value"}))
 
 	// Mock: Query events (empty).
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, event, created_at FROM")).
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, app_name, user_id, session_id, event, created_at FROM")).
 		WithArgs(key.AppName, key.UserID, key.SessionID).
-		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}))
+		WillReturnRows(sqlmock.NewRows([]string{"id", "app_name", "user_id", "session_id", "event", "created_at"}))
 
 	// Mock: Query track events.
 	trackEvent := &session.TrackEvent{
@@ -289,9 +289,9 @@ func TestGetSession_WithTTL(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"key", "value"}))
 
 	// Mock: Query events
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, event, created_at FROM")).
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, app_name, user_id, session_id, event, created_at FROM")).
 		WithArgs(key.AppName, key.UserID, key.SessionID).
-		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}))
+		WillReturnRows(sqlmock.NewRows([]string{"id", "app_name", "user_id", "session_id", "event", "created_at"}))
 
 	sess, err := s.GetSession(ctx, key)
 	require.NoError(t, err)
@@ -361,8 +361,8 @@ func TestListSessions_Success(t *testing.T) {
 			AddRow("session-1", stateBytes, time.Now(), time.Now()))
 
 	// Mock: Batch load events (empty)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, event, created_at FROM")).
-		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, app_name, user_id, session_id, event, created_at FROM")).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "app_name", "user_id", "session_id", "event", "created_at"}))
 
 	// Mock: Batch load summaries (empty)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, filter_key, summary, updated_at FROM session_summaries")).
@@ -414,8 +414,8 @@ func TestListSessions_WithTrackEvents(t *testing.T) {
 			AddRow("session-1", stateBytes, time.Now(), time.Now()))
 
 	// Mock: Batch load events (empty).
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, event, created_at FROM")).
-		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, app_name, user_id, session_id, event, created_at FROM")).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "app_name", "user_id", "session_id", "event", "created_at"}))
 
 	// Mock: Batch load summaries (empty).
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, filter_key, summary, updated_at FROM session_summaries")).
@@ -483,8 +483,8 @@ func TestListSessions_WithMultipleSessions(t *testing.T) {
 			AddRow("session-2", state2Bytes, time.Now(), time.Now()))
 
 	// Mock: Batch load events
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, event, created_at FROM")).
-		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, app_name, user_id, session_id, event, created_at FROM")).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "app_name", "user_id", "session_id", "event", "created_at"}))
 
 	// Mock: Batch load summaries
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, filter_key, summary, updated_at FROM session_summaries")).

--- a/session/mysql/service_test.go
+++ b/session/mysql/service_test.go
@@ -1840,9 +1840,9 @@ func TestListSessions_WithEvents(t *testing.T) {
 	eventBytes, _ := json.Marshal(evt)
 
 	// Mock: Batch load events with data
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, event, created_at FROM")).
-		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}).
-			AddRow(userKey.AppName, userKey.UserID, "session-1", eventBytes, time.Now()))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, app_name, user_id, session_id, event, created_at FROM")).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "app_name", "user_id", "session_id", "event", "created_at"}).
+			AddRow(int64(1), userKey.AppName, userKey.UserID, "session-1", eventBytes, time.Now()))
 
 	// Prepare mock summary
 	summary := session.Summary{Summary: "test summary", Topics: []string{}}
@@ -1915,11 +1915,11 @@ func TestGetSession_WithEvents(t *testing.T) {
 	event2Bytes, _ := json.Marshal(evt2)
 
 	// Mock: Query events (multiple rows)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, event, created_at FROM")).
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, app_name, user_id, session_id, event, created_at FROM")).
 		WithArgs(key.AppName, key.UserID, key.SessionID).
-		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}).
-			AddRow(key.AppName, key.UserID, key.SessionID, event1Bytes, time.Now()).
-			AddRow(key.AppName, key.UserID, key.SessionID, event2Bytes, time.Now()))
+		WillReturnRows(sqlmock.NewRows([]string{"id", "app_name", "user_id", "session_id", "event", "created_at"}).
+			AddRow(int64(1), key.AppName, key.UserID, key.SessionID, event1Bytes, time.Now()).
+			AddRow(int64(2), key.AppName, key.UserID, key.SessionID, event2Bytes, time.Now()))
 
 	// Prepare multiple summaries
 	sum1 := session.Summary{Summary: "summary1", Topics: []string{}}
@@ -2277,9 +2277,9 @@ func TestGetSession_WithAfterTime(t *testing.T) {
 
 	// Mock: Query events with afterTime filter (should filter events)
 	afterTime := time.Now().Add(-1 * time.Hour)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, event, created_at FROM")).
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, app_name, user_id, session_id, event, created_at FROM")).
 		WithArgs(key.AppName, key.UserID, key.SessionID).
-		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}))
+		WillReturnRows(sqlmock.NewRows([]string{"id", "app_name", "user_id", "session_id", "event", "created_at"}))
 
 	sess, err := s.GetSession(ctx, key, session.WithEventTime(afterTime))
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- Fix MySQL Error 1038 (Out of sort memory) when querying sessions with large event payloads
- For non-paged path (`getEventsList`): remove SQL `ORDER BY` on large JSON columns, perform sorting in Go memory using `sort.Slice` with `(created_at, id)` as sort keys
- For paged path (`getPagedEvents`): use deferred-join pattern — Phase 1 sorts only lightweight IDs with `ORDER BY + LIMIT/OFFSET`, Phase 2 fetches full event rows by PK (no filesort)

## Root Cause

The `event` column is a JSON/TEXT field storing full LLM responses (potentially 10-100KB per row). When MySQL performs `ORDER BY` involving this column in the sort buffer, it overflows the default 256KB `sort_buffer_size`, causing Error 1038.

## Changes

| Function | Before | After |
|----------|--------|-------|
| `getEventsList` | `SELECT ... ORDER BY created_at, id` (MySQL filesort on large rows) | `SELECT ...` (no ORDER BY) + Go `sort.Slice` |
| `getPagedEvents` | Single subquery sorting event JSON | Phase 1: `SELECT id ... ORDER BY ... LIMIT OFFSET` (8-byte rows) → Phase 2: `SELECT event WHERE id IN (...)` (PK scan) |

## Test plan

- [x] All existing unit tests pass (`go test ./...` in `session/mysql/`)
- [x] Updated mock expectations to match new query patterns
- [x] Verified behavioral equivalence: same sort order `(created_at ASC, id ASC)` preserved


Made with [Cursor](https://cursor.com)