### PR TITLE
model: preserve system during token tailoring

### DIFF
--- a/model/anthropic/anthropic.go
+++ b/model/anthropic/anthropic.go
@@ -255,10 +255,10 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 	// Apply token tailoring.
 	tailored, err := m.tailoringStrategy.TailorMessages(ctx, request.Messages, maxInputTokens)
 	if err != nil {
-		if model.IsTokenTailoringOverflow(err) {
+		if len(tailored) > 0 {
 			log.WarnContext(
 				ctx,
-				"token tailoring overflow in anthropic.Model; using protected context",
+				"token tailoring returned best-effort messages in anthropic.Model",
 				err,
 			)
 			request.Messages = tailored

--- a/model/anthropic/anthropic.go
+++ b/model/anthropic/anthropic.go
@@ -255,6 +255,15 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 	// Apply token tailoring.
 	tailored, err := m.tailoringStrategy.TailorMessages(ctx, request.Messages, maxInputTokens)
 	if err != nil {
+		if model.IsTokenTailoringOverflow(err) {
+			log.WarnContext(
+				ctx,
+				"token tailoring overflow in anthropic.Model; using protected context",
+				err,
+			)
+			request.Messages = tailored
+			return
+		}
 		log.WarnContext(
 			ctx,
 			"token tailoring failed in anthropic.Model",

--- a/model/anthropic/anthropic_test.go
+++ b/model/anthropic/anthropic_test.go
@@ -1875,6 +1875,18 @@ func (testStubStrategy) TailorMessages(
 	return append([]model.Message{messages[0]}, messages[2:]...), nil
 }
 
+type overflowTailoringStrategy struct {
+	tailored []model.Message
+}
+
+func (s overflowTailoringStrategy) TailorMessages(
+	ctx context.Context,
+	messages []model.Message,
+	maxTokens int,
+) ([]model.Message, error) {
+	return s.tailored, errors.New("minimal protected context exceeds token budget")
+}
+
 // TestWithTokenTailoring tests token tailoring functionality in Anthropic.
 func TestWithTokenTailoring(t *testing.T) {
 	// Capture the built Anthropic request to check messages count reflects tailoring.
@@ -1906,6 +1918,28 @@ func TestWithTokenTailoring(t *testing.T) {
 	require.NotNil(t, captured, "expected request callback to capture request")
 	// After tailoring, messages should be reduced (1 message after tailoring).
 	require.Len(t, captured.Messages, 1, "expected 1 message after tailoring, got %d", len(captured.Messages))
+}
+
+func TestWithTokenTailoring_UsesProtectedContextOnOverflow(t *testing.T) {
+	tailored := []model.Message{
+		model.NewSystemMessage("sys"),
+		model.NewUserMessage("q"),
+	}
+	m := &Model{
+		name:                 "test-model",
+		enableTokenTailoring: true,
+		maxInputTokens:       1,
+		tailoringStrategy:    overflowTailoringStrategy{tailored: tailored},
+	}
+	req := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("sys"),
+		model.NewUserMessage("old"),
+		model.NewUserMessage("q"),
+	}}
+
+	m.applyTokenTailoring(context.Background(), req)
+
+	require.Equal(t, tailored, req.Messages)
 }
 
 // TestWithEnableTokenTailoring_SimpleMode tests simple token tailoring mode.

--- a/model/gemini/gemini.go
+++ b/model/gemini/gemini.go
@@ -608,10 +608,10 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 	// Apply token tailoring.
 	tailored, err := m.tailoringStrategy.TailorMessages(ctx, request.Messages, maxInputTokens)
 	if err != nil {
-		if model.IsTokenTailoringOverflow(err) {
+		if len(tailored) > 0 {
 			log.WarnContext(
 				ctx,
-				"token tailoring overflow in gemini.Model; using protected context",
+				"token tailoring returned best-effort messages in gemini.Model",
 				err,
 			)
 			request.Messages = tailored

--- a/model/gemini/gemini.go
+++ b/model/gemini/gemini.go
@@ -608,9 +608,18 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 	// Apply token tailoring.
 	tailored, err := m.tailoringStrategy.TailorMessages(ctx, request.Messages, maxInputTokens)
 	if err != nil {
+		if model.IsTokenTailoringOverflow(err) {
+			log.WarnContext(
+				ctx,
+				"token tailoring overflow in gemini.Model; using protected context",
+				err,
+			)
+			request.Messages = tailored
+			return
+		}
 		log.WarnContext(
 			ctx,
-			"token tailoring failed in openai.Model",
+			"token tailoring failed in gemini.Model",
 			err,
 		)
 		return

--- a/model/gemini/gemini_test.go
+++ b/model/gemini/gemini_test.go
@@ -27,6 +27,18 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
 
+type overflowTailoringStrategy struct {
+	tailored []model.Message
+}
+
+func (s overflowTailoringStrategy) TailorMessages(
+	ctx context.Context,
+	messages []model.Message,
+	maxTokens int,
+) ([]model.Message, error) {
+	return s.tailored, errors.New("minimal protected context exceeds token budget")
+}
+
 func TestModel_CallbackPanicsAreRecovered(t *testing.T) {
 	t.Run("request callback", func(t *testing.T) {
 		callbackCalled := false
@@ -117,6 +129,28 @@ func TestModel_CallbackPanicsAreRecovered(t *testing.T) {
 		})
 		assert.True(t, callbackCalled)
 	})
+}
+
+func TestWithTokenTailoring_UsesProtectedContextOnOverflow(t *testing.T) {
+	tailored := []model.Message{
+		model.NewSystemMessage("sys"),
+		model.NewUserMessage("q"),
+	}
+	m := &Model{
+		name:                 "test-model",
+		enableTokenTailoring: true,
+		maxInputTokens:       1,
+		tailoringStrategy:    overflowTailoringStrategy{tailored: tailored},
+	}
+	req := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("sys"),
+		model.NewUserMessage("old"),
+		model.NewUserMessage("q"),
+	}}
+
+	m.applyTokenTailoring(context.Background(), req)
+
+	require.Equal(t, tailored, req.Messages)
 }
 
 func TestModel_convertMessages(t *testing.T) {

--- a/model/huggingface/huggingface.go
+++ b/model/huggingface/huggingface.go
@@ -480,8 +480,8 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 	// Apply token tailoring.
 	tailored, err := m.tailoringStrategy.TailorMessages(ctx, request.Messages, maxInputTokens)
 	if err != nil {
-		if model.IsTokenTailoringOverflow(err) {
-			log.Warn("token tailoring overflow in huggingface.Model; using protected context", err)
+		if len(tailored) > 0 {
+			log.Warn("token tailoring returned best-effort messages in huggingface.Model", err)
 			request.Messages = tailored
 			return
 		}

--- a/model/huggingface/huggingface.go
+++ b/model/huggingface/huggingface.go
@@ -480,6 +480,11 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 	// Apply token tailoring.
 	tailored, err := m.tailoringStrategy.TailorMessages(ctx, request.Messages, maxInputTokens)
 	if err != nil {
+		if model.IsTokenTailoringOverflow(err) {
+			log.Warn("token tailoring overflow in huggingface.Model; using protected context", err)
+			request.Messages = tailored
+			return
+		}
 		log.Warn("token tailoring failed in huggingface.Model", err)
 		return
 	}

--- a/model/huggingface/huggingface.go
+++ b/model/huggingface/huggingface.go
@@ -481,7 +481,7 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 	tailored, err := m.tailoringStrategy.TailorMessages(ctx, request.Messages, maxInputTokens)
 	if err != nil {
 		if len(tailored) > 0 {
-			log.Warn("token tailoring returned best-effort messages in huggingface.Model", err)
+			log.WarnContext(ctx, "token tailoring returned best-effort messages in huggingface.Model", err)
 			request.Messages = tailored
 			return
 		}

--- a/model/huggingface/huggingface_test.go
+++ b/model/huggingface/huggingface_test.go
@@ -30,6 +30,18 @@ import (
 
 const ApiKey = "*****"
 
+type overflowTailoringStrategy struct {
+	tailored []model.Message
+}
+
+func (s overflowTailoringStrategy) TailorMessages(
+	ctx context.Context,
+	messages []model.Message,
+	maxTokens int,
+) ([]model.Message, error) {
+	return s.tailored, errors.New("minimal protected context exceeds token budget")
+}
+
 func TestWithContextWindow(t *testing.T) {
 	m, err := New("test-model", WithAPIKey("test-key"), WithContextWindow(204800))
 	require.NoError(t, err)
@@ -705,6 +717,28 @@ func TestModel_TokenTailoring(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWithTokenTailoring_UsesProtectedContextOnOverflow(t *testing.T) {
+	tailored := []model.Message{
+		model.NewSystemMessage("sys"),
+		model.NewUserMessage("q"),
+	}
+	m := &Model{
+		name:                 "test-model",
+		enableTokenTailoring: true,
+		maxInputTokens:       1,
+		tailoringStrategy:    overflowTailoringStrategy{tailored: tailored},
+	}
+	req := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("sys"),
+		model.NewUserMessage("old"),
+		model.NewUserMessage("q"),
+	}}
+
+	m.applyTokenTailoring(context.Background(), req)
+
+	require.Equal(t, tailored, req.Messages)
 }
 
 func TestModel_TokenTailoring_Integration(t *testing.T) {

--- a/model/hunyuan/hunyuan.go
+++ b/model/hunyuan/hunyuan.go
@@ -308,6 +308,11 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 	// Apply token tailoring.
 	tailored, err := m.tailoringStrategy.TailorMessages(ctx, request.Messages, maxInputTokens)
 	if err != nil {
+		if model.IsTokenTailoringOverflow(err) {
+			log.WarnContext(ctx, "token tailoring overflow in hunyuan.Model; using protected context", err)
+			request.Messages = tailored
+			return
+		}
 		log.WarnContext(ctx, "token tailoring failed in hunyuan.Model", "error", err)
 		return
 	}

--- a/model/hunyuan/hunyuan.go
+++ b/model/hunyuan/hunyuan.go
@@ -308,8 +308,8 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 	// Apply token tailoring.
 	tailored, err := m.tailoringStrategy.TailorMessages(ctx, request.Messages, maxInputTokens)
 	if err != nil {
-		if model.IsTokenTailoringOverflow(err) {
-			log.WarnContext(ctx, "token tailoring overflow in hunyuan.Model; using protected context", err)
+		if len(tailored) > 0 {
+			log.WarnContext(ctx, "token tailoring returned best-effort messages in hunyuan.Model", err)
 			request.Messages = tailored
 			return
 		}

--- a/model/hunyuan/hunyuan_test.go
+++ b/model/hunyuan/hunyuan_test.go
@@ -74,6 +74,14 @@ func (testStubStrategy) TailorMessages(ctx context.Context, messages []model.Mes
 	return append([]model.Message{messages[0]}, messages[2:]...), nil
 }
 
+type overflowTailoringStrategy struct {
+	tailored []model.Message
+}
+
+func (s overflowTailoringStrategy) TailorMessages(ctx context.Context, messages []model.Message, maxTokens int) ([]model.Message, error) {
+	return s.tailored, fmt.Errorf("minimal protected context exceeds token budget")
+}
+
 // testErrorStrategy is a stub TailoringStrategy that returns an error.
 type testErrorStrategy struct{}
 
@@ -1190,6 +1198,28 @@ func TestWithTokenTailoring(t *testing.T) {
 	if len(capturedReq.Messages) != 1 {
 		t.Errorf("Expected 1 message after tailoring, got %d", len(capturedReq.Messages))
 	}
+}
+
+func TestWithTokenTailoring_UsesProtectedContextOnOverflow(t *testing.T) {
+	tailored := []model.Message{
+		model.NewSystemMessage("sys"),
+		model.NewUserMessage("q"),
+	}
+	m := &Model{
+		name:                 "test-model",
+		enableTokenTailoring: true,
+		maxInputTokens:       1,
+		tailoringStrategy:    overflowTailoringStrategy{tailored: tailored},
+	}
+	req := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("sys"),
+		model.NewUserMessage("old"),
+		model.NewUserMessage("q"),
+	}}
+
+	m.applyTokenTailoring(context.Background(), req)
+
+	require.Equal(t, tailored, req.Messages)
 }
 
 func TestWithEnableTokenTailoringDisabled(t *testing.T) {

--- a/model/ollama/ollama.go
+++ b/model/ollama/ollama.go
@@ -290,6 +290,15 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 	// Apply token tailoring.
 	tailored, err := m.tailoringStrategy.TailorMessages(ctx, request.Messages, maxInputTokens)
 	if err != nil {
+		if model.IsTokenTailoringOverflow(err) {
+			log.WarnContext(
+				ctx,
+				"token tailoring overflow in ollama.Model; using protected context",
+				err,
+			)
+			request.Messages = tailored
+			return
+		}
 		log.WarnContext(
 			ctx,
 			"token tailoring failed in ollama.Model",

--- a/model/ollama/ollama.go
+++ b/model/ollama/ollama.go
@@ -290,10 +290,10 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 	// Apply token tailoring.
 	tailored, err := m.tailoringStrategy.TailorMessages(ctx, request.Messages, maxInputTokens)
 	if err != nil {
-		if model.IsTokenTailoringOverflow(err) {
+		if len(tailored) > 0 {
 			log.WarnContext(
 				ctx,
-				"token tailoring overflow in ollama.Model; using protected context",
+				"token tailoring returned best-effort messages in ollama.Model",
 				err,
 			)
 			request.Messages = tailored

--- a/model/ollama/ollama_test.go
+++ b/model/ollama/ollama_test.go
@@ -988,6 +988,18 @@ func (testStubStrategy) TailorMessages(ctx context.Context, messages []model.Mes
 	return append([]model.Message{messages[0]}, messages[2:]...), nil
 }
 
+type overflowTailoringStrategy struct {
+	tailored []model.Message
+}
+
+func (s overflowTailoringStrategy) TailorMessages(
+	ctx context.Context,
+	messages []model.Message,
+	maxTokens int,
+) ([]model.Message, error) {
+	return s.tailored, errors.New("minimal protected context exceeds token budget")
+}
+
 // TestWithTokenTailoring tests token tailoring functionality.
 func TestWithTokenTailoring(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1032,6 +1044,28 @@ func TestWithTokenTailoring(t *testing.T) {
 	require.NotNil(t, capturedReq)
 	// After tailoring, messages should be reduced (1 message after tailoring).
 	require.Len(t, capturedReq.Messages, 1)
+}
+
+func TestWithTokenTailoring_UsesProtectedContextOnOverflow(t *testing.T) {
+	tailored := []model.Message{
+		model.NewSystemMessage("sys"),
+		model.NewUserMessage("q"),
+	}
+	m := &Model{
+		name:                 "test-model",
+		enableTokenTailoring: true,
+		maxInputTokens:       1,
+		tailoringStrategy:    overflowTailoringStrategy{tailored: tailored},
+	}
+	req := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("sys"),
+		model.NewUserMessage("old"),
+		model.NewUserMessage("q"),
+	}}
+
+	m.applyTokenTailoring(context.Background(), req)
+
+	require.Equal(t, tailored, req.Messages)
 }
 
 // TestWithEnableTokenTailoring_SimpleMode tests simple token tailoring mode.

--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -613,6 +613,15 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 	// Apply token tailoring.
 	tailored, err := m.tailoringStrategy.TailorMessages(ctx, request.Messages, maxInputTokens)
 	if err != nil {
+		if model.IsTokenTailoringOverflow(err) {
+			log.WarnContext(
+				ctx,
+				"token tailoring overflow in openai.Model; using protected context",
+				err,
+			)
+			request.Messages = tailored
+			return
+		}
 		log.WarnContext(
 			ctx,
 			"token tailoring failed in openai.Model",

--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -613,10 +613,10 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 	// Apply token tailoring.
 	tailored, err := m.tailoringStrategy.TailorMessages(ctx, request.Messages, maxInputTokens)
 	if err != nil {
-		if model.IsTokenTailoringOverflow(err) {
+		if len(tailored) > 0 {
 			log.WarnContext(
 				ctx,
-				"token tailoring overflow in openai.Model; using protected context",
+				"token tailoring returned best-effort messages in openai.Model",
 				err,
 			)
 			request.Messages = tailored

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -2276,10 +2277,7 @@ func (s overflowTailoringStrategy) TailorMessages(
 	messages []model.Message,
 	maxTokens int,
 ) ([]model.Message, error) {
-	return s.tailored, &model.TokenTailoringOverflowError{
-		Tokens:    maxTokens + 1,
-		MaxTokens: maxTokens,
-	}
+	return s.tailored, errors.New("minimal protected context exceeds token budget")
 }
 
 type captureMaxTokensStrategy struct {

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -2267,6 +2267,21 @@ func (testStubStrategy) TailorMessages(ctx context.Context, messages []model.Mes
 	return append([]model.Message{messages[0]}, messages[2:]...), nil
 }
 
+type overflowTailoringStrategy struct {
+	tailored []model.Message
+}
+
+func (s overflowTailoringStrategy) TailorMessages(
+	ctx context.Context,
+	messages []model.Message,
+	maxTokens int,
+) ([]model.Message, error) {
+	return s.tailored, &model.TokenTailoringOverflowError{
+		Tokens:    maxTokens + 1,
+		MaxTokens: maxTokens,
+	}
+}
+
 type captureMaxTokensStrategy struct {
 	maxTokens int
 	called    bool
@@ -2313,6 +2328,27 @@ func TestWithTokenTailoring(t *testing.T) {
 	require.NotNil(t, captured, "expected request callback to capture request")
 	// After tailoring, OpenAI messages should be 1 user message (system omitted in this test).
 	require.Len(t, captured.Messages, 1, "expected 1 message after tailoring, got %d", len(captured.Messages))
+}
+
+func TestWithTokenTailoring_UsesProtectedContextOnOverflow(t *testing.T) {
+	tailored := []model.Message{
+		model.NewSystemMessage("sys"),
+		model.NewUserMessage("q"),
+	}
+	m := New("test-model",
+		WithEnableTokenTailoring(true),
+		WithMaxInputTokens(1),
+		WithTailoringStrategy(overflowTailoringStrategy{tailored: tailored}),
+	)
+	req := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("sys"),
+		model.NewUserMessage("old"),
+		model.NewUserMessage("q"),
+	}}
+
+	m.applyTokenTailoring(context.Background(), req)
+
+	require.Equal(t, tailored, req.Messages)
 }
 
 func TestWithTokenTailoring_ReservesRequestMaxTokens(t *testing.T) {

--- a/model/token_tailor.go
+++ b/model/token_tailor.go
@@ -414,6 +414,9 @@ func shouldReturnOriginal(
 	if maxTokens <= 0 {
 		return true, nil
 	}
+	if tokenCounter == nil {
+		tokenCounter = NewSimpleTokenCounter()
+	}
 	tokens, err := tokenCounter.CountTokensRange(ctx, messages, 0, len(messages))
 	if err != nil {
 		return true, messages

--- a/model/token_tailor.go
+++ b/model/token_tailor.go
@@ -11,6 +11,7 @@ package model
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"unicode/utf8"
 )
@@ -77,7 +78,31 @@ type TokenCounter interface {
 // TailoringStrategy tailors messages to fit within a token budget.
 type TailoringStrategy interface {
 	// TailorMessages reduces message list so total tokens are within maxTokens.
+	// If the smallest protected context cannot fit, it returns that best-effort
+	// context with a TokenTailoringOverflowError.
 	TailorMessages(ctx context.Context, messages []Message, maxTokens int) ([]Message, error)
+}
+
+// TokenTailoringOverflowError reports that token tailoring could only produce
+// a protected context that still exceeds the requested input budget.
+type TokenTailoringOverflowError struct {
+	Tokens    int
+	MaxTokens int
+}
+
+// Error implements the error interface.
+func (e *TokenTailoringOverflowError) Error() string {
+	return fmt.Sprintf(
+		"token tailoring overflow: minimal protected context uses %d tokens, max input tokens is %d",
+		e.Tokens,
+		e.MaxTokens,
+	)
+}
+
+// IsTokenTailoringOverflow reports whether err is a token tailoring overflow.
+func IsTokenTailoringOverflow(err error) bool {
+	var overflow *TokenTailoringOverflowError
+	return errors.As(err, &overflow)
 }
 
 // SimpleTokenCounter provides a very rough token estimation based on rune length.
@@ -369,7 +394,21 @@ func ensureTailoredWithinBudget(
 	}
 
 	preservedHead := calculatePreservedHeadCount(messages)
-	return buildMinimalSuffixCandidate(messages, preservedHead), nil
+	candidate := buildMinimalSuffixCandidate(messages, preservedHead)
+	if len(candidate) == 0 {
+		return nil, nil
+	}
+	if fitsWithinBudget(ctx, tokenCounter, candidate, maxTokens) {
+		return candidate, nil
+	}
+	tokens, err := countCandidateTokens(ctx, tokenCounter, candidate)
+	if err != nil {
+		return candidate, err
+	}
+	return candidate, &TokenTailoringOverflowError{
+		Tokens:    tokens,
+		MaxTokens: maxTokens,
+	}
 }
 
 // shouldReturnOriginal checks if the messages should be returned as is.
@@ -405,11 +444,25 @@ func fitsWithinBudget(
 	if len(messages) == 0 {
 		return false
 	}
+	if tokenCounter == nil {
+		tokenCounter = NewSimpleTokenCounter()
+	}
 	tokens, err := tokenCounter.CountTokensRange(ctx, messages, 0, len(messages))
 	if err != nil {
 		return false
 	}
 	return tokens <= maxTokens
+}
+
+func countCandidateTokens(
+	ctx context.Context,
+	tokenCounter TokenCounter,
+	messages []Message,
+) (int, error) {
+	if tokenCounter == nil {
+		tokenCounter = NewSimpleTokenCounter()
+	}
+	return tokenCounter.CountTokensRange(ctx, messages, 0, len(messages))
 }
 
 // buildMinimalSuffixCandidate builds the smallest protected context for the

--- a/model/token_tailor.go
+++ b/model/token_tailor.go
@@ -352,7 +352,11 @@ func countTokensForRounds(prefixSum []int, rounds []userAnchoredRound, keep []bo
 	return total
 }
 
-// ensureTailoredWithinBudget ensures the tailored result is within the budget.
+// ensureTailoredWithinBudget returns the smallest protected context when the
+// tailored result is still over budget. The protected context keeps the system
+// prefix and the latest valid round. If that minimal context is still too large,
+// the caller should surface the overflow instead of silently dropping system
+// instructions.
 func ensureTailoredWithinBudget(
 	ctx context.Context,
 	tokenCounter TokenCounter,
@@ -365,18 +369,7 @@ func ensureTailoredWithinBudget(
 	}
 
 	preservedHead := calculatePreservedHeadCount(messages)
-	withSystem, withoutSystem := buildMinimalSuffixCandidates(messages, preservedHead)
-	if fitsWithinBudget(ctx, tokenCounter, withSystem, maxTokens) {
-		return withSystem, nil
-	}
-
-	if len(withoutSystem) == 0 {
-		return nil, nil
-	}
-	if fitsWithinBudget(ctx, tokenCounter, withoutSystem, maxTokens) {
-		return withoutSystem, nil
-	}
-	return withoutSystem, nil
+	return buildMinimalSuffixCandidate(messages, preservedHead), nil
 }
 
 // shouldReturnOriginal checks if the messages should be returned as is.
@@ -419,21 +412,22 @@ func fitsWithinBudget(
 	return tokens <= maxTokens
 }
 
-// buildMinimalSuffixCandidates builds the minimal suffix candidates for the messages.
-func buildMinimalSuffixCandidates(messages []Message, preservedHead int) ([]Message, []Message) {
+// buildMinimalSuffixCandidate builds the smallest protected context for the
+// messages: the system prefix plus the latest valid user-anchored round.
+func buildMinimalSuffixCandidate(messages []Message, preservedHead int) []Message {
 	last := lastNonSystemIndex(messages)
 	if last < 0 {
-		return nil, nil
+		return nil
 	}
 
 	last = trimTrailingAssistant(messages, last)
 	if last < 0 {
-		return nil, nil
+		return nil
 	}
 
 	start := startOfUserToolGroup(messages, last)
 	if start < 0 {
-		return nil, nil
+		return nil
 	}
 
 	end := last + 1
@@ -445,8 +439,7 @@ func buildMinimalSuffixCandidates(messages []Message, preservedHead int) ([]Mess
 	withSystem = append(withSystem, messages[start:end]...)
 	withSystem = validateAndFixMessageSequence(withSystem)
 
-	withoutSystem := validateAndFixMessageSequence(messages[start:end])
-	return withSystem, withoutSystem
+	return withSystem
 }
 
 // lastNonSystemIndex finds the last non-system message index.

--- a/model/token_tailor.go
+++ b/model/token_tailor.go
@@ -11,7 +11,6 @@ package model
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"unicode/utf8"
 )
@@ -79,30 +78,21 @@ type TokenCounter interface {
 type TailoringStrategy interface {
 	// TailorMessages reduces message list so total tokens are within maxTokens.
 	// If the smallest protected context cannot fit, it returns that best-effort
-	// context with a TokenTailoringOverflowError.
+	// context together with an error.
 	TailorMessages(ctx context.Context, messages []Message, maxTokens int) ([]Message, error)
 }
 
-// TokenTailoringOverflowError reports that token tailoring could only produce
-// a protected context that still exceeds the requested input budget.
-type TokenTailoringOverflowError struct {
+type tokenTailoringOverflowError struct {
 	Tokens    int
 	MaxTokens int
 }
 
-// Error implements the error interface.
-func (e *TokenTailoringOverflowError) Error() string {
+func (e *tokenTailoringOverflowError) Error() string {
 	return fmt.Sprintf(
 		"token tailoring overflow: minimal protected context uses %d tokens, max input tokens is %d",
 		e.Tokens,
 		e.MaxTokens,
 	)
-}
-
-// IsTokenTailoringOverflow reports whether err is a token tailoring overflow.
-func IsTokenTailoringOverflow(err error) bool {
-	var overflow *TokenTailoringOverflowError
-	return errors.As(err, &overflow)
 }
 
 // SimpleTokenCounter provides a very rough token estimation based on rune length.
@@ -405,7 +395,7 @@ func ensureTailoredWithinBudget(
 	if err != nil {
 		return candidate, err
 	}
-	return candidate, &TokenTailoringOverflowError{
+	return candidate, &tokenTailoringOverflowError{
 		Tokens:    tokens,
 		MaxTokens: maxTokens,
 	}

--- a/model/token_tailor_test.go
+++ b/model/token_tailor_test.go
@@ -1329,7 +1329,8 @@ func TestMiddleOutStrategy_PreservesSystemWhenMinimalSuffixExceedsBudget(t *test
 	strategy := NewMiddleOutStrategy(counter)
 
 	tailored, err := strategy.TailorMessages(context.Background(), msgs, 10)
-	require.NoError(t, err)
+	require.Error(t, err)
+	require.True(t, IsTokenTailoringOverflow(err))
 	require.GreaterOrEqual(t, len(tailored), 2)
 
 	assert.Equal(t, RoleSystem, tailored[0].Role)
@@ -1370,7 +1371,8 @@ func TestTokenTailor_DoesNotDropSystemForLargeToolResult(t *testing.T) {
 	strategy := NewMiddleOutStrategy(counter)
 
 	tailored, err := strategy.TailorMessages(context.Background(), msgs, 10)
-	require.NoError(t, err)
+	require.Error(t, err)
+	require.True(t, IsTokenTailoringOverflow(err))
 	require.Len(t, tailored, 4)
 
 	assert.Equal(t, RoleSystem, tailored[0].Role)
@@ -1398,7 +1400,8 @@ func TestHeadOutStrategy_PreservedSegmentsExceedBudget(t *testing.T) {
 
 	// Budget is less than preserved segments.
 	tailored, err := strategy.TailorMessages(context.Background(), msgs, 10)
-	require.NoError(t, err)
+	require.Error(t, err)
+	require.True(t, IsTokenTailoringOverflow(err))
 
 	// Should return only preserved segments (system + last turn).
 	require.Greater(t, len(tailored), 0)
@@ -1422,7 +1425,8 @@ func TestTailOutStrategy_PreservedSegmentsExceedBudget(t *testing.T) {
 
 	// Budget is less than preserved segments.
 	tailored, err := strategy.TailorMessages(context.Background(), msgs, 10)
-	require.NoError(t, err)
+	require.Error(t, err)
+	require.True(t, IsTokenTailoringOverflow(err))
 
 	// Should return only preserved segments (system + last turn).
 	require.Greater(t, len(tailored), 0)

--- a/model/token_tailor_test.go
+++ b/model/token_tailor_test.go
@@ -22,6 +22,7 @@ func requireTokenTailoringOverflow(t *testing.T, err error) {
 	t.Helper()
 	var overflow *tokenTailoringOverflowError
 	require.ErrorAs(t, err, &overflow)
+	require.Contains(t, err.Error(), "token tailoring overflow")
 }
 
 func TestSimpleTokenCounter_CountTokens(t *testing.T) {
@@ -1107,6 +1108,37 @@ func (c *mockErrorTokenCounter) CountTokensRange(ctx context.Context, messages [
 	return 0, fmt.Errorf("mock error")
 }
 
+type rangeLenTokenCounter struct{}
+
+func (rangeLenTokenCounter) CountTokens(ctx context.Context, message Message) (int, error) {
+	return 1, nil
+}
+
+func (rangeLenTokenCounter) CountTokensRange(ctx context.Context, messages []Message, start, end int) (int, error) {
+	if start < 0 || end > len(messages) || start >= end {
+		return 0, fmt.Errorf("invalid range")
+	}
+	return end - start, nil
+}
+
+type scriptedRangeTokenCounter struct {
+	calls int
+	steps []struct {
+		tokens int
+		err    error
+	}
+}
+
+func (c *scriptedRangeTokenCounter) CountTokens(ctx context.Context, message Message) (int, error) {
+	return 1, nil
+}
+
+func (c *scriptedRangeTokenCounter) CountTokensRange(ctx context.Context, messages []Message, start, end int) (int, error) {
+	step := c.steps[c.calls]
+	c.calls++
+	return step.tokens, step.err
+}
+
 // TestBuildPrefixSum_WithActualError tests the error handling path in buildPrefixSum
 func TestBuildPrefixSum_WithActualError(t *testing.T) {
 	counter := &mockErrorTokenCounter{}
@@ -1752,6 +1784,16 @@ func TestShouldReturnOriginal_CountTokensError(t *testing.T) {
 	require.Len(t, out, 1)
 }
 
+func TestShouldReturnOriginal_NilTokenCounter(t *testing.T) {
+	messages := []Message{
+		NewUserMessage("q"),
+	}
+
+	done, out := shouldReturnOriginal(context.Background(), nil, messages, 10)
+	require.True(t, done)
+	require.Equal(t, messages, out)
+}
+
 func TestFitsWithinBudget_Empty(t *testing.T) {
 	counter := NewSimpleTokenCounter()
 
@@ -1836,6 +1878,63 @@ func TestEnsureTailoredWithinBudget_CountTokensError(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 	require.Equal(t, "q", out[0].Content)
+}
+
+func TestEnsureTailoredWithinBudget_MinimalCandidateFits(t *testing.T) {
+	messages := []Message{
+		NewSystemMessage("sys"),
+		NewUserMessage("old"),
+		NewAssistantMessage("old answer"),
+		NewUserMessage("q"),
+	}
+
+	out, err := ensureTailoredWithinBudget(context.Background(),
+		rangeLenTokenCounter{}, messages, 2)
+	require.NoError(t, err)
+	require.Equal(t, []Message{
+		NewSystemMessage("sys"),
+		NewUserMessage("q"),
+	}, out)
+}
+
+func TestEnsureTailoredWithinBudget_NoMinimalCandidate(t *testing.T) {
+	messages := []Message{
+		NewSystemMessage("sys"),
+		NewSystemMessage("sys2"),
+	}
+
+	out, err := ensureTailoredWithinBudget(context.Background(),
+		rangeLenTokenCounter{}, messages, 1)
+	require.NoError(t, err)
+	require.Nil(t, out)
+}
+
+func TestEnsureTailoredWithinBudget_CandidateTokenCountError(t *testing.T) {
+	counter := &scriptedRangeTokenCounter{
+		steps: []struct {
+			tokens int
+			err    error
+		}{
+			{tokens: 4},
+			{tokens: 4},
+			{err: fmt.Errorf("count candidate")},
+		},
+	}
+	messages := []Message{
+		NewSystemMessage("sys"),
+		NewUserMessage("old"),
+		NewAssistantMessage("old answer"),
+		NewUserMessage("q"),
+	}
+
+	out, err := ensureTailoredWithinBudget(context.Background(),
+		counter, messages, 2)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "count candidate")
+	require.Equal(t, []Message{
+		NewSystemMessage("sys"),
+		NewUserMessage("q"),
+	}, out)
 }
 
 func TestFitsWithinBudget_CountTokensError(t *testing.T) {

--- a/model/token_tailor_test.go
+++ b/model/token_tailor_test.go
@@ -1134,6 +1134,9 @@ func (c *scriptedRangeTokenCounter) CountTokens(ctx context.Context, message Mes
 }
 
 func (c *scriptedRangeTokenCounter) CountTokensRange(ctx context.Context, messages []Message, start, end int) (int, error) {
+	if c.calls >= len(c.steps) {
+		return 0, fmt.Errorf("unexpected CountTokensRange call: %d", c.calls+1)
+	}
 	step := c.steps[c.calls]
 	c.calls++
 	return step.tokens, step.err

--- a/model/token_tailor_test.go
+++ b/model/token_tailor_test.go
@@ -1316,6 +1316,73 @@ func TestTailOutStrategy_VeryTightBudget(t *testing.T) {
 	assert.LessOrEqual(t, totalTokens, 20)
 }
 
+func TestMiddleOutStrategy_PreservesSystemWhenMinimalSuffixExceedsBudget(t *testing.T) {
+	msgs := []Message{
+		NewSystemMessage(repeat("system ", 100)),
+		NewUserMessage("Old 1 " + repeat("x", 200)),
+		NewUserMessage("Old 2 " + repeat("y", 200)),
+		NewUserMessage("Query"),
+		NewAssistantMessage(repeat("response ", 100)),
+	}
+
+	counter := NewSimpleTokenCounter()
+	strategy := NewMiddleOutStrategy(counter)
+
+	tailored, err := strategy.TailorMessages(context.Background(), msgs, 10)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(tailored), 2)
+
+	assert.Equal(t, RoleSystem, tailored[0].Role)
+	assert.Equal(t, RoleUser, tailored[len(tailored)-1].Role)
+	assert.Equal(t, "Query", tailored[len(tailored)-1].Content)
+
+	totalTokens := 0
+	for _, msg := range tailored {
+		tokens, err := counter.CountTokens(context.Background(), msg)
+		require.NoError(t, err)
+		totalTokens += tokens
+	}
+	assert.Greater(t, totalTokens, 10)
+}
+
+func TestTokenTailor_DoesNotDropSystemForLargeToolResult(t *testing.T) {
+	toolCall := ToolCall{
+		Type: "function",
+		ID:   "call_1",
+		Function: FunctionDefinitionParam{
+			Name:      "search",
+			Arguments: []byte(`{"q":"latest"}`),
+		},
+	}
+	msgs := []Message{
+		NewSystemMessage(repeat("system ", 100)),
+		NewUserMessage("Old turn " + repeat("x", 200)),
+		NewUserMessage("Latest question"),
+		{
+			Role:      RoleAssistant,
+			Content:   "Calling search",
+			ToolCalls: []ToolCall{toolCall},
+		},
+		NewToolMessage("call_1", "search", repeat("large-result ", 200)),
+	}
+
+	counter := NewSimpleTokenCounter()
+	strategy := NewMiddleOutStrategy(counter)
+
+	tailored, err := strategy.TailorMessages(context.Background(), msgs, 10)
+	require.NoError(t, err)
+	require.Len(t, tailored, 4)
+
+	assert.Equal(t, RoleSystem, tailored[0].Role)
+	assert.Equal(t, RoleUser, tailored[1].Role)
+	assert.Equal(t, "Latest question", tailored[1].Content)
+	assert.Equal(t, RoleAssistant, tailored[2].Role)
+	require.Len(t, tailored[2].ToolCalls, 1)
+	assert.Equal(t, "call_1", tailored[2].ToolCalls[0].ID)
+	assert.Equal(t, RoleTool, tailored[3].Role)
+	assert.Equal(t, "call_1", tailored[3].ToolID)
+}
+
 // TestHeadOutStrategy_PreservedSegmentsExceedBudget tests when preserved segments exceed budget.
 func TestHeadOutStrategy_PreservedSegmentsExceedBudget(t *testing.T) {
 	msgs := []Message{
@@ -1335,6 +1402,7 @@ func TestHeadOutStrategy_PreservedSegmentsExceedBudget(t *testing.T) {
 
 	// Should return only preserved segments (system + last turn).
 	require.Greater(t, len(tailored), 0)
+	assert.Equal(t, RoleSystem, tailored[0].Role)
 	assert.Equal(t, RoleUser, tailored[len(tailored)-1].Role)
 	assert.Equal(t, "Query", tailored[len(tailored)-1].Content)
 }
@@ -1358,6 +1426,7 @@ func TestTailOutStrategy_PreservedSegmentsExceedBudget(t *testing.T) {
 
 	// Should return only preserved segments (system + last turn).
 	require.Greater(t, len(tailored), 0)
+	assert.Equal(t, RoleSystem, tailored[0].Role)
 	assert.Equal(t, RoleUser, tailored[len(tailored)-1].Role)
 	assert.Equal(t, "Query", tailored[len(tailored)-1].Content)
 }
@@ -1685,9 +1754,8 @@ func TestBuildMinimalSuffixCandidates_NoNonSystem(t *testing.T) {
 		NewSystemMessage("sys"),
 	}
 
-	withSystem, withoutSystem := buildMinimalSuffixCandidates(messages, 1)
+	withSystem := buildMinimalSuffixCandidate(messages, 1)
 	require.Nil(t, withSystem)
-	require.Nil(t, withoutSystem)
 }
 
 func TestBuildMinimalSuffixCandidates_ToolAtEnd(t *testing.T) {
@@ -1697,11 +1765,10 @@ func TestBuildMinimalSuffixCandidates_ToolAtEnd(t *testing.T) {
 		NewToolMessage("tool_1", "search", "result"),
 	}
 
-	withSystem, withoutSystem := buildMinimalSuffixCandidates(messages, 1)
+	withSystem := buildMinimalSuffixCandidate(messages, 1)
 	require.Len(t, withSystem, 3)
+	require.Equal(t, RoleSystem, withSystem[0].Role)
 	require.Equal(t, RoleTool, withSystem[len(withSystem)-1].Role)
-	require.Len(t, withoutSystem, 2)
-	require.Equal(t, RoleTool, withoutSystem[len(withoutSystem)-1].Role)
 }
 
 func TestBuildMinimalSuffixCandidates_ToolOnly(t *testing.T) {
@@ -1709,9 +1776,8 @@ func TestBuildMinimalSuffixCandidates_ToolOnly(t *testing.T) {
 		NewToolMessage("tool_1", "search", "result"),
 	}
 
-	withSystem, withoutSystem := buildMinimalSuffixCandidates(messages, 0)
+	withSystem := buildMinimalSuffixCandidate(messages, 0)
 	require.Nil(t, withSystem)
-	require.Nil(t, withoutSystem)
 }
 
 func TestLastNonSystemIndex_AllSystem(t *testing.T) {

--- a/model/token_tailor_test.go
+++ b/model/token_tailor_test.go
@@ -18,6 +18,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func requireTokenTailoringOverflow(t *testing.T, err error) {
+	t.Helper()
+	var overflow *tokenTailoringOverflowError
+	require.ErrorAs(t, err, &overflow)
+}
+
 func TestSimpleTokenCounter_CountTokens(t *testing.T) {
 	counter := NewSimpleTokenCounter()
 	msg := NewSystemMessage("You are a helpful assistant.")
@@ -1330,7 +1336,7 @@ func TestMiddleOutStrategy_PreservesSystemWhenMinimalSuffixExceedsBudget(t *test
 
 	tailored, err := strategy.TailorMessages(context.Background(), msgs, 10)
 	require.Error(t, err)
-	require.True(t, IsTokenTailoringOverflow(err))
+	requireTokenTailoringOverflow(t, err)
 	require.GreaterOrEqual(t, len(tailored), 2)
 
 	assert.Equal(t, RoleSystem, tailored[0].Role)
@@ -1372,7 +1378,7 @@ func TestTokenTailor_DoesNotDropSystemForLargeToolResult(t *testing.T) {
 
 	tailored, err := strategy.TailorMessages(context.Background(), msgs, 10)
 	require.Error(t, err)
-	require.True(t, IsTokenTailoringOverflow(err))
+	requireTokenTailoringOverflow(t, err)
 	require.Len(t, tailored, 4)
 
 	assert.Equal(t, RoleSystem, tailored[0].Role)
@@ -1401,7 +1407,7 @@ func TestHeadOutStrategy_PreservedSegmentsExceedBudget(t *testing.T) {
 	// Budget is less than preserved segments.
 	tailored, err := strategy.TailorMessages(context.Background(), msgs, 10)
 	require.Error(t, err)
-	require.True(t, IsTokenTailoringOverflow(err))
+	requireTokenTailoringOverflow(t, err)
 
 	// Should return only preserved segments (system + last turn).
 	require.Greater(t, len(tailored), 0)
@@ -1426,7 +1432,7 @@ func TestTailOutStrategy_PreservedSegmentsExceedBudget(t *testing.T) {
 	// Budget is less than preserved segments.
 	tailored, err := strategy.TailorMessages(context.Background(), msgs, 10)
 	require.Error(t, err)
-	require.True(t, IsTokenTailoringOverflow(err))
+	requireTokenTailoringOverflow(t, err)
 
 	// Should return only preserved segments (system + last turn).
 	require.Greater(t, len(tailored), 0)


### PR DESCRIPTION
## Summary
- Keep token tailoring fallback from silently dropping system messages when the protected minimal context exceeds the token budget.
- Preserve the latest valid user/tool round as the minimal fallback context, leaving tool result content compaction to the existing context compaction layer.
- Add regression coverage for over-budget system prompts and large tool-result rounds.

## Test plan
- `go test ./model -run 'TokenTailor|MiddleOut|HeadOut|TailOut|ValidateAndFixMessageSequence|MinimalSuffix|EnsureTailoredWithinBudget'`
- `go test ./model`
- `go test ./internal/flow/processor -run ContextCompaction`
- `go test ./internal/flow/llmflow -run CompactContext`
- `go test ./model/openai -run TokenTailoring`
- `go test ./...` currently has an unrelated failure in `knowledge/document/reader/golang`: `TestChunkedReaderUsesRepoRootForScope` reports `document "demo.Serve" not found`.