### PR TITLE
session/internal/summary: prevent duplicate concurrent session summaries

### DIFF
--- a/session/clickhouse/summary.go
+++ b/session/clickhouse/summary.go
@@ -96,9 +96,10 @@ func (s *Service) EnqueueSummaryJob(ctx context.Context, sess *session.Session, 
 		return s.asyncWorker.EnqueueJob(ctx, sess, filterKey, force)
 	}
 
-	// Fallback to synchronous processing.
+	// Fallback to synchronous processing with the same detached context that
+	// async workers use.
 	return isummary.CreateSessionSummaryWithCascade(
-		ctx,
+		isummary.DetachContext(ctx),
 		sess,
 		filterKey,
 		force,

--- a/session/inmemory/summary.go
+++ b/session/inmemory/summary.go
@@ -128,9 +128,10 @@ func (s *SessionService) EnqueueSummaryJob(ctx context.Context, sess *session.Se
 		return s.asyncWorker.EnqueueJob(ctx, sess, filterKey, force)
 	}
 
-	// Fallback to synchronous processing.
+	// Fallback to synchronous processing with the same detached context that
+	// async workers use.
 	return isummary.CreateSessionSummaryWithCascade(
-		ctx,
+		isummary.DetachContext(ctx),
 		sess,
 		filterKey,
 		force,

--- a/session/internal/summary/async.go
+++ b/session/internal/summary/async.go
@@ -49,6 +49,14 @@ type AsyncSummaryConfig struct {
 	CreateSummaryFunc     func(context.Context, *session.Session, string, bool) error
 }
 
+// DetachContext clones ctx and strips cancellation for asynchronous summary work.
+func DetachContext(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithoutCancel(agent.CloneContext(ctx))
+}
+
 func (c AsyncSummaryConfig) hasSummarizer() bool {
 	return HasSummarizer(c.Summarizer)
 }
@@ -130,12 +138,8 @@ func (w *AsyncSummaryWorker) EnqueueJob(
 	}
 
 	// Create job with detached context.
-	jobCtx := ctx
-	if jobCtx == nil {
-		jobCtx = context.Background()
-	}
 	job := &summaryJob{
-		ctx:       context.WithoutCancel(agent.CloneContext(jobCtx)),
+		ctx:       DetachContext(ctx),
 		filterKey: filterKey,
 		force:     force,
 		session:   sess,

--- a/session/internal/summary/summary.go
+++ b/session/internal/summary/summary.go
@@ -100,6 +100,8 @@ func SummarizeSession(
 	if base == nil {
 		return false, nil
 	}
+	unlock := lockSessionSummary(base, filterKey)
+	defer unlock()
 
 	// Get previous summary info.
 	var prevText string
@@ -197,6 +199,62 @@ func selectUpdatedAt(tmp *session.Session, prevAt, latestTs time.Time, hasDelta 
 const lastIncludedTsKey = "summary:last_included_ts"
 
 type summaryTriggerFilterKeyContextKey struct{}
+
+type summaryLockKey struct {
+	appName   string
+	userID    string
+	sessionID string
+	filterKey string
+}
+
+type summaryLock struct {
+	mu   sync.Mutex
+	refs int
+}
+
+type summaryLockGroup struct {
+	mu    sync.Mutex
+	locks map[summaryLockKey]*summaryLock
+}
+
+var sessionSummaryLocks summaryLockGroup
+
+func (g *summaryLockGroup) lock(key summaryLockKey) func() {
+	g.mu.Lock()
+	if g.locks == nil {
+		g.locks = make(map[summaryLockKey]*summaryLock)
+	}
+	l := g.locks[key]
+	if l == nil {
+		l = &summaryLock{}
+		g.locks[key] = l
+	}
+	l.refs++
+	g.mu.Unlock()
+
+	l.mu.Lock()
+	return func() {
+		l.mu.Unlock()
+		g.mu.Lock()
+		defer g.mu.Unlock()
+		l.refs--
+		if l.refs == 0 && g.locks[key] == l {
+			delete(g.locks, key)
+		}
+	}
+}
+
+func lockSessionSummary(sess *session.Session, filterKey string) func() {
+	if sess == nil {
+		return func() {}
+	}
+	return sessionSummaryLocks.lock(summaryLockKey{
+		appName:   sess.AppName,
+		userID:    sess.UserID,
+		sessionID: sess.ID,
+		filterKey: filterKey,
+	})
+}
 
 func contextWithSummaryTriggerFilterKey(ctx context.Context, filterKey string) context.Context {
 	if filterKey == "" {

--- a/session/internal/summary/summary.go
+++ b/session/internal/summary/summary.go
@@ -112,61 +112,20 @@ func SummarizeSession(
 		return false, err
 	}
 
-	// Get previous summary info.
-	var prevText string
-	var prevAt time.Time
-	var needsPersistOnly bool
-	base.SummariesMu.RLock()
-	if base.Summaries != nil {
-		if s := base.Summaries[filterKey]; s != nil {
-			prevText = s.Summary
-			prevAt = s.UpdatedAt
-			// Zero UpdatedAt indicates summary was copied and needs persistence.
-			needsPersistOnly = prevText != "" && prevAt.IsZero()
-		}
-	}
-	base.SummariesMu.RUnlock()
-
-	// Handle copied summary that needs persistence only (no LLM call).
-	if needsPersistOnly {
-		// Compute the latest event timestamp for proper UpdatedAt.
-		_, latestTs := computeDeltaSince(base, time.Time{}, filterKey)
-		if latestTs.IsZero() {
-			latestTs = time.Now()
-		}
-		base.SummariesMu.Lock()
-		if base.Summaries != nil && base.Summaries[filterKey] != nil {
-			base.Summaries[filterKey].UpdatedAt = latestTs.UTC()
-		}
-		base.SummariesMu.Unlock()
+	prev := readPreviousSummary(base, filterKey)
+	if prev.needsPersistOnly {
+		persistCopiedSummary(base, filterKey)
 		return true, nil
 	}
-
 	if m == nil {
 		return false, nil
 	}
 
-	// Compute delta events with both time and filterKey filtering in one pass.
-	delta, latestTs := computeDeltaSince(base, prevAt, filterKey)
-	if !force && len(delta) == 0 {
+	input, ok := buildSummaryInput(ctx, m, base, filterKey, force, prev)
+	if !ok {
 		return false, nil
 	}
-
-	// Build input with previous summary prepended.
-	input := prependPrevSummary(prevText, delta, time.Now())
-	tmp := buildFilterSession(base, filterKey, input)
-	checkTmp := tmp
-	if filterKey == session.SummaryFilterKeyAllContents {
-		if triggerFilterKey := summaryTriggerFilterKeyFromContext(ctx); triggerFilterKey != "" {
-			checkTmp = buildFilterSession(base, triggerFilterKey, input)
-		}
-	}
-	if !force && !ShouldSummarize(ctx, m, checkTmp) {
-		return false, nil
-	}
-
-	// Generate summary.
-	text, err := m.Summarize(ctx, tmp)
+	text, err := m.Summarize(ctx, input.session)
 	if err != nil {
 		return false, fmt.Errorf("summarize session %s failed: %w", base.ID, err)
 	}
@@ -174,21 +133,118 @@ func SummarizeSession(
 		return false, nil
 	}
 
-	// Update summaries. UpdatedAt reflects the latest event included in this
-	// summarization to avoid skipping events during future delta computations.
-	// When no new events were summarized (e.g., force==true and delta empty),
-	// keep the previous timestamp.
-	updatedAt := selectUpdatedAt(tmp, prevAt, latestTs, len(delta) > 0)
+	updatedAt := selectUpdatedAt(
+		input.session,
+		prev.updatedAt,
+		input.latestEventTime,
+		input.hasDelta,
+	)
+	writeSummary(base, filterKey, text, updatedAt)
+	return true, nil
+}
 
-	// Acquire write lock to protect Summaries access.
+type previousSummary struct {
+	text             string
+	updatedAt        time.Time
+	needsPersistOnly bool
+}
+
+type summaryInput struct {
+	session         *session.Session
+	latestEventTime time.Time
+	hasDelta        bool
+}
+
+// readPreviousSummary returns the current summary state for filterKey.
+func readPreviousSummary(base *session.Session, filterKey string) previousSummary {
+	var prev previousSummary
+	base.SummariesMu.RLock()
+	defer base.SummariesMu.RUnlock()
+	if base.Summaries == nil {
+		return prev
+	}
+	s := base.Summaries[filterKey]
+	if s == nil {
+		return prev
+	}
+	prev.text = s.Summary
+	prev.updatedAt = s.UpdatedAt
+	// Zero UpdatedAt indicates summary was copied and needs persistence.
+	prev.needsPersistOnly = prev.text != "" && prev.updatedAt.IsZero()
+	return prev
+}
+
+// persistCopiedSummary marks a copied in-memory summary as persisted-ready.
+func persistCopiedSummary(base *session.Session, filterKey string) {
+	_, latestTs := computeDeltaSince(base, time.Time{}, filterKey)
+	if latestTs.IsZero() {
+		latestTs = time.Now()
+	}
 	base.SummariesMu.Lock()
 	defer base.SummariesMu.Unlock()
+	if base.Summaries != nil && base.Summaries[filterKey] != nil {
+		base.Summaries[filterKey].UpdatedAt = latestTs.UTC()
+	}
+}
 
+// buildSummaryInput prepares the temporary session used for summary generation.
+func buildSummaryInput(
+	ctx context.Context,
+	m summary.SessionSummarizer,
+	base *session.Session,
+	filterKey string,
+	force bool,
+	prev previousSummary,
+) (summaryInput, bool) {
+	delta, latestTs := computeDeltaSince(base, prev.updatedAt, filterKey)
+	if !force && len(delta) == 0 {
+		return summaryInput{}, false
+	}
+	input := prependPrevSummary(prev.text, delta, time.Now())
+	tmp := buildFilterSession(base, filterKey, input)
+	if !shouldGenerateSummary(ctx, m, base, tmp, input, filterKey, force) {
+		return summaryInput{}, false
+	}
+	return summaryInput{
+		session:         tmp,
+		latestEventTime: latestTs,
+		hasDelta:        len(delta) > 0,
+	}, true
+}
+
+// shouldGenerateSummary runs configured summary checks for the prepared input.
+func shouldGenerateSummary(
+	ctx context.Context,
+	m summary.SessionSummarizer,
+	base *session.Session,
+	tmp *session.Session,
+	input []event.Event,
+	filterKey string,
+	force bool,
+) bool {
+	if force {
+		return true
+	}
+	checkTmp := tmp
+	if filterKey == session.SummaryFilterKeyAllContents {
+		if triggerFilterKey := summaryTriggerFilterKeyFromContext(ctx); triggerFilterKey != "" {
+			checkTmp = buildFilterSession(base, triggerFilterKey, input)
+		}
+	}
+	return ShouldSummarize(ctx, m, checkTmp)
+}
+
+// writeSummary stores the generated summary under filterKey.
+func writeSummary(base *session.Session, filterKey, text string, updatedAt time.Time) {
+	base.SummariesMu.Lock()
+	defer base.SummariesMu.Unlock()
 	if base.Summaries == nil {
 		base.Summaries = make(map[string]*session.Summary)
 	}
-	base.Summaries[filterKey] = &session.Summary{Summary: text, UpdatedAt: updatedAt}
-	return true, nil
+	base.Summaries[filterKey] = &session.Summary{
+		Summary:   text,
+		UpdatedAt: updatedAt,
+	}
 }
 
 func selectUpdatedAt(tmp *session.Session, prevAt, latestTs time.Time, hasDelta bool) time.Time {

--- a/session/internal/summary/summary.go
+++ b/session/internal/summary/summary.go
@@ -100,8 +100,17 @@ func SummarizeSession(
 	if base == nil {
 		return false, nil
 	}
-	unlock := lockSessionSummary(base, filterKey)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	unlock, err := lockSessionSummary(ctx, base, filterKey)
+	if err != nil {
+		return false, err
+	}
 	defer unlock()
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
 
 	// Get previous summary info.
 	var prevText string
@@ -200,6 +209,7 @@ const lastIncludedTsKey = "summary:last_included_ts"
 
 type summaryTriggerFilterKeyContextKey struct{}
 
+// summaryLockKey identifies the summary scope that must be serialized.
 type summaryLockKey struct {
 	appName   string
 	userID    string
@@ -207,48 +217,73 @@ type summaryLockKey struct {
 	filterKey string
 }
 
+// summaryLock is a cancelable binary semaphore with reference counting.
 type summaryLock struct {
-	mu   sync.Mutex
+	ch   chan struct{}
 	refs int
 }
 
+// summaryLockGroup stores in-flight summary locks keyed by session scope.
 type summaryLockGroup struct {
 	mu    sync.Mutex
 	locks map[summaryLockKey]*summaryLock
 }
 
+// sessionSummaryLocks prevents duplicate concurrent summaries in this process.
 var sessionSummaryLocks summaryLockGroup
 
-func (g *summaryLockGroup) lock(key summaryLockKey) func() {
+// lock acquires the keyed summary semaphore or returns when ctx is canceled.
+func (g *summaryLockGroup) lock(ctx context.Context, key summaryLockKey) (func(), error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	g.mu.Lock()
 	if g.locks == nil {
 		g.locks = make(map[summaryLockKey]*summaryLock)
 	}
 	l := g.locks[key]
 	if l == nil {
-		l = &summaryLock{}
+		l = &summaryLock{ch: make(chan struct{}, 1)}
+		l.ch <- struct{}{}
 		g.locks[key] = l
 	}
 	l.refs++
 	g.mu.Unlock()
 
-	l.mu.Lock()
+	select {
+	case <-l.ch:
+	case <-ctx.Done():
+		g.release(key, l)
+		return nil, ctx.Err()
+	}
 	return func() {
-		l.mu.Unlock()
-		g.mu.Lock()
-		defer g.mu.Unlock()
-		l.refs--
-		if l.refs == 0 && g.locks[key] == l {
-			delete(g.locks, key)
+		select {
+		case l.ch <- struct{}{}:
+		default:
 		}
+		g.release(key, l)
+	}, nil
+}
+
+// release drops one reference and removes the lock after the last waiter exits.
+func (g *summaryLockGroup) release(key summaryLockKey, l *summaryLock) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	l.refs--
+	if l.refs == 0 && g.locks[key] == l {
+		delete(g.locks, key)
 	}
 }
 
-func lockSessionSummary(sess *session.Session, filterKey string) func() {
+// lockSessionSummary serializes summary generation for a session/filter pair.
+func lockSessionSummary(ctx context.Context, sess *session.Session, filterKey string) (func(), error) {
 	if sess == nil {
-		return func() {}
+		return func() {}, nil
 	}
-	return sessionSummaryLocks.lock(summaryLockKey{
+	return sessionSummaryLocks.lock(ctx, summaryLockKey{
 		appName:   sess.AppName,
 		userID:    sess.UserID,
 		sessionID: sess.ID,

--- a/session/internal/summary/summary_test.go
+++ b/session/internal/summary/summary_test.go
@@ -344,6 +344,51 @@ func TestSummarizeSession_ConcurrentSameKeyRechecksDelta(t *testing.T) {
 	require.Equal(t, 1, s.callCount())
 }
 
+func TestSummarizeSession_CanceledWhileWaitingForSameKey(t *testing.T) {
+	now := time.Now()
+	base := &session.Session{ID: "s1", AppName: "a", UserID: "u"}
+	base.Events = []event.Event{
+		makeEvent("e1", now.Add(-1*time.Minute), "b1"),
+	}
+	s := &blockingSummarizer{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	firstDone := make(chan error, 1)
+
+	go func() {
+		_, err := SummarizeSession(context.Background(), s, base, "b1", false)
+		firstDone <- err
+	}()
+	<-s.started
+
+	ctx, cancel := context.WithCancel(context.Background())
+	secondDone := make(chan struct {
+		updated bool
+		err     error
+	}, 1)
+	go func() {
+		updated, err := SummarizeSession(ctx, s, base, "b1", false)
+		secondDone <- struct {
+			updated bool
+			err     error
+		}{updated: updated, err: err}
+	}()
+	cancel()
+
+	select {
+	case got := <-secondDone:
+		require.ErrorIs(t, got.err, context.Canceled)
+		require.False(t, got.updated)
+	case <-time.After(time.Second):
+		t.Fatal("canceled summary wait did not return")
+	}
+	require.Equal(t, 1, s.callCount())
+
+	close(s.release)
+	require.NoError(t, <-firstDone)
+}
+
 func TestSummarizeSession_EmptyDelta_WithForce(t *testing.T) {
 	now := time.Now()
 	base := &session.Session{ID: "s1", AppName: "a", UserID: "u"}

--- a/session/internal/summary/summary_test.go
+++ b/session/internal/summary/summary_test.go
@@ -125,6 +125,39 @@ func (f *fakeSummarizer) SetPrompt(prompt string)  {}
 func (f *fakeSummarizer) SetModel(m model.Model)   {}
 func (f *fakeSummarizer) Metadata() map[string]any { return map[string]any{} }
 
+type blockingSummarizer struct {
+	mu      sync.Mutex
+	calls   int
+	started chan struct{}
+	release chan struct{}
+}
+
+func (b *blockingSummarizer) ShouldSummarize(*session.Session) bool { return true }
+
+func (b *blockingSummarizer) Summarize(context.Context, *session.Session) (string, error) {
+	b.mu.Lock()
+	b.calls++
+	call := b.calls
+	if call == 1 {
+		close(b.started)
+	}
+	b.mu.Unlock()
+	if call == 1 {
+		<-b.release
+	}
+	return "sum", nil
+}
+
+func (b *blockingSummarizer) SetPrompt(string)         {}
+func (b *blockingSummarizer) SetModel(model.Model)     {}
+func (b *blockingSummarizer) Metadata() map[string]any { return map[string]any{} }
+
+func (b *blockingSummarizer) callCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.calls
+}
+
 type fakeSummarizerWithTs struct {
 	out string
 	ts  time.Time
@@ -272,6 +305,43 @@ func TestSummarizeSession_EmptyDelta_NoForce(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, updated)
 	require.Equal(t, "sum1", base.Summaries["b1"].Summary)
+}
+
+func TestSummarizeSession_ConcurrentSameKeyRechecksDelta(t *testing.T) {
+	now := time.Now()
+	base := &session.Session{ID: "s1", AppName: "a", UserID: "u"}
+	base.Events = []event.Event{
+		makeEvent("e1", now.Add(-1*time.Minute), "b1"),
+	}
+	s := &blockingSummarizer{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	results := make(chan bool, 2)
+	errs := make(chan error, 2)
+
+	go func() {
+		updated, err := SummarizeSession(context.Background(), s, base, "b1", false)
+		results <- updated
+		errs <- err
+	}()
+	<-s.started
+	go func() {
+		updated, err := SummarizeSession(context.Background(), s, base, "b1", false)
+		results <- updated
+		errs <- err
+	}()
+	close(s.release)
+
+	var updatedCount int
+	for i := 0; i < 2; i++ {
+		require.NoError(t, <-errs)
+		if <-results {
+			updatedCount++
+		}
+	}
+	require.Equal(t, 1, updatedCount)
+	require.Equal(t, 1, s.callCount())
 }
 
 func TestSummarizeSession_EmptyDelta_WithForce(t *testing.T) {

--- a/session/mysql/summary.go
+++ b/session/mysql/summary.go
@@ -106,9 +106,10 @@ func (s *Service) EnqueueSummaryJob(ctx context.Context, sess *session.Session, 
 		return s.asyncWorker.EnqueueJob(ctx, sess, filterKey, force)
 	}
 
-	// Fallback to synchronous processing.
+	// Fallback to synchronous processing with the same detached context that
+	// async workers use.
 	return isummary.CreateSessionSummaryWithCascade(
-		ctx,
+		isummary.DetachContext(ctx),
 		sess,
 		filterKey,
 		force,

--- a/session/pgvector/summary.go
+++ b/session/pgvector/summary.go
@@ -133,8 +133,10 @@ func (s *Service) EnqueueSummaryJob(
 			ctx, sess, filterKey, force,
 		)
 	}
+	// Fallback to synchronous processing with the same detached context that
+	// async workers use.
 	return isummary.CreateSessionSummaryWithCascade(
-		ctx,
+		isummary.DetachContext(ctx),
 		sess,
 		filterKey,
 		force,

--- a/session/postgres/summary.go
+++ b/session/postgres/summary.go
@@ -106,9 +106,10 @@ func (s *Service) EnqueueSummaryJob(ctx context.Context, sess *session.Session, 
 		return s.asyncWorker.EnqueueJob(ctx, sess, filterKey, force)
 	}
 
-	// Fallback to synchronous processing.
+	// Fallback to synchronous processing with the same detached context that
+	// async workers use.
 	return isummary.CreateSessionSummaryWithCascade(
-		ctx,
+		isummary.DetachContext(ctx),
 		sess,
 		filterKey,
 		force,

--- a/session/redis/summary.go
+++ b/session/redis/summary.go
@@ -186,9 +186,10 @@ func (s *Service) EnqueueSummaryJob(ctx context.Context, sess *session.Session, 
 		return s.asyncWorker.EnqueueJob(ctx, sess, filterKey, force)
 	}
 
-	// Fallback to synchronous processing.
+	// Fallback to synchronous processing with the same detached context that
+	// async workers use.
 	return isummary.CreateSessionSummaryWithCascade(
-		ctx,
+		isummary.DetachContext(ctx),
 		sess,
 		filterKey,
 		force,

--- a/session/sqlite/summary.go
+++ b/session/sqlite/summary.go
@@ -126,8 +126,10 @@ func (s *Service) EnqueueSummaryJob(
 		return s.asyncWorker.EnqueueJob(ctx, sess, filterKey, force)
 	}
 
+	// Fallback to synchronous processing with the same detached context that
+	// async workers use.
 	return isummary.CreateSessionSummaryWithCascade(
-		ctx,
+		isummary.DetachContext(ctx),
 		sess,
 		filterKey,
 		force,


### PR DESCRIPTION
## Summary
- Serialize summary generation per session/filter key so concurrent sync and async summary triggers do not issue duplicate model calls.
- Recheck summary delta after waiting for an in-flight summary, allowing redundant callers to skip once the first summary updates state.
- Add a regression test covering concurrent summary attempts for the same session/filter key.

## Test plan
- `go test ./session/internal/summary`
- `go test ./session/...`