### PR TITLE
{team, runner, internal, docs}: add independent swarm sessions

### DIFF
--- a/docs/mkdocs/en/team.md
+++ b/docs/mkdocs/en/team.md
@@ -398,6 +398,32 @@ This is different from `await_user_reply` plus
 - `await_user_reply` is a one-shot route. It is consumed by exactly one future
   user turn and then cleared automatically.
 
+### Independent member history (optional)
+
+By default, Swarm member events are persisted in the root session. If members
+need private history, enable independent member sessions:
+
+```go
+tm, err := team.NewSwarm(
+    "support",
+    "main_agent",
+    []agent.Agent{mainAgent, refundAgent},
+    team.WithSwarmIndependentAgents(),
+)
+```
+
+With this enabled, the entry member continues to use the root session. Other
+members use stable sessions derived from the root session, team name, and
+member name. Member events are still emitted to the caller, but isolated member
+transcripts are persisted into their member sessions instead of the root
+session. The runner completion event remains a root-run marker; consume the
+forwarded member event for the member's final reply.
+
+This option only controls history isolation. If the last transfer target should
+receive future user messages, combine it with `team.WithCrossRequestTransfer(true)`.
+When both options are enabled, the next user message is persisted to the active
+member session before that member runs.
+
 ### Rewrite handoff input (optional)
 
 By default, when a Swarm member hands off with `transfer_to_agent`, the target member receives the tool call's `message` field as its user input. If your application needs to construct the target member's first input from the original user input, a template, or other context, configure `team.WithSwarmHandoffInputBuilder`:

--- a/docs/mkdocs/zh/team.md
+++ b/docs/mkdocs/zh/team.md
@@ -368,6 +368,23 @@ Session State 实现，因此需要复用同一个 session。
   transfer，后续用户消息都会继续落到当前 active member。
 - `await_user_reply` 是一次性路由。它只消费下一条用户消息，消费后会自动清掉。
 
+### 独立成员历史（可选）
+
+默认情况下，Swarm 成员事件会持久化到 root session。如果成员需要私有历史，可以开启独立成员 session：
+
+```go
+tm, err := team.NewSwarm(
+    "support",
+    "main_agent",
+    []agent.Agent{mainAgent, refundAgent},
+    team.WithSwarmIndependentAgents(),
+)
+```
+
+开启后，入口成员继续使用 root session；其他成员使用由 root session、team name 和成员名派生出的稳定成员 session。成员事件仍然会输出给调用方，但独立成员的 transcript 会持久化到对应成员 session，而不是 root session。Runner completion event 仍然只是 root run 的结束标记；成员最终回复请消费被转发出来的成员事件。
+
+这个 option 只控制历史隔离。如果希望最后一次 transfer 的目标成员继续接收后续用户输入，需要同时配置 `team.WithCrossRequestTransfer(true)`。两者同时开启时，下一条用户输入会在该成员运行前持久化到 active member session。
+
 ### 改写 handoff 输入（可选）
 
 默认情况下，Swarm 成员通过 `transfer_to_agent` 交接时，目标成员收到的用户输入就是工具调用中的 `message` 字段。如果业务希望用原始用户输入、模板或其他上下文重新构造目标成员的首轮输入，可以配置 `team.WithSwarmHandoffInputBuilder`：

--- a/internal/flow/processor/transfer.go
+++ b/internal/flow/processor/transfer.go
@@ -75,6 +75,7 @@ func (p *TransferResponseProcessor) ProcessResponse(
 	var nodeTimeout time.Duration
 	var transferCustomizer itransfer.InvocationCustomizer
 	var transferCompletionHandler itransfer.CompletionObserver
+	var transferTerminalErrorHandler itransfer.TerminalErrorObserver
 
 	// Look up the target agent from the current agent's sub-agents.
 	var targetAgent agent.Agent
@@ -124,6 +125,7 @@ func (p *TransferResponseProcessor) ProcessResponse(
 		nodeTimeout = targetTimeout
 		transferCustomizer = transferInvocationCustomizerFor(controller)
 		transferCompletionHandler = transferCompletionHandlerFor(controller)
+		transferTerminalErrorHandler = transferTerminalErrorHandlerFor(controller)
 	}
 
 	targetInvocation, targetMessageBeforeCustomize, err := prepareTransferTargetInvocation(
@@ -231,6 +233,7 @@ func (p *TransferResponseProcessor) ProcessResponse(
 		targetEventChan,
 		ch,
 		transferCompletionHandler,
+		transferTerminalErrorHandler,
 	) {
 		return
 	}
@@ -261,10 +264,23 @@ func forwardTransferTargetEvents(
 	events <-chan *event.Event,
 	out chan<- *event.Event,
 	completionHandler itransfer.CompletionObserver,
+	terminalErrorHandler itransfer.TerminalErrorObserver,
 ) bool {
 	result := transferForwardResult{}
 	for targetEvent := range events {
 		result.observe(targetEvent, target.InvocationID)
+		if result.shouldNotifyTerminalError(
+			terminalErrorHandler,
+			targetEvent,
+			target.InvocationID,
+		) {
+			terminalErrorHandler.OnTransferTerminalError(
+				ctx,
+				source,
+				target,
+				targetEvent,
+			)
+		}
 		if result.shouldNotifyCompletion(completionHandler, targetEvent, target.InvocationID) {
 			result.completed = true
 			completionHandler.OnTransferComplete(ctx, source, target, targetEvent)
@@ -310,6 +326,16 @@ func (r transferForwardResult) shouldNotifyCompletion(
 		evt.Response != nil &&
 		!r.terminalErrored &&
 		evt.Response.Done
+}
+
+func (r transferForwardResult) shouldNotifyTerminalError(
+	handler itransfer.TerminalErrorObserver,
+	evt *event.Event,
+	invocationID string,
+) bool {
+	return handler != nil &&
+		r.terminalErrored &&
+		isTransferTerminalErrorEvent(evt, invocationID)
 }
 
 func (r transferForwardResult) needsSyntheticCompletion() bool {
@@ -446,6 +472,16 @@ func transferCompletionHandlerFor(
 	controller agent.TransferController,
 ) itransfer.CompletionObserver {
 	handler, ok := controller.(itransfer.CompletionObserver)
+	if !ok {
+		return nil
+	}
+	return handler
+}
+
+func transferTerminalErrorHandlerFor(
+	controller agent.TransferController,
+) itransfer.TerminalErrorObserver {
+	handler, ok := controller.(itransfer.TerminalErrorObserver)
 	if !ok {
 		return nil
 	}

--- a/internal/flow/processor/transfer.go
+++ b/internal/flow/processor/transfer.go
@@ -25,9 +25,8 @@ import (
 )
 
 const (
-	swarmTeamNameKey          = "swarm_team_name"
-	swarmActiveAgentKeyPrefix = "swarm_active_agent:"
-	swarmTraceNodeIDKey       = "__swarm_trace_node_id__"
+	swarmTeamNameKey    = "swarm_team_name"
+	swarmTraceNodeIDKey = "__swarm_trace_node_id__"
 )
 
 // TransferResponseProcessor handles agent transfer operations after LLM responses.
@@ -75,6 +74,7 @@ func (p *TransferResponseProcessor) ProcessResponse(
 	targetAgentName := transferInfo.TargetAgentName
 	var nodeTimeout time.Duration
 	var transferCustomizer itransfer.InvocationCustomizer
+	var transferCompletionHandler itransfer.CompletionObserver
 
 	// Look up the target agent from the current agent's sub-agents.
 	var targetAgent agent.Agent
@@ -123,6 +123,7 @@ func (p *TransferResponseProcessor) ProcessResponse(
 		}
 		nodeTimeout = targetTimeout
 		transferCustomizer = transferInvocationCustomizerFor(controller)
+		transferCompletionHandler = transferCompletionHandlerFor(controller)
 	}
 
 	targetInvocation, targetMessageBeforeCustomize, err := prepareTransferTargetInvocation(
@@ -223,9 +224,24 @@ func (p *TransferResponseProcessor) ProcessResponse(
 	}
 
 	// Forward all events from the target agent.
+	targetCompleted := false
+	targetDelegated := false
+	targetErrored := false
 	for targetEvent := range targetEventChan {
-		if targetEvent != nil && targetEvent.Response != nil && targetEvent.Response.Done {
-			p.saveActiveAgent(ctx, invocation, targetAgent, targetEvent)
+		if isTransferDelegationEvent(targetEvent) {
+			targetDelegated = true
+		}
+		if isTransferErrorEvent(targetEvent) {
+			targetErrored = true
+		}
+		if transferCompletionHandler != nil &&
+			targetEvent != nil &&
+			targetEvent.InvocationID == targetInvocation.InvocationID &&
+			targetEvent.Response != nil &&
+			!targetErrored &&
+			targetEvent.Response.Done {
+			targetCompleted = true
+			transferCompletionHandler.OnTransferComplete(ctx, invocation, targetInvocation, targetEvent)
 		}
 		if err := event.EmitEvent(ctx, ch, targetEvent); err != nil {
 			return
@@ -235,6 +251,14 @@ func (p *TransferResponseProcessor) ProcessResponse(
 			"Transfer response processor: forwarded event from "+
 				"target agent %s",
 			targetAgent.Info().Name,
+		)
+	}
+	if transferCompletionHandler != nil && !targetCompleted && !targetDelegated && !targetErrored {
+		transferCompletionHandler.OnTransferComplete(
+			ctx,
+			invocation,
+			targetInvocation,
+			syntheticTransferCompletionEvent(targetInvocation),
 		)
 	}
 
@@ -301,39 +325,12 @@ func shouldEmitTransferMessageEcho(
 	return hasTransferMessage || !reflect.DeepEqual(beforeCustomize, afterCustomize)
 }
 
-// saveActiveAgent saves the target agent to session state for Swarm cross-request transfer
-// by attaching a StateDelta to the final response event.
-func (p *TransferResponseProcessor) saveActiveAgent(
-	ctx context.Context,
-	invocation *agent.Invocation,
-	targetAgent agent.Agent,
-	targetEvent *event.Event,
-) {
-	if invocation == nil || invocation.Session == nil || targetEvent == nil {
-		return
-	}
-
-	// Check if this session belongs to a Swarm Team with cross-request transfer enabled.
-	// In Swarm mode with cross-request transfer, Team.runSwarm() sets SwarmTeamNameKey in session state.
-	// This works for both direct Team transfers and member-to-member transfers.
-	teamNameBytes, ok := invocation.Session.GetState(swarmTeamNameKey)
-	if !ok || len(teamNameBytes) == 0 {
-		// Not a Swarm team session with cross-request transfer enabled, skip.
-		return
-	}
-	teamName := string(teamNameBytes)
-
-	if targetEvent.StateDelta == nil {
-		targetEvent.StateDelta = make(map[string][]byte)
-	}
-	// Save the target agent name for cross-request transfer.
-	// Next user message will start from this agent.
-	targetEvent.StateDelta[swarmActiveAgentKey(teamName)] = []byte(targetAgent.Info().Name)
-}
-
 func transferTargetTraceNodeID(invocation *agent.Invocation, targetAgent agent.Agent) string {
 	if invocation == nil || targetAgent == nil {
 		return ""
+	}
+	if root := agent.InvocationTeamMemberTraceRoot(invocation); root != "" {
+		return istructure.JoinNodeID(root, targetAgent.Info().Name)
 	}
 	if invocation.Session != nil {
 		if traceRootBytes, ok := invocation.Session.GetState(swarmTraceNodeIDKey); ok && len(traceRootBytes) > 0 {
@@ -359,6 +356,27 @@ func transferTargetSurfaceRootNodeID(invocation *agent.Invocation, targetAgent a
 	return transferTargetTraceNodeID(invocation, targetAgent)
 }
 
+func isTransferDelegationEvent(evt *event.Event) bool {
+	if evt == nil {
+		return false
+	}
+	return evt.Object == model.ObjectTypeTransfer || evt.ContainsTag(event.TransferTag)
+}
+
+func isTransferErrorEvent(evt *event.Event) bool {
+	return evt != nil && evt.IsError()
+}
+
+func syntheticTransferCompletionEvent(invocation *agent.Invocation) *event.Event {
+	invocationID := ""
+	author := ""
+	if invocation != nil {
+		invocationID = invocation.InvocationID
+		author = invocation.AgentName
+	}
+	return event.NewResponseEvent(invocationID, author, &model.Response{Done: true})
+}
+
 func parentTraceNodeID(nodeID string) string {
 	if nodeID == "" {
 		return ""
@@ -370,13 +388,6 @@ func parentTraceNodeID(nodeID string) string {
 	return nodeID[:lastSlash]
 }
 
-func swarmActiveAgentKey(teamName string) string {
-	if teamName == "" {
-		return swarmActiveAgentKeyPrefix
-	}
-	return swarmActiveAgentKeyPrefix + teamName
-}
-
 func transferInvocationCustomizerFor(
 	controller agent.TransferController,
 ) itransfer.InvocationCustomizer {
@@ -385,4 +396,14 @@ func transferInvocationCustomizerFor(
 		return nil
 	}
 	return customizer
+}
+
+func transferCompletionHandlerFor(
+	controller agent.TransferController,
+) itransfer.CompletionObserver {
+	handler, ok := controller.(itransfer.CompletionObserver)
+	if !ok {
+		return nil
+	}
+	return handler
 }

--- a/internal/flow/processor/transfer.go
+++ b/internal/flow/processor/transfer.go
@@ -226,19 +226,19 @@ func (p *TransferResponseProcessor) ProcessResponse(
 	// Forward all events from the target agent.
 	targetCompleted := false
 	targetDelegated := false
-	targetErrored := false
+	targetTerminalErrored := false
 	for targetEvent := range targetEventChan {
 		if isTransferDelegationEvent(targetEvent) {
 			targetDelegated = true
 		}
-		if isTransferErrorEvent(targetEvent) {
-			targetErrored = true
+		if isTransferTerminalErrorEvent(targetEvent, targetInvocation.InvocationID) {
+			targetTerminalErrored = true
 		}
 		if transferCompletionHandler != nil &&
 			targetEvent != nil &&
 			targetEvent.InvocationID == targetInvocation.InvocationID &&
 			targetEvent.Response != nil &&
-			!targetErrored &&
+			!targetTerminalErrored &&
 			targetEvent.Response.Done {
 			targetCompleted = true
 			transferCompletionHandler.OnTransferComplete(ctx, invocation, targetInvocation, targetEvent)
@@ -253,7 +253,7 @@ func (p *TransferResponseProcessor) ProcessResponse(
 			targetAgent.Info().Name,
 		)
 	}
-	if transferCompletionHandler != nil && !targetCompleted && !targetDelegated && !targetErrored {
+	if transferCompletionHandler != nil && !targetCompleted && !targetDelegated && !targetTerminalErrored {
 		transferCompletionHandler.OnTransferComplete(
 			ctx,
 			invocation,
@@ -363,8 +363,8 @@ func isTransferDelegationEvent(evt *event.Event) bool {
 	return evt.Object == model.ObjectTypeTransfer || evt.ContainsTag(event.TransferTag)
 }
 
-func isTransferErrorEvent(evt *event.Event) bool {
-	return evt != nil && evt.IsError()
+func isTransferTerminalErrorEvent(evt *event.Event, invocationID string) bool {
+	return evt != nil && evt.InvocationID == invocationID && evt.IsTerminalError()
 }
 
 func syntheticTransferCompletionEvent(invocation *agent.Invocation) *event.Event {
@@ -374,7 +374,9 @@ func syntheticTransferCompletionEvent(invocation *agent.Invocation) *event.Event
 		invocationID = invocation.InvocationID
 		author = invocation.AgentName
 	}
-	return event.NewResponseEvent(invocationID, author, &model.Response{Done: true})
+	evt := event.NewResponseEvent(invocationID, author, &model.Response{Done: true})
+	itransfer.MarkSyntheticCompletionEvent(evt)
+	return evt
 }
 
 func parentTraceNodeID(nodeID string) string {

--- a/internal/flow/processor/transfer.go
+++ b/internal/flow/processor/transfer.go
@@ -223,43 +223,16 @@ func (p *TransferResponseProcessor) ProcessResponse(
 		return
 	}
 
-	// Forward all events from the target agent.
-	targetCompleted := false
-	targetDelegated := false
-	targetTerminalErrored := false
-	for targetEvent := range targetEventChan {
-		if isTransferDelegationEvent(targetEvent) {
-			targetDelegated = true
-		}
-		if isTransferTerminalErrorEvent(targetEvent, targetInvocation.InvocationID) {
-			targetTerminalErrored = true
-		}
-		if transferCompletionHandler != nil &&
-			targetEvent != nil &&
-			targetEvent.InvocationID == targetInvocation.InvocationID &&
-			targetEvent.Response != nil &&
-			!targetTerminalErrored &&
-			targetEvent.Response.Done {
-			targetCompleted = true
-			transferCompletionHandler.OnTransferComplete(ctx, invocation, targetInvocation, targetEvent)
-		}
-		if err := event.EmitEvent(ctx, ch, targetEvent); err != nil {
-			return
-		}
-		log.DebugfContext(
-			ctx,
-			"Transfer response processor: forwarded event from "+
-				"target agent %s",
-			targetAgent.Info().Name,
-		)
-	}
-	if transferCompletionHandler != nil && !targetCompleted && !targetDelegated && !targetTerminalErrored {
-		transferCompletionHandler.OnTransferComplete(
-			ctx,
-			invocation,
-			targetInvocation,
-			syntheticTransferCompletionEvent(targetInvocation),
-		)
+	if !forwardTransferTargetEvents(
+		ctx,
+		invocation,
+		targetInvocation,
+		targetAgent,
+		targetEventChan,
+		ch,
+		transferCompletionHandler,
+	) {
+		return
 	}
 
 	// Clear the transfer info and end the original invocation to stop further LLM calls.
@@ -272,6 +245,75 @@ func (p *TransferResponseProcessor) ProcessResponse(
 	)
 	invocation.TransferInfo = nil
 	invocation.EndInvocation = p.endInvocationAfterTransfer
+}
+
+type transferForwardResult struct {
+	completed       bool
+	delegated       bool
+	terminalErrored bool
+}
+
+func forwardTransferTargetEvents(
+	ctx context.Context,
+	source *agent.Invocation,
+	target *agent.Invocation,
+	targetAgent agent.Agent,
+	events <-chan *event.Event,
+	out chan<- *event.Event,
+	completionHandler itransfer.CompletionObserver,
+) bool {
+	result := transferForwardResult{}
+	for targetEvent := range events {
+		result.observe(targetEvent, target.InvocationID)
+		if result.shouldNotifyCompletion(completionHandler, targetEvent, target.InvocationID) {
+			result.completed = true
+			completionHandler.OnTransferComplete(ctx, source, target, targetEvent)
+		}
+		if err := event.EmitEvent(ctx, out, targetEvent); err != nil {
+			return false
+		}
+		log.DebugfContext(
+			ctx,
+			"Transfer response processor: forwarded event from "+
+				"target agent %s",
+			targetAgent.Info().Name,
+		)
+	}
+	if completionHandler != nil && result.needsSyntheticCompletion() {
+		completionHandler.OnTransferComplete(
+			ctx,
+			source,
+			target,
+			syntheticTransferCompletionEvent(target),
+		)
+	}
+	return true
+}
+
+func (r *transferForwardResult) observe(evt *event.Event, invocationID string) {
+	if isTransferDelegationEvent(evt) {
+		r.delegated = true
+	}
+	if isTransferTerminalErrorEvent(evt, invocationID) {
+		r.terminalErrored = true
+	}
+}
+
+func (r transferForwardResult) shouldNotifyCompletion(
+	handler itransfer.CompletionObserver,
+	evt *event.Event,
+	invocationID string,
+) bool {
+	return handler != nil &&
+		evt != nil &&
+		evt.InvocationID == invocationID &&
+		evt.Response != nil &&
+		!r.terminalErrored &&
+		evt.Response.Done
+}
+
+func (r transferForwardResult) needsSyntheticCompletion() bool {
+	return !r.completed && !r.delegated && !r.terminalErrored
 }
 
 func prepareTransferTargetInvocation(

--- a/internal/flow/processor/transfer_test.go
+++ b/internal/flow/processor/transfer_test.go
@@ -1001,6 +1001,40 @@ func TestTransferResponseProc_CompletionHandlerDoesNotFallbackAfterTargetError(t
 	require.Zero(t, handler.count)
 }
 
+func TestTransferResponseProc_TerminalErrorHandlerMutatesTargetErrorBeforeForward(t *testing.T) {
+	target := &errorResponseAgent{name: "child"}
+	parent := &parentAgent{child: target}
+	handler := &terminalErrorTransferController{}
+	inv := &agent.Invocation{
+		Agent:        parent,
+		AgentName:    "parent",
+		InvocationID: "inv-terminal-error",
+		RunOptions: agent.RunOptions{RuntimeState: map[string]any{
+			agent.RuntimeStateKeyTransferController: handler,
+		}},
+		TransferInfo: &agent.TransferInfo{TargetAgentName: "child"},
+	}
+	rsp := &model.Response{ID: "r-terminal-error"}
+	out := make(chan *event.Event, 10)
+	NewTransferResponseProcessor(true).ProcessResponse(
+		context.Background(),
+		inv,
+		&model.Request{},
+		rsp,
+		out,
+	)
+	close(out)
+	var targetErr *event.Event
+	for evt := range out {
+		if evt != nil && evt.IsTerminalError() && evt.Author == "child" {
+			targetErr = evt
+		}
+	}
+	require.Equal(t, 1, handler.terminalErrors)
+	require.NotNil(t, targetErr)
+	require.Equal(t, []byte("child"), targetErr.StateDelta["owner"])
+}
+
 func TestTransferResponseProc_CompletionHandlerAllowsDoneAfterNonTerminalTargetError(t *testing.T) {
 	target := &nonTerminalErrorThenDoneAgent{name: "child"}
 	parent := &parentAgent{child: target}
@@ -1060,6 +1094,31 @@ func (h *completionInvocationCustomizer) CustomizeTransferInvocation(
 	*agent.Invocation,
 ) error {
 	return nil
+}
+
+type terminalErrorTransferController struct {
+	terminalErrors int
+}
+
+func (h *terminalErrorTransferController) OnTransfer(
+	context.Context,
+	string,
+	string,
+) (time.Duration, error) {
+	return 0, nil
+}
+
+func (h *terminalErrorTransferController) OnTransferTerminalError(
+	_ context.Context,
+	_ *agent.Invocation,
+	target *agent.Invocation,
+	targetEvent *event.Event,
+) {
+	h.terminalErrors++
+	if targetEvent.StateDelta == nil {
+		targetEvent.StateDelta = make(map[string][]byte)
+	}
+	targetEvent.StateDelta["owner"] = []byte(target.AgentName)
 }
 
 func TestTransferResponseProc_ControllerCompletionMethodIsObserved(t *testing.T) {

--- a/internal/flow/processor/transfer_test.go
+++ b/internal/flow/processor/transfer_test.go
@@ -710,6 +710,39 @@ func (d *errorResponseAgent) Run(_ context.Context, inv *agent.Invocation) (<-ch
 	return ch, nil
 }
 
+type nonTerminalErrorThenDoneAgent struct {
+	name string
+}
+
+func (d *nonTerminalErrorThenDoneAgent) Info() agent.Info { return agent.Info{Name: d.name} }
+func (d *nonTerminalErrorThenDoneAgent) SubAgents() []agent.Agent {
+	return nil
+}
+func (d *nonTerminalErrorThenDoneAgent) FindSubAgent(string) agent.Agent { return nil }
+func (d *nonTerminalErrorThenDoneAgent) Tools() []tool.Tool              { return nil }
+func (d *nonTerminalErrorThenDoneAgent) Run(_ context.Context, inv *agent.Invocation) (<-chan *event.Event, error) {
+	ch := make(chan *event.Event, 2)
+	go func() {
+		defer close(ch)
+		ch <- event.NewResponseEvent(
+			inv.InvocationID,
+			d.name,
+			&model.Response{
+				Error: &model.ResponseError{
+					Type:    model.ErrorTypeFlowError,
+					Message: "recoverable target signal",
+				},
+			},
+		)
+		ch <- event.NewResponseEvent(
+			inv.InvocationID,
+			d.name,
+			&model.Response{Done: true},
+		)
+	}()
+	return ch, nil
+}
+
 type forwardedDoneResponseAgent struct {
 	name string
 }
@@ -966,6 +999,35 @@ func TestTransferResponseProc_CompletionHandlerDoesNotFallbackAfterTargetError(t
 	for range out {
 	}
 	require.Zero(t, handler.count)
+}
+
+func TestTransferResponseProc_CompletionHandlerAllowsDoneAfterNonTerminalTargetError(t *testing.T) {
+	target := &nonTerminalErrorThenDoneAgent{name: "child"}
+	parent := &parentAgent{child: target}
+	handler := &completionInvocationCustomizer{}
+	inv := &agent.Invocation{
+		Agent:        parent,
+		AgentName:    "parent",
+		InvocationID: "inv-completion-target-recovered",
+		RunOptions: agent.RunOptions{RuntimeState: map[string]any{
+			agent.RuntimeStateKeyTransferController: handler,
+		}},
+		TransferInfo: &agent.TransferInfo{TargetAgentName: "child"},
+	}
+	rsp := &model.Response{ID: "r-target-recovered"}
+	out := make(chan *event.Event, 10)
+	NewTransferResponseProcessor(true).ProcessResponse(
+		context.Background(),
+		inv,
+		&model.Request{},
+		rsp,
+		out,
+	)
+	close(out)
+	for range out {
+	}
+	require.Equal(t, 1, handler.count)
+	require.True(t, handler.done)
 }
 
 type controllerCompletionObserver struct {

--- a/internal/flow/processor/transfer_test.go
+++ b/internal/flow/processor/transfer_test.go
@@ -22,7 +22,6 @@ import (
 	itransfer "trpc.group/trpc-go/trpc-agent-go/internal/transfer"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
-	"trpc.group/trpc-go/trpc-agent-go/team"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
 
@@ -689,22 +688,151 @@ func (d *doneResponseAgent) Run(_ context.Context, inv *agent.Invocation) (<-cha
 	return ch, nil
 }
 
-func TestTransferResponseProc_CrossRequestTransfer_SetsStateDelta(t *testing.T) {
+type errorResponseAgent struct {
+	name string
+}
+
+func (d *errorResponseAgent) Info() agent.Info                { return agent.Info{Name: d.name} }
+func (d *errorResponseAgent) SubAgents() []agent.Agent        { return nil }
+func (d *errorResponseAgent) FindSubAgent(string) agent.Agent { return nil }
+func (d *errorResponseAgent) Tools() []tool.Tool              { return nil }
+func (d *errorResponseAgent) Run(_ context.Context, inv *agent.Invocation) (<-chan *event.Event, error) {
+	ch := make(chan *event.Event, 1)
+	go func() {
+		defer close(ch)
+		ch <- event.NewErrorEvent(
+			inv.InvocationID,
+			d.name,
+			model.ErrorTypeFlowError,
+			"target failed",
+		)
+	}()
+	return ch, nil
+}
+
+type forwardedDoneResponseAgent struct {
+	name string
+}
+
+func (d *forwardedDoneResponseAgent) Info() agent.Info { return agent.Info{Name: d.name} }
+func (d *forwardedDoneResponseAgent) SubAgents() []agent.Agent {
+	return nil
+}
+func (d *forwardedDoneResponseAgent) FindSubAgent(string) agent.Agent { return nil }
+func (d *forwardedDoneResponseAgent) Tools() []tool.Tool              { return nil }
+func (d *forwardedDoneResponseAgent) Run(_ context.Context, inv *agent.Invocation) (<-chan *event.Event, error) {
+	ch := make(chan *event.Event, 2)
+	go func() {
+		defer close(ch)
+		ch <- event.NewResponseEvent(
+			inv.InvocationID,
+			d.name,
+			&model.Response{Done: true},
+		)
+		descendant := event.NewResponseEvent(
+			"descendant-invocation",
+			"descendant",
+			&model.Response{Done: true},
+		)
+		descendant.ParentInvocationID = inv.InvocationID
+		ch <- descendant
+	}()
+	return ch, nil
+}
+
+type descendantOnlyDoneResponseAgent struct {
+	name string
+}
+
+func (d *descendantOnlyDoneResponseAgent) Info() agent.Info { return agent.Info{Name: d.name} }
+func (d *descendantOnlyDoneResponseAgent) SubAgents() []agent.Agent {
+	return nil
+}
+func (d *descendantOnlyDoneResponseAgent) FindSubAgent(string) agent.Agent { return nil }
+func (d *descendantOnlyDoneResponseAgent) Tools() []tool.Tool              { return nil }
+func (d *descendantOnlyDoneResponseAgent) Run(_ context.Context, inv *agent.Invocation) (<-chan *event.Event, error) {
+	ch := make(chan *event.Event, 1)
+	go func() {
+		defer close(ch)
+		descendant := event.NewResponseEvent(
+			"descendant-invocation",
+			"descendant",
+			&model.Response{Done: true},
+		)
+		descendant.ParentInvocationID = inv.InvocationID
+		ch <- descendant
+	}()
+	return ch, nil
+}
+
+type nestedDelegationResponseAgent struct {
+	name string
+}
+
+func (d *nestedDelegationResponseAgent) Info() agent.Info { return agent.Info{Name: d.name} }
+func (d *nestedDelegationResponseAgent) SubAgents() []agent.Agent {
+	return nil
+}
+func (d *nestedDelegationResponseAgent) FindSubAgent(string) agent.Agent { return nil }
+func (d *nestedDelegationResponseAgent) Tools() []tool.Tool              { return nil }
+func (d *nestedDelegationResponseAgent) Run(_ context.Context, inv *agent.Invocation) (<-chan *event.Event, error) {
+	ch := make(chan *event.Event, 2)
+	go func() {
+		defer close(ch)
+		ch <- event.New(
+			inv.InvocationID,
+			d.name,
+			event.WithObject(model.ObjectTypeTransfer),
+			event.WithTag(event.TransferTag),
+		)
+		descendant := event.NewResponseEvent(
+			"descendant-invocation",
+			"descendant",
+			&model.Response{Done: true},
+		)
+		descendant.ParentInvocationID = inv.InvocationID
+		ch <- descendant
+	}()
+	return ch, nil
+}
+
+type recordingTransferCompletionObserver struct {
+	sourceAgent string
+	targetAgent string
+	count       int
+	done        bool
+}
+
+func (h *recordingTransferCompletionObserver) OnTransferComplete(
+	_ context.Context,
+	source *agent.Invocation,
+	target *agent.Invocation,
+	targetEvent *event.Event,
+) {
+	if source != nil {
+		h.sourceAgent = source.AgentName
+	}
+	if target != nil {
+		h.targetAgent = target.AgentName
+	}
+	h.count++
+	h.done = targetEvent != nil && targetEvent.Response != nil && targetEvent.Response.Done
+}
+
+func TestTransferResponseProc_CompletionHandlerFromController(t *testing.T) {
 	target := &doneResponseAgent{name: "child"}
 	parent := &parentAgent{child: target}
-
-	sess := session.NewSession("app", "user", "sess")
-	sess.SetState(team.SwarmTeamNameKey, []byte("team"))
-
+	handler := &completionInvocationCustomizer{}
 	inv := &agent.Invocation{
 		Agent:        parent,
 		AgentName:    "parent",
-		InvocationID: "inv-xrt",
-		Session:      sess,
+		InvocationID: "inv-completion",
+		RunOptions: agent.RunOptions{RuntimeState: map[string]any{
+			agent.RuntimeStateKeyTransferController: handler,
+		}},
 		TransferInfo: &agent.TransferInfo{TargetAgentName: "child"},
 	}
 	rsp := &model.Response{ID: "r1"}
-
 	out := make(chan *event.Event, 10)
 	NewTransferResponseProcessor(true).ProcessResponse(
 		context.Background(),
@@ -714,32 +842,28 @@ func TestTransferResponseProc_CrossRequestTransfer_SetsStateDelta(t *testing.T) 
 		out,
 	)
 	close(out)
-
-	var doneEvt *event.Event
-	for evt := range out {
-		if evt != nil && evt.Author == "child" && evt.Response != nil && evt.Response.Done {
-			doneEvt = evt
-		}
+	for range out {
 	}
-	require.NotNil(t, doneEvt)
-	require.Equal(t, []byte("child"), doneEvt.StateDelta[team.SwarmActiveAgentKeyPrefix+"team"])
+	require.Equal(t, "parent", handler.sourceAgent)
+	require.Equal(t, "child", handler.targetAgent)
+	require.Equal(t, 1, handler.count)
+	require.True(t, handler.done)
 }
 
-func TestTransferResponseProc_CrossRequestTransfer_SkipsStateDeltaWithoutMarker(t *testing.T) {
-	target := &doneResponseAgent{name: "child"}
+func TestTransferResponseProc_CompletionHandlerIgnoresForwardedDescendantDone(t *testing.T) {
+	target := &forwardedDoneResponseAgent{name: "child"}
 	parent := &parentAgent{child: target}
-
-	sess := session.NewSession("app", "user", "sess")
-
+	handler := &completionInvocationCustomizer{}
 	inv := &agent.Invocation{
 		Agent:        parent,
 		AgentName:    "parent",
-		InvocationID: "inv-xrt-skip",
-		Session:      sess,
+		InvocationID: "inv-completion-forwarded",
+		RunOptions: agent.RunOptions{RuntimeState: map[string]any{
+			agent.RuntimeStateKeyTransferController: handler,
+		}},
 		TransferInfo: &agent.TransferInfo{TargetAgentName: "child"},
 	}
-	rsp := &model.Response{ID: "r1"}
-
+	rsp := &model.Response{ID: "r-forwarded"}
 	out := make(chan *event.Event, 10)
 	NewTransferResponseProcessor(true).ProcessResponse(
 		context.Background(),
@@ -749,43 +873,157 @@ func TestTransferResponseProc_CrossRequestTransfer_SkipsStateDeltaWithoutMarker(
 		out,
 	)
 	close(out)
-
-	for evt := range out {
-		if evt == nil || evt.Author != "child" || evt.Response == nil || !evt.Response.Done {
-			continue
-		}
-		_, ok := evt.StateDelta[team.SwarmActiveAgentKeyPrefix+"team"]
-		require.False(t, ok)
-		return
+	for range out {
 	}
-	t.Fatal("missing done response event from child")
+	require.Equal(t, "parent", handler.sourceAgent)
+	require.Equal(t, "child", handler.targetAgent)
+	require.Equal(t, 1, handler.count)
+	require.True(t, handler.done)
 }
 
-func TestTransferResponseProc_SaveActiveAgent_EarlyReturns(t *testing.T) {
-	proc := NewTransferResponseProcessor(true)
+func TestTransferResponseProc_CompletionHandlerFallsBackWhenTargetForwardsOnlyDescendantDone(t *testing.T) {
+	target := &descendantOnlyDoneResponseAgent{name: "child"}
+	parent := &parentAgent{child: target}
+	handler := &completionInvocationCustomizer{}
+	inv := &agent.Invocation{
+		Agent:        parent,
+		AgentName:    "parent",
+		InvocationID: "inv-completion-descendant-only",
+		RunOptions: agent.RunOptions{RuntimeState: map[string]any{
+			agent.RuntimeStateKeyTransferController: handler,
+		}},
+		TransferInfo: &agent.TransferInfo{TargetAgentName: "child"},
+	}
+	rsp := &model.Response{ID: "r-descendant-only"}
+	out := make(chan *event.Event, 10)
+	NewTransferResponseProcessor(true).ProcessResponse(
+		context.Background(),
+		inv,
+		&model.Request{},
+		rsp,
+		out,
+	)
+	close(out)
+	for range out {
+	}
+	require.Equal(t, "parent", handler.sourceAgent)
+	require.Equal(t, "child", handler.targetAgent)
+	require.Equal(t, 1, handler.count)
+	require.True(t, handler.done)
+}
+
+func TestTransferResponseProc_CompletionHandlerDoesNotFallbackAfterNestedDelegation(t *testing.T) {
+	target := &nestedDelegationResponseAgent{name: "child"}
+	parent := &parentAgent{child: target}
+	handler := &completionInvocationCustomizer{}
+	inv := &agent.Invocation{
+		Agent:        parent,
+		AgentName:    "parent",
+		InvocationID: "inv-completion-nested-delegation",
+		RunOptions: agent.RunOptions{RuntimeState: map[string]any{
+			agent.RuntimeStateKeyTransferController: handler,
+		}},
+		TransferInfo: &agent.TransferInfo{TargetAgentName: "child"},
+	}
+	rsp := &model.Response{ID: "r-nested-delegation"}
+	out := make(chan *event.Event, 10)
+	NewTransferResponseProcessor(true).ProcessResponse(
+		context.Background(),
+		inv,
+		&model.Request{},
+		rsp,
+		out,
+	)
+	close(out)
+	for range out {
+	}
+	require.Zero(t, handler.count)
+}
+
+func TestTransferResponseProc_CompletionHandlerDoesNotFallbackAfterTargetError(t *testing.T) {
+	target := &errorResponseAgent{name: "child"}
+	parent := &parentAgent{child: target}
+	handler := &completionInvocationCustomizer{}
+	inv := &agent.Invocation{
+		Agent:        parent,
+		AgentName:    "parent",
+		InvocationID: "inv-completion-target-error",
+		RunOptions: agent.RunOptions{RuntimeState: map[string]any{
+			agent.RuntimeStateKeyTransferController: handler,
+		}},
+		TransferInfo: &agent.TransferInfo{TargetAgentName: "child"},
+	}
+	rsp := &model.Response{ID: "r-target-error"}
+	out := make(chan *event.Event, 10)
+	NewTransferResponseProcessor(true).ProcessResponse(
+		context.Background(),
+		inv,
+		&model.Request{},
+		rsp,
+		out,
+	)
+	close(out)
+	for range out {
+	}
+	require.Zero(t, handler.count)
+}
+
+type controllerCompletionObserver struct {
+	recordingTransferCompletionObserver
+}
+
+func (h *controllerCompletionObserver) OnTransfer(
+	context.Context,
+	string,
+	string,
+) (time.Duration, error) {
+	return 0, nil
+}
+
+type completionInvocationCustomizer struct {
+	recordingTransferCompletionObserver
+}
+
+func (h *completionInvocationCustomizer) OnTransfer(
+	context.Context,
+	string,
+	string,
+) (time.Duration, error) {
+	return 0, nil
+}
+
+func (h *completionInvocationCustomizer) CustomizeTransferInvocation(
+	context.Context,
+	*agent.Invocation,
+	*agent.Invocation,
+) error {
+	return nil
+}
+
+func TestTransferResponseProc_ControllerCompletionMethodIsObserved(t *testing.T) {
 	target := &doneResponseAgent{name: "child"}
-	ctx := context.Background()
-
-	require.NotPanics(t, func() {
-		proc.saveActiveAgent(ctx, nil, target, &event.Event{})
-	})
-
-	require.NotPanics(t, func() {
-		proc.saveActiveAgent(ctx, &agent.Invocation{}, target, &event.Event{})
-	})
-
-	sess := session.NewSession("app", "user", "sess")
-	inv := &agent.Invocation{Session: sess}
-
-	require.NotPanics(t, func() {
-		proc.saveActiveAgent(ctx, inv, target, nil)
-	})
-
-	evt := &event.Event{}
-	proc.saveActiveAgent(ctx, inv, target, evt)
-	require.Nil(t, evt.StateDelta)
-}
-
-func TestSwarmActiveAgentKey_EmptyTeamName(t *testing.T) {
-	require.Equal(t, swarmActiveAgentKeyPrefix, swarmActiveAgentKey(""))
+	parent := &parentAgent{child: target}
+	handler := &controllerCompletionObserver{}
+	inv := &agent.Invocation{
+		Agent:        parent,
+		AgentName:    "parent",
+		InvocationID: "inv-completion-controller",
+		RunOptions: agent.RunOptions{RuntimeState: map[string]any{
+			agent.RuntimeStateKeyTransferController: handler,
+		}},
+		TransferInfo: &agent.TransferInfo{TargetAgentName: "child"},
+	}
+	rsp := &model.Response{ID: "r-controller"}
+	out := make(chan *event.Event, 10)
+	NewTransferResponseProcessor(true).ProcessResponse(
+		context.Background(),
+		inv,
+		&model.Request{},
+		rsp,
+		out,
+	)
+	close(out)
+	for range out {
+	}
+	require.Equal(t, 1, handler.count)
 }

--- a/internal/state/sessionroute/sessionroute.go
+++ b/internal/state/sessionroute/sessionroute.go
@@ -1,0 +1,229 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+// Package sessionroute stores internal session-routing controls for runner
+// persistence.
+package sessionroute
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+const (
+	stateKey                    = "__trpc_agent_session_route__"
+	currentTurnRouteStatePrefix = "__trpc_agent_current_turn_session_route:"
+)
+
+// EventRouter routes an event to a non-root session for persistence.
+type EventRouter interface {
+	RouteEvent(
+		root *agent.Invocation,
+		routeEvt *event.Event,
+	) (*session.Session, bool)
+}
+
+type currentTurnRoute struct {
+	TargetAgentName string `json:"targetAgentName"`
+	SessionID       string `json:"sessionID"`
+}
+
+type controller struct {
+	mu      sync.Mutex
+	routers []EventRouter
+}
+
+// CurrentTurnRouteState returns the root-session state update for a current
+// turn session route.
+func CurrentTurnRouteState(
+	ownerAgentName string,
+	targetAgentName string,
+	root *session.Session,
+	target *session.Session,
+) (session.StateMap, error) {
+	stateKey := currentTurnRouteStateKey(ownerAgentName)
+	if root == nil || target == nil || sameSession(root, target) {
+		return session.StateMap{stateKey: nil}, nil
+	}
+	route := currentTurnRoute{
+		TargetAgentName: strings.TrimSpace(targetAgentName),
+		SessionID:       strings.TrimSpace(target.ID),
+	}
+	if strings.TrimSpace(ownerAgentName) == "" ||
+		route.TargetAgentName == "" ||
+		route.SessionID == "" {
+		return session.StateMap{stateKey: nil}, nil
+	}
+	raw, err := json.Marshal(route)
+	if err != nil {
+		return nil, err
+	}
+	return session.StateMap{stateKey: raw}, nil
+}
+
+// ApplyCurrentTurnRouteState applies a current-turn route state update to root.
+func ApplyCurrentTurnRouteState(root *session.Session, state session.StateMap) {
+	if root == nil {
+		return
+	}
+	for key, value := range state {
+		root.SetState(key, value)
+	}
+}
+
+// ResolveCurrentTurnSession returns the session that should receive this user
+// turn before the selected agent runs.
+func ResolveCurrentTurnSession(
+	ctx context.Context,
+	service session.Service,
+	root *session.Session,
+	owner agent.Agent,
+) (*session.Session, error) {
+	if root == nil {
+		return nil, nil
+	}
+	if owner == nil {
+		return root, nil
+	}
+	raw, ok := root.GetState(currentTurnRouteStateKey(owner.Info().Name))
+	if !ok || len(raw) == 0 {
+		return root, nil
+	}
+	var route currentTurnRoute
+	if err := json.Unmarshal(raw, &route); err != nil {
+		return nil, err
+	}
+	targetAgentName := strings.TrimSpace(route.TargetAgentName)
+	if targetAgentName == "" || owner.FindSubAgent(targetAgentName) == nil {
+		return root, nil
+	}
+	sessionID := strings.TrimSpace(route.SessionID)
+	if sessionID == "" || sessionID == root.ID {
+		return root, nil
+	}
+	if service == nil {
+		return nil, errors.New("session service is nil")
+	}
+	key := session.Key{
+		AppName:   root.AppName,
+		UserID:    root.UserID,
+		SessionID: sessionID,
+	}
+	sess, err := service.GetSession(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	if sess != nil {
+		return sess, nil
+	}
+	return service.CreateSession(ctx, key, session.StateMap{})
+}
+
+// AttachEventRouter attaches an internal event persistence router to the
+// invocation and its ancestors.
+func AttachEventRouter(inv *agent.Invocation, router EventRouter) {
+	if inv == nil || router == nil {
+		return
+	}
+	for current := inv; current != nil; current = current.GetParentInvocation() {
+		attachEventRouter(current, router)
+	}
+}
+
+// RouteEvent asks attached routers for event persistence decisions.
+func RouteEvent(
+	inv *agent.Invocation,
+	routeEvt *event.Event,
+) (*session.Session, bool) {
+	ctrl, ok := controllerFor(inv)
+	if !ok {
+		return nil, false
+	}
+	routers := ctrl.eventRouters()
+	for _, router := range routers {
+		if router == nil {
+			continue
+		}
+		if sess, ok := router.RouteEvent(inv, routeEvt); ok && sess != nil {
+			return sess, true
+		}
+	}
+	return nil, false
+}
+
+// SnapshotEventIdentity copies the event fields used for route lookup before
+// plugins can replace the event.
+func SnapshotEventIdentity(src *event.Event) *event.Event {
+	if src == nil {
+		return nil
+	}
+	return &event.Event{
+		RequestID:          src.RequestID,
+		InvocationID:       src.InvocationID,
+		ParentInvocationID: src.ParentInvocationID,
+		Branch:             src.Branch,
+		FilterKey:          src.FilterKey,
+	}
+}
+
+func attachEventRouter(inv *agent.Invocation, router EventRouter) {
+	ctrl := getOrCreateController(inv)
+	ctrl.mu.Lock()
+	defer ctrl.mu.Unlock()
+	ctrl.routers = append(ctrl.routers, nil)
+	copy(ctrl.routers[1:], ctrl.routers)
+	ctrl.routers[0] = router
+}
+
+func getOrCreateController(inv *agent.Invocation) *controller {
+	if ctrl, ok := controllerFor(inv); ok {
+		return ctrl
+	}
+	ctrl := &controller{}
+	inv.SetState(stateKey, ctrl)
+	return ctrl
+}
+
+func controllerFor(inv *agent.Invocation) (*controller, bool) {
+	if inv == nil {
+		return nil, false
+	}
+	ctrl, ok := agent.GetStateValue[*controller](inv, stateKey)
+	return ctrl, ok && ctrl != nil
+}
+
+func (c *controller) eventRouters() []EventRouter {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.routers) == 0 {
+		return nil
+	}
+	routers := make([]EventRouter, len(c.routers))
+	copy(routers, c.routers)
+	return routers
+}
+
+func currentTurnRouteStateKey(ownerAgentName string) string {
+	return currentTurnRouteStatePrefix + strings.TrimSpace(ownerAgentName)
+}
+
+func sameSession(a *session.Session, b *session.Session) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.AppName == b.AppName && a.UserID == b.UserID && a.ID == b.ID
+}

--- a/internal/state/sessionroute/sessionroute.go
+++ b/internal/state/sessionroute/sessionroute.go
@@ -85,6 +85,15 @@ func ApplyCurrentTurnRouteState(root *session.Session, state session.StateMap) {
 	}
 }
 
+// HasCurrentTurnRoute reports whether root stores a current-turn route.
+func HasCurrentTurnRoute(ownerAgentName string, root *session.Session) bool {
+	if root == nil {
+		return false
+	}
+	raw, ok := root.GetState(currentTurnRouteStateKey(ownerAgentName))
+	return ok && len(raw) > 0
+}
+
 // ResolveCurrentTurnSession returns the session that should receive this user
 // turn before the selected agent runs.
 func ResolveCurrentTurnSession(

--- a/internal/state/sessionroute/sessionroute_test.go
+++ b/internal/state/sessionroute/sessionroute_test.go
@@ -83,6 +83,45 @@ func TestResolveCurrentTurnSession(t *testing.T) {
 	require.Same(t, root, got)
 }
 
+func TestResolveCurrentTurnSession_EdgeCases(t *testing.T) {
+	ctx := context.Background()
+	service := sessioninmemory.NewSessionService()
+	root, err := service.CreateSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "root",
+	}, session.StateMap{})
+	require.NoError(t, err)
+	owner := &recordingAgent{
+		name:      "team",
+		subAgents: []agent.Agent{&recordingAgent{name: "member"}},
+	}
+	got, err := ResolveCurrentTurnSession(ctx, service, nil, owner)
+	require.NoError(t, err)
+	require.Nil(t, got)
+	got, err = ResolveCurrentTurnSession(ctx, service, root, nil)
+	require.NoError(t, err)
+	require.Same(t, root, got)
+	root.SetState(currentTurnRouteStateKey("team"), []byte("{"))
+	got, err = ResolveCurrentTurnSession(ctx, service, root, owner)
+	require.Error(t, err)
+	require.Nil(t, got)
+	state, err := CurrentTurnRouteState(
+		"team",
+		"member",
+		root,
+		session.NewSession("app", "user", "root/team/member"),
+	)
+	require.NoError(t, err)
+	ApplyCurrentTurnRouteState(root, state)
+	got, err = ResolveCurrentTurnSession(ctx, nil, root, owner)
+	require.Error(t, err)
+	require.Nil(t, got)
+	got, err = ResolveCurrentTurnSession(ctx, service, root, owner)
+	require.NoError(t, err)
+	require.Equal(t, "root/team/member", got.ID)
+}
+
 func TestCurrentTurnRouteState_ClearsRootRoute(t *testing.T) {
 	root := session.NewSession("app", "user", "root")
 	state, err := CurrentTurnRouteState("team", "member", root, root)
@@ -92,13 +131,95 @@ func TestCurrentTurnRouteState_ClearsRootRoute(t *testing.T) {
 	require.Nil(t, state[key])
 }
 
+func TestCurrentTurnRouteState_ClearsInvalidRoutes(t *testing.T) {
+	root := session.NewSession("app", "user", "root")
+	target := session.NewSession("app", "user", "root/team/member")
+	cases := []struct {
+		name        string
+		owner       string
+		targetAgent string
+		root        *session.Session
+		target      *session.Session
+	}{
+		{name: "nil root", owner: "team", targetAgent: "member", target: target},
+		{name: "nil target", owner: "team", targetAgent: "member", root: root},
+		{name: "empty owner", owner: " ", targetAgent: "member", root: root, target: target},
+		{name: "empty target agent", owner: "team", targetAgent: " ", root: root, target: target},
+		{name: "empty target session", owner: "team", targetAgent: "member", root: root, target: session.NewSession("app", "user", " ")},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			state, err := CurrentTurnRouteState(tt.owner, tt.targetAgent, tt.root, tt.target)
+			require.NoError(t, err)
+			key := currentTurnRouteStateKey(tt.owner)
+			require.Contains(t, state, key)
+			require.Nil(t, state[key])
+		})
+	}
+}
+
+func TestApplyCurrentTurnRouteState_NilAndEmptyState(t *testing.T) {
+	require.NotPanics(t, func() {
+		ApplyCurrentTurnRouteState(nil, session.StateMap{"route": []byte("member")})
+	})
+	root := session.NewSession("app", "user", "root")
+	ApplyCurrentTurnRouteState(root, nil)
+	_, ok := root.GetState("route")
+	require.False(t, ok)
+	ApplyCurrentTurnRouteState(root, session.StateMap{"route": []byte("member"), "clear": nil})
+	route, ok := root.GetState("route")
+	require.True(t, ok)
+	require.Equal(t, []byte("member"), route)
+	clear, ok := root.GetState("clear")
+	require.True(t, ok)
+	require.Nil(t, clear)
+}
+
 func TestHasCurrentTurnRoute(t *testing.T) {
 	root := session.NewSession("app", "user", "root")
+	require.False(t, HasCurrentTurnRoute("team", root))
+	require.False(t, HasCurrentTurnRoute("team", nil))
+	root.SetState(currentTurnRouteStateKey("team"), nil)
 	require.False(t, HasCurrentTurnRoute("team", root))
 	state, err := CurrentTurnRouteState("team", "member", root, session.NewSession("app", "user", "member"))
 	require.NoError(t, err)
 	ApplyCurrentTurnRouteState(root, state)
 	require.True(t, HasCurrentTurnRoute("team", root))
+}
+
+func TestRouteEvent_NilAndUnroutedInputs(t *testing.T) {
+	inv := agent.NewInvocation(agent.WithInvocationID("root"))
+	evt := event.New("invocation", "agent")
+	got, ok := RouteEvent(nil, evt)
+	require.False(t, ok)
+	require.Nil(t, got)
+	got, ok = RouteEvent(inv, evt)
+	require.False(t, ok)
+	require.Nil(t, got)
+	require.NotPanics(t, func() {
+		AttachEventRouter(nil, &recordingEventRouter{})
+		AttachEventRouter(inv, nil)
+	})
+	got, ok = RouteEvent(inv, evt)
+	require.False(t, ok)
+	require.Nil(t, got)
+}
+
+func TestSnapshotEventIdentity(t *testing.T) {
+	require.Nil(t, SnapshotEventIdentity(nil))
+	src := event.New("invocation", "agent")
+	src.RequestID = "request"
+	src.ParentInvocationID = "parent"
+	src.Branch = "team/member"
+	src.FilterKey = "filter"
+	got := SnapshotEventIdentity(src)
+	require.NotSame(t, src, got)
+	require.Equal(t, "request", got.RequestID)
+	require.Equal(t, "invocation", got.InvocationID)
+	require.Equal(t, "parent", got.ParentInvocationID)
+	require.Equal(t, "team/member", got.Branch)
+	require.Equal(t, "filter", got.FilterKey)
+	require.Nil(t, got.Response)
 }
 
 type recordingEventRouter struct {

--- a/internal/state/sessionroute/sessionroute_test.go
+++ b/internal/state/sessionroute/sessionroute_test.go
@@ -92,6 +92,15 @@ func TestCurrentTurnRouteState_ClearsRootRoute(t *testing.T) {
 	require.Nil(t, state[key])
 }
 
+func TestHasCurrentTurnRoute(t *testing.T) {
+	root := session.NewSession("app", "user", "root")
+	require.False(t, HasCurrentTurnRoute("team", root))
+	state, err := CurrentTurnRouteState("team", "member", root, session.NewSession("app", "user", "member"))
+	require.NoError(t, err)
+	ApplyCurrentTurnRouteState(root, state)
+	require.True(t, HasCurrentTurnRoute("team", root))
+}
+
 type recordingEventRouter struct {
 	root    *agent.Invocation
 	event   *event.Event

--- a/internal/state/sessionroute/sessionroute_test.go
+++ b/internal/state/sessionroute/sessionroute_test.go
@@ -1,0 +1,143 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package sessionroute
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	sessioninmemory "trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+func TestRouteEvent(t *testing.T) {
+	inv := agent.NewInvocation(agent.WithInvocationID("root"))
+	evt := event.New("invocation", "agent")
+	want := session.NewSession("app", "user", "member")
+	router := &recordingEventRouter{session: want}
+	AttachEventRouter(inv, router)
+	got, ok := RouteEvent(inv, evt)
+	require.True(t, ok)
+	require.Same(t, want, got)
+	require.Same(t, inv, router.root)
+	require.Same(t, evt, router.event)
+}
+
+func TestAttachEventRouter_AttachesAncestors(t *testing.T) {
+	root := agent.NewInvocation(agent.WithInvocationID("root"))
+	child := root.Clone(agent.WithInvocationID("child"))
+	evt := event.New("child", "agent")
+	want := session.NewSession("app", "user", "member")
+	router := &recordingEventRouter{session: want}
+	AttachEventRouter(child, router)
+	got, ok := RouteEvent(root, evt)
+	require.True(t, ok)
+	require.Same(t, want, got)
+	require.Same(t, root, router.root)
+	require.Same(t, evt, router.event)
+}
+
+func TestResolveCurrentTurnSession(t *testing.T) {
+	ctx := context.Background()
+	service := sessioninmemory.NewSessionService()
+	root, err := service.CreateSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "root",
+	}, session.StateMap{})
+	require.NoError(t, err)
+	member := session.NewSession("app", "user", "root/team/member")
+	state, err := CurrentTurnRouteState("team", "member", root, member)
+	require.NoError(t, err)
+	ApplyCurrentTurnRouteState(root, state)
+	require.NoError(t, service.UpdateSessionState(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "root",
+	}, state))
+	owner := &recordingAgent{
+		name:      "team",
+		subAgents: []agent.Agent{&recordingAgent{name: "member"}},
+	}
+	got, err := ResolveCurrentTurnSession(ctx, service, root, owner)
+	require.NoError(t, err)
+	require.Equal(t, "root/team/member", got.ID)
+	got, err = ResolveCurrentTurnSession(ctx, service, root, &recordingAgent{name: "other"})
+	require.NoError(t, err)
+	require.Same(t, root, got)
+	owner.subAgents = nil
+	got, err = ResolveCurrentTurnSession(ctx, service, root, owner)
+	require.NoError(t, err)
+	require.Same(t, root, got)
+}
+
+func TestCurrentTurnRouteState_ClearsRootRoute(t *testing.T) {
+	root := session.NewSession("app", "user", "root")
+	state, err := CurrentTurnRouteState("team", "member", root, root)
+	require.NoError(t, err)
+	key := currentTurnRouteStateKey("team")
+	require.Contains(t, state, key)
+	require.Nil(t, state[key])
+}
+
+type recordingEventRouter struct {
+	root    *agent.Invocation
+	event   *event.Event
+	session *session.Session
+}
+
+func (r *recordingEventRouter) RouteEvent(
+	root *agent.Invocation,
+	evt *event.Event,
+) (*session.Session, bool) {
+	r.root = root
+	r.event = evt
+	return r.session, r.session != nil
+}
+
+type recordingAgent struct {
+	name      string
+	subAgents []agent.Agent
+}
+
+func (a *recordingAgent) Info() agent.Info {
+	return agent.Info{Name: a.name}
+}
+
+func (a *recordingAgent) SubAgents() []agent.Agent {
+	return a.subAgents
+}
+
+func (a *recordingAgent) FindSubAgent(name string) agent.Agent {
+	for _, sub := range a.subAgents {
+		if sub != nil && sub.Info().Name == name {
+			return sub
+		}
+	}
+	return nil
+}
+
+func (a *recordingAgent) Tools() []tool.Tool {
+	return nil
+}
+
+func (a *recordingAgent) Run(
+	context.Context,
+	*agent.Invocation,
+) (<-chan *event.Event, error) {
+	ch := make(chan *event.Event)
+	close(ch)
+	return ch, nil
+}

--- a/internal/transfer/transfer.go
+++ b/internal/transfer/transfer.go
@@ -15,6 +15,7 @@ import (
 	"context"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
 )
 
 type transferMessageContextKey struct{}
@@ -37,4 +38,14 @@ type InvocationCustomizer interface {
 		source *agent.Invocation,
 		target *agent.Invocation,
 	) error
+}
+
+// CompletionObserver observes when a transfer target invocation completes.
+type CompletionObserver interface {
+	OnTransferComplete(
+		ctx context.Context,
+		source *agent.Invocation,
+		target *agent.Invocation,
+		targetEvent *event.Event,
+	)
 }

--- a/internal/transfer/transfer.go
+++ b/internal/transfer/transfer.go
@@ -20,6 +20,8 @@ import (
 
 type transferMessageContextKey struct{}
 
+const syntheticCompletionExtensionKey = "trpc_agent.transfer.synthetic_completion"
+
 // ContextWithTransferMessage returns a context carrying the raw transfer message.
 func ContextWithTransferMessage(ctx context.Context, message string) context.Context {
 	return context.WithValue(ctx, transferMessageContextKey{}, message)
@@ -29,6 +31,17 @@ func ContextWithTransferMessage(ctx context.Context, message string) context.Con
 func TransferMessageFromContext(ctx context.Context) (string, bool) {
 	message, ok := ctx.Value(transferMessageContextKey{}).(string)
 	return message, ok
+}
+
+// MarkSyntheticCompletionEvent marks a completion event synthesized by transfer.
+func MarkSyntheticCompletionEvent(evt *event.Event) {
+	_ = event.SetExtension(evt, syntheticCompletionExtensionKey, true)
+}
+
+// IsSyntheticCompletionEvent reports whether transfer synthesized the event.
+func IsSyntheticCompletionEvent(evt *event.Event) bool {
+	synthetic, ok, err := event.GetExtension[bool](evt, syntheticCompletionExtensionKey)
+	return err == nil && ok && synthetic
 }
 
 // InvocationCustomizer customizes a transfer target invocation before it runs.

--- a/internal/transfer/transfer.go
+++ b/internal/transfer/transfer.go
@@ -62,3 +62,14 @@ type CompletionObserver interface {
 		targetEvent *event.Event,
 	)
 }
+
+// TerminalErrorObserver observes when a transfer target invocation terminates
+// with an error.
+type TerminalErrorObserver interface {
+	OnTransferTerminalError(
+		ctx context.Context,
+		source *agent.Invocation,
+		target *agent.Invocation,
+		targetEvent *event.Event,
+	)
+}

--- a/internal/transfer/transfer_test.go
+++ b/internal/transfer/transfer_test.go
@@ -1,0 +1,45 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package transfer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+)
+
+func TestTransferMessageContext(t *testing.T) {
+	_, ok := TransferMessageFromContext(context.Background())
+	require.False(t, ok)
+	ctx := ContextWithTransferMessage(context.Background(), "")
+	message, ok := TransferMessageFromContext(ctx)
+	require.True(t, ok)
+	require.Empty(t, message)
+	ctx = ContextWithTransferMessage(context.Background(), "handoff message")
+	message, ok = TransferMessageFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, "handoff message", message)
+}
+
+func TestSyntheticCompletionEventMarker(t *testing.T) {
+	require.False(t, IsSyntheticCompletionEvent(nil))
+	require.NotPanics(t, func() {
+		MarkSyntheticCompletionEvent(nil)
+	})
+	evt := event.New("invocation", "agent")
+	require.False(t, IsSyntheticCompletionEvent(evt))
+	MarkSyntheticCompletionEvent(evt)
+	require.True(t, IsSyntheticCompletionEvent(evt))
+	evt.Extensions[syntheticCompletionExtensionKey] = []byte(`"invalid"`)
+	require.False(t, IsSyntheticCompletionEvent(evt))
+}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -30,6 +30,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/appender"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/barrier"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/flush"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/sessionroute"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/steer"
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/memory"
@@ -516,6 +517,16 @@ func (r *runner) Run(
 			rootLookupName,
 		)
 	}
+	currentTurnSession, err := sessionroute.ResolveCurrentTurnSession(
+		execCtx,
+		r.sessionService,
+		sess,
+		ag,
+	)
+	if err != nil {
+		execCancel()
+		return nil, err
+	}
 
 	queuedUserMessages := steer.NewQueue()
 	steer.Attach(invocation, queuedUserMessages)
@@ -539,7 +550,7 @@ func (r *runner) Run(
 
 	if err := r.persistCurrentTurnMessages(
 		execCtx,
-		sess,
+		currentTurnSession,
 		invocation,
 		ag,
 		message,
@@ -565,7 +576,14 @@ func (r *runner) Run(
 		if e == nil {
 			return nil
 		}
-		return r.sessionService.AppendEvent(ctx, sess, e)
+		persistSession, ok := sessionroute.RouteEvent(
+			invocation,
+			e,
+		)
+		if !ok || persistSession == nil {
+			persistSession = sess
+		}
+		return r.sessionService.AppendEvent(ctx, persistSession, e)
 	})
 	barrier.Enable(invocation)
 
@@ -583,7 +601,7 @@ func (r *runner) Run(
 		ensureErrorEventContent(errorEvent)
 		errorEvent = r.applyEventPlugins(execCtx, invocation, errorEvent)
 
-		appendErr := r.sessionService.AppendEvent(execCtx, sess, errorEvent)
+		appendErr := r.sessionService.AppendEvent(execCtx, currentTurnSession, errorEvent)
 		if appendErr != nil {
 			log.Errorf("failed to append agent run error event: %v", appendErr)
 		}
@@ -1011,18 +1029,26 @@ func (r *runner) processSingleAgentEvent(ctx context.Context, loop *eventLoopCon
 		log.Errorf("agentEvent is nil")
 		return nil
 	}
-
+	routeEvent := sessionroute.SnapshotEventIdentity(agentEvent)
 	agentEvent = r.applyEventPlugins(ctx, loop.invocation, agentEvent)
 	if agentEvent == nil {
 		return nil
 	}
-
-	// Capture graph-level completion snapshot for final event.
-	if isGraphCompletionSnapshotEvent(agentEvent) {
-		loop.graphCompletionSeen = true
-		loop.finalStateDelta, loop.finalChoices = r.captureGraphCompletion(agentEvent)
+	persistSession, routedEvent := sessionroute.RouteEvent(
+		loop.invocation,
+		routeEvent,
+	)
+	excludeRootCompletion := routedEvent && !sameSession(persistSession, loop.sess)
+	if excludeRootCompletion {
+		r.captureRoutedCompletionError(loop, agentEvent)
+	} else {
+		// Capture graph-level completion snapshot for final event.
+		if isGraphCompletionSnapshotEvent(agentEvent) {
+			loop.graphCompletionSeen = true
+			loop.finalStateDelta, loop.finalChoices = r.captureGraphCompletion(agentEvent)
+		}
+		r.captureCompletionFallback(loop, agentEvent)
 	}
-	r.captureCompletionFallback(loop, agentEvent)
 	r.markCompletionSnapshotOnly(loop, agentEvent)
 	if shouldSuppressGraphCompletionEvent(loop, agentEvent) {
 		return nil
@@ -1037,12 +1063,20 @@ func (r *runner) processSingleAgentEvent(ctx context.Context, loop *eventLoopCon
 	shouldForwardEvent := loop.streamFilter.Allows(agentEvent)
 
 	// Append qualifying events to session and trigger summarization.
-	persisted := r.handleEventPersistence(ctx, loop.invocation, loop.sess, agentEvent)
-	r.recordPersistedAssistantEvent(
-		loop,
+	persisted := r.handleEventPersistence(
+		ctx,
+		loop.invocation,
+		loop.sess,
+		persistSession,
 		agentEvent,
-		persisted,
 	)
+	if !excludeRootCompletion {
+		r.recordPersistedAssistantEvent(
+			loop,
+			agentEvent,
+			persisted,
+		)
+	}
 
 	// Notify completion if required.
 	if agentEvent.RequiresCompletion {
@@ -1055,8 +1089,10 @@ func (r *runner) processSingleAgentEvent(ctx context.Context, loop *eventLoopCon
 		return nil
 	}
 
-	r.recordEmittedAssistantResponseID(loop, agentEvent)
-	r.recordVisibleCompletionEmission(loop, agentEvent)
+	if !excludeRootCompletion {
+		r.recordEmittedAssistantResponseID(loop, agentEvent)
+		r.recordVisibleCompletionEmission(loop, agentEvent)
+	}
 
 	// Emit event to output channel.
 	if err := event.EmitEvent(ctx, loop.processedEventCh, agentEvent); err != nil {
@@ -1293,6 +1329,7 @@ func (r *runner) handleEventPersistence(
 	ctx context.Context,
 	invocation *agent.Invocation,
 	sess *session.Session,
+	persistSession *session.Session,
 	agentEvent *event.Event,
 ) bool {
 	// Ensure error events have content so they are valid for persistence.
@@ -1301,6 +1338,9 @@ func (r *runner) handleEventPersistence(
 	// Append event to session if it's complete (not partial).
 	if !r.shouldPersistEvent(agentEvent) {
 		return false
+	}
+	if persistSession == nil {
+		persistSession = sess
 	}
 
 	persistEvent := agentEvent
@@ -1316,7 +1356,7 @@ func (r *runner) handleEventPersistence(
 
 	if err := r.sessionService.AppendEvent(
 		ctx,
-		sess,
+		persistSession,
 		persistEvent,
 	); err != nil {
 		log.Errorf("Failed to append event to session: %v", err)
@@ -1356,7 +1396,7 @@ func (r *runner) handleEventPersistence(
 	// Use EnqueueSummaryJob for true asynchronous processing.
 	// Prefer filter-specific summarization to avoid scanning all filters.
 	if err := r.sessionService.EnqueueSummaryJob(
-		ctx, sess, agentEvent.FilterKey, false,
+		ctx, persistSession, agentEvent.FilterKey, false,
 	); err != nil {
 		log.DebugfContext(ctx, "Auto summarize after append skipped or failed: %v.", err)
 	}
@@ -1462,6 +1502,29 @@ func (r *runner) captureCompletionFallback(
 	// the terminal outcome seen by the runner.
 	loop.finalError = cloneResponseError(agentEvent.Response.Error)
 	loop.sawTerminalError = agentEvent.IsTerminalError()
+}
+
+func (r *runner) captureRoutedCompletionError(
+	loop *eventLoopContext,
+	agentEvent *event.Event,
+) {
+	if loop == nil || agentEvent == nil {
+		return
+	}
+	if agentEvent.Response == nil || agentEvent.IsPartial {
+		return
+	}
+	if agentEvent.Response.Error != nil {
+		loop.finalError = cloneResponseError(agentEvent.Response.Error)
+	}
+	loop.sawTerminalError = agentEvent.IsTerminalError()
+}
+
+func sameSession(a *session.Session, b *session.Session) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.AppName == b.AppName && a.UserID == b.UserID && a.ID == b.ID
 }
 
 func mergeCompletionFallbackStateDelta(

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -4201,6 +4201,46 @@ func TestCaptureCompletionFallback_IgnoresPartialError(t *testing.T) {
 	require.Nil(t, loop.finalError)
 }
 
+func TestCaptureRoutedCompletionError(t *testing.T) {
+	r := &runner{}
+	loop := &eventLoopContext{}
+	require.NotPanics(t, func() {
+		r.captureRoutedCompletionError(nil, nil)
+		r.captureRoutedCompletionError(loop, nil)
+		r.captureRoutedCompletionError(loop, &event.Event{})
+		r.captureRoutedCompletionError(loop, &event.Event{
+			Response: &model.Response{
+				IsPartial: true,
+				Error:     &model.ResponseError{Message: "partial"},
+			},
+		})
+	})
+	require.Nil(t, loop.finalError)
+	errEvt := event.NewErrorEvent("invocation", "agent", model.ErrorTypeFlowError, "hidden failure")
+	r.captureRoutedCompletionError(loop, errEvt)
+	require.NotNil(t, loop.finalError)
+	require.Equal(t, "hidden failure", loop.finalError.Message)
+	require.True(t, loop.sawTerminalError)
+	doneLoop := &eventLoopContext{}
+	r.captureRoutedCompletionError(doneLoop, event.NewResponseEvent("invocation", "agent", &model.Response{Done: true}))
+	require.Nil(t, doneLoop.finalError)
+	require.False(t, doneLoop.sawTerminalError)
+}
+
+func TestRunnerSameSession(t *testing.T) {
+	require.True(t, sameSession(nil, nil))
+	require.False(t, sameSession(session.NewSession("app", "user", "session"), nil))
+	require.False(t, sameSession(nil, session.NewSession("app", "user", "session")))
+	require.True(t, sameSession(
+		session.NewSession("app", "user", "session"),
+		session.NewSession("app", "user", "session"),
+	))
+	require.False(t, sameSession(
+		session.NewSession("app", "user", "session"),
+		session.NewSession("app", "user", "other"),
+	))
+}
+
 func TestMergeCompletionFallbackStateDelta(t *testing.T) {
 	t.Run("empty src", func(t *testing.T) {
 		dst := map[string][]byte{"keep": []byte("v")}

--- a/team/options.go
+++ b/team/options.go
@@ -15,11 +15,11 @@ import (
 )
 
 type options struct {
-	description          string
-	memberTools          memberToolOptions
-	swarm                SwarmConfig
-	crossRequestTransfer bool
-	swarmHandoffInput    SwarmHandoffInputBuilder
+	description       string
+	memberTools       memberToolOptions
+	swarm             SwarmConfig
+	swarmHandoff      swarmHandoffPolicy
+	swarmHandoffInput SwarmHandoffInputBuilder
 }
 
 // HistoryScope controls whether and how member AgentTools inherit parent
@@ -169,7 +169,32 @@ func WithSwarmConfig(cfg SwarmConfig) Option {
 // This only applies to swarm teams.
 func WithCrossRequestTransfer(enabled bool) Option {
 	return func(o *options) {
-		o.crossRequestTransfer = enabled
+		if enabled {
+			o.swarmHandoff.turnRouting = swarmTurnRoutingTargetTakesOver
+			return
+		}
+		o.swarmHandoff.turnRouting = swarmTurnRoutingEntry
+	}
+}
+
+// WithSwarmIndependentAgents makes Swarm members keep private history.
+//
+// The entry member continues to use the root session. Non-entry members use
+// stable member sessions derived from the root session, team name, and member
+// name. Member events are still emitted to callers, but isolated member
+// transcript events are not persisted into the root session.
+//
+// This option only controls member session isolation. It does not make the
+// last transfer target receive future user turns; combine it with
+// WithCrossRequestTransfer(true) when the active target should take over the
+// next runner.Run call.
+// Runner turn-end memory and session ingestor lifecycle still runs for the
+// root session only.
+//
+// This only applies to swarm teams.
+func WithSwarmIndependentAgents() Option {
+	return func(o *options) {
+		o.swarmHandoff.sessionScope = swarmSessionScopePerAgent
 	}
 }
 

--- a/team/options_test.go
+++ b/team/options_test.go
@@ -29,3 +29,32 @@ func TestWithSwarmHandoffInputBuilder_ConfiguresBuilder(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "input", msg.Content)
 }
+
+func TestWithSwarmIndependentAgents_ConfiguresIsolationOnly(t *testing.T) {
+	opts := defaultOptions("team")
+	WithSwarmIndependentAgents()(&opts)
+	require.True(t, opts.swarmHandoff.usesIsolatedSession())
+	require.False(t, opts.swarmHandoff.targetTakesOver())
+}
+
+func TestWithCrossRequestTransfer_ConfiguresTurnRouting(t *testing.T) {
+	opts := defaultOptions("team")
+	WithCrossRequestTransfer(true)(&opts)
+	require.True(t, opts.swarmHandoff.targetTakesOver())
+	require.False(t, opts.swarmHandoff.usesIsolatedSession())
+	WithCrossRequestTransfer(false)(&opts)
+	require.False(t, opts.swarmHandoff.targetTakesOver())
+}
+
+func TestSwarmHandoffOptions_ComposeIndependently(t *testing.T) {
+	opts := defaultOptions("team")
+	WithSwarmIndependentAgents()(&opts)
+	WithCrossRequestTransfer(true)(&opts)
+	require.True(t, opts.swarmHandoff.usesIsolatedSession())
+	require.True(t, opts.swarmHandoff.targetTakesOver())
+	reversed := defaultOptions("team")
+	WithCrossRequestTransfer(true)(&reversed)
+	WithSwarmIndependentAgents()(&reversed)
+	require.True(t, reversed.swarmHandoff.usesIsolatedSession())
+	require.True(t, reversed.swarmHandoff.targetTakesOver())
+}

--- a/team/runtime.go
+++ b/team/runtime.go
@@ -280,9 +280,21 @@ func (sr *swarmRuntime) OnTransferComplete(
 		}
 		targetEvent.StateDelta[activeAgentKey] = activeAgentValue
 		if !sr.handoff.usesIsolatedSession() {
+			if itransfer.IsSyntheticCompletionEvent(targetEvent) {
+				updateRootSessionState(ctx, source, root, state)
+			}
 			return
 		}
 	}
+	updateRootSessionState(ctx, source, root, state)
+}
+
+func updateRootSessionState(
+	ctx context.Context,
+	source *agent.Invocation,
+	root *session.Session,
+	state session.StateMap,
+) {
 	if source == nil || source.SessionService == nil {
 		return
 	}
@@ -431,6 +443,39 @@ func sameSession(a *session.Session, b *session.Session) bool {
 		return a == b
 	}
 	return a.AppName == b.AppName && a.UserID == b.UserID && a.ID == b.ID
+}
+
+func appendCurrentTurnUserEvents(
+	ctx context.Context,
+	invocation *agent.Invocation,
+	target *session.Session,
+) error {
+	if invocation == nil || invocation.SessionService == nil || target == nil || sameSession(invocation.Session, target) {
+		return nil
+	}
+	for _, evt := range currentTurnUserEvents(invocation) {
+		if err := invocation.SessionService.AppendEvent(ctx, target, evt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func currentTurnUserEvents(invocation *agent.Invocation) []*event.Event {
+	if invocation == nil || invocation.Session == nil {
+		return nil
+	}
+	events := make([]*event.Event, 0)
+	invocation.Session.EventMu.RLock()
+	defer invocation.Session.EventMu.RUnlock()
+	for i := range invocation.Session.Events {
+		evt := invocation.Session.Events[i]
+		if evt.InvocationID != invocation.InvocationID || !evt.IsUserMessage() {
+			continue
+		}
+		events = append(events, evt.Clone())
+	}
+	return events
 }
 
 func normalizeHandoffInputMessage(msg model.Message) model.Message {

--- a/team/runtime.go
+++ b/team/runtime.go
@@ -240,6 +240,24 @@ func (sr *swarmRuntime) OnTransferComplete(
 	target *agent.Invocation,
 	targetEvent *event.Event,
 ) {
+	sr.saveTransferOwner(ctx, source, target, targetEvent)
+}
+
+func (sr *swarmRuntime) OnTransferTerminalError(
+	ctx context.Context,
+	source *agent.Invocation,
+	target *agent.Invocation,
+	targetEvent *event.Event,
+) {
+	sr.saveTransferOwner(ctx, source, target, targetEvent)
+}
+
+func (sr *swarmRuntime) saveTransferOwner(
+	ctx context.Context,
+	source *agent.Invocation,
+	target *agent.Invocation,
+	targetEvent *event.Event,
+) {
 	if !sr.handoff.targetTakesOver() || target == nil || targetEvent == nil {
 		return
 	}
@@ -658,6 +676,20 @@ func (c chainedTransferController) OnTransferComplete(
 	}
 	if second, ok := c.second.(itransfer.CompletionObserver); ok && second != nil {
 		second.OnTransferComplete(ctx, source, target, targetEvent)
+	}
+}
+
+func (c chainedTransferController) OnTransferTerminalError(
+	ctx context.Context,
+	source *agent.Invocation,
+	target *agent.Invocation,
+	targetEvent *event.Event,
+) {
+	if first, ok := c.first.(itransfer.TerminalErrorObserver); ok && first != nil {
+		first.OnTransferTerminalError(ctx, source, target, targetEvent)
+	}
+	if second, ok := c.second.(itransfer.TerminalErrorObserver); ok && second != nil {
+		second.OnTransferTerminalError(ctx, source, target, targetEvent)
 	}
 }
 

--- a/team/runtime.go
+++ b/team/runtime.go
@@ -13,20 +13,30 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/sessionroute"
 	itransfer "trpc.group/trpc-go/trpc-agent-go/internal/transfer"
+	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
 )
 
 type swarmRuntime struct {
 	mu           sync.Mutex
+	teamName     string
+	entryName    string
 	cfg          SwarmConfig
+	handoff      swarmHandoffPolicy
 	inputBuilder SwarmHandoffInputBuilder
 	handoffs     int
 	recent       []string
+	sessions     map[string]*session.Session
+	branches     map[string]*session.Session
 }
 
 func (sr *swarmRuntime) OnTransfer(
@@ -35,10 +45,8 @@ func (sr *swarmRuntime) OnTransfer(
 	toAgent string,
 ) (time.Duration, error) {
 	_ = fromAgent
-
 	sr.mu.Lock()
 	defer sr.mu.Unlock()
-
 	sr.handoffs++
 	if sr.cfg.MaxHandoffs > 0 && sr.handoffs > sr.cfg.MaxHandoffs {
 		return 0, fmt.Errorf(
@@ -46,7 +54,6 @@ func (sr *swarmRuntime) OnTransfer(
 			sr.cfg.MaxHandoffs,
 		)
 	}
-
 	window := sr.cfg.RepetitiveHandoffWindow
 	minUnique := sr.cfg.RepetitiveHandoffMinUnique
 	if window > 0 && minUnique > 0 {
@@ -58,7 +65,6 @@ func (sr *swarmRuntime) OnTransfer(
 			return 0, errRepetitiveHandoff
 		}
 	}
-
 	return sr.cfg.NodeTimeout, nil
 }
 
@@ -67,7 +73,16 @@ func (sr *swarmRuntime) CustomizeTransferInvocation(
 	source *agent.Invocation,
 	target *agent.Invocation,
 ) error {
-	if target == nil || sr.inputBuilder == nil {
+	if target == nil {
+		return nil
+	}
+	if sr.handoff.usesIsolatedSession() {
+		if err := sr.isolateTargetSession(ctx, source, target); err != nil {
+			return err
+		}
+	}
+	sr.registerInvocationSession(target.InvocationID, target.Branch, target.Session)
+	if sr.inputBuilder == nil {
 		return nil
 	}
 	transferMessage := target.Message.Content
@@ -86,6 +101,291 @@ func (sr *swarmRuntime) CustomizeTransferInvocation(
 	}
 	target.Message = normalizeHandoffInputMessage(msg)
 	return nil
+}
+
+func (sr *swarmRuntime) isolateTargetSession(
+	ctx context.Context,
+	source *agent.Invocation,
+	target *agent.Invocation,
+) error {
+	root := rootSession(source)
+	if root == nil {
+		return errors.New("root session is nil")
+	}
+	if target.SessionService == nil {
+		return errors.New("target session service is nil")
+	}
+	sess, err := sr.sessionForTransferTarget(ctx, target, root)
+	if err != nil {
+		return err
+	}
+	target.Session = sess
+	return nil
+}
+
+func (sr *swarmRuntime) sessionForAgentStart(
+	ctx context.Context,
+	service session.Service,
+	root *session.Session,
+	agentName string,
+) (*session.Session, error) {
+	switch sr.handoff.normalizedSessionScope() {
+	case swarmSessionScopeShared:
+		return root, nil
+	default:
+		return sr.perAgentSession(ctx, service, root, agentName)
+	}
+}
+
+func (sr *swarmRuntime) sessionForTransferTarget(
+	ctx context.Context,
+	target *agent.Invocation,
+	root *session.Session,
+) (*session.Session, error) {
+	switch sr.handoff.normalizedSessionScope() {
+	case swarmSessionScopeShared:
+		return target.Session, nil
+	default:
+		return sr.perAgentSession(ctx, target.SessionService, root, target.AgentName)
+	}
+}
+
+func (sr *swarmRuntime) perAgentSession(
+	ctx context.Context,
+	service session.Service,
+	root *session.Session,
+	toAgent string,
+) (*session.Session, error) {
+	if root == nil {
+		return nil, errors.New("root session is nil")
+	}
+	if service == nil {
+		return nil, errors.New("session service is nil")
+	}
+	if toAgent == "" {
+		return nil, errors.New("target agent name is empty")
+	}
+	if toAgent == sr.entryName {
+		return root, nil
+	}
+	return sr.newIsolatedSession(ctx, service, root, toAgent)
+}
+
+func (sr *swarmRuntime) newIsolatedSession(
+	ctx context.Context,
+	service session.Service,
+	root *session.Session,
+	toAgent string,
+) (*session.Session, error) {
+	if root == nil {
+		return nil, errors.New("root session is nil")
+	}
+	if service == nil {
+		return nil, errors.New("session service is nil")
+	}
+	if toAgent == "" {
+		return nil, errors.New("target agent name is empty")
+	}
+	sessionID := sr.isolatedSessionID(root, toAgent)
+	if sessionID == "" {
+		return nil, errors.New("isolated session id is empty")
+	}
+	return sr.getOrCreateSession(ctx, service, root, sessionID)
+}
+
+func (sr *swarmRuntime) getOrCreateSession(
+	ctx context.Context,
+	service session.Service,
+	root *session.Session,
+	sessionID string,
+) (*session.Session, error) {
+	key := session.Key{
+		AppName:   root.AppName,
+		UserID:    root.UserID,
+		SessionID: sessionID,
+	}
+	sess, err := service.GetSession(ctx, key)
+	if err != nil {
+		return nil, fmt.Errorf("get isolated session: %w", err)
+	}
+	if sess != nil {
+		return sess, nil
+	}
+	sess, err = service.CreateSession(ctx, key, session.StateMap{})
+	if err != nil {
+		existing, getErr := service.GetSession(ctx, key)
+		if getErr == nil && existing != nil {
+			return existing, nil
+		}
+		return nil, fmt.Errorf("create isolated session: %w", err)
+	}
+	return sess, nil
+}
+
+func (sr *swarmRuntime) isolatedSessionID(
+	root *session.Session,
+	toAgent string,
+) string {
+	return defaultSwarmSessionID(swarmSessionIDArgs{
+		ParentSessionID: root.ID,
+		TeamName:        sr.teamName,
+		EntryAgentName:  sr.entryName,
+		ToAgentName:     toAgent,
+	})
+}
+
+func (sr *swarmRuntime) OnTransferComplete(
+	ctx context.Context,
+	source *agent.Invocation,
+	target *agent.Invocation,
+	targetEvent *event.Event,
+) {
+	if !sr.handoff.targetTakesOver() || target == nil || targetEvent == nil {
+		return
+	}
+	root := rootSession(source)
+	if root == nil {
+		return
+	}
+	teamName := sr.teamName
+	if teamName == "" {
+		teamNameBytes, ok := root.GetState(SwarmTeamNameKey)
+		if !ok || len(teamNameBytes) == 0 {
+			return
+		}
+		teamName = string(teamNameBytes)
+	}
+	activeAgentKey := swarmActiveAgentKey(teamName)
+	activeAgentValue := []byte(target.AgentName)
+	state := session.StateMap{activeAgentKey: activeAgentValue}
+	root.SetState(activeAgentKey, activeAgentValue)
+	if sr.handoff.usesIsolatedSession() {
+		routeState, err := sessionroute.CurrentTurnRouteState(
+			teamName,
+			target.AgentName,
+			root,
+			target.Session,
+		)
+		if err != nil {
+			log.DebugfContext(ctx, "save swarm current turn route skipped: %v", err)
+		}
+		for key, value := range routeState {
+			state[key] = value
+		}
+		sessionroute.ApplyCurrentTurnRouteState(root, routeState)
+	}
+	if sameSession(root, target.Session) {
+		if targetEvent.StateDelta == nil {
+			targetEvent.StateDelta = make(map[string][]byte)
+		}
+		targetEvent.StateDelta[activeAgentKey] = activeAgentValue
+		if !sr.handoff.usesIsolatedSession() {
+			return
+		}
+	}
+	if source == nil || source.SessionService == nil {
+		return
+	}
+	key := session.Key{
+		AppName:   root.AppName,
+		UserID:    root.UserID,
+		SessionID: root.ID,
+	}
+	if err := source.SessionService.UpdateSessionState(ctx, key, state); err != nil {
+		log.WarnfContext(ctx, "save active swarm agent state skipped or failed: %v", err)
+	}
+}
+
+func (sr *swarmRuntime) registerInvocationSession(
+	invocationID string,
+	branch string,
+	sess *session.Session,
+) {
+	if sr == nil || sess == nil {
+		return
+	}
+	sr.mu.Lock()
+	defer sr.mu.Unlock()
+	if invocationID == "" && branch == "" {
+		return
+	}
+	if sr.sessions == nil {
+		sr.sessions = make(map[string]*session.Session)
+	}
+	if invocationID != "" {
+		sr.sessions[invocationID] = sess
+	}
+	if branch == "" {
+		return
+	}
+	if sr.branches == nil {
+		sr.branches = make(map[string]*session.Session)
+	}
+	sr.branches[branch] = sess
+}
+
+func (sr *swarmRuntime) sessionForEvent(
+	evt *event.Event,
+) (*session.Session, bool) {
+	if sr == nil || evt == nil {
+		return nil, false
+	}
+	sr.mu.Lock()
+	defer sr.mu.Unlock()
+	if len(sr.sessions) == 0 && len(sr.branches) == 0 {
+		return nil, false
+	}
+	if sess, ok := sr.sessions[evt.InvocationID]; ok && sess != nil {
+		return sess, true
+	}
+	if sess, ok := sr.sessions[evt.ParentInvocationID]; ok && sess != nil {
+		if evt.InvocationID != "" {
+			sr.sessions[evt.InvocationID] = sess
+		}
+		return sess, true
+	}
+	if sess, ok := sr.sessionForBranchLocked(evt.Branch); ok && sess != nil {
+		return sess, true
+	}
+	return nil, false
+}
+
+func (sr *swarmRuntime) sessionForBranchLocked(
+	branch string,
+) (*session.Session, bool) {
+	var (
+		bestSession *session.Session
+		bestLen     int
+	)
+	for prefix, sess := range sr.branches {
+		if prefix == "" || !branchMatchesPrefix(branch, prefix) {
+			continue
+		}
+		if len(prefix) > bestLen {
+			bestSession = sess
+			bestLen = len(prefix)
+		}
+	}
+	return bestSession, bestLen > 0
+}
+
+func branchMatchesPrefix(branch string, prefix string) bool {
+	return branch == prefix || strings.HasPrefix(branch, prefix+agent.BranchDelimiter)
+}
+
+// RouteEvent routes isolated member events to their member session.
+func (sr *swarmRuntime) RouteEvent(
+	root *agent.Invocation,
+	routeEvt *event.Event,
+) (*session.Session, bool) {
+	if sr == nil || !sr.handoff.usesIsolatedSession() || root == nil || routeEvt == nil {
+		return nil, false
+	}
+	sess, ok := sr.sessionForEvent(routeEvt)
+	if !ok || sameSession(root.Session, sess) {
+		return nil, false
+	}
+	return sess, true
 }
 
 func sourceAgentName(source *agent.Invocation) string {
@@ -112,6 +412,27 @@ func rootMessage(source *agent.Invocation) model.Message {
 	return msg
 }
 
+func rootSession(inv *agent.Invocation) *session.Session {
+	var fallback *session.Session
+	for current := inv; current != nil; current = current.GetParentInvocation() {
+		if current.Session == nil {
+			continue
+		}
+		fallback = current.Session
+		if _, ok := current.Session.GetState(SwarmTeamNameKey); ok {
+			return current.Session
+		}
+	}
+	return fallback
+}
+
+func sameSession(a *session.Session, b *session.Session) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.AppName == b.AppName && a.UserID == b.UserID && a.ID == b.ID
+}
+
 func normalizeHandoffInputMessage(msg model.Message) model.Message {
 	if msg.Role == "" && model.HasPayload(msg) {
 		msg.Role = model.RoleUser
@@ -121,15 +442,25 @@ func normalizeHandoffInputMessage(msg model.Message) model.Message {
 
 func ensureSwarmRuntime(
 	inv *agent.Invocation,
+	teamName string,
+	entryName string,
 	cfg SwarmConfig,
+	handoff swarmHandoffPolicy,
 	inputBuilder SwarmHandoffInputBuilder,
-) {
+) *swarmRuntime {
 	if inv == nil {
-		return
+		return nil
 	}
 	cloneRuntimeStateForSwarm(&inv.RunOptions)
-	runtime := &swarmRuntime{cfg: cfg, inputBuilder: inputBuilder}
+	runtime := &swarmRuntime{
+		teamName:     teamName,
+		entryName:    entryName,
+		cfg:          cfg,
+		handoff:      handoff,
+		inputBuilder: inputBuilder,
+	}
 	installSwarmTransferController(&inv.RunOptions, runtime)
+	return runtime
 }
 
 func cloneRuntimeStateForSwarm(opts *agent.RunOptions) {
@@ -236,6 +567,20 @@ func (c chainedTransferController) CustomizeTransferInvocation(
 		return second.CustomizeTransferInvocation(ctx, source, target)
 	}
 	return nil
+}
+
+func (c chainedTransferController) OnTransferComplete(
+	ctx context.Context,
+	source *agent.Invocation,
+	target *agent.Invocation,
+	targetEvent *event.Event,
+) {
+	if first, ok := c.first.(itransfer.CompletionObserver); ok && first != nil {
+		first.OnTransferComplete(ctx, source, target, targetEvent)
+	}
+	if second, ok := c.second.(itransfer.CompletionObserver); ok && second != nil {
+		second.OnTransferComplete(ctx, source, target, targetEvent)
+	}
 }
 
 func tighterTimeout(a time.Duration, b time.Duration) time.Duration {

--- a/team/runtime.go
+++ b/team/runtime.go
@@ -445,6 +445,39 @@ func sameSession(a *session.Session, b *session.Session) bool {
 	return a.AppName == b.AppName && a.UserID == b.UserID && a.ID == b.ID
 }
 
+func (t *Team) prepareSwarmStartSession(
+	ctx context.Context,
+	invocation *agent.Invocation,
+	startAgent agent.Agent,
+	swarmRun *swarmRuntime,
+) (*session.Session, error) {
+	startSession := invocation.Session
+	currentTurnRouteMissing := t.swarmHandoff.usesIsolatedSession() &&
+		t.swarmHandoff.targetTakesOver() &&
+		!sessionroute.HasCurrentTurnRoute(t.name, invocation.Session)
+	if t.swarmHandoff.usesIsolatedSession() {
+		sess, err := swarmRun.sessionForAgentStart(
+			ctx,
+			invocation.SessionService,
+			invocation.Session,
+			startAgent.Info().Name,
+		)
+		if err != nil {
+			return nil, err
+		}
+		startSession = sess
+	}
+	if currentTurnRouteMissing && !sameSession(invocation.Session, startSession) {
+		if err := appendCurrentTurnUserEvents(ctx, invocation, startSession); err != nil {
+			return nil, err
+		}
+	}
+	if swarmRun != nil && t.swarmHandoff.usesIsolatedSession() {
+		sessionroute.AttachEventRouter(invocation, swarmRun)
+	}
+	return startSession, nil
+}
+
 func appendCurrentTurnUserEvents(
 	ctx context.Context,
 	invocation *agent.Invocation,

--- a/team/runtime_test.go
+++ b/team/runtime_test.go
@@ -17,8 +17,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/sessionroute"
 	itransfer "trpc.group/trpc-go/trpc-agent-go/internal/transfer"
 	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	sessioninmemory "trpc.group/trpc-go/trpc-agent-go/session/inmemory"
 )
 
 const (
@@ -103,7 +107,10 @@ func TestEnsureSwarmRuntime_PreservesExistingTransferControllerAndComposesCustom
 	}
 	ensureSwarmRuntime(
 		inv,
+		"team",
+		"entry",
 		SwarmConfig{NodeTimeout: testTimeout},
+		swarmHandoffPolicy{},
 		inputBuilder,
 	)
 	controller, ok := agent.GetRuntimeStateValue[agent.TransferController](
@@ -133,12 +140,18 @@ func TestEnsureSwarmRuntime_IsolatesSharedRuntimeState(t *testing.T) {
 	}))
 	ensureSwarmRuntime(
 		invA,
+		"team",
+		"entry",
 		SwarmConfig{MaxHandoffs: 1},
+		swarmHandoffPolicy{},
 		nil,
 	)
 	ensureSwarmRuntime(
 		invB,
+		"team",
+		"entry",
 		SwarmConfig{MaxHandoffs: 1},
+		swarmHandoffPolicy{},
 		nil,
 	)
 	require.NotContains(t, sharedState, agent.RuntimeStateKeyTransferController)
@@ -210,6 +223,288 @@ func TestSwarmRuntime_CustomizeTransferInvocation_UsesRawTransferMessage(t *test
 	require.Equal(t, "custom child input", target.Message.Content)
 }
 
+func TestSwarmRuntime_CustomizeTransferInvocation_IsolatesSessionAndBuildsInput(t *testing.T) {
+	ctx := context.Background()
+	service := sessioninmemory.NewSessionService()
+	parentSess, err := service.CreateSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "parent",
+	}, session.StateMap{})
+	require.NoError(t, err)
+	source := &agent.Invocation{
+		AgentName: "parent",
+		Session:   parentSess,
+		Message:   model.NewUserMessage("raw user input"),
+	}
+	target := &agent.Invocation{
+		AgentName:      "child",
+		InvocationID:   "target-invocation",
+		Session:        parentSess,
+		SessionService: service,
+		Message:        model.NewUserMessage("parent supplied transfer"),
+	}
+	rt := &swarmRuntime{
+		teamName: "support",
+		handoff:  swarmHandoffPolicy{sessionScope: swarmSessionScopePerAgent},
+		inputBuilder: func(ctx context.Context, args SwarmHandoffInputArgs) (model.Message, error) {
+			require.Equal(t, "parent", args.FromAgentName)
+			require.Equal(t, "child", args.ToAgentName)
+			require.Equal(t, "raw user input", args.RootInput.Content)
+			require.Equal(t, "raw user input", args.ParentInput.Content)
+			require.Equal(t, "parent supplied transfer", args.TransferMessage)
+			require.Equal(t, "parent/support/child", target.Session.ID)
+			_ = ctx
+			return model.Message{Content: "rendered child input"}, nil
+		},
+	}
+	require.NoError(t, rt.CustomizeTransferInvocation(ctx, source, target))
+	require.Equal(t, "parent/support/child", target.Session.ID)
+	require.Equal(t, model.RoleUser, target.Message.Role)
+	require.Equal(t, "rendered child input", target.Message.Content)
+	got, err := service.GetSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "parent/support/child",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Empty(t, got.Events)
+}
+
+func TestSwarmRuntime_OnTransferCompleteKeepsRootStateOutOfRoutedChildEvent(t *testing.T) {
+	ctx := context.Background()
+	service := sessioninmemory.NewSessionService()
+	rootSess, err := service.CreateSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "root",
+	}, session.StateMap{SwarmTeamNameKey: []byte("team")})
+	require.NoError(t, err)
+	childSess, err := service.CreateSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "child",
+	}, session.StateMap{})
+	require.NoError(t, err)
+	source := &agent.Invocation{
+		Session:        rootSess,
+		SessionService: service,
+	}
+	target := &agent.Invocation{
+		AgentName: "child",
+		Session:   childSess,
+	}
+	targetEvent := &event.Event{
+		StateDelta: map[string][]byte{"child_state": []byte("ok")},
+	}
+	rt := &swarmRuntime{handoff: swarmHandoffPolicy{
+		sessionScope: swarmSessionScopePerAgent,
+		turnRouting:  swarmTurnRoutingTargetTakesOver,
+	}}
+	rt.OnTransferComplete(ctx, source, target, targetEvent)
+	activeAgent, ok := rootSess.GetState(swarmActiveAgentKey("team"))
+	require.True(t, ok)
+	require.Equal(t, []byte("child"), activeAgent)
+	require.Equal(t, map[string][]byte{"child_state": []byte("ok")}, targetEvent.StateDelta)
+	rootGot, err := service.GetSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "root",
+	})
+	require.NoError(t, err)
+	require.Equal(t, []byte("child"), rootGot.State[swarmActiveAgentKey("team")])
+	owner := &testSwarmMember{
+		name:      "team",
+		subAgents: []agent.Agent{&testSwarmMember{name: "child"}},
+	}
+	turnSession, err := sessionroute.ResolveCurrentTurnSession(ctx, service, rootGot, owner)
+	require.NoError(t, err)
+	require.Equal(t, "child", turnSession.ID)
+}
+
+func TestSwarmRuntime_OnTransferCompletePreservesSharedStateDelta(t *testing.T) {
+	ctx := context.Background()
+	service := sessioninmemory.NewSessionService()
+	rootSess, err := service.CreateSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "root",
+	}, session.StateMap{SwarmTeamNameKey: []byte("team")})
+	require.NoError(t, err)
+	source := &agent.Invocation{
+		Session:        rootSess,
+		SessionService: service,
+	}
+	target := &agent.Invocation{
+		AgentName: "child",
+		Session:   rootSess,
+	}
+	targetEvent := &event.Event{
+		StateDelta: map[string][]byte{"child_state": []byte("ok")},
+	}
+	rt := &swarmRuntime{handoff: swarmHandoffPolicy{
+		turnRouting: swarmTurnRoutingTargetTakesOver,
+	}}
+	rt.OnTransferComplete(ctx, source, target, targetEvent)
+	require.Equal(t, []byte("child"), targetEvent.StateDelta[swarmActiveAgentKey("team")])
+	require.Equal(t, []byte("ok"), targetEvent.StateDelta["child_state"])
+	rootGot, err := service.GetSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "root",
+	})
+	require.NoError(t, err)
+	_, ok := rootGot.State[swarmActiveAgentKey("team")]
+	require.False(t, ok)
+}
+
+func TestSwarmRuntime_RouteIsolatedEventInheritsParentRoute(t *testing.T) {
+	ctx := context.Background()
+	service := sessioninmemory.NewSessionService()
+	root, err := service.CreateSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "root",
+	}, session.StateMap{})
+	require.NoError(t, err)
+	child, err := service.CreateSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "child",
+	}, session.StateMap{})
+	require.NoError(t, err)
+	rt := &swarmRuntime{handoff: swarmHandoffPolicy{sessionScope: swarmSessionScopePerAgent}}
+	rt.registerInvocationSession("child-parent", "team/child", child)
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(root),
+		agent.WithInvocationSessionService(service),
+	)
+	childEvent := event.NewResponseEvent(
+		"child-descendant",
+		"child",
+		&model.Response{Done: true, Choices: []model.Choice{{Message: model.NewAssistantMessage("child answer")}}},
+	)
+	childEvent.ParentInvocationID = "child-parent"
+	got, ok := rt.RouteEvent(inv, childEvent)
+	require.True(t, ok)
+	require.Same(t, child, got)
+	grandchildEvent := event.NewResponseEvent(
+		"child-grandchild",
+		"child",
+		&model.Response{Done: true, Choices: []model.Choice{{Message: model.NewAssistantMessage("grandchild answer")}}},
+	)
+	grandchildEvent.ParentInvocationID = "child-descendant"
+	grandchildEvent.Branch = "team/child/internal"
+	got, ok = rt.RouteEvent(inv, grandchildEvent)
+	require.True(t, ok)
+	require.Same(t, child, got)
+}
+
+func TestSwarmRuntime_RouteIsolatedEventUsesBranchFallback(t *testing.T) {
+	ctx := context.Background()
+	service := sessioninmemory.NewSessionService()
+	root, err := service.CreateSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "root",
+	}, session.StateMap{})
+	require.NoError(t, err)
+	child, err := service.CreateSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "child",
+	}, session.StateMap{})
+	require.NoError(t, err)
+	rt := &swarmRuntime{handoff: swarmHandoffPolicy{sessionScope: swarmSessionScopePerAgent}}
+	rt.registerInvocationSession("child-parent", "team/child", child)
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(root),
+		agent.WithInvocationSessionService(service),
+	)
+	childEvent := event.NewResponseEvent(
+		"child-internal-without-parent",
+		"child",
+		&model.Response{Done: true, Choices: []model.Choice{{Message: model.NewAssistantMessage("branch-routed answer")}}},
+	)
+	childEvent.Branch = "team/child/internal"
+	got, ok := rt.RouteEvent(inv, childEvent)
+	require.True(t, ok)
+	require.Same(t, child, got)
+	rt.mu.Lock()
+	_, cached := rt.sessions["child-internal-without-parent"]
+	rt.mu.Unlock()
+	require.False(t, cached)
+}
+
+func TestDefaultSwarmSessionID(t *testing.T) {
+	got := defaultSwarmSessionID(swarmSessionIDArgs{
+		ParentSessionID: "parent",
+		TeamName:        "team",
+		ToAgentName:     "child",
+	})
+	require.Equal(t, "parent/team/child", got)
+	escaped := defaultSwarmSessionID(swarmSessionIDArgs{
+		ParentSessionID: "parent/id",
+		TeamName:        "team/name",
+		ToAgentName:     "child/name",
+	})
+	require.Equal(t, "parent%2Fid/team%2Fname/child%2Fname", escaped)
+	left := defaultSwarmSessionID(swarmSessionIDArgs{
+		ParentSessionID: "p/a",
+		TeamName:        "b",
+		ToAgentName:     "c",
+	})
+	right := defaultSwarmSessionID(swarmSessionIDArgs{
+		ParentSessionID: "p",
+		TeamName:        "a/b",
+		ToAgentName:     "c",
+	})
+	require.NotEqual(t, left, right)
+	entry := defaultSwarmSessionID(swarmSessionIDArgs{
+		ParentSessionID: "parent",
+		EntryAgentName:  "main",
+		ToAgentName:     "main",
+	})
+	require.Equal(t, "parent", entry)
+}
+
+type createRaceSessionService struct {
+	session.Service
+}
+
+func (s createRaceSessionService) CreateSession(
+	ctx context.Context,
+	key session.Key,
+	state session.StateMap,
+	options ...session.Option,
+) (*session.Session, error) {
+	_, err := s.Service.CreateSession(ctx, key, state, options...)
+	if err != nil {
+		return nil, err
+	}
+	return nil, errors.New("session already exists and has not expired")
+}
+
+func TestSwarmRuntime_GetOrCreateSessionFallsBackAfterConcurrentCreate(t *testing.T) {
+	ctx := context.Background()
+	base := sessioninmemory.NewSessionService()
+	root, err := base.CreateSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "root",
+	}, session.StateMap{})
+	require.NoError(t, err)
+	got, err := (&swarmRuntime{}).getOrCreateSession(
+		ctx,
+		createRaceSessionService{Service: base},
+		root,
+		"root/team/child",
+	)
+	require.NoError(t, err)
+	require.Equal(t, "root/team/child", got.ID)
+}
+
 func TestRootMessageUsesRootMostPayload(t *testing.T) {
 	root := agent.NewInvocation(
 		agent.WithInvocationID("root"),
@@ -254,7 +549,7 @@ func TestSwarmRuntime_CustomizeTransferInvocation_HandlesNilAndBuilderErrors(t *
 
 func TestRuntimeControllerHelpers_HandleNilAndStripSwarmControllers(t *testing.T) {
 	require.NotPanics(t, func() {
-		ensureSwarmRuntime(nil, SwarmConfig{}, nil)
+		ensureSwarmRuntime(nil, "", "", SwarmConfig{}, swarmHandoffPolicy{}, nil)
 	})
 	installSwarmTransferController(nil, &swarmRuntime{})
 	opts := &agent.RunOptions{}

--- a/team/runtime_test.go
+++ b/team/runtime_test.go
@@ -359,6 +359,39 @@ func TestSwarmRuntime_OnTransferCompletePreservesSharedStateDelta(t *testing.T) 
 	require.False(t, ok)
 }
 
+func TestSwarmRuntime_OnTransferCompletePersistsSharedSyntheticFallback(t *testing.T) {
+	ctx := context.Background()
+	service := sessioninmemory.NewSessionService()
+	rootSess, err := service.CreateSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "root",
+	}, session.StateMap{SwarmTeamNameKey: []byte("team")})
+	require.NoError(t, err)
+	source := &agent.Invocation{
+		Session:        rootSess,
+		SessionService: service,
+	}
+	target := &agent.Invocation{
+		AgentName: "child",
+		Session:   rootSess,
+	}
+	targetEvent := event.NewResponseEvent("target", "child", &model.Response{Done: true})
+	itransfer.MarkSyntheticCompletionEvent(targetEvent)
+	rt := &swarmRuntime{handoff: swarmHandoffPolicy{
+		turnRouting: swarmTurnRoutingTargetTakesOver,
+	}}
+	rt.OnTransferComplete(ctx, source, target, targetEvent)
+	rootGot, err := service.GetSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "root",
+	})
+	require.NoError(t, err)
+	require.Equal(t, []byte("child"), rootGot.State[swarmActiveAgentKey("team")])
+	require.Equal(t, []byte("child"), targetEvent.StateDelta[swarmActiveAgentKey("team")])
+}
+
 func TestSwarmRuntime_RouteIsolatedEventInheritsParentRoute(t *testing.T) {
 	ctx := context.Background()
 	service := sessioninmemory.NewSessionService()

--- a/team/runtime_test.go
+++ b/team/runtime_test.go
@@ -272,6 +272,61 @@ func TestSwarmRuntime_CustomizeTransferInvocation_IsolatesSessionAndBuildsInput(
 	require.Empty(t, got.Events)
 }
 
+func TestSwarmRuntime_IsolateTargetSessionValidatesInputs(t *testing.T) {
+	ctx := context.Background()
+	service := sessioninmemory.NewSessionService()
+	root, err := service.CreateSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "root",
+	}, session.StateMap{})
+	require.NoError(t, err)
+	rt := &swarmRuntime{
+		teamName:  "support",
+		entryName: "parent",
+		handoff:   swarmHandoffPolicy{sessionScope: swarmSessionScopePerAgent},
+	}
+	target := &agent.Invocation{AgentName: "child"}
+	require.ErrorContains(t, rt.isolateTargetSession(ctx, nil, target), "root session is nil")
+	source := agent.NewInvocation(agent.WithInvocationSession(root))
+	require.ErrorContains(t, rt.isolateTargetSession(ctx, source, target), "target session service is nil")
+	target.SessionService = service
+	require.NoError(t, rt.isolateTargetSession(ctx, source, target))
+	require.Equal(t, "root/support/child", target.Session.ID)
+}
+
+func TestSwarmRuntime_SessionSelectionValidatesInputs(t *testing.T) {
+	ctx := context.Background()
+	service := sessioninmemory.NewSessionService()
+	root, err := service.CreateSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "root",
+	}, session.StateMap{})
+	require.NoError(t, err)
+	rt := &swarmRuntime{
+		teamName:  "support",
+		entryName: "entry",
+		handoff:   swarmHandoffPolicy{sessionScope: swarmSessionScopePerAgent},
+	}
+	_, err = rt.perAgentSession(ctx, service, nil, "child")
+	require.ErrorContains(t, err, "root session is nil")
+	_, err = rt.perAgentSession(ctx, nil, root, "child")
+	require.ErrorContains(t, err, "session service is nil")
+	_, err = rt.perAgentSession(ctx, service, root, "")
+	require.ErrorContains(t, err, "target agent name is empty")
+	got, err := rt.sessionForAgentStart(ctx, service, root, "entry")
+	require.NoError(t, err)
+	require.Same(t, root, got)
+	got, err = rt.sessionForAgentStart(ctx, service, root, "child")
+	require.NoError(t, err)
+	require.Equal(t, "root/support/child", got.ID)
+	shared := &swarmRuntime{handoff: swarmHandoffPolicy{sessionScope: swarmSessionScopeShared}}
+	got, err = shared.sessionForAgentStart(ctx, nil, root, "child")
+	require.NoError(t, err)
+	require.Same(t, root, got)
+}
+
 func TestSwarmRuntime_OnTransferCompleteKeepsRootStateOutOfRoutedChildEvent(t *testing.T) {
 	ctx := context.Background()
 	service := sessioninmemory.NewSessionService()
@@ -321,6 +376,33 @@ func TestSwarmRuntime_OnTransferCompleteKeepsRootStateOutOfRoutedChildEvent(t *t
 	turnSession, err := sessionroute.ResolveCurrentTurnSession(ctx, service, rootGot, owner)
 	require.NoError(t, err)
 	require.Equal(t, "child", turnSession.ID)
+}
+
+func TestSwarmRuntime_OnTransferCompleteUsesRuntimeTeamName(t *testing.T) {
+	ctx := context.Background()
+	service := sessioninmemory.NewSessionService()
+	rootSess, err := service.CreateSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "root",
+	}, session.StateMap{})
+	require.NoError(t, err)
+	source := &agent.Invocation{
+		Session:        rootSess,
+		SessionService: service,
+	}
+	target := &agent.Invocation{
+		AgentName: "child",
+		Session:   rootSess,
+	}
+	targetEvent := event.NewResponseEvent("target", "child", &model.Response{Done: true})
+	rt := &swarmRuntime{
+		teamName: "team",
+		handoff:  swarmHandoffPolicy{turnRouting: swarmTurnRoutingTargetTakesOver},
+	}
+	rt.OnTransferComplete(ctx, source, target, targetEvent)
+	require.Equal(t, []byte("child"), targetEvent.StateDelta[swarmActiveAgentKey("team")])
+	require.Equal(t, []byte("child"), rootSess.State[swarmActiveAgentKey("team")])
 }
 
 func TestSwarmRuntime_OnTransferCompletePreservesSharedStateDelta(t *testing.T) {
@@ -470,6 +552,24 @@ func TestSwarmRuntime_RouteIsolatedEventUsesBranchFallback(t *testing.T) {
 	require.False(t, cached)
 }
 
+func TestSwarmRuntime_RouteEventRejectsRootAndInvalidInputs(t *testing.T) {
+	root := session.NewSession("app", "user", "root")
+	rt := &swarmRuntime{handoff: swarmHandoffPolicy{sessionScope: swarmSessionScopePerAgent}}
+	inv := agent.NewInvocation(agent.WithInvocationSession(root))
+	got, ok := rt.RouteEvent(inv, nil)
+	require.False(t, ok)
+	require.Nil(t, got)
+	got, ok = (*swarmRuntime)(nil).RouteEvent(inv, event.New("child", "agent"))
+	require.False(t, ok)
+	require.Nil(t, got)
+	rt.registerInvocationSession("root-event", "team/entry", root)
+	got, ok = rt.RouteEvent(inv, event.New("root-event", "entry"))
+	require.False(t, ok)
+	require.Nil(t, got)
+	require.True(t, branchMatchesPrefix("team/member/tool", "team/member"))
+	require.False(t, branchMatchesPrefix("team/memberish", "team/member"))
+}
+
 func TestDefaultSwarmSessionID(t *testing.T) {
 	got := defaultSwarmSessionID(swarmSessionIDArgs{
 		ParentSessionID: "parent",
@@ -552,6 +652,114 @@ func TestRootMessageUsesRootMostPayload(t *testing.T) {
 		agent.WithInvocationMessage(model.NewUserMessage("child input")),
 	)
 	require.Equal(t, "root input", rootMessage(child).Content)
+}
+
+func TestRootSessionPrefersSwarmMarkedAncestor(t *testing.T) {
+	root := session.NewSession("app", "user", "root")
+	childSession := session.NewSession("app", "user", "child")
+	root.SetState(SwarmTeamNameKey, []byte("team"))
+	parent := agent.NewInvocation(agent.WithInvocationSession(root))
+	child := parent.Clone(agent.WithInvocationSession(childSession))
+	require.Same(t, root, rootSession(child))
+	require.Same(t, childSession, rootSession(agent.NewInvocation(agent.WithInvocationSession(childSession))))
+	require.Nil(t, rootSession(nil))
+}
+
+func TestCurrentTurnUserEventsCloneCurrentInvocationUserEvents(t *testing.T) {
+	sess := session.NewSession("app", "user", "root")
+	currentUser := event.NewResponseEvent("turn", "user", &model.Response{
+		Choices: []model.Choice{{Message: model.NewUserMessage("current input")}},
+	})
+	currentAssistant := event.NewResponseEvent("turn", "agent", &model.Response{
+		Choices: []model.Choice{{Message: model.NewAssistantMessage("answer")}},
+	})
+	otherUser := event.NewResponseEvent("other", "user", &model.Response{
+		Choices: []model.Choice{{Message: model.NewUserMessage("other input")}},
+	})
+	sess.Events = []event.Event{*currentUser, *currentAssistant, *otherUser}
+	inv := agent.NewInvocation(
+		agent.WithInvocationID("turn"),
+		agent.WithInvocationSession(sess),
+	)
+	got := currentTurnUserEvents(inv)
+	require.Len(t, got, 1)
+	require.Equal(t, "current input", got[0].Choices[0].Message.Content)
+	got[0].Choices[0].Message.Content = "changed"
+	require.Equal(t, "current input", sess.Events[0].Choices[0].Message.Content)
+	require.Nil(t, currentTurnUserEvents(nil))
+	require.Nil(t, currentTurnUserEvents(agent.NewInvocation(agent.WithInvocationID("turn"))))
+}
+
+func TestAppendCurrentTurnUserEvents(t *testing.T) {
+	ctx := context.Background()
+	service := sessioninmemory.NewSessionService()
+	root, err := service.CreateSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "root",
+	}, session.StateMap{})
+	require.NoError(t, err)
+	target, err := service.CreateSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "root/team/member",
+	}, session.StateMap{})
+	require.NoError(t, err)
+	root.Events = []event.Event{*event.NewResponseEvent("turn", "user", &model.Response{
+		Choices: []model.Choice{{Message: model.NewUserMessage("current input")}},
+	})}
+	inv := agent.NewInvocation(
+		agent.WithInvocationID("turn"),
+		agent.WithInvocationSession(root),
+		agent.WithInvocationSessionService(service),
+	)
+	require.NoError(t, appendCurrentTurnUserEvents(ctx, nil, target))
+	require.NoError(t, appendCurrentTurnUserEvents(ctx, inv, root))
+	require.NoError(t, appendCurrentTurnUserEvents(ctx, inv, target))
+	got, err := service.GetSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "root/team/member",
+	})
+	require.NoError(t, err)
+	require.Len(t, got.Events, 1)
+	require.Equal(t, "current input", got.Events[0].Choices[0].Message.Content)
+	missing := session.NewSession("app", "user", "missing")
+	require.Error(t, appendCurrentTurnUserEvents(ctx, inv, missing))
+}
+
+func TestPrepareSwarmStartSessionAppendsCurrentTurnInput(t *testing.T) {
+	ctx := context.Background()
+	service := sessioninmemory.NewSessionService()
+	root, err := service.CreateSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "root",
+	}, session.StateMap{})
+	require.NoError(t, err)
+	root.Events = []event.Event{*event.NewResponseEvent("turn", "user", &model.Response{
+		Choices: []model.Choice{{Message: model.NewUserMessage("current input")}},
+	})}
+	handoff := swarmHandoffPolicy{
+		sessionScope: swarmSessionScopePerAgent,
+		turnRouting:  swarmTurnRoutingTargetTakesOver,
+	}
+	tm := &Team{name: "team", swarmHandoff: handoff}
+	inv := agent.NewInvocation(
+		agent.WithInvocationID("turn"),
+		agent.WithInvocationSession(root),
+		agent.WithInvocationSessionService(service),
+	)
+	rt := &swarmRuntime{teamName: "team", entryName: "entry", handoff: handoff}
+	got, err := tm.prepareSwarmStartSession(ctx, inv, testAgent{name: "member"}, rt)
+	require.NoError(t, err)
+	require.Equal(t, "root/team/member", got.ID)
+	require.Len(t, got.Events, 1)
+	require.Equal(t, "current input", got.Events[0].Choices[0].Message.Content)
+	_, routed := sessionroute.RouteEvent(inv, event.New("unknown", "member"))
+	require.False(t, routed)
+	_, err = tm.prepareSwarmStartSession(ctx, agent.NewInvocation(agent.WithInvocationSession(root)), testAgent{name: "member"}, rt)
+	require.ErrorContains(t, err, "session service is nil")
 }
 
 func TestSwarmRuntime_CustomizeTransferInvocation_HandlesNilAndBuilderErrors(t *testing.T) {
@@ -657,6 +865,26 @@ func TestChainedTransferController_CustomizeTransferInvocation_PropagatesErrorsA
 	}).CustomizeTransferInvocation(context.Background(), nil, target))
 }
 
+func TestChainedTransferController_OnTransferCompleteNotifiesObservers(t *testing.T) {
+	first := &runtimeCompletionController{}
+	second := &runtimeCompletionController{}
+	targetEvent := event.NewResponseEvent("target", "child", &model.Response{Done: true})
+	(chainedTransferController{first: first, second: second}).OnTransferComplete(
+		context.Background(),
+		nil,
+		nil,
+		targetEvent,
+	)
+	require.Equal(t, 1, first.completed)
+	require.Equal(t, 1, second.completed)
+	require.Same(t, targetEvent, first.targetEvent)
+	require.Same(t, targetEvent, second.targetEvent)
+	(chainedTransferController{
+		first:  plainTransferController{},
+		second: plainTransferController{},
+	}).OnTransferComplete(context.Background(), nil, nil, targetEvent)
+}
+
 func TestTighterTimeout_SelectsNonZeroMinimum(t *testing.T) {
 	require.Equal(t, 3*time.Second, tighterTimeout(0, 3*time.Second))
 	require.Equal(t, 3*time.Second, tighterTimeout(3*time.Second, 0))
@@ -705,4 +933,27 @@ func (plainTransferController) OnTransfer(
 	string,
 ) (time.Duration, error) {
 	return 0, nil
+}
+
+type runtimeCompletionController struct {
+	completed   int
+	targetEvent *event.Event
+}
+
+func (c *runtimeCompletionController) OnTransfer(
+	context.Context,
+	string,
+	string,
+) (time.Duration, error) {
+	return 0, nil
+}
+
+func (c *runtimeCompletionController) OnTransferComplete(
+	_ context.Context,
+	_ *agent.Invocation,
+	_ *agent.Invocation,
+	targetEvent *event.Event,
+) {
+	c.completed++
+	c.targetEvent = targetEvent
 }

--- a/team/runtime_test.go
+++ b/team/runtime_test.go
@@ -474,6 +474,40 @@ func TestSwarmRuntime_OnTransferCompletePersistsSharedSyntheticFallback(t *testi
 	require.Equal(t, []byte("child"), targetEvent.StateDelta[swarmActiveAgentKey("team")])
 }
 
+func TestSwarmRuntime_OnTransferTerminalErrorPreservesSharedOwnerStateDelta(t *testing.T) {
+	ctx := context.Background()
+	service := sessioninmemory.NewSessionService()
+	rootSess, err := service.CreateSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "root",
+	}, session.StateMap{SwarmTeamNameKey: []byte("team")})
+	require.NoError(t, err)
+	source := &agent.Invocation{
+		Session:        rootSess,
+		SessionService: service,
+	}
+	target := &agent.Invocation{
+		AgentName: "child",
+		Session:   rootSess,
+	}
+	targetEvent := event.NewErrorEvent("target", "child", model.ErrorTypeFlowError, "boom")
+	rt := &swarmRuntime{handoff: swarmHandoffPolicy{
+		turnRouting: swarmTurnRoutingTargetTakesOver,
+	}}
+	rt.OnTransferTerminalError(ctx, source, target, targetEvent)
+	rootGot, err := service.GetSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "root",
+	})
+	require.NoError(t, err)
+	_, ok := rootGot.State[swarmActiveAgentKey("team")]
+	require.False(t, ok)
+	require.Equal(t, []byte("child"), targetEvent.StateDelta[swarmActiveAgentKey("team")])
+	require.Equal(t, []byte("child"), rootSess.State[swarmActiveAgentKey("team")])
+}
+
 func TestSwarmRuntime_RouteIsolatedEventInheritsParentRoute(t *testing.T) {
 	ctx := context.Background()
 	service := sessioninmemory.NewSessionService()
@@ -885,6 +919,26 @@ func TestChainedTransferController_OnTransferCompleteNotifiesObservers(t *testin
 	}).OnTransferComplete(context.Background(), nil, nil, targetEvent)
 }
 
+func TestChainedTransferController_OnTransferTerminalErrorNotifiesObservers(t *testing.T) {
+	first := &runtimeCompletionController{}
+	second := &runtimeCompletionController{}
+	targetEvent := event.NewErrorEvent("target", "child", model.ErrorTypeFlowError, "boom")
+	(chainedTransferController{first: first, second: second}).OnTransferTerminalError(
+		context.Background(),
+		nil,
+		nil,
+		targetEvent,
+	)
+	require.Equal(t, 1, first.terminalErrors)
+	require.Equal(t, 1, second.terminalErrors)
+	require.Same(t, targetEvent, first.terminalEvent)
+	require.Same(t, targetEvent, second.terminalEvent)
+	(chainedTransferController{
+		first:  plainTransferController{},
+		second: plainTransferController{},
+	}).OnTransferTerminalError(context.Background(), nil, nil, targetEvent)
+}
+
 func TestTighterTimeout_SelectsNonZeroMinimum(t *testing.T) {
 	require.Equal(t, 3*time.Second, tighterTimeout(0, 3*time.Second))
 	require.Equal(t, 3*time.Second, tighterTimeout(3*time.Second, 0))
@@ -936,8 +990,10 @@ func (plainTransferController) OnTransfer(
 }
 
 type runtimeCompletionController struct {
-	completed   int
-	targetEvent *event.Event
+	completed      int
+	targetEvent    *event.Event
+	terminalErrors int
+	terminalEvent  *event.Event
 }
 
 func (c *runtimeCompletionController) OnTransfer(
@@ -956,4 +1012,14 @@ func (c *runtimeCompletionController) OnTransferComplete(
 ) {
 	c.completed++
 	c.targetEvent = targetEvent
+}
+
+func (c *runtimeCompletionController) OnTransferTerminalError(
+	_ context.Context,
+	_ *agent.Invocation,
+	_ *agent.Invocation,
+	targetEvent *event.Event,
+) {
+	c.terminalErrors++
+	c.terminalEvent = targetEvent
 }

--- a/team/swarm.go
+++ b/team/swarm.go
@@ -11,6 +11,8 @@ package team
 
 import (
 	"context"
+	"net/url"
+	"strings"
 	"time"
 
 	"trpc.group/trpc-go/trpc-agent-go/model"
@@ -46,8 +48,40 @@ type SwarmHandoffInputArgs struct {
 	TransferMessage string
 }
 
-// SwarmHandoffInputBuilder builds the target agent input message for a Swarm handoff.
-type SwarmHandoffInputBuilder func(ctx context.Context, args SwarmHandoffInputArgs) (model.Message, error)
+// SwarmHandoffInputBuilder builds the target agent input message for a
+// Swarm handoff.
+type SwarmHandoffInputBuilder func(
+	ctx context.Context,
+	args SwarmHandoffInputArgs,
+) (model.Message, error)
+
+type swarmSessionIDArgs struct {
+	ParentSessionID string
+	TeamName        string
+	EntryAgentName  string
+	ToAgentName     string
+}
+
+type swarmSessionScope int
+
+const (
+	swarmSessionScopeDefault swarmSessionScope = iota
+	swarmSessionScopeShared
+	swarmSessionScopePerAgent
+)
+
+type swarmTurnRouting int
+
+const (
+	swarmTurnRoutingDefault swarmTurnRouting = iota
+	swarmTurnRoutingEntry
+	swarmTurnRoutingTargetTakesOver
+)
+
+type swarmHandoffPolicy struct {
+	sessionScope swarmSessionScope
+	turnRouting  swarmTurnRouting
+}
 
 // DefaultSwarmConfig returns conservative defaults that prevent unbounded
 // transfer loops while keeping behavior predictable.
@@ -57,4 +91,53 @@ func DefaultSwarmConfig() SwarmConfig {
 		RepetitiveHandoffWindow:    8,
 		RepetitiveHandoffMinUnique: 3,
 	}
+}
+
+func defaultSwarmSessionID(args swarmSessionIDArgs) string {
+	if strings.TrimSpace(args.ToAgentName) != "" &&
+		strings.TrimSpace(args.ToAgentName) == strings.TrimSpace(args.EntryAgentName) {
+		return strings.TrimSpace(args.ParentSessionID)
+	}
+	parts := []string{
+		encodeSwarmSessionIDPart(args.ParentSessionID),
+		encodeSwarmSessionIDPart(args.TeamName),
+		encodeSwarmSessionIDPart(args.ToAgentName),
+	}
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return strings.Join(out, "/")
+}
+
+func encodeSwarmSessionIDPart(part string) string {
+	return url.PathEscape(strings.TrimSpace(part))
+}
+
+func (p swarmHandoffPolicy) normalizedSessionScope() swarmSessionScope {
+	if p.sessionScope == swarmSessionScopeDefault {
+		return swarmSessionScopeShared
+	}
+	return p.sessionScope
+}
+
+func (p swarmHandoffPolicy) normalizedTurnRouting() swarmTurnRouting {
+	if p.turnRouting == swarmTurnRoutingDefault {
+		return swarmTurnRoutingEntry
+	}
+	return p.turnRouting
+}
+
+func (p swarmHandoffPolicy) usesIsolatedSession() bool {
+	return p.normalizedSessionScope() != swarmSessionScopeShared
+}
+
+func (p swarmHandoffPolicy) targetTakesOver() bool {
+	return p.normalizedTurnRouting() == swarmTurnRoutingTargetTakesOver
+}
+
+func (p swarmHandoffPolicy) needsRootState() bool {
+	return p.usesIsolatedSession() || p.targetTakesOver()
 }

--- a/team/team.go
+++ b/team/team.go
@@ -274,6 +274,9 @@ func (t *Team) runSwarm(
 		t.swarmHandoffInput,
 	)
 	startSession := invocation.Session
+	currentTurnRouteMissing := t.swarmHandoff.usesIsolatedSession() &&
+		t.swarmHandoff.targetTakesOver() &&
+		!sessionroute.HasCurrentTurnRoute(t.name, invocation.Session)
 	if t.swarmHandoff.usesIsolatedSession() {
 		var err error
 		startSession, err = swarmRun.sessionForAgentStart(
@@ -283,6 +286,12 @@ func (t *Team) runSwarm(
 			startAgent.Info().Name,
 		)
 		if err != nil {
+			teamtrace.ClearMemberTraceRootForInvocation(invocation)
+			return nil, err
+		}
+	}
+	if currentTurnRouteMissing && !sameSession(invocation.Session, startSession) {
+		if err := appendCurrentTurnUserEvents(ctx, invocation, startSession); err != nil {
 			teamtrace.ClearMemberTraceRootForInvocation(invocation)
 			return nil, err
 		}

--- a/team/team.go
+++ b/team/team.go
@@ -18,7 +18,6 @@ import (
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/event"
-	"trpc.group/trpc-go/trpc-agent-go/internal/state/sessionroute"
 	istructure "trpc.group/trpc-go/trpc-agent-go/internal/structure"
 	"trpc.group/trpc-go/trpc-agent-go/internal/teamtrace"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
@@ -273,31 +272,15 @@ func (t *Team) runSwarm(
 		t.swarmHandoff,
 		t.swarmHandoffInput,
 	)
-	startSession := invocation.Session
-	currentTurnRouteMissing := t.swarmHandoff.usesIsolatedSession() &&
-		t.swarmHandoff.targetTakesOver() &&
-		!sessionroute.HasCurrentTurnRoute(t.name, invocation.Session)
-	if t.swarmHandoff.usesIsolatedSession() {
-		var err error
-		startSession, err = swarmRun.sessionForAgentStart(
-			ctx,
-			invocation.SessionService,
-			invocation.Session,
-			startAgent.Info().Name,
-		)
-		if err != nil {
-			teamtrace.ClearMemberTraceRootForInvocation(invocation)
-			return nil, err
-		}
-	}
-	if currentTurnRouteMissing && !sameSession(invocation.Session, startSession) {
-		if err := appendCurrentTurnUserEvents(ctx, invocation, startSession); err != nil {
-			teamtrace.ClearMemberTraceRootForInvocation(invocation)
-			return nil, err
-		}
-	}
-	if swarmRun != nil && t.swarmHandoff.usesIsolatedSession() {
-		sessionroute.AttachEventRouter(invocation, swarmRun)
+	startSession, err := t.prepareSwarmStartSession(
+		ctx,
+		invocation,
+		startAgent,
+		swarmRun,
+	)
+	if err != nil {
+		teamtrace.ClearMemberTraceRootForInvocation(invocation)
+		return nil, err
 	}
 	memberPathAllocator := istructure.NewPathAllocator(traceRootNodeID)
 	var memberNodeID string

--- a/team/team.go
+++ b/team/team.go
@@ -18,6 +18,7 @@ import (
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/sessionroute"
 	istructure "trpc.group/trpc-go/trpc-agent-go/internal/structure"
 	"trpc.group/trpc-go/trpc-agent-go/internal/teamtrace"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
@@ -42,10 +43,10 @@ type Team struct {
 	members      []agent.Agent
 	memberByName map[string]agent.Agent
 
-	memberToolSet        tool.ToolSet
-	swarm                SwarmConfig
-	crossRequestTransfer bool
-	swarmHandoffInput    SwarmHandoffInputBuilder
+	memberToolSet     tool.ToolSet
+	swarm             SwarmConfig
+	swarmHandoff      swarmHandoffPolicy
+	swarmHandoffInput SwarmHandoffInputBuilder
 }
 
 // Mode controls how a Team runs.
@@ -167,15 +168,15 @@ func NewSwarm(
 	}
 
 	return &Team{
-		name:                 name,
-		description:          cfg.description,
-		mode:                 ModeSwarm,
-		entryName:            entryName,
-		members:              members,
-		memberByName:         memberByName,
-		swarm:                cfg.swarm,
-		crossRequestTransfer: cfg.crossRequestTransfer,
-		swarmHandoffInput:    cfg.swarmHandoffInput,
+		name:              name,
+		description:       cfg.description,
+		mode:              ModeSwarm,
+		entryName:         entryName,
+		members:           members,
+		memberByName:      memberByName,
+		swarm:             cfg.swarm,
+		swarmHandoff:      cfg.swarmHandoff,
+		swarmHandoffInput: cfg.swarmHandoffInput,
 	}, nil
 }
 
@@ -244,24 +245,15 @@ func (t *Team) runSwarm(
 ) (<-chan *event.Event, error) {
 	traceRootNodeID := teamtrace.TraceRootNodeID(invocation, t.name)
 	surfaceRootNodeID := teamtrace.RootNodeID(invocation, t.name)
-	// Mark this session as belonging to a Swarm team for transfer processor to detect.
-	// Only do this if cross-request transfer is enabled.
-	if t.crossRequestTransfer && invocation.Session != nil {
-		invocation.Session.SetState(SwarmTeamNameKey, []byte(t.name))
-		if invocation.RunOptions.ExecutionTraceEnabled {
-			if traceRootNodeID != "" {
-				invocation.Session.SetState(swarmTraceNodeIDKey, []byte(traceRootNodeID))
-			}
-		}
+	if t.swarmHandoff.needsRootState() && invocation.Session != nil {
+		teamtrace.SetMemberTraceRootForInvocation(invocation, traceRootNodeID)
+		t.markSwarmRootSession(invocation, traceRootNodeID)
 	}
-
 	var startAgent agent.Agent
-
-	if t.crossRequestTransfer {
+	if t.swarmHandoff.targetTakesOver() {
 		// Try to get the active agent from session state (for cross-request transfer).
 		startAgent = t.getActiveAgent(invocation)
 	}
-
 	// If no active agent (either cross-request transfer disabled or no active agent stored),
 	// fall back to entry member.
 	if startAgent == nil {
@@ -269,11 +261,35 @@ func (t *Team) runSwarm(
 		startAgent = t.memberByName[t.entryName]
 		t.mu.RUnlock()
 		if startAgent == nil {
+			teamtrace.ClearMemberTraceRootForInvocation(invocation)
 			return nil, fmt.Errorf("entry member %q not found", t.entryName)
 		}
 	}
-
-	ensureSwarmRuntime(invocation, t.swarm, t.swarmHandoffInput)
+	swarmRun := ensureSwarmRuntime(
+		invocation,
+		t.name,
+		t.entryName,
+		t.swarm,
+		t.swarmHandoff,
+		t.swarmHandoffInput,
+	)
+	startSession := invocation.Session
+	if t.swarmHandoff.usesIsolatedSession() {
+		var err error
+		startSession, err = swarmRun.sessionForAgentStart(
+			ctx,
+			invocation.SessionService,
+			invocation.Session,
+			startAgent.Info().Name,
+		)
+		if err != nil {
+			teamtrace.ClearMemberTraceRootForInvocation(invocation)
+			return nil, err
+		}
+	}
+	if swarmRun != nil && t.swarmHandoff.usesIsolatedSession() {
+		sessionroute.AttachEventRouter(invocation, swarmRun)
+	}
 	memberPathAllocator := istructure.NewPathAllocator(traceRootNodeID)
 	var memberNodeID string
 	startAgentName := startAgent.Info().Name
@@ -297,13 +313,60 @@ func (t *Team) runSwarm(
 		agent.WithInvocationAgent(startAgent),
 		agent.WithInvocationTraceNodeID(memberNodeID),
 		agent.WithInvocationEntryPredecessorStepIDs(agent.NextExecutionTracePredecessors(invocation)),
+		agent.WithInvocationSession(startSession),
 		func(inv *agent.Invocation) {
 			agent.SetInvocationSurfaceRootNodeID(inv, memberSurfaceRootNodeID)
 		},
 	)
+	if swarmRun != nil {
+		swarmRun.registerInvocationSession(
+			child.InvocationID,
+			child.Branch,
+			startSession,
+		)
+	}
 	childCtx := agent.NewInvocationContext(ctx, child)
+	memberEventCh, err := startAgent.Run(childCtx, child)
+	if err != nil {
+		teamtrace.ClearMemberTraceRootForInvocation(invocation)
+		return nil, err
+	}
+	return wrapSwarmInvocationState(invocation, memberEventCh), nil
+}
 
-	return startAgent.Run(childCtx, child)
+func wrapSwarmInvocationState(
+	invocation *agent.Invocation,
+	src <-chan *event.Event,
+) <-chan *event.Event {
+	if invocation == nil {
+		return src
+	}
+	if src == nil {
+		teamtrace.ClearMemberTraceRootForInvocation(invocation)
+		return nil
+	}
+	out := make(chan *event.Event)
+	go func() {
+		defer close(out)
+		defer teamtrace.ClearMemberTraceRootForInvocation(invocation)
+		for evt := range src {
+			out <- evt
+		}
+	}()
+	return out
+}
+
+func (t *Team) markSwarmRootSession(
+	invocation *agent.Invocation,
+	traceRootNodeID string,
+) {
+	if invocation == nil || invocation.Session == nil {
+		return
+	}
+	invocation.Session.SetState(SwarmTeamNameKey, []byte(t.name))
+	if invocation.RunOptions.ExecutionTraceEnabled && traceRootNodeID != "" {
+		invocation.Session.SetState(swarmTraceNodeIDKey, []byte(traceRootNodeID))
+	}
 }
 
 // getActiveAgent retrieves the active agent from session state for cross-request transfer.

--- a/team/team_test.go
+++ b/team/team_test.go
@@ -2002,6 +2002,65 @@ func TestRunnerRun_SwarmIndependentAgents_WithCrossRequestPersistsNextTurnToActi
 	require.True(t, teamSessionContainsContent(childSession, "second turn for child"))
 }
 
+func TestRunnerRun_SwarmIndependentAgents_BackfillsLegacyActiveMemberTurn(t *testing.T) {
+	ctx := context.Background()
+	service := sessioninmemory.NewSessionService()
+	_, err := service.CreateSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user-independent-legacy",
+		SessionID: "root-session",
+	}, session.StateMap{
+		swarmActiveAgentKey("support"): []byte("child"),
+	})
+	require.NoError(t, err)
+	parentModel := &teamScriptedSurfaceModel{
+		name:      "swarm-parent-model",
+		responses: []model.Message{model.NewAssistantMessage("parent should not run")},
+	}
+	childModel := &teamScriptedSurfaceModel{
+		name:      "swarm-child-model",
+		responses: []model.Message{model.NewAssistantMessage("child legacy answer")},
+	}
+	parent := llmagent.New("parent", llmagent.WithModel(parentModel))
+	child := llmagent.New("child", llmagent.WithModel(childModel))
+	swarm, err := NewSwarm(
+		"support",
+		"parent",
+		[]agent.Agent{parent, child},
+		WithSwarmIndependentAgents(),
+		WithCrossRequestTransfer(true),
+	)
+	require.NoError(t, err)
+	r := runner.NewRunner("app", swarm, runner.WithSessionService(service))
+	eventCh, err := r.Run(
+		ctx,
+		"user-independent-legacy",
+		"root-session",
+		model.NewUserMessage("legacy active child turn"),
+	)
+	require.NoError(t, err)
+	collectTeamRunnerCompletionEvent(t, eventCh)
+	childSessionID := defaultSwarmSessionID(swarmSessionIDArgs{
+		ParentSessionID: "root-session",
+		TeamName:        "support",
+		EntryAgentName:  "parent",
+		ToAgentName:     "child",
+	})
+	childSession, err := service.GetSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user-independent-legacy",
+		SessionID: childSessionID,
+	})
+	require.NoError(t, err)
+	require.Zero(t, parentModel.RequestCount())
+	require.Equal(t, 1, childModel.RequestCount())
+	require.True(t, teamMessagesContainContent(
+		childModel.LatestRequest().messages,
+		"legacy active child turn",
+	))
+	require.True(t, teamSessionContainsContent(childSession, "legacy active child turn"))
+}
+
 func TestRunnerRun_SwarmIndependentAgents_WithCrossRequestRemovedActiveMemberUsesRoot(t *testing.T) {
 	ctx := context.Background()
 	service := sessioninmemory.NewSessionService()

--- a/team/team_test.go
+++ b/team/team_test.go
@@ -28,10 +28,12 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/internal/teamtrace"
 	itool "trpc.group/trpc-go/trpc-agent-go/internal/tool"
 	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/plugin"
 	"trpc.group/trpc-go/trpc-agent-go/runner"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	sessioninmemory "trpc.group/trpc-go/trpc-agent-go/session/inmemory"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
+	agenttool "trpc.group/trpc-go/trpc-agent-go/tool/agent"
 	transfertool "trpc.group/trpc-go/trpc-agent-go/tool/transfer"
 )
 
@@ -83,6 +85,19 @@ func (t testAgent) Run(
 	ch := make(chan *event.Event)
 	close(ch)
 	return ch, nil
+}
+
+type teamTestPlugin struct {
+	name string
+	reg  func(*plugin.Registry)
+}
+
+func (p teamTestPlugin) Name() string { return p.name }
+
+func (p teamTestPlugin) Register(r *plugin.Registry) {
+	if p.reg != nil {
+		p.reg(r)
+	}
 }
 
 type testCoordinator struct {
@@ -175,6 +190,90 @@ func (t *testSwarmMember) FindSubAgent(name string) agent.Agent {
 		}
 	}
 	return nil
+}
+
+type agentToolCallingSwarmMember struct {
+	name      string
+	child     agent.Agent
+	subAgents []agent.Agent
+}
+
+func (m *agentToolCallingSwarmMember) SetSubAgents(subAgents []agent.Agent) {
+	m.subAgents = subAgents
+}
+
+func (m *agentToolCallingSwarmMember) Info() agent.Info {
+	return agent.Info{Name: m.name}
+}
+
+func (m *agentToolCallingSwarmMember) SubAgents() []agent.Agent { return m.subAgents }
+
+func (m *agentToolCallingSwarmMember) FindSubAgent(name string) agent.Agent {
+	for _, sub := range m.subAgents {
+		if sub != nil && sub.Info().Name == name {
+			return sub
+		}
+	}
+	return nil
+}
+
+func (m *agentToolCallingSwarmMember) Tools() []tool.Tool { return nil }
+
+func (m *agentToolCallingSwarmMember) Run(
+	ctx context.Context,
+	inv *agent.Invocation,
+) (<-chan *event.Event, error) {
+	result, err := agenttool.NewTool(m.child).Call(
+		agent.NewInvocationContext(ctx, inv),
+		[]byte(`{"request":"agent-tool-private-input"}`),
+	)
+	if err != nil {
+		return nil, err
+	}
+	text, _ := result.(string)
+	ch := make(chan *event.Event, 1)
+	go func() {
+		defer close(ch)
+		ch <- event.NewResponseEvent(inv.InvocationID, m.name, &model.Response{
+			Done: true,
+			Choices: []model.Choice{{
+				Message: model.NewAssistantMessage("worker final: " + text),
+			}},
+		})
+	}()
+	return ch, nil
+}
+
+type assistantTextAgent struct {
+	name    string
+	content string
+}
+
+func (a *assistantTextAgent) Info() agent.Info {
+	return agent.Info{Name: a.name}
+}
+
+func (a *assistantTextAgent) SubAgents() []agent.Agent { return nil }
+
+func (a *assistantTextAgent) FindSubAgent(string) agent.Agent { return nil }
+
+func (a *assistantTextAgent) Tools() []tool.Tool { return nil }
+
+func (a *assistantTextAgent) Run(
+	_ context.Context,
+	inv *agent.Invocation,
+) (<-chan *event.Event, error) {
+	ch := make(chan *event.Event, 1)
+	go func() {
+		defer close(ch)
+		ch <- event.NewResponseEvent(inv.InvocationID, a.name, &model.Response{
+			Done: true,
+			Choices: []model.Choice{{
+				Message: model.NewAssistantMessage(a.content),
+			}},
+		})
+	}()
+	return ch, nil
 }
 
 type testNonComparableSwarmMember struct {
@@ -1616,6 +1715,362 @@ func TestRunnerRun_SwarmHandoffInputBuilder_RewritesTargetInput(t *testing.T) {
 	))
 }
 
+func TestRunnerRun_SwarmIndependentAgents_KeepsMemberHistoryPrivate(t *testing.T) {
+	ctx := context.Background()
+	service := sessioninmemory.NewSessionService()
+	parentModel := &teamScriptedSurfaceModel{
+		name: "swarm-parent-model",
+		responses: []model.Message{
+			teamToolCallAssistantMessage(
+				transfertool.TransferToolName,
+				`{"agent_name":"child","message":"private child input"}`,
+			),
+		},
+	}
+	childModel := &teamScriptedSurfaceModel{
+		name:      "swarm-child-model",
+		responses: []model.Message{model.NewAssistantMessage("private child answer")},
+	}
+	parent := llmagent.New("parent", llmagent.WithModel(parentModel))
+	child := llmagent.New("child", llmagent.WithModel(childModel))
+	swarm, err := NewSwarm(
+		"support",
+		"parent",
+		[]agent.Agent{parent, child},
+		WithSwarmIndependentAgents(),
+	)
+	require.NoError(t, err)
+	r := runner.NewRunner("app", swarm, runner.WithSessionService(service))
+	eventCh, err := r.Run(
+		ctx,
+		"user-independent",
+		"root-session",
+		model.NewUserMessage("root user input"),
+	)
+	require.NoError(t, err)
+	completion := collectTeamRunnerCompletionEvent(t, eventCh)
+	require.NotNil(t, completion.Response)
+	require.False(t, teamEventContainsContent(completion, "private child answer"))
+	root, err := service.GetSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user-independent",
+		SessionID: "root-session",
+	})
+	require.NoError(t, err)
+	childSessionID := defaultSwarmSessionID(swarmSessionIDArgs{
+		ParentSessionID: "root-session",
+		TeamName:        "support",
+		EntryAgentName:  "parent",
+		ToAgentName:     "child",
+	})
+	childSession, err := service.GetSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user-independent",
+		SessionID: childSessionID,
+	})
+	require.NoError(t, err)
+	require.False(t, teamSessionContainsContent(root, "private child answer"))
+	require.True(t, teamSessionContainsContent(childSession, "private child answer"))
+}
+
+func TestRunnerRun_SwarmIndependentAgents_PersistsPostPluginEventByOriginalRoute(t *testing.T) {
+	ctx := context.Background()
+	service := sessioninmemory.NewSessionService()
+	parentModel := &teamScriptedSurfaceModel{
+		name: "swarm-parent-model",
+		responses: []model.Message{
+			teamToolCallAssistantMessage(
+				transfertool.TransferToolName,
+				`{"agent_name":"child","message":"private child input"}`,
+			),
+		},
+	}
+	childModel := &teamScriptedSurfaceModel{
+		name:      "swarm-child-model",
+		responses: []model.Message{model.NewAssistantMessage("sensitive child answer")},
+	}
+	parent := llmagent.New("parent", llmagent.WithModel(parentModel))
+	child := llmagent.New("child", llmagent.WithModel(childModel))
+	swarm, err := NewSwarm(
+		"support",
+		"parent",
+		[]agent.Agent{parent, child},
+		WithSwarmIndependentAgents(),
+	)
+	require.NoError(t, err)
+	redactPlugin := teamTestPlugin{
+		name: "redact-child",
+		reg: func(r *plugin.Registry) {
+			r.OnEvent(func(
+				_ context.Context,
+				_ *agent.Invocation,
+				e *event.Event,
+			) (*event.Event, error) {
+				if !teamEventContainsContent(e, "sensitive child answer") {
+					return e, nil
+				}
+				redacted := event.NewResponseEvent(
+					"wrong-invocation",
+					"child",
+					&model.Response{
+						ID:   "redacted-child",
+						Done: true,
+						Choices: []model.Choice{{
+							Message: model.NewAssistantMessage("redacted child answer"),
+						}},
+					},
+				)
+				redacted.ParentInvocationID = "wrong-parent"
+				redacted.Branch = "wrong/branch"
+				redacted.FilterKey = "wrong-filter"
+				return redacted, nil
+			})
+		},
+	}
+	r := runner.NewRunner(
+		"app",
+		swarm,
+		runner.WithSessionService(service),
+		runner.WithPlugins(redactPlugin),
+	)
+	eventCh, err := r.Run(
+		ctx,
+		"user-plugin-route",
+		"root-session",
+		model.NewUserMessage("root user input"),
+	)
+	require.NoError(t, err)
+	collectTeamRunnerCompletionEvent(t, eventCh)
+	root, err := service.GetSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user-plugin-route",
+		SessionID: "root-session",
+	})
+	require.NoError(t, err)
+	childSessionID := defaultSwarmSessionID(swarmSessionIDArgs{
+		ParentSessionID: "root-session",
+		TeamName:        "support",
+		EntryAgentName:  "parent",
+		ToAgentName:     "child",
+	})
+	childSession, err := service.GetSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user-plugin-route",
+		SessionID: childSessionID,
+	})
+	require.NoError(t, err)
+	require.False(t, teamSessionContainsContent(root, "redacted child answer"))
+	require.False(t, teamSessionContainsContent(childSession, "sensitive child answer"))
+	require.True(t, teamSessionContainsContent(childSession, "redacted child answer"))
+}
+
+func TestRunnerRun_SwarmIndependentAgents_RoutesAppenderEvents(t *testing.T) {
+	ctx := context.Background()
+	service := sessioninmemory.NewSessionService()
+	parentModel := &teamScriptedSurfaceModel{
+		name: "swarm-parent-model",
+		responses: []model.Message{
+			teamToolCallAssistantMessage(
+				transfertool.TransferToolName,
+				`{"agent_name":"worker","message":"handoff to worker"}`,
+			),
+		},
+	}
+	parent := llmagent.New("parent", llmagent.WithModel(parentModel))
+	helper := &assistantTextAgent{
+		name:    "helper",
+		content: "helper private answer",
+	}
+	worker := &agentToolCallingSwarmMember{
+		name:  "worker",
+		child: helper,
+	}
+	swarm, err := NewSwarm(
+		"support",
+		"parent",
+		[]agent.Agent{parent, worker},
+		WithSwarmIndependentAgents(),
+	)
+	require.NoError(t, err)
+	r := runner.NewRunner("app", swarm, runner.WithSessionService(service))
+	eventCh, err := r.Run(
+		ctx,
+		"user-appender-route",
+		"root-session",
+		model.NewUserMessage("root user input"),
+	)
+	require.NoError(t, err)
+	collectTeamRunnerCompletionEvent(t, eventCh)
+	root, err := service.GetSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user-appender-route",
+		SessionID: "root-session",
+	})
+	require.NoError(t, err)
+	workerSessionID := defaultSwarmSessionID(swarmSessionIDArgs{
+		ParentSessionID: "root-session",
+		TeamName:        "support",
+		EntryAgentName:  "parent",
+		ToAgentName:     "worker",
+	})
+	workerSession, err := service.GetSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user-appender-route",
+		SessionID: workerSessionID,
+	})
+	require.NoError(t, err)
+	require.False(t, teamSessionContainsContent(root, "agent-tool-private-input"))
+	require.False(t, teamSessionContainsContent(root, "helper private answer"))
+	require.True(t, teamSessionContainsContent(workerSession, "agent-tool-private-input"))
+	require.True(t, teamSessionContainsContent(workerSession, "helper private answer"))
+}
+
+func TestRunnerRun_SwarmIndependentAgents_WithCrossRequestPersistsNextTurnToActiveMember(t *testing.T) {
+	ctx := context.Background()
+	service := sessioninmemory.NewSessionService()
+	parentModel := &teamScriptedSurfaceModel{
+		name: "swarm-parent-model",
+		responses: []model.Message{
+			teamToolCallAssistantMessage(
+				transfertool.TransferToolName,
+				`{"agent_name":"child","message":"handoff to child"}`,
+			),
+		},
+	}
+	childModel := &teamScriptedSurfaceModel{
+		name: "swarm-child-model",
+		responses: []model.Message{
+			model.NewAssistantMessage("child first answer"),
+			model.NewAssistantMessage("child second answer"),
+		},
+	}
+	parent := llmagent.New("parent", llmagent.WithModel(parentModel))
+	child := llmagent.New("child", llmagent.WithModel(childModel))
+	swarm, err := NewSwarm(
+		"support",
+		"parent",
+		[]agent.Agent{parent, child},
+		WithSwarmIndependentAgents(),
+		WithCrossRequestTransfer(true),
+	)
+	require.NoError(t, err)
+	r := runner.NewRunner("app", swarm, runner.WithSessionService(service))
+	firstCh, err := r.Run(
+		ctx,
+		"user-independent-cross",
+		"root-session",
+		model.NewUserMessage("start child"),
+	)
+	require.NoError(t, err)
+	collectTeamRunnerCompletionEvent(t, firstCh)
+	secondCh, err := r.Run(
+		ctx,
+		"user-independent-cross",
+		"root-session",
+		model.NewUserMessage("second turn for child"),
+	)
+	require.NoError(t, err)
+	collectTeamRunnerCompletionEvent(t, secondCh)
+	require.Equal(t, 1, parentModel.RequestCount())
+	require.Equal(t, 2, childModel.RequestCount())
+	require.True(t, teamMessagesContainContent(
+		childModel.LatestRequest().messages,
+		"second turn for child",
+	))
+	root, err := service.GetSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user-independent-cross",
+		SessionID: "root-session",
+	})
+	require.NoError(t, err)
+	childSessionID := defaultSwarmSessionID(swarmSessionIDArgs{
+		ParentSessionID: "root-session",
+		TeamName:        "support",
+		EntryAgentName:  "parent",
+		ToAgentName:     "child",
+	})
+	childSession, err := service.GetSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user-independent-cross",
+		SessionID: childSessionID,
+	})
+	require.NoError(t, err)
+	activeAgent, ok := root.GetState(swarmActiveAgentKey("support"))
+	require.True(t, ok)
+	require.Equal(t, []byte("child"), activeAgent)
+	require.False(t, teamSessionContainsContent(root, "second turn for child"))
+	require.True(t, teamSessionContainsContent(childSession, "second turn for child"))
+}
+
+func TestRunnerRun_SwarmIndependentAgents_WithCrossRequestRemovedActiveMemberUsesRoot(t *testing.T) {
+	ctx := context.Background()
+	service := sessioninmemory.NewSessionService()
+	parentModel := &teamScriptedSurfaceModel{
+		name: "swarm-parent-model",
+		responses: []model.Message{
+			teamToolCallAssistantMessage(
+				transfertool.TransferToolName,
+				`{"agent_name":"child","message":"handoff to child"}`,
+			),
+			model.NewAssistantMessage("parent after removal"),
+		},
+	}
+	childModel := &teamScriptedSurfaceModel{
+		name:      "swarm-child-model",
+		responses: []model.Message{model.NewAssistantMessage("child first answer")},
+	}
+	parent := llmagent.New("parent", llmagent.WithModel(parentModel))
+	child := llmagent.New("child", llmagent.WithModel(childModel))
+	swarm, err := NewSwarm(
+		"support",
+		"parent",
+		[]agent.Agent{parent, child},
+		WithSwarmIndependentAgents(),
+		WithCrossRequestTransfer(true),
+	)
+	require.NoError(t, err)
+	r := runner.NewRunner("app", swarm, runner.WithSessionService(service))
+	firstCh, err := r.Run(
+		ctx,
+		"user-independent-removed",
+		"root-session",
+		model.NewUserMessage("start child"),
+	)
+	require.NoError(t, err)
+	collectTeamRunnerCompletionEvent(t, firstCh)
+	require.True(t, swarm.RemoveSwarmMember("child"))
+	secondCh, err := r.Run(
+		ctx,
+		"user-independent-removed",
+		"root-session",
+		model.NewUserMessage("second turn after removal"),
+	)
+	require.NoError(t, err)
+	collectTeamRunnerCompletionEvent(t, secondCh)
+	require.Equal(t, 2, parentModel.RequestCount())
+	require.Equal(t, 1, childModel.RequestCount())
+	root, err := service.GetSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user-independent-removed",
+		SessionID: "root-session",
+	})
+	require.NoError(t, err)
+	childSessionID := defaultSwarmSessionID(swarmSessionIDArgs{
+		ParentSessionID: "root-session",
+		TeamName:        "support",
+		EntryAgentName:  "parent",
+		ToAgentName:     "child",
+	})
+	childSession, err := service.GetSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user-independent-removed",
+		SessionID: childSessionID,
+	})
+	require.NoError(t, err)
+	require.True(t, teamSessionContainsContent(root, "second turn after removal"))
+	require.False(t, teamSessionContainsContent(childSession, "second turn after removal"))
+}
+
 func TestRunnerRun_WithSurfacePatchForNode_AppliesCoordinatorAndMemberPatches(
 	t *testing.T,
 ) {
@@ -1850,6 +2305,47 @@ func teamMessagesContainContent(messages []model.Message, content string) bool {
 	for _, msg := range messages {
 		if strings.Contains(msg.Content, content) {
 			return true
+		}
+	}
+	return false
+}
+
+func teamEventContainsContent(evt *event.Event, content string) bool {
+	if evt == nil || evt.Response == nil {
+		return false
+	}
+	for _, choice := range evt.Response.Choices {
+		if strings.Contains(choice.Message.Content, content) {
+			return true
+		}
+		for _, call := range choice.Message.ToolCalls {
+			if strings.Contains(string(call.Function.Arguments), content) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func teamSessionContainsContent(sess *session.Session, content string) bool {
+	if sess == nil {
+		return false
+	}
+	sess.EventMu.RLock()
+	defer sess.EventMu.RUnlock()
+	for _, evt := range sess.Events {
+		if evt.Response == nil {
+			continue
+		}
+		for _, choice := range evt.Response.Choices {
+			if strings.Contains(choice.Message.Content, content) {
+				return true
+			}
+			for _, call := range choice.Message.ToolCalls {
+				if strings.Contains(string(call.Function.Arguments), content) {
+					return true
+				}
+			}
 		}
 	}
 	return false


### PR DESCRIPTION
This adds an opt-in Swarm option that stores non-entry member transcripts in stable per-agent sessions derived from the root session while preserving the existing shared-history default. It routes member events and transfer completion state to the member session, keeps cross-request transfer behavior explicit through WithCrossRequestTransfer, and documents how independent member history interacts with handoffs.