### PR TITLE
openclaw/app: fix knowledge tool tests to use custom descriptions

### DIFF
--- a/openclaw/app/knowledge_tools_test.go
+++ b/openclaw/app/knowledge_tools_test.go
@@ -239,16 +239,15 @@ func TestBuildKnowledgeTools_SingleKnowledgeCustomDescription(t *testing.T) {
 vector_store:
   type: inmemory
 `)
-	entry.Description = "Search the trpc-agent-go documentation including API reference and design docs."
+	customDescription := "Search the trpc-agent-go documentation including API reference and design docs."
+	entry.Description = customDescription
 	bundle, err := buildKnowledgeTools([]knowledgeEntry{entry})
 	require.NoError(t, err)
 	require.NotNil(t, bundle)
 	require.Len(t, bundle.tools, 1)
 	require.Equal(t, "knowledge_search", bundle.tools[0].Declaration().Name)
-	require.Equal(t,
-		"Search the trpc-agent-go documentation including API reference and design docs.",
-		bundle.tools[0].Declaration().Description,
-	)
+	require.Contains(t, bundle.tools[0].Declaration().Description, customDescription)
+	require.Contains(t, bundle.tools[0].Declaration().Description, "== FILTER GUIDANCE ==")
 }
 
 func TestBuildKnowledgeTools_MultipleKnowledgesCustomDescription(t *testing.T) {
@@ -259,16 +258,15 @@ vector_store:
   type: inmemory
 `
 	docs := builtinKnowledgeEntry(t, "docs", inmemory)
-	docs.Description = "Framework documentation and design docs."
+	customDescription := "Framework documentation and design docs."
+	docs.Description = customDescription
 	faq := builtinKnowledgeEntry(t, "faq", inmemory)
 	bundle, err := buildKnowledgeTools([]knowledgeEntry{docs, faq})
 	require.NoError(t, err)
 	require.NotNil(t, bundle)
 	require.Len(t, bundle.tools, 2)
-	require.Equal(t,
-		"Framework documentation and design docs.",
-		bundle.tools[0].Declaration().Description,
-	)
+	require.Contains(t, bundle.tools[0].Declaration().Description, customDescription)
+	require.Contains(t, bundle.tools[0].Declaration().Description, "== FILTER GUIDANCE ==")
 	require.Contains(t,
 		bundle.tools[1].Declaration().Description,
 		`"faq"`,


### PR DESCRIPTION
- Updated test cases in `knowledge_tools_test.go` to assign custom descriptions to knowledge entries.
- Changed assertions to use `require.Contains` for validating tool descriptions, ensuring they include the custom description and filter guidance.
- This improves test clarity and maintains consistency in description validation.