### PR TITLE
memory: omit preload topic labels

### DIFF
--- a/internal/flow/processor/content.go
+++ b/internal/flow/processor/content.go
@@ -2229,9 +2229,10 @@ func formatMemoryContent(memories []*memory.Entry) string {
 		if mem.Memory.Location != "" {
 			meta = append(meta, fmt.Sprintf("at=%s", mem.Memory.Location))
 		}
-		if len(mem.Memory.Topics) > 0 {
-			meta = append(meta, fmt.Sprintf("topics=%s", strings.Join(mem.Memory.Topics, ", ")))
-		}
+		// Do not render topic labels in the preload prompt. The memory_add
+		// tool expects topics as []string, and showing inline
+		// "topics=foo, bar" text can lead models to copy a scalar value into
+		// tool arguments.
 		if len(meta) > 0 {
 			fmt.Fprintf(&sb, " (%s)", strings.Join(meta, "; "))
 		}

--- a/internal/flow/processor/content_memory_test.go
+++ b/internal/flow/processor/content_memory_test.go
@@ -148,6 +148,8 @@ func TestFormatMemoriesForPrompt(t *testing.T) {
 				"date=2024-05-07",
 				"with=Alice, Bob",
 				"at=Kyoto",
+			},
+			excludes: []string{
 				"topics=travel, hiking",
 			},
 		},


### PR DESCRIPTION
## Summary

- Stop rendering topic labels in preloaded user memory prompts.
- Keep fact and episodic metadata such as kind, date, participants, and location.
- Update processor test coverage to assert topic labels are omitted.

## Why

Preloaded memories rendered topics as inline text such as `topics=foo, bar`, which could encourage models to pass a scalar string to the `memory_add` tool even though its schema requires an array.

## Tests

- `go test ./internal/flow/processor ./memory/tool`