### PR TITLE
openclaw/cron: record scheduled run debug traces

### DIFF
--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -1220,11 +1220,18 @@ func NewRuntimeWithOptions(
 			memSvc,
 			rlCfg,
 		)
+		cronOpts := runtimeProfileCronOptions(runtimeProfileResolver)
+		if debugRec != nil {
+			cronOpts = append(
+				cronOpts,
+				cron.WithDebugRecorder(debugRec),
+			)
+		}
 		cronSvc, err = cron.NewService(
 			resolvedStateDir,
 			cronRunner,
 			openClawTools.router,
-			runtimeProfileCronOptions(runtimeProfileResolver)...,
+			cronOpts...,
 		)
 		if err != nil {
 			if cronRunner != nil {
@@ -1741,11 +1748,18 @@ func run(ctx context.Context, args []string) error {
 			memSvc,
 			rlCfg,
 		)
+		cronOpts := runtimeProfileCronOptions(runtimeProfileResolver)
+		if debugRec != nil {
+			cronOpts = append(
+				cronOpts,
+				cron.WithDebugRecorder(debugRec),
+			)
+		}
 		cronSvc, err = cron.NewService(
 			resolvedStateDir,
 			cronRunner,
 			openClawTools.router,
-			runtimeProfileCronOptions(runtimeProfileResolver)...,
+			cronOpts...,
 		)
 		if err != nil {
 			if cronRunner != nil {

--- a/openclaw/internal/cron/service.go
+++ b/openclaw/internal/cron/service.go
@@ -26,6 +26,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/debugrecorder"
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/outbound"
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/runtimeprofile"
 	"trpc.group/trpc-go/trpc-agent-go/runner"
@@ -63,6 +64,8 @@ const (
 	scheduledRunTaskPrefix = "\nTask:\n"
 
 	scheduledRunTemplateMarker = "{{"
+
+	debugTraceSourceCron = "cron"
 )
 
 // Service runs and persists scheduled jobs.
@@ -71,6 +74,7 @@ type Service struct {
 	runner   runner.Runner
 	router   *outbound.Router
 	profiles runtimeprofile.Resolver
+	recorder *debugrecorder.Recorder
 
 	tickInterval time.Duration
 	clock        func() time.Time
@@ -128,6 +132,13 @@ func WithClock(fn func() time.Time) Option {
 func WithRuntimeProfileResolver(resolver runtimeprofile.Resolver) Option {
 	return func(s *Service) {
 		s.profiles = resolver
+	}
+}
+
+// WithDebugRecorder records scheduled runs into the runtime debug dir.
+func WithDebugRecorder(recorder *debugrecorder.Recorder) Option {
+	return func(s *Service) {
+		s.recorder = recorder
 	}
 }
 
@@ -547,8 +558,31 @@ func (s *Service) executeJob(
 
 	sessionID := freshRunSessionID(job.ID, now)
 	s.setRunMetadata(job.ID, runToken, sessionID, requestID)
+	var runErr error
+	var deliveryErr error
+	trace, traceStartedAt := s.startDebugTrace(
+		runCtx,
+		job,
+		sessionID,
+		requestID,
+		scheduledAt,
+		reschedule,
+	)
+	if trace != nil {
+		runCtx = debugrecorder.WithTrace(runCtx, trace)
+		defer func() {
+			closeCronDebugTrace(
+				trace,
+				traceStartedAt,
+				runErr,
+				deliveryErr,
+			)
+		}()
+	}
+
 	profile, err := s.resolveRuntimeProfile(runCtx, job)
 	if err != nil {
+		runErr = err
 		s.finishRun(
 			job.ID,
 			runToken,
@@ -572,24 +606,35 @@ func (s *Service) executeJob(
 		model.NewUserMessage(buildScheduledRunMessage(job)),
 		runOpts...,
 	)
+	runErr = err
 
 	result := cronReplyAccumulator{}
-	if err == nil {
+	if runErr == nil {
 		for evt := range events {
+			if trace != nil && evt != nil {
+				_ = trace.Record(debugrecorder.KindRunnerEvent, evt)
+			}
 			result.consume(evt)
 		}
 		if result.err != nil {
-			err = result.err
+			runErr = result.err
 		}
 	}
+	if trace != nil && runErr != nil {
+		_ = trace.RecordError(runErr)
+	}
 
-	deliveryErr := error(nil)
 	output := sanitizeStoredOutput(result.text)
-	if err == nil &&
+	if trace != nil && output != "" {
+		_ = trace.RecordText(output)
+	}
+	deliveryAttempted := false
+	if runErr == nil &&
 		s.deliveryAllowed(job.ID, runToken) &&
 		job.Delivery.Channel != "" &&
 		job.Delivery.Target != "" &&
 		strings.TrimSpace(result.text) != "" {
+		deliveryAttempted = true
 		if s.router == nil {
 			deliveryErr = fmt.Errorf("cron: nil outbound router")
 		} else {
@@ -600,6 +645,12 @@ func (s *Service) executeJob(
 			)
 		}
 	}
+	recordCronDeliveryTrace(
+		trace,
+		job,
+		deliveryAttempted,
+		deliveryErr,
+	)
 
 	s.finishRun(
 		job.ID,
@@ -607,10 +658,133 @@ func (s *Service) executeJob(
 		scheduledAt,
 		now,
 		output,
-		err,
+		runErr,
 		deliveryErr,
 		reschedule,
 	)
+}
+
+func (s *Service) startDebugTrace(
+	ctx context.Context,
+	job *Job,
+	sessionID string,
+	requestID string,
+	scheduledAt time.Time,
+	reschedule bool,
+) (*debugrecorder.Trace, time.Time) {
+	recorder := s.recorder
+	if recorder == nil {
+		recorder = debugrecorder.RecorderFromContext(ctx)
+	}
+	if recorder == nil || job == nil {
+		return nil, time.Time{}
+	}
+
+	startedAt := time.Now()
+	trace, err := recorder.Start(debugrecorder.TraceStart{
+		Channel:   job.Delivery.Channel,
+		UserID:    job.UserID,
+		SessionID: sessionID,
+		Thread:    job.Delivery.Target,
+		RequestID: requestID,
+		Source:    debugTraceSourceCron,
+	})
+	if err != nil {
+		log.Warnf("cron: start debug trace: %v", err)
+		return nil, time.Time{}
+	}
+
+	_ = trace.Record(
+		debugrecorder.KindCronRun,
+		cronDebugRunRecord(job, scheduledAt, reschedule),
+	)
+	return trace, startedAt
+}
+
+func cronDebugRunRecord(
+	job *Job,
+	scheduledAt time.Time,
+	reschedule bool,
+) map[string]any {
+	record := map[string]any{
+		"job_id":           strings.TrimSpace(job.ID),
+		"job_name":         strings.TrimSpace(job.Name),
+		"schedule":         ScheduleSummary(job.Schedule),
+		"reschedule":       reschedule,
+		"delivery_channel": strings.TrimSpace(job.Delivery.Channel),
+		"delivery_target":  strings.TrimSpace(job.Delivery.Target),
+		"timeout_sec":      job.TimeoutSec,
+		"message":          strings.TrimSpace(job.Message),
+	}
+	runContext := scheduledRunContext(job)
+	record["run_index"] = runContext.RunIndex
+	record["has_max_runs"] = runContext.HasMaxRuns
+	record["max_runs"] = runContext.MaxRuns
+	record["remaining_runs"] = runContext.RemainingRuns
+	record["is_final_run"] = runContext.IsFinalRun
+	if !scheduledAt.IsZero() {
+		record["scheduled_at"] = scheduledAt
+	}
+	return record
+}
+
+func recordCronDeliveryTrace(
+	trace *debugrecorder.Trace,
+	job *Job,
+	attempted bool,
+	err error,
+) {
+	if trace == nil || job == nil {
+		return
+	}
+	record := map[string]any{
+		"attempted": attempted,
+		"channel":   strings.TrimSpace(job.Delivery.Channel),
+		"target":    strings.TrimSpace(job.Delivery.Target),
+	}
+	if err != nil {
+		record["error"] = err.Error()
+	}
+	_ = trace.Record(debugrecorder.KindCronDelivery, record)
+}
+
+func closeCronDebugTrace(
+	trace *debugrecorder.Trace,
+	startedAt time.Time,
+	runErr error,
+	deliveryErr error,
+) {
+	if trace == nil {
+		return
+	}
+	end := debugrecorder.TraceEnd{
+		Duration: time.Since(startedAt),
+		Status:   cronDebugTraceStatus(runErr, deliveryErr),
+		Error:    cronDebugTraceError(runErr, deliveryErr),
+	}
+	_ = trace.Close(end)
+}
+
+func cronDebugTraceStatus(runErr error, deliveryErr error) string {
+	switch {
+	case runErr != nil:
+		return StatusFailed
+	case deliveryErr != nil:
+		return StatusDeliveryFailed
+	default:
+		return StatusSucceeded
+	}
+}
+
+func cronDebugTraceError(runErr error, deliveryErr error) string {
+	switch {
+	case runErr != nil:
+		return runErr.Error()
+	case deliveryErr != nil:
+		return deliveryErr.Error()
+	default:
+		return ""
+	}
 }
 
 func (s *Service) resolveRuntimeProfile(

--- a/openclaw/internal/cron/service_test.go
+++ b/openclaw/internal/cron/service_test.go
@@ -12,6 +12,8 @@ package cron
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -22,6 +24,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/debugrecorder"
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/outbound"
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/runtimeprofile"
 	"trpc.group/trpc-go/trpc-agent-go/session"
@@ -192,6 +195,7 @@ type stubSender struct {
 	mu     sync.Mutex
 	target string
 	text   string
+	err    error
 }
 
 func (s *stubSender) ID() string { return "telegram" }
@@ -210,7 +214,7 @@ func (s *stubSender) SendText(
 	defer s.mu.Unlock()
 	s.target = target
 	s.text = text
-	return nil
+	return s.err
 }
 
 func TestServiceRunNowSendsToDeliveryTarget(t *testing.T) {
@@ -280,6 +284,122 @@ func TestServiceRunNowSendsToDeliveryTarget(t *testing.T) {
 		job.ID,
 		runner.runOpts.RuntimeState[runtimeStateJobID],
 	)
+}
+
+func TestServiceRunNowWritesDebugTrace(t *testing.T) {
+	router := outbound.NewRouter()
+	sender := &stubSender{}
+	router.RegisterSender(sender)
+
+	rec, err := debugrecorder.New(t.TempDir(), "")
+	require.NoError(t, err)
+
+	runner := &stubRunner{reply: "resource report"}
+	svc, err := NewService(
+		t.TempDir(),
+		runner,
+		router,
+		WithDebugRecorder(rec),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, svc.Close())
+	})
+
+	job, err := svc.Add(&Job{
+		Name:    "report",
+		Enabled: true,
+		Schedule: Schedule{
+			Kind:  ScheduleKindEvery,
+			Every: "1m",
+		},
+		Message: "collect system resources",
+		UserID:  "telegram:user",
+		Delivery: outbound.DeliveryTarget{
+			Channel: "telegram",
+			Target:  "100",
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = svc.RunNow(job.ID)
+	require.NoError(t, err)
+
+	traceDir := waitForCronTrace(t, rec.Dir())
+	events, err := debugrecorder.ReadEventsFile(traceDir)
+	require.NoError(t, err)
+	rawEvents := string(events)
+	require.Contains(t, rawEvents, debugrecorder.KindCronRun)
+	require.Contains(t, rawEvents, debugrecorder.KindRunnerEvent)
+	require.Contains(t, rawEvents, debugrecorder.KindCronDelivery)
+	require.Contains(t, rawEvents, "resource report")
+
+	meta := readCronTraceMeta(t, traceDir)
+	require.Equal(t, "cron", meta.Start.Source)
+	require.Equal(t, "telegram", meta.Start.Channel)
+	require.Equal(t, "telegram:user", meta.Start.UserID)
+	require.True(t, strings.HasPrefix(meta.Start.SessionID, cronSessionPrefix))
+	require.Empty(t, meta.Start.TraceID)
+
+	result := readCronTraceResult(t, traceDir)
+	require.Equal(t, StatusSucceeded, result.Status)
+	require.Empty(t, result.Error)
+}
+
+func TestServiceRunNowDebugTraceRecordsDeliveryFailure(t *testing.T) {
+	router := outbound.NewRouter()
+	sender := &stubSender{err: context.DeadlineExceeded}
+	router.RegisterSender(sender)
+
+	rec, err := debugrecorder.New(t.TempDir(), "")
+	require.NoError(t, err)
+
+	runner := &stubRunner{reply: "resource report"}
+	svc, err := NewService(
+		t.TempDir(),
+		runner,
+		router,
+		WithDebugRecorder(rec),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, svc.Close())
+	})
+
+	job, err := svc.Add(&Job{
+		Name:    "report",
+		Enabled: true,
+		Schedule: Schedule{
+			Kind:  ScheduleKindEvery,
+			Every: "1m",
+		},
+		Message: "collect system resources",
+		UserID:  "telegram:user",
+		Delivery: outbound.DeliveryTarget{
+			Channel: "telegram",
+			Target:  "100",
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = svc.RunNow(job.ID)
+	require.NoError(t, err)
+
+	waitFor(t, func() bool {
+		got := svc.Get(job.ID)
+		return got != nil && got.LastStatus == StatusDeliveryFailed
+	})
+
+	traceDir := waitForCronTrace(t, rec.Dir())
+	events, err := debugrecorder.ReadEventsFile(traceDir)
+	require.NoError(t, err)
+	rawEvents := string(events)
+	require.Contains(t, rawEvents, debugrecorder.KindCronDelivery)
+	require.Contains(t, rawEvents, context.DeadlineExceeded.Error())
+
+	result := readCronTraceResult(t, traceDir)
+	require.Equal(t, StatusDeliveryFailed, result.Status)
+	require.Equal(t, context.DeadlineExceeded.Error(), result.Error)
 }
 
 func TestServiceRunNowAppliesRuntimeProfile(t *testing.T) {
@@ -1468,6 +1588,54 @@ func waitFor(t *testing.T, fn func() bool) {
 		time.Sleep(20 * time.Millisecond)
 	}
 	t.Fatalf("condition was not met")
+}
+
+type cronTraceMeta struct {
+	Start debugrecorder.TraceStart `json:"start"`
+}
+
+func waitForCronTrace(t *testing.T, root string) string {
+	t.Helper()
+
+	var matches []string
+	waitFor(t, func() bool {
+		var err error
+		matches, err = filepath.Glob(
+			filepath.Join(root, "*", "*", "result.json"),
+		)
+		require.NoError(t, err)
+		if len(matches) == 0 {
+			return false
+		}
+		_, err = debugrecorder.ReadEventsFile(filepath.Dir(matches[0]))
+		return err == nil
+	})
+	return filepath.Dir(matches[0])
+}
+
+func readCronTraceMeta(t *testing.T, traceDir string) cronTraceMeta {
+	t.Helper()
+
+	data, err := os.ReadFile(filepath.Join(traceDir, "meta.json"))
+	require.NoError(t, err)
+
+	var meta cronTraceMeta
+	require.NoError(t, json.Unmarshal(data, &meta))
+	return meta
+}
+
+func readCronTraceResult(
+	t *testing.T,
+	traceDir string,
+) debugrecorder.TraceEnd {
+	t.Helper()
+
+	data, err := os.ReadFile(filepath.Join(traceDir, "result.json"))
+	require.NoError(t, err)
+
+	var result debugrecorder.TraceEnd
+	require.NoError(t, json.Unmarshal(data, &result))
+	return result
 }
 
 func timePointer(ts time.Time) *time.Time {

--- a/openclaw/internal/debugrecorder/recorder.go
+++ b/openclaw/internal/debugrecorder/recorder.go
@@ -61,6 +61,8 @@ const (
 	KindGatewayReq     = "gateway.request"
 	KindGatewayRsp     = "gateway.response"
 	KindGatewayRun     = "gateway.run.start"
+	KindCronRun        = "cron.run.start"
+	KindCronDelivery   = "cron.delivery"
 	KindRuntimeProfile = "runtime.profile"
 	KindModelReq       = "model.chat.request"
 	KindRunnerEvent    = "runner.event"


### PR DESCRIPTION
## Summary
- record OpenClaw scheduled cron runs with debug recorder traces
- add cron run and delivery trace events, including delivery failures
- pass the app debug recorder into cron service and cover success/failure cases

## Tests
- `cd openclaw && go test ./internal/cron ./internal/debugrecorder ./app`