### PR TITLE
session/summary: add dynamic summarizer

### DIFF
--- a/docs/mkdocs/en/session/summary.md
+++ b/docs/mkdocs/en/session/summary.md
@@ -246,6 +246,65 @@ application needs to distinguish different summary entry points, annotate the
 context before calling the session APIs and read the value inside your
 `ContextChecker`.
 
+## Dynamic Summarizer
+
+Use `NewDynamicSummarizer` when the session service should be reused, but the
+summary model, prompt, or checks must vary per request. This is useful for
+multi-tenant systems and custom model routing. Keep the session service
+long-lived, especially for database-backed services such as MySQL, so the
+underlying connection pool can be reused.
+
+```go
+type summaryCfgKey struct{}
+
+type SummaryCfg struct {
+    ModelName string
+    Prompt    string
+}
+
+func WithSummaryCfg(ctx context.Context, cfg SummaryCfg) context.Context {
+    return context.WithValue(ctx, summaryCfgKey{}, cfg)
+}
+
+func SummaryCfgFromContext(ctx context.Context) (SummaryCfg, bool) {
+    cfg, ok := ctx.Value(summaryCfgKey{}).(SummaryCfg)
+    return cfg, ok
+}
+
+summarizer := summary.NewDynamicSummarizer(func(
+    ctx context.Context,
+    sess *session.Session,
+) (summary.SessionSummarizer, error) {
+    cfg, ok := SummaryCfgFromContext(ctx)
+    if !ok {
+        return nil, nil // Skip automatic summary for this call.
+    }
+    return BuildSummarizer(cfg)
+})
+
+sessionService, err := mysql.NewService(
+    mysql.WithMySQLClientDSN(dsn),
+    mysql.WithSummarizer(summarizer),
+)
+```
+
+Before running the request, attach the request-scoped configuration to `ctx`:
+
+```go
+ctx = WithSummaryCfg(ctx, SummaryCfg{
+    ModelName: req.SummaryModel,
+    Prompt:    req.SummaryPrompt,
+})
+```
+
+The resolver should be cheap and deterministic for the same `ctx` and session.
+During non-forced summary, it may be called once for the summary gate and once
+for actual summary generation. If constructing the summarizer is expensive,
+store the already-built summarizer in `ctx` and let the resolver only read it.
+Returning nil from the resolver skips automatic summary checks. Direct
+`Summarize` calls, or forced summary calls without a resolved summarizer, return
+an error.
+
 ## Summarizer Options
 
 ### Trigger Conditions

--- a/docs/mkdocs/en/session/summary.md
+++ b/docs/mkdocs/en/session/summary.md
@@ -303,7 +303,10 @@ for actual summary generation. If constructing the summarizer is expensive,
 store the already-built summarizer in `ctx` and let the resolver only read it.
 Returning nil from the resolver skips automatic summary checks. Direct
 `Summarize` calls, or forced summary calls without a resolved summarizer, return
-an error.
+an error. If the resolver returns an error while `ShouldSummarizeWithContext`
+is checking an automatic, non-forced summary, the gate treats it as `false` and
+skips summary generation; direct `Summarize` calls propagate resolver errors to
+the caller.
 
 ## Summarizer Options
 

--- a/docs/mkdocs/zh/session/summary.md
+++ b/docs/mkdocs/zh/session/summary.md
@@ -301,7 +301,9 @@ ctx = WithSummaryCfg(ctx, SummaryCfg{
 场景下，它可能在摘要检查阶段调用一次，在实际生成摘要阶段再调用一次。如果
 构造摘要器成本较高，可以把已构造好的摘要器放到 `ctx`，resolver 只负责读取。
 resolver 返回 nil 会跳过自动摘要检查；如果直接调用 `Summarize`，或在没有
-解析到真实摘要器时强制摘要，会返回错误。
+解析到真实摘要器时强制摘要，会返回错误。如果 resolver 在
+`ShouldSummarizeWithContext` 执行自动、非强制摘要检查时返回错误，gate 会将其
+当作 `false` 并跳过摘要生成；直接调用 `Summarize` 时会把 resolver 错误返回给调用方。
 
 ## 摘要器选项
 

--- a/docs/mkdocs/zh/session/summary.md
+++ b/docs/mkdocs/zh/session/summary.md
@@ -247,6 +247,62 @@ summarizer := summary.NewSummarizer(
 摘要入口，可以在调用 session API 之前自行往 `ctx` 写入标记，并在
 `ContextChecker` 中读取。
 
+## 动态摘要器
+
+当会话服务需要复用，但摘要模型、提示词或检查条件需要按请求变化时，可以
+使用 `NewDynamicSummarizer`。这适合多租户系统、自定义模型路由等场景。
+对于 MySQL 等数据库会话服务，建议保持 session service 长生命周期复用，
+从而复用底层连接池，而不是为了更换摘要器按请求新建 service。
+
+```go
+type summaryCfgKey struct{}
+
+type SummaryCfg struct {
+    ModelName string
+    Prompt    string
+}
+
+func WithSummaryCfg(ctx context.Context, cfg SummaryCfg) context.Context {
+    return context.WithValue(ctx, summaryCfgKey{}, cfg)
+}
+
+func SummaryCfgFromContext(ctx context.Context) (SummaryCfg, bool) {
+    cfg, ok := ctx.Value(summaryCfgKey{}).(SummaryCfg)
+    return cfg, ok
+}
+
+summarizer := summary.NewDynamicSummarizer(func(
+    ctx context.Context,
+    sess *session.Session,
+) (summary.SessionSummarizer, error) {
+    cfg, ok := SummaryCfgFromContext(ctx)
+    if !ok {
+        return nil, nil // 本次调用跳过自动摘要。
+    }
+    return BuildSummarizer(cfg)
+})
+
+sessionService, err := mysql.NewService(
+    mysql.WithMySQLClientDSN(dsn),
+    mysql.WithSummarizer(summarizer),
+)
+```
+
+请求执行前，把本次摘要配置放到 `ctx`：
+
+```go
+ctx = WithSummaryCfg(ctx, SummaryCfg{
+    ModelName: req.SummaryModel,
+    Prompt:    req.SummaryPrompt,
+})
+```
+
+对于同一个 `ctx` 和 session，resolver 应尽量保持轻量且确定。非强制摘要
+场景下，它可能在摘要检查阶段调用一次，在实际生成摘要阶段再调用一次。如果
+构造摘要器成本较高，可以把已构造好的摘要器放到 `ctx`，resolver 只负责读取。
+resolver 返回 nil 会跳过自动摘要检查；如果直接调用 `Summarize`，或在没有
+解析到真实摘要器时强制摘要，会返回错误。
+
 ## 摘要器选项
 
 ### 触发条件

--- a/session/inmemory/summary_test.go
+++ b/session/inmemory/summary_test.go
@@ -20,6 +20,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
+	ssummary "trpc.group/trpc-go/trpc-agent-go/session/summary"
 )
 
 type fakeSummarizer struct {
@@ -946,6 +947,34 @@ func TestMemoryService_CreateSessionSummary_ContextAwareGateReceivesContext(t *t
 	assert.Equal(t, "provider-summary", text)
 }
 
+func TestMemoryService_CreateSessionSummary_DynamicSummarizerUsesContext(t *testing.T) {
+	s := NewSessionService(WithSummarizer(ssummary.NewDynamicSummarizer(
+		func(ctx context.Context, _ *session.Session) (ssummary.SessionSummarizer, error) {
+			trace, _ := ctx.Value(traceIDKey).(string)
+			return &fakeSummarizer{allow: true, out: "dynamic-" + trace}, nil
+		},
+	)))
+
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "sid-dynamic-sync"}
+	sess, err := s.CreateSession(context.Background(), key, session.StateMap{})
+	require.NoError(t, err)
+
+	e := event.New("inv", "user")
+	e.Timestamp = time.Now()
+	e.Response = &model.Response{Choices: []model.Choice{{Message: model.Message{
+		Role:    model.RoleUser,
+		Content: "hello",
+	}}}}
+	require.NoError(t, s.AppendEvent(context.Background(), sess, e))
+
+	ctx := context.WithValue(context.Background(), traceIDKey, "trace-dynamic-sync")
+	require.NoError(t, s.CreateSessionSummary(ctx, sess, "", false))
+
+	text, ok := s.GetSessionSummaryText(context.Background(), sess)
+	require.True(t, ok)
+	assert.Equal(t, "dynamic-trace-dynamic-sync", text)
+}
+
 func TestMemoryService_EnqueueSummaryJob_ContextValuePreserved(t *testing.T) {
 	captureSummarizer := &ctxCaptureSummarizer{done: make(chan struct{})}
 	s := NewSessionService(
@@ -1024,4 +1053,38 @@ func TestMemoryService_EnqueueSummaryJob_ContextAwareGateReceivesContext(t *test
 	assert.Equal(t, "trace-provider", resolved.capturedVal)
 	require.NotNil(t, resolved.sess)
 	assert.Len(t, resolved.sess.Events, 1)
+}
+
+func TestMemoryService_EnqueueSummaryJob_DynamicSummarizerUsesContext(t *testing.T) {
+	s := NewSessionService(
+		WithAsyncSummaryNum(1),
+		WithSummaryQueueSize(10),
+		WithSummarizer(ssummary.NewDynamicSummarizer(
+			func(ctx context.Context, _ *session.Session) (ssummary.SessionSummarizer, error) {
+				trace, _ := ctx.Value(traceIDKey).(string)
+				return &fakeSummarizer{allow: true, out: "dynamic-" + trace}, nil
+			},
+		)),
+	)
+	defer s.Close()
+
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "sid-dynamic-async"}
+	sess, err := s.CreateSession(context.Background(), key, session.StateMap{})
+	require.NoError(t, err)
+
+	e := event.New("inv", "user")
+	e.Timestamp = time.Now()
+	e.Response = &model.Response{Choices: []model.Choice{{Message: model.Message{
+		Role:    model.RoleUser,
+		Content: "hello",
+	}}}}
+	require.NoError(t, s.AppendEvent(context.Background(), sess, e))
+
+	ctx := context.WithValue(context.Background(), traceIDKey, "trace-dynamic-async")
+	require.NoError(t, s.EnqueueSummaryJob(ctx, sess, "", false))
+
+	require.Eventually(t, func() bool {
+		text, ok := s.GetSessionSummaryText(context.Background(), sess)
+		return ok && text == "dynamic-trace-dynamic-async"
+	}, 2*time.Second, 50*time.Millisecond)
 }

--- a/session/summary/dynamic.go
+++ b/session/summary/dynamic.go
@@ -25,8 +25,10 @@ var errNoDynamicSummarizerResolved = errors.New("no dynamic summarizer resolved"
 //
 // It is useful when the session service should be long-lived while the summary
 // model, prompt, or checks need to vary per request. Returning nil from resolve
-// skips automatic summary checks. Calling Summarize directly, or forcing a
-// summary without a resolved summarizer, returns an error.
+// skips automatic summary checks. Resolver errors also make the automatic
+// summary gate return false, while Summarize propagates resolver errors.
+// Calling Summarize directly, or forcing a summary without a resolved
+// summarizer, returns an error.
 func NewDynamicSummarizer(
 	resolve func(context.Context, *session.Session) (SessionSummarizer, error),
 ) SessionSummarizer {

--- a/session/summary/dynamic.go
+++ b/session/summary/dynamic.go
@@ -1,0 +1,105 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package summary
+
+import (
+	"context"
+	"errors"
+
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+const metadataDynamicSummarizerType = "dynamic"
+
+var errNoDynamicSummarizerResolved = errors.New("no dynamic summarizer resolved")
+
+// NewDynamicSummarizer creates a summarizer that resolves the actual
+// summarizer from the current request context and session at summary time.
+//
+// It is useful when the session service should be long-lived while the summary
+// model, prompt, or checks need to vary per request. Returning nil from resolve
+// skips automatic summary checks. Calling Summarize directly, or forcing a
+// summary without a resolved summarizer, returns an error.
+func NewDynamicSummarizer(
+	resolve func(context.Context, *session.Session) (SessionSummarizer, error),
+) SessionSummarizer {
+	if resolve == nil {
+		return nil
+	}
+	return &dynamicSummarizer{resolve: resolve}
+}
+
+type dynamicSummarizer struct {
+	resolve func(context.Context, *session.Session) (SessionSummarizer, error)
+}
+
+var _ ContextAwareSummarizer = (*dynamicSummarizer)(nil)
+
+func (d *dynamicSummarizer) resolveSummarizer(
+	ctx context.Context,
+	sess *session.Session,
+) (SessionSummarizer, error) {
+	if d == nil || d.resolve == nil {
+		return nil, nil
+	}
+	return d.resolve(ctx, sess)
+}
+
+// ShouldSummarize checks if the session should be summarized.
+func (d *dynamicSummarizer) ShouldSummarize(sess *session.Session) bool {
+	return d.ShouldSummarizeWithContext(context.Background(), sess)
+}
+
+// ShouldSummarizeWithContext resolves the current summarizer and evaluates its
+// summary gate with the provided context.
+func (d *dynamicSummarizer) ShouldSummarizeWithContext(
+	ctx context.Context,
+	sess *session.Session,
+) bool {
+	resolved, err := d.resolveSummarizer(ctx, sess)
+	if err != nil || resolved == nil {
+		return false
+	}
+	if contextual, ok := resolved.(ContextAwareSummarizer); ok {
+		return contextual.ShouldSummarizeWithContext(ctx, sess)
+	}
+	return resolved.ShouldSummarize(sess)
+}
+
+// Summarize resolves the current summarizer and delegates summary generation
+// to it.
+func (d *dynamicSummarizer) Summarize(
+	ctx context.Context,
+	sess *session.Session,
+) (string, error) {
+	resolved, err := d.resolveSummarizer(ctx, sess)
+	if err != nil {
+		return "", err
+	}
+	if resolved == nil {
+		return "", errNoDynamicSummarizerResolved
+	}
+	return resolved.Summarize(ctx, sess)
+}
+
+// SetPrompt is a no-op for dynamic summarizers. Configure request-scoped
+// prompts in the resolver instead.
+func (d *dynamicSummarizer) SetPrompt(string) {}
+
+// SetModel is a no-op for dynamic summarizers. Configure request-scoped models
+// in the resolver instead.
+func (d *dynamicSummarizer) SetModel(model.Model) {}
+
+// Metadata returns metadata about the dynamic summarizer.
+func (d *dynamicSummarizer) Metadata() map[string]any {
+	return map[string]any{
+		"type": metadataDynamicSummarizerType,
+	}
+}

--- a/session/summary/dynamic_test.go
+++ b/session/summary/dynamic_test.go
@@ -55,6 +55,26 @@ func TestDynamicSummarizer_DelegatesToResolvedSummarizer(t *testing.T) {
 	assert.Equal(t, "dynamic-summary", text)
 }
 
+func TestDynamicSummarizer_LegacyMethodsAndEmptyResolver(t *testing.T) {
+	sess := &session.Session{ID: "sid"}
+	s := NewDynamicSummarizer(func(
+		context.Context,
+		*session.Session,
+	) (SessionSummarizer, error) {
+		return &dynamicFakeSummarizer{allow: true}, nil
+	})
+
+	assert.True(t, s.ShouldSummarize(sess))
+	s.SetPrompt("ignored")
+	s.SetModel(nil)
+
+	var nilDynamic *dynamicSummarizer
+	assert.False(t, nilDynamic.ShouldSummarizeWithContext(context.Background(), sess))
+
+	emptyDynamic := &dynamicSummarizer{}
+	assert.False(t, emptyDynamic.ShouldSummarizeWithContext(context.Background(), sess))
+}
+
 func TestDynamicSummarizer_NilResolvedSummarizer(t *testing.T) {
 	s := NewDynamicSummarizer(func(
 		context.Context,

--- a/session/summary/dynamic_test.go
+++ b/session/summary/dynamic_test.go
@@ -1,0 +1,176 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package summary
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+type dynamicTestContextKey string
+
+func TestNewDynamicSummarizer_NilResolver(t *testing.T) {
+	assert.Nil(t, NewDynamicSummarizer(nil))
+}
+
+func TestDynamicSummarizer_DelegatesToResolvedSummarizer(t *testing.T) {
+	sess := &session.Session{ID: "sid"}
+	resolved := &dynamicFakeSummarizer{
+		allow:   true,
+		summary: "dynamic-summary",
+	}
+	ctx := context.WithValue(context.Background(), dynamicTestContextKey("route"), "tenant-a")
+	var capturedCtx context.Context
+	var capturedSess *session.Session
+
+	s := NewDynamicSummarizer(func(
+		ctx context.Context,
+		sess *session.Session,
+	) (SessionSummarizer, error) {
+		capturedCtx = ctx
+		capturedSess = sess
+		return resolved, nil
+	})
+
+	contextual, ok := s.(ContextAwareSummarizer)
+	require.True(t, ok)
+	require.True(t, contextual.ShouldSummarizeWithContext(ctx, sess))
+	assert.Equal(t, "tenant-a", capturedCtx.Value(dynamicTestContextKey("route")))
+	assert.Same(t, sess, capturedSess)
+
+	text, err := s.Summarize(ctx, sess)
+	require.NoError(t, err)
+	assert.Equal(t, "dynamic-summary", text)
+}
+
+func TestDynamicSummarizer_NilResolvedSummarizer(t *testing.T) {
+	s := NewDynamicSummarizer(func(
+		context.Context,
+		*session.Session,
+	) (SessionSummarizer, error) {
+		return nil, nil
+	})
+
+	contextual, ok := s.(ContextAwareSummarizer)
+	require.True(t, ok)
+	assert.False(t, contextual.ShouldSummarizeWithContext(context.Background(), &session.Session{}))
+
+	_, err := s.Summarize(context.Background(), &session.Session{})
+	require.ErrorIs(t, err, errNoDynamicSummarizerResolved)
+}
+
+func TestDynamicSummarizer_ResolverError(t *testing.T) {
+	wantErr := errors.New("resolve failed")
+	s := NewDynamicSummarizer(func(
+		context.Context,
+		*session.Session,
+	) (SessionSummarizer, error) {
+		return nil, wantErr
+	})
+
+	contextual, ok := s.(ContextAwareSummarizer)
+	require.True(t, ok)
+	assert.False(t, contextual.ShouldSummarizeWithContext(context.Background(), &session.Session{}))
+
+	_, err := s.Summarize(context.Background(), &session.Session{})
+	require.ErrorIs(t, err, wantErr)
+}
+
+func TestDynamicSummarizer_PrefersContextAwareGate(t *testing.T) {
+	resolved := &dynamicContextAwareSummarizer{}
+	s := NewDynamicSummarizer(func(
+		context.Context,
+		*session.Session,
+	) (SessionSummarizer, error) {
+		return resolved, nil
+	})
+
+	contextual, ok := s.(ContextAwareSummarizer)
+	require.True(t, ok)
+	ctx := context.WithValue(context.Background(), dynamicTestContextKey("allow"), true)
+
+	assert.True(t, contextual.ShouldSummarizeWithContext(ctx, &session.Session{}))
+	assert.True(t, resolved.contextGateCalled)
+	assert.False(t, resolved.legacyGateCalled)
+}
+
+func TestDynamicSummarizer_Metadata(t *testing.T) {
+	s := NewDynamicSummarizer(func(
+		context.Context,
+		*session.Session,
+	) (SessionSummarizer, error) {
+		return &dynamicFakeSummarizer{}, nil
+	})
+
+	assert.Equal(t, metadataDynamicSummarizerType, s.Metadata()["type"])
+}
+
+type dynamicFakeSummarizer struct {
+	allow   bool
+	summary string
+}
+
+func (f *dynamicFakeSummarizer) ShouldSummarize(*session.Session) bool {
+	return f.allow
+}
+
+func (f *dynamicFakeSummarizer) Summarize(
+	context.Context,
+	*session.Session,
+) (string, error) {
+	return f.summary, nil
+}
+
+func (f *dynamicFakeSummarizer) SetPrompt(string) {}
+
+func (f *dynamicFakeSummarizer) SetModel(model.Model) {}
+
+func (f *dynamicFakeSummarizer) Metadata() map[string]any {
+	return map[string]any{}
+}
+
+type dynamicContextAwareSummarizer struct {
+	legacyGateCalled  bool
+	contextGateCalled bool
+}
+
+func (f *dynamicContextAwareSummarizer) ShouldSummarize(*session.Session) bool {
+	f.legacyGateCalled = true
+	return false
+}
+
+func (f *dynamicContextAwareSummarizer) ShouldSummarizeWithContext(
+	ctx context.Context,
+	_ *session.Session,
+) bool {
+	f.contextGateCalled = true
+	allow, _ := ctx.Value(dynamicTestContextKey("allow")).(bool)
+	return allow
+}
+
+func (f *dynamicContextAwareSummarizer) Summarize(
+	context.Context,
+	*session.Session,
+) (string, error) {
+	return "context-aware-summary", nil
+}
+
+func (f *dynamicContextAwareSummarizer) SetPrompt(string) {}
+
+func (f *dynamicContextAwareSummarizer) SetModel(model.Model) {}
+
+func (f *dynamicContextAwareSummarizer) Metadata() map[string]any {
+	return map[string]any{}
+}


### PR DESCRIPTION
## Summary
- add `summary.NewDynamicSummarizer` for request-scoped summarizer resolution without adding new public interfaces
- keep the dynamic wrapper compatible with `SessionSummarizer` and `ContextAwareSummarizer`
- document dynamic summarizer usage for long-lived session services such as MySQL

## Tests
- `go test ./session/summary ./session/inmemory`
- `go test ./...` currently has one unrelated local failure in `knowledge/document/reader/golang`: `TestChunkedReaderUsesRepoRootForScope` reports `document "demo.Serve" not found`; isolated rerun of that test fails the same way.