### PR TITLE
agent/extension/todoenforcer: add hard TODO compliance extension

### DIFF
--- a/agent/extension/todoenforcer/doc.go
+++ b/agent/extension/todoenforcer/doc.go
@@ -1,0 +1,109 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+// Package todoenforcer turns the soft, advisory tool/todo workflow
+// into a hard contract: an LLMAgent that has open todo items
+// cannot declare itself "done" without either finishing them or
+// formally declaring an external blocker via the
+// todo_declare_blocker tool that this extension contributes.
+//
+// # Why this exists
+//
+// tool/todo is intentionally low-friction. The model writes a list,
+// the framework persists it to session.State, and a NudgeHook may
+// append text to the next tool result. Nothing prevents the model
+// from emitting a "final" answer while pending or in-progress
+// items remain — the empirical failure mode is the model deciding
+// it has done enough and exiting early. todoenforcer closes that
+// gap at the LLM-agent layer:
+//
+//  1. AfterModel inspects every final response. If the current
+//     branch's todo list still contains pending or in-progress
+//     items, the response's `Done` flag is flipped to false so
+//     llmflow keeps looping; a "reminder pending" marker is
+//     stored on the invocation.
+//  2. BeforeModel drains that marker on the next turn and
+//     appends a nudge user message to the request, listing the
+//     items that remain and the model's two valid next actions
+//     (continue or declare a blocker).
+//  3. todo_declare_blocker is the model's escape route for the
+//     case "I cannot make further progress because of an
+//     objective external blocker" (missing user permission, an
+//     ambiguous requirement that needs human clarification,
+//     infrastructure that is not yet provisioned, a sensitive
+//     decision that must be made by the user, …). Calling it
+//     records the model's stated reason on the invocation and
+//     latches a "declared" flag. From that point on, AfterModel
+//     stops blocking final responses for the rest of the
+//     invocation — the model is FREE to compose and send its
+//     final message explaining what input is missing.
+//  4. A bounded retry budget (WithMaxRetries) caps the loop. Once
+//     exhausted, the response passes through unchanged so that an
+//     undisciplined model cannot trap the runner forever; an
+//     OnEnforce observer surfaces the exhaustion event for
+//     metrics.
+//
+// # Usage
+//
+// Install the enforcer at the LLMAgent level via WithExtensions. The
+// extension contributes both todo_write (tool/todo's existing entry
+// point) and todo_declare_blocker, so the user does not need to
+// register a separate tool/todo instance:
+//
+//	enforcer := todoenforcer.New()
+//	ag := llmagent.New("planner",
+//	    llmagent.WithModel(myModel),
+//	    llmagent.WithExtensions(enforcer),
+//	)
+//
+// To customise the underlying todo tool (state-key prefix, default
+// nudge string, …) construct it explicitly and pass it via
+// WithTodoTool — the enforcer will reuse it instead of building a
+// default:
+//
+//	td := todo.New(todo.WithStateKeyPrefix("temp:plan"))
+//	ag := llmagent.New("planner",
+//	    llmagent.WithExtensions(todoenforcer.New(
+//	        todoenforcer.WithTodoTool(td),
+//	        todoenforcer.WithMaxRetries(3),
+//	    )),
+//	)
+//
+// # Scope
+//
+// todoenforcer is an agent-scoped extension. Its hooks fire only for
+// the LLMAgent it is installed on, never for sub-agents created via
+// chain / parallel / cycle / graph containers. Install it on each
+// agent that should be subject to the contract. Sharing a single
+// Enforcer instance across multiple agents IS supported —
+// per-invocation state (retry counter, reminder flag, declared
+// flag) is keyed off the invocation, not the extension — and is the
+// recommended deployment for cross-agent metric consistency.
+//
+// # Blocker declaration semantics
+//
+// Calling todo_declare_blocker:
+//
+//   - records the model's stated reason on the invocation
+//     (state key todoenforcer:blocker_reason) and emits an
+//     EnforceEvent with Reason = ReasonBlockerDeclared so
+//     observers can count / log it;
+//   - permanently allows future final responses on this
+//     invocation to pass enforcement, so the model can speak to
+//     the user immediately after the call;
+//   - does NOT terminate the invocation. The runner remains in
+//     control and may, as a separate concern, route the next
+//     user turn back to this agent (for example via the framework
+//     await_user_reply tool — entirely orthogonal and optional);
+//   - does NOT clear the todo list. The list stays in session
+//     state so a follow-up user turn (which arrives as a fresh
+//     invocation, with all per-invocation state reset) can pick
+//     up where the model left off once the missing precondition
+//     has been supplied.
+package todoenforcer

--- a/agent/extension/todoenforcer/enforcer.go
+++ b/agent/extension/todoenforcer/enforcer.go
@@ -116,7 +116,15 @@ func (e *Enforcer) Register(r *extension.Registry) {
 	r.AfterModel(e.afterModel)
 }
 
-// beforeModel injects a nudge user message when the previous
+// beforeModel prepares a model request while enforcement is active.
+//
+// It disables streaming whenever open todo items exist. The
+// enforcer can only make a hard allow/block decision after seeing
+// a complete model response; streaming deltas would otherwise
+// reach clients before AfterModel has a chance to reject the final
+// answer.
+//
+// It also injects a nudge user message when the previous
 // AfterModel turn flagged a pending reminder.
 //
 // Notes worth pinning down:
@@ -145,10 +153,10 @@ func (e *Enforcer) beforeModel(
 	if !e.opts.inScope(inv) {
 		return nil, nil
 	}
-	if !reminderPending(inv) {
-		return nil, nil
+	pendingReminder := reminderPending(inv)
+	if pendingReminder {
+		setReminderPending(inv, false)
 	}
-	setReminderPending(inv, false)
 
 	// Read through the prefix the configured todo tool actually
 	// writes with. todo.GetTodos hard-codes DefaultStateKeyPrefix,
@@ -159,7 +167,7 @@ func (e *Enforcer) beforeModel(
 	// "temp:todos:<branch>" and concluded the list was empty.
 	items, err := todo.GetTodosWithPrefix(
 		invocationSession(inv),
-		e.todoTool.StateKeyPrefix(),
+		e.todoStateKeyPrefix(),
 		invocationBranch(inv),
 	)
 	if err != nil {
@@ -170,6 +178,11 @@ func (e *Enforcer) beforeModel(
 	if len(inProgress) == 0 && len(pending) == 0 {
 		return nil, nil
 	}
+	args.Request.GenerationConfig.Stream = false
+
+	if !pendingReminder {
+		return nil, nil
+	}
 
 	msg := e.opts.NudgeFormatter(NudgeContext{
 		AgentName:              invocationAgentName(inv),
@@ -178,7 +191,7 @@ func (e *Enforcer) beforeModel(
 		AttemptNumber:          retryCount(inv),
 		MaxRetries:             e.opts.MaxRetries,
 		TodoToolName:           e.todoToolName(),
-		DeclareBlockerToolName: e.declareBlockerTool.name,
+		DeclareBlockerToolName: e.declareBlockerToolName(),
 	})
 	if msg == "" {
 		return nil, nil
@@ -196,6 +209,26 @@ func (e *Enforcer) todoToolName() string {
 		return todo.DefaultToolName
 	}
 	return decl.Name
+}
+
+func (e *Enforcer) todoStateKeyPrefix() string {
+	if e == nil || e.todoTool == nil {
+		return todo.DefaultStateKeyPrefix
+	}
+	return e.todoTool.StateKeyPrefix()
+}
+
+func (e *Enforcer) declareBlockerToolName() string {
+	if e == nil {
+		return DefaultDeclareBlockerToolName
+	}
+	if e.declareBlockerTool != nil && e.declareBlockerTool.name != "" {
+		return e.declareBlockerTool.name
+	}
+	if e.opts.DeclareBlockerToolName != "" {
+		return e.opts.DeclareBlockerToolName
+	}
+	return DefaultDeclareBlockerToolName
 }
 
 // afterModel decides whether the response is allowed to be final.
@@ -220,14 +253,14 @@ func (e *Enforcer) todoToolName() string {
 //     observability code that re-reads it sees a clean state;
 //     correctness does not depend on it because the Invocation
 //     is about to be discarded anyway.
-//  6. Otherwise: flip Done to false, set reminder pending, bump
-//     the retry counter, emit a blocked event, return the
-//     modified response as CustomResponse.
+//  6. Otherwise: return a non-content control response with
+//     Done=false, set reminder pending, bump the retry counter,
+//     and emit a blocked event.
 //
-// Returning CustomResponse rather than mutating args.Response in
-// place is intentional: the AfterModel chain treats CustomResponse
-// as the new authoritative response. The underlying pointer is the
-// same, so this is a "rebind" not a deep copy.
+// Returning a separate CustomResponse is intentional: the original
+// model text was a premature final answer. Letting it pass through
+// with Done=false would continue the loop, but still leak the false
+// answer to clients and session history.
 func (e *Enforcer) afterModel(
 	ctx context.Context,
 	args *model.AfterModelArgs,
@@ -259,7 +292,7 @@ func (e *Enforcer) afterModel(
 	// "temp:todos:<branch>" and concluded the list was empty.
 	items, err := todo.GetTodosWithPrefix(
 		invocationSession(inv),
-		e.todoTool.StateKeyPrefix(),
+		e.todoStateKeyPrefix(),
 		invocationBranch(inv),
 	)
 	if err != nil {
@@ -289,7 +322,6 @@ func (e *Enforcer) afterModel(
 		return nil, nil
 	}
 
-	args.Response.Done = false
 	setReminderPending(inv, true)
 	attempt := incRetryCount(inv)
 	e.notify(EnforceEvent{
@@ -300,7 +332,21 @@ func (e *Enforcer) afterModel(
 		PendingCount:    len(pending),
 		InProgressCount: len(inProgress),
 	})
-	return &model.AfterModelResult{CustomResponse: args.Response}, nil
+	return &model.AfterModelResult{
+		CustomResponse: blockedControlResponse(args.Response),
+	}, nil
+}
+
+func blockedControlResponse(src *model.Response) *model.Response {
+	if src == nil {
+		return &model.Response{Done: false}
+	}
+	rsp := src.Clone()
+	rsp.Done = false
+	rsp.IsPartial = false
+	rsp.Choices = nil
+	rsp.Error = nil
+	return rsp
 }
 
 // shouldConsiderResponse mirrors llmflow's loop-termination

--- a/agent/extension/todoenforcer/enforcer.go
+++ b/agent/extension/todoenforcer/enforcer.go
@@ -178,6 +178,7 @@ func (e *Enforcer) beforeModel(
 		InProgress:             inProgress,
 		AttemptNumber:          retryCount(inv),
 		MaxRetries:             e.opts.MaxRetries,
+		TodoToolName:           e.todoToolName(),
 		DeclareBlockerToolName: e.declareBlockerTool.name,
 	})
 	if msg == "" {
@@ -185,6 +186,17 @@ func (e *Enforcer) beforeModel(
 	}
 	args.Request.Messages = append(args.Request.Messages, model.NewUserMessage(msg))
 	return nil, nil
+}
+
+func (e *Enforcer) todoToolName() string {
+	if e == nil || e.todoTool == nil {
+		return todo.DefaultToolName
+	}
+	decl := e.todoTool.Declaration()
+	if decl == nil || decl.Name == "" {
+		return todo.DefaultToolName
+	}
+	return decl.Name
 }
 
 // afterModel decides whether the response is allowed to be final.

--- a/agent/extension/todoenforcer/enforcer.go
+++ b/agent/extension/todoenforcer/enforcer.go
@@ -1,0 +1,368 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package todoenforcer
+
+import (
+	"context"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/extension"
+	"trpc.group/trpc-go/trpc-agent-go/log"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/tool/todo"
+)
+
+// Enforcer is the agent-scoped extension that turns tool/todo's
+// advisory checklist into a hard contract. See doc.go for the
+// high-level rationale and lifecycle.
+//
+// An Enforcer implements extension.Extension. Its Register call
+// registers BeforeModel + AfterModel callbacks and contributes the
+// todo_write + todo_declare_blocker tools to the agent's tool list,
+// so callers do not need to install tool/todo separately.
+//
+// All enforcement state is invocation-scoped (see state.go).
+// Sharing a single Enforcer across multiple agents is supported
+// and is the recommended deployment for cross-agent metric
+// consistency.
+type Enforcer struct {
+	opts               Options
+	todoTool           *todo.Tool
+	declareBlockerTool *declareBlockerTool
+}
+
+// Compile-time interface assertion.
+var _ extension.Extension = (*Enforcer)(nil)
+
+// New builds an Enforcer with the supplied options applied on
+// top of the defaults. The returned value is ready to install via
+// llmagent.WithExtensions.
+func New(opts ...Option) *Enforcer {
+	o := Options{
+		Name:                   DefaultExtensionName,
+		MaxRetries:             DefaultMaxRetries,
+		DeclareBlockerToolName: DefaultDeclareBlockerToolName,
+		NudgeFormatter:         DefaultNudgeFormatter,
+		AllowToolCallFinal:     true,
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&o)
+		}
+	}
+	if o.MaxRetries <= 0 {
+		o.MaxRetries = DefaultMaxRetries
+	}
+	if o.NudgeFormatter == nil {
+		o.NudgeFormatter = DefaultNudgeFormatter
+	}
+
+	e := &Enforcer{opts: o}
+	if o.TodoTool != nil {
+		e.todoTool = o.TodoTool
+	} else {
+		e.todoTool = todo.New()
+	}
+	e.declareBlockerTool = newDeclareBlockerTool(
+		o.DeclareBlockerToolName, o.DeclareBlockerToolDescription, e,
+	)
+	return e
+}
+
+// Name implements extension.Extension.
+func (e *Enforcer) Name() string {
+	if e.opts.Name == "" {
+		return DefaultExtensionName
+	}
+	return e.opts.Name
+}
+
+// Register implements extension.Extension.
+//
+// Wires three things onto the agent:
+//
+//   - todo_write (the workhorse) and todo_declare_blocker
+//     (the escape hatch) tools, contributed in that fixed order so
+//     they appear in the agent declaration the same way users learn
+//     about them in the docs;
+//   - a BeforeModel callback that injects a nudge message when the
+//     previous turn flagged a reminder pending;
+//   - an AfterModel callback that flips Done=false when the model
+//     tries to finalise with open todo items.
+//
+// We deliberately do not register BeforeAgent / AfterAgent / tool
+// callbacks: enforcement decisions are about the model's structured
+// output (Done flag + tool calls), not the agent lifecycle or
+// per-tool dispatch.
+func (e *Enforcer) Register(r *extension.Registry) {
+	if r == nil {
+		return
+	}
+	if e.todoTool != nil {
+		r.Tools(e.todoTool)
+	}
+	if e.declareBlockerTool != nil {
+		r.Tools(e.declareBlockerTool)
+	}
+	r.BeforeModel(e.beforeModel)
+	r.AfterModel(e.afterModel)
+}
+
+// beforeModel injects a nudge user message when the previous
+// AfterModel turn flagged a pending reminder.
+//
+// Notes worth pinning down:
+//
+//   - We append directly to args.Request.Messages, mirroring how
+//     toolsearch / errormessage manipulate Request in BeforeModel.
+//     We do NOT use internal/state/steer.Queue: that queue is for
+//     runner-level injected user messages and persists into
+//     session history, which we want to avoid so retries don't
+//     pollute downstream transcripts.
+//   - The pending flag is consumed unconditionally — even when
+//     the formatter returns "" (silent block) — otherwise the
+//     next turn would try to inject again indefinitely.
+//   - Internal failures (todo decode error, missing invocation)
+//     are logged and skipped rather than propagated. Aborting a
+//     run because of a corrupted state entry would be worse than
+//     a missed nudge.
+func (e *Enforcer) beforeModel(
+	ctx context.Context,
+	args *model.BeforeModelArgs,
+) (*model.BeforeModelResult, error) {
+	if args == nil || args.Request == nil {
+		return nil, nil
+	}
+	inv, _ := agent.InvocationFromContext(ctx)
+	if !e.opts.inScope(inv) {
+		return nil, nil
+	}
+	if !reminderPending(inv) {
+		return nil, nil
+	}
+	setReminderPending(inv, false)
+
+	// Read through the prefix the configured todo tool actually
+	// writes with. todo.GetTodos hard-codes DefaultStateKeyPrefix,
+	// so a user that supplied WithTodoTool(todo.New(
+	// todo.WithStateKeyPrefix("custom"))) would otherwise see the
+	// enforcer silently miss every write — open items would
+	// linger in "custom:<branch>" while the enforcer looked at
+	// "temp:todos:<branch>" and concluded the list was empty.
+	items, err := todo.GetTodosWithPrefix(
+		invocationSession(inv),
+		e.todoTool.StateKeyPrefix(),
+		invocationBranch(inv),
+	)
+	if err != nil {
+		log.WarnfContext(ctx, "todoenforcer: read todos failed: %v", err)
+		return nil, nil
+	}
+	inProgress, pending := splitByStatus(items)
+	if len(inProgress) == 0 && len(pending) == 0 {
+		return nil, nil
+	}
+
+	msg := e.opts.NudgeFormatter(NudgeContext{
+		AgentName:              invocationAgentName(inv),
+		Pending:                pending,
+		InProgress:             inProgress,
+		AttemptNumber:          retryCount(inv),
+		MaxRetries:             e.opts.MaxRetries,
+		DeclareBlockerToolName: e.declareBlockerTool.name,
+	})
+	if msg == "" {
+		return nil, nil
+	}
+	args.Request.Messages = append(args.Request.Messages, model.NewUserMessage(msg))
+	return nil, nil
+}
+
+// afterModel decides whether the response is allowed to be final.
+//
+// Decision tree, ordered for fast no-op on the common path:
+//
+//  1. Missing invocation, no response, or out of scope → no-op.
+//  2. Response is not a candidate (still streaming, or carries
+//     tool calls and AllowToolCallFinal is true) → no-op.
+//     Tool-call responses are passed through because the natural
+//     completion pattern is `model -> todo_write(completed) ->
+//     model -> final`, and blocking the intermediate todo_write
+//     turn would break that.
+//  3. Blocker already declared on this invocation → pass through.
+//     Per the v2 contract, once the model has formally signalled
+//     "I cannot proceed without input you have to give me", we
+//     never block its final messages again until the next
+//     user-initiated invocation arrives. The whole point of the
+//     escape hatch is to LET the model talk to the user.
+//  4. Read todos. If none are open, pass through.
+//  5. Retry budget exhausted → emit an exhausted event and pass
+//     through (fail-open). The counter is reset so any
+//     observability code that re-reads it sees a clean state;
+//     correctness does not depend on it because the Invocation
+//     is about to be discarded anyway.
+//  6. Otherwise: flip Done to false, set reminder pending, bump
+//     the retry counter, emit a blocked event, return the
+//     modified response as CustomResponse.
+//
+// Returning CustomResponse rather than mutating args.Response in
+// place is intentional: the AfterModel chain treats CustomResponse
+// as the new authoritative response. The underlying pointer is the
+// same, so this is a "rebind" not a deep copy.
+func (e *Enforcer) afterModel(
+	ctx context.Context,
+	args *model.AfterModelArgs,
+) (*model.AfterModelResult, error) {
+	if args == nil || args.Response == nil {
+		return nil, nil
+	}
+	inv, _ := agent.InvocationFromContext(ctx)
+	if !e.opts.inScope(inv) {
+		return nil, nil
+	}
+	if !e.shouldConsiderResponse(args.Response) {
+		return nil, nil
+	}
+
+	if blockerDeclared(inv) {
+		return nil, nil
+	}
+
+	// Read through the prefix the configured todo tool actually
+	// writes with. todo.GetTodos hard-codes DefaultStateKeyPrefix,
+	// so a user that supplied WithTodoTool(todo.New(
+	// todo.WithStateKeyPrefix("custom"))) would otherwise see the
+	// enforcer silently miss every write — open items would
+	// linger in "custom:<branch>" while the enforcer looked at
+	// "temp:todos:<branch>" and concluded the list was empty.
+	items, err := todo.GetTodosWithPrefix(
+		invocationSession(inv),
+		e.todoTool.StateKeyPrefix(),
+		invocationBranch(inv),
+	)
+	if err != nil {
+		log.WarnfContext(ctx, "todoenforcer: read todos failed: %v", err)
+		return nil, nil
+	}
+	if !hasOpenItems(items) {
+		return nil, nil
+	}
+
+	inProgress, pending := splitByStatus(items)
+
+	if retryCount(inv) >= e.opts.MaxRetries {
+		// Budget exhausted. Surface for metrics, then let the
+		// response through — the model has "won" the loop, and we
+		// prefer letting the user see a possibly-wrong final
+		// answer over keeping the runner stuck.
+		e.notify(EnforceEvent{
+			Reason:          ReasonExhausted,
+			AgentName:       invocationAgentName(inv),
+			AttemptNumber:   retryCount(inv),
+			MaxRetries:      e.opts.MaxRetries,
+			PendingCount:    len(pending),
+			InProgressCount: len(inProgress),
+		})
+		resetRetryCount(inv)
+		return nil, nil
+	}
+
+	args.Response.Done = false
+	setReminderPending(inv, true)
+	attempt := incRetryCount(inv)
+	e.notify(EnforceEvent{
+		Reason:          ReasonBlocked,
+		AgentName:       invocationAgentName(inv),
+		AttemptNumber:   attempt,
+		MaxRetries:      e.opts.MaxRetries,
+		PendingCount:    len(pending),
+		InProgressCount: len(inProgress),
+	})
+	return &model.AfterModelResult{CustomResponse: args.Response}, nil
+}
+
+// shouldConsiderResponse mirrors llmflow's loop-termination
+// predicate, with one knob: when AllowToolCallFinal is true (the
+// default), tool-call responses are treated as non-final from our
+// standpoint and pass through. The model.Response.IsFinalResponse
+// method already returns false for tool-call responses, but we
+// replicate the check here so the AllowToolCallFinal=false branch
+// can be future-extended without touching the model package.
+func (e *Enforcer) shouldConsiderResponse(rsp *model.Response) bool {
+	if rsp == nil {
+		return false
+	}
+	if rsp.IsPartial {
+		return false
+	}
+	if rsp.IsToolCallResponse() {
+		return !e.opts.AllowToolCallFinal
+	}
+	return rsp.IsFinalResponse()
+}
+
+// notify is a thin wrapper around the user-supplied callback. We
+// recover panics so a misbehaving observer cannot crash the
+// model-callback hot path; the runtime cost is one extra deferred
+// call when an OnEnforce is configured.
+func (e *Enforcer) notify(evt EnforceEvent) {
+	if e.opts.OnEnforce == nil {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			log.Errorf("todoenforcer: OnEnforce panic: %v", r)
+		}
+	}()
+	e.opts.OnEnforce(evt)
+}
+
+// notifyBlockerDeclared is the declare-blocker side of notify.
+// Kept as a separate method so the escape-hatch tool does not
+// need to know the EnforceEvent layout.
+func (e *Enforcer) notifyBlockerDeclared(inv *agent.Invocation, reason string) {
+	if e == nil {
+		return
+	}
+	e.notify(EnforceEvent{
+		Reason:        ReasonBlockerDeclared,
+		AgentName:     invocationAgentName(inv),
+		MaxRetries:    e.opts.MaxRetries,
+		BlockerReason: strings.TrimSpace(reason),
+	})
+}
+
+// invocationSession / invocationBranch / invocationAgentName are
+// nil-safe shims around agent.Invocation field access. They exist
+// because BeforeModel / AfterModel can in principle be called
+// with a nil invocation in pure unit tests, and we prefer to
+// no-op gracefully rather than panic.
+func invocationSession(inv *agent.Invocation) *session.Session {
+	if inv == nil {
+		return nil
+	}
+	return inv.Session
+}
+
+func invocationBranch(inv *agent.Invocation) string {
+	if inv == nil {
+		return ""
+	}
+	return inv.Branch
+}
+
+func invocationAgentName(inv *agent.Invocation) string {
+	if inv == nil {
+		return ""
+	}
+	return inv.AgentName
+}

--- a/agent/extension/todoenforcer/enforcer.go
+++ b/agent/extension/todoenforcer/enforcer.go
@@ -52,7 +52,6 @@ func New(opts ...Option) *Enforcer {
 		MaxRetries:             DefaultMaxRetries,
 		DeclareBlockerToolName: DefaultDeclareBlockerToolName,
 		NudgeFormatter:         DefaultNudgeFormatter,
-		AllowToolCallFinal:     true,
 	}
 	for _, opt := range opts {
 		if opt != nil {
@@ -204,12 +203,11 @@ func (e *Enforcer) todoToolName() string {
 // Decision tree, ordered for fast no-op on the common path:
 //
 //  1. Missing invocation, no response, or out of scope → no-op.
-//  2. Response is not a candidate (still streaming, or carries
-//     tool calls and AllowToolCallFinal is true) → no-op.
-//     Tool-call responses are passed through because the natural
-//     completion pattern is `model -> todo_write(completed) ->
-//     model -> final`, and blocking the intermediate todo_write
-//     turn would break that.
+//  2. Response is an error, still streaming, or carries tool
+//     calls → no-op. Error responses must surface unchanged, and
+//     tool-call responses are passed through because tool calls
+//     are how the model continues doing the work (for example
+//     `model -> todo_write(completed) -> model -> final`).
 //  3. Blocker already declared on this invocation → pass through.
 //     Per the v2 contract, once the model has formally signalled
 //     "I cannot proceed without input you have to give me", we
@@ -239,6 +237,9 @@ func (e *Enforcer) afterModel(
 	}
 	inv, _ := agent.InvocationFromContext(ctx)
 	if !e.opts.inScope(inv) {
+		return nil, nil
+	}
+	if args.Error != nil || args.Response.Error != nil {
 		return nil, nil
 	}
 	if !e.shouldConsiderResponse(args.Response) {
@@ -303,21 +304,18 @@ func (e *Enforcer) afterModel(
 }
 
 // shouldConsiderResponse mirrors llmflow's loop-termination
-// predicate, with one knob: when AllowToolCallFinal is true (the
-// default), tool-call responses are treated as non-final from our
-// standpoint and pass through. The model.Response.IsFinalResponse
-// method already returns false for tool-call responses, but we
-// replicate the check here so the AllowToolCallFinal=false branch
-// can be future-extended without touching the model package.
+// predicate but narrows it to successful final text responses.
+// Tool-call responses are a continuation signal rather than an exit
+// signal, and error responses must surface without todo enforcement.
 func (e *Enforcer) shouldConsiderResponse(rsp *model.Response) bool {
 	if rsp == nil {
 		return false
 	}
-	if rsp.IsPartial {
+	if rsp.IsPartial || rsp.Error != nil {
 		return false
 	}
 	if rsp.IsToolCallResponse() {
-		return !e.opts.AllowToolCallFinal
+		return false
 	}
 	return rsp.IsFinalResponse()
 }

--- a/agent/extension/todoenforcer/enforcer_test.go
+++ b/agent/extension/todoenforcer/enforcer_test.go
@@ -1,0 +1,919 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package todoenforcer
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/extension"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/tool/todo"
+)
+
+// newTestInvocation builds a fresh Invocation+Session pair wired
+// into the returned context. Tests use it to exercise BeforeModel
+// / AfterModel directly without spinning up a full LLMAgent.
+//
+// We go through agent.NewInvocation rather than a struct literal
+// so the internal noticeMu / noticeChannels are initialised — the
+// state-setting helpers in agent/invocation.go warn loudly when
+// those are nil.
+func newTestInvocation(t *testing.T, agentName string) (context.Context, *agent.Invocation, *session.Session) {
+	t.Helper()
+	sess := session.NewSession("app", "user", "sid")
+	inv := agent.NewInvocation(agent.WithInvocationSession(sess))
+	inv.AgentName = agentName
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+	return ctx, inv, sess
+}
+
+// writeTodos persists a list directly into session state, so the
+// tests can simulate a state-after-todo_write without going
+// through the tool's Call. Bypassing Call keeps these tests
+// narrow: we exercise the enforcer's reaction to state, not the
+// parser inside todo_write.
+func writeTodos(t *testing.T, sess *session.Session, branch string, items []todo.Item) {
+	t.Helper()
+	raw, err := json.Marshal(items)
+	require.NoError(t, err)
+	key := todo.DefaultStateKeyPrefix
+	if branch != "" {
+		key = todo.DefaultStateKeyPrefix + ":" + branch
+	}
+	sess.SetState(key, raw)
+}
+
+// finalRsp returns a Response that satisfies IsFinalResponse.
+// Tests use it as the "model just declared we are done" input.
+func finalRsp(text string) *model.Response {
+	return &model.Response{
+		Done:    true,
+		Choices: []model.Choice{{Message: model.NewAssistantMessage(text)}},
+	}
+}
+
+// TestNew_DefaultsApplied is the option-pipeline regression net:
+// a default-constructed Enforcer must expose the documented
+// defaults across every config dimension, and registering it on a
+// fresh extension.Registry must contribute exactly the two tools
+// in the canonical order (todo_write first, todo_declare_blocker
+// second).
+func TestNew_DefaultsApplied(t *testing.T) {
+	e := New()
+	assert.Equal(t, DefaultExtensionName, e.Name())
+	assert.Equal(t, DefaultMaxRetries, e.opts.MaxRetries)
+	assert.Equal(t, DefaultDeclareBlockerToolName, e.declareBlockerTool.name)
+	assert.True(t, e.opts.AllowToolCallFinal)
+	assert.NotNil(t, e.opts.NudgeFormatter)
+
+	bundle, err := extension.Collect([]extension.Extension{e})
+	require.NoError(t, err)
+	require.NotNil(t, bundle)
+	tools := bundle.Tools()
+	require.Len(t, tools, 2,
+		"a default Enforcer must contribute exactly todo_write + todo_declare_blocker")
+	assert.Equal(t, todo.DefaultToolName, tools[0].Declaration().Name,
+		"todo_write must come first so the natural reading order in the agent declaration matches the docs")
+	assert.Equal(t, DefaultDeclareBlockerToolName, tools[1].Declaration().Name,
+		"todo_declare_blocker (the escape hatch) must come second")
+}
+
+// TestNew_OptionsOverridden ensures every With* option lands in
+// the constructed Options, including the ones whose fast paths
+// might silently drop bad inputs (WithMaxRetries clamps to
+// default on <=0, WithName ignores empty strings, …).
+func TestNew_OptionsOverridden(t *testing.T) {
+	td := todo.New(todo.WithStateKeyPrefix("temp:plan"))
+	e := New(
+		WithName("planner-enforcer"),
+		WithMaxRetries(7),
+		WithTodoTool(td),
+		WithDeclareBlockerToolName("need_human"),
+		WithDeclareBlockerToolDescription("custom desc"),
+		WithAllowToolCallFinal(false),
+	)
+	assert.Equal(t, "planner-enforcer", e.Name())
+	assert.Equal(t, 7, e.opts.MaxRetries)
+	assert.Same(t, td, e.todoTool)
+	assert.Equal(t, "need_human", e.declareBlockerTool.name)
+	assert.Equal(t, "custom desc", e.declareBlockerTool.description)
+	assert.False(t, e.opts.AllowToolCallFinal)
+}
+
+// TestRegister_WiresExpectedHooks installs the enforcer through
+// the same extension.Collect path that LLMAgent.New uses in
+// production and confirms the resulting Contributions exposes the
+// expected hook counts. This guards against accidental removal of
+// one of the two model hooks or accidental registration of agent /
+// tool hooks.
+func TestRegister_WiresExpectedHooks(t *testing.T) {
+	bundle, err := extension.Collect([]extension.Extension{New()})
+	require.NoError(t, err)
+	require.NotNil(t, bundle)
+
+	modelCallbacks := bundle.ModelCallbacks()
+	require.NotNil(t, modelCallbacks)
+	assert.Len(t, modelCallbacks.BeforeModel, 1,
+		"BeforeModel injects the nudge — exactly one registration expected")
+	assert.Len(t, modelCallbacks.AfterModel, 1,
+		"AfterModel decides whether the response is allowed to be final — exactly one registration expected")
+
+	// Accessors return nil when a callback surface is empty. The
+	// enforcer should leave agent/tool hooks empty: it only operates
+	// on model callbacks.
+	agentCallbacks := bundle.AgentCallbacks()
+	assert.Nil(t, agentCallbacks,
+		"enforcer must not register agent hooks")
+	toolCallbacks := bundle.ToolCallbacks()
+	assert.Nil(t, toolCallbacks,
+		"enforcer must not register tool hooks")
+}
+
+// TestAfterModel_NoTodos_PassesThrough is the empty-state baseline:
+// when no list has ever been written, IsFinalResponse must remain
+// true and no per-invocation state should be left behind.
+func TestAfterModel_NoTodos_PassesThrough(t *testing.T) {
+	ctx, inv, _ := newTestInvocation(t, "a")
+	e := New()
+
+	rsp := finalRsp("done")
+	res, err := e.afterModel(ctx, &model.AfterModelArgs{Response: rsp})
+	require.NoError(t, err)
+	assert.Nil(t, res, "no enforcement → nil result")
+	assert.True(t, rsp.Done, "Done must be untouched")
+	assert.False(t, reminderPending(inv))
+	assert.Equal(t, 0, retryCount(inv))
+}
+
+// TestAfterModel_AllCompleted_PassesThrough is the happy path:
+// every item completed → model is allowed to declare itself done.
+func TestAfterModel_AllCompleted_PassesThrough(t *testing.T) {
+	ctx, inv, sess := newTestInvocation(t, "a")
+	writeTodos(t, sess, "", []todo.Item{
+		{Content: "x", ActiveForm: "x", Status: todo.StatusCompleted},
+	})
+	e := New()
+
+	rsp := finalRsp("done")
+	res, err := e.afterModel(ctx, &model.AfterModelArgs{Response: rsp})
+	require.NoError(t, err)
+	assert.Nil(t, res)
+	assert.True(t, rsp.Done)
+	assert.False(t, reminderPending(inv))
+}
+
+// TestAfterModel_OpenItems_BlocksAndQueuesReminder is the core
+// enforcement assertion: open items present → AfterModel must
+//   - flip Done to false (so llmflow keeps looping),
+//   - return CustomResponse (so the AfterModel chain sees the
+//     rebind),
+//   - set reminder_pending so BeforeModel knows to inject,
+//   - bump the retry counter.
+func TestAfterModel_OpenItems_BlocksAndQueuesReminder(t *testing.T) {
+	ctx, inv, sess := newTestInvocation(t, "a")
+	writeTodos(t, sess, "", []todo.Item{
+		{Content: "Run tests", ActiveForm: "Running tests", Status: todo.StatusInProgress},
+		{Content: "Deploy", ActiveForm: "Deploying", Status: todo.StatusPending},
+	})
+	e := New()
+
+	rsp := finalRsp("done")
+	res, err := e.afterModel(ctx, &model.AfterModelArgs{Response: rsp})
+	require.NoError(t, err)
+	require.NotNil(t, res, "blocked response must be returned via CustomResponse")
+	assert.Same(t, rsp, res.CustomResponse,
+		"enforcer must rebind the SAME response so other AfterModel hooks see the flip")
+	assert.False(t, rsp.Done, "Done must be flipped so the loop continues")
+	assert.True(t, reminderPending(inv))
+	assert.Equal(t, 1, retryCount(inv))
+}
+
+// TestAfterModel_ToolCallResponse_DefaultPassesThrough confirms
+// the AllowToolCallFinal default: a response carrying tool calls
+// is treated as non-final and passes through, regardless of
+// pending todos. The natural completion pattern (model →
+// todo_write → model → final) relies on this.
+func TestAfterModel_ToolCallResponse_DefaultPassesThrough(t *testing.T) {
+	ctx, inv, sess := newTestInvocation(t, "a")
+	writeTodos(t, sess, "", []todo.Item{
+		{Content: "x", ActiveForm: "x", Status: todo.StatusInProgress},
+	})
+	e := New()
+
+	rsp := &model.Response{
+		Done: true,
+		Choices: []model.Choice{{Message: model.Message{
+			Role: model.RoleAssistant,
+			ToolCalls: []model.ToolCall{
+				{ID: "1", Function: model.FunctionDefinitionParam{Name: "todo_write"}},
+			},
+		}}},
+	}
+	res, err := e.afterModel(ctx, &model.AfterModelArgs{Response: rsp})
+	require.NoError(t, err)
+	assert.Nil(t, res)
+	assert.False(t, reminderPending(inv))
+	assert.Equal(t, 0, retryCount(inv))
+}
+
+// TestAfterModel_ToolCallResponse_StrictMode confirms that
+// AllowToolCallFinal=false causes tool-call responses to be
+// blocked too. This is the strict-enforcement mode for stacks
+// that want to refuse any "wrap-up" turn while items remain.
+func TestAfterModel_ToolCallResponse_StrictMode(t *testing.T) {
+	ctx, _, sess := newTestInvocation(t, "a")
+	writeTodos(t, sess, "", []todo.Item{
+		{Content: "x", ActiveForm: "x", Status: todo.StatusInProgress},
+	})
+	e := New(WithAllowToolCallFinal(false))
+
+	rsp := &model.Response{
+		Done: true,
+		Choices: []model.Choice{{Message: model.Message{
+			Role: model.RoleAssistant,
+			ToolCalls: []model.ToolCall{
+				{ID: "1", Function: model.FunctionDefinitionParam{Name: "x"}},
+			},
+		}}},
+	}
+	res, err := e.afterModel(ctx, &model.AfterModelArgs{Response: rsp})
+	require.NoError(t, err)
+	require.NotNil(t, res, "strict mode must block tool-call responses too")
+}
+
+// TestAfterModel_PartialResponse_PassesThrough ensures we never
+// interfere with streaming chunks. Partial responses are by
+// definition not final.
+func TestAfterModel_PartialResponse_PassesThrough(t *testing.T) {
+	ctx, _, sess := newTestInvocation(t, "a")
+	writeTodos(t, sess, "", []todo.Item{
+		{Content: "x", ActiveForm: "x", Status: todo.StatusInProgress},
+	})
+	e := New()
+
+	rsp := finalRsp("partial")
+	rsp.IsPartial = true
+	res, err := e.afterModel(ctx, &model.AfterModelArgs{Response: rsp})
+	require.NoError(t, err)
+	assert.Nil(t, res)
+}
+
+// TestAfterModel_BlockerDeclared_ShortCircuits proves that once
+// todo_declare_blocker has been called on this invocation,
+// AfterModel stops blocking — even with open items. This is the
+// model's escape route working as documented in v2: declare a
+// blocker, then immediately produce the user-facing final
+// message.
+func TestAfterModel_BlockerDeclared_ShortCircuits(t *testing.T) {
+	ctx, inv, sess := newTestInvocation(t, "a")
+	writeTodos(t, sess, "", []todo.Item{
+		{Content: "x", ActiveForm: "x", Status: todo.StatusInProgress},
+	})
+	markBlockerDeclared(inv, "user has not granted prod-write permission")
+	e := New()
+
+	rsp := finalRsp("Need prod-write to continue.")
+	res, err := e.afterModel(ctx, &model.AfterModelArgs{Response: rsp})
+	require.NoError(t, err)
+	assert.Nil(t, res)
+	assert.True(t, rsp.Done)
+}
+
+// TestAfterModel_BlockerDeclared_RemainsLatchedForRestOfInvocation
+// is the v2-specific guarantee: the latch is permanent for the
+// scope of one invocation. A second AfterModel call on the same
+// invocation must also pass through, even if new open items
+// appear in the meantime.
+func TestAfterModel_BlockerDeclared_RemainsLatchedForRestOfInvocation(t *testing.T) {
+	ctx, inv, sess := newTestInvocation(t, "a")
+	writeTodos(t, sess, "", []todo.Item{
+		{Content: "x", ActiveForm: "x", Status: todo.StatusInProgress},
+	})
+	markBlockerDeclared(inv, "missing creds")
+	e := New()
+
+	for i := 0; i < 3; i++ {
+		rsp := finalRsp("waiting on user")
+		res, err := e.afterModel(ctx, &model.AfterModelArgs{Response: rsp})
+		require.NoError(t, err, "pass %d", i)
+		assert.Nil(t, res, "pass %d: latched declaration must keep passing through", i)
+		assert.True(t, rsp.Done)
+	}
+}
+
+// TestAfterModel_RetryBudgetExhausted_FailsOpen verifies the
+// fail-open semantics: once the configured budget is gone, the
+// response passes through unchanged so an undisciplined model
+// cannot trap the runner. An OnEnforce callback observes both
+// the blocked events and the final exhaustion event.
+func TestAfterModel_RetryBudgetExhausted_FailsOpen(t *testing.T) {
+	ctx, inv, sess := newTestInvocation(t, "a")
+	writeTodos(t, sess, "", []todo.Item{
+		{Content: "x", ActiveForm: "x", Status: todo.StatusInProgress},
+	})
+	var observed []EnforceEvent
+	e := New(
+		WithMaxRetries(2),
+		WithOnEnforce(func(evt EnforceEvent) { observed = append(observed, evt) }),
+	)
+
+	for i := 0; i < 2; i++ {
+		rsp := finalRsp("done")
+		_, err := e.afterModel(ctx, &model.AfterModelArgs{Response: rsp})
+		require.NoError(t, err)
+		assert.False(t, rsp.Done, "block %d", i)
+	}
+	rsp := finalRsp("done")
+	res, err := e.afterModel(ctx, &model.AfterModelArgs{Response: rsp})
+	require.NoError(t, err)
+	assert.Nil(t, res, "after exhaustion the response must pass through")
+	assert.True(t, rsp.Done)
+	assert.Equal(t, 0, retryCount(inv),
+		"counter resets on exhaustion for observability cleanliness")
+
+	require.GreaterOrEqual(t, len(observed), 3)
+	assert.Equal(t, ReasonBlocked, observed[0].Reason)
+	assert.Equal(t, ReasonBlocked, observed[1].Reason)
+	assert.Equal(t, ReasonExhausted, observed[len(observed)-1].Reason)
+}
+
+// TestBeforeModel_InjectsNudge_WhenPending verifies the second
+// leg of the contract: a pending reminder is consumed and the
+// formatter output appears as a user message in args.Request.
+func TestBeforeModel_InjectsNudge_WhenPending(t *testing.T) {
+	ctx, inv, sess := newTestInvocation(t, "a")
+	writeTodos(t, sess, "", []todo.Item{
+		{Content: "Run tests", ActiveForm: "Running tests", Status: todo.StatusInProgress},
+	})
+	setReminderPending(inv, true)
+	incRetryCount(inv)
+	e := New()
+
+	req := &model.Request{Messages: []model.Message{model.NewUserMessage("hi")}}
+	_, err := e.beforeModel(ctx, &model.BeforeModelArgs{Request: req})
+	require.NoError(t, err)
+	require.Len(t, req.Messages, 2)
+	assert.Equal(t, model.RoleUser, req.Messages[1].Role)
+	assert.Contains(t, req.Messages[1].Content, "Running tests")
+	assert.Contains(t, req.Messages[1].Content, todo.DefaultToolName)
+	assert.Contains(t, req.Messages[1].Content, DefaultDeclareBlockerToolName)
+	assert.False(t, reminderPending(inv),
+		"BeforeModel must consume the pending flag")
+}
+
+// TestBeforeModel_NoPending_NoOp confirms the BeforeModel branch
+// is a true no-op on the common path.
+func TestBeforeModel_NoPending_NoOp(t *testing.T) {
+	ctx, _, _ := newTestInvocation(t, "a")
+	e := New()
+
+	req := &model.Request{Messages: []model.Message{model.NewUserMessage("hi")}}
+	_, err := e.beforeModel(ctx, &model.BeforeModelArgs{Request: req})
+	require.NoError(t, err)
+	assert.Len(t, req.Messages, 1)
+}
+
+// TestBeforeModel_EmptyFormatterOutput_SkipsInjection covers the
+// silent-block mode: when the formatter returns "", the pending
+// flag is still consumed but no message is appended.
+func TestBeforeModel_EmptyFormatterOutput_SkipsInjection(t *testing.T) {
+	ctx, inv, sess := newTestInvocation(t, "a")
+	writeTodos(t, sess, "", []todo.Item{
+		{Content: "x", ActiveForm: "x", Status: todo.StatusInProgress},
+	})
+	setReminderPending(inv, true)
+	e := New(WithNudgeFormatter(func(NudgeContext) string { return "" }))
+
+	req := &model.Request{Messages: []model.Message{model.NewUserMessage("hi")}}
+	_, err := e.beforeModel(ctx, &model.BeforeModelArgs{Request: req})
+	require.NoError(t, err)
+	assert.Len(t, req.Messages, 1, "silent block must not append a message")
+	assert.False(t, reminderPending(inv), "pending flag is still consumed")
+}
+
+// TestBeforeModel_NilArgs_NoOp covers the defensive early returns
+// at the very top of beforeModel. These cannot happen via the
+// llmflow path (which always supplies a non-nil args.Request), but
+// they exist so unit tests that drive the hook directly do not
+// crash.
+func TestBeforeModel_NilArgs_NoOp(t *testing.T) {
+	e := New()
+
+	res, err := e.beforeModel(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Nil(t, res, "nil args must produce a true no-op (nil, nil)")
+
+	res, err = e.beforeModel(context.Background(), &model.BeforeModelArgs{Request: nil})
+	require.NoError(t, err)
+	assert.Nil(t, res, "nil Request must produce a true no-op (nil, nil)")
+}
+
+// TestBeforeModel_OutOfScope_NoOp pins the scoping pass-through.
+// Without this branch, the enforcer would silently invoke its
+// state-reading code for every BeforeModel call across every
+// agent the extension happens to be installed on — wasteful on
+// its own and dangerous when those agents share a session-state
+// namespace with code that does not expect todoenforcer's keys.
+func TestBeforeModel_OutOfScope_NoOp(t *testing.T) {
+	e := New(WithScopedAgents("planner"))
+	ctx, inv, _ := newTestInvocation(t, "other")
+	setReminderPending(inv, true)
+
+	req := &model.Request{Messages: []model.Message{model.NewUserMessage("hi")}}
+	_, err := e.beforeModel(ctx, &model.BeforeModelArgs{Request: req})
+	require.NoError(t, err)
+	assert.Len(t, req.Messages, 1, "out-of-scope must not inject a nudge")
+	// The pending flag is *deliberately* not consumed by out-of-
+	// scope calls — if the user later re-runs the same invocation
+	// against the scoped agent, the reminder must still fire.
+	assert.True(t, reminderPending(inv),
+		"out-of-scope must leave the pending flag intact for the in-scope agent")
+}
+
+// TestBeforeModel_PendingButTodosEmpty_SkipsInjection covers the
+// "reminder pending, but the todo list has been completed since
+// the previous AfterModel turn" race. AfterModel can flag a
+// reminder and then the model immediately writes todo_write to
+// close the last item; BeforeModel must observe the now-empty
+// list and bail rather than injecting a stale-looking nudge.
+func TestBeforeModel_PendingButTodosEmpty_SkipsInjection(t *testing.T) {
+	ctx, inv, _ := newTestInvocation(t, "a")
+	setReminderPending(inv, true) // no writeTodos call → list is empty
+	e := New()
+
+	req := &model.Request{Messages: []model.Message{model.NewUserMessage("hi")}}
+	_, err := e.beforeModel(ctx, &model.BeforeModelArgs{Request: req})
+	require.NoError(t, err)
+	assert.Len(t, req.Messages, 1,
+		"empty todo list must skip injection — no items to nudge about")
+	// The pending flag IS consumed (setReminderPending(inv, false)
+	// runs before the empty-items check), because the contract
+	// is "one pending → at most one inspection attempt".
+	assert.False(t, reminderPending(inv),
+		"pending flag must be consumed even when the list turns out empty")
+}
+
+// TestScopedAgents_OnlyTargetEnforced exercises ScopedAgents and
+// the negative branch: out-of-scope invocations get a true pass-
+// through and never even read state.
+func TestScopedAgents_OnlyTargetEnforced(t *testing.T) {
+	e := New(WithScopedAgents("planner"))
+
+	ctxOther, _, sessOther := newTestInvocation(t, "other")
+	writeTodos(t, sessOther, "", []todo.Item{
+		{Content: "x", ActiveForm: "x", Status: todo.StatusInProgress},
+	})
+	rspOther := finalRsp("done")
+	resOther, err := e.afterModel(ctxOther, &model.AfterModelArgs{Response: rspOther})
+	require.NoError(t, err)
+	assert.Nil(t, resOther)
+	assert.True(t, rspOther.Done)
+
+	ctxPlan, _, sessPlan := newTestInvocation(t, "planner")
+	writeTodos(t, sessPlan, "", []todo.Item{
+		{Content: "x", ActiveForm: "x", Status: todo.StatusInProgress},
+	})
+	rspPlan := finalRsp("done")
+	resPlan, err := e.afterModel(ctxPlan, &model.AfterModelArgs{Response: rspPlan})
+	require.NoError(t, err)
+	require.NotNil(t, resPlan)
+	assert.False(t, rspPlan.Done)
+}
+
+// TestBypassAgents_SkipsEnforcement is the inverse of the scoped
+// case: an explicit exemption wins over the default everyone-in-
+// scope behaviour.
+func TestBypassAgents_SkipsEnforcement(t *testing.T) {
+	e := New(WithBypassAgents("planner"))
+
+	ctx, _, sess := newTestInvocation(t, "planner")
+	writeTodos(t, sess, "", []todo.Item{
+		{Content: "x", ActiveForm: "x", Status: todo.StatusInProgress},
+	})
+	rsp := finalRsp("done")
+	res, err := e.afterModel(ctx, &model.AfterModelArgs{Response: rsp})
+	require.NoError(t, err)
+	assert.Nil(t, res)
+	assert.True(t, rsp.Done)
+}
+
+// TestAfterModel_OnEnforce_PanicSwallowed confirms the recover
+// in notify: a misbehaving observer cannot crash the model-
+// callback hot path, and enforcement still happens.
+func TestAfterModel_OnEnforce_PanicSwallowed(t *testing.T) {
+	ctx, _, sess := newTestInvocation(t, "a")
+	writeTodos(t, sess, "", []todo.Item{
+		{Content: "x", ActiveForm: "x", Status: todo.StatusInProgress},
+	})
+	e := New(WithOnEnforce(func(EnforceEvent) { panic("boom") }))
+
+	rsp := finalRsp("done")
+	res, err := e.afterModel(ctx, &model.AfterModelArgs{Response: rsp})
+	require.NoError(t, err)
+	require.NotNil(t, res, "enforcement must still happen even if observer panics")
+}
+
+// TestDeclareBlockerTool_StoresStateAndReturnsSuccess is the
+// v2-defining test of the escape hatch: the tool MUST return a
+// normal success result (no StopError, no termination signal),
+// MUST latch the blocker_declared flag, MUST persist the reason,
+// and MUST surface a ReasonBlockerDeclared event so observers
+// can count it.
+func TestDeclareBlockerTool_StoresStateAndReturnsSuccess(t *testing.T) {
+	ctx, inv, _ := newTestInvocation(t, "a")
+	var observed *EnforceEvent
+	e := New(WithOnEnforce(func(evt EnforceEvent) {
+		observed = &evt
+	}))
+
+	args, err := json.Marshal(declareBlockerInput{Reason: "missing prod-write permission"})
+	require.NoError(t, err)
+	out, err := e.declareBlockerTool.Call(ctx, args)
+	require.NoError(t, err,
+		"declare-blocker must NOT return an error: the model still needs to send its final message")
+
+	require.NotNil(t, out)
+	payload, ok := out.(declareBlockerOutput)
+	require.True(t, ok)
+	assert.True(t, payload.OK)
+	assert.Equal(t, "missing prod-write permission", payload.Reason)
+
+	assert.True(t, blockerDeclared(inv))
+	assert.Equal(t, "missing prod-write permission", blockerReason(inv))
+
+	require.NotNil(t, observed)
+	assert.Equal(t, ReasonBlockerDeclared, observed.Reason)
+	assert.Equal(t, "missing prod-write permission", observed.BlockerReason)
+}
+
+// TestDeclareBlockerTool_DoesNotReturnStopError pins down the v2
+// behavioural promise: even if some upstream code looks for an
+// agent.StopError to terminate the run, the declare-blocker tool
+// must NEVER produce one. Termination is the runner's
+// responsibility, not the extension's.
+func TestDeclareBlockerTool_DoesNotReturnStopError(t *testing.T) {
+	ctx, _, _ := newTestInvocation(t, "a")
+	e := New()
+
+	args, err := json.Marshal(declareBlockerInput{Reason: "missing creds"})
+	require.NoError(t, err)
+	_, err = e.declareBlockerTool.Call(ctx, args)
+	require.NoError(t, err)
+
+	_, isStop := agent.AsStopError(err)
+	assert.False(t, isStop)
+}
+
+// TestDeclareBlockerTool_RejectsEmptyReason ensures the friction
+// described in tools.go is real: missing or blank reason is a
+// regular error so the model retries instead of latching the
+// declared flag with a useless empty reason.
+func TestDeclareBlockerTool_RejectsEmptyReason(t *testing.T) {
+	ctx, inv, _ := newTestInvocation(t, "a")
+	e := New()
+
+	args, _ := json.Marshal(declareBlockerInput{Reason: "   "})
+	_, err := e.declareBlockerTool.Call(ctx, args)
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "reason")
+	assert.False(t, blockerDeclared(inv),
+		"empty-reason rejection must NOT latch the declared flag")
+}
+
+// TestDeclareBlockerTool_RejectsMalformedJSON treats parse
+// failures as regular errors so the framework can show them back
+// to the model — declare-blocker side-effects must NOT happen.
+func TestDeclareBlockerTool_RejectsMalformedJSON(t *testing.T) {
+	ctx, inv, _ := newTestInvocation(t, "a")
+	e := New()
+
+	_, err := e.declareBlockerTool.Call(ctx, []byte("not json"))
+	require.Error(t, err)
+	assert.False(t, blockerDeclared(inv),
+		"parse failure must not latch the declared flag")
+}
+
+// TestEndToEnd_DeclareBlockerThenFinalPasses simulates the
+// happy path of the v2 escape hatch:
+//
+//  1. Open items present, model emits a premature final → blocked.
+//  2. Model receives the nudge, calls todo_declare_blocker with a
+//     real reason → success result, no termination.
+//  3. Model emits a follow-up final ("Need X from you to
+//     continue") → must pass through unmodified.
+//
+// This is the contract the extension advertises in doc.go and the
+// most important behavioural guarantee for users adopting the
+// new escape-hatch semantics.
+func TestEndToEnd_DeclareBlockerThenFinalPasses(t *testing.T) {
+	ctx, inv, sess := newTestInvocation(t, "a")
+	writeTodos(t, sess, "", []todo.Item{
+		{Content: "Open prod terminal", ActiveForm: "Opening prod terminal", Status: todo.StatusInProgress},
+	})
+	e := New()
+
+	rsp1 := finalRsp("done")
+	res1, err := e.afterModel(ctx, &model.AfterModelArgs{Response: rsp1})
+	require.NoError(t, err)
+	require.NotNil(t, res1, "first final response must be blocked")
+	assert.False(t, rsp1.Done)
+	assert.True(t, reminderPending(inv))
+
+	args, err := json.Marshal(declareBlockerInput{Reason: "prod-write not yet granted to this session"})
+	require.NoError(t, err)
+	out, err := e.declareBlockerTool.Call(ctx, args)
+	require.NoError(t, err, "v2: declare-blocker must succeed without terminating")
+	require.NotNil(t, out)
+	assert.True(t, blockerDeclared(inv))
+
+	rsp2 := finalRsp("I cannot continue until you grant prod-write.")
+	res2, err := e.afterModel(ctx, &model.AfterModelArgs{Response: rsp2})
+	require.NoError(t, err)
+	assert.Nil(t, res2,
+		"after declare-blocker, the model's final message must pass through")
+	assert.True(t, rsp2.Done)
+}
+
+// TestEndToEnd_BlockThenContinueThenComplete walks the
+// non-blocker recovery cycle: block once, model writes the
+// missing item as completed, next final response passes. This
+// exercises the original (pre-escape-hatch) loop and proves the
+// v2 changes did not regress it.
+func TestEndToEnd_BlockThenContinueThenComplete(t *testing.T) {
+	ctx, inv, sess := newTestInvocation(t, "a")
+	writeTodos(t, sess, "", []todo.Item{
+		{Content: "Run tests", ActiveForm: "Running tests", Status: todo.StatusInProgress},
+	})
+	e := New()
+
+	rsp1 := finalRsp("done")
+	res1, err := e.afterModel(ctx, &model.AfterModelArgs{Response: rsp1})
+	require.NoError(t, err)
+	require.NotNil(t, res1)
+	assert.False(t, rsp1.Done, "first final response must be blocked")
+	assert.True(t, reminderPending(inv))
+
+	req := &model.Request{Messages: []model.Message{model.NewUserMessage("hi")}}
+	_, err = e.beforeModel(ctx, &model.BeforeModelArgs{Request: req})
+	require.NoError(t, err)
+	require.Len(t, req.Messages, 2, "BeforeModel must inject the nudge")
+
+	writeTodos(t, sess, "", []todo.Item{
+		{Content: "Run tests", ActiveForm: "Running tests", Status: todo.StatusCompleted},
+	})
+
+	rsp2 := finalRsp("done for real")
+	res2, err := e.afterModel(ctx, &model.AfterModelArgs{Response: rsp2})
+	require.NoError(t, err)
+	assert.Nil(t, res2, "with all items completed, response must pass through")
+	assert.True(t, rsp2.Done)
+}
+
+// TestAfterModel_HonoursCustomTodoToolPrefix is the regression
+// guard for a review-time finding: the enforcer originally read
+// session state through todo.GetTodos, which hard-codes
+// DefaultStateKeyPrefix. A user who wired the enforcer with
+// WithTodoTool(todo.New(todo.WithStateKeyPrefix("custom"))) would
+// then see the enforcer silently miss every write the tool made
+// under "custom:<branch>", and conclude that the list was empty —
+// effectively disabling enforcement while the configuration looks
+// correct.
+//
+// The fix reads through e.todoTool.StateKeyPrefix() instead. This
+// test pins the contract: when the configured todo tool uses a
+// custom prefix, the enforcer must observe open items written
+// under that prefix (and trip into the BLOCKED branch), and must
+// NOT see items left over under the default prefix from a stale
+// installation (cross-prefix isolation).
+func TestAfterModel_HonoursCustomTodoToolPrefix(t *testing.T) {
+	const customPrefix = "temp:my_custom_todo"
+	customTool := todo.New(todo.WithStateKeyPrefix(customPrefix))
+	require.Equal(t, customPrefix, customTool.StateKeyPrefix(),
+		"sanity: getter must surface the configured prefix")
+
+	e := New(
+		WithTodoTool(customTool),
+		WithMaxRetries(3),
+	)
+
+	ctx, _, sess := newTestInvocation(t, "agent-A")
+
+	openItem := todo.Item{
+		Content: "Inspect the staging logs", ActiveForm: "Inspecting the staging logs",
+		Status: todo.StatusInProgress,
+	}
+	raw, err := json.Marshal([]todo.Item{openItem})
+	require.NoError(t, err)
+	// Write under the CUSTOM prefix the configured tool uses.
+	sess.SetState(customPrefix, raw)
+	// Also leave a CLEAN list under the DEFAULT prefix to prove the
+	// enforcer reads from the configured prefix, not the default.
+	cleanRaw, err := json.Marshal([]todo.Item{})
+	require.NoError(t, err)
+	sess.SetState(todo.DefaultStateKeyPrefix, cleanRaw)
+
+	rsp := finalRsp("all set, see you")
+	res, err := e.afterModel(ctx, &model.AfterModelArgs{Response: rsp})
+	require.NoError(t, err)
+	require.NotNil(t, res,
+		"enforcer must see the in_progress item written under the custom prefix and block")
+	assert.False(t, rsp.Done,
+		"enforcer must flip Done=false when open items remain at the custom prefix")
+}
+
+// The block below covers the small nil-safety / default-fallback
+// helpers in enforcer.go that live outside the AfterModel hot
+// path. They are trivial individually but they form the contract
+// that "creating an Enforcer should never panic on degenerate
+// inputs" — a contract the package doc relies on when it tells
+// users to share one Enforcer across multiple agents.
+
+func TestEnforcer_Name_DefaultsWhenOptionEmpty(t *testing.T) {
+	// New() always seeds opts.Name to DefaultExtensionName via
+	// defaultOptions, so this assertion goes through the
+	// "configured value" return path.
+	assert.Equal(t, DefaultExtensionName, New().Name(),
+		"the default constructor must surface DefaultExtensionName")
+	assert.Equal(t, "custom-name", New(WithName("custom-name")).Name(),
+		"Name() must surface the configured value when WithName was used")
+
+	// To exercise the "opts.Name == \"\"" defensive branch the
+	// Enforcer must be constructed without going through New —
+	// a zero-value struct has opts.Name == "". This branch
+	// shouldn't be reachable from a happy-path caller, but it
+	// exists so a future refactor that wires options differently
+	// (e.g. lazy options or builder pattern) cannot accidentally
+	// surface the empty string as an extension name to the
+	// registry.
+	bare := &Enforcer{}
+	assert.Equal(t, DefaultExtensionName, bare.Name(),
+		"empty opts.Name must fall back to DefaultExtensionName")
+}
+
+// TestNew_NilOptionAndZeroOptionsRecoverToDefaults documents the
+// three defensive fallbacks in New(): nil functional options are
+// skipped, a non-positive MaxRetries snaps back to the package
+// default, and a nil NudgeFormatter snaps back to
+// DefaultNudgeFormatter. None of these can happen via the
+// supplied With* helpers, but third-party Option implementations
+// could.
+func TestNew_NilOptionAndZeroOptionsRecoverToDefaults(t *testing.T) {
+	// nil option is skipped (guards against external callers that
+	// build []Option slices with conditional entries).
+	e := New(nil)
+	require.NotNil(t, e)
+	assert.Equal(t, DefaultMaxRetries, e.opts.MaxRetries)
+	assert.NotNil(t, e.opts.NudgeFormatter)
+
+	// Explicit zero/nil-equivalent options must trip the
+	// defaults-restoration branch. We intentionally use raw
+	// closures rather than helper With* — the helpers themselves
+	// already guard against bad inputs, which would never let the
+	// raw zero values reach the defaults-restoration code.
+	e = New(
+		func(o *Options) { o.MaxRetries = 0 },
+		func(o *Options) { o.NudgeFormatter = nil },
+	)
+	assert.Equal(t, DefaultMaxRetries, e.opts.MaxRetries,
+		"non-positive MaxRetries must snap back to DefaultMaxRetries")
+	require.NotNil(t, e.opts.NudgeFormatter,
+		"nil NudgeFormatter must snap back to DefaultNudgeFormatter")
+}
+
+func TestEnforcer_Register_NilRegistryIsNoOp(t *testing.T) {
+	// Register(nil) must short-circuit before dereferencing the
+	// registry. The contract extension.Collect maintains is that
+	// every Extension's Register sees a non-nil Registry, but
+	// nothing in the framework stops a future caller from invoking
+	// Register manually with nil; surfacing a panic in that case
+	// would propagate up to agent.New as a hard crash rather than
+	// a clean misuse error.
+	assert.NotPanics(t, func() { New().Register(nil) })
+}
+
+func TestEnforcer_NotifyBlockerDeclared_NilEnforcerIsNoOp(t *testing.T) {
+	// Tools constructed via newDeclareBlockerTool capture *Enforcer
+	// in a closure. Defending against e==nil makes the tool safe
+	// to call in pure unit tests that bypass enforcer construction
+	// (no observable behaviour change in normal operation).
+	var e *Enforcer
+	assert.NotPanics(t, func() { e.notifyBlockerDeclared(nil, "any") })
+}
+
+func TestEnforcer_Notify_NoOnEnforce_IsNoOp(t *testing.T) {
+	// Default Options.OnEnforce is nil. The hot path must not
+	// allocate or panic when there is no observer; this test
+	// keeps that invariant honest.
+	e := New() // no WithOnEnforce
+	assert.NotPanics(t, func() {
+		e.notify(EnforceEvent{Reason: ReasonBlocked})
+	})
+}
+
+func TestEnforcer_Notify_RecoversFromObserverPanic(t *testing.T) {
+	// OnEnforce sits on the model-callback hot path; a buggy
+	// observer must not be able to crash the agent. The fix is a
+	// deferred recover inside notify. The branch is small but the
+	// downside of regressing it is "one bad observer brings down
+	// the whole agent", so we pin it.
+	var calls int
+	e := New(WithOnEnforce(func(EnforceEvent) {
+		calls++
+		panic("observer is buggy")
+	}))
+	assert.NotPanics(t, func() {
+		e.notify(EnforceEvent{Reason: ReasonBlocked})
+	})
+	assert.Equal(t, 1, calls,
+		"observer must have been invoked exactly once before panicking")
+}
+
+func TestInvocationHelpers_NilSafe(t *testing.T) {
+	// invocationSession/Branch/AgentName are nil-safe shims; pure
+	// unit tests that bypass agent.NewInvocation rely on the
+	// shims to return zero values rather than panic.
+	assert.Nil(t, invocationSession(nil))
+	assert.Equal(t, "", invocationBranch(nil))
+	assert.Equal(t, "", invocationAgentName(nil))
+}
+
+func TestInvocationHelpers_HappyPath(t *testing.T) {
+	_, inv, sess := newTestInvocation(t, "agent-A")
+	assert.Same(t, sess, invocationSession(inv))
+	assert.Equal(t, "agent-A", invocationAgentName(inv))
+	// Branch is empty by default in the test helper; the helper
+	// chooses not to set Branch so the agent name acts as the
+	// implicit branch, mirroring single-agent production setups.
+	assert.Equal(t, "", invocationBranch(inv))
+}
+
+// TestShouldConsiderResponse_AllBranches covers the response
+// triage predicate in one shot. The hot path calls it on every
+// AfterModel invocation, so all four branches (nil, partial,
+// tool-call with AllowToolCallFinal, regular final) need pinning.
+func TestShouldConsiderResponse_AllBranches(t *testing.T) {
+	e := New()
+
+	assert.False(t, e.shouldConsiderResponse(nil),
+		"nil response must short-circuit (defensive)")
+	assert.False(t, e.shouldConsiderResponse(&model.Response{IsPartial: true}),
+		"streaming partials must never trigger enforcement")
+
+	// AllowToolCallFinal default is true; a tool-call response
+	// must therefore pass through (return false from
+	// shouldConsiderResponse — "no, do not consider").
+	toolCallRsp := &model.Response{
+		Choices: []model.Choice{{
+			Message: model.Message{
+				Role:      model.RoleAssistant,
+				ToolCalls: []model.ToolCall{{ID: "x", Type: "function"}},
+			},
+		}},
+	}
+	assert.False(t, e.shouldConsiderResponse(toolCallRsp),
+		"AllowToolCallFinal=true must keep tool-call responses out of enforcement")
+
+	// A regular final response is exactly what enforcement
+	// targets.
+	finalR := finalRsp("done")
+	assert.True(t, e.shouldConsiderResponse(finalR),
+		"regular final response must be considered for enforcement")
+}
+
+// TestAfterModel_DefaultPrefixUnchangedWhenNoCustomTool guards the
+// other direction of the same fix: without WithTodoTool, behaviour
+// must be byte-for-byte identical to before — the enforcer
+// constructs todo.New() (DefaultStateKeyPrefix) and reads through
+// that same default. Catches accidental regressions where a future
+// refactor of the prefix plumbing might hard-code "custom" or drop
+// the default entirely.
+func TestAfterModel_DefaultPrefixUnchangedWhenNoCustomTool(t *testing.T) {
+	e := New(WithMaxRetries(3))
+
+	ctx, _, sess := newTestInvocation(t, "agent-A")
+	writeTodos(t, sess, "", []todo.Item{{
+		Content: "Run tests", ActiveForm: "Running tests",
+		Status: todo.StatusPending,
+	}})
+
+	rsp := finalRsp("see you")
+	res, err := e.afterModel(ctx, &model.AfterModelArgs{Response: rsp})
+	require.NoError(t, err)
+	require.NotNil(t, res, "default-prefix path must remain functional")
+	assert.False(t, rsp.Done)
+}

--- a/agent/extension/todoenforcer/enforcer_test.go
+++ b/agent/extension/todoenforcer/enforcer_test.go
@@ -177,9 +177,8 @@ func TestAfterModel_AllCompleted_PassesThrough(t *testing.T) {
 
 // TestAfterModel_OpenItems_BlocksAndQueuesReminder is the core
 // enforcement assertion: open items present → AfterModel must
-//   - flip Done to false (so llmflow keeps looping),
-//   - return CustomResponse (so the AfterModel chain sees the
-//     rebind),
+//   - return a non-content CustomResponse with Done=false (so
+//     llmflow keeps looping without leaking the premature answer),
 //   - set reminder_pending so BeforeModel knows to inject,
 //   - bump the retry counter.
 func TestAfterModel_OpenItems_BlocksAndQueuesReminder(t *testing.T) {
@@ -194,9 +193,17 @@ func TestAfterModel_OpenItems_BlocksAndQueuesReminder(t *testing.T) {
 	res, err := e.afterModel(ctx, &model.AfterModelArgs{Response: rsp})
 	require.NoError(t, err)
 	require.NotNil(t, res, "blocked response must be returned via CustomResponse")
-	assert.Same(t, rsp, res.CustomResponse,
-		"enforcer must rebind the SAME response so other AfterModel hooks see the flip")
-	assert.False(t, rsp.Done, "Done must be flipped so the loop continues")
+	require.NotNil(t, res.CustomResponse)
+	assert.NotSame(t, rsp, res.CustomResponse,
+		"blocked responses must be scrubbed, not the original model text")
+	assert.True(t, rsp.Done, "original model response must not be mutated")
+	assert.Equal(t, "done", rsp.Choices[0].Message.Content)
+	assert.False(t, res.CustomResponse.Done,
+		"control response must keep the loop running")
+	assert.Empty(t, res.CustomResponse.Choices,
+		"premature assistant content must not leak to clients or session history")
+	assert.False(t, res.CustomResponse.IsValidContent(),
+		"control response must not be persisted as assistant content")
 	assert.True(t, reminderPending(inv))
 	assert.Equal(t, 1, retryCount(inv))
 }
@@ -348,9 +355,11 @@ func TestAfterModel_RetryBudgetExhausted_FailsOpen(t *testing.T) {
 
 	for i := 0; i < 2; i++ {
 		rsp := finalRsp("done")
-		_, err := e.afterModel(ctx, &model.AfterModelArgs{Response: rsp})
+		res, err := e.afterModel(ctx, &model.AfterModelArgs{Response: rsp})
 		require.NoError(t, err)
-		assert.False(t, rsp.Done, "block %d", i)
+		require.NotNil(t, res, "block %d", i)
+		require.NotNil(t, res.CustomResponse, "block %d", i)
+		assert.False(t, res.CustomResponse.Done, "block %d", i)
 	}
 	rsp := finalRsp("done")
 	res, err := e.afterModel(ctx, &model.AfterModelArgs{Response: rsp})
@@ -417,6 +426,50 @@ func TestBeforeModel_NoPending_NoOp(t *testing.T) {
 	req := &model.Request{Messages: []model.Message{model.NewUserMessage("hi")}}
 	_, err := e.beforeModel(ctx, &model.BeforeModelArgs{Request: req})
 	require.NoError(t, err)
+	assert.Len(t, req.Messages, 1)
+}
+
+// TestBeforeModel_OpenItems_DisablesStreamingWithoutNudge covers
+// the streaming side of hard compliance. Even when no reminder is
+// pending yet, the enforcer must turn streaming off while open
+// todo items exist; otherwise partial deltas could reach clients
+// before AfterModel can reject the final answer.
+func TestBeforeModel_OpenItems_DisablesStreamingWithoutNudge(t *testing.T) {
+	ctx, inv, sess := newTestInvocation(t, "a")
+	writeTodos(t, sess, "", []todo.Item{
+		{Content: "Run tests", ActiveForm: "Running tests", Status: todo.StatusInProgress},
+	})
+	e := New()
+
+	req := &model.Request{
+		Messages: []model.Message{model.NewUserMessage("hi")},
+		GenerationConfig: model.GenerationConfig{
+			Stream: true,
+		},
+	}
+	_, err := e.beforeModel(ctx, &model.BeforeModelArgs{Request: req})
+	require.NoError(t, err)
+	assert.False(t, req.GenerationConfig.Stream,
+		"hard enforcement must disable streaming while open todos exist")
+	assert.Len(t, req.Messages, 1,
+		"no pending reminder means no nudge message is injected yet")
+	assert.False(t, reminderPending(inv))
+}
+
+func TestBeforeModel_NoOpenItems_LeavesStreamingUntouched(t *testing.T) {
+	ctx, _, _ := newTestInvocation(t, "a")
+	e := New()
+
+	req := &model.Request{
+		Messages: []model.Message{model.NewUserMessage("hi")},
+		GenerationConfig: model.GenerationConfig{
+			Stream: true,
+		},
+	}
+	_, err := e.beforeModel(ctx, &model.BeforeModelArgs{Request: req})
+	require.NoError(t, err)
+	assert.True(t, req.GenerationConfig.Stream,
+		"streaming remains available when there is nothing to enforce")
 	assert.Len(t, req.Messages, 1)
 }
 
@@ -524,7 +577,8 @@ func TestScopedAgents_OnlyTargetEnforced(t *testing.T) {
 	resPlan, err := e.afterModel(ctxPlan, &model.AfterModelArgs{Response: rspPlan})
 	require.NoError(t, err)
 	require.NotNil(t, resPlan)
-	assert.False(t, rspPlan.Done)
+	require.NotNil(t, resPlan.CustomResponse)
+	assert.False(t, resPlan.CustomResponse.Done)
 }
 
 // TestBypassAgents_SkipsEnforcement is the inverse of the scoped
@@ -663,7 +717,8 @@ func TestEndToEnd_DeclareBlockerThenFinalPasses(t *testing.T) {
 	res1, err := e.afterModel(ctx, &model.AfterModelArgs{Response: rsp1})
 	require.NoError(t, err)
 	require.NotNil(t, res1, "first final response must be blocked")
-	assert.False(t, rsp1.Done)
+	require.NotNil(t, res1.CustomResponse)
+	assert.False(t, res1.CustomResponse.Done)
 	assert.True(t, reminderPending(inv))
 
 	args, err := json.Marshal(declareBlockerInput{Reason: "prod-write not yet granted to this session"})
@@ -697,7 +752,9 @@ func TestEndToEnd_BlockThenContinueThenComplete(t *testing.T) {
 	res1, err := e.afterModel(ctx, &model.AfterModelArgs{Response: rsp1})
 	require.NoError(t, err)
 	require.NotNil(t, res1)
-	assert.False(t, rsp1.Done, "first final response must be blocked")
+	require.NotNil(t, res1.CustomResponse)
+	assert.False(t, res1.CustomResponse.Done,
+		"first final response must be blocked")
 	assert.True(t, reminderPending(inv))
 
 	req := &model.Request{Messages: []model.Message{model.NewUserMessage("hi")}}
@@ -764,8 +821,9 @@ func TestAfterModel_HonoursCustomTodoToolPrefix(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, res,
 		"enforcer must see the in_progress item written under the custom prefix and block")
-	assert.False(t, rsp.Done,
-		"enforcer must flip Done=false when open items remain at the custom prefix")
+	require.NotNil(t, res.CustomResponse)
+	assert.False(t, res.CustomResponse.Done,
+		"enforcer must return Done=false when open items remain at the custom prefix")
 }
 
 // The block below covers the small nil-safety / default-fallback
@@ -954,5 +1012,6 @@ func TestAfterModel_DefaultPrefixUnchangedWhenNoCustomTool(t *testing.T) {
 	res, err := e.afterModel(ctx, &model.AfterModelArgs{Response: rsp})
 	require.NoError(t, err)
 	require.NotNil(t, res, "default-prefix path must remain functional")
-	assert.False(t, rsp.Done)
+	require.NotNil(t, res.CustomResponse)
+	assert.False(t, res.CustomResponse.Done)
 }

--- a/agent/extension/todoenforcer/enforcer_test.go
+++ b/agent/extension/todoenforcer/enforcer_test.go
@@ -308,6 +308,15 @@ func TestAfterModel_BlockerDeclared_RemainsLatchedForRestOfInvocation(t *testing
 	e := New()
 
 	for i := 0; i < 3; i++ {
+		if i == 1 {
+			writeTodos(t, sess, "", []todo.Item{
+				{
+					Content:    "new item",
+					ActiveForm: "processing new item",
+					Status:     todo.StatusInProgress,
+				},
+			})
+		}
 		rsp := finalRsp("waiting on user")
 		res, err := e.afterModel(ctx, &model.AfterModelArgs{Response: rsp})
 		require.NoError(t, err, "pass %d", i)
@@ -830,7 +839,10 @@ func TestEnforcer_NotifyBlockerDeclared_NilEnforcerIsNoOp(t *testing.T) {
 	// to call in pure unit tests that bypass enforcer construction
 	// (no observable behaviour change in normal operation).
 	var e *Enforcer
-	assert.NotPanics(t, func() { e.notifyBlockerDeclared(nil, "any") })
+	var inv *agent.Invocation
+	assert.NotPanics(t, func() {
+		e.notifyBlockerDeclared(inv, "any")
+	})
 }
 
 func TestEnforcer_Notify_NoOnEnforce_IsNoOp(t *testing.T) {
@@ -896,6 +908,7 @@ func TestShouldConsiderResponse_AllBranches(t *testing.T) {
 	// must therefore pass through (return false from
 	// shouldConsiderResponse — "no, do not consider").
 	toolCallRsp := &model.Response{
+		Done: true,
 		Choices: []model.Choice{{
 			Message: model.Message{
 				Role:      model.RoleAssistant,

--- a/agent/extension/todoenforcer/enforcer_test.go
+++ b/agent/extension/todoenforcer/enforcer_test.go
@@ -376,6 +376,24 @@ func TestBeforeModel_InjectsNudge_WhenPending(t *testing.T) {
 		"BeforeModel must consume the pending flag")
 }
 
+func TestBeforeModel_InjectsConfiguredTodoToolName(t *testing.T) {
+	ctx, inv, sess := newTestInvocation(t, "a")
+	writeTodos(t, sess, "", []todo.Item{
+		{Content: "Run tests", ActiveForm: "Running tests", Status: todo.StatusInProgress},
+	})
+	setReminderPending(inv, true)
+	incRetryCount(inv)
+	e := New(WithTodoTool(todo.New(todo.WithToolName("plan_update"))))
+
+	req := &model.Request{Messages: []model.Message{model.NewUserMessage("hi")}}
+	_, err := e.beforeModel(ctx, &model.BeforeModelArgs{Request: req})
+	require.NoError(t, err)
+	require.Len(t, req.Messages, 2)
+	assert.Contains(t, req.Messages[1].Content, "plan_update")
+	assert.NotContains(t, req.Messages[1].Content, "call "+todo.DefaultToolName,
+		"nudge must not tell the model to call a tool name that was overridden")
+}
+
 // TestBeforeModel_NoPending_NoOp confirms the BeforeModel branch
 // is a true no-op on the common path.
 func TestBeforeModel_NoPending_NoOp(t *testing.T) {

--- a/agent/extension/todoenforcer/enforcer_test.go
+++ b/agent/extension/todoenforcer/enforcer_test.go
@@ -12,6 +12,7 @@ package todoenforcer
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
@@ -78,7 +79,6 @@ func TestNew_DefaultsApplied(t *testing.T) {
 	assert.Equal(t, DefaultExtensionName, e.Name())
 	assert.Equal(t, DefaultMaxRetries, e.opts.MaxRetries)
 	assert.Equal(t, DefaultDeclareBlockerToolName, e.declareBlockerTool.name)
-	assert.True(t, e.opts.AllowToolCallFinal)
 	assert.NotNil(t, e.opts.NudgeFormatter)
 
 	bundle, err := extension.Collect([]extension.Extension{e})
@@ -105,14 +105,12 @@ func TestNew_OptionsOverridden(t *testing.T) {
 		WithTodoTool(td),
 		WithDeclareBlockerToolName("need_human"),
 		WithDeclareBlockerToolDescription("custom desc"),
-		WithAllowToolCallFinal(false),
 	)
 	assert.Equal(t, "planner-enforcer", e.Name())
 	assert.Equal(t, 7, e.opts.MaxRetries)
 	assert.Same(t, td, e.todoTool)
 	assert.Equal(t, "need_human", e.declareBlockerTool.name)
 	assert.Equal(t, "custom desc", e.declareBlockerTool.description)
-	assert.False(t, e.opts.AllowToolCallFinal)
 }
 
 // TestRegister_WiresExpectedHooks installs the enforcer through
@@ -203,12 +201,44 @@ func TestAfterModel_OpenItems_BlocksAndQueuesReminder(t *testing.T) {
 	assert.Equal(t, 1, retryCount(inv))
 }
 
-// TestAfterModel_ToolCallResponse_DefaultPassesThrough confirms
-// the AllowToolCallFinal default: a response carrying tool calls
-// is treated as non-final and passes through, regardless of
-// pending todos. The natural completion pattern (model →
-// todo_write → model → final) relies on this.
-func TestAfterModel_ToolCallResponse_DefaultPassesThrough(t *testing.T) {
+func TestAfterModel_ErrorResponse_PassesThrough(t *testing.T) {
+	ctx, inv, sess := newTestInvocation(t, "a")
+	writeTodos(t, sess, "", []todo.Item{
+		{Content: "x", ActiveForm: "x", Status: todo.StatusInProgress},
+	})
+	e := New()
+
+	rsp := &model.Response{
+		Done: true,
+		Error: &model.ResponseError{
+			Type:    model.ErrorTypeAPIError,
+			Message: "provider failed",
+		},
+	}
+	res, err := e.afterModel(ctx, &model.AfterModelArgs{Response: rsp})
+	require.NoError(t, err)
+	assert.Nil(t, res)
+	assert.True(t, rsp.Done, "error response must surface unchanged")
+	assert.False(t, reminderPending(inv))
+	assert.Equal(t, 0, retryCount(inv))
+
+	rsp = finalRsp("done")
+	res, err = e.afterModel(ctx, &model.AfterModelArgs{
+		Response: rsp,
+		Error:    errors.New("stream failed"),
+	})
+	require.NoError(t, err)
+	assert.Nil(t, res)
+	assert.True(t, rsp.Done, "callback error must bypass enforcement")
+	assert.False(t, reminderPending(inv))
+	assert.Equal(t, 0, retryCount(inv))
+}
+
+// TestAfterModel_ToolCallResponse_PassesThrough confirms that a
+// response carrying tool calls is treated as non-final and passes
+// through, regardless of pending todos. The natural completion
+// pattern (model → todo_write → model → final) relies on this.
+func TestAfterModel_ToolCallResponse_PassesThrough(t *testing.T) {
 	ctx, inv, sess := newTestInvocation(t, "a")
 	writeTodos(t, sess, "", []todo.Item{
 		{Content: "x", ActiveForm: "x", Status: todo.StatusInProgress},
@@ -229,31 +259,6 @@ func TestAfterModel_ToolCallResponse_DefaultPassesThrough(t *testing.T) {
 	assert.Nil(t, res)
 	assert.False(t, reminderPending(inv))
 	assert.Equal(t, 0, retryCount(inv))
-}
-
-// TestAfterModel_ToolCallResponse_StrictMode confirms that
-// AllowToolCallFinal=false causes tool-call responses to be
-// blocked too. This is the strict-enforcement mode for stacks
-// that want to refuse any "wrap-up" turn while items remain.
-func TestAfterModel_ToolCallResponse_StrictMode(t *testing.T) {
-	ctx, _, sess := newTestInvocation(t, "a")
-	writeTodos(t, sess, "", []todo.Item{
-		{Content: "x", ActiveForm: "x", Status: todo.StatusInProgress},
-	})
-	e := New(WithAllowToolCallFinal(false))
-
-	rsp := &model.Response{
-		Done: true,
-		Choices: []model.Choice{{Message: model.Message{
-			Role: model.RoleAssistant,
-			ToolCalls: []model.ToolCall{
-				{ID: "1", Function: model.FunctionDefinitionParam{Name: "x"}},
-			},
-		}}},
-	}
-	res, err := e.afterModel(ctx, &model.AfterModelArgs{Response: rsp})
-	require.NoError(t, err)
-	require.NotNil(t, res, "strict mode must block tool-call responses too")
 }
 
 // TestAfterModel_PartialResponse_PassesThrough ensures we never
@@ -894,8 +899,8 @@ func TestInvocationHelpers_HappyPath(t *testing.T) {
 
 // TestShouldConsiderResponse_AllBranches covers the response
 // triage predicate in one shot. The hot path calls it on every
-// AfterModel invocation, so all four branches (nil, partial,
-// tool-call with AllowToolCallFinal, regular final) need pinning.
+// AfterModel invocation, so all branches (nil, partial, error,
+// tool-call, regular final) need pinning.
 func TestShouldConsiderResponse_AllBranches(t *testing.T) {
 	e := New()
 
@@ -903,10 +908,13 @@ func TestShouldConsiderResponse_AllBranches(t *testing.T) {
 		"nil response must short-circuit (defensive)")
 	assert.False(t, e.shouldConsiderResponse(&model.Response{IsPartial: true}),
 		"streaming partials must never trigger enforcement")
+	assert.False(t, e.shouldConsiderResponse(&model.Response{
+		Done:  true,
+		Error: &model.ResponseError{Type: "x", Message: "boom"},
+	}), "error responses must bypass enforcement")
 
-	// AllowToolCallFinal default is true; a tool-call response
-	// must therefore pass through (return false from
-	// shouldConsiderResponse — "no, do not consider").
+	// Tool-call responses are continuation signals. They must
+	// pass through so the model can complete open todos via tools.
 	toolCallRsp := &model.Response{
 		Done: true,
 		Choices: []model.Choice{{
@@ -917,7 +925,7 @@ func TestShouldConsiderResponse_AllBranches(t *testing.T) {
 		}},
 	}
 	assert.False(t, e.shouldConsiderResponse(toolCallRsp),
-		"AllowToolCallFinal=true must keep tool-call responses out of enforcement")
+		"tool-call responses must stay out of enforcement")
 
 	// A regular final response is exactly what enforcement
 	// targets.

--- a/agent/extension/todoenforcer/format.go
+++ b/agent/extension/todoenforcer/format.go
@@ -42,6 +42,12 @@ type NudgeContext struct {
 	// to embed in its message.
 	MaxRetries int
 
+	// TodoToolName is the registered name of the todo-write tool.
+	// The default formatter quotes this so the model sees the
+	// exact name even when the underlying todo.Tool was supplied
+	// via WithTodoTool(todo.New(todo.WithToolName(...))).
+	TodoToolName string
+
 	// DeclareBlockerToolName is the registered name of
 	// todo_declare_blocker. The default formatter quotes this so
 	// the model sees the exact name even when it is overridden
@@ -100,6 +106,10 @@ func DefaultNudgeFormatter(ctx NudgeContext) string {
 	if declareBlockerName == "" {
 		declareBlockerName = DefaultDeclareBlockerToolName
 	}
+	todoToolName := ctx.TodoToolName
+	if todoToolName == "" {
+		todoToolName = todo.DefaultToolName
+	}
 	fmt.Fprintf(&b,
 		"\nYou must either:\n"+
 			"  1) continue executing — pick the next item, do the work, then call "+
@@ -112,7 +122,7 @@ func DefaultNudgeFormatter(ctx NudgeContext) string {
 			"explaining what input is missing.\n"+
 			"Do NOT use option 2 to give up on hard but tractable work, and do "+
 			"NOT produce a final answer while items remain open.",
-		todo.DefaultToolName, declareBlockerName,
+		todoToolName, declareBlockerName,
 	)
 	return b.String()
 }

--- a/agent/extension/todoenforcer/format.go
+++ b/agent/extension/todoenforcer/format.go
@@ -128,7 +128,10 @@ func DefaultNudgeFormatter(ctx NudgeContext) string {
 }
 
 // splitByStatus partitions items into in-progress and pending
-// buckets, dropping completed entries. Stable order is preserved
+// buckets, dropping completed entries. Unknown non-completed
+// statuses are treated as pending so a corrupted or externally
+// written state entry remains visible/actionable instead of
+// causing an invisible enforcement loop. Stable order is preserved
 // within each bucket — the model sees them in the order it wrote
 // them, which makes the nudge feel like a continuation rather
 // than a re-ordered scolding.
@@ -139,6 +142,10 @@ func splitByStatus(items []todo.Item) (inProgress, pending []todo.Item) {
 			inProgress = append(inProgress, it)
 		case todo.StatusPending:
 			pending = append(pending, it)
+		case todo.StatusCompleted:
+			// terminal: intentionally omitted
+		default:
+			pending = append(pending, it)
 		}
 	}
 	return
@@ -146,7 +153,8 @@ func splitByStatus(items []todo.Item) (inProgress, pending []todo.Item) {
 
 // hasOpenItems is the gate AfterModel uses to decide whether to
 // fire enforcement at all. Cheaper than splitByStatus when we only
-// need the boolean.
+// need the boolean. Unknown statuses are open for the same reason
+// splitByStatus keeps them visible as pending.
 func hasOpenItems(items []todo.Item) bool {
 	for _, it := range items {
 		if it.Status != todo.StatusCompleted {

--- a/agent/extension/todoenforcer/format.go
+++ b/agent/extension/todoenforcer/format.go
@@ -1,0 +1,147 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package todoenforcer
+
+import (
+	"fmt"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/tool/todo"
+)
+
+// NudgeContext captures everything a NudgeFormatter needs to
+// render the reminder message. Implementations must be
+// deterministic and side-effect free: the formatter can be
+// invoked twice (once for logging, once for the actual injection)
+// and must not mutate the input slices.
+type NudgeContext struct {
+	// AgentName is the name of the agent whose final response was
+	// blocked.
+	AgentName string
+
+	// Pending lists the items still in StatusPending. The slice is
+	// owned by the enforcer and must not be modified.
+	Pending []todo.Item
+
+	// InProgress lists the items still in StatusInProgress.
+	InProgress []todo.Item
+
+	// AttemptNumber is 1 on the first nudge, 2 on the second, …,
+	// up to MaxRetries. Surfaced so the formatter can convey
+	// "attempt N of M" to the model.
+	AttemptNumber int
+
+	// MaxRetries echoes the configured budget for the formatter
+	// to embed in its message.
+	MaxRetries int
+
+	// DeclareBlockerToolName is the registered name of
+	// todo_declare_blocker. The default formatter quotes this so
+	// the model sees the exact name even when it is overridden
+	// via WithDeclareBlockerToolName.
+	DeclareBlockerToolName string
+}
+
+// NudgeFormatter renders the reminder body. The role is fixed by
+// the enforcer (RoleUser) — only the text is formatter-controlled.
+//
+// Returning the empty string opts into a "silent block": the
+// pending flag is still consumed but no message is appended,
+// useful for tests or operators who prefer enforcement to be
+// invisible to the model.
+type NudgeFormatter func(ctx NudgeContext) string
+
+// DefaultNudgeFormatter is the formatter used when
+// WithNudgeFormatter is not specified. The wording is intentional:
+//
+//   - explicit about the contract violation (the model "marked
+//     its response as final but items remain") — politely-worded
+//     reminders are easy for capable models to ignore;
+//   - structured: in-progress before pending, so the model
+//     can pick up where it left off without re-planning;
+//   - prescriptive about the two valid next actions, with the
+//     exact tool names a model can invoke. The escape hatch is
+//     framed as a *declaration of an external blocker*, NOT as
+//     "give up if it's hard" — capable models honour this
+//     framing reliably and only invoke todo_declare_blocker on
+//     genuine missing-precondition cases.
+//
+// Plain ASCII to avoid tokenizer edge cases on smaller open-source
+// models; no embedded JSON because experiments showed some models
+// start replying with JSON when the prior message looks
+// structured, which interfered with downstream prompts.
+func DefaultNudgeFormatter(ctx NudgeContext) string {
+	var b strings.Builder
+	fmt.Fprintf(&b,
+		"[todo enforcement] You marked your response as final, but the todo list "+
+			"still has open items (attempt %d of %d).\n\n",
+		ctx.AttemptNumber, ctx.MaxRetries,
+	)
+	if len(ctx.InProgress) > 0 {
+		b.WriteString("Currently in progress:\n")
+		for _, it := range ctx.InProgress {
+			fmt.Fprintf(&b, "  - %s (%s)\n", it.ActiveForm, it.Content)
+		}
+	}
+	if len(ctx.Pending) > 0 {
+		b.WriteString("Still pending:\n")
+		for _, it := range ctx.Pending {
+			fmt.Fprintf(&b, "  - %s\n", it.Content)
+		}
+	}
+	declareBlockerName := ctx.DeclareBlockerToolName
+	if declareBlockerName == "" {
+		declareBlockerName = DefaultDeclareBlockerToolName
+	}
+	fmt.Fprintf(&b,
+		"\nYou must either:\n"+
+			"  1) continue executing — pick the next item, do the work, then call "+
+			"%s to update the list, or\n"+
+			"  2) call %s ONLY if an objective external blocker prevents further "+
+			"progress (missing user permission or credentials, an ambiguous "+
+			"requirement that needs the user to clarify, infrastructure not yet "+
+			"provisioned, a sensitive decision that must be made by the user). "+
+			"In that case, after the call you may produce a final message "+
+			"explaining what input is missing.\n"+
+			"Do NOT use option 2 to give up on hard but tractable work, and do "+
+			"NOT produce a final answer while items remain open.",
+		todo.DefaultToolName, declareBlockerName,
+	)
+	return b.String()
+}
+
+// splitByStatus partitions items into in-progress and pending
+// buckets, dropping completed entries. Stable order is preserved
+// within each bucket — the model sees them in the order it wrote
+// them, which makes the nudge feel like a continuation rather
+// than a re-ordered scolding.
+func splitByStatus(items []todo.Item) (inProgress, pending []todo.Item) {
+	for _, it := range items {
+		switch it.Status {
+		case todo.StatusInProgress:
+			inProgress = append(inProgress, it)
+		case todo.StatusPending:
+			pending = append(pending, it)
+		}
+	}
+	return
+}
+
+// hasOpenItems is the gate AfterModel uses to decide whether to
+// fire enforcement at all. Cheaper than splitByStatus when we only
+// need the boolean.
+func hasOpenItems(items []todo.Item) bool {
+	for _, it := range items {
+		if it.Status != todo.StatusCompleted {
+			return true
+		}
+	}
+	return false
+}

--- a/agent/extension/todoenforcer/format_test.go
+++ b/agent/extension/todoenforcer/format_test.go
@@ -173,16 +173,18 @@ func TestDefaultNudgeFormatter_ListEntryFormatting(t *testing.T) {
 	assert.True(t, strings.Contains(out, "  - step three\n"))
 }
 
-// TestSplitByStatus_DropsCompleted documents the contract that
-// splitByStatus already happily satisfies (100% coverage), but
-// future helpers in this file may want to share a fixture; this
-// test doubles as inline documentation.
-func TestSplitByStatus_DropsCompleted(t *testing.T) {
+// TestSplitByStatus_DropsCompletedAndSurfacesUnknown documents the
+// visibility contract: completed items disappear from the nudge,
+// but an unexpected non-completed status is still shown as pending
+// so enforcement cannot block without giving the model an
+// actionable item.
+func TestSplitByStatus_DropsCompletedAndSurfacesUnknown(t *testing.T) {
 	in := []todo.Item{
 		{Content: "a", Status: todo.StatusInProgress},
 		{Content: "b", Status: todo.StatusCompleted},
 		{Content: "c", Status: todo.StatusPending},
 		{Content: "d", Status: todo.StatusInProgress},
+		{Content: "e", Status: todo.Status("blocked")},
 	}
 	inProg, pending := splitByStatus(in)
 	assert.Equal(t, []todo.Item{
@@ -191,6 +193,7 @@ func TestSplitByStatus_DropsCompleted(t *testing.T) {
 	}, inProg)
 	assert.Equal(t, []todo.Item{
 		{Content: "c", Status: todo.StatusPending},
+		{Content: "e", Status: todo.Status("blocked")},
 	}, pending)
 }
 
@@ -210,4 +213,7 @@ func TestHasOpenItems(t *testing.T) {
 	assert.True(t, hasOpenItems([]todo.Item{
 		{Content: "x", Status: todo.StatusInProgress},
 	}))
+	assert.True(t, hasOpenItems([]todo.Item{
+		{Content: "x", Status: todo.Status("blocked")},
+	}), "unknown non-completed status must be treated as open and surfaced by splitByStatus")
 }

--- a/agent/extension/todoenforcer/format_test.go
+++ b/agent/extension/todoenforcer/format_test.go
@@ -28,14 +28,15 @@ import (
 //     their slices are non-empty (no awkward empty headers)
 //   - the escape-hatch name defaults correctly when the caller
 //     left DeclareBlockerToolName empty
-//   - both todo_write and the declare-blocker tool name appear in
-//     the trailing instruction (so the model knows the exact
-//     identifiers it should call)
+//   - both the todo-write tool and the declare-blocker tool name
+//     appear in the trailing instruction (so the model knows the
+//     exact identifiers it should call)
 
 func TestDefaultNudgeFormatter_BothBuckets(t *testing.T) {
 	out := DefaultNudgeFormatter(NudgeContext{
 		AttemptNumber:          2,
 		MaxRetries:             5,
+		TodoToolName:           todo.DefaultToolName,
 		DeclareBlockerToolName: "todo_declare_blocker",
 		InProgress: []todo.Item{
 			{Content: "Inspect pods", ActiveForm: "Inspecting pods"},
@@ -61,6 +62,7 @@ func TestDefaultNudgeFormatter_OnlyPending_OmitsInProgressHeader(t *testing.T) {
 	out := DefaultNudgeFormatter(NudgeContext{
 		AttemptNumber:          1,
 		MaxRetries:             3,
+		TodoToolName:           todo.DefaultToolName,
 		DeclareBlockerToolName: "todo_declare_blocker",
 		Pending: []todo.Item{
 			{Content: "Run tests"},
@@ -77,6 +79,7 @@ func TestDefaultNudgeFormatter_OnlyInProgress_OmitsPendingHeader(t *testing.T) {
 	out := DefaultNudgeFormatter(NudgeContext{
 		AttemptNumber:          3,
 		MaxRetries:             3,
+		TodoToolName:           todo.DefaultToolName,
 		DeclareBlockerToolName: "todo_declare_blocker",
 		InProgress: []todo.Item{
 			{Content: "Deploy staging", ActiveForm: "Deploying staging"},
@@ -97,6 +100,7 @@ func TestDefaultNudgeFormatter_BothEmpty_StillProducesValidNudge(t *testing.T) {
 	out := DefaultNudgeFormatter(NudgeContext{
 		AttemptNumber:          1,
 		MaxRetries:             1,
+		TodoToolName:           todo.DefaultToolName,
 		DeclareBlockerToolName: "todo_declare_blocker",
 	})
 
@@ -122,6 +126,23 @@ func TestDefaultNudgeFormatter_EmptyToolName_FallsBackToDefault(t *testing.T) {
 
 	assert.Contains(t, out, DefaultDeclareBlockerToolName,
 		"empty DeclareBlockerToolName must fall back to the package default")
+	assert.Contains(t, out, todo.DefaultToolName,
+		"empty TodoToolName must fall back to todo.DefaultToolName")
+}
+
+func TestDefaultNudgeFormatter_CustomTodoToolName(t *testing.T) {
+	out := DefaultNudgeFormatter(NudgeContext{
+		AttemptNumber:          1,
+		MaxRetries:             3,
+		TodoToolName:           "plan_update",
+		DeclareBlockerToolName: "todo_declare_blocker",
+		Pending:                []todo.Item{{Content: "Run tests"}},
+	})
+
+	assert.Contains(t, out, "plan_update",
+		"default nudge must quote the configured todo tool name")
+	assert.NotContains(t, out, "call "+todo.DefaultToolName,
+		"default nudge must not point the model at an unavailable default tool")
 }
 
 // TestDefaultNudgeFormatter_ListEntryFormatting nails down the
@@ -132,6 +153,7 @@ func TestDefaultNudgeFormatter_ListEntryFormatting(t *testing.T) {
 	out := DefaultNudgeFormatter(NudgeContext{
 		AttemptNumber:          1,
 		MaxRetries:             3,
+		TodoToolName:           todo.DefaultToolName,
 		DeclareBlockerToolName: "todo_declare_blocker",
 		InProgress: []todo.Item{
 			{Content: "step one", ActiveForm: "doing step one"},

--- a/agent/extension/todoenforcer/format_test.go
+++ b/agent/extension/todoenforcer/format_test.go
@@ -1,0 +1,191 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package todoenforcer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"trpc.group/trpc-go/trpc-agent-go/tool/todo"
+)
+
+// DefaultNudgeFormatter is the only piece of model-facing prompt
+// text this package owns. These tests pin its shape so a casual
+// refactor cannot silently break the contract that the package
+// doc / README advertise — specifically:
+//
+//   - the attempt/MaxRetries header is always present
+//   - the in-progress + pending sub-lists appear only when
+//     their slices are non-empty (no awkward empty headers)
+//   - the escape-hatch name defaults correctly when the caller
+//     left DeclareBlockerToolName empty
+//   - both todo_write and the declare-blocker tool name appear in
+//     the trailing instruction (so the model knows the exact
+//     identifiers it should call)
+
+func TestDefaultNudgeFormatter_BothBuckets(t *testing.T) {
+	out := DefaultNudgeFormatter(NudgeContext{
+		AttemptNumber:          2,
+		MaxRetries:             5,
+		DeclareBlockerToolName: "todo_declare_blocker",
+		InProgress: []todo.Item{
+			{Content: "Inspect pods", ActiveForm: "Inspecting pods"},
+		},
+		Pending: []todo.Item{
+			{Content: "Propose fix"},
+		},
+	})
+
+	assert.Contains(t, out, "attempt 2 of 5",
+		"header must surface the attempt/MaxRetries pair verbatim")
+	assert.Contains(t, out, "Currently in progress:")
+	assert.Contains(t, out, "Inspecting pods (Inspect pods)")
+	assert.Contains(t, out, "Still pending:")
+	assert.Contains(t, out, "Propose fix")
+	assert.Contains(t, out, todo.DefaultToolName,
+		"trailing instruction must name todo_write")
+	assert.Contains(t, out, "todo_declare_blocker",
+		"trailing instruction must name the declare-blocker tool")
+}
+
+func TestDefaultNudgeFormatter_OnlyPending_OmitsInProgressHeader(t *testing.T) {
+	out := DefaultNudgeFormatter(NudgeContext{
+		AttemptNumber:          1,
+		MaxRetries:             3,
+		DeclareBlockerToolName: "todo_declare_blocker",
+		Pending: []todo.Item{
+			{Content: "Run tests"},
+		},
+	})
+
+	assert.NotContains(t, out, "Currently in progress:",
+		"empty InProgress slice must skip the header entirely (no empty section)")
+	assert.Contains(t, out, "Still pending:")
+	assert.Contains(t, out, "Run tests")
+}
+
+func TestDefaultNudgeFormatter_OnlyInProgress_OmitsPendingHeader(t *testing.T) {
+	out := DefaultNudgeFormatter(NudgeContext{
+		AttemptNumber:          3,
+		MaxRetries:             3,
+		DeclareBlockerToolName: "todo_declare_blocker",
+		InProgress: []todo.Item{
+			{Content: "Deploy staging", ActiveForm: "Deploying staging"},
+		},
+	})
+
+	assert.Contains(t, out, "Currently in progress:")
+	assert.NotContains(t, out, "Still pending:",
+		"empty Pending slice must skip the header entirely")
+}
+
+func TestDefaultNudgeFormatter_BothEmpty_StillProducesValidNudge(t *testing.T) {
+	// In practice AfterModel only invokes the formatter when at
+	// least one list is non-empty (open items is the very
+	// definition of "should block"), but the formatter must still
+	// be robust to empty inputs — guards against a future caller
+	// that forgets the precondition.
+	out := DefaultNudgeFormatter(NudgeContext{
+		AttemptNumber:          1,
+		MaxRetries:             1,
+		DeclareBlockerToolName: "todo_declare_blocker",
+	})
+
+	assert.NotContains(t, out, "Currently in progress:")
+	assert.NotContains(t, out, "Still pending:")
+	// Trailing instruction is independent of list shape so it
+	// must still appear.
+	assert.Contains(t, out, todo.DefaultToolName)
+	assert.Contains(t, out, "todo_declare_blocker")
+}
+
+func TestDefaultNudgeFormatter_EmptyToolName_FallsBackToDefault(t *testing.T) {
+	// The caller (Enforcer) always passes a non-empty
+	// DeclareBlockerToolName, but the formatter defends against
+	// callers that forget. The branch is small and the default
+	// is the source-of-truth constant, so we assert the constant
+	// rather than re-derive the string here.
+	out := DefaultNudgeFormatter(NudgeContext{
+		AttemptNumber: 1,
+		MaxRetries:    3,
+		Pending:       []todo.Item{{Content: "x"}},
+	})
+
+	assert.Contains(t, out, DefaultDeclareBlockerToolName,
+		"empty DeclareBlockerToolName must fall back to the package default")
+}
+
+// TestDefaultNudgeFormatter_ListEntryFormatting nails down the
+// exact textual shape per item — the AfterForm/Content rendering
+// is what the model has to map back to its plan items, so any
+// drift here would degrade the nudge's effectiveness.
+func TestDefaultNudgeFormatter_ListEntryFormatting(t *testing.T) {
+	out := DefaultNudgeFormatter(NudgeContext{
+		AttemptNumber:          1,
+		MaxRetries:             3,
+		DeclareBlockerToolName: "todo_declare_blocker",
+		InProgress: []todo.Item{
+			{Content: "step one", ActiveForm: "doing step one"},
+		},
+		Pending: []todo.Item{
+			{Content: "step two"},
+			{Content: "step three"},
+		},
+	})
+
+	// in-progress: "  - <ActiveForm> (<Content>)\n"
+	assert.True(t,
+		strings.Contains(out, "  - doing step one (step one)\n"),
+		"in-progress entry must be rendered as '  - <ActiveForm> (<Content>)' with a trailing newline; got: %q", out)
+	// pending: "  - <Content>\n"
+	assert.True(t, strings.Contains(out, "  - step two\n"))
+	assert.True(t, strings.Contains(out, "  - step three\n"))
+}
+
+// TestSplitByStatus_DropsCompleted documents the contract that
+// splitByStatus already happily satisfies (100% coverage), but
+// future helpers in this file may want to share a fixture; this
+// test doubles as inline documentation.
+func TestSplitByStatus_DropsCompleted(t *testing.T) {
+	in := []todo.Item{
+		{Content: "a", Status: todo.StatusInProgress},
+		{Content: "b", Status: todo.StatusCompleted},
+		{Content: "c", Status: todo.StatusPending},
+		{Content: "d", Status: todo.StatusInProgress},
+	}
+	inProg, pending := splitByStatus(in)
+	assert.Equal(t, []todo.Item{
+		{Content: "a", Status: todo.StatusInProgress},
+		{Content: "d", Status: todo.StatusInProgress},
+	}, inProg)
+	assert.Equal(t, []todo.Item{
+		{Content: "c", Status: todo.StatusPending},
+	}, pending)
+}
+
+// TestHasOpenItems pins the "no open" predicate; the enforcer
+// uses it as the cheap fast-path before any allocation.
+func TestHasOpenItems(t *testing.T) {
+	assert.False(t, hasOpenItems(nil),
+		"nil slice must be treated as no-open-items")
+	assert.False(t, hasOpenItems([]todo.Item{}),
+		"empty slice must be treated as no-open-items")
+	assert.False(t, hasOpenItems([]todo.Item{
+		{Content: "x", Status: todo.StatusCompleted},
+	}), "all-completed list must be treated as no-open-items")
+	assert.True(t, hasOpenItems([]todo.Item{
+		{Content: "x", Status: todo.StatusPending},
+	}))
+	assert.True(t, hasOpenItems([]todo.Item{
+		{Content: "x", Status: todo.StatusInProgress},
+	}))
+}

--- a/agent/extension/todoenforcer/option.go
+++ b/agent/extension/todoenforcer/option.go
@@ -1,0 +1,270 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package todoenforcer
+
+import (
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/tool/todo"
+)
+
+// Public defaults exposed for embedders and tests.
+const (
+	// DefaultExtensionName is the extension.Extension Name
+	// registered into the host agent. Override via WithName when
+	// stacking more than one Enforcer with different policies on
+	// the same agent (rare but supported).
+	DefaultExtensionName = "todoenforcer"
+
+	// DefaultDeclareBlockerToolName is the registered name of the
+	// escape-hatch tool. Override via WithDeclareBlockerToolName
+	// to avoid collisions with another tool the agent already
+	// exposes.
+	DefaultDeclareBlockerToolName = "todo_declare_blocker"
+
+	// DefaultMaxRetries bounds the AfterModel block-retry loop.
+	// 3 is empirically a comfortable budget: it gives the model
+	// two follow-up turns to recover after the initial premature
+	// "done", which covers the typical "I forgot one step"
+	// failure mode without trapping a confused agent in a long
+	// loop.
+	DefaultMaxRetries = 3
+)
+
+// EnforceReason classifies the OnEnforce events surfaced by the
+// extension. Stringly typed (rather than int constants) so that
+// they stay readable in trace exports and metric labels.
+type EnforceReason string
+
+const (
+	// ReasonBlocked indicates AfterModel flipped a final response
+	// to non-final and queued a nudge.
+	ReasonBlocked EnforceReason = "blocked"
+
+	// ReasonExhausted indicates the retry budget ran out and the
+	// final response was allowed through unmodified (fail-open).
+	ReasonExhausted EnforceReason = "exhausted"
+
+	// ReasonBlockerDeclared indicates the model called
+	// todo_declare_blocker. The model is then free to emit its
+	// final message; the invocation is NOT terminated by this
+	// event.
+	ReasonBlockerDeclared EnforceReason = "blocker_declared"
+)
+
+// EnforceEvent is the payload passed to OnEnforce observers. The
+// fields chosen here are the ones that an operator dashboard or a
+// metrics pipeline typically wants — agent name (label), reason
+// (counter dimension), retry/budget (gauge), pending/in-progress
+// counts (histogram), and the blocker reason (free-form).
+type EnforceEvent struct {
+	Reason          EnforceReason
+	AgentName       string
+	AttemptNumber   int
+	MaxRetries      int
+	PendingCount    int
+	InProgressCount int
+	// BlockerReason is populated only on ReasonBlockerDeclared
+	// events; it carries the free-form reason the model supplied
+	// to todo_declare_blocker.
+	BlockerReason string
+}
+
+// EnforceCallback is invoked synchronously for every enforcement
+// event. It MUST be cheap (the call is on the model-callback hot
+// path) and MUST NOT block. Return values are intentionally not
+// part of the contract: the extension owns the enforcement
+// decision, callbacks are observers only. Panics are recovered by
+// the enforcer so a misbehaving observer cannot crash the run.
+type EnforceCallback func(event EnforceEvent)
+
+// Options aggregates every knob of an Enforcer. Made public so
+// tests and embedders can introspect a constructed Enforcer's
+// configuration; in normal code prefer the With* functional
+// options.
+type Options struct {
+	// Name is the extension.Extension Name. Defaults to
+	// DefaultExtensionName when zero.
+	Name string
+
+	// MaxRetries bounds the AfterModel block-retry loop. Values
+	// <= 0 fall back to DefaultMaxRetries — callers cannot
+	// accidentally disable the safety net by passing 0; pass a
+	// very large number for "effectively unlimited".
+	MaxRetries int
+
+	// TodoTool is an optional pre-configured todo.Tool. When nil
+	// the enforcer constructs one with default options. The tool
+	// is contributed via extension.Registry.Tools during Register,
+	// so users do NOT need to install it separately via WithTools.
+	TodoTool *todo.Tool
+
+	// DeclareBlockerToolName / DeclareBlockerToolDescription
+	// override the registered name / description of
+	// todo_declare_blocker. Empty inputs fall back to defaults;
+	// the description default is tuned to position the tool as a
+	// last-resort declaration, never a shortcut.
+	DeclareBlockerToolName        string
+	DeclareBlockerToolDescription string
+
+	// NudgeFormatter renders the user message injected before the
+	// next turn. Defaults to DefaultNudgeFormatter.
+	NudgeFormatter NudgeFormatter
+
+	// BypassAgents is an opt-out list of agent names. When the
+	// invocation's AgentName is in this list, no enforcement
+	// happens. Useful when one Enforcer instance is shared across
+	// multiple agents and a subset should be exempt.
+	BypassAgents []string
+
+	// ScopedAgents is an opt-in list of agent names. When non-
+	// empty, only invocations whose AgentName appears here are
+	// enforced; everything else passes through. BypassAgents is
+	// checked AFTER ScopedAgents (an agent in both lists is
+	// bypassed).
+	ScopedAgents []string
+
+	// AllowToolCallFinal controls whether responses that include
+	// tool calls bypass enforcement. Default is true, matching
+	// the natural completion pattern (`model -> todo_write -> model`)
+	// where the wrap-up turn is itself a tool call. Setting this
+	// to false makes enforcement strict: any response with open
+	// items is blocked, even tool-call ones.
+	AllowToolCallFinal bool
+
+	// OnEnforce is an optional observer; see EnforceCallback for
+	// the contract.
+	OnEnforce EnforceCallback
+}
+
+// Option mutates Options. Implementations must be safe to apply
+// in any order on a partially constructed Options value.
+type Option func(*Options)
+
+// WithName overrides the extension.Extension Name. Empty input
+// ignored.
+func WithName(name string) Option {
+	return func(o *Options) {
+		if name != "" {
+			o.Name = name
+		}
+	}
+}
+
+// WithMaxRetries sets the block-retry budget. Non-positive inputs
+// fall back to DefaultMaxRetries.
+func WithMaxRetries(n int) Option {
+	return func(o *Options) {
+		if n > 0 {
+			o.MaxRetries = n
+		}
+	}
+}
+
+// WithTodoTool injects a pre-configured todo.Tool to reuse
+// instead of constructing a default. Useful when the agent needs
+// a custom state-key prefix or NudgeHook shared across multiple
+// todo_write callsites.
+func WithTodoTool(t *todo.Tool) Option {
+	return func(o *Options) {
+		if t != nil {
+			o.TodoTool = t
+		}
+	}
+}
+
+// WithDeclareBlockerToolName overrides the registered name of
+// the escape-hatch tool. Empty input ignored.
+func WithDeclareBlockerToolName(name string) Option {
+	return func(o *Options) {
+		if name != "" {
+			o.DeclareBlockerToolName = name
+		}
+	}
+}
+
+// WithDeclareBlockerToolDescription overrides the LLM-facing
+// description of the escape-hatch tool. Empty input ignored.
+func WithDeclareBlockerToolDescription(desc string) Option {
+	return func(o *Options) {
+		if desc != "" {
+			o.DeclareBlockerToolDescription = desc
+		}
+	}
+}
+
+// WithNudgeFormatter overrides the message renderer. Pass nil to
+// keep the default.
+func WithNudgeFormatter(f NudgeFormatter) Option {
+	return func(o *Options) {
+		if f != nil {
+			o.NudgeFormatter = f
+		}
+	}
+}
+
+// WithScopedAgents restricts enforcement to invocations whose
+// AgentName is in the supplied list.
+func WithScopedAgents(names ...string) Option {
+	return func(o *Options) {
+		o.ScopedAgents = append(o.ScopedAgents, names...)
+	}
+}
+
+// WithBypassAgents exempts invocations whose AgentName is in the
+// supplied list. Bypass takes precedence over Scope.
+func WithBypassAgents(names ...string) Option {
+	return func(o *Options) {
+		o.BypassAgents = append(o.BypassAgents, names...)
+	}
+}
+
+// WithAllowToolCallFinal toggles the "tool-call responses pass
+// through" shortcut.
+func WithAllowToolCallFinal(allow bool) Option {
+	return func(o *Options) {
+		o.AllowToolCallFinal = allow
+	}
+}
+
+// WithOnEnforce installs an observer for enforcement events.
+func WithOnEnforce(cb EnforceCallback) Option {
+	return func(o *Options) {
+		o.OnEnforce = cb
+	}
+}
+
+// inScope decides whether enforcement applies to a given
+// invocation. Order of operations:
+//
+//   - Bypass beats Scope: an explicit exemption always wins.
+//   - When Scope is empty, every non-bypassed invocation is in
+//     scope. This is the common case since agent-level extensions
+//     are already per-agent.
+//   - When both lists are empty, every invocation is in scope.
+func (o *Options) inScope(inv *agent.Invocation) bool {
+	name := ""
+	if inv != nil {
+		name = inv.AgentName
+	}
+	for _, n := range o.BypassAgents {
+		if n == name {
+			return false
+		}
+	}
+	if len(o.ScopedAgents) == 0 {
+		return true
+	}
+	for _, n := range o.ScopedAgents {
+		if n == name {
+			return true
+		}
+	}
+	return false
+}

--- a/agent/extension/todoenforcer/option.go
+++ b/agent/extension/todoenforcer/option.go
@@ -130,14 +130,6 @@ type Options struct {
 	// bypassed).
 	ScopedAgents []string
 
-	// AllowToolCallFinal controls whether responses that include
-	// tool calls bypass enforcement. Default is true, matching
-	// the natural completion pattern (`model -> todo_write -> model`)
-	// where the wrap-up turn is itself a tool call. Setting this
-	// to false makes enforcement strict: any response with open
-	// items is blocked, even tool-call ones.
-	AllowToolCallFinal bool
-
 	// OnEnforce is an optional observer; see EnforceCallback for
 	// the contract.
 	OnEnforce EnforceCallback
@@ -222,14 +214,6 @@ func WithScopedAgents(names ...string) Option {
 func WithBypassAgents(names ...string) Option {
 	return func(o *Options) {
 		o.BypassAgents = append(o.BypassAgents, names...)
-	}
-}
-
-// WithAllowToolCallFinal toggles the "tool-call responses pass
-// through" shortcut.
-func WithAllowToolCallFinal(allow bool) Option {
-	return func(o *Options) {
-		o.AllowToolCallFinal = allow
 	}
 }
 

--- a/agent/extension/todoenforcer/state.go
+++ b/agent/extension/todoenforcer/state.go
@@ -1,0 +1,146 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package todoenforcer
+
+import "trpc.group/trpc-go/trpc-agent-go/agent"
+
+// Invocation-state keys owned by todoenforcer.
+//
+// All keys live on agent.Invocation (set via inv.SetState, read
+// via agent.GetStateValue) so that retries and blocker
+// declarations are strictly per-run. Concurrent runs that happen
+// to share a Session each get their own Invocation and therefore
+// their own counter and flags. The keys are namespaced under
+// "todoenforcer:" to stay easy to grep for and to prevent
+// collisions with other extensions.
+//
+// All entries here die with the Invocation that owns them. When
+// the user submits a follow-up turn the runner constructs a fresh
+// Invocation, so a previously declared blocker does NOT carry
+// over — the model gets a clean slate to attempt the work again
+// once the missing precondition has been supplied.
+const (
+	// stateKeyRetryCount counts how many times AfterModel has
+	// blocked a final response on the current invocation. Bounded
+	// by Options.MaxRetries.
+	stateKeyRetryCount = "todoenforcer:retry_count"
+
+	// stateKeyReminderPending is set by AfterModel when a response
+	// is blocked, and consumed by BeforeModel on the next turn to
+	// trigger nudge-injection.
+	stateKeyReminderPending = "todoenforcer:reminder_pending"
+
+	// stateKeyBlockerDeclared latches to true once
+	// todo_declare_blocker has been invoked. Subsequent final
+	// responses on this invocation are then allowed through
+	// regardless of the open-items state — the model has formally
+	// signalled that it cannot make further progress without
+	// user-supplied input, and forcing it back into the loop
+	// would be exactly the bullying behaviour this extension is
+	// designed to avoid.
+	stateKeyBlockerDeclared = "todoenforcer:blocker_declared"
+
+	// stateKeyBlockerReason holds the operator-readable reason
+	// the model supplied to todo_declare_blocker. Surfaced
+	// through EnforceEvent.BlockerReason for OnEnforce observers
+	// and kept on the invocation for trace-export consumers.
+	stateKeyBlockerReason = "todoenforcer:blocker_reason"
+)
+
+// retryCount returns the current counter (0 if unset / nil inv).
+func retryCount(inv *agent.Invocation) int {
+	if inv == nil {
+		return 0
+	}
+	v, _ := agent.GetStateValue[int](inv, stateKeyRetryCount)
+	return v
+}
+
+// incRetryCount increments and returns the new value. Inlining
+// the read avoids a separate Get → Set round-trip and keeps the
+// AfterModel hot path small.
+func incRetryCount(inv *agent.Invocation) int {
+	if inv == nil {
+		return 0
+	}
+	n := retryCount(inv) + 1
+	inv.SetState(stateKeyRetryCount, n)
+	return n
+}
+
+// resetRetryCount zeroes the counter. Called whenever the
+// retry budget is fully consumed (fail-open path) so that any
+// downstream code that re-reads the counter sees a stable
+// "no enforcement attempts pending" value. The Invocation itself
+// will be discarded shortly afterwards, so this is mostly for
+// observability cleanliness rather than correctness.
+func resetRetryCount(inv *agent.Invocation) {
+	if inv == nil {
+		return
+	}
+	inv.DeleteState(stateKeyRetryCount)
+}
+
+// reminderPending reports whether AfterModel asked the next
+// BeforeModel to inject a nudge.
+func reminderPending(inv *agent.Invocation) bool {
+	if inv == nil {
+		return false
+	}
+	v, _ := agent.GetStateValue[bool](inv, stateKeyReminderPending)
+	return v
+}
+
+// setReminderPending sets / clears the flag. We DeleteState on
+// false rather than writing a zero value so introspection tools
+// see "no key" instead of "key set to false" — slightly less
+// noisy in trace dumps.
+func setReminderPending(inv *agent.Invocation, pending bool) {
+	if inv == nil {
+		return
+	}
+	if pending {
+		inv.SetState(stateKeyReminderPending, true)
+		return
+	}
+	inv.DeleteState(stateKeyReminderPending)
+}
+
+// blockerDeclared reports whether todo_declare_blocker has been
+// called on this invocation.
+func blockerDeclared(inv *agent.Invocation) bool {
+	if inv == nil {
+		return false
+	}
+	v, _ := agent.GetStateValue[bool](inv, stateKeyBlockerDeclared)
+	return v
+}
+
+// markBlockerDeclared latches the flag and stores the reason
+// atomically from the caller's viewpoint (two SetState calls,
+// but the AfterModel decision tree only inspects the flag and
+// reason in strict order so a torn read is safe).
+func markBlockerDeclared(inv *agent.Invocation, reason string) {
+	if inv == nil {
+		return
+	}
+	inv.SetState(stateKeyBlockerDeclared, true)
+	inv.SetState(stateKeyBlockerReason, reason)
+}
+
+// blockerReason returns the stored reason, or "" when no blocker
+// has been declared on this invocation.
+func blockerReason(inv *agent.Invocation) string {
+	if inv == nil {
+		return ""
+	}
+	v, _ := agent.GetStateValue[string](inv, stateKeyBlockerReason)
+	return v
+}

--- a/agent/extension/todoenforcer/state_test.go
+++ b/agent/extension/todoenforcer/state_test.go
@@ -1,0 +1,161 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package todoenforcer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+)
+
+// The functions in state.go are intentionally trivial nil-safe
+// wrappers around agent.Invocation state helpers. Their value lies
+// almost entirely in their robustness to a nil invocation (which
+// AfterModel/BeforeModel can legitimately receive in pure unit
+// tests, see invocationSession docstring), so these tests focus
+// on the nil branches + happy-path round trip rather than the
+// agent.SetState plumbing itself.
+
+func TestState_NilInvocation_AllReadersReturnZero(t *testing.T) {
+	assert.Equal(t, 0, retryCount(nil),
+		"retryCount on nil invocation must return zero, not panic")
+	assert.False(t, reminderPending(nil),
+		"reminderPending on nil invocation must return false")
+	assert.False(t, blockerDeclared(nil),
+		"blockerDeclared on nil invocation must return false")
+	assert.Equal(t, "", blockerReason(nil),
+		"blockerReason on nil invocation must return empty string")
+}
+
+func TestState_NilInvocation_AllMutatorsAreNoOps(t *testing.T) {
+	// Each of these would panic on a real *Invocation if SetState
+	// dereferenced an uninitialised noticeMu; the nil-guard turns
+	// the call into a no-op. We don't assert anything beyond "does
+	// not panic" — that IS the contract.
+	assert.NotPanics(t, func() { _ = incRetryCount(nil) })
+	assert.NotPanics(t, func() { resetRetryCount(nil) })
+	assert.NotPanics(t, func() { setReminderPending(nil, true) })
+	assert.NotPanics(t, func() { setReminderPending(nil, false) })
+	assert.NotPanics(t, func() { markBlockerDeclared(nil, "any reason") })
+
+	assert.Equal(t, 0, incRetryCount(nil),
+		"incRetryCount on nil invocation must surface the same zero retryCount sees")
+}
+
+func TestState_RetryCounter_HappyPath(t *testing.T) {
+	_, inv, _ := newTestInvocation(t, "agent-A")
+
+	assert.Equal(t, 0, retryCount(inv),
+		"fresh invocation must read zero")
+	assert.Equal(t, 1, incRetryCount(inv))
+	assert.Equal(t, 2, incRetryCount(inv))
+	assert.Equal(t, 2, retryCount(inv),
+		"retryCount must observe what incRetryCount stored")
+
+	resetRetryCount(inv)
+	assert.Equal(t, 0, retryCount(inv),
+		"after reset the counter must read zero (DeleteState path)")
+}
+
+func TestState_ReminderPending_SetFalse_DeletesKey(t *testing.T) {
+	_, inv, _ := newTestInvocation(t, "agent-A")
+
+	setReminderPending(inv, true)
+	assert.True(t, reminderPending(inv))
+
+	// The "false" branch deletes the key rather than writing a
+	// zero value (see setReminderPending docstring). Subsequent
+	// reads must still return false — i.e. "absent key" and
+	// "key=false" are observationally equivalent through the
+	// getter, which is the contract we expose to AfterModel.
+	setReminderPending(inv, false)
+	assert.False(t, reminderPending(inv),
+		"setting false must leave the getter reading false")
+}
+
+func TestState_Blocker_LatchAndReason(t *testing.T) {
+	_, inv, _ := newTestInvocation(t, "agent-A")
+
+	assert.False(t, blockerDeclared(inv))
+	assert.Equal(t, "", blockerReason(inv))
+
+	markBlockerDeclared(inv, "missing kubeconfig")
+	assert.True(t, blockerDeclared(inv),
+		"latch must surface after markBlockerDeclared")
+	assert.Equal(t, "missing kubeconfig", blockerReason(inv),
+		"reason must round-trip verbatim")
+
+	// markBlockerDeclared is intentionally not idempotent-checked
+	// — the latest call wins on the reason. AfterModel never calls
+	// it twice today but we don't want a future caller to be
+	// surprised by a "first reason wins" semantics that isn't in
+	// the docstring.
+	markBlockerDeclared(inv, "ambiguous requirements")
+	assert.Equal(t, "ambiguous requirements", blockerReason(inv),
+		"latest reason must overwrite the previous one")
+}
+
+// TestState_KeysAreNamespaced is a defensive assertion: every state
+// key this package writes must carry the "todoenforcer:" prefix so
+// it cannot collide with other extensions / framework state on the
+// same invocation. The constants live in state.go; if a future
+// refactor ever rename-drops the prefix this test catches it
+// immediately.
+func TestState_KeysAreNamespaced(t *testing.T) {
+	keys := []string{
+		stateKeyRetryCount,
+		stateKeyReminderPending,
+		stateKeyBlockerDeclared,
+		stateKeyBlockerReason,
+	}
+	for _, k := range keys {
+		assert.Contains(t, k, "todoenforcer:",
+			"state key %q must be namespaced under todoenforcer:", k)
+	}
+
+	// Also assert the four keys are pairwise distinct — a
+	// copy-paste typo that shared a key would silently couple
+	// independent state pieces.
+	seen := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		_, dup := seen[k]
+		assert.False(t, dup, "duplicate state key: %s", k)
+		seen[k] = struct{}{}
+	}
+}
+
+// TestState_InvocationScopedIsolation verifies that two
+// concurrent invocations cannot read each other's counter — the
+// extension's whole concurrency story (Sharing one Enforcer across
+// agents is safe, see package doc) depends on this.
+func TestState_InvocationScopedIsolation(t *testing.T) {
+	_, invA, _ := newTestInvocation(t, "agent-A")
+	_, invB, _ := newTestInvocation(t, "agent-B")
+
+	incRetryCount(invA)
+	incRetryCount(invA)
+	incRetryCount(invB)
+
+	assert.Equal(t, 2, retryCount(invA))
+	assert.Equal(t, 1, retryCount(invB),
+		"invB's counter must not see invA's mutations")
+
+	markBlockerDeclared(invA, "A blocked")
+	assert.True(t, blockerDeclared(invA))
+	assert.False(t, blockerDeclared(invB),
+		"blocker latch is per-invocation; invB must remain clean")
+	assert.Equal(t, "", blockerReason(invB))
+
+	// agent.Invocation is the explicit isolation boundary; this
+	// asserts we kept that contract intact for every key we write.
+	_ = agent.Invocation{}
+}

--- a/agent/extension/todoenforcer/tools.go
+++ b/agent/extension/todoenforcer/tools.go
@@ -1,0 +1,181 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package todoenforcer
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+// DefaultDeclareBlockerToolDescription is the LLM-facing
+// description for todo_declare_blocker. The wording is tuned to
+// position this tool as a last-resort *declaration* — not a
+// shortcut, not a way to bail out of hard work, and explicitly
+// not a "task abandonment". Models that mistake one for the
+// other are the primary failure mode this extension is designed to
+// prevent.
+//
+// Notable phrasing choices:
+//
+//   - "objective external blocker" makes clear the trigger must
+//     be something the model cannot resolve on its own.
+//   - the enumerated examples are concrete user-facing concepts
+//     (permission, credentials, a missing requirement) so the
+//     model has anchors that look nothing like "this is hard".
+//   - we tell the model what happens AFTER the call ("you may
+//     send a final message"), removing the perceived need to
+//     also stop generating — the previous wording made some
+//     models truncate.
+//   - "Do not use this tool to give up on hard but tractable
+//     work." is a direct instruction that capable models honour
+//     surprisingly well.
+const DefaultDeclareBlockerToolDescription = "Declare that an objective external blocker prevents you from " +
+	"making any further progress on the remaining todo items. Use this ONLY when the obstacle is something " +
+	"YOU CANNOT resolve yourself — for example: missing user permission or credentials, a requirement that is " +
+	"ambiguous and needs the user to clarify, a dependency on infrastructure that is not yet provisioned, or " +
+	"a sensitive decision that must be made by the user. Calling this tool DOES NOT cancel the todo list; the " +
+	"items remain so the user (or a follow-up turn) can pick them up once the missing precondition is supplied. " +
+	"After this tool returns, you MAY produce a final message to the user explaining exactly what input is " +
+	"missing and what they need to provide. Always supply a concrete, user-facing reason. Do NOT use this " +
+	"tool to give up on hard but tractable work, and do NOT use it as a polite way to end the turn."
+
+// declareBlockerInput is the LLM-facing input. The reason is
+// required and must be non-empty. Empirically this friction
+// eliminates a non-trivial fraction of premature declarations:
+// capable models will rather think for one more turn than
+// fabricate a reason.
+type declareBlockerInput struct {
+	Reason string `json:"reason" description:"Concrete, user-facing description of what input is missing and why you cannot continue. Required."`
+}
+
+// declareBlockerOutput is the success payload. Compact on
+// purpose: the model only needs an ack so it can compose the
+// follow-up final message; everything else (state recording,
+// observer notification) happens as a side-effect of Call.
+type declareBlockerOutput struct {
+	OK     bool   `json:"ok"`
+	Reason string `json:"reason"`
+}
+
+// declareBlockerTool implements tool.CallableTool for
+// todo_declare_blocker. We hand-roll this rather than going
+// through tool/function so we can reach a private *Enforcer for
+// observer notification — function.NewFunctionTool would expose
+// only the input value to the closure, not enough to thread the
+// EnforceEvent through.
+type declareBlockerTool struct {
+	name        string
+	description string
+	enforcer    *Enforcer
+}
+
+// Compile-time interface assertion.
+var _ tool.CallableTool = (*declareBlockerTool)(nil)
+
+func newDeclareBlockerTool(name, description string, e *Enforcer) *declareBlockerTool {
+	if name == "" {
+		name = DefaultDeclareBlockerToolName
+	}
+	if description == "" {
+		description = DefaultDeclareBlockerToolDescription
+	}
+	return &declareBlockerTool{name: name, description: description, enforcer: e}
+}
+
+// Declaration exposes the tool to the model. The reason field is
+// declared `required` at the schema level so providers that
+// enforce JSON Schema's `required` (OpenAI, Gemini) reject
+// malformed calls before they even reach our Go code.
+func (t *declareBlockerTool) Declaration() *tool.Declaration {
+	return &tool.Declaration{
+		Name:        t.name,
+		Description: t.description,
+		InputSchema: &tool.Schema{
+			Type: "object",
+			Properties: map[string]*tool.Schema{
+				"reason": {
+					Type:        "string",
+					Description: "Concrete, user-facing description of what input is missing and why you cannot continue.",
+				},
+			},
+			Required: []string{"reason"},
+		},
+		OutputSchema: &tool.Schema{
+			Type: "object",
+			Properties: map[string]*tool.Schema{
+				"ok":     {Type: "boolean"},
+				"reason": {Type: "string"},
+			},
+			Required: []string{"ok", "reason"},
+		},
+	}
+}
+
+// Call records the declaration and returns success. Two
+// behaviours worth pinning down because they are the heart of
+// the v2 redesign:
+//
+//  1. We deliberately return a NORMAL (success) result, NOT an
+//     agent.StopError. The whole point of "declare blocker" is to
+//     LET the model emit its final message immediately afterwards;
+//     terminating the invocation here would suppress that message
+//     and break the contract advertised in Description. The
+//     enforcer's AfterModel sees the latched flag on the next
+//     pass and stops blocking — that is the only behavioural
+//     change.
+//
+//  2. State is set BEFORE this function returns, and the
+//     observer fires before we hand control back. If the LLMAgent
+//     is somehow torn down between the tool call and the next
+//     model turn (timeout, ctx cancel, panic in another tool),
+//     the declaration is still durably recorded on the
+//     invocation for trace exporters / metrics.
+//
+// JSON unmarshalling errors and empty-reason rejections are
+// returned WITHOUT marking the invocation as having declared a
+// blocker, so a malformed call surfaces back to the model as a
+// normal tool error and the model gets a chance to retry with a
+// real reason.
+func (t *declareBlockerTool) Call(ctx context.Context, jsonArgs []byte) (any, error) {
+	in, err := decodeDeclareBlockerInput(jsonArgs)
+	if err != nil {
+		return nil, err
+	}
+	reason := strings.TrimSpace(in.Reason)
+	if reason == "" {
+		return nil, errors.New("todo_declare_blocker: reason is required and must be non-empty")
+	}
+
+	inv, _ := agent.InvocationFromContext(ctx)
+	markBlockerDeclared(inv, reason)
+	if t.enforcer != nil {
+		t.enforcer.notifyBlockerDeclared(inv, reason)
+	}
+	return declareBlockerOutput{OK: true, Reason: reason}, nil
+}
+
+// decodeDeclareBlockerInput is split out so tests can reuse the
+// parser without going through Call.
+func decodeDeclareBlockerInput(raw []byte) (declareBlockerInput, error) {
+	var in declareBlockerInput
+	if len(raw) == 0 {
+		return in, errors.New("todo_declare_blocker: empty arguments")
+	}
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return in, fmt.Errorf("todo_declare_blocker: decode arguments: %w", err)
+	}
+	return in, nil
+}

--- a/agent/extension/todoenforcer/tools_test.go
+++ b/agent/extension/todoenforcer/tools_test.go
@@ -1,0 +1,129 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package todoenforcer
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+)
+
+// newDeclareBlockerTool falls back to package defaults whenever
+// the caller passes empty strings. New() always supplies non-empty
+// values via defaultOptions, so without these tests the fallback
+// branches stay dark — exactly the kind of "would never break in
+// practice but invisible if regressed" branch coverage demands.
+
+func TestNewDeclareBlockerTool_EmptyNameAndDescription_FallBackToDefaults(t *testing.T) {
+	tl := newDeclareBlockerTool("", "", nil)
+	require.NotNil(t, tl)
+	assert.Equal(t, DefaultDeclareBlockerToolName, tl.name,
+		"empty name must default to DefaultDeclareBlockerToolName")
+	assert.Equal(t, DefaultDeclareBlockerToolDescription, tl.description,
+		"empty description must default to DefaultDeclareBlockerToolDescription")
+	assert.Nil(t, tl.enforcer,
+		"nil enforcer must round-trip unchanged — Call must defend against this at use time")
+}
+
+func TestNewDeclareBlockerTool_ExplicitValuesAreUsedVerbatim(t *testing.T) {
+	tl := newDeclareBlockerTool("custom_name", "custom desc", nil)
+	assert.Equal(t, "custom_name", tl.name)
+	assert.Equal(t, "custom desc", tl.description)
+}
+
+// decodeDeclareBlockerInput is the schema-error fence between
+// JSON wire format and our Go types. The Call hot path is fairly
+// well covered already, but the two failure modes — empty payload
+// and malformed JSON — are not exercised because Call's "happy"
+// tests always pass a valid object. We test the parser directly.
+func TestDecodeDeclareBlockerInput_RejectsEmptyArgs(t *testing.T) {
+	_, err := decodeDeclareBlockerInput(nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty arguments",
+		"nil payload must produce the documented \"empty arguments\" error")
+
+	_, err = decodeDeclareBlockerInput([]byte{})
+	require.Error(t, err, "zero-length slice is observationally identical to nil")
+}
+
+func TestDecodeDeclareBlockerInput_RejectsMalformedJSON(t *testing.T) {
+	_, err := decodeDeclareBlockerInput([]byte("not a json"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decode arguments",
+		"unmarshal failures must be wrapped with the decode-arguments prefix so callers can match")
+}
+
+func TestDecodeDeclareBlockerInput_AcceptsWellFormedJSON(t *testing.T) {
+	in, err := decodeDeclareBlockerInput([]byte(`{"reason":"missing access"}`))
+	require.NoError(t, err)
+	assert.Equal(t, "missing access", in.Reason,
+		"well-formed JSON must round-trip the reason field")
+
+	// Extra unknown fields must be silently ignored — this is the
+	// jsonschema contract we advertise via "type:object" without
+	// "additionalProperties:false" in Declaration(). A future
+	// schema tightening should add a positive test here, not here
+	// (i.e. don't surprise downstream callers with an error path
+	// they previously did not see).
+	in, err = decodeDeclareBlockerInput([]byte(`{"reason":"x","unknown":42}`))
+	require.NoError(t, err)
+	assert.Equal(t, "x", in.Reason)
+}
+
+// TestCall_RejectsMalformedAndEmptyReason makes the Call-side
+// error paths explicit (Call → decodeDeclareBlockerInput) and
+// also pins the documented "do NOT mark the invocation as
+// declared on a malformed call" behaviour: the latch must stay
+// off so the model can retry.
+func TestCall_RejectsMalformedAndEmptyReason(t *testing.T) {
+	_, inv, _ := newTestInvocation(t, "agent-A")
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+
+	tl := newDeclareBlockerTool("", "", nil)
+
+	_, err := tl.Call(ctx, []byte(`not-json`))
+	require.Error(t, err)
+	assert.False(t, blockerDeclared(inv),
+		"malformed call must not flip the blocker-declared latch")
+
+	_, err = tl.Call(ctx, []byte(`{"reason":"   "}`))
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "reason is required",
+		"whitespace-only reason must produce the documented \"reason is required\" error")
+	assert.False(t, blockerDeclared(inv),
+		"empty-reason rejection must not flip the latch either")
+}
+
+// TestCall_HappyPath_NoEnforcer_NoNotify defends the documented
+// "tools constructed without an enforcer still record the
+// declaration" semantics. The notification is a no-op (no
+// observer to call), but the on-invocation latch must still flip
+// — otherwise the enforcer-less unit tests would silently break
+// any user that built the tool standalone for migration purposes.
+func TestCall_HappyPath_NoEnforcer_NoNotify(t *testing.T) {
+	_, inv, _ := newTestInvocation(t, "agent-A")
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+
+	tl := newDeclareBlockerTool("", "", nil)
+	out, err := tl.Call(ctx, []byte(`{"reason":"missing creds"}`))
+	require.NoError(t, err)
+	res, ok := out.(declareBlockerOutput)
+	require.True(t, ok, "Call must return declareBlockerOutput on success, got %T", out)
+	assert.True(t, res.OK)
+	assert.Equal(t, "missing creds", res.Reason,
+		"the output must echo the reason — the wire schema declares both ok and reason as required")
+	assert.True(t, blockerDeclared(inv))
+	assert.Equal(t, "missing creds", blockerReason(inv))
+}

--- a/docs/mkdocs/en/tool.md
+++ b/docs/mkdocs/en/tool.md
@@ -643,6 +643,7 @@ agent := llmagent.New("todo-assistant",
 import (
     "trpc.group/trpc-go/trpc-agent-go/agent/extension/todoenforcer"
     "trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+    "trpc.group/trpc-go/trpc-agent-go/tool/todo"
 )
 
 agent := llmagent.New("todo-assistant",

--- a/docs/mkdocs/en/tool.md
+++ b/docs/mkdocs/en/tool.md
@@ -635,6 +635,25 @@ agent := llmagent.New("todo-assistant",
 
 `todo.DefaultToolPrompt` is a ready-made system-instruction snippet that teaches the model when to call `todo_write` and how to phrase items. You can replace it with your own copy; the runtime checks below stay the same.
 
+#### Hard Compliance
+
+`todo_write` is advisory by default: the model can still decide to stop while items remain open. If an agent must finish the list before producing a final response, install the `todoenforcer` extension:
+
+```go
+import (
+    "trpc.group/trpc-go/trpc-agent-go/agent/extension/todoenforcer"
+    "trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+)
+
+agent := llmagent.New("todo-assistant",
+    llmagent.WithModel(model),
+    llmagent.WithInstruction(todo.DefaultToolPrompt),
+    llmagent.WithExtensions(todoenforcer.New()),
+)
+```
+
+The extension contributes both `todo_write` and `todo_declare_blocker`; do not also pass a separate `todo.New()` through `WithTools`. `todo_declare_blocker` is the escape hatch for objective blockers such as missing permissions, credentials, infrastructure, or user decisions.
+
 #### Tool Result
 
 `todo_write` returns a structured result instead of free-form text, so any caller — terminal, AG-UI, a custom HTTP frontend — can render the same data without parsing prose:
@@ -697,7 +716,7 @@ todoTool := todo.New(
 )
 ```
 
-A complete runnable demo, including the multi-turn pause/resume scenario and an ASCII renderer, lives in [`examples/todo/`](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/todo).
+A complete runnable demo of the base tool, including the multi-turn pause/resume scenario and an ASCII renderer, lives in [`examples/todo/`](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/todo). A side-by-side enforcement demo lives in [`examples/todoenforcer/`](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/todoenforcer).
 
 ## MCP Tools
 

--- a/docs/mkdocs/en/tool.md
+++ b/docs/mkdocs/en/tool.md
@@ -652,7 +652,7 @@ agent := llmagent.New("todo-assistant",
 )
 ```
 
-The extension contributes both `todo_write` and `todo_declare_blocker`; do not also pass a separate `todo.New()` through `WithTools`. `todo_declare_blocker` is the escape hatch for objective blockers such as missing permissions, credentials, infrastructure, or user decisions.
+The extension contributes both `todo_write` and `todo_declare_blocker`; do not also pass a separate `todo.New()` through `WithTools`. To reuse `tool/todo` options such as `WithStateKeyPrefix`, `WithClearOnAllDone`, or `WithNudgeHook`, construct the tool yourself and pass it with `todoenforcer.WithTodoTool(todo.New(...))`. `todo_declare_blocker` is the escape hatch for objective blockers such as missing permissions, credentials, infrastructure, or user decisions.
 
 #### Tool Result
 

--- a/docs/mkdocs/zh/tool.md
+++ b/docs/mkdocs/zh/tool.md
@@ -628,6 +628,25 @@ agent := llmagent.New("todo-assistant",
 
 `todo.DefaultToolPrompt` 是开箱即用的 system instruction 片段，告诉模型何时调用 `todo_write` 以及如何撰写条目；你也可以替换成自己的版本，下文的运行时校验规则不受影响。
 
+#### 强制完成
+
+默认情况下，`todo_write` 只是建议性工具：即使清单里还有未完成项，模型仍可能直接结束回复。若希望 Agent 必须完成清单后才能输出最终回复，可以安装 `todoenforcer` extension：
+
+```go
+import (
+    "trpc.group/trpc-go/trpc-agent-go/agent/extension/todoenforcer"
+    "trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+)
+
+agent := llmagent.New("todo-assistant",
+    llmagent.WithModel(model),
+    llmagent.WithInstruction(todo.DefaultToolPrompt),
+    llmagent.WithExtensions(todoenforcer.New()),
+)
+```
+
+该 extension 会自动贡献 `todo_write` 和 `todo_declare_blocker`，不要再通过 `WithTools` 额外传入 `todo.New()`。`todo_declare_blocker` 用于声明客观阻塞，例如缺少权限、凭据、基础设施或必须由用户决策的信息。
+
 #### 工具返回结构
 
 `todo_write` 返回的是结构化结果而不是自由文本，因此终端、AG-UI、自研 HTTP 前端等任何调用方都可以直接消费：
@@ -687,7 +706,7 @@ todoTool := todo.New(
 )
 ```
 
-完整可运行示例（包含多轮暂停/续接场景与 ASCII 渲染器）见 [`examples/todo/`](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/todo)。
+基础工具的完整可运行示例（包含多轮暂停/续接场景与 ASCII 渲染器）见 [`examples/todo/`](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/todo)。带强制完成对照的示例见 [`examples/todoenforcer/`](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/todoenforcer)。
 
 ## MCP Tools 协议工具
 

--- a/docs/mkdocs/zh/tool.md
+++ b/docs/mkdocs/zh/tool.md
@@ -645,7 +645,7 @@ agent := llmagent.New("todo-assistant",
 )
 ```
 
-该 extension 会自动贡献 `todo_write` 和 `todo_declare_blocker`，不要再通过 `WithTools` 额外传入 `todo.New()`。`todo_declare_blocker` 用于声明客观阻塞，例如缺少权限、凭据、基础设施或必须由用户决策的信息。
+该 extension 会自动贡献 `todo_write` 和 `todo_declare_blocker`，不要再通过 `WithTools` 额外传入 `todo.New()`。如果需要复用 `tool/todo` 的选项（例如 `WithStateKeyPrefix`、`WithClearOnAllDone` 或 `WithNudgeHook`），先构造 `todo.New(...)`，再通过 `todoenforcer.WithTodoTool(...)` 传入。`todo_declare_blocker` 用于声明客观阻塞，例如缺少权限、凭据、基础设施或必须由用户决策的信息。
 
 #### 工具返回结构
 

--- a/docs/mkdocs/zh/tool.md
+++ b/docs/mkdocs/zh/tool.md
@@ -636,6 +636,7 @@ agent := llmagent.New("todo-assistant",
 import (
     "trpc.group/trpc-go/trpc-agent-go/agent/extension/todoenforcer"
     "trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+    "trpc.group/trpc-go/trpc-agent-go/tool/todo"
 )
 
 agent := llmagent.New("todo-assistant",

--- a/examples/todoenforcer/README.md
+++ b/examples/todoenforcer/README.md
@@ -67,3 +67,5 @@ Inside interactive mode:
 - `[enforce] BLOCKER_DECLARED ...` — final responses are allowed for the rest of this invocation.
 
 See also `examples/todo/` for the same checklist tool without enforcement.
+Use `todoenforcer.WithTodoTool(todo.New(...))` when you need the
+underlying `tool/todo` options.

--- a/examples/todoenforcer/README.md
+++ b/examples/todoenforcer/README.md
@@ -14,8 +14,8 @@ the current invocation still has open todo items. It must either:
 ```bash
 cd examples/todoenforcer
 export OPENAI_API_KEY="your-key"
-# Optional for OpenAI-compatible gateways:
-# export OPENAI_BASE_URL="http://v2.open.venus.oa.com/llmproxy/"
+# Optional for an OpenAI-compatible endpoint:
+# export OPENAI_BASE_URL="https://your-openai-compatible-endpoint/v1"
 ```
 
 Baseline, without enforcement:

--- a/examples/todoenforcer/README.md
+++ b/examples/todoenforcer/README.md
@@ -1,0 +1,69 @@
+# todoenforcer Extension Demo
+
+This example compares the baseline `tool/todo` workflow with the
+`agent/extension/todoenforcer` extension.
+
+With `-enforce=true`, the agent cannot emit a final response while
+the current invocation still has open todo items. It must either:
+
+- finish the list; or
+- call `todo_declare_blocker` with a concrete external blocker.
+
+## Run
+
+```bash
+cd examples/todoenforcer
+export OPENAI_API_KEY="your-key"
+# Optional for OpenAI-compatible gateways:
+# export OPENAI_BASE_URL="http://v2.open.venus.oa.com/llmproxy/"
+```
+
+Baseline, without enforcement:
+
+```bash
+go run . -enforce=false \
+  -seed "Plan and execute a 4-step deployment: 1) write the deployment config, 2) run unit tests, 3) deploy to staging, 4) verify with smoke test."
+```
+
+Hardened, with todoenforcer:
+
+```bash
+go run . -enforce=true \
+  -seed "Plan and execute a 4-step deployment: 1) write the deployment config, 2) run unit tests, 3) deploy to staging, 4) verify with smoke test."
+```
+
+Use `-prefill-todos=true` to simulate resuming a previous turn that
+already has open todos:
+
+```bash
+go run . -enforce=true -prefill-todos=true \
+  -seed "Please continue the work you were doing."
+```
+
+## Useful Flags
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `-model` | `deepseek-chat` | OpenAI-compatible model name |
+| `-variant` | `openai` | OpenAI client variant |
+| `-streaming` | `true` | Stream assistant output |
+| `-enforce` | `true` | Install the todoenforcer extension |
+| `-max-retries` | `3` | Number of blocked final responses before fail-open |
+| `-max-tokens` | `4000` | Completion token budget |
+| `-prefill-todos` | `false` | Seed a synthetic prior turn with open todos |
+| `-seed` | empty | First user message; omit for interactive mode |
+
+Inside interactive mode:
+
+- `/list` prints the current checklist.
+- `/exit` quits.
+
+## Reading the Output
+
+- `[tool-call] todo_write ...` — the model created or updated the checklist.
+- `[tool-call] todo_declare_blocker ...` — the model declared an external blocker.
+- `[enforce] BLOCKED ...` — the model tried to finish with open todos; the extension kept the loop going.
+- `[enforce] EXHAUSTED ...` — retry budget was consumed; the extension fail-opened.
+- `[enforce] BLOCKER_DECLARED ...` — final responses are allowed for the rest of this invocation.
+
+See also `examples/todo/` for the same checklist tool without enforcement.

--- a/examples/todoenforcer/main.go
+++ b/examples/todoenforcer/main.go
@@ -1,0 +1,525 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+// Package main demonstrates the todoenforcer extension.
+//
+// Run side-by-side comparisons:
+//
+//	# baseline: tool/todo without any enforcement (model can exit early)
+//	go run ./examples/todoenforcer --enforce=false \
+//	  --seed "Plan and execute a 4-step deployment: write config, run tests, deploy to staging, verify with smoke test."
+//
+//	# hardened: same prompt with todoenforcer wired in
+//	go run ./examples/todoenforcer --enforce=true \
+//	  --seed "Plan and execute a 4-step deployment: write config, run tests, deploy to staging, verify with smoke test."
+//
+// In the hardened run, watch the [enforce] lines: they show every
+// blocked attempt the extension caught, the nudge it queued, and (if
+// the model gives up via todo_declare_blocker) the formal blocker
+// declaration. The key behavioural promise the demo verifies is
+// that the model can no longer end the turn while open items
+// remain — it must either work them, or formally declare a
+// blocker.
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/extension/todoenforcer"
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/model/openai"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	sessioninmemory "trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+	"trpc.group/trpc-go/trpc-agent-go/tool/todo"
+)
+
+var (
+	modelName  = flag.String("model", "deepseek-chat", "Model identifier (any OpenAI-compatible name; for venus llmproxy try claude-4-5-sonnet-20250929 or gpt-5)")
+	streaming  = flag.Bool("streaming", true, "Stream the assistant response")
+	variant    = flag.String("variant", "openai", "Provider variant passed to the OpenAI client")
+	enforce    = flag.Bool("enforce", true, "Install the todoenforcer extension (set false to compare baseline behaviour)")
+	maxRetries = flag.Int("max-retries", 3, "todoenforcer block-retry budget per invocation")
+	maxTokens  = flag.Int("max-tokens", 4000, "Max completion tokens (lower if your provider rejects the default)")
+	seed       = flag.String("seed", "", "Optional first user message; if set, the chat auto-starts with it")
+	prefill    = flag.Bool("prefill-todos", false, "Pre-seed the session with one in_progress + one pending todo BEFORE the first turn. Useful when your provider's OpenAI-compatible tool-call adapter is unstable and you need to verify the enforcer fires without depending on the model successfully invoking todo_write first.")
+)
+
+const (
+	appName   = "todoenforcer-demo"
+	agentName = "todoenforcer-assistant"
+)
+
+func main() {
+	flag.Parse()
+
+	fmt.Println("todoenforcer extension demo")
+	fmt.Printf("Model:       %s (variant=%s)\n", *modelName, *variant)
+	fmt.Printf("Streaming:   %t\n", *streaming)
+	fmt.Printf("Enforce:     %t (max-retries=%d)\n", *enforce, *maxRetries)
+	fmt.Println("Commands:    /exit to quit, /list to print the current checklist")
+	fmt.Println(strings.Repeat("=", 70))
+
+	c := &chat{
+		modelName:  *modelName,
+		streaming:  *streaming,
+		variant:    *variant,
+		enforce:    *enforce,
+		maxRetries: *maxRetries,
+		maxTokens:  *maxTokens,
+		prefill:    *prefill,
+	}
+	if err := c.run(); err != nil {
+		log.Fatalf("chat failed: %v", err)
+	}
+}
+
+// chat wraps the runner, session service and conversation loop.
+type chat struct {
+	modelName  string
+	streaming  bool
+	variant    string
+	enforce    bool
+	maxRetries int
+	maxTokens  int
+	prefill    bool
+
+	runner    runner.Runner
+	sessSvc   session.Service
+	userID    string
+	sessionID string
+}
+
+func (c *chat) run() error {
+	ctx := context.Background()
+	if err := c.setup(); err != nil {
+		return fmt.Errorf("setup: %w", err)
+	}
+	defer c.runner.Close()
+
+	if c.prefill {
+		if err := c.prefillTodos(ctx); err != nil {
+			return fmt.Errorf("prefill: %w", err)
+		}
+	}
+
+	if *seed != "" {
+		fmt.Printf("You (seed): %s\n", *seed)
+		if err := c.processMessage(ctx, *seed); err != nil {
+			fmt.Printf("Error: %v\n", err)
+		}
+		fmt.Println()
+		c.printTodos()
+	}
+	return c.startChat(ctx)
+}
+
+// prefillTodos simulates a mid-task resumption scenario. It
+// reproduces, by hand, the exact pair of artefacts a real prior
+// turn would have left behind:
+//
+//  1. session.State holds the current todo list (this is what
+//     the enforcer's AfterModel reads to detect open items).
+//  2. The session's event log holds the chat history that proves
+//     the model itself already wrote the list — a user turn
+//     asking for the work, an assistant turn calling todo_write,
+//     and a tool turn carrying todo_write's response.
+//
+// Both are required for the demo to feel honest:
+//
+//   - Without (1) the enforcer never trips, since there are no
+//     open items in state.
+//   - Without (2) the model is blind to its own past — when the
+//     user later says "please continue what you were doing", the
+//     model has nothing in its visible chat history to continue
+//     from. It will (correctly) say "I don't have any prior
+//     context" and force the enforcer into a teaching role
+//     ("here is a task you never knew about"), which is NOT the
+//     real production semantics. The extension is meant to remind
+//     a model of work it KNOWS it owes, not to dump unfamiliar
+//     work onto it.
+//
+// We construct (2) using event.NewResponseEvent + AppendEvent,
+// the same path examples/session/appendevent/ uses. The Branch
+// field on each event matches the agent's branch (the agent
+// name in a single-agent setup), so when the runner builds the
+// next request these messages show up in the right context.
+func (c *chat) prefillTodos(ctx context.Context) error {
+	items := []todo.Item{
+		{
+			Content:    "Inspect the Kubernetes pod logs for the recent failure",
+			ActiveForm: "Inspecting the Kubernetes pod logs for the recent failure",
+			Status:     todo.StatusInProgress,
+		},
+		{
+			Content:    "Identify the root cause and propose a fix",
+			ActiveForm: "Identifying the root cause and proposing a fix",
+			Status:     todo.StatusPending,
+		},
+	}
+	rawState, err := json.Marshal(items)
+	if err != nil {
+		return err
+	}
+	// Branch defaults to the agent name for a single-agent setup
+	// — same convention printTodos / GetTodos / the enforcer use.
+	stateKey := todo.DefaultStateKeyPrefix + ":" + agentName
+	sess, err := c.sessSvc.CreateSession(ctx, session.Key{
+		AppName:   appName,
+		UserID:    c.userID,
+		SessionID: c.sessionID,
+	}, session.StateMap{stateKey: rawState})
+	if err != nil {
+		return err
+	}
+
+	// Build the synthetic prior turn. The arguments and result
+	// payload mirror what a real todo_write call would carry, so
+	// downstream consumers (event log replays, evaluation
+	// pipelines, ...) see a turn that is structurally
+	// indistinguishable from one the model actually produced.
+	priorInvocationID := uuid.New().String()
+	toolCallID := "prefill-" + uuid.New().String()
+
+	priorUserMsg := "I just got a page about a Kubernetes pod failure in prod. " +
+		"Please investigate: dig the pod logs, find the root cause, then " +
+		"propose a fix. Plan the work with todo_write first."
+
+	todoWriteArgs, err := json.Marshal(map[string]any{"todos": items})
+	if err != nil {
+		return err
+	}
+	todoWriteResult, err := json.Marshal(map[string]any{
+		"message": "Todos have been modified successfully.",
+		"todos":   items,
+	})
+	if err != nil {
+		return err
+	}
+
+	events := []*event.Event{
+		// 1. The original user request that kicked the work off.
+		newPrefillEvent(priorInvocationID, "user", model.NewUserMessage(priorUserMsg)),
+		// 2. The assistant turn that called todo_write to plan.
+		newPrefillEvent(priorInvocationID, agentName, model.Message{
+			Role: model.RoleAssistant,
+			ToolCalls: []model.ToolCall{{
+				ID:   toolCallID,
+				Type: "function",
+				Function: model.FunctionDefinitionParam{
+					Name:      todo.DefaultToolName,
+					Arguments: todoWriteArgs,
+				},
+			}},
+		}),
+		// 3. The tool turn carrying todo_write's response.
+		// ToolName is set even though the spec doesn't strictly
+		// require it for assistant↔tool pairing — several
+		// OpenAI-compatible proxies (notably the adapters used by
+		// llmproxy gateways) reject tool messages whose name
+		// field is empty, even when the matching ID is present.
+		newPrefillEvent(priorInvocationID, agentName, model.Message{
+			Role:     model.RoleTool,
+			ToolID:   toolCallID,
+			ToolName: todo.DefaultToolName,
+			Content:  string(todoWriteResult),
+		}),
+	}
+	for _, evt := range events {
+		evt.Branch = agentName
+		if err := c.sessSvc.AppendEvent(ctx, sess, evt); err != nil {
+			return fmt.Errorf("append prefill event: %w", err)
+		}
+	}
+
+	fmt.Println("Prefilled the session with this synthetic prior turn:")
+	fmt.Printf("  user → %s\n", truncate(priorUserMsg, 90))
+	fmt.Printf("  assistant → tool_call %s(%d items)\n", todo.DefaultToolName, len(items))
+	fmt.Printf("  tool → %s response\n", todo.DefaultToolName)
+	fmt.Println("Open todos already in state:")
+	fmt.Println(formatTodos(items))
+	fmt.Println(strings.Repeat("-", 70))
+	return nil
+}
+
+// newPrefillEvent is a thin wrapper that fills in the boilerplate
+// every prefilled event needs: a non-streaming, non-partial
+// response carrying exactly one Choice with the supplied message.
+// IsValidContent() returns true for tool-call / tool-result
+// messages even when Content is empty, which is why the assistant
+// tool_call leg is well-formed despite having no text body.
+func newPrefillEvent(invocationID, author string, msg model.Message) *event.Event {
+	return event.NewResponseEvent(invocationID, author, &model.Response{
+		Done: false,
+		Choices: []model.Choice{{
+			Index:   0,
+			Message: msg,
+		}},
+	})
+}
+
+func (c *chat) setup() error {
+	modelInstance := openai.New(c.modelName, openai.WithVariant(openai.Variant(c.variant)))
+	c.sessSvc = sessioninmemory.NewSessionService()
+
+	// Two construction paths so the same demo can show both
+	// "raw tool/todo" baseline and "hardened by todoenforcer".
+	// Other than the WithExtensions / WithTools split, the agent
+	// configuration is identical, which keeps the comparison
+	// honest — any behavioural difference you see in [enforce]
+	// lines comes purely from the extension being installed.
+	instruction := "You are a careful assistant. When a user asks you to do " +
+		"anything with more than 2 steps, call todo_write to plan first, " +
+		"then work the items one by one, flipping status as you go. " +
+		"Do not produce a final answer while items remain open.\n\n" +
+		todo.DefaultToolPrompt
+
+	agentOpts := []llmagent.Option{
+		llmagent.WithModel(modelInstance),
+		llmagent.WithDescription("Demo agent that uses todo_write under enforced compliance."),
+		llmagent.WithInstruction(instruction),
+		llmagent.WithGenerationConfig(model.GenerationConfig{
+			MaxTokens: intPtr(c.maxTokens),
+			Stream:    c.streaming,
+		}),
+	}
+
+	if c.enforce {
+		// Install the extension. WithExtensions also routes the
+		// tools the enforcer contributes via extension.Registry.Tools
+		// — the enforcer ships both todo_write AND
+		// todo_declare_blocker, so we do NOT pass either via
+		// WithTools. Passing them here on top would trigger the
+		// name-collision dedup and silently drop the enforcer's
+		// copies; the dedup is correct but it's not what we want
+		// the demo to show.
+		enforcer := todoenforcer.New(
+			todoenforcer.WithMaxRetries(c.maxRetries),
+			todoenforcer.WithOnEnforce(c.observeEnforce),
+		)
+		agentOpts = append(agentOpts, llmagent.WithExtensions(enforcer))
+	} else {
+		// Baseline: hand-install todo so the model has a place to
+		// write a plan, but with no enforcement. The model is free
+		// to mark items pending and still emit a final answer —
+		// which is exactly the behaviour the extension exists to
+		// fix.
+		agentOpts = append(agentOpts, llmagent.WithTools([]tool.Tool{todo.New()}))
+	}
+
+	llmAgent := llmagent.New(agentName, agentOpts...)
+
+	c.runner = runner.NewRunner(appName, llmAgent, runner.WithSessionService(c.sessSvc))
+	c.userID = "demo-user"
+	c.sessionID = fmt.Sprintf("demo-session-%d", time.Now().Unix())
+
+	fmt.Printf("Ready. Session: %s\n\n", c.sessionID)
+	return nil
+}
+
+// observeEnforce is the OnEnforce callback. It runs on the model
+// callback hot path, so we keep it cheap (just printing). We
+// serialise prints with a mutex because the enforcer hook can
+// race with the streaming output goroutine in processResponse —
+// without it [enforce] lines occasionally interleave with
+// assistant deltas mid-token.
+var enforceMu sync.Mutex
+
+func (c *chat) observeEnforce(evt todoenforcer.EnforceEvent) {
+	enforceMu.Lock()
+	defer enforceMu.Unlock()
+	switch evt.Reason {
+	case todoenforcer.ReasonBlocked:
+		fmt.Printf("\n  [enforce] BLOCKED (attempt %d/%d): %d in_progress, %d pending → nudge queued\n",
+			evt.AttemptNumber, evt.MaxRetries, evt.InProgressCount, evt.PendingCount)
+	case todoenforcer.ReasonExhausted:
+		fmt.Printf("\n  [enforce] EXHAUSTED after %d attempts: %d in_progress, %d pending → fail-open\n",
+			evt.AttemptNumber, evt.InProgressCount, evt.PendingCount)
+	case todoenforcer.ReasonBlockerDeclared:
+		fmt.Printf("\n  [enforce] BLOCKER_DECLARED: %q → final response will be allowed for the rest of this turn\n",
+			evt.BlockerReason)
+	}
+}
+
+func (c *chat) startChat(ctx context.Context) error {
+	scanner := bufio.NewScanner(os.Stdin)
+	for {
+		fmt.Print("You: ")
+		if !scanner.Scan() {
+			break
+		}
+		line := strings.TrimSpace(scanner.Text())
+		switch line {
+		case "":
+			continue
+		case "/exit":
+			fmt.Println("bye")
+			return nil
+		case "/list":
+			c.printTodos()
+			continue
+		}
+		if err := c.processMessage(ctx, line); err != nil {
+			fmt.Printf("Error: %v\n", err)
+		}
+		fmt.Println()
+		c.printTodos()
+	}
+	return scanner.Err()
+}
+
+func (c *chat) processMessage(ctx context.Context, msg string) error {
+	reqID := uuid.New().String()
+	eventChan, err := c.runner.Run(
+		ctx, c.userID, c.sessionID, model.NewUserMessage(msg),
+		agent.WithRequestID(reqID),
+	)
+	if err != nil {
+		return err
+	}
+	return c.processResponse(eventChan)
+}
+
+// processResponse renders the stream: tool calls, tool responses
+// and assistant text are each formatted distinctly so the
+// enforcement loop is easy to follow visually.
+func (c *chat) processResponse(eventChan <-chan *event.Event) error {
+	fmt.Print("Assistant: ")
+	var assistantStarted bool
+	var toolCallsPrinted bool
+
+	for evt := range eventChan {
+		if evt.Error != nil {
+			fmt.Printf("\n[error] %s\n", evt.Error.Message)
+			continue
+		}
+		if evt.Response == nil || len(evt.Response.Choices) == 0 {
+			continue
+		}
+		ch := evt.Response.Choices[0]
+
+		if len(ch.Message.ToolCalls) > 0 {
+			if assistantStarted {
+				fmt.Println()
+			}
+			for _, tc := range ch.Message.ToolCalls {
+				fmt.Printf("  [tool-call] %s %s\n", tc.Function.Name, string(tc.Function.Arguments))
+			}
+			toolCallsPrinted = true
+			continue
+		}
+
+		if ch.Message.Role == model.RoleTool && ch.Message.ToolID != "" {
+			raw := strings.TrimSpace(ch.Message.Content)
+			fmt.Printf("  [tool-result] %s\n", truncate(raw, 200))
+			var out todo.Output
+			if err := json.Unmarshal([]byte(raw), &out); err == nil && len(out.Todos) > 0 {
+				fmt.Printf("  [tool-result decoded] %d todos (was %d)\n",
+					len(out.Todos), len(out.OldTodos))
+				for _, it := range out.Todos {
+					fmt.Printf("    - [%s] %s\n", it.Status, it.Content)
+				}
+			}
+			continue
+		}
+
+		text := ch.Delta.Content
+		if !c.streaming {
+			text = ch.Message.Content
+		}
+		if text == "" {
+			continue
+		}
+		if !assistantStarted {
+			if toolCallsPrinted {
+				fmt.Print("\nAssistant: ")
+			}
+			assistantStarted = true
+		}
+		fmt.Print(text)
+
+		if evt.IsFinalResponse() {
+			fmt.Println()
+		}
+	}
+	return nil
+}
+
+// printTodos reads the canonical checklist from session state at
+// the end of a turn. The enforcer reads from the same place, so
+// what you see here is what the enforcer's AfterModel saw when it
+// decided to block (or pass).
+func (c *chat) printTodos() {
+	sess, err := c.sessSvc.GetSession(context.Background(), session.Key{
+		AppName:   appName,
+		UserID:    c.userID,
+		SessionID: c.sessionID,
+	})
+	if err != nil || sess == nil {
+		return
+	}
+	items, err := todo.GetTodos(sess, agentName)
+	if err != nil {
+		fmt.Printf("[todo] decode error: %v\n", err)
+		return
+	}
+	fmt.Println("----- Current checklist -----")
+	fmt.Println(formatTodos(items))
+	fmt.Println("-----------------------------")
+}
+
+func formatTodos(todos []todo.Item) string {
+	if len(todos) == 0 {
+		return "(no todos)"
+	}
+	glyph := func(s todo.Status) string {
+		switch s {
+		case todo.StatusCompleted:
+			return "[x]"
+		case todo.StatusInProgress:
+			return "[>]"
+		default:
+			return "[ ]"
+		}
+	}
+	var b strings.Builder
+	for i, it := range todos {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		fmt.Fprintf(&b, "- %s %s", glyph(it.Status), it.Content)
+	}
+	return b.String()
+}
+
+// truncate keeps the demo output legible when a tool result is
+// long (the JSON payload of a 10-item todo list is otherwise
+// noisy enough to push the [enforce] lines off-screen).
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "...(truncated)"
+}
+
+func intPtr(i int) *int { return &i }

--- a/examples/todoenforcer/main.go
+++ b/examples/todoenforcer/main.go
@@ -444,7 +444,7 @@ func (c *chat) processResponse(eventChan <-chan *event.Event) error {
 		}
 
 		text := ch.Delta.Content
-		if !c.streaming {
+		if text == "" {
 			text = ch.Message.Content
 		}
 		if text == "" {

--- a/examples/todoenforcer/main.go
+++ b/examples/todoenforcer/main.go
@@ -55,7 +55,7 @@ import (
 )
 
 var (
-	modelName  = flag.String("model", "deepseek-chat", "Model identifier (any OpenAI-compatible name; for venus llmproxy try claude-4-5-sonnet-20250929 or gpt-5)")
+	modelName  = flag.String("model", "deepseek-chat", "Model identifier (any OpenAI-compatible name)")
 	streaming  = flag.Bool("streaming", true, "Stream the assistant response")
 	variant    = flag.String("variant", "openai", "Provider variant passed to the OpenAI client")
 	enforce    = flag.Bool("enforce", true, "Install the todoenforcer extension (set false to compare baseline behaviour)")
@@ -235,9 +235,9 @@ func (c *chat) prefillTodos(ctx context.Context) error {
 		// 3. The tool turn carrying todo_write's response.
 		// ToolName is set even though the spec doesn't strictly
 		// require it for assistant↔tool pairing — several
-		// OpenAI-compatible proxies (notably the adapters used by
-		// llmproxy gateways) reject tool messages whose name
-		// field is empty, even when the matching ID is present.
+		// Some OpenAI-compatible adapters reject tool messages
+		// whose name field is empty, even when the matching ID is
+		// present.
 		newPrefillEvent(priorInvocationID, agentName, model.Message{
 			Role:     model.RoleTool,
 			ToolID:   toolCallID,

--- a/tool/todo/todo.go
+++ b/tool/todo/todo.go
@@ -166,6 +166,25 @@ func New(opts ...Option) *Tool {
 	return &Tool{opts: o}
 }
 
+// StateKeyPrefix returns the session.State key prefix this Tool
+// instance was configured with (see WithStateKeyPrefix). The
+// returned value is what callers should hand to
+// GetTodosWithPrefix to read back exactly what this Tool will
+// write — relying on DefaultStateKeyPrefix would miss writes from
+// a Tool constructed with a custom prefix.
+//
+// Why a getter rather than re-exposing the option: making
+// stateKeyPrefix public on the options struct would invite
+// callers to mutate it post-construction, which the
+// functional-options pattern explicitly tries to prevent. A
+// read-only accessor preserves the single point of truth
+// (defaultOptions + WithStateKeyPrefix) while still letting
+// callers (e.g. agent/extension/todoenforcer) honour the configured
+// layout.
+func (t *Tool) StateKeyPrefix() string {
+	return t.opts.stateKeyPrefix
+}
+
 // Declaration implements tool.Tool.
 func (t *Tool) Declaration() *tool.Declaration {
 	// Build an explicit schema so that the item sub-schema, enum and


### PR DESCRIPTION
## Summary

This PR builds on the agent-scoped extension API that has already landed in `upstream/main` and adds one concrete extension: `agent/extension/todoenforcer`.

- Adds `todoenforcer.New(...)`, an `agent/extension.Extension` that contributes `todo_write` plus `todo_declare_blocker` through `extension.Registry.Tools`.
- Blocks final model responses while the current invocation has open todo items, nudging the model to either finish them or explicitly declare an objective blocker.
- Adds `todo_declare_blocker` as the non-terminating escape hatch for missing permissions, credentials, user decisions, unavailable infrastructure, or other external blockers.
- Adds `tool/todo.Tool.StateKeyPrefix()` so the enforcer can honor custom `todo.Tool` state prefixes.

## User-visible API

```go
agent := llmagent.New("worker",
    llmagent.WithExtensions(
        todoenforcer.New(todoenforcer.WithMaxRetries(3)),
    ),
)
```