### PR TITLE
session/summary: enhance token threshold checks for summary to include reasoning contents

### DIFF
--- a/session/summary/checker.go
+++ b/session/summary/checker.go
@@ -41,6 +41,8 @@ var (
 
 const tokenThresholdConversationTextStateKey = session.StateTempPrefix +
 	"summary:token_threshold_conversation_text"
+const tokenThresholdReasoningContentStateKey = session.StateTempPrefix +
+	"summary:token_threshold_reasoning_content"
 
 func getTokenCounter() model.TokenCounter {
 	defaultTokenCounterMu.RLock()
@@ -202,13 +204,14 @@ func CheckTimeThreshold(interval time.Duration) Checker {
 	}
 }
 
-// checkTokenThresholdFromText checks if the token count of the given text exceeds the threshold.
-func checkTokenThresholdFromText(
+// checkTokenThresholdFromMessage checks if the token count of the given message exceeds the threshold.
+func checkTokenThresholdFromMessage(
 	ctx context.Context,
 	tokenCount int,
-	conversationText string,
+	message model.Message,
 ) bool {
-	if conversationText == "" {
+	if strings.TrimSpace(message.Content) == "" &&
+		strings.TrimSpace(message.ReasoningContent) == "" {
 		return false
 	}
 	if ctx == nil {
@@ -218,7 +221,7 @@ func checkTokenThresholdFromText(
 	// SimpleTokenCounter.CountTokens currently never returns an error.
 	tokens, _ := getTokenCounter().CountTokens(
 		ctx,
-		model.Message{Content: conversationText},
+		message,
 	)
 	return tokens > tokenCount
 }
@@ -258,11 +261,11 @@ func checkTokenThreshold(
 	tokenCount int,
 	sess *session.Session,
 ) bool {
-	if conversationText, ok := getInjectedTokenThresholdConversationText(sess); ok {
-		return checkTokenThresholdFromText(
+	if message, ok := getInjectedTokenThresholdMessage(sess); ok {
+		return checkTokenThresholdFromMessage(
 			ctx,
 			tokenCount,
-			conversationText,
+			message,
 		)
 	}
 	delta := filterDeltaEvents(sess)
@@ -273,27 +276,29 @@ func checkTokenThreshold(
 	if len(thresholdEvents) == 0 {
 		return false
 	}
-	conversationText := extractConversationText(
+	message := extractTokenThresholdMessage(
 		thresholdEvents, nil, nil,
 	)
-	return checkTokenThresholdFromText(
+	return checkTokenThresholdFromMessage(
 		ctx,
 		tokenCount,
-		conversationText,
+		message,
 	)
 }
 
-func getInjectedTokenThresholdConversationText(
-	sess *session.Session,
-) (string, bool) {
+func getInjectedTokenThresholdMessage(sess *session.Session) (model.Message, bool) {
 	if sess == nil {
-		return "", false
+		return model.Message{}, false
 	}
-	raw, ok := sess.GetState(tokenThresholdConversationTextStateKey)
-	if !ok {
-		return "", false
+	content, hasContent := sess.GetState(tokenThresholdConversationTextStateKey)
+	reasoning, hasReasoning := sess.GetState(tokenThresholdReasoningContentStateKey)
+	if !hasContent && !hasReasoning {
+		return model.Message{}, false
 	}
-	return string(raw), true
+	return model.Message{
+		Content:          string(content),
+		ReasoningContent: string(reasoning),
+	}, true
 }
 
 // ChecksAll composes multiple checkers using AND logic.

--- a/session/summary/checker_test.go
+++ b/session/summary/checker_test.go
@@ -334,6 +334,22 @@ func TestCheckTokenThreshold(t *testing.T) {
 		assert.False(t, checker(sess))
 	})
 
+	t.Run("reasoning content counts toward token threshold", func(t *testing.T) {
+		checker := CheckTokenThreshold(100)
+		sess := &session.Session{Events: []event.Event{
+			{
+				Author:    "assistant",
+				Timestamp: time.Now(),
+				Response: &model.Response{Choices: []model.Choice{{
+					Message: model.Message{
+						ReasoningContent: strings.Repeat("r", 800),
+					},
+				}}},
+			},
+		}}
+		assert.True(t, checker(sess))
+	})
+
 	t.Run("tokens equal threshold does not trigger", func(t *testing.T) {
 		const contentLen = 200
 		sess := &session.Session{Events: []event.Event{

--- a/session/summary/checker_test.go
+++ b/session/summary/checker_test.go
@@ -335,19 +335,26 @@ func TestCheckTokenThreshold(t *testing.T) {
 	})
 
 	t.Run("reasoning content counts toward token threshold", func(t *testing.T) {
+		defer SetTokenCounter(nil)
+		counter := &testCaptureTokenCounter{}
+		SetTokenCounter(counter)
+
 		checker := CheckTokenThreshold(100)
+		reasoning := strings.Repeat("r", 800)
 		sess := &session.Session{Events: []event.Event{
 			{
 				Author:    "assistant",
 				Timestamp: time.Now(),
 				Response: &model.Response{Choices: []model.Choice{{
 					Message: model.Message{
-						ReasoningContent: strings.Repeat("r", 800),
+						Content:          "short answer",
+						ReasoningContent: reasoning,
 					},
 				}}},
 			},
 		}}
 		assert.True(t, checker(sess))
+		assert.Equal(t, reasoning, counter.lastMessage.ReasoningContent)
 	})
 
 	t.Run("tokens equal threshold does not trigger", func(t *testing.T) {
@@ -722,6 +729,38 @@ func (c testFixedTokenCounter) CountTokensRange(
 		return 0, nil
 	}
 	return c.tokens * (end - start), nil
+}
+
+type testCaptureTokenCounter struct {
+	lastMessage model.Message
+}
+
+func (c *testCaptureTokenCounter) CountTokens(_ context.Context, message model.Message) (int, error) {
+	c.lastMessage = message
+	if strings.TrimSpace(message.ReasoningContent) != "" {
+		return 1000, nil
+	}
+	return 0, nil
+}
+
+func (c *testCaptureTokenCounter) CountTokensRange(
+	ctx context.Context,
+	messages []model.Message,
+	start,
+	end int,
+) (int, error) {
+	if start >= end {
+		return 0, nil
+	}
+	total := 0
+	for i := start; i < end; i++ {
+		tokens, err := c.CountTokens(ctx, messages[i])
+		if err != nil {
+			return 0, err
+		}
+		total += tokens
+	}
+	return total, nil
 }
 
 type testContextTokenCounter struct {

--- a/session/summary/summarizer.go
+++ b/session/summary/summarizer.go
@@ -534,7 +534,7 @@ func (s *sessionSummarizer) Metadata() map[string]any {
 }
 
 // extractConversationText extracts conversation text from events.
-// This includes regular messages, tool calls, and tool responses.
+// This includes regular messages, reasoning content, tool calls, and tool responses.
 func (s *sessionSummarizer) extractConversationText(events []event.Event) string {
 	return extractConversationText(
 		events,
@@ -584,6 +584,11 @@ func extractConversationText(
 						parts = append(parts, fmt.Sprintf("%s: %s", author, toolCallText))
 					}
 				}
+			}
+
+			// Handle reasoning content.
+			if trimmed := strings.TrimSpace(msg.ReasoningContent); trimmed != "" {
+				parts = append(parts, fmt.Sprintf("%s: [Reasoning: %s]", author, trimmed))
 			}
 
 			// Handle tool response.

--- a/session/summary/summarizer.go
+++ b/session/summary/summarizer.go
@@ -363,9 +363,18 @@ func (s *sessionSummarizer) buildCheckSession(
 	delta := filterDeltaEvents(checkSess)
 	filtered := s.filterEventsForSummary(delta)
 	thresholdEvents := filterThresholdEventsForSession(filtered, checkSess)
+	thresholdMessage := extractTokenThresholdMessage(
+		thresholdEvents,
+		s.toolCallFormatter,
+		s.toolResultFormatter,
+	)
 	checkSess.SetState(
 		tokenThresholdConversationTextStateKey,
-		[]byte(s.extractConversationText(thresholdEvents)),
+		[]byte(thresholdMessage.Content),
+	)
+	checkSess.SetState(
+		tokenThresholdReasoningContentStateKey,
+		[]byte(thresholdMessage.ReasoningContent),
 	)
 	return checkSess
 }
@@ -534,7 +543,7 @@ func (s *sessionSummarizer) Metadata() map[string]any {
 }
 
 // extractConversationText extracts conversation text from events.
-// This includes regular messages, reasoning content, tool calls, and tool responses.
+// This includes regular messages, tool calls, and tool responses.
 func (s *sessionSummarizer) extractConversationText(events []event.Event) string {
 	return extractConversationText(
 		events,
@@ -586,11 +595,6 @@ func extractConversationText(
 				}
 			}
 
-			// Handle reasoning content.
-			if trimmed := strings.TrimSpace(msg.ReasoningContent); trimmed != "" {
-				parts = append(parts, fmt.Sprintf("%s: [Reasoning: %s]", author, trimmed))
-			}
-
 			// Handle tool response.
 			if msg.ToolID != "" {
 				toolRespText := toolResultFmt(msg)
@@ -607,6 +611,36 @@ func extractConversationText(
 		}
 	}
 
+	return strings.Join(parts, "\n")
+}
+
+func extractTokenThresholdMessage(
+	events []event.Event,
+	toolCallFmt ToolCallFormatter,
+	toolResultFmt ToolResultFormatter,
+) model.Message {
+	return model.Message{
+		Content: extractConversationText(
+			events,
+			toolCallFmt,
+			toolResultFmt,
+		),
+		ReasoningContent: extractReasoningContent(events),
+	}
+}
+
+func extractReasoningContent(events []event.Event) string {
+	var parts []string
+	for _, e := range events {
+		if e.Response == nil {
+			continue
+		}
+		for _, choice := range e.Response.Choices {
+			if trimmed := strings.TrimSpace(choice.Message.ReasoningContent); trimmed != "" {
+				parts = append(parts, trimmed)
+			}
+		}
+	}
 	return strings.Join(parts, "\n")
 }
 

--- a/session/summary/summarizer_test.go
+++ b/session/summary/summarizer_test.go
@@ -509,7 +509,7 @@ func TestSessionSummarizer_ExtractConversationText_WithAuthor(t *testing.T) {
 	assert.Contains(t, text, "assistant:")
 }
 
-func TestSessionSummarizer_ExtractConversationText_WithReasoningContent(t *testing.T) {
+func TestSessionSummarizer_ExtractConversationText_LeavesOutReasoningContent(t *testing.T) {
 	s := NewSummarizer(&fakeModel{})
 	sess := &session.Session{
 		ID: "test-reasoning-content",
@@ -528,7 +528,7 @@ func TestSessionSummarizer_ExtractConversationText_WithReasoningContent(t *testi
 
 	text, err := s.Summarize(context.Background(), sess)
 	require.NoError(t, err)
-	assert.Contains(t, text, "assistant: [Reasoning: I should inspect the user request first.]")
+	assert.NotContains(t, text, "I should inspect the user request first.")
 	assert.Contains(t, text, "assistant: Here is the final answer.")
 }
 
@@ -1705,6 +1705,32 @@ func TestSessionSummarizer_BuildCheckSession(t *testing.T) {
 		raw, ok := checkSess.GetState(tokenThresholdConversationTextStateKey)
 		require.True(t, ok)
 		assert.Empty(t, string(raw))
+	})
+
+	t.Run("injects reasoning content only for token threshold checks", func(t *testing.T) {
+		s := &sessionSummarizer{}
+		reasoning := "thinking through the answer"
+		sess := &session.Session{
+			Events: []event.Event{
+				{
+					Author:    "assistant",
+					Timestamp: time.Now(),
+					Response: &model.Response{Choices: []model.Choice{{
+						Message: model.Message{
+							Content:          "final answer",
+							ReasoningContent: reasoning,
+						},
+					}}},
+				},
+			},
+		}
+
+		checkSess := s.buildCheckSession(sess)
+		require.NotNil(t, checkSess)
+
+		raw, ok := checkSess.GetState(tokenThresholdReasoningContentStateKey)
+		require.True(t, ok)
+		assert.Equal(t, reasoning, string(raw))
 	})
 
 	t.Run("uses branch scope when building injected token text", func(t *testing.T) {

--- a/session/summary/summarizer_test.go
+++ b/session/summary/summarizer_test.go
@@ -509,6 +509,29 @@ func TestSessionSummarizer_ExtractConversationText_WithAuthor(t *testing.T) {
 	assert.Contains(t, text, "assistant:")
 }
 
+func TestSessionSummarizer_ExtractConversationText_WithReasoningContent(t *testing.T) {
+	s := NewSummarizer(&fakeModel{})
+	sess := &session.Session{
+		ID: "test-reasoning-content",
+		Events: []event.Event{
+			{
+				Author: "assistant",
+				Response: &model.Response{Choices: []model.Choice{{
+					Message: model.Message{
+						ReasoningContent: "I should inspect the user request first.",
+						Content:          "Here is the final answer.",
+					},
+				}}},
+			},
+		},
+	}
+
+	text, err := s.Summarize(context.Background(), sess)
+	require.NoError(t, err)
+	assert.Contains(t, text, "assistant: [Reasoning: I should inspect the user request first.]")
+	assert.Contains(t, text, "assistant: Here is the final answer.")
+}
+
 func TestSessionSummarizer_ExtractConversationText_WithToolCalls(t *testing.T) {
 	s := NewSummarizer(&fakeModel{})
 


### PR DESCRIPTION
- Added a test to verify that reasoning content is counted towards the token threshold in `checker_test.go`.
- Introduced a new test in `summarizer_test.go` to ensure reasoning content is correctly extracted and included in the summarized text.
- Updated the `extractConversationText` method in `summarizer.go` to handle reasoning content, ensuring it is included in the conversation text extraction process.

Fixes #1803