### PR TITLE
evaluation/workflow/promptiter: add eval case filters

### DIFF
--- a/docs/mkdocs/en/promptiter.md
+++ b/docs/mkdocs/en/promptiter.md
@@ -159,8 +159,16 @@ targetScore := 1.0
 targetSurfaceID := astructure.SurfaceID(candidateAgentName, astructure.SurfaceTypeInstruction)
 
 result, err := engineInstance.Run(ctx, &engine.RunRequest{
-	TrainEvalSetIDs:      []string{"nba-commentary-train"},
-	ValidationEvalSetIDs: []string{"nba-commentary-validation"},
+	Train: []engine.EvalSetInput{
+		{
+			EvalSetID: "nba-commentary-train",
+		},
+	},
+	Validation: []engine.EvalSetInput{
+		{
+			EvalSetID: "nba-commentary-validation",
+		},
+	},
 	EvaluationOptions: engine.EvaluationOptions{
 		EvalCaseParallelism:               8,
 		EvalCaseParallelInferenceEnabled:  true,
@@ -441,8 +449,8 @@ import (
 )
 
 type RunRequest struct {
-	TrainEvalSetIDs      []string            // TrainEvalSetIDs is the list of train EvalSet IDs.
-	ValidationEvalSetIDs []string            // ValidationEvalSetIDs is the list of validation EvalSet IDs.
+	Train                []EvalSetInput      // Train identifies evaluation data used to generate gradients.
+	Validation           []EvalSetInput      // Validation identifies evaluation data used for patch acceptance checks.
 	InitialProfile       *promptiter.Profile // InitialProfile is the initial candidate version before round one starts.
 	Teacher              runner.Runner       // Teacher is the Runner used to generate reference answers when needed.
 	Judge                runner.Runner       // Judge is the Runner used by judge-style metrics when needed.
@@ -453,6 +461,57 @@ type RunRequest struct {
 	TargetSurfaceIDs     []string            // TargetSurfaceIDs lists editable positions that may be changed in this run.
 }
 ```
+
+#### Train And Validation
+
+`Train` drives the training loop: PromptIter extracts losses from train evaluation results and uses them to generate gradients. `Validation` drives the validation loop: PromptIter computes the accepted baseline, decides whether a patch should be accepted, and participates in stop decisions.
+
+Both fields use `[]EvalSetInput` to describe the selected evaluation data:
+
+```go
+type EvalSetInput struct {
+	EvalSetID   string   // EvalSetID identifies the evaluation set to execute.
+	EvalCaseIDs []string // EvalCaseIDs limits evaluation to the specified cases when present.
+}
+```
+
+When `EvalCaseIDs` is omitted, PromptIter runs all cases in the corresponding eval set:
+
+```go
+request := &engine.RunRequest{
+	Train: []engine.EvalSetInput{
+		{
+			EvalSetID: "nba-commentary-train",
+		},
+	},
+	Validation: []engine.EvalSetInput{
+		{
+			EvalSetID: "nba-commentary-validation",
+		},
+	},
+}
+```
+
+To run only selected cases for a train or validation set, set `EvalCaseIDs` on the corresponding `EvalSetInput`:
+
+```go
+request := &engine.RunRequest{
+	Train: []engine.EvalSetInput{
+		{
+			EvalSetID:   "nba-commentary-train",
+			EvalCaseIDs: []string{"case_1", "case_2"},
+		},
+	},
+	Validation: []engine.EvalSetInput{
+		{
+			EvalSetID:   "nba-commentary-validation",
+			EvalCaseIDs: []string{"case_3"},
+		},
+	},
+}
+```
+
+Omitting `EvalCaseIDs` or passing an empty slice runs all cases in that eval set. Passing a non-empty slice runs only the listed cases.
 
 #### EvaluationOptions
 

--- a/docs/mkdocs/zh/promptiter.md
+++ b/docs/mkdocs/zh/promptiter.md
@@ -159,8 +159,16 @@ targetScore := 1.0
 targetSurfaceID := astructure.SurfaceID(candidateAgentName, astructure.SurfaceTypeInstruction)
 
 result, err := engineInstance.Run(ctx, &engine.RunRequest{
-	TrainEvalSetIDs:      []string{"nba-commentary-train"},
-	ValidationEvalSetIDs: []string{"nba-commentary-validation"},
+	Train: []engine.EvalSetInput{
+		{
+			EvalSetID: "nba-commentary-train",
+		},
+	},
+	Validation: []engine.EvalSetInput{
+		{
+			EvalSetID: "nba-commentary-validation",
+		},
+	},
 	EvaluationOptions: engine.EvaluationOptions{
 		EvalCaseParallelism:               8,
 		EvalCaseParallelInferenceEnabled:  true,
@@ -441,8 +449,8 @@ import (
 )
 
 type RunRequest struct {
-	TrainEvalSetIDs      []string            // TrainEvalSetIDs 表示训练集 EvalSet ID 列表。
-	ValidationEvalSetIDs []string            // ValidationEvalSetIDs 表示验证集 EvalSet ID 列表。
+	Train                []EvalSetInput      // Train 表示用于生成梯度的评估数据。
+	Validation           []EvalSetInput      // Validation 表示用于补丁接受检查的评估数据。
 	InitialProfile       *promptiter.Profile // InitialProfile 表示第一轮开始前的初始候选版本。
 	Teacher              runner.Runner       // Teacher 表示按需动态生成参考答案时使用的 Runner。
 	Judge                runner.Runner       // Judge 表示 Judge 类指标按需使用的 Runner。
@@ -453,6 +461,57 @@ type RunRequest struct {
 	TargetSurfaceIDs     []string            // TargetSurfaceIDs 表示本次运行允许修改的可编辑位置列表。
 }
 ```
+
+#### Train 和 Validation
+
+`Train` 用于训练阶段，PromptIter 会基于训练集评估结果提取 loss 并生成梯度。`Validation` 用于验证阶段，PromptIter 会基于验证集评估结果计算 baseline、判断补丁是否接受，并参与停止条件判断。
+
+二者都使用 `[]EvalSetInput` 描述评估数据选择：
+
+```go
+type EvalSetInput struct {
+	EvalSetID   string   // EvalSetID 表示要执行的评估集。
+	EvalCaseIDs []string // EvalCaseIDs 表示按需限制执行的评估用例列表。
+}
+```
+
+不指定 `EvalCaseIDs` 时，会执行对应评估集下的全部样本：
+
+```go
+request := &engine.RunRequest{
+	Train: []engine.EvalSetInput{
+		{
+			EvalSetID: "nba-commentary-train",
+		},
+	},
+	Validation: []engine.EvalSetInput{
+		{
+			EvalSetID: "nba-commentary-validation",
+		},
+	},
+}
+```
+
+如果只希望训练集或验证集执行指定样本，可以在对应的 `EvalSetInput` 中设置 `EvalCaseIDs`：
+
+```go
+request := &engine.RunRequest{
+	Train: []engine.EvalSetInput{
+		{
+			EvalSetID:   "nba-commentary-train",
+			EvalCaseIDs: []string{"case_1", "case_2"},
+		},
+	},
+	Validation: []engine.EvalSetInput{
+		{
+			EvalSetID:   "nba-commentary-validation",
+			EvalCaseIDs: []string{"case_3"},
+		},
+	},
+}
+```
+
+`EvalCaseIDs` 省略或传空数组时，表示执行该评估集下的全部样本；传非空数组时，只执行指定样本。
 
 #### EvaluationOptions
 

--- a/evaluation/workflow/promptiter/engine/engine.go
+++ b/evaluation/workflow/promptiter/engine/engine.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
@@ -35,10 +36,10 @@ type Engine interface {
 
 // RunRequest carries the inputs required to start PromptIter optimization.
 type RunRequest struct {
-	// TrainEvalSetIDs identifies evaluation sets used to generate gradients.
-	TrainEvalSetIDs []string
-	// ValidationEvalSetIDs identifies evaluation sets used for patch acceptance checks.
-	ValidationEvalSetIDs []string
+	// Train identifies evaluation data used to generate gradients.
+	Train []EvalSetInput `json:"train"`
+	// Validation identifies evaluation data used for patch acceptance checks.
+	Validation []EvalSetInput `json:"validation"`
 	// InitialProfile is the baseline profile for round one optimization.
 	InitialProfile *promptiter.Profile
 	// Teacher executes trace generation requests for evaluation.
@@ -55,6 +56,14 @@ type RunRequest struct {
 	MaxRounds int
 	// TargetSurfaceIDs limits this run to optimizing only the listed surfaces.
 	TargetSurfaceIDs []string
+}
+
+// EvalSetInput identifies one evaluation set and optional case filters for a PromptIter run.
+type EvalSetInput struct {
+	// EvalSetID identifies the eval set to execute.
+	EvalSetID string `json:"evalSetId"`
+	// EvalCaseIDs limits this eval set to specific eval cases when set.
+	EvalCaseIDs []string `json:"evalCaseIds,omitempty"`
 }
 
 // RunStatus identifies the lifecycle state of one PromptIter run view.
@@ -151,14 +160,15 @@ func New(ctx context.Context,
 		return nil, errors.New("aggregator is nil")
 	case optimizer == nil:
 		return nil, errors.New("optimizer is nil")
+	default:
+		return &engine{
+			targetAgent:    targetAgent,
+			backwarder:     backwarder,
+			aggregator:     aggregator,
+			optimizer:      optimizer,
+			agentEvaluator: agentEvaluator,
+		}, nil
 	}
-	return &engine{
-		targetAgent:    targetAgent,
-		backwarder:     backwarder,
-		aggregator:     aggregator,
-		optimizer:      optimizer,
-		agentEvaluator: agentEvaluator,
-	}, nil
 }
 
 // Describe returns the structure snapshot used for the current optimization session.
@@ -207,7 +217,7 @@ func (e *engine) run(
 	acceptedProfile := initialProfile
 	acceptedValidationScore := 0.0
 	baselineValidation, err := e.evaluate(ctx, structure, e.newEvaluationRequest(
-		request.ValidationEvalSetIDs,
+		request.Validation,
 		acceptedProfile,
 		request.Teacher,
 		request.Judge,
@@ -295,13 +305,16 @@ func (e *engine) run(
 }
 
 func (e *engine) validateRunRequest(request *RunRequest) error {
-	switch {
-	case request == nil:
+	if request == nil {
 		return errors.New("run request is nil")
-	case len(request.TrainEvalSetIDs) == 0:
-		return errors.New("train evaluation set ids are empty")
-	case len(request.ValidationEvalSetIDs) == 0:
-		return errors.New("validation evaluation set ids are empty")
+	}
+	if err := validateEvalSetInputs("train", request.Train); err != nil {
+		return err
+	}
+	if err := validateEvalSetInputs("validation", request.Validation); err != nil {
+		return err
+	}
+	switch {
 	case request.MaxRounds <= 0:
 		return errors.New("max rounds must be greater than 0")
 	case request.TargetSurfaceIDs != nil && len(request.TargetSurfaceIDs) == 0:
@@ -345,7 +358,7 @@ func (e *engine) executeRound(
 		InputProfile: iprofile.Clone(acceptedProfile),
 	}
 	trainResult, err := e.evaluate(ctx, structure, e.newEvaluationRequest(
-		request.TrainEvalSetIDs,
+		request.Train,
 		acceptedProfile,
 		request.Teacher,
 		request.Judge,
@@ -399,7 +412,7 @@ func (e *engine) executeRound(
 		return nil, 0, err
 	}
 	validationResult, err := e.evaluate(ctx, structure, e.newEvaluationRequest(
-		request.ValidationEvalSetIDs,
+		request.Validation,
 		outputProfile,
 		request.Teacher,
 		request.Judge,
@@ -427,20 +440,36 @@ func (e *engine) executeRound(
 }
 
 func (e *engine) newEvaluationRequest(
-	evalSetIDs []string,
+	inputs []EvalSetInput,
 	profile *promptiter.Profile,
 	teacher runner.Runner,
 	judge runner.Runner,
 	options EvaluationOptions,
 ) *EvaluationRequest {
 	return &EvaluationRequest{
-		EvalSetIDs: append(
-			[]string(nil),
-			evalSetIDs...,
-		),
-		Profile: profile,
-		Teacher: teacher,
-		Judge:   judge,
-		Options: options,
+		EvalSets: inputs,
+		Profile:  profile,
+		Teacher:  teacher,
+		Judge:    judge,
+		Options:  options,
 	}
+}
+
+func validateEvalSetInputs(role string, inputs []EvalSetInput) error {
+	prefix := ""
+	if role != "" {
+		prefix = role + " "
+	}
+	if len(inputs) == 0 {
+		return fmt.Errorf("%sevaluation sets are empty", prefix)
+	}
+	for _, input := range inputs {
+		if input.EvalSetID == "" {
+			return fmt.Errorf("%sevaluation set id is empty", prefix)
+		}
+		if slices.Contains(input.EvalCaseIDs, "") {
+			return fmt.Errorf("%seval case id for eval set %q is empty", prefix, input.EvalSetID)
+		}
+	}
+	return nil
 }

--- a/evaluation/workflow/promptiter/engine/engine_test.go
+++ b/evaluation/workflow/promptiter/engine/engine_test.go
@@ -158,6 +158,7 @@ func (m *providerBackedTestModel) Info() model.Info {
 type scriptedEvalService struct {
 	profiles         []string
 	runOptions       []agent.RunOptions
+	evalCaseIDs      map[string][][]string
 	profileByEvalSet map[string]string
 	outcomeByEvalSet map[string]scriptedEvalOutcome
 	script           func(evalSetID string, profileValue string) scriptedEvalOutcome
@@ -167,6 +168,7 @@ func newScriptedEvalService(
 	script func(evalSetID string, profileValue string) scriptedEvalOutcome,
 ) *scriptedEvalService {
 	return &scriptedEvalService{
+		evalCaseIDs:      make(map[string][][]string),
 		profileByEvalSet: make(map[string]string),
 		outcomeByEvalSet: make(map[string]scriptedEvalOutcome),
 		script:           script,
@@ -192,6 +194,7 @@ func (s *scriptedEvalService) Inference(
 	outcome := s.script(req.EvalSetID, profileValue)
 	s.profiles = append(s.profiles, profileValue)
 	s.runOptions = append(s.runOptions, runOptions)
+	s.evalCaseIDs[req.EvalSetID] = append(s.evalCaseIDs[req.EvalSetID], append([]string(nil), req.EvalCaseIDs...))
 	s.profileByEvalSet[req.EvalSetID] = profileValue
 	s.outcomeByEvalSet[req.EvalSetID] = outcome
 	result := &service.InferenceResult{
@@ -333,6 +336,14 @@ func seedTestEvalSet(t *testing.T, manager evalset.Manager, evalSetID string) {
 	assert.NoError(t, err)
 }
 
+func testEvalSetInputs(evalSetID string) []EvalSetInput {
+	return []EvalSetInput{
+		{
+			EvalSetID: evalSetID,
+		},
+	}
+}
+
 type fakeStructureAgent struct {
 	snapshot  *astructure.Snapshot
 	exportErr error
@@ -460,9 +471,9 @@ func TestRunAcceptsFirstRoundAndStopsAfterRejectedNextRound(t *testing.T) {
 	)
 	assert.NoError(t, err)
 	result, err := engineInstance.Run(context.Background(), &RunRequest{
-		TrainEvalSetIDs:      []string{"train"},
-		ValidationEvalSetIDs: []string{"validation"},
-		InitialProfile:       nil,
+		Train:          testEvalSetInputs("train"),
+		Validation:     testEvalSetInputs("validation"),
+		InitialProfile: nil,
 		AcceptancePolicy: AcceptancePolicy{
 			MinScoreGain: 0.1,
 		},
@@ -546,8 +557,8 @@ func TestRunObserverReceivesRuntimeEvents(t *testing.T) {
 	assert.NoError(t, err)
 	var observedEvents []Event
 	result, err := engineInstance.Run(context.Background(), &RunRequest{
-		TrainEvalSetIDs:      []string{"train"},
-		ValidationEvalSetIDs: []string{"validation"},
+		Train:      testEvalSetInputs("train"),
+		Validation: testEvalSetInputs("validation"),
 		AcceptancePolicy: AcceptancePolicy{
 			MinScoreGain: 0.1,
 		},
@@ -598,6 +609,102 @@ func TestRunObserverReceivesRuntimeEvents(t *testing.T) {
 	assert.Equal(t, EventKindRoundCompleted, observedEvents[10].Kind)
 	assert.Equal(t, 1, observedEvents[10].Round)
 	assert.IsType(t, &RoundCompleted{}, observedEvents[10].Payload)
+}
+
+func TestRunPassesEvalCaseIDsToTrainAndValidationInputs(t *testing.T) {
+	newEvalService := func() *scriptedEvalService {
+		return newScriptedEvalService(func(evalSetID string, profileValue string) scriptedEvalOutcome {
+			_ = evalSetID
+			_ = profileValue
+			return scriptedEvalOutcome{
+				score:             0.8,
+				metricStatus:      status.EvalStatusPassed,
+				appliedSurfaceIDs: []string{testSurfaceID},
+			}
+		})
+	}
+	newEngine := func(t *testing.T, evalService *scriptedEvalService) Engine {
+		t.Helper()
+		engineInstance, err := New(
+			context.Background(),
+			testTargetAgent(),
+			newTestAgentEvaluator(t, evalService),
+			&fakeBackwarder{},
+			&fakeAggregator{},
+			&fakeOptimizer{},
+		)
+		require.NoError(t, err)
+		return engineInstance
+	}
+	t.Run("forwards non-empty case filters", func(t *testing.T) {
+		evalService := newEvalService()
+		engineInstance := newEngine(t, evalService)
+		result, err := engineInstance.Run(context.Background(), &RunRequest{
+			Train: []EvalSetInput{
+				{
+					EvalSetID:   "train",
+					EvalCaseIDs: []string{"train_case_1", "train_case_2"},
+				},
+			},
+			Validation: []EvalSetInput{
+				{
+					EvalSetID:   "validation",
+					EvalCaseIDs: []string{"validation_case_1"},
+				},
+			},
+			MaxRounds: 1,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Equal(t, [][]string{{"train_case_1", "train_case_2"}}, evalService.evalCaseIDs["train"])
+		assert.Equal(t, [][]string{{"validation_case_1"}, {"validation_case_1"}}, evalService.evalCaseIDs["validation"])
+	})
+	t.Run("omits nil case filters", func(t *testing.T) {
+		evalService := newEvalService()
+		engineInstance := newEngine(t, evalService)
+		result, err := engineInstance.Run(context.Background(), &RunRequest{
+			Train: []EvalSetInput{
+				{
+					EvalSetID: "train",
+				},
+			},
+			Validation: []EvalSetInput{
+				{
+					EvalSetID: "validation",
+				},
+			},
+			MaxRounds: 1,
+		})
+		var noFilter []string
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Equal(t, [][]string{noFilter}, evalService.evalCaseIDs["train"])
+		assert.Equal(t, [][]string{noFilter, noFilter}, evalService.evalCaseIDs["validation"])
+	})
+	t.Run("omits empty case filters", func(t *testing.T) {
+		evalService := newEvalService()
+		engineInstance := newEngine(t, evalService)
+		result, err := engineInstance.Run(context.Background(), &RunRequest{
+			Train: []EvalSetInput{
+				{
+					EvalSetID:   "train",
+					EvalCaseIDs: []string{},
+				},
+			},
+			Validation: []EvalSetInput{
+				{
+					EvalSetID:   "validation",
+					EvalCaseIDs: []string{},
+				},
+			},
+			MaxRounds: 1,
+		})
+		var noFilter []string
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Equal(t, [][]string{noFilter}, evalService.evalCaseIDs["train"])
+		assert.Equal(t, [][]string{noFilter, noFilter}, evalService.evalCaseIDs["validation"])
+	})
 }
 
 func TestRunCompilesProfileIntoEvaluationRunOptions(t *testing.T) {
@@ -656,8 +763,8 @@ func TestRunCompilesProfileIntoEvaluationRunOptions(t *testing.T) {
 	)
 	assert.NoError(t, err)
 	result, err := engineInstance.Run(context.Background(), &RunRequest{
-		TrainEvalSetIDs:      []string{"train"},
-		ValidationEvalSetIDs: []string{"validation"},
+		Train:      testEvalSetInputs("train"),
+		Validation: testEvalSetInputs("validation"),
 		AcceptancePolicy: AcceptancePolicy{
 			MinScoreGain: 0.1,
 		},
@@ -834,18 +941,24 @@ func TestEvaluateValidatesRequests(t *testing.T) {
 	result, runErr := engineInstance.evaluate(context.Background(), structure, nil)
 	assert.Nil(t, result)
 	assert.EqualError(t, runErr, "evaluation request is nil")
-	result, runErr = engineInstance.evaluate(context.Background(), nil, &EvaluationRequest{EvalSetIDs: []string{"validation"}})
+	result, runErr = engineInstance.evaluate(context.Background(), nil, &EvaluationRequest{
+		EvalSets: []EvalSetInput{{EvalSetID: "validation"}},
+	})
 	assert.Nil(t, result)
 	assert.EqualError(t, runErr, "structure state is nil")
 	result, runErr = engineInstance.evaluate(context.Background(), structure, &EvaluationRequest{})
 	assert.Nil(t, result)
-	assert.EqualError(t, runErr, "evaluation set ids are empty")
+	assert.EqualError(t, runErr, "evaluation sets are empty")
 	engineInstance.agentEvaluator = nil
-	result, runErr = engineInstance.evaluate(context.Background(), structure, &EvaluationRequest{EvalSetIDs: []string{"validation"}})
+	result, runErr = engineInstance.evaluate(context.Background(), structure, &EvaluationRequest{
+		EvalSets: []EvalSetInput{{EvalSetID: "validation"}},
+	})
 	assert.Nil(t, result)
 	assert.EqualError(t, runErr, "agent evaluator is nil")
 	engineInstance.agentEvaluator = &fakeAgentEvaluator{}
-	result, runErr = engineInstance.evaluate(context.Background(), structure, &EvaluationRequest{EvalSetIDs: []string{""}})
+	result, runErr = engineInstance.evaluate(context.Background(), structure, &EvaluationRequest{
+		EvalSets: []EvalSetInput{{EvalSetID: ""}},
+	})
 	assert.Nil(t, result)
 	assert.EqualError(t, runErr, "evaluation set id is empty")
 }
@@ -856,15 +969,15 @@ func TestBuildEvaluationCallOptionsUsesConfiguredRunnersAndFlags(t *testing.T) {
 	teacher := &stubRunner{}
 	judge := &stubRunner{}
 	options, buildErr := buildEvaluationCallOptions(structure, &EvaluationRequest{
-		EvalSetIDs: []string{"validation"},
-		Teacher:    teacher,
-		Judge:      judge,
+		EvalSets: []EvalSetInput{{EvalSetID: "validation"}},
+		Teacher:  teacher,
+		Judge:    judge,
 		Options: EvaluationOptions{
 			EvalCaseParallelism:               3,
 			EvalCaseParallelInferenceEnabled:  true,
 			EvalCaseParallelEvaluationEnabled: true,
 		},
-	})
+	}, EvalSetInput{EvalSetID: "validation", EvalCaseIDs: []string{"case_1"}})
 	require.NoError(t, buildErr)
 	agentEvaluator, newErr := evaluation.New("promptiter-test", &stubRunner{}, options...)
 	require.NoError(t, newErr)
@@ -883,10 +996,12 @@ func TestBuildEvaluationCallOptionsUsesConfiguredRunnersAndFlags(t *testing.T) {
 	parallelEvaluationEnabled := readPrivateField[*bool](t, agentEvaluator, "evalCaseParallelEvaluationEnabled")
 	require.NotNil(t, parallelEvaluationEnabled)
 	assert.True(t, *parallelEvaluationEnabled)
+	evalCaseIDs := readPrivateField[[]string](t, agentEvaluator, "evalCaseIDs")
+	assert.Equal(t, []string{"case_1"}, evalCaseIDs)
 }
 
 func TestBuildEvaluationCallOptionsRejectsInvalidRequest(t *testing.T) {
-	options, err := buildEvaluationCallOptions(nil, nil)
+	options, err := buildEvaluationCallOptions(nil, nil, EvalSetInput{})
 	assert.Nil(t, options)
 	assert.EqualError(t, err, "evaluation request is nil")
 	structure, buildErr := newStructureState(testStructureSnapshot(t))
@@ -895,7 +1010,7 @@ func TestBuildEvaluationCallOptionsRejectsInvalidRequest(t *testing.T) {
 		Profile: &promptiter.Profile{
 			StructureID: "other",
 		},
-	})
+	}, EvalSetInput{EvalSetID: "validation"})
 	assert.Nil(t, options)
 	assert.ErrorContains(t, err, "profile structure id")
 }
@@ -1442,7 +1557,7 @@ func TestAdaptEvaluationCaseResultUsesFirstRunWhenMultipleRunsExist(t *testing.T
 	assert.Equal(t, 0.9, result.Metrics[0].Score)
 }
 
-func TestRunRejectsEmptyValidationEvalSetIDs(t *testing.T) {
+func TestRunRejectsEmptyValidationEvalSets(t *testing.T) {
 	engineInstance, err := New(
 		context.Background(),
 		testTargetAgent(),
@@ -1453,11 +1568,11 @@ func TestRunRejectsEmptyValidationEvalSetIDs(t *testing.T) {
 	)
 	assert.NoError(t, err)
 	_, err = engineInstance.Run(context.Background(), &RunRequest{
-		TrainEvalSetIDs: []string{"train"},
-		MaxRounds:       1,
+		Train:     testEvalSetInputs("train"),
+		MaxRounds: 1,
 	})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "validation evaluation set ids are empty")
+	assert.Contains(t, err.Error(), "validation evaluation sets are empty")
 }
 
 func TestRunRejectsNilRequest(t *testing.T) {
@@ -1475,7 +1590,7 @@ func TestRunRejectsNilRequest(t *testing.T) {
 	assert.EqualError(t, runErr, "run request is nil")
 }
 
-func TestRunRejectsEmptyTrainEvalSetIDs(t *testing.T) {
+func TestRunRejectsEmptyTrainEvalSets(t *testing.T) {
 	engineInstance, err := New(
 		context.Background(),
 		testTargetAgent(),
@@ -1486,11 +1601,39 @@ func TestRunRejectsEmptyTrainEvalSetIDs(t *testing.T) {
 	)
 	assert.NoError(t, err)
 	result, runErr := engineInstance.Run(context.Background(), &RunRequest{
-		ValidationEvalSetIDs: []string{"validation"},
-		MaxRounds:            1,
+		Validation: testEvalSetInputs("validation"),
+		MaxRounds:  1,
 	})
 	assert.Nil(t, result)
-	assert.EqualError(t, runErr, "train evaluation set ids are empty")
+	assert.EqualError(t, runErr, "train evaluation sets are empty")
+}
+
+func TestValidateEvalSetInputsRejectsInvalidInputs(t *testing.T) {
+	assert.EqualError(t, validateEvalSetInputs("train", []EvalSetInput{
+		{
+			EvalSetID: "",
+		},
+	}), "train evaluation set id is empty")
+	assert.NoError(t, validateEvalSetInputs("train", []EvalSetInput{
+		{
+			EvalSetID: "train",
+		},
+		{
+			EvalSetID: "train",
+		},
+	}))
+	assert.NoError(t, validateEvalSetInputs("train", []EvalSetInput{
+		{
+			EvalSetID:   "train",
+			EvalCaseIDs: []string{},
+		},
+	}))
+	assert.EqualError(t, validateEvalSetInputs("train", []EvalSetInput{
+		{
+			EvalSetID:   "train",
+			EvalCaseIDs: []string{""},
+		},
+	}), `train eval case id for eval set "train" is empty`)
 }
 
 func TestRunRejectsNonPositiveMaxRounds(t *testing.T) {
@@ -1504,9 +1647,9 @@ func TestRunRejectsNonPositiveMaxRounds(t *testing.T) {
 	)
 	assert.NoError(t, err)
 	result, runErr := engineInstance.Run(context.Background(), &RunRequest{
-		TrainEvalSetIDs:      []string{"train"},
-		ValidationEvalSetIDs: []string{"validation"},
-		MaxRounds:            0,
+		Train:      testEvalSetInputs("train"),
+		Validation: testEvalSetInputs("validation"),
+		MaxRounds:  0,
 	})
 	assert.Nil(t, result)
 	assert.EqualError(t, runErr, "max rounds must be greater than 0")
@@ -1526,8 +1669,8 @@ func TestRunRejectsInvalidInitialProfile(t *testing.T) {
 	)
 	assert.NoError(t, err)
 	_, err = engineInstance.Run(context.Background(), &RunRequest{
-		TrainEvalSetIDs:      []string{"train"},
-		ValidationEvalSetIDs: []string{"validation"},
+		Train:      testEvalSetInputs("train"),
+		Validation: testEvalSetInputs("validation"),
 		InitialProfile: &promptiter.Profile{
 			Overrides: []promptiter.SurfaceOverride{
 				{
@@ -2520,10 +2663,10 @@ func TestRunRejectsEmptyTargetSurfaceIDs(t *testing.T) {
 	)
 	assert.NoError(t, err)
 	_, err = engineInstance.Run(context.Background(), &RunRequest{
-		TrainEvalSetIDs:      []string{"train"},
-		ValidationEvalSetIDs: []string{"validation"},
-		TargetSurfaceIDs:     []string{},
-		MaxRounds:            1,
+		Train:            testEvalSetInputs("train"),
+		Validation:       testEvalSetInputs("validation"),
+		TargetSurfaceIDs: []string{},
+		MaxRounds:        1,
 	})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "target surface ids must not be empty")
@@ -2540,10 +2683,10 @@ func TestRunRejectsUnknownTargetSurfaceID(t *testing.T) {
 	)
 	assert.NoError(t, err)
 	_, err = engineInstance.Run(context.Background(), &RunRequest{
-		TrainEvalSetIDs:      []string{"train"},
-		ValidationEvalSetIDs: []string{"validation"},
-		TargetSurfaceIDs:     []string{"unknown#instruction"},
-		MaxRounds:            1,
+		Train:            testEvalSetInputs("train"),
+		Validation:       testEvalSetInputs("validation"),
+		TargetSurfaceIDs: []string{"unknown#instruction"},
+		MaxRounds:        1,
 	})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown")
@@ -2637,9 +2780,9 @@ func TestRunRejectsStructureExportFailure(t *testing.T) {
 	)
 	assert.NoError(t, err)
 	_, err = engineInstance.Run(context.Background(), &RunRequest{
-		TrainEvalSetIDs:      []string{"train"},
-		ValidationEvalSetIDs: []string{"validation"},
-		MaxRounds:            1,
+		Train:      testEvalSetInputs("train"),
+		Validation: testEvalSetInputs("validation"),
+		MaxRounds:  1,
 	})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "describe structure")

--- a/evaluation/workflow/promptiter/engine/evaluate.go
+++ b/evaluation/workflow/promptiter/engine/evaluate.go
@@ -41,8 +41,8 @@ type EvaluationOptions struct {
 
 // EvaluationRequest describes one evaluation execution requested by the engine.
 type EvaluationRequest struct {
-	// EvalSetIDs identifies the evaluation sets to execute.
-	EvalSetIDs []string
+	// EvalSets identifies the evaluation sets and case filters to execute.
+	EvalSets []EvalSetInput
 	// Profile is the normalized candidate profile being evaluated.
 	Profile *promptiter.Profile
 	// Teacher is the optional runner used by the evaluation runtime.
@@ -108,27 +108,24 @@ func (e *engine) evaluate(
 	if structure == nil {
 		return nil, errors.New("structure state is nil")
 	}
-	if len(request.EvalSetIDs) == 0 {
-		return nil, errors.New("evaluation set ids are empty")
+	if err := validateEvalSetInputs("", request.EvalSets); err != nil {
+		return nil, err
 	}
 	if e.agentEvaluator == nil {
 		return nil, errors.New("agent evaluator is nil")
 	}
-	if slices.Contains(request.EvalSetIDs, "") {
-		return nil, errors.New("evaluation set id is empty")
-	}
-	results := make([]EvalSetResult, 0, len(request.EvalSetIDs))
+	results := make([]EvalSetResult, 0, len(request.EvalSets))
 	totalScore := 0.0
-	for _, evalSetID := range request.EvalSetIDs {
-		options, err := buildEvaluationCallOptions(structure, request)
+	for _, input := range request.EvalSets {
+		options, err := buildEvaluationCallOptions(structure, request, input)
 		if err != nil {
 			return nil, err
 		}
-		genericResult, err := e.agentEvaluator.Evaluate(ctx, evalSetID, options...)
+		genericResult, err := e.agentEvaluator.Evaluate(ctx, input.EvalSetID, options...)
 		if err != nil {
 			return nil, err
 		}
-		evalSetResult, err := adaptEvaluationSetResult(structure, evalSetID, genericResult)
+		evalSetResult, err := adaptEvaluationSetResult(structure, input.EvalSetID, genericResult)
 		if err != nil {
 			return nil, err
 		}
@@ -154,6 +151,7 @@ func evaluationScore(result *EvaluationResult) (float64, error) {
 func buildEvaluationCallOptions(
 	structure *structureState,
 	request *EvaluationRequest,
+	input EvalSetInput,
 ) ([]evaluation.Option, error) {
 	if request == nil {
 		return nil, errors.New("evaluation request is nil")
@@ -162,7 +160,7 @@ func buildEvaluationCallOptions(
 	if err != nil {
 		return nil, err
 	}
-	options := make([]evaluation.Option, 0, 7)
+	options := make([]evaluation.Option, 0, 8)
 	options = append(options, evaluation.WithRunDetailsEnabled(true))
 	options = append(options, evaluation.WithRunOptions(runOptions...))
 	if request.Teacher != nil {
@@ -180,6 +178,9 @@ func buildEvaluationCallOptions(
 	}
 	if request.Options.EvalCaseParallelEvaluationEnabled {
 		options = append(options, evaluation.WithEvalCaseParallelEvaluationEnabled(true))
+	}
+	if len(input.EvalCaseIDs) > 0 {
+		options = append(options, evaluation.WithEvalCaseIDs(input.EvalCaseIDs...))
 	}
 	return options, nil
 }

--- a/evaluation/workflow/promptiter/manager/manager.go
+++ b/evaluation/workflow/promptiter/manager/manager.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"sync"
 
 	"github.com/google/uuid"
@@ -183,13 +184,16 @@ func (m *manager) clearCancel(runID string) {
 }
 
 func validateRunRequest(request *engine.RunRequest) error {
-	switch {
-	case request == nil:
+	if request == nil {
 		return errors.New("run request is nil")
-	case len(request.TrainEvalSetIDs) == 0:
-		return errors.New("train evaluation set ids are empty")
-	case len(request.ValidationEvalSetIDs) == 0:
-		return errors.New("validation evaluation set ids are empty")
+	}
+	if err := validateEvalSetInputs("train", request.Train); err != nil {
+		return err
+	}
+	if err := validateEvalSetInputs("validation", request.Validation); err != nil {
+		return err
+	}
+	switch {
 	case request.MaxRounds <= 0:
 		return errors.New("max rounds must be greater than 0")
 	case request.TargetSurfaceIDs != nil && len(request.TargetSurfaceIDs) == 0:
@@ -204,8 +208,8 @@ func cloneRunRequest(request *engine.RunRequest) *engine.RunRequest {
 		return nil
 	}
 	cloned := *request
-	cloned.TrainEvalSetIDs = append([]string(nil), request.TrainEvalSetIDs...)
-	cloned.ValidationEvalSetIDs = append([]string(nil), request.ValidationEvalSetIDs...)
+	cloned.Train = cloneEvalSetInputs(request.Train)
+	cloned.Validation = cloneEvalSetInputs(request.Validation)
 	cloned.InitialProfile = iprofile.Clone(request.InitialProfile)
 	cloned.TargetSurfaceIDs = append([]string(nil), request.TargetSurfaceIDs...)
 	if request.StopPolicy.TargetScore != nil {
@@ -213,4 +217,34 @@ func cloneRunRequest(request *engine.RunRequest) *engine.RunRequest {
 		cloned.StopPolicy.TargetScore = &targetScore
 	}
 	return &cloned
+}
+
+func validateEvalSetInputs(role string, inputs []engine.EvalSetInput) error {
+	prefix := role + " "
+	if len(inputs) == 0 {
+		return fmt.Errorf("%sevaluation sets are empty", prefix)
+	}
+	for _, input := range inputs {
+		if input.EvalSetID == "" {
+			return fmt.Errorf("%sevaluation set id is empty", prefix)
+		}
+		if slices.Contains(input.EvalCaseIDs, "") {
+			return fmt.Errorf("%seval case id for eval set %q is empty", prefix, input.EvalSetID)
+		}
+	}
+	return nil
+}
+
+func cloneEvalSetInputs(inputs []engine.EvalSetInput) []engine.EvalSetInput {
+	if inputs == nil {
+		return nil
+	}
+	cloned := make([]engine.EvalSetInput, 0, len(inputs))
+	for _, input := range inputs {
+		cloned = append(cloned, engine.EvalSetInput{
+			EvalSetID:   input.EvalSetID,
+			EvalCaseIDs: append([]string(nil), input.EvalCaseIDs...),
+		})
+	}
+	return cloned
 }

--- a/evaluation/workflow/promptiter/manager/manager_test.go
+++ b/evaluation/workflow/promptiter/manager/manager_test.go
@@ -130,6 +130,14 @@ func (f *fakePromptIterEngine) Run(
 	return &promptiterengine.RunResult{}, nil
 }
 
+func testEvalSetInputs(evalSetID string) []promptiterengine.EvalSetInput {
+	return []promptiterengine.EvalSetInput{
+		{
+			EvalSetID: evalSetID,
+		},
+	}
+}
+
 func TestManagerStartAndGetReturnRun(t *testing.T) {
 	engineInstance := &fakePromptIterEngine{
 		run: func(ctx context.Context, request *promptiterengine.RunRequest, opts ...promptiterengine.Option) (*promptiterengine.RunResult, error) {
@@ -161,10 +169,10 @@ func TestManagerStartAndGetReturnRun(t *testing.T) {
 		require.NoError(t, managerInstance.Close())
 	})
 	run, err := managerInstance.Start(context.Background(), &promptiterengine.RunRequest{
-		TrainEvalSetIDs:      []string{"train"},
-		ValidationEvalSetIDs: []string{"validation"},
-		MaxRounds:            1,
-		TargetSurfaceIDs:     []string{"candidate#instruction"},
+		Train:            testEvalSetInputs("train"),
+		Validation:       testEvalSetInputs("validation"),
+		MaxRounds:        1,
+		TargetSurfaceIDs: []string{"candidate#instruction"},
 	})
 	require.NoError(t, err)
 	require.NotNil(t, run)
@@ -210,9 +218,9 @@ func TestManagerCancelTransitionsRun(t *testing.T) {
 		require.NoError(t, managerInstance.Close())
 	})
 	run, err := managerInstance.Start(context.Background(), &promptiterengine.RunRequest{
-		TrainEvalSetIDs:      []string{"train"},
-		ValidationEvalSetIDs: []string{"validation"},
-		MaxRounds:            1,
+		Train:      testEvalSetInputs("train"),
+		Validation: testEvalSetInputs("validation"),
+		MaxRounds:  1,
 	})
 	require.NoError(t, err)
 	require.NoError(t, managerInstance.Cancel(context.Background(), run.ID))
@@ -527,9 +535,9 @@ func TestManagerStartRejectsClosedManager(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, managerInstance.Close())
 	run, err := managerInstance.Start(context.Background(), &promptiterengine.RunRequest{
-		TrainEvalSetIDs:      []string{"train"},
-		ValidationEvalSetIDs: []string{"validation"},
-		MaxRounds:            1,
+		Train:      testEvalSetInputs("train"),
+		Validation: testEvalSetInputs("validation"),
+		MaxRounds:  1,
 	})
 	assert.Nil(t, run)
 	assert.EqualError(t, err, "promptiter manager is closed")
@@ -549,9 +557,9 @@ func TestManagerStartReturnsCreateError(t *testing.T) {
 		require.NoError(t, managerInstance.Close())
 	})
 	run, err := managerInstance.Start(context.Background(), &promptiterengine.RunRequest{
-		TrainEvalSetIDs:      []string{"train"},
-		ValidationEvalSetIDs: []string{"validation"},
-		MaxRounds:            1,
+		Train:      testEvalSetInputs("train"),
+		Validation: testEvalSetInputs("validation"),
+		MaxRounds:  1,
 	})
 	assert.Nil(t, run)
 	assert.ErrorContains(t, err, "create run")
@@ -760,33 +768,57 @@ func TestManagerRunHandlesErrorBranches(t *testing.T) {
 
 func TestValidateRunRequest(t *testing.T) {
 	assert.EqualError(t, validateRunRequest(nil), "run request is nil")
-	assert.EqualError(t, validateRunRequest(&promptiterengine.RunRequest{}), "train evaluation set ids are empty")
+	assert.EqualError(t, validateRunRequest(&promptiterengine.RunRequest{}), "train evaluation sets are empty")
 	assert.EqualError(t, validateRunRequest(&promptiterengine.RunRequest{
-		TrainEvalSetIDs: []string{"train"},
-	}), "validation evaluation set ids are empty")
+		Train: testEvalSetInputs("train"),
+	}), "validation evaluation sets are empty")
 	assert.EqualError(t, validateRunRequest(&promptiterengine.RunRequest{
-		TrainEvalSetIDs:      []string{"train"},
-		ValidationEvalSetIDs: []string{"validation"},
+		Train: []promptiterengine.EvalSetInput{
+			{
+				EvalSetID: "",
+			},
+		},
+		Validation: testEvalSetInputs("validation"),
+		MaxRounds:  1,
+	}), "train evaluation set id is empty")
+	assert.EqualError(t, validateRunRequest(&promptiterengine.RunRequest{
+		Train: testEvalSetInputs("train"),
+		Validation: []promptiterengine.EvalSetInput{
+			{
+				EvalSetID:   "validation",
+				EvalCaseIDs: []string{""},
+			},
+		},
+		MaxRounds: 1,
+	}), `validation eval case id for eval set "validation" is empty`)
+	assert.EqualError(t, validateRunRequest(&promptiterengine.RunRequest{
+		Train:      testEvalSetInputs("train"),
+		Validation: testEvalSetInputs("validation"),
 	}), "max rounds must be greater than 0")
 	assert.EqualError(t, validateRunRequest(&promptiterengine.RunRequest{
-		TrainEvalSetIDs:      []string{"train"},
-		ValidationEvalSetIDs: []string{"validation"},
-		MaxRounds:            1,
-		TargetSurfaceIDs:     []string{},
+		Train:            testEvalSetInputs("train"),
+		Validation:       testEvalSetInputs("validation"),
+		MaxRounds:        1,
+		TargetSurfaceIDs: []string{},
 	}), "target surface ids must not be empty")
 	assert.NoError(t, validateRunRequest(&promptiterengine.RunRequest{
-		TrainEvalSetIDs:      []string{"train"},
-		ValidationEvalSetIDs: []string{"validation"},
-		MaxRounds:            1,
-		TargetSurfaceIDs:     []string{"candidate#instruction"},
+		Train:            testEvalSetInputs("train"),
+		Validation:       testEvalSetInputs("validation"),
+		MaxRounds:        1,
+		TargetSurfaceIDs: []string{"candidate#instruction"},
 	}))
 }
 
 func TestCloneRunRequestDeepCopiesFields(t *testing.T) {
 	targetScore := 0.9
 	request := &promptiterengine.RunRequest{
-		TrainEvalSetIDs:      []string{"train"},
-		ValidationEvalSetIDs: []string{"validation"},
+		Train: testEvalSetInputs("train"),
+		Validation: []promptiterengine.EvalSetInput{
+			{
+				EvalSetID:   "validation",
+				EvalCaseIDs: []string{"case_1"},
+			},
+		},
 		InitialProfile: &promptiter.Profile{
 			StructureID: "structure_1",
 			Overrides: []promptiter.SurfaceOverride{
@@ -805,13 +837,13 @@ func TestCloneRunRequestDeepCopiesFields(t *testing.T) {
 	}
 	cloned := cloneRunRequest(request)
 	require.NotNil(t, cloned)
-	cloned.TrainEvalSetIDs[0] = "mutated"
-	cloned.ValidationEvalSetIDs[0] = "mutated"
+	cloned.Train[0].EvalSetID = "mutated"
+	cloned.Validation[0].EvalCaseIDs[0] = "mutated"
 	cloned.TargetSurfaceIDs[0] = "mutated"
 	*cloned.InitialProfile.Overrides[0].Value.Text = "mutated"
 	*cloned.StopPolicy.TargetScore = 1.0
-	assert.Equal(t, "train", request.TrainEvalSetIDs[0])
-	assert.Equal(t, "validation", request.ValidationEvalSetIDs[0])
+	assert.Equal(t, "train", request.Train[0].EvalSetID)
+	assert.Equal(t, []string{"case_1"}, request.Validation[0].EvalCaseIDs)
 	assert.Equal(t, "candidate#instruction", request.TargetSurfaceIDs[0])
 	assert.Equal(t, "prompt", *request.InitialProfile.Overrides[0].Value.Text)
 	assert.Equal(t, 0.9, *request.StopPolicy.TargetScore)

--- a/examples/evaluation/promptiter/asyncrun/engine.go
+++ b/examples/evaluation/promptiter/asyncrun/engine.go
@@ -216,8 +216,16 @@ func buildPromptIterRuntime(ctx context.Context, cfg asyncRunConfig) (*promptIte
 func buildRunRequest(cfg asyncRunConfig, targetSurfaceID string) *promptiterengine.RunRequest {
 	targetScore := cfg.TargetScore
 	return &promptiterengine.RunRequest{
-		TrainEvalSetIDs:      []string{trainEvalSetID},
-		ValidationEvalSetIDs: []string{validationEvalSetID},
+		Train: []promptiterengine.EvalSetInput{
+			{
+				EvalSetID: trainEvalSetID,
+			},
+		},
+		Validation: []promptiterengine.EvalSetInput{
+			{
+				EvalSetID: validationEvalSetID,
+			},
+		},
 		EvaluationOptions: promptiterengine.EvaluationOptions{
 			EvalCaseParallelism:               cfg.EvalCaseParallelism,
 			EvalCaseParallelInferenceEnabled:  cfg.ParallelInferenceEnabled,

--- a/examples/evaluation/promptiter/server/README.md
+++ b/examples/evaluation/promptiter/server/README.md
@@ -166,14 +166,22 @@ curl -X POST "http://127.0.0.1:8080/promptiter/v1/apps/promptiter-nba-commentary
   -H "Content-Type: application/json" \
   -d '{
     "run": {
-      "TrainEvalSetIDs": ["nba-commentary-train"],
-      "ValidationEvalSetIDs": ["nba-commentary-validation"],
+      "train": [
+        {
+          "evalSetId": "nba-commentary-train"
+        }
+      ],
+      "validation": [
+        {
+          "evalSetId": "nba-commentary-validation"
+        }
+      ],
       "TargetSurfaceIDs": ["candidate#instruction"],
-        "EvaluationOptions": {
-          "EvalCaseParallelism": 8,
-          "EvalCaseParallelInferenceEnabled": true,
-          "EvalCaseParallelEvaluationEnabled": true
-        },
+      "EvaluationOptions": {
+        "EvalCaseParallelism": 8,
+        "EvalCaseParallelInferenceEnabled": true,
+        "EvalCaseParallelEvaluationEnabled": true
+      },
       "AcceptancePolicy": {
         "MinScoreGain": 0.005
       },
@@ -188,6 +196,29 @@ curl -X POST "http://127.0.0.1:8080/promptiter/v1/apps/promptiter-nba-commentary
 
 The `runs` endpoint waits until the run reaches a terminal state and then returns the full `run` result directly.
 
+To restrict a run to selected eval cases, add `evalCaseIds` to the corresponding eval set input:
+
+```json
+{
+  "run": {
+    "train": [
+      {
+        "evalSetId": "nba-commentary-train",
+        "evalCaseIds": ["case_1", "case_2"]
+      }
+    ],
+    "validation": [
+      {
+        "evalSetId": "nba-commentary-validation",
+        "evalCaseIds": ["case_3"]
+      }
+    ]
+  }
+}
+```
+
+Omitting `evalCaseIds` or passing an empty array runs all cases in that eval set. Passing a non-empty array runs only the listed cases. Empty string case IDs are invalid.
+
 Run one asynchronous PromptIter optimization session:
 
 ```bash
@@ -195,14 +226,22 @@ curl -X POST "http://127.0.0.1:8080/promptiter/v1/apps/promptiter-nba-commentary
   -H "Content-Type: application/json" \
   -d '{
     "run": {
-      "TrainEvalSetIDs": ["nba-commentary-train"],
-      "ValidationEvalSetIDs": ["nba-commentary-validation"],
+      "train": [
+        {
+          "evalSetId": "nba-commentary-train"
+        }
+      ],
+      "validation": [
+        {
+          "evalSetId": "nba-commentary-validation"
+        }
+      ],
       "TargetSurfaceIDs": ["candidate#instruction"],
       "EvaluationOptions": {
-          "EvalCaseParallelism": 8,
-          "EvalCaseParallelInferenceEnabled": true,
-          "EvalCaseParallelEvaluationEnabled": true
-        },
+        "EvalCaseParallelism": 8,
+        "EvalCaseParallelInferenceEnabled": true,
+        "EvalCaseParallelEvaluationEnabled": true
+      },
       "AcceptancePolicy": {
         "MinScoreGain": 0.005
       },

--- a/examples/evaluation/promptiter/server/client.py
+++ b/examples/evaluation/promptiter/server/client.py
@@ -138,8 +138,8 @@ def resolve_target_surface_id(structure: dict) -> str:
 def build_run_request(args: argparse.Namespace, target_surface_id: str) -> dict:
     return {
         "run": {
-            "TrainEvalSetIDs": ["nba-commentary-train"],
-            "ValidationEvalSetIDs": ["nba-commentary-validation"],
+            "train": [{"evalSetId": "nba-commentary-train"}],
+            "validation": [{"evalSetId": "nba-commentary-validation"}],
             "TargetSurfaceIDs": [target_surface_id],
             "EvaluationOptions": {
                 "EvalCaseParallelism": args.eval_case_parallelism,

--- a/examples/evaluation/promptiter/syncrun/engine.go
+++ b/examples/evaluation/promptiter/syncrun/engine.go
@@ -218,8 +218,16 @@ func buildPromptIterRuntime(ctx context.Context, cfg syncRunConfig) (*promptIter
 func buildRunRequest(cfg syncRunConfig, targetSurfaceID string) *promptiterengine.RunRequest {
 	targetScore := cfg.TargetScore
 	return &promptiterengine.RunRequest{
-		TrainEvalSetIDs:      []string{trainEvalSetID},
-		ValidationEvalSetIDs: []string{validationEvalSetID},
+		Train: []promptiterengine.EvalSetInput{
+			{
+				EvalSetID: trainEvalSetID,
+			},
+		},
+		Validation: []promptiterengine.EvalSetInput{
+			{
+				EvalSetID: validationEvalSetID,
+			},
+		},
 		EvaluationOptions: promptiterengine.EvaluationOptions{
 			EvalCaseParallelism:               cfg.EvalCaseParallelism,
 			EvalCaseParallelInferenceEnabled:  cfg.ParallelInferenceEnabled,

--- a/server/promptiter/server_test.go
+++ b/server/promptiter/server_test.go
@@ -84,6 +84,14 @@ func (f *fakeManager) Close() error {
 	return nil
 }
 
+func testEvalSetInputs(evalSetID string) []enginepkg.EvalSetInput {
+	return []enginepkg.EvalSetInput{
+		{
+			EvalSetID: evalSetID,
+		},
+	}
+}
+
 func (failingWriter) Header() http.Header {
 	return http.Header{}
 }
@@ -205,10 +213,10 @@ func TestHandleRunsPassesRequestThrough(t *testing.T) {
 	)
 	body, err := json.Marshal(&RunRequest{
 		Run: &enginepkg.RunRequest{
-			TrainEvalSetIDs:      []string{"train"},
-			ValidationEvalSetIDs: []string{"validation"},
-			TargetSurfaceIDs:     []string{"candidate#instruction"},
-			MaxRounds:            1,
+			Train:            testEvalSetInputs("train"),
+			Validation:       testEvalSetInputs("validation"),
+			TargetSurfaceIDs: []string{"candidate#instruction"},
+			MaxRounds:        1,
 		},
 	})
 	require.NoError(t, err)
@@ -217,14 +225,70 @@ func TestHandleRunsPassesRequestThrough(t *testing.T) {
 	srv.Handler().ServeHTTP(recorder, req)
 	require.Equal(t, http.StatusOK, recorder.Code)
 	require.NotNil(t, captured)
-	assert.Equal(t, []string{"train"}, captured.TrainEvalSetIDs)
-	assert.Equal(t, []string{"validation"}, captured.ValidationEvalSetIDs)
+	assert.Equal(t, testEvalSetInputs("train"), captured.Train)
+	assert.Equal(t, testEvalSetInputs("validation"), captured.Validation)
 	assert.Equal(t, []string{"candidate#instruction"}, captured.TargetSurfaceIDs)
 	assert.Equal(t, 1, captured.MaxRounds)
 	var resp RunResponse
 	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &resp))
 	require.NotNil(t, resp.Result)
 	assert.Equal(t, enginepkg.RunStatusSucceeded, resp.Result.Status)
+}
+
+func TestHandleRunsDecodesEvalSetInputs(t *testing.T) {
+	var captured *enginepkg.RunRequest
+	srv := newTestServer(t,
+		WithEngine(&fakeEngine{
+			describe: func(ctx context.Context) (*astructure.Snapshot, error) {
+				_ = ctx
+				return &astructure.Snapshot{
+					StructureID: "struct_1",
+					EntryNodeID: "node_1",
+					Nodes: []astructure.Node{
+						{NodeID: "node_1", Name: "candidate", Kind: astructure.NodeKindLLM},
+					},
+					Surfaces: []astructure.Surface{
+						{
+							SurfaceID: "candidate#instruction",
+							NodeID:    "node_1",
+							Type:      astructure.SurfaceTypeInstruction,
+						},
+					},
+				}, nil
+			},
+			run: func(ctx context.Context, request *enginepkg.RunRequest, opts ...enginepkg.Option) (*enginepkg.RunResult, error) {
+				_ = ctx
+				_ = opts
+				captured = request
+				return &enginepkg.RunResult{Status: enginepkg.RunStatusSucceeded}, nil
+			},
+		}),
+	)
+	body := `{
+		"run": {
+			"train": [{"evalSetId": "train", "evalCaseIds": ["train_case_1"]}],
+			"validation": [{"evalSetId": "validation", "evalCaseIds": ["validation_case_1", "validation_case_2"]}],
+			"TargetSurfaceIDs": ["candidate#instruction"],
+			"MaxRounds": 1
+		}
+	}`
+	req := httptest.NewRequest(http.MethodPost, srv.RunsPath(), bytes.NewBufferString(body))
+	recorder := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(recorder, req)
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.NotNil(t, captured)
+	assert.Equal(t, []enginepkg.EvalSetInput{
+		{
+			EvalSetID:   "train",
+			EvalCaseIDs: []string{"train_case_1"},
+		},
+	}, captured.Train)
+	assert.Equal(t, []enginepkg.EvalSetInput{
+		{
+			EvalSetID:   "validation",
+			EvalCaseIDs: []string{"validation_case_1", "validation_case_2"},
+		},
+	}, captured.Validation)
 }
 
 func TestHandleRunsRejectsInvalidRequest(t *testing.T) {
@@ -249,10 +313,10 @@ func TestHandleRunsRejectsUnknownTargetSurfaceID(t *testing.T) {
 	srv := newTestServer(t)
 	body, err := json.Marshal(&RunRequest{
 		Run: &enginepkg.RunRequest{
-			TrainEvalSetIDs:      []string{"train"},
-			ValidationEvalSetIDs: []string{"validation"},
-			TargetSurfaceIDs:     []string{"unknown#instruction"},
-			MaxRounds:            1,
+			Train:            testEvalSetInputs("train"),
+			Validation:       testEvalSetInputs("validation"),
+			TargetSurfaceIDs: []string{"unknown#instruction"},
+			MaxRounds:        1,
 		},
 	})
 	require.NoError(t, err)
@@ -288,10 +352,10 @@ func TestHandleAsyncRunsStartsRunWhenManagerIsConfigured(t *testing.T) {
 	)
 	body, err := json.Marshal(&RunRequest{
 		Run: &enginepkg.RunRequest{
-			TrainEvalSetIDs:      []string{"train"},
-			ValidationEvalSetIDs: []string{"validation"},
-			TargetSurfaceIDs:     []string{"candidate#instruction"},
-			MaxRounds:            1,
+			Train:            testEvalSetInputs("train"),
+			Validation:       testEvalSetInputs("validation"),
+			TargetSurfaceIDs: []string{"candidate#instruction"},
+			MaxRounds:        1,
 		},
 	})
 	require.NoError(t, err)
@@ -300,7 +364,7 @@ func TestHandleAsyncRunsStartsRunWhenManagerIsConfigured(t *testing.T) {
 	srv.Handler().ServeHTTP(recorder, req)
 	require.Equal(t, http.StatusCreated, recorder.Code)
 	require.NotNil(t, captured)
-	assert.Equal(t, []string{"train"}, captured.TrainEvalSetIDs)
+	assert.Equal(t, testEvalSetInputs("train"), captured.Train)
 	assert.Equal(t, "/promptiter/v1/apps/demo-app/async-runs/run_1", recorder.Header().Get("Location"))
 	var resp RunResponse
 	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &resp))
@@ -336,10 +400,10 @@ func TestHandleAsyncRunsSupportsOptionsAndMapsStartErrors(t *testing.T) {
 	require.Equal(t, http.StatusNoContent, optionsRecorder.Code)
 	body, err := json.Marshal(&RunRequest{
 		Run: &enginepkg.RunRequest{
-			TrainEvalSetIDs:      []string{"train"},
-			ValidationEvalSetIDs: []string{"validation"},
-			TargetSurfaceIDs:     []string{"candidate#instruction"},
-			MaxRounds:            1,
+			Train:            testEvalSetInputs("train"),
+			Validation:       testEvalSetInputs("validation"),
+			TargetSurfaceIDs: []string{"candidate#instruction"},
+			MaxRounds:        1,
 		},
 	})
 	require.NoError(t, err)
@@ -470,10 +534,10 @@ func TestHandleRunsMethodAndExecutionErrors(t *testing.T) {
 	assert.Equal(t, http.MethodPost, getRecorder.Header().Get(headerAllow))
 	body, err := json.Marshal(&RunRequest{
 		Run: &enginepkg.RunRequest{
-			TrainEvalSetIDs:      []string{"train"},
-			ValidationEvalSetIDs: []string{"validation"},
-			TargetSurfaceIDs:     []string{"candidate#instruction"},
-			MaxRounds:            1,
+			Train:            testEvalSetInputs("train"),
+			Validation:       testEvalSetInputs("validation"),
+			TargetSurfaceIDs: []string{"candidate#instruction"},
+			MaxRounds:        1,
 		},
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
This updates PromptIter run requests to select train and validation eval sets through EvalSetInput, allowing optional evalCaseIds filters while preserving full eval set execution when filters are omitted or empty. It updates async manager cloning, server request decoding coverage, examples, and PromptIter docs to use the new request shape.