### PR TITLE
runner: emit completion after cancellation

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1655,8 +1655,19 @@ func (r *runner) emitRunnerCompletion(ctx context.Context, loop *eventLoopContex
 		log.Errorf("Failed to append runner completion event to session: %v", err)
 	}
 
-	// Send the runner completion event to output channel.
-	agent.EmitEvent(ctx, loop.invocation, loop.processedEventCh, runnerCompletionEvent)
+	// Use a context to deliver runner-completion after cancellation without blocking cleanup indefinitely.
+	func() {
+		emitCtx, emitCancel := context.WithTimeout(
+			context.WithoutCancel(ctx),
+			time.Second,
+		)
+		defer emitCancel()
+		if err := agent.EmitEvent(
+			emitCtx, loop.invocation, loop.processedEventCh, runnerCompletionEvent,
+		); err != nil {
+			log.Errorf("Failed to emit runner completion event: %v", err)
+		}
+	}()
 
 	// Enqueue auto memory extraction job if memory service is configured.
 	r.enqueueAutoMemoryJob(ctx, loop.sess)

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -6012,16 +6012,18 @@ func (m *tickCtxAgent) Run(
 
 func TestProcessAgentEvents_EmitEventContextCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // cancel before running; EmitEvent should take ctx.Done() branch
+	cancel() // cancel before running
 	r := NewRunner("app", &oneEventAgent{name: "o"}, WithSessionService(sessioninmemory.NewSessionService()))
 	ch, err := r.Run(ctx, "u", "s", model.NewUserMessage(""))
 	require.NoError(t, err)
-	// Should close without emitting any event due to emit error path returning early.
-	var got int
-	for range ch {
-		got++
+	// Agent events are dropped due to cancelled context,
+	// but runner-completion should still be emitted as the terminal signal.
+	var events []*event.Event
+	for evt := range ch {
+		events = append(events, evt)
 	}
-	require.Equal(t, 0, got)
+	require.Len(t, events, 1)
+	require.True(t, events[0].IsRunnerCompletion())
 }
 
 func TestRunner_Run_DetachedCancelKeepsDeadline(t *testing.T) {
@@ -6150,6 +6152,67 @@ func TestRunner_ManagedRunner_CancelAndStatus(t *testing.T) {
 	require.False(t, mr.Cancel(requestID))
 }
 
+func TestRunner_CancelEmitsRunnerCompletion(t *testing.T) {
+	const (
+		requestID = "req-cancel-completion"
+		maxWait   = 2 * time.Second
+		interval  = 10 * time.Millisecond
+	)
+
+	r := NewRunner(
+		"app",
+		&tickCtxAgent{name: "t", interval: interval},
+		WithSessionService(sessioninmemory.NewSessionService()),
+	)
+	mr, ok := r.(ManagedRunner)
+	require.True(t, ok)
+
+	ch, err := r.Run(
+		context.Background(),
+		"u",
+		"s",
+		model.NewUserMessage(""),
+		agent.WithRequestID(requestID),
+		agent.WithDetachedCancel(true),
+		agent.WithExecutionTraceEnabled(true),
+	)
+	require.NoError(t, err)
+
+	// Wait for at least one tick event before cancelling.
+	select {
+	case <-time.After(maxWait):
+		t.Fatal("did not receive first event")
+	case _, ok := <-ch:
+		require.True(t, ok)
+	}
+
+	require.True(t, mr.Cancel(requestID))
+
+	// Drain remaining events and look for runner-completion.
+	var completionCount int
+	var completion *event.Event
+	deadline := time.After(maxWait)
+	for ch != nil {
+		select {
+		case evt, ok := <-ch:
+			if !ok {
+				ch = nil
+				continue
+			}
+			if evt != nil && evt.IsRunnerCompletion() {
+				completionCount++
+				completion = evt
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for channel to close")
+		}
+	}
+
+	require.Equal(t, 1, completionCount, "should receive exactly one runner-completion after cancel")
+	require.NotNil(t, completion.ExecutionTrace)
+	require.Equal(t, atrace.TraceStatusIncomplete, completion.ExecutionTrace.Status)
+}
+
 func TestRunner_Close_CancelsRunningRuns(t *testing.T) {
 	const (
 		requestID = "req-close-1"
@@ -6234,11 +6297,14 @@ func TestProcessAgentEvents_EmitEventErrorBranch_Direct(t *testing.T) {
 
 	// Do not read from processed until goroutine has had a chance to hit emit; then drain.
 	time.Sleep(50 * time.Millisecond)
-	var n int
-	for range processed {
-		n++
+	// Agent events are dropped due to cancelled context,
+	// but runner-completion should still be emitted.
+	var events []*event.Event
+	for evt := range processed {
+		events = append(events, evt)
 	}
-	require.Equal(t, 0, n)
+	require.Len(t, events, 1)
+	require.True(t, events[0].IsRunnerCompletion())
 }
 
 func drainChannel(ch <-chan *event.Event) <-chan struct{} {


### PR DESCRIPTION
## Summary

- Ensure the runner completion event is emitted even when the run context is canceled.
- Use a cancel-free context with a bounded timeout to avoid blocking indefinitely when sending the terminal completion event.

## Validation

- go test ./runner
- git diff --check