### PR TITLE
artifact/cos: expose object key helper

### DIFF
--- a/artifact/cos/service.go
+++ b/artifact/cos/service.go
@@ -102,6 +102,29 @@ func NewService(name, bucketURL string, opts ...Option) (*Service, error) {
 	}, nil
 }
 
+// ObjectKey returns the COS object key for an artifact version.
+func (*Service) ObjectKey(
+	sessionInfo artifact.SessionInfo,
+	filename string,
+	version int,
+) (string, error) {
+	if err := validateSessionInfo(sessionInfo); err != nil {
+		return "", err
+	}
+	if err := validateFilename(filename); err != nil {
+		return "", err
+	}
+	if version < 0 {
+		return "", fmt.Errorf("cos artifact: version cannot be negative: %d", version)
+	}
+	objectName, _ := buildObjectNameCandidates(
+		sessionInfo,
+		filename,
+		version,
+	)
+	return objectName, nil
+}
+
 // SaveArtifact saves an artifact to Tencent Cloud Object Storage.
 func (s *Service) SaveArtifact(
 	ctx context.Context,
@@ -135,11 +158,14 @@ func (s *Service) SaveArtifact(
 		version = maxVersion + 1
 	}
 
-	objectName, _ := buildObjectNameCandidates(
+	objectName, err := s.ObjectKey(
 		sessionInfo,
 		filename,
 		version,
 	)
+	if err != nil {
+		return 0, err
+	}
 
 	// Upload the artifact data
 	reader := bytes.NewReader(art.Data)

--- a/artifact/cos/service_test.go
+++ b/artifact/cos/service_test.go
@@ -817,6 +817,45 @@ func TestSaveArtifact_ValidatesInputs(t *testing.T) {
 	require.ErrorIs(t, err, ErrNilArtifact)
 }
 
+func TestService_ObjectKey(t *testing.T) {
+	s, _ := createMockService()
+	sessionInfo := artifact.SessionInfo{
+		AppName:   "testapp",
+		UserID:    "user123",
+		SessionID: "session456",
+	}
+
+	key, err := s.ObjectKey(sessionInfo, "out/site.zip", 2)
+	require.NoError(t, err)
+	assert.Equal(t, "artifact/testapp/user123/session456/out/site.zip/2", key)
+
+	key, err = s.ObjectKey(sessionInfo, "user:out/site.zip", 3)
+	require.NoError(t, err)
+	assert.Equal(t, "artifact/testapp/user123/user/user:out/site.zip/3", key)
+}
+
+func TestService_ObjectKeyValidatesInputs(t *testing.T) {
+	s, _ := createMockService()
+	sessionInfo := artifact.SessionInfo{
+		AppName:   "testapp",
+		UserID:    "user123",
+		SessionID: "session456",
+	}
+
+	_, err := s.ObjectKey(artifact.SessionInfo{}, "test.txt", 0)
+	require.ErrorIs(t, err, ErrEmptySessionInfo)
+
+	_, err = s.ObjectKey(sessionInfo, "", 0)
+	require.ErrorIs(t, err, ErrEmptyFilename)
+
+	_, err = s.ObjectKey(sessionInfo, "a\x00b", 0)
+	require.ErrorIs(t, err, ErrInvalidFilename)
+
+	_, err = s.ObjectKey(sessionInfo, "test.txt", -1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "version cannot be negative")
+}
+
 func TestService_ValidatesInputs(t *testing.T) {
 	s, _ := createMockService()
 	ctx := context.Background()


### PR DESCRIPTION
## Summary
- Add `Service.ObjectKey` so COS artifact callers can derive the actual object key for a saved artifact version.
- Reuse the helper in `SaveArtifact` to keep upload key construction aligned with the exported API.
- Cover session, filename, user-scoped artifact, and negative-version validation.

## Test plan
- `go test ./artifact/cos`