### PR TITLE
openclaw/cron: support relative delay schedules

### DIFF
--- a/openclaw/internal/cron/patch.go
+++ b/openclaw/internal/cron/patch.go
@@ -13,14 +13,15 @@ import "time"
 
 // Patch represents optional job updates.
 type Patch struct {
-	Name       *string
-	Message    *string
-	Enabled    *bool
-	Schedule   *Schedule
-	Policy     *ExecutionPolicy
-	TimeoutSec *int
-	Channel    *string
-	Target     *string
+	Name             *string
+	Message          *string
+	Enabled          *bool
+	Schedule         *Schedule
+	ScheduleTimezone *string
+	Policy           *ExecutionPolicy
+	TimeoutSec       *int
+	Channel          *string
+	Target           *string
 }
 
 func applyPatch(job *Job, patch Patch, now time.Time) error {
@@ -35,6 +36,9 @@ func applyPatch(job *Job, patch Patch, now time.Time) error {
 	}
 	if patch.Schedule != nil {
 		job.Schedule = *patch.Schedule
+	}
+	if patch.ScheduleTimezone != nil {
+		job.Schedule.Timezone = *patch.ScheduleTimezone
 	}
 	if patch.Policy != nil {
 		job.Policy = *patch.Policy

--- a/openclaw/internal/cron/schedule.go
+++ b/openclaw/internal/cron/schedule.go
@@ -38,8 +38,7 @@ func computeNextAfterRun(
 	base time.Time,
 	now time.Time,
 ) (*time.Time, error) {
-	kind := strings.ToLower(strings.TrimSpace(schedule.Kind))
-	switch kind {
+	switch normalizeScheduleKind(schedule.Kind) {
 	case ScheduleKindAt:
 		return nil, nil
 	case ScheduleKindEvery:
@@ -76,7 +75,7 @@ func computeNextRun(
 	schedule Schedule,
 	now time.Time,
 ) (time.Time, error) {
-	switch strings.ToLower(strings.TrimSpace(schedule.Kind)) {
+	switch normalizeScheduleKind(schedule.Kind) {
 	case ScheduleKindAt:
 		return parseAtTime(schedule.At)
 	case ScheduleKindEvery:

--- a/openclaw/internal/cron/schedule_test.go
+++ b/openclaw/internal/cron/schedule_test.go
@@ -70,6 +70,20 @@ func TestComputeNextRunVariants(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, nextPtr)
 
+	next, err = computeNextRun(Schedule{
+		Kind: ScheduleKindAfter,
+		At:   "2026-03-06T10:05:00Z",
+	}, now)
+	require.NoError(t, err)
+	require.Equal(t, now.Add(5*time.Minute), next)
+
+	nextPtr, err = computeNextAfterRun(Schedule{
+		Kind: ScheduleKindAfter,
+		At:   "2026-03-06T10:05:00Z",
+	}, now, now.Add(time.Minute))
+	require.NoError(t, err)
+	require.Nil(t, nextPtr)
+
 	nextPtr, err = computeNextAfterRun(Schedule{
 		Kind:  ScheduleKindEvery,
 		Every: "1m",

--- a/openclaw/internal/cron/service.go
+++ b/openclaw/internal/cron/service.go
@@ -46,10 +46,13 @@ const (
 		"needed instead of blindly following old shell " +
 		"snippets. Do not create, update, remove, clear, or " +
 		"run cron jobs from within this scheduled run. " +
-		"Do not use message unless you need an additional " +
-		"side message beyond the final result. The final " +
-		"answer will be delivered automatically to the job " +
-		"target. Do not ask for confirmation unless blocked. " +
+		"Prefer the final answer for normal job delivery. " +
+		"Use message only when you intentionally need to " +
+		"send the scheduled task text yourself. A successful " +
+		"text message sent to the job target counts as the " +
+		"job delivery, so the final answer will be kept as " +
+		"the run result instead of delivered again. Do not " +
+		"ask for confirmation unless blocked. " +
 		"Do not return only a statement of what you will do; " +
 		"perform the scheduled task and report the result or " +
 		"the exact blocker."
@@ -542,6 +545,8 @@ func (s *Service) executeJob(
 		defer cancel()
 	}
 
+	sentTextRecorder := outbound.NewSentTextRecorder()
+	runCtx = outbound.WithSentTextRecorder(runCtx, sentTextRecorder)
 	runtimeState := scheduledRunRuntimeState(job)
 	runOpts := make([]agent.RunOption, 0, 3)
 	if runtimeState != nil {
@@ -629,26 +634,32 @@ func (s *Service) executeJob(
 		_ = trace.RecordText(output)
 	}
 	deliveryAttempted := false
+	deliverySkipReason := ""
 	if runErr == nil &&
 		s.deliveryAllowed(job.ID, runToken) &&
 		job.Delivery.Channel != "" &&
 		job.Delivery.Target != "" &&
 		strings.TrimSpace(result.text) != "" {
-		deliveryAttempted = true
-		if s.router == nil {
-			deliveryErr = fmt.Errorf("cron: nil outbound router")
+		if sentTextRecorder.ContainsTarget(job.Delivery) {
+			deliverySkipReason = cronDeliverySkipMessageToolTarget
 		} else {
-			deliveryErr = s.router.SendText(
-				runCtx,
-				job.Delivery,
-				result.text,
-			)
+			deliveryAttempted = true
+			if s.router == nil {
+				deliveryErr = fmt.Errorf("cron: nil outbound router")
+			} else {
+				deliveryErr = s.router.SendText(
+					runCtx,
+					job.Delivery,
+					result.text,
+				)
+			}
 		}
 	}
 	recordCronDeliveryTrace(
 		trace,
 		job,
 		deliveryAttempted,
+		deliverySkipReason,
 		deliveryErr,
 	)
 
@@ -732,6 +743,7 @@ func recordCronDeliveryTrace(
 	trace *debugrecorder.Trace,
 	job *Job,
 	attempted bool,
+	skipReason string,
 	err error,
 ) {
 	if trace == nil || job == nil {
@@ -744,6 +756,9 @@ func recordCronDeliveryTrace(
 	}
 	if err != nil {
 		record["error"] = err.Error()
+	}
+	if skipReason != "" {
+		record["skip_reason"] = skipReason
 	}
 	_ = trace.Record(debugrecorder.KindCronDelivery, record)
 }

--- a/openclaw/internal/cron/service_test.go
+++ b/openclaw/internal/cron/service_test.go
@@ -24,6 +24,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/channel"
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/debugrecorder"
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/outbound"
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/runtimeprofile"
@@ -82,6 +83,63 @@ func (s *stubRunner) messagesSnapshot() []string {
 	out := make([]string, len(s.messages))
 	copy(out, s.messages)
 	return out
+}
+
+type toolCallingRunner struct {
+	mu         sync.Mutex
+	router     *outbound.Router
+	args       []byte
+	reply      string
+	toolResult any
+	toolErr    error
+}
+
+func (r *toolCallingRunner) Run(
+	ctx context.Context,
+	userID string,
+	sessionID string,
+	message model.Message,
+	opts ...agent.RunOption,
+) (<-chan *event.Event, error) {
+	var runOpts agent.RunOptions
+	for _, opt := range opts {
+		opt(&runOpts)
+	}
+
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(
+			session.NewSession("app", userID, sessionID),
+		),
+		agent.WithInvocationRunOptions(runOpts),
+	)
+	toolCtx := agent.NewInvocationContext(ctx, inv)
+	result, err := outbound.NewTool(r.router).Call(toolCtx, r.args)
+
+	r.mu.Lock()
+	r.toolResult = result
+	r.toolErr = err
+	r.mu.Unlock()
+
+	ch := make(chan *event.Event, 1)
+	ch <- &event.Event{
+		Response: &model.Response{
+			Object: model.ObjectTypeChatCompletion,
+			Choices: []model.Choice{{
+				Message: model.NewAssistantMessage(r.reply),
+			}},
+		},
+	}
+	close(ch)
+	return ch, nil
+}
+
+func (r *toolCallingRunner) Close() error { return nil }
+
+func (r *toolCallingRunner) resultSnapshot() (any, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.toolResult, r.toolErr
 }
 
 type blockingRunner struct {
@@ -192,10 +250,20 @@ func (r *replaceAwareRunner) ctxAt(index int) context.Context {
 }
 
 type stubSender struct {
-	mu     sync.Mutex
+	mu      sync.Mutex
+	target  string
+	text    string
+	files   []channel.OutboundFile
+	err     error
+	errs    []error
+	count   int
+	records []sendRecord
+}
+
+type sendRecord struct {
 	target string
 	text   string
-	err    error
+	files  []channel.OutboundFile
 }
 
 func (s *stubSender) ID() string { return "telegram" }
@@ -214,7 +282,62 @@ func (s *stubSender) SendText(
 	defer s.mu.Unlock()
 	s.target = target
 	s.text = text
-	return s.err
+	s.records = append(s.records, sendRecord{
+		target: target,
+		text:   text,
+	})
+	s.count++
+	return s.nextErrLocked()
+}
+
+func (s *stubSender) SendMessage(
+	_ context.Context,
+	target string,
+	msg channel.OutboundMessage,
+) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.target = target
+	s.text = msg.Text
+	s.files = append([]channel.OutboundFile(nil), msg.Files...)
+	s.records = append(s.records, sendRecord{
+		target: target,
+		text:   msg.Text,
+		files:  append([]channel.OutboundFile(nil), msg.Files...),
+	})
+	s.count++
+	return s.nextErrLocked()
+}
+
+func (s *stubSender) nextErrLocked() error {
+	if len(s.errs) == 0 {
+		return s.err
+	}
+	err := s.errs[0]
+	s.errs = s.errs[1:]
+	return err
+}
+
+func (s *stubSender) countSnapshot() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.count
+}
+
+func (s *stubSender) recordsSnapshot() []sendRecord {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	records := make([]sendRecord, len(s.records))
+	for i, record := range s.records {
+		records[i] = sendRecord{
+			target: record.target,
+			text:   record.text,
+			files:  append([]channel.OutboundFile(nil), record.files...),
+		}
+	}
+	return records
 }
 
 func TestServiceRunNowSendsToDeliveryTarget(t *testing.T) {
@@ -284,6 +407,292 @@ func TestServiceRunNowSendsToDeliveryTarget(t *testing.T) {
 		job.ID,
 		runner.runOpts.RuntimeState[runtimeStateJobID],
 	)
+}
+
+func TestServiceRunNowSuppressesFinalAfterMessageToolSend(
+	t *testing.T,
+) {
+	router := outbound.NewRouter()
+	sender := &stubSender{}
+	router.RegisterSender(sender)
+
+	rec, err := debugrecorder.New(t.TempDir(), "")
+	require.NoError(t, err)
+
+	runner := &toolCallingRunner{
+		router: router,
+		args: []byte(
+			`{"text":"提醒 wineguo：现在喝点水。"}`,
+		),
+		reply: "已在当前聊天中提醒 wineguo：现在喝点水。",
+	}
+	svc, err := NewService(
+		t.TempDir(),
+		runner,
+		router,
+		WithDebugRecorder(rec),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, svc.Close())
+	})
+
+	job, err := svc.Add(&Job{
+		Name:    "drink water",
+		Enabled: true,
+		Schedule: Schedule{
+			Kind:  ScheduleKindEvery,
+			Every: "1m",
+		},
+		Message: "remind wineguo to drink water",
+		UserID:  "telegram:user",
+		Delivery: outbound.DeliveryTarget{
+			Channel: "telegram",
+			Target:  "100",
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = svc.RunNow(job.ID)
+	require.NoError(t, err)
+
+	waitForJobStatus(t, svc, job.ID, StatusSucceeded)
+
+	result, toolErr := runner.resultSnapshot()
+	require.NoError(t, toolErr)
+	require.Equal(t, true, result.(map[string]any)["ok"])
+
+	sender.mu.Lock()
+	defer sender.mu.Unlock()
+	require.Equal(t, "100", sender.target)
+	require.Equal(t, "提醒 wineguo：现在喝点水。", sender.text)
+	require.Equal(t, 1, sender.count)
+
+	traceDir := waitForCronTrace(t, rec.Dir())
+	events, err := debugrecorder.ReadEventsFile(traceDir)
+	require.NoError(t, err)
+	require.Contains(t, string(events), "duplicate_message_tool_text")
+	require.Contains(t, string(events), cronDeliverySkipMessageToolTarget)
+}
+
+func TestServiceRunNowDeliversFinalTextWhenMessageToolFails(
+	t *testing.T,
+) {
+	router := outbound.NewRouter()
+	sender := &stubSender{
+		errs: []error{context.DeadlineExceeded, nil},
+	}
+	router.RegisterSender(sender)
+
+	runner := &toolCallingRunner{
+		router: router,
+		args:   []byte(`{"text":"report ready"}`),
+		reply:  "report ready",
+	}
+	svc, err := NewService(t.TempDir(), runner, router)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, svc.Close())
+	})
+
+	job, err := svc.Add(&Job{
+		Name:    "report",
+		Enabled: true,
+		Schedule: Schedule{
+			Kind:  ScheduleKindEvery,
+			Every: "1m",
+		},
+		Message: "send report",
+		UserID:  "telegram:user",
+		Delivery: outbound.DeliveryTarget{
+			Channel: "telegram",
+			Target:  "100",
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = svc.RunNow(job.ID)
+	require.NoError(t, err)
+
+	waitFor(t, func() bool {
+		return sender.countSnapshot() == 2
+	})
+
+	result, toolErr := runner.resultSnapshot()
+	require.Nil(t, result)
+	require.ErrorIs(t, toolErr, context.DeadlineExceeded)
+
+	sender.mu.Lock()
+	defer sender.mu.Unlock()
+	require.Equal(t, "100", sender.target)
+	require.Equal(t, "report ready", sender.text)
+	require.Equal(t, 2, sender.count)
+}
+
+func TestServiceRunNowDeliversSameTextWhenMessageToolSendsFile(
+	t *testing.T,
+) {
+	router := outbound.NewRouter()
+	sender := &stubSender{}
+	router.RegisterSender(sender)
+	router.RegisterMessageSender(sender)
+
+	runner := &toolCallingRunner{
+		router: router,
+		args: []byte(
+			`{"text":"report ready","file":"report.pdf"}`,
+		),
+		reply: "report ready",
+	}
+	svc, err := NewService(t.TempDir(), runner, router)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, svc.Close())
+	})
+
+	job, err := svc.Add(&Job{
+		Name:    "report",
+		Enabled: true,
+		Schedule: Schedule{
+			Kind:  ScheduleKindEvery,
+			Every: "1m",
+		},
+		Message: "send report",
+		UserID:  "telegram:user",
+		Delivery: outbound.DeliveryTarget{
+			Channel: "telegram",
+			Target:  "100",
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = svc.RunNow(job.ID)
+	require.NoError(t, err)
+
+	waitFor(t, func() bool {
+		return sender.countSnapshot() == 2
+	})
+
+	result, toolErr := runner.resultSnapshot()
+	require.NoError(t, toolErr)
+	require.Equal(t, true, result.(map[string]any)["ok"])
+
+	sender.mu.Lock()
+	defer sender.mu.Unlock()
+	require.Equal(t, "100", sender.target)
+	require.Equal(t, "report ready", sender.text)
+	require.Equal(t, 2, sender.count)
+}
+
+func TestServiceRunNowSuppressesWhitespaceDifferentFinalText(
+	t *testing.T,
+) {
+	router := outbound.NewRouter()
+	sender := &stubSender{}
+	router.RegisterSender(sender)
+
+	runner := &toolCallingRunner{
+		router: router,
+		args:   []byte(`{"text":"report ready"}`),
+		reply:  "report ready\n",
+	}
+	svc, err := NewService(t.TempDir(), runner, router)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, svc.Close())
+	})
+
+	job, err := svc.Add(&Job{
+		Name:    "report",
+		Enabled: true,
+		Schedule: Schedule{
+			Kind:  ScheduleKindEvery,
+			Every: "1m",
+		},
+		Message: "send report",
+		UserID:  "telegram:user",
+		Delivery: outbound.DeliveryTarget{
+			Channel: "telegram",
+			Target:  "100",
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = svc.RunNow(job.ID)
+	require.NoError(t, err)
+
+	waitForJobStatus(t, svc, job.ID, StatusSucceeded)
+
+	result, toolErr := runner.resultSnapshot()
+	require.NoError(t, toolErr)
+	require.Equal(t, true, result.(map[string]any)["ok"])
+
+	sender.mu.Lock()
+	defer sender.mu.Unlock()
+	require.Equal(t, "100", sender.target)
+	require.Equal(t, "report ready", sender.text)
+	require.Equal(t, 1, sender.count)
+}
+
+func TestServiceRunNowDeliversFinalAfterDifferentTargetToolSend(
+	t *testing.T,
+) {
+	router := outbound.NewRouter()
+	sender := &stubSender{}
+	router.RegisterSender(sender)
+
+	runner := &toolCallingRunner{
+		router: router,
+		args: []byte(
+			`{"text":"preparing report","channel":"telegram","target":"200"}`,
+		),
+		reply: "report ready",
+	}
+	svc, err := NewService(t.TempDir(), runner, router)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, svc.Close())
+	})
+
+	job, err := svc.Add(&Job{
+		Name:    "report",
+		Enabled: true,
+		Schedule: Schedule{
+			Kind:  ScheduleKindEvery,
+			Every: "1m",
+		},
+		Message: "prepare report",
+		UserID:  "telegram:user",
+		Delivery: outbound.DeliveryTarget{
+			Channel: "telegram",
+			Target:  "100",
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = svc.RunNow(job.ID)
+	require.NoError(t, err)
+
+	waitFor(t, func() bool {
+		return sender.countSnapshot() == 2
+	})
+
+	result, toolErr := runner.resultSnapshot()
+	require.NoError(t, toolErr)
+	require.Equal(t, true, result.(map[string]any)["ok"])
+
+	sender.mu.Lock()
+	require.Equal(t, "100", sender.target)
+	require.Equal(t, "report ready", sender.text)
+	require.Equal(t, 2, sender.count)
+	sender.mu.Unlock()
+
+	records := sender.recordsSnapshot()
+	require.Len(t, records, 2)
+	require.Equal(t, "200", records[0].target)
+	require.Equal(t, "preparing report", records[0].text)
+	require.Equal(t, "100", records[1].target)
+	require.Equal(t, "report ready", records[1].text)
 }
 
 func TestServiceRunNowWritesDebugTrace(t *testing.T) {
@@ -1444,6 +1853,8 @@ func TestServiceNormalizeAndAccumulatorHelpers(t *testing.T) {
 		},
 	})
 	require.Equal(t, true, runtimeState[runtimeStateScheduledRun])
+	require.Equal(t, "telegram", runtimeState["openclaw.delivery.channel"])
+	require.Equal(t, "1", runtimeState["openclaw.delivery.target"])
 	require.Equal(t, "job-1", runtimeState[runtimeStateJobID])
 	require.Equal(t, 2, runtimeState[runtimeStateRunIndex])
 	require.Equal(t, true, runtimeState[runtimeStateHasMaxRuns])
@@ -1575,6 +1986,11 @@ func TestRunContextPromptRequiresScheduledExecution(t *testing.T) {
 		runContextPrompt,
 		"perform the scheduled task and report the result",
 	)
+	require.Contains(
+		t,
+		runContextPrompt,
+		"counts as the job delivery",
+	)
 }
 
 func waitFor(t *testing.T, fn func() bool) {
@@ -1588,6 +2004,20 @@ func waitFor(t *testing.T, fn func() bool) {
 		time.Sleep(20 * time.Millisecond)
 	}
 	t.Fatalf("condition was not met")
+}
+
+func waitForJobStatus(
+	t *testing.T,
+	svc *Service,
+	jobID string,
+	status string,
+) {
+	t.Helper()
+
+	waitFor(t, func() bool {
+		got := svc.Get(jobID)
+		return got != nil && got.LastStatus == status
+	})
 }
 
 type cronTraceMeta struct {

--- a/openclaw/internal/cron/tool.go
+++ b/openclaw/internal/cron/tool.go
@@ -36,9 +36,13 @@ const (
 )
 
 const (
-	errJobIDRequired      = "job_id is required"
-	errProfileIDRequired  = "cron: runtime profile id is required"
-	errHeadlessWithTarget = "cron: headless jobs cannot set " +
+	errJobIDRequired     = "job_id is required"
+	errProfileIDRequired = "cron: runtime profile id is required"
+	errAfterWithSchedule = "cron: after cannot be combined with " +
+		"at, every, every_ms, or cron_expr"
+	errAfterAliasConflict   = "cron: after and delay cannot both be set"
+	errAfterMSDelayTooLarge = "cron: after_ms delay is too large"
+	errHeadlessWithTarget   = "cron: headless jobs cannot set " +
 		"channel or target"
 	errDeliveryTargetUnavailable = "cron: current chat delivery " +
 		"target is unavailable; pass channel/target explicitly " +
@@ -49,6 +53,8 @@ const (
 		"{{.Cron.RemainingRuns}}, and " +
 		"{{if .Cron.IsFinalRun}}...{{end}}. Do not hardcode " +
 		"counters like 1/5 into a repeating task."
+
+	maxDelayMilliseconds = int64(1<<63-1) / int64(time.Millisecond)
 )
 
 // Tool exposes the scheduler to the model.
@@ -77,7 +83,10 @@ func (t *Tool) Declaration() *tool.Declaration {
 			"becomes a future agent turn. If channel/target are " +
 			"omitted when adding a job from chat, the final " +
 			"result is delivered back to the current chat when " +
-			"possible. Use max_runs for bounded repeats, " +
+			"possible. For one-shot relative reminders, use " +
+			"after or delay instead of calculating an absolute " +
+			"at timestamp yourself. Use every only for " +
+			"recurring jobs, max_runs for bounded repeats, " +
 			"ends_at for a stop time, and overlap_policy to " +
 			"control what happens when one run is still busy. " +
 			cronTemplateHint + " " +
@@ -127,8 +136,10 @@ func (t *Tool) Declaration() *tool.Declaration {
 					Description: "Whether the job is enabled.",
 				},
 				"schedule_kind": {
-					Type:        "string",
-					Description: "at, every, or cron.",
+					Type: "string",
+					Description: "at, after, every, or cron. " +
+						"after is an alias for at when " +
+						"used with after or delay.",
 				},
 				"at": {
 					Type: "string",
@@ -146,7 +157,8 @@ func (t *Tool) Declaration() *tool.Declaration {
 				"every": {
 					Type: "string",
 					Description: "Duration like 1m, 2h, or " +
-						"24h for recurring jobs.",
+						"24h for recurring jobs. Do not use " +
+						"for one-shot reminders.",
 				},
 				"interval": {
 					Type:        "string",
@@ -165,6 +177,34 @@ func (t *Tool) Declaration() *tool.Declaration {
 					Type:        "number",
 					Description: "Alias for every_ms.",
 				},
+				"after": {
+					Type: "string",
+					Description: "One-shot relative delay " +
+						"duration like 30m, 2h, or 24h. " +
+						"Creates an at schedule from the " +
+						"service clock.",
+				},
+				"delay": {
+					Type:        "string",
+					Description: "Alias for after.",
+				},
+				"after_ms": {
+					Type: "number",
+					Description: "Alias one-shot relative " +
+						"delay in milliseconds.",
+				},
+				"delay_ms": {
+					Type:        "number",
+					Description: "Alias for after_ms.",
+				},
+				"afterMs": {
+					Type:        "number",
+					Description: "Alias for after_ms.",
+				},
+				"delayMs": {
+					Type:        "number",
+					Description: "Alias for after_ms.",
+				},
 				"cron_expr": {
 					Type: "string",
 					Description: "Cron expression with 5 or " +
@@ -177,7 +217,8 @@ func (t *Tool) Declaration() *tool.Declaration {
 				"timezone": {
 					Type: "string",
 					Description: "Optional IANA timezone for " +
-						"cron schedules.",
+						"cron schedules. Ignored for " +
+						"relative after/delay schedules.",
 				},
 				"max_runs": {
 					Type: "number",
@@ -257,6 +298,12 @@ type toolInput struct {
 	Duration     string `json:"duration,omitempty"`
 	EveryMS      *int64 `json:"every_ms,omitempty"`
 	EveryMSOld   *int64 `json:"everyMs,omitempty"`
+	After        string `json:"after,omitempty"`
+	Delay        string `json:"delay,omitempty"`
+	AfterMS      *int64 `json:"after_ms,omitempty"`
+	DelayMS      *int64 `json:"delay_ms,omitempty"`
+	AfterMSOld   *int64 `json:"afterMs,omitempty"`
+	DelayMSOld   *int64 `json:"delayMs,omitempty"`
 	CronExpr     string `json:"cron_expr,omitempty"`
 	CronExprOld  string `json:"cronExpr,omitempty"`
 	Timezone     string `json:"timezone,omitempty"`
@@ -346,11 +393,15 @@ func (t *Tool) add(
 		Name:       in.Name,
 		Message:    resolveMessage(in),
 		Enabled:    true,
-		Schedule:   scheduleFromInput(in),
 		Policy:     policy,
 		UserID:     userID,
 		TimeoutSec: firstIntValue(in.TimeoutSec, in.TimeoutOld),
 	}
+	schedule, err := scheduleFromInput(in, t.svc.clock())
+	if err != nil {
+		return nil, err
+	}
+	job.Schedule = schedule
 	if in.Enabled != nil {
 		job.Enabled = *in.Enabled
 	}
@@ -408,8 +459,16 @@ func (t *Tool) update(
 		patch.Enabled = in.Enabled
 	}
 	if hasScheduleInput(in) {
-		schedule := scheduleFromInput(in)
-		patch.Schedule = &schedule
+		if hasOnlyTimezoneScheduleInput(in) {
+			timezone := strings.TrimSpace(in.Timezone)
+			patch.ScheduleTimezone = &timezone
+		} else {
+			schedule, err := scheduleFromInput(in, t.svc.clock())
+			if err != nil {
+				return nil, err
+			}
+			patch.Schedule = &schedule
+		}
 	}
 	if hasPolicyInput(in) {
 		policy, err := policyFromInputWithError(in)
@@ -500,11 +559,18 @@ func (t *Tool) runNow(
 	return job, nil
 }
 
-func scheduleFromInput(in toolInput) Schedule {
-	at := resolveAt(in)
+func scheduleFromInput(in toolInput, now time.Time) (Schedule, error) {
+	at, err := resolveAt(in, now)
+	if err != nil {
+		return Schedule{}, err
+	}
 	every := resolveEvery(in)
 	everyMS := firstInt64Value(in.EveryMS, in.EveryMSOld)
 	cronExpr := firstString(in.CronExpr, in.CronExprOld)
+	timezone := strings.TrimSpace(in.Timezone)
+	if hasDelayInput(in) {
+		timezone = ""
+	}
 	return Schedule{
 		Kind: resolveScheduleKind(
 			in.ScheduleKind,
@@ -517,8 +583,8 @@ func scheduleFromInput(in toolInput) Schedule {
 		Every:    every,
 		EveryMS:  everyMS,
 		CronExpr: cronExpr,
-		Timezone: strings.TrimSpace(in.Timezone),
-	}
+		Timezone: timezone,
+	}, nil
 }
 
 func policyFromInputWithError(
@@ -549,7 +615,7 @@ func resolveScheduleKind(
 	everyMS int64,
 	cronExpr string,
 ) string {
-	kind = strings.TrimSpace(kind)
+	kind = normalizeScheduleKind(kind)
 	if kind != "" {
 		return kind
 	}
@@ -569,12 +635,109 @@ func resolveMessage(in toolInput) string {
 	return firstString(in.Message, in.Prompt, in.Task)
 }
 
-func resolveAt(in toolInput) string {
-	return firstString(in.At, in.RunAt, in.RunAtOld)
+func resolveAt(in toolInput, now time.Time) (string, error) {
+	delay, hasDelay, err := resolveDelay(in)
+	if err != nil {
+		return "", err
+	}
+	at := firstString(in.At, in.RunAt, in.RunAtOld)
+	if !hasDelay {
+		return at, nil
+	}
+	if hasNonDelayScheduleInput(in) {
+		return "", fmt.Errorf(errAfterWithSchedule)
+	}
+	if kind := normalizeScheduleKind(in.ScheduleKind); kind != "" &&
+		kind != ScheduleKindAt {
+		return "", fmt.Errorf(
+			"cron: schedule_kind must be empty, at, or after "+
+				"when using after, got %s",
+			in.ScheduleKind,
+		)
+	}
+	return now.Add(delay).Format(time.RFC3339Nano), nil
 }
 
 func resolveEvery(in toolInput) string {
 	return firstString(in.Every, in.Interval, in.Duration)
+}
+
+func resolveDelay(in toolInput) (time.Duration, bool, error) {
+	value, hasValue, err := delayDurationInput(in.After, in.Delay)
+	if err != nil {
+		return 0, false, err
+	}
+	ms, hasMS, err := delayMillisecondsInput(
+		in.AfterMS,
+		in.DelayMS,
+		in.AfterMSOld,
+		in.DelayMSOld,
+	)
+	if err != nil {
+		return 0, false, err
+	}
+	switch {
+	case value != "" && hasMS:
+		return 0, false, fmt.Errorf(
+			"cron: after and after_ms cannot both be set",
+		)
+	case hasValue:
+		delay, err := time.ParseDuration(value)
+		if err != nil {
+			return 0, false, fmt.Errorf(
+				"cron: invalid after delay: %w",
+				err,
+			)
+		}
+		if delay <= 0 {
+			return 0, false, fmt.Errorf(
+				"cron: after delay must be positive",
+			)
+		}
+		return delay, true, nil
+	case hasMS:
+		if ms <= 0 {
+			return 0, false, fmt.Errorf(
+				"cron: after_ms delay must be positive",
+			)
+		}
+		if ms > maxDelayMilliseconds {
+			return 0, false, fmt.Errorf(errAfterMSDelayTooLarge)
+		}
+		return time.Duration(ms) * time.Millisecond, true, nil
+	default:
+		return 0, false, nil
+	}
+}
+
+func delayDurationInput(after string, delay string) (string, bool, error) {
+	hasAfter := strings.TrimSpace(after) != ""
+	hasDelay := strings.TrimSpace(delay) != ""
+	if hasAfter && hasDelay {
+		return "", false, fmt.Errorf(errAfterAliasConflict)
+	}
+	value := firstString(after, delay)
+	return value, value != "", nil
+}
+
+func delayMillisecondsInput(values ...*int64) (int64, bool, error) {
+	var selected int64
+	count := 0
+	for _, value := range values {
+		if value == nil {
+			continue
+		}
+		if count == 0 {
+			selected = *value
+		}
+		count++
+	}
+	if count > 1 {
+		return 0, false, fmt.Errorf(
+			"cron: only one after_ms alias can be set",
+		)
+	}
+	return selected, count == 1, nil
 }
 
 func resolveEndsAt(in toolInput) string {
@@ -680,14 +843,41 @@ func isScheduledRunMutation(ctx context.Context, action string) bool {
 }
 
 func hasScheduleInput(in toolInput) bool {
+	return hasScheduleCoreInput(in) ||
+		strings.TrimSpace(in.Timezone) != ""
+}
+
+func hasScheduleCoreInput(in toolInput) bool {
 	return strings.TrimSpace(in.ScheduleKind) != "" ||
-		resolveAt(in) != "" ||
+		firstString(in.At, in.RunAt, in.RunAtOld) != "" ||
+		resolveEvery(in) != "" ||
+		in.EveryMS != nil ||
+		in.EveryMSOld != nil ||
+		hasDelayInput(in) ||
+		strings.TrimSpace(in.CronExpr) != "" ||
+		strings.TrimSpace(in.CronExprOld) != ""
+}
+
+func hasOnlyTimezoneScheduleInput(in toolInput) bool {
+	return strings.TrimSpace(in.Timezone) != "" &&
+		!hasScheduleCoreInput(in)
+}
+
+func hasDelayInput(in toolInput) bool {
+	return firstString(in.After, in.Delay) != "" ||
+		in.AfterMS != nil ||
+		in.DelayMS != nil ||
+		in.AfterMSOld != nil ||
+		in.DelayMSOld != nil
+}
+
+func hasNonDelayScheduleInput(in toolInput) bool {
+	return firstString(in.At, in.RunAt, in.RunAtOld) != "" ||
 		resolveEvery(in) != "" ||
 		in.EveryMS != nil ||
 		in.EveryMSOld != nil ||
 		strings.TrimSpace(in.CronExpr) != "" ||
-		strings.TrimSpace(in.CronExprOld) != "" ||
-		strings.TrimSpace(in.Timezone) != ""
+		strings.TrimSpace(in.CronExprOld) != ""
 }
 
 func hasPolicyInput(in toolInput) bool {

--- a/openclaw/internal/cron/tool_test.go
+++ b/openclaw/internal/cron/tool_test.go
@@ -337,10 +337,12 @@ func TestToolAddFailsWithoutResolvableDeliveryTarget(t *testing.T) {
 func TestToolAddSupportsRunAtAlias(t *testing.T) {
 	t.Parallel()
 
+	now := time.Date(2026, 3, 7, 8, 0, 0, 0, time.FixedZone("CST", 8*60*60))
 	svc, err := NewService(
 		t.TempDir(),
 		&stubRunner{reply: "ok"},
 		outbound.NewRouter(),
+		WithClock(func() time.Time { return now }),
 	)
 	require.NoError(t, err)
 
@@ -371,6 +373,605 @@ func TestToolAddSupportsRunAtAlias(t *testing.T) {
 	require.Equal(t, "send a reminder", job.Message)
 	require.Equal(t, ScheduleKindAt, job.Schedule.Kind)
 	require.Equal(t, "2026-03-07T09:00:00+08:00", job.Schedule.At)
+}
+
+func TestToolAddSupportsRelativeDelayOneShot(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 15, 11, 3, 0, 0, time.FixedZone("CST", 8*60*60))
+	svc, err := NewService(
+		t.TempDir(),
+		&stubRunner{reply: "ok"},
+		outbound.NewRouter(),
+		WithClock(func() time.Time { return now }),
+	)
+	require.NoError(t, err)
+
+	tool := NewTool(svc)
+	ctx := agent.NewInvocationContext(
+		context.Background(),
+		&agent.Invocation{
+			Session: &session.Session{
+				ID:     "telegram:dm:12345",
+				UserID: "user-1",
+			},
+		},
+	)
+
+	args, err := json.Marshal(map[string]any{
+		"action":  "add",
+		"message": "send a reminder",
+		"after":   "30m",
+	})
+	require.NoError(t, err)
+
+	result, err := tool.Call(ctx, args)
+	require.NoError(t, err)
+
+	job, ok := result.(*Job)
+	require.True(t, ok)
+	expectedAt := now.Add(30 * time.Minute)
+	require.Equal(t, ScheduleKindAt, job.Schedule.Kind)
+	require.Equal(t, expectedAt.Format(time.RFC3339), job.Schedule.At)
+	require.NotNil(t, job.NextRunAt)
+	require.True(t, job.NextRunAt.Equal(expectedAt))
+	require.Equal(t, "send a reminder", job.Message)
+}
+
+func TestToolAddSupportsMillisecondRelativeDelay(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(
+		2026,
+		time.May,
+		15,
+		11,
+		3,
+		0,
+		int(250*time.Millisecond),
+		time.FixedZone("CST", 8*60*60),
+	)
+	svc, err := NewService(
+		t.TempDir(),
+		&stubRunner{reply: "ok"},
+		outbound.NewRouter(),
+		WithClock(func() time.Time { return now }),
+	)
+	require.NoError(t, err)
+
+	tool := NewTool(svc)
+	ctx := agent.NewInvocationContext(
+		context.Background(),
+		&agent.Invocation{
+			Session: &session.Session{
+				ID:     "telegram:dm:12345",
+				UserID: "user-1",
+			},
+		},
+	)
+
+	delayMS := int64(1500)
+	args, err := json.Marshal(map[string]any{
+		"action":  "add",
+		"message": "send a reminder",
+		"delayMs": delayMS,
+	})
+	require.NoError(t, err)
+
+	result, err := tool.Call(ctx, args)
+	require.NoError(t, err)
+
+	job, ok := result.(*Job)
+	require.True(t, ok)
+	expectedAt := now.Add(time.Duration(delayMS) * time.Millisecond)
+	require.Equal(t, expectedAt.Format(time.RFC3339Nano), job.Schedule.At)
+	require.NotNil(t, job.NextRunAt)
+	require.True(t, job.NextRunAt.Equal(expectedAt))
+}
+
+func TestToolAddRejectsOverflowingMillisecondDelay(t *testing.T) {
+	t.Parallel()
+
+	svc, err := NewService(
+		t.TempDir(),
+		&stubRunner{reply: "ok"},
+		outbound.NewRouter(),
+	)
+	require.NoError(t, err)
+
+	tool := NewTool(svc)
+	ctx := agent.NewInvocationContext(
+		context.Background(),
+		&agent.Invocation{
+			Session: &session.Session{
+				ID:     "telegram:dm:12345",
+				UserID: "user-1",
+			},
+		},
+	)
+
+	args, err := json.Marshal(map[string]any{
+		"action":   "add",
+		"message":  "send a reminder",
+		"delay_ms": maxDelayMilliseconds + 1,
+	})
+	require.NoError(t, err)
+
+	_, err = tool.Call(ctx, args)
+	require.ErrorContains(t, err, errAfterMSDelayTooLarge)
+}
+
+func TestToolAddSupportsFractionalRelativeDelay(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 15, 11, 3, 0, 0, time.FixedZone("CST", 8*60*60))
+	svc, err := NewService(
+		t.TempDir(),
+		&stubRunner{reply: "ok"},
+		outbound.NewRouter(),
+		WithClock(func() time.Time { return now }),
+	)
+	require.NoError(t, err)
+
+	tool := NewTool(svc)
+	ctx := agent.NewInvocationContext(
+		context.Background(),
+		&agent.Invocation{
+			Session: &session.Session{
+				ID:     "telegram:dm:12345",
+				UserID: "user-1",
+			},
+		},
+	)
+
+	args, err := json.Marshal(map[string]any{
+		"action":  "add",
+		"message": "send a reminder",
+		"after":   "1.5s",
+	})
+	require.NoError(t, err)
+
+	result, err := tool.Call(ctx, args)
+	require.NoError(t, err)
+
+	job, ok := result.(*Job)
+	require.True(t, ok)
+	expectedAt := now.Add(1500 * time.Millisecond)
+	require.Equal(t, expectedAt.Format(time.RFC3339Nano), job.Schedule.At)
+	require.NotNil(t, job.NextRunAt)
+	require.True(t, job.NextRunAt.Equal(expectedAt))
+}
+
+func TestToolAddSupportsRelativeDelayAliases(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(
+		2026,
+		time.May,
+		15,
+		11,
+		3,
+		0,
+		int(250*time.Millisecond),
+		time.FixedZone("CST", 8*60*60),
+	)
+	svc, err := NewService(
+		t.TempDir(),
+		&stubRunner{reply: "ok"},
+		outbound.NewRouter(),
+		WithClock(func() time.Time { return now }),
+	)
+	require.NoError(t, err)
+
+	tool := NewTool(svc)
+	ctx := agent.NewInvocationContext(
+		context.Background(),
+		&agent.Invocation{
+			Session: &session.Session{
+				ID:     "telegram:dm:12345",
+				UserID: "user-1",
+			},
+		},
+	)
+
+	delayMS := int64(750)
+	args, err := json.Marshal(map[string]any{
+		"action":        "add",
+		"message":       "send a reminder",
+		"schedule_kind": ScheduleKindAfter,
+		"afterMs":       delayMS,
+	})
+	require.NoError(t, err)
+
+	result, err := tool.Call(ctx, args)
+	require.NoError(t, err)
+
+	job, ok := result.(*Job)
+	require.True(t, ok)
+	expectedAt := now.Add(time.Duration(delayMS) * time.Millisecond)
+	require.Equal(t, ScheduleKindAt, job.Schedule.Kind)
+	require.Equal(t, expectedAt.Format(time.RFC3339Nano), job.Schedule.At)
+	require.NotNil(t, job.NextRunAt)
+	require.True(t, job.NextRunAt.Equal(expectedAt))
+}
+
+func TestToolAddRejectsInvalidRelativeDelayInputs(t *testing.T) {
+	t.Parallel()
+
+	svc, err := NewService(
+		t.TempDir(),
+		&stubRunner{reply: "ok"},
+		outbound.NewRouter(),
+	)
+	require.NoError(t, err)
+
+	tool := NewTool(svc)
+	ctx := agent.NewInvocationContext(
+		context.Background(),
+		&agent.Invocation{
+			Session: &session.Session{
+				ID:     "telegram:dm:12345",
+				UserID: "user-1",
+			},
+		},
+	)
+
+	const reminderMessage = "send a reminder"
+	tests := []struct {
+		name     string
+		args     map[string]any
+		errorMsg string
+	}{
+		{
+			name: "duration and milliseconds",
+			args: map[string]any{
+				"after":    "30m",
+				"after_ms": int64(1000),
+			},
+			errorMsg: "cron: after and after_ms cannot both be set",
+		},
+		{
+			name: "duplicate millisecond aliases",
+			args: map[string]any{
+				"after_ms": int64(1000),
+				"delayMs":  int64(2000),
+			},
+			errorMsg: "cron: only one after_ms alias can be set",
+		},
+		{
+			name: "duplicate duration aliases",
+			args: map[string]any{
+				"after": "30m",
+				"delay": "20m",
+			},
+			errorMsg: errAfterAliasConflict,
+		},
+		{
+			name: "invalid duration",
+			args: map[string]any{
+				"after": "tomorrow",
+			},
+			errorMsg: "cron: invalid after delay",
+		},
+		{
+			name: "zero duration",
+			args: map[string]any{
+				"delay": "0s",
+			},
+			errorMsg: "cron: after delay must be positive",
+		},
+		{
+			name: "zero milliseconds",
+			args: map[string]any{
+				"after_ms": int64(0),
+			},
+			errorMsg: "cron: after_ms delay must be positive",
+		},
+		{
+			name: "recurring schedule kind",
+			args: map[string]any{
+				"after":         "30m",
+				"schedule_kind": ScheduleKindEvery,
+			},
+			errorMsg: "cron: schedule_kind must be empty, at, or after",
+		},
+		{
+			name: "absolute schedule",
+			args: map[string]any{
+				"after": "30m",
+				"at":    "2026-05-15T12:00:00+08:00",
+			},
+			errorMsg: errAfterWithSchedule,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			args := map[string]any{
+				"action":  "add",
+				"message": reminderMessage,
+			}
+			for key, value := range tt.args {
+				args[key] = value
+			}
+			payload, err := json.Marshal(args)
+			require.NoError(t, err)
+
+			_, err = tool.Call(ctx, payload)
+			require.ErrorContains(t, err, tt.errorMsg)
+		})
+	}
+}
+
+func TestToolAddKeepsPastRunAtCompatibility(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 15, 11, 3, 0, 0, time.FixedZone("CST", 8*60*60))
+	svc, err := NewService(
+		t.TempDir(),
+		&stubRunner{reply: "ok"},
+		outbound.NewRouter(),
+		WithClock(func() time.Time { return now }),
+	)
+	require.NoError(t, err)
+
+	tool := NewTool(svc)
+	ctx := agent.NewInvocationContext(
+		context.Background(),
+		&agent.Invocation{
+			Session: &session.Session{
+				ID:     "telegram:dm:12345",
+				UserID: "user-1",
+			},
+		},
+	)
+
+	args, err := json.Marshal(map[string]any{
+		"action": "add",
+		"prompt": "send a reminder",
+		"run_at": "2026-05-15T09:52:25+08:00",
+	})
+	require.NoError(t, err)
+
+	result, err := tool.Call(ctx, args)
+	require.NoError(t, err)
+
+	job, ok := result.(*Job)
+	require.True(t, ok)
+	pastAt, err := time.Parse(time.RFC3339, "2026-05-15T09:52:25+08:00")
+	require.NoError(t, err)
+	require.Equal(t, ScheduleKindAt, job.Schedule.Kind)
+	require.Equal(t, pastAt.Format(time.RFC3339), job.Schedule.At)
+	require.NotNil(t, job.NextRunAt)
+	require.True(t, job.NextRunAt.Equal(pastAt))
+}
+
+func TestToolAddRejectsAfterWithRecurringSchedule(t *testing.T) {
+	t.Parallel()
+
+	svc, err := NewService(
+		t.TempDir(),
+		&stubRunner{reply: "ok"},
+		outbound.NewRouter(),
+	)
+	require.NoError(t, err)
+
+	tool := NewTool(svc)
+	ctx := agent.NewInvocationContext(
+		context.Background(),
+		&agent.Invocation{
+			Session: &session.Session{
+				ID:     "telegram:dm:12345",
+				UserID: "user-1",
+			},
+		},
+	)
+	args, err := json.Marshal(map[string]any{
+		"action":  "add",
+		"message": "send a reminder",
+		"after":   "30m",
+		"every":   "30m",
+	})
+	require.NoError(t, err)
+
+	_, err = tool.Call(ctx, args)
+	require.ErrorContains(t, err, errAfterWithSchedule)
+}
+
+func TestToolAddAllowsDelayWithTimezone(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 15, 11, 3, 0, 0, time.FixedZone("CST", 8*60*60))
+	svc, err := NewService(
+		t.TempDir(),
+		&stubRunner{reply: "ok"},
+		outbound.NewRouter(),
+		WithClock(func() time.Time { return now }),
+	)
+	require.NoError(t, err)
+
+	tool := NewTool(svc)
+	ctx := agent.NewInvocationContext(
+		context.Background(),
+		&agent.Invocation{
+			Session: &session.Session{
+				ID:     "telegram:dm:12345",
+				UserID: "user-1",
+			},
+		},
+	)
+	args, err := json.Marshal(map[string]any{
+		"action":   "add",
+		"message":  "send a reminder",
+		"delay":    "30m",
+		"timezone": "Asia/Shanghai",
+	})
+	require.NoError(t, err)
+
+	result, err := tool.Call(ctx, args)
+	require.NoError(t, err)
+
+	job, ok := result.(*Job)
+	require.True(t, ok)
+	require.Equal(t, ScheduleKindAt, job.Schedule.Kind)
+	require.Empty(t, job.Schedule.Timezone)
+	require.Equal(
+		t,
+		now.Add(30*time.Minute).Format(time.RFC3339),
+		job.Schedule.At,
+	)
+}
+
+func TestToolUpdateTimezonePreservesExistingSchedule(t *testing.T) {
+	t.Parallel()
+
+	svc, err := NewService(
+		t.TempDir(),
+		&stubRunner{reply: "ok"},
+		outbound.NewRouter(),
+	)
+	require.NoError(t, err)
+
+	job, err := svc.Add(&Job{
+		Name:    "mine",
+		Enabled: true,
+		Schedule: Schedule{
+			Kind:     ScheduleKindCron,
+			CronExpr: "0 9 * * *",
+		},
+		Message: "send a reminder",
+		UserID:  "user-1",
+	})
+	require.NoError(t, err)
+
+	tool := NewTool(svc)
+	ctx := agent.NewInvocationContext(
+		context.Background(),
+		&agent.Invocation{
+			Session: &session.Session{
+				ID:     "telegram:dm:12345",
+				UserID: "user-1",
+			},
+		},
+	)
+	args, err := json.Marshal(map[string]any{
+		"action":   "update",
+		"job_id":   job.ID,
+		"timezone": "UTC",
+	})
+	require.NoError(t, err)
+
+	result, err := tool.Call(ctx, args)
+	require.NoError(t, err)
+
+	updated, ok := result.(*Job)
+	require.True(t, ok)
+	require.Equal(t, ScheduleKindCron, updated.Schedule.Kind)
+	require.Equal(t, "0 9 * * *", updated.Schedule.CronExpr)
+	require.Equal(t, "UTC", updated.Schedule.Timezone)
+}
+
+func TestToolUpdateSupportsRelativeDelay(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 15, 11, 3, 0, 0, time.FixedZone("CST", 8*60*60))
+	svc, err := NewService(
+		t.TempDir(),
+		&stubRunner{reply: "ok"},
+		outbound.NewRouter(),
+		WithClock(func() time.Time { return now }),
+	)
+	require.NoError(t, err)
+
+	job, err := svc.Add(&Job{
+		Name:    "mine",
+		Enabled: true,
+		Schedule: Schedule{
+			Kind:  ScheduleKindEvery,
+			Every: "1m",
+		},
+		Message: "send a reminder",
+		UserID:  "user-1",
+	})
+	require.NoError(t, err)
+
+	tool := NewTool(svc)
+	ctx := agent.NewInvocationContext(
+		context.Background(),
+		&agent.Invocation{
+			Session: &session.Session{
+				ID:     "telegram:dm:12345",
+				UserID: "user-1",
+			},
+		},
+	)
+	args, err := json.Marshal(map[string]any{
+		"action": "update",
+		"job_id": job.ID,
+		"after":  "30m",
+	})
+	require.NoError(t, err)
+
+	result, err := tool.Call(ctx, args)
+	require.NoError(t, err)
+
+	updated, ok := result.(*Job)
+	require.True(t, ok)
+	require.Equal(t, ScheduleKindAt, updated.Schedule.Kind)
+	require.Equal(
+		t,
+		now.Add(30*time.Minute).Format(time.RFC3339),
+		updated.Schedule.At,
+	)
+}
+
+func TestToolUpdateRejectsInvalidRelativeDelay(t *testing.T) {
+	t.Parallel()
+
+	svc, err := NewService(
+		t.TempDir(),
+		&stubRunner{reply: "ok"},
+		outbound.NewRouter(),
+	)
+	require.NoError(t, err)
+
+	job, err := svc.Add(&Job{
+		Name:    "mine",
+		Enabled: true,
+		Schedule: Schedule{
+			Kind:  ScheduleKindEvery,
+			Every: "1m",
+		},
+		Message: "send a reminder",
+		UserID:  "user-1",
+	})
+	require.NoError(t, err)
+
+	tool := NewTool(svc)
+	ctx := agent.NewInvocationContext(
+		context.Background(),
+		&agent.Invocation{
+			Session: &session.Session{
+				ID:     "telegram:dm:12345",
+				UserID: "user-1",
+			},
+		},
+	)
+	args, err := json.Marshal(map[string]any{
+		"action":        "update",
+		"job_id":        job.ID,
+		"after":         "30m",
+		"schedule_kind": ScheduleKindEvery,
+	})
+	require.NoError(t, err)
+
+	_, err = tool.Call(ctx, args)
+	require.ErrorContains(
+		t,
+		err,
+		"cron: schedule_kind must be empty, at, or after",
+	)
 }
 
 func TestToolAddInfersScheduleKindFromEvery(t *testing.T) {
@@ -723,7 +1324,9 @@ func TestTool_StatusUpdateRunAndHelpers(t *testing.T) {
 		Task: " message ",
 	}))
 	require.Equal(t, "1m", resolveEvery(toolInput{Duration: " 1m "}))
-	require.Equal(t, "2026", resolveAt(toolInput{RunAt: "2026"}))
+	at, err := resolveAt(toolInput{RunAt: "2026"}, time.Now())
+	require.NoError(t, err)
+	require.Equal(t, "2026", at)
 	require.Equal(t, "job-1", resolveJobID(toolInput{JobIDOld: "job-1"}))
 	require.True(t, hasScheduleInput(toolInput{CronExpr: "*/1 * * * *"}))
 	require.Equal(

--- a/openclaw/internal/cron/types.go
+++ b/openclaw/internal/cron/types.go
@@ -20,6 +20,7 @@ import (
 
 const (
 	ScheduleKindAt    = "at"
+	ScheduleKindAfter = "after"
 	ScheduleKindEvery = "every"
 	ScheduleKindCron  = "cron"
 )
@@ -38,6 +39,8 @@ const (
 	runtimeStateRemaining    = "openclaw.cron.remaining_runs"
 	runtimeStateIsFinalRun   = "openclaw.cron.is_final_run"
 )
+
+const cronDeliverySkipMessageToolTarget = "duplicate_message_tool_text"
 
 const cronSessionPrefix = "cron:"
 
@@ -197,9 +200,18 @@ func IsRunSessionID(sessionID string) bool {
 	)
 }
 
+func normalizeScheduleKind(kind string) string {
+	switch value := strings.ToLower(strings.TrimSpace(kind)); value {
+	case ScheduleKindAfter:
+		return ScheduleKindAt
+	default:
+		return value
+	}
+}
+
 // ScheduleSummary returns a stable human-readable schedule summary.
 func ScheduleSummary(schedule Schedule) string {
-	switch strings.ToLower(strings.TrimSpace(schedule.Kind)) {
+	switch normalizeScheduleKind(schedule.Kind) {
 	case ScheduleKindAt:
 		return "at " + strings.TrimSpace(schedule.At)
 	case ScheduleKindEvery:

--- a/openclaw/internal/outbound/record.go
+++ b/openclaw/internal/outbound/record.go
@@ -1,0 +1,143 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package outbound
+
+import (
+	"context"
+	"sync"
+)
+
+type sentTextRecorderContextKey struct{}
+
+// SentTextRecorder tracks successful text sends within one agent run.
+type SentTextRecorder struct {
+	mu      sync.Mutex
+	sent    map[sentTextKey]struct{}
+	targets map[sentTargetKey]struct{}
+}
+
+type sentTextKey struct {
+	Channel string
+	Target  string
+	Text    string
+}
+
+type sentTargetKey struct {
+	Channel string
+	Target  string
+}
+
+// NewSentTextRecorder creates an empty per-run delivery recorder.
+func NewSentTextRecorder() *SentTextRecorder {
+	return &SentTextRecorder{
+		sent:    make(map[sentTextKey]struct{}),
+		targets: make(map[sentTargetKey]struct{}),
+	}
+}
+
+// WithSentTextRecorder attaches a per-run recorder to a context.
+func WithSentTextRecorder(
+	ctx context.Context,
+	recorder *SentTextRecorder,
+) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if recorder == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, sentTextRecorderContextKey{}, recorder)
+}
+
+// Record stores a successful text delivery.
+func (r *SentTextRecorder) Record(target DeliveryTarget, text string) {
+	key, ok := sentTextKeyFor(target, text)
+	if r == nil || !ok {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.sent == nil {
+		r.sent = make(map[sentTextKey]struct{})
+	}
+	if r.targets == nil {
+		r.targets = make(map[sentTargetKey]struct{})
+	}
+	r.sent[key] = struct{}{}
+	r.targets[sentTargetKey{
+		Channel: key.Channel,
+		Target:  key.Target,
+	}] = struct{}{}
+}
+
+// Contains reports whether the exact text target was already delivered.
+func (r *SentTextRecorder) Contains(
+	target DeliveryTarget,
+	text string,
+) bool {
+	key, ok := sentTextKeyFor(target, text)
+	if r == nil || !ok {
+		return false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	_, ok = r.sent[key]
+	return ok
+}
+
+// ContainsTarget reports whether any text was delivered to the target.
+func (r *SentTextRecorder) ContainsTarget(target DeliveryTarget) bool {
+	key, ok := sentTargetKeyFor(target)
+	if r == nil || !ok {
+		return false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	_, ok = r.targets[key]
+	return ok
+}
+
+func sentTextRecorderFromContext(
+	ctx context.Context,
+) (*SentTextRecorder, bool) {
+	if ctx == nil {
+		return nil, false
+	}
+	recorder, ok := ctx.Value(
+		sentTextRecorderContextKey{},
+	).(*SentTextRecorder)
+	return recorder, ok && recorder != nil
+}
+
+func sentTextKeyFor(
+	target DeliveryTarget,
+	text string,
+) (sentTextKey, bool) {
+	targetKey, ok := sentTargetKeyFor(target)
+	if !ok || text == "" {
+		return sentTextKey{}, false
+	}
+	return sentTextKey{
+		Channel: targetKey.Channel,
+		Target:  targetKey.Target,
+		Text:    text,
+	}, true
+}
+
+func sentTargetKeyFor(target DeliveryTarget) (sentTargetKey, bool) {
+	clean := fillTargetFromOpaqueValue(sanitizeTarget(target))
+	if clean.Channel == "" || clean.Target == "" {
+		return sentTargetKey{}, false
+	}
+	return sentTargetKey{
+		Channel: clean.Channel,
+		Target:  clean.Target,
+	}, true
+}

--- a/openclaw/internal/outbound/resolve.go
+++ b/openclaw/internal/outbound/resolve.go
@@ -58,7 +58,7 @@ func ResolveTarget(
 }
 
 func RuntimeStateForTarget(target DeliveryTarget) map[string]any {
-	clean := sanitizeTarget(target)
+	clean := fillTargetFromOpaqueValue(sanitizeTarget(target))
 	if clean.Channel == "" || clean.Target == "" {
 		return nil
 	}
@@ -138,7 +138,8 @@ func fillTargetFromSession(
 	return target
 }
 
-// ResolveTargetFromSessionID infers an outbound target from a chat session id.
+// ResolveTargetFromSessionID infers an outbound target from a chat
+// session id.
 func ResolveTargetFromSessionID(sessionID string) (DeliveryTarget, bool) {
 	if target, ok := telegram.ResolveTextTargetFromSessionID(sessionID); ok {
 		return DeliveryTarget{

--- a/openclaw/internal/outbound/resolve_test.go
+++ b/openclaw/internal/outbound/resolve_test.go
@@ -131,6 +131,112 @@ func TestResolveTarget_RuntimeStateFallback(t *testing.T) {
 	}, target)
 }
 
+func TestSentTextRecorderNormalizesOpaqueTarget(t *testing.T) {
+	t.Parallel()
+
+	recorder := NewSentTextRecorder()
+	recorder.Record(DeliveryTarget{
+		Target: "wecom:thread:wecom:dm:user-1",
+	}, "hello")
+
+	require.True(t, recorder.Contains(DeliveryTarget{
+		Channel: "wecom",
+		Target:  "single:user-1",
+	}, "hello"))
+	require.True(t, recorder.ContainsTarget(DeliveryTarget{
+		Channel: "wecom",
+		Target:  "single:user-1",
+	}))
+	require.False(t, recorder.Contains(DeliveryTarget{
+		Channel: "wecom",
+		Target:  "single:user-1",
+	}, " hello "))
+	require.False(t, recorder.ContainsTarget(DeliveryTarget{
+		Channel: "wecom",
+		Target:  "single:user-2",
+	}))
+	require.False(t, recorder.Contains(DeliveryTarget{
+		Channel: "wecom",
+		Target:  "single:user-2",
+	}, "hello"))
+}
+
+func TestSentTextRecorderHandlesEmptyAndNilInputs(t *testing.T) {
+	t.Parallel()
+
+	var nilRecorder *SentTextRecorder
+	nilRecorder.Record(DeliveryTarget{
+		Channel: "telegram",
+		Target:  "100",
+	}, "hello")
+	require.False(t, nilRecorder.Contains(DeliveryTarget{
+		Channel: "telegram",
+		Target:  "100",
+	}, "hello"))
+	require.False(t, nilRecorder.ContainsTarget(DeliveryTarget{
+		Channel: "telegram",
+		Target:  "100",
+	}))
+
+	recorder := &SentTextRecorder{}
+	recorder.Record(DeliveryTarget{
+		Channel: "telegram",
+		Target:  "100",
+	}, "hello")
+	require.True(t, recorder.Contains(DeliveryTarget{
+		Channel: "telegram",
+		Target:  "100",
+	}, "hello"))
+	require.True(t, recorder.ContainsTarget(DeliveryTarget{
+		Channel: "telegram",
+		Target:  "100",
+	}))
+	require.False(t, recorder.Contains(DeliveryTarget{
+		Channel: "telegram",
+		Target:  "100",
+	}, " "))
+	require.False(t, recorder.ContainsTarget(DeliveryTarget{
+		Channel: "telegram",
+	}))
+	require.False(t, recorder.Contains(DeliveryTarget{
+		Channel: "telegram",
+	}, "hello"))
+}
+
+func TestWithSentTextRecorderSkipsNil(t *testing.T) {
+	t.Parallel()
+
+	ctx := WithSentTextRecorder(context.Background(), nil)
+	_, ok := sentTextRecorderFromContext(ctx)
+	require.False(t, ok)
+
+	recorder := NewSentTextRecorder()
+	ctx = WithSentTextRecorder(nil, recorder)
+	got, ok := sentTextRecorderFromContext(ctx)
+	require.True(t, ok)
+	require.Same(t, recorder, got)
+}
+
+func TestSentTextRecorderFromContextHandlesMissingValues(t *testing.T) {
+	t.Parallel()
+
+	_, ok := sentTextRecorderFromContext(nil)
+	require.False(t, ok)
+
+	_, ok = sentTextRecorderFromContext(context.Background())
+	require.False(t, ok)
+
+	recorder := NewSentTextRecorder()
+	ctx := WithSentTextRecorder(invocationCtx(
+		t,
+		"cron:job-1:1",
+		agent.RunOptions{},
+	), recorder)
+	got, ok := sentTextRecorderFromContext(ctx)
+	require.True(t, ok)
+	require.Same(t, recorder, got)
+}
+
 func TestResolveTarget_SessionFallback(t *testing.T) {
 	ctx := invocationCtx(t, "telegram:thread:999:topic:7", agent.RunOptions{})
 

--- a/openclaw/internal/outbound/tool.go
+++ b/openclaw/internal/outbound/tool.go
@@ -147,12 +147,28 @@ func (t *Tool) Call(ctx context.Context, args []byte) (any, error) {
 	if err := t.router.SendMessage(ctx, target, msg); err != nil {
 		return nil, err
 	}
+	recordSentText(ctx, target, msg)
 	return map[string]any{
 		"ok":         true,
 		"channel":    target.Channel,
 		"target":     target.Target,
 		"files_sent": len(msg.Files),
 	}, nil
+}
+
+func recordSentText(
+	ctx context.Context,
+	target DeliveryTarget,
+	msg channel.OutboundMessage,
+) {
+	if len(msg.Files) > 0 {
+		return
+	}
+	recorder, ok := sentTextRecorderFromContext(ctx)
+	if !ok {
+		return
+	}
+	recorder.Record(target, msg.Text)
 }
 
 func buildOutboundMessage(in toolInput) (channel.OutboundMessage, error) {

--- a/openclaw/internal/outbound/tool_test.go
+++ b/openclaw/internal/outbound/tool_test.go
@@ -124,6 +124,118 @@ func TestTool_Call_ExplicitTargetAndErrors(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestTool_Call_RecordsSentText(t *testing.T) {
+	t.Parallel()
+
+	router := NewRouter()
+	sender := &stubSender{id: "telegram"}
+	router.RegisterSender(sender)
+	router.RegisterMessageSender(sender)
+
+	tool := NewTool(router)
+	recorder := NewSentTextRecorder()
+	ctx := WithSentTextRecorder(invocationCtx(
+		t,
+		"cron:job-1:1",
+		agent.RunOptions{
+			RuntimeState: scheduledTargetRuntimeState(DeliveryTarget{
+				Channel: "telegram",
+				Target:  "100",
+			}),
+		},
+	), recorder)
+
+	result, err := tool.Call(ctx, []byte(`{"text":"implicit target"}`))
+	require.NoError(t, err)
+	require.Equal(t, true, result.(map[string]any)["ok"])
+	require.Equal(t, "implicit target", sender.text)
+	require.True(t, recorder.Contains(DeliveryTarget{
+		Channel: "telegram",
+		Target:  "100",
+	}, "implicit target"))
+	require.True(t, recorder.ContainsTarget(DeliveryTarget{
+		Channel: "telegram",
+		Target:  "100",
+	}))
+
+	result, err = tool.Call(
+		ctx,
+		[]byte(`{"text":"channel only","channel":"telegram"}`),
+	)
+	require.NoError(t, err)
+	require.Equal(t, true, result.(map[string]any)["ok"])
+	require.Equal(t, "channel only", sender.text)
+
+	result, err = tool.Call(
+		ctx,
+		[]byte(`{"text":"target only","target":"100"}`),
+	)
+	require.NoError(t, err)
+	require.Equal(t, true, result.(map[string]any)["ok"])
+	require.Equal(t, "target only", sender.text)
+
+	result, err = tool.Call(
+		ctx,
+		[]byte(`{"text":"same target","channel":"telegram","target":"100"}`),
+	)
+	require.NoError(t, err)
+	require.Equal(t, true, result.(map[string]any)["ok"])
+	require.Equal(t, "same target", sender.text)
+
+	_, err = tool.Call(
+		ctx,
+		[]byte(`{"text":"invalid","channel":"wecom","target":"bad"}`),
+	)
+	require.ErrorContains(t, err, "outbound: invalid target for wecom")
+	require.Equal(t, "same target", sender.text)
+
+	result, err = tool.Call(
+		ctx,
+		[]byte(`{"text":"different target","channel":"telegram","target":"200"}`),
+	)
+	require.NoError(t, err)
+	require.Equal(t, true, result.(map[string]any)["ok"])
+	require.Equal(t, "200", sender.target)
+	require.Equal(t, "different target", sender.text)
+	require.True(t, recorder.Contains(DeliveryTarget{
+		Channel: "telegram",
+		Target:  "200",
+	}, "different target"))
+	require.True(t, recorder.ContainsTarget(DeliveryTarget{
+		Channel: "telegram",
+		Target:  "200",
+	}))
+
+	result, err = tool.Call(
+		ctx,
+		[]byte(`{"text":"target only different","target":"300"}`),
+	)
+	require.NoError(t, err)
+	require.Equal(t, true, result.(map[string]any)["ok"])
+	require.Equal(t, "300", sender.target)
+	require.Equal(t, "target only different", sender.text)
+
+	result, err = tool.Call(
+		ctx,
+		[]byte(`{"text":"report","channel":"telegram","target":"100",
+			"file":"report.pdf"}`),
+	)
+	require.NoError(t, err)
+	require.Equal(t, true, result.(map[string]any)["ok"])
+	require.Equal(t, "100", sender.target)
+	require.Equal(t, "report", sender.text)
+	require.Len(t, sender.files, 1)
+	require.Equal(t, "report.pdf", sender.files[0].Path)
+	require.False(t, recorder.Contains(DeliveryTarget{
+		Channel: "telegram",
+		Target:  "100",
+	}, "report"))
+}
+
+func scheduledTargetRuntimeState(target DeliveryTarget) map[string]any {
+	return RuntimeStateForTarget(target)
+}
+
 func TestTool_Call_SendsFilesWithoutText(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

Adds duration-style one-shot relative scheduling inputs to the OpenClaw cron tool:

- `after` / `delay` for Go duration strings such as `30m` or `1.5s`
- `after_ms` / `delay_ms` plus `afterMs` / `delayMs` for millisecond delays
- accepts `schedule_kind: "after"` as an alias for one-shot delay schedules
- converts relative delays to the existing `at` schedule shape using the service clock
- preserves existing absolute `at` / `run_at` / `runAt` behavior, including due-now semantics for past absolute timestamps
- keeps `every` reserved for recurring jobs and rejects mixed relative-delay plus recurring/absolute schedule inputs
- rejects conflicting duration and millisecond-delay aliases instead of silently choosing one

Also prevents duplicate scheduled reminder delivery when a cron run has already sent a successful pure-text message to the job delivery target through the `message` tool:

- scheduled runs still expose the normal runtime delivery target for compatibility with existing tools, including subagents and channel/target-only message calls
- successful pure-text `message` sends keep their existing behavior and are recorded in the current run via context, not runtime state
- a successful pure-text `message` send to the job delivery target counts as that run's cron delivery, so cron stores the final answer as run output but does not deliver it again
- this covers confirmation-style final answers that differ from the actual reminder text, such as `已在当前聊天中提醒...`
- different-target messages and file/media messages remain allowed
- failed `message` sends do not suppress cron final delivery
- debug traces keep the existing skip reason value `duplicate_message_tool_text` for compatibility

## Why

The WeCom reminder incidents showed two related scheduling issues:

- asking a model to manually compute an absolute RFC3339 timestamp for duration-style requests can produce a past `at` value
- a scheduled reminder run can send once through the `message` tool and then produce a final confirmation that cron delivers again, causing duplicate messages from one job execution

This PR gives callers a generic duration-delay API so they can express "30 minutes later" without doing absolute time arithmetic themselves, and keeps scheduled final delivery from duplicating a same-run same-target successful text send.

This does not attempt to solve broad calendar-relative parsing such as "tomorrow at 9". Those still require caller context and model/tool interpretation.

## Notes

For `after` / `delay`, any submitted `timezone` is accepted for compatibility but is not used or persisted on the generated `at` schedule. The generated RFC3339 timestamp carries the service-clock offset.

The duplicate-delivery guard is scoped to one scheduler run and the job delivery target. It does not deduplicate at the channel transport layer and does not provide durable idempotency across process restarts, multiple scheduler instances, or background subagent runs.

## Validation

- `cd openclaw && go test ./...`
- `cd openclaw && go test -race ./internal/cron ./internal/outbound`
- `cd openclaw && go test -count=1 ./internal/cron ./internal/outbound -coverprofile=/tmp/openclaw_pr1813_target_guard.cover`
- `cd openclaw && go tool cover -func=/tmp/openclaw_pr1813_target_guard.cover` reports total 85.9% for the focused packages
- `git diff --check`
- changed Go line length check for touched Go files