### PR TITLE
knowledge: allow tcvector custom sparse encoder

### DIFF
--- a/docs/mkdocs/en/knowledge/vectorstore/tcvector.md
+++ b/docs/mkdocs/en/knowledge/vectorstore/tcvector.md
@@ -87,7 +87,7 @@ kb := knowledge.New(
 | `WithIndexDimension(dim)` | Vector dimension (must match embedding model) | `1536` |
 | `WithRemoteEmbeddingModel(model)` | Remote embedding model name (e.g., bge-base-zh) | - |
 | `WithEnableTSVector(enabled)` | Enable hybrid retrieval | `true` |
-| `WithSparseEncoder(encoder)` | Use a pre-initialized sparse encoder for keyword and hybrid retrieval | Default BM25 encoder |
+| `WithTCSparseEncoder(encoder)` | Use a pre-initialized sparse encoder for keyword and hybrid retrieval | Default BM25 encoder |
 | `WithHybridSearchWeights(vector, text)` | Hybrid retrieval weights (vector/text) | `0.7, 0.3` |
 | `WithLanguage(lang)` | Text tokenization language (zh/en) | `"en"` |
 
@@ -138,11 +138,11 @@ tcVS, err := vectortcvector.New(
     vectortcvector.WithURL("https://your-tcvector-endpoint"),
     vectortcvector.WithUsername("your-username"),
     vectortcvector.WithPassword("your-password"),
-    vectortcvector.WithSparseEncoder(sparseEncoder),
+    vectortcvector.WithTCSparseEncoder(sparseEncoder),
 )
 ```
 
-`WithSparseEncoder` only replaces the encoder used by TSVector. It does not enable TSVector by itself; keep `WithEnableTSVector(true)` when keyword or hybrid retrieval is required.
+`WithTCSparseEncoder` only replaces the encoder used by TSVector. It does not enable TSVector by itself; keep `WithEnableTSVector(true)` when keyword or hybrid retrieval is required.
 
 ## Filter Support
 

--- a/docs/mkdocs/en/knowledge/vectorstore/tcvector.md
+++ b/docs/mkdocs/en/knowledge/vectorstore/tcvector.md
@@ -125,7 +125,10 @@ kb := knowledge.New(
 When runner or vector store instances are created dynamically, initialize the sparse encoder once and pass it to TcVector to avoid repeated BM25 encoder setup:
 
 ```go
-import "github.com/tencent/vectordatabase-sdk-go/tcvdbtext/encoder"
+import (
+	"github.com/tencent/vectordatabase-sdk-go/tcvdbtext/encoder"
+	vectortcvector "trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/tcvector"
+)
 
 sparseEncoder, err := encoder.NewBM25Encoder(&encoder.BM25EncoderParams{
     Bm25Language: "en",

--- a/docs/mkdocs/en/knowledge/vectorstore/tcvector.md
+++ b/docs/mkdocs/en/knowledge/vectorstore/tcvector.md
@@ -87,6 +87,7 @@ kb := knowledge.New(
 | `WithIndexDimension(dim)` | Vector dimension (must match embedding model) | `1536` |
 | `WithRemoteEmbeddingModel(model)` | Remote embedding model name (e.g., bge-base-zh) | - |
 | `WithEnableTSVector(enabled)` | Enable hybrid retrieval | `true` |
+| `WithSparseEncoder(encoder)` | Use a pre-initialized sparse encoder for keyword and hybrid retrieval | Default BM25 encoder |
 | `WithHybridSearchWeights(vector, text)` | Hybrid retrieval weights (vector/text) | `0.7, 0.3` |
 | `WithLanguage(lang)` | Text tokenization language (zh/en) | `"en"` |
 
@@ -118,6 +119,30 @@ kb := knowledge.New(
 | `WithCreatedAtField(field)` | Created time field name | `"created_at"` |
 | `WithUpdatedAtField(field)` | Updated time field name | `"updated_at"` |
 | `WithSparseVectorField(field)` | Sparse vector field name | `"sparse_vector"` |
+
+### Reusing Sparse Encoders
+
+When runner or vector store instances are created dynamically, initialize the sparse encoder once and pass it to TcVector to avoid repeated BM25 encoder setup:
+
+```go
+import "github.com/tencent/vectordatabase-sdk-go/tcvdbtext/encoder"
+
+sparseEncoder, err := encoder.NewBM25Encoder(&encoder.BM25EncoderParams{
+    Bm25Language: "en",
+})
+if err != nil {
+    // Handle error
+}
+
+tcVS, err := vectortcvector.New(
+    vectortcvector.WithURL("https://your-tcvector-endpoint"),
+    vectortcvector.WithUsername("your-username"),
+    vectortcvector.WithPassword("your-password"),
+    vectortcvector.WithSparseEncoder(sparseEncoder),
+)
+```
+
+`WithSparseEncoder` only replaces the encoder used by TSVector. It does not enable TSVector by itself; keep `WithEnableTSVector(true)` when keyword or hybrid retrieval is required.
 
 ## Filter Support
 

--- a/docs/mkdocs/zh/knowledge/vectorstore/tcvector.md
+++ b/docs/mkdocs/zh/knowledge/vectorstore/tcvector.md
@@ -87,7 +87,7 @@ kb := knowledge.New(
 | `WithIndexDimension(dim)` | 向量维度（需与 embedding 模型匹配） | `1536` |
 | `WithRemoteEmbeddingModel(model)` | 远程 embedding 模型名称（如 bge-base-zh） | - |
 | `WithEnableTSVector(enabled)` | 启用混合检索 | `true` |
-| `WithSparseEncoder(encoder)` | 使用预初始化的稀疏向量编码器进行关键词和混合检索 | 默认 BM25 encoder |
+| `WithTCSparseEncoder(encoder)` | 使用预初始化的稀疏向量编码器进行关键词和混合检索 | 默认 BM25 encoder |
 | `WithHybridSearchWeights(vector, text)` | 混合检索权重（向量/文本） | `0.7, 0.3` |
 | `WithLanguage(lang)` | 文本分词语言（zh/en） | `"en"` |
 
@@ -138,11 +138,11 @@ tcVS, err := vectortcvector.New(
     vectortcvector.WithURL("https://your-tcvector-endpoint"),
     vectortcvector.WithUsername("your-username"),
     vectortcvector.WithPassword("your-password"),
-    vectortcvector.WithSparseEncoder(sparseEncoder),
+    vectortcvector.WithTCSparseEncoder(sparseEncoder),
 )
 ```
 
-`WithSparseEncoder` 只替换 TSVector 使用的 encoder，不会自动开启 TSVector；如果需要关键词或混合检索，仍需保持 `WithEnableTSVector(true)`。
+`WithTCSparseEncoder` 只替换 TSVector 使用的 encoder，不会自动开启 TSVector；如果需要关键词或混合检索，仍需保持 `WithEnableTSVector(true)`。
 
 ## 过滤器支持
 

--- a/docs/mkdocs/zh/knowledge/vectorstore/tcvector.md
+++ b/docs/mkdocs/zh/knowledge/vectorstore/tcvector.md
@@ -125,7 +125,10 @@ kb := knowledge.New(
 当 runner 或 vector store 动态创建时，可以先初始化一次 sparse encoder，再传给 TcVector，避免重复初始化 BM25 encoder：
 
 ```go
-import "github.com/tencent/vectordatabase-sdk-go/tcvdbtext/encoder"
+import (
+	"github.com/tencent/vectordatabase-sdk-go/tcvdbtext/encoder"
+	vectortcvector "trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/tcvector"
+)
 
 sparseEncoder, err := encoder.NewBM25Encoder(&encoder.BM25EncoderParams{
     Bm25Language: "en",

--- a/docs/mkdocs/zh/knowledge/vectorstore/tcvector.md
+++ b/docs/mkdocs/zh/knowledge/vectorstore/tcvector.md
@@ -87,6 +87,7 @@ kb := knowledge.New(
 | `WithIndexDimension(dim)` | 向量维度（需与 embedding 模型匹配） | `1536` |
 | `WithRemoteEmbeddingModel(model)` | 远程 embedding 模型名称（如 bge-base-zh） | - |
 | `WithEnableTSVector(enabled)` | 启用混合检索 | `true` |
+| `WithSparseEncoder(encoder)` | 使用预初始化的稀疏向量编码器进行关键词和混合检索 | 默认 BM25 encoder |
 | `WithHybridSearchWeights(vector, text)` | 混合检索权重（向量/文本） | `0.7, 0.3` |
 | `WithLanguage(lang)` | 文本分词语言（zh/en） | `"en"` |
 
@@ -118,6 +119,30 @@ kb := knowledge.New(
 | `WithCreatedAtField(field)` | 创建时间字段名 | `"created_at"` |
 | `WithUpdatedAtField(field)` | 更新时间字段名 | `"updated_at"` |
 | `WithSparseVectorField(field)` | 稀疏向量字段名 | `"sparse_vector"` |
+
+### 复用稀疏向量编码器
+
+当 runner 或 vector store 动态创建时，可以先初始化一次 sparse encoder，再传给 TcVector，避免重复初始化 BM25 encoder：
+
+```go
+import "github.com/tencent/vectordatabase-sdk-go/tcvdbtext/encoder"
+
+sparseEncoder, err := encoder.NewBM25Encoder(&encoder.BM25EncoderParams{
+    Bm25Language: "en",
+})
+if err != nil {
+    // 处理 error
+}
+
+tcVS, err := vectortcvector.New(
+    vectortcvector.WithURL("https://your-tcvector-endpoint"),
+    vectortcvector.WithUsername("your-username"),
+    vectortcvector.WithPassword("your-password"),
+    vectortcvector.WithSparseEncoder(sparseEncoder),
+)
+```
+
+`WithSparseEncoder` 只替换 TSVector 使用的 encoder，不会自动开启 TSVector；如果需要关键词或混合检索，仍需保持 `WithEnableTSVector(true)`。
 
 ## 过滤器支持
 

--- a/knowledge/vectorstore/tcvector/options.go
+++ b/knowledge/vectorstore/tcvector/options.go
@@ -32,7 +32,7 @@ type options struct {
 	replicas       uint32
 	sharding       uint32
 	enableTSVector bool
-	sparseEncoder  SparseEncoder
+	sparseEncoder  TCSparseEncoder
 	instanceName   string
 	extraOptions   []any
 
@@ -314,8 +314,8 @@ func WithSparseVectorField(field string) Option {
 	}
 }
 
-// WithSparseEncoder sets the sparse encoder for keyword and hybrid search.
-func WithSparseEncoder(sparseEncoder SparseEncoder) Option {
+// WithTCSparseEncoder sets the sparse encoder for keyword and hybrid search.
+func WithTCSparseEncoder(sparseEncoder TCSparseEncoder) Option {
 	return func(o *options) {
 		o.sparseEncoder = sparseEncoder
 	}

--- a/knowledge/vectorstore/tcvector/options.go
+++ b/knowledge/vectorstore/tcvector/options.go
@@ -32,6 +32,7 @@ type options struct {
 	replicas       uint32
 	sharding       uint32
 	enableTSVector bool
+	sparseEncoder  SparseEncoder
 	instanceName   string
 	extraOptions   []any
 
@@ -310,6 +311,13 @@ func WithUpdatedAtField(field string) Option {
 func WithSparseVectorField(field string) Option {
 	return func(o *options) {
 		o.sparseVectorFieldName = field
+	}
+}
+
+// WithSparseEncoder sets the sparse encoder for keyword and hybrid search.
+func WithSparseEncoder(sparseEncoder SparseEncoder) Option {
+	return func(o *options) {
+		o.sparseEncoder = sparseEncoder
 	}
 }
 

--- a/knowledge/vectorstore/tcvector/options_test.go
+++ b/knowledge/vectorstore/tcvector/options_test.go
@@ -113,6 +113,11 @@ func TestAllOptions(t *testing.T) {
 	// Test WithSparseVectorField
 	WithSparseVectorField("custom_sparse")(&opt)
 	assert.Equal(t, "custom_sparse", opt.sparseVectorFieldName)
+
+	// Test WithSparseEncoder
+	sparseEncoder := newMockSparseEncoder()
+	WithSparseEncoder(sparseEncoder)(&opt)
+	assert.Same(t, sparseEncoder, opt.sparseEncoder)
 }
 
 // TestOptionsDefaults verifies default option values

--- a/knowledge/vectorstore/tcvector/options_test.go
+++ b/knowledge/vectorstore/tcvector/options_test.go
@@ -114,9 +114,9 @@ func TestAllOptions(t *testing.T) {
 	WithSparseVectorField("custom_sparse")(&opt)
 	assert.Equal(t, "custom_sparse", opt.sparseVectorFieldName)
 
-	// Test WithSparseEncoder
+	// Test WithTCSparseEncoder
 	sparseEncoder := newMockSparseEncoder()
-	WithSparseEncoder(sparseEncoder)(&opt)
+	WithTCSparseEncoder(sparseEncoder)(&opt)
 	assert.Same(t, sparseEncoder, opt.sparseEncoder)
 }
 

--- a/knowledge/vectorstore/tcvector/tcvector.go
+++ b/knowledge/vectorstore/tcvector/tcvector.go
@@ -43,9 +43,8 @@ const (
 	metadataBatchSize = 5000 // Maximum records per batch when querying all metadata
 )
 
-// sparseVecEncoder is an interface for encoding text into sparse vectors for keyword search.
-// This interface abstracts the encoder dependency to make testing easier.
-type sparseVecEncoder interface {
+// SparseEncoder encodes text into sparse vectors for keyword and hybrid search.
+type SparseEncoder interface {
 	// EncodeText encodes a single text into sparse vector format.
 	EncodeText(text string) ([]encoder.SparseVecItem, error)
 	// EncodeQuery encodes a single query into sparse vector format.
@@ -58,7 +57,7 @@ type sparseVecEncoder interface {
 type VectorStore struct {
 	client          storage.ClientInterface
 	option          options
-	sparseEncoder   sparseVecEncoder
+	sparseEncoder   SparseEncoder
 	filterConverter searchfilter.Converter[*tcvectordb.Filter]
 }
 
@@ -101,11 +100,14 @@ func New(opts ...Option) (*VectorStore, error) {
 		return nil, err
 	}
 
-	var sparseEncoder encoder.SparseEncoder
+	var sparseEncoder SparseEncoder
 	if option.enableTSVector {
-		sparseEncoder, err = encoder.NewBM25Encoder(&encoder.BM25EncoderParams{Bm25Language: option.language})
-		if err != nil {
-			return nil, fmt.Errorf("tcvectordb new bm25 encoder: %w", err)
+		sparseEncoder = option.sparseEncoder
+		if sparseEncoder == nil {
+			sparseEncoder, err = encoder.NewBM25Encoder(&encoder.BM25EncoderParams{Bm25Language: option.language})
+			if err != nil {
+				return nil, fmt.Errorf("tcvectordb new bm25 encoder: %w", err)
+			}
 		}
 	}
 

--- a/knowledge/vectorstore/tcvector/tcvector.go
+++ b/knowledge/vectorstore/tcvector/tcvector.go
@@ -43,10 +43,6 @@ const (
 	metadataBatchSize = 5000 // Maximum records per batch when querying all metadata
 )
 
-var newBM25Encoder = func(params *encoder.BM25EncoderParams) (TCSparseEncoder, error) {
-	return encoder.NewBM25Encoder(params)
-}
-
 // TCSparseEncoder encodes text into sparse vectors for keyword and hybrid search.
 type TCSparseEncoder interface {
 	// EncodeText encodes a single text into sparse vector format.
@@ -108,7 +104,7 @@ func New(opts ...Option) (*VectorStore, error) {
 	if option.enableTSVector {
 		sparseEncoder = option.sparseEncoder
 		if sparseEncoder == nil {
-			sparseEncoder, err = newBM25Encoder(&encoder.BM25EncoderParams{Bm25Language: option.language})
+			sparseEncoder, err = encoder.NewBM25Encoder(&encoder.BM25EncoderParams{Bm25Language: option.language})
 			if err != nil {
 				return nil, fmt.Errorf("tcvectordb new bm25 encoder: %w", err)
 			}

--- a/knowledge/vectorstore/tcvector/tcvector.go
+++ b/knowledge/vectorstore/tcvector/tcvector.go
@@ -43,6 +43,10 @@ const (
 	metadataBatchSize = 5000 // Maximum records per batch when querying all metadata
 )
 
+var newBM25Encoder = func(params *encoder.BM25EncoderParams) (TCSparseEncoder, error) {
+	return encoder.NewBM25Encoder(params)
+}
+
 // TCSparseEncoder encodes text into sparse vectors for keyword and hybrid search.
 type TCSparseEncoder interface {
 	// EncodeText encodes a single text into sparse vector format.
@@ -104,7 +108,7 @@ func New(opts ...Option) (*VectorStore, error) {
 	if option.enableTSVector {
 		sparseEncoder = option.sparseEncoder
 		if sparseEncoder == nil {
-			sparseEncoder, err = encoder.NewBM25Encoder(&encoder.BM25EncoderParams{Bm25Language: option.language})
+			sparseEncoder, err = newBM25Encoder(&encoder.BM25EncoderParams{Bm25Language: option.language})
 			if err != nil {
 				return nil, fmt.Errorf("tcvectordb new bm25 encoder: %w", err)
 			}

--- a/knowledge/vectorstore/tcvector/tcvector.go
+++ b/knowledge/vectorstore/tcvector/tcvector.go
@@ -43,8 +43,8 @@ const (
 	metadataBatchSize = 5000 // Maximum records per batch when querying all metadata
 )
 
-// SparseEncoder encodes text into sparse vectors for keyword and hybrid search.
-type SparseEncoder interface {
+// TCSparseEncoder encodes text into sparse vectors for keyword and hybrid search.
+type TCSparseEncoder interface {
 	// EncodeText encodes a single text into sparse vector format.
 	EncodeText(text string) ([]encoder.SparseVecItem, error)
 	// EncodeQuery encodes a single query into sparse vector format.
@@ -57,7 +57,7 @@ type SparseEncoder interface {
 type VectorStore struct {
 	client          storage.ClientInterface
 	option          options
-	sparseEncoder   SparseEncoder
+	sparseEncoder   TCSparseEncoder
 	filterConverter searchfilter.Converter[*tcvectordb.Filter]
 }
 
@@ -100,7 +100,7 @@ func New(opts ...Option) (*VectorStore, error) {
 		return nil, err
 	}
 
-	var sparseEncoder SparseEncoder
+	var sparseEncoder TCSparseEncoder
 	if option.enableTSVector {
 		sparseEncoder = option.sparseEncoder
 		if sparseEncoder == nil {

--- a/knowledge/vectorstore/tcvector/tcvector_test.go
+++ b/knowledge/vectorstore/tcvector/tcvector_test.go
@@ -1493,6 +1493,7 @@ func TestNewWithTCSparseEncoder(t *testing.T) {
 			WithDatabase("test_db"),
 			WithCollection("test_collection"),
 			WithIndexDimension(128),
+			WithEnableTSVector(true),
 			WithTCSparseEncoder(sparseEncoder),
 		)
 		if err != nil {
@@ -1510,6 +1511,7 @@ func TestNewWithTCSparseEncoder(t *testing.T) {
 			WithDatabase("test_db"),
 			WithCollection("test_collection"),
 			WithIndexDimension(128),
+			WithEnableTSVector(true),
 			WithLanguage("invalid"),
 		)
 		if err == nil {

--- a/knowledge/vectorstore/tcvector/tcvector_test.go
+++ b/knowledge/vectorstore/tcvector/tcvector_test.go
@@ -13,11 +13,14 @@ import (
 	"context"
 	"errors"
 	"math"
+	"os"
+	"path/filepath"
 	"sort"
 	"sync"
 	"testing"
 	"time"
 
+	tcvdbtext "github.com/tencent/vectordatabase-sdk-go/tcvdbtext"
 	"github.com/tencent/vectordatabase-sdk-go/tcvdbtext/encoder"
 	"github.com/tencent/vectordatabase-sdk-go/tcvectordb"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/document"
@@ -1501,34 +1504,40 @@ func TestNewWithTCSparseEncoder(t *testing.T) {
 	})
 
 	t.Run("creates_default_encoder_when_not_provided", func(t *testing.T) {
-		oldNewBM25Encoder := newBM25Encoder
-		defer func() { newBM25Encoder = oldNewBM25Encoder }()
+		ensureDefaultStopWordsFile(t)
 
-		defaultEncoder := newMockSparseEncoder()
-		var receivedParams *encoder.BM25EncoderParams
-		newBM25Encoder = func(params *encoder.BM25EncoderParams) (TCSparseEncoder, error) {
-			receivedParams = params
-			return defaultEncoder, nil
-		}
-
-		vs, err := New(
+		_, err := New(
 			WithDatabase("test_db"),
 			WithCollection("test_collection"),
 			WithIndexDimension(128),
+			WithLanguage("invalid"),
 		)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+		if err == nil {
+			t.Fatal("expected error but got nil")
 		}
-		if vs.sparseEncoder != defaultEncoder {
-			t.Fatalf("expected default sparse encoder to be used")
-		}
-		if receivedParams == nil {
-			t.Fatal("expected bm25 encoder params")
-		}
-		if receivedParams.Bm25Language != defaultOptions.language {
-			t.Fatalf("expected language %q, got %q", defaultOptions.language, receivedParams.Bm25Language)
+		if !containsString(err.Error(), "tcvectordb new bm25 encoder") {
+			t.Fatalf("expected bm25 encoder error, got: %v", err)
 		}
 	})
+}
+
+func ensureDefaultStopWordsFile(t *testing.T) {
+	t.Helper()
+
+	path := filepath.Join(tcvdbtext.DefaultStorageDir, tcvdbtext.DefaultStopWordsFileName)
+	if _, err := os.Stat(path); err == nil {
+		return
+	} else if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("stat default stop words file: %v", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create default stop words dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("\n"), 0o644); err != nil {
+		t.Fatalf("write default stop words file: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(path) })
 }
 
 // containsString checks if s contains substr.

--- a/knowledge/vectorstore/tcvector/tcvector_test.go
+++ b/knowledge/vectorstore/tcvector/tcvector_test.go
@@ -1484,19 +1484,51 @@ func TestNewWithTCSparseEncoder(t *testing.T) {
 		return newMockClient(), nil
 	})
 
-	sparseEncoder := newMockSparseEncoder()
-	vs, err := New(
-		WithDatabase("test_db"),
-		WithCollection("test_collection"),
-		WithIndexDimension(128),
-		WithTCSparseEncoder(sparseEncoder),
-	)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if vs.sparseEncoder != sparseEncoder {
-		t.Fatalf("expected provided sparse encoder to be used")
-	}
+	t.Run("uses_provided_encoder", func(t *testing.T) {
+		sparseEncoder := newMockSparseEncoder()
+		vs, err := New(
+			WithDatabase("test_db"),
+			WithCollection("test_collection"),
+			WithIndexDimension(128),
+			WithTCSparseEncoder(sparseEncoder),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if vs.sparseEncoder != sparseEncoder {
+			t.Fatalf("expected provided sparse encoder to be used")
+		}
+	})
+
+	t.Run("creates_default_encoder_when_not_provided", func(t *testing.T) {
+		oldNewBM25Encoder := newBM25Encoder
+		defer func() { newBM25Encoder = oldNewBM25Encoder }()
+
+		defaultEncoder := newMockSparseEncoder()
+		var receivedParams *encoder.BM25EncoderParams
+		newBM25Encoder = func(params *encoder.BM25EncoderParams) (TCSparseEncoder, error) {
+			receivedParams = params
+			return defaultEncoder, nil
+		}
+
+		vs, err := New(
+			WithDatabase("test_db"),
+			WithCollection("test_collection"),
+			WithIndexDimension(128),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if vs.sparseEncoder != defaultEncoder {
+			t.Fatalf("expected default sparse encoder to be used")
+		}
+		if receivedParams == nil {
+			t.Fatal("expected bm25 encoder params")
+		}
+		if receivedParams.Bm25Language != defaultOptions.language {
+			t.Fatalf("expected language %q, got %q", defaultOptions.language, receivedParams.Bm25Language)
+		}
+	})
 }
 
 // containsString checks if s contains substr.

--- a/knowledge/vectorstore/tcvector/tcvector_test.go
+++ b/knowledge/vectorstore/tcvector/tcvector_test.go
@@ -1476,6 +1476,29 @@ func TestNewConnectionPriority(t *testing.T) {
 	})
 }
 
+func TestNewWithSparseEncoder(t *testing.T) {
+	oldBuilder := storage.GetClientBuilder()
+	defer func() { storage.SetClientBuilder(oldBuilder) }()
+
+	storage.SetClientBuilder(func(opts ...storage.ClientBuilderOpt) (storage.ClientInterface, error) {
+		return newMockClient(), nil
+	})
+
+	sparseEncoder := newMockSparseEncoder()
+	vs, err := New(
+		WithDatabase("test_db"),
+		WithCollection("test_collection"),
+		WithIndexDimension(128),
+		WithSparseEncoder(sparseEncoder),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if vs.sparseEncoder != sparseEncoder {
+		t.Fatalf("expected provided sparse encoder to be used")
+	}
+}
+
 // containsString checks if s contains substr.
 func containsString(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstring(s, substr))

--- a/knowledge/vectorstore/tcvector/tcvector_test.go
+++ b/knowledge/vectorstore/tcvector/tcvector_test.go
@@ -1476,7 +1476,7 @@ func TestNewConnectionPriority(t *testing.T) {
 	})
 }
 
-func TestNewWithSparseEncoder(t *testing.T) {
+func TestNewWithTCSparseEncoder(t *testing.T) {
 	oldBuilder := storage.GetClientBuilder()
 	defer func() { storage.SetClientBuilder(oldBuilder) }()
 
@@ -1489,7 +1489,7 @@ func TestNewWithSparseEncoder(t *testing.T) {
 		WithDatabase("test_db"),
 		WithCollection("test_collection"),
 		WithIndexDimension(128),
-		WithSparseEncoder(sparseEncoder),
+		WithTCSparseEncoder(sparseEncoder),
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
## Summary
- add tcvector.SparseEncoder and WithSparseEncoder for caller-provided sparse encoders
- reuse a provided encoder during VectorStore construction instead of always creating a BM25 encoder
- add option and constructor coverage

## Validation
- go test ./... in knowledge/vectorstore/tcvector