### PR TITLE
{agent, internal/flow/processor}: add prompt section overrides

### DIFF
--- a/agent/invocation.go
+++ b/agent/invocation.go
@@ -34,6 +34,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/memory"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/skill"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
 
@@ -213,6 +214,19 @@ type RunOption func(*RunOptions)
 // called concurrently by different runs and must protect any shared state it
 // owns.
 type ModelSelector func(ctx context.Context, inv *Invocation) (model.Model, error)
+
+// AvailableSkillsRenderRequest contains inputs for rendering the request-scoped
+// Available skills section.
+type AvailableSkillsRenderRequest struct {
+	// Summaries are the skills visible to the current request.
+	Summaries []skill.Summary
+}
+
+// AvailableSkillsRenderer renders the request-scoped Available skills section.
+type AvailableSkillsRenderer func(
+	ctx context.Context,
+	req AvailableSkillsRenderRequest,
+) string
 
 type runControlConfig struct {
 	DisableGraphCompletionEvent bool
@@ -691,6 +705,24 @@ func WithGlobalInstruction(instruction string) RunOption {
 	}
 }
 
+// WithWorkspaceExecGuidance sets request-scoped workspace_exec guidance.
+// Empty guidance leaves the built-in default guidance in use.
+func WithWorkspaceExecGuidance(guidance string) RunOption {
+	return func(opts *RunOptions) {
+		opts.WorkspaceExecGuidance = guidance
+	}
+}
+
+// WithAvailableSkillsRenderer sets a request-scoped renderer for the
+// Available skills section.
+//
+// Returning a blank string omits the Available skills section.
+func WithAvailableSkillsRenderer(renderer AvailableSkillsRenderer) RunOption {
+	return func(opts *RunOptions) {
+		opts.AvailableSkillsRenderer = renderer
+	}
+}
+
 // WithStructuredOutputJSONSchema sets a JSON schema structured output for this run.
 func WithStructuredOutputJSONSchema(name string, schema map[string]any, strict bool, description string) RunOption {
 	return func(opts *RunOptions) {
@@ -1083,6 +1115,14 @@ type RunOptions struct {
 	// If set, it temporarily overrides the agent's global instruction for
 	// this request only.
 	GlobalInstruction string
+
+	// WorkspaceExecGuidance overrides workspace_exec guidance for this run.
+	// If empty, the built-in guidance is used.
+	WorkspaceExecGuidance string
+	// AvailableSkillsRenderer renders the Available skills section for this run.
+	// If nil, the built-in renderer is used. If it returns blank text, the section
+	// is omitted.
+	AvailableSkillsRenderer AvailableSkillsRenderer
 
 	// StructuredOutput defines how the model should produce structured output for this run.
 	StructuredOutput *model.StructuredOutput

--- a/agent/invocation_messages_test.go
+++ b/agent/invocation_messages_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
 	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/skill"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
 
@@ -306,4 +307,30 @@ func TestWithToolCallArgumentsJSONRepairEnabled_SetsRunOptions(t *testing.T) {
 	WithToolCallArgumentsJSONRepairEnabled(false)(&ro)
 	require.NotNil(t, ro.ToolCallArgumentsJSONRepairEnabled)
 	require.False(t, *ro.ToolCallArgumentsJSONRepairEnabled)
+}
+
+func TestWithPromptSectionOptions_SetsRunOptions(t *testing.T) {
+	renderer := func(
+		_ context.Context,
+		req AvailableSkillsRenderRequest,
+	) string {
+		require.Len(t, req.Summaries, 1)
+		return "- " + req.Summaries[0].Name + ": compact"
+	}
+	var ro RunOptions
+	WithWorkspaceExecGuidance("compact workspace guidance")(&ro)
+	WithAvailableSkillsRenderer(renderer)(&ro)
+	require.Equal(t, "compact workspace guidance", ro.WorkspaceExecGuidance)
+	require.NotNil(t, ro.AvailableSkillsRenderer)
+	got := ro.AvailableSkillsRenderer(
+		context.Background(),
+		AvailableSkillsRenderRequest{
+			Summaries: []skill.Summary{
+				{Name: "alpha", Description: "alpha skill"},
+			},
+		},
+	)
+	require.Equal(t, "- alpha: compact", got)
+	WithAvailableSkillsRenderer(nil)(&ro)
+	require.Nil(t, ro.AvailableSkillsRenderer)
 }

--- a/agent/llmagent/llm_agent_skill_test.go
+++ b/agent/llmagent/llm_agent_skill_test.go
@@ -1474,6 +1474,79 @@ func TestLLMAgent_WithSkills_InsertsOverview(t *testing.T) {
 	require.Contains(t, sys, "echoer")
 }
 
+func TestLLMAgent_RunAvailableSkillsRenderer_WiresPrompt(t *testing.T) {
+	root := createTestSkill(t)
+	repo, err := skill.NewFSRepository(root)
+	require.NoError(t, err)
+	m := &captureModel{}
+	agt := New("tester", WithModel(m), WithSkills(repo))
+	gotSummaries := make(chan []skill.Summary, 1)
+	inv := agent.NewInvocation(
+		agent.WithInvocationMessage(model.NewUserMessage("hi")),
+		agent.WithInvocationSession(&session.Session{}),
+		agent.WithInvocationRunOptions(agent.NewRunOptions(
+			agent.WithAvailableSkillsRenderer(
+				func(
+					_ context.Context,
+					req agent.AvailableSkillsRenderRequest,
+				) string {
+					gotSummaries <- append([]skill.Summary(nil), req.Summaries...)
+					return "- echoer: compact"
+				},
+			),
+		)),
+	)
+	ch, err := agt.Run(context.Background(), inv)
+	require.NoError(t, err)
+	ctx := context.Background()
+	for evt := range ch {
+		if evt != nil && evt.RequiresCompletion {
+			key := agent.GetAppendEventNoticeKey(evt.ID)
+			_ = inv.AddNoticeChannel(ctx, key)
+			_ = inv.NotifyCompletion(ctx, key)
+		}
+	}
+	require.NotNil(t, m.got)
+	sys := findSystemMessageContaining(m.got, skillsOverviewHeader)
+	require.NotEmpty(t, sys)
+	require.Contains(t, sys, "- echoer: compact")
+	require.NotContains(t, sys, "simple echo skill")
+	require.Len(t, gotSummaries, 1)
+	require.Equal(t, "echoer", (<-gotSummaries)[0].Name)
+}
+
+func TestLLMAgent_RunWorkspaceExecGuidance_WiresPrompt(t *testing.T) {
+	root := createTestSkill(t)
+	repo, err := skill.NewFSRepository(root)
+	require.NoError(t, err)
+	m := &captureModel{}
+	agt := New("tester", WithModel(m), WithSkills(repo))
+	inv := agent.NewInvocation(
+		agent.WithInvocationMessage(model.NewUserMessage("hi")),
+		agent.WithInvocationSession(&session.Session{}),
+		agent.WithInvocationRunOptions(agent.NewRunOptions(
+			agent.WithWorkspaceExecGuidance(
+				"Workspace shell guidance:\n- Compact workspace guidance.",
+			),
+		)),
+	)
+	ch, err := agt.Run(context.Background(), inv)
+	require.NoError(t, err)
+	ctx := context.Background()
+	for evt := range ch {
+		if evt != nil && evt.RequiresCompletion {
+			key := agent.GetAppendEventNoticeKey(evt.ID)
+			_ = inv.AddNoticeChannel(ctx, key)
+			_ = inv.NotifyCompletion(ctx, key)
+		}
+	}
+	require.NotNil(t, m.got)
+	sys := findSystemMessageContaining(m.got, workspaceExecGuidanceHeader)
+	require.NotEmpty(t, sys)
+	require.Contains(t, sys, "Compact workspace guidance.")
+	require.NotContains(t, sys, "shell command tool for the current workspace")
+}
+
 func TestLLMAgent_WithSkillFilter_FiltersPromptAndDeclaration(t *testing.T) {
 	root1 := createNamedTestSkill(t, "alpha", "alpha skill")
 	root2 := createNamedTestSkill(t, "beta", "beta skill")

--- a/docs/mkdocs/en/skill.md
+++ b/docs/mkdocs/en/skill.md
@@ -1069,6 +1069,65 @@ their tokens via AG-UI `state` or HTTP headers; the provider reads
 them from the request context and injects them into the executor
 transparently — the LLM never sees the credentials.
 
+## Request-scoped Prompt Section Overrides
+
+For the small number of requests that need a shorter or custom system
+message, pass run options to `runner.Run(...)` to override the skill
+overview or `workspace_exec` guidance for that request:
+
+- `agent.WithAvailableSkillsRenderer(...)` customizes the
+  `Available skills:` overview. The renderer receives the
+  `skill.Summary` list visible to the current request; skill filters,
+  context-aware repositories, and other visibility rules have already
+  been applied. Use it to compact descriptions, change formatting, or
+  add request-specific selection constraints. If the returned text does
+  not start with `Available skills:`, the framework adds the header
+  automatically. Returning a blank string omits the `Available skills:`
+  section for that request.
+- `agent.WithWorkspaceExecGuidance(...)` customizes the `workspace_exec`
+  guidance. Passing an empty string means no override; the built-in
+  default guidance remains in use.
+
+```go
+events, err := r.Run(
+    ctx,
+    userID,
+    sessionID,
+    model.NewUserMessage("Run the release checklist skill."),
+    agent.WithAvailableSkillsRenderer(func(
+        ctx context.Context,
+        req agent.AvailableSkillsRenderRequest,
+    ) string {
+        if len(req.Summaries) == 0 {
+            return ""
+        }
+        var b strings.Builder
+        b.WriteString("Only call skill_load when a listed skill is directly relevant.\n")
+        for _, s := range req.Summaries {
+            b.WriteString("- ")
+            b.WriteString(s.Name)
+            if desc := strings.TrimSpace(s.Description); desc != "" {
+                b.WriteString(": ")
+                b.WriteString(desc)
+            }
+            b.WriteString("\n")
+        }
+        return b.String()
+    }),
+    agent.WithWorkspaceExecGuidance(
+        "Use workspace_exec only when shell execution is required.",
+    ),
+)
+```
+
+`WithAvailableSkillsRenderer` only changes the overview text. It does
+not change which skill tools are available, and it does not replace
+`skill_load` for loading skill bodies and docs on demand.
+`WithWorkspaceExecGuidance` only changes prompt text; it does not
+disable `workspace_exec`. To hide execution capability from the model,
+disable the workspace execution surface when creating the Agent, for
+example with `llmagent.WithWorkspaceExecSurfaceEnabled(false)`.
+
 ## Troubleshooting
 
 - Unknown skill: verify name and repository path; ensure the overview

--- a/docs/mkdocs/zh/skill.md
+++ b/docs/mkdocs/zh/skill.md
@@ -1027,6 +1027,58 @@ agent := llmagent.New(
 HTTP header 传入自己的 token，provider 从请求上下文中读取后注入
 执行器，LLM 无需感知。
 
+## 请求级提示词片段覆盖
+
+如果少数请求需要压缩或改写系统消息，可以在 `runner.Run(...)` 里
+覆盖本次请求的 skill 概览或 `workspace_exec` 指引：
+
+- `agent.WithAvailableSkillsRenderer(...)` 自定义 `Available skills:`
+  概览。renderer 会收到当前请求可见的 `skill.Summary` 列表
+  （已应用 skill filter、上下文仓库等可见性规则），可以按业务需要
+  压缩描述、调整格式或补充本次请求的选择约束。返回内容没有以
+  `Available skills:` 开头时，框架会自动补上标题；返回空白字符串
+  表示本次请求不输出 `Available skills:` 段。
+- `agent.WithWorkspaceExecGuidance(...)` 自定义 `workspace_exec` 使用
+  指引。传入空字符串表示不覆盖，继续使用框架默认指引。
+
+```go
+events, err := r.Run(
+    ctx,
+    userID,
+    sessionID,
+    model.NewUserMessage("Run the release checklist skill."),
+    agent.WithAvailableSkillsRenderer(func(
+        ctx context.Context,
+        req agent.AvailableSkillsRenderRequest,
+    ) string {
+        if len(req.Summaries) == 0 {
+            return ""
+        }
+        var b strings.Builder
+        b.WriteString("Only call skill_load when a listed skill is directly relevant.\n")
+        for _, s := range req.Summaries {
+            b.WriteString("- ")
+            b.WriteString(s.Name)
+            if desc := strings.TrimSpace(s.Description); desc != "" {
+                b.WriteString(": ")
+                b.WriteString(desc)
+            }
+            b.WriteString("\n")
+        }
+        return b.String()
+    }),
+    agent.WithWorkspaceExecGuidance(
+        "Use workspace_exec only when shell execution is required.",
+    ),
+)
+```
+
+`WithAvailableSkillsRenderer` 只改变概览文本，不改变实际可用的 skill
+工具，也不会替代 `skill_load` 对正文和文档的按需注入。
+`WithWorkspaceExecGuidance` 只改写提示词，不会禁用 `workspace_exec`。
+如果不希望暴露执行能力，请在创建 Agent 时关闭 workspace 执行
+surface，例如使用 `llmagent.WithWorkspaceExecSurfaceEnabled(false)`。
+
 ## 故障排查
 
 - “unknown skill”：确认技能名与仓库路径；调用 `skill_load` 前

--- a/internal/flow/processor/skills.go
+++ b/internal/flow/processor/skills.go
@@ -741,58 +741,114 @@ func (p *SkillsRequestProcessor) injectOverview(
 	if len(sums) == 0 {
 		return
 	}
-	var b strings.Builder
 	flags := p.toolFlagsForInvocation(inv)
-	if protocol := p.protocolGuidanceText(flags); protocol != "" {
-		b.WriteString(protocol)
-		b.WriteString("\n")
-		b.WriteString(skillsOverviewHeader)
-		b.WriteString("\n")
-		if p.directoryHints || p.filePathHints {
-			if rootsText := buildSkillRootsText(repo); rootsText != "" {
-				b.WriteString(rootsText)
-			}
-		}
-		for _, s := range sums {
-			line := fmt.Sprintf(
-				"- %s: %s%s\n",
-				s.Name,
-				s.Description,
-				p.skillOverviewSuffix(ctx, repo, s.Name),
-			)
-			b.WriteString(line)
-		}
-	} else {
-		b.WriteString(skillsOverviewHeader)
-		b.WriteString("\n")
-		if p.directoryHints || p.filePathHints {
-			if rootsText := buildSkillRootsText(repo); rootsText != "" {
-				b.WriteString(rootsText)
-			}
-		}
-		for _, s := range sums {
-			line := fmt.Sprintf(
-				"- %s: %s%s\n",
-				s.Name,
-				s.Description,
-				p.skillOverviewSuffix(ctx, repo, s.Name),
-			)
-			b.WriteString(line)
-		}
-		if capability := p.capabilityGuidanceText(flags); capability != "" {
-			b.WriteString(capability)
-		}
-		if guidance := p.toolingGuidanceText(flags); guidance != "" {
-			b.WriteString(guidance)
+	availableSkills := p.availableSkillsText(ctx, inv, repo, sums)
+	overview, prepend := p.defaultOverviewText(flags, availableSkills)
+	p.mergeOverview(req, overview, prepend)
+}
+
+func (p *SkillsRequestProcessor) availableSkillsText(
+	ctx context.Context,
+	inv *agent.Invocation,
+	repo skill.Repository,
+	sums []skill.Summary,
+) string {
+	if renderer := availableSkillsRendererFromInvocation(inv); renderer != nil {
+		return normalizeSkillsOverviewText(
+			renderer(ctx, agent.AvailableSkillsRenderRequest{
+				Summaries: append([]skill.Summary(nil), sums...),
+			}),
+		)
+	}
+	var b strings.Builder
+	b.WriteString(skillsOverviewHeader)
+	b.WriteString("\n")
+	if p.directoryHints || p.filePathHints {
+		if rootsText := buildSkillRootsText(repo); rootsText != "" {
+			b.WriteString(rootsText)
 		}
 	}
-	overview := b.String()
+	for _, s := range sums {
+		line := fmt.Sprintf(
+			"- %s: %s%s\n",
+			s.Name,
+			s.Description,
+			p.skillOverviewSuffix(ctx, repo, s.Name),
+		)
+		b.WriteString(line)
+	}
+	return b.String()
+}
 
+func (p *SkillsRequestProcessor) defaultOverviewText(
+	flags skillprofile.Flags,
+	availableSkills string,
+) (string, bool) {
+	var b strings.Builder
+	if protocol := p.protocolGuidanceText(flags); protocol != "" {
+		b.WriteString(protocol)
+		if availableSkills != "" {
+			b.WriteString("\n")
+			b.WriteString(availableSkills)
+		}
+		return b.String(), true
+	}
+	if availableSkills != "" {
+		b.WriteString(availableSkills)
+	}
+	if capability := p.capabilityGuidanceText(flags); capability != "" {
+		b.WriteString(capability)
+	}
+	if guidance := p.toolingGuidanceText(flags); guidance != "" {
+		b.WriteString(guidance)
+	}
+	return b.String(), false
+}
+
+func availableSkillsRendererFromInvocation(
+	inv *agent.Invocation,
+) agent.AvailableSkillsRenderer {
+	if inv != nil && inv.RunOptions.AvailableSkillsRenderer != nil {
+		return inv.RunOptions.AvailableSkillsRenderer
+	}
+	return nil
+}
+
+func normalizeSkillsOverviewText(text string) string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return ""
+	}
+	if startsWithSectionHeader(text, skillsOverviewHeader) {
+		return text
+	}
+	return skillsOverviewHeader + "\n" + text
+}
+
+func startsWithSectionHeader(text string, header string) bool {
+	lines := strings.Split(strings.TrimSpace(text), "\n")
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		return strings.TrimSpace(line) == header
+	}
+	return false
+}
+
+func (p *SkillsRequestProcessor) mergeOverview(
+	req *model.Request,
+	overview string,
+	prepend bool,
+) {
+	if req == nil || overview == "" {
+		return
+	}
 	idx := findSystemMessageIndex(req.Messages)
 	if idx >= 0 {
 		sys := &req.Messages[idx]
 		if !strings.Contains(sys.Content, skillsOverviewHeader) {
-			if p.protocolGuidanceText(flags) != "" {
+			if prepend {
 				if sys.Content != "" {
 					sys.Content = overview + "\n\n" + sys.Content
 				} else {

--- a/internal/flow/processor/skills.go
+++ b/internal/flow/processor/skills.go
@@ -847,7 +847,7 @@ func (p *SkillsRequestProcessor) mergeOverview(
 	idx := findSystemMessageIndex(req.Messages)
 	if idx >= 0 {
 		sys := &req.Messages[idx]
-		if !strings.Contains(sys.Content, skillsOverviewHeader) {
+		if !strings.Contains(sys.Content, skillsOverviewMergeMarker(overview)) {
 			if prepend {
 				if sys.Content != "" {
 					sys.Content = overview + "\n\n" + sys.Content
@@ -865,6 +865,19 @@ func (p *SkillsRequestProcessor) mergeOverview(
 	// No system message yet: create one at the front.
 	msg := model.NewSystemMessage(overview)
 	req.Messages = append([]model.Message{msg}, req.Messages...)
+}
+
+func skillsOverviewMergeMarker(overview string) string {
+	if strings.Contains(overview, skillsOverviewHeader) {
+		return skillsOverviewHeader
+	}
+	if strings.Contains(overview, skillsToolingGuidanceHeader) {
+		return skillsToolingGuidanceHeader
+	}
+	if strings.Contains(overview, skillsCapabilityHeader) {
+		return skillsCapabilityHeader
+	}
+	return strings.TrimSpace(overview)
 }
 
 func (p *SkillsRequestProcessor) toolFlagsForInvocation(

--- a/internal/flow/processor/skills_test.go
+++ b/internal/flow/processor/skills_test.go
@@ -821,6 +821,33 @@ func TestSkillsRequestProcessor_OverviewRendererBlankOmitsAvailableSkillsOnly(
 	require.Contains(t, sys, "Calc body")
 }
 
+func TestSkillsRequestProcessor_OverviewRendererBlankDoesNotDuplicateGuidance(
+	t *testing.T,
+) {
+	repo := &mockRepo{
+		sums: []skill.Summary{{Name: "calc", Description: "math ops"}},
+		full: map[string]*skill.Skill{},
+	}
+	inv := &agent.Invocation{
+		RunOptions: agent.RunOptions{
+			AvailableSkillsRenderer: func(
+				context.Context,
+				agent.AvailableSkillsRenderRequest,
+			) string {
+				return "  \n"
+			},
+		},
+		Session: &session.Session{},
+	}
+	req := &model.Request{Messages: nil}
+	p := NewSkillsRequestProcessor(repo)
+	p.ProcessRequest(context.Background(), inv, req, nil)
+	p.ProcessRequest(context.Background(), inv, req, nil)
+	sys := req.Messages[0].Content
+	require.NotContains(t, sys, skillsOverviewHeader)
+	require.Equal(t, 1, strings.Count(sys, skillsToolingGuidanceHeader))
+}
+
 func TestSkillsRequestProcessor_OverviewRendererNotCalledWithoutSummaries(
 	t *testing.T,
 ) {

--- a/internal/flow/processor/skills_test.go
+++ b/internal/flow/processor/skills_test.go
@@ -219,6 +219,26 @@ func TestSkillsRequestProcessor_NoDuplicateOverview(t *testing.T) {
 	require.Equal(t, 1, cnt)
 }
 
+func TestSkillsRequestProcessor_NoDuplicateOverviewWhenHeaderMentionedInline(
+	t *testing.T,
+) {
+	repo := &mockRepo{
+		sums: []skill.Summary{{Name: "x", Description: "d"}},
+		full: map[string]*skill.Skill{},
+	}
+	inv := &agent.Invocation{Session: &session.Session{}}
+	req := &model.Request{
+		Messages: []model.Message{
+			model.NewSystemMessage("Existing " + skillsOverviewHeader + " text."),
+		},
+	}
+	p := NewSkillsRequestProcessor(repo)
+	p.ProcessRequest(context.Background(), inv, req, nil)
+	sys := req.Messages[0].Content
+	require.NotContains(t, sys, "- x: d")
+	require.NotContains(t, sys, skillsToolingGuidanceHeader)
+}
+
 func TestSkillsRequestProcessor_ToolingGuidance_Disabled(t *testing.T) {
 	repo := &mockRepo{
 		sums: []skill.Summary{{Name: "x", Description: "d"}},
@@ -583,6 +603,246 @@ func TestSkillsRequestProcessor_ProtocolGuidanceOverride(t *testing.T) {
 	)
 	require.NotContains(t, sys, skillsCapabilityHeader)
 	require.NotContains(t, sys, skillsToolingGuidanceHeader)
+}
+
+func TestSkillsRequestProcessor_OverviewRendererOverride(t *testing.T) {
+	repo := &mockRepo{
+		sums: []skill.Summary{
+			{Name: "alpha", Description: "alpha skill"},
+			{Name: "beta", Description: "beta skill"},
+		},
+		full: map[string]*skill.Skill{},
+	}
+	var got []skill.Summary
+	inv := &agent.Invocation{
+		RunOptions: agent.RunOptions{
+			AvailableSkillsRenderer: func(
+				_ context.Context,
+				req agent.AvailableSkillsRenderRequest,
+			) string {
+				got = append([]skill.Summary(nil), req.Summaries...)
+				return "- alpha: compact\n"
+			},
+		},
+		Session: &session.Session{},
+	}
+	req := &model.Request{Messages: nil}
+	p := NewSkillsRequestProcessor(repo)
+	p.ProcessRequest(context.Background(), inv, req, nil)
+	require.Equal(t, repo.sums, got)
+	sys := req.Messages[0].Content
+	require.Contains(t, sys, skillsOverviewHeader)
+	require.Contains(t, sys, "- alpha: compact")
+	require.NotContains(t, sys, "beta skill")
+	require.Contains(t, sys, skillsToolingGuidanceHeader)
+}
+
+func TestSkillsRequestProcessor_OverviewRendererReceivesVisibleSummaries(
+	t *testing.T,
+) {
+	base := &mockRepo{
+		sums: []skill.Summary{
+			{Name: "alpha", Description: "alpha skill"},
+			{Name: "beta", Description: "beta skill"},
+		},
+		full: map[string]*skill.Skill{},
+	}
+	repo := skill.NewFilteredRepository(
+		base,
+		func(ctx context.Context, summary skill.Summary) bool {
+			userID, _ := agent.GetRuntimeStateValueFromContext[string](
+				ctx,
+				"user_id",
+			)
+			return userID == "user-a" && summary.Name == "alpha"
+		},
+	)
+	var got []skill.Summary
+	inv := &agent.Invocation{
+		RunOptions: agent.RunOptions{
+			RuntimeState: map[string]any{"user_id": "user-a"},
+			AvailableSkillsRenderer: func(
+				_ context.Context,
+				req agent.AvailableSkillsRenderRequest,
+			) string {
+				got = append([]skill.Summary(nil), req.Summaries...)
+				return "- alpha: compact"
+			},
+		},
+		Session: &session.Session{},
+	}
+	req := &model.Request{Messages: nil}
+	p := NewSkillsRequestProcessor(repo)
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+	p.ProcessRequest(ctx, inv, req, nil)
+	require.Equal(
+		t,
+		[]skill.Summary{{Name: "alpha", Description: "alpha skill"}},
+		got,
+	)
+	sys := req.Messages[0].Content
+	require.Contains(t, sys, "- alpha: compact")
+	require.NotContains(t, sys, "beta")
+}
+
+func TestSkillsRequestProcessor_OverviewRendererKeepsSingleHeader(
+	t *testing.T,
+) {
+	repo := &mockRepo{
+		sums: []skill.Summary{{Name: "x", Description: "d"}},
+		full: map[string]*skill.Skill{},
+	}
+	inv := &agent.Invocation{
+		RunOptions: agent.RunOptions{
+			AvailableSkillsRenderer: func(
+				context.Context,
+				agent.AvailableSkillsRenderRequest,
+			) string {
+				return skillsOverviewHeader + "\n- x: compact"
+			},
+		},
+		Session: &session.Session{},
+	}
+	req := &model.Request{Messages: nil}
+	p := NewSkillsRequestProcessor(repo)
+	p.ProcessRequest(context.Background(), inv, req, nil)
+	sys := req.Messages[0].Content
+	require.Equal(t, 1, strings.Count(sys, skillsOverviewHeader))
+	require.Contains(t, sys, "- x: compact")
+}
+
+func TestSkillsRequestProcessor_OverviewRendererAddsHeaderWhenMentionedInBody(
+	t *testing.T,
+) {
+	repo := &mockRepo{
+		sums: []skill.Summary{{Name: "x", Description: "d"}},
+		full: map[string]*skill.Skill{},
+	}
+	inv := &agent.Invocation{
+		RunOptions: agent.RunOptions{
+			AvailableSkillsRenderer: func(
+				context.Context,
+				agent.AvailableSkillsRenderRequest,
+			) string {
+				return "- x: mention Available skills: in prose"
+			},
+		},
+		Session: &session.Session{},
+	}
+	req := &model.Request{Messages: nil}
+	p := NewSkillsRequestProcessor(repo)
+	p.ProcessRequest(context.Background(), inv, req, nil)
+	sys := req.Messages[0].Content
+	require.True(t, strings.HasPrefix(sys, skillsOverviewHeader+"\n"))
+	require.Contains(t, sys, "- x: mention Available skills: in prose")
+}
+
+func TestSkillsRequestProcessor_OverviewRendererKeepsLoadedContent(
+	t *testing.T,
+) {
+	repo := &mockRepo{
+		sums: []skill.Summary{{Name: "calc", Description: "math ops"}},
+		full: map[string]*skill.Skill{
+			"calc": {
+				Summary: skill.Summary{Name: "calc"},
+				Body:    "Calc body",
+			},
+		},
+	}
+	inv := &agent.Invocation{
+		AgentName: "tester",
+		RunOptions: agent.RunOptions{
+			AvailableSkillsRenderer: func(
+				context.Context,
+				agent.AvailableSkillsRenderRequest,
+			) string {
+				return "- calc: compact"
+			},
+		},
+		Session: &session.Session{
+			State: session.StateMap{
+				skill.LoadedKey("tester", "calc"): []byte("1"),
+			},
+		},
+	}
+	req := &model.Request{Messages: nil}
+	p := NewSkillsRequestProcessor(
+		repo,
+		WithSkillLoadMode(SkillLoadModeSession),
+	)
+	p.ProcessRequest(context.Background(), inv, req, nil)
+	require.NotEmpty(t, req.Messages)
+	sys := req.Messages[0].Content
+	require.Contains(t, sys, "- calc: compact")
+	require.Contains(t, sys, "[Loaded] calc")
+	require.Contains(t, sys, "Calc body")
+}
+
+func TestSkillsRequestProcessor_OverviewRendererBlankOmitsAvailableSkillsOnly(
+	t *testing.T,
+) {
+	repo := &mockRepo{
+		sums: []skill.Summary{{Name: "calc", Description: "math ops"}},
+		full: map[string]*skill.Skill{
+			"calc": {
+				Summary: skill.Summary{Name: "calc"},
+				Body:    "Calc body",
+			},
+		},
+	}
+	inv := &agent.Invocation{
+		AgentName: "tester",
+		RunOptions: agent.RunOptions{
+			AvailableSkillsRenderer: func(
+				context.Context,
+				agent.AvailableSkillsRenderRequest,
+			) string {
+				return "  \n"
+			},
+		},
+		Session: &session.Session{
+			State: session.StateMap{
+				skill.LoadedKey("tester", "calc"): []byte("1"),
+			},
+		},
+	}
+	req := &model.Request{Messages: nil}
+	p := NewSkillsRequestProcessor(
+		repo,
+		WithSkillLoadMode(SkillLoadModeSession),
+	)
+	p.ProcessRequest(context.Background(), inv, req, nil)
+	require.NotEmpty(t, req.Messages)
+	sys := req.Messages[0].Content
+	require.NotContains(t, sys, skillsOverviewHeader)
+	require.NotContains(t, sys, "math ops")
+	require.Contains(t, sys, skillsToolingGuidanceHeader)
+	require.Contains(t, sys, "[Loaded] calc")
+	require.Contains(t, sys, "Calc body")
+}
+
+func TestSkillsRequestProcessor_OverviewRendererNotCalledWithoutSummaries(
+	t *testing.T,
+) {
+	repo := &mockRepo{full: map[string]*skill.Skill{}}
+	var called bool
+	inv := &agent.Invocation{
+		RunOptions: agent.RunOptions{
+			AvailableSkillsRenderer: func(
+				context.Context,
+				agent.AvailableSkillsRenderRequest,
+			) string {
+				called = true
+				return "- x"
+			},
+		},
+		Session: &session.Session{},
+	}
+	req := &model.Request{Messages: nil}
+	p := NewSkillsRequestProcessor(repo)
+	p.ProcessRequest(context.Background(), inv, req, nil)
+	require.False(t, called)
+	require.Empty(t, req.Messages)
 }
 
 func TestSkillsRequestProcessor_ExecToolsDisabled(t *testing.T) {

--- a/internal/flow/processor/workspaceexec.go
+++ b/internal/flow/processor/workspaceexec.go
@@ -166,6 +166,9 @@ func (p *WorkspaceExecRequestProcessor) guidanceText(
 	if !p.enabledForInvocation(inv) {
 		return ""
 	}
+	if guidance := workspaceExecGuidanceFromInvocation(inv); guidance != "" {
+		return guidance
+	}
 	var b strings.Builder
 	b.WriteString(workspaceExecGuidanceHeader)
 	b.WriteString("\n")
@@ -237,6 +240,25 @@ func (p *WorkspaceExecRequestProcessor) guidanceText(
 		b.WriteString("session.\n")
 	}
 	return b.String()
+}
+
+func workspaceExecGuidanceFromInvocation(inv *agent.Invocation) string {
+	if inv == nil {
+		return ""
+	}
+	return normalizeWorkspaceExecGuidance(inv.RunOptions.WorkspaceExecGuidance)
+}
+
+func normalizeWorkspaceExecGuidance(guidance string) string {
+	guidance = strings.TrimSpace(guidance)
+	if guidance == "" {
+		return ""
+	}
+	if startsWithSectionHeader(guidance, workspaceExecGuidanceHeader) ||
+		startsWithSectionHeader(guidance, legacyWorkspaceExecGuidanceHeader) {
+		return guidance
+	}
+	return workspaceExecGuidanceHeader + "\n" + guidance
 }
 
 func (p *WorkspaceExecRequestProcessor) enabledForInvocation(

--- a/internal/flow/processor/workspaceexec_test.go
+++ b/internal/flow/processor/workspaceexec_test.go
@@ -168,6 +168,23 @@ func TestWorkspaceExecRequestProcessor_NoDuplicateLegacyGuidance(t *testing.T) {
 	require.NotContains(t, req.Messages[0].Content, workspaceExecGuidanceHeader)
 }
 
+func TestWorkspaceExecRequestProcessor_NoDuplicateGuidanceWhenHeaderMentionedInline(
+	t *testing.T,
+) {
+	p := NewWorkspaceExecRequestProcessor()
+	req := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("Existing " + workspaceExecGuidanceHeader + " text."),
+	}}
+	p.ProcessRequest(
+		context.Background(),
+		&agent.Invocation{AgentName: "tester"},
+		req,
+		nil,
+	)
+	require.Len(t, req.Messages, 1)
+	require.NotContains(t, req.Messages[0].Content, "shell command tool")
+}
+
 func TestWorkspaceExecRequestProcessor_ProcessRequest_UsesSkillsRepoResolver(
 	t *testing.T,
 ) {
@@ -179,14 +196,12 @@ func TestWorkspaceExecRequestProcessor_ProcessRequest_UsesSkillsRepoResolver(
 		),
 	)
 	req := &model.Request{}
-
 	p.ProcessRequest(
 		context.Background(),
 		&agent.Invocation{AgentName: "tester"},
 		req,
 		nil,
 	)
-
 	require.NotEmpty(t, req.Messages)
 	require.Contains(
 		t,
@@ -207,14 +222,12 @@ func TestWorkspaceExecRequestProcessor_ProcessRequest_ResolverCanDisableSkillsGu
 		),
 	)
 	req := &model.Request{}
-
 	p.ProcessRequest(
 		context.Background(),
 		&agent.Invocation{AgentName: "tester"},
 		req,
 		nil,
 	)
-
 	require.NotEmpty(t, req.Messages)
 	require.NotContains(
 		t,
@@ -242,6 +255,118 @@ func TestWorkspaceExecRequestProcessor_ProcessRequest_DisabledByResolver(
 		nil,
 	)
 
+	require.Empty(t, req.Messages)
+}
+
+func TestWorkspaceExecRequestProcessor_ProcessRequest_GuidanceOverride(
+	t *testing.T,
+) {
+	p := NewWorkspaceExecRequestProcessor()
+	req := &model.Request{}
+	p.ProcessRequest(
+		context.Background(),
+		&agent.Invocation{
+			AgentName: "tester",
+			RunOptions: agent.RunOptions{
+				WorkspaceExecGuidance: "Use workspace_exec sparingly.",
+			},
+		},
+		req,
+		nil,
+	)
+	require.NotEmpty(t, req.Messages)
+	sys := req.Messages[0].Content
+	require.Contains(t, sys, workspaceExecGuidanceHeader)
+	require.Contains(t, sys, "Use workspace_exec sparingly.")
+	require.NotContains(t, sys, "shell command tool for the current workspace")
+}
+
+func TestWorkspaceExecRequestProcessor_ProcessRequest_GuidanceOverrideWithHeader(
+	t *testing.T,
+) {
+	p := NewWorkspaceExecRequestProcessor()
+	req := &model.Request{}
+	p.ProcessRequest(
+		context.Background(),
+		&agent.Invocation{
+			AgentName: "tester",
+			RunOptions: agent.RunOptions{
+				WorkspaceExecGuidance: workspaceExecGuidanceHeader + "\ncustom",
+			},
+		},
+		req,
+		nil,
+	)
+	require.NotEmpty(t, req.Messages)
+	sys := req.Messages[0].Content
+	require.Equal(t, 1, strings.Count(sys, workspaceExecGuidanceHeader))
+	require.Contains(t, sys, "custom")
+}
+
+func TestWorkspaceExecRequestProcessor_ProcessRequest_GuidanceOverrideAddsHeaderWhenMentionedInBody(
+	t *testing.T,
+) {
+	p := NewWorkspaceExecRequestProcessor()
+	req := &model.Request{}
+	p.ProcessRequest(
+		context.Background(),
+		&agent.Invocation{
+			AgentName: "tester",
+			RunOptions: agent.RunOptions{
+				WorkspaceExecGuidance: "- mention Workspace shell guidance: in prose",
+			},
+		},
+		req,
+		nil,
+	)
+	require.NotEmpty(t, req.Messages)
+	sys := req.Messages[0].Content
+	require.True(t, strings.HasPrefix(sys, workspaceExecGuidanceHeader+"\n"))
+	require.Contains(t, sys, "mention Workspace shell guidance: in prose")
+}
+
+func TestWorkspaceExecRequestProcessor_ProcessRequest_GuidanceOverrideEmptyUsesDefault(
+	t *testing.T,
+) {
+	p := NewWorkspaceExecRequestProcessor()
+	req := &model.Request{}
+	p.ProcessRequest(
+		context.Background(),
+		&agent.Invocation{
+			AgentName: "tester",
+			RunOptions: agent.RunOptions{
+				WorkspaceExecGuidance: "  \n",
+			},
+		},
+		req,
+		nil,
+	)
+	require.NotEmpty(t, req.Messages)
+	sys := req.Messages[0].Content
+	require.Contains(t, sys, workspaceExecGuidanceHeader)
+	require.Contains(t, sys, "shell command tool for the current workspace")
+}
+
+func TestWorkspaceExecRequestProcessor_ProcessRequest_GuidanceOverrideDisabled(
+	t *testing.T,
+) {
+	p := NewWorkspaceExecRequestProcessor(
+		WithWorkspaceExecEnabledResolver(func(*agent.Invocation) bool {
+			return false
+		}),
+	)
+	req := &model.Request{}
+	p.ProcessRequest(
+		context.Background(),
+		&agent.Invocation{
+			AgentName: "tester",
+			RunOptions: agent.RunOptions{
+				WorkspaceExecGuidance: "Use workspace_exec.",
+			},
+		},
+		req,
+		nil,
+	)
 	require.Empty(t, req.Messages)
 }
 


### PR DESCRIPTION
This adds request-scoped run options for overriding workspace_exec guidance and rendering the Available skills section, with processors reading typed RunOptions directly while preserving the default prompt injection behavior when no override is supplied.