### PR TITLE
runner: preserve interrupted assistant text

### DIFF
--- a/agent/invocation.go
+++ b/agent/invocation.go
@@ -402,6 +402,18 @@ func WithResume(enabled bool) RunOption {
 	}
 }
 
+// WithPersistInterruptedAssistant controls whether a cancelled streaming run
+// persists already-emitted assistant text as a final assistant message.
+//
+// By default this is not set, so the Runner uses its own default. The built-in
+// Runner default is false to preserve the "cancel discards partial text"
+// session semantics.
+func WithPersistInterruptedAssistant(enabled bool) RunOption {
+	return func(opts *RunOptions) {
+		opts.PersistInterruptedAssistant = &enabled
+	}
+}
+
 // WithGraphEmitFinalModelResponses controls whether graph-based agents emit
 // final (Done=true) model responses as events.
 //
@@ -945,6 +957,14 @@ type RunOptions struct {
 	// pending tool calls) and complete unfinished work prior to issuing a new
 	// LLM request.
 	Resume bool
+
+	// PersistInterruptedAssistant controls whether Runner persists already
+	// emitted assistant text as a final assistant message when a streaming run
+	// is cancelled before a normal final assistant response is produced.
+	//
+	// nil means the Runner default applies. The built-in Runner default is
+	// false to preserve the legacy cancellation semantics.
+	PersistInterruptedAssistant *bool
 
 	// GraphEmitFinalModelResponses controls event emission for graph-based
 	// Large Language Model (LLM) nodes.

--- a/agent/invocation_messages_test.go
+++ b/agent/invocation_messages_test.go
@@ -218,6 +218,19 @@ func TestWithResume(t *testing.T) {
 	require.False(t, ro.Resume)
 }
 
+func TestWithPersistInterruptedAssistant(t *testing.T) {
+	var ro RunOptions
+	require.Nil(t, ro.PersistInterruptedAssistant)
+
+	WithPersistInterruptedAssistant(true)(&ro)
+	require.NotNil(t, ro.PersistInterruptedAssistant)
+	require.True(t, *ro.PersistInterruptedAssistant)
+
+	WithPersistInterruptedAssistant(false)(&ro)
+	require.NotNil(t, ro.PersistInterruptedAssistant)
+	require.False(t, *ro.PersistInterruptedAssistant)
+}
+
 func TestWithGraphEmitFinalModelResponses(t *testing.T) {
 	var ro RunOptions
 	WithGraphEmitFinalModelResponses(true)(&ro)

--- a/docs/mkdocs/en/runner.md
+++ b/docs/mkdocs/en/runner.md
@@ -590,6 +590,57 @@ Runner enforces the earlier of:
 - the parent context deadline (if any)
 - `MaxRunDuration` (if set)
 
+#### Persist Interrupted Assistant Text (opt-in)
+
+By default, cancelling a streaming run does not write partial assistant chunks
+to the Session. This preserves the common "cancel means discard the unfinished
+reply" behavior.
+
+If your product has a "continue from where it stopped" interaction, you can
+opt in to persisting already-emitted assistant text when cancellation happens
+before the model produces a normal final assistant message. Runner aggregates
+assistant text deltas, synthesizes one non-partial assistant event, runs it
+through event plugins, and appends it to the Session.
+
+Enable it as a Runner default:
+
+```go
+r := runner.NewRunner("my-app", myAgent,
+    runner.WithPersistInterruptedAssistant(true),
+)
+```
+
+Or override it for one run:
+
+```go
+eventChan, err := r.Run(
+    ctx,
+    userID,
+    sessionID,
+    message,
+    agent.WithPersistInterruptedAssistant(true),
+)
+```
+
+You can also disable it for a single run even when the Runner default is
+enabled:
+
+```go
+eventChan, err := r.Run(
+    ctx,
+    userID,
+    sessionID,
+    message,
+    agent.WithPersistInterruptedAssistant(false),
+)
+```
+
+This option only persists text assistant deltas. Tool-call deltas, tool
+responses, and already-completed assistant messages are not converted into an
+interrupted assistant event. GraphAgent workflows use the same Runner event
+pipeline, so this option also applies to graph LLM node text chunks; no
+graph-specific option is required.
+
 #### Resume Interrupted Runs (tools-first resume)
 
 In long-running conversations, users may interrupt the agent while it is still

--- a/docs/mkdocs/zh/runner.md
+++ b/docs/mkdocs/zh/runner.md
@@ -569,6 +569,53 @@ Runner 会取以下两者中较早的时间作为真正的超时上限：
 - 父 `ctx` 的 deadline（如果存在）
 - `MaxRunDuration`（如果设置了）
 
+#### 持久化被中断的 Assistant 文本（显式开启）
+
+默认情况下，取消一个 streaming run 不会把 partial assistant chunk 写入
+Session。这样可以保留“取消等于丢弃未完成回复”的语义。
+
+如果你的产品形态需要“从上次被打断的位置继续”，可以显式开启该能力：
+当取消发生在模型产出正常 final assistant 消息之前，Runner 会聚合已经发出的
+assistant 文本 delta，合成一条非 partial 的 assistant 事件，经过 event plugin
+处理后写入 Session。
+
+作为 Runner 默认行为开启：
+
+```go
+r := runner.NewRunner("my-app", myAgent,
+    runner.WithPersistInterruptedAssistant(true),
+)
+```
+
+也可以只在单次 run 中开启：
+
+```go
+eventChan, err := r.Run(
+    ctx,
+    userID,
+    sessionID,
+    message,
+    agent.WithPersistInterruptedAssistant(true),
+)
+```
+
+如果 Runner 默认已经开启，也可以在单次 run 中关闭：
+
+```go
+eventChan, err := r.Run(
+    ctx,
+    userID,
+    sessionID,
+    message,
+    agent.WithPersistInterruptedAssistant(false),
+)
+```
+
+该选项只会持久化 assistant 文本 delta，不会把 tool-call delta、tool response
+或已经完成的 assistant 消息转换成 interrupted assistant 事件。GraphAgent 复用
+同一套 Runner event pipeline，因此 graph LLM 节点的文本 chunk 同样受该选项控制，
+不需要额外的 graph 专用开关。
+
 #### 中断恢复（工具优先继续执行）
 
 在真实业务里，用户可能在 Agent 还处于“工具调用阶段”时中断：

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -966,6 +966,7 @@ type eventLoopContext struct {
 	sawTerminalError                   bool
 	streamFilter                       graph.StreamModeFilter
 	interruptedAssistants              map[string]*interruptedAssistantAccumulator
+	interruptedAssistantSequence       int64
 	// emittedAssistantResponseIDs tracks response IDs that already produced a
 	// non-partial assistant message event during this run.
 	//
@@ -976,6 +977,7 @@ type eventLoopContext struct {
 
 type interruptedAssistantAccumulator struct {
 	sess                               *session.Session
+	sequence                           int64
 	responseID                         string
 	author                             string
 	invocationID                       string
@@ -1441,7 +1443,9 @@ func interruptedAssistantAccumulatorForLineage(
 	if acc := loop.interruptedAssistants[key]; acc != nil {
 		return acc
 	}
+	loop.interruptedAssistantSequence++
 	acc := &interruptedAssistantAccumulator{
+		sequence:                           loop.interruptedAssistantSequence,
 		sess:                               persistSession,
 		persistedAssistantResponseIDs:      collectPriorAssistantResponseIDs(persistSession),
 		persistedAssistantChoiceSignatures: collectPriorAssistantChoiceSignatures(persistSession),
@@ -1733,13 +1737,25 @@ func (r *runner) persistInterruptedAssistant(ctx context.Context, loop *eventLoo
 	}
 	persistCtx, cancel := sessionPersistenceContext(ctx)
 	defer cancel()
-	keys := make([]string, 0, len(loop.interruptedAssistants))
-	for key := range loop.interruptedAssistants {
-		keys = append(keys, key)
+	type persistTarget struct {
+		key string
+		acc *interruptedAssistantAccumulator
 	}
-	sort.Strings(keys)
-	for _, key := range keys {
-		acc := loop.interruptedAssistants[key]
+	targets := make([]persistTarget, 0, len(loop.interruptedAssistants))
+	for key, acc := range loop.interruptedAssistants {
+		if acc == nil {
+			continue
+		}
+		targets = append(targets, persistTarget{key: key, acc: acc})
+	}
+	sort.Slice(targets, func(i, j int) bool {
+		if targets[i].acc.sequence != targets[j].acc.sequence {
+			return targets[i].acc.sequence < targets[j].acc.sequence
+		}
+		return targets[i].key < targets[j].key
+	})
+	for _, target := range targets {
+		acc := target.acc
 		persistSession := acc.sess
 		if persistSession == nil {
 			persistSession = loop.sess
@@ -1757,6 +1773,13 @@ func (r *runner) persistInterruptedAssistant(ctx context.Context, loop *eventLoo
 			interruptedEvent,
 		)
 		if interruptedEvent == nil {
+			continue
+		}
+		if interruptedEvent.Response != nil &&
+			r.interruptedAssistantAlreadyPersistedForAccumulator(
+				acc,
+				interruptedEvent.Response.Choices,
+			) {
 			continue
 		}
 		if err := r.sessionService.AppendEvent(

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -965,17 +965,24 @@ type eventLoopContext struct {
 	visibleCompletionChoiceSignatures  map[string]struct{}
 	sawTerminalError                   bool
 	streamFilter                       graph.StreamModeFilter
-	interruptedAssistantResponseID     string
-	interruptedAssistantAuthor         string
-	interruptedAssistantInvocationID   string
-	interruptedAssistantCreated        int64
-	interruptedAssistantChoiceContent  map[int]*strings.Builder
+	interruptedAssistants              map[string]*interruptedAssistantAccumulator
 	// emittedAssistantResponseIDs tracks response IDs that already produced a
 	// non-partial assistant message event during this run.
 	//
 	// It is used to avoid echoing the same final assistant message again in the
 	// runner-completion event when graph final model responses are emitted.
 	emittedAssistantResponseIDs map[string]struct{}
+}
+
+type interruptedAssistantAccumulator struct {
+	sess                               *session.Session
+	responseID                         string
+	author                             string
+	invocationID                       string
+	created                            int64
+	choiceContent                      map[int]*strings.Builder
+	persistedAssistantResponseIDs      map[string]struct{}
+	persistedAssistantChoiceSignatures map[string]struct{}
 }
 
 // processAgentEvents consumes agent events, persists to session, and emits.
@@ -1066,14 +1073,17 @@ func (r *runner) processSingleAgentEvent(ctx context.Context, loop *eventLoopCon
 		return nil
 	}
 	routeEvent := sessionroute.SnapshotEventIdentity(agentEvent)
-	agentEvent = r.applyEventPlugins(ctx, loop.invocation, agentEvent)
-	if agentEvent == nil {
-		return nil
-	}
 	persistSession, routedEvent := sessionroute.RouteEvent(
 		loop.invocation,
 		routeEvent,
 	)
+	if shouldPersistInterruptedAssistant(loop) {
+		r.recordInterruptedAssistantDelta(loop, agentEvent, persistSession)
+	}
+	agentEvent = r.applyEventPlugins(ctx, loop.invocation, agentEvent)
+	if agentEvent == nil {
+		return nil
+	}
 	excludeRootCompletion := routedEvent && !sameSession(persistSession, loop.sess)
 	if excludeRootCompletion {
 		r.captureRoutedCompletionError(loop, agentEvent)
@@ -1097,9 +1107,6 @@ func (r *runner) processSingleAgentEvent(ctx context.Context, loop *eventLoopCon
 		return nil
 	}
 	shouldForwardEvent := loop.streamFilter.Allows(agentEvent)
-	if !excludeRootCompletion && shouldPersistInterruptedAssistant(loop) {
-		r.recordInterruptedAssistantDelta(loop, agentEvent)
-	}
 
 	// Append qualifying events to session and trigger summarization.
 	persisted := r.handleEventPersistence(
@@ -1116,6 +1123,12 @@ func (r *runner) processSingleAgentEvent(ctx context.Context, loop *eventLoopCon
 			persisted,
 		)
 	}
+	r.recordPersistedInterruptedAssistantSessionEvent(
+		loop,
+		persistSession,
+		agentEvent,
+		persisted,
+	)
 
 	// Notify completion if required.
 	if agentEvent.RequiresCompletion {
@@ -1180,6 +1193,54 @@ func (r *runner) recordPersistedAssistantEvent(
 		loop.persistedAssistantChoiceSignatures = make(map[string]struct{})
 	}
 	loop.persistedAssistantChoiceSignatures[signature] = struct{}{}
+}
+
+func (r *runner) recordPersistedInterruptedAssistantSessionEvent(
+	loop *eventLoopContext,
+	persistSession *session.Session,
+	agentEvent *event.Event,
+	persisted bool,
+) {
+	acc := getInterruptedAssistantAccumulator(loop, persistSession)
+	if acc == nil {
+		return
+	}
+	recordPersistedAssistantOnAccumulator(acc, agentEvent, persisted)
+}
+
+func recordPersistedAssistantOnAccumulator(
+	acc *interruptedAssistantAccumulator,
+	agentEvent *event.Event,
+	persisted bool,
+) {
+	if acc == nil || agentEvent == nil || !persisted {
+		return
+	}
+	if isGraphCompletionEvent(agentEvent) {
+		return
+	}
+	if !eventHasAssistantMessageContent(agentEvent) || agentEvent.Response == nil {
+		return
+	}
+	if acc.persistedAssistantResponseIDs == nil {
+		acc.persistedAssistantResponseIDs = make(map[string]struct{})
+	}
+	if agentEvent.Response.ID != "" {
+		acc.persistedAssistantResponseIDs[agentEvent.Response.ID] = struct{}{}
+	}
+	if graph.IsVisibleGraphCompletionEvent(agentEvent) {
+		if responseID := finalResponseIDFromStateDelta(agentEvent.StateDelta); responseID != "" {
+			acc.persistedAssistantResponseIDs[responseID] = struct{}{}
+		}
+	}
+	signature := assistantChoiceSignature(agentEvent.Response.Choices)
+	if signature == "" {
+		return
+	}
+	if acc.persistedAssistantChoiceSignatures == nil {
+		acc.persistedAssistantChoiceSignatures = make(map[string]struct{})
+	}
+	acc.persistedAssistantChoiceSignatures[signature] = struct{}{}
 }
 
 func (r *runner) recordVisibleCompletionEmission(
@@ -1335,9 +1396,62 @@ type interruptedAssistantMetadata struct {
 	Reason string `json:"reason,omitempty"`
 }
 
+func interruptedAssistantAccumulatorForSession(
+	loop *eventLoopContext,
+	persistSession *session.Session,
+) *interruptedAssistantAccumulator {
+	if loop == nil {
+		return nil
+	}
+	if persistSession == nil {
+		persistSession = loop.sess
+	}
+	key := interruptedAssistantSessionKey(persistSession)
+	if loop.interruptedAssistants == nil {
+		loop.interruptedAssistants = make(map[string]*interruptedAssistantAccumulator)
+	}
+	if acc := loop.interruptedAssistants[key]; acc != nil {
+		return acc
+	}
+	acc := &interruptedAssistantAccumulator{
+		sess:                               persistSession,
+		persistedAssistantResponseIDs:      collectPriorAssistantResponseIDs(persistSession),
+		persistedAssistantChoiceSignatures: collectPriorAssistantChoiceSignatures(persistSession),
+	}
+	loop.interruptedAssistants[key] = acc
+	return acc
+}
+
+func getInterruptedAssistantAccumulator(
+	loop *eventLoopContext,
+	persistSession *session.Session,
+) *interruptedAssistantAccumulator {
+	if loop == nil || len(loop.interruptedAssistants) == 0 {
+		return nil
+	}
+	if persistSession == nil {
+		persistSession = loop.sess
+	}
+	return loop.interruptedAssistants[interruptedAssistantSessionKey(persistSession)]
+}
+
+func defaultInterruptedAssistantAccumulator(
+	loop *eventLoopContext,
+) *interruptedAssistantAccumulator {
+	return getInterruptedAssistantAccumulator(loop, nil)
+}
+
+func interruptedAssistantSessionKey(sess *session.Session) string {
+	if sess == nil {
+		return ""
+	}
+	return sess.AppName + "\x00" + sess.UserID + "\x00" + sess.ID
+}
+
 func (r *runner) recordInterruptedAssistantDelta(
 	loop *eventLoopContext,
 	agentEvent *event.Event,
+	persistSession *session.Session,
 ) {
 	if loop == nil || agentEvent == nil || agentEvent.Response == nil {
 		return
@@ -1346,16 +1460,19 @@ func (r *runner) recordInterruptedAssistantDelta(
 	if !rsp.IsPartial || rsp.IsToolCallResponse() || rsp.IsToolResultResponse() {
 		return
 	}
+	acc := interruptedAssistantAccumulatorForSession(loop, persistSession)
+	if acc == nil {
+		return
+	}
 	responseID := rsp.ID
 	if responseID == "" {
-		responseID = loop.interruptedAssistantResponseID
+		responseID = acc.responseID
 	}
 	if responseID == "" {
 		responseID = "interrupted-assistant-" + uuid.NewString()
 	}
-	if loop.interruptedAssistantResponseID != "" &&
-		responseID != loop.interruptedAssistantResponseID {
-		loop.interruptedAssistantChoiceContent = nil
+	if acc.responseID != "" && responseID != acc.responseID {
+		acc.choiceContent = nil
 	}
 	recorded := false
 	for _, choice := range rsp.Choices {
@@ -1365,13 +1482,13 @@ func (r *runner) recordInterruptedAssistantDelta(
 		if choice.Delta.Content == "" {
 			continue
 		}
-		if loop.interruptedAssistantChoiceContent == nil {
-			loop.interruptedAssistantChoiceContent = make(map[int]*strings.Builder)
+		if acc.choiceContent == nil {
+			acc.choiceContent = make(map[int]*strings.Builder)
 		}
-		content := loop.interruptedAssistantChoiceContent[choice.Index]
+		content := acc.choiceContent[choice.Index]
 		if content == nil {
 			content = &strings.Builder{}
-			loop.interruptedAssistantChoiceContent[choice.Index] = content
+			acc.choiceContent[choice.Index] = content
 		}
 		content.WriteString(choice.Delta.Content)
 		recorded = true
@@ -1379,11 +1496,11 @@ func (r *runner) recordInterruptedAssistantDelta(
 	if !recorded {
 		return
 	}
-	loop.interruptedAssistantResponseID = responseID
-	loop.interruptedAssistantAuthor = agentEvent.Author
-	loop.interruptedAssistantInvocationID = agentEvent.InvocationID
+	acc.responseID = responseID
+	acc.author = agentEvent.Author
+	acc.invocationID = agentEvent.InvocationID
 	if rsp.Created > 0 {
-		loop.interruptedAssistantCreated = rsp.Created
+		acc.created = rsp.Created
 	}
 }
 
@@ -1401,55 +1518,78 @@ func (r *runner) safePersistInterruptedAssistant(ctx context.Context, loop *even
 func (r *runner) persistInterruptedAssistant(ctx context.Context, loop *eventLoopContext) {
 	if ctx.Err() == nil ||
 		loop == nil ||
-		loop.sess == nil ||
 		!shouldPersistInterruptedAssistant(loop) {
-		return
-	}
-	interruptedEvent := r.interruptedAssistantEvent(ctx, loop)
-	if interruptedEvent == nil {
 		return
 	}
 	persistCtx, cancel := sessionPersistenceContext(ctx)
 	defer cancel()
-	interruptedEvent = r.applyEventPlugins(
-		persistCtx,
-		loop.invocation,
-		interruptedEvent,
-	)
-	if interruptedEvent == nil {
-		return
+	for _, acc := range loop.interruptedAssistants {
+		persistSession := acc.sess
+		if persistSession == nil {
+			persistSession = loop.sess
+		}
+		if persistSession == nil {
+			continue
+		}
+		interruptedEvent := r.interruptedAssistantEventForAccumulator(ctx, loop, acc)
+		if interruptedEvent == nil {
+			continue
+		}
+		interruptedEvent = r.applyEventPlugins(
+			persistCtx,
+			loop.invocation,
+			interruptedEvent,
+		)
+		if interruptedEvent == nil {
+			continue
+		}
+		if err := r.sessionService.AppendEvent(
+			persistCtx,
+			persistSession,
+			interruptedEvent,
+		); err != nil {
+			log.Errorf("Failed to append interrupted assistant event to session: %v", err)
+			continue
+		}
+		recordPersistedAssistantOnAccumulator(acc, interruptedEvent, true)
+		if sameSession(persistSession, loop.sess) {
+			r.recordPersistedAssistantEvent(loop, interruptedEvent, true)
+		}
 	}
-	if err := r.sessionService.AppendEvent(
-		persistCtx,
-		loop.sess,
-		interruptedEvent,
-	); err != nil {
-		log.Errorf("Failed to append interrupted assistant event to session: %v", err)
-		return
-	}
-	r.recordPersistedAssistantEvent(loop, interruptedEvent, true)
 }
 
 func (r *runner) interruptedAssistantEvent(
 	ctx context.Context,
 	loop *eventLoopContext,
 ) *event.Event {
-	choices := interruptedAssistantChoices(loop)
+	return r.interruptedAssistantEventForAccumulator(
+		ctx,
+		loop,
+		defaultInterruptedAssistantAccumulator(loop),
+	)
+}
+
+func (r *runner) interruptedAssistantEventForAccumulator(
+	ctx context.Context,
+	loop *eventLoopContext,
+	acc *interruptedAssistantAccumulator,
+) *event.Event {
+	choices := interruptedAssistantChoicesFromAccumulator(acc)
 	if len(choices) == 0 {
 		return nil
 	}
-	if r.interruptedAssistantAlreadyPersisted(loop, choices) {
+	if r.interruptedAssistantAlreadyPersistedForAccumulator(acc, choices) {
 		return nil
 	}
-	created := loop.interruptedAssistantCreated
+	created := acc.created
 	if created == 0 {
 		created = time.Now().Unix()
 	}
-	author := loop.interruptedAssistantAuthor
+	author := acc.author
 	if author == "" && loop.invocation != nil {
 		author = loop.invocation.AgentName
 	}
-	invocationID := loop.interruptedAssistantInvocationID
+	invocationID := acc.invocationID
 	if invocationID == "" && loop.invocation != nil {
 		invocationID = loop.invocation.InvocationID
 	}
@@ -1457,7 +1597,7 @@ func (r *runner) interruptedAssistantEvent(
 		invocationID,
 		author,
 		&model.Response{
-			ID:        loop.interruptedAssistantResponseID,
+			ID:        acc.responseID,
 			Object:    model.ObjectTypeChatCompletion,
 			Created:   created,
 			Done:      true,
@@ -1479,18 +1619,26 @@ func (r *runner) interruptedAssistantEvent(
 }
 
 func interruptedAssistantChoices(loop *eventLoopContext) []model.Choice {
-	if loop == nil || len(loop.interruptedAssistantChoiceContent) == 0 {
+	return interruptedAssistantChoicesFromAccumulator(
+		defaultInterruptedAssistantAccumulator(loop),
+	)
+}
+
+func interruptedAssistantChoicesFromAccumulator(
+	acc *interruptedAssistantAccumulator,
+) []model.Choice {
+	if acc == nil || len(acc.choiceContent) == 0 {
 		return nil
 	}
-	indexes := make([]int, 0, len(loop.interruptedAssistantChoiceContent))
-	for index := range loop.interruptedAssistantChoiceContent {
+	indexes := make([]int, 0, len(acc.choiceContent))
+	for index := range acc.choiceContent {
 		indexes = append(indexes, index)
 	}
 	sort.Ints(indexes)
 	finishReason := interruptedAssistantFinishReason
 	choices := make([]model.Choice, 0, len(indexes))
 	for _, index := range indexes {
-		content := loop.interruptedAssistantChoiceContent[index]
+		content := acc.choiceContent[index]
 		if content == nil || content.Len() == 0 {
 			continue
 		}
@@ -1507,11 +1655,21 @@ func (r *runner) interruptedAssistantAlreadyPersisted(
 	loop *eventLoopContext,
 	choices []model.Choice,
 ) bool {
-	if loop == nil {
+	return r.interruptedAssistantAlreadyPersistedForAccumulator(
+		defaultInterruptedAssistantAccumulator(loop),
+		choices,
+	)
+}
+
+func (r *runner) interruptedAssistantAlreadyPersistedForAccumulator(
+	acc *interruptedAssistantAccumulator,
+	choices []model.Choice,
+) bool {
+	if acc == nil {
 		return false
 	}
-	if loop.interruptedAssistantResponseID != "" {
-		if _, ok := loop.persistedAssistantResponseIDs[loop.interruptedAssistantResponseID]; ok {
+	if acc.responseID != "" {
+		if _, ok := acc.persistedAssistantResponseIDs[acc.responseID]; ok {
 			return true
 		}
 	}
@@ -1519,7 +1677,7 @@ func (r *runner) interruptedAssistantAlreadyPersisted(
 	if signature == "" {
 		return false
 	}
-	_, ok := loop.persistedAssistantChoiceSignatures[signature]
+	_, ok := acc.persistedAssistantChoiceSignatures[signature]
 	return ok
 }
 
@@ -2353,6 +2511,31 @@ func collectPriorAssistantResponseIDs(sess *session.Session) map[string]struct{}
 		responseIDs[responseID] = struct{}{}
 	}
 	return responseIDs
+}
+
+func collectPriorAssistantChoiceSignatures(sess *session.Session) map[string]struct{} {
+	if sess == nil || len(sess.Events) == 0 {
+		return nil
+	}
+	var signatures map[string]struct{}
+	for i := range sess.Events {
+		evt := &sess.Events[i]
+		if evt.Response == nil || evt.IsPartial {
+			continue
+		}
+		if isGraphCompletionEvent(evt) || !eventHasAssistantMessageContent(evt) {
+			continue
+		}
+		signature := assistantChoiceSignature(evt.Response.Choices)
+		if signature == "" {
+			continue
+		}
+		if signatures == nil {
+			signatures = make(map[string]struct{})
+		}
+		signatures[signature] = struct{}{}
+	}
+	return signatures
 }
 
 func baselineFinalResponseIDFromRuntimeState(runtimeState map[string]any) string {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1445,10 +1445,18 @@ func interruptedAssistantAccumulatorForLineage(
 	}
 	loop.interruptedAssistantSequence++
 	acc := &interruptedAssistantAccumulator{
-		sequence:                           loop.interruptedAssistantSequence,
-		sess:                               persistSession,
-		persistedAssistantResponseIDs:      collectPriorAssistantResponseIDs(persistSession),
-		persistedAssistantChoiceSignatures: collectPriorAssistantChoiceSignatures(persistSession),
+		sequence: loop.interruptedAssistantSequence,
+		sess:     persistSession,
+		persistedAssistantResponseIDs: collectPriorAssistantResponseIDsForLineage(
+			loop,
+			persistSession,
+			lineageKey,
+		),
+		persistedAssistantChoiceSignatures: collectPriorAssistantChoiceSignaturesForLineage(
+			loop,
+			persistSession,
+			lineageKey,
+		),
 	}
 	loop.interruptedAssistants[key] = acc
 	return acc
@@ -1782,12 +1790,13 @@ func (r *runner) persistInterruptedAssistant(ctx context.Context, loop *eventLoo
 			) {
 			continue
 		}
-		if err := r.sessionService.AppendEvent(
+		if !r.handleEventPersistence(
 			persistCtx,
+			loop.invocation,
+			loop.sess,
 			persistSession,
 			interruptedEvent,
-		); err != nil {
-			log.Errorf("Failed to append interrupted assistant event to session: %v", err)
+		) {
 			continue
 		}
 		recordPersistedAssistantOnAccumulator(acc, interruptedEvent, true)
@@ -2756,6 +2765,46 @@ func collectPriorAssistantResponseIDs(sess *session.Session) map[string]struct{}
 	return responseIDs
 }
 
+func collectPriorAssistantResponseIDsForLineage(
+	loop *eventLoopContext,
+	sess *session.Session,
+	lineageKey string,
+) map[string]struct{} {
+	if sess == nil || len(sess.Events) == 0 {
+		return nil
+	}
+	var responseIDs map[string]struct{}
+	for i := range sess.Events {
+		evt := &sess.Events[i]
+		if interruptedAssistantLineageKey(loop, evt) != lineageKey {
+			continue
+		}
+		if evt.Response == nil || evt.IsPartial {
+			continue
+		}
+		if isGraphCompletionEvent(evt) {
+			continue
+		}
+		if !eventHasAssistantMessageContent(evt) {
+			continue
+		}
+		responseID := evt.Response.ID
+		if graph.IsVisibleGraphCompletionEvent(evt) {
+			if visibleResponseID := finalResponseIDFromStateDelta(evt.StateDelta); visibleResponseID != "" {
+				responseID = visibleResponseID
+			}
+		}
+		if responseID == "" {
+			continue
+		}
+		if responseIDs == nil {
+			responseIDs = make(map[string]struct{})
+		}
+		responseIDs[responseID] = struct{}{}
+	}
+	return responseIDs
+}
+
 func collectPriorAssistantChoiceSignatures(sess *session.Session) map[string]struct{} {
 	if sess == nil || len(sess.Events) == 0 {
 		return nil
@@ -2763,6 +2812,42 @@ func collectPriorAssistantChoiceSignatures(sess *session.Session) map[string]str
 	var signatures map[string]struct{}
 	for i := range sess.Events {
 		evt := &sess.Events[i]
+		if evt.Response == nil || evt.IsPartial {
+			continue
+		}
+		if isGraphCompletionEvent(evt) || !eventHasAssistantMessageContent(evt) {
+			continue
+		}
+		signature := interruptedAssistantSignatureKey(
+			evt.RequestID,
+			evt.InvocationID,
+			evt.Response.Choices,
+		)
+		if signature == "" {
+			continue
+		}
+		if signatures == nil {
+			signatures = make(map[string]struct{})
+		}
+		signatures[signature] = struct{}{}
+	}
+	return signatures
+}
+
+func collectPriorAssistantChoiceSignaturesForLineage(
+	loop *eventLoopContext,
+	sess *session.Session,
+	lineageKey string,
+) map[string]struct{} {
+	if sess == nil || len(sess.Events) == 0 {
+		return nil
+	}
+	var signatures map[string]struct{}
+	for i := range sess.Events {
+		evt := &sess.Events[i]
+		if interruptedAssistantLineageKey(loop, evt) != lineageKey {
+			continue
+		}
 		if evt.Response == nil || evt.IsPartial {
 			continue
 		}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -156,6 +156,19 @@ func WithAwaitUserReplyRouting(enabled bool) Option {
 	}
 }
 
+// WithPersistInterruptedAssistant sets the runner default for whether a
+// cancelled streaming run persists already-emitted assistant text as a final
+// assistant message.
+//
+// The default is false to preserve cancellation semantics for callers that
+// expect cancelled partial text not to affect later turns. A single run can
+// override this default with agent.WithPersistInterruptedAssistant.
+func WithPersistInterruptedAssistant(enabled bool) Option {
+	return func(opts *Options) {
+		opts.persistInterruptedAssistantDefault = enabled
+	}
+}
+
 // Runner is the interface for running agents.
 type Runner interface {
 	Run(
@@ -228,17 +241,18 @@ type RunStatus struct {
 
 // runner runs agents.
 type runner struct {
-	appName               string
-	defaultAgentName      string
-	agents                map[string]agent.Agent
-	agentFactories        map[string]AgentFactory
-	sessionService        session.Service
-	memoryService         memory.Service
-	ingestor              session.Ingestor
-	artifactService       artifact.Service
-	pluginManager         agent.PluginManager
-	ralphLoop             *RalphLoopConfig
-	awaitUserReplyRouting bool
+	appName                            string
+	defaultAgentName                   string
+	agents                             map[string]agent.Agent
+	agentFactories                     map[string]AgentFactory
+	sessionService                     session.Service
+	memoryService                      memory.Service
+	ingestor                           session.Ingestor
+	artifactService                    artifact.Service
+	pluginManager                      agent.PluginManager
+	ralphLoop                          *RalphLoopConfig
+	awaitUserReplyRouting              bool
+	persistInterruptedAssistantDefault bool
 
 	// Resource management fields.
 	ownedSessionService bool      // Indicates if sessionService was created by this runner.
@@ -258,15 +272,16 @@ type runHandle struct {
 
 // Options is the options for the Runner.
 type Options struct {
-	sessionService        session.Service
-	memoryService         memory.Service
-	ingestor              session.Ingestor
-	artifactService       artifact.Service
-	agents                map[string]agent.Agent
-	agentFactories        map[string]AgentFactory
-	plugins               []plugin.Plugin
-	ralphLoop             *RalphLoopConfig
-	awaitUserReplyRouting bool
+	sessionService                     session.Service
+	memoryService                      memory.Service
+	ingestor                           session.Ingestor
+	artifactService                    artifact.Service
+	agents                             map[string]agent.Agent
+	agentFactories                     map[string]AgentFactory
+	plugins                            []plugin.Plugin
+	ralphLoop                          *RalphLoopConfig
+	awaitUserReplyRouting              bool
+	persistInterruptedAssistantDefault bool
 }
 
 // newOptions creates a new Options.
@@ -306,18 +321,19 @@ func NewRunner(appName string, ag agent.Agent, opts ...Option) Runner {
 		appid.RegisterRunner(appName, a.Info().Name)
 	}
 	return &runner{
-		appName:               appName,
-		defaultAgentName:      ag.Info().Name,
-		agents:                agents,
-		agentFactories:        options.agentFactories,
-		sessionService:        options.sessionService,
-		memoryService:         options.memoryService,
-		ingestor:              options.ingestor,
-		artifactService:       options.artifactService,
-		pluginManager:         pm,
-		ralphLoop:             options.ralphLoop,
-		awaitUserReplyRouting: options.awaitUserReplyRouting,
-		ownedSessionService:   ownedSessionService,
+		appName:                            appName,
+		defaultAgentName:                   ag.Info().Name,
+		agents:                             agents,
+		agentFactories:                     options.agentFactories,
+		sessionService:                     options.sessionService,
+		memoryService:                      options.memoryService,
+		ingestor:                           options.ingestor,
+		artifactService:                    options.artifactService,
+		pluginManager:                      pm,
+		ralphLoop:                          options.ralphLoop,
+		awaitUserReplyRouting:              options.awaitUserReplyRouting,
+		persistInterruptedAssistantDefault: options.persistInterruptedAssistantDefault,
+		ownedSessionService:                ownedSessionService,
 	}
 }
 
@@ -358,18 +374,19 @@ func NewRunnerWithAgentFactory(
 	}
 
 	return &runner{
-		appName:               appName,
-		defaultAgentName:      defaultAgentName,
-		agents:                options.agents,
-		agentFactories:        options.agentFactories,
-		sessionService:        options.sessionService,
-		memoryService:         options.memoryService,
-		ingestor:              options.ingestor,
-		artifactService:       options.artifactService,
-		pluginManager:         pm,
-		ralphLoop:             options.ralphLoop,
-		awaitUserReplyRouting: options.awaitUserReplyRouting,
-		ownedSessionService:   ownedSessionService,
+		appName:                            appName,
+		defaultAgentName:                   defaultAgentName,
+		agents:                             options.agents,
+		agentFactories:                     options.agentFactories,
+		sessionService:                     options.sessionService,
+		memoryService:                      options.memoryService,
+		ingestor:                           options.ingestor,
+		artifactService:                    options.artifactService,
+		pluginManager:                      pm,
+		ralphLoop:                          options.ralphLoop,
+		awaitUserReplyRouting:              options.awaitUserReplyRouting,
+		persistInterruptedAssistantDefault: options.persistInterruptedAssistantDefault,
+		ownedSessionService:                ownedSessionService,
 	}
 }
 
@@ -440,6 +457,7 @@ func (r *runner) Run(
 	if ro.RequestID == "" {
 		ro.RequestID = uuid.NewString()
 	}
+	r.applyRunnerRunDefaults(&ro)
 
 	// Resolve per-request app name override. When the caller provides an
 	// AppName via RunOption, it takes precedence over the runner default so
@@ -626,6 +644,14 @@ func (r *runner) Run(
 		flushChan,
 		handle,
 	), nil
+}
+
+func (r *runner) applyRunnerRunDefaults(ro *agent.RunOptions) {
+	if ro == nil || ro.PersistInterruptedAssistant != nil {
+		return
+	}
+	persistInterruptedAssistant := r.persistInterruptedAssistantDefault
+	ro.PersistInterruptedAssistant = &persistInterruptedAssistant
 }
 
 // seedSessionHistory persists caller-supplied history messages into an empty
@@ -1071,7 +1097,7 @@ func (r *runner) processSingleAgentEvent(ctx context.Context, loop *eventLoopCon
 		return nil
 	}
 	shouldForwardEvent := loop.streamFilter.Allows(agentEvent)
-	if !excludeRootCompletion {
+	if !excludeRootCompletion && shouldPersistInterruptedAssistant(loop) {
 		r.recordInterruptedAssistantDelta(loop, agentEvent)
 	}
 
@@ -1373,7 +1399,10 @@ func (r *runner) safePersistInterruptedAssistant(ctx context.Context, loop *even
 }
 
 func (r *runner) persistInterruptedAssistant(ctx context.Context, loop *eventLoopContext) {
-	if ctx.Err() == nil || loop == nil || loop.sess == nil {
+	if ctx.Err() == nil ||
+		loop == nil ||
+		loop.sess == nil ||
+		!shouldPersistInterruptedAssistant(loop) {
 		return
 	}
 	interruptedEvent := r.interruptedAssistantEvent(ctx, loop)
@@ -1492,6 +1521,14 @@ func (r *runner) interruptedAssistantAlreadyPersisted(
 	}
 	_, ok := loop.persistedAssistantChoiceSignatures[signature]
 	return ok
+}
+
+func shouldPersistInterruptedAssistant(loop *eventLoopContext) bool {
+	if loop == nil || loop.invocation == nil {
+		return false
+	}
+	enabled := loop.invocation.RunOptions.PersistInterruptedAssistant
+	return enabled != nil && *enabled
 }
 
 func contextDoneReason(ctx context.Context) string {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime/debug"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -942,7 +943,7 @@ type eventLoopContext struct {
 	interruptedAssistantAuthor         string
 	interruptedAssistantInvocationID   string
 	interruptedAssistantCreated        int64
-	interruptedAssistantContent        strings.Builder
+	interruptedAssistantChoiceContent  map[int]*strings.Builder
 	// emittedAssistantResponseIDs tracks response IDs that already produced a
 	// non-partial assistant message event during this run.
 	//
@@ -1070,6 +1071,9 @@ func (r *runner) processSingleAgentEvent(ctx context.Context, loop *eventLoopCon
 		return nil
 	}
 	shouldForwardEvent := loop.streamFilter.Allows(agentEvent)
+	if !excludeRootCompletion {
+		r.recordInterruptedAssistantDelta(loop, agentEvent)
+	}
 
 	// Append qualifying events to session and trigger summarization.
 	persisted := r.handleEventPersistence(
@@ -1106,9 +1110,6 @@ func (r *runner) processSingleAgentEvent(ctx context.Context, loop *eventLoopCon
 	// Emit event to output channel.
 	if err := event.EmitEvent(ctx, loop.processedEventCh, agentEvent); err != nil {
 		return fmt.Errorf("emit event to output channel: %w", err)
-	}
-	if !excludeRootCompletion {
-		r.recordInterruptedAssistantDelta(loop, agentEvent)
 	}
 
 	return nil
@@ -1319,18 +1320,6 @@ func (r *runner) recordInterruptedAssistantDelta(
 	if !rsp.IsPartial || rsp.IsToolCallResponse() || rsp.IsToolResultResponse() {
 		return
 	}
-	var content strings.Builder
-	for _, choice := range rsp.Choices {
-		if choice.Delta.Role != "" && choice.Delta.Role != model.RoleAssistant {
-			continue
-		}
-		if choice.Delta.Content != "" {
-			content.WriteString(choice.Delta.Content)
-		}
-	}
-	if content.Len() == 0 {
-		return
-	}
 	responseID := rsp.ID
 	if responseID == "" {
 		responseID = loop.interruptedAssistantResponseID
@@ -1340,7 +1329,29 @@ func (r *runner) recordInterruptedAssistantDelta(
 	}
 	if loop.interruptedAssistantResponseID != "" &&
 		responseID != loop.interruptedAssistantResponseID {
-		loop.interruptedAssistantContent.Reset()
+		loop.interruptedAssistantChoiceContent = nil
+	}
+	recorded := false
+	for _, choice := range rsp.Choices {
+		if choice.Delta.Role != "" && choice.Delta.Role != model.RoleAssistant {
+			continue
+		}
+		if choice.Delta.Content == "" {
+			continue
+		}
+		if loop.interruptedAssistantChoiceContent == nil {
+			loop.interruptedAssistantChoiceContent = make(map[int]*strings.Builder)
+		}
+		content := loop.interruptedAssistantChoiceContent[choice.Index]
+		if content == nil {
+			content = &strings.Builder{}
+			loop.interruptedAssistantChoiceContent[choice.Index] = content
+		}
+		content.WriteString(choice.Delta.Content)
+		recorded = true
+	}
+	if !recorded {
+		return
 	}
 	loop.interruptedAssistantResponseID = responseID
 	loop.interruptedAssistantAuthor = agentEvent.Author
@@ -1348,7 +1359,6 @@ func (r *runner) recordInterruptedAssistantDelta(
 	if rsp.Created > 0 {
 		loop.interruptedAssistantCreated = rsp.Created
 	}
-	loop.interruptedAssistantContent.WriteString(content.String())
 }
 
 // safePersistInterruptedAssistant guards cancellation-time partial persistence
@@ -1363,7 +1373,7 @@ func (r *runner) safePersistInterruptedAssistant(ctx context.Context, loop *even
 }
 
 func (r *runner) persistInterruptedAssistant(ctx context.Context, loop *eventLoopContext) {
-	if ctx == nil || ctx.Err() == nil || loop == nil || loop.sess == nil {
+	if ctx.Err() == nil || loop == nil || loop.sess == nil {
 		return
 	}
 	interruptedEvent := r.interruptedAssistantEvent(ctx, loop)
@@ -1372,6 +1382,14 @@ func (r *runner) persistInterruptedAssistant(ctx context.Context, loop *eventLoo
 	}
 	persistCtx, cancel := sessionPersistenceContext(ctx)
 	defer cancel()
+	interruptedEvent = r.applyEventPlugins(
+		persistCtx,
+		loop.invocation,
+		interruptedEvent,
+	)
+	if interruptedEvent == nil {
+		return
+	}
 	if err := r.sessionService.AppendEvent(
 		persistCtx,
 		loop.sess,
@@ -1387,16 +1405,10 @@ func (r *runner) interruptedAssistantEvent(
 	ctx context.Context,
 	loop *eventLoopContext,
 ) *event.Event {
-	content := loop.interruptedAssistantContent.String()
-	if content == "" {
+	choices := interruptedAssistantChoices(loop)
+	if len(choices) == 0 {
 		return nil
 	}
-	finishReason := interruptedAssistantFinishReason
-	choices := []model.Choice{{
-		Index:        0,
-		Message:      model.NewAssistantMessage(content),
-		FinishReason: &finishReason,
-	}}
 	if r.interruptedAssistantAlreadyPersisted(loop, choices) {
 		return nil
 	}
@@ -1437,6 +1449,31 @@ func (r *runner) interruptedAssistantEvent(
 	return evt
 }
 
+func interruptedAssistantChoices(loop *eventLoopContext) []model.Choice {
+	if loop == nil || len(loop.interruptedAssistantChoiceContent) == 0 {
+		return nil
+	}
+	indexes := make([]int, 0, len(loop.interruptedAssistantChoiceContent))
+	for index := range loop.interruptedAssistantChoiceContent {
+		indexes = append(indexes, index)
+	}
+	sort.Ints(indexes)
+	finishReason := interruptedAssistantFinishReason
+	choices := make([]model.Choice, 0, len(indexes))
+	for _, index := range indexes {
+		content := loop.interruptedAssistantChoiceContent[index]
+		if content == nil || content.Len() == 0 {
+			continue
+		}
+		choices = append(choices, model.Choice{
+			Index:        index,
+			Message:      model.NewAssistantMessage(content.String()),
+			FinishReason: &finishReason,
+		})
+	}
+	return choices
+}
+
 func (r *runner) interruptedAssistantAlreadyPersisted(
 	loop *eventLoopContext,
 	choices []model.Choice,
@@ -1458,22 +1495,13 @@ func (r *runner) interruptedAssistantAlreadyPersisted(
 }
 
 func contextDoneReason(ctx context.Context) string {
-	if ctx == nil {
-		return ""
-	}
 	if cause := context.Cause(ctx); cause != nil {
 		return cause.Error()
-	}
-	if err := ctx.Err(); err != nil {
-		return err.Error()
 	}
 	return ""
 }
 
 func sessionPersistenceContext(ctx context.Context) (context.Context, context.CancelFunc) {
-	if ctx == nil {
-		return context.Background(), func() {}
-	}
 	if ctx.Err() == nil {
 		return ctx, func() {}
 	}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1237,7 +1237,11 @@ func recordPersistedAssistantOnAccumulator(
 			acc.persistedAssistantResponseIDs[responseID] = struct{}{}
 		}
 	}
-	signature := assistantChoiceSignature(agentEvent.Response.Choices)
+	signature := interruptedAssistantSignatureKey(
+		acc.requestID,
+		acc.invocationID,
+		agentEvent.Response.Choices,
+	)
 	if signature == "" {
 		return
 	}
@@ -1503,6 +1507,9 @@ func (r *runner) recordInterruptedAssistantDelta(
 	acc.responseID = responseID
 	acc.author = agentEvent.Author
 	captureInterruptedAssistantEventIdentity(acc, agentEvent)
+	if acc.requestID == "" && loop.invocation != nil {
+		acc.requestID = loop.invocation.RunOptions.RequestID
+	}
 	if rsp.Created > 0 {
 		acc.created = rsp.Created
 	}
@@ -1748,7 +1755,11 @@ func (r *runner) interruptedAssistantAlreadyPersistedForAccumulator(
 			return true
 		}
 	}
-	signature := assistantChoiceSignature(choices)
+	signature := interruptedAssistantSignatureKey(
+		acc.requestID,
+		acc.invocationID,
+		choices,
+	)
 	if signature == "" {
 		return false
 	}
@@ -2601,7 +2612,11 @@ func collectPriorAssistantChoiceSignatures(sess *session.Session) map[string]str
 		if isGraphCompletionEvent(evt) || !eventHasAssistantMessageContent(evt) {
 			continue
 		}
-		signature := assistantChoiceSignature(evt.Response.Choices)
+		signature := interruptedAssistantSignatureKey(
+			evt.RequestID,
+			evt.InvocationID,
+			evt.Response.Choices,
+		)
 		if signature == "" {
 			continue
 		}
@@ -2611,6 +2626,25 @@ func collectPriorAssistantChoiceSignatures(sess *session.Session) map[string]str
 		signatures[signature] = struct{}{}
 	}
 	return signatures
+}
+
+func interruptedAssistantSignatureKey(
+	requestID string,
+	invocationID string,
+	choices []model.Choice,
+) string {
+	signature := assistantChoiceSignature(choices)
+	if signature == "" {
+		return ""
+	}
+	lineage := requestID
+	if lineage == "" {
+		lineage = invocationID
+	}
+	if lineage == "" {
+		return signature
+	}
+	return lineage + "\x00" + signature
 }
 
 func baselineFinalResponseIDFromRuntimeState(runtimeState map[string]any) string {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1205,7 +1205,7 @@ func (r *runner) recordPersistedInterruptedAssistantSessionEvent(
 	agentEvent *event.Event,
 	persisted bool,
 ) {
-	acc := getInterruptedAssistantAccumulator(loop, persistSession)
+	acc := getInterruptedAssistantAccumulatorForEvent(loop, persistSession, agentEvent)
 	if acc == nil {
 		return
 	}
@@ -1408,13 +1408,33 @@ func interruptedAssistantAccumulatorForSession(
 	loop *eventLoopContext,
 	persistSession *session.Session,
 ) *interruptedAssistantAccumulator {
+	return interruptedAssistantAccumulatorForLineage(loop, persistSession, "")
+}
+
+func interruptedAssistantAccumulatorForEvent(
+	loop *eventLoopContext,
+	persistSession *session.Session,
+	agentEvent *event.Event,
+) *interruptedAssistantAccumulator {
+	return interruptedAssistantAccumulatorForLineage(
+		loop,
+		persistSession,
+		interruptedAssistantLineageKey(loop, agentEvent),
+	)
+}
+
+func interruptedAssistantAccumulatorForLineage(
+	loop *eventLoopContext,
+	persistSession *session.Session,
+	lineageKey string,
+) *interruptedAssistantAccumulator {
 	if loop == nil {
 		return nil
 	}
 	if persistSession == nil {
 		persistSession = loop.sess
 	}
-	key := interruptedAssistantSessionKey(persistSession)
+	key := interruptedAssistantAccumulatorKey(persistSession, lineageKey)
 	if loop.interruptedAssistants == nil {
 		loop.interruptedAssistants = make(map[string]*interruptedAssistantAccumulator)
 	}
@@ -1430,6 +1450,24 @@ func interruptedAssistantAccumulatorForSession(
 	return acc
 }
 
+func getInterruptedAssistantAccumulatorForEvent(
+	loop *eventLoopContext,
+	persistSession *session.Session,
+	agentEvent *event.Event,
+) *interruptedAssistantAccumulator {
+	if loop == nil || len(loop.interruptedAssistants) == 0 {
+		return nil
+	}
+	if persistSession == nil {
+		persistSession = loop.sess
+	}
+	key := interruptedAssistantAccumulatorKey(
+		persistSession,
+		interruptedAssistantLineageKey(loop, agentEvent),
+	)
+	return loop.interruptedAssistants[key]
+}
+
 func getInterruptedAssistantAccumulator(
 	loop *eventLoopContext,
 	persistSession *session.Session,
@@ -1440,7 +1478,18 @@ func getInterruptedAssistantAccumulator(
 	if persistSession == nil {
 		persistSession = loop.sess
 	}
-	return loop.interruptedAssistants[interruptedAssistantSessionKey(persistSession)]
+	prefix := interruptedAssistantAccumulatorKeyPrefix(persistSession)
+	var matched *interruptedAssistantAccumulator
+	for key, acc := range loop.interruptedAssistants {
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		if matched != nil {
+			return nil
+		}
+		matched = acc
+	}
+	return matched
 }
 
 func defaultInterruptedAssistantAccumulator(
@@ -1456,6 +1505,76 @@ func interruptedAssistantSessionKey(sess *session.Session) string {
 	return sess.AppName + "\x00" + sess.UserID + "\x00" + sess.ID
 }
 
+func interruptedAssistantAccumulatorKeyPrefix(sess *session.Session) string {
+	return interruptedAssistantSessionKey(sess) + "\x00"
+}
+
+func interruptedAssistantAccumulatorKey(sess *session.Session, lineageKey string) string {
+	return interruptedAssistantAccumulatorKeyPrefix(sess) + lineageKey
+}
+
+func interruptedAssistantLineageKey(
+	loop *eventLoopContext,
+	agentEvent *event.Event,
+) string {
+	if agentEvent == nil {
+		return ""
+	}
+	responseID := ""
+	if agentEvent.Response != nil {
+		responseID = agentEvent.Response.ID
+	}
+	invocationID := agentEvent.InvocationID
+	parentInvocationID := agentEvent.ParentInvocationID
+	branch := agentEvent.Branch
+	filterKey := agentEvent.FilterKey
+	requestID := agentEvent.RequestID
+	author := agentEvent.Author
+	if loop != nil && loop.invocation != nil {
+		inv := loop.invocation
+		if invocationID == "" {
+			invocationID = inv.InvocationID
+		}
+		if parentInvocationID == "" {
+			if parent := inv.GetParentInvocation(); parent != nil {
+				parentInvocationID = parent.InvocationID
+			}
+		}
+		if branch == "" {
+			branch = inv.Branch
+		}
+		if filterKey == "" {
+			filterKey = inv.GetEventFilterKey()
+		}
+		if requestID == "" {
+			requestID = inv.RunOptions.RequestID
+		}
+		if author == "" {
+			author = inv.AgentName
+		}
+	}
+	if responseID != "" {
+		return strings.Join([]string{
+			"response",
+			responseID,
+			requestID,
+			invocationID,
+			parentInvocationID,
+			branch,
+			filterKey,
+		}, "\x00")
+	}
+	return strings.Join([]string{
+		"fallback",
+		requestID,
+		invocationID,
+		parentInvocationID,
+		branch,
+		filterKey,
+		author,
+	}, "\x00")
+}
+
 func (r *runner) recordInterruptedAssistantDelta(
 	loop *eventLoopContext,
 	agentEvent *event.Event,
@@ -1468,7 +1587,10 @@ func (r *runner) recordInterruptedAssistantDelta(
 	if !rsp.IsPartial || rsp.IsToolCallResponse() || rsp.IsToolResultResponse() {
 		return
 	}
-	acc := interruptedAssistantAccumulatorForSession(loop, persistSession)
+	if !interruptedAssistantHasTextDelta(rsp) {
+		return
+	}
+	acc := interruptedAssistantAccumulatorForEvent(loop, persistSession, agentEvent)
 	if acc == nil {
 		return
 	}
@@ -1478,9 +1600,6 @@ func (r *runner) recordInterruptedAssistantDelta(
 	}
 	if responseID == "" {
 		responseID = "interrupted-assistant-" + uuid.NewString()
-	}
-	if acc.responseID != "" && responseID != acc.responseID {
-		resetInterruptedAssistantStreamState(acc)
 	}
 	recorded := false
 	for _, choice := range rsp.Choices {
@@ -1513,18 +1632,19 @@ func (r *runner) recordInterruptedAssistantDelta(
 	}
 }
 
-func resetInterruptedAssistantStreamState(acc *interruptedAssistantAccumulator) {
-	if acc == nil {
-		return
+func interruptedAssistantHasTextDelta(rsp *model.Response) bool {
+	if rsp == nil {
+		return false
 	}
-	acc.choiceContent = nil
-	acc.author = ""
-	acc.invocationID = ""
-	acc.parentInvocationID = ""
-	acc.branch = ""
-	acc.filterKey = ""
-	acc.requestID = ""
-	acc.created = 0
+	for _, choice := range rsp.Choices {
+		if choice.Delta.Role != "" && choice.Delta.Role != model.RoleAssistant {
+			continue
+		}
+		if choice.Delta.Content != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func captureInterruptedAssistantEventIdentity(
@@ -1613,7 +1733,13 @@ func (r *runner) persistInterruptedAssistant(ctx context.Context, loop *eventLoo
 	}
 	persistCtx, cancel := sessionPersistenceContext(ctx)
 	defer cancel()
-	for _, acc := range loop.interruptedAssistants {
+	keys := make([]string, 0, len(loop.interruptedAssistants))
+	for key := range loop.interruptedAssistants {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		acc := loop.interruptedAssistants[key]
 		persistSession := acc.sess
 		if persistSession == nil {
 			persistSession = loop.sess

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -979,6 +979,10 @@ type interruptedAssistantAccumulator struct {
 	responseID                         string
 	author                             string
 	invocationID                       string
+	parentInvocationID                 string
+	branch                             string
+	filterKey                          string
+	requestID                          string
 	created                            int64
 	choiceContent                      map[int]*strings.Builder
 	persistedAssistantResponseIDs      map[string]struct{}
@@ -1472,7 +1476,7 @@ func (r *runner) recordInterruptedAssistantDelta(
 		responseID = "interrupted-assistant-" + uuid.NewString()
 	}
 	if acc.responseID != "" && responseID != acc.responseID {
-		acc.choiceContent = nil
+		resetInterruptedAssistantStreamState(acc)
 	}
 	recorded := false
 	for _, choice := range rsp.Choices {
@@ -1498,10 +1502,81 @@ func (r *runner) recordInterruptedAssistantDelta(
 	}
 	acc.responseID = responseID
 	acc.author = agentEvent.Author
-	acc.invocationID = agentEvent.InvocationID
+	captureInterruptedAssistantEventIdentity(acc, agentEvent)
 	if rsp.Created > 0 {
 		acc.created = rsp.Created
 	}
+}
+
+func resetInterruptedAssistantStreamState(acc *interruptedAssistantAccumulator) {
+	if acc == nil {
+		return
+	}
+	acc.choiceContent = nil
+	acc.author = ""
+	acc.invocationID = ""
+	acc.parentInvocationID = ""
+	acc.branch = ""
+	acc.filterKey = ""
+	acc.requestID = ""
+	acc.created = 0
+}
+
+func captureInterruptedAssistantEventIdentity(
+	acc *interruptedAssistantAccumulator,
+	agentEvent *event.Event,
+) {
+	if acc == nil || agentEvent == nil {
+		return
+	}
+	if agentEvent.InvocationID != "" {
+		acc.invocationID = agentEvent.InvocationID
+	}
+	if agentEvent.ParentInvocationID != "" {
+		acc.parentInvocationID = agentEvent.ParentInvocationID
+	}
+	if agentEvent.Branch != "" {
+		acc.branch = agentEvent.Branch
+	}
+	if agentEvent.FilterKey != "" {
+		acc.filterKey = agentEvent.FilterKey
+	}
+	if agentEvent.RequestID != "" {
+		acc.requestID = agentEvent.RequestID
+	}
+}
+
+func injectInterruptedAssistantEventIdentity(
+	inv *agent.Invocation,
+	acc *interruptedAssistantAccumulator,
+	evt *event.Event,
+) {
+	if evt == nil || acc == nil {
+		return
+	}
+	if acc.invocationID != "" {
+		evt.InvocationID = acc.invocationID
+	}
+	if acc.parentInvocationID != "" {
+		evt.ParentInvocationID = acc.parentInvocationID
+	}
+	if acc.branch != "" {
+		evt.Branch = acc.branch
+	}
+	if acc.filterKey != "" {
+		evt.FilterKey = acc.filterKey
+	}
+	if evt.RequestID != "" {
+		return
+	}
+	if acc.requestID != "" {
+		evt.RequestID = acc.requestID
+		return
+	}
+	if inv == nil {
+		return
+	}
+	evt.RequestID = inv.RunOptions.RequestID
 }
 
 // safePersistInterruptedAssistant guards cancellation-time partial persistence
@@ -1605,7 +1680,7 @@ func (r *runner) interruptedAssistantEventForAccumulator(
 			Choices:   choices,
 		},
 	)
-	agent.InjectIntoEvent(loop.invocation, evt)
+	injectInterruptedAssistantEventIdentity(loop.invocation, acc, evt)
 	if reason := contextDoneReason(ctx); reason != "" {
 		if payload, err := json.Marshal(
 			interruptedAssistantMetadata{Reason: reason},

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -45,8 +45,11 @@ import (
 const (
 	authorUser = "user"
 
-	errMsgEmptyRequestID = "runner: empty request id"
-	errMsgNilCancelFunc  = "runner: nil cancel function"
+	errMsgEmptyRequestID               = "runner: empty request id"
+	errMsgNilCancelFunc                = "runner: nil cancel function"
+	interruptedAssistantFinishReason   = "cancelled"
+	interruptedAssistantExtensionKey   = "trpc_agent.runner.interrupted_assistant"
+	cancelledSessionPersistenceTimeout = time.Second
 )
 
 var (
@@ -935,6 +938,11 @@ type eventLoopContext struct {
 	visibleCompletionChoiceSignatures  map[string]struct{}
 	sawTerminalError                   bool
 	streamFilter                       graph.StreamModeFilter
+	interruptedAssistantResponseID     string
+	interruptedAssistantAuthor         string
+	interruptedAssistantInvocationID   string
+	interruptedAssistantCreated        int64
+	interruptedAssistantContent        strings.Builder
 	// emittedAssistantResponseIDs tracks response IDs that already produced a
 	// non-partial assistant message event during this run.
 	//
@@ -980,6 +988,7 @@ func (r *runner) runEventLoop(ctx context.Context, loop *eventLoopContext) {
 		}
 		// Agent event stream completed.
 		steer.Close(loop.invocation)
+		r.safePersistInterruptedAssistant(ctx, loop)
 		r.safeEmitRunnerCompletion(ctx, loop)
 		// Disable further flush requests for this invocation.
 		flush.Clear(loop.invocation)
@@ -1097,6 +1106,9 @@ func (r *runner) processSingleAgentEvent(ctx context.Context, loop *eventLoopCon
 	// Emit event to output channel.
 	if err := event.EmitEvent(ctx, loop.processedEventCh, agentEvent); err != nil {
 		return fmt.Errorf("emit event to output channel: %w", err)
+	}
+	if !excludeRootCompletion {
+		r.recordInterruptedAssistantDelta(loop, agentEvent)
 	}
 
 	return nil
@@ -1290,6 +1302,185 @@ func eventHasAssistantMessageContent(e *event.Event) bool {
 		}
 	}
 	return false
+}
+
+type interruptedAssistantMetadata struct {
+	Reason string `json:"reason,omitempty"`
+}
+
+func (r *runner) recordInterruptedAssistantDelta(
+	loop *eventLoopContext,
+	agentEvent *event.Event,
+) {
+	if loop == nil || agentEvent == nil || agentEvent.Response == nil {
+		return
+	}
+	rsp := agentEvent.Response
+	if !rsp.IsPartial || rsp.IsToolCallResponse() || rsp.IsToolResultResponse() {
+		return
+	}
+	var content strings.Builder
+	for _, choice := range rsp.Choices {
+		if choice.Delta.Role != "" && choice.Delta.Role != model.RoleAssistant {
+			continue
+		}
+		if choice.Delta.Content != "" {
+			content.WriteString(choice.Delta.Content)
+		}
+	}
+	if content.Len() == 0 {
+		return
+	}
+	responseID := rsp.ID
+	if responseID == "" {
+		responseID = loop.interruptedAssistantResponseID
+	}
+	if responseID == "" {
+		responseID = "interrupted-assistant-" + uuid.NewString()
+	}
+	if loop.interruptedAssistantResponseID != "" &&
+		responseID != loop.interruptedAssistantResponseID {
+		loop.interruptedAssistantContent.Reset()
+	}
+	loop.interruptedAssistantResponseID = responseID
+	loop.interruptedAssistantAuthor = agentEvent.Author
+	loop.interruptedAssistantInvocationID = agentEvent.InvocationID
+	if rsp.Created > 0 {
+		loop.interruptedAssistantCreated = rsp.Created
+	}
+	loop.interruptedAssistantContent.WriteString(content.String())
+}
+
+// safePersistInterruptedAssistant guards cancellation-time partial persistence
+// against panics from session services.
+func (r *runner) safePersistInterruptedAssistant(ctx context.Context, loop *eventLoopContext) {
+	defer func() {
+		if rr := recover(); rr != nil {
+			log.Errorf("panic persisting interrupted assistant: %v\n%s", rr, string(debug.Stack()))
+		}
+	}()
+	r.persistInterruptedAssistant(ctx, loop)
+}
+
+func (r *runner) persistInterruptedAssistant(ctx context.Context, loop *eventLoopContext) {
+	if ctx == nil || ctx.Err() == nil || loop == nil || loop.sess == nil {
+		return
+	}
+	interruptedEvent := r.interruptedAssistantEvent(ctx, loop)
+	if interruptedEvent == nil {
+		return
+	}
+	persistCtx, cancel := sessionPersistenceContext(ctx)
+	defer cancel()
+	if err := r.sessionService.AppendEvent(
+		persistCtx,
+		loop.sess,
+		interruptedEvent,
+	); err != nil {
+		log.Errorf("Failed to append interrupted assistant event to session: %v", err)
+		return
+	}
+	r.recordPersistedAssistantEvent(loop, interruptedEvent, true)
+}
+
+func (r *runner) interruptedAssistantEvent(
+	ctx context.Context,
+	loop *eventLoopContext,
+) *event.Event {
+	content := loop.interruptedAssistantContent.String()
+	if content == "" {
+		return nil
+	}
+	finishReason := interruptedAssistantFinishReason
+	choices := []model.Choice{{
+		Index:        0,
+		Message:      model.NewAssistantMessage(content),
+		FinishReason: &finishReason,
+	}}
+	if r.interruptedAssistantAlreadyPersisted(loop, choices) {
+		return nil
+	}
+	created := loop.interruptedAssistantCreated
+	if created == 0 {
+		created = time.Now().Unix()
+	}
+	author := loop.interruptedAssistantAuthor
+	if author == "" && loop.invocation != nil {
+		author = loop.invocation.AgentName
+	}
+	invocationID := loop.interruptedAssistantInvocationID
+	if invocationID == "" && loop.invocation != nil {
+		invocationID = loop.invocation.InvocationID
+	}
+	evt := event.NewResponseEvent(
+		invocationID,
+		author,
+		&model.Response{
+			ID:        loop.interruptedAssistantResponseID,
+			Object:    model.ObjectTypeChatCompletion,
+			Created:   created,
+			Done:      true,
+			IsPartial: false,
+			Choices:   choices,
+		},
+	)
+	agent.InjectIntoEvent(loop.invocation, evt)
+	if reason := contextDoneReason(ctx); reason != "" {
+		if payload, err := json.Marshal(
+			interruptedAssistantMetadata{Reason: reason},
+		); err == nil {
+			evt.Extensions = map[string]json.RawMessage{
+				interruptedAssistantExtensionKey: payload,
+			}
+		}
+	}
+	return evt
+}
+
+func (r *runner) interruptedAssistantAlreadyPersisted(
+	loop *eventLoopContext,
+	choices []model.Choice,
+) bool {
+	if loop == nil {
+		return false
+	}
+	if loop.interruptedAssistantResponseID != "" {
+		if _, ok := loop.persistedAssistantResponseIDs[loop.interruptedAssistantResponseID]; ok {
+			return true
+		}
+	}
+	signature := assistantChoiceSignature(choices)
+	if signature == "" {
+		return false
+	}
+	_, ok := loop.persistedAssistantChoiceSignatures[signature]
+	return ok
+}
+
+func contextDoneReason(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		return cause.Error()
+	}
+	if err := ctx.Err(); err != nil {
+		return err.Error()
+	}
+	return ""
+}
+
+func sessionPersistenceContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if ctx == nil {
+		return context.Background(), func() {}
+	}
+	if ctx.Err() == nil {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(
+		context.WithoutCancel(ctx),
+		cancelledSessionPersistenceTimeout,
+	)
 }
 
 // safeEmitRunnerCompletion guards emitRunnerCompletion against panics from session services.
@@ -1710,13 +1901,17 @@ func (r *runner) emitRunnerCompletion(ctx context.Context, loop *eventLoopContex
 			persistRunnerCompletionEvent.StateDelta,
 		)
 	}
-	if err := r.sessionService.AppendEvent(
-		ctx,
-		loop.sess,
-		persistRunnerCompletionEvent,
-	); err != nil {
-		log.Errorf("Failed to append runner completion event to session: %v", err)
-	}
+	func() {
+		persistCtx, persistCancel := sessionPersistenceContext(ctx)
+		defer persistCancel()
+		if err := r.sessionService.AppendEvent(
+			persistCtx,
+			loop.sess,
+			persistRunnerCompletionEvent,
+		); err != nil {
+			log.Errorf("Failed to append runner completion event to session: %v", err)
+		}
+	}()
 
 	// Use a context to deliver runner-completion after cancellation without blocking cleanup indefinitely.
 	func() {
@@ -2069,7 +2264,7 @@ func collectPriorAssistantResponseIDs(sess *session.Session) map[string]struct{}
 	var responseIDs map[string]struct{}
 	for i := range sess.Events {
 		evt := &sess.Events[i]
-		if evt == nil || evt.Response == nil || evt.IsPartial {
+		if evt.Response == nil || evt.IsPartial {
 			continue
 		}
 		if isGraphCompletionEvent(evt) {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -2645,14 +2645,16 @@ func interruptedAssistantSignatureKey(
 	if signature == "" {
 		return ""
 	}
-	lineage := requestID
-	if lineage == "" {
-		lineage = invocationID
-	}
-	if lineage == "" {
+	switch {
+	case requestID != "" && invocationID != "":
+		return requestID + "\x00" + invocationID + "\x00" + signature
+	case requestID != "":
+		return requestID + "\x00" + signature
+	case invocationID != "":
+		return invocationID + "\x00" + signature
+	default:
 		return signature
 	}
-	return lineage + "\x00" + signature
 }
 
 func baselineFinalResponseIDFromRuntimeState(runtimeState map[string]any) string {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1507,9 +1507,7 @@ func (r *runner) recordInterruptedAssistantDelta(
 	acc.responseID = responseID
 	acc.author = agentEvent.Author
 	captureInterruptedAssistantEventIdentity(acc, agentEvent)
-	if acc.requestID == "" && loop.invocation != nil {
-		acc.requestID = loop.invocation.RunOptions.RequestID
-	}
+	fillInterruptedAssistantRequestID(acc, loop)
 	if rsp.Created > 0 {
 		acc.created = rsp.Created
 	}
@@ -1551,6 +1549,16 @@ func captureInterruptedAssistantEventIdentity(
 	if agentEvent.RequestID != "" {
 		acc.requestID = agentEvent.RequestID
 	}
+}
+
+func fillInterruptedAssistantRequestID(
+	acc *interruptedAssistantAccumulator,
+	loop *eventLoopContext,
+) {
+	if acc == nil || acc.requestID != "" || loop == nil || loop.invocation == nil {
+		return
+	}
+	acc.requestID = loop.invocation.RunOptions.RequestID
 }
 
 func injectInterruptedAssistantEventIdentity(

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -7262,6 +7262,128 @@ func TestPersistInterruptedAssistantPersistsInterleavedBuffers(t *testing.T) {
 	}, persisted)
 }
 
+func TestPersistInterruptedAssistantPreservesFirstSeenOrder(t *testing.T) {
+	svc := &mockSessionService{}
+	rr := &runner{sessionService: svc}
+	sess := session.NewSession("app", "u", "s")
+	inv := agent.NewInvocation(
+		agent.WithInvocationRunOptions(agent.NewRunOptions(
+			agent.WithPersistInterruptedAssistant(true),
+		)),
+	)
+	loop := &eventLoopContext{
+		sess:       sess,
+		invocation: inv,
+	}
+	first := event.NewResponseEvent(
+		"inv",
+		"assistant",
+		&model.Response{
+			ID:        "z-response",
+			Object:    model.ObjectTypeChatCompletionChunk,
+			IsPartial: true,
+			Choices: []model.Choice{{
+				Index: 0,
+				Delta: model.Message{
+					Role:    model.RoleAssistant,
+					Content: "first",
+				},
+			}},
+		},
+	)
+	second := event.NewResponseEvent(
+		"inv",
+		"assistant",
+		&model.Response{
+			ID:        "a-response",
+			Object:    model.ObjectTypeChatCompletionChunk,
+			IsPartial: true,
+			Choices: []model.Choice{{
+				Index: 0,
+				Delta: model.Message{
+					Role:    model.RoleAssistant,
+					Content: "second",
+				},
+			}},
+		},
+	)
+	rr.recordInterruptedAssistantDelta(loop, first, nil)
+	rr.recordInterruptedAssistantDelta(loop, second, nil)
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	rr.persistInterruptedAssistant(cancelled, loop)
+
+	require.Len(t, svc.appendEventCalls, 2)
+	require.Equal(t, "z-response", svc.appendEventCalls[0].event.Response.ID)
+	require.Equal(t, "first", svc.appendEventCalls[0].event.Choices[0].Message.Content)
+	require.Equal(t, "a-response", svc.appendEventCalls[1].event.Response.ID)
+	require.Equal(t, "second", svc.appendEventCalls[1].event.Choices[0].Message.Content)
+}
+
+func TestPersistInterruptedAssistantDedupeAfterEventPlugin(t *testing.T) {
+	const requestID = "req-plugin-dedupe"
+	p := &testPlugin{
+		name: "final-content-plugin",
+		reg: func(r *plugin.Registry) {
+			r.OnEvent(func(
+				ctx context.Context,
+				inv *agent.Invocation,
+				e *event.Event,
+			) (*event.Event, error) {
+				if e == nil || e.Response == nil || e.IsPartial {
+					return e, nil
+				}
+				for i := range e.Response.Choices {
+					e.Response.Choices[i].Message.Content += "!"
+				}
+				return e, nil
+			})
+		},
+	}
+	svc := &mockSessionService{}
+	rr := &runner{sessionService: svc}
+	inv := agent.NewInvocation(
+		agent.WithInvocationRunOptions(agent.NewRunOptions(
+			agent.WithRequestID(requestID),
+			agent.WithPersistInterruptedAssistant(true),
+		)),
+	)
+	inv.Plugins = plugin.MustNewManager(p)
+	loop := &eventLoopContext{
+		sess:             session.NewSession("app", "u", "s"),
+		invocation:       inv,
+		processedEventCh: make(chan *event.Event, 2),
+		streamFilter:     graph.NewStreamModeFilter(false, nil),
+	}
+
+	partial := interruptedAssistantPartialEvent(inv.InvocationID, "hello")
+	partial.RequestID = requestID
+	require.NoError(t, rr.processSingleAgentEvent(context.Background(), loop, partial))
+	final := event.NewResponseEvent(
+		inv.InvocationID,
+		"assistant",
+		&model.Response{
+			Object: model.ObjectTypeChatCompletion,
+			Done:   true,
+			Choices: []model.Choice{{
+				Index:   0,
+				Message: model.NewAssistantMessage("hello"),
+			}},
+		},
+	)
+	final.RequestID = requestID
+	require.NoError(t, rr.processSingleAgentEvent(context.Background(), loop, final))
+	require.Len(t, svc.appendEventCalls, 1)
+	require.Equal(t, "hello!", svc.appendEventCalls[0].event.Choices[0].Message.Content)
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	rr.persistInterruptedAssistant(cancelled, loop)
+
+	require.Len(t, svc.appendEventCalls, 1)
+}
+
 func TestInterruptedAssistantDeltaGeneratesFallbackResponseID(t *testing.T) {
 	rr := NewRunner("app", &noOpAgent{name: "a"}).(*runner)
 	loop := &eventLoopContext{}

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -37,6 +37,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/graph"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/flush"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/sessionroute"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/steer"
 	runnerlog "trpc.group/trpc-go/trpc-agent-go/log"
 	memoryinmemory "trpc.group/trpc-go/trpc-agent-go/memory/inmemory"
@@ -53,6 +54,17 @@ import (
 // mockAgent implements the agent.Agent interface for testing.
 type mockAgent struct {
 	name string
+}
+
+type staticSessionRouter struct {
+	sess *session.Session
+}
+
+func (r staticSessionRouter) RouteEvent(
+	_ *agent.Invocation,
+	_ *event.Event,
+) (*session.Session, bool) {
+	return r.sess, r.sess != nil
 }
 
 func (m *mockAgent) Info() agent.Info {
@@ -6497,6 +6509,141 @@ func TestRunner_StreamModeUpdatesStillPersistsInterruptedPartialAssistant(t *tes
 	require.Equal(t, "filtered text", choices[0].Message.Content)
 }
 
+func TestRunner_InterruptedAssistantPluginRunsOnce(t *testing.T) {
+	const requestID = "req-cancel-plugin-once"
+	p := &testPlugin{
+		name: "append-once-plugin",
+		reg: func(r *plugin.Registry) {
+			r.OnEvent(func(
+				ctx context.Context,
+				inv *agent.Invocation,
+				e *event.Event,
+			) (*event.Event, error) {
+				if e == nil || e.Response == nil {
+					return e, nil
+				}
+				for i := range e.Response.Choices {
+					if e.IsPartial {
+						e.Response.Choices[i].Delta.Content += "!"
+						continue
+					}
+					e.Response.Choices[i].Message.Content += "!"
+				}
+				return e, nil
+			})
+		},
+	}
+	svc := sessioninmemory.NewSessionService()
+	r := NewRunner(
+		"app",
+		&partialTextAgent{
+			name:          "partial",
+			chunks:        []string{"hello"},
+			waitForCancel: true,
+		},
+		WithSessionService(svc),
+		WithPlugins(p),
+	)
+	mr, ok := r.(ManagedRunner)
+	require.True(t, ok)
+
+	ch, err := r.Run(
+		context.Background(),
+		"u",
+		"s-plugin-once",
+		model.NewUserMessage("start"),
+		agent.WithRequestID(requestID),
+		agent.WithDetachedCancel(true),
+		agent.WithPersistInterruptedAssistant(true),
+	)
+	require.NoError(t, err)
+	select {
+	case evt, ok := <-ch:
+		require.True(t, ok)
+		require.Equal(t, "hello!", evt.Choices[0].Delta.Content)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for partial event")
+	}
+	require.True(t, mr.Cancel(requestID))
+	select {
+	case <-drainChannel(ch):
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for cancelled run to finish")
+	}
+
+	sess, err := svc.GetSession(
+		context.Background(),
+		session.Key{AppName: "app", UserID: "u", SessionID: "s-plugin-once"},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Len(t, sess.Events, 2)
+	require.Equal(t, "hello!", sess.Events[1].Choices[0].Message.Content)
+}
+
+func TestRunner_RoutedSessionPersistsInterruptedPartialAssistant(t *testing.T) {
+	svc := &mockSessionService{}
+	rootSess := session.NewSession("app", "u", "root")
+	routedSess := session.NewSession("app", "u", "member")
+
+	rr := NewRunner(
+		"app",
+		&noOpAgent{name: "a"},
+		WithSessionService(svc),
+	).(*runner)
+	inv := agent.NewInvocation(
+		agent.WithInvocationRunOptions(agent.NewRunOptions(
+			agent.WithPersistInterruptedAssistant(true),
+		)),
+	)
+	sessionroute.AttachEventRouter(inv, staticSessionRouter{sess: routedSess})
+	require.True(t, shouldPersistInterruptedAssistant(&eventLoopContext{invocation: inv}))
+	loop := &eventLoopContext{
+		sess:             rootSess,
+		invocation:       inv,
+		processedEventCh: make(chan *event.Event, 1),
+		streamFilter:     graph.NewStreamModeFilter(false, nil),
+	}
+
+	err := rr.processSingleAgentEvent(context.Background(), loop, event.NewResponseEvent(
+		inv.InvocationID,
+		"member",
+		&model.Response{
+			ID:        "routed-partial",
+			Object:    model.ObjectTypeChatCompletionChunk,
+			IsPartial: true,
+			Choices: []model.Choice{{
+				Index: 0,
+				Delta: model.Message{
+					Role:    model.RoleAssistant,
+					Content: "member text",
+				},
+			}},
+		},
+	))
+	require.NoError(t, err)
+	require.Len(t, loop.interruptedAssistants, 1)
+	require.Equal(
+		t,
+		"member text",
+		interruptedAssistantChoicesFromAccumulator(
+			getInterruptedAssistantAccumulator(loop, routedSess),
+		)[0].Message.Content,
+	)
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.NotNil(t, rr.interruptedAssistantEventForAccumulator(
+		cancelled,
+		loop,
+		getInterruptedAssistantAccumulator(loop, routedSess),
+	))
+	rr.persistInterruptedAssistant(cancelled, loop)
+	require.Len(t, svc.appendEventCalls, 1)
+	require.Same(t, routedSess, svc.appendEventCalls[0].sess)
+	require.Equal(t, "member text", svc.appendEventCalls[0].event.Choices[0].Message.Content)
+}
+
 func TestRunner_CancelDoesNotPersistInterruptedPartialAssistantByDefault(t *testing.T) {
 	const (
 		requestID = "req-cancel-partial-default"
@@ -6721,7 +6868,7 @@ func TestRunner_CancelDoesNotPersistNonTextPartialAssistant(t *testing.T) {
 func TestInterruptedAssistantDeltaResetsOnNewResponse(t *testing.T) {
 	rr := NewRunner("app", &noOpAgent{name: "a"}).(*runner)
 	loop := &eventLoopContext{}
-	rr.recordInterruptedAssistantDelta(nil, nil)
+	rr.recordInterruptedAssistantDelta(nil, nil, nil)
 	rr.recordInterruptedAssistantDelta(loop, event.NewResponseEvent(
 		"inv",
 		"assistant",
@@ -6733,7 +6880,7 @@ func TestInterruptedAssistantDeltaResetsOnNewResponse(t *testing.T) {
 				Message: model.NewAssistantMessage("final"),
 			}},
 		},
-	))
+	), nil)
 	rr.recordInterruptedAssistantDelta(loop, event.NewResponseEvent(
 		"inv",
 		"assistant",
@@ -6748,7 +6895,7 @@ func TestInterruptedAssistantDeltaResetsOnNewResponse(t *testing.T) {
 				},
 			}},
 		},
-	))
+	), nil)
 	require.Empty(t, interruptedAssistantChoices(loop))
 
 	rr.recordInterruptedAssistantDelta(loop, event.NewResponseEvent(
@@ -6766,7 +6913,7 @@ func TestInterruptedAssistantDeltaResetsOnNewResponse(t *testing.T) {
 				},
 			}},
 		},
-	))
+	), nil)
 	rr.recordInterruptedAssistantDelta(loop, event.NewResponseEvent(
 		"inv",
 		"assistant",
@@ -6782,9 +6929,9 @@ func TestInterruptedAssistantDeltaResetsOnNewResponse(t *testing.T) {
 				},
 			}},
 		},
-	))
+	), nil)
 
-	require.Equal(t, "response-2", loop.interruptedAssistantResponseID)
+	require.Equal(t, "response-2", defaultInterruptedAssistantAccumulator(loop).responseID)
 	require.Equal(t, "second", interruptedAssistantChoices(loop)[0].Message.Content)
 }
 
@@ -6804,8 +6951,8 @@ func TestInterruptedAssistantDeltaGeneratesFallbackResponseID(t *testing.T) {
 				},
 			}},
 		},
-	))
-	require.NotEmpty(t, loop.interruptedAssistantResponseID)
+	), nil)
+	require.NotEmpty(t, defaultInterruptedAssistantAccumulator(loop).responseID)
 	require.Equal(t, "chunk", interruptedAssistantChoices(loop)[0].Message.Content)
 }
 
@@ -6836,7 +6983,7 @@ func TestInterruptedAssistantDeltaPreservesChoiceIndexes(t *testing.T) {
 				},
 			},
 		},
-	))
+	), nil)
 	evt := rr.interruptedAssistantEvent(context.Background(), loop)
 	require.NotNil(t, evt)
 	require.Len(t, evt.Choices, 2)
@@ -6854,27 +7001,28 @@ func TestInterruptedAssistantAlreadyPersisted(t *testing.T) {
 	}}
 
 	t.Run("by response id", func(t *testing.T) {
-		loop := &eventLoopContext{
-			interruptedAssistantResponseID: "resp",
-			persistedAssistantResponseIDs: map[string]struct{}{
-				"resp": {},
-			},
+		loop := &eventLoopContext{}
+		acc := interruptedAssistantAccumulatorForSession(loop, nil)
+		acc.responseID = "resp"
+		acc.persistedAssistantResponseIDs = map[string]struct{}{
+			"resp": {},
 		}
 		require.True(t, rr.interruptedAssistantAlreadyPersisted(loop, choices))
 	})
 
 	t.Run("by choice signature", func(t *testing.T) {
-		loop := &eventLoopContext{
-			interruptedAssistantResponseID: "different",
-			persistedAssistantChoiceSignatures: map[string]struct{}{
-				assistantChoiceSignature(choices): {},
-			},
+		loop := &eventLoopContext{}
+		acc := interruptedAssistantAccumulatorForSession(loop, nil)
+		acc.responseID = "different"
+		acc.persistedAssistantChoiceSignatures = map[string]struct{}{
+			assistantChoiceSignature(choices): {},
 		}
 		require.True(t, rr.interruptedAssistantAlreadyPersisted(loop, choices))
 	})
 
 	t.Run("not persisted", func(t *testing.T) {
-		loop := &eventLoopContext{interruptedAssistantResponseID: "resp"}
+		loop := &eventLoopContext{}
+		interruptedAssistantAccumulatorForSession(loop, nil).responseID = "resp"
 		require.False(t, rr.interruptedAssistantAlreadyPersisted(loop, choices))
 	})
 
@@ -6883,7 +7031,8 @@ func TestInterruptedAssistantAlreadyPersisted(t *testing.T) {
 	})
 
 	t.Run("empty signature", func(t *testing.T) {
-		loop := &eventLoopContext{interruptedAssistantResponseID: "resp"}
+		loop := &eventLoopContext{}
+		interruptedAssistantAccumulatorForSession(loop, nil).responseID = "resp"
 		require.False(t, rr.interruptedAssistantAlreadyPersisted(loop, nil))
 	})
 }
@@ -6897,11 +7046,11 @@ func TestInterruptedAssistantEventSkipsEmptyAndPersistedContent(t *testing.T) {
 		Index:   0,
 		Message: model.NewAssistantMessage("already there"),
 	}}
-	loop := &eventLoopContext{
-		interruptedAssistantResponseID: "resp",
-		persistedAssistantChoiceSignatures: map[string]struct{}{
-			assistantChoiceSignature(choices): {},
-		},
+	loop := &eventLoopContext{}
+	acc := interruptedAssistantAccumulatorForSession(loop, nil)
+	acc.responseID = "resp"
+	acc.persistedAssistantChoiceSignatures = map[string]struct{}{
+		assistantChoiceSignature(choices): {},
 	}
 	rr.recordInterruptedAssistantDelta(loop, event.NewResponseEvent(
 		"inv",
@@ -6917,7 +7066,7 @@ func TestInterruptedAssistantEventSkipsEmptyAndPersistedContent(t *testing.T) {
 				},
 			}},
 		},
-	))
+	), nil)
 	require.Nil(t, rr.interruptedAssistantEvent(context.Background(), loop))
 }
 
@@ -6937,8 +7086,7 @@ func TestPersistInterruptedAssistantGuardBranches(t *testing.T) {
 		invocation: agent.NewInvocation(agent.WithInvocationRunOptions(agent.NewRunOptions(
 			agent.WithPersistInterruptedAssistant(true),
 		))),
-		sess:                           &session.Session{},
-		interruptedAssistantResponseID: "resp",
+		sess: &session.Session{},
 	}
 	appendErrRunner.recordInterruptedAssistantDelta(loop, event.NewResponseEvent(
 		"inv",
@@ -6954,7 +7102,7 @@ func TestPersistInterruptedAssistantGuardBranches(t *testing.T) {
 				},
 			}},
 		},
-	))
+	), nil)
 	appendErrRunner.persistInterruptedAssistant(cancelled, loop)
 	require.Len(t, base.appendEventCalls, 1)
 }

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -6414,6 +6414,7 @@ func TestRunner_CancelPersistsInterruptedPartialAssistant(t *testing.T) {
 		model.NewUserMessage("start"),
 		agent.WithRequestID(requestID),
 		agent.WithDetachedCancel(true),
+		agent.WithPersistInterruptedAssistant(true),
 	)
 	require.NoError(t, err)
 
@@ -6460,6 +6461,7 @@ func TestRunner_StreamModeUpdatesStillPersistsInterruptedPartialAssistant(t *tes
 	inv := agent.NewInvocation(
 		agent.WithInvocationRunOptions(agent.NewRunOptions(
 			agent.WithStreamMode(agent.StreamModeUpdates),
+			agent.WithPersistInterruptedAssistant(true),
 		)),
 	)
 	loop := &eventLoopContext{
@@ -6493,6 +6495,127 @@ func TestRunner_StreamModeUpdatesStillPersistsInterruptedPartialAssistant(t *tes
 	choices := interruptedAssistantChoices(loop)
 	require.Len(t, choices, 1)
 	require.Equal(t, "filtered text", choices[0].Message.Content)
+}
+
+func TestRunner_CancelDoesNotPersistInterruptedPartialAssistantByDefault(t *testing.T) {
+	const (
+		requestID = "req-cancel-partial-default"
+		userID    = "u"
+		sessionID = "s-default"
+	)
+	svc := sessioninmemory.NewSessionService()
+	r := NewRunner(
+		"app",
+		&partialTextAgent{
+			name:          "partial",
+			chunks:        []string{"discard ", "me"},
+			waitForCancel: true,
+		},
+		WithSessionService(svc),
+	)
+	mr, ok := r.(ManagedRunner)
+	require.True(t, ok)
+
+	ch, err := r.Run(
+		context.Background(),
+		userID,
+		sessionID,
+		model.NewUserMessage("start"),
+		agent.WithRequestID(requestID),
+		agent.WithDetachedCancel(true),
+	)
+	require.NoError(t, err)
+	for i := 0; i < 2; i++ {
+		select {
+		case _, ok := <-ch:
+			require.True(t, ok)
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for partial event")
+		}
+	}
+	require.True(t, mr.Cancel(requestID))
+	select {
+	case <-drainChannel(ch):
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for cancelled run to finish")
+	}
+
+	sess, err := svc.GetSession(
+		context.Background(),
+		session.Key{AppName: "app", UserID: userID, SessionID: sessionID},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Len(t, sess.Events, 1)
+	require.True(t, sess.Events[0].IsUserMessage())
+}
+
+func TestRunner_RunOptionOverridesInterruptedAssistantRunnerDefault(t *testing.T) {
+	const (
+		requestID = "req-cancel-partial-override"
+		userID    = "u"
+		sessionID = "s-override"
+	)
+	svc := sessioninmemory.NewSessionService()
+	r := NewRunner(
+		"app",
+		&partialTextAgent{
+			name:          "partial",
+			chunks:        []string{"discard ", "override"},
+			waitForCancel: true,
+		},
+		WithSessionService(svc),
+		WithPersistInterruptedAssistant(true),
+	)
+	mr, ok := r.(ManagedRunner)
+	require.True(t, ok)
+
+	ch, err := r.Run(
+		context.Background(),
+		userID,
+		sessionID,
+		model.NewUserMessage("start"),
+		agent.WithRequestID(requestID),
+		agent.WithDetachedCancel(true),
+		agent.WithPersistInterruptedAssistant(false),
+	)
+	require.NoError(t, err)
+	for i := 0; i < 2; i++ {
+		select {
+		case _, ok := <-ch:
+			require.True(t, ok)
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for partial event")
+		}
+	}
+	require.True(t, mr.Cancel(requestID))
+	select {
+	case <-drainChannel(ch):
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for cancelled run to finish")
+	}
+
+	sess, err := svc.GetSession(
+		context.Background(),
+		session.Key{AppName: "app", UserID: userID, SessionID: sessionID},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Len(t, sess.Events, 1)
+	require.True(t, sess.Events[0].IsUserMessage())
+}
+
+func TestRunner_ApplyRunnerRunDefaultsForPersistInterruptedAssistant(t *testing.T) {
+	rr := &runner{persistInterruptedAssistantDefault: true}
+	var ro agent.RunOptions
+	rr.applyRunnerRunDefaults(&ro)
+	require.NotNil(t, ro.PersistInterruptedAssistant)
+	require.True(t, *ro.PersistInterruptedAssistant)
+
+	ro = agent.NewRunOptions(agent.WithPersistInterruptedAssistant(false))
+	rr.applyRunnerRunDefaults(&ro)
+	require.NotNil(t, ro.PersistInterruptedAssistant)
+	require.False(t, *ro.PersistInterruptedAssistant)
 }
 
 func TestRunner_CompletedStreamDoesNotDuplicateInterruptedAssistant(t *testing.T) {
@@ -6566,6 +6689,7 @@ func TestRunner_CancelDoesNotPersistNonTextPartialAssistant(t *testing.T) {
 				model.NewUserMessage("start"),
 				agent.WithRequestID(requestID),
 				agent.WithDetachedCancel(true),
+				agent.WithPersistInterruptedAssistant(true),
 			)
 			require.NoError(t, err)
 			select {
@@ -6810,6 +6934,9 @@ func TestPersistInterruptedAssistantGuardBranches(t *testing.T) {
 		sessionService: &appendErrorSessionService{mockSessionService: base},
 	}
 	loop := &eventLoopContext{
+		invocation: agent.NewInvocation(agent.WithInvocationRunOptions(agent.NewRunOptions(
+			agent.WithPersistInterruptedAssistant(true),
+		))),
 		sess:                           &session.Session{},
 		interruptedAssistantResponseID: "resp",
 	}

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -6050,6 +6050,124 @@ func (m *tickCtxAgent) Run(
 	return ch, nil
 }
 
+type partialTextAgent struct {
+	name          string
+	chunks        []string
+	final         string
+	waitForCancel bool
+	reasoningOnly bool
+	toolCallDelta bool
+}
+
+func (m *partialTextAgent) Info() agent.Info { return agent.Info{Name: m.name} }
+
+func (m *partialTextAgent) SubAgents() []agent.Agent { return nil }
+
+func (m *partialTextAgent) FindSubAgent(name string) agent.Agent { return nil }
+
+func (m *partialTextAgent) Tools() []tool.Tool { return nil }
+
+func (m *partialTextAgent) Run(
+	ctx context.Context,
+	inv *agent.Invocation,
+) (<-chan *event.Event, error) {
+	ch := make(chan *event.Event, len(m.chunks)+1)
+	go func() {
+		defer close(ch)
+		responseID := "partial-response"
+		for i, chunk := range m.chunks {
+			choice := model.Choice{Index: 0}
+			switch {
+			case m.toolCallDelta:
+				idx := i
+				choice.Delta = model.Message{
+					Role: model.RoleAssistant,
+					ToolCalls: []model.ToolCall{{
+						ID:    "call-1",
+						Type:  "function",
+						Index: &idx,
+						Function: model.FunctionDefinitionParam{
+							Name:      "lookup",
+							Arguments: []byte(chunk),
+						},
+					}},
+				}
+			case m.reasoningOnly:
+				choice.Delta = model.Message{
+					Role:             model.RoleAssistant,
+					ReasoningContent: chunk,
+				}
+			default:
+				role := model.Role("")
+				if i == 0 {
+					role = model.RoleAssistant
+				}
+				choice.Delta = model.Message{
+					Role:    role,
+					Content: chunk,
+				}
+			}
+			evt := event.NewResponseEvent(
+				inv.InvocationID,
+				m.name,
+				&model.Response{
+					ID:        responseID,
+					Object:    model.ObjectTypeChatCompletionChunk,
+					Done:      false,
+					IsPartial: true,
+					Choices:   []model.Choice{choice},
+				},
+			)
+			select {
+			case <-ctx.Done():
+				return
+			case ch <- evt:
+			}
+		}
+		if m.final != "" {
+			evt := event.NewResponseEvent(
+				inv.InvocationID,
+				m.name,
+				&model.Response{
+					ID:        responseID,
+					Object:    model.ObjectTypeChatCompletion,
+					Done:      true,
+					IsPartial: false,
+					Choices: []model.Choice{{
+						Index:   0,
+						Message: model.NewAssistantMessage(m.final),
+					}},
+				},
+			)
+			select {
+			case <-ctx.Done():
+				return
+			case ch <- evt:
+			}
+		}
+		if m.waitForCancel {
+			<-ctx.Done()
+		}
+	}()
+	return ch, nil
+}
+
+type contextCheckingSessionService struct {
+	*sessioninmemory.SessionService
+}
+
+func (s *contextCheckingSessionService) AppendEvent(
+	ctx context.Context,
+	sess *session.Session,
+	evt *event.Event,
+	opts ...session.Option,
+) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return s.SessionService.AppendEvent(ctx, sess, evt, opts...)
+}
+
 func TestProcessAgentEvents_EmitEventContextCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel before running
@@ -6251,6 +6369,379 @@ func TestRunner_CancelEmitsRunnerCompletion(t *testing.T) {
 	require.Equal(t, 1, completionCount, "should receive exactly one runner-completion after cancel")
 	require.NotNil(t, completion.ExecutionTrace)
 	require.Equal(t, atrace.TraceStatusIncomplete, completion.ExecutionTrace.Status)
+}
+
+func TestRunner_CancelPersistsInterruptedPartialAssistant(t *testing.T) {
+	const (
+		requestID = "req-cancel-partial"
+		userID    = "u"
+		sessionID = "s"
+	)
+	svc := &contextCheckingSessionService{
+		SessionService: sessioninmemory.NewSessionService(),
+	}
+	r := NewRunner(
+		"app",
+		&partialTextAgent{
+			name:          "partial",
+			chunks:        []string{"hello ", "world"},
+			waitForCancel: true,
+		},
+		WithSessionService(svc),
+	)
+	mr, ok := r.(ManagedRunner)
+	require.True(t, ok)
+
+	ch, err := r.Run(
+		context.Background(),
+		userID,
+		sessionID,
+		model.NewUserMessage("start"),
+		agent.WithRequestID(requestID),
+		agent.WithDetachedCancel(true),
+	)
+	require.NoError(t, err)
+
+	for i := 0; i < 2; i++ {
+		select {
+		case evt, ok := <-ch:
+			require.True(t, ok)
+			require.NotNil(t, evt)
+			require.True(t, evt.IsPartial)
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for partial event")
+		}
+	}
+
+	require.True(t, mr.Cancel(requestID))
+	select {
+	case <-drainChannel(ch):
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for cancelled run to finish")
+	}
+
+	sess, err := svc.GetSession(
+		context.Background(),
+		session.Key{AppName: "app", UserID: userID, SessionID: sessionID},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Len(t, sess.Events, 2)
+	require.False(t, sess.Events[1].IsPartial)
+	require.Equal(t, model.ObjectTypeChatCompletion, sess.Events[1].Object)
+	require.Equal(t, "hello world", sess.Events[1].Choices[0].Message.Content)
+	require.NotNil(t, sess.Events[1].Choices[0].FinishReason)
+	require.Equal(t, interruptedAssistantFinishReason, *sess.Events[1].Choices[0].FinishReason)
+	require.Contains(t, sess.Events[1].Extensions, interruptedAssistantExtensionKey)
+}
+
+func TestRunner_CompletedStreamDoesNotDuplicateInterruptedAssistant(t *testing.T) {
+	svc := sessioninmemory.NewSessionService()
+	r := NewRunner(
+		"app",
+		&partialTextAgent{
+			name:   "partial",
+			chunks: []string{"hello ", "world"},
+			final:  "hello world",
+		},
+		WithSessionService(svc),
+	)
+	ch, err := r.Run(
+		context.Background(),
+		"u",
+		"s",
+		model.NewUserMessage("start"),
+	)
+	require.NoError(t, err)
+	for range ch {
+	}
+
+	sess, err := svc.GetSession(
+		context.Background(),
+		session.Key{AppName: "app", UserID: "u", SessionID: "s"},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Len(t, sess.Events, 2)
+	require.Equal(t, "hello world", sess.Events[1].Choices[0].Message.Content)
+	require.Empty(t, sess.Events[1].Extensions)
+}
+
+func TestRunner_CancelDoesNotPersistNonTextPartialAssistant(t *testing.T) {
+	tests := []struct {
+		name  string
+		agent *partialTextAgent
+	}{
+		{
+			name: "reasoning only",
+			agent: &partialTextAgent{
+				name:          "reasoning",
+				chunks:        []string{"thinking"},
+				waitForCancel: true,
+				reasoningOnly: true,
+			},
+		},
+		{
+			name: "tool call delta",
+			agent: &partialTextAgent{
+				name:          "tool",
+				chunks:        []string{`{"q":"x"}`},
+				waitForCancel: true,
+				toolCallDelta: true,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const requestID = "req-cancel-non-text"
+			svc := sessioninmemory.NewSessionService()
+			r := NewRunner("app", tt.agent, WithSessionService(svc))
+			mr, ok := r.(ManagedRunner)
+			require.True(t, ok)
+
+			ch, err := r.Run(
+				context.Background(),
+				"u",
+				tt.name,
+				model.NewUserMessage("start"),
+				agent.WithRequestID(requestID),
+				agent.WithDetachedCancel(true),
+			)
+			require.NoError(t, err)
+			select {
+			case _, ok := <-ch:
+				require.True(t, ok)
+			case <-time.After(time.Second):
+				t.Fatal("timed out waiting for partial event")
+			}
+
+			require.True(t, mr.Cancel(requestID))
+			select {
+			case <-drainChannel(ch):
+			case <-time.After(2 * time.Second):
+				t.Fatal("timed out waiting for cancelled run to finish")
+			}
+
+			sess, err := svc.GetSession(
+				context.Background(),
+				session.Key{AppName: "app", UserID: "u", SessionID: tt.name},
+			)
+			require.NoError(t, err)
+			require.NotNil(t, sess)
+			require.Len(t, sess.Events, 1)
+			require.True(t, sess.Events[0].IsUserMessage())
+		})
+	}
+}
+
+func TestInterruptedAssistantDeltaResetsOnNewResponse(t *testing.T) {
+	rr := NewRunner("app", &noOpAgent{name: "a"}).(*runner)
+	loop := &eventLoopContext{}
+	rr.recordInterruptedAssistantDelta(nil, nil)
+	rr.recordInterruptedAssistantDelta(loop, event.NewResponseEvent(
+		"inv",
+		"assistant",
+		&model.Response{
+			ID:        "skip-final",
+			IsPartial: false,
+			Choices: []model.Choice{{
+				Index:   0,
+				Message: model.NewAssistantMessage("final"),
+			}},
+		},
+	))
+	rr.recordInterruptedAssistantDelta(loop, event.NewResponseEvent(
+		"inv",
+		"assistant",
+		&model.Response{
+			ID:        "skip-user",
+			IsPartial: true,
+			Choices: []model.Choice{{
+				Index: 0,
+				Delta: model.Message{
+					Role:    model.RoleUser,
+					Content: "not assistant",
+				},
+			}},
+		},
+	))
+	require.Empty(t, loop.interruptedAssistantContent.String())
+
+	rr.recordInterruptedAssistantDelta(loop, event.NewResponseEvent(
+		"inv",
+		"assistant",
+		&model.Response{
+			ID:        "response-1",
+			Object:    model.ObjectTypeChatCompletionChunk,
+			IsPartial: true,
+			Choices: []model.Choice{{
+				Index: 0,
+				Delta: model.Message{
+					Role:    model.RoleAssistant,
+					Content: "first",
+				},
+			}},
+		},
+	))
+	rr.recordInterruptedAssistantDelta(loop, event.NewResponseEvent(
+		"inv",
+		"assistant",
+		&model.Response{
+			ID:        "response-2",
+			Object:    model.ObjectTypeChatCompletionChunk,
+			IsPartial: true,
+			Choices: []model.Choice{{
+				Index: 0,
+				Delta: model.Message{
+					Role:    model.RoleAssistant,
+					Content: "second",
+				},
+			}},
+		},
+	))
+
+	require.Equal(t, "response-2", loop.interruptedAssistantResponseID)
+	require.Equal(t, "second", loop.interruptedAssistantContent.String())
+}
+
+func TestInterruptedAssistantDeltaGeneratesFallbackResponseID(t *testing.T) {
+	rr := NewRunner("app", &noOpAgent{name: "a"}).(*runner)
+	loop := &eventLoopContext{}
+	rr.recordInterruptedAssistantDelta(loop, event.NewResponseEvent(
+		"inv",
+		"assistant",
+		&model.Response{
+			IsPartial: true,
+			Choices: []model.Choice{{
+				Index: 0,
+				Delta: model.Message{
+					Role:    model.RoleAssistant,
+					Content: "chunk",
+				},
+			}},
+		},
+	))
+	require.NotEmpty(t, loop.interruptedAssistantResponseID)
+	require.Equal(t, "chunk", loop.interruptedAssistantContent.String())
+}
+
+func TestInterruptedAssistantAlreadyPersisted(t *testing.T) {
+	rr := NewRunner("app", &noOpAgent{name: "a"}).(*runner)
+	choices := []model.Choice{{
+		Index:   0,
+		Message: model.NewAssistantMessage("already there"),
+	}}
+
+	t.Run("by response id", func(t *testing.T) {
+		loop := &eventLoopContext{
+			interruptedAssistantResponseID: "resp",
+			persistedAssistantResponseIDs: map[string]struct{}{
+				"resp": {},
+			},
+		}
+		require.True(t, rr.interruptedAssistantAlreadyPersisted(loop, choices))
+	})
+
+	t.Run("by choice signature", func(t *testing.T) {
+		loop := &eventLoopContext{
+			interruptedAssistantResponseID: "different",
+			persistedAssistantChoiceSignatures: map[string]struct{}{
+				assistantChoiceSignature(choices): {},
+			},
+		}
+		require.True(t, rr.interruptedAssistantAlreadyPersisted(loop, choices))
+	})
+
+	t.Run("not persisted", func(t *testing.T) {
+		loop := &eventLoopContext{interruptedAssistantResponseID: "resp"}
+		require.False(t, rr.interruptedAssistantAlreadyPersisted(loop, choices))
+	})
+
+	t.Run("nil loop", func(t *testing.T) {
+		require.False(t, rr.interruptedAssistantAlreadyPersisted(nil, choices))
+	})
+
+	t.Run("empty signature", func(t *testing.T) {
+		loop := &eventLoopContext{interruptedAssistantResponseID: "resp"}
+		require.False(t, rr.interruptedAssistantAlreadyPersisted(loop, nil))
+	})
+}
+
+func TestInterruptedAssistantEventSkipsEmptyAndPersistedContent(t *testing.T) {
+	rr := NewRunner("app", &noOpAgent{name: "a"}).(*runner)
+
+	require.Nil(t, rr.interruptedAssistantEvent(context.Background(), &eventLoopContext{}))
+
+	choices := []model.Choice{{
+		Index:   0,
+		Message: model.NewAssistantMessage("already there"),
+	}}
+	loop := &eventLoopContext{
+		interruptedAssistantResponseID: "resp",
+		persistedAssistantChoiceSignatures: map[string]struct{}{
+			assistantChoiceSignature(choices): {},
+		},
+	}
+	loop.interruptedAssistantContent.WriteString("already there")
+	require.Nil(t, rr.interruptedAssistantEvent(context.Background(), loop))
+}
+
+func TestPersistInterruptedAssistantGuardBranches(t *testing.T) {
+	rr := NewRunner("app", &noOpAgent{name: "a"}).(*runner)
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	var nilCtx context.Context
+	rr.persistInterruptedAssistant(nilCtx, nil)
+	rr.persistInterruptedAssistant(context.Background(), &eventLoopContext{})
+	rr.persistInterruptedAssistant(cancelled, nil)
+	rr.persistInterruptedAssistant(cancelled, &eventLoopContext{sess: &session.Session{}})
+
+	base := &mockSessionService{}
+	appendErrRunner := &runner{
+		sessionService: &appendErrorSessionService{mockSessionService: base},
+	}
+	loop := &eventLoopContext{
+		sess:                           &session.Session{},
+		interruptedAssistantResponseID: "resp",
+	}
+	loop.interruptedAssistantContent.WriteString("partial")
+	appendErrRunner.persistInterruptedAssistant(cancelled, loop)
+	require.Len(t, base.appendEventCalls, 1)
+}
+
+func TestContextDoneReason(t *testing.T) {
+	var nilCtx context.Context
+	require.Empty(t, contextDoneReason(nilCtx))
+	require.Empty(t, contextDoneReason(context.Background()))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.Equal(t, context.Canceled.Error(), contextDoneReason(ctx))
+
+	causeCtx, cancelCause := context.WithCancelCause(context.Background())
+	cancelCause(errors.New("explicit"))
+	require.Equal(t, "explicit", contextDoneReason(causeCtx))
+}
+
+func TestSessionPersistenceContext(t *testing.T) {
+	ctx := context.Background()
+	got, cancel := sessionPersistenceContext(ctx)
+	defer cancel()
+	require.Equal(t, ctx, got)
+
+	cancelled, cancelOriginal := context.WithCancel(context.Background())
+	cancelOriginal()
+	got, cancel = sessionPersistenceContext(cancelled)
+	defer cancel()
+	require.NoError(t, got.Err())
+	_, ok := got.Deadline()
+	require.True(t, ok)
+
+	var nilCtx context.Context
+	got, cancel = sessionPersistenceContext(nilCtx)
+	defer cancel()
+	require.NotNil(t, got)
+	require.NoError(t, got.Err())
 }
 
 func TestRunner_Close_CancelsRunningRuns(t *testing.T) {

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -6644,6 +6644,90 @@ func TestRunner_RoutedSessionPersistsInterruptedPartialAssistant(t *testing.T) {
 	require.Equal(t, "member text", svc.appendEventCalls[0].event.Choices[0].Message.Content)
 }
 
+func TestRunner_InterruptedAssistantPreservesSourceEventIdentity(t *testing.T) {
+	rr := NewRunner("app", &noOpAgent{name: "a"}).(*runner)
+	rootInv := agent.NewInvocation(
+		agent.WithInvocationID("root-inv"),
+		agent.WithInvocationBranch("root/branch"),
+		agent.WithInvocationEventFilterKey("root/filter"),
+		agent.WithInvocationRunOptions(agent.RunOptions{RequestID: "root-request"}),
+	)
+	loop := &eventLoopContext{
+		invocation:       rootInv,
+		streamFilter:     graph.NewStreamModeFilter(false, nil),
+		processedEventCh: make(chan *event.Event, 1),
+	}
+	partial := event.NewResponseEvent(
+		"child-inv",
+		"child-agent",
+		&model.Response{
+			ID:        "child-response",
+			Object:    model.ObjectTypeChatCompletionChunk,
+			IsPartial: true,
+			Choices: []model.Choice{{
+				Index: 0,
+				Delta: model.Message{
+					Role:    model.RoleAssistant,
+					Content: "partial",
+				},
+			}},
+		},
+	)
+	partial.ParentInvocationID = "parent-inv"
+	partial.Branch = "child/branch"
+	partial.FilterKey = "child/filter"
+	partial.RequestID = "child-request"
+
+	rr.recordInterruptedAssistantDelta(loop, partial, nil)
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	evt := rr.interruptedAssistantEvent(cancelled, loop)
+	require.NotNil(t, evt)
+	require.Equal(t, "child-inv", evt.InvocationID)
+	require.Equal(t, "parent-inv", evt.ParentInvocationID)
+	require.Equal(t, "child/branch", evt.Branch)
+	require.Equal(t, "child/filter", evt.FilterKey)
+	require.Equal(t, "child-request", evt.RequestID)
+	require.NotEqual(t, rootInv.InvocationID, evt.InvocationID)
+	require.NotEqual(t, rootInv.Branch, evt.Branch)
+}
+
+func TestRunner_InterruptedAssistantFillsRequestIDFromRootInvocation(t *testing.T) {
+	rr := NewRunner("app", &noOpAgent{name: "a"}).(*runner)
+	rootInv := agent.NewInvocation(
+		agent.WithInvocationID("root-inv"),
+		agent.WithInvocationRunOptions(agent.RunOptions{RequestID: "root-request"}),
+	)
+	loop := &eventLoopContext{
+		invocation:       rootInv,
+		streamFilter:     graph.NewStreamModeFilter(false, nil),
+		processedEventCh: make(chan *event.Event, 1),
+	}
+	partial := event.NewResponseEvent(
+		rootInv.InvocationID,
+		"agent",
+		&model.Response{
+			ID:        "response",
+			Object:    model.ObjectTypeChatCompletionChunk,
+			IsPartial: true,
+			Choices: []model.Choice{{
+				Index: 0,
+				Delta: model.Message{
+					Role:    model.RoleAssistant,
+					Content: "partial",
+				},
+			}},
+		},
+	)
+
+	rr.recordInterruptedAssistantDelta(loop, partial, nil)
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	evt := rr.interruptedAssistantEvent(cancelled, loop)
+	require.NotNil(t, evt)
+	require.Equal(t, "root-request", evt.RequestID)
+}
+
 func TestRunner_CancelDoesNotPersistInterruptedPartialAssistantByDefault(t *testing.T) {
 	const (
 		requestID = "req-cancel-partial-default"

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -7098,10 +7098,22 @@ func TestInterruptedAssistantAlreadyPersisted(t *testing.T) {
 		loop := &eventLoopContext{}
 		acc := interruptedAssistantAccumulatorForSession(loop, nil)
 		acc.responseID = "different"
+		acc.requestID = "req"
 		acc.persistedAssistantChoiceSignatures = map[string]struct{}{
-			assistantChoiceSignature(choices): {},
+			interruptedAssistantSignatureKey("req", "", choices): {},
 		}
 		require.True(t, rr.interruptedAssistantAlreadyPersisted(loop, choices))
+	})
+
+	t.Run("same content different request", func(t *testing.T) {
+		loop := &eventLoopContext{}
+		acc := interruptedAssistantAccumulatorForSession(loop, nil)
+		acc.responseID = "different"
+		acc.requestID = "req-2"
+		acc.persistedAssistantChoiceSignatures = map[string]struct{}{
+			interruptedAssistantSignatureKey("req-1", "", choices): {},
+		}
+		require.False(t, rr.interruptedAssistantAlreadyPersisted(loop, choices))
 	})
 
 	t.Run("not persisted", func(t *testing.T) {
@@ -7121,6 +7133,73 @@ func TestInterruptedAssistantAlreadyPersisted(t *testing.T) {
 	})
 }
 
+func TestInterruptedAssistantSignatureDedupeScopedByRequest(t *testing.T) {
+	rr := NewRunner("app", &noOpAgent{name: "a"}).(*runner)
+	prior := event.NewResponseEvent(
+		"inv-1",
+		"assistant",
+		&model.Response{
+			Object: model.ObjectTypeChatCompletion,
+			Done:   true,
+			Choices: []model.Choice{{
+				Index:   0,
+				Message: model.NewAssistantMessage("same text"),
+			}},
+		},
+	)
+	prior.RequestID = "req-1"
+	sess := &session.Session{
+		Events: []event.Event{*prior},
+	}
+
+	sameRequestLoop := &eventLoopContext{
+		sess: sess,
+		invocation: agent.NewInvocation(
+			agent.WithInvocationRunOptions(agent.RunOptions{RequestID: "req-1"}),
+		),
+	}
+	rr.recordInterruptedAssistantDelta(
+		sameRequestLoop,
+		interruptedAssistantPartialEvent("inv-2", "same text"),
+		nil,
+	)
+	require.Nil(t, rr.interruptedAssistantEvent(context.Background(), sameRequestLoop))
+
+	differentRequestLoop := &eventLoopContext{
+		sess: sess,
+		invocation: agent.NewInvocation(
+			agent.WithInvocationRunOptions(agent.RunOptions{RequestID: "req-2"}),
+		),
+	}
+	rr.recordInterruptedAssistantDelta(
+		differentRequestLoop,
+		interruptedAssistantPartialEvent("inv-3", "same text"),
+		nil,
+	)
+	evt := rr.interruptedAssistantEvent(context.Background(), differentRequestLoop)
+	require.NotNil(t, evt)
+	require.Equal(t, "same text", evt.Choices[0].Message.Content)
+	require.Equal(t, "req-2", evt.RequestID)
+}
+
+func interruptedAssistantPartialEvent(invocationID string, content string) *event.Event {
+	return event.NewResponseEvent(
+		invocationID,
+		"assistant",
+		&model.Response{
+			Object:    model.ObjectTypeChatCompletionChunk,
+			IsPartial: true,
+			Choices: []model.Choice{{
+				Index: 0,
+				Delta: model.Message{
+					Role:    model.RoleAssistant,
+					Content: content,
+				},
+			}},
+		},
+	)
+}
+
 func TestInterruptedAssistantEventSkipsEmptyAndPersistedContent(t *testing.T) {
 	rr := NewRunner("app", &noOpAgent{name: "a"}).(*runner)
 
@@ -7133,8 +7212,9 @@ func TestInterruptedAssistantEventSkipsEmptyAndPersistedContent(t *testing.T) {
 	loop := &eventLoopContext{}
 	acc := interruptedAssistantAccumulatorForSession(loop, nil)
 	acc.responseID = "resp"
+	acc.requestID = "req"
 	acc.persistedAssistantChoiceSignatures = map[string]struct{}{
-		assistantChoiceSignature(choices): {},
+		interruptedAssistantSignatureKey("req", "", choices): {},
 	}
 	rr.recordInterruptedAssistantDelta(loop, event.NewResponseEvent(
 		"inv",

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -7384,6 +7384,49 @@ func TestPersistInterruptedAssistantDedupeAfterEventPlugin(t *testing.T) {
 	require.Len(t, svc.appendEventCalls, 1)
 }
 
+func TestPersistInterruptedAssistantEnqueuesSummary(t *testing.T) {
+	svc := &mockSessionService{}
+	rr := &runner{sessionService: svc}
+	sess := session.NewSession("app", "u", "s")
+	inv := agent.NewInvocation(
+		agent.WithInvocationRunOptions(agent.NewRunOptions(
+			agent.WithPersistInterruptedAssistant(true),
+		)),
+	)
+	loop := &eventLoopContext{
+		sess:       sess,
+		invocation: inv,
+	}
+	partial := event.NewResponseEvent(
+		"inv",
+		"assistant",
+		&model.Response{
+			ID:        "response",
+			Object:    model.ObjectTypeChatCompletionChunk,
+			IsPartial: true,
+			Choices: []model.Choice{{
+				Index: 0,
+				Delta: model.Message{
+					Role:    model.RoleAssistant,
+					Content: "summarize me",
+				},
+			}},
+		},
+	)
+	partial.FilterKey = "summary/filter"
+	rr.recordInterruptedAssistantDelta(loop, partial, nil)
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	rr.persistInterruptedAssistant(cancelled, loop)
+
+	require.Len(t, svc.appendEventCalls, 1)
+	require.Len(t, svc.enqueueSummaryJobCalls, 1)
+	require.Same(t, sess, svc.enqueueSummaryJobCalls[0].sess)
+	require.Equal(t, "summary/filter", svc.enqueueSummaryJobCalls[0].filterKey)
+	require.False(t, svc.enqueueSummaryJobCalls[0].force)
+}
+
 func TestInterruptedAssistantDeltaGeneratesFallbackResponseID(t *testing.T) {
 	rr := NewRunner("app", &noOpAgent{name: "a"}).(*runner)
 	loop := &eventLoopContext{}
@@ -7579,6 +7622,90 @@ func TestInterruptedAssistantSignatureDedupeScopedByRequest(t *testing.T) {
 	require.Equal(t, "req-2", evt.RequestID)
 }
 
+func TestInterruptedAssistantPriorDedupeScopedByLineage(t *testing.T) {
+	rr := NewRunner("app", &noOpAgent{name: "a"}).(*runner)
+
+	t.Run("same response id on sibling branch", func(t *testing.T) {
+		prior := event.NewResponseEvent(
+			"shared-invocation",
+			"assistant",
+			&model.Response{
+				ID:     "shared-response",
+				Object: model.ObjectTypeChatCompletion,
+				Done:   true,
+				Choices: []model.Choice{{
+					Index:   0,
+					Message: model.NewAssistantMessage("prior"),
+				}},
+			},
+		)
+		prior.RequestID = "req"
+		prior.Branch = "branch/b"
+		loop := &eventLoopContext{
+			sess: &session.Session{Events: []event.Event{*prior}},
+			invocation: agent.NewInvocation(
+				agent.WithInvocationRunOptions(agent.RunOptions{RequestID: "req"}),
+			),
+		}
+		partial := event.NewResponseEvent(
+			"shared-invocation",
+			"assistant",
+			&model.Response{
+				ID:        "shared-response",
+				Object:    model.ObjectTypeChatCompletionChunk,
+				IsPartial: true,
+				Choices: []model.Choice{{
+					Index: 0,
+					Delta: model.Message{
+						Role:    model.RoleAssistant,
+						Content: "current",
+					},
+				}},
+			},
+		)
+		partial.RequestID = "req"
+		partial.Branch = "branch/a"
+
+		rr.recordInterruptedAssistantDelta(loop, partial, nil)
+		evt := rr.interruptedAssistantEvent(context.Background(), loop)
+		require.NotNil(t, evt)
+		require.Equal(t, "current", evt.Choices[0].Message.Content)
+		require.Equal(t, "branch/a", evt.Branch)
+	})
+
+	t.Run("same signature on sibling branch", func(t *testing.T) {
+		prior := event.NewResponseEvent(
+			"shared-invocation",
+			"assistant",
+			&model.Response{
+				Object: model.ObjectTypeChatCompletion,
+				Done:   true,
+				Choices: []model.Choice{{
+					Index:   0,
+					Message: model.NewAssistantMessage("same text"),
+				}},
+			},
+		)
+		prior.RequestID = "req"
+		prior.Branch = "branch/b"
+		loop := &eventLoopContext{
+			sess: &session.Session{Events: []event.Event{*prior}},
+			invocation: agent.NewInvocation(
+				agent.WithInvocationRunOptions(agent.RunOptions{RequestID: "req"}),
+			),
+		}
+		partial := interruptedAssistantPartialEvent("shared-invocation", "same text")
+		partial.RequestID = "req"
+		partial.Branch = "branch/a"
+
+		rr.recordInterruptedAssistantDelta(loop, partial, nil)
+		evt := rr.interruptedAssistantEvent(context.Background(), loop)
+		require.NotNil(t, evt)
+		require.Equal(t, "same text", evt.Choices[0].Message.Content)
+		require.Equal(t, "branch/a", evt.Branch)
+	})
+}
+
 func interruptedAssistantPartialEvent(invocationID string, content string) *event.Event {
 	return event.NewResponseEvent(
 		invocationID,
@@ -7610,7 +7737,6 @@ func TestInterruptedAssistantEventSkipsEmptyAndPersistedContent(t *testing.T) {
 		"inv",
 		"assistant",
 		&model.Response{
-			ID:      "prior",
 			Object:  model.ObjectTypeChatCompletion,
 			Done:    true,
 			Choices: choices,
@@ -7629,7 +7755,6 @@ func TestInterruptedAssistantEventSkipsEmptyAndPersistedContent(t *testing.T) {
 		"inv",
 		"assistant",
 		&model.Response{
-			ID:        "resp",
 			IsPartial: true,
 			Choices: []model.Choice{{
 				Index: 0,

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -6377,6 +6377,20 @@ func TestRunner_CancelPersistsInterruptedPartialAssistant(t *testing.T) {
 		userID    = "u"
 		sessionID = "s"
 	)
+	const tagged = "interrupted-tagged"
+	p := &testPlugin{
+		name: "interrupted-event-plugin",
+		reg: func(r *plugin.Registry) {
+			r.OnEvent(func(
+				ctx context.Context,
+				inv *agent.Invocation,
+				e *event.Event,
+			) (*event.Event, error) {
+				e.Tag = tagged
+				return e, nil
+			})
+		},
+	}
 	svc := &contextCheckingSessionService{
 		SessionService: sessioninmemory.NewSessionService(),
 	}
@@ -6388,6 +6402,7 @@ func TestRunner_CancelPersistsInterruptedPartialAssistant(t *testing.T) {
 			waitForCancel: true,
 		},
 		WithSessionService(svc),
+		WithPlugins(p),
 	)
 	mr, ok := r.(ManagedRunner)
 	require.True(t, ok)
@@ -6433,6 +6448,51 @@ func TestRunner_CancelPersistsInterruptedPartialAssistant(t *testing.T) {
 	require.NotNil(t, sess.Events[1].Choices[0].FinishReason)
 	require.Equal(t, interruptedAssistantFinishReason, *sess.Events[1].Choices[0].FinishReason)
 	require.Contains(t, sess.Events[1].Extensions, interruptedAssistantExtensionKey)
+	require.Equal(t, tagged, sess.Events[1].Tag)
+}
+
+func TestRunner_StreamModeUpdatesStillPersistsInterruptedPartialAssistant(t *testing.T) {
+	rr := NewRunner(
+		"app",
+		&noOpAgent{name: "a"},
+		WithSessionService(sessioninmemory.NewSessionService()),
+	).(*runner)
+	inv := agent.NewInvocation(
+		agent.WithInvocationRunOptions(agent.NewRunOptions(
+			agent.WithStreamMode(agent.StreamModeUpdates),
+		)),
+	)
+	loop := &eventLoopContext{
+		sess:             session.NewSession("app", "u", "s"),
+		invocation:       inv,
+		processedEventCh: make(chan *event.Event, 1),
+		streamFilter: graph.NewStreamModeFilter(
+			inv.RunOptions.StreamModeEnabled,
+			inv.RunOptions.StreamModes,
+		),
+	}
+
+	err := rr.processSingleAgentEvent(context.Background(), loop, event.NewResponseEvent(
+		inv.InvocationID,
+		"a",
+		&model.Response{
+			ID:        "filtered-partial",
+			Object:    model.ObjectTypeChatCompletionChunk,
+			IsPartial: true,
+			Choices: []model.Choice{{
+				Index: 0,
+				Delta: model.Message{
+					Role:    model.RoleAssistant,
+					Content: "filtered text",
+				},
+			}},
+		},
+	))
+	require.NoError(t, err)
+	require.Empty(t, loop.processedEventCh)
+	choices := interruptedAssistantChoices(loop)
+	require.Len(t, choices, 1)
+	require.Equal(t, "filtered text", choices[0].Message.Content)
 }
 
 func TestRunner_CompletedStreamDoesNotDuplicateInterruptedAssistant(t *testing.T) {
@@ -6565,7 +6625,7 @@ func TestInterruptedAssistantDeltaResetsOnNewResponse(t *testing.T) {
 			}},
 		},
 	))
-	require.Empty(t, loop.interruptedAssistantContent.String())
+	require.Empty(t, interruptedAssistantChoices(loop))
 
 	rr.recordInterruptedAssistantDelta(loop, event.NewResponseEvent(
 		"inv",
@@ -6601,7 +6661,7 @@ func TestInterruptedAssistantDeltaResetsOnNewResponse(t *testing.T) {
 	))
 
 	require.Equal(t, "response-2", loop.interruptedAssistantResponseID)
-	require.Equal(t, "second", loop.interruptedAssistantContent.String())
+	require.Equal(t, "second", interruptedAssistantChoices(loop)[0].Message.Content)
 }
 
 func TestInterruptedAssistantDeltaGeneratesFallbackResponseID(t *testing.T) {
@@ -6622,7 +6682,44 @@ func TestInterruptedAssistantDeltaGeneratesFallbackResponseID(t *testing.T) {
 		},
 	))
 	require.NotEmpty(t, loop.interruptedAssistantResponseID)
-	require.Equal(t, "chunk", loop.interruptedAssistantContent.String())
+	require.Equal(t, "chunk", interruptedAssistantChoices(loop)[0].Message.Content)
+}
+
+func TestInterruptedAssistantDeltaPreservesChoiceIndexes(t *testing.T) {
+	rr := NewRunner("app", &noOpAgent{name: "a"}).(*runner)
+	loop := &eventLoopContext{}
+
+	rr.recordInterruptedAssistantDelta(loop, event.NewResponseEvent(
+		"inv",
+		"assistant",
+		&model.Response{
+			ID:        "multi-choice",
+			IsPartial: true,
+			Choices: []model.Choice{
+				{
+					Index: 1,
+					Delta: model.Message{
+						Role:    model.RoleAssistant,
+						Content: "choice one",
+					},
+				},
+				{
+					Index: 0,
+					Delta: model.Message{
+						Role:    model.RoleAssistant,
+						Content: "choice zero",
+					},
+				},
+			},
+		},
+	))
+	evt := rr.interruptedAssistantEvent(context.Background(), loop)
+	require.NotNil(t, evt)
+	require.Len(t, evt.Choices, 2)
+	require.Equal(t, 0, evt.Choices[0].Index)
+	require.Equal(t, "choice zero", evt.Choices[0].Message.Content)
+	require.Equal(t, 1, evt.Choices[1].Index)
+	require.Equal(t, "choice one", evt.Choices[1].Message.Content)
 }
 
 func TestInterruptedAssistantAlreadyPersisted(t *testing.T) {
@@ -6682,7 +6779,21 @@ func TestInterruptedAssistantEventSkipsEmptyAndPersistedContent(t *testing.T) {
 			assistantChoiceSignature(choices): {},
 		},
 	}
-	loop.interruptedAssistantContent.WriteString("already there")
+	rr.recordInterruptedAssistantDelta(loop, event.NewResponseEvent(
+		"inv",
+		"assistant",
+		&model.Response{
+			ID:        "resp",
+			IsPartial: true,
+			Choices: []model.Choice{{
+				Index: 0,
+				Delta: model.Message{
+					Role:    model.RoleAssistant,
+					Content: "already there",
+				},
+			}},
+		},
+	))
 	require.Nil(t, rr.interruptedAssistantEvent(context.Background(), loop))
 }
 
@@ -6690,8 +6801,6 @@ func TestPersistInterruptedAssistantGuardBranches(t *testing.T) {
 	rr := NewRunner("app", &noOpAgent{name: "a"}).(*runner)
 	cancelled, cancel := context.WithCancel(context.Background())
 	cancel()
-	var nilCtx context.Context
-	rr.persistInterruptedAssistant(nilCtx, nil)
 	rr.persistInterruptedAssistant(context.Background(), &eventLoopContext{})
 	rr.persistInterruptedAssistant(cancelled, nil)
 	rr.persistInterruptedAssistant(cancelled, &eventLoopContext{sess: &session.Session{}})
@@ -6704,14 +6813,26 @@ func TestPersistInterruptedAssistantGuardBranches(t *testing.T) {
 		sess:                           &session.Session{},
 		interruptedAssistantResponseID: "resp",
 	}
-	loop.interruptedAssistantContent.WriteString("partial")
+	appendErrRunner.recordInterruptedAssistantDelta(loop, event.NewResponseEvent(
+		"inv",
+		"assistant",
+		&model.Response{
+			ID:        "resp",
+			IsPartial: true,
+			Choices: []model.Choice{{
+				Index: 0,
+				Delta: model.Message{
+					Role:    model.RoleAssistant,
+					Content: "partial",
+				},
+			}},
+		},
+	))
 	appendErrRunner.persistInterruptedAssistant(cancelled, loop)
 	require.Len(t, base.appendEventCalls, 1)
 }
 
 func TestContextDoneReason(t *testing.T) {
-	var nilCtx context.Context
-	require.Empty(t, contextDoneReason(nilCtx))
 	require.Empty(t, contextDoneReason(context.Background()))
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -6727,7 +6848,8 @@ func TestSessionPersistenceContext(t *testing.T) {
 	ctx := context.Background()
 	got, cancel := sessionPersistenceContext(ctx)
 	defer cancel()
-	require.Equal(t, ctx, got)
+	require.NotNil(t, got)
+	require.NoError(t, got.Err())
 
 	cancelled, cancelOriginal := context.WithCancel(context.Background())
 	cancelOriginal()
@@ -6736,12 +6858,6 @@ func TestSessionPersistenceContext(t *testing.T) {
 	require.NoError(t, got.Err())
 	_, ok := got.Deadline()
 	require.True(t, ok)
-
-	var nilCtx context.Context
-	got, cancel = sessionPersistenceContext(nilCtx)
-	defer cancel()
-	require.NotNil(t, got)
-	require.NoError(t, got.Err())
 }
 
 func TestRunner_Close_CancelsRunningRuns(t *testing.T) {

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -7706,6 +7707,370 @@ func TestInterruptedAssistantPriorDedupeScopedByLineage(t *testing.T) {
 	})
 }
 
+func TestInterruptedAssistantAccumulatorLineageEdgeCases(t *testing.T) {
+	require.Nil(t, interruptedAssistantAccumulatorForLineage(nil, nil, "lineage"))
+	require.Empty(t, interruptedAssistantLineageKey(nil, nil))
+
+	sess := session.NewSession("app", "u", "s")
+	otherSess := session.NewSession("app", "u", "other")
+	loop := &eventLoopContext{sess: sess}
+	require.Nil(t, getInterruptedAssistantAccumulator(loop, sess))
+
+	first := interruptedAssistantAccumulatorForLineage(loop, sess, "one")
+	require.NotNil(t, first)
+	require.Same(t, first, interruptedAssistantAccumulatorForLineage(loop, sess, "one"))
+	require.NotNil(t, interruptedAssistantAccumulatorForLineage(loop, otherSess, "other"))
+	require.Same(t, first, getInterruptedAssistantAccumulator(loop, sess))
+
+	require.NotNil(t, interruptedAssistantAccumulatorForLineage(loop, sess, "two"))
+	require.Nil(t, getInterruptedAssistantAccumulator(loop, sess))
+
+	parent := agent.NewInvocation(
+		agent.WithInvocationID("parent-inv"),
+		agent.WithInvocationAgent(&noOpAgent{name: "parent"}),
+	)
+	child := parent.Clone(
+		agent.WithInvocationID("child-inv"),
+		agent.WithInvocationAgent(&noOpAgent{name: "child"}),
+		agent.WithInvocationBranch("child-branch"),
+		agent.WithInvocationEventFilterKey("child-filter"),
+		agent.WithInvocationRunOptions(agent.RunOptions{RequestID: "req"}),
+	)
+	key := interruptedAssistantLineageKey(&eventLoopContext{invocation: child}, &event.Event{
+		Response: &model.Response{ID: "resp"},
+	})
+	for _, part := range []string{
+		"resp",
+		"req",
+		"child-inv",
+		"parent-inv",
+		"child-branch",
+		"child-filter",
+		"child",
+	} {
+		require.Contains(t, key, part)
+	}
+}
+
+func TestRecordPersistedAssistantOnAccumulatorEdgeCases(t *testing.T) {
+	acc := &interruptedAssistantAccumulator{
+		requestID:    "req",
+		invocationID: "inv",
+	}
+
+	recordPersistedAssistantOnAccumulator(nil, nil, false)
+	recordPersistedAssistantOnAccumulator(acc, nil, true)
+	recordPersistedAssistantOnAccumulator(
+		acc,
+		interruptedAssistantFinalEvent("inv", "non-assistant-id", "user", model.RoleUser),
+		true,
+	)
+	require.Empty(t, acc.persistedAssistantResponseIDs)
+	require.Empty(t, acc.persistedAssistantChoiceSignatures)
+
+	rawGraph := graph.NewGraphCompletionEvent(
+		graph.WithCompletionEventInvocationID("inv"),
+		graph.WithCompletionEventFinalState(graph.State{
+			graph.StateKeyLastResponse:   "raw",
+			graph.StateKeyLastResponseID: "raw-final",
+		}),
+	)
+	recordPersistedAssistantOnAccumulator(acc, rawGraph, true)
+	require.Empty(t, acc.persistedAssistantResponseIDs)
+	require.Empty(t, acc.persistedAssistantChoiceSignatures)
+
+	visible, ok := graph.VisibleGraphCompletionEventForAuthor(
+		graph.NewGraphCompletionEvent(
+			graph.WithCompletionEventInvocationID("inv"),
+			graph.WithCompletionEventFinalState(graph.State{
+				graph.StateKeyLastResponse:   "visible",
+				graph.StateKeyLastResponseID: "visible-final",
+			}),
+		),
+		"assistant",
+	)
+	require.True(t, ok)
+	visible.Response.ID = "visible-wrapper"
+	visible.RequestID = "req"
+
+	recordPersistedAssistantOnAccumulator(acc, visible, true)
+	require.Contains(t, acc.persistedAssistantResponseIDs, "visible-wrapper")
+	require.Contains(t, acc.persistedAssistantResponseIDs, "visible-final")
+	require.Contains(
+		t,
+		acc.persistedAssistantChoiceSignatures,
+		interruptedAssistantSignatureKey("req", "inv", visible.Response.Choices),
+	)
+}
+
+func TestRecordInterruptedAssistantDeltaSkipsNonAssistantChoices(t *testing.T) {
+	rr := NewRunner("app", &noOpAgent{name: "a"}).(*runner)
+	require.False(t, interruptedAssistantHasTextDelta(nil))
+
+	loop := &eventLoopContext{}
+	rr.recordInterruptedAssistantDelta(loop, event.NewResponseEvent(
+		"inv",
+		"assistant",
+		&model.Response{
+			ID:        "resp",
+			Created:   123,
+			IsPartial: true,
+			Choices: []model.Choice{
+				{
+					Index: 0,
+					Delta: model.Message{
+						Role:    model.RoleUser,
+						Content: "skip wrong role",
+					},
+				},
+				{
+					Index: 1,
+					Delta: model.Message{Role: model.RoleAssistant},
+				},
+				{
+					Index: 2,
+					Delta: model.Message{
+						Role:    model.RoleAssistant,
+						Content: "keep",
+					},
+				},
+			},
+		},
+	), nil)
+
+	acc := defaultInterruptedAssistantAccumulator(loop)
+	require.NotNil(t, acc)
+	require.Equal(t, int64(123), acc.created)
+	choices := interruptedAssistantChoicesFromAccumulator(acc)
+	require.Len(t, choices, 1)
+	require.Equal(t, 2, choices[0].Index)
+	require.Equal(t, "keep", choices[0].Message.Content)
+}
+
+func TestInterruptedAssistantEventIdentityHelperEdgeCases(t *testing.T) {
+	rr := NewRunner("app", &noOpAgent{name: "a"}).(*runner)
+	captureInterruptedAssistantEventIdentity(nil, nil)
+	injectInterruptedAssistantEventIdentity(nil, nil, nil)
+
+	acc := &interruptedAssistantAccumulator{requestID: "existing"}
+	fillInterruptedAssistantRequestID(acc, &eventLoopContext{
+		invocation: agent.NewInvocation(
+			agent.WithInvocationRunOptions(agent.RunOptions{RequestID: "root"}),
+		),
+	})
+	require.Equal(t, "existing", acc.requestID)
+
+	evt := &event.Event{RequestID: "keep"}
+	injectInterruptedAssistantEventIdentity(
+		agent.NewInvocation(
+			agent.WithInvocationRunOptions(agent.RunOptions{RequestID: "root"}),
+		),
+		&interruptedAssistantAccumulator{requestID: "acc"},
+		evt,
+	)
+	require.Equal(t, "keep", evt.RequestID)
+
+	empty := &strings.Builder{}
+	require.Empty(t, interruptedAssistantChoicesFromAccumulator(
+		&interruptedAssistantAccumulator{
+			choiceContent: map[int]*strings.Builder{
+				0: nil,
+				1: empty,
+			},
+		},
+	))
+
+	content := &strings.Builder{}
+	content.WriteString("fallback")
+	inv := agent.NewInvocation(
+		agent.WithInvocationID("root-inv"),
+		agent.WithInvocationAgent(&noOpAgent{name: "root-agent"}),
+	)
+	out := rr.interruptedAssistantEventForAccumulator(
+		context.Background(),
+		&eventLoopContext{invocation: inv},
+		&interruptedAssistantAccumulator{
+			choiceContent: map[int]*strings.Builder{0: content},
+		},
+	)
+	require.NotNil(t, out)
+	require.Equal(t, "root-agent", out.Author)
+	require.Equal(t, "root-inv", out.InvocationID)
+}
+
+func TestPersistInterruptedAssistantSkipTargetsAndTieBreaker(t *testing.T) {
+	builderMap := func(text string) map[int]*strings.Builder {
+		b := &strings.Builder{}
+		b.WriteString(text)
+		return map[int]*strings.Builder{0: b}
+	}
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	inv := agent.NewInvocation(
+		agent.WithInvocationRunOptions(agent.NewRunOptions(
+			agent.WithPersistInterruptedAssistant(true),
+		)),
+	)
+
+	emptySvc := &mockSessionService{}
+	rr := &runner{sessionService: emptySvc}
+	rr.persistInterruptedAssistant(cancelled, &eventLoopContext{
+		invocation: inv,
+		interruptedAssistants: map[string]*interruptedAssistantAccumulator{
+			"empty": {
+				sequence:      2,
+				sess:          session.NewSession("app", "u", "empty"),
+				choiceContent: map[int]*strings.Builder{},
+			},
+			"nil":        nil,
+			"no-session": {sequence: 1, choiceContent: builderMap("no session")},
+		},
+	})
+	require.Empty(t, emptySvc.appendEventCalls)
+
+	svc := &mockSessionService{}
+	rr = &runner{sessionService: svc}
+	sess := session.NewSession("app", "u", "s")
+	rr.persistInterruptedAssistant(cancelled, &eventLoopContext{
+		sess:       sess,
+		invocation: inv,
+		interruptedAssistants: map[string]*interruptedAssistantAccumulator{
+			"b": {sequence: 1, choiceContent: builderMap("second")},
+			"a": {sequence: 1, choiceContent: builderMap("first")},
+		},
+	})
+	require.Len(t, svc.appendEventCalls, 2)
+	require.Same(t, sess, svc.appendEventCalls[0].sess)
+	require.Equal(t, "first", svc.appendEventCalls[0].event.Choices[0].Message.Content)
+	require.Equal(t, "second", svc.appendEventCalls[1].event.Choices[0].Message.Content)
+}
+
+func TestCollectPriorAssistantChoiceSignaturesSkipsAndCollects(t *testing.T) {
+	require.Nil(t, collectPriorAssistantChoiceSignatures(nil))
+	require.Nil(t, collectPriorAssistantChoiceSignatures(&session.Session{}))
+
+	partial := interruptedAssistantPartialEvent("inv", "partial")
+	rawGraph := graph.NewGraphCompletionEvent(
+		graph.WithCompletionEventInvocationID("inv"),
+		graph.WithCompletionEventFinalState(graph.State{
+			graph.StateKeyLastResponse: "graph",
+		}),
+	)
+	user := interruptedAssistantFinalEvent("inv", "user-id", "user", model.RoleUser)
+	assistant := interruptedAssistantFinalEvent(
+		"inv",
+		"assistant-id",
+		"assistant",
+		model.RoleAssistant,
+	)
+	assistant.RequestID = "req"
+
+	signatures := collectPriorAssistantChoiceSignatures(&session.Session{
+		Events: []event.Event{*partial, *rawGraph, *user, *assistant},
+	})
+	require.Equal(t, map[string]struct{}{
+		interruptedAssistantSignatureKey(
+			"req",
+			"inv",
+			assistant.Response.Choices,
+		): {},
+	}, signatures)
+}
+
+func TestCollectPriorAssistantLineageHelpersSkipAndCollect(t *testing.T) {
+	require.Nil(t, collectPriorAssistantResponseIDsForLineage(nil, nil, "lineage"))
+	require.Nil(t, collectPriorAssistantChoiceSignaturesForLineage(nil, nil, "lineage"))
+
+	loop := &eventLoopContext{}
+	regular := interruptedAssistantFinalEvent(
+		"inv",
+		"resp",
+		"assistant",
+		model.RoleAssistant,
+	)
+	regular.RequestID = "req"
+	regular.Branch = "branch/a"
+	regular.FilterKey = "filter/a"
+	lineage := interruptedAssistantLineageKey(loop, regular)
+
+	partial := interruptedAssistantPartialEvent("inv", "partial")
+	partial.Response.ID = "resp"
+	partial.RequestID = "req"
+	partial.Branch = "branch/a"
+	partial.FilterKey = "filter/a"
+
+	rawGraph := graph.NewGraphCompletionEvent(
+		graph.WithCompletionEventInvocationID("inv"),
+		graph.WithCompletionEventFinalState(graph.State{
+			graph.StateKeyLastResponse:   "graph",
+			graph.StateKeyLastResponseID: "graph-final",
+		}),
+	)
+	rawGraph.Response.ID = "resp"
+	rawGraph.RequestID = "req"
+	rawGraph.Branch = "branch/a"
+	rawGraph.FilterKey = "filter/a"
+	rawGraph.Author = "assistant"
+
+	user := interruptedAssistantFinalEvent("inv", "resp", "user", model.RoleUser)
+	user.RequestID = "req"
+	user.Branch = "branch/a"
+	user.FilterKey = "filter/a"
+
+	mismatch := interruptedAssistantFinalEvent(
+		"inv",
+		"other-resp",
+		"other",
+		model.RoleAssistant,
+	)
+	mismatch.RequestID = "req"
+	mismatch.Branch = "branch/b"
+
+	sess := &session.Session{
+		Events: []event.Event{*mismatch, *partial, *rawGraph, *user, *regular},
+	}
+	require.Equal(t, map[string]struct{}{"resp": {}},
+		collectPriorAssistantResponseIDsForLineage(loop, sess, lineage))
+	require.Equal(t, map[string]struct{}{
+		interruptedAssistantSignatureKey(
+			"req",
+			"inv",
+			regular.Response.Choices,
+		): {},
+	}, collectPriorAssistantChoiceSignaturesForLineage(loop, sess, lineage))
+
+	emptyID := interruptedAssistantFinalEvent(
+		"inv-empty",
+		"",
+		"empty id",
+		model.RoleAssistant,
+	)
+	require.Nil(t, collectPriorAssistantResponseIDsForLineage(
+		loop,
+		&session.Session{Events: []event.Event{*emptyID}},
+		interruptedAssistantLineageKey(loop, emptyID),
+	))
+
+	visible, ok := graph.VisibleGraphCompletionEventForAuthor(
+		graph.NewGraphCompletionEvent(
+			graph.WithCompletionEventInvocationID("inv-visible"),
+			graph.WithCompletionEventFinalState(graph.State{
+				graph.StateKeyLastResponse:   "visible",
+				graph.StateKeyLastResponseID: "visible-final",
+			}),
+		),
+		"assistant",
+	)
+	require.True(t, ok)
+	visible.Response.ID = "visible-wrapper"
+	ids := collectPriorAssistantResponseIDsForLineage(
+		loop,
+		&session.Session{Events: []event.Event{*visible}},
+		interruptedAssistantLineageKey(loop, visible),
+	)
+	require.Equal(t, map[string]struct{}{"visible-final": {}}, ids)
+}
+
 func interruptedAssistantPartialEvent(invocationID string, content string) *event.Event {
 	return event.NewResponseEvent(
 		invocationID,
@@ -7717,6 +8082,30 @@ func interruptedAssistantPartialEvent(invocationID string, content string) *even
 				Index: 0,
 				Delta: model.Message{
 					Role:    model.RoleAssistant,
+					Content: content,
+				},
+			}},
+		},
+	)
+}
+
+func interruptedAssistantFinalEvent(
+	invocationID string,
+	responseID string,
+	content string,
+	role model.Role,
+) *event.Event {
+	return event.NewResponseEvent(
+		invocationID,
+		"assistant",
+		&model.Response{
+			ID:     responseID,
+			Object: model.ObjectTypeChatCompletion,
+			Done:   true,
+			Choices: []model.Choice{{
+				Index: 0,
+				Message: model.Message{
+					Role:    role,
 					Content: content,
 				},
 			}},

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -7116,6 +7116,18 @@ func TestInterruptedAssistantAlreadyPersisted(t *testing.T) {
 		require.False(t, rr.interruptedAssistantAlreadyPersisted(loop, choices))
 	})
 
+	t.Run("same content same request different invocation", func(t *testing.T) {
+		loop := &eventLoopContext{}
+		acc := interruptedAssistantAccumulatorForSession(loop, nil)
+		acc.responseID = "different"
+		acc.requestID = "req"
+		acc.invocationID = "child-2"
+		acc.persistedAssistantChoiceSignatures = map[string]struct{}{
+			interruptedAssistantSignatureKey("req", "child-1", choices): {},
+		}
+		require.False(t, rr.interruptedAssistantAlreadyPersisted(loop, choices))
+	})
+
 	t.Run("not persisted", func(t *testing.T) {
 		loop := &eventLoopContext{}
 		interruptedAssistantAccumulatorForSession(loop, nil).responseID = "resp"
@@ -7160,10 +7172,30 @@ func TestInterruptedAssistantSignatureDedupeScopedByRequest(t *testing.T) {
 	}
 	rr.recordInterruptedAssistantDelta(
 		sameRequestLoop,
-		interruptedAssistantPartialEvent("inv-2", "same text"),
+		interruptedAssistantPartialEvent("inv-1", "same text"),
 		nil,
 	)
 	require.Nil(t, rr.interruptedAssistantEvent(context.Background(), sameRequestLoop))
+
+	sameRequestDifferentInvocationLoop := &eventLoopContext{
+		sess: sess,
+		invocation: agent.NewInvocation(
+			agent.WithInvocationRunOptions(agent.RunOptions{RequestID: "req-1"}),
+		),
+	}
+	rr.recordInterruptedAssistantDelta(
+		sameRequestDifferentInvocationLoop,
+		interruptedAssistantPartialEvent("inv-2", "same text"),
+		nil,
+	)
+	evt := rr.interruptedAssistantEvent(
+		context.Background(),
+		sameRequestDifferentInvocationLoop,
+	)
+	require.NotNil(t, evt)
+	require.Equal(t, "same text", evt.Choices[0].Message.Content)
+	require.Equal(t, "req-1", evt.RequestID)
+	require.Equal(t, "inv-2", evt.InvocationID)
 
 	differentRequestLoop := &eventLoopContext{
 		sess: sess,
@@ -7176,7 +7208,7 @@ func TestInterruptedAssistantSignatureDedupeScopedByRequest(t *testing.T) {
 		interruptedAssistantPartialEvent("inv-3", "same text"),
 		nil,
 	)
-	evt := rr.interruptedAssistantEvent(context.Background(), differentRequestLoop)
+	evt = rr.interruptedAssistantEvent(context.Background(), differentRequestLoop)
 	require.NotNil(t, evt)
 	require.Equal(t, "same text", evt.Choices[0].Message.Content)
 	require.Equal(t, "req-2", evt.RequestID)
@@ -7214,7 +7246,7 @@ func TestInterruptedAssistantEventSkipsEmptyAndPersistedContent(t *testing.T) {
 	acc.responseID = "resp"
 	acc.requestID = "req"
 	acc.persistedAssistantChoiceSignatures = map[string]struct{}{
-		interruptedAssistantSignatureKey("req", "", choices): {},
+		interruptedAssistantSignatureKey("req", "inv", choices): {},
 	}
 	rr.recordInterruptedAssistantDelta(loop, event.NewResponseEvent(
 		"inv",

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -6949,7 +6949,7 @@ func TestRunner_CancelDoesNotPersistNonTextPartialAssistant(t *testing.T) {
 	}
 }
 
-func TestInterruptedAssistantDeltaResetsOnNewResponse(t *testing.T) {
+func TestInterruptedAssistantDeltaBuffersInterleavedResponses(t *testing.T) {
 	rr := NewRunner("app", &noOpAgent{name: "a"}).(*runner)
 	loop := &eventLoopContext{}
 	rr.recordInterruptedAssistantDelta(nil, nil, nil)
@@ -6982,7 +6982,7 @@ func TestInterruptedAssistantDeltaResetsOnNewResponse(t *testing.T) {
 	), nil)
 	require.Empty(t, interruptedAssistantChoices(loop))
 
-	rr.recordInterruptedAssistantDelta(loop, event.NewResponseEvent(
+	first := event.NewResponseEvent(
 		"inv",
 		"assistant",
 		&model.Response{
@@ -6997,8 +6997,8 @@ func TestInterruptedAssistantDeltaResetsOnNewResponse(t *testing.T) {
 				},
 			}},
 		},
-	), nil)
-	rr.recordInterruptedAssistantDelta(loop, event.NewResponseEvent(
+	)
+	second := event.NewResponseEvent(
 		"inv",
 		"assistant",
 		&model.Response{
@@ -7013,10 +7013,148 @@ func TestInterruptedAssistantDeltaResetsOnNewResponse(t *testing.T) {
 				},
 			}},
 		},
-	), nil)
+	)
+	firstAgain := event.NewResponseEvent(
+		"inv",
+		"assistant",
+		&model.Response{
+			ID:        "response-1",
+			Object:    model.ObjectTypeChatCompletionChunk,
+			IsPartial: true,
+			Choices: []model.Choice{{
+				Index: 0,
+				Delta: model.Message{
+					Role:    model.RoleAssistant,
+					Content: " again",
+				},
+			}},
+		},
+	)
+	rr.recordInterruptedAssistantDelta(loop, first, nil)
+	rr.recordInterruptedAssistantDelta(loop, second, nil)
+	rr.recordInterruptedAssistantDelta(loop, firstAgain, nil)
 
-	require.Equal(t, "response-2", defaultInterruptedAssistantAccumulator(loop).responseID)
-	require.Equal(t, "second", interruptedAssistantChoices(loop)[0].Message.Content)
+	require.Len(t, loop.interruptedAssistants, 2)
+	firstAcc := getInterruptedAssistantAccumulatorForEvent(loop, nil, first)
+	secondAcc := getInterruptedAssistantAccumulatorForEvent(loop, nil, second)
+	require.NotNil(t, firstAcc)
+	require.NotNil(t, secondAcc)
+	require.Equal(t, "response-1", firstAcc.responseID)
+	require.Equal(t, "response-2", secondAcc.responseID)
+	require.Equal(
+		t,
+		"first again",
+		interruptedAssistantChoicesFromAccumulator(firstAcc)[0].Message.Content,
+	)
+	require.Equal(
+		t,
+		"second",
+		interruptedAssistantChoicesFromAccumulator(secondAcc)[0].Message.Content,
+	)
+}
+
+func TestInterruptedAssistantDeltaBuffersEmptyResponseByInvocationLineage(t *testing.T) {
+	rr := NewRunner("app", &noOpAgent{name: "a"}).(*runner)
+	loop := &eventLoopContext{
+		invocation: agent.NewInvocation(
+			agent.WithInvocationRunOptions(agent.RunOptions{RequestID: "req"}),
+		),
+	}
+	first := interruptedAssistantPartialEvent("child-a", "alpha ")
+	first.Branch = "parallel/a"
+	second := interruptedAssistantPartialEvent("child-b", "beta")
+	second.Branch = "parallel/b"
+	firstAgain := interruptedAssistantPartialEvent("child-a", "one")
+	firstAgain.Branch = "parallel/a"
+
+	rr.recordInterruptedAssistantDelta(loop, first, nil)
+	rr.recordInterruptedAssistantDelta(loop, second, nil)
+	rr.recordInterruptedAssistantDelta(loop, firstAgain, nil)
+
+	require.Len(t, loop.interruptedAssistants, 2)
+	firstAcc := getInterruptedAssistantAccumulatorForEvent(loop, nil, first)
+	secondAcc := getInterruptedAssistantAccumulatorForEvent(loop, nil, second)
+	require.NotNil(t, firstAcc)
+	require.NotNil(t, secondAcc)
+	require.NotEqual(t, firstAcc.responseID, secondAcc.responseID)
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	firstEvent := rr.interruptedAssistantEventForAccumulator(cancelled, loop, firstAcc)
+	secondEvent := rr.interruptedAssistantEventForAccumulator(cancelled, loop, secondAcc)
+	require.NotNil(t, firstEvent)
+	require.NotNil(t, secondEvent)
+	require.Equal(t, "child-a", firstEvent.InvocationID)
+	require.Equal(t, "parallel/a", firstEvent.Branch)
+	require.Equal(t, "alpha one", firstEvent.Choices[0].Message.Content)
+	require.Equal(t, "child-b", secondEvent.InvocationID)
+	require.Equal(t, "parallel/b", secondEvent.Branch)
+	require.Equal(t, "beta", secondEvent.Choices[0].Message.Content)
+}
+
+func TestPersistInterruptedAssistantPersistsInterleavedBuffers(t *testing.T) {
+	svc := &mockSessionService{}
+	rr := &runner{sessionService: svc}
+	sess := session.NewSession("app", "u", "s")
+	inv := agent.NewInvocation(
+		agent.WithInvocationRunOptions(agent.NewRunOptions(
+			agent.WithPersistInterruptedAssistant(true),
+		)),
+	)
+	loop := &eventLoopContext{
+		sess:       sess,
+		invocation: inv,
+	}
+	first := event.NewResponseEvent(
+		"child-a",
+		"assistant",
+		&model.Response{
+			ID:        "response-a",
+			Object:    model.ObjectTypeChatCompletionChunk,
+			IsPartial: true,
+			Choices: []model.Choice{{
+				Index: 0,
+				Delta: model.Message{
+					Role:    model.RoleAssistant,
+					Content: "alpha",
+				},
+			}},
+		},
+	)
+	second := event.NewResponseEvent(
+		"child-b",
+		"assistant",
+		&model.Response{
+			ID:        "response-b",
+			Object:    model.ObjectTypeChatCompletionChunk,
+			IsPartial: true,
+			Choices: []model.Choice{{
+				Index: 0,
+				Delta: model.Message{
+					Role:    model.RoleAssistant,
+					Content: "beta",
+				},
+			}},
+		},
+	)
+	rr.recordInterruptedAssistantDelta(loop, first, nil)
+	rr.recordInterruptedAssistantDelta(loop, second, nil)
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	rr.persistInterruptedAssistant(cancelled, loop)
+
+	require.Len(t, svc.appendEventCalls, 2)
+	persisted := map[string]string{}
+	for _, call := range svc.appendEventCalls {
+		require.Same(t, sess, call.sess)
+		require.Len(t, call.event.Choices, 1)
+		persisted[call.event.Response.ID] = call.event.Choices[0].Message.Content
+	}
+	require.Equal(t, map[string]string{
+		"response-a": "alpha",
+		"response-b": "beta",
+	}, persisted)
 }
 
 func TestInterruptedAssistantDeltaGeneratesFallbackResponseID(t *testing.T) {
@@ -7241,12 +7379,24 @@ func TestInterruptedAssistantEventSkipsEmptyAndPersistedContent(t *testing.T) {
 		Index:   0,
 		Message: model.NewAssistantMessage("already there"),
 	}}
-	loop := &eventLoopContext{}
-	acc := interruptedAssistantAccumulatorForSession(loop, nil)
-	acc.responseID = "resp"
-	acc.requestID = "req"
-	acc.persistedAssistantChoiceSignatures = map[string]struct{}{
-		interruptedAssistantSignatureKey("req", "inv", choices): {},
+	prior := event.NewResponseEvent(
+		"inv",
+		"assistant",
+		&model.Response{
+			ID:      "prior",
+			Object:  model.ObjectTypeChatCompletion,
+			Done:    true,
+			Choices: choices,
+		},
+	)
+	prior.RequestID = "req"
+	loop := &eventLoopContext{
+		sess: &session.Session{
+			Events: []event.Event{*prior},
+		},
+		invocation: agent.NewInvocation(
+			agent.WithInvocationRunOptions(agent.RunOptions{RequestID: "req"}),
+		),
 	}
 	rr.recordInterruptedAssistantDelta(loop, event.NewResponseEvent(
 		"inv",

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -7106,7 +7106,7 @@ func TestInterruptedAssistantDeltaSeparatesSameResponseIDByLineage(t *testing.T)
 		invocation: inv,
 	}
 	first := event.NewResponseEvent(
-		"child-a",
+		"shared-invocation",
 		"assistant",
 		&model.Response{
 			ID:        "shared-response",
@@ -7123,7 +7123,7 @@ func TestInterruptedAssistantDeltaSeparatesSameResponseIDByLineage(t *testing.T)
 	)
 	first.Branch = "parallel/a"
 	second := event.NewResponseEvent(
-		"child-b",
+		"shared-invocation",
 		"assistant",
 		&model.Response{
 			ID:        "shared-response",
@@ -7140,7 +7140,7 @@ func TestInterruptedAssistantDeltaSeparatesSameResponseIDByLineage(t *testing.T)
 	)
 	second.Branch = "parallel/b"
 	firstAgain := event.NewResponseEvent(
-		"child-a",
+		"shared-invocation",
 		"assistant",
 		&model.Response{
 			ID:        "shared-response",
@@ -7188,11 +7188,12 @@ func TestInterruptedAssistantDeltaSeparatesSameResponseIDByLineage(t *testing.T)
 	persisted := map[string]string{}
 	for _, call := range svc.appendEventCalls {
 		require.Equal(t, "shared-response", call.event.Response.ID)
-		persisted[call.event.InvocationID] = call.event.Choices[0].Message.Content
+		require.Equal(t, "shared-invocation", call.event.InvocationID)
+		persisted[call.event.Branch] = call.event.Choices[0].Message.Content
 	}
 	require.Equal(t, map[string]string{
-		"child-a": "alpha one",
-		"child-b": "beta",
+		"parallel/a": "alpha one",
+		"parallel/b": "beta",
 	}, persisted)
 }
 

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -7092,6 +7092,110 @@ func TestInterruptedAssistantDeltaBuffersEmptyResponseByInvocationLineage(t *tes
 	require.Equal(t, "beta", secondEvent.Choices[0].Message.Content)
 }
 
+func TestInterruptedAssistantDeltaSeparatesSameResponseIDByLineage(t *testing.T) {
+	svc := &mockSessionService{}
+	rr := &runner{sessionService: svc}
+	sess := session.NewSession("app", "u", "s")
+	inv := agent.NewInvocation(
+		agent.WithInvocationRunOptions(agent.NewRunOptions(
+			agent.WithPersistInterruptedAssistant(true),
+		)),
+	)
+	loop := &eventLoopContext{
+		sess:       sess,
+		invocation: inv,
+	}
+	first := event.NewResponseEvent(
+		"child-a",
+		"assistant",
+		&model.Response{
+			ID:        "shared-response",
+			Object:    model.ObjectTypeChatCompletionChunk,
+			IsPartial: true,
+			Choices: []model.Choice{{
+				Index: 0,
+				Delta: model.Message{
+					Role:    model.RoleAssistant,
+					Content: "alpha ",
+				},
+			}},
+		},
+	)
+	first.Branch = "parallel/a"
+	second := event.NewResponseEvent(
+		"child-b",
+		"assistant",
+		&model.Response{
+			ID:        "shared-response",
+			Object:    model.ObjectTypeChatCompletionChunk,
+			IsPartial: true,
+			Choices: []model.Choice{{
+				Index: 0,
+				Delta: model.Message{
+					Role:    model.RoleAssistant,
+					Content: "beta",
+				},
+			}},
+		},
+	)
+	second.Branch = "parallel/b"
+	firstAgain := event.NewResponseEvent(
+		"child-a",
+		"assistant",
+		&model.Response{
+			ID:        "shared-response",
+			Object:    model.ObjectTypeChatCompletionChunk,
+			IsPartial: true,
+			Choices: []model.Choice{{
+				Index: 0,
+				Delta: model.Message{
+					Role:    model.RoleAssistant,
+					Content: "one",
+				},
+			}},
+		},
+	)
+	firstAgain.Branch = "parallel/a"
+
+	rr.recordInterruptedAssistantDelta(loop, first, nil)
+	rr.recordInterruptedAssistantDelta(loop, second, nil)
+	rr.recordInterruptedAssistantDelta(loop, firstAgain, nil)
+
+	require.Len(t, loop.interruptedAssistants, 2)
+	firstAcc := getInterruptedAssistantAccumulatorForEvent(loop, nil, first)
+	secondAcc := getInterruptedAssistantAccumulatorForEvent(loop, nil, second)
+	require.NotNil(t, firstAcc)
+	require.NotNil(t, secondAcc)
+	require.NotSame(t, firstAcc, secondAcc)
+	require.Equal(t, "shared-response", firstAcc.responseID)
+	require.Equal(t, "shared-response", secondAcc.responseID)
+	require.Equal(
+		t,
+		"alpha one",
+		interruptedAssistantChoicesFromAccumulator(firstAcc)[0].Message.Content,
+	)
+	require.Equal(
+		t,
+		"beta",
+		interruptedAssistantChoicesFromAccumulator(secondAcc)[0].Message.Content,
+	)
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	rr.persistInterruptedAssistant(cancelled, loop)
+
+	require.Len(t, svc.appendEventCalls, 2)
+	persisted := map[string]string{}
+	for _, call := range svc.appendEventCalls {
+		require.Equal(t, "shared-response", call.event.Response.ID)
+		persisted[call.event.InvocationID] = call.event.Choices[0].Message.Content
+	}
+	require.Equal(t, map[string]string{
+		"child-a": "alpha one",
+		"child-b": "beta",
+	}, persisted)
+}
+
 func TestPersistInterruptedAssistantPersistsInterleavedBuffers(t *testing.T) {
 	svc := &mockSessionService{}
 	rr := &runner{sessionService: svc}


### PR DESCRIPTION
## Summary
- Persist a synthesized non-partial assistant message when a streamed run is cancelled after visible text deltas but before a final assistant response.
- Keep raw partial chunks out of Session and skip tool-call/reasoning-only deltas.
- Detach cancelled-context session writes for runner finalization with a bounded timeout.

## Test plan
- go test ./runner -coverprofile=/tmp/runner-cover.out
- go tool cover -func=/tmp/runner-cover.out | rg 'interruptedAssistant|recordInterrupted|persistInterrupted|sessionPersistence|contextDoneReason|^total:'
- go test ./...

Note: `go test ./...` currently fails in unrelated package `golang` at `TestChunkedReaderUsesRepoRootForScope` with `document "demo.Serve" not found`; runner package tests pass.

Fixes #1818