### PR TITLE
evaluation/workflow/promptiter/engine: accept non-optimizable trace surfaces

### DIFF
--- a/evaluation/workflow/promptiter/engine/backward.go
+++ b/evaluation/workflow/promptiter/engine/backward.go
@@ -289,6 +289,12 @@ func buildBackwardRequest(
 			continue
 		}
 		seenSurfaces[surfaceID] = struct{}{}
+		if _, ok := structure.knownSurfaceIDs[surfaceID]; !ok {
+			return nil, fmt.Errorf("surface id %q is unknown", surfaceID)
+		}
+		if _, ok := structure.surfaceIndex[surfaceID]; !ok {
+			continue
+		}
 		surface, err := resolveProfileSurface(structure, overrideIndex, surfaceID)
 		if err != nil {
 			return nil, err

--- a/evaluation/workflow/promptiter/engine/engine_test.go
+++ b/evaluation/workflow/promptiter/engine/engine_test.go
@@ -2146,6 +2146,61 @@ func TestNewStructureStateValidationErrors(t *testing.T) {
 	assert.NotContains(t, state.surfaceIndex, "candidate#unsupported")
 }
 
+func TestBuildKnownSurfaceIDsValidation(t *testing.T) {
+	nodes := map[string]astructure.Node{
+		"node_1": {NodeID: "node_1"},
+	}
+	known, err := buildKnownSurfaceIDs([]astructure.Surface{
+		{
+			SurfaceID: "node_1#instruction",
+			NodeID:    "node_1",
+		},
+		{
+			SurfaceID: "node_1#tool",
+			NodeID:    "node_1",
+		},
+	}, nodes)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]struct{}{
+		"node_1#instruction": {},
+		"node_1#tool":        {},
+	}, known)
+	known, err = buildKnownSurfaceIDs([]astructure.Surface{
+		{
+			NodeID: "node_1",
+		},
+	}, nodes)
+	assert.Nil(t, known)
+	assert.EqualError(t, err, "surface id is empty")
+	known, err = buildKnownSurfaceIDs([]astructure.Surface{
+		{
+			SurfaceID: "node_1#instruction",
+		},
+	}, nodes)
+	assert.Nil(t, known)
+	assert.EqualError(t, err, "surface node id is empty")
+	known, err = buildKnownSurfaceIDs([]astructure.Surface{
+		{
+			SurfaceID: "unknown#instruction",
+			NodeID:    "unknown",
+		},
+	}, nodes)
+	assert.Nil(t, known)
+	assert.EqualError(t, err, `surface "unknown#instruction" references unknown node id "unknown"`)
+	known, err = buildKnownSurfaceIDs([]astructure.Surface{
+		{
+			SurfaceID: "node_1#instruction",
+			NodeID:    "node_1",
+		},
+		{
+			SurfaceID: "node_1#instruction",
+			NodeID:    "node_1",
+		},
+	}, nodes)
+	assert.Nil(t, known)
+	assert.EqualError(t, err, `duplicate surface id "node_1#instruction"`)
+}
+
 func TestNormalizeProfileApplyPatchSetAndScopeHelpers(t *testing.T) {
 	structure, err := newStructureState(testStructureSnapshot(t))
 	assert.NoError(t, err)

--- a/evaluation/workflow/promptiter/engine/engine_test.go
+++ b/evaluation/workflow/promptiter/engine/engine_test.go
@@ -39,7 +39,10 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
 
-const testSurfaceID = "node_1#instruction"
+const (
+	testSurfaceID     = "node_1#instruction"
+	testToolSurfaceID = "node_1#tool"
+)
 
 type fakeBackwarder struct {
 	requests []*backwarder.Request
@@ -498,6 +501,82 @@ func TestRunAcceptsFirstRoundAndStopsAfterRejectedNextRound(t *testing.T) {
 	assert.Len(t, backward.requests, 2)
 	assert.Equal(t, "base prompt", *backward.requests[0].Surfaces[0].Value.Text)
 	assert.Equal(t, "accepted prompt", *backward.requests[1].Surfaces[0].Value.Text)
+}
+
+func TestRunAllowsToolSurfaceInTraceWhenTargetingInstruction(t *testing.T) {
+	backward := &fakeBackwarder{
+		fn: func(ctx context.Context, request *backwarder.Request) (*backwarder.Result, error) {
+			_ = ctx
+			require.Len(t, request.Surfaces, 1)
+			assert.Equal(t, testSurfaceID, request.Surfaces[0].SurfaceID)
+			assert.Equal(t, []string{testSurfaceID}, request.AllowedGradientSurfaceIDs)
+			return &backwarder.Result{
+				Gradients: []promptiter.SurfaceGradient{
+					{
+						EvalSetID:  request.EvalSetID,
+						EvalCaseID: request.EvalCaseID,
+						StepID:     request.StepID,
+						SurfaceID:  testSurfaceID,
+						Severity:   promptiter.LossSeverityP1,
+						Gradient:   "improve prompt",
+					},
+				},
+			}, nil
+		},
+	}
+	aggregatorInstance := &fakeAggregator{
+		fn: func(ctx context.Context, request *aggregator.Request) (*aggregator.Result, error) {
+			_ = ctx
+			return &aggregator.Result{
+				Gradient: &promptiter.AggregatedSurfaceGradient{
+					SurfaceID: request.SurfaceID,
+					NodeID:    request.NodeID,
+					Type:      request.Type,
+					Gradients: append([]promptiter.SurfaceGradient(nil), request.Gradients...),
+				},
+			}, nil
+		},
+	}
+	optimizerInstance := &fakeOptimizer{
+		fn: func(ctx context.Context, request *optimizer.Request) (*optimizer.Result, error) {
+			_ = ctx
+			return &optimizer.Result{
+				Patch: &promptiter.SurfacePatch{
+					SurfaceID: request.Surface.SurfaceID,
+					Value: astructure.SurfaceValue{
+						Text: stringPtr("accepted prompt"),
+					},
+					Reason: "update prompt",
+				},
+			}, nil
+		},
+	}
+	evalService := newScriptedEvalService(func(evalSetID string, profileValue string) scriptedEvalOutcome {
+		outcome := scriptedOutcome(evalSetID, profileValue)
+		outcome.appliedSurfaceIDs = []string{testSurfaceID, testToolSurfaceID}
+		return outcome
+	})
+	engineInstance, err := New(
+		context.Background(),
+		testTargetAgentWithToolSurface(),
+		newTestAgentEvaluator(t, evalService),
+		backward,
+		aggregatorInstance,
+		optimizerInstance,
+	)
+	assert.NoError(t, err)
+	result, err := engineInstance.Run(context.Background(), &RunRequest{
+		Train:            testEvalSetInputs("train"),
+		Validation:       testEvalSetInputs("validation"),
+		MaxRounds:        1,
+		TargetSurfaceIDs: []string{testSurfaceID},
+		AcceptancePolicy: AcceptancePolicy{
+			MinScoreGain: 0.1,
+		},
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Len(t, backward.requests, 1)
 }
 
 func TestRunObserverReceivesRuntimeEvents(t *testing.T) {
@@ -1784,6 +1863,31 @@ func TestValidateTraceAgainstStructure(t *testing.T) {
 	}))
 }
 
+func TestValidateTraceAgainstStructureAllowsKnownUnsupportedSurface(t *testing.T) {
+	structure, err := newStructureState(testStructureSnapshotWithToolSurface(t))
+	assert.NoError(t, err)
+	err = validateTraceAgainstStructure(structure, &atrace.Trace{
+		Steps: []atrace.Step{
+			{
+				StepID:            "step_1",
+				NodeID:            "node_1",
+				AppliedSurfaceIDs: []string{testSurfaceID, testToolSurfaceID},
+			},
+		},
+	})
+	assert.NoError(t, err)
+	err = validateTraceAgainstStructure(structure, &atrace.Trace{
+		Steps: []atrace.Step{
+			{
+				StepID:            "step_1",
+				NodeID:            "node_1",
+				AppliedSurfaceIDs: []string{"node_1#missing_tool"},
+			},
+		},
+	})
+	assert.EqualError(t, err, `execution trace step "step_1" references unknown surface id "node_1#missing_tool"`)
+}
+
 func TestExtractInferenceTraceDetails(t *testing.T) {
 	structure, err := newStructureState(testStructureSnapshot(t))
 	assert.NoError(t, err)
@@ -2626,6 +2730,21 @@ func TestBuildBackwardRequestValidationErrors(t *testing.T) {
 		traceIndex,
 		CaseResult{EvalSetID: "train", EvalCaseID: "case_1"},
 		atrace.Step{
+			StepID:            "step_2",
+			NodeID:            "node_1",
+			AppliedSurfaceIDs: []string{"node_1#missing"},
+		},
+		nil,
+		nil,
+	)
+	assert.Nil(t, request)
+	assert.EqualError(t, err, `surface id "node_1#missing" is unknown`)
+	request, err = buildBackwardRequest(
+		structure,
+		nil,
+		traceIndex,
+		CaseResult{EvalSetID: "train", EvalCaseID: "case_1"},
+		atrace.Step{
 			StepID:             "step_2",
 			NodeID:             "node_1",
 			PredecessorStepIDs: []string{"missing"},
@@ -2650,6 +2769,29 @@ func TestBuildBackwardRequestValidationErrors(t *testing.T) {
 	assert.NoError(t, err)
 	require.NotNil(t, request)
 	assert.NotNil(t, request.Input)
+}
+
+func TestBuildBackwardRequestSkipsUnsupportedAppliedSurfaces(t *testing.T) {
+	structure, err := newStructureState(testStructureSnapshotWithToolSurface(t))
+	assert.NoError(t, err)
+	request, err := buildBackwardRequest(
+		structure,
+		nil,
+		nil,
+		CaseResult{EvalSetID: "train", EvalCaseID: "case_1"},
+		atrace.Step{
+			StepID:            "step_1",
+			NodeID:            "node_1",
+			AppliedSurfaceIDs: []string{testSurfaceID, testToolSurfaceID, testSurfaceID},
+		},
+		nil,
+		targetSurfaceSet{testSurfaceID: struct{}{}},
+	)
+	assert.NoError(t, err)
+	require.NotNil(t, request)
+	require.Len(t, request.Surfaces, 1)
+	assert.Equal(t, testSurfaceID, request.Surfaces[0].SurfaceID)
+	assert.Equal(t, []string{testSurfaceID}, request.AllowedGradientSurfaceIDs)
 }
 
 func TestRunRejectsEmptyTargetSurfaceIDs(t *testing.T) {
@@ -2963,6 +3105,13 @@ func testStructureSnapshot(t *testing.T) *astructure.Snapshot {
 	return snapshot
 }
 
+func testStructureSnapshotWithToolSurface(t *testing.T) *astructure.Snapshot {
+	t.Helper()
+	snapshot, err := astructure.Export(context.Background(), testTargetAgentWithToolSurface())
+	assert.NoError(t, err)
+	return snapshot
+}
+
 func testTargetAgent() agent.Agent {
 	return &fakeStructureAgent{
 		snapshot: &astructure.Snapshot{
@@ -2980,6 +3129,42 @@ func testTargetAgent() agent.Agent {
 					Type:   astructure.SurfaceTypeInstruction,
 					Value: astructure.SurfaceValue{
 						Text: stringPtr("base prompt"),
+					},
+				},
+			},
+		},
+	}
+}
+
+func testTargetAgentWithToolSurface() agent.Agent {
+	return &fakeStructureAgent{
+		snapshot: &astructure.Snapshot{
+			EntryNodeID: "node_1",
+			Nodes: []astructure.Node{
+				{
+					NodeID: "node_1",
+					Kind:   astructure.NodeKindLLM,
+					Name:   "writer",
+				},
+			},
+			Surfaces: []astructure.Surface{
+				{
+					NodeID: "node_1",
+					Type:   astructure.SurfaceTypeInstruction,
+					Value: astructure.SurfaceValue{
+						Text: stringPtr("base prompt"),
+					},
+				},
+				{
+					NodeID: "node_1",
+					Type:   astructure.SurfaceTypeTool,
+					Value: astructure.SurfaceValue{
+						Tools: []astructure.ToolRef{
+							{
+								ID:          "bad_tool",
+								Description: "bad",
+							},
+						},
 					},
 				},
 			},

--- a/evaluation/workflow/promptiter/engine/evaluate.go
+++ b/evaluation/workflow/promptiter/engine/evaluate.go
@@ -519,7 +519,7 @@ func validateTraceAgainstStructure(
 			if surfaceID == "" {
 				return fmt.Errorf("execution trace step %q applied surface id is empty", step.StepID)
 			}
-			if _, ok := structure.surfaceIndex[surfaceID]; !ok {
+			if _, ok := structure.knownSurfaceIDs[surfaceID]; !ok {
 				return fmt.Errorf(
 					"execution trace step %q references unknown surface id %q",
 					step.StepID,

--- a/evaluation/workflow/promptiter/engine/structure.go
+++ b/evaluation/workflow/promptiter/engine/structure.go
@@ -18,9 +18,10 @@ import (
 )
 
 type structureState struct {
-	snapshot     *astructure.Snapshot
-	nodeIndex    map[string]astructure.Node
-	surfaceIndex map[string]astructure.Surface
+	snapshot        *astructure.Snapshot
+	nodeIndex       map[string]astructure.Node
+	surfaceIndex    map[string]astructure.Surface
+	knownSurfaceIDs map[string]struct{}
 }
 
 func newStructureState(snapshot *astructure.Snapshot) (*structureState, error) {
@@ -51,6 +52,10 @@ func newStructureState(snapshot *astructure.Snapshot) (*structureState, error) {
 	if err != nil {
 		return nil, fmt.Errorf("build surface index: %w", err)
 	}
+	knownSurfaceIDs, err := buildKnownSurfaceIDs(snapshot.Surfaces, nodeIndex)
+	if err != nil {
+		return nil, err
+	}
 	seenNodeTypes := make(map[string]struct{}, len(supportedSurfaces))
 	for _, surface := range supportedSurfaces {
 		if _, ok := nodeIndex[surface.NodeID]; !ok {
@@ -67,8 +72,32 @@ func newStructureState(snapshot *astructure.Snapshot) (*structureState, error) {
 		seenNodeTypes[nodeTypeKey] = struct{}{}
 	}
 	return &structureState{
-		snapshot:     snapshot,
-		nodeIndex:    nodeIndex,
-		surfaceIndex: surfaceIndex,
+		snapshot:        snapshot,
+		nodeIndex:       nodeIndex,
+		surfaceIndex:    surfaceIndex,
+		knownSurfaceIDs: knownSurfaceIDs,
 	}, nil
+}
+
+func buildKnownSurfaceIDs(
+	surfaces []astructure.Surface,
+	nodeIndex map[string]astructure.Node,
+) (map[string]struct{}, error) {
+	known := make(map[string]struct{}, len(surfaces))
+	for _, surface := range surfaces {
+		if surface.SurfaceID == "" {
+			return nil, errors.New("surface id is empty")
+		}
+		if surface.NodeID == "" {
+			return nil, errors.New("surface node id is empty")
+		}
+		if _, ok := nodeIndex[surface.NodeID]; !ok {
+			return nil, fmt.Errorf("surface %q references unknown node id %q", surface.SurfaceID, surface.NodeID)
+		}
+		if _, ok := known[surface.SurfaceID]; ok {
+			return nil, fmt.Errorf("duplicate surface id %q", surface.SurfaceID)
+		}
+		known[surface.SurfaceID] = struct{}{}
+	}
+	return known, nil
 }


### PR DESCRIPTION
Allow PromptIter trace validation to recognize all exported surface IDs while continuing to optimize only supported surface types, so tool surfaces recorded by LLM agent traces do not fail instruction-only runs and are skipped before backward optimization.