### PR TITLE
session: add ListSessions pagination

### DIFF
--- a/docs/mkdocs/en/session.md
+++ b/docs/mkdocs/en/session.md
@@ -1491,6 +1491,30 @@ for _, sess := range sessions {
 }
 ```
 
+```go
+// Fetch session metadata only, without Events or Tracks
+sessions, err := sessionService.ListSessions(ctx, session.UserKey{
+    AppName: "my-agent",
+    UserID:  "user123",
+}, session.WithListSessionOnlyMeta())
+```
+
+```go
+// Fetch the second page of sessions, ordered by UpdatedAt descending
+sessions, err := sessionService.ListSessions(ctx, session.UserKey{
+    AppName: "my-agent",
+    UserID:  "user123",
+}, session.WithListSessionPage(20, 20))
+```
+
+Notes:
+
+- `session.WithListSessionOnlyMeta()` is only for `ListSessions`
+- This optimization is currently supported only by the `inmemory` and `redis` backends
+- `session.WithListSessionPage(offset, limit)` is only for `ListSessions`; `offset` must be `>= 0`, and `limit == 0` means no session-level pagination
+- Session list pagination is independent from `session.WithEventNum()` and `session.WithEventTime()`, which filter events inside each returned session
+- Results are ordered by `UpdatedAt` descending, with session ID used as a deterministic tie-breaker
+
 #### Manually Delete Session
 
 ```go

--- a/docs/mkdocs/en/session/index.md
+++ b/docs/mkdocs/en/session/index.md
@@ -432,10 +432,21 @@ sessions, err := sessionService.ListSessions(ctx, session.UserKey{
 }, session.WithListSessionOnlyMeta())
 ```
 
+```go
+// Fetch the second page of sessions, ordered by UpdatedAt descending
+sessions, err := sessionService.ListSessions(ctx, session.UserKey{
+    AppName: "my-agent",
+    UserID:  "user123",
+}, session.WithListSessionPage(20, 20))
+```
+
 Notes:
 
 - `session.WithListSessionOnlyMeta()` is only for `ListSessions`
 - This optimization is currently supported only by the `inmemory` and `redis` backends
+- `session.WithListSessionPage(offset, limit)` is only for `ListSessions`; `offset` must be `>= 0`, and `limit == 0` means no session-level pagination
+- Session list pagination is independent from `session.WithEventNum()` and `session.WithEventTime()`, which filter events inside each returned session
+- Results are ordered by `UpdatedAt` descending, with session ID used as a deterministic tie-breaker
 
 #### Delete Session
 

--- a/docs/mkdocs/zh/session.md
+++ b/docs/mkdocs/zh/session.md
@@ -1470,6 +1470,30 @@ for _, sess := range sessions {
 }
 ```
 
+```go
+// 仅获取会话元数据，不返回 Events 和 Tracks
+sessions, err := sessionService.ListSessions(ctx, session.UserKey{
+    AppName: "my-agent",
+    UserID:  "user123",
+}, session.WithListSessionOnlyMeta())
+```
+
+```go
+// 获取第二页会话列表，按 UpdatedAt 倒序返回
+sessions, err := sessionService.ListSessions(ctx, session.UserKey{
+    AppName: "my-agent",
+    UserID:  "user123",
+}, session.WithListSessionPage(20, 20))
+```
+
+说明：
+
+- `session.WithListSessionOnlyMeta()` 只用于 `ListSessions`
+- 当前仅 `inmemory` 和 `redis` 后端支持该优化
+- `session.WithListSessionPage(offset, limit)` 只用于 `ListSessions`；`offset` 必须 `>= 0`，`limit == 0` 表示不做会话级分页
+- 会话列表分页与 `session.WithEventNum()`、`session.WithEventTime()` 相互独立，后两者用于过滤每个返回会话内部的事件
+- 结果按 `UpdatedAt` 倒序返回，`UpdatedAt` 相同时使用 session ID 做确定性排序
+
 #### 手动删除会话
 
 ```go

--- a/docs/mkdocs/zh/session/index.md
+++ b/docs/mkdocs/zh/session/index.md
@@ -436,10 +436,21 @@ sessions, err := sessionService.ListSessions(ctx, session.UserKey{
 }, session.WithListSessionOnlyMeta())
 ```
 
+```go
+// 获取第二页会话列表，按 UpdatedAt 倒序返回
+sessions, err := sessionService.ListSessions(ctx, session.UserKey{
+    AppName: "my-agent",
+    UserID:  "user123",
+}, session.WithListSessionPage(20, 20))
+```
+
 说明：
 
 - `session.WithListSessionOnlyMeta()` 只用于 `ListSessions`
 - 当前仅 `inmemory` 和 `redis` 后端支持该优化
+- `session.WithListSessionPage(offset, limit)` 只用于 `ListSessions`；`offset` 必须 `>= 0`，`limit == 0` 表示不做会话级分页
+- 会话列表分页与 `session.WithEventNum()`、`session.WithEventTime()` 相互独立，后两者用于过滤每个返回会话内部的事件
+- 结果按 `UpdatedAt` 倒序返回，`UpdatedAt` 相同时使用 session ID 做确定性排序
 
 #### 手动删除会话
 

--- a/session/clickhouse/service.go
+++ b/session/clickhouse/service.go
@@ -325,6 +325,7 @@ func (s *Service) ListSessions(
 		opt.EventNum,
 		opt.EventTime,
 		opt.ListSessionOnlyMeta,
+		opt.ListSessionPage,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("clickhouse session service get session list failed: %w", err)

--- a/session/clickhouse/service_helper.go
+++ b/session/clickhouse/service_helper.go
@@ -112,6 +112,7 @@ func (s *Service) listSessions(
 	limit int,
 	afterTime time.Time,
 	listOnlyMeta bool,
+	page *session.ListSessionPage,
 ) ([]*session.Session, error) {
 	// Query app state
 	appState, err := s.ListAppStates(ctx, key.AppName)
@@ -127,13 +128,18 @@ func (s *Service) listSessions(
 
 	// Query all session states for this user using FINAL
 	var sessStates []*SessionState
-	rows, err := s.chClient.Query(ctx,
-		fmt.Sprintf(`SELECT session_id, state, created_at, updated_at FROM %s FINAL
+	listQuery := fmt.Sprintf(`SELECT session_id, state, created_at, updated_at FROM %s FINAL
 			WHERE app_name = ? AND user_id = ?
 			AND (expires_at IS NULL OR expires_at > ?)
 			AND deleted_at IS NULL
-			ORDER BY updated_at DESC`, s.tableSessionStates),
-		key.AppName, key.UserID, time.Now())
+			ORDER BY updated_at DESC, session_id DESC`, s.tableSessionStates)
+	listArgs := []any{key.AppName, key.UserID, time.Now()}
+	if page != nil && page.Limit > 0 {
+		listQuery += " LIMIT ? OFFSET ?"
+		listArgs = append(listArgs, page.Limit, page.Offset)
+	}
+
+	rows, err := s.chClient.Query(ctx, listQuery, listArgs...)
 
 	if err != nil {
 		return nil, fmt.Errorf("list session states failed: %w", err)

--- a/session/clickhouse/service_test.go
+++ b/session/clickhouse/service_test.go
@@ -270,8 +270,8 @@ func TestService_ListSessions(t *testing.T) {
 		}
 		if callCount == 3 { // list session states
 			return newMockRows([][]any{
-				{sessState1.ID, string(stateBytes1), now, now},
 				{sessState2.ID, string(stateBytes2), now, now},
+				{sessState1.ID, string(stateBytes1), now, now},
 			}), nil
 		}
 		if callCount == 4 { // events
@@ -286,8 +286,61 @@ func TestService_ListSessions(t *testing.T) {
 	sessions, err := s.ListSessions(ctx, userKey)
 	assert.NoError(t, err)
 	assert.Len(t, sessions, 2)
-	assert.Equal(t, "sess1", sessions[0].ID)
-	assert.Equal(t, "sess2", sessions[1].ID)
+	assert.Equal(t, "sess2", sessions[0].ID)
+	assert.Equal(t, "sess1", sessions[1].ID)
+}
+
+func TestService_ListSessions_WithListSessionPage(t *testing.T) {
+	mockCli := &mockClient{}
+	s := &Service{
+		chClient:              mockCli,
+		opts:                  ServiceOpts{sessionTTL: time.Hour},
+		tableSessionStates:    "session_states",
+		tableSessionEvents:    "session_events",
+		tableSessionSummaries: "session_summaries",
+		tableAppStates:        "app_states",
+		tableUserStates:       "user_states",
+	}
+
+	ctx := context.Background()
+	userKey := session.UserKey{AppName: "test-app", UserID: "test-user"}
+	now := time.Now()
+
+	sessState2 := SessionState{
+		ID:        "sess2",
+		State:     session.StateMap{"k2": []byte("v2")},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	stateBytes2, _ := json.Marshal(sessState2)
+
+	callCount := 0
+	mockCli.queryFunc = func(ctx context.Context, query string, args ...any) (driver.Rows, error) {
+		callCount++
+		if callCount == 1 { // app state
+			return newMockRows([][]any{}), nil
+		}
+		if callCount == 2 { // user state
+			return newMockRows([][]any{}), nil
+		}
+		if callCount == 3 { // list session states (DB applies LIMIT 1 OFFSET 1)
+			return newMockRows([][]any{
+				{sessState2.ID, string(stateBytes2), now, now},
+			}), nil
+		}
+		if callCount == 4 { // events
+			return newMockRows([][]any{}), nil
+		}
+		if callCount == 5 { // summaries
+			return newMockRows([][]any{}), nil
+		}
+		return newMockRows([][]any{}), nil
+	}
+
+	sessions, err := s.ListSessions(ctx, userKey, session.WithListSessionPage(1, 1))
+	assert.NoError(t, err)
+	assert.Len(t, sessions, 1)
+	assert.Equal(t, "sess2", sessions[0].ID)
 }
 
 func TestService_ListSessionsWithListSessionOnlyMeta(t *testing.T) {

--- a/session/inmemory/service.go
+++ b/session/inmemory/service.go
@@ -21,6 +21,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/internal/session/hook"
 	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/session/internal/sessionopt"
 	isummary "trpc.group/trpc-go/trpc-agent-go/session/internal/summary"
 )
 
@@ -442,7 +443,8 @@ func (s *SessionService) ListSessions(
 
 		sessList = append(sessList, mergeState(appState, userState, copiedSess))
 	}
-	return sessList, nil
+	sessionopt.SortByUpdatedDesc(sessList)
+	return sessionopt.ApplyListPage(sessList, opt), nil
 }
 
 // DeleteSession removes a session from storage.

--- a/session/inmemory/service_test.go
+++ b/session/inmemory/service_test.go
@@ -538,6 +538,31 @@ func TestListSessions_WithListSessionOnlyMeta(t *testing.T) {
 	assert.False(t, got.UpdatedAt.IsZero())
 }
 
+func TestListSessions_WithListSessionPage(t *testing.T) {
+	service := NewSessionService()
+	defer service.Close()
+
+	ctx := context.Background()
+	userKey := session.UserKey{AppName: "app1", UserID: "user1"}
+	for _, id := range []string{"session1", "session2", "session3"} {
+		_, err := service.CreateSession(ctx, session.Key{
+			AppName:   userKey.AppName,
+			UserID:    userKey.UserID,
+			SessionID: id,
+		}, nil)
+		require.NoError(t, err)
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	sessions, err := service.ListSessions(
+		ctx, userKey, session.WithListSessionPage(1, 2),
+	)
+	require.NoError(t, err)
+	require.Len(t, sessions, 2)
+	assert.Equal(t, "session2", sessions[0].ID)
+	assert.Equal(t, "session1", sessions[1].ID)
+}
+
 func TestCloneSessionListMetadata(t *testing.T) {
 	t.Run("nil session", func(t *testing.T) {
 		assert.Nil(t, cloneSessionListMetadata(nil))

--- a/session/internal/sessionopt/pagination.go
+++ b/session/internal/sessionopt/pagination.go
@@ -1,0 +1,48 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+// Package sessionopt provides internal pagination helpers for session options.
+package sessionopt
+
+import (
+	"slices"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+// SortByUpdatedDesc sorts sessions by UpdatedAt descending, using ID descending
+// as a tiebreaker for deterministic pagination results.
+func SortByUpdatedDesc(sessions []*session.Session) {
+	slices.SortFunc(sessions, func(a, b *session.Session) int {
+		if cmp := b.UpdatedAt.Compare(a.UpdatedAt); cmp != 0 {
+			return cmp
+		}
+		return strings.Compare(b.ID, a.ID)
+	})
+}
+
+// ApplyListPage applies offset/limit pagination based on Options.
+// If ListSessionPage is nil, sessions are returned as-is.
+func ApplyListPage(sessions []*session.Session, opt *session.Options) []*session.Session {
+	if opt == nil || opt.ListSessionPage == nil {
+		return sessions
+	}
+	page := opt.ListSessionPage
+	n := len(sessions)
+	if page.Offset >= n {
+		return []*session.Session{}
+	}
+	remaining := n - page.Offset
+	limit := page.Limit
+	if limit > remaining {
+		limit = remaining
+	}
+	return sessions[page.Offset : page.Offset+limit]
+}

--- a/session/mysql/service.go
+++ b/session/mysql/service.go
@@ -396,6 +396,7 @@ func (s *Service) ListSessions(
 		opt.EventNum,
 		opt.EventTime,
 		opt.ListSessionOnlyMeta,
+		opt.ListSessionPage,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("mysql session service get session list failed: %w", err)

--- a/session/mysql/service_edge_test.go
+++ b/session/mysql/service_edge_test.go
@@ -191,7 +191,7 @@ func TestListSessions(t *testing.T) {
 			WithArgs(userKey.AppName, userKey.UserID, sqlmock.AnyArg()).
 			WillReturnRows(rows)
 
-		sessions, err := s.listSessions(context.Background(), userKey, 0, time.Time{}, false)
+		sessions, err := s.listSessions(context.Background(), userKey, 0, time.Time{}, false, nil)
 		assert.Error(t, err)
 		assert.Nil(t, sessions)
 		assert.Contains(t, err.Error(), "unmarshal session state failed")

--- a/session/mysql/service_helper.go
+++ b/session/mysql/service_helper.go
@@ -136,6 +136,7 @@ func (s *Service) listSessions(
 	limit int,
 	afterTime time.Time,
 	listOnlyMeta bool,
+	page *session.ListSessionPage,
 ) ([]*session.Session, error) {
 	// Query app state
 	appState, err := s.ListAppStates(ctx, key.AppName)
@@ -155,8 +156,12 @@ func (s *Service) listSessions(
 		WHERE app_name = ? AND user_id = ?
 		AND (expires_at IS NULL OR expires_at > ?)
 		AND deleted_at IS NULL
-		ORDER BY updated_at DESC`, s.tableSessionStates)
+		ORDER BY updated_at DESC, session_id DESC`, s.tableSessionStates)
 	listArgs := []any{key.AppName, key.UserID, time.Now()}
+	if page != nil && page.Limit > 0 {
+		listQuery += " LIMIT ? OFFSET ?"
+		listArgs = append(listArgs, page.Limit, page.Offset)
+	}
 
 	err = s.mysqlClient.Query(ctx, func(rows *sql.Rows) error {
 		// rows.Next() is already called by the Query loop

--- a/session/mysql/service_helper_test.go
+++ b/session/mysql/service_helper_test.go
@@ -546,6 +546,45 @@ func TestListSessions_WithMultipleSessions(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestListSessions_WithListSessionPage(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db)
+	ctx := context.Background()
+
+	userKey := session.UserKey{
+		AppName: "test-app",
+		UserID:  "user-123",
+	}
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT `key`, value FROM app_states")).
+		WithArgs(userKey.AppName, sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"key", "value"}))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT `key`, value FROM user_states")).
+		WithArgs(userKey.AppName, userKey.UserID, sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"key", "value"}))
+
+	sessState := SessionState{ID: "session-2"}
+	stateBytes, _ := json.Marshal(sessState)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT session_id, state, created_at, updated_at FROM session_states")).
+		WithArgs(userKey.AppName, userKey.UserID, sqlmock.AnyArg(), 1, 1).
+		WillReturnRows(sqlmock.NewRows([]string{"session_id", "state", "created_at", "updated_at"}).
+			AddRow("session-2", stateBytes, time.Now(), time.Now()))
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, app_name, user_id, session_id, event, created_at FROM")).
+		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, filter_key, summary, updated_at FROM session_summaries")).
+		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "filter_key", "summary", "updated_at"}))
+
+	sessions, err := s.ListSessions(ctx, userKey, session.WithListSessionPage(1, 1))
+	require.NoError(t, err)
+	require.Len(t, sessions, 1)
+	assert.Equal(t, "session-2", sessions[0].ID)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestListSessions_Error(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)

--- a/session/pgvector/service.go
+++ b/session/pgvector/service.go
@@ -467,6 +467,7 @@ func (s *Service) ListSessions(
 		opt.EventNum,
 		opt.EventTime,
 		opt.ListSessionOnlyMeta,
+		opt.ListSessionPage,
 	)
 	if err != nil {
 		return nil, fmt.Errorf(

--- a/session/pgvector/service_helper.go
+++ b/session/pgvector/service_helper.go
@@ -155,6 +155,7 @@ func (s *Service) listSessions(
 	limit int,
 	afterTime time.Time,
 	listOnlyMeta bool,
+	page *session.ListSessionPage,
 ) ([]*session.Session, error) {
 	appState, err := s.ListAppStates(ctx, key.AppName)
 	if err != nil {
@@ -173,11 +174,15 @@ func (s *Service) listSessions(
 		WHERE app_name = $1 AND user_id = $2
 		AND (expires_at IS NULL OR expires_at > NOW() AT TIME ZONE 'localtime')
 		AND deleted_at IS NULL
-		ORDER BY updated_at DESC`,
+		ORDER BY updated_at DESC, session_id DESC`,
 		s.tableSessionStates,
 	)
 	listArgs := []any{
 		key.AppName, key.UserID,
+	}
+	if page != nil && page.Limit > 0 {
+		listQuery += fmt.Sprintf(" LIMIT $%d OFFSET $%d", len(listArgs)+1, len(listArgs)+2)
+		listArgs = append(listArgs, page.Limit, page.Offset)
 	}
 
 	err = s.pgClient.Query(ctx,

--- a/session/pgvector/service_test.go
+++ b/session/pgvector/service_test.go
@@ -3205,6 +3205,43 @@ func TestListSessions_WithSessions(t *testing.T) {
 	assert.Equal(t, "sess1", sessions[0].ID)
 }
 
+func TestListSessions_WithListSessionPage(t *testing.T) {
+	s, mock, db := newTestServiceWithSliceSupport(
+		t, nil,
+	)
+	defer db.Close()
+
+	userKey := session.UserKey{
+		AppName: "app", UserID: "user",
+	}
+
+	now := time.Now()
+	makeState := func(id string) []byte {
+		b, _ := json.Marshal(SessionState{ID: id, State: session.StateMap{}})
+		return b
+	}
+
+	mock.ExpectQuery("SELECT key, value FROM app_states").
+		WillReturnRows(sqlmock.NewRows([]string{"key", "value"}))
+	mock.ExpectQuery("SELECT key, value FROM user_states").
+		WillReturnRows(sqlmock.NewRows([]string{"key", "value"}))
+	mock.ExpectQuery("SELECT session_id, state").
+		WillReturnRows(sqlmock.NewRows(
+			[]string{"session_id", "state", "created_at", "updated_at"},
+		).AddRow("sess2", makeState("sess2"), now, now))
+	mock.ExpectQuery("SELECT session_id, event").
+		WillReturnRows(sqlmock.NewRows([]string{"session_id", "event"}))
+	mock.ExpectQuery("SELECT session_id, filter_key").
+		WillReturnRows(sqlmock.NewRows([]string{"session_id", "filter_key", "summary"}))
+
+	sessions, err := s.ListSessions(
+		context.Background(), userKey, session.WithListSessionPage(1, 1),
+	)
+	require.NoError(t, err)
+	require.Len(t, sessions, 1)
+	assert.Equal(t, "sess2", sessions[0].ID)
+}
+
 func TestListSessions_WithTracks(t *testing.T) {
 	s, mock, db := newTestServiceWithSliceSupport(
 		t, nil,

--- a/session/postgres/service.go
+++ b/session/postgres/service.go
@@ -371,6 +371,7 @@ func (s *Service) ListSessions(
 		opt.EventNum,
 		opt.EventTime,
 		opt.ListSessionOnlyMeta,
+		opt.ListSessionPage,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("postgres session service get session list failed: %w", err)

--- a/session/postgres/service_edge_test.go
+++ b/session/postgres/service_edge_test.go
@@ -684,7 +684,7 @@ func TestListSessions(t *testing.T) {
 			WithArgs(userKey.AppName, userKey.UserID, sqlmock.AnyArg()).
 			WillReturnRows(rows)
 
-		sessions, err := s.listSessions(context.Background(), userKey, 0, time.Time{}, false)
+		sessions, err := s.listSessions(context.Background(), userKey, 0, time.Time{}, false, nil)
 		assert.Error(t, err)
 		assert.Nil(t, sessions)
 		assert.Contains(t, err.Error(), "unmarshal session state failed")

--- a/session/postgres/service_helper.go
+++ b/session/postgres/service_helper.go
@@ -127,6 +127,7 @@ func (s *Service) listSessions(
 	limit int,
 	afterTime time.Time,
 	listOnlyMeta bool,
+	page *session.ListSessionPage,
 ) ([]*session.Session, error) {
 	// Query app state
 	appState, err := s.ListAppStates(ctx, key.AppName)
@@ -146,8 +147,12 @@ func (s *Service) listSessions(
 		WHERE app_name = $1 AND user_id = $2
 		AND (expires_at IS NULL OR expires_at > $3)
 		AND deleted_at IS NULL
-		ORDER BY updated_at DESC`, s.tableSessionStates)
+		ORDER BY updated_at DESC, session_id DESC`, s.tableSessionStates)
 	listArgs := []any{key.AppName, key.UserID, time.Now()}
+	if page != nil && page.Limit > 0 {
+		listQuery += fmt.Sprintf(" LIMIT $%d OFFSET $%d", len(listArgs)+1, len(listArgs)+2)
+		listArgs = append(listArgs, page.Limit, page.Offset)
+	}
 
 	err = s.pgClient.Query(ctx, func(rows *sql.Rows) error {
 		for rows.Next() {

--- a/session/postgres/service_test.go
+++ b/session/postgres/service_test.go
@@ -1157,6 +1157,45 @@ func TestListSessions_WithMultipleSessions(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestListSessions_WithListSessionPage(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db)
+	ctx := context.Background()
+
+	userKey := session.UserKey{
+		AppName: "test-app",
+		UserID:  "user-123",
+	}
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT key, value FROM app_states")).
+		WithArgs(userKey.AppName, sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"key", "value"}))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT key, value FROM user_states")).
+		WithArgs(userKey.AppName, userKey.UserID, sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"key", "value"}))
+
+	sessState := SessionState{ID: "session-2"}
+	stateBytes, _ := json.Marshal(sessState)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT session_id, state, created_at, updated_at FROM session_states")).
+		WithArgs(userKey.AppName, userKey.UserID, sqlmock.AnyArg(), 1, 1).
+		WillReturnRows(sqlmock.NewRows([]string{"session_id", "state", "created_at", "updated_at"}).
+			AddRow("session-2", stateBytes, time.Now(), time.Now()))
+
+	mock.ExpectQuery("SELECT session_id, event FROM").
+		WillReturnRows(sqlmock.NewRows([]string{"session_id", "event"}))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT session_id, filter_key, summary FROM session_summaries")).
+		WillReturnRows(sqlmock.NewRows([]string{"session_id", "filter_key", "summary"}))
+
+	sessions, err := s.ListSessions(ctx, userKey, session.WithListSessionPage(1, 1))
+	require.NoError(t, err)
+	require.Len(t, sessions, 1)
+	assert.Equal(t, "session-2", sessions[0].ID)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestDeleteSession_Success(t *testing.T) {
 	s, mock, db := setupMockService(t, nil)
 	defer db.Close()

--- a/session/redis/service.go
+++ b/session/redis/service.go
@@ -13,7 +13,6 @@ package redis
 import (
 	"context"
 	"fmt"
-	"slices"
 	"sync"
 
 	"github.com/google/uuid"
@@ -24,6 +23,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/internal/session/hook"
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/session/internal/sessionopt"
 	isummary "trpc.group/trpc-go/trpc-agent-go/session/internal/summary"
 	"trpc.group/trpc-go/trpc-agent-go/session/redis/internal/hashidx"
 	"trpc.group/trpc-go/trpc-agent-go/session/redis/internal/util"
@@ -453,7 +453,8 @@ func (s *Service) ListSessions(
 
 	// List zset (if zset awareness is enabled: transition or legacy)
 	if !s.compatEnabled() {
-		return hashidxSessions, nil
+		sessionopt.SortByUpdatedDesc(hashidxSessions)
+		return sessionopt.ApplyListPage(hashidxSessions, opt), nil
 	}
 
 	zsetSessions, err := s.zsetClient.ListSessions(ctx, userKey, eventLimit, opt.EventTime, opt.ListSessionOnlyMeta)
@@ -481,11 +482,9 @@ func (s *Service) ListSessions(
 	}
 
 	// Sort by UpdatedAt descending to match SQL-based implementations.
-	slices.SortFunc(sessions, func(a, b *session.Session) int {
-		return b.UpdatedAt.Compare(a.UpdatedAt)
-	})
+	sessionopt.SortByUpdatedDesc(sessions)
 
-	return sessions, nil
+	return sessionopt.ApplyListPage(sessions, opt), nil
 }
 
 // DeleteSession deletes a session.

--- a/session/redis/service_test.go
+++ b/session/redis/service_test.go
@@ -779,6 +779,39 @@ func TestService_ListSessions_WithOptions(t *testing.T) {
 	assert.Len(t, sessions2, 3)
 }
 
+func TestService_ListSessions_WithListSessionPage(t *testing.T) {
+	redisURL, cleanup := setupTestRedis(t)
+	defer cleanup()
+
+	service, err := NewService(WithRedisClientURL(redisURL), WithEnableUserSessionIndex(true))
+	require.NoError(t, err)
+	defer service.Close()
+
+	ctx := context.Background()
+	userKey := session.UserKey{
+		AppName: "testapp",
+		UserID:  "user123",
+	}
+
+	for _, id := range []string{"session0", "session1", "session2"} {
+		_, err := service.CreateSession(ctx, session.Key{
+			AppName:   userKey.AppName,
+			UserID:    userKey.UserID,
+			SessionID: id,
+		}, session.StateMap{})
+		require.NoError(t, err)
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	sessions, err := service.ListSessions(
+		ctx, userKey, session.WithListSessionPage(1, 2),
+	)
+	require.NoError(t, err)
+	require.Len(t, sessions, 2)
+	assert.Equal(t, "session1", sessions[0].ID)
+	assert.Equal(t, "session0", sessions[1].ID)
+}
+
 func TestService_ListSessions_WithListSessionOnlyMeta(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/session/session.go
+++ b/session/session.go
@@ -45,6 +45,8 @@ var (
 	ErrInvalidEventPage = errors.New("event page requires offset >= 0 and limit > 0")
 	// ErrEventPageConflictsWithEventFilters indicates paging cannot be mixed with context filters.
 	ErrEventPageConflictsWithEventFilters = errors.New("event page cannot be combined with EventNum or EventTime")
+	// ErrInvalidListSessionPage indicates list-session paging arguments are invalid.
+	ErrInvalidListSessionPage = errors.New("list session page requires offset >= 0 and limit >= 0")
 )
 
 // SummaryFilterKeyAllContents is the filter key representing
@@ -589,10 +591,18 @@ type Summary struct {
 // Options contains shared session-service options.
 // Not every field applies to every service method.
 type Options struct {
-	EventNum            int        // EventNum is the number of recent events (context-window mode).
-	EventTime           time.Time  // EventTime is the after time.
-	EventPage           *EventPage // EventPage enables GetSession-only offset pagination when non-nil.
-	ListSessionOnlyMeta bool       // ListSessionOnlyMeta is only honored by ListSessions.
+	EventNum            int              // EventNum is the number of recent events (context-window mode).
+	EventTime           time.Time        // EventTime is the after time.
+	EventPage           *EventPage       // EventPage enables GetSession-only offset pagination when non-nil.
+	ListSessionOnlyMeta bool             // ListSessionOnlyMeta is only honored by ListSessions.
+	ListSessionPage     *ListSessionPage // ListSessionPage enables ListSessions offset pagination when non-nil.
+}
+
+// ListSessionPage specifies offset-based pagination for ListSessions.
+// When non-nil in Options, the backend applies LIMIT/OFFSET to the session list.
+type ListSessionPage struct {
+	Offset int // Offset is the number of sessions to skip.
+	Limit  int // Limit is the maximum number of sessions to return per page.
 }
 
 // EventPage specifies GetSession-only offset-based pagination for session events.
@@ -628,6 +638,15 @@ func WithListSessionOnlyMeta() Option {
 	}
 }
 
+// WithListSessionPage enables offset/limit pagination for ListSessions.
+// This option is orthogonal to WithEventNum/WithEventTime: those control event-level
+// filtering within each session, while this controls session-level pagination.
+func WithListSessionPage(offset, limit int) Option {
+	return func(o *Options) {
+		o.ListSessionPage = &ListSessionPage{Offset: offset, Limit: limit}
+	}
+}
+
 // WithGetSessionEventPage enables strict offset/limit pagination for GetSession events.
 // offset counts backwards from the most recent event (0 = most recent page).
 // limit is the page size. This option is only supported by postgres/mysql GetSession.
@@ -659,10 +678,16 @@ func ValidateGetSessionOptions(opts *Options, supportsEventPage bool) error {
 
 // ValidateListSessionsOptions validates ListSessions-only option semantics.
 func ValidateListSessionsOptions(opts *Options) error {
-	if opts == nil || opts.EventPage == nil {
+	if opts == nil {
 		return nil
 	}
-	return ErrEventPageOnlyForGetSession
+	if opts.EventPage != nil {
+		return ErrEventPageOnlyForGetSession
+	}
+	if opts.ListSessionPage != nil && (opts.ListSessionPage.Offset < 0 || opts.ListSessionPage.Limit <= 0) {
+		return ErrInvalidListSessionPage
+	}
+	return nil
 }
 
 // SummaryOption is the option for getting session summary.

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -141,6 +141,24 @@ func TestValidateListSessionsOptions(t *testing.T) {
 		EventPage: &EventPage{Offset: 0, Limit: 10},
 	})
 	require.ErrorIs(t, err, ErrEventPageOnlyForGetSession)
+
+	err = ValidateListSessionsOptions(&Options{
+		ListSessionPage: &ListSessionPage{Offset: -1, Limit: 10},
+	})
+	require.ErrorIs(t, err, ErrInvalidListSessionPage)
+
+	err = ValidateListSessionsOptions(&Options{
+		ListSessionPage: &ListSessionPage{Offset: 0, Limit: 0},
+	})
+	require.ErrorIs(t, err, ErrInvalidListSessionPage)
+
+	err = ValidateListSessionsOptions(&Options{
+		ListSessionPage: &ListSessionPage{Offset: 0, Limit: 10},
+	})
+	require.NoError(t, err)
+
+	err = ValidateListSessionsOptions(&Options{})
+	require.NoError(t, err)
 }
 
 func TestWithSummaryFilterKey(t *testing.T) {
@@ -2367,6 +2385,14 @@ func TestWithListSessionOnlyMeta(t *testing.T) {
 	opt := &Options{}
 	WithListSessionOnlyMeta()(opt)
 	assert.True(t, opt.ListSessionOnlyMeta)
+}
+
+func TestWithListSessionPage(t *testing.T) {
+	opt := &Options{}
+	WithListSessionPage(20, 50)(opt)
+	require.NotNil(t, opt.ListSessionPage)
+	assert.Equal(t, 20, opt.ListSessionPage.Offset)
+	assert.Equal(t, 50, opt.ListSessionPage.Limit)
 }
 
 // TestSession_SnapshotTracksState tests the SnapshotTracksState method.

--- a/session/sqlite/service.go
+++ b/session/sqlite/service.go
@@ -462,6 +462,7 @@ func (s *Service) ListSessions(
 		opt.EventNum,
 		opt.EventTime,
 		opt.ListSessionOnlyMeta,
+		opt.ListSessionPage,
 	)
 }
 

--- a/session/sqlite/service_helper.go
+++ b/session/sqlite/service_helper.go
@@ -142,6 +142,7 @@ func (s *Service) listSessions(
 	limit int,
 	afterTime time.Time,
 	listOnlyMeta bool,
+	page *session.ListSessionPage,
 ) ([]*session.Session, error) {
 	appState, err := s.ListAppStates(ctx, key.AppName)
 	if err != nil {
@@ -152,20 +153,18 @@ func (s *Service) listSessions(
 		return nil, err
 	}
 
-	const listSQL = `SELECT session_id, state, created_at, updated_at FROM %s
+	listSQL := fmt.Sprintf(`SELECT session_id, state, created_at, updated_at FROM %s
 WHERE app_name = ? AND user_id = ?
 AND (expires_at IS NULL OR expires_at > ?)
 AND deleted_at IS NULL
-ORDER BY updated_at DESC`
-	query := fmt.Sprintf(listSQL, s.tableSessionStates)
+ORDER BY updated_at DESC, session_id DESC`, s.tableSessionStates)
+	listArgs := []any{key.AppName, key.UserID, time.Now().UTC().UnixNano()}
+	if page != nil && page.Limit > 0 {
+		listSQL += " LIMIT ? OFFSET ?"
+		listArgs = append(listArgs, page.Limit, page.Offset)
+	}
 
-	rows, err := s.db.QueryContext(
-		ctx,
-		query,
-		key.AppName,
-		key.UserID,
-		time.Now().UTC().UnixNano(),
-	)
+	rows, err := s.db.QueryContext(ctx, listSQL, listArgs...)
 	if err != nil {
 		return nil, fmt.Errorf("list session states: %w", err)
 	}

--- a/session/sqlite/service_test.go
+++ b/session/sqlite/service_test.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -473,6 +474,30 @@ func TestSessionSQLite_ListSessions_WithListSessionOnlyMeta(t *testing.T) {
 	require.Empty(t, list[0].Events)
 	require.Nil(t, list[0].Tracks)
 	require.Equal(t, []byte("v"), list[0].State["k"])
+}
+
+func TestSessionSQLite_ListSessions_WithListSessionPage(t *testing.T) {
+	db, _, cleanup := openTempSQLiteDB(t)
+	defer cleanup()
+
+	svc, err := NewService(db)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, svc.Close()) }()
+
+	ctx := context.Background()
+	userKey := session.UserKey{AppName: "app", UserID: "u1"}
+
+	for i := 0; i < 3; i++ {
+		key := session.Key{AppName: "app", UserID: "u1", SessionID: fmt.Sprintf("s%d", i)}
+		s, createErr := svc.CreateSession(ctx, key, nil)
+		require.NoError(t, createErr)
+		require.NoError(t, svc.AppendEvent(ctx, s, newUserEvent("msg")))
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	list, err := svc.ListSessions(ctx, userKey, session.WithListSessionPage(1, 1))
+	require.NoError(t, err)
+	require.Len(t, list, 1)
 }
 
 func TestSessionSQLite_DeleteSession_Hard(t *testing.T) {


### PR DESCRIPTION
## Summary
- add a ListSessions offset/limit option with validation
- apply stable ordering and pagination for in-memory and Redis session services
- push pagination into MySQL and Postgres session-state queries

## Validation
- go test ./session ./session/inmemory
- (cd session/redis && go test ./...)
- (cd session/mysql && go test ./...)
- (cd session/postgres && go test ./...)