### PR TITLE
docs: clarify OpenAI file content handling

### DIFF
--- a/docs/mkdocs/en/codeexecutor.md
+++ b/docs/mkdocs/en/codeexecutor.md
@@ -193,6 +193,15 @@ msg := model.NewUserMessage("Please process this file.")
 _ = msg.AddFileData("report.pdf", pdfBytes, "application/pdf")
 ```
 
+If the file content is meant only for tools or the code executor, configure the
+OpenAI model with `openai.WithOmitFileContentParts(true)` to omit file content
+parts from provider requests. This does not hide normal message text or
+file-name hints that you include in the prompt. The current OpenAI adapter uses
+the Chat Completions API, whose file content support is limited to the request
+shapes accepted by that endpoint. PDF file data can be sent as file content,
+but Markdown or plain-text content should be passed as normal message text, or
+staged only for tools, instead of being sent as file content parts.
+
 ### Option 2: Upload to Artifact First, Then Attach a Reference
 
 If the file is already stored in the artifact service, attach an

--- a/docs/mkdocs/zh/codeexecutor.md
+++ b/docs/mkdocs/zh/codeexecutor.md
@@ -187,6 +187,13 @@ msg := model.NewUserMessage("请处理这个文件")
 _ = msg.AddFileData("report.pdf", pdfBytes, "application/pdf")
 ```
 
+如果文件内容只给工具或代码执行器使用，可以为 OpenAI 模型配置
+`openai.WithOmitFileContentParts(true)`，让 provider 请求省略 file content
+parts。这个选项不会隐藏你放在 prompt 里的普通消息文本或文件名提示。当前
+OpenAI adapter 使用 Chat Completions API，它只支持该接口接受的文件内容请求
+形式。PDF 文件数据可以作为 file content 发送；Markdown 或纯文本内容应作为
+普通消息文本传入，或只 stage 给工具使用，而不是作为 file content part 发送。
+
 ### 方式 2：先上传到 artifact，再在消息里只放引用
 
 如果文件已经提前上传到 artifact，可以把 `artifact://...` 作为 `file_id`


### PR DESCRIPTION
## Summary
- clarify that files meant only for tools or code execution can be omitted from OpenAI provider requests with `openai.WithOmitFileContentParts(true)`
- document the current OpenAI Chat Completions file-content limitation for Markdown/plain-text files
- call out PDF file content, message-text, and tool-staging alternatives
- update both English and Chinese codeexecutor docs

## Verification
- documentation-only change
- checked changed documentation section manually
- `rg -n $'\\t| +$' docs/mkdocs/en/codeexecutor.md docs/mkdocs/zh/codeexecutor.md` (only pre-existing trailing spaces in unrelated zh lines)

Refs #1816
Related to #786
