### PR TITLE
agent: add external tools run option

### DIFF
--- a/agent/invocation.go
+++ b/agent/invocation.go
@@ -794,6 +794,42 @@ func WithToolFilter(filter tool.FilterFunc) RunOption {
 	}
 }
 
+// WithAdditionalTools appends tools that are visible only for this run.
+//
+// Additional tools are treated as user tools, so WithToolFilter can still
+// hide them. If an additional tool has the same name as an already available
+// tool, the already available tool wins for that run.
+func WithAdditionalTools(tools []tool.Tool) RunOption {
+	return func(opts *RunOptions) {
+		appendRunTools(opts, tools)
+	}
+}
+
+// WithExternalTools appends caller-executed tools for this run.
+//
+// External tools are visible to the model like additional tools, but the
+// framework will not execute them. When the model calls one, the run stops
+// after the assistant tool_call response. The caller should execute the tool
+// externally and continue with model.NewToolMessage.
+func WithExternalTools(tools []tool.Tool) RunOption {
+	return func(opts *RunOptions) {
+		if opts == nil {
+			return
+		}
+		for _, tl := range tools {
+			name := declarationName(tl)
+			if name == "" {
+				continue
+			}
+			if opts.ExternalToolNames == nil {
+				opts.ExternalToolNames = make(map[string]bool)
+			}
+			opts.ExternalToolNames[name] = true
+			opts.ExternalTools = append(opts.ExternalTools, tl)
+		}
+	}
+}
+
 // WithToolExecutionFilter sets which tools the framework will execute.
 //
 // This is different from WithToolFilter:
@@ -809,6 +845,29 @@ func WithToolExecutionFilter(filter tool.FilterFunc) RunOption {
 	return func(opts *RunOptions) {
 		opts.ToolExecutionFilter = filter
 	}
+}
+
+func appendRunTools(opts *RunOptions, tools []tool.Tool) {
+	if opts == nil || len(tools) == 0 {
+		return
+	}
+	for _, tl := range tools {
+		if declarationName(tl) == "" {
+			continue
+		}
+		opts.AdditionalTools = append(opts.AdditionalTools, tl)
+	}
+}
+
+func declarationName(tl tool.Tool) string {
+	if tl == nil {
+		return ""
+	}
+	decl := tl.Declaration()
+	if decl == nil {
+		return ""
+	}
+	return decl.Name
 }
 
 // WithToolCallArgumentsJSONRepairEnabled enables best-effort JSON repair for tool call arguments.
@@ -1111,6 +1170,23 @@ type RunOptions struct {
 	//   })
 	ToolFilter tool.FilterFunc
 
+	// AdditionalTools contains tools that are visible only for this run.
+	//
+	// These tools are treated as user tools and are therefore affected by
+	// ToolFilter. They are appended to the effective tool surface without
+	// mutating the agent's registered tools.
+	AdditionalTools []tool.Tool
+
+	// ExternalTools contains caller-executed tools that are visible only for
+	// this run. The framework exposes them to the model, but does not execute
+	// them after the model returns a tool call.
+	ExternalTools []tool.Tool
+
+	// ExternalToolNames contains the accepted caller-executed tool names for
+	// this run. WithExternalTools initializes it, and LLM flows narrow it after
+	// the invocation tool surface rejects collisions with existing tools.
+	ExternalToolNames map[string]bool
+
 	// ToolExecutionFilter controls which tools are executed by the
 	// framework when the model returns tool calls.
 	//
@@ -1131,6 +1207,24 @@ type RunOptions struct {
 
 	// runControlConfig stores internal event and buffering controls.
 	runControlConfig runControlConfig
+}
+
+// ShouldExecuteTool reports whether the framework should execute a tool call.
+//
+// External tools are always caller-executed and therefore return false. The
+// ToolExecutionFilter is evaluated only for non-external tools.
+func (opts RunOptions) ShouldExecuteTool(
+	ctx context.Context,
+	tl tool.Tool,
+) bool {
+	name := declarationName(tl)
+	if name != "" && opts.ExternalToolNames[name] {
+		return false
+	}
+	if opts.ToolExecutionFilter == nil {
+		return true
+	}
+	return opts.ToolExecutionFilter(ctx, tl)
 }
 
 // IsGraphCompletionEventDisabled reports whether this invocation hides terminal graph completion events.

--- a/agent/invocation.go
+++ b/agent/invocation.go
@@ -817,14 +817,9 @@ func WithExternalTools(tools []tool.Tool) RunOption {
 			return
 		}
 		for _, tl := range tools {
-			name := declarationName(tl)
-			if name == "" {
+			if declarationName(tl) == "" {
 				continue
 			}
-			if opts.ExternalToolNames == nil {
-				opts.ExternalToolNames = make(map[string]bool)
-			}
-			opts.ExternalToolNames[name] = true
 			opts.ExternalTools = append(opts.ExternalTools, tl)
 		}
 	}
@@ -1183,8 +1178,8 @@ type RunOptions struct {
 	ExternalTools []tool.Tool
 
 	// ExternalToolNames contains the accepted caller-executed tool names for
-	// this run. WithExternalTools initializes it, and LLM flows narrow it after
-	// the invocation tool surface rejects collisions with existing tools.
+	// this run. LLM flows set it after the invocation tool surface rejects
+	// collisions with existing tools.
 	ExternalToolNames map[string]bool
 
 	// ToolExecutionFilter controls which tools are executed by the
@@ -1217,14 +1212,38 @@ func (opts RunOptions) ShouldExecuteTool(
 	ctx context.Context,
 	tl tool.Tool,
 ) bool {
-	name := declarationName(tl)
-	if name != "" && opts.ExternalToolNames[name] {
+	if opts.isExternalTool(tl) {
 		return false
 	}
 	if opts.ToolExecutionFilter == nil {
 		return true
 	}
 	return opts.ToolExecutionFilter(ctx, tl)
+}
+
+func (opts RunOptions) isExternalTool(tl tool.Tool) bool {
+	name := declarationName(tl)
+	if opts.ExternalToolNames != nil {
+		return name != "" && opts.ExternalToolNames[name]
+	}
+	for _, external := range opts.ExternalTools {
+		if sameRunTool(tl, external) {
+			return true
+		}
+	}
+	return false
+}
+
+func sameRunTool(a tool.Tool, b tool.Tool) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+	if av.Type() == bv.Type() && av.Type().Comparable() {
+		return a == b
+	}
+	return false
 }
 
 // IsGraphCompletionEventDisabled reports whether this invocation hides terminal graph completion events.

--- a/agent/invocation_messages_test.go
+++ b/agent/invocation_messages_test.go
@@ -311,12 +311,54 @@ func TestWithExternalTools(t *testing.T) {
 	)
 
 	require.Equal(t, []tool.Tool{externalTool}, ro.ExternalTools)
-	require.True(t, ro.ExternalToolNames[externalToolName])
+	require.Empty(t, ro.ExternalToolNames)
 
 	ctx := context.Background()
 	require.False(t, ro.ShouldExecuteTool(ctx, externalTool))
 	require.True(t, ro.ShouldExecuteTool(ctx, internalTool))
 	require.False(t, ro.ShouldExecuteTool(ctx, deniedTool))
+}
+
+func TestWithExternalTools_DoesNotShadowDifferentToolWithSameName(
+	t *testing.T,
+) {
+	const toolName = "client_tool"
+
+	externalTool := &stubTool{
+		decl: &tool.Declaration{Name: toolName},
+	}
+	registeredTool := &stubTool{
+		decl: &tool.Declaration{Name: toolName},
+	}
+
+	ro := NewRunOptions(
+		WithExternalTools([]tool.Tool{externalTool}),
+	)
+
+	ctx := context.Background()
+	require.False(t, ro.ShouldExecuteTool(ctx, externalTool))
+	require.True(t, ro.ShouldExecuteTool(ctx, registeredTool))
+
+	ro.ExternalToolNames = map[string]bool{toolName: true}
+	require.False(t, ro.ShouldExecuteTool(ctx, registeredTool))
+}
+
+func TestWithExternalTools_DoesNotUseDeclarationAsIdentity(
+	t *testing.T,
+) {
+	const toolName = "client_tool"
+
+	sharedDecl := &tool.Declaration{Name: toolName}
+	externalTool := &stubTool{decl: sharedDecl}
+	registeredTool := &stubTool{decl: sharedDecl}
+
+	ro := NewRunOptions(
+		WithExternalTools([]tool.Tool{externalTool}),
+	)
+
+	ctx := context.Background()
+	require.False(t, ro.ShouldExecuteTool(ctx, externalTool))
+	require.True(t, ro.ShouldExecuteTool(ctx, registeredTool))
 }
 
 func TestWithToolExecutionFilter(t *testing.T) {

--- a/agent/invocation_messages_test.go
+++ b/agent/invocation_messages_test.go
@@ -271,6 +271,54 @@ func (s *stubTool) Declaration() *tool.Declaration {
 	return s.decl
 }
 
+func TestWithAdditionalTools(t *testing.T) {
+	const toolName = "runtime_tool"
+
+	runtimeTool := &stubTool{
+		decl: &tool.Declaration{Name: toolName},
+	}
+
+	var ro RunOptions
+	WithAdditionalTools([]tool.Tool{runtimeTool})(&ro)
+
+	require.Equal(t, []tool.Tool{runtimeTool}, ro.AdditionalTools)
+	require.Empty(t, ro.ExternalTools)
+	require.Empty(t, ro.ExternalToolNames)
+}
+
+func TestWithExternalTools(t *testing.T) {
+	const (
+		externalToolName = "external_tool"
+		internalToolName = "internal_tool"
+		deniedToolName   = "denied_tool"
+	)
+
+	externalTool := &stubTool{
+		decl: &tool.Declaration{Name: externalToolName},
+	}
+	internalTool := &stubTool{
+		decl: &tool.Declaration{Name: internalToolName},
+	}
+	deniedTool := &stubTool{
+		decl: &tool.Declaration{Name: deniedToolName},
+	}
+
+	ro := NewRunOptions(
+		WithExternalTools([]tool.Tool{externalTool}),
+		WithToolExecutionFilter(
+			tool.NewIncludeToolNamesFilter(internalToolName),
+		),
+	)
+
+	require.Equal(t, []tool.Tool{externalTool}, ro.ExternalTools)
+	require.True(t, ro.ExternalToolNames[externalToolName])
+
+	ctx := context.Background()
+	require.False(t, ro.ShouldExecuteTool(ctx, externalTool))
+	require.True(t, ro.ShouldExecuteTool(ctx, internalTool))
+	require.False(t, ro.ShouldExecuteTool(ctx, deniedTool))
+}
+
 func TestWithToolExecutionFilter(t *testing.T) {
 	const (
 		allowedToolName = "tool1"

--- a/docs/mkdocs/en/agui/chat.md
+++ b/docs/mkdocs/en/agui/chat.md
@@ -751,11 +751,11 @@ The general flow is:
 - The caller sends the tool result back with a subsequent request, represented as a `role=tool` message.
 - The AG-UI server sends `TOOL_CALL_RESULT`, writes it to session history, and passes the tool result to the agent to continue running.
 
-Two server-side forms are currently supported. When directly wrapping an `llmagent.Agent`, use LLMAgent Tool-Filter mode. When external execution belongs to a GraphAgent node and must resume from a checkpoint, use GraphAgent Interrupt mode.
+Two server-side forms are currently supported. When directly wrapping an `llmagent.Agent`, use LLMAgent External Tool mode. When external execution belongs to a GraphAgent node and must resume from a checkpoint, use GraphAgent Interrupt mode.
 
-### LLMAgent Tool-Filter Mode
+### LLMAgent External Tool Mode
 
-Use this mode when the AG-UI server directly wraps an `llmagent.Agent` and only some tools need to be executed by the caller. External tools are still registered with the Agent so the model can generate the corresponding tool calls. `RunOptionResolver` returns `agent.WithToolExecutionFilter(...)` to declare which tools are not executed on the server.
+Use this mode when the AG-UI server directly wraps an `llmagent.Agent` and only some tools need to be executed by the caller. If the external tools are already registered with the Agent, `RunOptionResolver` can return `agent.WithToolExecutionFilter(...)` to declare which tools are not executed on the server. If the frontend or upstream service declares external tools dynamically for one request, convert those declarations to `[]tool.Tool` and return `agent.WithExternalTools(...)`.
 
 The first request uses `role=user`. When the model generates a tool call that must be executed by the caller, the event stream outputs `TOOL_CALL_START`, `TOOL_CALL_ARGS`, and `TOOL_CALL_END`, then ends the current run after that assistant tool-call response. The caller reads `toolCallId` and tool arguments from the event stream, executes the tool, and starts a second request with a `role=tool` message.
 
@@ -765,21 +765,24 @@ Code snippet:
 
 ```go
 import (
+    "context"
+
     "trpc.group/trpc-go/trpc-agent-go/agent"
     "trpc.group/trpc-go/trpc-agent-go/server/agui"
     aguiadapter "trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
     aguirunner "trpc.group/trpc-go/trpc-agent-go/server/agui/runner"
-    "trpc.group/trpc-go/trpc-agent-go/tool"
 )
 
 func resolveRunOptions(
     context.Context,
-    *aguiadapter.RunAgentInput,
+    input *aguiadapter.RunAgentInput,
 ) ([]agent.RunOption, error) {
+    externalTools, err := aguirunner.ExternalToolsFromRunAgentInput(input)
+    if err != nil {
+        return nil, err
+    }
     return []agent.RunOption{
-        agent.WithToolExecutionFilter(
-            tool.NewExcludeToolNamesFilter("external_note"),
-        ),
+        agent.WithExternalTools(externalTools),
     }, nil
 }
 
@@ -790,6 +793,12 @@ server, err := agui.New(
     ),
 )
 ```
+
+`ExternalToolsFromRunAgentInput` converts AG-UI `input.Tools` to declaration-only
+trpc-agent-go tools. `WithExternalTools` then exposes those tools to the model
+and defers execution to the caller. If a dynamic declaration has the same name
+as an existing server tool, the existing server tool wins and the dynamic
+declaration does not override or intercept it.
 
 For the complete LLMAgent example, see the server implementation in [examples/agui/server/externaltool/llmagent](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/server/externaltool/llmagent), and the frontend client in [examples/agui/client/tdesign-chat](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/client/tdesign-chat).
 

--- a/docs/mkdocs/en/agui/chat.md
+++ b/docs/mkdocs/en/agui/chat.md
@@ -273,10 +273,13 @@ server, _ := agui.New(
 
 ## Custom `RunOptionResolver`
 
-`RunOptionResolver` adds [`agent.RunOption`](https://github.com/trpc-group/trpc-agent-go/blob/main/agent/invocation.go) for the current agent run. It runs for every request, and the returned options only affect that run.
+`RunOptionResolver` adds [`agent.RunOption`](https://github.com/trpc-group/trpc-agent-go/blob/main/agent/invocation.go) for the current agent run. It runs for every request, and the returned options only affect that run. `WithRunOptionResolver` replaces the default resolver, so compose `ExternalToolsFromRunAgentInput` yourself if request `input.Tools` should still be exposed as caller-executed tools.
 
 ```go
 import (
+	"context"
+	"errors"
+
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/runner"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui"
@@ -288,11 +291,16 @@ resolver := func(_ context.Context, input *adapter.RunAgentInput) ([]agent.RunOp
 	if input == nil {
 		return nil, errors.New("empty input")
 	}
+	externalTools, err := aguirunner.ExternalToolsFromRunAgentInput(input)
+	if err != nil {
+		return nil, err
+	}
 	forwardedProps, ok := input.ForwardedProps.(map[string]any)
 	if !ok || forwardedProps == nil {
-		return nil, nil
+		return []agent.RunOption{agent.WithExternalTools(externalTools)}, nil
 	}
-	opts := make([]agent.RunOption, 0, 2)
+	opts := make([]agent.RunOption, 0, 3)
+	opts = append(opts, agent.WithExternalTools(externalTools))
 	if modelName, ok := forwardedProps["modelName"].(string); ok && modelName != "" {
 		opts = append(opts, agent.WithModelName(modelName))
 	}
@@ -755,7 +763,7 @@ Two server-side forms are currently supported. When directly wrapping an `llmage
 
 ### LLMAgent External Tool Mode
 
-Use this mode when the AG-UI server directly wraps an `llmagent.Agent` and only some tools need to be executed by the caller. If the external tools are already registered with the Agent, `RunOptionResolver` can return `agent.WithToolExecutionFilter(...)` to declare which tools are not executed on the server. If the frontend or upstream service declares external tools dynamically for one request, convert those declarations to `[]tool.Tool` and return `agent.WithExternalTools(...)`.
+Use this mode when the AG-UI server directly wraps an `llmagent.Agent` and only some tools need to be executed by the caller. If the external tools are already registered with the Agent, `RunOptionResolver` can return `agent.WithToolExecutionFilter(...)` to declare which tools are not executed on the server. If the frontend or upstream service declares tools in AG-UI `input.Tools`, the default AG-UI runner converts them to `agent.WithExternalTools(...)` and injects them into `runner.Run`.
 
 The first request uses `role=user`. When the model generates a tool call that must be executed by the caller, the event stream outputs `TOOL_CALL_START`, `TOOL_CALL_ARGS`, and `TOOL_CALL_END`, then ends the current run after that assistant tool-call response. The caller reads `toolCallId` and tool arguments from the event stream, executes the tool, and starts a second request with a `role=tool` message.
 
@@ -765,40 +773,21 @@ Code snippet:
 
 ```go
 import (
-    "context"
-
-    "trpc.group/trpc-go/trpc-agent-go/agent"
     "trpc.group/trpc-go/trpc-agent-go/server/agui"
-    aguiadapter "trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
-    aguirunner "trpc.group/trpc-go/trpc-agent-go/server/agui/runner"
 )
 
-func resolveRunOptions(
-    context.Context,
-    input *aguiadapter.RunAgentInput,
-) ([]agent.RunOption, error) {
-    externalTools, err := aguirunner.ExternalToolsFromRunAgentInput(input)
-    if err != nil {
-        return nil, err
-    }
-    return []agent.RunOption{
-        agent.WithExternalTools(externalTools),
-    }, nil
-}
-
-server, err := agui.New(
-    run,
-    agui.WithAGUIRunnerOptions(
-        aguirunner.WithRunOptionResolver(resolveRunOptions),
-    ),
-)
+server, err := agui.New(run)
 ```
 
-`ExternalToolsFromRunAgentInput` converts AG-UI `input.Tools` to declaration-only
-trpc-agent-go tools. `WithExternalTools` then exposes those tools to the model
-and defers execution to the caller. If a dynamic declaration has the same name
-as an existing server tool, the existing server tool wins and the dynamic
+By default, the AG-UI runner converts AG-UI `input.Tools` to declaration-only
+trpc-agent-go tools, passes them with `WithExternalTools`, exposes them to the
+model, and defers execution to the caller. If a dynamic declaration has the same
+name as an existing server tool, the existing server tool wins and the dynamic
 declaration does not override or intercept it.
+
+If you replace the default `RunOptionResolver`, compose this behavior manually
+with `aguirunner.ExternalToolsFromRunAgentInput(input)` and
+`agent.WithExternalTools(...)`.
 
 For the complete LLMAgent example, see the server implementation in [examples/agui/server/externaltool/llmagent](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/server/externaltool/llmagent), and the frontend client in [examples/agui/client/tdesign-chat](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/client/tdesign-chat).
 

--- a/docs/mkdocs/en/agui/chat.md
+++ b/docs/mkdocs/en/agui/chat.md
@@ -273,7 +273,7 @@ server, _ := agui.New(
 
 ## Custom `RunOptionResolver`
 
-`RunOptionResolver` adds [`agent.RunOption`](https://github.com/trpc-group/trpc-agent-go/blob/main/agent/invocation.go) for the current agent run. It runs for every request, and the returned options only affect that run. `WithRunOptionResolver` replaces the default resolver, so compose `ExternalToolsFromRunAgentInput` yourself if request `input.Tools` should still be exposed as caller-executed tools.
+`RunOptionResolver` adds [`agent.RunOption`](https://github.com/trpc-group/trpc-agent-go/blob/main/agent/invocation.go) for the current agent run. It runs for every request, and the returned options only affect that run. The AG-UI runner still maps request `input.Tools` to caller-executed tools after the custom resolver returns.
 
 ```go
 import (
@@ -291,16 +291,11 @@ resolver := func(_ context.Context, input *adapter.RunAgentInput) ([]agent.RunOp
 	if input == nil {
 		return nil, errors.New("empty input")
 	}
-	externalTools, err := aguirunner.ExternalToolsFromRunAgentInput(input)
-	if err != nil {
-		return nil, err
-	}
 	forwardedProps, ok := input.ForwardedProps.(map[string]any)
 	if !ok || forwardedProps == nil {
-		return []agent.RunOption{agent.WithExternalTools(externalTools)}, nil
+		return nil, nil
 	}
-	opts := make([]agent.RunOption, 0, 3)
-	opts = append(opts, agent.WithExternalTools(externalTools))
+	opts := make([]agent.RunOption, 0, 2)
 	if modelName, ok := forwardedProps["modelName"].(string); ok && modelName != "" {
 		opts = append(opts, agent.WithModelName(modelName))
 	}
@@ -785,9 +780,8 @@ model, and defers execution to the caller. If a dynamic declaration has the same
 name as an existing server tool, the existing server tool wins and the dynamic
 declaration does not override or intercept it.
 
-If you replace the default `RunOptionResolver`, compose this behavior manually
-with `aguirunner.ExternalToolsFromRunAgentInput(input)` and
-`agent.WithExternalTools(...)`.
+This automatic mapping also applies when `WithRunOptionResolver` is used; the
+custom resolver only needs to return additional run options.
 
 For the complete LLMAgent example, see the server implementation in [examples/agui/server/externaltool/llmagent](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/server/externaltool/llmagent), and the frontend client in [examples/agui/client/tdesign-chat](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/client/tdesign-chat).
 

--- a/docs/mkdocs/en/tool.md
+++ b/docs/mkdocs/en/tool.md
@@ -1877,7 +1877,7 @@ tools automatically, then sends the tool results back to the model.
 In some systems, you may want the caller (for example, a client, an upstream
 service, or an external tool runtime such as Model Context Protocol (MCP)) to
 execute tools instead. You can interrupt tool execution with
-`agent.WithToolExecutionFilter(...)`.
+`agent.WithExternalTools(...)` or `agent.WithToolExecutionFilter(...)`.
 
 **Key idea:**
 
@@ -1885,21 +1885,44 @@ execute tools instead. You can interrupt tool execution with
   see and call).
 - `agent.WithToolExecutionFilter(...)` controls **tool execution** (what the
   framework will auto-run after the model requests it).
+- `agent.WithAdditionalTools(...)` appends temporary tools for one run.
+- `agent.WithExternalTools(...)` appends temporary tools and marks them as
+  caller-executed.
 
 #### Basic Flow
 
-1. Run the agent with `WithToolExecutionFilter` so the framework does **not**
-   execute selected tools.
+1. Run the agent with `WithExternalTools` so the model can see caller-owned
+   tools.
 2. Read `tool_calls` from the model response.
 3. Execute the tool externally.
 4. Send a `role=tool` message back so the model can continue.
 
 ```go
-execFilter := tool.NewExcludeToolNamesFilter("external_search")
+type declarationOnlyTool struct {
+    decl *tool.Declaration
+}
+
+func (t *declarationOnlyTool) Declaration() *tool.Declaration {
+    return t.decl
+}
+
+externalSearch := &declarationOnlyTool{
+    decl: &tool.Declaration{
+        Name:        "external_search",
+        Description: "Search a caller-owned system.",
+        InputSchema: &tool.Schema{
+            Type: "object",
+            Properties: map[string]*tool.Schema{
+                "query": {Type: "string"},
+            },
+            Required: []string{"query"},
+        },
+    },
+}
 
 // Step 1: model returns tool_calls, but the tool is NOT executed.
 ch, err := r.Run(ctx, userID, sessionID, model.NewUserMessage("search ..."),
-    agent.WithToolExecutionFilter(execFilter),
+    agent.WithExternalTools([]tool.Tool{externalSearch}),
 )
 
 // Step 2: extract tool_call_id + arguments from events (omitted).
@@ -1909,9 +1932,18 @@ toolResultJSON := `{"status":"ok","data":"..."}`
 // Step 3/4: send tool result as role=tool, then model continues.
 toolMsg := model.NewToolMessage(toolCallID, "external_search", toolResultJSON)
 ch, err = r.Run(ctx, userID, sessionID, toolMsg,
-    agent.WithToolExecutionFilter(execFilter),
+    agent.WithExternalTools([]tool.Tool{externalSearch}),
 )
 ```
+
+If the tool is already registered on the Agent with `llmagent.WithTools(...)`
+and only its per-run execution policy should change, continue to use
+`agent.WithToolExecutionFilter(...)`. `WithExternalTools` is better for AG-UI,
+browser, mobile, or upstream-service callers that declare tools dynamically on
+each request. If an external tool has the same name as an existing tool, the
+existing tool wins; the external declaration does not override or intercept it.
+This includes tools registered on the Agent and tools added with
+`WithAdditionalTools`.
 
 **Complete example:** `examples/toolinterrupt/`
 

--- a/docs/mkdocs/en/tool.md
+++ b/docs/mkdocs/en/tool.md
@@ -1940,7 +1940,8 @@ If the tool is already registered on the Agent with `llmagent.WithTools(...)`
 and only its per-run execution policy should change, continue to use
 `agent.WithToolExecutionFilter(...)`. `WithExternalTools` is better for AG-UI,
 browser, mobile, or upstream-service callers that declare tools dynamically on
-each request. If an external tool has the same name as an existing tool, the
+each request. The AG-UI runner maps request `input.Tools` to `WithExternalTools`
+by default. If an external tool has the same name as an existing tool, the
 existing tool wins; the external declaration does not override or intercept it.
 This includes tools registered on the Agent and tools added with
 `WithAdditionalTools`.

--- a/docs/mkdocs/zh/agui/chat.md
+++ b/docs/mkdocs/zh/agui/chat.md
@@ -751,11 +751,11 @@ server, err := agui.New(
 - 调用方用后续请求回传工具结果，结果以 `role=tool` message 表示。
 - AG-UI 服务端发送 `TOOL_CALL_RESULT`，写入会话历史，并把工具结果交给 Agent 继续运行。
 
-当前支持两种服务端形态。直接包装 `llmagent.Agent` 时，使用 LLMAgent Tool-Filter 模式；外部执行属于 GraphAgent 节点并且需要从 checkpoint 恢复时，使用 GraphAgent Interrupt 模式。
+当前支持两种服务端形态。直接包装 `llmagent.Agent` 时，使用 LLMAgent 外部工具模式；外部执行属于 GraphAgent 节点并且需要从 checkpoint 恢复时，使用 GraphAgent Interrupt 模式。
 
-### LLMAgent Tool-Filter 模式
+### LLMAgent 外部工具模式
 
-当 AG-UI 服务端直接包装 `llmagent.Agent`，并且只需要把部分工具交给调用方执行时，使用该模式。外部工具仍注册到 Agent 中，使模型能够生成对应 tool call；`RunOptionResolver` 返回 `agent.WithToolExecutionFilter(...)`，声明哪些工具不在服务端执行。
+当 AG-UI 服务端直接包装 `llmagent.Agent`，并且只需要把部分工具交给调用方执行时，使用该模式。如果外部工具已经注册到 Agent 中，`RunOptionResolver` 可以返回 `agent.WithToolExecutionFilter(...)`，声明哪些工具不在服务端执行。如果外部工具由前端或上游服务在本次请求中动态声明，`RunOptionResolver` 可以把这些声明转换成 `[]tool.Tool`，再返回 `agent.WithExternalTools(...)`。
 
 第一次请求使用 `role=user`。当模型生成需要调用方执行的 tool call 时，事件流输出 `TOOL_CALL_START`、`TOOL_CALL_ARGS` 和 `TOOL_CALL_END`，并在该 assistant tool-call 响应后结束本次 run。调用方从事件流中获取 `toolCallId` 和工具参数，执行工具后，再用 `role=tool` message 发起第二次请求。
 
@@ -765,21 +765,24 @@ server, err := agui.New(
 
 ```go
 import (
+    "context"
+
     "trpc.group/trpc-go/trpc-agent-go/agent"
     "trpc.group/trpc-go/trpc-agent-go/server/agui"
     aguiadapter "trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
     aguirunner "trpc.group/trpc-go/trpc-agent-go/server/agui/runner"
-    "trpc.group/trpc-go/trpc-agent-go/tool"
 )
 
 func resolveRunOptions(
     context.Context,
-    *aguiadapter.RunAgentInput,
+    input *aguiadapter.RunAgentInput,
 ) ([]agent.RunOption, error) {
+    externalTools, err := aguirunner.ExternalToolsFromRunAgentInput(input)
+    if err != nil {
+        return nil, err
+    }
     return []agent.RunOption{
-        agent.WithToolExecutionFilter(
-            tool.NewExcludeToolNamesFilter("external_note"),
-        ),
+        agent.WithExternalTools(externalTools),
     }, nil
 }
 
@@ -790,6 +793,9 @@ server, err := agui.New(
     ),
 )
 ```
+
+`ExternalToolsFromRunAgentInput` 会把 AG-UI `input.Tools` 转成只有声明的
+trpc-agent-go 工具。`WithExternalTools` 再把这些工具暴露给模型，并把执行权交给调用方。如果动态声明与服务端已有工具同名，服务端已有工具优先，动态声明不会覆盖或拦截已有工具。
 
 完整 LLMAgent 示例：服务端可参考 [examples/agui/server/externaltool/llmagent](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/server/externaltool/llmagent)，前端客户端可参考 [examples/agui/client/tdesign-chat](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/client/tdesign-chat)。
 

--- a/docs/mkdocs/zh/agui/chat.md
+++ b/docs/mkdocs/zh/agui/chat.md
@@ -273,10 +273,13 @@ server, _ := agui.New(
 
 ## 自定义 `RunOptionResolver`
 
-`RunOptionResolver` 用于为本次 Agent 运行补充 [`agent.RunOption`](https://github.com/trpc-group/trpc-agent-go/blob/main/agent/invocation.go)。它会在每次请求处理时执行，返回的选项只作用于当前这次运行。
+`RunOptionResolver` 用于为本次 Agent 运行补充 [`agent.RunOption`](https://github.com/trpc-group/trpc-agent-go/blob/main/agent/invocation.go)。它会在每次请求处理时执行，返回的选项只作用于当前这次运行。`WithRunOptionResolver` 会替换默认 resolver，所以如果仍要把请求中的 `input.Tools` 暴露为调用方执行的工具，需要自行组合 `ExternalToolsFromRunAgentInput`。
 
 ```go
 import (
+	"context"
+	"errors"
+
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/runner"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui"
@@ -288,11 +291,16 @@ resolver := func(_ context.Context, input *adapter.RunAgentInput) ([]agent.RunOp
 	if input == nil {
 		return nil, errors.New("empty input")
 	}
+	externalTools, err := aguirunner.ExternalToolsFromRunAgentInput(input)
+	if err != nil {
+		return nil, err
+	}
 	forwardedProps, ok := input.ForwardedProps.(map[string]any)
 	if !ok || forwardedProps == nil {
-		return nil, nil
+		return []agent.RunOption{agent.WithExternalTools(externalTools)}, nil
 	}
-	opts := make([]agent.RunOption, 0, 2)
+	opts := make([]agent.RunOption, 0, 3)
+	opts = append(opts, agent.WithExternalTools(externalTools))
 	if modelName, ok := forwardedProps["modelName"].(string); ok && modelName != "" {
 		opts = append(opts, agent.WithModelName(modelName))
 	}
@@ -755,7 +763,7 @@ server, err := agui.New(
 
 ### LLMAgent 外部工具模式
 
-当 AG-UI 服务端直接包装 `llmagent.Agent`，并且只需要把部分工具交给调用方执行时，使用该模式。如果外部工具已经注册到 Agent 中，`RunOptionResolver` 可以返回 `agent.WithToolExecutionFilter(...)`，声明哪些工具不在服务端执行。如果外部工具由前端或上游服务在本次请求中动态声明，`RunOptionResolver` 可以把这些声明转换成 `[]tool.Tool`，再返回 `agent.WithExternalTools(...)`。
+当 AG-UI 服务端直接包装 `llmagent.Agent`，并且只需要把部分工具交给调用方执行时，使用该模式。如果外部工具已经注册到 Agent 中，`RunOptionResolver` 可以返回 `agent.WithToolExecutionFilter(...)`，声明哪些工具不在服务端执行。如果前端或上游服务通过 AG-UI `input.Tools` 动态声明工具，默认 AG-UI runner 会自动转换成 `agent.WithExternalTools(...)` 并注入 `runner.Run`。
 
 第一次请求使用 `role=user`。当模型生成需要调用方执行的 tool call 时，事件流输出 `TOOL_CALL_START`、`TOOL_CALL_ARGS` 和 `TOOL_CALL_END`，并在该 assistant tool-call 响应后结束本次 run。调用方从事件流中获取 `toolCallId` 和工具参数，执行工具后，再用 `role=tool` message 发起第二次请求。
 
@@ -765,37 +773,18 @@ server, err := agui.New(
 
 ```go
 import (
-    "context"
-
-    "trpc.group/trpc-go/trpc-agent-go/agent"
     "trpc.group/trpc-go/trpc-agent-go/server/agui"
-    aguiadapter "trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
-    aguirunner "trpc.group/trpc-go/trpc-agent-go/server/agui/runner"
 )
 
-func resolveRunOptions(
-    context.Context,
-    input *aguiadapter.RunAgentInput,
-) ([]agent.RunOption, error) {
-    externalTools, err := aguirunner.ExternalToolsFromRunAgentInput(input)
-    if err != nil {
-        return nil, err
-    }
-    return []agent.RunOption{
-        agent.WithExternalTools(externalTools),
-    }, nil
-}
-
-server, err := agui.New(
-    run,
-    agui.WithAGUIRunnerOptions(
-        aguirunner.WithRunOptionResolver(resolveRunOptions),
-    ),
-)
+server, err := agui.New(run)
 ```
 
-`ExternalToolsFromRunAgentInput` 会把 AG-UI `input.Tools` 转成只有声明的
-trpc-agent-go 工具。`WithExternalTools` 再把这些工具暴露给模型，并把执行权交给调用方。如果动态声明与服务端已有工具同名，服务端已有工具优先，动态声明不会覆盖或拦截已有工具。
+默认情况下，AG-UI runner 会把 AG-UI `input.Tools` 转成只有声明的
+trpc-agent-go 工具，通过 `WithExternalTools` 暴露给模型，并把执行权交给调用方。如果动态声明与服务端已有工具同名，服务端已有工具优先，动态声明不会覆盖或拦截已有工具。
+
+如果业务替换了默认 `RunOptionResolver`，需要自行组合
+`aguirunner.ExternalToolsFromRunAgentInput(input)` 和
+`agent.WithExternalTools(...)` 来保留这段默认行为。
 
 完整 LLMAgent 示例：服务端可参考 [examples/agui/server/externaltool/llmagent](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/server/externaltool/llmagent)，前端客户端可参考 [examples/agui/client/tdesign-chat](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/client/tdesign-chat)。
 

--- a/docs/mkdocs/zh/agui/chat.md
+++ b/docs/mkdocs/zh/agui/chat.md
@@ -273,7 +273,7 @@ server, _ := agui.New(
 
 ## 自定义 `RunOptionResolver`
 
-`RunOptionResolver` 用于为本次 Agent 运行补充 [`agent.RunOption`](https://github.com/trpc-group/trpc-agent-go/blob/main/agent/invocation.go)。它会在每次请求处理时执行，返回的选项只作用于当前这次运行。`WithRunOptionResolver` 会替换默认 resolver，所以如果仍要把请求中的 `input.Tools` 暴露为调用方执行的工具，需要自行组合 `ExternalToolsFromRunAgentInput`。
+`RunOptionResolver` 用于为本次 Agent 运行补充 [`agent.RunOption`](https://github.com/trpc-group/trpc-agent-go/blob/main/agent/invocation.go)。它会在每次请求处理时执行，返回的选项只作用于当前这次运行。AG-UI runner 会在自定义 resolver 返回后，继续把请求里的 `input.Tools` 映射为调用方执行的工具。
 
 ```go
 import (
@@ -291,16 +291,11 @@ resolver := func(_ context.Context, input *adapter.RunAgentInput) ([]agent.RunOp
 	if input == nil {
 		return nil, errors.New("empty input")
 	}
-	externalTools, err := aguirunner.ExternalToolsFromRunAgentInput(input)
-	if err != nil {
-		return nil, err
-	}
 	forwardedProps, ok := input.ForwardedProps.(map[string]any)
 	if !ok || forwardedProps == nil {
-		return []agent.RunOption{agent.WithExternalTools(externalTools)}, nil
+		return nil, nil
 	}
-	opts := make([]agent.RunOption, 0, 3)
-	opts = append(opts, agent.WithExternalTools(externalTools))
+	opts := make([]agent.RunOption, 0, 2)
 	if modelName, ok := forwardedProps["modelName"].(string); ok && modelName != "" {
 		opts = append(opts, agent.WithModelName(modelName))
 	}
@@ -782,9 +777,8 @@ server, err := agui.New(run)
 默认情况下，AG-UI runner 会把 AG-UI `input.Tools` 转成只有声明的
 trpc-agent-go 工具，通过 `WithExternalTools` 暴露给模型，并把执行权交给调用方。如果动态声明与服务端已有工具同名，服务端已有工具优先，动态声明不会覆盖或拦截已有工具。
 
-如果业务替换了默认 `RunOptionResolver`，需要自行组合
-`aguirunner.ExternalToolsFromRunAgentInput(input)` 和
-`agent.WithExternalTools(...)` 来保留这段默认行为。
+使用 `WithRunOptionResolver` 时仍然会保留这段自动映射；自定义
+resolver 只需要返回业务额外需要的 run options。
 
 完整 LLMAgent 示例：服务端可参考 [examples/agui/server/externaltool/llmagent](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/server/externaltool/llmagent)，前端客户端可参考 [examples/agui/client/tdesign-chat](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/client/tdesign-chat)。
 

--- a/docs/mkdocs/zh/tool.md
+++ b/docs/mkdocs/zh/tool.md
@@ -1881,8 +1881,8 @@ ch, err = r.Run(ctx, userID, sessionID, toolMsg,
 如果工具已经通过 `llmagent.WithTools(...)` 注册在 Agent 上，只是想在某次
 运行中改成由调用方执行，可以继续使用 `agent.WithToolExecutionFilter(...)`。
 `WithExternalTools` 更适合 AG-UI、浏览器、移动端或上游服务在每次请求中动态声明
-工具的场景。外部工具与已有工具同名时，已有工具优先，外部声明不会覆盖或拦截它。
-这里的已有工具包括 Agent 上注册的工具，以及通过 `WithAdditionalTools` 追加的工具。
+工具的场景。AG-UI runner 默认会把请求里的 `input.Tools` 映射为
+`WithExternalTools`。外部工具与已有工具同名时，已有工具优先，外部声明不会覆盖或拦截它。这里的已有工具包括 Agent 上注册的工具，以及通过 `WithAdditionalTools` 追加的工具。
 
 **完整示例：** `examples/toolinterrupt/`
 

--- a/docs/mkdocs/zh/tool.md
+++ b/docs/mkdocs/zh/tool.md
@@ -1822,26 +1822,49 @@ r := runner.NewRunner(
 
 在一些系统里，你可能希望由调用方（例如客户端、上游服务，或外部工具运行时，例如
 Model Context Protocol (MCP)）来执行工具。此时可以使用
-`agent.WithToolExecutionFilter(...)` 来中断工具的自动执行。
+`agent.WithExternalTools(...)` 或 `agent.WithToolExecutionFilter(...)`
+来中断工具的自动执行。
 
 **核心区别：**
 
 - `agent.WithToolFilter(...)` 控制**工具可见性**（模型能看到/能调用哪些工具）
 - `agent.WithToolExecutionFilter(...)` 控制**工具执行**（模型请求后，框架是否自动执行）
+- `agent.WithAdditionalTools(...)` 为本次运行追加临时可见工具
+- `agent.WithExternalTools(...)` 追加临时可见工具，并声明这些工具由调用方执行
 
 #### 基本流程
 
-1. 使用 `WithToolExecutionFilter` 发起一次 `runner.Run`，让框架**不执行**指定工具
+1. 使用 `WithExternalTools` 发起一次 `runner.Run`，让模型看到调用方工具
 2. 从事件里读取模型返回的 `tool_calls`
 3. 调用方在外部执行工具
 4. 通过 `role=tool` 的消息把结果回填，模型继续输出最终答案
 
 ```go
-execFilter := tool.NewExcludeToolNamesFilter("external_search")
+type declarationOnlyTool struct {
+    decl *tool.Declaration
+}
+
+func (t *declarationOnlyTool) Declaration() *tool.Declaration {
+    return t.decl
+}
+
+externalSearch := &declarationOnlyTool{
+    decl: &tool.Declaration{
+        Name:        "external_search",
+        Description: "Search a caller-owned system.",
+        InputSchema: &tool.Schema{
+            Type: "object",
+            Properties: map[string]*tool.Schema{
+                "query": {Type: "string"},
+            },
+            Required: []string{"query"},
+        },
+    },
+}
 
 // 第一步：模型会返回 tool_calls，但工具不会被框架执行。
 ch, err := r.Run(ctx, userID, sessionID, model.NewUserMessage("search ..."),
-    agent.WithToolExecutionFilter(execFilter),
+    agent.WithExternalTools([]tool.Tool{externalSearch}),
 )
 
 // 第二步：从事件里提取 tool_call_id + arguments（此处省略）。
@@ -1851,9 +1874,15 @@ toolResultJSON := `{"status":"ok","data":"..."}`
 // 第三/四步：用 role=tool 回填工具结果，模型继续输出。
 toolMsg := model.NewToolMessage(toolCallID, "external_search", toolResultJSON)
 ch, err = r.Run(ctx, userID, sessionID, toolMsg,
-    agent.WithToolExecutionFilter(execFilter),
+    agent.WithExternalTools([]tool.Tool{externalSearch}),
 )
 ```
+
+如果工具已经通过 `llmagent.WithTools(...)` 注册在 Agent 上，只是想在某次
+运行中改成由调用方执行，可以继续使用 `agent.WithToolExecutionFilter(...)`。
+`WithExternalTools` 更适合 AG-UI、浏览器、移动端或上游服务在每次请求中动态声明
+工具的场景。外部工具与已有工具同名时，已有工具优先，外部声明不会覆盖或拦截它。
+这里的已有工具包括 Agent 上注册的工具，以及通过 `WithAdditionalTools` 追加的工具。
 
 **完整示例：** `examples/toolinterrupt/`
 

--- a/examples/agui/server/README.md
+++ b/examples/agui/server/README.md
@@ -8,7 +8,7 @@ This directory shows AG-UI servers that can talk to the AG-UI client examples.
 - [`skill_artifacts/`](skill_artifacts/) – Demonstrates `skill_run` output artifacts surfaced as `CustomEvent("tool.artifacts")`.
 - [`event_emitter/`](event_emitter/) – Demonstrates Node EventEmitter for emitting custom events, progress updates, and streaming text from NodeFunc.
 - [`finishresult/`](finishresult/) – Demonstrates populating `RUN_FINISHED.result` by wrapping the default translator.
-- [`externaltool/llmagent/`](externaltool/llmagent/) – Demonstrates `llmagent + agui + WithToolExecutionFilter` with two internal tools and two external tools in the same conversation.
+- [`externaltool/llmagent/`](externaltool/llmagent/) – Demonstrates `llmagent + agui + WithExternalTools` with two internal tools and two dynamically declared external tools in the same conversation.
 - [`externaltool/graphagent/`](externaltool/graphagent/) – Demonstrates a `GraphAgent` interrupt workflow with two internal tools and two external tools in the same turn.
 - [`streamtool/`](streamtool/) – Demonstrates a minimal `StreamableTool` that uses `agui.WithStreamingToolResultActivityEnabled(true)` to stream tool progress as `ACTIVITY_SNAPSHOT` / `ACTIVITY_DELTA` while preserving a final `TOOL_CALL_RESULT`.
 - [`heartbeat/`](heartbeat/) – Demonstrates SSE heartbeat keepalive frames with `agui.WithHeartbeatInterval`.

--- a/examples/agui/server/externaltool/README.md
+++ b/examples/agui/server/externaltool/README.md
@@ -2,5 +2,6 @@
 
 This directory groups AG-UI examples where tool execution is split between the server-side agent flow and the caller.
 
-- [`llmagent/`](llmagent/) uses `LLMAgent` with `WithToolExecutionFilter` for caller-executed tools.
+- [`llmagent/`](llmagent/) uses `LLMAgent` with dynamically declared
+  `WithExternalTools` caller-executed tools.
 - [`graphagent/`](graphagent/) uses `GraphAgent` interrupt and resume with two graph-executed internal tools and two caller-executed external tools.

--- a/examples/agui/server/externaltool/llmagent/README.md
+++ b/examples/agui/server/externaltool/llmagent/README.md
@@ -24,8 +24,7 @@ in one conversation:
 Call 2 uses the same `threadId` and a new `runId` for the follow-up `role=tool`
 request.
 
-The server converts `input.Tools` with
-`aguirunner.ExternalToolsFromRunAgentInput(input)` and passes them to
+The default AG-UI runner converts `input.Tools` and passes them to
 `agent.WithExternalTools(...)`. These tools do not need a backend `Call`
 implementation.
 

--- a/examples/agui/server/externaltool/llmagent/README.md
+++ b/examples/agui/server/externaltool/llmagent/README.md
@@ -3,12 +3,15 @@
 This example exposes an AG-UI SSE endpoint backed by an `LLMAgent` that mixes:
 
 - internal tools (`calculator`, `internal_lookup`) executed automatically by the framework
-- external tools (`external_note`, `external_approval`) executed by the caller through `role=tool`
+- external tools (`external_note`, `external_approval`) declared by the AG-UI
+  request and executed by the caller through `role=tool`
 
-The goal is to verify that `agui + llmagent + agent.WithToolExecutionFilter(...)`
-can handle a mixed tool flow in one conversation:
+The goal is to verify that
+`agui + llmagent + agent.WithExternalTools(...)` can handle a mixed tool flow
+in one conversation:
 
-1. Call 1 (`role=user`) emits tool calls for all four tools.
+1. Call 1 (`role=user`) sends AG-UI `tools` for `external_note` and
+   `external_approval`, then emits tool calls for all four tools.
 2. The framework executes `calculator` and `internal_lookup` immediately and
    returns their `TOOL_CALL_RESULT` events.
 3. The framework defers `external_note` and `external_approval`, ends the run,
@@ -20,6 +23,11 @@ can handle a mixed tool flow in one conversation:
 
 Call 2 uses the same `threadId` and a new `runId` for the follow-up `role=tool`
 request.
+
+The server converts `input.Tools` with
+`aguirunner.ExternalToolsFromRunAgentInput(input)` and passes them to
+`agent.WithExternalTools(...)`. These tools do not need a backend `Call`
+implementation.
 
 ## Run
 

--- a/examples/agui/server/externaltool/llmagent/agent.go
+++ b/examples/agui/server/externaltool/llmagent/agent.go
@@ -29,7 +29,7 @@ func newAgent(modelInstance model.Model, generationConfig model.GenerationConfig
 	return llmagent.New(
 		agentName,
 		llmagent.WithModel(modelInstance),
-		llmagent.WithTools(demotool.NewTools()),
+		llmagent.WithTools(demotool.NewInternalTools()),
 		llmagent.WithEnableParallelTools(true),
 		llmagent.WithGenerationConfig(generationConfig),
 		llmagent.WithInstruction(agentInstruction),

--- a/examples/agui/server/externaltool/llmagent/agui.go
+++ b/examples/agui/server/externaltool/llmagent/agui.go
@@ -14,18 +14,11 @@ import (
 	"errors"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
-	demotool "trpc.group/trpc-go/trpc-agent-go/examples/agui/server/externaltool/llmagent/tool"
 	"trpc.group/trpc-go/trpc-agent-go/runner"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui"
 	aguiadapter "trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
 	aguirunner "trpc.group/trpc-go/trpc-agent-go/server/agui/runner"
 	"trpc.group/trpc-go/trpc-agent-go/session"
-	"trpc.group/trpc-go/trpc-agent-go/tool"
-)
-
-var externalToolExecutionFilter = tool.NewExcludeToolNamesFilter(
-	demotool.ExternalNoteName,
-	demotool.ExternalApprovalName,
 )
 
 func newAGUIServer(run runner.Runner, sessionService session.Service) (*agui.Server, error) {
@@ -51,7 +44,11 @@ func resolveRunOptions(_ context.Context, input *aguiadapter.RunAgentInput) ([]a
 	if len(input.Messages) == 0 {
 		return nil, errors.New("no messages provided")
 	}
+	externalTools, err := aguirunner.ExternalToolsFromRunAgentInput(input)
+	if err != nil {
+		return nil, err
+	}
 	return []agent.RunOption{
-		agent.WithToolExecutionFilter(externalToolExecutionFilter),
+		agent.WithExternalTools(externalTools),
 	}, nil
 }

--- a/examples/agui/server/externaltool/llmagent/agui.go
+++ b/examples/agui/server/externaltool/llmagent/agui.go
@@ -10,14 +10,8 @@
 package main
 
 import (
-	"context"
-	"errors"
-
-	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/runner"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui"
-	aguiadapter "trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
-	aguirunner "trpc.group/trpc-go/trpc-agent-go/server/agui/runner"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 )
 
@@ -28,27 +22,5 @@ func newAGUIServer(run runner.Runner, sessionService session.Service) (*agui.Ser
 		agui.WithSessionService(sessionService),
 		agui.WithPath(*path),
 		agui.WithMessagesSnapshotEnabled(true),
-		agui.WithAGUIRunnerOptions(
-			aguirunner.WithRunOptionResolver(resolveRunOptions),
-		),
 	)
-}
-
-func resolveRunOptions(_ context.Context, input *aguiadapter.RunAgentInput) ([]agent.RunOption, error) {
-	if input == nil {
-		return nil, errors.New("run input is nil")
-	}
-	if input.ThreadID == "" {
-		return nil, errors.New("threadId is required")
-	}
-	if len(input.Messages) == 0 {
-		return nil, errors.New("no messages provided")
-	}
-	externalTools, err := aguirunner.ExternalToolsFromRunAgentInput(input)
-	if err != nil {
-		return nil, err
-	}
-	return []agent.RunOption{
-		agent.WithExternalTools(externalTools),
-	}, nil
 }

--- a/examples/agui/server/externaltool/llmagent/run.sh
+++ b/examples/agui/server/externaltool/llmagent/run.sh
@@ -18,6 +18,36 @@ first_response="$(curl --no-buffer --silent --show-error --fail --location \
   --data '{
     "threadId": "externaltool-llmagent-thread",
     "runId": "externaltool-llmagent-run-1",
+    "tools": [
+      {
+        "name": "external_note",
+        "description": "Ask the caller to provide a plain text note for the given topic.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "topic": {
+              "type": "string",
+              "description": "The topic that needs an external note."
+            }
+          },
+          "required": ["topic"]
+        }
+      },
+      {
+        "name": "external_approval",
+        "description": "Ask the caller to provide an approval decision for the given item.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "item": {
+              "type": "string",
+              "description": "The item that needs caller approval."
+            }
+          },
+          "required": ["item"]
+        }
+      }
+    ],
     "messages": [
       {
         "role": "user",

--- a/examples/agui/server/externaltool/llmagent/tool/tools.go
+++ b/examples/agui/server/externaltool/llmagent/tool/tools.go
@@ -11,11 +11,23 @@ package tool
 
 import agenttool "trpc.group/trpc-go/trpc-agent-go/tool"
 
-// NewTools returns the full tool set used by the LLMAgent external-tool example.
+// NewTools returns the full tool set used by the LLMAgent external-tool
+// example.
 func NewTools() []agenttool.Tool {
+	return append(NewInternalTools(), NewExternalTools()...)
+}
+
+// NewInternalTools returns tools executed automatically by the framework.
+func NewInternalTools() []agenttool.Tool {
 	return []agenttool.Tool{
 		newCalculatorTool(),
 		newInternalLookupTool(),
+	}
+}
+
+// NewExternalTools returns declarations for tools executed by the caller.
+func NewExternalTools() []agenttool.Tool {
+	return []agenttool.Tool{
 		newExternalNoteTool(),
 		newExternalApprovalTool(),
 	}

--- a/examples/toolinterrupt/README.md
+++ b/examples/toolinterrupt/README.md
@@ -24,10 +24,17 @@ This matches the common protocol order:
 
 ## Key API
 
-- `agent.WithToolExecutionFilter(...)`
-  - Controls **which tool calls are auto-executed** by the framework.
-  - Different from `agent.WithToolFilter(...)` which controls **which tools are
-    visible/callable** by the model.
+- `agent.WithExternalTools(...)`
+  - Adds caller-executed tools for one run.
+  - The model can call these tools, but the framework does not execute them.
+  - The tool only needs a declaration (`name`, `description`, `input_schema`)
+    when the caller will execute it outside the framework.
+- `model.NewToolMessage(...)`
+  - Sends the external tool result back with the original `tool_call_id`.
+  - The next `runner.Run` continues the same session from that result.
+
+Use `agent.WithToolExecutionFilter(...)` when the tool is already registered on
+the agent and only its execution policy should change for a run.
 
 ## Prerequisites
 
@@ -57,4 +64,3 @@ first, then answer based on the tool result.
 - `examples/humaninloop/` demonstrates a Human-in-the-Loop (HIL) pattern using a
   long-running tool.
 - This example focuses on **manual tool execution** (interrupt + resume).
-

--- a/examples/toolinterrupt/main.go
+++ b/examples/toolinterrupt/main.go
@@ -31,7 +31,6 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/runner"
 	"trpc.group/trpc-go/trpc-agent-go/session/inmemory"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
-	"trpc.group/trpc-go/trpc-agent-go/tool/function"
 )
 
 var (
@@ -54,8 +53,13 @@ const (
 	agentName = "tool-interrupt-agent"
 	userID    = "demo-user"
 
-	externalToolName = "external_search"
-	externalToolDesc = "Search an external system for information."
+	externalToolName  = "external_search"
+	externalToolDesc  = "Search an external system for information."
+	externalQueryArg  = "query"
+	externalQueryDesc = "Search query."
+
+	jsonSchemaTypeObject = "object"
+	jsonSchemaTypeString = "string"
 
 	maxTokens   = 1500
 	temperature = 0.2
@@ -97,7 +101,7 @@ type toolInterruptDemo struct {
 	runner    runner.Runner
 	sessionID string
 
-	execFilter tool.FilterFunc
+	externalTools []tool.Tool
 }
 
 func (d *toolInterruptDemo) run() error {
@@ -121,12 +125,6 @@ func (d *toolInterruptDemo) setup(_ context.Context) error {
 		Stream:      d.streaming,
 	}
 
-	toolDef := function.NewFunctionTool(
-		externalSearchTool,
-		function.WithName(externalToolName),
-		function.WithDescription(externalToolDesc),
-	)
-
 	ag := llmagent.New(
 		agentName,
 		llmagent.WithModel(modelInstance),
@@ -135,7 +133,6 @@ func (d *toolInterruptDemo) setup(_ context.Context) error {
 		),
 		llmagent.WithInstruction(agentInstruction),
 		llmagent.WithGenerationConfig(genConfig),
-		llmagent.WithTools([]tool.Tool{toolDef}),
 	)
 
 	d.runner = runner.NewRunner(
@@ -145,7 +142,7 @@ func (d *toolInterruptDemo) setup(_ context.Context) error {
 	)
 
 	d.sessionID = fmt.Sprintf("session-%d", time.Now().Unix())
-	d.execFilter = tool.NewExcludeToolNamesFilter(externalToolName)
+	d.externalTools = []tool.Tool{newExternalSearchDeclaration()}
 
 	fmt.Printf("✅ Demo ready! Session: %s\n\n", d.sessionID)
 	return nil
@@ -229,7 +226,7 @@ func (d *toolInterruptDemo) runOnce(
 		userID,
 		d.sessionID,
 		message,
-		agent.WithToolExecutionFilter(d.execFilter),
+		agent.WithExternalTools(d.externalTools),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("runner.Run failed: %w", err)
@@ -371,6 +368,33 @@ func runExternalSearch(args []byte) (string, error) {
 		return "", fmt.Errorf("marshal tool result: %w", err)
 	}
 	return string(b), nil
+}
+
+type declarationOnlyTool struct {
+	declaration *tool.Declaration
+}
+
+func (t *declarationOnlyTool) Declaration() *tool.Declaration {
+	return t.declaration
+}
+
+func newExternalSearchDeclaration() tool.Tool {
+	return &declarationOnlyTool{
+		declaration: &tool.Declaration{
+			Name:        externalToolName,
+			Description: externalToolDesc,
+			InputSchema: &tool.Schema{
+				Type: jsonSchemaTypeObject,
+				Properties: map[string]*tool.Schema{
+					externalQueryArg: {
+						Type:        jsonSchemaTypeString,
+						Description: externalQueryDesc,
+					},
+				},
+				Required: []string{externalQueryArg},
+			},
+		},
+	}
 }
 
 func intPtr(i int) *int {

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -1549,6 +1549,7 @@ func appendRunOptionTools(
 	if len(opts.AdditionalTools) == 0 && len(opts.ExternalTools) == 0 {
 		return allTools, userToolNames, hasUserToolTracking, nil
 	}
+	allTools = append([]tool.Tool(nil), allTools...)
 	if hasUserToolTracking {
 		userToolNames = copyToolNames(userToolNames)
 	}

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -1549,6 +1549,9 @@ func appendRunOptionTools(
 	if len(opts.AdditionalTools) == 0 && len(opts.ExternalTools) == 0 {
 		return allTools, userToolNames, hasUserToolTracking, nil
 	}
+	if hasUserToolTracking {
+		userToolNames = copyToolNames(userToolNames)
+	}
 	serverNames := collectToolNames(allTools)
 	seen := copyToolNames(serverNames)
 	allTools, userToolNames = appendRunOptionToolList(

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -1470,29 +1470,36 @@ func (f *Flow) getFilteredTools(ctx context.Context, invocation *agent.Invocatio
 		allTools = invocation.Agent.Tools()
 	}
 
+	// Get user tools (if the agent supports it).
+	// User tools are those explicitly registered via WithTools and
+	// WithToolSets. Framework tools (Knowledge, SubAgents) are never filtered.
+	if invocation.RunOptions.ToolFilter != nil && !hasUserToolTracking {
+		if provider, ok := invocation.Agent.(UserToolsProvider); ok {
+			userTools := provider.UserTools()
+			hasUserToolTracking = true
+			userToolNames = make(map[string]bool, len(userTools))
+			for _, t := range userTools {
+				userToolNames[t.Declaration().Name] = true
+			}
+		}
+	}
+	allTools, userToolNames, hasUserToolTracking, externalToolNames :=
+		appendRunOptionTools(
+			allTools,
+			userToolNames,
+			hasUserToolTracking,
+			invocation.RunOptions,
+		)
+
 	// If no filter is specified, return all tools for this invocation.
 	if invocation.RunOptions.ToolFilter == nil {
+		setVisibleExternalToolNames(invocation, allTools, externalToolNames)
 		invocation.SetState(stateKeyToolsSnapshot, allTools)
 		invocation.SetState(
 			stateKeyHasFilteredUserTools,
 			hasTrackedUserTool(allTools, hasUserToolTracking, userToolNames),
 		)
 		return allTools
-	}
-
-	// Get user tools (if the agent supports it).
-	// User tools are those explicitly registered via WithTools and WithToolSets.
-	// Framework tools (Knowledge, SubAgents) are never filtered.
-	if !hasUserToolTracking {
-		if provider, ok := invocation.Agent.(UserToolsProvider); ok {
-			userTools := provider.UserTools()
-			hasUserToolTracking = true
-			// Build a map for fast lookup.
-			userToolNames = make(map[string]bool, len(userTools))
-			for _, t := range userTools {
-				userToolNames[t.Declaration().Name] = true
-			}
-		}
 	}
 
 	// Apply the filter function to each tool.
@@ -1523,6 +1530,7 @@ func (f *Flow) getFilteredTools(ctx context.Context, invocation *agent.Invocatio
 		return filtered[i].Declaration().Name < filtered[j].Declaration().Name
 	})
 
+	setVisibleExternalToolNames(invocation, filtered, externalToolNames)
 	invocation.SetState(stateKeyToolsSnapshot, filtered)
 	invocation.SetState(
 		stateKeyHasFilteredUserTools,
@@ -1530,6 +1538,117 @@ func (f *Flow) getFilteredTools(ctx context.Context, invocation *agent.Invocatio
 	)
 
 	return filtered
+}
+
+func appendRunOptionTools(
+	allTools []tool.Tool,
+	userToolNames map[string]bool,
+	hasUserToolTracking bool,
+	opts agent.RunOptions,
+) ([]tool.Tool, map[string]bool, bool, map[string]bool) {
+	if len(opts.AdditionalTools) == 0 && len(opts.ExternalTools) == 0 {
+		return allTools, userToolNames, hasUserToolTracking, nil
+	}
+	serverNames := collectToolNames(allTools)
+	seen := copyToolNames(serverNames)
+	allTools, userToolNames = appendRunOptionToolList(
+		allTools,
+		userToolNames,
+		hasUserToolTracking,
+		seen,
+		opts.AdditionalTools,
+	)
+	externalNames := make(map[string]bool, len(opts.ExternalTools))
+	for _, tl := range opts.ExternalTools {
+		name := toolName(tl)
+		if name == "" || serverNames[name] {
+			continue
+		}
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		allTools = append(allTools, tl)
+		externalNames[name] = true
+		if hasUserToolTracking {
+			if userToolNames == nil {
+				userToolNames = make(map[string]bool)
+			}
+			userToolNames[name] = true
+		}
+	}
+	return allTools, userToolNames, hasUserToolTracking, externalNames
+}
+
+func appendRunOptionToolList(
+	allTools []tool.Tool,
+	userToolNames map[string]bool,
+	hasUserToolTracking bool,
+	seen map[string]bool,
+	tools []tool.Tool,
+) ([]tool.Tool, map[string]bool) {
+	for _, tl := range tools {
+		name := toolName(tl)
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		allTools = append(allTools, tl)
+		if hasUserToolTracking {
+			if userToolNames == nil {
+				userToolNames = make(map[string]bool)
+			}
+			userToolNames[name] = true
+		}
+	}
+	return allTools, userToolNames
+}
+
+func collectToolNames(tools []tool.Tool) map[string]bool {
+	names := make(map[string]bool, len(tools))
+	for _, tl := range tools {
+		if name := toolName(tl); name != "" {
+			names[name] = true
+		}
+	}
+	return names
+}
+
+func copyToolNames(src map[string]bool) map[string]bool {
+	dst := make(map[string]bool, len(src))
+	for name, ok := range src {
+		dst[name] = ok
+	}
+	return dst
+}
+
+func setVisibleExternalToolNames(
+	invocation *agent.Invocation,
+	tools []tool.Tool,
+	externalNames map[string]bool,
+) {
+	if invocation == nil || externalNames == nil {
+		return
+	}
+	visible := make(map[string]bool, len(externalNames))
+	for _, tl := range tools {
+		name := toolName(tl)
+		if name != "" && externalNames[name] {
+			visible[name] = true
+		}
+	}
+	invocation.RunOptions.ExternalToolNames = visible
+}
+
+func toolName(tl tool.Tool) string {
+	if tl == nil {
+		return ""
+	}
+	decl := tl.Declaration()
+	if decl == nil {
+		return ""
+	}
+	return decl.Name
 }
 
 func hasTrackedUserTool(

--- a/internal/flow/llmflow/tool_filter_test.go
+++ b/internal/flow/llmflow/tool_filter_test.go
@@ -607,6 +607,46 @@ func TestGetFilteredTools_ExternalToolCannotShadowAdditionalTool(
 	))
 }
 
+func TestGetFilteredTools_RunOptionToolsDoNotMutateUserToolNames(
+	t *testing.T,
+) {
+	f := New(nil, nil, Options{})
+
+	const (
+		registeredToolName = "registered_tool"
+		runtimeToolName    = "runtime_tool"
+		externalToolName   = "external_tool"
+	)
+
+	registeredTool := &mockTool{name: registeredToolName}
+	runtimeTool := &mockTool{name: runtimeToolName}
+	externalTool := &mockTool{name: externalToolName}
+	userToolNames := map[string]bool{
+		registeredToolName: true,
+	}
+
+	mockAgent := &mockAgentWithInvocationToolSurface{
+		name:          "test-agent",
+		allTools:      []tool.Tool{registeredTool},
+		userToolNames: userToolNames,
+	}
+	inv := agent.NewInvocation()
+	inv.Agent = mockAgent
+	inv.AgentName = "test-agent"
+	inv.RunOptions = agent.NewRunOptions(
+		agent.WithAdditionalTools([]tool.Tool{runtimeTool}),
+		agent.WithExternalTools([]tool.Tool{externalTool}),
+	)
+
+	filtered := f.getFilteredTools(context.Background(), inv)
+
+	require.Len(t, filtered, 3)
+	require.True(t, hasToolName(filtered, registeredToolName))
+	require.True(t, hasToolName(filtered, runtimeToolName))
+	require.True(t, hasToolName(filtered, externalToolName))
+	require.Equal(t, map[string]bool{registeredToolName: true}, userToolNames)
+}
+
 // TestGetFilteredTools_WithExcludeFilter tests tool filtering using exclude filter.
 func TestGetFilteredTools_WithExcludeFilter(t *testing.T) {
 	f := New(nil, nil, Options{})

--- a/internal/flow/llmflow/tool_filter_test.go
+++ b/internal/flow/llmflow/tool_filter_test.go
@@ -32,6 +32,15 @@ func (m *mockTool) Call(context.Context, []byte) (any, error) {
 	return nil, nil
 }
 
+func hasToolName(tools []tool.Tool, name string) bool {
+	for _, tl := range tools {
+		if tl.Declaration().Name == name {
+			return true
+		}
+	}
+	return false
+}
+
 // mockAgentWithUserTools implements agent.Agent and UserToolsProvider.
 type mockAgentWithUserTools struct {
 	allTools       []tool.Tool
@@ -107,6 +116,15 @@ func (m *mockAgentWithFilterTools) SubAgents() []agent.Agent {
 
 func (m *mockAgentWithFilterTools) FindSubAgent(string) agent.Agent {
 	return nil
+}
+
+type mockAgentWithFilterAndUserTools struct {
+	*mockAgentWithFilterTools
+	userTools []tool.Tool
+}
+
+func (m *mockAgentWithFilterAndUserTools) UserTools() []tool.Tool {
+	return m.userTools
 }
 
 // mockAgentWithoutUserTools implements agent.Agent without UserToolsProvider.
@@ -441,6 +459,152 @@ func TestGetFilteredTools_WithToolFilter(t *testing.T) {
 	if foundUserTool2 {
 		t.Error("user_tool_2 should be filtered out")
 	}
+}
+
+func TestGetFilteredTools_AppendsRunOptionTools(t *testing.T) {
+	f := New(nil, nil, Options{})
+
+	frameworkTool := &mockTool{name: "framework_tool"}
+	runtimeAllowed := &mockTool{name: "runtime_allowed"}
+	runtimeDenied := &mockTool{name: "runtime_denied"}
+
+	mockAgent := &mockAgentWithInvocationToolSurface{
+		name:          "test-agent",
+		allTools:      []tool.Tool{frameworkTool},
+		userToolNames: map[string]bool{},
+	}
+
+	inv := agent.NewInvocation()
+	inv.Agent = mockAgent
+	inv.AgentName = "test-agent"
+	inv.RunOptions = agent.NewRunOptions(
+		agent.WithAdditionalTools(
+			[]tool.Tool{runtimeAllowed, runtimeDenied},
+		),
+		agent.WithToolFilter(
+			tool.NewIncludeToolNamesFilter("runtime_allowed"),
+		),
+	)
+
+	filtered := f.getFilteredTools(context.Background(), inv)
+
+	require.Len(t, filtered, 2)
+	require.True(t, hasToolName(filtered, "framework_tool"))
+	require.True(t, hasToolName(filtered, "runtime_allowed"))
+	require.False(t, hasToolName(filtered, "runtime_denied"))
+}
+
+func TestGetFilteredTools_FiltersRunOptionToolsWithFilterProvider(
+	t *testing.T,
+) {
+	const (
+		frameworkToolName  = "framework_tool"
+		registeredToolName = "registered_user_tool"
+		runtimeAllowedName = "runtime_allowed"
+		runtimeDeniedName  = "runtime_denied"
+	)
+
+	f := New(nil, nil, Options{})
+
+	frameworkTool := &mockTool{name: frameworkToolName}
+	registeredTool := &mockTool{name: registeredToolName}
+	runtimeAllowed := &mockTool{name: runtimeAllowedName}
+	runtimeDenied := &mockTool{name: runtimeDeniedName}
+
+	mockAgent := &mockAgentWithFilterAndUserTools{
+		mockAgentWithFilterTools: &mockAgentWithFilterTools{
+			name:          "test-agent",
+			filteredTools: []tool.Tool{frameworkTool, registeredTool},
+		},
+		userTools: []tool.Tool{registeredTool},
+	}
+
+	inv := agent.NewInvocation()
+	inv.Agent = mockAgent
+	inv.AgentName = "test-agent"
+	inv.RunOptions = agent.NewRunOptions(
+		agent.WithAdditionalTools(
+			[]tool.Tool{runtimeAllowed, runtimeDenied},
+		),
+		agent.WithToolFilter(
+			tool.NewIncludeToolNamesFilter(
+				registeredToolName,
+				runtimeAllowedName,
+			),
+		),
+	)
+
+	filtered := f.getFilteredTools(context.Background(), inv)
+
+	require.Len(t, filtered, 3)
+	require.True(t, hasToolName(filtered, frameworkToolName))
+	require.True(t, hasToolName(filtered, registeredToolName))
+	require.True(t, hasToolName(filtered, runtimeAllowedName))
+	require.False(t, hasToolName(filtered, runtimeDeniedName))
+}
+
+func TestGetFilteredTools_ExternalToolCannotShadowExistingTool(t *testing.T) {
+	f := New(nil, nil, Options{})
+
+	const toolName = "workspace_exec"
+
+	serverTool := &mockTool{name: toolName}
+	frontendTool := &mockTool{name: toolName}
+
+	mockAgent := &mockAgentWithInvocationToolSurface{
+		name:          "test-agent",
+		allTools:      []tool.Tool{serverTool},
+		userToolNames: map[string]bool{},
+	}
+
+	inv := agent.NewInvocation()
+	inv.Agent = mockAgent
+	inv.AgentName = "test-agent"
+	inv.RunOptions = agent.NewRunOptions(
+		agent.WithExternalTools([]tool.Tool{frontendTool}),
+	)
+
+	filtered := f.getFilteredTools(context.Background(), inv)
+
+	require.Equal(t, []tool.Tool{serverTool}, filtered)
+	require.Empty(t, inv.RunOptions.ExternalToolNames)
+	require.True(t, inv.RunOptions.ShouldExecuteTool(
+		context.Background(),
+		serverTool,
+	))
+}
+
+func TestGetFilteredTools_ExternalToolCannotShadowAdditionalTool(
+	t *testing.T,
+) {
+	f := New(nil, nil, Options{})
+
+	const toolName = "client_tool"
+
+	runtimeTool := &mockTool{name: toolName}
+
+	mockAgent := &mockAgentWithInvocationToolSurface{
+		name:          "test-agent",
+		allTools:      nil,
+		userToolNames: map[string]bool{},
+	}
+
+	inv := agent.NewInvocation()
+	inv.Agent = mockAgent
+	inv.AgentName = "test-agent"
+	inv.RunOptions = agent.NewRunOptions(
+		agent.WithAdditionalTools([]tool.Tool{runtimeTool}),
+		agent.WithExternalTools([]tool.Tool{runtimeTool}),
+	)
+
+	filtered := f.getFilteredTools(context.Background(), inv)
+
+	require.Equal(t, []tool.Tool{runtimeTool}, filtered)
+	require.Empty(t, inv.RunOptions.ExternalToolNames)
+	require.True(t, inv.RunOptions.ShouldExecuteTool(
+		context.Background(),
+		runtimeTool,
+	))
 }
 
 // TestGetFilteredTools_WithExcludeFilter tests tool filtering using exclude filter.

--- a/internal/flow/llmflow/tool_filter_test.go
+++ b/internal/flow/llmflow/tool_filter_test.go
@@ -647,6 +647,47 @@ func TestGetFilteredTools_RunOptionToolsDoNotMutateUserToolNames(
 	require.Equal(t, map[string]bool{registeredToolName: true}, userToolNames)
 }
 
+func TestGetFilteredTools_RunOptionToolsDoNotMutateToolSlice(
+	t *testing.T,
+) {
+	f := New(nil, nil, Options{})
+
+	const (
+		registeredToolName = "registered_tool"
+		runtimeToolName    = "runtime_tool"
+		externalToolName   = "external_tool"
+	)
+
+	registeredTool := &mockTool{name: registeredToolName}
+	runtimeTool := &mockTool{name: runtimeToolName}
+	externalTool := &mockTool{name: externalToolName}
+	backing := make([]tool.Tool, 1, 3)
+	backing[0] = registeredTool
+
+	mockAgent := &mockAgentWithInvocationToolSurface{
+		name:          "test-agent",
+		allTools:      backing[:1],
+		userToolNames: map[string]bool{},
+	}
+	inv := agent.NewInvocation()
+	inv.Agent = mockAgent
+	inv.AgentName = "test-agent"
+	inv.RunOptions = agent.NewRunOptions(
+		agent.WithAdditionalTools([]tool.Tool{runtimeTool}),
+		agent.WithExternalTools([]tool.Tool{externalTool}),
+	)
+
+	filtered := f.getFilteredTools(context.Background(), inv)
+
+	require.Len(t, filtered, 3)
+	require.True(t, hasToolName(filtered, registeredToolName))
+	require.True(t, hasToolName(filtered, runtimeToolName))
+	require.True(t, hasToolName(filtered, externalToolName))
+	expandedBacking := backing[:cap(backing)]
+	require.Nil(t, expandedBacking[1])
+	require.Nil(t, expandedBacking[2])
+}
+
 // TestGetFilteredTools_WithExcludeFilter tests tool filtering using exclude filter.
 func TestGetFilteredTools_WithExcludeFilter(t *testing.T) {
 	f := New(nil, nil, Options{})

--- a/internal/flow/processor/functioncall.go
+++ b/internal/flow/processor/functioncall.go
@@ -210,7 +210,7 @@ func (p *FunctionCallResponseProcessor) ProcessResponse(
 		return
 	}
 
-	if deferred && !unknown {
+	if deferred {
 		invocation.EndInvocation = true
 	}
 

--- a/internal/flow/processor/functioncall.go
+++ b/internal/flow/processor/functioncall.go
@@ -239,10 +239,6 @@ func (p *FunctionCallResponseProcessor) toolExecutionDecision(
 	if invocation == nil {
 		return false, true, false
 	}
-	filter := invocation.RunOptions.ToolExecutionFilter
-	if filter == nil {
-		return false, true, false
-	}
 	if req == nil || req.Tools == nil || rsp == nil {
 		return false, true, false
 	}
@@ -255,7 +251,7 @@ func (p *FunctionCallResponseProcessor) toolExecutionDecision(
 			unknown = true
 			continue
 		}
-		if filter(ctx, tl) {
+		if invocation.RunOptions.ShouldExecuteTool(ctx, tl) {
 			executable = true
 			continue
 		}
@@ -360,13 +356,10 @@ func (p *FunctionCallResponseProcessor) handleFunctionCalls(
 		toolResults,
 	)
 
-	if len(toolCallResponsesEvents) == 0 &&
-		invocation != nil &&
-		invocation.RunOptions.ToolExecutionFilter != nil {
-		filter := invocation.RunOptions.ToolExecutionFilter
+	if len(toolCallResponsesEvents) == 0 && invocation != nil {
 		for _, tc := range toolCalls {
 			tl, ok := tools[tc.Function.Name]
-			if ok && !filter(ctx, tl) {
+			if ok && !invocation.RunOptions.ShouldExecuteTool(ctx, tl) {
 				return nil, nil
 			}
 		}
@@ -548,13 +541,10 @@ func (p *FunctionCallResponseProcessor) executeToolCallsInParallel(
 		invocation,
 		toolResults,
 	)
-	if len(toolCallResponsesEvents) == 0 &&
-		invocation != nil &&
-		invocation.RunOptions.ToolExecutionFilter != nil {
-		filter := invocation.RunOptions.ToolExecutionFilter
+	if len(toolCallResponsesEvents) == 0 && invocation != nil {
 		for _, tc := range toolCalls {
 			tl, ok := tools[tc.Function.Name]
-			if ok && !filter(ctx, tl) {
+			if ok && !invocation.RunOptions.ShouldExecuteTool(ctx, tl) {
 				return nil, nil
 			}
 		}
@@ -1423,10 +1413,9 @@ func (p *FunctionCallResponseProcessor) resolveToolCallTarget(
 			return toolCall, nil, true, fmt.Errorf("executeToolCall: %s", ErrorToolNotFound)
 		}
 	}
-	if invocation != nil && invocation.RunOptions.ToolExecutionFilter != nil {
-		if !invocation.RunOptions.ToolExecutionFilter(ctx, tl) {
-			return toolCall, nil, true, nil
-		}
+	if invocation != nil &&
+		!invocation.RunOptions.ShouldExecuteTool(ctx, tl) {
+		return toolCall, nil, true, nil
 	}
 	return toolCall, tl, false, nil
 }

--- a/internal/flow/processor/functioncall_test.go
+++ b/internal/flow/processor/functioncall_test.go
@@ -2230,6 +2230,65 @@ func TestFunctionCallResponseProcessor_ToolExecutionFilter_AllDeferred(
 	require.True(t, inv.EndInvocation)
 }
 
+func TestFunctionCallResponseProcessor_WithExternalTools_AllDeferred(
+	t *testing.T,
+) {
+	const (
+		toolName = "external_tool"
+		callID   = "call-1"
+	)
+
+	ctx := context.Background()
+	p := NewFunctionCallResponseProcessor(false, nil)
+	externalTool := &mockTool{
+		name:        toolName,
+		shouldPanic: true,
+	}
+
+	inv := &agent.Invocation{
+		InvocationID: "inv-external-tool",
+		AgentName:    "test-agent",
+		RunOptions: agent.NewRunOptions(
+			agent.WithExternalTools([]tool.Tool{externalTool}),
+		),
+	}
+
+	req := &model.Request{
+		Tools: map[string]tool.Tool{
+			toolName: externalTool,
+		},
+	}
+	rsp := &model.Response{
+		Choices: []model.Choice{
+			{
+				Message: model.Message{
+					Role: model.RoleAssistant,
+					ToolCalls: []model.ToolCall{
+						{
+							ID:   callID,
+							Type: "function",
+							Function: model.FunctionDefinitionParam{
+								Name:      toolName,
+								Arguments: []byte(`{}`),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	ch := make(chan *event.Event, 1)
+
+	p.ProcessResponse(ctx, inv, req, rsp, ch)
+
+	select {
+	case <-ch:
+		t.Fatalf("unexpected tool response event")
+	default:
+	}
+	require.True(t, inv.EndInvocation)
+}
+
 func TestFunctionCallResponseProcessor_WaitsForToolResponseCompletion(
 	t *testing.T,
 ) {

--- a/internal/flow/processor/functioncall_test.go
+++ b/internal/flow/processor/functioncall_test.go
@@ -2294,6 +2294,83 @@ func TestFunctionCallResponseProcessor_WithExternalTools_AllDeferred(
 	require.True(t, inv.EndInvocation)
 }
 
+func TestFunctionCallResponseProcessor_WithExternalTools_UnknownStops(
+	t *testing.T,
+) {
+	const (
+		externalToolName = "external_tool"
+		unknownToolName  = "unknown_tool"
+		externalCallID   = "call-external"
+		unknownCallID    = "call-unknown"
+	)
+
+	ctx := context.Background()
+	p := NewFunctionCallResponseProcessor(false, nil)
+	var callCount atomic.Int32
+	externalTool := &mockTool{
+		name: externalToolName,
+		callHook: func() {
+			callCount.Add(1)
+		},
+	}
+	inv := &agent.Invocation{
+		InvocationID: "inv-external-tool-unknown",
+		AgentName:    "test-agent",
+		Model:        &mockModel{},
+		RunOptions: agent.NewRunOptions(
+			agent.WithExternalTools([]tool.Tool{externalTool}),
+		),
+	}
+	req := &model.Request{
+		Tools: map[string]tool.Tool{
+			externalToolName: externalTool,
+		},
+	}
+	rsp := &model.Response{
+		Choices: []model.Choice{
+			{
+				Message: model.Message{
+					Role: model.RoleAssistant,
+					ToolCalls: []model.ToolCall{
+						{
+							ID:   externalCallID,
+							Type: "function",
+							Function: model.FunctionDefinitionParam{
+								Name:      externalToolName,
+								Arguments: []byte(`{}`),
+							},
+						},
+						{
+							ID:   unknownCallID,
+							Type: "function",
+							Function: model.FunctionDefinitionParam{
+								Name:      unknownToolName,
+								Arguments: []byte(`{}`),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	ch := make(chan *event.Event, 1)
+
+	p.ProcessResponse(ctx, inv, req, rsp, ch)
+
+	select {
+	case ev := <-ch:
+		require.NotNil(t, ev.Response)
+		require.Len(t, ev.Response.Choices, 1)
+		msg := ev.Response.Choices[0].Message
+		require.Equal(t, model.RoleTool, msg.Role)
+		require.Equal(t, unknownCallID, msg.ToolID)
+	case <-time.After(time.Second):
+		t.Fatalf("expected a tool error response event")
+	}
+	assert.Zero(t, callCount.Load())
+	require.True(t, inv.EndInvocation)
+}
+
 func TestFunctionCallResponseProcessor_WaitsForToolResponseCompletion(
 	t *testing.T,
 ) {

--- a/internal/flow/processor/functioncall_test.go
+++ b/internal/flow/processor/functioncall_test.go
@@ -18,6 +18,7 @@ import (
 	"math"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -2240,9 +2241,12 @@ func TestFunctionCallResponseProcessor_WithExternalTools_AllDeferred(
 
 	ctx := context.Background()
 	p := NewFunctionCallResponseProcessor(false, nil)
+	var callCount atomic.Int32
 	externalTool := &mockTool{
-		name:        toolName,
-		shouldPanic: true,
+		name: toolName,
+		callHook: func() {
+			callCount.Add(1)
+		},
 	}
 
 	inv := &agent.Invocation{
@@ -2286,6 +2290,7 @@ func TestFunctionCallResponseProcessor_WithExternalTools_AllDeferred(
 		t.Fatalf("unexpected tool response event")
 	default:
 	}
+	assert.Zero(t, callCount.Load())
 	require.True(t, inv.EndInvocation)
 }
 
@@ -3364,6 +3369,7 @@ type mockTool struct {
 	shouldPanic bool
 	delay       time.Duration
 	result      any
+	callHook    func()
 }
 
 func (m *mockTool) Declaration() *tool.Declaration {
@@ -3374,6 +3380,10 @@ func (m *mockTool) Declaration() *tool.Declaration {
 }
 
 func (m *mockTool) Call(ctx context.Context, args []byte) (any, error) {
+	if m.callHook != nil {
+		m.callHook()
+	}
+
 	// Add delay to simulate processing time
 	if m.delay > 0 {
 		select {

--- a/server/agui/runner/external_tools.go
+++ b/server/agui/runner/external_tools.go
@@ -20,6 +20,7 @@ import (
 
 const (
 	errAGUIToolNameRequired        = "agui tool name is required"
+	errConvertAGUIToolParameters   = "convert agui tool[%d] %q parameters: %w"
 	errMarshalAGUIToolParameters   = "marshal agui tool parameters"
 	errUnmarshalAGUIToolParameters = "unmarshal agui tool parameters"
 	jsonSchemaTypeObject           = "object"
@@ -36,13 +37,18 @@ func ExternalToolsFromRunAgentInput(
 		return nil, nil
 	}
 	tools := make([]agenttool.Tool, 0, len(input.Tools))
-	for _, inputTool := range input.Tools {
+	for i, inputTool := range input.Tools {
 		if inputTool.Name == "" {
 			return nil, errors.New(errAGUIToolNameRequired)
 		}
 		schema, err := aguiToolParametersToSchema(inputTool.Parameters)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf(
+				errConvertAGUIToolParameters,
+				i,
+				inputTool.Name,
+				err,
+			)
 		}
 		tools = append(tools, &declarationOnlyTool{
 			declaration: &agenttool.Declaration{

--- a/server/agui/runner/external_tools.go
+++ b/server/agui/runner/external_tools.go
@@ -11,7 +11,6 @@ package runner
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
@@ -20,6 +19,7 @@ import (
 
 const (
 	errAGUIToolNameRequired        = "agui tool name is required"
+	errAGUIToolNameRequiredAt      = "agui tool[%d]: %s"
 	errConvertAGUIToolParameters   = "convert agui tool[%d] %q parameters: %w"
 	errMarshalAGUIToolParameters   = "marshal agui tool parameters"
 	errUnmarshalAGUIToolParameters = "unmarshal agui tool parameters"
@@ -39,7 +39,11 @@ func ExternalToolsFromRunAgentInput(
 	tools := make([]agenttool.Tool, 0, len(input.Tools))
 	for i, inputTool := range input.Tools {
 		if inputTool.Name == "" {
-			return nil, errors.New(errAGUIToolNameRequired)
+			return nil, fmt.Errorf(
+				errAGUIToolNameRequiredAt,
+				i,
+				errAGUIToolNameRequired,
+			)
 		}
 		schema, err := aguiToolParametersToSchema(inputTool.Parameters)
 		if err != nil {

--- a/server/agui/runner/external_tools.go
+++ b/server/agui/runner/external_tools.go
@@ -1,0 +1,79 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package runner
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
+	agenttool "trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+const (
+	errAGUIToolNameRequired        = "agui tool name is required"
+	errMarshalAGUIToolParameters   = "marshal agui tool parameters"
+	errUnmarshalAGUIToolParameters = "unmarshal agui tool parameters"
+	jsonSchemaTypeObject           = "object"
+)
+
+// ExternalToolsFromRunAgentInput converts AG-UI request tools to declaration
+// only trpc-agent-go tools. The returned tools are intended for
+// agent.WithExternalTools so the model can call frontend-owned tools while
+// the framework defers execution to the caller.
+func ExternalToolsFromRunAgentInput(
+	input *adapter.RunAgentInput,
+) ([]agenttool.Tool, error) {
+	if input == nil || len(input.Tools) == 0 {
+		return nil, nil
+	}
+	tools := make([]agenttool.Tool, 0, len(input.Tools))
+	for _, inputTool := range input.Tools {
+		if inputTool.Name == "" {
+			return nil, errors.New(errAGUIToolNameRequired)
+		}
+		schema, err := aguiToolParametersToSchema(inputTool.Parameters)
+		if err != nil {
+			return nil, err
+		}
+		tools = append(tools, &declarationOnlyTool{
+			declaration: &agenttool.Declaration{
+				Name:        inputTool.Name,
+				Description: inputTool.Description,
+				InputSchema: schema,
+			},
+		})
+	}
+	return tools, nil
+}
+
+func aguiToolParametersToSchema(params any) (*agenttool.Schema, error) {
+	if params == nil {
+		return &agenttool.Schema{Type: jsonSchemaTypeObject}, nil
+	}
+	b, err := json.Marshal(params)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", errMarshalAGUIToolParameters, err)
+	}
+	var schema agenttool.Schema
+	if err := json.Unmarshal(b, &schema); err != nil {
+		return nil, fmt.Errorf("%s: %w", errUnmarshalAGUIToolParameters, err)
+	}
+	return &schema, nil
+}
+
+type declarationOnlyTool struct {
+	declaration *agenttool.Declaration
+}
+
+func (t *declarationOnlyTool) Declaration() *agenttool.Declaration {
+	return t.declaration
+}

--- a/server/agui/runner/external_tools.go
+++ b/server/agui/runner/external_tools.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
 	agenttool "trpc.group/trpc-go/trpc-agent-go/tool"
 )
@@ -26,11 +27,21 @@ const (
 	jsonSchemaTypeObject           = "object"
 )
 
-// ExternalToolsFromRunAgentInput converts AG-UI request tools to declaration
-// only trpc-agent-go tools. The returned tools are intended for
-// agent.WithExternalTools so the model can call frontend-owned tools while
-// the framework defers execution to the caller.
-func ExternalToolsFromRunAgentInput(
+func appendExternalToolRunOption(
+	opts []agent.RunOption,
+	input *adapter.RunAgentInput,
+) ([]agent.RunOption, error) {
+	externalTools, err := externalToolsFromRunAgentInput(input)
+	if err != nil {
+		return nil, err
+	}
+	if len(externalTools) == 0 {
+		return opts, nil
+	}
+	return append(opts, agent.WithExternalTools(externalTools)), nil
+}
+
+func externalToolsFromRunAgentInput(
 	input *adapter.RunAgentInput,
 ) ([]agenttool.Tool, error) {
 	if input == nil || len(input.Tools) == 0 {

--- a/server/agui/runner/external_tools_test.go
+++ b/server/agui/runner/external_tools_test.go
@@ -1,0 +1,101 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package runner
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
+)
+
+func TestExternalToolsFromRunAgentInput(t *testing.T) {
+	const (
+		toolName        = "client_search"
+		toolDescription = "Search a frontend-owned source."
+		argName         = "query"
+		argType         = "string"
+		schemaType      = "object"
+	)
+
+	var input adapter.RunAgentInput
+	err := json.Unmarshal([]byte(`{
+		"tools": [
+			{
+				"name": "client_search",
+				"description": "Search a frontend-owned source.",
+				"parameters": {
+					"type": "object",
+					"properties": {
+						"query": {"type": "string"}
+					},
+					"required": ["query"]
+				}
+			}
+		]
+	}`), &input)
+	require.NoError(t, err)
+
+	tools, err := ExternalToolsFromRunAgentInput(&input)
+
+	require.NoError(t, err)
+	require.Len(t, tools, 1)
+	decl := tools[0].Declaration()
+	require.NotNil(t, decl)
+	assert.Equal(t, toolName, decl.Name)
+	assert.Equal(t, toolDescription, decl.Description)
+	require.NotNil(t, decl.InputSchema)
+	assert.Equal(t, schemaType, decl.InputSchema.Type)
+	require.Contains(t, decl.InputSchema.Properties, argName)
+	assert.Equal(t, argType, decl.InputSchema.Properties[argName].Type)
+	assert.Equal(t, []string{argName}, decl.InputSchema.Required)
+}
+
+func TestExternalToolsFromRunAgentInputEmpty(t *testing.T) {
+	tools, err := ExternalToolsFromRunAgentInput(nil)
+
+	require.NoError(t, err)
+	assert.Nil(t, tools)
+}
+
+func TestExternalToolsFromRunAgentInputDefaultsNilParameters(t *testing.T) {
+	const toolName = "client_notify"
+
+	var input adapter.RunAgentInput
+	err := json.Unmarshal([]byte(`{
+		"tools": [{"name": "client_notify"}]
+	}`), &input)
+	require.NoError(t, err)
+
+	tools, err := ExternalToolsFromRunAgentInput(&input)
+
+	require.NoError(t, err)
+	require.Len(t, tools, 1)
+	decl := tools[0].Declaration()
+	require.NotNil(t, decl)
+	require.NotNil(t, decl.InputSchema)
+	assert.Equal(t, toolName, decl.Name)
+	assert.Equal(t, jsonSchemaTypeObject, decl.InputSchema.Type)
+}
+
+func TestExternalToolsFromRunAgentInputRejectsEmptyName(t *testing.T) {
+	var input adapter.RunAgentInput
+	err := json.Unmarshal([]byte(`{
+		"tools": [{"description": "missing name"}]
+	}`), &input)
+	require.NoError(t, err)
+
+	tools, err := ExternalToolsFromRunAgentInput(&input)
+
+	require.Error(t, err)
+	assert.Nil(t, tools)
+}

--- a/server/agui/runner/external_tools_test.go
+++ b/server/agui/runner/external_tools_test.go
@@ -28,7 +28,7 @@ func (badMarshalValue) MarshalJSON() ([]byte, error) {
 	return nil, errors.New(errBadMarshalValue)
 }
 
-func TestExternalToolsFromRunAgentInput(t *testing.T) {
+func TestExternalToolsFromInput(t *testing.T) {
 	const (
 		toolName        = "client_search"
 		toolDescription = "Search a frontend-owned source."
@@ -55,7 +55,7 @@ func TestExternalToolsFromRunAgentInput(t *testing.T) {
 	}`), &input)
 	require.NoError(t, err)
 
-	tools, err := ExternalToolsFromRunAgentInput(&input)
+	tools, err := externalToolsFromRunAgentInput(&input)
 
 	require.NoError(t, err)
 	require.Len(t, tools, 1)
@@ -70,14 +70,14 @@ func TestExternalToolsFromRunAgentInput(t *testing.T) {
 	assert.Equal(t, []string{argName}, decl.InputSchema.Required)
 }
 
-func TestExternalToolsFromRunAgentInputEmpty(t *testing.T) {
-	tools, err := ExternalToolsFromRunAgentInput(nil)
+func TestExternalToolsFromInputEmpty(t *testing.T) {
+	tools, err := externalToolsFromRunAgentInput(nil)
 
 	require.NoError(t, err)
 	assert.Nil(t, tools)
 }
 
-func TestExternalToolsFromRunAgentInputDefaultsNilParameters(t *testing.T) {
+func TestExternalToolsFromInputDefaultsNilParameters(t *testing.T) {
 	const toolName = "client_notify"
 
 	var input adapter.RunAgentInput
@@ -86,7 +86,7 @@ func TestExternalToolsFromRunAgentInputDefaultsNilParameters(t *testing.T) {
 	}`), &input)
 	require.NoError(t, err)
 
-	tools, err := ExternalToolsFromRunAgentInput(&input)
+	tools, err := externalToolsFromRunAgentInput(&input)
 
 	require.NoError(t, err)
 	require.Len(t, tools, 1)
@@ -97,14 +97,14 @@ func TestExternalToolsFromRunAgentInputDefaultsNilParameters(t *testing.T) {
 	assert.Equal(t, jsonSchemaTypeObject, decl.InputSchema.Type)
 }
 
-func TestExternalToolsFromRunAgentInputRejectsEmptyName(t *testing.T) {
+func TestExternalToolsFromInputRejectsEmptyName(t *testing.T) {
 	var input adapter.RunAgentInput
 	err := json.Unmarshal([]byte(`{
 		"tools": [{"description": "missing name"}]
 	}`), &input)
 	require.NoError(t, err)
 
-	tools, err := ExternalToolsFromRunAgentInput(&input)
+	tools, err := externalToolsFromRunAgentInput(&input)
 
 	require.Error(t, err)
 	assert.Nil(t, tools)
@@ -112,7 +112,7 @@ func TestExternalToolsFromRunAgentInputRejectsEmptyName(t *testing.T) {
 	assert.ErrorContains(t, err, errAGUIToolNameRequired)
 }
 
-func TestExternalToolsFromRunAgentInputReportsMarshalError(t *testing.T) {
+func TestExternalToolsFromInputReportsMarshalError(t *testing.T) {
 	const toolName = "bad_marshal"
 
 	var input adapter.RunAgentInput
@@ -122,7 +122,7 @@ func TestExternalToolsFromRunAgentInputReportsMarshalError(t *testing.T) {
 	require.NoError(t, err)
 	input.Tools[0].Parameters = badMarshalValue{}
 
-	tools, err := ExternalToolsFromRunAgentInput(&input)
+	tools, err := externalToolsFromRunAgentInput(&input)
 
 	require.Error(t, err)
 	assert.Nil(t, tools)
@@ -132,7 +132,7 @@ func TestExternalToolsFromRunAgentInputReportsMarshalError(t *testing.T) {
 	assert.ErrorContains(t, err, errBadMarshalValue)
 }
 
-func TestExternalToolsFromRunAgentInputReportsUnmarshalError(t *testing.T) {
+func TestExternalToolsFromInputReportsUnmarshalError(t *testing.T) {
 	const toolName = "bad_unmarshal"
 
 	var input adapter.RunAgentInput
@@ -146,7 +146,7 @@ func TestExternalToolsFromRunAgentInputReportsUnmarshalError(t *testing.T) {
 	}`), &input)
 	require.NoError(t, err)
 
-	tools, err := ExternalToolsFromRunAgentInput(&input)
+	tools, err := externalToolsFromRunAgentInput(&input)
 
 	require.Error(t, err)
 	assert.Nil(t, tools)

--- a/server/agui/runner/external_tools_test.go
+++ b/server/agui/runner/external_tools_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 const errBadMarshalValue = "bad marshal value"
+const errToolIndexZero = "tool[0]"
 
 type badMarshalValue struct{}
 
@@ -107,6 +108,8 @@ func TestExternalToolsFromRunAgentInputRejectsEmptyName(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Nil(t, tools)
+	assert.ErrorContains(t, err, errToolIndexZero)
+	assert.ErrorContains(t, err, errAGUIToolNameRequired)
 }
 
 func TestExternalToolsFromRunAgentInputReportsMarshalError(t *testing.T) {
@@ -123,6 +126,7 @@ func TestExternalToolsFromRunAgentInputReportsMarshalError(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Nil(t, tools)
+	assert.ErrorContains(t, err, errToolIndexZero)
 	assert.ErrorContains(t, err, errMarshalAGUIToolParameters)
 	assert.ErrorContains(t, err, toolName)
 	assert.ErrorContains(t, err, errBadMarshalValue)
@@ -146,6 +150,7 @@ func TestExternalToolsFromRunAgentInputReportsUnmarshalError(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Nil(t, tools)
+	assert.ErrorContains(t, err, errToolIndexZero)
 	assert.ErrorContains(t, err, errUnmarshalAGUIToolParameters)
 	assert.ErrorContains(t, err, toolName)
 }

--- a/server/agui/runner/external_tools_test.go
+++ b/server/agui/runner/external_tools_test.go
@@ -11,12 +11,21 @@ package runner
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
 )
+
+const errBadMarshalValue = "bad marshal value"
+
+type badMarshalValue struct{}
+
+func (badMarshalValue) MarshalJSON() ([]byte, error) {
+	return nil, errors.New(errBadMarshalValue)
+}
 
 func TestExternalToolsFromRunAgentInput(t *testing.T) {
 	const (
@@ -98,4 +107,45 @@ func TestExternalToolsFromRunAgentInputRejectsEmptyName(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Nil(t, tools)
+}
+
+func TestExternalToolsFromRunAgentInputReportsMarshalError(t *testing.T) {
+	const toolName = "bad_marshal"
+
+	var input adapter.RunAgentInput
+	err := json.Unmarshal([]byte(`{
+		"tools": [{"name": "bad_marshal"}]
+	}`), &input)
+	require.NoError(t, err)
+	input.Tools[0].Parameters = badMarshalValue{}
+
+	tools, err := ExternalToolsFromRunAgentInput(&input)
+
+	require.Error(t, err)
+	assert.Nil(t, tools)
+	assert.ErrorContains(t, err, errMarshalAGUIToolParameters)
+	assert.ErrorContains(t, err, toolName)
+	assert.ErrorContains(t, err, errBadMarshalValue)
+}
+
+func TestExternalToolsFromRunAgentInputReportsUnmarshalError(t *testing.T) {
+	const toolName = "bad_unmarshal"
+
+	var input adapter.RunAgentInput
+	err := json.Unmarshal([]byte(`{
+		"tools": [
+			{
+				"name": "bad_unmarshal",
+				"parameters": {"type": 123}
+			}
+		]
+	}`), &input)
+	require.NoError(t, err)
+
+	tools, err := ExternalToolsFromRunAgentInput(&input)
+
+	require.Error(t, err)
+	assert.Nil(t, tools)
+	assert.ErrorContains(t, err, errUnmarshalAGUIToolParameters)
+	assert.ErrorContains(t, err, toolName)
 }

--- a/server/agui/runner/options.go
+++ b/server/agui/runner/options.go
@@ -334,7 +334,14 @@ func defaultAppNameResolver(ctx context.Context, input *adapter.RunAgentInput) (
 
 // defaultRunOptionResolver is the default run option resolver.
 func defaultRunOptionResolver(ctx context.Context, input *adapter.RunAgentInput) ([]agent.RunOption, error) {
-	return nil, nil
+	externalTools, err := ExternalToolsFromRunAgentInput(input)
+	if err != nil {
+		return nil, err
+	}
+	if len(externalTools) == 0 {
+		return nil, nil
+	}
+	return []agent.RunOption{agent.WithExternalTools(externalTools)}, nil
 }
 
 // defaultStateResolver returns no runtime state.

--- a/server/agui/runner/options.go
+++ b/server/agui/runner/options.go
@@ -334,14 +334,7 @@ func defaultAppNameResolver(ctx context.Context, input *adapter.RunAgentInput) (
 
 // defaultRunOptionResolver is the default run option resolver.
 func defaultRunOptionResolver(ctx context.Context, input *adapter.RunAgentInput) ([]agent.RunOption, error) {
-	externalTools, err := ExternalToolsFromRunAgentInput(input)
-	if err != nil {
-		return nil, err
-	}
-	if len(externalTools) == 0 {
-		return nil, nil
-	}
-	return []agent.RunOption{agent.WithExternalTools(externalTools)}, nil
+	return nil, nil
 }
 
 // defaultStateResolver returns no runtime state.

--- a/server/agui/runner/options_test.go
+++ b/server/agui/runner/options_test.go
@@ -11,7 +11,6 @@ package runner
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -83,36 +82,6 @@ func TestNewOptionsDefaults(t *testing.T) {
 	assert.False(t, opts.ToolCallDeltaStreamingEnabled)
 	assert.False(t, opts.StreamingToolResultActivityEnabled)
 	assert.False(t, opts.MessagesSnapshotRunLifecycleEventsEnabled)
-}
-
-func TestDefaultRunOptionResolverAddsExternalTools(t *testing.T) {
-	const toolName = "client_search"
-
-	var input adapter.RunAgentInput
-	err := json.Unmarshal([]byte(`{
-		"tools": [
-			{
-				"name": "client_search",
-				"description": "Search a frontend-owned source.",
-				"parameters": {"type": "object"}
-			}
-		]
-	}`), &input)
-	assert.NoError(t, err)
-
-	opts := NewOptions()
-	resolvedOpts, err := opts.RunOptionResolver(context.Background(), &input)
-
-	assert.NoError(t, err)
-	runOpts := agent.NewRunOptions(resolvedOpts...)
-	if assert.Len(t, runOpts.ExternalTools, 1) {
-		decl := runOpts.ExternalTools[0].Declaration()
-		assert.Equal(t, toolName, decl.Name)
-		assert.False(t, runOpts.ShouldExecuteTool(
-			context.Background(),
-			runOpts.ExternalTools[0],
-		))
-	}
 }
 
 func TestWithUserIDResolver(t *testing.T) {

--- a/server/agui/runner/options_test.go
+++ b/server/agui/runner/options_test.go
@@ -11,6 +11,7 @@ package runner
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -82,6 +83,36 @@ func TestNewOptionsDefaults(t *testing.T) {
 	assert.False(t, opts.ToolCallDeltaStreamingEnabled)
 	assert.False(t, opts.StreamingToolResultActivityEnabled)
 	assert.False(t, opts.MessagesSnapshotRunLifecycleEventsEnabled)
+}
+
+func TestDefaultRunOptionResolverAddsExternalTools(t *testing.T) {
+	const toolName = "client_search"
+
+	var input adapter.RunAgentInput
+	err := json.Unmarshal([]byte(`{
+		"tools": [
+			{
+				"name": "client_search",
+				"description": "Search a frontend-owned source.",
+				"parameters": {"type": "object"}
+			}
+		]
+	}`), &input)
+	assert.NoError(t, err)
+
+	opts := NewOptions()
+	resolvedOpts, err := opts.RunOptionResolver(context.Background(), &input)
+
+	assert.NoError(t, err)
+	runOpts := agent.NewRunOptions(resolvedOpts...)
+	if assert.Len(t, runOpts.ExternalTools, 1) {
+		decl := runOpts.ExternalTools[0].Declaration()
+		assert.Equal(t, toolName, decl.Name)
+		assert.False(t, runOpts.ShouldExecuteTool(
+			context.Background(),
+			runOpts.ExternalTools[0],
+		))
+	}
 }
 
 func TestWithUserIDResolver(t *testing.T) {

--- a/server/agui/runner/runner.go
+++ b/server/agui/runner/runner.go
@@ -47,6 +47,7 @@ var (
 
 const (
 	toolResultInputEventAuthor = "agui.runner"
+	errResolveExternalTools    = "resolve external tools: %w"
 )
 
 // Runner executes AG-UI runs and emits AG-UI events.
@@ -343,6 +344,10 @@ func (r *runner) Run(ctx context.Context, runAgentInput *adapter.RunAgentInput) 
 	runOption, err := r.runOptionResolver(ctx, runAgentInput)
 	if err != nil {
 		return nil, fmt.Errorf("resolve run option: %w", err)
+	}
+	runOption, err = appendExternalToolRunOption(runOption, runAgentInput)
+	if err != nil {
+		return nil, fmt.Errorf(errResolveExternalTools, err)
 	}
 	appName, err := r.resolveAppName(ctx, runAgentInput)
 	if err != nil {

--- a/server/agui/runner/runner_test.go
+++ b/server/agui/runner/runner_test.go
@@ -1037,6 +1037,52 @@ func TestRunTailToolMessagesEmitAndPersistAsCurrentTurn(t *testing.T) {
 	assert.Equal(t, "lookup", currentTurn[1].ToolName)
 }
 
+func TestRunInjectsAGUIInputToolsByDefault(t *testing.T) {
+	const toolName = "client_search"
+
+	var gotOptions agent.RunOptions
+	underlying := &fakeRunner{
+		run: func(ctx context.Context,
+			userID, sessionID string,
+			message model.Message,
+			opts ...agent.RunOption) (<-chan *agentevent.Event, error) {
+			gotOptions = agent.NewRunOptions(opts...)
+			ch := make(chan *agentevent.Event)
+			close(ch)
+			return ch, nil
+		},
+	}
+	r := New(underlying)
+	var input adapter.RunAgentInput
+	err := json.Unmarshal([]byte(`{
+		"threadId": "thread",
+		"runId": "run",
+		"messages": [{"role": "user", "content": "hi"}],
+		"tools": [
+			{
+				"name": "client_search",
+				"description": "Search a frontend-owned source.",
+				"parameters": {"type": "object"}
+			}
+		]
+	}`), &input)
+	require.NoError(t, err)
+
+	eventsCh, err := r.Run(context.Background(), &input)
+	require.NoError(t, err)
+	collectEvents(t, eventsCh)
+
+	require.Len(t, gotOptions.ExternalTools, 1)
+	externalTool := gotOptions.ExternalTools[0]
+	decl := externalTool.Declaration()
+	require.NotNil(t, decl)
+	assert.Equal(t, toolName, decl.Name)
+	assert.False(t, gotOptions.ShouldExecuteTool(
+		context.Background(),
+		externalTool,
+	))
+}
+
 func TestRunToolMessageKeepsCurrentTurnWithoutRewriter(t *testing.T) {
 	var gotMessage model.Message
 	var gotOptions agent.RunOptions

--- a/server/agui/runner/runner_test.go
+++ b/server/agui/runner/runner_test.go
@@ -1925,6 +1925,43 @@ func TestRunRunOptionResolverError(t *testing.T) {
 	assert.Equal(t, 0, underlying.calls)
 }
 
+func TestRunExternalToolConversionError(t *testing.T) {
+	const (
+		errResolveExternalToolsPrefix = "resolve external tools"
+		toolDescription               = "missing name"
+	)
+
+	called := false
+	underlying := &fakeRunner{
+		run: func(ctx context.Context,
+			userID, sessionID string,
+			message model.Message,
+			opts ...agent.RunOption) (<-chan *agentevent.Event, error) {
+			called = true
+			ch := make(chan *agentevent.Event)
+			close(ch)
+			return ch, nil
+		},
+	}
+	r := New(underlying)
+	input := &adapter.RunAgentInput{
+		ThreadID: "thread",
+		RunID:    "run",
+		Messages: []types.Message{{Role: types.RoleUser, Content: "hi"}},
+		Tools: []types.Tool{{
+			Description: toolDescription,
+		}},
+	}
+
+	eventsCh, err := r.Run(context.Background(), input)
+
+	assert.Nil(t, eventsCh)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, errResolveExternalToolsPrefix)
+	assert.ErrorContains(t, err, errAGUIToolNameRequired)
+	assert.False(t, called)
+}
+
 func TestRunStartSpanError(t *testing.T) {
 	startErr := errors.New("start span fail")
 	underlying := &fakeRunner{}

--- a/server/agui/runner/runner_test.go
+++ b/server/agui/runner/runner_test.go
@@ -1038,8 +1038,6 @@ func TestRunTailToolMessagesEmitAndPersistAsCurrentTurn(t *testing.T) {
 }
 
 func TestRunInjectsAGUIInputToolsByDefault(t *testing.T) {
-	const toolName = "client_search"
-
 	var gotOptions agent.RunOptions
 	underlying := &fakeRunner{
 		run: func(ctx context.Context,
@@ -1053,22 +1051,9 @@ func TestRunInjectsAGUIInputToolsByDefault(t *testing.T) {
 		},
 	}
 	r := New(underlying)
-	var input adapter.RunAgentInput
-	err := json.Unmarshal([]byte(`{
-		"threadId": "thread",
-		"runId": "run",
-		"messages": [{"role": "user", "content": "hi"}],
-		"tools": [
-			{
-				"name": "client_search",
-				"description": "Search a frontend-owned source.",
-				"parameters": {"type": "object"}
-			}
-		]
-	}`), &input)
-	require.NoError(t, err)
+	input, toolName := newExternalToolRunAgentInput()
 
-	eventsCh, err := r.Run(context.Background(), &input)
+	eventsCh, err := r.Run(context.Background(), input)
 	require.NoError(t, err)
 	collectEvents(t, eventsCh)
 
@@ -1081,6 +1066,78 @@ func TestRunInjectsAGUIInputToolsByDefault(t *testing.T) {
 		context.Background(),
 		externalTool,
 	))
+}
+
+func TestRunInjectsAGUIInputToolsWithCustomResolver(t *testing.T) {
+	const customModelName = "custom-model"
+
+	var gotOptions agent.RunOptions
+	underlying := &fakeRunner{
+		run: func(ctx context.Context,
+			userID, sessionID string,
+			message model.Message,
+			opts ...agent.RunOption) (<-chan *agentevent.Event, error) {
+			gotOptions = agent.NewRunOptions(opts...)
+			ch := make(chan *agentevent.Event)
+			close(ch)
+			return ch, nil
+		},
+	}
+	r := New(
+		underlying,
+		WithRunOptionResolver(
+			func(context.Context,
+				*adapter.RunAgentInput) ([]agent.RunOption, error) {
+				return []agent.RunOption{
+					agent.WithModelName(customModelName),
+				}, nil
+			},
+		),
+	)
+	input, toolName := newExternalToolRunAgentInput()
+
+	eventsCh, err := r.Run(context.Background(), input)
+	require.NoError(t, err)
+	collectEvents(t, eventsCh)
+
+	assert.Equal(t, customModelName, gotOptions.ModelName)
+	require.Len(t, gotOptions.ExternalTools, 1)
+	externalTool := gotOptions.ExternalTools[0]
+	decl := externalTool.Declaration()
+	require.NotNil(t, decl)
+	assert.Equal(t, toolName, decl.Name)
+	assert.False(t, gotOptions.ShouldExecuteTool(
+		context.Background(),
+		externalTool,
+	))
+}
+
+func newExternalToolRunAgentInput() (*adapter.RunAgentInput, string) {
+	const (
+		threadID        = "thread"
+		runID           = "run"
+		userContent     = "hi"
+		toolName        = "client_search"
+		toolDescription = "Search a frontend-owned source."
+		schemaTypeKey   = "type"
+	)
+
+	input := &adapter.RunAgentInput{
+		ThreadID: threadID,
+		RunID:    runID,
+		Messages: []types.Message{{
+			Role:    types.RoleUser,
+			Content: userContent,
+		}},
+		Tools: []types.Tool{{
+			Name:        toolName,
+			Description: toolDescription,
+			Parameters: map[string]any{
+				schemaTypeKey: jsonSchemaTypeObject,
+			},
+		}},
+	}
+	return input, toolName
 }
 
 func TestRunToolMessageKeepsCurrentTurnWithoutRewriter(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add per-run `agent.WithAdditionalTools` and `agent.WithExternalTools` APIs.
- Defer caller-executed external tool calls through the existing tool-call stop/resume flow.
- Convert AG-UI `input.Tools` to declaration-only external tools by default and update examples/docs.

## Tests

- `go test ./agent ./internal/flow/llmflow ./internal/flow/processor`
- `(cd server/agui && go test ./...)`
- `(cd examples/agui && go test ./server/externaltool/...)`
- `(cd examples && go test ./toolinterrupt)`

## Notes

- `go test ./...` still fails on macOS in `tool/hostexec` because `syscall.SysProcAttr.Pdeathsig` is unavailable on Darwin; this is unrelated to this change.
- xhigh subagent review found no remaining material compatibility/design risks after the collision, nil-schema, unknown-tool, tool-identity, user-tool-map, and tool-slice isolation fixes.
- A local coverprofile check over changed packages estimates changed executable line coverage at 89.57% on the latest head.
