### PR TITLE
{evaluation/workflow/promptiter, docs}: add stage parallelism

### DIFF
--- a/docs/mkdocs/en/promptiter.md
+++ b/docs/mkdocs/en/promptiter.md
@@ -455,6 +455,9 @@ type RunRequest struct {
 	Teacher              runner.Runner       // Teacher is the Runner used to generate reference answers when needed.
 	Judge                runner.Runner       // Judge is the Runner used by judge-style metrics when needed.
 	EvaluationOptions    EvaluationOptions   // EvaluationOptions defines evaluation execution parameters.
+	BackwardOptions      BackwardOptions     // BackwardOptions defines backward-stage execution parameters.
+	AggregationOptions   AggregationOptions  // AggregationOptions defines aggregation-stage execution parameters.
+	OptimizerOptions     OptimizerOptions    // OptimizerOptions defines optimizer-stage execution parameters.
 	AcceptancePolicy     AcceptancePolicy    // AcceptancePolicy defines how acceptance is decided.
 	StopPolicy           StopPolicy          // StopPolicy defines when the run should stop.
 	MaxRounds            int                 // MaxRounds is the maximum number of optimization rounds.
@@ -526,6 +529,45 @@ type EvaluationOptions struct {
 ```
 
 Its semantics stay aligned with Evaluation. PromptIter directly reuses the Evaluation concurrency model and fixes execution to a single run internally.
+
+#### BackwardOptions
+
+`BackwardOptions` controls concurrency in the backward stage. By default, train cases run backward serially.
+
+```go
+type BackwardOptions struct {
+	CaseParallelismEnabled bool // CaseParallelismEnabled controls whether train cases run backward in parallel.
+	CaseParallelism        int  // CaseParallelism is the upper bound of parallel backward cases.
+}
+```
+
+When `CaseParallelismEnabled` is enabled, PromptIter runs backward in parallel across train cases. A `CaseParallelism` value of `0` uses `GOMAXPROCS` as the default parallelism; a negative value makes `Engine` return an argument error.
+
+#### AggregationOptions
+
+`AggregationOptions` controls concurrency in the gradient aggregation stage. By default, target surfaces are aggregated serially.
+
+```go
+type AggregationOptions struct {
+	SurfaceParallelismEnabled bool // SurfaceParallelismEnabled controls whether target surfaces are aggregated in parallel.
+	SurfaceParallelism        int  // SurfaceParallelism is the upper bound of parallel aggregation surfaces.
+}
+```
+
+When `SurfaceParallelismEnabled` is enabled, PromptIter aggregates gradients in parallel across target surfaces. A `SurfaceParallelism` value of `0` uses `GOMAXPROCS` as the default parallelism; a negative value makes `Engine` return an argument error.
+
+#### OptimizerOptions
+
+`OptimizerOptions` controls concurrency in the optimizer stage that generates patch candidates. By default, target surfaces are optimized serially.
+
+```go
+type OptimizerOptions struct {
+	SurfaceParallelismEnabled bool // SurfaceParallelismEnabled controls whether target surfaces are optimized in parallel.
+	SurfaceParallelism        int  // SurfaceParallelism is the upper bound of parallel optimization surfaces.
+}
+```
+
+When `SurfaceParallelismEnabled` is enabled, PromptIter generates patch candidates in parallel across target surfaces. A `SurfaceParallelism` value of `0` uses `GOMAXPROCS` as the default parallelism; a negative value makes `Engine` return an argument error.
 
 #### AcceptancePolicy And StopPolicy
 

--- a/docs/mkdocs/zh/promptiter.md
+++ b/docs/mkdocs/zh/promptiter.md
@@ -455,6 +455,9 @@ type RunRequest struct {
 	Teacher              runner.Runner       // Teacher 表示按需动态生成参考答案时使用的 Runner。
 	Judge                runner.Runner       // Judge 表示 Judge 类指标按需使用的 Runner。
 	EvaluationOptions    EvaluationOptions   // EvaluationOptions 表示评估执行参数。
+	BackwardOptions      BackwardOptions     // BackwardOptions 表示反向传播阶段执行参数。
+	AggregationOptions   AggregationOptions  // AggregationOptions 表示梯度聚合阶段执行参数。
+	OptimizerOptions     OptimizerOptions    // OptimizerOptions 表示优化器阶段执行参数。
 	AcceptancePolicy     AcceptancePolicy    // AcceptancePolicy 表示接受策略。
 	StopPolicy           StopPolicy          // StopPolicy 表示停止策略。
 	MaxRounds            int                 // MaxRounds 表示最大优化轮数。
@@ -526,6 +529,45 @@ type EvaluationOptions struct {
 ```
 
 它与 Evaluation 中的评估选项保持一致。PromptIter 直接复用 Evaluation 的并发执行方式，并在内部固定使用单次评估结果。
+
+#### BackwardOptions
+
+`BackwardOptions` 用于控制反向传播阶段的并发方式。默认情况下，训练集样本会按串行方式依次执行 backward。
+
+```go
+type BackwardOptions struct {
+	CaseParallelismEnabled bool // CaseParallelismEnabled 表示是否并行处理训练集样本的反向传播。
+	CaseParallelism        int  // CaseParallelism 表示反向传播样本并发数上限。
+}
+```
+
+启用 `CaseParallelismEnabled` 后，PromptIter 会按训练集样本并发执行 backward。`CaseParallelism` 为 `0` 时使用 `GOMAXPROCS` 作为默认并发数；为负数时，`Engine` 会返回参数错误。
+
+#### AggregationOptions
+
+`AggregationOptions` 用于控制梯度聚合阶段的并发方式。默认情况下，多个目标 surface 会按串行方式依次聚合。
+
+```go
+type AggregationOptions struct {
+	SurfaceParallelismEnabled bool // SurfaceParallelismEnabled 表示是否并行聚合多个目标 surface。
+	SurfaceParallelism        int  // SurfaceParallelism 表示聚合阶段 surface 并发数上限。
+}
+```
+
+启用 `SurfaceParallelismEnabled` 后，PromptIter 会按目标 surface 并发执行梯度聚合。`SurfaceParallelism` 为 `0` 时使用 `GOMAXPROCS` 作为默认并发数；为负数时，`Engine` 会返回参数错误。
+
+#### OptimizerOptions
+
+`OptimizerOptions` 用于控制优化器生成修改建议阶段的并发方式。默认情况下，多个目标 surface 会按串行方式依次优化。
+
+```go
+type OptimizerOptions struct {
+	SurfaceParallelismEnabled bool // SurfaceParallelismEnabled 表示是否并行优化多个目标 surface。
+	SurfaceParallelism        int  // SurfaceParallelism 表示优化阶段 surface 并发数上限。
+}
+```
+
+启用 `SurfaceParallelismEnabled` 后，PromptIter 会按目标 surface 并发生成修改建议。`SurfaceParallelism` 为 `0` 时使用 `GOMAXPROCS` 作为默认并发数；为负数时，`Engine` 会返回参数错误。
 
 #### AcceptancePolicy 与 StopPolicy
 

--- a/evaluation/workflow/promptiter/engine/aggregate.go
+++ b/evaluation/workflow/promptiter/engine/aggregate.go
@@ -13,11 +13,20 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
 	"sort"
 
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/aggregator"
 )
+
+// AggregationOptions configures aggregation-stage execution behavior.
+type AggregationOptions struct {
+	// SurfaceParallelismEnabled enables concurrent aggregation across target surfaces.
+	SurfaceParallelismEnabled bool
+	// SurfaceParallelism caps concurrent aggregation across target surfaces when SurfaceParallelismEnabled is true. Zero uses GOMAXPROCS.
+	SurfaceParallelism int
+}
 
 // AggregationResult groups all surfaces after sample gradient merge.
 type AggregationResult struct {
@@ -30,6 +39,7 @@ func (e *engine) aggregate(
 	structure *structureState,
 	backward *BackwardResult,
 	targetSurfaceSet targetSurfaceSet,
+	options AggregationOptions,
 ) (*AggregationResult, error) {
 	if e.aggregator == nil {
 		return nil, errors.New("aggregator is nil")
@@ -58,10 +68,19 @@ func (e *engine) aggregate(
 	result := &AggregationResult{
 		Surfaces: make([]promptiter.AggregatedSurfaceGradient, 0, len(surfaceIDs)),
 	}
-	for _, surfaceID := range surfaceIDs {
+	surfaces := make([]promptiter.AggregatedSurfaceGradient, len(surfaceIDs))
+	parallelism := 0
+	if options.SurfaceParallelismEnabled {
+		parallelism = options.SurfaceParallelism
+		if parallelism <= 0 {
+			parallelism = runtime.GOMAXPROCS(0)
+		}
+	}
+	if err := runIndexedParallel(ctx, len(surfaceIDs), parallelism, func(ctx context.Context, index int) error {
+		surfaceID := surfaceIDs[index]
 		surface, ok := structure.surfaceIndex[surfaceID]
 		if !ok {
-			return nil, fmt.Errorf("aggregated surface id %q is unknown", surfaceID)
+			return fmt.Errorf("aggregated surface id %q is unknown", surfaceID)
 		}
 		response, err := e.aggregator.Aggregate(ctx, &aggregator.Request{
 			SurfaceID: surfaceID,
@@ -70,12 +89,16 @@ func (e *engine) aggregate(
 			Gradients: grouped[surfaceID],
 		})
 		if err != nil {
-			return nil, fmt.Errorf("aggregate surface %q: %w", surfaceID, err)
+			return fmt.Errorf("aggregate surface %q: %w", surfaceID, err)
 		}
 		if response == nil || response.Gradient == nil {
-			return nil, fmt.Errorf("aggregate surface %q returned empty result", surfaceID)
+			return fmt.Errorf("aggregate surface %q returned empty result", surfaceID)
 		}
-		result.Surfaces = append(result.Surfaces, *response.Gradient)
+		surfaces[index] = *response.Gradient
+		return nil
+	}); err != nil {
+		return nil, err
 	}
+	result.Surfaces = append(result.Surfaces, surfaces...)
 	return result, nil
 }

--- a/evaluation/workflow/promptiter/engine/backward.go
+++ b/evaluation/workflow/promptiter/engine/backward.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
 	"sort"
 	"strings"
 
@@ -22,6 +23,14 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/backwarder"
 	iloss "trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/internal/loss"
 )
+
+// BackwardOptions configures backward-stage execution behavior.
+type BackwardOptions struct {
+	// CaseParallelismEnabled enables concurrent backward processing across eval cases.
+	CaseParallelismEnabled bool
+	// CaseParallelism caps concurrent backward processing across eval cases when CaseParallelismEnabled is true. Zero uses GOMAXPROCS.
+	CaseParallelism int
+}
 
 // CaseBackwardResult stores all step gradients produced for one eval case.
 type CaseBackwardResult struct {
@@ -46,6 +55,7 @@ func (e *engine) backward(
 	train *EvaluationResult,
 	losses []promptiter.CaseLoss,
 	targetSurfaceSet targetSurfaceSet,
+	options BackwardOptions,
 ) (*BackwardResult, error) {
 	if e.backwarder == nil {
 		return nil, errors.New("backwarder is nil")
@@ -55,14 +65,23 @@ func (e *engine) backward(
 	}
 	caseIndex := indexCaseResults(train)
 	overrideIndex := buildOverrideIndex(profile)
+	caseResults := make([]*CaseBackwardResult, len(losses))
 	result := &BackwardResult{
 		Cases: make([]CaseBackwardResult, 0, len(losses)),
 	}
-	for _, caseLoss := range losses {
+	parallelism := 0
+	if options.CaseParallelismEnabled {
+		parallelism = options.CaseParallelism
+		if parallelism <= 0 {
+			parallelism = runtime.GOMAXPROCS(0)
+		}
+	}
+	if err := runIndexedParallel(ctx, len(losses), parallelism, func(ctx context.Context, index int) error {
+		caseLoss := losses[index]
 		caseKey := caseResultKey{evalSetID: caseLoss.EvalSetID, evalCaseID: caseLoss.EvalCaseID}
 		evalCase, ok := caseIndex[caseKey]
 		if !ok {
-			return nil, fmt.Errorf(
+			return fmt.Errorf(
 				"eval case %q from eval set %q is missing from training result",
 				caseLoss.EvalCaseID,
 				caseLoss.EvalSetID,
@@ -70,8 +89,14 @@ func (e *engine) backward(
 		}
 		caseResult, err := e.backwardCase(ctx, structure, overrideIndex, evalCase, caseLoss, targetSurfaceSet)
 		if err != nil {
-			return nil, err
+			return err
 		}
+		caseResults[index] = caseResult
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	for _, caseResult := range caseResults {
 		if caseResult == nil {
 			continue
 		}

--- a/evaluation/workflow/promptiter/engine/engine.go
+++ b/evaluation/workflow/promptiter/engine/engine.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"slices"
 
+	"golang.org/x/sync/errgroup"
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation"
@@ -48,6 +49,12 @@ type RunRequest struct {
 	Judge runner.Runner
 	// EvaluationOptions configures how training and validation runs are executed.
 	EvaluationOptions EvaluationOptions
+	// BackwardOptions configures backward-stage execution.
+	BackwardOptions BackwardOptions
+	// AggregationOptions configures aggregation-stage execution.
+	AggregationOptions AggregationOptions
+	// OptimizerOptions configures optimizer-stage execution.
+	OptimizerOptions OptimizerOptions
 	// AcceptancePolicy controls minimum quality gain required to accept patching.
 	AcceptancePolicy AcceptancePolicy
 	// StopPolicy controls termination conditions between rounds.
@@ -319,6 +326,12 @@ func (e *engine) validateRunRequest(request *RunRequest) error {
 		return errors.New("max rounds must be greater than 0")
 	case request.TargetSurfaceIDs != nil && len(request.TargetSurfaceIDs) == 0:
 		return errors.New("target surface ids must not be empty")
+	case request.BackwardOptions.CaseParallelism < 0:
+		return errors.New("backward case parallelism must be non-negative")
+	case request.AggregationOptions.SurfaceParallelism < 0:
+		return errors.New("aggregation surface parallelism must be non-negative")
+	case request.OptimizerOptions.SurfaceParallelism < 0:
+		return errors.New("optimizer surface parallelism must be non-negative")
 	case e.targetAgent == nil:
 		return errors.New("target agent is nil")
 	case e.agentEvaluator == nil:
@@ -379,7 +392,15 @@ func (e *engine) executeRound(
 	if err := appendRunEvent(ctx, observer, EventKindRoundLosses, roundNumber, losses); err != nil {
 		return nil, 0, err
 	}
-	backwardResult, err := e.backward(ctx, structure, acceptedProfile, trainResult, losses, targetSurfaceSet)
+	backwardResult, err := e.backward(
+		ctx,
+		structure,
+		acceptedProfile,
+		trainResult,
+		losses,
+		targetSurfaceSet,
+		request.BackwardOptions,
+	)
 	if err != nil {
 		return nil, 0, fmt.Errorf("backward round %d: %w", roundNumber, err)
 	}
@@ -387,7 +408,13 @@ func (e *engine) executeRound(
 	if err := appendRunEvent(ctx, observer, EventKindRoundBackward, roundNumber, backwardResult); err != nil {
 		return nil, 0, err
 	}
-	aggregationResult, err := e.aggregate(ctx, structure, backwardResult, targetSurfaceSet)
+	aggregationResult, err := e.aggregate(
+		ctx,
+		structure,
+		backwardResult,
+		targetSurfaceSet,
+		request.AggregationOptions,
+	)
 	if err != nil {
 		return nil, 0, fmt.Errorf("aggregate round %d: %w", roundNumber, err)
 	}
@@ -395,7 +422,14 @@ func (e *engine) executeRound(
 	if err := appendRunEvent(ctx, observer, EventKindRoundAggregation, roundNumber, aggregationResult); err != nil {
 		return nil, 0, err
 	}
-	patchSet, err := e.optimize(ctx, structure, acceptedProfile, aggregationResult, targetSurfaceSet)
+	patchSet, err := e.optimize(
+		ctx,
+		structure,
+		acceptedProfile,
+		aggregationResult,
+		targetSurfaceSet,
+		request.OptimizerOptions,
+	)
 	if err != nil {
 		return nil, 0, fmt.Errorf("optimize round %d: %w", roundNumber, err)
 	}
@@ -472,4 +506,45 @@ func validateEvalSetInputs(role string, inputs []EvalSetInput) error {
 		}
 	}
 	return nil
+}
+
+func runIndexedParallel(
+	ctx context.Context,
+	count int,
+	parallelism int,
+	fn func(context.Context, int) error,
+) error {
+	if parallelism <= 1 || count <= 1 {
+		for index := range count {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if err := fn(ctx, index); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	group, groupCtx := errgroup.WithContext(ctx)
+	indexErrors := make([]error, count)
+	group.SetLimit(parallelism)
+	for index := range count {
+		if err := groupCtx.Err(); err != nil {
+			break
+		}
+		index := index
+		group.Go(func() error {
+			if err := groupCtx.Err(); err != nil {
+				return err
+			}
+			if err := fn(groupCtx, index); err != nil {
+				indexErrors[index] = err
+				return err
+			}
+			return nil
+		})
+	}
+	waitErr := group.Wait()
+	indexErrors = append(indexErrors, waitErr, ctx.Err())
+	return errors.Join(indexErrors...)
 }

--- a/evaluation/workflow/promptiter/engine/engine_test.go
+++ b/evaluation/workflow/promptiter/engine/engine_test.go
@@ -12,7 +12,10 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"runtime"
+	"sync"
 	"testing"
+	"time"
 	"unsafe"
 
 	"github.com/stretchr/testify/assert"
@@ -45,6 +48,7 @@ const (
 )
 
 type fakeBackwarder struct {
+	mu       sync.Mutex
 	requests []*backwarder.Request
 	fn       func(ctx context.Context, request *backwarder.Request) (*backwarder.Result, error)
 }
@@ -53,7 +57,9 @@ func (f *fakeBackwarder) Backward(
 	ctx context.Context,
 	request *backwarder.Request,
 ) (*backwarder.Result, error) {
+	f.mu.Lock()
 	f.requests = append(f.requests, request)
+	f.mu.Unlock()
 	if f.fn == nil {
 		return &backwarder.Result{}, nil
 	}
@@ -61,6 +67,7 @@ func (f *fakeBackwarder) Backward(
 }
 
 type fakeAggregator struct {
+	mu       sync.Mutex
 	requests []*aggregator.Request
 	fn       func(ctx context.Context, request *aggregator.Request) (*aggregator.Result, error)
 }
@@ -69,7 +76,9 @@ func (f *fakeAggregator) Aggregate(
 	ctx context.Context,
 	request *aggregator.Request,
 ) (*aggregator.Result, error) {
+	f.mu.Lock()
 	f.requests = append(f.requests, request)
+	f.mu.Unlock()
 	if f.fn == nil {
 		return &aggregator.Result{}, nil
 	}
@@ -77,6 +86,7 @@ func (f *fakeAggregator) Aggregate(
 }
 
 type fakeOptimizer struct {
+	mu       sync.Mutex
 	requests []*optimizer.Request
 	fn       func(ctx context.Context, request *optimizer.Request) (*optimizer.Result, error)
 }
@@ -85,7 +95,9 @@ func (f *fakeOptimizer) Optimize(
 	ctx context.Context,
 	request *optimizer.Request,
 ) (*optimizer.Result, error) {
+	f.mu.Lock()
 	f.requests = append(f.requests, request)
+	f.mu.Unlock()
 	if f.fn == nil {
 		return &optimizer.Result{}, nil
 	}
@@ -1291,7 +1303,7 @@ func TestAggregateRejectsOutOfScopeGradient(t *testing.T) {
 				},
 			},
 		},
-	}, targetSurfaceSet{testSurfaceID: {}})
+	}, targetSurfaceSet{testSurfaceID: {}}, AggregationOptions{})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "outside target surfaces")
 	assert.Empty(t, aggregatorInstance.requests)
@@ -1302,13 +1314,13 @@ func TestAggregateValidatesDependenciesAndResponses(t *testing.T) {
 	require.NoError(t, err)
 	t.Run("nil aggregator", func(t *testing.T) {
 		engineInstance := &engine{}
-		result, runErr := engineInstance.aggregate(context.Background(), structure, nil, targetSurfaceSet{})
+		result, runErr := engineInstance.aggregate(context.Background(), structure, nil, targetSurfaceSet{}, AggregationOptions{})
 		assert.Nil(t, result)
 		assert.EqualError(t, runErr, "aggregator is nil")
 	})
 	t.Run("nil structure", func(t *testing.T) {
 		engineInstance := &engine{aggregator: &fakeAggregator{}}
-		result, runErr := engineInstance.aggregate(context.Background(), nil, nil, targetSurfaceSet{})
+		result, runErr := engineInstance.aggregate(context.Background(), nil, nil, targetSurfaceSet{}, AggregationOptions{})
 		assert.Nil(t, result)
 		assert.EqualError(t, runErr, "structure state is nil")
 	})
@@ -1329,7 +1341,7 @@ func TestAggregateValidatesDependenciesAndResponses(t *testing.T) {
 					},
 				},
 			},
-		}, targetSurfaceSet{"missing#instruction": {}})
+		}, targetSurfaceSet{"missing#instruction": {}}, AggregationOptions{})
 		assert.Nil(t, result)
 		assert.ErrorContains(t, runErr, "aggregated surface id")
 	})
@@ -1358,7 +1370,7 @@ func TestAggregateValidatesDependenciesAndResponses(t *testing.T) {
 					},
 				},
 			},
-		}, targetSurfaceSet{testSurfaceID: {}})
+		}, targetSurfaceSet{testSurfaceID: {}}, AggregationOptions{})
 		assert.Nil(t, result)
 		assert.ErrorContains(t, runErr, "aggregate surface")
 	})
@@ -1387,7 +1399,7 @@ func TestAggregateValidatesDependenciesAndResponses(t *testing.T) {
 					},
 				},
 			},
-		}, targetSurfaceSet{testSurfaceID: {}})
+		}, targetSurfaceSet{testSurfaceID: {}}, AggregationOptions{})
 		assert.Nil(t, result)
 		assert.ErrorContains(t, runErr, "returned empty result")
 	})
@@ -1423,7 +1435,7 @@ func TestOptimizeRejectsOutOfScopeSurface(t *testing.T) {
 				Type:      astructure.SurfaceTypeModel,
 			},
 		},
-	}, targetSurfaceSet{testSurfaceID: {}})
+	}, targetSurfaceSet{testSurfaceID: {}}, OptimizerOptions{})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "outside target surfaces")
 	assert.Empty(t, optimizerInstance.requests)
@@ -1434,13 +1446,13 @@ func TestOptimizeValidatesDependenciesAndResponses(t *testing.T) {
 	require.NoError(t, err)
 	t.Run("nil optimizer", func(t *testing.T) {
 		engineInstance := &engine{}
-		patchSet, runErr := engineInstance.optimize(context.Background(), structure, nil, nil, targetSurfaceSet{})
+		patchSet, runErr := engineInstance.optimize(context.Background(), structure, nil, nil, targetSurfaceSet{}, OptimizerOptions{})
 		assert.Nil(t, patchSet)
 		assert.EqualError(t, runErr, "optimizer is nil")
 	})
 	t.Run("nil structure", func(t *testing.T) {
 		engineInstance := &engine{optimizer: &fakeOptimizer{}}
-		patchSet, runErr := engineInstance.optimize(context.Background(), nil, nil, nil, targetSurfaceSet{})
+		patchSet, runErr := engineInstance.optimize(context.Background(), nil, nil, nil, targetSurfaceSet{}, OptimizerOptions{})
 		assert.Nil(t, patchSet)
 		assert.EqualError(t, runErr, "structure state is nil")
 	})
@@ -1455,7 +1467,7 @@ func TestOptimizeValidatesDependenciesAndResponses(t *testing.T) {
 					Gradients: []promptiter.SurfaceGradient{{SurfaceID: "missing#instruction", Gradient: "fix"}},
 				},
 			},
-		}, targetSurfaceSet{"missing#instruction": {}})
+		}, targetSurfaceSet{"missing#instruction": {}}, OptimizerOptions{})
 		assert.Nil(t, patchSet)
 		assert.ErrorContains(t, runErr, "surface id")
 	})
@@ -1478,7 +1490,7 @@ func TestOptimizeValidatesDependenciesAndResponses(t *testing.T) {
 					Gradients: []promptiter.SurfaceGradient{{SurfaceID: testSurfaceID, Gradient: "fix"}},
 				},
 			},
-		}, targetSurfaceSet{testSurfaceID: {}})
+		}, targetSurfaceSet{testSurfaceID: {}}, OptimizerOptions{})
 		assert.Nil(t, patchSet)
 		assert.ErrorContains(t, runErr, "returned empty result")
 	})
@@ -1535,7 +1547,7 @@ func TestOptimizeValidatesDependenciesAndResponses(t *testing.T) {
 					Gradients: []promptiter.SurfaceGradient{{SurfaceID: secondSurfaceID, Gradient: "fix global"}},
 				},
 			},
-		}, targetSurfaceSet{testSurfaceID: {}, secondSurfaceID: {}})
+		}, targetSurfaceSet{testSurfaceID: {}, secondSurfaceID: {}}, OptimizerOptions{})
 		require.NoError(t, runErr)
 		require.NotNil(t, patchSet)
 		require.Len(t, patchSet.Patches, 2)
@@ -1732,6 +1744,37 @@ func TestRunRejectsNonPositiveMaxRounds(t *testing.T) {
 	})
 	assert.Nil(t, result)
 	assert.EqualError(t, runErr, "max rounds must be greater than 0")
+}
+
+func TestRunRejectsNegativeStageOptions(t *testing.T) {
+	engineInstance, err := New(
+		context.Background(),
+		testTargetAgent(),
+		newTestAgentEvaluator(t, newScriptedEvalService(scriptedOutcome)),
+		&fakeBackwarder{},
+		&fakeAggregator{},
+		&fakeOptimizer{},
+	)
+	require.NoError(t, err)
+	baseRequest := func() *RunRequest {
+		return &RunRequest{
+			Train:      testEvalSetInputs("train"),
+			Validation: testEvalSetInputs("validation"),
+			MaxRounds:  1,
+		}
+	}
+	request := baseRequest()
+	request.BackwardOptions = BackwardOptions{CaseParallelism: -1}
+	_, runErr := engineInstance.Run(context.Background(), request)
+	assert.EqualError(t, runErr, "backward case parallelism must be non-negative")
+	request = baseRequest()
+	request.AggregationOptions = AggregationOptions{SurfaceParallelism: -1}
+	_, runErr = engineInstance.Run(context.Background(), request)
+	assert.EqualError(t, runErr, "aggregation surface parallelism must be non-negative")
+	request = baseRequest()
+	request.OptimizerOptions = OptimizerOptions{SurfaceParallelism: -1}
+	_, runErr = engineInstance.Run(context.Background(), request)
+	assert.EqualError(t, runErr, "optimizer surface parallelism must be non-negative")
 }
 
 func TestRunRejectsInvalidInitialProfile(t *testing.T) {
@@ -2358,16 +2401,16 @@ func TestBackwardCoversAdditionalBranches(t *testing.T) {
 	structure, err := newStructureState(testStructureSnapshot(t))
 	assert.NoError(t, err)
 	engineInstance := &engine{}
-	result, backwardErr := engineInstance.backward(context.Background(), structure, nil, nil, nil, nil)
+	result, backwardErr := engineInstance.backward(context.Background(), structure, nil, nil, nil, nil, BackwardOptions{})
 	assert.Nil(t, result)
 	assert.EqualError(t, backwardErr, "backwarder is nil")
 	engineInstance.backwarder = &fakeBackwarder{}
-	result, backwardErr = engineInstance.backward(context.Background(), nil, nil, nil, nil, nil)
+	result, backwardErr = engineInstance.backward(context.Background(), nil, nil, nil, nil, nil, BackwardOptions{})
 	assert.Nil(t, result)
 	assert.EqualError(t, backwardErr, "structure state is nil")
 	result, backwardErr = engineInstance.backward(context.Background(), structure, nil, &EvaluationResult{}, []promptiter.CaseLoss{
 		{EvalSetID: "train", EvalCaseID: "case_1"},
-	}, nil)
+	}, nil, BackwardOptions{})
 	assert.Nil(t, result)
 	assert.EqualError(t, backwardErr, `eval case "case_1" from eval set "train" is missing from training result`)
 	caseResult, backwardErr := engineInstance.backwardCase(context.Background(), structure, nil, CaseResult{
@@ -2476,7 +2519,7 @@ func TestBackwardCoversAdditionalBranches(t *testing.T) {
 	}, []promptiter.CaseLoss{
 		{EvalSetID: "set_b", EvalCaseID: "case_b", TerminalLosses: []promptiter.TerminalLoss{{StepID: "step_1", Loss: "b"}}},
 		{EvalSetID: "set_a", EvalCaseID: "case_a", TerminalLosses: []promptiter.TerminalLoss{{StepID: "step_1", Loss: "a"}}},
-	}, targetSurfaceSet{testSurfaceID: {}})
+	}, targetSurfaceSet{testSurfaceID: {}}, BackwardOptions{})
 	assert.NoError(t, backwardErr)
 	require.NotNil(t, result)
 	require.Len(t, result.Cases, 2)
@@ -2484,6 +2527,309 @@ func TestBackwardCoversAdditionalBranches(t *testing.T) {
 	assert.Equal(t, "case_a", result.Cases[0].EvalCaseID)
 	assert.Equal(t, "set_b", result.Cases[1].EvalSetID)
 	assert.Equal(t, "case_b", result.Cases[1].EvalCaseID)
+}
+
+func TestBackwardRunsEvalCasesInParallel(t *testing.T) {
+	structure, err := newStructureState(testStructureSnapshot(t))
+	require.NoError(t, err)
+	previousGOMAXPROCS := runtime.GOMAXPROCS(2)
+	defer runtime.GOMAXPROCS(previousGOMAXPROCS)
+	started := make(chan string, 2)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseAll := func() {
+		releaseOnce.Do(func() {
+			close(release)
+		})
+	}
+	engineInstance := &engine{
+		backwarder: &fakeBackwarder{
+			fn: func(ctx context.Context, request *backwarder.Request) (*backwarder.Result, error) {
+				started <- request.EvalCaseID
+				select {
+				case <-release:
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+				return &backwarder.Result{
+					Gradients: []promptiter.SurfaceGradient{{
+						EvalSetID:  request.EvalSetID,
+						EvalCaseID: request.EvalCaseID,
+						StepID:     request.StepID,
+						SurfaceID:  testSurfaceID,
+						Gradient:   "fix",
+					}},
+				}, nil
+			},
+		},
+	}
+	done := make(chan struct {
+		result *BackwardResult
+		err    error
+	}, 1)
+	go func() {
+		result, runErr := engineInstance.backward(
+			context.Background(),
+			structure,
+			nil,
+			parallelBackwardTrainResult(),
+			parallelBackwardLosses(),
+			targetSurfaceSet{testSurfaceID: {}},
+			BackwardOptions{CaseParallelismEnabled: true},
+		)
+		done <- struct {
+			result *BackwardResult
+			err    error
+		}{result: result, err: runErr}
+	}()
+	first := waitForParallelStart(t, started, releaseAll)
+	second := waitForParallelStart(t, started, releaseAll)
+	assert.ElementsMatch(t, []string{"case_a", "case_b"}, []string{first, second})
+	releaseAll()
+	select {
+	case output := <-done:
+		require.NoError(t, output.err)
+		require.NotNil(t, output.result)
+		require.Len(t, output.result.Cases, 2)
+		assert.Equal(t, "case_a", output.result.Cases[0].EvalCaseID)
+		assert.Equal(t, "case_b", output.result.Cases[1].EvalCaseID)
+	case <-time.After(time.Second):
+		require.FailNow(t, "parallel backward did not finish")
+	}
+}
+
+func TestAggregateRunsSurfacesInParallel(t *testing.T) {
+	structure, secondSurfaceID := twoSurfaceStructure(t)
+	previousGOMAXPROCS := runtime.GOMAXPROCS(2)
+	defer runtime.GOMAXPROCS(previousGOMAXPROCS)
+	started := make(chan string, 2)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseAll := func() {
+		releaseOnce.Do(func() {
+			close(release)
+		})
+	}
+	engineInstance := &engine{
+		aggregator: &fakeAggregator{
+			fn: func(ctx context.Context, request *aggregator.Request) (*aggregator.Result, error) {
+				started <- request.SurfaceID
+				select {
+				case <-release:
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+				return &aggregator.Result{
+					Gradient: &promptiter.AggregatedSurfaceGradient{
+						SurfaceID: request.SurfaceID,
+						NodeID:    request.NodeID,
+						Type:      request.Type,
+						Gradients: append([]promptiter.SurfaceGradient(nil), request.Gradients...),
+					},
+				}, nil
+			},
+		},
+	}
+	done := make(chan struct {
+		result *AggregationResult
+		err    error
+	}, 1)
+	go func() {
+		result, runErr := engineInstance.aggregate(
+			context.Background(),
+			structure,
+			twoSurfaceBackwardResult(secondSurfaceID),
+			targetSurfaceSet{testSurfaceID: {}, secondSurfaceID: {}},
+			AggregationOptions{SurfaceParallelismEnabled: true},
+		)
+		done <- struct {
+			result *AggregationResult
+			err    error
+		}{result: result, err: runErr}
+	}()
+	first := waitForParallelStart(t, started, releaseAll)
+	second := waitForParallelStart(t, started, releaseAll)
+	assert.ElementsMatch(t, []string{testSurfaceID, secondSurfaceID}, []string{first, second})
+	releaseAll()
+	select {
+	case output := <-done:
+		require.NoError(t, output.err)
+		require.NotNil(t, output.result)
+		require.Len(t, output.result.Surfaces, 2)
+		assert.Equal(t, secondSurfaceID, output.result.Surfaces[0].SurfaceID)
+		assert.Equal(t, testSurfaceID, output.result.Surfaces[1].SurfaceID)
+	case <-time.After(time.Second):
+		require.FailNow(t, "parallel aggregation did not finish")
+	}
+}
+
+func TestOptimizeRunsSurfacesInParallel(t *testing.T) {
+	structure, secondSurfaceID := twoSurfaceStructure(t)
+	previousGOMAXPROCS := runtime.GOMAXPROCS(2)
+	defer runtime.GOMAXPROCS(previousGOMAXPROCS)
+	started := make(chan string, 2)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseAll := func() {
+		releaseOnce.Do(func() {
+			close(release)
+		})
+	}
+	engineInstance := &engine{
+		optimizer: &fakeOptimizer{
+			fn: func(ctx context.Context, request *optimizer.Request) (*optimizer.Result, error) {
+				started <- request.Surface.SurfaceID
+				select {
+				case <-release:
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+				return &optimizer.Result{
+					Patch: &promptiter.SurfacePatch{
+						SurfaceID: request.Surface.SurfaceID,
+						Value:     request.Surface.Value,
+						Reason:    "keep",
+					},
+				}, nil
+			},
+		},
+	}
+	done := make(chan struct {
+		result *promptiter.PatchSet
+		err    error
+	}, 1)
+	go func() {
+		result, runErr := engineInstance.optimize(
+			context.Background(),
+			structure,
+			nil,
+			twoSurfaceAggregationResult(secondSurfaceID),
+			targetSurfaceSet{testSurfaceID: {}, secondSurfaceID: {}},
+			OptimizerOptions{SurfaceParallelismEnabled: true},
+		)
+		done <- struct {
+			result *promptiter.PatchSet
+			err    error
+		}{result: result, err: runErr}
+	}()
+	first := waitForParallelStart(t, started, releaseAll)
+	second := waitForParallelStart(t, started, releaseAll)
+	assert.ElementsMatch(t, []string{testSurfaceID, secondSurfaceID}, []string{first, second})
+	releaseAll()
+	select {
+	case output := <-done:
+		require.NoError(t, output.err)
+		require.NotNil(t, output.result)
+		require.Len(t, output.result.Patches, 2)
+		assert.Equal(t, secondSurfaceID, output.result.Patches[0].SurfaceID)
+		assert.Equal(t, testSurfaceID, output.result.Patches[1].SurfaceID)
+	case <-time.After(time.Second):
+		require.FailNow(t, "parallel optimization did not finish")
+	}
+}
+
+func TestRunIndexedParallelStopsSchedulingAfterErrorAndAggregatesErrors(t *testing.T) {
+	err0 := errors.New("index 0 failed")
+	err1 := errors.New("index 1 failed")
+	started := make(chan int, 3)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseAll := func() {
+		releaseOnce.Do(func() {
+			close(release)
+		})
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- runIndexedParallel(context.Background(), 3, 2, func(ctx context.Context, index int) error {
+			started <- index
+			select {
+			case <-release:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+			if index == 0 {
+				return err0
+			}
+			if index == 1 {
+				return err1
+			}
+			return nil
+		})
+	}()
+	first := waitForParallelIndexStart(t, started, releaseAll)
+	second := waitForParallelIndexStart(t, started, releaseAll)
+	assert.ElementsMatch(t, []int{0, 1}, []int{first, second})
+	releaseAll()
+	select {
+	case runErr := <-done:
+		assert.ErrorIs(t, runErr, err0)
+		assert.ErrorIs(t, runErr, err1)
+	case <-time.After(time.Second):
+		require.FailNow(t, "parallel work did not finish")
+	}
+	select {
+	case index := <-started:
+		require.Failf(t, "unexpected work started", "index %d started after cancellation", index)
+	default:
+	}
+}
+
+func TestRunIndexedParallelDoesNotMaskBusinessErrorWithSiblingCancel(t *testing.T) {
+	businessErr := errors.New("business failed")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	started := make(chan int, 2)
+	indexZeroStarted := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- runIndexedParallel(ctx, 2, 2, func(ctx context.Context, index int) error {
+			started <- index
+			if index == 0 {
+				close(indexZeroStarted)
+				<-ctx.Done()
+				return ctx.Err()
+			}
+			select {
+			case <-indexZeroStarted:
+				return businessErr
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		})
+	}()
+	first := waitForParallelIndexStart(t, started, cancel)
+	second := waitForParallelIndexStart(t, started, cancel)
+	assert.ElementsMatch(t, []int{0, 1}, []int{first, second})
+	select {
+	case runErr := <-done:
+		assert.ErrorIs(t, runErr, businessErr)
+	case <-time.After(time.Second):
+		require.FailNow(t, "parallel work did not finish")
+	}
+}
+
+func TestRunIndexedParallelReturnsParentCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	started := make(chan int, 2)
+	done := make(chan error, 1)
+	go func() {
+		done <- runIndexedParallel(ctx, 2, 2, func(ctx context.Context, index int) error {
+			started <- index
+			<-ctx.Done()
+			return ctx.Err()
+		})
+	}()
+	first := waitForParallelIndexStart(t, started, cancel)
+	second := waitForParallelIndexStart(t, started, cancel)
+	assert.ElementsMatch(t, []int{0, 1}, []int{first, second})
+	cancel()
+	select {
+	case runErr := <-done:
+		assert.ErrorIs(t, runErr, context.Canceled)
+	case <-time.After(time.Second):
+		require.FailNow(t, "parallel work did not finish")
+	}
 }
 
 func TestLossStopAndEventHelpers(t *testing.T) {
@@ -2572,7 +2918,7 @@ func TestOptimizeHelpersAndLossValidation(t *testing.T) {
 	structure, err := newStructureState(testStructureSnapshot(t))
 	assert.NoError(t, err)
 	engineInstance := &engine{optimizer: &fakeOptimizer{}}
-	patchSet, err := engineInstance.optimize(context.Background(), structure, nil, nil, nil)
+	patchSet, err := engineInstance.optimize(context.Background(), structure, nil, nil, nil, OptimizerOptions{})
 	assert.NoError(t, err)
 	require.NotNil(t, patchSet)
 	assert.Empty(t, patchSet.Patches)
@@ -2591,7 +2937,7 @@ func TestOptimizeHelpersAndLossValidation(t *testing.T) {
 				Type:      astructure.SurfaceTypeInstruction,
 			},
 		},
-	}, targetSurfaceSet{testSurfaceID: {}})
+	}, targetSurfaceSet{testSurfaceID: {}}, OptimizerOptions{})
 	assert.Nil(t, patchSet)
 	assert.EqualError(t, err, `optimize surface "node_1#instruction": boom`)
 	originalGradient := promptiter.AggregatedSurfaceGradient{
@@ -3165,6 +3511,125 @@ func testStructureSnapshotWithToolSurface(t *testing.T) *astructure.Snapshot {
 	snapshot, err := astructure.Export(context.Background(), testTargetAgentWithToolSurface())
 	assert.NoError(t, err)
 	return snapshot
+}
+
+func twoSurfaceStructure(t *testing.T) (*structureState, string) {
+	t.Helper()
+	secondSurfaceID := astructure.SurfaceID("node_1", astructure.SurfaceTypeGlobalInstruction)
+	structure, err := newStructureState(&astructure.Snapshot{
+		StructureID: "structure_1",
+		EntryNodeID: "node_1",
+		Nodes: []astructure.Node{
+			{NodeID: "node_1", Kind: astructure.NodeKindLLM, Name: "writer"},
+		},
+		Surfaces: []astructure.Surface{
+			{
+				SurfaceID: secondSurfaceID,
+				NodeID:    "node_1",
+				Type:      astructure.SurfaceTypeGlobalInstruction,
+				Value:     astructure.SurfaceValue{Text: stringPtr("global")},
+			},
+			{
+				SurfaceID: testSurfaceID,
+				NodeID:    "node_1",
+				Type:      astructure.SurfaceTypeInstruction,
+				Value:     astructure.SurfaceValue{Text: stringPtr("instruction")},
+			},
+		},
+	})
+	require.NoError(t, err)
+	return structure, secondSurfaceID
+}
+
+func parallelBackwardTrainResult() *EvaluationResult {
+	return &EvaluationResult{
+		EvalSets: []EvalSetResult{{
+			EvalSetID: "train",
+			Cases: []CaseResult{
+				parallelBackwardCase("case_b"),
+				parallelBackwardCase("case_a"),
+			},
+		}},
+	}
+}
+
+func parallelBackwardCase(evalCaseID string) CaseResult {
+	return CaseResult{
+		EvalSetID:  "train",
+		EvalCaseID: evalCaseID,
+		Trace: &atrace.Trace{
+			Steps: []atrace.Step{{
+				StepID:            "step_1",
+				NodeID:            "node_1",
+				AppliedSurfaceIDs: []string{testSurfaceID},
+			}},
+		},
+	}
+}
+
+func parallelBackwardLosses() []promptiter.CaseLoss {
+	return []promptiter.CaseLoss{
+		{EvalSetID: "train", EvalCaseID: "case_b", TerminalLosses: []promptiter.TerminalLoss{{StepID: "step_1", Loss: "b"}}},
+		{EvalSetID: "train", EvalCaseID: "case_a", TerminalLosses: []promptiter.TerminalLoss{{StepID: "step_1", Loss: "a"}}},
+	}
+}
+
+func twoSurfaceBackwardResult(secondSurfaceID string) *BackwardResult {
+	return &BackwardResult{
+		Cases: []CaseBackwardResult{{
+			StepGradients: []promptiter.StepGradient{{
+				StepID: "step_1",
+				NodeID: "node_1",
+				Gradients: []promptiter.SurfaceGradient{
+					{SurfaceID: testSurfaceID, Gradient: "fix instruction"},
+					{SurfaceID: secondSurfaceID, Gradient: "fix global"},
+				},
+			}},
+		}},
+	}
+}
+
+func twoSurfaceAggregationResult(secondSurfaceID string) *AggregationResult {
+	return &AggregationResult{
+		Surfaces: []promptiter.AggregatedSurfaceGradient{
+			{
+				SurfaceID: testSurfaceID,
+				NodeID:    "node_1",
+				Type:      astructure.SurfaceTypeInstruction,
+				Gradients: []promptiter.SurfaceGradient{{SurfaceID: testSurfaceID, Gradient: "fix instruction"}},
+			},
+			{
+				SurfaceID: secondSurfaceID,
+				NodeID:    "node_1",
+				Type:      astructure.SurfaceTypeGlobalInstruction,
+				Gradients: []promptiter.SurfaceGradient{{SurfaceID: secondSurfaceID, Gradient: "fix global"}},
+			},
+		},
+	}
+}
+
+func waitForParallelStart(t *testing.T, started <-chan string, release func()) string {
+	t.Helper()
+	select {
+	case value := <-started:
+		return value
+	case <-time.After(time.Second):
+		release()
+		require.FailNow(t, "parallel work did not start")
+		return ""
+	}
+}
+
+func waitForParallelIndexStart(t *testing.T, started <-chan int, release func()) int {
+	t.Helper()
+	select {
+	case value := <-started:
+		return value
+	case <-time.After(time.Second):
+		release()
+		require.FailNow(t, "parallel work did not start")
+		return 0
+	}
 }
 
 func testTargetAgent() agent.Agent {

--- a/evaluation/workflow/promptiter/engine/optimize.go
+++ b/evaluation/workflow/promptiter/engine/optimize.go
@@ -13,11 +13,20 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
 	"sort"
 
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/optimizer"
 )
+
+// OptimizerOptions configures optimizer-stage execution behavior.
+type OptimizerOptions struct {
+	// SurfaceParallelismEnabled enables concurrent optimization across target surfaces.
+	SurfaceParallelismEnabled bool
+	// SurfaceParallelism caps concurrent optimization across target surfaces when SurfaceParallelismEnabled is true. Zero uses GOMAXPROCS.
+	SurfaceParallelism int
+}
 
 func (e *engine) optimize(
 	ctx context.Context,
@@ -25,6 +34,7 @@ func (e *engine) optimize(
 	profile *promptiter.Profile,
 	aggregation *AggregationResult,
 	targetSurfaceSet targetSurfaceSet,
+	options OptimizerOptions,
 ) (*promptiter.PatchSet, error) {
 	if e.optimizer == nil {
 		return nil, errors.New("optimizer is nil")
@@ -36,26 +46,37 @@ func (e *engine) optimize(
 		return &promptiter.PatchSet{Patches: []promptiter.SurfacePatch{}}, nil
 	}
 	overrideIndex := buildOverrideIndex(profile)
-	patches := make([]promptiter.SurfacePatch, 0, len(aggregation.Surfaces))
-	for _, aggregatedSurface := range aggregation.Surfaces {
+	patches := make([]promptiter.SurfacePatch, len(aggregation.Surfaces))
+	parallelism := 0
+	if options.SurfaceParallelismEnabled {
+		parallelism = options.SurfaceParallelism
+		if parallelism <= 0 {
+			parallelism = runtime.GOMAXPROCS(0)
+		}
+	}
+	if err := runIndexedParallel(ctx, len(aggregation.Surfaces), parallelism, func(ctx context.Context, index int) error {
+		aggregatedSurface := aggregation.Surfaces[index]
 		if !targetSurfaceSet.contains(aggregatedSurface.SurfaceID) {
-			return nil, fmt.Errorf("aggregated surface id %q is outside target surfaces", aggregatedSurface.SurfaceID)
+			return fmt.Errorf("aggregated surface id %q is outside target surfaces", aggregatedSurface.SurfaceID)
 		}
 		surface, err := resolveProfileSurface(structure, overrideIndex, aggregatedSurface.SurfaceID)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		response, err := e.optimizer.Optimize(ctx, &optimizer.Request{
 			Surface:  &surface,
 			Gradient: cloneAggregatedGradient(aggregatedSurface),
 		})
 		if err != nil {
-			return nil, fmt.Errorf("optimize surface %q: %w", aggregatedSurface.SurfaceID, err)
+			return fmt.Errorf("optimize surface %q: %w", aggregatedSurface.SurfaceID, err)
 		}
 		if response == nil || response.Patch == nil {
-			return nil, fmt.Errorf("optimize surface %q returned empty result", aggregatedSurface.SurfaceID)
+			return fmt.Errorf("optimize surface %q returned empty result", aggregatedSurface.SurfaceID)
 		}
-		patches = append(patches, *response.Patch)
+		patches[index] = *response.Patch
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 	sort.SliceStable(patches, func(i, j int) bool {
 		return patches[i].SurfaceID < patches[j].SurfaceID

--- a/evaluation/workflow/promptiter/manager/manager.go
+++ b/evaluation/workflow/promptiter/manager/manager.go
@@ -207,6 +207,12 @@ func validateRunRequest(request *engine.RunRequest) error {
 		return errors.New("max rounds must be greater than 0")
 	case request.TargetSurfaceIDs != nil && len(request.TargetSurfaceIDs) == 0:
 		return errors.New("target surface ids must not be empty")
+	case request.BackwardOptions.CaseParallelism < 0:
+		return errors.New("backward case parallelism must be non-negative")
+	case request.AggregationOptions.SurfaceParallelism < 0:
+		return errors.New("aggregation surface parallelism must be non-negative")
+	case request.OptimizerOptions.SurfaceParallelism < 0:
+		return errors.New("optimizer surface parallelism must be non-negative")
 	default:
 		return nil
 	}

--- a/evaluation/workflow/promptiter/manager/manager_test.go
+++ b/evaluation/workflow/promptiter/manager/manager_test.go
@@ -983,11 +983,47 @@ func TestValidateRunRequest(t *testing.T) {
 		MaxRounds:        1,
 		TargetSurfaceIDs: []string{},
 	}), "target surface ids must not be empty")
+	assert.EqualError(t, validateRunRequest(&promptiterengine.RunRequest{
+		Train:      testEvalSetInputs("train"),
+		Validation: testEvalSetInputs("validation"),
+		MaxRounds:  1,
+		BackwardOptions: promptiterengine.BackwardOptions{
+			CaseParallelism: -1,
+		},
+	}), "backward case parallelism must be non-negative")
+	assert.EqualError(t, validateRunRequest(&promptiterengine.RunRequest{
+		Train:      testEvalSetInputs("train"),
+		Validation: testEvalSetInputs("validation"),
+		MaxRounds:  1,
+		AggregationOptions: promptiterengine.AggregationOptions{
+			SurfaceParallelism: -1,
+		},
+	}), "aggregation surface parallelism must be non-negative")
+	assert.EqualError(t, validateRunRequest(&promptiterengine.RunRequest{
+		Train:      testEvalSetInputs("train"),
+		Validation: testEvalSetInputs("validation"),
+		MaxRounds:  1,
+		OptimizerOptions: promptiterengine.OptimizerOptions{
+			SurfaceParallelism: -1,
+		},
+	}), "optimizer surface parallelism must be non-negative")
 	assert.NoError(t, validateRunRequest(&promptiterengine.RunRequest{
 		Train:            testEvalSetInputs("train"),
 		Validation:       testEvalSetInputs("validation"),
 		MaxRounds:        1,
 		TargetSurfaceIDs: []string{"candidate#instruction"},
+		BackwardOptions: promptiterengine.BackwardOptions{
+			CaseParallelismEnabled: true,
+			CaseParallelism:        1,
+		},
+		AggregationOptions: promptiterengine.AggregationOptions{
+			SurfaceParallelismEnabled: true,
+			SurfaceParallelism:        1,
+		},
+		OptimizerOptions: promptiterengine.OptimizerOptions{
+			SurfaceParallelismEnabled: true,
+			SurfaceParallelism:        1,
+		},
 	}))
 }
 
@@ -1013,6 +1049,18 @@ func TestCloneRunRequestDeepCopiesFields(t *testing.T) {
 			},
 		},
 		TargetSurfaceIDs: []string{"candidate#instruction"},
+		BackwardOptions: promptiterengine.BackwardOptions{
+			CaseParallelismEnabled: true,
+			CaseParallelism:        4,
+		},
+		AggregationOptions: promptiterengine.AggregationOptions{
+			SurfaceParallelismEnabled: true,
+			SurfaceParallelism:        3,
+		},
+		OptimizerOptions: promptiterengine.OptimizerOptions{
+			SurfaceParallelismEnabled: true,
+			SurfaceParallelism:        2,
+		},
 		StopPolicy: promptiterengine.StopPolicy{
 			TargetScore: &targetScore,
 		},
@@ -1029,6 +1077,9 @@ func TestCloneRunRequestDeepCopiesFields(t *testing.T) {
 	assert.Equal(t, "candidate#instruction", request.TargetSurfaceIDs[0])
 	assert.Equal(t, "prompt", *request.InitialProfile.Overrides[0].Value.Text)
 	assert.Equal(t, 0.9, *request.StopPolicy.TargetScore)
+	assert.Equal(t, promptiterengine.BackwardOptions{CaseParallelismEnabled: true, CaseParallelism: 4}, cloned.BackwardOptions)
+	assert.Equal(t, promptiterengine.AggregationOptions{SurfaceParallelismEnabled: true, SurfaceParallelism: 3}, cloned.AggregationOptions)
+	assert.Equal(t, promptiterengine.OptimizerOptions{SurfaceParallelismEnabled: true, SurfaceParallelism: 2}, cloned.OptimizerOptions)
 }
 
 func TestCloneRunRequestNil(t *testing.T) {


### PR DESCRIPTION
Adds configurable parallel execution for PromptIter backward, aggregation, and optimizer stages, exposes the options through manager requests, and documents the new RunRequest fields in English and Chinese.