### PR TITLE
{evaluation/workflow/promptiter, server/promptiter, docs}: add loss hints

### DIFF
--- a/docs/mkdocs/en/promptiter.md
+++ b/docs/mkdocs/en/promptiter.md
@@ -473,8 +473,16 @@ Both fields use `[]EvalSetInput` to describe the selected evaluation data:
 
 ```go
 type EvalSetInput struct {
-	EvalSetID   string   // EvalSetID identifies the evaluation set to execute.
-	EvalCaseIDs []string // EvalCaseIDs limits evaluation to the specified cases when present.
+	EvalSetID   string     // EvalSetID identifies the evaluation set to execute.
+	EvalCaseIDs []string   // EvalCaseIDs limits evaluation to the specified cases when present.
+	LossHints   []LossHint // LossHints provides operator-written failure reasons.
+}
+
+type LossHint struct {
+	EvalCaseID string                  // EvalCaseID identifies the case to annotate.
+	MetricName string                  // MetricName identifies the failed metric to annotate.
+	Severity   promptiter.LossSeverity // Severity marks the priority of the hint.
+	Reason     string                  // Reason describes the operator-written failure cause.
 }
 ```
 
@@ -515,6 +523,33 @@ request := &engine.RunRequest{
 ```
 
 Omitting `EvalCaseIDs` or passing an empty slice runs all cases in that eval set. Passing a non-empty slice runs only the listed cases.
+
+If you already know why some bad cases failed, set `LossHints` on the corresponding `EvalSetInput`. Callers only need to provide the case, metric, and reason; PromptIter handles trace and step details internally.
+
+```go
+request := &engine.RunRequest{
+	Train: []engine.EvalSetInput{
+		{
+			EvalSetID: "nba-commentary-train",
+			LossHints: []engine.LossHint{
+				{
+					EvalCaseID: "case_1",
+					MetricName: "answer_quality",
+					Severity:   promptiter.LossSeverityP1,
+					Reason:     "The answer missed the key defensive strategy constraint.",
+				},
+			},
+		},
+	},
+	Validation: []engine.EvalSetInput{
+		{
+			EvalSetID: "nba-commentary-validation",
+		},
+	},
+}
+```
+
+`LossHints` only supplements training optimization signals. It does not change evaluation scores or validation acceptance decisions. PromptIter uses a hint only when the corresponding case and metric fail in the current round; passing results are not forced into failures. A misspelled case or metric returns an argument error.
 
 #### EvaluationOptions
 

--- a/docs/mkdocs/zh/promptiter.md
+++ b/docs/mkdocs/zh/promptiter.md
@@ -473,8 +473,16 @@ type RunRequest struct {
 
 ```go
 type EvalSetInput struct {
-	EvalSetID   string   // EvalSetID 表示要执行的评估集。
-	EvalCaseIDs []string // EvalCaseIDs 表示按需限制执行的评估用例列表。
+	EvalSetID   string     // EvalSetID 表示要执行的评估集。
+	EvalCaseIDs []string   // EvalCaseIDs 表示按需限制执行的评估用例列表。
+	LossHints   []LossHint // LossHints 表示人工补充的失败原因提示。
+}
+
+type LossHint struct {
+	EvalCaseID string                  // EvalCaseID 表示要附加提示的评估用例。
+	MetricName string                  // MetricName 表示要附加提示的失败指标名称。
+	Severity   promptiter.LossSeverity // Severity 表示该提示的优先级。
+	Reason     string                  // Reason 表示人工补充的失败原因。
 }
 ```
 
@@ -515,6 +523,33 @@ request := &engine.RunRequest{
 ```
 
 `EvalCaseIDs` 省略或传空数组时，表示执行该评估集下的全部样本；传非空数组时，只执行指定样本。
+
+如果业务已经知道某些 badcase 的失败原因，可以在对应的 `EvalSetInput` 中设置 `LossHints`。调用方只需要填写 case、metric 和原因，不需要关心 trace 或 step 细节。
+
+```go
+request := &engine.RunRequest{
+	Train: []engine.EvalSetInput{
+		{
+			EvalSetID: "nba-commentary-train",
+			LossHints: []engine.LossHint{
+				{
+					EvalCaseID: "case_1",
+					MetricName: "answer_quality",
+					Severity:   promptiter.LossSeverityP1,
+					Reason:     "回答遗漏了球队关键防守策略的约束。",
+				},
+			},
+		},
+	},
+	Validation: []engine.EvalSetInput{
+		{
+			EvalSetID: "nba-commentary-validation",
+		},
+	},
+}
+```
+
+`LossHints` 只补充训练阶段的优化信号，不改变评测分数，也不影响 validation 接受判定。框架只会在对应 case 的对应 metric 本轮确实失败时使用 hint；如果本轮通过，则不会强行把它当作失败处理。case 或 metric 写错时会返回参数错误。
 
 #### EvaluationOptions
 

--- a/evaluation/workflow/promptiter/engine/engine.go
+++ b/evaluation/workflow/promptiter/engine/engine.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 
 	"golang.org/x/sync/errgroup"
 	"trpc.group/trpc-go/trpc-agent-go/agent"
@@ -71,6 +72,20 @@ type EvalSetInput struct {
 	EvalSetID string `json:"evalSetId"`
 	// EvalCaseIDs limits this eval set to specific eval cases when set.
 	EvalCaseIDs []string `json:"evalCaseIds,omitempty"`
+	// LossHints stores operator-provided loss reasons keyed by failed eval case and metric.
+	LossHints []LossHint `json:"lossHints,omitempty"`
+}
+
+// LossHint carries operator-provided context for one failed metric on one eval case.
+type LossHint struct {
+	// EvalCaseID identifies the eval case to receive this hint.
+	EvalCaseID string `json:"evalCaseId"`
+	// MetricName identifies the failed metric to receive this hint.
+	MetricName string `json:"metricName"`
+	// Severity indicates how urgently this hint should influence optimization when set.
+	Severity promptiter.LossSeverity `json:"severity,omitempty"`
+	// Reason stores the manual loss text used by gradient computation.
+	Reason string `json:"reason"`
 }
 
 // RunStatus identifies the lifecycle state of one PromptIter run view.
@@ -388,6 +403,10 @@ func (e *engine) executeRound(
 	if err != nil {
 		return nil, 0, fmt.Errorf("extract train losses round %d: %w", roundNumber, err)
 	}
+	losses, err = mergeLossHints(losses, trainResult, request.Train)
+	if err != nil {
+		return nil, 0, fmt.Errorf("merge train loss hints round %d: %w", roundNumber, err)
+	}
 	roundResult.Losses = losses
 	if err := appendRunEvent(ctx, observer, EventKindRoundLosses, roundNumber, losses); err != nil {
 		return nil, 0, err
@@ -497,15 +516,78 @@ func validateEvalSetInputs(role string, inputs []EvalSetInput) error {
 	if len(inputs) == 0 {
 		return fmt.Errorf("%sevaluation sets are empty", prefix)
 	}
+	seenEvalSetIDs := make(map[string]struct{}, len(inputs))
 	for _, input := range inputs {
 		if input.EvalSetID == "" {
 			return fmt.Errorf("%sevaluation set id is empty", prefix)
 		}
+		if _, ok := seenEvalSetIDs[input.EvalSetID]; ok {
+			return fmt.Errorf("%sevaluation set id %q is duplicated", prefix, input.EvalSetID)
+		}
+		seenEvalSetIDs[input.EvalSetID] = struct{}{}
 		if slices.Contains(input.EvalCaseIDs, "") {
 			return fmt.Errorf("%seval case id for eval set %q is empty", prefix, input.EvalSetID)
 		}
+		selectedCaseIDs := make(map[string]struct{}, len(input.EvalCaseIDs))
+		for _, evalCaseID := range input.EvalCaseIDs {
+			selectedCaseIDs[evalCaseID] = struct{}{}
+		}
+		for _, hint := range input.LossHints {
+			hintEvalCaseID := strings.TrimSpace(hint.EvalCaseID)
+			switch {
+			case hintEvalCaseID == "":
+				return fmt.Errorf("%sloss hint eval case id for eval set %q is empty", prefix, input.EvalSetID)
+			case strings.TrimSpace(hint.MetricName) == "":
+				return fmt.Errorf(
+					"%sloss hint metric name for eval set %q case %q is empty",
+					prefix,
+					input.EvalSetID,
+					hint.EvalCaseID,
+				)
+			case strings.TrimSpace(hint.Reason) == "":
+				return fmt.Errorf(
+					"%sloss hint reason for eval set %q case %q metric %q is empty",
+					prefix,
+					input.EvalSetID,
+					hint.EvalCaseID,
+					hint.MetricName,
+				)
+			case !isValidLossHintSeverity(hint.Severity):
+				return fmt.Errorf(
+					"%sloss hint severity %q for eval set %q case %q metric %q is invalid",
+					prefix,
+					hint.Severity,
+					input.EvalSetID,
+					hint.EvalCaseID,
+					hint.MetricName,
+				)
+			}
+			if len(selectedCaseIDs) > 0 {
+				if _, ok := selectedCaseIDs[hintEvalCaseID]; !ok {
+					return fmt.Errorf(
+						"%sloss hint eval case %q is not selected for eval set %q",
+						prefix,
+						hint.EvalCaseID,
+						input.EvalSetID,
+					)
+				}
+			}
+		}
 	}
 	return nil
+}
+
+func isValidLossHintSeverity(severity promptiter.LossSeverity) bool {
+	switch severity {
+	case "",
+		promptiter.LossSeverityP0,
+		promptiter.LossSeverityP1,
+		promptiter.LossSeverityP2,
+		promptiter.LossSeverityP3:
+		return true
+	default:
+		return false
+	}
 }
 
 func runIndexedParallel(

--- a/evaluation/workflow/promptiter/engine/engine.go
+++ b/evaluation/workflow/promptiter/engine/engine.go
@@ -516,15 +516,10 @@ func validateEvalSetInputs(role string, inputs []EvalSetInput) error {
 	if len(inputs) == 0 {
 		return fmt.Errorf("%sevaluation sets are empty", prefix)
 	}
-	seenEvalSetIDs := make(map[string]struct{}, len(inputs))
 	for _, input := range inputs {
 		if input.EvalSetID == "" {
 			return fmt.Errorf("%sevaluation set id is empty", prefix)
 		}
-		if _, ok := seenEvalSetIDs[input.EvalSetID]; ok {
-			return fmt.Errorf("%sevaluation set id %q is duplicated", prefix, input.EvalSetID)
-		}
-		seenEvalSetIDs[input.EvalSetID] = struct{}{}
 		if slices.Contains(input.EvalCaseIDs, "") {
 			return fmt.Errorf("%seval case id for eval set %q is empty", prefix, input.EvalSetID)
 		}

--- a/evaluation/workflow/promptiter/engine/engine_test.go
+++ b/evaluation/workflow/promptiter/engine/engine_test.go
@@ -1705,14 +1705,14 @@ func TestValidateEvalSetInputsRejectsInvalidInputs(t *testing.T) {
 			EvalSetID: "",
 		},
 	}), "train evaluation set id is empty")
-	assert.NoError(t, validateEvalSetInputs("train", []EvalSetInput{
+	assert.EqualError(t, validateEvalSetInputs("train", []EvalSetInput{
 		{
 			EvalSetID: "train",
 		},
 		{
 			EvalSetID: "train",
 		},
-	}))
+	}), `train evaluation set id "train" is duplicated`)
 	assert.NoError(t, validateEvalSetInputs("train", []EvalSetInput{
 		{
 			EvalSetID:   "train",
@@ -1725,6 +1725,58 @@ func TestValidateEvalSetInputsRejectsInvalidInputs(t *testing.T) {
 			EvalCaseIDs: []string{""},
 		},
 	}), `train eval case id for eval set "train" is empty`)
+	assert.NoError(t, validateEvalSetInputs("train", []EvalSetInput{
+		{
+			EvalSetID:   "train",
+			EvalCaseIDs: []string{"case_1"},
+			LossHints: []LossHint{
+				{
+					EvalCaseID: "case_1",
+					MetricName: "quality",
+					Severity:   promptiter.LossSeverityP1,
+					Reason:     "business reason",
+				},
+			},
+		},
+	}))
+	assert.EqualError(t, validateEvalSetInputs("train", []EvalSetInput{
+		{
+			EvalSetID: "train",
+			LossHints: []LossHint{
+				{
+					EvalCaseID: "case_1",
+					MetricName: "quality",
+					Reason:     " ",
+				},
+			},
+		},
+	}), `train loss hint reason for eval set "train" case "case_1" metric "quality" is empty`)
+	assert.EqualError(t, validateEvalSetInputs("train", []EvalSetInput{
+		{
+			EvalSetID: "train",
+			LossHints: []LossHint{
+				{
+					EvalCaseID: "case_1",
+					MetricName: "quality",
+					Severity:   promptiter.LossSeverity("P4"),
+					Reason:     "business reason",
+				},
+			},
+		},
+	}), `train loss hint severity "P4" for eval set "train" case "case_1" metric "quality" is invalid`)
+	assert.EqualError(t, validateEvalSetInputs("train", []EvalSetInput{
+		{
+			EvalSetID:   "train",
+			EvalCaseIDs: []string{"case_1"},
+			LossHints: []LossHint{
+				{
+					EvalCaseID: "case_2",
+					MetricName: "quality",
+					Reason:     "business reason",
+				},
+			},
+		},
+	}), `train loss hint eval case "case_2" is not selected for eval set "train"`)
 }
 
 func TestRunRejectsNonPositiveMaxRounds(t *testing.T) {
@@ -3461,6 +3513,141 @@ func TestLossExpandsMetricAcrossTraceTerminalSteps(t *testing.T) {
 		assert.Equal(t, "step_2", losses[0].TerminalLosses[0].StepID)
 		assert.Equal(t, "step_3", losses[0].TerminalLosses[1].StepID)
 	}
+}
+
+func TestMergeLossHintsAppendsToExistingFailedMetricLoss(t *testing.T) {
+	result := &EvaluationResult{
+		EvalSets: []EvalSetResult{
+			{
+				EvalSetID: "train",
+				Cases: []CaseResult{
+					{
+						EvalSetID:  "train",
+						EvalCaseID: "case_1",
+						Trace: &atrace.Trace{
+							Status: atrace.TraceStatusCompleted,
+							Steps: []atrace.Step{
+								{
+									StepID: "step_1",
+									NodeID: "node_1",
+								},
+							},
+						},
+						Metrics: []MetricResult{
+							{
+								MetricName: "quality",
+								Status:     status.EvalStatusFailed,
+								Reason:     "needs improvement",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	losses, err := (&engine{}).loss(result)
+	require.NoError(t, err)
+	mergedLosses, err := mergeLossHints(losses, result, []EvalSetInput{
+		{
+			EvalSetID: "train",
+			LossHints: []LossHint{
+				{
+					EvalCaseID: "case_1",
+					MetricName: "quality",
+					Severity:   promptiter.LossSeverityP1,
+					Reason:     " hallucinated business answer ",
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, mergedLosses, 1)
+	require.Len(t, mergedLosses[0].TerminalLosses, 2)
+	assert.Equal(t, promptiter.TerminalLoss{
+		EvalSetID:  "train",
+		EvalCaseID: "case_1",
+		MetricName: "quality",
+		Severity:   promptiter.LossSeverityP1,
+		StepID:     "step_1",
+		Loss:       "hallucinated business answer",
+	}, mergedLosses[0].TerminalLosses[0])
+	assert.Equal(t, "needs improvement", mergedLosses[0].TerminalLosses[1].Loss)
+}
+
+func TestMergeLossHintsSkipsPassedMetric(t *testing.T) {
+	result := &EvaluationResult{
+		EvalSets: []EvalSetResult{
+			{
+				EvalSetID: "train",
+				Cases: []CaseResult{
+					{
+						EvalSetID:  "train",
+						EvalCaseID: "case_1",
+						Metrics: []MetricResult{
+							{
+								MetricName: "quality",
+								Status:     status.EvalStatusPassed,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	mergedLosses, err := mergeLossHints(nil, result, []EvalSetInput{
+		{
+			EvalSetID: "train",
+			LossHints: []LossHint{
+				{
+					EvalCaseID: "case_1",
+					MetricName: "quality",
+					Severity:   promptiter.LossSeverityP0,
+					Reason:     "manual concern",
+				},
+			},
+		},
+	})
+	assert.NoError(t, err)
+	assert.Empty(t, mergedLosses)
+}
+
+func TestMergeLossHintsRequiresMetricInTrainingResult(t *testing.T) {
+	result := &EvaluationResult{
+		EvalSets: []EvalSetResult{
+			{
+				EvalSetID: "train",
+				Cases: []CaseResult{
+					{
+						EvalSetID:  "train",
+						EvalCaseID: "case_1",
+						Metrics: []MetricResult{
+							{
+								MetricName: "accuracy",
+								Status:     status.EvalStatusPassed,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	_, err := mergeLossHints(nil, result, []EvalSetInput{
+		{
+			EvalSetID: "train",
+			LossHints: []LossHint{
+				{
+					EvalCaseID: "case_1",
+					MetricName: "quality",
+					Reason:     "manual concern",
+				},
+			},
+		},
+	})
+	assert.EqualError(
+		t,
+		err,
+		`loss hint metric "quality" for eval case "case_1" from eval set "train" is missing from training result`,
+	)
 }
 
 func scriptedOutcome(evalSetID string, profileValue string) scriptedEvalOutcome {

--- a/evaluation/workflow/promptiter/engine/engine_test.go
+++ b/evaluation/workflow/promptiter/engine/engine_test.go
@@ -1705,14 +1705,14 @@ func TestValidateEvalSetInputsRejectsInvalidInputs(t *testing.T) {
 			EvalSetID: "",
 		},
 	}), "train evaluation set id is empty")
-	assert.EqualError(t, validateEvalSetInputs("train", []EvalSetInput{
+	assert.NoError(t, validateEvalSetInputs("train", []EvalSetInput{
 		{
 			EvalSetID: "train",
 		},
 		{
 			EvalSetID: "train",
 		},
-	}), `train evaluation set id "train" is duplicated`)
+	}))
 	assert.NoError(t, validateEvalSetInputs("train", []EvalSetInput{
 		{
 			EvalSetID:   "train",

--- a/evaluation/workflow/promptiter/engine/engine_test.go
+++ b/evaluation/workflow/promptiter/engine/engine_test.go
@@ -1756,6 +1756,30 @@ func TestValidateEvalSetInputsRejectsInvalidInputs(t *testing.T) {
 			EvalSetID: "train",
 			LossHints: []LossHint{
 				{
+					EvalCaseID: " ",
+					MetricName: "quality",
+					Reason:     "business reason",
+				},
+			},
+		},
+	}), `train loss hint eval case id for eval set "train" is empty`)
+	assert.EqualError(t, validateEvalSetInputs("train", []EvalSetInput{
+		{
+			EvalSetID: "train",
+			LossHints: []LossHint{
+				{
+					EvalCaseID: "case_1",
+					MetricName: " ",
+					Reason:     "business reason",
+				},
+			},
+		},
+	}), `train loss hint metric name for eval set "train" case "case_1" is empty`)
+	assert.EqualError(t, validateEvalSetInputs("train", []EvalSetInput{
+		{
+			EvalSetID: "train",
+			LossHints: []LossHint{
+				{
 					EvalCaseID: "case_1",
 					MetricName: "quality",
 					Severity:   promptiter.LossSeverity("P4"),
@@ -3574,6 +3598,50 @@ func TestMergeLossHintsAppendsToExistingFailedMetricLoss(t *testing.T) {
 	assert.Equal(t, "needs improvement", mergedLosses[0].TerminalLosses[1].Loss)
 }
 
+func TestMergeLossHintsReturnsOriginalLossesWhenHintsAreEmpty(t *testing.T) {
+	losses := []promptiter.CaseLoss{
+		{
+			EvalSetID:  "train",
+			EvalCaseID: "case_1",
+		},
+	}
+	mergedLosses, err := mergeLossHints(losses, nil, []EvalSetInput{{EvalSetID: "train"}})
+	assert.NoError(t, err)
+	assert.Equal(t, losses, mergedLosses)
+}
+
+func TestMergeLossHintsRejectsNilResultWhenHintsExist(t *testing.T) {
+	_, err := mergeLossHints(nil, nil, []EvalSetInput{
+		{
+			EvalSetID: "train",
+			LossHints: []LossHint{
+				{
+					EvalCaseID: "case_1",
+					MetricName: "quality",
+					Reason:     "manual concern",
+				},
+			},
+		},
+	})
+	assert.EqualError(t, err, "evaluation result is nil")
+}
+
+func TestMergeLossHintsRequiresCaseInTrainingResult(t *testing.T) {
+	_, err := mergeLossHints(nil, &EvaluationResult{}, []EvalSetInput{
+		{
+			EvalSetID: "train",
+			LossHints: []LossHint{
+				{
+					EvalCaseID: "case_1",
+					MetricName: "quality",
+					Reason:     "manual concern",
+				},
+			},
+		},
+	})
+	assert.EqualError(t, err, `loss hint case "case_1" from eval set "train" is missing from training result`)
+}
+
 func TestMergeLossHintsSkipsPassedMetric(t *testing.T) {
 	result := &EvaluationResult{
 		EvalSets: []EvalSetResult{
@@ -3602,6 +3670,44 @@ func TestMergeLossHintsSkipsPassedMetric(t *testing.T) {
 					EvalCaseID: "case_1",
 					MetricName: "quality",
 					Severity:   promptiter.LossSeverityP0,
+					Reason:     "manual concern",
+				},
+			},
+		},
+	})
+	assert.NoError(t, err)
+	assert.Empty(t, mergedLosses)
+}
+
+func TestMergeLossHintsSkipsFailedMetricWithoutExistingLoss(t *testing.T) {
+	result := &EvaluationResult{
+		EvalSets: []EvalSetResult{
+			{
+				EvalSetID: "train",
+				Cases: []CaseResult{
+					{
+						EvalSetID:  "train",
+						EvalCaseID: "case_1",
+						Metrics: []MetricResult{
+							{
+								MetricName: "quality",
+								Status:     status.EvalStatusFailed,
+								Reason:     "needs improvement",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	mergedLosses, err := mergeLossHints(nil, result, []EvalSetInput{
+		{
+			EvalSetID: "train",
+			LossHints: []LossHint{
+				{
+					EvalCaseID: "case_1",
+					MetricName: "quality",
+					Severity:   promptiter.LossSeverityP1,
 					Reason:     "manual concern",
 				},
 			},
@@ -3648,6 +3754,130 @@ func TestMergeLossHintsRequiresMetricInTrainingResult(t *testing.T) {
 		err,
 		`loss hint metric "quality" for eval case "case_1" from eval set "train" is missing from training result`,
 	)
+}
+
+func TestIndexLossHintTargetsDeduplicatesStepIDs(t *testing.T) {
+	_, stepIndex := indexLossHintTargets([]promptiter.CaseLoss{
+		{
+			EvalSetID:  "train",
+			EvalCaseID: "case_1",
+			TerminalLosses: []promptiter.TerminalLoss{
+				{
+					EvalSetID:  "train",
+					EvalCaseID: "case_1",
+					MetricName: "quality",
+					StepID:     "step_1",
+				},
+				{
+					EvalSetID:  "train",
+					EvalCaseID: "case_1",
+					MetricName: "quality",
+					StepID:     "step_1",
+				},
+			},
+		},
+	})
+	assert.Equal(t, []string{"step_1"}, stepIndex[lossHintMetricKey{
+		evalSetID:  "train",
+		evalCaseID: "case_1",
+		metricName: "quality",
+	}])
+}
+
+func TestSortCaseLossesOrdersCasesAndTerminalLosses(t *testing.T) {
+	losses := []promptiter.CaseLoss{
+		{
+			EvalSetID:  "train_b",
+			EvalCaseID: "case_2",
+			TerminalLosses: []promptiter.TerminalLoss{
+				{
+					MetricName: "quality",
+					Severity:   promptiter.LossSeverityP2,
+					StepID:     "step_2",
+					Loss:       "z",
+				},
+				{
+					MetricName: "quality",
+					Severity:   promptiter.LossSeverityP1,
+					StepID:     "step_2",
+					Loss:       "y",
+				},
+				{
+					MetricName: "accuracy",
+					Severity:   promptiter.LossSeverityP1,
+					StepID:     "step_2",
+					Loss:       "y",
+				},
+				{
+					MetricName: "accuracy",
+					Severity:   promptiter.LossSeverityP1,
+					StepID:     "step_1",
+					Loss:       "y",
+				},
+				{
+					MetricName: "accuracy",
+					Severity:   promptiter.LossSeverityP1,
+					StepID:     "step_1",
+					Loss:       "x",
+				},
+			},
+		},
+		{
+			EvalSetID:  "train_a",
+			EvalCaseID: "case_1",
+		},
+		{
+			EvalSetID:  "train_b",
+			EvalCaseID: "case_1",
+		},
+	}
+	sortCaseLosses(losses)
+	assert.Equal(t, []promptiter.CaseLoss{
+		{
+			EvalSetID:  "train_a",
+			EvalCaseID: "case_1",
+		},
+		{
+			EvalSetID:  "train_b",
+			EvalCaseID: "case_1",
+		},
+		{
+			EvalSetID:  "train_b",
+			EvalCaseID: "case_2",
+			TerminalLosses: []promptiter.TerminalLoss{
+				{
+					MetricName: "accuracy",
+					Severity:   promptiter.LossSeverityP1,
+					StepID:     "step_1",
+					Loss:       "x",
+				},
+				{
+					MetricName: "accuracy",
+					Severity:   promptiter.LossSeverityP1,
+					StepID:     "step_1",
+					Loss:       "y",
+				},
+				{
+					MetricName: "accuracy",
+					Severity:   promptiter.LossSeverityP1,
+					StepID:     "step_2",
+					Loss:       "y",
+				},
+				{
+					MetricName: "quality",
+					Severity:   promptiter.LossSeverityP1,
+					StepID:     "step_2",
+					Loss:       "y",
+				},
+				{
+					MetricName: "quality",
+					Severity:   promptiter.LossSeverityP2,
+					StepID:     "step_2",
+					Loss:       "z",
+				},
+			},
+		},
+	}, losses)
 }
 
 func scriptedOutcome(evalSetID string, profileValue string) scriptedEvalOutcome {

--- a/evaluation/workflow/promptiter/engine/loss.go
+++ b/evaluation/workflow/promptiter/engine/loss.go
@@ -18,7 +18,14 @@ import (
 	atrace "trpc.group/trpc-go/trpc-agent-go/agent/trace"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/status"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter"
+	iloss "trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/internal/loss"
 )
+
+type lossHintMetricKey struct {
+	evalSetID  string
+	evalCaseID string
+	metricName string
+}
 
 func (e *engine) loss(result *EvaluationResult) ([]promptiter.CaseLoss, error) {
 	if result == nil {
@@ -67,25 +74,134 @@ func (e *engine) loss(result *EvaluationResult) ([]promptiter.CaseLoss, error) {
 			if len(caseLoss.TerminalLosses) == 0 {
 				continue
 			}
-			sort.SliceStable(caseLoss.TerminalLosses, func(i, j int) bool {
-				if caseLoss.TerminalLosses[i].MetricName != caseLoss.TerminalLosses[j].MetricName {
-					return caseLoss.TerminalLosses[i].MetricName < caseLoss.TerminalLosses[j].MetricName
-				}
-				if caseLoss.TerminalLosses[i].StepID != caseLoss.TerminalLosses[j].StepID {
-					return caseLoss.TerminalLosses[i].StepID < caseLoss.TerminalLosses[j].StepID
-				}
-				return caseLoss.TerminalLosses[i].Loss < caseLoss.TerminalLosses[j].Loss
-			})
 			losses = append(losses, caseLoss)
 		}
 	}
-	sort.SliceStable(losses, func(i, j int) bool {
-		if losses[i].EvalSetID != losses[j].EvalSetID {
-			return losses[i].EvalSetID < losses[j].EvalSetID
-		}
-		return losses[i].EvalCaseID < losses[j].EvalCaseID
-	})
+	sortCaseLosses(losses)
 	return losses, nil
+}
+
+func mergeLossHints(
+	losses []promptiter.CaseLoss,
+	result *EvaluationResult,
+	inputs []EvalSetInput,
+) ([]promptiter.CaseLoss, error) {
+	hintIndex := indexLossHints(inputs)
+	if len(hintIndex) == 0 {
+		return losses, nil
+	}
+	if result == nil {
+		return nil, errors.New("evaluation result is nil")
+	}
+	caseIndex := indexCaseResults(result)
+	lossIndex, stepIndex := indexLossHintTargets(losses)
+	for caseKey, hints := range hintIndex {
+		evalCase, ok := caseIndex[caseKey]
+		if !ok {
+			return nil, fmt.Errorf(
+				"loss hint case %q from eval set %q is missing from training result",
+				caseKey.evalCaseID,
+				caseKey.evalSetID,
+			)
+		}
+		for _, hint := range hints {
+			metric, ok := findMetricResult(evalCase.Metrics, hint.MetricName)
+			if !ok {
+				return nil, fmt.Errorf(
+					"loss hint metric %q for eval case %q from eval set %q is missing from training result",
+					hint.MetricName,
+					caseKey.evalCaseID,
+					caseKey.evalSetID,
+				)
+			}
+			if metric.Status != status.EvalStatusFailed {
+				continue
+			}
+			metricKey := lossHintMetricKey{
+				evalSetID:  caseKey.evalSetID,
+				evalCaseID: caseKey.evalCaseID,
+				metricName: hint.MetricName,
+			}
+			stepIDs := stepIndex[metricKey]
+			if len(stepIDs) == 0 {
+				continue
+			}
+			lossPosition, ok := lossIndex[caseKey]
+			if !ok {
+				continue
+			}
+			for _, stepID := range stepIDs {
+				losses[lossPosition].TerminalLosses = append(losses[lossPosition].TerminalLosses,
+					promptiter.TerminalLoss{
+						EvalSetID:  caseKey.evalSetID,
+						EvalCaseID: caseKey.evalCaseID,
+						MetricName: hint.MetricName,
+						Severity:   hint.Severity,
+						StepID:     stepID,
+						Loss:       hint.Reason,
+					})
+			}
+		}
+	}
+	sortCaseLosses(losses)
+	return losses, nil
+}
+
+func indexLossHints(inputs []EvalSetInput) map[caseResultKey][]LossHint {
+	index := make(map[caseResultKey][]LossHint)
+	for _, input := range inputs {
+		for _, hint := range input.LossHints {
+			hint.EvalCaseID = strings.TrimSpace(hint.EvalCaseID)
+			hint.MetricName = strings.TrimSpace(hint.MetricName)
+			hint.Reason = strings.TrimSpace(hint.Reason)
+			key := caseResultKey{
+				evalSetID:  input.EvalSetID,
+				evalCaseID: hint.EvalCaseID,
+			}
+			index[key] = append(index[key], hint)
+		}
+	}
+	return index
+}
+
+func indexLossHintTargets(
+	losses []promptiter.CaseLoss,
+) (map[caseResultKey]int, map[lossHintMetricKey][]string) {
+	lossIndex := make(map[caseResultKey]int, len(losses))
+	stepIndex := make(map[lossHintMetricKey][]string)
+	seenSteps := make(map[lossHintMetricKey]map[string]struct{})
+	for index := range losses {
+		caseKey := caseResultKey{
+			evalSetID:  losses[index].EvalSetID,
+			evalCaseID: losses[index].EvalCaseID,
+		}
+		lossIndex[caseKey] = index
+		for _, terminalLoss := range losses[index].TerminalLosses {
+			metricKey := lossHintMetricKey{
+				evalSetID:  terminalLoss.EvalSetID,
+				evalCaseID: terminalLoss.EvalCaseID,
+				metricName: terminalLoss.MetricName,
+			}
+			if _, ok := seenSteps[metricKey]; !ok {
+				seenSteps[metricKey] = make(map[string]struct{})
+			}
+			if _, ok := seenSteps[metricKey][terminalLoss.StepID]; ok {
+				continue
+			}
+			seenSteps[metricKey][terminalLoss.StepID] = struct{}{}
+			stepIndex[metricKey] = append(stepIndex[metricKey], terminalLoss.StepID)
+		}
+	}
+	return lossIndex, stepIndex
+}
+
+func findMetricResult(metrics []MetricResult, metricName string) (MetricResult, bool) {
+	for _, metric := range metrics {
+		if metric.MetricName == metricName {
+			return metric, true
+		}
+	}
+	return MetricResult{}, false
 }
 
 func traceTerminalStepIDs(trace *atrace.Trace) ([]string, error) {
@@ -146,4 +262,31 @@ func sortStepIDs(stepIDs map[string]struct{}, stepOrder map[string]int) []string
 		return stepOrder[ids[i]] < stepOrder[ids[j]]
 	})
 	return ids
+}
+
+func sortCaseLosses(losses []promptiter.CaseLoss) {
+	for index := range losses {
+		sort.SliceStable(losses[index].TerminalLosses, func(i, j int) bool {
+			return terminalLossLess(losses[index].TerminalLosses[i], losses[index].TerminalLosses[j])
+		})
+	}
+	sort.SliceStable(losses, func(i, j int) bool {
+		if losses[i].EvalSetID != losses[j].EvalSetID {
+			return losses[i].EvalSetID < losses[j].EvalSetID
+		}
+		return losses[i].EvalCaseID < losses[j].EvalCaseID
+	})
+}
+
+func terminalLossLess(left promptiter.TerminalLoss, right promptiter.TerminalLoss) bool {
+	if iloss.SeverityRank(left.Severity) != iloss.SeverityRank(right.Severity) {
+		return iloss.SeverityRank(left.Severity) < iloss.SeverityRank(right.Severity)
+	}
+	if left.MetricName != right.MetricName {
+		return left.MetricName < right.MetricName
+	}
+	if left.StepID != right.StepID {
+		return left.StepID < right.StepID
+	}
+	return left.Loss < right.Loss
 }

--- a/evaluation/workflow/promptiter/manager/manager.go
+++ b/evaluation/workflow/promptiter/manager/manager.go
@@ -15,9 +15,11 @@ import (
 	"fmt"
 	"os"
 	"slices"
+	"strings"
 	"sync"
 
 	"github.com/google/uuid"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
 	iprofile "trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/internal/profile"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/store"
@@ -239,15 +241,78 @@ func validateEvalSetInputs(role string, inputs []engine.EvalSetInput) error {
 	if len(inputs) == 0 {
 		return fmt.Errorf("%sevaluation sets are empty", prefix)
 	}
+	seenEvalSetIDs := make(map[string]struct{}, len(inputs))
 	for _, input := range inputs {
 		if input.EvalSetID == "" {
 			return fmt.Errorf("%sevaluation set id is empty", prefix)
 		}
+		if _, ok := seenEvalSetIDs[input.EvalSetID]; ok {
+			return fmt.Errorf("%sevaluation set id %q is duplicated", prefix, input.EvalSetID)
+		}
+		seenEvalSetIDs[input.EvalSetID] = struct{}{}
 		if slices.Contains(input.EvalCaseIDs, "") {
 			return fmt.Errorf("%seval case id for eval set %q is empty", prefix, input.EvalSetID)
 		}
+		selectedCaseIDs := make(map[string]struct{}, len(input.EvalCaseIDs))
+		for _, evalCaseID := range input.EvalCaseIDs {
+			selectedCaseIDs[evalCaseID] = struct{}{}
+		}
+		for _, hint := range input.LossHints {
+			hintEvalCaseID := strings.TrimSpace(hint.EvalCaseID)
+			switch {
+			case hintEvalCaseID == "":
+				return fmt.Errorf("%sloss hint eval case id for eval set %q is empty", prefix, input.EvalSetID)
+			case strings.TrimSpace(hint.MetricName) == "":
+				return fmt.Errorf(
+					"%sloss hint metric name for eval set %q case %q is empty",
+					prefix,
+					input.EvalSetID,
+					hint.EvalCaseID,
+				)
+			case strings.TrimSpace(hint.Reason) == "":
+				return fmt.Errorf(
+					"%sloss hint reason for eval set %q case %q metric %q is empty",
+					prefix,
+					input.EvalSetID,
+					hint.EvalCaseID,
+					hint.MetricName,
+				)
+			case !isValidLossHintSeverity(hint.Severity):
+				return fmt.Errorf(
+					"%sloss hint severity %q for eval set %q case %q metric %q is invalid",
+					prefix,
+					hint.Severity,
+					input.EvalSetID,
+					hint.EvalCaseID,
+					hint.MetricName,
+				)
+			}
+			if len(selectedCaseIDs) > 0 {
+				if _, ok := selectedCaseIDs[hintEvalCaseID]; !ok {
+					return fmt.Errorf(
+						"%sloss hint eval case %q is not selected for eval set %q",
+						prefix,
+						hint.EvalCaseID,
+						input.EvalSetID,
+					)
+				}
+			}
+		}
 	}
 	return nil
+}
+
+func isValidLossHintSeverity(severity promptiter.LossSeverity) bool {
+	switch severity {
+	case "",
+		promptiter.LossSeverityP0,
+		promptiter.LossSeverityP1,
+		promptiter.LossSeverityP2,
+		promptiter.LossSeverityP3:
+		return true
+	default:
+		return false
+	}
 }
 
 func cloneEvalSetInputs(inputs []engine.EvalSetInput) []engine.EvalSetInput {
@@ -259,6 +324,7 @@ func cloneEvalSetInputs(inputs []engine.EvalSetInput) []engine.EvalSetInput {
 		cloned = append(cloned, engine.EvalSetInput{
 			EvalSetID:   input.EvalSetID,
 			EvalCaseIDs: append([]string(nil), input.EvalCaseIDs...),
+			LossHints:   append([]engine.LossHint(nil), input.LossHints...),
 		})
 	}
 	return cloned

--- a/evaluation/workflow/promptiter/manager/manager.go
+++ b/evaluation/workflow/promptiter/manager/manager.go
@@ -241,15 +241,10 @@ func validateEvalSetInputs(role string, inputs []engine.EvalSetInput) error {
 	if len(inputs) == 0 {
 		return fmt.Errorf("%sevaluation sets are empty", prefix)
 	}
-	seenEvalSetIDs := make(map[string]struct{}, len(inputs))
 	for _, input := range inputs {
 		if input.EvalSetID == "" {
 			return fmt.Errorf("%sevaluation set id is empty", prefix)
 		}
-		if _, ok := seenEvalSetIDs[input.EvalSetID]; ok {
-			return fmt.Errorf("%sevaluation set id %q is duplicated", prefix, input.EvalSetID)
-		}
-		seenEvalSetIDs[input.EvalSetID] = struct{}{}
 		if slices.Contains(input.EvalCaseIDs, "") {
 			return fmt.Errorf("%seval case id for eval set %q is empty", prefix, input.EvalSetID)
 		}

--- a/evaluation/workflow/promptiter/manager/manager_test.go
+++ b/evaluation/workflow/promptiter/manager/manager_test.go
@@ -973,7 +973,7 @@ func TestValidateRunRequest(t *testing.T) {
 		},
 		MaxRounds: 1,
 	}), `validation eval case id for eval set "validation" is empty`)
-	assert.EqualError(t, validateRunRequest(&promptiterengine.RunRequest{
+	assert.NoError(t, validateRunRequest(&promptiterengine.RunRequest{
 		Train: []promptiterengine.EvalSetInput{
 			{
 				EvalSetID: "train",
@@ -984,7 +984,7 @@ func TestValidateRunRequest(t *testing.T) {
 		},
 		Validation: testEvalSetInputs("validation"),
 		MaxRounds:  1,
-	}), `train evaluation set id "train" is duplicated`)
+	}))
 	assert.EqualError(t, validateRunRequest(&promptiterengine.RunRequest{
 		Train: []promptiterengine.EvalSetInput{
 			{

--- a/evaluation/workflow/promptiter/manager/manager_test.go
+++ b/evaluation/workflow/promptiter/manager/manager_test.go
@@ -991,6 +991,71 @@ func TestValidateRunRequest(t *testing.T) {
 				EvalSetID: "train",
 				LossHints: []promptiterengine.LossHint{
 					{
+						EvalCaseID: " ",
+						MetricName: "quality",
+						Reason:     "business reason",
+					},
+				},
+			},
+		},
+		Validation: testEvalSetInputs("validation"),
+		MaxRounds:  1,
+	}), `train loss hint eval case id for eval set "train" is empty`)
+	assert.EqualError(t, validateRunRequest(&promptiterengine.RunRequest{
+		Train: []promptiterengine.EvalSetInput{
+			{
+				EvalSetID: "train",
+				LossHints: []promptiterengine.LossHint{
+					{
+						EvalCaseID: "case_1",
+						MetricName: " ",
+						Reason:     "business reason",
+					},
+				},
+			},
+		},
+		Validation: testEvalSetInputs("validation"),
+		MaxRounds:  1,
+	}), `train loss hint metric name for eval set "train" case "case_1" is empty`)
+	assert.EqualError(t, validateRunRequest(&promptiterengine.RunRequest{
+		Train: []promptiterengine.EvalSetInput{
+			{
+				EvalSetID: "train",
+				LossHints: []promptiterengine.LossHint{
+					{
+						EvalCaseID: "case_1",
+						MetricName: "quality",
+						Reason:     " ",
+					},
+				},
+			},
+		},
+		Validation: testEvalSetInputs("validation"),
+		MaxRounds:  1,
+	}), `train loss hint reason for eval set "train" case "case_1" metric "quality" is empty`)
+	assert.EqualError(t, validateRunRequest(&promptiterengine.RunRequest{
+		Train: []promptiterengine.EvalSetInput{
+			{
+				EvalSetID:   "train",
+				EvalCaseIDs: []string{"case_1"},
+				LossHints: []promptiterengine.LossHint{
+					{
+						EvalCaseID: "case_2",
+						MetricName: "quality",
+						Reason:     "business reason",
+					},
+				},
+			},
+		},
+		Validation: testEvalSetInputs("validation"),
+		MaxRounds:  1,
+	}), `train loss hint eval case "case_2" is not selected for eval set "train"`)
+	assert.EqualError(t, validateRunRequest(&promptiterengine.RunRequest{
+		Train: []promptiterengine.EvalSetInput{
+			{
+				EvalSetID: "train",
+				LossHints: []promptiterengine.LossHint{
+					{
 						EvalCaseID: "case_1",
 						MetricName: "quality",
 						Severity:   promptiter.LossSeverity("P4"),

--- a/evaluation/workflow/promptiter/manager/manager_test.go
+++ b/evaluation/workflow/promptiter/manager/manager_test.go
@@ -974,6 +974,35 @@ func TestValidateRunRequest(t *testing.T) {
 		MaxRounds: 1,
 	}), `validation eval case id for eval set "validation" is empty`)
 	assert.EqualError(t, validateRunRequest(&promptiterengine.RunRequest{
+		Train: []promptiterengine.EvalSetInput{
+			{
+				EvalSetID: "train",
+			},
+			{
+				EvalSetID: "train",
+			},
+		},
+		Validation: testEvalSetInputs("validation"),
+		MaxRounds:  1,
+	}), `train evaluation set id "train" is duplicated`)
+	assert.EqualError(t, validateRunRequest(&promptiterengine.RunRequest{
+		Train: []promptiterengine.EvalSetInput{
+			{
+				EvalSetID: "train",
+				LossHints: []promptiterengine.LossHint{
+					{
+						EvalCaseID: "case_1",
+						MetricName: "quality",
+						Severity:   promptiter.LossSeverity("P4"),
+						Reason:     "business reason",
+					},
+				},
+			},
+		},
+		Validation: testEvalSetInputs("validation"),
+		MaxRounds:  1,
+	}), `train loss hint severity "P4" for eval set "train" case "case_1" metric "quality" is invalid`)
+	assert.EqualError(t, validateRunRequest(&promptiterengine.RunRequest{
 		Train:      testEvalSetInputs("train"),
 		Validation: testEvalSetInputs("validation"),
 	}), "max rounds must be greater than 0")
@@ -1035,6 +1064,14 @@ func TestCloneRunRequestDeepCopiesFields(t *testing.T) {
 			{
 				EvalSetID:   "validation",
 				EvalCaseIDs: []string{"case_1"},
+				LossHints: []promptiterengine.LossHint{
+					{
+						EvalCaseID: "case_1",
+						MetricName: "quality",
+						Severity:   promptiter.LossSeverityP1,
+						Reason:     "business reason",
+					},
+				},
 			},
 		},
 		InitialProfile: &promptiter.Profile{
@@ -1069,11 +1106,13 @@ func TestCloneRunRequestDeepCopiesFields(t *testing.T) {
 	require.NotNil(t, cloned)
 	cloned.Train[0].EvalSetID = "mutated"
 	cloned.Validation[0].EvalCaseIDs[0] = "mutated"
+	cloned.Validation[0].LossHints[0].Reason = "mutated"
 	cloned.TargetSurfaceIDs[0] = "mutated"
 	*cloned.InitialProfile.Overrides[0].Value.Text = "mutated"
 	*cloned.StopPolicy.TargetScore = 1.0
 	assert.Equal(t, "train", request.Train[0].EvalSetID)
 	assert.Equal(t, []string{"case_1"}, request.Validation[0].EvalCaseIDs)
+	assert.Equal(t, "business reason", request.Validation[0].LossHints[0].Reason)
 	assert.Equal(t, "candidate#instruction", request.TargetSurfaceIDs[0])
 	assert.Equal(t, "prompt", *request.InitialProfile.Overrides[0].Value.Text)
 	assert.Equal(t, 0.9, *request.StopPolicy.TargetScore)

--- a/server/promptiter/handler.go
+++ b/server/promptiter/handler.go
@@ -18,10 +18,12 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"slices"
 	"strings"
 	"time"
 
 	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
 	"trpc.group/trpc-go/trpc-agent-go/log"
 )
@@ -296,7 +298,6 @@ func decodeJSONBody[T any](
 	defer r.Body.Close()
 	var req T
 	decoder := json.NewDecoder(r.Body)
-	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(&req); err != nil {
 		respond(w, r, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("invalid request body: %v", err)})
 		return req, err
@@ -319,5 +320,110 @@ func validateRunRequest(req *RunRequest) error {
 	if req.Run == nil {
 		return errors.New("run must not be nil")
 	}
+	return validateEngineRunRequest(req.Run)
+}
+
+func validateEngineRunRequest(request *engine.RunRequest) error {
+	if request == nil {
+		return errors.New("run request is nil")
+	}
+	if err := validateEvalSetInputs("train", request.Train); err != nil {
+		return err
+	}
+	if err := validateEvalSetInputs("validation", request.Validation); err != nil {
+		return err
+	}
+	switch {
+	case request.MaxRounds <= 0:
+		return errors.New("max rounds must be greater than 0")
+	case request.TargetSurfaceIDs != nil && len(request.TargetSurfaceIDs) == 0:
+		return errors.New("target surface ids must not be empty")
+	case request.BackwardOptions.CaseParallelism < 0:
+		return errors.New("backward case parallelism must be non-negative")
+	case request.AggregationOptions.SurfaceParallelism < 0:
+		return errors.New("aggregation surface parallelism must be non-negative")
+	case request.OptimizerOptions.SurfaceParallelism < 0:
+		return errors.New("optimizer surface parallelism must be non-negative")
+	default:
+		return nil
+	}
+}
+
+func validateEvalSetInputs(role string, inputs []engine.EvalSetInput) error {
+	prefix := role + " "
+	if len(inputs) == 0 {
+		return fmt.Errorf("%sevaluation sets are empty", prefix)
+	}
+	seenEvalSetIDs := make(map[string]struct{}, len(inputs))
+	for _, input := range inputs {
+		if input.EvalSetID == "" {
+			return fmt.Errorf("%sevaluation set id is empty", prefix)
+		}
+		if _, ok := seenEvalSetIDs[input.EvalSetID]; ok {
+			return fmt.Errorf("%sevaluation set id %q is duplicated", prefix, input.EvalSetID)
+		}
+		seenEvalSetIDs[input.EvalSetID] = struct{}{}
+		if slices.Contains(input.EvalCaseIDs, "") {
+			return fmt.Errorf("%seval case id for eval set %q is empty", prefix, input.EvalSetID)
+		}
+		selectedCaseIDs := make(map[string]struct{}, len(input.EvalCaseIDs))
+		for _, evalCaseID := range input.EvalCaseIDs {
+			selectedCaseIDs[evalCaseID] = struct{}{}
+		}
+		for _, hint := range input.LossHints {
+			hintEvalCaseID := strings.TrimSpace(hint.EvalCaseID)
+			switch {
+			case hintEvalCaseID == "":
+				return fmt.Errorf("%sloss hint eval case id for eval set %q is empty", prefix, input.EvalSetID)
+			case strings.TrimSpace(hint.MetricName) == "":
+				return fmt.Errorf(
+					"%sloss hint metric name for eval set %q case %q is empty",
+					prefix,
+					input.EvalSetID,
+					hint.EvalCaseID,
+				)
+			case strings.TrimSpace(hint.Reason) == "":
+				return fmt.Errorf(
+					"%sloss hint reason for eval set %q case %q metric %q is empty",
+					prefix,
+					input.EvalSetID,
+					hint.EvalCaseID,
+					hint.MetricName,
+				)
+			case !isValidLossHintSeverity(hint.Severity):
+				return fmt.Errorf(
+					"%sloss hint severity %q for eval set %q case %q metric %q is invalid",
+					prefix,
+					hint.Severity,
+					input.EvalSetID,
+					hint.EvalCaseID,
+					hint.MetricName,
+				)
+			}
+			if len(selectedCaseIDs) > 0 {
+				if _, ok := selectedCaseIDs[hintEvalCaseID]; !ok {
+					return fmt.Errorf(
+						"%sloss hint eval case %q is not selected for eval set %q",
+						prefix,
+						hint.EvalCaseID,
+						input.EvalSetID,
+					)
+				}
+			}
+		}
+	}
 	return nil
+}
+
+func isValidLossHintSeverity(severity promptiter.LossSeverity) bool {
+	switch severity {
+	case "",
+		promptiter.LossSeverityP0,
+		promptiter.LossSeverityP1,
+		promptiter.LossSeverityP2,
+		promptiter.LossSeverityP3:
+		return true
+	default:
+		return false
+	}
 }

--- a/server/promptiter/handler.go
+++ b/server/promptiter/handler.go
@@ -354,15 +354,10 @@ func validateEvalSetInputs(role string, inputs []engine.EvalSetInput) error {
 	if len(inputs) == 0 {
 		return fmt.Errorf("%sevaluation sets are empty", prefix)
 	}
-	seenEvalSetIDs := make(map[string]struct{}, len(inputs))
 	for _, input := range inputs {
 		if input.EvalSetID == "" {
 			return fmt.Errorf("%sevaluation set id is empty", prefix)
 		}
-		if _, ok := seenEvalSetIDs[input.EvalSetID]; ok {
-			return fmt.Errorf("%sevaluation set id %q is duplicated", prefix, input.EvalSetID)
-		}
-		seenEvalSetIDs[input.EvalSetID] = struct{}{}
 		if slices.Contains(input.EvalCaseIDs, "") {
 			return fmt.Errorf("%seval case id for eval set %q is empty", prefix, input.EvalSetID)
 		}

--- a/server/promptiter/handler.go
+++ b/server/promptiter/handler.go
@@ -297,14 +297,41 @@ func decodeJSONBody[T any](
 ) (T, error) {
 	defer r.Body.Close()
 	var req T
-	decoder := json.NewDecoder(r.Body)
-	if err := decoder.Decode(&req); err != nil {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
 		respond(w, r, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("invalid request body: %v", err)})
+		return req, err
+	}
+	req, err = decodeJSONPayload[T](body, true)
+	if err == nil {
+		return req, nil
+	}
+	strictErr := err
+	req, err = decodeJSONPayload[T](body, false)
+	if err != nil {
+		respond(w, r, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("invalid request body: %v", err)})
+		return req, err
+	}
+	log.Warnf(
+		"promptiter server: ignored unknown request field for %s %s: %v",
+		r.Method,
+		r.URL.RequestURI(),
+		strictErr,
+	)
+	return req, nil
+}
+
+func decodeJSONPayload[T any](body []byte, disallowUnknownFields bool) (T, error) {
+	var req T
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	if disallowUnknownFields {
+		decoder.DisallowUnknownFields()
+	}
+	if err := decoder.Decode(&req); err != nil {
 		return req, err
 	}
 	extraErr := decoder.Decode(&struct{}{})
 	if extraErr != io.EOF {
-		respond(w, r, http.StatusBadRequest, map[string]string{"error": "invalid request body: request body must contain a single JSON object"})
 		if extraErr == nil {
 			extraErr = errors.New("request body must contain a single JSON object")
 		}

--- a/server/promptiter/server_test.go
+++ b/server/promptiter/server_test.go
@@ -789,6 +789,156 @@ func TestValidateRunRequest(t *testing.T) {
 	assert.EqualError(t, validateRunRequest(nil), "request must not be nil")
 	assert.EqualError(t, validateRunRequest(&RunRequest{}), "run must not be nil")
 	assert.EqualError(t, validateRunRequest(&RunRequest{Run: &enginepkg.RunRequest{}}), "train evaluation sets are empty")
+	assert.EqualError(t, validateRunRequest(&RunRequest{Run: &enginepkg.RunRequest{
+		Train: testEvalSetInputs("train"),
+	}}), "validation evaluation sets are empty")
+	assert.EqualError(t, validateRunRequest(&RunRequest{Run: &enginepkg.RunRequest{
+		Train: []enginepkg.EvalSetInput{
+			{
+				EvalSetID: "",
+			},
+		},
+		Validation: testEvalSetInputs("validation"),
+		MaxRounds:  1,
+	}}), "train evaluation set id is empty")
+	assert.EqualError(t, validateRunRequest(&RunRequest{Run: &enginepkg.RunRequest{
+		Train: []enginepkg.EvalSetInput{
+			{
+				EvalSetID: "train",
+			},
+			{
+				EvalSetID: "train",
+			},
+		},
+		Validation: testEvalSetInputs("validation"),
+		MaxRounds:  1,
+	}}), `train evaluation set id "train" is duplicated`)
+	assert.EqualError(t, validateRunRequest(&RunRequest{Run: &enginepkg.RunRequest{
+		Train: testEvalSetInputs("train"),
+		Validation: []enginepkg.EvalSetInput{
+			{
+				EvalSetID:   "validation",
+				EvalCaseIDs: []string{""},
+			},
+		},
+		MaxRounds: 1,
+	}}), `validation eval case id for eval set "validation" is empty`)
+	assert.EqualError(t, validateRunRequest(&RunRequest{Run: &enginepkg.RunRequest{
+		Train: []enginepkg.EvalSetInput{
+			{
+				EvalSetID: "train",
+				LossHints: []enginepkg.LossHint{
+					{
+						EvalCaseID: " ",
+						MetricName: "quality",
+						Reason:     "business reason",
+					},
+				},
+			},
+		},
+		Validation: testEvalSetInputs("validation"),
+		MaxRounds:  1,
+	}}), `train loss hint eval case id for eval set "train" is empty`)
+	assert.EqualError(t, validateRunRequest(&RunRequest{Run: &enginepkg.RunRequest{
+		Train: []enginepkg.EvalSetInput{
+			{
+				EvalSetID: "train",
+				LossHints: []enginepkg.LossHint{
+					{
+						EvalCaseID: "case_1",
+						MetricName: " ",
+						Reason:     "business reason",
+					},
+				},
+			},
+		},
+		Validation: testEvalSetInputs("validation"),
+		MaxRounds:  1,
+	}}), `train loss hint metric name for eval set "train" case "case_1" is empty`)
+	assert.EqualError(t, validateRunRequest(&RunRequest{Run: &enginepkg.RunRequest{
+		Train: []enginepkg.EvalSetInput{
+			{
+				EvalSetID: "train",
+				LossHints: []enginepkg.LossHint{
+					{
+						EvalCaseID: "case_1",
+						MetricName: "quality",
+						Reason:     " ",
+					},
+				},
+			},
+		},
+		Validation: testEvalSetInputs("validation"),
+		MaxRounds:  1,
+	}}), `train loss hint reason for eval set "train" case "case_1" metric "quality" is empty`)
+	assert.EqualError(t, validateRunRequest(&RunRequest{Run: &enginepkg.RunRequest{
+		Train: []enginepkg.EvalSetInput{
+			{
+				EvalSetID: "train",
+				LossHints: []enginepkg.LossHint{
+					{
+						EvalCaseID: "case_1",
+						MetricName: "quality",
+						Severity:   "P4",
+						Reason:     "business reason",
+					},
+				},
+			},
+		},
+		Validation: testEvalSetInputs("validation"),
+		MaxRounds:  1,
+	}}), `train loss hint severity "P4" for eval set "train" case "case_1" metric "quality" is invalid`)
+	assert.EqualError(t, validateRunRequest(&RunRequest{Run: &enginepkg.RunRequest{
+		Train: []enginepkg.EvalSetInput{
+			{
+				EvalSetID:   "train",
+				EvalCaseIDs: []string{"case_1"},
+				LossHints: []enginepkg.LossHint{
+					{
+						EvalCaseID: "case_2",
+						MetricName: "quality",
+						Reason:     "business reason",
+					},
+				},
+			},
+		},
+		Validation: testEvalSetInputs("validation"),
+		MaxRounds:  1,
+	}}), `train loss hint eval case "case_2" is not selected for eval set "train"`)
+	assert.EqualError(t, validateRunRequest(&RunRequest{Run: &enginepkg.RunRequest{
+		Train:      testEvalSetInputs("train"),
+		Validation: testEvalSetInputs("validation"),
+	}}), "max rounds must be greater than 0")
+	assert.EqualError(t, validateRunRequest(&RunRequest{Run: &enginepkg.RunRequest{
+		Train:            testEvalSetInputs("train"),
+		Validation:       testEvalSetInputs("validation"),
+		MaxRounds:        1,
+		TargetSurfaceIDs: []string{},
+	}}), "target surface ids must not be empty")
+	assert.EqualError(t, validateRunRequest(&RunRequest{Run: &enginepkg.RunRequest{
+		Train:      testEvalSetInputs("train"),
+		Validation: testEvalSetInputs("validation"),
+		MaxRounds:  1,
+		BackwardOptions: enginepkg.BackwardOptions{
+			CaseParallelism: -1,
+		},
+	}}), "backward case parallelism must be non-negative")
+	assert.EqualError(t, validateRunRequest(&RunRequest{Run: &enginepkg.RunRequest{
+		Train:      testEvalSetInputs("train"),
+		Validation: testEvalSetInputs("validation"),
+		MaxRounds:  1,
+		AggregationOptions: enginepkg.AggregationOptions{
+			SurfaceParallelism: -1,
+		},
+	}}), "aggregation surface parallelism must be non-negative")
+	assert.EqualError(t, validateRunRequest(&RunRequest{Run: &enginepkg.RunRequest{
+		Train:      testEvalSetInputs("train"),
+		Validation: testEvalSetInputs("validation"),
+		MaxRounds:  1,
+		OptimizerOptions: enginepkg.OptimizerOptions{
+			SurfaceParallelism: -1,
+		},
+	}}), "optimizer surface parallelism must be non-negative")
 	assert.NoError(t, validateRunRequest(&RunRequest{Run: &enginepkg.RunRequest{
 		Train:      testEvalSetInputs("train"),
 		Validation: testEvalSetInputs("validation"),

--- a/server/promptiter/server_test.go
+++ b/server/promptiter/server_test.go
@@ -317,11 +317,22 @@ func TestHandleRunsDecodesEvalSetInputs(t *testing.T) {
 	)
 	body := `{
 		"run": {
-			"train": [{"evalSetId": "train", "evalCaseIds": ["train_case_1"]}],
+			"train": [{
+				"evalSetId": "train",
+				"evalCaseIds": ["train_case_1"],
+				"lossHints": [{
+					"evalCaseId": "train_case_1",
+					"metricName": "quality",
+					"severity": "P1",
+					"reason": "business reason"
+				}]
+			}],
 			"validation": [{"evalSetId": "validation", "evalCaseIds": ["validation_case_1", "validation_case_2"]}],
 			"TargetSurfaceIDs": ["candidate#instruction"],
-			"MaxRounds": 1
-		}
+			"MaxRounds": 1,
+			"unknownRunField": "ignored"
+		},
+		"unknownRootField": "ignored"
 	}`
 	req := httptest.NewRequest(http.MethodPost, srv.RunsPath(), bytes.NewBufferString(body))
 	recorder := httptest.NewRecorder()
@@ -332,6 +343,14 @@ func TestHandleRunsDecodesEvalSetInputs(t *testing.T) {
 		{
 			EvalSetID:   "train",
 			EvalCaseIDs: []string{"train_case_1"},
+			LossHints: []enginepkg.LossHint{
+				{
+					EvalCaseID: "train_case_1",
+					MetricName: "quality",
+					Severity:   "P1",
+					Reason:     "business reason",
+				},
+			},
 		},
 	}, captured.Train)
 	assert.Equal(t, []enginepkg.EvalSetInput{
@@ -760,13 +779,21 @@ func TestDecodeJSONBodyRejectsInvalidPayloads(t *testing.T) {
 	extraReq := httptest.NewRequest(http.MethodPost, "/runs", bytes.NewBufferString(`{} {}`))
 	_, err = decodeJSONBody[RunRequest](httptest.NewRecorder(), extraReq, respond)
 	assert.Error(t, err)
+	unknownReq := httptest.NewRequest(http.MethodPost, "/runs", bytes.NewBufferString(`{"unknown":true}`))
+	_, err = decodeJSONBody[RunRequest](httptest.NewRecorder(), unknownReq, respond)
+	assert.NoError(t, err)
 	assert.Equal(t, []int{http.StatusBadRequest, http.StatusBadRequest}, respondCalls)
 }
 
 func TestValidateRunRequest(t *testing.T) {
 	assert.EqualError(t, validateRunRequest(nil), "request must not be nil")
 	assert.EqualError(t, validateRunRequest(&RunRequest{}), "run must not be nil")
-	assert.NoError(t, validateRunRequest(&RunRequest{Run: &enginepkg.RunRequest{}}))
+	assert.EqualError(t, validateRunRequest(&RunRequest{Run: &enginepkg.RunRequest{}}), "train evaluation sets are empty")
+	assert.NoError(t, validateRunRequest(&RunRequest{Run: &enginepkg.RunRequest{
+		Train:      testEvalSetInputs("train"),
+		Validation: testEvalSetInputs("validation"),
+		MaxRounds:  1,
+	}}))
 }
 
 var _ managerpkg.Manager = (*fakeManager)(nil)

--- a/server/promptiter/server_test.go
+++ b/server/promptiter/server_test.go
@@ -370,6 +370,41 @@ func TestHandleRunsRejectsInvalidRequest(t *testing.T) {
 	assert.Contains(t, recorder.Body.String(), "run must not be nil")
 }
 
+func TestHandleRunsRejectsInvalidLossHints(t *testing.T) {
+	called := false
+	srv := newTestServer(t,
+		WithEngine(&fakeEngine{
+			run: func(ctx context.Context, request *enginepkg.RunRequest, opts ...enginepkg.Option) (*enginepkg.RunResult, error) {
+				_ = ctx
+				_ = request
+				_ = opts
+				called = true
+				return &enginepkg.RunResult{Status: enginepkg.RunStatusSucceeded}, nil
+			},
+		}),
+	)
+	body := `{
+		"run": {
+			"train": [{
+				"evalSetId": "train",
+				"lossHints": [{
+					"evalCaseId": "case_1",
+					"metricName": "quality",
+					"reason": " "
+				}]
+			}],
+			"validation": [{"evalSetId": "validation"}],
+			"MaxRounds": 1
+		}
+	}`
+	req := httptest.NewRequest(http.MethodPost, srv.RunsPath(), bytes.NewBufferString(body))
+	recorder := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(recorder, req)
+	require.Equal(t, http.StatusBadRequest, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), "loss hint reason")
+	assert.False(t, called)
+}
+
 func TestHandleRunsSupportsOptions(t *testing.T) {
 	srv := newTestServer(t)
 	req := httptest.NewRequest(http.MethodOptions, srv.RunsPath(), nil)
@@ -801,7 +836,7 @@ func TestValidateRunRequest(t *testing.T) {
 		Validation: testEvalSetInputs("validation"),
 		MaxRounds:  1,
 	}}), "train evaluation set id is empty")
-	assert.EqualError(t, validateRunRequest(&RunRequest{Run: &enginepkg.RunRequest{
+	assert.NoError(t, validateRunRequest(&RunRequest{Run: &enginepkg.RunRequest{
 		Train: []enginepkg.EvalSetInput{
 			{
 				EvalSetID: "train",
@@ -812,7 +847,7 @@ func TestValidateRunRequest(t *testing.T) {
 		},
 		Validation: testEvalSetInputs("validation"),
 		MaxRounds:  1,
-	}}), `train evaluation set id "train" is duplicated`)
+	}}))
 	assert.EqualError(t, validateRunRequest(&RunRequest{Run: &enginepkg.RunRequest{
 		Train: testEvalSetInputs("train"),
 		Validation: []enginepkg.EvalSetInput{

--- a/server/promptiter/server_test.go
+++ b/server/promptiter/server_test.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -26,6 +27,7 @@ import (
 	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
 	enginepkg "trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
 	managerpkg "trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/manager"
+	agentlog "trpc.group/trpc-go/trpc-agent-go/log"
 )
 
 type fakeEngine struct {
@@ -58,6 +60,32 @@ type fakeManager struct {
 }
 
 type failingWriter struct{}
+
+type stubLogger struct {
+	warnfCalls []string
+}
+
+func (s *stubLogger) Debug(args ...any) {}
+
+func (s *stubLogger) Debugf(format string, args ...any) {}
+
+func (s *stubLogger) Info(args ...any) {}
+
+func (s *stubLogger) Infof(format string, args ...any) {}
+
+func (s *stubLogger) Warn(args ...any) {}
+
+func (s *stubLogger) Warnf(format string, args ...any) {
+	s.warnfCalls = append(s.warnfCalls, fmt.Sprintf(format, args...))
+}
+
+func (s *stubLogger) Error(args ...any) {}
+
+func (s *stubLogger) Errorf(format string, args ...any) {}
+
+func (s *stubLogger) Fatal(args ...any) {}
+
+func (s *stubLogger) Fatalf(format string, args ...any) {}
 
 func (f *fakeManager) Start(ctx context.Context, request *enginepkg.RunRequest) (*enginepkg.RunResult, error) {
 	if f.start != nil {
@@ -288,6 +316,12 @@ func TestHandleRunsAppliesResponseResultSlimming(t *testing.T) {
 
 func TestHandleRunsDecodesEvalSetInputs(t *testing.T) {
 	var captured *enginepkg.RunRequest
+	logger := &stubLogger{}
+	originalLogger := agentlog.Default
+	agentlog.Default = logger
+	defer func() {
+		agentlog.Default = originalLogger
+	}()
 	srv := newTestServer(t,
 		WithEngine(&fakeEngine{
 			describe: func(ctx context.Context) (*astructure.Snapshot, error) {
@@ -324,8 +358,10 @@ func TestHandleRunsDecodesEvalSetInputs(t *testing.T) {
 					"evalCaseId": "train_case_1",
 					"metricName": "quality",
 					"severity": "P1",
-					"reason": "business reason"
-				}]
+					"reason": "business reason",
+					"unknownHintField": "ignored"
+				}],
+				"unknownEvalSetField": "ignored"
 			}],
 			"validation": [{"evalSetId": "validation", "evalCaseIds": ["validation_case_1", "validation_case_2"]}],
 			"TargetSurfaceIDs": ["candidate#instruction"],
@@ -359,6 +395,9 @@ func TestHandleRunsDecodesEvalSetInputs(t *testing.T) {
 			EvalCaseIDs: []string{"validation_case_1", "validation_case_2"},
 		},
 	}, captured.Validation)
+	require.Len(t, logger.warnfCalls, 1)
+	assert.Contains(t, logger.warnfCalls[0], "ignored unknown request field")
+	assert.Contains(t, logger.warnfCalls[0], "json: unknown field")
 }
 
 func TestHandleRunsRejectsInvalidRequest(t *testing.T) {
@@ -802,6 +841,12 @@ func TestNewExecutionContext(t *testing.T) {
 
 func TestDecodeJSONBodyRejectsInvalidPayloads(t *testing.T) {
 	respondCalls := make([]int, 0, 2)
+	logger := &stubLogger{}
+	originalLogger := agentlog.Default
+	agentlog.Default = logger
+	defer func() {
+		agentlog.Default = originalLogger
+	}()
 	respond := func(w http.ResponseWriter, r *http.Request, statusCode int, payload any) {
 		_ = w
 		_ = r
@@ -817,6 +862,8 @@ func TestDecodeJSONBodyRejectsInvalidPayloads(t *testing.T) {
 	unknownReq := httptest.NewRequest(http.MethodPost, "/runs", bytes.NewBufferString(`{"unknown":true}`))
 	_, err = decodeJSONBody[RunRequest](httptest.NewRecorder(), unknownReq, respond)
 	assert.NoError(t, err)
+	require.Len(t, logger.warnfCalls, 1)
+	assert.Contains(t, logger.warnfCalls[0], "unknown")
 	assert.Equal(t, []int{http.StatusBadRequest, http.StatusBadRequest}, respondCalls)
 }
 


### PR DESCRIPTION
This change adds LossHints to PromptIter eval set inputs so callers can provide operator-written failure reasons for specific failed metrics. The engine merges applicable hints into train losses without changing evaluation scores or validation acceptance, manager and server request handling preserve the new field, and the PromptIter docs describe the user-facing usage.