### PR TITLE
{openclaw, internal/tool}: support code-driven runtime profiles

### DIFF
--- a/internal/tool/tool_test.go
+++ b/internal/tool/tool_test.go
@@ -105,6 +105,7 @@ func TestNamedTool_OriginalAndCloseAndName(t *testing.T) {
 	nt, ok := got[0].(*NamedTool)
 	require.True(t, ok, "expected NamedTool, got %T", got[0])
 	require.Equal(t, t1, nt.Original())
+	require.Equal(t, "fs", nt.ToolSetName())
 	require.Equal(t, "fs", nts.Name())
 	require.NoError(t, nts.Close())
 	require.True(t, base.closed, "underlying Close() not called")

--- a/internal/tool/toolset.go
+++ b/internal/tool/toolset.go
@@ -92,6 +92,11 @@ func (t *NamedTool) Original() tool.Tool {
 	return t.original
 }
 
+// ToolSetName returns the source ToolSet name for runtime policy checks.
+func (t *NamedTool) ToolSetName() string {
+	return t.name
+}
+
 // Call delegates to the original tool's Call method.
 func (t *NamedTool) Call(ctx context.Context, jsonArgs []byte) (any, error) {
 	if callable, ok := t.original.(tool.CallableTool); ok {

--- a/openclaw/EXTENDING.md
+++ b/openclaw/EXTENDING.md
@@ -498,6 +498,80 @@ agent:
   add_session_summary: true
 ```
 
+## Runtime profile providers (code-driven multi-tenancy)
+
+Use `runtime_profiles` in YAML for small static deployments. For custom
+OpenClaw binaries that already import private model, tool, or channel plugins,
+prefer code-driven profiles when profile data lives in a database, config
+center, or control plane.
+
+`app.MainWithOptions` keeps the normal OpenClaw CLI behavior while allowing the
+custom binary to pass runtime options:
+
+```go
+package main
+
+import (
+	"context"
+	"os"
+
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/app"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/runtimeprofile"
+
+	_ "example.com/your/openclaw/plugins/channels/wecom"
+	_ "example.com/your/openclaw/plugins/model"
+	_ "example.com/your/openclaw/plugins/tools"
+)
+
+func main() {
+	store := runtimeprofile.StoreFunc(func(ctx context.Context) (
+		runtimeprofile.Config,
+		error,
+	) {
+		return runtimeprofile.Config{
+			Profiles: map[string]runtimeprofile.Profile{
+				"tenant_alpha": {
+					AppName: "tenant-alpha",
+					Prompt: runtimeprofile.Prompt{
+						Instruction: "You are the tenant Alpha assistant.",
+					},
+					Skills: runtimeprofile.SkillPolicy{
+						Include: []string{"tenant-alpha-guide"},
+					},
+				},
+			},
+			Selectors: []runtimeprofile.Selector{
+				{
+					ProfileID: "tenant_alpha",
+					Channels:  []string{"wecom"},
+					Users:     []string{"replace-with-user-id"},
+				},
+			},
+		}, nil
+	})
+
+	os.Exit(app.MainWithOptions(
+		os.Args[1:],
+		app.WithRuntimeProfileStore(store, true),
+	))
+}
+```
+
+When `Selectors` are present, selection fails closed. Requests that do not
+match a selector, explicitly request a different profile, or select a missing
+profile return an error instead of falling back to the default profile. This is
+important for multi-tenant prompts, tools, credentials, workspaces, and
+knowledge indexes.
+
+Use `Tenants` selectors when the caller or custom channel populates
+`tenant_id` in the `openclaw.runtime_profile` request extension. Use
+`Channels`, `Users`, or `Sessions` when selection should come only from normal
+gateway metadata.
+
+If the application already owns the HTTP server, use
+`app.NewRuntimeWithOptions` and mount `rt.Gateway.Handler` instead of
+`app.MainWithOptions`.
+
 ## Memory backend plugin (centralized user memory storage)
 
 Memory backends implement `memory.Service` (from `trpc-agent-go`).

--- a/openclaw/EXTENDING.md
+++ b/openclaw/EXTENDING.md
@@ -598,6 +598,11 @@ OpenClaw hides search tools for other knowledge providers on that request;
 `Knowledge.Filter` remains the metadata filter sent to the selected knowledge
 provider.
 
+`Tools.ToolSets` uses the `name` values from the top-level `tools.toolsets`
+configuration. When it is non-empty, OpenClaw hides tools that do not come from
+one of the selected toolsets. `Tools.Include` and `Tools.Exclude` still apply
+to concrete tool names inside the selected toolsets.
+
 `Tools.CredentialRefs` maps a concrete tool name or toolset name to a
 credential reference. When `Credentials.AllowedRefs` is non-empty, OpenClaw
 hides tools mapped to references outside that allowlist. The selected

--- a/openclaw/EXTENDING.md
+++ b/openclaw/EXTENDING.md
@@ -531,12 +531,42 @@ func main() {
 		return runtimeprofile.Config{
 			Profiles: map[string]runtimeprofile.Profile{
 				"tenant_alpha": {
-					AppName: "tenant-alpha",
+					AppName:   "tenant-alpha",
+					ModelName: "gpt-5",
 					Prompt: runtimeprofile.Prompt{
 						Instruction: "You are the tenant Alpha assistant.",
 					},
+					Workspace: runtimeprofile.WorkspacePolicy{
+						Workdir: "/srv/openclaw/workspaces/tenant-alpha",
+						AllowedRoots: []string{
+							"/srv/openclaw/workspaces/tenant-alpha",
+						},
+					},
 					Skills: runtimeprofile.SkillPolicy{
+						Roots: []string{
+							"/srv/openclaw/skills/tenant-alpha",
+						},
 						Include: []string{"tenant-alpha-guide"},
+					},
+					Knowledge: runtimeprofile.KnowledgePolicy{
+						Indexes: []string{"tenant-alpha-faq"},
+						Filter: map[string]any{
+							"tenant": "tenant-alpha",
+						},
+					},
+					Tools: runtimeprofile.ToolPolicy{
+						ToolSets: []string{"tenant-alpha-tools"},
+						CredentialRefs: map[string]string{
+							"tenant-alpha-tools": "tenant-alpha-tools",
+						},
+					},
+					Credentials: runtimeprofile.CredentialPolicy{
+						AllowedRefs: []string{"tenant-alpha-tools"},
+					},
+					Isolation: runtimeprofile.IsolationPolicy{
+						Mode:         runtimeprofile.IsolationModeProfileCache,
+						AgentCache:   true,
+						ToolSetCache: true,
 					},
 				},
 			},
@@ -562,6 +592,23 @@ match a selector, explicitly request a different profile, or select a missing
 profile return an error instead of falling back to the default profile. This is
 important for multi-tenant prompts, tools, credentials, workspaces, and
 knowledge indexes.
+
+`Knowledge.Indexes` uses the `name` values from `knowledges.providers`.
+OpenClaw hides search tools for other knowledge providers on that request;
+`Knowledge.Filter` remains the metadata filter sent to the selected knowledge
+provider.
+
+`Tools.CredentialRefs` maps a concrete tool name or toolset name to a
+credential reference. When `Credentials.AllowedRefs` is non-empty, OpenClaw
+hides tools mapped to references outside that allowlist. The selected
+credential refs are also available in runtime state for custom tools that
+resolve secrets through a private credential provider.
+
+`Isolation.Mode` also has runtime behavior: `profile_cache` and `service`
+derive the run app name from the profile id when `AppName` is empty, isolating
+session, memory, and event filter keys. If your deployment needs a stronger
+process or sandbox boundary, read the isolation fields from runtime state in
+your custom runtime layer.
 
 Use `Tenants` selectors when the caller or custom channel populates
 `tenant_id` in the `openclaw.runtime_profile` request extension. Use

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -381,6 +381,110 @@ Notes:
     custom binary. See `openclaw/INTEGRATIONS.md` and
     `openclaw/EXTENDING.md`.
 
+## Runtime profiles
+
+Use `runtime_profiles` when one OpenClaw deployment serves multiple users,
+tenants, or product surfaces that need different runtime behavior. A profile
+can override prompt text, app name, model name, tool policy, knowledge policy,
+workspace roots, credentials, skill visibility, isolation mode, runtime state,
+and model request extras.
+
+Static profiles can be configured in YAML:
+
+```yaml
+tools:
+  toolsets:
+    - type: "mcp"
+      name: "tenant-alpha-tools"
+      config:
+        transport: "stdio"
+        command: "tenant-alpha-mcp"
+
+runtime_profiles:
+  default: default
+  profiles:
+    default:
+      app_name: "default"
+      prompt:
+        instruction: "You are a helpful assistant."
+    tenant_alpha:
+      app_name: "tenant-alpha"
+      prompt:
+        instruction: "You are the tenant Alpha assistant."
+      workspace:
+        workdir: "/srv/openclaw/workspaces/tenant-alpha"
+        allowed_roots:
+          - "/srv/openclaw/workspaces/tenant-alpha"
+      skills:
+        roots:
+          - "/srv/openclaw/skills/tenant-alpha"
+        include: ["tenant-alpha-guide"]
+      knowledge:
+        indexes: ["tenant-alpha-faq"]
+        filter:
+          tenant: "tenant-alpha"
+      tools:
+        toolsets: ["tenant-alpha-tools"]
+      isolation:
+        mode: "profile_cache"
+        agent_cache: true
+        toolset_cache: true
+  selectors:
+    - profile_id: "tenant_alpha"
+      channels: ["wecom"]
+      users: ["replace-with-user-id"]
+    - profile_id: "tenant_alpha"
+      tenants: ["tenant-alpha"]
+```
+
+Selectors are matched in order. All non-empty fields in a selector must match
+the request before its `profile_id` is selected. When selectors are configured,
+profile selection fails closed: a request with no matching selector, an
+explicit profile that conflicts with the selected profile, or a selector that
+points at a missing profile fails the run instead of silently falling back.
+
+`channels`, `users`, and `sessions` match gateway metadata. `tenants` matches
+the `tenant_id` field in the `openclaw.runtime_profile` request extension, so
+custom channels or callers that use tenant selectors must pass an extension
+like this:
+
+```json
+{
+  "extensions": {
+    "openclaw.runtime_profile": {
+      "tenant_id": "tenant-alpha"
+    }
+  }
+}
+```
+
+Profile `tools.toolsets` selects from the globally configured `tools.toolsets`
+entries by `name`. It does not create a toolset by itself; it hides tools from
+other named toolsets for that request. `tools.include` and `tools.exclude`
+still apply to concrete tool names.
+
+For custom OpenClaw binaries, load profiles from code by passing runtime
+options to `app.MainWithOptions`:
+
+```go
+func main() {
+	store := runtimeprofile.StoreFunc(func(ctx context.Context) (
+		runtimeprofile.Config,
+		error,
+	) {
+		return loadRuntimeProfilesFromDB(ctx)
+	})
+	os.Exit(app.MainWithOptions(
+		os.Args[1:],
+		app.WithRuntimeProfileStore(store, true),
+	))
+}
+```
+
+The store can read from a database, config center, or control plane. Returning
+`Selectors` in the loaded `runtimeprofile.Config` gives code-loaded profiles
+the same fail-closed selector semantics as YAML.
+
 ## Expose OpenClaw as an A2A sub-agent
 
 OpenClaw can publish a native A2A surface alongside the HTTP gateway.

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -459,9 +459,10 @@ like this:
 ```
 
 Profile `tools.toolsets` selects from the globally configured `tools.toolsets`
-entries by `name`. It does not create a toolset by itself; it hides tools from
-other named toolsets for that request. `tools.include` and `tools.exclude`
-still apply to concrete tool names.
+entries by `name`. It does not create a toolset by itself; it hides tools that
+do not come from the selected toolsets for that request. `tools.include` and
+`tools.exclude` still apply to concrete tool names inside the selected
+toolsets.
 
 Profile `knowledge.indexes` selects from `knowledges.providers` by `name`.
 Search tools for other knowledge providers are hidden for that request, and

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -463,6 +463,23 @@ entries by `name`. It does not create a toolset by itself; it hides tools from
 other named toolsets for that request. `tools.include` and `tools.exclude`
 still apply to concrete tool names.
 
+Profile `knowledge.indexes` selects from `knowledges.providers` by `name`.
+Search tools for other knowledge providers are hidden for that request, and
+`knowledge.filter` still applies as metadata filter criteria when querying the
+selected knowledge provider.
+
+Profile `tools.credential_refs` maps a concrete tool name or toolset `name` to
+a credential reference. When `credentials.allowed_refs` is set, tools mapped to
+other credential references are hidden for that request. Allowed credential
+references are also copied into runtime state so custom tools can resolve
+their own secrets through the deployment's credential provider.
+
+When `isolation.mode` is `profile_cache` or `service` and `app_name` is not
+set, OpenClaw uses the profile id as the run app name. That isolates session,
+memory, and event filter keys for the profile. Deployments that need a
+separate process or sandbox boundary can read the isolation fields from
+runtime state and enforce that boundary in their custom runtime.
+
 For custom OpenClaw binaries, load profiles from code by passing runtime
 options to `app.MainWithOptions`:
 

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -397,6 +397,14 @@ const (
 //
 // args should not include the program name.
 func Main(args []string) int {
+	return MainWithOptions(args)
+}
+
+// MainWithOptions runs the OpenClaw-like CLI with runtime options and returns
+// an exit code.
+//
+// args should not include the program name.
+func MainWithOptions(args []string, options ...RuntimeOption) int {
 	if len(args) > 0 {
 		switch args[0] {
 		case subcmdPairing:
@@ -417,7 +425,7 @@ func Main(args []string) int {
 	)
 	defer stop()
 
-	if err := run(ctx, args); err != nil {
+	if err := RunWithOptions(ctx, args, options...); err != nil {
 		var exitErr *exitError
 		if errors.As(err, &exitErr) {
 			if errors.Is(exitErr.Err, flag.ErrHelp) {
@@ -432,6 +440,15 @@ func Main(args []string) int {
 		return 1
 	}
 	return 0
+}
+
+// RunWithOptions runs OpenClaw until ctx is canceled or the runtime exits.
+func RunWithOptions(
+	ctx context.Context,
+	args []string,
+	options ...RuntimeOption,
+) error {
+	return run(ctx, args, options...)
 }
 
 type exitError struct {
@@ -1337,8 +1354,13 @@ func (r *Runtime) Close() error {
 	return errors.Join(errs...)
 }
 
-func run(ctx context.Context, args []string) error {
+func run(
+	ctx context.Context,
+	args []string,
+	options ...RuntimeOption,
+) error {
 	startedAt := time.Now()
+	runtimeOpts := buildRuntimeOptions(options)
 	opts, err := parseRunOptions(args)
 	if err != nil {
 		return err
@@ -1606,7 +1628,7 @@ func run(ctx context.Context, args []string) error {
 	runtimeProfileResolver, runtimeProfileCatalog, runtimeProfileRequired :=
 		runtimeProfileResolverFromOptions(
 			opts.RuntimeProfiles,
-			runtimeOptions{},
+			runtimeOpts,
 		)
 
 	gwOpts := makeGatewayOptions(

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -1296,6 +1296,7 @@ func TestMain_InspectDispatches(t *testing.T) {
 	t.Parallel()
 
 	require.Equal(t, 0, Main([]string{subcmdInspect}))
+	require.Equal(t, 0, MainWithOptions([]string{subcmdInspect}, nil))
 }
 
 func TestMain_BootstrapDispatches(t *testing.T) {

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -1284,6 +1284,17 @@ func TestMain_HelpReturnsUsageCode(t *testing.T) {
 	require.Equal(t, 0, Main([]string{"-h"}))
 }
 
+func TestMainWithOptionsAppliesRuntimeOptions(t *testing.T) {
+	t.Parallel()
+
+	observed := false
+	code := MainWithOptions([]string{"-h"}, func(*runtimeOptions) {
+		observed = true
+	})
+	require.Equal(t, 0, code)
+	require.True(t, observed)
+}
+
 func TestMain_HelpSkipsErrorLog(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/app/knowledge_tools.go
+++ b/openclaw/app/knowledge_tools.go
@@ -10,6 +10,7 @@
 package app
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -27,6 +28,11 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/registry"
+)
+
+const (
+	genericKnowledgeToolName = "knowledge_search"
+	knowledgeToolNameSuffix  = "_knowledge_search"
 )
 
 // knowledgeEntry is the parsed intermediate representation of a knowledge
@@ -134,7 +140,7 @@ func buildKnowledgeTools(
 			desc = "Search for relevant information in the knowledge base."
 		}
 		toolOpts := []knowledgetool.Option{
-			knowledgetool.WithToolName("knowledge_search"),
+			knowledgetool.WithToolName(genericKnowledgeToolName),
 			knowledgetool.WithToolDescription(desc),
 		}
 		if entry.maxResults > 0 {
@@ -143,13 +149,14 @@ func buildKnowledgeTools(
 				knowledgetool.WithMaxResults(entry.maxResults),
 			)
 		}
+		searchTool := knowledgetool.NewAgenticFilterSearchTool(
+			entry.kb,
+			nil,
+			toolOpts...,
+		)
 		return &knowledgeToolsBundle{
 			tools: []tool.Tool{
-				knowledgetool.NewAgenticFilterSearchTool(
-					entry.kb,
-					nil,
-					toolOpts...,
-				),
+				newKnowledgeIndexTool(names[0], searchTool),
 			},
 		}, nil
 	}
@@ -185,11 +192,12 @@ func buildKnowledgeTools(
 				knowledgetool.WithMaxResults(entry.maxResults),
 			)
 		}
-		tools = append(tools, knowledgetool.NewAgenticFilterSearchTool(
+		searchTool := knowledgetool.NewAgenticFilterSearchTool(
 			entry.kb,
 			nil,
 			toolOpts...,
-		))
+		)
+		tools = append(tools, newKnowledgeIndexTool(name, searchTool))
 	}
 
 	return &knowledgeToolsBundle{tools: tools}, nil
@@ -438,7 +446,96 @@ func knowledgeToolName(name string) string {
 	if base == "" {
 		base = "knowledge"
 	}
-	return base + "_knowledge_search"
+	return base + knowledgeToolNameSuffix
+}
+
+type knowledgeIndexBaseTool struct {
+	original  tool.Tool
+	indexName string
+}
+
+func newKnowledgeIndexTool(indexName string, original tool.Tool) tool.Tool {
+	if original == nil {
+		return nil
+	}
+	base := &knowledgeIndexBaseTool{
+		original:  original,
+		indexName: strings.TrimSpace(indexName),
+	}
+	_, callable := original.(tool.CallableTool)
+	_, streamable := original.(tool.StreamableTool)
+	switch {
+	case callable && streamable:
+		return &knowledgeIndexCallableStreamableTool{
+			knowledgeIndexBaseTool: base,
+		}
+	case streamable:
+		return &knowledgeIndexStreamableTool{
+			knowledgeIndexBaseTool: base,
+		}
+	case callable:
+		return &knowledgeIndexCallableTool{
+			knowledgeIndexBaseTool: base,
+		}
+	default:
+		return base
+	}
+}
+
+func (t *knowledgeIndexBaseTool) Declaration() *tool.Declaration {
+	return t.original.Declaration()
+}
+
+func (t *knowledgeIndexBaseTool) KnowledgeIndexName() string {
+	return t.indexName
+}
+
+func (t *knowledgeIndexBaseTool) SkipSummarization() bool {
+	type skipper interface{ SkipSummarization() bool }
+	if s, ok := t.original.(skipper); ok {
+		return s.SkipSummarization()
+	}
+	return false
+}
+
+type knowledgeIndexCallableTool struct {
+	*knowledgeIndexBaseTool
+}
+
+func (t *knowledgeIndexCallableTool) Call(
+	ctx context.Context,
+	jsonArgs []byte,
+) (any, error) {
+	return t.original.(tool.CallableTool).Call(ctx, jsonArgs)
+}
+
+type knowledgeIndexStreamableTool struct {
+	*knowledgeIndexBaseTool
+}
+
+func (t *knowledgeIndexStreamableTool) StreamableCall(
+	ctx context.Context,
+	jsonArgs []byte,
+) (*tool.StreamReader, error) {
+	return t.original.(tool.StreamableTool).StreamableCall(ctx, jsonArgs)
+}
+
+type knowledgeIndexCallableStreamableTool struct {
+	*knowledgeIndexBaseTool
+}
+
+func (t *knowledgeIndexCallableStreamableTool) Call(
+	ctx context.Context,
+	jsonArgs []byte,
+) (any, error) {
+	return t.original.(tool.CallableTool).Call(ctx, jsonArgs)
+}
+
+func (t *knowledgeIndexCallableStreamableTool) StreamableCall(
+	ctx context.Context,
+	jsonArgs []byte,
+) (*tool.StreamReader, error) {
+	return t.original.(tool.StreamableTool).StreamableCall(ctx, jsonArgs)
 }
 
 func sanitizeKnowledgeToolSegment(name string) string {

--- a/openclaw/app/knowledge_tools_test.go
+++ b/openclaw/app/knowledge_tools_test.go
@@ -22,10 +22,13 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
+	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/document"
 	openaiembedder "trpc.group/trpc-go/trpc-agent-go/knowledge/embedder/openai"
+	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/registry"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/runtimeprofile"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
 
@@ -85,6 +88,7 @@ vector_store:
 	require.NotNil(t, bundle)
 	require.Len(t, bundle.tools, 1)
 	require.Equal(t, "knowledge_search", bundle.tools[0].Declaration().Name)
+	require.Equal(t, "docs", knowledgeIndexName(bundle.tools[0]))
 }
 
 func TestBuildKnowledgeTools_MultipleKnowledgesCreateNamedTools(t *testing.T) {
@@ -103,6 +107,34 @@ vector_store:
 	require.Len(t, bundle.tools, 2)
 	require.Equal(t, "docs_kb_knowledge_search", bundle.tools[0].Declaration().Name)
 	require.Equal(t, "faq_knowledge_search", bundle.tools[1].Declaration().Name)
+	require.Equal(t, "Docs KB", knowledgeIndexName(bundle.tools[0]))
+	require.Equal(t, "FAQ", knowledgeIndexName(bundle.tools[1]))
+}
+
+func TestKnowledgeIndexToolPreservesToolCapabilities(t *testing.T) {
+	t.Parallel()
+
+	callable := newKnowledgeIndexTool(
+		"docs",
+		knowledgeCallableTool{name: "knowledge_search"},
+	)
+	require.Implements(t, (*tool.CallableTool)(nil), callable)
+	require.NotImplements(t, (*tool.StreamableTool)(nil), callable)
+	require.Equal(t, "docs", knowledgeIndexName(callable))
+
+	streamable := newKnowledgeIndexTool(
+		"stream",
+		knowledgeStreamableTool{name: "stream_search"},
+	)
+	require.Implements(t, (*tool.StreamableTool)(nil), streamable)
+	require.NotImplements(t, (*tool.CallableTool)(nil), streamable)
+
+	both := newKnowledgeIndexTool(
+		"both",
+		knowledgeCallableStreamableTool{name: "both_search"},
+	)
+	require.Implements(t, (*tool.CallableTool)(nil), both)
+	require.Implements(t, (*tool.StreamableTool)(nil), both)
 }
 
 func TestBuildKnowledgeTools_RejectsCollidingToolNames(t *testing.T) {
@@ -739,6 +771,41 @@ vector_store:
 	require.Contains(t, req.Tools, "faq_knowledge_search")
 }
 
+func TestNewAgent_RuntimeProfileKnowledgeIndexesFilter(t *testing.T) {
+	t.Parallel()
+
+	inmemory := `
+vector_store:
+  type: inmemory
+`
+	mdl := &captureRequestModel{}
+	agt, _, err := newAgent(mdl, agentConfig{
+		AppName:    "demo",
+		SkillsRoot: t.TempDir(),
+		StateDir:   t.TempDir(),
+		KnowledgesConfig: []knowledgeEntry{
+			builtinKnowledgeEntry(t, "docs", inmemory),
+			builtinKnowledgeEntry(t, "faq", inmemory),
+		},
+	}, nil, nil)
+	require.NoError(t, err)
+
+	runOpts := agent.NewRunOptions(runtimeprofile.RunOptions(
+		runtimeprofile.Profile{
+			Knowledge: runtimeprofile.KnowledgePolicy{
+				Indexes: []string{"docs"},
+			},
+		},
+	)...)
+	inv := agent.NewInvocation(
+		agent.WithInvocationMessage(model.NewUserMessage("hi")),
+		agent.WithInvocationRunOptions(runOpts),
+	)
+	req := runInvocationAndCapture(t, agt, mdl, inv)
+	require.Contains(t, req.Tools, "docs_knowledge_search")
+	require.NotContains(t, req.Tools, "faq_knowledge_search")
+}
+
 func TestNewAgent_InvalidKnowledgeConfigReturnsError(t *testing.T) {
 	t.Parallel()
 
@@ -756,4 +823,70 @@ vector_store:
 	}, nil, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), `knowledge "docs" config invalid`)
+}
+
+func knowledgeIndexName(tl tool.Tool) string {
+	named, ok := tl.(interface {
+		KnowledgeIndexName() string
+	})
+	if !ok {
+		return ""
+	}
+	return named.KnowledgeIndexName()
+}
+
+type knowledgeCallableTool struct {
+	name string
+}
+
+func (t knowledgeCallableTool) Declaration() *tool.Declaration {
+	return &tool.Declaration{Name: t.name}
+}
+
+func (t knowledgeCallableTool) Call(
+	context.Context,
+	[]byte,
+) (any, error) {
+	return "ok", nil
+}
+
+type knowledgeStreamableTool struct {
+	name string
+}
+
+func (t knowledgeStreamableTool) Declaration() *tool.Declaration {
+	return &tool.Declaration{Name: t.name}
+}
+
+func (t knowledgeStreamableTool) StreamableCall(
+	context.Context,
+	[]byte,
+) (*tool.StreamReader, error) {
+	stream := tool.NewStream(1)
+	stream.Writer.Close()
+	return stream.Reader, nil
+}
+
+type knowledgeCallableStreamableTool struct {
+	name string
+}
+
+func (t knowledgeCallableStreamableTool) Declaration() *tool.Declaration {
+	return &tool.Declaration{Name: t.name}
+}
+
+func (t knowledgeCallableStreamableTool) Call(
+	context.Context,
+	[]byte,
+) (any, error) {
+	return "ok", nil
+}
+
+func (t knowledgeCallableStreamableTool) StreamableCall(
+	context.Context,
+	[]byte,
+) (*tool.StreamReader, error) {
+	stream := tool.NewStream(1)
+	stream.Writer.Close()
+	return stream.Reader, nil
 }

--- a/openclaw/app/run_options_test.go
+++ b/openclaw/app/run_options_test.go
@@ -10,6 +10,7 @@
 package app
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math"
@@ -203,6 +204,39 @@ runtime_profiles:
 	resolver, err := runtimeprofile.NewResolver(*opts.RuntimeProfiles)
 	require.NoError(t, err)
 	require.NotNil(t, resolver)
+}
+
+func TestParseRunOptions_RuntimeProfilesSelectorsFailClosed(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	cfgPath := writeTempConfig(t, `
+runtime_profiles:
+  required: false
+  profiles:
+    retail:
+      app_name: retail-app
+  selectors:
+    - profile_id: retail
+      users: ["user-a"]
+`)
+
+	opts, err := parseRunOptions([]string{"-config", cfgPath})
+	require.NoError(t, err)
+	require.NotNil(t, opts.RuntimeProfiles)
+	require.False(t, opts.RuntimeProfiles.Required)
+
+	resolver, _, required := runtimeProfileResolverFromOptions(
+		opts.RuntimeProfiles,
+		runtimeOptions{},
+	)
+	require.True(t, required)
+	_, err = resolver.Resolve(
+		context.Background(),
+		runtimeprofile.Request{UserID: "user-b"},
+	)
+	require.ErrorIs(t, err, runtimeprofile.ErrProfileSelectorDenied)
 }
 
 func TestParseRunOptions_RuntimeProfilesRejectUnsupportedAgent(

--- a/openclaw/app/run_options_test.go
+++ b/openclaw/app/run_options_test.go
@@ -132,6 +132,11 @@ runtime_profiles:
         plan: vip
       model_request_extra:
         reasoning_effort: medium
+  selectors:
+    - profile_id: retail
+      channels: ["wecom"]
+      tenants: ["tenant-a"]
+      users: ["user-a"]
 `)
 
 	opts, err := parseRunOptions([]string{"-config", cfgPath})
@@ -186,8 +191,17 @@ runtime_profiles:
 	require.Equal(t, "sidecar", profile.Isolation.ServiceMode)
 	require.Equal(t, "vip", profile.State["plan"])
 	require.Equal(t, "medium", profile.ExtraModel["reasoning_effort"])
+	require.Equal(t, []runtimeprofile.Selector{
+		{
+			ProfileID: "retail",
+			Channels:  []string{"wecom"},
+			Tenants:   []string{"tenant-a"},
+			Users:     []string{"user-a"},
+		},
+	}, opts.RuntimeProfiles.Selectors)
 
-	resolver := runtimeprofile.NewMapResolver(*opts.RuntimeProfiles)
+	resolver, err := runtimeprofile.NewResolver(*opts.RuntimeProfiles)
+	require.NoError(t, err)
 	require.NotNil(t, resolver)
 }
 

--- a/openclaw/app/runtime_profile.go
+++ b/openclaw/app/runtime_profile.go
@@ -245,7 +245,7 @@ func runtimeProfileRequired(cfg *runtimeprofile.Config) bool {
 	if cfg == nil {
 		return false
 	}
-	return cfg.Required
+	return cfg.Required || len(cfg.Selectors) > 0
 }
 
 func validateRuntimeProfiles(cfg *runtimeprofile.Config) error {

--- a/openclaw/app/runtime_profile.go
+++ b/openclaw/app/runtime_profile.go
@@ -275,8 +275,15 @@ func runtimeProfileAppNames(cfg *runtimeprofile.Config) []string {
 		return nil
 	}
 	appNames := make([]string, 0, len(cfg.Profiles))
-	for _, profile := range cfg.Profiles {
-		appNames = appendUniqueAppNames(appNames, profile.AppName)
+	for key, profile := range cfg.Profiles {
+		id := strings.TrimSpace(profile.ID)
+		if id == "" {
+			profile.ID = strings.TrimSpace(key)
+		}
+		appNames = appendUniqueAppNames(
+			appNames,
+			runtimeprofile.RuntimeAppName(profile),
+		)
 	}
 	return appNames
 }

--- a/openclaw/app/runtime_profile_test.go
+++ b/openclaw/app/runtime_profile_test.go
@@ -363,6 +363,34 @@ func TestRuntimeProfileResolverFromInjectedResolver(t *testing.T) {
 	require.Equal(t, injectedProfileID, profile.ID)
 }
 
+func TestRuntimeProfileResolverFromConfigSelectorsRequired(t *testing.T) {
+	t.Parallel()
+
+	cfg := runtimeprofile.Config{
+		Profiles: map[string]runtimeprofile.Profile{
+			testRuntimeProfileID: {},
+		},
+		Selectors: []runtimeprofile.Selector{
+			{
+				ProfileID: testRuntimeProfileID,
+				Users:     []string{"user-a"},
+			},
+		},
+	}
+
+	resolver, _, required := runtimeProfileResolverFromOptions(
+		&cfg,
+		runtimeOptions{},
+	)
+
+	require.True(t, required)
+	_, err := resolver.Resolve(
+		context.Background(),
+		runtimeprofile.Request{UserID: "user-b"},
+	)
+	require.ErrorIs(t, err, runtimeprofile.ErrProfileSelectorDenied)
+}
+
 func TestBuildRuntimeOptionsIgnoresNilRuntimeProfileInputs(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/app/runtime_profile_test.go
+++ b/openclaw/app/runtime_profile_test.go
@@ -645,12 +645,25 @@ func TestRuntimeProfileAppNames(t *testing.T) {
 			"support": {
 				AppName: "support-app",
 			},
+			"isolated": {
+				Isolation: runtimeprofile.IsolationPolicy{
+					Mode: runtimeprofile.IsolationModeProfileCache,
+				},
+			},
+			"service-key": {
+				ID: "service-profile",
+				Isolation: runtimeprofile.IsolationPolicy{
+					Mode: runtimeprofile.IsolationModeService,
+				},
+			},
 		},
 	}
 
 	got := runtimeProfileAppNames(&cfg)
 	require.ElementsMatch(t, []string{
+		"isolated",
 		"retail-app",
+		"service-profile",
 		"support-app",
 	}, got)
 }

--- a/openclaw/runtimeprofile/copy.go
+++ b/openclaw/runtimeprofile/copy.go
@@ -38,6 +38,21 @@ func cloneProfile(profile Profile) Profile {
 	return profile
 }
 
+func cloneSelectors(selectors []Selector) []Selector {
+	if len(selectors) == 0 {
+		return nil
+	}
+	copied := make([]Selector, len(selectors))
+	for i, selector := range selectors {
+		copied[i] = selector
+		copied[i].Channels = copyStrings(selector.Channels)
+		copied[i].Tenants = copyStrings(selector.Tenants)
+		copied[i].Users = copyStrings(selector.Users)
+		copied[i].Sessions = copyStrings(selector.Sessions)
+	}
+	return copied
+}
+
 func copyStrings(values []string) []string {
 	if len(values) == 0 {
 		return nil

--- a/openclaw/runtimeprofile/profile.go
+++ b/openclaw/runtimeprofile/profile.go
@@ -23,6 +23,8 @@ import (
 )
 
 const (
+	runtimeStateKeyPrefix = "openclaw.profile."
+
 	// ExtensionKey is the request extension key used to select a profile.
 	ExtensionKey = "openclaw.runtime_profile"
 
@@ -217,26 +219,12 @@ func ValidateConfig(cfg Config) error {
 		return nil
 	}
 
-	effectiveIDs := make(map[string]string, len(cfg.Profiles))
+	knownIDs, err := profileIDAliases(cfg.Profiles)
+	if err != nil {
+		return err
+	}
 	for key, profile := range cfg.Profiles {
 		lookupID := strings.TrimSpace(key)
-		if lookupID == "" {
-			return fmt.Errorf("%w: empty profile key", ErrConfigInvalid)
-		}
-		effectiveID := strings.TrimSpace(profile.ID)
-		if effectiveID == "" {
-			effectiveID = lookupID
-		}
-		if previous, ok := effectiveIDs[effectiveID]; ok {
-			return fmt.Errorf(
-				"%w: duplicate profile id %q for %q and %q",
-				ErrConfigInvalid,
-				effectiveID,
-				previous,
-				lookupID,
-			)
-		}
-		effectiveIDs[effectiveID] = lookupID
 		if err := validateIsolationPolicy(profile.Isolation); err != nil {
 			return fmt.Errorf(
 				"%w: profiles.%s.%w",
@@ -252,19 +240,76 @@ func ValidateConfig(cfg Config) error {
 		if cfg.FallbackToDefault {
 			return fmt.Errorf("%w: fallback needs default", ErrConfigInvalid)
 		}
-		return validateSelectors(cfg.Selectors, effectiveIDs)
+		return validateSelectors(cfg.Selectors, knownIDs)
 	}
-	if _, ok := cfg.Profiles[defaultID]; ok {
-		return validateSelectors(cfg.Selectors, effectiveIDs)
-	}
-	if _, ok := effectiveIDs[defaultID]; ok {
-		return validateSelectors(cfg.Selectors, effectiveIDs)
+	if _, ok := knownIDs[defaultID]; ok {
+		return validateSelectors(cfg.Selectors, knownIDs)
 	}
 	return fmt.Errorf(
 		"%w: default profile %q is not configured",
 		ErrConfigInvalid,
 		defaultID,
 	)
+}
+
+func profileIDAliases(
+	profiles map[string]Profile,
+) (map[string]string, error) {
+	aliases := make(map[string]string, len(profiles)*2)
+	effectiveIDs := make(map[string]string, len(profiles))
+	for key, profile := range profiles {
+		lookupID := strings.TrimSpace(key)
+		if lookupID == "" {
+			return nil, fmt.Errorf("%w: empty profile key", ErrConfigInvalid)
+		}
+		effectiveID := strings.TrimSpace(profile.ID)
+		if effectiveID == "" {
+			effectiveID = lookupID
+		}
+		if previous, ok := effectiveIDs[effectiveID]; ok {
+			return nil, fmt.Errorf(
+				"%w: duplicate profile id %q for %q and %q",
+				ErrConfigInvalid,
+				effectiveID,
+				previous,
+				lookupID,
+			)
+		}
+		effectiveIDs[effectiveID] = lookupID
+		if err := addProfileIDAlias(
+			aliases,
+			lookupID,
+			effectiveID,
+		); err != nil {
+			return nil, err
+		}
+		if err := addProfileIDAlias(
+			aliases,
+			effectiveID,
+			effectiveID,
+		); err != nil {
+			return nil, err
+		}
+	}
+	return aliases, nil
+}
+
+func addProfileIDAlias(
+	aliases map[string]string,
+	alias string,
+	effectiveID string,
+) error {
+	if previous, ok := aliases[alias]; ok && previous != effectiveID {
+		return fmt.Errorf(
+			"%w: profile alias %q points to both %q and %q",
+			ErrConfigInvalid,
+			alias,
+			previous,
+			effectiveID,
+		)
+	}
+	aliases[alias] = effectiveID
+	return nil
 }
 
 func validateIsolationPolicy(policy IsolationPolicy) error {
@@ -395,7 +440,7 @@ func cloneRequest(req Request) Request {
 // AppNameFromContext returns the profile app name or the provided fallback.
 func AppNameFromContext(ctx context.Context, fallback string) string {
 	if profile, ok := ProfileFromContext(ctx); ok {
-		if appName := strings.TrimSpace(profile.AppName); appName != "" {
+		if appName := RuntimeAppName(profile); appName != "" {
 			return appName
 		}
 	}
@@ -407,7 +452,7 @@ func TraceFields(profile Profile) map[string]any {
 	fields := make(map[string]any)
 	addTraceString(fields, "profile_id", profile.ID)
 	addTraceString(fields, "profile_version", profile.Version)
-	addTraceString(fields, "profile_app_name", profile.AppName)
+	addTraceString(fields, "profile_app_name", RuntimeAppName(profile))
 	addTraceStrings(fields, "skill_include", profile.Skills.Include)
 	addTraceStrings(fields, "skill_exclude", profile.Skills.Exclude)
 	addTraceStrings(fields, "knowledge_indexes", profile.Knowledge.Indexes)
@@ -546,7 +591,7 @@ func (r *MapResolver) AppNames(context.Context) ([]string, error) {
 	out := make([]string, 0, len(r.cache))
 	seen := make(map[string]struct{}, len(r.cache))
 	for _, profile := range r.cache {
-		appName := strings.TrimSpace(profile.AppName)
+		appName := RuntimeAppName(profile)
 		if appName == "" {
 			continue
 		}
@@ -583,7 +628,7 @@ func ExtensionFromRequestExtensions(
 // RunOptions converts a profile to agent run options.
 func RunOptions(profile Profile) []agent.RunOption {
 	var opts []agent.RunOption
-	if appName := strings.TrimSpace(profile.AppName); appName != "" {
+	if appName := RuntimeAppName(profile); appName != "" {
 		opts = append(opts, agent.WithAppName(appName))
 	}
 	if agentName := strings.TrimSpace(profile.AgentName); agentName != "" {
@@ -604,7 +649,11 @@ func RunOptions(profile Profile) []agent.RunOption {
 			agent.WithGlobalInstruction(profile.Prompt.SystemPrompt),
 		)
 	}
-	if filter := toolPolicyFilter(profile.Tools); filter != nil {
+	if filter := toolVisibilityFilter(
+		profile.Tools,
+		profile.Knowledge,
+		profile.Credentials,
+	); filter != nil {
 		opts = append(opts, agent.WithToolFilter(filter))
 	}
 	if filter := toolNamesFilter(
@@ -635,8 +684,25 @@ func RunOptions(profile Profile) []agent.RunOption {
 	return opts
 }
 
+// RuntimeAppName returns the app name OpenClaw should use for a profile run.
+func RuntimeAppName(profile Profile) string {
+	appName := strings.TrimSpace(profile.AppName)
+	if appName != "" {
+		return appName
+	}
+	if !requiresProfileRuntimeIsolation(profile.Isolation) {
+		return ""
+	}
+	return strings.TrimSpace(profile.ID)
+}
+
+func requiresProfileRuntimeIsolation(policy IsolationPolicy) bool {
+	mode := strings.TrimSpace(string(policy.Mode))
+	return mode != "" && mode != string(IsolationModeShared)
+}
+
 func runtimeState(profile Profile) map[string]any {
-	state := copyAnyMap(profile.State)
+	state := userRuntimeState(profile.State)
 	if id := strings.TrimSpace(profile.ID); id != "" {
 		if state == nil {
 			state = make(map[string]any)
@@ -689,7 +755,10 @@ func runtimeState(profile Profile) map[string]any {
 		RuntimeStateToolSets,
 		profile.Tools.ToolSets,
 	)
-	if refs := copyStringMap(profile.Tools.CredentialRefs); len(refs) > 0 {
+	if refs := allowedCredentialRefs(
+		profile.Tools.CredentialRefs,
+		profile.Credentials.AllowedRefs,
+	); len(refs) > 0 {
 		if state == nil {
 			state = make(map[string]any)
 		}
@@ -718,6 +787,19 @@ func runtimeState(profile Profile) map[string]any {
 		RuntimeStateIsolationServiceMode,
 		profile.Isolation.ServiceMode,
 	)
+	return state
+}
+
+func userRuntimeState(values map[string]any) map[string]any {
+	state := copyAnyMap(values)
+	for key := range state {
+		if strings.HasPrefix(key, runtimeStateKeyPrefix) {
+			delete(state, key)
+		}
+	}
+	if len(state) == 0 {
+		return nil
+	}
 	return state
 }
 
@@ -809,6 +891,20 @@ func hasIsolationPolicy(policy IsolationPolicy) bool {
 		strings.TrimSpace(policy.ServiceMode) != ""
 }
 
+func toolVisibilityFilter(
+	toolPolicy ToolPolicy,
+	knowledgePolicy KnowledgePolicy,
+	credentialPolicy CredentialPolicy,
+) tool.FilterFunc {
+	tools := toolPolicyFilter(toolPolicy)
+	knowledge := knowledgeIndexFilter(knowledgePolicy.Indexes)
+	credentials := toolCredentialFilter(
+		toolPolicy.CredentialRefs,
+		credentialPolicy.AllowedRefs,
+	)
+	return allToolFilters(tools, knowledge, credentials)
+}
+
 func toolPolicyFilter(policy ToolPolicy) tool.FilterFunc {
 	names := toolNamesFilter(policy.Include, policy.Exclude)
 	toolSets := toolSetNamesFilter(policy.ToolSets)
@@ -822,6 +918,71 @@ func toolPolicyFilter(policy ToolPolicy) tool.FilterFunc {
 			return toolSets(ctx, tl) && names(ctx, tl)
 		}
 	}
+}
+
+func knowledgeIndexFilter(indexes []string) tool.FilterFunc {
+	indexes = cleanStrings(indexes)
+	if len(indexes) == 0 {
+		return nil
+	}
+	allowed := nameSet(indexes)
+	return func(_ context.Context, tl tool.Tool) bool {
+		index := sourceKnowledgeIndex(tl)
+		if index == "" {
+			return true
+		}
+		_, ok := allowed[index]
+		return ok
+	}
+}
+
+func toolCredentialFilter(
+	refs map[string]string,
+	allowedRefs []string,
+) tool.FilterFunc {
+	refs = cleanStringMap(refs)
+	if len(refs) == 0 {
+		return nil
+	}
+	allowed := nameSet(cleanStrings(allowedRefs))
+	return func(_ context.Context, tl tool.Tool) bool {
+		ref := credentialRefForTool(tl, refs)
+		if ref == "" || len(allowed) == 0 {
+			return true
+		}
+		_, ok := allowed[ref]
+		return ok
+	}
+}
+
+func credentialRefForTool(
+	tl tool.Tool,
+	refs map[string]string,
+) string {
+	if len(refs) == 0 || tl == nil || tl.Declaration() == nil {
+		return ""
+	}
+	if ref := strings.TrimSpace(refs[tl.Declaration().Name]); ref != "" {
+		return ref
+	}
+	if toolSetName := sourceToolSetName(tl); toolSetName != "" {
+		if ref := strings.TrimSpace(refs[toolSetName]); ref != "" {
+			return ref
+		}
+	}
+	return ""
+}
+
+type knowledgeIndexNamer interface {
+	KnowledgeIndexName() string
+}
+
+func sourceKnowledgeIndex(tl tool.Tool) string {
+	named, ok := tl.(knowledgeIndexNamer)
+	if !ok || named == nil {
+		return ""
+	}
+	return strings.TrimSpace(named.KnowledgeIndexName())
 }
 
 func toolNamesFilter(include []string, exclude []string) tool.FilterFunc {
@@ -877,6 +1038,26 @@ func sourceToolSetName(tl tool.Tool) string {
 	return strings.TrimSpace(named.ToolSetName())
 }
 
+func allToolFilters(filters ...tool.FilterFunc) tool.FilterFunc {
+	out := make([]tool.FilterFunc, 0, len(filters))
+	for _, filter := range filters {
+		if filter != nil {
+			out = append(out, filter)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return func(ctx context.Context, tl tool.Tool) bool {
+		for _, filter := range out {
+			if !filter(ctx, tl) {
+				return false
+			}
+		}
+		return true
+	}
+}
+
 func nameSet(names []string) map[string]struct{} {
 	if len(names) == 0 {
 		return nil
@@ -886,6 +1067,43 @@ func nameSet(names []string) map[string]struct{} {
 		set[name] = struct{}{}
 	}
 	return set
+}
+
+func cleanStringMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(values))
+	for key, value := range values {
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" || value == "" {
+			continue
+		}
+		out[key] = value
+	}
+	return out
+}
+
+func allowedCredentialRefs(
+	refs map[string]string,
+	allowedRefs []string,
+) map[string]string {
+	refs = cleanStringMap(refs)
+	if len(refs) == 0 {
+		return nil
+	}
+	allowed := nameSet(cleanStrings(allowedRefs))
+	if len(allowed) == 0 {
+		return refs
+	}
+	out := make(map[string]string, len(refs))
+	for key, ref := range refs {
+		if _, ok := allowed[ref]; ok {
+			out[key] = ref
+		}
+	}
+	return out
 }
 
 func cleanStrings(values []string) []string {

--- a/openclaw/runtimeprofile/profile.go
+++ b/openclaw/runtimeprofile/profile.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
@@ -74,6 +75,9 @@ const (
 // ErrProfileNotFound means a resolver could not find the selected profile.
 var ErrProfileNotFound = errors.New("runtime profile not found")
 
+// ErrProfileSelectorDenied means selector policy rejected profile resolution.
+var ErrProfileSelectorDenied = errors.New("runtime profile selector denied")
+
 // ErrConfigInvalid means a runtime profile config is internally inconsistent.
 var ErrConfigInvalid = errors.New("runtime profile config invalid")
 
@@ -93,6 +97,7 @@ type Config struct {
 	Required          bool               `yaml:"required,omitempty"`
 	FallbackToDefault bool               `yaml:"fallback_to_default,omitempty"`
 	Profiles          map[string]Profile `yaml:"profiles,omitempty"`
+	Selectors         []Selector         `yaml:"selectors,omitempty"`
 }
 
 // Request describes one profile resolution request.
@@ -194,6 +199,12 @@ type Profile struct {
 // modes without assuming any OpenClaw application-specific agent names.
 func ValidateConfig(cfg Config) error {
 	if len(cfg.Profiles) == 0 {
+		if len(cfg.Selectors) > 0 {
+			return fmt.Errorf(
+				"%w: selectors need configured profiles",
+				ErrConfigInvalid,
+			)
+		}
 		if cfg.Required {
 			return fmt.Errorf("%w: required profiles are empty", ErrConfigInvalid)
 		}
@@ -241,13 +252,13 @@ func ValidateConfig(cfg Config) error {
 		if cfg.FallbackToDefault {
 			return fmt.Errorf("%w: fallback needs default", ErrConfigInvalid)
 		}
-		return nil
+		return validateSelectors(cfg.Selectors, effectiveIDs)
 	}
 	if _, ok := cfg.Profiles[defaultID]; ok {
-		return nil
+		return validateSelectors(cfg.Selectors, effectiveIDs)
 	}
 	if _, ok := effectiveIDs[defaultID]; ok {
-		return nil
+		return validateSelectors(cfg.Selectors, effectiveIDs)
 	}
 	return fmt.Errorf(
 		"%w: default profile %q is not configured",
@@ -511,6 +522,44 @@ func (r *MapResolver) Resolve(
 	return cloneProfile(profile), nil
 }
 
+// ProfileIDs implements Catalog.
+func (r *MapResolver) ProfileIDs(context.Context) ([]string, error) {
+	if r == nil || len(r.cache) == 0 {
+		return nil, nil
+	}
+	out := make([]string, 0, len(r.cache))
+	for key := range r.cache {
+		if key.id == "" {
+			continue
+		}
+		out = append(out, key.id)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// AppNames implements Catalog.
+func (r *MapResolver) AppNames(context.Context) ([]string, error) {
+	if r == nil || len(r.cache) == 0 {
+		return nil, nil
+	}
+	out := make([]string, 0, len(r.cache))
+	seen := make(map[string]struct{}, len(r.cache))
+	for _, profile := range r.cache {
+		appName := strings.TrimSpace(profile.AppName)
+		if appName == "" {
+			continue
+		}
+		if _, ok := seen[appName]; ok {
+			continue
+		}
+		seen[appName] = struct{}{}
+		out = append(out, appName)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
 // ExtensionFromRequestExtensions reads the runtime-profile request extension.
 func ExtensionFromRequestExtensions(
 	extensions map[string]json.RawMessage,
@@ -555,10 +604,7 @@ func RunOptions(profile Profile) []agent.RunOption {
 			agent.WithGlobalInstruction(profile.Prompt.SystemPrompt),
 		)
 	}
-	if filter := toolNamesFilter(
-		profile.Tools.Include,
-		profile.Tools.Exclude,
-	); filter != nil {
+	if filter := toolPolicyFilter(profile.Tools); filter != nil {
 		opts = append(opts, agent.WithToolFilter(filter))
 	}
 	if filter := toolNamesFilter(
@@ -763,6 +809,21 @@ func hasIsolationPolicy(policy IsolationPolicy) bool {
 		strings.TrimSpace(policy.ServiceMode) != ""
 }
 
+func toolPolicyFilter(policy ToolPolicy) tool.FilterFunc {
+	names := toolNamesFilter(policy.Include, policy.Exclude)
+	toolSets := toolSetNamesFilter(policy.ToolSets)
+	switch {
+	case names == nil:
+		return toolSets
+	case toolSets == nil:
+		return names
+	default:
+		return func(ctx context.Context, tl tool.Tool) bool {
+			return toolSets(ctx, tl) && names(ctx, tl)
+		}
+	}
+}
+
 func toolNamesFilter(include []string, exclude []string) tool.FilterFunc {
 	include = cleanStrings(include)
 	exclude = cleanStrings(exclude)
@@ -786,6 +847,34 @@ func toolNamesFilter(include []string, exclude []string) tool.FilterFunc {
 		_, allowed := included[name]
 		return allowed
 	}
+}
+
+func toolSetNamesFilter(names []string) tool.FilterFunc {
+	names = cleanStrings(names)
+	if len(names) == 0 {
+		return nil
+	}
+	allowed := nameSet(names)
+	return func(_ context.Context, tl tool.Tool) bool {
+		name := sourceToolSetName(tl)
+		if name == "" {
+			return true
+		}
+		_, ok := allowed[name]
+		return ok
+	}
+}
+
+type toolSetNamer interface {
+	ToolSetName() string
+}
+
+func sourceToolSetName(tl tool.Tool) string {
+	named, ok := tl.(toolSetNamer)
+	if !ok || named == nil {
+		return ""
+	}
+	return strings.TrimSpace(named.ToolSetName())
 }
 
 func nameSet(names []string) map[string]struct{} {

--- a/openclaw/runtimeprofile/profile.go
+++ b/openclaw/runtimeprofile/profile.go
@@ -1019,7 +1019,7 @@ func toolSetNamesFilter(names []string) tool.FilterFunc {
 	return func(_ context.Context, tl tool.Tool) bool {
 		name := sourceToolSetName(tl)
 		if name == "" {
-			return true
+			return false
 		}
 		_, ok := allowed[name]
 		return ok

--- a/openclaw/runtimeprofile/profile_test.go
+++ b/openclaw/runtimeprofile/profile_test.go
@@ -466,7 +466,7 @@ func TestRunOptionsAppliesProfile(t *testing.T) {
 
 	require.True(t, runOpts.ToolFilter(
 		context.Background(),
-		testTool{name: testToolAllowed},
+		testTool{name: testToolAllowed, toolSetName: "mcp-retail"},
 	))
 	require.False(t, runOpts.ToolFilter(
 		context.Background(),
@@ -495,11 +495,11 @@ func TestRunOptionsFiltersProfileToolSets(t *testing.T) {
 		},
 	})...)
 
-	require.True(t, runOpts.ToolFilter(
+	require.False(t, runOpts.ToolFilter(
 		context.Background(),
 		testTool{name: "direct"},
 	))
-	require.True(t, runOpts.ToolFilter(
+	require.False(t, runOpts.ToolFilter(
 		context.Background(),
 		declarationOnlyTool{name: "direct"},
 	))

--- a/openclaw/runtimeprofile/profile_test.go
+++ b/openclaw/runtimeprofile/profile_test.go
@@ -37,11 +37,16 @@ func (nilDeclarationTool) Declaration() *tool.Declaration {
 }
 
 type testTool struct {
-	name string
+	name        string
+	toolSetName string
 }
 
 func (t testTool) Declaration() *tool.Declaration {
 	return &tool.Declaration{Name: t.name}
+}
+
+func (t testTool) ToolSetName() string {
+	return t.toolSetName
 }
 
 func TestMapResolver(t *testing.T) {
@@ -421,6 +426,44 @@ func TestRunOptionsAppliesProfile(t *testing.T) {
 	require.False(t, runOpts.ToolExecutionFilter(
 		context.Background(),
 		testTool{name: testToolOther},
+	))
+}
+
+func TestRunOptionsFiltersProfileToolSets(t *testing.T) {
+	t.Parallel()
+
+	runOpts := agent.NewRunOptions(RunOptions(Profile{
+		Tools: ToolPolicy{
+			ToolSets: []string{"crm"},
+		},
+	})...)
+
+	require.True(t, runOpts.ToolFilter(
+		context.Background(),
+		testTool{name: "direct"},
+	))
+	require.True(t, runOpts.ToolFilter(
+		context.Background(),
+		testTool{name: "crm_search", toolSetName: "crm"},
+	))
+	require.False(t, runOpts.ToolFilter(
+		context.Background(),
+		testTool{name: "erp_search", toolSetName: "erp"},
+	))
+
+	concreteOpts := agent.NewRunOptions(RunOptions(Profile{
+		Tools: ToolPolicy{
+			Include:  []string{"crm_search"},
+			ToolSets: []string{"crm"},
+		},
+	})...)
+	require.True(t, concreteOpts.ToolFilter(
+		context.Background(),
+		testTool{name: "crm_search", toolSetName: "crm"},
+	))
+	require.False(t, concreteOpts.ToolFilter(
+		context.Background(),
+		testTool{name: "crm_update", toolSetName: "crm"},
 	))
 }
 

--- a/openclaw/runtimeprofile/profile_test.go
+++ b/openclaw/runtimeprofile/profile_test.go
@@ -36,9 +36,18 @@ func (nilDeclarationTool) Declaration() *tool.Declaration {
 	return nil
 }
 
+type declarationOnlyTool struct {
+	name string
+}
+
+func (t declarationOnlyTool) Declaration() *tool.Declaration {
+	return &tool.Declaration{Name: t.name}
+}
+
 type testTool struct {
-	name        string
-	toolSetName string
+	name               string
+	toolSetName        string
+	knowledgeIndexName string
 }
 
 func (t testTool) Declaration() *tool.Declaration {
@@ -47,6 +56,10 @@ func (t testTool) Declaration() *tool.Declaration {
 
 func (t testTool) ToolSetName() string {
 	return t.toolSetName
+}
+
+func (t testTool) KnowledgeIndexName() string {
+	return t.knowledgeIndexName
 }
 
 func TestMapResolver(t *testing.T) {
@@ -249,6 +262,50 @@ func TestMapResolverEdgeCases(t *testing.T) {
 	require.Empty(t, profile)
 }
 
+func TestMapResolverCatalogEdgeCases(t *testing.T) {
+	t.Parallel()
+
+	var nilResolver *MapResolver
+	ids, err := nilResolver.ProfileIDs(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, ids)
+
+	appNames, err := nilResolver.AppNames(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, appNames)
+
+	resolver := NewMapResolver(Config{
+		Profiles: map[string]Profile{
+			"empty": {},
+			testProfileRetail: {
+				AppName: "retail-app",
+			},
+			"retail-alias": {
+				ID:      "retail-alias",
+				AppName: "retail-app",
+			},
+			"isolated": {
+				Isolation: IsolationPolicy{
+					Mode: IsolationModeProfileCache,
+				},
+			},
+		},
+	})
+
+	ids, err = resolver.ProfileIDs(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"empty",
+		"isolated",
+		testProfileRetail,
+		"retail-alias",
+	}, ids)
+
+	appNames, err = resolver.AppNames(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []string{"isolated", "retail-app"}, appNames)
+}
+
 func TestRunOptionsAppliesProfile(t *testing.T) {
 	t.Parallel()
 
@@ -444,6 +501,10 @@ func TestRunOptionsFiltersProfileToolSets(t *testing.T) {
 	))
 	require.True(t, runOpts.ToolFilter(
 		context.Background(),
+		declarationOnlyTool{name: "direct"},
+	))
+	require.True(t, runOpts.ToolFilter(
+		context.Background(),
 		testTool{name: "crm_search", toolSetName: "crm"},
 	))
 	require.False(t, runOpts.ToolFilter(
@@ -465,6 +526,129 @@ func TestRunOptionsFiltersProfileToolSets(t *testing.T) {
 		context.Background(),
 		testTool{name: "crm_update", toolSetName: "crm"},
 	))
+}
+
+func TestRunOptionsFiltersProfileKnowledgeIndexes(t *testing.T) {
+	t.Parallel()
+
+	runOpts := agent.NewRunOptions(RunOptions(Profile{
+		Knowledge: KnowledgePolicy{
+			Indexes: []string{"docs"},
+		},
+	})...)
+
+	require.True(t, runOpts.ToolFilter(
+		context.Background(),
+		declarationOnlyTool{name: "direct"},
+	))
+	require.True(t, runOpts.ToolFilter(
+		context.Background(),
+		testTool{
+			name:               "knowledge_search",
+			knowledgeIndexName: "docs",
+		},
+	))
+	require.False(t, runOpts.ToolFilter(
+		context.Background(),
+		testTool{
+			name:               "faq_knowledge_search",
+			knowledgeIndexName: "faq",
+		},
+	))
+}
+
+func TestRunOptionsFiltersProfileCredentialRefs(t *testing.T) {
+	t.Parallel()
+
+	runOpts := agent.NewRunOptions(RunOptions(Profile{
+		Tools: ToolPolicy{
+			CredentialRefs: map[string]string{
+				"crm":          "secret://tenant/crm",
+				"crm_delete":   "secret://tenant/admin",
+				"erp_search":   "secret://tenant/erp",
+				"empty_search": " ",
+			},
+		},
+		Credentials: CredentialPolicy{
+			AllowedRefs: []string{"secret://tenant/crm"},
+		},
+	})...)
+
+	require.True(t, runOpts.ToolFilter(
+		context.Background(),
+		declarationOnlyTool{name: "direct"},
+	))
+	require.True(t, runOpts.ToolFilter(
+		context.Background(),
+		testTool{name: "crm_search", toolSetName: "crm"},
+	))
+	require.False(t, runOpts.ToolFilter(
+		context.Background(),
+		testTool{name: "crm_delete", toolSetName: "crm"},
+	))
+	require.False(t, runOpts.ToolFilter(
+		context.Background(),
+		testTool{name: "erp_search"},
+	))
+	require.Equal(
+		t,
+		map[string]string{"crm": "secret://tenant/crm"},
+		runOpts.RuntimeState[RuntimeStateToolCredentialRefs],
+	)
+}
+
+func TestRunOptionsDropsReservedUserRuntimeState(t *testing.T) {
+	t.Parallel()
+
+	runOpts := agent.NewRunOptions(RunOptions(Profile{
+		ID: testProfileRetail,
+		State: map[string]any{
+			"plan":                         "vip",
+			RuntimeStateProfileID:          "spoofed",
+			RuntimeStateToolCredentialRefs: "secret://tenant/admin",
+		},
+		Tools: ToolPolicy{
+			CredentialRefs: map[string]string{
+				"crm_delete": "secret://tenant/admin",
+			},
+		},
+		Credentials: CredentialPolicy{
+			AllowedRefs: []string{"secret://tenant/crm"},
+		},
+	})...)
+
+	require.Equal(t, "vip", runOpts.RuntimeState["plan"])
+	require.Equal(
+		t,
+		testProfileRetail,
+		runOpts.RuntimeState[RuntimeStateProfileID],
+	)
+	require.NotContains(
+		t,
+		runOpts.RuntimeState,
+		RuntimeStateToolCredentialRefs,
+	)
+}
+
+func TestRunOptionsUsesProfileIDForRuntimeIsolation(t *testing.T) {
+	t.Parallel()
+
+	runOpts := agent.NewRunOptions(RunOptions(Profile{
+		ID: testProfileRetail,
+		Isolation: IsolationPolicy{
+			Mode: IsolationModeProfileCache,
+		},
+	})...)
+	require.Equal(t, testProfileRetail, runOpts.AppName)
+
+	runOpts = agent.NewRunOptions(RunOptions(Profile{
+		ID:      testProfileRetail,
+		AppName: "retail-app",
+		Isolation: IsolationPolicy{
+			Mode: IsolationModeProfileCache,
+		},
+	})...)
+	require.Equal(t, "retail-app", runOpts.AppName)
 }
 
 func TestRunOptionsEdgeCases(t *testing.T) {
@@ -689,6 +873,15 @@ func TestContextProfile(t *testing.T) {
 	profile, ok = ProfileFromContext(ctx)
 	require.True(t, ok)
 	require.Equal(t, "vip", profile.State["plan"])
+
+	ctx = WithProfile(context.Background(), Profile{
+		ID: testProfileRetail,
+		Isolation: IsolationPolicy{
+			Mode: IsolationModeProfileCache,
+		},
+	})
+	require.Equal(t, testProfileRetail, AppNameFromContext(ctx, "fallback"))
+
 	require.Equal(t, "fallback", AppNameFromContext(
 		context.Background(),
 		" fallback ",
@@ -784,6 +977,14 @@ func TestTraceFields(t *testing.T) {
 	require.Equal(t, 1, fields["skill_root_count"])
 	require.NotContains(t, fields, "workspace_workdir")
 	require.NotContains(t, fields, "workspace_allowed_roots")
+
+	fields = TraceFields(Profile{
+		ID: testProfileRetail,
+		Isolation: IsolationPolicy{
+			Mode: IsolationModeProfileCache,
+		},
+	})
+	require.Equal(t, testProfileRetail, fields["profile_app_name"])
 }
 
 func TestResolverFuncNil(t *testing.T) {

--- a/openclaw/runtimeprofile/selector.go
+++ b/openclaw/runtimeprofile/selector.go
@@ -74,6 +74,9 @@ func newSelectorResolver(
 			ErrConfigInvalid,
 		)
 	}
+	if len(aliases) == 0 {
+		aliases = resolverProfileAliases(base)
+	}
 	return &SelectorResolver{
 		base:      base,
 		selectors: cleaned,
@@ -125,6 +128,15 @@ func (r *SelectorResolver) Resolve(
 			profileID,
 		)
 	}
+	if resolvedID := strings.TrimSpace(profile.ID); resolvedID != "" &&
+		r.canonicalProfileID(resolvedID) != selected {
+		return Profile{}, fmt.Errorf(
+			"%w: selected profile %q resolved to profile %q",
+			ErrProfileSelectorDenied,
+			profileID,
+			resolvedID,
+		)
+	}
 	return profile, nil
 }
 
@@ -137,6 +149,32 @@ func (r *SelectorResolver) canonicalProfileID(profileID string) string {
 		return effectiveID
 	}
 	return profileID
+}
+
+func resolverProfileAliases(base Resolver) map[string]string {
+	resolver, ok := base.(*MapResolver)
+	if !ok || resolver == nil || len(resolver.profiles) == 0 {
+		return nil
+	}
+	aliases := make(map[string]string, len(resolver.profiles))
+	for alias, key := range resolver.profiles {
+		alias = strings.TrimSpace(alias)
+		if alias == "" {
+			continue
+		}
+		profile, ok := resolver.cache[key]
+		if !ok {
+			continue
+		}
+		effectiveID := strings.TrimSpace(profile.ID)
+		if effectiveID == "" {
+			effectiveID = strings.TrimSpace(key.id)
+		}
+		if effectiveID != "" {
+			aliases[alias] = effectiveID
+		}
+	}
+	return aliases
 }
 
 // ProfileIDs implements Catalog when the base resolver also implements it.

--- a/openclaw/runtimeprofile/selector.go
+++ b/openclaw/runtimeprofile/selector.go
@@ -32,6 +32,7 @@ type Selector struct {
 type SelectorResolver struct {
 	base      Resolver
 	selectors []Selector
+	aliases   map[string]string
 }
 
 // NewResolver creates a resolver from config, including selectors.
@@ -40,13 +41,25 @@ func NewResolver(cfg Config) (Resolver, error) {
 		return nil, err
 	}
 	base := NewMapResolver(cfg)
-	return NewSelectorResolver(base, cfg.Selectors)
+	aliases, err := profileIDAliases(cfg.Profiles)
+	if err != nil {
+		return nil, err
+	}
+	return newSelectorResolver(base, cfg.Selectors, aliases)
 }
 
 // NewSelectorResolver wraps base with selector-based profile selection.
 func NewSelectorResolver(
 	base Resolver,
 	selectors []Selector,
+) (Resolver, error) {
+	return newSelectorResolver(base, selectors, nil)
+}
+
+func newSelectorResolver(
+	base Resolver,
+	selectors []Selector,
+	aliases map[string]string,
 ) (Resolver, error) {
 	cleaned, err := cleanSelectors(selectors)
 	if err != nil {
@@ -64,6 +77,7 @@ func NewSelectorResolver(
 	return &SelectorResolver{
 		base:      base,
 		selectors: cleaned,
+		aliases:   copyStringMap(aliases),
 	}, nil
 }
 
@@ -82,8 +96,9 @@ func (r *SelectorResolver) Resolve(
 			ErrProfileSelectorDenied,
 		)
 	}
+	selected := r.canonicalProfileID(profileID)
 	if requested := strings.TrimSpace(req.ProfileID); requested != "" &&
-		requested != profileID {
+		r.canonicalProfileID(requested) != selected {
 		return Profile{}, fmt.Errorf(
 			"%w: requested profile %q does not match selector profile %q",
 			ErrProfileSelectorDenied,
@@ -91,7 +106,7 @@ func (r *SelectorResolver) Resolve(
 			profileID,
 		)
 	}
-	req.ProfileID = profileID
+	req.ProfileID = selected
 	profile, err := r.base.Resolve(ctx, req)
 	if errors.Is(err, ErrProfileNotFound) {
 		return Profile{}, fmt.Errorf(
@@ -111,6 +126,17 @@ func (r *SelectorResolver) Resolve(
 		)
 	}
 	return profile, nil
+}
+
+func (r *SelectorResolver) canonicalProfileID(profileID string) string {
+	profileID = strings.TrimSpace(profileID)
+	if r == nil || len(r.aliases) == 0 {
+		return profileID
+	}
+	if effectiveID, ok := r.aliases[profileID]; ok {
+		return effectiveID
+	}
+	return profileID
 }
 
 // ProfileIDs implements Catalog when the base resolver also implements it.
@@ -142,7 +168,11 @@ func SelectProfileID(
 ) string {
 	for _, selector := range selectors {
 		if selector.matches(req) {
-			return strings.TrimSpace(selector.ProfileID)
+			profileID, err := selector.runtimeProfileID()
+			if err != nil {
+				return ""
+			}
+			return profileID
 		}
 	}
 	return ""

--- a/openclaw/runtimeprofile/selector.go
+++ b/openclaw/runtimeprofile/selector.go
@@ -1,0 +1,255 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package runtimeprofile
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const selectorConfigPath = "runtime_profiles.selectors"
+
+// Selector maps request attributes to a runtime profile.
+type Selector struct {
+	ProfileID string   `yaml:"profile_id,omitempty"`
+	Profile   string   `yaml:"profile,omitempty"`
+	Channels  []string `yaml:"channels,omitempty"`
+	Tenants   []string `yaml:"tenants,omitempty"`
+	Users     []string `yaml:"users,omitempty"`
+	Sessions  []string `yaml:"sessions,omitempty"`
+}
+
+// SelectorResolver chooses a selector profile before delegating to base.
+type SelectorResolver struct {
+	base      Resolver
+	selectors []Selector
+}
+
+// NewResolver creates a resolver from config, including selectors.
+func NewResolver(cfg Config) (Resolver, error) {
+	if err := ValidateConfig(cfg); err != nil {
+		return nil, err
+	}
+	base := NewMapResolver(cfg)
+	return NewSelectorResolver(base, cfg.Selectors)
+}
+
+// NewSelectorResolver wraps base with selector-based profile selection.
+func NewSelectorResolver(
+	base Resolver,
+	selectors []Selector,
+) (Resolver, error) {
+	cleaned, err := cleanSelectors(selectors)
+	if err != nil {
+		return nil, err
+	}
+	if len(cleaned) == 0 {
+		return base, nil
+	}
+	if base == nil {
+		return nil, fmt.Errorf(
+			"%w: selectors need a base resolver",
+			ErrConfigInvalid,
+		)
+	}
+	return &SelectorResolver{
+		base:      base,
+		selectors: cleaned,
+	}, nil
+}
+
+// Resolve implements Resolver.
+func (r *SelectorResolver) Resolve(
+	ctx context.Context,
+	req Request,
+) (Profile, error) {
+	if r == nil || r.base == nil {
+		return Profile{}, nil
+	}
+	profileID := SelectProfileID(r.selectors, req)
+	if profileID == "" {
+		return Profile{}, fmt.Errorf(
+			"%w: no selector matched",
+			ErrProfileSelectorDenied,
+		)
+	}
+	if requested := strings.TrimSpace(req.ProfileID); requested != "" &&
+		requested != profileID {
+		return Profile{}, fmt.Errorf(
+			"%w: requested profile %q does not match selector profile %q",
+			ErrProfileSelectorDenied,
+			requested,
+			profileID,
+		)
+	}
+	req.ProfileID = profileID
+	profile, err := r.base.Resolve(ctx, req)
+	if errors.Is(err, ErrProfileNotFound) {
+		return Profile{}, fmt.Errorf(
+			"%w: selected profile %q was not found",
+			ErrProfileSelectorDenied,
+			profileID,
+		)
+	}
+	if err != nil {
+		return Profile{}, err
+	}
+	if !HasProfile(profile) {
+		return Profile{}, fmt.Errorf(
+			"%w: selected profile %q was empty",
+			ErrProfileSelectorDenied,
+			profileID,
+		)
+	}
+	return profile, nil
+}
+
+// ProfileIDs implements Catalog when the base resolver also implements it.
+func (r *SelectorResolver) ProfileIDs(
+	ctx context.Context,
+) ([]string, error) {
+	catalog, ok := r.base.(Catalog)
+	if !ok || catalog == nil {
+		return nil, nil
+	}
+	return catalog.ProfileIDs(ctx)
+}
+
+// AppNames implements Catalog when the base resolver also implements it.
+func (r *SelectorResolver) AppNames(
+	ctx context.Context,
+) ([]string, error) {
+	catalog, ok := r.base.(Catalog)
+	if !ok || catalog == nil {
+		return nil, nil
+	}
+	return catalog.AppNames(ctx)
+}
+
+// SelectProfileID returns the first selector profile that matches req.
+func SelectProfileID(
+	selectors []Selector,
+	req Request,
+) string {
+	for _, selector := range selectors {
+		if selector.matches(req) {
+			return strings.TrimSpace(selector.ProfileID)
+		}
+	}
+	return ""
+}
+
+func validateSelectors(
+	selectors []Selector,
+	known map[string]string,
+) error {
+	for i, selector := range selectors {
+		profileID, err := selector.runtimeProfileID()
+		if err != nil {
+			return selectorError(i, err)
+		}
+		if profileID == "" {
+			return selectorError(i, errors.New("profile_id is required"))
+		}
+		if !selector.hasCriteria() {
+			return selectorError(
+				i,
+				errors.New("at least one match field is required"),
+			)
+		}
+		if len(known) == 0 {
+			continue
+		}
+		if _, ok := known[profileID]; !ok {
+			return selectorError(
+				i,
+				fmt.Errorf("unknown profile_id %q", profileID),
+			)
+		}
+	}
+	return nil
+}
+
+func cleanSelectors(selectors []Selector) ([]Selector, error) {
+	if err := validateSelectors(selectors, nil); err != nil {
+		return nil, err
+	}
+	if len(selectors) == 0 {
+		return nil, nil
+	}
+	out := make([]Selector, 0, len(selectors))
+	for _, selector := range selectors {
+		profileID, _ := selector.runtimeProfileID()
+		out = append(out, Selector{
+			ProfileID: profileID,
+			Channels:  cleanStrings(selector.Channels),
+			Tenants:   cleanStrings(selector.Tenants),
+			Users:     cleanStrings(selector.Users),
+			Sessions:  cleanStrings(selector.Sessions),
+		})
+	}
+	return out, nil
+}
+
+func selectorError(index int, err error) error {
+	return fmt.Errorf(
+		"%w: %s[%d]: %w",
+		ErrConfigInvalid,
+		selectorConfigPath,
+		index,
+		err,
+	)
+}
+
+func (s Selector) runtimeProfileID() (string, error) {
+	profileID := strings.TrimSpace(s.ProfileID)
+	alias := strings.TrimSpace(s.Profile)
+	if profileID != "" && alias != "" && profileID != alias {
+		return "", fmt.Errorf(
+			"profile_id %q conflicts with profile %q",
+			profileID,
+			alias,
+		)
+	}
+	if profileID != "" {
+		return profileID, nil
+	}
+	return alias, nil
+}
+
+func (s Selector) hasCriteria() bool {
+	return len(cleanStrings(s.Channels)) > 0 ||
+		len(cleanStrings(s.Tenants)) > 0 ||
+		len(cleanStrings(s.Users)) > 0 ||
+		len(cleanStrings(s.Sessions)) > 0
+}
+
+func (s Selector) matches(req Request) bool {
+	return matchesSelectorValue(s.Channels, req.Channel) &&
+		matchesSelectorValue(s.Tenants, req.TenantID) &&
+		matchesSelectorValue(s.Users, req.UserID) &&
+		matchesSelectorValue(s.Sessions, req.SessionID)
+}
+
+func matchesSelectorValue(values []string, got string) bool {
+	values = cleanStrings(values)
+	if len(values) == 0 {
+		return true
+	}
+	got = strings.TrimSpace(got)
+	for _, value := range values {
+		if value == got {
+			return true
+		}
+	}
+	return false
+}

--- a/openclaw/runtimeprofile/selector_test.go
+++ b/openclaw/runtimeprofile/selector_test.go
@@ -87,6 +87,51 @@ func TestSelectorResolverRejectsMissAndMismatch(t *testing.T) {
 	require.ErrorIs(t, err, ErrProfileSelectorDenied)
 }
 
+func TestSelectorResolverAllowsProfileKeyAlias(t *testing.T) {
+	t.Parallel()
+
+	const (
+		profileKey = "tenant_alpha"
+		profileID  = "tenant-alpha-v2"
+	)
+
+	resolver, err := NewResolver(Config{
+		Profiles: map[string]Profile{
+			profileKey: {
+				ID:      profileID,
+				AppName: "tenant-alpha-app",
+			},
+		},
+		Selectors: []Selector{
+			{
+				ProfileID: profileKey,
+				Tenants:   []string{"tenant-a"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	profile, err := resolver.Resolve(context.Background(), Request{
+		ProfileID: profileID,
+		TenantID:  "tenant-a",
+	})
+	require.NoError(t, err)
+	require.Equal(t, profileID, profile.ID)
+	require.Equal(t, "tenant-alpha-app", profile.AppName)
+}
+
+func TestSelectProfileIDUsesProfileAlias(t *testing.T) {
+	t.Parallel()
+
+	profileID := SelectProfileID([]Selector{
+		{
+			Profile: testProfileRetail,
+			Users:   []string{"user-a"},
+		},
+	}, Request{UserID: "user-a"})
+	require.Equal(t, testProfileRetail, profileID)
+}
+
 func TestSelectorResolverRejectsStaleSelectorProfile(t *testing.T) {
 	t.Parallel()
 
@@ -107,6 +152,80 @@ func TestSelectorResolverRejectsStaleSelectorProfile(t *testing.T) {
 	_, err = resolver.Resolve(context.Background(), Request{UserID: "user-a"})
 	require.ErrorIs(t, err, ErrProfileSelectorDenied)
 	require.False(t, errors.Is(err, ErrProfileNotFound))
+}
+
+func TestSelectorResolverPropagatesBaseError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("resolver down")
+	base := ResolverFunc(func(
+		context.Context,
+		Request,
+	) (Profile, error) {
+		return Profile{}, wantErr
+	})
+	resolver, err := NewSelectorResolver(base, []Selector{
+		{
+			ProfileID: testProfileRetail,
+			Users:     []string{"user-a"},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = resolver.Resolve(context.Background(), Request{UserID: "user-a"})
+	require.ErrorIs(t, err, wantErr)
+}
+
+func TestSelectorResolverRejectsEmptySelectedProfile(t *testing.T) {
+	t.Parallel()
+
+	base := ResolverFunc(func(
+		context.Context,
+		Request,
+	) (Profile, error) {
+		return Profile{}, nil
+	})
+	resolver, err := NewSelectorResolver(base, []Selector{
+		{
+			ProfileID: testProfileRetail,
+			Users:     []string{"user-a"},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = resolver.Resolve(context.Background(), Request{UserID: "user-a"})
+	require.ErrorIs(t, err, ErrProfileSelectorDenied)
+	require.Contains(t, err.Error(), "selected profile")
+}
+
+func TestSelectorResolverNilBranches(t *testing.T) {
+	t.Parallel()
+
+	var nilResolver *SelectorResolver
+	profile, err := nilResolver.Resolve(context.Background(), Request{})
+	require.NoError(t, err)
+	require.Empty(t, profile)
+
+	resolver := &SelectorResolver{
+		base: ResolverFunc(func(
+			context.Context,
+			Request,
+		) (Profile, error) {
+			return Profile{ID: testProfileRetail}, nil
+		}),
+		selectors: []Selector{
+			{
+				ProfileID: testProfileRetail,
+				Users:     []string{"user-a"},
+			},
+		},
+	}
+	ids, err := resolver.ProfileIDs(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, ids)
+	appNames, err := resolver.AppNames(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, appNames)
 }
 
 func TestSelectorResolverRejectsMissingBase(t *testing.T) {
@@ -144,6 +263,18 @@ func TestValidateConfigRejectsInvalidSelectors(t *testing.T) {
 				},
 			},
 			wantErr: `unknown profile_id "retail"`,
+		},
+		{
+			name: "missing profile id",
+			cfg: Config{
+				Profiles: map[string]Profile{
+					testProfileDefault: {},
+				},
+				Selectors: []Selector{
+					{Users: []string{"user-a"}},
+				},
+			},
+			wantErr: "profile_id is required",
 		},
 		{
 			name: "missing criteria",
@@ -199,6 +330,34 @@ func TestValidateConfigRejectsInvalidSelectors(t *testing.T) {
 			require.Contains(t, err.Error(), tc.wantErr)
 		})
 	}
+}
+
+func TestNewResolverRejectsInvalidConfig(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewResolver(Config{
+		Default: "missing",
+		Profiles: map[string]Profile{
+			testProfileDefault: {},
+		},
+	})
+	require.ErrorIs(t, err, ErrConfigInvalid)
+}
+
+func TestNewSelectorResolverRejectsInvalidSelectors(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewSelectorResolver(
+		ResolverFunc(func(
+			context.Context,
+			Request,
+		) (Profile, error) {
+			return Profile{}, nil
+		}),
+		[]Selector{{Users: []string{"user-a"}}},
+	)
+	require.ErrorIs(t, err, ErrConfigInvalid)
+	require.Contains(t, err.Error(), "profile_id is required")
 }
 
 func TestSelectorResolverDelegatesCatalog(t *testing.T) {

--- a/openclaw/runtimeprofile/selector_test.go
+++ b/openclaw/runtimeprofile/selector_test.go
@@ -1,0 +1,230 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package runtimeprofile
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelectorResolverSelectsProfile(t *testing.T) {
+	t.Parallel()
+
+	resolver, err := NewResolver(Config{
+		Default: testProfileDefault,
+		Profiles: map[string]Profile{
+			testProfileDefault: {
+				AppName: "default-app",
+			},
+			testProfileRetail: {
+				AppName: "retail-app",
+				Prompt: Prompt{
+					Instruction: "help retail customers",
+				},
+			},
+		},
+		Selectors: []Selector{
+			{
+				ProfileID: testProfileRetail,
+				Channels:  []string{"wecom"},
+				Tenants:   []string{"tenant-a"},
+				Users:     []string{"user-a"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	profile, err := resolver.Resolve(context.Background(), Request{
+		Channel:  "wecom",
+		TenantID: "tenant-a",
+		UserID:   "user-a",
+	})
+	require.NoError(t, err)
+	require.Equal(t, testProfileRetail, profile.ID)
+	require.Equal(t, "help retail customers", profile.Prompt.Instruction)
+}
+
+func TestSelectorResolverRejectsMissAndMismatch(t *testing.T) {
+	t.Parallel()
+
+	resolver, err := NewResolver(Config{
+		Profiles: map[string]Profile{
+			testProfileDefault: {},
+			testProfileRetail:  {},
+		},
+		Selectors: []Selector{
+			{
+				ProfileID: testProfileRetail,
+				Channels:  []string{"wecom"},
+				Users:     []string{"user-a"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = resolver.Resolve(context.Background(), Request{
+		Channel: "wecom",
+		UserID:  "user-b",
+	})
+	require.ErrorIs(t, err, ErrProfileSelectorDenied)
+	require.False(t, errors.Is(err, ErrProfileNotFound))
+
+	_, err = resolver.Resolve(context.Background(), Request{
+		Channel:   "wecom",
+		ProfileID: testProfileDefault,
+		UserID:    "user-a",
+	})
+	require.ErrorIs(t, err, ErrProfileSelectorDenied)
+}
+
+func TestSelectorResolverRejectsStaleSelectorProfile(t *testing.T) {
+	t.Parallel()
+
+	base := ResolverFunc(func(
+		context.Context,
+		Request,
+	) (Profile, error) {
+		return Profile{}, ErrProfileNotFound
+	})
+	resolver, err := NewSelectorResolver(base, []Selector{
+		{
+			ProfileID: testProfileRetail,
+			Users:     []string{"user-a"},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = resolver.Resolve(context.Background(), Request{UserID: "user-a"})
+	require.ErrorIs(t, err, ErrProfileSelectorDenied)
+	require.False(t, errors.Is(err, ErrProfileNotFound))
+}
+
+func TestSelectorResolverRejectsMissingBase(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewSelectorResolver(nil, []Selector{
+		{
+			ProfileID: testProfileRetail,
+			Users:     []string{"user-a"},
+		},
+	})
+	require.ErrorIs(t, err, ErrConfigInvalid)
+	require.Contains(t, err.Error(), "selectors need a base resolver")
+}
+
+func TestValidateConfigRejectsInvalidSelectors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		cfg     Config
+		wantErr string
+	}{
+		{
+			name: "unknown profile",
+			cfg: Config{
+				Profiles: map[string]Profile{
+					testProfileDefault: {},
+				},
+				Selectors: []Selector{
+					{
+						ProfileID: testProfileRetail,
+						Users:     []string{"user-a"},
+					},
+				},
+			},
+			wantErr: `unknown profile_id "retail"`,
+		},
+		{
+			name: "missing criteria",
+			cfg: Config{
+				Profiles: map[string]Profile{
+					testProfileDefault: {},
+				},
+				Selectors: []Selector{
+					{ProfileID: testProfileDefault},
+				},
+			},
+			wantErr: "at least one match field is required",
+		},
+		{
+			name: "conflicting aliases",
+			cfg: Config{
+				Profiles: map[string]Profile{
+					testProfileDefault: {},
+					testProfileRetail:  {},
+				},
+				Selectors: []Selector{
+					{
+						ProfileID: testProfileDefault,
+						Profile:   testProfileRetail,
+						Users:     []string{"user-a"},
+					},
+				},
+			},
+			wantErr: `profile_id "default" conflicts with profile "retail"`,
+		},
+		{
+			name: "selectors without profiles",
+			cfg: Config{
+				Selectors: []Selector{
+					{
+						ProfileID: testProfileDefault,
+						Users:     []string{"user-a"},
+					},
+				},
+			},
+			wantErr: "selectors need configured profiles",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidateConfig(tc.cfg)
+			require.Error(t, err)
+			require.ErrorIs(t, err, ErrConfigInvalid)
+			require.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+func TestSelectorResolverDelegatesCatalog(t *testing.T) {
+	t.Parallel()
+
+	resolver, err := NewResolver(Config{
+		Profiles: map[string]Profile{
+			testProfileRetail: {
+				AppName: "retail-app",
+			},
+		},
+		Selectors: []Selector{
+			{
+				ProfileID: testProfileRetail,
+				Users:     []string{"user-a"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	catalog, ok := resolver.(Catalog)
+	require.True(t, ok)
+	ids, err := catalog.ProfileIDs(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []string{testProfileRetail}, ids)
+	appNames, err := catalog.AppNames(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []string{"retail-app"}, appNames)
+}

--- a/openclaw/runtimeprofile/selector_test.go
+++ b/openclaw/runtimeprofile/selector_test.go
@@ -118,6 +118,14 @@ func TestSelectorResolverAllowsProfileKeyAlias(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, profileID, profile.ID)
 	require.Equal(t, "tenant-alpha-app", profile.AppName)
+
+	profile, err = resolver.Resolve(context.Background(), Request{
+		ProfileID: profileKey,
+		TenantID:  "tenant-a",
+	})
+	require.NoError(t, err)
+	require.Equal(t, profileID, profile.ID)
+	require.Equal(t, "tenant-alpha-app", profile.AppName)
 }
 
 func TestSelectProfileIDUsesProfileAlias(t *testing.T) {

--- a/openclaw/runtimeprofile/selector_test.go
+++ b/openclaw/runtimeprofile/selector_test.go
@@ -126,6 +126,30 @@ func TestSelectorResolverAllowsProfileKeyAlias(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, profileID, profile.ID)
 	require.Equal(t, "tenant-alpha-app", profile.AppName)
+
+	base := NewMapResolver(Config{
+		Profiles: map[string]Profile{
+			profileKey: {
+				ID:      profileID,
+				AppName: "tenant-alpha-app",
+			},
+		},
+	})
+	resolver, err = NewSelectorResolver(base, []Selector{
+		{
+			ProfileID: profileKey,
+			Tenants:   []string{"tenant-a"},
+		},
+	})
+	require.NoError(t, err)
+
+	profile, err = resolver.Resolve(context.Background(), Request{
+		ProfileID: profileKey,
+		TenantID:  "tenant-a",
+	})
+	require.NoError(t, err)
+	require.Equal(t, profileID, profile.ID)
+	require.Equal(t, "tenant-alpha-app", profile.AppName)
 }
 
 func TestSelectProfileIDUsesProfileAlias(t *testing.T) {
@@ -160,6 +184,56 @@ func TestSelectorResolverRejectsStaleSelectorProfile(t *testing.T) {
 	_, err = resolver.Resolve(context.Background(), Request{UserID: "user-a"})
 	require.ErrorIs(t, err, ErrProfileSelectorDenied)
 	require.False(t, errors.Is(err, ErrProfileNotFound))
+}
+
+func TestSelectorResolverRejectsFallbackProfile(t *testing.T) {
+	t.Parallel()
+
+	base := NewMapResolver(Config{
+		Default:           testProfileDefault,
+		FallbackToDefault: true,
+		Profiles: map[string]Profile{
+			testProfileDefault: {
+				AppName: "default-app",
+			},
+		},
+	})
+	resolver, err := NewSelectorResolver(base, []Selector{
+		{
+			ProfileID: testProfileRetail,
+			Users:     []string{"user-a"},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = resolver.Resolve(context.Background(), Request{UserID: "user-a"})
+	require.ErrorIs(t, err, ErrProfileSelectorDenied)
+	require.Contains(t, err.Error(), "resolved to profile")
+}
+
+func TestSelectorResolverAllowsCustomProfileWithoutID(t *testing.T) {
+	t.Parallel()
+
+	base := ResolverFunc(func(
+		context.Context,
+		Request,
+	) (Profile, error) {
+		return Profile{AppName: "custom-app"}, nil
+	})
+	resolver, err := NewSelectorResolver(base, []Selector{
+		{
+			ProfileID: testProfileRetail,
+			Users:     []string{"user-a"},
+		},
+	})
+	require.NoError(t, err)
+
+	profile, err := resolver.Resolve(
+		context.Background(),
+		Request{UserID: "user-a"},
+	)
+	require.NoError(t, err)
+	require.Equal(t, "custom-app", profile.AppName)
 }
 
 func TestSelectorResolverPropagatesBaseError(t *testing.T) {

--- a/openclaw/runtimeprofile/store.go
+++ b/openclaw/runtimeprofile/store.go
@@ -100,9 +100,6 @@ func (r *CachedResolver) Reload(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if err := ValidateConfig(cfg); err != nil {
-		return err
-	}
 	resolver, err := NewResolver(cfg)
 	if err != nil {
 		return err
@@ -222,8 +219,12 @@ func appNames(cfg Config) []string {
 	}
 	out := make([]string, 0, len(cfg.Profiles))
 	seen := make(map[string]struct{}, len(cfg.Profiles))
-	for _, profile := range cfg.Profiles {
-		appName := strings.TrimSpace(profile.AppName)
+	for key, profile := range cfg.Profiles {
+		id := strings.TrimSpace(profile.ID)
+		if id == "" {
+			profile.ID = strings.TrimSpace(key)
+		}
+		appName := RuntimeAppName(profile)
 		if appName == "" {
 			continue
 		}

--- a/openclaw/runtimeprofile/store.go
+++ b/openclaw/runtimeprofile/store.go
@@ -67,7 +67,7 @@ func (s StaticStore) AppNames(context.Context) ([]string, error) {
 type CachedResolver struct {
 	mu       sync.RWMutex
 	store    Store
-	resolver *MapResolver
+	resolver Resolver
 	loaded   bool
 }
 
@@ -103,7 +103,10 @@ func (r *CachedResolver) Reload(ctx context.Context) error {
 	if err := ValidateConfig(cfg); err != nil {
 		return err
 	}
-	resolver := NewMapResolver(cfg)
+	resolver, err := NewResolver(cfg)
+	if err != nil {
+		return err
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.resolver = resolver
@@ -142,7 +145,7 @@ func (r *CachedResolver) AppNames(ctx context.Context) ([]string, error) {
 
 func (r *CachedResolver) resolverForRead(
 	ctx context.Context,
-) (*MapResolver, error) {
+) (Resolver, error) {
 	if r == nil {
 		return nil, nil
 	}
@@ -176,6 +179,7 @@ func (r *CachedResolver) configForCatalog(
 
 func cloneConfig(cfg Config) Config {
 	cfg.Default = strings.TrimSpace(cfg.Default)
+	cfg.Selectors = cloneSelectors(cfg.Selectors)
 	if len(cfg.Profiles) == 0 {
 		cfg.Profiles = nil
 		return cfg

--- a/openclaw/runtimeprofile/store_test.go
+++ b/openclaw/runtimeprofile/store_test.go
@@ -135,6 +135,11 @@ func TestProfileCatalog(t *testing.T) {
 			"support-alias": {
 				AppName: "support-app",
 			},
+			"isolated": {
+				Isolation: IsolationPolicy{
+					Mode: IsolationModeProfileCache,
+				},
+			},
 		},
 	}
 
@@ -142,6 +147,7 @@ func TestProfileCatalog(t *testing.T) {
 	ids, err := store.ProfileIDs(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, []string{
+		"isolated",
 		testProfileRetail,
 		"support",
 		"support-alias",
@@ -150,6 +156,7 @@ func TestProfileCatalog(t *testing.T) {
 	appNames, err := store.AppNames(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, []string{
+		"isolated",
 		"retail-app",
 		"support-app",
 	}, appNames)
@@ -158,6 +165,7 @@ func TestProfileCatalog(t *testing.T) {
 	appNames, err = resolver.AppNames(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, []string{
+		"isolated",
 		"retail-app",
 		"support-app",
 	}, appNames)
@@ -165,10 +173,49 @@ func TestProfileCatalog(t *testing.T) {
 	ids, err = resolver.ProfileIDs(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, []string{
+		"isolated",
 		testProfileRetail,
 		"support",
 		"support-alias",
 	}, ids)
+}
+
+func TestStaticStoreCopiesSelectors(t *testing.T) {
+	t.Parallel()
+
+	store := StaticStore{Config: Config{
+		Profiles: map[string]Profile{
+			testProfileRetail: {},
+		},
+		Selectors: []Selector{
+			{
+				ProfileID: testProfileRetail,
+				Channels:  []string{"wecom"},
+				Tenants:   []string{"tenant-a"},
+				Users:     []string{"user-a"},
+				Sessions:  []string{"session-a"},
+			},
+		},
+	}}
+
+	cfg, err := store.Load(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []string{"wecom"}, cfg.Selectors[0].Channels)
+	require.Equal(t, []string{"tenant-a"}, cfg.Selectors[0].Tenants)
+	require.Equal(t, []string{"user-a"}, cfg.Selectors[0].Users)
+	require.Equal(t, []string{"session-a"}, cfg.Selectors[0].Sessions)
+
+	cfg.Selectors[0].Channels[0] = "changed"
+	cfg.Selectors[0].Tenants[0] = "changed"
+	cfg.Selectors[0].Users[0] = "changed"
+	cfg.Selectors[0].Sessions[0] = "changed"
+
+	cfg, err = store.Load(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []string{"wecom"}, cfg.Selectors[0].Channels)
+	require.Equal(t, []string{"tenant-a"}, cfg.Selectors[0].Tenants)
+	require.Equal(t, []string{"user-a"}, cfg.Selectors[0].Users)
+	require.Equal(t, []string{"session-a"}, cfg.Selectors[0].Sessions)
 }
 
 func TestCachedResolverCatalogErrorsAndNilBranches(t *testing.T) {


### PR DESCRIPTION
## Summary
- add code-driven OpenClaw runtime profile entry points via MainWithOptions and RunWithOptions
- add runtime profile selectors with fail-closed matching and catalog support
- support profile toolset allowlists and document YAML/code multi-tenant usage

## Tests
- go test ./runtimeprofile -run 'TestRunOptions|TestSelector|TestValidateConfigRejectsInvalidSelectors' -count=1\n- go test ./app -run 'TestParseRunOptions_RuntimeProfilesConfig|TestRuntimeProfileResolver|TestBuildRuntimeProfileRunOptionResolver|TestMain_InspectDispatches' -count=1\n- go test ./internal/tool -run 'TestNamedTool' -count=1\n\n## Notes\n- Full ./runtimeprofile ./app currently has existing environment-sensitive failures in policy_test.go and agent_prompts_test.go.