### PR TITLE
session/mysql: add TDSQL distributed sharding support

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -33,6 +33,7 @@ nav:
           - SQLite Session: session/sqlite.md
           - Redis Session: session/redis.md
           - MySQL Session: session/mysql.md
+          - TDSQL Session: session/tdsql.md
           - PostgreSQL Session: session/postgres.md
           - PGVector Session: session/pgvector.md
           - ClickHouse Session: session/clickhouse.md
@@ -114,6 +115,7 @@ plugins:
                     - SQLite Session: session/sqlite.md
                     - Redis Session: session/redis.md
                     - MySQL Session: session/mysql.md
+                    - TDSQL Session: session/tdsql.md
                     - PostgreSQL Session: session/postgres.md
                     - PGVector Session: session/pgvector.md
                     - ClickHouse Session: session/clickhouse.md

--- a/docs/mkdocs/en/session/tdsql.md
+++ b/docs/mkdocs/en/session/tdsql.md
@@ -1,0 +1,77 @@
+# TDSQL Distributed Storage
+
+TDSQL mode builds on the [MySQL Session backend](mysql.md). Enable it with `WithTDSQLSharding(true)`. The API is **fully compatible** with MySQL Session — all interfaces and configuration options are shared. Only the DDL and sharding strategy differ.
+
+## Features
+
+- ✅ Built on [MySQL Session backend](mysql.md), fully API-compatible
+- ✅ Automatic TDSQL sharded table DDL (`shardkey=user_id`)
+- ✅ Internally handles DML shard routing, TTL cleanup, and other TDSQL compatibility logic
+- ✅ Supports all MySQL Session features: soft delete, table prefix, async persistence, summarizer, hooks, etc.
+
+## Configuration Options
+
+TDSQL mode adds only one configuration option:
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `WithTDSQLSharding(enable bool)` | `bool` | `false` | Enable TDSQL distributed mode |
+
+All other configuration options (connection, session, async persistence, summarizer, table prefix, hooks, etc.) are identical to [MySQL Storage](mysql.md). Please refer to the MySQL documentation.
+
+## Quick Start
+
+```go
+import "trpc.group/trpc-go/trpc-agent-go/session/mysql"
+
+sessionService, err := mysql.NewService(
+    mysql.WithMySQLClientDSN("user:password@tcp(tdsql-proxy:3306)/db?parseTime=true&charset=utf8mb4"),
+    mysql.WithTDSQLSharding(true),  // Enable TDSQL distributed mode
+    mysql.WithTablePrefix("trpc_"),
+    mysql.WithSessionTTL(30*time.Minute),
+    mysql.WithSoftDelete(true),
+)
+```
+
+The only difference is the addition of `WithTDSQLSharding(true)`. All other options (`WithSessionEventLimit`, `WithSummarizer`, `WithEnableAsyncPersist`, etc.) are identical to [MySQL Storage](mysql.md).
+
+### Running the Example
+
+```bash
+export TDSQL_HOST=your-tdsql-proxy-host
+export TDSQL_PORT=3306
+export TDSQL_USER=your_user
+export TDSQL_PASSWORD='your_password'
+export TDSQL_DATABASE=your_database
+```
+
+```bash
+go run ./examples/session/simple/ -session=tdsql
+```
+
+## Sharding Strategy
+
+TDSQL requires each sharded table to specify a `shardkey`. This column must appear in all PRIMARY KEYs and UNIQUE KEYs.
+
+Since all Session read/write paths naturally carry `user_id`, it is used directly as the shard key. All data for the same user lands on the same shard:
+
+| Table | shardkey | Description |
+| --- | --- | --- |
+| `session_states` | `user_id` | All sessions for the same user land on the same shard |
+| `session_events` | `user_id` | Events co-located with sessions |
+| `session_track_events` | `user_id` | Track events co-located with sessions |
+| `session_summaries` | `user_id` | Summaries co-located with sessions |
+| `user_states` | `user_id` | User states co-located with sessions |
+| `app_states` | `noshardkey_allset` | Broadcast table, full copy on every node |
+
+`app_states` stores app-level configuration — small dataset, infrequent writes. As a broadcast table, it can be read locally on any node without cross-shard queries.
+
+## Table Schema
+
+- **TDSQL schema**: [`session/mysql/schema_tdsql.sql`](https://github.com/trpc-group/trpc-agent-go/blob/main/session/mysql/schema_tdsql.sql)
+- **MySQL schema** (for comparison): [`session/mysql/schema.sql`](https://github.com/trpc-group/trpc-agent-go/blob/main/session/mysql/schema.sql)
+
+## Known Limitations
+
+1. **`session_summaries` column length**: `app_name`, `session_id`, `filter_key` limited to 128 characters (due to InnoDB index length constraints)
+2. **`user_id` character set**: ASCII strings recommended; non-ASCII values may cause TDSQL Proxy routing instability

--- a/docs/mkdocs/zh/session/tdsql.md
+++ b/docs/mkdocs/zh/session/tdsql.md
@@ -1,0 +1,77 @@
+# TDSQL 分布式存储
+
+TDSQL 模式基于 [MySQL Session 后端](mysql.md)，通过 `WithTDSQLSharding(true)` 启用。用法与 MySQL Session **完全一致**，所有接口、配置选项均通用，仅建表语句和分片策略有所不同。
+
+## 特点
+
+- ✅ 基于 [MySQL Session 后端](mysql.md)，API 完全兼容
+- ✅ 自动使用 TDSQL 分片表 DDL（`shardkey=user_id`）
+- ✅ 内部自动处理 DML 分片路由、TTL 清理等 TDSQL 兼容逻辑
+- ✅ 支持 MySQL Session 的全部功能：软删除、表前缀、异步持久化、摘要、Hook 等
+
+## 配置选项
+
+TDSQL 模式仅新增一个配置项：
+
+| 选项 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `WithTDSQLSharding(enable bool)` | `bool` | `false` | 启用 TDSQL 分布式模式 |
+
+其余所有配置选项（连接、会话、异步持久化、摘要、表前缀、Hook 等）与 [MySQL 存储](mysql.md) 完全一致，请参考 MySQL 文档。
+
+## 快速开始
+
+```go
+import "trpc.group/trpc-go/trpc-agent-go/session/mysql"
+
+sessionService, err := mysql.NewService(
+    mysql.WithMySQLClientDSN("user:password@tcp(tdsql-proxy:3306)/db?parseTime=true&charset=utf8mb4"),
+    mysql.WithTDSQLSharding(true),  // 启用 TDSQL 分布式模式
+    mysql.WithTablePrefix("trpc_"),
+    mysql.WithSessionTTL(30*time.Minute),
+    mysql.WithSoftDelete(true),
+)
+```
+
+唯一的区别是多了一个 `WithTDSQLSharding(true)`，其余配置选项（`WithSessionEventLimit`、`WithSummarizer`、`WithEnableAsyncPersist` 等）与 [MySQL 存储](mysql.md) 完全一致。
+
+### 运行示例
+
+```bash
+export TDSQL_HOST=your-tdsql-proxy-host
+export TDSQL_PORT=3306
+export TDSQL_USER=your_user
+export TDSQL_PASSWORD='your_password'
+export TDSQL_DATABASE=your_database
+```
+
+```bash
+go run ./examples/session/simple/ -session=tdsql
+```
+
+## 分片策略
+
+TDSQL 要求每张分片表指定一个 `shardkey`，该列必须出现在 PRIMARY KEY 和 UNIQUE KEY 中。
+
+Session 的所有读写路径天然携带 `user_id`，因此直接使用 `user_id` 作为分片键，同一用户的所有数据落在同一分片：
+
+| 表 | shardkey | 说明 |
+| --- | --- | --- |
+| `session_states` | `user_id` | 同一用户的所有 session 落在同一分片 |
+| `session_events` | `user_id` | 事件与 session 同分片 |
+| `session_track_events` | `user_id` | track 事件与 session 同分片 |
+| `session_summaries` | `user_id` | 摘要与 session 同分片 |
+| `user_states` | `user_id` | 用户状态与 session 同分片 |
+| `app_states` | `noshardkey_allset` | 广播表，每个节点全量复制 |
+
+`app_states` 是应用级配置数据，数据量小、写入频率低，使用广播表可在任意节点本地读取，无需跨分片查询。
+
+## 表结构
+
+- **TDSQL schema**：[`session/mysql/schema_tdsql.sql`](https://github.com/trpc-group/trpc-agent-go/blob/main/session/mysql/schema_tdsql.sql)
+- **MySQL schema**（对比参考）：[`session/mysql/schema.sql`](https://github.com/trpc-group/trpc-agent-go/blob/main/session/mysql/schema.sql)
+
+## 已知限制
+
+1. **`session_summaries` 列长度**：`app_name`、`session_id`、`filter_key` 限制为 128 字符（受 InnoDB 索引长度约束）
+2. **`user_id` 字符集**：建议使用 ASCII 字符串，非 ASCII 值可能导致 TDSQL Proxy 路由不稳定

--- a/examples/session/simple/main.go
+++ b/examples/session/simple/main.go
@@ -104,7 +104,7 @@ var (
 		"session",
 		"redis",
 		"Name of the session service to use, inmemory / noop / "+
-			"sqlite / redis / postgres / pgvector / mysql / clickhouse",
+			"sqlite / redis / postgres / pgvector / mysql / tdsql / clickhouse",
 	)
 	streaming = flag.Bool(
 		"streaming",
@@ -118,7 +118,7 @@ var (
 	)
 	sessionTTL = flag.Duration(
 		"session-ttl",
-		10*time.Second,
+		300*time.Second,
 		"Session time-to-live duration",
 	)
 	searchTopK = flag.Int(

--- a/examples/session/util.go
+++ b/examples/session/util.go
@@ -53,6 +53,7 @@ const (
 	SessionPostgres   SessionType = "postgres"
 	SessionPGVector   SessionType = "pgvector"
 	SessionMySQL      SessionType = "mysql"
+	SessionTDSQL      SessionType = "tdsql"
 	SessionClickHouse SessionType = "clickhouse"
 )
 
@@ -83,6 +84,8 @@ type SessionServiceConfig struct {
 //	  PGVECTOR_PASSWORD, PGVECTOR_DATABASE, PGVECTOR_EMBEDDER_MODEL
 //	mysql:      MYSQL_HOST, MYSQL_PORT, MYSQL_USER, MYSQL_PASSWORD,
 //	  MYSQL_DATABASE
+//	tdsql:      TDSQL_HOST, TDSQL_PORT, TDSQL_USER, TDSQL_PASSWORD,
+//	  TDSQL_DATABASE
 //	clickhouse: CLICKHOUSE_HOST, CLICKHOUSE_PORT, CLICKHOUSE_USER,
 //	  CLICKHOUSE_PASSWORD, CLICKHOUSE_DATABASE
 func NewSessionServiceByType(
@@ -100,6 +103,8 @@ func NewSessionServiceByType(
 		return newPGVectorSessionService(cfg)
 	case SessionMySQL:
 		return newMySQLSessionService(cfg)
+	case SessionTDSQL:
+		return newTDSQLSessionService(cfg)
 	case SessionClickHouse:
 		return newClickHouseSessionService(cfg)
 	case SessionNoop:
@@ -305,6 +310,38 @@ func newMySQLSessionService(
 	return mysql.NewService(
 		mysql.WithMySQLClientDSN(dsn),
 		mysql.WithTablePrefix("trpc_"),
+		mysql.WithSessionEventLimit(cfg.EventLimit),
+		mysql.WithSessionTTL(cfg.TTL),
+		mysql.WithAppendEventHook(cfg.AppendEventHooks...),
+		mysql.WithGetSessionHook(cfg.GetSessionHooks...),
+	)
+}
+
+// newTDSQLSessionService creates a TDSQL (distributed MySQL) session service.
+// TDSQL requires shardkey-aware DDL/DML; WithTDSQLSharding enables the
+// necessary table definitions and query routing.
+// Environment variables:
+//   - TDSQL_HOST: TDSQL proxy host (default: localhost)
+//   - TDSQL_PORT: TDSQL proxy port (default: 3306)
+//   - TDSQL_USER: TDSQL user (default: root)
+//   - TDSQL_PASSWORD: TDSQL password (default: empty)
+//   - TDSQL_DATABASE: TDSQL database (default: trpc_agent_go)
+func newTDSQLSessionService(
+	cfg SessionServiceConfig,
+) (session.Service, error) {
+	host := GetEnvOrDefault("TDSQL_HOST", "localhost")
+	port := GetEnvOrDefault("TDSQL_PORT", "3306")
+	user := GetEnvOrDefault("TDSQL_USER", "root")
+	password := GetEnvOrDefault("TDSQL_PASSWORD", "")
+	database := GetEnvOrDefault("TDSQL_DATABASE", "trpc_agent_go")
+
+	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?parseTime=true&charset=utf8mb4",
+		user, password, host, port, database)
+
+	return mysql.NewService(
+		mysql.WithMySQLClientDSN(dsn),
+		mysql.WithTablePrefix("trpc_"),
+		mysql.WithTDSQLSharding(true),
 		mysql.WithSessionEventLimit(cfg.EventLimit),
 		mysql.WithSessionTTL(cfg.TTL),
 		mysql.WithAppendEventHook(cfg.AppendEventHooks...),

--- a/session/mysql/init.go
+++ b/session/mysql/init.go
@@ -218,11 +218,14 @@ type tableIndex struct {
 	unique  bool     // Whether this is a unique index
 }
 
-// expectedSchema defines the expected schema for each table
-var expectedSchema = map[string]struct {
+// tableSchema defines the expected schema for a table.
+type tableSchema struct {
 	columns []tableColumn
 	indexes []tableIndex
-}{
+}
+
+// expectedSchema defines the expected schema for each table.
+var expectedSchema = map[string]tableSchema{
 	sqldb.TableNameSessionStates: {
 		columns: []tableColumn{
 			{"id", "bigint", false},
@@ -328,6 +331,25 @@ var expectedSchema = map[string]struct {
 	},
 }
 
+// tdsqlExpectedSchema extends expectedSchema with TDSQL-specific indexes.
+var tdsqlExpectedSchema = func() map[string]tableSchema {
+	s := make(map[string]tableSchema, len(expectedSchema))
+	for k, v := range expectedSchema {
+		s[k] = v
+	}
+	ss := s[sqldb.TableNameSessionStates]
+	newIndexes := make([]tableIndex, len(ss.indexes)+1)
+	copy(newIndexes, ss.indexes)
+	newIndexes[len(ss.indexes)] = tableIndex{
+		table:   sqldb.TableNameSessionStates,
+		suffix:  "list",
+		columns: []string{"app_name", "user_id", "updated_at"},
+	}
+	ss.indexes = newIndexes
+	s[sqldb.TableNameSessionStates] = ss
+	return s
+}()
+
 // Global table definitions
 var tableDefs = []tableDefinition{
 	{sqldb.TableNameSessionStates, sqlCreateSessionStatesTable},
@@ -359,12 +381,152 @@ var indexDefs = []indexDefinition{
 	{sqldb.TableNameUserStates, sqldb.IndexSuffixExpires, sqlCreateUserStatesExpiresIndex},
 }
 
+// TDSQL table templates: PK includes shardkey (user_id for session tables, broadcast for app_states).
+const (
+	tdsqlCreateSessionStatesTable = `
+		CREATE TABLE IF NOT EXISTS {{TABLE_NAME}} (
+			id BIGINT NOT NULL AUTO_INCREMENT,
+			app_name VARCHAR(255) NOT NULL,
+			user_id VARCHAR(255) NOT NULL,
+			session_id VARCHAR(255) NOT NULL,
+			state JSON DEFAULT NULL,
+			created_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+			updated_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+			expires_at TIMESTAMP(6) NULL DEFAULT NULL,
+			deleted_at TIMESTAMP(6) NULL DEFAULT NULL,
+			PRIMARY KEY (id, user_id)
+		) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci shardkey=user_id`
+
+	tdsqlCreateSessionEventsTable = `
+		CREATE TABLE IF NOT EXISTS {{TABLE_NAME}} (
+			id BIGINT NOT NULL AUTO_INCREMENT,
+			app_name VARCHAR(255) NOT NULL,
+			user_id VARCHAR(255) NOT NULL,
+			session_id VARCHAR(255) NOT NULL,
+			event JSON NOT NULL,
+			created_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+			updated_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+			expires_at TIMESTAMP(6) NULL DEFAULT NULL,
+			deleted_at TIMESTAMP(6) NULL DEFAULT NULL,
+			PRIMARY KEY (id, user_id)
+		) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci shardkey=user_id`
+
+	tdsqlCreateSessionTrackEventsTable = `
+		CREATE TABLE IF NOT EXISTS {{TABLE_NAME}} (
+			id BIGINT NOT NULL AUTO_INCREMENT,
+			app_name VARCHAR(255) NOT NULL,
+			user_id VARCHAR(255) NOT NULL,
+			session_id VARCHAR(255) NOT NULL,
+			track VARCHAR(255) NOT NULL,
+			event JSON NOT NULL,
+			created_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+			updated_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+			expires_at TIMESTAMP(6) NULL DEFAULT NULL,
+			deleted_at TIMESTAMP(6) NULL DEFAULT NULL,
+			PRIMARY KEY (id, user_id)
+		) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci shardkey=user_id`
+
+	// TDSQL session_summaries: app_name/session_id/filter_key use VARCHAR(128)
+	// so the UNIQUE KEY fits within InnoDB's 3072-byte limit at full length:
+	// 128*4*3 + 255*4 = 1536 + 1020 = 2556 < 3072. No prefix index needed.
+	tdsqlCreateSessionSummariesTable = `
+		CREATE TABLE IF NOT EXISTS {{TABLE_NAME}} (
+			id BIGINT NOT NULL AUTO_INCREMENT,
+			app_name VARCHAR(128) NOT NULL,
+			user_id VARCHAR(255) NOT NULL,
+			session_id VARCHAR(128) NOT NULL,
+			filter_key VARCHAR(128) NOT NULL DEFAULT '',
+			summary JSON DEFAULT NULL,
+			updated_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+			expires_at TIMESTAMP(6) NULL DEFAULT NULL,
+			deleted_at TIMESTAMP(6) NULL DEFAULT NULL,
+			PRIMARY KEY (id, user_id)
+		) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci shardkey=user_id`
+
+	tdsqlCreateAppStatesTable = `
+		CREATE TABLE IF NOT EXISTS {{TABLE_NAME}} (
+			id BIGINT AUTO_INCREMENT PRIMARY KEY,
+			app_name VARCHAR(255) NOT NULL,
+			` + "`key`" + ` VARCHAR(255) NOT NULL,
+			value TEXT DEFAULT NULL,
+			created_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+			updated_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+			expires_at TIMESTAMP(6) NULL DEFAULT NULL,
+			deleted_at TIMESTAMP(6) NULL DEFAULT NULL
+		) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci shardkey=noshardkey_allset`
+
+	tdsqlCreateUserStatesTable = `
+		CREATE TABLE IF NOT EXISTS {{TABLE_NAME}} (
+			id BIGINT NOT NULL AUTO_INCREMENT,
+			app_name VARCHAR(255) NOT NULL,
+			user_id VARCHAR(255) NOT NULL,
+			` + "`key`" + ` VARCHAR(255) NOT NULL,
+			value TEXT DEFAULT NULL,
+			created_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+			updated_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+			expires_at TIMESTAMP(6) NULL DEFAULT NULL,
+			deleted_at TIMESTAMP(6) NULL DEFAULT NULL,
+			PRIMARY KEY (id, user_id)
+		) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci shardkey=user_id`
+
+	tdsqlCreateSessionStatesListIndex = `
+		CREATE INDEX {{INDEX_NAME}}
+		ON {{TABLE_NAME}}(app_name, user_id, updated_at)`
+
+	// TDSQL session_summaries uses VARCHAR(128) for app_name/session_id/filter_key,
+	// so UNIQUE KEY fits at full column length without prefix indexes.
+	tdsqlCreateSessionSummariesUniqueIndex = `
+		CREATE UNIQUE INDEX {{INDEX_NAME}}
+		ON {{TABLE_NAME}}(app_name, user_id, session_id, filter_key)`
+)
+
+var tdsqlTableDefs = []tableDefinition{
+	{sqldb.TableNameSessionStates, tdsqlCreateSessionStatesTable},
+	{sqldb.TableNameSessionEvents, tdsqlCreateSessionEventsTable},
+	{sqldb.TableNameSessionTrackEvents, tdsqlCreateSessionTrackEventsTable},
+	{sqldb.TableNameSessionSummaries, tdsqlCreateSessionSummariesTable},
+	{sqldb.TableNameAppStates, tdsqlCreateAppStatesTable},
+	{sqldb.TableNameUserStates, tdsqlCreateUserStatesTable},
+}
+
+var tdsqlIndexDefs = []indexDefinition{
+	// Unique indexes (same as MySQL, shardkey already in UNIQUE KEYs)
+	{sqldb.TableNameSessionStates, sqldb.IndexSuffixUniqueActive, sqlCreateSessionStatesUniqueIndex},
+	{sqldb.TableNameSessionSummaries, sqldb.IndexSuffixUniqueActive, tdsqlCreateSessionSummariesUniqueIndex},
+	{sqldb.TableNameAppStates, sqldb.IndexSuffixUniqueActive, sqlCreateAppStatesUniqueIndex},
+	{sqldb.TableNameUserStates, sqldb.IndexSuffixUniqueActive, sqlCreateUserStatesUniqueIndex},
+
+	// Lookup indexes (same as MySQL)
+	{sqldb.TableNameSessionEvents, sqldb.IndexSuffixLookup, sqlCreateSessionEventsLookupIndex},
+	{sqldb.TableNameSessionTrackEvents, sqldb.IndexSuffixLookup, sqlCreateSessionTracksIndex},
+
+	// TDSQL-specific: ListSessions sort index
+	{sqldb.TableNameSessionStates, "list", tdsqlCreateSessionStatesListIndex},
+
+	// TTL indexes (same as MySQL)
+	{sqldb.TableNameSessionStates, sqldb.IndexSuffixExpires, sqlCreateSessionStatesExpiresIndex},
+	{sqldb.TableNameSessionEvents, sqldb.IndexSuffixExpires, sqlCreateSessionEventsExpiresIndex},
+	{sqldb.TableNameSessionTrackEvents, sqldb.IndexSuffixExpires, sqlCreateSessionTracksExpiresIndex},
+	{sqldb.TableNameSessionSummaries, sqldb.IndexSuffixExpires, sqlCreateSessionSummariesExpiresIndex},
+	{sqldb.TableNameAppStates, sqldb.IndexSuffixExpires, sqlCreateAppStatesExpiresIndex},
+	{sqldb.TableNameUserStates, sqldb.IndexSuffixExpires, sqlCreateUserStatesExpiresIndex},
+}
+
 // initDB initializes the database schema.
 func (s *Service) initDB(ctx context.Context) error {
 	log.InfoContext(ctx, "initializing mysql session database schema...")
 
+	// Select table and index definitions based on TDSQL mode.
+	tables := tableDefs
+	indexes := indexDefs
+	if s.opts.tdsqlSharding {
+		tables = tdsqlTableDefs
+		indexes = tdsqlIndexDefs
+		log.InfoContext(ctx, "TDSQL sharding mode enabled, using TDSQL schema")
+	}
+
 	// Create tables
-	for _, tableDef := range tableDefs {
+	for _, tableDef := range tables {
 		fullTableName := sqldb.BuildTableName(s.opts.tablePrefix, tableDef.name)
 		sql := strings.ReplaceAll(tableDef.template, "{{TABLE_NAME}}", fullTableName)
 
@@ -375,7 +537,7 @@ func (s *Service) initDB(ctx context.Context) error {
 	}
 
 	// Create indexes
-	for _, indexDef := range indexDefs {
+	for _, indexDef := range indexes {
 		fullTableName := sqldb.BuildTableName(s.opts.tablePrefix, indexDef.table)
 		indexName := sqldb.BuildIndexName(s.opts.tablePrefix, indexDef.table, indexDef.suffix)
 		sql := indexDef.template
@@ -413,10 +575,15 @@ func (s *Service) initDB(ctx context.Context) error {
 
 // verifySchema verifies that the database schema matches expectations.
 func (s *Service) verifySchema(ctx context.Context) error {
-	// Use tableDefs order for deterministic verification
-	for _, tableDef := range tableDefs {
+	tables := tableDefs
+	schemas := expectedSchema
+	if s.opts.tdsqlSharding {
+		tables = tdsqlTableDefs
+		schemas = tdsqlExpectedSchema
+	}
+	for _, tableDef := range tables {
 		tableName := tableDef.name
-		schema, ok := expectedSchema[tableName]
+		schema, ok := schemas[tableName]
 		if !ok {
 			continue
 		}
@@ -540,7 +707,7 @@ func (s *Service) verifyIndexes(ctx context.Context, fullTableName string, expec
 		actualColumns, exists := actualIndexes[expectedIndexName]
 		if !exists {
 			// Build CREATE INDEX statement for user reference.
-			columnsStr := buildIndexColumnsStr(expected.table, expected.suffix, expected.columns)
+			columnsStr := buildIndexColumnsStr(expected.table, expected.suffix, expected.columns, s.opts.tdsqlSharding)
 			createSQL := buildCreateIndexSQL(expectedIndexName, fullTableName, columnsStr, expected.unique)
 			log.WarnfContext(ctx, "index %s on table %s is missing, please run: %s",
 				expectedIndexName, fullTableName, createSQL)
@@ -549,7 +716,7 @@ func (s *Service) verifyIndexes(ctx context.Context, fullTableName string, expec
 
 		if !stringSlicesEqual(actualColumns, expected.columns) {
 			// Build DROP and CREATE INDEX statements for user reference.
-			columnsStr := buildIndexColumnsStr(expected.table, expected.suffix, expected.columns)
+			columnsStr := buildIndexColumnsStr(expected.table, expected.suffix, expected.columns, s.opts.tdsqlSharding)
 			dropSQL := fmt.Sprintf("DROP INDEX %s ON %s;", expectedIndexName, fullTableName)
 			createSQL := buildCreateIndexSQL(expectedIndexName, fullTableName, columnsStr, expected.unique)
 			log.WarnfContext(ctx, "index %s on table %s has wrong columns: got %v, want %v. "+
@@ -587,9 +754,10 @@ func stringSlicesEqual(a, b []string) bool {
 
 // buildIndexColumnsStr builds a comma-separated column list with appropriate
 // prefix lengths for indexes that require them.
-func buildIndexColumnsStr(table, suffix string, columns []string) string {
-	// session_summaries unique_active index requires prefix lengths to avoid Error 1071.
-	if table == sqldb.TableNameSessionSummaries && suffix == sqldb.IndexSuffixUniqueActive {
+func buildIndexColumnsStr(table, suffix string, columns []string, tdsqlSharding bool) string {
+	// MySQL mode: session_summaries unique_active index requires prefix lengths
+	// to avoid Error 1071. TDSQL mode uses VARCHAR(128) so no prefix needed.
+	if !tdsqlSharding && table == sqldb.TableNameSessionSummaries && suffix == sqldb.IndexSuffixUniqueActive {
 		var prefixed []string
 		for _, col := range columns {
 			prefixed = append(prefixed, fmt.Sprintf("%s(%d)", col, mysqlVarCharIndexPrefixLen))

--- a/session/mysql/init_test.go
+++ b/session/mysql/init_test.go
@@ -307,10 +307,7 @@ func TestVerifySchema_Success(t *testing.T) {
 
 	// Override expectedSchema to test only one table for simplicity
 	testTable := sqldb.TableNameSessionStates
-	expectedSchema = map[string]struct {
-		columns []tableColumn
-		indexes []tableIndex
-	}{
+	expectedSchema = map[string]tableSchema{
 		testTable: originalExpectedSchema[testTable],
 	}
 
@@ -700,7 +697,7 @@ func TestBuildIndexColumnsStr(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := buildIndexColumnsStr(tt.table, tt.suffix, tt.columns)
+			got := buildIndexColumnsStr(tt.table, tt.suffix, tt.columns, false)
 			assert.Equal(t, tt.expected, got)
 		})
 	}

--- a/session/mysql/options.go
+++ b/session/mysql/options.go
@@ -74,6 +74,11 @@ type ServiceOpts struct {
 	// hooks for session operations.
 	appendEventHooks []session.AppendEventHook
 	getSessionHooks  []session.GetSessionHook
+
+	// tdsqlSharding enables TDSQL distributed instance mode.
+	// When true, uses user_id as shardkey for session/user tables,
+	// broadcast table for app_states, and two-phase TTL cleanup.
+	tdsqlSharding bool
 }
 
 // ServiceOpt is the option for the MySQL session service.
@@ -297,5 +302,20 @@ func WithAppendEventHook(hooks ...session.AppendEventHook) ServiceOpt {
 func WithGetSessionHook(hooks ...session.GetSessionHook) ServiceOpt {
 	return func(opts *ServiceOpts) {
 		opts.getSessionHooks = append(opts.getSessionHooks, hooks...)
+	}
+}
+
+// WithTDSQLSharding enables TDSQL distributed instance mode.
+// In this mode:
+//   - session/user tables use user_id as shardkey (PK becomes (id, user_id))
+//   - app_states uses broadcast table (noshardkey_allset)
+//   - TTL cleanup uses two-phase approach (scan then targeted delete)
+//   - DML statements include shardkey in WHERE clause for routing
+//
+// Constraint: user_id must be ASCII-only. TDSQL proxy does not convert
+// character sets; non-ASCII shardkey values may cause routing instability.
+func WithTDSQLSharding(enable bool) ServiceOpt {
+	return func(opts *ServiceOpts) {
+		opts.tdsqlSharding = enable
 	}
 }

--- a/session/mysql/schema_tdsql.sql
+++ b/session/mysql/schema_tdsql.sql
@@ -1,0 +1,137 @@
+-- TDSQL MySQL Session Service Schema
+-- Replace {{PREFIX}} with the configured table prefix.
+--
+-- Sharding strategy:
+--   - 5 session/user scoped tables: shardkey = user_id
+--   - app_states: broadcast table (noshardkey_allset), full copy on every node.
+--     Small dataset, infrequently updated, no need to shard.
+--
+-- Shard count:
+--   TDSQL does NOT support per-table shard count in CREATE TABLE syntax.
+--   Shard count = number of physical sets in the TDSQL instance (e.g., 2, 4, 8).
+--   All sharded tables share the same set topology.
+--
+-- Index design notes:
+--   - PRIMARY KEY and UNIQUE KEY must include shardkey (TDSQL hard requirement).
+--   - user_id / app_name are already present in all existing UNIQUE KEYs, so UNIQUE KEYs are unchanged.
+--   - Normal KEY does NOT need shardkey (TDSQL routes via WHERE clause, not index definition).
+--   - InnoDB index key length limit is 3072 bytes (DYNAMIC/COMPRESSED row format).
+--     VARCHAR(255) utf8mb4 = 1020 bytes, TIMESTAMP(6) = 7 bytes.
+--
+-- Constraint: user_id and app_name must be ASCII strings.
+--   TDSQL proxy does not convert character sets; non-ASCII shardkey values may cause routing instability.
+
+-- ============================================================================
+-- Table: session_states
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS `{{PREFIX}}session_states` (
+    `id` BIGINT NOT NULL AUTO_INCREMENT,
+    `app_name` VARCHAR(255) NOT NULL,
+    `user_id` VARCHAR(255) NOT NULL,
+    `session_id` VARCHAR(255) NOT NULL,
+    `state` JSON DEFAULT NULL,
+    `created_at` TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    `updated_at` TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    `expires_at` TIMESTAMP(6) NULL DEFAULT NULL,
+    `deleted_at` TIMESTAMP(6) NULL DEFAULT NULL,
+    PRIMARY KEY (`id`, `user_id`),
+    UNIQUE KEY `idx_{{PREFIX}}session_states_unique_active` (`app_name`,`user_id`,`session_id`,`deleted_at`),
+    KEY `idx_{{PREFIX}}session_states_list` (`app_name`,`user_id`,`updated_at`),
+    KEY `idx_{{PREFIX}}session_states_expires` (`expires_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci shardkey=user_id;
+
+-- ============================================================================
+-- Table: session_events
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS `{{PREFIX}}session_events` (
+    `id` BIGINT NOT NULL AUTO_INCREMENT,
+    `app_name` VARCHAR(255) NOT NULL,
+    `user_id` VARCHAR(255) NOT NULL,
+    `session_id` VARCHAR(255) NOT NULL,
+    `event` JSON NOT NULL,
+    `created_at` TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    `updated_at` TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    `expires_at` TIMESTAMP(6) NULL DEFAULT NULL,
+    `deleted_at` TIMESTAMP(6) NULL DEFAULT NULL,
+    PRIMARY KEY (`id`, `user_id`),
+    KEY `idx_{{PREFIX}}session_events_lookup` (`app_name`,`user_id`,`session_id`,`created_at`),
+    KEY `idx_{{PREFIX}}session_events_expires` (`expires_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci shardkey=user_id;
+
+-- ============================================================================
+-- Table: session_track_events
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS `{{PREFIX}}session_track_events` (
+    `id` BIGINT NOT NULL AUTO_INCREMENT,
+    `app_name` VARCHAR(255) NOT NULL,
+    `user_id` VARCHAR(255) NOT NULL,
+    `session_id` VARCHAR(255) NOT NULL,
+    `track` VARCHAR(255) NOT NULL,
+    `event` JSON NOT NULL,
+    `created_at` TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    `updated_at` TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    `expires_at` TIMESTAMP(6) NULL DEFAULT NULL,
+    `deleted_at` TIMESTAMP(6) NULL DEFAULT NULL,
+    PRIMARY KEY (`id`, `user_id`),
+    KEY `idx_{{PREFIX}}session_track_events_lookup` (`app_name`,`user_id`,`session_id`,`created_at`),
+    KEY `idx_{{PREFIX}}session_track_events_expires` (`expires_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci shardkey=user_id;
+
+-- ============================================================================
+-- Table: session_summaries
+-- ============================================================================
+-- Note: app_name/session_id/filter_key use VARCHAR(128) instead of VARCHAR(255)
+-- so the UNIQUE KEY fits within InnoDB's 3072-byte limit at full column length:
+-- 128*4*3 + 255*4 = 1536 + 1020 = 2556 < 3072. No prefix index needed.
+CREATE TABLE IF NOT EXISTS `{{PREFIX}}session_summaries` (
+    `id` BIGINT NOT NULL AUTO_INCREMENT,
+    `app_name` VARCHAR(128) NOT NULL,
+    `user_id` VARCHAR(255) NOT NULL,
+    `session_id` VARCHAR(128) NOT NULL,
+    `filter_key` VARCHAR(128) NOT NULL DEFAULT '',
+    `summary` JSON DEFAULT NULL,
+    `updated_at` TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    `expires_at` TIMESTAMP(6) NULL DEFAULT NULL,
+    `deleted_at` TIMESTAMP(6) NULL DEFAULT NULL,
+    PRIMARY KEY (`id`, `user_id`),
+    UNIQUE KEY `idx_{{PREFIX}}session_summaries_unique_active` (`app_name`,`user_id`,`session_id`,`filter_key`),
+    KEY `idx_{{PREFIX}}session_summaries_expires` (`expires_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci shardkey=user_id;
+
+-- ============================================================================
+-- Table: app_states
+-- Broadcast table (noshardkey_allset): full copy on every node.
+-- app_states is a small, infrequently-updated table (app-level config).
+-- Broadcast gives local reads and keeps schema identical to MySQL (no PK change).
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS `{{PREFIX}}app_states` (
+    `id` BIGINT NOT NULL AUTO_INCREMENT,
+    `app_name` VARCHAR(255) NOT NULL,
+    `key` VARCHAR(255) NOT NULL,
+    `value` TEXT DEFAULT NULL,
+    `created_at` TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    `updated_at` TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    `expires_at` TIMESTAMP(6) NULL DEFAULT NULL,
+    `deleted_at` TIMESTAMP(6) NULL DEFAULT NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `idx_{{PREFIX}}app_states_unique_active` (`app_name`,`key`,`deleted_at`),
+    KEY `idx_{{PREFIX}}app_states_expires` (`expires_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci shardkey=noshardkey_allset;
+
+-- ============================================================================
+-- Table: user_states
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS `{{PREFIX}}user_states` (
+    `id` BIGINT NOT NULL AUTO_INCREMENT,
+    `app_name` VARCHAR(255) NOT NULL,
+    `user_id` VARCHAR(255) NOT NULL,
+    `key` VARCHAR(255) NOT NULL,
+    `value` TEXT DEFAULT NULL,
+    `created_at` TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    `updated_at` TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    `expires_at` TIMESTAMP(6) NULL DEFAULT NULL,
+    `deleted_at` TIMESTAMP(6) NULL DEFAULT NULL,
+    PRIMARY KEY (`id`, `user_id`),
+    UNIQUE KEY `idx_{{PREFIX}}user_states_unique_active` (`app_name`,`user_id`,`key`,`deleted_at`),
+    KEY `idx_{{PREFIX}}user_states_expires` (`expires_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci shardkey=user_id;

--- a/session/mysql/service.go
+++ b/session/mysql/service.go
@@ -547,7 +547,8 @@ func (s *Service) upsertUserState(ctx context.Context, appName, userID, key stri
 			fmt.Sprintf("INSERT INTO %s (app_name, user_id, `key`, value, created_at, updated_at, expires_at) VALUES (?, ?, ?, ?, ?, ?, ?)", s.tableUserStates),
 			appName, userID, key, value, now, now, expiresAt)
 	} else {
-		// TDSQL PK is (id, user_id); include user_id for shard routing.
+		// Include user_id for shard routing (TDSQL PK is (id, user_id));
+		// also valid as an extra filter for standard MySQL.
 		_, err = s.mysqlClient.Exec(ctx,
 			fmt.Sprintf("UPDATE %s SET value = ?, updated_at = ?, expires_at = ? WHERE id = ? AND user_id = ?", s.tableUserStates),
 			value, now, expiresAt, id, userID)
@@ -982,12 +983,13 @@ func (s *Service) cleanupExpiredSessions(ctx context.Context, now time.Time) {
 		}
 
 		// 2. Delete the locked sessions
-		if err := s.deleteSessions(ctx, tx, sessionKeys, now); err != nil {
+		n, err := s.deleteSessions(ctx, tx, sessionKeys, now)
+		if err != nil {
 			return err
 		}
 
 		// We count the number of sessions deleted, not the total rows affected across all tables
-		deletedCount = int64(len(sessionKeys))
+		deletedCount = int64(n)
 		return nil
 	})
 
@@ -1002,8 +1004,37 @@ func (s *Service) cleanupExpiredSessions(ctx context.Context, now time.Time) {
 }
 
 // deleteSessions deletes session data for the given keys within a transaction.
-func (s *Service) deleteSessions(ctx context.Context, tx *sql.Tx, keys []session.Key, now time.Time) error {
-	// Prepare delete args for verified keys
+func (s *Service) deleteSessions(ctx context.Context, tx *sql.Tx, keys []session.Key, now time.Time) (int, error) {
+	whereClause, args := s.sessionKeysWhereClause(keys)
+	if whereClause == "" {
+		return 0, nil
+	}
+
+	stateWhereClause := whereClause + " AND expires_at IS NOT NULL AND expires_at <= ?"
+	stateArgs := append(append([]any(nil), args...), now)
+
+	verifiedKeys, err := s.lockExpiredSessionKeys(ctx, tx, stateWhereClause, stateArgs)
+	if err != nil {
+		return 0, err
+	}
+	if len(verifiedKeys) == 0 {
+		return 0, nil
+	}
+
+	childWhereClause, childArgs := s.sessionKeysWhereClause(verifiedKeys)
+	stateWhereClause = childWhereClause + " AND expires_at IS NOT NULL AND expires_at <= ?"
+	stateArgs = append(append([]any(nil), childArgs...), now)
+
+	if s.opts.softDelete {
+		return len(verifiedKeys), s.softDeleteSessions(ctx, tx, stateWhereClause, stateArgs, childWhereClause, childArgs, now)
+	}
+	return len(verifiedKeys), s.hardDeleteSessions(ctx, tx, stateWhereClause, stateArgs, childWhereClause, childArgs)
+}
+
+func (s *Service) sessionKeysWhereClause(keys []session.Key) (string, []any) {
+	if len(keys) == 0 {
+		return "", nil
+	}
 	placeholders := make([]string, len(keys))
 	args := make([]any, 0, len(keys)*3+1)
 	for i, key := range keys {
@@ -1012,53 +1043,80 @@ func (s *Service) deleteSessions(ctx context.Context, tx *sql.Tx, keys []session
 	}
 	whereClause := fmt.Sprintf(`(app_name, user_id, session_id) IN (%s) AND deleted_at IS NULL`, strings.Join(placeholders, ","))
 
-	// TDSQL proxy cannot extract shardkey from tuple comparison.
-	// Add explicit user_id = ? for DML routing when all keys share the same user_id.
-	if s.opts.tdsqlSharding && len(keys) > 0 {
+	// TDSQL proxy cannot extract shardkey from tuple comparison. Add an
+	// explicit user_id filter for DML routing when keys share the same user_id.
+	if s.opts.tdsqlSharding {
 		whereClause += " AND user_id = ?"
 		args = append(args, keys[0].UserID)
 	}
+	return whereClause, args
+}
 
-	// Recheck expiry to prevent deleting renewed sessions between scan and delete
-	// (two-phase cleanup has no row lock across phases). Redundant but safe for
-	// single-phase MySQL cleanup where FOR UPDATE already holds the lock.
-	whereClause += " AND expires_at IS NOT NULL AND expires_at <= ?"
-	args = append(args, now)
-
-	if s.opts.softDelete {
-		return s.softDeleteSessions(ctx, tx, whereClause, args, now)
+func (s *Service) lockExpiredSessionKeys(
+	ctx context.Context,
+	tx *sql.Tx,
+	stateWhereClause string,
+	stateArgs []any,
+) ([]session.Key, error) {
+	rows, err := tx.QueryContext(ctx,
+		fmt.Sprintf(`SELECT app_name, user_id, session_id FROM %s WHERE %s FOR UPDATE`,
+			s.tableSessionStates, stateWhereClause),
+		stateArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("recheck expired sessions failed: %w", err)
 	}
-	return s.hardDeleteSessions(ctx, tx, whereClause, args)
+	defer rows.Close()
+
+	var keys []session.Key
+	for rows.Next() {
+		var key session.Key
+		if err := rows.Scan(&key.AppName, &key.UserID, &key.SessionID); err != nil {
+			return nil, err
+		}
+		keys = append(keys, key)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return keys, nil
 }
 
 // softDeleteSessions performs soft delete on session tables.
-func (s *Service) softDeleteSessions(ctx context.Context, tx *sql.Tx, whereClause string, args []any, now time.Time) error {
+func (s *Service) softDeleteSessions(
+	ctx context.Context,
+	tx *sql.Tx,
+	stateWhereClause string,
+	stateArgs []any,
+	childWhereClause string,
+	childArgs []any,
+	now time.Time,
+) error {
 	// Soft delete session states
 	_, err := tx.ExecContext(ctx,
-		fmt.Sprintf(`UPDATE %s SET deleted_at = ? WHERE %s`, s.tableSessionStates, whereClause),
-		append([]any{now}, args...)...)
+		fmt.Sprintf(`UPDATE %s SET deleted_at = ? WHERE %s`, s.tableSessionStates, stateWhereClause),
+		append([]any{now}, stateArgs...)...)
 	if err != nil {
 		return fmt.Errorf("soft delete sessions: %w", err)
 	}
 
 	// Soft delete summaries
 	if _, err := tx.ExecContext(ctx,
-		fmt.Sprintf(`UPDATE %s SET deleted_at = ? WHERE %s`, s.tableSessionSummaries, whereClause),
-		append([]any{now}, args...)...); err != nil {
+		fmt.Sprintf(`UPDATE %s SET deleted_at = ? WHERE %s`, s.tableSessionSummaries, childWhereClause),
+		append([]any{now}, childArgs...)...); err != nil {
 		return fmt.Errorf("soft delete summaries: %w", err)
 	}
 
 	// Soft delete events
 	if _, err := tx.ExecContext(ctx,
-		fmt.Sprintf(`UPDATE %s SET deleted_at = ? WHERE %s`, s.tableSessionEvents, whereClause),
-		append([]any{now}, args...)...); err != nil {
+		fmt.Sprintf(`UPDATE %s SET deleted_at = ? WHERE %s`, s.tableSessionEvents, childWhereClause),
+		append([]any{now}, childArgs...)...); err != nil {
 		return fmt.Errorf("soft delete events: %w", err)
 	}
 
 	// Soft delete track events
 	if _, err := tx.ExecContext(ctx,
-		fmt.Sprintf(`UPDATE %s SET deleted_at = ? WHERE %s`, s.tableSessionTracks, whereClause),
-		append([]any{now}, args...)...); err != nil {
+		fmt.Sprintf(`UPDATE %s SET deleted_at = ? WHERE %s`, s.tableSessionTracks, childWhereClause),
+		append([]any{now}, childArgs...)...); err != nil {
 		return fmt.Errorf("soft delete track events: %w", err)
 	}
 
@@ -1066,33 +1124,40 @@ func (s *Service) softDeleteSessions(ctx context.Context, tx *sql.Tx, whereClaus
 }
 
 // hardDeleteSessions performs hard delete on session tables.
-func (s *Service) hardDeleteSessions(ctx context.Context, tx *sql.Tx, whereClause string, args []any) error {
+func (s *Service) hardDeleteSessions(
+	ctx context.Context,
+	tx *sql.Tx,
+	stateWhereClause string,
+	stateArgs []any,
+	childWhereClause string,
+	childArgs []any,
+) error {
 	// Hard delete session states
 	_, err := tx.ExecContext(ctx,
-		fmt.Sprintf(`DELETE FROM %s WHERE %s`, s.tableSessionStates, whereClause),
-		args...)
+		fmt.Sprintf(`DELETE FROM %s WHERE %s`, s.tableSessionStates, stateWhereClause),
+		stateArgs...)
 	if err != nil {
 		return fmt.Errorf("hard delete sessions: %w", err)
 	}
 
 	// Hard delete summaries
 	if _, err := tx.ExecContext(ctx,
-		fmt.Sprintf(`DELETE FROM %s WHERE %s`, s.tableSessionSummaries, whereClause),
-		args...); err != nil {
+		fmt.Sprintf(`DELETE FROM %s WHERE %s`, s.tableSessionSummaries, childWhereClause),
+		childArgs...); err != nil {
 		return fmt.Errorf("hard delete summaries: %w", err)
 	}
 
 	// Hard delete events
 	if _, err := tx.ExecContext(ctx,
-		fmt.Sprintf(`DELETE FROM %s WHERE %s`, s.tableSessionEvents, whereClause),
-		args...); err != nil {
+		fmt.Sprintf(`DELETE FROM %s WHERE %s`, s.tableSessionEvents, childWhereClause),
+		childArgs...); err != nil {
 		return fmt.Errorf("hard delete events: %w", err)
 	}
 
 	// Hard delete track events
 	if _, err := tx.ExecContext(ctx,
-		fmt.Sprintf(`DELETE FROM %s WHERE %s`, s.tableSessionTracks, whereClause),
-		args...); err != nil {
+		fmt.Sprintf(`DELETE FROM %s WHERE %s`, s.tableSessionTracks, childWhereClause),
+		childArgs...); err != nil {
 		return fmt.Errorf("hard delete track events: %w", err)
 	}
 
@@ -1218,14 +1283,17 @@ func (s *Service) tdsqlCleanupExpiredSessions(ctx context.Context, now time.Time
 
 	var total int64
 	for _, keys := range grouped {
+		var n int
 		err := s.mysqlClient.Transaction(ctx, func(tx *sql.Tx) error {
-			return s.deleteSessions(ctx, tx, keys, now)
+			var err error
+			n, err = s.deleteSessions(ctx, tx, keys, now)
+			return err
 		})
 		if err != nil {
 			log.ErrorfContext(ctx, "tdsql cleanup: delete sessions failed: %v", err)
 			continue
 		}
-		total += int64(len(keys))
+		total += int64(n)
 	}
 
 	if total > 0 {
@@ -1273,23 +1341,29 @@ func (s *Service) tdsqlCleanupExpiredUserStates(ctx context.Context, now time.Ti
 	var total int64
 	for userID, ids := range grouped {
 		placeholders := make([]string, len(ids))
-		args := make([]any, 0, len(ids)+2)
-		for i, id := range ids {
+		for i := range ids {
 			placeholders[i] = "?"
-			args = append(args, id)
 		}
 		idClause := strings.Join(placeholders, ",")
 
 		// Recheck expiry to prevent deleting renewed user states between scan and delete.
 		var err error
 		if s.opts.softDelete {
-			args = append([]any{now}, args...)
+			args := make([]any, 0, len(ids)+3)
+			args = append(args, now)
+			for _, id := range ids {
+				args = append(args, id)
+			}
 			args = append(args, userID, now)
 			_, err = s.mysqlClient.Exec(ctx,
 				fmt.Sprintf(`UPDATE %s SET deleted_at = ? WHERE id IN (%s) AND user_id = ? AND expires_at IS NOT NULL AND expires_at <= ?`,
 					s.tableUserStates, idClause),
 				args...)
 		} else {
+			args := make([]any, 0, len(ids)+2)
+			for _, id := range ids {
+				args = append(args, id)
+			}
 			args = append(args, userID, now)
 			_, err = s.mysqlClient.Exec(ctx,
 				fmt.Sprintf(`DELETE FROM %s WHERE id IN (%s) AND user_id = ? AND expires_at IS NOT NULL AND expires_at <= ?`,

--- a/session/mysql/service.go
+++ b/session/mysql/service.go
@@ -547,10 +547,10 @@ func (s *Service) upsertUserState(ctx context.Context, appName, userID, key stri
 			fmt.Sprintf("INSERT INTO %s (app_name, user_id, `key`, value, created_at, updated_at, expires_at) VALUES (?, ?, ?, ?, ?, ?, ?)", s.tableUserStates),
 			appName, userID, key, value, now, now, expiresAt)
 	} else {
-		// Update existing record
+		// TDSQL PK is (id, user_id); include user_id for shard routing.
 		_, err = s.mysqlClient.Exec(ctx,
-			fmt.Sprintf("UPDATE %s SET value = ?, updated_at = ?, expires_at = ? WHERE id = ?", s.tableUserStates),
-			value, now, expiresAt, id)
+			fmt.Sprintf("UPDATE %s SET value = ?, updated_at = ?, expires_at = ? WHERE id = ? AND user_id = ?", s.tableUserStates),
+			value, now, expiresAt, id, userID)
 	}
 	return err
 }
@@ -922,17 +922,25 @@ func (s *Service) cleanupExpiredData(ctx context.Context) {
 
 	// Clean up expired sessions
 	if s.opts.sessionTTL > 0 {
-		s.cleanupExpiredSessions(ctx, now)
+		if s.opts.tdsqlSharding {
+			s.tdsqlCleanupExpiredSessions(ctx, now)
+		} else {
+			s.cleanupExpiredSessions(ctx, now)
+		}
 	}
 
-	// Clean up expired app states
+	// Clean up expired app states (broadcast table, no routing needed)
 	if s.opts.appStateTTL > 0 {
 		s.cleanupExpiredAppStates(ctx, now)
 	}
 
 	// Clean up expired user states
 	if s.opts.userStateTTL > 0 {
-		s.cleanupExpiredUserStates(ctx, now)
+		if s.opts.tdsqlSharding {
+			s.tdsqlCleanupExpiredUserStates(ctx, now)
+		} else {
+			s.cleanupExpiredUserStates(ctx, now)
+		}
 	}
 }
 
@@ -997,12 +1005,19 @@ func (s *Service) cleanupExpiredSessions(ctx context.Context, now time.Time) {
 func (s *Service) deleteSessions(ctx context.Context, tx *sql.Tx, keys []session.Key, now time.Time) error {
 	// Prepare delete args for verified keys
 	placeholders := make([]string, len(keys))
-	args := make([]any, 0, len(keys)*3)
+	args := make([]any, 0, len(keys)*3+1)
 	for i, key := range keys {
 		placeholders[i] = "(?, ?, ?)"
 		args = append(args, key.AppName, key.UserID, key.SessionID)
 	}
 	whereClause := fmt.Sprintf(`(app_name, user_id, session_id) IN (%s) AND deleted_at IS NULL`, strings.Join(placeholders, ","))
+
+	// TDSQL proxy cannot extract shardkey from tuple comparison.
+	// Add explicit user_id = ? for DML routing when all keys share the same user_id.
+	if s.opts.tdsqlSharding && len(keys) > 0 {
+		whereClause += " AND user_id = ?"
+		args = append(args, keys[0].UserID)
+	}
 
 	if s.opts.softDelete {
 		return s.softDeleteSessions(ctx, tx, whereClause, args, now)
@@ -1157,6 +1172,132 @@ func (s *Service) cleanupExpiredUserStates(ctx context.Context, now time.Time) {
 			"cleaned up %d expired user states",
 			deletedCount,
 		)
+	}
+}
+
+// tdsqlCleanupExpiredSessions uses two-phase cleanup for TDSQL distributed mode.
+// Phase 1: scan expired sessions without FOR UPDATE (cross-shard read is allowed).
+// Phase 2: delete per user_id so DML routes to the correct shard.
+func (s *Service) tdsqlCleanupExpiredSessions(ctx context.Context, now time.Time) {
+	query := fmt.Sprintf(`SELECT app_name, user_id, session_id FROM %s
+		WHERE expires_at IS NOT NULL AND expires_at <= ? AND deleted_at IS NULL
+		LIMIT 1000`,
+		s.tableSessionStates)
+
+	var sessionKeys []session.Key
+	err := s.mysqlClient.Query(ctx, func(rows *sql.Rows) error {
+		var app, user, sess string
+		if err := rows.Scan(&app, &user, &sess); err != nil {
+			return err
+		}
+		sessionKeys = append(sessionKeys, session.Key{
+			AppName: app, UserID: user, SessionID: sess,
+		})
+		return nil
+	}, query, now)
+
+	if err != nil {
+		log.ErrorfContext(ctx, "tdsql cleanup: scan expired sessions failed: %v", err)
+		return
+	}
+	if len(sessionKeys) == 0 {
+		return
+	}
+
+	// Group by user_id for shard-local DML.
+	grouped := make(map[string][]session.Key)
+	for _, k := range sessionKeys {
+		grouped[k.UserID] = append(grouped[k.UserID], k)
+	}
+
+	var total int64
+	for _, keys := range grouped {
+		err := s.mysqlClient.Transaction(ctx, func(tx *sql.Tx) error {
+			return s.deleteSessions(ctx, tx, keys, now)
+		})
+		if err != nil {
+			log.ErrorfContext(ctx, "tdsql cleanup: delete sessions failed: %v", err)
+			continue
+		}
+		total += int64(len(keys))
+	}
+
+	if total > 0 {
+		log.InfofContext(ctx, "tdsql cleanup: cleaned up %d expired sessions", total)
+	}
+}
+
+// tdsqlCleanupExpiredUserStates uses two-phase cleanup for TDSQL distributed mode.
+// Phase 1: scan expired user_states to get (id, user_id) pairs.
+// Phase 2: delete per user_id for shard routing.
+func (s *Service) tdsqlCleanupExpiredUserStates(ctx context.Context, now time.Time) {
+	type idPair struct {
+		id     int64
+		userID string
+	}
+
+	query := fmt.Sprintf(`SELECT id, user_id FROM %s
+		WHERE expires_at IS NOT NULL AND expires_at <= ? AND deleted_at IS NULL
+		LIMIT 1000`, s.tableUserStates)
+
+	var pairs []idPair
+	err := s.mysqlClient.Query(ctx, func(rows *sql.Rows) error {
+		var p idPair
+		if err := rows.Scan(&p.id, &p.userID); err != nil {
+			return err
+		}
+		pairs = append(pairs, p)
+		return nil
+	}, query, now)
+
+	if err != nil {
+		log.ErrorfContext(ctx, "tdsql cleanup: scan expired user states failed: %v", err)
+		return
+	}
+	if len(pairs) == 0 {
+		return
+	}
+
+	// Group by user_id for shard-local DML.
+	grouped := make(map[string][]int64)
+	for _, p := range pairs {
+		grouped[p.userID] = append(grouped[p.userID], p.id)
+	}
+
+	var total int64
+	for userID, ids := range grouped {
+		placeholders := make([]string, len(ids))
+		args := make([]any, 0, len(ids)+2)
+		for i, id := range ids {
+			placeholders[i] = "?"
+			args = append(args, id)
+		}
+		idClause := strings.Join(placeholders, ",")
+
+		var err error
+		if s.opts.softDelete {
+			args = append([]any{now}, args...)
+			args = append(args, userID)
+			_, err = s.mysqlClient.Exec(ctx,
+				fmt.Sprintf(`UPDATE %s SET deleted_at = ? WHERE id IN (%s) AND user_id = ?`,
+					s.tableUserStates, idClause),
+				args...)
+		} else {
+			args = append(args, userID)
+			_, err = s.mysqlClient.Exec(ctx,
+				fmt.Sprintf(`DELETE FROM %s WHERE id IN (%s) AND user_id = ?`,
+					s.tableUserStates, idClause),
+				args...)
+		}
+		if err != nil {
+			log.ErrorfContext(ctx, "tdsql cleanup: delete user states failed: %v", err)
+			continue
+		}
+		total += int64(len(ids))
+	}
+
+	if total > 0 {
+		log.InfofContext(ctx, "tdsql cleanup: cleaned up %d expired user states", total)
 	}
 }
 

--- a/session/mysql/service.go
+++ b/session/mysql/service.go
@@ -1019,6 +1019,12 @@ func (s *Service) deleteSessions(ctx context.Context, tx *sql.Tx, keys []session
 		args = append(args, keys[0].UserID)
 	}
 
+	// Recheck expiry to prevent deleting renewed sessions between scan and delete
+	// (two-phase cleanup has no row lock across phases). Redundant but safe for
+	// single-phase MySQL cleanup where FOR UPDATE already holds the lock.
+	whereClause += " AND expires_at IS NOT NULL AND expires_at <= ?"
+	args = append(args, now)
+
 	if s.opts.softDelete {
 		return s.softDeleteSessions(ctx, tx, whereClause, args, now)
 	}
@@ -1274,18 +1280,19 @@ func (s *Service) tdsqlCleanupExpiredUserStates(ctx context.Context, now time.Ti
 		}
 		idClause := strings.Join(placeholders, ",")
 
+		// Recheck expiry to prevent deleting renewed user states between scan and delete.
 		var err error
 		if s.opts.softDelete {
 			args = append([]any{now}, args...)
-			args = append(args, userID)
+			args = append(args, userID, now)
 			_, err = s.mysqlClient.Exec(ctx,
-				fmt.Sprintf(`UPDATE %s SET deleted_at = ? WHERE id IN (%s) AND user_id = ?`,
+				fmt.Sprintf(`UPDATE %s SET deleted_at = ? WHERE id IN (%s) AND user_id = ? AND expires_at IS NOT NULL AND expires_at <= ?`,
 					s.tableUserStates, idClause),
 				args...)
 		} else {
-			args = append(args, userID)
+			args = append(args, userID, now)
 			_, err = s.mysqlClient.Exec(ctx,
-				fmt.Sprintf(`DELETE FROM %s WHERE id IN (%s) AND user_id = ?`,
+				fmt.Sprintf(`DELETE FROM %s WHERE id IN (%s) AND user_id = ? AND expires_at IS NOT NULL AND expires_at <= ?`,
 					s.tableUserStates, idClause),
 				args...)
 		}

--- a/session/mysql/service_edge_test.go
+++ b/session/mysql/service_edge_test.go
@@ -87,7 +87,7 @@ func TestGetSession(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows([]string{"key", "value"}))
 
 		mock.ExpectQuery("SELECT id, app_name, user_id, session_id, event, created_at FROM").
-			WithArgs(key.AppName, key.UserID, key.SessionID).
+			WithArgs(key.AppName, key.UserID, key.SessionID, key.UserID).
 			WillReturnRows(sqlmock.NewRows([]string{"id", "app_name", "user_id", "session_id", "event", "created_at"}).
 				AddRow(int64(1), "app1", "user1", "session1", []byte("invalid-event-json"), time.Now()))
 
@@ -152,7 +152,7 @@ func TestGetSession(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows([]string{"key", "value"}))
 
 		mock.ExpectQuery("SELECT id, app_name, user_id, session_id, event, created_at FROM").
-			WithArgs(key.AppName, key.UserID, key.SessionID).
+			WithArgs(key.AppName, key.UserID, key.SessionID, key.UserID).
 			WillReturnRows(sqlmock.NewRows([]string{"id", "app_name", "user_id", "session_id", "event", "created_at"}))
 
 		// GetSession is a pure read operation - no UPDATE expected.
@@ -297,7 +297,7 @@ func TestGetEventsList(t *testing.T) {
 			AddRow(int64(1), "app1", "user1", "sess1", []byte("invalid-json"), time.Now())
 
 		mock.ExpectQuery("SELECT id, app_name, user_id, session_id, event, created_at FROM").
-			WithArgs("app1", "user1", "sess1").
+			WithArgs("app1", "user1", "sess1", "user1").
 			WillReturnRows(rows)
 
 		result, err := s.getEventsList(context.Background(), keys, createdAts, 0, time.Time{}, nil)
@@ -360,7 +360,7 @@ func TestGetEventsList(t *testing.T) {
 			AddRow(int64(3), keys[0].AppName, keys[0].UserID, keys[0].SessionID, evt3Bytes, now)
 
 		mock.ExpectQuery("SELECT id, app_name, user_id, session_id, event, created_at FROM").
-			WithArgs(keys[0].AppName, keys[0].UserID, keys[0].SessionID).
+			WithArgs(keys[0].AppName, keys[0].UserID, keys[0].SessionID, keys[0].UserID).
 			WillReturnRows(rows)
 
 		result, err := s.getEventsList(context.Background(), keys, createdAts, 2, time.Time{}, nil)
@@ -404,7 +404,7 @@ func TestGetEventsList(t *testing.T) {
 			AddRow(int64(3), "app1", "user1", "sess1", evt3Bytes, now)
 
 		mock.ExpectQuery("SELECT id, app_name, user_id, session_id, event, created_at FROM").
-			WithArgs("app1", "user1", "sess1").
+			WithArgs("app1", "user1", "sess1", "user1").
 			WillReturnRows(rows)
 
 		result, err := s.getEventsList(context.Background(), keys, createdAts, 2, time.Time{}, nil)
@@ -449,7 +449,7 @@ func TestGetEventsList(t *testing.T) {
 			AddRow(int64(1), "app1", "user1", "sess1", evt1Bytes, now)
 
 		mock.ExpectQuery("SELECT id, app_name, user_id, session_id, event, created_at FROM").
-			WithArgs("app1", "user1", "sess1").
+			WithArgs("app1", "user1", "sess1", "user1").
 			WillReturnRows(rows)
 
 		result, err := s.getEventsList(context.Background(), keys, createdAts, 0, time.Time{}, nil)
@@ -500,7 +500,7 @@ func TestGetEventsList(t *testing.T) {
 			AddRow(int64(10), evt3Bytes).
 			AddRow(int64(11), evt2Bytes)
 		mock.ExpectQuery("SELECT id, event FROM").
-			WithArgs(int64(10), int64(11)).
+			WithArgs(int64(10), int64(11), "user1").
 			WillReturnRows(eventRows)
 
 		result, err := s.getEventsList(
@@ -553,7 +553,7 @@ func TestGetEventsList(t *testing.T) {
 			AddRow(int64(2), evt2Bytes).
 			AddRow(int64(1), evt1Bytes)
 		mock.ExpectQuery("SELECT id, event FROM").
-			WithArgs(int64(3), int64(2), int64(1)).
+			WithArgs(int64(3), int64(2), int64(1), "user1").
 			WillReturnRows(eventRows)
 
 		result, err := s.getEventsList(
@@ -597,7 +597,7 @@ func TestGetEventsList(t *testing.T) {
 		eventRows := sqlmock.NewRows([]string{"id", "event"}).
 			AddRow(int64(10), evt3Bytes)
 		mock.ExpectQuery("SELECT id, event FROM").
-			WithArgs(int64(10), int64(11)).
+			WithArgs(int64(10), int64(11), "user1").
 			WillReturnRows(eventRows)
 
 		result, err := s.getEventsList(
@@ -708,7 +708,7 @@ func TestGetEventsList(t *testing.T) {
 			AddRow(int64(3), "app1", "user1", "sess1", evt3Bytes, now)
 
 		mock.ExpectQuery("SELECT id, app_name, user_id, session_id, event, created_at FROM").
-			WithArgs("app1", "user1", "sess1").
+			WithArgs("app1", "user1", "sess1", "user1").
 			WillReturnRows(rows)
 
 		result, err := s.getEventsList(context.Background(), keys, createdAts, 0, time.Time{}, nil)
@@ -736,7 +736,7 @@ func TestGetEventsList(t *testing.T) {
 			AddRow("app1", "user1")
 
 		mock.ExpectQuery("SELECT id, app_name, user_id, session_id, event, created_at FROM").
-			WithArgs("app1", "user1", "sess1").
+			WithArgs("app1", "user1", "sess1", "user1").
 			WillReturnRows(rows)
 
 		result, err := s.getEventsList(context.Background(), keys, createdAts, 0, time.Time{}, nil)
@@ -763,7 +763,7 @@ func TestGetSummariesList(t *testing.T) {
 		AddRow("app1", "user1", "sess1", "filter1", []byte("invalid-json"), time.Now())
 
 	mock.ExpectQuery("SELECT app_name, user_id, session_id, filter_key, summary, updated_at FROM session_summaries").
-		WithArgs("app1", "user1", "sess1", sqlmock.AnyArg()).
+		WithArgs("app1", "user1", "sess1", "user1", sqlmock.AnyArg()).
 		WillReturnRows(rows)
 
 	result, err := s.getSummariesList(context.Background(), keys, createdAts)

--- a/session/mysql/service_edge_test.go
+++ b/session/mysql/service_edge_test.go
@@ -928,6 +928,9 @@ func TestCleanupExpired(t *testing.T) {
 		mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id FROM session_states")).
 			WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id"}).
 				AddRow("app-1", "user-1", "session-1"))
+		mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id FROM session_states WHERE")).
+			WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id"}).
+				AddRow("app-1", "user-1", "session-1"))
 
 		// Mock: Soft delete session states
 		mock.ExpectExec("UPDATE session_states SET deleted_at").
@@ -1439,6 +1442,9 @@ func TestCleanupExpiredSessions_DeleteError(t *testing.T) {
 
 	mock.ExpectBegin()
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id FROM session_states")).
+		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id"}).
+			AddRow("app", "user", "sess"))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id FROM session_states WHERE")).
 		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id"}).
 			AddRow("app", "user", "sess"))
 

--- a/session/mysql/service_helper.go
+++ b/session/mysql/service_helper.go
@@ -547,10 +547,14 @@ func (s *Service) getEventsList(
 		afterTime = time.Now().Add(-s.opts.sessionTTL)
 	}
 
+	// TDSQL proxy cannot extract shardkey from tuple comparison;
+	// add explicit user_id for shard routing. Harmless on MySQL.
 	query := fmt.Sprintf(`SELECT id, app_name, user_id, session_id, event, created_at FROM %s
 		WHERE (app_name, user_id, session_id) IN (%s)
+		AND user_id = ?
 		AND deleted_at IS NULL`,
 		s.tableSessionEvents, strings.Join(placeholders, ","))
+	args = append(args, sessionKeys[0].UserID)
 
 	sessionCreatedAtMap := make(map[string]time.Time, len(sessionKeys))
 	for i, key := range sessionKeys {
@@ -678,8 +682,10 @@ func (s *Service) getPagedEvents(
 		args[i] = ref.id
 	}
 
-	eventsQuery := fmt.Sprintf(`SELECT id, event FROM %s WHERE id IN (%s)`,
+	// TDSQL PK is (id, user_id); include user_id for shard routing.
+	eventsQuery := fmt.Sprintf(`SELECT id, event FROM %s WHERE id IN (%s) AND user_id = ?`,
 		s.tableSessionEvents, strings.Join(placeholders, ","))
+	args = append(args, key.UserID)
 
 	eventsByID := make(map[int64]event.Event, len(refs))
 	err = s.mysqlClient.Query(ctx, func(rows *sql.Rows) error {
@@ -836,10 +842,13 @@ func (s *Service) getSummariesList(
 		args = append(args, key.AppName, key.UserID, key.SessionID)
 	}
 
-	args = append(args, time.Now())
+	// TDSQL proxy cannot extract shardkey from tuple comparison;
+	// add explicit user_id for shard routing. Harmless on MySQL.
+	args = append(args, sessionKeys[0].UserID, time.Now())
 
 	query := fmt.Sprintf(`SELECT app_name, user_id, session_id, filter_key, summary, updated_at FROM %s
 		WHERE (app_name, user_id, session_id) IN (%s)
+		AND user_id = ?
 		AND (expires_at IS NULL OR expires_at > ?)
 		AND deleted_at IS NULL`,
 		s.tableSessionSummaries, strings.Join(placeholders, ","))

--- a/session/mysql/service_helper_test.go
+++ b/session/mysql/service_helper_test.go
@@ -69,7 +69,7 @@ func TestGetSession_Success(t *testing.T) {
 
 	// Mock: Query events (empty)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, app_name, user_id, session_id, event, created_at FROM")).
-		WithArgs(key.AppName, key.UserID, key.SessionID).
+		WithArgs(key.AppName, key.UserID, key.SessionID, key.UserID).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "app_name", "user_id", "session_id", "event", "created_at"}))
 
 	sess, err := s.GetSession(ctx, key)
@@ -164,7 +164,7 @@ func TestGetSession_WithLimit(t *testing.T) {
 
 	// Mock: Query events with limit
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, app_name, user_id, session_id, event, created_at FROM")).
-		WithArgs(key.AppName, key.UserID, key.SessionID).
+		WithArgs(key.AppName, key.UserID, key.SessionID, key.UserID).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "app_name", "user_id", "session_id", "event", "created_at"}).
 			AddRow(int64(1), key.AppName, key.UserID, key.SessionID, eventBytes, time.Now()))
 
@@ -221,7 +221,7 @@ func TestGetSession_WithTrackEvents(t *testing.T) {
 
 	// Mock: Query events (empty).
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, app_name, user_id, session_id, event, created_at FROM")).
-		WithArgs(key.AppName, key.UserID, key.SessionID).
+		WithArgs(key.AppName, key.UserID, key.SessionID, key.UserID).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "app_name", "user_id", "session_id", "event", "created_at"}))
 
 	// Mock: Query track events.
@@ -290,7 +290,7 @@ func TestGetSession_WithTTL(t *testing.T) {
 
 	// Mock: Query events
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, app_name, user_id, session_id, event, created_at FROM")).
-		WithArgs(key.AppName, key.UserID, key.SessionID).
+		WithArgs(key.AppName, key.UserID, key.SessionID, key.UserID).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "app_name", "user_id", "session_id", "event", "created_at"}))
 
 	sess, err := s.GetSession(ctx, key)

--- a/session/mysql/service_test.go
+++ b/session/mysql/service_test.go
@@ -1058,6 +1058,263 @@ func TestCleanupExpiredSessions(t *testing.T) {
 	}
 }
 
+func TestSessionKeysWhereClause(t *testing.T) {
+	db, _, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db)
+	keys := []session.Key{
+		{AppName: "app-1", UserID: "user-1", SessionID: "session-1"},
+		{AppName: "app-1", UserID: "user-1", SessionID: "session-2"},
+	}
+
+	whereClause, args := s.sessionKeysWhereClause(nil)
+	assert.Empty(t, whereClause)
+	assert.Nil(t, args)
+
+	n, err := s.deleteSessions(context.Background(), nil, nil, time.Now())
+	assert.NoError(t, err)
+	assert.Zero(t, n)
+
+	whereClause, args = s.sessionKeysWhereClause(keys)
+	assert.Equal(t, "(app_name, user_id, session_id) IN ((?, ?, ?),(?, ?, ?)) AND deleted_at IS NULL", whereClause)
+	assert.Equal(t, []any{"app-1", "user-1", "session-1", "app-1", "user-1", "session-2"}, args)
+
+	s.opts.tdsqlSharding = true
+	whereClause, args = s.sessionKeysWhereClause(keys)
+	assert.Equal(t, "(app_name, user_id, session_id) IN ((?, ?, ?),(?, ?, ?)) AND deleted_at IS NULL AND user_id = ?", whereClause)
+	assert.Equal(t, []any{"app-1", "user-1", "session-1", "app-1", "user-1", "session-2", "user-1"}, args)
+}
+
+func TestLockExpiredSessionKeysErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		rows *sqlmock.Rows
+	}{
+		{
+			name: "ScanError",
+			rows: sqlmock.NewRows([]string{"app_name", "user_id", "session_id"}).
+				AddRow(nil, "user-1", "session-1"),
+		},
+		{
+			name: "RowsError",
+			rows: sqlmock.NewRows([]string{"app_name", "user_id", "session_id"}).
+				AddRow("app-1", "user-1", "session-1").
+				RowError(0, assert.AnError),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			require.NoError(t, err)
+			defer db.Close()
+
+			s := createTestService(t, db)
+			mock.ExpectBegin()
+			mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id FROM session_states WHERE")).
+				WithArgs("app-1").
+				WillReturnRows(tt.rows)
+			mock.ExpectRollback()
+
+			tx, err := db.Begin()
+			require.NoError(t, err)
+
+			keys, err := s.lockExpiredSessionKeys(context.Background(), tx, "app_name = ?", []any{"app-1"})
+			assert.Error(t, err)
+			assert.Nil(t, keys)
+			assert.NoError(t, tx.Rollback())
+			assert.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestLockExpiredSessionKeysQueryError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db)
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id FROM session_states WHERE")).
+		WithArgs("app-1").
+		WillReturnError(assert.AnError)
+	mock.ExpectRollback()
+
+	tx, err := db.Begin()
+	require.NoError(t, err)
+
+	keys, err := s.lockExpiredSessionKeys(context.Background(), tx, "app_name = ?", []any{"app-1"})
+	assert.ErrorContains(t, err, "recheck expired sessions failed")
+	assert.Nil(t, keys)
+	assert.NoError(t, tx.Rollback())
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestDeleteSessionsRecheckError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db)
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id FROM session_states WHERE")).
+		WithArgs("app-1", "user-1", "session-1", sqlmock.AnyArg()).
+		WillReturnError(assert.AnError)
+	mock.ExpectRollback()
+
+	tx, err := db.Begin()
+	require.NoError(t, err)
+
+	n, err := s.deleteSessions(context.Background(), tx, []session.Key{{
+		AppName:   "app-1",
+		UserID:    "user-1",
+		SessionID: "session-1",
+	}}, time.Now())
+	assert.Error(t, err)
+	assert.Zero(t, n)
+	assert.NoError(t, tx.Rollback())
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSoftDeleteSessionsChildErrors(t *testing.T) {
+	tests := []struct {
+		name          string
+		expectFailure func(mock sqlmock.Sqlmock)
+		wantErr       string
+	}{
+		{
+			name: "SummariesError",
+			expectFailure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec(regexp.QuoteMeta("UPDATE session_summaries SET deleted_at = ?")).
+					WillReturnError(assert.AnError)
+			},
+			wantErr: "soft delete summaries",
+		},
+		{
+			name: "EventsError",
+			expectFailure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec(regexp.QuoteMeta("UPDATE session_summaries SET deleted_at = ?")).
+					WillReturnResult(sqlmock.NewResult(0, 1))
+				mock.ExpectExec(regexp.QuoteMeta("UPDATE session_events SET deleted_at = ?")).
+					WillReturnError(assert.AnError)
+			},
+			wantErr: "soft delete events",
+		},
+		{
+			name: "TrackEventsError",
+			expectFailure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec(regexp.QuoteMeta("UPDATE session_summaries SET deleted_at = ?")).
+					WillReturnResult(sqlmock.NewResult(0, 1))
+				mock.ExpectExec(regexp.QuoteMeta("UPDATE session_events SET deleted_at = ?")).
+					WillReturnResult(sqlmock.NewResult(0, 1))
+				mock.ExpectExec(regexp.QuoteMeta("UPDATE session_track_events SET deleted_at = ?")).
+					WillReturnError(assert.AnError)
+			},
+			wantErr: "soft delete track events",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			require.NoError(t, err)
+			defer db.Close()
+
+			s := createTestService(t, db)
+			mock.ExpectBegin()
+			mock.ExpectExec(regexp.QuoteMeta("UPDATE session_states SET deleted_at = ?")).
+				WillReturnResult(sqlmock.NewResult(0, 1))
+			tt.expectFailure(mock)
+			mock.ExpectRollback()
+
+			tx, err := db.Begin()
+			require.NoError(t, err)
+			err = s.softDeleteSessions(
+				context.Background(),
+				tx,
+				"app_name = ? AND expires_at IS NOT NULL AND expires_at <= ?",
+				[]any{"app-1", time.Now()},
+				"app_name = ?",
+				[]any{"app-1"},
+				time.Now(),
+			)
+			assert.ErrorContains(t, err, tt.wantErr)
+			assert.NoError(t, tx.Rollback())
+			assert.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestHardDeleteSessionsChildErrors(t *testing.T) {
+	tests := []struct {
+		name          string
+		expectFailure func(mock sqlmock.Sqlmock)
+		wantErr       string
+	}{
+		{
+			name: "SummariesError",
+			expectFailure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec(regexp.QuoteMeta("DELETE FROM session_summaries")).
+					WillReturnError(assert.AnError)
+			},
+			wantErr: "hard delete summaries",
+		},
+		{
+			name: "EventsError",
+			expectFailure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec(regexp.QuoteMeta("DELETE FROM session_summaries")).
+					WillReturnResult(sqlmock.NewResult(0, 1))
+				mock.ExpectExec(regexp.QuoteMeta("DELETE FROM session_events")).
+					WillReturnError(assert.AnError)
+			},
+			wantErr: "hard delete events",
+		},
+		{
+			name: "TrackEventsError",
+			expectFailure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec(regexp.QuoteMeta("DELETE FROM session_summaries")).
+					WillReturnResult(sqlmock.NewResult(0, 1))
+				mock.ExpectExec(regexp.QuoteMeta("DELETE FROM session_events")).
+					WillReturnResult(sqlmock.NewResult(0, 1))
+				mock.ExpectExec(regexp.QuoteMeta("DELETE FROM session_track_events")).
+					WillReturnError(assert.AnError)
+			},
+			wantErr: "hard delete track events",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			require.NoError(t, err)
+			defer db.Close()
+
+			s := createTestService(t, db)
+			mock.ExpectBegin()
+			mock.ExpectExec(regexp.QuoteMeta("DELETE FROM session_states")).
+				WillReturnResult(sqlmock.NewResult(0, 1))
+			tt.expectFailure(mock)
+			mock.ExpectRollback()
+
+			tx, err := db.Begin()
+			require.NoError(t, err)
+			err = s.hardDeleteSessions(
+				context.Background(),
+				tx,
+				"app_name = ? AND expires_at IS NOT NULL AND expires_at <= ?",
+				[]any{"app-1", time.Now()},
+				"app_name = ?",
+				[]any{"app-1"},
+			)
+			assert.ErrorContains(t, err, tt.wantErr)
+			assert.NoError(t, tx.Rollback())
+			assert.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
 // Mock summarizer for testing
 type mockSummarizer struct {
 	summarizeFunc       func(ctx context.Context, sess *session.Session) (string, error)
@@ -3588,6 +3845,24 @@ func TestTDSQLCleanupExpiredSessions_ScanError(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestTDSQLCleanupExpiredSessions_RowScanError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db,
+		WithSessionTTL(time.Hour),
+		WithTDSQLSharding(true),
+	)
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id FROM session_states")).
+		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id"}).
+			AddRow(nil, "user-1", "session-1"))
+
+	s.tdsqlCleanupExpiredSessions(context.Background(), time.Now())
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestTDSQLCleanupExpiredSessions_NoExpired(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
@@ -3716,6 +3991,41 @@ func TestTDSQLCleanupExpiredUserStates_ScanError(t *testing.T) {
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, user_id FROM user_states")).
 		WillReturnError(assert.AnError)
+
+	s.tdsqlCleanupExpiredUserStates(context.Background(), time.Now())
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestTDSQLCleanupExpiredUserStates_RowScanError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db,
+		WithUserStateTTL(time.Hour),
+		WithTDSQLSharding(true),
+	)
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, user_id FROM user_states")).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id"}).
+			AddRow(nil, "user-1"))
+
+	s.tdsqlCleanupExpiredUserStates(context.Background(), time.Now())
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestTDSQLCleanupExpiredUserStates_NoExpired(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db,
+		WithUserStateTTL(time.Hour),
+		WithTDSQLSharding(true),
+	)
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, user_id FROM user_states")).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id"}))
 
 	s.tdsqlCleanupExpiredUserStates(context.Background(), time.Now())
 	assert.NoError(t, mock.ExpectationsWereMet())

--- a/session/mysql/service_test.go
+++ b/session/mysql/service_test.go
@@ -1017,32 +1017,36 @@ func TestCleanupExpiredSessions(t *testing.T) {
 			mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id FROM session_states")).
 				WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id"}).
 					AddRow("app-1", "user-1", "session-1"))
+			mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id FROM session_states WHERE")).
+				WithArgs("app-1", "user-1", "session-1", sqlmock.AnyArg()).
+				WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id"}).
+					AddRow("app-1", "user-1", "session-1"))
 
 			if tt.softDelete {
 				mock.ExpectExec(regexp.QuoteMeta("UPDATE session_states SET deleted_at = ?")).
 					WithArgs(sqlmock.AnyArg(), "app-1", "user-1", "session-1", sqlmock.AnyArg()).
 					WillReturnResult(sqlmock.NewResult(0, 1))
 				mock.ExpectExec(regexp.QuoteMeta("UPDATE session_summaries SET deleted_at = ?")).
-					WithArgs(sqlmock.AnyArg(), "app-1", "user-1", "session-1", sqlmock.AnyArg()).
+					WithArgs(sqlmock.AnyArg(), "app-1", "user-1", "session-1").
 					WillReturnResult(sqlmock.NewResult(0, 0))
 				mock.ExpectExec(regexp.QuoteMeta("UPDATE session_events SET deleted_at = ?")).
-					WithArgs(sqlmock.AnyArg(), "app-1", "user-1", "session-1", sqlmock.AnyArg()).
+					WithArgs(sqlmock.AnyArg(), "app-1", "user-1", "session-1").
 					WillReturnResult(sqlmock.NewResult(0, 0))
 				mock.ExpectExec(regexp.QuoteMeta("UPDATE session_track_events SET deleted_at = ?")).
-					WithArgs(sqlmock.AnyArg(), "app-1", "user-1", "session-1", sqlmock.AnyArg()).
+					WithArgs(sqlmock.AnyArg(), "app-1", "user-1", "session-1").
 					WillReturnResult(sqlmock.NewResult(0, 0))
 			} else {
 				mock.ExpectExec(regexp.QuoteMeta("DELETE FROM session_states")).
 					WithArgs("app-1", "user-1", "session-1", sqlmock.AnyArg()).
 					WillReturnResult(sqlmock.NewResult(0, 1))
 				mock.ExpectExec(regexp.QuoteMeta("DELETE FROM session_summaries")).
-					WithArgs("app-1", "user-1", "session-1", sqlmock.AnyArg()).
+					WithArgs("app-1", "user-1", "session-1").
 					WillReturnResult(sqlmock.NewResult(0, 0))
 				mock.ExpectExec(regexp.QuoteMeta("DELETE FROM session_events")).
-					WithArgs("app-1", "user-1", "session-1", sqlmock.AnyArg()).
+					WithArgs("app-1", "user-1", "session-1").
 					WillReturnResult(sqlmock.NewResult(0, 0))
 				mock.ExpectExec(regexp.QuoteMeta("DELETE FROM session_track_events")).
-					WithArgs("app-1", "user-1", "session-1", sqlmock.AnyArg()).
+					WithArgs("app-1", "user-1", "session-1").
 					WillReturnResult(sqlmock.NewResult(0, 0))
 			}
 
@@ -2350,6 +2354,10 @@ func TestCleanupExpiredData(t *testing.T) {
 		WithArgs(sqlmock.AnyArg()). // now
 		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id"}).
 			AddRow("app-1", "user-1", "session-1"))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id FROM session_states WHERE")).
+		WithArgs("app-1", "user-1", "session-1", sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id"}).
+			AddRow("app-1", "user-1", "session-1"))
 
 	// 2. Soft delete session states
 	mock.ExpectExec(regexp.QuoteMeta("UPDATE session_states SET deleted_at = ?")).
@@ -2358,17 +2366,17 @@ func TestCleanupExpiredData(t *testing.T) {
 
 	// 3. Soft delete summaries
 	mock.ExpectExec(regexp.QuoteMeta("UPDATE session_summaries SET deleted_at = ?")).
-		WithArgs(sqlmock.AnyArg(), "app-1", "user-1", "session-1", sqlmock.AnyArg()).
+		WithArgs(sqlmock.AnyArg(), "app-1", "user-1", "session-1").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	// 4. Soft delete events
 	mock.ExpectExec(regexp.QuoteMeta("UPDATE session_events SET deleted_at = ?")).
-		WithArgs(sqlmock.AnyArg(), "app-1", "user-1", "session-1", sqlmock.AnyArg()).
+		WithArgs(sqlmock.AnyArg(), "app-1", "user-1", "session-1").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	// 5. Soft delete track events
 	mock.ExpectExec(regexp.QuoteMeta("UPDATE session_track_events SET deleted_at = ?")).
-		WithArgs(sqlmock.AnyArg(), "app-1", "user-1", "session-1", sqlmock.AnyArg()).
+		WithArgs(sqlmock.AnyArg(), "app-1", "user-1", "session-1").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()
 
@@ -2398,19 +2406,23 @@ func TestCleanupExpiredSessions_HardDelete(t *testing.T) {
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id FROM session_states")).
 		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id"}).
 			AddRow("app-1", "user-1", "session-1"))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id FROM session_states WHERE")).
+		WithArgs("app-1", "user-1", "session-1", sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id"}).
+			AddRow("app-1", "user-1", "session-1"))
 
 	// Mock hard delete sessions, events, and summaries in transaction
 	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM session_states")).
 		WithArgs("app-1", "user-1", "session-1", sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM session_summaries")).
-		WithArgs("app-1", "user-1", "session-1", sqlmock.AnyArg()).
+		WithArgs("app-1", "user-1", "session-1").
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM session_events")).
-		WithArgs("app-1", "user-1", "session-1", sqlmock.AnyArg()).
+		WithArgs("app-1", "user-1", "session-1").
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM session_track_events")).
-		WithArgs("app-1", "user-1", "session-1", sqlmock.AnyArg()).
+		WithArgs("app-1", "user-1", "session-1").
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 
@@ -3527,6 +3539,11 @@ func TestTDSQLCleanupExpiredSessions(t *testing.T) {
 
 			// Phase 2: grouped delete (both keys share user_id="user-1")
 			mock.ExpectBegin()
+			mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id FROM session_states WHERE")).
+				WithArgs("app-1", "user-1", "session-1", "app-1", "user-1", "session-2", "user-1", sqlmock.AnyArg()).
+				WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id"}).
+					AddRow("app-1", "user-1", "session-1").
+					AddRow("app-1", "user-1", "session-2"))
 			if tt.softDelete {
 				mock.ExpectExec(regexp.QuoteMeta("UPDATE session_states SET deleted_at = ?")).
 					WillReturnResult(sqlmock.NewResult(0, 2))
@@ -3588,6 +3605,32 @@ func TestTDSQLCleanupExpiredSessions_NoExpired(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestTDSQLCleanupExpiredSessions_RecheckSkipsRenewedSession(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db,
+		WithSessionTTL(time.Hour),
+		WithTDSQLSharding(true),
+		WithSoftDelete(true),
+	)
+	ctx := context.Background()
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id FROM session_states")).
+		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id"}).
+			AddRow("app-1", "user-1", "session-1"))
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id FROM session_states WHERE")).
+		WithArgs("app-1", "user-1", "session-1", "user-1", sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id"}))
+	mock.ExpectCommit()
+
+	s.tdsqlCleanupExpiredSessions(ctx, time.Now())
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestTDSQLCleanupExpiredSessions_DeleteError(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
@@ -3605,6 +3648,9 @@ func TestTDSQLCleanupExpiredSessions_DeleteError(t *testing.T) {
 			AddRow("app-1", "user-1", "session-1"))
 
 	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id FROM session_states WHERE")).
+		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id"}).
+			AddRow("app-1", "user-1", "session-1"))
 	mock.ExpectExec(regexp.QuoteMeta("UPDATE session_states SET deleted_at = ?")).
 		WillReturnError(assert.AnError)
 	mock.ExpectRollback()
@@ -3717,6 +3763,9 @@ func TestTDSQLCleanupExpiredData(t *testing.T) {
 			AddRow("app-1", "user-1", "session-1"))
 
 	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id FROM session_states WHERE")).
+		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id"}).
+			AddRow("app-1", "user-1", "session-1"))
 	mock.ExpectExec(regexp.QuoteMeta("UPDATE session_states SET deleted_at = ?")).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec(regexp.QuoteMeta("UPDATE session_summaries SET deleted_at = ?")).

--- a/session/mysql/service_test.go
+++ b/session/mysql/service_test.go
@@ -1916,7 +1916,7 @@ func TestGetSession_WithEvents(t *testing.T) {
 
 	// Mock: Query events (multiple rows)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, app_name, user_id, session_id, event, created_at FROM")).
-		WithArgs(key.AppName, key.UserID, key.SessionID).
+		WithArgs(key.AppName, key.UserID, key.SessionID, key.UserID).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "app_name", "user_id", "session_id", "event", "created_at"}).
 			AddRow(int64(1), key.AppName, key.UserID, key.SessionID, event1Bytes, time.Now()).
 			AddRow(int64(2), key.AppName, key.UserID, key.SessionID, event2Bytes, time.Now()))
@@ -1929,7 +1929,7 @@ func TestGetSession_WithEvents(t *testing.T) {
 
 	// Mock: Query summaries (multiple rows)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, filter_key, summary, updated_at FROM session_summaries")).
-		WithArgs(key.AppName, key.UserID, key.SessionID, sqlmock.AnyArg()).
+		WithArgs(key.AppName, key.UserID, key.SessionID, key.UserID, sqlmock.AnyArg()).
 		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "filter_key", "summary", "updated_at"}).
 			AddRow(key.AppName, key.UserID, key.SessionID, "filter1", sum1Bytes, time.Now()).
 			AddRow(key.AppName, key.UserID, key.SessionID, "filter2", sum2Bytes, time.Now()))
@@ -2278,7 +2278,7 @@ func TestGetSession_WithAfterTime(t *testing.T) {
 	// Mock: Query events with afterTime filter (should filter events)
 	afterTime := time.Now().Add(-1 * time.Hour)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, app_name, user_id, session_id, event, created_at FROM")).
-		WithArgs(key.AppName, key.UserID, key.SessionID).
+		WithArgs(key.AppName, key.UserID, key.SessionID, key.UserID).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "app_name", "user_id", "session_id", "event", "created_at"}))
 
 	sess, err := s.GetSession(ctx, key, session.WithEventTime(afterTime))

--- a/session/mysql/service_test.go
+++ b/session/mysql/service_test.go
@@ -1020,29 +1020,29 @@ func TestCleanupExpiredSessions(t *testing.T) {
 
 			if tt.softDelete {
 				mock.ExpectExec(regexp.QuoteMeta("UPDATE session_states SET deleted_at = ?")).
-					WithArgs(sqlmock.AnyArg(), "app-1", "user-1", "session-1").
+					WithArgs(sqlmock.AnyArg(), "app-1", "user-1", "session-1", sqlmock.AnyArg()).
 					WillReturnResult(sqlmock.NewResult(0, 1))
 				mock.ExpectExec(regexp.QuoteMeta("UPDATE session_summaries SET deleted_at = ?")).
-					WithArgs(sqlmock.AnyArg(), "app-1", "user-1", "session-1").
+					WithArgs(sqlmock.AnyArg(), "app-1", "user-1", "session-1", sqlmock.AnyArg()).
 					WillReturnResult(sqlmock.NewResult(0, 0))
 				mock.ExpectExec(regexp.QuoteMeta("UPDATE session_events SET deleted_at = ?")).
-					WithArgs(sqlmock.AnyArg(), "app-1", "user-1", "session-1").
+					WithArgs(sqlmock.AnyArg(), "app-1", "user-1", "session-1", sqlmock.AnyArg()).
 					WillReturnResult(sqlmock.NewResult(0, 0))
 				mock.ExpectExec(regexp.QuoteMeta("UPDATE session_track_events SET deleted_at = ?")).
-					WithArgs(sqlmock.AnyArg(), "app-1", "user-1", "session-1").
+					WithArgs(sqlmock.AnyArg(), "app-1", "user-1", "session-1", sqlmock.AnyArg()).
 					WillReturnResult(sqlmock.NewResult(0, 0))
 			} else {
 				mock.ExpectExec(regexp.QuoteMeta("DELETE FROM session_states")).
-					WithArgs("app-1", "user-1", "session-1").
+					WithArgs("app-1", "user-1", "session-1", sqlmock.AnyArg()).
 					WillReturnResult(sqlmock.NewResult(0, 1))
 				mock.ExpectExec(regexp.QuoteMeta("DELETE FROM session_summaries")).
-					WithArgs("app-1", "user-1", "session-1").
+					WithArgs("app-1", "user-1", "session-1", sqlmock.AnyArg()).
 					WillReturnResult(sqlmock.NewResult(0, 0))
 				mock.ExpectExec(regexp.QuoteMeta("DELETE FROM session_events")).
-					WithArgs("app-1", "user-1", "session-1").
+					WithArgs("app-1", "user-1", "session-1", sqlmock.AnyArg()).
 					WillReturnResult(sqlmock.NewResult(0, 0))
 				mock.ExpectExec(regexp.QuoteMeta("DELETE FROM session_track_events")).
-					WithArgs("app-1", "user-1", "session-1").
+					WithArgs("app-1", "user-1", "session-1", sqlmock.AnyArg()).
 					WillReturnResult(sqlmock.NewResult(0, 0))
 			}
 
@@ -2353,22 +2353,22 @@ func TestCleanupExpiredData(t *testing.T) {
 
 	// 2. Soft delete session states
 	mock.ExpectExec(regexp.QuoteMeta("UPDATE session_states SET deleted_at = ?")).
-		WithArgs(sqlmock.AnyArg(), "app-1", "user-1", "session-1").
+		WithArgs(sqlmock.AnyArg(), "app-1", "user-1", "session-1", sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	// 3. Soft delete summaries
 	mock.ExpectExec(regexp.QuoteMeta("UPDATE session_summaries SET deleted_at = ?")).
-		WithArgs(sqlmock.AnyArg(), "app-1", "user-1", "session-1").
+		WithArgs(sqlmock.AnyArg(), "app-1", "user-1", "session-1", sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	// 4. Soft delete events
 	mock.ExpectExec(regexp.QuoteMeta("UPDATE session_events SET deleted_at = ?")).
-		WithArgs(sqlmock.AnyArg(), "app-1", "user-1", "session-1").
+		WithArgs(sqlmock.AnyArg(), "app-1", "user-1", "session-1", sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	// 5. Soft delete track events
 	mock.ExpectExec(regexp.QuoteMeta("UPDATE session_track_events SET deleted_at = ?")).
-		WithArgs(sqlmock.AnyArg(), "app-1", "user-1", "session-1").
+		WithArgs(sqlmock.AnyArg(), "app-1", "user-1", "session-1", sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()
 
@@ -2401,16 +2401,16 @@ func TestCleanupExpiredSessions_HardDelete(t *testing.T) {
 
 	// Mock hard delete sessions, events, and summaries in transaction
 	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM session_states")).
-		WithArgs("app-1", "user-1", "session-1").
+		WithArgs("app-1", "user-1", "session-1", sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM session_summaries")).
-		WithArgs("app-1", "user-1", "session-1").
+		WithArgs("app-1", "user-1", "session-1", sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM session_events")).
-		WithArgs("app-1", "user-1", "session-1").
+		WithArgs("app-1", "user-1", "session-1", sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM session_track_events")).
-		WithArgs("app-1", "user-1", "session-1").
+		WithArgs("app-1", "user-1", "session-1", sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 
@@ -3482,4 +3482,262 @@ func TestAppendEventInternal_SendOnClosedChannel(t *testing.T) {
 	// Should not panic even though channel is closed.
 	err = s.appendEventInternal(ctx, sess, evt, key)
 	require.NoError(t, err)
+}
+
+func TestWithTDSQLSharding(t *testing.T) {
+	opt := WithTDSQLSharding(true)
+	opts := &ServiceOpts{}
+	opt(opts)
+	assert.True(t, opts.tdsqlSharding)
+
+	opt = WithTDSQLSharding(false)
+	opt(opts)
+	assert.False(t, opts.tdsqlSharding)
+}
+
+func TestTDSQLCleanupExpiredSessions(t *testing.T) {
+	tests := []struct {
+		name       string
+		softDelete bool
+	}{
+		{"SoftDelete", true},
+		{"HardDelete", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			require.NoError(t, err)
+			defer db.Close()
+
+			s := createTestService(t, db,
+				WithSoftDelete(tt.softDelete),
+				WithSessionTTL(time.Hour),
+				WithTDSQLSharding(true),
+			)
+			ctx := context.Background()
+			now := time.Now()
+
+			// Phase 1: scan expired sessions (no FOR UPDATE)
+			mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id FROM session_states")).
+				WithArgs(sqlmock.AnyArg()).
+				WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id"}).
+					AddRow("app-1", "user-1", "session-1").
+					AddRow("app-1", "user-1", "session-2"))
+
+			// Phase 2: grouped delete (both keys share user_id="user-1")
+			mock.ExpectBegin()
+			if tt.softDelete {
+				mock.ExpectExec(regexp.QuoteMeta("UPDATE session_states SET deleted_at = ?")).
+					WillReturnResult(sqlmock.NewResult(0, 2))
+				mock.ExpectExec(regexp.QuoteMeta("UPDATE session_summaries SET deleted_at = ?")).
+					WillReturnResult(sqlmock.NewResult(0, 0))
+				mock.ExpectExec(regexp.QuoteMeta("UPDATE session_events SET deleted_at = ?")).
+					WillReturnResult(sqlmock.NewResult(0, 0))
+				mock.ExpectExec(regexp.QuoteMeta("UPDATE session_track_events SET deleted_at = ?")).
+					WillReturnResult(sqlmock.NewResult(0, 0))
+			} else {
+				mock.ExpectExec(regexp.QuoteMeta("DELETE FROM session_states")).
+					WillReturnResult(sqlmock.NewResult(0, 2))
+				mock.ExpectExec(regexp.QuoteMeta("DELETE FROM session_summaries")).
+					WillReturnResult(sqlmock.NewResult(0, 0))
+				mock.ExpectExec(regexp.QuoteMeta("DELETE FROM session_events")).
+					WillReturnResult(sqlmock.NewResult(0, 0))
+				mock.ExpectExec(regexp.QuoteMeta("DELETE FROM session_track_events")).
+					WillReturnResult(sqlmock.NewResult(0, 0))
+			}
+			mock.ExpectCommit()
+
+			s.tdsqlCleanupExpiredSessions(ctx, now)
+			assert.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestTDSQLCleanupExpiredSessions_ScanError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db,
+		WithSessionTTL(time.Hour),
+		WithTDSQLSharding(true),
+	)
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id FROM session_states")).
+		WillReturnError(assert.AnError)
+
+	s.tdsqlCleanupExpiredSessions(context.Background(), time.Now())
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestTDSQLCleanupExpiredSessions_NoExpired(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db,
+		WithSessionTTL(time.Hour),
+		WithTDSQLSharding(true),
+	)
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id FROM session_states")).
+		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id"}))
+
+	s.tdsqlCleanupExpiredSessions(context.Background(), time.Now())
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestTDSQLCleanupExpiredSessions_DeleteError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db,
+		WithSessionTTL(time.Hour),
+		WithTDSQLSharding(true),
+		WithSoftDelete(true),
+	)
+	ctx := context.Background()
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id FROM session_states")).
+		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id"}).
+			AddRow("app-1", "user-1", "session-1"))
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE session_states SET deleted_at = ?")).
+		WillReturnError(assert.AnError)
+	mock.ExpectRollback()
+
+	s.tdsqlCleanupExpiredSessions(ctx, time.Now())
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestTDSQLCleanupExpiredUserStates(t *testing.T) {
+	tests := []struct {
+		name       string
+		softDelete bool
+	}{
+		{"SoftDelete", true},
+		{"HardDelete", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			require.NoError(t, err)
+			defer db.Close()
+
+			s := createTestService(t, db,
+				WithSoftDelete(tt.softDelete),
+				WithUserStateTTL(time.Hour),
+				WithTDSQLSharding(true),
+			)
+			ctx := context.Background()
+			now := time.Now()
+
+			// Phase 1: scan expired user states
+			mock.ExpectQuery(regexp.QuoteMeta("SELECT id, user_id FROM user_states")).
+				WithArgs(sqlmock.AnyArg()).
+				WillReturnRows(sqlmock.NewRows([]string{"id", "user_id"}).
+					AddRow(100, "user-1").
+					AddRow(101, "user-1"))
+
+			// Phase 2: grouped delete
+			if tt.softDelete {
+				mock.ExpectExec(regexp.QuoteMeta("UPDATE user_states SET deleted_at = ?")).
+					WillReturnResult(sqlmock.NewResult(0, 2))
+			} else {
+				mock.ExpectExec(regexp.QuoteMeta("DELETE FROM user_states")).
+					WillReturnResult(sqlmock.NewResult(0, 2))
+			}
+
+			s.tdsqlCleanupExpiredUserStates(ctx, now)
+			assert.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestTDSQLCleanupExpiredUserStates_ScanError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db,
+		WithUserStateTTL(time.Hour),
+		WithTDSQLSharding(true),
+	)
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, user_id FROM user_states")).
+		WillReturnError(assert.AnError)
+
+	s.tdsqlCleanupExpiredUserStates(context.Background(), time.Now())
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestTDSQLCleanupExpiredUserStates_DeleteError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db,
+		WithUserStateTTL(time.Hour),
+		WithTDSQLSharding(true),
+		WithSoftDelete(true),
+	)
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, user_id FROM user_states")).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id"}).
+			AddRow(100, "user-1"))
+
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE user_states SET deleted_at = ?")).
+		WillReturnError(assert.AnError)
+
+	s.tdsqlCleanupExpiredUserStates(context.Background(), time.Now())
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestTDSQLCleanupExpiredData(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db,
+		WithSessionTTL(time.Hour),
+		WithUserStateTTL(time.Hour),
+		WithAppStateTTL(time.Hour),
+		WithTDSQLSharding(true),
+		WithSoftDelete(true),
+	)
+	ctx := context.Background()
+
+	// TDSQL session cleanup
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id FROM session_states")).
+		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id"}).
+			AddRow("app-1", "user-1", "session-1"))
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE session_states SET deleted_at = ?")).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE session_summaries SET deleted_at = ?")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE session_events SET deleted_at = ?")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE session_track_events SET deleted_at = ?")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	// App states cleanup (no TDSQL special handling)
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE app_states SET deleted_at = ?")).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	// TDSQL user states cleanup
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, user_id FROM user_states")).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id"}).
+			AddRow(100, "user-1"))
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE user_states SET deleted_at = ?")).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	s.cleanupExpiredData(ctx)
+	assert.NoError(t, mock.ExpectationsWereMet())
 }

--- a/tdsql_known_issues.md
+++ b/tdsql_known_issues.md
@@ -1,0 +1,83 @@
+# TDSQL Session 已知潜在问题
+
+> 本文档记录 TDSQL session 实现中已识别但暂未修复的潜在问题，供后续迭代参考。
+
+## 1. upsertAppState / upsertUserState 并发安全性
+
+**影响范围：** `app_states`、`user_states` 表的写入
+
+**问题描述：**
+
+`upsertAppState` 和 `upsertUserState` 使用 SELECT-then-INSERT 两步模式：
+
+```go
+// 1. 查询是否存在活跃记录
+SELECT id FROM app_states WHERE app_name = ? AND `key` = ? AND deleted_at IS NULL
+
+// 2a. 不存在则插入
+INSERT INTO app_states (app_name, `key`, value, ...) VALUES (?, ?, ?, ...)
+
+// 2b. 存在则更新
+UPDATE app_states SET value = ? WHERE id = ?
+```
+
+UNIQUE KEY 定义为 `(app_name, key, deleted_at)` / `(app_name, user_id, key, deleted_at)`，包含 `deleted_at` 列。
+由于 MySQL 中 `NULL != NULL`，当 `deleted_at` 为 NULL 时，唯一索引**无法阻止重复插入**。
+
+两个并发请求可能同时 SELECT 到 `ErrNoRows`，然后都 INSERT 成功，产生重复的活跃记录。
+
+**影响程度：** 低。`app_state` 和 `user_state` 的写入频率通常很低，实际触发的概率极小。
+
+**可选修复方案：**
+
+- **方案 A：** 使用 `INSERT ... ON DUPLICATE KEY UPDATE`，去掉 `deleted_at` 列（参考 `session_summaries` 的做法）
+- **方案 B：** 使用 `SELECT ... FOR UPDATE` 加事务锁
+- **方案 C：** 维持现状，记录为已知限制
+
+---
+
+## 2. session_summaries 的 VARCHAR(128) 长度限制
+
+**影响范围：** TDSQL 模式下的 `session_summaries` 表
+
+**问题描述：**
+
+为满足 TDSQL 的 UNIQUE KEY 约束（shardkey 不能使用前缀索引）和 InnoDB 3072 字节索引长度限制，
+TDSQL 模式下 `session_summaries` 的 `app_name`、`session_id`、`filter_key` 列被限制为 `VARCHAR(128)`，
+而其他 5 张表仍为 `VARCHAR(255)`。
+
+如果用户的 `app_name` 或 `session_id` 超过 128 字符，在 TDSQL 模式下插入 `session_summaries` 时会报错。
+
+**影响程度：** 低。实际使用中 128 字符通常足够。
+
+**建议：** 在用户文档中明确标注此限制。
+
+---
+
+## 3. getEventsList / getSummariesList 的 user_id 假设
+
+**影响范围：** `service_helper.go` 中的批量查询函数
+
+**问题描述：**
+
+`getEventsList` 和 `getSummariesList` 在构造 TDSQL 路由 hint 时，使用 `sessionKeys[0].UserID` 作为 shardkey：
+
+```go
+query := fmt.Sprintf(`SELECT ... FROM %s
+    WHERE (app_name, user_id, session_id) IN (%s)
+    AND user_id = ?
+    AND deleted_at IS NULL`, ...)
+args = append(args, sessionKeys[0].UserID)
+```
+
+这隐含假设：**所有传入的 sessionKeys 属于同一个 user_id**。
+
+当前调用路径下是安全的：
+- `getSession` — 单个 key
+- `listSessions` — 同一 `UserKey` 下的所有 session
+
+但如果将来新增跨用户的批量查询场景，此处会导致非 `keys[0]` 用户的数据被过滤掉。
+
+**影响程度：** 当前无功能问题，属于脆弱设计。
+
+**建议：** 在函数注释中明确标注"all sessionKeys must belong to the same user_id"的前置条件。


### PR DESCRIPTION
## Summary

- Add `WithTDSQLSharding(true)` option to enable TDSQL-compatible session storage, reusing the existing `session/mysql` backend without a new backend package
- Use `user_id` as the shard key for all session tables, with `app_states` as a broadcast table (`noshardkey_allset`)
- Implement two-phase TTL cleanup (cross-shard scan + per-user_id grouped delete) to comply with TDSQL DML routing constraints
- Add TDSQL-specific schema verification, DML routing with explicit `user_id` in WHERE clauses, and `schema_tdsql.sql` DDL file
- Add TDSQL example in `examples/session/simple` and documentation (Chinese + English)

## Changes

### Core implementation (`session/mysql/`)
- `options.go`: New `WithTDSQLSharding` option
- `schema_tdsql.sql`: TDSQL DDL with `shardkey=user_id`, composite PKs `(id, user_id)`, broadcast table for `app_states`
- `init.go`: TDSQL schema initialization and verification (TDSQL-specific expected columns/indexes)
- `service.go`: `tdsqlCleanupExpiredSessions` two-phase TTL cleanup; `deleteSessions` with conditional `user_id` routing
- `service_helper.go`: Add `AND user_id = ?` to batch/paged queries for TDSQL proxy routing (harmless for MySQL)

### Tests (`session/mysql/*_test.go`)
- Updated mock expectations to match new SQL patterns with `user_id` routing

### Example & Docs
- `examples/session/util.go`: Add `SessionTDSQL` type and `newTDSQLSessionService`
- `docs/mkdocs/zh/session/tdsql.md` + `docs/mkdocs/en/session/tdsql.md`: Usage documentation
- `tdsql_known_issues.md`: Known limitations and potential issues

## Test plan

- [x] All existing unit tests pass (`go test ./session/mysql/...`)
- [x] Integration tests verified on real TDSQL instance (schema init, CRUD, events, TTL cleanup, schema verification)
- [x] EXPLAIN analysis confirmed single-shard routing for all DML statements
- [x] Example builds successfully (`go build ./examples/session/simple/`)


Made with [Cursor](https://cursor.com)