### PR TITLE
tool/agent: fix agent tool event routing

### DIFF
--- a/tool/agent/agent_tool.go
+++ b/tool/agent/agent_tool.go
@@ -970,6 +970,9 @@ func (at *Tool) forwardSubInvocationStream(
 	emitFinalResultChunk := tool.FinalResultChunksFromContext(ctx)
 	state := streamCompletionState{}
 	for ev := range wrapped {
+		if ev != nil {
+			ensureInvocationEventFields(subInv, ev)
+		}
 		if shouldSuppressGraphExecutorBarrierEvent(subInv, ev) {
 			at.completeSuppressedBarrierStreamEvent(ctx, subInv, ev, &state)
 			continue

--- a/tool/agent/agent_tool.go
+++ b/tool/agent/agent_tool.go
@@ -323,10 +323,13 @@ func (at *Tool) wrapWithCompletion(ctx context.Context, inv *agent.Invocation, s
 	go func(ctx context.Context) {
 		defer close(out)
 		for evt := range src {
-			if evt != nil && evt.RequiresCompletion {
-				completionID := agent.GetAppendEventNoticeKey(evt.ID)
-				if err := inv.NotifyCompletion(ctx, completionID); err != nil {
-					log.Errorf("AgentTool: notify completion failed: %v", err)
+			if evt != nil {
+				ensureInvocationEventFields(inv, evt)
+				if evt.RequiresCompletion {
+					completionID := agent.GetAppendEventNoticeKey(evt.ID)
+					if err := inv.NotifyCompletion(ctx, completionID); err != nil {
+						log.Errorf("AgentTool: notify completion failed: %v", err)
+					}
 				}
 			}
 			out <- evt
@@ -357,6 +360,7 @@ func (at *Tool) wrapWithCallSemantics(
 		var pendingVisibleCompletion *event.Event
 		for evt := range src {
 			if evt != nil {
+				ensureInvocationEventFields(inv, evt)
 				pendingVisibleCompletion = at.updatePendingVisibleCompletionForSession(
 					ctx,
 					inv,
@@ -409,6 +413,29 @@ func (at *Tool) wrapWithCallSemantics(
 		}
 	}(runCtx)
 	return out
+}
+
+func ensureInvocationEventFields(inv *agent.Invocation, evt *event.Event) {
+	if inv == nil || evt == nil {
+		return
+	}
+	if evt.RequestID == "" {
+		evt.RequestID = inv.RunOptions.RequestID
+	}
+	if evt.InvocationID == "" {
+		evt.InvocationID = inv.InvocationID
+	}
+	if evt.ParentInvocationID == "" {
+		if parent := inv.GetParentInvocation(); parent != nil {
+			evt.ParentInvocationID = parent.InvocationID
+		}
+	}
+	if evt.Branch == "" {
+		evt.Branch = inv.Branch
+	}
+	if evt.FilterKey == "" {
+		evt.FilterKey = inv.GetEventFilterKey()
+	}
 }
 
 func (at *Tool) updatePendingVisibleCompletionForSession(
@@ -499,7 +526,8 @@ func (at *Tool) ensureUserMessageForCall(
 
 	inv.Session.EventMu.RLock()
 	for i := range inv.Session.Events {
-		if inv.Session.Events[i].IsUserMessage() {
+		if inv.Session.Events[i].InvocationID == inv.InvocationID &&
+			inv.Session.Events[i].IsUserMessage() {
 			inv.Session.EventMu.RUnlock()
 			return
 		}

--- a/tool/agent/agent_tool_test.go
+++ b/tool/agent/agent_tool_test.go
@@ -1876,12 +1876,14 @@ func TestTool_wrapWithCallSemantics_FillsMissingInvocationFields(t *testing.T) {
 	)
 
 	src := make(chan *event.Event, 1)
-	src <- event.NewResponseEvent(child.InvocationID, "child", &model.Response{
+	evt := event.NewResponseEvent(child.InvocationID, "child", &model.Response{
 		Done: true,
 		Choices: []model.Choice{{
 			Message: model.NewAssistantMessage("child answer"),
 		}},
 	})
+	evt.InvocationID = ""
+	src <- evt
 	close(src)
 
 	out := at.wrapWithCallSemantics(context.Background(), child, src)
@@ -2273,6 +2275,40 @@ func TestTool_StreamableCall_DefersCompletionToRunner(t *testing.T) {
 	}
 	require.Contains(t, contents, "done")
 	require.Len(t, parent.Session.Events, 0)
+}
+
+func TestTool_StreamableCall_DefersCompletion_FillsMissingInvocationFields(t *testing.T) {
+	const toolCallID = "call-1"
+	parent := agent.NewInvocation(
+		agent.WithInvocationID("parent-inv"),
+		agent.WithInvocationSession(session.NewSession("app", "user", "session")),
+		agent.WithInvocationRunOptions(agent.RunOptions{RequestID: "req-stream"}),
+		agent.WithInvocationEventFilterKey("parent-filter"),
+	)
+	appender.Attach(parent, func(context.Context, *event.Event) error {
+		return nil
+	})
+	at := NewTool(&streamingMockAgent{name: "stream-agent"}, WithStreamInner(true))
+	toolCtx := agent.NewInvocationContext(context.Background(), parent)
+	ctxWithToolCallID := context.WithValue(
+		toolCtx,
+		tool.ContextKeyToolCallID{},
+		toolCallID,
+	)
+
+	reader, err := at.StreamableCall(ctxWithToolCallID, []byte(`{"request":"hi"}`))
+	require.NoError(t, err)
+	defer reader.Close()
+
+	chunk, err := reader.Recv()
+	require.NoError(t, err)
+	ev, ok := chunk.Content.(*event.Event)
+	require.True(t, ok)
+	require.Equal(t, "req-stream", ev.RequestID)
+	require.NotEmpty(t, ev.InvocationID)
+	require.Equal(t, "parent-inv", ev.ParentInvocationID)
+	require.Equal(t, "stream-agent", ev.Branch)
+	require.Contains(t, ev.FilterKey, "stream-agent-")
 }
 
 func TestTool_StreamableCall_DefersCompletion_FlushesVisibleCompletionBeforeBarrierNotification(

--- a/tool/agent/agent_tool_test.go
+++ b/tool/agent/agent_tool_test.go
@@ -1768,6 +1768,26 @@ func TestTool_ensureUserMessageForCall_SkipsWhenUserExists(t *testing.T) {
 	require.Equal(t, 1, sess.GetEventCount())
 }
 
+func TestTool_ensureUserMessageForCall_AppendsWhenOnlyOtherUserExists(t *testing.T) {
+	at := NewTool(&mockAgent{name: "x", description: "x"})
+	sess := session.NewSession("app", "user", "session")
+	sess.UpdateUserSession(event.NewResponseEvent("other-inv", "user", &model.Response{
+		Choices: []model.Choice{{
+			Message: model.NewUserMessage("existing user"),
+		}},
+	}))
+	inv := agent.NewInvocation(
+		agent.WithInvocationID("child-inv"),
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationMessage(model.NewUserMessage("tool input")),
+	)
+
+	at.ensureUserMessageForCall(context.Background(), inv)
+	require.Equal(t, 2, sess.GetEventCount())
+	require.Equal(t, "child-inv", sess.Events[1].InvocationID)
+	require.Equal(t, "tool input", sess.Events[1].Choices[0].Message.Content)
+}
+
 func TestTool_ensureUserMessageForCall_NilCases(t *testing.T) {
 	at := NewTool(&mockAgent{name: "x", description: "x"})
 	at.ensureUserMessageForCall(context.Background(), nil)
@@ -1830,6 +1850,54 @@ func TestTool_wrapWithCallSemantics_NotifyCompletionError(t *testing.T) {
 	require.True(t, ok)
 	_, ok = <-out
 	require.False(t, ok)
+}
+
+func TestTool_wrapWithCallSemantics_FillsMissingInvocationFields(t *testing.T) {
+	at := NewTool(&mockAgent{name: "child", description: "child"})
+	sess := session.NewSession("app", "user", "session")
+	parent := agent.NewInvocation(
+		agent.WithInvocationID("parent-inv"),
+		agent.WithInvocationAgent(&mockAgent{name: "parent"}),
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationRunOptions(agent.RunOptions{RequestID: "req-1"}),
+		agent.WithInvocationEventFilterKey("parent-filter"),
+	)
+	var appended *event.Event
+	appender.Attach(parent, func(_ context.Context, evt *event.Event) error {
+		copied := *evt
+		appended = &copied
+		return nil
+	})
+	child := parent.Clone(
+		agent.WithInvocationID("child-inv"),
+		agent.WithInvocationAgent(&mockAgent{name: "child"}),
+		agent.WithInvocationBranch("parent/child"),
+		agent.WithInvocationEventFilterKey("child-filter"),
+	)
+
+	src := make(chan *event.Event, 1)
+	src <- event.NewResponseEvent(child.InvocationID, "child", &model.Response{
+		Done: true,
+		Choices: []model.Choice{{
+			Message: model.NewAssistantMessage("child answer"),
+		}},
+	})
+	close(src)
+
+	out := at.wrapWithCallSemantics(context.Background(), child, src)
+	got, ok := <-out
+	require.True(t, ok)
+	require.Equal(t, "req-1", got.RequestID)
+	require.Equal(t, "child-inv", got.InvocationID)
+	require.Equal(t, "parent-inv", got.ParentInvocationID)
+	require.Equal(t, "parent/child", got.Branch)
+	require.Equal(t, "child-filter", got.FilterKey)
+	_, ok = <-out
+	require.False(t, ok)
+	require.NotNil(t, appended)
+	require.Equal(t, "parent-inv", appended.ParentInvocationID)
+	require.Equal(t, "parent/child", appended.Branch)
+	require.Equal(t, "child-filter", appended.FilterKey)
 }
 
 func TestTool_wrapWithCallSemantics_ForwardsNilEvents(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fix AgentTool-local child events to carry invocation routing fields before completion handling and session mirroring, so swarm per-agent appender routing can persist child events to the isolated member session.
- Only skip AgentTool synthetic user input when the current child invocation already has a user event, preserving tool-private input when transfer input was appended first.

## Failure
```text
2026-05-20T14:37:11Z	INFO	agent/invocation.go:1888	[AddNoticeChannelAndWait]: Wait for notification message timeout. key: append_event:706372be-e4e1-4f1b-b8b4-d3b18a063963, timeout: 5(s)
--- FAIL: TestRunnerRun_SwarmIndependentAgents_RoutesAppenderEvents (0.00s)
    team_test.go:1923:
        Error Trace:	/home/runner/work/trpc-agent-go/trpc-agent-go/team/team_test.go:1923
        Error:		Should be false
        Test:		TestRunnerRun_SwarmIndependentAgents_RoutesAppenderEvents
FAIL
```

## Test plan
- `go test ./tool/agent ./team`
- `go test ./team -run TestRunnerRun_SwarmIndependentAgents_RoutesAppenderEvents -count=100`