### PR TITLE
examples/memory/simple: close injected memory.Service on exit

### DIFF
--- a/examples/memory/simple/README.md
+++ b/examples/memory/simple/README.md
@@ -67,6 +67,10 @@ runner := runner.NewRunner(
     runner.WithSessionService(sessionService),
     runner.WithMemoryService(memoryService), // Step 2: Set memory service in runner
 )
+
+// Caller owns the memory service lifecycle — runner does not close it.
+defer memoryService.Close()
+defer runner.Close()
 ```
 
 ## Prerequisites

--- a/examples/memory/simple/main.go
+++ b/examples/memory/simple/main.go
@@ -76,6 +76,7 @@ import (
 
 	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
 	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/memory"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/model/openai"
 	"trpc.group/trpc-go/trpc-agent-go/runner"
@@ -140,6 +141,7 @@ type memoryChat struct {
 	memServiceName string
 	streaming      bool
 	runner         runner.Runner
+	memoryService  memory.Service
 	userID         string
 	sessionID      string
 }
@@ -151,6 +153,7 @@ func (c *memoryChat) run() error {
 		return fmt.Errorf("setup failed: %w", err)
 	}
 
+	defer c.memoryService.Close()
 	defer c.runner.Close()
 
 	return c.startChat(ctx)
@@ -165,6 +168,7 @@ func (c *memoryChat) setup(_ context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to create memory service: %w", err)
 	}
+	c.memoryService = memoryService
 
 	c.userID = "user"
 	c.sessionID = fmt.Sprintf("memory-session-%d", time.Now().Unix())


### PR DESCRIPTION
## Summary

Close the injected memory.Service on exit in the simple memory chat example. Without this fix, every run leaks the underlying *sql.DB / connection pool for the sqlite, sqlitevec, mysql, mysqlvec, postgres, pgvector and redis backends.

## Motivation

runner.Close() is documented to release only resources owned by the runner itself (see runner/runner.go:374), so memory services injected via WithMemoryService are owned by the caller. The simple example built a memory.Service via util.NewMemoryServiceByType and only ran defer runner.Close() on exit, never calling memoryService.Close() — so the connection pool stayed alive after the example finished.

The sibling example examples/memory/auto/main.go already follows the correct pattern.

## Changes

- examples/memory/simple/main.go: hold memory.Service on memoryChat and close it together with the runner in the same deferred cleanup.
- examples/memory/simple/README.md: update the canonical wiring snippet to document the caller-owns-the-lifecycle contract.

No public API or runner behaviour is changed.

RELEASE NOTES: NONE