### PR TITLE
docs: clarify token counter units

### DIFF
--- a/agent/llmagent/option.go
+++ b/agent/llmagent/option.go
@@ -335,7 +335,9 @@ type Options struct {
 	// processor.DefaultContextCompactionOversizedToolResultMaxTokens (8192).
 	ContextCompactionOversizedToolResultMaxTokens int
 	// ContextCompactionTokenCounter estimates request and tool-result size for
-	// context compaction. When nil, SimpleTokenCounter is used.
+	// context compaction. Compaction thresholds are compared against this
+	// estimate, not provider-reported usage tokens. When nil,
+	// SimpleTokenCounter is used.
 	ContextCompactionTokenCounter model.TokenCounter
 	// summaryFormatter allows custom formatting of session summary content.
 	// When nil (default), uses the default formatSummaryContent function.
@@ -1356,7 +1358,10 @@ func WithContextCompactionOversizedToolResultMaxTokens(tokens int) Option {
 }
 
 // WithContextCompactionTokenCounter sets the token counter used by context
-// compaction to evaluate request thresholds and tool-result budgets.
+// compaction to evaluate request thresholds and tool-result budgets. These
+// budgets use the counter's estimated token count, not provider-reported usage
+// tokens. For SimpleTokenCounter, WithApproxRunesPerToken is runes per token
+// (estimated tokens = counted runes / value).
 func WithContextCompactionTokenCounter(counter model.TokenCounter) Option {
 	return func(opts *Options) {
 		if counter != nil {

--- a/docs/mkdocs/en/model.md
+++ b/docs/mkdocs/en/model.md
@@ -1401,7 +1401,7 @@ Uses heuristic rules: approximately `N` UTF-8 characters per token, where `N` ca
 estimatedTokens = countedUTF8Runes / N
 ```
 
-Therefore, `WithApproxRunesPerToken(1.5)` means approximately `1.5` characters per token. Passing `10.0/15` means approximately `0.67` characters per token, which is about `1.5` tokens per character.
+Therefore, `WithApproxRunesPerToken(1.5)` means approximately `1.5` characters per token. Passing `2.0/3.0` means approximately `0.67` characters per token, which is about `1.5` tokens per character.
 
 **Usage:**
 

--- a/docs/mkdocs/en/model.md
+++ b/docs/mkdocs/en/model.md
@@ -1395,7 +1395,13 @@ The Token Counter is used to estimate the token count of text content. The frame
 
 **Estimation Principle:**
 
-Uses heuristic rules: approximately `N` UTF-8 characters per token, where `N` can be configured via `WithApproxRunesPerToken`.
+Uses heuristic rules: approximately `N` UTF-8 characters per token, where `N` can be configured via `WithApproxRunesPerToken`. `N` is a divisor, not a multiplier:
+
+```text
+estimatedTokens = countedUTF8Runes / N
+```
+
+Therefore, `WithApproxRunesPerToken(1.5)` means approximately `1.5` characters per token. Passing `10.0/15` means approximately `0.67` characters per token, which is about `1.5` tokens per character.
 
 **Usage:**
 
@@ -1424,6 +1430,7 @@ counter := model.NewSimpleTokenCounter(
 - **Type**: float64
 - **Default Value**: 4.0 (approx. 4 characters per token, suitable for English scenarios)
 - **Value Constraint**: Values <= 0 will be ignored, keeping the default value
+- **Formula**: estimated tokens = counted UTF-8 characters / `v`; for example, `v=1.5` means approximately `1.5` characters per token
 
 **Recommended Values for Common Languages:**
 

--- a/docs/mkdocs/en/session/summary.md
+++ b/docs/mkdocs/en/session/summary.md
@@ -572,6 +572,8 @@ Notes:
 
 By default, `CheckTokenThreshold` uses a built-in `SimpleTokenCounter` that estimates token count based on text length. To customize token counting behavior, use `summary.SetTokenCounter` to set a global token counter:
 
+For `SimpleTokenCounter`, `WithApproxRunesPerToken(v)` means roughly `v` UTF-8 characters per token. The formula is `estimatedTokens = countedUTF8Runes / v`. For example, `v=1.5` means about `1.5` characters per token; do not treat it as a token multiplier.
+
 ```go
 import (
     "context"
@@ -617,6 +619,7 @@ summary.SetTokenCounter(&MyCustomCounter{})
 
 - **Global effect**: `SetTokenCounter` affects all `CheckTokenThreshold` evaluations in the current process; set it once during application initialization
 - **Default counter**: If not set, the default `SimpleTokenCounter` is used (approximately 4 characters per token)
+- **Parameter meaning**: `v` in `WithApproxRunesPerToken(v)` is characters per token. Passing `10.0/15` means about `0.67` characters per token, which is about `1.5` tokens per character
 
 ## Skip Recent Events
 
@@ -945,7 +948,7 @@ Additionally:
 
 ```go
 counter := model.NewSimpleTokenCounter(
-    model.WithApproxRunesPerToken(1.6), // Example for Chinese-heavy content.
+    model.WithApproxRunesPerToken(1.6), // About 1.6 chars/token; this value is a divisor, not a multiplier.
 )
 
 modelInstance := openai.New(

--- a/docs/mkdocs/en/session/summary.md
+++ b/docs/mkdocs/en/session/summary.md
@@ -619,7 +619,7 @@ summary.SetTokenCounter(&MyCustomCounter{})
 
 - **Global effect**: `SetTokenCounter` affects all `CheckTokenThreshold` evaluations in the current process; set it once during application initialization
 - **Default counter**: If not set, the default `SimpleTokenCounter` is used (approximately 4 characters per token)
-- **Parameter meaning**: `v` in `WithApproxRunesPerToken(v)` is characters per token. Passing `10.0/15` means about `0.67` characters per token, which is about `1.5` tokens per character
+- **Parameter meaning**: `v` in `WithApproxRunesPerToken(v)` is characters per token. Passing `2.0/3.0` means about `0.67` characters per token, which is about `1.5` tokens per character
 
 ## Skip Recent Events
 

--- a/docs/mkdocs/zh/model.md
+++ b/docs/mkdocs/zh/model.md
@@ -1383,7 +1383,13 @@ Token 计数器用于估算文本内容的 token 数量。框架提供了 `Simpl
 
 **估算原理：**
 
-使用启发式规则：每 token 大约对应 `N` 个 UTF-8 字符，其中 `N` 可通过 `WithApproxRunesPerToken` 配置。
+使用启发式规则：每 token 大约对应 `N` 个 UTF-8 字符，其中 `N` 可通过 `WithApproxRunesPerToken` 配置。这里的 `N` 是除数，不是乘数：
+
+```text
+estimatedTokens = countedUTF8Runes / N
+```
+
+因此 `WithApproxRunesPerToken(1.5)` 表示约 `1.5` 字符/token；如果传入 `10.0/15`，则表示约 `0.67` 字符/token，等价于约 `1.5` token/字符。
 
 **使用方式：**
 
@@ -1412,6 +1418,7 @@ counter := model.NewSimpleTokenCounter(
 - **类型**：float64
 - **默认值**：4.0（约每 4 个字符对应 1 个 token，适合英文场景）
 - **值限制**：<= 0 的值会被忽略，保持默认值
+- **计算方式**：估算 token 数 = 统计到的 UTF-8 字符数 / `v`；例如 `v=1.5` 才是约 `1.5` 字符/token
 
 **常见语言的推荐值：**
 

--- a/docs/mkdocs/zh/model.md
+++ b/docs/mkdocs/zh/model.md
@@ -1389,7 +1389,7 @@ Token 计数器用于估算文本内容的 token 数量。框架提供了 `Simpl
 estimatedTokens = countedUTF8Runes / N
 ```
 
-因此 `WithApproxRunesPerToken(1.5)` 表示约 `1.5` 字符/token；如果传入 `10.0/15`，则表示约 `0.67` 字符/token，等价于约 `1.5` token/字符。
+因此 `WithApproxRunesPerToken(1.5)` 表示约 `1.5` 字符/token；如果传入 `2.0/3.0`，则表示约 `0.67` 字符/token，等价于约 `1.5` token/字符。
 
 **使用方式：**
 

--- a/docs/mkdocs/zh/session/summary.md
+++ b/docs/mkdocs/zh/session/summary.md
@@ -563,6 +563,8 @@ summarizer := summary.NewSummarizer(
 
 默认情况下，`CheckTokenThreshold` 使用内置的 `SimpleTokenCounter` 基于文本长度估算 token 数量。如果需要自定义 token 计数行为，可以使用 `summary.SetTokenCounter` 设置全局 token 计数器：
 
+`SimpleTokenCounter` 的 `WithApproxRunesPerToken(v)` 表示约 `v` 个 UTF-8 字符对应 1 个 token，估算公式是 `estimatedTokens = countedUTF8Runes / v`。例如 `v=1.5` 表示约 `1.5` 字符/token；不要把它当成 token 乘数。
+
 ```go
 import (
     "context"
@@ -608,6 +610,7 @@ summary.SetTokenCounter(&MyCustomCounter{})
 
 - **全局影响**：`SetTokenCounter` 会影响当前进程中所有的 `CheckTokenThreshold` 评估，建议在应用初始化时一次性设置
 - **默认计数器**：如果不设置，将使用默认的 `SimpleTokenCounter`（约每 token 对应 4 个字符）
+- **参数语义**：`WithApproxRunesPerToken(v)` 中的 `v` 是字符/token。传入 `10.0/15` 表示约 `0.67` 字符/token，等价于约 `1.5` token/字符
 
 ## 跳过最近事件
 
@@ -932,7 +935,7 @@ Pass 2 默认是关闭的（`0`），需要满足两个条件才会生效：(1) 
 
 ```go
 counter := model.NewSimpleTokenCounter(
-    model.WithApproxRunesPerToken(1.6), // 中文内容较多时的示例值
+    model.WithApproxRunesPerToken(1.6), // 约 1.6 字符/token；该值是除数，不是乘数
 )
 
 modelInstance := openai.New(

--- a/docs/mkdocs/zh/session/summary.md
+++ b/docs/mkdocs/zh/session/summary.md
@@ -610,7 +610,7 @@ summary.SetTokenCounter(&MyCustomCounter{})
 
 - **全局影响**：`SetTokenCounter` 会影响当前进程中所有的 `CheckTokenThreshold` 评估，建议在应用初始化时一次性设置
 - **默认计数器**：如果不设置，将使用默认的 `SimpleTokenCounter`（约每 token 对应 4 个字符）
-- **参数语义**：`WithApproxRunesPerToken(v)` 中的 `v` 是字符/token。传入 `10.0/15` 表示约 `0.67` 字符/token，等价于约 `1.5` token/字符
+- **参数语义**：`WithApproxRunesPerToken(v)` 中的 `v` 是字符/token。传入 `2.0/3.0` 表示约 `0.67` 字符/token，等价于约 `1.5` token/字符
 
 ## 跳过最近事件
 

--- a/model/token_tailor.go
+++ b/model/token_tailor.go
@@ -27,7 +27,7 @@ type SimpleTokenCounterOption func(*simpleTokenCounterOptions)
 
 // WithApproxRunesPerToken sets the approximate runes per token heuristic.
 // The value is a divisor: estimated tokens = counted UTF-8 runes / v.
-// For example, v=1.5 means roughly 1.5 runes per token, while v=10.0/15
+// For example, v=1.5 means roughly 1.5 runes per token, while v=2.0/3.0
 // means roughly 0.67 runes per token, or about 1.5 tokens per rune.
 // This is a heuristic and may vary across languages and models.
 //

--- a/model/token_tailor.go
+++ b/model/token_tailor.go
@@ -26,6 +26,9 @@ type simpleTokenCounterOptions struct {
 type SimpleTokenCounterOption func(*simpleTokenCounterOptions)
 
 // WithApproxRunesPerToken sets the approximate runes per token heuristic.
+// The value is a divisor: estimated tokens = counted UTF-8 runes / v.
+// For example, v=1.5 means roughly 1.5 runes per token, while v=10.0/15
+// means roughly 0.67 runes per token, or about 1.5 tokens per rune.
 // This is a heuristic and may vary across languages and models.
 //
 // Note:
@@ -96,7 +99,7 @@ func (e *tokenTailoringOverflowError) Error() string {
 }
 
 // SimpleTokenCounter provides a very rough token estimation based on rune length.
-// Heuristic: approximately one token per several UTF-8 runes for text fields.
+// Heuristic: approximately one token per configured number of UTF-8 runes.
 type SimpleTokenCounter struct {
 	approxRunesPerToken float64
 }


### PR DESCRIPTION
## Summary
- Clarify that `WithApproxRunesPerToken` is configured as runes/characters per token, not a token multiplier.
- Note that context compaction thresholds use estimated token counts rather than provider-reported usage tokens.
- Add the same guidance to model and session summary docs in both English and Chinese.

## Test plan
- `go test ./model ./agent/llmagent`