### PR TITLE
{evaluation/evaluator/llm, docs}: add structured rubric output

### DIFF
--- a/docs/mkdocs/en/evaluation.md
+++ b/docs/mkdocs/en/evaluation.md
@@ -1607,7 +1607,7 @@ type RubricContent struct {
 
 `EvalCase.rubrics` adds extra evaluation criteria for a single case. Each rubric targets a configured metric through `metricName`; when that case is evaluated, the framework appends those criteria after the metric's shared rubrics. This affects only the current case and leaves the metric file's global configuration unchanged. Rubric `id` values must be unique after merging.
 
-The target metric uses `criterion.llmJudge` to carry the rubric list. Built-in rubric evaluators read the merged criteria and use structured output to make the judge return per-rubric scores through `rubricScores`. Rubrics that participate in structured output must have non-empty and unique `id` values; otherwise evaluation fails directly. Custom rubric evaluators can read the same field.
+The target metric uses `criterion.llmJudge` to carry the rubric list. Built-in rubric evaluators read the merged criteria and use structured output by default to make the judge return per-rubric scores through `rubricScores`. During `Evaluate`, after metric-level rubrics and `EvalCase.rubrics` are merged and before the judge model is called, each merged rubric used by structured output must have a non-empty and unique `id`. If validation fails, evaluation returns an error such as `llm judge rubric id is required for structured output` or `duplicate llm judge rubric id "accuracy"`. To debug ID conflicts, inspect the merged `criterion.llmJudge.rubrics` from the metric configuration and case-level rubrics. Custom rubric evaluators can read the same field.
 
 `template` is used only by `llm_judge_template`. It keeps template-based evaluation focused on cases where the prompt changes while the evaluation orchestration stays the same. Template evaluators do not read `rubrics`; evaluation criteria should be written directly into `template.prompt`.
 
@@ -2086,6 +2086,7 @@ import (
 // MessagesConstructor builds judge input.
 type MessagesConstructor interface {
 	// ConstructMessages builds judge input messages.
+	// LLMBaseEvaluator passes per-invocation prefix slices: actuals[:i+1] and expecteds[:i+1].
 	ConstructMessages(ctx context.Context, actuals, expecteds []*evalset.Invocation,
 		evalMetric *metric.EvalMetric) ([]model.Message, error)
 }
@@ -2094,12 +2095,13 @@ type MessagesConstructor interface {
 type StructuredOutputMessagesConstructor interface {
 	MessagesConstructor
 	// StructuredOutput returns the structured output schema for the judge model.
+	// LLMBaseEvaluator calls it with the same per-invocation prefix slices used for ConstructMessages.
 	StructuredOutput(ctx context.Context, actuals, expecteds []*evalset.Invocation,
 		evalMetric *metric.EvalMetric) (*model.StructuredOutput, error)
 }
 ```
 
-`StructuredOutputMessagesConstructor` is an optional extension interface. If a concrete LLM evaluator implements it, the framework calls `StructuredOutput` after constructing judge input for each turn and passes the returned schema to the judge model or judge Runner. The default template evaluator and built-in `llm_rubric_*` evaluators use this mechanism; when the interface is not implemented, the framework does not attach structured output constraints.
+`StructuredOutputMessagesConstructor` is an optional extension interface. If a concrete LLM evaluator implements it, the framework calls `StructuredOutput` after constructing judge input for each turn and passes the returned schema to the judge model or judge Runner. The default template evaluator and built-in `llm_rubric_*` evaluators use this mechanism; when the interface is not implemented, the framework does not attach structured output constraints. Returning `(nil, nil)` from `StructuredOutput` is valid and means no structured output constraint is attached for that turn. Returning a non-nil error stops evaluation and returns that error to the caller.
 
 The framework includes multiple `MessagesConstructor` implementations for different built-in evaluators. Default selection is as follows:
 

--- a/docs/mkdocs/en/evaluation.md
+++ b/docs/mkdocs/en/evaluation.md
@@ -1607,7 +1607,7 @@ type RubricContent struct {
 
 `EvalCase.rubrics` adds extra evaluation criteria for a single case. Each rubric targets a configured metric through `metricName`; when that case is evaluated, the framework appends those criteria after the metric's shared rubrics. This affects only the current case and leaves the metric file's global configuration unchanged. Rubric `id` values must be unique after merging.
 
-The target metric uses `criterion.llmJudge` to carry the rubric list. Built-in rubric evaluators read the merged criteria, and custom rubric evaluators can read the same field.
+The target metric uses `criterion.llmJudge` to carry the rubric list. Built-in rubric evaluators read the merged criteria and use structured output to make the judge return per-rubric scores through `rubricScores`. Rubrics that participate in structured output must have non-empty and unique `id` values; otherwise evaluation fails directly. Custom rubric evaluators can read the same field.
 
 `template` is used only by `llm_judge_template`. It keeps template-based evaluation focused on cases where the prompt changes while the evaluation orchestration stays the same. Template evaluators do not read `rubrics`; evaluation criteria should be written directly into `template.prompt`.
 
@@ -2089,7 +2089,17 @@ type MessagesConstructor interface {
 	ConstructMessages(ctx context.Context, actuals, expecteds []*evalset.Invocation,
 		evalMetric *metric.EvalMetric) ([]model.Message, error)
 }
+
+// StructuredOutputMessagesConstructor provides structured output constraints in addition to judge input construction.
+type StructuredOutputMessagesConstructor interface {
+	MessagesConstructor
+	// StructuredOutput returns the structured output schema for the judge model.
+	StructuredOutput(ctx context.Context, actuals, expecteds []*evalset.Invocation,
+		evalMetric *metric.EvalMetric) (*model.StructuredOutput, error)
+}
 ```
+
+`StructuredOutputMessagesConstructor` is an optional extension interface. If a concrete LLM evaluator implements it, the framework calls `StructuredOutput` after constructing judge input for each turn and passes the returned schema to the judge model or judge Runner. The default template evaluator and built-in `llm_rubric_*` evaluators use this mechanism; when the interface is not implemented, the framework does not attach structured output constraints.
 
 The framework includes multiple `MessagesConstructor` implementations for different built-in evaluators. Default selection is as follows:
 
@@ -2127,8 +2137,7 @@ The framework includes multiple `ResponseScorer` implementations. Default select
 - `responsescorer/finalresponse` for `llm_final_response`, parsing `valid` or `invalid` from judge output and mapping to 1 or 0, while preserving `reasoning` as `reason`.
 - `responsescorer/hallucination` for `llm_hallucinations`, parsing sentence-level judgments, scoring supported or non-factual sentences as 1 and the rest as 0, and averaging across sentences for the turn score.
 - `responsescorer/singlescore` for the `single_score` mode of `llm_judge_template`, parsing `score` and `reason`.
-- `responsescorer/rubricscores` for the `rubric_scores` mode of `llm_judge_template`, parsing `rubricScores`.
-- `responsescorer/rubricresponse` for `llm_rubric_critic`, `llm_rubric_reference_critic`, `llm_rubric_response`, and `llm_rubric_knowledge_recall`, parsing verdict `yes` or `no` for each rubric, mapping each to 1 or 0, averaging as the turn score, and outputting `rubricScores`.
+- `responsescorer/rubricscores` for the `rubric_scores` mode of `llm_judge_template`, and for `llm_rubric_critic`, `llm_rubric_reference_critic`, `llm_rubric_response`, and `llm_rubric_knowledge_recall`, parsing `rubricScores` and averaging per-item `score` values as the turn score.
 
 ##### Samples Aggregator Operator
 
@@ -2390,7 +2399,7 @@ See [examples/evaluation/llm/template](https://github.com/trpc-group/trpc-agent-
 
 The LLM rubric critic evaluator has the metric name `llm_rubric_critic` and is an LLM Judge evaluator. It combines the strengths of reference-based checking and rubric-based decomposition: it compares the agent final answer against the reference final answer, but still scores per rubric item. This makes it suitable for scenarios where you want the judge to behave like a strict reviewer, explicitly look for defects, and fail on ambiguity, incompleteness, or unsupported claims.
 
-The evaluator constructs judge input from user input, actual final response, expected final response, and `criterion.llmJudge.rubrics`. The default prompt instructs the judge to adopt a skeptical, failure-oriented stance, treat the reference answer as authoritative, and return `no` whenever fulfillment is missing, partial, ambiguous, or unverifiable. The judge returns `yes` or `no` for each rubric. A single sample score is the average across rubrics, and with multiple samples the evaluator uses majority vote before comparing with `threshold`.
+The evaluator constructs judge input from user input, actual final response, expected final response, and `criterion.llmJudge.rubrics`. The default prompt emphasizes that the reference answer is the golden answer, judgment should focus on the current rubric, semantically equivalent wording is acceptable, score 0 should be assigned only when there is a material defect, and the judge should neither nitpick nor infer hidden requirements. Through structured output, the judge returns `id`, `score`, and `reason` for each rubric, where `score` must be 0 or 1. A single sample score is the average across all rubric scores, and with multiple samples the evaluator uses `samplesaggregator/majorityvote` to select the representative result before comparing with `threshold`.
 
 Use `llm_rubric_critic` when plain `llm_final_response` is too coarse-grained, but `llm_rubric_response` is too permissive because it does not compare against a reference answer. Rubrics should remain atomic and directly checkable. Because this evaluator depends on a reference answer, it usually requires `finalResponse` on the expected side. For security, avoid writing `judgeModel.apiKey` and `judgeModel.baseURL` in plain text, and use environment variables instead.
 
@@ -2443,7 +2452,7 @@ Example metric configuration for LLM rubric critic:
 
 The LLM rubric reference critic evaluator has the metric name `llm_rubric_reference_critic` and is an LLM Judge evaluator. It also compares the agent final answer against a reference final answer and scores by rubric item, but it is less failure-oriented than `llm_rubric_critic`. The reference answer serves as a quality anchor that defines the target level of grounding, specificity, and completeness, while still allowing faithful paraphrases and different sentence structure.
 
-The evaluator constructs judge input from user input, actual final response, expected final response, and `criterion.llmJudge.rubrics`. The default prompt tells the judge to preserve the same decisive facts, level of useful detail, and overall fidelity demonstrated by the reference answer, while avoiding exact-match bias. The judge returns `yes` or `no` for each rubric. A single sample score is the average across rubrics, and with multiple samples the evaluator uses majority vote before comparing with `threshold`.
+The evaluator constructs judge input from user input, actual final response, expected final response, and `criterion.llmJudge.rubrics`. The default prompt asks the judge to preserve the key facts, decisive clues, and useful details shown by the reference answer, while accepting faithful paraphrases and different sentence structures instead of failing only because the wording differs. Through structured output, the judge returns `id`, `score`, and `reason` for each rubric, where `score` must be 0 or 1. A single sample score is the average across all rubric scores, and with multiple samples the evaluator uses `samplesaggregator/majorityvote` to select the representative result before comparing with `threshold`.
 
 Use `llm_rubric_reference_critic` when `llm_final_response` is too coarse-grained, `llm_rubric_response` is too permissive because it ignores the reference answer, and `llm_rubric_critic` is too strict because it treats the reference as an authoritative golden answer. Rubrics should still remain atomic and directly checkable. Because this evaluator depends on a reference answer, it usually requires `finalResponse` on the expected side. For security, avoid writing `judgeModel.apiKey` and `judgeModel.baseURL` in plain text, and use environment variables instead.
 
@@ -2496,7 +2505,7 @@ Example metric configuration for LLM rubric reference critic:
 
 The LLM rubric response evaluator has the metric name `llm_rubric_response` and is an LLM Judge evaluator. It uses [LLMCriterion](#llmcriterion) to configure the judge model and splits a metric into multiple independent rubrics via `rubrics`. It focuses on whether the final answer satisfies each rubric, suitable for automated evaluation of correctness, relevance, compliance, and other goals that are hard to cover with deterministic rules.
 
-The evaluator constructs judge input based on `criterion.llmJudge.rubrics`, and the judge model returns `yes` or `no` for each rubric. The score for one sample is the average across rubrics, where `yes` is 1 and `no` is 0. When `numSamples` is configured, it uses `samplesaggregator/majorityvote` to select the representative result and then compares with `threshold` to determine pass or fail.
+The evaluator constructs judge input based on `criterion.llmJudge.rubrics`, and through structured output the judge model returns `id`, `score`, and `reason` for each rubric. The score for one sample is the average across rubrics, where `score=1` means pass and `score=0` means fail. When `numSamples` is configured, it uses `samplesaggregator/majorityvote` to select the representative result and then compares with `threshold` to determine pass or fail.
 
 Rubrics should be concrete and directly verifiable from user input and the final answer. Avoid combining multiple requirements into one rubric to reduce judge variance and make issues easier to locate. For security, avoid writing `judgeModel.apiKey` and `judgeModel.baseURL` in plain text, and use environment variables instead.
 
@@ -2551,7 +2560,7 @@ See [examples/evaluation/llm/rubricresponse](https://github.com/trpc-group/trpc-
 
 The LLM rubric knowledge recall evaluator has the metric name `llm_rubric_knowledge_recall` and is an LLM Judge evaluator. It uses [LLMCriterion](#llmcriterion) to configure the judge model and describes key information that retrieved evidence must support via `rubrics`. This evaluator focuses on whether retrieved knowledge is sufficient to support the user's question or key facts in rubrics, and is suitable for automated recall quality evaluation in RAG scenarios.
 
-The evaluator extracts responses from knowledge retrieval tools such as `knowledge_search` and `knowledge_search_with_agentic_filter` as evidence, and constructs judge input together with `criterion.llmJudge.rubrics`. The judge model returns `yes` or `no` for each rubric. A single sample score is the average. With multiple samples, it uses majority vote to select the representative result, then compares with `threshold` to determine pass or fail.
+The evaluator extracts responses from knowledge retrieval tools such as `knowledge_search` and `knowledge_search_with_agentic_filter` as evidence, and constructs judge input together with `criterion.llmJudge.rubrics`. Through structured output, the judge model returns `id`, `score`, and `reason` for each rubric. A single sample score is the average. With multiple samples, it uses majority vote to select the representative result, then compares with `threshold` to determine pass or fail.
 
 This evaluator requires knowledge retrieval tool calls in actual traces that return usable retrieval results, otherwise it cannot form stable judge input. Rubrics should focus on whether evidence contains and supports key facts, and avoid mixing final answer quality requirements into recall evaluation. For security, avoid writing `judgeModel.apiKey` and `judgeModel.baseURL` in plain text, and use environment variables instead.
 

--- a/docs/mkdocs/zh/evaluation.md
+++ b/docs/mkdocs/zh/evaluation.md
@@ -1610,7 +1610,7 @@ type RubricContent struct {
 
 `EvalCase.rubrics` 用于给单个用例补充额外评估细则。每条 rubric 通过 `metricName` 指向一个已配置的 metric；评估该 case 时，框架会在该 metric 的公共 rubrics 之后追加这些细则，只影响当前 case，不改变指标文件中的全局配置。合并后的 rubric `id` 需要保持唯一。
 
-目标 metric 使用 `criterion.llmJudge` 承载 rubric 列表。内置 rubric evaluator 会读取合并后的细则，并使用结构化输出让裁判按 `rubricScores` 返回逐条评分。参与结构化输出的 rubric 必须具备非空且唯一的 `id`，否则评估会直接报错；自定义 rubric evaluator 按同一字段读取即可。
+目标 metric 使用 `criterion.llmJudge` 承载 rubric 列表。内置 rubric evaluator 会读取合并后的细则，并默认使用结构化输出让裁判按 `rubricScores` 返回逐条评分。每次 `Evaluate` 执行时，框架会先合并 metric 级 rubrics 与 `EvalCase.rubrics`，再在调用裁判模型前校验参与结构化输出的 merged rubric：每条 rubric 都必须具备非空且唯一的 `id`。如果校验失败，评估会返回类似 `llm judge rubric id is required for structured output` 或 `duplicate llm judge rubric id "accuracy"` 的错误。排查时请检查 metric 配置与 case 级 rubrics 合并后的 `criterion.llmJudge.rubrics` 及其 `id`。自定义 rubric evaluator 按同一字段读取即可。
 
 `template` 仅用于 `llm_judge_template`。它将模板化评估限制在“prompt 不同，但评估编排逻辑相同”的场景，不要求框架把所有评估器都表达成模板。模板评估器不读取 `rubrics`，评估标准应直接写入 `template.prompt`。
 
@@ -2089,6 +2089,7 @@ import (
 // MessagesConstructor 负责构造裁判输入
 type MessagesConstructor interface {
 	// ConstructMessages 构造裁判输入消息
+	// LLMBaseEvaluator 会传入按轮次截取的前缀切片：actuals[:i+1] 与 expecteds[:i+1]
 	ConstructMessages(ctx context.Context, actuals, expecteds []*evalset.Invocation,
 		evalMetric *metric.EvalMetric) ([]model.Message, error)
 }
@@ -2097,12 +2098,13 @@ type MessagesConstructor interface {
 type StructuredOutputMessagesConstructor interface {
 	MessagesConstructor
 	// StructuredOutput 返回裁判模型的结构化输出 schema
+	// LLMBaseEvaluator 会使用与 ConstructMessages 相同的前缀切片调用该方法
 	StructuredOutput(ctx context.Context, actuals, expecteds []*evalset.Invocation,
 		evalMetric *metric.EvalMetric) (*model.StructuredOutput, error)
 }
 ```
 
-`StructuredOutputMessagesConstructor` 是可选扩展接口。若具体 LLM 评估器实现了该接口，框架会在每一轮构造完裁判输入后调用 `StructuredOutput`，并把返回的 schema 传给裁判模型或裁判 Runner。默认的模板评估器以及内置 `llm_rubric_*` 评估器都使用该机制；未实现该接口时，框架不会附加结构化输出约束。
+`StructuredOutputMessagesConstructor` 是可选扩展接口。若具体 LLM 评估器实现了该接口，框架会在每一轮构造完裁判输入后调用 `StructuredOutput`，并把返回的 schema 传给裁判模型或裁判 Runner。默认的模板评估器以及内置 `llm_rubric_*` 评估器都使用该机制；未实现该接口时，框架不会附加结构化输出约束。`StructuredOutput` 返回 `(nil, nil)` 是合法的，表示当前轮不附加结构化输出约束；如果返回非空 error，评估会停止并把该错误返回给调用方。
 
 框架内置了多种 `MessagesConstructor` 实现，分别对应不同内置评估器的打分目标。默认选择关系如下。
 

--- a/docs/mkdocs/zh/evaluation.md
+++ b/docs/mkdocs/zh/evaluation.md
@@ -1610,7 +1610,7 @@ type RubricContent struct {
 
 `EvalCase.rubrics` 用于给单个用例补充额外评估细则。每条 rubric 通过 `metricName` 指向一个已配置的 metric；评估该 case 时，框架会在该 metric 的公共 rubrics 之后追加这些细则，只影响当前 case，不改变指标文件中的全局配置。合并后的 rubric `id` 需要保持唯一。
 
-目标 metric 使用 `criterion.llmJudge` 承载 rubric 列表。内置 rubric evaluator 会读取合并后的细则；自定义 rubric evaluator 按同一字段读取即可。
+目标 metric 使用 `criterion.llmJudge` 承载 rubric 列表。内置 rubric evaluator 会读取合并后的细则，并使用结构化输出让裁判按 `rubricScores` 返回逐条评分。参与结构化输出的 rubric 必须具备非空且唯一的 `id`，否则评估会直接报错；自定义 rubric evaluator 按同一字段读取即可。
 
 `template` 仅用于 `llm_judge_template`。它将模板化评估限制在“prompt 不同，但评估编排逻辑相同”的场景，不要求框架把所有评估器都表达成模板。模板评估器不读取 `rubrics`，评估标准应直接写入 `template.prompt`。
 
@@ -2092,7 +2092,17 @@ type MessagesConstructor interface {
 	ConstructMessages(ctx context.Context, actuals, expecteds []*evalset.Invocation,
 		evalMetric *metric.EvalMetric) ([]model.Message, error)
 }
+
+// StructuredOutputMessagesConstructor 在构造裁判输入之外提供结构化输出约束
+type StructuredOutputMessagesConstructor interface {
+	MessagesConstructor
+	// StructuredOutput 返回裁判模型的结构化输出 schema
+	StructuredOutput(ctx context.Context, actuals, expecteds []*evalset.Invocation,
+		evalMetric *metric.EvalMetric) (*model.StructuredOutput, error)
+}
 ```
+
+`StructuredOutputMessagesConstructor` 是可选扩展接口。若具体 LLM 评估器实现了该接口，框架会在每一轮构造完裁判输入后调用 `StructuredOutput`，并把返回的 schema 传给裁判模型或裁判 Runner。默认的模板评估器以及内置 `llm_rubric_*` 评估器都使用该机制；未实现该接口时，框架不会附加结构化输出约束。
 
 框架内置了多种 `MessagesConstructor` 实现，分别对应不同内置评估器的打分目标。默认选择关系如下。
 
@@ -2130,8 +2140,7 @@ type ResponseScorer interface {
 - `responsescorer/finalresponse` 用于 `llm_final_response`，解析裁判输出中的 valid 或 invalid 并映射为 1 或 0，同时保留 reasoning 作为 `reason`
 - `responsescorer/hallucination` 用于 `llm_hallucinations`，逐句解析裁判结论；被证据支撑或无需事实支撑的句子记 1 分，其余句子记 0 分，再按句级平均值得到该轮分数
 - `responsescorer/singlescore` 用于 `llm_judge_template` 的 `single_score` 模式，解析 `score` 与 `reason`
-- `responsescorer/rubricscores` 用于 `llm_judge_template` 的 `rubric_scores` 模式，解析 `rubricScores`
-- `responsescorer/rubricresponse` 用于 `llm_rubric_critic`、`llm_rubric_reference_critic`、`llm_rubric_response` 与 `llm_rubric_knowledge_recall`，逐条解析评估细则的 verdict yes 或 no，将每条细则映射为 1 或 0 并取平均作为该轮分数，同时输出 `rubricScores`
+- `responsescorer/rubricscores` 用于 `llm_judge_template` 的 `rubric_scores` 模式，以及 `llm_rubric_critic`、`llm_rubric_reference_critic`、`llm_rubric_response` 与 `llm_rubric_knowledge_recall`，解析 `rubricScores` 并按逐条 `score` 平均得到该轮分数
 
 ##### 样本聚合算子 samplesaggregator
 
@@ -2393,9 +2402,9 @@ LLM 模板评估器对应的评估器名称为 `llm_judge_template`，属于 LLM
 
 LLM 细则批判评估器对应的指标名称为 `llm_rubric_critic`，属于 LLM Judge 类评估器。它把“参考答案约束”与“细则拆解”结合起来：一方面使用 [LLMCriterion](#llmcriterion) 配置裁判模型，并通过 `rubrics` 将一个指标拆成多条可独立验证的评估细则；另一方面要求 EvalSet 预期侧提供 `finalResponse` 作为 golden answer，再对实际最终回答逐条做批判式比较。
 
-该评估器适合这样的场景：`llm_final_response` 过于粗粒度，只能给出整体通过或失败；`llm_rubric_response` 又过于宽松，因为它只判断“是否满足细则”，不强制将参考答案作为对照目标。`llm_rubric_critic` 则要求裁判站在评估器本身的视角执行评分逻辑，以参考答案为权威目标，逐条判断实际输出是否在当前 rubric 上真正满足要求，并在存在实质缺陷、遗漏、矛盾或无法验证时返回 `no`。
+该评估器适合这样的场景：`llm_final_response` 过于粗粒度，只能给出整体通过或失败；`llm_rubric_response` 又过于宽松，因为它只判断“是否满足细则”，不强制将参考答案作为对照目标。`llm_rubric_critic` 则要求裁判站在评估器本身的视角执行评分逻辑，以参考答案为权威目标，逐条判断实际输出是否在当前 rubric 上真正满足要求，并在存在实质缺陷、遗漏、矛盾或无法验证时给出 0 分。
 
-评估器会基于用户输入、实际最终回答、预期最终回答以及 `criterion.llmJudge.rubrics` 构造裁判输入。默认提示词会强调以下几点：参考答案是 golden answer；判断应聚焦当前 rubric；允许语义等价；只有存在 material defect 时才判 `no`；不能吹毛求疵，也不能脑补隐藏要求。裁判模型对每条 rubric 返回 `yes` 或 `no`，单次采样得分为所有 rubric 得分的平均值；当配置 `numSamples` 进行多次采样时，评估器会使用 `samplesaggregator/majorityvote` 选择代表结果，再与 `threshold` 对比得到通过或失败。
+评估器会基于用户输入、实际最终回答、预期最终回答以及 `criterion.llmJudge.rubrics` 构造裁判输入。默认提示词会强调以下几点：参考答案是 golden answer；判断应聚焦当前 rubric；允许语义等价；只有存在 material defect 时才给出 0 分；不能吹毛求疵，也不能脑补隐藏要求。裁判模型通过结构化输出对每条 rubric 返回 `id`、`score` 与 `reason`，其中 `score` 只能为 0 或 1，单次采样得分为所有 rubric 得分的平均值；当配置 `numSamples` 进行多次采样时，评估器会使用 `samplesaggregator/majorityvote` 选择代表结果，再与 `threshold` 对比得到通过或失败。
 
 使用 `llm_rubric_critic` 时，建议将 rubric 写得足够原子化，并确保每条 rubric 都能从用户输入、参考答案和实际回答中直接验证。由于该评估器依赖 golden answer，通常要求 EvalSet 预期侧提供 `finalResponse`。出于安全考虑，建议不要在指标配置中明文写入 `judgeModel.apiKey` 和 `judgeModel.baseURL`，可使用环境变量引用以降低泄露风险。
 
@@ -2448,7 +2457,7 @@ LLM 细则批判评估指标配置示例如下：
 
 LLM 参考答案细则批判评估器对应的指标名称为 `llm_rubric_reference_critic`，属于 LLM Judge 类评估器。它同样会结合参考答案与细则做逐条打分，但没有 `llm_rubric_critic` 那么强的失败导向。这里的参考答案更像质量锚点，用来规定应该达到的 grounding、具体度与完整度，而不是要求实际回答逐字贴齐参考答案。
 
-评估器会基于用户输入、实际最终回答、预期最终回答以及 `criterion.llmJudge.rubrics` 构造裁判输入。默认提示词会要求裁判保留参考答案所体现的关键事实、决定性线索和有效细节，同时接受忠实的同义改写和不同句式，不因措辞不同就判失败。裁判模型对每条 rubric 返回 `yes` 或 `no`，单次采样得分为所有 rubric 得分的平均值；当配置 `numSamples` 进行多次采样时，评估器会使用 `samplesaggregator/majorityvote` 选择代表结果，再与 `threshold` 对比得到通过或失败。
+评估器会基于用户输入、实际最终回答、预期最终回答以及 `criterion.llmJudge.rubrics` 构造裁判输入。默认提示词会要求裁判保留参考答案所体现的关键事实、决定性线索和有效细节，同时接受忠实的同义改写和不同句式，不因措辞不同就判失败。裁判模型通过结构化输出对每条 rubric 返回 `id`、`score` 与 `reason`，其中 `score` 只能为 0 或 1，单次采样得分为所有 rubric 得分的平均值；当配置 `numSamples` 进行多次采样时，评估器会使用 `samplesaggregator/majorityvote` 选择代表结果，再与 `threshold` 对比得到通过或失败。
 
 当 `llm_final_response` 过于粗粒度，`llm_rubric_response` 又因为完全不看参考答案而偏宽松，而 `llm_rubric_critic` 又因为把参考答案当 golden answer 而过严时，可以使用 `llm_rubric_reference_critic`。rubric 仍然建议保持原子化，并确保每条都能从用户输入、参考答案和实际回答中直接验证。由于该评估器依赖参考答案，通常要求 EvalSet 预期侧提供 `finalResponse`。出于安全考虑，建议不要在指标配置中明文写入 `judgeModel.apiKey` 和 `judgeModel.baseURL`，可使用环境变量引用以降低泄露风险。
 
@@ -2501,7 +2510,7 @@ LLM 参考答案细则批判评估指标配置示例如下：
 
 LLM 细则响应评估器对应的指标名称为 `llm_rubric_response`，属于 LLM Judge 类评估器，使用 [LLMCriterion](#llmcriterion) 配置裁判模型，并通过 `rubrics` 将一个指标拆成多条可独立验证的评估细则。该评估器侧重判定最终回答是否满足各项细则要求，适合对正确性、相关性与合规性等难以用确定性规则覆盖的目标进行自动化评估。
 
-评估器会基于 `criterion.llmJudge.rubrics` 构造裁判输入，裁判模型对每条 rubric 给出 `yes` 或 `no` 判定。单次采样得分为所有 rubric 得分的平均值，其中 `yes` 记 1 分，`no` 记 0 分。当配置 `numSamples` 进行多次采样时，评估器会使用 `samplesaggregator/majorityvote` 选择代表结果，再与 `threshold` 对比得到通过或失败。
+评估器会基于 `criterion.llmJudge.rubrics` 构造裁判输入，裁判模型通过结构化输出对每条 rubric 返回 `id`、`score` 与 `reason`。单次采样得分为所有 rubric 得分的平均值，其中 `score=1` 表示通过，`score=0` 表示失败。当配置 `numSamples` 进行多次采样时，评估器会使用 `samplesaggregator/majorityvote` 选择代表结果，再与 `threshold` 对比得到通过或失败。
 
 rubric 的表述尽量具体，并且能够直接从用户输入与最终回答中验证，避免把多条要求揉在同一条 rubric 里，以降低裁判波动并便于定位问题。出于安全考虑，建议不要在指标配置中明文写入 `judgeModel.apiKey` 和 `judgeModel.baseURL`，可使用环境变量引用以降低泄露风险。
 
@@ -2556,7 +2565,7 @@ LLM 细则响应评估指标配置示例如下：
 
 LLM 细则知识库召回评估器对应的指标名称为 `llm_rubric_knowledge_recall`，属于 LLM Judge 类评估器，使用 [LLMCriterion](#llmcriterion) 配置裁判模型，并通过 `rubrics` 描述检索证据需要支撑的关键信息。该评估器侧重评估检索到的知识是否足以支撑用户问题或细则中的关键事实，适用于 RAG 类场景对召回质量进行自动化评估。
 
-评估器会从工具调用中提取 `knowledge_search` 和 `knowledge_search_with_agentic_filter` 等知识检索工具的响应作为检索结果证据，并结合 `criterion.llmJudge.rubrics` 构造裁判输入。裁判模型对每条 rubric 返回 `yes` 或 `no` 判定，单次采样得分为平均值，多次采样时使用多数表决确定代表结果，再与 `threshold` 对比得到通过或失败。
+评估器会从工具调用中提取 `knowledge_search` 和 `knowledge_search_with_agentic_filter` 等知识检索工具的响应作为检索结果证据，并结合 `criterion.llmJudge.rubrics` 构造裁判输入。裁判模型通过结构化输出对每条 rubric 返回 `id`、`score` 与 `reason`，单次采样得分为平均值，多次采样时使用多数表决确定代表结果，再与 `threshold` 对比得到通过或失败。
 
 该评估器要求实际轨迹中包含知识检索类工具调用并返回可用的检索结果，否则无法形成稳定的裁判输入。rubric 应尽量围绕证据是否包含并支撑关键事实来写，避免将最终回答质量要求混入召回评估目标。出于安全考虑，建议不要在指标配置中明文写入 `judgeModel.apiKey` 和 `judgeModel.baseURL`，可使用环境变量引用以降低泄露风险。
 

--- a/evaluation/evaluator/llm/finalresponse/finalresponse.go
+++ b/evaluation/evaluator/llm/finalresponse/finalresponse.go
@@ -68,6 +68,16 @@ func (e *finalResponseEvaluator) ConstructMessages(ctx context.Context, actuals,
 	return e.messagesConstructor.ConstructMessages(ctx, actuals, expecteds, evalMetric)
 }
 
+// StructuredOutput delegates structured output schema construction to the prompt builder.
+func (e *finalResponseEvaluator) StructuredOutput(ctx context.Context, actuals, expecteds []*evalset.Invocation,
+	evalMetric *metric.EvalMetric) (*model.StructuredOutput, error) {
+	constructor, ok := e.messagesConstructor.(messagesconstructor.StructuredOutputMessagesConstructor)
+	if !ok {
+		return nil, nil
+	}
+	return constructor.StructuredOutput(ctx, actuals, expecteds, evalMetric)
+}
+
 // ScoreBasedOnResponse converts judge feedback to a numeric score.
 func (e *finalResponseEvaluator) ScoreBasedOnResponse(ctx context.Context, response *model.Response,
 	evalMetric *metric.EvalMetric) (*evaluator.ScoreResult, error) {

--- a/evaluation/evaluator/llm/finalresponse/finalresponse_test.go
+++ b/evaluation/evaluator/llm/finalresponse/finalresponse_test.go
@@ -35,6 +35,23 @@ func (s *stubMessagesConstructor) ConstructMessages(ctx context.Context, actuals
 	return []model.Message{{Role: model.RoleUser, Content: actuals[0].InvocationID + expecteds[0].InvocationID}}, nil
 }
 
+type stubStructuredMessagesConstructor struct {
+	stubMessagesConstructor
+	structuredCalled bool
+	output           *model.StructuredOutput
+	err              error
+}
+
+func (s *stubStructuredMessagesConstructor) StructuredOutput(ctx context.Context, actuals,
+	expecteds []*evalset.Invocation, _ *metric.EvalMetric) (*model.StructuredOutput, error) {
+	s.structuredCalled = true
+	s.ctx = ctx
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.output, nil
+}
+
 type stubResponseScorer struct {
 	called bool
 	ctx    context.Context
@@ -152,4 +169,46 @@ func TestFinalResponseEvaluator_DelegatesToDependencies(t *testing.T) {
 	assert.Equal(t, status.EvalStatusPassed, result.OverallStatus)
 	assert.Equal(t, "llm_final_response", impl.Name())
 	assert.Equal(t, "LLM judge for final responses", impl.Description())
+}
+
+func TestFinalResponseEvaluator_DelegatesStructuredOutput(t *testing.T) {
+	ctx := context.Background()
+	output := &model.StructuredOutput{
+		Type: model.StructuredOutputJSONSchema,
+		JSONSchema: &model.JSONSchemaConfig{
+			Name:   "custom_schema",
+			Schema: map[string]any{"type": "object"},
+		},
+	}
+	mc := &stubStructuredMessagesConstructor{output: output}
+	ev := New(WithMessagesConstructor(mc))
+	impl, ok := ev.(*finalResponseEvaluator)
+	require.True(t, ok)
+	actuals := []*evalset.Invocation{{InvocationID: "a"}}
+	expecteds := []*evalset.Invocation{{InvocationID: "b"}}
+	got, err := impl.StructuredOutput(ctx, actuals, expecteds, nil)
+	require.NoError(t, err)
+	assert.Same(t, output, got)
+	assert.True(t, mc.structuredCalled)
+	assert.Equal(t, ctx, mc.ctx)
+}
+
+func TestFinalResponseEvaluator_StructuredOutputReturnsNilForPlainConstructor(t *testing.T) {
+	ev := New(WithMessagesConstructor(&stubMessagesConstructor{}))
+	impl, ok := ev.(*finalResponseEvaluator)
+	require.True(t, ok)
+	got, err := impl.StructuredOutput(context.Background(), nil, nil, nil)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestFinalResponseEvaluator_StructuredOutputPropagatesError(t *testing.T) {
+	mc := &stubStructuredMessagesConstructor{err: assert.AnError}
+	ev := New(WithMessagesConstructor(mc))
+	impl, ok := ev.(*finalResponseEvaluator)
+	require.True(t, ok)
+	got, err := impl.StructuredOutput(context.Background(), nil, nil, nil)
+	require.Error(t, err)
+	assert.Nil(t, got)
+	assert.ErrorIs(t, err, assert.AnError)
 }

--- a/evaluation/evaluator/llm/hallucination/hallucination.go
+++ b/evaluation/evaluator/llm/hallucination/hallucination.go
@@ -66,6 +66,16 @@ func (e *hallucinationEvaluator) ConstructMessages(ctx context.Context, actuals,
 	return e.messagesConstructor.ConstructMessages(ctx, actuals, expecteds, evalMetric)
 }
 
+// StructuredOutput delegates structured output schema construction to the prompt builder.
+func (e *hallucinationEvaluator) StructuredOutput(ctx context.Context, actuals, expecteds []*evalset.Invocation,
+	evalMetric *metric.EvalMetric) (*model.StructuredOutput, error) {
+	constructor, ok := e.messagesConstructor.(messagesconstructor.StructuredOutputMessagesConstructor)
+	if !ok {
+		return nil, nil
+	}
+	return constructor.StructuredOutput(ctx, actuals, expecteds, evalMetric)
+}
+
 // ScoreBasedOnResponse scores the response of the evaluator.
 func (e *hallucinationEvaluator) ScoreBasedOnResponse(ctx context.Context, response *model.Response,
 	evalMetric *metric.EvalMetric) (*evaluator.ScoreResult, error) {

--- a/evaluation/evaluator/llm/llm.go
+++ b/evaluation/evaluator/llm/llm.go
@@ -17,7 +17,6 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/internal/judger"
-	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/internal/templateresolver"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/invocationsaggregator"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/messagesconstructor"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/responsescorer"
@@ -37,8 +36,6 @@ type LLMEvaluator interface {
 	samplesaggregator.SamplesAggregator
 	invocationsaggregator.InvocationsAggregator
 }
-
-const templateEvaluatorName = "llm_judge_template"
 
 // LLMBaseEvaluator hosts shared orchestration logic for LLM evaluators.
 type LLMBaseEvaluator struct {
@@ -90,17 +87,19 @@ func (r *LLMBaseEvaluator) Evaluate(ctx context.Context, actuals, expecteds []*e
 		return nil, fmt.Errorf("actual invocations (%d) and expected invocations (%d) count mismatch",
 			len(actuals), len(expecteds))
 	}
-	structuredOutput, err := r.resolveStructuredOutput(ctx, evalMetric)
-	if err != nil {
-		return nil, fmt.Errorf("resolve structured output: %w", err)
-	}
 	results := make([]*evaluator.PerInvocationResult, 0, len(actuals))
 	for i := range actuals {
 		actual := actuals[i]
 		expected := expecteds[i]
-		messages, err := r.ConstructMessages(ctx, actuals[:i+1], expecteds[:i+1], evalMetric)
+		currentActuals := actuals[:i+1]
+		currentExpecteds := expecteds[:i+1]
+		messages, err := r.ConstructMessages(ctx, currentActuals, currentExpecteds, evalMetric)
 		if err != nil {
 			return nil, fmt.Errorf("construct messages: %w", err)
+		}
+		structuredOutput, err := r.resolveStructuredOutput(ctx, currentActuals, currentExpecteds, evalMetric)
+		if err != nil {
+			return nil, fmt.Errorf("resolve structured output: %w", err)
 		}
 		samples := make([]*evaluator.PerInvocationResult, 0, numSamples)
 		for range numSamples {
@@ -162,26 +161,10 @@ func (r *LLMBaseEvaluator) ConstructMessages(ctx context.Context, actuals, expec
 }
 
 func (r *LLMBaseEvaluator) resolveStructuredOutput(ctx context.Context,
-	evalMetric *metric.EvalMetric) (*model.StructuredOutput, error) {
-	if ctx == nil || evalMetric == nil || evalMetric.Criterion == nil || evalMetric.Criterion.LLMJudge == nil {
-		return nil, nil
+	actuals, expecteds []*evalset.Invocation, evalMetric *metric.EvalMetric) (*model.StructuredOutput, error) {
+	constructor, ok := r.LLMEvaluator.(messagesconstructor.StructuredOutputMessagesConstructor)
+	if ok {
+		return constructor.StructuredOutput(ctx, actuals, expecteds, evalMetric)
 	}
-	if resolveEvaluatorName(evalMetric) != templateEvaluatorName {
-		return nil, nil
-	}
-	templateOptions := evalMetric.Criterion.LLMJudge.Template
-	if templateOptions == nil {
-		return nil, nil
-	}
-	return templateresolver.StructuredOutput(templateOptions.ResponseScorerName)
-}
-
-func resolveEvaluatorName(evalMetric *metric.EvalMetric) string {
-	if evalMetric == nil {
-		return ""
-	}
-	if evalMetric.EvaluatorName != "" {
-		return evalMetric.EvaluatorName
-	}
-	return evalMetric.MetricName
+	return nil, nil
 }

--- a/evaluation/evaluator/llm/llm_test.go
+++ b/evaluation/evaluator/llm/llm_test.go
@@ -106,12 +106,20 @@ func (f *fakeModel) Info() model.Info {
 }
 
 type fakeJudgeRunner struct {
-	events   []*event.Event
-	runCalls int
+	events                []*event.Event
+	runCalls              int
+	structuredOutputNames []string
 }
 
-func (f *fakeJudgeRunner) Run(_ context.Context, _ string, _ string, _ model.Message, _ ...agent.RunOption) (<-chan *event.Event, error) {
+func (f *fakeJudgeRunner) Run(_ context.Context, _ string, _ string, _ model.Message, opts ...agent.RunOption) (<-chan *event.Event, error) {
 	f.runCalls++
+	runOpts := &agent.RunOptions{}
+	for _, opt := range opts {
+		opt(runOpts)
+	}
+	if runOpts.StructuredOutput != nil && runOpts.StructuredOutput.JSONSchema != nil {
+		f.structuredOutputNames = append(f.structuredOutputNames, runOpts.StructuredOutput.JSONSchema.Name)
+	}
 	ch := make(chan *event.Event, len(f.events))
 	for _, e := range f.events {
 		ch <- e
@@ -248,6 +256,26 @@ func (s *scriptedLLMEvaluator) AggregateInvocations(_ context.Context, results [
 	}, nil
 }
 
+type structuredLLMEvaluator struct {
+	scriptedLLMEvaluator
+	structuredOutput *model.StructuredOutput
+	structuredErr    error
+	structuredCalls  int
+	actualLens       []int
+	expectedLens     []int
+}
+
+func (s *structuredLLMEvaluator) StructuredOutput(_ context.Context, actuals, expecteds []*evalset.Invocation,
+	_ *metric.EvalMetric) (*model.StructuredOutput, error) {
+	s.structuredCalls++
+	s.actualLens = append(s.actualLens, len(actuals))
+	s.expectedLens = append(s.expectedLens, len(expecteds))
+	if s.structuredErr != nil {
+		return nil, s.structuredErr
+	}
+	return s.structuredOutput, nil
+}
+
 func TestLLMBaseEvaluator_ErrorPaths(t *testing.T) {
 	provider.Register("llm-test-provider", func(_ *provider.Options) (model.Model, error) {
 		return &fakeModel{responses: []*model.Response{{
@@ -360,60 +388,102 @@ func TestLLMBaseEvaluator_UsesJudgeRunnerAndIgnoresJudgeModelNumSamples(t *testi
 
 func TestLLMBaseEvaluator_ResolveStructuredOutput(t *testing.T) {
 	base := &LLMBaseEvaluator{}
-	output, err := base.resolveStructuredOutput(nil, nil)
+	output, err := base.resolveStructuredOutput(nil, nil, nil, nil)
 	require.NoError(t, err)
 	assert.Nil(t, output)
-	output, err = base.resolveStructuredOutput(context.Background(), &metric.EvalMetric{MetricName: "final_response"})
+	output, err = base.resolveStructuredOutput(context.Background(), nil, nil,
+		&metric.EvalMetric{MetricName: "final_response"})
 	require.NoError(t, err)
 	assert.Nil(t, output)
-	output, err = base.resolveStructuredOutput(context.Background(), &metric.EvalMetric{
-		EvaluatorName: templateEvaluatorName,
-		Criterion: &criterion.Criterion{
-			LLMJudge: &llm.LLMCriterion{},
-		},
-	})
-	require.NoError(t, err)
-	assert.Nil(t, output)
-	output, err = base.resolveStructuredOutput(context.Background(), &metric.EvalMetric{
-		EvaluatorName: templateEvaluatorName,
-		Criterion: &criterion.Criterion{
-			LLMJudge: &llm.LLMCriterion{
-				Template: &llm.JudgeTemplateOptions{
-					ResponseScorerName: "single_score",
-				},
-			},
-		},
-	})
-	require.NoError(t, err)
-	require.NotNil(t, output)
-	require.NotNil(t, output.JSONSchema)
-	assert.Equal(t, "single_score_result", output.JSONSchema.Name)
 }
 
-func TestLLMBaseEvaluator_ResolveStructuredOutputRejectsUnknownScorer(t *testing.T) {
-	base := &LLMBaseEvaluator{}
-	output, err := base.resolveStructuredOutput(context.Background(), &metric.EvalMetric{
-		EvaluatorName: templateEvaluatorName,
-		Criterion: &criterion.Criterion{
-			LLMJudge: &llm.LLMCriterion{
-				Template: &llm.JudgeTemplateOptions{
-					ResponseScorerName: "missing",
-				},
-			},
+func TestLLMBaseEvaluator_ResolveStructuredOutputUsesProvider(t *testing.T) {
+	expected := &model.StructuredOutput{
+		Type: model.StructuredOutputJSONSchema,
+		JSONSchema: &model.JSONSchemaConfig{
+			Name:   "custom_schema",
+			Schema: map[string]any{"type": "object"},
 		},
-	})
-	require.Error(t, err)
-	assert.Nil(t, output)
-	assert.Contains(t, err.Error(), `unsupported response scorer "missing"`)
-}
-
-func TestLLMBaseEvaluator_EvaluateRejectsTemplateStructuredOutputError(t *testing.T) {
-	base := &LLMBaseEvaluator{LLMEvaluator: &scriptedLLMEvaluator{scoreValue: 1}}
-	evalMetric := buildEvalMetric("unknown-provider", 1)
-	evalMetric.EvaluatorName = templateEvaluatorName
-	evalMetric.Criterion.LLMJudge.Template = &llm.JudgeTemplateOptions{
-		ResponseScorerName: "missing",
 	}
+	stub := &structuredLLMEvaluator{structuredOutput: expected}
+	base := &LLMBaseEvaluator{LLMEvaluator: stub}
+	actuals := []*evalset.Invocation{{InvocationID: "a"}}
+	expecteds := []*evalset.Invocation{{InvocationID: "b"}}
+	output, err := base.resolveStructuredOutput(context.Background(), actuals, expecteds,
+		&metric.EvalMetric{MetricName: "final_response"})
+	require.NoError(t, err)
+	assert.Same(t, expected, output)
+	assert.Equal(t, 1, stub.structuredCalls)
+	assert.Equal(t, []int{1}, stub.actualLens)
+	assert.Equal(t, []int{1}, stub.expectedLens)
+}
+
+func TestLLMBaseEvaluator_ResolveStructuredOutputRespectsProviderNil(t *testing.T) {
+	base := &LLMBaseEvaluator{LLMEvaluator: &structuredLLMEvaluator{}}
+	output, err := base.resolveStructuredOutput(context.Background(), nil, nil,
+		&metric.EvalMetric{MetricName: "final_response"})
+	require.NoError(t, err)
+	assert.Nil(t, output)
+}
+
+func TestLLMBaseEvaluator_EvaluateResolvesStructuredOutputAfterConstructMessages(t *testing.T) {
+	stub := &structuredLLMEvaluator{
+		scriptedLLMEvaluator: scriptedLLMEvaluator{constructErr: assert.AnError},
+	}
+	base := &LLMBaseEvaluator{LLMEvaluator: stub}
+	_, err := base.Evaluate(
+		context.Background(),
+		[]*evalset.Invocation{{}},
+		[]*evalset.Invocation{{}},
+		buildEvalMetric("unknown-provider", 1),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "construct messages")
+	assert.Equal(t, 0, stub.structuredCalls)
+}
+
+func TestLLMBaseEvaluator_EvaluateResolvesStructuredOutputPerInvocation(t *testing.T) {
+	r := &fakeJudgeRunner{
+		events: []*event.Event{
+			event.NewResponseEvent("inv", "judge", &model.Response{
+				Choices: []model.Choice{{Message: model.Message{Content: "ok"}}},
+				Done:    true,
+			}, event.WithStructuredOutputPayload(map[string]any{"score": 1})),
+		},
+	}
+	stub := &structuredLLMEvaluator{
+		scriptedLLMEvaluator: scriptedLLMEvaluator{scoreValue: 1},
+		structuredOutput: &model.StructuredOutput{
+			Type: model.StructuredOutputJSONSchema,
+			JSONSchema: &model.JSONSchemaConfig{
+				Name:   "custom_schema",
+				Schema: map[string]any{"type": "object"},
+				Strict: true,
+			},
+		},
+	}
+	base := &LLMBaseEvaluator{LLMEvaluator: stub}
+	evalMetric := buildEvalMetric("unused-provider", 1)
+	evalMetric.Criterion.LLMJudge.JudgeRunnerOptions = &llm.JudgeRunnerOptions{Runner: r}
+	_, err := base.Evaluate(
+		context.Background(),
+		[]*evalset.Invocation{{InvocationID: "a"}, {InvocationID: "b"}},
+		[]*evalset.Invocation{{InvocationID: "c"}, {InvocationID: "d"}},
+		evalMetric,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, []int{1, 2}, stub.actualLens)
+	assert.Equal(t, []int{1, 2}, stub.expectedLens)
+	assert.Equal(t, []string{"custom_schema", "custom_schema"}, r.structuredOutputNames)
+}
+
+func TestLLMBaseEvaluator_EvaluateRejectsStructuredOutputError(t *testing.T) {
+	stub := &structuredLLMEvaluator{
+		scriptedLLMEvaluator: scriptedLLMEvaluator{scoreValue: 1},
+		structuredErr:        assert.AnError,
+	}
+	base := &LLMBaseEvaluator{LLMEvaluator: stub}
+	evalMetric := buildEvalMetric("unknown-provider", 1)
 	_, err := base.Evaluate(
 		context.Background(),
 		[]*evalset.Invocation{{}},
@@ -492,56 +562,4 @@ func TestLLMBaseEvaluator_EvaluateUsesDefaultNumSamplesWhenNil(t *testing.T) {
 		evalMetric,
 	)
 	require.NoError(t, err)
-}
-
-func TestLLMBaseEvaluator_ResolveStructuredOutputForTemplateEvaluator(t *testing.T) {
-	base := &LLMBaseEvaluator{}
-	evalMetric := &metric.EvalMetric{
-		MetricName:    "answer_quality",
-		EvaluatorName: templateEvaluatorName,
-		Threshold:     0.5,
-		Criterion: &criterion.Criterion{
-			LLMJudge: &llm.LLMCriterion{
-				Template: &llm.JudgeTemplateOptions{
-					ResponseScorerName: "single_score",
-				},
-			},
-		},
-	}
-
-	out, err := base.resolveStructuredOutput(context.Background(), evalMetric)
-	require.NoError(t, err)
-	require.NotNil(t, out)
-	require.NotNil(t, out.JSONSchema)
-	assert.Equal(t, "single_score_result", out.JSONSchema.Name)
-}
-
-func TestLLMBaseEvaluator_ResolveStructuredOutputRejectsUnsupportedScorer(t *testing.T) {
-	base := &LLMBaseEvaluator{}
-	evalMetric := &metric.EvalMetric{
-		MetricName:    "answer_quality",
-		EvaluatorName: templateEvaluatorName,
-		Criterion: &criterion.Criterion{
-			LLMJudge: &llm.LLMCriterion{
-				Template: &llm.JudgeTemplateOptions{
-					ResponseScorerName: "missing",
-				},
-			},
-		},
-	}
-
-	_, err := base.resolveStructuredOutput(context.Background(), evalMetric)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), `unsupported response scorer "missing"`)
-}
-
-func TestResolveEvaluatorNamePrefersEvaluatorName(t *testing.T) {
-	assert.Equal(t, "configured", resolveEvaluatorName(&metric.EvalMetric{
-		MetricName:    "metric-instance",
-		EvaluatorName: "configured",
-	}))
-	assert.Equal(t, "metric-instance", resolveEvaluatorName(&metric.EvalMetric{
-		MetricName: "metric-instance",
-	}))
-	assert.Equal(t, "", resolveEvaluatorName(nil))
 }

--- a/evaluation/evaluator/llm/llm_test.go
+++ b/evaluation/evaluator/llm/llm_test.go
@@ -388,7 +388,7 @@ func TestLLMBaseEvaluator_UsesJudgeRunnerAndIgnoresJudgeModelNumSamples(t *testi
 
 func TestLLMBaseEvaluator_ResolveStructuredOutput(t *testing.T) {
 	base := &LLMBaseEvaluator{}
-	output, err := base.resolveStructuredOutput(nil, nil, nil, nil)
+	output, err := base.resolveStructuredOutput(context.Background(), nil, nil, nil)
 	require.NoError(t, err)
 	assert.Nil(t, output)
 	output, err = base.resolveStructuredOutput(context.Background(), nil, nil,

--- a/evaluation/evaluator/llm/operator/internal/rubrics/rubrics.go
+++ b/evaluation/evaluator/llm/operator/internal/rubrics/rubrics.go
@@ -1,0 +1,114 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package rubrics extracts and validates LLM judge rubrics shared by evaluator operators.
+package rubrics
+
+import (
+	"fmt"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+// VisibleRubric is a rubric that is visible to the judge prompt.
+type VisibleRubric struct {
+	ID string
+}
+
+// Visible returns rubrics that would be rendered into judge prompts.
+func Visible(evalMetric *metric.EvalMetric) []VisibleRubric {
+	if evalMetric == nil || evalMetric.Criterion == nil || evalMetric.Criterion.LLMJudge == nil {
+		return nil
+	}
+	rubrics := make([]VisibleRubric, 0, len(evalMetric.Criterion.LLMJudge.Rubrics))
+	for _, rubric := range evalMetric.Criterion.LLMJudge.Rubrics {
+		if rubric == nil || rubric.Content == nil {
+			continue
+		}
+		rubrics = append(rubrics, VisibleRubric{ID: strings.TrimSpace(rubric.ID)})
+	}
+	return rubrics
+}
+
+// Count returns the number of rubrics that would be rendered into judge prompts.
+func Count(evalMetric *metric.EvalMetric) int {
+	return len(Visible(evalMetric))
+}
+
+// ValidateStructured returns visible rubrics that can safely drive structured output schemas.
+func ValidateStructured(evalMetric *metric.EvalMetric) ([]VisibleRubric, error) {
+	if evalMetric == nil {
+		return nil, fmt.Errorf("eval metric is nil")
+	}
+	if evalMetric.Criterion == nil || evalMetric.Criterion.LLMJudge == nil {
+		return nil, fmt.Errorf("llm judge criterion is required")
+	}
+	rubrics := Visible(evalMetric)
+	if len(rubrics) == 0 {
+		return nil, fmt.Errorf("llm judge rubrics are required")
+	}
+	seen := make(map[string]struct{}, len(rubrics))
+	for _, rubric := range rubrics {
+		if rubric.ID == "" {
+			return nil, fmt.Errorf("llm judge rubric id is required for structured output")
+		}
+		if _, ok := seen[rubric.ID]; ok {
+			return nil, fmt.Errorf("duplicate llm judge rubric id %q", rubric.ID)
+		}
+		seen[rubric.ID] = struct{}{}
+	}
+	return rubrics, nil
+}
+
+// ScoresOutput returns a structured output schema for per-rubric scores.
+func ScoresOutput(name, description string, visibleRubrics []VisibleRubric) *model.StructuredOutput {
+	ids := make([]string, 0, len(visibleRubrics))
+	for _, rubric := range visibleRubrics {
+		ids = append(ids, rubric.ID)
+	}
+	return &model.StructuredOutput{
+		Type: model.StructuredOutputJSONSchema,
+		JSONSchema: &model.JSONSchemaConfig{
+			Name:        name,
+			Strict:      true,
+			Description: description,
+			Schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"rubricScores": map[string]any{
+						"type":     "array",
+						"minItems": len(visibleRubrics),
+						"maxItems": len(visibleRubrics),
+						"items": map[string]any{
+							"type": "object",
+							"properties": map[string]any{
+								"id": map[string]any{
+									"type": "string",
+									"enum": ids,
+								},
+								"score": map[string]any{
+									"type": "number",
+									"enum": []float64{0, 1},
+								},
+								"reason": map[string]any{
+									"type": "string",
+								},
+							},
+							"required":             []string{"id", "score", "reason"},
+							"additionalProperties": false,
+						},
+					},
+				},
+				"required":             []string{"rubricScores"},
+				"additionalProperties": false,
+			},
+		},
+	}
+}

--- a/evaluation/evaluator/llm/operator/internal/rubrics/rubrics_test.go
+++ b/evaluation/evaluator/llm/operator/internal/rubrics/rubrics_test.go
@@ -1,0 +1,96 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package rubrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion/llm"
+)
+
+func TestVisibleReturnsJudgeRenderedRubrics(t *testing.T) {
+	evalMetric := &metric.EvalMetric{
+		Criterion: &criterion.Criterion{
+			LLMJudge: &llm.LLMCriterion{
+				Rubrics: []*llm.Rubric{
+					nil,
+					{ID: " skipped "},
+					{ID: " one ", Content: &llm.RubricContent{Text: "alpha"}},
+					{ID: "two", Content: &llm.RubricContent{Text: "beta"}},
+				},
+			},
+		},
+	}
+	assert.Equal(t, []VisibleRubric{{ID: "one"}, {ID: "two"}}, Visible(evalMetric))
+	assert.Equal(t, 2, Count(evalMetric))
+}
+
+func TestValidateStructuredRejectsInvalidRubrics(t *testing.T) {
+	_, err := ValidateStructured(nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "eval metric is nil")
+	_, err = ValidateStructured(&metric.EvalMetric{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "llm judge criterion is required")
+	_, err = ValidateStructured(&metric.EvalMetric{
+		Criterion: &criterion.Criterion{LLMJudge: &llm.LLMCriterion{}},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "llm judge rubrics are required")
+	_, err = ValidateStructured(metricWithRubrics(&llm.Rubric{
+		ID:      "",
+		Content: &llm.RubricContent{Text: "alpha"},
+	}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rubric id is required")
+	_, err = ValidateStructured(metricWithRubrics(
+		&llm.Rubric{ID: "same", Content: &llm.RubricContent{Text: "alpha"}},
+		&llm.Rubric{ID: " same ", Content: &llm.RubricContent{Text: "beta"}},
+	))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `duplicate llm judge rubric id "same"`)
+}
+
+func TestValidateStructuredReturnsVisibleRubrics(t *testing.T) {
+	got, err := ValidateStructured(metricWithRubrics(
+		&llm.Rubric{ID: " one ", Content: &llm.RubricContent{Text: "alpha"}},
+		&llm.Rubric{ID: "two", Content: &llm.RubricContent{Text: "beta"}},
+	))
+	require.NoError(t, err)
+	assert.Equal(t, []VisibleRubric{{ID: "one"}, {ID: "two"}}, got)
+}
+
+func TestScoresOutputBuildsRubricScoreSchema(t *testing.T) {
+	output := ScoresOutput("test_scores", "test description", []VisibleRubric{{ID: "one"}, {ID: "two"}})
+	require.NotNil(t, output)
+	require.NotNil(t, output.JSONSchema)
+	assert.Equal(t, "test_scores", output.JSONSchema.Name)
+	assert.Equal(t, "test description", output.JSONSchema.Description)
+	schema := output.JSONSchema.Schema
+	properties := schema["properties"].(map[string]any)
+	rubricScores := properties["rubricScores"].(map[string]any)
+	assert.Equal(t, 2, rubricScores["minItems"])
+	assert.Equal(t, 2, rubricScores["maxItems"])
+	items := rubricScores["items"].(map[string]any)
+	itemProperties := items["properties"].(map[string]any)
+	idSchema := itemProperties["id"].(map[string]any)
+	assert.Equal(t, []string{"one", "two"}, idSchema["enum"])
+}
+
+func metricWithRubrics(rubrics ...*llm.Rubric) *metric.EvalMetric {
+	return &metric.EvalMetric{
+		Criterion: &criterion.Criterion{
+			LLMJudge: &llm.LLMCriterion{Rubrics: rubrics},
+		},
+	}
+}

--- a/evaluation/evaluator/llm/operator/messagesconstructor/messagesconstructor.go
+++ b/evaluation/evaluator/llm/operator/messagesconstructor/messagesconstructor.go
@@ -24,3 +24,11 @@ type MessagesConstructor interface {
 	ConstructMessages(ctx context.Context, actuals, expecteds []*evalset.Invocation,
 		evalMetric *metric.EvalMetric) ([]model.Message, error)
 }
+
+// StructuredOutputMessagesConstructor extends MessagesConstructor with a structured output contract.
+type StructuredOutputMessagesConstructor interface {
+	MessagesConstructor
+	// StructuredOutput returns the structured output schema for the judge model.
+	StructuredOutput(ctx context.Context, actuals, expecteds []*evalset.Invocation,
+		evalMetric *metric.EvalMetric) (*model.StructuredOutput, error)
+}

--- a/evaluation/evaluator/llm/operator/messagesconstructor/messagesconstructor.go
+++ b/evaluation/evaluator/llm/operator/messagesconstructor/messagesconstructor.go
@@ -21,6 +21,8 @@ import (
 // MessagesConstructor defines the interface for building judge prompts.
 type MessagesConstructor interface {
 	// ConstructMessages builds prompts for the judge model.
+	// LLMBaseEvaluator passes per-invocation prefix slices: actuals[:i+1] and expecteds[:i+1].
+	// Implementations should treat the slices as grounding context up to the current invocation.
 	ConstructMessages(ctx context.Context, actuals, expecteds []*evalset.Invocation,
 		evalMetric *metric.EvalMetric) ([]model.Message, error)
 }
@@ -29,6 +31,7 @@ type MessagesConstructor interface {
 type StructuredOutputMessagesConstructor interface {
 	MessagesConstructor
 	// StructuredOutput returns the structured output schema for the judge model.
+	// LLMBaseEvaluator calls it with the same per-invocation prefix slices used for ConstructMessages.
 	StructuredOutput(ctx context.Context, actuals, expecteds []*evalset.Invocation,
 		evalMetric *metric.EvalMetric) (*model.StructuredOutput, error)
 }

--- a/evaluation/evaluator/llm/operator/messagesconstructor/rubriccritic/rubriccritic.go
+++ b/evaluation/evaluator/llm/operator/messagesconstructor/rubriccritic/rubriccritic.go
@@ -16,6 +16,7 @@ import (
 	"text/template"
 
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/internal/rubrics"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/messagesconstructor"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/messagesconstructor/internal/content"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
@@ -45,8 +46,8 @@ For each rubric item, first determine what the rubric item requires by reading:
 3. the relevant part of the GOLDEN ANSWER.
 
 Then compare the ACTUAL OUTPUT against that requirement.
-Return "yes" only if the ACTUAL OUTPUT materially satisfies the current rubric item.
-If a material defect remains, return "no".
+Use score 1 only if the ACTUAL OUTPUT materially satisfies the current rubric item.
+Use score 0 if a material defect remains.
 
 # Decision Rules
 
@@ -71,7 +72,7 @@ If a material defect remains, return "no".
    Literal wording does not need to match.
    Material meaning does need to match.
 
-5. **A "no" must be caused by a material defect**
+5. **A score of 0 must be caused by a material defect**
    A defect is material only if it would make a reasonable evaluator conclude that the current rubric item is not truly satisfied.
    Typical material defects include:
    * missing required information,
@@ -85,10 +86,10 @@ If a material defect remains, return "no".
    Do not invent hidden requirements.
    Do not fail an item because of style, tone, verbosity, brevity, formatting, or ordering alone.
    Do not fail an item for extra detail unless that detail contradicts, weakens, or obscures what the current rubric item requires.
-   If the ACTUAL OUTPUT is reasonably semantically equivalent to the GOLDEN ANSWER for the current rubric item, return "yes".
+   If the ACTUAL OUTPUT is reasonably semantically equivalent to the GOLDEN ANSWER for the current rubric item, use score 1.
 
 7. **Conditional rubric items**
-   If a rubric item is conditional, you may treat it as not applicable and return "yes" only when the condition is clearly not met based on <user_prompt> and <reference_answer>.
+   If a rubric item is conditional, you may treat it as not applicable and use score 1 only when the condition is clearly not met based on <user_prompt> and <reference_answer>.
    If applicability is unclear, do not guess. Treat the item as applicable.
 
 # Internal Evaluation Procedure
@@ -98,26 +99,16 @@ For each rubric item, do this internally:
 2. Extract the decisive evidence from the GOLDEN ANSWER and, if needed, the USER REQUEST.
 3. Extract the corresponding evidence from the ACTUAL OUTPUT.
 4. Decide whether there is a material mismatch, omission, contradiction, or unverifiable gap.
-5. If there is a material defect, return "no".
-6. Otherwise, return "yes".
+5. If there is a material defect, use score 0.
+6. Otherwise, use score 1.
 
-# Output Format
+# Rubric Scoring Requirements
 
-Repeat the following block for every rubric item, starting on a new line.
-
-ID: [The ID of the rubric item, unique within the rubric. If the rubric itself is numbered 1..N, the ID must match that numbering.]
-Rubric: [Repeat the rubric item word-for-word without any changes. Keep punctuation and capitalization exactly as-is. Do not translate or paraphrase.]
-Evidence: [Quote only the decisive snippets from the GOLDEN ANSWER, the ACTUAL OUTPUT, and the USER REQUEST when needed. If something required is missing, explicitly state what is missing.]
-Reason: [State the key evaluation reason from the evaluator's perspective. Compare the ACTUAL OUTPUT against the GOLDEN ANSWER for this rubric item. Prefer one decisive material reason over a long list of minor complaints.]
-Verdict: [yes|no]
-
-# Output Constraints
-
-* Output only the rubric blocks in the exact format above.
-* Do not output JSON.
-* Do not add an overall summary.
-* Be decisive.
-* When the verdict is "no", the reason must point to a concrete mismatch, omission, contradiction, or unverifiable gap.
+Score every rubric item exactly once.
+Use the exact rubric ID from the input rubric.
+Do not add, omit, merge, split, translate, or rename rubric IDs.
+Use score 1 for pass and score 0 for fail.
+State the decisive evaluation reason and compare the ACTUAL OUTPUT against the GOLDEN ANSWER for that rubric item.
 
 # Your Turn
 
@@ -143,7 +134,9 @@ Verdict: [yes|no]
 
 ## Output
 `
-	rubricCriticPromptTemplate = template.Must(template.New("rubricCriticPrompt").Parse(rubricCriticPrompt))
+	rubricCriticPromptTemplate = template.Must(
+		template.New("rubricCriticPrompt").Parse(rubricCriticPrompt),
+	)
 )
 
 type rubricCriticMessagesConstructor struct {
@@ -154,7 +147,7 @@ func New() messagesconstructor.MessagesConstructor {
 	return &rubricCriticMessagesConstructor{}
 }
 
-// ConstructMessages builds critic-style judge prompts for rubric evaluation.
+// ConstructMessages builds structured-output critic prompts for rubric evaluation.
 func (e *rubricCriticMessagesConstructor) ConstructMessages(ctx context.Context, actuals, expecteds []*evalset.Invocation,
 	evalMetric *metric.EvalMetric) ([]model.Message, error) {
 	if len(actuals) == 0 {
@@ -169,7 +162,7 @@ func (e *rubricCriticMessagesConstructor) ConstructMessages(ctx context.Context,
 	if evalMetric.Criterion == nil || evalMetric.Criterion.LLMJudge == nil {
 		return nil, fmt.Errorf("llm judge criterion is required")
 	}
-	if effectiveRubricCount(evalMetric) == 0 {
+	if rubrics.Count(evalMetric) == 0 {
 		return nil, fmt.Errorf("llm judge rubrics are required")
 	}
 	actual := actuals[len(actuals)-1]
@@ -201,23 +194,23 @@ func (e *rubricCriticMessagesConstructor) ConstructMessages(ctx context.Context,
 	}, nil
 }
 
+// StructuredOutput returns the structured output schema for rubric critic evaluation.
+func (e *rubricCriticMessagesConstructor) StructuredOutput(ctx context.Context,
+	actuals, expecteds []*evalset.Invocation, evalMetric *metric.EvalMetric) (*model.StructuredOutput, error) {
+	visibleRubrics, err := rubrics.ValidateStructured(evalMetric)
+	if err != nil {
+		return nil, err
+	}
+	return rubrics.ScoresOutput(
+		"rubric_critic_scores",
+		"Per-rubric binary scores and reasons for rubric critic evaluation.",
+		visibleRubrics,
+	), nil
+}
+
 type rubricCriticPromptData struct {
 	UserInput        string
 	FinalResponse    string
 	ExpectedResponse string
 	Rubrics          string
-}
-
-func effectiveRubricCount(evalMetric *metric.EvalMetric) int {
-	if evalMetric == nil || evalMetric.Criterion == nil || evalMetric.Criterion.LLMJudge == nil {
-		return 0
-	}
-	count := 0
-	for _, rubric := range evalMetric.Criterion.LLMJudge.Rubrics {
-		if rubric == nil || rubric.Content == nil {
-			continue
-		}
-		count++
-	}
-	return count
 }

--- a/evaluation/evaluator/llm/operator/messagesconstructor/rubriccritic/rubriccritic.go
+++ b/evaluation/evaluator/llm/operator/messagesconstructor/rubriccritic/rubriccritic.go
@@ -102,13 +102,29 @@ For each rubric item, do this internally:
 5. If there is a material defect, use score 0.
 6. Otherwise, use score 1.
 
-# Rubric Scoring Requirements
+# Output Format
 
-Score every rubric item exactly once.
-Use the exact rubric ID from the input rubric.
-Do not add, omit, merge, split, translate, or rename rubric IDs.
-Use score 1 for pass and score 0 for fail.
-State the decisive evaluation reason and compare the ACTUAL OUTPUT against the GOLDEN ANSWER for that rubric item.
+Return a single valid JSON object and nothing else:
+
+{
+  "rubricScores": [
+    {
+      "id": "[The ID of the rubric item, unique within the rubric. If the rubric itself is numbered 1..N, the ID must match that numbering.]",
+      "score": 0,
+      "reason": "[Evidence: cite source-labeled decisive snippets, e.g. Golden: ..., Actual: ..., User: ... when needed. Judgment: explain whether the ACTUAL OUTPUT materially matches the GOLDEN ANSWER for this rubric item; if required content is missing, state exactly what is missing.]"
+    }
+  ]
+}
+
+# Output Rules
+
+Produce exactly one rubricScores item for each input rubric item, in the same order. Use the exact input rubric ID; do not add, omit, merge, split, translate, or rename IDs.
+
+Set score to 1 when the ACTUAL OUTPUT materially satisfies the rubric item under the GOLDEN ANSWER. Set score to 0 when a material mismatch, omission, contradiction, or unverifiable gap remains. The numeric score in the example is not a default.
+
+Write reason as one concise evaluator note containing both source-labeled evidence and judgment. Be decisive; when score is 0, name the concrete defect. Do not add separate Rubric, Evidence, Reason, or Verdict fields.
+
+Return JSON only: double-quote keys and strings, escape quotes/newlines inside strings, and do not include markdown, comments, trailing commas, summaries, or extra fields.
 
 # Your Turn
 

--- a/evaluation/evaluator/llm/operator/messagesconstructor/rubriccritic/rubriccritic_test.go
+++ b/evaluation/evaluator/llm/operator/messagesconstructor/rubriccritic/rubriccritic_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/messagesconstructor"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion/llm"
@@ -36,7 +37,7 @@ func testRubricCriticEvalMetric() *metric.EvalMetric {
 	}
 }
 
-func TestConstructMessagesBuildsCriticPrompt(t *testing.T) {
+func TestConstructMessagesBuildsStructuredPrompt(t *testing.T) {
 	constructor := New()
 	actual := &evalset.Invocation{
 		UserContent:   &model.Message{Content: "What is the capital of France?"},
@@ -60,9 +61,61 @@ func TestConstructMessagesBuildsCriticPrompt(t *testing.T) {
 	assert.Contains(t, messages[0].Content, "llm_rubric_critic")
 	assert.Contains(t, messages[0].Content, "<reference_answer>")
 	assert.Contains(t, messages[0].Content, "The final answer states the correct city.")
-	assert.Contains(t, messages[0].Content, "Verdict:")
-	assert.Contains(t, messages[0].Content, "Reason:")
+	assert.Contains(t, messages[0].Content, "Score every rubric item exactly once.")
+	assert.Contains(t, messages[0].Content, "score 1")
 	assert.Contains(t, messages[0].Content, "Semantic equivalence")
+	assert.NotContains(t, messages[0].Content, "Do not output JSON")
+	assert.NotContains(t, messages[0].Content, "Output Format")
+	assert.NotContains(t, messages[0].Content, "rubricScores")
+	assert.NotContains(t, messages[0].Content, "Verdict:")
+}
+
+func TestStructuredOutputReturnsRubricSchema(t *testing.T) {
+	constructor, ok := New().(messagesconstructor.StructuredOutputMessagesConstructor)
+	require.True(t, ok)
+	output, err := constructor.StructuredOutput(context.Background(), nil, nil, testRubricCriticEvalMetric())
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	require.NotNil(t, output.JSONSchema)
+	assert.Equal(t, "rubric_critic_scores", output.JSONSchema.Name)
+	schema := output.JSONSchema.Schema
+	properties := schema["properties"].(map[string]any)
+	rubricScores := properties["rubricScores"].(map[string]any)
+	assert.Equal(t, 1, rubricScores["minItems"])
+	assert.Equal(t, 1, rubricScores["maxItems"])
+}
+
+func TestConstructMessagesAllowsRubricIDsForStructuredOutputValidation(t *testing.T) {
+	constructor := New()
+	evalMetric := testRubricCriticEvalMetric()
+	evalMetric.Criterion.LLMJudge.Rubrics[0].ID = ""
+	messages, err := constructor.ConstructMessages(
+		context.Background(),
+		[]*evalset.Invocation{{FinalResponse: &model.Message{Content: "answer"}}},
+		[]*evalset.Invocation{{FinalResponse: &model.Message{Content: "reference"}}},
+		evalMetric,
+	)
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+}
+
+func TestStructuredOutputRequiresUsableRubricIDs(t *testing.T) {
+	constructor := New()
+	evalMetric := testRubricCriticEvalMetric()
+	evalMetric.Criterion.LLMJudge.Rubrics[0].ID = ""
+	structured, ok := constructor.(messagesconstructor.StructuredOutputMessagesConstructor)
+	require.True(t, ok)
+	_, err := structured.StructuredOutput(context.Background(), nil, nil, evalMetric)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rubric id is required")
+	evalMetric = testRubricCriticEvalMetric()
+	evalMetric.Criterion.LLMJudge.Rubrics = append(evalMetric.Criterion.LLMJudge.Rubrics, &llm.Rubric{
+		ID:      "1",
+		Content: &llm.RubricContent{Text: "The answer is concise."},
+	})
+	_, err = structured.StructuredOutput(context.Background(), nil, nil, evalMetric)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `duplicate llm judge rubric id "1"`)
 }
 
 func TestConstructMessagesRequiresExpecteds(t *testing.T) {

--- a/evaluation/evaluator/llm/operator/messagesconstructor/rubriccritic/rubriccritic_test.go
+++ b/evaluation/evaluator/llm/operator/messagesconstructor/rubriccritic/rubriccritic_test.go
@@ -61,12 +61,14 @@ func TestConstructMessagesBuildsStructuredPrompt(t *testing.T) {
 	assert.Contains(t, messages[0].Content, "llm_rubric_critic")
 	assert.Contains(t, messages[0].Content, "<reference_answer>")
 	assert.Contains(t, messages[0].Content, "The final answer states the correct city.")
-	assert.Contains(t, messages[0].Content, "Score every rubric item exactly once.")
+	assert.Contains(t, messages[0].Content, "Produce exactly one rubricScores item")
 	assert.Contains(t, messages[0].Content, "score 1")
 	assert.Contains(t, messages[0].Content, "Semantic equivalence")
+	assert.Contains(t, messages[0].Content, "Return a single valid JSON object")
+	assert.Contains(t, messages[0].Content, "rubricScores")
 	assert.NotContains(t, messages[0].Content, "Do not output JSON")
-	assert.NotContains(t, messages[0].Content, "Output Format")
-	assert.NotContains(t, messages[0].Content, "rubricScores")
+	assert.Contains(t, messages[0].Content, "Output Format")
+	assert.Contains(t, messages[0].Content, "Output Rules")
 	assert.NotContains(t, messages[0].Content, "Verdict:")
 }
 

--- a/evaluation/evaluator/llm/operator/messagesconstructor/rubricknowledgerecall/rubricknowledgerecall.go
+++ b/evaluation/evaluator/llm/operator/messagesconstructor/rubricknowledgerecall/rubricknowledgerecall.go
@@ -57,7 +57,7 @@ Score 0: The rubric item is applicable, but the retrieved knowledge is missing, 
 
 * Prefer **verbatim excerpts** (you may truncate, but must not change meaning).
 * If you must paraphrase, it must be a **near-verbatim** paraphrase that can be directly located in the documents.
-* If <retrieved_knowledge> contains document IDs/titles/sectioning, you must cite the source location in Evidence (e.g., “Doc 2 / Paragraph 3”). If there is no numbering, include enough raw text to make the source identifiable.
+* If <retrieved_knowledge> contains document IDs/titles/sectioning, cite the source location inside the reason string (e.g., “Doc 2 / Paragraph 3”). If there is no numbering, include enough raw text in the reason to make the source identifiable.
 
 5. **Conditional rubric items (not applicable => score 1)**
    If a rubric item is conditional (e.g., “If … then …”):
@@ -72,15 +72,31 @@ Score 0: The rubric item is applicable, but the retrieved knowledge is missing, 
 2. Collect relevant excerpts from <retrieved_knowledge> as evidence.
 3. Judge whether the evidence is relevant and sufficient (using the sufficiency test).
 4. Choose score 1 or score 0 and state the decisive reason.
-   Note: These steps are for your internal analysis only and must not be output.
+   Note: Do not output these steps as separate sections. The final JSON reason should still include the decisive evidence and judgment.
 
-# Rubric Scoring Requirements
+# Output Format
 
-Score every rubric item exactly once.
-Use the exact rubric ID from the input rubric.
-Do not add, omit, merge, split, translate, or rename rubric IDs.
-Use score 1 for pass and score 0 for fail.
-State the decisive evaluation reason using evidence from <retrieved_knowledge> and, for not-applicable items, <user_prompt>.
+Return a single valid JSON object and nothing else:
+
+{
+  "rubricScores": [
+    {
+      "id": "[The ID of the rubric item, unique within the rubric. If the rubric is numbered 1..N, the ID must match that numbering.]",
+      "score": 0,
+      "reason": "[Evidence: cite source-labeled verbatim excerpts, or near-verbatim paraphrases, from <retrieved_knowledge>. Judgment: state whether the evidence is relevant and sufficient for this rubric item; if insufficient, state the missing key information; if not applicable, cite the part of <user_prompt> that makes it not applicable.]"
+    }
+  ]
+}
+
+# Output Rules
+
+Produce exactly one rubricScores item for each input rubric item, in the same order. Use the exact input rubric ID; do not add, omit, merge, split, translate, or rename IDs.
+
+Set score to 1 only when <retrieved_knowledge> directly supports the rubric item, or when the item is clearly not applicable to <user_prompt>. Set score to 0 when the retrieved knowledge is missing, insufficient, loosely related, irrelevant, or cannot support the required answer. The numeric score in the example is not a default.
+
+Write reason as one concise evaluator note containing both source-labeled evidence and judgment. Do not add separate Rubric, Evidence, Reason, or Verdict fields.
+
+Return JSON only: double-quote keys and strings, escape quotes/newlines inside strings, and do not include markdown, comments, trailing commas, summaries, or extra fields.
 
 # Your Turn
 

--- a/evaluation/evaluator/llm/operator/messagesconstructor/rubricknowledgerecall/rubricknowledgerecall.go
+++ b/evaluation/evaluator/llm/operator/messagesconstructor/rubricknowledgerecall/rubricknowledgerecall.go
@@ -16,6 +16,7 @@ import (
 	"text/template"
 
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/internal/rubrics"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/messagesconstructor"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/messagesconstructor/internal/content"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
@@ -32,8 +33,8 @@ Only respond to the rubric items provided. Do not invent new rubric items.
 
 # Rubric
 
-"yes": The retrieved knowledge **directly supports** the key information required by the rubric item, OR the rubric item’s condition is clearly not applicable to this user question.
-"no": The rubric item is applicable, but the retrieved knowledge is missing, insufficient, only broadly on-topic, or clearly irrelevant, and therefore cannot support the rubric item.
+Score 1: The retrieved knowledge **directly supports** the key information required by the rubric item, OR the rubric item’s condition is clearly not applicable to this user question.
+Score 0: The rubric item is applicable, but the retrieved knowledge is missing, insufficient, only broadly on-topic, or clearly irrelevant, and therefore cannot support the rubric item.
 
 # Key Evaluation Principles
 
@@ -42,14 +43,14 @@ Only respond to the rubric items provided. Do not invent new rubric items.
 
 2. **Relevance first, and it must be answerable**
    Even if the retrieved knowledge contains correct facts, it must be relevant to the user’s intent and usable for satisfying the corresponding rubric item.
-   If it is merely “same topic / loosely related / generic background” but does not support the required information for the rubric item, answer "no".
+   If it is merely “same topic / loosely related / generic background” but does not support the required information for the rubric item, use score 0.
 
 3. **Sufficiency must be judged with an operational test**
    For each rubric item, use the following test to determine whether the retrieval is “sufficient”:
 
 * Imagine an answerer who can only see <retrieved_knowledge> (no external knowledge, no guessing).
-* If they could complete the rubric item using only that retrieved knowledge (i.e., produce the key conclusion/elements required), then the item may be "yes".
-* If they could not (missing key entities, steps, numbers, conditions, definitions, etc.), then it must be "no".
+* If they could complete the rubric item using only that retrieved knowledge (i.e., produce the key conclusion/elements required), then use score 1.
+* If they could not (missing key entities, steps, numbers, conditions, definitions, etc.), then use score 0.
 
 4. **Evidence must be close to the original text; no abstract fabrication**
    Evidence must come from <retrieved_knowledge>, with these requirements:
@@ -58,31 +59,28 @@ Only respond to the rubric items provided. Do not invent new rubric items.
 * If you must paraphrase, it must be a **near-verbatim** paraphrase that can be directly located in the documents.
 * If <retrieved_knowledge> contains document IDs/titles/sectioning, you must cite the source location in Evidence (e.g., “Doc 2 / Paragraph 3”). If there is no numbering, include enough raw text to make the source identifiable.
 
-5. **Conditional rubric items (not applicable => yes)**
+5. **Conditional rubric items (not applicable => score 1)**
    If a rubric item is conditional (e.g., “If … then …”):
 
-* You may return "yes" as not applicable only if you can **clearly determine from <user_prompt>** that the condition is not met.
-* If you cannot determine whether the condition is met, treat the item as applicable; if retrieval is insufficient, return "no".
-* When you return "yes" due to not-applicable, your Reason must explicitly state what part of <user_prompt> makes it not applicable.
-
-6. **No extra output**
-   You must output only the per-item evaluations in the format below. Do not add any overall summary or additional commentary.
+* You may use score 1 as not applicable only if you can **clearly determine from <user_prompt>** that the condition is not met.
+* If you cannot determine whether the condition is met, treat the item as applicable; if retrieval is insufficient, use score 0.
+* When you use score 1 due to not-applicable, your reason must explicitly state what part of <user_prompt> makes it not applicable.
 
 # Internal steps for each rubric item (for internal analysis only)
 
 1. Understand the rubric item and the key evaluation principles.
 2. Collect relevant excerpts from <retrieved_knowledge> as evidence.
 3. Judge whether the evidence is relevant and sufficient (using the sufficiency test).
-4. Output the verdict in the required format.
+4. Choose score 1 or score 0 and state the decisive reason.
    Note: These steps are for your internal analysis only and must not be output.
 
-# Output Format (repeat this format for every rubric item, starting with a new line)
+# Rubric Scoring Requirements
 
-ID: [The ID of the rubric item, unique within the rubric. If the rubric is numbered 1..N, the ID must match that numbering.]
-Rubric: [Repeat the rubric item word-for-word without any changes. Keep punctuation and capitalization exactly as-is. Do not translate or paraphrase.]
-Evidence: [Relevant verbatim excerpts (or near-verbatim paraphrases) from <retrieved_knowledge>, with source/location where possible. If there is no relevant evidence, write “none”.]
-Reason: [Explain why the evidence directly supports the rubric item, or why evidence is missing/insufficient/irrelevant; or explain why the item is not applicable, and cite which part of <user_prompt> establishes that.]
-Verdict: [yes|no]
+Score every rubric item exactly once.
+Use the exact rubric ID from the input rubric.
+Do not add, omit, merge, split, translate, or rename rubric IDs.
+Use score 1 for pass and score 0 for fail.
+State the decisive evaluation reason using evidence from <retrieved_knowledge> and, for not-applicable items, <user_prompt>.
 
 # Your Turn
 
@@ -121,6 +119,15 @@ func (e *rubricKnowledgeRecallMessagesConstructor) ConstructMessages(ctx context
 	if len(actuals) == 0 {
 		return nil, fmt.Errorf("actuals is empty")
 	}
+	if evalMetric == nil {
+		return nil, fmt.Errorf("eval metric is nil")
+	}
+	if evalMetric.Criterion == nil || evalMetric.Criterion.LLMJudge == nil {
+		return nil, fmt.Errorf("llm judge criterion is required")
+	}
+	if rubrics.Count(evalMetric) == 0 {
+		return nil, fmt.Errorf("llm judge rubrics are required")
+	}
 	actual := actuals[len(actuals)-1]
 	retrieved, err := content.ExtractKnowledgeRecall(actual.Tools)
 	if err != nil {
@@ -144,6 +151,20 @@ func (e *rubricKnowledgeRecallMessagesConstructor) ConstructMessages(ctx context
 			Content: buf.String(),
 		},
 	}, nil
+}
+
+// StructuredOutput returns the structured output schema for knowledge recall evaluation.
+func (e *rubricKnowledgeRecallMessagesConstructor) StructuredOutput(ctx context.Context,
+	actuals, expecteds []*evalset.Invocation, evalMetric *metric.EvalMetric) (*model.StructuredOutput, error) {
+	visibleRubrics, err := rubrics.ValidateStructured(evalMetric)
+	if err != nil {
+		return nil, err
+	}
+	return rubrics.ScoresOutput(
+		"rubric_knowledge_recall_scores",
+		"Per-rubric binary scores and reasons for knowledge recall evaluation.",
+		visibleRubrics,
+	), nil
 }
 
 type rubricKnowledgeRecallPromptData struct {

--- a/evaluation/evaluator/llm/operator/messagesconstructor/rubricknowledgerecall/rubricknowledgerecall_test.go
+++ b/evaluation/evaluator/llm/operator/messagesconstructor/rubricknowledgerecall/rubricknowledgerecall_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/messagesconstructor"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion/llm"
@@ -56,6 +57,11 @@ func TestConstructMessagesWithKnowledge(t *testing.T) {
 	assert.Contains(t, messages[0].Content, "result")
 	assert.Contains(t, messages[0].Content, "who?")
 	assert.Contains(t, messages[0].Content, "rubric")
+	assert.Contains(t, messages[0].Content, "Score every rubric item exactly once.")
+	assert.NotContains(t, messages[0].Content, "Do not output JSON")
+	assert.NotContains(t, messages[0].Content, "Output Format")
+	assert.NotContains(t, messages[0].Content, "rubricScores")
+	assert.NotContains(t, messages[0].Content, "Verdict:")
 }
 
 func TestConstructMessagesNoKnowledgeFound(t *testing.T) {
@@ -66,11 +72,7 @@ func TestConstructMessagesNoKnowledgeFound(t *testing.T) {
 		InvocationID:      "id",
 		CreationTimestamp: nil,
 	}
-	evalMetric := &metric.EvalMetric{
-		Criterion: &criterion.Criterion{
-			LLMJudge: &llm.LLMCriterion{},
-		},
-	}
+	evalMetric := validEvalMetric()
 
 	messages, err := constructor.ConstructMessages(context.Background(), []*evalset.Invocation{actual}, nil, evalMetric)
 	require.NoError(t, err)
@@ -92,12 +94,51 @@ func TestConstructMessagesKnowledgeError(t *testing.T) {
 			},
 		},
 	}
-	evalMetric := &metric.EvalMetric{
-		Criterion: &criterion.Criterion{
-			LLMJudge: &llm.LLMCriterion{},
-		},
-	}
+	evalMetric := validEvalMetric()
 
 	_, err := constructor.ConstructMessages(context.Background(), []*evalset.Invocation{actual}, nil, evalMetric)
 	require.Error(t, err)
+}
+
+func TestConstructMessagesRequiresLLMJudgeRubrics(t *testing.T) {
+	constructor := New()
+	actual := &evalset.Invocation{
+		UserContent: &model.Message{Content: "question"},
+	}
+	_, err := constructor.ConstructMessages(context.Background(), []*evalset.Invocation{actual}, nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "eval metric is nil")
+	_, err = constructor.ConstructMessages(context.Background(), []*evalset.Invocation{actual}, nil, &metric.EvalMetric{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "llm judge criterion is required")
+	_, err = constructor.ConstructMessages(context.Background(), []*evalset.Invocation{actual}, nil, &metric.EvalMetric{
+		Criterion: &criterion.Criterion{LLMJudge: &llm.LLMCriterion{}},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "llm judge rubrics are required")
+}
+
+func TestStructuredOutputReturnsRubricSchema(t *testing.T) {
+	constructor, ok := New().(messagesconstructor.StructuredOutputMessagesConstructor)
+	require.True(t, ok)
+	output, err := constructor.StructuredOutput(context.Background(), nil, nil, validEvalMetric())
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	require.NotNil(t, output.JSONSchema)
+	assert.Equal(t, "rubric_knowledge_recall_scores", output.JSONSchema.Name)
+	schema := output.JSONSchema.Schema
+	properties := schema["properties"].(map[string]any)
+	rubricScores := properties["rubricScores"].(map[string]any)
+	assert.Equal(t, 1, rubricScores["minItems"])
+	assert.Equal(t, 1, rubricScores["maxItems"])
+}
+
+func validEvalMetric() *metric.EvalMetric {
+	return &metric.EvalMetric{
+		Criterion: &criterion.Criterion{
+			LLMJudge: &llm.LLMCriterion{
+				Rubrics: []*llm.Rubric{{ID: "r1", Content: &llm.RubricContent{Text: "rubric"}}},
+			},
+		},
+	}
 }

--- a/evaluation/evaluator/llm/operator/messagesconstructor/rubricknowledgerecall/rubricknowledgerecall_test.go
+++ b/evaluation/evaluator/llm/operator/messagesconstructor/rubricknowledgerecall/rubricknowledgerecall_test.go
@@ -57,10 +57,12 @@ func TestConstructMessagesWithKnowledge(t *testing.T) {
 	assert.Contains(t, messages[0].Content, "result")
 	assert.Contains(t, messages[0].Content, "who?")
 	assert.Contains(t, messages[0].Content, "rubric")
-	assert.Contains(t, messages[0].Content, "Score every rubric item exactly once.")
+	assert.Contains(t, messages[0].Content, "Produce exactly one rubricScores item")
+	assert.Contains(t, messages[0].Content, "Return a single valid JSON object")
+	assert.Contains(t, messages[0].Content, "rubricScores")
 	assert.NotContains(t, messages[0].Content, "Do not output JSON")
-	assert.NotContains(t, messages[0].Content, "Output Format")
-	assert.NotContains(t, messages[0].Content, "rubricScores")
+	assert.Contains(t, messages[0].Content, "Output Format")
+	assert.Contains(t, messages[0].Content, "Output Rules")
 	assert.NotContains(t, messages[0].Content, "Verdict:")
 }
 
@@ -131,6 +133,24 @@ func TestStructuredOutputReturnsRubricSchema(t *testing.T) {
 	rubricScores := properties["rubricScores"].(map[string]any)
 	assert.Equal(t, 1, rubricScores["minItems"])
 	assert.Equal(t, 1, rubricScores["maxItems"])
+}
+
+func TestStructuredOutputRequiresUsableRubricIDs(t *testing.T) {
+	constructor, ok := New().(messagesconstructor.StructuredOutputMessagesConstructor)
+	require.True(t, ok)
+	evalMetric := validEvalMetric()
+	evalMetric.Criterion.LLMJudge.Rubrics[0].ID = ""
+	_, err := constructor.StructuredOutput(context.Background(), nil, nil, evalMetric)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rubric id is required")
+	evalMetric = validEvalMetric()
+	evalMetric.Criterion.LLMJudge.Rubrics = append(evalMetric.Criterion.LLMJudge.Rubrics, &llm.Rubric{
+		ID:      "r1",
+		Content: &llm.RubricContent{Text: "another rubric"},
+	})
+	_, err = constructor.StructuredOutput(context.Background(), nil, nil, evalMetric)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `duplicate llm judge rubric id "r1"`)
 }
 
 func validEvalMetric() *metric.EvalMetric {

--- a/evaluation/evaluator/llm/operator/messagesconstructor/rubricreferencecritic/rubricreferencecritic.go
+++ b/evaluation/evaluator/llm/operator/messagesconstructor/rubricreferencecritic/rubricreferencecritic.go
@@ -16,6 +16,7 @@ import (
 	"text/template"
 
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/internal/rubrics"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/messagesconstructor"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/messagesconstructor/internal/content"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
@@ -45,8 +46,8 @@ For each rubric item, first determine what the rubric item requires by reading:
 3. the relevant part of the REFERENCE ANSWER.
 
 Then compare the ACTUAL OUTPUT against that requirement.
-Return "yes" only if the ACTUAL OUTPUT materially satisfies the current rubric item.
-If a material defect remains, return "no".
+Use score 1 only if the ACTUAL OUTPUT materially satisfies the current rubric item.
+If a material defect remains, use score 0.
 
 # Decision Rules
 
@@ -71,7 +72,7 @@ If a material defect remains, return "no".
    The ACTUAL OUTPUT does not need to mirror the REFERENCE ANSWER literally.
    It does need to preserve the same grounded meaning, decisive context, and comparable level of useful detail required by the current rubric item.
 
-5. **A "no" must be caused by a material defect**
+5. **Score 0 must be caused by a material defect**
    A defect is material only if it would make a reasonable evaluator conclude that the current rubric item is not truly satisfied.
    Typical material defects include:
    * missing required information,
@@ -85,10 +86,10 @@ If a material defect remains, return "no".
    Do not invent hidden requirements.
    Do not fail an item because of style, tone, verbosity, brevity, formatting, or ordering alone.
    Do not fail an item for extra detail unless that detail contradicts, weakens, or obscures what the current rubric item requires.
-   If the ACTUAL OUTPUT is reasonably equivalent in grounded meaning and fidelity for the current rubric item, return "yes".
+   If the ACTUAL OUTPUT is reasonably equivalent in grounded meaning and fidelity for the current rubric item, use score 1.
 
 7. **Conditional rubric items**
-   If a rubric item is conditional, you may treat it as not applicable and return "yes" only when the condition is clearly not met based on <user_prompt> and <reference_answer>.
+   If a rubric item is conditional, you may treat it as not applicable and use score 1 only when the condition is clearly not met based on <user_prompt> and <reference_answer>.
    If applicability is unclear, do not guess. Treat the item as applicable.
 
 # Internal Evaluation Procedure
@@ -98,26 +99,17 @@ For each rubric item, do this internally:
 2. Extract the decisive evidence from the REFERENCE ANSWER and, if needed, the USER REQUEST.
 3. Extract the corresponding evidence from the ACTUAL OUTPUT.
 4. Decide whether there is a material mismatch, omission, contradiction, unsupported specificity, or unverifiable gap.
-5. If there is a material defect, return "no".
-6. Otherwise, return "yes".
+5. If there is a material defect, use score 0.
+6. Otherwise, use score 1.
 
-# Output Format
+# Rubric Scoring Requirements
 
-Repeat the following block for every rubric item, starting on a new line.
-
-ID: [The ID of the rubric item, unique within the rubric. If the rubric itself is numbered 1..N, the ID must match that numbering.]
-Rubric: [Repeat the rubric item word-for-word without any changes. Keep punctuation and capitalization exactly as-is. Do not translate or paraphrase.]
-Evidence: [Quote only the decisive snippets from the REFERENCE ANSWER, the ACTUAL OUTPUT, and the USER REQUEST when needed. If something required is missing or unverifiable, explicitly state what is missing or unverifiable.]
-Reason: [State the key evaluation reason from the evaluator's perspective. Compare the ACTUAL OUTPUT against the REFERENCE ANSWER for this rubric item. Prefer one decisive material reason over a long list of minor complaints.]
-Verdict: [yes|no]
-
-# Output Constraints
-
-* Output only the rubric blocks in the exact format above.
-* Do not output JSON.
-* Do not add an overall summary.
-* Be decisive.
-* When the verdict is "no", the reason must point to a concrete mismatch, omission, unsupported specificity, contradiction, or unverifiable gap.
+Score every rubric item exactly once.
+Use the exact rubric ID from the input rubric.
+Do not add, omit, merge, split, translate, or rename rubric IDs.
+Use score 1 for pass and score 0 for fail.
+State the decisive evaluation reason based only on <user_prompt>, <reference_answer>, and <final_answer>.
+When score is 0, the reason must point to a concrete mismatch, omission, unsupported specificity, contradiction, or unverifiable gap.
 
 # Your Turn
 
@@ -172,7 +164,7 @@ func (e *rubricReferenceCriticMessagesConstructor) ConstructMessages(ctx context
 	if evalMetric.Criterion == nil || evalMetric.Criterion.LLMJudge == nil {
 		return nil, fmt.Errorf("llm judge criterion is required")
 	}
-	if effectiveRubricCount(evalMetric) == 0 {
+	if rubrics.Count(evalMetric) == 0 {
 		return nil, fmt.Errorf("llm judge rubrics are required")
 	}
 	actual := actuals[len(actuals)-1]
@@ -204,23 +196,23 @@ func (e *rubricReferenceCriticMessagesConstructor) ConstructMessages(ctx context
 	}, nil
 }
 
+// StructuredOutput returns the structured output schema for reference-aware rubric criticism.
+func (e *rubricReferenceCriticMessagesConstructor) StructuredOutput(ctx context.Context,
+	actuals, expecteds []*evalset.Invocation, evalMetric *metric.EvalMetric) (*model.StructuredOutput, error) {
+	visibleRubrics, err := rubrics.ValidateStructured(evalMetric)
+	if err != nil {
+		return nil, err
+	}
+	return rubrics.ScoresOutput(
+		"rubric_reference_critic_scores",
+		"Per-rubric binary scores and reasons for rubric reference critic evaluation.",
+		visibleRubrics,
+	), nil
+}
+
 type rubricReferenceCriticPromptData struct {
 	UserInput             string
 	ExpectedFinalResponse string
 	ActualFinalResponse   string
 	Rubrics               string
-}
-
-func effectiveRubricCount(evalMetric *metric.EvalMetric) int {
-	if evalMetric == nil || evalMetric.Criterion == nil || evalMetric.Criterion.LLMJudge == nil {
-		return 0
-	}
-	count := 0
-	for _, rubric := range evalMetric.Criterion.LLMJudge.Rubrics {
-		if rubric == nil || rubric.Content == nil {
-			continue
-		}
-		count++
-	}
-	return count
 }

--- a/evaluation/evaluator/llm/operator/messagesconstructor/rubricreferencecritic/rubricreferencecritic.go
+++ b/evaluation/evaluator/llm/operator/messagesconstructor/rubricreferencecritic/rubricreferencecritic.go
@@ -102,14 +102,29 @@ For each rubric item, do this internally:
 5. If there is a material defect, use score 0.
 6. Otherwise, use score 1.
 
-# Rubric Scoring Requirements
+# Output Format
 
-Score every rubric item exactly once.
-Use the exact rubric ID from the input rubric.
-Do not add, omit, merge, split, translate, or rename rubric IDs.
-Use score 1 for pass and score 0 for fail.
-State the decisive evaluation reason based only on <user_prompt>, <reference_answer>, and <final_answer>.
-When score is 0, the reason must point to a concrete mismatch, omission, unsupported specificity, contradiction, or unverifiable gap.
+Return a single valid JSON object and nothing else:
+
+{
+  "rubricScores": [
+    {
+      "id": "[The ID of the rubric item, unique within the rubric. If the rubric itself is numbered 1..N, the ID must match that numbering.]",
+      "score": 0,
+      "reason": "[Evidence: cite source-labeled decisive snippets, e.g. Reference: ..., Actual: ..., User: ... when needed. Judgment: explain whether the ACTUAL OUTPUT preserves the grounded meaning, fidelity, and useful detail required by this rubric item; if required content is missing or unverifiable, state exactly what is missing or unverifiable.]"
+    }
+  ]
+}
+
+# Output Rules
+
+Produce exactly one rubricScores item for each input rubric item, in the same order. Use the exact input rubric ID; do not add, omit, merge, split, translate, or rename IDs.
+
+Set score to 1 when the ACTUAL OUTPUT preserves the grounded meaning, fidelity, and useful detail required by the rubric item. Set score to 0 when a material mismatch, omission, unsupported specificity, contradiction, or unverifiable gap remains. The numeric score in the example is not a default.
+
+Write reason as one concise evaluator note containing both source-labeled evidence and judgment. Be decisive; when score is 0, name the concrete defect. Do not add separate Rubric, Evidence, Reason, or Verdict fields.
+
+Return JSON only: double-quote keys and strings, escape quotes/newlines inside strings, and do not include markdown, comments, trailing commas, summaries, or extra fields.
 
 # Your Turn
 

--- a/evaluation/evaluator/llm/operator/messagesconstructor/rubricreferencecritic/rubricreferencecritic_test.go
+++ b/evaluation/evaluator/llm/operator/messagesconstructor/rubricreferencecritic/rubricreferencecritic_test.go
@@ -67,10 +67,12 @@ func TestConstructMessagesIncludesReferenceAnswer(t *testing.T) {
 	assert.Contains(t, messages[0].Content, "test_rubric_text")
 	assert.NotContains(t, messages[0].Content, "guessed basketball context")
 	assert.NotContains(t, messages[0].Content, "current play")
-	assert.Contains(t, messages[0].Content, "Score every rubric item exactly once.")
+	assert.Contains(t, messages[0].Content, "Produce exactly one rubricScores item")
+	assert.Contains(t, messages[0].Content, "Return a single valid JSON object")
+	assert.Contains(t, messages[0].Content, "rubricScores")
 	assert.NotContains(t, messages[0].Content, "Do not output JSON")
-	assert.NotContains(t, messages[0].Content, "Output Format")
-	assert.NotContains(t, messages[0].Content, "rubricScores")
+	assert.Contains(t, messages[0].Content, "Output Format")
+	assert.Contains(t, messages[0].Content, "Output Rules")
 	assert.NotContains(t, messages[0].Content, "Verdict:")
 }
 

--- a/evaluation/evaluator/llm/operator/messagesconstructor/rubricreferencecritic/rubricreferencecritic_test.go
+++ b/evaluation/evaluator/llm/operator/messagesconstructor/rubricreferencecritic/rubricreferencecritic_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/messagesconstructor"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion"
 	criterionllm "trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion/llm"
@@ -66,6 +67,11 @@ func TestConstructMessagesIncludesReferenceAnswer(t *testing.T) {
 	assert.Contains(t, messages[0].Content, "test_rubric_text")
 	assert.NotContains(t, messages[0].Content, "guessed basketball context")
 	assert.NotContains(t, messages[0].Content, "current play")
+	assert.Contains(t, messages[0].Content, "Score every rubric item exactly once.")
+	assert.NotContains(t, messages[0].Content, "Do not output JSON")
+	assert.NotContains(t, messages[0].Content, "Output Format")
+	assert.NotContains(t, messages[0].Content, "rubricScores")
+	assert.NotContains(t, messages[0].Content, "Verdict:")
 }
 
 func TestConstructMessagesRequiresReferenceAnswer(t *testing.T) {
@@ -93,6 +99,21 @@ func TestConstructMessagesRequiresLLMJudgeRubrics(t *testing.T) {
 	_, err := constructor.ConstructMessages(context.Background(), []*evalset.Invocation{actual}, []*evalset.Invocation{expected}, evalMetric)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "llm judge rubrics are required")
+}
+
+func TestStructuredOutputReturnsRubricSchema(t *testing.T) {
+	constructor, ok := New().(messagesconstructor.StructuredOutputMessagesConstructor)
+	require.True(t, ok)
+	output, err := constructor.StructuredOutput(context.Background(), nil, nil, newValidEvalMetric())
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	require.NotNil(t, output.JSONSchema)
+	assert.Equal(t, "rubric_reference_critic_scores", output.JSONSchema.Name)
+	schema := output.JSONSchema.Schema
+	properties := schema["properties"].(map[string]any)
+	rubricScores := properties["rubricScores"].(map[string]any)
+	assert.Equal(t, 1, rubricScores["minItems"])
+	assert.Equal(t, 1, rubricScores["maxItems"])
 }
 
 func TestConstructMessagesRequiresLLMJudgeCriterion(t *testing.T) {
@@ -158,25 +179,4 @@ func TestConstructMessagesValidationErrors(t *testing.T) {
 			assert.ErrorContains(t, err, tt.wantErr)
 		})
 	}
-}
-
-func TestEffectiveRubricCount(t *testing.T) {
-	assert.Equal(t, 0, effectiveRubricCount(nil))
-	assert.Equal(t, 0, effectiveRubricCount(&metric.EvalMetric{}))
-	assert.Equal(t, 1, effectiveRubricCount(&metric.EvalMetric{
-		Criterion: &criterion.Criterion{
-			LLMJudge: &criterionllm.LLMCriterion{
-				Rubrics: []*criterionllm.Rubric{
-					nil,
-					{ID: "1"},
-					{
-						ID: "2",
-						Content: &criterionllm.RubricContent{
-							Text: "valid",
-						},
-					},
-				},
-			},
-		},
-	}))
 }

--- a/evaluation/evaluator/llm/operator/messagesconstructor/rubricresponse/rubricresponse.go
+++ b/evaluation/evaluator/llm/operator/messagesconstructor/rubricresponse/rubricresponse.go
@@ -56,13 +56,29 @@ Score 0: The rubric item is applicable but the final answer fails to fulfill it,
    If a rubric item is conditional (e.g., “If … then …”), you may mark it as not applicable and use score 1 only if you can clearly determine from <user_prompt> and <final_answer> that the condition is not met.
    If you cannot determine whether the condition is met, you may not mark it as “probably not applicable.” Treat it as not fulfilled (typically score 0).
 
-# Rubric Scoring Requirements
+# Output Format
 
-Score every rubric item exactly once.
-Use the exact rubric ID from the input rubric.
-Do not add, omit, merge, split, translate, or rename rubric IDs.
-Use score 1 for pass and score 0 for fail.
-State the decisive evaluation reason based only on <user_prompt> and <final_answer>.
+Return a single valid JSON object and nothing else:
+
+{
+  "rubricScores": [
+    {
+      "id": "[The ID of the rubric item, unique within the rubric. If the rubric itself is numbered 1..N, the ID must match that numbering.]",
+      "score": 0,
+      "reason": "[Evidence: cite source-labeled decisive evidence from <user_prompt> and/or <final_answer>. Judgment: explain whether the final answer satisfies this rubric item; if the item is not applicable, state the exact evidence that makes it not applicable.]"
+    }
+  ]
+}
+
+# Output Rules
+
+Produce exactly one rubricScores item for each input rubric item, in the same order. Use the exact input rubric ID; do not add, omit, merge, split, translate, or rename IDs.
+
+Set score to 1 when the item is fulfilled or clearly not applicable. Set score to 0 when the item is applicable but not fulfilled, or when fulfillment cannot be unambiguously verified from the allowed evidence. The numeric score in the example is not a default.
+
+Write reason as one concise evaluator note containing both source-labeled evidence and judgment. Do not add separate Rubric, Evidence, Reason, or Verdict fields.
+
+Return JSON only: double-quote keys and strings, escape quotes/newlines inside strings, and do not include markdown, comments, trailing commas, summaries, or extra fields.
 
 # Your Turn
 

--- a/evaluation/evaluator/llm/operator/messagesconstructor/rubricresponse/rubricresponse.go
+++ b/evaluation/evaluator/llm/operator/messagesconstructor/rubricresponse/rubricresponse.go
@@ -17,6 +17,7 @@ import (
 	"text/template"
 
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/internal/rubrics"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/messagesconstructor"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/messagesconstructor/internal/content"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
@@ -32,8 +33,8 @@ Only respond to the rubric items provided. Do not invent new rubric items.
 
 # Rubric
 
-"yes": The final answer fulfills the rubric item, OR the rubric item’s condition was not applicable to the response.
-"no": The rubric item is applicable but the final answer fails to fulfill it, OR the rubric item requires a fact/conclusion that cannot be unambiguously verified from <user_prompt> and <final_answer> (i.e., it is ambiguous or lacks checkable information).
+Score 1: The final answer fulfills the rubric item, OR the rubric item’s condition was not applicable to the response.
+Score 0: The rubric item is applicable but the final answer fails to fulfill it, OR the rubric item requires a fact/conclusion that cannot be unambiguously verified from <user_prompt> and <final_answer> (i.e., it is ambiguous or lacks checkable information).
 
 # Key Evaluation Principles
 
@@ -51,19 +52,17 @@ Only respond to the rubric items provided. Do not invent new rubric items.
    As long as the rubric item is still satisfied, accept different wording, formatting, and paraphrases.
    For numbers, accept numerically equivalent expressions (different representations), and allow minor rounding/precision differences as long as they do not change the final conclusion.
 
-4. **Conditional rubric items (not applicable => yes)**
-   If a rubric item is conditional (e.g., “If … then …”), you may mark it as not applicable and return "yes" only if you can clearly determine from <user_prompt> and <final_answer> that the condition is not met.
-   If you cannot determine whether the condition is met, you may not mark it as “probably not applicable.” Treat it as not fulfilled (typically "no").
+4. **Conditional rubric items (not applicable => score 1)**
+   If a rubric item is conditional (e.g., “If … then …”), you may mark it as not applicable and use score 1 only if you can clearly determine from <user_prompt> and <final_answer> that the condition is not met.
+   If you cannot determine whether the condition is met, you may not mark it as “probably not applicable.” Treat it as not fulfilled (typically score 0).
 
-# Output Format (repeat this format for every rubric item, starting on a new line)
+# Rubric Scoring Requirements
 
-ID: [The ID of the rubric item, unique within the rubric. If the rubric itself is numbered 1..N, the ID must match that numbering.]
-Rubric: [Repeat the rubric item word-for-word without any changes. Keep punctuation and capitalization exactly as-is. Do not translate or paraphrase.]
-Evidence: [List the evidence text snippets relevant to this rubric item from <user_prompt> and/or <final_answer>. If no evidence is required to decide, explain why. If it cannot be unambiguously verified, explain why it cannot be verified.]
-Reason: [Explain your reasoning: how the evidence supports/contradicts the final answer, or why the rubric item is not applicable.]
-Verdict: [yes|no]
-
-REMEMBER: Your answer will help improve the AI agent. It is important to determine whether rubric items are fulfilled correctly. Even answering "no" can improve the agent! Respond in pure text, not json.
+Score every rubric item exactly once.
+Use the exact rubric ID from the input rubric.
+Do not add, omit, merge, split, translate, or rename rubric IDs.
+Use score 1 for pass and score 0 for fail.
+State the decisive evaluation reason based only on <user_prompt> and <final_answer>.
 
 # Your Turn
 
@@ -105,6 +104,15 @@ func (e *rubricResponseMessagesConstructor) ConstructMessages(ctx context.Contex
 	if len(actuals) == 0 {
 		return nil, fmt.Errorf("actuals is empty")
 	}
+	if evalMetric == nil {
+		return nil, fmt.Errorf("eval metric is nil")
+	}
+	if evalMetric.Criterion == nil || evalMetric.Criterion.LLMJudge == nil {
+		return nil, fmt.Errorf("llm judge criterion is required")
+	}
+	if rubrics.Count(evalMetric) == 0 {
+		return nil, fmt.Errorf("llm judge rubrics are required")
+	}
 	actual := actuals[len(actuals)-1]
 	data := rubricResponsePromptData{
 		UserInput:     content.ExtractTextFromContent(actual.UserContent),
@@ -121,6 +129,20 @@ func (e *rubricResponseMessagesConstructor) ConstructMessages(ctx context.Contex
 			Content: buf.String(),
 		},
 	}, nil
+}
+
+// StructuredOutput returns the structured output schema for rubric response evaluation.
+func (e *rubricResponseMessagesConstructor) StructuredOutput(ctx context.Context,
+	actuals, expecteds []*evalset.Invocation, evalMetric *metric.EvalMetric) (*model.StructuredOutput, error) {
+	visibleRubrics, err := rubrics.ValidateStructured(evalMetric)
+	if err != nil {
+		return nil, err
+	}
+	return rubrics.ScoresOutput(
+		"rubric_response_scores",
+		"Per-rubric binary scores and reasons for rubric response evaluation.",
+		visibleRubrics,
+	), nil
 }
 
 // rubricResponsePromptData feeds values into the judge prompt template.

--- a/evaluation/evaluator/llm/operator/messagesconstructor/rubricresponse/rubricresponse_test.go
+++ b/evaluation/evaluator/llm/operator/messagesconstructor/rubricresponse/rubricresponse_test.go
@@ -51,10 +51,12 @@ func TestConstructMessagesIncludesAllFields(t *testing.T) {
 	assert.Contains(t, messages[0].Content, "test_user_content")
 	assert.Contains(t, messages[0].Content, "test_final_response")
 	assert.Contains(t, messages[0].Content, "test_rubric_text")
-	assert.Contains(t, messages[0].Content, "Score every rubric item exactly once.")
+	assert.Contains(t, messages[0].Content, "Produce exactly one rubricScores item")
+	assert.Contains(t, messages[0].Content, "Return a single valid JSON object")
+	assert.Contains(t, messages[0].Content, "rubricScores")
 	assert.NotContains(t, messages[0].Content, "Do not output JSON")
-	assert.NotContains(t, messages[0].Content, "Output Format")
-	assert.NotContains(t, messages[0].Content, "rubricScores")
+	assert.Contains(t, messages[0].Content, "Output Format")
+	assert.Contains(t, messages[0].Content, "Output Rules")
 	assert.NotContains(t, messages[0].Content, "Verdict:")
 }
 

--- a/evaluation/evaluator/llm/operator/messagesconstructor/rubricresponse/rubricresponse_test.go
+++ b/evaluation/evaluator/llm/operator/messagesconstructor/rubricresponse/rubricresponse_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/messagesconstructor"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion/llm"
@@ -50,4 +51,49 @@ func TestConstructMessagesIncludesAllFields(t *testing.T) {
 	assert.Contains(t, messages[0].Content, "test_user_content")
 	assert.Contains(t, messages[0].Content, "test_final_response")
 	assert.Contains(t, messages[0].Content, "test_rubric_text")
+	assert.Contains(t, messages[0].Content, "Score every rubric item exactly once.")
+	assert.NotContains(t, messages[0].Content, "Do not output JSON")
+	assert.NotContains(t, messages[0].Content, "Output Format")
+	assert.NotContains(t, messages[0].Content, "rubricScores")
+	assert.NotContains(t, messages[0].Content, "Verdict:")
+}
+
+func TestStructuredOutputReturnsRubricSchema(t *testing.T) {
+	constructor, ok := New().(messagesconstructor.StructuredOutputMessagesConstructor)
+	require.True(t, ok)
+	output, err := constructor.StructuredOutput(context.Background(), nil, nil, &metric.EvalMetric{
+		Criterion: &criterion.Criterion{
+			LLMJudge: &llm.LLMCriterion{
+				Rubrics: []*llm.Rubric{{ID: "r1", Content: &llm.RubricContent{Text: "rubric"}}},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	require.NotNil(t, output.JSONSchema)
+	assert.Equal(t, "rubric_response_scores", output.JSONSchema.Name)
+	schema := output.JSONSchema.Schema
+	properties := schema["properties"].(map[string]any)
+	rubricScores := properties["rubricScores"].(map[string]any)
+	assert.Equal(t, 1, rubricScores["minItems"])
+	assert.Equal(t, 1, rubricScores["maxItems"])
+}
+
+func TestConstructMessagesRequiresLLMJudgeRubrics(t *testing.T) {
+	constructor := New()
+	actual := &evalset.Invocation{
+		UserContent:   &model.Message{Content: "test_user_content"},
+		FinalResponse: &model.Message{Content: "test_final_response"},
+	}
+	_, err := constructor.ConstructMessages(context.Background(), []*evalset.Invocation{actual}, nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "eval metric is nil")
+	_, err = constructor.ConstructMessages(context.Background(), []*evalset.Invocation{actual}, nil, &metric.EvalMetric{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "llm judge criterion is required")
+	_, err = constructor.ConstructMessages(context.Background(), []*evalset.Invocation{actual}, nil, &metric.EvalMetric{
+		Criterion: &criterion.Criterion{LLMJudge: &llm.LLMCriterion{}},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "llm judge rubrics are required")
 }

--- a/evaluation/evaluator/llm/operator/messagesconstructor/template/template.go
+++ b/evaluation/evaluator/llm/operator/messagesconstructor/template/template.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/internal/templateresolver"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/messagesconstructor"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/messagesconstructor/internal/content"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
@@ -61,6 +62,16 @@ func (c *templateMessagesConstructor) ConstructMessages(ctx context.Context, act
 		Role:    model.RoleUser,
 		Content: rendered,
 	}}, nil
+}
+
+// StructuredOutput returns the structured output schema for the configured response scorer.
+func (c *templateMessagesConstructor) StructuredOutput(ctx context.Context, actuals, expecteds []*evalset.Invocation,
+	evalMetric *metric.EvalMetric) (*model.StructuredOutput, error) {
+	templateOptions, err := judgeTemplateOptions(evalMetric)
+	if err != nil {
+		return nil, err
+	}
+	return templateresolver.StructuredOutput(templateOptions.ResponseScorerName)
 }
 
 func judgeTemplateOptions(evalMetric *metric.EvalMetric) (*metricllm.JudgeTemplateOptions, error) {

--- a/evaluation/evaluator/llm/operator/messagesconstructor/template/template_test.go
+++ b/evaluation/evaluator/llm/operator/messagesconstructor/template/template_test.go
@@ -17,6 +17,7 @@ import (
 
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/internal/templateresolver"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/messagesconstructor"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion"
 	criterionllm "trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion/llm"
@@ -119,6 +120,47 @@ func TestConstructMessagesRequiresExpectedFinalResponse(t *testing.T) {
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "expected finalResponse is empty")
+}
+
+func TestStructuredOutputResolvesResponseScorerSchema(t *testing.T) {
+	constructor, ok := New().(messagesconstructor.StructuredOutputMessagesConstructor)
+	require.True(t, ok)
+	output, err := constructor.StructuredOutput(context.Background(), nil, nil,
+		buildTemplateEvalMetric("Answer: {{answer}}", nil))
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	require.NotNil(t, output.JSONSchema)
+	assert.Equal(t, "single_score_result", output.JSONSchema.Name)
+	evalMetric := buildTemplateEvalMetric("Answer: {{answer}}", nil)
+	evalMetric.Criterion.LLMJudge.Template.ResponseScorerName = templateresolver.ResponseScorerRubricScoresName
+	output, err = constructor.StructuredOutput(context.Background(), nil, nil, evalMetric)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	require.NotNil(t, output.JSONSchema)
+	assert.Equal(t, "rubric_scores_result", output.JSONSchema.Name)
+}
+
+func TestStructuredOutputRejectsInvalidTemplateOptions(t *testing.T) {
+	constructor := New().(messagesconstructor.StructuredOutputMessagesConstructor)
+	_, err := constructor.StructuredOutput(context.Background(), nil, nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing llm judge criterion")
+	_, err = constructor.StructuredOutput(context.Background(), nil, nil, &metric.EvalMetric{
+		Criterion: &criterion.Criterion{
+			LLMJudge: &criterionllm.LLMCriterion{},
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "template is nil")
+}
+
+func TestStructuredOutputRejectsUnsupportedScorer(t *testing.T) {
+	constructor := New().(messagesconstructor.StructuredOutputMessagesConstructor)
+	evalMetric := buildTemplateEvalMetric("Answer: {{answer}}", nil)
+	evalMetric.Criterion.LLMJudge.Template.ResponseScorerName = "missing"
+	_, err := constructor.StructuredOutput(context.Background(), nil, nil, evalMetric)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unsupported response scorer "missing"`)
 }
 
 func TestConstructMessagesRejectsUnknownPlaceholder(t *testing.T) {

--- a/evaluation/evaluator/llm/operator/responsescorer/rubricscores/rubricscores.go
+++ b/evaluation/evaluator/llm/operator/responsescorer/rubricscores/rubricscores.go
@@ -16,6 +16,7 @@ import (
 
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/internal/rubrics"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/responsescorer"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/responsescorer/internal/responsejson"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
@@ -42,7 +43,7 @@ func New() responsescorer.ResponseScorer {
 
 // ScoreBasedOnResponse parses the structured judge response.
 func (s *rubricScoresResponseScorer) ScoreBasedOnResponse(ctx context.Context, response *model.Response,
-	_ *metric.EvalMetric) (*evaluator.ScoreResult, error) {
+	evalMetric *metric.EvalMetric) (*evaluator.ScoreResult, error) {
 	var payload rubricScoresResponse
 	if err := responsejson.UnmarshalContent(response, &payload); err != nil {
 		return nil, err
@@ -50,14 +51,23 @@ func (s *rubricScoresResponseScorer) ScoreBasedOnResponse(ctx context.Context, r
 	if len(payload.RubricScores) == 0 {
 		return nil, fmt.Errorf("rubricScores is empty")
 	}
+	expectedIDs, err := expectedRubricIDs(evalMetric)
+	if err != nil {
+		return nil, err
+	}
 	result := &evaluator.ScoreResult{
 		RubricScores: make([]*evalresult.RubricScore, 0, len(payload.RubricScores)),
 	}
 	reasons := make([]string, 0, len(payload.RubricScores))
+	seenIDs := make(map[string]struct{}, len(payload.RubricScores))
 	total := 0.0
 	for _, item := range payload.RubricScores {
 		if item.ID == nil || strings.TrimSpace(*item.ID) == "" {
 			return nil, fmt.Errorf("rubric score id is empty")
+		}
+		id := strings.TrimSpace(*item.ID)
+		if err := validateRubricScoreID(id, seenIDs, expectedIDs); err != nil {
+			return nil, err
 		}
 		if item.Score == nil {
 			return nil, fmt.Errorf("rubric score is required")
@@ -69,14 +79,56 @@ func (s *rubricScoresResponseScorer) ScoreBasedOnResponse(ctx context.Context, r
 			return nil, fmt.Errorf("rubric score must be between 0 and 1")
 		}
 		result.RubricScores = append(result.RubricScores, &evalresult.RubricScore{
-			ID:     *item.ID,
+			ID:     id,
 			Score:  *item.Score,
 			Reason: *item.Reason,
 		})
 		total += *item.Score
 		reasons = append(reasons, *item.Reason)
 	}
+	if expectedIDs != nil {
+		if missing := missingRubricScoreID(seenIDs, expectedIDs); missing != "" {
+			return nil, fmt.Errorf("missing rubric score id %q", missing)
+		}
+	}
 	result.Score = total / float64(len(payload.RubricScores))
 	result.Reason = strings.Join(reasons, "\n")
 	return result, nil
+}
+
+func expectedRubricIDs(evalMetric *metric.EvalMetric) (map[string]struct{}, error) {
+	if rubrics.Count(evalMetric) == 0 {
+		return nil, nil
+	}
+	visibleRubrics, err := rubrics.ValidateStructured(evalMetric)
+	if err != nil {
+		return nil, err
+	}
+	expected := make(map[string]struct{}, len(visibleRubrics))
+	for _, rubric := range visibleRubrics {
+		expected[rubric.ID] = struct{}{}
+	}
+	return expected, nil
+}
+
+func validateRubricScoreID(id string, seen, expected map[string]struct{}) error {
+	if _, ok := seen[id]; ok {
+		return fmt.Errorf("duplicate rubric score id %q", id)
+	}
+	if expected != nil {
+		if _, ok := expected[id]; !ok {
+			return fmt.Errorf("unexpected rubric score id %q", id)
+		}
+	}
+	seen[id] = struct{}{}
+	return nil
+}
+
+func missingRubricScoreID(seen, expected map[string]struct{}) string {
+	for id := range expected {
+		if _, ok := seen[id]; !ok {
+			return id
+		}
+	}
+	return ""
 }

--- a/evaluation/evaluator/llm/operator/responsescorer/rubricscores/rubricscores_test.go
+++ b/evaluation/evaluator/llm/operator/responsescorer/rubricscores/rubricscores_test.go
@@ -15,6 +15,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion/llm"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 )
 
@@ -32,6 +35,43 @@ func TestScoreBasedOnResponseParsesRubricScores(t *testing.T) {
 	assert.Equal(t, 0.5, result.Score)
 	assert.Len(t, result.RubricScores, 2)
 	assert.Equal(t, "Correct.\nMissing evidence.", result.Reason)
+}
+
+func TestScoreBasedOnResponseValidatesRubricScoreIDs(t *testing.T) {
+	scorer := New()
+	evalMetric := metricWithRubrics("1", "2")
+	result, err := scorer.ScoreBasedOnResponse(context.Background(), makeResponse(`{
+		"rubricScores":[
+			{"id":"1","score":1,"reason":"Correct."},
+			{"id":"2","score":0,"reason":"Missing evidence."}
+		]
+	}`), evalMetric)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 0.5, result.Score)
+	_, err = scorer.ScoreBasedOnResponse(context.Background(), makeResponse(`{
+		"rubricScores":[
+			{"id":"1","score":1,"reason":"Correct."},
+			{"id":"1","score":0,"reason":"Duplicate."}
+		]
+	}`), evalMetric)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `duplicate rubric score id "1"`)
+	_, err = scorer.ScoreBasedOnResponse(context.Background(), makeResponse(`{
+		"rubricScores":[
+			{"id":"1","score":1,"reason":"Correct."},
+			{"id":"3","score":0,"reason":"Unknown."}
+		]
+	}`), evalMetric)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unexpected rubric score id "3"`)
+	_, err = scorer.ScoreBasedOnResponse(context.Background(), makeResponse(`{
+		"rubricScores":[
+			{"id":"1","score":1,"reason":"Correct."}
+		]
+	}`), evalMetric)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing rubric score id")
 }
 
 func TestScoreBasedOnResponseRejectsInvalidRubricScores(t *testing.T) {
@@ -59,5 +99,20 @@ func TestScoreBasedOnResponseRejectsInvalidRubricScores(t *testing.T) {
 func makeResponse(content string) *model.Response {
 	return &model.Response{
 		Choices: []model.Choice{{Message: model.Message{Content: content}}},
+	}
+}
+
+func metricWithRubrics(ids ...string) *metric.EvalMetric {
+	rubrics := make([]*llm.Rubric, 0, len(ids))
+	for _, id := range ids {
+		rubrics = append(rubrics, &llm.Rubric{
+			ID:      id,
+			Content: &llm.RubricContent{Text: "rubric " + id},
+		})
+	}
+	return &metric.EvalMetric{
+		Criterion: &criterion.Criterion{
+			LLMJudge: &llm.LLMCriterion{Rubrics: rubrics},
+		},
 	}
 }

--- a/evaluation/evaluator/llm/rubriccritic/options.go
+++ b/evaluation/evaluator/llm/rubriccritic/options.go
@@ -14,7 +14,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/messagesconstructor"
 	cmessagesconstructor "trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/messagesconstructor/rubriccritic"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/responsescorer"
-	rresponsescorer "trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/responsescorer/rubricresponse"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/responsescorer/rubricscores"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/samplesaggregator"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/samplesaggregator/majorityvote"
 )
@@ -29,7 +29,7 @@ type options struct {
 func newOptions(opt ...Option) *options {
 	opts := &options{
 		messagesConstructor:   cmessagesconstructor.New(),
-		responsescorer:        rresponsescorer.New(),
+		responsescorer:        rubricscores.New(),
 		samplesAggregator:     majorityvote.New(),
 		invocationsAggregator: average.New(),
 	}

--- a/evaluation/evaluator/llm/rubriccritic/options_test.go
+++ b/evaluation/evaluator/llm/rubriccritic/options_test.go
@@ -18,8 +18,9 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/invocationsaggregator/average"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/messagesconstructor"
 	cmessages "trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/messagesconstructor/rubriccritic"
-	rresponsescorer "trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/responsescorer/rubricresponse"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/responsescorer/rubricscores"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/samplesaggregator/majorityvote"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
 	"trpc.group/trpc-go/trpc-agent-go/model"
@@ -60,7 +61,9 @@ func TestNewOptionsDefaults(t *testing.T) {
 	require.NotNil(t, opts.samplesAggregator)
 	require.NotNil(t, opts.invocationsAggregator)
 	assert.IsType(t, cmessages.New(), opts.messagesConstructor)
-	assert.IsType(t, rresponsescorer.New(), opts.responsescorer)
+	_, ok := opts.messagesConstructor.(messagesconstructor.StructuredOutputMessagesConstructor)
+	assert.True(t, ok)
+	assert.IsType(t, rubricscores.New(), opts.responsescorer)
 	assert.IsType(t, majorityvote.New(), opts.samplesAggregator)
 	assert.IsType(t, average.New(), opts.invocationsAggregator)
 }

--- a/evaluation/evaluator/llm/rubriccritic/rubriccritic.go
+++ b/evaluation/evaluator/llm/rubriccritic/rubriccritic.go
@@ -66,6 +66,16 @@ func (e *rubricCriticEvaluator) ConstructMessages(ctx context.Context, actuals, 
 	return e.messagesConstructor.ConstructMessages(ctx, actuals, expecteds, evalMetric)
 }
 
+// StructuredOutput delegates structured output schema construction to the prompt builder.
+func (e *rubricCriticEvaluator) StructuredOutput(ctx context.Context, actuals, expecteds []*evalset.Invocation,
+	evalMetric *metric.EvalMetric) (*model.StructuredOutput, error) {
+	constructor, ok := e.messagesConstructor.(messagesconstructor.StructuredOutputMessagesConstructor)
+	if !ok {
+		return nil, nil
+	}
+	return constructor.StructuredOutput(ctx, actuals, expecteds, evalMetric)
+}
+
 // ScoreBasedOnResponse scores the response of the evaluator.
 func (e *rubricCriticEvaluator) ScoreBasedOnResponse(ctx context.Context, response *model.Response,
 	evalMetric *metric.EvalMetric) (*evaluator.ScoreResult, error) {

--- a/evaluation/evaluator/llm/rubriccritic/rubriccritic_test.go
+++ b/evaluation/evaluator/llm/rubriccritic/rubriccritic_test.go
@@ -18,6 +18,8 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion"
+	criterionllm "trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion/llm"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/status"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 )
@@ -131,4 +133,44 @@ func TestRubricCriticEvaluatorDelegates(t *testing.T) {
 	assert.Equal(t, "llm_rubric_critic", impl.Name())
 	assert.Equal(t, "LLM rubric critic evaluator", impl.Description())
 	assert.Equal(t, status.EvalStatusPassed, result.OverallStatus)
+}
+
+func TestRubricCriticEvaluatorDefaultsToStructuredOutput(t *testing.T) {
+	ev := New()
+	impl, ok := ev.(*rubricCriticEvaluator)
+	require.True(t, ok)
+	output, err := impl.StructuredOutput(context.Background(), nil, nil, &metric.EvalMetric{
+		Criterion: &criterion.Criterion{
+			LLMJudge: &criterionllm.LLMCriterion{
+				Rubrics: []*criterionllm.Rubric{
+					{
+						ID:      "1",
+						Content: &criterionllm.RubricContent{Text: "The answer is correct."},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	require.NotNil(t, output.JSONSchema)
+	assert.Equal(t, "rubric_critic_scores", output.JSONSchema.Name)
+}
+
+func TestRubricCriticEvaluatorStructuredOutputUsesStrictJSONScorer(t *testing.T) {
+	response := &model.Response{
+		Choices: []model.Choice{{Message: model.Message{Content: `{"debug": true}
+
+ID: 1
+Rubric: alpha
+Evidence: e1
+Reason: r1
+Verdict: yes
+`}}},
+	}
+	defaultImpl, ok := New().(*rubricCriticEvaluator)
+	require.True(t, ok)
+	_, err := defaultImpl.ScoreBasedOnResponse(context.Background(), response, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unmarshal response json")
 }

--- a/evaluation/evaluator/llm/rubricknowledgerecall/options.go
+++ b/evaluation/evaluator/llm/rubricknowledgerecall/options.go
@@ -14,7 +14,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/messagesconstructor"
 	rmessagesconstructor "trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/messagesconstructor/rubricknowledgerecall"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/responsescorer"
-	rresponsescorer "trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/responsescorer/rubricresponse"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/responsescorer/rubricscores"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/samplesaggregator"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/samplesaggregator/majorityvote"
 )
@@ -29,7 +29,7 @@ type options struct {
 func newOptions(opt ...Option) *options {
 	opts := &options{
 		messagesConstructor:   rmessagesconstructor.New(),
-		responsescorer:        rresponsescorer.New(),
+		responsescorer:        rubricscores.New(),
 		samplesAggregator:     majorityvote.New(),
 		invocationsAggregator: average.New(),
 	}

--- a/evaluation/evaluator/llm/rubricknowledgerecall/options_test.go
+++ b/evaluation/evaluator/llm/rubricknowledgerecall/options_test.go
@@ -20,7 +20,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/invocationsaggregator/average"
 	knmessages "trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/messagesconstructor/rubricknowledgerecall"
-	rresponsescorer "trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/responsescorer/rubricresponse"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/responsescorer/rubricscores"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/samplesaggregator/majorityvote"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
 	"trpc.group/trpc-go/trpc-agent-go/model"
@@ -63,7 +63,7 @@ func TestNewOptionsDefaults(t *testing.T) {
 	require.NotNil(t, opts.invocationsAggregator)
 
 	assert.IsType(t, knmessages.New(), opts.messagesConstructor)
-	assert.IsType(t, rresponsescorer.New(), opts.responsescorer)
+	assert.IsType(t, rubricscores.New(), opts.responsescorer)
 	assert.IsType(t, majorityvote.New(), opts.samplesAggregator)
 	assert.IsType(t, average.New(), opts.invocationsAggregator)
 }

--- a/evaluation/evaluator/llm/rubricknowledgerecall/options_test.go
+++ b/evaluation/evaluator/llm/rubricknowledgerecall/options_test.go
@@ -19,6 +19,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/invocationsaggregator/average"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/messagesconstructor"
 	knmessages "trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/messagesconstructor/rubricknowledgerecall"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/responsescorer/rubricscores"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/samplesaggregator/majorityvote"
@@ -63,6 +64,8 @@ func TestNewOptionsDefaults(t *testing.T) {
 	require.NotNil(t, opts.invocationsAggregator)
 
 	assert.IsType(t, knmessages.New(), opts.messagesConstructor)
+	_, ok := opts.messagesConstructor.(messagesconstructor.StructuredOutputMessagesConstructor)
+	assert.True(t, ok)
 	assert.IsType(t, rubricscores.New(), opts.responsescorer)
 	assert.IsType(t, majorityvote.New(), opts.samplesAggregator)
 	assert.IsType(t, average.New(), opts.invocationsAggregator)

--- a/evaluation/evaluator/llm/rubricknowledgerecall/rubricknowledgerecall.go
+++ b/evaluation/evaluator/llm/rubricknowledgerecall/rubricknowledgerecall.go
@@ -66,6 +66,16 @@ func (e *rubricKnowledgeRecallEvaluator) ConstructMessages(ctx context.Context, 
 	return e.messagesConstructor.ConstructMessages(ctx, actuals, expecteds, evalMetric)
 }
 
+// StructuredOutput delegates structured output schema construction to the prompt builder.
+func (e *rubricKnowledgeRecallEvaluator) StructuredOutput(ctx context.Context, actuals,
+	expecteds []*evalset.Invocation, evalMetric *metric.EvalMetric) (*model.StructuredOutput, error) {
+	constructor, ok := e.messagesConstructor.(messagesconstructor.StructuredOutputMessagesConstructor)
+	if !ok {
+		return nil, nil
+	}
+	return constructor.StructuredOutput(ctx, actuals, expecteds, evalMetric)
+}
+
 // ScoreBasedOnResponse scores the response of the evaluator.
 func (e *rubricKnowledgeRecallEvaluator) ScoreBasedOnResponse(ctx context.Context, response *model.Response,
 	evalMetric *metric.EvalMetric) (*evaluator.ScoreResult, error) {

--- a/evaluation/evaluator/llm/rubricknowledgerecall/rubricknowledgerecall_test.go
+++ b/evaluation/evaluator/llm/rubricknowledgerecall/rubricknowledgerecall_test.go
@@ -19,6 +19,8 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion"
+	criterionllm "trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion/llm"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/status"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 )
@@ -136,4 +138,44 @@ func TestRubricKnowledgeRecallEvaluatorDelegates(t *testing.T) {
 	assert.Equal(t, "llm_rubric_knowledge_recall", impl.Name())
 	assert.Equal(t, "LLM rubric knowledge recall evaluator", impl.Description())
 	assert.Equal(t, status.EvalStatusPassed, result.OverallStatus)
+}
+
+func TestRubricKnowledgeRecallEvaluatorDefaultsToStructuredOutput(t *testing.T) {
+	ev := New()
+	impl, ok := ev.(*rubricKnowledgeRecallEvaluator)
+	require.True(t, ok)
+	output, err := impl.StructuredOutput(context.Background(), nil, nil, &metric.EvalMetric{
+		Criterion: &criterion.Criterion{
+			LLMJudge: &criterionllm.LLMCriterion{
+				Rubrics: []*criterionllm.Rubric{
+					{
+						ID:      "1",
+						Content: &criterionllm.RubricContent{Text: "The answer is supported."},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	require.NotNil(t, output.JSONSchema)
+	assert.Equal(t, "rubric_knowledge_recall_scores", output.JSONSchema.Name)
+}
+
+func TestRubricKnowledgeRecallEvaluatorStructuredOutputUsesStrictJSONScorer(t *testing.T) {
+	response := &model.Response{
+		Choices: []model.Choice{{Message: model.Message{Content: `{"debug": true}
+
+ID: 1
+Rubric: alpha
+Evidence: e1
+Reason: r1
+Verdict: yes
+`}}},
+	}
+	defaultImpl, ok := New().(*rubricKnowledgeRecallEvaluator)
+	require.True(t, ok)
+	_, err := defaultImpl.ScoreBasedOnResponse(context.Background(), response, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unmarshal response json")
 }

--- a/evaluation/evaluator/llm/rubricreferencecritic/options.go
+++ b/evaluation/evaluator/llm/rubricreferencecritic/options.go
@@ -14,7 +14,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/messagesconstructor"
 	rmessagesconstructor "trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/messagesconstructor/rubricreferencecritic"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/responsescorer"
-	rresponsescorer "trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/responsescorer/rubricresponse"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/responsescorer/rubricscores"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/samplesaggregator"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/samplesaggregator/majorityvote"
 )
@@ -29,7 +29,7 @@ type options struct {
 func newOptions(opt ...Option) *options {
 	opts := &options{
 		messagesConstructor:   rmessagesconstructor.New(),
-		responsescorer:        rresponsescorer.New(),
+		responsescorer:        rubricscores.New(),
 		samplesAggregator:     majorityvote.New(),
 		invocationsAggregator: average.New(),
 	}

--- a/evaluation/evaluator/llm/rubricreferencecritic/rubricreferencecritic.go
+++ b/evaluation/evaluator/llm/rubricreferencecritic/rubricreferencecritic.go
@@ -70,6 +70,16 @@ func (e *rubricReferenceCriticEvaluator) ConstructMessages(ctx context.Context, 
 	return e.messagesConstructor.ConstructMessages(ctx, actuals, expecteds, evalMetric)
 }
 
+// StructuredOutput delegates structured output schema construction to the prompt builder.
+func (e *rubricReferenceCriticEvaluator) StructuredOutput(ctx context.Context, actuals,
+	expecteds []*evalset.Invocation, evalMetric *metric.EvalMetric) (*model.StructuredOutput, error) {
+	constructor, ok := e.messagesConstructor.(messagesconstructor.StructuredOutputMessagesConstructor)
+	if !ok {
+		return nil, nil
+	}
+	return constructor.StructuredOutput(ctx, actuals, expecteds, evalMetric)
+}
+
 // ScoreBasedOnResponse scores the response of the evaluator.
 func (e *rubricReferenceCriticEvaluator) ScoreBasedOnResponse(ctx context.Context, response *model.Response,
 	evalMetric *metric.EvalMetric) (*evaluator.ScoreResult, error) {

--- a/evaluation/evaluator/llm/rubricreferencecritic/rubricreferencecritic_test.go
+++ b/evaluation/evaluator/llm/rubricreferencecritic/rubricreferencecritic_test.go
@@ -18,6 +18,8 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion"
+	criterionllm "trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion/llm"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/status"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 )
@@ -131,4 +133,44 @@ func TestRubricReferenceCriticEvaluatorDelegates(t *testing.T) {
 	assert.Equal(t, evaluatorName, impl.Name())
 	assert.Equal(t, "LLM rubric critic evaluator against reference answers", impl.Description())
 	assert.Equal(t, status.EvalStatusPassed, result.OverallStatus)
+}
+
+func TestRubricReferenceCriticEvaluatorDefaultsToStructuredOutput(t *testing.T) {
+	ev := New()
+	impl, ok := ev.(*rubricReferenceCriticEvaluator)
+	require.True(t, ok)
+	output, err := impl.StructuredOutput(context.Background(), nil, nil, &metric.EvalMetric{
+		Criterion: &criterion.Criterion{
+			LLMJudge: &criterionllm.LLMCriterion{
+				Rubrics: []*criterionllm.Rubric{
+					{
+						ID:      "1",
+						Content: &criterionllm.RubricContent{Text: "The answer matches the reference."},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	require.NotNil(t, output.JSONSchema)
+	assert.Equal(t, "rubric_reference_critic_scores", output.JSONSchema.Name)
+}
+
+func TestRubricReferenceCriticEvaluatorStructuredOutputUsesStrictJSONScorer(t *testing.T) {
+	response := &model.Response{
+		Choices: []model.Choice{{Message: model.Message{Content: `{"debug": true}
+
+ID: 1
+Rubric: alpha
+Evidence: e1
+Reason: r1
+Verdict: yes
+`}}},
+	}
+	defaultImpl, ok := New().(*rubricReferenceCriticEvaluator)
+	require.True(t, ok)
+	_, err := defaultImpl.ScoreBasedOnResponse(context.Background(), response, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unmarshal response json")
 }

--- a/evaluation/evaluator/llm/rubricresponse/options.go
+++ b/evaluation/evaluator/llm/rubricresponse/options.go
@@ -15,7 +15,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/messagesconstructor"
 	rmessagesconstructor "trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/messagesconstructor/rubricresponse"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/responsescorer"
-	rresponsescorer "trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/responsescorer/rubricresponse"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/responsescorer/rubricscores"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/samplesaggregator"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/samplesaggregator/majorityvote"
 )
@@ -30,7 +30,7 @@ type options struct {
 func newOptions(opt ...Option) *options {
 	opts := &options{
 		messagesConstructor:   rmessagesconstructor.New(),
-		responsescorer:        rresponsescorer.New(),
+		responsescorer:        rubricscores.New(),
 		samplesAggregator:     majorityvote.New(),
 		invocationsAggregator: average.New(),
 	}

--- a/evaluation/evaluator/llm/rubricresponse/options_test.go
+++ b/evaluation/evaluator/llm/rubricresponse/options_test.go
@@ -20,7 +20,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/invocationsaggregator/average"
 	rmessagesconstructor "trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/messagesconstructor/rubricresponse"
-	rresponsescorer "trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/responsescorer/rubricresponse"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/responsescorer/rubricscores"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/samplesaggregator/majorityvote"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
 	"trpc.group/trpc-go/trpc-agent-go/model"
@@ -63,7 +63,7 @@ func TestNewOptionsDefaults(t *testing.T) {
 	require.NotNil(t, opts.invocationsAggregator)
 
 	assert.IsType(t, rmessagesconstructor.New(), opts.messagesConstructor)
-	assert.IsType(t, rresponsescorer.New(), opts.responsescorer)
+	assert.IsType(t, rubricscores.New(), opts.responsescorer)
 	assert.IsType(t, majorityvote.New(), opts.samplesAggregator)
 	assert.IsType(t, average.New(), opts.invocationsAggregator)
 }

--- a/evaluation/evaluator/llm/rubricresponse/options_test.go
+++ b/evaluation/evaluator/llm/rubricresponse/options_test.go
@@ -19,6 +19,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/invocationsaggregator/average"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/messagesconstructor"
 	rmessagesconstructor "trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/messagesconstructor/rubricresponse"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/responsescorer/rubricscores"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/samplesaggregator/majorityvote"
@@ -63,6 +64,8 @@ func TestNewOptionsDefaults(t *testing.T) {
 	require.NotNil(t, opts.invocationsAggregator)
 
 	assert.IsType(t, rmessagesconstructor.New(), opts.messagesConstructor)
+	_, ok := opts.messagesConstructor.(messagesconstructor.StructuredOutputMessagesConstructor)
+	assert.True(t, ok)
 	assert.IsType(t, rubricscores.New(), opts.responsescorer)
 	assert.IsType(t, majorityvote.New(), opts.samplesAggregator)
 	assert.IsType(t, average.New(), opts.invocationsAggregator)

--- a/evaluation/evaluator/llm/rubricresponse/rubricresponse.go
+++ b/evaluation/evaluator/llm/rubricresponse/rubricresponse.go
@@ -67,6 +67,16 @@ func (e *rubricResponseEvaluator) ConstructMessages(ctx context.Context, actuals
 	return e.messagesConstructor.ConstructMessages(ctx, actuals, expecteds, evalMetric)
 }
 
+// StructuredOutput delegates structured output schema construction to the prompt builder.
+func (e *rubricResponseEvaluator) StructuredOutput(ctx context.Context, actuals, expecteds []*evalset.Invocation,
+	evalMetric *metric.EvalMetric) (*model.StructuredOutput, error) {
+	constructor, ok := e.messagesConstructor.(messagesconstructor.StructuredOutputMessagesConstructor)
+	if !ok {
+		return nil, nil
+	}
+	return constructor.StructuredOutput(ctx, actuals, expecteds, evalMetric)
+}
+
 // ScoreBasedOnResponse scores the response of the evaluator.
 func (e *rubricResponseEvaluator) ScoreBasedOnResponse(ctx context.Context, response *model.Response,
 	evalMetric *metric.EvalMetric) (*evaluator.ScoreResult, error) {

--- a/evaluation/evaluator/llm/rubricresponse/rubricresponse_test.go
+++ b/evaluation/evaluator/llm/rubricresponse/rubricresponse_test.go
@@ -19,6 +19,8 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion"
+	criterionllm "trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion/llm"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/status"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 )
@@ -136,4 +138,44 @@ func TestRubricResponseEvaluatorDelegates(t *testing.T) {
 	assert.Equal(t, "llm_rubric_response", impl.Name())
 	assert.Equal(t, "LLM rubric response evaluator", impl.Description())
 	assert.Equal(t, status.EvalStatusPassed, result.OverallStatus)
+}
+
+func TestRubricResponseEvaluatorDefaultsToStructuredOutput(t *testing.T) {
+	ev := New()
+	impl, ok := ev.(*rubricResponseEvaluator)
+	require.True(t, ok)
+	output, err := impl.StructuredOutput(context.Background(), nil, nil, &metric.EvalMetric{
+		Criterion: &criterion.Criterion{
+			LLMJudge: &criterionllm.LLMCriterion{
+				Rubrics: []*criterionllm.Rubric{
+					{
+						ID:      "1",
+						Content: &criterionllm.RubricContent{Text: "The answer is correct."},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	require.NotNil(t, output.JSONSchema)
+	assert.Equal(t, "rubric_response_scores", output.JSONSchema.Name)
+}
+
+func TestRubricResponseEvaluatorStructuredOutputUsesStrictJSONScorer(t *testing.T) {
+	response := &model.Response{
+		Choices: []model.Choice{{Message: model.Message{Content: `{"debug": true}
+
+ID: 1
+Rubric: alpha
+Evidence: e1
+Reason: r1
+Verdict: yes
+`}}},
+	}
+	defaultImpl, ok := New().(*rubricResponseEvaluator)
+	require.True(t, ok)
+	_, err := defaultImpl.ScoreBasedOnResponse(context.Background(), response, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unmarshal response json")
 }

--- a/evaluation/evaluator/llm/template/template.go
+++ b/evaluation/evaluator/llm/template/template.go
@@ -63,6 +63,16 @@ func (e *templateEvaluator) ConstructMessages(ctx context.Context, actuals, expe
 	return e.messagesConstructor.ConstructMessages(ctx, actuals, expecteds, evalMetric)
 }
 
+// StructuredOutput delegates structured output schema construction to the prompt builder.
+func (e *templateEvaluator) StructuredOutput(ctx context.Context, actuals, expecteds []*evalset.Invocation,
+	evalMetric *metric.EvalMetric) (*model.StructuredOutput, error) {
+	constructor, ok := e.messagesConstructor.(messagesconstructor.StructuredOutputMessagesConstructor)
+	if !ok {
+		return nil, nil
+	}
+	return constructor.StructuredOutput(ctx, actuals, expecteds, evalMetric)
+}
+
 // ScoreBasedOnResponse scores the judge response with the configured scorer.
 func (e *templateEvaluator) ScoreBasedOnResponse(ctx context.Context, response *model.Response,
 	evalMetric *metric.EvalMetric) (*evaluator.ScoreResult, error) {


### PR DESCRIPTION
Adds structured output support for built-in rubric-based LLM evaluators, shares rubric schema validation and score output construction, defaults rubric evaluators to rubricScores parsing, and updates evaluation docs to describe the structured rubric output flow.