### PR TITLE
{server/agui, docs}: add distributed cancel

### DIFF
--- a/docs/mkdocs/en/agui/cancel.md
+++ b/docs/mkdocs/en/agui/cancel.md
@@ -6,7 +6,7 @@ The cancel route actively stops a backend task that is currently running in the 
 
 When canceling, the framework uses `AppName`, `UserID`, and `threadId` to form the same `SessionKey`, then cancels the backend task running under that session. Therefore, the cancel request must resolve to the same `AppName`, `UserID`, and `threadId` as the real-time conversation request.
 
-In multi-instance deployments, the cancel request must hit the same instance that started the real-time conversation request. Running tasks are only kept locally in the instance. Sharing `SessionService` alone does not let other instances cancel the task. If the request hits another instance, it usually returns `404 Not Found`.
+By default, in multi-instance deployments, the cancel request must hit the same instance that started the real-time conversation request. Running tasks are only kept locally in the instance. If the request hits another instance, it usually returns `404 Not Found`.
 
 The cancel route is commonly used when:
 
@@ -56,7 +56,31 @@ curl -X POST http://localhost:8080/cancel \
 
 Typical responses:
 
-- `200 OK`: cancellation succeeded.
+- `200 OK`: local cancellation has been triggered, or a remote cancel signal has been delivered when distributed cancel is enabled.
 - `404 Not Found`: no running task was found for the corresponding `SessionKey`, usually because it has already finished or identifiers do not match.
 
-After cancellation succeeds, the framework still performs the required run finalization, fills in protocol closing events, and tries to write the aggregation cache to `SessionService`. Therefore, when history is later read through `/history`, the result is a valid and consistent state after cancellation rather than an unfinished intermediate state. For finalization and timeout configuration, see [Session Storage and Event Aggregation](history.md#session-storage-and-event-aggregation).
+After cancellation succeeds, the framework still performs the required run finalization, fills in protocol closing events, and tries to write the aggregation cache to `SessionService`. A successful cancel response does not mean the same `SessionKey` can immediately start a new real-time conversation request. If you need to start the next run, wait for the original real-time conversation stream to return a terminal event. Therefore, when history is later read through `/history`, the result is a valid and consistent state after cancellation rather than an unfinished intermediate state. For finalization and timeout configuration, see [Session Storage and Event Aggregation](history.md#session-storage-and-event-aggregation).
+
+## Multi-Instance Distributed Cancel
+
+If a multi-instance deployment cannot guarantee that the real-time conversation request and cancel request for the same `SessionKey` hit the same instance, enable distributed cancel:
+
+```go
+import "trpc.group/trpc-go/trpc-agent-go/server/agui"
+
+server, err := agui.New(
+    runner,
+    agui.WithSessionService(sessionService),
+    agui.WithCancelEnabled(true),
+    agui.WithDistributedCancelEnabled(true),
+    agui.WithDistributedCancelPollInterval(time.Second),
+)
+```
+
+After this is enabled, AG-UI instances that participate in the same request group need to use the same shared `SessionService`. When a cancel request hits an instance that does not hold the local run, the framework delivers a cancel signal through the shared `SessionService`, and the instance that holds the run triggers local cancellation.
+
+Distributed cancel still locates running tasks by the `SessionKey` formed from `AppName`, `UserID`, and `threadId`. A successful remote cancel response only means the cancel signal has been delivered. It does not mean the instance that holds the run has finished cancellation. If you need to start the next run, wait for the original real-time conversation stream to return a terminal event.
+
+Distributed cancel depends on the shared `SessionService` to deliver cancel signals. If reading from or writing to the shared `SessionService` fails, cross-instance cancellation may not take effect or may return an error.
+
+The instance that holds the run checks for cancel signals at the polling interval. The default interval is `1s`, and it can be changed with `agui.WithDistributedCancelPollInterval(d)`. A shorter interval usually reduces remote cancellation latency, but increases the number of reads to `SessionService`.

--- a/docs/mkdocs/zh/agui/cancel.md
+++ b/docs/mkdocs/zh/agui/cancel.md
@@ -6,7 +6,7 @@
 
 取消时，框架会使用 `AppName`、`UserID` 和 `threadId` 组成同一个 `SessionKey`，并取消该会话下正在运行的后端任务。因此，取消请求需要与实时对话请求解析出一致的 `AppName`、`UserID` 和 `threadId`。
 
-多实例部署时，取消请求需要打到启动该实时对话请求的同一个实例。正在运行的任务只保存在实例本地，单独共享 `SessionService` 不能让其他实例取消该任务；如果请求打到其他实例，通常会返回 `404 Not Found`。
+默认情况下，多实例部署时，取消请求需要打到启动该实时对话请求的同一个实例。正在运行的任务只保存在实例本地；如果请求打到其他实例，通常会返回 `404 Not Found`。
 
 取消路由通常用于：
 
@@ -56,7 +56,31 @@ curl -X POST http://localhost:8080/cancel \
 
 典型返回：
 
-- `200 OK`：取消成功
+- `200 OK`：已触发本机取消，或在开启分布式取消时已投递远程取消信号
 - `404 Not Found`：没有找到对应 `SessionKey` 的运行中任务（可能已结束，或标识不匹配）
 
-取消成功后，框架仍会执行必要的运行结束收尾，补齐协议结束事件，并将聚合缓存尽量写入 `SessionService`。因此，后续通过 `/history` 读取历史时，拿到的是取消后的合法一致状态，而不是一段未收尾的中间状态。收尾流程和超时配置可参考 [Session 存储与事件聚合](history.md#session-存储与事件聚合)。
+取消成功后，框架仍会执行必要的运行结束收尾，补齐协议结束事件，并将聚合缓存尽量写入 `SessionService`。取消请求返回成功不表示同一个 `SessionKey` 已经可以立即发起新的实时对话请求；如果需要继续发起下一次运行，应等待原实时对话流返回终态事件。因此，后续通过 `/history` 读取历史时，拿到的是取消后的合法一致状态，而不是一段未收尾的中间状态。收尾流程和超时配置可参考 [Session 存储与事件聚合](history.md#session-存储与事件聚合)。
+
+## 多实例分布式取消
+
+如果多实例部署中无法保证同一个 `SessionKey` 的实时对话请求和取消请求落到同一个实例，可以开启分布式取消：
+
+```go
+import "trpc.group/trpc-go/trpc-agent-go/server/agui"
+
+server, err := agui.New(
+    runner,
+    agui.WithSessionService(sessionService),
+    agui.WithCancelEnabled(true),
+    agui.WithDistributedCancelEnabled(true),
+    agui.WithDistributedCancelPollInterval(time.Second),
+)
+```
+
+开启后，参与同一组请求的 AG-UI 实例需要配置同一个共享 `SessionService`。取消请求命中未持有该本地运行的实例时，框架会通过共享 `SessionService` 投递取消信号，由持有该运行的实例触发本机取消。
+
+分布式取消仍按 `AppName`、`UserID` 和 `threadId` 组成的 `SessionKey` 定位运行任务。远程取消返回成功只表示取消信号已投递，不表示持有该运行的实例已经完成取消；如果需要继续发起下一次运行，应等待原实时对话流返回终态事件。
+
+分布式取消依赖共享 `SessionService` 传递取消信号；如果共享 `SessionService` 读写失败，跨实例取消可能无法生效或返回错误。
+
+持有运行的实例会按轮询间隔检查取消信号，默认间隔为 `1s`，可通过 `agui.WithDistributedCancelPollInterval(d)` 调整。较短的间隔通常能降低远程取消延迟，但会增加对 `SessionService` 的读取次数。

--- a/server/agui/agui.go
+++ b/server/agui/agui.go
@@ -59,6 +59,9 @@ func newService(runner runner.Runner, opts *options) (service.Service, error) {
 	if opts.serviceFactory == nil {
 		return nil, errors.New("agui: serviceFactory must not be nil")
 	}
+	if opts.distributedCancelEnabled && opts.sessionService == nil {
+		return nil, errors.New("agui: session service is required when distributed cancel is enabled")
+	}
 	aguiRunner := aguirunner.New(runner, opts.aguiRunnerOptions...)
 	chatPath, err := joinURLPath(opts.basePath, opts.path)
 	if err != nil {

--- a/server/agui/agui_test.go
+++ b/server/agui/agui_test.go
@@ -167,6 +167,14 @@ func TestNewMessagesSnapshotRequiresSessionService(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestNewDistributedCancelRequiresSessionService(t *testing.T) {
+	agent := &mockAgent{info: agent.Info{Name: "demo"}}
+	r := runner.NewRunner(agent.Info().Name, agent)
+	srv, err := New(r, WithDistributedCancelEnabled(true))
+	assert.Nil(t, srv)
+	assert.EqualError(t, err, "new service: agui: session service is required when distributed cancel is enabled")
+}
+
 func TestNewServiceRequiresServiceFactory(t *testing.T) {
 	opts := &options{serviceFactory: nil}
 	svc, err := newService(runner.NewRunner("demo", &mockAgent{info: agent.Info{Name: "demo"}}), opts)

--- a/server/agui/options.go
+++ b/server/agui/options.go
@@ -30,17 +30,18 @@ var (
 
 // options holds the options for the AG-UI server.
 type options struct {
-	basePath                string
-	path                    string
-	serviceFactory          ServiceFactory
-	aguiRunnerOptions       []aguirunner.Option
-	messagesSnapshotPath    string
-	messagesSnapshotEnabled bool
-	cancelPath              string
-	cancelEnabled           bool
-	heartbeatInterval       time.Duration
-	appName                 string
-	sessionService          session.Service
+	basePath                 string
+	path                     string
+	serviceFactory           ServiceFactory
+	aguiRunnerOptions        []aguirunner.Option
+	messagesSnapshotPath     string
+	messagesSnapshotEnabled  bool
+	cancelPath               string
+	cancelEnabled            bool
+	distributedCancelEnabled bool
+	heartbeatInterval        time.Duration
+	appName                  string
+	sessionService           session.Service
 }
 
 // newOptions creates a new options instance.
@@ -95,6 +96,21 @@ func WithCancelEnabled(e bool) Option {
 func WithCancelOnContextDoneEnabled(enabled bool) Option {
 	return func(o *options) {
 		o.aguiRunnerOptions = append(o.aguiRunnerOptions, aguirunner.WithCancelOnContextDoneEnabled(enabled))
+	}
+}
+
+// WithDistributedCancelEnabled enables best-effort multi-instance cancel signaling through SessionState.
+func WithDistributedCancelEnabled(enabled bool) Option {
+	return func(o *options) {
+		o.distributedCancelEnabled = enabled
+		o.aguiRunnerOptions = append(o.aguiRunnerOptions, aguirunner.WithDistributedCancelEnabled(enabled))
+	}
+}
+
+// WithDistributedCancelPollInterval sets how often owner runs poll cancel markers.
+func WithDistributedCancelPollInterval(d time.Duration) Option {
+	return func(o *options) {
+		o.aguiRunnerOptions = append(o.aguiRunnerOptions, aguirunner.WithDistributedCancelPollInterval(d))
 	}
 }
 

--- a/server/agui/options_test.go
+++ b/server/agui/options_test.go
@@ -176,6 +176,18 @@ func TestWithCancelOnContextDoneEnabled(t *testing.T) {
 	assert.True(t, ro.CancelOnContextDoneEnabled)
 }
 
+func TestWithDistributedCancelEnabled(t *testing.T) {
+	opts := newOptions(WithDistributedCancelEnabled(true))
+	ro := aguirunner.NewOptions(opts.aguiRunnerOptions...)
+	assert.True(t, ro.DistributedCancelEnabled)
+}
+
+func TestWithDistributedCancelPollInterval(t *testing.T) {
+	opts := newOptions(WithDistributedCancelPollInterval(2 * time.Second))
+	ro := aguirunner.NewOptions(opts.aguiRunnerOptions...)
+	assert.Equal(t, 2*time.Second, ro.DistributedCancelPollInterval)
+}
+
 func TestWithAppNameResolver(t *testing.T) {
 	called := false
 	resolver := func(ctx context.Context, input *adapter.RunAgentInput) (string, error) {

--- a/server/agui/runner/cancel.go
+++ b/server/agui/runner/cancel.go
@@ -11,12 +11,24 @@ package runner
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
+	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 )
+
+const (
+	distributedCancelRunMarkerKey    = session.StateTempPrefix + "agui:distributed_cancel:run"
+	distributedCancelCancelMarkerKey = session.StateTempPrefix + "agui:distributed_cancel:cancel"
+)
+
+type distributedCancelMarker struct {
+	UpdatedAt string `json:"updatedAt"`
+}
 
 // Canceler cancels a running run identified by the request payload.
 type Canceler interface {
@@ -53,9 +65,198 @@ func (r *runner) Cancel(ctx context.Context, runAgentInput *adapter.RunAgentInpu
 	entry, ok := r.running[key]
 	if !ok {
 		r.runningMu.Unlock()
-		return fmt.Errorf("%w: session: %v", ErrRunNotFound, key)
+		if !r.distributedCancelEnabled {
+			return fmt.Errorf("%w: session: %v", ErrRunNotFound, key)
+		}
+		return r.cancelDistributed(ctx, key)
 	}
 	entry.cancel(errExplicitCancel)
 	r.runningMu.Unlock()
 	return nil
+}
+
+func (r *runner) startDistributedCancel(
+	ctx context.Context,
+	key session.Key,
+	cancel context.CancelCauseFunc,
+) (context.CancelFunc, error) {
+	sessionService := r.sessionService
+	if sessionService == nil {
+		return nil, errors.New("agui: session service is required when distributed cancel is enabled")
+	}
+	if err := writeDistributedRunMarker(ctx, sessionService, key); err != nil {
+		return nil, err
+	}
+	watchCtx, stop := context.WithCancel(context.Background())
+	go r.watchDistributedCancel(watchCtx, sessionService, key, cancel)
+	return stop, nil
+}
+
+func (r *runner) finishDistributedCancel(ctx context.Context, key session.Key) {
+	started, stop := r.distributedCancelSnapshot(key)
+	if stop != nil {
+		stop()
+	}
+	if !started {
+		return
+	}
+	sessionService := r.sessionService
+	if sessionService == nil {
+		return
+	}
+	cleanupCtx := context.WithoutCancel(ctx)
+	if r.postRunFinalizationTimeout > 0 {
+		var cancel context.CancelFunc
+		cleanupCtx, cancel = context.WithTimeout(cleanupCtx, r.postRunFinalizationTimeout)
+		defer cancel()
+	}
+	if err := clearDistributedCancelMarkers(cleanupCtx, sessionService, key); err != nil {
+		log.WarnfContext(cleanupCtx, "agui distributed cancel cleanup: session: %v, err: %v", key, err)
+	}
+}
+
+func (r *runner) watchDistributedCancel(
+	ctx context.Context,
+	sessionService session.Service,
+	key session.Key,
+	cancel context.CancelCauseFunc,
+) {
+	interval := r.distributedCancelPollInterval
+	if interval <= 0 {
+		interval = defaultDistributedCancelPollInterval
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			requested, err := readDistributedCancelMarker(ctx, sessionService, key)
+			if err != nil {
+				log.WarnfContext(ctx, "agui distributed cancel poll: session: %v, err: %v", key, err)
+				continue
+			}
+			if requested {
+				cancel(errExplicitCancel)
+				return
+			}
+		}
+	}
+}
+
+func writeDistributedRunMarker(
+	ctx context.Context,
+	service session.Service,
+	key session.Key,
+) error {
+	raw, err := marshalDistributedCancelMarker()
+	if err != nil {
+		return fmt.Errorf("marshal run marker: %w", err)
+	}
+	state := session.StateMap{
+		distributedCancelRunMarkerKey:    raw,
+		distributedCancelCancelMarkerKey: nil,
+	}
+	sess, err := service.GetSession(ctx, key)
+	if err != nil {
+		return fmt.Errorf("get session: %w", err)
+	}
+	if sess == nil {
+		if _, err = service.CreateSession(ctx, key, state); err == nil {
+			return nil
+		}
+		sess, getErr := service.GetSession(ctx, key)
+		if getErr != nil {
+			return fmt.Errorf("create session: %v; get session: %w", err, getErr)
+		}
+		if sess == nil {
+			return fmt.Errorf("create session: %w", err)
+		}
+	}
+	return service.UpdateSessionState(ctx, key, state)
+}
+
+func writeDistributedCancelMarker(
+	ctx context.Context,
+	service session.Service,
+	key session.Key,
+) error {
+	raw, err := marshalDistributedCancelMarker()
+	if err != nil {
+		return fmt.Errorf("marshal cancel marker: %w", err)
+	}
+	return service.UpdateSessionState(ctx, key, session.StateMap{
+		distributedCancelCancelMarkerKey: raw,
+	})
+}
+
+func marshalDistributedCancelMarker() ([]byte, error) {
+	return json.Marshal(distributedCancelMarker{
+		UpdatedAt: time.Now().UTC().Format(time.RFC3339Nano),
+	})
+}
+
+func clearDistributedCancelMarkers(
+	ctx context.Context,
+	service session.Service,
+	key session.Key,
+) error {
+	return service.UpdateSessionState(ctx, key, session.StateMap{
+		distributedCancelRunMarkerKey:    nil,
+		distributedCancelCancelMarkerKey: nil,
+	})
+}
+
+func readDistributedCancelMarker(
+	ctx context.Context,
+	service session.Service,
+	key session.Key,
+) (bool, error) {
+	sess, err := service.GetSession(ctx, key)
+	if err != nil {
+		return false, fmt.Errorf("get session: %w", err)
+	}
+	if sess == nil {
+		return false, nil
+	}
+	raw, ok := sess.GetState(distributedCancelCancelMarkerKey)
+	return ok && len(raw) > 0, nil
+}
+
+func (r *runner) cancelDistributed(ctx context.Context, key session.Key) error {
+	sessionService := r.sessionService
+	if sessionService == nil {
+		return errors.New("agui: session service is required when distributed cancel is enabled")
+	}
+	active, err := activeDistributedRun(ctx, sessionService, key)
+	if err != nil {
+		return err
+	}
+	if !active {
+		return fmt.Errorf("%w: session: %v", ErrRunNotFound, key)
+	}
+	if err := writeDistributedCancelMarker(ctx, sessionService, key); err != nil {
+		return fmt.Errorf("write cancel marker: %w", err)
+	}
+	return nil
+}
+
+func activeDistributedRun(
+	ctx context.Context,
+	service session.Service,
+	key session.Key,
+) (bool, error) {
+	sess, err := service.GetSession(ctx, key)
+	if err != nil {
+		return false, fmt.Errorf("get session: %w", err)
+	}
+	if sess == nil {
+		return false, nil
+	}
+	raw, ok := sess.GetState(distributedCancelRunMarkerKey)
+	if !ok || len(raw) == 0 {
+		return false, nil
+	}
+	return true, nil
 }

--- a/server/agui/runner/cancel_test.go
+++ b/server/agui/runner/cancel_test.go
@@ -56,6 +56,63 @@ func (s *updateFailSessionService) UpdateSessionState(context.Context, session.K
 	return s.err
 }
 
+type distributedCancelSessionServiceStub struct {
+	session.Service
+	getSessions []*session.Session
+	getErrs     []error
+	createErr   error
+	updateErr   error
+	getCalls    int
+}
+
+func (s *distributedCancelSessionServiceStub) GetSession(context.Context, session.Key,
+	...session.Option) (*session.Session, error) {
+	call := s.getCalls
+	s.getCalls++
+	if call < len(s.getErrs) && s.getErrs[call] != nil {
+		return nil, s.getErrs[call]
+	}
+	if call < len(s.getSessions) {
+		return s.getSessions[call], nil
+	}
+	return nil, nil
+}
+
+func (s *distributedCancelSessionServiceStub) CreateSession(
+	_ context.Context,
+	key session.Key,
+	state session.StateMap,
+	_ ...session.Option,
+) (*session.Session, error) {
+	if s.createErr != nil {
+		return nil, s.createErr
+	}
+	return session.NewSession(key.AppName, key.UserID, key.SessionID, session.WithSessionState(state)), nil
+}
+
+func (s *distributedCancelSessionServiceStub) UpdateSessionState(
+	context.Context,
+	session.Key,
+	session.StateMap,
+) error {
+	return s.updateErr
+}
+
+type distributedCancelGetErrorSessionService struct {
+	session.Service
+	err   error
+	calls chan struct{}
+}
+
+func (s *distributedCancelGetErrorSessionService) GetSession(context.Context, session.Key,
+	...session.Option) (*session.Session, error) {
+	select {
+	case s.calls <- struct{}{}:
+	default:
+	}
+	return nil, s.err
+}
+
 type blockingRunRunner struct {
 	entered chan struct{}
 	unblock chan struct{}
@@ -300,6 +357,112 @@ func TestDistributedCancelRunMarkerFailureIsFailOpen(t *testing.T) {
 		return runCtx.Err() != nil
 	}, time.Second, 10*time.Millisecond)
 	collectEvents(t, events)
+}
+
+func TestDistributedCancelReadAndActiveRunReturnGetSessionError(t *testing.T) {
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "thread"}
+	getErr := errors.New("get failed")
+	sessionService := &distributedCancelSessionServiceStub{getErrs: []error{getErr, getErr}}
+	requested, err := readDistributedCancelMarker(ctx, sessionService, key)
+	assert.ErrorContains(t, err, "get session")
+	assert.False(t, requested)
+	active, err := activeDistributedRun(ctx, sessionService, key)
+	assert.ErrorContains(t, err, "get session")
+	assert.False(t, active)
+}
+
+func TestDistributedCancelReadMarkerMissingSessionIsFalse(t *testing.T) {
+	requested, err := readDistributedCancelMarker(
+		context.Background(),
+		&distributedCancelSessionServiceStub{},
+		session.Key{AppName: "app", UserID: "user", SessionID: "thread"},
+	)
+	assert.NoError(t, err)
+	assert.False(t, requested)
+}
+
+func TestCancelDistributedReturnsSessionServiceErrors(t *testing.T) {
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "thread"}
+	err := (&runner{}).cancelDistributed(ctx, key)
+	assert.ErrorContains(t, err, "session service is required")
+	getErr := errors.New("get failed")
+	err = (&runner{sessionService: &distributedCancelSessionServiceStub{getErrs: []error{getErr}}}).cancelDistributed(ctx, key)
+	assert.ErrorContains(t, err, "get session")
+	updateErr := errors.New("update failed")
+	sess := session.NewSession("app", "user", "thread", session.WithSessionState(session.StateMap{
+		distributedCancelRunMarkerKey: []byte("active"),
+	}))
+	err = (&runner{sessionService: &distributedCancelSessionServiceStub{
+		getSessions: []*session.Session{sess},
+		updateErr:   updateErr,
+	}}).cancelDistributed(ctx, key)
+	assert.ErrorContains(t, err, "write cancel marker")
+}
+
+func TestWriteDistributedRunMarkerReturnsSessionServiceErrors(t *testing.T) {
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "thread"}
+	getErr := errors.New("get failed")
+	err := writeDistributedRunMarker(ctx, &distributedCancelSessionServiceStub{getErrs: []error{getErr}}, key)
+	assert.ErrorContains(t, err, "get session")
+	createErr := errors.New("create failed")
+	err = writeDistributedRunMarker(ctx, &distributedCancelSessionServiceStub{
+		getErrs:   []error{nil, getErr},
+		createErr: createErr,
+	}, key)
+	assert.ErrorContains(t, err, "create session")
+	assert.ErrorContains(t, err, "get session")
+	err = writeDistributedRunMarker(ctx, &distributedCancelSessionServiceStub{createErr: createErr}, key)
+	assert.ErrorContains(t, err, "create session")
+}
+
+func TestWatchDistributedCancelContinuesAfterReadError(t *testing.T) {
+	ctx, stop := context.WithCancel(context.Background())
+	defer stop()
+	calls := make(chan struct{}, 1)
+	sessionService := &distributedCancelGetErrorSessionService{
+		err:   errors.New("get failed"),
+		calls: calls,
+	}
+	r := &runner{distributedCancelPollInterval: time.Millisecond}
+	done := make(chan struct{})
+	go func() {
+		r.watchDistributedCancel(ctx, sessionService, session.Key{AppName: "app", UserID: "user", SessionID: "thread"}, func(error) {})
+		close(done)
+	}()
+	select {
+	case <-calls:
+	case <-time.After(time.Second):
+		assert.FailNow(t, "timeout waiting for distributed cancel poll")
+	}
+	stop()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		assert.FailNow(t, "timeout waiting for distributed cancel watcher")
+	}
+}
+
+func TestWatchDistributedCancelUsesDefaultInterval(t *testing.T) {
+	ctx, stop := context.WithCancel(context.Background())
+	stop()
+	r := &runner{}
+	r.watchDistributedCancel(ctx, &distributedCancelSessionServiceStub{}, session.Key{}, func(error) {})
+}
+
+func TestFinishDistributedCancelHandlesMissingSessionService(t *testing.T) {
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "thread"}
+	r := &runner{running: map[session.Key]*sessionContext{
+		key: {distributedCancelStarted: true},
+	}}
+	assert.NotPanics(t, func() {
+		r.finishDistributedCancel(context.Background(), key)
+	})
+	started, stop := r.distributedCancelSnapshot(session.Key{AppName: "app", UserID: "user", SessionID: "missing"})
+	assert.False(t, started)
+	assert.Nil(t, stop)
 }
 
 func TestDistributedCancelMarkerKeysAreSessionScoped(t *testing.T) {

--- a/server/agui/runner/cancel_test.go
+++ b/server/agui/runner/cancel_test.go
@@ -11,6 +11,7 @@ package runner
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"sync/atomic"
 	"testing"
@@ -19,11 +20,14 @@ import (
 	aguievents "github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/events"
 	"github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	agentevent "trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/translator"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/session/inmemory"
 )
 
 type waitCancelRunner struct {
@@ -42,6 +46,15 @@ func (w *waitCancelRunner) Run(ctx context.Context, userID, sessionID string, _ 
 }
 
 func (w *waitCancelRunner) Close() error { return nil }
+
+type updateFailSessionService struct {
+	session.Service
+	err error
+}
+
+func (s *updateFailSessionService) UpdateSessionState(context.Context, session.Key, session.StateMap) error {
+	return s.err
+}
 
 type blockingRunRunner struct {
 	entered chan struct{}
@@ -167,6 +180,192 @@ func TestCancelIgnoresRunID(t *testing.T) {
 	}, 5*time.Second, 10*time.Millisecond)
 
 	collectEvents(t, events)
+}
+
+func TestDistributedCancelIgnoresRunID(t *testing.T) {
+	sessionService := inmemory.NewSessionService()
+	ownerCtxCh := make(chan context.Context, 1)
+	owner := New(
+		&waitCancelRunner{ctxCh: ownerCtxCh},
+		WithAppName("app"),
+		WithSessionService(sessionService),
+		WithDistributedCancelEnabled(true),
+		WithDistributedCancelPollInterval(10*time.Millisecond),
+	).(*runner)
+	requester := New(
+		&waitCancelRunner{ctxCh: make(chan context.Context, 1)},
+		WithAppName("app"),
+		WithSessionService(sessionService),
+		WithDistributedCancelEnabled(true),
+		WithDistributedCancelPollInterval(10*time.Millisecond),
+	).(*runner)
+	events, err := owner.Run(context.Background(), distributedCancelInput("thread", "run"))
+	assert.NoError(t, err)
+	waitForDistributedCancelRunStarted(t, events)
+	runCtx := <-ownerCtxCh
+	err = requester.Cancel(context.Background(), distributedCancelInput("thread", "different-run"))
+	assert.NoError(t, err)
+	assert.Eventually(t, func() bool {
+		return runCtx.Err() != nil
+	}, time.Second, 10*time.Millisecond)
+	collectEvents(t, events)
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "thread"}
+	active, err := activeDistributedRun(context.Background(), sessionService, key)
+	assert.NoError(t, err)
+	assert.False(t, active)
+	requested, err := readDistributedCancelMarker(context.Background(), sessionService, key)
+	assert.NoError(t, err)
+	assert.False(t, requested)
+}
+
+func TestDistributedCancelWithoutRunMarkerReturnsNotFound(t *testing.T) {
+	sessionService := inmemory.NewSessionService()
+	requester := newDistributedCancelTestRunner(sessionService, make(chan context.Context, 1))
+	err := requester.Cancel(context.Background(), distributedCancelInput("thread", "run"))
+	assert.ErrorIs(t, err, ErrRunNotFound)
+}
+
+func TestDistributedCancelRunWithoutSessionServiceIsFailOpen(t *testing.T) {
+	ctxCh := make(chan context.Context, 1)
+	r := New(
+		&waitCancelRunner{ctxCh: ctxCh},
+		WithAppName("app"),
+		WithDistributedCancelEnabled(true),
+	).(*runner)
+	events, err := r.Run(context.Background(), distributedCancelInput("thread", "run"))
+	assert.NoError(t, err)
+	waitForDistributedCancelRunStarted(t, events)
+	runCtx := <-ctxCh
+	assert.NoError(t, r.Cancel(context.Background(), distributedCancelInput("thread", "run")))
+	assert.Eventually(t, func() bool {
+		return runCtx.Err() != nil
+	}, time.Second, 10*time.Millisecond)
+	collectEvents(t, events)
+}
+
+func TestDistributedCancelRunStartClearsStaleCancelMarker(t *testing.T) {
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "thread"}
+	sessionService := inmemory.NewSessionService()
+	_, err := sessionService.CreateSession(ctx, key, nil)
+	assert.NoError(t, err)
+	err = sessionService.UpdateSessionState(ctx, key, session.StateMap{
+		distributedCancelCancelMarkerKey: []byte("stale"),
+	})
+	assert.NoError(t, err)
+	ctxCh := make(chan context.Context, 1)
+	r := newDistributedCancelTestRunner(sessionService, ctxCh)
+	events, err := r.Run(ctx, distributedCancelInput("thread", "run"))
+	assert.NoError(t, err)
+	waitForDistributedCancelRunStarted(t, events)
+	runCtx := <-ctxCh
+	requested, err := readDistributedCancelMarker(ctx, sessionService, key)
+	assert.NoError(t, err)
+	assert.False(t, requested)
+	assert.Never(t, func() bool {
+		return runCtx.Err() != nil
+	}, 100*time.Millisecond, 10*time.Millisecond)
+	assert.NoError(t, r.Cancel(ctx, distributedCancelInput("thread", "run")))
+	assert.Eventually(t, func() bool {
+		return runCtx.Err() != nil
+	}, time.Second, 10*time.Millisecond)
+	collectEvents(t, events)
+}
+
+func TestDistributedCancelRunMarkerFailureIsFailOpen(t *testing.T) {
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "thread"}
+	updateErr := errors.New("update failed")
+	baseSessionService := inmemory.NewSessionService()
+	_, err := baseSessionService.CreateSession(ctx, key, nil)
+	assert.NoError(t, err)
+	sessionService := &updateFailSessionService{
+		Service: baseSessionService,
+		err:     updateErr,
+	}
+	ctxCh := make(chan context.Context, 1)
+	r := New(
+		&waitCancelRunner{ctxCh: ctxCh},
+		WithAppName("app"),
+		WithSessionService(sessionService),
+		WithDistributedCancelEnabled(true),
+		WithDistributedCancelPollInterval(10*time.Millisecond),
+	).(*runner)
+	events, err := r.Run(ctx, distributedCancelInput("thread", "run"))
+	assert.NoError(t, err)
+	waitForDistributedCancelRunStarted(t, events)
+	runCtx := <-ctxCh
+	assert.NoError(t, r.Cancel(ctx, distributedCancelInput("thread", "run")))
+	assert.Eventually(t, func() bool {
+		return runCtx.Err() != nil
+	}, time.Second, 10*time.Millisecond)
+	collectEvents(t, events)
+}
+
+func TestDistributedCancelMarkerKeysAreSessionScoped(t *testing.T) {
+	assert.Equal(t, session.StateTempPrefix+"agui:distributed_cancel:run", distributedCancelRunMarkerKey)
+	assert.Equal(t, session.StateTempPrefix+"agui:distributed_cancel:cancel", distributedCancelCancelMarkerKey)
+}
+
+func TestDistributedCancelMarkerValuesAreJSON(t *testing.T) {
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "thread"}
+	sessionService := inmemory.NewSessionService()
+	_, err := sessionService.CreateSession(ctx, key, nil)
+	assert.NoError(t, err)
+	assert.NoError(t, writeDistributedRunMarker(ctx, sessionService, key))
+	assertDistributedCancelMarkerValue(t, sessionService, key, distributedCancelRunMarkerKey)
+	assert.NoError(t, writeDistributedCancelMarker(ctx, sessionService, key))
+	assertDistributedCancelMarkerValue(t, sessionService, key, distributedCancelCancelMarkerKey)
+}
+
+func assertDistributedCancelMarkerValue(
+	t *testing.T,
+	sessionService session.Service,
+	key session.Key,
+	stateKey string,
+) {
+	t.Helper()
+	sess, err := sessionService.GetSession(context.Background(), key)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	raw, ok := sess.GetState(stateKey)
+	assert.True(t, ok)
+	var marker distributedCancelMarker
+	assert.NoError(t, json.Unmarshal(raw, &marker))
+	_, err = time.Parse(time.RFC3339Nano, marker.UpdatedAt)
+	assert.NoError(t, err)
+}
+
+func newDistributedCancelTestRunner(
+	sessionService session.Service,
+	ctxCh chan context.Context,
+) *runner {
+	return New(
+		&waitCancelRunner{ctxCh: ctxCh},
+		WithAppName("app"),
+		WithSessionService(sessionService),
+		WithDistributedCancelEnabled(true),
+		WithDistributedCancelPollInterval(10*time.Millisecond),
+	).(*runner)
+}
+
+func distributedCancelInput(threadID string, runID string) *adapter.RunAgentInput {
+	return &adapter.RunAgentInput{
+		ThreadID: threadID,
+		RunID:    runID,
+		Messages: []types.Message{{Role: types.RoleUser, Content: "hi"}},
+	}
+}
+
+func waitForDistributedCancelRunStarted(t *testing.T, events <-chan aguievents.Event) {
+	t.Helper()
+	select {
+	case evt := <-events:
+		assert.IsType(t, (*aguievents.RunStartedEvent)(nil), evt)
+	case <-time.After(time.Second):
+		assert.FailNow(t, "timeout waiting for RUN_STARTED")
+	}
 }
 
 func TestCancelUsesResolvedAppName(t *testing.T) {

--- a/server/agui/runner/options.go
+++ b/server/agui/runner/options.go
@@ -33,6 +33,8 @@ const (
 	defaultToolResultInputTranslationEnabled      = false
 	defaultToolCallDeltaStreamingEnabled          = false
 	defaultStreamingToolResultActivityEnabled     = false
+	defaultDistributedCancelEnabled               = false
+	defaultDistributedCancelPollInterval          = time.Second
 )
 
 // Options holds the options for the runner.
@@ -64,6 +66,8 @@ type Options struct {
 	ToolResultInputTranslationEnabled         bool                  // ToolResultInputTranslationEnabled controls whether tool-result inputs are translated before emission.
 	ToolCallDeltaStreamingEnabled             bool                  // ToolCallDeltaStreamingEnabled streams partial tool-call arguments.
 	StreamingToolResultActivityEnabled        bool                  // StreamingToolResultActivityEnabled rewrites partial tool results as activity events.
+	DistributedCancelEnabled                  bool                  // DistributedCancelEnabled enables best-effort cancel signaling through SessionState.
+	DistributedCancelPollInterval             time.Duration         // DistributedCancelPollInterval controls how often owner runs poll cancel markers.
 }
 
 // NewOptions creates a new options instance.
@@ -88,6 +92,8 @@ func NewOptions(opt ...Option) *Options {
 		ToolResultInputTranslationEnabled:      defaultToolResultInputTranslationEnabled,
 		ToolCallDeltaStreamingEnabled:          defaultToolCallDeltaStreamingEnabled,
 		StreamingToolResultActivityEnabled:     defaultStreamingToolResultActivityEnabled,
+		DistributedCancelEnabled:               defaultDistributedCancelEnabled,
+		DistributedCancelPollInterval:          defaultDistributedCancelPollInterval,
 	}
 	for _, o := range opt {
 		o(opts)
@@ -308,6 +314,20 @@ func WithToolCallDeltaStreamingEnabled(enabled bool) Option {
 func WithStreamingToolResultActivityEnabled(enabled bool) Option {
 	return func(o *Options) {
 		o.StreamingToolResultActivityEnabled = enabled
+	}
+}
+
+// WithDistributedCancelEnabled enables best-effort cancel signaling through SessionState.
+func WithDistributedCancelEnabled(enabled bool) Option {
+	return func(o *Options) {
+		o.DistributedCancelEnabled = enabled
+	}
+}
+
+// WithDistributedCancelPollInterval sets how often owner runs poll cancel markers.
+func WithDistributedCancelPollInterval(d time.Duration) Option {
+	return func(o *Options) {
+		o.DistributedCancelPollInterval = d
 	}
 }
 

--- a/server/agui/runner/options_test.go
+++ b/server/agui/runner/options_test.go
@@ -82,6 +82,8 @@ func TestNewOptionsDefaults(t *testing.T) {
 	assert.False(t, opts.ToolCallDeltaStreamingEnabled)
 	assert.False(t, opts.StreamingToolResultActivityEnabled)
 	assert.False(t, opts.MessagesSnapshotRunLifecycleEventsEnabled)
+	assert.False(t, opts.DistributedCancelEnabled)
+	assert.Equal(t, time.Second, opts.DistributedCancelPollInterval)
 }
 
 func TestWithUserIDResolver(t *testing.T) {
@@ -285,6 +287,16 @@ func TestWithTimeout(t *testing.T) {
 func TestWithCancelOnContextDoneEnabled(t *testing.T) {
 	opts := NewOptions(WithCancelOnContextDoneEnabled(true))
 	assert.True(t, opts.CancelOnContextDoneEnabled)
+}
+
+func TestWithDistributedCancelEnabled(t *testing.T) {
+	opts := NewOptions(WithDistributedCancelEnabled(true))
+	assert.True(t, opts.DistributedCancelEnabled)
+}
+
+func TestWithDistributedCancelPollInterval(t *testing.T) {
+	opts := NewOptions(WithDistributedCancelPollInterval(2 * time.Second))
+	assert.Equal(t, 2*time.Second, opts.DistributedCancelPollInterval)
 }
 
 func TestWithMessagesSnapshotFollowEnabled(t *testing.T) {

--- a/server/agui/runner/runner.go
+++ b/server/agui/runner/runner.go
@@ -86,6 +86,7 @@ func New(r trunner.Runner, opt ...Option) Runner {
 		runAgentInputHook:                      opts.RunAgentInputHook,
 		stateResolver:                          opts.StateResolver,
 		runOptionResolver:                      opts.RunOptionResolver,
+		sessionService:                         opts.SessionService,
 		tracker:                                tracker,
 		running:                                make(map[session.Key]*sessionContext),
 		startSpan:                              opts.StartSpan,
@@ -99,6 +100,8 @@ func New(r trunner.Runner, opt ...Option) Runner {
 		toolResultInputTranslationEnabled:         opts.ToolResultInputTranslationEnabled,
 		toolCallDeltaStreamingEnabled:             opts.ToolCallDeltaStreamingEnabled,
 		streamingToolResultActivityEnabled:        opts.StreamingToolResultActivityEnabled,
+		distributedCancelEnabled:                  opts.DistributedCancelEnabled,
+		distributedCancelPollInterval:             opts.DistributedCancelPollInterval,
 	}
 	return run
 }
@@ -119,6 +122,7 @@ type runner struct {
 	runAgentInputHook                         RunAgentInputHook
 	stateResolver                             StateResolver
 	runOptionResolver                         RunOptionResolver
+	sessionService                            session.Service
 	tracker                                   track.Tracker
 	runningMu                                 sync.Mutex
 	running                                   map[session.Key]*sessionContext
@@ -133,11 +137,15 @@ type runner struct {
 	toolResultInputTranslationEnabled         bool
 	toolCallDeltaStreamingEnabled             bool
 	streamingToolResultActivityEnabled        bool
+	distributedCancelEnabled                  bool
+	distributedCancelPollInterval             time.Duration
 }
 
 type sessionContext struct {
-	ctx    context.Context
-	cancel context.CancelCauseFunc
+	ctx                      context.Context
+	cancel                   context.CancelCauseFunc
+	distributedCancelStarted bool
+	stopDistributedCancel    context.CancelFunc
 }
 
 type runInput struct {
@@ -405,6 +413,14 @@ func (r *runner) Run(ctx context.Context, runAgentInput *adapter.RunAgentInput) 
 		span.End()
 		return nil, fmt.Errorf("register running context: %w", err)
 	}
+	if r.distributedCancelEnabled {
+		stopDistributedCancel, err := r.startDistributedCancel(ctx, input.key, cancel)
+		if err != nil {
+			log.WarnfContext(ctx, "agui distributed cancel disabled for run: threadID: %s, runID: %s, err: %v", input.threadID, input.runID, err)
+		} else {
+			r.setDistributedCancel(input.key, stopDistributedCancel)
+		}
+	}
 	go r.run(ctx, cancel, input.key, input, events)
 	return events, nil
 }
@@ -412,6 +428,7 @@ func (r *runner) Run(ctx context.Context, runAgentInput *adapter.RunAgentInput) 
 func (r *runner) run(ctx context.Context, cancel context.CancelCauseFunc, key session.Key, input *runInput, events chan<- aguievents.Event) {
 	defer func() {
 		cancel(nil)
+		r.finishDistributedCancel(ctx, key)
 		r.unregister(key)
 		input.span.End()
 		close(events)
@@ -951,6 +968,24 @@ func (r *runner) register(key session.Key, ctx context.Context, cancel context.C
 	}
 	r.running[key] = &sessionContext{ctx: ctx, cancel: cancel}
 	return nil
+}
+
+func (r *runner) setDistributedCancel(key session.Key, stop context.CancelFunc) {
+	r.runningMu.Lock()
+	defer r.runningMu.Unlock()
+	if entry, ok := r.running[key]; ok {
+		entry.distributedCancelStarted = true
+		entry.stopDistributedCancel = stop
+	}
+}
+
+func (r *runner) distributedCancelSnapshot(key session.Key) (bool, context.CancelFunc) {
+	r.runningMu.Lock()
+	defer r.runningMu.Unlock()
+	if entry, ok := r.running[key]; ok {
+		return entry.distributedCancelStarted, entry.stopDistributedCancel
+	}
+	return false, nil
 }
 
 func (r *runner) unregister(key session.Key) {


### PR DESCRIPTION
Adds opt-in distributed cancel signaling for AG-UI multi-instance deployments using shared SessionService state, including runner and server options, session-scoped run and cancel markers, watcher cleanup, and cancel route documentation for remote delivery semantics and polling behavior.