### PR TITLE
model: add structured output request option

### DIFF
--- a/agent/invocation.go
+++ b/agent/invocation.go
@@ -697,7 +697,7 @@ func WithStructuredOutputJSONSchema(name string, schema map[string]any, strict b
 		if schema == nil {
 			return
 		}
-		opts.StructuredOutput = runStructuredOutput(
+		opts.StructuredOutput = newStructuredOutput(
 			structuredoutput.Name(name),
 			schema,
 			strict,
@@ -714,12 +714,12 @@ func WithStructuredOutputJSON(examplePtr any, strict bool, description string) R
 		if schema == nil {
 			return
 		}
-		opts.StructuredOutput = runStructuredOutput(name, schema, strict, description)
+		opts.StructuredOutput = newStructuredOutput(name, schema, strict, description)
 		opts.StructuredOutputType = t
 	}
 }
 
-func runStructuredOutput(name string, schema map[string]any, strict bool, description string) *model.StructuredOutput {
+func newStructuredOutput(name string, schema map[string]any, strict bool, description string) *model.StructuredOutput {
 	if schema == nil {
 		return nil
 	}

--- a/agent/invocation.go
+++ b/agent/invocation.go
@@ -26,7 +26,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/artifact"
 	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
 	"trpc.group/trpc-go/trpc-agent-go/event"
-	"trpc.group/trpc-go/trpc-agent-go/internal/jsonschema"
+	"trpc.group/trpc-go/trpc-agent-go/internal/structuredoutput"
 	"trpc.group/trpc-go/trpc-agent-go/internal/tracecapture"
 	"trpc.group/trpc-go/trpc-agent-go/internal/util"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/searchfilter"
@@ -697,18 +697,12 @@ func WithStructuredOutputJSONSchema(name string, schema map[string]any, strict b
 		if schema == nil {
 			return
 		}
-		if name == "" {
-			name = "output"
-		}
-		opts.StructuredOutput = &model.StructuredOutput{
-			Type: model.StructuredOutputJSONSchema,
-			JSONSchema: &model.JSONSchemaConfig{
-				Name:        name,
-				Schema:      schema,
-				Strict:      strict,
-				Description: description,
-			},
-		}
+		opts.StructuredOutput = runStructuredOutput(
+			structuredoutput.Name(name),
+			schema,
+			strict,
+			description,
+		)
 	}
 }
 
@@ -716,36 +710,27 @@ func WithStructuredOutputJSONSchema(name string, schema map[string]any, strict b
 // The schema is constructed automatically from the provided example type.
 func WithStructuredOutputJSON(examplePtr any, strict bool, description string) RunOption {
 	return func(opts *RunOptions) {
-		// Infer reflect.Type from examplePtr.
-		var t reflect.Type
-		if examplePtr == nil {
+		name, schema, t := structuredoutput.FromType(examplePtr, strict)
+		if schema == nil {
 			return
 		}
-		if rt := reflect.TypeOf(examplePtr); rt.Kind() == reflect.Pointer {
-			t = rt
-		} else {
-			t = reflect.PointerTo(rt)
-		}
-		genOpts := make([]jsonschema.Option, 0, 1)
-		if strict {
-			genOpts = append(genOpts, jsonschema.WithStrict())
-		}
-		gen := jsonschema.New(genOpts...)
-		schema := gen.Generate(t.Elem())
-		name := t.Elem().Name()
-		if name == "" {
-			name = "output"
-		}
-		opts.StructuredOutput = &model.StructuredOutput{
-			Type: model.StructuredOutputJSONSchema,
-			JSONSchema: &model.JSONSchemaConfig{
-				Name:        name,
-				Schema:      schema,
-				Strict:      strict,
-				Description: description,
-			},
-		}
+		opts.StructuredOutput = runStructuredOutput(name, schema, strict, description)
 		opts.StructuredOutputType = t
+	}
+}
+
+func runStructuredOutput(name string, schema map[string]any, strict bool, description string) *model.StructuredOutput {
+	if schema == nil {
+		return nil
+	}
+	return &model.StructuredOutput{
+		Type: model.StructuredOutputJSONSchema,
+		JSONSchema: &model.JSONSchemaConfig{
+			Name:        name,
+			Schema:      schema,
+			Strict:      strict,
+			Description: description,
+		},
 	}
 }
 

--- a/agent/llmagent/option.go
+++ b/agent/llmagent/option.go
@@ -1247,7 +1247,7 @@ func WithStructuredOutputJSONSchema(name string, schema map[string]any, strict b
 		if schema == nil {
 			return
 		}
-		opts.StructuredOutput = llmAgentStructuredOutput(
+		opts.StructuredOutput = newStructuredOutput(
 			structuredoutput.Name(name),
 			schema,
 			strict,
@@ -1265,12 +1265,12 @@ func WithStructuredOutputJSON(examplePtr any, strict bool, description string) O
 		if schema == nil {
 			return
 		}
-		opts.StructuredOutput = llmAgentStructuredOutput(name, schema, strict, description)
+		opts.StructuredOutput = newStructuredOutput(name, schema, strict, description)
 		opts.StructuredOutputType = t
 	}
 }
 
-func llmAgentStructuredOutput(name string, schema map[string]any, strict bool, description string) *model.StructuredOutput {
+func newStructuredOutput(name string, schema map[string]any, strict bool, description string) *model.StructuredOutput {
 	if schema == nil {
 		return nil
 	}

--- a/agent/llmagent/option.go
+++ b/agent/llmagent/option.go
@@ -18,8 +18,8 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
 	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/internal/flow/processor"
-	"trpc.group/trpc-go/trpc-agent-go/internal/jsonschema"
 	"trpc.group/trpc-go/trpc-agent-go/internal/skillprofile"
+	"trpc.group/trpc-go/trpc-agent-go/internal/structuredoutput"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/searchfilter"
 	"trpc.group/trpc-go/trpc-agent-go/model"
@@ -1247,18 +1247,12 @@ func WithStructuredOutputJSONSchema(name string, schema map[string]any, strict b
 		if schema == nil {
 			return
 		}
-		if name == "" {
-			name = "output"
-		}
-		opts.StructuredOutput = &model.StructuredOutput{
-			Type: model.StructuredOutputJSONSchema,
-			JSONSchema: &model.JSONSchemaConfig{
-				Name:        name,
-				Schema:      schema,
-				Strict:      strict,
-				Description: description,
-			},
-		}
+		opts.StructuredOutput = llmAgentStructuredOutput(
+			structuredoutput.Name(name),
+			schema,
+			strict,
+			description,
+		)
 	}
 }
 
@@ -1267,37 +1261,27 @@ func WithStructuredOutputJSONSchema(name string, schema map[string]any, strict b
 // Provide a typed zero-value pointer like: new(MyStruct) or (*MyStruct)(nil) and we infer the type.
 func WithStructuredOutputJSON(examplePtr any, strict bool, description string) Option {
 	return func(opts *Options) {
-		// Infer reflect.Type from examplePtr.
-		var t reflect.Type
-		if examplePtr == nil {
+		name, schema, t := structuredoutput.FromType(examplePtr, strict)
+		if schema == nil {
 			return
 		}
-		if rt := reflect.TypeOf(examplePtr); rt.Kind() == reflect.Pointer {
-			t = rt
-		} else {
-			t = reflect.PointerTo(rt)
-		}
-		// Generate a robust JSON schema via the generator.
-		genOpts := make([]jsonschema.Option, 0, 1)
-		if strict {
-			genOpts = append(genOpts, jsonschema.WithStrict())
-		}
-		gen := jsonschema.New(genOpts...)
-		schema := gen.Generate(t.Elem())
-		name := t.Elem().Name()
-		if name == "" {
-			name = "output"
-		}
-		opts.StructuredOutput = &model.StructuredOutput{
-			Type: model.StructuredOutputJSONSchema,
-			JSONSchema: &model.JSONSchemaConfig{
-				Name:        name,
-				Schema:      schema,
-				Strict:      strict,
-				Description: description,
-			},
-		}
+		opts.StructuredOutput = llmAgentStructuredOutput(name, schema, strict, description)
 		opts.StructuredOutputType = t
+	}
+}
+
+func llmAgentStructuredOutput(name string, schema map[string]any, strict bool, description string) *model.StructuredOutput {
+	if schema == nil {
+		return nil
+	}
+	return &model.StructuredOutput{
+		Type: model.StructuredOutputJSONSchema,
+		JSONSchema: &model.JSONSchemaConfig{
+			Name:        name,
+			Schema:      schema,
+			Strict:      strict,
+			Description: description,
+		},
 	}
 }
 

--- a/docs/mkdocs/en/model.md
+++ b/docs/mkdocs/en/model.md
@@ -396,6 +396,55 @@ func main() {
 }
 ```
 
+### Structured Output
+
+When calling `model.GenerateContent` directly, use `model.NewRequest` and
+`model.WithStructuredOutputJSON` to generate a JSON schema from a Go struct and
+pass it to model adapters that support provider-native structured output.
+
+```go
+type StageParseResult struct {
+    Stage  string `json:"stage"`
+    Reason string `json:"reason"`
+}
+
+request := model.NewRequest(
+    []model.Message{
+        model.NewUserMessage("Classify the current user intent stage."),
+    },
+    model.WithStructuredOutputJSON(
+        new(StageParseResult),
+        true,
+        "Return stage parse result as JSON.",
+    ),
+)
+
+responseChan, err := llm.GenerateContent(ctx, request)
+if err != nil {
+    return err
+}
+
+var final string
+for response := range responseChan {
+    if response.Error != nil {
+        return fmt.Errorf("model error: %s", response.Error.Message)
+    }
+    if len(response.Choices) > 0 {
+        final = response.Choices[0].Message.Content
+    }
+}
+
+var result StageParseResult
+if err := json.Unmarshal([]byte(final), &result); err != nil {
+    return err
+}
+```
+
+`WithStructuredOutputJSON` only configures the model request. Direct `model`
+callers still receive normal `model.Response` values and should unmarshal the
+final JSON content themselves. If you already have a hand-written schema, set
+`request.StructuredOutput` directly.
+
 ### Streaming Output
 
 ```go

--- a/docs/mkdocs/zh/model.md
+++ b/docs/mkdocs/zh/model.md
@@ -393,6 +393,54 @@ func main() {
 }
 ```
 
+### 结构化输出
+
+直接调用 `model.GenerateContent` 时，可以用 `model.NewRequest` 和
+`model.WithStructuredOutputJSON` 从 Go 结构体自动生成 JSON schema，并传给支持
+provider-native structured output 的模型适配器。
+
+```go
+type StageParseResult struct {
+    Stage  string `json:"stage"`
+    Reason string `json:"reason"`
+}
+
+request := model.NewRequest(
+    []model.Message{
+        model.NewUserMessage("分析当前用户意图属于哪个阶段。"),
+    },
+    model.WithStructuredOutputJSON(
+        new(StageParseResult),
+        true,
+        "Return stage parse result as JSON.",
+    ),
+)
+
+responseChan, err := llm.GenerateContent(ctx, request)
+if err != nil {
+    return err
+}
+
+var final string
+for response := range responseChan {
+    if response.Error != nil {
+        return fmt.Errorf("model error: %s", response.Error.Message)
+    }
+    if len(response.Choices) > 0 {
+        final = response.Choices[0].Message.Content
+    }
+}
+
+var result StageParseResult
+if err := json.Unmarshal([]byte(final), &result); err != nil {
+    return err
+}
+```
+
+`WithStructuredOutputJSON` 只负责配置模型请求；直接使用 `model` 包时，最终响应仍在
+`model.Response` 中，需要调用方自行解析 JSON。若已经有手写 schema，也可以直接设置
+`request.StructuredOutput`。
+
 ### 流式输出
 
 ```go

--- a/internal/structuredoutput/structuredoutput.go
+++ b/internal/structuredoutput/structuredoutput.go
@@ -1,0 +1,53 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+// Package structuredoutput builds structured output schema data from Go types.
+package structuredoutput
+
+import (
+	"reflect"
+
+	"trpc.group/trpc-go/trpc-agent-go/internal/jsonschema"
+)
+
+// Name returns the provider-facing structured output schema name.
+func Name(name string) string {
+	if name == "" {
+		return "output"
+	}
+	return name
+}
+
+// FromType returns the schema name, generated JSON schema, and pointer type.
+func FromType(examplePtr any, strict bool) (string, map[string]any, reflect.Type) {
+	t := TypeOf(examplePtr)
+	if t == nil {
+		return "", nil, nil
+	}
+	genOpts := make([]jsonschema.Option, 0, 1)
+	if strict {
+		genOpts = append(genOpts, jsonschema.WithStrict())
+	}
+	gen := jsonschema.New(genOpts...)
+	schema := gen.Generate(t.Elem())
+	name := t.Elem().Name()
+	return Name(name), schema, t
+}
+
+// TypeOf returns the pointer type used for typed structured output.
+func TypeOf(examplePtr any) reflect.Type {
+	if examplePtr == nil {
+		return nil
+	}
+	rt := reflect.TypeOf(examplePtr)
+	if rt.Kind() == reflect.Pointer {
+		return rt
+	}
+	return reflect.PointerTo(rt)
+}

--- a/internal/structuredoutput/structuredoutput_test.go
+++ b/internal/structuredoutput/structuredoutput_test.go
@@ -1,0 +1,82 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package structuredoutput
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type testPayload struct {
+	Answer   string `json:"answer"`
+	Optional *int   `json:"optional,omitempty"`
+}
+
+func TestName(t *testing.T) {
+	require.Equal(t, "output", Name(""))
+	require.Equal(t, "custom", Name("custom"))
+}
+
+func TestTypeOf(t *testing.T) {
+	require.Nil(t, TypeOf(nil))
+	require.Equal(t, reflect.TypeOf((*testPayload)(nil)), TypeOf(new(testPayload)))
+	require.Equal(t, reflect.TypeOf((*testPayload)(nil)), TypeOf(testPayload{}))
+}
+
+func TestFromType_Strict(t *testing.T) {
+	name, schema, outputType := FromType(new(testPayload), true)
+
+	require.Equal(t, "testPayload", name)
+	require.Equal(t, reflect.TypeOf((*testPayload)(nil)), outputType)
+	require.Equal(t, "object", schema["type"])
+
+	properties, ok := schema["properties"].(map[string]any)
+	require.True(t, ok)
+	require.Contains(t, properties, "answer")
+	require.Contains(t, properties, "optional")
+	_, hasAnyOf := properties["optional"].(map[string]any)["anyOf"]
+	require.True(t, hasAnyOf)
+
+	required, ok := schema["required"].([]string)
+	require.True(t, ok)
+	require.ElementsMatch(t, []string{"answer", "optional"}, required)
+}
+
+func TestFromType_NonStrict(t *testing.T) {
+	name, schema, outputType := FromType(testPayload{}, false)
+
+	require.Equal(t, "testPayload", name)
+	require.Equal(t, reflect.TypeOf((*testPayload)(nil)), outputType)
+
+	properties, ok := schema["properties"].(map[string]any)
+	require.True(t, ok)
+	_, hasAnyOf := properties["optional"].(map[string]any)["anyOf"]
+	require.False(t, hasAnyOf)
+
+	required, ok := schema["required"].([]string)
+	require.True(t, ok)
+	require.Equal(t, []string{"answer"}, required)
+}
+
+func TestFromType_NilAndUnnamed(t *testing.T) {
+	name, schema, outputType := FromType(nil, true)
+	require.Empty(t, name)
+	require.Nil(t, schema)
+	require.Nil(t, outputType)
+
+	name, schema, outputType = FromType(struct {
+		Value string `json:"value"`
+	}{}, true)
+	require.Equal(t, "output", name)
+	require.NotNil(t, schema)
+	require.NotNil(t, outputType)
+}

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -34,6 +34,50 @@ func TestModelInterface(t *testing.T) {
 	require.Nil(t, responseChan)
 }
 
+type requestStructuredOutputPayload struct {
+	Answer   string `json:"answer"`
+	Optional *int   `json:"optional,omitempty"`
+}
+
+func TestRequestOptions_WithStructuredOutputJSON(t *testing.T) {
+	req := NewRequest(
+		[]Message{NewUserMessage("hello")},
+		WithStructuredOutputJSON(
+			new(requestStructuredOutputPayload),
+			true,
+			"Return a typed payload.",
+		),
+	)
+
+	require.Len(t, req.Messages, 1)
+	require.NotNil(t, req.StructuredOutput)
+	require.Equal(t, StructuredOutputJSONSchema, req.StructuredOutput.Type)
+	require.NotNil(t, req.StructuredOutput.JSONSchema)
+	require.Equal(t, "requestStructuredOutputPayload", req.StructuredOutput.JSONSchema.Name)
+	require.True(t, req.StructuredOutput.JSONSchema.Strict)
+	require.Equal(t, "Return a typed payload.", req.StructuredOutput.JSONSchema.Description)
+
+	schema := req.StructuredOutput.JSONSchema.Schema
+	require.Equal(t, "object", schema["type"])
+	properties, ok := schema["properties"].(map[string]any)
+	require.True(t, ok)
+	require.Contains(t, properties, "answer")
+	require.Contains(t, properties, "optional")
+	required, ok := schema["required"].([]string)
+	require.True(t, ok)
+	require.Contains(t, required, "answer")
+	require.Contains(t, required, "optional")
+}
+
+func TestRequestOptions_IgnoresNilStructuredOutputInputs(t *testing.T) {
+	req := NewRequest(
+		nil,
+		WithStructuredOutputJSON(nil, true, "ignored"),
+	)
+
+	require.Nil(t, req.StructuredOutput)
+}
+
 // mockModel is a simple mock implementation for testing the interface.
 type mockModel struct{}
 

--- a/model/request.go
+++ b/model/request.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"trpc.group/trpc-go/trpc-agent-go/internal/structuredoutput"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
 
@@ -503,6 +504,36 @@ type Request struct {
 	Tools map[string]tool.Tool `json:"-"` // Tools are not serialized, handled separately
 }
 
+// RequestOption configures a Request.
+type RequestOption func(*Request)
+
+// NewRequest creates a model request from messages and applies options.
+func NewRequest(messages []Message, opts ...RequestOption) *Request {
+	req := &Request{
+		Messages: messages,
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(req)
+		}
+	}
+	return req
+}
+
+// WithStructuredOutputJSON sets JSON schema structured output for a request.
+// The schema is constructed automatically from the provided example type.
+//
+// This configures provider-native structured output where supported. Direct
+// model callers still receive normal model.Response values and should unmarshal
+// the final JSON content themselves.
+func WithStructuredOutputJSON(examplePtr any, strict bool, description string) RequestOption {
+	return func(req *Request) {
+		if out := structuredOutputJSON(examplePtr, strict, description); out != nil {
+			req.StructuredOutput = out
+		}
+	}
+}
+
 // ToolCall represents a call to a tool (function) in the model response.
 type ToolCall struct {
 	// Type of the tool. Currently, only `function` is supported.
@@ -629,4 +660,20 @@ type StructuredOutput struct {
 	Type StructuredOutputType `json:"type"`
 	// JSONSchema is used when Type is StructuredOutputJSONSchema.
 	JSONSchema *JSONSchemaConfig `json:"json_schema,omitempty"`
+}
+
+func structuredOutputJSON(examplePtr any, strict bool, description string) *StructuredOutput {
+	name, schema, _ := structuredoutput.FromType(examplePtr, strict)
+	if schema == nil {
+		return nil
+	}
+	return &StructuredOutput{
+		Type: StructuredOutputJSONSchema,
+		JSONSchema: &JSONSchemaConfig{
+			Name:        name,
+			Schema:      schema,
+			Strict:      strict,
+			Description: description,
+		},
+	}
 }


### PR DESCRIPTION
## Summary
- Add a `model.NewRequest` option path for generating structured output JSON schema from Go types.
- Share schema/type inference through an internal helper so agent and model paths avoid duplicated reflection logic.
- Cover request option and internal structured output helper behavior with focused tests.

## Test plan
- `go test ./internal/structuredoutput ./model ./agent ./agent/llmagent`