### PR TITLE
model/gemini: support thinking level and thought signatures

### DIFF
--- a/graph/call_options.go
+++ b/graph/call_options.go
@@ -304,7 +304,8 @@ func isEmptyGenPatch(p model.GenerationConfigPatch) bool {
 		p.FrequencyPenalty == nil &&
 		p.ReasoningEffort == nil &&
 		p.ThinkingEnabled == nil &&
-		p.ThinkingTokens == nil
+		p.ThinkingTokens == nil &&
+		p.ThinkingLevel == nil
 }
 
 func cloneGenPatch(
@@ -351,6 +352,9 @@ func mergeGenPatch(
 	}
 	if override.ThinkingTokens != nil {
 		out.ThinkingTokens = override.ThinkingTokens
+	}
+	if override.ThinkingLevel != nil {
+		out.ThinkingLevel = override.ThinkingLevel
 	}
 	return out
 }

--- a/graph/call_options_test.go
+++ b/graph/call_options_test.go
@@ -38,6 +38,7 @@ const (
 	callOptsTestStopA      = "A"
 	callOptsTestStopB      = "B"
 	callOptsTestEffort     = "high"
+	callOptsTestThinkLevel = "low"
 )
 
 func TestWithCallOptions_MergesCustomAgentConfigs(t *testing.T) {
@@ -81,6 +82,21 @@ func TestWithCallOptions_MergesCustomAgentConfigs(t *testing.T) {
 	require.Equal(t, callOptsTestMaxTokens, *patch.MaxTokens)
 }
 
+func TestWithCallOptions_ThinkingLevelOnlyPatchIsPreserved(t *testing.T) {
+	runOpts := agent.RunOptions{}
+	WithCallOptions(
+		WithCallGenerationConfigPatch(model.GenerationConfigPatch{
+			ThinkingLevel: model.StringPtr(callOptsTestThinkLevel),
+		}),
+	)(&runOpts)
+
+	opts := graphCallOptionsFromConfigs(runOpts.CustomAgentConfigs)
+	require.NotNil(t, opts)
+	patch := generationPatchForNode(opts, "")
+	require.NotNil(t, patch.ThinkingLevel)
+	require.Equal(t, callOptsTestThinkLevel, *patch.ThinkingLevel)
+}
+
 func TestMergeGenPatch_AllFields(t *testing.T) {
 	base := model.GenerationConfigPatch{
 		Stop: []string{callOptsTestStopA},
@@ -96,6 +112,7 @@ func TestMergeGenPatch_AllFields(t *testing.T) {
 		ReasoningEffort:  model.StringPtr(callOptsTestEffort),
 		ThinkingEnabled:  model.BoolPtr(true),
 		ThinkingTokens:   model.IntPtr(callOptsTestThinkTok),
+		ThinkingLevel:    model.StringPtr(callOptsTestThinkLevel),
 	}
 	got := mergeGenPatch(base, override)
 	require.NotNil(t, got.MaxTokens)
@@ -117,9 +134,23 @@ func TestMergeGenPatch_AllFields(t *testing.T) {
 	require.True(t, *got.ThinkingEnabled)
 	require.NotNil(t, got.ThinkingTokens)
 	require.Equal(t, callOptsTestThinkTok, *got.ThinkingTokens)
+	require.NotNil(t, got.ThinkingLevel)
+	require.Equal(t, callOptsTestThinkLevel, *got.ThinkingLevel)
 
 	override.Stop[0] = callOptsTestStopA
 	require.Equal(t, []string{callOptsTestStopB}, got.Stop)
+}
+
+func TestMergeGenPatch_ThinkingLevelOnlyIsNotEmpty(t *testing.T) {
+	patch := model.GenerationConfigPatch{
+		ThinkingLevel: model.StringPtr(callOptsTestThinkLevel),
+	}
+
+	require.False(t, isEmptyGenPatch(patch))
+
+	got := mergeGenPatch(model.GenerationConfigPatch{}, patch)
+	require.NotNil(t, got.ThinkingLevel)
+	require.Equal(t, callOptsTestThinkLevel, *got.ThinkingLevel)
 }
 
 func TestGraphCallOptionsFromConfigs_ClonesValueType(t *testing.T) {

--- a/model/gemini/gemini.go
+++ b/model/gemini/gemini.go
@@ -12,6 +12,7 @@ package gemini
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -34,6 +35,8 @@ import (
 // treats the corresponding tool result as orphaned and downgrades it to a user
 // message, injecting "[orphan_tool_result]" noise into the conversation history.
 var geminiCallSeq uint64
+
+const geminiThoughtSignatureKey = "thought_signature"
 
 // Model implements the model.Model interface for Gemini API.
 type Model struct {
@@ -431,6 +434,7 @@ func (m *Model) convertContentBlock(candidates []*genai.Candidate) (model.Messag
 		reasoningBuilder strings.Builder
 		toolCalls        []model.ToolCall
 		finishReason     string
+		reasoningSig     string
 	)
 	for _, candidate := range candidates {
 		if candidate.FinishReason != "" {
@@ -459,22 +463,31 @@ func (m *Model) convertContentBlock(candidates []*genai.Candidate) (model.Messag
 					if id == "" {
 						id = fmt.Sprintf("gemini_call_%d", atomic.AddUint64(&geminiCallSeq, 1))
 					}
-					toolCalls = append(toolCalls, model.ToolCall{
+					toolCall := model.ToolCall{
 						ID: id,
 						Function: model.FunctionDefinitionParam{
 							Name:      part.FunctionCall.Name,
 							Arguments: args,
 						},
-					})
+					}
+					if len(part.ThoughtSignature) > 0 {
+						toolCall.ExtraFields = map[string]any{
+							geminiThoughtSignatureKey: append([]byte(nil), part.ThoughtSignature...),
+						}
+					}
+					toolCalls = append(toolCalls, toolCall)
+				} else if len(part.ThoughtSignature) > 0 {
+					reasoningSig = base64.StdEncoding.EncodeToString(part.ThoughtSignature)
 				}
 			}
 		}
 	}
 	return model.Message{
-		Role:             model.RoleAssistant,
-		Content:          textBuilder.String(),
-		ReasoningContent: reasoningBuilder.String(),
-		ToolCalls:        toolCalls,
+		Role:               model.RoleAssistant,
+		Content:            textBuilder.String(),
+		ReasoningContent:   reasoningBuilder.String(),
+		ReasoningSignature: reasoningSig,
+		ToolCalls:          toolCalls,
 	}, finishReason
 }
 
@@ -676,13 +689,19 @@ func (m *Model) buildChatConfig(request *model.Request) *genai.GenerateContentCo
 // buildThinkingConfig converts our Request to Gemini request ThinkingConfig
 func (m *Model) buildThinkingConfig(request *model.Request) *genai.ThinkingConfig {
 	res := &genai.ThinkingConfig{}
-	if request.ThinkingTokens != nil {
+	if request.ThinkingLevel != nil {
+		res.ThinkingLevel = normalizeThinkingLevel(*request.ThinkingLevel)
+	} else if request.ThinkingTokens != nil {
 		res.ThinkingBudget = genai.Ptr(int32(*request.ThinkingTokens))
 	}
 	if request.ThinkingEnabled != nil {
 		res.IncludeThoughts = *request.ThinkingEnabled
 	}
 	return res
+}
+
+func normalizeThinkingLevel(level string) genai.ThinkingLevel {
+	return genai.ThinkingLevel(strings.TrimSpace(level))
 }
 
 // convertMessages converts our Message format to OpenAI's format.
@@ -727,10 +746,20 @@ func (m *Model) convertMessageContent(
 	}
 	// Add Content as a text part if present.
 	if msg.Content != "" {
-		contentParts = append(
-			contentParts,
-			genai.NewContentFromText(msg.Content, genai.Role(role)),
-		)
+		if signature := thoughtSignatureFromString(msg.ReasoningSignature); len(signature) > 0 {
+			contentParts = append(
+				contentParts,
+				genai.NewContentFromParts([]*genai.Part{{
+					Text:             msg.Content,
+					ThoughtSignature: signature,
+				}}, genai.Role(role)),
+			)
+		} else {
+			contentParts = append(
+				contentParts,
+				genai.NewContentFromText(msg.Content, genai.Role(role)),
+			)
+		}
 	}
 	for _, part := range msg.ContentParts {
 		contentPart := m.convertContentPart(part)
@@ -740,7 +769,69 @@ func (m *Model) convertMessageContent(
 		// For non-file or non-skipped file types, add to contentParts.
 		contentParts = append(contentParts, genai.NewContentFromParts([]*genai.Part{contentPart}, genai.Role(role)))
 	}
+	for _, toolCall := range msg.ToolCalls {
+		contentPart := m.convertToolCallPart(toolCall)
+		if contentPart == nil {
+			continue
+		}
+		contentParts = append(contentParts, genai.NewContentFromParts([]*genai.Part{contentPart}, genai.Role(role)))
+	}
 	return contentParts
+}
+
+func (m *Model) convertToolCallPart(toolCall model.ToolCall) *genai.Part {
+	if toolCall.Function.Name == "" {
+		return nil
+	}
+	args := map[string]any{}
+	if len(toolCall.Function.Arguments) > 0 {
+		if err := json.Unmarshal(toolCall.Function.Arguments, &args); err != nil {
+			args = map[string]any{}
+		}
+	}
+	part := &genai.Part{
+		FunctionCall: &genai.FunctionCall{
+			ID:   toolCall.ID,
+			Name: toolCall.Function.Name,
+			Args: args,
+		},
+	}
+	if signature := thoughtSignatureFromExtraFields(toolCall.ExtraFields); len(signature) > 0 {
+		part.ThoughtSignature = signature
+	}
+	return part
+}
+
+func thoughtSignatureFromExtraFields(extraFields map[string]any) []byte {
+	if len(extraFields) == 0 {
+		return nil
+	}
+	raw, ok := extraFields[geminiThoughtSignatureKey]
+	if !ok {
+		return nil
+	}
+	switch v := raw.(type) {
+	case []byte:
+		return append([]byte(nil), v...)
+	case string:
+		if decoded, err := base64.StdEncoding.DecodeString(v); err == nil {
+			return decoded
+		}
+		return []byte(v)
+	default:
+		return nil
+	}
+}
+
+func thoughtSignatureFromString(signature string) []byte {
+	signature = strings.TrimSpace(signature)
+	if signature == "" {
+		return nil
+	}
+	if decoded, err := base64.StdEncoding.DecodeString(signature); err == nil {
+		return decoded
+	}
+	return []byte(signature)
 }
 
 func (m *Model) convertTools(tools map[string]tool.Tool) []*genai.Tool {

--- a/model/gemini/gemini_test.go
+++ b/model/gemini/gemini_test.go
@@ -11,6 +11,7 @@ package gemini
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"iter"
@@ -521,6 +522,7 @@ func TestModel_buildChatConfig(t *testing.T) {
 		PresencePenalty  = 0.1
 		FrequencyPenalty = 0.1
 		ThinkingTokens   = 100
+		ThinkingLevel    = "low"
 		ThinkingEnabled  = true
 		Stop             = []string{"Stop"}
 	)
@@ -560,6 +562,7 @@ func TestModel_buildChatConfig(t *testing.T) {
 						FrequencyPenalty: &FrequencyPenalty,
 						Stop:             Stop,
 						ThinkingTokens:   &ThinkingTokens,
+						ThinkingLevel:    &ThinkingLevel,
 						ThinkingEnabled:  &ThinkingEnabled,
 					},
 				},
@@ -572,7 +575,7 @@ func TestModel_buildChatConfig(t *testing.T) {
 				PresencePenalty:  genai.Ptr(float32(PresencePenalty)),
 				FrequencyPenalty: genai.Ptr(float32(FrequencyPenalty)),
 				ThinkingConfig: &genai.ThinkingConfig{
-					ThinkingBudget:  genai.Ptr(int32(ThinkingTokens)),
+					ThinkingLevel:   genai.ThinkingLevel(ThinkingLevel),
 					IncludeThoughts: true,
 				},
 			},
@@ -626,6 +629,7 @@ func TestModel_buildFinalResponse(t *testing.T) {
 	now := time.Now()
 	functionArgs := map[string]any{"args": "1"}
 	functionArgsBytes, _ := json.Marshal(functionArgs)
+	thoughtSignature := []byte("thought-signature")
 
 	type fields struct {
 		m *Model
@@ -687,6 +691,7 @@ func TestModel_buildFinalResponse(t *testing.T) {
 											Name: "function_call",
 											Args: functionArgs,
 										},
+										ThoughtSignature: thoughtSignature,
 									},
 									{Text: "Answer"},
 								},
@@ -723,6 +728,9 @@ func TestModel_buildFinalResponse(t *testing.T) {
 									Function: model.FunctionDefinitionParam{
 										Name:      "function_call",
 										Arguments: functionArgsBytes,
+									},
+									ExtraFields: map[string]any{
+										geminiThoughtSignatureKey: thoughtSignature,
 									},
 								},
 							},
@@ -809,6 +817,7 @@ func TestModel_buildChunkResponse(t *testing.T) {
 	now := time.Now()
 	functionArgs := map[string]any{"args": "1"}
 	functionArgsBytes, _ := json.Marshal(functionArgs)
+	thoughtSignature := []byte("thought-signature")
 
 	type fields struct {
 		m *Model
@@ -852,6 +861,7 @@ func TestModel_buildChunkResponse(t *testing.T) {
 											Name: "function_call",
 											Args: functionArgs,
 										},
+										ThoughtSignature: thoughtSignature,
 									},
 									{Text: "Answer"},
 								},
@@ -889,6 +899,9 @@ func TestModel_buildChunkResponse(t *testing.T) {
 										Name:      "function_call",
 										Arguments: functionArgsBytes,
 									},
+									ExtraFields: map[string]any{
+										geminiThoughtSignatureKey: thoughtSignature,
+									},
 								},
 							},
 						},
@@ -912,6 +925,209 @@ func TestModel_buildChunkResponse(t *testing.T) {
 			assert.Equal(t, tt.want, response)
 		})
 	}
+}
+
+func TestModel_buildChatConfig_ThinkingTokensFallback(t *testing.T) {
+	thinkingTokens := 100
+	req := &model.Request{
+		GenerationConfig: model.GenerationConfig{
+			ThinkingTokens: &thinkingTokens,
+		},
+	}
+
+	cfg := (&Model{}).buildChatConfig(req)
+
+	require.NotNil(t, cfg.ThinkingConfig)
+	require.NotNil(t, cfg.ThinkingConfig.ThinkingBudget)
+	assert.Equal(t, int32(thinkingTokens), *cfg.ThinkingConfig.ThinkingBudget)
+	assert.Empty(t, cfg.ThinkingConfig.ThinkingLevel)
+}
+
+func TestModel_buildThinkingConfig_ThinkingLevelTakesPrecedenceOverBudget(t *testing.T) {
+	thinkingTokens := 100
+	thinkingLevel := "low"
+	req := &model.Request{
+		GenerationConfig: model.GenerationConfig{
+			ThinkingTokens: &thinkingTokens,
+			ThinkingLevel:  &thinkingLevel,
+		},
+	}
+
+	cfg := (&Model{}).buildThinkingConfig(req)
+
+	require.NotNil(t, cfg)
+	require.Nil(t, cfg.ThinkingBudget)
+	assert.Equal(t, genai.ThinkingLevel(thinkingLevel), cfg.ThinkingLevel)
+}
+
+func TestModel_buildFinalResponse_PreservesTextThoughtSignature(t *testing.T) {
+	now := time.Now()
+	thoughtSignature := []byte("text-thought-signature")
+	response := (&Model{}).buildFinalResponse(&genai.GenerateContentResponse{
+		ResponseID:   "3",
+		CreateTime:   now,
+		ModelVersion: "pro-v1",
+		Candidates: []*genai.Candidate{
+			{
+				Content: &genai.Content{
+					Parts: []*genai.Part{
+						{
+							Text:             "Answer",
+							ThoughtSignature: thoughtSignature,
+						},
+					},
+				},
+			},
+		},
+	})
+
+	require.Len(t, response.Choices, 1)
+	msg := response.Choices[0].Message
+	assert.Equal(t, "Answer", msg.Content)
+	assert.Equal(t, base64.StdEncoding.EncodeToString(thoughtSignature), msg.ReasoningSignature)
+}
+
+func TestModel_convertMessageContent_PreservesTextThoughtSignature(t *testing.T) {
+	signature := []byte("text-thought-signature")
+	message := model.Message{
+		Role:               model.RoleAssistant,
+		Content:            "Answer",
+		ReasoningSignature: base64.StdEncoding.EncodeToString(signature),
+	}
+
+	contents := (&Model{}).convertMessageContent(message)
+
+	require.Len(t, contents, 1)
+	require.Equal(t, genai.RoleModel, contents[0].Role)
+	require.Len(t, contents[0].Parts, 1)
+	assert.Equal(t, "Answer", contents[0].Parts[0].Text)
+	assert.Equal(t, signature, contents[0].Parts[0].ThoughtSignature)
+}
+
+func TestModel_convertMessageContent_PreservesFunctionCallThoughtSignature(t *testing.T) {
+	signature := []byte("thought-signature")
+	args := []byte(`{"city":"shenzhen"}`)
+	message := model.Message{
+		Role: model.RoleAssistant,
+		ToolCalls: []model.ToolCall{
+			{
+				ID: "call-1",
+				Function: model.FunctionDefinitionParam{
+					Name:      "weather",
+					Arguments: args,
+				},
+				ExtraFields: map[string]any{
+					geminiThoughtSignatureKey: signature,
+				},
+			},
+		},
+	}
+
+	contents := (&Model{}).convertMessageContent(message)
+
+	require.Len(t, contents, 1)
+	require.Equal(t, genai.RoleModel, contents[0].Role)
+	require.Len(t, contents[0].Parts, 1)
+	part := contents[0].Parts[0]
+	require.NotNil(t, part.FunctionCall)
+	assert.Equal(t, "call-1", part.FunctionCall.ID)
+	assert.Equal(t, "weather", part.FunctionCall.Name)
+	assert.Equal(t, signature, part.ThoughtSignature)
+}
+
+func TestModel_convertToolCallPart_EdgeCases(t *testing.T) {
+	t.Run("empty function name returns nil", func(t *testing.T) {
+		assert.Nil(t, (&Model{}).convertToolCallPart(model.ToolCall{}))
+	})
+
+	t.Run("invalid json args falls back to empty args", func(t *testing.T) {
+		part := (&Model{}).convertToolCallPart(model.ToolCall{
+			ID: "call-1",
+			Function: model.FunctionDefinitionParam{
+				Name:      "weather",
+				Arguments: []byte(`{"city"`),
+			},
+		})
+
+		require.NotNil(t, part)
+		require.NotNil(t, part.FunctionCall)
+		assert.Empty(t, part.FunctionCall.Args)
+	})
+}
+
+func TestThoughtSignatureFromExtraFields(t *testing.T) {
+	signature := []byte("thought-signature")
+	encoded := base64.StdEncoding.EncodeToString(signature)
+
+	tests := []struct {
+		name        string
+		extraFields map[string]any
+		want        []byte
+	}{
+		{
+			name: "nil extra fields",
+		},
+		{
+			name:        "missing signature key",
+			extraFields: map[string]any{"other": signature},
+		},
+		{
+			name:        "byte slice signature is copied",
+			extraFields: map[string]any{geminiThoughtSignatureKey: signature},
+			want:        signature,
+		},
+		{
+			name:        "base64 string signature decodes",
+			extraFields: map[string]any{geminiThoughtSignatureKey: encoded},
+			want:        signature,
+		},
+		{
+			name:        "plain string signature falls back to raw bytes",
+			extraFields: map[string]any{geminiThoughtSignatureKey: "plain-signature"},
+			want:        []byte("plain-signature"),
+		},
+		{
+			name:        "unsupported type returns nil",
+			extraFields: map[string]any{geminiThoughtSignatureKey: 123},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := thoughtSignatureFromExtraFields(tt.extraFields)
+			assert.Equal(t, tt.want, got)
+			if raw, ok := tt.extraFields[geminiThoughtSignatureKey].([]byte); ok && len(got) > 0 {
+				got[0] = 'X'
+				assert.NotEqual(t, got[0], raw[0], "expected signature bytes to be copied")
+			}
+		})
+	}
+}
+
+func TestThoughtSignatureFromString(t *testing.T) {
+	signature := []byte("text-thought-signature")
+	encoded := base64.StdEncoding.EncodeToString(signature)
+
+	tests := []struct {
+		name string
+		in   string
+		want []byte
+	}{
+		{name: "empty"},
+		{name: "whitespace", in: " \t\n "},
+		{name: "base64", in: " " + encoded + " ", want: signature},
+		{name: "plain", in: " plain-signature ", want: []byte("plain-signature")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, thoughtSignatureFromString(tt.in))
+		})
+	}
+}
+
+func TestNormalizeThinkingLevel_TrimsWhitespace(t *testing.T) {
+	assert.Equal(t, genai.ThinkingLevel("low"), normalizeThinkingLevel(" low "))
 }
 
 func TestNew(t *testing.T) {

--- a/model/request.go
+++ b/model/request.go
@@ -417,6 +417,10 @@ type GenerationConfig struct {
 	// ThinkingTokens controls the fixed thinking token budget for providers that support it.
 	// Anthropic adaptive-thinking models ignore this field and use ReasoningEffort instead.
 	ThinkingTokens *int `json:"thinking_tokens,omitempty"`
+
+	// ThinkingLevel controls the qualitative thinking level for providers that support it.
+	// Gemini 3 uses this field for thinkingConfig.thinkingLevel.
+	ThinkingLevel *string `json:"thinking_level,omitempty"`
 }
 
 // GenerationConfigPatch selectively overrides fields in GenerationConfig.
@@ -440,6 +444,7 @@ type GenerationConfigPatch struct {
 	ReasoningEffort  *string  `json:"reasoning_effort,omitempty"`
 	ThinkingEnabled  *bool    `json:"thinking_enabled,omitempty"`
 	ThinkingTokens   *int     `json:"thinking_tokens,omitempty"`
+	ThinkingLevel    *string  `json:"thinking_level,omitempty"`
 }
 
 // ApplyGenerationConfigPatch applies patch to base and returns the merged
@@ -477,6 +482,9 @@ func ApplyGenerationConfigPatch(
 	}
 	if patch.ThinkingTokens != nil {
 		base.ThinkingTokens = patch.ThinkingTokens
+	}
+	if patch.ThinkingLevel != nil {
+		base.ThinkingLevel = patch.ThinkingLevel
 	}
 	return base
 }

--- a/model/request_test.go
+++ b/model/request_test.go
@@ -289,6 +289,7 @@ func TestApplyGenerationConfigPatch(t *testing.T) {
 		ReasoningEffort:  StringPtr("low"),
 		ThinkingEnabled:  BoolPtr(true),
 		ThinkingTokens:   IntPtr(100),
+		ThinkingLevel:    StringPtr("medium"),
 	}
 	patch := GenerationConfigPatch{
 		MaxTokens:        IntPtr(20),
@@ -301,6 +302,7 @@ func TestApplyGenerationConfigPatch(t *testing.T) {
 		ReasoningEffort:  StringPtr("high"),
 		ThinkingEnabled:  BoolPtr(false),
 		ThinkingTokens:   IntPtr(200),
+		ThinkingLevel:    StringPtr("low"),
 	}
 	got := ApplyGenerationConfigPatch(base, patch)
 	require.NotNil(t, got.MaxTokens)
@@ -321,6 +323,8 @@ func TestApplyGenerationConfigPatch(t *testing.T) {
 	require.False(t, *got.ThinkingEnabled)
 	require.NotNil(t, got.ThinkingTokens)
 	require.Equal(t, 200, *got.ThinkingTokens)
+	require.NotNil(t, got.ThinkingLevel)
+	require.Equal(t, "low", *got.ThinkingLevel)
 
 	patch.Stop[0] = "Y"
 	require.Equal(t, []string{"X"}, got.Stop)


### PR DESCRIPTION
## Summary

* Add Gemini `thinkingLevel` request support via `model.GenerationConfig`.
* Preserve Gemini thought signatures across text and function-call turns.
* Add focused unit tests and opt-in integration coverage for Gemini text generation and thought signature round trip.

## Test plan

* `go test -count=1 ./model`
* `cd model/gemini && go test -count=1 ./...`
* `GEMINI_INTEGRATION_TEST=1 GEMINI_API_KEY=*** go test -count=1 -run 'TestGeminiIntegration_' -v ./...`