### PR TITLE
evaluation/workflow/promptiter: reduce LLM prompt contract noise

### DIFF
--- a/evaluation/workflow/promptiter/aggregator/aggregator.go
+++ b/evaluation/workflow/promptiter/aggregator/aggregator.go
@@ -50,6 +50,15 @@ type Result struct {
 	Gradient *promptiter.AggregatedSurfaceGradient
 }
 
+type aggregatedGradientProposal struct {
+	Gradients []gradientProposal
+}
+
+type gradientProposal struct {
+	Severity promptiter.LossSeverity
+	Gradient string
+}
+
 // aggregator is the default Aggregator implementation used by engine.
 type aggregator struct {
 	// runner executes model-assisted aggregation workflows when required.
@@ -135,16 +144,16 @@ func (a *aggregator) Aggregate(ctx context.Context, request *Request) (*Result, 
 	if err != nil {
 		return nil, fmt.Errorf("capture runner output: %w", err)
 	}
-	gradient, err := idecode.DecodeOutputJSON[promptiter.AggregatedSurfaceGradient](output)
+	proposal, err := idecode.DecodeOutputJSON[aggregatedGradientProposal](output)
 	if err != nil {
-		return nil, fmt.Errorf("decode aggregated gradient: %w", err)
+		return nil, fmt.Errorf("decode aggregated gradient proposal: %w", err)
 	}
-	if gradient == nil {
-		return nil, errors.New("aggregated gradient is empty")
+	if proposal == nil {
+		return nil, errors.New("aggregated gradient proposal is empty")
 	}
-	gradient, err = sanitizeAggregatedGradient(normalizedRequest, gradient)
+	gradient, err := sanitizeAggregatedGradientProposal(normalizedRequest, proposal)
 	if err != nil {
-		return nil, fmt.Errorf("sanitize aggregated gradient: %w", err)
+		return nil, fmt.Errorf("sanitize aggregated gradient proposal: %w", err)
 	}
 	return &Result{Gradient: gradient}, nil
 }
@@ -228,61 +237,31 @@ func compareGradients(left promptiter.SurfaceGradient, right promptiter.SurfaceG
 	return strings.Compare(left.Gradient, right.Gradient)
 }
 
-func sanitizeAggregatedGradient(
+func sanitizeAggregatedGradientProposal(
 	request *Request,
-	gradient *promptiter.AggregatedSurfaceGradient,
+	proposal *aggregatedGradientProposal,
 ) (*promptiter.AggregatedSurfaceGradient, error) {
 	if request == nil {
 		return nil, errors.New("request is nil")
 	}
-	if gradient == nil {
-		return nil, errors.New("aggregated gradient is nil")
-	}
-	if surfaceID := gradient.SurfaceID; surfaceID != "" && surfaceID != request.SurfaceID {
-		return nil, fmt.Errorf(
-			"aggregated gradient surface id %q does not match request surface id %q",
-			gradient.SurfaceID,
-			request.SurfaceID,
-		)
-	}
-	if nodeID := gradient.NodeID; nodeID != "" && nodeID != request.NodeID {
-		return nil, fmt.Errorf(
-			"aggregated gradient node id %q does not match request node id %q",
-			gradient.NodeID,
-			request.NodeID,
-		)
-	}
-	if gradient.Type != "" && gradient.Type != request.Type {
-		return nil, fmt.Errorf(
-			"aggregated gradient surface type %q does not match request surface type %q",
-			gradient.Type,
-			request.Type,
-		)
+	if proposal == nil {
+		return nil, errors.New("aggregated gradient proposal is nil")
 	}
 	resolved := &promptiter.AggregatedSurfaceGradient{
 		SurfaceID: request.SurfaceID,
 		NodeID:    request.NodeID,
 		Type:      request.Type,
-		Gradients: make([]promptiter.SurfaceGradient, 0, len(gradient.Gradients)),
+		Gradients: make([]promptiter.SurfaceGradient, 0, len(proposal.Gradients)),
 	}
-	for _, item := range gradient.Gradients {
-		surfaceID := item.SurfaceID
-		switch {
-		case surfaceID == "":
-			item.SurfaceID = request.SurfaceID
-		case surfaceID != request.SurfaceID:
-			return nil, fmt.Errorf(
-				"aggregated gradient item surface id %q does not match request surface id %q",
-				item.SurfaceID,
-				request.SurfaceID,
-			)
-		default:
-			item.SurfaceID = request.SurfaceID
-		}
+	for _, item := range proposal.Gradients {
 		if item.Gradient == "" {
 			continue
 		}
-		resolved.Gradients = append(resolved.Gradients, item)
+		resolved.Gradients = append(resolved.Gradients, promptiter.SurfaceGradient{
+			SurfaceID: request.SurfaceID,
+			Severity:  item.Severity,
+			Gradient:  item.Gradient,
+		})
 	}
 	if len(resolved.Gradients) == 0 {
 		return nil, errors.New("aggregated gradient is empty")

--- a/evaluation/workflow/promptiter/aggregator/aggregator_test.go
+++ b/evaluation/workflow/promptiter/aggregator/aggregator_test.go
@@ -107,26 +107,15 @@ func TestAggregateUsesRunnerStructuredOutput(t *testing.T) {
 						{Message: model.NewAssistantMessage("ignored")},
 					},
 				},
-				event.WithStructuredOutputPayload(&promptiter.AggregatedSurfaceGradient{
-					SurfaceID: "surf_1",
-					NodeID:    "node_1",
-					Type:      astructure.SurfaceTypeInstruction,
-					Gradients: []promptiter.SurfaceGradient{
+				event.WithStructuredOutputPayload(&aggregatedGradientProposal{
+					Gradients: []gradientProposal{
 						{
-							EvalSetID:  "set_b",
-							EvalCaseID: "case_2",
-							StepID:     "s2",
-							SurfaceID:  "surf_1",
-							Severity:   promptiter.LossSeverityP2,
-							Gradient:   "  merged detail  ",
+							Severity: promptiter.LossSeverityP2,
+							Gradient: "  merged detail  ",
 						},
 						{
-							EvalSetID:  "set_a",
-							EvalCaseID: "case_1",
-							StepID:     "s1",
-							SurfaceID:  "surf_1",
-							Severity:   promptiter.LossSeverityP0,
-							Gradient:   "  merged grounding  ",
+							Severity: promptiter.LossSeverityP0,
+							Gradient: "  merged grounding  ",
 						},
 					},
 				}),
@@ -215,20 +204,14 @@ func TestAggregateUsesRunnerStructuredOutput(t *testing.T) {
 			Type:      astructure.SurfaceTypeInstruction,
 			Gradients: []promptiter.SurfaceGradient{
 				{
-					EvalSetID:  "set_a",
-					EvalCaseID: "case_1",
-					StepID:     "s1",
-					SurfaceID:  "surf_1",
-					Severity:   promptiter.LossSeverityP0,
-					Gradient:   "  merged grounding  ",
+					SurfaceID: "surf_1",
+					Severity:  promptiter.LossSeverityP0,
+					Gradient:  "  merged grounding  ",
 				},
 				{
-					EvalSetID:  "set_b",
-					EvalCaseID: "case_2",
-					StepID:     "s2",
-					SurfaceID:  "surf_1",
-					Severity:   promptiter.LossSeverityP2,
-					Gradient:   "  merged detail  ",
+					SurfaceID: "surf_1",
+					Severity:  promptiter.LossSeverityP2,
+					Gradient:  "  merged detail  ",
 				},
 			},
 		},
@@ -244,7 +227,7 @@ func TestAggregateUsesDefaultUUIDSessionID(t *testing.T) {
 				&model.Response{
 					Done: true,
 					Choices: []model.Choice{
-						{Message: model.NewAssistantMessage(`{"Gradients":[{"EvalSetID":"set_a","EvalCaseID":"case_1","StepID":"s1","SurfaceID":"surf_1","Severity":"P1","Gradient":"keep citation"}]}`)},
+						{Message: model.NewAssistantMessage(`{"Gradients":[{"Severity":"P1","Gradient":"keep citation"}]}`)},
 					},
 				},
 			),
@@ -277,7 +260,7 @@ func TestAggregateUsesDefaultUUIDSessionID(t *testing.T) {
 	assert.Equal(t, model.StructuredOutputJSONSchema, r.lastRunOpts.StructuredOutput.Type)
 	assert.Equal(
 		t,
-		reflect.TypeOf((*promptiter.AggregatedSurfaceGradient)(nil)),
+		reflect.TypeOf((*aggregatedGradientProposal)(nil)),
 		r.lastRunOpts.StructuredOutputType,
 	)
 }
@@ -292,7 +275,7 @@ func TestAggregateFallsBackToFinalContent(t *testing.T) {
 					Done: true,
 					Choices: []model.Choice{
 						{
-							Message: model.NewAssistantMessage(`{"SurfaceID":"surf_1","NodeID":"node_1","Type":"instruction","Gradients":[{"EvalSetID":"set_a","EvalCaseID":"case_1","StepID":"s1","SurfaceID":"surf_1","Severity":"P1","Gradient":"keep citation"}]}`),
+							Message: model.NewAssistantMessage(`{"Gradients":[{"Severity":"P1","Gradient":"keep citation"}]}`),
 						},
 					},
 				},
@@ -332,17 +315,10 @@ func TestAggregateRejectsBareGradientArrayOutput(t *testing.T) {
 					"aggregator",
 					&model.Response{Done: true},
 					event.WithStructuredOutputPayload(map[string]any{
-						"SurfaceID": "surf_1",
-						"NodeID":    "node_1",
-						"Type":      "instruction",
 						"Gradients": []map[string]any{
 							{
-								"EvalSetID":  "set_a",
-								"EvalCaseID": "case_1",
-								"StepID":     "s1",
-								"SurfaceID":  "surf_1",
-								"Severity":   "P1",
-								"Gradient":   "keep citation",
+								"Severity": "P1",
+								"Gradient": "keep citation",
 							},
 						},
 					}),
@@ -634,7 +610,7 @@ func TestAggregateRejectsMessageBuildAndEmptyDecodedGradient(t *testing.T) {
 			Gradients: []promptiter.SurfaceGradient{{SurfaceID: "surf_1", Gradient: "citation issue"}},
 		})
 		assert.Nil(t, result)
-		assert.EqualError(t, runErr, "sanitize aggregated gradient: aggregated gradient is empty")
+		assert.EqualError(t, runErr, "sanitize aggregated gradient proposal: aggregated gradient is empty")
 	})
 }
 
@@ -808,38 +784,23 @@ func TestNormalizeRequestAndSanitizeAggregatedGradient(t *testing.T) {
 	})
 	assert.Nil(t, request)
 	assert.EqualError(t, err, "normalize gradients: gradient surface id is empty")
-	gradient, err := sanitizeAggregatedGradient(nil, &promptiter.AggregatedSurfaceGradient{})
+	gradient, err := sanitizeAggregatedGradientProposal(nil, &aggregatedGradientProposal{})
 	assert.Nil(t, gradient)
 	assert.EqualError(t, err, "request is nil")
-	gradient, err = sanitizeAggregatedGradient(validRequest, nil)
+	gradient, err = sanitizeAggregatedGradientProposal(validRequest, nil)
 	assert.Nil(t, gradient)
-	assert.EqualError(t, err, "aggregated gradient is nil")
-	gradient, err = sanitizeAggregatedGradient(validRequest, &promptiter.AggregatedSurfaceGradient{
-		SurfaceID: "other",
-	})
-	assert.Nil(t, gradient)
-	assert.EqualError(t, err, `aggregated gradient surface id "other" does not match request surface id "surf_1"`)
-	gradient, err = sanitizeAggregatedGradient(validRequest, &promptiter.AggregatedSurfaceGradient{
-		NodeID: "other",
-	})
-	assert.Nil(t, gradient)
-	assert.EqualError(t, err, `aggregated gradient node id "other" does not match request node id "node_1"`)
-	gradient, err = sanitizeAggregatedGradient(validRequest, &promptiter.AggregatedSurfaceGradient{
-		Type: astructure.SurfaceTypeModel,
-	})
-	assert.Nil(t, gradient)
-	assert.EqualError(t, err, `aggregated gradient surface type "model" does not match request surface type "instruction"`)
-	gradient, err = sanitizeAggregatedGradient(validRequest, &promptiter.AggregatedSurfaceGradient{
-		Gradients: []promptiter.SurfaceGradient{
+	assert.EqualError(t, err, "aggregated gradient proposal is nil")
+	gradient, err = sanitizeAggregatedGradientProposal(validRequest, &aggregatedGradientProposal{
+		Gradients: []gradientProposal{
 			{Gradient: ""},
 		},
 	})
 	assert.Nil(t, gradient)
 	assert.EqualError(t, err, "aggregated gradient is empty")
-	gradient, err = sanitizeAggregatedGradient(validRequest, &promptiter.AggregatedSurfaceGradient{
-		Gradients: []promptiter.SurfaceGradient{
+	gradient, err = sanitizeAggregatedGradientProposal(validRequest, &aggregatedGradientProposal{
+		Gradients: []gradientProposal{
 			{Gradient: "detail", Severity: promptiter.LossSeverityP2},
-			{SurfaceID: "surf_1", Gradient: "grounding", Severity: promptiter.LossSeverityP0},
+			{Gradient: "grounding", Severity: promptiter.LossSeverityP0},
 		},
 	})
 	assert.NoError(t, err)
@@ -848,13 +809,7 @@ func TestNormalizeRequestAndSanitizeAggregatedGradient(t *testing.T) {
 	assert.Equal(t, "node_1", gradient.NodeID)
 	assert.Equal(t, astructure.SurfaceTypeInstruction, gradient.Type)
 	assert.Equal(t, "grounding", gradient.Gradients[0].Gradient)
-	gradient, err = sanitizeAggregatedGradient(validRequest, &promptiter.AggregatedSurfaceGradient{
-		Gradients: []promptiter.SurfaceGradient{
-			{SurfaceID: "other", Gradient: "grounding"},
-		},
-	})
-	assert.Nil(t, gradient)
-	assert.EqualError(t, err, `aggregated gradient item surface id "other" does not match request surface id "surf_1"`)
+	assert.Equal(t, "surf_1", gradient.Gradients[0].SurfaceID)
 }
 
 func TestCompareGradientsOrdersByAllTieBreakers(t *testing.T) {

--- a/evaluation/workflow/promptiter/aggregator/message.go
+++ b/evaluation/workflow/promptiter/aggregator/message.go
@@ -15,6 +15,8 @@ import (
 	"fmt"
 	"text/template"
 
+	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 )
 
@@ -24,12 +26,12 @@ type MessageBuilder func(ctx context.Context, request *Request) (*model.Message,
 const defaultMessageTemplateText = `Aggregate PromptIter gradients for a single surface.
 
 You will receive one aggregation request with all sample-level gradients that belong to the same surface.
-Return exactly one JSON object that can be unmarshaled into promptiter.AggregatedSurfaceGradient.
+Return exactly one JSON object with a Gradients field.
 
 Requirements:
 - Keep the response as raw JSON only.
 - Do not wrap the response in markdown code fences.
-- Preserve the request surface identity and surface type.
+- Return only merged gradient items. The caller will attach the target surface identity and type.
 - Merge duplicated or overlapping gradients when appropriate.
 - Drop clearly empty or redundant gradient items.
 
@@ -48,12 +50,43 @@ func defaultMessageBuilder() MessageBuilder {
 	}
 	return func(ctx context.Context, request *Request) (*model.Message, error) {
 		var content bytes.Buffer
-		if err := tmpl.Execute(&content, request); err != nil {
+		if err := tmpl.Execute(&content, newPromptData(request)); err != nil {
 			return nil, fmt.Errorf("render aggregation message template: %w", err)
 		}
 		message := model.NewUserMessage(content.String())
 		return &message, nil
 	}
+}
+
+type promptData struct {
+	Surface   promptSurface
+	Gradients []promptGradient
+}
+
+type promptSurface struct {
+	Type astructure.SurfaceType
+}
+
+type promptGradient struct {
+	Severity promptiter.LossSeverity
+	Gradient string
+}
+
+func newPromptData(request *Request) promptData {
+	if request == nil {
+		return promptData{}
+	}
+	data := promptData{
+		Surface: promptSurface{Type: request.Type},
+	}
+	data.Gradients = make([]promptGradient, 0, len(request.Gradients))
+	for _, gradient := range request.Gradients {
+		data.Gradients = append(data.Gradients, promptGradient{
+			Severity: gradient.Severity,
+			Gradient: gradient.Gradient,
+		})
+	}
+	return data
 }
 
 // toPrettyJSON renders one value as indented JSON for prompts.

--- a/evaluation/workflow/promptiter/aggregator/options.go
+++ b/evaluation/workflow/promptiter/aggregator/options.go
@@ -34,7 +34,7 @@ func newOptions(opt ...Option) *options {
 			agent.WithStructuredOutputJSON(
 				new(aggregatedGradientProposal),
 				true,
-				"One aggregated PromptIter surface gradient.",
+				"One aggregated PromptIter gradient proposal.",
 			),
 		},
 		messageBuilder:    defaultMessageBuilder(),

--- a/evaluation/workflow/promptiter/aggregator/options.go
+++ b/evaluation/workflow/promptiter/aggregator/options.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/google/uuid"
 	"trpc.group/trpc-go/trpc-agent-go/agent"
-	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter"
 )
 
 // options stores optional aggregation behavior.
@@ -33,7 +32,7 @@ func newOptions(opt ...Option) *options {
 	opts := &options{
 		runOptions: []agent.RunOption{
 			agent.WithStructuredOutputJSON(
-				new(promptiter.AggregatedSurfaceGradient),
+				new(aggregatedGradientProposal),
 				true,
 				"One aggregated PromptIter surface gradient.",
 			),

--- a/evaluation/workflow/promptiter/aggregator/options_test.go
+++ b/evaluation/workflow/promptiter/aggregator/options_test.go
@@ -48,10 +48,16 @@ func TestDefaultMessageBuilder(t *testing.T) {
 	}
 	assert.Equal(t, model.RoleUser, msg.Role)
 	assert.Contains(t, msg.Content, "Aggregate PromptIter gradients for a single surface.")
+	assert.Contains(t, msg.Content, "Return only merged gradient items.")
 	assert.NotContains(t, msg.Content, "Surface ID:")
 	assert.NotContains(t, msg.Content, "Node ID:")
 	assert.NotContains(t, msg.Content, "Surface Type:")
 	assert.NotContains(t, msg.Content, "Gradient Count:")
+	assert.NotContains(t, msg.Content, "SurfaceID")
+	assert.NotContains(t, msg.Content, "NodeID")
+	assert.NotContains(t, msg.Content, "EvalSetID")
+	assert.NotContains(t, msg.Content, "EvalCaseID")
+	assert.NotContains(t, msg.Content, "StepID")
 
 	payloadContent, ok := extractRequestJSON(msg.Content)
 	assert.True(t, ok)
@@ -59,21 +65,15 @@ func TestDefaultMessageBuilder(t *testing.T) {
 		return
 	}
 
-	var payload Request
+	var payload promptData
 	err = json.Unmarshal([]byte(payloadContent), &payload)
 	assert.NoError(t, err)
-	assert.Equal(t, &Request{
-		SurfaceID: "surf_1",
-		NodeID:    "node_1",
-		Type:      astructure.SurfaceTypeInstruction,
-		Gradients: []promptiter.SurfaceGradient{
+	assert.Equal(t, &promptData{
+		Surface: promptSurface{Type: astructure.SurfaceTypeInstruction},
+		Gradients: []promptGradient{
 			{
-				EvalSetID:  "set_a",
-				EvalCaseID: "case_1",
-				StepID:     "s1",
-				SurfaceID:  "surf_1",
-				Severity:   promptiter.LossSeverityP1,
-				Gradient:   "keep citation",
+				Severity: promptiter.LossSeverityP1,
+				Gradient: "keep citation",
 			},
 		},
 	}, &payload)

--- a/evaluation/workflow/promptiter/backwarder/message.go
+++ b/evaluation/workflow/promptiter/backwarder/message.go
@@ -16,6 +16,9 @@ import (
 	"fmt"
 	"text/template"
 
+	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
+	atrace "trpc.group/trpc-go/trpc-agent-go/agent/trace"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 )
 
@@ -25,13 +28,13 @@ type MessageBuilder func(ctx context.Context, request *Request) (*model.Message,
 const defaultMessageTemplateText = `Compute PromptIter backward attribution for one step.
 
 You will receive one backward request for a single executed step.
-Return exactly one JSON object that can be unmarshaled into backwarder.Result.
+Return exactly one JSON object with Gradients and Upstream fields.
 
 Requirements:
 - Keep the response as raw JSON only.
 - Do not wrap the response in markdown code fences.
-- Attribute gradients only to surfaces that affected the current step.
-- Route upstream gradients only to explicit predecessor steps.
+- Attribute gradients only to listed gradient surfaces.
+- Route upstream gradients only to listed predecessor steps.
 - Do not broadcast the same gradient packet to every predecessor.
 
 Request JSON:
@@ -52,12 +55,104 @@ func defaultMessageBuilder() MessageBuilder {
 			return nil, errors.New("render backward message template: request is nil")
 		}
 		var content bytes.Buffer
-		if err := tmpl.Execute(&content, request); err != nil {
+		if err := tmpl.Execute(&content, newPromptData(request)); err != nil {
 			return nil, fmt.Errorf("render backward message template: %w", err)
 		}
 		message := model.NewUserMessage(content.String())
 		return &message, nil
 	}
+}
+
+type promptData struct {
+	Node             promptNode
+	Input            *atrace.Snapshot         `json:",omitempty"`
+	Output           *atrace.Snapshot         `json:",omitempty"`
+	Error            string                   `json:",omitempty"`
+	GradientSurfaces []promptSurface          `json:",omitempty"`
+	OtherSurfaces    []promptContextSurface   `json:",omitempty"`
+	Predecessors     []promptPredecessor      `json:",omitempty"`
+	Incoming         []promptIncomingGradient `json:",omitempty"`
+}
+
+type promptNode struct {
+	Kind astructure.NodeKind `json:",omitempty"`
+	Name string              `json:",omitempty"`
+}
+
+type promptSurface struct {
+	SurfaceID string
+	Type      astructure.SurfaceType
+	Value     astructure.SurfaceValue
+}
+
+type promptContextSurface struct {
+	Type  astructure.SurfaceType
+	Value astructure.SurfaceValue
+}
+
+type promptPredecessor struct {
+	StepID string
+	Output *atrace.Snapshot `json:",omitempty"`
+	Error  string           `json:",omitempty"`
+}
+
+type promptIncomingGradient struct {
+	Severity promptiter.LossSeverity
+	Gradient string
+}
+
+func newPromptData(request *Request) promptData {
+	if request == nil {
+		return promptData{}
+	}
+	data := promptData{
+		Input:  request.Input,
+		Output: request.Output,
+		Error:  request.Error,
+	}
+	if request.Node != nil {
+		data.Node = promptNode{
+			Kind: request.Node.Kind,
+			Name: request.Node.Name,
+		}
+	}
+	allowedSurfaceIDList := requestAllowedGradientSurfaceIDs(request)
+	allowedSurfaceIDs := make(map[string]struct{}, len(allowedSurfaceIDList))
+	for _, surfaceID := range allowedSurfaceIDList {
+		allowedSurfaceIDs[surfaceID] = struct{}{}
+	}
+	data.GradientSurfaces = make([]promptSurface, 0, len(request.Surfaces))
+	data.OtherSurfaces = make([]promptContextSurface, 0, len(request.Surfaces))
+	for _, surface := range request.Surfaces {
+		if _, ok := allowedSurfaceIDs[surface.SurfaceID]; ok {
+			data.GradientSurfaces = append(data.GradientSurfaces, promptSurface{
+				SurfaceID: surface.SurfaceID,
+				Type:      surface.Type,
+				Value:     surface.Value,
+			})
+			continue
+		}
+		data.OtherSurfaces = append(data.OtherSurfaces, promptContextSurface{
+			Type:  surface.Type,
+			Value: surface.Value,
+		})
+	}
+	data.Predecessors = make([]promptPredecessor, 0, len(request.Predecessors))
+	for _, predecessor := range request.Predecessors {
+		data.Predecessors = append(data.Predecessors, promptPredecessor{
+			StepID: predecessor.StepID,
+			Output: predecessor.Output,
+			Error:  predecessor.Error,
+		})
+	}
+	data.Incoming = make([]promptIncomingGradient, 0, len(request.Incoming))
+	for _, incoming := range request.Incoming {
+		data.Incoming = append(data.Incoming, promptIncomingGradient{
+			Severity: incoming.Severity,
+			Gradient: incoming.Gradient,
+		})
+	}
+	return data
 }
 
 // toPrettyJSON renders one value as indented JSON for prompts.

--- a/evaluation/workflow/promptiter/backwarder/options_test.go
+++ b/evaluation/workflow/promptiter/backwarder/options_test.go
@@ -26,6 +26,7 @@ import (
 func TestDefaultMessageBuilder(t *testing.T) {
 	builder := defaultMessageBuilder()
 	currentText := "current instruction"
+	otherText := "non-target instruction"
 
 	msg, err := builder(context.Background(), &Request{
 		EvalSetID:  "set_a",
@@ -51,7 +52,16 @@ func TestDefaultMessageBuilder(t *testing.T) {
 					Text: &currentText,
 				},
 			},
+			{
+				SurfaceID: "surf_2",
+				NodeID:    "node_1",
+				Type:      astructure.SurfaceTypeGlobalInstruction,
+				Value: astructure.SurfaceValue{
+					Text: &otherText,
+				},
+			},
 		},
+		AllowedGradientSurfaceIDs: []string{"surf_1"},
 		Predecessors: []Predecessor{
 			{
 				StepID: "pred_1",
@@ -77,6 +87,16 @@ func TestDefaultMessageBuilder(t *testing.T) {
 	}
 	assert.Equal(t, model.RoleUser, msg.Role)
 	assert.Contains(t, msg.Content, "Compute PromptIter backward attribution for one step.")
+	assert.Contains(t, msg.Content, "Attribute gradients only to listed gradient surfaces.")
+	assert.NotContains(t, msg.Content, "EvalSetID")
+	assert.NotContains(t, msg.Content, "EvalCaseID")
+	assert.NotContains(t, msg.Content, "NodeID")
+	assert.NotContains(t, msg.Content, "AllowedGradientSurfaceIDs")
+	assert.NotContains(t, msg.Content, "FromStepID")
+	assert.NotContains(t, msg.Content, "set_a")
+	assert.NotContains(t, msg.Content, "case_1")
+	assert.NotContains(t, msg.Content, "node_pred")
+	assert.NotContains(t, msg.Content, "step_downstream")
 
 	payloadContent, ok := extractRequestJSON(msg.Content)
 	assert.True(t, ok)
@@ -84,48 +104,49 @@ func TestDefaultMessageBuilder(t *testing.T) {
 		return
 	}
 
-	var payload Request
+	var payload promptData
 	err = json.Unmarshal([]byte(payloadContent), &payload)
 	assert.NoError(t, err)
-	assert.Equal(t, &Request{
-		EvalSetID:  "set_a",
-		EvalCaseID: "case_1",
-		Node: &astructure.Node{
-			NodeID: "node_1",
-			Kind:   "llm",
-			Name:   "responder",
+	assert.Equal(t, &promptData{
+		Node: promptNode{
+			Kind: "llm",
+			Name: "responder",
 		},
-		StepID: "step_1",
 		Input: &atrace.Snapshot{
 			Text: "input text",
 		},
 		Output: &atrace.Snapshot{
 			Text: "output text",
 		},
-		Surfaces: []astructure.Surface{
+		GradientSurfaces: []promptSurface{
 			{
 				SurfaceID: "surf_1",
-				NodeID:    "node_1",
 				Type:      astructure.SurfaceTypeInstruction,
 				Value: astructure.SurfaceValue{
 					Text: &currentText,
 				},
 			},
 		},
-		Predecessors: []Predecessor{
+		OtherSurfaces: []promptContextSurface{
+			{
+				Type: astructure.SurfaceTypeGlobalInstruction,
+				Value: astructure.SurfaceValue{
+					Text: &otherText,
+				},
+			},
+		},
+		Predecessors: []promptPredecessor{
 			{
 				StepID: "pred_1",
-				NodeID: "node_pred",
 				Output: &atrace.Snapshot{
 					Text: "predecessor output",
 				},
 			},
 		},
-		Incoming: []GradientPacket{
+		Incoming: []promptIncomingGradient{
 			{
-				FromStepID: "step_downstream",
-				Severity:   promptiter.LossSeverityP1,
-				Gradient:   "need citations",
+				Severity: promptiter.LossSeverityP1,
+				Gradient: "need citations",
 			},
 		},
 	}, &payload)

--- a/evaluation/workflow/promptiter/optimizer/message.go
+++ b/evaluation/workflow/promptiter/optimizer/message.go
@@ -15,6 +15,8 @@ import (
 	"fmt"
 	"text/template"
 
+	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 )
 
@@ -24,12 +26,12 @@ type MessageBuilder func(ctx context.Context, request *Request) (*model.Message,
 const defaultMessageTemplateText = `Optimize one PromptIter surface from the provided current value and aggregated gradients.
 
 You will receive one optimization request for a single surface.
-Return exactly one JSON object that can be unmarshaled into promptiter.SurfacePatch.
+Return exactly one JSON object with Value and Reason fields.
 
 Requirements:
 - Keep the response as raw JSON only.
 - Do not wrap the response in markdown code fences.
-- Preserve the request surface identity.
+- Return only Value and Reason fields. The caller will attach the target surface identity.
 - The patch value must match the request surface type.
 - Prefer the smallest high-confidence change that preserves working parts of the current value.
 - When the current value is mostly correct, prefer removing unsupported or speculative detail before adding new detail.
@@ -54,12 +56,50 @@ func defaultMessageBuilder() MessageBuilder {
 	}
 	return func(ctx context.Context, request *Request) (*model.Message, error) {
 		var content bytes.Buffer
-		if err := tmpl.Execute(&content, request); err != nil {
+		if err := tmpl.Execute(&content, newPromptData(request)); err != nil {
 			return nil, fmt.Errorf("render optimization message template: %w", err)
 		}
 		message := model.NewUserMessage(content.String())
 		return &message, nil
 	}
+}
+
+type promptData struct {
+	Surface   promptSurface
+	Gradients []promptGradient
+}
+
+type promptSurface struct {
+	Type  astructure.SurfaceType
+	Value astructure.SurfaceValue
+}
+
+type promptGradient struct {
+	Severity promptiter.LossSeverity
+	Gradient string
+}
+
+func newPromptData(request *Request) promptData {
+	if request == nil {
+		return promptData{}
+	}
+	data := promptData{}
+	if request.Surface != nil {
+		data.Surface = promptSurface{
+			Type:  request.Surface.Type,
+			Value: request.Surface.Value,
+		}
+	}
+	if request.Gradient != nil {
+		data.Gradients = make([]promptGradient, 0, len(request.Gradient.Gradients))
+		for _, gradient := range request.Gradient.Gradients {
+			data.Gradients = append(data.Gradients, promptGradient{
+				Severity: gradient.Severity,
+				Gradient: gradient.Gradient,
+			})
+		}
+	}
+	return data
 }
 
 // toPrettyJSON renders one value as indented JSON for prompts.

--- a/evaluation/workflow/promptiter/optimizer/optimizer.go
+++ b/evaluation/workflow/promptiter/optimizer/optimizer.go
@@ -43,6 +43,11 @@ type Result struct {
 	Patch *promptiter.SurfacePatch
 }
 
+type surfacePatchProposal struct {
+	Value  astructure.SurfaceValue
+	Reason string
+}
+
 // optimizer is the default Optimizer implementation used by the engine.
 type optimizer struct {
 	// runner executes external inference needed to draft patch proposals.
@@ -128,16 +133,16 @@ func (o *optimizer) Optimize(ctx context.Context, request *Request) (*Result, er
 	if err != nil {
 		return nil, fmt.Errorf("capture runner output: %w", err)
 	}
-	patch, err := idecode.DecodeOutputJSON[promptiter.SurfacePatch](output)
+	proposal, err := idecode.DecodeOutputJSON[surfacePatchProposal](output)
 	if err != nil {
-		return nil, fmt.Errorf("decode surface patch: %w", err)
+		return nil, fmt.Errorf("decode surface patch proposal: %w", err)
 	}
-	if patch == nil {
-		return nil, errors.New("surface patch is empty")
+	if proposal == nil {
+		return nil, errors.New("surface patch proposal is empty")
 	}
-	patch, err = sanitizeSurfacePatch(normalizedRequest, patch)
+	patch, err := sanitizePatchProposal(normalizedRequest, proposal)
 	if err != nil {
-		return nil, fmt.Errorf("sanitize surface patch: %w", err)
+		return nil, fmt.Errorf("sanitize surface patch proposal: %w", err)
 	}
 	return &Result{Patch: patch}, nil
 }
@@ -196,33 +201,26 @@ func normalizeRequest(request *Request) (*Request, error) {
 	return request, nil
 }
 
-func sanitizeSurfacePatch(request *Request, patch *promptiter.SurfacePatch) (*promptiter.SurfacePatch, error) {
+func sanitizePatchProposal(request *Request, proposal *surfacePatchProposal) (*promptiter.SurfacePatch, error) {
 	if request == nil {
 		return nil, errors.New("request is nil")
 	}
 	if request.Surface == nil {
 		return nil, errors.New("surface is nil")
 	}
-	if patch == nil {
-		return nil, errors.New("surface patch is nil")
+	if proposal == nil {
+		return nil, errors.New("surface patch proposal is nil")
 	}
-	if surfaceID := patch.SurfaceID; surfaceID != "" && surfaceID != request.Surface.SurfaceID {
-		return nil, fmt.Errorf(
-			"patch surface id %q does not match surface id %q",
-			patch.SurfaceID,
-			request.Surface.SurfaceID,
-		)
-	}
-	if patch.Reason == "" {
+	if proposal.Reason == "" {
 		return nil, errors.New("patch reason is empty")
 	}
-	value, err := isurface.SanitizeValue(request.Surface.Type, patch.Value)
+	value, err := isurface.SanitizeValue(request.Surface.Type, proposal.Value)
 	if err != nil {
 		return nil, fmt.Errorf("sanitize patch value: %w", err)
 	}
 	return &promptiter.SurfacePatch{
 		SurfaceID: request.Surface.SurfaceID,
 		Value:     value,
-		Reason:    patch.Reason,
+		Reason:    proposal.Reason,
 	}, nil
 }

--- a/evaluation/workflow/promptiter/optimizer/optimizer.go
+++ b/evaluation/workflow/promptiter/optimizer/optimizer.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
@@ -211,7 +212,8 @@ func sanitizePatchProposal(request *Request, proposal *surfacePatchProposal) (*p
 	if proposal == nil {
 		return nil, errors.New("surface patch proposal is nil")
 	}
-	if proposal.Reason == "" {
+	reason := strings.TrimSpace(proposal.Reason)
+	if reason == "" {
 		return nil, errors.New("patch reason is empty")
 	}
 	value, err := isurface.SanitizeValue(request.Surface.Type, proposal.Value)
@@ -221,6 +223,6 @@ func sanitizePatchProposal(request *Request, proposal *surfacePatchProposal) (*p
 	return &promptiter.SurfacePatch{
 		SurfaceID: request.Surface.SurfaceID,
 		Value:     value,
-		Reason:    proposal.Reason,
+		Reason:    reason,
 	}, nil
 }

--- a/evaluation/workflow/promptiter/optimizer/optimizer_test.go
+++ b/evaluation/workflow/promptiter/optimizer/optimizer_test.go
@@ -109,7 +109,7 @@ func TestOptimizeUsesRunnerStructuredOutput(t *testing.T) {
 						{Message: model.NewAssistantMessage("ignored")},
 					},
 				},
-				event.WithStructuredOutputPayload(&promptiter.SurfacePatch{
+				event.WithStructuredOutputPayload(&surfacePatchProposal{
 					Value: astructure.SurfaceValue{
 						Text:    &updatedText,
 						FewShot: []astructure.FewShotExample{},
@@ -242,7 +242,7 @@ func TestOptimizeUsesDefaultUUIDSessionID(t *testing.T) {
 	assert.Equal(t, model.StructuredOutputJSONSchema, r.lastRunOpts.StructuredOutput.Type)
 	assert.Equal(
 		t,
-		reflect.TypeOf((*promptiter.SurfacePatch)(nil)),
+		reflect.TypeOf((*surfacePatchProposal)(nil)),
 		r.lastRunOpts.StructuredOutputType,
 	)
 	assert.Equal(t, &updatedText, rsp.Patch.Value.Text)
@@ -323,7 +323,7 @@ func TestOptimizeRejectsInvalidPatchOutput(t *testing.T) {
 		assert.Nil(t, rsp)
 	})
 
-	t.Run("patch surface id mismatch", func(t *testing.T) {
+	t.Run("legacy patch surface id is ignored", func(t *testing.T) {
 		oz, err := New(context.Background(), &fakeRunner{
 			events: []*event.Event{
 				event.NewResponseEvent(
@@ -344,8 +344,9 @@ func TestOptimizeRejectsInvalidPatchOutput(t *testing.T) {
 
 		rsp, err := oz.Optimize(context.Background(), newInstructionRequest("current instruction"))
 
-		assert.Error(t, err)
-		assert.Nil(t, rsp)
+		assert.NoError(t, err)
+		assert.Equal(t, "surf_1", rsp.Patch.SurfaceID)
+		assert.Equal(t, "updated instruction", *rsp.Patch.Value.Text)
 	})
 
 	t.Run("patch reason is empty", func(t *testing.T) {
@@ -504,7 +505,7 @@ func TestOptimizeRejectsMessageBuildAndEmptyDecodedPatch(t *testing.T) {
 		assert.NoError(t, err)
 		result, runErr := oz.Optimize(context.Background(), newInstructionRequest("current instruction"))
 		assert.Nil(t, result)
-		assert.EqualError(t, runErr, "sanitize surface patch: patch reason is empty")
+		assert.EqualError(t, runErr, "sanitize surface patch proposal: patch reason is empty")
 	})
 }
 
@@ -705,17 +706,17 @@ func TestOptimizeRejectsInvalidRequests(t *testing.T) {
 	}
 }
 
-func TestSanitizeSurfacePatchValidationErrors(t *testing.T) {
-	patch, err := sanitizeSurfacePatch(nil, &promptiter.SurfacePatch{})
+func TestSanitizePatchProposalValidationErrors(t *testing.T) {
+	patch, err := sanitizePatchProposal(nil, &surfacePatchProposal{})
 	assert.Nil(t, patch)
 	assert.EqualError(t, err, "request is nil")
-	patch, err = sanitizeSurfacePatch(&Request{}, &promptiter.SurfacePatch{})
+	patch, err = sanitizePatchProposal(&Request{}, &surfacePatchProposal{})
 	assert.Nil(t, patch)
 	assert.EqualError(t, err, "surface is nil")
-	patch, err = sanitizeSurfacePatch(newInstructionRequest("current instruction"), nil)
+	patch, err = sanitizePatchProposal(newInstructionRequest("current instruction"), nil)
 	assert.Nil(t, patch)
-	assert.EqualError(t, err, "surface patch is nil")
-	patch, err = sanitizeSurfacePatch(newInstructionRequest("current instruction"), &promptiter.SurfacePatch{
+	assert.EqualError(t, err, "surface patch proposal is nil")
+	patch, err = sanitizePatchProposal(newInstructionRequest("current instruction"), &surfacePatchProposal{
 		Reason: "update",
 		Value: astructure.SurfaceValue{
 			Model: &astructure.ModelRef{Name: "gpt-test"},

--- a/evaluation/workflow/promptiter/optimizer/optimizer_test.go
+++ b/evaluation/workflow/promptiter/optimizer/optimizer_test.go
@@ -220,7 +220,7 @@ func TestOptimizeUsesDefaultUUIDSessionID(t *testing.T) {
 				&model.Response{
 					Done: true,
 					Choices: []model.Choice{
-						{Message: model.NewAssistantMessage(`{"SurfaceID":"surf_1","Value":{"Text":"updated instruction"},"Reason":"tighten the system instruction"}`)},
+						{Message: model.NewAssistantMessage(`{"Value":{"Text":"updated instruction"},"Reason":"tighten the system instruction"}`)},
 					},
 				},
 			),
@@ -360,6 +360,30 @@ func TestOptimizeRejectsInvalidPatchOutput(t *testing.T) {
 						Value: astructure.SurfaceValue{
 							Text: textPtr("updated instruction"),
 						},
+					}),
+				),
+			},
+		})
+		assert.NoError(t, err)
+
+		rsp, err := oz.Optimize(context.Background(), newInstructionRequest("current instruction"))
+
+		assert.Error(t, err)
+		assert.Nil(t, rsp)
+	})
+
+	t.Run("patch reason is whitespace only", func(t *testing.T) {
+		oz, err := New(context.Background(), &fakeRunner{
+			events: []*event.Event{
+				event.NewResponseEvent(
+					"invocation-id",
+					"optimizer",
+					&model.Response{Done: true},
+					event.WithStructuredOutputPayload(&surfacePatchProposal{
+						Value: astructure.SurfaceValue{
+							Text: textPtr("updated instruction"),
+						},
+						Reason: "   ",
 					}),
 				),
 			},
@@ -724,6 +748,18 @@ func TestSanitizePatchProposalValidationErrors(t *testing.T) {
 	})
 	assert.Nil(t, patch)
 	assert.EqualError(t, err, "sanitize patch value: text is nil")
+}
+
+func TestSanitizePatchProposalTrimsReason(t *testing.T) {
+	patch, err := sanitizePatchProposal(newInstructionRequest("current instruction"), &surfacePatchProposal{
+		Reason: " tighten the system instruction ",
+		Value: astructure.SurfaceValue{
+			Text: textPtr("updated instruction"),
+		},
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "tighten the system instruction", patch.Reason)
 }
 
 func newInstructionRequest(currentText string) *Request {

--- a/evaluation/workflow/promptiter/optimizer/options.go
+++ b/evaluation/workflow/promptiter/optimizer/options.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/google/uuid"
 	"trpc.group/trpc-go/trpc-agent-go/agent"
-	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter"
 )
 
 // options stores optional optimizer behavior flags.
@@ -33,7 +32,7 @@ func newOptions(opt ...Option) *options {
 	opts := &options{
 		runOptions: []agent.RunOption{
 			agent.WithStructuredOutputJSON(
-				new(promptiter.SurfacePatch),
+				new(surfacePatchProposal),
 				true,
 				"One PromptIter surface patch proposal.",
 			),

--- a/evaluation/workflow/promptiter/optimizer/options_test.go
+++ b/evaluation/workflow/promptiter/optimizer/options_test.go
@@ -63,6 +63,11 @@ func TestDefaultMessageBuilder(t *testing.T) {
 	assert.Contains(t, msg.Content, "When the current value is mostly correct, prefer removing unsupported or speculative detail before adding new detail.")
 	assert.Contains(t, msg.Content, "Do not trade factual precision for stylistic vividness.")
 	assert.Contains(t, msg.Content, "Avoid broad rewrites unless the gradients indicate multiple independent failures.")
+	assert.Contains(t, msg.Content, "Return only Value and Reason fields.")
+	assert.NotContains(t, msg.Content, "SurfaceID")
+	assert.NotContains(t, msg.Content, "EvalSetID")
+	assert.NotContains(t, msg.Content, "EvalCaseID")
+	assert.NotContains(t, msg.Content, "StepID")
 
 	payloadContent, ok := extractRequestJSON(msg.Content)
 	assert.True(t, ok)
@@ -70,10 +75,28 @@ func TestDefaultMessageBuilder(t *testing.T) {
 		return
 	}
 
-	var payload Request
+	var payload promptData
 	err = json.Unmarshal([]byte(payloadContent), &payload)
 	assert.NoError(t, err)
-	assert.Equal(t, &Request{
+	assert.Equal(t, &promptData{
+		Surface: promptSurface{
+			Type: astructure.SurfaceTypeInstruction,
+			Value: astructure.SurfaceValue{
+				Text: &currentText,
+			},
+		},
+		Gradients: []promptGradient{
+			{
+				Severity: promptiter.LossSeverityP1,
+				Gradient: "keep citation",
+			},
+		},
+	}, &payload)
+}
+
+func TestNewPromptDataOmitsSurfaceIdentity(t *testing.T) {
+	currentText := "current instruction"
+	data := newPromptData(&Request{
 		Surface: &astructure.Surface{
 			SurfaceID: "surf_1",
 			NodeID:    "node_1",
@@ -97,7 +120,16 @@ func TestDefaultMessageBuilder(t *testing.T) {
 				},
 			},
 		},
-	}, &payload)
+	})
+
+	payload, err := json.Marshal(data)
+
+	assert.NoError(t, err)
+	assert.NotContains(t, string(payload), "SurfaceID")
+	assert.NotContains(t, string(payload), "NodeID")
+	assert.NotContains(t, string(payload), "EvalSetID")
+	assert.NotContains(t, string(payload), "EvalCaseID")
+	assert.NotContains(t, string(payload), "StepID")
 }
 
 func extractRequestJSON(content string) (string, bool) {


### PR DESCRIPTION
This narrows the default PromptIter LLM contracts so backwarder, aggregator, and optimizer prompts only expose fields the model needs to decide, while framework-owned surface identity and provenance are filled by the engine. It also updates structured outputs to avoid asking the model to copy fixed surface fields.