### PR TITLE
fix(container): parse bind mounts without mode

### DIFF
--- a/codeexecutor/container/workspace_runtime.go
+++ b/codeexecutor/container/workspace_runtime.go
@@ -96,26 +96,50 @@ func newWorkspaceRuntime(c *CodeExecutor) (*workspaceRuntime, error) {
 }
 
 // findBindSource returns the host path whose bind dest equals dest.
-// Bind spec is source:dest[:mode]. We parse from right to handle ':'
-// that may appear in the source path (Windows not considered here).
+// Bind spec is source:dest[:mode]. We parse from the right so ':'
+// may appear in the source path (Windows not considered here).
 func findBindSource(binds []string, dest string) string {
 	for _, b := range binds {
 		parts := strings.Split(b, ":")
 		if len(parts) < 2 {
 			continue
 		}
-		// Last part may be mode; second last is dest.
-		d := parts[len(parts)-2]
-		if d != dest {
-			continue
-		}
-		// Join all but the last two parts as source.
-		src := strings.Join(parts[:len(parts)-2], ":")
-		if st, err := os.Stat(src); err == nil && st.IsDir() {
-			return src
+		for _, i := range bindDestCandidateIndexes(parts) {
+			if parts[i] == dest {
+				src := strings.Join(parts[:i], ":")
+				if st, err := os.Stat(src); err == nil && st.IsDir() {
+					return src
+				}
+			}
 		}
 	}
 	return ""
+}
+
+func bindDestCandidateIndexes(parts []string) []int {
+	if len(parts) == 2 {
+		return []int{1}
+	}
+	if isBindMode(parts[len(parts)-1]) {
+		return []int{len(parts) - 2}
+	}
+	return []int{len(parts) - 1}
+}
+
+func isBindMode(s string) bool {
+	if s == "" {
+		return true
+	}
+	for _, opt := range strings.Split(s, ",") {
+		switch opt {
+		case "ro", "rw", "z", "Z", "cached", "delegated", "consistent",
+			"private", "rprivate", "shared", "rshared", "slave", "rslave",
+			"nocopy":
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // CreateWorkspace ensures a per‑execution directory inside container.

--- a/codeexecutor/container/workspace_runtime_test.go
+++ b/codeexecutor/container/workspace_runtime_test.go
@@ -188,7 +188,7 @@ func TestWorkspaceRuntime_CreateWorkspace_AutoMapsInputs(t *testing.T) {
 		container: &tcontainer.Summary{ID: testCID},
 		hostConfig: tcontainer.HostConfig{
 			Binds: []string{
-				host + ":" + defaultInputsContainer + ":ro",
+				host + ":" + defaultInputsContainer,
 			},
 		},
 		autoInputs: true,
@@ -1303,10 +1303,29 @@ func TestWorkspaceRuntime_RunProgram_NoDupWorkspaceEnv(t *testing.T) {
 
 func TestHelpers_Simple(t *testing.T) {
 	tmp := t.TempDir()
-	b := []string{tmp + ":/opt/trpc-agent/skills:ro"}
+	tmpWithColon := filepath.Join(tmp, "host:with-colon")
+	require.NoError(t, os.Mkdir(tmpWithColon, 0o755))
+	b := []string{
+		tmp + ":/opt/trpc-agent/skills:ro",
+		tmp + ":/opt/trpc-agent/inputs",
+		tmp + ":/opt/trpc-agent/empty-mode:",
+		tmpWithColon + ":/opt/trpc-agent/colon:ro",
+	}
 	got := findBindSource(b, "/opt/trpc-agent/skills")
 	require.Equal(t, tmp, got)
 
+	require.Equal(t, tmp, findBindSource(
+		b, "/opt/trpc-agent/inputs",
+	))
+	require.Equal(t, tmp, findBindSource(
+		b, "/opt/trpc-agent/empty-mode",
+	))
+	require.Equal(t, tmpWithColon, findBindSource(
+		b, "/opt/trpc-agent/colon",
+	))
+	require.Equal(t, "", findBindSource([]string{
+		tmp + ":/opt/trpc-agent/inputs:/other:ro",
+	}, "/opt/trpc-agent/inputs"))
 	require.Equal(t, "", findBindSource(b, "/none"))
 	require.Equal(t, "ab_12__X", sanitize("ab 12!@X"))
 


### PR DESCRIPTION
## Summary
- fix container workspace bind source detection for Docker bind specs without a mode suffix (`source:dest`)
- keep support for `source:dest:mode` and host paths containing `:`
- cover the auto-inputs workspace path with a no-mode bind mount

## Tests
- `go test -run "TestHelpers_Simple|TestWorkspaceRuntime_CreateWorkspace_AutoMapsInputs" .` in `codeexecutor/container`
- `go test -run "^$" .` in `codeexecutor/container`

Note: I also tried `go test ./...` in `codeexecutor/container`, but stopped it after it entered the longer Docker-backed integration path on my machine.