### PR TITLE
{evaluation/workflow/promptiter, server/promptiter}: add app run isolation

### DIFF
--- a/docs/mkdocs/en/promptiter.md
+++ b/docs/mkdocs/en/promptiter.md
@@ -659,6 +659,7 @@ import (
 )
 
 type RunResult struct {
+	AppName            string               // AppName is the app that owns this run.
 	ID                 string               // ID is the run identifier.
 	Status             RunStatus            // Status is the current run status.
 	CurrentRound       int                  // CurrentRound is the current round number.
@@ -941,7 +942,7 @@ The minimal usage is:
 ```go
 import "trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/manager"
 
-managerInstance, err := manager.New(engineInstance)
+managerInstance, err := manager.New(appName, engineInstance)
 if err != nil {
 	return err
 }
@@ -978,9 +979,9 @@ import (
 )
 
 type Store interface {
-	Create(ctx context.Context, run *engine.RunResult) error
-	Get(ctx context.Context, runID string) (*engine.RunResult, error)
-	Update(ctx context.Context, run *engine.RunResult) error
+	Create(ctx context.Context, appName string, run *engine.RunResult) error
+	Get(ctx context.Context, appName, runID string) (*engine.RunResult, error)
+	Update(ctx context.Context, appName string, run *engine.RunResult) error
 	Close() error
 }
 ```
@@ -993,7 +994,7 @@ type Store interface {
 
 `store/mysql` fits cross-process persistence and platform queries. It serializes `RunResult` into MySQL and supports both manual schema initialization and automatic table creation.
 
-The current implementation uses a single table to store run records. Core fields include `run_id`, `status`, serialized `run_result`, and timestamps such as `created_at` and `updated_at`. The full schema is available in [schema.sql](https://github.com/trpc-group/trpc-agent-go/tree/main/evaluation/workflow/promptiter/store/mysql/schema.sql).
+The current implementation uses a single table to store run records. Core fields include `app_name`, `run_id`, `status`, serialized `run_result`, and timestamps such as `created_at` and `updated_at`. `app_name` and `run_id` form the unique key that isolates run records across apps. The full schema is available in [schema.sql](https://github.com/trpc-group/trpc-agent-go/tree/main/evaluation/workflow/promptiter/store/mysql/schema.sql).
 
 ### HTTP APIs
 

--- a/docs/mkdocs/zh/promptiter.md
+++ b/docs/mkdocs/zh/promptiter.md
@@ -659,6 +659,7 @@ import (
 )
 
 type RunResult struct {
+	AppName            string               // AppName 表示本次运行所属的应用名。
 	ID                 string               // ID 表示运行标识。
 	Status             RunStatus            // Status 表示当前运行状态。
 	CurrentRound       int                  // CurrentRound 表示当前执行到第几轮。
@@ -937,7 +938,7 @@ type Manager interface {
 ```go
 import "trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/manager"
 
-managerInstance, err := manager.New(engineInstance)
+managerInstance, err := manager.New(appName, engineInstance)
 if err != nil {
 	return err
 }
@@ -974,9 +975,9 @@ import (
 )
 
 type Store interface {
-	Create(ctx context.Context, run *engine.RunResult) error
-	Get(ctx context.Context, runID string) (*engine.RunResult, error)
-	Update(ctx context.Context, run *engine.RunResult) error
+	Create(ctx context.Context, appName string, run *engine.RunResult) error
+	Get(ctx context.Context, appName, runID string) (*engine.RunResult, error)
+	Update(ctx context.Context, appName string, run *engine.RunResult) error
 	Close() error
 }
 ```
@@ -989,7 +990,7 @@ type Store interface {
 
 `store/mysql` 适合跨进程持久化与平台查询。该实现会将 `RunResult` 序列化后存入 MySQL，并支持手工初始化 schema 或自动建表。
 
-当前实现使用单表保存运行记录，核心字段包括 `run_id`、`status`、序列化后的 `run_result`，以及 `created_at`、`updated_at` 等时间字段。完整表结构可参考 [schema.sql](https://github.com/trpc-group/trpc-agent-go/tree/main/evaluation/workflow/promptiter/store/mysql/schema.sql)。
+当前实现使用单表保存运行记录，核心字段包括 `app_name`、`run_id`、`status`、序列化后的 `run_result`，以及 `created_at`、`updated_at` 等时间字段。`app_name` 和 `run_id` 组成唯一键，用于隔离不同应用下的运行记录。完整表结构可参考 [schema.sql](https://github.com/trpc-group/trpc-agent-go/tree/main/evaluation/workflow/promptiter/store/mysql/schema.sql)。
 
 ### HTTP 接口
 

--- a/evaluation/workflow/promptiter/engine/engine.go
+++ b/evaluation/workflow/promptiter/engine/engine.go
@@ -106,6 +106,8 @@ const (
 
 // RunResult stores the state and historical trace of one PromptIter execution.
 type RunResult struct {
+	// AppName identifies the PromptIter target app that owns this run.
+	AppName string
 	// ID uniquely identifies this run when the caller uses manager-backed execution.
 	ID string
 	// Status stores the lifecycle state of the run.

--- a/evaluation/workflow/promptiter/manager/manager.go
+++ b/evaluation/workflow/promptiter/manager/manager.go
@@ -38,6 +38,7 @@ type Manager interface {
 }
 
 type manager struct {
+	appName              string
 	engine               engine.Engine
 	store                store.Store
 	storedResultSlimming engine.RunResultSlimming
@@ -46,13 +47,17 @@ type manager struct {
 	closed               bool
 }
 
-// New creates a PromptIter run manager.
-func New(engine engine.Engine, opts ...Option) (Manager, error) {
+// New creates a PromptIter run manager for one app.
+func New(appName string, engine engine.Engine, opts ...Option) (Manager, error) {
 	options := newOptions(opts...)
+	if strings.TrimSpace(appName) == "" {
+		return nil, errors.New("promptiter manager: app name must not be empty")
+	}
 	if engine == nil {
 		return nil, errors.New("promptiter manager: engine must not be nil")
 	}
 	return &manager{
+		appName:              appName,
 		engine:               engine,
 		store:                options.store,
 		storedResultSlimming: options.storedResultSlimming,
@@ -67,15 +72,16 @@ func (m *manager) Start(ctx context.Context, request *engine.RunRequest) (*engin
 	}
 	runID := uuid.NewString()
 	run := &engine.RunResult{
-		ID:     runID,
-		Status: engine.RunStatusQueued,
+		AppName: m.appName,
+		ID:      runID,
+		Status:  engine.RunStatusQueued,
 	}
 	m.mu.Lock()
 	if m.closed {
 		m.mu.Unlock()
 		return nil, errors.New("promptiter manager is closed")
 	}
-	if err := m.store.Create(ctx, m.slimStoredRun(run)); err != nil {
+	if err := m.store.Create(ctx, m.appName, m.slimStoredRun(run)); err != nil {
 		m.mu.Unlock()
 		return nil, fmt.Errorf("create run %q: %w", runID, err)
 	}
@@ -88,7 +94,7 @@ func (m *manager) Start(ctx context.Context, request *engine.RunRequest) (*engin
 
 // Get loads one persisted PromptIter run.
 func (m *manager) Get(ctx context.Context, runID string) (*engine.RunResult, error) {
-	return m.store.Get(ctx, runID)
+	return m.store.Get(ctx, m.appName, runID)
 }
 
 // Cancel cancels one running PromptIter run.
@@ -100,14 +106,14 @@ func (m *manager) Cancel(ctx context.Context, runID string) error {
 		return fmt.Errorf("run %q is not running: %w", runID, os.ErrNotExist)
 	}
 	cancel()
-	run, err := m.store.Get(ctx, runID)
+	run, err := m.store.Get(ctx, m.appName, runID)
 	if err != nil {
 		return err
 	}
 	if run.Status == engine.RunStatusQueued || run.Status == engine.RunStatusRunning {
 		run.Status = engine.RunStatusCanceled
 		run.ErrorMessage = "run canceled"
-		if err := m.store.Update(ctx, m.slimStoredRun(run)); err != nil {
+		if err := m.store.Update(ctx, m.appName, m.slimStoredRun(run)); err != nil {
 			return err
 		}
 	}
@@ -135,13 +141,13 @@ func (m *manager) Close() error {
 }
 
 func (m *manager) run(ctx context.Context, runID string, request *engine.RunRequest) {
-	run, err := m.store.Get(context.Background(), runID)
+	run, err := m.store.Get(context.Background(), m.appName, runID)
 	if err != nil {
 		m.clearCancel(runID)
 		return
 	}
 	run.Status = engine.RunStatusRunning
-	if err := m.store.Update(context.Background(), m.slimStoredRun(run)); err != nil {
+	if err := m.store.Update(context.Background(), m.appName, m.slimStoredRun(run)); err != nil {
 		m.clearCancel(runID)
 		return
 	}
@@ -160,23 +166,24 @@ func (m *manager) run(ctx context.Context, runID string, request *engine.RunRequ
 			observer.run.Status = engine.RunStatusFailed
 			observer.run.ErrorMessage = err.Error()
 		}
-		_ = m.store.Update(context.Background(), m.slimStoredRun(observer.run))
+		_ = m.store.Update(context.Background(), m.appName, m.slimStoredRun(observer.run))
 		m.clearCancel(runID)
 		return
 	}
 	if result == nil {
 		observer.run.Status = engine.RunStatusFailed
 		observer.run.ErrorMessage = "engine returned nil run"
-		_ = m.store.Update(context.Background(), m.slimStoredRun(observer.run))
+		_ = m.store.Update(context.Background(), m.appName, m.slimStoredRun(observer.run))
 		m.clearCancel(runID)
 		return
 	}
 	result.ID = runID
+	result.AppName = m.appName
 	result.Status = engine.RunStatusSucceeded
-	if err := m.store.Update(context.Background(), m.slimStoredRun(result)); err != nil {
+	if err := m.store.Update(context.Background(), m.appName, m.slimStoredRun(result)); err != nil {
 		observer.run.Status = engine.RunStatusFailed
 		observer.run.ErrorMessage = err.Error()
-		_ = m.store.Update(context.Background(), m.slimStoredRun(observer.run))
+		_ = m.store.Update(context.Background(), m.appName, m.slimStoredRun(observer.run))
 	}
 	m.clearCancel(runID)
 }

--- a/evaluation/workflow/promptiter/manager/manager.go
+++ b/evaluation/workflow/promptiter/manager/manager.go
@@ -50,7 +50,8 @@ type manager struct {
 // New creates a PromptIter run manager for one app.
 func New(appName string, engine engine.Engine, opts ...Option) (Manager, error) {
 	options := newOptions(opts...)
-	if strings.TrimSpace(appName) == "" {
+	appName = strings.TrimSpace(appName)
+	if appName == "" {
 		return nil, errors.New("promptiter manager: app name must not be empty")
 	}
 	if engine == nil {

--- a/evaluation/workflow/promptiter/manager/manager_test.go
+++ b/evaluation/workflow/promptiter/manager/manager_test.go
@@ -20,26 +20,31 @@ import (
 	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
 	promptiter "trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter"
 	promptiterengine "trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+	promptiterinmemory "trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/store/inmemory"
 )
 
 type recordingStore struct {
-	updateCtx context.Context
-	updateRun *promptiterengine.RunResult
+	updateAppName string
+	updateCtx     context.Context
+	updateRun     *promptiterengine.RunResult
 }
 
-func (s *recordingStore) Create(ctx context.Context, run *promptiterengine.RunResult) error {
+func (s *recordingStore) Create(ctx context.Context, appName string, run *promptiterengine.RunResult) error {
 	_ = ctx
+	_ = appName
 	_ = run
 	return nil
 }
 
-func (s *recordingStore) Get(ctx context.Context, runID string) (*promptiterengine.RunResult, error) {
+func (s *recordingStore) Get(ctx context.Context, appName, runID string) (*promptiterengine.RunResult, error) {
 	_ = ctx
+	_ = appName
 	_ = runID
 	return nil, os.ErrNotExist
 }
 
-func (s *recordingStore) Update(ctx context.Context, run *promptiterengine.RunResult) error {
+func (s *recordingStore) Update(ctx context.Context, appName string, run *promptiterengine.RunResult) error {
+	s.updateAppName = appName
 	s.updateCtx = ctx
 	s.updateRun = run
 	return nil
@@ -60,7 +65,7 @@ type scriptedStore struct {
 	runs            map[string]*promptiterengine.RunResult
 }
 
-func (s *scriptedStore) Create(ctx context.Context, run *promptiterengine.RunResult) error {
+func (s *scriptedStore) Create(ctx context.Context, appName string, run *promptiterengine.RunResult) error {
 	_ = ctx
 	if s.createErr != nil {
 		return s.createErr
@@ -68,12 +73,14 @@ func (s *scriptedStore) Create(ctx context.Context, run *promptiterengine.RunRes
 	if s.runs == nil {
 		s.runs = make(map[string]*promptiterengine.RunResult)
 	}
+	run.AppName = appName
 	s.runs[run.ID] = run
 	return nil
 }
 
-func (s *scriptedStore) Get(ctx context.Context, runID string) (*promptiterengine.RunResult, error) {
+func (s *scriptedStore) Get(ctx context.Context, appName, runID string) (*promptiterengine.RunResult, error) {
 	_ = ctx
+	_ = appName
 	if s.getErr != nil {
 		return nil, s.getErr
 	}
@@ -87,7 +94,7 @@ func (s *scriptedStore) Get(ctx context.Context, runID string) (*promptiterengin
 	return run, nil
 }
 
-func (s *scriptedStore) Update(ctx context.Context, run *promptiterengine.RunResult) error {
+func (s *scriptedStore) Update(ctx context.Context, appName string, run *promptiterengine.RunResult) error {
 	_ = ctx
 	s.updateCalls++
 	if s.updateErr != nil {
@@ -98,6 +105,7 @@ func (s *scriptedStore) Update(ctx context.Context, run *promptiterengine.RunRes
 	if s.runs == nil {
 		s.runs = make(map[string]*promptiterengine.RunResult)
 	}
+	run.AppName = appName
 	s.runs[run.ID] = run
 	return nil
 }
@@ -163,7 +171,7 @@ func TestManagerStartAndGetReturnRun(t *testing.T) {
 			}, nil
 		},
 	}
-	managerInstance, err := New(engineInstance)
+	managerInstance, err := New("demo-app", engineInstance)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, managerInstance.Close())
@@ -176,6 +184,7 @@ func TestManagerStartAndGetReturnRun(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, run)
+	assert.Equal(t, "demo-app", run.AppName)
 	assert.Equal(t, promptiterengine.RunStatusQueued, run.Status)
 	assert.NotEmpty(t, run.ID)
 	require.Eventually(t, func() bool {
@@ -186,6 +195,7 @@ func TestManagerStartAndGetReturnRun(t *testing.T) {
 	current, err := managerInstance.Get(context.Background(), run.ID)
 	require.NoError(t, err)
 	require.NotNil(t, current)
+	assert.Equal(t, "demo-app", current.AppName)
 	assert.Equal(t, run.ID, current.ID)
 	assert.Equal(t, promptiterengine.RunStatusSucceeded, current.Status)
 	require.NotNil(t, current.Structure)
@@ -217,6 +227,7 @@ func TestManagerStartStoresFinalSlimmedRun(t *testing.T) {
 		},
 	}
 	managerInstance, err := New(
+		"demo-app",
 		engineInstance,
 		WithStoredResultSlimming(promptiterengine.RunResultSlimming{OmitStructure: true}),
 	)
@@ -340,7 +351,7 @@ func TestManagerCancelTransitionsRun(t *testing.T) {
 			return nil, ctx.Err()
 		},
 	}
-	managerInstance, err := New(engineInstance)
+	managerInstance, err := New("demo-app", engineInstance)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, managerInstance.Close())
@@ -364,7 +375,7 @@ func TestManagerCancelTransitionsRun(t *testing.T) {
 }
 
 func TestRunObserverBuildsIncrementalRun(t *testing.T) {
-	managerInstance, err := New(&fakePromptIterEngine{})
+	managerInstance, err := New("demo-app", &fakePromptIterEngine{})
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, managerInstance.Close())
@@ -372,10 +383,11 @@ func TestRunObserverBuildsIncrementalRun(t *testing.T) {
 	concreteManager, ok := managerInstance.(*manager)
 	require.True(t, ok)
 	run := &promptiterengine.RunResult{
-		ID:     "run-1",
-		Status: promptiterengine.RunStatusRunning,
+		AppName: "demo-app",
+		ID:      "run-1",
+		Status:  promptiterengine.RunStatusRunning,
 	}
-	require.NoError(t, concreteManager.store.Create(context.Background(), run))
+	require.NoError(t, concreteManager.store.Create(context.Background(), "demo-app", run))
 	observer := &observer{
 		manager: concreteManager,
 		run:     run,
@@ -474,7 +486,7 @@ func TestRunObserverBuildsIncrementalRun(t *testing.T) {
 
 func TestRunObserverPassesContextToStoreUpdate(t *testing.T) {
 	store := &recordingStore{}
-	managerInstance, err := New(&fakePromptIterEngine{}, WithStore(store))
+	managerInstance, err := New("demo-app", &fakePromptIterEngine{}, WithStore(store))
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, managerInstance.Close())
@@ -482,8 +494,9 @@ func TestRunObserverPassesContextToStoreUpdate(t *testing.T) {
 	concreteManager, ok := managerInstance.(*manager)
 	require.True(t, ok)
 	run := &promptiterengine.RunResult{
-		ID:     "run-ctx",
-		Status: promptiterengine.RunStatusRunning,
+		AppName: "demo-app",
+		ID:      "run-ctx",
+		Status:  promptiterengine.RunStatusRunning,
 	}
 	observer := &observer{
 		manager: concreteManager,
@@ -498,7 +511,9 @@ func TestRunObserverPassesContextToStoreUpdate(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, store.updateCtx)
 	assert.Equal(t, "store-update", store.updateCtx.Value(ctxKey{}))
+	assert.Equal(t, "demo-app", store.updateAppName)
 	require.NotNil(t, store.updateRun)
+	assert.Equal(t, "demo-app", store.updateRun.AppName)
 	assert.Equal(t, run.ID, store.updateRun.ID)
 	assert.Equal(t, run.Status, store.updateRun.Status)
 	require.NotNil(t, store.updateRun.BaselineValidation)
@@ -507,8 +522,7 @@ func TestRunObserverPassesContextToStoreUpdate(t *testing.T) {
 
 func TestRunObserverStoresSlimmedCopy(t *testing.T) {
 	store := &recordingStore{}
-	managerInstance, err := New(
-		&fakePromptIterEngine{},
+	managerInstance, err := New("demo-app", &fakePromptIterEngine{},
 		WithStore(store),
 		WithStoredResultSlimming(promptiterengine.RunResultSlimming{
 			OmitStructure:       true,
@@ -522,8 +536,9 @@ func TestRunObserverStoresSlimmedCopy(t *testing.T) {
 	concreteManager, ok := managerInstance.(*manager)
 	require.True(t, ok)
 	run := &promptiterengine.RunResult{
-		ID:     "run-slim",
-		Status: promptiterengine.RunStatusRunning,
+		AppName: "demo-app",
+		ID:      "run-slim",
+		Status:  promptiterengine.RunStatusRunning,
 	}
 	observer := &observer{
 		manager: concreteManager,
@@ -560,7 +575,7 @@ func TestRunObserverStoresSlimmedCopy(t *testing.T) {
 }
 
 func TestRunObserverRejectsInvalidEvents(t *testing.T) {
-	managerInstance, err := New(&fakePromptIterEngine{})
+	managerInstance, err := New("demo-app", &fakePromptIterEngine{})
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, managerInstance.Close())
@@ -569,11 +584,12 @@ func TestRunObserverRejectsInvalidEvents(t *testing.T) {
 	observer := &observer{
 		manager: concreteManager,
 		run: &promptiterengine.RunResult{
-			ID:     "run-1",
-			Status: promptiterengine.RunStatusRunning,
+			AppName: "demo-app",
+			ID:      "run-1",
+			Status:  promptiterengine.RunStatusRunning,
 		},
 	}
-	require.NoError(t, concreteManager.store.Create(context.Background(), observer.run))
+	require.NoError(t, concreteManager.store.Create(context.Background(), "demo-app", observer.run))
 	assert.EqualError(t, observer.append(context.Background(), nil), "promptiter event is nil")
 	testCases := []struct {
 		name       string
@@ -702,7 +718,7 @@ func TestRunObserverRejectsInvalidEvents(t *testing.T) {
 }
 
 func TestManagerGetReturnsNotFoundForMissingRun(t *testing.T) {
-	managerInstance, err := New(&fakePromptIterEngine{})
+	managerInstance, err := New("demo-app", &fakePromptIterEngine{})
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, managerInstance.Close())
@@ -712,8 +728,37 @@ func TestManagerGetReturnsNotFoundForMissingRun(t *testing.T) {
 	assert.ErrorIs(t, err, os.ErrNotExist)
 }
 
+func TestManagerGetIsolatesSharedStoreByAppName(t *testing.T) {
+	ctx := context.Background()
+	sharedStore := promptiterinmemory.New()
+	managerA, err := New("app-a", &fakePromptIterEngine{}, WithStore(sharedStore))
+	require.NoError(t, err)
+	managerB, err := New("app-b", &fakePromptIterEngine{}, WithStore(sharedStore))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, managerA.Close())
+		require.NoError(t, managerB.Close())
+	})
+	require.NoError(t, sharedStore.Create(ctx, "app-a", &promptiterengine.RunResult{
+		ID:     "run-1",
+		Status: promptiterengine.RunStatusQueued,
+	}))
+	require.NoError(t, sharedStore.Create(ctx, "app-b", &promptiterengine.RunResult{
+		ID:     "run-1",
+		Status: promptiterengine.RunStatusSucceeded,
+	}))
+	runA, err := managerA.Get(ctx, "run-1")
+	require.NoError(t, err)
+	runB, err := managerB.Get(ctx, "run-1")
+	require.NoError(t, err)
+	assert.Equal(t, "app-a", runA.AppName)
+	assert.Equal(t, promptiterengine.RunStatusQueued, runA.Status)
+	assert.Equal(t, "app-b", runB.AppName)
+	assert.Equal(t, promptiterengine.RunStatusSucceeded, runB.Status)
+}
+
 func TestManagerStartRejectsClosedManager(t *testing.T) {
-	managerInstance, err := New(&fakePromptIterEngine{})
+	managerInstance, err := New("demo-app", &fakePromptIterEngine{})
 	require.NoError(t, err)
 	require.NoError(t, managerInstance.Close())
 	run, err := managerInstance.Start(context.Background(), &promptiterengine.RunRequest{
@@ -726,14 +771,17 @@ func TestManagerStartRejectsClosedManager(t *testing.T) {
 }
 
 func TestNewRejectsNilEngine(t *testing.T) {
-	managerInstance, err := New(nil)
+	managerInstance, err := New("demo-app", nil)
 	assert.Nil(t, managerInstance)
 	assert.EqualError(t, err, "promptiter manager: engine must not be nil")
+	managerInstance, err = New("", &fakePromptIterEngine{})
+	assert.Nil(t, managerInstance)
+	assert.EqualError(t, err, "promptiter manager: app name must not be empty")
 }
 
 func TestManagerStartReturnsCreateError(t *testing.T) {
 	store := &scriptedStore{createErr: errors.New("create failed")}
-	managerInstance, err := New(&fakePromptIterEngine{}, WithStore(store))
+	managerInstance, err := New("demo-app", &fakePromptIterEngine{}, WithStore(store))
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, managerInstance.Close())
@@ -749,7 +797,7 @@ func TestManagerStartReturnsCreateError(t *testing.T) {
 }
 
 func TestManagerCancelRejectsMissingRun(t *testing.T) {
-	managerInstance, err := New(&fakePromptIterEngine{})
+	managerInstance, err := New("demo-app", &fakePromptIterEngine{})
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, managerInstance.Close())
@@ -765,12 +813,13 @@ func TestManagerCancelReturnsStoreErrors(t *testing.T) {
 			getErr: errors.New("load failed"),
 			runs: map[string]*promptiterengine.RunResult{
 				"run-1": {
-					ID:     "run-1",
-					Status: promptiterengine.RunStatusRunning,
+					AppName: "demo-app",
+					ID:      "run-1",
+					Status:  promptiterengine.RunStatusRunning,
 				},
 			},
 		}
-		managerInstance, err := New(&fakePromptIterEngine{}, WithStore(store))
+		managerInstance, err := New("demo-app", &fakePromptIterEngine{}, WithStore(store))
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			require.NoError(t, managerInstance.Close())
@@ -785,12 +834,13 @@ func TestManagerCancelReturnsStoreErrors(t *testing.T) {
 			updateErr: errors.New("update failed"),
 			runs: map[string]*promptiterengine.RunResult{
 				"run-1": {
-					ID:     "run-1",
-					Status: promptiterengine.RunStatusRunning,
+					AppName: "demo-app",
+					ID:      "run-1",
+					Status:  promptiterengine.RunStatusRunning,
 				},
 			},
 		}
-		managerInstance, err := New(&fakePromptIterEngine{}, WithStore(store))
+		managerInstance, err := New("demo-app", &fakePromptIterEngine{}, WithStore(store))
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			require.NoError(t, managerInstance.Close())
@@ -804,7 +854,7 @@ func TestManagerCancelReturnsStoreErrors(t *testing.T) {
 
 func TestManagerCloseIsIdempotent(t *testing.T) {
 	store := &scriptedStore{}
-	managerInstance, err := New(&fakePromptIterEngine{}, WithStore(store))
+	managerInstance, err := New("demo-app", &fakePromptIterEngine{}, WithStore(store))
 	require.NoError(t, err)
 	require.NoError(t, managerInstance.Close())
 	require.NoError(t, managerInstance.Close())
@@ -814,7 +864,7 @@ func TestManagerCloseIsIdempotent(t *testing.T) {
 func TestManagerRunHandlesErrorBranches(t *testing.T) {
 	t.Run("get error clears cancel", func(t *testing.T) {
 		store := &scriptedStore{getErr: errors.New("load failed")}
-		managerInstance, err := New(&fakePromptIterEngine{}, WithStore(store))
+		managerInstance, err := New("demo-app", &fakePromptIterEngine{}, WithStore(store))
 		require.NoError(t, err)
 		concreteManager := managerInstance.(*manager)
 		concreteManager.cancelFuncs["run-1"] = func() {}
@@ -828,12 +878,13 @@ func TestManagerRunHandlesErrorBranches(t *testing.T) {
 			updateErrAtCall: 1,
 			runs: map[string]*promptiterengine.RunResult{
 				"run-1": {
-					ID:     "run-1",
-					Status: promptiterengine.RunStatusQueued,
+					AppName: "demo-app",
+					ID:      "run-1",
+					Status:  promptiterengine.RunStatusQueued,
 				},
 			},
 		}
-		managerInstance, err := New(&fakePromptIterEngine{}, WithStore(store))
+		managerInstance, err := New("demo-app", &fakePromptIterEngine{}, WithStore(store))
 		require.NoError(t, err)
 		concreteManager := managerInstance.(*manager)
 		concreteManager.cancelFuncs["run-1"] = func() {}
@@ -845,8 +896,9 @@ func TestManagerRunHandlesErrorBranches(t *testing.T) {
 		store := &scriptedStore{
 			runs: map[string]*promptiterengine.RunResult{
 				"run-1": {
-					ID:     "run-1",
-					Status: promptiterengine.RunStatusRunning,
+					AppName: "demo-app",
+					ID:      "run-1",
+					Status:  promptiterengine.RunStatusRunning,
 				},
 			},
 		}
@@ -857,7 +909,7 @@ func TestManagerRunHandlesErrorBranches(t *testing.T) {
 				return nil, context.Canceled
 			},
 		}
-		managerInstance, err := New(engineInstance, WithStore(store))
+		managerInstance, err := New("demo-app", engineInstance, WithStore(store))
 		require.NoError(t, err)
 		concreteManager := managerInstance.(*manager)
 		concreteManager.cancelFuncs["run-1"] = func() {}
@@ -870,8 +922,9 @@ func TestManagerRunHandlesErrorBranches(t *testing.T) {
 		store := &scriptedStore{
 			runs: map[string]*promptiterengine.RunResult{
 				"run-1": {
-					ID:     "run-1",
-					Status: promptiterengine.RunStatusRunning,
+					AppName: "demo-app",
+					ID:      "run-1",
+					Status:  promptiterengine.RunStatusRunning,
 				},
 			},
 		}
@@ -883,7 +936,7 @@ func TestManagerRunHandlesErrorBranches(t *testing.T) {
 				return nil, errors.New("engine failed")
 			},
 		}
-		managerInstance, err := New(engineInstance, WithStore(store))
+		managerInstance, err := New("demo-app", engineInstance, WithStore(store))
 		require.NoError(t, err)
 		concreteManager := managerInstance.(*manager)
 		concreteManager.cancelFuncs["run-1"] = func() {}
@@ -896,8 +949,9 @@ func TestManagerRunHandlesErrorBranches(t *testing.T) {
 		store := &scriptedStore{
 			runs: map[string]*promptiterengine.RunResult{
 				"run-1": {
-					ID:     "run-1",
-					Status: promptiterengine.RunStatusRunning,
+					AppName: "demo-app",
+					ID:      "run-1",
+					Status:  promptiterengine.RunStatusRunning,
 				},
 			},
 		}
@@ -909,7 +963,7 @@ func TestManagerRunHandlesErrorBranches(t *testing.T) {
 				return nil, nil
 			},
 		}
-		managerInstance, err := New(engineInstance, WithStore(store))
+		managerInstance, err := New("demo-app", engineInstance, WithStore(store))
 		require.NoError(t, err)
 		concreteManager := managerInstance.(*manager)
 		concreteManager.cancelFuncs["run-1"] = func() {}
@@ -924,8 +978,9 @@ func TestManagerRunHandlesErrorBranches(t *testing.T) {
 			updateErrAtCall: 2,
 			runs: map[string]*promptiterengine.RunResult{
 				"run-1": {
-					ID:     "run-1",
-					Status: promptiterengine.RunStatusRunning,
+					AppName: "demo-app",
+					ID:      "run-1",
+					Status:  promptiterengine.RunStatusRunning,
 				},
 			},
 		}
@@ -937,7 +992,7 @@ func TestManagerRunHandlesErrorBranches(t *testing.T) {
 				return &promptiterengine.RunResult{}, nil
 			},
 		}
-		managerInstance, err := New(engineInstance, WithStore(store))
+		managerInstance, err := New("demo-app", engineInstance, WithStore(store))
 		require.NoError(t, err)
 		concreteManager := managerInstance.(*manager)
 		concreteManager.cancelFuncs["run-1"] = func() {}

--- a/evaluation/workflow/promptiter/manager/manager_test.go
+++ b/evaluation/workflow/promptiter/manager/manager_test.go
@@ -770,6 +770,16 @@ func TestManagerStartRejectsClosedManager(t *testing.T) {
 	assert.EqualError(t, err, "promptiter manager is closed")
 }
 
+func TestNewTrimsAppName(t *testing.T) {
+	managerInstance, err := New(" demo-app ", &fakePromptIterEngine{})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, managerInstance.Close())
+	})
+	concreteManager := managerInstance.(*manager)
+	assert.Equal(t, "demo-app", concreteManager.appName)
+}
+
 func TestNewRejectsNilEngine(t *testing.T) {
 	managerInstance, err := New("demo-app", nil)
 	assert.Nil(t, managerInstance)

--- a/evaluation/workflow/promptiter/manager/observer.go
+++ b/evaluation/workflow/promptiter/manager/observer.go
@@ -35,7 +35,7 @@ func (o *observer) append(ctx context.Context, event *engine.Event) error {
 	if err := o.applyEvent(event); err != nil {
 		return err
 	}
-	return o.manager.store.Update(ctx, o.manager.slimStoredRun(o.run))
+	return o.manager.store.Update(ctx, o.manager.appName, o.manager.slimStoredRun(o.run))
 }
 
 func (o *observer) applyEvent(event *engine.Event) error {

--- a/evaluation/workflow/promptiter/store/inmemory/inmemory.go
+++ b/evaluation/workflow/promptiter/store/inmemory/inmemory.go
@@ -23,67 +23,77 @@ import (
 
 type inMemoryStore struct {
 	mu   sync.RWMutex
-	runs map[string]*engine.RunResult
+	runs map[string]map[string]*engine.RunResult
 }
 
 // New creates an in-memory PromptIter store.
 func New() store.Store {
 	return &inMemoryStore{
-		runs: make(map[string]*engine.RunResult),
+		runs: make(map[string]map[string]*engine.RunResult),
 	}
 }
 
-func (s *inMemoryStore) Create(_ context.Context, run *engine.RunResult) error {
-	if run == nil {
-		return errors.New("promptiter run is nil")
+func (s *inMemoryStore) Create(_ context.Context, appName string, run *engine.RunResult) error {
+	if err := validateRun(appName, run); err != nil {
+		return err
 	}
-	if run.ID == "" {
-		return errors.New("promptiter run id is empty")
-	}
-	cloned, err := cloneRun(run)
+	persisted := *run
+	persisted.AppName = appName
+	cloned, err := cloneRun(&persisted)
 	if err != nil {
 		return fmt.Errorf("clone promptiter run: %w", err)
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if _, ok := s.runs[run.ID]; ok {
-		return fmt.Errorf("run %q already exists", run.ID)
+	appRuns := s.runs[appName]
+	if appRuns == nil {
+		appRuns = make(map[string]*engine.RunResult)
+		s.runs[appName] = appRuns
 	}
-	s.runs[run.ID] = cloned
+	if _, ok := appRuns[run.ID]; ok {
+		return fmt.Errorf("run %q for app %q already exists", run.ID, appName)
+	}
+	appRuns[run.ID] = cloned
 	return nil
 }
 
-func (s *inMemoryStore) Get(_ context.Context, runID string) (*engine.RunResult, error) {
+func (s *inMemoryStore) Get(_ context.Context, appName, runID string) (*engine.RunResult, error) {
+	if err := validateRunKey(appName, runID); err != nil {
+		return nil, err
+	}
 	s.mu.RLock()
-	run, ok := s.runs[runID]
+	appRuns := s.runs[appName]
+	run, ok := appRuns[runID]
 	s.mu.RUnlock()
 	if !ok {
-		return nil, fmt.Errorf("run %q not found: %w", runID, os.ErrNotExist)
+		return nil, fmt.Errorf("run %q for app %q not found: %w", runID, appName, os.ErrNotExist)
 	}
 	cloned, err := cloneRun(run)
 	if err != nil {
 		return nil, fmt.Errorf("clone promptiter run %q: %w", runID, err)
 	}
+	cloned.AppName = appName
+	cloned.ID = runID
 	return cloned, nil
 }
 
-func (s *inMemoryStore) Update(_ context.Context, run *engine.RunResult) error {
-	if run == nil {
-		return errors.New("promptiter run is nil")
+func (s *inMemoryStore) Update(_ context.Context, appName string, run *engine.RunResult) error {
+	if err := validateRun(appName, run); err != nil {
+		return err
 	}
-	if run.ID == "" {
-		return errors.New("promptiter run id is empty")
-	}
-	cloned, err := cloneRun(run)
+	persisted := *run
+	persisted.AppName = appName
+	cloned, err := cloneRun(&persisted)
 	if err != nil {
 		return fmt.Errorf("clone promptiter run: %w", err)
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if _, ok := s.runs[run.ID]; !ok {
-		return fmt.Errorf("run %q not found: %w", run.ID, os.ErrNotExist)
+	appRuns := s.runs[appName]
+	if _, ok := appRuns[run.ID]; !ok {
+		return fmt.Errorf("run %q for app %q not found: %w", run.ID, appName, os.ErrNotExist)
 	}
-	s.runs[run.ID] = cloned
+	appRuns[run.ID] = cloned
 	return nil
 }
 
@@ -104,4 +114,27 @@ func cloneRun(run *engine.RunResult) (*engine.RunResult, error) {
 		return nil, err
 	}
 	return &cloned, nil
+}
+
+func validateRun(appName string, run *engine.RunResult) error {
+	if run == nil {
+		return errors.New("promptiter run is nil")
+	}
+	if err := validateRunKey(appName, run.ID); err != nil {
+		return err
+	}
+	if run.AppName != "" && run.AppName != appName {
+		return fmt.Errorf("promptiter run app name %q does not match %q", run.AppName, appName)
+	}
+	return nil
+}
+
+func validateRunKey(appName, runID string) error {
+	if appName == "" {
+		return errors.New("promptiter run app name is empty")
+	}
+	if runID == "" {
+		return errors.New("promptiter run id is empty")
+	}
+	return nil
 }

--- a/evaluation/workflow/promptiter/store/inmemory/inmemory_test.go
+++ b/evaluation/workflow/promptiter/store/inmemory/inmemory_test.go
@@ -28,8 +28,9 @@ func TestInMemoryStoreCreateGetUpdate(t *testing.T) {
 		assert.NoError(t, store.Close())
 	})
 	run := &engine.RunResult{
-		ID:     "run-1",
-		Status: engine.RunStatusQueued,
+		AppName: "demo-app",
+		ID:      "run-1",
+		Status:  engine.RunStatusQueued,
 		AcceptedProfile: &promptiter.Profile{
 			StructureID: "structure-1",
 			Overrides: []promptiter.SurfaceOverride{
@@ -46,13 +47,14 @@ func TestInMemoryStoreCreateGetUpdate(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, store.Create(ctx, run))
+	require.NoError(t, store.Create(ctx, "demo-app", run))
 	run.Status = engine.RunStatusFailed
 	run.AcceptedProfile.StructureID = "mutated"
 	run.Rounds[0].Acceptance.Reason = "mutated"
-	loaded, err := store.Get(ctx, "run-1")
+	loaded, err := store.Get(ctx, "demo-app", "run-1")
 	require.NoError(t, err)
 	require.NotNil(t, loaded)
+	assert.Equal(t, "demo-app", loaded.AppName)
 	assert.Equal(t, engine.RunStatusQueued, loaded.Status)
 	require.NotNil(t, loaded.AcceptedProfile)
 	assert.Equal(t, "structure-1", loaded.AcceptedProfile.StructureID)
@@ -61,15 +63,15 @@ func TestInMemoryStoreCreateGetUpdate(t *testing.T) {
 	assert.Equal(t, "accepted", loaded.Rounds[0].Acceptance.Reason)
 	loaded.Status = engine.RunStatusSucceeded
 	loaded.AcceptedProfile.StructureID = "loaded-mutated"
-	require.NoError(t, store.Update(ctx, loaded))
-	loadedAgain, err := store.Get(ctx, "run-1")
+	require.NoError(t, store.Update(ctx, "demo-app", loaded))
+	loadedAgain, err := store.Get(ctx, "demo-app", "run-1")
 	require.NoError(t, err)
 	require.NotNil(t, loadedAgain)
 	assert.Equal(t, engine.RunStatusSucceeded, loadedAgain.Status)
 	require.NotNil(t, loadedAgain.AcceptedProfile)
 	assert.Equal(t, "loaded-mutated", loadedAgain.AcceptedProfile.StructureID)
 	loadedAgain.AcceptedProfile.StructureID = "second-mutation"
-	loadedOnceMore, err := store.Get(ctx, "run-1")
+	loadedOnceMore, err := store.Get(ctx, "demo-app", "run-1")
 	require.NoError(t, err)
 	require.NotNil(t, loadedOnceMore)
 	require.NotNil(t, loadedOnceMore.AcceptedProfile)
@@ -82,8 +84,10 @@ func TestInMemoryStoreValidationAndNotFoundErrors(t *testing.T) {
 	t.Cleanup(func() {
 		assert.NoError(t, store.Close())
 	})
-	assert.EqualError(t, store.Create(ctx, nil), "promptiter run is nil")
-	assert.EqualError(t, store.Create(ctx, &engine.RunResult{}), "promptiter run id is empty")
+	assert.EqualError(t, store.Create(ctx, "demo-app", nil), "promptiter run is nil")
+	assert.EqualError(t, store.Create(ctx, "", &engine.RunResult{ID: "run-1"}), "promptiter run app name is empty")
+	assert.EqualError(t, store.Create(ctx, "demo-app", &engine.RunResult{}), "promptiter run id is empty")
+	assert.EqualError(t, store.Create(ctx, "demo-app", &engine.RunResult{AppName: "other-app", ID: "run-1"}), `promptiter run app name "other-app" does not match "demo-app"`)
 }
 
 func TestInMemoryStoreGetMissingRun(t *testing.T) {
@@ -92,7 +96,7 @@ func TestInMemoryStoreGetMissingRun(t *testing.T) {
 	t.Cleanup(func() {
 		assert.NoError(t, store.Close())
 	})
-	run, err := store.Get(ctx, "missing")
+	run, err := store.Get(ctx, "demo-app", "missing")
 	assert.Nil(t, run)
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, os.ErrNotExist)
@@ -104,17 +108,45 @@ func TestInMemoryStoreCreateDuplicateAndUpdateMissing(t *testing.T) {
 	t.Cleanup(func() {
 		assert.NoError(t, store.Close())
 	})
-	run := &engine.RunResult{ID: "run-1", Status: engine.RunStatusQueued}
-	require.NoError(t, store.Create(ctx, run))
-	err := store.Create(ctx, run)
-	assert.EqualError(t, err, `run "run-1" already exists`)
-	err = store.Update(ctx, nil)
+	run := &engine.RunResult{AppName: "demo-app", ID: "run-1", Status: engine.RunStatusQueued}
+	require.NoError(t, store.Create(ctx, "demo-app", run))
+	err := store.Create(ctx, "demo-app", run)
+	assert.EqualError(t, err, `run "run-1" for app "demo-app" already exists`)
+	err = store.Update(ctx, "demo-app", nil)
 	assert.EqualError(t, err, "promptiter run is nil")
-	err = store.Update(ctx, &engine.RunResult{})
+	err = store.Update(ctx, "", &engine.RunResult{ID: "run-1"})
+	assert.EqualError(t, err, "promptiter run app name is empty")
+	err = store.Update(ctx, "demo-app", &engine.RunResult{})
 	assert.EqualError(t, err, "promptiter run id is empty")
-	err = store.Update(ctx, &engine.RunResult{ID: "missing", Status: engine.RunStatusQueued})
+	err = store.Update(ctx, "demo-app", &engine.RunResult{AppName: "other-app", ID: "run-1"})
+	assert.EqualError(t, err, `promptiter run app name "other-app" does not match "demo-app"`)
+	err = store.Update(ctx, "demo-app", &engine.RunResult{AppName: "demo-app", ID: "missing", Status: engine.RunStatusQueued})
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestInMemoryStoreIsolatesRunsByAppName(t *testing.T) {
+	ctx := context.Background()
+	store := New().(*inMemoryStore)
+	t.Cleanup(func() {
+		assert.NoError(t, store.Close())
+	})
+	require.NoError(t, store.Create(ctx, "app-a", &engine.RunResult{
+		AppName: "app-a",
+		ID:      "run-1",
+		Status:  engine.RunStatusQueued,
+	}))
+	require.NoError(t, store.Create(ctx, "app-b", &engine.RunResult{
+		AppName: "app-b",
+		ID:      "run-1",
+		Status:  engine.RunStatusSucceeded,
+	}))
+	appA, err := store.Get(ctx, "app-a", "run-1")
+	require.NoError(t, err)
+	appB, err := store.Get(ctx, "app-b", "run-1")
+	require.NoError(t, err)
+	assert.Equal(t, engine.RunStatusQueued, appA.Status)
+	assert.Equal(t, engine.RunStatusSucceeded, appB.Status)
 }
 
 func TestInMemoryStoreCloneErrors(t *testing.T) {
@@ -124,18 +156,19 @@ func TestInMemoryStoreCloneErrors(t *testing.T) {
 		assert.NoError(t, store.Close())
 	})
 	badRun := &engine.RunResult{
-		ID: "run-1",
+		AppName: "demo-app",
+		ID:      "run-1",
 		BaselineValidation: &engine.EvaluationResult{
 			OverallScore: math.NaN(),
 		},
 	}
-	err := store.Create(ctx, badRun)
+	err := store.Create(ctx, "demo-app", badRun)
 	assert.ErrorContains(t, err, "clone promptiter run")
-	store.runs["run-1"] = badRun
-	loaded, err := store.Get(ctx, "run-1")
+	store.runs["demo-app"] = map[string]*engine.RunResult{"run-1": badRun}
+	loaded, err := store.Get(ctx, "demo-app", "run-1")
 	assert.Nil(t, loaded)
 	assert.ErrorContains(t, err, "clone promptiter run")
-	err = store.Update(ctx, badRun)
+	err = store.Update(ctx, "demo-app", badRun)
 	assert.ErrorContains(t, err, "clone promptiter run")
 }
 

--- a/evaluation/workflow/promptiter/store/mysql/mysql.go
+++ b/evaluation/workflow/promptiter/store/mysql/mysql.go
@@ -51,44 +51,43 @@ func New(opts ...Option) (store.Store, error) {
 }
 
 // Create persists one new PromptIter run.
-func (s *mysqlStore) Create(ctx context.Context, run *engine.RunResult) error {
-	if run == nil {
-		return errors.New("promptiter run is nil")
+func (s *mysqlStore) Create(ctx context.Context, appName string, run *engine.RunResult) error {
+	if err := validateRun(appName, run); err != nil {
+		return err
 	}
-	if run.ID == "" {
-		return errors.New("promptiter run id is empty")
-	}
-	payload, err := json.Marshal(run)
+	persisted := *run
+	persisted.AppName = appName
+	payload, err := json.Marshal(&persisted)
 	if err != nil {
 		return fmt.Errorf("marshal promptiter run %q: %w", run.ID, err)
 	}
 	query := fmt.Sprintf(
-		"INSERT INTO %s (run_id, status, run_result) VALUES (?, ?, ?)",
+		"INSERT INTO %s (app_name, run_id, status, run_result) VALUES (?, ?, ?, ?)",
 		s.tableName,
 	)
 	// Pass JSON as a UTF-8 string so the driver does not bind []byte as BINARY (MySQL JSON rejects binary charset).
-	if _, err := s.db.Exec(ctx, query, run.ID, string(run.Status), string(payload)); err != nil {
+	if _, err := s.db.Exec(ctx, query, appName, run.ID, string(run.Status), string(payload)); err != nil {
 		if mysqldb.IsDuplicateEntry(err) {
-			return fmt.Errorf("run %q already exists", run.ID)
+			return fmt.Errorf("run %q for app %q already exists", run.ID, appName)
 		}
 		return fmt.Errorf("create run %q: %w", run.ID, err)
 	}
 	return nil
 }
 
-// Get loads one persisted PromptIter run by run ID.
-func (s *mysqlStore) Get(ctx context.Context, runID string) (*engine.RunResult, error) {
-	if runID == "" {
-		return nil, errors.New("run id is empty")
+// Get loads one persisted PromptIter run by app name and run ID.
+func (s *mysqlStore) Get(ctx context.Context, appName, runID string) (*engine.RunResult, error) {
+	if err := validateRunKey(appName, runID); err != nil {
+		return nil, err
 	}
 	var payload []byte
 	query := fmt.Sprintf(
-		"SELECT run_result FROM %s WHERE run_id = ?",
+		"SELECT run_result FROM %s WHERE app_name = ? AND run_id = ?",
 		s.tableName,
 	)
-	if err := s.db.QueryRow(ctx, []any{&payload}, query, runID); err != nil {
+	if err := s.db.QueryRow(ctx, []any{&payload}, query, appName, runID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, fmt.Errorf("run %q not found: %w", runID, os.ErrNotExist)
+			return nil, fmt.Errorf("run %q for app %q not found: %w", runID, appName, os.ErrNotExist)
 		}
 		return nil, fmt.Errorf("load run %q: %w", runID, err)
 	}
@@ -96,29 +95,27 @@ func (s *mysqlStore) Get(ctx context.Context, runID string) (*engine.RunResult, 
 	if err := json.Unmarshal(payload, &run); err != nil {
 		return nil, fmt.Errorf("unmarshal run %q: %w", runID, err)
 	}
-	if run.ID == "" {
-		run.ID = runID
-	}
+	run.AppName = appName
+	run.ID = runID
 	return &run, nil
 }
 
 // Update persists changes to one existing PromptIter run.
-func (s *mysqlStore) Update(ctx context.Context, run *engine.RunResult) error {
-	if run == nil {
-		return errors.New("promptiter run is nil")
+func (s *mysqlStore) Update(ctx context.Context, appName string, run *engine.RunResult) error {
+	if err := validateRun(appName, run); err != nil {
+		return err
 	}
-	if run.ID == "" {
-		return errors.New("promptiter run id is empty")
-	}
-	payload, err := json.Marshal(run)
+	persisted := *run
+	persisted.AppName = appName
+	payload, err := json.Marshal(&persisted)
 	if err != nil {
 		return fmt.Errorf("marshal promptiter run %q: %w", run.ID, err)
 	}
 	query := fmt.Sprintf(
-		"UPDATE %s SET status = ?, run_result = ?, updated_at = CURRENT_TIMESTAMP(6) WHERE run_id = ?",
+		"UPDATE %s SET status = ?, run_result = ?, updated_at = CURRENT_TIMESTAMP(6) WHERE app_name = ? AND run_id = ?",
 		s.tableName,
 	)
-	result, err := s.db.Exec(ctx, query, string(run.Status), string(payload), run.ID)
+	result, err := s.db.Exec(ctx, query, string(run.Status), string(payload), appName, run.ID)
 	if err != nil {
 		return fmt.Errorf("update run %q: %w", run.ID, err)
 	}
@@ -127,7 +124,7 @@ func (s *mysqlStore) Update(ctx context.Context, run *engine.RunResult) error {
 		return fmt.Errorf("rows affected for run %q: %w", run.ID, err)
 	}
 	if affected == 0 {
-		return fmt.Errorf("run %q not found: %w", run.ID, os.ErrNotExist)
+		return fmt.Errorf("run %q for app %q not found: %w", run.ID, appName, os.ErrNotExist)
 	}
 	return nil
 }
@@ -138,4 +135,27 @@ func (s *mysqlStore) Close() error {
 		return nil
 	}
 	return s.db.Close()
+}
+
+func validateRun(appName string, run *engine.RunResult) error {
+	if run == nil {
+		return errors.New("promptiter run is nil")
+	}
+	if err := validateRunKey(appName, run.ID); err != nil {
+		return err
+	}
+	if run.AppName != "" && run.AppName != appName {
+		return fmt.Errorf("promptiter run app name %q does not match %q", run.AppName, appName)
+	}
+	return nil
+}
+
+func validateRunKey(appName, runID string) error {
+	if appName == "" {
+		return errors.New("promptiter run app name is empty")
+	}
+	if runID == "" {
+		return errors.New("promptiter run id is empty")
+	}
+	return nil
 }

--- a/evaluation/workflow/promptiter/store/mysql/mysql_test.go
+++ b/evaluation/workflow/promptiter/store/mysql/mysql_test.go
@@ -116,10 +116,14 @@ func TestClose_NilClient(t *testing.T) {
 func TestCreateValidationErrors(t *testing.T) {
 	ctx := context.Background()
 	store := &mysqlStore{}
-	err := store.Create(ctx, nil)
+	err := store.Create(ctx, "demo-app", nil)
 	assert.Error(t, err)
-	err = store.Create(ctx, &engine.RunResult{})
+	err = store.Create(ctx, "", &engine.RunResult{ID: "run-1"})
 	assert.Error(t, err)
+	err = store.Create(ctx, "demo-app", &engine.RunResult{})
+	assert.Error(t, err)
+	err = store.Create(ctx, "demo-app", &engine.RunResult{AppName: "other-app", ID: "run-1"})
+	assert.EqualError(t, err, `promptiter run app name "other-app" does not match "demo-app"`)
 }
 
 func TestCreateStoresRun(t *testing.T) {
@@ -127,17 +131,20 @@ func TestCreateStoresRun(t *testing.T) {
 	store, db, mock := newMySQLStore(t)
 	t.Cleanup(func() { _ = db.Close() })
 	run := &engine.RunResult{
-		ID:     "run-1",
-		Status: engine.RunStatusQueued,
+		AppName: "demo-app",
+		ID:      "run-1",
+		Status:  engine.RunStatusQueued,
 	}
+	payload, err := json.Marshal(run)
+	assert.NoError(t, err)
 	query := fmt.Sprintf(
-		"INSERT INTO %s \\(run_id, status, run_result\\) VALUES \\(\\?, \\?, \\?\\)",
+		"INSERT INTO %s \\(app_name, run_id, status, run_result\\) VALUES \\(\\?, \\?, \\?, \\?\\)",
 		regexp.QuoteMeta(store.tableName),
 	)
 	mock.ExpectExec(query).
-		WithArgs("run-1", string(engine.RunStatusQueued), sqlmock.AnyArg()).
+		WithArgs("demo-app", "run-1", string(engine.RunStatusQueued), string(payload)).
 		WillReturnResult(sqlmock.NewResult(1, 1))
-	err := store.Create(ctx, run)
+	err = store.Create(ctx, "demo-app", run)
 	assert.NoError(t, err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
@@ -147,25 +154,28 @@ func TestCreateDuplicateEntryReturnsFriendlyError(t *testing.T) {
 	store, db, mock := newMySQLStore(t)
 	t.Cleanup(func() { _ = db.Close() })
 	run := &engine.RunResult{
-		ID:     "run-1",
-		Status: engine.RunStatusQueued,
+		AppName: "demo-app",
+		ID:      "run-1",
+		Status:  engine.RunStatusQueued,
 	}
 	query := fmt.Sprintf(
-		"INSERT INTO %s \\(run_id, status, run_result\\) VALUES \\(\\?, \\?, \\?\\)",
+		"INSERT INTO %s \\(app_name, run_id, status, run_result\\) VALUES \\(\\?, \\?, \\?, \\?\\)",
 		regexp.QuoteMeta(store.tableName),
 	)
 	mock.ExpectExec(query).
-		WithArgs("run-1", string(engine.RunStatusQueued), sqlmock.AnyArg()).
+		WithArgs("demo-app", "run-1", string(engine.RunStatusQueued), sqlmock.AnyArg()).
 		WillReturnError(&mysqlerr.MySQLError{Number: sqldb.MySQLErrDuplicateEntry})
-	err := store.Create(ctx, run)
-	assert.EqualError(t, err, `run "run-1" already exists`)
+	err := store.Create(ctx, "demo-app", run)
+	assert.EqualError(t, err, `run "run-1" for app "demo-app" already exists`)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestGetValidationError(t *testing.T) {
 	ctx := context.Background()
 	store := &mysqlStore{}
-	_, err := store.Get(ctx, "")
+	_, err := store.Get(ctx, "", "run-1")
+	assert.Error(t, err)
+	_, err = store.Get(ctx, "demo-app", "")
 	assert.Error(t, err)
 }
 
@@ -174,6 +184,7 @@ func TestGetLoadsRun(t *testing.T) {
 	store, db, mock := newMySQLStore(t)
 	t.Cleanup(func() { _ = db.Close() })
 	run := &engine.RunResult{
+		AppName:      "demo-app",
 		ID:           "run-1",
 		Status:       engine.RunStatusRunning,
 		CurrentRound: 2,
@@ -182,13 +193,14 @@ func TestGetLoadsRun(t *testing.T) {
 	payload, err := json.Marshal(run)
 	assert.NoError(t, err)
 	query := fmt.Sprintf(
-		"SELECT run_result FROM %s WHERE run_id = \\?",
+		"SELECT run_result FROM %s WHERE app_name = \\? AND run_id = \\?",
 		regexp.QuoteMeta(store.tableName),
 	)
 	rows := sqlmock.NewRows([]string{"run_result"}).AddRow(payload)
-	mock.ExpectQuery(query).WithArgs("run-1").WillReturnRows(rows)
-	loaded, err := store.Get(ctx, "run-1")
+	mock.ExpectQuery(query).WithArgs("demo-app", "run-1").WillReturnRows(rows)
+	loaded, err := store.Get(ctx, "demo-app", "run-1")
 	assert.NoError(t, err)
+	assert.Equal(t, run.AppName, loaded.AppName)
 	assert.Equal(t, run.ID, loaded.ID)
 	assert.Equal(t, run.Status, loaded.Status)
 	assert.Equal(t, run.CurrentRound, loaded.CurrentRound)
@@ -201,11 +213,11 @@ func TestGetNotFound(t *testing.T) {
 	store, db, mock := newMySQLStore(t)
 	t.Cleanup(func() { _ = db.Close() })
 	query := fmt.Sprintf(
-		"SELECT run_result FROM %s WHERE run_id = \\?",
+		"SELECT run_result FROM %s WHERE app_name = \\? AND run_id = \\?",
 		regexp.QuoteMeta(store.tableName),
 	)
-	mock.ExpectQuery(query).WithArgs("run-1").WillReturnError(sql.ErrNoRows)
-	_, err := store.Get(ctx, "run-1")
+	mock.ExpectQuery(query).WithArgs("demo-app", "run-1").WillReturnError(sql.ErrNoRows)
+	_, err := store.Get(ctx, "demo-app", "run-1")
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, os.ErrNotExist)
 	assert.NoError(t, mock.ExpectationsWereMet())
@@ -216,12 +228,12 @@ func TestGetUnmarshalError(t *testing.T) {
 	store, db, mock := newMySQLStore(t)
 	t.Cleanup(func() { _ = db.Close() })
 	query := fmt.Sprintf(
-		"SELECT run_result FROM %s WHERE run_id = \\?",
+		"SELECT run_result FROM %s WHERE app_name = \\? AND run_id = \\?",
 		regexp.QuoteMeta(store.tableName),
 	)
 	rows := sqlmock.NewRows([]string{"run_result"}).AddRow([]byte("{"))
-	mock.ExpectQuery(query).WithArgs("run-1").WillReturnRows(rows)
-	_, err := store.Get(ctx, "run-1")
+	mock.ExpectQuery(query).WithArgs("demo-app", "run-1").WillReturnRows(rows)
+	_, err := store.Get(ctx, "demo-app", "run-1")
 	assert.Error(t, err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
@@ -229,10 +241,14 @@ func TestGetUnmarshalError(t *testing.T) {
 func TestUpdateValidationErrors(t *testing.T) {
 	ctx := context.Background()
 	store := &mysqlStore{}
-	err := store.Update(ctx, nil)
+	err := store.Update(ctx, "demo-app", nil)
 	assert.Error(t, err)
-	err = store.Update(ctx, &engine.RunResult{})
+	err = store.Update(ctx, "", &engine.RunResult{ID: "run-1"})
 	assert.Error(t, err)
+	err = store.Update(ctx, "demo-app", &engine.RunResult{})
+	assert.Error(t, err)
+	err = store.Update(ctx, "demo-app", &engine.RunResult{AppName: "other-app", ID: "run-1"})
+	assert.EqualError(t, err, `promptiter run app name "other-app" does not match "demo-app"`)
 }
 
 func TestUpdatePersistsRun(t *testing.T) {
@@ -240,17 +256,20 @@ func TestUpdatePersistsRun(t *testing.T) {
 	store, db, mock := newMySQLStore(t)
 	t.Cleanup(func() { _ = db.Close() })
 	run := &engine.RunResult{
-		ID:     "run-1",
-		Status: engine.RunStatusSucceeded,
+		AppName: "demo-app",
+		ID:      "run-1",
+		Status:  engine.RunStatusSucceeded,
 	}
+	payload, err := json.Marshal(run)
+	assert.NoError(t, err)
 	query := fmt.Sprintf(
-		"UPDATE %s SET status = \\?, run_result = \\?, updated_at = CURRENT_TIMESTAMP\\(6\\) WHERE run_id = \\?",
+		"UPDATE %s SET status = \\?, run_result = \\?, updated_at = CURRENT_TIMESTAMP\\(6\\) WHERE app_name = \\? AND run_id = \\?",
 		regexp.QuoteMeta(store.tableName),
 	)
 	mock.ExpectExec(query).
-		WithArgs(string(engine.RunStatusSucceeded), sqlmock.AnyArg(), "run-1").
+		WithArgs(string(engine.RunStatusSucceeded), string(payload), "demo-app", "run-1").
 		WillReturnResult(sqlmock.NewResult(0, 1))
-	err := store.Update(ctx, run)
+	err = store.Update(ctx, "demo-app", run)
 	assert.NoError(t, err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
@@ -260,17 +279,18 @@ func TestUpdateMissingRunReturnsNotFound(t *testing.T) {
 	store, db, mock := newMySQLStore(t)
 	t.Cleanup(func() { _ = db.Close() })
 	run := &engine.RunResult{
-		ID:     "run-1",
-		Status: engine.RunStatusSucceeded,
+		AppName: "demo-app",
+		ID:      "run-1",
+		Status:  engine.RunStatusSucceeded,
 	}
 	query := fmt.Sprintf(
-		"UPDATE %s SET status = \\?, run_result = \\?, updated_at = CURRENT_TIMESTAMP\\(6\\) WHERE run_id = \\?",
+		"UPDATE %s SET status = \\?, run_result = \\?, updated_at = CURRENT_TIMESTAMP\\(6\\) WHERE app_name = \\? AND run_id = \\?",
 		regexp.QuoteMeta(store.tableName),
 	)
 	mock.ExpectExec(query).
-		WithArgs(string(engine.RunStatusSucceeded), sqlmock.AnyArg(), "run-1").
+		WithArgs(string(engine.RunStatusSucceeded), sqlmock.AnyArg(), "demo-app", "run-1").
 		WillReturnResult(sqlmock.NewResult(0, 0))
-	err := store.Update(ctx, run)
+	err := store.Update(ctx, "demo-app", run)
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, os.ErrNotExist)
 	assert.NoError(t, mock.ExpectationsWereMet())
@@ -285,7 +305,7 @@ func TestEnsureSchemaIgnoresDuplicateIndexName(t *testing.T) {
 	tableName := sqldb.BuildTableName("test_", tableNameRuns)
 	mock.ExpectExec("CREATE TABLE IF NOT EXISTS\\s+" + regexp.QuoteMeta(tableName)).
 		WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectExec("CREATE UNIQUE INDEX\\s+" + regexp.QuoteMeta(runIDUniqueIndexName) + "\\s+ON\\s+" + regexp.QuoteMeta(tableName)).
+	mock.ExpectExec("CREATE UNIQUE INDEX\\s+" + regexp.QuoteMeta(appRunUniqueIndexName) + "\\s+ON\\s+" + regexp.QuoteMeta(tableName)).
 		WillReturnError(&mysqlerr.MySQLError{Number: sqldb.MySQLErrDuplicateKeyName})
 	err = ensureSchema(ctx, client, tableName)
 	assert.NoError(t, err)

--- a/evaluation/workflow/promptiter/store/mysql/schema.go
+++ b/evaluation/workflow/promptiter/store/mysql/schema.go
@@ -18,11 +18,12 @@ import (
 )
 
 const (
-	tableNameRuns        = "promptiter_runs"
-	runIDUniqueIndexName = "uniq_promptiter_runs_run_id"
-	sqlCreateRunsTable   = `
+	tableNameRuns         = "promptiter_runs"
+	appRunUniqueIndexName = "uniq_promptiter_runs_app_run"
+	sqlCreateRunsTable    = `
 		CREATE TABLE IF NOT EXISTS {{TABLE_NAME}} (
 			id BIGINT NOT NULL AUTO_INCREMENT,
+			app_name VARCHAR(255) NOT NULL,
 			run_id VARCHAR(255) NOT NULL,
 			status VARCHAR(32) NOT NULL DEFAULT '',
 			run_result JSON NOT NULL,
@@ -30,8 +31,8 @@ const (
 			updated_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
 			PRIMARY KEY (id)
 		) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`
-	sqlCreateRunIDUniqueIndex = `
-		CREATE UNIQUE INDEX {{INDEX_NAME}} ON {{TABLE_NAME}}(run_id)`
+	sqlCreateAppRunUniqueIndex = `
+		CREATE UNIQUE INDEX {{INDEX_NAME}} ON {{TABLE_NAME}}(app_name, run_id)`
 )
 
 func ensureSchema(ctx context.Context, db storage.Client, tableName string) error {
@@ -39,13 +40,13 @@ func ensureSchema(ctx context.Context, db storage.Client, tableName string) erro
 	if _, err := db.Exec(ctx, createTableQuery); err != nil {
 		return fmt.Errorf("create table %s failed: %w", tableName, err)
 	}
-	createIndexQuery := strings.ReplaceAll(sqlCreateRunIDUniqueIndex, "{{TABLE_NAME}}", tableName)
-	createIndexQuery = strings.ReplaceAll(createIndexQuery, "{{INDEX_NAME}}", runIDUniqueIndexName)
+	createIndexQuery := strings.ReplaceAll(sqlCreateAppRunUniqueIndex, "{{TABLE_NAME}}", tableName)
+	createIndexQuery = strings.ReplaceAll(createIndexQuery, "{{INDEX_NAME}}", appRunUniqueIndexName)
 	if _, err := db.Exec(ctx, createIndexQuery); err != nil {
 		if mysqldb.IsDuplicateKeyName(err) {
 			return nil
 		}
-		return fmt.Errorf("create index %s on table %s failed: %w", runIDUniqueIndexName, tableName, err)
+		return fmt.Errorf("create index %s on table %s failed: %w", appRunUniqueIndexName, tableName, err)
 	}
 	return nil
 }

--- a/evaluation/workflow/promptiter/store/mysql/schema.sql
+++ b/evaluation/workflow/promptiter/store/mysql/schema.sql
@@ -5,11 +5,12 @@
 
 CREATE TABLE IF NOT EXISTS `{{PREFIX}}promptiter_runs` (
   `id` BIGINT NOT NULL AUTO_INCREMENT,
+  `app_name` VARCHAR(255) NOT NULL,
   `run_id` VARCHAR(255) NOT NULL,
   `status` VARCHAR(32) NOT NULL DEFAULT '',
   `run_result` JSON NOT NULL,
   `created_at` TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   `updated_at` TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
   PRIMARY KEY (`id`),
-  UNIQUE KEY `uniq_promptiter_runs_run_id` (`run_id`)
+  UNIQUE KEY `uniq_promptiter_runs_app_run` (`app_name`, `run_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/evaluation/workflow/promptiter/store/store.go
+++ b/evaluation/workflow/promptiter/store/store.go
@@ -18,11 +18,11 @@ import (
 // Store stores persisted PromptIter runs.
 type Store interface {
 	// Create persists one new PromptIter run.
-	Create(ctx context.Context, run *engine.RunResult) error
-	// Get loads one persisted PromptIter run by run ID.
-	Get(ctx context.Context, runID string) (*engine.RunResult, error)
+	Create(ctx context.Context, appName string, run *engine.RunResult) error
+	// Get loads one persisted PromptIter run by app name and run ID.
+	Get(ctx context.Context, appName, runID string) (*engine.RunResult, error)
 	// Update persists changes to one existing PromptIter run.
-	Update(ctx context.Context, run *engine.RunResult) error
+	Update(ctx context.Context, appName string, run *engine.RunResult) error
 	// Close releases store resources.
 	Close() error
 }

--- a/examples/evaluation/promptiter/asyncrun/engine.go
+++ b/examples/evaluation/promptiter/asyncrun/engine.go
@@ -197,7 +197,7 @@ func buildPromptIterRuntime(ctx context.Context, cfg asyncRunConfig) (*promptIte
 		closeAll()
 		return nil, fmt.Errorf("create promptiter engine: %w", err)
 	}
-	managerInstance, err := promptitermanager.New(engineInstance)
+	managerInstance, err := promptitermanager.New(appName, engineInstance)
 	if err != nil {
 		agentEvaluator.Close()
 		closeAll()

--- a/examples/evaluation/promptiter/server/engine.go
+++ b/examples/evaluation/promptiter/server/engine.go
@@ -163,7 +163,7 @@ func buildPromptIterRuntime(ctx context.Context, cfg serverConfig) (*promptIterR
 		closeAll()
 		return nil, fmt.Errorf("create promptiter engine: %w", err)
 	}
-	managerInstance, err := promptitermanager.New(engineInstance)
+	managerInstance, err := promptitermanager.New(appName, engineInstance)
 	if err != nil {
 		agentEvaluator.Close()
 		closeAll()

--- a/server/promptiter/handler.go
+++ b/server/promptiter/handler.go
@@ -204,6 +204,11 @@ func (s *Server) runResponse(run *engine.RunResult) *RunResponse {
 	if s == nil {
 		return &RunResponse{Result: run}
 	}
+	if run != nil && run.AppName == "" {
+		cloned := *run
+		cloned.AppName = s.appName
+		run = &cloned
+	}
 	return &RunResponse{
 		Result: slimRunResult(run, s.responseResultSlimming),
 	}

--- a/server/promptiter/server.go
+++ b/server/promptiter/server.go
@@ -46,14 +46,15 @@ type Server struct {
 // New creates a new PromptIter HTTP server.
 func New(opts ...Option) (*Server, error) {
 	options := newOptions(opts...)
-	if strings.TrimSpace(options.appName) == "" {
+	appName := strings.TrimSpace(options.appName)
+	if appName == "" {
 		return nil, errors.New("promptiter server: app name must not be empty")
 	}
 	if options.engine == nil {
 		return nil, errors.New("promptiter server: engine must not be nil")
 	}
 	basePath := normalizeBasePath(options.basePath)
-	appBasePath, err := joinURLPath(basePath, options.appName)
+	appBasePath, err := joinURLPath(basePath, appName)
 	if err != nil {
 		return nil, fmt.Errorf("promptiter server: join app base path: %w", err)
 	}
@@ -70,7 +71,7 @@ func New(opts ...Option) (*Server, error) {
 		return nil, fmt.Errorf("promptiter server: join async runs path: %w", err)
 	}
 	server := &Server{
-		appName:                options.appName,
+		appName:                appName,
 		basePath:               appBasePath,
 		structurePath:          structurePath,
 		runsPath:               runsPath,

--- a/server/promptiter/server_test.go
+++ b/server/promptiter/server_test.go
@@ -260,6 +260,7 @@ func TestHandleRunsPassesRequestThrough(t *testing.T) {
 	var resp RunResponse
 	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &resp))
 	require.NotNil(t, resp.Result)
+	assert.Equal(t, "demo-app", resp.Result.AppName)
 	assert.Equal(t, enginepkg.RunStatusSucceeded, resp.Result.Status)
 }
 
@@ -489,6 +490,7 @@ func TestHandleAsyncRunsStartsRunWhenManagerIsConfigured(t *testing.T) {
 				_ = ctx
 				captured = request
 				return &enginepkg.RunResult{
+					AppName:   "demo-app",
 					ID:        "run_1",
 					Status:    enginepkg.RunStatusQueued,
 					Structure: &astructure.Snapshot{StructureID: "struct_1", EntryNodeID: "node_1"},
@@ -515,6 +517,7 @@ func TestHandleAsyncRunsStartsRunWhenManagerIsConfigured(t *testing.T) {
 	var resp RunResponse
 	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &resp))
 	require.NotNil(t, resp.Result)
+	assert.Equal(t, "demo-app", resp.Result.AppName)
 	assert.Equal(t, "run_1", resp.Result.ID)
 	assert.Equal(t, enginepkg.RunStatusQueued, resp.Result.Status)
 	assert.Nil(t, resp.Result.Structure)
@@ -568,6 +571,7 @@ func TestHandleGetRunReturnsRun(t *testing.T) {
 			get: func(ctx context.Context, runID string) (*enginepkg.RunResult, error) {
 				_ = ctx
 				return &enginepkg.RunResult{
+					AppName:      "demo-app",
 					ID:           runID,
 					Status:       enginepkg.RunStatusRunning,
 					CurrentRound: 2,
@@ -583,6 +587,7 @@ func TestHandleGetRunReturnsRun(t *testing.T) {
 	var resp RunResponse
 	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &resp))
 	require.NotNil(t, resp.Result)
+	assert.Equal(t, "demo-app", resp.Result.AppName)
 	assert.Equal(t, "run_1", resp.Result.ID)
 	assert.Equal(t, enginepkg.RunStatusRunning, resp.Result.Status)
 	assert.Equal(t, 2, resp.Result.CurrentRound)

--- a/server/promptiter/server_test.go
+++ b/server/promptiter/server_test.go
@@ -195,6 +195,12 @@ func TestDefaultAndCustomPaths(t *testing.T) {
 	assert.Equal(t, "/api/promptiter/demo-app/background-executions", customServer.AsyncRunsPath())
 }
 
+func TestNewTrimsAppName(t *testing.T) {
+	srv := newTestServer(t, WithAppName(" demo-app "))
+	assert.Equal(t, "demo-app", srv.appName)
+	assert.Equal(t, "/promptiter/v1/apps/demo-app", srv.BasePath())
+}
+
 func TestHandleStructure(t *testing.T) {
 	srv := newTestServer(t)
 	req := httptest.NewRequest(http.MethodGet, srv.StructurePath(), nil)
@@ -490,7 +496,6 @@ func TestHandleAsyncRunsStartsRunWhenManagerIsConfigured(t *testing.T) {
 				_ = ctx
 				captured = request
 				return &enginepkg.RunResult{
-					AppName:   "demo-app",
 					ID:        "run_1",
 					Status:    enginepkg.RunStatusQueued,
 					Structure: &astructure.Snapshot{StructureID: "struct_1", EntryNodeID: "node_1"},
@@ -571,7 +576,6 @@ func TestHandleGetRunReturnsRun(t *testing.T) {
 			get: func(ctx context.Context, runID string) (*enginepkg.RunResult, error) {
 				_ = ctx
 				return &enginepkg.RunResult{
-					AppName:      "demo-app",
 					ID:           runID,
 					Status:       enginepkg.RunStatusRunning,
 					CurrentRound: 2,


### PR DESCRIPTION
This change makes PromptIter run persistence app-scoped by adding appName to RunResult and the MySQL schema, changing Store and Manager construction to carry appName through create, load, and update paths, and updating server responses, examples, and docs to reflect app-scoped async run data. It intentionally treats the new store and manager signatures as a breaking API change.