### PR TITLE
evaluation: add judge runner sample count

### DIFF
--- a/docs/mkdocs/en/evaluation.md
+++ b/docs/mkdocs/en/evaluation.md
@@ -2189,7 +2189,7 @@ The framework includes `invocationsaggregator/average`, which is the default for
 
 By default, LLM Judge evaluators call the judge model directly via `criterion.llmJudge.judgeModel`. You can also inject a judge runner with `evaluation.WithJudgeRunner`, and use the runner's final `*model.Response` instead of a direct model call.
 
-When enabled, `judgeModel` is ignored. Each invocation calls the judge runner once.
+When enabled, `judgeModel` is ignored. Each invocation calls the judge runner once by default. You can explicitly increase runner sampling with `evaluation.WithJudgeRunnerNumSamples(...)`; multiple samples reuse the evaluator's current sample aggregator, which selects a representative sample by majority vote by default.
 
 Example snippet:
 
@@ -2206,6 +2206,7 @@ agentEvaluator, err := evaluation.New(
 	appName,
 	agentRunner,
 	evaluation.WithJudgeRunner(judgeRunner),
+	evaluation.WithJudgeRunnerNumSamples(3),
 )
 ```
 

--- a/docs/mkdocs/en/evaluation.md
+++ b/docs/mkdocs/en/evaluation.md
@@ -2189,7 +2189,7 @@ The framework includes `invocationsaggregator/average`, which is the default for
 
 By default, LLM Judge evaluators call the judge model directly via `criterion.llmJudge.judgeModel`. You can also inject a judge runner with `evaluation.WithJudgeRunner`, and use the runner's final `*model.Response` instead of a direct model call.
 
-When enabled, `judgeModel` is ignored. Each invocation calls the judge runner once by default. You can explicitly increase runner sampling with `evaluation.WithJudgeRunnerNumSamples(...)`; multiple samples reuse the evaluator's current sample aggregator, which selects a representative sample by majority vote by default.
+When enabled, `judgeModel` is ignored. Each invocation calls the judge runner once by default. You can explicitly increase runner sampling with `evaluation.WithJudgeRunnerNumSamples(n)`, where `n` must be greater than or equal to 1; non-positive values return an error from `evaluation.New(...)` or `Evaluate(...)` option merging. Multiple samples reuse the evaluator's current sample aggregator, which selects a representative sample by majority vote by default.
 
 Example snippet:
 

--- a/docs/mkdocs/zh/evaluation.md
+++ b/docs/mkdocs/zh/evaluation.md
@@ -2192,7 +2192,7 @@ type InvocationsAggregator interface {
 
 LLM Judge 类评估器默认通过 `criterion.llmJudge.judgeModel` 直连裁判模型获取裁判输出。也可以通过 `evaluation.WithJudgeRunner` 注入一个裁判 Runner，用 runner 的最终 `*model.Response` 替代直连模型。
 
-启用后 `judgeModel` 被忽略，每个 invocation 默认调用 judge runner 1 次。可以通过 `evaluation.WithJudgeRunnerNumSamples(...)` 显式增加 runner 采样次数；多次采样会复用当前评估器的 sample aggregator，默认按多数票选出代表样本。
+启用后 `judgeModel` 被忽略，每个 invocation 默认调用 judge runner 1 次。可以通过 `evaluation.WithJudgeRunnerNumSamples(n)` 显式增加 runner 采样次数，`n` 必须大于等于 1，非正数会在 `evaluation.New(...)` 或 `Evaluate(...)` 合并选项时返回错误。多次采样会复用当前评估器的 sample aggregator，默认按多数票选出代表样本。
 
 示例片段如下：
 

--- a/docs/mkdocs/zh/evaluation.md
+++ b/docs/mkdocs/zh/evaluation.md
@@ -2192,7 +2192,7 @@ type InvocationsAggregator interface {
 
 LLM Judge 类评估器默认通过 `criterion.llmJudge.judgeModel` 直连裁判模型获取裁判输出。也可以通过 `evaluation.WithJudgeRunner` 注入一个裁判 Runner，用 runner 的最终 `*model.Response` 替代直连模型。
 
-启用后 `judgeModel` 被忽略，每个 invocation 默认调用 judge runner 1 次。
+启用后 `judgeModel` 被忽略，每个 invocation 默认调用 judge runner 1 次。可以通过 `evaluation.WithJudgeRunnerNumSamples(...)` 显式增加 runner 采样次数；多次采样会复用当前评估器的 sample aggregator，默认按多数票选出代表样本。
 
 示例片段如下：
 
@@ -2209,6 +2209,7 @@ agentEvaluator, err := evaluation.New(
 	appName,
 	agentRunner,
 	evaluation.WithJudgeRunner(judgeRunner),
+	evaluation.WithJudgeRunnerNumSamples(3),
 )
 ```
 

--- a/evaluation/evaluation.go
+++ b/evaluation/evaluation.go
@@ -333,15 +333,22 @@ func (a *agentEvaluator) runEvaluation(ctx context.Context, evalSetID string, op
 		if err != nil {
 			return nil, fmt.Errorf("get metric %s: %w", metricName, err)
 		}
+		metricForRun := evalMetric
 		if opts.judgeRunner != nil && evalMetric != nil && evalMetric.Criterion != nil && evalMetric.Criterion.LLMJudge != nil {
+			metricCopy := *evalMetric
+			criterionCopy := *evalMetric.Criterion
+			llmJudgeCopy := *evalMetric.Criterion.LLMJudge
 			judgeRunnerOptions := &metricllm.JudgeRunnerOptions{Runner: opts.judgeRunner}
 			if opts.judgeRunnerNumSamples != nil {
 				numSamples := *opts.judgeRunnerNumSamples
 				judgeRunnerOptions.NumSamples = &numSamples
 			}
-			evalMetric.Criterion.LLMJudge.JudgeRunnerOptions = judgeRunnerOptions
+			llmJudgeCopy.JudgeRunnerOptions = judgeRunnerOptions
+			criterionCopy.LLMJudge = &llmJudgeCopy
+			metricCopy.Criterion = &criterionCopy
+			metricForRun = &metricCopy
 		}
-		evalMetrics = append(evalMetrics, evalMetric)
+		evalMetrics = append(evalMetrics, metricForRun)
 	}
 	var runCaseResults [][]*evalresult.EvalCaseResult
 	if opts != nil && opts.numRunsParallelEnabled != nil && *opts.numRunsParallelEnabled {

--- a/evaluation/evaluation.go
+++ b/evaluation/evaluation.go
@@ -59,6 +59,7 @@ func New(appName string, runner runner.Runner, opt ...Option) (AgentEvaluator, e
 		appName:                           appName,
 		runner:                            runner,
 		judgeRunner:                       opts.judgeRunner,
+		judgeRunnerNumSamples:             opts.judgeRunnerNumSamples,
 		evalSetManager:                    opts.evalSetManager,
 		evalResultManager:                 opts.evalResultManager,
 		metricManager:                     opts.metricManager,
@@ -116,6 +117,7 @@ type agentEvaluator struct {
 	appName                           string
 	runner                            runner.Runner
 	judgeRunner                       runner.Runner
+	judgeRunnerNumSamples             *int
 	evalSetManager                    evalset.Manager
 	evalResultManager                 evalresult.Manager
 	metricManager                     metric.Manager
@@ -216,6 +218,8 @@ func (a *agentEvaluator) mergeCallOptions(opt ...Option) (*options, error) {
 		evalService:                       a.evalService,
 		callbacks:                         a.callbacks,
 		expectedRunner:                    a.expectedRunner,
+		judgeRunner:                       a.judgeRunner,
+		judgeRunnerNumSamples:             a.judgeRunnerNumSamples,
 		numRuns:                           a.numRuns,
 		evalCaseIDs:                       append([]string(nil), a.evalCaseIDs...),
 		numRunsParallelEnabled:            a.numRunsParallelEnabled,
@@ -329,10 +333,13 @@ func (a *agentEvaluator) runEvaluation(ctx context.Context, evalSetID string, op
 		if err != nil {
 			return nil, fmt.Errorf("get metric %s: %w", metricName, err)
 		}
-		if a.judgeRunner != nil && evalMetric != nil && evalMetric.Criterion != nil && evalMetric.Criterion.LLMJudge != nil {
-			evalMetric.Criterion.LLMJudge.JudgeRunnerOptions = &metricllm.JudgeRunnerOptions{
-				Runner: a.judgeRunner,
+		if opts.judgeRunner != nil && evalMetric != nil && evalMetric.Criterion != nil && evalMetric.Criterion.LLMJudge != nil {
+			judgeRunnerOptions := &metricllm.JudgeRunnerOptions{Runner: opts.judgeRunner}
+			if opts.judgeRunnerNumSamples != nil {
+				numSamples := *opts.judgeRunnerNumSamples
+				judgeRunnerOptions.NumSamples = &numSamples
 			}
+			evalMetric.Criterion.LLMJudge.JudgeRunnerOptions = judgeRunnerOptions
 		}
 		evalMetrics = append(evalMetrics, evalMetric)
 	}

--- a/evaluation/evaluation_test.go
+++ b/evaluation/evaluation_test.go
@@ -971,6 +971,55 @@ func TestAgentEvaluatorEvaluateAppliesPerCallJudgeRunnerNumSamples(t *testing.T)
 	assert.NotSame(t, &judgeRunnerNumSamples, gotMetric.Criterion.LLMJudge.JudgeRunnerOptions.NumSamples)
 }
 
+func TestAgentEvaluatorRunEvaluationDoesNotMutateMetricWhenInjectingJudgeRunner(t *testing.T) {
+	ctx := context.Background()
+	appName := "app"
+	evalSetID := "set"
+	modelNumSamples := 1
+	configuredMetric := &metric.EvalMetric{
+		MetricName: "metric",
+		Threshold:  0.5,
+		Criterion: &criterion.Criterion{
+			LLMJudge: &criterionllm.LLMCriterion{
+				JudgeModel: &criterionllm.JudgeModelOptions{
+					ProviderName: "provider",
+					ModelName:    "model",
+					NumSamples:   &modelNumSamples,
+					Generation:   &model.GenerationConfig{},
+				},
+			},
+		},
+	}
+	metricMgr := &fakeMetricManager{metrics: map[string]*metric.EvalMetric{
+		configuredMetric.MetricName: configuredMetric,
+	}}
+	svc := &fakeService{
+		inferenceResults: [][]*service.InferenceResult{{}},
+	}
+	judgeRunner := &stubRunner{}
+	judgeRunnerNumSamples := 2
+	ae := &agentEvaluator{
+		appName:               appName,
+		evalService:           svc,
+		metricManager:         metricMgr,
+		evalResultManager:     evalresultinmemory.New(),
+		judgeRunner:           judgeRunner,
+		judgeRunnerNumSamples: &judgeRunnerNumSamples,
+		numRuns:               1,
+	}
+	_, err := ae.runEvaluation(ctx, evalSetID, defaultTestOptions(ae))
+	assert.NoError(t, err)
+	require.Len(t, svc.evaluateRequests, 1)
+	gotMetric := svc.evaluateRequests[0].EvaluateConfig.EvalMetrics[0]
+	require.NotNil(t, gotMetric.Criterion.LLMJudge.JudgeRunnerOptions)
+	assert.Nil(t, configuredMetric.Criterion.LLMJudge.JudgeRunnerOptions)
+	assert.NotSame(t, configuredMetric, gotMetric)
+	assert.NotSame(t, configuredMetric.Criterion, gotMetric.Criterion)
+	assert.NotSame(t, configuredMetric.Criterion.LLMJudge, gotMetric.Criterion.LLMJudge)
+	assert.Same(t, judgeRunner, gotMetric.Criterion.LLMJudge.JudgeRunnerOptions.Runner)
+	assert.Equal(t, &judgeRunnerNumSamples, gotMetric.Criterion.LLMJudge.JudgeRunnerOptions.NumSamples)
+}
+
 func TestAgentEvaluatorRunEvaluationExecutesRunsConcurrently(t *testing.T) {
 	ctx := context.Background()
 	svc := newBlockingRunService()

--- a/evaluation/evaluation_test.go
+++ b/evaluation/evaluation_test.go
@@ -356,6 +356,7 @@ func defaultTestOptions(ae *agentEvaluator) *options {
 		metricRegistry:         ae.metricRegistry,
 		evalService:            ae.evalService,
 		judgeRunner:            ae.judgeRunner,
+		judgeRunnerNumSamples:  ae.judgeRunnerNumSamples,
 		numRuns:                ae.numRuns,
 		numRunsParallelEnabled: ae.numRunsParallelEnabled,
 		runDetailsEnabled:      ae.runDetailsEnabled,
@@ -368,6 +369,9 @@ func TestNewAgentEvaluatorValidation(t *testing.T) {
 	assert.Error(t, err)
 
 	_, err = New("app", stubRunner{}, WithNumRuns(0))
+	assert.Error(t, err)
+
+	_, err = New("app", stubRunner{}, WithJudgeRunnerNumSamples(0))
 	assert.Error(t, err)
 
 	ae, err := New("app", stubRunner{}, WithEvalCaseParallelism(0))
@@ -903,6 +907,68 @@ func TestAgentEvaluatorEvaluateAppliesPerCallNumRuns(t *testing.T) {
 
 	assert.Len(t, svc.inferenceRequests, 2)
 	assert.Len(t, svc.evaluateRequests, 2)
+}
+
+func TestAgentEvaluatorEvaluateAppliesPerCallJudgeRunnerNumSamples(t *testing.T) {
+	ctx := context.Background()
+	appName := "app"
+	evalSetID := "set"
+
+	evalSetMgr := evalsetinmemory.New()
+	_, err := evalSetMgr.Create(ctx, appName, evalSetID)
+	assert.NoError(t, err)
+
+	metricMgr := metricinmemory.New()
+	modelNumSamples := 1
+	err = metricMgr.Add(ctx, appName, evalSetID, &metric.EvalMetric{
+		MetricName: "metric",
+		Threshold:  0.5,
+		Criterion: &criterion.Criterion{
+			LLMJudge: &criterionllm.LLMCriterion{
+				JudgeModel: &criterionllm.JudgeModelOptions{
+					ProviderName: "provider",
+					ModelName:    "model",
+					NumSamples:   &modelNumSamples,
+					Generation:   &model.GenerationConfig{},
+				},
+			},
+		},
+	})
+	assert.NoError(t, err)
+
+	svc := &fakeService{}
+	ae, err := New(
+		appName,
+		stubRunner{},
+		WithEvalSetManager(evalSetMgr),
+		WithEvalResultManager(evalresultinmemory.New()),
+		WithMetricManager(metricMgr),
+		WithRegistry(registry.New()),
+		WithEvaluationService(svc),
+	)
+	assert.NoError(t, err)
+	if err != nil {
+		return
+	}
+	defer func() {
+		assert.NoError(t, ae.Close())
+	}()
+
+	judgeRunner := &stubRunner{}
+	judgeRunnerNumSamples := 4
+	_, err = ae.Evaluate(
+		ctx,
+		evalSetID,
+		WithJudgeRunner(judgeRunner),
+		WithJudgeRunnerNumSamples(judgeRunnerNumSamples),
+	)
+	assert.NoError(t, err)
+	require.Len(t, svc.evaluateRequests, 1)
+	gotMetric := svc.evaluateRequests[0].EvaluateConfig.EvalMetrics[0]
+	require.NotNil(t, gotMetric.Criterion.LLMJudge.JudgeRunnerOptions)
+	assert.Same(t, judgeRunner, gotMetric.Criterion.LLMJudge.JudgeRunnerOptions.Runner)
+	assert.Equal(t, &judgeRunnerNumSamples, gotMetric.Criterion.LLMJudge.JudgeRunnerOptions.NumSamples)
+	assert.NotSame(t, &judgeRunnerNumSamples, gotMetric.Criterion.LLMJudge.JudgeRunnerOptions.NumSamples)
 }
 
 func TestAgentEvaluatorRunEvaluationExecutesRunsConcurrently(t *testing.T) {
@@ -1475,12 +1541,14 @@ func TestAgentEvaluatorRunEvaluationInjectsJudgeRunnerIntoLLMJudgeMetrics(t *tes
 
 	agentRunner := &stubRunner{}
 	judgeRunner := &stubRunner{}
+	judgeRunnerNumSamples := 2
 	res, err := New(
 		appName,
 		agentRunner,
 		WithEvaluationService(svc),
 		WithMetricManager(metricMgr),
 		WithJudgeRunner(judgeRunner),
+		WithJudgeRunnerNumSamples(judgeRunnerNumSamples),
 	)
 	if !assert.NoError(t, err) {
 		return
@@ -1523,6 +1591,7 @@ func TestAgentEvaluatorRunEvaluationInjectsJudgeRunnerIntoLLMJudgeMetrics(t *tes
 		return
 	}
 	assert.Equal(t, judgeRunner, gotMetric.Criterion.LLMJudge.JudgeRunnerOptions.Runner)
+	assert.Equal(t, &judgeRunnerNumSamples, gotMetric.Criterion.LLMJudge.JudgeRunnerOptions.NumSamples)
 }
 
 func TestAgentEvaluatorRunEvaluationPassesMetricRegistryToService(t *testing.T) {

--- a/evaluation/evaluator/llm/llm.go
+++ b/evaluation/evaluator/llm/llm.go
@@ -72,7 +72,11 @@ func (r *LLMBaseEvaluator) Evaluate(ctx context.Context, actuals, expecteds []*e
 		return nil, fmt.Errorf("missing required fields in eval metric")
 	}
 	numSamples := 1
-	if judgeRunner == nil {
+	if judgeRunner != nil {
+		if judgeCriterion.JudgeRunnerOptions.NumSamples != nil {
+			numSamples = *judgeCriterion.JudgeRunnerOptions.NumSamples
+		}
+	} else {
 		numSamplesPtr := judgeCriterion.JudgeModel.NumSamples
 		if numSamplesPtr == nil {
 			defaultNumSamples := llm.DefaultNumSamples

--- a/evaluation/evaluator/llm/llm_test.go
+++ b/evaluation/evaluator/llm/llm_test.go
@@ -419,12 +419,13 @@ func TestLLMBaseEvaluator_UsesJudgeRunnerNumSamples(t *testing.T) {
 func TestLLMBaseEvaluator_RejectsInvalidJudgeRunnerNumSamples(t *testing.T) {
 	base := &LLMBaseEvaluator{LLMEvaluator: &fakeLLMEvaluator{}}
 	numSamples := 0
+	r := &fakeJudgeRunner{}
 	evalMetric := &metric.EvalMetric{
 		Threshold: 0.5,
 		Criterion: &criterion.Criterion{
 			LLMJudge: &llm.LLMCriterion{
 				JudgeRunnerOptions: &llm.JudgeRunnerOptions{
-					Runner:     &fakeJudgeRunner{},
+					Runner:     r,
 					NumSamples: &numSamples,
 				},
 			},
@@ -439,6 +440,7 @@ func TestLLMBaseEvaluator_RejectsInvalidJudgeRunnerNumSamples(t *testing.T) {
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "num samples must be greater than 0")
+	assert.Equal(t, 0, r.runCalls)
 }
 
 func TestLLMBaseEvaluator_ResolveStructuredOutput(t *testing.T) {

--- a/evaluation/evaluator/llm/llm_test.go
+++ b/evaluation/evaluator/llm/llm_test.go
@@ -386,6 +386,61 @@ func TestLLMBaseEvaluator_UsesJudgeRunnerAndIgnoresJudgeModelNumSamples(t *testi
 	assert.Equal(t, 1, r.runCalls)
 }
 
+func TestLLMBaseEvaluator_UsesJudgeRunnerNumSamples(t *testing.T) {
+	stub := &fakeLLMEvaluator{}
+	base := &LLMBaseEvaluator{LLMEvaluator: stub}
+	evalMetric := buildEvalMetric("unknown-provider", 1)
+
+	r := &fakeJudgeRunner{
+		events: []*event.Event{
+			event.NewResponseEvent("inv", "judge", &model.Response{
+				Choices: []model.Choice{{Message: model.Message{Content: "ok"}}},
+				Done:    true,
+			}),
+		},
+	}
+	numSamples := 3
+	evalMetric.Criterion.LLMJudge.JudgeRunnerOptions = &llm.JudgeRunnerOptions{
+		Runner:     r,
+		NumSamples: &numSamples,
+	}
+
+	_, err := base.Evaluate(
+		context.Background(),
+		[]*evalset.Invocation{{InvocationID: "a"}},
+		[]*evalset.Invocation{{InvocationID: "b"}},
+		evalMetric,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 3, r.runCalls)
+	require.Len(t, stub.receivedSamples, 3)
+}
+
+func TestLLMBaseEvaluator_RejectsInvalidJudgeRunnerNumSamples(t *testing.T) {
+	base := &LLMBaseEvaluator{LLMEvaluator: &fakeLLMEvaluator{}}
+	numSamples := 0
+	evalMetric := &metric.EvalMetric{
+		Threshold: 0.5,
+		Criterion: &criterion.Criterion{
+			LLMJudge: &llm.LLMCriterion{
+				JudgeRunnerOptions: &llm.JudgeRunnerOptions{
+					Runner:     &fakeJudgeRunner{},
+					NumSamples: &numSamples,
+				},
+			},
+		},
+	}
+
+	_, err := base.Evaluate(
+		context.Background(),
+		[]*evalset.Invocation{{InvocationID: "a"}},
+		[]*evalset.Invocation{{InvocationID: "b"}},
+		evalMetric,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "num samples must be greater than 0")
+}
+
 func TestLLMBaseEvaluator_ResolveStructuredOutput(t *testing.T) {
 	base := &LLMBaseEvaluator{}
 	output, err := base.resolveStructuredOutput(context.Background(), nil, nil, nil)

--- a/evaluation/metric/criterion/llm/llm.go
+++ b/evaluation/metric/criterion/llm/llm.go
@@ -41,7 +41,8 @@ type RubricContent struct {
 
 // JudgeRunnerOptions configures how judge responses are obtained via a runner at runtime.
 type JudgeRunnerOptions struct {
-	Runner runner.Runner // Runner is the runner to use for judge responses.
+	Runner     runner.Runner // Runner is the runner to use for judge responses.
+	NumSamples *int          // NumSamples sets how many judge runner samples to collect.
 }
 
 // JudgeModelOptions captures model and generation configuration for the judge.

--- a/evaluation/options.go
+++ b/evaluation/options.go
@@ -41,6 +41,7 @@ type options struct {
 	userSimulator                     usersimulation.Simulator
 	callbacks                         *service.Callbacks
 	judgeRunner                       runner.Runner
+	judgeRunnerNumSamples             *int
 	numRuns                           int
 	evalCaseIDs                       []string
 	numRunsParallelEnabled            *bool
@@ -136,6 +137,13 @@ func WithJudgeRunner(judge runner.Runner) Option {
 	}
 }
 
+// WithJudgeRunnerNumSamples sets how many samples to collect from the judge runner.
+func WithJudgeRunnerNumSamples(numSamples int) Option {
+	return func(o *options) {
+		o.judgeRunnerNumSamples = &numSamples
+	}
+}
+
 // WithExpectedRunner sets the runner used to generate dynamic expected outputs.
 func WithExpectedRunner(r runner.Runner) Option {
 	return func(o *options) {
@@ -205,6 +213,9 @@ func (o *options) validate(requireEvalService bool) error {
 	}
 	if o.numRuns <= 0 {
 		return errors.New("num runs must be greater than 0")
+	}
+	if o.judgeRunnerNumSamples != nil && *o.judgeRunnerNumSamples <= 0 {
+		return errors.New("judge runner num samples must be greater than 0")
 	}
 	parallelInferenceEnabled := o.evalCaseParallelInferenceEnabled != nil && *o.evalCaseParallelInferenceEnabled
 	parallelEvaluationEnabled := o.evalCaseParallelEvaluationEnabled != nil && *o.evalCaseParallelEvaluationEnabled

--- a/evaluation/options_test.go
+++ b/evaluation/options_test.go
@@ -138,6 +138,12 @@ func TestWithJudgeRunner(t *testing.T) {
 	assert.Equal(t, custom, opts.judgeRunner)
 }
 
+func TestWithJudgeRunnerNumSamples(t *testing.T) {
+	opts := newOptions(WithJudgeRunnerNumSamples(3))
+	numSamples := 3
+	assert.Equal(t, &numSamples, opts.judgeRunnerNumSamples)
+}
+
 func TestWithNumRuns(t *testing.T) {
 	opts := newOptions(WithNumRuns(5))
 	assert.Equal(t, 5, opts.numRuns)
@@ -206,6 +212,15 @@ func TestOptionsValidateRejectsNilRegistry(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "registry is nil")
+}
+
+func TestOptionsValidateRejectsInvalidJudgeRunnerNumSamples(t *testing.T) {
+	opts := newOptions(WithJudgeRunnerNumSamples(0))
+
+	err := opts.validate(false)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "judge runner num samples must be greater than 0")
 }
 
 func TestOptionsValidateRejectsNilMetricRegistry(t *testing.T) {

--- a/evaluation/options_test.go
+++ b/evaluation/options_test.go
@@ -140,8 +140,8 @@ func TestWithJudgeRunner(t *testing.T) {
 
 func TestWithJudgeRunnerNumSamples(t *testing.T) {
 	opts := newOptions(WithJudgeRunnerNumSamples(3))
-	numSamples := 3
-	assert.Equal(t, &numSamples, opts.judgeRunnerNumSamples)
+	assert.NotNil(t, opts.judgeRunnerNumSamples)
+	assert.Equal(t, 3, *opts.judgeRunnerNumSamples)
 }
 
 func TestWithNumRuns(t *testing.T) {


### PR DESCRIPTION
Adds an explicit judge runner sample count option for LLM judge evaluation while preserving the default single runner call and direct judge model sampling semantics. The evaluation pipeline now carries the runner sample count into runtime judge options, validates invalid values, and documents how runner samples are aggregated.