### PR TITLE
codeexecutor/e2b: back-fill envd access token from create/connect response

### DIFF
--- a/codeexecutor/e2b/internal/codeinterpreter/sandbox.go
+++ b/codeexecutor/e2b/internal/codeinterpreter/sandbox.go
@@ -60,6 +60,13 @@ type SandboxInfo struct {
 	State      string            `json:"state,omitempty"`
 	// Domain is the actual domain on which this sandbox runs.
 	Domain string `json:"domain,omitempty"`
+	// EnvdAccessToken is an optional access token issued by the management
+	// API for authenticating data-plane requests against the sandbox's
+	// envd/jupyter endpoints. Some E2B-compatible deployments return this
+	// token at sandbox creation time. The official Python SDK behaves the
+	// same way: when present and the caller did not provide an AccessToken,
+	// the SDK uses this value as the X-Access-Token header.
+	EnvdAccessToken string `json:"envdAccessToken,omitempty"`
 }
 
 // Sandbox is a running E2B sandbox with code-interpreter capabilities.
@@ -176,14 +183,19 @@ func Create(ctx context.Context, opts *SandboxOpts) (*Sandbox, error) {
 	}
 
 	var out struct {
-		SandboxID  string `json:"sandboxID"`
-		ClientID   string `json:"clientID"`
-		TemplateID string `json:"templateID"`
-		EnvdPort   int    `json:"envdPort"`
-		Domain     string `json:"domain,omitempty"`
+		SandboxID       string `json:"sandboxID"`
+		ClientID        string `json:"clientID"`
+		TemplateID      string `json:"templateID"`
+		EnvdPort        int    `json:"envdPort"`
+		Domain          string `json:"domain,omitempty"`
+		EnvdAccessToken string `json:"envdAccessToken,omitempty"`
 	}
 	if err := cfg.do(ctx, "POST", "/sandboxes", body, &out); err != nil {
 		return nil, err
+	}
+
+	if out.EnvdAccessToken != "" && cfg.AccessToken == "" {
+		cfg.AccessToken = out.EnvdAccessToken
 	}
 
 	return &Sandbox{
@@ -217,6 +229,10 @@ func Connect(ctx context.Context, sandboxID string, opts *SandboxOpts) (*Sandbox
 	var info SandboxInfo
 	if err := cfg.do(ctx, "GET", "/sandboxes/"+sandboxID, nil, &info); err != nil {
 		return nil, err
+	}
+
+	if info.EnvdAccessToken != "" && cfg.AccessToken == "" {
+		cfg.AccessToken = info.EnvdAccessToken
 	}
 
 	return &Sandbox{

--- a/codeexecutor/e2b/internal/codeinterpreter/sandbox_test.go
+++ b/codeexecutor/e2b/internal/codeinterpreter/sandbox_test.go
@@ -606,3 +606,134 @@ func TestSandbox_GetInfoConcurrentWithGetHost(t *testing.T) {
 	}
 	<-done
 }
+
+func TestCreate_BackfillsEnvdAccessToken(t *testing.T) {
+	t.Setenv("E2B_ACCESS_TOKEN", "")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/sandboxes" || r.Method != "POST" {
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"sandboxID":"sbx-1",
+			"clientID":"c-1",
+			"templateID":"tpl",
+			"envdPort":49999,
+			"envdAccessToken":"envd-from-api"
+		}`))
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Transport: &rewriteToServerTransport{target: srv.URL}}
+	sbx, err := Create(context.Background(), &SandboxOpts{
+		APIKey:     "k",
+		Domain:     "e2b.test",
+		Debug:      true,
+		HTTPClient: client,
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if got := sbx.connection.AccessToken; got != "envd-from-api" {
+		t.Errorf("expected AccessToken to be back-filled from envdAccessToken; got %q", got)
+	}
+	h := http.Header{}
+	sbx.addAuthHeaders(h)
+	if got := h.Get("X-Access-Token"); got != "envd-from-api" {
+		t.Errorf("X-Access-Token header: %q", got)
+	}
+}
+
+func TestCreate_DoesNotOverrideExplicitAccessToken(t *testing.T) {
+	t.Setenv("E2B_ACCESS_TOKEN", "")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"sandboxID":"sbx-1",
+			"clientID":"c-1",
+			"templateID":"tpl",
+			"envdPort":49999,
+			"envdAccessToken":"envd-from-api"
+		}`))
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Transport: &rewriteToServerTransport{target: srv.URL}}
+	sbx, err := Create(context.Background(), &SandboxOpts{
+		APIKey:      "k",
+		AccessToken: "explicit-token",
+		Domain:      "e2b.test",
+		Debug:       true,
+		HTTPClient:  client,
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if got := sbx.connection.AccessToken; got != "explicit-token" {
+		t.Errorf("explicit AccessToken should not be overridden; got %q", got)
+	}
+}
+
+func TestConnect_BackfillsEnvdAccessToken(t *testing.T) {
+	t.Setenv("E2B_ACCESS_TOKEN", "")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" || r.URL.Path != "/sandboxes/abc" {
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"sandboxID":"abc",
+			"clientID":"cid",
+			"templateID":"tpl",
+			"envdAccessToken":"envd-from-api"
+		}`))
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Transport: &rewriteToServerTransport{target: srv.URL}}
+	sbx, err := Connect(context.Background(), "abc", &SandboxOpts{
+		APIKey:     "k",
+		Domain:     "e2b.test",
+		Debug:      true,
+		HTTPClient: client,
+	})
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	if got := sbx.connection.AccessToken; got != "envd-from-api" {
+		t.Errorf("expected AccessToken to be back-filled; got %q", got)
+	}
+}
+
+func TestConnect_DoesNotOverrideExplicitAccessToken(t *testing.T) {
+	t.Setenv("E2B_ACCESS_TOKEN", "")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"sandboxID":"abc",
+			"clientID":"cid",
+			"templateID":"tpl",
+			"envdAccessToken":"envd-from-api"
+		}`))
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Transport: &rewriteToServerTransport{target: srv.URL}}
+	sbx, err := Connect(context.Background(), "abc", &SandboxOpts{
+		APIKey:      "k",
+		AccessToken: "explicit-token",
+		Domain:      "e2b.test",
+		Debug:       true,
+		HTTPClient:  client,
+	})
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	if got := sbx.connection.AccessToken; got != "explicit-token" {
+		t.Errorf("explicit AccessToken should not be overridden; got %q", got)
+	}
+}


### PR DESCRIPTION
Fixes #1853

## What

Back-fill the data-plane `AccessToken` from the management API's
`envdAccessToken` field on both `Create` and `Connect` paths. When the
caller already supplies an explicit `AccessToken`, it is preserved
(principle of least surprise).

## Why

Some E2B-compatible deployments issue a short-lived `envdAccessToken`
at sandbox creation time and expect it as the `X-Access-Token` header
on subsequent data-plane requests against the sandbox's envd/jupyter
endpoints. The official Python SDK already behaves this way; this
change brings the Go SDK to parity.

Without this change, talking to gateway-fronted E2B-compatible services
fails on every data-plane call with `AUTHENTICATION_FAILED` even
though sandbox creation succeeds.

## How

- Add `EnvdAccessToken` field to `SandboxInfo`.
- Add `envdAccessToken` to the `Create` response struct.
- In both `Create` and `Connect`, if the API returns a non-empty
  `envdAccessToken` and the caller did not set an `AccessToken`,
  adopt the API-returned value.

## Tests

- 4 new unit tests in `sandbox_test.go` covering both Create and
  Connect paths, plus "explicit wins" semantics.
- All existing tests pass.
- Verified end-to-end against a real E2B-compatible deployment:
  ExecutePython / ExecuteBash / MultipleBlocks / WorkspaceFileOps /
  ErrorHandling all pass after the change (all fail with
  `AUTHENTICATION_FAILED` before). Connect path also verified
  separately via `WithSandboxID`.

## Release Notes

`codeexecutor/e2b` now automatically picks up the `envdAccessToken`
returned by the E2B management API at sandbox creation/connect time,
enabling compatibility with gateway-fronted E2B-compatible services