### PR TITLE
evaluation/workflow/promptiter: merge duplicate backward propagations

### DIFF
--- a/evaluation/workflow/promptiter/backwarder/backwarder.go
+++ b/evaluation/workflow/promptiter/backwarder/backwarder.go
@@ -443,7 +443,7 @@ func sanitizeBackwardResult(request *Request, result *Result) (*Result, error) {
 	if len(predecessorIndex) == 0 && len(result.Upstream) > 0 {
 		return nil, errors.New("upstream propagations are not allowed without predecessors")
 	}
-	seenPredecessors := make(map[string]struct{}, len(result.Upstream))
+	upstreamIndex := make(map[string]int, len(result.Upstream))
 	for _, propagation := range result.Upstream {
 		sanitizedPropagation, keep, err := sanitizePropagation(request, predecessorIndex, propagation)
 		if err != nil {
@@ -452,13 +452,14 @@ func sanitizeBackwardResult(request *Request, result *Result) (*Result, error) {
 		if !keep {
 			continue
 		}
-		if _, ok := seenPredecessors[sanitizedPropagation.PredecessorStepID]; ok {
-			return nil, fmt.Errorf(
-				"duplicate propagation for predecessor step id %q",
-				sanitizedPropagation.PredecessorStepID,
+		if existingIndex, ok := upstreamIndex[sanitizedPropagation.PredecessorStepID]; ok {
+			sanitized.Upstream[existingIndex].Gradients = append(
+				sanitized.Upstream[existingIndex].Gradients,
+				sanitizedPropagation.Gradients...,
 			)
+			continue
 		}
-		seenPredecessors[sanitizedPropagation.PredecessorStepID] = struct{}{}
+		upstreamIndex[sanitizedPropagation.PredecessorStepID] = len(sanitized.Upstream)
 		sanitized.Upstream = append(sanitized.Upstream, sanitizedPropagation)
 	}
 	if len(sanitized.Gradients) == 0 && len(sanitized.Upstream) == 0 {

--- a/evaluation/workflow/promptiter/backwarder/backwarder_test.go
+++ b/evaluation/workflow/promptiter/backwarder/backwarder_test.go
@@ -1039,8 +1039,14 @@ func TestNormalizeRequestAndSanitizeBackwardResult(t *testing.T) {
 			},
 		},
 	})
-	assert.Nil(t, result)
-	assert.EqualError(t, err, `duplicate propagation for predecessor step id "pred_1"`)
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Len(t, result.Upstream, 1)
+	assert.Equal(t, "pred_1", result.Upstream[0].PredecessorStepID)
+	assert.Equal(t, []GradientPacket{
+		{FromStepID: request.StepID, Gradient: "send upstream"},
+		{FromStepID: request.StepID, Gradient: "send upstream again"},
+	}, result.Upstream[0].Gradients)
 	result, err = sanitizeBackwardResult(request, &Result{
 		Gradients: []promptiter.SurfaceGradient{
 			{SurfaceID: "surf_1", Gradient: ""},


### PR DESCRIPTION
This updates PromptIter backward result sanitization to merge multiple upstream propagation entries for the same predecessor step while preserving output order and the existing validation for unknown predecessors and malformed packets, so model outputs that split gradients across repeated predecessor entries do not fail a run.