### PR TITLE
memory/mem0: advance checkpoint after successful ingest

### DIFF
--- a/memory/mem0/ingest_worker.go
+++ b/memory/mem0/ingest_worker.go
@@ -162,7 +162,9 @@ func (w *ingestWorker) process(job *ingestJob) {
 	}
 	if err := w.ingest(ctx, job.UserKey, job.Session, job.Messages, job.Options); err != nil {
 		log.WarnfContext(ctx, "mem0: ingest failed for user %s/%s: %v", job.UserKey.AppName, job.UserKey.UserID, err)
+		return
 	}
+	writeLastExtractAt(job.Session, job.LatestTs)
 }
 
 func (w *ingestWorker) ingest(

--- a/memory/mem0/ingest_worker.go
+++ b/memory/mem0/ingest_worker.go
@@ -27,9 +27,16 @@ type ingestJob struct {
 	Ctx      context.Context
 	UserKey  memory.UserKey
 	Session  *session.Session
+	Since    time.Time
 	LatestTs time.Time
 	Messages []model.Message
 	Options  session.IngestOptions
+}
+
+type ingestSessionKey struct {
+	AppName   string
+	UserID    string
+	SessionID string
 }
 
 type ingestWorker struct {
@@ -47,6 +54,9 @@ type ingestWorker struct {
 	mu      sync.RWMutex
 	wg      sync.WaitGroup
 	started bool
+
+	progressMu sync.Mutex
+	inFlight   map[ingestSessionKey]time.Time
 }
 
 const (
@@ -74,6 +84,7 @@ func newIngestWorker(c *client, opts serviceOpts) *ingestWorker {
 		orgID:     opts.orgID,
 		projectID: opts.projectID,
 		jobChans:  make([]chan *ingestJob, num),
+		inFlight:  make(map[ingestSessionKey]time.Time),
 	}
 	for i := 0; i < num; i++ {
 		w.jobChans[i] = make(chan *ingestJob, queueSize)
@@ -147,10 +158,80 @@ func (w *ingestWorker) tryEnqueue(ctx context.Context, job *ingestJob) bool {
 	}
 }
 
+func (w *ingestWorker) scanSince(userKey memory.UserKey, sess *session.Session) time.Time {
+	w.progressMu.Lock()
+	defer w.progressMu.Unlock()
+	since := readLastExtractAt(sess)
+	key, ok := newIngestSessionKey(userKey, sess)
+	if !ok {
+		return since
+	}
+	latest, ok := w.inFlight[key]
+	if ok && latest.After(since) {
+		return latest
+	}
+	return since
+}
+
+func (w *ingestWorker) claimInFlight(
+	userKey memory.UserKey,
+	sess *session.Session,
+	since time.Time,
+	latest time.Time,
+) bool {
+	w.progressMu.Lock()
+	defer w.progressMu.Unlock()
+	if readLastExtractAt(sess).After(since) {
+		return false
+	}
+	key, ok := newIngestSessionKey(userKey, sess)
+	if !ok {
+		return true
+	}
+	if w.inFlight == nil {
+		w.inFlight = make(map[ingestSessionKey]time.Time)
+	}
+	current, ok := w.inFlight[key]
+	if ok && current.After(since) {
+		return false
+	}
+	if !ok || latest.After(current) {
+		w.inFlight[key] = latest
+	}
+	return true
+}
+
+func (w *ingestWorker) finishInFlight(userKey memory.UserKey, sess *session.Session, latest time.Time) {
+	key, ok := newIngestSessionKey(userKey, sess)
+	if !ok {
+		return
+	}
+	w.progressMu.Lock()
+	defer w.progressMu.Unlock()
+	current, ok := w.inFlight[key]
+	if ok && !current.After(latest) {
+		delete(w.inFlight, key)
+	}
+}
+
+func (w *ingestWorker) advanceCheckpoint(sess *session.Session, since time.Time, latest time.Time) bool {
+	w.progressMu.Lock()
+	defer w.progressMu.Unlock()
+	current := readLastExtractAt(sess)
+	if current.Before(since) {
+		return false
+	}
+	if latest.After(current) {
+		writeLastExtractAt(sess, latest)
+	}
+	return true
+}
+
 func (w *ingestWorker) process(job *ingestJob) {
 	if job == nil {
 		return
 	}
+	defer w.finishInFlight(job.UserKey, job.Session, job.LatestTs)
 	ctx := job.Ctx
 	if ctx == nil {
 		ctx = context.Background()
@@ -164,7 +245,7 @@ func (w *ingestWorker) process(job *ingestJob) {
 		log.WarnfContext(ctx, "mem0: ingest failed for user %s/%s: %v", job.UserKey.AppName, job.UserKey.UserID, err)
 		return
 	}
-	writeLastExtractAt(job.Session, job.LatestTs)
+	w.advanceCheckpoint(job.Session, job.Since, job.LatestTs)
 }
 
 func (w *ingestWorker) ingest(
@@ -253,4 +334,15 @@ func hashUserKey(userKey memory.UserKey) int {
 	_, _ = h.Write([]byte(userKey.AppName))
 	_, _ = h.Write([]byte(userKey.UserID))
 	return int(h.Sum32())
+}
+
+func newIngestSessionKey(userKey memory.UserKey, sess *session.Session) (ingestSessionKey, bool) {
+	if sess == nil || sess.ID == "" {
+		return ingestSessionKey{}, false
+	}
+	return ingestSessionKey{
+		AppName:   userKey.AppName,
+		UserID:    userKey.UserID,
+		SessionID: sess.ID,
+	}, true
 }

--- a/memory/mem0/ingest_worker_test.go
+++ b/memory/mem0/ingest_worker_test.go
@@ -63,6 +63,19 @@ func TestHashUserKey_Deterministic(t *testing.T) {
 	assert.NotEqual(t, hashUserKey(k), hashUserKey(other), "different keys should hash differently")
 }
 
+func TestNewIngestSessionKey_RequiresSessionID(t *testing.T) {
+	userKey := memory.UserKey{AppName: "app", UserID: "user"}
+	_, ok := newIngestSessionKey(userKey, nil)
+	assert.False(t, ok)
+
+	_, ok = newIngestSessionKey(userKey, &session.Session{AppName: "app", UserID: "user"})
+	assert.False(t, ok)
+
+	key, ok := newIngestSessionKey(userKey, &session.Session{AppName: "app", UserID: "user", ID: "s"})
+	require.True(t, ok)
+	assert.Equal(t, ingestSessionKey{AppName: "app", UserID: "user", SessionID: "s"}, key)
+}
+
 func TestNewIngestWorker_AppliesDefaults(t *testing.T) {
 	w, _ := newWorkerWithServer(t, http.NotFoundHandler(), serviceOpts{})
 	assert.Len(t, w.jobChans, defaultAsyncMemoryNum)
@@ -293,6 +306,23 @@ func TestProcess_LogsErrorButRecovers(t *testing.T) {
 			Messages: []model.Message{{Role: model.RoleUser, Content: "x"}},
 		})
 	})
+}
+
+func TestIngestWorker_AdvanceCheckpointDoesNotSkipGap(t *testing.T) {
+	w := &ingestWorker{}
+	t0 := time.Date(2026, 5, 15, 10, 0, 0, 0, time.UTC)
+	t1 := t0.Add(time.Minute)
+	t2 := t1.Add(time.Minute)
+	sess := &session.Session{}
+	writeLastExtractAt(sess, t0)
+
+	assert.False(t, w.advanceCheckpoint(sess, t1, t2))
+	assert.True(t, readLastExtractAt(sess).Equal(t0))
+
+	assert.True(t, w.advanceCheckpoint(sess, t0, t1))
+	assert.True(t, readLastExtractAt(sess).Equal(t1))
+	assert.True(t, w.advanceCheckpoint(sess, t1, t2))
+	assert.True(t, readLastExtractAt(sess).Equal(t2))
 }
 
 func TestIngestWorker_TryEnqueue_HashesBySessionOrUserKey(t *testing.T) {

--- a/memory/mem0/ingest_worker_test.go
+++ b/memory/mem0/ingest_worker_test.go
@@ -325,6 +325,57 @@ func TestIngestWorker_AdvanceCheckpointDoesNotSkipGap(t *testing.T) {
 	assert.True(t, readLastExtractAt(sess).Equal(t2))
 }
 
+func TestIngestWorker_ProgressNoSessionID(t *testing.T) {
+	w := &ingestWorker{}
+	userKey := memory.UserKey{AppName: "app", UserID: "user"}
+	t0 := time.Date(2026, 5, 15, 13, 0, 0, 0, time.UTC)
+	t1 := t0.Add(time.Minute)
+	sess := &session.Session{AppName: "app", UserID: "user"}
+	writeLastExtractAt(sess, t0)
+
+	assert.True(t, w.scanSince(userKey, sess).Equal(t0))
+	assert.True(t, w.claimInFlight(userKey, sess, t0, t1))
+	w.finishInFlight(userKey, sess, t1)
+	assert.True(t, w.scanSince(userKey, sess).Equal(t0))
+
+	assert.True(t, w.advanceCheckpoint(sess, t0, t0))
+	assert.True(t, readLastExtractAt(sess).Equal(t0))
+}
+
+func TestIngestWorker_InFlightProgressLifecycle(t *testing.T) {
+	w := &ingestWorker{}
+	userKey := memory.UserKey{AppName: "app", UserID: "user"}
+	t0 := time.Date(2026, 5, 15, 14, 0, 0, 0, time.UTC)
+	t1 := t0.Add(time.Minute)
+	t2 := t1.Add(time.Minute)
+	sess := &session.Session{AppName: "app", UserID: "user", ID: "s"}
+	writeLastExtractAt(sess, t0)
+
+	assert.True(t, w.claimInFlight(userKey, sess, t0, t1))
+	assert.True(t, w.scanSince(userKey, sess).Equal(t1))
+	assert.False(t, w.claimInFlight(userKey, sess, t0, t2))
+
+	assert.True(t, w.claimInFlight(userKey, sess, t1, t2))
+	assert.True(t, w.scanSince(userKey, sess).Equal(t2))
+	w.finishInFlight(userKey, sess, t1)
+	assert.True(t, w.scanSince(userKey, sess).Equal(t2))
+
+	w.finishInFlight(userKey, sess, t2)
+	assert.True(t, w.scanSince(userKey, sess).Equal(t0))
+}
+
+func TestIngestWorker_ClaimInFlightRejectsAdvancedCheckpoint(t *testing.T) {
+	w := &ingestWorker{}
+	userKey := memory.UserKey{AppName: "app", UserID: "user"}
+	t0 := time.Date(2026, 5, 15, 15, 0, 0, 0, time.UTC)
+	t1 := t0.Add(time.Minute)
+	t2 := t1.Add(time.Minute)
+	sess := &session.Session{AppName: "app", UserID: "user", ID: "s"}
+	writeLastExtractAt(sess, t2)
+
+	assert.False(t, w.claimInFlight(userKey, sess, t0, t1))
+}
+
 func TestIngestWorker_TryEnqueue_HashesBySessionOrUserKey(t *testing.T) {
 	w, _ := newWorkerWithServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/memory/mem0/service.go
+++ b/memory/mem0/service.go
@@ -82,7 +82,6 @@ func (s *Service) IngestSession(
 	if len(messages) == 0 {
 		return nil
 	}
-	writeLastExtractAt(sess, latestTs)
 	var reqOpts session.IngestOptions
 	for _, opt := range opts {
 		if opt == nil {
@@ -111,7 +110,11 @@ func (s *Service) IngestSession(
 	}
 	syncCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), timeout)
 	defer cancel()
-	return s.ingestWorker.ingest(syncCtx, userKey, sess, messages, reqOpts)
+	if err := s.ingestWorker.ingest(syncCtx, userKey, sess, messages, reqOpts); err != nil {
+		return err
+	}
+	writeLastExtractAt(sess, latestTs)
+	return nil
 }
 
 // ReadMemories reads memories for a user.

--- a/memory/mem0/service.go
+++ b/memory/mem0/service.go
@@ -14,9 +14,11 @@ import (
 	"net/url"
 	"sort"
 	"strings"
+	"time"
 
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/memory"
+	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
@@ -77,11 +79,6 @@ func (s *Service) IngestSession(
 	if err := userKey.CheckUserKey(); err != nil {
 		return err
 	}
-	since := readLastExtractAt(sess)
-	latestTs, messages := scanDeltaSince(sess, since)
-	if len(messages) == 0 {
-		return nil
-	}
 	var reqOpts session.IngestOptions
 	for _, opt := range opts {
 		if opt == nil {
@@ -89,10 +86,24 @@ func (s *Service) IngestSession(
 		}
 		opt(&reqOpts)
 	}
+	var since time.Time
+	var latestTs time.Time
+	var messages []model.Message
+	for {
+		since = s.ingestWorker.scanSince(userKey, sess)
+		latestTs, messages = scanDeltaSince(sess, since)
+		if len(messages) == 0 {
+			return nil
+		}
+		if s.ingestWorker.claimInFlight(userKey, sess, since, latestTs) {
+			break
+		}
+	}
 	job := &ingestJob{
 		Ctx:      context.WithoutCancel(ctx),
 		UserKey:  userKey,
 		Session:  sess,
+		Since:    since,
 		LatestTs: latestTs,
 		Messages: messages,
 		Options:  reqOpts,
@@ -100,6 +111,7 @@ func (s *Service) IngestSession(
 	if s.ingestWorker.tryEnqueue(ctx, job) {
 		return nil
 	}
+	defer s.ingestWorker.finishInFlight(userKey, sess, latestTs)
 	if err := ctx.Err(); err != nil {
 		return nil
 	}
@@ -113,7 +125,7 @@ func (s *Service) IngestSession(
 	if err := s.ingestWorker.ingest(syncCtx, userKey, sess, messages, reqOpts); err != nil {
 		return err
 	}
-	writeLastExtractAt(sess, latestTs)
+	s.ingestWorker.advanceCheckpoint(sess, since, latestTs)
 	return nil
 }
 

--- a/memory/mem0/service_test.go
+++ b/memory/mem0/service_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -100,12 +101,15 @@ func TestIngestSession_NilContext(t *testing.T) {
 }
 
 func TestIngestSession_ForwardsMessagesToBackend(t *testing.T) {
+	var gotBodyMu sync.Mutex
 	var gotBody []byte
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 		buf := make([]byte, 4096)
 		n, _ := r.Body.Read(buf)
+		gotBodyMu.Lock()
 		gotBody = buf[:n]
+		gotBodyMu.Unlock()
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`[{"id":"x","status":"SUCCEEDED"}]`))
 	})
@@ -137,15 +141,173 @@ func TestIngestSession_ForwardsMessagesToBackend(t *testing.T) {
 	))
 
 	// Wait for the async worker to hit the backend.
-	assert.Eventually(t, func() bool { return len(gotBody) > 0 },
+	assert.Eventually(t, func() bool {
+		gotBodyMu.Lock()
+		defer gotBodyMu.Unlock()
+		return len(gotBody) > 0
+	},
 		2*time.Second, 10*time.Millisecond, "backend was not hit")
 	assert.Eventually(t, func() bool { return readLastExtractAt(sess).Equal(eventTs) },
 		2*time.Second, 10*time.Millisecond, "checkpoint was not advanced after successful ingest")
 
+	gotBodyMu.Lock()
 	body := string(gotBody)
+	gotBodyMu.Unlock()
 	for _, want := range []string{"hello", "agent-1", "run-1", `"k":"v"`} {
 		assert.Contains(t, body, want)
 	}
+}
+
+func TestIngestSession_DedupesWhileAsyncInFlight(t *testing.T) {
+	var ingestCalls int32
+	var releaseClosed int32
+	firstStarted := make(chan struct{})
+	release := make(chan struct{})
+	releaseOnce := func() {
+		if atomic.CompareAndSwapInt32(&releaseClosed, 0, 1) {
+			close(release)
+		}
+	}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/memories/" {
+			http.NotFound(w, r)
+			return
+		}
+		n := atomic.AddInt32(&ingestCalls, 1)
+		if n == 1 {
+			close(firstStarted)
+			<-release
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[{"id":"x","status":"SUCCEEDED"}]`))
+	})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	svc, err := NewService(
+		WithAPIKey("k"),
+		WithHost(srv.URL),
+		WithAsyncMode(false),
+		WithAsyncMemoryNum(1),
+		WithMemoryQueueSize(4),
+		WithMemoryJobTimeout(time.Second),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		releaseOnce()
+		_ = svc.Close()
+	})
+
+	eventTs := time.Date(2026, 5, 15, 11, 0, 0, 0, time.UTC)
+	sess := &session.Session{AppName: "app", UserID: "user", ID: "s"}
+	sess.Events = []event.Event{{
+		Timestamp: eventTs,
+		Response: &model.Response{Choices: []model.Choice{{
+			Message: model.Message{Role: model.RoleUser, Content: "hello"},
+		}}},
+	}}
+
+	require.NoError(t, svc.IngestSession(context.Background(), sess))
+	require.Eventually(t, func() bool {
+		select {
+		case <-firstStarted:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond, "first ingest did not start")
+
+	require.NoError(t, svc.IngestSession(context.Background(), sess))
+	assert.Equal(t, int32(1), atomic.LoadInt32(&ingestCalls))
+
+	releaseOnce()
+	assert.Eventually(t, func() bool { return readLastExtractAt(sess).Equal(eventTs) },
+		2*time.Second, 10*time.Millisecond, "checkpoint was not advanced after successful ingest")
+	require.NoError(t, svc.Close())
+	assert.Equal(t, int32(1), atomic.LoadInt32(&ingestCalls))
+}
+
+func TestIngestSession_DedupesConcurrentAsyncCalls(t *testing.T) {
+	var ingestCalls int32
+	var releaseClosed int32
+	firstStarted := make(chan struct{})
+	release := make(chan struct{})
+	releaseOnce := func() {
+		if atomic.CompareAndSwapInt32(&releaseClosed, 0, 1) {
+			close(release)
+		}
+	}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/memories/" {
+			http.NotFound(w, r)
+			return
+		}
+		n := atomic.AddInt32(&ingestCalls, 1)
+		if n == 1 {
+			close(firstStarted)
+			<-release
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[{"id":"x","status":"SUCCEEDED"}]`))
+	})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	svc, err := NewService(
+		WithAPIKey("k"),
+		WithHost(srv.URL),
+		WithAsyncMode(false),
+		WithAsyncMemoryNum(1),
+		WithMemoryQueueSize(16),
+		WithMemoryJobTimeout(time.Second),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		releaseOnce()
+		_ = svc.Close()
+	})
+
+	eventTs := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	sess := &session.Session{AppName: "app", UserID: "user", ID: "s"}
+	sess.Events = []event.Event{{
+		Timestamp: eventTs,
+		Response: &model.Response{Choices: []model.Choice{{
+			Message: model.Message{Role: model.RoleUser, Content: "hello"},
+		}}},
+	}}
+
+	const callers = 8
+	start := make(chan struct{})
+	errCh := make(chan error, callers)
+	var wg sync.WaitGroup
+	wg.Add(callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			errCh <- svc.IngestSession(context.Background(), sess)
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		require.NoError(t, err)
+	}
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-firstStarted:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond, "first ingest did not start")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&ingestCalls))
+
+	releaseOnce()
+	assert.Eventually(t, func() bool { return readLastExtractAt(sess).Equal(eventTs) },
+		2*time.Second, 10*time.Millisecond, "checkpoint was not advanced after successful ingest")
 }
 
 func TestIngestSession_SyncFallbackWhenQueueFull(t *testing.T) {

--- a/memory/mem0/service_test.go
+++ b/memory/mem0/service_test.go
@@ -122,8 +122,9 @@ func TestIngestSession_ForwardsMessagesToBackend(t *testing.T) {
 	defer svc.Close()
 
 	sess := &session.Session{AppName: "app", UserID: "user", ID: "s"}
+	eventTs := time.Now()
 	sess.Events = []event.Event{{
-		Timestamp: time.Now(),
+		Timestamp: eventTs,
 		Response: &model.Response{Choices: []model.Choice{{
 			Message: model.Message{Role: model.RoleUser, Content: "hello"},
 		}}},
@@ -138,6 +139,8 @@ func TestIngestSession_ForwardsMessagesToBackend(t *testing.T) {
 	// Wait for the async worker to hit the backend.
 	assert.Eventually(t, func() bool { return len(gotBody) > 0 },
 		2*time.Second, 10*time.Millisecond, "backend was not hit")
+	assert.Eventually(t, func() bool { return readLastExtractAt(sess).Equal(eventTs) },
+		2*time.Second, 10*time.Millisecond, "checkpoint was not advanced after successful ingest")
 
 	body := string(gotBody)
 	for _, want := range []string{"hello", "agent-1", "run-1", `"k":"v"`} {
@@ -178,8 +181,9 @@ func TestIngestSession_SyncFallbackWhenQueueFull(t *testing.T) {
 	svc.ingestWorker.Stop()
 
 	sess := &session.Session{AppName: "app", UserID: "user", ID: "s1"}
+	eventTs := time.Now()
 	sess.Events = []event.Event{{
-		Timestamp: time.Now(),
+		Timestamp: eventTs,
 		Response: &model.Response{Choices: []model.Choice{{
 			Message: model.Message{Role: model.RoleUser, Content: "hello"},
 		}}},
@@ -188,6 +192,51 @@ func TestIngestSession_SyncFallbackWhenQueueFull(t *testing.T) {
 	require.NoError(t, svc.IngestSession(context.Background(), sess))
 	assert.Equal(t, int32(1), atomic.LoadInt32(&ingestCalls),
 		"sync fallback must hit the backend exactly once")
+	assert.True(t, readLastExtractAt(sess).Equal(eventTs))
+}
+
+func TestIngestSession_SyncFallbackFailureDoesNotAdvanceCheckpoint(t *testing.T) {
+	var ingestCalls int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/memories/" {
+			atomic.AddInt32(&ingestCalls, 1)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		http.NotFound(w, r)
+	})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	svc, err := NewService(
+		WithAPIKey("k"),
+		WithHost(srv.URL),
+		WithAsyncMode(false),
+		WithMemoryJobTimeout(100*time.Millisecond),
+	)
+	require.NoError(t, err)
+	defer svc.Close()
+
+	svc.ingestWorker.Stop()
+
+	eventTs := time.Date(2026, 5, 15, 10, 0, 0, 0, time.UTC)
+	sess := &session.Session{AppName: "app", UserID: "user", ID: "s1"}
+	sess.Events = []event.Event{{
+		Timestamp: eventTs,
+		Response: &model.Response{Choices: []model.Choice{{
+			Message: model.Message{Role: model.RoleUser, Content: "hello"},
+		}}},
+	}}
+
+	require.Error(t, svc.IngestSession(context.Background(), sess))
+	assert.Equal(t, int32(1), atomic.LoadInt32(&ingestCalls),
+		"sync fallback must hit the backend exactly once")
+	assert.True(t, readLastExtractAt(sess).IsZero())
+
+	latestTs, messages := scanDeltaSince(sess, readLastExtractAt(sess))
+	require.Len(t, messages, 1)
+	assert.Equal(t, "hello", messages[0].Content)
+	assert.True(t, latestTs.Equal(eventTs))
 }
 
 // --- ReadMemories ---


### PR DESCRIPTION
## Summary

- Move mem0 session ingest checkpoint writes until after ingest succeeds.
- Advance the checkpoint from the async worker only after successful processing.
- Keep the checkpoint unchanged on sync fallback or async ingest failures so failed messages can be retried.
- Add regression coverage for sync fallback failure and successful checkpoint updates.

## Problem

`mem0.Service.IngestSession` writes `memory:last_extract_at` before the session transcript is actually ingested. If enqueue fails and the sync fallback then returns an error from mem0, the checkpoint has already advanced to the failed event timestamp. The next scan treats that event as processed, so the failed message is skipped and will not be retried.(This problem is found and solved by autotest agent workflow)

## Tests

- go test ./memory/mem0 -run 'TestIngestSession_(ForwardsMessagesToBackend|SyncFallbackWhenQueueFull|SyncFallbackFailureDoesNotAdvanceCheckpoint)' -count=1 -v
- go test ./memory/mem0

