### PR TITLE
examples/evaluation/promptiter: add multinode sports recap example

### DIFF
--- a/examples/evaluation/promptiter/README.md
+++ b/examples/evaluation/promptiter/README.md
@@ -1,14 +1,15 @@
 # PromptIter Examples
 
-This directory contains three fully independent PromptIter examples:
+This directory contains four PromptIter examples:
 
 - [syncrun](./syncrun): runs the full PromptIter optimization loop directly through `engine.Run`. Its initial candidate instruction intentionally stays simple so that PromptIter, rather than a strong hand-written seed, drives the gain.
 - [asyncrun](./asyncrun): runs the same PromptIter workflow through `manager.Start/Get`.
 - [server](./server): exposes the same PromptIter workflow through the HTTP control-plane service in `server/promptiter`.
+- [multinode](./multinode): runs PromptIter against a multinode sports recap agent with regular function nodes, AgentNode fan-out/fan-in, and multiple optimized instruction surfaces.
 
-All three examples evaluate against fixed static gold answers stored directly in the eval sets, so repeated runs stay comparable instead of regenerating expected answers online.
+All examples evaluate against fixed static gold answers stored directly in the eval sets, so repeated runs stay comparable instead of regenerating expected answers online.
 
-Each example keeps its own command entrypoint and data layout:
+The optimization examples keep their own command entrypoint and data layout:
 
 - `main.go`
 - `agent.go`
@@ -16,4 +17,4 @@ Each example keeps its own command entrypoint and data layout:
 - `data/`
 - `output/`
 
-Choose `syncrun` when you want the simplest synchronous engine example. Choose `asyncrun` when you want asynchronous run lifecycle management without HTTP. Choose `server` when you want to serve PromptIter over HTTP and trigger runs remotely.
+Choose `syncrun` when you want the simplest synchronous single-agent engine example. Choose `asyncrun` when you want asynchronous run lifecycle management without HTTP. Choose `server` when you want to serve PromptIter over HTTP and trigger runs remotely. Choose `multinode` when you want to see PromptIter optimize several AgentNode instruction surfaces inside a richer candidate graph.

--- a/examples/evaluation/promptiter/multinode/README.md
+++ b/examples/evaluation/promptiter/multinode/README.md
@@ -40,7 +40,7 @@ sports-recap-validation.evalset.json
 sports-recap.metrics.json
 ```
 
-The train and validation evalsets each contain eight sports recap cases. The cases intentionally cover different scoring systems and recap pitfalls, including basketball, football, baseball, tennis, badminton, ice hockey, Formula 1, road cycling, and cricket. The shared metric file is strict about factual grounding, numeric precision, sport-specific terminology, decisive details, and polished Chinese copy.
+The train and validation evalsets each contain eight sports recap cases. Across both evalsets, the cases intentionally cover different scoring systems and recap pitfalls, including basketball, football, baseball, tennis, badminton, ice hockey, Formula 1, road cycling, and cricket. The shared metric file is strict about factual grounding, numeric precision, sport-specific terminology, decisive details, and polished Chinese copy.
 
 ## Run
 

--- a/examples/evaluation/promptiter/multinode/README.md
+++ b/examples/evaluation/promptiter/multinode/README.md
@@ -1,0 +1,263 @@
+# PromptIter Multinode Sports Recap Example
+
+This example starts a PromptIter manager run against a compact multinode sports recap agent. It reads inputs and reference outputs from evalcase files, evaluates the final recap, optimizes instruction surfaces on multiple AgentNode-backed sub-agents, and polls the manager for progress while the long-running optimization is still active.
+
+The graph intentionally mixes regular function nodes and AgentNode nodes:
+
+```text
+prepare_game_input
+   ├── headline_agent
+   ├── highlights_agent
+   └── stats_angle_agent
+        ↓
+join_recap_parts
+        ↓
+recap_writer
+        ↓
+sports_editor
+```
+
+- `prepare_game_input` is a regular function node that sends the same game JSON to three focused branches.
+- `headline_agent`, `highlights_agent`, and `stats_angle_agent` are parallel AgentNode branches.
+- `join_recap_parts` is a regular function node that waits for all three branches and builds a joined brief.
+- `recap_writer` and `sports_editor` are AgentNode nodes that create and polish the final recap.
+
+PromptIter optimizes the candidate instruction surfaces on the AgentNode-backed sub-agents:
+
+```text
+promptiter-sports-recap-agent/headline_agent#instruction
+promptiter-sports-recap-agent/highlights_agent#instruction
+promptiter-sports-recap-agent/stats_angle_agent#instruction
+promptiter-sports-recap-agent/recap_writer#instruction
+promptiter-sports-recap-agent/sports_editor#instruction
+```
+
+The example data lives under `./data/promptiter-sports-recap-agent/`:
+
+```text
+sports-recap-train.evalset.json
+sports-recap-validation.evalset.json
+sports-recap.metrics.json
+```
+
+The train and validation evalsets each contain eight sports recap cases. The cases intentionally cover different scoring systems and recap pitfalls, including basketball, football, baseball, tennis, badminton, ice hockey, Formula 1, road cycling, and cricket. The shared metric file is strict about factual grounding, numeric precision, sport-specific terminology, decisive details, and polished Chinese copy.
+
+## Run
+
+```bash
+cd examples/evaluation/promptiter/multinode
+export OPENAI_BASE_URL="..."
+export OPENAI_API_KEY="..."
+go run .
+```
+
+Useful flags:
+
+```text
+-model deepseek-v3.2
+-judge-model gpt-5.2
+-worker-model gpt-5.2
+-data-dir ./data
+-output-dir ./output
+-max-rounds 4
+-eval-case-parallelism 16
+-backward-case-parallelism 16
+-aggregation-parallelism 16
+-optimizer-parallelism 16
+-parallel-inference true
+-parallel-evaluation true
+-parallel-backward false
+-parallel-aggregation true
+-parallel-optimization true
+-min-score-gain 0.01
+-max-rounds-without-acceptance 3
+-target-score 1.01
+-poll-interval 30s
+```
+
+When a PromptIter stage parallelism flag is `0` and the corresponding `-parallel-*` flag is enabled, the stage uses `GOMAXPROCS` as the default parallelism.
+
+## Sample Log
+
+The following abbreviated log shows a successful run with the default flags. Scores are not expected to improve monotonically every round; PromptIter accepts only patches that improve validation score over the current accepted candidate.
+
+```text
+Started PromptIter manager run: f5278caf-9dd5-436d-8a95-9640e3b2d5fb
+Run f5278caf-9dd5-436d-8a95-9640e3b2d5fb baseline validation score: 0.66
+Run f5278caf-9dd5-436d-8a95-9640e3b2d5fb round 1 train score: 0.67
+Run f5278caf-9dd5-436d-8a95-9640e3b2d5fb round 1 validation score: 0.47
+Run f5278caf-9dd5-436d-8a95-9640e3b2d5fb round 1 completed: accepted=false, delta=-0.19, stop=false (continue optimization)
+Run f5278caf-9dd5-436d-8a95-9640e3b2d5fb round 2 train score: 0.55
+Run f5278caf-9dd5-436d-8a95-9640e3b2d5fb round 2 validation score: 0.59
+Run f5278caf-9dd5-436d-8a95-9640e3b2d5fb round 2 completed: accepted=false, delta=-0.06, stop=false (continue optimization)
+Run f5278caf-9dd5-436d-8a95-9640e3b2d5fb round 3 train score: 0.55
+Run f5278caf-9dd5-436d-8a95-9640e3b2d5fb round 3 validation score: 0.81
+Run f5278caf-9dd5-436d-8a95-9640e3b2d5fb round 3 completed: accepted=true, delta=0.16, stop=false (continue optimization)
+Run f5278caf-9dd5-436d-8a95-9640e3b2d5fb round 4 train score: 0.80
+Run f5278caf-9dd5-436d-8a95-9640e3b2d5fb round 4 validation score: 0.83
+Run f5278caf-9dd5-436d-8a95-9640e3b2d5fb round 4 completed: accepted=true, delta=0.02, stop=true (max rounds reached)
+PromptIter multinode sports recap example completed.
+Status: succeeded
+Baseline validation score: 0.66
+Final accepted validation score: 0.83
+Rounds executed: 4
+```
+
+## Final Accepted Prompts
+
+The sample run accepted the following instruction surfaces after round 4.
+
+<details>
+<summary><code>headline_agent#instruction</code></summary>
+
+```text
+根据输入的比赛JSON生成【一行】中文标题。
+硬性要求：
+1) 只输出标题本身：单行、不换行、不含正文/解释、不含Markdown、不加项目符号或额外段落；不要在标题末尾添加句号等补充标点。
+2) 标题必须且只能基于输入JSON中的事实生成；优先突出给定的recapAngle、1–2个关键转折/决定性瞬间与比赛结果，避免摘要式长句与多重从句。
+3) 长度优先控制在18–28字；若超过32字视为不合格，需进一步压缩（优先删背景/过程性细节，只保留赛果+关键钩子）。
+4) 尽量包含：对阵双方、赛事/阶段（若提供）、胜负方、比分/关键时间点/胜负差（仅限输入已给信息）。
+5) 禁止添加输入未提供的内容：采访/引语、主观评价、背景标签、统计趋势、未来对手；若nextStageKnown=false或未明确给出，不得写“晋级四强/挺进决赛”等结论。
+6) 比分/数值格式硬约束：所有比分/局分/抢七/时间/板球overs等必须严格按输入原样与含义书写并保留分隔符（如23-21、8-6、4:12、抢七括号等）；禁止用空格分隔数字（如“66 49”）；不得编造、补全或改写。输出前自检并纠正为与输入一致的分隔符格式。
+7) 项目语义一致性校验（如板球）：ballsRemaining=2表示追逐已完成且还剩2球；19.4 overs应理解为第20个over第4个合法球结束比赛，禁止误写为“第19.4个over/19.4个over结束”。
+8) recapAngle执行：标题需优先纳入recapAngle中的关键数字钩子/决定性瞬间（在字数内），并与赛果同句绑定，不做分节回顾式结构。
+9) 用中性表述“胜/负/出局/晋级（仅在明确给出时）”，避免“险胜”等主观词。
+```
+
+</details>
+
+<details>
+<summary><code>highlights_agent#instruction</code></summary>
+
+```text
+根据用户提供的比赛信息JSON，提取并撰写“比赛高光”正文。必须遵守：
+1) 严格只使用输入JSON中明确给出的事实与字段（例如turningPoints、recapAngle、keyPlayers、scoringSummary等）；不得补充/推断未提供的信息（如国籍/排名/伤病/连胜/身份标签/晋级与下一对手/未来展望等）。当nextStageKnown=false时，不得写“晋级/将对阵”等内容。
+2) 禁止编造引语、归因、额外数据；禁止输出战术/心理/强弱评价（如“以弱胜强”“战术纪律性更好”），除非输入JSON明确给出。
+3) 必须优先突出用户指定主线/recapAngle，并围绕给定关键转折点turningPoints展开；避免使用泛化渲染词（如“惊心动魄/险胜/宝贵胜利”）稀释重点。
+4) 逐项核对并准确呈现比分/分节/盘分/回合序列与关键节点；严格保留原格式要求：
+- 所有“比分/分差/局分/回合分/小节比分/系列比分”等数字对，必须统一使用连字符连接（如66-49、34-25、20-21、2-2），禁止空格、额外空格或其他分隔变体（如“66 49”“15 -13”“15- 13”）。
+- 网球比分使用连字符与括号（如7-6(6)，不得写7 6(6)）；ace写作“ace”；其他比分如21-21保持连字符。
+- 若输入包含时间点（如第四节8:42），必须原样准确呈现，不得改写为其他格式。
+5) 严格镜像输入JSON字段与语义：不得外推或改写成不同含义。统计与术语尽量保持中性并贴近原格式（例如“破发点转化5/13”就写“5/13”，不要在未提供时擅自改成“挽救/兑现”等语义）。棒球打击如“2-for-4”可原样保留或统一规范为“4打数2安打”，但全文只能选一种写法且不得混用。投手局数如“0.2局”按输入呈现，不自行换算。
+6) 运动项目记法需正确且不误读（尤其板球）：
+- “19.4”表示第20个over的第4个合法球/在19.4 overs时，禁止写成“第19.4个over”。
+- ballsRemaining仅在追逐完成/比赛结束语境下表述为“还剩X球”，不得与“还差X球/距目标还差”并存；target、最终分、margin、ballsRemaining之间表述必须与输入一致。
+7) 行文结构要求：首段必须直接点明recapAngle，并落到关键人物+关键回合/转折点+最终比分（均来自输入）；随后再按scoringSummary推进；末段用keyPlayers一次性收束，避免同一事实在开头与结尾重复。
+8) 名称/拼写一致性：队名、球员名、称谓必须与输入完全一致，不得误写或自行替换。
+9) 输出前自检清单（必须执行）：
+- 全文逐一检查所有数字比分是否均为“X-Y”连字符格式（含分节/半场/盘分/回合分/系列比分/分差）。
+- 逐条核对turningPoints、scoringSummary、keyPlayers、recapAngle中的事实是否被准确复述且未改变语义。
+- 若涉及板球overs/target/ballsRemaining，确认19.4等写法解释正确且各字段表述一致。
+- 核对所有专有名词拼写与输入一致。
+10) 输出为可直接发布的纯文本正文（段落或编号句均可）；不使用Markdown标题/项目符号；不输出多版本；不输出任何改写说明、额外提示或口号式金句。
+```
+
+</details>
+
+<details>
+<summary><code>recap_writer#instruction</code></summary>
+
+```text
+你是中文体育新闻战报写作助手。请根据输入中提供的GAME_JSON以及给定的HEADLINE、HIGHLIGHTS、STATS_ANGLE、recapAngle、keyPoints生成一篇可直接发布的中文新闻体战报正文。
+
+一、事实与来源约束（必须遵守）
+1) 仅能使用上述输入中明确给出的事实与数据写作；禁止编造、补充或推断任何未提供的信息。
+2) 禁止出现素材未明确给出的内容，包括但不限于：赛后引语、教练/球员评论、技战术细节（球路/球速/落点等）、国籍/外号/热度标签、评价性口号、下一轮展望、晋级轮次/阶段信息等。
+3) 若nextStageKnown=false或素材未明确说明，不得写“晋级/等待对手/下一轮将对阵”等表述。
+4) 若某项数据未提供，不要写具体数字；不要用“通常/大概率/可能/似乎/被认为”等推断性措辞。
+
+二、数字、术语与记法一致性（逐项核对，硬性要求）
+1) 所有数字与专有记法必须与GAME_JSON完全一致并逐项核对关键字段（如日期、场馆、比分、战绩、分节/半场/三节、最大领先、垃圾时间节点与当时比分、三分与命中率、助攻/失误、替补得分、关键球员数据等）。
+2) 比分与统计的原始格式必须原样保留：包括连字符、括号、空格、分隔符与专用记法；禁止任何“格式漂移/重排/补零/去空格/改分隔符”。例如输入为“7-5”就必须写“7-5”，不得写“7 5”；输入为“66-49”不得写“66 49”；输入为“15-13”不得写“15 -13”。
+3) 若输入提供分段比分线（如分节/半场/盘/局/加时/抢七等），必须逐段准确复现，顺序与符号完全一致；不得合并、改写或遗漏。
+4) 关键分/关键回合叙述必须逐点对应keyPoints，不得用“连得X分”等概括替代未明确给出的连续得分细节。
+5) 不同项目术语按输入记法原样使用：
+   a) 网球发球直接得分写作“ace”。
+   b) 板球overs/balls表述必须符合规则：19.4 overs表示第20个over的第4个合法球；可写“在19.4 overs时（第20个over第4个合法球）……/还剩2 balls……”，禁止写“第19.4个over结束”。
+   c) 板球追分叙述：当比赛已完成追分并获胜，只能写“达到目标并获胜，剩余X balls/剩余Y wickets”等与输入一致的结果句式；禁止出现与最终分/target不一致的句式（如“还差目标X分还剩Y球”等）。
+   d) 棒球等项目的专用统计格式（如“2-for-4”等）必须原样保留或按输入明确指定的等价规范转换；禁止随意改写成不同口径。
+   e) specialTeams等仅可做事实陈述或列数据，不得套用“表现/成功率/出色/低迷”等评价框架。
+
+三、禁区词与风格硬约束（输出前自检）
+1) 全文保持新闻体客观表述，只复述可核对的转折点与比分变化；禁止渲染性、评价性、煽情性、因果推断性措辞，包括但不限于：“惊天逆转/陷入绝境/焦点战/胜负手/状态不佳/统治/碾压/爆发/崩盘/关键先生”等。
+2) 对未给出细节的事件只能使用输入提供的结果标签（如scored/missed等）；不得猜测原因或过程（例如点球miss不得写“被扑出/打偏”，除非输入明确给出）。
+3) 禁区词硬检查：若输入未明确给出，禁止出现“晋级/下一轮/将对阵/等待对手”等结论性表述；如草稿中出现，必须删除或改写为不包含该含义的中性表述。
+
+四、结构与角度（固定结构，主线前置）
+1) 标题与开头必须突出给定headline与recapAngle/angle作为主线，不得偏离。
+2) 标题+导语/首段必须立即点明recapAngle主线与输入明确给出的关键节点（来自HIGHLIGHTS或keyPoints），避免先流水账回顾稀释主线。
+3) 正文采用固定结构输出（可用小标题分段）：
+   标题
+   比赛进程
+   数据亮点（结合STATS_ANGLE）
+   关键球员
+   总结（回扣recapAngle与headline）
+
+五、去重与压缩（编辑规则）
+1) 同一信息点（主线句、关键球员数据、关键回合）只出现一次；避免在不同段落重复复述HIGHLIGHTS/STATS_ANGLE导致冗余。
+2) 句子尽量短、信息密度高；不添加与主线无关的背景扩写。
+
+六、输出格式限制
+1) 仅输出中文纯文本段落与小标题；不使用任何Markdown符号（如#、##、**、列表符号等）。
+2) 不输出元话语、改写说明、提示语、数据来源说明；不输出多版本或重复段落。
+
+七、生成后自检清单（必须执行，发现问题立即改写后再输出）
+1) 数字与格式：逐项核对所有比分、分段比分、关键统计数字、命中率与专用记法，确保与GAME_JSON完全一致，且连字符/空格/括号/分隔符不变。
+2) 关键节点：逐条对照keyPoints，确保每条叙述都有对应来源且不被概括替代。
+3) 禁区词：全文搜索并清除“晋级/下一轮/将对阵/等待对手”等未被输入明确允许的表述。
+4) 风格：删除任何评价、渲染、推断、因果解释；仅保留可核对事实。
+5) 去重：检查是否在多个段落重复同一信息点，重复则保留一次并压缩表述。
+```
+
+</details>
+
+<details>
+<summary><code>sports_editor#instruction</code></summary>
+
+```text
+请将我提供的比赛素材润色并改写为一篇可直接发布的中文战报成稿。
+
+输入可能包含：GAME_JSON、HEADLINE、DRAFT、keyPoints、keyStats、recapAngle 等字段。你的任务是：仅基于输入素材进行改写、结构优化与语言润色，不得新增任何输入未提供的事实、数字、引语、评价或推测性后果（例如：确定性“晋级/出线”、下一轮对手、争冠前景等）。若阶段信息未明确或存在 nextStageKnown=false 等提示，则不要写确定性晋级表述。
+
+成稿要求：
+1) 输出为纯文本，不使用Markdown（禁止#、列表符号、加粗、分隔线等）。
+2) 不要输出“改写说明/写作思路/如果需要我可以……”等任何元评论，只给最终成稿。
+3) 结构强制为：标题 + 导语 + 正文（若干自然段）。不得使用小标题。压缩重复与同义反复：同一叙事或同一数据最多出现一次总述+一次必要补充，避免反复强调。
+4) 角度优先：标题与导语必须优先贴合 recapAngle 或 HEADLINE，导语首段先写清输入指定的主线亮点与关键转折节点（按给定的时间点/回合/局数/轮次），其余进程再在正文按时间/局数推进，不得偏离或弱化指定角度。
+5) 计分与数字必须逐项对照输入并在输出前做最终核查，任何不一致或格式不合格均视为不可发布：
+   - 所有比分一律使用半角连字符“-”且两侧不留空格（如 20-21、22-21、15-13），不得用空格替代连字符，不得出现多余空格或缺失分隔符。
+   - 网球：盘分用连字符，抢七用括号标注（如 7-6(7-5)）。
+   - 篮球/足球：区分各节/半场与总比分（以输入提供为准）。
+   - 板球：严格区分 overs 与 balls。19.4 overs 表示第20个 over 的第4个合法球后结束；逐球写作 19.1/19.2/19.3/19.4（球）时需与输入一致，必要时可补充“第20个over第4球”以避免歧义。追分完成的结果句必须逻辑自洽：例如“在还剩2球情况下完成追分/以145/6超过143分目标”，避免出现“距目标还剩2球”等自相矛盾表述。
+   - 统计与数字：所有球员数据、局数、时间点、比分、技术统计必须与输入完全一致；不得擅自改写口径或单位（例如输入为 2-for-4 就必须保留 2-for-4，不得改写成其他表述），不得补写输入未给出的细分比分或统计。
+6) 关键过程叙述需逐点对应输入的关键回合/时间点/关键事件（keyPoints 等），避免可能失真的概括性描述（如未给出细节时不要写“连得三分/一波流/完全压制”等）。
+7) 语气中性克制：避免主观褒贬与夸张结论（如“立下汗马功劳/奠定胜局”等），改用可由素材直接支撑的表述（如“关键回合/关键因素/关键节点”）。
+8) 若输入包含 keyStats，正文需加入至少1-2句基于给定统计的对比解读，把数据与比赛进程/转折关联起来（不只是罗列数字），且不得超出素材。
+
+请直接输出最终中文战报成稿。
+```
+
+</details>
+
+<details>
+<summary><code>stats_angle_agent#instruction</code></summary>
+
+```text
+你是体育赛况新闻写作者。请基于输入JSON生成一段可直接发布的中文纯文本新闻（单段或少量自然段均可），并严格遵守以下规则：
+1) 叙事角度强约束：必须以输入给定的recapAngle作为唯一主线/导语角度展开。标题与开头必须直接点明recapAngle，不得改用其他噱头或角度（例如球星数据钩子、历史意义、赛季走势等）。文中所有关键数据与时间点都要回扣并服务于recapAngle，禁止出现与recapAngle无关的泛化复盘或堆砌数据。
+- 若输入包含advancingTeam，必须在开头用一句话明确写出“X晋级”（仅按输入字段表述，不得扩展含义）。
+- 若recapAngle依赖逐步序列（如点球轮次/加时阶段/逐回合runningScore等），必须严格按输入提供的轮次与runningScore字符串逐条衔接叙述，不得合并、跳步或添加解释性判断。
+2) 事实来源强约束：仅可使用输入JSON中明确提供的事实与字段（例如比分、分节/逐局得分、scoringSummary、keyPlayers、keyPoints等）。禁止添加任何未提供的信息或推断，包括但不限于：赛程/晋级路径/对手后续、赛季走势、引语、战术分析、评价性结论、国籍/排名、夸张修辞、因果推断。
+3) 数字与记法强约束（逐字复现）：所有数字、比分与记法必须严格按输入原样复现并可逐条定位。
+- 总比分/局分/任何比分片段必须保留输入中的原始分隔符与格式（如2-1、23-21、66-49、97-76、22-21等），不得改写为“22比21”“22:21”“22 21”等任何变体。
+- 分节/逐局得分必须按输入给定的顺序与格式输出，不得调换、合并、概括或重排。
+- 若提供keyPoints，必须逐点对应叙述；其中任何score字段（如keyPoints.score、runningScore等）必须逐字照抄，不得改写或重新排版。
+- keyPlayers中的统计字符串（例如棒球/垒球AB-H、投球K、板球“2-for-4”等）必须逐字照抄，不得同义改写、拆分重组或补充单位；并确保文中引用的每一项关键统计都能与输入字段一一对应。
+- 输出前自检（必须执行）：逐条核对你文中出现的每一个数字/比分/记法，确认与输入完全一致（字符级一致，含连字符、斜杠、小数点等），且每个数字都能指向输入中的具体字段；发现不一致则删除该句或改为严格照抄输入。
+4) 板球overs/balls语义强约束（如适用）：当recapAngle或输入涉及板球计分/追分语境时，任何x.y记法必须按“x个over加y个合法球（legal balls）后”的含义表述，禁止写成“第x.y个over/第x.y局/over结束”等错误语义。
+- 任何关于“剩余球数/目标分/追分进度”的句子，必须与输入提供的追分状态字段保持一致；输出前逐句自检其与输入数据是否一致，不一致则删除或改为仅复述输入字段。
+5) 去重与简洁：禁止重复相同导语句式或重复陈述同一事实；同一比分/同一关键点只写一次，避免冗余回环。
+6) 体裁与格式强约束：输出必须为纯文本新闻段落；禁止Markdown标题/小标题/项目符号/表格/加粗及任何元说明（如“根据数据”“如下所示”“JSON显示”等）。内容简洁、不重复。
+```
+
+</details>

--- a/examples/evaluation/promptiter/multinode/agent.go
+++ b/examples/evaluation/promptiter/multinode/agent.go
@@ -1,0 +1,197 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/graphagent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/graph"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+const (
+	sportsRecapAgentName  = "promptiter-sports-recap-agent"
+	headlineAgentName     = "headline_agent"
+	highlightsAgentName   = "highlights_agent"
+	statsAngleAgentName   = "stats_angle_agent"
+	recapWriterAgentName  = "recap_writer"
+	sportsEditorAgentName = "sports_editor"
+	nodePrepareGameInput  = "prepare_game_input"
+	nodeJoinRecapParts    = "join_recap_parts"
+	keyHeadlineInput      = "headline_input"
+	keyHighlightsInput    = "highlights_input"
+	keyStatsAngleInput    = "stats_angle_input"
+	keyHeadline           = "headline"
+	keyHighlights         = "highlights"
+	keyStatsAngle         = "stats_angle"
+	keyWriterInput        = "writer_input"
+	keyEditorInput        = "editor_input"
+	keyFinalRecap         = "final_recap"
+)
+
+func newSportsRecapAgent(m model.Model) (agent.Agent, error) {
+	cfg := model.GenerationConfig{
+		MaxTokens:   intPtr(32768),
+		Temperature: floatPtr(0.0),
+		Stream:      false,
+	}
+	subAgents := []agent.Agent{
+		newStageAgent(headlineAgentName, headlineInstruction, m, cfg),
+		newStageAgent(highlightsAgentName, highlightsInstruction, m, cfg),
+		newStageAgent(statsAngleAgentName, statsAngleInstruction, m, cfg),
+		newStageAgent(recapWriterAgentName, recapWriterInstruction, m, cfg),
+		newStageAgent(sportsEditorAgentName, sportsEditorInstruction, m, cfg),
+	}
+	g, err := buildSportsRecapGraph()
+	if err != nil {
+		return nil, fmt.Errorf("build graph: %w", err)
+	}
+	return graphagent.New(
+		sportsRecapAgentName,
+		g,
+		graphagent.WithDescription("PromptIter multinode sports recap example."),
+		graphagent.WithSubAgents(subAgents),
+	)
+}
+
+func newStageAgent(name string, instruction string, m model.Model, cfg model.GenerationConfig) agent.Agent {
+	return llmagent.New(
+		name,
+		llmagent.WithModel(m),
+		llmagent.WithInstruction(instruction),
+		llmagent.WithGenerationConfig(cfg),
+	)
+}
+
+func buildSportsRecapGraph() (*graph.Graph, error) {
+	sg := graph.NewStateGraph(graph.NewStateSchema())
+	sg.AddNode(nodePrepareGameInput, prepareGameInput)
+	sg.AddAgentNode(headlineAgentName, branchOptions(keyHeadlineInput, keyHeadline)...)
+	sg.AddAgentNode(highlightsAgentName, branchOptions(keyHighlightsInput, keyHighlights)...)
+	sg.AddAgentNode(statsAngleAgentName, branchOptions(keyStatsAngleInput, keyStatsAngle)...)
+	sg.AddNode(nodeJoinRecapParts, joinRecapParts)
+	sg.AddAgentNode(
+		recapWriterAgentName,
+		graph.WithUserInputKey(keyWriterInput),
+		graph.WithSubgraphIsolatedMessages(true),
+		graph.WithSubgraphOutputMapper(storeDraft),
+	)
+	sg.AddAgentNode(
+		sportsEditorAgentName,
+		graph.WithUserInputKey(keyEditorInput),
+		graph.WithSubgraphIsolatedMessages(true),
+		graph.WithSubgraphOutputMapper(storeFinal),
+	)
+	sg.SetEntryPoint(nodePrepareGameInput)
+	sg.AddEdge(nodePrepareGameInput, headlineAgentName)
+	sg.AddEdge(nodePrepareGameInput, highlightsAgentName)
+	sg.AddEdge(nodePrepareGameInput, statsAngleAgentName)
+	sg.AddJoinEdge([]string{headlineAgentName, highlightsAgentName, statsAngleAgentName}, nodeJoinRecapParts)
+	sg.AddEdge(nodeJoinRecapParts, recapWriterAgentName)
+	sg.AddEdge(recapWriterAgentName, sportsEditorAgentName)
+	sg.SetFinishPoint(sportsEditorAgentName)
+	return sg.Compile()
+}
+
+func branchOptions(inputKey string, outputKey string) []graph.Option {
+	return []graph.Option{
+		graph.WithUserInputKey(inputKey),
+		graph.WithSubgraphIsolatedMessages(true),
+		graph.WithSubgraphOutputMapper(func(parent graph.State, result graph.SubgraphResult) graph.State {
+			return graph.State{outputKey: strings.TrimSpace(result.LastResponse)}
+		}),
+	}
+}
+
+func prepareGameInput(ctx context.Context, state graph.State) (any, error) {
+	gameJSON, _ := graph.GetStateValue[string](state, graph.StateKeyUserInput)
+	if strings.TrimSpace(gameJSON) == "" {
+		return nil, errors.New("game input is empty")
+	}
+	return graph.State{
+		keyHeadlineInput:   gameJSON,
+		keyHighlightsInput: gameJSON,
+		keyStatsAngleInput: gameJSON,
+	}, nil
+}
+
+func joinRecapParts(ctx context.Context, state graph.State) (any, error) {
+	gameJSON, _ := graph.GetStateValue[string](state, graph.StateKeyUserInput)
+	headline, _ := graph.GetStateValue[string](state, keyHeadline)
+	highlights, _ := graph.GetStateValue[string](state, keyHighlights)
+	statsAngle, _ := graph.GetStateValue[string](state, keyStatsAngle)
+	if strings.TrimSpace(headline) == "" || strings.TrimSpace(highlights) == "" || strings.TrimSpace(statsAngle) == "" {
+		return nil, errors.New("recap parts are incomplete")
+	}
+	brief := strings.Join([]string{
+		"GAME_JSON:",
+		gameJSON,
+		"HEADLINE:",
+		headline,
+		"HIGHLIGHTS:",
+		highlights,
+		"STATS_ANGLE:",
+		statsAngle,
+	}, "\n\n")
+	return graph.State{keyWriterInput: brief}, nil
+}
+
+func storeDraft(parent graph.State, result graph.SubgraphResult) graph.State {
+	gameJSON, _ := graph.GetStateValue[string](parent, graph.StateKeyUserInput)
+	headline, _ := graph.GetStateValue[string](parent, keyHeadline)
+	highlights, _ := graph.GetStateValue[string](parent, keyHighlights)
+	statsAngle, _ := graph.GetStateValue[string](parent, keyStatsAngle)
+	draft := strings.TrimSpace(result.LastResponse)
+	return graph.State{
+		keyEditorInput: strings.Join([]string{
+			"GAME_JSON:",
+			gameJSON,
+			"HEADLINE:",
+			headline,
+			"HIGHLIGHTS:",
+			highlights,
+			"STATS_ANGLE:",
+			statsAngle,
+			"DRAFT:",
+			draft,
+		}, "\n\n"),
+	}
+}
+
+func storeFinal(parent graph.State, result graph.SubgraphResult) graph.State {
+	final := strings.TrimSpace(result.LastResponse)
+	return graph.State{
+		keyFinalRecap:              final,
+		graph.StateKeyLastResponse: final,
+	}
+}
+
+func intPtr(value int) *int {
+	return &value
+}
+
+func floatPtr(value float64) *float64 {
+	return &value
+}
+
+const headlineInstruction = `生成标题。`
+
+const highlightsInstruction = `提取比赛高光。`
+
+const statsAngleInstruction = `选择数据角度。`
+
+const recapWriterInstruction = `生成中文战报。`
+
+const sportsEditorInstruction = `润色中文战报。`

--- a/examples/evaluation/promptiter/multinode/data/promptiter-sports-recap-agent/sports-recap-train.evalset.json
+++ b/examples/evaluation/promptiter/multinode/data/promptiter-sports-recap-agent/sports-recap-train.evalset.json
@@ -1,0 +1,166 @@
+{
+  "evalSetId": "sports-recap-train",
+  "name": "sports-recap-train",
+  "evalCases": [
+    {
+      "evalId": "train_01_nba_nuggets_blowout",
+      "conversation": [
+        {
+          "invocationId": "train_01_nba_nuggets_blowout-1",
+          "userContent": {
+            "role": "user",
+            "content": "{\"sport\":\"basketball\",\"league\":\"NBA\",\"date\":\"2026-01-12\",\"venue\":\"Ball Arena\",\"teams\":{\"home\":{\"name\":\"丹佛掘金\",\"score\":128,\"recordAfter\":\"28-12\",\"scoreByQuarter\":[34,32,31,31]},\"away\":{\"name\":\"波特兰开拓者\",\"score\":104,\"recordAfter\":\"14-27\",\"scoreByQuarter\":[25,24,27,28]}},\"result\":{\"winner\":\"丹佛掘金\",\"margin\":24,\"largestLead\":29},\"garbageTime\":{\"start\":\"第四节8:42\",\"score\":\"丹佛掘金108-84波特兰开拓者\",\"benchPointsAfterStart\":{\"丹佛掘金\":17,\"波特兰开拓者\":14}},\"teamStats\":{\"丹佛掘金\":{\"fieldGoals\":\"48-91\",\"threePointers\":\"18-39\",\"threePointPct\":\"46.2%\",\"assists\":31,\"turnovers\":11,\"benchPoints\":52},\"波特兰开拓者\":{\"fieldGoals\":\"40-92\",\"threePointers\":\"10-34\",\"threePointPct\":\"29.4%\",\"assists\":23,\"turnovers\":14,\"benchPoints\":39}},\"keyPlayers\":[{\"team\":\"丹佛掘金\",\"name\":\"尼古拉·约基奇\",\"points\":22,\"rebounds\":10,\"assists\":8,\"minutes\":28},{\"team\":\"丹佛掘金\",\"name\":\"贾马尔·穆雷\",\"points\":20,\"assists\":6,\"threePointers\":\"4-7\"},{\"team\":\"丹佛掘金\",\"name\":\"朱利安·斯特劳瑟\",\"points\":12,\"fieldGoals\":\"4-6\",\"bench\":true},{\"team\":\"波特兰开拓者\",\"name\":\"安芬尼·西蒙斯\",\"points\":24,\"threePointers\":\"4-9\"}],\"recapAngle\":\"丹佛外线和替补深度早早拉开比赛，主力末节无需久留\"}"
+          },
+          "finalResponse": {
+            "role": "assistant",
+            "content": "掘金128比104大胜开拓者 18记三分+替补52分让主力末节早收\n\n2026年1月12日，丹佛掘金在Ball Arena以128比104击败波特兰开拓者，战绩来到28-12，开拓者赛后为14-27。掘金前三节分别拿到34分、32分和31分，三节结束已以97比76领先；第四节还剩8分42秒时比分来到108比84，比赛提前进入替补收尾节奏。外线效率和板凳深度，是丹佛把比赛打成大胜的两条主线。\n\n比赛从首节就向掘金倾斜。丹佛第一节34比25领先9分，第二节又以32比24继续扩大优势，半场已经66比49领先17分。第三节开拓者仍没能缩小差距，掘金再打出31比27，带着21分优势进入末节。第四节还剩8分42秒时，掘金领先达到24分，此后比赛悬念基本消失，最终最大领先来到29分。\n\n数据层面，掘金赢在进攻质量和阵容厚度。全队91投48中，三分39投18中，三分命中率达到46.2%；开拓者三分34投10中，命中率只有29.4%。丹佛还送出31次助攻且只有11次失误，开拓者为23次助攻、14次失误。更关键的是替补得分，掘金板凳席拿到52分，比开拓者替补多出13分；进入垃圾时间后，掘金替补仍以17比14压过对手，没有让比分走势出现反复。\n\n尼古拉·约基奇只打28分钟就交出22分10篮板8助攻，无需长时间留在场上。贾马尔·穆雷得到20分6助攻，三分7投4中，延续了掘金外线优势；替补席上朱利安·斯特劳瑟6投4中拿到12分，成为板凳火力的一部分。开拓者方面，安芬尼·西蒙斯得到24分并命中4记三分，但球队整体外线效率、传导质量和替补输出都落在下风，最终以24分差距告负。"
+          }
+        }
+      ],
+      "sessionInput": {
+        "appName": "promptiter-sports-recap-agent",
+        "userId": "promptiter-demo-user"
+      }
+    },
+    {
+      "evalId": "train_02_football_penalty_advancement",
+      "conversation": [
+        {
+          "invocationId": "train_02_football_penalty_advancement-1",
+          "userContent": {
+            "role": "user",
+            "content": "{\"sport\":\"football\",\"competition\":\"东岸杯\",\"round\":\"1/8决赛\",\"game\":\"北港竞技 vs 山城骑士\",\"advancingTeam\":\"北港竞技\",\"regularTimeScore\":\"北港竞技 0-0 山城骑士\",\"extraTimeScore\":\"北港竞技 1-1 山城骑士\",\"goals\":[{\"minute\":105,\"team\":\"北港竞技\",\"player\":\"韩序\",\"period\":\"extra_time\",\"method\":\"禁区内推射\"},{\"minute\":118,\"team\":\"山城骑士\",\"player\":\"周临\",\"period\":\"extra_time\",\"method\":\"后点头球\"}],\"penaltyShootout\":{\"score\":\"北港竞技 5-4 山城骑士\",\"rounds\":[{\"round\":1,\"北港竞技\":\"scored\",\"山城骑士\":\"scored\",\"runningScore\":\"1-1\"},{\"round\":2,\"北港竞技\":\"scored\",\"山城骑士\":\"scored\",\"runningScore\":\"2-2\"},{\"round\":3,\"北港竞技\":\"scored\",\"山城骑士\":\"missed\",\"runningScore\":\"3-2\"},{\"round\":4,\"北港竞技\":\"missed\",\"山城骑士\":\"scored\",\"runningScore\":\"3-3\"},{\"round\":5,\"北港竞技\":\"scored\",\"山城骑士\":\"scored\",\"runningScore\":\"4-4\"},{\"round\":6,\"北港竞技\":\"scored\",\"山城骑士\":\"missed\",\"runningScore\":\"5-4\"}]},\"recapAngle\":\"有明确advancingTeam时可以写晋级；点球轮次要交代第三、第四和第六轮变化\"}"
+          },
+          "finalResponse": {
+            "role": "assistant",
+            "content": "北港竞技点球5比4晋级，山城骑士118分钟追平仍倒在第六轮\n\n东岸杯1/8决赛，北港竞技与山城骑士常规时间0比0战平，加时赛各进一球，最终北港竞技在点球大战中5比4胜出并晋级。比赛主线从加时末段的破门与追平，转向点球大战第三轮、第四轮和第六轮的连续变化：北港竞技先获得主动，又被追平，最后在第六轮抓住机会完成晋级。\n\n常规时间双方都没有进球，僵局一直延续到加时赛。第105分钟，韩序在禁区内推射破门，北港竞技率先打破0比0；第118分钟，周临用后点头球为山城骑士追成1比1，把比赛拖入点球决胜。山城骑士的扳平让比赛重新回到同一起跑线，但也把胜负压缩到每一轮点球的执行质量上。\n\n点球大战前两轮双方全部命中，比分来到2比2。第三轮出现第一次转折，北港竞技罚进，山城骑士罚失，北港竞技以3比2取得领先。第四轮局势又被改写，北港竞技罚失，山城骑士命中，点球比分被追成3比3。第五轮双方再次命中后，悬念留到第六轮。\n\n第六轮成为决定晋级的一轮。北港竞技继续罚进，山城骑士第二次罚失，点球比分定格在5比4。北港竞技赢在关键轮次的兑现：第三轮先抢到优势，第六轮完成收口；山城骑士虽然靠第118分钟的头球延续希望，但第三轮和第六轮两次罚失，最终让他们止步东岸杯1/8决赛。"
+          }
+        }
+      ],
+      "sessionInput": {
+        "appName": "promptiter-sports-recap-agent",
+        "userId": "promptiter-demo-user"
+      }
+    },
+    {
+      "evalId": "train_03_football_late_header",
+      "conversation": [
+        {
+          "invocationId": "train_03_football_late_header-1",
+          "userContent": {
+            "role": "user",
+            "content": "{\"sport\":\"football\",\"competition\":\"城市杯\",\"round\":\"半决赛\",\"nextStageKnown\":false,\"game\":\"滨河FC vs 海港联\",\"teams\":{\"home\":\"滨河FC\",\"away\":\"海港联\"},\"result\":{\"winner\":\"滨河FC\",\"score\":\"2-1\"},\"goals\":[{\"minute\":23,\"team\":\"海港联\",\"player\":\"陈佑\",\"method\":\"禁区弧顶低射\"},{\"minute\":67,\"team\":\"滨河FC\",\"player\":\"林越\",\"method\":\"点球\"},{\"minute\":\"90+4\",\"team\":\"滨河FC\",\"player\":\"刘凯\",\"method\":\"角球头球\"}],\"teamStats\":{\"滨河FC\":{\"possession\":\"42%\",\"shots\":11,\"shotsOnTarget\":5,\"corners\":6,\"fouls\":13},\"海港联\":{\"possession\":\"58%\",\"shots\":14,\"shotsOnTarget\":4,\"corners\":5,\"fouls\":10}},\"keyMoments\":[\"海港联第23分钟先入一球\",\"滨河FC第67分钟利用点球扳平\",\"第90+4分钟滨河FC角球进攻中由刘凯头球破门\"],\"recapAngle\":\"控球少的一方通过定位球和补时头球完成逆转\"}"
+          },
+          "finalResponse": {
+            "role": "assistant",
+            "content": "滨河FC2比1逆转海港联 刘凯90+4角球头球制胜\n\n城市杯半决赛，滨河FC在先丢一球的情况下以2比1击败海港联。海港联第23分钟由陈佑禁区弧顶低射破门，并凭借58%的控球率长时间占据球权；但滨河FC用第67分钟林越的点球扳平比分，随后在第90+4分钟把角球机会转化为刘凯的制胜头球，完成一场控球少的一方的逆转。\n\n比赛走势先由海港联打开。第23分钟，陈佑在禁区弧顶低射得手，海港联取得1比0领先。此后滨河FC并没有在控球上占优，全场控球率只有42%，但他们逐渐把机会集中到更直接的进攻和定位球上。第67分钟，滨河FC获得点球，林越主罚命中，将比分追成1比1。\n\n真正改变胜负的是补时阶段的关键定位球。第90+4分钟，滨河FC角球进攻中由刘凯头球破门，把比分改写为2比1。这个进球不仅完成反超，也让海港联此前的控球和射门优势未能转化为胜势。\n\n数据上，海港联射门14比11领先，控球率也高出16个百分点，但射正只有4次，反而少于滨河FC的5次。滨河FC角球6比5略占上风，并把点球和补时角球两次关键机会都转化成进球。相比海港联更长时间控球，滨河FC赢在关键机会的效率和定位球终结。"
+          }
+        }
+      ],
+      "sessionInput": {
+        "appName": "promptiter-sports-recap-agent",
+        "userId": "promptiter-demo-user"
+      }
+    },
+    {
+      "evalId": "train_04_mlb_walkoff_single",
+      "conversation": [
+        {
+          "invocationId": "train_04_mlb_walkoff_single-1",
+          "userContent": {
+            "role": "user",
+            "content": "{\"sport\":\"baseball\",\"league\":\"MLB\",\"game\":\"辛辛那提红人 vs 芝加哥小熊\",\"venue\":\"Great American Ball Park\",\"result\":{\"winner\":\"辛辛那提红人\",\"score\":\"3-2\",\"walkOff\":true},\"linescore\":{\"辛辛那提红人\":{\"runs\":3,\"hits\":8,\"errors\":0},\"芝加哥小熊\":{\"runs\":2,\"hits\":6,\"errors\":1}},\"scoringSummary\":[{\"inning\":\"3上\",\"team\":\"芝加哥小熊\",\"detail\":\"Ian Happ二垒安打送回1分\"},{\"inning\":\"4下\",\"team\":\"辛辛那提红人\",\"detail\":\"Elly De La Cruz阳春本垒打追成1-1\"},{\"inning\":\"7上\",\"team\":\"芝加哥小熊\",\"detail\":\"Seiya Suzuki高飞牺牲打，芝加哥2-1领先\"},{\"inning\":\"9下\",\"team\":\"辛辛那提红人\",\"detail\":\"Tyler Stephenson一出局满垒再见安打，送回2分\"}],\"keyPlayers\":[{\"team\":\"辛辛那提红人\",\"name\":\"Tyler Stephenson\",\"batting\":\"2-for-4\",\"rbi\":2,\"notable\":\"九局下再见安打\"},{\"team\":\"辛辛那提红人\",\"name\":\"Hunter Greene\",\"inningsPitched\":6,\"runsAllowed\":1,\"strikeouts\":8},{\"team\":\"芝加哥小熊\",\"name\":\"Justin Steele\",\"inningsPitched\":7,\"runsAllowed\":1,\"strikeouts\":6},{\"team\":\"芝加哥小熊\",\"name\":\"Adbert Alzolay\",\"inningsPitched\":0.2,\"runsAllowed\":2,\"blownSave\":true}],\"recapAngle\":\"投手战直到九局下被Stephenson再见安打和Alzolay救援失败改写\"}"
+          },
+          "finalResponse": {
+            "role": "assistant",
+            "content": "Stephenson九下满垒再见安打，红人3比2逆转小熊\n\nMLB比赛中，辛辛那提红人在Great American Ball Park以3比2再见击败芝加哥小熊。整场主线是投手战被九局下最后一击改写：小熊两度领先，红人靠Elly De La Cruz阳春本垒打追平，最终由Tyler Stephenson在一出局满垒时敲出送回2分的再见安打完成逆转。\n\n小熊第3局先打开局面，Ian Happ在3上击出二垒安打送回1分。红人第4局回应，Elly De La Cruz轰出阳春本垒打，把比分追成1比1。第7局，Seiya Suzuki高飞牺牲打帮助芝加哥再拿1分，小熊带着2比1领先进入最后阶段。\n\n两队先发把比赛压在低比分区间。红人先发Hunter Greene投6局只失1分并送出8次三振，小熊先发Justin Steele投7局仅失1分、三振6次。前八局的拉锯里，两边得分机会都有限，这也让九局下的每一次上垒都被放大。\n\n决定胜负的是小熊救援端没能守住2比1。Adbert Alzolay只投0.2局失2分并救援失败，Stephenson则在一出局满垒局面完成全场最关键打席。他此役4打数2安打、贡献2分打点，全部打点都来自这支再见安打。全场红人8支安打且没有失误，小熊6支安打并出现1次失误；在一场只有5分的比赛里，红人把最后一次进攻转化成了决定性的两分。"
+          }
+        }
+      ],
+      "sessionInput": {
+        "appName": "promptiter-sports-recap-agent",
+        "userId": "promptiter-demo-user"
+      }
+    },
+    {
+      "evalId": "train_05_tennis_five_set_comeback",
+      "conversation": [
+        {
+          "invocationId": "train_05_tennis_five_set_comeback-1",
+          "userContent": {
+            "role": "user",
+            "content": "{\"sport\":\"tennis\",\"event\":\"上海大师赛\",\"round\":\"男单第三轮\",\"match\":\"陈林 vs Diego Martinez\",\"winner\":\"陈林\",\"score\":{\"sets\":[\"3-6\",\"4-6\",\"6-4\",\"7-5\",\"7-6(6)\"],\"finalSetTiebreak\":\"8-6\",\"duration\":\"4小时18分钟\"},\"keyStats\":{\"陈林\":{\"aces\":18,\"doubleFaults\":5,\"breakPoints\":\"5/13\",\"winners\":54,\"unforcedErrors\":41},\"Diego Martinez\":{\"aces\":11,\"doubleFaults\":3,\"breakPoints\":\"5/11\",\"winners\":47,\"unforcedErrors\":38}},\"turningPoints\":[\"陈林先丢两盘后第三盘第10局完成关键破发\",\"第四盘5-5后陈林连赢两局将比赛拖入决胜盘\",\"决胜盘抢七陈林在5-6挽救赛点，随后连得3分以8-6取胜\"],\"recapAngle\":\"五盘逆转，关键是决胜盘抢七挽救赛点\",\"styleNote\":\"保留网球比分连字符和抢七括号，ace写作记ace，不写ACE球\"}"
+          },
+          "finalResponse": {
+            "role": "assistant",
+            "content": "陈林决胜盘5-6救赛点连得3分，五盘逆转Diego Martinez\n\n上海大师赛男单第三轮，陈林耗时4小时18分钟，以3-6、4-6、6-4、7-5、7-6(6)击败Diego Martinez。陈林前两盘连续失守，一度以0-2落后，但第三盘第10局完成关键破发后，比赛走势开始被重新拉回。\n\n第四盘的分水岭出现在5-5之后。陈林连赢两局，以7-5将比赛拖入决胜盘，也把前两盘被动局面改写成最后一盘决胜。决胜盘抢七中，陈林在5-6面对赛点时守住关键分，随后连得3分，以8-6拿下抢七，完成这场五盘逆转。\n\n数据上，陈林的主动进攻更有冲击力：他发出18记ace，高于Martinez的11记ace，制胜分也以54比47领先；代价是5次双误和41次非受迫性失误，均多于Martinez的3次双误和38次非受迫性失误。两人破发总数同为5次，陈林13个破发点兑现5个，Martinez11个破发点兑现5个，真正决定胜负的不是破发次数，而是陈林在第三盘第10局、第四盘5-5后以及决胜盘抢七赛点上的连续关键分处理。"
+          }
+        }
+      ],
+      "sessionInput": {
+        "appName": "promptiter-sports-recap-agent",
+        "userId": "promptiter-demo-user"
+      }
+    },
+    {
+      "evalId": "train_06_badminton_saved_match_point",
+      "conversation": [
+        {
+          "invocationId": "train_06_badminton_saved_match_point-1",
+          "userContent": {
+            "role": "user",
+            "content": "{\"sport\":\"badminton\",\"competition\":\"亚洲羽毛球挑战赛\",\"event\":\"女单1/4决赛\",\"players\":{\"winner\":\"王岚\",\"loser\":\"陈思思\"},\"score\":{\"winner\":\"王岚\",\"games\":\"2-1\",\"gameScores\":[\"18-21\",\"23-21\",\"21-15\"]},\"keyPoints\":[{\"game\":2,\"score\":\"20-21\",\"server\":\"陈思思\",\"event\":\"王岚网前封网挽救赛点\"},{\"game\":2,\"score\":\"21-21\",\"event\":\"王岚连续压后场造成陈思思回球出界\"},{\"game\":2,\"score\":\"22-21\",\"event\":\"王岚反手勾对角得分，以23-21扳回一局\"},{\"game\":3,\"score\":\"15-13\",\"event\":\"王岚连拿4分扩大到19-13\"}],\"stats\":{\"王岚\":{\"netPoints\":21,\"unforcedErrors\":13,\"smashWinners\":16},\"陈思思\":{\"netPoints\":16,\"unforcedErrors\":19,\"smashWinners\":18}},\"recapAngle\":\"比分必须保留连字符；重点是第二局20-21挽救赛点和决胜局15-13后的4分攻势\"}"
+          },
+          "finalResponse": {
+            "role": "assistant",
+            "content": "王岚20-21救赛点连扳两局，2-1逆转陈思思\n\n亚洲羽毛球挑战赛女单1/4决赛，王岚在先丢一局后以18-21、23-21、21-15击败陈思思。整场主线集中在第二局局末：王岚在20-21、陈思思发球的赛点压力下完成网前封网，把比分追成21-21，也把比赛从败局边缘重新拉回拉锯。\n\n随后王岚连续压后场造成陈思思回球出界，以22-21反拿局点；下一分又用反手勾对角得分，将第二局定格在23-21。这个三分段直接改写比赛走势，陈思思从握有赛点变成被拖入决胜局。\n\n决胜局双方打到15-13后，王岚再次在关键段提速，连拿4分把比分扩大到19-13。相比第二局末段的险中求生，这波攻势让王岚真正建立缓冲，并最终以21-15收下决胜局。\n\n数据也解释了逆转原因。王岚网前得分21比16领先，非受迫性失误只有13次，少于陈思思的19次；陈思思扣杀得分18比16略占优势，但在第二局20-21之后和决胜局15-13之后，王岚在网前处理、后场压迫和失误控制上连续赢下更关键的分段。"
+          }
+        }
+      ],
+      "sessionInput": {
+        "appName": "promptiter-sports-recap-agent",
+        "userId": "promptiter-demo-user"
+      }
+    },
+    {
+      "evalId": "train_07_ice_hockey_overtime",
+      "conversation": [
+        {
+          "invocationId": "train_07_ice_hockey_overtime-1",
+          "userContent": {
+            "role": "user",
+            "content": "{\"sport\":\"ice_hockey\",\"gameType\":\"regular_season\",\"venue\":\"East Ice Center\",\"teams\":{\"home\":\"雪原狼\",\"away\":\"湖湾骑士\"},\"score\":{\"雪原狼\":3,\"湖湾骑士\":2,\"periods\":[{\"period\":1,\"雪原狼\":0,\"湖湾骑士\":1},{\"period\":2,\"雪原狼\":1,\"湖湾骑士\":0},{\"period\":3,\"雪原狼\":1,\"湖湾骑士\":1},{\"period\":\"OT\",\"雪原狼\":1,\"湖湾骑士\":0}]},\"keyPlays\":[{\"time\":\"第三节18:26\",\"team\":\"雪原狼\",\"player\":\"顾南\",\"event\":\"扳平进球\",\"detail\":\"顾南在门前混战中补射得手，将比分追成2比2\"},{\"time\":\"加时赛00:54\",\"team\":\"雪原狼\",\"player\":\"林川\",\"event\":\"犯规\",\"detail\":\"林川因阻挡被判2分钟小罚，雪原狼进入少打一人防守\"},{\"time\":\"加时赛01:22\",\"team\":\"湖湾骑士\",\"player\":\"阿列克谢·诺瓦克\",\"event\":\"强打射门\",\"detail\":\"诺瓦克在左侧争球圈直接射门，被门将沈澈用肩部挡出\"},{\"time\":\"加时赛02:31\",\"team\":\"湖湾骑士\",\"player\":\"何屿\",\"event\":\"门前补射\",\"detail\":\"何屿在门前补射，被沈澈用护腿封出\"},{\"time\":\"加时赛02:54\",\"team\":\"雪原狼\",\"player\":\"林川\",\"event\":\"回场\",\"detail\":\"林川结束受罚回到冰面，雪原狼完成少打一人防守\"},{\"time\":\"加时赛04:12\",\"team\":\"雪原狼\",\"player\":\"唐越\",\"event\":\"绝杀进球\",\"detail\":\"唐越接顾南回传，在右侧低射破门，帮助雪原狼3比2取胜\"}],\"goalieStats\":{\"雪原狼\":{\"goalie\":\"沈澈\",\"saves\":41,\"goalsAgainst\":2,\"overtimeSaves\":6},\"湖湾骑士\":{\"goalie\":\"罗森\",\"saves\":33,\"goalsAgainst\":3,\"overtimeSaves\":2}},\"specialTeams\":{\"雪原狼\":{\"penaltyKill\":\"1/1\",\"overtimePenaltyKill\":\"1/1\"},\"湖湾骑士\":{\"powerPlay\":\"0/1\",\"overtimePowerPlay\":\"0/1\"}},\"recapAngle\":\"不要用未给出的特勤组评价；重点写少打一人防守的两次扑救和4:12绝杀\"}"
+          },
+          "finalResponse": {
+            "role": "assistant",
+            "content": "沈澈加时少防多两连扑，唐越4分12秒助雪原狼绝杀湖湾骑士\n\n雪原狼在East Ice Center以3比2加时击败湖湾骑士。比赛胜负的分水岭不只在最后一攻，而是加时初段的少打一人防守：林川受罚后，沈澈连续挡出阿列克谢·诺瓦克的左侧争球圈直接射门和何屿的门前补射，帮助雪原狼熬过湖湾骑士唯一一次强打机会。守住这两次攻门后，唐越在加时4分12秒接顾南回传右侧低射破门，完成终结。\n\n湖湾骑士首节1比0领先，雪原狼第二节扳成1比1。第三节双方各进一球，雪原狼直到18分26秒才追平：顾南在门前混战中补射得手，把比分改写为2比2，也把比赛带入加时。进入加时后，雪原狼很快陷入被动，00分54秒林川因阻挡被判2分钟小罚，球队进入少打一人防守。\n\n这次少防多决定了比赛走向。01分22秒，诺瓦克在左侧争球圈直接起杆，沈澈用肩部挡出；02分31秒，何屿在门前补射，沈澈又用护腿封住。02分54秒林川回到冰面，雪原狼完成加时少防多。不到1分半钟后，顾南从追平进球者变成进攻发起点，他的回传找到唐越，唐越右侧低射击穿罗森，将比分定格为3比2。\n\n数据上，沈澈全场41次扑救、只丢2球，加时赛完成6次扑救，是雪原狼能够从被强打压制中脱身的核心。罗森完成33次扑救、加时2次扑救，但湖湾骑士唯一一次强打未能兑现，直接错过结束比赛的窗口。雪原狼守住加时少防多后，才有唐越4分12秒绝杀的进攻空间。"
+          }
+        }
+      ],
+      "sessionInput": {
+        "appName": "promptiter-sports-recap-agent",
+        "userId": "promptiter-demo-user"
+      }
+    },
+    {
+      "evalId": "train_08_cricket_last_over_chase",
+      "conversation": [
+        {
+          "invocationId": "train_08_cricket_last_over_chase-1",
+          "userContent": {
+            "role": "user",
+            "content": "{\"sport\":\"cricket\",\"format\":\"T20\",\"match\":\"南岸海鸥 vs 首都流星\",\"innings\":[{\"team\":\"南岸海鸥\",\"runs\":142,\"wickets\":9,\"overs\":\"20.0\",\"topScorer\":{\"name\":\"伊桑·周\",\"runs\":38,\"balls\":31}},{\"team\":\"首都流星\",\"runs\":145,\"wickets\":6,\"overs\":\"19.4\",\"target\":143,\"topScorer\":{\"name\":\"卡里姆·汗\",\"runs\":52,\"balls\":44,\"notOut\":true}}],\"result\":{\"winner\":\"首都流星\",\"margin\":\"4 wickets\",\"ballsRemaining\":2},\"finalOver\":{\"bowler\":\"罗伊·陈\",\"runsNeeded\":9,\"battingTeamScoreBefore\":\"134/6\",\"balls\":[{\"ball\":\"19.1\",\"runs\":1,\"detail\":\"卡里姆·汗推向长边拿1分\"},{\"ball\":\"19.2\",\"runs\":2,\"detail\":\"萨米尔·帕特尔穿过midwicket拿2分\"},{\"ball\":\"19.3\",\"runs\":0,\"detail\":\"罗伊·陈投出慢球，帕特尔挥空\"},{\"ball\":\"19.4\",\"runs\":8,\"detail\":\"帕特尔先打出四分，随后因no-ball获得1分并在free hit再打出三分，首都流星达到145/6\"}]},\"bowlingFigure\":{\"team\":\"南岸海鸥\",\"bowler\":\"罗伊·陈\",\"overs\":\"4.0\",\"wickets\":2,\"runsConceded\":31},\"recapAngle\":\"板球用over、wickets和balls remaining表达；不要把19.4 overs写成第19.4个球\"}"
+          },
+          "finalResponse": {
+            "role": "assistant",
+            "content": "首都流星19.4 overs追到145/6，最后over拿11分以4 wickets险胜南岸海鸥\n\nT20追逐战中，南岸海鸥先打出142/9，首都流星追143分目标时在19.4 overs达到145/6，以4 wickets、剩2 balls取胜。卡里姆·汗44 balls拿到52分且未出局，稳住首都流星的追逐底盘；萨米尔·帕特尔则在最后一个over完成决定性打击，把134/6、需9分的局面直接改写为胜利。\n\n南岸海鸥一局中由伊桑·周31 balls得到38分，全队定格在142/9。首都流星追逐到最后一个over前为134/6，仍需9分，罗伊·陈承担守分任务。19.1，卡里姆·汗推向长边拿1分；19.2，帕特尔穿过midwicket跑2分；19.3，罗伊·陈用慢球让帕特尔挥空，首都流星前三球只拿3分，剩下3个合法球仍需6分。转折出现在19.4：帕特尔先打出四分，随后借no-ball再得1分，并在free hit跑出3分，这组进攻合计8分，首都流星直接越过目标到145/6。\n\n首都流星赢球时只丢6 wickets，最终胜差是4 wickets；19.4 overs意味着他们在19个完整over后的第4个合法球就完成追逐。罗伊·陈全场4.0 overs失31分、取2 wickets，但最后一个over丢掉11分，未能守住9分额度。卡里姆·汗52 not out是追逐成功的稳定轴，帕特尔在19.2和19.4合计制造10分，尤其no-ball与free hit连续把守方压力放大，决定了最后两球不用再打的结局。"
+          }
+        }
+      ],
+      "sessionInput": {
+        "appName": "promptiter-sports-recap-agent",
+        "userId": "promptiter-demo-user"
+      }
+    }
+  ]
+}

--- a/examples/evaluation/promptiter/multinode/data/promptiter-sports-recap-agent/sports-recap-validation.evalset.json
+++ b/examples/evaluation/promptiter/multinode/data/promptiter-sports-recap-agent/sports-recap-validation.evalset.json
@@ -1,0 +1,166 @@
+{
+  "evalSetId": "sports-recap-validation",
+  "name": "sports-recap-validation",
+  "evalCases": [
+    {
+      "evalId": "validation_01_nba_empty_48",
+      "conversation": [
+        {
+          "invocationId": "validation_01_nba_empty_48-1",
+          "userContent": {
+            "role": "user",
+            "content": "{\"sport\":\"basketball\",\"league\":\"NBA\",\"date\":\"2026-02-12\",\"venue\":\"Ball Arena\",\"teams\":{\"home\":{\"name\":\"丹佛掘金\",\"score\":118},\"away\":{\"name\":\"菲尼克斯太阳\",\"score\":111}},\"result\":{\"winner\":\"丹佛掘金\",\"margin\":7},\"teamStats\":{\"丹佛掘金\":{\"rebounds\":52,\"offensiveRebounds\":15,\"turnovers\":8,\"assists\":30,\"playersInDoubleFigures\":6},\"菲尼克斯太阳\":{\"rebounds\":39,\"offensiveRebounds\":7,\"turnovers\":16,\"assists\":18,\"playersInDoubleFigures\":3}},\"keyPlayers\":[{\"team\":\"菲尼克斯太阳\",\"name\":\"德文·布克\",\"points\":48,\"rebounds\":5,\"assists\":6,\"fieldGoals\":\"17-31\",\"threePointers\":\"6-12\"},{\"team\":\"丹佛掘金\",\"name\":\"尼古拉·约基奇\",\"points\":24,\"rebounds\":13,\"assists\":9},{\"team\":\"丹佛掘金\",\"name\":\"贾马尔·穆雷\",\"points\":22,\"assists\":7},{\"team\":\"丹佛掘金\",\"name\":\"阿龙·戈登\",\"points\":18,\"rebounds\":9}],\"decisiveStretch\":{\"quarter\":\"第四节\",\"timeRemaining\":\"5:42\",\"run\":\"丹佛掘金14-4菲尼克斯太阳\",\"sunTurnovers\":4,\"nuggetsOffensiveRebounds\":5},\"recapAngle\":\"输球方球星高分，赢球方靠篮板和失误控制取胜\"}"
+          },
+          "finalResponse": {
+            "role": "assistant",
+            "content": "掘金末节14比4定胜局，布克48分难阻太阳111比118落败\n\n2026年2月12日，NBA一场比赛在Ball Arena结束，丹佛掘金以118比111击败菲尼克斯太阳。德文·布克31投17中、三分12投6中轰下48分5篮板6助攻，但太阳没有把个人爆发转化为团队胜势；掘金凭借52比39的篮板优势、15比7的进攻篮板优势，以及8次失误对16次失误的回合控制，最终赢下7分。\n\n比赛转折集中在第四节还剩5分42秒后的关键阶段。掘金打出14比4攻势，太阳在这段时间出现4次失误，掘金则抢下5个进攻篮板。分差被拉开的核心不只是命中率，而是回合数和二次进攻：太阳的进攻被失误切断，掘金连续通过前场篮板延长进攻，比赛主动权随之转向主队。\n\n布克的48分撑起了太阳火力，但太阳全队只有18次助攻、3人得分上双，进攻更依赖单点输出。掘金则有6人得分上双、全队30次助攻，尼古拉·约基奇得到24分13篮板9助攻，贾马尔·穆雷贡献22分7助攻，阿龙·戈登拿到18分9篮板。约基奇的篮板和策应、穆雷的后场组织、戈登的锋线冲击，共同把掘金的进攻维持在更稳定的团队节奏里。\n\n这场球的胜负逻辑很清楚：太阳拥有全场最强的个人得分点，掘金则赢在更高质量的回合管理。13个篮板差、8个进攻篮板差、8次失误差，最终都在末节关键14比4里集中兑现。布克的高分让太阳始终有追赶资本，但掘金用篮板、少失误和多点分担完成了收比赛。"
+          }
+        }
+      ],
+      "sessionInput": {
+        "appName": "promptiter-sports-recap-agent",
+        "userId": "promptiter-demo-user"
+      }
+    },
+    {
+      "evalId": "validation_02_football_penalties",
+      "conversation": [
+        {
+          "invocationId": "validation_02_football_penalties-1",
+          "userContent": {
+            "role": "user",
+            "content": "{\"sport\":\"football\",\"competition\":\"洲际杯\",\"round\":\"1/4决赛\",\"game\":\"河城FC vs 海港联\",\"advancingTeam\":\"海港联\",\"regularTimeScore\":\"河城FC 1-1 海港联\",\"extraTimeScore\":\"河城FC 2-2 海港联\",\"goals\":[{\"minute\":27,\"team\":\"河城FC\",\"player\":\"卢卡·莫雷诺\",\"period\":\"regular_time\"},{\"minute\":71,\"team\":\"海港联\",\"player\":\"诺亚·里德\",\"period\":\"regular_time\"},{\"minute\":98,\"team\":\"河城FC\",\"player\":\"马特奥·席尔瓦\",\"period\":\"extra_time\"},{\"minute\":114,\"team\":\"海港联\",\"player\":\"埃文·布鲁克斯\",\"period\":\"extra_time\"}],\"penaltyShootout\":{\"score\":\"河城FC 3-4 海港联\",\"rounds\":[{\"round\":1,\"河城FC\":\"scored\",\"海港联\":\"scored\",\"runningScore\":\"1-1\"},{\"round\":2,\"河城FC\":\"scored\",\"海港联\":\"scored\",\"runningScore\":\"2-2\"},{\"round\":3,\"河城FC\":\"missed\",\"海港联\":\"scored\",\"runningScore\":\"2-3\"},{\"round\":4,\"河城FC\":\"scored\",\"海港联\":\"missed\",\"runningScore\":\"3-3\"},{\"round\":5,\"河城FC\":\"missed\",\"海港联\":\"scored\",\"runningScore\":\"3-4\"}]}}"
+          },
+          "finalResponse": {
+            "role": "assistant",
+            "content": "海港联两度追平后点球4比3晋级 河城FC第3、第5轮罚失出局\n\n洲际杯1/4决赛，海港联与河城FC常规时间1比1、加时赛2比2战平，最终海港联在点球大战中4比3胜出晋级。河城FC两次取得领先，但海港联分别在第71分钟和第114分钟追平；进入点球大战后，河城FC第3轮和第5轮两次罚失，海港联抓住最后一轮命中机会完成晋级。\n\n第27分钟，卢卡·莫雷诺为河城FC破门，河城FC在常规时间先取得1比0领先。第71分钟，诺亚·里德为海港联扳平，双方常规时间战成1比1。加时赛第98分钟，马特奥·席尔瓦帮助河城FC再次领先，比分变为2比1；第114分钟，埃文·布鲁克斯为海港联再度追平，比赛进入点球大战前定格为2比2。\n\n点球大战前两轮双方全部命中，比分来到2比2。第3轮，河城FC罚失，海港联命中，海港联以3比2取得主动。第4轮，河城FC命中，海港联罚失，点球比分回到3比3。第5轮成为胜负分界，河城FC再次罚失，海港联命中，将点球比分锁定为4比3。\n\n这场比赛的核心走势是河城FC两次领先，海港联两次追平。河城FC在常规时间和加时赛都先打破平衡，但都没有把领先带到阶段结束；海港联则在第71分钟和第114分钟两次把比赛拉回同一起点，尤其第114分钟的加时追平直接把胜负推向点球大战。点球环节的差距非常明确：海港联5轮4中，只在第4轮罚失；河城FC5轮3中，第3轮和第5轮两次罚失。最终，海港联不是依靠单一进球完成晋级，而是在两次落后后的追平能力和点球执行稳定性上占到优势。"
+          }
+        }
+      ],
+      "sessionInput": {
+        "appName": "promptiter-sports-recap-agent",
+        "userId": "promptiter-demo-user"
+      }
+    },
+    {
+      "evalId": "validation_03_f1_rain_safety_car",
+      "conversation": [
+        {
+          "invocationId": "validation_03_f1_rain_safety_car-1",
+          "userContent": {
+            "role": "user",
+            "content": "{\"sport\":\"Formula 1\",\"event\":\"Rain Grand Prix\",\"venue\":\"Harbor Street Circuit\",\"conditions\":\"Rain\",\"raceDistanceLaps\":58,\"safetyCar\":{\"deployedLap\":31,\"endedLap\":34,\"reason\":\"Car 22 stopped at Turn 7\"},\"postSafetyCarPitWindow\":{\"laps\":[34,35,36],\"tireChanges\":[{\"driver\":\"Marco Silva\",\"team\":\"Aurora Racing\",\"lap\":35,\"from\":\"Wet\",\"to\":\"Intermediate\"},{\"driver\":\"Evan Brooks\",\"team\":\"Northstar GP\",\"lap\":35,\"from\":\"Wet\",\"to\":\"Intermediate\"},{\"driver\":\"Luca Ren\",\"team\":\"Vector Motorsport\",\"lap\":36,\"from\":\"Wet\",\"to\":\"Intermediate\"}]},\"classification\":[{\"position\":1,\"driver\":\"Marco Silva\",\"team\":\"Aurora Racing\"},{\"position\":2,\"driver\":\"Evan Brooks\",\"team\":\"Northstar GP\",\"gap\":\"+4.812s\"},{\"position\":3,\"driver\":\"Luca Ren\",\"team\":\"Vector Motorsport\",\"gap\":\"+9.337s\"}],\"fastestLap\":{\"driver\":\"Evan Brooks\",\"team\":\"Northstar GP\",\"lap\":52,\"time\":\"1:42.318\"}}"
+          },
+          "finalResponse": {
+            "role": "assistant",
+            "content": "Silva第35圈换胎后夺冠，Brooks最快圈未改第二\n\nRain Grand Prix在Harbor Street Circuit完成58圈雨战，胜负节点集中在第31圈后的安全车阶段。第31圈，22号赛车停在7号弯触发安全车；第34圈安全车结束后，第34至36圈成为关键进站窗口。Marco Silva与Evan Brooks同在第35圈从Wet换上Intermediate，Luca Ren第36圈完成同样调整。最终Silva代表Aurora Racing夺冠，Brooks为Northstar GP获得第二，落后4.812秒；Ren代表Vector Motorsport排名第三，落后9.337秒。\n\n第31圈的安全车把雨战节奏重新压缩。第34圈安全车结束，比赛立刻进入换胎窗口；第35圈，Silva和Brooks同步完成Wet到Intermediate的切换，并最终占据前两名。第36圈，Ren进站换上Intermediate，最终以第三名完赛。第52圈，Brooks跑出1:42.318的最快圈，但仍以4.812秒差距排在Silva之后。\n\n这场比赛不是由单圈速度单独决定。Brooks在第52圈做出全场最快圈，说明他后段仍有速度优势，但最快圈无法抹平安全车后换胎窗口形成的完赛差距。Silva的胜利核心在于第35圈完成Wet到Intermediate的关键切换，并在58圈结束时把优势转化为冠军；Ren晚一圈完成同类换胎，最终与冠军差距扩大到9.337秒。雨战、安全车、进站窗口和最快圈共同构成了前三名排序的解释链条。"
+          }
+        }
+      ],
+      "sessionInput": {
+        "appName": "promptiter-sports-recap-agent",
+        "userId": "promptiter-demo-user"
+      }
+    },
+    {
+      "evalId": "validation_04_badminton_match_point",
+      "conversation": [
+        {
+          "invocationId": "validation_04_badminton_match_point-1",
+          "userContent": {
+            "role": "user",
+            "content": "{\"sport\":\"badminton\",\"event\":\"国际羽毛球邀请赛\",\"discipline\":\"女单半决赛\",\"match\":\"林悦 vs 高桥美咲\",\"winner\":\"林悦\",\"finalScore\":\"17-21, 22-20, 21-16\",\"sets\":[{\"set\":1,\"score\":\"17-21\",\"winner\":\"高桥美咲\"},{\"set\":2,\"score\":\"22-20\",\"winner\":\"林悦\"},{\"set\":3,\"score\":\"21-16\",\"winner\":\"林悦\"}],\"competitors\":[{\"name\":\"林悦\",\"result\":\"win\",\"netFrontPoints\":18,\"netFrontErrors\":6,\"matchPointsSaved\":1},{\"name\":\"高桥美咲\",\"result\":\"loss\",\"netFrontPoints\":14,\"netFrontErrors\":11,\"matchPointsEarned\":1}],\"turningPoints\":[\"林悦首局17-21告负，随后以22-20和21-16连赢两局\",\"第二局林悦19-20落后时用一次网前扑球挽救赛点\",\"林悦第二局从19-20连得3分，以22-20拿下该局\"],\"netFrontMargin\":{\"winnerPointsAdvantage\":4,\"winnerFewerErrors\":5}}"
+          },
+          "finalResponse": {
+            "role": "assistant",
+            "content": "林悦19-20救赛点连下三分，2比1逆转高桥美咲\n\n国际羽毛球邀请赛女单半决赛，林悦在先丢一局、第二局又被逼到赛点的情况下，以17-21、22-20、21-16逆转高桥美咲。比赛的胜负拐点出现在第二局尾声：高桥美咲20-19握有局点兼赛点，林悦用一次网前扑球追成20平，随后再拿两分，以22-20把比赛带入决胜局。\n\n林悦首局17-21落后，总比分0比1进入第二局。第二局她一度19-20被动，但从这一分开始连得3分完成反扑，既化解高桥美咲的赛点，也拿下这一局。决胜局林悦延续反转后的主动，以21-16再胜一局，最终完成连扳两局的逆转。\n\n网前表现是林悦翻盘最明确的数据支撑。她全场网前得分18比14领先高桥美咲，多拿4分；网前失误6比11更少，少送5次失误。也就是说，林悦不只是靠第二局赛点上的单次扑球止住败势，而是在整场网前攻防里同时取得得分优势和稳定性优势。高桥美咲曾在第二局拿到终结比赛的机会，但没能兑现，最终被林悦从19-20的绝境中拉回并完成逆转。"
+          }
+        }
+      ],
+      "sessionInput": {
+        "appName": "promptiter-sports-recap-agent",
+        "userId": "promptiter-demo-user"
+      }
+    },
+    {
+      "evalId": "validation_05_ice_hockey_overtime",
+      "conversation": [
+        {
+          "invocationId": "validation_05_ice_hockey_overtime-1",
+          "userContent": {
+            "role": "user",
+            "content": "{\"sport\":\"ice_hockey\",\"gameType\":\"regular_season\",\"venue\":\"North Harbor Arena\",\"teams\":{\"home\":\"港城海鹰\",\"away\":\"北岸风暴\"},\"score\":{\"港城海鹰\":4,\"北岸风暴\":3,\"periods\":[{\"period\":1,\"港城海鹰\":1,\"北岸风暴\":1},{\"period\":2,\"港城海鹰\":1,\"北岸风暴\":2},{\"period\":3,\"港城海鹰\":1,\"北岸风暴\":0},{\"period\":\"OT\",\"港城海鹰\":1,\"北岸风暴\":0}]},\"keyPlays\":[{\"time\":\"第三节17:42\",\"team\":\"港城海鹰\",\"player\":\"林澈\",\"event\":\"扳平进球\",\"detail\":\"林澈在门前补射得手，将比分追成3比3\"},{\"time\":\"加时赛01:08\",\"team\":\"港城海鹰\",\"player\":\"周砚\",\"event\":\"犯规\",\"detail\":\"周砚因钩人被判2分钟小罚，港城海鹰进入少打一人防守\"},{\"time\":\"加时赛01:41\",\"team\":\"北岸风暴\",\"player\":\"韩维\",\"event\":\"强打射门\",\"detail\":\"韩维在右侧争球圈完成一次直接射门，被门将许知远用右腿挡出\"},{\"time\":\"加时赛02:16\",\"team\":\"北岸风暴\",\"player\":\"叶铭\",\"event\":\"强打补射\",\"detail\":\"叶铭在门前补射，被许知远用手套接住，比赛暂停\"},{\"time\":\"加时赛03:04\",\"team\":\"港城海鹰\",\"player\":\"周砚\",\"event\":\"回场\",\"detail\":\"周砚结束受罚回到冰面，港城海鹰完成少打一人防守\"},{\"time\":\"加时赛03:47\",\"team\":\"港城海鹰\",\"player\":\"陆行舟\",\"event\":\"绝杀进球\",\"detail\":\"陆行舟接林澈横传，在左侧低射破门，帮助港城海鹰4比3取胜\"}],\"goalieStats\":{\"港城海鹰\":{\"goalie\":\"许知远\",\"saves\":38,\"goalsAgainst\":3,\"overtimeSaves\":5},\"北岸风暴\":{\"goalie\":\"沈岳\",\"saves\":29,\"goalsAgainst\":4,\"overtimeSaves\":1}},\"specialTeams\":{\"港城海鹰\":{\"penaltyKill\":\"1/1\",\"overtimePenaltyKill\":\"1/1\"},\"北岸风暴\":{\"powerPlay\":\"0/1\",\"overtimePowerPlay\":\"0/1\"}}}"
+          },
+          "finalResponse": {
+            "role": "assistant",
+            "content": "守住少防多再绝杀，陆行舟加时03:47低射助港城海鹰4比3逆转北岸风暴\n\n港城海鹰在North Harbor Arena以4比3加时击败北岸风暴。比赛前三节从1比1、2比3走到3比3，第三节17:42，林澈在门前补射得手，为港城海鹰扳平比分。进入加时后，港城海鹰先因周砚钩人小罚陷入人数劣势，但许知远连续挡下北岸风暴强打攻势；等到周砚回场后，陆行舟接林澈横传完成低射绝杀。\n\n这场加时的胜负点先落在少打一人防守。加时01:08，周砚被判2分钟小罚，北岸风暴获得强打机会；01:41，韩维在右侧争球圈直接射门，被许知远用右腿挡出；02:16，叶铭门前补射，又被许知远用手套接住并造成比赛暂停。03:04，周砚结束受罚回到冰面，港城海鹰完成加时少打一人防守，也让北岸风暴全场唯一一次强打机会以0/1收场。\n\n防住强打后，港城海鹰把比赛带回自己的节奏。加时03:47，林澈送出横传，陆行舟在左侧低射破门，将比分定格为4比3。林澈先在第三节末段补射扳平，又在加时绝杀回合送出关键传球，是港城海鹰从落后到取胜的进攻连接点。\n\n门将数据也说明了比赛转折。许知远全场完成38次扑救、只丢3球，加时阶段有5次扑救，其中包括少防多期间对韩维直接射门和叶铭门前补射的连续化解；沈岳完成29次扑救、加时1次扑救，但最终未能挡住陆行舟的左侧低射。港城海鹰少打一人防守为1/1，加时同样1/1，这次防守成功直接为后续绝杀创造了前提。"
+          }
+        }
+      ],
+      "sessionInput": {
+        "appName": "promptiter-sports-recap-agent",
+        "userId": "promptiter-demo-user"
+      }
+    },
+    {
+      "evalId": "validation_06_tennis_tiebreak",
+      "conversation": [
+        {
+          "invocationId": "validation_06_tennis_tiebreak-1",
+          "userContent": {
+            "role": "user",
+            "content": "{\"sport\":\"tennis\",\"discipline\":\"女单\",\"winner\":\"林诗语\",\"loser\":\"赵清岚\",\"score\":{\"sets\":[\"7-6(10)\",\"6-3\"],\"straightSets\":true,\"setOneTiebreak\":\"12-10\"},\"keyFacts\":{\"setPointsSavedByWinner\":3,\"setPointDetails\":[\"首盘5-6发球局挽救2个盘点\",\"首盘抢七8-9再挽救1个盘点\"],\"aces\":{\"林诗语\":9,\"赵清岚\":4},\"firstServePointsWon\":{\"林诗语\":\"78%\",\"赵清岚\":\"66%\"},\"breakPoints\":{\"林诗语\":\"3/7\",\"赵清岚\":\"2/6\"},\"decisiveSecondSetFact\":\"第二盘林诗语两次破发，赵清岚一次回破\"},\"recapAngle\":\"直落两盘但首盘抢七极胶着，不能写成轻松横扫\"}"
+          },
+          "finalResponse": {
+            "role": "assistant",
+            "content": "林诗语三救盘点抢下首盘，7-6(10)、6-3直落两盘击败赵清岚\n\n林诗语以7-6(10)、6-3战胜赵清岚，比分是直落两盘，胜负手却集中在极其胶着的首盘。她先是在首盘5-6的发球局挽救2个盘点，把比赛拖入抢七；随后又在抢七8-9落后时化解第3个盘点，最终以12-10拿下抢七，也把比赛走势从被动边缘拉回自己手中。\n\n进入第二盘后，林诗语把首盘关键分带来的主动权转化到接发环节。她本盘两次破发，赵清岚虽完成一次回破，但未能持续抵消差距，林诗语最终以6-3收下第二盘，完成直落两盘取胜。\n\n数据层面，林诗语发出9记ace，高于赵清岚的4记；一发得分率也以78%对66%占优，这让她在关键发球局和抢七中拥有更稳定的保分基础。破发点上，林诗语7次机会兑现3次，赵清岚6次机会兑现2次，双方都有破发效率，但林诗语在首盘三次盘点压力下守住比分，并在第二盘多一次破发兑现，才是比赛被拉向她一边的决定性差别。"
+          }
+        }
+      ],
+      "sessionInput": {
+        "appName": "promptiter-sports-recap-agent",
+        "userId": "promptiter-demo-user"
+      }
+    },
+    {
+      "evalId": "validation_07_road_cycling_breakaway",
+      "conversation": [
+        {
+          "invocationId": "validation_07_road_cycling_breakaway-1",
+          "userContent": {
+            "role": "user",
+            "content": "{\"sport\":\"road_cycling\",\"raceType\":\"individual_road_race\",\"distanceRemainingKmAtKeyMove\":5,\"winner\":{\"name\":\"林澈\",\"team\":\"青岚车队\"},\"teammateLeadout\":{\"name\":\"赵屿\",\"team\":\"青岚车队\",\"role\":\"在最后5公里进入突围后持续领骑，帮助林澈维持优势，最后600米退出争夺\"},\"breakaway\":{\"riders\":[\"林澈\",\"赵屿\",\"周明远\",\"韩砚\"],\"gapToChasingGroup\":[{\"remainingKm\":5,\"gapSeconds\":9},{\"remainingKm\":3,\"gapSeconds\":6},{\"remainingKm\":1,\"gapSeconds\":4},{\"remainingKm\":0,\"gapSeconds\":7}]},\"finalSprint\":{\"launchDistanceMeters\":180,\"winnerAction\":\"林澈从周明远右侧启动冲刺并率先过线\",\"margin\":\"半个车身\"},\"result\":[{\"rank\":1,\"rider\":\"林澈\",\"team\":\"青岚车队\"},{\"rank\":2,\"rider\":\"周明远\",\"team\":\"北湾车队\",\"gap\":\"半个车身\"},{\"rank\":3,\"rider\":\"韩砚\",\"team\":\"岩川车队\",\"gap\":\"同秒\"},{\"rank\":4,\"rider\":\"赵屿\",\"team\":\"青岚车队\",\"gap\":\"同秒\"},{\"rank\":5,\"rider\":\"集团第一名\",\"gapSeconds\":7}],\"scoringNote\":\"这是个人公路赛，胜利归属车手林澈，不是青岚车队的团队胜利\"}"
+          },
+          "finalResponse": {
+            "role": "assistant",
+            "content": "林澈终点前180米右侧开冲 半个车身赢下四人突围\n\n个人公路赛最后5公里形成胜负分界：林澈、赵屿、周明远和韩砚组成四人突围，领先追击集团9秒。追击集团随后持续压缩差距，最后3公里追到6秒，最后1公里只剩4秒，但四人突围没有被追回，反而在终点时把优势扩大到7秒。\n\n青岚车队的赵屿是林澈夺冠前最关键的支点。他在最后5公里进入突围后持续领骑，把突围速度维持在追击集团难以彻底合拢的区间；到最后600米，赵屿退出争冠节奏，把冲刺空间留给林澈、周明远和韩砚。\n\n最终冲刺在终点前180米打开。林澈选择从周明远右侧启动，先手进入最高速度区间，并以半个车身优势率先过线。周明远第二，韩砚与赵屿同秒分列第三、第四，追击集团第一名落后7秒。\n\n这场胜利的核心不是大集团冲刺，而是小集团突围守住微弱时间差后的终点爆发。9秒到4秒的变化说明追击集团一度接近完成追回，但赵屿的领骑帮助突围维持到冲刺门槛；终点差距回到7秒，则说明四人突围在最后1公里没有被打散。由于这是个人公路赛，冠军归属林澈个人，青岚车队的作用体现在赵屿对队友的领骑和牵制，而不是团队成绩取胜。"
+          }
+        }
+      ],
+      "sessionInput": {
+        "appName": "promptiter-sports-recap-agent",
+        "userId": "promptiter-demo-user"
+      }
+    },
+    {
+      "evalId": "validation_08_cricket_t20_chase",
+      "conversation": [
+        {
+          "invocationId": "validation_08_cricket_t20_chase-1",
+          "userContent": {
+            "role": "user",
+            "content": "{\"sport\":\"cricket\",\"format\":\"T20\",\"teams\":{\"battingFirst\":\"海港国王\",\"chasing\":\"都会猎鹰\"},\"innings\":[{\"inningsNumber\":1,\"team\":\"海港国王\",\"score\":119,\"wickets\":8,\"overs\":\"20.0\"},{\"inningsNumber\":2,\"team\":\"都会猎鹰\",\"target\":120,\"score\":121,\"wickets\":7,\"overs\":\"19.5\",\"ballsRemaining\":1}],\"finalOver\":{\"startState\":{\"team\":\"都会猎鹰\",\"score\":109,\"wickets\":7,\"runsNeeded\":11,\"ballsRemaining\":6},\"battingTeamRunsInOver\":12,\"targetPassedOnBall\":\"19.5\"},\"keyBatsman\":{\"team\":\"都会猎鹰\",\"name\":\"阿拉夫·梅塔\",\"runs\":47,\"balls\":39,\"notOut\":true,\"fours\":3,\"sixes\":2},\"keyBowler\":{\"team\":\"海港国王\",\"name\":\"尼基尔·拉奥\",\"overs\":\"4.0\",\"maidens\":0,\"runsConceded\":18,\"wickets\":3,\"bowledFinalOver\":true,\"runsConcededInFinalOver\":12},\"result\":{\"winner\":\"都会猎鹰\",\"margin\":\"3 wickets\",\"winningScore\":\"121/7\",\"chaseCompletedInOvers\":\"19.5\"}}"
+          },
+          "finalResponse": {
+            "role": "assistant",
+            "content": "梅塔47*撑到19.5 overs 都会猎鹰3 wickets险胜海港国王\n\n海港国王先打出119/8，把都会猎鹰的追逐目标压在120分。都会猎鹰一路追到最后一个over仍未摆脱险境：109/7、6 balls需要11分，手里只剩3个wickets。最终他们在19.5 overs来到121/7，提前1 ball越过目标，以3 wickets完成追逐。\n\n胜负转折集中在最后一个over。尼基尔·拉奥此前全场数据仍然亮眼，4.0 overs失18分并取3 wickets，但他主投收官over时被都会猎鹰拿到12分。对海港国王来说，109/7的局面本应让防守方握有压力优势；对都会猎鹰来说，目标不是拖到最后一球，而是在剩余6 balls内完成11分追逐，他们最终在第5 ball就超过目标线。\n\n阿拉夫·梅塔是都会猎鹰这次追逐的核心。他39 balls拿到47分并保持not out，包含3个四分球和2个六分球，既提供边界球得分，也在7个wickets已失的情况下把追逐带到终点。121/7的比分意味着都会猎鹰没有崩盘到全队出局，3 wickets的胜差也说明比赛悬念一直压到最后一个over。\n\n这场球的关键不在总分多高，而在最后阶段的资源交换：海港国王20.0 overs只给出119/8的低目标，但靠拉奥的3 wickets把追逐方压到109/7；都会猎鹰则用梅塔的未出局和最后over的12分，把原本11 off 6的高压局面转化成19.5 overs完成的成功chase。"
+          }
+        }
+      ],
+      "sessionInput": {
+        "appName": "promptiter-sports-recap-agent",
+        "userId": "promptiter-demo-user"
+      }
+    }
+  ]
+}

--- a/examples/evaluation/promptiter/multinode/data/promptiter-sports-recap-agent/sports-recap.metrics.json
+++ b/examples/evaluation/promptiter/multinode/data/promptiter-sports-recap-agent/sports-recap.metrics.json
@@ -1,0 +1,76 @@
+[
+  {
+    "metricName": "llm_rubric_critic",
+    "threshold": 0.98,
+    "criterion": {
+      "llmJudge": {
+        "rubrics": [
+          {
+            "id": "source_grounding",
+            "description": "The recap is fully grounded in the user JSON.",
+            "type": "FINAL_RESPONSE_QUALITY",
+            "content": {
+              "text": "The actual recap must only use facts supported by the user JSON and the golden recap. Fail if it invents a venue, ranking, streak, injury, future opponent, qualification consequence, tactical intent, emotion, unsupported cause, unsupported translation, renamed participant, or any other fact not supported by the allowed evidence."
+            }
+          },
+          {
+            "id": "lead_main_story",
+            "description": "The lead states the result and main story with the same editorial priority as the golden recap.",
+            "type": "FINAL_RESPONSE_QUALITY",
+            "content": {
+              "text": "The opening body paragraph must state the event context, final result, and winning storyline emphasized by the golden recap. Fail if the lead is only a generic result sentence, a raw fact list, or misses the main angle that the golden recap puts first."
+            }
+          },
+          {
+            "id": "decisive_sequence",
+            "description": "The decisive sequence is preserved in the correct order.",
+            "type": "FINAL_RESPONSE_QUALITY",
+            "content": {
+              "text": "The actual recap must preserve the decisive chain from the golden recap in the correct order, including late plays, penalty rounds, saved set or match points, safety-car pit windows, overtime penalty kill, final over, lead-out and sprint, or failed relief outing when present. Fail if a named decisive step is missing, reordered in a way that changes meaning, or replaced with a vague summary."
+            }
+          },
+          {
+            "id": "numbers_sport_logic",
+            "description": "Scores, numbers, and sport-specific notation are accurate.",
+            "type": "FINAL_RESPONSE_QUALITY",
+            "content": {
+              "text": "All scores, margins, timestamps, innings, overs, balls remaining, wickets, tiebreaks, periods, laps, gaps, shooting lines, and sport-specific notation in the actual recap must match the user JSON and preserve the sport semantics used by the golden recap. Fail for any wrong number, wrong score direction, malformed score that changes meaning, or mixed terminology such as treating cricket overs as a decimal ball count."
+            }
+          },
+          {
+            "id": "headline_angle",
+            "description": "The headline is publishable and carries the decisive angle.",
+            "type": "FINAL_RESPONSE_QUALITY",
+            "content": {
+              "text": "The first line must work as a sports-news headline that combines the result with a key number or decisive angle comparable to the golden recap. Fail if it is just a plain result sentence, misses the golden recap's headline angle, contains an unsupported stage/result claim, or uses a title-level number or timing error."
+            }
+          },
+          {
+            "id": "data_player_interpretation",
+            "description": "Data and player details explain why the result happened.",
+            "type": "FINAL_RESPONSE_QUALITY",
+            "content": {
+              "text": "Player and team data in the actual recap must be selected and interpreted to explain the result at a level comparable to the golden recap. Fail if the actual recap mostly dumps statistics, omits a key performer or decisive data contrast present in the golden recap, or does not connect the data to the winning storyline."
+            }
+          },
+          {
+            "id": "reference_depth_style",
+            "description": "The recap matches the golden recap's density, ordering, and sports-desk style.",
+            "type": "FINAL_RESPONSE_QUALITY",
+            "content": {
+              "text": "The actual recap should match the golden recap's content density, ordering, and professional Chinese sports-desk style. Fail if it replaces named sequences, time points, and score changes with vague summaries, becomes a thin field dump, or loses multiple details that define the golden recap's editorial substance."
+            }
+          },
+          {
+            "id": "production_copy",
+            "description": "The Chinese copy is polished and publishable.",
+            "type": "FORMAT_COMPLIANCE",
+            "content": {
+              "text": "The actual recap must be concise, fluent, professional Chinese sports copy without Markdown styling, meta commentary, multiple rewritten versions, slogan-like hype, translationese, malformed score spacing, awkward data dumping, or unnatural terms such as ACE球. Fail if it would require substantial editing before publication."
+            }
+          }
+        ]
+      }
+    }
+  }
+]

--- a/examples/evaluation/promptiter/multinode/evaluate.go
+++ b/examples/evaluation/promptiter/multinode/evaluate.go
@@ -1,0 +1,65 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
+	evalresultlocal "trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult/local"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
+	evalsetlocal "trpc.group/trpc-go/trpc-agent-go/evaluation/evalset/local"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/registry"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
+	metriclocal "trpc.group/trpc-go/trpc-agent-go/evaluation/metric/local"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+)
+
+func newSportsRecapEvaluator(candidateRunner runner.Runner, judgeRunner runner.Runner) (evaluation.AgentEvaluator, error) {
+	agentEvaluator, err := evaluation.New(
+		sportsRecapAgentName,
+		candidateRunner,
+		evaluation.WithEvalSetManager(evalsetlocal.New(evalset.WithBaseDir(*dataDir))),
+		evaluation.WithMetricManager(metriclocal.New(
+			metric.WithBaseDir(*dataDir),
+			metric.WithLocator(sportsRecapMetricLocator{}),
+		)),
+		evaluation.WithEvalResultManager(evalresultlocal.New(evalresult.WithBaseDir(*outputDir))),
+		evaluation.WithRegistry(registry.New()),
+		evaluation.WithJudgeRunner(judgeRunner),
+		evaluation.WithNumRuns(1),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create evaluator: %w", err)
+	}
+	return agentEvaluator, nil
+}
+
+type sportsRecapMetricLocator struct{}
+
+func (sportsRecapMetricLocator) Build(baseDir string, appName string, _ string) string {
+	return filepath.Join(baseDir, appName, "sports-recap.metrics.json")
+}
+
+func newJudgeAgent(m model.Model) agent.Agent {
+	return llmagent.New(
+		"judge",
+		llmagent.WithModel(m),
+		llmagent.WithGenerationConfig(model.GenerationConfig{
+			MaxTokens:   intPtr(32768),
+			Temperature: floatPtr(0.0),
+			Stream:      false,
+		}),
+	)
+}

--- a/examples/evaluation/promptiter/multinode/main.go
+++ b/examples/evaluation/promptiter/multinode/main.go
@@ -1,0 +1,90 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/model/openai"
+)
+
+var (
+	modelName                  = flag.String("model", "deepseek-v3.2", "Model identifier used by the candidate sports recap agent")
+	judgeModelName             = flag.String("judge-model", "gpt-5.2", "Model identifier used by the judge agent")
+	workerModelName            = flag.String("worker-model", "gpt-5.2", "Model identifier used by the PromptIter worker agents")
+	dataDir                    = flag.String("data-dir", "./data", "Directory containing evaluation set and metric files")
+	outputDir                  = flag.String("output-dir", "./output", "Directory where evaluation results will be stored")
+	maxRounds                  = flag.Int("max-rounds", 4, "Maximum PromptIter optimization rounds")
+	evalCaseParallelism        = flag.Int("eval-case-parallelism", 16, "Maximum number of eval cases processed in parallel")
+	backwardCaseParallelism    = flag.Int("backward-case-parallelism", 16, "Maximum number of train eval cases processed in parallel during backward; 0 uses GOMAXPROCS")
+	aggregationParallelism     = flag.Int("aggregation-parallelism", 16, "Maximum number of target surfaces aggregated in parallel; 0 uses GOMAXPROCS")
+	optimizerParallelism       = flag.Int("optimizer-parallelism", 16, "Maximum number of target surfaces optimized in parallel; 0 uses GOMAXPROCS")
+	parallelInferenceEnabled   = flag.Bool("parallel-inference", true, "Enable parallel inference across eval cases")
+	parallelEvaluationEnabled  = flag.Bool("parallel-evaluation", true, "Enable parallel evaluation across eval cases")
+	parallelBackwardEnabled    = flag.Bool("parallel-backward", false, "Enable parallel backward processing across train eval cases")
+	parallelAggregationEnabled = flag.Bool("parallel-aggregation", true, "Enable parallel aggregation across target surfaces")
+	parallelOptimizerEnabled   = flag.Bool("parallel-optimization", true, "Enable parallel optimization across target surfaces")
+	minScoreGain               = flag.Float64("min-score-gain", 0.01, "Minimum validation score gain required to accept a patch")
+	maxRoundsWithoutAcceptance = flag.Int("max-rounds-without-acceptance", 3, "Maximum consecutive rejected rounds before stopping")
+	targetScore                = flag.Float64("target-score", 1.01, "Target validation score that stops optimization when reached")
+	pollInterval               = flag.Duration("poll-interval", 30*time.Second, "Polling interval used to report PromptIter manager progress")
+)
+
+func main() {
+	flag.Parse()
+	if err := run(context.Background()); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run(ctx context.Context) error {
+	modelInstance, err := loadOpenAIModel(*modelName)
+	if err != nil {
+		return fmt.Errorf("load model: %w", err)
+	}
+	judgeModelInstance, err := loadOpenAIModel(*judgeModelName)
+	if err != nil {
+		return fmt.Errorf("load judge model: %w", err)
+	}
+	workerModelInstance, err := loadOpenAIModel(*workerModelName)
+	if err != nil {
+		return fmt.Errorf("load worker model: %w", err)
+	}
+	result, err := runPromptIter(ctx, modelInstance, judgeModelInstance, workerModelInstance)
+	if err != nil {
+		return err
+	}
+	printRunSummary(result, candidateSurfaceIDs())
+	return nil
+}
+
+func loadOpenAIModel(modelName string) (model.Model, error) {
+	name := strings.TrimSpace(modelName)
+	apiKey := strings.TrimSpace(os.Getenv("OPENAI_API_KEY"))
+	baseURL := strings.TrimSpace(os.Getenv("OPENAI_BASE_URL"))
+	if name == "" {
+		return nil, errors.New("model name is empty")
+	}
+	if apiKey == "" {
+		return nil, errors.New("OPENAI_API_KEY is empty")
+	}
+	options := []openai.Option{openai.WithAPIKey(apiKey)}
+	if baseURL != "" {
+		options = append(options, openai.WithBaseURL(baseURL))
+	}
+	return openai.New(name, options...), nil
+}

--- a/examples/evaluation/promptiter/multinode/print.go
+++ b/examples/evaluation/promptiter/multinode/print.go
@@ -1,0 +1,150 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"fmt"
+	"time"
+
+	promptiterengine "trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+)
+
+func printProgress(runID string, run *promptiterengine.RunResult) {
+	fmt.Printf("[%s] Run %s progress: %s\n", time.Now().Format("15:04:05"), runID, describeRunProgress(run))
+}
+
+func reportBaseline(runID string, run *promptiterengine.RunResult, reported bool) bool {
+	if reported || run.BaselineValidation == nil {
+		return reported
+	}
+	fmt.Printf("Run %s baseline validation score: %.2f\n", runID, run.BaselineValidation.OverallScore)
+	return true
+}
+
+func reportRoundMilestones(
+	runID string,
+	run *promptiterengine.RunResult,
+	reportedTrainRounds map[int]struct{},
+	reportedValidationRounds map[int]struct{},
+	reportedCompletedRounds map[int]struct{},
+) {
+	for i := range run.Rounds {
+		round := &run.Rounds[i]
+		if round.Train != nil {
+			if _, ok := reportedTrainRounds[round.Round]; !ok {
+				fmt.Printf("Run %s round %d train score: %.2f\n", runID, round.Round, round.Train.OverallScore)
+				reportedTrainRounds[round.Round] = struct{}{}
+			}
+		}
+		if round.Validation != nil {
+			if _, ok := reportedValidationRounds[round.Round]; !ok {
+				fmt.Printf("Run %s round %d validation score: %.2f\n", runID, round.Round, round.Validation.OverallScore)
+				reportedValidationRounds[round.Round] = struct{}{}
+			}
+		}
+		if round.Acceptance != nil && round.Stop != nil {
+			if _, ok := reportedCompletedRounds[round.Round]; !ok {
+				fmt.Printf("Run %s round %d completed: accepted=%t, delta=%.2f, stop=%t (%s)\n", runID, round.Round, round.Acceptance.Accepted, round.Acceptance.ScoreDelta, round.Stop.ShouldStop, round.Stop.Reason)
+				reportedCompletedRounds[round.Round] = struct{}{}
+			}
+		}
+	}
+}
+
+func describeRunProgress(run *promptiterengine.RunResult) string {
+	if run == nil {
+		return ""
+	}
+	switch run.Status {
+	case promptiterengine.RunStatusQueued:
+		return "queued"
+	case promptiterengine.RunStatusRunning:
+	default:
+		return string(run.Status)
+	}
+	if run.BaselineValidation == nil {
+		return "baseline validation"
+	}
+	if run.CurrentRound == 0 {
+		return "waiting to start round 1"
+	}
+	round := currentRoundResult(run, run.CurrentRound)
+	if round == nil {
+		return fmt.Sprintf("round %d started", run.CurrentRound)
+	}
+	if round.Train == nil {
+		return fmt.Sprintf("round %d train evaluation", round.Round)
+	}
+	if round.Losses == nil {
+		return fmt.Sprintf("round %d terminal loss extraction", round.Round)
+	}
+	if round.Backward == nil {
+		return fmt.Sprintf("round %d backward pass", round.Round)
+	}
+	if round.Aggregation == nil {
+		return fmt.Sprintf("round %d gradient aggregation", round.Round)
+	}
+	if round.Patches == nil {
+		return fmt.Sprintf("round %d optimizer", round.Round)
+	}
+	if round.OutputProfile == nil {
+		return fmt.Sprintf("round %d applying patch set", round.Round)
+	}
+	if round.Validation == nil {
+		return fmt.Sprintf("round %d validation evaluation", round.Round)
+	}
+	if round.Acceptance == nil || round.Stop == nil {
+		return fmt.Sprintf("round %d acceptance and stop checks", round.Round)
+	}
+	if round.Acceptance.Accepted {
+		return fmt.Sprintf("round %d completed and accepted", round.Round)
+	}
+	return fmt.Sprintf("round %d completed and rejected", round.Round)
+}
+
+func currentRoundResult(run *promptiterengine.RunResult, roundNumber int) *promptiterengine.RoundResult {
+	for i := range run.Rounds {
+		if run.Rounds[i].Round != roundNumber {
+			continue
+		}
+		return &run.Rounds[i]
+	}
+	return nil
+}
+
+func printRunSummary(result *promptiterengine.RunResult, candidateSurfaceIDs []string) {
+	fmt.Println("PromptIter multinode sports recap example completed.")
+	fmt.Printf("Status: %s\n", result.Status)
+	fmt.Printf("Baseline validation score: %.2f\n", result.BaselineValidation.OverallScore)
+	fmt.Printf("Final accepted validation score: %.2f\n", finalAcceptedValidationScore(result))
+	fmt.Printf("Rounds executed: %d\n", len(result.Rounds))
+	fmt.Println("Candidate surfaces:")
+	for _, surfaceID := range candidateSurfaceIDs {
+		fmt.Printf("  %s\n", surfaceID)
+	}
+	for _, round := range result.Rounds {
+		fmt.Printf("Round %d -> train %.2f, validation %.2f, accepted %t, delta %.2f\n", round.Round, round.Train.OverallScore, round.Validation.OverallScore, round.Acceptance.Accepted, round.Acceptance.ScoreDelta)
+		for _, patch := range round.Patches.Patches {
+			if patch.Value.Text == nil {
+				continue
+			}
+			fmt.Printf("  Patch %s: %q\n", patch.SurfaceID, *patch.Value.Text)
+		}
+	}
+}
+
+func finalAcceptedValidationScore(result *promptiterengine.RunResult) float64 {
+	score := result.BaselineValidation.OverallScore
+	for _, round := range result.Rounds {
+		if round.Acceptance != nil && round.Acceptance.Accepted {
+			score = round.Validation.OverallScore
+		}
+	}
+	return score
+}

--- a/examples/evaluation/promptiter/multinode/promptiter.go
+++ b/examples/evaluation/promptiter/multinode/promptiter.go
@@ -1,0 +1,213 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/aggregator"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/backwarder"
+	promptiterengine "trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+	promptitermanager "trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/manager"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/optimizer"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+)
+
+func runPromptIter(
+	ctx context.Context,
+	candidateModel model.Model,
+	judgeModel model.Model,
+	workerModel model.Model,
+) (*promptiterengine.RunResult, error) {
+	candidateAgent, err := newSportsRecapAgent(candidateModel)
+	if err != nil {
+		return nil, fmt.Errorf("create candidate agent: %w", err)
+	}
+	candidateRunner := runner.NewRunner(sportsRecapAgentName, candidateAgent)
+	judgeRunner := runner.NewRunner("judge", newJudgeAgent(judgeModel))
+	backwarderRunner := runner.NewRunner("backwarder", newPromptIterAgent("backwarder", workerModel))
+	aggregatorRunner := runner.NewRunner("aggregator", newPromptIterAgent("aggregator", workerModel))
+	optimizerRunner := runner.NewRunner("optimizer", newPromptIterAgent("optimizer", workerModel))
+	defer closeRunners(candidateRunner, judgeRunner, backwarderRunner, aggregatorRunner, optimizerRunner)
+	agentEvaluator, err := newSportsRecapEvaluator(candidateRunner, judgeRunner)
+	if err != nil {
+		return nil, err
+	}
+	defer agentEvaluator.Close()
+	backwarderInstance, err := backwarder.New(ctx, backwarderRunner)
+	if err != nil {
+		return nil, fmt.Errorf("create backwarder: %w", err)
+	}
+	aggregatorInstance, err := aggregator.New(ctx, aggregatorRunner)
+	if err != nil {
+		return nil, fmt.Errorf("create aggregator: %w", err)
+	}
+	optimizerInstance, err := optimizer.New(ctx, optimizerRunner)
+	if err != nil {
+		return nil, fmt.Errorf("create optimizer: %w", err)
+	}
+	engineInstance, err := promptiterengine.New(ctx, candidateAgent, agentEvaluator, backwarderInstance, aggregatorInstance, optimizerInstance)
+	if err != nil {
+		return nil, fmt.Errorf("create promptiter engine: %w", err)
+	}
+	managerInstance, err := promptitermanager.New(sportsRecapAgentName, engineInstance)
+	if err != nil {
+		return nil, fmt.Errorf("create promptiter manager: %w", err)
+	}
+	defer managerInstance.Close()
+	run, err := managerInstance.Start(ctx, buildPromptIterRunRequest())
+	if err != nil {
+		return nil, fmt.Errorf("start promptiter run: %w", err)
+	}
+	fmt.Printf("Started PromptIter manager run: %s\n", run.ID)
+	result, err := waitForRun(ctx, managerInstance, run.ID, *pollInterval)
+	if err != nil {
+		return nil, fmt.Errorf("wait for promptiter run: %w", err)
+	}
+	return result, nil
+}
+
+func buildPromptIterRunRequest() *promptiterengine.RunRequest {
+	desiredScore := *targetScore
+	return &promptiterengine.RunRequest{
+		Train:      []promptiterengine.EvalSetInput{{EvalSetID: "sports-recap-train"}},
+		Validation: []promptiterengine.EvalSetInput{{EvalSetID: "sports-recap-validation"}},
+		EvaluationOptions: promptiterengine.EvaluationOptions{
+			EvalCaseParallelism:               *evalCaseParallelism,
+			EvalCaseParallelInferenceEnabled:  *parallelInferenceEnabled,
+			EvalCaseParallelEvaluationEnabled: *parallelEvaluationEnabled,
+		},
+		BackwardOptions: promptiterengine.BackwardOptions{
+			CaseParallelismEnabled: *parallelBackwardEnabled,
+			CaseParallelism:        *backwardCaseParallelism,
+		},
+		AggregationOptions: promptiterengine.AggregationOptions{
+			SurfaceParallelismEnabled: *parallelAggregationEnabled,
+			SurfaceParallelism:        *aggregationParallelism,
+		},
+		OptimizerOptions: promptiterengine.OptimizerOptions{
+			SurfaceParallelismEnabled: *parallelOptimizerEnabled,
+			SurfaceParallelism:        *optimizerParallelism,
+		},
+		AcceptancePolicy: promptiterengine.AcceptancePolicy{
+			MinScoreGain: *minScoreGain,
+		},
+		StopPolicy: promptiterengine.StopPolicy{
+			MaxRoundsWithoutAcceptance: *maxRoundsWithoutAcceptance,
+			TargetScore:                &desiredScore,
+		},
+		MaxRounds:        *maxRounds,
+		TargetSurfaceIDs: candidateSurfaceIDs(),
+	}
+}
+
+func waitForRun(
+	ctx context.Context,
+	manager promptitermanager.Manager,
+	runID string,
+	interval time.Duration,
+) (*promptiterengine.RunResult, error) {
+	if interval <= 0 {
+		return nil, errors.New("poll interval must be greater than 0")
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	reportedBaseline := false
+	reportedTrainRounds := make(map[int]struct{})
+	reportedValidationRounds := make(map[int]struct{})
+	reportedCompletedRounds := make(map[int]struct{})
+	for {
+		run, err := manager.Get(ctx, runID)
+		if err != nil {
+			return nil, err
+		}
+		if run == nil {
+			return nil, errors.New("manager returned nil run")
+		}
+		printProgress(runID, run)
+		reportedBaseline = reportBaseline(runID, run, reportedBaseline)
+		reportRoundMilestones(runID, run, reportedTrainRounds, reportedValidationRounds, reportedCompletedRounds)
+		if isTerminalRunStatus(run.Status) {
+			if err := terminalRunError(run); err != nil {
+				return nil, err
+			}
+			return run, nil
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func newPromptIterAgent(name string, m model.Model) agent.Agent {
+	return llmagent.New(
+		name,
+		llmagent.WithModel(m),
+		llmagent.WithGenerationConfig(model.GenerationConfig{
+			MaxTokens:   intPtr(32768),
+			Temperature: floatPtr(0.0),
+			Stream:      false,
+		}),
+	)
+}
+
+func candidateSurfaceIDs() []string {
+	return []string{
+		astructure.SurfaceID(sportsRecapAgentName+"/"+headlineAgentName, astructure.SurfaceTypeInstruction),
+		astructure.SurfaceID(sportsRecapAgentName+"/"+highlightsAgentName, astructure.SurfaceTypeInstruction),
+		astructure.SurfaceID(sportsRecapAgentName+"/"+statsAngleAgentName, astructure.SurfaceTypeInstruction),
+		astructure.SurfaceID(sportsRecapAgentName+"/"+recapWriterAgentName, astructure.SurfaceTypeInstruction),
+		astructure.SurfaceID(sportsRecapAgentName+"/"+sportsEditorAgentName, astructure.SurfaceTypeInstruction),
+	}
+}
+
+func isTerminalRunStatus(status promptiterengine.RunStatus) bool {
+	switch status {
+	case promptiterengine.RunStatusSucceeded,
+		promptiterengine.RunStatusFailed,
+		promptiterengine.RunStatusCanceled:
+		return true
+	default:
+		return false
+	}
+}
+
+func terminalRunError(run *promptiterengine.RunResult) error {
+	switch run.Status {
+	case promptiterengine.RunStatusSucceeded:
+		return nil
+	case promptiterengine.RunStatusFailed:
+		message := run.ErrorMessage
+		if message == "" {
+			message = "unknown error"
+		}
+		return fmt.Errorf("run %s failed: %s", run.ID, message)
+	case promptiterengine.RunStatusCanceled:
+		return fmt.Errorf("run %s canceled", run.ID)
+	default:
+		return nil
+	}
+}
+
+func closeRunners(runners ...runner.Runner) {
+	for _, r := range runners {
+		if r != nil {
+			_ = r.Close()
+		}
+	}
+}


### PR DESCRIPTION
This adds a PromptIter multinode sports recap example that combines regular function nodes with AgentNode fan-out/fan-in, evaluates train and validation eval cases from static files, optimizes multiple instruction surfaces, reports manager progress during long-running runs, and documents a sample score trajectory with the final accepted prompts.