### PR TITLE
memory/tencentdb: add TencentDB Agent Memory integration

### DIFF
--- a/docs/mkdocs/en/memory.md
+++ b/docs/mkdocs/en/memory.md
@@ -1733,11 +1733,161 @@ In short, `MemoryService` means "the framework manages memories directly", while
 - Call `Close()` on the service so background workers shut down cleanly.
 - If you need full CRUD tools or framework-side preload, use one of the built-in memory backends instead.
 
+## TencentDB Agent Memory Integration (`memory/tencentdb`)
+
+`memory/tencentdb` integrates
+[TencentDB Agent Memory](https://github.com/Tencent/TencentDB-Agent-Memory)
+through its standalone gateway sidecar. It is suitable when you want the
+TencentDB Agent Memory SDK to own the L0-L3 memory pipeline while
+tRPC-Agent-Go keeps the Runner, session, plugin, and tool lifecycle in Go.
+
+The boundary is intentionally different from built-in backends:
+
+- The TencentDB Agent Memory gateway performs capture, extraction, storage,
+  recall, and search.
+- The Go adapter sends completed session turns through `session.Ingestor`.
+- A Runner plugin calls `/recall` before each model request and injects the
+  returned context.
+- Native tools expose read-oriented search through `tdai_memory_search` and
+  `tdai_conversation_search`.
+
+Even when the SDK uses local SQLite storage, the gateway is still required
+because it hosts the memory engine. Direct VectorDB or SQLite access only talks
+to storage and does not run the SDK's extraction and recall pipeline.
+
+**Use case**: Sidecar memory engine, local or self-managed storage, automatic
+recall before model calls, and external SDK-owned memory extraction.
+
+### Start the TencentDB Agent Memory Gateway
+
+Clone the SDK repository and start the standalone gateway:
+
+```bash
+git clone https://github.com/Tencent/TencentDB-Agent-Memory.git
+cd TencentDB-Agent-Memory
+npm install
+
+export TDAI_LLM_API_KEY="your-openai-compatible-api-key"
+export TDAI_LLM_BASE_URL="https://api.openai.com/v1"
+export TDAI_LLM_MODEL="deepseek-v4-flash"
+
+node --import tsx src/gateway/server.ts
+```
+
+The gateway listens on `http://127.0.0.1:8420` by default. It reads
+`TDAI_LLM_API_KEY`, `TDAI_LLM_BASE_URL`, and `TDAI_LLM_MODEL` for extraction,
+scene/persona generation, and recall.
+
+### Configuration Example
+
+```go
+import (
+    "os"
+
+    "trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+    memorytencentdb "trpc.group/trpc-go/trpc-agent-go/memory/tencentdb"
+    "trpc.group/trpc-go/trpc-agent-go/model/openai"
+    "trpc.group/trpc-go/trpc-agent-go/runner"
+    sessioninmemory "trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+)
+
+gatewayURL := os.Getenv("TENCENTDB_AGENT_MEMORY_GATEWAY")
+if gatewayURL == "" {
+    gatewayURL = "http://127.0.0.1:8420"
+}
+
+memSvc, err := memorytencentdb.NewService(
+    memorytencentdb.WithGatewayURL(gatewayURL),
+)
+if err != nil {
+    panic(err)
+}
+defer memSvc.Close()
+
+sessionSvc := sessioninmemory.NewSessionService()
+agent := llmagent.New(
+    "assistant",
+    llmagent.WithModel(openai.New("deepseek-v4-flash")),
+    llmagent.WithTools(memSvc.Tools()),
+)
+
+r := runner.NewRunner(
+    "my-app",
+    agent,
+    runner.WithSessionService(sessionSvc),
+    runner.WithSessionIngestor(memSvc),
+    runner.WithPlugins(memSvc.Plugin()),
+)
+defer r.Close()
+```
+
+**Integration points**:
+
+- Register TencentDB-native search tools with `llmagent.WithTools(memSvc.Tools())`
+- Use `runner.WithSessionIngestor(memSvc)` to send timestamped session
+  transcripts to `/capture`
+- Use `runner.WithPlugins(memSvc.Plugin())` to enable automatic `/recall`
+  before model calls
+- Do **not** use `runner.WithMemoryService(...)` with this integration
+
+### Interactive Example
+
+Run the example after the gateway is ready:
+
+```bash
+cd examples/memory/tencentdb
+export OPENAI_API_KEY="your-openai-compatible-api-key"
+export TENCENTDB_AGENT_MEMORY_GATEWAY="http://127.0.0.1:8420"
+go run .
+```
+
+Then send facts, flush into a new session, and ask related questions:
+
+```text
+You: Remember this profile: my project code name is Apollo Lake, my deployment window is Friday night, and I prefer concise answers.
+You: /new
+You: What is my project code name, deployment window, and answer preference?
+```
+
+The first messages are captured by the gateway. The example's `/new` command
+flushes the current gateway session before switching to a fresh session, so the
+same user can recall extracted memories through the plugin and native search
+tools even after conversation history is reset.
+
+### Configuration Options
+
+| Option | Purpose | Default |
+| ------ | ------- | ------- |
+| `WithGatewayURL(url)` | TencentDB Agent Memory gateway URL. | `http://127.0.0.1:8420` |
+| `WithTimeout(d)` | HTTP timeout used by the gateway client. | `5s` |
+| `WithIngestWorkers(n)` | Number of async capture workers. | `1` |
+| `WithIngestQueueSize(n)` | Queue size for async capture jobs. | `10` |
+| `WithIngestJobTimeout(d)` | Timeout for queued capture jobs. | `30s` |
+| `WithSessionKeyFunc(fn)` | Customize session to gateway `session_key` mapping. | `app:user:session` |
+| `WithRecallEnabled(bool)` | Enable automatic recall plugin behavior. | `true` |
+| `WithConversationSearchTool(bool)` | Expose `tdai_conversation_search`. | `true` |
+| `WithStandardAliases(bool)` | Also expose standard `memory_search` alias. | `false` |
+| `WithToolPrefix(prefix)` | Change native tool prefix. | `tdai` |
+
+### Notes
+
+- The adapter forwards app, user, and session identifiers to the gateway, but
+  hard multi-tenant isolation depends on the gateway and SDK honoring those
+  fields end-to-end.
+- `tdai_memory_search` searches extracted long-term memory; extraction is
+  asynchronous, so newly captured facts may take a short time to become
+  searchable.
+- `tdai_conversation_search` searches conversation history and defaults to the
+  current gateway `session_key`.
+- Call `Close()` on the service so background capture workers shut down cleanly.
+
 ## References
 
 - [Memory Module Source](https://github.com/trpc-group/trpc-agent-go/tree/main/memory)
 - [Agentic Mode Example](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/memory)
 - [Auto Mode Example](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/memory/auto)
 - [mem0 Example](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/memory/mem0)
+- [TencentDB Agent Memory Example](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/memory/tencentdb)
+- [TencentDB Agent Memory SDK](https://github.com/Tencent/TencentDB-Agent-Memory)
 - [Ecosystem Guide](https://github.com/trpc-group/trpc-agent-go/blob/main/docs/mkdocs/en/ecosystem.md)
 - [API Documentation](https://pkg.go.dev/trpc.group/trpc-go/trpc-agent-go/memory)

--- a/docs/mkdocs/en/memory.md
+++ b/docs/mkdocs/en/memory.md
@@ -1874,7 +1874,7 @@ tools even after conversation history is reset.
 | `WithIngestWorkers(n)` | Number of async capture workers. | `1` |
 | `WithIngestQueueSize(n)` | Queue size for async capture jobs. | `10` |
 | `WithIngestJobTimeout(d)` | Timeout for queued capture jobs. | `30s` |
-| `WithSessionKeyFunc(fn)` | Customize session to gateway `session_key` mapping. | `app:user:session` |
+| `WithSessionKeyFunc(fn)` | Customize session to gateway `session_key` mapping. | `base64url(app):base64url(user):base64url(session)` |
 | `WithAPIKey(key)` | Send `Authorization: Bearer <key>` (gateway `TDAI_GATEWAY_API_KEY`). | none |
 | `WithRecallEnabled(bool)` | Enable automatic recall plugin behavior (opt-in; reads shared store). | `false` |
 | `WithMemorySearchTool(bool)` | Expose `tdai_memory_search` (opt-in; reads shared store). | `false` |

--- a/docs/mkdocs/en/memory.md
+++ b/docs/mkdocs/en/memory.md
@@ -1747,9 +1747,16 @@ The boundary is intentionally different from built-in backends:
   recall, and search.
 - The Go adapter sends completed session turns through `session.Ingestor`.
 - A Runner plugin calls `/recall` before each model request and injects the
-  returned context.
-- Native tools expose read-oriented search through `tdai_memory_search` and
-  `tdai_conversation_search`.
+  returned context (opt-in via `WithRecallEnabled(true)`).
+- Native tools expose read-oriented search through `tdai_conversation_search`
+  (session-scoped, on by default) and `tdai_memory_search` (opt-in via
+  `WithMemorySearchTool(true)`).
+
+> **Multi-tenant note:** automatic recall and `tdai_memory_search` read from the
+> gateway's shared long-term store, which does not currently enforce
+> user/session scoping. They are therefore disabled by default; enable them only
+> when the gateway guarantees per-tenant isolation. Only session-scoped capture
+> and `tdai_conversation_search` are on by default.
 
 Even when the SDK uses local SQLite storage, the gateway is still required
 because it hosts the memory engine. Direct VectorDB or SQLite access only talks
@@ -1798,6 +1805,10 @@ if gatewayURL == "" {
 
 memSvc, err := memorytencentdb.NewService(
     memorytencentdb.WithGatewayURL(gatewayURL),
+    // Opt-in cross-session/user reads; enable only for a trusted/isolated gateway.
+    memorytencentdb.WithRecallEnabled(true),
+    memorytencentdb.WithMemorySearchTool(true),
+    // memorytencentdb.WithAPIKey(os.Getenv("TDAI_GATEWAY_API_KEY")),
 )
 if err != nil {
     panic(err)
@@ -1864,16 +1875,22 @@ tools even after conversation history is reset.
 | `WithIngestQueueSize(n)` | Queue size for async capture jobs. | `10` |
 | `WithIngestJobTimeout(d)` | Timeout for queued capture jobs. | `30s` |
 | `WithSessionKeyFunc(fn)` | Customize session to gateway `session_key` mapping. | `app:user:session` |
-| `WithRecallEnabled(bool)` | Enable automatic recall plugin behavior. | `true` |
+| `WithAPIKey(key)` | Send `Authorization: Bearer <key>` (gateway `TDAI_GATEWAY_API_KEY`). | none |
+| `WithRecallEnabled(bool)` | Enable automatic recall plugin behavior (opt-in; reads shared store). | `false` |
+| `WithMemorySearchTool(bool)` | Expose `tdai_memory_search` (opt-in; reads shared store). | `false` |
 | `WithConversationSearchTool(bool)` | Expose `tdai_conversation_search`. | `true` |
-| `WithStandardAliases(bool)` | Also expose standard `memory_search` alias. | `false` |
+| `WithStandardAliases(bool)` | Also expose standard `memory_search` alias (requires memory search enabled). | `false` |
 | `WithToolPrefix(prefix)` | Change native tool prefix. | `tdai` |
 
 ### Notes
 
 - The adapter forwards app, user, and session identifiers to the gateway, but
   hard multi-tenant isolation depends on the gateway and SDK honoring those
-  fields end-to-end.
+  fields end-to-end. Because of this, automatic recall and `tdai_memory_search`
+  are opt-in and disabled by default.
+- When the gateway is started with `TDAI_GATEWAY_API_KEY`, set `WithAPIKey(...)`
+  so requests carry `Authorization: Bearer <key>`; otherwise every non-health
+  route returns 401 while the health check still passes.
 - `tdai_memory_search` searches extracted long-term memory; extraction is
   asynchronous, so newly captured facts may take a short time to become
   searchable.

--- a/docs/mkdocs/zh/memory.md
+++ b/docs/mkdocs/zh/memory.md
@@ -1895,7 +1895,7 @@ You: 我的项目代号、部署窗口和回答偏好是什么？
 | `WithIngestWorkers(n)` | 异步 capture worker 数量。 | `1` |
 | `WithIngestQueueSize(n)` | 异步 capture 任务队列长度。 | `10` |
 | `WithIngestJobTimeout(d)` | 队列中 capture 任务的超时时间。 | `30s` |
-| `WithSessionKeyFunc(fn)` | 自定义 framework session 到 gateway `session_key` 的映射。 | `app:user:session` |
+| `WithSessionKeyFunc(fn)` | 自定义 framework session 到 gateway `session_key` 的映射。 | `base64url(app):base64url(user):base64url(session)` |
 | `WithAPIKey(key)` | 发送 `Authorization: Bearer <key>`（对应 gateway 的 `TDAI_GATEWAY_API_KEY`）。 | 无 |
 | `WithRecallEnabled(bool)` | 是否启用自动 recall plugin（opt-in；读取共享存储）。 | `false` |
 | `WithMemorySearchTool(bool)` | 是否暴露 `tdai_memory_search`（opt-in；读取共享存储）。 | `false` |

--- a/docs/mkdocs/zh/memory.md
+++ b/docs/mkdocs/zh/memory.md
@@ -1766,11 +1766,146 @@ defer r.Close()
 - 使用完成后请调用 `Close()`，确保后台 worker 干净退出。
 - 如果你需要完整的 CRUD 工具面，或依赖框架侧 preload，建议优先选择内置 Memory 后端。
 
+## TencentDB Agent Memory 集成（`memory/tencentdb`）
+
+`memory/tencentdb` 通过独立 gateway sidecar 接入
+[TencentDB Agent Memory](https://github.com/Tencent/TencentDB-Agent-Memory)。
+它适合把 L0-L3 记忆流水线交给 TencentDB Agent Memory SDK，而
+tRPC-Agent-Go 侧继续负责 Runner、Session、Plugin 和 Tool 生命周期的场景。
+
+这个集成与内置后端的边界不同：
+
+- TencentDB Agent Memory gateway 负责 capture、提取、存储、recall 和 search。
+- Go adapter 通过 `session.Ingestor` 把每轮完成后的会话内容发送给 gateway。
+- Runner plugin 在每次模型调用前请求 `/recall`，并把返回的上下文注入模型请求。
+- 通过 `tdai_memory_search` 和 `tdai_conversation_search` 暴露只读检索工具。
+
+即使 SDK 配置为本地 SQLite 存储，gateway 仍然是必需的，因为记忆引擎运行在
+gateway/SDK 侧。直接访问 VectorDB 或 SQLite 只能访问存储层，不会执行 SDK 的
+提取与召回流水线。
+
+**适用场景**：sidecar 记忆引擎、本地或自托管存储、模型调用前自动召回，以及由外部 SDK 托管的记忆提取。
+
+### 启动 TencentDB Agent Memory Gateway
+
+先克隆 SDK 仓库并启动 standalone gateway：
+
+```bash
+git clone https://github.com/Tencent/TencentDB-Agent-Memory.git
+cd TencentDB-Agent-Memory
+npm install
+
+export TDAI_LLM_API_KEY="your-openai-compatible-api-key"
+export TDAI_LLM_BASE_URL="https://api.openai.com/v1"
+export TDAI_LLM_MODEL="deepseek-v4-flash"
+
+node --import tsx src/gateway/server.ts
+```
+
+gateway 默认监听 `http://127.0.0.1:8420`。它会读取
+`TDAI_LLM_API_KEY`、`TDAI_LLM_BASE_URL` 和 `TDAI_LLM_MODEL`，用于记忆提取、
+场景/画像生成和召回。
+
+### 配置示例
+
+```go
+import (
+    "os"
+
+    "trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+    memorytencentdb "trpc.group/trpc-go/trpc-agent-go/memory/tencentdb"
+    "trpc.group/trpc-go/trpc-agent-go/model/openai"
+    "trpc.group/trpc-go/trpc-agent-go/runner"
+    sessioninmemory "trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+)
+
+gatewayURL := os.Getenv("TENCENTDB_AGENT_MEMORY_GATEWAY")
+if gatewayURL == "" {
+    gatewayURL = "http://127.0.0.1:8420"
+}
+
+memSvc, err := memorytencentdb.NewService(
+    memorytencentdb.WithGatewayURL(gatewayURL),
+)
+if err != nil {
+    panic(err)
+}
+defer memSvc.Close()
+
+sessionSvc := sessioninmemory.NewSessionService()
+agent := llmagent.New(
+    "assistant",
+    llmagent.WithModel(openai.New("deepseek-v4-flash")),
+    llmagent.WithTools(memSvc.Tools()),
+)
+
+r := runner.NewRunner(
+    "my-app",
+    agent,
+    runner.WithSessionService(sessionSvc),
+    runner.WithSessionIngestor(memSvc),
+    runner.WithPlugins(memSvc.Plugin()),
+)
+defer r.Close()
+```
+
+**接入要点**：
+
+- 通过 `llmagent.WithTools(memSvc.Tools())` 注册 TencentDB 原生检索工具。
+- 通过 `runner.WithSessionIngestor(memSvc)` 把带时间戳的 session transcript 发送给 `/capture`。
+- 通过 `runner.WithPlugins(memSvc.Plugin())` 在模型调用前启用自动 `/recall`。
+- 不要对该集成使用 `runner.WithMemoryService(...)`。
+
+### 交互式示例
+
+gateway 就绪后运行示例：
+
+```bash
+cd examples/memory/tencentdb
+export OPENAI_API_KEY="your-openai-compatible-api-key"
+export TENCENTDB_AGENT_MEMORY_GATEWAY="http://127.0.0.1:8420"
+go run .
+```
+
+然后发送事实、flush 后新建会话，再提相关问题：
+
+```text
+You: 请记住以下信息：我的项目代号是 Apollo Lake，部署窗口是周五晚上，回答偏好是简洁。
+You: /new
+You: 我的项目代号、部署窗口和回答偏好是什么？
+```
+
+前两条消息会被 gateway capture。示例里的 `/new` 命令会先 flush 当前 gateway session，再切换到新 session；对话历史会重置，但同一个用户仍然可以通过 plugin 和原生检索工具召回已经提取的长期记忆。
+
+### 配置选项
+
+| 选项 | 作用 | 默认值 |
+| ---- | ---- | ------ |
+| `WithGatewayURL(url)` | TencentDB Agent Memory gateway URL。 | `http://127.0.0.1:8420` |
+| `WithTimeout(d)` | gateway HTTP 客户端超时时间。 | `5s` |
+| `WithIngestWorkers(n)` | 异步 capture worker 数量。 | `1` |
+| `WithIngestQueueSize(n)` | 异步 capture 任务队列长度。 | `10` |
+| `WithIngestJobTimeout(d)` | 队列中 capture 任务的超时时间。 | `30s` |
+| `WithSessionKeyFunc(fn)` | 自定义 framework session 到 gateway `session_key` 的映射。 | `app:user:session` |
+| `WithRecallEnabled(bool)` | 是否启用自动 recall plugin。 | `true` |
+| `WithConversationSearchTool(bool)` | 是否暴露 `tdai_conversation_search`。 | `true` |
+| `WithStandardAliases(bool)` | 是否额外暴露标准 `memory_search` 别名。 | `false` |
+| `WithToolPrefix(prefix)` | 修改原生工具名前缀。 | `tdai` |
+
+### 注意事项
+
+- adapter 会把 app、user、session 标识传给 gateway，但强多租户隔离依赖 gateway 和 SDK 端完整遵守这些字段。
+- `tdai_memory_search` 检索已提取的长期记忆；提取是异步的，新捕获的信息可能需要短暂等待后才可检索。
+- `tdai_conversation_search` 检索对话历史，默认使用当前 gateway `session_key`。
+- 使用完成后请调用 `Close()`，确保后台 capture worker 干净退出。
+
 ## 参考链接
 
 - [Memory 模块源码](https://github.com/trpc-group/trpc-agent-go/tree/main/memory)
 - [工具驱动模式示例](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/memory)
 - [自动提取模式示例](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/memory/auto)
 - [mem0 示例](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/memory/mem0)
+- [TencentDB Agent Memory 示例](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/memory/tencentdb)
+- [TencentDB Agent Memory SDK](https://github.com/Tencent/TencentDB-Agent-Memory)
 - [生态建设文档](https://github.com/trpc-group/trpc-agent-go/blob/main/docs/mkdocs/zh/ecosystem.md)
 - [API 文档](https://pkg.go.dev/trpc.group/trpc-go/trpc-agent-go/memory)

--- a/docs/mkdocs/zh/memory.md
+++ b/docs/mkdocs/zh/memory.md
@@ -1777,8 +1777,13 @@ tRPC-Agent-Go 侧继续负责 Runner、Session、Plugin 和 Tool 生命周期的
 
 - TencentDB Agent Memory gateway 负责 capture、提取、存储、recall 和 search。
 - Go adapter 通过 `session.Ingestor` 把每轮完成后的会话内容发送给 gateway。
-- Runner plugin 在每次模型调用前请求 `/recall`，并把返回的上下文注入模型请求。
-- 通过 `tdai_memory_search` 和 `tdai_conversation_search` 暴露只读检索工具。
+- Runner plugin 在每次模型调用前请求 `/recall`，并把返回的上下文注入模型请求（需通过 `WithRecallEnabled(true)` 显式开启）。
+- 通过 `tdai_conversation_search`（按 session 作用域，默认开启）和 `tdai_memory_search`（需 `WithMemorySearchTool(true)` 显式开启）暴露只读检索工具。
+
+> **多租户提示**：自动 recall 和 `tdai_memory_search` 会读取 gateway 的共享长期
+> 存储，而当前 gateway 并不会在这些路径上强制按 user/session 隔离，因此它们默认
+> 关闭，只有在 gateway 能保证按租户隔离时才应开启。默认只开启按 session 作用域的
+> capture 和 `tdai_conversation_search`。
 
 即使 SDK 配置为本地 SQLite 存储，gateway 仍然是必需的，因为记忆引擎运行在
 gateway/SDK 侧。直接访问 VectorDB 或 SQLite 只能访问存储层，不会执行 SDK 的
@@ -1826,6 +1831,10 @@ if gatewayURL == "" {
 
 memSvc, err := memorytencentdb.NewService(
     memorytencentdb.WithGatewayURL(gatewayURL),
+    // 跨 session/user 的读取属于 opt-in，仅在 gateway 可信/隔离时开启。
+    memorytencentdb.WithRecallEnabled(true),
+    memorytencentdb.WithMemorySearchTool(true),
+    // memorytencentdb.WithAPIKey(os.Getenv("TDAI_GATEWAY_API_KEY")),
 )
 if err != nil {
     panic(err)
@@ -1887,14 +1896,17 @@ You: 我的项目代号、部署窗口和回答偏好是什么？
 | `WithIngestQueueSize(n)` | 异步 capture 任务队列长度。 | `10` |
 | `WithIngestJobTimeout(d)` | 队列中 capture 任务的超时时间。 | `30s` |
 | `WithSessionKeyFunc(fn)` | 自定义 framework session 到 gateway `session_key` 的映射。 | `app:user:session` |
-| `WithRecallEnabled(bool)` | 是否启用自动 recall plugin。 | `true` |
+| `WithAPIKey(key)` | 发送 `Authorization: Bearer <key>`（对应 gateway 的 `TDAI_GATEWAY_API_KEY`）。 | 无 |
+| `WithRecallEnabled(bool)` | 是否启用自动 recall plugin（opt-in；读取共享存储）。 | `false` |
+| `WithMemorySearchTool(bool)` | 是否暴露 `tdai_memory_search`（opt-in；读取共享存储）。 | `false` |
 | `WithConversationSearchTool(bool)` | 是否暴露 `tdai_conversation_search`。 | `true` |
-| `WithStandardAliases(bool)` | 是否额外暴露标准 `memory_search` 别名。 | `false` |
+| `WithStandardAliases(bool)` | 是否额外暴露标准 `memory_search` 别名（需先启用 memory search）。 | `false` |
 | `WithToolPrefix(prefix)` | 修改原生工具名前缀。 | `tdai` |
 
 ### 注意事项
 
-- adapter 会把 app、user、session 标识传给 gateway，但强多租户隔离依赖 gateway 和 SDK 端完整遵守这些字段。
+- adapter 会把 app、user、session 标识传给 gateway，但强多租户隔离依赖 gateway 和 SDK 端完整遵守这些字段；正因如此，自动 recall 和 `tdai_memory_search` 默认关闭，需显式 opt-in。
+- 当 gateway 设置了 `TDAI_GATEWAY_API_KEY` 时，请用 `WithAPIKey(...)` 让请求携带 `Authorization: Bearer <key>`，否则除 `/health` 外的路由都会返回 401（health 仍可通过）。
 - `tdai_memory_search` 检索已提取的长期记忆；提取是异步的，新捕获的信息可能需要短暂等待后才可检索。
 - `tdai_conversation_search` 检索对话历史，默认使用当前 gateway `session_key`。
 - 使用完成后请调用 `Close()`，确保后台 capture worker 干净退出。

--- a/examples/memory/README.md
+++ b/examples/memory/README.md
@@ -97,6 +97,32 @@ go run .
 
 [Read full documentation →](./mem0/README.md)
 
+### 📁 tencentdb/
+
+**TencentDB Agent Memory Integration - Sidecar Memory Engine**
+
+Demonstrates integration with TencentDB Agent Memory through its local gateway
+sidecar. The runner sends session transcripts after each turn, a plugin injects
+automatic recall before model calls, and the agent can use TencentDB-native
+read-only search tools.
+
+**Key Features:**
+
+- Session ingestion via `runner.WithSessionIngestor(...)`
+- Automatic recall via `runner.WithPlugins(memSvc.Plugin())`
+- Native `tdai_memory_search` and `tdai_conversation_search` tools
+
+**Getting Started:**
+
+```bash
+cd examples/memory/tencentdb
+export OPENAI_API_KEY="your-api-key"
+export TENCENTDB_AGENT_MEMORY_GATEWAY="http://127.0.0.1:8420"
+go run .
+```
+
+[Read full documentation →](./tencentdb/README.md)
+
 ### 📁 compare/
 
 **Retrieval Comparison - SQLite vs SQLiteVec**

--- a/examples/memory/tencentdb/README.md
+++ b/examples/memory/tencentdb/README.md
@@ -1,0 +1,236 @@
+# TencentDB Agent Memory Integration Example
+
+This example demonstrates how to integrate TencentDB Agent Memory as a
+sidecar-backed long-term memory engine using the **ingest + recall plugin**
+pattern. The Go framework keeps runner/session/tool wiring in-process while
+delegating memory capture, indexing, and recall to the TencentDB Agent Memory
+gateway.
+
+## Overview
+
+The integration works in three parts:
+
+1. **Session ingestion** — After each conversation turn the Runner sends the
+   new session transcript to the gateway via `runner.WithSessionIngestor(...)`.
+2. **Automatic recall** — Before each model call, `runner.WithPlugins(...)`
+   invokes the TencentDB recall endpoint and injects the returned context into
+   the model request.
+3. **Read-only tools** — The agent can explicitly search memory through
+   `tdai_memory_search` and conversation history through
+   `tdai_conversation_search`.
+
+### Architecture
+
+```text
+User message
+      │
+      ▼
+   Runner ──► BeforeModel plugin ──► TencentDB Agent Memory gateway
+      │              │                         │
+      │              ▼                         ▼
+      │        recalled context           SDK memory engine
+      │
+      ▼
+   Agent ──► LLM ──► Response
+      │        │
+      │   (may call tdai_memory_search
+      │    or tdai_conversation_search)
+      │
+      ▼  (after turn completes)
+ session.Ingestor ──► /capture
+```
+
+### What This Example Does
+
+The program starts an interactive chat loop:
+
+1. Send a few messages that contain stable facts or preferences.
+2. Use `/new` to flush the current session and start a fresh session for the
+   same user.
+3. Ask related questions in the new session. The recall plugin and native
+   search tools can retrieve memories extracted by the gateway.
+
+## Prerequisites
+
+- Go 1.21 or later
+- A running TencentDB Agent Memory gateway sidecar
+- A valid OpenAI-compatible API key for the chat model
+
+The gateway is the local HTTP facade over the TencentDB Agent Memory SDK. It is
+responsible for the L0-L3 memory engine: capture, extraction, storage, recall,
+and search. If the SDK is configured to use local SQLite, the gateway is still
+needed because direct VectorDB storage access does not run the SDK's memory
+pipeline.
+
+### Start the Gateway
+
+Clone the TencentDB Agent Memory repository and start the standalone gateway:
+
+```bash
+git clone https://github.com/Tencent/TencentDB-Agent-Memory.git
+cd TencentDB-Agent-Memory
+npm install
+
+export TDAI_LLM_API_KEY="your-openai-compatible-api-key"
+export TDAI_LLM_BASE_URL="https://api.openai.com/v1"
+export TDAI_LLM_MODEL="deepseek-v4-flash"
+
+node --import tsx src/gateway/server.ts
+```
+
+The example connects to `http://127.0.0.1:8420` by default. The gateway reads
+the `TDAI_LLM_*` variables above for extraction and recall. You can point the Go
+example at another gateway URL with `-gateway`.
+
+## Environment Variables
+
+| Variable                         | Required | Description                         | Default                  |
+| -------------------------------- | -------- | ----------------------------------- | ------------------------ |
+| `OPENAI_API_KEY`                 | Yes      | API key for the chat model          |                          |
+| `OPENAI_BASE_URL`                | No       | Base URL for the model API endpoint | `https://api.openai.com/v1` |
+| `TENCENTDB_AGENT_MEMORY_GATEWAY` | No       | TencentDB Agent Memory gateway URL  | `http://127.0.0.1:8420`  |
+
+## Command Line Arguments
+
+| Argument             | Description                                      | Default                    |
+| -------------------- | ------------------------------------------------ | -------------------------- |
+| `-model`             | Chat model name                                  | `deepseek-v4-flash`        |
+| `-app`               | Application name used for session ownership      | `tencentdb-memory-demo`    |
+| `-user`              | User ID used for session ownership               | `demo-user`                |
+| `-session`           | Session ID (auto-generated if empty)             | `tencentdb-<unix-time>`    |
+| `-gateway`           | TencentDB Agent Memory gateway URL               | env or `http://127.0.0.1:8420` |
+| `-gateway-timeout`   | Timeout for gateway calls, including session flush | `60s`                   |
+| `-turn-wait`         | Delay after each turn for gateway capture/extraction | `0s`                   |
+| `-end-session`       | Call `/session/end` before exit                  | `false`                    |
+
+## Usage
+
+### Quick Start
+
+```bash
+export OPENAI_API_KEY="your-openai-api-key"
+export TENCENTDB_AGENT_MEMORY_GATEWAY="http://127.0.0.1:8420"
+
+cd examples/memory/tencentdb
+go run .
+```
+
+Then try:
+
+```text
+You: Remember this profile: my project code name is Apollo Lake, my deployment window is Friday night, and I prefer concise answers.
+You: /new
+You: What is my project code name, deployment window, and answer preference?
+You: /exit
+```
+
+### Custom Model
+
+```bash
+go run . -model gpt-4o-mini
+```
+
+### Custom Gateway
+
+```bash
+go run . -gateway http://127.0.0.1:8420
+```
+
+### Expected Output
+
+```text
+Model: deepseek-v4-flash
+Gateway: http://127.0.0.1:8420 (status=ok version=...)
+App: tencentdb-memory-demo
+User: demo-user
+Session: tencentdb-1713012345
+============================================================
+Special commands:
+  /new      - flush current session and start a new session for the same user
+  /session  - show current session
+  /end      - call TencentDB Agent Memory /session/end for current session
+  /exit     - end the conversation
+
+You: My project code name is Apollo Lake. I prefer concise answers.
+Tool calls: tdai_memory_search, tdai_conversation_search
+Assistant: Noted.
+
+You: /new
+Started new session.
+
+You: What is my project code name?
+Tool calls: tdai_memory_search
+Assistant: Your project code name is Apollo Lake.
+```
+
+## Integration Pattern
+
+The core wiring in Go looks like this:
+
+```go
+import (
+    memorytencentdb "trpc.group/trpc-go/trpc-agent-go/memory/tencentdb"
+    "trpc.group/trpc-go/trpc-agent-go/runner"
+)
+
+// 1. Create the TencentDB Agent Memory service.
+memSvc, err := memorytencentdb.NewService(
+    memorytencentdb.WithGatewayURL("http://127.0.0.1:8420"),
+)
+if err != nil {
+    log.Fatalf("create memory service: %v", err)
+}
+defer memSvc.Close()
+
+// 2. Create the agent with TencentDB-native memory tools.
+agent := llmagent.New(
+    "assistant",
+    llmagent.WithModel(openai.New("deepseek-v4-flash")),
+    llmagent.WithTools(memSvc.Tools()),
+)
+
+// 3. Create the runner with ingestion and automatic recall enabled.
+r := runner.NewRunner(
+    "my-app",
+    agent,
+    runner.WithSessionService(sessionSvc),
+    runner.WithSessionIngestor(memSvc),
+    runner.WithPlugins(memSvc.Plugin()),
+)
+defer r.Close()
+```
+
+Key points:
+
+- `memSvc.Tools()` returns `tdai_memory_search` and
+  `tdai_conversation_search` by default.
+- `runner.WithSessionIngestor(memSvc)` sends timestamped session transcript
+  messages to the gateway after each turn.
+- `runner.WithPlugins(memSvc.Plugin())` performs automatic recall before model
+  calls and injects returned context into the request.
+- The adapter forwards app/user/session identifiers, but hard multi-tenant
+  isolation depends on the gateway and SDK honoring those fields end-to-end.
+
+## Configuration Options
+
+| Option                         | Description                                         | Default                 |
+| ------------------------------ | --------------------------------------------------- | ----------------------- |
+| `WithGatewayURL(url)`          | TencentDB Agent Memory gateway URL                  | `http://127.0.0.1:8420` |
+| `WithTimeout(d)`               | HTTP timeout for gateway requests                   | `5s`                    |
+| `WithIngestWorkers(n)`         | Number of async capture workers                     | `1`                     |
+| `WithIngestQueueSize(n)`       | Queue size for async capture jobs                   | `10`                    |
+| `WithIngestJobTimeout(d)`      | Timeout for queued capture jobs                     | `30s`                   |
+| `WithSessionKeyFunc(fn)`       | Custom framework session to gateway `session_key` mapping | app:user:session |
+| `WithRecallEnabled(bool)`      | Enable automatic recall plugin behavior             | `true`                  |
+| `WithConversationSearchTool(bool)` | Expose `tdai_conversation_search`               | `true`                  |
+| `WithStandardAliases(bool)`    | Also expose standard `memory_search` alias          | `false`                 |
+| `WithToolPrefix(prefix)`       | Change native tool prefix                           | `tdai`                  |
+
+## See Also
+
+- [Mem0 Integration Example](../mem0/) — Ingest-first external memory platform
+- [Simple Memory Example](../simple/) — Agentic mode with manual tool calling
+- [Auto Memory Example](../auto/) — Automatic background extraction using a
+  local LLM extractor
+- [Memory Documentation](../../../docs/mkdocs/en/memory.md)
+- [Ecosystem Integration Guide](../../../docs/mkdocs/en/ecosystem.md)

--- a/examples/memory/tencentdb/README.md
+++ b/examples/memory/tencentdb/README.md
@@ -14,10 +14,17 @@ The integration works in three parts:
    new session transcript to the gateway via `runner.WithSessionIngestor(...)`.
 2. **Automatic recall** — Before each model call, `runner.WithPlugins(...)`
    invokes the TencentDB recall endpoint and injects the returned context into
-   the model request.
+   the model request. Recall is opt-in (`WithRecallEnabled(true)`).
 3. **Read-only tools** — The agent can explicitly search memory through
-   `tdai_memory_search` and conversation history through
-   `tdai_conversation_search`.
+   `tdai_memory_search` (opt-in via `WithMemorySearchTool(true)`) and
+   conversation history through `tdai_conversation_search`.
+
+> **Multi-tenant note:** automatic recall and `tdai_memory_search` read from the
+> gateway's shared long-term store, which does not currently enforce
+> user/session scoping. They are therefore disabled by default. Only the
+> session-scoped capture and `tdai_conversation_search` surfaces are on by
+> default. This demo enables recall and memory search explicitly because it runs
+> a single trusted local sidecar.
 
 ### Architecture
 
@@ -89,6 +96,7 @@ example at another gateway URL with `-gateway`.
 | `OPENAI_API_KEY`                 | Yes      | API key for the chat model          |                          |
 | `OPENAI_BASE_URL`                | No       | Base URL for the model API endpoint | `https://api.openai.com/v1` |
 | `TENCENTDB_AGENT_MEMORY_GATEWAY` | No       | TencentDB Agent Memory gateway URL  | `http://127.0.0.1:8420`  |
+| `TDAI_GATEWAY_API_KEY`           | No       | Gateway API key (sent as `Authorization: Bearer`) when the gateway requires auth | |
 
 ## Command Line Arguments
 
@@ -100,6 +108,7 @@ example at another gateway URL with `-gateway`.
 | `-session`           | Session ID (auto-generated if empty)             | `tencentdb-<unix-time>`    |
 | `-gateway`           | TencentDB Agent Memory gateway URL               | env or `http://127.0.0.1:8420` |
 | `-gateway-timeout`   | Timeout for gateway calls, including session flush | `60s`                   |
+| `-gateway-api-key`   | Gateway API key sent as `Authorization: Bearer`  | env `TDAI_GATEWAY_API_KEY`  |
 | `-turn-wait`         | Delay after each turn for gateway capture/extraction | `0s`                   |
 | `-end-session`       | Call `/session/end` before exit                  | `false`                    |
 
@@ -174,8 +183,14 @@ import (
 )
 
 // 1. Create the TencentDB Agent Memory service.
+//    Recall and the long-term memory_search tool are opt-in; enable them only
+//    when the gateway enforces per-user/session isolation (e.g. a trusted local
+//    sidecar). Pass WithAPIKey when the gateway sets TDAI_GATEWAY_API_KEY.
 memSvc, err := memorytencentdb.NewService(
     memorytencentdb.WithGatewayURL("http://127.0.0.1:8420"),
+    memorytencentdb.WithRecallEnabled(true),
+    memorytencentdb.WithMemorySearchTool(true),
+    // memorytencentdb.WithAPIKey(os.Getenv("TDAI_GATEWAY_API_KEY")),
 )
 if err != nil {
     log.Fatalf("create memory service: %v", err)
@@ -202,14 +217,16 @@ defer r.Close()
 
 Key points:
 
-- `memSvc.Tools()` returns `tdai_memory_search` and
-  `tdai_conversation_search` by default.
+- `memSvc.Tools()` returns `tdai_conversation_search` by default;
+  `tdai_memory_search` is added only when `WithMemorySearchTool(true)` is set.
 - `runner.WithSessionIngestor(memSvc)` sends timestamped session transcript
   messages to the gateway after each turn.
 - `runner.WithPlugins(memSvc.Plugin())` performs automatic recall before model
-  calls and injects returned context into the request.
+  calls and injects returned context into the request, but only when
+  `WithRecallEnabled(true)` is set.
 - The adapter forwards app/user/session identifiers, but hard multi-tenant
-  isolation depends on the gateway and SDK honoring those fields end-to-end.
+  isolation depends on the gateway and SDK honoring those fields end-to-end, so
+  cross-session/user reads (recall and memory search) are opt-in.
 
 ## Configuration Options
 
@@ -221,9 +238,11 @@ Key points:
 | `WithIngestQueueSize(n)`       | Queue size for async capture jobs                   | `10`                    |
 | `WithIngestJobTimeout(d)`      | Timeout for queued capture jobs                     | `30s`                   |
 | `WithSessionKeyFunc(fn)`       | Custom framework session to gateway `session_key` mapping | app:user:session |
-| `WithRecallEnabled(bool)`      | Enable automatic recall plugin behavior             | `true`                  |
+| `WithAPIKey(key)`              | Send `Authorization: Bearer <key>` (gateway `TDAI_GATEWAY_API_KEY`) | none      |
+| `WithRecallEnabled(bool)`      | Enable automatic recall plugin behavior (opt-in; shared-store reads) | `false`        |
+| `WithMemorySearchTool(bool)`   | Expose `tdai_memory_search` (opt-in; shared-store reads) | `false`              |
 | `WithConversationSearchTool(bool)` | Expose `tdai_conversation_search`               | `true`                  |
-| `WithStandardAliases(bool)`    | Also expose standard `memory_search` alias          | `false`                 |
+| `WithStandardAliases(bool)`    | Also expose standard `memory_search` alias (needs memory search enabled) | `false` |
 | `WithToolPrefix(prefix)`       | Change native tool prefix                           | `tdai`                  |
 
 ## See Also

--- a/examples/memory/tencentdb/README.md
+++ b/examples/memory/tencentdb/README.md
@@ -237,7 +237,7 @@ Key points:
 | `WithIngestWorkers(n)`         | Number of async capture workers                     | `1`                     |
 | `WithIngestQueueSize(n)`       | Queue size for async capture jobs                   | `10`                    |
 | `WithIngestJobTimeout(d)`      | Timeout for queued capture jobs                     | `30s`                   |
-| `WithSessionKeyFunc(fn)`       | Custom framework session to gateway `session_key` mapping | app:user:session |
+| `WithSessionKeyFunc(fn)`       | Custom framework session to gateway `session_key` mapping | base64url(app):base64url(user):base64url(session) |
 | `WithAPIKey(key)`              | Send `Authorization: Bearer <key>` (gateway `TDAI_GATEWAY_API_KEY`) | none      |
 | `WithRecallEnabled(bool)`      | Enable automatic recall plugin behavior (opt-in; shared-store reads) | `false`        |
 | `WithMemorySearchTool(bool)`   | Expose `tdai_memory_search` (opt-in; shared-store reads) | `false`              |

--- a/examples/memory/tencentdb/main.go
+++ b/examples/memory/tencentdb/main.go
@@ -61,6 +61,11 @@ var (
 		60*time.Second,
 		"Timeout for TencentDB Agent Memory gateway requests",
 	)
+	gatewayAPIKey = flag.String(
+		"gateway-api-key",
+		os.Getenv("TDAI_GATEWAY_API_KEY"),
+		"Gateway API key sent as Authorization: Bearer when the gateway sets TDAI_GATEWAY_API_KEY",
+	)
 	waitBeforeRecall = flag.Duration(
 		"turn-wait",
 		0,
@@ -84,11 +89,17 @@ func main() {
 		sid = fmt.Sprintf("tencentdb-%d", time.Now().Unix())
 	}
 
+	// Recall and the long-term memory_search tool are opt-in because the gateway
+	// does not enforce per-user/session scoping on those paths; enable them here
+	// for the demo, which runs a single trusted local sidecar.
 	memSvc, err := memorytencentdb.NewService(
 		memorytencentdb.WithGatewayURL(*gatewayURL),
 		memorytencentdb.WithTimeout(*gatewayTimeout),
 		memorytencentdb.WithIngestQueueSize(8),
 		memorytencentdb.WithIngestJobTimeout(30*time.Second),
+		memorytencentdb.WithAPIKey(*gatewayAPIKey),
+		memorytencentdb.WithRecallEnabled(true),
+		memorytencentdb.WithMemorySearchTool(true),
 	)
 	if err != nil {
 		log.Fatalf("create TencentDB Agent Memory service: %v", err)

--- a/examples/memory/tencentdb/main.go
+++ b/examples/memory/tencentdb/main.go
@@ -1,0 +1,315 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"bufio"
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	memorytencentdb "trpc.group/trpc-go/trpc-agent-go/memory/tencentdb"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/model/openai"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	sessioninmemory "trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+)
+
+const (
+	defaultModelName  = "deepseek-v4-flash"
+	defaultGatewayURL = "http://127.0.0.1:8420"
+)
+
+var (
+	modelName = flag.String("model", defaultModelName, "Chat model name")
+	appName   = flag.String(
+		"app",
+		"tencentdb-memory-demo",
+		"Application name used for session ownership",
+	)
+	userID = flag.String(
+		"user",
+		"demo-user",
+		"User ID used for session ownership",
+	)
+	sessionID = flag.String(
+		"session",
+		"",
+		"Session ID (default: generated from timestamp)",
+	)
+	gatewayURL = flag.String(
+		"gateway",
+		envOrDefault("TENCENTDB_AGENT_MEMORY_GATEWAY", defaultGatewayURL),
+		"TencentDB Agent Memory gateway URL",
+	)
+	gatewayTimeout = flag.Duration(
+		"gateway-timeout",
+		60*time.Second,
+		"Timeout for TencentDB Agent Memory gateway requests",
+	)
+	waitBeforeRecall = flag.Duration(
+		"turn-wait",
+		0,
+		"Delay after each user turn to wait for gateway capture/extraction",
+	)
+	endSession = flag.Bool(
+		"end-session",
+		false,
+		"Call TencentDB Agent Memory /session/end before exit",
+	)
+)
+
+func main() {
+	flag.Parse()
+	if os.Getenv("OPENAI_API_KEY") == "" {
+		log.Fatal("OPENAI_API_KEY is required")
+	}
+
+	sid := *sessionID
+	if sid == "" {
+		sid = fmt.Sprintf("tencentdb-%d", time.Now().Unix())
+	}
+
+	memSvc, err := memorytencentdb.NewService(
+		memorytencentdb.WithGatewayURL(*gatewayURL),
+		memorytencentdb.WithTimeout(*gatewayTimeout),
+		memorytencentdb.WithIngestQueueSize(8),
+		memorytencentdb.WithIngestJobTimeout(30*time.Second),
+	)
+	if err != nil {
+		log.Fatalf("create TencentDB Agent Memory service: %v", err)
+	}
+	defer memSvc.Close()
+
+	ctx := context.Background()
+	health, err := memSvc.Health(ctx)
+	if err != nil {
+		log.Fatalf("TencentDB Agent Memory gateway is not ready: %v", err)
+	}
+
+	chatAgent := llmagent.New(
+		"tencentdb-memory-demo-agent",
+		llmagent.WithModel(openai.New(*modelName)),
+		llmagent.WithDescription("A concise assistant with TencentDB Agent Memory integration."),
+		llmagent.WithTools(memSvc.Tools()),
+	)
+
+	sessionSvc := sessioninmemory.NewSessionService()
+	r := runner.NewRunner(
+		*appName,
+		chatAgent,
+		runner.WithSessionService(sessionSvc),
+		runner.WithSessionIngestor(memSvc),
+		runner.WithPlugins(memSvc.Plugin()),
+	)
+	defer r.Close()
+
+	fmt.Printf("Model: %s\n", *modelName)
+	fmt.Printf("Gateway: %s (status=%s version=%s)\n", *gatewayURL, health.Status, health.Version)
+	fmt.Printf("App: %s\nUser: %s\nSession: %s\n", *appName, *userID, sid)
+	fmt.Println(strings.Repeat("=", 60))
+
+	chat := &memoryChat{
+		runner:     r,
+		sessionSvc: sessionSvc,
+		memSvc:     memSvc,
+		userID:     *userID,
+		sessionID:  sid,
+	}
+	if err := chat.start(ctx); err != nil {
+		log.Fatalf("chat failed: %v", err)
+	}
+}
+
+type memoryChat struct {
+	runner     runner.Runner
+	sessionSvc session.Service
+	memSvc     *memorytencentdb.Service
+	userID     string
+	sessionID  string
+}
+
+func (c *memoryChat) start(ctx context.Context) error {
+	if *endSession {
+		defer func() {
+			if err := c.endCurrentSession(ctx); err != nil {
+				fmt.Printf("End session failed: %v\n", err)
+			} else {
+				fmt.Println("Session flushed through TencentDB Agent Memory gateway.")
+			}
+		}()
+	}
+
+	scanner := bufio.NewScanner(os.Stdin)
+	fmt.Println("Special commands:")
+	fmt.Println("  /new      - flush current session and start a new session for the same user")
+	fmt.Println("  /session  - show current session")
+	fmt.Println("  /end      - call TencentDB Agent Memory /session/end for current session")
+	fmt.Println("  /exit     - end the conversation")
+	fmt.Println()
+
+	for {
+		fmt.Print("You: ")
+		if !scanner.Scan() {
+			break
+		}
+		input := strings.TrimSpace(scanner.Text())
+		if input == "" {
+			continue
+		}
+		switch strings.ToLower(input) {
+		case "/exit":
+			fmt.Println("Goodbye!")
+			return nil
+		case "/new":
+			if err := c.startNewSession(ctx); err != nil {
+				fmt.Printf("Start new session failed: %v\n\n", err)
+			}
+			continue
+		case "/session":
+			fmt.Printf("Current session: %s\n\n", c.sessionID)
+			continue
+		case "/end":
+			if err := c.endCurrentSession(ctx); err != nil {
+				fmt.Printf("End session failed: %v\n\n", err)
+			} else {
+				fmt.Println("Session flushed through TencentDB Agent Memory gateway.")
+				fmt.Println()
+			}
+			continue
+		}
+
+		if err := c.processMessage(ctx, input); err != nil {
+			fmt.Printf("Error: %v\n", err)
+		}
+		fmt.Println()
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("input scanner error: %w", err)
+	}
+	return nil
+}
+
+func (c *memoryChat) processMessage(ctx context.Context, input string) error {
+	result, err := runOnce(ctx, c.runner, c.userID, c.sessionID, model.NewUserMessage(input))
+	if err != nil {
+		return err
+	}
+	printRunResult(result)
+	if *waitBeforeRecall > 0 {
+		fmt.Printf("Waiting %s for gateway capture/extraction...\n", *waitBeforeRecall)
+		time.Sleep(*waitBeforeRecall)
+	}
+	return nil
+}
+
+func (c *memoryChat) startNewSession(ctx context.Context) error {
+	oldSessionID := c.sessionID
+	if err := c.endCurrentSession(ctx); err != nil {
+		return err
+	}
+	c.sessionID = fmt.Sprintf("tencentdb-%d", time.Now().UnixNano())
+	fmt.Println("Started new session.")
+	fmt.Printf("  Previous: %s\n", oldSessionID)
+	fmt.Printf("  Current:  %s\n", c.sessionID)
+	fmt.Println("  Long-term memories are preserved for the same user.")
+	fmt.Println()
+	return nil
+}
+
+func (c *memoryChat) endCurrentSession(ctx context.Context) error {
+	sess, err := c.sessionSvc.GetSession(ctx, sessionKey(c.userID, c.sessionID))
+	if err != nil {
+		return fmt.Errorf("lookup session: %w", err)
+	}
+	if sess == nil {
+		return fmt.Errorf("session %s not found", c.sessionID)
+	}
+	return c.memSvc.EndSession(ctx, sess)
+}
+
+type runResult struct {
+	toolCalls []string
+	reply     string
+}
+
+func runOnce(ctx context.Context, r runner.Runner, userID, sessionID string, msg model.Message) (*runResult, error) {
+	ch, err := r.Run(ctx, userID, sessionID, msg)
+	if err != nil {
+		return nil, err
+	}
+	out := &runResult{}
+	seen := make(map[string]struct{})
+	for evt := range ch {
+		if evt == nil {
+			continue
+		}
+		if evt.Error != nil {
+			return nil, fmt.Errorf("runner event error: %s", evt.Error.Message)
+		}
+		collectResponse(out, seen, evt)
+	}
+	return out, nil
+}
+
+func collectResponse(out *runResult, seen map[string]struct{}, evt *event.Event) {
+	if evt == nil || evt.Response == nil {
+		return
+	}
+	for _, choice := range evt.Response.Choices {
+		for _, tc := range choice.Message.ToolCalls {
+			name := strings.TrimSpace(tc.Function.Name)
+			if name == "" {
+				continue
+			}
+			if _, ok := seen[name]; ok {
+				continue
+			}
+			seen[name] = struct{}{}
+			out.toolCalls = append(out.toolCalls, name)
+		}
+		if text := strings.TrimSpace(choice.Message.Content); text != "" {
+			out.reply = text
+		}
+	}
+}
+
+func printRunResult(result *runResult) {
+	if len(result.toolCalls) > 0 {
+		fmt.Printf("Tool calls: %s\n", strings.Join(result.toolCalls, ", "))
+	} else {
+		fmt.Println("Tool calls: <none>")
+	}
+	if reply := strings.TrimSpace(result.reply); reply != "" {
+		fmt.Printf("Assistant: %s\n", reply)
+	}
+}
+
+func envOrDefault(name, fallback string) string {
+	if value := os.Getenv(name); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func sessionKey(userID, sessionID string) session.Key {
+	return session.Key{
+		AppName:   *appName,
+		UserID:    userID,
+		SessionID: sessionID,
+	}
+}

--- a/memory/tencentdb/client.go
+++ b/memory/tencentdb/client.go
@@ -1,0 +1,204 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package tencentdb
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	httpHeaderAccept      = "Accept"
+	httpHeaderContentType = "Content-Type"
+	httpContentTypeJSON   = "application/json"
+
+	httpMethodGet  = "GET"
+	httpMethodPost = "POST"
+
+	pathCapture             = "/capture"
+	pathRecall              = "/recall"
+	pathSearchMemories      = "/search/memories"
+	pathSearchConversations = "/search/conversations"
+	pathEndSession          = "/session/end"
+	pathHealth              = "/health"
+
+	maxErrorBodyPreview = 512
+)
+
+// APIError describes a non-2xx response returned by the gateway.
+type APIError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("tencentdb memory gateway request failed: status=%d body=%s", e.StatusCode, e.Body)
+}
+
+type gatewayClient struct {
+	baseURL      string
+	hc           *http.Client
+	timeout      time.Duration
+	maxBodyBytes int64
+}
+
+func newGatewayClient(opts Options) (*gatewayClient, error) {
+	baseURL := strings.TrimRight(strings.TrimSpace(opts.GatewayURL), "/")
+	if baseURL == "" {
+		return nil, errors.New("tencentdb memory: gateway url is required")
+	}
+	if _, err := url.ParseRequestURI(baseURL); err != nil {
+		return nil, fmt.Errorf("tencentdb memory: invalid gateway url: %w", err)
+	}
+	hc := opts.HTTPClient
+	if hc == nil {
+		hc = &http.Client{}
+	}
+	maxBodyBytes := opts.MaxBodyBytes
+	if maxBodyBytes <= 0 {
+		maxBodyBytes = defaultMaxBodyBytes
+	}
+	return &gatewayClient{
+		baseURL:      baseURL,
+		hc:           hc,
+		timeout:      opts.Timeout,
+		maxBodyBytes: maxBodyBytes,
+	}, nil
+}
+
+func (c *gatewayClient) capture(ctx context.Context, req captureRequest) (*captureResponse, error) {
+	var rsp captureResponse
+	if err := c.doJSON(ctx, httpMethodPost, pathCapture, req, &rsp); err != nil {
+		return nil, err
+	}
+	return &rsp, nil
+}
+
+func (c *gatewayClient) recall(ctx context.Context, req recallRequest) (*recallResponse, error) {
+	var rsp recallResponse
+	if err := c.doJSON(ctx, httpMethodPost, pathRecall, req, &rsp); err != nil {
+		return nil, err
+	}
+	return &rsp, nil
+}
+
+func (c *gatewayClient) searchMemories(ctx context.Context, req searchMemoriesRequest) (*searchMemoriesResponse, error) {
+	var rsp searchMemoriesResponse
+	if err := c.doJSON(ctx, httpMethodPost, pathSearchMemories, req, &rsp); err != nil {
+		return nil, err
+	}
+	return &rsp, nil
+}
+
+func (c *gatewayClient) searchConversations(ctx context.Context, req searchConversationsRequest) (*searchConversationsResponse, error) {
+	var rsp searchConversationsResponse
+	if err := c.doJSON(ctx, httpMethodPost, pathSearchConversations, req, &rsp); err != nil {
+		return nil, err
+	}
+	return &rsp, nil
+}
+
+func (c *gatewayClient) endSession(ctx context.Context, req endSessionRequest) (*endSessionResponse, error) {
+	var rsp endSessionResponse
+	if err := c.doJSON(ctx, httpMethodPost, pathEndSession, req, &rsp); err != nil {
+		return nil, err
+	}
+	return &rsp, nil
+}
+
+func (c *gatewayClient) health(ctx context.Context) (*HealthResponse, error) {
+	var rsp HealthResponse
+	if err := c.doJSON(ctx, httpMethodGet, pathHealth, nil, &rsp); err != nil {
+		return nil, err
+	}
+	return &rsp, nil
+}
+
+func (c *gatewayClient) doJSON(
+	ctx context.Context,
+	method string,
+	path string,
+	in any,
+	out any,
+) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if c.timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, c.timeout)
+		defer cancel()
+	}
+	var payload []byte
+	var err error
+	if in != nil {
+		payload, err = json.Marshal(in)
+		if err != nil {
+			return fmt.Errorf("tencentdb memory: marshal request failed: %w", err)
+		}
+	}
+	return c.doJSONOnce(ctx, method, c.baseURL+path, payload, out)
+}
+
+func (c *gatewayClient) doJSONOnce(
+	ctx context.Context,
+	method string,
+	urlStr string,
+	payload []byte,
+	out any,
+) error {
+	var body io.Reader
+	if payload != nil {
+		body = bytes.NewReader(payload)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, urlStr, body)
+	if err != nil {
+		return fmt.Errorf("tencentdb memory: build request failed: %w", err)
+	}
+	req.Header.Set(httpHeaderAccept, httpContentTypeJSON)
+	if payload != nil {
+		req.Header.Set(httpHeaderContentType, httpContentTypeJSON)
+	}
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return fmt.Errorf("tencentdb memory: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, c.maxBodyBytes+1))
+	if err != nil {
+		return fmt.Errorf("tencentdb memory: read response failed: %w", err)
+	}
+	if int64(len(respBody)) > c.maxBodyBytes {
+		return errors.New("tencentdb memory: response body too large")
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		preview := string(respBody)
+		if len(preview) > maxErrorBodyPreview {
+			preview = preview[:maxErrorBodyPreview] + "...(truncated)"
+		}
+		return &APIError{StatusCode: resp.StatusCode, Body: preview}
+	}
+	if out == nil || len(respBody) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(respBody, out); err != nil {
+		return fmt.Errorf("tencentdb memory: unmarshal response failed: %w", err)
+	}
+	return nil
+}

--- a/memory/tencentdb/client.go
+++ b/memory/tencentdb/client.go
@@ -23,9 +23,11 @@ import (
 )
 
 const (
-	httpHeaderAccept      = "Accept"
-	httpHeaderContentType = "Content-Type"
-	httpContentTypeJSON   = "application/json"
+	httpHeaderAccept        = "Accept"
+	httpHeaderContentType   = "Content-Type"
+	httpHeaderAuthorization = "Authorization"
+	httpContentTypeJSON     = "application/json"
+	httpAuthBearerPrefix    = "Bearer "
 
 	httpMethodGet  = "GET"
 	httpMethodPost = "POST"
@@ -55,6 +57,7 @@ type gatewayClient struct {
 	hc           *http.Client
 	timeout      time.Duration
 	maxBodyBytes int64
+	apiKey       string
 }
 
 func newGatewayClient(opts Options) (*gatewayClient, error) {
@@ -82,6 +85,7 @@ func newGatewayClient(opts Options) (*gatewayClient, error) {
 		hc:           hc,
 		timeout:      opts.Timeout,
 		maxBodyBytes: maxBodyBytes,
+		apiKey:       strings.TrimSpace(opts.APIKey),
 	}, nil
 }
 
@@ -177,6 +181,9 @@ func (c *gatewayClient) doJSONOnce(
 	req.Header.Set(httpHeaderAccept, httpContentTypeJSON)
 	if payload != nil {
 		req.Header.Set(httpHeaderContentType, httpContentTypeJSON)
+	}
+	if c.apiKey != "" {
+		req.Header.Set(httpHeaderAuthorization, httpAuthBearerPrefix+c.apiKey)
 	}
 	resp, err := c.hc.Do(req)
 	if err != nil {

--- a/memory/tencentdb/client.go
+++ b/memory/tencentdb/client.go
@@ -160,7 +160,7 @@ func (c *gatewayClient) doJSON(
 			return fmt.Errorf("tencentdb memory: marshal request failed: %w", err)
 		}
 	}
-	return c.doJSONOnce(ctx, method, c.baseURL+path, payload, out)
+	return c.doJSONOnce(ctx, method, c.baseURL+path, payload, out, path != pathHealth)
 }
 
 func (c *gatewayClient) doJSONOnce(
@@ -169,6 +169,7 @@ func (c *gatewayClient) doJSONOnce(
 	urlStr string,
 	payload []byte,
 	out any,
+	authorize bool,
 ) error {
 	var body io.Reader
 	if payload != nil {
@@ -182,7 +183,7 @@ func (c *gatewayClient) doJSONOnce(
 	if payload != nil {
 		req.Header.Set(httpHeaderContentType, httpContentTypeJSON)
 	}
-	if c.apiKey != "" {
+	if authorize && c.apiKey != "" {
 		req.Header.Set(httpHeaderAuthorization, httpAuthBearerPrefix+c.apiKey)
 	}
 	resp, err := c.hc.Do(req)

--- a/memory/tencentdb/client.go
+++ b/memory/tencentdb/client.go
@@ -62,8 +62,12 @@ func newGatewayClient(opts Options) (*gatewayClient, error) {
 	if baseURL == "" {
 		return nil, errors.New("tencentdb memory: gateway url is required")
 	}
-	if _, err := url.ParseRequestURI(baseURL); err != nil {
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
 		return nil, fmt.Errorf("tencentdb memory: invalid gateway url: %w", err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" || parsed.Host == "" {
+		return nil, fmt.Errorf("tencentdb memory: gateway url must be an absolute http(s) URL with host: %q", baseURL)
 	}
 	hc := opts.HTTPClient
 	if hc == nil {

--- a/memory/tencentdb/client_test.go
+++ b/memory/tencentdb/client_test.go
@@ -1,0 +1,121 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package tencentdb
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGatewayClientEndpointsAndErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case pathRecall:
+			_ = json.NewEncoder(w).Encode(recallResponse{
+				Context:             "legacy",
+				PrependContext:      "prepend",
+				AppendSystemContext: "append",
+				Strategy:            "hybrid",
+				MemoryCount:         2,
+			})
+		case pathSearchMemories:
+			_ = json.NewEncoder(w).Encode(searchMemoriesResponse{
+				Results:  "memory hit",
+				Total:    1,
+				Strategy: "semantic",
+			})
+		case pathEndSession:
+			_ = json.NewEncoder(w).Encode(endSessionResponse{Flushed: true})
+		case pathHealth:
+			_ = json.NewEncoder(w).Encode(HealthResponse{Status: "ok", Version: "test"})
+		default:
+			http.Error(w, strings.Repeat("x", 700), http.StatusBadGateway)
+		}
+	}))
+	defer server.Close()
+
+	client, err := newGatewayClient(Options{
+		GatewayURL:   server.URL,
+		Timeout:      time.Second,
+		MaxBodyBytes: defaultMaxBodyBytes,
+	})
+	require.NoError(t, err, "newGatewayClient")
+	recall, err := client.recall(context.Background(), recallRequest{Query: "q", SessionKey: "s"})
+	require.NoError(t, err, "recall")
+	assert.Equal(t, "append", recall.AppendSystemContext)
+	assert.Equal(t, 2, recall.MemoryCount)
+	memories, err := client.searchMemories(context.Background(), searchMemoriesRequest{Query: "q"})
+	require.NoError(t, err, "searchMemories")
+	assert.Equal(t, "memory hit", memories.Results)
+	assert.Equal(t, "semantic", memories.Strategy)
+	ended, err := client.endSession(context.Background(), endSessionRequest{SessionKey: "s"})
+	require.NoError(t, err, "endSession")
+	assert.True(t, ended.Flushed)
+	health, err := client.health(context.Background())
+	require.NoError(t, err, "health")
+	assert.Equal(t, "ok", health.Status)
+	assert.Equal(t, "test", health.Version)
+
+	err = client.doJSON(context.Background(), httpMethodGet, "/missing", nil, nil)
+	require.Error(t, err)
+	var apiErr *APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Contains(t, apiErr.Error(), "status=502")
+	assert.LessOrEqual(t, len(apiErr.Body), maxErrorBodyPreview+len("...(truncated)"))
+	err = client.doJSON(context.Background(), httpMethodPost, pathCapture, map[string]any{
+		"bad": func() {},
+	}, nil)
+	require.Error(t, err, "expected marshal error")
+
+	tiny, err := newGatewayClient(Options{GatewayURL: server.URL, MaxBodyBytes: 4})
+	require.NoError(t, err, "new tiny client")
+	_, err = tiny.health(context.Background())
+	require.Error(t, err, "expected response body too large")
+	_, err = newGatewayClient(Options{GatewayURL: "://bad"})
+	require.Error(t, err, "expected invalid gateway url error")
+	_, err = newGatewayClient(Options{GatewayURL: "/path-only"})
+	require.Error(t, err, "expected path-only gateway url error")
+	_, err = newGatewayClient(Options{GatewayURL: "ftp://example.com"})
+	require.Error(t, err, "expected unsupported scheme gateway url error")
+	_, err = newGatewayClient(Options{})
+	require.Error(t, err, "expected empty gateway url error")
+	nullable, err := newGatewayClient(Options{GatewayURL: server.URL})
+	require.NoError(t, err, "new nullable client")
+	require.NoError(t, nullable.doJSON(context.Background(), httpMethodGet, pathHealth, nil, nil), "nil output should be accepted")
+}
+
+func TestGatewayClientDecodeAndRequestEdges(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/empty":
+			w.WriteHeader(http.StatusNoContent)
+		case "/bad-json":
+			_, _ = w.Write([]byte("{"))
+		default:
+			_ = json.NewEncoder(w).Encode(HealthResponse{Status: "ok"})
+		}
+	}))
+	defer server.Close()
+
+	client, err := newGatewayClient(Options{GatewayURL: server.URL})
+	require.NoError(t, err, "newGatewayClient")
+	var out HealthResponse
+	require.NoError(t, client.doJSON(context.Background(), httpMethodGet, "/empty", nil, &out), "empty response should be accepted")
+	require.Error(t, client.doJSON(context.Background(), httpMethodGet, "/bad-json", nil, &out), "expected unmarshal error")
+	require.Error(t, client.doJSONOnce(context.Background(), httpMethodGet, "://bad", nil, nil), "expected request build error")
+}

--- a/memory/tencentdb/client_test.go
+++ b/memory/tencentdb/client_test.go
@@ -123,7 +123,7 @@ func TestGatewayClientSendsAPIKeyHeader(t *testing.T) {
 	assert.Equal(t, "Bearer secret-key", captureAuth)
 	_, err = client.health(context.Background())
 	require.NoError(t, err, "health")
-	assert.Equal(t, "Bearer secret-key", healthAuth)
+	assert.Empty(t, healthAuth, "health should remain unauthenticated")
 
 	captureAuth = ""
 	noKey, err := newGatewayClient(Options{GatewayURL: server.URL})
@@ -156,5 +156,5 @@ func TestGatewayClientDecodeAndRequestEdges(t *testing.T) {
 	var out HealthResponse
 	require.NoError(t, client.doJSON(context.Background(), httpMethodGet, "/empty", nil, &out), "empty response should be accepted")
 	require.Error(t, client.doJSON(context.Background(), httpMethodGet, "/bad-json", nil, &out), "expected unmarshal error")
-	require.Error(t, client.doJSONOnce(context.Background(), httpMethodGet, "://bad", nil, nil), "expected request build error")
+	require.Error(t, client.doJSONOnce(context.Background(), httpMethodGet, "://bad", nil, nil, true), "expected request build error")
 }

--- a/memory/tencentdb/client_test.go
+++ b/memory/tencentdb/client_test.go
@@ -99,6 +99,45 @@ func TestGatewayClientEndpointsAndErrors(t *testing.T) {
 	require.NoError(t, nullable.doJSON(context.Background(), httpMethodGet, pathHealth, nil, nil), "nil output should be accepted")
 }
 
+func TestGatewayClientSendsAPIKeyHeader(t *testing.T) {
+	var captureAuth, healthAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case pathHealth:
+			healthAuth = r.Header.Get(httpHeaderAuthorization)
+			_ = json.NewEncoder(w).Encode(HealthResponse{Status: "ok"})
+		case pathCapture:
+			captureAuth = r.Header.Get(httpHeaderAuthorization)
+			_ = json.NewEncoder(w).Encode(captureResponse{})
+		default:
+			http.Error(w, "unexpected", http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client, err := newGatewayClient(Options{GatewayURL: server.URL, APIKey: "  secret-key  "})
+	require.NoError(t, err, "newGatewayClient")
+	assert.Equal(t, "secret-key", client.apiKey, "api key should be trimmed")
+	_, err = client.capture(context.Background(), captureRequest{SessionKey: "s"})
+	require.NoError(t, err, "capture")
+	assert.Equal(t, "Bearer secret-key", captureAuth)
+	_, err = client.health(context.Background())
+	require.NoError(t, err, "health")
+	assert.Equal(t, "Bearer secret-key", healthAuth)
+
+	captureAuth = ""
+	noKey, err := newGatewayClient(Options{GatewayURL: server.URL})
+	require.NoError(t, err, "newGatewayClient without key")
+	_, err = noKey.capture(context.Background(), captureRequest{SessionKey: "s"})
+	require.NoError(t, err, "capture without key")
+	assert.Empty(t, captureAuth, "no Authorization header without an API key")
+
+	svc, err := NewService(WithGatewayURL(server.URL), WithAPIKey("  k  "))
+	require.NoError(t, err, "NewService WithAPIKey")
+	defer svc.Close()
+	assert.Equal(t, "k", svc.client.apiKey, "WithAPIKey should trim and wire the key through")
+}
+
 func TestGatewayClientDecodeAndRequestEdges(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/memory/tencentdb/ingest_test.go
+++ b/memory/tencentdb/ingest_test.go
@@ -75,7 +75,7 @@ func TestIngestSessionCapturesTimestampedMessagesAndCursor(t *testing.T) {
 	require.NoError(t, svc.IngestSession(context.Background(), sess), "IngestSession")
 	require.NoError(t, svc.Close(), "Close")
 
-	assert.Equal(t, "app:user:sess-1", got.SessionKey)
+	assert.Equal(t, defaultSessionKey(sess), got.SessionKey)
 	assert.Equal(t, "remember this", got.UserContent)
 	assert.Equal(t, "stored", got.AssistantContent)
 	require.Len(t, got.Messages, 2)

--- a/memory/tencentdb/ingest_test.go
+++ b/memory/tencentdb/ingest_test.go
@@ -1,0 +1,367 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package tencentdb
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+func TestIngestSessionCapturesTimestampedMessagesAndCursor(t *testing.T) {
+	var got captureRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != pathCapture {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(captureResponse{L0Recorded: len(got.Messages)})
+	}))
+	defer server.Close()
+
+	svc, err := NewService(
+		WithGatewayURL(server.URL),
+		WithIngestQueueSize(1),
+		WithIngestJobTimeout(time.Second),
+	)
+	require.NoError(t, err, "NewService")
+
+	ts1 := time.Date(2026, 5, 22, 8, 0, 0, 123*1e6, time.UTC)
+	ts2 := ts1.Add(time.Second)
+	sess := &session.Session{
+		ID:      "sess-1",
+		AppName: "app",
+		UserID:  "user",
+		State:   session.StateMap{},
+		Events: []event.Event{
+			{
+				ID:        "u1",
+				Timestamp: ts1,
+				Response: &model.Response{Choices: []model.Choice{{
+					Index:   0,
+					Message: model.NewUserMessage("remember this"),
+				}}},
+			},
+			{
+				ID:        "a1",
+				Timestamp: ts2,
+				Response: &model.Response{Choices: []model.Choice{{
+					Index:   0,
+					Message: model.NewAssistantMessage("stored"),
+				}}},
+			},
+		},
+	}
+	require.NoError(t, svc.IngestSession(context.Background(), sess), "IngestSession")
+	require.NoError(t, svc.Close(), "Close")
+
+	assert.Equal(t, "app:user:sess-1", got.SessionKey)
+	assert.Equal(t, "remember this", got.UserContent)
+	assert.Equal(t, "stored", got.AssistantContent)
+	require.Len(t, got.Messages, 2)
+	assert.Greater(t, got.Messages[0].Timestamp, ts2.UnixMilli())
+	assert.Equal(t, got.Messages[0].Timestamp+1, got.Messages[1].Timestamp)
+	assert.Equal(t, ts2, readBestEffortLastCaptureAt(sess))
+}
+
+func TestIngestSessionMarksInFlightBeforeAsyncCaptureCompletes(t *testing.T) {
+	release := make(chan struct{})
+	started := make(chan struct{}, 1)
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != pathCapture {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		requests.Add(1)
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+		<-release
+		_ = json.NewEncoder(w).Encode(captureResponse{L0Recorded: 2})
+	}))
+	defer server.Close()
+
+	svc, err := NewService(
+		WithGatewayURL(server.URL),
+		WithIngestQueueSize(1),
+		WithIngestJobTimeout(time.Second),
+	)
+	require.NoError(t, err, "NewService")
+	defer func() {
+		close(release)
+		assert.NoError(t, svc.Close())
+	}()
+	sess := captureReadySession()
+	require.NoError(t, svc.IngestSession(context.Background(), sess), "IngestSession")
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatalf("capture request did not start")
+	}
+	assert.True(t, readBestEffortLastCaptureAt(sess).IsZero())
+	require.NoError(t, svc.IngestSession(context.Background(), sess), "second IngestSession")
+	assert.Equal(t, int32(1), requests.Load())
+}
+
+func TestIngestSessionRetriesAfterAsyncCaptureFailure(t *testing.T) {
+	firstDone := make(chan struct{})
+	secondDone := make(chan struct{})
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != pathCapture {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		switch requests.Add(1) {
+		case 1:
+			http.Error(w, "gateway unavailable", http.StatusBadGateway)
+			close(firstDone)
+		case 2:
+			_ = json.NewEncoder(w).Encode(captureResponse{L0Recorded: 2})
+			close(secondDone)
+		default:
+			t.Fatalf("unexpected extra capture request")
+		}
+	}))
+	defer server.Close()
+
+	svc, err := NewService(
+		WithGatewayURL(server.URL),
+		WithIngestQueueSize(1),
+		WithIngestJobTimeout(time.Second),
+	)
+	require.NoError(t, err, "NewService")
+	defer func() {
+		assert.NoError(t, svc.Close())
+	}()
+	sess := captureReadySession()
+	want := sess.Events[len(sess.Events)-1].Timestamp
+	require.NoError(t, svc.IngestSession(context.Background(), sess), "IngestSession")
+	select {
+	case <-firstDone:
+	case <-time.After(time.Second):
+		t.Fatalf("first capture request did not complete")
+	}
+	waitForCondition(t, time.Second, func() bool {
+		svc.cursorMu.Lock()
+		defer svc.cursorMu.Unlock()
+		_, ok := svc.inFlight[svc.sessionKey(sess)]
+		return !ok
+	})
+	assert.True(t, readBestEffortLastCaptureAt(sess).IsZero())
+	require.NoError(t, svc.IngestSession(context.Background(), sess), "retry IngestSession")
+	select {
+	case <-secondDone:
+	case <-time.After(time.Second):
+		t.Fatalf("retry capture request did not complete")
+	}
+	require.NoError(t, svc.Close(), "Close")
+	assert.True(t, readBestEffortLastCaptureAt(sess).Equal(want))
+}
+
+func TestIngestSessionSerializesSameSessionCapturesAndTimestamps(t *testing.T) {
+	releaseFirst := make(chan struct{})
+	firstReqC := make(chan captureRequest, 1)
+	secondReqC := make(chan captureRequest, 1)
+	var released atomic.Bool
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != pathCapture {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		var req captureRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		switch requests.Add(1) {
+		case 1:
+			firstReqC <- req
+			<-releaseFirst
+		case 2:
+			secondReqC <- req
+		default:
+			t.Fatalf("unexpected extra capture request")
+		}
+		_ = json.NewEncoder(w).Encode(captureResponse{L0Recorded: len(req.Messages)})
+	}))
+	defer server.Close()
+	defer func() {
+		if released.CompareAndSwap(false, true) {
+			close(releaseFirst)
+		}
+	}()
+
+	svc, err := NewService(
+		WithGatewayURL(server.URL),
+		WithIngestWorkers(2),
+		WithIngestQueueSize(2),
+		WithIngestJobTimeout(time.Second),
+	)
+	require.NoError(t, err, "NewService")
+	defer func() {
+		assert.NoError(t, svc.Close())
+	}()
+	sess := captureReadySession()
+	require.NoError(t, svc.IngestSession(context.Background(), sess), "first IngestSession")
+	firstReq := waitCaptureRequest(t, firstReqC, "first capture")
+
+	events := sess.GetEvents()
+	nextAt := events[len(events)-1].Timestamp.Add(time.Second)
+	appendSessionPair(sess, nextAt, "u2", "second fact", "a2", "stored second")
+	require.NoError(t, svc.IngestSession(context.Background(), sess), "second IngestSession")
+	select {
+	case req := <-secondReqC:
+		t.Fatalf("second capture started before first completed: %#v", req)
+	case <-time.After(50 * time.Millisecond):
+	}
+	if released.CompareAndSwap(false, true) {
+		close(releaseFirst)
+	}
+	secondReq := waitCaptureRequest(t, secondReqC, "second capture")
+	require.NotEmpty(t, firstReq.Messages)
+	require.NotEmpty(t, secondReq.Messages)
+	firstLast := firstReq.Messages[len(firstReq.Messages)-1].Timestamp
+	assert.Greater(t, secondReq.Messages[0].Timestamp, firstLast)
+	assert.Equal(t, "second fact", secondReq.UserContent)
+	assert.Equal(t, "stored second", secondReq.AssistantContent)
+}
+
+func TestEndSessionWaitsForPendingCapture(t *testing.T) {
+	releaseCapture := make(chan struct{})
+	captureStarted := make(chan struct{}, 1)
+	endCalled := make(chan struct{}, 1)
+	var released atomic.Bool
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case pathCapture:
+			requests.Add(1)
+			select {
+			case captureStarted <- struct{}{}:
+			default:
+			}
+			<-releaseCapture
+			_ = json.NewEncoder(w).Encode(captureResponse{L0Recorded: 2})
+		case pathEndSession:
+			if got := requests.Load(); got != 1 {
+				t.Fatalf("end called before capture request: captures=%d", got)
+			}
+			select {
+			case endCalled <- struct{}{}:
+			default:
+			}
+			_ = json.NewEncoder(w).Encode(endSessionResponse{Flushed: true})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	svc, err := NewService(
+		WithGatewayURL(server.URL),
+		WithIngestWorkers(2),
+		WithIngestQueueSize(2),
+		WithIngestJobTimeout(time.Second),
+	)
+	require.NoError(t, err, "NewService")
+	defer func() {
+		if released.CompareAndSwap(false, true) {
+			close(releaseCapture)
+		}
+		assert.NoError(t, svc.Close())
+	}()
+
+	sess := captureReadySession()
+	require.NoError(t, svc.IngestSession(context.Background(), sess), "IngestSession")
+	select {
+	case <-captureStarted:
+	case <-time.After(time.Second):
+		t.Fatalf("capture request did not start")
+	}
+	endDone := make(chan error, 1)
+	go func() {
+		endDone <- svc.EndSession(context.Background(), sess)
+	}()
+	select {
+	case <-endCalled:
+		t.Fatalf("end session reached gateway before capture completed")
+	case <-time.After(50 * time.Millisecond):
+	}
+	if released.CompareAndSwap(false, true) {
+		close(releaseCapture)
+	}
+	select {
+	case err := <-endDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatalf("EndSession did not complete")
+	}
+	select {
+	case <-endCalled:
+	default:
+		t.Fatalf("end session gateway call was not observed")
+	}
+}
+
+func TestServiceCheckpointSkipsReloadedSessionEvents(t *testing.T) {
+	requests := make(chan captureRequest, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != pathCapture {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		var req captureRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		requests <- req
+		_ = json.NewEncoder(w).Encode(captureResponse{L0Recorded: len(req.Messages)})
+	}))
+	defer server.Close()
+
+	svc, err := NewService(
+		WithGatewayURL(server.URL),
+		WithIngestQueueSize(2),
+		WithIngestJobTimeout(time.Second),
+	)
+	require.NoError(t, err, "NewService")
+	defer func() {
+		assert.NoError(t, svc.Close())
+	}()
+
+	sess := captureReadySession()
+	require.NoError(t, svc.IngestSession(context.Background(), sess), "first IngestSession")
+	_ = waitCaptureRequest(t, requests, "first capture")
+	reloaded := &session.Session{
+		ID:      sess.ID,
+		AppName: sess.AppName,
+		UserID:  sess.UserID,
+		Events:  sess.GetEvents(),
+		State:   session.StateMap{},
+	}
+	require.NoError(t, svc.IngestSession(context.Background(), reloaded), "reloaded IngestSession")
+	select {
+	case req := <-requests:
+		t.Fatalf("reloaded session resent captured events: %#v", req)
+	case <-time.After(50 * time.Millisecond):
+	}
+}

--- a/memory/tencentdb/ingest_test.go
+++ b/memory/tencentdb/ingest_test.go
@@ -365,3 +365,69 @@ func TestServiceCheckpointSkipsReloadedSessionEvents(t *testing.T) {
 	case <-time.After(50 * time.Millisecond):
 	}
 }
+
+func TestEndSessionRetainsCaptureCheckpoint(t *testing.T) {
+	requests := make(chan captureRequest, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case pathCapture:
+			var req captureRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode request: %v", err)
+			}
+			requests <- req
+			_ = json.NewEncoder(w).Encode(captureResponse{L0Recorded: len(req.Messages)})
+		case pathEndSession:
+			_ = json.NewEncoder(w).Encode(endSessionResponse{Flushed: true})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	svc, err := NewService(
+		WithGatewayURL(server.URL),
+		WithIngestQueueSize(2),
+		WithIngestJobTimeout(time.Second),
+	)
+	require.NoError(t, err, "NewService")
+	defer func() {
+		assert.NoError(t, svc.Close())
+	}()
+
+	sess := captureReadySession()
+	require.NoError(t, svc.IngestSession(context.Background(), sess), "IngestSession")
+	_ = waitCaptureRequest(t, requests, "initial capture")
+
+	sessionKey := svc.sessionKey(sess)
+	waitForCondition(t, time.Second, func() bool {
+		svc.cursorMu.Lock()
+		defer svc.cursorMu.Unlock()
+		_, ok := svc.lastCapture[sessionKey]
+		return ok
+	})
+
+	require.NoError(t, svc.EndSession(context.Background(), sess), "EndSession")
+
+	svc.cursorMu.Lock()
+	_, retained := svc.lastCapture[sessionKey]
+	svc.cursorMu.Unlock()
+	assert.True(t, retained, "capture checkpoint should be retained after EndSession")
+
+	// A session that keeps running (here modeled as a reload without the
+	// in-state cursor) must not resend already captured transcript, because the
+	// service-level checkpoint survives EndSession.
+	reloaded := &session.Session{
+		ID:      sess.ID,
+		AppName: sess.AppName,
+		UserID:  sess.UserID,
+		Events:  sess.GetEvents(),
+		State:   session.StateMap{},
+	}
+	require.NoError(t, svc.IngestSession(context.Background(), reloaded), "reloaded IngestSession")
+	select {
+	case req := <-requests:
+		t.Fatalf("session resent captured events after EndSession: %#v", req)
+	case <-time.After(50 * time.Millisecond):
+	}
+}

--- a/memory/tencentdb/options.go
+++ b/memory/tencentdb/options.go
@@ -13,6 +13,7 @@ package tencentdb
 
 import (
 	"net/http"
+	"strings"
 	"time"
 
 	"trpc.group/trpc-go/trpc-agent-go/session"
@@ -42,9 +43,15 @@ type Options struct {
 	IngestQueueSize  int
 	IngestJobTimeout time.Duration
 
+	// APIKey is sent as an "Authorization: Bearer <key>" header on gateway
+	// requests. It is required when the gateway is started with
+	// TDAI_GATEWAY_API_KEY.
+	APIKey string
+
 	SessionKeyFunc SessionKeyFunc
 
 	RecallEnabled                bool
+	EnableMemorySearchTool       bool
 	EnableConversationSearchTool bool
 	EnableStandardAliases        bool
 	ToolPrefix                   string
@@ -53,6 +60,11 @@ type Options struct {
 // Option configures Service.
 type Option func(*Options)
 
+// defaultOptions returns conservative defaults. Cross-session/user reads are
+// opt-in: automatic recall and the long-term memory_search tool stay disabled
+// because the shared gateway sidecar does not currently enforce user/session
+// scoping on those paths. Only session-scoped surfaces (capture and
+// conversation search) are enabled by default.
 func defaultOptions() Options {
 	return Options{
 		GatewayURL:                   defaultGatewayURL,
@@ -62,7 +74,8 @@ func defaultOptions() Options {
 		IngestQueueSize:              defaultIngestQueueSize,
 		IngestJobTimeout:             defaultIngestJobTimeout,
 		SessionKeyFunc:               defaultSessionKey,
-		RecallEnabled:                true,
+		RecallEnabled:                false,
+		EnableMemorySearchTool:       false,
 		EnableConversationSearchTool: true,
 		ToolPrefix:                   "tdai",
 	}
@@ -104,6 +117,18 @@ func WithMaxBodyBytes(max int64) Option {
 	}
 }
 
+// WithAPIKey sets the gateway API key. When the gateway is started with
+// TDAI_GATEWAY_API_KEY it requires an "Authorization: Bearer <key>" header on
+// every non-health route, so capture, recall, search, and session-end requests
+// return 401 without it even though the health check still passes.
+func WithAPIKey(key string) Option {
+	return func(o *Options) {
+		if k := strings.TrimSpace(key); k != "" {
+			o.APIKey = k
+		}
+	}
+}
+
 // WithIngestWorkers sets the number of async capture workers.
 func WithIngestWorkers(n int) Option {
 	return func(o *Options) {
@@ -141,9 +166,27 @@ func WithSessionKeyFunc(fn SessionKeyFunc) Option {
 }
 
 // WithRecallEnabled controls whether Plugin performs automatic recall.
+//
+// It is off by default: the gateway currently recalls from a shared long-term
+// store without enforcing the request's user/session scope, so on a shared
+// sidecar automatic recall can surface another user's or session's memories.
+// Only enable it when the gateway guarantees per-tenant isolation.
 func WithRecallEnabled(enabled bool) Option {
 	return func(o *Options) {
 		o.RecallEnabled = enabled
+	}
+}
+
+// WithMemorySearchTool controls whether the long-term memory_search tool
+// (tdai_memory_search, plus the standard alias when enabled) is exposed.
+//
+// It is off by default for the same reason as recall: the gateway memory search
+// does not enforce user/session scoping, so the tool can read a shared
+// long-term store. Only enable it when the gateway guarantees per-tenant
+// isolation. The session-scoped conversation search tool stays available.
+func WithMemorySearchTool(enabled bool) Option {
+	return func(o *Options) {
+		o.EnableMemorySearchTool = enabled
 	}
 }
 
@@ -157,7 +200,8 @@ func WithConversationSearchTool(enabled bool) Option {
 // WithStandardAliases exposes memory_search as an additional alias.
 //
 // This can conflict with the framework's built-in memory tools, so it is off by
-// default. TencentDB-native tdai_* names are always preferred.
+// default. TencentDB-native tdai_* names are always preferred. The alias is
+// only exposed when the memory search tool is enabled via WithMemorySearchTool.
 func WithStandardAliases(enabled bool) Option {
 	return func(o *Options) {
 		o.EnableStandardAliases = enabled

--- a/memory/tencentdb/options.go
+++ b/memory/tencentdb/options.go
@@ -1,0 +1,175 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package tencentdb integrates with TencentDB Agent Memory through its
+// local gateway sidecar.
+package tencentdb
+
+import (
+	"net/http"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+const (
+	defaultGatewayURL       = "http://127.0.0.1:8420"
+	defaultTimeout          = 5 * time.Second
+	defaultMaxBodyBytes     = 10 << 20
+	defaultIngestWorkers    = 1
+	defaultIngestQueueSize  = 10
+	defaultIngestJobTimeout = 30 * time.Second
+)
+
+// SessionKeyFunc maps a framework session to the TencentDB Agent Memory
+// session_key. The default avoids collisions across app/user/session IDs but
+// does not provide strong multi-tenant isolation in a shared sidecar.
+type SessionKeyFunc func(*session.Session) string
+
+// Options configures Service.
+type Options struct {
+	GatewayURL       string
+	Timeout          time.Duration
+	HTTPClient       *http.Client
+	MaxBodyBytes     int64
+	IngestWorkers    int
+	IngestQueueSize  int
+	IngestJobTimeout time.Duration
+
+	SessionKeyFunc SessionKeyFunc
+
+	RecallEnabled                bool
+	EnableConversationSearchTool bool
+	EnableStandardAliases        bool
+	ToolPrefix                   string
+}
+
+// Option configures Service.
+type Option func(*Options)
+
+func defaultOptions() Options {
+	return Options{
+		GatewayURL:                   defaultGatewayURL,
+		Timeout:                      defaultTimeout,
+		MaxBodyBytes:                 defaultMaxBodyBytes,
+		IngestWorkers:                defaultIngestWorkers,
+		IngestQueueSize:              defaultIngestQueueSize,
+		IngestJobTimeout:             defaultIngestJobTimeout,
+		SessionKeyFunc:               defaultSessionKey,
+		RecallEnabled:                true,
+		EnableConversationSearchTool: true,
+		ToolPrefix:                   "tdai",
+	}
+}
+
+// WithGatewayURL sets the TencentDB Agent Memory gateway URL.
+func WithGatewayURL(url string) Option {
+	return func(o *Options) {
+		if url != "" {
+			o.GatewayURL = url
+		}
+	}
+}
+
+// WithTimeout sets the request timeout used by the gateway client.
+func WithTimeout(timeout time.Duration) Option {
+	return func(o *Options) {
+		if timeout > 0 {
+			o.Timeout = timeout
+		}
+	}
+}
+
+// WithHTTPClient injects a custom HTTP client.
+func WithHTTPClient(client *http.Client) Option {
+	return func(o *Options) {
+		if client != nil {
+			o.HTTPClient = client
+		}
+	}
+}
+
+// WithMaxBodyBytes limits gateway response bodies.
+func WithMaxBodyBytes(max int64) Option {
+	return func(o *Options) {
+		if max > 0 {
+			o.MaxBodyBytes = max
+		}
+	}
+}
+
+// WithIngestWorkers sets the number of async capture workers.
+func WithIngestWorkers(n int) Option {
+	return func(o *Options) {
+		if n > 0 {
+			o.IngestWorkers = n
+		}
+	}
+}
+
+// WithIngestQueueSize sets the per-worker capture queue size.
+func WithIngestQueueSize(size int) Option {
+	return func(o *Options) {
+		if size > 0 {
+			o.IngestQueueSize = size
+		}
+	}
+}
+
+// WithIngestJobTimeout sets the timeout applied to queued capture jobs.
+func WithIngestJobTimeout(timeout time.Duration) Option {
+	return func(o *Options) {
+		if timeout > 0 {
+			o.IngestJobTimeout = timeout
+		}
+	}
+}
+
+// WithSessionKeyFunc overrides the session_key mapping.
+func WithSessionKeyFunc(fn SessionKeyFunc) Option {
+	return func(o *Options) {
+		if fn != nil {
+			o.SessionKeyFunc = fn
+		}
+	}
+}
+
+// WithRecallEnabled controls whether Plugin performs automatic recall.
+func WithRecallEnabled(enabled bool) Option {
+	return func(o *Options) {
+		o.RecallEnabled = enabled
+	}
+}
+
+// WithConversationSearchTool controls whether tdai_conversation_search is exposed.
+func WithConversationSearchTool(enabled bool) Option {
+	return func(o *Options) {
+		o.EnableConversationSearchTool = enabled
+	}
+}
+
+// WithStandardAliases exposes memory_search as an additional alias.
+//
+// This can conflict with the framework's built-in memory tools, so it is off by
+// default. TencentDB-native tdai_* names are always preferred.
+func WithStandardAliases(enabled bool) Option {
+	return func(o *Options) {
+		o.EnableStandardAliases = enabled
+	}
+}
+
+// WithToolPrefix changes the native tool name prefix. The default prefix "tdai"
+// yields tdai_memory_search and tdai_conversation_search.
+func WithToolPrefix(prefix string) Option {
+	return func(o *Options) {
+		if prefix != "" {
+			o.ToolPrefix = prefix
+		}
+	}
+}

--- a/memory/tencentdb/plugin.go
+++ b/memory/tencentdb/plugin.go
@@ -1,0 +1,73 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package tencentdb
+
+import (
+	"context"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/log"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/plugin"
+)
+
+var _ plugin.Plugin = (*recallPlugin)(nil)
+
+// Plugin returns a runner plugin that injects recalled TencentDB Agent Memory
+// context before model calls.
+func (s *Service) Plugin() plugin.Plugin {
+	return &recallPlugin{service: s}
+}
+
+type recallPlugin struct {
+	service *Service
+}
+
+func (p *recallPlugin) Name() string {
+	return "tencentdb_agent_memory"
+}
+
+func (p *recallPlugin) Register(r *plugin.Registry) {
+	if p == nil || p.service == nil || !p.service.opts.RecallEnabled {
+		return
+	}
+	r.BeforeModel(p.beforeModel)
+}
+
+func (p *recallPlugin) beforeModel(
+	ctx context.Context,
+	args *model.BeforeModelArgs,
+) (*model.BeforeModelResult, error) {
+	if args == nil || args.Request == nil {
+		return nil, nil
+	}
+	inv, ok := agent.InvocationFromContext(ctx)
+	if !ok || inv == nil || inv.Session == nil {
+		return nil, nil
+	}
+	if err := validateSessionScope(inv.Session); err != nil {
+		return nil, nil
+	}
+	query := latestUserText(args.Request)
+	if query == "" {
+		return nil, nil
+	}
+	rsp, err := p.service.client.recall(ctx, recallRequest{
+		Query:      query,
+		SessionKey: p.service.sessionKey(inv.Session),
+		UserID:     inv.Session.UserID,
+	})
+	if err != nil {
+		log.Warnf("tencentdb memory: recall failed: %v", err)
+		return nil, nil
+	}
+	injectRecallContext(args.Request, rsp)
+	return nil, nil
+}

--- a/memory/tencentdb/plugin_test.go
+++ b/memory/tencentdb/plugin_test.go
@@ -1,0 +1,126 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package tencentdb
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	pluginpkg "trpc.group/trpc-go/trpc-agent-go/plugin"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+func TestInjectRecallContext(t *testing.T) {
+	req := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("base"),
+		model.NewUserMessage("hello"),
+	}}
+	injectRecallContext(req, &recallResponse{
+		AppendSystemContext: "system recall",
+		PrependContext:      "user recall",
+	})
+
+	require.Len(t, req.Messages, 3)
+	assert.Equal(t, model.RoleSystem, req.Messages[0].Role)
+	assert.Equal(t, "base\n\nsystem recall", req.Messages[0].Content)
+	assert.Equal(t, model.RoleUser, req.Messages[1].Role)
+	assert.Equal(t, "user recall", req.Messages[1].Content)
+	assert.Equal(t, "hello", req.Messages[2].Content)
+}
+
+func TestRecallPluginInjectsContext(t *testing.T) {
+	var got recallRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, pathRecall, r.URL.Path)
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+		_ = json.NewEncoder(w).Encode(recallResponse{
+			AppendSystemContext: "remembered system",
+			PrependContext:      "remembered user context",
+		})
+	}))
+	defer server.Close()
+
+	svc, err := NewService(WithGatewayURL(server.URL))
+	require.NoError(t, err, "NewService")
+	defer svc.Close()
+
+	p := svc.Plugin()
+	assert.Equal(t, "tencentdb_agent_memory", p.Name())
+	mgr, err := pluginpkg.NewManager(p)
+	require.NoError(t, err, "NewManager")
+	callbacks := mgr.ModelCallbacks()
+	require.NotNil(t, callbacks)
+	require.Len(t, callbacks.BeforeModel, 1)
+
+	req := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("base"),
+		model.NewUserMessage("what did I say?"),
+	}}
+	sess := &session.Session{ID: "s1", AppName: "app", UserID: "user"}
+	ctx := agent.NewInvocationContext(context.Background(), &agent.Invocation{Session: sess}).Context
+	_, err = callbacks.BeforeModel[0](ctx, &model.BeforeModelArgs{Request: req})
+	require.NoError(t, err)
+
+	assert.Equal(t, recallRequest{Query: "what did I say?", SessionKey: "app:user:s1", UserID: "user"}, got)
+	require.Len(t, req.Messages, 3)
+	assert.Equal(t, "base\n\nremembered system", req.Messages[0].Content)
+	assert.Equal(t, "remembered user context", req.Messages[1].Content)
+}
+
+func TestRecallAndPluginEdges(t *testing.T) {
+	assert.Empty(t, latestUserText(nil))
+	assert.Empty(t, latestUserText(&model.Request{Messages: []model.Message{model.NewSystemMessage("sys")}}))
+
+	empty := &model.Request{}
+	injectRecallContext(empty, &recallResponse{Context: "legacy context"})
+	require.Len(t, empty.Messages, 1)
+	assert.Equal(t, model.RoleSystem, empty.Messages[0].Role)
+
+	noSystem := &model.Request{Messages: []model.Message{model.NewAssistantMessage("hi")}}
+	injectRecallContext(noSystem, &recallResponse{AppendSystemContext: "sys", PrependContext: "ctx"})
+	require.Len(t, noSystem.Messages, 3)
+	assert.Equal(t, model.RoleSystem, noSystem.Messages[0].Role)
+	assert.Equal(t, "sys", noSystem.Messages[0].Content)
+	assert.Equal(t, "ctx", noSystem.Messages[2].Content)
+	insertBeforeLatestUser(nil, model.NewUserMessage("ignored"))
+
+	svc := &Service{opts: defaultOptions(), client: &gatewayClient{}}
+	p := &recallPlugin{service: svc}
+	_, err := p.beforeModel(context.Background(), nil)
+	require.NoError(t, err)
+	_, err = p.beforeModel(context.Background(), &model.BeforeModelArgs{})
+	require.NoError(t, err)
+	_, err = p.beforeModel(context.Background(), &model.BeforeModelArgs{
+		Request: &model.Request{Messages: []model.Message{model.NewUserMessage("q")}},
+	})
+	require.NoError(t, err)
+	ctx := agent.NewInvocationContext(context.Background(), &agent.Invocation{
+		Session: &session.Session{ID: "s", AppName: "app", UserID: "user"},
+	}).Context
+	_, err = p.beforeModel(ctx, &model.BeforeModelArgs{
+		Request: &model.Request{Messages: []model.Message{model.NewSystemMessage("sys")}},
+	})
+	require.NoError(t, err)
+	badScope := agent.NewInvocationContext(context.Background(), &agent.Invocation{
+		Session: &session.Session{ID: "s", AppName: "app"},
+	}).Context
+	_, err = p.beforeModel(badScope, &model.BeforeModelArgs{
+		Request: &model.Request{Messages: []model.Message{model.NewUserMessage("q")}},
+	})
+	require.NoError(t, err)
+}

--- a/memory/tencentdb/plugin_test.go
+++ b/memory/tencentdb/plugin_test.go
@@ -76,7 +76,7 @@ func TestRecallPluginInjectsContext(t *testing.T) {
 	_, err = callbacks.BeforeModel[0](ctx, &model.BeforeModelArgs{Request: req})
 	require.NoError(t, err)
 
-	assert.Equal(t, recallRequest{Query: "what did I say?", SessionKey: "app:user:s1", UserID: "user"}, got)
+	assert.Equal(t, recallRequest{Query: "what did I say?", SessionKey: defaultSessionKey(sess), UserID: "user"}, got)
 	require.Len(t, req.Messages, 3)
 	assert.Equal(t, "base\n\nremembered system", req.Messages[0].Content)
 	assert.Equal(t, "remembered user context", req.Messages[1].Content)

--- a/memory/tencentdb/plugin_test.go
+++ b/memory/tencentdb/plugin_test.go
@@ -55,7 +55,7 @@ func TestRecallPluginInjectsContext(t *testing.T) {
 	}))
 	defer server.Close()
 
-	svc, err := NewService(WithGatewayURL(server.URL))
+	svc, err := NewService(WithGatewayURL(server.URL), WithRecallEnabled(true))
 	require.NoError(t, err, "NewService")
 	defer svc.Close()
 

--- a/memory/tencentdb/recall.go
+++ b/memory/tencentdb/recall.go
@@ -1,0 +1,95 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package tencentdb
+
+import (
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+func latestUserText(req *model.Request) string {
+	if req == nil {
+		return ""
+	}
+	for i := len(req.Messages) - 1; i >= 0; i-- {
+		msg := req.Messages[i]
+		if msg.Role != model.RoleUser {
+			continue
+		}
+		if text := messageText(msg); text != "" {
+			return text
+		}
+	}
+	return ""
+}
+
+func injectRecallContext(req *model.Request, rsp *recallResponse) {
+	if req == nil || rsp == nil {
+		return
+	}
+	if sys := strings.TrimSpace(firstNonEmpty(
+		rsp.AppendSystemContext,
+		rsp.Context,
+	)); sys != "" {
+		prependOrMergeSystem(req, sys)
+	}
+	if userCtx := strings.TrimSpace(rsp.PrependContext); userCtx != "" {
+		insertBeforeLatestUser(req, model.NewUserMessage(userCtx))
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func prependOrMergeSystem(req *model.Request, text string) {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return
+	}
+	msg := model.NewSystemMessage(text)
+	if len(req.Messages) == 0 {
+		req.Messages = []model.Message{msg}
+		return
+	}
+	for i := range req.Messages {
+		if req.Messages[i].Role != model.RoleSystem {
+			continue
+		}
+		existing := strings.TrimSpace(req.Messages[i].Content)
+		if existing == "" {
+			req.Messages[i].Content = text
+		} else {
+			req.Messages[i].Content = existing + "\n\n" + text
+		}
+		return
+	}
+	req.Messages = append([]model.Message{msg}, req.Messages...)
+}
+
+func insertBeforeLatestUser(req *model.Request, msg model.Message) {
+	if req == nil {
+		return
+	}
+	for i := len(req.Messages) - 1; i >= 0; i-- {
+		if req.Messages[i].Role != model.RoleUser {
+			continue
+		}
+		req.Messages = append(req.Messages[:i], append([]model.Message{msg}, req.Messages[i:]...)...)
+		return
+	}
+	req.Messages = append(req.Messages, msg)
+}

--- a/memory/tencentdb/service.go
+++ b/memory/tencentdb/service.go
@@ -319,7 +319,11 @@ func (s *Service) waitForPreviousCapture(ctx context.Context, serial *captureSer
 	select {
 	case <-serial.previous.done:
 		if serial.previous.err != nil {
-			return fmt.Errorf("tencentdb memory: previous capture failed for session_key %q", serial.sessionKey)
+			return fmt.Errorf(
+				"tencentdb memory: previous capture failed for session_key %q: %w",
+				serial.sessionKey,
+				serial.previous.err,
+			)
 		}
 		return nil
 	case <-ctx.Done():

--- a/memory/tencentdb/service.go
+++ b/memory/tencentdb/service.go
@@ -38,6 +38,9 @@ type Service struct {
 	wg     sync.WaitGroup
 	once   sync.Once
 
+	cursorMu sync.Mutex
+	inFlight map[string]time.Time
+
 	tools []tool.Tool
 }
 
@@ -54,9 +57,10 @@ func NewService(opts ...Option) (*Service, error) {
 		return nil, err
 	}
 	s := &Service{
-		opts:   options,
-		client: client,
-		queue:  make(chan ingestJob, options.IngestQueueSize),
+		opts:     options,
+		client:   client,
+		queue:    make(chan ingestJob, options.IngestQueueSize),
+		inFlight: make(map[string]time.Time),
 	}
 	s.tools = s.buildTools()
 	s.startWorkers()
@@ -80,42 +84,26 @@ func (s *Service) IngestSession(
 		return err
 	}
 
-	scan := scanTranscript(sess, readBestEffortLastCaptureAt(sess))
-	if len(scan.Messages) == 0 {
-		return nil
-	}
-	userContent, assistantContent := lastUserAssistantPair(scan.Messages)
-	if strings.TrimSpace(userContent) == "" || strings.TrimSpace(assistantContent) == "" {
-		return nil
-	}
-
-	req := captureRequest{
-		UserContent:      userContent,
-		AssistantContent: assistantContent,
-		SessionKey:       s.sessionKey(sess),
-		SessionID:        sess.ID,
-		UserID:           sess.UserID,
-		Messages:         normalizeGatewayMessageTimestamps(scan.Messages, time.Now()),
-	}
-	job := ingestJob{
-		req:    req,
-		sess:   sess,
-		cursor: scan.Latest,
-	}
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	sessionKey := s.sessionKey(sess)
 	s.mu.RLock()
 	if s.closed {
 		s.mu.RUnlock()
 		return errors.New("tencentdb memory: service is closed")
 	}
+	job, ok := s.reserveIngestJob(sess, sessionKey)
+	if !ok {
+		s.mu.RUnlock()
+		return nil
+	}
 	select {
 	case s.queue <- job:
 		s.mu.RUnlock()
-		writeBestEffortLastCaptureAt(sess, scan.Latest)
 		return nil
 	case <-ctx.Done():
+		s.clearInFlight(sessionKey, job.cursor)
 		s.mu.RUnlock()
 		return ctx.Err()
 	}
@@ -211,8 +199,51 @@ func (s *Service) capture(ctx context.Context, job ingestJob) error {
 	}
 	_, err := s.client.capture(ctx, job.req)
 	if err != nil {
+		s.clearInFlight(job.req.SessionKey, job.cursor)
 		return fmt.Errorf("tencentdb memory: capture failed: %w", err)
 	}
 	writeBestEffortLastCaptureAt(job.sess, job.cursor)
+	s.clearInFlight(job.req.SessionKey, job.cursor)
 	return nil
+}
+
+func (s *Service) reserveIngestJob(sess *session.Session, sessionKey string) (ingestJob, bool) {
+	s.cursorMu.Lock()
+	defer s.cursorMu.Unlock()
+
+	since := readBestEffortLastCaptureAt(sess)
+	if inFlight, ok := s.inFlight[sessionKey]; ok && inFlight.After(since) {
+		since = inFlight
+	}
+	scan := scanTranscript(sess, since)
+	if len(scan.Messages) == 0 {
+		return ingestJob{}, false
+	}
+	userContent, assistantContent := lastUserAssistantPair(scan.Messages)
+	if strings.TrimSpace(userContent) == "" || strings.TrimSpace(assistantContent) == "" {
+		return ingestJob{}, false
+	}
+	if current, ok := s.inFlight[sessionKey]; !ok || scan.Latest.After(current) {
+		s.inFlight[sessionKey] = scan.Latest
+	}
+	return ingestJob{
+		req: captureRequest{
+			UserContent:      userContent,
+			AssistantContent: assistantContent,
+			SessionKey:       sessionKey,
+			SessionID:        sess.ID,
+			UserID:           sess.UserID,
+			Messages:         normalizeGatewayMessageTimestamps(scan.Messages, time.Now()),
+		},
+		sess:   sess,
+		cursor: scan.Latest,
+	}, true
+}
+
+func (s *Service) clearInFlight(sessionKey string, cursor time.Time) {
+	s.cursorMu.Lock()
+	defer s.cursorMu.Unlock()
+	if current, ok := s.inFlight[sessionKey]; ok && !current.After(cursor) {
+		delete(s.inFlight, sessionKey)
+	}
 }

--- a/memory/tencentdb/service.go
+++ b/memory/tencentdb/service.go
@@ -11,6 +11,7 @@ package tencentdb
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"strings"
@@ -199,6 +200,9 @@ func defaultSessionKey(sess *session.Session) string {
 		strings.TrimSpace(sess.AppName),
 		strings.TrimSpace(sess.UserID),
 		strings.TrimSpace(sess.ID),
+	}
+	for i, part := range parts {
+		parts[i] = base64.RawURLEncoding.EncodeToString([]byte(part))
 	}
 	return strings.Join(parts, ":")
 }

--- a/memory/tencentdb/service.go
+++ b/memory/tencentdb/service.go
@@ -38,10 +38,9 @@ type Service struct {
 	wg     sync.WaitGroup
 	once   sync.Once
 
-	cursorMu           sync.Mutex
-	inFlight           map[string]time.Time
-	serialTail         map[string]*captureSerialState
-	syntheticTimestamp map[string]int64
+	cursorMu   sync.Mutex
+	inFlight   map[string]time.Time
+	serialTail map[string]*captureSerialState
 
 	tools []tool.Tool
 }
@@ -59,12 +58,11 @@ func NewService(opts ...Option) (*Service, error) {
 		return nil, err
 	}
 	s := &Service{
-		opts:               options,
-		client:             client,
-		queue:              make(chan ingestJob, options.IngestQueueSize),
-		inFlight:           make(map[string]time.Time),
-		serialTail:         make(map[string]*captureSerialState),
-		syntheticTimestamp: make(map[string]int64),
+		opts:       options,
+		client:     client,
+		queue:      make(chan ingestJob, options.IngestQueueSize),
+		inFlight:   make(map[string]time.Time),
+		serialTail: make(map[string]*captureSerialState),
 	}
 	s.tools = s.buildTools()
 	s.startWorkers()
@@ -129,6 +127,9 @@ func (s *Service) EndSession(ctx context.Context, sess *session.Session) error {
 		SessionKey: s.sessionKey(sess),
 		UserID:     sess.UserID,
 	})
+	if err == nil {
+		clearBestEffortSyntheticTimestamp(sess)
+	}
 	return err
 }
 
@@ -247,9 +248,9 @@ func (s *Service) reserveIngestJob(sess *session.Session, sessionKey string) (in
 	messages, latestSynthetic := normalizeGatewayMessageTimestampsAfter(
 		scan.Messages,
 		time.Now(),
-		s.syntheticTimestamp[sessionKey],
+		readBestEffortSyntheticTimestamp(sess),
 	)
-	s.syntheticTimestamp[sessionKey] = latestSynthetic
+	writeBestEffortSyntheticTimestamp(sess, latestSynthetic)
 	previous := s.serialTail[sessionKey]
 	serial := &captureSerialState{done: make(chan struct{})}
 	s.serialTail[sessionKey] = serial

--- a/memory/tencentdb/service.go
+++ b/memory/tencentdb/service.go
@@ -38,8 +38,10 @@ type Service struct {
 	wg     sync.WaitGroup
 	once   sync.Once
 
-	cursorMu sync.Mutex
-	inFlight map[string]time.Time
+	cursorMu           sync.Mutex
+	inFlight           map[string]time.Time
+	serialTail         map[string]*captureSerialState
+	syntheticTimestamp map[string]int64
 
 	tools []tool.Tool
 }
@@ -57,10 +59,12 @@ func NewService(opts ...Option) (*Service, error) {
 		return nil, err
 	}
 	s := &Service{
-		opts:     options,
-		client:   client,
-		queue:    make(chan ingestJob, options.IngestQueueSize),
-		inFlight: make(map[string]time.Time),
+		opts:               options,
+		client:             client,
+		queue:              make(chan ingestJob, options.IngestQueueSize),
+		inFlight:           make(map[string]time.Time),
+		serialTail:         make(map[string]*captureSerialState),
+		syntheticTimestamp: make(map[string]int64),
 	}
 	s.tools = s.buildTools()
 	s.startWorkers()
@@ -103,7 +107,7 @@ func (s *Service) IngestSession(
 		s.mu.RUnlock()
 		return nil
 	case <-ctx.Done():
-		s.clearInFlight(sessionKey, job.cursor)
+		s.finishCaptureJob(job, ctx.Err())
 		s.mu.RUnlock()
 		return ctx.Err()
 	}
@@ -197,13 +201,27 @@ func (s *Service) capture(ctx context.Context, job ingestJob) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	if job.previous != nil {
+		select {
+		case <-job.previous.done:
+			if job.previous.err != nil {
+				err := fmt.Errorf("tencentdb memory: previous capture failed for session_key %q", job.req.SessionKey)
+				s.finishCaptureJob(job, err)
+				return err
+			}
+		case <-ctx.Done():
+			s.finishCaptureJob(job, ctx.Err())
+			return ctx.Err()
+		}
+	}
 	_, err := s.client.capture(ctx, job.req)
 	if err != nil {
-		s.clearInFlight(job.req.SessionKey, job.cursor)
-		return fmt.Errorf("tencentdb memory: capture failed: %w", err)
+		err = fmt.Errorf("tencentdb memory: capture failed: %w", err)
+		s.finishCaptureJob(job, err)
+		return err
 	}
 	writeBestEffortLastCaptureAt(job.sess, job.cursor)
-	s.clearInFlight(job.req.SessionKey, job.cursor)
+	s.finishCaptureJob(job, nil)
 	return nil
 }
 
@@ -226,6 +244,15 @@ func (s *Service) reserveIngestJob(sess *session.Session, sessionKey string) (in
 	if current, ok := s.inFlight[sessionKey]; !ok || scan.Latest.After(current) {
 		s.inFlight[sessionKey] = scan.Latest
 	}
+	messages, latestSynthetic := normalizeGatewayMessageTimestampsAfter(
+		scan.Messages,
+		time.Now(),
+		s.syntheticTimestamp[sessionKey],
+	)
+	s.syntheticTimestamp[sessionKey] = latestSynthetic
+	previous := s.serialTail[sessionKey]
+	serial := &captureSerialState{done: make(chan struct{})}
+	s.serialTail[sessionKey] = serial
 	return ingestJob{
 		req: captureRequest{
 			UserContent:      userContent,
@@ -233,17 +260,26 @@ func (s *Service) reserveIngestJob(sess *session.Session, sessionKey string) (in
 			SessionKey:       sessionKey,
 			SessionID:        sess.ID,
 			UserID:           sess.UserID,
-			Messages:         normalizeGatewayMessageTimestamps(scan.Messages, time.Now()),
+			Messages:         messages,
 		},
-		sess:   sess,
-		cursor: scan.Latest,
+		sess:     sess,
+		cursor:   scan.Latest,
+		previous: previous,
+		serial:   serial,
 	}, true
 }
 
-func (s *Service) clearInFlight(sessionKey string, cursor time.Time) {
+func (s *Service) finishCaptureJob(job ingestJob, err error) {
 	s.cursorMu.Lock()
 	defer s.cursorMu.Unlock()
-	if current, ok := s.inFlight[sessionKey]; ok && !current.After(cursor) {
-		delete(s.inFlight, sessionKey)
+	if current, ok := s.inFlight[job.req.SessionKey]; ok && !current.After(job.cursor) {
+		delete(s.inFlight, job.req.SessionKey)
+	}
+	if job.serial != nil {
+		job.serial.err = err
+		if s.serialTail[job.req.SessionKey] == job.serial {
+			delete(s.serialTail, job.req.SessionKey)
+		}
+		close(job.serial.done)
 	}
 }

--- a/memory/tencentdb/service.go
+++ b/memory/tencentdb/service.go
@@ -1,0 +1,217 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package tencentdb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+var _ session.Ingestor = (*Service)(nil)
+
+// Service is a TencentDB Agent Memory gateway adapter.
+//
+// The current TencentDB SDK gateway is best treated as a trusted sidecar. The
+// adapter forwards app/user/session identifiers, but hard multi-tenant isolation
+// depends on the gateway and SDK honoring those fields end-to-end.
+type Service struct {
+	opts   Options
+	client *gatewayClient
+
+	queue  chan ingestJob
+	mu     sync.RWMutex
+	closed bool
+	wg     sync.WaitGroup
+	once   sync.Once
+
+	tools []tool.Tool
+}
+
+// NewService creates a TencentDB Agent Memory service.
+func NewService(opts ...Option) (*Service, error) {
+	options := defaultOptions()
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&options)
+		}
+	}
+	client, err := newGatewayClient(options)
+	if err != nil {
+		return nil, err
+	}
+	s := &Service{
+		opts:   options,
+		client: client,
+		queue:  make(chan ingestJob, options.IngestQueueSize),
+	}
+	s.tools = s.buildTools()
+	s.startWorkers()
+	return s, nil
+}
+
+// IngestSession captures the latest user/assistant exchange and transcript
+// messages into the TencentDB Agent Memory gateway.
+func (s *Service) IngestSession(
+	ctx context.Context,
+	sess *session.Session,
+	opts ...session.IngestOption,
+) error {
+	if s == nil {
+		return errors.New("tencentdb memory: nil service")
+	}
+	if sess == nil {
+		return errors.New("tencentdb memory: session is required")
+	}
+	if err := validateSessionScope(sess); err != nil {
+		return err
+	}
+
+	scan := scanTranscript(sess, readBestEffortLastCaptureAt(sess))
+	if len(scan.Messages) == 0 {
+		return nil
+	}
+	userContent, assistantContent := lastUserAssistantPair(scan.Messages)
+	if strings.TrimSpace(userContent) == "" || strings.TrimSpace(assistantContent) == "" {
+		return nil
+	}
+
+	req := captureRequest{
+		UserContent:      userContent,
+		AssistantContent: assistantContent,
+		SessionKey:       s.sessionKey(sess),
+		SessionID:        sess.ID,
+		UserID:           sess.UserID,
+		Messages:         normalizeGatewayMessageTimestamps(scan.Messages, time.Now()),
+	}
+	job := ingestJob{
+		req:    req,
+		sess:   sess,
+		cursor: scan.Latest,
+	}
+	s.mu.RLock()
+	if s.closed {
+		s.mu.RUnlock()
+		return errors.New("tencentdb memory: service is closed")
+	}
+	select {
+	case s.queue <- job:
+		s.mu.RUnlock()
+		return nil
+	default:
+		s.mu.RUnlock()
+		if err := s.capture(ctx, job); err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+// EndSession flushes short-term session state managed by the sidecar, if
+// supported by the gateway.
+func (s *Service) EndSession(ctx context.Context, sess *session.Session) error {
+	if s == nil {
+		return errors.New("tencentdb memory: nil service")
+	}
+	if sess == nil {
+		return errors.New("tencentdb memory: session is required")
+	}
+	if err := validateSessionScope(sess); err != nil {
+		return err
+	}
+	_, err := s.client.endSession(ctx, endSessionRequest{
+		SessionKey: s.sessionKey(sess),
+		UserID:     sess.UserID,
+	})
+	return err
+}
+
+// Health checks gateway readiness.
+func (s *Service) Health(ctx context.Context) (*HealthResponse, error) {
+	if s == nil {
+		return nil, errors.New("tencentdb memory: nil service")
+	}
+	return s.client.health(ctx)
+}
+
+// Tools returns TencentDB-native memory tools.
+func (s *Service) Tools() []tool.Tool {
+	if s == nil || len(s.tools) == 0 {
+		return nil
+	}
+	out := make([]tool.Tool, len(s.tools))
+	copy(out, s.tools)
+	return out
+}
+
+// Close stops capture workers after draining queued work.
+func (s *Service) Close() error {
+	if s == nil {
+		return nil
+	}
+	s.once.Do(func() {
+		s.mu.Lock()
+		s.closed = true
+		close(s.queue)
+		s.mu.Unlock()
+	})
+	s.wg.Wait()
+	return nil
+}
+
+func (s *Service) sessionKey(sess *session.Session) string {
+	if s.opts.SessionKeyFunc != nil {
+		return s.opts.SessionKeyFunc(sess)
+	}
+	return defaultSessionKey(sess)
+}
+
+func defaultSessionKey(sess *session.Session) string {
+	if sess == nil {
+		return ""
+	}
+	parts := []string{
+		strings.TrimSpace(sess.AppName),
+		strings.TrimSpace(sess.UserID),
+		strings.TrimSpace(sess.ID),
+	}
+	return strings.Join(parts, ":")
+}
+
+func validateSessionScope(sess *session.Session) error {
+	if strings.TrimSpace(sess.AppName) == "" {
+		return errors.New("tencentdb memory: session app name is required")
+	}
+	if strings.TrimSpace(sess.UserID) == "" {
+		return errors.New("tencentdb memory: session user id is required")
+	}
+	if strings.TrimSpace(sess.ID) == "" {
+		return errors.New("tencentdb memory: session id is required")
+	}
+	return nil
+}
+
+func (s *Service) capture(ctx context.Context, job ingestJob) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	_, err := s.client.capture(ctx, job.req)
+	if err != nil {
+		return fmt.Errorf("tencentdb memory: capture failed: %w", err)
+	}
+	writeBestEffortLastCaptureAt(job.sess, job.cursor)
+	return nil
+}

--- a/memory/tencentdb/service.go
+++ b/memory/tencentdb/service.go
@@ -102,6 +102,9 @@ func (s *Service) IngestSession(
 		sess:   sess,
 		cursor: scan.Latest,
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	s.mu.RLock()
 	if s.closed {
 		s.mu.RUnlock()
@@ -112,12 +115,9 @@ func (s *Service) IngestSession(
 		s.mu.RUnlock()
 		writeBestEffortLastCaptureAt(sess, scan.Latest)
 		return nil
-	default:
+	case <-ctx.Done():
 		s.mu.RUnlock()
-		if err := s.capture(ctx, job); err != nil {
-			return err
-		}
-		return nil
+		return ctx.Err()
 	}
 }
 

--- a/memory/tencentdb/service.go
+++ b/memory/tencentdb/service.go
@@ -110,6 +110,7 @@ func (s *Service) IngestSession(
 	select {
 	case s.queue <- job:
 		s.mu.RUnlock()
+		writeBestEffortLastCaptureAt(sess, scan.Latest)
 		return nil
 	default:
 		s.mu.RUnlock()

--- a/memory/tencentdb/service.go
+++ b/memory/tencentdb/service.go
@@ -140,7 +140,12 @@ func (s *Service) EndSession(ctx context.Context, sess *session.Session) error {
 	})
 	if err == nil {
 		clearBestEffortSyntheticTimestamp(sess)
-		s.clearSessionCheckpoint(sessionKey)
+		// Intentionally retain the service-level capture checkpoint until the
+		// service shuts down. It is the only reliable cursor for reloaded or
+		// cloned sessions, so dropping it here would let a framework session
+		// that keeps running after EndSession re-scan and resend transcript
+		// that was already captured. Keeping it is safe because new events
+		// always carry timestamps after the cursor.
 	}
 	s.finishSerialBarrier(sessionKey, barrier, nil)
 	return err
@@ -339,10 +344,4 @@ func (s *Service) finishSerialBarrier(sessionKey string, barrier *captureSerialS
 		delete(s.serialTail, sessionKey)
 	}
 	close(barrier.done)
-}
-
-func (s *Service) clearSessionCheckpoint(sessionKey string) {
-	s.cursorMu.Lock()
-	defer s.cursorMu.Unlock()
-	delete(s.lastCapture, sessionKey)
 }

--- a/memory/tencentdb/service.go
+++ b/memory/tencentdb/service.go
@@ -38,9 +38,10 @@ type Service struct {
 	wg     sync.WaitGroup
 	once   sync.Once
 
-	cursorMu   sync.Mutex
-	inFlight   map[string]time.Time
-	serialTail map[string]*captureSerialState
+	cursorMu    sync.Mutex
+	inFlight    map[string]time.Time
+	lastCapture map[string]time.Time
+	serialTail  map[string]*captureSerialState
 
 	tools []tool.Tool
 }
@@ -58,11 +59,12 @@ func NewService(opts ...Option) (*Service, error) {
 		return nil, err
 	}
 	s := &Service{
-		opts:       options,
-		client:     client,
-		queue:      make(chan ingestJob, options.IngestQueueSize),
-		inFlight:   make(map[string]time.Time),
-		serialTail: make(map[string]*captureSerialState),
+		opts:        options,
+		client:      client,
+		queue:       make(chan ingestJob, options.IngestQueueSize),
+		inFlight:    make(map[string]time.Time),
+		lastCapture: make(map[string]time.Time),
+		serialTail:  make(map[string]*captureSerialState),
 	}
 	s.tools = s.buildTools()
 	s.startWorkers()
@@ -123,13 +125,24 @@ func (s *Service) EndSession(ctx context.Context, sess *session.Session) error {
 	if err := validateSessionScope(sess); err != nil {
 		return err
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	sessionKey := s.sessionKey(sess)
+	barrier := s.reserveSerialBarrier(sessionKey)
+	if err := s.waitForPreviousCapture(ctx, barrier); err != nil {
+		s.finishSerialBarrier(sessionKey, barrier, err)
+		return err
+	}
 	_, err := s.client.endSession(ctx, endSessionRequest{
-		SessionKey: s.sessionKey(sess),
+		SessionKey: sessionKey,
 		UserID:     sess.UserID,
 	})
 	if err == nil {
 		clearBestEffortSyntheticTimestamp(sess)
+		s.clearSessionCheckpoint(sessionKey)
 	}
+	s.finishSerialBarrier(sessionKey, barrier, nil)
 	return err
 }
 
@@ -202,18 +215,9 @@ func (s *Service) capture(ctx context.Context, job ingestJob) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if job.previous != nil {
-		select {
-		case <-job.previous.done:
-			if job.previous.err != nil {
-				err := fmt.Errorf("tencentdb memory: previous capture failed for session_key %q", job.req.SessionKey)
-				s.finishCaptureJob(job, err)
-				return err
-			}
-		case <-ctx.Done():
-			s.finishCaptureJob(job, ctx.Err())
-			return ctx.Err()
-		}
+	if err := s.waitForPreviousCapture(ctx, job.serial); err != nil {
+		s.finishCaptureJob(job, err)
+		return err
 	}
 	_, err := s.client.capture(ctx, job.req)
 	if err != nil {
@@ -231,6 +235,9 @@ func (s *Service) reserveIngestJob(sess *session.Session, sessionKey string) (in
 	defer s.cursorMu.Unlock()
 
 	since := readBestEffortLastCaptureAt(sess)
+	if last, ok := s.lastCapture[sessionKey]; ok && last.After(since) {
+		since = last
+	}
 	if inFlight, ok := s.inFlight[sessionKey]; ok && inFlight.After(since) {
 		since = inFlight
 	}
@@ -252,7 +259,11 @@ func (s *Service) reserveIngestJob(sess *session.Session, sessionKey string) (in
 	)
 	writeBestEffortSyntheticTimestamp(sess, latestSynthetic)
 	previous := s.serialTail[sessionKey]
-	serial := &captureSerialState{done: make(chan struct{})}
+	serial := &captureSerialState{
+		sessionKey: sessionKey,
+		previous:   previous,
+		done:       make(chan struct{}),
+	}
 	s.serialTail[sessionKey] = serial
 	return ingestJob{
 		req: captureRequest{
@@ -263,16 +274,20 @@ func (s *Service) reserveIngestJob(sess *session.Session, sessionKey string) (in
 			UserID:           sess.UserID,
 			Messages:         messages,
 		},
-		sess:     sess,
-		cursor:   scan.Latest,
-		previous: previous,
-		serial:   serial,
+		sess:   sess,
+		cursor: scan.Latest,
+		serial: serial,
 	}, true
 }
 
 func (s *Service) finishCaptureJob(job ingestJob, err error) {
 	s.cursorMu.Lock()
 	defer s.cursorMu.Unlock()
+	if err == nil && !job.cursor.IsZero() {
+		if last, ok := s.lastCapture[job.req.SessionKey]; !ok || job.cursor.After(last) {
+			s.lastCapture[job.req.SessionKey] = job.cursor
+		}
+	}
 	if current, ok := s.inFlight[job.req.SessionKey]; ok && !current.After(job.cursor) {
 		delete(s.inFlight, job.req.SessionKey)
 	}
@@ -283,4 +298,47 @@ func (s *Service) finishCaptureJob(job ingestJob, err error) {
 		}
 		close(job.serial.done)
 	}
+}
+
+func (s *Service) reserveSerialBarrier(sessionKey string) *captureSerialState {
+	s.cursorMu.Lock()
+	defer s.cursorMu.Unlock()
+	barrier := &captureSerialState{
+		sessionKey: sessionKey,
+		previous:   s.serialTail[sessionKey],
+		done:       make(chan struct{}),
+	}
+	s.serialTail[sessionKey] = barrier
+	return barrier
+}
+
+func (s *Service) waitForPreviousCapture(ctx context.Context, serial *captureSerialState) error {
+	if serial == nil || serial.previous == nil {
+		return nil
+	}
+	select {
+	case <-serial.previous.done:
+		if serial.previous.err != nil {
+			return fmt.Errorf("tencentdb memory: previous capture failed for session_key %q", serial.sessionKey)
+		}
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (s *Service) finishSerialBarrier(sessionKey string, barrier *captureSerialState, err error) {
+	s.cursorMu.Lock()
+	defer s.cursorMu.Unlock()
+	barrier.err = err
+	if s.serialTail[sessionKey] == barrier {
+		delete(s.serialTail, sessionKey)
+	}
+	close(barrier.done)
+}
+
+func (s *Service) clearSessionCheckpoint(sessionKey string) {
+	s.cursorMu.Lock()
+	defer s.cursorMu.Unlock()
+	delete(s.lastCapture, sessionKey)
 }

--- a/memory/tencentdb/service_test.go
+++ b/memory/tencentdb/service_test.go
@@ -302,6 +302,12 @@ func TestGatewayClientEndpointsAndErrors(t *testing.T) {
 	if _, err := newGatewayClient(Options{GatewayURL: "://bad"}); err == nil {
 		t.Fatalf("expected invalid gateway url error")
 	}
+	if _, err := newGatewayClient(Options{GatewayURL: "/path-only"}); err == nil {
+		t.Fatalf("expected path-only gateway url error")
+	}
+	if _, err := newGatewayClient(Options{GatewayURL: "ftp://example.com"}); err == nil {
+		t.Fatalf("expected unsupported scheme gateway url error")
+	}
 }
 
 func TestRecallPluginInjectsContext(t *testing.T) {
@@ -409,6 +415,19 @@ func TestServiceOptionsAndLifecycleEdges(t *testing.T) {
 	}
 	if names["custom_conversation_search"] {
 		t.Fatalf("conversation search should be disabled")
+	}
+	deduped, err := NewService(
+		WithGatewayURL(server.URL),
+		WithStandardAliases(true),
+		WithConversationSearchTool(false),
+		func(o *Options) { o.ToolPrefix = "" },
+	)
+	if err != nil {
+		t.Fatalf("NewService deduped: %v", err)
+	}
+	defer deduped.Close()
+	if got := len(deduped.Tools()); got != 1 {
+		t.Fatalf("deduped tool count = %d, want 1", got)
 	}
 	if plugin, ok := svc.Plugin().(*recallPlugin); !ok || plugin.service != svc {
 		t.Fatalf("unexpected plugin = %#v", plugin)

--- a/memory/tencentdb/service_test.go
+++ b/memory/tencentdb/service_test.go
@@ -479,6 +479,45 @@ func TestGatewayClientEndpointsAndErrors(t *testing.T) {
 	if _, err := newGatewayClient(Options{GatewayURL: "ftp://example.com"}); err == nil {
 		t.Fatalf("expected unsupported scheme gateway url error")
 	}
+	if _, err := newGatewayClient(Options{}); err == nil {
+		t.Fatalf("expected empty gateway url error")
+	}
+	nullable, err := newGatewayClient(Options{GatewayURL: server.URL})
+	if err != nil {
+		t.Fatalf("new nullable client: %v", err)
+	}
+	if err := nullable.doJSON(context.Background(), httpMethodGet, pathHealth, nil, nil); err != nil {
+		t.Fatalf("nil output should be accepted: %v", err)
+	}
+}
+
+func TestGatewayClientDecodeAndRequestEdges(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/empty":
+			w.WriteHeader(http.StatusNoContent)
+		case "/bad-json":
+			_, _ = w.Write([]byte("{"))
+		default:
+			_ = json.NewEncoder(w).Encode(HealthResponse{Status: "ok"})
+		}
+	}))
+	defer server.Close()
+
+	client, err := newGatewayClient(Options{GatewayURL: server.URL})
+	if err != nil {
+		t.Fatalf("newGatewayClient: %v", err)
+	}
+	var out HealthResponse
+	if err := client.doJSON(nil, httpMethodGet, "/empty", nil, &out); err != nil {
+		t.Fatalf("empty response should be accepted: %v", err)
+	}
+	if err := client.doJSON(context.Background(), httpMethodGet, "/bad-json", nil, &out); err == nil {
+		t.Fatalf("expected unmarshal error")
+	}
+	if err := client.doJSONOnce(context.Background(), httpMethodGet, "://bad", nil, nil); err == nil {
+		t.Fatalf("expected request build error")
+	}
 }
 
 func TestRecallPluginInjectsContext(t *testing.T) {
@@ -548,6 +587,7 @@ func TestServiceOptionsAndLifecycleEdges(t *testing.T) {
 
 	customClient := server.Client()
 	svc, err := NewService(
+		nil,
 		WithGatewayURL(server.URL),
 		WithTimeout(time.Second),
 		WithHTTPClient(customClient),
@@ -613,6 +653,15 @@ func TestServiceOptionsAndLifecycleEdges(t *testing.T) {
 	}
 
 	var nilSvc *Service
+	if nilSvc.Tools() != nil {
+		t.Fatalf("nil service should not expose tools")
+	}
+	if (&Service{}).Tools() != nil {
+		t.Fatalf("empty service should not expose tools")
+	}
+	if err := nilSvc.Close(); err != nil {
+		t.Fatalf("nil service close should be nil: %v", err)
+	}
 	if err := nilSvc.IngestSession(context.Background(), &session.Session{}); err == nil {
 		t.Fatalf("expected nil service error")
 	}
@@ -709,6 +758,98 @@ func TestMemorySearchToolAndHelpers(t *testing.T) {
 	writeBestEffortLastCaptureAt(nil, time.Now())
 	if !readBestEffortLastCaptureAt(&session.Session{}).IsZero() {
 		t.Fatalf("empty cursor should be zero")
+	}
+}
+
+func TestSessionScanTimestampAndStateEdges(t *testing.T) {
+	if got := scanTranscript(nil, time.Time{}); len(got.Messages) != 0 {
+		t.Fatalf("nil session scan = %#v", got)
+	}
+	if got := scanTranscript(&session.Session{}, time.Time{}); len(got.Messages) != 0 {
+		t.Fatalf("empty session scan = %#v", got)
+	}
+
+	base := time.Date(2026, 5, 22, 8, 0, 0, 0, time.UTC)
+	sess := &session.Session{
+		ID:      "s1",
+		AppName: "app",
+		UserID:  "user",
+		Events: []event.Event{
+			{ID: "old", Timestamp: base, Response: &model.Response{Choices: []model.Choice{{
+				Message: model.NewUserMessage("old"),
+			}}}},
+			{ID: "nil-response", Timestamp: base.Add(time.Second)},
+			{ID: "system", Timestamp: base.Add(2 * time.Second), Response: &model.Response{Choices: []model.Choice{{
+				Message: model.NewSystemMessage("system"),
+			}}}},
+			{ID: "empty", Timestamp: base.Add(3 * time.Second), Response: &model.Response{Choices: []model.Choice{{
+				Message: model.NewUserMessage("   "),
+			}}}},
+			{ID: "user", Timestamp: base.Add(4 * time.Second), Response: &model.Response{Choices: []model.Choice{{
+				Index:   2,
+				Message: model.NewUserMessage("new"),
+			}}}},
+		},
+	}
+	scan := scanTranscript(sess, base)
+	if len(scan.Messages) != 1 || scan.Messages[0].ID != "user:2" || scan.Latest != base.Add(4*time.Second) {
+		t.Fatalf("scan = %#v", scan)
+	}
+
+	if got := normalizeGatewayMessageTimestamps(nil, time.Now()); got != nil {
+		t.Fatalf("nil normalized messages = %#v", got)
+	}
+	normalized := normalizeGatewayMessageTimestamps([]tdaiMessage{{Content: "x"}}, time.Time{})
+	if len(normalized) != 1 || normalized[0].Timestamp == 0 {
+		t.Fatalf("normalized messages = %#v", normalized)
+	}
+	empty, latest := normalizeGatewayMessageTimestampsAfter(nil, time.Now(), 123)
+	if empty != nil || latest != 123 {
+		t.Fatalf("empty normalize result = %#v latest=%d", empty, latest)
+	}
+	bumped, latest := normalizeGatewayMessageTimestampsAfter(
+		[]tdaiMessage{{Content: "a"}, {Content: "b"}},
+		time.UnixMilli(1000),
+		5000,
+	)
+	if bumped[0].Timestamp != 5001 || bumped[1].Timestamp != 5002 || latest != 5002 {
+		t.Fatalf("bumped timestamps = %#v latest=%d", bumped, latest)
+	}
+
+	stateSess := &session.Session{}
+	stateSess.SetState(lastCaptureAtStateKey, []byte("not-a-time"))
+	if got := readBestEffortLastCaptureAt(stateSess); !got.IsZero() {
+		t.Fatalf("malformed last capture should be zero: %v", got)
+	}
+	writeBestEffortSyntheticTimestamp(nil, 10)
+	writeBestEffortSyntheticTimestamp(stateSess, 0)
+	if got := readBestEffortSyntheticTimestamp(stateSess); got != 0 {
+		t.Fatalf("non-positive synthetic timestamp should be ignored: %d", got)
+	}
+	stateSess.SetState(syntheticTimestampStateKey, []byte("bad"))
+	if got := readBestEffortSyntheticTimestamp(stateSess); got != 0 {
+		t.Fatalf("malformed synthetic timestamp should be zero: %d", got)
+	}
+	writeBestEffortSyntheticTimestamp(stateSess, 77)
+	if got := readBestEffortSyntheticTimestamp(stateSess); got != 77 {
+		t.Fatalf("synthetic timestamp = %d", got)
+	}
+	clearBestEffortSyntheticTimestamp(nil)
+	clearBestEffortSyntheticTimestamp(stateSess)
+	if got := readBestEffortSyntheticTimestamp(stateSess); got != 0 {
+		t.Fatalf("cleared synthetic timestamp = %d", got)
+	}
+
+	if messageText(model.Message{Role: model.RoleUser}) != "" {
+		t.Fatalf("empty message should have no text")
+	}
+	if messageText(model.Message{
+		Role: model.RoleUser,
+		ContentParts: []model.ContentPart{{
+			Type: model.ContentTypeText,
+		}},
+	}) != "" {
+		t.Fatalf("nil text part should have no text")
 	}
 }
 
@@ -855,6 +996,26 @@ func TestCaptureAndClientFailurePaths(t *testing.T) {
 	}
 	if _, err := svc.client.endSession(context.Background(), endSessionRequest{SessionKey: "s"}); err == nil {
 		t.Fatalf("expected client end session failure")
+	}
+
+	previousFailed := &captureSerialState{done: make(chan struct{}), err: errors.New("previous failed")}
+	close(previousFailed.done)
+	if err := svc.capture(context.Background(), ingestJob{
+		req:      captureRequest{SessionKey: "s"},
+		previous: previousFailed,
+		serial:   &captureSerialState{done: make(chan struct{})},
+	}); err == nil {
+		t.Fatalf("expected previous capture failure")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := svc.capture(ctx, ingestJob{
+		req:      captureRequest{SessionKey: "s"},
+		previous: &captureSerialState{done: make(chan struct{})},
+		serial:   &captureSerialState{done: make(chan struct{})},
+	}); err == nil {
+		t.Fatalf("expected context cancellation while waiting for previous capture")
 	}
 }
 

--- a/memory/tencentdb/service_test.go
+++ b/memory/tencentdb/service_test.go
@@ -122,6 +122,24 @@ func TestSafeDefaultsDisableCrossTenantReads(t *testing.T) {
 	assert.False(t, names["tdai_memory_search"], "memory search should be opt-in; tools=%#v", names)
 	assert.True(t, names["tdai_conversation_search"], "conversation search should be on by default; tools=%#v", names)
 
+	aliasOnly, err := NewService(
+		WithGatewayURL(server.URL),
+		WithStandardAliases(true),
+	)
+	require.NoError(t, err, "NewService alias only")
+	defer aliasOnly.Close()
+
+	aliasOnlyMgr, err := pluginpkg.NewManager(aliasOnly.Plugin())
+	require.NoError(t, err, "NewManager alias only")
+	assert.Nil(t, aliasOnlyMgr.ModelCallbacks(), "recall should remain disabled when only aliases are enabled")
+
+	aliasOnlyNames := map[string]bool{}
+	for _, tl := range aliasOnly.Tools() {
+		aliasOnlyNames[tl.Declaration().Name] = true
+	}
+	assert.False(t, aliasOnlyNames["tdai_memory_search"], "native memory search should stay opt-in; tools=%#v", aliasOnlyNames)
+	assert.False(t, aliasOnlyNames["memory_search"], "standard alias should require memory search to be enabled; tools=%#v", aliasOnlyNames)
+
 	enabled, err := NewService(
 		WithGatewayURL(server.URL),
 		WithRecallEnabled(true),

--- a/memory/tencentdb/service_test.go
+++ b/memory/tencentdb/service_test.go
@@ -1,0 +1,660 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package tencentdb
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	pluginpkg "trpc.group/trpc-go/trpc-agent-go/plugin"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+func TestIngestSessionCapturesTimestampedMessagesAndCursor(t *testing.T) {
+	var got captureRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != pathCapture {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(captureResponse{L0Recorded: len(got.Messages)})
+	}))
+	defer server.Close()
+
+	svc, err := NewService(
+		WithGatewayURL(server.URL),
+		WithIngestQueueSize(1),
+		WithIngestJobTimeout(time.Second),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	ts1 := time.Date(2026, 5, 22, 8, 0, 0, 123*1e6, time.UTC)
+	ts2 := ts1.Add(time.Second)
+	sess := &session.Session{
+		ID:      "sess-1",
+		AppName: "app",
+		UserID:  "user",
+		State:   session.StateMap{},
+		Events: []event.Event{
+			{
+				ID:        "u1",
+				Timestamp: ts1,
+				Response: &model.Response{Choices: []model.Choice{{
+					Index:   0,
+					Message: model.NewUserMessage("remember this"),
+				}}},
+			},
+			{
+				ID:        "a1",
+				Timestamp: ts2,
+				Response: &model.Response{Choices: []model.Choice{{
+					Index:   0,
+					Message: model.NewAssistantMessage("stored"),
+				}}},
+			},
+		},
+	}
+	if err := svc.IngestSession(context.Background(), sess); err != nil {
+		t.Fatalf("IngestSession: %v", err)
+	}
+	if err := svc.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if got.SessionKey != "app:user:sess-1" {
+		t.Fatalf("session_key = %q", got.SessionKey)
+	}
+	if got.UserContent != "remember this" || got.AssistantContent != "stored" {
+		t.Fatalf("captured pair = %q / %q", got.UserContent, got.AssistantContent)
+	}
+	if len(got.Messages) != 2 {
+		t.Fatalf("messages length = %d", len(got.Messages))
+	}
+	if got.Messages[0].Timestamp <= ts2.UnixMilli() || got.Messages[1].Timestamp != got.Messages[0].Timestamp+1 {
+		t.Fatalf("timestamps = %d, %d", got.Messages[0].Timestamp, got.Messages[1].Timestamp)
+	}
+	if readBestEffortLastCaptureAt(sess) != ts2 {
+		t.Fatalf("cursor was not advanced to latest event")
+	}
+}
+
+func TestInjectRecallContext(t *testing.T) {
+	req := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("base"),
+		model.NewUserMessage("hello"),
+	}}
+	injectRecallContext(req, &recallResponse{
+		AppendSystemContext: "system recall",
+		PrependContext:      "user recall",
+	})
+
+	if len(req.Messages) != 3 {
+		t.Fatalf("message length = %d", len(req.Messages))
+	}
+	if req.Messages[0].Role != model.RoleSystem || req.Messages[0].Content != "base\n\nsystem recall" {
+		t.Fatalf("system message = %#v", req.Messages[0])
+	}
+	if req.Messages[1].Role != model.RoleUser || req.Messages[1].Content != "user recall" {
+		t.Fatalf("prepended user message = %#v", req.Messages[1])
+	}
+	if req.Messages[2].Content != "hello" {
+		t.Fatalf("latest user was not preserved: %#v", req.Messages[2])
+	}
+}
+
+func TestConversationSearchToolUsesCurrentSessionKey(t *testing.T) {
+	var got searchConversationsRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != pathSearchConversations {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(searchConversationsResponse{
+			Results: "hit",
+			Total:   1,
+		})
+	}))
+	defer server.Close()
+
+	svc, err := NewService(WithGatewayURL(server.URL))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	defer svc.Close()
+
+	var convTool tool.CallableTool
+	for _, tl := range svc.Tools() {
+		if tl.Declaration().Name == "tdai_conversation_search" {
+			var ok bool
+			convTool, ok = tl.(tool.CallableTool)
+			if !ok {
+				t.Fatalf("conversation tool is not callable")
+			}
+			break
+		}
+	}
+	if convTool == nil {
+		t.Fatalf("conversation tool not found")
+	}
+
+	sess := &session.Session{ID: "s1", AppName: "app", UserID: "u1"}
+	ctx := agent.NewInvocationContext(context.Background(), &agent.Invocation{Session: sess}).Context
+	raw, err := convTool.Call(ctx, []byte(`{"query":"previous topic"}`))
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	rsp := raw.(*searchConversationsToolResponse)
+	if rsp.Results != "hit" || rsp.Total != 1 {
+		t.Fatalf("response = %#v", rsp)
+	}
+	if got.SessionKey != "app:u1:s1" {
+		t.Fatalf("session_key = %q", got.SessionKey)
+	}
+	if got.Limit != defaultSearchLimit {
+		t.Fatalf("limit = %d", got.Limit)
+	}
+}
+
+func TestGatewayClientEndpointsAndErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case pathRecall:
+			_ = json.NewEncoder(w).Encode(recallResponse{
+				Context:             "legacy",
+				PrependContext:      "prepend",
+				AppendSystemContext: "append",
+				Strategy:            "hybrid",
+				MemoryCount:         2,
+			})
+		case pathSearchMemories:
+			_ = json.NewEncoder(w).Encode(searchMemoriesResponse{
+				Results:  "memory hit",
+				Total:    1,
+				Strategy: "semantic",
+			})
+		case pathEndSession:
+			_ = json.NewEncoder(w).Encode(endSessionResponse{Flushed: true})
+		case pathHealth:
+			_ = json.NewEncoder(w).Encode(HealthResponse{Status: "ok", Version: "test"})
+		default:
+			http.Error(w, strings.Repeat("x", 700), http.StatusBadGateway)
+		}
+	}))
+	defer server.Close()
+
+	client, err := newGatewayClient(Options{
+		GatewayURL:   server.URL,
+		Timeout:      time.Second,
+		MaxBodyBytes: defaultMaxBodyBytes,
+	})
+	if err != nil {
+		t.Fatalf("newGatewayClient: %v", err)
+	}
+	recall, err := client.recall(context.Background(), recallRequest{Query: "q", SessionKey: "s"})
+	if err != nil {
+		t.Fatalf("recall: %v", err)
+	}
+	if recall.AppendSystemContext != "append" || recall.MemoryCount != 2 {
+		t.Fatalf("recall response = %#v", recall)
+	}
+	memories, err := client.searchMemories(context.Background(), searchMemoriesRequest{Query: "q"})
+	if err != nil {
+		t.Fatalf("searchMemories: %v", err)
+	}
+	if memories.Results != "memory hit" || memories.Strategy != "semantic" {
+		t.Fatalf("search memories response = %#v", memories)
+	}
+	ended, err := client.endSession(context.Background(), endSessionRequest{SessionKey: "s"})
+	if err != nil {
+		t.Fatalf("endSession: %v", err)
+	}
+	if !ended.Flushed {
+		t.Fatalf("end session response = %#v", ended)
+	}
+	health, err := client.health(context.Background())
+	if err != nil {
+		t.Fatalf("health: %v", err)
+	}
+	if health.Status != "ok" || health.Version != "test" {
+		t.Fatalf("health response = %#v", health)
+	}
+
+	if err := client.doJSON(context.Background(), httpMethodGet, "/missing", nil, nil); err == nil {
+		t.Fatalf("expected API error")
+	} else {
+		var apiErr *APIError
+		if !errors.As(err, &apiErr) {
+			t.Fatalf("expected APIError, got %T: %v", err, err)
+		}
+		if !strings.Contains(apiErr.Error(), "status=502") {
+			t.Fatalf("unexpected APIError string: %s", apiErr.Error())
+		}
+		if len(apiErr.Body) > maxErrorBodyPreview+len("...(truncated)") {
+			t.Fatalf("error preview was not truncated")
+		}
+	}
+	if err := client.doJSON(context.Background(), httpMethodPost, pathCapture, map[string]any{
+		"bad": func() {},
+	}, nil); err == nil {
+		t.Fatalf("expected marshal error")
+	}
+
+	tiny, err := newGatewayClient(Options{GatewayURL: server.URL, MaxBodyBytes: 4})
+	if err != nil {
+		t.Fatalf("new tiny client: %v", err)
+	}
+	if _, err := tiny.health(context.Background()); err == nil {
+		t.Fatalf("expected response body too large")
+	}
+	if _, err := newGatewayClient(Options{GatewayURL: "://bad"}); err == nil {
+		t.Fatalf("expected invalid gateway url error")
+	}
+}
+
+func TestRecallPluginInjectsContext(t *testing.T) {
+	var got recallRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != pathRecall {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(recallResponse{
+			AppendSystemContext: "remembered system",
+			PrependContext:      "remembered user context",
+		})
+	}))
+	defer server.Close()
+
+	svc, err := NewService(WithGatewayURL(server.URL))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	defer svc.Close()
+
+	p := svc.Plugin()
+	if p.Name() != "tencentdb_agent_memory" {
+		t.Fatalf("plugin name = %q", p.Name())
+	}
+	mgr, err := pluginpkg.NewManager(p)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	callbacks := mgr.ModelCallbacks()
+	if callbacks == nil || len(callbacks.BeforeModel) != 1 {
+		t.Fatalf("expected one before model callback")
+	}
+
+	req := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("base"),
+		model.NewUserMessage("what did I say?"),
+	}}
+	sess := &session.Session{ID: "s1", AppName: "app", UserID: "user"}
+	ctx := agent.NewInvocationContext(context.Background(), &agent.Invocation{Session: sess}).Context
+	if _, err := callbacks.BeforeModel[0](ctx, &model.BeforeModelArgs{Request: req}); err != nil {
+		t.Fatalf("before model: %v", err)
+	}
+
+	if got.Query != "what did I say?" || got.SessionKey != "app:user:s1" || got.UserID != "user" {
+		t.Fatalf("recall request = %#v", got)
+	}
+	if len(req.Messages) != 3 {
+		t.Fatalf("message length = %d", len(req.Messages))
+	}
+	if req.Messages[0].Content != "base\n\nremembered system" {
+		t.Fatalf("system message = %#v", req.Messages[0])
+	}
+	if req.Messages[1].Content != "remembered user context" {
+		t.Fatalf("inserted context = %#v", req.Messages[1])
+	}
+}
+
+func TestServiceOptionsAndLifecycleEdges(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(captureResponse{})
+	}))
+	defer server.Close()
+
+	customClient := server.Client()
+	svc, err := NewService(
+		WithGatewayURL(server.URL),
+		WithTimeout(time.Second),
+		WithHTTPClient(customClient),
+		WithMaxBodyBytes(1024),
+		WithIngestWorkers(2),
+		WithIngestQueueSize(2),
+		WithIngestJobTimeout(time.Second),
+		WithSessionKeyFunc(func(sess *session.Session) string {
+			return "custom:" + sess.ID
+		}),
+		WithRecallEnabled(false),
+		WithConversationSearchTool(false),
+		WithStandardAliases(true),
+		WithToolPrefix("_custom_"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	defer svc.Close()
+
+	if svc.client.hc != customClient {
+		t.Fatalf("custom HTTP client was not used")
+	}
+	if svc.client.timeout != time.Second || svc.client.maxBodyBytes != 1024 {
+		t.Fatalf("client options = timeout %v max %d", svc.client.timeout, svc.client.maxBodyBytes)
+	}
+	if svc.sessionKey(&session.Session{ID: "s1"}) != "custom:s1" {
+		t.Fatalf("custom session key was not used")
+	}
+	names := map[string]bool{}
+	for _, tl := range svc.Tools() {
+		names[tl.Declaration().Name] = true
+	}
+	if !names["custom_memory_search"] || !names["memory_search"] {
+		t.Fatalf("tool names = %#v", names)
+	}
+	if names["custom_conversation_search"] {
+		t.Fatalf("conversation search should be disabled")
+	}
+	if plugin, ok := svc.Plugin().(*recallPlugin); !ok || plugin.service != svc {
+		t.Fatalf("unexpected plugin = %#v", plugin)
+	} else {
+		mgr, err := pluginpkg.NewManager(plugin)
+		if err != nil {
+			t.Fatalf("NewManager: %v", err)
+		}
+		if mgr.ModelCallbacks() != nil {
+			t.Fatalf("recall disabled should not register callbacks")
+		}
+	}
+
+	var nilSvc *Service
+	if err := nilSvc.IngestSession(context.Background(), &session.Session{}); err == nil {
+		t.Fatalf("expected nil service error")
+	}
+	if err := svc.IngestSession(context.Background(), nil); err == nil {
+		t.Fatalf("expected nil session error")
+	}
+	if err := svc.IngestSession(context.Background(), &session.Session{ID: "s", AppName: "app"}); err == nil {
+		t.Fatalf("expected missing user error")
+	}
+	if err := svc.IngestSession(context.Background(), &session.Session{ID: "s", AppName: "app", UserID: "u"}); err != nil {
+		t.Fatalf("empty transcript should be ignored: %v", err)
+	}
+	if defaultSessionKey(nil) != "" {
+		t.Fatalf("nil default session key should be empty")
+	}
+
+	closed, err := NewService(WithGatewayURL(server.URL), WithIngestQueueSize(1))
+	if err != nil {
+		t.Fatalf("NewService closed: %v", err)
+	}
+	if err := closed.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := closed.IngestSession(context.Background(), captureReadySession()); err == nil {
+		t.Fatalf("expected closed service error")
+	}
+}
+
+func TestMemorySearchToolAndHelpers(t *testing.T) {
+	var got searchMemoriesRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != pathSearchMemories {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(searchMemoriesResponse{
+			Results:  "memory result",
+			Total:    3,
+			Strategy: "hybrid",
+		})
+	}))
+	defer server.Close()
+
+	svc, err := NewService(WithGatewayURL(server.URL), WithConversationSearchTool(false))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	defer svc.Close()
+
+	memTool, ok := svc.Tools()[0].(tool.CallableTool)
+	if !ok {
+		t.Fatalf("memory tool is not callable")
+	}
+	if _, err := memTool.Call(context.Background(), []byte(`{"query":"hello"}`)); err == nil {
+		t.Fatalf("expected missing invocation error")
+	}
+	if _, err := memTool.Call(context.Background(), []byte(`{"query":""}`)); err == nil {
+		t.Fatalf("expected query validation error")
+	}
+
+	sess := &session.Session{ID: "s1", AppName: "app", UserID: "u1"}
+	ctx := agent.NewInvocationContext(context.Background(), &agent.Invocation{Session: sess}).Context
+	raw, err := memTool.Call(ctx, []byte(`{"query":"profile","limit":99,"type":"L1","scene":"work"}`))
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	rsp := raw.(*searchMemoriesToolResponse)
+	if rsp.Results != "memory result" || rsp.Total != 3 || rsp.Strategy != "hybrid" {
+		t.Fatalf("response = %#v", rsp)
+	}
+	if got.Query != "profile" || got.Limit != maxSearchLimit || got.Type != "L1" || got.Scene != "work" {
+		t.Fatalf("search request = %#v", got)
+	}
+	if normalizeLimit(-1) != defaultSearchLimit || normalizeLimit(7) != 7 || normalizeLimit(99) != maxSearchLimit {
+		t.Fatalf("normalizeLimit returned unexpected values")
+	}
+
+	partText := " content part text "
+	msg := model.Message{
+		Role: model.RoleUser,
+		ContentParts: []model.ContentPart{
+			{Type: model.ContentTypeFile},
+			{Type: model.ContentTypeText, Text: &partText},
+		},
+	}
+	if messageText(msg) != "content part text" {
+		t.Fatalf("messageText did not read text parts")
+	}
+	if messageID("", 0) != "" || messageID("evt", 2) != "evt:2" {
+		t.Fatalf("unexpected messageID behavior")
+	}
+	writeBestEffortLastCaptureAt(nil, time.Now())
+	if !readBestEffortLastCaptureAt(&session.Session{}).IsZero() {
+		t.Fatalf("empty cursor should be zero")
+	}
+}
+
+func TestEndSessionAndHealth(t *testing.T) {
+	var ended endSessionRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case pathEndSession:
+			if err := json.NewDecoder(r.Body).Decode(&ended); err != nil {
+				t.Fatalf("decode end session: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(endSessionResponse{Flushed: true})
+		case pathHealth:
+			_ = json.NewEncoder(w).Encode(HealthResponse{Status: "ok"})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	svc, err := NewService(WithGatewayURL(server.URL))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	defer svc.Close()
+
+	sess := &session.Session{ID: "s1", AppName: "app", UserID: "user"}
+	if err := svc.EndSession(context.Background(), sess); err != nil {
+		t.Fatalf("EndSession: %v", err)
+	}
+	if ended.SessionKey != "app:user:s1" || ended.UserID != "user" {
+		t.Fatalf("end session request = %#v", ended)
+	}
+	health, err := svc.Health(context.Background())
+	if err != nil {
+		t.Fatalf("Health: %v", err)
+	}
+	if health.Status != "ok" {
+		t.Fatalf("health = %#v", health)
+	}
+
+	var nilSvc *Service
+	if err := nilSvc.EndSession(context.Background(), sess); err == nil {
+		t.Fatalf("expected nil service EndSession error")
+	}
+	if err := svc.EndSession(context.Background(), nil); err == nil {
+		t.Fatalf("expected nil session EndSession error")
+	}
+	if _, err := nilSvc.Health(context.Background()); err == nil {
+		t.Fatalf("expected nil service Health error")
+	}
+}
+
+func TestRecallAndPluginEdges(t *testing.T) {
+	if latestUserText(nil) != "" {
+		t.Fatalf("nil request should not have latest user text")
+	}
+	if latestUserText(&model.Request{Messages: []model.Message{model.NewSystemMessage("sys")}}) != "" {
+		t.Fatalf("request without user should not have latest user text")
+	}
+
+	empty := &model.Request{}
+	injectRecallContext(empty, &recallResponse{Context: "legacy context"})
+	if len(empty.Messages) != 1 || empty.Messages[0].Role != model.RoleSystem {
+		t.Fatalf("legacy context should create system message: %#v", empty.Messages)
+	}
+
+	noSystem := &model.Request{Messages: []model.Message{model.NewAssistantMessage("hi")}}
+	injectRecallContext(noSystem, &recallResponse{AppendSystemContext: "sys", PrependContext: "ctx"})
+	if len(noSystem.Messages) != 3 {
+		t.Fatalf("expected system, assistant, context messages: %#v", noSystem.Messages)
+	}
+	if noSystem.Messages[0].Role != model.RoleSystem || noSystem.Messages[0].Content != "sys" {
+		t.Fatalf("system was not prepended: %#v", noSystem.Messages)
+	}
+	if noSystem.Messages[2].Content != "ctx" {
+		t.Fatalf("context should append when no user exists: %#v", noSystem.Messages)
+	}
+	insertBeforeLatestUser(nil, model.NewUserMessage("ignored"))
+
+	svc := &Service{opts: defaultOptions(), client: &gatewayClient{}}
+	p := &recallPlugin{service: svc}
+	if _, err := p.beforeModel(context.Background(), nil); err != nil {
+		t.Fatalf("nil args should be ignored: %v", err)
+	}
+	if _, err := p.beforeModel(context.Background(), &model.BeforeModelArgs{}); err != nil {
+		t.Fatalf("nil request should be ignored: %v", err)
+	}
+	if _, err := p.beforeModel(context.Background(), &model.BeforeModelArgs{
+		Request: &model.Request{Messages: []model.Message{model.NewUserMessage("q")}},
+	}); err != nil {
+		t.Fatalf("missing invocation should be ignored: %v", err)
+	}
+	ctx := agent.NewInvocationContext(context.Background(), &agent.Invocation{
+		Session: &session.Session{ID: "s", AppName: "app", UserID: "user"},
+	}).Context
+	if _, err := p.beforeModel(ctx, &model.BeforeModelArgs{
+		Request: &model.Request{Messages: []model.Message{model.NewSystemMessage("sys")}},
+	}); err != nil {
+		t.Fatalf("missing query should be ignored: %v", err)
+	}
+	badScope := agent.NewInvocationContext(context.Background(), &agent.Invocation{
+		Session: &session.Session{ID: "s", AppName: "app"},
+	}).Context
+	if _, err := p.beforeModel(badScope, &model.BeforeModelArgs{
+		Request: &model.Request{Messages: []model.Message{model.NewUserMessage("q")}},
+	}); err != nil {
+		t.Fatalf("invalid session scope should be ignored: %v", err)
+	}
+}
+
+func TestCaptureAndClientFailurePaths(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	svc, err := NewService(WithGatewayURL(server.URL))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	defer svc.Close()
+
+	if err := svc.capture(context.Background(), ingestJob{
+		req: captureRequest{SessionKey: "s"},
+	}); err == nil {
+		t.Fatalf("expected capture failure")
+	}
+	if _, err := svc.client.capture(context.Background(), captureRequest{SessionKey: "s"}); err == nil {
+		t.Fatalf("expected client capture failure")
+	}
+	if _, err := svc.client.recall(context.Background(), recallRequest{Query: "q"}); err == nil {
+		t.Fatalf("expected client recall failure")
+	}
+	if _, err := svc.client.searchMemories(context.Background(), searchMemoriesRequest{Query: "q"}); err == nil {
+		t.Fatalf("expected client memory search failure")
+	}
+	if _, err := svc.client.searchConversations(context.Background(), searchConversationsRequest{Query: "q"}); err == nil {
+		t.Fatalf("expected client conversation search failure")
+	}
+	if _, err := svc.client.endSession(context.Background(), endSessionRequest{SessionKey: "s"}); err == nil {
+		t.Fatalf("expected client end session failure")
+	}
+}
+
+func captureReadySession() *session.Session {
+	now := time.Now()
+	return &session.Session{
+		ID:      "s1",
+		AppName: "app",
+		UserID:  "user",
+		Events: []event.Event{
+			{
+				ID:        "u",
+				Timestamp: now,
+				Response: &model.Response{Choices: []model.Choice{{
+					Message: model.NewUserMessage("remember"),
+				}}},
+			},
+			{
+				ID:        "a",
+				Timestamp: now.Add(time.Second),
+				Response: &model.Response{Choices: []model.Choice{{
+					Message: model.NewAssistantMessage("ok"),
+				}}},
+			},
+		},
+	}
+}

--- a/memory/tencentdb/service_test.go
+++ b/memory/tencentdb/service_test.go
@@ -645,7 +645,7 @@ func TestGatewayClientDecodeAndRequestEdges(t *testing.T) {
 		t.Fatalf("newGatewayClient: %v", err)
 	}
 	var out HealthResponse
-	if err := client.doJSON(nil, httpMethodGet, "/empty", nil, &out); err != nil {
+	if err := client.doJSON(context.Background(), httpMethodGet, "/empty", nil, &out); err != nil {
 		t.Fatalf("empty response should be accepted: %v", err)
 	}
 	if err := client.doJSON(context.Background(), httpMethodGet, "/bad-json", nil, &out); err == nil {

--- a/memory/tencentdb/service_test.go
+++ b/memory/tencentdb/service_test.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -99,9 +100,19 @@ func TestIngestSessionCapturesTimestampedMessagesAndCursor(t *testing.T) {
 	}
 }
 
-func TestIngestSessionAdvancesCursorBeforeAsyncCaptureCompletes(t *testing.T) {
+func TestIngestSessionMarksInFlightBeforeAsyncCaptureCompletes(t *testing.T) {
 	release := make(chan struct{})
+	started := make(chan struct{}, 1)
+	var requests atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != pathCapture {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		requests.Add(1)
+		select {
+		case started <- struct{}{}:
+		default:
+		}
 		<-release
 		_ = json.NewEncoder(w).Encode(captureResponse{L0Recorded: 2})
 	}))
@@ -115,17 +126,98 @@ func TestIngestSessionAdvancesCursorBeforeAsyncCaptureCompletes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewService: %v", err)
 	}
+	defer func() {
+		close(release)
+		if err := svc.Close(); err != nil {
+			t.Errorf("Close: %v", err)
+		}
+	}()
+	sess := captureReadySession()
+	if err := svc.IngestSession(context.Background(), sess); err != nil {
+		t.Fatalf("IngestSession: %v", err)
+	}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatalf("capture request did not start")
+	}
+	if got := readBestEffortLastCaptureAt(sess); !got.IsZero() {
+		t.Fatalf("persistent cursor advanced before capture success: %v", got)
+	}
+	if err := svc.IngestSession(context.Background(), sess); err != nil {
+		t.Fatalf("second IngestSession: %v", err)
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("capture requests = %d, want 1", got)
+	}
+}
+
+func TestIngestSessionRetriesAfterAsyncCaptureFailure(t *testing.T) {
+	firstDone := make(chan struct{})
+	secondDone := make(chan struct{})
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != pathCapture {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		switch requests.Add(1) {
+		case 1:
+			http.Error(w, "gateway unavailable", http.StatusBadGateway)
+			close(firstDone)
+		case 2:
+			_ = json.NewEncoder(w).Encode(captureResponse{L0Recorded: 2})
+			close(secondDone)
+		default:
+			t.Fatalf("unexpected extra capture request")
+		}
+	}))
+	defer server.Close()
+
+	svc, err := NewService(
+		WithGatewayURL(server.URL),
+		WithIngestQueueSize(1),
+		WithIngestJobTimeout(time.Second),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	defer func() {
+		if err := svc.Close(); err != nil {
+			t.Errorf("Close: %v", err)
+		}
+	}()
 	sess := captureReadySession()
 	want := sess.Events[len(sess.Events)-1].Timestamp
 	if err := svc.IngestSession(context.Background(), sess); err != nil {
 		t.Fatalf("IngestSession: %v", err)
 	}
-	if got := readBestEffortLastCaptureAt(sess); !got.Equal(want) {
-		t.Fatalf("cursor = %v, want %v", got, want)
+	select {
+	case <-firstDone:
+	case <-time.After(time.Second):
+		t.Fatalf("first capture request did not complete")
 	}
-	close(release)
+	waitForCondition(t, time.Second, func() bool {
+		svc.cursorMu.Lock()
+		defer svc.cursorMu.Unlock()
+		_, ok := svc.inFlight[svc.sessionKey(sess)]
+		return !ok
+	})
+	if got := readBestEffortLastCaptureAt(sess); !got.IsZero() {
+		t.Fatalf("persistent cursor advanced after failed capture: %v", got)
+	}
+	if err := svc.IngestSession(context.Background(), sess); err != nil {
+		t.Fatalf("retry IngestSession: %v", err)
+	}
+	select {
+	case <-secondDone:
+	case <-time.After(time.Second):
+		t.Fatalf("retry capture request did not complete")
+	}
 	if err := svc.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
+	}
+	if got := readBestEffortLastCaptureAt(sess); !got.Equal(want) {
+		t.Fatalf("cursor = %v, want %v", got, want)
 	}
 }
 
@@ -705,5 +797,19 @@ func captureReadySession() *session.Session {
 				}}},
 			},
 		},
+	}
+}
+
+func waitForCondition(t *testing.T, timeout time.Duration, condition func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !condition() {
+		t.Fatalf("condition was not met within %s", timeout)
 	}
 }

--- a/memory/tencentdb/service_test.go
+++ b/memory/tencentdb/service_test.go
@@ -507,8 +507,8 @@ func TestConversationSearchToolUsesCurrentSessionKey(t *testing.T) {
 	if rsp.Results != "hit" || rsp.Total != 1 {
 		t.Fatalf("response = %#v", rsp)
 	}
-	if got.SessionKey != "app:u1:s1" {
-		t.Fatalf("session_key = %q", got.SessionKey)
+	if got.SessionKey != "app:u1:s1" || got.UserID != "u1" {
+		t.Fatalf("conversation search scope = %#v", got)
 	}
 	if got.Limit != defaultSearchLimit {
 		t.Fatalf("limit = %d", got.Limit)
@@ -849,9 +849,19 @@ func TestMemorySearchToolAndHelpers(t *testing.T) {
 	}
 	defer svc.Close()
 
-	memTool, ok := svc.Tools()[0].(tool.CallableTool)
-	if !ok {
-		t.Fatalf("memory tool is not callable")
+	var memTool tool.CallableTool
+	for _, tl := range svc.Tools() {
+		if tl.Declaration().Name == "tdai_memory_search" {
+			var ok bool
+			memTool, ok = tl.(tool.CallableTool)
+			if !ok {
+				t.Fatalf("memory tool is not callable")
+			}
+			break
+		}
+	}
+	if memTool == nil {
+		t.Fatalf("memory tool not found")
 	}
 	if _, err := memTool.Call(context.Background(), []byte(`{"query":"hello"}`)); err == nil {
 		t.Fatalf("expected missing invocation error")
@@ -870,7 +880,8 @@ func TestMemorySearchToolAndHelpers(t *testing.T) {
 	if rsp.Results != "memory result" || rsp.Total != 3 || rsp.Strategy != "hybrid" {
 		t.Fatalf("response = %#v", rsp)
 	}
-	if got.Query != "profile" || got.Limit != maxSearchLimit || got.Type != "L1" || got.Scene != "work" {
+	if got.Query != "profile" || got.Limit != maxSearchLimit || got.Type != "L1" ||
+		got.Scene != "work" || got.UserID != "u1" {
 		t.Fatalf("search request = %#v", got)
 	}
 	if normalizeLimit(-1) != defaultSearchLimit || normalizeLimit(7) != 7 || normalizeLimit(99) != maxSearchLimit {

--- a/memory/tencentdb/service_test.go
+++ b/memory/tencentdb/service_test.go
@@ -300,6 +300,142 @@ func TestIngestSessionSerializesSameSessionCapturesAndTimestamps(t *testing.T) {
 	}
 }
 
+func TestEndSessionWaitsForPendingCapture(t *testing.T) {
+	releaseCapture := make(chan struct{})
+	captureStarted := make(chan struct{}, 1)
+	endCalled := make(chan struct{}, 1)
+	var released atomic.Bool
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case pathCapture:
+			requests.Add(1)
+			select {
+			case captureStarted <- struct{}{}:
+			default:
+			}
+			<-releaseCapture
+			_ = json.NewEncoder(w).Encode(captureResponse{L0Recorded: 2})
+		case pathEndSession:
+			if got := requests.Load(); got != 1 {
+				t.Fatalf("end called before capture request: captures=%d", got)
+			}
+			select {
+			case endCalled <- struct{}{}:
+			default:
+			}
+			_ = json.NewEncoder(w).Encode(endSessionResponse{Flushed: true})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	svc, err := NewService(
+		WithGatewayURL(server.URL),
+		WithIngestWorkers(2),
+		WithIngestQueueSize(2),
+		WithIngestJobTimeout(time.Second),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	defer func() {
+		if released.CompareAndSwap(false, true) {
+			close(releaseCapture)
+		}
+		if err := svc.Close(); err != nil {
+			t.Errorf("Close: %v", err)
+		}
+	}()
+
+	sess := captureReadySession()
+	if err := svc.IngestSession(context.Background(), sess); err != nil {
+		t.Fatalf("IngestSession: %v", err)
+	}
+	select {
+	case <-captureStarted:
+	case <-time.After(time.Second):
+		t.Fatalf("capture request did not start")
+	}
+	endDone := make(chan error, 1)
+	go func() {
+		endDone <- svc.EndSession(context.Background(), sess)
+	}()
+	select {
+	case <-endCalled:
+		t.Fatalf("end session reached gateway before capture completed")
+	case <-time.After(50 * time.Millisecond):
+	}
+	if released.CompareAndSwap(false, true) {
+		close(releaseCapture)
+	}
+	select {
+	case err := <-endDone:
+		if err != nil {
+			t.Fatalf("EndSession: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("EndSession did not complete")
+	}
+	select {
+	case <-endCalled:
+	default:
+		t.Fatalf("end session gateway call was not observed")
+	}
+}
+
+func TestServiceCheckpointSkipsReloadedSessionEvents(t *testing.T) {
+	requests := make(chan captureRequest, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != pathCapture {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		var req captureRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		requests <- req
+		_ = json.NewEncoder(w).Encode(captureResponse{L0Recorded: len(req.Messages)})
+	}))
+	defer server.Close()
+
+	svc, err := NewService(
+		WithGatewayURL(server.URL),
+		WithIngestQueueSize(2),
+		WithIngestJobTimeout(time.Second),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	defer func() {
+		if err := svc.Close(); err != nil {
+			t.Errorf("Close: %v", err)
+		}
+	}()
+
+	sess := captureReadySession()
+	if err := svc.IngestSession(context.Background(), sess); err != nil {
+		t.Fatalf("first IngestSession: %v", err)
+	}
+	_ = waitCaptureRequest(t, requests, "first capture")
+	reloaded := &session.Session{
+		ID:      sess.ID,
+		AppName: sess.AppName,
+		UserID:  sess.UserID,
+		Events:  sess.GetEvents(),
+		State:   session.StateMap{},
+	}
+	if err := svc.IngestSession(context.Background(), reloaded); err != nil {
+		t.Fatalf("reloaded IngestSession: %v", err)
+	}
+	select {
+	case req := <-requests:
+		t.Fatalf("reloaded session resent captured events: %#v", req)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
 func TestInjectRecallContext(t *testing.T) {
 	req := &model.Request{Messages: []model.Message{
 		model.NewSystemMessage("base"),
@@ -1001,9 +1137,12 @@ func TestCaptureAndClientFailurePaths(t *testing.T) {
 	previousFailed := &captureSerialState{done: make(chan struct{}), err: errors.New("previous failed")}
 	close(previousFailed.done)
 	if err := svc.capture(context.Background(), ingestJob{
-		req:      captureRequest{SessionKey: "s"},
-		previous: previousFailed,
-		serial:   &captureSerialState{done: make(chan struct{})},
+		req: captureRequest{SessionKey: "s"},
+		serial: &captureSerialState{
+			sessionKey: "s",
+			previous:   previousFailed,
+			done:       make(chan struct{}),
+		},
 	}); err == nil {
 		t.Fatalf("expected previous capture failure")
 	}
@@ -1011,9 +1150,12 @@ func TestCaptureAndClientFailurePaths(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	if err := svc.capture(ctx, ingestJob{
-		req:      captureRequest{SessionKey: "s"},
-		previous: &captureSerialState{done: make(chan struct{})},
-		serial:   &captureSerialState{done: make(chan struct{})},
+		req: captureRequest{SessionKey: "s"},
+		serial: &captureSerialState{
+			sessionKey: "s",
+			previous:   &captureSerialState{done: make(chan struct{})},
+			done:       make(chan struct{}),
+		},
 	}); err == nil {
 		t.Fatalf("expected context cancellation while waiting for previous capture")
 	}

--- a/memory/tencentdb/service_test.go
+++ b/memory/tencentdb/service_test.go
@@ -45,6 +45,7 @@ func TestServiceOptionsAndLifecycleEdges(t *testing.T) {
 			return "custom:" + sess.ID
 		}),
 		WithRecallEnabled(false),
+		WithMemorySearchTool(true),
 		WithConversationSearchTool(false),
 		WithStandardAliases(true),
 		WithToolPrefix("_custom_"),
@@ -65,6 +66,7 @@ func TestServiceOptionsAndLifecycleEdges(t *testing.T) {
 	assert.False(t, names["custom_conversation_search"], "conversation search should be disabled")
 	deduped, err := NewService(
 		WithGatewayURL(server.URL),
+		WithMemorySearchTool(true),
 		WithStandardAliases(true),
 		WithConversationSearchTool(false),
 		func(o *Options) { o.ToolPrefix = "" },
@@ -93,6 +95,51 @@ func TestServiceOptionsAndLifecycleEdges(t *testing.T) {
 	require.NoError(t, err, "NewService closed")
 	require.NoError(t, closed.Close(), "Close")
 	require.Error(t, closed.IngestSession(context.Background(), captureReadySession()), "expected closed service error")
+}
+
+func TestSafeDefaultsDisableCrossTenantReads(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(captureResponse{})
+	}))
+	defer server.Close()
+
+	svc, err := NewService(WithGatewayURL(server.URL))
+	require.NoError(t, err, "NewService")
+	defer svc.Close()
+
+	// Recall is opt-in: the plugin must not register a BeforeModel callback by
+	// default, since the shared gateway does not enforce user/session scoping.
+	mgr, err := pluginpkg.NewManager(svc.Plugin())
+	require.NoError(t, err, "NewManager")
+	assert.Nil(t, mgr.ModelCallbacks(), "recall should be disabled by default")
+
+	// memory_search is opt-in: only the session-scoped conversation search is
+	// exposed by default.
+	names := map[string]bool{}
+	for _, tl := range svc.Tools() {
+		names[tl.Declaration().Name] = true
+	}
+	assert.False(t, names["tdai_memory_search"], "memory search should be opt-in; tools=%#v", names)
+	assert.True(t, names["tdai_conversation_search"], "conversation search should be on by default; tools=%#v", names)
+
+	enabled, err := NewService(
+		WithGatewayURL(server.URL),
+		WithRecallEnabled(true),
+		WithMemorySearchTool(true),
+	)
+	require.NoError(t, err, "NewService enabled")
+	defer enabled.Close()
+
+	enabledMgr, err := pluginpkg.NewManager(enabled.Plugin())
+	require.NoError(t, err, "NewManager enabled")
+	require.NotNil(t, enabledMgr.ModelCallbacks(), "recall should register when enabled")
+	assert.Len(t, enabledMgr.ModelCallbacks().BeforeModel, 1)
+
+	enabledNames := map[string]bool{}
+	for _, tl := range enabled.Tools() {
+		enabledNames[tl.Declaration().Name] = true
+	}
+	assert.True(t, enabledNames["tdai_memory_search"], "memory search should be exposed when enabled; tools=%#v", enabledNames)
 }
 
 func TestEndSessionAndHealth(t *testing.T) {

--- a/memory/tencentdb/service_test.go
+++ b/memory/tencentdb/service_test.go
@@ -99,6 +99,36 @@ func TestIngestSessionCapturesTimestampedMessagesAndCursor(t *testing.T) {
 	}
 }
 
+func TestIngestSessionAdvancesCursorBeforeAsyncCaptureCompletes(t *testing.T) {
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release
+		_ = json.NewEncoder(w).Encode(captureResponse{L0Recorded: 2})
+	}))
+	defer server.Close()
+
+	svc, err := NewService(
+		WithGatewayURL(server.URL),
+		WithIngestQueueSize(1),
+		WithIngestJobTimeout(time.Second),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	sess := captureReadySession()
+	want := sess.Events[len(sess.Events)-1].Timestamp
+	if err := svc.IngestSession(context.Background(), sess); err != nil {
+		t.Fatalf("IngestSession: %v", err)
+	}
+	if got := readBestEffortLastCaptureAt(sess); !got.Equal(want) {
+		t.Fatalf("cursor = %v, want %v", got, want)
+	}
+	close(release)
+	if err := svc.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
 func TestInjectRecallContext(t *testing.T) {
 	req := &model.Request{Messages: []model.Message{
 		model.NewSystemMessage("base"),

--- a/memory/tencentdb/service_test.go
+++ b/memory/tencentdb/service_test.go
@@ -97,6 +97,15 @@ func TestServiceOptionsAndLifecycleEdges(t *testing.T) {
 	require.Error(t, closed.IngestSession(context.Background(), captureReadySession()), "expected closed service error")
 }
 
+func TestDefaultSessionKeyAvoidsDelimiterCollisions(t *testing.T) {
+	left := &session.Session{AppName: "app", UserID: "user:session", ID: "id"}
+	right := &session.Session{AppName: "app:user", UserID: "session", ID: "id"}
+
+	assert.NotEqual(t, defaultSessionKey(left), defaultSessionKey(right))
+	assert.Equal(t, "YXBw:dXNlcjpzZXNzaW9u:aWQ", defaultSessionKey(left))
+	assert.Equal(t, "YXBwOnVzZXI:c2Vzc2lvbg:aWQ", defaultSessionKey(right))
+}
+
 func TestSafeDefaultsDisableCrossTenantReads(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(captureResponse{})
@@ -182,7 +191,7 @@ func TestEndSessionAndHealth(t *testing.T) {
 	sess := &session.Session{ID: "s1", AppName: "app", UserID: "user"}
 	writeBestEffortSyntheticTimestamp(sess, 123)
 	require.NoError(t, svc.EndSession(context.Background(), sess), "EndSession")
-	assert.Equal(t, endSessionRequest{SessionKey: "app:user:s1", UserID: "user"}, ended)
+	assert.Equal(t, endSessionRequest{SessionKey: defaultSessionKey(sess), UserID: "user"}, ended)
 	assert.Zero(t, readBestEffortSyntheticTimestamp(sess))
 	health, err := svc.Health(context.Background())
 	require.NoError(t, err, "Health")

--- a/memory/tencentdb/service_test.go
+++ b/memory/tencentdb/service_test.go
@@ -736,11 +736,15 @@ func TestEndSessionAndHealth(t *testing.T) {
 	defer svc.Close()
 
 	sess := &session.Session{ID: "s1", AppName: "app", UserID: "user"}
+	writeBestEffortSyntheticTimestamp(sess, 123)
 	if err := svc.EndSession(context.Background(), sess); err != nil {
 		t.Fatalf("EndSession: %v", err)
 	}
 	if ended.SessionKey != "app:user:s1" || ended.UserID != "user" {
 		t.Fatalf("end session request = %#v", ended)
+	}
+	if got := readBestEffortSyntheticTimestamp(sess); got != 0 {
+		t.Fatalf("synthetic timestamp was not cleared: %d", got)
 	}
 	health, err := svc.Health(context.Background())
 	if err != nil {

--- a/memory/tencentdb/service_test.go
+++ b/memory/tencentdb/service_test.go
@@ -499,7 +499,7 @@ func TestConversationSearchToolUsesCurrentSessionKey(t *testing.T) {
 
 	sess := &session.Session{ID: "s1", AppName: "app", UserID: "u1"}
 	ctx := agent.NewInvocationContext(context.Background(), &agent.Invocation{Session: sess}).Context
-	raw, err := convTool.Call(ctx, []byte(`{"query":"previous topic"}`))
+	raw, err := convTool.Call(ctx, []byte(`{"query":"previous topic","session_key":"app:other:secret"}`))
 	if err != nil {
 		t.Fatalf("Call: %v", err)
 	}

--- a/memory/tencentdb/service_test.go
+++ b/memory/tencentdb/service_test.go
@@ -221,6 +221,85 @@ func TestIngestSessionRetriesAfterAsyncCaptureFailure(t *testing.T) {
 	}
 }
 
+func TestIngestSessionSerializesSameSessionCapturesAndTimestamps(t *testing.T) {
+	releaseFirst := make(chan struct{})
+	firstReqC := make(chan captureRequest, 1)
+	secondReqC := make(chan captureRequest, 1)
+	var released atomic.Bool
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != pathCapture {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		var req captureRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		switch requests.Add(1) {
+		case 1:
+			firstReqC <- req
+			<-releaseFirst
+		case 2:
+			secondReqC <- req
+		default:
+			t.Fatalf("unexpected extra capture request")
+		}
+		_ = json.NewEncoder(w).Encode(captureResponse{L0Recorded: len(req.Messages)})
+	}))
+	defer server.Close()
+	defer func() {
+		if released.CompareAndSwap(false, true) {
+			close(releaseFirst)
+		}
+	}()
+
+	svc, err := NewService(
+		WithGatewayURL(server.URL),
+		WithIngestWorkers(2),
+		WithIngestQueueSize(2),
+		WithIngestJobTimeout(time.Second),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	defer func() {
+		if err := svc.Close(); err != nil {
+			t.Errorf("Close: %v", err)
+		}
+	}()
+	sess := captureReadySession()
+	if err := svc.IngestSession(context.Background(), sess); err != nil {
+		t.Fatalf("first IngestSession: %v", err)
+	}
+	firstReq := waitCaptureRequest(t, firstReqC, "first capture")
+
+	events := sess.GetEvents()
+	nextAt := events[len(events)-1].Timestamp.Add(time.Second)
+	appendSessionPair(sess, nextAt, "u2", "second fact", "a2", "stored second")
+	if err := svc.IngestSession(context.Background(), sess); err != nil {
+		t.Fatalf("second IngestSession: %v", err)
+	}
+	select {
+	case req := <-secondReqC:
+		t.Fatalf("second capture started before first completed: %#v", req)
+	case <-time.After(50 * time.Millisecond):
+	}
+	if released.CompareAndSwap(false, true) {
+		close(releaseFirst)
+	}
+	secondReq := waitCaptureRequest(t, secondReqC, "second capture")
+	if len(firstReq.Messages) == 0 || len(secondReq.Messages) == 0 {
+		t.Fatalf("empty capture messages: first=%d second=%d", len(firstReq.Messages), len(secondReq.Messages))
+	}
+	firstLast := firstReq.Messages[len(firstReq.Messages)-1].Timestamp
+	if secondReq.Messages[0].Timestamp <= firstLast {
+		t.Fatalf("second timestamp = %d, want > %d", secondReq.Messages[0].Timestamp, firstLast)
+	}
+	if secondReq.UserContent != "second fact" || secondReq.AssistantContent != "stored second" {
+		t.Fatalf("second captured pair = %q / %q", secondReq.UserContent, secondReq.AssistantContent)
+	}
+}
+
 func TestInjectRecallContext(t *testing.T) {
 	req := &model.Request{Messages: []model.Message{
 		model.NewSystemMessage("base"),
@@ -797,6 +876,45 @@ func captureReadySession() *session.Session {
 				}}},
 			},
 		},
+	}
+}
+
+func appendSessionPair(
+	sess *session.Session,
+	at time.Time,
+	userID string,
+	userContent string,
+	assistantID string,
+	assistantContent string,
+) {
+	sess.EventMu.Lock()
+	defer sess.EventMu.Unlock()
+	sess.Events = append(sess.Events,
+		event.Event{
+			ID:        userID,
+			Timestamp: at,
+			Response: &model.Response{Choices: []model.Choice{{
+				Message: model.NewUserMessage(userContent),
+			}}},
+		},
+		event.Event{
+			ID:        assistantID,
+			Timestamp: at.Add(time.Second),
+			Response: &model.Response{Choices: []model.Choice{{
+				Message: model.NewAssistantMessage(assistantContent),
+			}}},
+		},
+	)
+}
+
+func waitCaptureRequest(t *testing.T, ch <-chan captureRequest, name string) captureRequest {
+	t.Helper()
+	select {
+	case req := <-ch:
+		return req
+	case <-time.After(time.Second):
+		t.Fatalf("%s did not start", name)
+		return captureRequest{}
 	}
 }
 

--- a/memory/tencentdb/service_test.go
+++ b/memory/tencentdb/service_test.go
@@ -15,705 +15,15 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
-	"trpc.group/trpc-go/trpc-agent-go/agent"
-	"trpc.group/trpc-go/trpc-agent-go/event"
-	"trpc.group/trpc-go/trpc-agent-go/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	pluginpkg "trpc.group/trpc-go/trpc-agent-go/plugin"
 	"trpc.group/trpc-go/trpc-agent-go/session"
-	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
-
-func TestIngestSessionCapturesTimestampedMessagesAndCursor(t *testing.T) {
-	var got captureRequest
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != pathCapture {
-			t.Fatalf("unexpected path %s", r.URL.Path)
-		}
-		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
-			t.Fatalf("decode request: %v", err)
-		}
-		_ = json.NewEncoder(w).Encode(captureResponse{L0Recorded: len(got.Messages)})
-	}))
-	defer server.Close()
-
-	svc, err := NewService(
-		WithGatewayURL(server.URL),
-		WithIngestQueueSize(1),
-		WithIngestJobTimeout(time.Second),
-	)
-	if err != nil {
-		t.Fatalf("NewService: %v", err)
-	}
-
-	ts1 := time.Date(2026, 5, 22, 8, 0, 0, 123*1e6, time.UTC)
-	ts2 := ts1.Add(time.Second)
-	sess := &session.Session{
-		ID:      "sess-1",
-		AppName: "app",
-		UserID:  "user",
-		State:   session.StateMap{},
-		Events: []event.Event{
-			{
-				ID:        "u1",
-				Timestamp: ts1,
-				Response: &model.Response{Choices: []model.Choice{{
-					Index:   0,
-					Message: model.NewUserMessage("remember this"),
-				}}},
-			},
-			{
-				ID:        "a1",
-				Timestamp: ts2,
-				Response: &model.Response{Choices: []model.Choice{{
-					Index:   0,
-					Message: model.NewAssistantMessage("stored"),
-				}}},
-			},
-		},
-	}
-	if err := svc.IngestSession(context.Background(), sess); err != nil {
-		t.Fatalf("IngestSession: %v", err)
-	}
-	if err := svc.Close(); err != nil {
-		t.Fatalf("Close: %v", err)
-	}
-
-	if got.SessionKey != "app:user:sess-1" {
-		t.Fatalf("session_key = %q", got.SessionKey)
-	}
-	if got.UserContent != "remember this" || got.AssistantContent != "stored" {
-		t.Fatalf("captured pair = %q / %q", got.UserContent, got.AssistantContent)
-	}
-	if len(got.Messages) != 2 {
-		t.Fatalf("messages length = %d", len(got.Messages))
-	}
-	if got.Messages[0].Timestamp <= ts2.UnixMilli() || got.Messages[1].Timestamp != got.Messages[0].Timestamp+1 {
-		t.Fatalf("timestamps = %d, %d", got.Messages[0].Timestamp, got.Messages[1].Timestamp)
-	}
-	if readBestEffortLastCaptureAt(sess) != ts2 {
-		t.Fatalf("cursor was not advanced to latest event")
-	}
-}
-
-func TestIngestSessionMarksInFlightBeforeAsyncCaptureCompletes(t *testing.T) {
-	release := make(chan struct{})
-	started := make(chan struct{}, 1)
-	var requests atomic.Int32
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != pathCapture {
-			t.Fatalf("unexpected path %s", r.URL.Path)
-		}
-		requests.Add(1)
-		select {
-		case started <- struct{}{}:
-		default:
-		}
-		<-release
-		_ = json.NewEncoder(w).Encode(captureResponse{L0Recorded: 2})
-	}))
-	defer server.Close()
-
-	svc, err := NewService(
-		WithGatewayURL(server.URL),
-		WithIngestQueueSize(1),
-		WithIngestJobTimeout(time.Second),
-	)
-	if err != nil {
-		t.Fatalf("NewService: %v", err)
-	}
-	defer func() {
-		close(release)
-		if err := svc.Close(); err != nil {
-			t.Errorf("Close: %v", err)
-		}
-	}()
-	sess := captureReadySession()
-	if err := svc.IngestSession(context.Background(), sess); err != nil {
-		t.Fatalf("IngestSession: %v", err)
-	}
-	select {
-	case <-started:
-	case <-time.After(time.Second):
-		t.Fatalf("capture request did not start")
-	}
-	if got := readBestEffortLastCaptureAt(sess); !got.IsZero() {
-		t.Fatalf("persistent cursor advanced before capture success: %v", got)
-	}
-	if err := svc.IngestSession(context.Background(), sess); err != nil {
-		t.Fatalf("second IngestSession: %v", err)
-	}
-	if got := requests.Load(); got != 1 {
-		t.Fatalf("capture requests = %d, want 1", got)
-	}
-}
-
-func TestIngestSessionRetriesAfterAsyncCaptureFailure(t *testing.T) {
-	firstDone := make(chan struct{})
-	secondDone := make(chan struct{})
-	var requests atomic.Int32
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != pathCapture {
-			t.Fatalf("unexpected path %s", r.URL.Path)
-		}
-		switch requests.Add(1) {
-		case 1:
-			http.Error(w, "gateway unavailable", http.StatusBadGateway)
-			close(firstDone)
-		case 2:
-			_ = json.NewEncoder(w).Encode(captureResponse{L0Recorded: 2})
-			close(secondDone)
-		default:
-			t.Fatalf("unexpected extra capture request")
-		}
-	}))
-	defer server.Close()
-
-	svc, err := NewService(
-		WithGatewayURL(server.URL),
-		WithIngestQueueSize(1),
-		WithIngestJobTimeout(time.Second),
-	)
-	if err != nil {
-		t.Fatalf("NewService: %v", err)
-	}
-	defer func() {
-		if err := svc.Close(); err != nil {
-			t.Errorf("Close: %v", err)
-		}
-	}()
-	sess := captureReadySession()
-	want := sess.Events[len(sess.Events)-1].Timestamp
-	if err := svc.IngestSession(context.Background(), sess); err != nil {
-		t.Fatalf("IngestSession: %v", err)
-	}
-	select {
-	case <-firstDone:
-	case <-time.After(time.Second):
-		t.Fatalf("first capture request did not complete")
-	}
-	waitForCondition(t, time.Second, func() bool {
-		svc.cursorMu.Lock()
-		defer svc.cursorMu.Unlock()
-		_, ok := svc.inFlight[svc.sessionKey(sess)]
-		return !ok
-	})
-	if got := readBestEffortLastCaptureAt(sess); !got.IsZero() {
-		t.Fatalf("persistent cursor advanced after failed capture: %v", got)
-	}
-	if err := svc.IngestSession(context.Background(), sess); err != nil {
-		t.Fatalf("retry IngestSession: %v", err)
-	}
-	select {
-	case <-secondDone:
-	case <-time.After(time.Second):
-		t.Fatalf("retry capture request did not complete")
-	}
-	if err := svc.Close(); err != nil {
-		t.Fatalf("Close: %v", err)
-	}
-	if got := readBestEffortLastCaptureAt(sess); !got.Equal(want) {
-		t.Fatalf("cursor = %v, want %v", got, want)
-	}
-}
-
-func TestIngestSessionSerializesSameSessionCapturesAndTimestamps(t *testing.T) {
-	releaseFirst := make(chan struct{})
-	firstReqC := make(chan captureRequest, 1)
-	secondReqC := make(chan captureRequest, 1)
-	var released atomic.Bool
-	var requests atomic.Int32
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != pathCapture {
-			t.Fatalf("unexpected path %s", r.URL.Path)
-		}
-		var req captureRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			t.Fatalf("decode request: %v", err)
-		}
-		switch requests.Add(1) {
-		case 1:
-			firstReqC <- req
-			<-releaseFirst
-		case 2:
-			secondReqC <- req
-		default:
-			t.Fatalf("unexpected extra capture request")
-		}
-		_ = json.NewEncoder(w).Encode(captureResponse{L0Recorded: len(req.Messages)})
-	}))
-	defer server.Close()
-	defer func() {
-		if released.CompareAndSwap(false, true) {
-			close(releaseFirst)
-		}
-	}()
-
-	svc, err := NewService(
-		WithGatewayURL(server.URL),
-		WithIngestWorkers(2),
-		WithIngestQueueSize(2),
-		WithIngestJobTimeout(time.Second),
-	)
-	if err != nil {
-		t.Fatalf("NewService: %v", err)
-	}
-	defer func() {
-		if err := svc.Close(); err != nil {
-			t.Errorf("Close: %v", err)
-		}
-	}()
-	sess := captureReadySession()
-	if err := svc.IngestSession(context.Background(), sess); err != nil {
-		t.Fatalf("first IngestSession: %v", err)
-	}
-	firstReq := waitCaptureRequest(t, firstReqC, "first capture")
-
-	events := sess.GetEvents()
-	nextAt := events[len(events)-1].Timestamp.Add(time.Second)
-	appendSessionPair(sess, nextAt, "u2", "second fact", "a2", "stored second")
-	if err := svc.IngestSession(context.Background(), sess); err != nil {
-		t.Fatalf("second IngestSession: %v", err)
-	}
-	select {
-	case req := <-secondReqC:
-		t.Fatalf("second capture started before first completed: %#v", req)
-	case <-time.After(50 * time.Millisecond):
-	}
-	if released.CompareAndSwap(false, true) {
-		close(releaseFirst)
-	}
-	secondReq := waitCaptureRequest(t, secondReqC, "second capture")
-	if len(firstReq.Messages) == 0 || len(secondReq.Messages) == 0 {
-		t.Fatalf("empty capture messages: first=%d second=%d", len(firstReq.Messages), len(secondReq.Messages))
-	}
-	firstLast := firstReq.Messages[len(firstReq.Messages)-1].Timestamp
-	if secondReq.Messages[0].Timestamp <= firstLast {
-		t.Fatalf("second timestamp = %d, want > %d", secondReq.Messages[0].Timestamp, firstLast)
-	}
-	if secondReq.UserContent != "second fact" || secondReq.AssistantContent != "stored second" {
-		t.Fatalf("second captured pair = %q / %q", secondReq.UserContent, secondReq.AssistantContent)
-	}
-}
-
-func TestEndSessionWaitsForPendingCapture(t *testing.T) {
-	releaseCapture := make(chan struct{})
-	captureStarted := make(chan struct{}, 1)
-	endCalled := make(chan struct{}, 1)
-	var released atomic.Bool
-	var requests atomic.Int32
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case pathCapture:
-			requests.Add(1)
-			select {
-			case captureStarted <- struct{}{}:
-			default:
-			}
-			<-releaseCapture
-			_ = json.NewEncoder(w).Encode(captureResponse{L0Recorded: 2})
-		case pathEndSession:
-			if got := requests.Load(); got != 1 {
-				t.Fatalf("end called before capture request: captures=%d", got)
-			}
-			select {
-			case endCalled <- struct{}{}:
-			default:
-			}
-			_ = json.NewEncoder(w).Encode(endSessionResponse{Flushed: true})
-		default:
-			t.Fatalf("unexpected path %s", r.URL.Path)
-		}
-	}))
-	defer server.Close()
-
-	svc, err := NewService(
-		WithGatewayURL(server.URL),
-		WithIngestWorkers(2),
-		WithIngestQueueSize(2),
-		WithIngestJobTimeout(time.Second),
-	)
-	if err != nil {
-		t.Fatalf("NewService: %v", err)
-	}
-	defer func() {
-		if released.CompareAndSwap(false, true) {
-			close(releaseCapture)
-		}
-		if err := svc.Close(); err != nil {
-			t.Errorf("Close: %v", err)
-		}
-	}()
-
-	sess := captureReadySession()
-	if err := svc.IngestSession(context.Background(), sess); err != nil {
-		t.Fatalf("IngestSession: %v", err)
-	}
-	select {
-	case <-captureStarted:
-	case <-time.After(time.Second):
-		t.Fatalf("capture request did not start")
-	}
-	endDone := make(chan error, 1)
-	go func() {
-		endDone <- svc.EndSession(context.Background(), sess)
-	}()
-	select {
-	case <-endCalled:
-		t.Fatalf("end session reached gateway before capture completed")
-	case <-time.After(50 * time.Millisecond):
-	}
-	if released.CompareAndSwap(false, true) {
-		close(releaseCapture)
-	}
-	select {
-	case err := <-endDone:
-		if err != nil {
-			t.Fatalf("EndSession: %v", err)
-		}
-	case <-time.After(time.Second):
-		t.Fatalf("EndSession did not complete")
-	}
-	select {
-	case <-endCalled:
-	default:
-		t.Fatalf("end session gateway call was not observed")
-	}
-}
-
-func TestServiceCheckpointSkipsReloadedSessionEvents(t *testing.T) {
-	requests := make(chan captureRequest, 2)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != pathCapture {
-			t.Fatalf("unexpected path %s", r.URL.Path)
-		}
-		var req captureRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			t.Fatalf("decode request: %v", err)
-		}
-		requests <- req
-		_ = json.NewEncoder(w).Encode(captureResponse{L0Recorded: len(req.Messages)})
-	}))
-	defer server.Close()
-
-	svc, err := NewService(
-		WithGatewayURL(server.URL),
-		WithIngestQueueSize(2),
-		WithIngestJobTimeout(time.Second),
-	)
-	if err != nil {
-		t.Fatalf("NewService: %v", err)
-	}
-	defer func() {
-		if err := svc.Close(); err != nil {
-			t.Errorf("Close: %v", err)
-		}
-	}()
-
-	sess := captureReadySession()
-	if err := svc.IngestSession(context.Background(), sess); err != nil {
-		t.Fatalf("first IngestSession: %v", err)
-	}
-	_ = waitCaptureRequest(t, requests, "first capture")
-	reloaded := &session.Session{
-		ID:      sess.ID,
-		AppName: sess.AppName,
-		UserID:  sess.UserID,
-		Events:  sess.GetEvents(),
-		State:   session.StateMap{},
-	}
-	if err := svc.IngestSession(context.Background(), reloaded); err != nil {
-		t.Fatalf("reloaded IngestSession: %v", err)
-	}
-	select {
-	case req := <-requests:
-		t.Fatalf("reloaded session resent captured events: %#v", req)
-	case <-time.After(50 * time.Millisecond):
-	}
-}
-
-func TestInjectRecallContext(t *testing.T) {
-	req := &model.Request{Messages: []model.Message{
-		model.NewSystemMessage("base"),
-		model.NewUserMessage("hello"),
-	}}
-	injectRecallContext(req, &recallResponse{
-		AppendSystemContext: "system recall",
-		PrependContext:      "user recall",
-	})
-
-	if len(req.Messages) != 3 {
-		t.Fatalf("message length = %d", len(req.Messages))
-	}
-	if req.Messages[0].Role != model.RoleSystem || req.Messages[0].Content != "base\n\nsystem recall" {
-		t.Fatalf("system message = %#v", req.Messages[0])
-	}
-	if req.Messages[1].Role != model.RoleUser || req.Messages[1].Content != "user recall" {
-		t.Fatalf("prepended user message = %#v", req.Messages[1])
-	}
-	if req.Messages[2].Content != "hello" {
-		t.Fatalf("latest user was not preserved: %#v", req.Messages[2])
-	}
-}
-
-func TestConversationSearchToolUsesCurrentSessionKey(t *testing.T) {
-	var got searchConversationsRequest
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != pathSearchConversations {
-			t.Fatalf("unexpected path %s", r.URL.Path)
-		}
-		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
-			t.Fatalf("decode request: %v", err)
-		}
-		_ = json.NewEncoder(w).Encode(searchConversationsResponse{
-			Results: "hit",
-			Total:   1,
-		})
-	}))
-	defer server.Close()
-
-	svc, err := NewService(WithGatewayURL(server.URL))
-	if err != nil {
-		t.Fatalf("NewService: %v", err)
-	}
-	defer svc.Close()
-
-	var convTool tool.CallableTool
-	for _, tl := range svc.Tools() {
-		if tl.Declaration().Name == "tdai_conversation_search" {
-			var ok bool
-			convTool, ok = tl.(tool.CallableTool)
-			if !ok {
-				t.Fatalf("conversation tool is not callable")
-			}
-			break
-		}
-	}
-	if convTool == nil {
-		t.Fatalf("conversation tool not found")
-	}
-
-	sess := &session.Session{ID: "s1", AppName: "app", UserID: "u1"}
-	ctx := agent.NewInvocationContext(context.Background(), &agent.Invocation{Session: sess}).Context
-	raw, err := convTool.Call(ctx, []byte(`{"query":"previous topic","session_key":"app:other:secret"}`))
-	if err != nil {
-		t.Fatalf("Call: %v", err)
-	}
-	rsp := raw.(*searchConversationsToolResponse)
-	if rsp.Results != "hit" || rsp.Total != 1 {
-		t.Fatalf("response = %#v", rsp)
-	}
-	if got.SessionKey != "app:u1:s1" || got.UserID != "u1" {
-		t.Fatalf("conversation search scope = %#v", got)
-	}
-	if got.Limit != defaultSearchLimit {
-		t.Fatalf("limit = %d", got.Limit)
-	}
-}
-
-func TestGatewayClientEndpointsAndErrors(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case pathRecall:
-			_ = json.NewEncoder(w).Encode(recallResponse{
-				Context:             "legacy",
-				PrependContext:      "prepend",
-				AppendSystemContext: "append",
-				Strategy:            "hybrid",
-				MemoryCount:         2,
-			})
-		case pathSearchMemories:
-			_ = json.NewEncoder(w).Encode(searchMemoriesResponse{
-				Results:  "memory hit",
-				Total:    1,
-				Strategy: "semantic",
-			})
-		case pathEndSession:
-			_ = json.NewEncoder(w).Encode(endSessionResponse{Flushed: true})
-		case pathHealth:
-			_ = json.NewEncoder(w).Encode(HealthResponse{Status: "ok", Version: "test"})
-		default:
-			http.Error(w, strings.Repeat("x", 700), http.StatusBadGateway)
-		}
-	}))
-	defer server.Close()
-
-	client, err := newGatewayClient(Options{
-		GatewayURL:   server.URL,
-		Timeout:      time.Second,
-		MaxBodyBytes: defaultMaxBodyBytes,
-	})
-	if err != nil {
-		t.Fatalf("newGatewayClient: %v", err)
-	}
-	recall, err := client.recall(context.Background(), recallRequest{Query: "q", SessionKey: "s"})
-	if err != nil {
-		t.Fatalf("recall: %v", err)
-	}
-	if recall.AppendSystemContext != "append" || recall.MemoryCount != 2 {
-		t.Fatalf("recall response = %#v", recall)
-	}
-	memories, err := client.searchMemories(context.Background(), searchMemoriesRequest{Query: "q"})
-	if err != nil {
-		t.Fatalf("searchMemories: %v", err)
-	}
-	if memories.Results != "memory hit" || memories.Strategy != "semantic" {
-		t.Fatalf("search memories response = %#v", memories)
-	}
-	ended, err := client.endSession(context.Background(), endSessionRequest{SessionKey: "s"})
-	if err != nil {
-		t.Fatalf("endSession: %v", err)
-	}
-	if !ended.Flushed {
-		t.Fatalf("end session response = %#v", ended)
-	}
-	health, err := client.health(context.Background())
-	if err != nil {
-		t.Fatalf("health: %v", err)
-	}
-	if health.Status != "ok" || health.Version != "test" {
-		t.Fatalf("health response = %#v", health)
-	}
-
-	if err := client.doJSON(context.Background(), httpMethodGet, "/missing", nil, nil); err == nil {
-		t.Fatalf("expected API error")
-	} else {
-		var apiErr *APIError
-		if !errors.As(err, &apiErr) {
-			t.Fatalf("expected APIError, got %T: %v", err, err)
-		}
-		if !strings.Contains(apiErr.Error(), "status=502") {
-			t.Fatalf("unexpected APIError string: %s", apiErr.Error())
-		}
-		if len(apiErr.Body) > maxErrorBodyPreview+len("...(truncated)") {
-			t.Fatalf("error preview was not truncated")
-		}
-	}
-	if err := client.doJSON(context.Background(), httpMethodPost, pathCapture, map[string]any{
-		"bad": func() {},
-	}, nil); err == nil {
-		t.Fatalf("expected marshal error")
-	}
-
-	tiny, err := newGatewayClient(Options{GatewayURL: server.URL, MaxBodyBytes: 4})
-	if err != nil {
-		t.Fatalf("new tiny client: %v", err)
-	}
-	if _, err := tiny.health(context.Background()); err == nil {
-		t.Fatalf("expected response body too large")
-	}
-	if _, err := newGatewayClient(Options{GatewayURL: "://bad"}); err == nil {
-		t.Fatalf("expected invalid gateway url error")
-	}
-	if _, err := newGatewayClient(Options{GatewayURL: "/path-only"}); err == nil {
-		t.Fatalf("expected path-only gateway url error")
-	}
-	if _, err := newGatewayClient(Options{GatewayURL: "ftp://example.com"}); err == nil {
-		t.Fatalf("expected unsupported scheme gateway url error")
-	}
-	if _, err := newGatewayClient(Options{}); err == nil {
-		t.Fatalf("expected empty gateway url error")
-	}
-	nullable, err := newGatewayClient(Options{GatewayURL: server.URL})
-	if err != nil {
-		t.Fatalf("new nullable client: %v", err)
-	}
-	if err := nullable.doJSON(context.Background(), httpMethodGet, pathHealth, nil, nil); err != nil {
-		t.Fatalf("nil output should be accepted: %v", err)
-	}
-}
-
-func TestGatewayClientDecodeAndRequestEdges(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/empty":
-			w.WriteHeader(http.StatusNoContent)
-		case "/bad-json":
-			_, _ = w.Write([]byte("{"))
-		default:
-			_ = json.NewEncoder(w).Encode(HealthResponse{Status: "ok"})
-		}
-	}))
-	defer server.Close()
-
-	client, err := newGatewayClient(Options{GatewayURL: server.URL})
-	if err != nil {
-		t.Fatalf("newGatewayClient: %v", err)
-	}
-	var out HealthResponse
-	if err := client.doJSON(context.Background(), httpMethodGet, "/empty", nil, &out); err != nil {
-		t.Fatalf("empty response should be accepted: %v", err)
-	}
-	if err := client.doJSON(context.Background(), httpMethodGet, "/bad-json", nil, &out); err == nil {
-		t.Fatalf("expected unmarshal error")
-	}
-	if err := client.doJSONOnce(context.Background(), httpMethodGet, "://bad", nil, nil); err == nil {
-		t.Fatalf("expected request build error")
-	}
-}
-
-func TestRecallPluginInjectsContext(t *testing.T) {
-	var got recallRequest
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != pathRecall {
-			t.Fatalf("unexpected path %s", r.URL.Path)
-		}
-		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
-			t.Fatalf("decode request: %v", err)
-		}
-		_ = json.NewEncoder(w).Encode(recallResponse{
-			AppendSystemContext: "remembered system",
-			PrependContext:      "remembered user context",
-		})
-	}))
-	defer server.Close()
-
-	svc, err := NewService(WithGatewayURL(server.URL))
-	if err != nil {
-		t.Fatalf("NewService: %v", err)
-	}
-	defer svc.Close()
-
-	p := svc.Plugin()
-	if p.Name() != "tencentdb_agent_memory" {
-		t.Fatalf("plugin name = %q", p.Name())
-	}
-	mgr, err := pluginpkg.NewManager(p)
-	if err != nil {
-		t.Fatalf("NewManager: %v", err)
-	}
-	callbacks := mgr.ModelCallbacks()
-	if callbacks == nil || len(callbacks.BeforeModel) != 1 {
-		t.Fatalf("expected one before model callback")
-	}
-
-	req := &model.Request{Messages: []model.Message{
-		model.NewSystemMessage("base"),
-		model.NewUserMessage("what did I say?"),
-	}}
-	sess := &session.Session{ID: "s1", AppName: "app", UserID: "user"}
-	ctx := agent.NewInvocationContext(context.Background(), &agent.Invocation{Session: sess}).Context
-	if _, err := callbacks.BeforeModel[0](ctx, &model.BeforeModelArgs{Request: req}); err != nil {
-		t.Fatalf("before model: %v", err)
-	}
-
-	if got.Query != "what did I say?" || got.SessionKey != "app:user:s1" || got.UserID != "user" {
-		t.Fatalf("recall request = %#v", got)
-	}
-	if len(req.Messages) != 3 {
-		t.Fatalf("message length = %d", len(req.Messages))
-	}
-	if req.Messages[0].Content != "base\n\nremembered system" {
-		t.Fatalf("system message = %#v", req.Messages[0])
-	}
-	if req.Messages[1].Content != "remembered user context" {
-		t.Fatalf("inserted context = %#v", req.Messages[1])
-	}
-}
 
 func TestServiceOptionsAndLifecycleEdges(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -739,265 +49,50 @@ func TestServiceOptionsAndLifecycleEdges(t *testing.T) {
 		WithStandardAliases(true),
 		WithToolPrefix("_custom_"),
 	)
-	if err != nil {
-		t.Fatalf("NewService: %v", err)
-	}
+	require.NoError(t, err, "NewService")
 	defer svc.Close()
 
-	if svc.client.hc != customClient {
-		t.Fatalf("custom HTTP client was not used")
-	}
-	if svc.client.timeout != time.Second || svc.client.maxBodyBytes != 1024 {
-		t.Fatalf("client options = timeout %v max %d", svc.client.timeout, svc.client.maxBodyBytes)
-	}
-	if svc.sessionKey(&session.Session{ID: "s1"}) != "custom:s1" {
-		t.Fatalf("custom session key was not used")
-	}
+	assert.Same(t, customClient, svc.client.hc)
+	assert.Equal(t, time.Second, svc.client.timeout)
+	assert.Equal(t, int64(1024), svc.client.maxBodyBytes)
+	assert.Equal(t, "custom:s1", svc.sessionKey(&session.Session{ID: "s1"}))
 	names := map[string]bool{}
 	for _, tl := range svc.Tools() {
 		names[tl.Declaration().Name] = true
 	}
-	if !names["custom_memory_search"] || !names["memory_search"] {
-		t.Fatalf("tool names = %#v", names)
-	}
-	if names["custom_conversation_search"] {
-		t.Fatalf("conversation search should be disabled")
-	}
+	assert.True(t, names["custom_memory_search"], "tool names = %#v", names)
+	assert.True(t, names["memory_search"], "tool names = %#v", names)
+	assert.False(t, names["custom_conversation_search"], "conversation search should be disabled")
 	deduped, err := NewService(
 		WithGatewayURL(server.URL),
 		WithStandardAliases(true),
 		WithConversationSearchTool(false),
 		func(o *Options) { o.ToolPrefix = "" },
 	)
-	if err != nil {
-		t.Fatalf("NewService deduped: %v", err)
-	}
+	require.NoError(t, err, "NewService deduped")
 	defer deduped.Close()
-	if got := len(deduped.Tools()); got != 1 {
-		t.Fatalf("deduped tool count = %d, want 1", got)
-	}
-	if plugin, ok := svc.Plugin().(*recallPlugin); !ok || plugin.service != svc {
-		t.Fatalf("unexpected plugin = %#v", plugin)
-	} else {
-		mgr, err := pluginpkg.NewManager(plugin)
-		if err != nil {
-			t.Fatalf("NewManager: %v", err)
-		}
-		if mgr.ModelCallbacks() != nil {
-			t.Fatalf("recall disabled should not register callbacks")
-		}
-	}
+	assert.Len(t, deduped.Tools(), 1)
+	plugin, ok := svc.Plugin().(*recallPlugin)
+	require.True(t, ok, "unexpected plugin = %#v", plugin)
+	assert.Same(t, svc, plugin.service)
+	mgr, err := pluginpkg.NewManager(plugin)
+	require.NoError(t, err)
+	assert.Nil(t, mgr.ModelCallbacks(), "recall disabled should not register callbacks")
 
 	var nilSvc *Service
-	if nilSvc.Tools() != nil {
-		t.Fatalf("nil service should not expose tools")
-	}
-	if (&Service{}).Tools() != nil {
-		t.Fatalf("empty service should not expose tools")
-	}
-	if err := nilSvc.Close(); err != nil {
-		t.Fatalf("nil service close should be nil: %v", err)
-	}
-	if err := nilSvc.IngestSession(context.Background(), &session.Session{}); err == nil {
-		t.Fatalf("expected nil service error")
-	}
-	if err := svc.IngestSession(context.Background(), nil); err == nil {
-		t.Fatalf("expected nil session error")
-	}
-	if err := svc.IngestSession(context.Background(), &session.Session{ID: "s", AppName: "app"}); err == nil {
-		t.Fatalf("expected missing user error")
-	}
-	if err := svc.IngestSession(context.Background(), &session.Session{ID: "s", AppName: "app", UserID: "u"}); err != nil {
-		t.Fatalf("empty transcript should be ignored: %v", err)
-	}
-	if defaultSessionKey(nil) != "" {
-		t.Fatalf("nil default session key should be empty")
-	}
+	assert.Nil(t, nilSvc.Tools())
+	assert.Nil(t, (&Service{}).Tools())
+	require.NoError(t, nilSvc.Close(), "nil service close should be nil")
+	require.Error(t, nilSvc.IngestSession(context.Background(), &session.Session{}), "expected nil service error")
+	require.Error(t, svc.IngestSession(context.Background(), nil), "expected nil session error")
+	require.Error(t, svc.IngestSession(context.Background(), &session.Session{ID: "s", AppName: "app"}), "expected missing user error")
+	require.NoError(t, svc.IngestSession(context.Background(), &session.Session{ID: "s", AppName: "app", UserID: "u"}), "empty transcript should be ignored")
+	assert.Empty(t, defaultSessionKey(nil))
 
 	closed, err := NewService(WithGatewayURL(server.URL), WithIngestQueueSize(1))
-	if err != nil {
-		t.Fatalf("NewService closed: %v", err)
-	}
-	if err := closed.Close(); err != nil {
-		t.Fatalf("Close: %v", err)
-	}
-	if err := closed.IngestSession(context.Background(), captureReadySession()); err == nil {
-		t.Fatalf("expected closed service error")
-	}
-}
-
-func TestMemorySearchToolAndHelpers(t *testing.T) {
-	var got searchMemoriesRequest
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != pathSearchMemories {
-			t.Fatalf("unexpected path %s", r.URL.Path)
-		}
-		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
-			t.Fatalf("decode request: %v", err)
-		}
-		_ = json.NewEncoder(w).Encode(searchMemoriesResponse{
-			Results:  "memory result",
-			Total:    3,
-			Strategy: "hybrid",
-		})
-	}))
-	defer server.Close()
-
-	svc, err := NewService(WithGatewayURL(server.URL), WithConversationSearchTool(false))
-	if err != nil {
-		t.Fatalf("NewService: %v", err)
-	}
-	defer svc.Close()
-
-	var memTool tool.CallableTool
-	for _, tl := range svc.Tools() {
-		if tl.Declaration().Name == "tdai_memory_search" {
-			var ok bool
-			memTool, ok = tl.(tool.CallableTool)
-			if !ok {
-				t.Fatalf("memory tool is not callable")
-			}
-			break
-		}
-	}
-	if memTool == nil {
-		t.Fatalf("memory tool not found")
-	}
-	if _, err := memTool.Call(context.Background(), []byte(`{"query":"hello"}`)); err == nil {
-		t.Fatalf("expected missing invocation error")
-	}
-	if _, err := memTool.Call(context.Background(), []byte(`{"query":""}`)); err == nil {
-		t.Fatalf("expected query validation error")
-	}
-
-	sess := &session.Session{ID: "s1", AppName: "app", UserID: "u1"}
-	ctx := agent.NewInvocationContext(context.Background(), &agent.Invocation{Session: sess}).Context
-	raw, err := memTool.Call(ctx, []byte(`{"query":"profile","limit":99,"type":"L1","scene":"work"}`))
-	if err != nil {
-		t.Fatalf("Call: %v", err)
-	}
-	rsp := raw.(*searchMemoriesToolResponse)
-	if rsp.Results != "memory result" || rsp.Total != 3 || rsp.Strategy != "hybrid" {
-		t.Fatalf("response = %#v", rsp)
-	}
-	if got.Query != "profile" || got.Limit != maxSearchLimit || got.Type != "L1" ||
-		got.Scene != "work" || got.UserID != "u1" {
-		t.Fatalf("search request = %#v", got)
-	}
-	if normalizeLimit(-1) != defaultSearchLimit || normalizeLimit(7) != 7 || normalizeLimit(99) != maxSearchLimit {
-		t.Fatalf("normalizeLimit returned unexpected values")
-	}
-
-	partText := " content part text "
-	msg := model.Message{
-		Role: model.RoleUser,
-		ContentParts: []model.ContentPart{
-			{Type: model.ContentTypeFile},
-			{Type: model.ContentTypeText, Text: &partText},
-		},
-	}
-	if messageText(msg) != "content part text" {
-		t.Fatalf("messageText did not read text parts")
-	}
-	if messageID("", 0) != "" || messageID("evt", 2) != "evt:2" {
-		t.Fatalf("unexpected messageID behavior")
-	}
-	writeBestEffortLastCaptureAt(nil, time.Now())
-	if !readBestEffortLastCaptureAt(&session.Session{}).IsZero() {
-		t.Fatalf("empty cursor should be zero")
-	}
-}
-
-func TestSessionScanTimestampAndStateEdges(t *testing.T) {
-	if got := scanTranscript(nil, time.Time{}); len(got.Messages) != 0 {
-		t.Fatalf("nil session scan = %#v", got)
-	}
-	if got := scanTranscript(&session.Session{}, time.Time{}); len(got.Messages) != 0 {
-		t.Fatalf("empty session scan = %#v", got)
-	}
-
-	base := time.Date(2026, 5, 22, 8, 0, 0, 0, time.UTC)
-	sess := &session.Session{
-		ID:      "s1",
-		AppName: "app",
-		UserID:  "user",
-		Events: []event.Event{
-			{ID: "old", Timestamp: base, Response: &model.Response{Choices: []model.Choice{{
-				Message: model.NewUserMessage("old"),
-			}}}},
-			{ID: "nil-response", Timestamp: base.Add(time.Second)},
-			{ID: "system", Timestamp: base.Add(2 * time.Second), Response: &model.Response{Choices: []model.Choice{{
-				Message: model.NewSystemMessage("system"),
-			}}}},
-			{ID: "empty", Timestamp: base.Add(3 * time.Second), Response: &model.Response{Choices: []model.Choice{{
-				Message: model.NewUserMessage("   "),
-			}}}},
-			{ID: "user", Timestamp: base.Add(4 * time.Second), Response: &model.Response{Choices: []model.Choice{{
-				Index:   2,
-				Message: model.NewUserMessage("new"),
-			}}}},
-		},
-	}
-	scan := scanTranscript(sess, base)
-	if len(scan.Messages) != 1 || scan.Messages[0].ID != "user:2" || scan.Latest != base.Add(4*time.Second) {
-		t.Fatalf("scan = %#v", scan)
-	}
-
-	if got := normalizeGatewayMessageTimestamps(nil, time.Now()); got != nil {
-		t.Fatalf("nil normalized messages = %#v", got)
-	}
-	normalized := normalizeGatewayMessageTimestamps([]tdaiMessage{{Content: "x"}}, time.Time{})
-	if len(normalized) != 1 || normalized[0].Timestamp == 0 {
-		t.Fatalf("normalized messages = %#v", normalized)
-	}
-	empty, latest := normalizeGatewayMessageTimestampsAfter(nil, time.Now(), 123)
-	if empty != nil || latest != 123 {
-		t.Fatalf("empty normalize result = %#v latest=%d", empty, latest)
-	}
-	bumped, latest := normalizeGatewayMessageTimestampsAfter(
-		[]tdaiMessage{{Content: "a"}, {Content: "b"}},
-		time.UnixMilli(1000),
-		5000,
-	)
-	if bumped[0].Timestamp != 5001 || bumped[1].Timestamp != 5002 || latest != 5002 {
-		t.Fatalf("bumped timestamps = %#v latest=%d", bumped, latest)
-	}
-
-	stateSess := &session.Session{}
-	stateSess.SetState(lastCaptureAtStateKey, []byte("not-a-time"))
-	if got := readBestEffortLastCaptureAt(stateSess); !got.IsZero() {
-		t.Fatalf("malformed last capture should be zero: %v", got)
-	}
-	writeBestEffortSyntheticTimestamp(nil, 10)
-	writeBestEffortSyntheticTimestamp(stateSess, 0)
-	if got := readBestEffortSyntheticTimestamp(stateSess); got != 0 {
-		t.Fatalf("non-positive synthetic timestamp should be ignored: %d", got)
-	}
-	stateSess.SetState(syntheticTimestampStateKey, []byte("bad"))
-	if got := readBestEffortSyntheticTimestamp(stateSess); got != 0 {
-		t.Fatalf("malformed synthetic timestamp should be zero: %d", got)
-	}
-	writeBestEffortSyntheticTimestamp(stateSess, 77)
-	if got := readBestEffortSyntheticTimestamp(stateSess); got != 77 {
-		t.Fatalf("synthetic timestamp = %d", got)
-	}
-	clearBestEffortSyntheticTimestamp(nil)
-	clearBestEffortSyntheticTimestamp(stateSess)
-	if got := readBestEffortSyntheticTimestamp(stateSess); got != 0 {
-		t.Fatalf("cleared synthetic timestamp = %d", got)
-	}
-
-	if messageText(model.Message{Role: model.RoleUser}) != "" {
-		t.Fatalf("empty message should have no text")
-	}
-	if messageText(model.Message{
-		Role: model.RoleUser,
-		ContentParts: []model.ContentPart{{
-			Type: model.ContentTypeText,
-		}},
-	}) != "" {
-		t.Fatalf("nil text part should have no text")
-	}
+	require.NoError(t, err, "NewService closed")
+	require.NoError(t, closed.Close(), "Close")
+	require.Error(t, closed.IngestSession(context.Background(), captureReadySession()), "expected closed service error")
 }
 
 func TestEndSessionAndHealth(t *testing.T) {
@@ -1005,111 +100,34 @@ func TestEndSessionAndHealth(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case pathEndSession:
-			if err := json.NewDecoder(r.Body).Decode(&ended); err != nil {
-				t.Fatalf("decode end session: %v", err)
-			}
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&ended))
 			_ = json.NewEncoder(w).Encode(endSessionResponse{Flushed: true})
 		case pathHealth:
 			_ = json.NewEncoder(w).Encode(HealthResponse{Status: "ok"})
 		default:
-			t.Fatalf("unexpected path %s", r.URL.Path)
+			require.Failf(t, "unexpected path", "path=%s", r.URL.Path)
 		}
 	}))
 	defer server.Close()
 
 	svc, err := NewService(WithGatewayURL(server.URL))
-	if err != nil {
-		t.Fatalf("NewService: %v", err)
-	}
+	require.NoError(t, err, "NewService")
 	defer svc.Close()
 
 	sess := &session.Session{ID: "s1", AppName: "app", UserID: "user"}
 	writeBestEffortSyntheticTimestamp(sess, 123)
-	if err := svc.EndSession(context.Background(), sess); err != nil {
-		t.Fatalf("EndSession: %v", err)
-	}
-	if ended.SessionKey != "app:user:s1" || ended.UserID != "user" {
-		t.Fatalf("end session request = %#v", ended)
-	}
-	if got := readBestEffortSyntheticTimestamp(sess); got != 0 {
-		t.Fatalf("synthetic timestamp was not cleared: %d", got)
-	}
+	require.NoError(t, svc.EndSession(context.Background(), sess), "EndSession")
+	assert.Equal(t, endSessionRequest{SessionKey: "app:user:s1", UserID: "user"}, ended)
+	assert.Zero(t, readBestEffortSyntheticTimestamp(sess))
 	health, err := svc.Health(context.Background())
-	if err != nil {
-		t.Fatalf("Health: %v", err)
-	}
-	if health.Status != "ok" {
-		t.Fatalf("health = %#v", health)
-	}
+	require.NoError(t, err, "Health")
+	assert.Equal(t, "ok", health.Status)
 
 	var nilSvc *Service
-	if err := nilSvc.EndSession(context.Background(), sess); err == nil {
-		t.Fatalf("expected nil service EndSession error")
-	}
-	if err := svc.EndSession(context.Background(), nil); err == nil {
-		t.Fatalf("expected nil session EndSession error")
-	}
-	if _, err := nilSvc.Health(context.Background()); err == nil {
-		t.Fatalf("expected nil service Health error")
-	}
-}
-
-func TestRecallAndPluginEdges(t *testing.T) {
-	if latestUserText(nil) != "" {
-		t.Fatalf("nil request should not have latest user text")
-	}
-	if latestUserText(&model.Request{Messages: []model.Message{model.NewSystemMessage("sys")}}) != "" {
-		t.Fatalf("request without user should not have latest user text")
-	}
-
-	empty := &model.Request{}
-	injectRecallContext(empty, &recallResponse{Context: "legacy context"})
-	if len(empty.Messages) != 1 || empty.Messages[0].Role != model.RoleSystem {
-		t.Fatalf("legacy context should create system message: %#v", empty.Messages)
-	}
-
-	noSystem := &model.Request{Messages: []model.Message{model.NewAssistantMessage("hi")}}
-	injectRecallContext(noSystem, &recallResponse{AppendSystemContext: "sys", PrependContext: "ctx"})
-	if len(noSystem.Messages) != 3 {
-		t.Fatalf("expected system, assistant, context messages: %#v", noSystem.Messages)
-	}
-	if noSystem.Messages[0].Role != model.RoleSystem || noSystem.Messages[0].Content != "sys" {
-		t.Fatalf("system was not prepended: %#v", noSystem.Messages)
-	}
-	if noSystem.Messages[2].Content != "ctx" {
-		t.Fatalf("context should append when no user exists: %#v", noSystem.Messages)
-	}
-	insertBeforeLatestUser(nil, model.NewUserMessage("ignored"))
-
-	svc := &Service{opts: defaultOptions(), client: &gatewayClient{}}
-	p := &recallPlugin{service: svc}
-	if _, err := p.beforeModel(context.Background(), nil); err != nil {
-		t.Fatalf("nil args should be ignored: %v", err)
-	}
-	if _, err := p.beforeModel(context.Background(), &model.BeforeModelArgs{}); err != nil {
-		t.Fatalf("nil request should be ignored: %v", err)
-	}
-	if _, err := p.beforeModel(context.Background(), &model.BeforeModelArgs{
-		Request: &model.Request{Messages: []model.Message{model.NewUserMessage("q")}},
-	}); err != nil {
-		t.Fatalf("missing invocation should be ignored: %v", err)
-	}
-	ctx := agent.NewInvocationContext(context.Background(), &agent.Invocation{
-		Session: &session.Session{ID: "s", AppName: "app", UserID: "user"},
-	}).Context
-	if _, err := p.beforeModel(ctx, &model.BeforeModelArgs{
-		Request: &model.Request{Messages: []model.Message{model.NewSystemMessage("sys")}},
-	}); err != nil {
-		t.Fatalf("missing query should be ignored: %v", err)
-	}
-	badScope := agent.NewInvocationContext(context.Background(), &agent.Invocation{
-		Session: &session.Session{ID: "s", AppName: "app"},
-	}).Context
-	if _, err := p.beforeModel(badScope, &model.BeforeModelArgs{
-		Request: &model.Request{Messages: []model.Message{model.NewUserMessage("q")}},
-	}); err != nil {
-		t.Fatalf("invalid session scope should be ignored: %v", err)
-	}
+	require.Error(t, nilSvc.EndSession(context.Background(), sess), "expected nil service EndSession error")
+	require.Error(t, svc.EndSession(context.Background(), nil), "expected nil session EndSession error")
+	_, err = nilSvc.Health(context.Background())
+	require.Error(t, err, "expected nil service Health error")
 }
 
 func TestCaptureAndClientFailurePaths(t *testing.T) {
@@ -1119,136 +137,46 @@ func TestCaptureAndClientFailurePaths(t *testing.T) {
 	defer server.Close()
 
 	svc, err := NewService(WithGatewayURL(server.URL))
-	if err != nil {
-		t.Fatalf("NewService: %v", err)
-	}
+	require.NoError(t, err, "NewService")
 	defer svc.Close()
 
-	if err := svc.capture(context.Background(), ingestJob{
+	err = svc.capture(context.Background(), ingestJob{
 		req: captureRequest{SessionKey: "s"},
-	}); err == nil {
-		t.Fatalf("expected capture failure")
-	}
-	if _, err := svc.client.capture(context.Background(), captureRequest{SessionKey: "s"}); err == nil {
-		t.Fatalf("expected client capture failure")
-	}
-	if _, err := svc.client.recall(context.Background(), recallRequest{Query: "q"}); err == nil {
-		t.Fatalf("expected client recall failure")
-	}
-	if _, err := svc.client.searchMemories(context.Background(), searchMemoriesRequest{Query: "q"}); err == nil {
-		t.Fatalf("expected client memory search failure")
-	}
-	if _, err := svc.client.searchConversations(context.Background(), searchConversationsRequest{Query: "q"}); err == nil {
-		t.Fatalf("expected client conversation search failure")
-	}
-	if _, err := svc.client.endSession(context.Background(), endSessionRequest{SessionKey: "s"}); err == nil {
-		t.Fatalf("expected client end session failure")
-	}
+	})
+	require.Error(t, err, "expected capture failure")
+	_, err = svc.client.capture(context.Background(), captureRequest{SessionKey: "s"})
+	require.Error(t, err, "expected client capture failure")
+	_, err = svc.client.recall(context.Background(), recallRequest{Query: "q"})
+	require.Error(t, err, "expected client recall failure")
+	_, err = svc.client.searchMemories(context.Background(), searchMemoriesRequest{Query: "q"})
+	require.Error(t, err, "expected client memory search failure")
+	_, err = svc.client.searchConversations(context.Background(), searchConversationsRequest{Query: "q"})
+	require.Error(t, err, "expected client conversation search failure")
+	_, err = svc.client.endSession(context.Background(), endSessionRequest{SessionKey: "s"})
+	require.Error(t, err, "expected client end session failure")
 
 	previousErr := errors.New("previous failed")
 	previousFailed := &captureSerialState{done: make(chan struct{}), err: previousErr}
 	close(previousFailed.done)
-	if err := svc.capture(context.Background(), ingestJob{
+	err = svc.capture(context.Background(), ingestJob{
 		req: captureRequest{SessionKey: "s"},
 		serial: &captureSerialState{
 			sessionKey: "s",
 			previous:   previousFailed,
 			done:       make(chan struct{}),
 		},
-	}); err == nil {
-		t.Fatalf("expected previous capture failure")
-	} else if !errors.Is(err, previousErr) {
-		t.Fatalf("expected wrapped previous error, got %v", err)
-	}
+	})
+	require.ErrorIs(t, err, previousErr)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	if err := svc.capture(ctx, ingestJob{
+	err = svc.capture(ctx, ingestJob{
 		req: captureRequest{SessionKey: "s"},
 		serial: &captureSerialState{
 			sessionKey: "s",
 			previous:   &captureSerialState{done: make(chan struct{})},
 			done:       make(chan struct{}),
 		},
-	}); err == nil {
-		t.Fatalf("expected context cancellation while waiting for previous capture")
-	}
-}
-
-func captureReadySession() *session.Session {
-	now := time.Now()
-	return &session.Session{
-		ID:      "s1",
-		AppName: "app",
-		UserID:  "user",
-		Events: []event.Event{
-			{
-				ID:        "u",
-				Timestamp: now,
-				Response: &model.Response{Choices: []model.Choice{{
-					Message: model.NewUserMessage("remember"),
-				}}},
-			},
-			{
-				ID:        "a",
-				Timestamp: now.Add(time.Second),
-				Response: &model.Response{Choices: []model.Choice{{
-					Message: model.NewAssistantMessage("ok"),
-				}}},
-			},
-		},
-	}
-}
-
-func appendSessionPair(
-	sess *session.Session,
-	at time.Time,
-	userID string,
-	userContent string,
-	assistantID string,
-	assistantContent string,
-) {
-	sess.EventMu.Lock()
-	defer sess.EventMu.Unlock()
-	sess.Events = append(sess.Events,
-		event.Event{
-			ID:        userID,
-			Timestamp: at,
-			Response: &model.Response{Choices: []model.Choice{{
-				Message: model.NewUserMessage(userContent),
-			}}},
-		},
-		event.Event{
-			ID:        assistantID,
-			Timestamp: at.Add(time.Second),
-			Response: &model.Response{Choices: []model.Choice{{
-				Message: model.NewAssistantMessage(assistantContent),
-			}}},
-		},
-	)
-}
-
-func waitCaptureRequest(t *testing.T, ch <-chan captureRequest, name string) captureRequest {
-	t.Helper()
-	select {
-	case req := <-ch:
-		return req
-	case <-time.After(time.Second):
-		t.Fatalf("%s did not start", name)
-		return captureRequest{}
-	}
-}
-
-func waitForCondition(t *testing.T, timeout time.Duration, condition func() bool) {
-	t.Helper()
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		if condition() {
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	if !condition() {
-		t.Fatalf("condition was not met within %s", timeout)
-	}
+	})
+	require.ErrorIs(t, err, context.Canceled)
 }

--- a/memory/tencentdb/service_test.go
+++ b/memory/tencentdb/service_test.go
@@ -1134,7 +1134,8 @@ func TestCaptureAndClientFailurePaths(t *testing.T) {
 		t.Fatalf("expected client end session failure")
 	}
 
-	previousFailed := &captureSerialState{done: make(chan struct{}), err: errors.New("previous failed")}
+	previousErr := errors.New("previous failed")
+	previousFailed := &captureSerialState{done: make(chan struct{}), err: previousErr}
 	close(previousFailed.done)
 	if err := svc.capture(context.Background(), ingestJob{
 		req: captureRequest{SessionKey: "s"},
@@ -1145,6 +1146,8 @@ func TestCaptureAndClientFailurePaths(t *testing.T) {
 		},
 	}); err == nil {
 		t.Fatalf("expected previous capture failure")
+	} else if !errors.Is(err, previousErr) {
+		t.Fatalf("expected wrapped previous error, got %v", err)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/memory/tencentdb/session_scan.go
+++ b/memory/tencentdb/session_scan.go
@@ -128,7 +128,7 @@ func readBestEffortLastCaptureAt(sess *session.Session) time.Time {
 	if sess == nil {
 		return time.Time{}
 	}
-	raw, ok := sess.State[lastCaptureAtStateKey]
+	raw, ok := sess.GetState(lastCaptureAtStateKey)
 	if !ok || len(raw) == 0 {
 		return time.Time{}
 	}
@@ -143,8 +143,5 @@ func writeBestEffortLastCaptureAt(sess *session.Session, t time.Time) {
 	if sess == nil || t.IsZero() {
 		return
 	}
-	if sess.State == nil {
-		sess.State = map[string][]byte{}
-	}
-	sess.State[lastCaptureAtStateKey] = []byte(t.UTC().Format(time.RFC3339Nano))
+	sess.SetState(lastCaptureAtStateKey, []byte(t.UTC().Format(time.RFC3339Nano)))
 }

--- a/memory/tencentdb/session_scan.go
+++ b/memory/tencentdb/session_scan.go
@@ -11,6 +11,7 @@ package tencentdb
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -18,7 +19,10 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/session"
 )
 
-const lastCaptureAtStateKey = "tencentdb_agent_memory.last_capture_at"
+const (
+	lastCaptureAtStateKey      = "tencentdb_agent_memory.last_capture_at"
+	syntheticTimestampStateKey = "tencentdb_agent_memory.synthetic_timestamp"
+)
 
 type scanResult struct {
 	Messages []tdaiMessage
@@ -162,4 +166,33 @@ func writeBestEffortLastCaptureAt(sess *session.Session, t time.Time) {
 		return
 	}
 	sess.SetState(lastCaptureAtStateKey, []byte(t.UTC().Format(time.RFC3339Nano)))
+}
+
+func readBestEffortSyntheticTimestamp(sess *session.Session) int64 {
+	if sess == nil {
+		return 0
+	}
+	raw, ok := sess.GetState(syntheticTimestampStateKey)
+	if !ok || len(raw) == 0 {
+		return 0
+	}
+	ts, err := strconv.ParseInt(strings.TrimSpace(string(raw)), 10, 64)
+	if err != nil {
+		return 0
+	}
+	return ts
+}
+
+func writeBestEffortSyntheticTimestamp(sess *session.Session, timestamp int64) {
+	if sess == nil || timestamp <= 0 {
+		return
+	}
+	sess.SetState(syntheticTimestampStateKey, []byte(strconv.FormatInt(timestamp, 10)))
+}
+
+func clearBestEffortSyntheticTimestamp(sess *session.Session) {
+	if sess == nil {
+		return
+	}
+	sess.SetState(syntheticTimestampStateKey, nil)
 }

--- a/memory/tencentdb/session_scan.go
+++ b/memory/tencentdb/session_scan.go
@@ -1,0 +1,150 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package tencentdb
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+const lastCaptureAtStateKey = "tencentdb_agent_memory.last_capture_at"
+
+type scanResult struct {
+	Messages []tdaiMessage
+	Latest   time.Time
+}
+
+func scanTranscript(sess *session.Session, since time.Time) scanResult {
+	if sess == nil || len(sess.Events) == 0 {
+		return scanResult{}
+	}
+	var out scanResult
+	for _, e := range sess.Events {
+		if e.Response == nil || !since.IsZero() && !e.Timestamp.After(since) {
+			continue
+		}
+		if e.Timestamp.After(out.Latest) {
+			out.Latest = e.Timestamp
+		}
+		for _, choice := range e.Response.Choices {
+			msg := choice.Message
+			if msg.Role != model.RoleUser && msg.Role != model.RoleAssistant {
+				continue
+			}
+			content := messageText(msg)
+			if content == "" {
+				continue
+			}
+			out.Messages = append(out.Messages, tdaiMessage{
+				ID:        messageID(e.ID, choice.Index),
+				Role:      string(msg.Role),
+				Content:   content,
+				Timestamp: e.Timestamp.UTC().UnixMilli(),
+			})
+		}
+	}
+	return out
+}
+
+func normalizeGatewayMessageTimestamps(messages []tdaiMessage, captureAt time.Time) []tdaiMessage {
+	if len(messages) == 0 {
+		return nil
+	}
+	if captureAt.IsZero() {
+		captureAt = time.Now()
+	}
+	out := make([]tdaiMessage, len(messages))
+	copy(out, messages)
+	base := captureAt.Add(time.Second).UTC().UnixMilli()
+	for i := range out {
+		// The gateway's first per-session cursor is initialized when the capture
+		// request arrives. Use capture-time timestamps so the SDK's incremental
+		// filter treats this batch as new while preserving message order. A small
+		// forward offset avoids clock-order races between Go request construction
+		// and gateway request handling.
+		out[i].Timestamp = base + int64(i)
+	}
+	return out
+}
+
+func messageID(eventID string, choiceIndex int) string {
+	if eventID == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s:%d", eventID, choiceIndex)
+}
+
+func lastUserAssistantPair(messages []tdaiMessage) (string, string) {
+	var pendingUser string
+	var lastUser string
+	var lastAssistant string
+	for _, msg := range messages {
+		switch msg.Role {
+		case string(model.RoleUser):
+			pendingUser = strings.TrimSpace(msg.Content)
+		case string(model.RoleAssistant):
+			assistant := strings.TrimSpace(msg.Content)
+			if pendingUser != "" && assistant != "" {
+				lastUser = pendingUser
+				lastAssistant = assistant
+			}
+		}
+	}
+	return lastUser, lastAssistant
+}
+
+func messageText(msg model.Message) string {
+	if strings.TrimSpace(msg.Content) != "" {
+		return strings.TrimSpace(msg.Content)
+	}
+	if len(msg.ContentParts) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(msg.ContentParts))
+	for _, part := range msg.ContentParts {
+		if part.Type != model.ContentTypeText || part.Text == nil {
+			continue
+		}
+		text := strings.TrimSpace(*part.Text)
+		if text != "" {
+			parts = append(parts, text)
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+func readBestEffortLastCaptureAt(sess *session.Session) time.Time {
+	if sess == nil {
+		return time.Time{}
+	}
+	raw, ok := sess.State[lastCaptureAtStateKey]
+	if !ok || len(raw) == 0 {
+		return time.Time{}
+	}
+	t, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(string(raw)))
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}
+
+func writeBestEffortLastCaptureAt(sess *session.Session, t time.Time) {
+	if sess == nil || t.IsZero() {
+		return
+	}
+	if sess.State == nil {
+		sess.State = map[string][]byte{}
+	}
+	sess.State[lastCaptureAtStateKey] = []byte(t.UTC().Format(time.RFC3339Nano))
+}

--- a/memory/tencentdb/session_scan.go
+++ b/memory/tencentdb/session_scan.go
@@ -26,11 +26,15 @@ type scanResult struct {
 }
 
 func scanTranscript(sess *session.Session, since time.Time) scanResult {
-	if sess == nil || len(sess.Events) == 0 {
+	if sess == nil {
+		return scanResult{}
+	}
+	events := sess.GetEvents()
+	if len(events) == 0 {
 		return scanResult{}
 	}
 	var out scanResult
-	for _, e := range sess.Events {
+	for _, e := range events {
 		if e.Response == nil || !since.IsZero() && !e.Timestamp.After(since) {
 			continue
 		}
@@ -58,8 +62,17 @@ func scanTranscript(sess *session.Session, since time.Time) scanResult {
 }
 
 func normalizeGatewayMessageTimestamps(messages []tdaiMessage, captureAt time.Time) []tdaiMessage {
+	out, _ := normalizeGatewayMessageTimestampsAfter(messages, captureAt, 0)
+	return out
+}
+
+func normalizeGatewayMessageTimestampsAfter(
+	messages []tdaiMessage,
+	captureAt time.Time,
+	previousTimestamp int64,
+) ([]tdaiMessage, int64) {
 	if len(messages) == 0 {
-		return nil
+		return nil, previousTimestamp
 	}
 	if captureAt.IsZero() {
 		captureAt = time.Now()
@@ -67,15 +80,20 @@ func normalizeGatewayMessageTimestamps(messages []tdaiMessage, captureAt time.Ti
 	out := make([]tdaiMessage, len(messages))
 	copy(out, messages)
 	base := captureAt.Add(time.Second).UTC().UnixMilli()
+	if base <= previousTimestamp {
+		base = previousTimestamp + 1
+	}
 	for i := range out {
 		// The gateway's first per-session cursor is initialized when the capture
 		// request arrives. Use capture-time timestamps so the SDK's incremental
 		// filter treats this batch as new while preserving message order. A small
 		// forward offset avoids clock-order races between Go request construction
-		// and gateway request handling.
+		// and gateway request handling. Callers may also pass the last synthetic
+		// timestamp for the session so consecutive batches stay strictly
+		// increasing even if the wall clock does not move forward.
 		out[i].Timestamp = base + int64(i)
 	}
-	return out
+	return out, out[len(out)-1].Timestamp
 }
 
 func messageID(eventID string, choiceIndex int) string {

--- a/memory/tencentdb/session_scan_test.go
+++ b/memory/tencentdb/session_scan_test.go
@@ -1,0 +1,93 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package tencentdb
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+func TestSessionScanTimestampAndStateEdges(t *testing.T) {
+	assert.Empty(t, scanTranscript(nil, time.Time{}).Messages)
+	assert.Empty(t, scanTranscript(&session.Session{}, time.Time{}).Messages)
+
+	base := time.Date(2026, 5, 22, 8, 0, 0, 0, time.UTC)
+	sess := &session.Session{
+		ID:      "s1",
+		AppName: "app",
+		UserID:  "user",
+		Events: []event.Event{
+			{ID: "old", Timestamp: base, Response: &model.Response{Choices: []model.Choice{{
+				Message: model.NewUserMessage("old"),
+			}}}},
+			{ID: "nil-response", Timestamp: base.Add(time.Second)},
+			{ID: "system", Timestamp: base.Add(2 * time.Second), Response: &model.Response{Choices: []model.Choice{{
+				Message: model.NewSystemMessage("system"),
+			}}}},
+			{ID: "empty", Timestamp: base.Add(3 * time.Second), Response: &model.Response{Choices: []model.Choice{{
+				Message: model.NewUserMessage("   "),
+			}}}},
+			{ID: "user", Timestamp: base.Add(4 * time.Second), Response: &model.Response{Choices: []model.Choice{{
+				Index:   2,
+				Message: model.NewUserMessage("new"),
+			}}}},
+		},
+	}
+	scan := scanTranscript(sess, base)
+	require.Len(t, scan.Messages, 1)
+	assert.Equal(t, "user:2", scan.Messages[0].ID)
+	assert.Equal(t, base.Add(4*time.Second), scan.Latest)
+
+	assert.Nil(t, normalizeGatewayMessageTimestamps(nil, time.Now()))
+	normalized := normalizeGatewayMessageTimestamps([]tdaiMessage{{Content: "x"}}, time.Time{})
+	require.Len(t, normalized, 1)
+	assert.NotZero(t, normalized[0].Timestamp)
+	empty, latest := normalizeGatewayMessageTimestampsAfter(nil, time.Now(), 123)
+	assert.Nil(t, empty)
+	assert.Equal(t, int64(123), latest)
+	bumped, latest := normalizeGatewayMessageTimestampsAfter(
+		[]tdaiMessage{{Content: "a"}, {Content: "b"}},
+		time.UnixMilli(1000),
+		5000,
+	)
+	require.Len(t, bumped, 2)
+	assert.Equal(t, int64(5001), bumped[0].Timestamp)
+	assert.Equal(t, int64(5002), bumped[1].Timestamp)
+	assert.Equal(t, int64(5002), latest)
+
+	stateSess := &session.Session{}
+	stateSess.SetState(lastCaptureAtStateKey, []byte("not-a-time"))
+	assert.True(t, readBestEffortLastCaptureAt(stateSess).IsZero())
+	writeBestEffortSyntheticTimestamp(nil, 10)
+	writeBestEffortSyntheticTimestamp(stateSess, 0)
+	assert.Zero(t, readBestEffortSyntheticTimestamp(stateSess))
+	stateSess.SetState(syntheticTimestampStateKey, []byte("bad"))
+	assert.Zero(t, readBestEffortSyntheticTimestamp(stateSess))
+	writeBestEffortSyntheticTimestamp(stateSess, 77)
+	assert.Equal(t, int64(77), readBestEffortSyntheticTimestamp(stateSess))
+	clearBestEffortSyntheticTimestamp(nil)
+	clearBestEffortSyntheticTimestamp(stateSess)
+	assert.Zero(t, readBestEffortSyntheticTimestamp(stateSess))
+
+	assert.Empty(t, messageText(model.Message{Role: model.RoleUser}))
+	assert.Empty(t, messageText(model.Message{
+		Role: model.RoleUser,
+		ContentParts: []model.ContentPart{{
+			Type: model.ContentTypeText,
+		}},
+	}))
+}

--- a/memory/tencentdb/test_helpers_test.go
+++ b/memory/tencentdb/test_helpers_test.go
@@ -1,0 +1,97 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package tencentdb
+
+import (
+	"testing"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+func captureReadySession() *session.Session {
+	now := time.Now()
+	return &session.Session{
+		ID:      "s1",
+		AppName: "app",
+		UserID:  "user",
+		Events: []event.Event{
+			{
+				ID:        "u",
+				Timestamp: now,
+				Response: &model.Response{Choices: []model.Choice{{
+					Message: model.NewUserMessage("remember"),
+				}}},
+			},
+			{
+				ID:        "a",
+				Timestamp: now.Add(time.Second),
+				Response: &model.Response{Choices: []model.Choice{{
+					Message: model.NewAssistantMessage("ok"),
+				}}},
+			},
+		},
+	}
+}
+
+func appendSessionPair(
+	sess *session.Session,
+	at time.Time,
+	userID string,
+	userContent string,
+	assistantID string,
+	assistantContent string,
+) {
+	sess.EventMu.Lock()
+	defer sess.EventMu.Unlock()
+	sess.Events = append(sess.Events,
+		event.Event{
+			ID:        userID,
+			Timestamp: at,
+			Response: &model.Response{Choices: []model.Choice{{
+				Message: model.NewUserMessage(userContent),
+			}}},
+		},
+		event.Event{
+			ID:        assistantID,
+			Timestamp: at.Add(time.Second),
+			Response: &model.Response{Choices: []model.Choice{{
+				Message: model.NewAssistantMessage(assistantContent),
+			}}},
+		},
+	)
+}
+
+func waitCaptureRequest(t *testing.T, ch <-chan captureRequest, name string) captureRequest {
+	t.Helper()
+	select {
+	case req := <-ch:
+		return req
+	case <-time.After(time.Second):
+		t.Fatalf("%s did not start", name)
+		return captureRequest{}
+	}
+}
+
+func waitForCondition(t *testing.T, timeout time.Duration, condition func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !condition() {
+		t.Fatalf("condition was not met within %s", timeout)
+	}
+}

--- a/memory/tencentdb/tools.go
+++ b/memory/tencentdb/tools.go
@@ -47,10 +47,9 @@ type searchConversationsToolRequest struct {
 }
 
 type searchConversationsToolResponse struct {
-	Query      string `json:"query"`
-	SessionKey string `json:"session_key,omitempty"`
-	Results    string `json:"results"`
-	Total      int    `json:"total"`
+	Query   string `json:"query"`
+	Results string `json:"results"`
+	Total   int    `json:"total"`
 }
 
 func (s *Service) buildTools() []tool.Tool {
@@ -144,10 +143,9 @@ func (s *Service) newConversationSearchTool(name string) tool.CallableTool {
 			return nil, err
 		}
 		return &searchConversationsToolResponse{
-			Query:      strings.TrimSpace(req.Query),
-			SessionKey: sessionKey,
-			Results:    strings.TrimSpace(rsp.Results),
-			Total:      rsp.Total,
+			Query:   strings.TrimSpace(req.Query),
+			Results: strings.TrimSpace(rsp.Results),
+			Total:   rsp.Total,
 		}, nil
 	}
 	return function.NewFunctionTool(

--- a/memory/tencentdb/tools.go
+++ b/memory/tencentdb/tools.go
@@ -55,12 +55,26 @@ type searchConversationsToolResponse struct {
 }
 
 func (s *Service) buildTools() []tool.Tool {
-	out := []tool.Tool{s.newMemorySearchTool(s.nativeToolName("memory_search"))}
+	out := make([]tool.Tool, 0, 3)
+	seen := make(map[string]struct{}, 3)
+	add := func(t tool.Tool) {
+		if t == nil || t.Declaration() == nil {
+			return
+		}
+		name := t.Declaration().Name
+		if _, ok := seen[name]; ok {
+			return
+		}
+		seen[name] = struct{}{}
+		out = append(out, t)
+	}
+
+	add(s.newMemorySearchTool(s.nativeToolName("memory_search")))
 	if s.opts.EnableConversationSearchTool {
-		out = append(out, s.newConversationSearchTool(s.nativeToolName("conversation_search")))
+		add(s.newConversationSearchTool(s.nativeToolName("conversation_search")))
 	}
 	if s.opts.EnableStandardAliases {
-		out = append(out, s.newMemorySearchTool(memorypkg.SearchToolName))
+		add(s.newMemorySearchTool(memorypkg.SearchToolName))
 	}
 	return out
 }

--- a/memory/tencentdb/tools.go
+++ b/memory/tencentdb/tools.go
@@ -91,16 +91,17 @@ func (s *Service) newMemorySearchTool(name string) tool.CallableTool {
 		if req == nil || strings.TrimSpace(req.Query) == "" {
 			return nil, fmt.Errorf("%s: query is required", name)
 		}
-		_, err := currentSession(ctx)
+		sess, err := currentSession(ctx)
 		if err != nil {
 			return nil, err
 		}
 		limit := normalizeLimit(req.Limit)
 		rsp, err := s.client.searchMemories(ctx, searchMemoriesRequest{
-			Query: strings.TrimSpace(req.Query),
-			Limit: limit,
-			Type:  strings.TrimSpace(req.Type),
-			Scene: strings.TrimSpace(req.Scene),
+			Query:  strings.TrimSpace(req.Query),
+			Limit:  limit,
+			Type:   strings.TrimSpace(req.Type),
+			Scene:  strings.TrimSpace(req.Scene),
+			UserID: sess.UserID,
 		})
 		if err != nil {
 			return nil, err
@@ -135,6 +136,7 @@ func (s *Service) newConversationSearchTool(name string) tool.CallableTool {
 			Query:      strings.TrimSpace(req.Query),
 			Limit:      limit,
 			SessionKey: sessionKey,
+			UserID:     sess.UserID,
 		})
 		if err != nil {
 			return nil, err

--- a/memory/tencentdb/tools.go
+++ b/memory/tencentdb/tools.go
@@ -42,9 +42,8 @@ type searchMemoriesToolResponse struct {
 }
 
 type searchConversationsToolRequest struct {
-	Query      string `json:"query" description:"Search query for raw or summarized conversation history."`
-	Limit      int    `json:"limit,omitempty" description:"Maximum number of results to return. Defaults to 5, maximum 20."`
-	SessionKey string `json:"session_key,omitempty" description:"Optional TencentDB Agent Memory session_key. Defaults to the current session."`
+	Query string `json:"query" description:"Search query for raw or summarized conversation history."`
+	Limit int    `json:"limit,omitempty" description:"Maximum number of results to return. Defaults to 5, maximum 20."`
 }
 
 type searchConversationsToolResponse struct {
@@ -130,10 +129,7 @@ func (s *Service) newConversationSearchTool(name string) tool.CallableTool {
 		if err != nil {
 			return nil, err
 		}
-		sessionKey := strings.TrimSpace(req.SessionKey)
-		if sessionKey == "" {
-			sessionKey = s.sessionKey(sess)
-		}
+		sessionKey := s.sessionKey(sess)
 		limit := normalizeLimit(req.Limit)
 		rsp, err := s.client.searchConversations(ctx, searchConversationsRequest{
 			Query:      strings.TrimSpace(req.Query),

--- a/memory/tencentdb/tools.go
+++ b/memory/tencentdb/tools.go
@@ -1,0 +1,166 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package tencentdb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	memorypkg "trpc.group/trpc-go/trpc-agent-go/memory"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+	"trpc.group/trpc-go/trpc-agent-go/tool/function"
+)
+
+const (
+	defaultSearchLimit = 5
+	maxSearchLimit     = 20
+)
+
+type searchMemoriesToolRequest struct {
+	Query string `json:"query" description:"Search query for long-term memories. Use short keyword style queries when possible."`
+	Limit int    `json:"limit,omitempty" description:"Maximum number of results to return. Defaults to 5, maximum 20."`
+	Type  string `json:"type,omitempty" description:"Optional memory type or layer selector supported by the TencentDB Agent Memory gateway."`
+	Scene string `json:"scene,omitempty" description:"Optional scene name to narrow the search if the gateway supports scene filtering."`
+}
+
+type searchMemoriesToolResponse struct {
+	Query    string `json:"query"`
+	Results  string `json:"results"`
+	Total    int    `json:"total"`
+	Strategy string `json:"strategy,omitempty"`
+}
+
+type searchConversationsToolRequest struct {
+	Query      string `json:"query" description:"Search query for raw or summarized conversation history."`
+	Limit      int    `json:"limit,omitempty" description:"Maximum number of results to return. Defaults to 5, maximum 20."`
+	SessionKey string `json:"session_key,omitempty" description:"Optional TencentDB Agent Memory session_key. Defaults to the current session."`
+}
+
+type searchConversationsToolResponse struct {
+	Query      string `json:"query"`
+	SessionKey string `json:"session_key,omitempty"`
+	Results    string `json:"results"`
+	Total      int    `json:"total"`
+}
+
+func (s *Service) buildTools() []tool.Tool {
+	out := []tool.Tool{s.newMemorySearchTool(s.nativeToolName("memory_search"))}
+	if s.opts.EnableConversationSearchTool {
+		out = append(out, s.newConversationSearchTool(s.nativeToolName("conversation_search")))
+	}
+	if s.opts.EnableStandardAliases {
+		out = append(out, s.newMemorySearchTool(memorypkg.SearchToolName))
+	}
+	return out
+}
+
+func (s *Service) nativeToolName(name string) string {
+	prefix := strings.Trim(strings.TrimSpace(s.opts.ToolPrefix), "_-")
+	if prefix == "" {
+		return name
+	}
+	return prefix + "_" + name
+}
+
+func (s *Service) newMemorySearchTool(name string) tool.CallableTool {
+	fn := func(ctx context.Context, req *searchMemoriesToolRequest) (*searchMemoriesToolResponse, error) {
+		if req == nil || strings.TrimSpace(req.Query) == "" {
+			return nil, fmt.Errorf("%s: query is required", name)
+		}
+		_, err := currentSession(ctx)
+		if err != nil {
+			return nil, err
+		}
+		limit := normalizeLimit(req.Limit)
+		rsp, err := s.client.searchMemories(ctx, searchMemoriesRequest{
+			Query: strings.TrimSpace(req.Query),
+			Limit: limit,
+			Type:  strings.TrimSpace(req.Type),
+			Scene: strings.TrimSpace(req.Scene),
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &searchMemoriesToolResponse{
+			Query:    strings.TrimSpace(req.Query),
+			Results:  strings.TrimSpace(rsp.Results),
+			Total:    rsp.Total,
+			Strategy: rsp.Strategy,
+		}, nil
+	}
+	return function.NewFunctionTool(
+		fn,
+		function.WithName(name),
+		function.WithDescription("Search TencentDB Agent Memory long-term memories scoped by the configured gateway sidecar. "+
+			"Use this directly when the current request depends on remembered facts, preferences, or prior episodes."),
+	)
+}
+
+func (s *Service) newConversationSearchTool(name string) tool.CallableTool {
+	fn := func(ctx context.Context, req *searchConversationsToolRequest) (*searchConversationsToolResponse, error) {
+		if req == nil || strings.TrimSpace(req.Query) == "" {
+			return nil, fmt.Errorf("%s: query is required", name)
+		}
+		sess, err := currentSession(ctx)
+		if err != nil {
+			return nil, err
+		}
+		sessionKey := strings.TrimSpace(req.SessionKey)
+		if sessionKey == "" {
+			sessionKey = s.sessionKey(sess)
+		}
+		limit := normalizeLimit(req.Limit)
+		rsp, err := s.client.searchConversations(ctx, searchConversationsRequest{
+			Query:      strings.TrimSpace(req.Query),
+			Limit:      limit,
+			SessionKey: sessionKey,
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &searchConversationsToolResponse{
+			Query:      strings.TrimSpace(req.Query),
+			SessionKey: sessionKey,
+			Results:    strings.TrimSpace(rsp.Results),
+			Total:      rsp.Total,
+		}, nil
+	}
+	return function.NewFunctionTool(
+		fn,
+		function.WithName(name),
+		function.WithDescription("Search TencentDB Agent Memory conversation history. "+
+			"Defaults to the current session_key and is useful for recalling earlier raw exchanges."),
+	)
+}
+
+func currentSession(ctx context.Context) (*session.Session, error) {
+	inv, ok := agent.InvocationFromContext(ctx)
+	if !ok || inv == nil || inv.Session == nil {
+		return nil, errors.New("tencentdb memory tool: invocation session is required")
+	}
+	if err := validateSessionScope(inv.Session); err != nil {
+		return nil, err
+	}
+	return inv.Session, nil
+}
+
+func normalizeLimit(limit int) int {
+	if limit <= 0 {
+		return defaultSearchLimit
+	}
+	if limit > maxSearchLimit {
+		return maxSearchLimit
+	}
+	return limit
+}

--- a/memory/tencentdb/tools.go
+++ b/memory/tencentdb/tools.go
@@ -68,12 +68,14 @@ func (s *Service) buildTools() []tool.Tool {
 		out = append(out, t)
 	}
 
-	add(s.newMemorySearchTool(s.nativeToolName("memory_search")))
+	if s.opts.EnableMemorySearchTool {
+		add(s.newMemorySearchTool(s.nativeToolName("memory_search")))
+		if s.opts.EnableStandardAliases {
+			add(s.newMemorySearchTool(memorypkg.SearchToolName))
+		}
+	}
 	if s.opts.EnableConversationSearchTool {
 		add(s.newConversationSearchTool(s.nativeToolName("conversation_search")))
-	}
-	if s.opts.EnableStandardAliases {
-		add(s.newMemorySearchTool(memorypkg.SearchToolName))
 	}
 	return out
 }

--- a/memory/tencentdb/tools_test.go
+++ b/memory/tencentdb/tools_test.go
@@ -78,7 +78,7 @@ func TestMemorySearchToolAndHelpers(t *testing.T) {
 	}))
 	defer server.Close()
 
-	svc, err := NewService(WithGatewayURL(server.URL), WithConversationSearchTool(false))
+	svc, err := NewService(WithGatewayURL(server.URL), WithConversationSearchTool(false), WithMemorySearchTool(true))
 	require.NoError(t, err, "NewService")
 	defer svc.Close()
 

--- a/memory/tencentdb/tools_test.go
+++ b/memory/tencentdb/tools_test.go
@@ -60,7 +60,10 @@ func TestConversationSearchToolUsesCurrentSessionKey(t *testing.T) {
 	rsp := raw.(*searchConversationsToolResponse)
 	assert.Equal(t, "hit", rsp.Results)
 	assert.Equal(t, 1, rsp.Total)
-	assert.Equal(t, "app:u1:s1", got.SessionKey)
+	responseJSON, err := json.Marshal(rsp)
+	require.NoError(t, err, "marshal tool response")
+	assert.NotContains(t, string(responseJSON), "session_key")
+	assert.Equal(t, "YXBw:dTE:czE", got.SessionKey)
 	assert.Equal(t, "u1", got.UserID)
 	assert.Equal(t, defaultSearchLimit, got.Limit)
 }

--- a/memory/tencentdb/tools_test.go
+++ b/memory/tencentdb/tools_test.go
@@ -1,0 +1,132 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package tencentdb
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+func TestConversationSearchToolUsesCurrentSessionKey(t *testing.T) {
+	var got searchConversationsRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, pathSearchConversations, r.URL.Path)
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+		_ = json.NewEncoder(w).Encode(searchConversationsResponse{
+			Results: "hit",
+			Total:   1,
+		})
+	}))
+	defer server.Close()
+
+	svc, err := NewService(WithGatewayURL(server.URL))
+	require.NoError(t, err, "NewService")
+	defer svc.Close()
+
+	var convTool tool.CallableTool
+	for _, tl := range svc.Tools() {
+		if tl.Declaration().Name == "tdai_conversation_search" {
+			var ok bool
+			convTool, ok = tl.(tool.CallableTool)
+			require.True(t, ok, "conversation tool is not callable")
+			break
+		}
+	}
+	require.NotNil(t, convTool, "conversation tool not found")
+
+	sess := &session.Session{ID: "s1", AppName: "app", UserID: "u1"}
+	ctx := agent.NewInvocationContext(context.Background(), &agent.Invocation{Session: sess}).Context
+	raw, err := convTool.Call(ctx, []byte(`{"query":"previous topic","session_key":"app:other:secret"}`))
+	require.NoError(t, err, "Call")
+	rsp := raw.(*searchConversationsToolResponse)
+	assert.Equal(t, "hit", rsp.Results)
+	assert.Equal(t, 1, rsp.Total)
+	assert.Equal(t, "app:u1:s1", got.SessionKey)
+	assert.Equal(t, "u1", got.UserID)
+	assert.Equal(t, defaultSearchLimit, got.Limit)
+}
+
+func TestMemorySearchToolAndHelpers(t *testing.T) {
+	var got searchMemoriesRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, pathSearchMemories, r.URL.Path)
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+		_ = json.NewEncoder(w).Encode(searchMemoriesResponse{
+			Results:  "memory result",
+			Total:    3,
+			Strategy: "hybrid",
+		})
+	}))
+	defer server.Close()
+
+	svc, err := NewService(WithGatewayURL(server.URL), WithConversationSearchTool(false))
+	require.NoError(t, err, "NewService")
+	defer svc.Close()
+
+	var memTool tool.CallableTool
+	for _, tl := range svc.Tools() {
+		if tl.Declaration().Name == "tdai_memory_search" {
+			var ok bool
+			memTool, ok = tl.(tool.CallableTool)
+			require.True(t, ok, "memory tool is not callable")
+			break
+		}
+	}
+	require.NotNil(t, memTool, "memory tool not found")
+	_, err = memTool.Call(context.Background(), []byte(`{"query":"hello"}`))
+	require.Error(t, err, "expected missing invocation error")
+	_, err = memTool.Call(context.Background(), []byte(`{"query":""}`))
+	require.Error(t, err, "expected query validation error")
+
+	sess := &session.Session{ID: "s1", AppName: "app", UserID: "u1"}
+	ctx := agent.NewInvocationContext(context.Background(), &agent.Invocation{Session: sess}).Context
+	raw, err := memTool.Call(ctx, []byte(`{"query":"profile","limit":99,"type":"L1","scene":"work"}`))
+	require.NoError(t, err, "Call")
+	rsp := raw.(*searchMemoriesToolResponse)
+	assert.Equal(t, "memory result", rsp.Results)
+	assert.Equal(t, 3, rsp.Total)
+	assert.Equal(t, "hybrid", rsp.Strategy)
+	assert.Equal(t, searchMemoriesRequest{
+		Query:  "profile",
+		Limit:  maxSearchLimit,
+		Type:   "L1",
+		Scene:  "work",
+		UserID: "u1",
+	}, got)
+	assert.Equal(t, defaultSearchLimit, normalizeLimit(-1))
+	assert.Equal(t, 7, normalizeLimit(7))
+	assert.Equal(t, maxSearchLimit, normalizeLimit(99))
+
+	partText := " content part text "
+	msg := model.Message{
+		Role: model.RoleUser,
+		ContentParts: []model.ContentPart{
+			{Type: model.ContentTypeFile},
+			{Type: model.ContentTypeText, Text: &partText},
+		},
+	}
+	assert.Equal(t, "content part text", messageText(msg))
+	assert.Empty(t, messageID("", 0))
+	assert.Equal(t, "evt:2", messageID("evt", 2))
+	writeBestEffortLastCaptureAt(nil, time.Now())
+	assert.True(t, readBestEffortLastCaptureAt(&session.Session{}).IsZero())
+}

--- a/memory/tencentdb/tools_test.go
+++ b/memory/tencentdb/tools_test.go
@@ -94,11 +94,14 @@ func TestMemorySearchToolAndHelpers(t *testing.T) {
 	require.NotNil(t, memTool, "memory tool not found")
 	_, err = memTool.Call(context.Background(), []byte(`{"query":"hello"}`))
 	require.Error(t, err, "expected missing invocation error")
-	_, err = memTool.Call(context.Background(), []byte(`{"query":""}`))
-	require.Error(t, err, "expected query validation error")
+	assert.ErrorContains(t, err, "invocation")
 
 	sess := &session.Session{ID: "s1", AppName: "app", UserID: "u1"}
 	ctx := agent.NewInvocationContext(context.Background(), &agent.Invocation{Session: sess}).Context
+	_, err = memTool.Call(ctx, []byte(`{"query":""}`))
+	require.Error(t, err, "expected query validation error")
+	assert.ErrorContains(t, err, "query")
+
 	raw, err := memTool.Call(ctx, []byte(`{"query":"profile","limit":99,"type":"L1","scene":"work"}`))
 	require.NoError(t, err, "Call")
 	rsp := raw.(*searchMemoriesToolResponse)

--- a/memory/tencentdb/types.go
+++ b/memory/tencentdb/types.go
@@ -45,10 +45,11 @@ type recallResponse struct {
 }
 
 type searchMemoriesRequest struct {
-	Query string `json:"query"`
-	Limit int    `json:"limit,omitempty"`
-	Type  string `json:"type,omitempty"`
-	Scene string `json:"scene,omitempty"`
+	Query  string `json:"query"`
+	Limit  int    `json:"limit,omitempty"`
+	Type   string `json:"type,omitempty"`
+	Scene  string `json:"scene,omitempty"`
+	UserID string `json:"user_id,omitempty"`
 }
 
 type searchMemoriesResponse struct {
@@ -61,6 +62,7 @@ type searchConversationsRequest struct {
 	Query      string `json:"query"`
 	Limit      int    `json:"limit,omitempty"`
 	SessionKey string `json:"session_key,omitempty"`
+	UserID     string `json:"user_id,omitempty"`
 }
 
 type searchConversationsResponse struct {

--- a/memory/tencentdb/types.go
+++ b/memory/tencentdb/types.go
@@ -1,0 +1,89 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package tencentdb
+
+type tdaiMessage struct {
+	ID        string `json:"id,omitempty"`
+	Role      string `json:"role"`
+	Content   string `json:"content"`
+	Timestamp int64  `json:"timestamp"`
+}
+
+type captureRequest struct {
+	UserContent      string        `json:"user_content"`
+	AssistantContent string        `json:"assistant_content"`
+	SessionKey       string        `json:"session_key"`
+	SessionID        string        `json:"session_id,omitempty"`
+	UserID           string        `json:"user_id,omitempty"`
+	Messages         []tdaiMessage `json:"messages,omitempty"`
+}
+
+type captureResponse struct {
+	L0Recorded        int  `json:"l0_recorded"`
+	SchedulerNotified bool `json:"scheduler_notified"`
+}
+
+type recallRequest struct {
+	Query      string `json:"query"`
+	SessionKey string `json:"session_key"`
+	UserID     string `json:"user_id,omitempty"`
+}
+
+type recallResponse struct {
+	Context             string `json:"context"`
+	PrependContext      string `json:"prepend_context,omitempty"`
+	AppendSystemContext string `json:"append_system_context,omitempty"`
+	Strategy            string `json:"strategy,omitempty"`
+	MemoryCount         int    `json:"memory_count,omitempty"`
+}
+
+type searchMemoriesRequest struct {
+	Query string `json:"query"`
+	Limit int    `json:"limit,omitempty"`
+	Type  string `json:"type,omitempty"`
+	Scene string `json:"scene,omitempty"`
+}
+
+type searchMemoriesResponse struct {
+	Results  string `json:"results"`
+	Total    int    `json:"total"`
+	Strategy string `json:"strategy"`
+}
+
+type searchConversationsRequest struct {
+	Query      string `json:"query"`
+	Limit      int    `json:"limit,omitempty"`
+	SessionKey string `json:"session_key,omitempty"`
+}
+
+type searchConversationsResponse struct {
+	Results string `json:"results"`
+	Total   int    `json:"total"`
+}
+
+type endSessionRequest struct {
+	SessionKey string `json:"session_key"`
+	UserID     string `json:"user_id,omitempty"`
+}
+
+type endSessionResponse struct {
+	Flushed bool `json:"flushed"`
+}
+
+// HealthResponse describes gateway readiness.
+type HealthResponse struct {
+	Status  string `json:"status"`
+	Version string `json:"version"`
+	Uptime  int64  `json:"uptime"`
+	Stores  struct {
+		VectorStore      bool `json:"vectorStore"`
+		EmbeddingService bool `json:"embeddingService"`
+	} `json:"stores"`
+}

--- a/memory/tencentdb/worker.go
+++ b/memory/tencentdb/worker.go
@@ -18,16 +18,17 @@ import (
 )
 
 type ingestJob struct {
-	req      captureRequest
-	sess     *session.Session
-	cursor   time.Time
-	previous *captureSerialState
-	serial   *captureSerialState
+	req    captureRequest
+	sess   *session.Session
+	cursor time.Time
+	serial *captureSerialState
 }
 
 type captureSerialState struct {
-	done chan struct{}
-	err  error
+	sessionKey string
+	previous   *captureSerialState
+	done       chan struct{}
+	err        error
 }
 
 func (s *Service) startWorkers() {

--- a/memory/tencentdb/worker.go
+++ b/memory/tencentdb/worker.go
@@ -18,9 +18,16 @@ import (
 )
 
 type ingestJob struct {
-	req    captureRequest
-	sess   *session.Session
-	cursor time.Time
+	req      captureRequest
+	sess     *session.Session
+	cursor   time.Time
+	previous *captureSerialState
+	serial   *captureSerialState
+}
+
+type captureSerialState struct {
+	done chan struct{}
+	err  error
 }
 
 func (s *Service) startWorkers() {

--- a/memory/tencentdb/worker.go
+++ b/memory/tencentdb/worker.go
@@ -1,0 +1,48 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package tencentdb
+
+import (
+	"context"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/log"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+type ingestJob struct {
+	req    captureRequest
+	sess   *session.Session
+	cursor time.Time
+}
+
+func (s *Service) startWorkers() {
+	for i := 0; i < s.opts.IngestWorkers; i++ {
+		s.wg.Add(1)
+		go func() {
+			defer s.wg.Done()
+			for job := range s.queue {
+				ctx := context.Background()
+				if s.opts.IngestJobTimeout > 0 {
+					var cancel context.CancelFunc
+					ctx, cancel = context.WithTimeout(ctx, s.opts.IngestJobTimeout)
+					if err := s.capture(ctx, job); err != nil {
+						log.Warnf("tencentdb memory: async capture failed: %v", err)
+					}
+					cancel()
+					continue
+				}
+				if err := s.capture(ctx, job); err != nil {
+					log.Warnf("tencentdb memory: async capture failed: %v", err)
+				}
+			}
+		}()
+	}
+}


### PR DESCRIPTION
## Summary
- Add a TencentDB Agent Memory adapter that captures session turns through `session.Ingestor`, injects recall context through a Runner plugin, and exposes TencentDB-native search tools.
- Add unit coverage for the gateway client, service lifecycle, recall injection, tools, and transcript scanning behavior.
- Add an interactive TencentDB memory example and update English/Chinese mkdocs memory documentation with public gateway setup instructions.

## Test plan
- `go test -v -count=1 -cover ./memory/tencentdb`
- `go test ./...` from `examples/memory`
- Ran `examples/memory/tencentdb` against a TencentDB Agent Memory gateway and verified cross-session memory recall.