### PR TITLE
tool/claudecode: stabilize PDF helper test

### DIFF
--- a/tool/claudecode/claudecode_test.go
+++ b/tool/claudecode/claudecode_test.go
@@ -2302,6 +2302,25 @@ func TestPDFHelpersCoverRemainingBranches(t *testing.T) {
 	require.EqualError(t, err, "failed to extract PDF pages: render failed")
 }
 
+func TestPdftoppmRunUsesDefaultCommandRunner(t *testing.T) {
+	t.Parallel()
+	pdftoppmTestMu.Lock()
+	t.Cleanup(func() {
+		pdftoppmTestMu.Unlock()
+	})
+	output, err := pdftoppmRun(os.Args[0], "-test.run=TestPdftoppmRunHelperProcess", "--", "pdftoppm-run-helper")
+	require.NoError(t, err)
+	require.Equal(t, "pdftoppm helper\n", string(output))
+}
+
+func TestPdftoppmRunHelperProcess(t *testing.T) {
+	if len(os.Args) == 0 || os.Args[len(os.Args)-1] != "pdftoppm-run-helper" {
+		return
+	}
+	_, _ = fmt.Fprintln(os.Stdout, "pdftoppm helper")
+	os.Exit(0)
+}
+
 func TestExtractPDFPagesFailsWhenPdftoppmIsUnavailable(t *testing.T) {
 	t.Parallel()
 	pdftoppmTestMu.Lock()

--- a/tool/claudecode/claudecode_test.go
+++ b/tool/claudecode/claudecode_test.go
@@ -2241,19 +2241,37 @@ func TestPDFHelpersCoverRemainingBranches(t *testing.T) {
 	require.EqualError(t, err, `Page range "5-6" exceeds the PDF page count of 4.`)
 	scriptDir := t.TempDir()
 	successScript := filepath.Join(scriptDir, "pdftoppm-success")
-	require.NoError(t, os.WriteFile(successScript, []byte("#!/bin/bash\nprefix=\"${@: -1}\"\ntouch \"${prefix}-1.jpg\" \"${prefix}-2.jpg\"\n"), 0o755))
+	noImageScript := filepath.Join(scriptDir, "pdftoppm-empty")
+	failScript := filepath.Join(scriptDir, "pdftoppm-fail")
 	oldLookPath := pdftoppmLookPath
 	oldPath := pdftoppmPath
-	oldOnce := pdftoppmOnce
+	oldRun := pdftoppmRun
 	pdftoppmLookPath = func(string) (string, error) {
 		return successScript, nil
+	}
+	pdftoppmRun = func(path string, args ...string) ([]byte, error) {
+		require.NotEmpty(t, args)
+		outputPrefix := args[len(args)-1]
+		switch path {
+		case successScript:
+			require.NoError(t, os.WriteFile(outputPrefix+"-1.jpg", nil, 0o644))
+			require.NoError(t, os.WriteFile(outputPrefix+"-2.jpg", nil, 0o644))
+			return nil, nil
+		case noImageScript:
+			return nil, nil
+		case failScript:
+			return []byte("render failed\n"), errors.New("exit status 1")
+		default:
+			return nil, fmt.Errorf("unexpected pdftoppm path %q", path)
+		}
 	}
 	pdftoppmPath = ""
 	pdftoppmOnce = sync.Once{}
 	t.Cleanup(func() {
 		pdftoppmLookPath = oldLookPath
 		pdftoppmPath = oldPath
-		pdftoppmOnce = oldOnce
+		pdftoppmOnce = sync.Once{}
+		pdftoppmRun = oldRun
 	})
 	path, err := pdftoppmBinary()
 	require.NoError(t, err)
@@ -2268,8 +2286,6 @@ func TestPDFHelpersCoverRemainingBranches(t *testing.T) {
 	defer os.RemoveAll(outputDir)
 	_, statErr := os.Stat(filepath.Join(outputDir, "page-1.jpg"))
 	require.NoError(t, statErr)
-	noImageScript := filepath.Join(scriptDir, "pdftoppm-empty")
-	require.NoError(t, os.WriteFile(noImageScript, []byte("#!/bin/bash\nexit 0\n"), 0o755))
 	pdftoppmPath = noImageScript
 	_, _, err = extractPDFPages(filepath.Join(t.TempDir(), "fake.pdf"), pdfPageRange{
 		FirstPage: 1,
@@ -2277,8 +2293,6 @@ func TestPDFHelpersCoverRemainingBranches(t *testing.T) {
 		Count:     1,
 	})
 	require.EqualError(t, err, "failed to extract PDF pages: no rendered page images were produced")
-	failScript := filepath.Join(scriptDir, "pdftoppm-fail")
-	require.NoError(t, os.WriteFile(failScript, []byte("#!/bin/bash\necho render failed >&2\nexit 1\n"), 0o755))
 	pdftoppmPath = failScript
 	_, _, err = extractPDFPages(filepath.Join(t.TempDir(), "fake.pdf"), pdfPageRange{
 		FirstPage: 1,
@@ -2296,7 +2310,6 @@ func TestExtractPDFPagesFailsWhenPdftoppmIsUnavailable(t *testing.T) {
 	})
 	oldLookPath := pdftoppmLookPath
 	oldPath := pdftoppmPath
-	oldOnce := pdftoppmOnce
 	pdftoppmLookPath = func(string) (string, error) {
 		return "", errors.New("not found")
 	}
@@ -2305,7 +2318,7 @@ func TestExtractPDFPagesFailsWhenPdftoppmIsUnavailable(t *testing.T) {
 	t.Cleanup(func() {
 		pdftoppmLookPath = oldLookPath
 		pdftoppmPath = oldPath
-		pdftoppmOnce = oldOnce
+		pdftoppmOnce = sync.Once{}
 	})
 	_, _, err := extractPDFPages(filepath.Join(t.TempDir(), "missing.pdf"), pdfPageRange{
 		FirstPage: 1,

--- a/tool/claudecode/constants.go
+++ b/tool/claudecode/constants.go
@@ -51,6 +51,9 @@ var (
 	pdftoppmLookPath  = func(file string) (string, error) {
 		return exec.LookPath(file)
 	}
+	pdftoppmRun = func(path string, args ...string) ([]byte, error) {
+		return exec.Command(path, args...).CombinedOutput()
+	}
 )
 
 var grepExcludedDirs = []string{

--- a/tool/claudecode/pdf.go
+++ b/tool/claudecode/pdf.go
@@ -13,7 +13,6 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -121,7 +120,7 @@ func extractPDFPages(
 		filePath,
 		outputPrefix,
 	}
-	output, err := exec.Command(pdftoppmPath, args...).CombinedOutput()
+	output, err := pdftoppmRun(pdftoppmPath, args...)
 	if err != nil {
 		_ = os.RemoveAll(outputDir)
 		message := strings.TrimSpace(string(output))


### PR DESCRIPTION
## Summary
- Stabilize the PDF helper branch-coverage test by injecting the pdftoppm execution hook instead of writing and immediately executing temporary shell scripts.
- Keep production behavior unchanged; the default hook still runs pdftoppm with CombinedOutput.
- Background: CI saw TestPDFHelpersCoverRemainingBranches fail with `text file busy` while executing a temporary `pdftoppm-empty` script, instead of reaching the expected no-rendered-images error path.

## Test plan
- `go test . -run TestPDFHelpersCoverRemainingBranches -count=20` from `tool/claudecode`
- `go test ./...` from `tool/claudecode`