### PR TITLE
runner: log leading non-user seed messages at info level

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -668,10 +668,28 @@ func (r *runner) seedSessionHistory(
 	if len(ro.Messages) == 0 || sess.GetEventCount() != 0 {
 		return false, nil
 	}
+	infoLeadingNonUserSeedMessages(ctx, ro.Messages)
 	if err := r.appendMessagesAsSessionEvents(ctx, sess, invocation, ag, ro.Messages); err != nil {
 		return false, err
 	}
 	return true, nil
+}
+
+func infoLeadingNonUserSeedMessages(ctx context.Context, messages []model.Message) {
+	for i, msg := range messages {
+		if !model.HasPayload(msg) && len(msg.ToolCalls) == 0 {
+			continue
+		}
+		if msg.Role == model.RoleUser {
+			return
+		}
+		log.InfoContext(ctx, fmt.Sprintf(
+			"runner: WithMessages is used to seed session history; "+
+				"leading %s message at index %d may be filtered before the first user message. "+
+				"Use WithInjectedContextMessages for per-run context or agent instruction for system prompts.",
+			msg.Role, i))
+		return
+	}
 }
 
 // appendSessionMessages persists messages into the session transcript in the
@@ -3064,6 +3082,7 @@ func (r *runner) persistCurrentTurnMessages(
 		return r.appendIncomingMessage(ctx, sess, invocation, message, ro, historySeeded)
 	}
 	if sess.GetEventCount() == 0 {
+		infoLeadingNonUserSeedMessages(ctx, ro.Messages)
 		initialMessages := mergeCurrentTurnMessagesIntoSeed(
 			ro.Messages,
 			message,

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -1648,6 +1648,80 @@ func TestRunner_SkipAppendingSeedUserMessage(t *testing.T) {
 	require.Equal(t, 1, userCount)
 }
 
+func TestRunner_InfosOnLeadingNonUserSeedMessage(t *testing.T) {
+	original := runnerlog.InfoContext
+	var infos []string
+	runnerlog.InfoContext = func(ctx context.Context, args ...any) {
+		infos = append(infos, fmt.Sprint(args...))
+	}
+	defer func() {
+		runnerlog.InfoContext = original
+	}()
+
+	sessionService := sessioninmemory.NewSessionService()
+	mockAgent := &mockAgent{name: "test-agent"}
+	runner := NewRunner("test-app", mockAgent, WithSessionService(sessionService))
+
+	eventCh, err := runner.Run(
+		context.Background(),
+		"seed-user",
+		"seed-session",
+		model.NewUserMessage("hello"),
+		agent.WithMessages([]model.Message{
+			model.NewSystemMessage("system prompt"),
+			model.NewUserMessage("hello"),
+		}),
+	)
+	require.NoError(t, err)
+	for range eventCh {
+	}
+
+	require.Len(t, infos, 1)
+	require.Contains(t, infos[0], "WithMessages is used to seed session history")
+	require.Contains(t, infos[0], "leading system message")
+	require.Contains(t, infos[0], "WithInjectedContextMessages")
+}
+
+func TestRunner_InfosOnLeadingNonUserSeedMessageWithRewriter(t *testing.T) {
+	original := runnerlog.InfoContext
+	var infos []string
+	runnerlog.InfoContext = func(ctx context.Context, args ...any) {
+		infos = append(infos, fmt.Sprint(args...))
+	}
+	defer func() {
+		runnerlog.InfoContext = original
+	}()
+
+	sessionService := sessioninmemory.NewSessionService()
+	mockAgent := &mockAgent{name: "test-agent"}
+	runner := NewRunner("test-app", mockAgent, WithSessionService(sessionService))
+
+	eventCh, err := runner.Run(
+		context.Background(),
+		"seed-user",
+		"seed-session",
+		model.NewUserMessage("hello"),
+		agent.WithMessages([]model.Message{
+			model.NewAssistantMessage("assistant prefix"),
+			model.NewUserMessage("hello"),
+		}),
+		agent.WithUserMessageRewriter(func(
+			ctx context.Context,
+			args *agent.UserMessageRewriteArgs,
+		) ([]model.Message, error) {
+			return []model.Message{model.NewUserMessage("hello")}, nil
+		}),
+	)
+	require.NoError(t, err)
+	for range eventCh {
+	}
+
+	require.Len(t, infos, 1)
+	require.Contains(t, infos[0], "WithMessages is used to seed session history")
+	require.Contains(t, infos[0], "leading assistant message")
+	require.Contains(t, infos[0], "WithInjectedContextMessages")
+}
+
 func TestRunner_AppendsDifferentUserAfterSeed(t *testing.T) {
 	sessionService := sessioninmemory.NewSessionService()
 	mockAgent := &mockAgent{name: "test-agent"}


### PR DESCRIPTION
## Summary

- Log an info message when `WithMessages` seeds an empty session with leading non-user messages.
- Cover both the normal seed path and the empty-session `UserMessageRewriter` seed path.
- Point callers to `WithInjectedContextMessages` for per-run context and agent instruction for system prompts.

## Why

`WithMessages` is session-history seed data. When callers pass a leading system/assistant/tool message before the first user message, session event filtering can drop that prefix, so the call usually succeeds but those leading messages are not preserved. An info log makes this behavior visible without changing the existing session semantics.

A seed that starts with a user message can still continue with assistant messages, assistant tool calls, and tool results; those later messages remain after the user anchor.

## Tests

```bash
go test ./runner
```