### PR TITLE
{tool, agent}: add tool permission policy

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,48 +1,36 @@
-version: "2"
-output:
-  formats:
-    text:
-      path: stdout
+linters-settings:
+  gocyclo:
+    min-complexity: 20
+  goliddjoijnt:
+    min-confidence: 0
+  revive:
+    rules:
+      - name: package-comments
+      - name: exported
+        arguments:
+          - disableStutteringCheck
+
+issues:
+  include:
+    - EXC0012 # exported should have comment
+    - EXC0013 # package comment should be of the form
+    - EXC0014 # comment on exported should be of the form
+    - EXC0015 # should have a package comment
+  exclude-files:
+    - ".*.pb.go"
+    - ".*_mock.go"
+    - ".*_test.go"
+
 linters:
-  default: none
+  disable-all: true
   enable:
+    - govet
+    - goimports
+    - gofmt
+    - revive
     - gocyclo
     - gosec
-    - govet
     - ineffassign
-    - revive
-  settings:
-    gocyclo:
-      min-complexity: 20
-    revive:
-      rules:
-        - name: package-comments
-        - name: exported
-          arguments:
-            - disableStutteringCheck
-  exclusions:
-    generated: lax
-    presets:
-      - common-false-positives
-      - legacy
-      - std-error-handling
-    paths:
-      - .*.pb.go
-      - .*_mock.go
-      - .*_test.go
-      - third_party$
-      - builtin$
-      - examples$
-formatters:
-  enable:
-    - gofmt
-    - goimports
-  exclusions:
-    generated: lax
-    paths:
-      - .*.pb.go
-      - .*_mock.go
-      - .*_test.go
-      - third_party$
-      - builtin$
-      - examples$
+
+output:
+  formats: colored-line-number

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,36 +1,48 @@
-linters-settings:
-  gocyclo:
-    min-complexity: 20
-  goliddjoijnt:
-    min-confidence: 0
-  revive:
-    rules:
-      - name: package-comments
-      - name: exported
-        arguments:
-          - disableStutteringCheck
-
-issues:
-  include:
-    - EXC0012 # exported should have comment
-    - EXC0013 # package comment should be of the form
-    - EXC0014 # comment on exported should be of the form
-    - EXC0015 # should have a package comment
-  exclude-files:
-    - ".*.pb.go"
-    - ".*_mock.go"
-    - ".*_test.go"
-
+version: "2"
+output:
+  formats:
+    text:
+      path: stdout
 linters:
-  disable-all: true
+  default: none
   enable:
-    - govet 
-    - goimports
-    - gofmt
-    - revive
     - gocyclo
     - gosec
+    - govet
     - ineffassign
-
-output:
-  formats: colored-line-number 
+    - revive
+  settings:
+    gocyclo:
+      min-complexity: 20
+    revive:
+      rules:
+        - name: package-comments
+        - name: exported
+          arguments:
+            - disableStutteringCheck
+  exclusions:
+    generated: lax
+    presets:
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - .*.pb.go
+      - .*_mock.go
+      - .*_test.go
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - .*.pb.go
+      - .*_mock.go
+      - .*_test.go
+      - third_party$
+      - builtin$
+      - examples$

--- a/agent/invocation.go
+++ b/agent/invocation.go
@@ -851,7 +851,10 @@ func WithToolExecutionFilter(filter tool.FilterFunc) RunOption {
 //   - WithToolPermissionPolicy executes a permission check for tools the
 //     framework is about to run.
 //
-// Tools without permission checks keep the legacy allow behavior.
+// When no per-run policy is configured, tools without their own checker keep
+// the legacy allow behavior. When a per-run policy is configured, it is applied
+// to every tool the framework is about to execute, including tools that do not
+// implement tool.PermissionChecker.
 func WithToolPermissionPolicy(policy tool.PermissionPolicy) RunOption {
 	return func(opts *RunOptions) {
 		opts.ToolPermissionPolicy = policy

--- a/agent/invocation.go
+++ b/agent/invocation.go
@@ -839,8 +839,9 @@ func WithToolExecutionFilter(filter tool.FilterFunc) RunOption {
 	}
 }
 
-// WithToolPermissionPolicy sets a per-run policy that is checked immediately
-// before the framework executes a tool call.
+// WithToolPermissionPolicy sets a per-run policy that is checked after
+// before-tool callbacks finalize arguments and immediately before the
+// framework executes a tool call.
 //
 // The policy is intentionally separate from WithToolFilter and
 // WithToolExecutionFilter:
@@ -1226,12 +1227,14 @@ type RunOptions struct {
 	ToolExecutionFilter tool.FilterFunc
 
 	// ToolPermissionPolicy checks whether a tool call may run after the model
-	// has requested it and after the framework has repaired its arguments.
+	// has requested it, after argument repair, and after before-tool callbacks
+	// have finalized arguments.
 	//
 	// This policy does not change the visible tool surface. Use ToolFilter for
-	// that. It also does not replace callbacks or guardrail plugins; those still
-	// run around actually executed tools. A deny or ask decision skips tool
-	// execution and returns a structured permission result to the model.
+	// that. It also does not replace callbacks or guardrail plugins; before-tool
+	// callbacks can still normalize arguments before the policy sees them. A deny
+	// or ask decision skips tool execution and returns a structured permission
+	// result to the model.
 	ToolPermissionPolicy tool.PermissionPolicy
 
 	// ToolCallArgumentsJSONRepairEnabled enables best-effort JSON repair for tool call arguments.

--- a/agent/invocation.go
+++ b/agent/invocation.go
@@ -839,6 +839,29 @@ func WithToolExecutionFilter(filter tool.FilterFunc) RunOption {
 	}
 }
 
+// WithToolPermissionPolicy sets a per-run policy that is checked immediately
+// before the framework executes a tool call.
+//
+// The policy is intentionally separate from WithToolFilter and
+// WithToolExecutionFilter:
+//   - WithToolFilter controls which tools are visible to the model.
+//   - WithToolExecutionFilter controls whether the framework auto-executes
+//     a visible tool or leaves it to the caller.
+//   - WithToolPermissionPolicy executes a permission check for tools the
+//     framework is about to run.
+//
+// Tools without permission checks keep the legacy allow behavior.
+func WithToolPermissionPolicy(policy tool.PermissionPolicy) RunOption {
+	return func(opts *RunOptions) {
+		opts.ToolPermissionPolicy = policy
+	}
+}
+
+// WithToolPermissionPolicyFunc adapts fn into a per-run tool permission policy.
+func WithToolPermissionPolicyFunc(fn tool.PermissionPolicyFunc) RunOption {
+	return WithToolPermissionPolicy(fn)
+}
+
 func appendRunTools(opts *RunOptions, tools []tool.Tool) {
 	if opts == nil || len(tools) == 0 {
 		return
@@ -1201,6 +1224,16 @@ type RunOptions struct {
 	// assistant tool_call response so the caller can execute the tool
 	// externally and later provide tool results (RoleTool messages).
 	ToolExecutionFilter tool.FilterFunc
+
+	// ToolPermissionPolicy checks whether a tool call may run after the model
+	// has requested it and after the framework has repaired its arguments.
+	//
+	// This policy does not change the visible tool surface. Use ToolFilter for
+	// that. It also does not replace callbacks or guardrail plugins; those still
+	// run around actually executed tools. A deny or ask decision skips tool
+	// execution and returns a structured permission result to the model.
+	ToolPermissionPolicy tool.PermissionPolicy
+
 	// ToolCallArgumentsJSONRepairEnabled enables best-effort JSON repair for tool call arguments.
 	// When nil, JSON repair is disabled by default.
 	ToolCallArgumentsJSONRepairEnabled *bool

--- a/agent/invocation_test.go
+++ b/agent/invocation_test.go
@@ -1108,6 +1108,28 @@ func TestWithModelSelector(t *testing.T) {
 	require.Equal(t, "selector-model", got.Info().Name)
 }
 
+func TestWithToolPermissionPolicy(t *testing.T) {
+	const (
+		toolName    = "dangerous_tool"
+		blockReason = "blocked"
+	)
+	opts := &RunOptions{}
+	WithToolPermissionPolicyFunc(
+		func(_ context.Context, req *tool.PermissionRequest) (tool.PermissionDecision, error) {
+			require.Equal(t, toolName, req.ToolName)
+			return tool.DenyPermission(blockReason), nil
+		},
+	)(opts)
+
+	require.NotNil(t, opts.ToolPermissionPolicy)
+	decision, err := opts.ToolPermissionPolicy.CheckToolPermission(
+		context.Background(),
+		&tool.PermissionRequest{ToolName: toolName},
+	)
+	require.NoError(t, err)
+	require.Equal(t, tool.PermissionActionDeny, decision.Action)
+}
+
 func TestWithInstruction(t *testing.T) {
 	opts := &RunOptions{}
 	WithInstruction(testRunInstruction)(opts)

--- a/docs/mkdocs/en/tool.md
+++ b/docs/mkdocs/en/tool.md
@@ -38,6 +38,67 @@ type CallableTool interface {
 
 > For Function Tools, set these via `function.WithName(...)` / `function.WithDescription(...)`. For custom Tools, set `Name` / `Description` on the `tool.Declaration` returned by `Declaration()`.
 
+#### 🛡️ Tool Metadata and Permission Policy
+
+Tool metadata is an optional description of execution behavior. It does not
+change the core `tool.Tool` interface.
+
+Use metadata when a host, policy, or UI needs to understand whether a tool is
+read-only, destructive, concurrency-safe, search/read oriented, open-world, or
+has an advisory result size limit.
+
+```go
+type ToolMetadata struct {
+    ReadOnly        bool
+    Destructive     bool
+    ConcurrencySafe bool
+    SearchOrRead    bool
+    OpenWorld       bool
+    MaxResultSize   int
+}
+
+type MetadataProvider interface {
+    ToolMetadata() tool.ToolMetadata
+}
+```
+
+Permission policy is checked after the model requests a tool and before the
+framework executes it:
+
+```go
+runner.Run(ctx, userID, sessionID, message,
+    agent.WithToolPermissionPolicyFunc(
+        func(ctx context.Context, req *tool.PermissionRequest) (tool.PermissionDecision, error) {
+            if req.Metadata.Destructive {
+                return tool.AskPermission("destructive tools require approval"), nil
+            }
+            return tool.AllowPermission(), nil
+        },
+    ),
+)
+```
+
+Tools can also enforce their own rule by implementing `tool.PermissionChecker`.
+The tool-level checker runs before the per-run policy, and the first non-allow
+decision wins.
+
+Decision behavior:
+
+- `tool.AllowPermission()`: execute the tool.
+- `tool.DenyPermission(reason)`: skip execution and return a structured `denied` tool result to the model.
+- `tool.AskPermission(reason)`: skip execution and return a structured `approval_required` tool result to the model.
+
+If your application has an approval UI, ask the user inside the policy and
+return `tool.AllowPermission()` only after approval. The framework does not
+invent a UI flow for `ask`.
+
+Keep the boundaries clear:
+
+- `agent.WithToolFilter(...)`: controls which tools are visible to the model.
+- `agent.WithToolExecutionFilter(...)`: leaves selected visible tool calls for the caller to execute externally.
+- `agent.WithToolPermissionPolicy(...)`: checks permission for tools the framework is about to execute.
+- Tool callbacks and guardrail plugins still work for authorization, audit, and review workflows. Use the permission policy for simple deterministic allow/deny/ask checks.
+
 #### 📦 ToolSet
 
 A ToolSet is a collection of related tools that implements the `tool.ToolSet` interface. A ToolSet manages the lifecycle of tools, connections, and resource cleanup.

--- a/docs/mkdocs/en/tool.md
+++ b/docs/mkdocs/en/tool.md
@@ -81,7 +81,9 @@ runner.Run(ctx, userID, sessionID, message,
 
 Tools can also enforce their own rule by implementing `tool.PermissionChecker`.
 The tool-level checker runs before the per-run policy, and the first non-allow
-decision wins.
+decision wins. Tools without their own checker are still evaluated by the
+per-run policy when one is configured. If neither a tool checker nor a per-run
+policy exists, the legacy allow-by-default behavior is preserved.
 
 Decision behavior:
 
@@ -97,7 +99,7 @@ Keep the boundaries clear:
 
 - `agent.WithToolFilter(...)`: controls which tools are visible to the model.
 - `agent.WithToolExecutionFilter(...)`: leaves selected visible tool calls for the caller to execute externally.
-- `agent.WithToolPermissionPolicy(...)`: checks permission for tools the framework is about to execute.
+- `agent.WithToolPermissionPolicy(...)`: checks permission for every tool the framework is about to execute.
 - Tool callbacks and guardrail plugins still work for authorization, audit, and review workflows. Use the permission policy for simple deterministic allow/deny/ask checks.
 
 #### 📦 ToolSet

--- a/docs/mkdocs/en/tool.md
+++ b/docs/mkdocs/en/tool.md
@@ -44,7 +44,7 @@ Tool metadata is an optional description of execution behavior. It does not
 change the core `tool.Tool` interface.
 
 Use metadata when a host, policy, or UI needs to understand whether a tool is
-read-only, destructive, concurrency-safe, search/read oriented, open-world, or
+read-only, destructive, concurrency-safe, search/read-oriented, open-world, or
 has an advisory result size limit.
 
 ```go
@@ -62,7 +62,8 @@ type MetadataProvider interface {
 }
 ```
 
-Permission policy is checked after the model requests a tool and before the
+Permission policy is checked after the model requests a tool, after JSON repair
+and before-tool callbacks have finalized arguments, and immediately before the
 framework executes it:
 
 ```go

--- a/docs/mkdocs/zh/tool.md
+++ b/docs/mkdocs/zh/tool.md
@@ -38,6 +38,59 @@ type CallableTool interface {
 
 > 对于 Function Tool：通过 `function.WithName(...)` / `function.WithDescription(...)` 配置；对于自定义 Tool：在 `Declaration()` 返回的 `tool.Declaration` 中设置 `Name` / `Description`。
 
+#### 🛡️ Tool Metadata 与权限策略
+
+Tool Metadata 是可选的执行行为描述，不改变核心 `tool.Tool` 接口。
+
+当宿主、策略或 UI 需要判断一个工具是否只读、是否具有破坏性、是否可并发、是否主要用于搜索/读取、是否会访问外部世界，或是否声明了建议的结果大小上限时，可以让工具实现 metadata。
+
+```go
+type ToolMetadata struct {
+    ReadOnly        bool
+    Destructive     bool
+    ConcurrencySafe bool
+    SearchOrRead    bool
+    OpenWorld       bool
+    MaxResultSize   int
+}
+
+type MetadataProvider interface {
+    ToolMetadata() tool.ToolMetadata
+}
+```
+
+权限策略发生在模型已经发起 tool call、框架即将真正执行工具之前：
+
+```go
+runner.Run(ctx, userID, sessionID, message,
+    agent.WithToolPermissionPolicyFunc(
+        func(ctx context.Context, req *tool.PermissionRequest) (tool.PermissionDecision, error) {
+            if req.Metadata.Destructive {
+                return tool.AskPermission("destructive tools require approval"), nil
+            }
+            return tool.AllowPermission(), nil
+        },
+    ),
+)
+```
+
+工具也可以实现 `tool.PermissionChecker` 来声明自己的强约束。工具级检查先于本次运行的 policy 执行，遇到第一个非 allow 决策就停止。
+
+决策语义：
+
+- `tool.AllowPermission()`：执行工具。
+- `tool.DenyPermission(reason)`：不执行工具，并向模型返回结构化的 `denied` 工具结果。
+- `tool.AskPermission(reason)`：不执行工具，并向模型返回结构化的 `approval_required` 工具结果。
+
+如果你的应用有真正的审批 UI，请在 policy 内部完成询问，并在用户同意后返回 `tool.AllowPermission()`。框架不会为 `ask` 自行发明一套 UI 交互流程。
+
+几个机制的边界需要区分清楚：
+
+- `agent.WithToolFilter(...)`：控制哪些工具对模型可见。
+- `agent.WithToolExecutionFilter(...)`：让部分已可见的 tool call 留给调用方外部执行。
+- `agent.WithToolPermissionPolicy(...)`：对框架即将执行的工具做权限判断。
+- Tool callbacks 与 guardrail plugins 仍然适合做鉴权、审计、自动审批评估等流程。简单确定性的 allow/deny/ask 判断，优先使用 permission policy。
+
 #### 📦 ToolSet（工具集）
 
 ToolSet 是一组相关工具的集合，实现 `tool.ToolSet` 接口。ToolSet 负责管理工具的生命周期、连接和资源清理。

--- a/docs/mkdocs/zh/tool.md
+++ b/docs/mkdocs/zh/tool.md
@@ -74,7 +74,7 @@ runner.Run(ctx, userID, sessionID, message,
 )
 ```
 
-工具也可以实现 `tool.PermissionChecker` 来声明自己的强约束。工具级检查先于本次运行的 policy 执行，遇到第一个非 allow 决策就停止。
+工具也可以实现 `tool.PermissionChecker` 来声明自己的强约束。工具级检查先于本次运行的 policy 执行，遇到第一个非 allow 决策就停止。没有实现 checker 的工具，在配置了本次运行 policy 时仍然会被 policy 检查；如果工具 checker 和本次运行 policy 都不存在，则保持旧行为，默认允许执行。
 
 决策语义：
 
@@ -88,7 +88,7 @@ runner.Run(ctx, userID, sessionID, message,
 
 - `agent.WithToolFilter(...)`：控制哪些工具对模型可见。
 - `agent.WithToolExecutionFilter(...)`：让部分已可见的 tool call 留给调用方外部执行。
-- `agent.WithToolPermissionPolicy(...)`：对框架即将执行的工具做权限判断。
+- `agent.WithToolPermissionPolicy(...)`：对框架即将执行的每个工具做权限判断。
 - Tool callbacks 与 guardrail plugins 仍然适合做鉴权、审计、自动审批评估等流程。简单确定性的 allow/deny/ask 判断，优先使用 permission policy。
 
 #### 📦 ToolSet（工具集）

--- a/docs/mkdocs/zh/tool.md
+++ b/docs/mkdocs/zh/tool.md
@@ -59,7 +59,7 @@ type MetadataProvider interface {
 }
 ```
 
-权限策略发生在模型已经发起 tool call、框架即将真正执行工具之前：
+权限策略发生在模型已经发起 tool call、框架完成 JSON 修复和 before-tool callbacks 参数改写、并且即将真正执行工具之前：
 
 ```go
 runner.Run(ctx, userID, sessionID, message,

--- a/examples/toolpolicy/README.md
+++ b/examples/toolpolicy/README.md
@@ -1,0 +1,41 @@
+# Tool Policy Example
+
+This example shows how to combine tool metadata with a per-run permission
+policy.
+
+The example has two inventory tools:
+
+- `read_inventory`: marked as read-only and search/read.
+- `set_inventory`: marked as destructive.
+
+The permission policy uses those metadata fields:
+
+- `admin`: can run both tools.
+- `operator`: can read inventory, but destructive updates return
+  `approval_required`.
+- `viewer`: can read inventory, but destructive updates return `denied`.
+
+`ask` and `deny` decisions do not execute the tool. They return a structured
+tool result to the model, so the assistant can explain what happened. If your
+application has a real approval UI, ask the user inside the policy and return
+`tool.AllowPermission()` only after approval.
+
+## Run
+
+```bash
+export OPENAI_API_KEY="your-api-key"
+go run . --role operator
+```
+
+Try:
+
+```text
+read the inventory
+set notebook count to 8
+```
+
+Run as admin to allow the update:
+
+```bash
+go run . --role admin
+```

--- a/examples/toolpolicy/main.go
+++ b/examples/toolpolicy/main.go
@@ -1,0 +1,247 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package main demonstrates tool metadata and per-run permission policy.
+package main
+
+import (
+	"bufio"
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/model/openai"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+	"trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+	"trpc.group/trpc-go/trpc-agent-go/tool/function"
+)
+
+const (
+	defaultModelName  = "deepseek-v4-flash"
+	appName           = "tool-policy-example"
+	sessionIDPrefix   = "tool-policy"
+	toolReadInventory = "read_inventory"
+	toolSetInventory  = "set_inventory"
+	roleViewer        = "viewer"
+	roleOperator      = "operator"
+	roleAdmin         = "admin"
+	approvalReason    = "destructive inventory changes require an admin role"
+	deniedReason      = "unknown role cannot execute tools"
+	viewerDenyReason  = "viewer role cannot change inventory"
+	itemNotebook      = "notebook"
+	itemPen           = "pen"
+	notebookCount     = 12
+	penCount          = 30
+)
+
+var (
+	modelName = flag.String("model", defaultModelName, "Name of the model to use")
+	role      = flag.String("role", roleOperator, "User role: viewer, operator, or admin")
+)
+
+type inventoryItem struct {
+	Name  string `json:"name" jsonschema:"description=Inventory item name"`
+	Count int    `json:"count" jsonschema:"description=Inventory count"`
+}
+
+type metadataTool struct {
+	tool.CallableTool
+	metadata tool.ToolMetadata
+}
+
+func (m metadataTool) ToolMetadata() tool.ToolMetadata {
+	return m.metadata
+}
+
+type example struct {
+	runner    runner.Runner
+	role      string
+	sessionID string
+	inventory map[string]int
+}
+
+func main() {
+	flag.Parse()
+
+	ex := &example{
+		role:      *role,
+		sessionID: fmt.Sprintf("%s-%d", sessionIDPrefix, time.Now().Unix()),
+		inventory: map[string]int{
+			itemNotebook: notebookCount,
+			itemPen:      penCount,
+		},
+	}
+	if err := ex.run(context.Background()); err != nil {
+		log.Fatalf("tool policy example failed: %v", err)
+	}
+}
+
+func (e *example) run(ctx context.Context) error {
+	if err := e.setup(); err != nil {
+		return err
+	}
+	defer e.runner.Close()
+
+	fmt.Println("Tool metadata and permission policy example")
+	fmt.Printf("Model: %s\n", *modelName)
+	fmt.Printf("Role: %s\n", e.role)
+	fmt.Println()
+	fmt.Println("Try:")
+	fmt.Println("  - read the inventory")
+	fmt.Println("  - set notebook count to 8")
+	fmt.Println("  - set pen count to 10")
+	fmt.Println("Type /exit to quit.")
+	fmt.Println()
+
+	scanner := bufio.NewScanner(os.Stdin)
+	for {
+		fmt.Print("You: ")
+		if !scanner.Scan() {
+			break
+		}
+		text := strings.TrimSpace(scanner.Text())
+		if text == "" {
+			continue
+		}
+		if text == "/exit" {
+			return nil
+		}
+		if err := e.send(ctx, text); err != nil {
+			fmt.Printf("error: %v\n", err)
+		}
+	}
+	return scanner.Err()
+}
+
+func (e *example) setup() error {
+	modelInstance := openai.New(*modelName)
+	ag := llmagent.New(
+		"inventory-assistant",
+		llmagent.WithModel(modelInstance),
+		llmagent.WithInstruction(
+			"Help the user inspect and update a small inventory. "+
+				"If a tool result says approval is required, explain that the change was not applied.",
+		),
+		llmagent.WithTools(e.tools()),
+	)
+	e.runner = runner.NewRunner(
+		appName,
+		ag,
+		runner.WithSessionService(inmemory.NewSessionService()),
+	)
+	return nil
+}
+
+func (e *example) tools() []tool.Tool {
+	readTool := function.NewFunctionTool(
+		e.readInventory,
+		function.WithName(toolReadInventory),
+		function.WithDescription("Read the current inventory counts."),
+	)
+	setTool := function.NewFunctionTool(
+		e.setInventory,
+		function.WithName(toolSetInventory),
+		function.WithDescription("Set the count for one inventory item."),
+	)
+	return []tool.Tool{
+		metadataTool{
+			CallableTool: readTool,
+			metadata: tool.ToolMetadata{
+				ReadOnly:        true,
+				ConcurrencySafe: true,
+				SearchOrRead:    true,
+			},
+		},
+		metadataTool{
+			CallableTool: setTool,
+			metadata: tool.ToolMetadata{
+				Destructive: true,
+			},
+		},
+	}
+}
+
+func (e *example) readInventory(_ context.Context, _ struct{}) (map[string]int, error) {
+	out := make(map[string]int, len(e.inventory))
+	for name, count := range e.inventory {
+		out[name] = count
+	}
+	return out, nil
+}
+
+func (e *example) setInventory(_ context.Context, item inventoryItem) (map[string]any, error) {
+	e.inventory[item.Name] = item.Count
+	return map[string]any{
+		"updated": item.Name,
+		"count":   item.Count,
+	}, nil
+}
+
+func (e *example) send(ctx context.Context, text string) error {
+	events, err := e.runner.Run(
+		ctx,
+		e.role,
+		e.sessionID,
+		model.NewUserMessage(text),
+		agent.WithToolPermissionPolicyFunc(e.permissionPolicy),
+	)
+	if err != nil {
+		return err
+	}
+	for ev := range events {
+		printEvent(ev)
+	}
+	return nil
+}
+
+func (e *example) permissionPolicy(
+	_ context.Context,
+	req *tool.PermissionRequest,
+) (tool.PermissionDecision, error) {
+	switch e.role {
+	case roleAdmin:
+		return tool.AllowPermission(), nil
+	case roleOperator:
+		if req.Metadata.Destructive {
+			return tool.AskPermission(approvalReason), nil
+		}
+		return tool.AllowPermission(), nil
+	case roleViewer:
+		if req.Metadata.Destructive {
+			return tool.DenyPermission(viewerDenyReason), nil
+		}
+		return tool.AllowPermission(), nil
+	default:
+		return tool.DenyPermission(deniedReason), nil
+	}
+}
+
+func printEvent(ev *event.Event) {
+	if ev == nil || ev.Response == nil {
+		return
+	}
+	for _, choice := range ev.Response.Choices {
+		if choice.Message.Role == model.RoleAssistant &&
+			choice.Message.Content != "" {
+			fmt.Printf("Assistant: %s\n", choice.Message.Content)
+		}
+		if choice.Message.Role == model.RoleTool &&
+			choice.Message.Content != "" {
+			fmt.Printf("Tool result: %s\n", choice.Message.Content)
+		}
+	}
+}

--- a/graph/state_graph.go
+++ b/graph/state_graph.go
@@ -4163,27 +4163,7 @@ func runToolWithEventContexts(
 	if err != nil {
 		return startCtx, startInvocation, ctx, startInvocation, nil, toolCall.Function.Arguments, err
 	}
-	var result any
-	var toolErr error
-	if retryPolicy == nil {
-		result, toolErr = callableTool.Call(ctx, toolCall.Function.Arguments)
-	} else {
-		runResult := toolretry.Execute(ctx, toolretry.ExecuteInput{
-			ToolName:   toolCall.Function.Name,
-			ToolCallID: toolCall.ID,
-			Arguments:  toolCall.Function.Arguments,
-			Policy:     retryPolicy,
-			Call:       callableTool.Call,
-			ResultError: func(result any) bool {
-				return extractResultError(result)
-			},
-			IsTerminalError: func(err error) bool {
-				return IsInterruptError(err)
-			},
-		})
-		result = runResult.Result
-		toolErr = runResult.Error
-	}
+	result, toolErr := callToolWithRetry(ctx, toolCall, callableTool, retryPolicy)
 	completeInvocation := startInvocation
 
 	ctx, customResult, err = runAfterToolPluginCallbacks(
@@ -4240,6 +4220,31 @@ func runToolWithEventContexts(
 			fmt.Errorf("tool %s call failed: %w", toolCall.Function.Name, toolErr)
 	}
 	return startCtx, startInvocation, ctx, completeInvocation, result, toolCall.Function.Arguments, nil
+}
+
+func callToolWithRetry(
+	ctx context.Context,
+	toolCall model.ToolCall,
+	callableTool tool.CallableTool,
+	retryPolicy *tool.RetryPolicy,
+) (any, error) {
+	if retryPolicy == nil {
+		return callableTool.Call(ctx, toolCall.Function.Arguments)
+	}
+	runResult := toolretry.Execute(ctx, toolretry.ExecuteInput{
+		ToolName:   toolCall.Function.Name,
+		ToolCallID: toolCall.ID,
+		Arguments:  toolCall.Function.Arguments,
+		Policy:     retryPolicy,
+		Call:       callableTool.Call,
+		ResultError: func(result any) bool {
+			return extractResultError(result)
+		},
+		IsTerminalError: func(err error) bool {
+			return IsInterruptError(err)
+		},
+	})
+	return runResult.Result, runResult.Error
 }
 
 func checkToolPermission(

--- a/graph/state_graph.go
+++ b/graph/state_graph.go
@@ -4144,6 +4144,19 @@ func runToolWithEventContexts(
 	if customResult != nil {
 		return ctx, startInvocation, ctx, startInvocation, customResult, toolCall.Function.Arguments, nil
 	}
+	permissionResult, err := checkToolPermission(
+		ctx,
+		startInvocation,
+		toolCall,
+		t,
+		decl,
+	)
+	if err != nil {
+		return ctx, startInvocation, ctx, startInvocation, nil, toolCall.Function.Arguments, err
+	}
+	if permissionResult != nil {
+		return ctx, startInvocation, ctx, startInvocation, permissionResult, toolCall.Function.Arguments, nil
+	}
 	startCtx := ctx
 
 	callableTool, err := ensureCallableTool(t, toolCall.Function.Name)
@@ -4227,6 +4240,54 @@ func runToolWithEventContexts(
 			fmt.Errorf("tool %s call failed: %w", toolCall.Function.Name, toolErr)
 	}
 	return startCtx, startInvocation, ctx, completeInvocation, result, toolCall.Function.Arguments, nil
+}
+
+func checkToolPermission(
+	ctx context.Context,
+	invocation *agent.Invocation,
+	toolCall model.ToolCall,
+	t tool.Tool,
+	decl *tool.Declaration,
+) (*tool.PermissionResult, error) {
+	req := &tool.PermissionRequest{
+		Tool:        t,
+		ToolName:    toolCall.Function.Name,
+		ToolCallID:  toolCall.ID,
+		Declaration: decl,
+		Arguments:   toolCall.Function.Arguments,
+		Metadata:    tool.MetadataOf(t),
+	}
+	if checker, ok := t.(tool.PermissionChecker); ok {
+		decision, err := checker.CheckPermission(ctx, req)
+		result, err := normalizeToolPermissionResult(req, decision, err)
+		if result != nil || err != nil {
+			return result, err
+		}
+	}
+	if invocation == nil || invocation.RunOptions.ToolPermissionPolicy == nil {
+		return nil, nil
+	}
+	decision, err := invocation.RunOptions.ToolPermissionPolicy.CheckToolPermission(ctx, req)
+	return normalizeToolPermissionResult(req, decision, err)
+}
+
+func normalizeToolPermissionResult(
+	req *tool.PermissionRequest,
+	decision tool.PermissionDecision,
+	checkErr error,
+) (*tool.PermissionResult, error) {
+	if checkErr != nil {
+		return nil, checkErr
+	}
+	decision, err := tool.NormalizePermissionDecision(decision)
+	if err != nil {
+		return nil, err
+	}
+	if decision.Action == tool.PermissionActionAllow {
+		return nil, nil
+	}
+	result := tool.PermissionResultFor(req.ToolName, decision)
+	return &result, nil
 }
 
 func extractResultError(result any) bool {

--- a/graph/state_graph_test.go
+++ b/graph/state_graph_test.go
@@ -1432,6 +1432,81 @@ func TestRunToolWithEventContexts_NoRetryPolicyCallsToolOnCanceledContext(t *tes
 	require.Equal(t, toolCall.Function.Arguments, modifiedArgs)
 }
 
+func TestRunToolWithEventContexts_ToolPermissionPolicyDenySkipsExecution(
+	t *testing.T,
+) {
+	const (
+		toolName      = "delete_file"
+		toolCallID    = "call-deny"
+		denyReason    = "write access is disabled"
+		originalArgs  = `{"path":"unsafe"}`
+		rewrittenArgs = `{"path":"safe"}`
+	)
+
+	var (
+		beforeCalled bool
+		afterCalled  bool
+		policyCalled bool
+	)
+	callbacks := tool.NewCallbacks()
+	callbacks.RegisterBeforeTool(func(
+		_ context.Context,
+		_ *tool.BeforeToolArgs,
+	) (*tool.BeforeToolResult, error) {
+		beforeCalled = true
+		return &tool.BeforeToolResult{
+			ModifiedArguments: []byte(rewrittenArgs),
+		}, nil
+	})
+	callbacks.RegisterAfterTool(func(
+		_ context.Context,
+		_ *tool.AfterToolArgs,
+	) (*tool.AfterToolResult, error) {
+		afterCalled = true
+		return &tool.AfterToolResult{}, nil
+	})
+	invocation := &agent.Invocation{
+		RunOptions: agent.NewRunOptions(agent.WithToolPermissionPolicyFunc(
+			func(_ context.Context, req *tool.PermissionRequest) (tool.PermissionDecision, error) {
+				policyCalled = true
+				require.Equal(t, toolName, req.ToolName)
+				require.Equal(t, toolCallID, req.ToolCallID)
+				require.JSONEq(t, rewrittenArgs, string(req.Arguments))
+				return tool.DenyPermission(denyReason), nil
+			},
+		)),
+	}
+	ctx := agent.NewInvocationContext(context.Background(), invocation)
+	tl := &captureTool{name: toolName, result: map[string]any{"ok": true}}
+	toolCall := model.ToolCall{
+		ID: toolCallID,
+		Function: model.FunctionDefinitionParam{
+			Name:      toolName,
+			Arguments: []byte(originalArgs),
+		},
+	}
+
+	_, _, _, _, result, modifiedArgs, err := runToolWithEventContexts(
+		ctx,
+		toolCall,
+		callbacks,
+		tl,
+		State{},
+		nil,
+	)
+	require.NoError(t, err)
+	require.True(t, beforeCalled)
+	require.True(t, policyCalled)
+	require.False(t, afterCalled)
+	require.False(t, tl.called)
+	require.JSONEq(t, rewrittenArgs, string(modifiedArgs))
+	permissionResult, ok := result.(*tool.PermissionResult)
+	require.True(t, ok)
+	require.Equal(t, tool.PermissionResultStatusDenied, permissionResult.Status)
+	require.Equal(t, toolName, permissionResult.Tool)
+	require.Equal(t, denyReason, permissionResult.Reason)
+}
+
 func TestNewToolsNodeFunc_ToolCallbacksPrecedence(t *testing.T) {
 	// Test that node-configured callbacks take precedence over state callbacks.
 	var nodeCallbackUsed, stateCallbackUsed bool

--- a/internal/flow/processor/functioncall.go
+++ b/internal/flow/processor/functioncall.go
@@ -82,6 +82,7 @@ type toolEventStateDelta struct {
 type resolvedToolContextKey struct{}
 type stateDeltaSessionBaselineContextKey struct{}
 type executingToolArgsContextKey struct{}
+type skipToolStateDeltaContextKey struct{}
 
 // toolResult holds the result of a single tool execution.
 type toolResult struct {
@@ -896,7 +897,9 @@ func (p *FunctionCallResponseProcessor) buildToolEventStateDelta(
 	args []byte,
 	choices []model.Choice,
 ) *toolEventStateDelta {
-	if len(choices) == 0 || hasSyntheticStateOnlyToolChoice(ctx) {
+	if len(choices) == 0 ||
+		hasSyntheticStateOnlyToolChoice(ctx) ||
+		shouldSkipToolStateDelta(ctx) {
 		return nil
 	}
 	tl, ok := resolvedToolFromContext(ctx)
@@ -1057,6 +1060,21 @@ func resolvedToolFromContext(ctx context.Context) (tool.Tool, bool) {
 	}
 	tl, ok := ctx.Value(resolvedToolContextKey{}).(tool.Tool)
 	return tl, ok
+}
+
+func withSkippedToolStateDelta(ctx context.Context) context.Context {
+	if ctx == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, skipToolStateDeltaContextKey{}, true)
+}
+
+func shouldSkipToolStateDelta(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	skip, _ := ctx.Value(skipToolStateDeltaContextKey{}).(bool)
+	return skip
 }
 
 func (p *FunctionCallResponseProcessor) attachStateDeltaToToolResults(
@@ -1829,6 +1847,7 @@ func (p *FunctionCallResponseProcessor) executeToolWithCallbacks(
 		return ctx, nil, toolCall.Function.Arguments, false, false, err
 	}
 	if permissionResult != nil {
+		ctx = withSkippedToolStateDelta(ctx)
 		return ctx, *permissionResult, toolCall.Function.Arguments, false,
 			false, nil
 	}

--- a/internal/flow/processor/functioncall.go
+++ b/internal/flow/processor/functioncall.go
@@ -1310,7 +1310,9 @@ func (p *FunctionCallResponseProcessor) executeToolCall(
 			{Index: index, Message: defaultMsg},
 		}
 		ctx = markSyntheticStateOnlyToolChoice(ctx)
-		if p.toolCallbacks == nil || p.toolCallbacks.ToolResultMessages == nil {
+		if p.toolCallbacks == nil ||
+			p.toolCallbacks.ToolResultMessages == nil ||
+			isPermissionResult(result) {
 			return ctx, defaultChoices, modifiedArgs, true,
 				skipSummarization, nil
 		}
@@ -1354,7 +1356,8 @@ func (p *FunctionCallResponseProcessor) executeToolCall(
 		{Index: index, Message: defaultMsg},
 	}
 
-	if p.toolCallbacks != nil &&
+	if !isPermissionResult(result) &&
+		p.toolCallbacks != nil &&
 		p.toolCallbacks.ToolResultMessages != nil {
 		customChoices, overridden, cbErr :=
 			p.applyToolResultMessagesCallback(
@@ -1382,6 +1385,27 @@ func (p *FunctionCallResponseProcessor) executeToolCall(
 	)
 
 	return ctx, choices, modifiedArgs, true, skipSummarization, nil
+}
+
+func isPermissionResult(result any) bool {
+	switch v := result.(type) {
+	case tool.PermissionResult:
+		return isPermissionResultStatus(v.Status)
+	case *tool.PermissionResult:
+		return v != nil && isPermissionResultStatus(v.Status)
+	default:
+		return false
+	}
+}
+
+func isPermissionResultStatus(status string) bool {
+	switch status {
+	case tool.PermissionResultStatusDenied,
+		tool.PermissionResultStatusApprovalRequired:
+		return true
+	default:
+		return false
+	}
 }
 
 // resolveToolCallTarget resolves the callable tool, applies compatibility remapping,
@@ -1755,20 +1779,6 @@ func (p *FunctionCallResponseProcessor) executeToolWithCallbacks(
 	}
 	rememberExecutingToolArgs(ctx, toolCall.Function.Arguments)
 	toolDeclaration := tl.Declaration()
-	permissionResult, err := p.checkToolPermission(
-		ctx,
-		invocation,
-		toolCall,
-		tl,
-		toolDeclaration,
-	)
-	if err != nil {
-		return ctx, nil, toolCall.Function.Arguments, false, false, err
-	}
-	if permissionResult != nil {
-		return ctx, *permissionResult, toolCall.Function.Arguments, false,
-			false, nil
-	}
 	ctx, toolCall, customResult, err := p.runBeforeToolPluginCallbacks(
 		ctx,
 		invocation,
@@ -1796,6 +1806,20 @@ func (p *FunctionCallResponseProcessor) executeToolWithCallbacks(
 	rememberExecutingToolArgs(ctx, toolCall.Function.Arguments)
 	if customResult != nil {
 		return ctx, customResult, toolCall.Function.Arguments, false,
+			false, nil
+	}
+	permissionResult, err := p.checkToolPermission(
+		ctx,
+		invocation,
+		toolCall,
+		tl,
+		toolDeclaration,
+	)
+	if err != nil {
+		return ctx, nil, toolCall.Function.Arguments, false, false, err
+	}
+	if permissionResult != nil {
+		return ctx, *permissionResult, toolCall.Function.Arguments, false,
 			false, nil
 	}
 	// Execute the actual tool.

--- a/internal/flow/processor/functioncall.go
+++ b/internal/flow/processor/functioncall.go
@@ -1755,6 +1755,20 @@ func (p *FunctionCallResponseProcessor) executeToolWithCallbacks(
 	}
 	rememberExecutingToolArgs(ctx, toolCall.Function.Arguments)
 	toolDeclaration := tl.Declaration()
+	permissionResult, err := p.checkToolPermission(
+		ctx,
+		invocation,
+		toolCall,
+		tl,
+		toolDeclaration,
+	)
+	if err != nil {
+		return ctx, nil, toolCall.Function.Arguments, false, false, err
+	}
+	if permissionResult != nil {
+		return ctx, *permissionResult, toolCall.Function.Arguments, false,
+			false, nil
+	}
 	ctx, toolCall, customResult, err := p.runBeforeToolPluginCallbacks(
 		ctx,
 		invocation,
@@ -1850,6 +1864,54 @@ func (p *FunctionCallResponseProcessor) executeToolWithCallbacks(
 	}
 	return ctx, toolResult, toolCall.Function.Arguments,
 		suppressDefaultToolMessage, skipSummarization || localSkip, toolErr
+}
+
+func (p *FunctionCallResponseProcessor) checkToolPermission(
+	ctx context.Context,
+	invocation *agent.Invocation,
+	toolCall model.ToolCall,
+	tl tool.Tool,
+	decl *tool.Declaration,
+) (*tool.PermissionResult, error) {
+	req := &tool.PermissionRequest{
+		Tool:        tl,
+		ToolName:    toolCall.Function.Name,
+		ToolCallID:  toolCall.ID,
+		Declaration: decl,
+		Arguments:   toolCall.Function.Arguments,
+		Metadata:    tool.MetadataOf(tl),
+	}
+	if checker, ok := tl.(tool.PermissionChecker); ok {
+		decision, err := checker.CheckPermission(ctx, req)
+		result, err := normalizeToolPermissionResult(req, decision, err)
+		if result != nil || err != nil {
+			return result, err
+		}
+	}
+	if invocation == nil || invocation.RunOptions.ToolPermissionPolicy == nil {
+		return nil, nil
+	}
+	decision, err := invocation.RunOptions.ToolPermissionPolicy.CheckToolPermission(ctx, req)
+	return normalizeToolPermissionResult(req, decision, err)
+}
+
+func normalizeToolPermissionResult(
+	req *tool.PermissionRequest,
+	decision tool.PermissionDecision,
+	checkErr error,
+) (*tool.PermissionResult, error) {
+	if checkErr != nil {
+		return nil, checkErr
+	}
+	decision, err := tool.NormalizePermissionDecision(decision)
+	if err != nil {
+		return nil, err
+	}
+	if decision.Action == tool.PermissionActionAllow {
+		return nil, nil
+	}
+	result := tool.PermissionResultFor(req.ToolName, decision)
+	return &result, nil
 }
 
 func rememberExecutingToolArgs(ctx context.Context, args []byte) {

--- a/internal/flow/processor/functioncall.go
+++ b/internal/flow/processor/functioncall.go
@@ -1306,17 +1306,8 @@ func (p *FunctionCallResponseProcessor) executeToolCall(
 				fmt.Errorf("%s: %w", ErrorMarshalResult, err)
 		}
 		defaultMsg.ToolName = toolCall.Function.Name
-		defaultChoices := []model.Choice{
-			{Index: index, Message: defaultMsg},
-		}
 		ctx = markSyntheticStateOnlyToolChoice(ctx)
-		if p.toolCallbacks == nil ||
-			p.toolCallbacks.ToolResultMessages == nil ||
-			isPermissionResult(result) {
-			return ctx, defaultChoices, modifiedArgs, true,
-				skipSummarization, nil
-		}
-		customChoices, overridden, cbErr := p.applyToolResultMessagesCallback(
+		choices, cbErr := p.buildToolResultChoices(
 			ctx,
 			toolCall,
 			tl,
@@ -1328,11 +1319,7 @@ func (p *FunctionCallResponseProcessor) executeToolCall(
 		if cbErr != nil {
 			return ctx, nil, modifiedArgs, true, skipSummarization, cbErr
 		}
-		if overridden {
-			return ctx, customChoices, modifiedArgs, true,
-				skipSummarization, nil
-		}
-		return ctx, defaultChoices, modifiedArgs, true,
+		return ctx, choices, modifiedArgs, true,
 			skipSummarization, nil
 	}
 
@@ -1352,29 +1339,17 @@ func (p *FunctionCallResponseProcessor) executeToolCall(
 	}
 	defaultMsg.ToolName = toolCall.Function.Name
 
-	choices := []model.Choice{
-		{Index: index, Message: defaultMsg},
-	}
-
-	if !isPermissionResult(result) &&
-		p.toolCallbacks != nil &&
-		p.toolCallbacks.ToolResultMessages != nil {
-		customChoices, overridden, cbErr :=
-			p.applyToolResultMessagesCallback(
-				ctx,
-				toolCall,
-				tl,
-				result,
-				modifiedArgs,
-				index,
-				defaultMsg,
-			)
-		if cbErr != nil {
-			return ctx, nil, modifiedArgs, true, skipSummarization, cbErr
-		}
-		if overridden {
-			choices = customChoices
-		}
+	choices, cbErr := p.buildToolResultChoices(
+		ctx,
+		toolCall,
+		tl,
+		result,
+		modifiedArgs,
+		index,
+		defaultMsg,
+	)
+	if cbErr != nil {
+		return ctx, nil, modifiedArgs, true, skipSummarization, cbErr
 	}
 
 	log.DebugfContext(
@@ -1385,6 +1360,41 @@ func (p *FunctionCallResponseProcessor) executeToolCall(
 	)
 
 	return ctx, choices, modifiedArgs, true, skipSummarization, nil
+}
+
+func (p *FunctionCallResponseProcessor) buildToolResultChoices(
+	ctx context.Context,
+	toolCall model.ToolCall,
+	tl tool.Tool,
+	result any,
+	modifiedArgs []byte,
+	index int,
+	defaultMsg model.Message,
+) ([]model.Choice, error) {
+	defaultChoices := []model.Choice{
+		{Index: index, Message: defaultMsg},
+	}
+	if isPermissionResult(result) ||
+		p.toolCallbacks == nil ||
+		p.toolCallbacks.ToolResultMessages == nil {
+		return defaultChoices, nil
+	}
+	customChoices, overridden, err := p.applyToolResultMessagesCallback(
+		ctx,
+		toolCall,
+		tl,
+		result,
+		modifiedArgs,
+		index,
+		defaultMsg,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if overridden {
+		return customChoices, nil
+	}
+	return defaultChoices, nil
 }
 
 func isPermissionResult(result any) bool {

--- a/internal/flow/processor/functioncall.go
+++ b/internal/flow/processor/functioncall.go
@@ -83,6 +83,7 @@ type resolvedToolContextKey struct{}
 type stateDeltaSessionBaselineContextKey struct{}
 type executingToolArgsContextKey struct{}
 type skipToolStateDeltaContextKey struct{}
+type skipToolSkipSummarizationContextKey struct{}
 
 // toolResult holds the result of a single tool execution.
 type toolResult struct {
@@ -439,6 +440,7 @@ func (p *FunctionCallResponseProcessor) executeSingleToolCallSequentialResult(
 		}
 	}
 	toolEvent := p.buildToolCallResponseEvent(
+		ctx,
 		invocation,
 		llmResponse,
 		choices,
@@ -646,6 +648,7 @@ func (p *FunctionCallResponseProcessor) runParallelToolCall(
 			tools,
 			tc,
 			skipSummarization,
+			!shouldSkipToolSkipSummarization(ctx),
 		)
 		// Only propagate the error if it's not ignorable (e.g., stop errors)
 		var returnErr error
@@ -663,6 +666,7 @@ func (p *FunctionCallResponseProcessor) runParallelToolCall(
 
 	// No error and at least one choice means we have tool result messages.
 	toolCallResponseEvent := p.buildToolCallResponseEvent(
+		ctx,
 		invocation,
 		llmResponse,
 		choices,
@@ -728,6 +732,7 @@ func (p *FunctionCallResponseProcessor) runParallelToolCall(
 }
 
 func (p *FunctionCallResponseProcessor) buildToolCallResponseEvent(
+	ctx context.Context,
 	invocation *agent.Invocation,
 	llmResponse *model.Response,
 	choices []model.Choice,
@@ -752,6 +757,7 @@ func (p *FunctionCallResponseProcessor) buildToolCallResponseEvent(
 			tools,
 			toolCall,
 			skipSummarization,
+			!shouldSkipToolSkipSummarization(ctx),
 		)
 	}
 	annotateToolChoicesWithName(choices, toolCall.Function.Name)
@@ -762,6 +768,7 @@ func (p *FunctionCallResponseProcessor) buildToolCallResponseEvent(
 		tools,
 		toolCall,
 		skipSummarization,
+		!shouldSkipToolSkipSummarization(ctx),
 	)
 }
 
@@ -818,6 +825,7 @@ func (p *FunctionCallResponseProcessor) decorateToolCallResponseEvent(
 	tools map[string]tool.Tool,
 	toolCall model.ToolCall,
 	skipSummarization bool,
+	allowToolSkipSummarization bool,
 ) *event.Event {
 	if ev == nil {
 		return nil
@@ -826,7 +834,12 @@ func (p *FunctionCallResponseProcessor) decorateToolCallResponseEvent(
 		ev.Tag = event.TransferTag
 	}
 	if tl, ok := tools[toolCall.Function.Name]; ok {
-		p.annotateSkipSummarization(ev, tl, skipSummarization)
+		p.annotateSkipSummarization(
+			ev,
+			tl,
+			skipSummarization,
+			allowToolSkipSummarization,
+		)
 	} else if skipSummarization {
 		markSkipSummarization(ev)
 	}
@@ -885,8 +898,9 @@ func (p *FunctionCallResponseProcessor) annotateSkipSummarization(
 	ev *event.Event,
 	tl tool.Tool,
 	dynamic bool,
+	allowToolPreference bool,
 ) {
-	if dynamic || toolPrefersSkipSummarization(tl) {
+	if dynamic || (allowToolPreference && toolPrefersSkipSummarization(tl)) {
 		markSkipSummarization(ev)
 	}
 }
@@ -1074,6 +1088,21 @@ func shouldSkipToolStateDelta(ctx context.Context) bool {
 		return false
 	}
 	skip, _ := ctx.Value(skipToolStateDeltaContextKey{}).(bool)
+	return skip
+}
+
+func withSkippedToolSkipSummarization(ctx context.Context) context.Context {
+	if ctx == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, skipToolSkipSummarizationContextKey{}, true)
+}
+
+func shouldSkipToolSkipSummarization(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	skip, _ := ctx.Value(skipToolSkipSummarizationContextKey{}).(bool)
 	return skip
 }
 
@@ -1848,6 +1877,7 @@ func (p *FunctionCallResponseProcessor) executeToolWithCallbacks(
 	}
 	if permissionResult != nil {
 		ctx = withSkippedToolStateDelta(ctx)
+		ctx = withSkippedToolSkipSummarization(ctx)
 		return ctx, *permissionResult, toolCall.Function.Arguments, false,
 			false, nil
 	}

--- a/internal/flow/processor/functioncall_test.go
+++ b/internal/flow/processor/functioncall_test.go
@@ -106,8 +106,10 @@ func (m *mockCallableTool) Call(ctx context.Context, args []byte) (any, error) {
 
 type permissionMockTool struct {
 	*mockCallableTool
-	metadata tool.ToolMetadata
-	decision tool.PermissionDecision
+	metadata         tool.ToolMetadata
+	decision         tool.PermissionDecision
+	stateDelta       map[string][]byte
+	stateDeltaCalled bool
 }
 
 func (m *permissionMockTool) ToolMetadata() tool.ToolMetadata {
@@ -119,6 +121,16 @@ func (m *permissionMockTool) CheckPermission(
 	_ *tool.PermissionRequest,
 ) (tool.PermissionDecision, error) {
 	return m.decision, nil
+}
+
+func (m *permissionMockTool) StateDeltaForInvocation(
+	_ *agent.Invocation,
+	_ string,
+	_ []byte,
+	_ []byte,
+) map[string][]byte {
+	m.stateDeltaCalled = true
+	return m.stateDelta
 }
 
 type delayedLoadTool struct {
@@ -7868,6 +7880,56 @@ func TestExecuteToolCall_ToolPermissionResultSkipsToolResultMessagesCallback(
 	require.Equal(t, toolCallID, choices[0].Message.ToolID)
 	require.Equal(t, toolName, choices[0].Message.ToolName)
 	require.JSONEq(t, permissionJSON, choices[0].Message.Content)
+}
+
+func TestExecuteSingleToolCallSequential_ToolPermissionResultSkipsStateDelta(
+	t *testing.T,
+) {
+	const (
+		toolName       = "delete_file"
+		toolCallID     = "call-deny-delta"
+		denyReason     = "write access is disabled"
+		stateDeltaKey  = "denied_delta"
+		permissionJSON = `{"status":"denied","tool":"delete_file","reason":"write access is disabled"}`
+	)
+
+	var calledTool bool
+	tl := &permissionMockTool{
+		mockCallableTool: &mockCallableTool{
+			declaration: &tool.Declaration{Name: toolName},
+			callFn: func(_ context.Context, _ []byte) (any, error) {
+				calledTool = true
+				return map[string]any{"ok": true}, nil
+			},
+		},
+		decision: tool.DenyPermission(denyReason),
+		stateDelta: map[string][]byte{
+			stateDeltaKey: []byte("should-not-persist"),
+		},
+	}
+	ev, err := NewFunctionCallResponseProcessor(false, nil).
+		executeSingleToolCallSequential(
+			context.Background(),
+			&agent.Invocation{AgentName: "a", Model: &mockModel{}},
+			&model.Response{Choices: []model.Choice{{}}},
+			map[string]tool.Tool{toolName: tl},
+			make(chan *event.Event, 1),
+			0,
+			model.ToolCall{
+				ID: toolCallID,
+				Function: model.FunctionDefinitionParam{
+					Name:      toolName,
+					Arguments: []byte(`{}`),
+				},
+			},
+		)
+	require.NoError(t, err)
+	require.NotNil(t, ev)
+	require.False(t, calledTool)
+	require.False(t, tl.stateDeltaCalled)
+	require.NotContains(t, ev.StateDelta, stateDeltaKey)
+	require.Len(t, ev.Choices, 1)
+	require.JSONEq(t, permissionJSON, ev.Choices[0].Message.Content)
 }
 
 func TestExecuteToolWithCallbacks_ToolPermissionCheckerAskSkipsRunPolicy(

--- a/internal/flow/processor/functioncall_test.go
+++ b/internal/flow/processor/functioncall_test.go
@@ -110,6 +110,7 @@ type permissionMockTool struct {
 	decision         tool.PermissionDecision
 	stateDelta       map[string][]byte
 	stateDeltaCalled bool
+	skipSummarize    bool
 }
 
 func (m *permissionMockTool) ToolMetadata() tool.ToolMetadata {
@@ -131,6 +132,10 @@ func (m *permissionMockTool) StateDeltaForInvocation(
 ) map[string][]byte {
 	m.stateDeltaCalled = true
 	return m.stateDelta
+}
+
+func (m *permissionMockTool) SkipSummarization() bool {
+	return m.skipSummarize
 }
 
 type delayedLoadTool struct {
@@ -7928,6 +7933,49 @@ func TestExecuteSingleToolCallSequential_ToolPermissionResultSkipsStateDelta(
 	require.False(t, calledTool)
 	require.False(t, tl.stateDeltaCalled)
 	require.NotContains(t, ev.StateDelta, stateDeltaKey)
+	require.Len(t, ev.Choices, 1)
+	require.JSONEq(t, permissionJSON, ev.Choices[0].Message.Content)
+}
+
+func TestExecuteSingleToolCallSequential_ToolPermissionResultIgnoresToolSkipSummarization(
+	t *testing.T,
+) {
+	const (
+		toolName       = "delete_file"
+		toolCallID     = "call-deny-skip"
+		denyReason     = "write access is disabled"
+		permissionJSON = `{"status":"denied","tool":"delete_file","reason":"write access is disabled"}`
+	)
+
+	tl := &permissionMockTool{
+		mockCallableTool: &mockCallableTool{
+			declaration: &tool.Declaration{Name: toolName},
+			callFn: func(_ context.Context, _ []byte) (any, error) {
+				return map[string]any{"ok": true}, nil
+			},
+		},
+		decision:      tool.DenyPermission(denyReason),
+		skipSummarize: true,
+	}
+	ev, err := NewFunctionCallResponseProcessor(false, nil).
+		executeSingleToolCallSequential(
+			context.Background(),
+			&agent.Invocation{AgentName: "a", Model: &mockModel{}},
+			&model.Response{Choices: []model.Choice{{}}},
+			map[string]tool.Tool{toolName: tl},
+			make(chan *event.Event, 1),
+			0,
+			model.ToolCall{
+				ID: toolCallID,
+				Function: model.FunctionDefinitionParam{
+					Name:      toolName,
+					Arguments: []byte(`{}`),
+				},
+			},
+		)
+	require.NoError(t, err)
+	require.NotNil(t, ev)
+	require.False(t, ev.Actions != nil && ev.Actions.SkipSummarization)
 	require.Len(t, ev.Choices, 1)
 	require.JSONEq(t, permissionJSON, ev.Choices[0].Message.Content)
 }

--- a/internal/flow/processor/functioncall_test.go
+++ b/internal/flow/processor/functioncall_test.go
@@ -7746,6 +7746,8 @@ func TestExecuteToolWithCallbacks_ToolPermissionPolicyDenySkipsExecution(
 		toolName       = "delete_file"
 		toolCallID     = "call-deny"
 		denyReason     = "write access is disabled"
+		originalArgs   = `{"path":"unsafe"}`
+		rewrittenArgs  = `{"path":"safe"}`
 		permissionJSON = `{"status":"denied","tool":"delete_file","reason":"write access is disabled"}`
 	)
 
@@ -7759,7 +7761,9 @@ func TestExecuteToolWithCallbacks_ToolPermissionPolicyDenySkipsExecution(
 		_ *tool.BeforeToolArgs,
 	) (*tool.BeforeToolResult, error) {
 		calledCallback = true
-		return nil, nil
+		return &tool.BeforeToolResult{
+			ModifiedArguments: []byte(rewrittenArgs),
+		}, nil
 	})
 	p := NewFunctionCallResponseProcessor(false, callbacks)
 	tl := &mockCallableTool{
@@ -7774,12 +7778,75 @@ func TestExecuteToolWithCallbacks_ToolPermissionPolicyDenySkipsExecution(
 			func(_ context.Context, req *tool.PermissionRequest) (tool.PermissionDecision, error) {
 				require.Equal(t, toolName, req.ToolName)
 				require.Equal(t, toolCallID, req.ToolCallID)
+				require.JSONEq(t, rewrittenArgs, string(req.Arguments))
 				return tool.DenyPermission(denyReason), nil
 			},
 		)),
 	}
 
-	_, res, _, suppressDefault, _, err := p.executeToolWithCallbacks(
+	_, res, modifiedArgs, suppressDefault, _, err := p.executeToolWithCallbacks(
+		context.Background(),
+		inv,
+		model.ToolCall{
+			ID: toolCallID,
+			Function: model.FunctionDefinitionParam{
+				Name:      toolName,
+				Arguments: []byte(originalArgs),
+			},
+		},
+		tl,
+		nil,
+	)
+	require.NoError(t, err)
+	require.False(t, suppressDefault)
+	require.False(t, calledTool)
+	require.True(t, calledCallback)
+	require.JSONEq(t, rewrittenArgs, string(modifiedArgs))
+	require.JSONEq(t, permissionJSON, string(mustJSON(res)))
+}
+
+func TestExecuteToolCall_ToolPermissionResultSkipsToolResultMessagesCallback(
+	t *testing.T,
+) {
+	const (
+		toolName       = "delete_file"
+		toolCallID     = "call-deny-message"
+		denyReason     = "write access is disabled"
+		permissionJSON = `{"status":"denied","tool":"delete_file","reason":"write access is disabled"}`
+	)
+
+	var (
+		calledTool           bool
+		calledResultMessages bool
+	)
+	callbacks := tool.NewCallbacks()
+	callbacks.RegisterToolResultMessages(func(
+		_ context.Context,
+		_ *tool.ToolResultMessagesInput,
+	) (any, error) {
+		calledResultMessages = true
+		return model.Message{
+			Role:    model.RoleUser,
+			Content: "overridden",
+		}, nil
+	})
+	p := NewFunctionCallResponseProcessor(false, callbacks)
+	tl := &mockCallableTool{
+		declaration: &tool.Declaration{Name: toolName},
+		callFn: func(_ context.Context, _ []byte) (any, error) {
+			calledTool = true
+			return map[string]any{"ok": true}, nil
+		},
+	}
+	inv := &agent.Invocation{
+		RunOptions: agent.NewRunOptions(agent.WithToolPermissionPolicyFunc(
+			func(_ context.Context, _ *tool.PermissionRequest) (tool.PermissionDecision, error) {
+				return tool.DenyPermission(denyReason), nil
+			},
+		)),
+	}
+
+	_, choices, _, _, _, err := p.executeToolCall(
 		context.Background(),
 		inv,
 		model.ToolCall{
@@ -7789,14 +7856,18 @@ func TestExecuteToolWithCallbacks_ToolPermissionPolicyDenySkipsExecution(
 				Arguments: []byte(`{}`),
 			},
 		},
-		tl,
+		map[string]tool.Tool{toolName: tl},
+		0,
 		nil,
 	)
 	require.NoError(t, err)
-	require.False(t, suppressDefault)
 	require.False(t, calledTool)
-	require.False(t, calledCallback)
-	require.JSONEq(t, permissionJSON, string(mustJSON(res)))
+	require.False(t, calledResultMessages)
+	require.Len(t, choices, 1)
+	require.Equal(t, model.RoleTool, choices[0].Message.Role)
+	require.Equal(t, toolCallID, choices[0].Message.ToolID)
+	require.Equal(t, toolName, choices[0].Message.ToolName)
+	require.JSONEq(t, permissionJSON, choices[0].Message.Content)
 }
 
 func TestExecuteToolWithCallbacks_ToolPermissionCheckerAskSkipsRunPolicy(
@@ -7855,6 +7926,7 @@ func TestExecuteToolWithCallbacks_ToolPermissionReceivesMetadata(
 	t *testing.T,
 ) {
 	const toolName = "web_search"
+	var calledRunPolicy bool
 	tl := &permissionMockTool{
 		mockCallableTool: &mockCallableTool{
 			declaration: &tool.Declaration{Name: toolName},
@@ -7872,6 +7944,7 @@ func TestExecuteToolWithCallbacks_ToolPermissionReceivesMetadata(
 	inv := &agent.Invocation{
 		RunOptions: agent.NewRunOptions(agent.WithToolPermissionPolicyFunc(
 			func(_ context.Context, req *tool.PermissionRequest) (tool.PermissionDecision, error) {
+				calledRunPolicy = true
 				require.True(t, req.Metadata.ReadOnly)
 				require.True(t, req.Metadata.SearchOrRead)
 				require.True(t, req.Metadata.OpenWorld)
@@ -7895,6 +7968,7 @@ func TestExecuteToolWithCallbacks_ToolPermissionReceivesMetadata(
 			nil,
 		)
 	require.NoError(t, err)
+	require.True(t, calledRunPolicy)
 	require.JSONEq(t, `{"ok":true}`, string(mustJSON(res)))
 }
 

--- a/internal/flow/processor/functioncall_test.go
+++ b/internal/flow/processor/functioncall_test.go
@@ -104,6 +104,23 @@ func (m *mockCallableTool) Call(ctx context.Context, args []byte) (any, error) {
 	return m.callFn(ctx, args)
 }
 
+type permissionMockTool struct {
+	*mockCallableTool
+	metadata tool.ToolMetadata
+	decision tool.PermissionDecision
+}
+
+func (m *permissionMockTool) ToolMetadata() tool.ToolMetadata {
+	return m.metadata
+}
+
+func (m *permissionMockTool) CheckPermission(
+	_ context.Context,
+	_ *tool.PermissionRequest,
+) (tool.PermissionDecision, error) {
+	return m.decision, nil
+}
+
 type delayedLoadTool struct {
 	*skilltool.LoadTool
 	delays map[string]time.Duration
@@ -7720,6 +7737,165 @@ func TestExecuteTool_NamedTool(t *testing.T) {
 	require.NoError(t, err)
 	b, _ := json.Marshal(map[string]any{"k": "v"})
 	require.JSONEq(t, string(b), string(mustJSON(res)))
+}
+
+func TestExecuteToolWithCallbacks_ToolPermissionPolicyDenySkipsExecution(
+	t *testing.T,
+) {
+	const (
+		toolName       = "delete_file"
+		toolCallID     = "call-deny"
+		denyReason     = "write access is disabled"
+		permissionJSON = `{"status":"denied","tool":"delete_file","reason":"write access is disabled"}`
+	)
+
+	var (
+		calledTool     bool
+		calledCallback bool
+	)
+	callbacks := tool.NewCallbacks()
+	callbacks.RegisterBeforeTool(func(
+		_ context.Context,
+		_ *tool.BeforeToolArgs,
+	) (*tool.BeforeToolResult, error) {
+		calledCallback = true
+		return nil, nil
+	})
+	p := NewFunctionCallResponseProcessor(false, callbacks)
+	tl := &mockCallableTool{
+		declaration: &tool.Declaration{Name: toolName},
+		callFn: func(_ context.Context, _ []byte) (any, error) {
+			calledTool = true
+			return map[string]any{"ok": true}, nil
+		},
+	}
+	inv := &agent.Invocation{
+		RunOptions: agent.NewRunOptions(agent.WithToolPermissionPolicyFunc(
+			func(_ context.Context, req *tool.PermissionRequest) (tool.PermissionDecision, error) {
+				require.Equal(t, toolName, req.ToolName)
+				require.Equal(t, toolCallID, req.ToolCallID)
+				return tool.DenyPermission(denyReason), nil
+			},
+		)),
+	}
+
+	_, res, _, suppressDefault, _, err := p.executeToolWithCallbacks(
+		context.Background(),
+		inv,
+		model.ToolCall{
+			ID: toolCallID,
+			Function: model.FunctionDefinitionParam{
+				Name:      toolName,
+				Arguments: []byte(`{}`),
+			},
+		},
+		tl,
+		nil,
+	)
+	require.NoError(t, err)
+	require.False(t, suppressDefault)
+	require.False(t, calledTool)
+	require.False(t, calledCallback)
+	require.JSONEq(t, permissionJSON, string(mustJSON(res)))
+}
+
+func TestExecuteToolWithCallbacks_ToolPermissionCheckerAskSkipsRunPolicy(
+	t *testing.T,
+) {
+	const (
+		toolName       = "shell"
+		askReason      = "shell commands require review"
+		permissionJSON = `{"status":"approval_required","tool":"shell","reason":"shell commands require review"}`
+	)
+
+	var (
+		calledTool      bool
+		calledRunPolicy bool
+	)
+	tl := &permissionMockTool{
+		mockCallableTool: &mockCallableTool{
+			declaration: &tool.Declaration{Name: toolName},
+			callFn: func(_ context.Context, _ []byte) (any, error) {
+				calledTool = true
+				return map[string]any{"ok": true}, nil
+			},
+		},
+		decision: tool.AskPermission(askReason),
+	}
+	inv := &agent.Invocation{
+		RunOptions: agent.NewRunOptions(agent.WithToolPermissionPolicyFunc(
+			func(_ context.Context, _ *tool.PermissionRequest) (tool.PermissionDecision, error) {
+				calledRunPolicy = true
+				return tool.AllowPermission(), nil
+			},
+		)),
+	}
+
+	_, res, _, _, _, err := NewFunctionCallResponseProcessor(false, nil).
+		executeToolWithCallbacks(
+			context.Background(),
+			inv,
+			model.ToolCall{
+				ID: "call-ask",
+				Function: model.FunctionDefinitionParam{
+					Name:      toolName,
+					Arguments: []byte(`{}`),
+				},
+			},
+			tl,
+			nil,
+		)
+	require.NoError(t, err)
+	require.False(t, calledTool)
+	require.False(t, calledRunPolicy)
+	require.JSONEq(t, permissionJSON, string(mustJSON(res)))
+}
+
+func TestExecuteToolWithCallbacks_ToolPermissionReceivesMetadata(
+	t *testing.T,
+) {
+	const toolName = "web_search"
+	tl := &permissionMockTool{
+		mockCallableTool: &mockCallableTool{
+			declaration: &tool.Declaration{Name: toolName},
+			callFn: func(_ context.Context, _ []byte) (any, error) {
+				return map[string]any{"ok": true}, nil
+			},
+		},
+		metadata: tool.ToolMetadata{
+			ReadOnly:     true,
+			SearchOrRead: true,
+			OpenWorld:    true,
+		},
+		decision: tool.AllowPermission(),
+	}
+	inv := &agent.Invocation{
+		RunOptions: agent.NewRunOptions(agent.WithToolPermissionPolicyFunc(
+			func(_ context.Context, req *tool.PermissionRequest) (tool.PermissionDecision, error) {
+				require.True(t, req.Metadata.ReadOnly)
+				require.True(t, req.Metadata.SearchOrRead)
+				require.True(t, req.Metadata.OpenWorld)
+				return tool.AllowPermission(), nil
+			},
+		)),
+	}
+
+	_, res, _, _, _, err := NewFunctionCallResponseProcessor(false, nil).
+		executeToolWithCallbacks(
+			context.Background(),
+			inv,
+			model.ToolCall{
+				ID: "call-allow",
+				Function: model.FunctionDefinitionParam{
+					Name:      toolName,
+					Arguments: []byte(`{}`),
+				},
+			},
+			tl,
+			nil,
+		)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"ok":true}`, string(mustJSON(res)))
 }
 
 func TestExecuteToolCall_StreamableFinalStateOnlyResultAfterToolContextReplacementStillSkipsDefaultMessage(t *testing.T) {

--- a/internal/tool/tool_test.go
+++ b/internal/tool/tool_test.go
@@ -58,6 +58,34 @@ func (s *skipperTool) Declaration() *tool.Declaration {
 
 func (s *skipperTool) SkipSummarization() bool { return s.skip }
 
+type metadataPolicyTool struct {
+	name             string
+	metadata         tool.ToolMetadata
+	deferTool        bool
+	decision         tool.PermissionDecision
+	permissionCalled bool
+}
+
+func (m *metadataPolicyTool) Declaration() *tool.Declaration {
+	return &tool.Declaration{Name: m.name}
+}
+
+func (m *metadataPolicyTool) ToolMetadata() tool.ToolMetadata {
+	return m.metadata
+}
+
+func (m *metadataPolicyTool) ShouldDefer(context.Context) bool {
+	return m.deferTool
+}
+
+func (m *metadataPolicyTool) CheckPermission(
+	_ context.Context,
+	_ *tool.PermissionRequest,
+) (tool.PermissionDecision, error) {
+	m.permissionCalled = true
+	return m.decision, nil
+}
+
 // fakeToolSet implements tool.ToolSet.
 type fakeToolSet struct {
 	name   string
@@ -158,6 +186,47 @@ func TestNamedTool_SkipSummarizationDelegation(t *testing.T) {
 	})
 	t2 := nts2.Tools(context.Background())[0].(*NamedTool)
 	require.False(t, t2.SkipSummarization())
+}
+
+func TestNamedTool_MetadataAndPermissionDelegation(t *testing.T) {
+	const denyReason = "blocked"
+	ctx := context.Background()
+	original := &metadataPolicyTool{
+		name: "raw",
+		metadata: tool.ToolMetadata{
+			ReadOnly:        true,
+			ConcurrencySafe: true,
+			SearchOrRead:    true,
+			MaxResultSize:   128,
+		},
+		deferTool: true,
+		decision:  tool.DenyPermission(denyReason),
+	}
+	nts := NewNamedToolSet(&fakeToolSet{
+		name:  "fs",
+		tools: []tool.Tool{original},
+	})
+	nt := nts.Tools(ctx)[0].(*NamedTool)
+
+	require.Equal(t, original.metadata, nt.ToolMetadata())
+	require.True(t, nt.IsConcurrencySafe())
+	require.True(t, nt.ShouldDefer(ctx))
+	decision, err := nt.CheckPermission(ctx, &tool.PermissionRequest{})
+	require.NoError(t, err)
+	require.Equal(t, tool.PermissionActionDeny, decision.Action)
+	require.Equal(t, denyReason, decision.Reason)
+	require.True(t, original.permissionCalled)
+
+	plain := NewNamedToolSet(&fakeToolSet{
+		name:  "fs",
+		tools: []tool.Tool{&simpleTool{name: "plain"}},
+	}).Tools(ctx)[0].(*NamedTool)
+	require.Equal(t, tool.ToolMetadata{}, plain.ToolMetadata())
+	require.False(t, plain.IsConcurrencySafe())
+	require.False(t, plain.ShouldDefer(ctx))
+	decision, err = plain.CheckPermission(ctx, &tool.PermissionRequest{})
+	require.NoError(t, err)
+	require.Equal(t, tool.PermissionActionAllow, decision.Action)
 }
 
 func TestGenerateJSONSchema_Primitives(t *testing.T) {

--- a/internal/tool/toolset.go
+++ b/internal/tool/toolset.go
@@ -92,6 +92,35 @@ func (t *NamedTool) Original() tool.Tool {
 	return t.original
 }
 
+// ToolMetadata delegates to the original tool.
+func (t *NamedTool) ToolMetadata() tool.ToolMetadata {
+	return tool.MetadataOf(t.original)
+}
+
+// IsConcurrencySafe delegates to the original tool.
+func (t *NamedTool) IsConcurrencySafe() bool {
+	return tool.MetadataOf(t.original).ConcurrencySafe
+}
+
+// ShouldDefer delegates to the original tool.
+func (t *NamedTool) ShouldDefer(ctx context.Context) bool {
+	return tool.ShouldDefer(ctx, t.original)
+}
+
+// CheckPermission delegates to the original tool when it implements
+// tool.PermissionChecker. Wrappers keep the model-visible declaration and name
+// in the request.
+func (t *NamedTool) CheckPermission(
+	ctx context.Context,
+	req *tool.PermissionRequest,
+) (tool.PermissionDecision, error) {
+	checker, ok := t.original.(tool.PermissionChecker)
+	if !ok {
+		return tool.AllowPermission(), nil
+	}
+	return checker.CheckPermission(ctx, req)
+}
+
 // ToolSetName returns the source ToolSet name for runtime policy checks.
 func (t *NamedTool) ToolSetName() string {
 	return t.name

--- a/tool/claudecode/claudecode_test.go
+++ b/tool/claudecode/claudecode_test.go
@@ -2423,7 +2423,12 @@ func newTestPDF(t *testing.T, pages []string) []byte {
 func writeExecutableFile(t *testing.T, dir string, name string, content string) string {
 	t.Helper()
 	path := filepath.Join(dir, name)
-	require.NoError(t, os.WriteFile(path, []byte(content), 0o755))
+	file, err := os.Create(path)
+	require.NoError(t, err)
+	_, err = file.WriteString(content)
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+	require.NoError(t, os.Chmod(path, 0o555))
 	return path
 }
 

--- a/tool/metadata.go
+++ b/tool/metadata.go
@@ -1,0 +1,83 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package tool
+
+import "context"
+
+// ToolMetadata describes execution properties that hosts and policies can use
+// before deciding whether a tool is safe to expose or execute.
+//
+// Metadata is descriptive. The framework does not change scheduling or loading
+// behavior from these fields alone; callers can opt in by using filters,
+// permission policies, or custom runners.
+type ToolMetadata struct {
+	// ReadOnly reports that the tool does not intentionally mutate external
+	// state. Read-only tools can still be expensive or read sensitive data.
+	ReadOnly bool
+	// Destructive reports that the tool may delete, overwrite, or otherwise
+	// irreversibly change external state.
+	Destructive bool
+	// ConcurrencySafe reports that independent calls to the same tool can run at
+	// the same time without corrupting shared state.
+	ConcurrencySafe bool
+	// SearchOrRead reports that the tool primarily searches or reads data.
+	SearchOrRead bool
+	// OpenWorld reports that the tool can reach outside the current process or
+	// workspace, for example through network, shell, or remote service calls.
+	OpenWorld bool
+	// MaxResultSize is an optional advisory result-size limit in bytes. Zero
+	// means the tool does not publish a limit.
+	MaxResultSize int
+}
+
+// MetadataProvider is implemented by tools that publish ToolMetadata.
+type MetadataProvider interface {
+	ToolMetadata() ToolMetadata
+}
+
+// ConcurrencyAware is a small opt-in interface for tools that only need to
+// publish their concurrency property.
+type ConcurrencyAware interface {
+	IsConcurrencySafe() bool
+}
+
+// DeferredTool is implemented by tools that want hosts to hide the full tool
+// declaration until it is explicitly needed. The core runner does not defer
+// tools by itself; this is intended for tool-search or host-side loading logic.
+type DeferredTool interface {
+	ShouldDefer(ctx context.Context) bool
+}
+
+// MetadataOf returns the metadata published by a tool. Tools that do not
+// implement MetadataProvider get the zero value, preserving existing behavior.
+//
+// If a tool implements ConcurrencyAware but not MetadataProvider, that value
+// fills ConcurrencySafe.
+func MetadataOf(t Tool) ToolMetadata {
+	if t == nil {
+		return ToolMetadata{}
+	}
+	if provider, ok := t.(MetadataProvider); ok {
+		return provider.ToolMetadata()
+	}
+	if aware, ok := t.(ConcurrencyAware); ok {
+		return ToolMetadata{ConcurrencySafe: aware.IsConcurrencySafe()}
+	}
+	return ToolMetadata{}
+}
+
+// ShouldDefer reports whether a tool asks host-side loading logic to defer
+// loading its full declaration.
+func ShouldDefer(ctx context.Context, t Tool) bool {
+	if t == nil {
+		return false
+	}
+	deferred, ok := t.(DeferredTool)
+	return ok && deferred.ShouldDefer(ctx)
+}

--- a/tool/permission.go
+++ b/tool/permission.go
@@ -88,7 +88,8 @@ type PermissionRequest struct {
 	ToolCallID string
 	// Declaration is the tool declaration.
 	Declaration *Declaration
-	// Arguments is the JSON-encoded argument payload after framework repairs.
+	// Arguments is the JSON-encoded argument payload after framework repairs and
+	// before-tool callbacks have finalized it.
 	Arguments []byte
 	// Metadata is the metadata published by the tool.
 	Metadata ToolMetadata

--- a/tool/permission.go
+++ b/tool/permission.go
@@ -1,0 +1,140 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package tool
+
+import (
+	"context"
+	"fmt"
+)
+
+const (
+	// PermissionActionAllow allows the tool call to execute.
+	PermissionActionAllow PermissionAction = "allow"
+	// PermissionActionDeny skips execution and returns a denial result to the model.
+	PermissionActionDeny PermissionAction = "deny"
+	// PermissionActionAsk skips execution and returns an approval-required
+	// result to the model. Hosts that can ask a user should do that inside
+	// their PermissionPolicy and return allow when approved.
+	PermissionActionAsk PermissionAction = "ask"
+
+	// PermissionResultStatusDenied is returned when a tool call is denied.
+	PermissionResultStatusDenied = "denied"
+	// PermissionResultStatusApprovalRequired is returned when a tool call needs approval.
+	PermissionResultStatusApprovalRequired = "approval_required"
+)
+
+// PermissionAction is the normalized action returned by permission checks.
+type PermissionAction string
+
+// PermissionDecision is the result of a permission check.
+//
+// The zero value is allow. That keeps tools without permission checks fully
+// backward compatible.
+type PermissionDecision struct {
+	// Action decides whether the framework should execute the tool call.
+	Action PermissionAction
+	// Reason is an optional human-readable reason returned to the model when
+	// Action is deny or ask.
+	Reason string
+}
+
+// AllowPermission returns an allow decision.
+func AllowPermission() PermissionDecision {
+	return PermissionDecision{Action: PermissionActionAllow}
+}
+
+// DenyPermission returns a deny decision with a reason.
+func DenyPermission(reason string) PermissionDecision {
+	return PermissionDecision{
+		Action: PermissionActionDeny,
+		Reason: reason,
+	}
+}
+
+// AskPermission returns an approval-required decision with a reason.
+func AskPermission(reason string) PermissionDecision {
+	return PermissionDecision{
+		Action: PermissionActionAsk,
+		Reason: reason,
+	}
+}
+
+// NormalizePermissionDecision fills the default allow action and validates the action.
+func NormalizePermissionDecision(decision PermissionDecision) (PermissionDecision, error) {
+	if decision.Action == "" {
+		decision.Action = PermissionActionAllow
+	}
+	switch decision.Action {
+	case PermissionActionAllow, PermissionActionDeny, PermissionActionAsk:
+		return decision, nil
+	default:
+		return PermissionDecision{}, fmt.Errorf("unknown permission action %q", decision.Action)
+	}
+}
+
+// PermissionRequest describes one pending tool call for permission checks.
+type PermissionRequest struct {
+	// Tool is the tool about to be executed.
+	Tool Tool
+	// ToolName is the model-visible tool name.
+	ToolName string
+	// ToolCallID is the ID emitted by the model for this tool call.
+	ToolCallID string
+	// Declaration is the tool declaration.
+	Declaration *Declaration
+	// Arguments is the JSON-encoded argument payload after framework repairs.
+	Arguments []byte
+	// Metadata is the metadata published by the tool.
+	Metadata ToolMetadata
+}
+
+// PermissionChecker is implemented by tools that need to enforce their own
+// non-negotiable permission rule before execution.
+type PermissionChecker interface {
+	CheckPermission(ctx context.Context, req *PermissionRequest) (PermissionDecision, error)
+}
+
+// PermissionPolicy checks tool permissions for a run.
+type PermissionPolicy interface {
+	CheckToolPermission(ctx context.Context, req *PermissionRequest) (PermissionDecision, error)
+}
+
+// PermissionPolicyFunc adapts a function into PermissionPolicy.
+type PermissionPolicyFunc func(ctx context.Context, req *PermissionRequest) (PermissionDecision, error)
+
+// CheckToolPermission implements PermissionPolicy.
+func (f PermissionPolicyFunc) CheckToolPermission(
+	ctx context.Context,
+	req *PermissionRequest,
+) (PermissionDecision, error) {
+	if f == nil {
+		return AllowPermission(), nil
+	}
+	return f(ctx, req)
+}
+
+// PermissionResult is returned to the model when a permission check skips tool execution.
+type PermissionResult struct {
+	Status string `json:"status"`
+	Tool   string `json:"tool"`
+	Reason string `json:"reason,omitempty"`
+}
+
+// PermissionResultFor builds the structured tool result for a non-allow decision.
+func PermissionResultFor(toolName string, decision PermissionDecision) PermissionResult {
+	status := PermissionResultStatusDenied
+	if decision.Action == PermissionActionAsk {
+		status = PermissionResultStatusApprovalRequired
+	}
+	return PermissionResult{
+		Status: status,
+		Tool:   toolName,
+		Reason: decision.Reason,
+	}
+}

--- a/tool/permission.go
+++ b/tool/permission.go
@@ -34,8 +34,8 @@ type PermissionAction string
 
 // PermissionDecision is the result of a permission check.
 //
-// The zero value is allow. That keeps tools without permission checks fully
-// backward compatible.
+// The zero value is allow. That keeps calls without a tool checker or per-run
+// policy fully backward compatible.
 type PermissionDecision struct {
 	// Action decides whether the framework should execute the tool call.
 	Action PermissionAction

--- a/tool/permission_test.go
+++ b/tool/permission_test.go
@@ -1,0 +1,137 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package tool
+
+import (
+	"context"
+	"testing"
+)
+
+const (
+	testToolName      = "test_tool"
+	testReason        = "requires approval"
+	testMaxResultSize = 1024
+	testInvalidAction = "bad"
+)
+
+type metadataTool struct {
+	metadata ToolMetadata
+}
+
+func (m *metadataTool) Declaration() *Declaration {
+	return &Declaration{Name: testToolName}
+}
+
+func (m *metadataTool) ToolMetadata() ToolMetadata {
+	return m.metadata
+}
+
+type concurrencyTool struct {
+	safe bool
+}
+
+func (c *concurrencyTool) Declaration() *Declaration {
+	return &Declaration{Name: testToolName}
+}
+
+func (c *concurrencyTool) IsConcurrencySafe() bool {
+	return c.safe
+}
+
+type deferredTool struct {
+	deferTool bool
+}
+
+func (d *deferredTool) Declaration() *Declaration {
+	return &Declaration{Name: testToolName}
+}
+
+func (d *deferredTool) ShouldDefer(context.Context) bool {
+	return d.deferTool
+}
+
+func TestMetadataOf_DefaultsToZeroValue(t *testing.T) {
+	meta := MetadataOf(newMockTool(testToolName))
+	if meta != (ToolMetadata{}) {
+		t.Fatalf("expected zero metadata, got %+v", meta)
+	}
+}
+
+func TestMetadataOf_UsesProvider(t *testing.T) {
+	want := ToolMetadata{
+		ReadOnly:        true,
+		Destructive:     false,
+		ConcurrencySafe: true,
+		SearchOrRead:    true,
+		OpenWorld:       true,
+		MaxResultSize:   testMaxResultSize,
+	}
+	got := MetadataOf(&metadataTool{metadata: want})
+	if got != want {
+		t.Fatalf("expected metadata %+v, got %+v", want, got)
+	}
+}
+
+func TestMetadataOf_UsesConcurrencyAwareFallback(t *testing.T) {
+	got := MetadataOf(&concurrencyTool{safe: true})
+	if !got.ConcurrencySafe {
+		t.Fatalf("expected concurrency-aware tool to be marked safe")
+	}
+}
+
+func TestShouldDefer(t *testing.T) {
+	if !ShouldDefer(context.Background(), &deferredTool{deferTool: true}) {
+		t.Fatalf("expected deferred tool to ask for deferral")
+	}
+	if ShouldDefer(context.Background(), newMockTool(testToolName)) {
+		t.Fatalf("expected plain tool not to ask for deferral")
+	}
+}
+
+func TestNormalizePermissionDecision(t *testing.T) {
+	decision, err := NormalizePermissionDecision(PermissionDecision{})
+	if err != nil {
+		t.Fatalf("zero decision should be valid: %v", err)
+	}
+	if decision.Action != PermissionActionAllow {
+		t.Fatalf("expected zero decision to normalize to allow, got %q", decision.Action)
+	}
+
+	_, err = NormalizePermissionDecision(PermissionDecision{Action: PermissionAction(testInvalidAction)})
+	if err == nil {
+		t.Fatalf("expected invalid permission action to fail")
+	}
+}
+
+func TestPermissionPolicyFunc_NilAllows(t *testing.T) {
+	var fn PermissionPolicyFunc
+	decision, err := fn.CheckToolPermission(context.Background(), &PermissionRequest{})
+	if err != nil {
+		t.Fatalf("nil policy func returned error: %v", err)
+	}
+	if decision.Action != PermissionActionAllow {
+		t.Fatalf("expected nil policy func to allow, got %q", decision.Action)
+	}
+}
+
+func TestPermissionResultFor(t *testing.T) {
+	denied := PermissionResultFor(testToolName, DenyPermission(testReason))
+	if denied.Status != PermissionResultStatusDenied ||
+		denied.Tool != testToolName ||
+		denied.Reason != testReason {
+		t.Fatalf("unexpected deny result: %+v", denied)
+	}
+
+	ask := PermissionResultFor(testToolName, AskPermission(testReason))
+	if ask.Status != PermissionResultStatusApprovalRequired ||
+		ask.Tool != testToolName ||
+		ask.Reason != testReason {
+		t.Fatalf("unexpected ask result: %+v", ask)
+	}
+}

--- a/tool/permission_test.go
+++ b/tool/permission_test.go
@@ -63,6 +63,15 @@ func TestMetadataOf_DefaultsToZeroValue(t *testing.T) {
 	}
 }
 
+func TestMetadataHelpers_NilTool(t *testing.T) {
+	if got := MetadataOf(nil); got != (ToolMetadata{}) {
+		t.Fatalf("expected nil tool metadata to be zero, got %+v", got)
+	}
+	if ShouldDefer(context.Background(), nil) {
+		t.Fatalf("expected nil tool not to ask for deferral")
+	}
+}
+
 func TestMetadataOf_UsesProvider(t *testing.T) {
 	want := ToolMetadata{
 		ReadOnly:        true,


### PR DESCRIPTION
## Summary
- add optional tool metadata and permission policy interfaces without changing the base tool.Tool contract
- wire per-run agent.WithToolPermissionPolicy into framework-managed tool execution
- add docs and a runnable toolpolicy example that separates filters, execution filters, callbacks, and permission policy

## Testing
- go test ./tool ./agent ./internal/tool ./internal/flow/processor
- (cd examples && go test ./toolpolicy)
