### PR TITLE
evaluation/workflow/promptiter: preserve empty allowed gradients

### DIFF
--- a/evaluation/workflow/promptiter/backwarder/backwarder.go
+++ b/evaluation/workflow/promptiter/backwarder/backwarder.go
@@ -218,11 +218,16 @@ func backwardStructuredOutput(request *Request) agent.RunOption {
 func backwardResultSchema(request *Request) map[string]any {
 	surfaceIDs := requestAllowedGradientSurfaceIDs(request)
 	predecessorStepIDs := requestPredecessorStepIDs(request)
+	gradientsSchema := backwardGradientArraySchema(surfaceIDs)
+	upstreamSchema := backwardPropagationArraySchema(predecessorStepIDs)
+	if len(surfaceIDs) == 0 && len(predecessorStepIDs) > 0 {
+		upstreamSchema["minItems"] = 1
+	}
 	return map[string]any{
 		"type": "object",
 		"properties": map[string]any{
-			"Gradients": backwardGradientArraySchema(surfaceIDs),
-			"Upstream":  backwardPropagationArraySchema(predecessorStepIDs),
+			"Gradients": gradientsSchema,
+			"Upstream":  upstreamSchema,
 		},
 		"required":             []string{"Gradients", "Upstream"},
 		"additionalProperties": false,
@@ -255,7 +260,9 @@ func requestAllowedGradientSurfaceIDs(request *Request) []string {
 	if request.AllowedGradientSurfaceIDs == nil {
 		return requestSurfaceIDs(request)
 	}
-	return append([]string(nil), request.AllowedGradientSurfaceIDs...)
+	cloned := make([]string, len(request.AllowedGradientSurfaceIDs))
+	copy(cloned, request.AllowedGradientSurfaceIDs)
+	return cloned
 }
 
 func requestPredecessorStepIDs(request *Request) []string {
@@ -323,7 +330,8 @@ func backwardPropagationArraySchema(predecessorStepIDs []string) map[string]any 
 				"enum": predecessorStepIDs,
 			},
 			"Gradients": map[string]any{
-				"type": "array",
+				"type":     "array",
+				"minItems": 1,
 				"items": map[string]any{
 					"type": "object",
 					"properties": map[string]any{

--- a/evaluation/workflow/promptiter/backwarder/backwarder_test.go
+++ b/evaluation/workflow/promptiter/backwarder/backwarder_test.go
@@ -380,6 +380,62 @@ func TestBackwardStructuredOutputSchema_EmptyCollectionsStillDeclareItems(t *tes
 	assert.Contains(t, upstreamSchema, "items")
 }
 
+func TestBackwardStructuredOutputSchema_EmptyAllowedGradientSurfaceIDsStayEmpty(t *testing.T) {
+	request := newInstructionRequest()
+	request.AllowedGradientSurfaceIDs = []string{}
+
+	schema := backwardResultSchema(request)
+	schemaProps, ok := schema["properties"].(map[string]any)
+	assert.True(t, ok)
+	if !ok {
+		return
+	}
+	gradientsSchema, ok := schemaProps["Gradients"].(map[string]any)
+	assert.True(t, ok)
+	if !ok {
+		return
+	}
+	assert.Equal(t, 0, gradientsSchema["maxItems"])
+	gradientItem, ok := gradientsSchema["items"].(map[string]any)
+	assert.True(t, ok)
+	if !ok {
+		return
+	}
+	gradientProps, ok := gradientItem["properties"].(map[string]any)
+	assert.True(t, ok)
+	if !ok {
+		return
+	}
+	gradientSurfaceIDSchema, ok := gradientProps["SurfaceID"].(map[string]any)
+	assert.True(t, ok)
+	if !ok {
+		return
+	}
+	assert.Equal(t, []string{}, gradientSurfaceIDSchema["enum"])
+	upstreamSchema, ok := schemaProps["Upstream"].(map[string]any)
+	assert.True(t, ok)
+	if !ok {
+		return
+	}
+	assert.Equal(t, 1, upstreamSchema["minItems"])
+	upstreamItem, ok := upstreamSchema["items"].(map[string]any)
+	assert.True(t, ok)
+	if !ok {
+		return
+	}
+	upstreamProps, ok := upstreamItem["properties"].(map[string]any)
+	assert.True(t, ok)
+	if !ok {
+		return
+	}
+	upstreamGradientsSchema, ok := upstreamProps["Gradients"].(map[string]any)
+	assert.True(t, ok)
+	if !ok {
+		return
+	}
+	assert.Equal(t, 1, upstreamGradientsSchema["minItems"])
+}
+
 func TestBackwardAllowsEmptyResultForRootControlStep(t *testing.T) {
 	r := &fakeRunner{
 		events: []*event.Event{
@@ -1167,6 +1223,10 @@ func TestRequestHelpersHandleNilAndDeduplicate(t *testing.T) {
 	assert.Equal(t, []string{"surf_1", "surf_2"}, requestSurfaceIDs(request))
 	assert.Equal(t, []string{"surf_1", "surf_2"}, requestAllowedGradientSurfaceIDs(request))
 	assert.Equal(t, []string{"pred_1", "pred_2"}, requestPredecessorStepIDs(request))
+	request.AllowedGradientSurfaceIDs = []string{}
+	restrictedSurfaceIDs := requestAllowedGradientSurfaceIDs(request)
+	assert.NotNil(t, restrictedSurfaceIDs)
+	assert.Empty(t, restrictedSurfaceIDs)
 }
 
 func newInstructionRequest() *Request {

--- a/evaluation/workflow/promptiter/backwarder/message.go
+++ b/evaluation/workflow/promptiter/backwarder/message.go
@@ -35,6 +35,7 @@ Requirements:
 - Do not wrap the response in markdown code fences.
 - Attribute gradients only to listed gradient surfaces.
 - Route upstream gradients only to listed predecessor steps.
+- If no gradient surfaces are listed and predecessor steps are listed, route non-empty upstream gradients to the relevant predecessor steps.
 - Do not broadcast the same gradient packet to every predecessor.
 
 Request JSON:

--- a/evaluation/workflow/promptiter/engine/backward.go
+++ b/evaluation/workflow/promptiter/engine/backward.go
@@ -368,7 +368,9 @@ func allowedGradientSurfaceIDsOrNil(
 	if targetSurfaceSet == nil {
 		return nil
 	}
-	return append([]string(nil), allowedGradientSurfaceIDs...)
+	cloned := make([]string, len(allowedGradientSurfaceIDs))
+	copy(cloned, allowedGradientSurfaceIDs)
+	return cloned
 }
 
 func cloneTraceSnapshot(snapshot *atrace.Snapshot) *atrace.Snapshot {

--- a/evaluation/workflow/promptiter/engine/engine_test.go
+++ b/evaluation/workflow/promptiter/engine/engine_test.go
@@ -1264,6 +1264,61 @@ func TestBuildBackwardRequestKeepsContextSurfacesButRestrictsAllowedGradientSurf
 	}
 }
 
+func TestBuildBackwardRequestPreservesEmptyAllowedGradientSurfaceIDs(t *testing.T) {
+	instructionText := "base prompt"
+	instructionSurfaceID := astructure.SurfaceID("node_1", astructure.SurfaceTypeInstruction)
+	modelSurfaceID := astructure.SurfaceID("node_1", astructure.SurfaceTypeModel)
+	structure, err := newStructureState(&astructure.Snapshot{
+		StructureID: "structure_1",
+		EntryNodeID: "node_1",
+		Nodes: []astructure.Node{
+			{NodeID: "node_1", Kind: astructure.NodeKindLLM, Name: "writer"},
+		},
+		Surfaces: []astructure.Surface{
+			{
+				SurfaceID: instructionSurfaceID,
+				NodeID:    "node_1",
+				Type:      astructure.SurfaceTypeInstruction,
+				Value: astructure.SurfaceValue{
+					Text: &instructionText,
+				},
+			},
+			{
+				SurfaceID: modelSurfaceID,
+				NodeID:    "node_1",
+				Type:      astructure.SurfaceTypeModel,
+				Value: astructure.SurfaceValue{
+					Model: &astructure.ModelRef{Name: "gpt-test"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	request, err := buildBackwardRequest(
+		structure,
+		nil,
+		map[string]indexedTraceStep{},
+		CaseResult{EvalSetID: "train", EvalCaseID: "case_1"},
+		atrace.Step{
+			StepID:            "step_1",
+			NodeID:            "node_1",
+			AppliedSurfaceIDs: []string{instructionSurfaceID},
+		},
+		[]backwarder.GradientPacket{
+			{
+				FromStepID: "step_2",
+				Severity:   promptiter.LossSeverityP1,
+				Gradient:   "focus on the live call",
+			},
+		},
+		targetSurfaceSet{modelSurfaceID: {}},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, request)
+	assert.NotNil(t, request.AllowedGradientSurfaceIDs)
+	assert.Empty(t, request.AllowedGradientSurfaceIDs)
+}
+
 func TestAggregateRejectsOutOfScopeGradient(t *testing.T) {
 	modelSurfaceID := astructure.SurfaceID("node_1", astructure.SurfaceTypeModel)
 	structure, err := newStructureState(&astructure.Snapshot{


### PR DESCRIPTION
This preserves the distinction between unrestricted backward requests and restricted requests with no matching target surfaces across engine and backwarder request handling. It keeps contextual surfaces available while preserving empty allowed gradient lists, emits valid structured-output schemas for those requests, and requires upstream propagation when restricted intermediate steps have predecessors but no local gradient surfaces.