### PR TITLE
docs: clarify taskrun delegation usage

### DIFF
--- a/docs/mkdocs/en/taskrun.md
+++ b/docs/mkdocs/en/taskrun.md
@@ -22,6 +22,130 @@ implementations that call `runner.Run` directly. Distributed controllers
 should normalize those values at the product adapter boundary instead of
 serializing arbitrary Go objects.
 
+## agenttool.NewTool, transfer_to_agent, and taskrun
+
+tRPC-Agent-Go has three common ways to delegate work to another agent. They
+all let another agent participate, but they do not mean the same thing.
+
+| Mechanism | Use it when | Waits for a result | Has a manageable run id |
+| --- | --- | --- | --- |
+| `agenttool.NewTool` / `tool/agent.Tool` | A parent agent needs to call a specialist agent like a normal synchronous tool | Yes | No |
+| `transfer_to_agent` | The current invocation should hand control to a sub-agent that continues the turn | Continues in the same invocation | No |
+| `tool/taskrun` | Work should run in a separate child session and remain queryable, waitable, or cancelable | Sync or async | Yes |
+
+Use the distinction as three separate questions:
+
+- "Do I need a specialist to return a value now?" Use `agenttool.NewTool`.
+- "Should another agent take over this turn?" Use `transfer_to_agent`.
+- "Should this become a tracked task that can be queried, waited for, or
+  canceled?" Use `taskrun`.
+
+### Synchronous specialist calls: agenttool.NewTool
+
+`agenttool.NewTool` wraps an already constructed agent as a normal tool. When
+the parent calls that tool, it waits for the child agent to finish. By default,
+the tool result aggregates non-empty assistant messages from the child agent.
+When configured with `agenttool.WithResponseMode(agenttool.ResponseModeFinalOnly)`,
+as shown below, the tool returns only the last complete assistant message. This
+is a good fit for small synchronous subtasks such as reviewing a paragraph,
+checking a design, or producing a short analysis.
+
+```go
+reviewer := llmagent.New(
+	"reviewer",
+	llmagent.WithModel(reviewModel),
+	llmagent.WithInstruction(
+		"Review the input carefully and return concise findings.",
+	),
+)
+
+reviewTool := agenttool.NewTool(
+	reviewer,
+	agenttool.WithResponseMode(agenttool.ResponseModeFinalOnly),
+)
+
+parent := llmagent.New(
+	"parent",
+	llmagent.WithModel(parentModel),
+	llmagent.WithTools([]tool.Tool{reviewTool}),
+)
+```
+
+There is no background run and no run id. The model sees a normal tool named
+`reviewer`; after the tool call finishes, the parent continues reasoning in
+the current invocation.
+
+### Handing off the current turn: transfer_to_agent
+
+When the parent decides that another agent should continue the current turn,
+configure a sub-agent and use transfer instead of a task run. When an
+LLMAgent has sub-agents, the framework exposes `transfer_to_agent`.
+
+```go
+support := llmagent.New(
+	"support",
+	llmagent.WithModel(supportModel),
+	llmagent.WithInstruction(
+		"Handle product support questions and ask for missing details.",
+	),
+)
+
+router := llmagent.New(
+	"router",
+	llmagent.WithModel(routerModel),
+	llmagent.WithInstruction(
+		"Route product support requests to the support agent.",
+	),
+	llmagent.WithSubAgents([]agent.Agent{support}),
+)
+```
+
+The model can call:
+
+```json
+{
+  "agent_name": "support",
+  "message": "The user is asking how to configure retries. Continue from here."
+}
+```
+
+This is not a background task. It means control for the current invocation
+moves to `support`, and the emitted events still belong to that run.
+
+### Manageable background work: taskrun
+
+Use `taskrun` when the delegated work may take longer, when the parent should
+continue without waiting, or when the application needs status, waiting, or
+cancellation. Every `start_task_run` creates a child session and returns a run
+id. The parent can later call `get_task_run`, `wait_task_run`, or
+`cancel_task_run`.
+
+```json
+{
+  "task": "Read the design notes and summarize the migration risks.",
+  "agent_name": "worker",
+  "mode": "async",
+  "timeout_seconds": 600
+}
+```
+
+If the parent must wait for the answer, use `sync`:
+
+```json
+{
+  "task": "Compare the two API designs and return a recommendation.",
+  "agent_name": "worker",
+  "mode": "sync",
+  "timeout_seconds": 600,
+  "wait_timeout_seconds": 120
+}
+```
+
+`sync` only means the tool waits for the child run to reach a terminal status.
+It still creates a run id and follows the same taskrun lifecycle. If
+`wait_timeout_seconds` expires, the child run is not canceled; the parent can
+still use the returned run id to check it later.
+
 ## Code-Side Usage
 
 Create one normal `runner.Runner`, then wrap it with
@@ -75,6 +199,53 @@ Use `tool/taskrun` when the parent agent should decide when to delegate work
 to background task runs. The tools use the current invocation session as the
 parent session.
 
+If the parent agent needs the taskrun tools, and `inprocess.Service` also
+needs the same runner, create the tools first without a controller and call
+`SetController` after the service is created. This avoids an initialization
+cycle where the parent needs the service, the service needs the runner, and
+the runner needs the parent.
+
+```go
+taskRunTools := taskruntool.NewTools(
+	nil,
+	taskruntool.WithDefaultAgentName("worker"),
+)
+
+worker := llmagent.New(
+	"worker",
+	llmagent.WithModel(workerModel),
+	llmagent.WithInstruction(
+		"Work on delegated tasks and return a clear final result.",
+	),
+)
+
+parent := llmagent.New(
+	"parent",
+	llmagent.WithModel(parentModel),
+	llmagent.WithTools(taskRunTools.All()),
+	llmagent.WithInstruction(
+		"Use taskrun tools only when the work can run in a separate task.",
+	),
+)
+
+r := runner.NewRunner(
+	"taskrun-example",
+	parent,
+	runner.WithAgent("worker", worker),
+)
+
+svc, err := inprocess.NewService(r)
+if err != nil {
+	return err
+}
+svc.Start(ctx)
+defer svc.Close()
+
+taskRunTools.SetController(svc)
+```
+
+If your application already has a `taskrun.Controller`, pass it directly:
+
 ```go
 taskRunTools := taskruntool.NewTools(
 	svc,
@@ -109,6 +280,83 @@ run when the wait times out.
 Nested task runs are rejected by default. Enable them explicitly with
 `taskruntool.WithNestedSpawns(true)` only when the application has its own
 fan-out limits.
+
+## Guidance for the Parent Agent
+
+After exposing `tool/taskrun`, describe when the parent agent should use it.
+Do not only tell the model that it can start tasks; explain the boundary.
+
+```go
+parent := llmagent.New(
+	"parent",
+	llmagent.WithModel(parentModel),
+	llmagent.WithTools(taskRunTools.All()),
+	llmagent.WithInstruction(`
+You coordinate user requests.
+
+Use start_task_run when a delegated task can continue in a separate child
+session, especially when it may take a long time or the user does not need the
+result immediately.
+
+Use mode="async" when you can continue the current response after receiving the
+run id. Use mode="sync" only when the delegated result is required before you
+can answer.
+
+After starting an async task, keep the returned run id. Use get_task_run or
+wait_task_run when you need the latest status or final result. Use
+cancel_task_run only when the user asks to stop the task or continuing it would
+be wasteful.
+`),
+)
+```
+
+If the parent only needs a specialist to synchronously return analysis, wrap
+that specialist with `agenttool.NewTool`. If the current invocation should be
+routed to another agent, configure sub-agents and use `transfer_to_agent`. Use
+`taskrun` only when you need a run id, status checks, waiting, or cancellation.
+
+## Choosing Named Agents
+
+The `agent_name` field in `start_task_run` maps to a named agent registered on
+the runner. The simplest form is `runner.WithAgent`, which registers an
+already constructed worker.
+
+```go
+r := runner.NewRunner(
+	"taskrun-example",
+	parent,
+	runner.WithAgent("worker", worker),
+)
+```
+
+If the worker must be built per request, for example with tenant-specific
+prompts, models, or sandboxes, use `runner.WithAgentFactory`. taskrun passes
+`agent_name` to the runner, and the runner resolves the target agent when the
+child run starts.
+
+```go
+r := runner.NewRunner(
+	"taskrun-example",
+	parent,
+	runner.WithAgentFactory(
+		"worker",
+		func(ctx context.Context, ro agent.RunOptions) (agent.Agent, error) {
+			return llmagent.New(
+				"worker",
+				llmagent.WithModel(workerModel),
+				llmagent.WithInstruction(
+					"Handle delegated background work for this request.",
+				),
+			), nil
+		},
+	),
+)
+```
+
+Prefer named agents such as `fast_worker`, `deep_reviewer`, or
+`readonly_researcher` to represent execution policies. The model chooses a
+business role, while the application owns the actual model, tools, and
+permission boundary.
 
 ## Runtime State
 

--- a/docs/mkdocs/zh/taskrun.md
+++ b/docs/mkdocs/zh/taskrun.md
@@ -20,6 +20,126 @@ wire protocol；其中 `RuntimeState map[string]any` 这类字段只适合直接
 `runner.Run` 的实现。分布式 controller 应在产品适配层把这些值规范化，
 不要直接序列化任意 Go 对象。
 
+## 和 agenttool.NewTool、transfer_to_agent 的区别
+
+tRPC-Agent-Go 里有三种常见的 agent 委托方式。它们都能让另一个 agent
+参与工作，但语义不一样。
+
+| 方式 | 适合场景 | 是否立即返回结果 | 是否有可管理的 run id |
+| --- | --- | --- | --- |
+| `agenttool.NewTool` / `tool/agent.Tool` | 把一个专家 agent 当成普通工具同步调用，父 agent 需要拿到返回值继续推理 | 是 | 否 |
+| `transfer_to_agent` | 当前 invocation 的控制权交给某个 sub-agent，后续由目标 agent 接着处理这一轮 | 在同一轮内继续 | 否 |
+| `tool/taskrun` | 另起一个子 session 执行任务，父 agent 可以继续当前轮，也可以查询、等待或取消子任务 | 可同步也可异步 | 是 |
+
+可以把它们理解成三个不同的问题：
+
+- “我现在需要一个专家给我一个结果吗？”用 `agenttool.NewTool`。
+- “这轮对话应该交给另一个 agent 接管吗？”用 `transfer_to_agent`。
+- “这个任务应该变成一个可跟踪、可取消、可等待的后台 run 吗？”用
+  `taskrun`。
+
+### 同步调用专家 agent：使用 agenttool.NewTool
+
+`agenttool.NewTool` 会把一个已经构造好的 agent 包装成一个普通 tool。父 agent
+调用这个 tool 时，会等待子 agent 完成。默认情况下，tool result 会聚合子
+agent 产生的非空 assistant 消息。下面的示例配置了
+`agenttool.WithResponseMode(agenttool.ResponseModeFinalOnly)`，因此 tool 只返回
+最后一条完整 assistant 消息。它适合“查资料、审查一段内容、生成一个小结果”
+这类同步子任务。
+
+```go
+reviewer := llmagent.New(
+	"reviewer",
+	llmagent.WithModel(reviewModel),
+	llmagent.WithInstruction(
+		"Review the input carefully and return concise findings.",
+	),
+)
+
+reviewTool := agenttool.NewTool(
+	reviewer,
+	agenttool.WithResponseMode(agenttool.ResponseModeFinalOnly),
+)
+
+parent := llmagent.New(
+	"parent",
+	llmagent.WithModel(parentModel),
+	llmagent.WithTools([]tool.Tool{reviewTool}),
+)
+```
+
+这里没有后台 run，也没有 `run id`。父 agent 的模型看到的是一个名为
+`reviewer` 的普通工具；工具调用结束后，父 agent 继续当前推理。
+
+### 当前轮交给 sub-agent：使用 transfer_to_agent
+
+当父 agent 不只是需要一个工具结果，而是判断“后续应该由另一个 agent
+处理这一轮”时，用 sub-agent transfer 更合适。配置 sub-agent 后，LLMAgent
+会为当前 agent 暴露框架工具 `transfer_to_agent`。
+
+```go
+support := llmagent.New(
+	"support",
+	llmagent.WithModel(supportModel),
+	llmagent.WithInstruction(
+		"Handle product support questions and ask for missing details.",
+	),
+)
+
+router := llmagent.New(
+	"router",
+	llmagent.WithModel(routerModel),
+	llmagent.WithInstruction(
+		"Route product support requests to the support agent.",
+	),
+	llmagent.WithSubAgents([]agent.Agent{support}),
+)
+```
+
+模型可以调用：
+
+```json
+{
+  "agent_name": "support",
+  "message": "The user is asking how to configure retries. Continue from here."
+}
+```
+
+这不是后台任务。它表示当前 invocation 的控制流转到 `support`，事件仍然属于
+这一次运行。
+
+### 可管理的后台任务：使用 taskrun
+
+`taskrun` 适合“任务可能比较久、父 agent 不一定要等、之后还要查状态或取消”
+的场景。每次 `start_task_run` 都会创建一个新的 child session，并返回一个
+run id。后续可以用 `get_task_run`、`wait_task_run`、`cancel_task_run`
+管理它。
+
+```json
+{
+  "task": "Read the design notes and summarize the migration risks.",
+  "agent_name": "worker",
+  "mode": "async",
+  "timeout_seconds": 600
+}
+```
+
+如果父 agent 必须等结果，可以用 `sync`：
+
+```json
+{
+  "task": "Compare the two API designs and return a recommendation.",
+  "agent_name": "worker",
+  "mode": "sync",
+  "timeout_seconds": 600,
+  "wait_timeout_seconds": 120
+}
+```
+
+`sync` 只表示工具会等待子 run 进入终态；它仍然会创建 run id，并走同一套
+taskrun 生命周期。`wait_timeout_seconds` 到期时不会取消子 run，父 agent
+仍然可以拿 run id 后续查询。
+
 ## 代码侧用法
 
 先创建普通的 `runner.Runner`，再用 `inprocess.Service` 包装它。
@@ -72,6 +192,52 @@ log.Printf("result: %s", final.Result)
 当父 agent 需要自行判断是否委托后台任务时，可以接入 `tool/taskrun`。
 这些工具会使用当前 invocation session 作为父 session。
 
+如果父 agent 的工具列表里包含 taskrun 工具，而 `inprocess.Service` 又需要
+持有同一个 runner，可以先创建一个没有 controller 的工具集合，再在 service
+创建后调用 `SetController`。这样可以避免“parent agent 需要 service，
+service 又需要 runner，runner 又需要 parent agent”的初始化循环。
+
+```go
+taskRunTools := taskruntool.NewTools(
+	nil,
+	taskruntool.WithDefaultAgentName("worker"),
+)
+
+worker := llmagent.New(
+	"worker",
+	llmagent.WithModel(workerModel),
+	llmagent.WithInstruction(
+		"Work on delegated tasks and return a clear final result.",
+	),
+)
+
+parent := llmagent.New(
+	"parent",
+	llmagent.WithModel(parentModel),
+	llmagent.WithTools(taskRunTools.All()),
+	llmagent.WithInstruction(
+		"Use taskrun tools only when the work can run in a separate task.",
+	),
+)
+
+r := runner.NewRunner(
+	"taskrun-example",
+	parent,
+	runner.WithAgent("worker", worker),
+)
+
+svc, err := inprocess.NewService(r)
+if err != nil {
+	return err
+}
+svc.Start(ctx)
+defer svc.Close()
+
+taskRunTools.SetController(svc)
+```
+
+如果你的应用已经先创建好了 `taskrun.Controller`，也可以直接传入：
+
 ```go
 taskRunTools := taskruntool.NewTools(
 	svc,
@@ -102,6 +268,80 @@ parent := llmagent.New(
 
 默认禁止嵌套创建 task run。只有当应用自己有并发和扇出限制时，才应通过
 `taskruntool.WithNestedSpawns(true)` 显式开启。
+
+## 给模型的使用建议
+
+把 `tool/taskrun` 暴露给父 agent 后，建议在父 agent 的 instruction 中说明
+什么时候应该使用它。不要只告诉模型“你可以启动任务”，而要说明边界。
+
+```go
+parent := llmagent.New(
+	"parent",
+	llmagent.WithModel(parentModel),
+	llmagent.WithTools(taskRunTools.All()),
+	llmagent.WithInstruction(`
+You coordinate user requests.
+
+Use start_task_run when a delegated task can continue in a separate child
+session, especially when it may take a long time or the user does not need the
+result immediately.
+
+Use mode="async" when you can continue the current response after receiving the
+run id. Use mode="sync" only when the delegated result is required before you
+can answer.
+
+After starting an async task, keep the returned run id. Use get_task_run or
+wait_task_run when you need the latest status or final result. Use
+cancel_task_run only when the user asks to stop the task or continuing it would
+be wasteful.
+`),
+)
+```
+
+如果只是需要另一个 agent 同步返回一段分析，优先用 `agenttool.NewTool`
+包装那个 agent。如果是路由到另一个 agent 继续处理当前 invocation，优先配置
+sub-agent 并使用 `transfer_to_agent`。只有需要 run id、状态查询、等待或取消
+时，才使用 `taskrun`。
+
+## 选择具名 agent
+
+`start_task_run` 的 `agent_name` 对应 runner 里的具名 agent。最简单的方式是
+用 `runner.WithAgent` 注册一个已经构造好的 worker。
+
+```go
+r := runner.NewRunner(
+	"taskrun-example",
+	parent,
+	runner.WithAgent("worker", worker),
+)
+```
+
+如果 worker 需要按请求动态构造，比如不同租户使用不同 prompt、模型或沙箱，
+可以使用 `runner.WithAgentFactory`。taskrun 会把 `agent_name` 传给 runner，
+由 runner 在每个子 run 开始时解析对应 agent。
+
+```go
+r := runner.NewRunner(
+	"taskrun-example",
+	parent,
+	runner.WithAgentFactory(
+		"worker",
+		func(ctx context.Context, ro agent.RunOptions) (agent.Agent, error) {
+			return llmagent.New(
+				"worker",
+				llmagent.WithModel(workerModel),
+				llmagent.WithInstruction(
+					"Handle delegated background work for this request.",
+				),
+			), nil
+		},
+	),
+)
+```
+
+推荐用不同的 `agent_name` 表达不同执行策略，例如 `fast_worker`、
+`deep_reviewer`、`readonly_researcher`。这样模型只选择业务角色，具体模型、
+工具和权限由应用侧配置，成本和安全边界更可控。
 
 ## 运行时状态
 


### PR DESCRIPTION
## Summary
- Clarify when to use AgentTool, transfer_to_agent, and taskrun for agent delegation.
- Add taskrun tool wiring examples, including SetController to avoid runner/service initialization cycles.
- Document parent-agent guidance and named-agent selection patterns in English and Chinese.

## Tests
- git diff --check
- mkdocs build -f docs/mkdocs.yml --strict (not run: mkdocs is not installed in this environment)