### PR TITLE
{agent, docs}: add lazy agent guidance

### DIFF
--- a/agent/lazy_agent.go
+++ b/agent/lazy_agent.go
@@ -68,6 +68,10 @@ func (a *lazyAgent) Run(ctx context.Context, invocation *Invocation) (<-chan *ev
 	if created == nil {
 		return nil, errors.New(errLazyAgentFactoryNilAgent)
 	}
+	if invocation != nil {
+		invocation.Agent = created
+		invocation.AgentName = created.Info().Name
+	}
 	return created.Run(ctx, invocation)
 }
 

--- a/agent/lazy_agent.go
+++ b/agent/lazy_agent.go
@@ -24,9 +24,9 @@ const (
 
 // AgentFactory creates an Agent for one run.
 //
-// Runner uses the same shape for request-scoped root agents. NewLazyAgent uses
-// it for sub-agents that should be described up front but constructed only
-// when they are actually invoked.
+// Runner uses the same shape for request-scoped root agents. NewLazyAgent
+// accepts this shape for sub-agents that should be described up front but
+// constructed only when they are actually invoked.
 type AgentFactory func(ctx context.Context, ro RunOptions) (Agent, error)
 
 type lazyAgent struct {
@@ -43,7 +43,10 @@ type lazyAgent struct {
 //
 // The factory should return an Agent with the same Info().Name as info.Name so
 // traces, transfer targets, and session branches remain easy to follow.
-func NewLazyAgent(info Info, factory AgentFactory) Agent {
+func NewLazyAgent(
+	info Info,
+	factory func(context.Context, RunOptions) (Agent, error),
+) Agent {
 	return &lazyAgent{
 		info:    info,
 		factory: factory,

--- a/agent/lazy_agent.go
+++ b/agent/lazy_agent.go
@@ -1,0 +1,92 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+const (
+	errLazyAgentNilFactory      = "agent: lazy agent factory is nil"
+	errLazyAgentFactoryNilAgent = "agent: lazy agent factory returned nil"
+)
+
+// AgentFactory creates an Agent for one run.
+//
+// Runner uses the same shape for request-scoped root agents. NewLazyAgent uses
+// it for sub-agents that should be described up front but constructed only
+// when they are actually invoked.
+type AgentFactory func(ctx context.Context, ro RunOptions) (Agent, error)
+
+type lazyAgent struct {
+	info    Info
+	factory AgentFactory
+}
+
+// NewLazyAgent returns an Agent that exposes info immediately and builds the
+// concrete Agent only when Run is called.
+//
+// This is useful for optional or expensive sub-agents. The parent agent can
+// still advertise the lazy agent through transfer_to_agent because Info is
+// available without constructing the concrete implementation.
+//
+// The factory should return an Agent with the same Info().Name as info.Name so
+// traces, transfer targets, and session branches remain easy to follow.
+func NewLazyAgent(info Info, factory AgentFactory) Agent {
+	return &lazyAgent{
+		info:    info,
+		factory: factory,
+	}
+}
+
+// Run implements Agent.
+func (a *lazyAgent) Run(ctx context.Context, invocation *Invocation) (<-chan *event.Event, error) {
+	if a.factory == nil {
+		return nil, errors.New(errLazyAgentNilFactory)
+	}
+
+	ro := RunOptions{}
+	if invocation != nil {
+		ro = invocation.RunOptions
+	}
+
+	created, err := a.factory(ctx, ro)
+	if err != nil {
+		return nil, fmt.Errorf("agent: lazy agent factory: %w", err)
+	}
+	if created == nil {
+		return nil, errors.New(errLazyAgentFactoryNilAgent)
+	}
+	return created.Run(ctx, invocation)
+}
+
+// Tools implements Agent.
+func (a *lazyAgent) Tools() []tool.Tool {
+	return nil
+}
+
+// Info implements Agent.
+func (a *lazyAgent) Info() Info {
+	return a.info
+}
+
+// SubAgents implements Agent.
+func (a *lazyAgent) SubAgents() []Agent {
+	return nil
+}
+
+// FindSubAgent implements Agent.
+func (a *lazyAgent) FindSubAgent(string) Agent {
+	return nil
+}

--- a/agent/lazy_agent_test.go
+++ b/agent/lazy_agent_test.go
@@ -22,18 +22,24 @@ import (
 
 const (
 	lazyAgentTestName        = "lazy-agent"
+	lazyAgentTestChildName   = "lazy-child"
 	lazyAgentTestDescription = "created only when invoked"
 	lazyAgentTestRequestID   = "lazy-request"
 	lazyAgentTestFactoryErr  = "factory failed"
 )
 
 type lazyAgentTestAgent struct {
-	name string
-	ran  bool
+	name      string
+	ran       bool
+	subAgents []Agent
+	onRun     func(*Invocation)
 }
 
-func (a *lazyAgentTestAgent) Run(context.Context, *Invocation) (<-chan *event.Event, error) {
+func (a *lazyAgentTestAgent) Run(_ context.Context, inv *Invocation) (<-chan *event.Event, error) {
 	a.ran = true
+	if a.onRun != nil {
+		a.onRun(inv)
+	}
 	ch := make(chan *event.Event)
 	close(ch)
 	return ch, nil
@@ -45,9 +51,18 @@ func (a *lazyAgentTestAgent) Info() Info {
 	return Info{Name: a.name}
 }
 
-func (a *lazyAgentTestAgent) SubAgents() []Agent { return nil }
+func (a *lazyAgentTestAgent) SubAgents() []Agent {
+	return append([]Agent(nil), a.subAgents...)
+}
 
-func (a *lazyAgentTestAgent) FindSubAgent(string) Agent { return nil }
+func (a *lazyAgentTestAgent) FindSubAgent(name string) Agent {
+	for _, subAgent := range a.subAgents {
+		if subAgent.Info().Name == name {
+			return subAgent
+		}
+	}
+	return nil
+}
 
 func TestNewLazyAgent_ExposesInfoWithoutCallingFactory(t *testing.T) {
 	called := false
@@ -91,6 +106,32 @@ func TestNewLazyAgent_RunBuildsAndDelegates(t *testing.T) {
 
 	assert.True(t, created.ran)
 	assert.Equal(t, lazyAgentTestRequestID, gotRunOptions.RequestID)
+}
+
+func TestNewLazyAgent_RunUpdatesInvocationAgentBeforeDelegating(t *testing.T) {
+	child := &lazyAgentTestAgent{name: lazyAgentTestChildName}
+	var created *lazyAgentTestAgent
+	created = &lazyAgentTestAgent{
+		name:      lazyAgentTestName,
+		subAgents: []Agent{child},
+		onRun: func(inv *Invocation) {
+			require.NotNil(t, inv)
+			assert.Same(t, created, inv.Agent)
+			assert.Equal(t, lazyAgentTestName, inv.AgentName)
+			assert.Same(t, child, inv.Agent.FindSubAgent(lazyAgentTestChildName))
+		},
+	}
+	lazy := NewLazyAgent(
+		Info{Name: lazyAgentTestName},
+		func(context.Context, RunOptions) (Agent, error) {
+			return created, nil
+		},
+	)
+
+	ch, err := lazy.Run(context.Background(), NewInvocation())
+	require.NoError(t, err)
+	for range ch {
+	}
 }
 
 func TestNewLazyAgent_RunReturnsFactoryErrors(t *testing.T) {

--- a/agent/lazy_agent_test.go
+++ b/agent/lazy_agent_test.go
@@ -1,0 +1,141 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+const (
+	lazyAgentTestName        = "lazy-agent"
+	lazyAgentTestDescription = "created only when invoked"
+	lazyAgentTestRequestID   = "lazy-request"
+	lazyAgentTestFactoryErr  = "factory failed"
+)
+
+type lazyAgentTestAgent struct {
+	name string
+	ran  bool
+}
+
+func (a *lazyAgentTestAgent) Run(context.Context, *Invocation) (<-chan *event.Event, error) {
+	a.ran = true
+	ch := make(chan *event.Event)
+	close(ch)
+	return ch, nil
+}
+
+func (a *lazyAgentTestAgent) Tools() []tool.Tool { return nil }
+
+func (a *lazyAgentTestAgent) Info() Info {
+	return Info{Name: a.name}
+}
+
+func (a *lazyAgentTestAgent) SubAgents() []Agent { return nil }
+
+func (a *lazyAgentTestAgent) FindSubAgent(string) Agent { return nil }
+
+func TestNewLazyAgent_ExposesInfoWithoutCallingFactory(t *testing.T) {
+	called := false
+	lazy := NewLazyAgent(
+		Info{
+			Name:        lazyAgentTestName,
+			Description: lazyAgentTestDescription,
+		},
+		func(context.Context, RunOptions) (Agent, error) {
+			called = true
+			return &lazyAgentTestAgent{name: lazyAgentTestName}, nil
+		},
+	)
+
+	assert.Equal(t, lazyAgentTestName, lazy.Info().Name)
+	assert.Equal(t, lazyAgentTestDescription, lazy.Info().Description)
+	assert.Nil(t, lazy.Tools())
+	assert.Nil(t, lazy.SubAgents())
+	assert.Nil(t, lazy.FindSubAgent(lazyAgentTestName))
+	assert.False(t, called)
+}
+
+func TestNewLazyAgent_RunBuildsAndDelegates(t *testing.T) {
+	created := &lazyAgentTestAgent{name: lazyAgentTestName}
+	var gotRunOptions RunOptions
+	lazy := NewLazyAgent(
+		Info{Name: lazyAgentTestName},
+		func(_ context.Context, ro RunOptions) (Agent, error) {
+			gotRunOptions = ro
+			return created, nil
+		},
+	)
+	inv := NewInvocation(WithInvocationRunOptions(RunOptions{
+		RequestID: lazyAgentTestRequestID,
+	}))
+
+	ch, err := lazy.Run(context.Background(), inv)
+	require.NoError(t, err)
+	for range ch {
+	}
+
+	assert.True(t, created.ran)
+	assert.Equal(t, lazyAgentTestRequestID, gotRunOptions.RequestID)
+}
+
+func TestNewLazyAgent_RunReturnsFactoryErrors(t *testing.T) {
+	factoryErr := errors.New(lazyAgentTestFactoryErr)
+	lazy := NewLazyAgent(
+		Info{Name: lazyAgentTestName},
+		func(context.Context, RunOptions) (Agent, error) {
+			return nil, factoryErr
+		},
+	)
+
+	_, err := lazy.Run(context.Background(), NewInvocation())
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, factoryErr)
+}
+
+func TestNewLazyAgent_RunRejectsInvalidFactories(t *testing.T) {
+	tests := []struct {
+		name    string
+		lazy    Agent
+		wantErr string
+	}{
+		{
+			name:    "nil factory",
+			lazy:    NewLazyAgent(Info{Name: lazyAgentTestName}, nil),
+			wantErr: errLazyAgentNilFactory,
+		},
+		{
+			name: "nil agent",
+			lazy: NewLazyAgent(
+				Info{Name: lazyAgentTestName},
+				func(context.Context, RunOptions) (Agent, error) {
+					return nil, nil
+				},
+			),
+			wantErr: errLazyAgentFactoryNilAgent,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.lazy.Run(context.Background(), NewInvocation())
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}

--- a/docs/mkdocs/en/multiagent.md
+++ b/docs/mkdocs/en/multiagent.md
@@ -67,6 +67,163 @@ mainAgent := llmagent.New(
 )
 ```
 
+## Dynamic SubAgents and Agent Factories
+
+In trpc-agent-go, a SubAgent is not a different runtime type. It is still an
+ordinary `agent.Agent`. The word "SubAgent" only describes where the Agent is
+visible: it is listed under a parent Agent through `WithSubAgents`, so that the
+parent can delegate work to it.
+
+This distinction is important when you need dynamic Agent construction.
+
+### Root Agent vs. SubAgent
+
+Use the smallest API that matches the problem:
+
+| Need | Recommended API | Why |
+| --- | --- | --- |
+| The whole request should start from a different Agent by name | `runner.WithAgentFactory` + `agent.WithAgentByName` | Runner chooses the root Agent before the run starts. |
+| A parent Agent should delegate to already-built specialists | `llmagent.WithSubAgents` | The parent can immediately describe all specialists to the model. |
+| A parent Agent should delegate to a specialist, but building that specialist is expensive or request-specific | `agent.NewLazyAgent` inside `WithSubAgents` | The parent can advertise the specialist from `agent.Info`, while the concrete Agent is built only if it is invoked. |
+| A tenant, project, or database decides which specialists exist | Build the slice in your application code, then pass it to `WithSubAgents` | Discovery, authorization, and configuration ownership usually belong to the application. |
+
+`runner.WithAgentFactory` is for **root Agent lookup**. It answers: "I already
+know the root Agent name for this run; please create it."
+
+`WithSubAgents` is for **parent-scoped visibility**. It answers: "While this
+parent Agent is running, which specialists may it delegate to?"
+
+Registering an Agent factory on the Runner does not automatically make that
+Agent visible to every parent Agent. This is intentional: different parent
+Agents often need different delegation boundaries.
+
+### Request-Scoped Root Agent with Request-Scoped SubAgents
+
+If the full Agent tree depends on the request, build the parent Agent in a
+Runner factory and pass the request-specific SubAgents into `WithSubAgents`.
+
+```go
+r := runner.NewRunnerWithAgentFactory(
+	"support-app",
+	"support-coordinator",
+	func(ctx context.Context, ro agent.RunOptions) (agent.Agent, error) {
+		tenantID, _ := agent.GetRuntimeStateValue[string](&ro, "tenant_id")
+
+		billingAgent := llmagent.New(
+			"billing-agent",
+			llmagent.WithModel(modelInstance),
+			llmagent.WithDescription("Handles billing and invoice questions"),
+			llmagent.WithInstruction(
+				"Answer billing questions for tenant " + tenantID + ".",
+			),
+		)
+
+		coordinator := llmagent.New(
+			"support-coordinator",
+			llmagent.WithModel(modelInstance),
+			llmagent.WithDescription("Routes support requests to specialists"),
+			llmagent.WithInstruction(
+				"Decide whether to answer directly or transfer to a specialist.",
+			),
+			llmagent.WithSubAgents([]agent.Agent{billingAgent}),
+		)
+		return coordinator, nil
+	},
+)
+
+events, err := r.Run(
+	ctx,
+	userID,
+	sessionID,
+	model.NewUserMessage("Why was my invoice higher this month?"),
+	agent.MergeRuntimeState(map[string]any{
+		"tenant_id": "tenant-001",
+	}),
+)
+_ = events
+_ = err
+```
+
+This pattern keeps ownership clear:
+
+- Your application decides which tenant or project configuration to load.
+- The Runner creates the request-specific root Agent.
+- The parent Agent explicitly receives the SubAgents it is allowed to use.
+
+### Lazy SubAgent Construction
+
+Sometimes the parent only needs a specialist in rare cases. Creating that
+specialist up front may be wasteful if it opens network clients, builds a large
+tool set, or prepares a sandbox.
+
+`agent.NewLazyAgent` solves this small framework boundary. It gives the parent
+an `agent.Info` immediately, so the `transfer_to_agent` tool can show the
+specialist name and description. The concrete Agent is created only when the
+lazy Agent's `Run` method is called.
+
+```go
+lazyBillingAgent := agent.NewLazyAgent(
+	agent.Info{
+		Name:        "billing-agent",
+		Description: "Handles billing and invoice questions",
+	},
+	func(ctx context.Context, ro agent.RunOptions) (agent.Agent, error) {
+		tenantID, _ := agent.GetRuntimeStateValue[string](&ro, "tenant_id")
+
+		return llmagent.New(
+			"billing-agent",
+			llmagent.WithModel(modelInstance),
+			llmagent.WithDescription("Handles billing and invoice questions"),
+			llmagent.WithInstruction(
+				"Answer billing questions for tenant " + tenantID + ".",
+			),
+		), nil
+	},
+)
+
+coordinator := llmagent.New(
+	"support-coordinator",
+	llmagent.WithModel(modelInstance),
+	llmagent.WithDescription("Routes support requests to specialists"),
+	llmagent.WithInstruction(
+		"Use transfer_to_agent when a specialist should handle the request.",
+	),
+	llmagent.WithSubAgents([]agent.Agent{lazyBillingAgent}),
+)
+```
+
+The lazy Agent is still an ordinary `agent.Agent`. The parent sees it through
+the normal `WithSubAgents` mechanism, and `transfer_to_agent` finds it through
+the normal `FindSubAgent` path.
+
+Keep these rules in mind:
+
+- `agent.Info.Name` is the stable transfer target name. The factory should
+  return a concrete Agent with the same name so events and session branches are
+  easy to follow.
+- `NewLazyAgent` is best for leaf specialists. If the specialist itself needs
+  nested SubAgents, build and configure them inside the factory.
+- The framework does not own resources created by the factory. If the factory
+  opens per-request resources, clean them up in your application or callbacks.
+
+### Application-Owned Discovery
+
+The framework deliberately does not prescribe where dynamic SubAgent
+definitions come from. They may come from code, a database, a tenant
+configuration service, a plugin, or files in your own application.
+
+The recommended boundary is:
+
+1. Your application discovers and validates the configuration.
+2. Your application converts that configuration into `agent.Agent` values
+   or `agent.NewLazyAgent(...)` descriptors.
+3. The framework runs the resulting Agents through `WithSubAgents`,
+   `transfer_to_agent`, AgentTool, ChainAgent, ParallelAgent, CycleAgent, or
+   GraphAgent.
+
+This keeps configuration, authorization, and rollout policy in the application
+while preserving the framework's single runtime abstraction: `agent.Agent`.
+
 ## Core Collaboration Patterns
 
 All collaboration patterns are based on the SubAgent concept, implemented through different execution strategies:

--- a/docs/mkdocs/en/runner.md
+++ b/docs/mkdocs/en/runner.md
@@ -203,6 +203,10 @@ Notes:
 
 - The factory is called once per `Runner.Run(...)`.
 - `agent.WithAgent(...)` still overrides everything (useful for tests).
+- Runner factories select the root Agent for a run. To configure specialists
+  that a parent Agent can delegate to, use `WithSubAgents`. For request-scoped
+  or lazily constructed SubAgents, see
+  [Dynamic SubAgents and Agent Factories](./multiagent.md#dynamic-subagents-and-agent-factories).
 
 #### Resource Ownership Inside Agent Factories
 

--- a/docs/mkdocs/zh/multiagent.md
+++ b/docs/mkdocs/zh/multiagent.md
@@ -67,6 +67,156 @@ mainAgent := llmagent.New(
 )
 ```
 
+## 动态 SubAgent 与 Agent Factory
+
+在 trpc-agent-go 中，SubAgent 并不是一种新的运行时类型。它仍然只是普通的
+`agent.Agent`。所谓 SubAgent，只是描述它和父 Agent 的关系：它通过
+`WithSubAgents` 挂在某个父 Agent 下面，因此这个父 Agent 可以把任务委托给它。
+
+理解这个边界之后，动态创建 Agent 时就不容易选错 API。
+
+### Root Agent 与 SubAgent 的区别
+
+优先选择能解决问题的最小 API：
+
+| 需求 | 推荐 API | 原因 |
+| --- | --- | --- |
+| 本次请求要从某个命名 Agent 开始执行 | `runner.WithAgentFactory` + `agent.WithAgentByName` | Runner 在 run 开始前选择 root Agent。 |
+| 父 Agent 要委托给一批已经构建好的专家 Agent | `llmagent.WithSubAgents` | 父 Agent 可以直接把所有专家的名称和描述暴露给模型。 |
+| 父 Agent 要委托给某个专家，但这个专家构建成本较高，或需要请求级参数 | `agent.NewLazyAgent` + `WithSubAgents` | 父 Agent 先通过 `agent.Info` 暴露专家信息，真正调用时才构建具体 Agent。 |
+| 租户、项目或数据库决定有哪些专家 Agent | 在业务代码中构建 `[]agent.Agent`，再传给 `WithSubAgents` | 配置发现、鉴权、覆盖规则通常应由业务应用负责。 |
+
+`runner.WithAgentFactory` 面向的是 **root Agent 查找**。它回答的问题是：
+“这次 run 已经知道要用哪个 root Agent 名字，请帮我创建它。”
+
+`WithSubAgents` 面向的是 **父 Agent 作用域内的可见性**。它回答的问题是：
+“当前这个父 Agent 正在运行时，它可以委托给哪些专家？”
+
+因此，把一个 Agent factory 注册到 Runner 上，并不意味着所有父 Agent 都能
+自动委托给这个 Agent。这是有意设计的：不同父 Agent 往往需要不同的委托边界。
+
+### 按请求构建 root Agent 和 SubAgents
+
+如果整棵 Agent 树都依赖本次请求，推荐在 Runner factory 中构建父 Agent，
+再把请求级 SubAgents 显式传给 `WithSubAgents`。
+
+```go
+r := runner.NewRunnerWithAgentFactory(
+	"support-app",
+	"support-coordinator",
+	func(ctx context.Context, ro agent.RunOptions) (agent.Agent, error) {
+		tenantID, _ := agent.GetRuntimeStateValue[string](&ro, "tenant_id")
+
+		billingAgent := llmagent.New(
+			"billing-agent",
+			llmagent.WithModel(modelInstance),
+			llmagent.WithDescription("Handles billing and invoice questions"),
+			llmagent.WithInstruction(
+				"Answer billing questions for tenant " + tenantID + ".",
+			),
+		)
+
+		coordinator := llmagent.New(
+			"support-coordinator",
+			llmagent.WithModel(modelInstance),
+			llmagent.WithDescription("Routes support requests to specialists"),
+			llmagent.WithInstruction(
+				"Decide whether to answer directly or transfer to a specialist.",
+			),
+			llmagent.WithSubAgents([]agent.Agent{billingAgent}),
+		)
+		return coordinator, nil
+	},
+)
+
+events, err := r.Run(
+	ctx,
+	userID,
+	sessionID,
+	model.NewUserMessage("Why was my invoice higher this month?"),
+	agent.MergeRuntimeState(map[string]any{
+		"tenant_id": "tenant-001",
+	}),
+)
+_ = events
+_ = err
+```
+
+这个模式把职责拆得很清楚：
+
+- 业务应用决定加载哪个租户或项目配置。
+- Runner 负责创建本次请求使用的 root Agent。
+- 父 Agent 显式声明本次允许委托的 SubAgents。
+
+### 懒加载 SubAgent
+
+有些专家 Agent 只有少数请求会用到。如果它会打开网络连接、初始化大型工具集、
+准备沙箱环境，那么每次都提前构建会造成浪费。
+
+`agent.NewLazyAgent` 解决的是这个很小的框架边界：父 Agent 可以先拿到
+`agent.Info`，因此 `transfer_to_agent` 工具能展示专家名称和描述；只有当这个
+懒加载 Agent 的 `Run` 方法真正被调用时，才会创建具体 Agent。
+
+```go
+lazyBillingAgent := agent.NewLazyAgent(
+	agent.Info{
+		Name:        "billing-agent",
+		Description: "Handles billing and invoice questions",
+	},
+	func(ctx context.Context, ro agent.RunOptions) (agent.Agent, error) {
+		tenantID, _ := agent.GetRuntimeStateValue[string](&ro, "tenant_id")
+
+		return llmagent.New(
+			"billing-agent",
+			llmagent.WithModel(modelInstance),
+			llmagent.WithDescription("Handles billing and invoice questions"),
+			llmagent.WithInstruction(
+				"Answer billing questions for tenant " + tenantID + ".",
+			),
+		), nil
+	},
+)
+
+coordinator := llmagent.New(
+	"support-coordinator",
+	llmagent.WithModel(modelInstance),
+	llmagent.WithDescription("Routes support requests to specialists"),
+	llmagent.WithInstruction(
+		"Use transfer_to_agent when a specialist should handle the request.",
+	),
+	llmagent.WithSubAgents([]agent.Agent{lazyBillingAgent}),
+)
+```
+
+懒加载 Agent 仍然是普通的 `agent.Agent`。父 Agent 仍然通过标准
+`WithSubAgents` 机制看到它，`transfer_to_agent` 也仍然通过标准
+`FindSubAgent` 路径找到它。
+
+使用时注意：
+
+- `agent.Info.Name` 是稳定的委托目标名。factory 返回的具体 Agent 应使用相同
+  名字，便于事件、trace 和 session 分支保持一致。
+- `NewLazyAgent` 最适合叶子专家 Agent。如果这个专家内部还需要自己的
+  SubAgents，请在 factory 内部继续构建和配置。
+- 框架不会接管 factory 内部创建的资源。如果 factory 创建了请求级连接、
+  tool set 或沙箱，请在业务代码或 callback 中自行清理。
+
+### 业务侧负责发现配置
+
+框架不规定动态 SubAgent 的定义必须来自哪里。它们可以来自代码、数据库、
+租户配置服务、插件，或业务应用自己管理的文件。
+
+推荐边界是：
+
+1. 业务应用负责发现、校验和合并配置。
+2. 业务应用把配置转换成 `agent.Agent`，或者转换成 `agent.NewLazyAgent(...)`
+   描述。
+3. 框架通过 `WithSubAgents`、`transfer_to_agent`、AgentTool、ChainAgent、
+   ParallelAgent、CycleAgent 或 GraphAgent 运行这些 Agent。
+
+这样配置来源、鉴权、灰度策略仍然由业务掌控，同时框架继续保持一个统一的
+运行时抽象：`agent.Agent`。
+
 ## 核心协作模式
 
 所有协作模式都基于 SubAgent 概念，通过不同的执行策略实现：

--- a/docs/mkdocs/zh/runner.md
+++ b/docs/mkdocs/zh/runner.md
@@ -202,6 +202,9 @@ _ = err
 
 - 每次调用 `Runner.Run(...)`，Factory 会被调用一次。
 - `agent.WithAgent(...)` 依然优先生效（测试时很方便）。
+- Runner factory 用来选择本次 run 的 root Agent。如果你要配置父 Agent
+  可以委托的专家 Agent，请使用 `WithSubAgents`。请求级或懒加载 SubAgent
+  的写法见 [动态 SubAgent 与 Agent Factory](./multiagent.md#动态-subagent-与-agent-factory)。
 
 #### Agent Factory 中的资源边界
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -82,7 +82,10 @@ func WithSessionService(service session.Service) Option {
 //
 // This enables request-scoped agent construction (for example, building the
 // agent with a prompt/model/sandbox that depends on the current request).
-type AgentFactory = agent.AgentFactory
+type AgentFactory func(
+	ctx context.Context,
+	ro agent.RunOptions,
+) (agent.Agent, error)
 
 // WithMemoryService sets the memory service to use.
 func WithMemoryService(service memory.Service) Option {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -82,10 +82,7 @@ func WithSessionService(service session.Service) Option {
 //
 // This enables request-scoped agent construction (for example, building the
 // agent with a prompt/model/sandbox that depends on the current request).
-type AgentFactory func(
-	ctx context.Context,
-	ro agent.RunOptions,
-) (agent.Agent, error)
+type AgentFactory = agent.AgentFactory
 
 // WithMemoryService sets the memory service to use.
 func WithMemoryService(service memory.Service) Option {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -82,7 +82,7 @@ func WithSessionService(service session.Service) Option {
 //
 // This enables request-scoped agent construction (for example, building the
 // agent with a prompt/model/sandbox that depends on the current request).
-type AgentFactory = agent.AgentFactory
+type AgentFactory func(ctx context.Context, ro agent.RunOptions) (agent.Agent, error)
 
 // WithMemoryService sets the memory service to use.
 func WithMemoryService(service memory.Service) Option {

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -1994,6 +1994,19 @@ func TestRunner_Run_WithDefaultAgentFactory(t *testing.T) {
 	assert.Equal(t, defaultNameBase+"1", events[0].Author)
 }
 
+func TestRunnerAgentFactoryCanBuildLazyAgent(t *testing.T) {
+	const agentName = "lazy-runner-agent"
+	var factory AgentFactory = func(
+		_ context.Context,
+		_ agent.RunOptions,
+	) (agent.Agent, error) {
+		return &mockAgent{name: agentName}, nil
+	}
+
+	lazy := agent.NewLazyAgent(agent.Info{Name: agentName}, factory)
+	require.Equal(t, agentName, lazy.Info().Name)
+}
+
 func TestRunner_NewRunnerWithAgentFactory_CoverageBranches(t *testing.T) {
 	const (
 		appName       = "test-app"


### PR DESCRIPTION
## Summary

- Add `agent.NewLazyAgent` for optional or expensive sub-agents that should expose `agent.Info` before constructing the concrete agent.
- Share the `AgentFactory` shape from the `agent` package and keep `runner.AgentFactory` as an alias.
- Expand English and Chinese multi-agent docs with root-agent factory vs. sub-agent visibility guidance, request-scoped examples, lazy sub-agent examples, and application-owned discovery boundaries.

## Validation

- `go test ./agent ./runner ./tool/agent ./tool/transfer`
- `go test ./codeexecutor/local`
- Attempted `go test ./...`; local macOS run is blocked by existing `tool/hostexec` test references to Linux-only `syscall.SysProcAttr.Pdeathsig`.
