### PR TITLE
codeexecutor/e2b: add WithStableWorkspace option for deterministic workspace paths

### DIFF
--- a/codeexecutor/e2b/e2b.go
+++ b/codeexecutor/e2b/e2b.go
@@ -113,6 +113,29 @@ func WithSandboxRunBase(dir string) Option {
 	return func(c *CodeExecutor) { c.sandboxRunBase = dir }
 }
 
+// WorkspacePersistenceMode controls how long a sandbox workspace is reused.
+type WorkspacePersistenceMode int
+
+const (
+	// WorkspacePersistencePerTurn creates a fresh workspace for each turn.
+	// Files written during one turn are not visible to later turns through the
+	// session workspace.
+	WorkspacePersistencePerTurn WorkspacePersistenceMode = iota
+
+	// WorkspacePersistencePerSession reuses one deterministic workspace for all
+	// turns in the same session. Files written during one turn remain visible to
+	// later turns in that session.
+	WorkspacePersistencePerSession
+)
+
+// WithWorkspacePersistence sets the workspace persistence mode. The default is
+// WorkspacePersistencePerTurn (a fresh workspace per CreateWorkspace call). Use
+// WorkspacePersistencePerSession when multi-turn agents should keep files and
+// intermediate state across turns.
+func WithWorkspacePersistence(mode WorkspacePersistenceMode) Option {
+	return func(c *CodeExecutor) { c.workspacePersistence = mode }
+}
+
 // CodeExecutor executes code inside an E2B code-interpreter sandbox.
 type CodeExecutor struct {
 	mu sync.Mutex
@@ -137,8 +160,9 @@ type CodeExecutor struct {
 	defaultLanguage  ci.RunCodeLanguage
 
 	// Workspace integration (runs entirely inside the sandbox).
-	sandboxRunBase string
-	rt             *workspaceRuntime
+	sandboxRunBase       string
+	workspacePersistence WorkspacePersistenceMode
+	rt                   *workspaceRuntime
 
 	// Sandbox instance.
 	sbx *ci.Sandbox

--- a/codeexecutor/e2b/workspace_runtime.go
+++ b/codeexecutor/e2b/workspace_runtime.go
@@ -14,7 +14,9 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -75,7 +77,8 @@ type workspaceRuntime struct {
 }
 
 type runtimeConfig struct {
-	runBase string
+	runBase              string
+	workspacePersistence WorkspacePersistenceMode
 }
 
 func newWorkspaceRuntime(c *CodeExecutor) *workspaceRuntime {
@@ -83,7 +86,10 @@ func newWorkspaceRuntime(c *CodeExecutor) *workspaceRuntime {
 	if base == "" {
 		base = defaultSandboxRunBase
 	}
-	return &workspaceRuntime{ce: c, cfg: runtimeConfig{runBase: base}}
+	return &workspaceRuntime{ce: c, cfg: runtimeConfig{
+		runBase:              base,
+		workspacePersistence: c.workspacePersistence,
+	}}
 }
 
 // CreateWorkspace creates a per-execution directory inside the sandbox.
@@ -103,11 +109,23 @@ func (r *workspaceRuntime) CreateWorkspace(
 		)
 	}
 
+	if r.cfg.workspacePersistence == WorkspacePersistencePerSession && execID == "" {
+		return codeexecutor.Workspace{}, errors.New(
+			"e2b: execID must not be empty when using WorkspacePersistencePerSession",
+		)
+	}
+
 	safe := sanitize(execID)
-	suf := time.Now().UnixNano()
-	wsPath := path.Join(
-		r.cfg.runBase, fmt.Sprintf("ws_%s_%d", safe, suf),
-	)
+	var wsPath string
+	if r.cfg.workspacePersistence == WorkspacePersistencePerSession {
+		// Use a stable hash of the raw exec ID to avoid collisions from
+		// sanitize() (e.g. "a/b" and "a_b" both sanitize to "a_b").
+		h := stableWorkspaceHash(execID)
+		wsPath = path.Join(r.cfg.runBase, fmt.Sprintf("ws_%s", h))
+	} else {
+		suf := time.Now().UnixNano()
+		wsPath = path.Join(r.cfg.runBase, fmt.Sprintf("ws_%s_%d", safe, suf))
+	}
 
 	var sb strings.Builder
 	sb.WriteString("set -e; mkdir -p ")
@@ -1317,6 +1335,15 @@ func sanitize(s string) string {
 		}
 	}
 	return b.String()
+}
+
+// stableWorkspaceHash returns a collision-free, filesystem-safe identifier
+// derived from the raw exec/session ID. It uses the first 16 hex characters of
+// a SHA-256 hash (64 bits), which is sufficient for workspace deduplication
+// within a single sandbox while keeping directory names short.
+func stableWorkspaceHash(id string) string {
+	h := sha256.Sum256([]byte(id))
+	return hex.EncodeToString(h[:8])
 }
 
 func shellQuote(s string) string {

--- a/codeexecutor/e2b/workspace_runtime_test.go
+++ b/codeexecutor/e2b/workspace_runtime_test.go
@@ -300,6 +300,62 @@ func TestCreateAndCleanupWorkspace(t *testing.T) {
 	require.NoError(t, c.Cleanup(ctx, ws))
 }
 
+func TestCreateWorkspace_PerSessionPersistence(t *testing.T) {
+	srv := newMockE2BServer(t, func(code string) string { return "" })
+	defer srv.close()
+	c := newMockedExecutor(t, srv, WithWorkspacePersistence(WorkspacePersistencePerSession))
+	ctx := context.Background()
+
+	// First call creates the workspace with a deterministic hash-based path.
+	ws1, err := c.CreateWorkspace(ctx, "session-xyz", codeexecutor.WorkspacePolicy{})
+	require.NoError(t, err)
+	assert.Equal(t, "session-xyz", ws1.ID)
+	// SHA-256("session-xyz")[:16 hex] = "090d29dd6bd25e05"
+	assert.Equal(t, defaultSandboxRunBase+"/ws_090d29dd6bd25e05", ws1.Path)
+
+	// Second call with the same exec ID returns the exact same path.
+	ws2, err := c.CreateWorkspace(ctx, "session-xyz", codeexecutor.WorkspacePolicy{})
+	require.NoError(t, err)
+	assert.Equal(t, ws1.Path, ws2.Path)
+
+	// Different exec ID gets a different stable path.
+	ws3, err := c.CreateWorkspace(ctx, "other-session", codeexecutor.WorkspacePolicy{})
+	require.NoError(t, err)
+	// SHA-256("other-session")[:16 hex] = "5f711b23ee4fecbb"
+	assert.Equal(t, defaultSandboxRunBase+"/ws_5f711b23ee4fecbb", ws3.Path)
+	assert.NotEqual(t, ws1.Path, ws3.Path)
+
+	// Collision-prone inputs that sanitize() would merge are now distinct.
+	wsA, _ := c.CreateWorkspace(ctx, "a/b", codeexecutor.WorkspacePolicy{})
+	wsB, _ := c.CreateWorkspace(ctx, "a_b", codeexecutor.WorkspacePolicy{})
+	assert.NotEqual(t, wsA.Path, wsB.Path)
+}
+
+func TestCreateWorkspace_DefaultIsPerTurn(t *testing.T) {
+	srv := newMockE2BServer(t, func(code string) string { return "" })
+	defer srv.close()
+	c := newMockedExecutor(t, srv) // default: WorkspacePersistencePerTurn
+	ctx := context.Background()
+
+	ws1, err := c.CreateWorkspace(ctx, "same-id", codeexecutor.WorkspacePolicy{})
+	require.NoError(t, err)
+	ws2, err := c.CreateWorkspace(ctx, "same-id", codeexecutor.WorkspacePolicy{})
+	require.NoError(t, err)
+
+	// Default behavior: each call creates a unique path (timestamp suffix).
+	assert.NotEqual(t, ws1.Path, ws2.Path)
+}
+
+func TestCreateWorkspace_PerSessionRejectsEmptyID(t *testing.T) {
+	srv := newMockE2BServer(t, func(code string) string { return "" })
+	defer srv.close()
+	c := newMockedExecutor(t, srv, WithWorkspacePersistence(WorkspacePersistencePerSession))
+
+	_, err := c.CreateWorkspace(context.Background(), "", codeexecutor.WorkspacePolicy{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "execID must not be empty")
+}
+
 func TestPutFilesAndPutDirectory(t *testing.T) {
 	srv := newMockE2BServer(t, func(code string) string { return "" })
 	defer srv.close()


### PR DESCRIPTION
Fixes #1873 

## What

Add `WithStableWorkspace(true)` option to `e2b.CodeExecutor`. When
enabled, `CreateWorkspace` produces a deterministic path based solely
on the sanitized exec ID (`ws_<execID>`), without appending a
timestamp suffix. Repeated calls with the same exec ID reuse the same
directory.

## Why

In multi-turn agent sessions sharing a single sandbox, the same exec
ID (typically the session ID) is passed across invocations. The
current behavior creates a new timestamped directory every time,
losing files and state from previous turns. A stable workspace path
allows multi-turn conversations to share state naturally.

## How

- Add `WithStableWorkspace(bool)` option and `stableWorkspace` field
  to `CodeExecutor` (`e2b.go`).
- Thread the flag through `runtimeConfig` to `CreateWorkspace`
  (`workspace_runtime.go`).
- When `stableWorkspace` is true, omit the nanosecond suffix; the
  existing `mkdir -p` + `[ -f meta ] || echo '{}'` ensures the second
  call is a safe no-op that preserves existing contents.
- Default behavior (unique timestamped path per call) is unchanged.

## Tests

- `TestCreateWorkspace_StablePath`: same exec ID → same path, different ID → different path.
- `TestCreateWorkspace_DefaultIsUnstable`: default behavior unchanged (unique per call).
- All existing tests pass.
- Verified end-to-end: files written in turn N are present when the
  workspace is "re-created" in turn N+1 with the same exec ID.

## Release Notes

`codeexecutor/e2b` adds `WithStableWorkspace(true)` option that gives
each exec ID a fixed workspace path, allowing multi-turn conversations
to reuse the same workspace directory instead of creating a new one on
every invocation.
