### PR TITLE
{session, internal/flow, openclaw}: track summary boundaries

### DIFF
--- a/internal/flow/llmflow/context_compact_test.go
+++ b/internal/flow/llmflow/context_compact_test.go
@@ -122,6 +122,57 @@ func (s *summaryPartialFailureService) Calls() int {
 	return s.calls
 }
 
+func TestSummarySnapshotAdvancedUsesBoundary(t *testing.T) {
+	cutoff := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	sess := &session.Session{
+		Summaries: map[string]*session.Summary{
+			"": {
+				Summary:   "same summary",
+				UpdatedAt: cutoff.Add(2 * time.Minute),
+				Boundary: session.NewSummaryBoundary(
+					"",
+					cutoff,
+				),
+			},
+		},
+	}
+	before := snapshotSummary(sess, "")
+
+	sess.Summaries[""].Boundary = session.NewSummaryBoundary(
+		"",
+		cutoff.Add(time.Minute),
+	)
+	after := snapshotSummary(sess, "")
+
+	require.True(t, before.advanced(after))
+}
+
+func TestSummarySnapshotAdvancedUsesBoundaryEventID(t *testing.T) {
+	cutoff := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	sess := &session.Session{
+		Summaries: map[string]*session.Summary{
+			"": {
+				Summary: "same summary",
+				Boundary: session.NewSummaryBoundaryWithEventID(
+					"",
+					cutoff,
+					"event-1",
+				),
+			},
+		},
+	}
+	before := snapshotSummary(sess, "")
+
+	sess.Summaries[""].Boundary = session.NewSummaryBoundaryWithEventID(
+		"",
+		cutoff,
+		"event-2",
+	)
+	after := snapshotSummary(sess, "")
+
+	require.True(t, before.advanced(after))
+}
+
 type countingRequestProcessor struct {
 	mu       sync.Mutex
 	calls    int

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -129,9 +129,11 @@ type contextCompactionRebuildPlan struct {
 }
 
 type summarySnapshot struct {
-	exists    bool
-	summary   string
-	updatedAt time.Time
+	exists              bool
+	summary             string
+	updatedAt           time.Time
+	boundaryCutoff      time.Time
+	boundaryLastEventID string
 }
 
 // New creates a new basic flow instance with the provided processors.
@@ -1337,10 +1339,19 @@ func snapshotSummary(sess *session.Session, filterKey string) summarySnapshot {
 	if summary == nil {
 		return summarySnapshot{}
 	}
+	boundary := summary.CutoffBoundary()
+	var boundaryCutoff time.Time
+	var boundaryLastEventID string
+	if boundary != nil {
+		boundaryCutoff = boundary.CutoffTime()
+		boundaryLastEventID = boundary.LastEventID
+	}
 	return summarySnapshot{
-		exists:    true,
-		summary:   summary.Summary,
-		updatedAt: summary.UpdatedAt,
+		exists:              true,
+		summary:             summary.Summary,
+		updatedAt:           summary.UpdatedAt,
+		boundaryCutoff:      boundaryCutoff,
+		boundaryLastEventID: boundaryLastEventID,
 	}
 }
 
@@ -1349,6 +1360,13 @@ func (s summarySnapshot) advanced(next summarySnapshot) bool {
 		return false
 	}
 	if !s.exists {
+		return true
+	}
+	if next.boundaryCutoff.After(s.boundaryCutoff) {
+		return true
+	}
+	if next.boundaryCutoff.Equal(s.boundaryCutoff) &&
+		next.boundaryLastEventID != s.boundaryLastEventID {
 		return true
 	}
 	if next.updatedAt.After(s.updatedAt) {

--- a/internal/flow/processor/content.go
+++ b/internal/flow/processor/content.go
@@ -617,14 +617,14 @@ func (p *ContentRequestProcessor) appendSessionMessages(
 	}
 
 	var messages []model.Message
-	var summaryUpdatedAt time.Time
+	var summaryCutoff summaryHistoryCutoff
 	var summaryText string
 	// Skip session summary when include_contents=none, but still get current
 	// invocation's events (tool calls/results) to maintain ReAct loop context.
 	if !skipHistory && p.AddSessionSummary && p.TimelineFilterMode == TimelineFilterAll {
 		// Fetch session summary early so we can insert it after other
 		// semi-stable system blocks (for example, preloaded memories).
-		summaryText, summaryUpdatedAt = p.getSessionSummaryText(invocation)
+		summaryText, summaryCutoff = p.getSessionSummaryText(invocation)
 	}
 
 	// Preload memories into system prompt if configured.
@@ -666,8 +666,8 @@ func (p *ContentRequestProcessor) appendSessionMessages(
 			messages = p.getCurrentInvocationMessages(invocation)
 		}
 	} else {
-		messages = p.getIncrementMessages(invocation, summaryUpdatedAt)
-		if p.hasCompactedCurrentInvocationToolResults(invocation, summaryUpdatedAt) {
+		messages = p.getIncrementMessagesAfterCutoff(invocation, summaryCutoff)
+		if p.hasCompactedCurrentInvocationToolResultsAfterCutoff(invocation, summaryCutoff) {
 			invocation.SetState(contentHasCompactedToolResultsStateKey, true)
 		}
 	}
@@ -721,12 +721,76 @@ func (p *ContentRequestProcessor) injectInjectedContextMessages(invocation *agen
 	req.Messages = append(req.Messages, messages...)
 }
 
-// getSessionSummaryText returns the raw session summary text and its
-// UpdatedAt timestamp for the current branch. It does not format or assign
+type summaryHistoryCutoff struct {
+	at          time.Time
+	lastEventID string
+}
+
+func summaryHistoryCutoffFromTime(at time.Time) summaryHistoryCutoff {
+	return summaryHistoryCutoff{at: at.UTC()}
+}
+
+func summaryHistoryCutoffFromBoundary(
+	boundary *session.SummaryBoundary,
+) summaryHistoryCutoff {
+	if boundary == nil {
+		return summaryHistoryCutoff{}
+	}
+	return summaryHistoryCutoff{
+		at:          boundary.CutoffTime(),
+		lastEventID: boundary.LastEventID,
+	}
+}
+
+func (c summaryHistoryCutoff) IsZero() bool {
+	return c.at.IsZero()
+}
+
+func (c summaryHistoryCutoff) CutoffTime() time.Time {
+	return c.at
+}
+
+type eventHistoryCutoff struct {
+	summaryHistoryCutoff
+	lastEventIndex int
+}
+
+func newEventHistoryCutoff(
+	events []event.Event,
+	cutoff summaryHistoryCutoff,
+) eventHistoryCutoff {
+	eventCutoff := eventHistoryCutoff{
+		summaryHistoryCutoff: cutoff,
+		lastEventIndex:       -1,
+	}
+	if cutoff.lastEventID == "" {
+		return eventCutoff
+	}
+	for i, evt := range events {
+		if evt.ID == cutoff.lastEventID {
+			eventCutoff.lastEventIndex = i
+			return eventCutoff
+		}
+	}
+	return eventCutoff
+}
+
+func (c eventHistoryCutoff) excludesEvent(index int, evt event.Event) bool {
+	if c.IsZero() {
+		return false
+	}
+	if c.lastEventIndex >= 0 {
+		return index <= c.lastEventIndex
+	}
+	return evt.Timestamp.Before(c.CutoffTime())
+}
+
+// getSessionSummaryText returns the raw session summary text and its event
+// cutoff for the current branch. It does not format or assign
 // a role — callers decide how to inject the text into the request.
-func (p *ContentRequestProcessor) getSessionSummaryText(inv *agent.Invocation) (string, time.Time) {
+func (p *ContentRequestProcessor) getSessionSummaryText(inv *agent.Invocation) (string, summaryHistoryCutoff) {
 	if inv.Session == nil {
-		return "", time.Time{}
+		return "", summaryHistoryCutoff{}
 	}
 
 	// Acquire read lock to protect Summaries access.
@@ -734,7 +798,7 @@ func (p *ContentRequestProcessor) getSessionSummaryText(inv *agent.Invocation) (
 	defer inv.Session.SummariesMu.RUnlock()
 
 	if inv.Session.Summaries == nil {
-		return "", time.Time{}
+		return "", summaryHistoryCutoff{}
 	}
 	filter := inv.GetEventFilterKey()
 	// For BranchFilterModeAll, prefer the full-session summary under empty filter key.
@@ -745,25 +809,25 @@ func (p *ContentRequestProcessor) getSessionSummaryText(inv *agent.Invocation) (
 	// Try exact match first.
 	sum := inv.Session.Summaries[filter]
 	if sum != nil && sum.Summary != "" {
-		return sum.Summary, sum.UpdatedAt
+		return sum.Summary, summaryHistoryCutoffFromBoundary(sum.CutoffBoundary())
 	}
 
 	// For BranchFilterModePrefix, aggregate summaries with matching prefix.
 	if p.BranchFilterMode == BranchFilterModePrefix && filter != "" {
 		return p.aggregatePrefixSummaries(inv.Session.Summaries, filter)
 	}
-	return "", time.Time{}
+	return "", summaryHistoryCutoff{}
 }
 
 // getSessionSummaryMessage returns the current-branch session summary as a
-// system message if available and non-empty, along with its UpdatedAt timestamp.
+// system message if available and non-empty, along with its event cutoff.
 func (p *ContentRequestProcessor) getSessionSummaryMessage(inv *agent.Invocation) (*model.Message, time.Time) {
-	text, updatedAt := p.getSessionSummaryText(inv)
+	text, cutoff := p.getSessionSummaryText(inv)
 	if text == "" {
 		return nil, time.Time{}
 	}
 	content := p.formatSummary(text)
-	return &model.Message{Role: model.RoleSystem, Content: content}, updatedAt
+	return &model.Message{Role: model.RoleSystem, Content: content}, cutoff.CutoffTime()
 }
 
 // prependSummaryUserMessage prepends the session summary as a user message
@@ -847,10 +911,8 @@ func (p *ContentRequestProcessor) formatSummaryForUser(summary string) string {
 func (p *ContentRequestProcessor) aggregatePrefixSummaries(
 	summaries map[string]*session.Summary,
 	prefix string,
-) (string, time.Time) {
+) (string, summaryHistoryCutoff) {
 	var parts []string
-	var latestTime time.Time
-	filterPrefix := prefix + agent.EventFilterKeyDelimiter
 
 	keys := make([]string, 0, len(summaries))
 	for key := range summaries {
@@ -864,18 +926,15 @@ func (p *ContentRequestProcessor) aggregatePrefixSummaries(
 			continue
 		}
 		// Check if key matches prefix (key starts with "prefix/" or key equals prefix).
-		keyWithDelim := key + agent.EventFilterKeyDelimiter
-		if key == prefix || strings.HasPrefix(keyWithDelim, filterPrefix) {
+		if session.SummaryFilterKeyMatchesPrefix(key, prefix) {
 			parts = append(parts, sum.Summary)
-			if sum.UpdatedAt.After(latestTime) {
-				latestTime = sum.UpdatedAt
-			}
 		}
 	}
 	if len(parts) == 0 {
-		return "", time.Time{}
+		return "", summaryHistoryCutoff{}
 	}
-	return strings.Join(parts, "\n\n"), latestTime
+	boundary, _ := session.SummaryPrefixBoundary(summaries, prefix)
+	return strings.Join(parts, "\n\n"), summaryHistoryCutoffFromBoundary(boundary)
 }
 
 // formatSummary applies custom formatter if available, otherwise uses default.
@@ -893,29 +952,59 @@ func (p *ContentRequestProcessor) formatSummary(summary string) string {
 // getHistoryMessages gets history messages for the current filter, potentially truncated by MaxHistoryRuns.
 // This method is used when AddSessionSummary is false to get recent history messages.
 func (p *ContentRequestProcessor) getIncrementMessages(inv *agent.Invocation, since time.Time) []model.Message {
+	return p.getIncrementMessagesAfterCutoff(inv, summaryHistoryCutoffFromTime(since))
+}
+
+func (p *ContentRequestProcessor) getIncrementMessagesAfterCutoff(
+	inv *agent.Invocation,
+	cutoff summaryHistoryCutoff,
+) []model.Message {
 	if inv.Session == nil {
 		return nil
 	}
-	isZeroTime := since.IsZero()
 	filter := inv.GetEventFilterKey()
 	var includedInvocationMessage bool
 
 	var events []event.Event
-	inv.Session.EventMu.RLock()
-	for _, evt := range inv.Session.Events {
+	sessionEvents := sessionEventsSnapshot(inv.Session)
+	eventCutoff := newEventHistoryCutoff(sessionEvents, cutoff)
+	toolCallIDsToRestoreByEvent := p.toolCallIDsToRestoreByEvent(
+		sessionEvents,
+		inv,
+		filter,
+		eventCutoff,
+	)
+	for i, evt := range sessionEvents {
 		if compactedEvt, ok := p.compactCurrentInvocationEvent(
 			evt,
+			i,
 			inv,
 			filter,
-			isZeroTime,
-			since,
+			eventCutoff,
 		); ok {
 			events = append(events, compactedEvt)
 			continue
 		}
-		shouldInclude, isInvocationMessage := p.shouldIncludeEvent(evt, inv, filter, isZeroTime, since)
+		shouldInclude, isInvocationMessage := p.shouldIncludeEvent(
+			evt,
+			i,
+			inv,
+			filter,
+			eventCutoff,
+		)
 		if !shouldInclude {
-			continue
+			restoredEvt, ok := p.restorePreCutoffToolCallEvent(
+				evt,
+				i,
+				inv,
+				filter,
+				eventCutoff,
+				toolCallIDsToRestoreByEvent[i],
+			)
+			if !ok {
+				continue
+			}
+			evt = restoredEvt
 		}
 		if isInvocationMessage {
 			includedInvocationMessage = true
@@ -928,7 +1017,6 @@ func (p *ContentRequestProcessor) getIncrementMessages(inv *agent.Invocation, si
 		}
 		events = append(events, evt)
 	}
-	inv.Session.EventMu.RUnlock()
 
 	// insert invocation message
 	if !includedInvocationMessage && model.HasPayload(inv.Message) {
@@ -1000,6 +1088,128 @@ func (p *ContentRequestProcessor) getIncrementMessages(inv *agent.Invocation, si
 	return messages
 }
 
+func sessionEventsSnapshot(sess *session.Session) []event.Event {
+	if sess == nil {
+		return nil
+	}
+	sess.EventMu.RLock()
+	defer sess.EventMu.RUnlock()
+	events := make([]event.Event, len(sess.Events))
+	for i, evt := range sess.Events {
+		events[i] = cloneEventForContentSnapshot(evt)
+	}
+	return events
+}
+
+func cloneEventForContentSnapshot(evt event.Event) event.Event {
+	cloned := evt
+	if evt.Response != nil {
+		cloned.Response = evt.Response.Clone()
+	}
+	if evt.LongRunningToolIDs != nil {
+		cloned.LongRunningToolIDs = make(map[string]struct{}, len(evt.LongRunningToolIDs))
+		for id := range evt.LongRunningToolIDs {
+			cloned.LongRunningToolIDs[id] = struct{}{}
+		}
+	}
+	if evt.StateDelta != nil {
+		cloned.StateDelta = make(map[string][]byte, len(evt.StateDelta))
+		for key, value := range evt.StateDelta {
+			cloned.StateDelta[key] = append([]byte(nil), value...)
+		}
+	}
+	if evt.Actions != nil {
+		actions := *evt.Actions
+		cloned.Actions = &actions
+	}
+	return cloned
+}
+
+func (p *ContentRequestProcessor) toolCallIDsToRestoreByEvent(
+	events []event.Event,
+	inv *agent.Invocation,
+	filter string,
+	cutoff eventHistoryCutoff,
+) map[int]map[string]struct{} {
+	if cutoff.IsZero() {
+		return nil
+	}
+
+	responseMatchesByCallEvent := toolResponseMatchesByCallEventFiltered(
+		events,
+		func(_ int, evt event.Event) bool {
+			return p.canMatchToolRound(evt, inv, filter)
+		},
+	)
+	idsByEvent := make(map[int]map[string]struct{})
+	for callEventIndex, responseMatches := range responseMatchesByCallEvent {
+		shouldIncludeCall, _ := p.shouldIncludeEvent(
+			events[callEventIndex],
+			callEventIndex,
+			inv,
+			filter,
+			cutoff,
+		)
+		if shouldIncludeCall {
+			continue
+		}
+		for _, match := range responseMatches {
+			shouldIncludeResult, _ := p.shouldIncludeEvent(
+				events[match.eventIndex],
+				match.eventIndex,
+				inv,
+				filter,
+				cutoff,
+			)
+			if !shouldIncludeResult {
+				continue
+			}
+			for _, choiceIndex := range match.choiceIndices {
+				choices := events[match.eventIndex].Response.Choices
+				if choiceIndex < 0 || choiceIndex >= len(choices) {
+					continue
+				}
+				resultID := toolResponseIDFromChoice(choices[choiceIndex])
+				addToolCallIDToRestore(
+					idsByEvent,
+					callEventIndex,
+					resultID,
+				)
+			}
+		}
+	}
+	if len(idsByEvent) == 0 {
+		return nil
+	}
+	return idsByEvent
+}
+
+func (p *ContentRequestProcessor) canMatchToolRound(
+	evt event.Event,
+	inv *agent.Invocation,
+	filter string,
+) bool {
+	return isEventEligibleForInclusion(evt) &&
+		p.passTimelineFilter(evt, inv) &&
+		p.passBranchFilter(evt, filter)
+}
+
+func addToolCallIDToRestore(
+	idsByEvent map[int]map[string]struct{},
+	eventIndex int,
+	toolCallID string,
+) {
+	if toolCallID == "" {
+		return
+	}
+	ids := idsByEvent[eventIndex]
+	if ids == nil {
+		ids = make(map[string]struct{})
+		idsByEvent[eventIndex] = ids
+	}
+	ids[toolCallID] = struct{}{}
+}
+
 // compactCurrentInvocationEvent preserves the minimum structured state needed
 // for same-turn tool loops after a summary has already absorbed earlier
 // invocation history. Assistant tool-call messages are kept intact, while tool
@@ -1007,19 +1217,19 @@ func (p *ContentRequestProcessor) getIncrementMessages(inv *agent.Invocation, si
 // summary for details.
 func (p *ContentRequestProcessor) compactCurrentInvocationEvent(
 	evt event.Event,
+	eventIndex int,
 	inv *agent.Invocation,
 	filter string,
-	isZeroTime bool,
-	since time.Time,
+	cutoff eventHistoryCutoff,
 ) (event.Event, bool) {
-	if isZeroTime || inv == nil {
+	if cutoff.IsZero() || inv == nil {
 		return event.Event{}, false
 	}
 	if evt.RequestID != inv.RunOptions.RequestID ||
 		evt.InvocationID != inv.InvocationID {
 		return event.Event{}, false
 	}
-	if evt.Timestamp.After(since) {
+	if !cutoff.excludesEvent(eventIndex, evt) {
 		return event.Event{}, false
 	}
 	if !isEventEligibleForInclusion(evt) {
@@ -1642,8 +1852,13 @@ func (p *ContentRequestProcessor) mergeUserMessages(
 // exact invocation-message matches return true. Mid-turn user-message
 // protection may still include an event, but returns false for this flag to
 // avoid conflating inclusion with strict message equality.
-func (p *ContentRequestProcessor) shouldIncludeEvent(evt event.Event, inv *agent.Invocation, filter string,
-	isZeroTime bool, since time.Time) (bool, bool) {
+func (p *ContentRequestProcessor) shouldIncludeEvent(
+	evt event.Event,
+	eventIndex int,
+	inv *agent.Invocation,
+	filter string,
+	cutoff eventHistoryCutoff,
+) (bool, bool) {
 	// Fast reject malformed, partial, or empty-content events.
 	if !isEventEligibleForInclusion(evt) {
 		return false, false
@@ -1652,16 +1867,14 @@ func (p *ContentRequestProcessor) shouldIncludeEvent(evt event.Event, inv *agent
 	if isStrictInvocationMessage(evt, inv) {
 		return true, true
 	}
-	// Keep the current invocation user message even when summary UpdatedAt
+	// Keep the current invocation user message even when the summary cutoff
 	// would otherwise exclude it. This preserves the original request while
 	// still allowing same-turn tool/assistant history already covered by the
 	// summary to be compacted out of the next prompt.
 	if isCurrentInvocationUserMessage(evt, inv) {
 		return true, false
 	}
-	// Use strict After so events stamped exactly at summary UpdatedAt are
-	// treated as already summarized and not re-sent.
-	if !isZeroTime && !evt.Timestamp.After(since) {
+	if cutoff.excludesEvent(eventIndex, evt) {
 		return false, false
 	}
 	if !p.passTimelineFilter(evt, inv) {
@@ -1671,6 +1884,108 @@ func (p *ContentRequestProcessor) shouldIncludeEvent(evt event.Event, inv *agent
 		return false, false
 	}
 	return true, false
+}
+
+func (p *ContentRequestProcessor) restorePreCutoffToolCallEvent(
+	evt event.Event,
+	eventIndex int,
+	inv *agent.Invocation,
+	filter string,
+	cutoff eventHistoryCutoff,
+	neededToolCallIDs map[string]struct{},
+) (event.Event, bool) {
+	if cutoff.IsZero() || len(neededToolCallIDs) == 0 {
+		return event.Event{}, false
+	}
+	if !isEventEligibleForInclusion(evt) || !evt.IsToolCallResponse() {
+		return event.Event{}, false
+	}
+	if !cutoff.excludesEvent(eventIndex, evt) {
+		return event.Event{}, false
+	}
+	if !p.passTimelineFilter(evt, inv) || !p.passBranchFilter(evt, filter) {
+		return event.Event{}, false
+	}
+
+	var choices []model.Choice
+	for _, choice := range evt.Response.Choices {
+		if filtered, ok := filterToolCallChoice(
+			choice,
+			neededToolCallIDs,
+		); ok {
+			choices = append(choices, filtered)
+		}
+	}
+	if len(choices) == 0 {
+		return event.Event{}, false
+	}
+	restored := evt
+	restored.Response = &model.Response{
+		Done:    evt.Response.Done,
+		Object:  evt.Response.Object,
+		Choices: choices,
+	}
+	return restored, true
+}
+
+func filterToolCallChoice(
+	choice model.Choice,
+	neededToolCallIDs map[string]struct{},
+) (model.Choice, bool) {
+	messageToolCalls := filterToolCallsByID(
+		choice.Message.ToolCalls,
+		neededToolCallIDs,
+	)
+	deltaToolCalls := filterToolCallsByID(
+		choice.Delta.ToolCalls,
+		neededToolCallIDs,
+	)
+	if len(messageToolCalls) == 0 && len(deltaToolCalls) == 0 {
+		return model.Choice{}, false
+	}
+	filtered := model.Choice{Index: choice.Index}
+	if len(messageToolCalls) > 0 {
+		filtered.Message = minimalToolCallMessage(
+			choice.Message.Role,
+			messageToolCalls,
+		)
+	}
+	if len(deltaToolCalls) > 0 {
+		filtered.Delta = minimalToolCallMessage(
+			choice.Delta.Role,
+			deltaToolCalls,
+		)
+	}
+	return filtered, true
+}
+
+func minimalToolCallMessage(
+	role model.Role,
+	toolCalls []model.ToolCall,
+) model.Message {
+	if role == "" {
+		role = model.RoleAssistant
+	}
+	return model.Message{
+		Role:      role,
+		ToolCalls: toolCalls,
+	}
+}
+
+func filterToolCallsByID(
+	toolCalls []model.ToolCall,
+	neededIDs map[string]struct{},
+) []model.ToolCall {
+	if len(toolCalls) == 0 || len(neededIDs) == 0 {
+		return nil
+	}
+	filtered := make([]model.ToolCall, 0, len(toolCalls))
+	for _, toolCall := range toolCalls {
+		if _, ok := neededIDs[toolCall.ID]; ok {
+			filtered = append(filtered, toolCall)
+		}
+	}
+	return filtered
 }
 
 // isEventEligibleForInclusion checks basic event validity before expensive
@@ -1691,7 +2006,7 @@ func isStrictInvocationMessage(evt event.Event, inv *agent.Invocation) bool {
 }
 
 // isCurrentInvocationUserMessage keeps the current invocation's user message
-// even when summary UpdatedAt would exclude it by timestamp.
+// even when the summary cutoff would exclude it by timestamp.
 //
 // RequestID + InvocationID matching avoids preserving unrelated user messages
 // from other invocations that may share the same request scope.
@@ -1711,7 +2026,17 @@ func (p *ContentRequestProcessor) hasCompactedCurrentInvocationToolResults(
 	inv *agent.Invocation,
 	since time.Time,
 ) bool {
-	if inv == nil || inv.Session == nil || since.IsZero() {
+	return p.hasCompactedCurrentInvocationToolResultsAfterCutoff(
+		inv,
+		summaryHistoryCutoffFromTime(since),
+	)
+}
+
+func (p *ContentRequestProcessor) hasCompactedCurrentInvocationToolResultsAfterCutoff(
+	inv *agent.Invocation,
+	cutoff summaryHistoryCutoff,
+) bool {
+	if inv == nil || inv.Session == nil || cutoff.IsZero() {
 		return false
 	}
 	if inv.RunOptions.RequestID == "" || inv.InvocationID == "" {
@@ -1720,15 +2045,15 @@ func (p *ContentRequestProcessor) hasCompactedCurrentInvocationToolResults(
 
 	filter := inv.GetEventFilterKey()
 
-	inv.Session.EventMu.RLock()
-	defer inv.Session.EventMu.RUnlock()
+	events := sessionEventsSnapshot(inv.Session)
+	eventCutoff := newEventHistoryCutoff(events, cutoff)
 
-	for _, evt := range inv.Session.Events {
+	for i, evt := range events {
 		if evt.RequestID != inv.RunOptions.RequestID ||
 			evt.InvocationID != inv.InvocationID {
 			continue
 		}
-		if evt.Timestamp.After(since) {
+		if !eventCutoff.excludesEvent(i, evt) {
 			continue
 		}
 		if !isEventEligibleForInclusion(evt) ||
@@ -2058,10 +2383,20 @@ type matchedToolResponseEvent struct {
 // toolResponseMatchesByCallEvent matches tool-result choices to the nearest
 // preceding tool-call round that is still waiting for the result ID.
 func toolResponseMatchesByCallEvent(events []event.Event) map[int][]matchedToolResponseEvent {
+	return toolResponseMatchesByCallEventFiltered(events, nil)
+}
+
+func toolResponseMatchesByCallEventFiltered(
+	events []event.Event,
+	includeEvent func(int, event.Event) bool,
+) map[int][]matchedToolResponseEvent {
 	responseMatchesByCallEvent := make(map[int][]matchedToolResponseEvent)
 	var pendingCallRounds []pendingToolCallRound
 	for i, evt := range events {
 		evt := evt
+		if includeEvent != nil && !includeEvent(i, evt) {
+			continue
+		}
 		if evt.IsToolCallResponse() {
 			ids := evt.GetToolCallIDs()
 			if len(ids) == 0 {
@@ -2077,10 +2412,7 @@ func toolResponseMatchesByCallEvent(events []event.Event) map[int][]matchedToolR
 			continue
 		}
 		for choiceIndex, choice := range evt.Response.Choices {
-			responseID := choice.Message.ToolID
-			if responseID == "" {
-				responseID = choice.Delta.ToolID
-			}
+			responseID := toolResponseIDFromChoice(choice)
 			if responseID == "" {
 				continue
 			}
@@ -2099,6 +2431,13 @@ func toolResponseMatchesByCallEvent(events []event.Event) map[int][]matchedToolR
 		}
 	}
 	return responseMatchesByCallEvent
+}
+
+func toolResponseIDFromChoice(choice model.Choice) string {
+	if choice.Message.ToolID != "" {
+		return choice.Message.ToolID
+	}
+	return choice.Delta.ToolID
 }
 
 // appendToolResponseChoice records one matching choice while coalescing choices

--- a/internal/flow/processor/content_memory_test.go
+++ b/internal/flow/processor/content_memory_test.go
@@ -15,7 +15,9 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/memory"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
@@ -1083,4 +1085,103 @@ func TestProcessRequest_MergesSummary(t *testing.T) {
 		}
 	}
 	assert.Equal(t, 1, systemCount)
+}
+
+func TestContentRequestProcessor_UsesSummaryBoundaryCutoff(t *testing.T) {
+	cutoff := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	updatedAt := cutoff.Add(2 * time.Minute)
+	sess := &session.Session{
+		Events: []event.Event{
+			{
+				FilterKey: "branch",
+				Timestamp: cutoff.Add(-time.Minute),
+				Response: &model.Response{Choices: []model.Choice{{Message: model.Message{
+					Role:    model.RoleUser,
+					Content: "covered by summary",
+				}}}},
+			},
+			{
+				FilterKey: "branch",
+				Timestamp: cutoff.Add(time.Minute),
+				Response: &model.Response{Choices: []model.Choice{{Message: model.Message{
+					Role:    model.RoleUser,
+					Content: "after boundary",
+				}}}},
+			},
+		},
+		Summaries: map[string]*session.Summary{
+			"branch": {
+				Summary:   "summary text",
+				UpdatedAt: updatedAt,
+				Boundary: session.NewSummaryBoundary(
+					"branch",
+					cutoff,
+				),
+			},
+		},
+	}
+	p := NewContentRequestProcessor(WithAddSessionSummary(true))
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationEventFilterKey("branch"),
+	)
+
+	summaryText, summaryCutoff := p.getSessionSummaryText(inv)
+	require.Equal(t, "summary text", summaryText)
+	require.True(t, summaryCutoff.CutoffTime().Equal(cutoff))
+
+	messages := p.getIncrementMessagesAfterCutoff(inv, summaryCutoff)
+	require.Len(t, messages, 1)
+	assert.Equal(t, "after boundary", messages[0].Content)
+}
+
+func TestContentRequestProcessor_AggregatePrefixSummariesUsesEarliestCutoff(t *testing.T) {
+	baseTime := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	p := NewContentRequestProcessor()
+	t.Run("uses earliest cutoff", func(t *testing.T) {
+		text, cutoff := p.aggregatePrefixSummaries(
+			map[string]*session.Summary{
+				"root/a": {
+					Summary: "summary a",
+					Boundary: session.NewSummaryBoundary(
+						"root/a",
+						baseTime,
+					),
+				},
+				"root/b": {
+					Summary: "summary b",
+					Boundary: session.NewSummaryBoundary(
+						"root/b",
+						baseTime.Add(10*time.Minute),
+					),
+				},
+			},
+			"root",
+		)
+
+		require.Contains(t, text, "summary a")
+		require.Contains(t, text, "summary b")
+		assert.True(t, cutoff.CutoffTime().Equal(baseTime))
+	})
+	t.Run("returns zero cutoff when metadata is missing", func(t *testing.T) {
+		text, cutoff := p.aggregatePrefixSummaries(
+			map[string]*session.Summary{
+				"root/a": {
+					Summary: "summary a",
+					Boundary: session.NewSummaryBoundary(
+						"root/a",
+						baseTime,
+					),
+				},
+				"root/b": {
+					Summary: "summary b",
+				},
+			},
+			"root",
+		)
+
+		require.Contains(t, text, "summary a")
+		require.Contains(t, text, "summary b")
+		assert.True(t, cutoff.IsZero())
+	})
 }

--- a/internal/flow/processor/content_messages_test.go
+++ b/internal/flow/processor/content_messages_test.go
@@ -741,10 +741,16 @@ func TestProcessRequest_SessionSummary_CompactsSameTurnToolHistory(t *testing.T)
 			"test-agent": {
 				Summary:   "step 1 completed successfully",
 				UpdatedAt: baseTime.Add(2 * time.Second),
+				Boundary: session.NewSummaryBoundaryWithEventID(
+					"test-agent",
+					baseTime.Add(2*time.Second),
+					"tool-result-1",
+				),
 			},
 		},
 		Events: []event.Event{
 			{
+				ID:           "user-1",
 				Author:       "user",
 				RequestID:    "req1",
 				InvocationID: "inv1",
@@ -756,6 +762,7 @@ func TestProcessRequest_SessionSummary_CompactsSameTurnToolHistory(t *testing.T)
 				},
 			},
 			{
+				ID:           "tool-call-1",
 				Author:       "test-agent",
 				RequestID:    "req1",
 				InvocationID: "inv1",
@@ -767,6 +774,7 @@ func TestProcessRequest_SessionSummary_CompactsSameTurnToolHistory(t *testing.T)
 				},
 			},
 			{
+				ID:           "tool-result-1",
 				Author:       "test-agent",
 				RequestID:    "req1",
 				InvocationID: "inv1",
@@ -1183,8 +1191,8 @@ func TestContentRequestProcessor_AggregatePrefixSummaries_Sorted(
 	got, updatedAt := p.aggregatePrefixSummaries(summaries, "app")
 	require.Equal(t, "root\n\na\n\nb", got)
 	require.Equal(t,
-		time.Date(2023, 1, 3, 12, 0, 0, 0, time.UTC),
-		updatedAt,
+		time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
+		updatedAt.CutoffTime(),
 	)
 }
 

--- a/internal/flow/processor/content_test.go
+++ b/internal/flow/processor/content_test.go
@@ -486,12 +486,12 @@ func TestContentRequestProcessor_getSessionSummaryMessageWithTime(t *testing.T) 
 			includeContents: BranchFilterModePrefix,
 			// The aggregated summary should contain both matching summaries.
 			// Note: map iteration order is not guaranteed, so we check for non-nil
-			// and verify the latest timestamp.
+			// and verify the conservative prefix cutoff.
 			expectedMsg: &model.Message{
 				Role: model.RoleSystem,
 				// Content will be checked separately due to non-deterministic order.
 			},
-			expectedTime: time.Date(2023, 1, 1, 14, 0, 0, 0, time.UTC),
+			expectedTime: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
 		},
 	}
 
@@ -3089,7 +3089,7 @@ func TestContentRequestProcessor_shouldIncludeEvent(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "timestamp equal since when not zero time, same invocation excluded",
+			name: "timestamp equal legacy cutoff included conservatively",
 			setup: func() (*ContentRequestProcessor, event.Event, *agent.Invocation, string, bool, time.Time) {
 				p := &ContentRequestProcessor{}
 				evt := event.Event{
@@ -3110,7 +3110,7 @@ func TestContentRequestProcessor_shouldIncludeEvent(t *testing.T) {
 				inv := &agent.Invocation{InvocationID: "123", RunOptions: agent.RunOptions{RequestID: "123"}}
 				return p, evt, inv, "", false, sinceTime
 			},
-			expected: false,
+			expected: true,
 		},
 		{
 			name: "timestamp before since when not zero time, different invocation excluded",
@@ -3848,7 +3848,18 @@ func TestContentRequestProcessor_shouldIncludeEvent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p, evt, inv, filter, isZeroTime, since := tt.setup()
-			result, isInvocationMessage := p.shouldIncludeEvent(evt, inv, filter, isZeroTime, since)
+			cutoff := summaryHistoryCutoffFromTime(since)
+			if isZeroTime {
+				cutoff = summaryHistoryCutoff{}
+			}
+			eventCutoff := newEventHistoryCutoff([]event.Event{evt}, cutoff)
+			result, isInvocationMessage := p.shouldIncludeEvent(
+				evt,
+				0,
+				inv,
+				filter,
+				eventCutoff,
+			)
 			if result != tt.expected {
 				t.Errorf("shouldIncludeEvent() = %v, want %v", result, tt.expected)
 			}
@@ -3904,6 +3915,7 @@ func TestContentRequestProcessor_getIncrementMessages_SummaryPreservesToolState(
 		EventMu: sync.RWMutex{},
 		Events: []event.Event{
 			{
+				ID:           "user-1",
 				Author:       "user",
 				RequestID:    "req1",
 				InvocationID: "inv1",
@@ -3915,6 +3927,7 @@ func TestContentRequestProcessor_getIncrementMessages_SummaryPreservesToolState(
 				},
 			},
 			{
+				ID:           "tool-call-1",
 				Author:       "test-agent",
 				RequestID:    "req1",
 				InvocationID: "inv1",
@@ -3926,6 +3939,7 @@ func TestContentRequestProcessor_getIncrementMessages_SummaryPreservesToolState(
 				},
 			},
 			{
+				ID:           "tool-result-1",
 				Author:       "test-agent",
 				RequestID:    "req1",
 				InvocationID: "inv1",
@@ -3938,6 +3952,7 @@ func TestContentRequestProcessor_getIncrementMessages_SummaryPreservesToolState(
 				},
 			},
 			{
+				ID:           "tool-call-2",
 				Author:       "test-agent",
 				RequestID:    "req1",
 				InvocationID: "inv1",
@@ -3949,6 +3964,7 @@ func TestContentRequestProcessor_getIncrementMessages_SummaryPreservesToolState(
 				},
 			},
 			{
+				ID:           "tool-result-2",
 				Author:       "test-agent",
 				RequestID:    "req1",
 				InvocationID: "inv1",
@@ -3972,7 +3988,13 @@ func TestContentRequestProcessor_getIncrementMessages_SummaryPreservesToolState(
 	inv.AgentName = "test-agent"
 
 	p := NewContentRequestProcessor(WithAddSessionSummary(true))
-	messages := p.getIncrementMessages(inv, baseTime.Add(2*time.Second))
+	messages := p.getIncrementMessagesAfterCutoff(
+		inv,
+		summaryHistoryCutoff{
+			at:          baseTime.Add(2 * time.Second),
+			lastEventID: "tool-result-1",
+		},
+	)
 
 	if assert.Len(t, messages, 5) {
 		assert.True(t, model.MessagesEqual(userMsg, messages[0]))
@@ -3987,6 +4009,222 @@ func TestContentRequestProcessor_getIncrementMessages_SummaryPreservesToolState(
 		assert.Equal(t, toolCall2.ToolCalls, messages[3].ToolCalls)
 		assert.True(t, model.MessagesEqual(toolResult2, messages[4]))
 	}
+}
+
+func TestContentRequestProcessor_getIncrementMessages_ExactBoundaryKeepsSameTimestampTail(t *testing.T) {
+	baseTime := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	sess := &session.Session{
+		Events: []event.Event{
+			{
+				ID:        "covered",
+				Timestamp: baseTime,
+				Version:   event.CurrentVersion,
+				Response: &model.Response{
+					Choices: []model.Choice{{Message: model.Message{
+						Role:    model.RoleUser,
+						Content: "covered",
+					}}},
+				},
+			},
+			{
+				ID:        "same-time-tail",
+				Timestamp: baseTime,
+				Version:   event.CurrentVersion,
+				Response: &model.Response{
+					Choices: []model.Choice{{Message: model.Message{
+						Role:    model.RoleAssistant,
+						Content: "same timestamp tail",
+					}}},
+				},
+			},
+		},
+	}
+	inv := agent.NewInvocation(agent.WithInvocationSession(sess))
+	p := NewContentRequestProcessor(WithAddSessionSummary(true))
+
+	messages := p.getIncrementMessagesAfterCutoff(
+		inv,
+		summaryHistoryCutoff{
+			at:          baseTime,
+			lastEventID: "covered",
+		},
+	)
+
+	require.Len(t, messages, 1)
+	assert.Equal(t, "same timestamp tail", messages[0].Content)
+}
+
+func TestContentRequestProcessor_getIncrementMessages_RestoresNeededPreCutoffToolCall(t *testing.T) {
+	baseTime := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	toolCall := model.Message{
+		Role:             model.RoleAssistant,
+		Content:          "covered assistant text",
+		ReasoningContent: "covered reasoning",
+		ToolCalls: []model.ToolCall{
+			{
+				Type: "function",
+				ID:   "call_1",
+				Function: model.FunctionDefinitionParam{
+					Name:      "lookup",
+					Arguments: []byte(`{"q":"covered"}`),
+				},
+			},
+			{
+				Type: "function",
+				ID:   "call_2",
+				Function: model.FunctionDefinitionParam{
+					Name:      "lookup",
+					Arguments: []byte(`{"q":"needed"}`),
+				},
+			},
+		},
+	}
+	coveredToolResult := model.Message{
+		Role:     model.RoleTool,
+		ToolID:   "call_1",
+		ToolName: "lookup",
+		Content:  "covered",
+	}
+	neededToolResult := model.Message{
+		Role:     model.RoleTool,
+		ToolID:   "call_2",
+		ToolName: "lookup",
+		Content:  "ok",
+	}
+	cutoff := baseTime.Add(time.Second)
+	sess := &session.Session{
+		Events: []event.Event{
+			{
+				Author:       "test-agent",
+				RequestID:    "req1",
+				InvocationID: "inv1",
+				Timestamp:    baseTime,
+				Version:      event.CurrentVersion,
+				Response: &model.Response{
+					Done:    true,
+					Choices: []model.Choice{{Index: 0, Message: toolCall}},
+				},
+			},
+			{
+				Author:       "test-agent",
+				RequestID:    "req1",
+				InvocationID: "inv1",
+				Timestamp:    baseTime.Add(500 * time.Millisecond),
+				Version:      event.CurrentVersion,
+				Response: &model.Response{
+					Done:    true,
+					Object:  model.ObjectTypeToolResponse,
+					Choices: []model.Choice{{Index: 0, Message: coveredToolResult}},
+				},
+			},
+			{
+				Author:       "test-agent",
+				RequestID:    "req1",
+				InvocationID: "inv1",
+				Timestamp:    baseTime.Add(2 * time.Second),
+				Version:      event.CurrentVersion,
+				Response: &model.Response{
+					Done:   true,
+					Object: model.ObjectTypeToolResponse,
+					Choices: []model.Choice{
+						{Index: 0, Message: coveredToolResult},
+						{Index: 1, Message: neededToolResult},
+					},
+				},
+			},
+		},
+	}
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationID("inv2"),
+		agent.WithInvocationRunOptions(agent.RunOptions{RequestID: "req2"}),
+	)
+	inv.AgentName = "test-agent"
+
+	p := NewContentRequestProcessor(WithAddSessionSummary(true))
+	messages := p.getIncrementMessages(inv, cutoff)
+
+	require.Len(t, messages, 2)
+	assert.Equal(t, model.RoleAssistant, messages[0].Role)
+	assert.Empty(t, messages[0].Content)
+	assert.Empty(t, messages[0].ReasoningContent)
+	require.Len(t, messages[0].ToolCalls, 1)
+	assert.Equal(t, "call_2", messages[0].ToolCalls[0].ID)
+	assert.Equal(t, model.RoleTool, messages[1].Role)
+	assert.Equal(t, "call_2", messages[1].ToolID)
+	assert.Equal(t, "ok", messages[1].Content)
+}
+
+func TestContentRequestProcessor_getIncrementMessages_DoesNotRestoreReusedToolCallID(t *testing.T) {
+	baseTime := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	makeToolCall := func(content string) model.Message {
+		return model.Message{
+			Role:    model.RoleAssistant,
+			Content: content,
+			ToolCalls: []model.ToolCall{{
+				Type: "function",
+				ID:   "call_1",
+				Function: model.FunctionDefinitionParam{
+					Name:      "lookup",
+					Arguments: []byte(`{"q":"status"}`),
+				},
+			}},
+		}
+	}
+	makeToolResult := func(content string) model.Message {
+		return model.Message{
+			Role:     model.RoleTool,
+			ToolID:   "call_1",
+			ToolName: "lookup",
+			Content:  content,
+		}
+	}
+	makeEvent := func(ts time.Time, msg model.Message, object string) event.Event {
+		return event.Event{
+			Author:       "test-agent",
+			RequestID:    "req1",
+			InvocationID: "inv1",
+			Timestamp:    ts,
+			Version:      event.CurrentVersion,
+			Response: &model.Response{
+				Done:    true,
+				Object:  object,
+				Choices: []model.Choice{{Index: 0, Message: msg}},
+			},
+		}
+	}
+	cutoff := baseTime.Add(time.Second)
+	sess := &session.Session{
+		Events: []event.Event{
+			makeEvent(baseTime, makeToolCall("old call"), ""),
+			makeEvent(
+				baseTime.Add(500*time.Millisecond),
+				makeToolResult("old result"),
+				model.ObjectTypeToolResponse,
+			),
+			makeEvent(baseTime.Add(2*time.Second), makeToolCall("new call"), ""),
+			makeEvent(
+				baseTime.Add(3*time.Second),
+				makeToolResult("new result"),
+				model.ObjectTypeToolResponse,
+			),
+		},
+	}
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationID("inv2"),
+		agent.WithInvocationRunOptions(agent.RunOptions{RequestID: "req2"}),
+	)
+	inv.AgentName = "test-agent"
+
+	p := NewContentRequestProcessor(WithAddSessionSummary(true))
+	messages := p.getIncrementMessages(inv, cutoff)
+
+	require.Len(t, messages, 2)
+	assert.Equal(t, "new call", messages[0].Content)
+	assert.Equal(t, model.RoleAssistant, messages[0].Role)
+	assert.Equal(t, model.RoleTool, messages[1].Role)
+	assert.Equal(t, "new result", messages[1].Content)
 }
 
 func TestContentRequestProcessor_getIncrementMessages_MixedToolContinuationPreservesRoundResults(t *testing.T) {
@@ -5356,6 +5594,34 @@ func TestContentRequestProcessor_AnnotatesUserFileInputs_HostRef(t *testing.T) {
 		assert.Contains(t, *first.Text, "application/pdf")
 		assert.NotContains(t, *first.Text, "/tmp/openclaw/report.pdf")
 	}
+}
+
+func TestCloneEventForContentSnapshotAllowsNilResponse(t *testing.T) {
+	const (
+		eventID      = "event-1"
+		toolCallID   = "call-1"
+		otherCallID  = "call-2"
+		stateKey     = "state"
+		stateValue   = "value"
+		changedValue = 'x'
+	)
+	evt := event.Event{
+		ID: eventID,
+		LongRunningToolIDs: map[string]struct{}{
+			toolCallID: {},
+		},
+		StateDelta: map[string][]byte{
+			stateKey: []byte(stateValue),
+		},
+	}
+
+	cloned := cloneEventForContentSnapshot(evt)
+
+	require.Nil(t, cloned.Response)
+	cloned.LongRunningToolIDs[otherCallID] = struct{}{}
+	cloned.StateDelta[stateKey][0] = changedValue
+	assert.NotContains(t, evt.LongRunningToolIDs, otherCallID)
+	assert.Equal(t, stateValue, string(evt.StateDelta[stateKey]))
 }
 
 func TestFileNameFromArtifactRef_EdgeCases(t *testing.T) {

--- a/internal/session/tool/recall/helpers_test.go
+++ b/internal/session/tool/recall/helpers_test.go
@@ -77,6 +77,9 @@ func TestCurrentSummaryCutoff_StateAndSummaryFallbacks(t *testing.T) {
 
 	updatedAt := time.Date(2025, 4, 7, 11, 0, 0, 0, time.UTC)
 	childUpdatedAt := updatedAt.Add(2 * time.Minute)
+	fullCutoff := updatedAt.Add(-2 * time.Minute)
+	earliestChildCutoff := updatedAt.Add(-time.Minute)
+	childCutoff := updatedAt.Add(time.Minute)
 	sess := session.NewSession(
 		"app",
 		"user",
@@ -85,10 +88,26 @@ func TestCurrentSummaryCutoff_StateAndSummaryFallbacks(t *testing.T) {
 			"team/child": {
 				Summary:   "team child summary",
 				UpdatedAt: childUpdatedAt,
+				Boundary: session.NewSummaryBoundary(
+					"team/child",
+					childCutoff,
+				),
+			},
+			"team/earlier": {
+				Summary:   "team earlier summary",
+				UpdatedAt: childUpdatedAt,
+				Boundary: session.NewSummaryBoundary(
+					"team/earlier",
+					earliestChildCutoff,
+				),
 			},
 			session.SummaryFilterKeyAllContents: {
 				Summary:   "full summary",
 				UpdatedAt: updatedAt,
+				Boundary: session.NewSummaryBoundary(
+					session.SummaryFilterKeyAllContents,
+					fullCutoff,
+				),
 			},
 		}),
 	)
@@ -98,21 +117,74 @@ func TestCurrentSummaryCutoff_StateAndSummaryFallbacks(t *testing.T) {
 		agent.WithInvocationSession(sess),
 		agent.WithInvocationEventFilterKey("team"),
 	)
-	assert.Equal(t, childUpdatedAt, currentSummaryCutoff(inv))
+	assert.Equal(t, earliestChildCutoff, currentSummaryCutoff(inv))
+
+	otherInv := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationEventFilterKey("other"),
+	)
+	assert.Equal(t, fullCutoff, currentSummaryCutoff(otherInv))
 
 	exactUpdatedAt := updatedAt.Add(4 * time.Minute)
+	exactCutoff := updatedAt.Add(3 * time.Minute)
 	sess.Summaries["team"] = &session.Summary{
 		Summary:   "team summary",
 		UpdatedAt: exactUpdatedAt,
+		Boundary: session.NewSummaryBoundary(
+			"team",
+			exactCutoff,
+		),
 	}
-	assert.Equal(t, exactUpdatedAt, currentSummaryCutoff(inv))
+	assert.Equal(t, exactCutoff, currentSummaryCutoff(inv))
 
 	lastIncludedAt := updatedAt.Add(-time.Minute)
 	sess.SetState(
 		summaryLastIncludedTsKey,
 		[]byte(lastIncludedAt.Format(time.RFC3339Nano)),
 	)
-	assert.Equal(t, lastIncludedAt, currentSummaryCutoff(inv))
+	assert.Equal(t, exactCutoff, currentSummaryCutoff(inv))
+
+	stateOnly := session.NewSession("app", "user", "state-only")
+	stateOnly.SetState(
+		summaryLastIncludedTsKey,
+		[]byte(lastIncludedAt.Format(time.RFC3339Nano)),
+	)
+	stateOnlyInv := agent.NewInvocation(
+		agent.WithInvocationSession(stateOnly),
+		agent.WithInvocationEventFilterKey("team"),
+	)
+	assert.Equal(t, lastIncludedAt, currentSummaryCutoff(stateOnlyInv))
+}
+
+func TestCurrentSummaryCutoff_PrefixMissingCutoff(t *testing.T) {
+	updatedAt := time.Date(2025, 4, 7, 11, 0, 0, 0, time.UTC)
+	sess := session.NewSession(
+		"app",
+		"user",
+		"sess",
+		session.WithSessionSummaries(map[string]*session.Summary{
+			"team/a": {
+				Summary: "team a summary",
+				Boundary: session.NewSummaryBoundary(
+					"team/a",
+					updatedAt,
+				),
+			},
+			"team/b": {
+				Summary: "team b summary",
+			},
+		}),
+	)
+	sess.SetState(
+		summaryLastIncludedTsKey,
+		[]byte(updatedAt.Format(time.RFC3339Nano)),
+	)
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationEventFilterKey("team"),
+	)
+
+	assert.True(t, currentSummaryCutoff(inv).IsZero())
 }
 
 func TestExtractSessionMessageText(t *testing.T) {

--- a/internal/session/tool/recall/helpers_test.go
+++ b/internal/session/tool/recall/helpers_test.go
@@ -574,7 +574,7 @@ func TestLexicalScanSessionEvents_HonorsCutoffAndTopK(t *testing.T) {
 		},
 		"budget planning friday",
 		"",
-		base.Add(90*time.Second),
+		session.NewSummaryBoundary("", base.Add(90*time.Second)),
 		1,
 	)
 	require.Len(t, results, 1)
@@ -620,7 +620,7 @@ func TestLexicalScanSessionEvents_HonorsFilterKey(t *testing.T) {
 		session.Key{AppName: "app", UserID: "user", SessionID: "sess"},
 		"budget planning",
 		"branch/a",
-		time.Time{},
+		nil,
 		5,
 	)
 	require.Len(t, results, 1)
@@ -907,8 +907,8 @@ func TestSearchHelpers_EdgeBranches(t *testing.T) {
 	assert.Empty(t, keywordSearchQuery("the and or"))
 	assert.Nil(t, keywordTokens("the and or"))
 
-	assert.Nil(t, lexicalScanSessionEvents(nil, session.Key{}, "alpha", "", time.Time{}, 1))
-	assert.Nil(t, lexicalScanSessionEvents(session.NewSession("app", "user", "sess"), session.Key{}, "", "", time.Time{}, 1))
+	assert.Nil(t, lexicalScanSessionEvents(nil, session.Key{}, "alpha", "", nil, 1))
+	assert.Nil(t, lexicalScanSessionEvents(session.NewSession("app", "user", "sess"), session.Key{}, "", "", nil, 1))
 
 	assert.Zero(
 		t,
@@ -1027,7 +1027,7 @@ func TestSearchSessionHistory_AndScanErrorBranches(t *testing.T) {
 			},
 		},
 		&SearchSessionRequest{Query: "alpha"},
-		time.Time{},
+		nil,
 	)
 	require.Error(t, err)
 
@@ -1046,7 +1046,7 @@ func TestSearchSessionHistory_AndScanErrorBranches(t *testing.T) {
 			},
 		},
 		&SearchSessionRequest{Query: "alpha"},
-		time.Time{},
+		nil,
 	)
 	require.Error(t, err)
 
@@ -1065,7 +1065,7 @@ func TestSearchSessionHistory_AndScanErrorBranches(t *testing.T) {
 			},
 		},
 		&SearchSessionRequest{Query: "alpha"},
-		time.Time{},
+		nil,
 	)
 	require.NoError(t, err)
 	assert.Nil(t, results)

--- a/internal/session/tool/recall/search.go
+++ b/internal/session/tool/recall/search.go
@@ -195,8 +195,8 @@ func searchCurrentHidden(
 	inv *agent.Invocation,
 	req *SearchSessionRequest,
 ) ([]session.EventSearchResult, error) {
-	cutoff := currentSummaryCutoff(inv)
-	if cutoff.IsZero() {
+	boundary := currentSummaryBoundary(inv)
+	if boundary == nil || boundary.CutoffTime().IsZero() {
 		return nil, nil
 	}
 
@@ -217,14 +217,15 @@ func searchCurrentHidden(
 			model.RoleAssistant,
 			model.RoleTool,
 		},
-		CreatedBefore: &cutoff,
+		CreatedBefore: ptrTime(boundary.CutoffTime()),
 		SearchMode:    normalizeSearchMode(req.SearchMode),
 	}
 	results, err := searchWithFallback(ctx, searchable, searchReq)
+	results = filterCurrentHiddenResults(inv.Session, boundary, results)
 	if err != nil || len(results) > 0 {
 		return results, err
 	}
-	return searchCurrentHiddenBySessionScan(ctx, inv, req, cutoff)
+	return searchCurrentHiddenBySessionScan(ctx, inv, req, boundary)
 }
 
 func searchOtherSessions(
@@ -422,23 +423,23 @@ func searchCurrentSessionByScan(
 	inv *agent.Invocation,
 	req *SearchSessionRequest,
 ) ([]session.EventSearchResult, error) {
-	return searchCurrentSessionScan(ctx, inv, req, time.Time{})
+	return searchCurrentSessionScan(ctx, inv, req, nil)
 }
 
 func searchCurrentHiddenBySessionScan(
 	ctx context.Context,
 	inv *agent.Invocation,
 	req *SearchSessionRequest,
-	cutoff time.Time,
+	boundary *session.SummaryBoundary,
 ) ([]session.EventSearchResult, error) {
-	return searchCurrentSessionScan(ctx, inv, req, cutoff)
+	return searchCurrentSessionScan(ctx, inv, req, boundary)
 }
 
 func searchCurrentSessionScan(
 	ctx context.Context,
 	inv *agent.Invocation,
 	req *SearchSessionRequest,
-	cutoff time.Time,
+	boundary *session.SummaryBoundary,
 ) ([]session.EventSearchResult, error) {
 	if inv == nil || inv.Session == nil || inv.SessionService == nil {
 		return nil, nil
@@ -465,7 +466,7 @@ func searchCurrentSessionScan(
 			key,
 			query,
 			invocationFilterKey(inv),
-			cutoff,
+			boundary,
 			topK,
 		)
 		merged = mergeSearchResults(merged, matches)
@@ -487,7 +488,7 @@ func lexicalScanSessionEvents(
 	key session.Key,
 	query string,
 	filterKey string,
-	cutoff time.Time,
+	boundary *session.SummaryBoundary,
 	topK int,
 ) []session.EventSearchResult {
 	if sess == nil || strings.TrimSpace(query) == "" {
@@ -504,12 +505,25 @@ func lexicalScanSessionEvents(
 	}
 
 	results := make([]session.EventSearchResult, 0)
+	hiddenIDs, hasEventBoundary := hiddenEventIDs(sess, "")
+	if boundary != nil {
+		hiddenIDs, hasEventBoundary = hiddenEventIDs(
+			sess,
+			boundary.LastEventID,
+		)
+	}
 	for _, evt := range sess.Events {
 		if filterKey != "" && !evt.Filter(filterKey) {
 			continue
 		}
+		if hasEventBoundary {
+			if _, ok := hiddenIDs[evt.ID]; !ok {
+				continue
+			}
+		}
 		createdAt := evt.Timestamp
-		if !cutoff.IsZero() && !createdAt.IsZero() && createdAt.After(cutoff) {
+		if !hasEventBoundary &&
+			!summaryBoundaryContainsEvent(boundary, createdAt) {
 			continue
 		}
 		text, role, ok := extractSessionMessageText(evt)
@@ -545,6 +559,72 @@ func lexicalScanSessionEvents(
 		results = results[:topK]
 	}
 	return results
+}
+
+func ptrTime(value time.Time) *time.Time {
+	return &value
+}
+
+func filterCurrentHiddenResults(
+	sess *session.Session,
+	boundary *session.SummaryBoundary,
+	results []session.EventSearchResult,
+) []session.EventSearchResult {
+	if len(results) == 0 || boundary == nil {
+		return results
+	}
+	hiddenIDs, ok := hiddenEventIDs(sess, boundary.LastEventID)
+	filtered := make([]session.EventSearchResult, 0, len(results))
+	for _, result := range results {
+		eventID := strings.TrimSpace(result.Event.ID)
+		if ok {
+			if eventID == "" {
+				continue
+			}
+			if _, hidden := hiddenIDs[eventID]; hidden {
+				filtered = append(filtered, result)
+			}
+			continue
+		}
+		if summaryBoundaryContainsEvent(boundary, result.EventCreatedAt) {
+			filtered = append(filtered, result)
+		}
+	}
+	return filtered
+}
+
+func hiddenEventIDs(
+	sess *session.Session,
+	lastEventID string,
+) (map[string]struct{}, bool) {
+	lastEventID = strings.TrimSpace(lastEventID)
+	if sess == nil || lastEventID == "" {
+		return nil, false
+	}
+	hidden := make(map[string]struct{})
+	for _, evt := range sess.Events {
+		if evt.ID != "" {
+			hidden[evt.ID] = struct{}{}
+		}
+		if evt.ID == lastEventID {
+			return hidden, true
+		}
+	}
+	return nil, false
+}
+
+func summaryBoundaryContainsEvent(
+	boundary *session.SummaryBoundary,
+	createdAt time.Time,
+) bool {
+	if boundary == nil {
+		return true
+	}
+	cutoff := boundary.CutoffTime()
+	if cutoff.IsZero() || createdAt.IsZero() {
+		return true
+	}
+	return !createdAt.After(cutoff)
 }
 
 func invocationFilterKey(inv *agent.Invocation) string {

--- a/internal/session/tool/recall/tool_test.go
+++ b/internal/session/tool/recall/tool_test.go
@@ -286,6 +286,102 @@ func TestSearchTool_CurrentHiddenPrefersSummaryCutoff(
 	assert.Equal(t, summaryCutoff, *svc.lastSearchReq.CreatedBefore)
 }
 
+func TestSearchTool_CurrentHiddenFiltersSameTimestampAfterBoundary(
+	t *testing.T,
+) {
+	cutoff := time.Date(2025, 4, 7, 10, 0, 0, 0, time.UTC)
+	hiddenEvent := event.Event{
+		ID:        "covered",
+		Timestamp: cutoff,
+		Response: &model.Response{
+			Choices: []model.Choice{{
+				Message: model.Message{
+					Role:    model.RoleUser,
+					Content: "hidden budget detail",
+				},
+			}},
+		},
+	}
+	visibleEvent := event.Event{
+		ID:        "visible",
+		Timestamp: cutoff,
+		Response: &model.Response{
+			Choices: []model.Choice{{
+				Message: model.Message{
+					Role:    model.RoleUser,
+					Content: "visible budget detail",
+				},
+			}},
+		},
+	}
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "sess"}
+	current := session.NewSession(
+		"app",
+		"user",
+		"sess",
+		session.WithSessionSummaries(map[string]*session.Summary{
+			"": {
+				Summary: "summary",
+				Boundary: session.NewSummaryBoundaryWithEventID(
+					"",
+					cutoff,
+					"covered",
+				),
+			},
+		}),
+	)
+	current.Events = []event.Event{hiddenEvent, visibleEvent}
+	svc := &mockSessionService{
+		Service: sessioninmemory.NewSessionService(),
+		searchResults: []session.EventSearchResult{
+			{
+				SessionKey:       key,
+				EventCreatedAt:   cutoff,
+				Event:            visibleEvent,
+				Role:             model.RoleUser,
+				Text:             "visible budget detail",
+				Score:            0.9,
+				SessionCreatedAt: current.CreatedAt,
+			},
+			{
+				SessionKey:       key,
+				EventCreatedAt:   cutoff,
+				Event:            hiddenEvent,
+				Role:             model.RoleUser,
+				Text:             "hidden budget detail",
+				Score:            0.8,
+				SessionCreatedAt: current.CreatedAt,
+			},
+		},
+		window: &session.EventWindow{
+			SessionKey:    key,
+			AnchorEventID: "covered",
+			Entries: []session.EventWindowEntry{
+				{
+					Event:     hiddenEvent,
+					CreatedAt: cutoff,
+				},
+			},
+		},
+	}
+	inv := &agent.Invocation{Session: current, SessionService: svc}
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+
+	args, err := json.Marshal(&SearchSessionRequest{
+		Query: "budget detail",
+		Scope: ScopeCurrentHidden,
+	})
+	require.NoError(t, err)
+
+	result, err := NewSearchTool().Call(ctx, args)
+	require.NoError(t, err)
+
+	resp, ok := result.(*SearchSessionResponse)
+	require.True(t, ok)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, "covered", resp.Results[0].EventID)
+}
+
 func TestSummaryCutoffForFilterIgnoresWhitespaceSummaries(t *testing.T) {
 	updatedAt := time.Date(2025, 4, 7, 10, 0, 0, 0, time.UTC)
 	sess := session.NewSession(
@@ -469,6 +565,97 @@ func TestSearchTool_CurrentHiddenSessionScanFallback(t *testing.T) {
 	assert.Equal(t, "evt-before", resp.Results[0].EventID)
 	assert.Contains(t, resp.Results[0].Snippet, "David Hopkins")
 	assert.GreaterOrEqual(t, len(svc.searchReqs), 2)
+}
+
+func TestSearchTool_CurrentHiddenScanKeepsSameTimestampBoundary(
+	t *testing.T,
+) {
+	cutoff := time.Date(2025, 4, 7, 10, 0, 0, 0, time.UTC)
+	hiddenSession := session.NewSession("app", "user", "sess")
+	hiddenSession.Events = []event.Event{
+		{
+			ID:        "covered",
+			Timestamp: cutoff,
+			Response: &model.Response{
+				Choices: []model.Choice{{
+					Message: model.Message{
+						Role:    model.RoleUser,
+						Content: "covered budget detail",
+					},
+				}},
+			},
+		},
+		{
+			ID:        "visible",
+			Timestamp: cutoff,
+			Response: &model.Response{
+				Choices: []model.Choice{{
+					Message: model.Message{
+						Role:    model.RoleUser,
+						Content: "visible budget detail",
+					},
+				}},
+			},
+		},
+	}
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "sess"}
+	svc := &mockSessionService{
+		Service: sessioninmemory.NewSessionService(),
+		searchFunc: func(
+			req session.EventSearchRequest,
+		) ([]session.EventSearchResult, error) {
+			return nil, nil
+		},
+		getSessionFunc: func(
+			key session.Key,
+			_ ...session.Option,
+		) (*session.Session, error) {
+			return hiddenSession, nil
+		},
+		window: &session.EventWindow{
+			SessionKey:    key,
+			AnchorEventID: "covered",
+			Entries: []session.EventWindowEntry{
+				{
+					Event:     hiddenSession.Events[0],
+					CreatedAt: cutoff,
+				},
+			},
+		},
+	}
+	inv := &agent.Invocation{
+		Session: session.NewSession(
+			"app",
+			"user",
+			"sess",
+			session.WithSessionSummaries(map[string]*session.Summary{
+				"": {
+					Summary: "summary",
+					Boundary: session.NewSummaryBoundaryWithEventID(
+						"",
+						cutoff,
+						"covered",
+					),
+				},
+			}),
+		),
+		SessionService: svc,
+	}
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+
+	args, err := json.Marshal(&SearchSessionRequest{
+		Query: "budget detail",
+		Scope: ScopeCurrentHidden,
+	})
+	require.NoError(t, err)
+
+	result, err := NewSearchTool().Call(ctx, args)
+	require.NoError(t, err)
+
+	resp, ok := result.(*SearchSessionResponse)
+	require.True(t, ok)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, "covered", resp.Results[0].EventID)
 }
 
 func TestSearchTool_BroadensSparsePrimaryResults(t *testing.T) {

--- a/internal/session/tool/recall/tool_test.go
+++ b/internal/session/tool/recall/tool_test.go
@@ -216,10 +216,11 @@ func TestSearchTool_CurrentHidden(t *testing.T) {
 	)
 }
 
-func TestSearchTool_CurrentHiddenUsesLastIncludedTimestamp(
+func TestSearchTool_CurrentHiddenPrefersSummaryCutoff(
 	t *testing.T,
 ) {
 	summaryUpdatedAt := time.Date(2025, 4, 7, 10, 0, 0, 0, time.UTC)
+	summaryCutoff := summaryUpdatedAt.Add(-2 * time.Minute)
 	lastIncludedAt := summaryUpdatedAt.Add(-3 * time.Minute)
 	svc := &mockSessionService{
 		Service: sessioninmemory.NewSessionService(),
@@ -257,6 +258,7 @@ func TestSearchTool_CurrentHiddenUsesLastIncludedTimestamp(
 			"": {
 				Summary:   "summary",
 				UpdatedAt: summaryUpdatedAt,
+				Boundary:  session.NewSummaryBoundary("", summaryCutoff),
 			},
 		}),
 	)
@@ -281,7 +283,30 @@ func TestSearchTool_CurrentHiddenUsesLastIncludedTimestamp(
 	require.True(t, ok)
 	require.Len(t, resp.Results, 1)
 	require.NotNil(t, svc.lastSearchReq.CreatedBefore)
-	assert.Equal(t, lastIncludedAt, *svc.lastSearchReq.CreatedBefore)
+	assert.Equal(t, summaryCutoff, *svc.lastSearchReq.CreatedBefore)
+}
+
+func TestSummaryCutoffForFilterIgnoresWhitespaceSummaries(t *testing.T) {
+	updatedAt := time.Date(2025, 4, 7, 10, 0, 0, 0, time.UTC)
+	sess := session.NewSession(
+		"app",
+		"user",
+		"sess",
+		session.WithSessionSummaries(map[string]*session.Summary{
+			"branch": {
+				Summary:   " \t\n",
+				UpdatedAt: updatedAt,
+			},
+			session.SummaryFilterKeyAllContents: {
+				Summary:   "   ",
+				UpdatedAt: updatedAt,
+			},
+		}),
+	)
+
+	cutoff, ok := summaryCutoffForFilter(sess, "branch")
+	assert.False(t, ok)
+	assert.True(t, cutoff.IsZero())
 }
 
 func TestSearchTool_FallbackQuery(t *testing.T) {

--- a/internal/session/tool/recall/tool_test.go
+++ b/internal/session/tool/recall/tool_test.go
@@ -382,6 +382,83 @@ func TestSearchTool_CurrentHiddenFiltersSameTimestampAfterBoundary(
 	assert.Equal(t, "covered", resp.Results[0].EventID)
 }
 
+func TestSearchTool_CurrentHiddenStateFallbackKeepsEventBoundary(
+	t *testing.T,
+) {
+	cutoff := time.Date(2025, 4, 7, 10, 0, 0, 0, time.UTC)
+	hiddenEvent := event.Event{
+		ID:        "covered",
+		Timestamp: cutoff,
+		Response: &model.Response{
+			Choices: []model.Choice{{
+				Message: model.Message{
+					Role:    model.RoleUser,
+					Content: "hidden state detail",
+				},
+			}},
+		},
+	}
+	visibleEvent := event.Event{
+		ID:        "visible",
+		Timestamp: cutoff,
+		Response: &model.Response{
+			Choices: []model.Choice{{
+				Message: model.Message{
+					Role:    model.RoleUser,
+					Content: "visible state detail",
+				},
+			}},
+		},
+	}
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "sess"}
+	current := session.NewSession("app", "user", "sess")
+	current.Events = []event.Event{hiddenEvent, visibleEvent}
+	current.SetState(
+		summaryLastIncludedTsKey,
+		[]byte(cutoff.Format(time.RFC3339Nano)),
+	)
+	current.SetState(summaryLastIncludedEventIDKey, []byte("covered"))
+	svc := &mockSessionService{
+		Service: sessioninmemory.NewSessionService(),
+		searchResults: []session.EventSearchResult{
+			{
+				SessionKey:       key,
+				EventCreatedAt:   cutoff,
+				Event:            visibleEvent,
+				Role:             model.RoleUser,
+				Text:             "visible state detail",
+				Score:            0.9,
+				SessionCreatedAt: current.CreatedAt,
+			},
+			{
+				SessionKey:       key,
+				EventCreatedAt:   cutoff,
+				Event:            hiddenEvent,
+				Role:             model.RoleUser,
+				Text:             "hidden state detail",
+				Score:            0.8,
+				SessionCreatedAt: current.CreatedAt,
+			},
+		},
+	}
+	inv := &agent.Invocation{Session: current, SessionService: svc}
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+
+	args, err := json.Marshal(&SearchSessionRequest{
+		Query: "state detail",
+		Scope: ScopeCurrentHidden,
+	})
+	require.NoError(t, err)
+
+	result, err := NewSearchTool().Call(ctx, args)
+	require.NoError(t, err)
+
+	resp, ok := result.(*SearchSessionResponse)
+	require.True(t, ok)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, "covered", resp.Results[0].EventID)
+}
+
 func TestSummaryCutoffForFilterIgnoresWhitespaceSummaries(t *testing.T) {
 	updatedAt := time.Date(2025, 4, 7, 10, 0, 0, 0, time.UTC)
 	sess := session.NewSession(

--- a/internal/session/tool/recall/types.go
+++ b/internal/session/tool/recall/types.go
@@ -60,7 +60,10 @@ var (
 	errWindowUnavailable         = errors.New("session window loading is not available for this session service")
 )
 
-const summaryLastIncludedTsKey = session.SummaryLastIncludedTimestampStateKey
+const (
+	summaryLastIncludedTsKey      = session.SummaryLastIncludedTimestampStateKey
+	summaryLastIncludedEventIDKey = session.SummaryLastIncludedEventIDStateKey
+)
 
 // SearchSessionRequest is the input for session_search.
 type SearchSessionRequest struct {
@@ -317,11 +320,23 @@ func currentSummaryBoundary(
 	if boundary, ok := summaryBoundaryForFilter(inv.Session, filterKey); ok {
 		return boundary
 	}
-	cutoff := summaryCutoffFromState(inv.Session)
+	boundary := summaryBoundaryFromState(inv.Session)
+	if boundary == nil {
+		return nil
+	}
+	return boundary
+}
+
+func summaryBoundaryFromState(sess *session.Session) *session.SummaryBoundary {
+	cutoff := summaryCutoffFromState(sess)
 	if cutoff.IsZero() {
 		return nil
 	}
-	return session.NewSummaryBoundary("", cutoff)
+	return session.NewSummaryBoundaryWithEventID(
+		"",
+		cutoff,
+		summaryLastIncludedEventIDFromState(sess),
+	)
 }
 
 func summaryCutoffFromState(sess *session.Session) time.Time {
@@ -337,6 +352,17 @@ func summaryCutoffFromState(sess *session.Session) time.Time {
 		return time.Time{}
 	}
 	return parsed
+}
+
+func summaryLastIncludedEventIDFromState(sess *session.Session) string {
+	if sess == nil {
+		return ""
+	}
+	raw, ok := sess.GetState(summaryLastIncludedEventIDKey)
+	if !ok || len(raw) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(string(raw))
 }
 
 func summaryCutoffForFilter(

--- a/internal/session/tool/recall/types.go
+++ b/internal/session/tool/recall/types.go
@@ -60,7 +60,7 @@ var (
 	errWindowUnavailable         = errors.New("session window loading is not available for this session service")
 )
 
-const summaryLastIncludedTsKey = "summary:last_included_ts"
+const summaryLastIncludedTsKey = session.SummaryLastIncludedTimestampStateKey
 
 // SearchSessionRequest is the input for session_search.
 type SearchSessionRequest struct {
@@ -302,45 +302,54 @@ func currentSummaryCutoff(
 	if inv == nil || inv.Session == nil {
 		return time.Time{}
 	}
-	if raw, ok := inv.Session.GetState(summaryLastIncludedTsKey); ok && len(raw) > 0 {
-		if parsed, err := time.Parse(time.RFC3339Nano, string(raw)); err == nil {
-			return parsed
-		}
-	}
 
 	filterKey := strings.TrimSpace(inv.GetEventFilterKey())
-	inv.Session.SummariesMu.RLock()
-	defer inv.Session.SummariesMu.RUnlock()
+	if cutoff, ok := summaryCutoffForFilter(inv.Session, filterKey); ok {
+		return cutoff
+	}
+	return summaryCutoffFromState(inv.Session)
+}
 
-	if len(inv.Session.Summaries) == 0 {
+func summaryCutoffFromState(sess *session.Session) time.Time {
+	if sess == nil {
 		return time.Time{}
 	}
+	raw, ok := sess.GetState(summaryLastIncludedTsKey)
+	if !ok || len(raw) == 0 {
+		return time.Time{}
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, string(raw))
+	if err != nil {
+		return time.Time{}
+	}
+	return parsed
+}
 
-	if sum := inv.Session.Summaries[filterKey]; sum != nil && sum.Summary != "" {
-		return sum.UpdatedAt
+func summaryCutoffForFilter(
+	sess *session.Session,
+	filterKey string,
+) (time.Time, bool) {
+	sess.SummariesMu.RLock()
+	defer sess.SummariesMu.RUnlock()
+
+	if len(sess.Summaries) == 0 {
+		return time.Time{}, false
+	}
+
+	if sum := sess.Summaries[filterKey]; sum != nil &&
+		strings.TrimSpace(sum.Summary) != "" {
+		return sum.CutoffTime(), true
 	}
 	if filterKey != "" {
-		var latest time.Time
-		prefix := filterKey + event.FilterKeyDelimiter
-		for key, sum := range inv.Session.Summaries {
-			if sum == nil || sum.Summary == "" {
-				continue
-			}
-			if key != filterKey && !strings.HasPrefix(key, prefix) {
-				continue
-			}
-			if sum.UpdatedAt.After(latest) {
-				latest = sum.UpdatedAt
-			}
-		}
-		if !latest.IsZero() {
-			return latest
+		if cutoff, ok := session.SummaryPrefixCutoff(sess.Summaries, filterKey); ok {
+			return cutoff, true
 		}
 	}
-	if sum := inv.Session.Summaries[session.SummaryFilterKeyAllContents]; sum != nil && sum.Summary != "" {
-		return sum.UpdatedAt
+	if sum := sess.Summaries[session.SummaryFilterKeyAllContents]; sum != nil &&
+		strings.TrimSpace(sum.Summary) != "" {
+		return sum.CutoffTime(), true
 	}
-	return time.Time{}
+	return time.Time{}, false
 }
 
 func extractSessionMessageText(

--- a/internal/session/tool/recall/types.go
+++ b/internal/session/tool/recall/types.go
@@ -299,15 +299,29 @@ func normalizeWindowSize(
 func currentSummaryCutoff(
 	inv *agent.Invocation,
 ) time.Time {
+	boundary := currentSummaryBoundary(inv)
+	if boundary != nil {
+		return boundary.CutoffTime()
+	}
+	return time.Time{}
+}
+
+func currentSummaryBoundary(
+	inv *agent.Invocation,
+) *session.SummaryBoundary {
 	if inv == nil || inv.Session == nil {
-		return time.Time{}
+		return nil
 	}
 
 	filterKey := strings.TrimSpace(inv.GetEventFilterKey())
-	if cutoff, ok := summaryCutoffForFilter(inv.Session, filterKey); ok {
-		return cutoff
+	if boundary, ok := summaryBoundaryForFilter(inv.Session, filterKey); ok {
+		return boundary
 	}
-	return summaryCutoffFromState(inv.Session)
+	cutoff := summaryCutoffFromState(inv.Session)
+	if cutoff.IsZero() {
+		return nil
+	}
+	return session.NewSummaryBoundary("", cutoff)
 }
 
 func summaryCutoffFromState(sess *session.Session) time.Time {
@@ -329,27 +343,44 @@ func summaryCutoffForFilter(
 	sess *session.Session,
 	filterKey string,
 ) (time.Time, bool) {
+	boundary, ok := summaryBoundaryForFilter(sess, filterKey)
+	if !ok {
+		return time.Time{}, false
+	}
+	return boundary.CutoffTime(), true
+}
+
+func summaryBoundaryForFilter(
+	sess *session.Session,
+	filterKey string,
+) (*session.SummaryBoundary, bool) {
+	if sess == nil {
+		return nil, false
+	}
 	sess.SummariesMu.RLock()
 	defer sess.SummariesMu.RUnlock()
 
 	if len(sess.Summaries) == 0 {
-		return time.Time{}, false
+		return nil, false
 	}
 
 	if sum := sess.Summaries[filterKey]; sum != nil &&
 		strings.TrimSpace(sum.Summary) != "" {
-		return sum.CutoffTime(), true
+		return sum.CutoffBoundary(), true
 	}
 	if filterKey != "" {
-		if cutoff, ok := session.SummaryPrefixCutoff(sess.Summaries, filterKey); ok {
-			return cutoff, true
+		if boundary, ok := session.SummaryPrefixBoundary(
+			sess.Summaries,
+			filterKey,
+		); ok {
+			return boundary, true
 		}
 	}
 	if sum := sess.Summaries[session.SummaryFilterKeyAllContents]; sum != nil &&
 		strings.TrimSpace(sum.Summary) != "" {
-		return sum.CutoffTime(), true
+		return sum.CutoffBoundary(), true
 	}
-	return time.Time{}, false
+	return nil, false
 }
 
 func extractSessionMessageText(

--- a/openclaw/conversation/history.go
+++ b/openclaw/conversation/history.go
@@ -614,7 +614,7 @@ func sessionSummary(
 	if text == "" {
 		return "", time.Time{}, false
 	}
-	return text, sum.UpdatedAt, true
+	return text, sum.CutoffTime(), true
 }
 
 func speakerLabel(

--- a/openclaw/conversation/history.go
+++ b/openclaw/conversation/history.go
@@ -54,22 +54,22 @@ func BuildInjectedContextMessages(
 		return nil
 	}
 	out := make([]model.Message, 0, opts.MaxHistoryRuns+1)
-	var since time.Time
+	var boundary *session.SummaryBoundary
 	if opts.AddSessionSummary {
-		if text, updatedAt, ok := sessionSummary(sess); ok {
+		if text, sumBoundary, ok := sessionSummary(sess); ok {
 			out = append(
 				out,
 				model.NewSystemMessage(
 					formatSummary(text),
 				),
 			)
-			since = updatedAt
+			boundary = sumBoundary
 		}
 	}
 
 	history := buildVisibleHistory(
 		sess.Events,
-		since,
+		boundary,
 		normalizeActorLabels(opts.LabelOverrides),
 	)
 	if opts.MaxHistoryRuns > 0 && len(history) > opts.MaxHistoryRuns {
@@ -131,10 +131,24 @@ func BuildSummaryText(events []event.Event) string {
 
 func buildVisibleHistory(
 	events []event.Event,
-	since time.Time,
+	boundary *session.SummaryBoundary,
 	labelOverrides map[string]string,
 ) []model.Message {
+	if boundary != nil && strings.TrimSpace(boundary.LastEventID) != "" {
+		if history, ok := buildVisibleHistoryAfterEvent(
+			events,
+			boundary.LastEventID,
+			labelOverrides,
+		); ok {
+			return history
+		}
+	}
+
 	out := make([]model.Message, 0, len(events))
+	since := time.Time{}
+	if boundary != nil {
+		since = boundary.CutoffTime()
+	}
 	for i := range events {
 		evt := events[i]
 		if !includeEvent(evt, since) {
@@ -147,6 +161,33 @@ func buildVisibleHistory(
 		out = append(out, msgs...)
 	}
 	return out
+}
+
+func buildVisibleHistoryAfterEvent(
+	events []event.Event,
+	lastEventID string,
+	labelOverrides map[string]string,
+) ([]model.Message, bool) {
+	out := make([]model.Message, 0, len(events))
+	var foundBoundary bool
+	for i := range events {
+		evt := events[i]
+		if !foundBoundary {
+			if evt.ID == lastEventID {
+				foundBoundary = true
+			}
+			continue
+		}
+		if !includeEvent(evt, time.Time{}) {
+			continue
+		}
+		msgs := visibleMessagesFromEvent(
+			evt,
+			labelOverrides,
+		)
+		out = append(out, msgs...)
+	}
+	return out, foundBoundary
 }
 
 func buildTurns(
@@ -600,21 +641,21 @@ func messageText(msg model.Message) string {
 
 func sessionSummary(
 	sess *session.Session,
-) (string, time.Time, bool) {
+) (string, *session.SummaryBoundary, bool) {
 	sess.SummariesMu.RLock()
 	defer sess.SummariesMu.RUnlock()
 	if sess.Summaries == nil {
-		return "", time.Time{}, false
+		return "", nil, false
 	}
 	sum := sess.Summaries[session.SummaryFilterKeyAllContents]
 	if sum == nil {
-		return "", time.Time{}, false
+		return "", nil, false
 	}
 	text := strings.TrimSpace(sum.Summary)
 	if text == "" {
-		return "", time.Time{}, false
+		return "", nil, false
 	}
-	return text, sum.CutoffTime(), true
+	return text, sum.CutoffBoundary(), true
 }
 
 func speakerLabel(

--- a/openclaw/conversation/history_test.go
+++ b/openclaw/conversation/history_test.go
@@ -133,7 +133,11 @@ func TestBuildInjectedContextMessages(t *testing.T) {
 		Summaries: map[string]*session.Summary{
 			session.SummaryFilterKeyAllContents: {
 				Summary:   "older history",
-				UpdatedAt: base,
+				UpdatedAt: base.Add(3 * time.Minute),
+				Boundary: session.NewSummaryBoundary(
+					session.SummaryFilterKeyAllContents,
+					base,
+				),
 			},
 		},
 		Events: []event.Event{
@@ -559,7 +563,7 @@ func TestHistoryHelpers_RenderAndFilter(t *testing.T) {
 	text, updatedAt, ok := sessionSummary(sess)
 	require.True(t, ok)
 	require.Equal(t, "summary", text)
-	require.Equal(t, base, updatedAt)
+	require.True(t, updatedAt.Equal(base))
 }
 
 func TestBuildSummaryText(t *testing.T) {

--- a/openclaw/conversation/history_test.go
+++ b/openclaw/conversation/history_test.go
@@ -177,6 +177,73 @@ func TestBuildInjectedContextMessages(t *testing.T) {
 	require.Equal(t, "latest answer", got[2].Content)
 }
 
+func TestBuildInjectedContextMessagesKeepsSameTimestampAfterBoundary(
+	t *testing.T,
+) {
+	base := time.Now().Add(-10 * time.Minute).UTC()
+	sess := &session.Session{
+		Summaries: map[string]*session.Summary{
+			session.SummaryFilterKeyAllContents: {
+				Summary: "older history",
+				Boundary: session.NewSummaryBoundaryWithEventID(
+					session.SummaryFilterKeyAllContents,
+					base,
+					"covered",
+				),
+			},
+		},
+		Events: []event.Event{
+			userEvent("u1", "Alice", "covered", base),
+			userEvent("u2", "Bob", "same timestamp visible", base),
+			assistantEvent("later answer", base.Add(time.Minute)),
+		},
+	}
+	sess.Events[0].ID = "covered"
+	sess.Events[1].ID = "visible"
+	sess.Events[2].ID = "later"
+
+	got := BuildInjectedContextMessages(sess, HistoryOptions{
+		AddSessionSummary: true,
+		MaxHistoryRuns:    10,
+	})
+
+	require.Len(t, got, 3)
+	require.Equal(t, model.RoleSystem, got[0].Role)
+	require.Contains(t, got[1].Content, "same timestamp visible")
+	require.Equal(t, "later answer", got[2].Content)
+}
+
+func TestBuildInjectedContextMessagesFallsBackToTimestampBoundary(
+	t *testing.T,
+) {
+	base := time.Now().Add(-10 * time.Minute).UTC()
+	sess := &session.Session{
+		Summaries: map[string]*session.Summary{
+			session.SummaryFilterKeyAllContents: {
+				Summary: "older history",
+				Boundary: session.NewSummaryBoundaryWithEventID(
+					session.SummaryFilterKeyAllContents,
+					base,
+					"missing",
+				),
+			},
+		},
+		Events: []event.Event{
+			userEvent("u1", "Alice", "same timestamp", base),
+			assistantEvent("later answer", base.Add(time.Minute)),
+		},
+	}
+
+	got := BuildInjectedContextMessages(sess, HistoryOptions{
+		AddSessionSummary: true,
+		MaxHistoryRuns:    10,
+	})
+
+	require.Len(t, got, 2)
+	require.Equal(t, model.RoleSystem, got[0].Role)
+	require.Equal(t, "later answer", got[1].Content)
+}
+
 func TestProjectEventMessage(t *testing.T) {
 	inv := agent.NewInvocation(
 		agent.WithInvocationMessage(model.Message{
@@ -560,10 +627,10 @@ func TestHistoryHelpers_RenderAndFilter(t *testing.T) {
 			},
 		},
 	}
-	text, updatedAt, ok := sessionSummary(sess)
+	text, boundary, ok := sessionSummary(sess)
 	require.True(t, ok)
 	require.Equal(t, "summary", text)
-	require.True(t, updatedAt.Equal(base))
+	require.True(t, boundary.CutoffTime().Equal(base))
 }
 
 func TestBuildSummaryText(t *testing.T) {
@@ -782,10 +849,10 @@ func TestHistoryHelpers_SystemTurnsAndSummary(t *testing.T) {
 	}
 	require.Equal(t, "hello", messageText(msg))
 
-	text, ts, ok := sessionSummary(&session.Session{})
+	text, boundary, ok := sessionSummary(&session.Session{})
 	require.False(t, ok)
 	require.Empty(t, text)
-	require.True(t, ts.IsZero())
+	require.Nil(t, boundary)
 
 	sess := &session.Session{
 		Summaries: map[string]*session.Summary{

--- a/session/clickhouse/init.go
+++ b/session/clickhouse/init.go
@@ -19,7 +19,9 @@ import (
 )
 
 // SQL templates for table creation (ClickHouse syntax)
-// Using ReplacingMergeTree with updated_at as version column for deduplication.
+// Most tables use updated_at as the ReplacingMergeTree version column. Session
+// summaries keep updated_at as the semantic summary cutoff and use version_at
+// only for replacement ordering.
 // Partition by (app_name, cityHash64(user_id) % 64) for user-centric query optimization.
 // CRITICAL: deleted_at is NOT included in ORDER BY to allow ReplacingMergeTree to collapse deleted records.
 const (
@@ -65,9 +67,10 @@ const (
 			summary     JSON,
 			created_at  DateTime64(6),
 			updated_at  DateTime64(6),
+			version_at  DateTime64(9),
 			expires_at  Nullable(DateTime64(6)),
 			deleted_at  Nullable(DateTime64(6))
-		) ENGINE = ReplacingMergeTree(updated_at)
+		) ENGINE = ReplacingMergeTree(version_at)
 		PARTITION BY (app_name, cityHash64(user_id) % 64)
 		ORDER BY (app_name, user_id, session_id, filter_key)
 		SETTINGS allow_nullable_key = 1`

--- a/session/clickhouse/service.go
+++ b/session/clickhouse/service.go
@@ -981,11 +981,11 @@ func (s *Service) softDeleteSessionSummaries(ctx context.Context, key session.Ke
 
 	if len(summaries) > 0 {
 		err = s.chClient.BatchInsert(ctx,
-			fmt.Sprintf(`INSERT INTO %s (app_name, user_id, session_id, filter_key, summary, created_at, updated_at, deleted_at)`,
+			fmt.Sprintf(`INSERT INTO %s (app_name, user_id, session_id, filter_key, summary, created_at, updated_at, version_at, deleted_at)`,
 				s.tableSessionSummaries),
 			func(batch driver.Batch) error {
 				for _, sum := range summaries {
-					if err := batch.Append(key.AppName, key.UserID, key.SessionID, sum.filterKey, sum.summaryData, sum.createdAt, now, now); err != nil {
+					if err := batch.Append(key.AppName, key.UserID, key.SessionID, sum.filterKey, sum.summaryData, sum.createdAt, sum.updatedAt, now, now); err != nil {
 						return err
 					}
 				}

--- a/session/clickhouse/summary.go
+++ b/session/clickhouse/summary.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"time"
 
+	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	isummary "trpc.group/trpc-go/trpc-agent-go/session/internal/summary"
 )
@@ -60,27 +61,136 @@ func (s *Service) CreateSessionSummary(
 	if err != nil {
 		return fmt.Errorf("marshal summary failed: %w", err)
 	}
+	stale, err := s.summaryWriteIsStale(
+		ctx,
+		key,
+		filterKey,
+		sess.CreatedAt,
+		summary,
+		sess.Events,
+	)
+	if err != nil {
+		return fmt.Errorf("check existing summary failed: %w", err)
+	}
+	if stale {
+		return nil
+	}
 
 	// Note: expires_at is set to NULL - summaries are bound to session
 	// lifecycle and will be deleted when session is deleted or expires.
-	now := time.Now()
-	// Summary.UpdatedAt stores the event cutoff. Use a separate write timestamp
-	// for ReplacingMergeTree's version column so same-timestamp event cutoffs
-	// that only advance by Boundary.LastEventID still replace deterministically.
-	writeVersion := now
-	if !summary.UpdatedAt.IsZero() && !writeVersion.After(summary.UpdatedAt) {
-		writeVersion = summary.UpdatedAt.Add(time.Nanosecond)
-	}
+	now := time.Now().UTC()
+	updatedAt := summaryUpdatedAt(summary, now)
 	err = s.chClient.Exec(ctx,
-		fmt.Sprintf(`INSERT INTO %s (app_name, user_id, session_id, filter_key, summary, created_at, updated_at, expires_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?)`, s.tableSessionSummaries),
-		key.AppName, key.UserID, key.SessionID, filterKey, string(summaryBytes), now, writeVersion, nil)
+		fmt.Sprintf(`INSERT INTO %s (app_name, user_id, session_id, filter_key, summary, created_at, updated_at, version_at, expires_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`, s.tableSessionSummaries),
+		key.AppName, key.UserID, key.SessionID, filterKey, string(summaryBytes), now, updatedAt, now, nil)
 
 	if err != nil {
 		return fmt.Errorf("upsert summary failed: %w", err)
 	}
 
 	return nil
+}
+
+func summaryUpdatedAt(summary *session.Summary, fallback time.Time) time.Time {
+	if summary == nil {
+		return fallback.UTC()
+	}
+	if cutoff := summary.CutoffTime(); !cutoff.IsZero() {
+		return cutoff.UTC()
+	}
+	return fallback.UTC()
+}
+
+func (s *Service) summaryWriteIsStale(
+	ctx context.Context,
+	key session.Key,
+	filterKey string,
+	sessionCreatedAt time.Time,
+	next *session.Summary,
+	events []event.Event,
+) (bool, error) {
+	current, err := s.getPersistedSummary(ctx, key, filterKey, sessionCreatedAt)
+	if err != nil || current == nil {
+		return false, err
+	}
+	return summaryBoundaryBefore(next, current, events), nil
+}
+
+func (s *Service) getPersistedSummary(
+	ctx context.Context,
+	key session.Key,
+	filterKey string,
+	sessionCreatedAt time.Time,
+) (*session.Summary, error) {
+	rows, err := s.chClient.Query(ctx,
+		fmt.Sprintf(`SELECT summary FROM %s FINAL
+			WHERE app_name = ? AND user_id = ? AND session_id = ? AND filter_key = ?
+			AND updated_at >= ?
+			AND (expires_at IS NULL OR expires_at > ?)
+			AND deleted_at IS NULL`, s.tableSessionSummaries),
+		key.AppName, key.UserID, key.SessionID, filterKey, sessionCreatedAt, time.Now())
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	if !rows.Next() {
+		return nil, nil
+	}
+	var summaryBytes []byte
+	if err := rows.Scan(&summaryBytes); err != nil {
+		return nil, err
+	}
+	var sum session.Summary
+	if err := json.Unmarshal(summaryBytes, &sum); err != nil {
+		return nil, err
+	}
+	return &sum, nil
+}
+
+func summaryBoundaryBefore(
+	next *session.Summary,
+	current *session.Summary,
+	events []event.Event,
+) bool {
+	if next == nil || current == nil {
+		return false
+	}
+	nextBoundary := next.CutoffBoundary()
+	currentBoundary := current.CutoffBoundary()
+	if nextBoundary == nil || currentBoundary == nil {
+		return false
+	}
+	nextCutoff := nextBoundary.CutoffTime()
+	currentCutoff := currentBoundary.CutoffTime()
+	if nextCutoff.IsZero() || currentCutoff.IsZero() {
+		return false
+	}
+	if nextCutoff.Before(currentCutoff) {
+		return true
+	}
+	if nextCutoff.After(currentCutoff) {
+		return false
+	}
+	nextIndex, nextOK := summaryBoundaryEventIndex(events, nextBoundary)
+	currentIndex, currentOK := summaryBoundaryEventIndex(events, currentBoundary)
+	return nextOK && currentOK && nextIndex < currentIndex
+}
+
+func summaryBoundaryEventIndex(
+	events []event.Event,
+	boundary *session.SummaryBoundary,
+) (int, bool) {
+	if boundary == nil || boundary.LastEventID == "" {
+		return 0, false
+	}
+	for i := range events {
+		if events[i].ID == boundary.LastEventID {
+			return i, true
+		}
+	}
+	return 0, false
 }
 
 // EnqueueSummaryJob enqueues a summary job for asynchronous processing.

--- a/session/clickhouse/summary.go
+++ b/session/clickhouse/summary.go
@@ -64,11 +64,17 @@ func (s *Service) CreateSessionSummary(
 	// Note: expires_at is set to NULL - summaries are bound to session
 	// lifecycle and will be deleted when session is deleted or expires.
 	now := time.Now()
-	// INSERT new version (ReplacingMergeTree will deduplicate based on updated_at).
+	// Summary.UpdatedAt stores the event cutoff. Use a separate write timestamp
+	// for ReplacingMergeTree's version column so same-timestamp event cutoffs
+	// that only advance by Boundary.LastEventID still replace deterministically.
+	writeVersion := now
+	if !summary.UpdatedAt.IsZero() && !writeVersion.After(summary.UpdatedAt) {
+		writeVersion = summary.UpdatedAt.Add(time.Nanosecond)
+	}
 	err = s.chClient.Exec(ctx,
 		fmt.Sprintf(`INSERT INTO %s (app_name, user_id, session_id, filter_key, summary, created_at, updated_at, expires_at)
 			VALUES (?, ?, ?, ?, ?, ?, ?, ?)`, s.tableSessionSummaries),
-		key.AppName, key.UserID, key.SessionID, filterKey, string(summaryBytes), now, summary.UpdatedAt, nil)
+		key.AppName, key.UserID, key.SessionID, filterKey, string(summaryBytes), now, writeVersion, nil)
 
 	if err != nil {
 		return fmt.Errorf("upsert summary failed: %w", err)

--- a/session/clickhouse/summary_test.go
+++ b/session/clickhouse/summary_test.go
@@ -174,12 +174,13 @@ func TestService_CreateSessionSummary_NoTTL(t *testing.T) {
 	assert.NoError(t, err)
 	s.chClient = mockCli
 
+	eventTime := time.Now().UTC().Add(-time.Minute)
 	sess := &session.Session{
 		ID:        "sess1",
 		AppName:   "app1",
 		UserID:    "user1",
 		Summaries: make(map[string]*session.Summary),
-		Events:    []event.Event{{ID: "1"}},
+		Events:    []event.Event{{ID: "1", Timestamp: eventTime}},
 	}
 
 	mockSum.summarizeFunc = func(ctx context.Context, sess *session.Session) (string, error) {
@@ -192,21 +193,63 @@ func TestService_CreateSessionSummary_NoTTL(t *testing.T) {
 		execCalled = true
 		assert.Contains(t, query, "INSERT INTO session_summaries")
 		// expires_at should be nil (last argument)
-		assert.Len(t, args, 8)
+		assert.Len(t, args, 9)
 		summary := sess.Summaries["key"]
 		if assert.NotNil(t, summary) {
-			writeVersion, ok := args[6].(time.Time)
+			updatedAt, ok := args[6].(time.Time)
 			if assert.True(t, ok) {
-				assert.True(t, writeVersion.After(summary.UpdatedAt))
+				assert.True(t, updatedAt.Equal(summary.CutoffTime()))
+			}
+			writeVersion, ok := args[7].(time.Time)
+			if assert.True(t, ok) {
+				assert.True(t, writeVersion.After(summary.CutoffTime()))
 			}
 		}
-		assert.Nil(t, args[7]) // expires_at should be nil
+		assert.Nil(t, args[8]) // expires_at should be nil
 		return nil
 	}
 
 	err = s.CreateSessionSummary(context.Background(), sess, "key", true)
 	assert.NoError(t, err)
 	assert.True(t, execCalled)
+}
+
+func TestSummaryBoundaryBefore(t *testing.T) {
+	cutoff := time.Now().UTC()
+	events := []event.Event{
+		{ID: "event-1", Timestamp: cutoff},
+		{ID: "event-2", Timestamp: cutoff},
+	}
+	current := &session.Summary{
+		Summary:   "current",
+		UpdatedAt: cutoff,
+		Boundary: session.NewSummaryBoundaryWithEventID(
+			"key",
+			cutoff,
+			"event-2",
+		),
+	}
+	olderEvent := &session.Summary{
+		Summary:   "older",
+		UpdatedAt: cutoff,
+		Boundary: session.NewSummaryBoundaryWithEventID(
+			"key",
+			cutoff,
+			"event-1",
+		),
+	}
+	laterCutoff := &session.Summary{
+		Summary:   "later",
+		UpdatedAt: cutoff.Add(time.Second),
+		Boundary: session.NewSummaryBoundaryWithEventID(
+			"key",
+			cutoff.Add(time.Second),
+			"event-3",
+		),
+	}
+
+	assert.True(t, summaryBoundaryBefore(olderEvent, current, events))
+	assert.False(t, summaryBoundaryBefore(laterCutoff, current, events))
 }
 
 func TestService_CreateSessionSummary_FilterAllowlistSkipsDisallowedKey(t *testing.T) {

--- a/session/clickhouse/summary_test.go
+++ b/session/clickhouse/summary_test.go
@@ -128,7 +128,10 @@ func TestService_CreateSessionSummary_Error(t *testing.T) {
 		AppName:   "app1",
 		UserID:    "user1",
 		Summaries: make(map[string]*session.Summary),
-		Events:    []event.Event{{ID: "1"}},
+		Events: []event.Event{{
+			ID:        "1",
+			Timestamp: time.Now().Add(time.Hour),
+		}},
 	}
 
 	// Case 1: Summarize failed
@@ -190,6 +193,13 @@ func TestService_CreateSessionSummary_NoTTL(t *testing.T) {
 		assert.Contains(t, query, "INSERT INTO session_summaries")
 		// expires_at should be nil (last argument)
 		assert.Len(t, args, 8)
+		summary := sess.Summaries["key"]
+		if assert.NotNil(t, summary) {
+			writeVersion, ok := args[6].(time.Time)
+			if assert.True(t, ok) {
+				assert.True(t, writeVersion.After(summary.UpdatedAt))
+			}
+		}
 		assert.Nil(t, args[7]) // expires_at should be nil
 		return nil
 	}

--- a/session/inmemory/service.go
+++ b/session/inmemory/service.go
@@ -141,8 +141,9 @@ func cloneSessionListMetadata(sess *session.Session) *session.Session {
 			if sum == nil {
 				continue
 			}
-			copied := *sum
-			copiedSess.Summaries[key] = &copied
+			if copied := sum.Clone(); copied != nil {
+				copiedSess.Summaries[key] = copied
+			}
 		}
 	}
 	sess.SummariesMu.RUnlock()

--- a/session/inmemory/service_test.go
+++ b/session/inmemory/service_test.go
@@ -506,6 +506,19 @@ func TestListSessions_WithListSessionOnlyMeta(t *testing.T) {
 
 	sess, err := service.CreateSession(ctx, key, session.StateMap{"session_key": []byte("session_value")})
 	require.NoError(t, err)
+	app, ok := service.getAppSessions(key.AppName)
+	require.True(t, ok)
+	app.mu.Lock()
+	stored := app.sessions[key.UserID][key.SessionID].session
+	stored.SummariesMu.Lock()
+	stored.Summaries = map[string]*session.Summary{
+		"nil": nil,
+		"valid": {
+			Summary: "summary",
+		},
+	}
+	stored.SummariesMu.Unlock()
+	app.mu.Unlock()
 
 	evt := event.New("test-invocation", "author")
 	evt.Response = &model.Response{
@@ -536,6 +549,9 @@ func TestListSessions_WithListSessionOnlyMeta(t *testing.T) {
 	assert.Equal(t, key.SessionID, got.ID)
 	assert.False(t, got.CreatedAt.IsZero())
 	assert.False(t, got.UpdatedAt.IsZero())
+	require.Len(t, got.Summaries, 1)
+	assert.NotContains(t, got.Summaries, "nil")
+	assert.Equal(t, "summary", got.Summaries["valid"].Summary)
 }
 
 func TestListSessions_WithListSessionPage(t *testing.T) {

--- a/session/inmemory/summary.go
+++ b/session/inmemory/summary.go
@@ -83,8 +83,7 @@ func (s *SessionService) writeSummaryUnderLock(app *appSessions, key session.Key
 		cur.Summaries = make(map[string]*session.Summary)
 	}
 	// Copy the summary to preserve UpdatedAt calculated by isummary.SummarizeSession.
-	sumCopy := *sum
-	cur.Summaries[filterKey] = &sumCopy
+	cur.Summaries[filterKey] = sum.Clone()
 	cur.UpdatedAt = sum.UpdatedAt
 	swt.session = cur
 	swt.expiredAt = calculateExpiredAt(s.opts.sessionTTL)

--- a/session/internal/summary/summary.go
+++ b/session/internal/summary/summary.go
@@ -26,10 +26,10 @@ import (
 // authorSystem is the system author.
 const authorSystem = "system"
 
-// computeDeltaSince returns events that occurred strictly after the given
-// time and match the filterKey, along with the latest event timestamp among
-// the returned events. When since is zero, all events are considered. When
-// filterKey is empty, all events are considered (no filtering).
+// computeDeltaSince returns events that occurred strictly after the given time
+// and match the filterKey, along with the latest event timestamp among the
+// returned events. When since is zero, all events are considered. When filterKey
+// is empty, all events are considered.
 func computeDeltaSince(sess *session.Session, since time.Time, filterKey string) ([]event.Event, time.Time) {
 	sess.EventMu.RLock()
 	defer sess.EventMu.RUnlock()
@@ -50,6 +50,82 @@ func computeDeltaSince(sess *session.Session, since time.Time, filterKey string)
 		}
 	}
 	return out, latest
+}
+
+// computeDeltaAfterBoundary returns events after the structural summary
+// boundary. Exact boundaries use event order, while legacy timestamp-only
+// boundaries keep same-timestamp events to avoid dropping uncovered history.
+func computeDeltaAfterBoundary(
+	sess *session.Session,
+	boundary *session.SummaryBoundary,
+	filterKey string,
+) ([]event.Event, *session.SummaryBoundary) {
+	sess.EventMu.RLock()
+	defer sess.EventMu.RUnlock()
+
+	startIndex := deltaStartIndex(sess.Events, boundary)
+	out := make([]event.Event, 0, len(sess.Events))
+	var latest *session.SummaryBoundary
+	for i, e := range sess.Events {
+		if !eventAfterBoundaryIndex(i, e, startIndex, boundary) {
+			continue
+		}
+		if filterKey != "" && !e.Filter(filterKey) {
+			continue
+		}
+		out = append(out, e)
+		latest = laterBoundary(filterKey, latest, e)
+	}
+	return out, latest
+}
+
+func deltaStartIndex(
+	events []event.Event,
+	boundary *session.SummaryBoundary,
+) int {
+	if boundary == nil || boundary.LastEventID == "" {
+		return -1
+	}
+	for i, e := range events {
+		if e.ID == boundary.LastEventID {
+			return i + 1
+		}
+	}
+	return -1
+}
+
+func eventAfterBoundaryIndex(
+	index int,
+	evt event.Event,
+	startIndex int,
+	boundary *session.SummaryBoundary,
+) bool {
+	if startIndex >= 0 {
+		return index >= startIndex
+	}
+	if boundary == nil {
+		return true
+	}
+	cutoff := boundary.CutoffTime()
+	if cutoff.IsZero() {
+		return true
+	}
+	return !evt.Timestamp.Before(cutoff)
+}
+
+func laterBoundary(
+	filterKey string,
+	current *session.SummaryBoundary,
+	evt event.Event,
+) *session.SummaryBoundary {
+	if current != nil && evt.Timestamp.Before(current.CutoffAt) {
+		return current
+	}
+	return session.NewSummaryBoundaryWithEventID(
+		filterKey,
+		evt.Timestamp,
+		evt.ID,
+	)
 }
 
 // prependPrevSummary returns a new slice that prepends the previous summary as
@@ -133,26 +209,34 @@ func SummarizeSession(
 		return false, nil
 	}
 
-	updatedAt := selectUpdatedAt(
+	boundary := selectSummaryBoundary(
 		input.session,
-		prev.updatedAt,
-		input.latestEventTime,
+		filterKey,
+		prev.boundary,
+		input.latestBoundary,
 		input.hasDelta,
 	)
-	writeSummary(base, filterKey, text, updatedAt)
+	updatedAt := boundary.CutoffTime()
+	writeSummary(
+		base,
+		filterKey,
+		text,
+		updatedAt,
+		boundary,
+	)
 	return true, nil
 }
 
 type previousSummary struct {
 	text             string
-	updatedAt        time.Time
+	boundary         *session.SummaryBoundary
 	needsPersistOnly bool
 }
 
 type summaryInput struct {
-	session         *session.Session
-	latestEventTime time.Time
-	hasDelta        bool
+	session        *session.Session
+	latestBoundary *session.SummaryBoundary
+	hasDelta       bool
 }
 
 // readPreviousSummary returns the current summary state for filterKey.
@@ -168,23 +252,56 @@ func readPreviousSummary(base *session.Session, filterKey string) previousSummar
 		return prev
 	}
 	prev.text = s.Summary
-	prev.updatedAt = s.UpdatedAt
+	prev.boundary = s.CutoffBoundary()
 	// Zero UpdatedAt indicates summary was copied and needs persistence.
-	prev.needsPersistOnly = prev.text != "" && prev.updatedAt.IsZero()
+	prev.needsPersistOnly = prev.text != "" && s.UpdatedAt.IsZero()
 	return prev
 }
 
 // persistCopiedSummary marks a copied in-memory summary as persisted-ready.
 func persistCopiedSummary(base *session.Session, filterKey string) {
-	_, latestTs := computeDeltaSince(base, time.Time{}, filterKey)
-	if latestTs.IsZero() {
-		latestTs = time.Now()
+	summary := readSummaryClone(base, filterKey)
+	if summary == nil {
+		return
+	}
+	boundary := summary.CutoffBoundary()
+	updatedAt := time.Time{}
+	if boundary != nil {
+		updatedAt = boundary.CutoffTime()
+	}
+	if updatedAt.IsZero() {
+		_, latestTs := computeDeltaSince(base, time.Time{}, filterKey)
+		updatedAt = latestTs
+	}
+	if updatedAt.IsZero() {
+		updatedAt = time.Now()
+	}
+	if boundary == nil {
+		boundary = session.NewSummaryBoundary(filterKey, updatedAt)
+	} else {
+		boundary.FilterKey = filterKey
+		if boundary.CutoffAt.IsZero() {
+			boundary.CutoffAt = updatedAt.UTC()
+		}
 	}
 	base.SummariesMu.Lock()
 	defer base.SummariesMu.Unlock()
 	if base.Summaries != nil && base.Summaries[filterKey] != nil {
-		base.Summaries[filterKey].UpdatedAt = latestTs.UTC()
+		base.Summaries[filterKey].UpdatedAt = updatedAt.UTC()
+		base.Summaries[filterKey].Boundary = boundary
 	}
+}
+
+func readSummaryClone(base *session.Session, filterKey string) *session.Summary {
+	if base == nil {
+		return nil
+	}
+	base.SummariesMu.RLock()
+	defer base.SummariesMu.RUnlock()
+	if base.Summaries == nil {
+		return nil
+	}
+	return base.Summaries[filterKey].Clone()
 }
 
 // buildSummaryInput prepares the temporary session used for summary generation.
@@ -196,7 +313,7 @@ func buildSummaryInput(
 	force bool,
 	prev previousSummary,
 ) (summaryInput, bool) {
-	delta, latestTs := computeDeltaSince(base, prev.updatedAt, filterKey)
+	delta, latestBoundary := computeDeltaAfterBoundary(base, prev.boundary, filterKey)
 	if !force && len(delta) == 0 {
 		return summaryInput{}, false
 	}
@@ -206,9 +323,9 @@ func buildSummaryInput(
 		return summaryInput{}, false
 	}
 	return summaryInput{
-		session:         tmp,
-		latestEventTime: latestTs,
-		hasDelta:        len(delta) > 0,
+		session:        tmp,
+		latestBoundary: latestBoundary,
+		hasDelta:       len(delta) > 0,
 	}, true
 }
 
@@ -235,7 +352,13 @@ func shouldGenerateSummary(
 }
 
 // writeSummary stores the generated summary under filterKey.
-func writeSummary(base *session.Session, filterKey, text string, updatedAt time.Time) {
+func writeSummary(
+	base *session.Session,
+	filterKey string,
+	text string,
+	updatedAt time.Time,
+	boundary *session.SummaryBoundary,
+) {
 	base.SummariesMu.Lock()
 	defer base.SummariesMu.Unlock()
 	if base.Summaries == nil {
@@ -244,24 +367,39 @@ func writeSummary(base *session.Session, filterKey, text string, updatedAt time.
 	base.Summaries[filterKey] = &session.Summary{
 		Summary:   text,
 		UpdatedAt: updatedAt,
+		Boundary:  boundary,
 	}
 }
 
 func selectUpdatedAt(tmp *session.Session, prevAt, latestTs time.Time, hasDelta bool) time.Time {
-	updatedAt := prevAt.UTC()
-	if !hasDelta || latestTs.IsZero() {
-		return updatedAt
-	}
-
-	if ts := readLastIncludedTimestamp(tmp); !ts.IsZero() {
-		return ts.UTC()
-	}
-	return latestTs.UTC()
+	prev := session.NewSummaryBoundary("", prevAt)
+	latest := session.NewSummaryBoundary("", latestTs)
+	return selectSummaryBoundary(tmp, "", prev, latest, hasDelta).CutoffTime()
 }
 
-// lastIncludedTsKey is the key for the last included timestamp.
-// This key is used to store the last included timestamp in the session state.
-const lastIncludedTsKey = "summary:last_included_ts"
+func selectSummaryBoundary(
+	tmp *session.Session,
+	filterKey string,
+	prevBoundary *session.SummaryBoundary,
+	latestBoundary *session.SummaryBoundary,
+	hasDelta bool,
+) *session.SummaryBoundary {
+	boundary := prevBoundary.Clone()
+	if boundary == nil {
+		boundary = session.NewSummaryBoundary(filterKey, time.Time{})
+	}
+	boundary.FilterKey = filterKey
+	if !hasDelta || latestBoundary == nil || latestBoundary.CutoffTime().IsZero() {
+		return boundary
+	}
+
+	if recorded := readLastIncludedBoundary(tmp, filterKey); recorded != nil {
+		return recorded
+	}
+	latest := latestBoundary.Clone()
+	latest.FilterKey = filterKey
+	return latest
+}
 
 type summaryTriggerFilterKeyContextKey struct{}
 
@@ -366,18 +504,33 @@ func summaryTriggerFilterKeyFromContext(ctx context.Context) string {
 }
 
 func readLastIncludedTimestamp(tmp *session.Session) time.Time {
-	if tmp == nil {
+	boundary := readLastIncludedBoundary(tmp, "")
+	if boundary == nil {
 		return time.Time{}
 	}
-	raw, ok := tmp.GetState(lastIncludedTsKey)
+	return boundary.CutoffTime()
+}
+
+func readLastIncludedBoundary(
+	tmp *session.Session,
+	filterKey string,
+) *session.SummaryBoundary {
+	if tmp == nil {
+		return nil
+	}
+	raw, ok := tmp.GetState(session.SummaryLastIncludedTimestampStateKey)
 	if !ok || len(raw) == 0 {
-		return time.Time{}
+		return nil
 	}
 	parsed, err := time.Parse(time.RFC3339Nano, string(raw))
 	if err != nil {
-		return time.Time{}
+		return nil
 	}
-	return parsed
+	eventID := ""
+	if rawID, ok := tmp.GetState(session.SummaryLastIncludedEventIDStateKey); ok {
+		eventID = string(rawID)
+	}
+	return session.NewSummaryBoundaryWithEventID(filterKey, parsed, eventID)
 }
 
 // meetsTimeCriteria checks if a summary meets the minimum time requirement.
@@ -488,19 +641,18 @@ func copySummaryToKey(sess *session.Session, srcKey, dstKey string) {
 	if !ok || src == nil {
 		return
 	}
-	// Copy Topics slice to avoid sharing underlying array.
-	var topics []string
-	if len(src.Topics) > 0 {
-		topics = make([]string, len(src.Topics))
-		copy(topics, src.Topics)
+	copied := src.Clone()
+	if boundary := copied.CutoffBoundary(); boundary != nil {
+		boundary.FilterKey = dstKey
+		copied.Boundary = boundary
 	}
 	// Use zero UpdatedAt to mark as needing persistence.
 	// SummarizeSession will detect this and return updated=true.
-	sess.Summaries[dstKey] = &session.Summary{
-		Summary:   src.Summary,
-		Topics:    topics,
-		UpdatedAt: time.Time{},
+	copied.UpdatedAt = time.Time{}
+	if len(copied.Topics) == 0 {
+		copied.Topics = nil
 	}
+	sess.Summaries[dstKey] = copied
 }
 
 // CreateSessionSummaryWithCascade creates one or more session summaries for the

--- a/session/internal/summary/summary_test.go
+++ b/session/internal/summary/summary_test.go
@@ -41,7 +41,10 @@ func (m *mockSummarizerWithTs) Summarize(
 	if sess.State == nil {
 		sess.State = make(session.StateMap)
 	}
-	sess.State[lastIncludedTsKey] = []byte(m.last.UTC().Format(time.RFC3339Nano))
+	sess.State[session.SummaryLastIncludedTimestampStateKey] = []byte(m.last.UTC().Format(time.RFC3339Nano))
+	if len(sess.Events) > 0 {
+		sess.State[session.SummaryLastIncludedEventIDStateKey] = []byte(sess.Events[len(sess.Events)-1].ID)
+	}
 	return "ok", nil
 }
 
@@ -80,6 +83,124 @@ func TestSummarizeSession_UsesLastIncludedTimestamp(t *testing.T) {
 	assert.True(t, sum.UpdatedAt.Equal(t2.UTC()))
 }
 
+func TestSummarizeSession_WritesSummaryBoundary(t *testing.T) {
+	t1 := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	t2 := t1.Add(time.Minute)
+	t3 := t2.Add(time.Minute)
+	sess := &session.Session{
+		ID: "s1",
+		Events: []event.Event{
+			{
+				ID:        "event-1",
+				FilterKey: "branch",
+				Timestamp: t1,
+				Response: &model.Response{Choices: []model.Choice{{Message: model.Message{
+					Role:    model.RoleUser,
+					Content: "first",
+				}}}},
+			},
+			{
+				ID:        "event-2",
+				FilterKey: "branch",
+				Timestamp: t2,
+				Response: &model.Response{Choices: []model.Choice{{Message: model.Message{
+					Role:    model.RoleAssistant,
+					Content: "second",
+				}}}},
+			},
+			{
+				ID:        "event-3",
+				FilterKey: "branch",
+				Timestamp: t3,
+				Response: &model.Response{Choices: []model.Choice{{Message: model.Message{
+					Role:    model.RoleUser,
+					Content: "recent",
+				}}}},
+			},
+		},
+	}
+
+	updated, err := SummarizeSession(
+		context.Background(),
+		&fakeSummarizerWithTs{out: "summary", ts: t2},
+		sess,
+		"branch",
+		false,
+	)
+	require.NoError(t, err)
+	require.True(t, updated)
+
+	sess.SummariesMu.RLock()
+	sum := sess.Summaries["branch"]
+	sess.SummariesMu.RUnlock()
+	require.NotNil(t, sum)
+	require.NotNil(t, sum.Boundary)
+	assert.Equal(t, session.SummaryBoundaryVersion, sum.Boundary.Version)
+	assert.Equal(t, "branch", sum.Boundary.FilterKey)
+	assert.True(t, sum.Boundary.CutoffAt.Equal(t2.UTC()))
+	assert.Equal(t, "event-2", sum.Boundary.LastEventID)
+}
+
+func TestSummarizeSession_UsesPreviousBoundaryCutoff(t *testing.T) {
+	t1 := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	t2 := t1.Add(time.Minute)
+	t3 := t2.Add(time.Minute)
+	sess := &session.Session{
+		ID: "s1",
+		Events: []event.Event{
+			{
+				ID:        "event-1",
+				Timestamp: t1,
+				Response: &model.Response{Choices: []model.Choice{{Message: model.Message{
+					Role:    model.RoleUser,
+					Content: "covered",
+				}}}},
+			},
+			{
+				ID:        "event-2",
+				Timestamp: t2,
+				Response: &model.Response{Choices: []model.Choice{{Message: model.Message{
+					Role:    model.RoleUser,
+					Content: "new delta",
+				}}}},
+			},
+		},
+		Summaries: map[string]*session.Summary{
+			"": {
+				Summary:   "old summary",
+				UpdatedAt: t3,
+				Boundary: session.NewSummaryBoundaryWithEventID(
+					"",
+					t1,
+					"event-1",
+				),
+			},
+		},
+	}
+	summarizer := &recordingThresholdSummarizer{
+		out:     "new summary",
+		checker: func(*session.Session) bool { return true },
+	}
+
+	updated, err := SummarizeSession(
+		context.Background(),
+		summarizer,
+		sess,
+		"",
+		false,
+	)
+	require.NoError(t, err)
+	require.True(t, updated)
+	assert.Equal(t, 2, summarizer.summarizedEvents)
+
+	sess.SummariesMu.RLock()
+	sum := sess.Summaries[""]
+	sess.SummariesMu.RUnlock()
+	require.NotNil(t, sum)
+	require.NotNil(t, sum.Boundary)
+	assert.True(t, sum.CutoffTime().Equal(t2.UTC()))
+}
+
 func TestSelectUpdatedAt_Fallbacks(t *testing.T) {
 	prev := time.Date(2023, 1, 2, 9, 0, 0, 0, time.UTC)
 	latest := time.Date(2023, 1, 2, 10, 0, 0, 0, time.UTC)
@@ -91,7 +212,7 @@ func TestSelectUpdatedAt_Fallbacks(t *testing.T) {
 
 	t.Run("invalid ts falls back to latest", func(t *testing.T) {
 		tmp := &session.Session{State: session.StateMap{
-			lastIncludedTsKey: []byte("bad-ts"),
+			session.SummaryLastIncludedTimestampStateKey: []byte("bad-ts"),
 		}}
 		got := selectUpdatedAt(tmp, prev, latest, true)
 		assert.True(t, got.Equal(latest.UTC()))
@@ -169,7 +290,13 @@ func (f *fakeSummarizerWithTs) Summarize(ctx context.Context, sess *session.Sess
 		sess.State = make(session.StateMap)
 	}
 	if !f.ts.IsZero() {
-		sess.State[lastIncludedTsKey] = []byte(f.ts.UTC().Format(time.RFC3339Nano))
+		sess.State[session.SummaryLastIncludedTimestampStateKey] = []byte(f.ts.UTC().Format(time.RFC3339Nano))
+		for _, e := range sess.Events {
+			if e.Timestamp.Equal(f.ts) {
+				sess.State[session.SummaryLastIncludedEventIDStateKey] = []byte(e.ID)
+				break
+			}
+		}
 	}
 	return f.out, nil
 }
@@ -220,6 +347,7 @@ func (r *recordingThresholdSummarizer) Metadata() map[string]any { return map[st
 
 func makeEvent(content string, ts time.Time, filterKey string) event.Event {
 	return event.Event{
+		ID:        content,
 		Branch:    filterKey,
 		FilterKey: filterKey,
 		Timestamp: ts,
@@ -495,6 +623,28 @@ func TestComputeDeltaSince_WithTime(t *testing.T) {
 	require.Equal(t, base.Events[2].Timestamp, latestTs)
 }
 
+func TestComputeDeltaAfterBoundary_UsesEventIDTieBreaker(t *testing.T) {
+	ts := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	base := &session.Session{ID: "s1"}
+	base.Events = []event.Event{
+		{ID: "covered", Timestamp: ts, Response: &model.Response{Choices: []model.Choice{{Message: model.Message{Content: "covered"}}}}},
+		{ID: "same-time", Timestamp: ts, Response: &model.Response{Choices: []model.Choice{{Message: model.Message{Content: "same time"}}}}},
+		{ID: "later", Timestamp: ts.Add(time.Second), Response: &model.Response{Choices: []model.Choice{{Message: model.Message{Content: "later"}}}}},
+	}
+
+	delta, latest := computeDeltaAfterBoundary(
+		base,
+		session.NewSummaryBoundaryWithEventID("", ts, "covered"),
+		"",
+	)
+
+	require.Len(t, delta, 2)
+	assert.Equal(t, "same-time", delta[0].ID)
+	assert.Equal(t, "later", delta[1].ID)
+	require.NotNil(t, latest)
+	assert.Equal(t, "later", latest.LastEventID)
+}
+
 func TestSummarizeSession_UsesLastIncludedTimestampWhenProvided(t *testing.T) {
 	now := time.Now()
 	t1 := now.Add(-3 * time.Minute)
@@ -510,7 +660,7 @@ func TestSummarizeSession_UsesLastIncludedTimestampWhenProvided(t *testing.T) {
 
 	s := &fakeSummarizerWithTs{
 		out: "sum",
-		ts:  t2, // simulate summarizer skipping the latest event and using t2 as last included
+		ts:  t2, // simulate summarizer skipping the latest event and using t2 as cutoff
 	}
 
 	updated, err := SummarizeSession(context.Background(), s, base, "", false)
@@ -1532,6 +1682,9 @@ func TestCopySummaryToKey(t *testing.T) {
 		require.Equal(t, "source summary", sess.Summaries["dst"].Summary)
 		// UpdatedAt is set to zero to mark as needing persistence.
 		require.True(t, sess.Summaries["dst"].UpdatedAt.IsZero())
+		require.NotNil(t, sess.Summaries["dst"].Boundary)
+		require.Equal(t, "dst", sess.Summaries["dst"].Boundary.FilterKey)
+		require.True(t, sess.Summaries["dst"].Boundary.CutoffAt.Equal(now.UTC()))
 	})
 
 	t.Run("overwrite existing destination", func(t *testing.T) {
@@ -1567,6 +1720,28 @@ func TestCopySummaryToKey(t *testing.T) {
 		// Verify Topics slice is a copy, not shared reference.
 		sess.Summaries["src"].Topics[0] = "modified"
 		require.Equal(t, "topic1", sess.Summaries["dst"].Topics[0])
+	})
+
+	t.Run("copies boundary and updates destination filter key", func(t *testing.T) {
+		cutoff := now.Add(-time.Minute)
+		sess := &session.Session{
+			ID: "s1",
+			Summaries: map[string]*session.Summary{
+				"src": {
+					Summary:   "summary with boundary",
+					UpdatedAt: now,
+					Boundary: session.NewSummaryBoundary(
+						"src",
+						cutoff,
+					),
+				},
+			},
+		}
+		copySummaryToKey(sess, "src", "dst")
+		require.NotNil(t, sess.Summaries["dst"])
+		require.NotNil(t, sess.Summaries["dst"].Boundary)
+		require.Equal(t, "dst", sess.Summaries["dst"].Boundary.FilterKey)
+		require.Equal(t, "src", sess.Summaries["src"].Boundary.FilterKey)
 	})
 
 	t.Run("handles nil Topics", func(t *testing.T) {
@@ -1626,6 +1801,8 @@ func TestSummarizeSession_NeedsPersistOnly(t *testing.T) {
 		require.NotNil(t, sum)
 		require.Equal(t, "copied summary", sum.Summary) // Summary unchanged.
 		require.False(t, sum.UpdatedAt.IsZero())        // UpdatedAt now set.
+		require.NotNil(t, sum.Boundary)
+		require.True(t, sum.Boundary.CutoffAt.Equal(now.Add(-1*time.Minute).UTC()))
 	})
 
 	t.Run("copied summary with no events uses current time", func(t *testing.T) {
@@ -1656,6 +1833,75 @@ func TestSummarizeSession_NeedsPersistOnly(t *testing.T) {
 			sum.UpdatedAt.Equal(before.Add(-time.Second)))
 		require.True(t, sum.UpdatedAt.Before(after.Add(time.Second)) ||
 			sum.UpdatedAt.Equal(after.Add(time.Second)))
+	})
+
+	t.Run("copied summary preserves existing boundary cutoff", func(t *testing.T) {
+		cutoff := now.Add(-2 * time.Minute)
+		base := &session.Session{
+			ID:      "s1",
+			AppName: "a",
+			UserID:  "u",
+			Events: []event.Event{
+				makeEvent("covered", cutoff, "branch"),
+				makeEvent("not covered", now.Add(-time.Minute), "branch"),
+			},
+			Summaries: map[string]*session.Summary{
+				"branch": {
+					Summary: "copied summary",
+					Boundary: session.NewSummaryBoundary(
+						"branch",
+						cutoff,
+					),
+				},
+			},
+		}
+
+		updated, err := SummarizeSession(context.Background(), nil, base, "branch", false)
+		require.NoError(t, err)
+		require.True(t, updated)
+
+		base.SummariesMu.RLock()
+		sum := base.Summaries["branch"]
+		base.SummariesMu.RUnlock()
+		require.NotNil(t, sum)
+		require.True(t, sum.UpdatedAt.Equal(cutoff.UTC()))
+		require.NotNil(t, sum.Boundary)
+		require.True(t, sum.Boundary.CutoffAt.Equal(cutoff.UTC()))
+	})
+
+	t.Run("copied summary backfills zero boundary cutoff", func(t *testing.T) {
+		latest := now.Add(-1 * time.Minute)
+		base := &session.Session{
+			ID:      "s1",
+			AppName: "a",
+			UserID:  "u",
+			Events: []event.Event{
+				makeEvent("covered", now.Add(-2*time.Minute), "branch"),
+				makeEvent("latest", latest, "branch"),
+			},
+			Summaries: map[string]*session.Summary{
+				"branch": {
+					Summary: "copied summary",
+					Boundary: &session.SummaryBoundary{
+						Version:   session.SummaryBoundaryVersion,
+						FilterKey: "old",
+					},
+				},
+			},
+		}
+
+		updated, err := SummarizeSession(context.Background(), nil, base, "branch", false)
+		require.NoError(t, err)
+		require.True(t, updated)
+
+		base.SummariesMu.RLock()
+		sum := base.Summaries["branch"]
+		base.SummariesMu.RUnlock()
+		require.NotNil(t, sum)
+		require.True(t, sum.UpdatedAt.Equal(latest.UTC()))
+		require.NotNil(t, sum.Boundary)
+		require.Equal(t, "branch", sum.Boundary.FilterKey)
+		require.True(t, sum.Boundary.CutoffAt.Equal(latest.UTC()))
 	})
 
 	t.Run("copied summary persists without summarizer", func(t *testing.T) {
@@ -1710,6 +1956,9 @@ func TestSummarizeSession_NeedsPersistOnly(t *testing.T) {
 		require.NotNil(t, sum)
 		require.Equal(t, "copied summary for b1", sum.Summary)
 		require.True(t, sum.UpdatedAt.Equal(now.Add(-2*time.Minute).UTC()))
+		require.NotNil(t, sum.Boundary)
+		require.Equal(t, "b1", sum.Boundary.FilterKey)
+		require.True(t, sum.Boundary.CutoffAt.Equal(now.Add(-2*time.Minute).UTC()))
 	})
 
 	t.Run("normal summary with non-zero UpdatedAt follows normal path", func(t *testing.T) {

--- a/session/pgvector/service_helper.go
+++ b/session/pgvector/service_helper.go
@@ -105,7 +105,9 @@ func (s *Service) getSession(
 
 	summaries := make(map[string]*session.Summary)
 	summariesList, err := s.getSummariesList(
-		ctx, []session.Key{key},
+		ctx,
+		[]session.Key{key},
+		[]time.Time{sessState.CreatedAt},
 	)
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -240,12 +242,19 @@ func (s *Service) listSessions(
 	sessionKeys := make(
 		[]session.Key, 0, len(sessStates),
 	)
+	sessionCreatedAts := make(
+		[]time.Time, 0, len(sessStates),
+	)
 	for _, st := range sessStates {
 		sessionKeys = append(sessionKeys, session.Key{
 			AppName:   key.AppName,
 			UserID:    key.UserID,
 			SessionID: st.ID,
 		})
+		sessionCreatedAts = append(
+			sessionCreatedAts,
+			st.CreatedAt,
+		)
 	}
 
 	eventsList, err := s.getEventsList(
@@ -258,7 +267,9 @@ func (s *Service) listSessions(
 	}
 
 	summariesList, err := s.getSummariesList(
-		ctx, sessionKeys,
+		ctx,
+		sessionKeys,
+		sessionCreatedAts,
 	)
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -1020,6 +1031,7 @@ func (s *Service) getTrackEvents(
 func (s *Service) getSummariesList(
 	ctx context.Context,
 	sessionKeys []session.Key,
+	sessionCreatedAts ...[]time.Time,
 ) ([]map[string]*session.Summary, error) {
 	if len(sessionKeys) == 0 {
 		return []map[string]*session.Summary{}, nil
@@ -1030,13 +1042,34 @@ func (s *Service) getSummariesList(
 		sessionIDs[i] = key.SessionID
 	}
 
+	sessionCreatedAtMap := map[string]time.Time(nil)
+	if len(sessionCreatedAts) > 0 {
+		if len(sessionKeys) != len(sessionCreatedAts[0]) {
+			return nil, fmt.Errorf(
+				"session keys and createdAts length mismatch",
+			)
+		}
+		sessionCreatedAtMap = make(
+			map[string]time.Time, len(sessionKeys),
+		)
+		for i, key := range sessionKeys {
+			sessionCreatedAtMap[key.SessionID] =
+				sessionCreatedAts[0][i]
+		}
+	}
+
+	summaryColumns := "session_id, filter_key, summary"
+	if sessionCreatedAtMap != nil {
+		summaryColumns += ", updated_at"
+	}
 	summaryQuery := fmt.Sprintf(
-		`SELECT session_id, filter_key, summary
+		`SELECT %s
 		FROM %s
 		WHERE app_name = $1 AND user_id = $2
 		AND session_id = ANY($3::varchar[])
 		AND (expires_at IS NULL OR expires_at > NOW() AT TIME ZONE 'localtime')
 		AND deleted_at IS NULL`,
+		summaryColumns,
 		s.tableSessionSummaries,
 	)
 
@@ -1048,11 +1081,27 @@ func (s *Service) getSummariesList(
 			for rows.Next() {
 				var sessionID, filterKey string
 				var summaryBytes []byte
-				if err := rows.Scan(
-					&sessionID, &filterKey,
-					&summaryBytes,
-				); err != nil {
-					return err
+				if sessionCreatedAtMap == nil {
+					if err := rows.Scan(
+						&sessionID, &filterKey,
+						&summaryBytes,
+					); err != nil {
+						return err
+					}
+				} else {
+					var updatedAt time.Time
+					if err := rows.Scan(
+						&sessionID, &filterKey,
+						&summaryBytes, &updatedAt,
+					); err != nil {
+						return err
+					}
+					createdAt, exists :=
+						sessionCreatedAtMap[sessionID]
+					if !exists ||
+						updatedAt.Before(createdAt) {
+						continue
+					}
 				}
 				var sum session.Summary
 				if err := json.Unmarshal(

--- a/session/pgvector/service_helper_test.go
+++ b/session/pgvector/service_helper_test.go
@@ -428,6 +428,66 @@ func TestGetSummariesList_Success(t *testing.T) {
 	)
 }
 
+func TestGetSummariesList_FiltersStaleAndPreservesBoundary(t *testing.T) {
+	s, mock, db := newTestServiceWithSliceSupport(
+		t, nil,
+	)
+	defer db.Close()
+
+	key := session.Key{
+		AppName: "app", UserID: "user",
+		SessionID: "sess",
+	}
+	createdAt := time.Date(2026, 5, 27, 10, 0, 0, 0, time.UTC)
+	cutoffAt := createdAt.Add(time.Minute)
+	fresh := session.Summary{
+		Summary:   "fresh",
+		UpdatedAt: cutoffAt,
+		Boundary: session.NewSummaryBoundaryWithEventID(
+			"all",
+			cutoffAt,
+			"event-fresh",
+		),
+	}
+	stale := session.Summary{
+		Summary:   "stale",
+		UpdatedAt: createdAt.Add(-time.Hour),
+		Boundary: session.NewSummaryBoundaryWithEventID(
+			"old",
+			createdAt.Add(-time.Hour),
+			"event-stale",
+		),
+	}
+	freshBytes, err := json.Marshal(fresh)
+	require.NoError(t, err)
+	staleBytes, err := json.Marshal(stale)
+	require.NoError(t, err)
+
+	mock.ExpectQuery("SELECT session_id, filter_key").
+		WillReturnRows(sqlmock.NewRows(
+			[]string{
+				"session_id",
+				"filter_key",
+				"summary",
+				"updated_at",
+			},
+		).
+			AddRow("sess", "all", freshBytes, cutoffAt).
+			AddRow("sess", "old", staleBytes, createdAt.Add(-time.Minute)))
+
+	result, err := s.getSummariesList(
+		context.Background(),
+		[]session.Key{key},
+		[]time.Time{createdAt},
+	)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	require.NotNil(t, result[0]["all"])
+	assert.Equal(t, "fresh", result[0]["all"].Summary)
+	assert.Equal(t, "event-fresh", result[0]["all"].Boundary.LastEventID)
+	assert.Nil(t, result[0]["old"])
+}
+
 func TestGetSummariesList_NoSummaries(t *testing.T) {
 	s, mock, db := newTestServiceWithSliceSupport(
 		t, nil,

--- a/session/pgvector/service_test.go
+++ b/session/pgvector/service_test.go
@@ -2600,9 +2600,9 @@ func TestGetSession_SuccessPath(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows(
 			[]string{"session_id", "event"},
 		))
-	mock.ExpectQuery("SELECT session_id, filter_key, summary").
+	mock.ExpectQuery("SELECT session_id, filter_key").
 		WillReturnRows(sqlmock.NewRows(
-			[]string{"session_id", "filter_key", "summary"},
+			[]string{"session_id", "filter_key", "summary", "updated_at"},
 		))
 
 	// refreshSessionTTL.
@@ -2659,9 +2659,9 @@ func TestGetSession_SuccessNoTTL(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows(
 			[]string{"session_id", "event"},
 		))
-	mock.ExpectQuery("SELECT session_id, filter_key, summary").
+	mock.ExpectQuery("SELECT session_id, filter_key").
 		WillReturnRows(sqlmock.NewRows(
-			[]string{"session_id", "filter_key", "summary"},
+			[]string{"session_id", "filter_key", "summary", "updated_at"},
 		))
 
 	sess, err := s.GetSession(
@@ -2738,8 +2738,9 @@ func TestGetSession_WithEventsAndSummaries(
 		WillReturnRows(sqlmock.NewRows(
 			[]string{
 				"session_id", "filter_key", "summary",
+				"updated_at",
 			},
-		).AddRow("sess", "all", sumBytes))
+		).AddRow("sess", "all", sumBytes, time.Now()))
 
 	// getTrackEvents - no tracks.
 
@@ -2821,8 +2822,9 @@ func TestGetSession_WithEventsAndTracks(
 		WillReturnRows(sqlmock.NewRows(
 			[]string{
 				"session_id", "filter_key", "summary",
+				"updated_at",
 			},
-		).AddRow("sess", "all", sumBytes))
+		).AddRow("sess", "all", sumBytes, time.Now()))
 
 	// Track events for "alpha".
 	te := session.TrackEvent{
@@ -3232,7 +3234,7 @@ func TestListSessions_WithListSessionPage(t *testing.T) {
 	mock.ExpectQuery("SELECT session_id, event").
 		WillReturnRows(sqlmock.NewRows([]string{"session_id", "event"}))
 	mock.ExpectQuery("SELECT session_id, filter_key").
-		WillReturnRows(sqlmock.NewRows([]string{"session_id", "filter_key", "summary"}))
+		WillReturnRows(sqlmock.NewRows([]string{"session_id", "filter_key", "summary", "updated_at"}))
 
 	sessions, err := s.ListSessions(
 		context.Background(), userKey, session.WithListSessionPage(1, 1),
@@ -4668,9 +4670,9 @@ func TestGetSession_WithRefreshTTLError(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows(
 			[]string{"session_id", "event"},
 		))
-	mock.ExpectQuery("SELECT session_id, filter_key, summary").
+	mock.ExpectQuery("SELECT session_id, filter_key").
 		WillReturnRows(sqlmock.NewRows(
-			[]string{"session_id", "filter_key", "summary"},
+			[]string{"session_id", "filter_key", "summary", "updated_at"},
 		))
 
 	// refreshSessionTTL fails but should not cause

--- a/session/postgres/service_edge_test.go
+++ b/session/postgres/service_edge_test.go
@@ -1044,6 +1044,71 @@ func TestGetSummariesList(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestGetSummariesList_FiltersStaleAndPreservesBoundary(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db)
+	key := session.Key{
+		AppName:   "app1",
+		UserID:    "user1",
+		SessionID: "sess1",
+	}
+	createdAt := time.Date(2026, 5, 27, 10, 0, 0, 0, time.UTC)
+	cutoffAt := createdAt.Add(time.Minute)
+	fresh := session.Summary{
+		Summary:   "fresh",
+		UpdatedAt: cutoffAt,
+		Boundary: session.NewSummaryBoundaryWithEventID(
+			"filter1",
+			cutoffAt,
+			"event-fresh",
+		),
+	}
+	stale := session.Summary{
+		Summary:   "stale",
+		UpdatedAt: createdAt.Add(-time.Hour),
+		Boundary: session.NewSummaryBoundaryWithEventID(
+			"filter2",
+			createdAt.Add(-time.Hour),
+			"event-stale",
+		),
+	}
+	freshBytes, err := json.Marshal(fresh)
+	require.NoError(t, err)
+	staleBytes, err := json.Marshal(stale)
+	require.NoError(t, err)
+
+	rows := sqlmock.NewRows([]string{
+		"session_id",
+		"filter_key",
+		"summary",
+		"updated_at",
+	}).
+		AddRow("sess1", "filter1", freshBytes, cutoffAt).
+		AddRow("sess1", "filter2", staleBytes, createdAt.Add(-time.Minute))
+
+	mock.ExpectQuery(
+		"SELECT session_id, filter_key, summary, updated_at FROM session_summaries",
+	).
+		WithArgs("app1", "user1", sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnRows(rows)
+
+	result, err := s.getSummariesList(
+		context.Background(),
+		[]session.Key{key},
+		[]time.Time{createdAt},
+	)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	require.NotNil(t, result[0]["filter1"])
+	assert.Equal(t, "fresh", result[0]["filter1"].Summary)
+	assert.Equal(t, "event-fresh", result[0]["filter1"].Boundary.LastEventID)
+	assert.Nil(t, result[0]["filter2"])
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestDeleteSessionState_SoftDelete_StateError(t *testing.T) {
 	s, mock, db := setupMockService(t, &TestServiceOpts{
 		softDelete: boolPtr(true),

--- a/session/postgres/service_helper.go
+++ b/session/postgres/service_helper.go
@@ -88,7 +88,11 @@ func (s *Service) getSession(
 	summaries := make(map[string]*session.Summary)
 	if len(events) > 0 {
 		// Batch load summaries for all sessions
-		summariesList, err := s.getSummariesList(ctx, []session.Key{key})
+		summariesList, err := s.getSummariesList(
+			ctx,
+			[]session.Key{key},
+			[]time.Time{sessState.CreatedAt},
+		)
 		if err != nil {
 			return nil, fmt.Errorf("get summaries failed: %w", err)
 		}
@@ -194,12 +198,14 @@ func (s *Service) listSessions(
 
 	// Build session keys for batch loading events and summaries
 	sessionKeys := make([]session.Key, 0, len(sessStates))
+	sessionCreatedAts := make([]time.Time, 0, len(sessStates))
 	for _, sessState := range sessStates {
 		sessionKeys = append(sessionKeys, session.Key{
 			AppName:   key.AppName,
 			UserID:    key.UserID,
 			SessionID: sessState.ID,
 		})
+		sessionCreatedAts = append(sessionCreatedAts, sessState.CreatedAt)
 	}
 
 	// Batch load events for all sessions
@@ -210,7 +216,11 @@ func (s *Service) listSessions(
 	}
 
 	// Batch load summaries for all sessions
-	summariesList, err := s.getSummariesList(ctx, sessionKeys)
+	summariesList, err := s.getSummariesList(
+		ctx,
+		sessionKeys,
+		sessionCreatedAts,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("get summaries list failed: %w", err)
 	}
@@ -863,6 +873,7 @@ func (s *Service) getTrackEvents(
 func (s *Service) getSummariesList(
 	ctx context.Context,
 	sessionKeys []session.Key,
+	sessionCreatedAts ...[]time.Time,
 ) ([]map[string]*session.Summary, error) {
 	if len(sessionKeys) == 0 {
 		return []map[string]*session.Summary{}, nil
@@ -874,11 +885,26 @@ func (s *Service) getSummariesList(
 		sessionIDs[i] = key.SessionID
 	}
 
+	sessionCreatedAtMap := map[string]time.Time(nil)
+	if len(sessionCreatedAts) > 0 {
+		if len(sessionKeys) != len(sessionCreatedAts[0]) {
+			return nil, fmt.Errorf("session keys and createdAts length mismatch")
+		}
+		sessionCreatedAtMap = make(map[string]time.Time, len(sessionKeys))
+		for i, key := range sessionKeys {
+			sessionCreatedAtMap[key.SessionID] = sessionCreatedAts[0][i]
+		}
+	}
+
 	// Query all summaries for all sessions (always filter deleted records)
-	summaryQuery := fmt.Sprintf(`SELECT session_id, filter_key, summary FROM %s
+	summaryColumns := "session_id, filter_key, summary"
+	if sessionCreatedAtMap != nil {
+		summaryColumns += ", updated_at"
+	}
+	summaryQuery := fmt.Sprintf(`SELECT %s FROM %s
 		WHERE app_name = $1 AND user_id = $2 AND session_id = ANY($3::varchar[])
 		AND (expires_at IS NULL OR expires_at > $4)
-		AND deleted_at IS NULL`, s.tableSessionSummaries)
+		AND deleted_at IS NULL`, summaryColumns, s.tableSessionSummaries)
 
 	// Query all summaries for all sessions
 	summariesMap := make(map[string]map[string]*session.Summary)
@@ -886,8 +912,24 @@ func (s *Service) getSummariesList(
 		for rows.Next() {
 			var sessionID, filterKey string
 			var summaryBytes []byte
-			if err := rows.Scan(&sessionID, &filterKey, &summaryBytes); err != nil {
-				return err
+			if sessionCreatedAtMap == nil {
+				if err := rows.Scan(&sessionID, &filterKey, &summaryBytes); err != nil {
+					return err
+				}
+			} else {
+				var updatedAt time.Time
+				if err := rows.Scan(
+					&sessionID,
+					&filterKey,
+					&summaryBytes,
+					&updatedAt,
+				); err != nil {
+					return err
+				}
+				createdAt, exists := sessionCreatedAtMap[sessionID]
+				if !exists || updatedAt.Before(createdAt) {
+					continue
+				}
 			}
 
 			var sum session.Summary

--- a/session/postgres/service_test.go
+++ b/session/postgres/service_test.go
@@ -684,8 +684,8 @@ func TestGetSession_Success(t *testing.T) {
 			AddRow(key.SessionID, eventBytes))
 
 	// Mock: Batch load summaries with data
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT session_id, filter_key, summary FROM session_summaries")).
-		WillReturnRows(sqlmock.NewRows([]string{"session_id", "filter_key", "summary"}))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT session_id, filter_key, summary, updated_at FROM session_summaries")).
+		WillReturnRows(sqlmock.NewRows([]string{"session_id", "filter_key", "summary", "updated_at"}))
 
 	sess, err := s.GetSession(context.Background(), key)
 	require.NoError(t, err)
@@ -946,8 +946,8 @@ func TestListSessions_WithTrackEvents(t *testing.T) {
 		WithArgs("test-app", "test-user", "{session-1}").
 		WillReturnRows(eventRows)
 
-	summaryRows := sqlmock.NewRows([]string{"session_id", "filter_key", "summary"})
-	mock.ExpectQuery("SELECT session_id, filter_key, summary FROM session_summaries").
+	summaryRows := sqlmock.NewRows([]string{"session_id", "filter_key", "summary", "updated_at"})
+	mock.ExpectQuery("SELECT session_id, filter_key, summary, updated_at FROM session_summaries").
 		WithArgs("test-app", "test-user", sqlmock.AnyArg(), sqlmock.AnyArg()).
 		WillReturnRows(summaryRows)
 
@@ -1044,8 +1044,8 @@ func TestListSessions_Success(t *testing.T) {
 			AddRow("session-1", eventBytes))
 
 	// Mock: Batch load summaries (empty)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT session_id, filter_key, summary FROM session_summaries")).
-		WillReturnRows(sqlmock.NewRows([]string{"session_id", "filter_key", "summary"}))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT session_id, filter_key, summary, updated_at FROM session_summaries")).
+		WillReturnRows(sqlmock.NewRows([]string{"session_id", "filter_key", "summary", "updated_at"}))
 
 	sessions, err := s.ListSessions(ctx, userKey)
 	require.NoError(t, err)
@@ -1144,8 +1144,8 @@ func TestListSessions_WithMultipleSessions(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"session_id", "event"}))
 
 	// Mock: Batch load summaries
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT session_id, filter_key, summary FROM session_summaries")).
-		WillReturnRows(sqlmock.NewRows([]string{"session_id", "filter_key", "summary"}))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT session_id, filter_key, summary, updated_at FROM session_summaries")).
+		WillReturnRows(sqlmock.NewRows([]string{"session_id", "filter_key", "summary", "updated_at"}))
 
 	sessions, err := s.ListSessions(ctx, userKey)
 	require.NoError(t, err)
@@ -1186,8 +1186,8 @@ func TestListSessions_WithListSessionPage(t *testing.T) {
 
 	mock.ExpectQuery("SELECT session_id, event FROM").
 		WillReturnRows(sqlmock.NewRows([]string{"session_id", "event"}))
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT session_id, filter_key, summary FROM session_summaries")).
-		WillReturnRows(sqlmock.NewRows([]string{"session_id", "filter_key", "summary"}))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT session_id, filter_key, summary, updated_at FROM session_summaries")).
+		WillReturnRows(sqlmock.NewRows([]string{"session_id", "filter_key", "summary", "updated_at"}))
 
 	sessions, err := s.ListSessions(ctx, userKey, session.WithListSessionPage(1, 1))
 	require.NoError(t, err)

--- a/session/redis/internal/hashidx/summary.go
+++ b/session/redis/internal/hashidx/summary.go
@@ -12,6 +12,7 @@ package hashidx
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -28,6 +29,8 @@ import (
 //   Type:  String
 //   Value: JSON(map[filterKey]*session.Summary)
 
+const summaryNilError = "summary is nil"
+
 // CreateSummary creates or updates a summary for the session.
 // Uses Lua script to atomically merge filterKey summary only if newer.
 // TTL is set atomically inside the Lua script to avoid orphan keys without expiry.
@@ -40,11 +43,14 @@ func (c *Client) CreateSummary(
 	sum *session.Summary,
 	ttl time.Duration,
 ) error {
+	if sum == nil {
+		return errors.New(summaryNilError)
+	}
 	// Normalize to UTC so Lua string comparison of "updated_at" is correct.
-	normalized := *sum
+	normalized := sum.Clone()
 	normalized.UpdatedAt = sum.UpdatedAt.UTC()
 
-	payload, err := json.Marshal(&normalized)
+	payload, err := json.Marshal(normalized)
 	if err != nil {
 		return fmt.Errorf("marshal summary failed: %w", err)
 	}

--- a/session/redis/internal/hashidx/summary_test.go
+++ b/session/redis/internal/hashidx/summary_test.go
@@ -25,6 +25,12 @@ func TestClient_CreateSummary(t *testing.T) {
 	ctx := context.Background()
 	key := session.Key{AppName: "app", UserID: "u1", SessionID: "sum1"}
 
+	t.Run("nil summary returns error", func(t *testing.T) {
+		err := c.CreateSummary(ctx, key, "all", nil, time.Hour)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, summaryNilError)
+	})
+
 	t.Run("creates new summary", func(t *testing.T) {
 		now := time.Now()
 		sum := &session.Summary{Summary: "test summary", UpdatedAt: now}

--- a/session/session.go
+++ b/session/session.go
@@ -137,12 +137,9 @@ func (sess *Session) Clone() *Session {
 	if sess.Summaries != nil {
 		copiedSess.Summaries = make(map[string]*Summary, len(sess.Summaries))
 		for b, sum := range sess.Summaries {
-			if sum == nil {
-				continue
+			if copied := sum.Clone(); copied != nil {
+				copiedSess.Summaries[b] = copied
 			}
-			// Shallow copy is fine since Summary is immutable after write.
-			copied := *sum
-			copiedSess.Summaries[b] = &copied
 		}
 	}
 	sess.SummariesMu.RUnlock()
@@ -583,9 +580,191 @@ func applyOptions(opts ...Option) *Options {
 // Summary represents a concise, structured summary of a conversation branch.
 // It is stored on the session object rather than in the StateMap.
 type Summary struct {
-	Summary   string    `json:"summary"`          // Summary is the concise conversation summary.
-	Topics    []string  `json:"topics,omitempty"` // Topics is the optional topics list.
-	UpdatedAt time.Time `json:"updated_at"`       // UpdatedAt is the update timestamp in UTC.
+	Summary   string           `json:"summary"`            // Summary is the concise conversation summary.
+	Topics    []string         `json:"topics,omitempty"`   // Topics is the optional topics list.
+	UpdatedAt time.Time        `json:"updated_at"`         // UpdatedAt is the legacy cutoff timestamp in UTC.
+	Boundary  *SummaryBoundary `json:"boundary,omitempty"` // Boundary records the summarized history cutoff.
+}
+
+const (
+	// SummaryBoundaryVersion is the current summary boundary metadata version.
+	SummaryBoundaryVersion = 1
+	// SummaryLastIncludedTimestampStateKey stores the last summarized event timestamp.
+	SummaryLastIncludedTimestampStateKey = "summary:last_included_ts"
+	// SummaryLastIncludedEventIDStateKey stores the last summarized event ID.
+	SummaryLastIncludedEventIDStateKey = "summary:last_included_event_id"
+)
+
+// SummaryBoundary records the history cutoff represented by a summary.
+// Summary keeps semantic content; Boundary keeps the structural cutoff used by
+// request builders and storage backends. CutoffAt keeps compatibility with the
+// existing timestamp-based summary model, and LastEventID disambiguates events
+// that share the same timestamp when the writer can identify the last covered
+// transcript event.
+type SummaryBoundary struct {
+	Version     int       `json:"version"`
+	FilterKey   string    `json:"filter_key,omitempty"`
+	CutoffAt    time.Time `json:"cutoff_at,omitempty"`
+	LastEventID string    `json:"last_event_id,omitempty"`
+}
+
+// NewSummaryBoundary creates boundary metadata for a generated summary.
+func NewSummaryBoundary(filterKey string, cutoffAt time.Time) *SummaryBoundary {
+	return NewSummaryBoundaryWithEventID(filterKey, cutoffAt, "")
+}
+
+// NewSummaryBoundaryWithEventID creates boundary metadata anchored to a
+// specific last summarized event.
+func NewSummaryBoundaryWithEventID(
+	filterKey string,
+	cutoffAt time.Time,
+	lastEventID string,
+) *SummaryBoundary {
+	return &SummaryBoundary{
+		Version:     SummaryBoundaryVersion,
+		FilterKey:   filterKey,
+		CutoffAt:    cutoffAt.UTC(),
+		LastEventID: lastEventID,
+	}
+}
+
+// CutoffTime returns the timestamp cutoff represented by the boundary.
+func (b *SummaryBoundary) CutoffTime() time.Time {
+	if b == nil {
+		return time.Time{}
+	}
+	return b.CutoffAt.UTC()
+}
+
+// Clone returns a deep copy of the summary boundary.
+func (b *SummaryBoundary) Clone() *SummaryBoundary {
+	if b == nil {
+		return nil
+	}
+	copied := *b
+	return &copied
+}
+
+// CutoffBoundary returns normalized cutoff metadata represented by the summary.
+// Summaries written before boundary metadata existed fall back to UpdatedAt.
+func (s *Summary) CutoffBoundary() *SummaryBoundary {
+	if s == nil {
+		return nil
+	}
+	if boundary := s.Boundary.Clone(); boundary != nil {
+		if boundary.Version == 0 {
+			boundary.Version = SummaryBoundaryVersion
+		}
+		if boundary.CutoffAt.IsZero() {
+			boundary.CutoffAt = s.UpdatedAt.UTC()
+		} else {
+			boundary.CutoffAt = boundary.CutoffAt.UTC()
+		}
+		if !boundary.CutoffAt.IsZero() {
+			return boundary
+		}
+	}
+	if s.UpdatedAt.IsZero() {
+		return nil
+	}
+	return NewSummaryBoundary("", s.UpdatedAt)
+}
+
+// CutoffTime returns the event cutoff represented by the summary.
+// Summaries written before boundary metadata existed fall back to UpdatedAt.
+func (s *Summary) CutoffTime() time.Time {
+	boundary := s.CutoffBoundary()
+	if boundary == nil {
+		return time.Time{}
+	}
+	return boundary.CutoffTime()
+}
+
+// SummaryFilterKeyMatchesPrefix reports whether key belongs to prefix's
+// hierarchical summary scope.
+func SummaryFilterKeyMatchesPrefix(key, prefix string) bool {
+	filterPrefix := prefix + event.FilterKeyDelimiter
+	keyWithDelim := key + event.FilterKeyDelimiter
+	return key == prefix || strings.HasPrefix(keyWithDelim, filterPrefix)
+}
+
+// SummaryPrefixCutoff returns the effective cutoff for summaries matching a
+// hierarchical prefix. It returns ok=false when no non-empty summaries match.
+// The effective cutoff is Summary.CutoffTime: boundary cutoff when present,
+// otherwise legacy UpdatedAt. When any matching summary has a zero effective
+// cutoff, the returned cutoff is zero so callers keep raw history instead of
+// dropping potentially uncovered events.
+// Callers must hold the session summaries read lock when passing a live session
+// summary map.
+func SummaryPrefixCutoff(
+	summaries map[string]*Summary,
+	prefix string,
+) (time.Time, bool) {
+	boundary, ok := SummaryPrefixBoundary(summaries, prefix)
+	if !ok || boundary == nil {
+		return time.Time{}, ok
+	}
+	return boundary.CutoffTime(), true
+}
+
+// SummaryPrefixBoundary returns the effective boundary for summaries matching
+// a hierarchical prefix. Prefix aggregation clears LastEventID because one
+// branch-local event ID cannot represent the whole prefix scope.
+func SummaryPrefixBoundary(
+	summaries map[string]*Summary,
+	prefix string,
+) (*SummaryBoundary, bool) {
+	var boundary *SummaryBoundary
+	var matched bool
+	var hasMissingCutoff bool
+	for key, sum := range summaries {
+		if sum == nil || strings.TrimSpace(sum.Summary) == "" {
+			continue
+		}
+		if !SummaryFilterKeyMatchesPrefix(key, prefix) {
+			continue
+		}
+		matched = true
+		sumBoundary := sum.CutoffBoundary()
+		if sumBoundary == nil || sumBoundary.CutoffTime().IsZero() {
+			hasMissingCutoff = true
+			continue
+		}
+		sumBoundary.FilterKey = key
+		if boundary == nil || sumBoundary.CutoffAt.Before(boundary.CutoffAt) {
+			boundary = sumBoundary
+			continue
+		}
+		if sumBoundary.CutoffAt.Equal(boundary.CutoffAt) {
+			boundary.LastEventID = ""
+		}
+	}
+	if !matched {
+		return nil, false
+	}
+	if hasMissingCutoff {
+		return NewSummaryBoundary(prefix, time.Time{}), true
+	}
+	if boundary == nil {
+		return NewSummaryBoundary(prefix, time.Time{}), true
+	}
+	boundary.FilterKey = prefix
+	boundary.LastEventID = ""
+	return boundary, true
+}
+
+// Clone returns a deep copy of the summary.
+func (s *Summary) Clone() *Summary {
+	if s == nil {
+		return nil
+	}
+	copied := *s
+	if s.Topics != nil {
+		copied.Topics = make([]string, len(s.Topics))
+		copy(copied.Topics, s.Topics)
+	}
+	copied.Boundary = s.Boundary.Clone()
+	return &copied
 }
 
 // Options contains shared session-service options.

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -190,6 +190,240 @@ func TestWithSummaryFilterKey(t *testing.T) {
 	}
 }
 
+func TestSummaryCutoffTimeAndClone(t *testing.T) {
+	updatedAt := time.Date(2025, 1, 2, 10, 0, 0, 0, time.UTC)
+	cutoff := updatedAt.Add(-time.Minute)
+
+	t.Run("legacy summary falls back to updated time", func(t *testing.T) {
+		sum := &Summary{Summary: "legacy", UpdatedAt: updatedAt}
+		assert.True(t, sum.CutoffTime().Equal(updatedAt))
+	})
+
+	t.Run("boundary cutoff wins over updated time", func(t *testing.T) {
+		sum := &Summary{
+			Summary:   "bounded",
+			UpdatedAt: updatedAt,
+			Boundary: NewSummaryBoundaryWithEventID(
+				"branch",
+				cutoff,
+				"event-1",
+			),
+		}
+		assert.True(t, sum.CutoffTime().Equal(cutoff))
+		assert.Equal(t, SummaryBoundaryVersion, sum.Boundary.Version)
+		assert.Equal(t, "event-1", sum.CutoffBoundary().LastEventID)
+	})
+
+	t.Run("clone deep copies mutable fields", func(t *testing.T) {
+		sum := &Summary{
+			Summary: "bounded",
+			Topics:  []string{"topic-a"},
+			Boundary: NewSummaryBoundary(
+				"branch",
+				cutoff,
+			),
+		}
+		cloned := sum.Clone()
+		require.NotNil(t, cloned)
+
+		sum.Topics[0] = "changed"
+		sum.Boundary.FilterKey = "other"
+		sum.Boundary.LastEventID = "changed"
+
+		assert.Equal(t, "topic-a", cloned.Topics[0])
+		assert.Equal(t, "branch", cloned.Boundary.FilterKey)
+		assert.Empty(t, cloned.Boundary.LastEventID)
+	})
+
+	t.Run("clone deep copies empty topics backing array", func(t *testing.T) {
+		sum := &Summary{
+			Summary: "bounded",
+			Topics:  make([]string, 0, 1),
+		}
+		cloned := sum.Clone()
+		require.NotNil(t, cloned)
+
+		sum.Topics = append(sum.Topics, "original")
+		cloned.Topics = append(cloned.Topics, "clone")
+
+		assert.Equal(t, "original", sum.Topics[0])
+		assert.Equal(t, "clone", cloned.Topics[0])
+	})
+}
+
+func TestSummaryPrefixCutoff(t *testing.T) {
+	base := time.Date(2025, 1, 2, 10, 0, 0, 0, time.UTC)
+
+	t.Run("uses earliest matching cutoff", func(t *testing.T) {
+		cutoff, ok := SummaryPrefixCutoff(
+			map[string]*Summary{
+				"root/a": {
+					Summary: "summary a",
+					Boundary: NewSummaryBoundary(
+						"root/a",
+						base,
+					),
+				},
+				"root/b": {
+					Summary: "summary b",
+					Boundary: NewSummaryBoundary(
+						"root/b",
+						base.Add(time.Minute),
+					),
+				},
+				"rooted/c": {
+					Summary: "summary c",
+					Boundary: NewSummaryBoundary(
+						"rooted/c",
+						base.Add(-time.Hour),
+					),
+				},
+			},
+			"root",
+		)
+
+		require.True(t, ok)
+		assert.True(t, cutoff.Equal(base))
+	})
+
+	t.Run("returns zero cutoff when metadata is missing", func(t *testing.T) {
+		cutoff, ok := SummaryPrefixCutoff(
+			map[string]*Summary{
+				"root/a": {
+					Summary: "summary a",
+					Boundary: NewSummaryBoundary(
+						"root/a",
+						base,
+					),
+				},
+				"root/b": {
+					Summary: "summary b",
+				},
+			},
+			"root",
+		)
+
+		require.True(t, ok)
+		assert.True(t, cutoff.IsZero())
+	})
+
+	t.Run("reports no match", func(t *testing.T) {
+		cutoff, ok := SummaryPrefixCutoff(
+			map[string]*Summary{
+				"other": {
+					Summary: "summary",
+					Boundary: NewSummaryBoundary(
+						"other",
+						base,
+					),
+				},
+			},
+			"root",
+		)
+
+		assert.False(t, ok)
+		assert.True(t, cutoff.IsZero())
+	})
+
+	t.Run("ignores whitespace-only summaries", func(t *testing.T) {
+		cutoff, ok := SummaryPrefixCutoff(
+			map[string]*Summary{
+				"root/a": {
+					Summary:   " \t\n",
+					UpdatedAt: base,
+				},
+			},
+			"root",
+		)
+
+		assert.False(t, ok)
+		assert.True(t, cutoff.IsZero())
+	})
+
+	t.Run("clears ambiguous event id for tied prefix cutoff", func(t *testing.T) {
+		boundary, ok := SummaryPrefixBoundary(
+			map[string]*Summary{
+				"root/a": {
+					Summary: "summary a",
+					Boundary: NewSummaryBoundaryWithEventID(
+						"root/a",
+						base,
+						"event-a",
+					),
+				},
+				"root/b": {
+					Summary: "summary b",
+					Boundary: NewSummaryBoundaryWithEventID(
+						"root/b",
+						base,
+						"event-b",
+					),
+				},
+			},
+			"root",
+		)
+
+		require.True(t, ok)
+		require.NotNil(t, boundary)
+		assert.True(t, boundary.CutoffTime().Equal(base))
+		assert.Empty(t, boundary.LastEventID)
+	})
+
+	t.Run("clears branch event id for single prefix match", func(t *testing.T) {
+		boundary, ok := SummaryPrefixBoundary(
+			map[string]*Summary{
+				"root/a": {
+					Summary: "summary a",
+					Boundary: NewSummaryBoundaryWithEventID(
+						"root/a",
+						base,
+						"event-a",
+					),
+				},
+			},
+			"root",
+		)
+
+		require.True(t, ok)
+		require.NotNil(t, boundary)
+		assert.True(t, boundary.CutoffTime().Equal(base))
+		assert.Empty(t, boundary.LastEventID)
+	})
+}
+
+func TestSummaryBoundaryJSONCompatibility(t *testing.T) {
+	cutoff := time.Date(2025, 1, 2, 10, 0, 0, 0, time.UTC)
+
+	t.Run("round trip boundary", func(t *testing.T) {
+		sum := &Summary{
+			Summary: "bounded",
+			Boundary: NewSummaryBoundaryWithEventID(
+				"branch",
+				cutoff,
+				"event-1",
+			),
+		}
+		raw, err := json.Marshal(sum)
+		require.NoError(t, err)
+
+		var decoded Summary
+		require.NoError(t, json.Unmarshal(raw, &decoded))
+		require.NotNil(t, decoded.Boundary)
+		assert.Equal(t, "branch", decoded.Boundary.FilterKey)
+		assert.Equal(t, "event-1", decoded.Boundary.LastEventID)
+		assert.True(t, decoded.CutoffTime().Equal(cutoff))
+	})
+
+	t.Run("old summary falls back to updated time", func(t *testing.T) {
+		raw := []byte(`{"summary":"legacy","updated_at":"2025-01-02T10:00:00Z"}`)
+
+		var decoded Summary
+		require.NoError(t, json.Unmarshal(raw, &decoded))
+		require.Nil(t, decoded.Boundary)
+		assert.True(t, decoded.CutoffTime().Equal(cutoff))
+	})
+}
+
 func TestKey_CheckSessionKey(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/session/sqlite/summary_test.go
+++ b/session/sqlite/summary_test.go
@@ -195,6 +195,69 @@ func TestSessionSQLite_GetSession_LoadsAndFiltersSummaries(t *testing.T) {
 	require.Len(t, got.Summaries, 0)
 }
 
+func TestSessionSQLite_SummaryBoundaryLastEventIDRoundTrip(t *testing.T) {
+	db, _, cleanup := openTempSQLiteDB(t)
+	defer cleanup()
+
+	svc, err := NewService(db, WithSummarizer(&fakeSummarizer{}))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, svc.Close()) }()
+
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "s1"}
+	sess, err := svc.CreateSession(ctx, key, nil)
+	require.NoError(t, err)
+
+	ev := newUserEvent("hi")
+	ev.ID = "event-1"
+	require.NoError(t, svc.AppendEvent(ctx, sess, ev))
+
+	require.NoError(t, svc.CreateSessionSummary(
+		ctx,
+		sess,
+		session.SummaryFilterKeyAllContents,
+		true,
+	))
+
+	got, err := svc.GetSession(ctx, key)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assertSummaryLastEventID(
+		t,
+		got.Summaries,
+		session.SummaryFilterKeyAllContents,
+		ev.ID,
+	)
+
+	list, err := svc.ListSessions(ctx, session.UserKey{
+		AppName: key.AppName,
+		UserID:  key.UserID,
+	})
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assertSummaryLastEventID(
+		t,
+		list[0].Summaries,
+		session.SummaryFilterKeyAllContents,
+		ev.ID,
+	)
+}
+
+func assertSummaryLastEventID(
+	t *testing.T,
+	summaries map[string]*session.Summary,
+	filterKey string,
+	want string,
+) {
+	t.Helper()
+	require.NotEmpty(t, summaries)
+	sum := summaries[filterKey]
+	require.NotNil(t, sum)
+	boundary := sum.CutoffBoundary()
+	require.NotNil(t, boundary)
+	require.Equal(t, want, boundary.LastEventID)
+}
+
 func TestSessionSQLite_GetSummariesList_EmptyInput(t *testing.T) {
 	db, _, cleanup := openTempSQLiteDB(t)
 	defer cleanup()

--- a/session/summary/checker.go
+++ b/session/summary/checker.go
@@ -67,12 +67,21 @@ func SetTokenCounter(counter model.TokenCounter) {
 	defaultTokenCounterMu.Unlock()
 }
 
-// filterDeltaEvents returns events that occurred strictly after the last
-// summarized timestamp stored in session state. If the timestamp is not set
-// or invalid, it returns all events (first summarization scenario).
+// filterDeltaEvents returns events after the last summarized boundary stored
+// in session state. Exact boundaries use the last event ID when available;
+// timestamp-only boundaries keep same-timestamp events to avoid dropping
+// uncovered history.
 func filterDeltaEvents(sess *session.Session) []event.Event {
 	if sess == nil || len(sess.Events) == 0 {
 		return nil
+	}
+
+	if rawID, ok := sess.GetState(lastIncludedEventIDKey); ok && len(rawID) > 0 {
+		for i, e := range sess.Events {
+			if e.ID == string(rawID) {
+				return sess.Events[i+1:]
+			}
+		}
 	}
 
 	raw, ok := sess.GetState(lastIncludedTsKey)
@@ -93,7 +102,7 @@ func filterDeltaEvents(sess *session.Session) []event.Event {
 
 	out := make([]event.Event, 0, len(sess.Events))
 	for _, e := range sess.Events {
-		if e.Timestamp.After(lastTs) {
+		if !e.Timestamp.Before(lastTs) {
 			out = append(out, e)
 		}
 	}

--- a/session/summary/checker_test.go
+++ b/session/summary/checker_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/model"
@@ -57,17 +58,18 @@ func TestCheckEventThreshold(t *testing.T) {
 		assert.False(t, checker(sess))
 	})
 
-	t.Run("delta filtering with lastIncludedTs", func(t *testing.T) {
+	t.Run("delta filtering with last included boundary", func(t *testing.T) {
 		baseTime := time.Now()
 		sess := &session.Session{
 			Events: []event.Event{
-				{Timestamp: baseTime.Add(-3 * time.Hour)},
-				{Timestamp: baseTime.Add(-2 * time.Hour)},
-				{Timestamp: baseTime.Add(-1 * time.Hour)},
-				{Timestamp: baseTime},
+				{ID: "event-1", Timestamp: baseTime.Add(-3 * time.Hour)},
+				{ID: "event-2", Timestamp: baseTime.Add(-2 * time.Hour)},
+				{ID: "event-3", Timestamp: baseTime.Add(-1 * time.Hour)},
+				{ID: "event-4", Timestamp: baseTime},
 			},
 			State: session.StateMap{
-				lastIncludedTsKey: []byte(baseTime.Add(-2 * time.Hour).UTC().Format(time.RFC3339Nano)),
+				lastIncludedTsKey:      []byte(baseTime.Add(-2 * time.Hour).UTC().Format(time.RFC3339Nano)),
+				lastIncludedEventIDKey: []byte("event-2"),
 			},
 		}
 
@@ -77,6 +79,46 @@ func TestCheckEventThreshold(t *testing.T) {
 
 		checker = CheckEventThreshold(1)
 		assert.True(t, checker(sess))
+	})
+
+	t.Run("legacy timestamp boundary keeps same timestamp events", func(t *testing.T) {
+		baseTime := time.Now()
+		sess := &session.Session{
+			Events: []event.Event{
+				{ID: "covered", Timestamp: baseTime},
+				{ID: "same-time-tail", Timestamp: baseTime},
+				{ID: "later", Timestamp: baseTime.Add(time.Second)},
+			},
+			State: session.StateMap{
+				lastIncludedTsKey: []byte(baseTime.UTC().Format(time.RFC3339Nano)),
+			},
+		}
+
+		delta := filterDeltaEvents(sess)
+		assert.Len(t, delta, 3)
+		assert.Equal(t, "covered", delta[0].ID)
+	})
+
+	t.Run("event id boundary wins when timestamp is invalid", func(t *testing.T) {
+		const (
+			includedEventID = "event-1"
+			deltaEventID    = "event-2"
+			invalidTS       = "invalid-timestamp"
+		)
+		sess := &session.Session{
+			Events: []event.Event{
+				{ID: includedEventID, Timestamp: time.Now().Add(-time.Minute)},
+				{ID: deltaEventID, Timestamp: time.Now()},
+			},
+			State: session.StateMap{
+				lastIncludedTsKey:      []byte(invalidTS),
+				lastIncludedEventIDKey: []byte(includedEventID),
+			},
+		}
+
+		delta := filterDeltaEvents(sess)
+		require.Len(t, delta, 1)
+		assert.Equal(t, deltaEventID, delta[0].ID)
 	})
 
 	t.Run("lastIncludedTs in future yields no delta events", func(t *testing.T) {
@@ -381,13 +423,14 @@ func TestCheckTokenThreshold(t *testing.T) {
 		assert.False(t, checker(sess))
 	})
 
-	t.Run("delta filtering with lastIncludedTs", func(t *testing.T) {
+	t.Run("delta filtering with last included boundary", func(t *testing.T) {
 		const threshold = 50
 		baseTime := time.Now()
 
 		sess := &session.Session{
 			Events: []event.Event{
 				{
+					ID:        "event-1",
 					Author:    "user",
 					Timestamp: baseTime.Add(-2 * time.Hour),
 					Response: &model.Response{Choices: []model.Choice{{
@@ -395,6 +438,7 @@ func TestCheckTokenThreshold(t *testing.T) {
 					}}},
 				},
 				{
+					ID:        "event-2",
 					Author:    "assistant",
 					Timestamp: baseTime,
 					Response: &model.Response{Choices: []model.Choice{{
@@ -403,7 +447,8 @@ func TestCheckTokenThreshold(t *testing.T) {
 				},
 			},
 			State: session.StateMap{
-				lastIncludedTsKey: []byte(baseTime.Add(-2 * time.Hour).UTC().Format(time.RFC3339Nano)),
+				lastIncludedTsKey:      []byte(baseTime.Add(-2 * time.Hour).UTC().Format(time.RFC3339Nano)),
+				lastIncludedEventIDKey: []byte("event-1"),
 			},
 		}
 

--- a/session/summary/summarizer.go
+++ b/session/summary/summarizer.go
@@ -47,8 +47,9 @@ const (
 
 const (
 	// lastIncludedTsKey is the key for last included timestamp in summary.
-	// This key is used to store the last included timestamp in the session state.
-	lastIncludedTsKey = "summary:last_included_ts"
+	lastIncludedTsKey = session.SummaryLastIncludedTimestampStateKey
+	// lastIncludedEventIDKey is the key for last included event ID in summary.
+	lastIncludedEventIDKey = session.SummaryLastIncludedEventIDStateKey
 
 	// conversationTextVar is the prompt variable name for conversation text (without braces).
 	conversationTextVar = "conversation_text"
@@ -324,7 +325,7 @@ func (s *sessionSummarizer) Summarize(ctx context.Context, sess *session.Session
 		return "", fmt.Errorf("failed to generate summary for session %s: %w", sess.ID, err)
 	}
 
-	s.recordLastIncludedTimestamp(sess, eventsToSummarize)
+	s.recordLastIncludedBoundary(sess, eventsToSummarize)
 
 	if s.postHook != nil {
 		hookCtx := &PostSummaryHookContext{
@@ -344,13 +345,19 @@ func (s *sessionSummarizer) Summarize(ctx context.Context, sess *session.Session
 	return summaryText, nil
 }
 
-// recordLastIncludedTimestamp records the last included timestamp in the session state.
-func (s *sessionSummarizer) recordLastIncludedTimestamp(sess *session.Session, events []event.Event) {
+// recordLastIncludedBoundary records the last included summary boundary in the session state.
+func (s *sessionSummarizer) recordLastIncludedBoundary(sess *session.Session, events []event.Event) {
 	if sess == nil || len(events) == 0 {
 		return
 	}
-	last := events[len(events)-1].Timestamp.UTC()
-	sess.SetState(lastIncludedTsKey, []byte(last.Format(time.RFC3339Nano)))
+	last := events[len(events)-1]
+	lastTimestamp := last.Timestamp.UTC()
+	sess.SetState(lastIncludedTsKey, []byte(lastTimestamp.Format(time.RFC3339Nano)))
+	if last.ID == "" {
+		sess.DeleteState(lastIncludedEventIDKey)
+		return
+	}
+	sess.SetState(lastIncludedEventIDKey, []byte(last.ID))
 }
 
 func (s *sessionSummarizer) buildCheckSession(

--- a/session/summary/summarizer_test.go
+++ b/session/summary/summarizer_test.go
@@ -1623,13 +1623,14 @@ func TestSessionSummarizer_SummarizeWithSkipRecent(t *testing.T) {
 	})
 }
 
-func TestSessionSummarizer_RecordLastIncludedTimestamp(t *testing.T) {
+func TestSessionSummarizer_RecordLastIncludedBoundary(t *testing.T) {
 	now := time.Now().UTC()
 	keepTs := now.Add(-2 * time.Minute)
 	sess := &session.Session{
 		ID: "ts-session",
 		Events: []event.Event{
 			{
+				ID:        "keep-event",
 				Author:    "user",
 				Timestamp: keepTs,
 				Response: &model.Response{Choices: []model.Choice{{
@@ -1657,18 +1658,19 @@ func TestSessionSummarizer_RecordLastIncludedTimestamp(t *testing.T) {
 	got, err := time.Parse(time.RFC3339Nano, string(raw))
 	require.NoError(t, err)
 	assert.True(t, got.Equal(keepTs))
+	assert.Equal(t, "keep-event", string(sess.State[lastIncludedEventIDKey]))
 }
 
-func TestSessionSummarizer_RecordLastIncludedTimestamp_NoStateOrEvents(t *testing.T) {
+func TestSessionSummarizer_RecordLastIncludedBoundary_NoStateOrEvents(t *testing.T) {
 	s := &sessionSummarizer{}
 
 	t.Run("nil session", func(t *testing.T) {
-		s.recordLastIncludedTimestamp(nil, nil)
+		s.recordLastIncludedBoundary(nil, nil)
 	})
 
 	t.Run("empty events does nothing", func(t *testing.T) {
 		sess := &session.Session{}
-		s.recordLastIncludedTimestamp(sess, []event.Event{})
+		s.recordLastIncludedBoundary(sess, []event.Event{})
 		assert.Nil(t, sess.State)
 	})
 }


### PR DESCRIPTION
## Summary

- add explicit summary boundary metadata with a conservative cutoff timestamp
- use summary boundaries when rebuilding prompt history and pre-LLM compaction snapshots
- preserve tool-call protocol shape when a summary cutoff lands between historical tool calls and tool results

## Tests

- go test -cover ./session ./session/internal/summary ./internal/flow/processor ./internal/flow/llmflow
- go test ./... in session/redis
- go test ./... in session/sqlite
- go test ./... in session/mysql
- go test ./... in session/postgres
- go test ./... in session/clickhouse
- go test ./... in session/pgvector

## Notes

- root go test ./... still fails locally on macOS in unrelated packages: tool/hostexec references Linux-only SysProcAttr.Pdeathsig, and internal/skillstage panics while cleaning a read-only symlink workspace
