### PR TITLE
telemetry: add workflow elapsed metrics

### DIFF
--- a/graph/executor.go
+++ b/graph/executor.go
@@ -459,6 +459,7 @@ func (e *Executor) executeGraph(
 		eventChan, invocation.InvocationID, execState, resumed, lastCkpt,
 	)
 	execCtx.Invocation = invocation
+	execCtx.startTime = startTime
 	// Initialize per-execution input channels from the prepared state.
 	e.initializeChannels(execCtx, execState, true)
 	if len(restoredPending) > 0 {
@@ -3144,8 +3145,10 @@ type nodeExecutionContext struct {
 }
 
 type workflowMetricRecorder struct {
-	once       sync.Once
-	start      time.Time
+	once      sync.Once
+	start     time.Time
+	rootStart time.Time
+
 	attributes itelemetry.WorkflowAttributes
 }
 
@@ -3165,6 +3168,9 @@ func (r *workflowMetricRecorder) record(ctx context.Context, err error) {
 		attrs := r.attributes
 		attrs.Error = err
 		itelemetry.ReportWorkflowMetrics(ctx, attrs, time.Since(r.start))
+		if !r.rootStart.IsZero() {
+			itelemetry.ReportWorkflowElapsedMetrics(ctx, attrs, time.Since(r.rootStart))
+		}
 	})
 }
 
@@ -3669,8 +3675,14 @@ func (e *Executor) newWorkflowMetricRecorder(
 		}
 	}
 
+	var rootStart time.Time
+	if execCtx != nil {
+		rootStart = execCtx.startTime
+	}
 	return &workflowMetricRecorder{
-		start:      start,
+		start:     start,
+		rootStart: rootStart,
+
 		attributes: attrs,
 	}
 }

--- a/graph/executor_metric_workflow_test.go
+++ b/graph/executor_metric_workflow_test.go
@@ -110,6 +110,10 @@ func TestWorkflowMetricRetryRecordsOnce(t *testing.T) {
 	require.Len(t, points, 1)
 	require.Equal(t, uint64(1), points[0].Count)
 	require.False(t, workflowPointHasAttrKey(points[0], semconvtrace.KeyErrorType))
+	elapsedPts := collectWorkflowElapsedMetricPoints(t, reader)
+	require.Len(t, elapsedPts, 1)
+	require.Equal(t, uint64(1), elapsedPts[0].Count)
+	require.False(t, workflowPointHasAttrKey(elapsedPts[0], semconvtrace.KeyErrorType))
 }
 
 func TestWorkflowMetricCacheHitRecordsWithoutCacheDimension(t *testing.T) {
@@ -140,6 +144,10 @@ func TestWorkflowMetricCacheHitRecordsWithoutCacheDimension(t *testing.T) {
 	require.Len(t, points, 1)
 	require.Equal(t, uint64(2), points[0].Count)
 	require.False(t, workflowPointHasAttrKey(points[0], MetadataKeyCacheHit))
+	elapsedPts := collectWorkflowElapsedMetricPoints(t, reader)
+	require.Len(t, elapsedPts, 1)
+	require.Equal(t, uint64(2), elapsedPts[0].Count)
+	require.False(t, workflowPointHasAttrKey(elapsedPts[0], MetadataKeyCacheHit))
 }
 
 func TestWorkflowMetricBeforeCallbackCustomResultRecordsSuccess(t *testing.T) {
@@ -166,6 +174,109 @@ func TestWorkflowMetricBeforeCallbackCustomResultRecordsSuccess(t *testing.T) {
 	require.Len(t, points, 1)
 	require.Equal(t, uint64(1), points[0].Count)
 	require.False(t, workflowPointHasAttrKey(points[0], semconvtrace.KeyErrorType))
+	elapsedPts := collectWorkflowElapsedMetricPoints(t, reader)
+	require.Len(t, elapsedPts, 1)
+	require.Equal(t, uint64(1), elapsedPts[0].Count)
+	require.False(t, workflowPointHasAttrKey(elapsedPts[0], semconvtrace.KeyErrorType))
+}
+
+func TestWorkflowElapsedMetricRecordsOnSuccess(t *testing.T) {
+	reader, cleanup := setupWorkflowMetricReader(t)
+	defer cleanup()
+
+	sg := NewStateGraph(NewStateSchema())
+	sg.AddNode("work", func(ctx context.Context, state State) (any, error) {
+		time.Sleep(10 * time.Millisecond)
+		return State{"ok": true}, nil
+	}).SetEntryPoint("work").SetFinishPoint("work")
+	exec := compileExecutorForWorkflowMetric(t, sg)
+
+	inv := agent.NewInvocation(
+		agent.WithInvocationID("inv-workflow-elapsed-success"),
+		agent.WithInvocationSession(&session.Session{AppName: "test-app", UserID: "user-1"}),
+	)
+	ch, err := exec.Execute(context.Background(), State{}, inv)
+	require.NoError(t, err)
+	drainWorkflowEvents(ch)
+
+	nodePts := collectWorkflowMetricPoints(t, reader)
+	require.Len(t, nodePts, 1)
+	require.False(t, workflowPointHasAttrKey(nodePts[0], semconvmetrics.KeyGenAIWorkflowElapsedFrom))
+	require.False(t, workflowPointHasAttrKey(nodePts[0], semconvmetrics.KeyGenAIWorkflowElapsedTo))
+
+	elapsedPts := collectWorkflowElapsedMetricPoints(t, reader)
+	require.Len(t, elapsedPts, 1)
+	require.Equal(t, uint64(1), elapsedPts[0].Count)
+	require.GreaterOrEqual(t, elapsedPts[0].Sum, nodePts[0].Sum)
+	require.True(t, workflowPointHasAttr(elapsedPts[0], semconvtrace.KeyGenAIWorkflowID, "work"))
+	require.True(t, workflowPointHasAttr(elapsedPts[0], semconvtrace.KeyGenAIAppName, "test-app"))
+	require.True(t, workflowPointHasAttr(elapsedPts[0], semconvmetrics.KeyGenAIWorkflowElapsedFrom, semconvmetrics.ValueGenAIWorkflowElapsedFromRootWorkflowStart))
+	require.True(t, workflowPointHasAttr(elapsedPts[0], semconvmetrics.KeyGenAIWorkflowElapsedTo, semconvmetrics.ValueGenAIWorkflowElapsedToCurrentWorkflowEnd))
+	require.False(t, workflowPointHasAttrKey(elapsedPts[0], semconvtrace.KeyErrorType))
+}
+
+func TestWorkflowElapsedMetricRecordsOnFailure(t *testing.T) {
+	reader, cleanup := setupWorkflowMetricReader(t)
+	defer cleanup()
+
+	sg := NewStateGraph(NewStateSchema())
+	sg.AddNode("fail", func(ctx context.Context, state State) (any, error) {
+		return nil, fmt.Errorf("boom")
+	}).SetEntryPoint("fail").SetFinishPoint("fail")
+	exec := compileExecutorForWorkflowMetric(t, sg)
+
+	ch, err := exec.Execute(context.Background(), State{}, agent.NewInvocation(
+		agent.WithInvocationID("inv-workflow-elapsed-failure"),
+	))
+	require.NoError(t, err)
+	drainWorkflowEvents(ch)
+
+	elapsedPts := collectWorkflowElapsedMetricPoints(t, reader)
+	require.Len(t, elapsedPts, 1)
+	require.Equal(t, uint64(1), elapsedPts[0].Count)
+	require.True(t, workflowPointHasAttr(elapsedPts[0], semconvtrace.KeyGenAIWorkflowID, "fail"))
+	require.True(t, workflowPointHasAttr(elapsedPts[0], semconvtrace.KeyErrorType, semconvtrace.ValueDefaultErrorType))
+}
+
+func TestWorkflowElapsedMetricMultipleNodes(t *testing.T) {
+	reader, cleanup := setupWorkflowMetricReader(t)
+	defer cleanup()
+
+	sg := NewStateGraph(NewStateSchema())
+	sg.AddNode("step1", func(ctx context.Context, state State) (any, error) {
+		time.Sleep(20 * time.Millisecond)
+		return State{"step1": true}, nil
+	})
+	sg.AddNode("step2", func(ctx context.Context, state State) (any, error) {
+		time.Sleep(20 * time.Millisecond)
+		return State{"step2": true}, nil
+	})
+	sg.SetEntryPoint("step1")
+	sg.AddEdge("step1", "step2")
+	sg.SetFinishPoint("step2")
+	exec := compileExecutorForWorkflowMetric(t, sg)
+
+	ch, err := exec.Execute(context.Background(), State{}, agent.NewInvocation(
+		agent.WithInvocationID("inv-workflow-elapsed-multi"),
+	))
+	require.NoError(t, err)
+	drainWorkflowEvents(ch)
+
+	elapsedPts := collectWorkflowElapsedMetricPoints(t, reader)
+	require.Len(t, elapsedPts, 2)
+
+	var step1Elapsed, step2Elapsed float64
+	for _, pt := range elapsedPts {
+		if workflowPointHasAttr(pt, semconvtrace.KeyGenAIWorkflowID, "step1") {
+			step1Elapsed = pt.Sum
+		}
+		if workflowPointHasAttr(pt, semconvtrace.KeyGenAIWorkflowID, "step2") {
+			step2Elapsed = pt.Sum
+		}
+	}
+	require.Positive(t, step1Elapsed)
+	require.Positive(t, step2Elapsed)
+	require.Greater(t, step2Elapsed, step1Elapsed)
 }
 
 func TestWorkflowMetricRecorderBuildsFallbackAttributes(t *testing.T) {
@@ -387,6 +498,7 @@ func setupWorkflowMetricReader(t *testing.T) (*sdkmetric.ManualReader, func()) {
 	originalProvider := itelemetry.MeterProvider
 	originalMeter := itelemetry.WorkflowMeter
 	originalDuration := itelemetry.WorkflowMetricGenAIClientOperationDuration
+	originalElapsed := itelemetry.WorkflowMetricGenAIWorkflowElapsedTime
 
 	itelemetry.MeterProvider = provider
 	itelemetry.WorkflowMeter = provider.Meter(semconvmetrics.MeterNameWorkflow)
@@ -397,11 +509,18 @@ func setupWorkflowMetricReader(t *testing.T) (*sdkmetric.ManualReader, func()) {
 		semconvmetrics.MetricGenAIClientOperationDuration,
 	)
 	require.NoError(t, err)
+	itelemetry.WorkflowMetricGenAIWorkflowElapsedTime, err = histogram.NewDynamicFloat64Histogram(
+		provider,
+		semconvmetrics.MeterNameWorkflow,
+		semconvmetrics.MetricGenAIWorkflowElapsedTime,
+	)
+	require.NoError(t, err)
 
 	return reader, func() {
 		itelemetry.MeterProvider = originalProvider
 		itelemetry.WorkflowMeter = originalMeter
 		itelemetry.WorkflowMetricGenAIClientOperationDuration = originalDuration
+		itelemetry.WorkflowMetricGenAIWorkflowElapsedTime = originalElapsed
 	}
 }
 
@@ -423,12 +542,27 @@ func collectWorkflowMetricPoints(
 	t *testing.T,
 	reader *sdkmetric.ManualReader,
 ) []metricdata.HistogramDataPoint[float64] {
+	return collectWorkflowMetricPointsByName(t, reader, semconvmetrics.MetricGenAIClientOperationDuration)
+}
+
+func collectWorkflowElapsedMetricPoints(
+	t *testing.T,
+	reader *sdkmetric.ManualReader,
+) []metricdata.HistogramDataPoint[float64] {
+	return collectWorkflowMetricPointsByName(t, reader, semconvmetrics.MetricGenAIWorkflowElapsedTime)
+}
+
+func collectWorkflowMetricPointsByName(
+	t *testing.T,
+	reader *sdkmetric.ManualReader,
+	metricName string,
+) []metricdata.HistogramDataPoint[float64] {
 	t.Helper()
 	var rm metricdata.ResourceMetrics
 	require.NoError(t, reader.Collect(context.Background(), &rm))
 	for _, scopeMetric := range rm.ScopeMetrics {
 		for _, metric := range scopeMetric.Metrics {
-			if metric.Name != semconvmetrics.MetricGenAIClientOperationDuration {
+			if metric.Name != metricName {
 				continue
 			}
 			hist, ok := metric.Data.(metricdata.Histogram[float64])
@@ -436,7 +570,7 @@ func collectWorkflowMetricPoints(
 			return hist.DataPoints
 		}
 	}
-	t.Fatalf("metric %s not found", semconvmetrics.MetricGenAIClientOperationDuration)
+	t.Fatalf("metric %s not found", metricName)
 	return nil
 }
 

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -16,6 +16,7 @@ import (
 	"sort"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/event"
@@ -485,6 +486,8 @@ type ExecutionContext struct {
 	Graph        *Graph
 	EventChan    chan<- *event.Event
 	InvocationID string
+	// startTime is the root workflow start time for elapsed-time metrics.
+	startTime time.Time
 	// Invocation is the per-run invocation context. Nodes may use it to
 	// read invocation-scoped state (for example, {invocation:*} placeholders).
 	Invocation *agent.Invocation

--- a/internal/telemetry/metric_workflow.go
+++ b/internal/telemetry/metric_workflow.go
@@ -26,6 +26,9 @@ var (
 
 	// WorkflowMetricGenAIClientOperationDuration records graph workflow/node execution durations in seconds.
 	WorkflowMetricGenAIClientOperationDuration *histogram.DynamicFloat64Histogram
+
+	// WorkflowMetricGenAIWorkflowElapsedTime records relative workflow elapsed time in seconds.
+	WorkflowMetricGenAIWorkflowElapsedTime *histogram.DynamicFloat64Histogram
 )
 
 // WorkflowAttributes is the attributes for workflow execution metrics.
@@ -38,6 +41,8 @@ type WorkflowAttributes struct {
 	WorkflowID   string
 	WorkflowName string
 	WorkflowType string
+	ElapsedFrom  string
+	ElapsedTo    string
 	Error        error
 	ErrorType    string
 }
@@ -64,6 +69,24 @@ func (a WorkflowAttributes) toAttributes() []attribute.KeyValue {
 	return attrs
 }
 
+func (a WorkflowAttributes) toElapsedAttributes() []attribute.KeyValue {
+	attrs := a.toAttributes()
+	elapsedFrom := a.ElapsedFrom
+	if elapsedFrom == "" {
+		elapsedFrom = metrics.ValueGenAIWorkflowElapsedFromRootWorkflowStart
+	}
+	elapsedTo := a.ElapsedTo
+	if elapsedTo == "" {
+		elapsedTo = metrics.ValueGenAIWorkflowElapsedToCurrentWorkflowEnd
+	}
+	attrs = append(
+		attrs,
+		attribute.String(metrics.KeyGenAIWorkflowElapsedFrom, elapsedFrom),
+		attribute.String(metrics.KeyGenAIWorkflowElapsedTo, elapsedTo),
+	)
+	return attrs
+}
+
 // ReportWorkflowMetrics reports the workflow execution metrics.
 func ReportWorkflowMetrics(ctx context.Context, attrs WorkflowAttributes, duration time.Duration) {
 	if WorkflowMetricGenAIClientOperationDuration == nil {
@@ -73,5 +96,17 @@ func ReportWorkflowMetrics(ctx context.Context, attrs WorkflowAttributes, durati
 		ctx,
 		duration.Seconds(),
 		metric.WithAttributes(attrs.toAttributes()...),
+	)
+}
+
+// ReportWorkflowElapsedMetrics reports relative workflow elapsed-time metrics.
+func ReportWorkflowElapsedMetrics(ctx context.Context, attrs WorkflowAttributes, duration time.Duration) {
+	if WorkflowMetricGenAIWorkflowElapsedTime == nil {
+		return
+	}
+	WorkflowMetricGenAIWorkflowElapsedTime.Record(
+		ctx,
+		duration.Seconds(),
+		metric.WithAttributes(attrs.toElapsedAttributes()...),
 	)
 }

--- a/internal/telemetry/metric_workflow_test.go
+++ b/internal/telemetry/metric_workflow_test.go
@@ -78,10 +78,12 @@ func TestReportWorkflowMetrics(t *testing.T) {
 	originalProvider := MeterProvider
 	originalMeter := WorkflowMeter
 	originalDuration := WorkflowMetricGenAIClientOperationDuration
+	originalElapsed := WorkflowMetricGenAIWorkflowElapsedTime
 	defer func() {
 		MeterProvider = originalProvider
 		WorkflowMeter = originalMeter
 		WorkflowMetricGenAIClientOperationDuration = originalDuration
+		WorkflowMetricGenAIWorkflowElapsedTime = originalElapsed
 	}()
 
 	MeterProvider = provider
@@ -112,6 +114,52 @@ func TestReportWorkflowMetrics(t *testing.T) {
 	require.Len(t, points, 1)
 	require.Equal(t, uint64(1), points[0].Count)
 	require.True(t, workflowAttrSetContains(points[0].Attributes, semconvtrace.KeyGenAIWorkflowID, "retrieve"))
+	require.False(t, workflowAttrSetContainsKey(points[0].Attributes, metrics.KeyGenAIWorkflowElapsedFrom))
+	require.False(t, workflowAttrSetContainsKey(points[0].Attributes, metrics.KeyGenAIWorkflowElapsedTo))
+}
+
+func TestReportWorkflowElapsedMetrics(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	originalProvider := MeterProvider
+	originalMeter := WorkflowMeter
+	originalElapsed := WorkflowMetricGenAIWorkflowElapsedTime
+	defer func() {
+		MeterProvider = originalProvider
+		WorkflowMeter = originalMeter
+		WorkflowMetricGenAIWorkflowElapsedTime = originalElapsed
+	}()
+
+	MeterProvider = provider
+	WorkflowMeter = provider.Meter(metrics.MeterNameWorkflow)
+	var err error
+	WorkflowMetricGenAIWorkflowElapsedTime, err = histogram.NewDynamicFloat64Histogram(
+		provider,
+		metrics.MeterNameWorkflow,
+		metrics.MetricGenAIWorkflowElapsedTime,
+		metric.WithUnit("s"),
+	)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	ReportWorkflowElapsedMetrics(ctx, WorkflowAttributes{
+		AppName:      "test-app",
+		UserID:       "user-123",
+		AgentID:      "agent-1",
+		WorkflowID:   "retrieve",
+		WorkflowName: "retrieve",
+		WorkflowType: WorkflowTypeFunction.String(),
+	}, 250*time.Millisecond)
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(ctx, &rm))
+	points := workflowHistogramPointsByName(t, rm, metrics.MetricGenAIWorkflowElapsedTime)
+	require.Len(t, points, 1)
+	require.Equal(t, uint64(1), points[0].Count)
+	require.True(t, workflowAttrSetContains(points[0].Attributes, semconvtrace.KeyGenAIWorkflowID, "retrieve"))
+	require.True(t, workflowAttrSetContains(points[0].Attributes, metrics.KeyGenAIWorkflowElapsedFrom, metrics.ValueGenAIWorkflowElapsedFromRootWorkflowStart))
+	require.True(t, workflowAttrSetContains(points[0].Attributes, metrics.KeyGenAIWorkflowElapsedTo, metrics.ValueGenAIWorkflowElapsedToCurrentWorkflowEnd))
 }
 
 func TestReportWorkflowMetricsNoopWhenHistogramNil(t *testing.T) {
@@ -123,6 +171,18 @@ func TestReportWorkflowMetricsNoopWhenHistogramNil(t *testing.T) {
 
 	require.NotPanics(t, func() {
 		ReportWorkflowMetrics(context.Background(), WorkflowAttributes{}, time.Millisecond)
+	})
+}
+
+func TestReportWorkflowElapsedMetricsNoopWhenHistogramNil(t *testing.T) {
+	originalElapsed := WorkflowMetricGenAIWorkflowElapsedTime
+	defer func() {
+		WorkflowMetricGenAIWorkflowElapsedTime = originalElapsed
+	}()
+	WorkflowMetricGenAIWorkflowElapsedTime = nil
+
+	require.NotPanics(t, func() {
+		ReportWorkflowElapsedMetrics(context.Background(), WorkflowAttributes{}, time.Millisecond)
 	})
 }
 
@@ -148,10 +208,18 @@ func workflowHistogramPoints(
 	t *testing.T,
 	rm metricdata.ResourceMetrics,
 ) []metricdata.HistogramDataPoint[float64] {
+	return workflowHistogramPointsByName(t, rm, metrics.MetricGenAIClientOperationDuration)
+}
+
+func workflowHistogramPointsByName(
+	t *testing.T,
+	rm metricdata.ResourceMetrics,
+	metricName string,
+) []metricdata.HistogramDataPoint[float64] {
 	t.Helper()
 	for _, scopeMetric := range rm.ScopeMetrics {
 		for _, metric := range scopeMetric.Metrics {
-			if metric.Name != metrics.MetricGenAIClientOperationDuration {
+			if metric.Name != metricName {
 				continue
 			}
 			require.Equal(t, "s", metric.Unit)
@@ -160,13 +228,22 @@ func workflowHistogramPoints(
 			return hist.DataPoints
 		}
 	}
-	t.Fatalf("metric %s not found", metrics.MetricGenAIClientOperationDuration)
+	t.Fatalf("metric %s not found", metricName)
 	return nil
 }
 
 func workflowAttrSetContains(set attribute.Set, key string, value string) bool {
 	for _, kv := range set.ToSlice() {
 		if string(kv.Key) == key && kv.Value.AsString() == value {
+			return true
+		}
+	}
+	return false
+}
+
+func workflowAttrSetContainsKey(set attribute.Set, key string) bool {
+	for _, kv := range set.ToSlice() {
+		if string(kv.Key) == key {
 			return true
 		}
 	}

--- a/telemetry/metric/genai_workflow_zh.md
+++ b/telemetry/metric/genai_workflow_zh.md
@@ -10,7 +10,12 @@
 - `gen_ai.workflow.name`
 - `gen_ai.workflow.type`
 
-该监控项的指标名使用 `gen_ai.client.operation.duration`，通过 workflow 维度标识 graph node 执行耗时语义。
+该监控项当前包含两类耗时：
+
+- `gen_ai.client.operation.duration`：当前 workflow 观测对象自身的执行耗时。
+- `gen_ai.workflow.elapsed_time`：当前 workflow 观测对象相对某两个生命周期点的累计耗时。
+
+trpc-agent-go 当前把 graph node 适配为 workflow 观测对象，因此 `gen_ai.workflow.id/name/type` 标识当前 graph node，而不是额外引入 `workflow -> node` 层级。
 
 ## 监控项
 
@@ -24,6 +29,7 @@
 | 指标名 | 指标语义 | 指标类型 | 单位 | 上报时机 |
 | --- | --- | --- | --- | --- |
 | `gen_ai.client.operation.duration` | graph workflow/node 执行耗时 | histogram | 秒 | graph node 执行完成或执行失败时上报一次 |
+| `gen_ai.workflow.elapsed_time` | 当前 workflow 观测对象的相对累计耗时 | histogram | 秒 | graph node 执行完成或执行失败时上报一次 |
 
 `histogram` 用于支持平均值、p95、p99 等聚合统计。
 
@@ -39,6 +45,8 @@
 | `gen_ai.workflow.id` | string | workflow/node id | `retrieve` | 必填 |
 | `gen_ai.workflow.name` | string | workflow/node 名称 | `execute_function_node retrieve` | 必填 |
 | `gen_ai.workflow.type` | string | workflow/node 类型 | `function` | 必填 |
+| `gen_ai.workflow.elapsed.from` | string | elapsed time 计算起点 | `root_workflow.start` | 仅上报 `gen_ai.workflow.elapsed_time` 时填写 |
+| `gen_ai.workflow.elapsed.to` | string | elapsed time 计算终点 | `current_workflow.end` | 仅上报 `gen_ai.workflow.elapsed_time` 时填写 |
 | `error.type` | string | 错误类型 | `timeout` | 错误时必填 |
 | `gen_ai.agent.name` | string | agent name | `agent_1` | 选填 |
 
@@ -58,14 +66,23 @@
 
 ## 上报口径
 
-节点耗时从 graph executor 记录的 node start time 开始，到节点最终 complete 或 error 为止。
+`gen_ai.client.operation.duration` 从 graph executor 记录的 node start time 开始，到节点最终 complete 或 error 为止。
+
+`gen_ai.workflow.elapsed_time` 是可选的相对耗时指标；只有上报该指标时，才需要同时填写 `gen_ai.workflow.elapsed.from` 和 `gen_ai.workflow.elapsed.to` 描述计算口径。当前 trpc-agent-go 初始映射为：
+
+- `gen_ai.workflow.elapsed.from=root_workflow.start`：本次 root workflow 执行窗口开始。当前实现对应本次 graph `Execute()` start。
+- `gen_ai.workflow.elapsed.to=current_workflow.end`：当前 workflow 观测对象结束。当前实现对应当前 graph node 最终 complete 或 error。
+
+`gen_ai.workflow.elapsed.from/to` 只描述耗时计算点；当前观测对象仍由 `gen_ai.workflow.id/name/type` 标识。
+
+当前先不扩展额外拓扑维度，避免在 DAG 分支、join、resume 等场景下引入未定义的聚合口径。
 
 需要覆盖以下场景：
 
 - 正常执行成功：上报耗时，不带 `error.type`。
 - 执行失败：上报耗时，并带 `error.type`。
 - before callback 返回 custom result 跳过节点函数：仍视为节点完成，上报从 node start 到 custom result 完成的耗时。
-- cache hit：仍视为节点完成，上报 cache hit 路径耗时；不增加 cache hit 维度。
+- cache hit：仍视为节点完成，上报 cache hit 节点耗时和 elapsed time；不增加 cache hit 维度。
 - retry：只对最终结果上报一次完整节点耗时；不增加 retry attempt 维度。
 
 ## 与现有指标的关系
@@ -73,6 +90,8 @@
 `GenAIInvokeAgent` 统计一次 agent 调用的整体耗时，适合看单次请求总耗时。
 
 `trpc_agent_go.internal.workflow` 统计 graph workflow/node 维度耗时，适合定位具体慢节点。两者是父子关系，指标名同为 `gen_ai.client.operation.duration` 时，需要通过 `gen_ai.workflow.*` 等维度区分 graph node 口径。
+
+`gen_ai.workflow.elapsed_time` 补充当前 workflow 观测对象相对 root workflow start 的累计耗时，适合观察“从本次 workflow 开始到当前对象完成”的用户视角到达时间；它不表示各节点耗时求和。
 
 ## 与现有代码的差异
 
@@ -95,3 +114,5 @@
 - app/user 维度统一使用 `gen_ai.*` 命名，即 `gen_ai.app.name`、`gen_ai.user.id`。
 - cache hit、retry attempt 不作为维度。
 - `gen_ai.system` 允许为空；有模型信息时优先使用模型 system。
+- elapsed time 为可选指标；仅上报 `gen_ai.workflow.elapsed_time` 时填写 `gen_ai.workflow.elapsed.from/to`，初始取值为 `root_workflow.start` 到 `current_workflow.end`。
+- 暂不增加额外拓扑维度。

--- a/telemetry/metric/metric.go
+++ b/telemetry/metric/metric.go
@@ -226,6 +226,11 @@ func setWorkflowHistogramBuckets(metricName string, boundaries []float64) error 
 			return fmt.Errorf("workflow metric %s not initialized", metricName)
 		}
 		return itelemetry.WorkflowMetricGenAIClientOperationDuration.SetBuckets(boundaries)
+	case metrics.MetricGenAIWorkflowElapsedTime:
+		if itelemetry.WorkflowMetricGenAIWorkflowElapsedTime == nil {
+			return fmt.Errorf("workflow metric %s not initialized", metricName)
+		}
+		return itelemetry.WorkflowMetricGenAIWorkflowElapsedTime.SetBuckets(boundaries)
 	default:
 		return fmt.Errorf("unknown or unsupported workflow histogram metric: %s", metricName)
 	}
@@ -293,6 +298,15 @@ func initWorkflowMetrics(mp metric.MeterProvider) error {
 		metric.WithUnit("s"),
 	); err != nil {
 		return fmt.Errorf("failed to create %s metric %s: %w", meterName, metrics.MetricGenAIClientOperationDuration, err)
+	}
+	if itelemetry.WorkflowMetricGenAIWorkflowElapsedTime, err = histogram.NewDynamicFloat64Histogram(
+		mp,
+		metrics.MeterNameWorkflow,
+		metrics.MetricGenAIWorkflowElapsedTime,
+		metric.WithDescription("Elapsed time from root workflow start to current workflow end"),
+		metric.WithUnit("s"),
+	); err != nil {
+		return fmt.Errorf("failed to create %s metric %s: %w", meterName, metrics.MetricGenAIWorkflowElapsedTime, err)
 	}
 
 	return nil

--- a/telemetry/metric/metric_test.go
+++ b/telemetry/metric/metric_test.go
@@ -357,16 +357,21 @@ func TestInitMeterProvider(t *testing.T) {
 	if itelemetry.WorkflowMetricGenAIClientOperationDuration == nil {
 		t.Error("WorkflowMetricGenAIClientOperationDuration was not created")
 	}
+	if itelemetry.WorkflowMetricGenAIWorkflowElapsedTime == nil {
+		t.Error("WorkflowMetricGenAIWorkflowElapsedTime was not created")
+	}
 }
 
 func TestInitMeterProvider_WorkflowMetricError(t *testing.T) {
 	originalMP := itelemetry.MeterProvider
 	originalWorkflowMeter := itelemetry.WorkflowMeter
 	originalWorkflowOpDur := itelemetry.WorkflowMetricGenAIClientOperationDuration
+	originalWorkflowElapsed := itelemetry.WorkflowMetricGenAIWorkflowElapsedTime
 	defer func() {
 		itelemetry.MeterProvider = originalMP
 		itelemetry.WorkflowMeter = originalWorkflowMeter
 		itelemetry.WorkflowMetricGenAIClientOperationDuration = originalWorkflowOpDur
+		itelemetry.WorkflowMetricGenAIWorkflowElapsedTime = originalWorkflowElapsed
 	}()
 
 	mp := &namedMockMeterProvider{
@@ -389,9 +394,11 @@ func TestInitMeterProvider_WorkflowMetricError(t *testing.T) {
 func TestInitWorkflowMetrics_ErrorHandling(t *testing.T) {
 	originalWorkflowMeter := itelemetry.WorkflowMeter
 	originalWorkflowOpDur := itelemetry.WorkflowMetricGenAIClientOperationDuration
+	originalWorkflowElapsed := itelemetry.WorkflowMetricGenAIWorkflowElapsedTime
 	defer func() {
 		itelemetry.WorkflowMeter = originalWorkflowMeter
 		itelemetry.WorkflowMetricGenAIClientOperationDuration = originalWorkflowOpDur
+		itelemetry.WorkflowMetricGenAIWorkflowElapsedTime = originalWorkflowElapsed
 	}()
 
 	if err := initWorkflowMetrics(nil); err == nil || !strings.Contains(err.Error(), "workflow meter provider is nil") {
@@ -409,6 +416,18 @@ func TestInitWorkflowMetrics_ErrorHandling(t *testing.T) {
 	if !strings.Contains(err.Error(), "failed to create trpc_agent_go.internal.workflow metric gen_ai.client.operation.duration") {
 		t.Fatalf("unexpected error: %v", err)
 	}
+
+	mp = &mockMeterProvider{meter: &mockMeter{
+		shouldFail: true,
+		failOn:     metrics.MetricGenAIWorkflowElapsedTime,
+	}}
+	err = initWorkflowMetrics(mp)
+	if err == nil {
+		t.Fatalf("expected workflow elapsed histogram creation error")
+	}
+	if !strings.Contains(err.Error(), "failed to create trpc_agent_go.internal.workflow metric gen_ai.workflow.elapsed_time") {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }
 
 func TestSetHistogramBuckets_RoutingAndErrors(t *testing.T) {
@@ -424,6 +443,7 @@ func TestSetHistogramBuckets_RoutingAndErrors(t *testing.T) {
 	origInvokeTokenUsage := itelemetry.InvokeAgentMetricGenAIClientTokenUsage
 	origInvokeOpDur := itelemetry.InvokeAgentMetricGenAIClientOperationDuration
 	origWorkflowOpDur := itelemetry.WorkflowMetricGenAIClientOperationDuration
+	origWorkflowElapsed := itelemetry.WorkflowMetricGenAIWorkflowElapsedTime
 	defer func() {
 		itelemetry.MeterProvider = originalMP
 		itelemetry.ChatMetricGenAIClientOperationDuration = origChatOpDur
@@ -437,6 +457,7 @@ func TestSetHistogramBuckets_RoutingAndErrors(t *testing.T) {
 		itelemetry.InvokeAgentMetricGenAIClientTokenUsage = origInvokeTokenUsage
 		itelemetry.InvokeAgentMetricGenAIClientOperationDuration = origInvokeOpDur
 		itelemetry.WorkflowMetricGenAIClientOperationDuration = origWorkflowOpDur
+		itelemetry.WorkflowMetricGenAIWorkflowElapsedTime = origWorkflowElapsed
 	}()
 
 	reset := func(t *testing.T) {
@@ -496,6 +517,8 @@ func TestSetHistogramBuckets_RoutingAndErrors(t *testing.T) {
 			switch metricName {
 			case metrics.MetricGenAIClientOperationDuration:
 				itelemetry.WorkflowMetricGenAIClientOperationDuration = nil
+			case metrics.MetricGenAIWorkflowElapsedTime:
+				itelemetry.WorkflowMetricGenAIWorkflowElapsedTime = nil
 			}
 		}
 	}
@@ -577,6 +600,12 @@ func TestSetHistogramBuckets_RoutingAndErrors(t *testing.T) {
 			name:       "workflow: operation duration",
 			meterName:  metrics.MeterNameWorkflow,
 			metricName: metrics.MetricGenAIClientOperationDuration,
+			boundaries: []float64{0.1, 1, 10},
+		},
+		{
+			name:       "workflow: elapsed time",
+			meterName:  metrics.MeterNameWorkflow,
+			metricName: metrics.MetricGenAIWorkflowElapsedTime,
 			boundaries: []float64{0.1, 1, 10},
 		},
 
@@ -719,6 +748,15 @@ func TestSetHistogramBuckets_RoutingAndErrors(t *testing.T) {
 			metricName:  metrics.MetricGenAIClientOperationDuration,
 			boundaries:  []float64{1},
 			before:      nilWorkflowMetric(metrics.MetricGenAIClientOperationDuration),
+			wantErr:     true,
+			errContains: "not initialized",
+		},
+		{
+			name:        "workflow elapsed time not initialized",
+			meterName:   metrics.MeterNameWorkflow,
+			metricName:  metrics.MetricGenAIWorkflowElapsedTime,
+			boundaries:  []float64{1},
+			before:      nilWorkflowMetric(metrics.MetricGenAIWorkflowElapsedTime),
 			wantErr:     true,
 			errContains: "not initialized",
 		},

--- a/telemetry/semconv/metrics/metrics.go
+++ b/telemetry/semconv/metrics/metrics.go
@@ -39,6 +39,16 @@ const (
 
 	// MetricGenAIClientOperationDuration represents the duration of client operation.
 	MetricGenAIClientOperationDuration = "gen_ai.client.operation.duration"
+	// MetricGenAIWorkflowElapsedTime represents workflow elapsed time between two lifecycle points.
+	MetricGenAIWorkflowElapsedTime = "gen_ai.workflow.elapsed_time"
+	// KeyGenAIWorkflowElapsedFrom represents the lifecycle point elapsed time is measured from.
+	KeyGenAIWorkflowElapsedFrom = "gen_ai.workflow.elapsed.from"
+	// KeyGenAIWorkflowElapsedTo represents the lifecycle point elapsed time is measured to.
+	KeyGenAIWorkflowElapsedTo = "gen_ai.workflow.elapsed.to"
+	// ValueGenAIWorkflowElapsedFromRootWorkflowStart represents the root workflow start point.
+	ValueGenAIWorkflowElapsedFromRootWorkflowStart = "root_workflow.start"
+	// ValueGenAIWorkflowElapsedToCurrentWorkflowEnd represents the current workflow end point.
+	ValueGenAIWorkflowElapsedToCurrentWorkflowEnd = "current_workflow.end"
 	// MetricTRPCAgentGoClientTimeToFirstToken represents the time to first token for client.
 	// Note: This metric will be reported alongside MetricGenAIServerTimeToFirstToken with the same value.
 	MetricTRPCAgentGoClientTimeToFirstToken = "trpc_agent_go.client.time_to_first_token" // #nosec G101 - this is a metric key name, not a credential.


### PR DESCRIPTION
## Summary
- Add workflow elapsed-time metric reporting from root workflow start to current node completion.
- Add semantic constants, meter initialization, bucket routing, and focused metric tests.
- Update the workflow metric protocol doc to clarify optional elapsed-time dimensions and avoid extra topology/path terminology.

## Test plan
- go test ./graph