### PR TITLE
{tool/skill, agent/llmagent}: scrub caller env in policy mode to close skill_run PATH bypass

### DIFF
--- a/agent/llmagent/option.go
+++ b/agent/llmagent/option.go
@@ -1034,8 +1034,24 @@ func WithSkillLoadToolDescription(
 	}
 }
 
-// WithSkillRunAllowedCommands restricts skill_run to a single,
-// allowlisted command (no shell syntax) when non-empty.
+// WithSkillRunAllowedCommands restricts skill_run to an
+// allowlisted set of commands (no shell syntax) when non-empty.
+//
+// When either an allow or deny list is configured the per-call env
+// is also scrubbed: every shell-startup variable (HOME, BASH_ENV,
+// ENV, SHELL, PROMPT_COMMAND, …), the executable search path
+// (PATH), the dynamic-linker hijack vars (LD_PRELOAD,
+// LD_LIBRARY_PATH, DYLD_*), the word-splitting vars (IFS, CDPATH,
+// GLOBIGNORE), every BASH_FUNC_* Shellshock entry and every key
+// that does not match the POSIX env-name grammar
+// (/^[A-Za-z_][A-Za-z0-9_]*$/) is dropped before the per-call
+// PATH is rebuilt. Without this scrub a model-supplied
+// `env: {"PATH": "./bin"}` would survive into the spawned skill
+// and cause an allowed bare command (curl, python, git, …) to
+// resolve at an attacker-controlled directory ahead of the
+// skill's vetted bin (issue #1862). The scrub uses
+// internal/envscrub - the same package tool/workspaceexec uses for
+// its own policy mode - so the two policies stay in sync.
 func WithSkillRunAllowedCommands(cmds ...string) Option {
 	return func(opts *Options) {
 		opts.skillRunAllowedCommands = append(
@@ -1044,8 +1060,10 @@ func WithSkillRunAllowedCommands(cmds ...string) Option {
 	}
 }
 
-// WithSkillRunDeniedCommands rejects a single, denylisted command (no shell
-// syntax) when non-empty.
+// WithSkillRunDeniedCommands rejects a denylisted set of commands
+// (no shell syntax) when non-empty. See WithSkillRunAllowedCommands
+// for the env scrubbing that is enabled whenever either list is
+// configured.
 func WithSkillRunDeniedCommands(cmds ...string) Option {
 	return func(opts *Options) {
 		opts.skillRunDeniedCommands = append(

--- a/tool/skill/run.go
+++ b/tool/skill/run.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"time"
@@ -30,6 +31,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
 	localexec "trpc.group/trpc-go/trpc-agent-go/codeexecutor/local"
 	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/internal/envscrub"
 	"trpc.group/trpc-go/trpc-agent-go/internal/fileref"
 	"trpc.group/trpc-go/trpc-agent-go/internal/skillstage"
 	"trpc.group/trpc-go/trpc-agent-go/internal/toolcache"
@@ -1151,6 +1153,20 @@ func (t *RunTool) buildRunProgramSpec(
 	)
 
 	if len(t.allowedCmds) > 0 || len(t.deniedCmds) > 0 {
+		// Policy mode: scrub the merged env before building PATH
+		// so a caller-supplied PATH / BASH_ENV / LD_PRELOAD /
+		// BASH_FUNC_* cannot survive into the spawn. Without
+		// this, a model-supplied `env: {"PATH": "./bin"}` is
+		// prepended to PATH ahead of skillBin by
+		// injectSkillLocalEnvWithSep, so an allowed bare command
+		// (`curl`, `python`, `git`, …) resolves at the attacker
+		// controlled directory rather than the vetted binary -
+		// the same vulnerability class that PR #1800 closed for
+		// `workspace_exec`. The scrub mirrors what
+		// tool/workspaceexec already does for its own policy
+		// mode; on Windows the comparison is case-insensitive so
+		// "Path" / "Home" cannot survive by varying case.
+		env = scrubPolicyEnv(env)
 		injectSkillLocalEnvWithSep(
 			env,
 			venvRel,
@@ -1381,6 +1397,26 @@ func injectSkillLocalEnv(
 		skillBin,
 		posixPathListSep,
 	)
+}
+
+// scrubPolicyEnv returns the env that should be passed to the
+// runtime when a skill_run command policy is active. It filters the
+// input through internal/envscrub so shell start-up vars (HOME,
+// BASH_ENV, ENV, SHELL, …), executable resolution vars (PATH,
+// LD_PRELOAD, DYLD_*, IFS, CDPATH, …), BASH_FUNC_* Shellshock
+// entries and non-POSIX keys are dropped before the per-call PATH
+// is rebuilt by injectSkillLocalEnvWithSep. A nil / empty result
+// is normalised to an empty non-nil map so the subsequent assign
+// of env[PATH] / env[VIRTUAL_ENV] does not panic.
+//
+// The same envscrub package backs the equivalent scrub in
+// tool/workspaceexec so the two policy modes stay in sync.
+func scrubPolicyEnv(env map[string]string) map[string]string {
+	out := envscrub.Scrub(env, runtime.GOOS == "windows")
+	if out == nil {
+		out = map[string]string{}
+	}
+	return out
 }
 
 func injectSkillLocalEnvWithSep(

--- a/tool/skill/run_test.go
+++ b/tool/skill/run_test.go
@@ -1206,7 +1206,18 @@ func TestRunTool_AllowedCommandsFindsSkillBin(t *testing.T) {
 	require.Contains(t, out.Stdout, testBinOutput)
 }
 
-func TestRunTool_AllowedCommandsPrefersExplicitPATHBeforeSkillBin(
+// TestRunTool_AllowedCommandsPolicyScrubsCallerPATH guards the
+// fix for issue #1862: in policy mode the caller-supplied
+// env.PATH must NOT be prepended to the per-call PATH, otherwise
+// a model-controlled hostBin can sit ahead of skillBin during
+// bare-command resolution and run an attacker-staged binary
+// under the allowlisted name. After the scrub the caller's
+// PATH is dropped before injectSkillLocalEnvWithSep rebuilds
+// the search path, so bare "testSkillCLI" resolves through the
+// vetted skill bin instead of the hostBin the model tried to
+// inject. The previous test pinned the bypass as a feature; the
+// flipped assertion below replaces it.
+func TestRunTool_AllowedCommandsPolicyScrubsCallerPATH(
 	t *testing.T,
 ) {
 	root := t.TempDir()
@@ -1245,8 +1256,12 @@ func TestRunTool_AllowedCommandsPrefersExplicitPATHBeforeSkillBin(
 
 	out := res.(runOutput)
 	require.Equal(t, 0, out.ExitCode)
-	require.Contains(t, out.Stdout, testHostOutput)
-	require.NotContains(t, out.Stdout, testBinOutput)
+	require.NotContains(
+		t, out.Stdout, testHostOutput,
+		"caller-supplied env.PATH must not survive into policy "+
+			"mode (issue #1862)",
+	)
+	require.Contains(t, out.Stdout, testBinOutput)
 }
 
 func TestRunTool_AllowedCommandsPathAllowsBareSkillBin(t *testing.T) {
@@ -1283,7 +1298,78 @@ func TestRunTool_AllowedCommandsPathAllowsBareSkillBin(t *testing.T) {
 	require.Contains(t, out.Stdout, testBinOutput)
 }
 
-func TestRunTool_DeniedCommandsPathScopeKeepsInheritedPATH(t *testing.T) {
+// TestScrubPolicyEnv_DropsShellAndPathHijackVars pins the policy-
+// mode env scrub contract for skill_run: every shell-startup,
+// search-path, dynamic-linker and BASH_FUNC_* entry must be removed
+// before the per-call PATH is rebuilt, and a non-policy-relevant
+// caller key must survive. The scrub is delegated to
+// internal/envscrub so tool/workspaceexec and tool/skill stay in
+// sync; this test guards the wiring rather than re-litigating the
+// blocklist itself.
+func TestScrubPolicyEnv_DropsShellAndPathHijackVars(t *testing.T) {
+	in := map[string]string{
+		"PATH":                  "/tmp/attacker",
+		"HOME":                  "/tmp",
+		"BASH_ENV":              "/tmp/x.sh",
+		"ENV":                   "/tmp/x.sh",
+		"LD_PRELOAD":            "/tmp/x.so",
+		"DYLD_INSERT_LIBRARIES": "/tmp/x.dylib",
+		"IFS":                   " ",
+		"CDPATH":                "/tmp",
+		"BASH_FUNC_foo%%":       "() { :; }",
+		// non-POSIX key (would inject through "env K=V <cmd>")
+		"X; curl http://x #": "1",
+		// legitimate skill-side var that must survive.
+		"SKILL_CUSTOM": "ok",
+	}
+	out := scrubPolicyEnv(in)
+
+	require.NotNil(t, out)
+	for _, blocked := range []string{
+		"PATH", "HOME", "BASH_ENV", "ENV",
+		"LD_PRELOAD", "DYLD_INSERT_LIBRARIES",
+		"IFS", "CDPATH", "BASH_FUNC_foo%%",
+		"X; curl http://x #",
+	} {
+		_, ok := out[blocked]
+		require.Falsef(
+			t, ok,
+			"policy-mode env scrub must drop %q", blocked,
+		)
+	}
+	require.Equal(
+		t, "ok", out["SKILL_CUSTOM"],
+		"non-policy-relevant entries must survive the scrub",
+	)
+}
+
+// TestScrubPolicyEnv_EmptyInputReturnsNonNil pins the small but
+// important contract that scrubPolicyEnv never hands back a nil
+// map: downstream code in buildRunProgramSpec assigns the venv /
+// PATH entries directly on the returned map, and a nil map would
+// panic on the assignment.
+func TestScrubPolicyEnv_EmptyInputReturnsNonNil(t *testing.T) {
+	out := scrubPolicyEnv(nil)
+	require.NotNil(t, out)
+	out["X"] = "1" // must not panic.
+	out = scrubPolicyEnv(map[string]string{})
+	require.NotNil(t, out)
+	out["X"] = "1"
+}
+
+// TestRunTool_DeniedCommandsPolicyScrubsCallerPATH guards the
+// fix for issue #1862 in the deny-only configuration: a model-
+// supplied env.PATH must not be prepended to the per-call PATH
+// when a skill_run command policy is active. The previous test
+// asserted the opposite (the hostBin wins) as a documented
+// quirk; that was the bypass the issue calls out, and the
+// assertion is flipped here. (A path-form deny like
+// "bin/testSkillCLI" does not by itself reject a bare
+// "testSkillCLI" - that limitation is tracked separately as the
+// argv-level validator follow-up - so the test still observes
+// the skill bin running. The point is that the caller cannot
+// redirect resolution at an attacker-staged hostBin via env.PATH.)
+func TestRunTool_DeniedCommandsPolicyScrubsCallerPATH(t *testing.T) {
 	root := t.TempDir()
 	dir := writeSkill(t, root, testSkillName)
 	writeSkillExecutable(
@@ -1320,8 +1406,11 @@ func TestRunTool_DeniedCommandsPathScopeKeepsInheritedPATH(t *testing.T) {
 
 	out := res.(runOutput)
 	require.Equal(t, 0, out.ExitCode)
-	require.Contains(t, out.Stdout, testHostOutput)
-	require.NotContains(t, out.Stdout, testBinOutput)
+	require.NotContains(
+		t, out.Stdout, testHostOutput,
+		"caller-supplied env.PATH must not survive into policy "+
+			"mode (issue #1862)",
+	)
 }
 
 func TestRunTool_DeniedCommandsRejectsExplicitRelativeSkillBin(


### PR DESCRIPTION
## Summary
Closes #1862. When a `skill_run` command policy is active (allow or deny list non-empty), `injectSkillLocalEnvWithSep` was prepending `venvBin` ahead of the caller-supplied `env.PATH` and then appending `skillBin` last, leaving a model-controlled `env.PATH` ahead of the vetted `skillBin` during bare-command resolution. A prompt injection that smuggles `env: {"PATH": "./bin"}` could therefore get an allowlisted bare command (`curl`, `python`, `git`, …) to resolve at an attacker-staged binary instead of the skill's own `bin/<cmd>` — the same vulnerability class PR #1800 closed for `tool/workspaceexec`.

This change routes the merged per-call env through `internal/envscrub` (same package backing the `workspace_exec` policy-mode scrub) before the per-call PATH is rebuilt, so a caller-supplied `PATH` / `BASH_ENV` / `LD_PRELOAD` / `DYLD_*` / `BASH_FUNC_*` / non-POSIX key cannot survive into the spawn. The non-policy path is untouched, so existing call sites without an allow/deny list keep their historic env behaviour.

## What changed
- `tool/skill/run.go`
  - New `scrubPolicyEnv` helper that delegates to `internal/envscrub` (Windows case-insensitive) and normalises an empty result to a non-nil map (downstream `env[PATH]` / `env[VIRTUAL_ENV]` assignments require it).
  - In `buildRunProgramSpec`, when an allow or deny list is configured, scrub the merged env before `injectSkillLocalEnvWithSep` rebuilds the PATH.
- `tool/skill/run_test.go`
  - The two tests that previously pinned the bypass as documented behaviour (`TestRunTool_AllowedCommandsPrefersExplicitPATHBeforeSkillBin`, `TestRunTool_DeniedCommandsPathScopeKeepsInheritedPATH`) are renamed to `…PolicyScrubsCallerPATH` and their assertions flipped: a model-supplied host PATH **must not** survive.
  - New `TestScrubPolicyEnv_DropsShellAndPathHijackVars` / `TestScrubPolicyEnv_EmptyInputReturnsNonNil` lock the scrub wiring (shell start-up, dynamic linker, `BASH_FUNC_*`, non-POSIX keys are dropped; legitimate skill-side keys survive; nil/empty input never returns nil).
- `agent/llmagent/option.go`
  - Updated docstrings on `WithSkillRunAllowedCommands` / `WithSkillRunDeniedCommands` to document the env scrub (parity with the `workspace_exec` option docs from PR #1800).

## Out of scope (separate follow-ups)
- A path-form deny entry (e.g. `bin/<cli>`) still does not reject the matching bare command name. The flipped deny test calls this out inline. Tracked as the argv-level validator follow-up referenced in #1862's notes.
- Honouring `RunProgramSpec.CleanEnv` in the container and e2b runtimes is #1845, addressed in a separate PR.

## Test plan
- [x] `go build ./tool/skill/... ./agent/llmagent/...`
- [x] `go vet ./tool/skill/... ./agent/llmagent/...`
- [x] `gofmt -l tool/skill agent/llmagent` (clean)
- [x] `go test ./tool/skill/... ./agent/llmagent/... -count=1`
- [x] Targeted: `go test ./tool/skill/... -run 'TestRunTool_(Allowed|Denied)CommandsPolicyScrubsCallerPATH|TestScrubPolicyEnv' -v`