### PR TITLE
session: respect tool result threshold for summaries

### DIFF
--- a/internal/flow/processor/content.go
+++ b/internal/flow/processor/content.go
@@ -1002,9 +1002,9 @@ func (p *ContentRequestProcessor) getIncrementMessages(inv *agent.Invocation, si
 
 // compactCurrentInvocationEvent preserves the minimum structured state needed
 // for same-turn tool loops after a summary has already absorbed earlier
-// invocation history. Assistant tool-call messages are kept intact, while tool
-// results are replaced with a small placeholder that points the model at the
-// summary for details.
+// invocation history. Assistant tool-call messages are kept intact, while
+// oversized tool results are replaced with a small placeholder that points the
+// model at the summary for details.
 func (p *ContentRequestProcessor) compactCurrentInvocationEvent(
 	evt event.Event,
 	inv *agent.Invocation,
@@ -1029,11 +1029,12 @@ func (p *ContentRequestProcessor) compactCurrentInvocationEvent(
 		return event.Event{}, false
 	}
 
+	cfg := normalizeContextCompactionConfig(p.ContextCompactionConfig)
 	var compactedChoices []model.Choice
 	for _, choice := range evt.Choices {
 		msg, ok := compactedCurrentInvocationMessage(
 			choice.Message,
-			p.ContextCompactionConfig,
+			cfg,
 		)
 		if !ok {
 			continue
@@ -1073,6 +1074,9 @@ func compactedCurrentInvocationMessage(
 		if cfg.keepToolResult(msg) {
 			return msg, true
 		}
+		if !shouldCompactCurrentInvocationToolResult(msg, cfg) {
+			return msg, true
+		}
 		return model.Message{
 			Role:     msg.Role,
 			Content:  compactedToolResultPlaceholder,
@@ -1082,6 +1086,24 @@ func compactedCurrentInvocationMessage(
 	default:
 		return model.Message{}, false
 	}
+}
+
+func shouldCompactCurrentInvocationToolResult(
+	msg model.Message,
+	cfg ContextCompactionConfig,
+) bool {
+	if cfg.ToolResultMaxTokens <= 0 {
+		return false
+	}
+	counter := cfg.TokenCounter
+	if counter == nil {
+		counter = model.NewSimpleTokenCounter()
+	}
+	tokens, err := counter.CountTokens(context.Background(), msg)
+	if err != nil {
+		return false
+	}
+	return tokens > cfg.ToolResultMaxTokens
 }
 
 func annotateUserMessagesWithAttachedFiles(
@@ -1733,6 +1755,7 @@ func eventHasCompactedCurrentInvocationToolResult(
 	evt event.Event,
 	cfg ContextCompactionConfig,
 ) bool {
+	cfg = normalizeContextCompactionConfig(cfg)
 	for _, choice := range evt.Choices {
 		msg := choice.Message
 		if msg.Role != model.RoleTool || msg.ToolID == "" {

--- a/internal/flow/processor/content.go
+++ b/internal/flow/processor/content.go
@@ -901,8 +901,7 @@ func (p *ContentRequestProcessor) getIncrementMessages(inv *agent.Invocation, si
 	var includedInvocationMessage bool
 
 	var events []event.Event
-	inv.Session.EventMu.RLock()
-	for _, evt := range inv.Session.Events {
+	for _, evt := range snapshotSessionEvents(inv.Session) {
 		if compactedEvt, ok := p.compactCurrentInvocationEvent(
 			evt,
 			inv,
@@ -928,7 +927,6 @@ func (p *ContentRequestProcessor) getIncrementMessages(inv *agent.Invocation, si
 		}
 		events = append(events, evt)
 	}
-	inv.Session.EventMu.RUnlock()
 
 	// insert invocation message
 	if !includedInvocationMessage && model.HasPayload(inv.Message) {
@@ -1394,15 +1392,22 @@ func (p *ContentRequestProcessor) collectCurrentInvocationEvents(
 	inv *agent.Invocation,
 ) []event.Event {
 	var events []event.Event
-	inv.Session.EventMu.RLock()
-	for _, evt := range inv.Session.Events {
+	for _, evt := range snapshotSessionEvents(inv.Session) {
 		if !isCurrentInvocationEligibleEvent(evt, inv.InvocationID) {
 			continue
 		}
 		events = append(events, normalizeCurrentInvocationEvent(evt))
 	}
-	inv.Session.EventMu.RUnlock()
 	return events
+}
+
+func snapshotSessionEvents(sess *session.Session) []event.Event {
+	if sess == nil {
+		return nil
+	}
+	sess.EventMu.RLock()
+	defer sess.EventMu.RUnlock()
+	return append([]event.Event(nil), sess.Events...)
 }
 
 func isCurrentInvocationEligibleEvent(
@@ -1723,10 +1728,7 @@ func (p *ContentRequestProcessor) hasCompactedCurrentInvocationToolResults(
 
 	filter := inv.GetEventFilterKey()
 
-	inv.Session.EventMu.RLock()
-	defer inv.Session.EventMu.RUnlock()
-
-	for _, evt := range inv.Session.Events {
+	for _, evt := range snapshotSessionEvents(inv.Session) {
 		if evt.RequestID != inv.RunOptions.RequestID ||
 			evt.InvocationID != inv.InvocationID {
 			continue

--- a/internal/flow/processor/content_messages_test.go
+++ b/internal/flow/processor/content_messages_test.go
@@ -795,7 +795,10 @@ func TestProcessRequest_SessionSummary_CompactsSameTurnToolHistory(t *testing.T)
 			model.NewSystemMessage("system prompt"),
 		},
 	}
-	p := NewContentRequestProcessor(WithAddSessionSummary(true))
+	p := NewContentRequestProcessor(
+		WithAddSessionSummary(true),
+		WithContextCompactionToolResultMaxTokens(10),
+	)
 	p.ProcessRequest(context.Background(), inv, req, nil)
 
 	raw, ok := inv.GetState(contentHasCompactedToolResultsStateKey)
@@ -818,6 +821,99 @@ func TestProcessRequest_SessionSummary_CompactsSameTurnToolHistory(t *testing.T)
 	require.Equal(t, compactedToolResultPlaceholder,
 		req.Messages[3].Content)
 	require.NotContains(t, req.Messages[3].Content, "large-result;")
+}
+
+func TestProcessRequest_SessionSummary_PreservesSmallSameTurnToolHistory(t *testing.T) {
+	baseTime := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	userMsg := model.NewUserMessage("run the task")
+	toolCallMsg := model.Message{
+		Role:    model.RoleAssistant,
+		Content: "Starting with step 1.",
+		ToolCalls: []model.ToolCall{{
+			Type: "function",
+			ID:   "call_1",
+			Function: model.FunctionDefinitionParam{
+				Name:      "step_worker",
+				Arguments: []byte(`{"step":1}`),
+			},
+		}},
+	}
+	toolResultMsg := model.Message{
+		Role:     model.RoleTool,
+		ToolID:   "call_1",
+		ToolName: "step_worker",
+		Content:  "small result",
+	}
+	sess := &session.Session{
+		Summaries: map[string]*session.Summary{
+			"test-agent": {
+				Summary:   "step 1 completed successfully",
+				UpdatedAt: baseTime.Add(2 * time.Second),
+			},
+		},
+		Events: []event.Event{
+			{
+				Author:       "user",
+				RequestID:    "req1",
+				InvocationID: "inv1",
+				Timestamp:    baseTime,
+				Version:      event.CurrentVersion,
+				Response: &model.Response{
+					Done:    true,
+					Choices: []model.Choice{{Index: 0, Message: userMsg}},
+				},
+			},
+			{
+				Author:       "test-agent",
+				RequestID:    "req1",
+				InvocationID: "inv1",
+				Timestamp:    baseTime.Add(time.Second),
+				Version:      event.CurrentVersion,
+				Response: &model.Response{
+					Done:    true,
+					Choices: []model.Choice{{Index: 0, Message: toolCallMsg}},
+				},
+			},
+			{
+				Author:       "test-agent",
+				RequestID:    "req1",
+				InvocationID: "inv1",
+				Timestamp:    baseTime.Add(2 * time.Second),
+				Version:      event.CurrentVersion,
+				Response: &model.Response{
+					Done:    true,
+					Object:  model.ObjectTypeToolResponse,
+					Choices: []model.Choice{{Index: 0, Message: toolResultMsg}},
+				},
+			},
+		},
+	}
+
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationID("inv1"),
+		agent.WithInvocationEventFilterKey("test-agent"),
+		agent.WithInvocationMessage(userMsg),
+		agent.WithInvocationRunOptions(agent.RunOptions{RequestID: "req1"}),
+	)
+	inv.AgentName = "test-agent"
+
+	req := &model.Request{
+		Messages: []model.Message{
+			model.NewSystemMessage("system prompt"),
+		},
+	}
+	p := NewContentRequestProcessor(WithAddSessionSummary(true))
+	p.ProcessRequest(context.Background(), inv, req, nil)
+
+	_, ok := inv.GetState(contentHasCompactedToolResultsStateKey)
+	require.False(t, ok)
+
+	require.Len(t, req.Messages, 4)
+	require.Equal(t, model.RoleTool, req.Messages[3].Role)
+	require.Equal(t, "call_1", req.Messages[3].ToolID)
+	require.Equal(t, "step_worker", req.Messages[3].ToolName)
+	require.Equal(t, "small result", req.Messages[3].Content)
 }
 
 func TestContentRequestProcessor_HasCompactedCurrentInvocationToolResults(t *testing.T) {
@@ -920,7 +1016,7 @@ func TestContentRequestProcessor_HasCompactedCurrentInvocationToolResults(t *tes
 	})
 
 	t.Run("detects compacted tool result", func(t *testing.T) {
-		p := NewContentRequestProcessor()
+		p := NewContentRequestProcessor(WithContextCompactionToolResultMaxTokens(1))
 		inv := agent.NewInvocation(
 			agent.WithInvocationID("inv1"),
 			agent.WithInvocationRunOptions(agent.RunOptions{RequestID: "req1"}),
@@ -936,7 +1032,7 @@ func TestContentRequestProcessor_HasCompactedCurrentInvocationToolResults(t *tes
 							Choices: []model.Choice{{Index: 0, Message: model.NewToolMessage(
 								"call_1",
 								"worker",
-								"result",
+								"result result",
 							)}},
 						},
 					},
@@ -973,6 +1069,7 @@ func TestContentRequestProcessor_HasCompactedCurrentInvocationToolResults(t *tes
 		p := NewContentRequestProcessor(
 			WithBranchFilterMode(BranchFilterModeExact),
 			WithContextCompactionKeepToolNames("session_load"),
+			WithContextCompactionToolResultMaxTokens(1),
 		)
 		inv := agent.NewInvocation(
 			agent.WithInvocationID("inv1"),
@@ -993,7 +1090,7 @@ func TestContentRequestProcessor_HasCompactedCurrentInvocationToolResults(t *tes
 							Choices: []model.Choice{{Index: 0, Message: model.NewToolMessage(
 								reusedToolID,
 								"",
-								"result",
+								"result result",
 							)}},
 						},
 					},
@@ -1053,7 +1150,7 @@ func TestContentRequestProcessor_HasCompactedCurrentInvocationToolResults(t *tes
 	})
 
 	t.Run("detects compacted tool result in later choice", func(t *testing.T) {
-		p := NewContentRequestProcessor()
+		p := NewContentRequestProcessor(WithContextCompactionToolResultMaxTokens(1))
 		inv := agent.NewInvocation(
 			agent.WithInvocationID("inv1"),
 			agent.WithInvocationRunOptions(agent.RunOptions{RequestID: "req1"}),
@@ -1071,7 +1168,7 @@ func TestContentRequestProcessor_HasCompactedCurrentInvocationToolResults(t *tes
 								{Index: 1, Message: model.NewToolMessage(
 									"call_1",
 									"worker",
-									"result",
+									"result result",
 								)},
 							},
 						},

--- a/internal/flow/processor/content_test.go
+++ b/internal/flow/processor/content_test.go
@@ -3971,7 +3971,10 @@ func TestContentRequestProcessor_getIncrementMessages_SummaryPreservesToolState(
 	)
 	inv.AgentName = "test-agent"
 
-	p := NewContentRequestProcessor(WithAddSessionSummary(true))
+	p := NewContentRequestProcessor(
+		WithAddSessionSummary(true),
+		WithContextCompactionToolResultMaxTokens(1),
+	)
 	messages := p.getIncrementMessages(inv, baseTime.Add(2*time.Second))
 
 	if assert.Len(t, messages, 5) {

--- a/internal/flow/processor/context_compact_test.go
+++ b/internal/flow/processor/context_compact_test.go
@@ -535,7 +535,9 @@ func TestCompactedCurrentInvocationMessage_KeepToolName(t *testing.T) {
 
 	baseline, baselineOK := compactedCurrentInvocationMessage(
 		msg,
-		ContextCompactionConfig{},
+		ContextCompactionConfig{
+			ToolResultMaxTokens: 10,
+		},
 	)
 	require.True(t, baselineOK)
 	require.Equal(t, compactedToolResultPlaceholder, baseline.Content)
@@ -543,6 +545,7 @@ func TestCompactedCurrentInvocationMessage_KeepToolName(t *testing.T) {
 	compacted, ok := compactedCurrentInvocationMessage(
 		msg,
 		ContextCompactionConfig{
+			ToolResultMaxTokens: 10,
 			toolResultCompactionRules: toolResultCompactionRules{
 				keepToolNames: toolNameSet([]string{"session_load"}),
 			},

--- a/internal/flow/processor/context_compact_test.go
+++ b/internal/flow/processor/context_compact_test.go
@@ -558,6 +558,42 @@ func TestCompactedCurrentInvocationMessage_KeepToolName(t *testing.T) {
 	require.Equal(t, msg.ToolName, compacted.ToolName)
 }
 
+func TestShouldCompactCurrentInvocationToolResult_DisabledAndErrors(t *testing.T) {
+	msg := model.NewToolMessage("call_worker", "worker", "large result")
+
+	require.False(t, shouldCompactCurrentInvocationToolResult(
+		msg,
+		ContextCompactionConfig{ToolResultMaxTokens: 0},
+	))
+
+	require.False(t, shouldCompactCurrentInvocationToolResult(
+		msg,
+		ContextCompactionConfig{
+			ToolResultMaxTokens: 1,
+			TokenCounter: &sequenceTokenCounter{
+				errs: []error{errors.New("count tokens")},
+			},
+		},
+	))
+}
+
+func TestSnapshotSessionEvents(t *testing.T) {
+	require.Nil(t, snapshotSessionEvents(nil))
+
+	sess := &session.Session{
+		Events: []event.Event{{
+			RequestID: "req1",
+		}},
+	}
+	events := snapshotSessionEvents(sess)
+
+	require.Len(t, events, 1)
+	require.Equal(t, "req1", events[0].RequestID)
+
+	events[0].RequestID = "changed"
+	require.Equal(t, "req1", sess.Events[0].RequestID)
+}
+
 func TestContextCompactionToolResultOptions(t *testing.T) {
 	skipFunc := func([]event.Event) int { return 2 }
 	p := NewContentRequestProcessor(


### PR DESCRIPTION
## Summary
- keep same-turn summary-covered tool results in raw history when they are under ToolResultMaxTokens
- only replace oversized same-turn tool results with the summary placeholder, while preserving ToolID/ToolName
- add regression coverage for both compacted and preserved cases

## Validation
- go test ./internal/flow/processor -count=1
- go test ./internal/flow/... ./model/... -count=1
- go test ./... -count=1 (fails in existing unrelated TestChunkedReaderUsesRepoRootForScope: document "demo.Serve" not found)
