### PR TITLE
feat: implement e2b sandbox Pause/Resume via standard connect endpoint

### DIFF
--- a/codeexecutor/e2b/e2b.go
+++ b/codeexecutor/e2b/e2b.go
@@ -523,6 +523,20 @@ func (c *CodeExecutor) Engine() codeexecutor.Engine {
 	return codeexecutor.NewEngine(rt, rt, rt)
 }
 
+// Pause suspends the sandbox without destroying it. The sandbox filesystem
+// and memory state are preserved. Call New with WithSandboxID to resume.
+// Only the owner of a sandbox (i.e. the executor that created it) should
+// pause it; connected executors should leave lifecycle management to the
+// creator.
+func (c *CodeExecutor) Pause(ctx context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.sbx == nil {
+		return fmt.Errorf("e2b: sandbox not initialized")
+	}
+	return c.sbx.Pause(ctx)
+}
+
 // Close terminates the owned sandbox (if any).
 func (c *CodeExecutor) Close() error {
 	c.mu.Lock()

--- a/codeexecutor/e2b/internal/codeinterpreter/sandbox.go
+++ b/codeexecutor/e2b/internal/codeinterpreter/sandbox.go
@@ -67,6 +67,11 @@ type SandboxInfo struct {
 	// same way: when present and the caller did not provide an AccessToken,
 	// the SDK uses this value as the X-Access-Token header.
 	EnvdAccessToken string `json:"envdAccessToken,omitempty"`
+	// TrafficAccessToken is an optional access token returned by the
+	// POST /sandboxes/{id}/connect endpoint. When present it is forwarded as
+	// the E2B-Traffic-Access-Token header on direct sandbox data-plane
+	// requests.
+	TrafficAccessToken string `json:"trafficAccessToken,omitempty"`
 }
 
 // Sandbox is a running E2B sandbox with code-interpreter capabilities.
@@ -208,8 +213,11 @@ func Create(ctx context.Context, opts *SandboxOpts) (*Sandbox, error) {
 	}, nil
 }
 
-// Connect attaches to an already running sandbox by its ID. The caller must
-// supply at least the API key (via opts or the env var).
+// Connect attaches to a sandbox by its ID. The sandbox may be running or
+// paused — the POST /sandboxes/{id}/connect endpoint handles both cases
+// (returning 200 for already-running sandboxes and 201 when a paused sandbox
+// is resumed). The caller must supply at least the API key (via opts or the
+// E2B_API_KEY env var).
 func Connect(ctx context.Context, sandboxID string, opts *SandboxOpts) (*Sandbox, error) {
 	if opts == nil {
 		opts = &SandboxOpts{}
@@ -226,13 +234,27 @@ func Connect(ctx context.Context, sandboxID string, opts *SandboxOpts) (*Sandbox
 	}
 	cfg.init()
 
+	if cfg.APIKey == "" {
+		return nil, &AuthenticationError{Message: "API key is required; set E2B_API_KEY or SandboxOpts.APIKey"}
+	}
+
+	timeoutSec := int(opts.Timeout / time.Second)
+	if timeoutSec == 0 {
+		timeoutSec = DefaultSandboxTimeout
+	}
+
+	body := map[string]any{"timeout": timeoutSec}
+
 	var info SandboxInfo
-	if err := cfg.do(ctx, "GET", "/sandboxes/"+sandboxID, nil, &info); err != nil {
+	if err := cfg.do(ctx, "POST", "/sandboxes/"+sandboxID+"/connect", body, &info); err != nil {
 		return nil, err
 	}
 
 	if info.EnvdAccessToken != "" && cfg.AccessToken == "" {
 		cfg.AccessToken = info.EnvdAccessToken
+	}
+	if info.TrafficAccessToken != "" && cfg.TrafficAccessToken == "" {
+		cfg.TrafficAccessToken = info.TrafficAccessToken
 	}
 
 	return &Sandbox{
@@ -256,6 +278,14 @@ func (s *Sandbox) SetTimeout(ctx context.Context, timeout time.Duration) error {
 		"timeout": int(timeout / time.Second),
 	}
 	return s.connection.do(ctx, "POST", "/sandboxes/"+s.id+"/timeout", body, nil)
+}
+
+// Pause suspends the sandbox, preserving its filesystem and memory state.
+// The sandbox can be resumed later by calling Connect with the same sandbox ID.
+// Pause is not destructive — the sandbox is not billed while paused and can
+// be woken up at any time.
+func (s *Sandbox) Pause(ctx context.Context) error {
+	return s.connection.do(ctx, "POST", "/sandboxes/"+s.id+"/pause", nil, nil)
 }
 
 // IsRunning checks whether the sandbox is still reachable.

--- a/codeexecutor/e2b/internal/codeinterpreter/sandbox_test.go
+++ b/codeexecutor/e2b/internal/codeinterpreter/sandbox_test.go
@@ -435,7 +435,7 @@ func (r *rewriteToServerTransport) RoundTrip(req *http.Request) (*http.Response,
 
 func TestConnect_ThroughMockAPI(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != "GET" || r.URL.Path != "/sandboxes/abc" {
+		if r.Method != "POST" || r.URL.Path != "/sandboxes/abc/connect" {
 			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -517,7 +517,10 @@ func TestConnect_MissingAPIKey(t *testing.T) {
 	t.Setenv("E2B_API_KEY", "")
 	_, err := Connect(context.Background(), "abc", nil)
 	if err == nil {
-		t.Fatal("expected error (no API key, no server)")
+		t.Fatal("expected error when API key missing")
+	}
+	if _, ok := err.(*AuthenticationError); !ok {
+		t.Errorf("expected AuthenticationError, got %T: %v", err, err)
 	}
 }
 
@@ -680,7 +683,7 @@ func TestConnect_BackfillsEnvdAccessToken(t *testing.T) {
 	t.Setenv("E2B_ACCESS_TOKEN", "")
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != "GET" || r.URL.Path != "/sandboxes/abc" {
+		if r.Method != "POST" || r.URL.Path != "/sandboxes/abc/connect" {
 			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -735,5 +738,71 @@ func TestConnect_DoesNotOverrideExplicitAccessToken(t *testing.T) {
 	}
 	if got := sbx.connection.AccessToken; got != "explicit-token" {
 		t.Errorf("explicit AccessToken should not be overridden; got %q", got)
+	}
+}
+
+func TestPause_ThroughMockAPI(t *testing.T) {
+	var paused bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" && r.URL.Path == "/sandboxes/abc/pause" {
+			paused = true
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	sbx := &Sandbox{
+		id: "abc",
+		connection: &ConnectionConfig{
+			APIKey:     "k",
+			Domain:     "e2b.test",
+			Debug:      true,
+			HTTPClient: &http.Client{Transport: &rewriteToServerTransport{target: srv.URL}},
+		},
+	}
+	if err := sbx.Pause(context.Background()); err != nil {
+		t.Fatalf("pause: %v", err)
+	}
+	if !paused {
+		t.Error("expected pause handler to have been called")
+	}
+}
+
+func TestConnect_BackfillsTrafficAccessToken(t *testing.T) {
+	t.Setenv("E2B_ACCESS_TOKEN", "")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" || r.URL.Path != "/sandboxes/abc/connect" {
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"sandboxID":"abc",
+			"clientID":"cid",
+			"templateID":"tpl",
+			"trafficAccessToken":"traffic-tok"
+		}`))
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Transport: &rewriteToServerTransport{target: srv.URL}}
+	sbx, err := Connect(context.Background(), "abc", &SandboxOpts{
+		APIKey:     "k",
+		Domain:     "e2b.test",
+		Debug:      true,
+		HTTPClient: client,
+	})
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	if got := sbx.connection.TrafficAccessToken; got != "traffic-tok" {
+		t.Errorf("expected TrafficAccessToken to be back-filled; got %q", got)
+	}
+	h := http.Header{}
+	sbx.addAuthHeaders(h)
+	if got := h.Get("E2B-Traffic-Access-Token"); got != "traffic-tok" {
+		t.Errorf("E2B-Traffic-Access-Token header: %q", got)
 	}
 }

--- a/codeexecutor/e2b/workspace_runtime_test.go
+++ b/codeexecutor/e2b/workspace_runtime_test.go
@@ -79,6 +79,10 @@ func (m *mockE2BServer) handle(w http.ResponseWriter, r *http.Request) {
 		m.mu.Unlock()
 		w.WriteHeader(http.StatusNoContent)
 		return
+	case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/connect"):
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"sandboxID":"sbx-mock","clientID":"c-mock","templateID":"code-interpreter-v1","state":"running"}`))
+		return
 	case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/sandboxes/"):
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"sandboxID":"sbx-mock","clientID":"c-mock","templateID":"code-interpreter-v1","state":"running"}`))


### PR DESCRIPTION
- Fix Connect() to use POST /sandboxes/{id}/connect instead of GET /sandboxes/{id}; the connect endpoint handles both running (200) and paused (201) sandboxes and is the E2B SDK standard
- Add explicit API key validation in Connect() before any network call
- Add TrafficAccessToken field to SandboxInfo and back-fill logic in Connect() so the E2B-Traffic-Access-Token header is set automatically
- Add Sandbox.Pause() calling POST /sandboxes/{id}/pause (204) which suspends the sandbox while preserving filesystem and memory state
- Add CodeExecutor.Pause() as the high-level wrapper with nil/lock guards
- Update sandbox_test.go: fix three Connect tests to assert POST /connect, upgrade TestConnect_MissingAPIKey to verify AuthenticationError type, add TestPause_ThroughMockAPI and TestConnect_BackfillsTrafficAccessToken
- Update mock server in workspace_runtime_test.go to handle POST /connect
- Add SKILL.md agent skill reference for the e2b sandbox executor