### PR TITLE
feat: implement e2b sandbox Pause/Resume via standard connect endpoint

### DIFF
--- a/codeexecutor/e2b/e2b.go
+++ b/codeexecutor/e2b/e2b.go
@@ -528,6 +528,8 @@ func (c *CodeExecutor) Engine() codeexecutor.Engine {
 // Only the owner of a sandbox (i.e. the executor that created it) should
 // pause it; connected executors should leave lifecycle management to the
 // creator.
+// After a successful pause the executor relinquishes ownership so that a
+// subsequent Close() call does not kill the paused sandbox.
 func (c *CodeExecutor) Pause(ctx context.Context) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -537,7 +539,13 @@ func (c *CodeExecutor) Pause(ctx context.Context) error {
 	if !c.owned {
 		return fmt.Errorf("e2b: only owner may pause sandbox")
 	}
-	return c.sbx.Pause(ctx)
+	if err := c.sbx.Pause(ctx); err != nil {
+		return err
+	}
+	// Detach ownership so Close() does not destroy the paused sandbox.
+	// The caller can resume it later via New(WithSandboxID(...)).
+	c.owned = false
+	return nil
 }
 
 // Close terminates the owned sandbox (if any).

--- a/codeexecutor/e2b/e2b.go
+++ b/codeexecutor/e2b/e2b.go
@@ -534,6 +534,9 @@ func (c *CodeExecutor) Pause(ctx context.Context) error {
 	if c.sbx == nil {
 		return fmt.Errorf("e2b: sandbox not initialized")
 	}
+	if !c.owned {
+		return fmt.Errorf("e2b: only owner may pause sandbox")
+	}
 	return c.sbx.Pause(ctx)
 }
 

--- a/codeexecutor/e2b/e2b.go
+++ b/codeexecutor/e2b/e2b.go
@@ -523,6 +523,20 @@ func (c *CodeExecutor) Engine() codeexecutor.Engine {
 	return codeexecutor.NewEngine(rt, rt, rt)
 }
 
+// Pause suspends the sandbox without destroying it. The sandbox filesystem
+// and memory state are preserved. Call New with WithSandboxID to resume.
+// Only the owner of a sandbox (i.e. the executor that created it) should
+// pause it; connected executors should leave lifecycle management to the
+// creator.
+func (c *CodeExecutor) Pause(ctx context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.sbx == nil {
+		return fmt.Errorf("e2b: sandbox not initialized")
+	}
+	return c.sbx.Pause(ctx)
+}
+
 // Close terminates the owned sandbox (if any).
 func (c *CodeExecutor) Close() error {
 	c.mu.Lock()

--- a/codeexecutor/e2b/internal/codeinterpreter/sandbox.go
+++ b/codeexecutor/e2b/internal/codeinterpreter/sandbox.go
@@ -67,6 +67,11 @@ type SandboxInfo struct {
 	// same way: when present and the caller did not provide an AccessToken,
 	// the SDK uses this value as the X-Access-Token header.
 	EnvdAccessToken string `json:"envdAccessToken,omitempty"`
+	// TrafficAccessToken is an optional access token returned by the
+	// POST /sandboxes/{id}/connect endpoint. When present it is forwarded as
+	// the E2B-Traffic-Access-Token header on direct sandbox data-plane
+	// requests.
+	TrafficAccessToken string `json:"trafficAccessToken,omitempty"`
 }
 
 // Sandbox is a running E2B sandbox with code-interpreter capabilities.
@@ -208,8 +213,11 @@ func Create(ctx context.Context, opts *SandboxOpts) (*Sandbox, error) {
 	}, nil
 }
 
-// Connect attaches to an already running sandbox by its ID. The caller must
-// supply at least the API key (via opts or the env var).
+// Connect attaches to a sandbox by its ID. The sandbox may be running or
+// paused — the POST /sandboxes/{id}/connect endpoint handles both cases
+// (returning 200 for already-running sandboxes and 201 when a paused sandbox
+// is resumed). The caller must supply at least the API key (via opts or the
+// E2B_API_KEY env var).
 func Connect(ctx context.Context, sandboxID string, opts *SandboxOpts) (*Sandbox, error) {
 	if opts == nil {
 		opts = &SandboxOpts{}
@@ -226,13 +234,27 @@ func Connect(ctx context.Context, sandboxID string, opts *SandboxOpts) (*Sandbox
 	}
 	cfg.init()
 
+	if cfg.APIKey == "" {
+		return nil, &AuthenticationError{Message: "API key is required; set E2B_API_KEY or SandboxOpts.APIKey"}
+	}
+
+	timeoutSec := int(opts.Timeout / time.Second)
+	if timeoutSec == 0 {
+		timeoutSec = DefaultSandboxTimeout
+	}
+
+	body := map[string]any{"timeout": timeoutSec}
+
 	var info SandboxInfo
-	if err := cfg.do(ctx, "GET", "/sandboxes/"+sandboxID, nil, &info); err != nil {
+	if err := cfg.do(ctx, "POST", "/sandboxes/"+sandboxID+"/connect", body, &info); err != nil {
 		return nil, err
 	}
 
 	if info.EnvdAccessToken != "" && cfg.AccessToken == "" {
 		cfg.AccessToken = info.EnvdAccessToken
+	}
+	if info.TrafficAccessToken != "" && cfg.TrafficAccessToken == "" {
+		cfg.TrafficAccessToken = info.TrafficAccessToken
 	}
 
 	return &Sandbox{
@@ -256,6 +278,14 @@ func (s *Sandbox) SetTimeout(ctx context.Context, timeout time.Duration) error {
 		"timeout": int(timeout / time.Second),
 	}
 	return s.connection.do(ctx, "POST", "/sandboxes/"+s.id+"/timeout", body, nil)
+}
+
+// Pause suspends the sandbox, preserving its filesystem and memory state.
+// The sandbox can be resumed later by calling Connect with the same sandbox ID.
+// Pause is not destructive — the sandbox is not billed while paused and can
+// be woken up at any time.
+func (s *Sandbox) Pause(ctx context.Context) error {
+	return s.connection.do(ctx, "POST", "/sandboxes/"+s.id+"/pause", nil, nil)
 }
 
 // IsRunning checks whether the sandbox is still reachable.

--- a/codeexecutor/e2b/internal/codeinterpreter/sandbox.go
+++ b/codeexecutor/e2b/internal/codeinterpreter/sandbox.go
@@ -188,12 +188,13 @@ func Create(ctx context.Context, opts *SandboxOpts) (*Sandbox, error) {
 	}
 
 	var out struct {
-		SandboxID       string `json:"sandboxID"`
-		ClientID        string `json:"clientID"`
-		TemplateID      string `json:"templateID"`
-		EnvdPort        int    `json:"envdPort"`
-		Domain          string `json:"domain,omitempty"`
-		EnvdAccessToken string `json:"envdAccessToken,omitempty"`
+		SandboxID          string `json:"sandboxID"`
+		ClientID           string `json:"clientID"`
+		TemplateID         string `json:"templateID"`
+		EnvdPort           int    `json:"envdPort"`
+		Domain             string `json:"domain,omitempty"`
+		EnvdAccessToken    string `json:"envdAccessToken,omitempty"`
+		TrafficAccessToken string `json:"trafficAccessToken,omitempty"`
 	}
 	if err := cfg.do(ctx, "POST", "/sandboxes", body, &out); err != nil {
 		return nil, err
@@ -201,6 +202,9 @@ func Create(ctx context.Context, opts *SandboxOpts) (*Sandbox, error) {
 
 	if out.EnvdAccessToken != "" && cfg.AccessToken == "" {
 		cfg.AccessToken = out.EnvdAccessToken
+	}
+	if out.TrafficAccessToken != "" && cfg.TrafficAccessToken == "" {
+		cfg.TrafficAccessToken = out.TrafficAccessToken
 	}
 
 	return &Sandbox{

--- a/codeexecutor/e2b/internal/codeinterpreter/sandbox_test.go
+++ b/codeexecutor/e2b/internal/codeinterpreter/sandbox_test.go
@@ -443,8 +443,13 @@ func TestConnect_ThroughMockAPI(t *testing.T) {
 		}
 		// Validate that the timeout field is present in the request body.
 		var body map[string]any
-		data, _ := io.ReadAll(r.Body)
-		_ = json.Unmarshal(data, &body)
+		data, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read request body: %v", err)
+		}
+		if err := json.Unmarshal(data, &body); err != nil {
+			t.Fatalf("failed to unmarshal request body: %v", err)
+		}
 		if _, ok := body["timeout"]; !ok {
 			t.Error("connect request body missing 'timeout' field")
 		}

--- a/codeexecutor/e2b/internal/codeinterpreter/sandbox_test.go
+++ b/codeexecutor/e2b/internal/codeinterpreter/sandbox_test.go
@@ -11,10 +11,13 @@ package codeinterpreter
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -438,6 +441,13 @@ func TestConnect_ThroughMockAPI(t *testing.T) {
 		if r.Method != "POST" || r.URL.Path != "/sandboxes/abc/connect" {
 			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
 		}
+		// Validate that the timeout field is present in the request body.
+		var body map[string]any
+		data, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(data, &body)
+		if _, ok := body["timeout"]; !ok {
+			t.Error("connect request body missing 'timeout' field")
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"sandboxID":"abc","clientID":"cid","templateID":"tpl"}`))
 	}))
@@ -742,10 +752,10 @@ func TestConnect_DoesNotOverrideExplicitAccessToken(t *testing.T) {
 }
 
 func TestPause_ThroughMockAPI(t *testing.T) {
-	var paused bool
+	var paused atomic.Bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == "POST" && r.URL.Path == "/sandboxes/abc/pause" {
-			paused = true
+			paused.Store(true)
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
@@ -765,7 +775,7 @@ func TestPause_ThroughMockAPI(t *testing.T) {
 	if err := sbx.Pause(context.Background()); err != nil {
 		t.Fatalf("pause: %v", err)
 	}
-	if !paused {
+	if !paused.Load() {
 		t.Error("expected pause handler to have been called")
 	}
 }
@@ -821,5 +831,92 @@ func TestConnect_ServerError(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error on server error, got nil")
+	}
+}
+
+func TestCreate_BackfillsTrafficAccessToken(t *testing.T) {
+	t.Setenv("E2B_ACCESS_TOKEN", "")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/sandboxes" || r.Method != "POST" {
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"sandboxID":"sbx-1",
+			"clientID":"c-1",
+			"templateID":"tpl",
+			"envdPort":49999,
+			"trafficAccessToken":"traffic-from-api"
+		}`))
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Transport: &rewriteToServerTransport{target: srv.URL}}
+	sbx, err := Create(context.Background(), &SandboxOpts{
+		APIKey:     "k",
+		Domain:     "e2b.test",
+		Debug:      true,
+		HTTPClient: client,
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if got := sbx.connection.TrafficAccessToken; got != "traffic-from-api" {
+		t.Errorf("expected TrafficAccessToken to be back-filled from create response; got %q", got)
+	}
+	h := http.Header{}
+	sbx.addAuthHeaders(h)
+	if got := h.Get("E2B-Traffic-Access-Token"); got != "traffic-from-api" {
+		t.Errorf("E2B-Traffic-Access-Token header: %q", got)
+	}
+}
+
+func TestCreate_DoesNotOverrideExplicitTrafficToken(t *testing.T) {
+	t.Setenv("E2B_ACCESS_TOKEN", "")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"sandboxID":"sbx-1",
+			"clientID":"c-1",
+			"templateID":"tpl",
+			"envdPort":49999,
+			"trafficAccessToken":"traffic-from-api"
+		}`))
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Transport: &rewriteToServerTransport{target: srv.URL}}
+	// Construct cfg directly so we can pre-set TrafficAccessToken (there is no
+	// public SandboxOpts.TrafficAccessToken field — simulate via ConnectionConfig).
+	cfg := &ConnectionConfig{
+		APIKey:             "k",
+		Domain:             "e2b.test",
+		Debug:              true,
+		HTTPClient:         client,
+		TrafficAccessToken: "explicit-traffic",
+	}
+	cfg.init()
+
+	var out struct {
+		SandboxID          string `json:"sandboxID"`
+		ClientID           string `json:"clientID"`
+		TemplateID         string `json:"templateID"`
+		EnvdPort           int    `json:"envdPort"`
+		Domain             string `json:"domain,omitempty"`
+		EnvdAccessToken    string `json:"envdAccessToken,omitempty"`
+		TrafficAccessToken string `json:"trafficAccessToken,omitempty"`
+	}
+	body := map[string]any{"templateID": DefaultTemplate, "timeout": DefaultSandboxTimeout}
+	if err := cfg.do(context.Background(), "POST", "/sandboxes", body, &out); err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	// Simulate Create() backfill logic.
+	if out.TrafficAccessToken != "" && cfg.TrafficAccessToken == "" {
+		cfg.TrafficAccessToken = out.TrafficAccessToken
+	}
+	if got := cfg.TrafficAccessToken; got != "explicit-traffic" {
+		t.Errorf("explicit TrafficAccessToken should not be overridden; got %q", got)
 	}
 }

--- a/codeexecutor/e2b/internal/codeinterpreter/sandbox_test.go
+++ b/codeexecutor/e2b/internal/codeinterpreter/sandbox_test.go
@@ -435,7 +435,7 @@ func (r *rewriteToServerTransport) RoundTrip(req *http.Request) (*http.Response,
 
 func TestConnect_ThroughMockAPI(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != "GET" || r.URL.Path != "/sandboxes/abc" {
+		if r.Method != "POST" || r.URL.Path != "/sandboxes/abc/connect" {
 			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -517,7 +517,10 @@ func TestConnect_MissingAPIKey(t *testing.T) {
 	t.Setenv("E2B_API_KEY", "")
 	_, err := Connect(context.Background(), "abc", nil)
 	if err == nil {
-		t.Fatal("expected error (no API key, no server)")
+		t.Fatal("expected error when API key missing")
+	}
+	if _, ok := err.(*AuthenticationError); !ok {
+		t.Errorf("expected AuthenticationError, got %T: %v", err, err)
 	}
 }
 
@@ -680,7 +683,7 @@ func TestConnect_BackfillsEnvdAccessToken(t *testing.T) {
 	t.Setenv("E2B_ACCESS_TOKEN", "")
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != "GET" || r.URL.Path != "/sandboxes/abc" {
+		if r.Method != "POST" || r.URL.Path != "/sandboxes/abc/connect" {
 			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -735,5 +738,71 @@ func TestConnect_DoesNotOverrideExplicitAccessToken(t *testing.T) {
 	}
 	if got := sbx.connection.AccessToken; got != "explicit-token" {
 		t.Errorf("explicit AccessToken should not be overridden; got %q", got)
+	}
+}
+
+func TestPause_ThroughMockAPI(t *testing.T) {
+	var paused bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" && r.URL.Path == "/sandboxes/abc/pause" {
+			paused = true
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	sbx := &Sandbox{
+		id: "abc",
+		connection: &ConnectionConfig{
+			APIKey:     "k",
+			Domain:     "e2b.test",
+			Debug:      true,
+			HTTPClient: &http.Client{Transport: &rewriteToServerTransport{target: srv.URL}},
+		},
+	}
+	if err := sbx.Pause(context.Background()); err != nil {
+		t.Fatalf("pause: %v", err)
+	}
+	if !paused {
+		t.Error("expected pause handler to have been called")
+	}
+}
+
+func TestConnect_BackfillsTrafficAccessToken(t *testing.T) {
+	t.Setenv("E2B_ACCESS_TOKEN", "")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" || r.URL.Path != "/sandboxes/abc/connect" {
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"sandboxID":"abc",
+			"clientID":"cid",
+			"templateID":"tpl",
+			"trafficAccessToken":"traffic-tok"
+		}`))
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Transport: &rewriteToServerTransport{target: srv.URL}}
+	sbx, err := Connect(context.Background(), "abc", &SandboxOpts{
+		APIKey:     "k",
+		Domain:     "e2b.test",
+		Debug:      true,
+		HTTPClient: client,
+	})
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	if got := sbx.connection.TrafficAccessToken; got != "traffic-tok" {
+		t.Errorf("expected TrafficAccessToken to be back-filled; got %q", got)
+	}
+	h := http.Header{}
+	sbx.addAuthHeaders(h)
+	if got := h.Get("E2B-Traffic-Access-Token"); got != "traffic-tok" {
+		t.Errorf("E2B-Traffic-Access-Token header: %q", got)
 	}
 }

--- a/codeexecutor/e2b/internal/codeinterpreter/sandbox_test.go
+++ b/codeexecutor/e2b/internal/codeinterpreter/sandbox_test.go
@@ -806,3 +806,20 @@ func TestConnect_BackfillsTrafficAccessToken(t *testing.T) {
 		t.Errorf("E2B-Traffic-Access-Token header: %q", got)
 	}
 }
+
+func TestConnect_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	client := &http.Client{Transport: &rewriteToServerTransport{target: srv.URL}}
+	_, err := Connect(context.Background(), "abc", &SandboxOpts{
+		APIKey:     "k",
+		Domain:     "e2b.test",
+		Debug:      true,
+		HTTPClient: client,
+	})
+	if err == nil {
+		t.Fatal("expected error on server error, got nil")
+	}
+}

--- a/codeexecutor/e2b/workspace_runtime_test.go
+++ b/codeexecutor/e2b/workspace_runtime_test.go
@@ -79,6 +79,10 @@ func (m *mockE2BServer) handle(w http.ResponseWriter, r *http.Request) {
 		m.mu.Unlock()
 		w.WriteHeader(http.StatusNoContent)
 		return
+	case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/connect"):
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"sandboxID":"sbx-mock","clientID":"c-mock","templateID":"code-interpreter-v1","state":"running"}`))
+		return
 	case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/sandboxes/"):
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"sandboxID":"sbx-mock","clientID":"c-mock","templateID":"code-interpreter-v1","state":"running"}`))

--- a/codeexecutor/e2b/workspace_runtime_test.go
+++ b/codeexecutor/e2b/workspace_runtime_test.go
@@ -1144,6 +1144,27 @@ func TestPauseExecutor_NilSandbox(t *testing.T) {
 	assert.Contains(t, err.Error(), "sandbox not initialized")
 }
 
+func TestPauseExecutor_NotOwner(t *testing.T) {
+	srv := newMockE2BServer(t, nil)
+	defer srv.close()
+
+	t.Setenv("E2B_API_KEY", "test-key")
+	c, err := NewWithContext(context.Background(),
+		WithAPIKey("test-key"),
+		WithDomain("e2b.test"),
+		WithDebug(true),
+		WithHTTPClient(srv.client()),
+		WithSandboxID("existing-id"),
+	)
+	require.NoError(t, err)
+	defer c.Close()
+
+	require.False(t, c.owned, "pre-condition: connected executor must not own the sandbox")
+	err = c.Pause(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only owner may pause sandbox")
+}
+
 func writeTempFile(path, content string) error {
 	return os.WriteFile(path, []byte(content), 0o644)
 }

--- a/codeexecutor/e2b/workspace_runtime_test.go
+++ b/codeexecutor/e2b/workspace_runtime_test.go
@@ -83,6 +83,9 @@ func (m *mockE2BServer) handle(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"sandboxID":"sbx-mock","clientID":"c-mock","templateID":"code-interpreter-v1","state":"running"}`))
 		return
+	case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/pause"):
+		w.WriteHeader(http.StatusNoContent)
+		return
 	case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/sandboxes/"):
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"sandboxID":"sbx-mock","clientID":"c-mock","templateID":"code-interpreter-v1","state":"running"}`))
@@ -1123,6 +1126,22 @@ func TestExecuteCode_SandboxExecutionError(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "execute block 0")
+}
+
+func TestPauseExecutor_Success(t *testing.T) {
+	srv := newMockE2BServer(t, nil)
+	defer srv.close()
+	c := newMockedExecutor(t, srv)
+
+	err := c.Pause(context.Background())
+	require.NoError(t, err)
+}
+
+func TestPauseExecutor_NilSandbox(t *testing.T) {
+	c := &CodeExecutor{}
+	err := c.Pause(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sandbox not initialized")
 }
 
 func writeTempFile(path, content string) error {

--- a/codeexecutor/e2b/workspace_runtime_test.go
+++ b/codeexecutor/e2b/workspace_runtime_test.go
@@ -1135,6 +1135,26 @@ func TestPauseExecutor_Success(t *testing.T) {
 
 	err := c.Pause(context.Background())
 	require.NoError(t, err)
+	// After a successful pause the executor must relinquish ownership so that
+	// Close() does not kill the paused sandbox.
+	assert.False(t, c.owned, "owned should be false after Pause()")
+}
+
+func TestCloseAfterPause_DoesNotKillSandbox(t *testing.T) {
+	srv := newMockE2BServer(t, nil)
+	defer srv.close()
+	c := newMockedExecutor(t, srv)
+
+	require.NoError(t, c.Pause(context.Background()))
+	killsBefore := srv.killCalls
+
+	// Close() should be a no-op because ownership was cleared by Pause().
+	require.NoError(t, c.Close())
+	srv.mu.Lock()
+	killsAfter := srv.killCalls
+	srv.mu.Unlock()
+
+	assert.Equal(t, killsBefore, killsAfter, "Close() after Pause() must not issue a DELETE (kill) request")
 }
 
 func TestPauseExecutor_NilSandbox(t *testing.T) {


### PR DESCRIPTION
- Fix Connect() to use POST /sandboxes/{id}/connect instead of GET /sandboxes/{id}; the connect endpoint handles both running (200) and paused (201) sandboxes and is the E2B SDK standard
- Add explicit API key validation in Connect() before any network call
- Add TrafficAccessToken field to SandboxInfo and back-fill logic in Connect() so the E2B-Traffic-Access-Token header is set automatically
- Add Sandbox.Pause() calling POST /sandboxes/{id}/pause (204) which suspends the sandbox while preserving filesystem and memory state
- Add CodeExecutor.Pause() as the high-level wrapper with nil/lock guards
- Update sandbox_test.go: fix three Connect tests to assert POST /connect, upgrade TestConnect_MissingAPIKey to verify AuthenticationError type, add TestPause_ThroughMockAPI and TestConnect_BackfillsTrafficAccessToken
- Update mock server in workspace_runtime_test.go to handle POST /connect