### PR TITLE
tool/mcp: propagate annotations to metadata

### DIFF
--- a/docs/mkdocs/en/tool.md
+++ b/docs/mkdocs/en/tool.md
@@ -62,6 +62,27 @@ type MetadataProvider interface {
 }
 ```
 
+Direct MCP ToolSet tools also publish metadata from explicit MCP annotations:
+
+| MCP annotation | ToolMetadata field |
+| -------------- | ------------------ |
+| `readOnlyHint` | `ReadOnly`         |
+| `destructiveHint` | `Destructive`  |
+| `openWorldHint` | `OpenWorld`      |
+
+Only explicit MCP hints are mapped. If an MCP server omits
+`destructiveHint` or `openWorldHint`, the framework keeps the Go zero value
+(`false`) in `ToolMetadata`. This differs from MCP's default hint semantics,
+where `destructiveHint` defaults to `true` for non-read-only tools and
+`openWorldHint` defaults to `true`. `ToolMetadata` uses plain `bool` fields,
+so it cannot distinguish "missing" from "explicit false". If your policy must
+follow MCP's default semantics, treat non-read-only MCP tools conservatively
+unless your application has another trust signal.
+
+MCP annotations do not have matching fields for `SearchOrRead` or
+`ConcurrencySafe`. The framework also does not treat `readOnlyHint` or
+`idempotentHint` as a concurrency-safety signal.
+
 Permission policy is checked after the model requests a tool, after JSON repair
 and before-tool callbacks have finalized arguments, and immediately before the
 framework executes it:
@@ -821,6 +842,19 @@ agent := llmagent.New("mcp-assistant",
     llmagent.WithToolSets([]tool.ToolSet{mcpToolSet}))
 ```
 
+### MCP Annotations and Permission Metadata
+
+When a remote MCP server returns tool annotations from `tools/list`, direct
+MCP ToolSet tools implement `tool.MetadataProvider`. Permission policies can
+read `req.Metadata.ReadOnly`, `req.Metadata.Destructive`, and
+`req.Metadata.OpenWorld` without inspecting MCP-specific data structures.
+
+The mapping uses the tool snapshot returned by `tools/list`. Refreshing a
+ToolSet rebuilds the framework tool list rather than mutating existing
+`mcpTool` instances. If future code adds in-place hot updates from MCP
+`ToolListChangedNotification`, metadata reads should be checked again for
+thread safety.
+
 ### ToolSet Lifecycle and Ownership
 
 The `ToolSet` interface explicitly includes `Close()`. That means the
@@ -1068,9 +1102,11 @@ The main difference is **when** remote MCP tools become visible:
 - `MCP ToolSet`
   - performs `initialize + tools/list`
   - expands remote MCP tools into model-visible Tools
+  - maps explicit remote MCP safety annotations into `PermissionRequest.Metadata`
 - `mcpbroker`
   - initially exposes only 4 broker tools
   - the model discovers servers, then tools, then inspects selected schemas, then calls a concrete tool
+  - exposes broker tools such as `mcp_call`; remote tool annotations are not automatically reflected in `PermissionRequest.Metadata`
 
 You can think of them as:
 

--- a/docs/mkdocs/zh/tool.md
+++ b/docs/mkdocs/zh/tool.md
@@ -59,6 +59,26 @@ type MetadataProvider interface {
 }
 ```
 
+直接使用 MCP ToolSet 暴露出来的工具，也会从显式 MCP annotations 生成
+metadata：
+
+| MCP annotation | ToolMetadata 字段 |
+| -------------- | ----------------- |
+| `readOnlyHint` | `ReadOnly`        |
+| `destructiveHint` | `Destructive` |
+| `openWorldHint` | `OpenWorld`     |
+
+框架只映射 MCP server 显式返回的 hint。如果 MCP server 没有返回
+`destructiveHint` 或 `openWorldHint`，`ToolMetadata` 会保持 Go 零值
+（`false`）。这与 MCP 规范的默认 hint 语义不同：MCP 中非只读工具的
+`destructiveHint` 默认是 `true`，`openWorldHint` 默认也是 `true`。
+由于 `ToolMetadata` 使用普通 `bool` 字段，无法区分“未设置”和“显式
+false”。如果你的 permission policy 需要遵循 MCP 默认语义，请对非只读
+MCP 工具采用更保守的策略，除非业务侧还有额外的可信信号。
+
+MCP annotations 没有与 `SearchOrRead` 或 `ConcurrencySafe` 对应的字段。
+框架也不会把 `readOnlyHint` 或 `idempotentHint` 推断为并发安全信号。
+
 权限策略发生在模型已经发起 tool call、框架完成 JSON 修复和 before-tool callbacks 参数改写、并且即将真正执行工具之前：
 
 ```go
@@ -800,6 +820,18 @@ agent := llmagent.New("mcp-assistant",
     llmagent.WithToolSets([]tool.ToolSet{mcpToolSet}))
 ```
 
+### MCP Annotations 与权限 Metadata
+
+当远端 MCP server 在 `tools/list` 中返回 tool annotations 时，直接通过
+MCP ToolSet 暴露的工具会实现 `tool.MetadataProvider`。Permission policy
+可以直接读取 `req.Metadata.ReadOnly`、`req.Metadata.Destructive` 和
+`req.Metadata.OpenWorld`，无需再解析 MCP 专属结构。
+
+这个映射基于 `tools/list` 返回的工具快照。ToolSet 刷新工具列表时，会
+重新构造框架内的工具列表，而不是原地修改已有 `mcpTool` 实例。如果未来
+支持基于 MCP `ToolListChangedNotification` 的原地热更新，需要重新评估
+metadata 读取的线程安全性。
+
 ### ToolSet 生命周期与所有权
 
 `ToolSet` 接口里显式提供了 `Close()`，这意味着它持有的连接、会话和缓存
@@ -1042,9 +1074,11 @@ agent := llmagent.New(
 - `MCP ToolSet`
   - 在初始化或运行时先 `initialize + tools/list`
   - 把远端每个 MCP tool 直接变成 Agent 可见 Tool
+  - 把远端 MCP 工具显式声明的安全 annotations 映射到 `PermissionRequest.Metadata`
 - `mcpbroker`
   - 初始只暴露 4 个 broker 工具
   - 模型先发现 server，再发现 tool，再检查指定 tool 的 schema，最后再调用
+  - 暴露的是 `mcp_call` 等 broker 工具，远端 tool annotations 不会自动进入 `PermissionRequest.Metadata`
 
 可以把它理解为：
 

--- a/tool/mcp/tool.go
+++ b/tool/mcp/tool.go
@@ -57,6 +57,8 @@ type mcpTool struct {
 	sessionManager *mcpSessionManager
 }
 
+var _ tool.MetadataProvider = (*mcpTool)(nil)
+
 // newMCPTool creates a new MCP tool wrapper.
 func newMCPTool(mcpToolData mcp.Tool, sessionManager *mcpSessionManager) *mcpTool {
 	mcpTool := &mcpTool{
@@ -75,6 +77,26 @@ func newMCPTool(mcpToolData mcp.Tool, sessionManager *mcpSessionManager) *mcpToo
 	}
 
 	return mcpTool
+}
+
+// ToolMetadata converts explicit MCP tool annotations into framework metadata.
+func (t *mcpTool) ToolMetadata() tool.ToolMetadata {
+	if t == nil || t.mcpToolRef == nil || t.mcpToolRef.Annotations == nil {
+		return tool.ToolMetadata{}
+	}
+
+	annotations := t.mcpToolRef.Annotations
+	var metadata tool.ToolMetadata
+	if annotations.ReadOnlyHint != nil {
+		metadata.ReadOnly = *annotations.ReadOnlyHint
+	}
+	if annotations.DestructiveHint != nil {
+		metadata.Destructive = *annotations.DestructiveHint
+	}
+	if annotations.OpenWorldHint != nil {
+		metadata.OpenWorld = *annotations.OpenWorldHint
+	}
+	return metadata
 }
 
 // Call implements the Tool interface.

--- a/tool/mcp/tool_test.go
+++ b/tool/mcp/tool_test.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"trpc.group/trpc-go/trpc-agent-go/tool"
 	mcp "trpc.group/trpc-go/trpc-mcp-go"
 )
 
@@ -96,6 +97,82 @@ func TestMCPTool_Declaration(t *testing.T) {
 			}
 			if decl.Description != tc.expectedDesc {
 				t.Errorf("expected description %q, got %q", tc.expectedDesc, decl.Description)
+			}
+		})
+	}
+}
+
+func TestMCPTool_ToolMetadata(t *testing.T) {
+	testCases := []struct {
+		name        string
+		annotations *mcp.ToolAnnotations
+		want        tool.ToolMetadata
+	}{
+		{
+			name: "nil annotations",
+			want: tool.ToolMetadata{},
+		},
+		{
+			name: "title only annotations",
+			annotations: &mcp.ToolAnnotations{
+				Title: "Human title",
+			},
+			want: tool.ToolMetadata{},
+		},
+		{
+			name: "explicit safety hints",
+			annotations: &mcp.ToolAnnotations{
+				ReadOnlyHint:    mcp.BoolPtr(true),
+				DestructiveHint: mcp.BoolPtr(true),
+				OpenWorldHint:   mcp.BoolPtr(true),
+			},
+			want: tool.ToolMetadata{
+				ReadOnly:    true,
+				Destructive: true,
+				OpenWorld:   true,
+			},
+		},
+		{
+			name: "partial safety hints",
+			annotations: &mcp.ToolAnnotations{
+				ReadOnlyHint: mcp.BoolPtr(true),
+			},
+			want: tool.ToolMetadata{
+				ReadOnly: true,
+			},
+		},
+		{
+			name: "title and idempotent are ignored",
+			annotations: &mcp.ToolAnnotations{
+				Title:          "Ignored title",
+				IdempotentHint: mcp.BoolPtr(true),
+			},
+			want: tool.ToolMetadata{},
+		},
+		{
+			name: "explicit false stays zero value",
+			annotations: &mcp.ToolAnnotations{
+				ReadOnlyHint:    mcp.BoolPtr(false),
+				DestructiveHint: mcp.BoolPtr(false),
+				OpenWorldHint:   mcp.BoolPtr(false),
+			},
+			want: tool.ToolMetadata{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mcpTool := newMCPTool(mcp.Tool{
+				Name:        "metadata_tool",
+				Description: "Tool with metadata",
+				Annotations: tc.annotations,
+			}, &mcpSessionManager{})
+
+			if got := mcpTool.ToolMetadata(); got != tc.want {
+				t.Fatalf("expected metadata %+v, got %+v", tc.want, got)
+			}
+			if got := tool.MetadataOf(mcpTool); got != tc.want {
+				t.Fatalf("expected MetadataOf metadata %+v, got %+v", tc.want, got)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- 这个 PR 为直接通过 `mcp.NewMCPToolSet(...)` 暴露出来的 MCP 工具补充 `ToolMetadata` 传播能力。

- 在这个修改之前，MCP server 通过 `tools/list` 返回的 annotations 虽然保留在底层 MCP tool 对象中，但没有通过 `tool.MetadataProvider` 暴露出来。因此，对于 MCP 工具来说，`PermissionRequest.Metadata` 一直是 Go 零值。

- 这个 PR 之后，直接 MCP ToolSet 暴露出来的工具会把显式 MCP annotations 映射到 `ToolMetadata`，从而让 permission policy 可以通过 `req.Metadata` 读取这些信息。

### Annotation 处理方式

| MCP annotation | MCP 类型 | 是否映射到 `ToolMetadata` | 当前处理方式 | 说明 |
|---|---|---|---|---|
| `readOnlyHint` | `*bool` | 是，映射到 `ReadOnly` | 显式 `true` -> `ReadOnly=true`；显式 `false` 或缺失 -> `ReadOnly=false` | 与现有 `ToolMetadata.ReadOnly` 语义直接对应。 |
| `destructiveHint` | `*bool` | 是，映射到 `Destructive` | 显式 `true` -> `Destructive=true`；显式 `false` 或缺失 -> `Destructive=false` | 与现有 `ToolMetadata.Destructive` 语义直接对应；缺失时不套用 MCP 默认语义。 |
| `openWorldHint` | `*bool` | 是，映射到 `OpenWorld` | 显式 `true` -> `OpenWorld=true`；显式 `false` 或缺失 -> `OpenWorld=false` | 与现有 `ToolMetadata.OpenWorld` 语义直接对应；缺失时不套用 MCP 默认语义。 |
| `idempotentHint` | `*bool` | 否 | 忽略 | 幂等不等于只读、不等于非破坏性，也不等于并发安全，因此不做推断映射。 |
| `title` | `string` | 否 | 忽略 | `title` 更偏展示层信息，而 `ToolMetadata` 当前主要描述执行和权限相关属性。 |

### nil / 缺失 annotation 的处理

| MCP annotation 状态 | 当前 `ToolMetadata` 行为 | 原因 |
|---|---|---|
| `annotations == nil` | 所有映射字段保持 Go 零值：`ReadOnly=false`、`Destructive=false`、`OpenWorld=false` | 保持与修改前行为兼容。 |
| `annotations != nil`，但某个 hint 字段缺失 | 对应的 `ToolMetadata` 字段保持 `false` | `ToolMetadata` 使用普通 `bool` 字段，无法区分“未设置”和“显式 false”。 |
| `readOnlyHint` 缺失 | `ReadOnly=false` | 这与 MCP 默认语义一致。 |
| `destructiveHint` 缺失 | `Destructive=false` | 这里**没有套用 MCP 默认语义**，避免影响已有无注解 MCP 工具的行为。 |
| `openWorldHint` 缺失 | `OpenWorld=false` | 这里**没有套用 MCP 默认语义**，避免把常见的无注解工具默认视为 open-world。 |


## Tests
- go test ./tool/mcp/... 
- go test ./internal/tool/...

Fixes #1882.