### PR TITLE
session: store pgvector timestamps in UTC

### DIFF
--- a/session/pgvector/service.go
+++ b/session/pgvector/service.go
@@ -277,11 +277,12 @@ func (s *Service) CreateSession(
 	}
 
 	now := time.Now()
+	nowUTC := now.UTC()
 	sessState := &SessionState{
 		ID:        key.SessionID,
 		State:     make(session.StateMap),
-		UpdatedAt: now,
-		CreatedAt: now,
+		UpdatedAt: nowUTC,
+		CreatedAt: nowUTC,
 	}
 	for k, v := range state {
 		if v == nil {

--- a/session/pgvector/service_helper.go
+++ b/session/pgvector/service_helper.go
@@ -332,6 +332,8 @@ func (s *Service) addEvent(
 	evt *event.Event,
 ) error {
 	now := time.Now()
+	nowUTC := now.UTC()
+	eventCreatedAt := eventCreatedAtUTC(evt, now)
 	eventBytes, err := json.Marshal(evt)
 	if err != nil {
 		return fmt.Errorf(
@@ -391,7 +393,7 @@ func (s *Service) addEvent(
 					key.AppName, key.UserID, key.SessionID,
 				)
 			}
-			sessState.UpdatedAt = now
+			sessState.UpdatedAt = nowUTC
 			if sessState.State == nil {
 				sessState.State = make(session.StateMap)
 			}
@@ -443,7 +445,7 @@ func (s *Service) addEvent(
 					),
 					key.AppName, key.UserID,
 					key.SessionID, eventBytes,
-					now, now, expiresAt,
+					eventCreatedAt, nowUTC, expiresAt,
 				)
 				if err != nil {
 					return fmt.Errorf(
@@ -460,6 +462,13 @@ func (s *Service) addEvent(
 		)
 	}
 	return nil
+}
+
+func eventCreatedAtUTC(evt *event.Event, fallback time.Time) time.Time {
+	if evt != nil && !evt.Timestamp.IsZero() {
+		return evt.Timestamp.UTC()
+	}
+	return fallback.UTC()
 }
 
 // addTrackEvent adds a track event to a session.

--- a/session/pgvector/service_helper.go
+++ b/session/pgvector/service_helper.go
@@ -466,7 +466,24 @@ func (s *Service) addEvent(
 
 func eventCreatedAtUTC(evt *event.Event, fallback time.Time) time.Time {
 	if evt != nil && !evt.Timestamp.IsZero() {
-		return evt.Timestamp.UTC()
+		return timestampUTC(evt.Timestamp, fallback)
+	}
+	return timestampUTC(time.Time{}, fallback)
+}
+
+func trackEventCreatedAtUTC(
+	trackEvent *session.TrackEvent,
+	fallback time.Time,
+) time.Time {
+	if trackEvent != nil && !trackEvent.Timestamp.IsZero() {
+		return timestampUTC(trackEvent.Timestamp, fallback)
+	}
+	return timestampUTC(time.Time{}, fallback)
+}
+
+func timestampUTC(ts time.Time, fallback time.Time) time.Time {
+	if !ts.IsZero() {
+		return ts.UTC()
 	}
 	return fallback.UTC()
 }
@@ -478,6 +495,8 @@ func (s *Service) addTrackEvent(
 	trackEvent *session.TrackEvent,
 ) error {
 	now := time.Now()
+	nowUTC := now.UTC()
+	trackCreatedAt := trackEventCreatedAtUTC(trackEvent, now)
 	eventBytes, err := json.Marshal(trackEvent)
 	if err != nil {
 		return fmt.Errorf(
@@ -549,7 +568,7 @@ func (s *Service) addTrackEvent(
 				return err
 			}
 			sessState.State = sess.SnapshotState()
-			sessState.UpdatedAt = sess.UpdatedAt
+			sessState.UpdatedAt = nowUTC
 			updatedStateBytes, err := json.Marshal(
 				&sessState,
 			)
@@ -592,8 +611,8 @@ func (s *Service) addTrackEvent(
 				),
 				key.AppName, key.UserID,
 				key.SessionID, trackEvent.Track,
-				eventBytes, trackEvent.Timestamp,
-				trackEvent.Timestamp, expiresAt,
+				eventBytes, trackCreatedAt,
+				nowUTC, expiresAt,
 			)
 			if err != nil {
 				return fmt.Errorf(

--- a/session/pgvector/service_helper_test.go
+++ b/session/pgvector/service_helper_test.go
@@ -128,6 +128,62 @@ func TestAddEvent_TransactionError(t *testing.T) {
 	assert.Contains(t, err.Error(), "store event failed")
 }
 
+func TestAddEvent_StoresEventCreatedAtAsTimestampUTC(
+	t *testing.T,
+) {
+	s, mock, db := newTestService(t, nil)
+	defer db.Close()
+
+	key := session.Key{
+		AppName: "app", UserID: "user", SessionID: "sess",
+	}
+
+	sessState := SessionState{
+		ID:    "sess",
+		State: session.StateMap{},
+	}
+	stateBytes, err := json.Marshal(sessState)
+	require.NoError(t, err)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT state, expires_at FROM").
+		WillReturnRows(sqlmock.NewRows(
+			[]string{"state", "expires_at"},
+		).AddRow(stateBytes, nil))
+	mock.ExpectExec("UPDATE .* SET state").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	eventTime := time.Date(
+		2026, 5, 31, 20, 25, 0, 123456000,
+		time.FixedZone("UTC+8", 8*60*60),
+	)
+	mock.ExpectExec("INSERT INTO session_events").
+		WithArgs(
+			"app", "user", "sess",
+			sqlmock.AnyArg(),
+			exactUTCTimeArg{want: eventTime},
+			utcTimeArg{}, sqlmock.AnyArg(),
+		).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	evt := &event.Event{
+		Timestamp: eventTime,
+		Response: &model.Response{
+			Choices: []model.Choice{
+				{Message: model.Message{
+					Role:    model.RoleUser,
+					Content: "hello",
+				}},
+			},
+		},
+	}
+
+	err = s.addEvent(context.Background(), key, evt)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestAddEvent_QueryStateError(t *testing.T) {
 	s, mock, db := newTestService(t, nil)
 	defer db.Close()

--- a/session/pgvector/service_helper_test.go
+++ b/session/pgvector/service_helper_test.go
@@ -184,6 +184,38 @@ func TestAddEvent_StoresEventCreatedAtAsTimestampUTC(
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestCreatedAtUTCUsesTimestampOrFallback(t *testing.T) {
+	fallback := time.Date(
+		2026, 5, 31, 20, 25, 0, 0,
+		time.FixedZone("UTC+8", 8*60*60),
+	)
+	eventTime := fallback.Add(time.Minute)
+
+	assert.Equal(
+		t,
+		fallback.UTC(),
+		eventCreatedAtUTC(nil, fallback),
+	)
+	assert.Equal(
+		t,
+		eventTime.UTC(),
+		eventCreatedAtUTC(&event.Event{Timestamp: eventTime}, fallback),
+	)
+	assert.Equal(
+		t,
+		fallback.UTC(),
+		trackEventCreatedAtUTC(nil, fallback),
+	)
+	assert.Equal(
+		t,
+		eventTime.UTC(),
+		trackEventCreatedAtUTC(
+			&session.TrackEvent{Timestamp: eventTime},
+			fallback,
+		),
+	)
+}
+
 func TestAddEvent_QueryStateError(t *testing.T) {
 	s, mock, db := newTestService(t, nil)
 	defer db.Close()

--- a/session/pgvector/service_test.go
+++ b/session/pgvector/service_test.go
@@ -3865,13 +3865,23 @@ func TestAddTrackEvent_Success(t *testing.T) {
 		).AddRow(stateBytes, nil))
 	mock.ExpectExec("UPDATE .* SET state").
 		WillReturnResult(sqlmock.NewResult(0, 1))
+	eventTime := time.Date(
+		2026, 5, 31, 20, 25, 0, 123456000,
+		time.FixedZone("UTC+8", 8*60*60),
+	)
 	mock.ExpectExec("INSERT INTO session_track").
+		WithArgs(
+			"app", "user", "sess",
+			sqlmock.AnyArg(), sqlmock.AnyArg(),
+			exactUTCTimeArg{want: eventTime},
+			utcTimeArg{}, sqlmock.AnyArg(),
+		).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 
 	te := &session.TrackEvent{
 		Track:     "track1",
-		Timestamp: time.Now(),
+		Timestamp: eventTime,
 	}
 	err := s.addTrackEvent(
 		context.Background(), key, te,

--- a/session/pgvector/service_test.go
+++ b/session/pgvector/service_test.go
@@ -166,6 +166,24 @@ func (a anyVectorArg) Match(_ driver.Value) bool {
 	return true
 }
 
+type utcTimeArg struct{}
+
+func (a utcTimeArg) Match(v driver.Value) bool {
+	t, ok := v.(time.Time)
+	return ok && t.Location() == time.UTC
+}
+
+type exactUTCTimeArg struct {
+	want time.Time
+}
+
+func (a exactUTCTimeArg) Match(v driver.Value) bool {
+	t, ok := v.(time.Time)
+	return ok &&
+		t.Location() == time.UTC &&
+		t.Equal(a.want.UTC())
+}
+
 // sliceValueConverter converts []string to a
 // comma-separated driver.Value for go-sqlmock testing.
 // PostgreSQL drivers handle []string natively but
@@ -1094,6 +1112,11 @@ func TestCreateSession_Success(t *testing.T) {
 
 	// INSERT session.
 	mock.ExpectExec("INSERT INTO session_states").
+		WithArgs(
+			"app", "user", "sess",
+			sqlmock.AnyArg(), utcTimeArg{},
+			utcTimeArg{}, sqlmock.AnyArg(),
+		).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	// ListAppStates query.
@@ -1118,6 +1141,8 @@ func TestCreateSession_Success(t *testing.T) {
 	assert.Equal(t, "sess", sess.ID)
 	assert.Equal(t, "app", sess.AppName)
 	assert.Equal(t, "user", sess.UserID)
+	assert.Equal(t, time.UTC, sess.CreatedAt.Location())
+	assert.Equal(t, time.UTC, sess.UpdatedAt.Location())
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 


### PR DESCRIPTION
## Summary
- store pgvector session `created_at`/`updated_at` values in UTC for newly created sessions
- store pgvector event `created_at` from the event logical timestamp in UTC, with a UTC insertion-time fallback
- add sqlmock coverage for UTC session creation and event timestamp persistence

## Root cause
PR #1875 added summary-boundary filtering that compares persisted session `created_at` values with UTC summary boundary times. On non-UTC hosts, pgvector was writing naive PostgreSQL timestamps from local wall-clock time, so summaries could be treated as stale and `current_hidden` search could bail before querying. The same local-vs-UTC mismatch also affected the event cutoff used by `current_hidden` searches.

## Validation
- `go test ./...` in `session/pgvector`
- `TZ=Asia/Shanghai go test ./...` in `session/pgvector`
- local pgvector/PostgreSQL integration smoke test with a non-UTC timezone, covering summary reload and `CreatedBefore` search cutoff behavior
