### PR TITLE
session: align SQL backend timestamps to UTC

### DIFF
--- a/session/clickhouse/service.go
+++ b/session/clickhouse/service.go
@@ -545,19 +545,21 @@ func (s *Service) UpdateSessionState(ctx context.Context, key session.Key, state
 	}
 
 	// Marshal updated state
+	now := time.Now()
+	nowUTC := now.UTC()
+	sessState.UpdatedAt = nowUTC
 	updatedStateBytes, err := json.Marshal(sessState)
 	if err != nil {
 		return fmt.Errorf("clickhouse session service update session state failed: marshal state: %w", err)
 	}
 
 	// Update session state in database (INSERT new version for ReplacingMergeTree)
-	now := time.Now()
 	expiresAt := calculateExpiresAt(s.opts.sessionTTL)
 
 	err = s.chClient.Exec(ctx,
 		fmt.Sprintf(`INSERT INTO %s (app_name, user_id, session_id, state, extra_data, created_at, updated_at, expires_at)
 			VALUES (?, ?, ?, ?, ?, ?, ?, ?)`, s.tableSessionStates),
-		key.AppName, key.UserID, key.SessionID, string(updatedStateBytes), "{}", sessState.CreatedAt, now, expiresAt)
+		key.AppName, key.UserID, key.SessionID, string(updatedStateBytes), "{}", sessState.CreatedAt, nowUTC, expiresAt)
 
 	if err != nil {
 		return fmt.Errorf("clickhouse session service update session state failed: %w", err)

--- a/session/clickhouse/service.go
+++ b/session/clickhouse/service.go
@@ -199,11 +199,12 @@ func (s *Service) CreateSession(
 	}
 
 	now := time.Now()
+	nowUTC := now.UTC()
 	sessState := &SessionState{
 		ID:        key.SessionID,
 		State:     make(session.StateMap),
-		UpdatedAt: now,
-		CreatedAt: now,
+		UpdatedAt: nowUTC,
+		CreatedAt: nowUTC,
 	}
 	for k, v := range state {
 		sessState.State[k] = v

--- a/session/clickhouse/service_helper.go
+++ b/session/clickhouse/service_helper.go
@@ -226,7 +226,6 @@ func (s *Service) listSessions(
 func (s *Service) addEvent(ctx context.Context, key session.Key, evt *event.Event) error {
 	now := time.Now()
 	nowUTC := now.UTC()
-	eventCreatedAt := eventCreatedAtUTC(evt, now)
 
 	// Get current session state using FINAL
 	var stateStr string
@@ -285,7 +284,7 @@ func (s *Service) addEvent(ctx context.Context, key session.Key, evt *event.Even
 	// Events do not have their own expires_at; they are filtered by session's created_at.
 	// Use UnixMicro to preserve microsecond precision (ClickHouse driver has precision loss issue #1545).
 	if evt.Response != nil && !evt.IsPartial && evt.IsValidContent() {
-		eventCreatedMicro := eventCreatedAt.UnixMicro()
+		eventCreatedMicro := nowUTC.UnixMicro()
 		eventUpdatedMicro := nowUTC.UnixMicro()
 		err = s.chClient.Exec(ctx,
 			fmt.Sprintf(`INSERT INTO %s (app_name, user_id, session_id, event_id, event, extra_data, created_at, updated_at)
@@ -297,20 +296,6 @@ func (s *Service) addEvent(ctx context.Context, key session.Key, evt *event.Even
 	}
 
 	return nil
-}
-
-func eventCreatedAtUTC(evt *event.Event, fallback time.Time) time.Time {
-	if evt != nil && !evt.Timestamp.IsZero() {
-		return timestampUTC(evt.Timestamp, fallback)
-	}
-	return timestampUTC(time.Time{}, fallback)
-}
-
-func timestampUTC(ts time.Time, fallback time.Time) time.Time {
-	if !ts.IsZero() {
-		return ts.UTC()
-	}
-	return fallback.UTC()
 }
 
 // deleteSessionState soft-deletes a session and its related data.

--- a/session/clickhouse/service_helper.go
+++ b/session/clickhouse/service_helper.go
@@ -225,6 +225,8 @@ func (s *Service) listSessions(
 // addEvent adds an event to a session.
 func (s *Service) addEvent(ctx context.Context, key session.Key, evt *event.Event) error {
 	now := time.Now()
+	nowUTC := now.UTC()
+	eventCreatedAt := eventCreatedAtUTC(evt, now)
 
 	// Get current session state using FINAL
 	var stateStr string
@@ -252,7 +254,7 @@ func (s *Service) addEvent(ctx context.Context, key session.Key, evt *event.Even
 		return fmt.Errorf("unmarshal session state failed: %w", err)
 	}
 
-	sessState.UpdatedAt = now
+	sessState.UpdatedAt = nowUTC
 	sessState.CreatedAt = createdAt
 	if sessState.State == nil {
 		sessState.State = make(session.StateMap)
@@ -283,17 +285,32 @@ func (s *Service) addEvent(ctx context.Context, key session.Key, evt *event.Even
 	// Events do not have their own expires_at; they are filtered by session's created_at.
 	// Use UnixMicro to preserve microsecond precision (ClickHouse driver has precision loss issue #1545).
 	if evt.Response != nil && !evt.IsPartial && evt.IsValidContent() {
-		eventNowMicro := time.Now().UnixMicro()
+		eventCreatedMicro := eventCreatedAt.UnixMicro()
+		eventUpdatedMicro := nowUTC.UnixMicro()
 		err = s.chClient.Exec(ctx,
 			fmt.Sprintf(`INSERT INTO %s (app_name, user_id, session_id, event_id, event, extra_data, created_at, updated_at)
 				VALUES (?, ?, ?, ?, ?, ?, fromUnixTimestamp64Micro(?), fromUnixTimestamp64Micro(?))`, s.tableSessionEvents),
-			key.AppName, key.UserID, key.SessionID, evt.ID, string(eventBytes), "{}", eventNowMicro, eventNowMicro)
+			key.AppName, key.UserID, key.SessionID, evt.ID, string(eventBytes), "{}", eventCreatedMicro, eventUpdatedMicro)
 		if err != nil {
 			return fmt.Errorf("insert event failed: %w", err)
 		}
 	}
 
 	return nil
+}
+
+func eventCreatedAtUTC(evt *event.Event, fallback time.Time) time.Time {
+	if evt != nil && !evt.Timestamp.IsZero() {
+		return timestampUTC(evt.Timestamp, fallback)
+	}
+	return timestampUTC(time.Time{}, fallback)
+}
+
+func timestampUTC(ts time.Time, fallback time.Time) time.Time {
+	if !ts.IsZero() {
+		return ts.UTC()
+	}
+	return fallback.UTC()
 }
 
 // deleteSessionState soft-deletes a session and its related data.

--- a/session/clickhouse/service_helper_test.go
+++ b/session/clickhouse/service_helper_test.go
@@ -86,7 +86,9 @@ func TestService_AppendEvent(t *testing.T) {
 			sawEventInsert = true
 			createdMicro, ok := args[6].(int64)
 			assert.True(t, ok)
-			assert.Equal(t, e.Timestamp.UTC().UnixMicro(), createdMicro)
+			createdAt := time.UnixMicro(createdMicro).UTC()
+			assert.False(t, createdAt.Before(before.Add(-time.Second)))
+			assert.False(t, createdAt.After(time.Now().UTC().Add(time.Second)))
 			updatedMicro, ok := args[7].(int64)
 			assert.True(t, ok)
 			updatedAt := time.UnixMicro(updatedMicro).UTC()
@@ -100,21 +102,6 @@ func TestService_AppendEvent(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, sawStateInsert)
 	assert.True(t, sawEventInsert)
-}
-
-func TestEventCreatedAtUTCUsesTimestampOrFallback(t *testing.T) {
-	fallback := time.Date(
-		2026, 5, 31, 20, 25, 0, 0,
-		time.FixedZone("UTC+8", 8*60*60),
-	)
-	eventTime := fallback.Add(time.Minute)
-
-	assert.Equal(t, fallback.UTC(), eventCreatedAtUTC(nil, fallback))
-	assert.Equal(
-		t,
-		eventTime.UTC(),
-		eventCreatedAtUTC(&event.Event{Timestamp: eventTime}, fallback),
-	)
 }
 
 func TestService_AppendEvent_Error(t *testing.T) {

--- a/session/clickhouse/service_helper_test.go
+++ b/session/clickhouse/service_helper_test.go
@@ -38,7 +38,8 @@ func TestService_AppendEvent(t *testing.T) {
 	sess.CreatedAt = time.Now()
 
 	e := &event.Event{
-		ID: "evt1",
+		ID:        "evt1",
+		Timestamp: time.Date(2026, 5, 31, 20, 25, 0, 123456000, time.FixedZone("UTC+8", 8*60*60)),
 		Response: &model.Response{
 			Object: model.ObjectTypeChatCompletion,
 			Choices: []model.Choice{
@@ -68,12 +69,52 @@ func TestService_AppendEvent(t *testing.T) {
 		return newMockRows([][]any{{string(stateBytes), now}}), nil
 	}
 
+	var sawStateInsert bool
+	var sawEventInsert bool
+	before := time.Now().UTC()
 	mockCli.execFunc = func(ctx context.Context, query string, args ...any) error {
+		if strings.Contains(query, "INSERT INTO session_states") {
+			sawStateInsert = true
+			createdAt, ok := args[5].(time.Time)
+			assert.True(t, ok)
+			assert.True(t, createdAt.Equal(now))
+			updatedAt, ok := args[6].(time.Time)
+			assert.True(t, ok)
+			assert.Equal(t, time.UTC, updatedAt.Location())
+		}
+		if strings.Contains(query, "INSERT INTO session_events") {
+			sawEventInsert = true
+			createdMicro, ok := args[6].(int64)
+			assert.True(t, ok)
+			assert.Equal(t, e.Timestamp.UTC().UnixMicro(), createdMicro)
+			updatedMicro, ok := args[7].(int64)
+			assert.True(t, ok)
+			updatedAt := time.UnixMicro(updatedMicro).UTC()
+			assert.False(t, updatedAt.Before(before.Add(-time.Second)))
+			assert.False(t, updatedAt.After(time.Now().UTC().Add(time.Second)))
+		}
 		return nil
 	}
 
 	err := s.AppendEvent(ctx, sess, e)
 	assert.NoError(t, err)
+	assert.True(t, sawStateInsert)
+	assert.True(t, sawEventInsert)
+}
+
+func TestEventCreatedAtUTCUsesTimestampOrFallback(t *testing.T) {
+	fallback := time.Date(
+		2026, 5, 31, 20, 25, 0, 0,
+		time.FixedZone("UTC+8", 8*60*60),
+	)
+	eventTime := fallback.Add(time.Minute)
+
+	assert.Equal(t, fallback.UTC(), eventCreatedAtUTC(nil, fallback))
+	assert.Equal(
+		t,
+		eventTime.UTC(),
+		eventCreatedAtUTC(&event.Event{Timestamp: eventTime}, fallback),
+	)
 }
 
 func TestService_AppendEvent_Error(t *testing.T) {

--- a/session/clickhouse/service_test.go
+++ b/session/clickhouse/service_test.go
@@ -594,13 +594,36 @@ func TestService_UpdateSessionState(t *testing.T) {
 	}
 	ctx := context.Background()
 	key := session.Key{AppName: "test-app", UserID: "test-user", SessionID: "test-session"}
+	createdAt := time.Date(2026, 5, 31, 20, 25, 0, 0, time.UTC)
+	updatedAt := createdAt.Add(time.Minute)
+	stateBytes, err := json.Marshal(&SessionState{
+		ID:        key.SessionID,
+		State:     session.StateMap{"existing": []byte("old")},
+		CreatedAt: createdAt,
+		UpdatedAt: updatedAt,
+	})
+	assert.NoError(t, err)
 
 	// Mock query for existing session
 	mockCli.queryFunc = func(ctx context.Context, query string, args ...any) (driver.Rows, error) {
-		return newMockRows([][]any{{"{}"}}), nil
+		return newMockRows([][]any{{string(stateBytes)}}), nil
+	}
+	mockCli.execFunc = func(ctx context.Context, query string, args ...any) error {
+		if strings.Contains(query, "INSERT INTO session_states") {
+			var stored SessionState
+			assert.NoError(t, json.Unmarshal([]byte(args[3].(string)), &stored))
+			assert.Equal(t, createdAt, stored.CreatedAt)
+			assert.Equal(t, time.UTC, stored.UpdatedAt.Location())
+			assert.True(t, stored.UpdatedAt.After(updatedAt))
+
+			dbUpdatedAt, ok := args[6].(time.Time)
+			assert.True(t, ok)
+			assert.Equal(t, time.UTC, dbUpdatedAt.Location())
+		}
+		return nil
 	}
 
-	err := s.UpdateSessionState(ctx, key, session.StateMap{"k1": []byte("v1")})
+	err = s.UpdateSessionState(ctx, key, session.StateMap{"k1": []byte("v1")})
 	assert.NoError(t, err)
 }
 

--- a/session/clickhouse/service_test.go
+++ b/session/clickhouse/service_test.go
@@ -93,6 +93,14 @@ func TestService_GetSession(t *testing.T) {
 
 	// Mock exec for insert
 	mockCli.execFunc = func(ctx context.Context, query string, args ...any) error {
+		if strings.Contains(query, "INSERT INTO session_states") {
+			createdAt, ok := args[5].(time.Time)
+			assert.True(t, ok)
+			assert.Equal(t, time.UTC, createdAt.Location())
+			updatedAt, ok := args[6].(time.Time)
+			assert.True(t, ok)
+			assert.Equal(t, time.UTC, updatedAt.Location())
+		}
 		return nil
 	}
 
@@ -104,6 +112,8 @@ func TestService_GetSession(t *testing.T) {
 	assert.Equal(t, key.UserID, sess.UserID)
 	assert.Equal(t, key.SessionID, sess.ID)
 	assert.Equal(t, state, sess.State)
+	assert.Equal(t, time.UTC, sess.CreatedAt.Location())
+	assert.Equal(t, time.UTC, sess.UpdatedAt.Location())
 }
 
 func TestService_CreateSession_Exists(t *testing.T) {

--- a/session/mysql/service.go
+++ b/session/mysql/service.go
@@ -216,11 +216,12 @@ func (s *Service) CreateSession(
 	}
 
 	now := time.Now()
+	nowUTC := now.UTC()
 	sessState := &SessionState{
 		ID:        key.SessionID,
 		State:     make(session.StateMap),
-		UpdatedAt: now,
-		CreatedAt: now,
+		UpdatedAt: nowUTC,
+		CreatedAt: nowUTC,
 	}
 	for k, v := range state {
 		if v == nil {

--- a/session/mysql/service.go
+++ b/session/mysql/service.go
@@ -618,6 +618,7 @@ func (s *Service) UpdateSessionState(ctx context.Context, key session.Key, state
 			return fmt.Errorf("mysql session service update session state failed: %w", err)
 		}
 		now := time.Now()
+		nowUTC := now.UTC()
 
 		if sessState.State == nil {
 			sessState.State = make(session.StateMap)
@@ -631,7 +632,7 @@ func (s *Service) UpdateSessionState(ctx context.Context, key session.Key, state
 			copy(copiedValue, v)
 			sessState.State[k] = copiedValue
 		}
-		sessState.UpdatedAt = now
+		sessState.UpdatedAt = nowUTC
 
 		updatedStateBytes, err := json.Marshal(sessState)
 		if err != nil {
@@ -642,7 +643,7 @@ func (s *Service) UpdateSessionState(ctx context.Context, key session.Key, state
 		_, err = tx.ExecContext(ctx,
 			fmt.Sprintf(`UPDATE %s SET state = ?, updated_at = ?, expires_at = ?
 		 WHERE app_name = ? AND user_id = ? AND session_id = ? AND deleted_at IS NULL`, s.tableSessionStates),
-			string(updatedStateBytes), now, expiresAt,
+			string(updatedStateBytes), nowUTC, expiresAt,
 			key.AppName, key.UserID, key.SessionID)
 		if err != nil {
 			return fmt.Errorf("mysql session service update session state failed: %w", err)

--- a/session/mysql/service_helper.go
+++ b/session/mysql/service_helper.go
@@ -309,7 +309,6 @@ func (s *Service) addEvent(ctx context.Context, key session.Key, event *event.Ev
 		}
 		now := time.Now()
 		nowUTC := now.UTC()
-		eventCreatedAt := eventCreatedAtUTC(event, now)
 
 		// Check if session is expired
 		if currentExpiresAt.Valid && currentExpiresAt.Time.Before(now) {
@@ -351,7 +350,7 @@ func (s *Service) addEvent(ctx context.Context, key session.Key, event *event.Ev
 			_, err = tx.ExecContext(ctx,
 				fmt.Sprintf(`INSERT INTO %s (app_name, user_id, session_id, event, created_at, updated_at)
 				 VALUES (?, ?, ?, ?, ?, ?)`, s.tableSessionEvents),
-				key.AppName, key.UserID, key.SessionID, string(eventBytes), eventCreatedAt, nowUTC)
+				key.AppName, key.UserID, key.SessionID, string(eventBytes), nowUTC, nowUTC)
 			if err != nil {
 				return fmt.Errorf("insert event failed: %w", err)
 			}
@@ -363,13 +362,6 @@ func (s *Service) addEvent(ctx context.Context, key session.Key, event *event.Ev
 		return fmt.Errorf("store event failed: %w", err)
 	}
 	return nil
-}
-
-func eventCreatedAtUTC(evt *event.Event, fallback time.Time) time.Time {
-	if evt != nil && !evt.Timestamp.IsZero() {
-		return timestampUTC(evt.Timestamp, fallback)
-	}
-	return timestampUTC(time.Time{}, fallback)
 }
 
 func trackEventCreatedAtUTC(trackEvent *session.TrackEvent, fallback time.Time) time.Time {

--- a/session/mysql/service_helper.go
+++ b/session/mysql/service_helper.go
@@ -308,6 +308,8 @@ func (s *Service) addEvent(ctx context.Context, key session.Key, event *event.Ev
 			return err
 		}
 		now := time.Now()
+		nowUTC := now.UTC()
+		eventCreatedAt := eventCreatedAtUTC(event, now)
 
 		// Check if session is expired
 		if currentExpiresAt.Valid && currentExpiresAt.Time.Before(now) {
@@ -321,7 +323,7 @@ func (s *Service) addEvent(ctx context.Context, key session.Key, event *event.Ev
 			)
 		}
 
-		sessState.UpdatedAt = now
+		sessState.UpdatedAt = nowUTC
 		if sessState.State == nil {
 			sessState.State = make(session.StateMap)
 		}
@@ -349,7 +351,7 @@ func (s *Service) addEvent(ctx context.Context, key session.Key, event *event.Ev
 			_, err = tx.ExecContext(ctx,
 				fmt.Sprintf(`INSERT INTO %s (app_name, user_id, session_id, event, created_at, updated_at)
 				 VALUES (?, ?, ?, ?, ?, ?)`, s.tableSessionEvents),
-				key.AppName, key.UserID, key.SessionID, string(eventBytes), now, now)
+				key.AppName, key.UserID, key.SessionID, string(eventBytes), eventCreatedAt, nowUTC)
 			if err != nil {
 				return fmt.Errorf("insert event failed: %w", err)
 			}
@@ -361,6 +363,27 @@ func (s *Service) addEvent(ctx context.Context, key session.Key, event *event.Ev
 		return fmt.Errorf("store event failed: %w", err)
 	}
 	return nil
+}
+
+func eventCreatedAtUTC(evt *event.Event, fallback time.Time) time.Time {
+	if evt != nil && !evt.Timestamp.IsZero() {
+		return timestampUTC(evt.Timestamp, fallback)
+	}
+	return timestampUTC(time.Time{}, fallback)
+}
+
+func trackEventCreatedAtUTC(trackEvent *session.TrackEvent, fallback time.Time) time.Time {
+	if trackEvent != nil && !trackEvent.Timestamp.IsZero() {
+		return timestampUTC(trackEvent.Timestamp, fallback)
+	}
+	return timestampUTC(time.Time{}, fallback)
+}
+
+func timestampUTC(ts time.Time, fallback time.Time) time.Time {
+	if !ts.IsZero() {
+		return ts.UTC()
+	}
+	return fallback.UTC()
 }
 
 // addTrackEvent adds a track event to a session (MySQL syntax).
@@ -379,6 +402,8 @@ func (s *Service) addTrackEvent(ctx context.Context, key session.Key, trackEvent
 			return err
 		}
 		now := time.Now()
+		nowUTC := now.UTC()
+		trackCreatedAt := trackEventCreatedAtUTC(trackEvent, now)
 
 		// Check if session is expired.
 		if currentExpiresAt.Valid && currentExpiresAt.Time.Before(now) {
@@ -399,7 +424,7 @@ func (s *Service) addTrackEvent(ctx context.Context, key session.Key, trackEvent
 			return err
 		}
 		sessState.State = sess.SnapshotState()
-		sessState.UpdatedAt = now
+		sessState.UpdatedAt = nowUTC
 		updatedAt = sessState.UpdatedAt
 
 		updatedStateBytes, err = json.Marshal(sessState)
@@ -423,7 +448,7 @@ func (s *Service) addTrackEvent(ctx context.Context, key session.Key, trackEvent
 			fmt.Sprintf(`INSERT INTO %s (app_name, user_id, session_id, track, event, created_at, updated_at, expires_at)
 			 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`, s.tableSessionTracks),
 			key.AppName, key.UserID, key.SessionID, trackEvent.Track, string(eventBytes),
-			trackEvent.Timestamp, trackEvent.Timestamp, expiresAt)
+			trackCreatedAt, nowUTC, expiresAt)
 		if err != nil {
 			return fmt.Errorf("insert track event failed: %w", err)
 		}

--- a/session/mysql/service_helper_test.go
+++ b/session/mysql/service_helper_test.go
@@ -1149,10 +1149,10 @@ func TestAddEvent_StoresAppendTimeAsTimestampUTC(t *testing.T) {
 	stateBytes, err := json.Marshal(sessState)
 	require.NoError(t, err)
 
-	eventTime := time.Date(
-		2026, 5, 31, 20, 25, 0, 123456000,
-		time.FixedZone("UTC+8", 8*60*60),
-	)
+	// event.Timestamp is logical event time; created_at stores the append time.
+	// Keep eventTime outside the append window so regressions cannot pass.
+	eventTime := time.Now().In(time.FixedZone("UTC+8", 8*60*60)).Add(-24 * time.Hour)
+	beforeAppend := time.Now().UTC()
 
 	expectLoadSessionStateForUpdate(mock, key).
 		WillReturnRows(sqlmock.NewRows([]string{"state", "expires_at"}).
@@ -1162,7 +1162,7 @@ func TestAddEvent_StoresAppendTimeAsTimestampUTC(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO session_events")).
 		WithArgs(key.AppName, key.UserID, key.SessionID, sqlmock.AnyArg(),
-			utcTimeNotEqualArg{not: eventTime}, utcTimeArg{}).
+			appendTimeUTCArg{notBefore: beforeAppend}, utcTimeArg{}).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 

--- a/session/mysql/service_helper_test.go
+++ b/session/mysql/service_helper_test.go
@@ -1136,6 +1136,69 @@ func TestAddEvent_ExpiredSession(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestAddEvent_StoresEventCreatedAtAsTimestampUTC(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db)
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "sess"}
+
+	sessState := SessionState{ID: key.SessionID, State: session.StateMap{}}
+	stateBytes, err := json.Marshal(sessState)
+	require.NoError(t, err)
+
+	eventTime := time.Date(
+		2026, 5, 31, 20, 25, 0, 123456000,
+		time.FixedZone("UTC+8", 8*60*60),
+	)
+
+	expectLoadSessionStateForUpdate(mock, key).
+		WillReturnRows(sqlmock.NewRows([]string{"state", "expires_at"}).
+			AddRow(stateBytes, nil))
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE session_states SET state = ?, updated_at = ?, expires_at = ?")).
+		WithArgs(sqlmock.AnyArg(), utcTimeArg{}, sqlmock.AnyArg(), key.AppName, key.UserID, key.SessionID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO session_events")).
+		WithArgs(key.AppName, key.UserID, key.SessionID, sqlmock.AnyArg(),
+			exactUTCTimeArg{want: eventTime}, utcTimeArg{}).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	evt := &event.Event{
+		Timestamp: eventTime,
+		Response: &model.Response{Choices: []model.Choice{{
+			Message: model.Message{Role: model.RoleUser, Content: "hello"},
+		}}},
+	}
+
+	err = s.addEvent(ctx, key, evt)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCreatedAtUTCUsesTimestampOrFallback(t *testing.T) {
+	fallback := time.Date(
+		2026, 5, 31, 20, 25, 0, 0,
+		time.FixedZone("UTC+8", 8*60*60),
+	)
+	eventTime := fallback.Add(time.Minute)
+
+	assert.Equal(t, fallback.UTC(), eventCreatedAtUTC(nil, fallback))
+	assert.Equal(
+		t,
+		eventTime.UTC(),
+		eventCreatedAtUTC(&event.Event{Timestamp: eventTime}, fallback),
+	)
+	assert.Equal(t, fallback.UTC(), trackEventCreatedAtUTC(nil, fallback))
+	assert.Equal(
+		t,
+		eventTime.UTC(),
+		trackEventCreatedAtUTC(&session.TrackEvent{Timestamp: eventTime}, fallback),
+	)
+}
+
 func TestAddEvent_PartialEvent(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
@@ -1201,9 +1264,12 @@ func TestAddTrackEvent_PreservesExistingSkillMarker(t *testing.T) {
 	require.NoError(t, err)
 
 	trackEvent := &session.TrackEvent{
-		Track:     "agui",
-		Payload:   json.RawMessage(`{"delta":"hi"}`),
-		Timestamp: time.Now(),
+		Track:   "agui",
+		Payload: json.RawMessage(`{"delta":"hi"}`),
+		Timestamp: time.Date(
+			2026, 5, 31, 20, 25, 0, 123456000,
+			time.FixedZone("UTC+8", 8*60*60),
+		),
 	}
 
 	expectLoadSessionStateForUpdate(mock, key).
@@ -1230,7 +1296,7 @@ func TestAddTrackEvent_PreservesExistingSkillMarker(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO session_track_events")).
 		WithArgs(key.AppName, key.UserID, key.SessionID, "agui",
-			sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+			sqlmock.AnyArg(), exactUTCTimeArg{want: trackEvent.Timestamp}, utcTimeArg{}, sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 

--- a/session/mysql/service_helper_test.go
+++ b/session/mysql/service_helper_test.go
@@ -1136,7 +1136,7 @@ func TestAddEvent_ExpiredSession(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestAddEvent_StoresEventCreatedAtAsTimestampUTC(t *testing.T) {
+func TestAddEvent_StoresAppendTimeAsTimestampUTC(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer db.Close()
@@ -1162,7 +1162,7 @@ func TestAddEvent_StoresEventCreatedAtAsTimestampUTC(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO session_events")).
 		WithArgs(key.AppName, key.UserID, key.SessionID, sqlmock.AnyArg(),
-			exactUTCTimeArg{want: eventTime}, utcTimeArg{}).
+			utcTimeNotEqualArg{not: eventTime}, utcTimeArg{}).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 
@@ -1178,19 +1178,13 @@ func TestAddEvent_StoresEventCreatedAtAsTimestampUTC(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestCreatedAtUTCUsesTimestampOrFallback(t *testing.T) {
+func TestTrackCreatedAtUTCUsesTimestampOrFallback(t *testing.T) {
 	fallback := time.Date(
 		2026, 5, 31, 20, 25, 0, 0,
 		time.FixedZone("UTC+8", 8*60*60),
 	)
 	eventTime := fallback.Add(time.Minute)
 
-	assert.Equal(t, fallback.UTC(), eventCreatedAtUTC(nil, fallback))
-	assert.Equal(
-		t,
-		eventTime.UTC(),
-		eventCreatedAtUTC(&event.Event{Timestamp: eventTime}, fallback),
-	)
 	assert.Equal(t, fallback.UTC(), trackEventCreatedAtUTC(nil, fallback))
 	assert.Equal(
 		t,
@@ -1287,7 +1281,7 @@ func TestAddTrackEvent_PreservesExistingSkillMarker(t *testing.T) {
 				createdAt:  createdAt,
 				previousAt: updatedAt,
 			},
-			sqlmock.AnyArg(),
+			utcTimeArg{},
 			sqlmock.AnyArg(),
 			key.AppName,
 			key.UserID,

--- a/session/mysql/service_test.go
+++ b/session/mysql/service_test.go
@@ -32,6 +32,24 @@ import (
 	storage "trpc.group/trpc-go/trpc-agent-go/storage/mysql"
 )
 
+type utcTimeArg struct{}
+
+func (a utcTimeArg) Match(v driver.Value) bool {
+	t, ok := v.(time.Time)
+	return ok && t.Location() == time.UTC
+}
+
+type exactUTCTimeArg struct {
+	want time.Time
+}
+
+func (a exactUTCTimeArg) Match(v driver.Value) bool {
+	t, ok := v.(time.Time)
+	return ok &&
+		t.Location() == time.UTC &&
+		t.Equal(a.want.UTC())
+}
+
 // mockMySQLClient implements storage.Client for testing with sqlmock
 type mockMySQLClient struct {
 	db *sql.DB
@@ -310,8 +328,8 @@ func TestCreateSession_Success(t *testing.T) {
 			key.UserID,
 			key.SessionID,
 			sqlmock.AnyArg(), // state (JSON)
-			sqlmock.AnyArg(), // created_at
-			sqlmock.AnyArg(), // updated_at
+			utcTimeArg{},     // created_at
+			utcTimeArg{},     // updated_at
 			sqlmock.AnyArg(), // expires_at
 		).
 		WillReturnResult(sqlmock.NewResult(1, 1))
@@ -331,6 +349,8 @@ func TestCreateSession_Success(t *testing.T) {
 	assert.NotNil(t, sess)
 	assert.Equal(t, key.SessionID, sess.ID)
 	assert.Equal(t, state, sess.State)
+	assert.Equal(t, time.UTC, sess.CreatedAt.Location())
+	assert.Equal(t, time.UTC, sess.UpdatedAt.Location())
 
 	assert.NoError(t, mock.ExpectationsWereMet())
 }

--- a/session/mysql/service_test.go
+++ b/session/mysql/service_test.go
@@ -50,6 +50,17 @@ func (a exactUTCTimeArg) Match(v driver.Value) bool {
 		t.Equal(a.want.UTC())
 }
 
+type utcTimeNotEqualArg struct {
+	not time.Time
+}
+
+func (a utcTimeNotEqualArg) Match(v driver.Value) bool {
+	t, ok := v.(time.Time)
+	return ok &&
+		t.Location() == time.UTC &&
+		!t.Equal(a.not.UTC())
+}
+
 // mockMySQLClient implements storage.Client for testing with sqlmock
 type mockMySQLClient struct {
 	db *sql.DB
@@ -269,6 +280,10 @@ func (m *sessionStateJSONMatcher) Match(v driver.Value) bool {
 	}
 	if stored.UpdatedAt.IsZero() {
 		m.t.Errorf("updatedAt should be set")
+		return false
+	}
+	if stored.UpdatedAt.Location() != time.UTC {
+		m.t.Errorf("updatedAt should be UTC, got %v", stored.UpdatedAt.Location())
 		return false
 	}
 	if !m.previousAt.IsZero() && !stored.UpdatedAt.After(m.previousAt) {
@@ -1900,7 +1915,7 @@ func TestUpdateSessionState_UnmarshalSessionEnvelope(t *testing.T) {
 				createdAt:     createdAt,
 				previousAt:    updatedAt,
 			},
-			sqlmock.AnyArg(),
+			utcTimeArg{},
 			sqlmock.AnyArg(),
 			key.AppName,
 			key.UserID,
@@ -1956,7 +1971,7 @@ func TestUpdateSessionState_UnmarshalNilState(t *testing.T) {
 				createdAt:     createdAt,
 				previousAt:    updatedAt,
 			},
-			sqlmock.AnyArg(),
+			utcTimeArg{},
 			sqlmock.AnyArg(),
 			key.AppName,
 			key.UserID,
@@ -2014,7 +2029,7 @@ func TestUpdateSessionState_CopiesStateValueAndKeepsNil(t *testing.T) {
 				createdAt:     createdAt,
 				previousAt:    updatedAt,
 			},
-			sqlmock.AnyArg(),
+			utcTimeArg{},
 			sqlmock.AnyArg(),
 			key.AppName,
 			key.UserID,

--- a/session/mysql/service_test.go
+++ b/session/mysql/service_test.go
@@ -50,15 +50,16 @@ func (a exactUTCTimeArg) Match(v driver.Value) bool {
 		t.Equal(a.want.UTC())
 }
 
-type utcTimeNotEqualArg struct {
-	not time.Time
+type appendTimeUTCArg struct {
+	notBefore time.Time
 }
 
-func (a utcTimeNotEqualArg) Match(v driver.Value) bool {
+func (a appendTimeUTCArg) Match(v driver.Value) bool {
 	t, ok := v.(time.Time)
 	return ok &&
 		t.Location() == time.UTC &&
-		!t.Equal(a.not.UTC())
+		!t.Before(a.notBefore.UTC()) &&
+		!t.After(time.Now().UTC().Add(time.Second))
 }
 
 // mockMySQLClient implements storage.Client for testing with sqlmock

--- a/session/postgres/service.go
+++ b/session/postgres/service.go
@@ -210,11 +210,12 @@ func (s *Service) CreateSession(
 	}
 
 	now := time.Now()
+	nowUTC := now.UTC()
 	sessState := &SessionState{
 		ID:        key.SessionID,
 		State:     make(session.StateMap),
-		UpdatedAt: now,
-		CreatedAt: now,
+		UpdatedAt: nowUTC,
+		CreatedAt: nowUTC,
 	}
 	for k, v := range state {
 		if v == nil {

--- a/session/postgres/service.go
+++ b/session/postgres/service.go
@@ -579,6 +579,7 @@ func (s *Service) UpdateSessionState(ctx context.Context, key session.Key, state
 		}
 
 		now := time.Now()
+		nowUTC := now.UTC()
 		if sessState.State == nil {
 			sessState.State = make(session.StateMap)
 		}
@@ -591,7 +592,7 @@ func (s *Service) UpdateSessionState(ctx context.Context, key session.Key, state
 			copy(copiedValue, v)
 			sessState.State[k] = copiedValue
 		}
-		sessState.UpdatedAt = now
+		sessState.UpdatedAt = nowUTC
 
 		updatedStateBytes, err := json.Marshal(sessState)
 		if err != nil {
@@ -607,7 +608,7 @@ func (s *Service) UpdateSessionState(ctx context.Context, key session.Key, state
 		_, err = tx.ExecContext(ctx,
 			fmt.Sprintf(`UPDATE %s SET state = $1, updated_at = $2, expires_at = $3
 		 WHERE app_name = $4 AND user_id = $5 AND session_id = $6 AND deleted_at IS NULL`, s.tableSessionStates),
-			updatedStateBytes, now, expiresAt,
+			updatedStateBytes, nowUTC, expiresAt,
 			key.AppName, key.UserID, key.SessionID)
 		if err != nil {
 			return fmt.Errorf("postgres session service update session state failed: %w", err)

--- a/session/postgres/service_edge_test.go
+++ b/session/postgres/service_edge_test.go
@@ -350,7 +350,7 @@ func TestAddEvent_InitializesNilState(t *testing.T) {
 				expectedID:    key.SessionID,
 				expectedState: session.StateMap{"marker": []byte("1")},
 			},
-			sqlmock.AnyArg(),
+			utcTimeArg{},
 			sqlmock.AnyArg(),
 			key.AppName,
 			key.UserID,

--- a/session/postgres/service_helper.go
+++ b/session/postgres/service_helper.go
@@ -280,7 +280,6 @@ func (s *Service) addEvent(ctx context.Context, key session.Key, event *event.Ev
 
 		now := time.Now()
 		nowUTC := now.UTC()
-		eventCreatedAt := eventCreatedAtUTC(event, now)
 		if currentExpiresAt != nil && currentExpiresAt.Before(now) {
 			log.InfofContext(
 				ctx,
@@ -325,7 +324,7 @@ func (s *Service) addEvent(ctx context.Context, key session.Key, event *event.Ev
 			_, err = tx.ExecContext(ctx,
 				fmt.Sprintf(`INSERT INTO %s (app_name, user_id, session_id, event, created_at, updated_at)
 				 VALUES ($1, $2, $3, $4, $5, $6)`, s.tableSessionEvents),
-				key.AppName, key.UserID, key.SessionID, eventBytes, eventCreatedAt, nowUTC)
+				key.AppName, key.UserID, key.SessionID, eventBytes, nowUTC, nowUTC)
 			if err != nil {
 				return fmt.Errorf("insert event failed: %w", err)
 			}
@@ -337,13 +336,6 @@ func (s *Service) addEvent(ctx context.Context, key session.Key, event *event.Ev
 		return fmt.Errorf("store event failed: %w", err)
 	}
 	return nil
-}
-
-func eventCreatedAtUTC(evt *event.Event, fallback time.Time) time.Time {
-	if evt != nil && !evt.Timestamp.IsZero() {
-		return timestampUTC(evt.Timestamp, fallback)
-	}
-	return timestampUTC(time.Time{}, fallback)
 }
 
 func trackEventCreatedAtUTC(trackEvent *session.TrackEvent, fallback time.Time) time.Time {

--- a/session/postgres/service_helper.go
+++ b/session/postgres/service_helper.go
@@ -279,6 +279,8 @@ func (s *Service) addEvent(ctx context.Context, key session.Key, event *event.Ev
 		}
 
 		now := time.Now()
+		nowUTC := now.UTC()
+		eventCreatedAt := eventCreatedAtUTC(event, now)
 		if currentExpiresAt != nil && currentExpiresAt.Before(now) {
 			log.InfofContext(
 				ctx,
@@ -290,12 +292,12 @@ func (s *Service) addEvent(ctx context.Context, key session.Key, event *event.Ev
 			)
 		}
 
-		sessState.UpdatedAt = now
+		sessState.UpdatedAt = nowUTC
 		if sessState.State == nil {
 			sessState.State = make(session.StateMap)
 		}
 		session.ApplyEventStateDeltaMap(sessState.State, event)
-		updatedAt = now
+		updatedAt = nowUTC
 
 		updatedStateBytes, err = json.Marshal(sessState)
 		if err != nil {
@@ -323,7 +325,7 @@ func (s *Service) addEvent(ctx context.Context, key session.Key, event *event.Ev
 			_, err = tx.ExecContext(ctx,
 				fmt.Sprintf(`INSERT INTO %s (app_name, user_id, session_id, event, created_at, updated_at)
 				 VALUES ($1, $2, $3, $4, $5, $6)`, s.tableSessionEvents),
-				key.AppName, key.UserID, key.SessionID, eventBytes, now, now)
+				key.AppName, key.UserID, key.SessionID, eventBytes, eventCreatedAt, nowUTC)
 			if err != nil {
 				return fmt.Errorf("insert event failed: %w", err)
 			}
@@ -335,6 +337,27 @@ func (s *Service) addEvent(ctx context.Context, key session.Key, event *event.Ev
 		return fmt.Errorf("store event failed: %w", err)
 	}
 	return nil
+}
+
+func eventCreatedAtUTC(evt *event.Event, fallback time.Time) time.Time {
+	if evt != nil && !evt.Timestamp.IsZero() {
+		return timestampUTC(evt.Timestamp, fallback)
+	}
+	return timestampUTC(time.Time{}, fallback)
+}
+
+func trackEventCreatedAtUTC(trackEvent *session.TrackEvent, fallback time.Time) time.Time {
+	if trackEvent != nil && !trackEvent.Timestamp.IsZero() {
+		return timestampUTC(trackEvent.Timestamp, fallback)
+	}
+	return timestampUTC(time.Time{}, fallback)
+}
+
+func timestampUTC(ts time.Time, fallback time.Time) time.Time {
+	if !ts.IsZero() {
+		return ts.UTC()
+	}
+	return fallback.UTC()
 }
 
 func (s *Service) addTrackEvent(ctx context.Context, key session.Key, trackEvent *session.TrackEvent) error {
@@ -353,6 +376,8 @@ func (s *Service) addTrackEvent(ctx context.Context, key session.Key, trackEvent
 		}
 
 		now := time.Now()
+		nowUTC := now.UTC()
+		trackCreatedAt := trackEventCreatedAtUTC(trackEvent, now)
 		if currentExpiresAt != nil && currentExpiresAt.Before(now) {
 			log.InfofContext(
 				ctx,
@@ -377,8 +402,8 @@ func (s *Service) addTrackEvent(ctx context.Context, key session.Key, trackEvent
 			return err
 		}
 		sessState.State = sess.SnapshotState()
-		sessState.UpdatedAt = now
-		updatedAt = now
+		sessState.UpdatedAt = nowUTC
+		updatedAt = nowUTC
 
 		updatedStateBytes, err = json.Marshal(sessState)
 		if err != nil {
@@ -406,7 +431,7 @@ func (s *Service) addTrackEvent(ctx context.Context, key session.Key, trackEvent
 			fmt.Sprintf(`INSERT INTO %s (app_name, user_id, session_id, track, event, created_at, updated_at, expires_at)
 			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`, s.tableSessionTracks),
 			key.AppName, key.UserID, key.SessionID, trackEvent.Track, eventBytes,
-			trackEvent.Timestamp, trackEvent.Timestamp, expiresAt)
+			trackCreatedAt, nowUTC, expiresAt)
 		if err != nil {
 			return fmt.Errorf("insert track event failed: %w", err)
 		}

--- a/session/postgres/service_helper_test.go
+++ b/session/postgres/service_helper_test.go
@@ -32,10 +32,10 @@ func TestAddEvent_StoresAppendTimeAsTimestampUTC(t *testing.T) {
 	stateBytes, err := json.Marshal(sessState)
 	require.NoError(t, err)
 
-	eventTime := time.Date(
-		2026, 5, 31, 20, 25, 0, 123456000,
-		time.FixedZone("UTC+8", 8*60*60),
-	)
+	// event.Timestamp is logical event time; created_at stores the append time.
+	// Keep eventTime outside the append window so regressions cannot pass.
+	eventTime := time.Now().In(time.FixedZone("UTC+8", 8*60*60)).Add(-24 * time.Hour)
+	beforeAppend := time.Now().UTC()
 
 	expectLoadSessionStateForUpdate(mock, key).
 		WillReturnRows(sqlmock.NewRows([]string{"state", "expires_at"}).
@@ -46,7 +46,7 @@ func TestAddEvent_StoresAppendTimeAsTimestampUTC(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec("INSERT INTO session_events").
 		WithArgs(key.AppName, key.UserID, key.SessionID, sqlmock.AnyArg(),
-			utcTimeNotEqualArg{not: eventTime}, utcTimeArg{}).
+			appendTimeUTCArg{notBefore: beforeAppend}, utcTimeArg{}).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 

--- a/session/postgres/service_helper_test.go
+++ b/session/postgres/service_helper_test.go
@@ -8,3 +8,77 @@
 //
 
 package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+func TestAddEvent_StoresEventCreatedAtAsTimestampUTC(t *testing.T) {
+	s, mock, db := setupMockService(t, nil)
+	defer db.Close()
+
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "sess"}
+	sessState := &SessionState{ID: key.SessionID, State: session.StateMap{}}
+	stateBytes, err := json.Marshal(sessState)
+	require.NoError(t, err)
+
+	eventTime := time.Date(
+		2026, 5, 31, 20, 25, 0, 123456000,
+		time.FixedZone("UTC+8", 8*60*60),
+	)
+
+	expectLoadSessionStateForUpdate(mock, key).
+		WillReturnRows(sqlmock.NewRows([]string{"state", "expires_at"}).
+			AddRow(stateBytes, nil))
+	mock.ExpectExec("UPDATE session_states SET state").
+		WithArgs(sqlmock.AnyArg(), utcTimeArg{}, sqlmock.AnyArg(),
+			key.AppName, key.UserID, key.SessionID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO session_events").
+		WithArgs(key.AppName, key.UserID, key.SessionID, sqlmock.AnyArg(),
+			exactUTCTimeArg{want: eventTime}, utcTimeArg{}).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	evt := &event.Event{
+		Timestamp: eventTime,
+		Response: &model.Response{Choices: []model.Choice{{
+			Message: model.Message{Role: model.RoleUser, Content: "hello"},
+		}}},
+	}
+
+	err = s.addEvent(context.Background(), key, evt)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCreatedAtUTCUsesTimestampOrFallback(t *testing.T) {
+	fallback := time.Date(
+		2026, 5, 31, 20, 25, 0, 0,
+		time.FixedZone("UTC+8", 8*60*60),
+	)
+	eventTime := fallback.Add(time.Minute)
+
+	assert.Equal(t, fallback.UTC(), eventCreatedAtUTC(nil, fallback))
+	assert.Equal(
+		t,
+		eventTime.UTC(),
+		eventCreatedAtUTC(&event.Event{Timestamp: eventTime}, fallback),
+	)
+	assert.Equal(t, fallback.UTC(), trackEventCreatedAtUTC(nil, fallback))
+	assert.Equal(
+		t,
+		eventTime.UTC(),
+		trackEventCreatedAtUTC(&session.TrackEvent{Timestamp: eventTime}, fallback),
+	)
+}

--- a/session/postgres/service_helper_test.go
+++ b/session/postgres/service_helper_test.go
@@ -23,7 +23,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/session"
 )
 
-func TestAddEvent_StoresEventCreatedAtAsTimestampUTC(t *testing.T) {
+func TestAddEvent_StoresAppendTimeAsTimestampUTC(t *testing.T) {
 	s, mock, db := setupMockService(t, nil)
 	defer db.Close()
 
@@ -46,7 +46,7 @@ func TestAddEvent_StoresEventCreatedAtAsTimestampUTC(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec("INSERT INTO session_events").
 		WithArgs(key.AppName, key.UserID, key.SessionID, sqlmock.AnyArg(),
-			exactUTCTimeArg{want: eventTime}, utcTimeArg{}).
+			utcTimeNotEqualArg{not: eventTime}, utcTimeArg{}).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 
@@ -62,19 +62,13 @@ func TestAddEvent_StoresEventCreatedAtAsTimestampUTC(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestCreatedAtUTCUsesTimestampOrFallback(t *testing.T) {
+func TestTrackCreatedAtUTCUsesTimestampOrFallback(t *testing.T) {
 	fallback := time.Date(
 		2026, 5, 31, 20, 25, 0, 0,
 		time.FixedZone("UTC+8", 8*60*60),
 	)
 	eventTime := fallback.Add(time.Minute)
 
-	assert.Equal(t, fallback.UTC(), eventCreatedAtUTC(nil, fallback))
-	assert.Equal(
-		t,
-		eventTime.UTC(),
-		eventCreatedAtUTC(&event.Event{Timestamp: eventTime}, fallback),
-	)
 	assert.Equal(t, fallback.UTC(), trackEventCreatedAtUTC(nil, fallback))
 	assert.Equal(
 		t,

--- a/session/postgres/service_test.go
+++ b/session/postgres/service_test.go
@@ -66,6 +66,17 @@ func (a exactUTCTimeArg) Match(v driver.Value) bool {
 		t.Equal(a.want.UTC())
 }
 
+type utcTimeNotEqualArg struct {
+	not time.Time
+}
+
+func (a utcTimeNotEqualArg) Match(v driver.Value) bool {
+	t, ok := v.(time.Time)
+	return ok &&
+		t.Location() == time.UTC &&
+		!t.Equal(a.not.UTC())
+}
+
 // AnyStringSlice returns a custom matcher for []string arguments.
 // WARNING: Due to database/sql driver limitations, this matcher cannot
 // prevent runtime type validation errors when actual queries execute.
@@ -168,6 +179,10 @@ func (m *sessionStateJSONMatcher) Match(v driver.Value) bool {
 	}
 	if stored.UpdatedAt.IsZero() {
 		m.t.Errorf("updatedAt should be set")
+		return false
+	}
+	if stored.UpdatedAt.Location() != time.UTC {
+		m.t.Errorf("updatedAt should be UTC, got %v", stored.UpdatedAt.Location())
 		return false
 	}
 	if !m.previousAt.IsZero() && !stored.UpdatedAt.After(m.previousAt) {
@@ -1523,7 +1538,7 @@ func TestUpdateSessionState_UnmarshalSessionEnvelope(t *testing.T) {
 				createdAt:     createdAt,
 				previousAt:    updatedAt,
 			},
-			sqlmock.AnyArg(),
+			utcTimeArg{},
 			sqlmock.AnyArg(),
 			key.AppName,
 			key.UserID,
@@ -1575,7 +1590,7 @@ func TestUpdateSessionState_UnmarshalNilState(t *testing.T) {
 				createdAt:     createdAt,
 				previousAt:    updatedAt,
 			},
-			sqlmock.AnyArg(),
+			utcTimeArg{},
 			sqlmock.AnyArg(),
 			key.AppName,
 			key.UserID,
@@ -1629,7 +1644,7 @@ func TestUpdateSessionState_CopiesStateValueAndKeepsNil(t *testing.T) {
 				createdAt:     createdAt,
 				previousAt:    updatedAt,
 			},
-			sqlmock.AnyArg(),
+			utcTimeArg{},
 			sqlmock.AnyArg(),
 			key.AppName,
 			key.UserID,

--- a/session/postgres/service_test.go
+++ b/session/postgres/service_test.go
@@ -66,15 +66,16 @@ func (a exactUTCTimeArg) Match(v driver.Value) bool {
 		t.Equal(a.want.UTC())
 }
 
-type utcTimeNotEqualArg struct {
-	not time.Time
+type appendTimeUTCArg struct {
+	notBefore time.Time
 }
 
-func (a utcTimeNotEqualArg) Match(v driver.Value) bool {
+func (a appendTimeUTCArg) Match(v driver.Value) bool {
 	t, ok := v.(time.Time)
 	return ok &&
 		t.Location() == time.UTC &&
-		!t.Equal(a.not.UTC())
+		!t.Before(a.notBefore.UTC()) &&
+		!t.After(time.Now().UTC().Add(time.Second))
 }
 
 // AnyStringSlice returns a custom matcher for []string arguments.

--- a/session/postgres/service_test.go
+++ b/session/postgres/service_test.go
@@ -48,6 +48,24 @@ func (s stringSliceValuer) Match(v driver.Value) bool {
 	return ok
 }
 
+type utcTimeArg struct{}
+
+func (a utcTimeArg) Match(v driver.Value) bool {
+	t, ok := v.(time.Time)
+	return ok && t.Location() == time.UTC
+}
+
+type exactUTCTimeArg struct {
+	want time.Time
+}
+
+func (a exactUTCTimeArg) Match(v driver.Value) bool {
+	t, ok := v.(time.Time)
+	return ok &&
+		t.Location() == time.UTC &&
+		t.Equal(a.want.UTC())
+}
+
 // AnyStringSlice returns a custom matcher for []string arguments.
 // WARNING: Due to database/sql driver limitations, this matcher cannot
 // prevent runtime type validation errors when actual queries execute.
@@ -429,7 +447,7 @@ func TestCreateSession_Success(t *testing.T) {
 	// Mock INSERT session state
 	mock.ExpectExec("INSERT INTO session_states").
 		WithArgs("test-app", "test-user", sqlmock.AnyArg(), sqlmock.AnyArg(),
-			sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+			utcTimeArg{}, utcTimeArg{}, sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	// Mock SELECT app_states
@@ -451,6 +469,8 @@ func TestCreateSession_Success(t *testing.T) {
 	assert.Equal(t, "test-user", sess.UserID)
 	assert.NotEmpty(t, sess.ID)
 	assert.Equal(t, []byte("value1"), sess.State["key1"])
+	assert.Equal(t, time.UTC, sess.CreatedAt.Location())
+	assert.Equal(t, time.UTC, sess.UpdatedAt.Location())
 
 	require.NoError(t, mock.ExpectationsWereMet())
 }
@@ -2224,9 +2244,12 @@ func TestAddTrackEvent_ExpiredSessionWithTTL(t *testing.T) {
 		SessionID: "session-1",
 	}
 	trackEvent := &session.TrackEvent{
-		Track:     "alpha",
-		Payload:   json.RawMessage(`"ttl"`),
-		Timestamp: time.Now(),
+		Track:   "alpha",
+		Payload: json.RawMessage(`"ttl"`),
+		Timestamp: time.Date(
+			2026, 5, 31, 20, 25, 0, 123456000,
+			time.FixedZone("UTC+8", 8*60*60),
+		),
 	}
 
 	sessState := &SessionState{
@@ -2244,7 +2267,7 @@ func TestAddTrackEvent_ExpiredSessionWithTTL(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec("INSERT INTO session_track_events").
 		WithArgs("test-app", "test-user", "session-1", "alpha",
-			sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+			sqlmock.AnyArg(), exactUTCTimeArg{want: trackEvent.Timestamp}, utcTimeArg{}, sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 


### PR DESCRIPTION
## What

- Store newly written PostgreSQL, MySQL, and ClickHouse session `created_at` / `updated_at` timestamps in UTC.
- Persist event `created_at` from the event logical timestamp normalized to UTC, with a UTC fallback for missing timestamps.
- Persist track-event `created_at` from the track timestamp normalized to UTC for PostgreSQL and MySQL.
- Add targeted tests that verify UTC arguments even when event timestamps carry a non-UTC location.

## Why

#1875 added summary/event filtering against session creation boundaries. Backends that persisted local wall-clock timestamps could compare non-equivalent boundaries after round trips through timestamp columns. This aligns the remaining SQL session backends with the UTC timestamp contract used by the other implementations.

## Validation

- `go test ./...`
- `go test ./...` in `session/postgres`, `session/mysql`, and `session/clickhouse`
- `TZ=Asia/Shanghai go test ./...` in `session/postgres`, `session/mysql`, and `session/clickhouse`
- Local PostgreSQL, MySQL, and ClickHouse smoke checks for non-UTC event timestamps and persisted summary reloads
