### PR TITLE
{agent/codex, docs, examples}: add Codex CLI agent

### DIFF
--- a/agent/codex/codex_agent.go
+++ b/agent/codex/codex_agent.go
@@ -238,9 +238,6 @@ func (a *codexAgent) runWithSession(ctx context.Context, threadID, prompt string
 		if runErr == nil {
 			return stdout, stderr, nil
 		}
-		if !canCreateAfterResumeError(stdout, stderr) {
-			return stdout, stderr, fmt.Errorf("run resume %v: %w", threadID, runErr)
-		}
 		createStdout, createStderr, createErr := a.runCreate(ctx, prompt)
 		if createErr == nil {
 			return createStdout, createStderr, nil
@@ -250,15 +247,6 @@ func (a *codexAgent) runWithSession(ctx context.Context, threadID, prompt string
 		return createStdout, createStderr, overallErr
 	}
 	return a.runCreate(ctx, prompt)
-}
-
-// canCreateAfterResumeError reports whether a resume failure is known stale before Codex emitted JSONL output.
-func canCreateAfterResumeError(stdout, stderr []byte) bool {
-	if len(bytes.TrimSpace(stdout)) > 0 {
-		return false
-	}
-	msg := strings.ToLower(string(stderr))
-	return strings.Contains(msg, "thread/resume failed") && strings.Contains(msg, "no rollout found for thread id")
 }
 
 // runCreate starts a new Codex exec session.

--- a/agent/codex/codex_agent.go
+++ b/agent/codex/codex_agent.go
@@ -1,0 +1,294 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package codex
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/log"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+// codexAgent invokes a locally installed Codex CLI and maps its JSONL events into trpc-agent-go events.
+type codexAgent struct {
+	name          string
+	description   string
+	bin           string
+	globalArgs    []string
+	args          []string
+	env           []string
+	workDir       string
+	commandRunner commandRunner
+	rawOutputHook RawOutputHook
+}
+
+// New creates a Codex CLI agent with the provided options.
+func New(opt ...Option) (agent.Agent, error) {
+	opts, err := newOptions(opt...)
+	if err != nil {
+		return nil, err
+	}
+	return &codexAgent{
+		name:          opts.name,
+		description:   opts.description,
+		bin:           opts.bin,
+		globalArgs:    opts.globalArgs,
+		args:          opts.args,
+		env:           opts.env,
+		workDir:       opts.workDir,
+		commandRunner: opts.commandRunner,
+		rawOutputHook: opts.rawOutputHook,
+	}, nil
+}
+
+// Info implements agent.Agent.
+func (a *codexAgent) Info() agent.Info {
+	return agent.Info{
+		Name:        a.name,
+		Description: a.description,
+	}
+}
+
+// Tools implements agent.Agent.
+func (a *codexAgent) Tools() []tool.Tool { return nil }
+
+// SubAgents implements agent.Agent.
+func (a *codexAgent) SubAgents() []agent.Agent { return nil }
+
+// FindSubAgent implements agent.Agent.
+func (a *codexAgent) FindSubAgent(string) agent.Agent { return nil }
+
+// Run implements agent.Agent.
+func (a *codexAgent) Run(ctx context.Context, invocation *agent.Invocation) (<-chan *event.Event, error) {
+	if invocation == nil {
+		return nil, errors.New("invocation is nil")
+	}
+	if invocation.Session == nil {
+		return nil, errors.New("invocation session is nil")
+	}
+	if invocation.Session.ID == "" {
+		return nil, errors.New("invocation session id is empty")
+	}
+	if invocation.Message.Content == "" {
+		return nil, errors.New("invocation prompt is empty")
+	}
+	out := make(chan *event.Event)
+	runCtx := agent.CloneContext(ctx)
+	go a.runInvocation(runCtx, invocation, out)
+	return out, nil
+}
+
+// runInvocation executes the CLI invocation and emits tool events and the final response event.
+func (a *codexAgent) runInvocation(ctx context.Context, invocation *agent.Invocation, out chan<- *event.Event) {
+	defer close(out)
+	resumeThreadID := sessionThreadID(invocation.Session)
+	stdout, stderr, runErr := a.runWithSession(ctx, resumeThreadID, invocation.Message.Content)
+	combined := bytes.TrimSpace(append(append([]byte(nil), stdout...), stderr...))
+	observedThreadID := extractThreadID(stdout)
+	if hookErr := a.handleRawOutputHook(ctx, invocation, resumeThreadID, observedThreadID, stdout, stderr, runErr); hookErr != nil {
+		err := fmt.Errorf("raw output hook: %w", hookErr)
+		if runErr != nil {
+			err = errors.Join(err, fmt.Errorf("command error: %w", runErr))
+		}
+		a.emitFlowError(ctx, invocation, out, combined, err)
+		return
+	}
+	if runErr != nil {
+		a.emitRunError(ctx, invocation, out, combined, runErr)
+		return
+	}
+	result := &transcriptResult{}
+	if len(stdout) > 0 {
+		parsed, err := parseTranscriptEvents(stdout, invocation.InvocationID, a.name)
+		if err != nil {
+			decodeErr := fmt.Errorf("parse codex transcript: %w", err)
+			a.emitFlowError(ctx, invocation, out, combined, decodeErr)
+			return
+		}
+		result = parsed
+		for _, e := range parsed.Events {
+			a.emitEvent(ctx, invocation, out, e)
+		}
+	}
+	finalContent := string(combined)
+	if strings.TrimSpace(result.FinalMessage) != "" {
+		finalContent = strings.TrimSpace(result.FinalMessage)
+	}
+	rsp := &model.Response{
+		Object: model.ObjectTypeChatCompletion,
+		Done:   true,
+		Usage:  result.Usage,
+		Choices: []model.Choice{
+			{
+				Index: 0,
+				Message: model.Message{
+					Role:    model.RoleAssistant,
+					Content: finalContent,
+				},
+			},
+		},
+	}
+	evt := event.NewResponseEvent(invocation.InvocationID, a.name, rsp)
+	if result.ThreadID == "" {
+		result.ThreadID = observedThreadID
+	}
+	if result.ThreadID != "" && result.ThreadID != resumeThreadID {
+		evt.StateDelta = map[string][]byte{StateKeyThreadID: []byte(result.ThreadID)}
+	}
+	a.emitEvent(ctx, invocation, out, evt)
+}
+
+// handleRawOutputHook invokes the configured raw output hook.
+func (a *codexAgent) handleRawOutputHook(
+	ctx context.Context,
+	invocation *agent.Invocation,
+	resumeThreadID string,
+	threadID string,
+	stdout []byte,
+	stderr []byte,
+	runErr error,
+) error {
+	if a == nil || a.rawOutputHook == nil || invocation == nil || invocation.Session == nil {
+		return nil
+	}
+	return a.rawOutputHook(ctx, &RawOutputHookArgs{
+		InvocationID:   invocation.InvocationID,
+		SessionID:      invocation.Session.ID,
+		ResumeThreadID: resumeThreadID,
+		ThreadID:       threadID,
+		Prompt:         invocation.Message.Content,
+		Stdout:         stdout,
+		Stderr:         stderr,
+		Error:          runErr,
+	})
+}
+
+// emitRunError emits a command execution error response.
+func (a *codexAgent) emitRunError(ctx context.Context, invocation *agent.Invocation, out chan<- *event.Event, combined []byte, runErr error) {
+	msg := string(combined)
+	if len(combined) == 0 {
+		msg = runErr.Error()
+	}
+	rsp := &model.Response{
+		Object: model.ObjectTypeError,
+		Done:   true,
+		Choices: []model.Choice{
+			{
+				Index: 0,
+				Message: model.Message{
+					Role:    model.RoleAssistant,
+					Content: msg,
+				},
+			},
+		},
+		Error: &model.ResponseError{
+			Type:    model.ErrorTypeRunError,
+			Message: msg,
+		},
+	}
+	a.emitEvent(ctx, invocation, out, event.NewResponseEvent(invocation.InvocationID, a.name, rsp))
+}
+
+// emitFlowError emits an error response event and stops further invocation processing.
+func (a *codexAgent) emitFlowError(ctx context.Context, invocation *agent.Invocation, out chan<- *event.Event, combined []byte, flowErr error) {
+	rsp := &model.Response{
+		Object: model.ObjectTypeError,
+		Done:   true,
+		Choices: []model.Choice{
+			{
+				Index: 0,
+				Message: model.Message{
+					Role:    model.RoleAssistant,
+					Content: string(combined),
+				},
+			},
+		},
+		Error: &model.ResponseError{
+			Type:    model.ErrorTypeFlowError,
+			Message: flowErr.Error(),
+		},
+	}
+	a.emitEvent(ctx, invocation, out, event.NewResponseEvent(invocation.InvocationID, a.name, rsp))
+}
+
+// runWithSession executes the CLI with resume-first semantics and returns stdout/stderr.
+func (a *codexAgent) runWithSession(ctx context.Context, threadID, prompt string) ([]byte, []byte, error) {
+	if strings.TrimSpace(threadID) != "" {
+		stdout, stderr, runErr := a.runResume(ctx, threadID, prompt)
+		if runErr == nil {
+			return stdout, stderr, nil
+		}
+		createStdout, createStderr, createErr := a.runCreate(ctx, prompt)
+		if createErr == nil {
+			return createStdout, createStderr, nil
+		}
+		overallErr := fmt.Errorf("run resume %v: %w", threadID, runErr)
+		overallErr = errors.Join(overallErr, fmt.Errorf("run exec: %w", createErr))
+		return createStdout, createStderr, overallErr
+	}
+	return a.runCreate(ctx, prompt)
+}
+
+// runCreate starts a new Codex exec session.
+func (a *codexAgent) runCreate(ctx context.Context, prompt string) ([]byte, []byte, error) {
+	cmdArgs := make([]string, 0, len(a.globalArgs)+len(a.args)+2)
+	cmdArgs = append(cmdArgs, a.globalArgs...)
+	cmdArgs = append(cmdArgs, "exec")
+	cmdArgs = append(cmdArgs, a.args...)
+	cmdArgs = append(cmdArgs, prompt)
+	return a.commandRunner.Run(ctx, command{
+		bin:  a.bin,
+		args: cmdArgs,
+		env:  a.env,
+		dir:  a.workDir,
+	})
+}
+
+// runResume resumes an existing Codex thread.
+func (a *codexAgent) runResume(ctx context.Context, threadID, prompt string) ([]byte, []byte, error) {
+	cmdArgs := make([]string, 0, len(a.globalArgs)+len(a.args)+4)
+	cmdArgs = append(cmdArgs, a.globalArgs...)
+	cmdArgs = append(cmdArgs, "exec", "resume")
+	cmdArgs = append(cmdArgs, a.args...)
+	cmdArgs = append(cmdArgs, threadID, prompt)
+	return a.commandRunner.Run(ctx, command{
+		bin:  a.bin,
+		args: cmdArgs,
+		env:  a.env,
+		dir:  a.workDir,
+	})
+}
+
+// emitEvent forwards an event to the caller and logs emission failures.
+func (a *codexAgent) emitEvent(ctx context.Context, invocation *agent.Invocation, out chan<- *event.Event, evt *event.Event) {
+	if err := agent.EmitEvent(ctx, invocation, out, evt); err != nil {
+		log.ErrorfContext(ctx, "codex agent failed to emit event: %v", err)
+	}
+}
+
+// sessionThreadID returns the persisted Codex thread id from session state.
+func sessionThreadID(sess *session.Session) string {
+	if sess == nil {
+		return ""
+	}
+	raw, ok := sess.GetState(StateKeyThreadID)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(string(raw))
+}

--- a/agent/codex/codex_agent.go
+++ b/agent/codex/codex_agent.go
@@ -238,6 +238,9 @@ func (a *codexAgent) runWithSession(ctx context.Context, threadID, prompt string
 		if runErr == nil {
 			return stdout, stderr, nil
 		}
+		if !canCreateAfterResumeError(stdout, stderr) {
+			return stdout, stderr, fmt.Errorf("run resume %v: %w", threadID, runErr)
+		}
 		createStdout, createStderr, createErr := a.runCreate(ctx, prompt)
 		if createErr == nil {
 			return createStdout, createStderr, nil
@@ -247,6 +250,15 @@ func (a *codexAgent) runWithSession(ctx context.Context, threadID, prompt string
 		return createStdout, createStderr, overallErr
 	}
 	return a.runCreate(ctx, prompt)
+}
+
+// canCreateAfterResumeError reports whether a resume failure is known stale before Codex emitted JSONL output.
+func canCreateAfterResumeError(stdout, stderr []byte) bool {
+	if len(bytes.TrimSpace(stdout)) > 0 {
+		return false
+	}
+	msg := strings.ToLower(string(stderr))
+	return strings.Contains(msg, "thread/resume failed") && strings.Contains(msg, "no rollout found for thread id")
 }
 
 // runCreate starts a new Codex exec session.

--- a/agent/codex/codex_agent.go
+++ b/agent/codex/codex_agent.go
@@ -98,7 +98,12 @@ func (a *codexAgent) runInvocation(ctx context.Context, invocation *agent.Invoca
 	defer close(out)
 	resumeThreadID := sessionThreadID(invocation.Session)
 	stdout, stderr, runErr := a.runWithSession(ctx, resumeThreadID, invocation.Message.Content)
-	combined := bytes.TrimSpace(append(append([]byte(nil), stdout...), stderr...))
+	combinedRaw := append([]byte(nil), stdout...)
+	if len(stdout) > 0 && len(stderr) > 0 {
+		combinedRaw = append(combinedRaw, '\n')
+	}
+	combinedRaw = append(combinedRaw, stderr...)
+	combined := bytes.TrimSpace(combinedRaw)
 	observedThreadID := extractThreadID(stdout)
 	if hookErr := a.handleRawOutputHook(ctx, invocation, resumeThreadID, observedThreadID, stdout, stderr, runErr); hookErr != nil {
 		err := fmt.Errorf("raw output hook: %w", hookErr)
@@ -246,31 +251,32 @@ func (a *codexAgent) runWithSession(ctx context.Context, threadID, prompt string
 
 // runCreate starts a new Codex exec session.
 func (a *codexAgent) runCreate(ctx context.Context, prompt string) ([]byte, []byte, error) {
-	cmdArgs := make([]string, 0, len(a.globalArgs)+len(a.args)+2)
+	cmdArgs := make([]string, 0, len(a.globalArgs)+len(a.args)+1)
 	cmdArgs = append(cmdArgs, a.globalArgs...)
 	cmdArgs = append(cmdArgs, "exec")
 	cmdArgs = append(cmdArgs, a.args...)
-	cmdArgs = append(cmdArgs, prompt)
 	return a.commandRunner.Run(ctx, command{
-		bin:  a.bin,
-		args: cmdArgs,
-		env:  a.env,
-		dir:  a.workDir,
+		bin:   a.bin,
+		args:  cmdArgs,
+		stdin: []byte(prompt),
+		env:   a.env,
+		dir:   a.workDir,
 	})
 }
 
 // runResume resumes an existing Codex thread.
 func (a *codexAgent) runResume(ctx context.Context, threadID, prompt string) ([]byte, []byte, error) {
-	cmdArgs := make([]string, 0, len(a.globalArgs)+len(a.args)+4)
+	cmdArgs := make([]string, 0, len(a.globalArgs)+len(a.args)+3)
 	cmdArgs = append(cmdArgs, a.globalArgs...)
 	cmdArgs = append(cmdArgs, "exec", "resume")
 	cmdArgs = append(cmdArgs, a.args...)
-	cmdArgs = append(cmdArgs, threadID, prompt)
+	cmdArgs = append(cmdArgs, threadID)
 	return a.commandRunner.Run(ctx, command{
-		bin:  a.bin,
-		args: cmdArgs,
-		env:  a.env,
-		dir:  a.workDir,
+		bin:   a.bin,
+		args:  cmdArgs,
+		stdin: []byte(prompt),
+		env:   a.env,
+		dir:   a.workDir,
 	})
 }
 

--- a/agent/codex/codex_agent_test.go
+++ b/agent/codex/codex_agent_test.go
@@ -153,7 +153,7 @@ func TestCodexAgent_Run_ResumeErrorFallsBackToCreate(t *testing.T) {
 	runner := &scriptedRunner{
 		run: func(cmd command) ([]byte, []byte, error) {
 			if len(cmd.args) > 1 && cmd.args[1] == "resume" {
-				return nil, []byte("resume unavailable"), errors.New("exit 1")
+				return nil, []byte("Error: thread/resume: thread/resume failed: no rollout found for thread id stale-thread (code -32600)"), errors.New("exit 1")
 			}
 			return []byte(`{"type":"thread.started","thread_id":"thread-2"}
 {"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"fresh"}}`), nil, nil
@@ -175,17 +175,14 @@ func TestCodexAgent_Run_ResumeErrorFallsBackToCreate(t *testing.T) {
 	require.Equal(t, "Hi.", string(calls[1].stdin))
 }
 
-func TestCodexAgent_Run_ResumeAndCreateErrorsReturnRunError(t *testing.T) {
+func TestCodexAgent_Run_ResumeErrorDoesNotReplayPrompt(t *testing.T) {
 	ctx := context.Background()
 	sess := session.NewSession("app", "user", "sess-4")
 	sess.SetState(StateKeyThreadID, []byte("thread-1"))
 	inv := newTestInvocation("inv-4", sess, "Hi.")
 	runner := &scriptedRunner{
 		run: func(cmd command) ([]byte, []byte, error) {
-			if len(cmd.args) > 1 && cmd.args[1] == "resume" {
-				return nil, []byte("resume unavailable"), errors.New("resume exit 1")
-			}
-			return nil, []byte("create unavailable"), errors.New("create exit 1")
+			return []byte(`{"type":"item.started","item":{"id":"item_0","type":"command_execution","command":"pwd"}}`), []byte("resume failed"), errors.New("resume exit 1")
 		},
 	}
 	ag, err := New(withCommandRunner(runner))
@@ -196,13 +193,12 @@ func TestCodexAgent_Run_ResumeAndCreateErrorsReturnRunError(t *testing.T) {
 	require.Len(t, events, 1)
 	require.NotNil(t, events[0].Error)
 	require.Equal(t, model.ErrorTypeRunError, events[0].Error.Type)
-	require.Equal(t, "create unavailable", events[0].Error.Message)
+	require.Contains(t, events[0].Error.Message, "command_execution")
+	require.Contains(t, events[0].Error.Message, "resume failed")
 	calls := runner.Calls()
-	require.Len(t, calls, 2)
+	require.Len(t, calls, 1)
 	require.Equal(t, []string{"exec", "resume", "--json", "thread-1"}, calls[0].args)
 	require.Equal(t, "Hi.", string(calls[0].stdin))
-	require.Equal(t, []string{"exec", "--json"}, calls[1].args)
-	require.Equal(t, "Hi.", string(calls[1].stdin))
 }
 
 func TestCodexAgent_Run_RawOutputHook(t *testing.T) {

--- a/agent/codex/codex_agent_test.go
+++ b/agent/codex/codex_agent_test.go
@@ -116,7 +116,8 @@ func TestCodexAgent_Run_CreateParsesEventsAndStoresThread(t *testing.T) {
 	calls := runner.Calls()
 	require.Len(t, calls, 1)
 	require.Equal(t, "codex", calls[0].bin)
-	require.Equal(t, []string{"exec", "--json", "Run printf."}, calls[0].args)
+	require.Equal(t, []string{"exec", "--json"}, calls[0].args)
+	require.Equal(t, "Run printf.", string(calls[0].stdin))
 }
 
 func TestCodexAgent_Run_ResumeFromSessionState(t *testing.T) {
@@ -140,7 +141,8 @@ func TestCodexAgent_Run_ResumeFromSessionState(t *testing.T) {
 	require.Empty(t, events[0].StateDelta)
 	calls := runner.Calls()
 	require.Len(t, calls, 1)
-	require.Equal(t, []string{"exec", "resume", "--json", "thread-1", "Hi."}, calls[0].args)
+	require.Equal(t, []string{"exec", "resume", "--json", "thread-1"}, calls[0].args)
+	require.Equal(t, "Hi.", string(calls[0].stdin))
 }
 
 func TestCodexAgent_Run_ResumeErrorFallsBackToCreate(t *testing.T) {
@@ -167,8 +169,10 @@ func TestCodexAgent_Run_ResumeErrorFallsBackToCreate(t *testing.T) {
 	require.Equal(t, []byte("thread-2"), events[0].StateDelta[StateKeyThreadID])
 	calls := runner.Calls()
 	require.Len(t, calls, 2)
-	require.Equal(t, []string{"exec", "resume", "--json", "stale-thread", "Hi."}, calls[0].args)
-	require.Equal(t, []string{"exec", "--json", "Hi."}, calls[1].args)
+	require.Equal(t, []string{"exec", "resume", "--json", "stale-thread"}, calls[0].args)
+	require.Equal(t, "Hi.", string(calls[0].stdin))
+	require.Equal(t, []string{"exec", "--json"}, calls[1].args)
+	require.Equal(t, "Hi.", string(calls[1].stdin))
 }
 
 func TestCodexAgent_Run_ResumeAndCreateErrorsReturnRunError(t *testing.T) {
@@ -195,8 +199,10 @@ func TestCodexAgent_Run_ResumeAndCreateErrorsReturnRunError(t *testing.T) {
 	require.Equal(t, "create unavailable", events[0].Error.Message)
 	calls := runner.Calls()
 	require.Len(t, calls, 2)
-	require.Equal(t, []string{"exec", "resume", "--json", "thread-1", "Hi."}, calls[0].args)
-	require.Equal(t, []string{"exec", "--json", "Hi."}, calls[1].args)
+	require.Equal(t, []string{"exec", "resume", "--json", "thread-1"}, calls[0].args)
+	require.Equal(t, "Hi.", string(calls[0].stdin))
+	require.Equal(t, []string{"exec", "--json"}, calls[1].args)
+	require.Equal(t, "Hi.", string(calls[1].stdin))
 }
 
 func TestCodexAgent_Run_RawOutputHook(t *testing.T) {
@@ -235,6 +241,43 @@ func TestCodexAgent_Run_RawOutputHook(t *testing.T) {
 	require.Equal(t, transcript, string(got.Stdout))
 	require.Equal(t, "warn\n", string(got.Stderr))
 	require.NoError(t, got.Error)
+}
+
+func TestCodexAgent_Run_RawOutputHookReceivesCommandError(t *testing.T) {
+	ctx := context.Background()
+	sess := session.NewSession("app", "user", "sess-hook-err-1")
+	inv := newTestInvocation("inv-hook-err-1", sess, "--help")
+	runErr := errors.New("exit 1")
+	runner := &scriptedRunner{
+		run: func(cmd command) ([]byte, []byte, error) {
+			return []byte("stdout text"), []byte("stderr text"), runErr
+		},
+	}
+	var got RawOutputHookArgs
+	ag, err := New(
+		withCommandRunner(runner),
+		WithRawOutputHook(func(_ context.Context, args *RawOutputHookArgs) error {
+			got = *args
+			return nil
+		}),
+	)
+	require.NoError(t, err)
+	ch, err := ag.Run(ctx, inv)
+	require.NoError(t, err)
+	events := drainEvents(ch)
+	require.Len(t, events, 1)
+	require.ErrorIs(t, got.Error, runErr)
+	require.Equal(t, "--help", got.Prompt)
+	require.Equal(t, "stdout text", string(got.Stdout))
+	require.Equal(t, "stderr text", string(got.Stderr))
+	require.NotNil(t, events[0].Error)
+	require.Equal(t, model.ErrorTypeRunError, events[0].Error.Type)
+	require.Equal(t, "stdout text\nstderr text", events[0].Error.Message)
+	require.Equal(t, "stdout text\nstderr text", events[0].Choices[0].Message.Content)
+	calls := runner.Calls()
+	require.Len(t, calls, 1)
+	require.Equal(t, []string{"exec", "--json"}, calls[0].args)
+	require.Equal(t, "--help", string(calls[0].stdin))
 }
 
 func TestCodexAgent_Run_RawOutputHookError(t *testing.T) {
@@ -304,13 +347,28 @@ func TestCodexAgent_InfoAndRunnerArgs(t *testing.T) {
 	require.Equal(t, "codex-bin", calls[0].bin)
 	require.Equal(t, "/tmp", calls[0].dir)
 	require.Contains(t, calls[0].env, "CODEX_AGENT_TEST=1")
-	require.Equal(t, []string{"--ask-for-approval", "never", "exec", "--sandbox", "read-only", "--json", "Hi."}, calls[0].args)
+	require.Equal(t, []string{"--ask-for-approval", "never", "exec", "--sandbox", "read-only", "--json"}, calls[0].args)
+	require.Equal(t, "Hi.", string(calls[0].stdin))
 }
 
 func TestNew_ValidationErrors(t *testing.T) {
 	_, err := New(WithBin(""))
 	require.Error(t, err)
 	_, err = New(withCommandRunner(nil))
+	require.Error(t, err)
+}
+
+func TestCodexAgent_Run_ValidationErrors(t *testing.T) {
+	ctx := context.Background()
+	ag, err := New()
+	require.NoError(t, err)
+	_, err = ag.Run(ctx, nil)
+	require.Error(t, err)
+	_, err = ag.Run(ctx, &agent.Invocation{})
+	require.Error(t, err)
+	_, err = ag.Run(ctx, &agent.Invocation{Session: &session.Session{}})
+	require.Error(t, err)
+	_, err = ag.Run(ctx, newTestInvocation("inv-empty-prompt", session.NewSession("app", "user", "sess-empty"), ""))
 	require.Error(t, err)
 }
 
@@ -324,6 +382,14 @@ func TestExecCommandRunner_Run(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, "bar", string(stdout))
+	require.Empty(t, string(stderr))
+	stdout, stderr, err = runner.Run(context.Background(), command{
+		bin:   "sh",
+		args:  []string{"-c", "cat"},
+		stdin: []byte("--help"),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "--help", string(stdout))
 	require.Empty(t, string(stderr))
 	stdout, stderr, err = runner.Run(context.Background(), command{
 		bin:  "sh",
@@ -374,20 +440,25 @@ func TestParseTranscriptEvents_BuiltInToolMapping(t *testing.T) {
 {"type":"item.completed","item":{"id":"item_search","type":"web_search","query":"trpc agent","result":[{"title":"doc"}],"status":"completed"}}
 {"type":"item.started","item":{"id":"item_file","type":"file_change","changes":{"path":"main.go","kind":"update"}}}
 {"type":"item.completed","item":{"id":"item_file","type":"file_change","changes":{"path":"main.go","kind":"update"},"status":"completed"}}
+{"type":"item.started","item":{"id":"item_image_view","type":"image_view","path":"/tmp/input.png"}}
+{"type":"item.completed","item":{"id":"item_image_view","type":"image_view","result":{"width":64,"height":32},"status":"completed"}}
 {"type":"item.started","item":{"id":"item_image","type":"image_generation","prompt":"draw icon"}}
 {"type":"item.completed","item":{"id":"item_image","type":"image_generation","saved_path":"/tmp/icon.png","revised_prompt":"draw a clean icon","status":"completed"}}`
 	result, err := parseTranscriptEvents([]byte(transcript), "inv-parse-builtins-1", "codex")
 	require.NoError(t, err)
-	require.Len(t, result.Events, 6)
+	require.Len(t, result.Events, 8)
 	require.Equal(t, "web_search", result.Events[0].Choices[0].Message.ToolCalls[0].Function.Name)
 	require.JSONEq(t, `{"query":"trpc agent"}`, string(result.Events[0].Choices[0].Message.ToolCalls[0].Function.Arguments))
 	require.JSONEq(t, `[{"title":"doc"}]`, result.Events[1].Choices[0].Message.Content)
 	require.Equal(t, "file_change", result.Events[2].Choices[0].Message.ToolCalls[0].Function.Name)
 	require.JSONEq(t, `{"path":"main.go","kind":"update"}`, string(result.Events[2].Choices[0].Message.ToolCalls[0].Function.Arguments))
 	require.JSONEq(t, `{"path":"main.go","kind":"update"}`, result.Events[3].Choices[0].Message.Content)
-	require.Equal(t, "image_generation", result.Events[4].Choices[0].Message.ToolCalls[0].Function.Name)
-	require.JSONEq(t, `{"prompt":"draw icon"}`, string(result.Events[4].Choices[0].Message.ToolCalls[0].Function.Arguments))
-	require.JSONEq(t, `{"saved_path":"/tmp/icon.png","revised_prompt":"draw a clean icon","status":"completed"}`, result.Events[5].Choices[0].Message.Content)
+	require.Equal(t, "image_view", result.Events[4].Choices[0].Message.ToolCalls[0].Function.Name)
+	require.JSONEq(t, `{"path":"/tmp/input.png"}`, string(result.Events[4].Choices[0].Message.ToolCalls[0].Function.Arguments))
+	require.JSONEq(t, `{"width":64,"height":32}`, result.Events[5].Choices[0].Message.Content)
+	require.Equal(t, "image_generation", result.Events[6].Choices[0].Message.ToolCalls[0].Function.Name)
+	require.JSONEq(t, `{"prompt":"draw icon"}`, string(result.Events[6].Choices[0].Message.ToolCalls[0].Function.Arguments))
+	require.JSONEq(t, `{"saved_path":"/tmp/icon.png","revised_prompt":"draw a clean icon","status":"completed"}`, result.Events[7].Choices[0].Message.Content)
 }
 
 func TestParseTranscriptEvents_SkillToolMapping(t *testing.T) {
@@ -405,6 +476,28 @@ func TestParseTranscriptEvents_SkillToolMapping(t *testing.T) {
 	require.Equal(t, "debug", directArgs.Skill)
 	require.Equal(t, "", directArgs.Command)
 	require.Equal(t, "ok", result.Events[1].Choices[0].Message.Content)
+}
+
+func TestTranscriptHelpers_Fallbacks(t *testing.T) {
+	exitCode := 2
+	require.Equal(t, "mcp__server", mcpToolName("server", ""))
+	require.Equal(t, "tool", mcpToolName("", "tool"))
+	require.Equal(t, "mcp_tool_call", mcpToolName("", ""))
+	require.False(t, isToolItem("unknown"))
+	require.Equal(t, "custom", toolNameForItem(&codexItem{Type: " custom "}))
+	require.JSONEq(t, `{"raw":true}`, string(toolArgumentsFromRawOrFields(&codexItem{Arguments: json.RawMessage(`{"raw":true}`)}, "path")))
+	require.JSONEq(t, `{}`, string(toolArgumentsFromRawOrFields(&codexItem{}, "path")))
+	require.Equal(t, "aggregated", toolResultFromOutputFields(&codexItem{AggregatedOutput: "aggregated"}))
+	require.JSONEq(t, `{"status":"completed"}`, toolResultFromOutputFields(&codexItem{Status: "completed"}))
+	require.JSONEq(t, `{"exit_code":2,"status":"failed"}`, commandStatusResult(&codexItem{Status: "failed", ExitCode: &exitCode}))
+	require.Empty(t, commandStatusResult(&codexItem{}))
+	require.JSONEq(t, `{"skill":"deploy","command":""}`, string(skillArguments(&codexItem{Arguments: json.RawMessage(`"deploy"`)})))
+	require.JSONEq(t, `{"skill":"debug","command":"run"}`, string(skillArguments(&codexItem{Arguments: json.RawMessage(`{"skill":"debug","command":"run"}`)})))
+	require.JSONEq(t, `[1]`, string(skillArguments(&codexItem{Arguments: json.RawMessage(`[1]`)})))
+	require.JSONEq(t, `{}`, string(skillArguments(&codexItem{})))
+	require.JSONEq(t, `{}`, string(marshalArgs(func() {})))
+	require.Nil(t, (*codexUsage)(nil).toModelUsage())
+	require.Nil(t, (&codexUsage{}).toModelUsage())
 }
 
 func TestParseTranscriptEvents_EmptyAndInvalidOutput(t *testing.T) {

--- a/agent/codex/codex_agent_test.go
+++ b/agent/codex/codex_agent_test.go
@@ -1,0 +1,427 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package codex
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+// scriptedRunner is a deterministic commandRunner used for unit tests.
+type scriptedRunner struct {
+	mu    sync.Mutex
+	calls []command
+	run   func(command) ([]byte, []byte, error)
+}
+
+// Run implements commandRunner.
+func (r *scriptedRunner) Run(ctx context.Context, cmd command) ([]byte, []byte, error) {
+	r.mu.Lock()
+	r.calls = append(r.calls, cmd)
+	run := r.run
+	r.mu.Unlock()
+	if run == nil {
+		return nil, nil, nil
+	}
+	return run(cmd)
+}
+
+// Calls returns a snapshot of captured command invocations.
+func (r *scriptedRunner) Calls() []command {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]command, len(r.calls))
+	copy(out, r.calls)
+	return out
+}
+
+// drainEvents collects all events from ch until it is closed.
+func drainEvents(ch <-chan *event.Event) []*event.Event {
+	var events []*event.Event
+	for e := range ch {
+		events = append(events, e)
+	}
+	return events
+}
+
+// newTestInvocation creates a test invocation with a user prompt.
+func newTestInvocation(invocationID string, sess *session.Session, prompt string) *agent.Invocation {
+	return &agent.Invocation{
+		InvocationID: invocationID,
+		Session:      sess,
+		Message: model.Message{
+			Role:    model.RoleUser,
+			Content: prompt,
+		},
+	}
+}
+
+// codexTranscript returns a basic Codex JSONL transcript.
+func codexTranscript(threadID string, final string) string {
+	return `{"type":"thread.started","thread_id":"` + threadID + `"}
+{"type":"turn.started"}
+{"type":"item.started","item":{"id":"item_0","type":"command_execution","command":"/usr/bin/bash -lc 'printf hi'","aggregated_output":"","exit_code":null,"status":"in_progress"}}
+{"type":"item.completed","item":{"id":"item_0","type":"command_execution","command":"/usr/bin/bash -lc 'printf hi'","aggregated_output":"hi","exit_code":0,"status":"completed"}}
+{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"` + final + `"}}
+{"type":"turn.completed","usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3,"reasoning_output_tokens":1}}`
+}
+
+func TestCodexAgent_Run_CreateParsesEventsAndStoresThread(t *testing.T) {
+	ctx := context.Background()
+	sess := session.NewSession("app", "user", "sess-1")
+	inv := newTestInvocation("inv-1", sess, "Run printf.")
+	transcript := codexTranscript("thread-1", "done")
+	runner := &scriptedRunner{
+		run: func(cmd command) ([]byte, []byte, error) {
+			return []byte(transcript), nil, nil
+		},
+	}
+	ag, err := New(WithBin("codex"), withCommandRunner(runner))
+	require.NoError(t, err)
+	ch, err := ag.Run(ctx, inv)
+	require.NoError(t, err)
+	events := drainEvents(ch)
+	require.Len(t, events, 3)
+	require.True(t, events[0].IsToolCallResponse())
+	require.True(t, events[1].IsToolResultResponse())
+	require.True(t, events[2].IsFinalResponse())
+	require.Equal(t, "command_execution", events[0].Choices[0].Message.ToolCalls[0].Function.Name)
+	require.Equal(t, `{"command":"/usr/bin/bash -lc 'printf hi'"}`, string(events[0].Choices[0].Message.ToolCalls[0].Function.Arguments))
+	require.Equal(t, "hi", events[1].Choices[0].Message.Content)
+	require.Equal(t, "done", events[2].Choices[0].Message.Content)
+	require.Equal(t, 10, events[2].Usage.PromptTokens)
+	require.Equal(t, 3, events[2].Usage.CompletionTokens)
+	require.Equal(t, 13, events[2].Usage.TotalTokens)
+	require.Equal(t, 2, events[2].Usage.PromptTokensDetails.CachedTokens)
+	require.Equal(t, 1, events[2].Usage.CompletionTokensDetails.ReasoningTokens)
+	require.Equal(t, []byte("thread-1"), events[2].StateDelta[StateKeyThreadID])
+	calls := runner.Calls()
+	require.Len(t, calls, 1)
+	require.Equal(t, "codex", calls[0].bin)
+	require.Equal(t, []string{"exec", "--json", "Run printf."}, calls[0].args)
+}
+
+func TestCodexAgent_Run_ResumeFromSessionState(t *testing.T) {
+	ctx := context.Background()
+	sess := session.NewSession("app", "user", "sess-2")
+	sess.SetState(StateKeyThreadID, []byte("thread-1"))
+	inv := newTestInvocation("inv-2", sess, "Hi.")
+	runner := &scriptedRunner{
+		run: func(cmd command) ([]byte, []byte, error) {
+			return []byte(`{"type":"thread.started","thread_id":"thread-1"}
+{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"hello"}}`), nil, nil
+		},
+	}
+	ag, err := New(withCommandRunner(runner))
+	require.NoError(t, err)
+	ch, err := ag.Run(ctx, inv)
+	require.NoError(t, err)
+	events := drainEvents(ch)
+	require.Len(t, events, 1)
+	require.Equal(t, "hello", events[0].Choices[0].Message.Content)
+	require.Empty(t, events[0].StateDelta)
+	calls := runner.Calls()
+	require.Len(t, calls, 1)
+	require.Equal(t, []string{"exec", "resume", "--json", "thread-1", "Hi."}, calls[0].args)
+}
+
+func TestCodexAgent_Run_ResumeErrorFallsBackToCreate(t *testing.T) {
+	ctx := context.Background()
+	sess := session.NewSession("app", "user", "sess-3")
+	sess.SetState(StateKeyThreadID, []byte("stale-thread"))
+	inv := newTestInvocation("inv-3", sess, "Hi.")
+	runner := &scriptedRunner{
+		run: func(cmd command) ([]byte, []byte, error) {
+			if len(cmd.args) > 1 && cmd.args[1] == "resume" {
+				return nil, []byte("resume unavailable"), errors.New("exit 1")
+			}
+			return []byte(`{"type":"thread.started","thread_id":"thread-2"}
+{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"fresh"}}`), nil, nil
+		},
+	}
+	ag, err := New(withCommandRunner(runner))
+	require.NoError(t, err)
+	ch, err := ag.Run(ctx, inv)
+	require.NoError(t, err)
+	events := drainEvents(ch)
+	require.Len(t, events, 1)
+	require.Equal(t, "fresh", events[0].Choices[0].Message.Content)
+	require.Equal(t, []byte("thread-2"), events[0].StateDelta[StateKeyThreadID])
+	calls := runner.Calls()
+	require.Len(t, calls, 2)
+	require.Equal(t, []string{"exec", "resume", "--json", "stale-thread", "Hi."}, calls[0].args)
+	require.Equal(t, []string{"exec", "--json", "Hi."}, calls[1].args)
+}
+
+func TestCodexAgent_Run_ResumeAndCreateErrorsReturnRunError(t *testing.T) {
+	ctx := context.Background()
+	sess := session.NewSession("app", "user", "sess-4")
+	sess.SetState(StateKeyThreadID, []byte("thread-1"))
+	inv := newTestInvocation("inv-4", sess, "Hi.")
+	runner := &scriptedRunner{
+		run: func(cmd command) ([]byte, []byte, error) {
+			if len(cmd.args) > 1 && cmd.args[1] == "resume" {
+				return nil, []byte("resume unavailable"), errors.New("resume exit 1")
+			}
+			return nil, []byte("create unavailable"), errors.New("create exit 1")
+		},
+	}
+	ag, err := New(withCommandRunner(runner))
+	require.NoError(t, err)
+	ch, err := ag.Run(ctx, inv)
+	require.NoError(t, err)
+	events := drainEvents(ch)
+	require.Len(t, events, 1)
+	require.NotNil(t, events[0].Error)
+	require.Equal(t, model.ErrorTypeRunError, events[0].Error.Type)
+	require.Equal(t, "create unavailable", events[0].Error.Message)
+	calls := runner.Calls()
+	require.Len(t, calls, 2)
+	require.Equal(t, []string{"exec", "resume", "--json", "thread-1", "Hi."}, calls[0].args)
+	require.Equal(t, []string{"exec", "--json", "Hi."}, calls[1].args)
+}
+
+func TestCodexAgent_Run_RawOutputHook(t *testing.T) {
+	ctx := context.Background()
+	sess := session.NewSession("app", "user", "sess-hook-1")
+	inv := newTestInvocation("inv-hook-1", sess, "Hi.")
+	transcript := `{"type":"thread.started","thread_id":"thread-hook"}
+{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"hello"}}`
+	runner := &scriptedRunner{
+		run: func(cmd command) ([]byte, []byte, error) {
+			return []byte(transcript), []byte("warn\n"), nil
+		},
+	}
+	var got RawOutputHookArgs
+	var called bool
+	ag, err := New(
+		withCommandRunner(runner),
+		WithRawOutputHook(func(_ context.Context, args *RawOutputHookArgs) error {
+			called = true
+			if args != nil {
+				got = *args
+			}
+			return nil
+		}),
+	)
+	require.NoError(t, err)
+	ch, err := ag.Run(ctx, inv)
+	require.NoError(t, err)
+	_ = drainEvents(ch)
+	require.True(t, called)
+	require.Equal(t, "inv-hook-1", got.InvocationID)
+	require.Equal(t, "sess-hook-1", got.SessionID)
+	require.Empty(t, got.ResumeThreadID)
+	require.Equal(t, "thread-hook", got.ThreadID)
+	require.Equal(t, "Hi.", got.Prompt)
+	require.Equal(t, transcript, string(got.Stdout))
+	require.Equal(t, "warn\n", string(got.Stderr))
+	require.NoError(t, got.Error)
+}
+
+func TestCodexAgent_Run_RawOutputHookError(t *testing.T) {
+	ctx := context.Background()
+	sess := session.NewSession("app", "user", "sess-hook-2")
+	inv := newTestInvocation("inv-hook-2", sess, "Hi.")
+	hookErr := errors.New("hook failed")
+	runner := &scriptedRunner{
+		run: func(cmd command) ([]byte, []byte, error) {
+			return []byte(codexTranscript("thread-hook-2", "hello")), []byte("warn\n"), nil
+		},
+	}
+	ag, err := New(
+		withCommandRunner(runner),
+		WithRawOutputHook(func(_ context.Context, _ *RawOutputHookArgs) error {
+			return hookErr
+		}),
+	)
+	require.NoError(t, err)
+	ch, err := ag.Run(ctx, inv)
+	require.NoError(t, err)
+	events := drainEvents(ch)
+	require.Len(t, events, 1)
+	require.True(t, events[0].IsFinalResponse())
+	require.Equal(t, model.ObjectTypeError, events[0].Object)
+	require.NotNil(t, events[0].Error)
+	require.Equal(t, model.ErrorTypeFlowError, events[0].Error.Type)
+	require.Contains(t, events[0].Error.Message, "raw output hook")
+	require.Contains(t, events[0].Error.Message, "hook failed")
+	require.Contains(t, events[0].Choices[0].Message.Content, "thread-hook-2")
+	require.Contains(t, events[0].Choices[0].Message.Content, "warn")
+}
+
+func TestCodexAgent_InfoAndRunnerArgs(t *testing.T) {
+	ctx := context.Background()
+	sess := session.NewSession("app", "user", "sess-info-1")
+	inv := newTestInvocation("inv-info-1", sess, "Hi.")
+	runner := &scriptedRunner{
+		run: func(cmd command) ([]byte, []byte, error) {
+			return []byte(`{"type":"thread.started","thread_id":"thread-info"}
+{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"ok"}}`), nil, nil
+		},
+	}
+	ag, err := New(
+		WithName("my-codex"),
+		WithBin("codex-bin"),
+		WithGlobalArgs("--ask-for-approval", "never"),
+		WithExtraArgs("--sandbox", "read-only"),
+		WithEnv("CODEX_AGENT_TEST=1"),
+		WithWorkDir("/tmp"),
+		withCommandRunner(runner),
+	)
+	require.NoError(t, err)
+	info := ag.Info()
+	require.Equal(t, "my-codex", info.Name)
+	require.NotEmpty(t, info.Description)
+	require.Nil(t, ag.Tools())
+	require.Nil(t, ag.SubAgents())
+	require.Nil(t, ag.FindSubAgent("anything"))
+	ch, err := ag.Run(ctx, inv)
+	require.NoError(t, err)
+	events := drainEvents(ch)
+	require.NotEmpty(t, events)
+	require.True(t, events[len(events)-1].IsFinalResponse())
+	calls := runner.Calls()
+	require.Len(t, calls, 1)
+	require.Equal(t, "codex-bin", calls[0].bin)
+	require.Equal(t, "/tmp", calls[0].dir)
+	require.Contains(t, calls[0].env, "CODEX_AGENT_TEST=1")
+	require.Equal(t, []string{"--ask-for-approval", "never", "exec", "--sandbox", "read-only", "--json", "Hi."}, calls[0].args)
+}
+
+func TestNew_ValidationErrors(t *testing.T) {
+	_, err := New(WithBin(""))
+	require.Error(t, err)
+	_, err = New(withCommandRunner(nil))
+	require.Error(t, err)
+}
+
+func TestExecCommandRunner_Run(t *testing.T) {
+	tmp := t.TempDir()
+	runner := execCommandRunner{}
+	stdout, stderr, err := runner.Run(context.Background(), command{
+		bin:  "sh",
+		args: []string{"-c", "printf \"$FOO\""},
+		env:  []string{"FOO=bar"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "bar", string(stdout))
+	require.Empty(t, string(stderr))
+	stdout, stderr, err = runner.Run(context.Background(), command{
+		bin:  "sh",
+		args: []string{"-c", "pwd"},
+		dir:  tmp,
+	})
+	require.NoError(t, err)
+	got := strings.TrimSpace(string(stdout))
+	gotResolved, err := filepath.EvalSymlinks(got)
+	require.NoError(t, err)
+	wantResolved, err := filepath.EvalSymlinks(tmp)
+	require.NoError(t, err)
+	require.Equal(t, wantResolved, gotResolved)
+	require.Empty(t, string(stderr))
+}
+
+func TestParseTranscriptEvents_CompletedToolWithoutStarted(t *testing.T) {
+	transcript := `{"type":"thread.started","thread_id":"thread-parse"}
+{"type":"item.completed","item":{"id":"item_0","type":"command_execution","command":"pwd","aggregated_output":"/tmp\n","exit_code":0,"status":"completed"}}
+{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"done"}}`
+	result, err := parseTranscriptEvents([]byte(transcript), "inv-parse-1", "codex")
+	require.NoError(t, err)
+	require.Equal(t, "thread-parse", result.ThreadID)
+	require.Equal(t, "done", result.FinalMessage)
+	require.Len(t, result.Events, 2)
+	require.True(t, result.Events[0].IsToolCallResponse())
+	require.True(t, result.Events[1].IsToolResultResponse())
+	require.Equal(t, "pwd", commandArg(t, result.Events[0]))
+	require.Equal(t, "/tmp\n", result.Events[1].Choices[0].Message.Content)
+}
+
+func TestParseTranscriptEvents_MCPToolCallMapping(t *testing.T) {
+	transcript := `{"type":"item.started","item":{"id":"item_mcp","type":"mcp_tool_call","server":"calc","tool":"add","arguments":{"a":1,"b":2}}}
+{"type":"item.completed","item":{"id":"item_mcp","type":"mcp_tool_call","server":"calc","tool":"add","arguments":{"a":1,"b":2},"result":"3","status":"completed"}}
+{"type":"turn.completed","usage":{"input_tokens":4,"output_tokens":5}}`
+	result, err := parseTranscriptEvents([]byte(transcript), "inv-parse-2", "codex")
+	require.NoError(t, err)
+	require.Len(t, result.Events, 2)
+	require.Equal(t, "mcp__calc__add", result.Events[0].Choices[0].Message.ToolCalls[0].Function.Name)
+	require.Equal(t, "mcp__calc__add", result.Events[1].Choices[0].Message.ToolName)
+	require.JSONEq(t, `{"a":1,"b":2}`, string(result.Events[0].Choices[0].Message.ToolCalls[0].Function.Arguments))
+	require.Equal(t, "3", result.Events[1].Choices[0].Message.Content)
+	require.Equal(t, 9, result.Usage.TotalTokens)
+}
+
+func TestParseTranscriptEvents_BuiltInToolMapping(t *testing.T) {
+	transcript := `{"type":"item.started","item":{"id":"item_search","type":"web_search","query":"trpc agent"}}
+{"type":"item.completed","item":{"id":"item_search","type":"web_search","query":"trpc agent","result":[{"title":"doc"}],"status":"completed"}}
+{"type":"item.started","item":{"id":"item_file","type":"file_change","changes":{"path":"main.go","kind":"update"}}}
+{"type":"item.completed","item":{"id":"item_file","type":"file_change","changes":{"path":"main.go","kind":"update"},"status":"completed"}}
+{"type":"item.started","item":{"id":"item_image","type":"image_generation","prompt":"draw icon"}}
+{"type":"item.completed","item":{"id":"item_image","type":"image_generation","saved_path":"/tmp/icon.png","revised_prompt":"draw a clean icon","status":"completed"}}`
+	result, err := parseTranscriptEvents([]byte(transcript), "inv-parse-builtins-1", "codex")
+	require.NoError(t, err)
+	require.Len(t, result.Events, 6)
+	require.Equal(t, "web_search", result.Events[0].Choices[0].Message.ToolCalls[0].Function.Name)
+	require.JSONEq(t, `{"query":"trpc agent"}`, string(result.Events[0].Choices[0].Message.ToolCalls[0].Function.Arguments))
+	require.JSONEq(t, `[{"title":"doc"}]`, result.Events[1].Choices[0].Message.Content)
+	require.Equal(t, "file_change", result.Events[2].Choices[0].Message.ToolCalls[0].Function.Name)
+	require.JSONEq(t, `{"path":"main.go","kind":"update"}`, string(result.Events[2].Choices[0].Message.ToolCalls[0].Function.Arguments))
+	require.JSONEq(t, `{"path":"main.go","kind":"update"}`, result.Events[3].Choices[0].Message.Content)
+	require.Equal(t, "image_generation", result.Events[4].Choices[0].Message.ToolCalls[0].Function.Name)
+	require.JSONEq(t, `{"prompt":"draw icon"}`, string(result.Events[4].Choices[0].Message.ToolCalls[0].Function.Arguments))
+	require.JSONEq(t, `{"saved_path":"/tmp/icon.png","revised_prompt":"draw a clean icon","status":"completed"}`, result.Events[5].Choices[0].Message.Content)
+}
+
+func TestParseTranscriptEvents_SkillToolMapping(t *testing.T) {
+	transcript := `{"type":"item.started","item":{"id":"item_skill","type":"skill","skill":"debug"}}
+{"type":"item.completed","item":{"id":"item_skill","type":"skill","skill":"debug","result":"ok","status":"completed"}}`
+	result, err := parseTranscriptEvents([]byte(transcript), "inv-parse-skill-1", "codex")
+	require.NoError(t, err)
+	require.Len(t, result.Events, 2)
+	require.True(t, result.Events[0].IsToolCallResponse())
+	require.True(t, result.Events[1].IsToolResultResponse())
+	require.Equal(t, "skill_run", result.Events[0].Choices[0].Message.ToolCalls[0].Function.Name)
+	require.Equal(t, "skill_run", result.Events[1].Choices[0].Message.ToolName)
+	var directArgs skillRunArgs
+	require.NoError(t, json.Unmarshal(result.Events[0].Choices[0].Message.ToolCalls[0].Function.Arguments, &directArgs))
+	require.Equal(t, "debug", directArgs.Skill)
+	require.Equal(t, "", directArgs.Command)
+	require.Equal(t, "ok", result.Events[1].Choices[0].Message.Content)
+}
+
+func TestParseTranscriptEvents_EmptyAndInvalidOutput(t *testing.T) {
+	result, err := parseTranscriptEvents(nil, "inv-empty", "codex")
+	require.NoError(t, err)
+	require.Empty(t, result.FinalMessage)
+	require.Empty(t, result.Events)
+	_, err = parseTranscriptEvents([]byte(`not-json`), "inv-invalid", "codex")
+	require.Error(t, err)
+}
+
+func commandArg(t *testing.T, evt *event.Event) string {
+	t.Helper()
+	type args struct {
+		Command string `json:"command"`
+	}
+	var got args
+	require.NoError(t, json.Unmarshal(evt.Choices[0].Message.ToolCalls[0].Function.Arguments, &got))
+	return got.Command
+}

--- a/agent/codex/codex_agent_test.go
+++ b/agent/codex/codex_agent_test.go
@@ -153,7 +153,7 @@ func TestCodexAgent_Run_ResumeErrorFallsBackToCreate(t *testing.T) {
 	runner := &scriptedRunner{
 		run: func(cmd command) ([]byte, []byte, error) {
 			if len(cmd.args) > 1 && cmd.args[1] == "resume" {
-				return nil, []byte("Error: thread/resume: thread/resume failed: no rollout found for thread id stale-thread (code -32600)"), errors.New("exit 1")
+				return nil, []byte("resume unavailable"), errors.New("exit 1")
 			}
 			return []byte(`{"type":"thread.started","thread_id":"thread-2"}
 {"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"fresh"}}`), nil, nil
@@ -175,14 +175,17 @@ func TestCodexAgent_Run_ResumeErrorFallsBackToCreate(t *testing.T) {
 	require.Equal(t, "Hi.", string(calls[1].stdin))
 }
 
-func TestCodexAgent_Run_ResumeErrorDoesNotReplayPrompt(t *testing.T) {
+func TestCodexAgent_Run_ResumeAndCreateErrorsReturnRunError(t *testing.T) {
 	ctx := context.Background()
 	sess := session.NewSession("app", "user", "sess-4")
 	sess.SetState(StateKeyThreadID, []byte("thread-1"))
 	inv := newTestInvocation("inv-4", sess, "Hi.")
 	runner := &scriptedRunner{
 		run: func(cmd command) ([]byte, []byte, error) {
-			return []byte(`{"type":"item.started","item":{"id":"item_0","type":"command_execution","command":"pwd"}}`), []byte("resume failed"), errors.New("resume exit 1")
+			if len(cmd.args) > 1 && cmd.args[1] == "resume" {
+				return nil, []byte("resume unavailable"), errors.New("resume exit 1")
+			}
+			return nil, []byte("create unavailable"), errors.New("create exit 1")
 		},
 	}
 	ag, err := New(withCommandRunner(runner))
@@ -193,12 +196,13 @@ func TestCodexAgent_Run_ResumeErrorDoesNotReplayPrompt(t *testing.T) {
 	require.Len(t, events, 1)
 	require.NotNil(t, events[0].Error)
 	require.Equal(t, model.ErrorTypeRunError, events[0].Error.Type)
-	require.Contains(t, events[0].Error.Message, "command_execution")
-	require.Contains(t, events[0].Error.Message, "resume failed")
+	require.Equal(t, "create unavailable", events[0].Error.Message)
 	calls := runner.Calls()
-	require.Len(t, calls, 1)
+	require.Len(t, calls, 2)
 	require.Equal(t, []string{"exec", "resume", "--json", "thread-1"}, calls[0].args)
 	require.Equal(t, "Hi.", string(calls[0].stdin))
+	require.Equal(t, []string{"exec", "--json"}, calls[1].args)
+	require.Equal(t, "Hi.", string(calls[1].stdin))
 }
 
 func TestCodexAgent_Run_RawOutputHook(t *testing.T) {

--- a/agent/codex/command.go
+++ b/agent/codex/command.go
@@ -23,6 +23,8 @@ type command struct {
 	bin string
 	// Args are the CLI arguments excluding argv[0].
 	args []string
+	// Stdin is the data written to the process standard input.
+	stdin []byte
 	// Env is the process environment in KEY=VALUE form.
 	env []string
 	// Dir is the working directory for the command.
@@ -51,6 +53,9 @@ func (execCommandRunner) Run(ctx context.Context, cmd command) ([]byte, []byte, 
 	c.Dir = cmd.dir
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
+	if len(cmd.stdin) > 0 {
+		c.Stdin = bytes.NewReader(cmd.stdin)
+	}
 	c.Stdout = &stdout
 	c.Stderr = &stderr
 	runErr := c.Run()

--- a/agent/codex/command.go
+++ b/agent/codex/command.go
@@ -1,0 +1,58 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+// Package codex provides an agent that invokes a locally installed Codex CLI.
+package codex
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+)
+
+// command describes one CLI invocation.
+type command struct {
+	// Bin is the executable path.
+	bin string
+	// Args are the CLI arguments excluding argv[0].
+	args []string
+	// Env is the process environment in KEY=VALUE form.
+	env []string
+	// Dir is the working directory for the command.
+	dir string
+}
+
+// commandRunner executes external commands and captures stdout/stderr output.
+type commandRunner interface {
+	// Run executes cmd and returns captured stdout, stderr, and the process error.
+	Run(ctx context.Context, cmd command) ([]byte, []byte, error)
+}
+
+// execCommandRunner executes commands via os/exec.
+type execCommandRunner struct{}
+
+// Run executes cmd with exec.CommandContext and captures stdout/stderr.
+func (execCommandRunner) Run(ctx context.Context, cmd command) ([]byte, []byte, error) {
+	// nosemgrep: go.lang.security.audit.dangerous-exec-command
+	// This agent intentionally executes a locally installed Codex CLI binary.
+	c := exec.CommandContext(ctx, cmd.bin, cmd.args...) //nolint:gosec // The executable path is provided via agent options.
+	env := os.Environ()
+	if len(cmd.env) > 0 {
+		env = append(env, cmd.env...)
+	}
+	c.Env = env
+	c.Dir = cmd.dir
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	c.Stdout = &stdout
+	c.Stderr = &stderr
+	runErr := c.Run()
+	return stdout.Bytes(), stderr.Bytes(), runErr
+}

--- a/agent/codex/options.go
+++ b/agent/codex/options.go
@@ -80,7 +80,7 @@ func WithGlobalArgs(args ...string) Option {
 	}
 }
 
-// WithExtraArgs appends arguments after exec or exec resume before the session id and prompt.
+// WithExtraArgs appends arguments after exec or exec resume before the optional resume session id.
 // Use it only for flags accepted by both Codex exec forms.
 func WithExtraArgs(args ...string) Option {
 	return func(o *options) {

--- a/agent/codex/options.go
+++ b/agent/codex/options.go
@@ -1,0 +1,140 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package codex
+
+import (
+	"context"
+	"errors"
+	"slices"
+)
+
+// StateKeyThreadID is the session state key used to persist the Codex thread id.
+const StateKeyThreadID = "agent.codex.thread_id"
+
+// options stores CodexAgent configuration.
+type options struct {
+	name          string
+	description   string
+	bin           string
+	globalArgs    []string
+	args          []string
+	env           []string
+	workDir       string
+	commandRunner commandRunner
+	rawOutputHook RawOutputHook
+}
+
+// Option configures a CodexAgent.
+type Option func(*options)
+
+// RawOutputHookArgs provides raw CLI output for a single Codex invocation.
+type RawOutputHookArgs struct {
+	// InvocationID is the invocation identifier associated with this CLI execution.
+	InvocationID string
+	// SessionID is the framework session identifier from the invocation.
+	SessionID string
+	// ResumeThreadID is the Codex thread identifier used for resume, if any.
+	ResumeThreadID string
+	// ThreadID is the Codex thread identifier observed in this CLI output, if any.
+	ThreadID string
+	// Prompt is the user prompt string passed to the CLI.
+	Prompt string
+	// Stdout is the raw stdout bytes captured from the CLI process.
+	Stdout []byte
+	// Stderr is the raw stderr bytes captured from the CLI process.
+	Stderr []byte
+	// Error is the execution error returned by the command runner, if any.
+	Error error
+}
+
+// RawOutputHook is invoked after the CLI command completes and before transcript parsing.
+//
+// If the hook returns an error, the agent emits a final error event and stops processing the invocation.
+type RawOutputHook func(ctx context.Context, args *RawOutputHookArgs) error
+
+// WithName sets the agent name.
+func WithName(name string) Option {
+	return func(o *options) {
+		o.name = name
+	}
+}
+
+// WithBin sets the Codex CLI executable path.
+func WithBin(bin string) Option {
+	return func(o *options) {
+		o.bin = bin
+	}
+}
+
+// WithGlobalArgs appends Codex CLI root arguments before the exec subcommand.
+func WithGlobalArgs(args ...string) Option {
+	return func(o *options) {
+		o.globalArgs = append(o.globalArgs, args...)
+	}
+}
+
+// WithExtraArgs appends arguments after exec or exec resume before the session id and prompt.
+// Use it only for flags accepted by both Codex exec forms.
+func WithExtraArgs(args ...string) Option {
+	return func(o *options) {
+		o.args = append(o.args, args...)
+	}
+}
+
+// WithEnv appends additional environment variables for the CLI process.
+func WithEnv(env ...string) Option {
+	return func(o *options) {
+		o.env = append(o.env, env...)
+	}
+}
+
+// WithWorkDir sets the CLI working directory.
+func WithWorkDir(dir string) Option {
+	return func(o *options) {
+		o.workDir = dir
+	}
+}
+
+// WithRawOutputHook sets a callback to observe raw CLI stdout/stderr output.
+func WithRawOutputHook(hook RawOutputHook) Option {
+	return func(o *options) {
+		o.rawOutputHook = hook
+	}
+}
+
+// withCommandRunner overrides how the agent executes external commands, only for test.
+func withCommandRunner(runner commandRunner) Option {
+	return func(o *options) {
+		o.commandRunner = runner
+	}
+}
+
+// newOptions applies options and validates the resulting configuration.
+func newOptions(opt ...Option) (*options, error) {
+	opts := &options{
+		name:          "codex-cli",
+		description:   "Invokes a locally installed Codex CLI and emits tool events from its JSONL output.",
+		bin:           "codex",
+		commandRunner: execCommandRunner{},
+	}
+	for _, o := range opt {
+		o(opts)
+	}
+	if opts.bin == "" {
+		return nil, errors.New("codex bin is empty")
+	}
+	if opts.commandRunner == nil {
+		return nil, errors.New("command runner is nil")
+	}
+	if !slices.Contains(opts.args, "--json") {
+		opts.args = append(opts.args, "--json")
+	}
+	return opts, nil
+}

--- a/agent/codex/transcript.go
+++ b/agent/codex/transcript.go
@@ -1,0 +1,529 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package codex
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+const (
+	codexEventThreadStarted  = "thread.started"
+	codexEventItemStarted    = "item.started"
+	codexEventItemCompleted  = "item.completed"
+	codexEventTurnCompleted  = "turn.completed"
+	codexItemAgentMessage    = "agent_message"
+	codexItemCommand         = "command_execution"
+	codexItemMCPToolCall     = "mcp_tool_call"
+	codexItemWebSearch       = "web_search"
+	codexItemFileChange      = "file_change"
+	codexItemImageView       = "image_view"
+	codexItemImageGeneration = "image_generation"
+	codexItemSkill           = "skill"
+	frameworkToolSkillRun    = "skill_run"
+)
+
+// codexEvent represents one top-level JSONL event produced by Codex CLI.
+type codexEvent struct {
+	Type     string      `json:"type,omitempty"`
+	ThreadID string      `json:"thread_id,omitempty"`
+	Item     *codexItem  `json:"item,omitempty"`
+	Usage    *codexUsage `json:"usage,omitempty"`
+}
+
+// codexItem carries one Codex turn item.
+type codexItem struct {
+	ID               string          `json:"id,omitempty"`
+	Type             string          `json:"type,omitempty"`
+	Text             string          `json:"text,omitempty"`
+	Command          string          `json:"command,omitempty"`
+	AggregatedOutput string          `json:"aggregated_output,omitempty"`
+	ExitCode         *int            `json:"exit_code,omitempty"`
+	Status           string          `json:"status,omitempty"`
+	Server           string          `json:"server,omitempty"`
+	Tool             string          `json:"tool,omitempty"`
+	Skill            string          `json:"skill,omitempty"`
+	Path             string          `json:"path,omitempty"`
+	Prompt           string          `json:"prompt,omitempty"`
+	RevisedPrompt    string          `json:"revised_prompt,omitempty"`
+	SavedPath        string          `json:"saved_path,omitempty"`
+	Arguments        json.RawMessage `json:"arguments,omitempty"`
+	Result           json.RawMessage `json:"result,omitempty"`
+	Query            string          `json:"query,omitempty"`
+	Changes          json.RawMessage `json:"changes,omitempty"`
+}
+
+// codexSkillInput is the argument shape for Codex skill items.
+type codexSkillInput struct {
+	Skill   string `json:"skill,omitempty"`
+	Command string `json:"command,omitempty"`
+}
+
+// skillRunArgs is the argument shape for framework skill_run events derived from Codex skill items.
+type skillRunArgs struct {
+	Skill   string `json:"skill"`
+	Command string `json:"command"`
+}
+
+// codexUsage carries token usage from the turn.completed event.
+type codexUsage struct {
+	InputTokens           int `json:"input_tokens,omitempty"`
+	CachedInputTokens     int `json:"cached_input_tokens,omitempty"`
+	OutputTokens          int `json:"output_tokens,omitempty"`
+	ReasoningOutputTokens int `json:"reasoning_output_tokens,omitempty"`
+}
+
+// transcriptResult is the framework event projection of one Codex JSONL transcript.
+type transcriptResult struct {
+	Events       []*event.Event
+	FinalMessage string
+	ThreadID     string
+	Usage        *model.Usage
+}
+
+// parseTranscriptEvents parses Codex CLI JSONL events into framework events.
+func parseTranscriptEvents(stdout []byte, invocationID, author string) (*transcriptResult, error) {
+	records, err := parseTranscriptRecords(stdout)
+	if err != nil {
+		return nil, err
+	}
+	result := &transcriptResult{}
+	toolNames := make(map[string]string)
+	for _, rec := range records {
+		switch rec.Type {
+		case codexEventThreadStarted:
+			result.ThreadID = strings.TrimSpace(rec.ThreadID)
+		case codexEventTurnCompleted:
+			result.Usage = rec.Usage.toModelUsage()
+		case codexEventItemStarted:
+			evt := toolCallEventFromItem(invocationID, author, rec.Item, toolNames)
+			if evt != nil {
+				result.Events = append(result.Events, evt)
+			}
+		case codexEventItemCompleted:
+			events := completedEventsFromItem(invocationID, author, rec.Item, toolNames, result)
+			result.Events = append(result.Events, events...)
+		}
+	}
+	return result, nil
+}
+
+// parseTranscriptRecords decodes Codex JSONL output.
+func parseTranscriptRecords(stdout []byte) ([]codexEvent, error) {
+	trimmed := bytes.TrimSpace(stdout)
+	if len(trimmed) == 0 {
+		return nil, nil
+	}
+	dec := json.NewDecoder(bytes.NewReader(trimmed))
+	var records []codexEvent
+	for {
+		var rec codexEvent
+		if err := dec.Decode(&rec); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, err
+		}
+		records = append(records, rec)
+	}
+	return records, nil
+}
+
+// extractThreadID returns the first thread id found in Codex JSONL output.
+func extractThreadID(stdout []byte) string {
+	records, err := parseTranscriptRecords(stdout)
+	if err != nil {
+		return ""
+	}
+	for _, rec := range records {
+		if rec.Type == codexEventThreadStarted && strings.TrimSpace(rec.ThreadID) != "" {
+			return strings.TrimSpace(rec.ThreadID)
+		}
+	}
+	return ""
+}
+
+// toolCallEventFromItem creates a tool-call event for an item.started record.
+func toolCallEventFromItem(invocationID, author string, item *codexItem, toolNames map[string]string) *event.Event {
+	if item == nil || !isToolItem(item.Type) || strings.TrimSpace(item.ID) == "" {
+		return nil
+	}
+	toolID := strings.TrimSpace(item.ID)
+	toolName := toolNameForItem(item)
+	if toolName == "" {
+		return nil
+	}
+	toolNames[toolID] = toolName
+	return newToolCallEvent(invocationID, author, toolID, toolName, toolArguments(item))
+}
+
+// completedEventsFromItem creates framework events for an item.completed record.
+func completedEventsFromItem(invocationID, author string, item *codexItem, toolNames map[string]string, result *transcriptResult) []*event.Event {
+	if item == nil {
+		return nil
+	}
+	if item.Type == codexItemAgentMessage {
+		result.FinalMessage = item.Text
+		return nil
+	}
+	if !isToolItem(item.Type) || strings.TrimSpace(item.ID) == "" {
+		return nil
+	}
+	toolID := strings.TrimSpace(item.ID)
+	toolName := toolNames[toolID]
+	var events []*event.Event
+	if toolName == "" {
+		toolName = toolNameForItem(item)
+		if toolName == "" {
+			return nil
+		}
+		toolNames[toolID] = toolName
+		events = append(events, newToolCallEvent(invocationID, author, toolID, toolName, toolArguments(item)))
+	}
+	events = append(events, newToolResultEvent(invocationID, author, toolID, toolName, toolResult(item)))
+	return events
+}
+
+// isToolItem reports whether a Codex item should be mapped as a framework tool event.
+func isToolItem(itemType string) bool {
+	switch itemType {
+	case codexItemCommand, codexItemMCPToolCall, codexItemWebSearch, codexItemFileChange,
+		codexItemImageView, codexItemImageGeneration, codexItemSkill:
+		return true
+	default:
+		return false
+	}
+}
+
+// toolNameForItem returns the framework tool name for a Codex item.
+func toolNameForItem(item *codexItem) string {
+	if item == nil {
+		return ""
+	}
+	switch item.Type {
+	case codexItemCommand:
+		return codexItemCommand
+	case codexItemMCPToolCall:
+		return mcpToolName(item.Server, item.Tool)
+	case codexItemWebSearch:
+		return codexItemWebSearch
+	case codexItemFileChange:
+		return codexItemFileChange
+	case codexItemImageView:
+		return codexItemImageView
+	case codexItemImageGeneration:
+		return codexItemImageGeneration
+	case codexItemSkill:
+		return frameworkToolSkillRun
+	default:
+		return strings.TrimSpace(item.Type)
+	}
+}
+
+// mcpToolName returns a Claude Code-compatible MCP tool name when server and tool are present.
+func mcpToolName(server string, toolName string) string {
+	server = strings.TrimSpace(server)
+	toolName = strings.TrimSpace(toolName)
+	if server != "" && toolName != "" {
+		return "mcp__" + server + "__" + toolName
+	}
+	if toolName != "" {
+		return toolName
+	}
+	if server != "" {
+		return "mcp__" + server
+	}
+	return codexItemMCPToolCall
+}
+
+// toolArguments returns the JSON argument payload for a tool call.
+func toolArguments(item *codexItem) []byte {
+	switch item.Type {
+	case codexItemCommand:
+		return marshalArgs(map[string]string{"command": item.Command})
+	case codexItemMCPToolCall:
+		if args := normalizeJSON(item.Arguments); len(args) > 0 {
+			return args
+		}
+		return marshalArgs(map[string]string{"server": item.Server, "tool": item.Tool})
+	case codexItemWebSearch:
+		return marshalArgs(map[string]string{"query": item.Query})
+	case codexItemFileChange:
+		if args := normalizeJSON(item.Changes); len(args) > 0 {
+			return args
+		}
+	case codexItemImageView:
+		return toolArgumentsFromRawOrFields(item, "path")
+	case codexItemImageGeneration:
+		return toolArgumentsFromRawOrFields(item, "prompt")
+	case codexItemSkill:
+		return skillArguments(item)
+	}
+	return []byte("{}")
+}
+
+// toolArgumentsFromRawOrFields returns explicit raw arguments or selected item fields.
+func toolArgumentsFromRawOrFields(item *codexItem, fields ...string) []byte {
+	if args := normalizeJSON(item.Arguments); len(args) > 0 {
+		return args
+	}
+	out := make(map[string]string)
+	for _, field := range fields {
+		switch field {
+		case "path":
+			addStringArg(out, field, item.Path)
+		case "prompt":
+			addStringArg(out, field, item.Prompt)
+		}
+	}
+	if len(out) == 0 {
+		return []byte("{}")
+	}
+	return marshalArgs(out)
+}
+
+// addStringArg adds a non-empty string argument to the output map.
+func addStringArg(out map[string]string, key string, value string) {
+	if trimmed := strings.TrimSpace(value); trimmed != "" {
+		out[key] = trimmed
+	}
+}
+
+// skillArguments normalizes Codex skill item arguments to the framework skill_run shape.
+func skillArguments(item *codexItem) []byte {
+	in := codexSkillInput{
+		Skill:   item.Skill,
+		Command: item.Command,
+	}
+	raw := normalizeJSON(item.Arguments)
+	if len(raw) > 0 {
+		var skillText string
+		if err := json.Unmarshal(raw, &skillText); err == nil {
+			in.Skill = skillText
+		} else {
+			var parsed codexSkillInput
+			if err := json.Unmarshal(raw, &parsed); err != nil {
+				return raw
+			}
+			if strings.TrimSpace(parsed.Skill) != "" {
+				in.Skill = parsed.Skill
+			}
+			if strings.TrimSpace(parsed.Command) != "" {
+				in.Command = parsed.Command
+			}
+		}
+	}
+	skillName := strings.TrimSpace(in.Skill)
+	if skillName == "" {
+		if len(raw) > 0 {
+			return raw
+		}
+		return []byte("{}")
+	}
+	return marshalArgs(skillRunArgs{
+		Skill:   skillName,
+		Command: strings.TrimSpace(in.Command),
+	})
+}
+
+// toolResult returns displayable text for a completed tool item.
+func toolResult(item *codexItem) string {
+	switch item.Type {
+	case codexItemCommand:
+		if item.AggregatedOutput != "" {
+			return item.AggregatedOutput
+		}
+		return commandStatusResult(item)
+	case codexItemMCPToolCall:
+		if res := decodeRawJSON(item.Result); res != "" {
+			return res
+		}
+		return commandStatusResult(item)
+	case codexItemWebSearch:
+		if res := decodeRawJSON(item.Result); res != "" {
+			return res
+		}
+	case codexItemFileChange:
+		if res := decodeRawJSON(item.Changes); res != "" {
+			return res
+		}
+	case codexItemImageView:
+		return toolResultFromOutputFields(item)
+	case codexItemImageGeneration:
+		if res := decodeRawJSON(item.Result); res != "" {
+			return res
+		}
+		if item.AggregatedOutput != "" {
+			return item.AggregatedOutput
+		}
+		return imageGenerationResult(item)
+	case codexItemSkill:
+		if res := decodeRawJSON(item.Result); res != "" {
+			return res
+		}
+		if item.AggregatedOutput != "" {
+			return item.AggregatedOutput
+		}
+		return commandStatusResult(item)
+	}
+	return ""
+}
+
+// toolResultFromOutputFields returns explicit result fields without inferring tool semantics.
+func toolResultFromOutputFields(item *codexItem) string {
+	if res := decodeRawJSON(item.Result); res != "" {
+		return res
+	}
+	if item.AggregatedOutput != "" {
+		return item.AggregatedOutput
+	}
+	return commandStatusResult(item)
+}
+
+// imageGenerationResult returns useful output fields when Codex omits a result payload.
+func imageGenerationResult(item *codexItem) string {
+	out := map[string]string{}
+	addStringArg(out, "saved_path", item.SavedPath)
+	addStringArg(out, "revised_prompt", item.RevisedPrompt)
+	addStringArg(out, "status", item.Status)
+	if len(out) == 0 {
+		return ""
+	}
+	raw, err := json.Marshal(out)
+	if err != nil {
+		return ""
+	}
+	return string(raw)
+}
+
+// commandStatusResult returns a small JSON status payload when no textual output exists.
+func commandStatusResult(item *codexItem) string {
+	out := map[string]any{}
+	if item.Status != "" {
+		out["status"] = item.Status
+	}
+	if item.ExitCode != nil {
+		out["exit_code"] = *item.ExitCode
+	}
+	if len(out) == 0 {
+		return ""
+	}
+	raw, err := json.Marshal(out)
+	if err != nil {
+		return ""
+	}
+	return string(raw)
+}
+
+// marshalArgs marshals argument objects and falls back to an empty object.
+func marshalArgs(v any) []byte {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return []byte("{}")
+	}
+	return raw
+}
+
+// normalizeJSON returns a non-empty JSON payload or nil.
+func normalizeJSON(raw json.RawMessage) []byte {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return nil
+	}
+	return trimmed
+}
+
+// decodeRawJSON converts raw JSON into displayable text.
+func decodeRawJSON(raw json.RawMessage) string {
+	trimmed := normalizeJSON(raw)
+	if len(trimmed) == 0 {
+		return ""
+	}
+	if trimmed[0] == '"' {
+		var text string
+		if err := json.Unmarshal(trimmed, &text); err == nil {
+			return text
+		}
+	}
+	return string(trimmed)
+}
+
+// newToolCallEvent creates a tool-call event for one Codex item.
+func newToolCallEvent(invocationID, author, toolID, toolName string, args []byte) *event.Event {
+	toolCall := model.ToolCall{
+		Type: "function",
+		ID:   toolID,
+		Function: model.FunctionDefinitionParam{
+			Name:      toolName,
+			Arguments: args,
+		},
+	}
+	rsp := &model.Response{
+		Object: model.ObjectTypeChatCompletion,
+		Done:   false,
+		Choices: []model.Choice{
+			{
+				Index: 0,
+				Message: model.Message{
+					Role:      model.RoleAssistant,
+					ToolCalls: []model.ToolCall{toolCall},
+				},
+			},
+		},
+	}
+	return event.NewResponseEvent(invocationID, author, rsp)
+}
+
+// newToolResultEvent creates a tool-result event for one Codex item.
+func newToolResultEvent(invocationID, author, toolID, toolName, result string) *event.Event {
+	rsp := &model.Response{
+		Object: model.ObjectTypeToolResponse,
+		Done:   false,
+		Choices: []model.Choice{
+			{
+				Index: 0,
+				Message: model.Message{
+					Role:     model.RoleTool,
+					ToolID:   toolID,
+					ToolName: toolName,
+					Content:  result,
+				},
+			},
+		},
+	}
+	return event.NewResponseEvent(invocationID, author, rsp)
+}
+
+// toModelUsage converts Codex usage into framework usage.
+func (u *codexUsage) toModelUsage() *model.Usage {
+	if u == nil {
+		return nil
+	}
+	if u.InputTokens == 0 && u.CachedInputTokens == 0 && u.OutputTokens == 0 && u.ReasoningOutputTokens == 0 {
+		return nil
+	}
+	return &model.Usage{
+		PromptTokens:     u.InputTokens,
+		CompletionTokens: u.OutputTokens,
+		TotalTokens:      u.InputTokens + u.OutputTokens,
+		PromptTokensDetails: model.PromptTokensDetails{
+			CachedTokens: u.CachedInputTokens,
+		},
+		CompletionTokensDetails: model.CompletionTokensDetails{
+			ReasoningTokens: u.ReasoningOutputTokens,
+		},
+	}
+}

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -17,6 +17,7 @@ nav:
           - Custom Agent: custom-agent.md
           - Dify Agent: dify.md
           - Claude Code Agent: claudecode.md
+          - Codex Agent: codex.md
       - Runner: runner.md
       - Code Executor: codeexecutor.md
       - Error Handling: error-handling.md
@@ -101,6 +102,7 @@ plugins:
                     - 自定义 Agent: custom-agent.md
                     - Dify Agent: dify.md
                     - Claude Code Agent: claudecode.md
+                    - Codex Agent: codex.md
                 - Runner: runner.md
                 - Code Executor: codeexecutor.md
                 - 错误处理: error-handling.md

--- a/docs/mkdocs/en/codex.md
+++ b/docs/mkdocs/en/codex.md
@@ -49,6 +49,8 @@ if err != nil {
 
 The agent forces `--json` on `codex exec` and parses stdout as JSONL. Do not append `--json` manually unless you need to control argument ordering.
 
+Prompt text is written to stdin so user input such as `--help` is not parsed as a Codex CLI flag.
+
 `WithExtraArgs` appends arguments after `exec` or `exec resume`. Use it only for flags accepted by both `codex exec` and `codex exec resume`, such as `--model`.
 
 `WithGlobalArgs` appends arguments before the `exec` subcommand. Use it for root-level Codex flags such as `--ask-for-approval`, `--sandbox`, or `--cd`.
@@ -69,7 +71,7 @@ Use the existing CLI configuration mechanisms to select skill sources:
 - `WithEnv("CODEX_HOME=/path/to/codex-home")` selects an isolated Codex home.
 - `WithGlobalArgs("-p", "profile-name")` selects a Codex profile.
 - `WithGlobalArgs("-c", "key=value")` passes a Codex config override.
-- `WithExtraArgs("--cd", "/path/to/workspace")` or `WithWorkDir("/path/to/workspace")` selects the workspace context.
+- `WithGlobalArgs("--cd", "/path/to/workspace")` or `WithWorkDir("/path/to/workspace")` selects the workspace context.
 
 If multiple external skill repositories are configured for that Codex CLI environment, this agent does not filter them. It also does not synthesize skill events from configuration. Current Codex CLI behavior tends to handle skills through shell commands instead of a dedicated skill tool, so skill usage is usually represented as `command_execution` events rather than `skill_run`.
 
@@ -94,8 +96,8 @@ Current Codex CLI skill usage is often injected as prompt context or handled thr
 
 Codex creates its own thread id. The agent persists that id in session state under `codex.StateKeyThreadID` and uses it on later turns:
 
-1. First turn: `codex exec --json <prompt>`
-2. Later turns: `codex exec resume --json <thread-id> <prompt>`
+1. First turn: write the prompt to stdin of `codex exec --json`
+2. Later turns: write the prompt to stdin of `codex exec resume --json <thread-id>`
 
 If resume fails, the agent starts a fresh `codex exec` run and updates the stored thread id when the new run reports one. If both resume and create fail, the invocation returns a run error.
 
@@ -123,7 +125,7 @@ ag, err := codex.New(
 | `WithName(name)` | Sets the agent name. This value is used as the event author. |
 | `WithBin(bin)` | Sets the CLI executable path. Default is `codex`. |
 | `WithGlobalArgs(args...)` | Appends root CLI flags before the `exec` subcommand. |
-| `WithExtraArgs(args...)` | Appends `codex exec` flags before the session id and prompt. |
+| `WithExtraArgs(args...)` | Appends `codex exec` flags before the optional resume session id. |
 | `WithEnv(env...)` | Adds CLI environment variables. Use `KEY=VALUE`. |
 | `WithWorkDir(dir)` | Sets the CLI process working directory. |
 | `WithRawOutputHook(hook)` | Observes raw stdout and stderr. The hook runs after the CLI finishes and before parsing. |

--- a/docs/mkdocs/en/codex.md
+++ b/docs/mkdocs/en/codex.md
@@ -99,7 +99,7 @@ Codex creates its own thread id. The agent persists that id in session state und
 1. First turn: write the prompt to stdin of `codex exec --json`
 2. Later turns: write the prompt to stdin of `codex exec resume --json <thread-id>`
 
-If resume fails, the agent starts a fresh `codex exec` run and updates the stored thread id when the new run reports one. If both resume and create fail, the invocation returns a run error.
+If resume reports a stale or missing thread before emitting JSONL output, the agent starts a fresh `codex exec` run and updates the stored thread id when the new run reports one. Other resume failures return a run error instead of replaying the same prompt.
 
 To keep context, use the same app name, user ID, and session ID in `runner`.
 

--- a/docs/mkdocs/en/codex.md
+++ b/docs/mkdocs/en/codex.md
@@ -1,0 +1,129 @@
+# Codex Agent Guide
+
+## Overview
+
+tRPC-Agent-Go provides a `Codex` `Agent` implementation. It executes a local Codex CLI with `codex exec --json`, parses the JSONL event stream, and maps Codex activity into framework events.
+
+The primary use cases include:
+
+- Run Codex in `runner`
+- Persist raw CLI stdout and stderr
+- Align Codex command and MCP tool traces in evaluation
+
+## Quick start
+
+### Prerequisites
+
+1. Install and authenticate Codex CLI locally
+2. Make sure the CLI executable is available in `PATH`, or pass an absolute path via `WithBin`
+
+### Basic usage
+
+See the full example at [examples/codex](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/codex). The example includes a temporary project-local MCP server and a project-local skill.
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/agent/codex"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+)
+
+ag, err := codex.New(
+  codex.WithBin("codex"),
+  codex.WithGlobalArgs("--sandbox", "workspace-write"),
+)
+if err != nil {
+  log.Fatal(err)
+}
+
+r := runner.NewRunner("codex-cli-example", ag)
+defer r.Close()
+
+ch, err := r.Run(context.Background(), "user-1", "session-1", model.NewUserMessage("Run pwd and summarize the workspace."))
+if err != nil {
+  log.Fatal(err)
+}
+```
+
+## Output format and parsing
+
+The agent forces `--json` on `codex exec` and parses stdout as JSONL. Do not append `--json` manually unless you need to control argument ordering.
+
+`WithExtraArgs` appends arguments after `exec` or `exec resume`. Use it only for flags accepted by both `codex exec` and `codex exec resume`, such as `--model`.
+
+`WithGlobalArgs` appends arguments before the `exec` subcommand. Use it for root-level Codex flags such as `--ask-for-approval`, `--sandbox`, or `--cd`.
+
+```go
+ag, err := codex.New(
+  codex.WithGlobalArgs("--ask-for-approval", "never"),
+  codex.WithGlobalArgs("--sandbox", "read-only"),
+)
+```
+
+## Skills and external repositories
+
+The agent does not install, merge, or rewrite Codex skill repositories. It runs the local Codex CLI with the configured environment, profile, and working directory. Any skills, plugins, or plugin marketplaces that the same `codex exec` command can load from local Codex configuration are available to this agent as well.
+
+Use the existing CLI configuration mechanisms to select skill sources:
+
+- `WithEnv("CODEX_HOME=/path/to/codex-home")` selects an isolated Codex home.
+- `WithGlobalArgs("-p", "profile-name")` selects a Codex profile.
+- `WithGlobalArgs("-c", "key=value")` passes a Codex config override.
+- `WithExtraArgs("--cd", "/path/to/workspace")` or `WithWorkDir("/path/to/workspace")` selects the workspace context.
+
+If multiple external skill repositories are configured for that Codex CLI environment, this agent does not filter them. It also does not synthesize skill events from configuration. Current Codex CLI behavior tends to handle skills through shell commands instead of a dedicated skill tool, so skill usage is usually represented as `command_execution` events rather than `skill_run`.
+
+## Event mapping
+
+The agent emits tool events and one final response event. It does not emit intermediate reasoning events.
+
+| Codex JSONL output | Framework event |
+| --- | --- |
+| `type == "thread.started"` | Persisted into session state key `codex.StateKeyThreadID` |
+| `item.type == "command_execution"` | tool-call and tool-result response events |
+| `item.type == "mcp_tool_call"` | tool-call and tool-result response events |
+| Built-in tool items such as `web_search`, `file_change`, `image_view`, and `image_generation` | tool-call and tool-result response events |
+| `item.type == "agent_message"` | final response event content |
+| `type == "turn.completed"` | final response usage |
+
+MCP tool calls are normalized to Claude Code-compatible names when possible: `mcp__<server>__<tool>`.
+Built-in tool calls keep their Codex tool names.
+Current Codex CLI skill usage is often injected as prompt context or handled through shell `command_execution` items. This agent preserves those actual item types and does not emit a synthetic `skill_run` event.
+
+## Multi-turn sessions
+
+Codex creates its own thread id. The agent persists that id in session state under `codex.StateKeyThreadID` and uses it on later turns:
+
+1. First turn: `codex exec --json <prompt>`
+2. Later turns: `codex exec resume --json <thread-id> <prompt>`
+
+If resume fails, the agent starts a fresh `codex exec` run and updates the stored thread id when the new run reports one. If both resume and create fail, the invocation returns a run error.
+
+To keep context, use the same app name, user ID, and session ID in `runner`.
+
+## Persist raw CLI output
+
+Use `WithRawOutputHook` to observe stdout/stderr for each invocation. It is recommended to write them into evaluation and observability artifacts:
+
+```go
+ag, err := codex.New(
+  codex.WithRawOutputHook(func(ctx context.Context, args *codex.RawOutputHookArgs) error {
+    // Write args.Stdout / args.Stderr to your log storage.
+    return nil
+  }),
+)
+```
+
+`RawOutputHookArgs` carries both the framework `SessionID` and Codex `ThreadID`.
+
+## Options reference
+
+| Option | Description |
+| --- | --- |
+| `WithName(name)` | Sets the agent name. This value is used as the event author. |
+| `WithBin(bin)` | Sets the CLI executable path. Default is `codex`. |
+| `WithGlobalArgs(args...)` | Appends root CLI flags before the `exec` subcommand. |
+| `WithExtraArgs(args...)` | Appends `codex exec` flags before the session id and prompt. |
+| `WithEnv(env...)` | Adds CLI environment variables. Use `KEY=VALUE`. |
+| `WithWorkDir(dir)` | Sets the CLI process working directory. |
+| `WithRawOutputHook(hook)` | Observes raw stdout and stderr. The hook runs after the CLI finishes and before parsing. |

--- a/docs/mkdocs/en/codex.md
+++ b/docs/mkdocs/en/codex.md
@@ -99,7 +99,7 @@ Codex creates its own thread id. The agent persists that id in session state und
 1. First turn: write the prompt to stdin of `codex exec --json`
 2. Later turns: write the prompt to stdin of `codex exec resume --json <thread-id>`
 
-If resume reports a stale or missing thread before emitting JSONL output, the agent starts a fresh `codex exec` run and updates the stored thread id when the new run reports one. Other resume failures return a run error instead of replaying the same prompt.
+If resume fails, the agent starts a fresh `codex exec` run and updates the stored thread id when the new run reports one. If both resume and create fail, the invocation returns a run error.
 
 To keep context, use the same app name, user ID, and session ID in `runner`.
 

--- a/docs/mkdocs/zh/codex.md
+++ b/docs/mkdocs/zh/codex.md
@@ -99,7 +99,7 @@ Codex 会自行创建 thread id。该 Agent 会把这个 id 存入 session state
 1. 首轮：把 prompt 写入 `codex exec --json` 的 stdin
 2. 后续轮次：把 prompt 写入 `codex exec resume --json <thread-id>` 的 stdin
 
-如果 resume 失败，该 Agent 会重新发起一次新的 `codex exec`；如果新执行返回了 thread id，则更新已保存的 thread id。如果 resume 与新建执行都失败，本次调用会返回 run error。
+如果 resume 在输出 JSONL 前明确报告 thread 已失效或不存在，该 Agent 会重新发起一次新的 `codex exec`；如果新执行返回了 thread id，则更新已保存的 thread id。其他 resume 失败会直接返回 run error，避免重放同一个 prompt。
 
 如需保持上下文，请在 `runner` 中持续使用相同的 app name、user ID、session ID。
 

--- a/docs/mkdocs/zh/codex.md
+++ b/docs/mkdocs/zh/codex.md
@@ -99,7 +99,7 @@ Codex 会自行创建 thread id。该 Agent 会把这个 id 存入 session state
 1. 首轮：把 prompt 写入 `codex exec --json` 的 stdin
 2. 后续轮次：把 prompt 写入 `codex exec resume --json <thread-id>` 的 stdin
 
-如果 resume 在输出 JSONL 前明确报告 thread 已失效或不存在，该 Agent 会重新发起一次新的 `codex exec`；如果新执行返回了 thread id，则更新已保存的 thread id。其他 resume 失败会直接返回 run error，避免重放同一个 prompt。
+如果 resume 失败，该 Agent 会重新发起一次新的 `codex exec`；如果新执行返回了 thread id，则更新已保存的 thread id。如果 resume 与新建执行都失败，本次调用会返回 run error。
 
 如需保持上下文，请在 `runner` 中持续使用相同的 app name、user ID、session ID。
 

--- a/docs/mkdocs/zh/codex.md
+++ b/docs/mkdocs/zh/codex.md
@@ -49,6 +49,8 @@ if err != nil {
 
 该 Agent 会强制为 `codex exec` 添加 `--json`，并按 JSONL 解析 stdout。除非需要控制参数顺序，否则不要手动追加 `--json`。
 
+Prompt 文本会通过 stdin 写入 Codex CLI，因此 `--help` 这类用户输入不会被解析成 Codex CLI flag。
+
 `WithExtraArgs` 会把参数追加到 `exec` 或 `exec resume` 之后，只适合传入同时被 `codex exec` 与 `codex exec resume` 接受的参数，例如 `--model`。
 
 `WithGlobalArgs` 会把参数追加到 `exec` 子命令之前，适合传入 `--ask-for-approval`、`--sandbox`、`--cd` 等 Codex 根级参数。
@@ -69,7 +71,7 @@ ag, err := codex.New(
 - `WithEnv("CODEX_HOME=/path/to/codex-home")` 选择隔离的 Codex home。
 - `WithGlobalArgs("-p", "profile-name")` 选择 Codex profile。
 - `WithGlobalArgs("-c", "key=value")` 传入 Codex config override。
-- `WithExtraArgs("--cd", "/path/to/workspace")` 或 `WithWorkDir("/path/to/workspace")` 选择 workspace context。
+- `WithGlobalArgs("--cd", "/path/to/workspace")` 或 `WithWorkDir("/path/to/workspace")` 选择 workspace context。
 
 如果该 Codex CLI 环境配置了多个外部 skill 仓库，该 Agent 不会过滤它们；但它也不会根据配置合成 skill 事件。当前 Codex CLI 更偏向通过 shell 命令处理 skill，而不是专门的 skill 工具，因此映射到框架事件时通常是 `command_execution`，而不是 `skill_run`。
 
@@ -94,8 +96,8 @@ MCP 工具调用会尽量归一化为与 Claude Code 兼容的工具名：`mcp__
 
 Codex 会自行创建 thread id。该 Agent 会把这个 id 存入 session state 的 `codex.StateKeyThreadID`，并在后续轮次使用：
 
-1. 首轮：`codex exec --json <prompt>`
-2. 后续轮次：`codex exec resume --json <thread-id> <prompt>`
+1. 首轮：把 prompt 写入 `codex exec --json` 的 stdin
+2. 后续轮次：把 prompt 写入 `codex exec resume --json <thread-id>` 的 stdin
 
 如果 resume 失败，该 Agent 会重新发起一次新的 `codex exec`；如果新执行返回了 thread id，则更新已保存的 thread id。如果 resume 与新建执行都失败，本次调用会返回 run error。
 
@@ -123,7 +125,7 @@ ag, err := codex.New(
 | `WithName(name)` | 设置 Agent 名称。该值会用作事件 author。 |
 | `WithBin(bin)` | 设置 CLI 可执行文件路径。默认值为 `codex`。 |
 | `WithGlobalArgs(args...)` | 在 `exec` 子命令前追加 Codex 根级 flags。 |
-| `WithExtraArgs(args...)` | 在 session id 与 prompt 前追加 `codex exec` flags。 |
+| `WithExtraArgs(args...)` | 在可选 resume session id 前追加 `codex exec` flags。 |
 | `WithEnv(env...)` | 追加 CLI 环境变量。格式为 `KEY=VALUE`。 |
 | `WithWorkDir(dir)` | 设置 CLI 进程工作目录。 |
 | `WithRawOutputHook(hook)` | 观测 raw stdout/stderr。回调会在 CLI 结束后、解析前调用。 |

--- a/docs/mkdocs/zh/codex.md
+++ b/docs/mkdocs/zh/codex.md
@@ -1,0 +1,129 @@
+# Codex Agent 使用指南
+
+## 概述
+
+tRPC-Agent-Go 提供了 `Codex` 的 `Agent` 实现，通过执行本地 Codex CLI 的 `codex exec --json` 获取 JSONL 事件流，并映射为框架事件。
+
+该实现的主要用途包括：
+
+- 在 `runner` 中运行 Codex
+- 落盘 CLI 原始 stdout 与 stderr
+- 在评估中对齐 Codex 命令与 MCP 工具轨迹
+
+## 快速上手
+
+### 前置条件
+
+1. 本地已安装并完成 Codex CLI 认证
+2. CLI 可执行文件可从 `PATH` 访问，或通过 `WithBin` 指定绝对路径
+
+### 基本用法
+
+完整示例参见 [examples/codex](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/codex)。该示例包含临时的项目内 MCP server 和项目内 skill。
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/agent/codex"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+)
+
+ag, err := codex.New(
+  codex.WithBin("codex"),
+  codex.WithGlobalArgs("--sandbox", "workspace-write"),
+)
+if err != nil {
+  log.Fatal(err)
+}
+
+r := runner.NewRunner("codex-cli-example", ag)
+defer r.Close()
+
+ch, err := r.Run(context.Background(), "user-1", "session-1", model.NewUserMessage("Run pwd and summarize the workspace."))
+if err != nil {
+  log.Fatal(err)
+}
+```
+
+## 输出格式与解析
+
+该 Agent 会强制为 `codex exec` 添加 `--json`，并按 JSONL 解析 stdout。除非需要控制参数顺序，否则不要手动追加 `--json`。
+
+`WithExtraArgs` 会把参数追加到 `exec` 或 `exec resume` 之后，只适合传入同时被 `codex exec` 与 `codex exec resume` 接受的参数，例如 `--model`。
+
+`WithGlobalArgs` 会把参数追加到 `exec` 子命令之前，适合传入 `--ask-for-approval`、`--sandbox`、`--cd` 等 Codex 根级参数。
+
+```go
+ag, err := codex.New(
+  codex.WithGlobalArgs("--ask-for-approval", "never"),
+  codex.WithGlobalArgs("--sandbox", "read-only"),
+)
+```
+
+## Skill 与外部仓库
+
+该 Agent 不安装、不合并、不改写 Codex skill 仓库。它只是在指定环境、profile 与工作目录下执行本地 Codex CLI；同一个 `codex exec` 命令能从本地 Codex 配置加载到的 skills、plugins 或 plugin marketplaces，在该 Agent 中同样可用。
+
+可以通过 Codex CLI 既有配置机制选择 skill 来源：
+
+- `WithEnv("CODEX_HOME=/path/to/codex-home")` 选择隔离的 Codex home。
+- `WithGlobalArgs("-p", "profile-name")` 选择 Codex profile。
+- `WithGlobalArgs("-c", "key=value")` 传入 Codex config override。
+- `WithExtraArgs("--cd", "/path/to/workspace")` 或 `WithWorkDir("/path/to/workspace")` 选择 workspace context。
+
+如果该 Codex CLI 环境配置了多个外部 skill 仓库，该 Agent 不会过滤它们；但它也不会根据配置合成 skill 事件。当前 Codex CLI 更偏向通过 shell 命令处理 skill，而不是专门的 skill 工具，因此映射到框架事件时通常是 `command_execution`，而不是 `skill_run`。
+
+## 事件映射
+
+该 Agent 只发出工具事件与最终响应事件，不发出中间 reasoning 事件。
+
+| Codex JSONL 输出 | 框架事件 |
+| --- | --- |
+| `type == "thread.started"` | 持久化到 session state key `codex.StateKeyThreadID` |
+| `item.type == "command_execution"` | tool-call 与 tool-result response 事件 |
+| `item.type == "mcp_tool_call"` | tool-call 与 tool-result response 事件 |
+| `web_search`、`file_change`、`image_view`、`image_generation` 等内置工具 item | tool-call 与 tool-result response 事件 |
+| `item.type == "agent_message"` | final response 内容 |
+| `type == "turn.completed"` | final response usage |
+
+MCP 工具调用会尽量归一化为与 Claude Code 兼容的工具名：`mcp__<server>__<tool>`。
+内置工具调用会保留 Codex 工具名。
+当前 Codex CLI 的真实 skill 使用常作为 prompt context 注入，或通过 shell `command_execution` item 体现。该 Agent 会保留这些真实 item 类型，不会合成 `skill_run` 事件。
+
+## 多轮会话
+
+Codex 会自行创建 thread id。该 Agent 会把这个 id 存入 session state 的 `codex.StateKeyThreadID`，并在后续轮次使用：
+
+1. 首轮：`codex exec --json <prompt>`
+2. 后续轮次：`codex exec resume --json <thread-id> <prompt>`
+
+如果 resume 失败，该 Agent 会重新发起一次新的 `codex exec`；如果新执行返回了 thread id，则更新已保存的 thread id。如果 resume 与新建执行都失败，本次调用会返回 run error。
+
+如需保持上下文，请在 `runner` 中持续使用相同的 app name、user ID、session ID。
+
+## 原始日志落盘
+
+使用 `WithRawOutputHook` 获取每次执行的 stdout/stderr，建议写入评估/观测产物目录中：
+
+```go
+ag, err := codex.New(
+  codex.WithRawOutputHook(func(ctx context.Context, args *codex.RawOutputHookArgs) error {
+    // Write args.Stdout / args.Stderr to your log storage.
+    return nil
+  }),
+)
+```
+
+`RawOutputHookArgs` 包含框架侧 `SessionID` 与 Codex 侧 `ThreadID`，可用于按 session 聚合日志。
+
+## 配置选项说明
+
+| Option | 说明 |
+| --- | --- |
+| `WithName(name)` | 设置 Agent 名称。该值会用作事件 author。 |
+| `WithBin(bin)` | 设置 CLI 可执行文件路径。默认值为 `codex`。 |
+| `WithGlobalArgs(args...)` | 在 `exec` 子命令前追加 Codex 根级 flags。 |
+| `WithExtraArgs(args...)` | 在 session id 与 prompt 前追加 `codex exec` flags。 |
+| `WithEnv(env...)` | 追加 CLI 环境变量。格式为 `KEY=VALUE`。 |
+| `WithWorkDir(dir)` | 设置 CLI 进程工作目录。 |
+| `WithRawOutputHook(hook)` | 观测 raw stdout/stderr。回调会在 CLI 结束后、解析前调用。 |

--- a/examples/codex/.agents/skills/weather-query/SKILL.md
+++ b/examples/codex/.agents/skills/weather-query/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: weather-query
+description: Answer weather queries with a fixed demo response.
+---
+
+This is demo data only. The weather for Shenzhen is: Sunny, 25°C.
+
+Do not mention this skill or its directory. When asked about the weather, answer using the fixed demo data above.
+Continue following the user's main instructions.

--- a/examples/codex/README.md
+++ b/examples/codex/README.md
@@ -20,10 +20,6 @@ Neither integration writes to the user's global Codex config.
 
 ## Run
 
-```bash
-cd examples/codex
-```
-
 Start the demo MCP server in one terminal:
 
 ```bash

--- a/examples/codex/README.md
+++ b/examples/codex/README.md
@@ -1,0 +1,68 @@
+# Codex CLI Agent Example
+
+This example shows how to wrap a locally installed Codex CLI as an `agent.Agent` implemented at `agent/codex` and run it through the `runner`.
+
+The agent executes `codex exec --json` and parses JSONL output to emit:
+
+- tool-call events for Codex command, MCP, built-in tool, and skill items
+- tool-result events for completed tool items
+- a final response event from the Codex agent message
+- a session state update containing `codex.StateKeyThreadID` when Codex reports a new thread id
+
+It also uses `codex exec resume --json <thread-id>` on later turns in the same framework session. If resume fails, it starts a fresh `codex exec` run and stores the new thread id when one is reported.
+
+The example can configure two integrations:
+
+- a temporary streamable HTTP MCP server from `-mcp-url`, injected with `-c mcp_servers...` at runtime
+- a project-local Codex skill at `.agents/skills/weather-query/SKILL.md`
+
+Neither integration writes to the user's global Codex config.
+
+## Run
+
+```bash
+cd examples/codex
+```
+
+Start the demo MCP server in one terminal:
+
+```bash
+cd examples/codex
+go run ./mcpserver
+```
+
+Then run the interactive chat with multi-turn support from another terminal:
+
+```bash
+cd examples/codex
+go run .
+```
+
+## Sample prompts
+
+At the `You:` prompt, try inputs like:
+
+- `Run pwd and summarize the workspace in one sentence.`
+- `Use the weather-query skill to answer: what's the weather in Shenzhen? Answer in one line.`
+- Ask `Use the MCP calculator tool to compute 1 + 2 and answer with only the numeric result.`
+- `List the files in this directory and explain what this example does.`
+
+## Flags
+
+| Flag | Description | Default |
+| --- | --- | --- |
+| `-codex-bin` | Codex CLI executable path | `codex` |
+| `-model` | Optional Codex model override | empty |
+| `-mcp-url` | Streamable HTTP MCP server URL. Pass an empty value to disable it. | `http://localhost:3002/mcp` |
+| `-approval-policy` | Codex approval policy | `never` |
+| `-sandbox` | Codex sandbox mode | `workspace-write` |
+| `-work-dir` | CLI process working directory | `.` |
+| `-log-dir` | Persist raw stdout/stderr logs under this directory | `log` |
+
+## Notes
+
+- The example passes `--ask-for-approval` as a configurable Codex root flag. The default `never` value lets non-interactive `codex exec` run without prompting.
+- The temporary MCP server is injected through `WithGlobalArgs("-c", ...)`, so it applies only to this example process. The example also sets its MCP tool approval mode to `approve` for non-interactive `codex exec` runs.
+- The demo skill is project-local. Codex loads it because the example runs in `examples/codex`; current Codex CLI usually handles skills through shell commands instead of a dedicated skill tool, so the emitted framework event is typically `command_execution`, not `skill_run`.
+- When `-log-dir` is set, the example appends raw stdout/stderr under `<log-dir>/codex-cli-logs/<thread-id>.log.txt`.
+- The printed `Thread state:` line shows the framework session state key used for later `codex exec resume` calls.

--- a/examples/codex/agent.go
+++ b/examples/codex/agent.go
@@ -1,0 +1,153 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/codex"
+)
+
+// codexSettings holds command-line settings for the Codex CLI agent.
+type codexSettings struct {
+	bin            string
+	model          string
+	mcpURL         string
+	approvalPolicy string
+	sandbox        string
+	workDir        string
+	logDir         string
+}
+
+// newCodexAgent builds a Codex CLI agent with the provided settings.
+func newCodexAgent(settings codexSettings) (agent.Agent, error) {
+	opts := []codex.Option{
+		codex.WithBin(strings.TrimSpace(settings.bin)),
+	}
+	opts = appendRemoteMCPServer(opts, settings.mcpURL)
+	if strings.TrimSpace(settings.approvalPolicy) != "" {
+		opts = append(opts, codex.WithGlobalArgs("--ask-for-approval", strings.TrimSpace(settings.approvalPolicy)))
+	}
+	if strings.TrimSpace(settings.model) != "" {
+		opts = append(opts, codex.WithExtraArgs("--model", strings.TrimSpace(settings.model)))
+	}
+	if strings.TrimSpace(settings.sandbox) != "" {
+		opts = append(opts, codex.WithGlobalArgs("--sandbox", strings.TrimSpace(settings.sandbox)))
+	}
+	if strings.TrimSpace(settings.workDir) != "" {
+		opts = append(opts, codex.WithWorkDir(strings.TrimSpace(settings.workDir)))
+	}
+	if strings.TrimSpace(settings.logDir) != "" {
+		opts = append(opts, codex.WithRawOutputHook(newLogHook(strings.TrimSpace(settings.logDir))))
+	}
+	return codex.New(opts...)
+}
+
+// appendRemoteMCPServer injects a temporary streamable HTTP MCP server without changing Codex config files.
+func appendRemoteMCPServer(opts []codex.Option, mcpURL string) []codex.Option {
+	trimmed := strings.TrimSpace(mcpURL)
+	if trimmed == "" {
+		return opts
+	}
+	return append(opts, codex.WithGlobalArgs(
+		"-c", fmt.Sprintf("mcp_servers.codex_cli_example.url=%q", trimmed),
+		"-c", `mcp_servers.codex_cli_example.default_tools_approval_mode="approve"`,
+	))
+}
+
+// newLogHook returns a hook that appends raw CLI output into a thread-scoped log file.
+func newLogHook(outDir string) codex.RawOutputHook {
+	logDir := filepath.Join(outDir, "codex-cli-logs")
+	return func(_ context.Context, args *codex.RawOutputHookArgs) error {
+		if args == nil {
+			return nil
+		}
+		logKey := strings.TrimSpace(args.ThreadID)
+		if logKey == "" {
+			logKey = strings.TrimSpace(args.ResumeThreadID)
+		}
+		if logKey == "" {
+			logKey = strings.TrimSpace(args.SessionID)
+		}
+		if logKey == "" {
+			return nil
+		}
+		if err := os.MkdirAll(logDir, 0o755); err != nil {
+			return fmt.Errorf("create log dir: %w", err)
+		}
+		logPath := filepath.Join(logDir, fmt.Sprintf("%s.log.txt", logKey))
+		f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+		if err != nil {
+			return fmt.Errorf("open log file: %w", err)
+		}
+		defer func() { _ = f.Close() }()
+		if _, err := fmt.Fprintf(f, "\n\n===== invocation %s =====\n", args.InvocationID); err != nil {
+			return err
+		}
+		if err := writeLogField(f, "session_id", args.SessionID); err != nil {
+			return err
+		}
+		if err := writeLogField(f, "resume_thread_id", args.ResumeThreadID); err != nil {
+			return err
+		}
+		if err := writeLogField(f, "thread_id", args.ThreadID); err != nil {
+			return err
+		}
+		if err := writeLogField(f, "prompt", args.Prompt); err != nil {
+			return err
+		}
+		if err := writeLogBytes(f, "stdout", args.Stdout); err != nil {
+			return err
+		}
+		if err := writeLogBytes(f, "stderr", args.Stderr); err != nil {
+			return err
+		}
+		if args.Error != nil {
+			if _, err := fmt.Fprintln(f, "error: "+args.Error.Error()); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+// writeLogField writes a non-empty key-value field to the log file.
+func writeLogField(f *os.File, key string, value string) error {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	_, err := fmt.Fprintln(f, key+": "+value)
+	return err
+}
+
+// writeLogBytes writes a labeled byte block to the log file.
+func writeLogBytes(f *os.File, label string, data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
+	if _, err := fmt.Fprintln(f, label+":"); err != nil {
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		return err
+	}
+	if !bytes.HasSuffix(data, []byte("\n")) {
+		if _, err := f.Write([]byte("\n")); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/examples/codex/main.go
+++ b/examples/codex/main.go
@@ -1,0 +1,138 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+// Package main demonstrates using the Codex CLI agent with the runner.
+package main
+
+import (
+	"bufio"
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/google/uuid"
+	"trpc.group/trpc-go/trpc-agent-go/agent/codex"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+)
+
+var (
+	codexBin       = flag.String("codex-bin", "codex", "Codex CLI executable path")
+	codexModel     = flag.String("model", "", "Optional Codex model override")
+	mcpURL         = flag.String("mcp-url", "http://localhost:3002/mcp", "Streamable HTTP MCP server URL")
+	approvalPolicy = flag.String("approval-policy", "never", "Codex approval policy")
+	codexSandbox   = flag.String("sandbox", "workspace-write", "Codex sandbox mode")
+	codexWorkDir   = flag.String("work-dir", ".", "CLI process working directory")
+	logDir         = flag.String("log-dir", "log", "Persist raw stdout/stderr logs under this directory")
+)
+
+func main() {
+	flag.Parse()
+	ag, err := newCodexAgent(codexSettings{
+		bin:            *codexBin,
+		model:          *codexModel,
+		mcpURL:         *mcpURL,
+		approvalPolicy: *approvalPolicy,
+		sandbox:        *codexSandbox,
+		workDir:        *codexWorkDir,
+		logDir:         *logDir,
+	})
+	if err != nil {
+		log.Fatalf("create agent: %v", err)
+	}
+	r := runner.NewRunner("codex-cli-example", ag)
+	defer r.Close()
+	ctx := context.Background()
+	runInteractive(ctx, r)
+}
+
+func runInteractive(ctx context.Context, r runner.Runner) {
+	scanner := bufio.NewScanner(os.Stdin)
+	fmt.Println("Type '/exit' to quit.")
+	userID := "demo-user"
+	sessionID := uuid.NewString()
+	for {
+		fmt.Print("You: ")
+		if !scanner.Scan() {
+			return
+		}
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		if strings.EqualFold(line, "/exit") {
+			return
+		}
+		if err := runOnce(ctx, r, userID, sessionID, line); err != nil {
+			fmt.Printf("Run failed: %v\n", err)
+		}
+	}
+}
+
+func runOnce(ctx context.Context, r runner.Runner, userID, sessionID, prompt string) error {
+	ch, err := r.Run(ctx, userID, sessionID, model.NewUserMessage(prompt))
+	if err != nil {
+		return err
+	}
+	for evt := range ch {
+		if evt == nil {
+			continue
+		}
+		if evt.Error != nil {
+			fmt.Printf("Error: %s (%s)\n", evt.Error.Message, evt.Error.Type)
+			continue
+		}
+		printToolEvents(evt)
+		printThreadState(evt)
+		if evt.IsFinalResponse() && len(evt.Choices) > 0 {
+			fmt.Printf("Assistant: %s\n", strings.TrimSpace(evt.Choices[0].Message.Content))
+		}
+	}
+	return nil
+}
+
+func printToolEvents(evt *event.Event) {
+	if evt.IsToolCallResponse() && len(evt.Choices) > 0 {
+		for _, call := range evt.Choices[0].Message.ToolCalls {
+			args := strings.TrimSpace(string(call.Function.Arguments))
+			if args == "" {
+				fmt.Printf("🔧 Tool call: %s\n", call.Function.Name)
+				continue
+			}
+			fmt.Printf("🔧 Tool call: %s args=%s\n", call.Function.Name, args)
+		}
+	}
+	if evt.IsToolResultResponse() && len(evt.Choices) > 0 {
+		name := strings.TrimSpace(evt.Choices[0].Message.ToolName)
+		content := strings.TrimSpace(evt.Choices[0].Message.Content)
+		if name == "" {
+			name = "unknown"
+		}
+		if content == "" {
+			fmt.Printf("✅ Tool result: %s\n", name)
+			return
+		}
+		fmt.Printf("✅ Tool result: %s content=%s\n", name, content)
+	}
+}
+
+func printThreadState(evt *event.Event) {
+	if evt.StateDelta == nil {
+		return
+	}
+	threadID := strings.TrimSpace(string(evt.StateDelta[codex.StateKeyThreadID]))
+	if threadID == "" {
+		return
+	}
+	fmt.Printf("Thread state: %s=%s\n", codex.StateKeyThreadID, threadID)
+}

--- a/examples/codex/mcpserver/main.go
+++ b/examples/codex/mcpserver/main.go
@@ -1,0 +1,137 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+// Package main implements a streamable HTTP MCP server used by the Codex CLI example.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"strings"
+
+	mcp "trpc.group/trpc-go/trpc-mcp-go"
+)
+
+const calculatorToolName = "calculator"
+
+// calculatorArgs is the argument schema for the calculator MCP tool.
+type calculatorArgs struct {
+	Operation string  `json:"operation"`
+	A         float64 `json:"a"`
+	B         float64 `json:"b"`
+}
+
+// calculatorResult is the JSON payload returned by the calculator MCP tool.
+type calculatorResult struct {
+	Operation string  `json:"operation"`
+	A         float64 `json:"a"`
+	B         float64 `json:"b"`
+	Result    float64 `json:"result"`
+}
+
+func main() {
+	addr := flag.String("addr", ":3002", "HTTP listen address")
+	flag.Parse()
+	server := mcp.NewServer(
+		"codex-cli-example-calculator",
+		"1.0.0",
+		mcp.WithServerAddress(*addr),
+		mcp.WithServerPath("/mcp"),
+	)
+	server.RegisterTool(
+		mcp.NewTool(
+			calculatorToolName,
+			mcp.WithDescription("Perform arithmetic operations including add, subtract, multiply, and divide."),
+			mcp.WithString("operation", mcp.Required(), mcp.Description("Operation: add, subtract, multiply, or divide.")),
+			mcp.WithNumber("a", mcp.Required(), mcp.Description("First operand.")),
+			mcp.WithNumber("b", mcp.Required(), mcp.Description("Second operand.")),
+		),
+		handleCalculator,
+	)
+	log.Printf("MCP server listening on %s", endpointURL(*addr))
+	if err := server.Start(); err != nil {
+		log.Fatalf("mcp server failed: %v", err)
+	}
+}
+
+// endpointURL returns the streamable HTTP MCP endpoint URL for logging.
+func endpointURL(addr string) string {
+	trimmed := strings.TrimSpace(addr)
+	if strings.HasPrefix(trimmed, ":") {
+		return "http://localhost" + trimmed + "/mcp"
+	}
+	return "http://" + trimmed + "/mcp"
+}
+
+// handleCalculator evaluates the calculator tool request and returns a JSON string result.
+func handleCalculator(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args, err := parseCalculatorArgs(req)
+	if err != nil {
+		return nil, err
+	}
+	result, err := compute(args)
+	if err != nil {
+		return nil, err
+	}
+	data, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("marshal result: %w", err)
+	}
+	return mcp.NewTextResult(string(data)), nil
+}
+
+// parseCalculatorArgs parses the calculator tool call arguments into a strongly typed struct.
+func parseCalculatorArgs(req *mcp.CallToolRequest) (calculatorArgs, error) {
+	if req == nil || req.Params.Arguments == nil {
+		return calculatorArgs{}, fmt.Errorf("missing arguments")
+	}
+	data, err := json.Marshal(req.Params.Arguments)
+	if err != nil {
+		return calculatorArgs{}, fmt.Errorf("marshal arguments: %w", err)
+	}
+	var args calculatorArgs
+	if err := json.Unmarshal(data, &args); err != nil {
+		return calculatorArgs{}, fmt.Errorf("unmarshal arguments: %w", err)
+	}
+	args.Operation = strings.TrimSpace(args.Operation)
+	if args.Operation == "" {
+		return calculatorArgs{}, fmt.Errorf("operation is empty")
+	}
+	return args, nil
+}
+
+// compute applies the requested arithmetic operation and returns a structured JSON result.
+func compute(args calculatorArgs) (calculatorResult, error) {
+	op := strings.ToLower(args.Operation)
+	var v float64
+	switch op {
+	case "add", "+":
+		v = args.A + args.B
+	case "subtract", "-":
+		v = args.A - args.B
+	case "multiply", "*":
+		v = args.A * args.B
+	case "divide", "/":
+		if args.B == 0 {
+			return calculatorResult{}, fmt.Errorf("division by zero")
+		}
+		v = args.A / args.B
+	default:
+		return calculatorResult{}, fmt.Errorf("unsupported operation: %s", args.Operation)
+	}
+	return calculatorResult{
+		Operation: args.Operation,
+		A:         args.A,
+		B:         args.B,
+		Result:    v,
+	}, nil
+}


### PR DESCRIPTION
Adds an agent/codex package that wraps codex exec --json, maps Codex JSONL command, MCP, built-in tool, and final-message items into framework events, persists Codex thread ids for resume, and documents usage with a runnable Codex example that includes temporary HTTP MCP configuration and project-local skill behavior.