### PR TITLE
docs/mkdocs: update PromptIter guide

### DIFF
--- a/docs/mkdocs/assets/img/promptiter/backwarder.svg
+++ b/docs/mkdocs/assets/img/promptiter/backwarder.svg
@@ -1,0 +1,63 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1500" height="500" viewBox="0 0 1500 500" role="img" aria-label="backwarder input output">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="10" markerHeight="10" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#718096" />
+    </marker>
+    <marker id="back-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="10" markerHeight="10" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#8b6f47" />
+    </marker>
+    <marker id="surface-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="10" markerHeight="10" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#d59b23" />
+    </marker>
+    <style>
+      .bg { fill: #f8fafc; }
+      .fn { fill: #f1f5f9; stroke: #94a3b8; stroke-width: 1.4; }
+      .agent { fill: #eef6ff; stroke: #3f7fbf; stroke-width: 1.5; }
+      .surface { fill: #fff7df; stroke: #d59b23; stroke-width: 1.1; }
+      .step { fill: #173b63; font: 700 25px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      .fn-step { fill: #334155; font: 700 23px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      .node-name { fill: #64748b; font: 600 15px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+      .id { fill: #6f4a00; font: 600 11px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+      .label { fill: #334155; font: 700 17px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      .branch { fill: #8b6f47; font: 700 14px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+      .edge { stroke: #718096; stroke-width: 1.7; fill: none; }
+      .back { stroke: #8b6f47; stroke-width: 1.8; stroke-dasharray: 7 5; fill: none; }
+      .gradient-edge { stroke: #d59b23; stroke-width: 1.8; fill: none; }
+      .gradient-arrow-head { fill: #d59b23; }
+      .edge-arrow { fill: #718096; }
+      .back-arrow-head { fill: #8b6f47; }
+    </style>
+  </defs>
+  <rect class="bg" width="1500" height="500" rx="18" />
+
+  <path class="edge" d="M 350 195 L 580 195" />
+  <polygon class="edge-arrow" points="580,195 566,187 566,203" />
+  <path class="edge" d="M 910 195 L 1140 195" />
+  <polygon class="edge-arrow" points="1140,195 1126,187 1126,203" />
+
+  <rect class="fn" x="90" y="135" width="260" height="120" rx="10" />
+  <text class="fn-step" x="220" y="177" text-anchor="middle">s1</text>
+  <text class="node-name" x="220" y="218" text-anchor="middle">candidate/merge</text>
+
+  <rect class="agent" x="590" y="120" width="320" height="150" rx="10" />
+  <text class="step" x="750" y="160" text-anchor="middle">s2</text>
+  <text class="node-name" x="750" y="202" text-anchor="middle">candidate/polish</text>
+  <rect class="surface" x="625" y="223" width="250" height="34" rx="7" />
+  <text class="id" x="750" y="245" text-anchor="middle">candidate/polish#instruction</text>
+
+  <rect class="agent" x="1150" y="135" width="260" height="120" rx="10" />
+  <text class="step" x="1280" y="177" text-anchor="middle">s3</text>
+  <text class="node-name" x="1280" y="218" text-anchor="middle">candidate/review</text>
+
+  <path class="back" d="M 1150 270 C 1040 430, 980 430, 910 280" />
+  <polygon class="back-arrow-head" points="910,280 922,292 911,297" />
+  <text class="branch" x="1092" y="438" text-anchor="middle">Incoming GradientPacket</text>
+
+  <path class="back" d="M 590 280 C 505 430, 430 430, 350 270" />
+  <polygon class="back-arrow-head" points="350,270 363,282 352,287" />
+  <text class="branch" x="407" y="438" text-anchor="middle">Upstream GradientPacket</text>
+
+  <path class="gradient-edge" d="M 750 270 L 750 356" />
+  <polygon class="gradient-arrow-head" points="750,356 742,342 758,342" />
+  <text class="label" x="750" y="388" text-anchor="middle">Gradients</text>
+</svg>

--- a/docs/mkdocs/assets/img/promptiter/graphagent-structure.svg
+++ b/docs/mkdocs/assets/img/promptiter/graphagent-structure.svg
@@ -1,0 +1,84 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1540" height="620" viewBox="0 0 1540 620" role="img" aria-label="graph">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#718096" />
+    </marker>
+    <marker id="dash-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#8b6f47" />
+    </marker>
+    <style>
+      .bg { fill: #f8fafc; }
+      .fn { fill: #f1f5f9; stroke: #94a3b8; stroke-width: 1.3; }
+      .agent { fill: #eef6ff; stroke: #3f7fbf; stroke-width: 1.5; }
+      .surface { fill: #fff7df; stroke: #d59b23; stroke-width: 1.1; }
+      .name { fill: #173b63; font: 700 18px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      .fn-name { fill: #334155; font: 700 14px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      .id { fill: #6f4a00; font: 600 11.5px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+      .prompt { fill: #475569; font: 600 13px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      .branch { fill: #8b6f47; font: 600 13px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+      .branch-bg { fill: #f8fafc; }
+      .edge { stroke: #718096; stroke-width: 1.7; fill: none; marker-end: url(#arrow); }
+      .cond { stroke: #8b6f47; stroke-width: 1.7; stroke-dasharray: 6 5; fill: none; marker-end: url(#dash-arrow); }
+    </style>
+  </defs>
+  <rect class="bg" width="1540" height="620" rx="18" />
+
+  <rect class="agent" x="30" y="282" width="118" height="58" rx="10" />
+  <text class="name" x="89" y="317" text-anchor="middle">candidate</text>
+
+  <rect class="fn" x="170" y="282" width="140" height="58" rx="10" />
+  <text class="fn-name" x="240" y="317" text-anchor="middle">candidate/prepare</text>
+
+  <rect class="agent" x="390" y="68" width="270" height="124" rx="10" />
+  <text class="name" x="525" y="100" text-anchor="middle">candidate/title</text>
+  <rect class="surface" x="400" y="120" width="250" height="52" rx="7" />
+  <text class="id" x="525" y="141" text-anchor="middle">candidate/title#instruction</text>
+  <text class="prompt" x="525" y="162" text-anchor="middle">生成中文战报标题</text>
+
+  <rect class="agent" x="390" y="249" width="270" height="124" rx="10" />
+  <text class="name" x="525" y="281" text-anchor="middle">candidate/introduction</text>
+  <rect class="surface" x="400" y="301" width="250" height="52" rx="7" />
+  <text class="id" x="525" y="322" text-anchor="middle">candidate/introduction#instruction</text>
+  <text class="prompt" x="525" y="343" text-anchor="middle">写出比赛背景和开场导语</text>
+
+  <rect class="agent" x="390" y="430" width="270" height="124" rx="10" />
+  <text class="name" x="525" y="462" text-anchor="middle">candidate/highlight</text>
+  <rect class="surface" x="400" y="482" width="250" height="52" rx="7" />
+  <text class="id" x="525" y="503" text-anchor="middle">candidate/highlight#instruction</text>
+  <text class="prompt" x="525" y="524" text-anchor="middle">提取关键回合和转折点</text>
+
+  <rect class="fn" x="720" y="282" width="145" height="58" rx="10" />
+  <text class="fn-name" x="793" y="317" text-anchor="middle">candidate/merge</text>
+
+  <rect class="agent" x="875" y="249" width="220" height="124" rx="10" />
+  <text class="name" x="985" y="281" text-anchor="middle">candidate/polish</text>
+  <rect class="surface" x="885" y="301" width="200" height="52" rx="7" />
+  <text class="id" x="985" y="322" text-anchor="middle">candidate/polish#instruction</text>
+  <text class="prompt" x="985" y="343" text-anchor="middle">润色战报结构和表达</text>
+
+  <rect class="agent" x="1145" y="249" width="220" height="124" rx="10" />
+  <text class="name" x="1255" y="281" text-anchor="middle">candidate/review</text>
+  <rect class="surface" x="1155" y="301" width="200" height="52" rx="7" />
+  <text class="id" x="1255" y="322" text-anchor="middle">candidate/review#instruction</text>
+  <text class="prompt" x="1255" y="343" text-anchor="middle">审核事实一致性和发布标准</text>
+
+  <rect class="fn" x="1400" y="282" width="125" height="58" rx="10" />
+  <text class="fn-name" x="1463" y="317" text-anchor="middle">candidate/publish</text>
+
+  <path class="edge" d="M 148 311 L 170 311" />
+  <path class="edge" d="M 310 311 C 360 311, 340 130, 390 130" />
+  <path class="edge" d="M 310 311 L 390 311" />
+  <path class="edge" d="M 310 311 C 360 311, 340 492, 390 492" />
+
+  <path class="edge" d="M 660 130 C 700 130, 680 296, 720 296" />
+  <path class="edge" d="M 660 311 L 720 311" />
+  <path class="edge" d="M 660 492 C 700 492, 680 326, 720 326" />
+  <path class="edge" d="M 865 311 L 875 311" />
+  <path class="edge" d="M 1095 311 L 1145 311" />
+
+  <path class="cond" d="M 1365 311 L 1400 311" />
+  <rect class="branch-bg" x="1368" y="262" width="42" height="22" rx="5" />
+  <text class="branch" x="1389" y="277" text-anchor="middle">pass</text>
+  <path class="cond" d="M 1255 373 C 1255 520, 985 520, 985 373" />
+  <text class="branch" x="1120" y="522" text-anchor="middle">revise</text>
+</svg>

--- a/docs/mkdocs/assets/img/promptiter/graphagent-trace.svg
+++ b/docs/mkdocs/assets/img/promptiter/graphagent-trace.svg
@@ -1,0 +1,95 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1760" height="760" viewBox="0 0 1760 760" role="img" aria-label="graph agent execution trace">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#718096" />
+    </marker>
+    <marker id="dash-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#8b6f47" />
+    </marker>
+    <style>
+      .bg { fill: #f8fafc; }
+      .fn { fill: #f1f5f9; stroke: #94a3b8; stroke-width: 1.4; }
+      .agent { fill: #eef6ff; stroke: #3f7fbf; stroke-width: 1.5; }
+      .surface { fill: #fff7df; stroke: #d59b23; stroke-width: 1.1; }
+      .step { fill: #173b63; font: 700 25px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      .fn-step { fill: #334155; font: 700 23px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      .node-name { fill: #64748b; font: 600 15px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+      .id { fill: #6f4a00; font: 600 11px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+      .branch { fill: #8b6f47; font: 700 14px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+      .edge { stroke: #718096; stroke-width: 1.7; fill: none; marker-end: url(#arrow); }
+      .cond { stroke: #8b6f47; stroke-width: 1.8; stroke-dasharray: 7 5; fill: none; marker-end: url(#dash-arrow); }
+    </style>
+  </defs>
+  <rect class="bg" width="1760" height="760" rx="18" />
+
+  <rect class="fn" x="48" y="340" width="165" height="84" rx="10" />
+  <text class="fn-step" x="130" y="372" text-anchor="middle">s1</text>
+  <text class="node-name" x="130" y="405" text-anchor="middle">candidate/prepare</text>
+
+  <rect class="agent" x="320" y="70" width="260" height="126" rx="10" />
+  <text class="step" x="450" y="104" text-anchor="middle">s2</text>
+  <text class="node-name" x="450" y="135" text-anchor="middle">candidate/title</text>
+  <rect class="surface" x="335" y="152" width="230" height="34" rx="7" />
+  <text class="id" x="450" y="174" text-anchor="middle">candidate/title#instruction</text>
+
+  <rect class="agent" x="320" y="318" width="260" height="126" rx="10" />
+  <text class="step" x="450" y="352" text-anchor="middle">s3</text>
+  <text class="node-name" x="450" y="383" text-anchor="middle">candidate/introduction</text>
+  <rect class="surface" x="335" y="400" width="230" height="34" rx="7" />
+  <text class="id" x="450" y="422" text-anchor="middle">candidate/introduction#instruction</text>
+
+  <rect class="agent" x="320" y="566" width="260" height="126" rx="10" />
+  <text class="step" x="450" y="600" text-anchor="middle">s4</text>
+  <text class="node-name" x="450" y="631" text-anchor="middle">candidate/highlight</text>
+  <rect class="surface" x="335" y="648" width="230" height="34" rx="7" />
+  <text class="id" x="450" y="670" text-anchor="middle">candidate/highlight#instruction</text>
+
+  <rect class="fn" x="690" y="340" width="145" height="84" rx="10" />
+  <text class="fn-step" x="763" y="372" text-anchor="middle">s5</text>
+  <text class="node-name" x="763" y="405" text-anchor="middle">candidate/merge</text>
+
+  <rect class="agent" x="930" y="270" width="250" height="126" rx="10" />
+  <text class="step" x="1055" y="304" text-anchor="middle">s6</text>
+  <text class="node-name" x="1055" y="335" text-anchor="middle">candidate/polish</text>
+  <rect class="surface" x="945" y="352" width="220" height="34" rx="7" />
+  <text class="id" x="1055" y="374" text-anchor="middle">candidate/polish#instruction</text>
+
+  <rect class="agent" x="1260" y="270" width="250" height="126" rx="10" />
+  <text class="step" x="1385" y="304" text-anchor="middle">s7</text>
+  <text class="node-name" x="1385" y="335" text-anchor="middle">candidate/review</text>
+  <rect class="surface" x="1275" y="352" width="220" height="34" rx="7" />
+  <text class="id" x="1385" y="374" text-anchor="middle">candidate/review#instruction</text>
+
+  <rect class="agent" x="930" y="542" width="250" height="126" rx="10" />
+  <text class="step" x="1055" y="576" text-anchor="middle">s8</text>
+  <text class="node-name" x="1055" y="607" text-anchor="middle">candidate/polish</text>
+  <rect class="surface" x="945" y="624" width="220" height="34" rx="7" />
+  <text class="id" x="1055" y="646" text-anchor="middle">candidate/polish#instruction</text>
+
+  <rect class="agent" x="1260" y="542" width="250" height="126" rx="10" />
+  <text class="step" x="1385" y="576" text-anchor="middle">s9</text>
+  <text class="node-name" x="1385" y="607" text-anchor="middle">candidate/review</text>
+  <rect class="surface" x="1275" y="624" width="220" height="34" rx="7" />
+  <text class="id" x="1385" y="646" text-anchor="middle">candidate/review#instruction</text>
+
+  <rect class="fn" x="1588" y="422" width="150" height="84" rx="10" />
+  <text class="fn-step" x="1663" y="454" text-anchor="middle">s10</text>
+  <text class="node-name" x="1663" y="487" text-anchor="middle">candidate/publish</text>
+
+  <path class="edge" d="M 213 382 C 262 382, 268 133, 320 133" />
+  <path class="edge" d="M 213 382 L 320 382" />
+  <path class="edge" d="M 213 382 C 262 382, 268 629, 320 629" />
+
+  <path class="edge" d="M 580 133 C 635 133, 635 356, 690 356" />
+  <path class="edge" d="M 580 382 L 690 382" />
+  <path class="edge" d="M 580 629 C 635 629, 635 408, 690 408" />
+
+  <path class="edge" d="M 835 382 L 930 333" />
+  <path class="edge" d="M 1180 333 L 1260 333" />
+
+  <path class="cond" d="M 1385 396 C 1385 482, 1055 482, 1055 542" />
+  <text class="branch" x="1232" y="462" text-anchor="middle">revise</text>
+  <path class="edge" d="M 1180 605 L 1260 605" />
+  <path class="cond" d="M 1510 605 C 1552 605, 1552 464, 1588 464" />
+  <text class="branch" x="1560" y="624" text-anchor="middle">pass</text>
+</svg>

--- a/docs/mkdocs/assets/img/promptiter/llmagent-structure.svg
+++ b/docs/mkdocs/assets/img/promptiter/llmagent-structure.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="560" height="220" viewBox="0 0 560 220" role="img" aria-label="candidate candidate#instruction">
+  <defs>
+    <style>
+      .bg { fill: #f8fafc; }
+      .node { fill: #eef6ff; stroke: #3f7fbf; stroke-width: 1.6; }
+      .surface { fill: #fff7df; stroke: #d59b23; stroke-width: 1.2; }
+      .name { fill: #173b63; font: 700 22px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      .id { fill: #6f4a00; font: 600 16px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+      .prompt { fill: #475569; font: 600 15px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    </style>
+  </defs>
+  <rect class="bg" width="560" height="220" rx="18" />
+  <rect class="node" x="110" y="42" width="340" height="136" rx="14" />
+  <text class="name" x="280" y="96" text-anchor="middle">candidate</text>
+  <rect class="surface" x="148" y="116" width="264" height="48" rx="8" />
+  <text class="id" x="280" y="136" text-anchor="middle">candidate#instruction</text>
+  <text class="prompt" x="280" y="154" text-anchor="middle">生成一篇中文体育战报</text>
+</svg>

--- a/docs/mkdocs/assets/img/promptiter/llmagent-trace.svg
+++ b/docs/mkdocs/assets/img/promptiter/llmagent-trace.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="626" height="208" viewBox="0 0 626 208" role="img" aria-label="llmagent execution trace">
+  <defs>
+    <style>
+      .bg { fill: #f8fafc; }
+      .step { fill: #eef6ff; stroke: #3f7fbf; stroke-width: 1.8; }
+      .surface { fill: #fff7df; stroke: #d59b23; stroke-width: 1.4; }
+      .name { fill: #173b63; font: 700 40px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      .node-name { fill: #64748b; font: 600 34px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      .id { fill: #6f4a00; font: 700 30px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    </style>
+  </defs>
+  <rect class="bg" width="626" height="208" rx="18" />
+  <rect class="step" x="24" y="31" width="578" height="146" rx="14" />
+  <text class="name" x="313" y="71" text-anchor="middle">s1</text>
+  <text class="node-name" x="313" y="107" text-anchor="middle">candidate</text>
+  <rect class="surface" x="46" y="121" width="534" height="42" rx="8" />
+  <text class="id" x="313" y="152" text-anchor="middle">candidate#instruction</text>
+</svg>

--- a/docs/mkdocs/assets/img/promptiter/overview.svg
+++ b/docs/mkdocs/assets/img/promptiter/overview.svg
@@ -1,0 +1,68 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="360" viewBox="0 0 1280 360">
+  <rect x="0" y="0" width="1280" height="360" fill="#ffffff"/>
+
+  <rect x="56" y="64" width="126" height="60" rx="10" fill="#f8fafc" stroke="#334155" stroke-width="1.4"/>
+  <text x="119" y="100" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="15" font-weight="700" fill="#111827">RunRequest</text>
+
+  <rect x="228" y="64" width="150" height="60" rx="10" fill="#f8fafc" stroke="#334155" stroke-width="1.4"/>
+  <text x="303" y="88" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="700" fill="#111827">Initial Baseline</text>
+  <text x="303" y="108" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="700" fill="#111827">Validation</text>
+
+  <rect x="424" y="64" width="138" height="60" rx="10" fill="#f8fafc" stroke="#334155" stroke-width="1.4"/>
+  <text x="493" y="88" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="700" fill="#111827">Train</text>
+  <text x="493" y="108" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="700" fill="#111827">Evaluation</text>
+
+  <rect x="610" y="64" width="116" height="60" rx="10" fill="#f8fafc" stroke="#334155" stroke-width="1.4"/>
+  <text x="668" y="100" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="700" fill="#111827">Backward</text>
+
+  <rect x="784" y="64" width="116" height="60" rx="10" fill="#f8fafc" stroke="#334155" stroke-width="1.4"/>
+  <text x="842" y="100" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="700" fill="#111827">Aggregate</text>
+
+  <rect x="958" y="64" width="116" height="60" rx="10" fill="#f8fafc" stroke="#334155" stroke-width="1.4"/>
+  <text x="1016" y="100" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="700" fill="#111827">Optimize</text>
+
+  <rect x="76" y="236" width="126" height="60" rx="10" fill="#f8fafc" stroke="#334155" stroke-width="1.4"/>
+  <text x="139" y="260" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="700" fill="#111827">Candidate</text>
+  <text x="139" y="280" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="700" fill="#111827">Profile</text>
+
+  <rect x="260" y="236" width="138" height="60" rx="10" fill="#f8fafc" stroke="#334155" stroke-width="1.4"/>
+  <text x="329" y="260" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="700" fill="#111827">Validation</text>
+  <text x="329" y="280" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="700" fill="#111827">Evaluation</text>
+
+  <path d="M514 222 L574 266 L514 310 L454 266 Z" fill="#f8fafc" stroke="#334155" stroke-width="1.4"/>
+  <text x="514" y="260" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="700" fill="#111827">Accept</text>
+  <text x="514" y="280" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="700" fill="#111827">Policy</text>
+
+  <path d="M688 222 L748 266 L688 310 L628 266 Z" fill="#f8fafc" stroke="#334155" stroke-width="1.4"/>
+  <text x="688" y="260" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="700" fill="#111827">Stop</text>
+  <text x="688" y="280" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="700" fill="#111827">Policy</text>
+
+  <rect x="804" y="236" width="116" height="60" rx="10" fill="#f8fafc" stroke="#334155" stroke-width="1.4"/>
+  <text x="862" y="272" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="15" font-weight="700" fill="#111827">RunResult</text>
+
+  <path d="M182 94 L228 94" fill="none" stroke="#475569" stroke-width="1.5"/>
+  <polygon points="228,94 216,88 216,100" fill="#475569"/>
+  <path d="M378 94 L424 94" fill="none" stroke="#475569" stroke-width="1.5"/>
+  <polygon points="424,94 412,88 412,100" fill="#475569"/>
+  <path d="M562 94 L610 94" fill="none" stroke="#475569" stroke-width="1.5"/>
+  <polygon points="610,94 598,88 598,100" fill="#475569"/>
+  <path d="M726 94 L784 94" fill="none" stroke="#475569" stroke-width="1.5"/>
+  <polygon points="784,94 772,88 772,100" fill="#475569"/>
+  <path d="M900 94 L958 94" fill="none" stroke="#475569" stroke-width="1.5"/>
+  <polygon points="958,94 946,88 946,100" fill="#475569"/>
+
+  <path d="M1074 94 L1180 94 L1180 184 L139 184 L139 236" fill="none" stroke="#475569" stroke-width="1.5"/>
+  <polygon points="139,236 133,224 145,224" fill="#475569"/>
+
+  <path d="M202 266 L260 266" fill="none" stroke="#475569" stroke-width="1.5"/>
+  <polygon points="260,266 248,260 248,272" fill="#475569"/>
+  <path d="M398 266 L454 266" fill="none" stroke="#475569" stroke-width="1.5"/>
+  <polygon points="454,266 442,260 442,272" fill="#475569"/>
+  <path d="M574 266 L628 266" fill="none" stroke="#475569" stroke-width="1.5"/>
+  <polygon points="628,266 616,260 616,272" fill="#475569"/>
+  <path d="M748 266 L804 266" fill="none" stroke="#475569" stroke-width="1.5"/>
+  <polygon points="804,266 792,260 792,272" fill="#475569"/>
+
+  <path d="M688 222 L688 162 L493 162 L493 124" fill="none" stroke="#64748b" stroke-width="1.4" stroke-dasharray="7 6"/>
+  <polygon points="493,124 487,136 499,136" fill="#64748b"/>
+</svg>

--- a/docs/mkdocs/en/promptiter.md
+++ b/docs/mkdocs/en/promptiter.md
@@ -1,68 +1,111 @@
 # PromptIter Guide
 
-As evaluation capabilities mature, prompt optimization is no longer a matter of manually rewriting one prompt and checking a few examples subjectively. It needs fixed evaluation sets, fixed metrics, and stable acceptance criteria so that optimization results remain comparable and regressible over time.
+When an Agent's prompts carry business rules, version risk comes not only from visible failures but also from behavior drift after rewrites. A manual rewrite may fix one failed sample and at the same time lower output quality in other scenarios. A higher training-set score alone cannot prove that a candidate version is acceptable. Validation-set evaluation and the acceptance policy together form the acceptance decision for a candidate version. PromptIter organizes training sets, validation sets, structure snapshots, and execution traces into a reproducible prompt iteration workflow, and persists each round's candidate version, score, patch, and stop reason as a result snapshot.
 
-Evaluation measures the quality of the current version. PromptIter continuously produces better prompt versions by separating training sets from validation sets. It is built on top of Evaluation, reuses evaluation sets, evaluation metrics, and evaluator infrastructure, and adds capabilities such as train/validation separation, multi-round optimization, acceptance policy, stop policy, asynchronous run management, and HTTP APIs.
+tRPC-Agent-Go provides PromptIter on top of the Evaluation capability to move Agent prompt optimization from manual rewriting to an evaluation-constrained automated iteration workflow. PromptIter centers on training sets, validation sets, and evaluation metrics. It backpropagates failure signals exposed by the training set along the execution trace, converts them into candidate prompts through text-gradient aggregation and optimization patch generation, and then lets validation-set evaluation and the acceptance policy decide whether the candidate prompt enters later rounds. Each run records candidate prompts, validation results, acceptance decisions, and stop reasons, so different prompt versions can be compared, reviewed, and traced under fixed evaluation criteria. It supports synchronous runs, asynchronous runs, HTTP iteration services, and multi-node iteration.
 
-If you are not yet familiar with evaluation sets, evaluation metrics, and evaluation services, read the [Evaluation Guide](evaluation.md) first.
+## Background
+
+Prompt optimization in the experiment phase usually relies on manual judgment and rewriting. Developers adjust prompts according to scattered failed samples and then validate them with a small number of cases. This works for exploration, but it is hard to use for continuous delivery. A single prompt change may affect task understanding, tool selection, and the content, structure, and expression of the final answer at the same time. Improvement on one sample is only a local signal and cannot replace regression validation across multiple scenarios.
+
+After an Agent enters a business workflow, common risks in prompt optimization can be divided into four categories.
+
+1. The optimization objective may drift. When manually fixing a single failed sample, a developer may add constraints that are too narrow. If those constraints only cover the current sample, output quality on other samples may drop.
+2. Training signals and acceptance signals may be mixed. If the same failed samples are used both to generate modification suggestions and to evaluate candidate prompts, overfitting risk is amplified. A more rigorous approach is to let the training set expose problems and generate optimization signals, and let the validation set provide the validation score needed for candidate-prompt acceptance.
+3. Failure signals are hard to attribute to specific nodes. For a single Agent, the issue may come from that Agent's prompt. For graph orchestration and multi-Agent systems, the issue may come from planning, retrieval, draft generation, editing review, or any other step. Looking only at the final answer makes it hard to decide which node should receive the failure signal.
+4. Prompt versions lack structured records. Manually replacing prompt text can complete one change, but it is hard to trace which failure signals produced the candidate prompt, which positions were modified, and why the candidate was accepted or rejected.
+
+PromptIter handles these risks through separate workflow stages. Evaluation provides reproducible evaluation inputs and metric outputs. The structure snapshot describes the static composition of the target Agent, including nodes, edges, and iterable content associated with nodes. The execution trace records the actual dynamic step path for the current run. Backpropagation attribution, text-gradient aggregation, and optimization patch generation gradually convert failure signals into candidate patches. Validation-set evaluation and the acceptance policy together form the acceptance decision for the candidate prompt.
+
+## Industry Survey
+
+Prompt optimization is not just direct rewriting of prompt text. A more stable approach is to define evaluation criteria first, extract modification directions from failed samples, generate candidate prompts, and then validate whether candidates meet acceptance conditions on independent samples. The industry has explored several methods in this direction.
+
+[ProTeGi](https://arxiv.org/abs/2305.03495) focuses on automatic search for a single task prompt. It analogizes gradient descent in numerical optimization to natural-language scenarios. The process first runs the current prompt and collects error samples, then asks a model to summarize the prompt issues exposed by those errors and form natural-language gradients. It then generates multiple candidate prompts from those gradients, keeps higher-scoring candidates in each round, continues the search, and finally selects the version with better evaluation performance.
+
+[TextGrad](https://arxiv.org/abs/2406.07496) focuses on optimizing text variables in complex AI systems. It represents the system as a computation graph. Variables in the graph can be prompts, code snippets, or other text objects. After forward execution, feedback is produced by the objective function, evaluator, or downstream loss signal. An LLM writes the feedback as natural-language gradients, which are then backpropagated along the computation graph to related variables.
+
+[DSPy](https://arxiv.org/abs/2310.03714) focuses on processing pipelines composed of multiple language-model calls. Developers describe module inputs and outputs with signatures, organize module calls with programs, and let the compiler optimize learnable parts such as examples and prompts around given metrics.
+
+These methods show that prompt optimization can form an automated workflow around evaluation feedback, candidate generation, and metric validation. From a business implementation perspective, however, ProTeGi mainly targets single-prompt search and is hard to apply directly to multi-node Agent scenarios. TextGrad provides a general abstraction for text-variable optimization, but engineering implementation such as evaluation asset management, candidate-version acceptance, and run-result tracing still needs to be built separately. DSPy requires language-model call flows to be reorganized around its modules and signatures, which brings a high migration cost for existing Agent projects.
+
+tRPC-Agent-Go uses PromptIter to bring this type of optimization workflow into existing Agent projects. It organizes training-set evaluation feedback, backpropagation attribution, text-gradient aggregation, optimization patch generation, candidate-prompt construction, validation-set acceptance decisions, and result tracing into a closed loop.
 
 ## Quick Start
 
-This section provides a minimal example so you can complete one PromptIter run first, then continue to the core concepts and usage sections.
+This section uses `examples/evaluation/promptiter/syncrun` to show the minimal integration path for synchronous prompt iteration. See the complete example at [examples/evaluation/promptiter/syncrun](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/promptiter/syncrun).
 
-PromptIter currently provides three examples:
+The example code covers the following integration modes.
 
-- [examples/evaluation/promptiter/syncrun](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/promptiter/syncrun), which runs synchronous optimization through `engine.Run(...)`.
-- [examples/evaluation/promptiter/asyncrun](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/promptiter/asyncrun), which manages asynchronous runs through `manager.Start` and `manager.Get`.
-- [examples/evaluation/promptiter/server](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/promptiter/server), which exposes PromptIter through the HTTP service module.
-
-This section uses `syncrun` to show the minimal integration path.
+- [examples/evaluation/promptiter/syncrun](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/promptiter/syncrun) demonstrates synchronous prompt iteration.
+- [examples/evaluation/promptiter/asyncrun](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/promptiter/asyncrun) demonstrates asynchronous prompt iteration.
+- [examples/evaluation/promptiter/server](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/promptiter/server) demonstrates HTTP integration for prompt iteration.
+- [examples/evaluation/promptiter/multinode](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/promptiter/multinode) demonstrates multi-node prompt iteration.
 
 ### Environment Setup
 
-- Go 1.24+
-- Accessible OpenAI-compatible model service
-- Prepared train EvalSet file, validation EvalSet file, and metric file
+Prepare three types of resources before running the example.
 
-Set model service environment variables before running.
+- An accessible OpenAI-compatible model service.
+- Training set, validation set, and metric files.
+- Model names for the target Agent, judge, and PromptIter worker components.
+
+The example reads the model service endpoint and key from environment variables.
 
 ```bash
+# Set the model service key.
 export OPENAI_API_KEY="sk-xxx"
+# This is optional. If it is not set, the example uses the OpenAI-compatible default endpoint.
 export OPENAI_BASE_URL="https://api.openai.com/v1"
 ```
 
-### Synchronous Optimization Example With Local Files
+### Target Agent
 
-This example runs PromptIter with local files. Full source is available at [examples/evaluation/promptiter/syncrun](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/promptiter/syncrun).
+The target Agent in the `syncrun` example is named `candidate`. It is an LLMAgent created with `llmagent.New`. The example creates this Agent through `newCandidateAgent` and passes the initial prompt as `instruction`. Later runs limit the modification target to the `instruction` of `candidate`.
 
-If you want to complete one run and inspect the result first, go to the example directory and execute `go run .`. The code snippets in this section only explain how PromptIter dependencies are assembled; they are not intended to be copied as a full application from scratch.
+The default initial prompt is `Write a Chinese sports game recap`. This initial prompt demonstrates how PromptIter generates candidate patches from training-set failure signals and accepts or rejects candidate prompts round by round according to validation-set evaluation results and the acceptance policy.
 
-The three core snippets below are used to prepare evaluation dependencies, construct the Engine, and execute one run.
-
-#### Agent And Evaluator Snippet
-
-This part prepares PromptIter runtime dependencies. It mainly does three things:
-
-- Create the target candidate Agent and the judge Agent used during evaluation.
-- Create a Runner for the candidate Agent and the judge Agent.
-- Reuse the Evaluation stack to create an `AgentEvaluator`, which PromptIter uses in both train and validation phases.
-
-The example `candidateAgent` is a normal `llmagent`. The optimized target is its prompt content. A minimal construction looks like this:
+The target Agent and Runner are created as follows.
 
 ```go
-import "trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
-
-candidateAgent, err := llmagent.New(
-	candidateAgentName,
-	llmagent.WithModel(candidateModel),
-	llmagent.WithInstruction("You are a helpful assistant."),
+import (
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
 )
-if err != nil {
-	return err
+
+// newCandidateAgent creates the target Agent.
+func newCandidateAgent(m model.Model) (agent.Agent, error) {
+	// generationConfig fixes the generation parameters of the target Agent.
+	generationConfig := model.GenerationConfig{
+		// MaxTokens keeps enough output space for a sports recap.
+		MaxTokens: intPtr(32768),
+		// Temperature reduces random fluctuation on the same evaluation case.
+		Temperature: floatPtr(0.0),
+		// Stream disables streaming output so Evaluation can collect the full answer.
+		Stream: false,
+	}
+	return llmagent.New(
+		"candidate",
+		llmagent.WithModel(m),
+		// PromptIter iterates this instruction in the current run.
+		llmagent.WithInstruction("Write a Chinese sports game recap"),
+		llmagent.WithGenerationConfig(generationConfig),
+	), nil
 }
+
+candidateAgent, err := newCandidateAgent(candidateModel)
+if err != nil {
+	return nil, fmt.Errorf("create candidate agent: %w", err)
+}
+// Runner is the entry point for Evaluation to execute the target Agent.
+candidateRunner := runner.NewRunner("promptiter-nba-commentary-candidate", candidateAgent)
 ```
 
-The example `judgeAgent` is also a normal Agent. The snippet below shows how to create Runners for `candidateAgent` and `judgeAgent`, then assemble an `AgentEvaluator` on top of the Evaluation stack.
+### Construct AgentEvaluator
+
+The evaluation stage needs to run the target Agent and calculate scores with the training set, validation set, and metric file. The example uses `candidateRunner` as the execution entry point for the target Agent and creates an `AgentEvaluator` through `evaluation.New`. When LLM Judge metrics are used, a Judge Runner must also be provided. The example then creates local `EvalSetManager`, `MetricManager`, and `EvalResultManager` instances to read evaluation sets, read metrics, and save evaluation results.
 
 ```go
 import (
@@ -71,30 +114,26 @@ import (
 	evalresultlocal "trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult/local"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
 	evalsetlocal "trpc.group/trpc-go/trpc-agent-go/evaluation/evalset/local"
-	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/registry"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
 	metriclocal "trpc.group/trpc-go/trpc-agent-go/evaluation/metric/local"
 	"trpc.group/trpc-go/trpc-agent-go/runner"
 )
 
-candidateRunner := runner.NewRunner(candidateAppName, candidateAgent)
+// A judge Runner is required when LLM Judge metrics are used.
 judgeRunner := runner.NewRunner(judgeAppName, judgeAgent)
 
-evalSetManager := evalsetlocal.New(evalset.WithBaseDir(cfg.DataDir))
-metricManager := metriclocal.New(
-	metric.WithBaseDir(cfg.DataDir),
-	metric.WithLocator(&sharedMetricLocator{metricFileID: sharedMetricFileID}),
-)
-evalResultManager := evalresultlocal.New(evalresult.WithBaseDir(cfg.OutputDir))
-registry := registry.New()
+// Evaluation sets, metrics, and evaluation results are managed by their managers.
+evalSetManager := evalsetlocal.New(evalset.WithBaseDir("./data"))
+metricManager := metriclocal.New(metric.WithBaseDir("./data"))
+evalResultManager := evalresultlocal.New(evalresult.WithBaseDir("./output"))
 
+// AgentEvaluator runs training-set and validation-set evaluation.
 agentEvaluator, err := evaluation.New(
 	appName,
 	candidateRunner,
 	evaluation.WithEvalSetManager(evalSetManager),
 	evaluation.WithMetricManager(metricManager),
 	evaluation.WithEvalResultManager(evalResultManager),
-	evaluation.WithRegistry(registry),
 	evaluation.WithJudgeRunner(judgeRunner),
 )
 if err != nil {
@@ -102,9 +141,92 @@ if err != nil {
 }
 ```
 
-#### Engine Construction
+### Evaluation Files
 
-This part creates a Runner and an instance for each workflow component: backwarder, aggregator, and optimizer. Then it assembles those instances together with `candidateAgent` and `AgentEvaluator` into an `Engine`.
+The local `EvalSetManager` and `MetricManager` read evaluation sets and metric files from the example data directory. PromptIter follows the local file organization used by Evaluation. One PromptIter run specifies the training set and validation set through evaluation set IDs. The complete example reuses the same metric file, which is an Evaluation file-organization detail and is not expanded here.
+
+```text
+# data is the example evaluation file directory.
+data/
+  promptiter-nba-commentary-app/
+    nba-commentary-train.evalset.json
+    nba-commentary-validation.evalset.json
+    sports-commentary.metrics.json
+```
+
+These three types of files have different responsibilities.
+
+- `nba-commentary-train.evalset.json` is the training set, used to produce failure signals and optimization signals.
+- `nba-commentary-validation.evalset.json` is the validation set, used to provide evaluation results required for acceptance decisions.
+- `sports-commentary.metrics.json` is the metric file, used to define scoring rules shared by the training set and validation set.
+
+The training set and validation set in this example use the same evaluation-case structure. `userContent.content` is the input to the target Agent and contains structured game JSON. `finalResponse.content` is the reference output used during evaluation and contains a prewritten Chinese sports recap.
+
+```json
+{
+  "evalId": "train_01_nba_nuggets_blowout",
+  "conversation": [
+    {
+      "userContent": {
+        "role": "user",
+        "content": "{\"sport\":\"basketball\",\"league\":\"NBA\",\"teams\":{\"home\":{\"name\":\"Denver Nuggets\",\"score\":128},\"away\":{\"name\":\"Portland Trail Blazers\",\"score\":104}},\"recapAngle\":\"Denver's perimeter shooting and bench depth opened the game early, so the starters did not need to stay late in the fourth quarter\"}"
+      },
+      "finalResponse": {
+        "role": "assistant",
+        "content": "Nuggets beat Trail Blazers 128-104 as 18 threes and 52 bench points let starters finish early\n\nOn January 12, 2026, the Denver Nuggets defeated the Portland Trail Blazers 128-104 at Ball Arena..."
+      }
+    }
+  ]
+}
+```
+
+During evaluation, Evaluation sends `userContent.content` to the target Agent and calculates metrics by comparing the actual output of the target Agent with `finalResponse.content`. Fixed reference outputs keep each run aligned with the same evaluation baseline and avoid extra fluctuation from online reference-answer generation.
+
+The metric file contains two metrics. The key fields are shown below.
+
+```json
+[
+  {
+    "metricName": "final_response_avg_score",
+    "threshold": 1.0,
+    "criterion": {
+      "finalResponse": {
+        "text": {
+          "length": {
+            "min": 350,
+            "max": 850
+          },
+          "matchStrategy": "skip"
+        }
+      }
+    }
+  },
+  {
+    "metricName": "llm_rubric_critic",
+    "threshold": 0.98,
+    "criterion": {
+      "llmJudge": {
+        "rubrics": [
+          {
+            "id": "source_grounding",
+            "description": "The recap must be fully grounded in the user input.",
+            "type": "FINAL_RESPONSE_QUALITY",
+            "content": {
+              "text": "The actual recap may only use facts supported by the user input and reference recap."
+            }
+          }
+        ]
+      }
+    }
+  }
+]
+```
+
+`final_response_avg_score` is the final-response evaluator provided by Evaluation. The example uses it to constrain recap length. `llm_rubric_critic` is an LLM Judge metric. The example uses it together with the reference recap and rubrics to check factual grounding, the main storyline, decisive process, numbers, title, data interpretation, and the quality of Chinese sports copy.
+
+### Construct Engine
+
+When constructing the PromptIter `Engine`, provide the target Agent and `AgentEvaluator` first. The target Agent is used to export the structure snapshot, and `AgentEvaluator` is used to run training-set and validation-set evaluation. Candidate patches also depend on `Backwarder`, `Aggregator`, and `Optimizer`. `Backwarder` performs backpropagation attribution and converts training-set failure signals into text gradients, that is, modification directions pointing to related steps and prompts. `Aggregator` aggregates text gradients by merging multiple text gradients on the same prompt to be modified. `Optimizer` generates optimization patches by producing a candidate patch for that prompt from the aggregated result.
 
 ```go
 import (
@@ -115,23 +237,30 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/runner"
 )
 
+// backwarderRunner calls the model to perform backpropagation attribution.
 backwarderRunner := runner.NewRunner(backwarderAppName, backwarderAgent)
+// aggregatorRunner calls the model to perform text-gradient aggregation.
 aggregatorRunner := runner.NewRunner(aggregatorAppName, aggregatorAgent)
+// optimizerRunner calls the model to perform optimization patch generation.
 optimizerRunner := runner.NewRunner(optimizerAppName, optimizerAgent)
 
+// Backwarder performs backpropagation attribution.
 backwarderInstance, err := backwarder.New(ctx, backwarderRunner)
 if err != nil {
 	return err
 }
+// Aggregator performs text-gradient aggregation.
 aggregatorInstance, err := aggregator.New(ctx, aggregatorRunner)
 if err != nil {
 	return err
 }
+// Optimizer performs optimization patch generation.
 optimizerInstance, err := optimizer.New(ctx, optimizerRunner)
 if err != nil {
 	return err
 }
 
+// Engine binds the target Agent, evaluator, and three PromptIter worker components.
 engineInstance, err := engine.New(
 	ctx,
 	candidateAgent,
@@ -145,9 +274,9 @@ if err != nil {
 }
 ```
 
-#### Build The Request And Execute
+### Construct RunRequest
 
-This snippet constructs `RunRequest`, including train and validation sets, evaluation execution options, acceptance policy, stop policy, and target editable positions, then calls `engine.Run(...)` to execute one multi-round optimization run.
+`RunRequest` specifies the training set, validation set, iteration target, maximum rounds, acceptance policy, and stop policy for one PromptIter run.
 
 ```go
 import (
@@ -155,292 +284,859 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
 )
 
+// targetScore is the target validation score for this run.
 targetScore := 1.0
-targetSurfaceID := astructure.SurfaceID(candidateAgentName, astructure.SurfaceTypeInstruction)
+// targetInstructionID points to the instruction of the candidate Agent. Its value is candidate#instruction.
+targetInstructionID := astructure.SurfaceID("candidate", astructure.SurfaceTypeInstruction)
 
 result, err := engineInstance.Run(ctx, &engine.RunRequest{
+	// Train specifies the training set that produces optimization signals.
 	Train: []engine.EvalSetInput{
 		{
-			EvalSetID: "nba-commentary-train",
+			// EvalSetID points to the training set used to produce optimization signals.
+			EvalSetID: trainEvalSetID,
 		},
 	},
+	// Validation specifies the validation set used for acceptance decisions.
 	Validation: []engine.EvalSetInput{
 		{
-			EvalSetID: "nba-commentary-validation",
+			// EvalSetID points to the validation set used for acceptance decisions.
+			EvalSetID: validationEvalSetID,
 		},
 	},
+	// Training-set and validation-set evaluation run concurrently by evaluation case.
 	EvaluationOptions: engine.EvaluationOptions{
-		EvalCaseParallelism:               8,
-		EvalCaseParallelInferenceEnabled:  true,
+		// EvalCaseParallelism limits evaluation-case concurrency.
+		EvalCaseParallelism: 16,
+		// EvalCaseParallelInferenceEnabled enables concurrent inference for the target Agent.
+		EvalCaseParallelInferenceEnabled: true,
+		// EvalCaseParallelEvaluationEnabled enables concurrent metric calculation.
 		EvalCaseParallelEvaluationEnabled: true,
 	},
+	// Backpropagation attribution processes evaluation cases sequentially by default.
+	BackwardOptions: engine.BackwardOptions{
+		// CaseParallelismEnabled controls whether training-set evaluation cases are processed concurrently.
+		CaseParallelismEnabled: false,
+		// CaseParallelism is the evaluation-case concurrency limit after concurrency is enabled.
+		CaseParallelism: 16,
+	},
+	// Text-gradient aggregation runs concurrently by iteration target.
+	AggregationOptions: engine.AggregationOptions{
+		// SurfaceParallelismEnabled controls whether multiple iteration targets are processed concurrently.
+		SurfaceParallelismEnabled: true,
+		// SurfaceParallelism is the iteration-target concurrency limit.
+		SurfaceParallelism: 16,
+	},
+	// Optimization patch generation runs concurrently by iteration target.
+	OptimizerOptions: engine.OptimizerOptions{
+		// SurfaceParallelismEnabled controls whether patches are generated concurrently for multiple iteration targets.
+		SurfaceParallelismEnabled: true,
+		// SurfaceParallelism is the iteration-target concurrency limit.
+		SurfaceParallelism: 16,
+	},
+	// A candidate prompt must improve over the current baseline prompt by at least 0.01 points.
 	AcceptancePolicy: engine.AcceptancePolicy{
-		MinScoreGain: 0.005,
+		// MinScoreGain is the minimum validation-score gain required to accept a candidate prompt.
+		MinScoreGain: 0.01,
 	},
+	// The run stops when it reaches max rounds, consecutive non-accepted rounds, or the target score.
+	MaxRounds: 4,
 	StopPolicy: engine.StopPolicy{
-		MaxRoundsWithoutAcceptance: 5,
-		TargetScore:                &targetScore,
+		// MaxRoundsWithoutAcceptance limits consecutive rounds without accepting a candidate prompt.
+		MaxRoundsWithoutAcceptance: 3,
+		// TargetScore is the target validation score after which the run can stop.
+		TargetScore: &targetScore,
 	},
-	MaxRounds:        4,
-	TargetSurfaceIDs: []string{targetSurfaceID},
+	// The iteration target of this run is the instruction of the candidate Agent.
+	TargetSurfaceIDs: []string{targetInstructionID},
 })
 if err != nil {
 	return err
 }
 ```
 
-#### Evaluation Files
+In the example, `TargetSurfaceIDs` is set to `candidate#instruction`, so the iteration target of this run is the instruction of the target Agent. When integrating multi-Agent or graph orchestration scenarios, first use `engine.Describe(ctx)` or the HTTP `/structure` endpoint to get the structure snapshot, then select targets from the returned result. This avoids hard-coding target IDs in business code.
 
-PromptIter uses the same evaluation asset layout as Evaluation, except that one run uses both train and validation sets. The example directory looks like this:
-
-```bash
-data/
-  promptiter-nba-commentary-app/
-    nba-commentary-train.evalset.json
-    nba-commentary-validation.evalset.json
-    sports-commentary.metrics.json
-```
-
-The responsibilities of these files are:
-
-- `nba-commentary-train.evalset.json` acts as the training set and produces optimization signals and patch suggestions. In each round, PromptIter first performs forward inference and metric evaluation on the training set, then extracts losses from failed cases, runs backward propagation, and aggregates gradients.
-- `nba-commentary-validation.evalset.json` acts as the validation set and decides whether the current modification should be accepted. The training set provides optimization signals, while the validation set decides whether the modification is truly better. These two roles are different and should not be mixed.
-- `sports-commentary.metrics.json` acts as the metric file and defines evaluation metrics. PromptIter directly reuses Evaluation metrics. The example uses `llm_rubric_reference_critic` and `final_response_length_compliance` by default. The former measures alignment with the reference answer, and the latter enforces response length. The example directly uses static reference answers stored in the EvalSet for reference-based evaluation.
-
-#### Execute The Run
+### Execute Synchronous Iteration
 
 ```bash
-cd examples/evaluation/promptiter/syncrun
+# Set the model service key.
 export OPENAI_API_KEY="sk-xxx"
+# This is optional. If it is not set, the example uses the OpenAI-compatible default endpoint.
 export OPENAI_BASE_URL="https://api.openai.com/v1"
-go run .
+
+# Run the synchronous prompt iteration example.
+go -C examples/evaluation run ./promptiter/syncrun \
+  -data-dir ./promptiter/syncrun/data \
+  -output-dir ./promptiter/syncrun/output \
+  -model "deepseek-v3.2" \
+  -judge-model "gpt-5.2" \
+  -worker-model "gpt-5.2"
 ```
 
-#### View The Result
+The example enables evaluation-case-level concurrent inference and concurrent evaluation for the training set and validation set by default. It also enables iteration-target-level concurrency for text-gradient aggregation and optimization patch generation by default. Backpropagation attribution processes evaluation cases sequentially by default. If the model service limits concurrency, reduce `-eval-case-parallelism`, `-aggregation-parallelism`, or `-optimizer-parallelism`, or disable the corresponding concurrency switch.
 
-After the run completes, results are mainly inspected in two places:
+### View Results
 
-- Terminal output, which shows the initial prompt, the final accepted prompt, per-round scores, and the stop reason.
-- Output directory, which stores per-round train and validation evaluation results together with intermediate artifacts.
+After synchronous prompt iteration finishes, `engine.Run(...)` returns a `RunResult`. The example prints the structure ID, iteration target, initial prompt, final accepted baseline prompt, validation score, and each round's decision in the terminal.
 
-For synchronous runs, `engine.Run(...)` returns `RunResult` directly. Asynchronous runs and HTTP APIs also use `RunResult` as the result structure.
+Example output is shown below.
+
+| Output item | Example value |
+| --- | --- |
+| Initial validation score | `0.49` |
+| Final accepted validation score | `0.90` |
+| Rounds executed | `4` |
+| Round 1 | train `0.35`, validation `0.85`, accepted `true`, delta `0.36` |
+| Round 2 | train `0.83`, validation `0.90`, accepted `true`, delta `0.05` |
+| Round 3 | train `0.87`, validation `0.81`, accepted `false`, delta `-0.09` |
+| Round 4 | train `0.89`, validation `0.80`, accepted `false`, delta `-0.10` |
+
+This output reflects PromptIter's acceptance semantics. The candidates in rounds 1 and 2 pass the acceptance decision, so the current baseline is gradually updated to the round-2 candidate prompt. Although rounds 3 and 4 have high training-set scores, their validation scores do not exceed the validation score of the current baseline prompt, so they are not accepted. The final baseline remains the round-2 candidate prompt.
 
 ## Core Concepts
 
-PromptIter adds a multi-round optimization loop on top of Evaluation. Its core inputs include train sets, validation sets, target editable positions, and run policies. Its core output is the result of one run, `RunResult`.
+As shown below, PromptIter starts iterating from the initial prompt. At run start, the initial prompt forms the initial baseline and is used as the current baseline of the first round. Each round generates candidate prompts from training-set failure signals, then uses validation-set evaluation and the acceptance policy to decide whether a candidate prompt is better than the current baseline. Only after a candidate prompt passes the acceptance decision is the current baseline updated for the next round. If the candidate is not accepted, the current baseline remains unchanged. Iteration input is described by `RunRequest`, and iteration output is `RunResult`.
 
-`Engine` executes the entire optimization flow. Both train evaluation and validation evaluation include two sub-steps: forward inference and metric evaluation. The diagram below shows the order of stages and the loop back to the next round.
+![overview.svg](../assets/img/promptiter/overview.svg)
 
-```mermaid
-flowchart TB
-    A[RunRequest] --> B[Baseline Validation]
-    B --> C[Train Evaluation]
-    C --> D[Backward Propagation]
-    D --> E[Gradient Aggregation]
-    E --> F[Optimizer Generates Patch]
-    F --> G[New Candidate Version]
-    G --> H[Validation Evaluation]
-    H --> I[Acceptance Decision]
-    I --> J[Stop Decision]
-    J --> K[RunResult]
-    J -->|Continue Next Round| C
-```
+- **Run Request** describes the input of one iteration run, including training sets, validation sets, iteration targets, maximum rounds, acceptance policy, and stop policy.
+- **Baseline Validation** runs validation-set evaluation on the initial prompt and records the validation score of the initial baseline.
+- **Train Evaluation** runs training-set evaluation on the current baseline prompt and produces failure signals needed by later optimization stages. The training set is not responsible for candidate-prompt acceptance.
+- **Backward** performs backpropagation attribution with training-set failure reasons and dynamic execution traces, associates failure signals with target prompts, and generates text gradients.
+- **Aggregate** aggregates text gradients by target prompt and forms an aggregated gradient for that target.
+- **Optimize** generates candidate patches from aggregated gradients.
+- **Candidate Profile** represents the prompt snapshot produced by applying candidate patches to the current baseline prompt. It is the input of validation-set evaluation.
+- **Validation Evaluation** runs validation-set evaluation on the candidate prompt snapshot and outputs validation scores and metric details.
+- **Accept Policy** compares the candidate prompt snapshot with the validation result of the current baseline and decides whether to update the current baseline.
+- **Stop Policy** decides whether to end the current run according to run state. If no stop condition is met, the workflow returns to training-set evaluation and enters the next round.
+- **Run Result** summarizes the structure snapshot, initial baseline validation, training evaluation, failure signals, backpropagation attribution, text-gradient aggregation, candidate patches, candidate prompt snapshot, validation evaluation, and decision results of the current run.
 
-One PromptIter run usually unfolds in the following order:
+One PromptIter run usually contains these steps.
 
-1. Read `RunRequest` to determine the train set, validation set, target editable positions, and run policies.
-2. Execute one baseline validation on the current candidate version.
-3. Run forward inference and metric evaluation on the training set, then extract losses from failed cases.
-4. Send the losses to the backwarder and aggregator to obtain aggregated optimization signals.
-5. Let the optimizer generate patch suggestions from the aggregated optimization signals and produce a new candidate version.
-6. Run forward inference and metric evaluation on the validation set for the new candidate version.
-7. Decide whether to accept the current modification based on the acceptance policy, and decide whether to stop based on the stop policy.
-8. If no stop condition is triggered, the next round starts again from train evaluation.
+1. PromptIter confirms the training set, validation set, and prompts allowed to be iterated according to `RunRequest`.
+2. Train Evaluation runs training-set evaluation on the current baseline prompt and extracts failure signals.
+3. Backward generates text gradients for target prompts from failure reasons and the dynamic execution trace.
+4. Aggregate merges text gradients on the same target prompt.
+5. Optimize generates candidate patches from aggregated gradients and forms a candidate Profile.
+6. Validation Evaluation runs validation-set evaluation on the candidate Profile.
+7. Accept Policy decides whether to accept the candidate Profile as the new current baseline.
+8. Stop Policy decides whether the run should end. If not, the workflow enters the next round.
+9. PromptIter writes the process and results into `RunResult`.
 
-PromptIter is a multi-round flow composed of evaluation, attribution, aggregation, optimizer-generated patch suggestions, acceptance decisions, and stop decisions. The following sections explain evaluation data, target editable positions, candidate versions, patch suggestions, run inputs and outputs, and access patterns.
+## Usage
 
-### Evaluation Stack
+### Evaluation System
 
-PromptIter is built directly on top of Evaluation and reuses its evaluation data and execution flow.
+PromptIter reuses Evaluation assets and execution capabilities.
 
-- `EvalSet` defines evaluation cases in train and validation sets.
-- `EvalMetric` defines the scoring rules of each metric.
-- `Evaluator` runs the scoring logic for one metric.
-- `EvalResult` stores the detailed result of each evaluation run.
-- `AgentEvaluator` orchestrates one complete evaluation, loads evaluation sets, metrics, and evaluators, and returns the evaluation result.
+- `EvalSet` describes evaluation cases in the training set and validation set.
+- `EvalMetric` describes each metric and the score threshold that determines whether it passes.
+- `Evaluator` executes scoring logic for one metric.
+- `AgentEvaluator` organizes one evaluation, reads the evaluation set and metrics, invokes evaluators through the registry, and returns aggregated results.
+- `EvalResultManager` saves each evaluation result. In local mode, it writes local files.
 
-In PromptIter, both train evaluation and validation evaluation are executed through `AgentEvaluator`. The difference is that train evaluation results continue into loss extraction, backward propagation, and gradient aggregation, while validation evaluation results are mainly used for acceptance and stop decisions.
+In PromptIter, training-set evaluation results are used to extract optimization signals. The extracted signals then enter backpropagation attribution, text-gradient aggregation, and optimization patch generation. Validation-set evaluation results are used to decide whether a candidate prompt satisfies the acceptance policy and to provide the current baseline validation score for the stop policy.
 
-For more detail about evaluation sets, evaluation metrics, evaluators, and evaluation results, see [EvalSet](evaluation.md#evaluation-set-evalset), [EvalMetric](evaluation.md#evaluation-metric-evalmetric), [Evaluator](evaluation.md#evaluator), [EvalResult](evaluation.md#evaluation-result-evalresult), and [AgentEvaluator](evaluation.md#agentevaluator).
+### Train/Validation Separation
 
-### Train And Validation Sets
-
-PromptIter uses two kinds of evaluation sets in one run:
-
-- The training set generates optimization signals.
-- The validation set determines whether the current modification should be accepted.
-
-A training score can be high while the validation set still rejects the change. A gain on the training set only means that the current modification provides a stronger optimization signal. Whether the change is accepted is still determined by validation results.
-
-### Structure Snapshot And Surface
-
-A structure snapshot is the exported static structure of an Agent. It contains nodes, edges, and editable `surface`s. A `Surface` is a stable editable baseline field on a node, such as `instruction`, `model`, `tool`, or `skill`. Every surface has a stable `SurfaceID`, and PromptIter uses `TargetSurfaceIDs` to specify which editable positions may be optimized in the current run.
-
-PromptIter reads the structure snapshot first, then finds the surfaces that are allowed to be optimized. The recommended approach is to obtain editable positions from the structure snapshot and then write the targets into `TargetSurfaceIDs`. Do not assume that every Agent has only one instruction surface, and do not hardcode fields outside the structure in business code.
-
-For more detail about structure export and runtime surface overrides, see [Static Structure Export](agent.md#static-structure-export) and [Override Runtime Surface By `nodeID`](agent.md#override-runtime-surface-by-nodeid).
-
-### Execution Trace
-
-Execution Trace records the execution steps that actually happened in one evaluation and the real dependency relations between those steps. Here a step means one execution record of a static node in one concrete run. The same node can be executed multiple times across branches, rounds, or cycles, so one Trace may contain multiple steps that share the same `NodeID`. It describes one concrete run as it happened.
-
-Each step usually carries the following information:
-
-- `NodeID`, which identifies the corresponding static node.
-- `PredecessorStepIDs`, which identifies the direct predecessor steps in the current run.
-- `Input` and `Output`, which record the input and output snapshots observed by that step.
-- `Error`, which records the runtime error when the step fails.
-
-PromptIter uses Execution Trace to locate which steps contain problems and to decide along which path losses and gradients should propagate.
-
-### Backward Propagation
-
-After train evaluation produces failed samples and an Execution Trace, PromptIter enters the backward propagation stage. Backward propagation converts failed samples into propagatable attribution signals. It combines step input/output snapshots, predecessor steps, and editable positions to determine where the problem first appears and whether the issue needs to continue propagating upstream.
-
-### Gradient Aggregation
-
-Gradient aggregation merges local attribution signals from multiple samples and multiple steps by `SurfaceID`, producing a unified optimization signal for one editable position. This stage turns local and scattered failure signals into stable input for the next stage.
-
-### Optimization
-
-Optimization generates patch suggestions from the current baseline value of one editable position together with the aggregated optimization signal, and ultimately forms a new candidate version. Evaluation discovers problems, backward propagation attributes and propagates them, gradient aggregation consolidates signals, and optimization generates new patch suggestions.
-
-### Working Example
-
-The following example uses a realistic multi-stage workflow to connect the static structure graph, execution trace, evaluation, backward propagation, gradient aggregation, and optimization. The example represents a common workflow pattern: `planner` decides the processing strategy, `retrieve` fetches external information, `compose` drafts an answer, and `reviewer` performs unified review. If the review decides the output still needs revision, control goes to `rewrite` and then back to `planner`; otherwise it goes directly to `finalize`.
-
-The static structure graph may look like this:
-
-```mermaid
-flowchart LR
-    planner[planner]
-    retrieve[retrieve]
-    compose[compose]
-    reviewer[reviewer]
-    rewrite[rewrite]
-    finalize[finalize]
-
-    planner --> retrieve
-    planner --> compose
-    retrieve --> reviewer
-    compose --> reviewer
-    reviewer -->|need_revision| rewrite
-    reviewer --> finalize
-    rewrite --> planner
-```
-
-This graph describes the stable structure of the workflow:
-
-- `planner` decomposes the task, so it fans out into `retrieve` and `compose`.
-- `reviewer` is a fan-in node, meaning it may depend on multiple upstream branches at the same time.
-- `reviewer -> rewrite` is a conditional edge, meaning the flow returns upstream when revision is needed.
-- `rewrite -> planner` means the graph can loop back upstream and form a cycle.
-- Editable positions are attached to static nodes, such as `planner#instruction` and `reviewer#instruction`.
-
-The execution trace of one evaluation run may look like this:
-
-```mermaid
-flowchart LR
-    step1["step_1 planner"]
-    step2["step_2 retrieve"]
-    step3["step_3 compose"]
-    step4["step_4 reviewer"]
-    step5["step_5 rewrite"]
-    step6["step_6 planner"]
-    step7["step_7 retrieve"]
-    step8["step_8 compose"]
-    step9["step_9 reviewer"]
-    step10["step_10 finalize"]
-
-    step1 --> step2
-    step1 --> step3
-    step2 --> step4
-    step3 --> step4
-    step4 --> step5
-    step5 --> step6
-    step6 --> step7
-    step6 --> step8
-    step7 --> step9
-    step8 --> step9
-    step9 --> step10
-```
-
-This trace shows the steps that actually happened in this run:
-
-- `planner` triggered the downstream branches `retrieve` and `compose` twice. This is fan-out.
-- `reviewer` depended on both `retrieve` and `compose` twice. This is fan-in.
-- The first time the flow reached `reviewer`, it went to `rewrite` and then back to `planner`. This is one loop.
-- The second time the flow reached `reviewer`, it went to `finalize`, which means the run did not re-enter the revision branch.
-
-This example can be read in the following order:
-
-1. Train evaluation first produces actual outputs, scores, and the execution trace for this run. The static structure graph does not change, but the system now knows which steps were actually executed.
-2. If train evaluation finds that the output quality of `step_9 reviewer` is insufficient, the loss is attached to that step. `Backwarder` uses the input/output snapshots of `step_9`, its predecessor steps, and editable positions to convert the problem into step-level gradients.
-3. If the issue mainly comes from how `reviewer` expresses the result, `Backwarder` may directly attribute gradients to `reviewer#instruction`. If the issue comes from insufficient upstream information, it may continue propagating to `step_7 retrieve` and `step_8 compose`, then further back to the shared predecessor `step_6 planner`.
-4. Gradients produced by different samples, steps, and branches are eventually merged by `Aggregator` by `SurfaceID`. For example, multiple steps may attribute issues to `planner#instruction`, and those gradients will be merged into one unified signal.
-5. `Optimizer` looks at the current baseline value of one `surface` and its aggregated gradient, and generates the corresponding `SurfacePatch`.
-6. `Engine` applies the `SurfacePatch` to the current candidate version, produces a new `Profile`, and passes it to validation evaluation.
-7. Validation determines whether the current round is truly better. If the score gain satisfies the acceptance policy, the new candidate version becomes the accepted version. Otherwise the system rolls back to the previous accepted version and decides whether to continue.
-
-This example shows the responsibilities of three layers of information:
-
-- The static structure graph determines which positions may be modified.
-- Execution Trace determines which steps actually contain problems in the current run and how gradients should propagate.
-- `Backwarder`, `Aggregator`, and `Optimizer` progressively convert step-level problems into surface-level patch suggestions.
-
-For how execution traces are exported, see [Execution Trace Export](agent.md#execution-trace-export). For more detail about fan-out, join, and cycle semantics in graph-based workflows, see [Graph Guide](graph.md).
-
-### Profile
-
-`Profile` represents a set of overrides applied on top of a structure snapshot. Every time one round is accepted, PromptIter creates a new candidate configuration version and uses it as input for the next round.
+The training set is used to produce optimization signals, and the validation set is used to provide evaluation results required for candidate-prompt acceptance decisions. Both are specified through `EvalSetInput`. Each input can point to the whole evaluation set or use `EvalCaseIDs` to narrow the scope to specific evaluation cases.
 
 ```go
-import astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter"
+)
 
-type Profile struct {
-	StructureID string            // StructureID is the structure version used by the current candidate version.
-	Overrides   []SurfaceOverride // Overrides stores override values on editable positions.
+// EvalSetInput specifies one training-set or validation-set input.
+type EvalSetInput struct {
+	// EvalSetID is the evaluation set ID to run.
+	EvalSetID string
+	// EvalCaseIDs narrows the run scope to specific evaluation cases. An empty list means all evaluation cases run.
+	EvalCaseIDs []string
+	// LossHints supplements known business-side problem reasons for failed training-set metrics.
+	LossHints []LossHint
 }
 
-type SurfaceOverride struct {
-	SurfaceID string                  // SurfaceID identifies the target editable position.
-	Value     astructure.SurfaceValue // Value is the candidate value on that editable position.
+// LossHint supplements the problem reason for one failed metric on one evaluation case.
+type LossHint struct {
+	// EvalCaseID specifies the evaluation case corresponding to the problem reason.
+	EvalCaseID string
+	// MetricName specifies the metric corresponding to the problem reason.
+	MetricName string
+	// Severity indicates the priority of the problem reason.
+	Severity promptiter.LossSeverity
+	// Reason is the problem-reason text used for backpropagation attribution.
+	Reason string
 }
 ```
 
-### PatchSet
+If `EvalCaseIDs` is not specified, PromptIter runs all evaluation cases under the corresponding evaluation set. If a non-empty list is specified, only the listed evaluation cases run.
 
-`PatchSet` represents the set of candidate patch suggestions generated by the optimizer in one round.
+When the business side already knows the specific problem in a training-set evaluation case, `LossHint` can supplement the problem reason. PromptIter merges `Reason` into the optimization signal of the corresponding failed metric, so backpropagation attribution can consider both the reason from the evaluator and the reason supplemented by the business side. When `LossHint` is used, `EvalCaseID` and `MetricName` must match a failed metric in the current training evaluation result, and `Severity` must be `P0`, `P1`, `P2`, or `P3`. `LossHint` does not change the evaluation score and does not participate in validation-set acceptance decisions.
+
+Training sets and validation sets must be used separately. A higher training-set score only means the candidate patch is closer to metric requirements on samples used for optimization. It cannot prove that samples not used for optimization also satisfy the metrics. The validation set exposes overfitting risk and participates in acceptance decisions.
+
+### Static Structure Snapshot
+
+The static structure snapshot is the exported structure of the target Agent. It contains nodes, edges, and iterable slots. Content that can be used as an iteration target in the structure snapshot is called a surface in code. Each surface has a stable `SurfaceID`. This document discusses only `instruction` prompt iteration. PromptIter uses the structure snapshot to confirm whether the specified `instruction` surface exists for the current run.
+
+This document discusses only `instruction`-type surfaces, that is, instruction prompts on nodes. Prompt iteration needs an explicit target scope, so integration code must write the selected `SurfaceID` into `TargetSurfaceIDs` in the iteration request.
+
+`Describe` can be used to inspect the structure snapshot. After determining the `instruction` surface to iterate, write the corresponding ID into `TargetSurfaceIDs` in the iteration request.
 
 ```go
-import astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
+// Describe returns the static structure snapshot of the target Agent.
+snapshot, err := engineInstance.Describe(ctx)
+if err != nil {
+	return err
+}
+// Surfaces lists the surfaces that can be used as iteration targets in the current structure.
+for _, surface := range snapshot.Surfaces {
+	fmt.Println(surface.SurfaceID, surface.Type)
+}
+```
 
+#### LLMAgent Example
+
+In an LLMAgent scenario, the target Agent is created with `llmagent.New`.
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+)
+
+// llmagent.New creates the target Agent.
+llmagent.New(
+	"candidate",
+	llmagent.WithModel(candidateModel),
+	// WithInstruction writes the initial prompt corresponding to candidate#instruction.
+	llmagent.WithInstruction("Write a Chinese sports game recap"),
+)
+```
+
+This Agent has only one node in its static structure. The `instruction` surface is the iterable prompt on that node, and its ID is `candidate#instruction`. The corresponding static structure is shown below.
+
+![llmagent-structure.svg](../assets/img/promptiter/llmagent-structure.svg)
+
+#### Graph Agent Example
+
+In a Graph Agent scenario, the static structure contains the root Agent, graph nodes, and edges. Code mounts child Agents through `AddAgentNode`, and those nodes export their own `instruction` surfaces. The flow fans out from `prepare` to `title`, `introduction`, and `highlight`, then joins at `merge`. Finally, `review` chooses either publish or return to polish according to the result, covering fan-out, fan-in, and conditional edges.
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/graphagent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/graph"
+)
+
+// newGraphAgent creates a Graph Agent with fan-out, fan-in, and conditional edges.
+func newGraphAgent() (agent.Agent, error) {
+	// subAgents lists the child Agents used by the Graph Agent.
+	subAgents := []agent.Agent{
+		// title corresponds to candidate/title#instruction.
+		llmagent.New(
+			"title",
+			llmagent.WithModel(modelInstance),
+			llmagent.WithInstruction("Generate a Chinese recap title"),
+		),
+		// introduction corresponds to candidate/introduction#instruction.
+		llmagent.New(
+			"introduction",
+			llmagent.WithModel(modelInstance),
+			llmagent.WithInstruction("Write the game background and opening lead"),
+		),
+		// highlight corresponds to candidate/highlight#instruction.
+		llmagent.New(
+			"highlight",
+			llmagent.WithModel(modelInstance),
+			llmagent.WithInstruction("Extract key possessions and turning points"),
+		),
+		// polish corresponds to candidate/polish#instruction.
+		llmagent.New(
+			"polish",
+			llmagent.WithModel(modelInstance),
+			llmagent.WithInstruction("Polish the recap structure and wording"),
+		),
+		// review corresponds to candidate/review#instruction.
+		llmagent.New(
+			"review",
+			llmagent.WithModel(modelInstance),
+			llmagent.WithInstruction("Review factual consistency and publishing standards"),
+		),
+	}
+	// StateGraph connects normal function nodes and AgentNode nodes.
+	sg := graph.NewStateGraph(graph.NewStateSchema())
+	sg.AddNode("prepare", prepare)
+	sg.AddAgentNode("title")
+	sg.AddAgentNode("introduction")
+	sg.AddAgentNode("highlight")
+	sg.AddNode("merge", mergeDraft)
+	sg.AddAgentNode("polish")
+	sg.AddAgentNode("review")
+	sg.AddNode("publish", publish)
+	sg.SetEntryPoint("prepare")
+	// fan-out means one node dispatches to three AgentNode nodes.
+	sg.AddEdge("prepare", "title")
+	sg.AddEdge("prepare", "introduction")
+	sg.AddEdge("prepare", "highlight")
+	// fan-in waits for title, introduction, and highlight to all finish before entering merge.
+	sg.AddJoinEdge([]string{"title", "introduction", "highlight"}, "merge")
+	sg.AddEdge("merge", "polish")
+	sg.AddEdge("polish", "review")
+	// Conditional edges use routeAfterReview to choose publish or return to polish according to state.
+	sg.AddConditionalEdges("review", routeAfterReview, map[string]string{
+		"pass": "publish",
+		"revise": "polish",
+	})
+	sg.SetFinishPoint("publish")
+	// Compile generates the graph structure required by graphagent.New.
+	g, err := sg.Compile()
+	if err != nil {
+		return nil, err
+	}
+	// graphagent.New binds the graph structure and child Agents.
+	return graphagent.New("candidate", g, graphagent.WithSubAgents(subAgents))
+}
+```
+
+In this example, `prepare`, `merge`, and `publish` are normal function nodes and do not expose `instruction` surfaces. Nodes mounted through `AddAgentNode` export the `instruction` surfaces of their child Agents.
+
+The `NodeID` exported by a Graph Agent has the root Agent name as a prefix. For example, `merge` in the code corresponds to `candidate/merge` in the structure snapshot. The `SurfaceID` of an `instruction` surface on an AgentNode has the form `<root Agent>/<node name>#instruction`.
+
+This example contains five `instruction` surfaces. Their `SurfaceID` values are:
+
+- `candidate/title#instruction`
+- `candidate/introduction#instruction`
+- `candidate/highlight#instruction`
+- `candidate/polish#instruction`
+- `candidate/review#instruction`
+
+The corresponding static structure is shown below.
+
+![graphagent-structure.svg](../assets/img/promptiter/graphagent-structure.svg)
+
+### Dynamic Execution Trace
+
+The dynamic execution trace records the steps actually passed during one evaluation run and their dependencies. The static structure snapshot describes the nodes, edges, and surfaces an Agent may contain. The dynamic execution trace records the steps actually passed in the current run.
+
+Each execution step has a `StepID` and is associated with a node in the static structure through `NodeID`. `PredecessorStepIDs` records direct predecessors, and `AppliedSurfaceIDs` records the surfaces actually applied by the current step. The trace also contains input and output snapshots and error information. Static nodes and execution steps are not one-to-one. A static node may not execute in a run, or it may execute multiple times because of loops or conditional fallback.
+
+#### LLMAgent Example
+
+In an LLMAgent scenario, there is only one static node. One evaluation run corresponds to one execution step. The `StepID` in the actual trace is assigned at runtime, `NodeID` is `candidate`, and `PredecessorStepIDs` is empty. The step's `AppliedSurfaceIDs` records the surfaces actually applied. If the sample produces failed metrics, backpropagation attribution starts from this step.
+
+The corresponding dynamic execution trace is shown below.
+
+![llmagent-trace.svg](../assets/img/promptiter/llmagent-trace.svg)
+
+#### Graph Agent Example
+
+In a Graph Agent scenario, branches and conditional edges in the static structure appear in the step path of the current run. The dynamic trace uses `StepID` and `NodeID` together to describe one execution step. `StepID` is a runtime-assigned step identifier, and `NodeID` points to the node in the static structure. The same `NodeID` can correspond to multiple different `StepID` values.
+
+In the diagram, `s1`, `s2`, and similar labels are `StepID` values, while `candidate/prepare`, `candidate/title`, and similar labels are `NodeID` values. In this run, `candidate/review` first hits `revise`, so the flow returns to `candidate/polish`. After the second review hits `pass`, the flow enters `candidate/publish`.
+
+![graphagent-trace.svg](../assets/img/promptiter/graphagent-trace.svg)
+
+`candidate/title`, `candidate/introduction`, `candidate/highlight`, `candidate/polish`, and `candidate/review` are AgentNode nodes with `instruction` surfaces. The `AppliedSurfaceIDs` of the corresponding steps contain their `instruction` surfaces, such as `candidate/title#instruction`. `candidate/prepare`, `candidate/merge`, and `candidate/publish` are normal function nodes and do not expose `instruction` surfaces.
+
+If conditional routing hits `revise`, the trace returns to `candidate/polish`. When the same static node executes again, a new execution step and a new `StepID` are created. If `revise` is hit again, the trace continues to append new steps whose `NodeID` values still point to `candidate/polish` and `candidate/review`.
+
+Backpropagation attribution needs to consider both the static structure and dynamic execution trace. After training-set evaluation completes, failure signals are first associated with terminal steps. Terminal steps are steps not referenced by any other step and usually correspond to the last output step or the last group of output steps in the current run. Then backpropagation attribution processes steps backward along `PredecessorStepIDs`. It uses the current step's input, output, error, actually applied surfaces, and problem signals returned from successor steps to decide whether the problem should be attributed to the current step's target `instruction` surface or passed to predecessor steps.
+
+### Loss Extraction
+
+After training-set evaluation completes, PromptIter extracts losses from failed metrics. Only metrics with status `failed` enter loss extraction. Passed metrics do not produce optimization signals.
+
+Evaluation metric results contain the `Details.Reason` field, which records the reason for the metric decision. For failed metrics, this field explains why the evaluation case did not pass. When a custom evaluator integrates with PromptIter, it should write a concrete reason usable for loss construction, such as missing facts, excessive length, overly generic output, or deviation from the reference answer.
+
+When the business side needs to supplement problem reasons, set `LossHints` in the training-set `EvalSetInput`.
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+)
+
+// train specifies the training set that produces optimization signals and supplements known business-side problem reasons.
+train := []engine.EvalSetInput{
+	{
+		// EvalSetID points to the training set used to produce optimization signals.
+		EvalSetID: trainEvalSetID,
+		// LossHints only supplements problem reasons for failed metrics and does not change evaluation scores.
+		LossHints: []engine.LossHint{
+			{
+				// EvalCaseID specifies the evaluation case corresponding to the problem reason.
+				EvalCaseID: "case_1",
+				// MetricName specifies the metric corresponding to the problem reason.
+				MetricName: "llm_rubric_critic",
+				// Severity indicates the priority of this problem reason.
+				Severity: promptiter.LossSeverityP1,
+				// Reason writes a concrete problem reason for backpropagation attribution.
+				Reason: "The answer omitted the decisive player and score state of the current possession.",
+			},
+		},
+	},
+}
+```
+
+`LossHints` only supplements optimization signals in the training phase. It does not change evaluation scores and does not affect validation-set acceptance decisions. PromptIter only uses a `LossHint` when the corresponding Metric of the corresponding EvalCase is in `failed` status in the current training evaluation. If the metric passes in the current round, `LossHint` will not change the evaluation case to failed.
+
+### Backwarder
+
+The responsibility of `Backwarder` is to generate two kinds of output from failed samples, current step context, and incoming gradient packets. One is text gradients attributed to the current step's surfaces. The other is gradient packets that need to continue being passed to predecessor steps.
+
+```go
+import (
+	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
+	atrace "trpc.group/trpc-go/trpc-agent-go/agent/trace"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter"
+)
+
+// Backwarder performs backpropagation attribution on a single step.
+type Backwarder interface {
+	// Backward generates text gradients and upstream gradient packets from step context.
+	Backward(ctx context.Context, request *Request) (*Result, error)
+}
+
+// Request describes the backpropagation-attribution input for one execution step.
+type Request struct {
+	// EvalSetID identifies the current evaluation set.
+	EvalSetID string
+	// EvalCaseID identifies the current evaluation case.
+	EvalCaseID string
+	// Node is the static node corresponding to the current step.
+	Node *astructure.Node
+	// StepID identifies the current execution step.
+	StepID string
+	// Input is the input snapshot of the current step.
+	Input *atrace.Snapshot
+	// Output is the output snapshot of the current step.
+	Output *atrace.Snapshot
+	// Error records the runtime error of the current step.
+	Error string
+	// Surfaces are the surfaces that affect the current step.
+	Surfaces []astructure.Surface
+	// AllowedGradientSurfaceIDs limits the surfaces allowed for attribution.
+	AllowedGradientSurfaceIDs []string
+	// Predecessors are the direct predecessor steps of the current step.
+	Predecessors []Predecessor
+	// Incoming is the gradient packets passed from successor steps.
+	Incoming []GradientPacket
+}
+
+// Predecessor describes one direct predecessor step of the current step.
+type Predecessor struct {
+	// StepID identifies the predecessor step.
+	StepID string
+	// NodeID identifies the static node corresponding to the predecessor step.
+	NodeID string
+	// Output is the output snapshot of the predecessor step.
+	Output *atrace.Snapshot
+	// Error records the runtime error of the predecessor step.
+	Error string
+}
+
+// GradientPacket describes one problem signal passed back from a successor step.
+type GradientPacket struct {
+	// FromStepID identifies the successor step that produced the problem signal.
+	FromStepID string
+	// Severity indicates the priority of the problem signal.
+	Severity promptiter.LossSeverity
+	// Gradient stores the text content of the problem signal.
+	Gradient string
+}
+
+// Result describes the backpropagation-attribution result of the current step.
+type Result struct {
+	// Gradients are text gradients attributed to the current step's surfaces.
+	Gradients []promptiter.SurfaceGradient
+	// Upstream is the problem signals that need to continue to predecessor steps.
+	Upstream []Propagation
+}
+
+// Propagation describes the problem-signal collection to pass to one predecessor step.
+type Propagation struct {
+	// PredecessorStepID identifies the predecessor step receiving the problem signals.
+	PredecessorStepID string
+	// Gradients are the problem signals passed to the predecessor step.
+	Gradients []GradientPacket
+}
+```
+
+`Backwarder.Request` describes the current evaluation set, evaluation case, static node, and step ID. The request also carries attribution context, including input and output snapshots and errors, surfaces applied by the current step, `SurfaceID` values allowed for attribution, predecessor steps, and incoming gradient packets. The default implementation organizes this attribution context into one user message and constrains the model to return `Gradients` and `Upstream` through structured output.
+
+`Gradients` represents text gradients attributed to surfaces of the current step. `Upstream` represents problem signals that need to continue to predecessor steps and will be processed by those predecessor steps.
+
+The diagram below uses three execution-step nodes, `s1`, `s2`, and `s3`, as an example. During backpropagation, `s3` passes `Incoming` gradient packets to `s2`. After reading the context of `s2`, `Backwarder` outputs `Gradients` attributed to the surfaces of `s2` and passes `Upstream` gradient packets on to `s1`.
+
+![backwarder.svg](../assets/img/promptiter/backwarder.svg)
+
+The default `Backwarder` implementation is created through `backwarder.New`. It organizes the current step context, failure reasons, and problem signals passed back from successor steps into model input, and asks the model to return text gradients attributed to current surfaces and `Upstream` values for predecessor steps.
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+)
+
+// New creates the default Backwarder implementation.
+func New(ctx context.Context, runner runner.Runner, opt ...Option) (Backwarder, error)
+```
+
+Example usage:
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/backwarder"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+)
+
+// backwarderRunner calls the model to perform backpropagation attribution.
+backwarderRunner := runner.NewRunner("promptiter-backwarder", backwarderAgent)
+
+// backwarder.New creates the default Backwarder implementation.
+backwarderInstance, err := backwarder.New(ctx, backwarderRunner)
+```
+
+Construction-time options can adjust message construction, Runner parameters, and session identifiers. They are defined as follows.
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+// Option configures the default Backwarder implementation.
+type Option func(*options)
+
+// MessageBuilder encodes a Backwarder request into the message passed to Runner.
+type MessageBuilder func(ctx context.Context, request *Request) (*model.Message, error)
+
+// UserIDSupplier provides a user ID for one internal Backwarder Runner call.
+type UserIDSupplier func(ctx context.Context) string
+
+// SessionIDSupplier provides a session ID for one internal Backwarder Runner call.
+type SessionIDSupplier func(ctx context.Context) string
+
+// WithRunOptions appends RunOption values used by internal Backwarder Runner calls.
+func WithRunOptions(runOptions ...agent.RunOption) Option
+
+// WithMessageBuilder replaces the default message-building logic.
+func WithMessageBuilder(builder MessageBuilder) Option
+
+// WithUserIDSupplier replaces the default user ID generation logic.
+func WithUserIDSupplier(supplier UserIDSupplier) Option
+
+// WithSessionIDSupplier replaces the default session ID generation logic.
+func WithSessionIDSupplier(supplier SessionIDSupplier) Option
+```
+
+`WithRunOptions` is passed through to internal Runner calls of the component. `WithMessageBuilder` can replace the default message-building logic. `WithUserIDSupplier` and `WithSessionIDSupplier` can specify session identifiers for internal calls.
+
+### Aggregator
+
+Different samples and different steps in the training set may attribute problems to the same surface. The responsibility of `Aggregator` is to aggregate local text gradients by `SurfaceID` and output an aggregated result for a single surface.
+
+```go
+import (
+	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter"
+)
+
+// Aggregator aggregates multiple text gradients on the same surface.
+type Aggregator interface {
+	// Aggregate merges local text gradients into an aggregated result for a single surface.
+	Aggregate(ctx context.Context, request *Request) (*Result, error)
+}
+
+// Request describes the text-gradient aggregation input for a single surface.
+type Request struct {
+	// SurfaceID identifies the surface being aggregated.
+	SurfaceID string
+	// NodeID identifies the static node that owns this surface.
+	NodeID string
+	// Type identifies the type of this surface.
+	Type astructure.SurfaceType
+	// Gradients contains all local text gradients attributed to this surface.
+	Gradients []promptiter.SurfaceGradient
+}
+
+// Result describes the text-gradient aggregation result for a single surface.
+type Result struct {
+	// Gradient is the aggregated surface-level text gradient.
+	Gradient *promptiter.AggregatedSurfaceGradient
+}
+
+// SurfaceGradient stores a local text gradient attributed to one surface.
+type SurfaceGradient struct {
+	// EvalSetID identifies the evaluation set that produced this text gradient.
+	EvalSetID string
+	// EvalCaseID identifies the evaluation case that produced this text gradient.
+	EvalCaseID string
+	// StepID identifies the execution step that produced this text gradient.
+	StepID string
+	// SurfaceID identifies the surface this text gradient is attributed to.
+	SurfaceID string
+	// Severity indicates the priority of the issue corresponding to this text gradient.
+	Severity LossSeverity
+	// Gradient stores the text-gradient content.
+	Gradient string
+}
+
+// AggregatedSurfaceGradient stores the aggregated text gradient of a single surface.
+type AggregatedSurfaceGradient struct {
+	// SurfaceID identifies the surface corresponding to the aggregation result.
+	SurfaceID string
+	// NodeID identifies the static node that owns this surface.
+	NodeID string
+	// Type identifies the type of this surface.
+	Type astructure.SurfaceType
+	// Gradients stores the aggregated text gradients.
+	Gradients []SurfaceGradient
+}
+```
+
+`Aggregator.Request` contains the target `SurfaceID`, owner `NodeID`, surface type, and all text gradients under this surface. The default implementation asks the model to aggregate duplicate or similar text gradients. The model returns a merged text-gradient list, and the default implementation binds the target `SurfaceID`, `NodeID`, and surface type to form `AggregatedSurfaceGradient`.
+
+The text-gradient aggregation stage does not directly modify prompts. Its output is still an aggregated text gradient for a single surface and is used by the next Optimizer stage to generate patches.
+
+The default `Aggregator` implementation is created through `aggregator.New`. It organizes text gradients from different samples or steps on the same surface into model input and converts the model-returned aggregated text gradients into `AggregatedSurfaceGradient`.
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+)
+
+// New creates the default Aggregator implementation.
+func New(ctx context.Context, runner runner.Runner, opt ...Option) (Aggregator, error)
+```
+
+Example usage:
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/aggregator"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+)
+
+// aggregatorRunner calls the model to perform text-gradient aggregation.
+aggregatorRunner := runner.NewRunner("promptiter-aggregator", aggregatorAgent)
+
+// aggregator.New creates the default Aggregator implementation.
+aggregatorInstance, err := aggregator.New(ctx, aggregatorRunner)
+```
+
+Construction-time options can adjust message construction, Runner parameters, and session identifiers. They are defined as follows.
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+// Option configures the default Aggregator implementation.
+type Option func(*options)
+
+// MessageBuilder encodes an Aggregator request into the message passed to Runner.
+type MessageBuilder func(ctx context.Context, request *Request) (*model.Message, error)
+
+// UserIDSupplier provides a user ID for one internal Aggregator Runner call.
+type UserIDSupplier func(ctx context.Context) string
+
+// SessionIDSupplier provides a session ID for one internal Aggregator Runner call.
+type SessionIDSupplier func(ctx context.Context) string
+
+// WithRunOptions appends RunOption values used by internal Aggregator Runner calls.
+func WithRunOptions(runOptions ...agent.RunOption) Option
+
+// WithMessageBuilder replaces the default message-building logic.
+func WithMessageBuilder(builder MessageBuilder) Option
+
+// WithUserIDSupplier replaces the default user ID generation logic.
+func WithUserIDSupplier(supplier UserIDSupplier) Option
+
+// WithSessionIDSupplier replaces the default session ID generation logic.
+func WithSessionIDSupplier(supplier SessionIDSupplier) Option
+```
+
+`WithRunOptions` is passed through to internal Runner calls of the component. `WithMessageBuilder` can replace the default message-building logic. `WithUserIDSupplier` and `WithSessionIDSupplier` can specify session identifiers for internal calls.
+
+### Optimizer
+
+The responsibility of `Optimizer` is to generate a `SurfacePatch` from the current surface value and the aggregated text gradient.
+
+```go
+import (
+	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter"
+)
+
+// Optimizer generates candidate patches from aggregated text gradients.
+type Optimizer interface {
+	// Optimize generates one candidate SurfacePatch for the target surface.
+	Optimize(ctx context.Context, request *Request) (*Result, error)
+}
+
+// Request describes optimization input for a single surface.
+type Request struct {
+	// Surface stores the surface value in the current baseline Profile.
+	Surface *astructure.Surface
+	// Gradient stores the aggregated text gradient for this surface.
+	Gradient *promptiter.AggregatedSurfaceGradient
+}
+
+// Result describes the optimization result for a single surface.
+type Result struct {
+	// Patch is the candidate patch generated for this surface.
+	Patch *promptiter.SurfacePatch
+}
+
+// PatchSet stores the candidate patch collection produced by one optimization round.
 type PatchSet struct {
-	Patches []SurfacePatch // Patches stores the patch suggestions generated in the current round.
+	// Patches contains all candidate surface patches in the current round.
+	Patches []SurfacePatch
 }
 
+// SurfacePatch describes a candidate modification for one surface.
 type SurfacePatch struct {
-	SurfaceID string                  // SurfaceID identifies which editable position this patch targets.
-	Value     astructure.SurfaceValue // Value is the new candidate value.
-	Reason    string                  // Reason stores the explanation of why the patch was generated.
+	// SurfaceID identifies the modified surface.
+	SurfaceID string
+	// Value stores the candidate surface value.
+	Value astructure.SurfaceValue
+	// Reason explains why this patch was generated.
+	Reason string
 }
 ```
 
-The optimizer outputs `PatchSet`. The engine applies those patches to the current candidate version, creates a new candidate version, and then lets the validation set decide whether it should be accepted.
+`Request.Surface` provides the surface value in the current baseline Profile, and `Request.Gradient` provides the aggregated modification direction. One `Optimize` call returns one `SurfacePatch`. One round may contain multiple target surfaces, and Engine summarizes these patches into a `PatchSet`.
+
+The default `Optimizer` implementation is created through `optimizer.New`. It organizes the current surface value and aggregated text gradient into model input and asks the model to return a candidate `SurfacePatch`.
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+)
+
+// New creates the default Optimizer implementation.
+func New(ctx context.Context, runner runner.Runner, opt ...Option) (Optimizer, error)
+```
+
+Example usage:
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/optimizer"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+)
+
+// optimizerRunner calls the model to perform optimization patch generation.
+optimizerRunner := runner.NewRunner("promptiter-optimizer", optimizerAgent)
+
+// optimizer.New creates the default Optimizer implementation.
+optimizerInstance, err := optimizer.New(ctx, optimizerRunner)
+```
+
+Construction-time options can adjust message construction, Runner parameters, and session identifiers. They are defined as follows.
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+// Option configures the default Optimizer implementation.
+type Option func(*options)
+
+// MessageBuilder encodes an Optimizer request into the message passed to Runner.
+type MessageBuilder func(ctx context.Context, request *Request) (*model.Message, error)
+
+// UserIDSupplier provides a user ID for one internal Optimizer Runner call.
+type UserIDSupplier func(ctx context.Context) string
+
+// SessionIDSupplier provides a session ID for one internal Optimizer Runner call.
+type SessionIDSupplier func(ctx context.Context) string
+
+// WithRunOptions appends RunOption values used by internal Optimizer Runner calls.
+func WithRunOptions(runOptions ...agent.RunOption) Option
+
+// WithMessageBuilder replaces the default message-building logic.
+func WithMessageBuilder(builder MessageBuilder) Option
+
+// WithUserIDSupplier replaces the default user ID generation logic.
+func WithUserIDSupplier(supplier UserIDSupplier) Option
+
+// WithSessionIDSupplier replaces the default session ID generation logic.
+func WithSessionIDSupplier(supplier SessionIDSupplier) Option
+```
+
+`WithRunOptions` is passed through to internal Runner calls of the component. `WithMessageBuilder` can replace the default patch-generation message, which is useful when integrating business-specific patch constraints or output style requirements. `WithUserIDSupplier` and `WithSessionIDSupplier` can specify session identifiers for internal calls.
+
+### Override Profile
+
+`Profile` represents a group of surface override values bound to a structure snapshot.
+
+```go
+import (
+	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
+)
+
+// Profile stores surface override values bound to a structure snapshot.
+type Profile struct {
+	// StructureID identifies the structure snapshot this Profile applies to.
+	StructureID string
+	// Overrides stores override entries relative to original values in the structure snapshot.
+	Overrides []SurfaceOverride
+}
+
+// SurfaceOverride describes the override value of a single surface.
+type SurfaceOverride struct {
+	// SurfaceID identifies the overridden surface.
+	SurfaceID string
+	// Value stores the new value of this surface.
+	Value astructure.SurfaceValue
+}
+```
+
+Engine applies the `PatchSet` to the current baseline `Profile` to obtain a candidate `Profile`. Only after the acceptance decision passes does the candidate `Profile` become the new current baseline.
+
+### Run Decision Policies
+
+`AcceptancePolicy` controls whether the current candidate `Profile` is accepted.
+
+```go
+// AcceptancePolicy controls whether a candidate Profile is accepted.
+type AcceptancePolicy struct {
+	// MinScoreGain is the minimum validation-score gain of the candidate Profile over the current baseline Profile.
+	MinScoreGain float64
+}
+```
+
+The implementation calculates `candidateScore - baselineScore`, where `baselineScore` is the validation score of the current baseline Profile and `candidateScore` is the validation score of the candidate Profile in the current round. The candidate Profile is accepted only when the score gain is not less than `MinScoreGain`.
+
+`StopPolicy` controls when the current run stops.
+
+```go
+// StopPolicy controls when one PromptIter run stops.
+type StopPolicy struct {
+	// MaxRoundsWithoutAcceptance limits consecutive rounds without accepting a candidate Profile.
+	MaxRoundsWithoutAcceptance int
+	// TargetScore is the target validation score after which the run can stop. nil means disabled.
+	TargetScore *float64
+}
+```
+
+Stop decisions are executed in the following order.
+
+1. Stop when the current round reaches `MaxRounds`.
+2. Stop when consecutive non-accepted rounds reach `MaxRoundsWithoutAcceptance`.
+3. Stop when the current baseline validation score reaches `TargetScore`.
+4. Otherwise, continue to the next round.
+
+`MaxRounds` itself is a required constraint in `RunRequest` and must be greater than 0. When `TargetScore` is `nil`, the target-score stop condition is not enabled.
 
 ### RunRequest
 
-`RunRequest` describes the input of one PromptIter run.
+`RunRequest` describes all inputs of one PromptIter run. It specifies training sets, validation sets, initial version, iteration targets, stage configuration, and stop conditions.
 
 ```go
 import (
@@ -448,209 +1144,112 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/runner"
 )
 
+// RunRequest describes all inputs of one PromptIter run.
 type RunRequest struct {
-	Train                []EvalSetInput      // Train identifies evaluation data used to generate gradients.
-	Validation           []EvalSetInput      // Validation identifies evaluation data used for patch acceptance checks.
-	InitialProfile       *promptiter.Profile // InitialProfile is the initial candidate version before round one starts.
-	Teacher              runner.Runner       // Teacher is the Runner used to generate reference answers when needed.
-	Judge                runner.Runner       // Judge is the Runner used by judge-style metrics when needed.
-	EvaluationOptions    EvaluationOptions   // EvaluationOptions defines evaluation execution parameters.
-	BackwardOptions      BackwardOptions     // BackwardOptions defines backward-stage execution parameters.
-	AggregationOptions   AggregationOptions  // AggregationOptions defines aggregation-stage execution parameters.
-	OptimizerOptions     OptimizerOptions    // OptimizerOptions defines optimizer-stage execution parameters.
-	AcceptancePolicy     AcceptancePolicy    // AcceptancePolicy defines how acceptance is decided.
-	StopPolicy           StopPolicy          // StopPolicy defines when the run should stop.
-	MaxRounds            int                 // MaxRounds is the maximum number of optimization rounds.
-	TargetSurfaceIDs     []string            // TargetSurfaceIDs lists editable positions that may be changed in this run.
+	// Train specifies the training sets used to produce optimization signals.
+	Train []EvalSetInput
+	// Validation specifies the validation sets used for acceptance decisions.
+	Validation []EvalSetInput
+	// InitialProfile specifies the initial version. nil means original values in the structure snapshot are used.
+	InitialProfile *promptiter.Profile
+	// Teacher is the optional expected Runner passed to Evaluation.
+	Teacher runner.Runner
+	// Judge is the optional judge Runner passed to LLM Judge metrics.
+	Judge runner.Runner
+	// EvaluationOptions configures the training-set and validation-set evaluation stages.
+	EvaluationOptions EvaluationOptions
+	// BackwardOptions configures the backpropagation-attribution stage.
+	BackwardOptions BackwardOptions
+	// AggregationOptions configures the text-gradient aggregation stage.
+	AggregationOptions AggregationOptions
+	// OptimizerOptions configures the optimization patch generation stage.
+	OptimizerOptions OptimizerOptions
+	// AcceptancePolicy controls candidate Profile acceptance conditions.
+	AcceptancePolicy AcceptancePolicy
+	// StopPolicy controls run stop conditions.
+	StopPolicy StopPolicy
+	// MaxRounds limits the maximum number of iteration rounds.
+	MaxRounds int
+	// TargetSurfaceIDs limits the surfaces allowed to be iterated in this run.
+	TargetSurfaceIDs []string
 }
-```
 
-#### Train And Validation
-
-`Train` drives the training loop: PromptIter extracts losses from train evaluation results and uses them to generate gradients. `Validation` drives the validation loop: PromptIter computes the accepted baseline, decides whether a patch should be accepted, and participates in stop decisions.
-
-Both fields use `[]EvalSetInput` to describe the selected evaluation data:
-
-```go
+// EvalSetInput specifies one training-set or validation-set input.
 type EvalSetInput struct {
-	EvalSetID   string     // EvalSetID identifies the evaluation set to execute.
-	EvalCaseIDs []string   // EvalCaseIDs limits evaluation to the specified cases when present.
-	LossHints   []LossHint // LossHints provides operator-written failure reasons.
+	// EvalSetID is the evaluation set ID to run.
+	EvalSetID string
+	// EvalCaseIDs narrows the run scope to specific evaluation cases. An empty list means all evaluation cases run.
+	EvalCaseIDs []string
+	// LossHints supplements known business-side problem reasons for failed training-set metrics.
+	LossHints []LossHint
 }
 
+// LossHint supplements the problem reason for one failed metric on one evaluation case.
 type LossHint struct {
-	EvalCaseID string                  // EvalCaseID identifies the case to annotate.
-	MetricName string                  // MetricName identifies the failed metric to annotate.
-	Severity   promptiter.LossSeverity // Severity marks the priority of the hint.
-	Reason     string                  // Reason describes the operator-written failure cause.
+	// EvalCaseID specifies the evaluation case corresponding to the problem reason.
+	EvalCaseID string
+	// MetricName specifies the metric corresponding to the problem reason.
+	MetricName string
+	// Severity indicates the priority of the problem reason.
+	Severity promptiter.LossSeverity
+	// Reason is the problem-reason text used for backpropagation attribution.
+	Reason string
 }
-```
 
-When `EvalCaseIDs` is omitted, PromptIter runs all cases in the corresponding eval set:
-
-```go
-request := &engine.RunRequest{
-	Train: []engine.EvalSetInput{
-		{
-			EvalSetID: "nba-commentary-train",
-		},
-	},
-	Validation: []engine.EvalSetInput{
-		{
-			EvalSetID: "nba-commentary-validation",
-		},
-	},
-}
-```
-
-To run only selected cases for a train or validation set, set `EvalCaseIDs` on the corresponding `EvalSetInput`:
-
-```go
-request := &engine.RunRequest{
-	Train: []engine.EvalSetInput{
-		{
-			EvalSetID:   "nba-commentary-train",
-			EvalCaseIDs: []string{"case_1", "case_2"},
-		},
-	},
-	Validation: []engine.EvalSetInput{
-		{
-			EvalSetID:   "nba-commentary-validation",
-			EvalCaseIDs: []string{"case_3"},
-		},
-	},
-}
-```
-
-Omitting `EvalCaseIDs` or passing an empty slice runs all cases in that eval set. Passing a non-empty slice runs only the listed cases.
-
-If you already know why some bad cases failed, set `LossHints` on the corresponding `EvalSetInput`. Callers only need to provide the case, metric, and reason; PromptIter handles trace and step details internally.
-
-```go
-request := &engine.RunRequest{
-	Train: []engine.EvalSetInput{
-		{
-			EvalSetID: "nba-commentary-train",
-			LossHints: []engine.LossHint{
-				{
-					EvalCaseID: "case_1",
-					MetricName: "answer_quality",
-					Severity:   promptiter.LossSeverityP1,
-					Reason:     "The answer missed the key defensive strategy constraint.",
-				},
-			},
-		},
-	},
-	Validation: []engine.EvalSetInput{
-		{
-			EvalSetID: "nba-commentary-validation",
-		},
-	},
-}
-```
-
-`LossHints` only supplements training optimization signals. It does not change evaluation scores or validation acceptance decisions. PromptIter uses a hint only when the corresponding case and metric fail in the current round; passing results are not forced into failures. A misspelled case or metric returns an argument error.
-
-#### EvaluationOptions
-
-`EvaluationOptions` controls concurrency in the evaluation phase.
-
-```go
+// EvaluationOptions configures the training-set and validation-set evaluation stages.
 type EvaluationOptions struct {
-	EvalCaseParallelism               int  // EvalCaseParallelism is the upper bound of parallel evaluation cases.
-	EvalCaseParallelInferenceEnabled  bool // EvalCaseParallelInferenceEnabled controls whether inference runs in parallel.
-	EvalCaseParallelEvaluationEnabled bool // EvalCaseParallelEvaluationEnabled controls whether evaluation runs in parallel.
+	// EvalCaseParallelism limits evaluation-case-level concurrency.
+	EvalCaseParallelism int
+	// EvalCaseParallelInferenceEnabled enables evaluation-case-level concurrent inference.
+	EvalCaseParallelInferenceEnabled bool
+	// EvalCaseParallelEvaluationEnabled enables evaluation-case-level concurrent metric calculation.
+	EvalCaseParallelEvaluationEnabled bool
 }
-```
 
-Its semantics stay aligned with Evaluation. PromptIter directly reuses the Evaluation concurrency model and fixes execution to a single run internally.
-
-#### BackwardOptions
-
-`BackwardOptions` controls concurrency in the backward stage. By default, train cases run backward serially.
-
-```go
+// BackwardOptions configures the backpropagation-attribution stage.
 type BackwardOptions struct {
-	CaseParallelismEnabled bool // CaseParallelismEnabled controls whether train cases run backward in parallel.
-	CaseParallelism        int  // CaseParallelism is the upper bound of parallel backward cases.
+	// CaseParallelismEnabled enables training-set evaluation-case-level concurrent backpropagation attribution.
+	CaseParallelismEnabled bool
+	// CaseParallelism limits evaluation-case concurrency in the backpropagation-attribution stage.
+	CaseParallelism int
 }
-```
 
-When `CaseParallelismEnabled` is enabled, PromptIter runs backward in parallel across train cases. A `CaseParallelism` value of `0` uses `GOMAXPROCS` as the default parallelism; a negative value makes `Engine` return an argument error.
-
-#### AggregationOptions
-
-`AggregationOptions` controls concurrency in the gradient aggregation stage. By default, target surfaces are aggregated serially.
-
-```go
+// AggregationOptions configures the text-gradient aggregation stage.
 type AggregationOptions struct {
-	SurfaceParallelismEnabled bool // SurfaceParallelismEnabled controls whether target surfaces are aggregated in parallel.
-	SurfaceParallelism        int  // SurfaceParallelism is the upper bound of parallel aggregation surfaces.
+	// SurfaceParallelismEnabled enables concurrent aggregation for multiple surfaces.
+	SurfaceParallelismEnabled bool
+	// SurfaceParallelism limits surface concurrency in the text-gradient aggregation stage.
+	SurfaceParallelism int
 }
-```
 
-When `SurfaceParallelismEnabled` is enabled, PromptIter aggregates gradients in parallel across target surfaces. A `SurfaceParallelism` value of `0` uses `GOMAXPROCS` as the default parallelism; a negative value makes `Engine` return an argument error.
-
-#### OptimizerOptions
-
-`OptimizerOptions` controls concurrency in the optimizer stage that generates patch candidates. By default, target surfaces are optimized serially.
-
-```go
+// OptimizerOptions configures the optimization patch generation stage.
 type OptimizerOptions struct {
-	SurfaceParallelismEnabled bool // SurfaceParallelismEnabled controls whether target surfaces are optimized in parallel.
-	SurfaceParallelism        int  // SurfaceParallelism is the upper bound of parallel optimization surfaces.
+	// SurfaceParallelismEnabled enables concurrent patch generation for multiple surfaces.
+	SurfaceParallelismEnabled bool
+	// SurfaceParallelism limits surface concurrency in the optimization patch generation stage.
+	SurfaceParallelism int
 }
 ```
 
-When `SurfaceParallelismEnabled` is enabled, PromptIter generates patch candidates in parallel across target surfaces. A `SurfaceParallelism` value of `0` uses `GOMAXPROCS` as the default parallelism; a negative value makes `Engine` return an argument error.
+`RunRequest` first specifies training sets and validation sets. `Train` is used to produce optimization signals, and `Validation` is used for acceptance decisions. Both must be non-empty. Each `EvalSetInput` can point to a complete evaluation set or use `EvalCaseIDs` to run only part of its evaluation cases. `LossHints` only serves the training set and is used to supplement known business-side problem reasons.
 
-#### AcceptancePolicy And StopPolicy
+`InitialProfile` specifies the starting Profile of this iteration. If it is not passed, PromptIter uses the original surface values in the structure snapshot as the initial baseline. If `InitialProfile` is passed and `StructureID` is non-empty, it must match the current structure snapshot ID.
 
-`AcceptancePolicy` and `StopPolicy` determine whether the current modification is accepted and when the run stops.
+`Teacher` and `Judge` are passed to Evaluation. `Teacher` is used to generate expected traces or reference answers when the evaluation needs them. If the EvalSet already contains these expected values, `Teacher` can be omitted. `Judge` supports LLM Judge metric scoring. If this type of metric is not used, `Judge` can be omitted.
 
-```go
-type AcceptancePolicy struct {
-	MinScoreGain float64 // MinScoreGain is the minimum validation score gain required for acceptance.
-}
+`TargetSurfaceIDs` sets the surfaces allowed to be iterated in this run. A single-Agent scenario usually points to `candidate#instruction`, while a multi-node Agent scenario can point to `instruction` surfaces of multiple nodes.
 
-type StopPolicy struct {
-	MaxRoundsWithoutAcceptance int      // MaxRoundsWithoutAcceptance is the maximum number of consecutive non-accepted rounds.
-	TargetScore                *float64 // TargetScore stops the run when the accepted score reaches this threshold.
-}
-```
+`EvaluationOptions` configures the training-set and validation-set evaluation stages. `Train` and `Validation` can each contain multiple EvalSets, and each EvalSet can contain multiple EvalCases, so one evaluation may need to run multiple evaluation cases. `EvalCaseParallelism` sets evaluation-case concurrency, `EvalCaseParallelInferenceEnabled` controls whether Agents in multiple evaluation cases run concurrently, and `EvalCaseParallelEvaluationEnabled` controls whether scoring for multiple evaluation cases runs concurrently.
 
-The corresponding decisions appear in each `RoundResult`:
+`BackwardOptions` configures the backpropagation-attribution stage. `Train` can contain multiple EvalSets, and each EvalSet can contain multiple EvalCases. After training-set evaluation completes, PromptIter performs attribution by the evaluation cases that contain failure signals. `CaseParallelismEnabled` controls whether multiple training-set evaluation cases are processed concurrently, and `CaseParallelism` limits evaluation-case concurrency.
 
-```go
-type AcceptanceDecision struct {
-	Accepted   bool    // Accepted indicates whether the current round is accepted.
-	ScoreDelta float64 // ScoreDelta is the validation score gain relative to the accepted baseline.
-	Reason     string  // Reason explains the acceptance decision.
-}
+`AggregationOptions` configures the text-gradient aggregation stage. One run can specify multiple iteration targets through `TargetSurfaceIDs`, and training-set failure signals may also be attributed to multiple surfaces. `SurfaceParallelismEnabled` controls whether multiple surfaces are aggregated concurrently, and `SurfaceParallelism` limits surface concurrency.
 
-type StopDecision struct {
-	ShouldStop bool   // ShouldStop indicates whether the run should stop after the current round.
-	Reason     string // Reason explains the stop decision.
-}
-```
-
-The values below are example starting points rather than framework-enforced defaults:
-
-- `MinScoreGain = 0.005`
-- `MaxRounds = 4`
-- `MaxRoundsWithoutAcceptance = 5`
-- `TargetScore = 1.0`
-
-These example values usually correspond to the following runtime semantics:
-
-- The current round is accepted only when the validation score gain reaches `MinScoreGain`.
-- The run stops when it reaches `MaxRounds`, when too many consecutive rounds are not accepted, or when `TargetScore` is reached.
-
-If you want to reduce false acceptance caused by score jitter, increase `MinScoreGain`. If you want to stop earlier after long ineffective optimization, lower `MaxRoundsWithoutAcceptance`. If you want the run to exit as soon as it reaches a target quality bar, set `TargetScore`.
+`OptimizerOptions` configures the optimization patch generation stage. After text-gradient aggregation, aggregated results may exist for multiple surfaces, and each surface needs a corresponding candidate patch. `SurfaceParallelismEnabled` controls whether candidate patches are generated concurrently for multiple surfaces, and `SurfaceParallelism` limits surface concurrency.
 
 ### RunResult
 
-`RunResult` is the result and state snapshot of one PromptIter run. It is both the final result of a synchronous run and the state snapshot returned by asynchronous queries.
+`RunResult` stores the state and historical results of one PromptIter run. Synchronous iteration returns this structure directly. Asynchronous start returns an initial `RunResult`, and later queries return the latest `RunResult`.
 
 ```go
 import (
@@ -658,406 +1257,1243 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter"
 )
 
+// RunResult stores the state and historical results of one PromptIter run.
 type RunResult struct {
-	AppName            string               // AppName is the app that owns this run.
-	ID                 string               // ID is the run identifier.
-	Status             RunStatus            // Status is the current run status.
-	CurrentRound       int                  // CurrentRound is the current round number.
-	Structure          *astructure.Snapshot // Structure is the structure snapshot used in this run.
-	BaselineValidation *EvaluationResult    // BaselineValidation is the baseline validation result before optimization starts.
-	AcceptedProfile    *promptiter.Profile  // AcceptedProfile is the currently accepted best candidate version.
-	Rounds             []RoundResult        // Rounds stores detailed results of each round.
-	ErrorMessage       string               // ErrorMessage stores the error message when the run fails or is canceled.
+	// AppName identifies the owning application.
+	AppName string
+	// ID identifies the current PromptIter run.
+	ID string
+	// Status stores the current run status.
+	Status RunStatus
+	// CurrentRound records the current or last executed round.
+	CurrentRound int
+	// Structure stores the structure snapshot of the target Agent.
+	Structure *astructure.Snapshot
+	// BaselineValidation stores the validation result of the initial baseline.
+	BaselineValidation *EvaluationResult
+	// AcceptedProfile stores the current baseline Profile.
+	AcceptedProfile *promptiter.Profile
+	// Rounds stores training, patch, and validation results for each round.
+	Rounds []RoundResult
+	// ErrorMessage stores the error message on failure or cancellation.
+	ErrorMessage string
 }
 
+// RoundResult stores the complete result of one iteration round.
 type RoundResult struct {
-	Round         int                   // Round is the round number.
-	InputProfile  *promptiter.Profile   // InputProfile is the candidate version entering the round.
-	Train         *EvaluationResult     // Train is the training-set evaluation result.
-	Losses        []promptiter.CaseLoss // Losses stores losses extracted from failed cases.
-	Backward      *BackwardResult       // Backward is the backward propagation result.
-	Aggregation   *AggregationResult    // Aggregation is the gradient aggregation result.
-	Patches       *promptiter.PatchSet  // Patches stores patch suggestions generated by the optimizer.
-	OutputProfile *promptiter.Profile   // OutputProfile is the candidate version after applying patch suggestions.
-	Validation    *EvaluationResult     // Validation is the validation-set evaluation result.
-	Acceptance    *AcceptanceDecision   // Acceptance is the acceptance decision of the current round.
-	Stop          *StopDecision         // Stop is the stop decision of the current round.
+	// Round is the current round number.
+	Round int
+	// InputProfile is the current baseline Profile at the start of this round.
+	InputProfile *promptiter.Profile
+	// Train stores the training-set evaluation result of this round.
+	Train *EvaluationResult
+	// Losses stores losses extracted from failed training-set metrics.
+	Losses []promptiter.CaseLoss
+	// Backward stores backpropagation-attribution results.
+	Backward *BackwardResult
+	// Aggregation stores text-gradient aggregation results.
+	Aggregation *AggregationResult
+	// Patches stores the candidate patch collection generated by Optimizer.
+	Patches *promptiter.PatchSet
+	// OutputProfile is the candidate Profile after candidate patches are applied.
+	OutputProfile *promptiter.Profile
+	// Validation stores the validation-set evaluation result of the candidate Profile.
+	Validation *EvaluationResult
+	// Acceptance stores the acceptance decision of this round.
+	Acceptance *AcceptanceDecision
+	// Stop stores the stop decision of this round.
+	Stop *StopDecision
 }
 ```
 
-#### Result Inspection
+To inspect one run, read results in this order.
 
-Results are usually inspected from the following positions:
+1. Check `BaselineValidation.OverallScore` to confirm the validation score of the initial baseline.
+2. Check `Rounds[n].Train` to confirm whether the training set exposes expected problems.
+3. Check `Rounds[n].Losses` to confirm whether failed metrics provide usable reasons.
+4. Check `Rounds[n].Patches` to confirm which surfaces Optimizer modified and why.
+5. Check `Rounds[n].Validation` to confirm the validation score and failed metrics of the candidate Profile.
+6. Check `Rounds[n].Acceptance` to confirm whether the round was accepted and what the score delta was.
+7. Check `AcceptedProfile` to confirm the final baseline Profile.
 
-- `RunResult.BaselineValidation`, which shows the baseline score before optimization starts.
-- `RunResult.AcceptedProfile`, which shows the currently accepted best version.
-- `RunResult.Rounds`, which shows per-round train evaluation, validation evaluation, patch suggestions, and decisions.
-- `RoundResult.Acceptance`, which shows whether the current round is accepted and the score delta.
-- `RoundResult.Stop`, which shows whether the current round triggers a stop condition.
-
-The following is a typical summary:
-
-```text
-Initial validation score: 0.35
-Final accepted validation score: 0.92
-Round 1 -> train 0.25, validation 0.81, accepted true, delta 0.46
-Round 2 -> train 0.88, validation 0.92, accepted true, delta 0.12
-Round 3 -> train 1.00, validation 0.90, accepted false, delta -0.02
-```
-
-The meanings are:
-
-- `Initial validation score` is the baseline score.
-- `Final accepted validation score` is the score of the final accepted version in this run.
-- `accepted true` means the modification of that round is accepted.
-- `accepted false` means the modification of that round is rejected and the best accepted version remains unchanged.
-- `delta` is the validation score gain of the round relative to the current accepted version.
-
-To inspect full evaluation details, continue into `EvaluationResult.EvalSets`, `Cases`, and per-metric scores for each round.
-
-### Backwarder
-
-`Backwarder` converts failed samples, trace, and loss into per-sample gradients to determine where the issue mainly occurs and which editable positions should be blamed.
-
-### Aggregator
-
-`Aggregator` aggregates gradients from multiple samples on the same editable position into one unified signal in order to extract repeated cross-sample problems.
-
-### Optimizer
-
-`Optimizer` generates patch suggestions from aggregated gradients to determine how the current editable position should be adjusted.
-
-## Usage
-
-PromptIter usage usually revolves around four kinds of objects:
-
-- `RunRequest`, which describes the input of one run.
-- `RunResult`, which exposes the state and result of one run.
-- `Engine` and workflow components, which execute synchronous optimization and optionally replace key stages in the multi-round optimization chain.
-- `Manager / Store`, which provide asynchronous and persistent integration paths.
-- The PromptIter HTTP service module, which exposes HTTP APIs.
-
-Common access patterns are:
-
-- Use `engine` for purely local synchronous execution. See [syncrun](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/promptiter/syncrun).
-- Introduce `manager` when you need asynchronous lifecycle management. See [asyncrun](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/promptiter/asyncrun).
-- Use the PromptIter HTTP service module when you need remote triggering and platform integration. See [server](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/promptiter/server).
-
-### Backwarder
-
-`Backwarder` converts failed samples, trace, and loss into per-sample gradients.
-
-```go
-type Backwarder interface {
-	Backward(ctx context.Context, request *Request) (*Result, error)
-}
-```
-
-The default implementation is created with `backwarder.New(ctx, runner, opts...)`. The constructor supports the following options:
-
-- `WithRunOptions(...)`, which appends `agent.RunOption` values to internal Runner calls.
-- `WithMessageBuilder(...)`, which overrides how `Backwarder.Request` is encoded into the message sent to the Runner.
-- `WithUserIDSupplier(...)`, which overrides the `userID` used by each backward propagation call.
-- `WithSessionIDSupplier(...)`, which overrides the `sessionID` used by each backward propagation call.
-
-In most cases the default constructor is sufficient. Explicit options are only needed when you want to reuse a unified Runner option set, replace the default context encoding, or align with an existing user/session identity system.
-
-`Request` contains the current step input/output snapshot, related editable positions, predecessor steps, and incoming gradients. `Result` contains two kinds of outputs:
-
-- `Gradients`, which are gradients attributed to editable positions at the current step.
-- `Upstream`, which are gradients that still need to propagate to predecessor steps.
-
-The default implementation organizes one `Backwarder.Request` into a single-step context and sends it to the Runner. This context mainly includes:
-
-- Current evaluation sample identifiers, such as `EvalSetID` and `EvalCaseID`.
-- Current step information, such as `Node`, `StepID`, `Input`, `Output`, and `Error`.
-- Editable positions that may be blamed by this step, namely `Surfaces` and `AllowedGradientSurfaceIDs`.
-- Direct predecessor steps, namely `Predecessors`.
-- Gradient packets propagated back from downstream, namely `Incoming`.
-
-The default `Backwarder` serializes these items into one user message and uses structured output constraints so that the Runner may return only two kinds of content:
-
-- `Gradients` attributed to editable positions at the current step.
-- `Upstream` to be propagated further to predecessor steps.
-
-Backwarder turns failed samples into propagatable attribution signals, deciding which editable positions should be blamed and how the issue should continue propagating upstream.
-
-### Aggregator
-
-`Aggregator` merges gradients from multiple samples on the same editable position into one unified signal.
-
-```go
-type Aggregator interface {
-	Aggregate(ctx context.Context, request *Request) (*Result, error)
-}
-```
-
-The default implementation is created with `aggregator.New(ctx, runner, opts...)`. The constructor supports the following options:
-
-- `WithRunOptions(...)`, which appends `agent.RunOption` values to internal Runner calls.
-- `WithMessageBuilder(...)`, which overrides how `aggregator.Request` is encoded into the message sent to the Runner.
-- `WithUserIDSupplier(...)`, which overrides the `userID` used by each aggregation call.
-- `WithSessionIDSupplier(...)`, which overrides the `sessionID` used by each aggregation call.
-
-In most cases the default constructor is sufficient. Explicit options are only needed when you want to reuse a unified Runner option set, replace the default context encoding, or align with an existing user/session identity system.
-
-Specifically:
-
-- `Request.SurfaceID` identifies the editable position currently being aggregated.
-- `Request.Gradients` contains all sample-level gradients produced for that editable position.
-- `Result.Gradient` is the single aggregated signal at the editable-position level.
-
-The default implementation organizes one `aggregator.Request` into a single-surface aggregation context and sends it to the Runner. This context mainly includes:
-
-- The target editable position, `SurfaceID`.
-- The static node that owns that editable position, `NodeID`.
-- The type of that editable position, `Type`.
-- The raw gradient list from multiple samples, `Gradients`.
-
-The default `Aggregator` serializes these items into one user message and requires the Runner to return one aggregated `AggregatedSurfaceGradient`, which can be consumed directly by the next optimization stage.
-
-Aggregator reduces local sample-level gradients into a unified signal and extracts repeated problems that appear across samples.
-
-### Optimizer
-
-`Optimizer` generates patch suggestions from aggregated gradients.
-
-```go
-type Optimizer interface {
-	Optimize(ctx context.Context, request *Request) (*Result, error)
-}
-```
-
-The default implementation is created with `optimizer.New(ctx, runner, opts...)`. The constructor supports the following options:
-
-- `WithRunOptions(...)`, which appends `agent.RunOption` values to internal Runner calls.
-- `WithMessageBuilder(...)`, which overrides how `optimizer.Request` is encoded into the message sent to the Runner.
-- `WithUserIDSupplier(...)`, which overrides the `userID` used by each optimization call.
-- `WithSessionIDSupplier(...)`, which overrides the `sessionID` used by each optimization call.
-
-In most cases the default constructor is sufficient. Explicit options are only needed when you want to reuse a unified Runner option set, replace the default context encoding, or align with an existing user/session identity system.
-
-Specifically:
-
-- `Request.Surface` is the baseline value of the current editable position.
-- `Request.Gradient` is the aggregated gradient on that editable position.
-- `Result.Patch` is the generated patch suggestion.
-
-The default implementation organizes one `optimizer.Request` into a single-surface optimization context and sends it to the Runner. This context mainly includes:
-
-- The editable position itself, `Surface`.
-- The current baseline value of that editable position.
-- The aggregated gradient for that editable position, `Gradient`.
-
-The default `Optimizer` serializes these items into one user message and requires the Runner to return one `SurfacePatch`, including the new candidate value and the reason for the change.
-
-Optimizer converts aggregated gradients into concrete patch suggestions that determine how the current editable position should change.
+`RunStatus` includes `queued`, `running`, `succeeded`, `failed`, and `canceled`. When synchronous `engine.Run` returns successfully, the status is `succeeded`. An asynchronous run first creates the `queued` status, then `Manager` updates it to `running` and finally to a terminal status.
 
 ### Engine
 
-If you only need to execute one PromptIter run directly, use the `engine` package.
-
-See the corresponding example at [syncrun](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/promptiter/syncrun).
+`Engine` is the synchronous prompt iteration entry point. It executes the full PromptIter workflow in the current call and returns `RunResult` after the run finishes. Local debugging, scripted tasks, and integration modes that need to block for results usually use `Engine` directly.
 
 ```go
 import (
 	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
 )
 
+// Engine provides synchronous prompt iteration capability.
 type Engine interface {
+	// Describe returns the structure snapshot of the target Agent.
 	Describe(ctx context.Context) (*astructure.Snapshot, error)
+	// Run executes one multi-round prompt iteration.
 	Run(ctx context.Context, request *RunRequest, opts ...Option) (*RunResult, error)
 }
 ```
 
-Specifically:
-
-- `Describe` returns the current structure snapshot.
-- `Run` executes multi-round prompt optimization.
-
-The default implementation is created with `engine.New(ctx, targetAgent, agentEvaluator, backwarder, aggregator, optimizer)`. The constructor itself does not expose extra options. It requires five kinds of dependencies:
-
-- The target Agent being optimized.
-- `agentEvaluator` for train and validation evaluation.
-- The three workflow components: backwarder, aggregator, and optimizer.
-
-Among these dependencies, `targetAgent` is used to provide the structure snapshot. `Engine` exports the static structure graph through it so that it can determine editable positions, validate `TargetSurfaceIDs`, normalize `Profile`, and implement `Describe()`. `agentEvaluator` executes train and validation evaluation. These two dependencies correspond to structure description and evaluation execution respectively, and their responsibilities do not overlap.
-
-`Engine` options are provided at `Run(...)` time. Currently the only run-time option is `WithObserver(...)`, which receives stage events during one run. No additional run-time option is currently exposed beyond observation.
-
-#### Observer
-
-`engine.Run` supports `WithObserver(...)` to inject one runtime observer and receive stage events during a single run.
+The default implementation is created through `engine.New`. It requires the target Agent, `AgentEvaluator`, `Backwarder`, `Aggregator`, and `Optimizer`.
 
 ```go
-type Observer func(ctx context.Context, event *Event) error
+import (
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/aggregator"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/backwarder"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/optimizer"
+)
 
-type Event struct {
-	Kind    EventKind
-	Round   int
-	Payload any
-}
+// New creates the default Engine implementation.
+func New(
+	ctx context.Context,
+	targetAgent agent.Agent,
+	agentEvaluator evaluation.AgentEvaluator,
+	backwarder backwarder.Backwarder,
+	aggregator aggregator.Aggregator,
+	optimizer optimizer.Optimizer,
+) (Engine, error)
 ```
 
-Typical events include:
-
-- `structure_snapshot`
-- `baseline_validation`
-- `round_train_evaluation`
-- `round_losses`
-- `round_backward`
-- `round_aggregation`
-- `round_patch_set`
-- `round_output_profile`
-- `round_validation`
-- `round_completed`
-
-If you only need local synchronous debugging, `RunResult` is usually enough. Introduce `Observer` only when you need to observe stage changes during the run.
-
-### Manager
-
-If you need lifecycle management for asynchronous runs, use the `manager` package.
-
-See the corresponding example at [asyncrun](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/promptiter/asyncrun).
-
-#### Interface
+Example usage:
 
 ```go
 import (
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
 )
 
+// engine.New assembles the synchronous PromptIter iteration entry point.
+engineInstance, err := engine.New(
+	ctx,
+	candidateAgent,
+	agentEvaluator,
+	backwarderInstance,
+	aggregatorInstance,
+	optimizerInstance,
+)
+if err != nil {
+	return err
+}
+```
+
+After creation, use `Describe` to inspect the structure snapshot and `Run` to execute synchronous iteration.
+
+```go
+// Describe returns the structure snapshot of the target Agent.
+snapshot, err := engineInstance.Describe(ctx)
+if err != nil {
+	return err
+}
+
+// Run executes one synchronous prompt iteration and returns RunResult after completion.
+result, err := engineInstance.Run(ctx, request)
+if err != nil {
+	return err
+}
+```
+
+`WithObserver(...)` receives run events and observes iteration progress.
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+)
+
+// WithObserver registers a run-event callback.
+result, err := engineInstance.Run(ctx, request, engine.WithObserver(
+	func(ctx context.Context, event *engine.Event) error {
+		// event.Kind is the event type, and event.Round is the owning round.
+		fmt.Println(event.Kind, event.Round)
+		return nil
+	},
+))
+```
+
+Observable events are listed below.
+
+| Event type | Meaning |
+| --- | --- |
+| `structure_snapshot` | The structure snapshot used by the current run. |
+| `baseline_validation` | The validation result of the initial baseline Profile. |
+| `round_started` | One iteration round has started. |
+| `round_train_evaluation` | The training-set evaluation result of this round. |
+| `round_losses` | Losses extracted from failed training-set metrics. |
+| `round_backward` | The backpropagation-attribution result of this round. |
+| `round_aggregation` | The text-gradient aggregation result of this round. |
+| `round_patch_set` | The candidate patch collection of this round. |
+| `round_output_profile` | The candidate Profile produced after applying candidate patches. |
+| `round_validation` | The validation-set evaluation result of the candidate Profile. |
+| `round_completed` | The acceptance decision and stop decision summary of this round. |
+
+### Manager
+
+`Manager` provides asynchronous prompt iteration capability on top of `Engine`. It submits background runs, queries `RunResult`, cancels runs, and releases resources.
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+)
+
+// Manager manages asynchronous PromptIter runs.
 type Manager interface {
+	// Start creates an asynchronous run and returns the initial RunResult.
 	Start(ctx context.Context, request *engine.RunRequest) (*engine.RunResult, error)
+	// Get queries the current RunResult by runID.
 	Get(ctx context.Context, runID string) (*engine.RunResult, error)
+	// Cancel requests cancellation of the specified run.
 	Cancel(ctx context.Context, runID string) error
+	// Close releases resources held by Manager.
 	Close() error
 }
 ```
 
-#### Usage
-
-The minimal usage is:
+The default implementation is created through `manager.New`. It requires the application name and synchronous `Engine`.
 
 ```go
-import "trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/manager"
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+)
 
+// New creates the default Manager implementation.
+func New(appName string, engine engine.Engine, opts ...Option) (Manager, error)
+```
+
+Example usage:
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/manager"
+)
+
+// manager.New creates an asynchronous run manager with the default store.
+managerInstance, err := manager.New(appName, engineInstance)
+if err != nil {
+	return err
+}
+defer managerInstance.Close()
+```
+
+After creation, call `Start` to submit asynchronous iteration and call `Get` to query the latest `RunResult`.
+
+```go
+// Start submits one asynchronous prompt iteration.
+run, err := managerInstance.Start(ctx, request)
+if err != nil {
+	return err
+}
+
+// Get queries the current RunResult.
+current, err := managerInstance.Get(ctx, run.ID)
+if err != nil {
+	return err
+}
+```
+
+`Start` submits an asynchronous iteration task and immediately returns `RunResult`. The task then runs in the background. Call `Get` to query the latest `RunResult`.
+
+Construction-time options can replace the storage implementation and configure result slimming before writing to storage.
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/store"
+)
+
+// Option configures the default Manager implementation.
+type Option func(*options)
+
+// WithStore specifies the storage used for asynchronous run state.
+func WithStore(store store.Store) Option
+
+// WithStoredResultSlimming specifies the RunResult slimming policy before writing to storage.
+func WithStoredResultSlimming(slimming engine.RunResultSlimming) Option
+```
+
+`WithStore` replaces the storage implementation for asynchronous run state. `WithStoredResultSlimming` accepts `engine.RunResultSlimming`, which describes the field omission policy for `RunResult`. If no omission items are configured, the result is preserved in full.
+
+```go
+// RunResultSlimming controls which fields in RunResult are omitted before saving or returning.
+type RunResultSlimming struct {
+	// OmitStructure omits the exported Agent structure snapshot.
+	OmitStructure bool
+	// OmitEvaluationCases omits evaluation-case details in each stage's evaluation results.
+	OmitEvaluationCases bool
+	// OmitBackward omits each round's backpropagation-attribution result.
+	OmitBackward bool
+	// OmitAggregation omits each round's text-gradient aggregation result.
+	OmitAggregation bool
+	// OmitPatches omits each round's optimization patch result.
+	OmitPatches bool
+	// OmitProfiles omits input Profile, candidate Profile, and current baseline Profile.
+	OmitProfiles bool
+	// OmitLosses omits each round's loss details.
+	OmitLosses bool
+}
+```
+
+### Store
+
+`Store` persists the `RunResult` of asynchronous iteration. `Manager.Start` calls `Create` when creating a run record. During background execution, it writes the latest result through `Update`. `Manager.Get` queries the current result through `Get`.
+
+#### Interface Definition
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+)
+
+// Store persists RunResult values of asynchronous PromptIter runs.
+type Store interface {
+	// Create saves a newly created run record.
+	Create(ctx context.Context, appName string, run *engine.RunResult) error
+	// Get reads the specified run record.
+	Get(ctx context.Context, appName, runID string) (*engine.RunResult, error)
+	// Update overwrites the latest RunResult of the specified run record.
+	Update(ctx context.Context, appName string, run *engine.RunResult) error
+	// Close releases storage resources.
+	Close() error
+}
+```
+
+#### inmemory Implementation
+
+`Manager` uses the in-memory implementation by default. The in-memory implementation is created through `inmemory.New`. It is suitable for local debugging and tests, and records are lost after the process exits.
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/store"
+)
+
+// New creates an in-memory Store implementation.
+func New() store.Store
+```
+
+Example usage:
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/store/inmemory"
+)
+
+// inmemory.New creates an in-memory Store.
+store := inmemory.New()
+```
+
+#### mysql Implementation
+
+Use the MySQL implementation when runs need to be queried across processes or stored long term. The MySQL implementation is created through `mysql.New`. It serializes `RunResult` and writes it into a single table. Core fields include `app_name`, `run_id`, `status`, `run_result`, `created_at`, and `updated_at`. `app_name` and `run_id` form a unique key to isolate run records from different applications.
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/store"
+)
+
+// New creates a MySQL Store implementation.
+func New(opts ...Option) (store.Store, error)
+```
+
+Example usage:
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/store/mysql"
+)
+
+// mysql.New creates a MySQL Store.
+store, err := mysql.New(
+	// WithMySQLClientDSN initializes the MySQL connection with a DSN.
+	mysql.WithMySQLClientDSN(dsn),
+)
+```
+
+If automatic initialization is disabled or the table needs to be created by an external system in advance, use the SQL below. The default table name is `promptiter_runs`. After `WithTablePrefix` is configured, the actual table name receives that prefix.
+
+```sql
+CREATE TABLE IF NOT EXISTS promptiter_runs (
+	id BIGINT NOT NULL AUTO_INCREMENT,
+	app_name VARCHAR(255) NOT NULL,
+	run_id VARCHAR(255) NOT NULL,
+	status VARCHAR(32) NOT NULL DEFAULT '',
+	run_result JSON NOT NULL,
+	created_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+	updated_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+	PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE UNIQUE INDEX uniq_promptiter_runs_app_run ON promptiter_runs(app_name, run_id);
+```
+
+After creating the Store, pass it into Manager through `WithStore`.
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/manager"
+)
+
+// WithStore lets Manager use the specified Store to save asynchronous run state.
+managerInstance, err := manager.New(
+	appName,
+	engineInstance,
+	manager.WithStore(store),
+)
+```
+
+The MySQL implementation can specify connection source, initialization behavior, and table prefix through options at construction time.
+
+```go
+// Option configures the MySQL Store implementation.
+type Option func(*options)
+
+// WithMySQLClientDSN initializes the MySQL connection with a DSN.
+func WithMySQLClientDSN(dsn string) Option
+
+// WithMySQLInstance uses a registered MySQL instance.
+func WithMySQLInstance(instanceName string) Option
+
+// WithExtraOptions appends options passed to MySQL client construction logic.
+func WithExtraOptions(extraOptions ...any) Option
+
+// WithSkipDBInit specifies whether table schema and index initialization should be skipped.
+func WithSkipDBInit(skip bool) Option
+
+// WithTablePrefix specifies the PromptIter table-name prefix.
+func WithTablePrefix(prefix string) Option
+
+// WithInitTimeout specifies the table-schema initialization timeout.
+func WithInitTimeout(timeout time.Duration) Option
+```
+
+`WithMySQLClientDSN` creates a connection directly from the DSN. `WithMySQLInstance` uses a registered MySQL instance when no DSN is passed. `WithExtraOptions` passes through extra client construction options. `WithSkipDBInit` can skip table-schema initialization and is suitable for environments where an external system creates the table in advance. `WithTablePrefix` isolates table names across deployments. `WithInitTimeout` controls the table-schema initialization timeout.
+
+### HTTP Service
+
+`server/promptiter` exposes PromptIter structure queries, synchronous iteration, and asynchronous iteration management as HTTP APIs.
+
+```go
+import "net/http"
+
+// New builds the PromptIter HTTP service.
+func New(opts ...Option) (*Server, error)
+
+// Handler returns an HTTP handler for mounting with net/http.
+func (s *Server) Handler() http.Handler
+```
+
+If the caller only reads structure snapshots and starts blocking synchronous iteration, configure the server with `WithAppName` and `WithEngine`. This configuration registers structure-query and synchronous-iteration routes, but does not register asynchronous run-management routes.
+
+```go
+import (
+	"net/http"
+
+	spromptiter "trpc.group/trpc-go/trpc-agent-go/server/promptiter"
+)
+
+const addr = ":8080"
+
+// New creates a PromptIter service that only exposes structure query and synchronous iteration.
+serverInstance, err := spromptiter.New(
+	// WithAppName specifies the application name handled by the service.
+	spromptiter.WithAppName(appName),
+	// WithEngine provides synchronous iteration and structure-query capability.
+	spromptiter.WithEngine(engineInstance),
+)
+if err != nil {
+	return err
+}
+
+// ListenAndServe starts the PromptIter HTTP service with net/http.
+if err := http.ListenAndServe(addr, serverInstance.Handler()); err != nil {
+	return err
+}
+```
+
+If the caller needs to submit background iteration tasks and query status or request cancellation while execution is in progress, the server also needs `WithManager`. After it is configured, asynchronous run, asynchronous query, and cancellation routes are registered in addition to structure-query and synchronous-iteration routes.
+
+```go
+import (
+	"net/http"
+
+	spromptiter "trpc.group/trpc-go/trpc-agent-go/server/promptiter"
+)
+
+const addr = ":8080"
+
+// New creates a PromptIter service that exposes both synchronous and asynchronous iteration APIs.
+serverInstance, err := spromptiter.New(
+	// WithAppName specifies the application name handled by the service.
+	spromptiter.WithAppName(appName),
+	// WithEngine provides synchronous iteration and structure-query capability.
+	spromptiter.WithEngine(engineInstance),
+	// WithManager provides asynchronous run, query, and cancellation capability.
+	spromptiter.WithManager(managerInstance),
+)
+if err != nil {
+	return err
+}
+
+// ListenAndServe starts the PromptIter HTTP service with net/http.
+if err := http.ListenAndServe(addr, serverInstance.Handler()); err != nil {
+	return err
+}
+```
+
+In addition to `WithAppName`, `WithEngine`, and `WithManager` shown above, the HTTP service also allows the default routes, per-request timeout, and response-body slimming policy to be adjusted.
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/manager"
+)
+
+// Option configures the PromptIter HTTP service.
+type Option func(*options)
+
+// WithAppName specifies the application name handled by the service. It is required.
+func WithAppName(name string) Option
+
+// WithBasePath specifies the base path of the application collection. The default is /promptiter/v1/apps.
+func WithBasePath(path string) Option
+
+// WithStructurePath specifies the structure-query path. The default is /structure.
+func WithStructurePath(path string) Option
+
+// WithRunsPath specifies the synchronous iteration path. The default is /runs.
+func WithRunsPath(path string) Option
+
+// WithAsyncRunsPath specifies the asynchronous iteration path. The default is /async-runs.
+func WithAsyncRunsPath(path string) Option
+
+// WithTimeout specifies the maximum execution time of a single HTTP request.
+func WithTimeout(timeout time.Duration) Option
+
+// WithEngine specifies the Engine used for structure query and synchronous iteration. It is required.
+func WithEngine(promptIterEngine engine.Engine) Option
+
+// WithManager specifies the Manager used for asynchronous run management. Asynchronous routes are registered only after it is configured.
+func WithManager(promptIterManager manager.Manager) Option
+
+// WithResponseResultSlimming specifies the RunResult slimming policy before HTTP response.
+func WithResponseResultSlimming(slimming engine.RunResultSlimming) Option
+```
+
+The HTTP service registers the routes below by default. `{appName}` is the application name specified by `WithAppName`. Asynchronous routes are registered only after `WithManager` is configured.
+
+| Method | Path | Behavior |
+| --- | --- | --- |
+| `GET` | `/promptiter/v1/apps/{appName}/structure` | Returns the structure snapshot of the target Agent. |
+| `POST` | `/promptiter/v1/apps/{appName}/runs` | Executes synchronous prompt iteration and returns `RunResult` after completion. |
+| `POST` | `/promptiter/v1/apps/{appName}/async-runs` | Submits asynchronous prompt iteration. On success, returns `201 Created` and the initial `RunResult`, and writes the run-query path into the `Location` response header. |
+| `GET` | `/promptiter/v1/apps/{appName}/async-runs/{runID}` | Queries the current `RunResult` of an asynchronous run. |
+| `POST` | `/promptiter/v1/apps/{appName}/async-runs/{runID}/cancel` | Requests cancellation of the specified asynchronous run. On success, returns `202 Accepted`. |
+
+Synchronous and asynchronous run APIs use the same request and response structures. The structure-query API returns the structure snapshot of the target Agent.
+
+```go
+import (
+	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+)
+
+// RunRequest represents one PromptIter run request.
+type RunRequest struct {
+	// Run stores the run configuration passed to Engine or Manager.
+	Run *engine.RunRequest `json:"run"`
+}
+
+// RunResponse represents one PromptIter run result.
+type RunResponse struct {
+	// Result stores the run result returned by Engine or Manager.
+	Result *engine.RunResult `json:"result"`
+}
+
+// GetStructureResponse represents a structure-query result.
+type GetStructureResponse struct {
+	// Structure stores the structure snapshot of the target Agent.
+	Structure *astructure.Snapshot `json:"structure"`
+}
+```
+
+When integrating PromptIter on the business side, callers usually call `/structure` first to read the structure snapshot, select the surfaces that need to be iterated, and write the corresponding IDs into `run.TargetSurfaceIDs` in the request body. Call `/runs` when synchronous results are needed. Call `/async-runs` when background execution is needed, then use the returned run ID to query the current `RunResult`.
+
+### Synchronous Iteration
+
+Synchronous iteration completes in the current process through `Engine.Run`. It is suitable for local debugging, script tasks, and integration modes that block while waiting for results. The key steps are creating the target Runner, judge Runner, `AgentEvaluator`, three PromptIter worker components, and `Engine`, then submitting `RunRequest`. See the complete code at [examples/evaluation/promptiter/syncrun](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/promptiter/syncrun).
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation"
+	evalresultlocal "trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult/local"
+	evalsetlocal "trpc.group/trpc-go/trpc-agent-go/evaluation/evalset/local"
+	metriclocal "trpc.group/trpc-go/trpc-agent-go/evaluation/metric/local"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/aggregator"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/backwarder"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/optimizer"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+)
+
+// candidateAgent is the target Agent of this iteration.
+candidateAgent := llmagent.New(
+	candidateAgentName,
+	llmagent.WithModel(candidateModel),
+	// WithInstruction writes the initial prompt corresponding to candidate#instruction.
+	llmagent.WithInstruction("Write a Chinese sports game recap"),
+)
+// candidateRunner is the entry point for Evaluation to execute the target Agent.
+candidateRunner := runner.NewRunner(candidateAppName, candidateAgent)
+
+// judgeRunner is used by LLM Judge metrics to call the judge model.
+judgeAgent := llmagent.New(judgeAppName, llmagent.WithModel(judgeModel))
+judgeRunner := runner.NewRunner(judgeAppName, judgeAgent)
+
+// Evaluation sets, metrics, and evaluation results are managed by their managers.
+evalSetManager := evalsetlocal.New()
+metricManager := metriclocal.New()
+evalResultManager := evalresultlocal.New()
+
+// AgentEvaluator runs training-set and validation-set evaluation.
+agentEvaluator, err := evaluation.New(
+	appName,
+	candidateRunner,
+	evaluation.WithEvalSetManager(evalSetManager),
+	evaluation.WithMetricManager(metricManager),
+	evaluation.WithEvalResultManager(evalResultManager),
+	evaluation.WithJudgeRunner(judgeRunner),
+)
+if err != nil {
+	return err
+}
+
+// Backwarder performs backpropagation attribution.
+backwarderRunner := runner.NewRunner(
+	backwarderAppName,
+	llmagent.New(backwarderAppName, llmagent.WithModel(workerModel)),
+)
+backwarderInstance, err := backwarder.New(ctx, backwarderRunner)
+if err != nil {
+	return err
+}
+
+// Aggregator performs text-gradient aggregation.
+aggregatorRunner := runner.NewRunner(
+	aggregatorAppName,
+	llmagent.New(aggregatorAppName, llmagent.WithModel(workerModel)),
+)
+aggregatorInstance, err := aggregator.New(ctx, aggregatorRunner)
+if err != nil {
+	return err
+}
+
+// Optimizer performs optimization patch generation.
+optimizerRunner := runner.NewRunner(
+	optimizerAppName,
+	llmagent.New(optimizerAppName, llmagent.WithModel(workerModel)),
+)
+optimizerInstance, err := optimizer.New(ctx, optimizerRunner)
+if err != nil {
+	return err
+}
+
+// Engine binds the target Agent, evaluator, and three PromptIter worker components.
+engineInstance, err := engine.New(
+	ctx,
+	candidateAgent,
+	agentEvaluator,
+	backwarderInstance,
+	aggregatorInstance,
+	optimizerInstance,
+)
+if err != nil {
+	return err
+}
+
+// targetInstructionID points to the instruction of the candidate Agent. Its value is candidate#instruction.
+targetInstructionID := astructure.SurfaceID(candidateAgentName, astructure.SurfaceTypeInstruction)
+// targetScore is the target validation score for this run.
+targetScore := 1.0
+
+// RunRequest specifies the training set, validation set, iteration target, concurrency options, max rounds, acceptance policy, and stop policy.
+// result stores the complete RunResult of this synchronous iteration.
+result, err := engineInstance.Run(ctx, &engine.RunRequest{
+	// Train specifies the training set that produces optimization signals.
+	Train: []engine.EvalSetInput{
+		{
+			// EvalSetID points to the training set used to produce optimization signals.
+			EvalSetID: trainEvalSetID,
+		},
+	},
+	// Validation specifies the validation set used for acceptance decisions.
+	Validation: []engine.EvalSetInput{
+		{
+			// EvalSetID points to the validation set used for acceptance decisions.
+			EvalSetID: validationEvalSetID,
+		},
+	},
+	// Training-set and validation-set evaluation run concurrently by evaluation case.
+	EvaluationOptions: engine.EvaluationOptions{
+		// EvalCaseParallelism limits evaluation-case concurrency.
+		EvalCaseParallelism: 16,
+		// EvalCaseParallelInferenceEnabled enables concurrent inference for the target Agent.
+		EvalCaseParallelInferenceEnabled: true,
+		// EvalCaseParallelEvaluationEnabled enables concurrent metric calculation.
+		EvalCaseParallelEvaluationEnabled: true,
+	},
+	// Backpropagation attribution processes evaluation cases sequentially by default.
+	BackwardOptions: engine.BackwardOptions{
+		// CaseParallelismEnabled controls whether training-set evaluation cases are processed concurrently.
+		CaseParallelismEnabled: false,
+		// CaseParallelism is the evaluation-case concurrency limit after concurrency is enabled.
+		CaseParallelism: 16,
+	},
+	// Text-gradient aggregation runs concurrently by iteration target.
+	AggregationOptions: engine.AggregationOptions{
+		// SurfaceParallelismEnabled controls whether multiple iteration targets are processed concurrently.
+		SurfaceParallelismEnabled: true,
+		// SurfaceParallelism is the iteration-target concurrency limit.
+		SurfaceParallelism: 16,
+	},
+	// Optimization patch generation runs concurrently by iteration target.
+	OptimizerOptions: engine.OptimizerOptions{
+		// SurfaceParallelismEnabled controls whether patches are generated concurrently for multiple iteration targets.
+		SurfaceParallelismEnabled: true,
+		// SurfaceParallelism is the iteration-target concurrency limit.
+		SurfaceParallelism: 16,
+	},
+	// A candidate prompt must improve over the current baseline prompt by at least 0.01 points.
+	AcceptancePolicy: engine.AcceptancePolicy{
+		// MinScoreGain is the minimum validation-score gain required to accept a candidate prompt.
+		MinScoreGain: 0.01,
+	},
+	// The run stops when it reaches max rounds, consecutive non-accepted rounds, or the target score.
+	StopPolicy: engine.StopPolicy{
+		// MaxRoundsWithoutAcceptance limits consecutive rounds without accepting a candidate prompt.
+		MaxRoundsWithoutAcceptance: 3,
+		// TargetScore is the target validation score after which the run can stop.
+		TargetScore: &targetScore,
+	},
+	// MaxRounds is the maximum number of iteration rounds for this run.
+	MaxRounds: 4,
+	// TargetSurfaceIDs specifies the prompts allowed to be iterated in this run.
+	TargetSurfaceIDs: []string{targetInstructionID},
+})
+if err != nil {
+	return err
+}
+```
+
+The `RunResult` returned by `Engine.Run` records the structure ID, iteration target, initial prompt, final baseline prompt, validation score, and each round's decision result.
+
+| Output item | Example value |
+| --- | --- |
+| Initial validation score | `0.49` |
+| Final accepted validation score | `0.90` |
+| Rounds executed | `4` |
+| Round 1 | train `0.35`, validation `0.85`, accepted `true`, delta `0.36` |
+| Round 2 | train `0.83`, validation `0.90`, accepted `true`, delta `0.05` |
+| Round 3 | train `0.87`, validation `0.81`, accepted `false`, delta `-0.09` |
+| Round 4 | train `0.89`, validation `0.80`, accepted `false`, delta `-0.10` |
+
+This output reflects PromptIter's acceptance semantics. The candidates in rounds 1 and 2 pass the acceptance decision, so the current baseline is gradually updated to the round-2 candidate prompt. Although rounds 3 and 4 have high training-set scores, their validation scores do not exceed the validation score of the current baseline prompt, so they are not accepted. The final baseline remains the round-2 candidate prompt.
+
+### Asynchronous Iteration
+
+Asynchronous iteration manages background execution of `Engine.Run` through `Manager`. It is suitable for integration modes where the caller submits a run request and queries the result later. Integration still needs to assemble the target Agent, `AgentEvaluator`, and three PromptIter worker components first, then create `Engine` and `Manager` from those dependencies. See the complete code at [examples/evaluation/promptiter/asyncrun](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/promptiter/asyncrun).
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation"
+	evalresultlocal "trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult/local"
+	evalsetlocal "trpc.group/trpc-go/trpc-agent-go/evaluation/evalset/local"
+	metriclocal "trpc.group/trpc-go/trpc-agent-go/evaluation/metric/local"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/aggregator"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/backwarder"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/manager"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/optimizer"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+)
+
+// candidateAgent is the target Agent of this iteration.
+candidateAgent := llmagent.New(
+	candidateAgentName,
+	llmagent.WithModel(candidateModel),
+	// WithInstruction writes the initial prompt corresponding to candidate#instruction.
+	llmagent.WithInstruction("Write a Chinese sports game recap"),
+)
+
+// candidateRunner is the entry point for Evaluation to execute the target Agent.
+candidateRunner := runner.NewRunner(candidateAppName, candidateAgent)
+
+// judgeRunner is used by LLM Judge metrics to call the judge model.
+judgeAgent := llmagent.New(judgeAppName, llmagent.WithModel(judgeModel))
+judgeRunner := runner.NewRunner(judgeAppName, judgeAgent)
+
+// Evaluation sets, metrics, and evaluation results are managed by their managers.
+evalSetManager := evalsetlocal.New()
+metricManager := metriclocal.New()
+evalResultManager := evalresultlocal.New()
+
+// AgentEvaluator runs training-set and validation-set evaluation.
+agentEvaluator, err := evaluation.New(
+	appName,
+	candidateRunner,
+	evaluation.WithEvalSetManager(evalSetManager),
+	evaluation.WithMetricManager(metricManager),
+	evaluation.WithEvalResultManager(evalResultManager),
+	evaluation.WithJudgeRunner(judgeRunner),
+)
+if err != nil {
+	return err
+}
+
+// Backwarder performs backpropagation attribution.
+backwarderRunner := runner.NewRunner(
+	backwarderAppName,
+	llmagent.New(backwarderAppName, llmagent.WithModel(workerModel)),
+)
+backwarderInstance, err := backwarder.New(ctx, backwarderRunner)
+if err != nil {
+	return err
+}
+
+// Aggregator performs text-gradient aggregation.
+aggregatorRunner := runner.NewRunner(
+	aggregatorAppName,
+	llmagent.New(aggregatorAppName, llmagent.WithModel(workerModel)),
+)
+aggregatorInstance, err := aggregator.New(ctx, aggregatorRunner)
+if err != nil {
+	return err
+}
+
+// Optimizer performs optimization patch generation.
+optimizerRunner := runner.NewRunner(
+	optimizerAppName,
+	llmagent.New(optimizerAppName, llmagent.WithModel(workerModel)),
+)
+optimizerInstance, err := optimizer.New(ctx, optimizerRunner)
+if err != nil {
+	return err
+}
+
+// Engine binds the target Agent, evaluator, and three PromptIter worker components.
+engineInstance, err := engine.New(
+	ctx,
+	candidateAgent,
+	agentEvaluator,
+	backwarderInstance,
+	aggregatorInstance,
+	optimizerInstance,
+)
+if err != nil {
+	return err
+}
+
+// Manager manages asynchronous PromptIter runs on top of Engine.
 managerInstance, err := manager.New(appName, engineInstance)
 if err != nil {
 	return err
 }
 defer managerInstance.Close()
 
-run, err := managerInstance.Start(ctx, request)
-if err != nil {
-	return err
+// targetInstructionID points to the instruction of the candidate Agent. Its value is candidate#instruction.
+targetInstructionID := astructure.SurfaceID(candidateAgentName, astructure.SurfaceTypeInstruction)
+// targetScore is the target validation score for this run.
+targetScore := 1.0
+
+// RunRequest specifies the training set, validation set, iteration target, concurrency options, max rounds, acceptance policy, and stop policy.
+runRequest := &engine.RunRequest{
+	// Train specifies the training set that produces optimization signals.
+	Train: []engine.EvalSetInput{
+		{
+			// EvalSetID points to the training set used to produce optimization signals.
+			EvalSetID: trainEvalSetID,
+		},
+	},
+	// Validation specifies the validation set used for acceptance decisions.
+	Validation: []engine.EvalSetInput{
+		{
+			// EvalSetID points to the validation set used for acceptance decisions.
+			EvalSetID: validationEvalSetID,
+		},
+	},
+	// Training-set and validation-set evaluation run concurrently by evaluation case.
+	EvaluationOptions: engine.EvaluationOptions{
+		// EvalCaseParallelism limits evaluation-case concurrency.
+		EvalCaseParallelism: 16,
+		// EvalCaseParallelInferenceEnabled enables concurrent inference for the target Agent.
+		EvalCaseParallelInferenceEnabled: true,
+		// EvalCaseParallelEvaluationEnabled enables concurrent metric calculation.
+		EvalCaseParallelEvaluationEnabled: true,
+	},
+	// Backpropagation attribution processes evaluation cases sequentially by default.
+	BackwardOptions: engine.BackwardOptions{
+		// CaseParallelismEnabled controls whether training-set evaluation cases are processed concurrently.
+		CaseParallelismEnabled: false,
+		// CaseParallelism is the evaluation-case concurrency limit after concurrency is enabled.
+		CaseParallelism: 16,
+	},
+	// Text-gradient aggregation runs concurrently by iteration target.
+	AggregationOptions: engine.AggregationOptions{
+		// SurfaceParallelismEnabled controls whether multiple iteration targets are processed concurrently.
+		SurfaceParallelismEnabled: true,
+		// SurfaceParallelism is the iteration-target concurrency limit.
+		SurfaceParallelism: 16,
+	},
+	// Optimization patch generation runs concurrently by iteration target.
+	OptimizerOptions: engine.OptimizerOptions{
+		// SurfaceParallelismEnabled controls whether patches are generated concurrently for multiple iteration targets.
+		SurfaceParallelismEnabled: true,
+		// SurfaceParallelism is the iteration-target concurrency limit.
+		SurfaceParallelism: 16,
+	},
+	// A candidate prompt must improve over the current baseline prompt by at least 0.01 points.
+	AcceptancePolicy: engine.AcceptancePolicy{
+		// MinScoreGain is the minimum validation-score gain required to accept a candidate prompt.
+		MinScoreGain: 0.01,
+	},
+	// The run stops when it reaches max rounds, consecutive non-accepted rounds, or the target score.
+	StopPolicy: engine.StopPolicy{
+		// MaxRoundsWithoutAcceptance limits consecutive rounds without accepting a candidate prompt.
+		MaxRoundsWithoutAcceptance: 3,
+		// TargetScore is the target validation score after which the run can stop.
+		TargetScore: &targetScore,
+	},
+	// MaxRounds is the maximum number of iteration rounds for this run.
+	MaxRounds: 4,
+	// TargetSurfaceIDs specifies the prompts allowed to be iterated in this run.
+	TargetSurfaceIDs: []string{targetInstructionID},
 }
 
-current, err := managerInstance.Get(ctx, run.ID)
+// Start submits asynchronous prompt iteration and returns the initial RunResult with a run ID.
+run, err := managerInstance.Start(ctx, runRequest)
 if err != nil {
 	return err
 }
-_ = current
+runID := run.ID
+
+// Get queries the current RunResult by run ID.
+current, err := managerInstance.Get(ctx, runID)
+if err != nil {
+	return err
+}
 ```
 
-Manager fits the following scenarios:
+`Start` returns the initial `RunResult`, and `Get` returns the continuously updated `RunResult` during background execution. During the run, `RunResult` is gradually written with baseline validation, current round, training-set evaluation, backpropagation attribution, text-gradient aggregation, candidate patches, validation-set evaluation, acceptance decision, and stop decision. After the run enters `succeeded`, `failed`, or `canceled`, callers can read `AcceptedProfile`, each round's scores, and patch reasons from the terminal result.
 
-- Background tasks
-- Frontend progress polling
-- Long-running optimization that must be cancelable
-- Cross-request status queries
+### HTTP Iteration Service
 
-### Store
+The HTTP service exposes structure query, synchronous iteration, and asynchronous iteration as remote APIs. It is suitable for console pages, task systems, or other backend services. The HTTP layer receives `Engine` and optional `Manager` instances, and converts requests into local `Describe`, `Run`, `Start`, `Get`, and `Cancel` calls. See the complete code at [examples/evaluation/promptiter/server](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/promptiter/server).
 
-Asynchronous run persistence is handled by the `store` package.
-
-#### Interface
+When structure query and synchronous iteration are needed, create `Engine` according to the synchronous iteration integration method, then configure `WithAppName` and `WithEngine`.
 
 ```go
 import (
+	"net/http"
+
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+	spromptiter "trpc.group/trpc-go/trpc-agent-go/server/promptiter"
 )
 
-type Store interface {
-	Create(ctx context.Context, appName string, run *engine.RunResult) error
-	Get(ctx context.Context, appName, runID string) (*engine.RunResult, error)
-	Update(ctx context.Context, appName string, run *engine.RunResult) error
-	Close() error
+// engineInstance binds the target Agent, evaluator, and three PromptIter worker components.
+engineInstance, err := engine.New(
+	ctx,
+	candidateAgent,
+	agentEvaluator,
+	backwarderInstance,
+	aggregatorInstance,
+	optimizerInstance,
+)
+if err != nil {
+	return err
+}
+
+// serverInstance exposes structure-query and synchronous-iteration APIs.
+serverInstance, err := spromptiter.New(
+	// WithAppName specifies the application name handled by the service.
+	spromptiter.WithAppName(appName),
+	// WithEngine provides structure-query and synchronous-iteration capability.
+	spromptiter.WithEngine(engineInstance),
+)
+if err != nil {
+	return err
+}
+
+// ListenAndServe starts the PromptIter HTTP service with net/http.
+if err := http.ListenAndServe(":8080", serverInstance.Handler()); err != nil {
+	return err
 }
 ```
 
-#### InMemory Implementation
+When asynchronous submit, query, and cancellation capabilities are needed, create `Manager` from the same `Engine`, then also configure `WithManager`. `WithManager` does not change synchronous APIs. It only adds routes related to asynchronous runs.
 
-`store/inmemory` fits local debugging and testing. It does not depend on external storage and data is lost when the process exits.
+```go
+import (
+	"net/http"
 
-#### MySQL Implementation
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/manager"
+	spromptiter "trpc.group/trpc-go/trpc-agent-go/server/promptiter"
+)
 
-`store/mysql` fits cross-process persistence and platform queries. It serializes `RunResult` into MySQL and supports both manual schema initialization and automatic table creation.
+// engineInstance binds the target Agent, evaluator, and three PromptIter worker components.
+engineInstance, err := engine.New(
+	ctx,
+	candidateAgent,
+	agentEvaluator,
+	backwarderInstance,
+	aggregatorInstance,
+	optimizerInstance,
+)
+if err != nil {
+	return err
+}
 
-The current implementation uses a single table to store run records. Core fields include `app_name`, `run_id`, `status`, serialized `run_result`, and timestamps such as `created_at` and `updated_at`. `app_name` and `run_id` form the unique key that isolates run records across apps. The full schema is available in [schema.sql](https://github.com/trpc-group/trpc-agent-go/tree/main/evaluation/workflow/promptiter/store/mysql/schema.sql).
+// managerInstance manages asynchronous PromptIter runs.
+managerInstance, err := manager.New(appName, engineInstance)
+if err != nil {
+	return err
+}
+defer managerInstance.Close()
 
-### HTTP APIs
+// serverInstance exposes both synchronous and asynchronous iteration APIs.
+serverInstance, err := spromptiter.New(
+	// WithAppName specifies the application name handled by the service.
+	spromptiter.WithAppName(appName),
+	// WithEngine provides structure-query and synchronous-iteration capability.
+	spromptiter.WithEngine(engineInstance),
+	// WithManager provides asynchronous submit, query, and cancellation capability.
+	spromptiter.WithManager(managerInstance),
+)
+if err != nil {
+	return err
+}
 
-If you need to trigger PromptIter over HTTP, use the PromptIter HTTP service module.
+// ListenAndServe starts the PromptIter HTTP service with net/http.
+if err := http.ListenAndServe(":8080", serverInstance.Handler()); err != nil {
+	return err
+}
+```
 
-See the corresponding example at [server](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/promptiter/server).
+Default paths consist of the base path, application name, and operation path. `{appName}` comes from `WithAppName`. Asynchronous routes are registered only after `WithManager` is configured.
 
-#### Request And Response
+| Method | Path | Behavior |
+| --- | --- | --- |
+| `GET` | `/promptiter/v1/apps/{appName}/structure` | Returns the structure snapshot of the target Agent. |
+| `POST` | `/promptiter/v1/apps/{appName}/runs` | Executes synchronous prompt iteration and returns `RunResult` after completion. |
+| `POST` | `/promptiter/v1/apps/{appName}/async-runs` | Submits asynchronous prompt iteration and returns the initial `RunResult` with a run ID. |
+| `GET` | `/promptiter/v1/apps/{appName}/async-runs/{runID}` | Queries the current `RunResult` of an asynchronous run. |
+| `POST` | `/promptiter/v1/apps/{appName}/async-runs/{runID}/cancel` | Requests cancellation of the specified asynchronous run. |
 
-The core payloads exposed by the PromptIter HTTP service module are:
+When external systems start prompt iteration, they usually call `/structure` first to read the structure snapshot, confirm the `SurfaceID` values allowed to be iterated in the current run, and then write those IDs into `run.TargetSurfaceIDs` in the request body. Call `/runs` when the caller needs to block for the result. Call `/async-runs` when background execution is needed, save the returned run ID, and read the latest `RunResult` through the asynchronous query API.
+
+### Multi-Node Iteration
+
+Multi-node iteration applies when the target object is a Graph Agent and prompts of multiple child Agents jointly affect the final output. Normal function nodes participate in the execution flow but do not export iterable prompts. Child Agents mounted through `AddAgentNode` export their own `instruction surface` values, and these IDs can be written into `RunRequest.TargetSurfaceIDs` as iteration targets. See the complete `multinode` code at [examples/evaluation/promptiter/multinode](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/promptiter/multinode).
+
+`multinode` constructs a sports-recap Graph Agent. The flow first dispatches input from `prepare_game_input`, then generates the headline, highlights, and data angle in parallel. The three results join at `join_recap_parts`, then enter body generation, and finally go to an editor-polish node to produce the final result. The code below shows the Graph Agent node relationships and target Runner creation. Branch input and output mapping belongs to Graph Agent business logic and is handled in the complete source code.
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/graphagent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/graph"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+)
+
+// subAgents are child Agents in the Graph Agent that can be iterated by PromptIter.
+subAgents := []agent.Agent{
+	llmagent.New(
+		headlineAgentName,
+		llmagent.WithModel(candidateModel),
+		// headlineInstruction writes the instruction surface of the headline node.
+		llmagent.WithInstruction(headlineInstruction),
+	),
+	llmagent.New(
+		highlightsAgentName,
+		llmagent.WithModel(candidateModel),
+		// highlightsInstruction writes the instruction surface of the highlights node.
+		llmagent.WithInstruction(highlightsInstruction),
+	),
+	llmagent.New(
+		statsAngleAgentName,
+		llmagent.WithModel(candidateModel),
+		// statsAngleInstruction writes the instruction surface of the data-angle node.
+		llmagent.WithInstruction(statsAngleInstruction),
+	),
+	llmagent.New(
+		recapWriterAgentName,
+		llmagent.WithModel(candidateModel),
+		// recapWriterInstruction writes the instruction surface of the body-generation node.
+		llmagent.WithInstruction(recapWriterInstruction),
+	),
+	llmagent.New(
+		sportsEditorAgentName,
+		llmagent.WithModel(candidateModel),
+		// sportsEditorInstruction writes the instruction surface of the editor-polish node.
+		llmagent.WithInstruction(sportsEditorInstruction),
+	),
+}
+
+// sg describes the static nodes and edges of the target Graph Agent.
+sg := graph.NewStateGraph(graph.NewStateSchema())
+// prepareGameInput is a normal function node that dispatches raw input.
+sg.AddNode(nodePrepareGameInput, prepareGameInput)
+// Three AgentNode nodes generate the headline, highlights, and data angle in parallel.
+sg.AddAgentNode(headlineAgentName)
+sg.AddAgentNode(highlightsAgentName)
+sg.AddAgentNode(statsAngleAgentName)
+// joinRecapParts is a normal function node that joins intermediate results from three branches.
+sg.AddNode(nodeJoinRecapParts, joinRecapParts)
+// recapWriterAgentName and sportsEditorAgentName correspond to serial body-generation and editor-polish nodes.
+sg.AddAgentNode(recapWriterAgentName)
+sg.AddAgentNode(sportsEditorAgentName)
+// SetEntryPoint specifies the graph execution entry point.
+sg.SetEntryPoint(nodePrepareGameInput)
+// AddEdge builds fan-out from the input preparation node to three parallel branches.
+sg.AddEdge(nodePrepareGameInput, headlineAgentName)
+sg.AddEdge(nodePrepareGameInput, highlightsAgentName)
+sg.AddEdge(nodePrepareGameInput, statsAngleAgentName)
+// AddJoinEdge builds fan-in from three parallel branches to the join node.
+sg.AddJoinEdge([]string{headlineAgentName, highlightsAgentName, statsAngleAgentName}, nodeJoinRecapParts)
+// Subsequent edges pass the joined result to the body-generation and editor-polish nodes.
+sg.AddEdge(nodeJoinRecapParts, recapWriterAgentName)
+sg.AddEdge(recapWriterAgentName, sportsEditorAgentName)
+// SetFinishPoint specifies the graph execution finish point.
+sg.SetFinishPoint(sportsEditorAgentName)
+
+// sportsGraph is the compiled graph structure used by the target Graph Agent.
+sportsGraph, err := sg.Compile()
+if err != nil {
+	return err
+}
+
+// candidateAgent is the target Graph Agent of this iteration.
+candidateAgent, err := graphagent.New(
+	rootAgentName,
+	sportsGraph,
+	graphagent.WithSubAgents(subAgents),
+)
+if err != nil {
+	return err
+}
+// candidateRunner is the entry point for Evaluation to execute the target Graph Agent.
+candidateRunner := runner.NewRunner(candidateAppName, candidateAgent)
+```
+
+The example below omits repeated assembly code for `Engine`, `AgentEvaluator`, `Manager`, and the three PromptIter worker components. It focuses on `TargetSurfaceIDs` in the multi-node scenario. A single-Agent scenario usually writes one `candidate#instruction`. A Graph Agent scenario can use the `instruction surface` values of multiple AgentNode nodes as iteration targets at the same time.
 
 ```go
 import (
 	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/manager"
 )
 
-type RunRequest struct {
-	Run *engine.RunRequest `json:"run"`
+// targetSurfaceIDs specifies the instructions of multiple AgentNode nodes allowed to be iterated in this run.
+targetSurfaceIDs := []string{
+	astructure.SurfaceID(rootAgentName+"/"+headlineAgentName, astructure.SurfaceTypeInstruction),
+	astructure.SurfaceID(rootAgentName+"/"+highlightsAgentName, astructure.SurfaceTypeInstruction),
+	astructure.SurfaceID(rootAgentName+"/"+statsAngleAgentName, astructure.SurfaceTypeInstruction),
+	astructure.SurfaceID(rootAgentName+"/"+recapWriterAgentName, astructure.SurfaceTypeInstruction),
+	astructure.SurfaceID(rootAgentName+"/"+sportsEditorAgentName, astructure.SurfaceTypeInstruction),
 }
 
-type RunResponse struct {
-	Result *engine.RunResult `json:"result"`
+// runRequest still specifies the training set, validation set, max rounds, and iteration targets.
+runRequest := &engine.RunRequest{
+	// Train specifies the training set that produces optimization signals.
+	Train: []engine.EvalSetInput{
+		{
+			// EvalSetID points to the training set used to produce optimization signals.
+			EvalSetID: trainEvalSetID,
+		},
+	},
+	// Validation specifies the validation set used for acceptance decisions.
+	Validation: []engine.EvalSetInput{
+		{
+			// EvalSetID points to the validation set used for acceptance decisions.
+			EvalSetID: validationEvalSetID,
+		},
+	},
+	// MaxRounds is the maximum number of iteration rounds for this run.
+	MaxRounds: maxRounds,
+	// TargetSurfaceIDs specifies the multiple prompts allowed to be iterated in this run.
+	TargetSurfaceIDs: targetSurfaceIDs,
 }
 
-type GetStructureResponse struct {
-	Structure *astructure.Snapshot `json:"structure"`
-}
-```
-
-#### Server Construction
-
-The minimal construction is:
-
-```go
-import promptiterserver "trpc.group/trpc-go/trpc-agent-go/server/promptiter"
-
-server, err := promptiterserver.New(
-	promptiterserver.WithAppName(appName),
-	promptiterserver.WithBasePath("/promptiter/v1/apps"),
-	promptiterserver.WithEngine(engineInstance),
-	promptiterserver.WithManager(managerInstance),
+// engineInstance binds the target Graph Agent, evaluator, and three PromptIter worker components.
+engineInstance, err := engine.New(
+	ctx,
+	candidateAgent,
+	agentEvaluator,
+	backwarderInstance,
+	aggregatorInstance,
+	optimizerInstance,
 )
 if err != nil {
 	return err
 }
 
-return http.ListenAndServe(":8080", server.Handler())
+// managerInstance manages asynchronous multi-node iteration on top of Engine.
+managerInstance, err := manager.New(appName, engineInstance)
+if err != nil {
+	return err
+}
+defer managerInstance.Close()
+
+// Start submits multi-node prompt iteration and returns the initial RunResult with a run ID.
+run, err := managerInstance.Start(ctx, runRequest)
+if err != nil {
+	return err
+}
 ```
 
-#### Routes
+Multi-node iteration follows the main PromptIter workflow. The difference is that one run can write multiple AgentNode `instruction surface` values into `TargetSurfaceIDs`. Training-set failure signals are attributed through backpropagation with the actual execution trace. Later text-gradient aggregation and optimization patch generation are limited to these target prompts.
 
-When `WithBasePath("/promptiter/v1/apps")` and `WithAppName(appName)` are used together, the effective routes are:
+## Practical Experience
 
-- `GET /promptiter/v1/apps/{appName}/structure`
-- `POST /promptiter/v1/apps/{appName}/runs`
-- `POST /promptiter/v1/apps/{appName}/async-runs`
-- `GET /promptiter/v1/apps/{appName}/async-runs/{run_id}`
-- `POST /promptiter/v1/apps/{appName}/async-runs/{run_id}/cancel`
+The practical experience below follows PromptIter's integration order: first stabilize evaluation criteria and expected outputs, then complete judge context and failure reasons, and finally narrow iteration targets.
 
-The recommended call order is:
+#### Align Evaluation Metrics
 
-1. Use `/promptiter/v1/apps/{appName}/structure` to fetch the structure snapshot and target editable positions.
-2. Construct `RunRequest` and write `TargetSurfaceIDs`.
-3. For simple scenarios, use blocking `POST /promptiter/v1/apps/{appName}/runs`.
-4. When lifecycle management is needed, use asynchronous `POST /promptiter/v1/apps/{appName}/async-runs` and `GET /promptiter/v1/apps/{appName}/async-runs/{run_id}`.
+The training set is used to expose problems and produce optimization signals, while the validation set is used to decide whether a candidate prompt is acceptable. They can contain different evaluation cases, but the evaluation metrics should express quality requirements that both the training set and validation set need to satisfy. Metrics written specifically around training samples will narrow optimization signals to the training set. Training scores may increase, but candidate prompts may fail validation-set acceptance.
+
+Evaluation criteria should be split into observable and independently verifiable requirements, such as factual grounding, no omission of key process, and title accuracy. Expression preferences in a small number of training samples should not be promoted into evaluation metric requirements shared by the training set and validation set.
+
+#### Expected Output Sources
+
+When metrics that require expected output are used, Evaluation compares the target Agent's actual response or trace with expected-side content and generates scores and decision results. In these metrics, training-set expected output affects losses, text gradients, and candidate patches through failure reasons. Validation-set expected output affects whether a candidate prompt is accepted through validation scores and the acceptance policy, and does not participate in patch generation for the current round. Common sources of expected output are human gold labels and Teacher distillation.
+
+Human gold labels are annotated or reviewed expected outputs. They are suitable for tasks with stable input distribution, clear evaluation criteria, and long-term regression needs. When gold labels are used in the training set, factual errors or inconsistent criteria may produce incorrect failure reasons. When gold labels are used in the validation set, they may cause candidate prompts to be incorrectly accepted or rejected. Therefore, before gold labels enter the training set or validation set, their facts, format, and criteria should be reviewed.
+
+Teacher distillation means using a stronger model during evaluation, or using a prompt that contains more rules, examples, and context to generate dynamic expected output. The Teacher can be heavier than the target Agent because it is only used to generate evaluation references and does not enter the target Agent's production call path. It is suitable when the sample scale is large, manual annotation cost is high, or expected output depends on real-time context and can be reproducibly generated.
+
+Teacher output still needs sampling review. If the Teacher has factual errors, format drift, or inconsistent criteria, training-set evaluation will convert those deviations into incorrect optimization signals, and validation-set evaluation will convert them into distorted acceptance decisions. Complex prompts can be used for the Teacher, but they should not be directly migrated to the target Agent. Rules, examples, and context in the Teacher prompt are not necessarily effective for the target Agent. Long prompts also increase context usage, constraint conflicts, and maintenance cost. The goal of Teacher distillation is not to copy the full Teacher prompt, but to convert high-quality expected output into evaluation signals, then let PromptIter generate prompt patches that the target Agent can maintain long term.
+
+#### Judge Context
+
+Judge context is used to construct LLM Judge input and should be organized around evaluation criteria. When evaluation criteria only check expression quality, structural completeness, or consistency with a reference answer, the user input, actual final answer, and reference answer are usually enough. When evaluation criteria involve factual grounding, retrieval results, tool results, or business rules, related evidence must also enter the judge input. Evidence can come from business data, key retrieval results, tool results, or evaluation samples. Content not included in the judge input does not participate in the LLM Judge decision.
+
+When supplementing judge context, include only verifiable materials directly related to evaluation criteria, such as business data, key retrieval results, tool results, and rule descriptions. If evidence is insufficient, failure reasons tend to become generic. If too much material is included, irrelevant information dilutes the evaluation focus and increases decision fluctuation. Training sets and validation sets should use consistent context-construction rules to avoid training-stage failure reasons and validation-stage scores coming from different evaluation criteria.
+
+#### Supplement Reasons With LossHint
+
+PromptIter extracts losses from failed training-set metrics. `LossHint` supplements business-side known problem reasons on top of existing losses. Its position is the training-set optimization signal. Training scores are still produced by evaluation metrics, and validation-set acceptance decisions are still produced by validation-set evaluation results and the acceptance policy. After `LossHint` matches an evaluation case and metric that have already failed in the current training evaluation, it is merged into the corresponding loss for `Backward` to generate text gradients.
+
+The benefit of `LossHint` comes from incremental problem information. If failure reasons in evaluation results already cover the business-side problem, a synonymous `LossHint` mainly serves as a record and brings limited optimization benefit. It is more suitable for training samples whose judge-generated failure reasons are inaccurate or incomplete. In that case, `LossHint` adds the manually confirmed issue to the training-set loss as an optimization direction for subsequent backpropagation attribution and prompt patch generation.
+
+#### Select Iteration Targets
+
+When selecting iteration targets, align failure signals with node responsibilities first. The structure snapshot confirms iterable node prompts in the target Agent, and the execution trace reconstructs nodes and steps passed in the current run. After combining failure reasons and node outputs, you can decide which node prompts mainly caused the issue.
+
+If failure reasons are concentrated in the output of one node, the iteration target can be limited to that node's prompt. If failure reasons involve multiple cooperating nodes, prompts of adjacent-responsibility nodes that jointly affect the same type of quality issue can be included in the same round. Prompts that already show stable quality and limited optimization space in execution traces and evaluation results should keep their current version. Too many targets expand the impact range of patches and reduce the interpretability of validation results.
+
+When the target scope is focused, the relationship between candidate patches and validation results is clearer. When expanding the target scope, each newly added target should carry failure signals from the current round and jointly point to the same type of quality issue with the other targets in the same round. After a candidate prompt passes the acceptance decision, review each target's patch content, modification reason, and validation result in a test environment before entering the business release process.

--- a/docs/mkdocs/zh/promptiter.md
+++ b/docs/mkdocs/zh/promptiter.md
@@ -1,68 +1,111 @@
 # PromptIter 使用文档
 
-随着评估能力逐步完善，提示词优化不再只是手工修改一段提示词，再用少量样本做一次主观验证，而需要基于固定评估集、固定指标和稳定接受标准，持续得到可比较、可回归的优化结果。
+当 Agent 的提示词承载业务规则，版本风险不只来自显性失败，也来自改写后的行为漂移。一次手工改写可能修复某个失败样本，也可能降低其他场景的输出质量。训练集分数提升无法证明候选版本可被接受，验证集评估结果和接受策略共同形成候选版本的接受判定。PromptIter 将训练集、验证集、结构快照与执行轨迹组织为可复现的提示词迭代流程，并把每轮候选版本、分数、补丁和停止原因沉淀为结果快照。
 
-Evaluation 用于评估当前版本的表现，PromptIter 用于基于训练集和验证集持续得到更好的提示词版本。它建立在 Evaluation 之上，复用评估集、评估指标和评估器体系，并在此基础上增加训练集与验证集分离、多轮优化、接受策略、停止策略、异步运行管理和 HTTP 接口等能力。
+tRPC-Agent-Go 框架在 Evaluation 的评估能力基础上提供 PromptIter，用于把 Agent 提示词优化从人工改写推进为受评估约束的自动化迭代流程。PromptIter 以训练集、验证集和评估指标为核心，将训练集暴露出的失败信号沿执行轨迹做反向传播归因，再通过文本梯度聚合和优化补丁生成形成候选提示词，并由验证集评估与接受策略决定候选提示词是否进入后续轮次。每次运行都会沉淀候选提示词、验证结果、接受判定和停止原因，使不同提示词版本可以在既定评估标准下被比较、审查和追踪，支持同步运行、异步运行、HTTP 迭代服务和多节点迭代。
 
-如果你还不熟悉评估集、评估指标和评估服务的基本概念，建议先阅读 [Evaluation 使用文档](evaluation.md)。
+## 背景
+
+提示词优化在试验阶段通常依赖手工判断与改写，根据零散失败样本调整提示词，再用少量样本验证。该方式适用于探索，但难以支撑持续交付。同一处提示词改动可能同时影响任务理解、工具选择，以及最终回答的内容、结构和表达方式。单个样本上的改善只是局部信号，不能替代覆盖多场景的回归验证。
+
+当 Agent 进入业务链路后，提示词优化的常见风险可分为四类。
+
+1. 优化目标存在漂移风险。人工修复单个失败样本时，可能向提示词中加入过窄约束。约束范围若只覆盖当前样本，其他样本的输出质量可能下降
+2. 训练信号和验收信号存在混用风险。同一批失败样本既用于产生修改建议，又用于评估候选提示词，会放大过拟合风险。更严谨的方式是让训练集负责暴露问题和产生优化信号，让验证集提供候选提示词接受判定所需的验证分数
+3. 失败信号难以归因到具体节点。对于单 Agent，问题可能来自该 Agent 的提示词。对于图编排和多 Agent，问题可能来自规划、检索、草稿生成、编辑审核中的任一步。仅看最终回答，难以判断失败信号应归因到哪个节点
+4. 提示词版本缺少结构化记录。手工替换提示词内容能够完成一次修改，但难以追踪候选提示词来自哪些失败信号、修改了哪些位置、因何被接受或拒绝
+
+PromptIter 通过独立环节分别处理上述风险。Evaluation 提供可复现的评估输入和指标输出。结构快照描述待测 Agent 的静态组成，包括节点、边与节点关联的可迭代内容。执行轨迹记录本次运行实际的动态步骤路径。反向传播归因、文本梯度聚合和优化补丁生成三个阶段把失败信号逐步转成候选补丁。验证集评估结果和接受策略共同形成候选提示词的接受判定。
+
+## 业界调研
+
+提示词优化不只是对提示词文本进行直接改写。更稳定的方式是先定义评估标准，再从失败样本中提取修改方向，生成候选提示词，并通过独立样本验证候选提示词是否满足接受条件。业界在这个方向已有多种探索。
+
+[ProTeGi](https://arxiv.org/abs/2305.03495) 面向单个任务提示词的自动搜索。该方法将数值优化中的梯度下降类比到自然语言场景。流程先运行当前提示词并收集错误样本，再让模型总结这些错误暴露出的提示词问题，形成自然语言梯度。随后根据自然语言梯度生成多条候选提示词，并在每轮保留得分较高的候选继续搜索，最终选择评估表现更优的版本。
+
+[TextGrad](https://arxiv.org/abs/2406.07496) 面向复杂 AI 系统中的文本变量优化。它把系统表示为计算图，图中的变量可以是提示词、代码片段或其他文本对象。前向执行后，目标函数、评价器或下游损失信号产生反馈，LLM 将反馈写成自然语言梯度，再沿计算图反向传播到相关变量。
+
+[DSPy](https://arxiv.org/abs/2310.03714) 面向由多个语言模型调用组成的处理流程。开发者用签名描述模块输入输出，再用程序组织模块调用关系，由编译器围绕给定指标优化示例、提示词等可学习部分。
+
+上述方法说明，提示词优化可以围绕评估反馈、候选生成和指标验证形成自动化流程。但从业务落地看，ProTeGi 主要面向单段提示词搜索，难以直接适用于多节点 Agent 场景。TextGrad 提供通用文本变量优化抽象，但评估资产管理、候选版本验收和运行结果追踪等工程化实现仍需自行实现。DSPy 需要按其模块和签名重新组织语言模型调用流程，对已有 Agent 工程存在较高迁移成本。
+
+tRPC-Agent-Go 通过 PromptIter 将这类优化流程落到已有 Agent 工程中，将训练集评估反馈、反向传播归因、文本梯度聚合、优化补丁生成、候选提示词构造、验证集接受判定和结果追踪组织成闭环。
 
 ## 快速开始
 
-本节给出一个最小使用示例，帮助读者先完成一次 PromptIter 运行，再继续理解后面的核心概念与使用方法。
+本节用 `examples/evaluation/promptiter/syncrun` 说明提示词同步迭代的最小接入方式。完整示例见 [examples/evaluation/promptiter/syncrun](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/promptiter/syncrun)。
 
-PromptIter 提供以下三个示例：
+示例代码覆盖以下接入方式。
 
-- [examples/evaluation/promptiter/syncrun](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/promptiter/syncrun)，直接使用 `engine.Run(...)` 执行同步优化。
-- [examples/evaluation/promptiter/asyncrun](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/promptiter/asyncrun)，通过 `manager.Start` 和 `manager.Get` 管理异步运行。
-- [examples/evaluation/promptiter/server](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/promptiter/server)，通过 PromptIter HTTP 服务模块暴露接口。
-
-本节以 `syncrun` 为例，说明最小接入方式。
+- [examples/evaluation/promptiter/syncrun](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/promptiter/syncrun) 演示提示词同步迭代。
+- [examples/evaluation/promptiter/asyncrun](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/promptiter/asyncrun) 演示提示词异步迭代。
+- [examples/evaluation/promptiter/server](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/promptiter/server) 演示提示词迭代 HTTP 接入。
+- [examples/evaluation/promptiter/multinode](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/promptiter/multinode) 演示多节点提示词迭代。
 
 ### 环境准备
 
-- Go 1.24+
-- 可访问的 OpenAI 兼容模型服务
-- 已准备好的训练集评估文件、验证集评估文件和指标文件
+运行示例前需要准备三类资源。
 
-运行前需要设置模型服务环境变量。
+- 可访问的 OpenAI 兼容模型服务
+- 训练集、验证集和指标文件
+- 待测 Agent、裁判和 PromptIter 工作组件的模型名称
+
+示例通过环境变量读取模型服务地址和密钥。
 
 ```bash
+# 设置模型服务密钥
 export OPENAI_API_KEY="sk-xxx"
+# 可选，不设置时示例使用 OpenAI 兼容默认地址
 export OPENAI_BASE_URL="https://api.openai.com/v1"
 ```
 
-### 基于本地文件的同步优化示例
+### 待测 Agent
 
-本示例基于本地文件运行 PromptIter，完整代码见 [examples/evaluation/promptiter/syncrun](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/promptiter/syncrun)。
+`syncrun` 示例中的待测 Agent 名为 `candidate`，是由 `llmagent.New` 创建的 LLMAgent。示例通过 `newCandidateAgent` 创建该 Agent，并把起始提示词作为 `instruction` 传入。后续运行会把修改目标限定为 `candidate` 的 `instruction`。
 
-如需先完成一次运行并观察结果，可以直接进入示例目录执行 `go run .`。本节代码片段用于说明 PromptIter 依赖的组装方式，并不要求读者从零手写完整示例。
+默认起始提示词为 `生成一篇中文体育战报`。这段起始提示词用于展示 PromptIter 如何根据训练集失败信号生成候选补丁，并依据验证集评估结果和接受策略逐轮接受或拒绝候选提示词。
 
-下面给出三段核心代码片段，分别用于准备评估依赖、构造 Engine 和发起运行。
-
-#### Agent 与 Evaluator 代码片段
-
-这段代码用于准备 PromptIter 运行依赖，主要包括三部分：
-
-- 构建被优化的 candidate Agent，以及评估阶段使用的 judge Agent。
-- 为 candidate Agent 和 judge Agent 创建 Runner。
-- 复用 Evaluation 体系创建 `AgentEvaluator`，供 PromptIter 在训练集和验证集阶段执行评估。
-
-示例中的 `candidateAgent` 是一个普通的 `llmagent`，被优化的目标是它的提示词内容。最小构造方式如下：
+待测 Agent 和 Runner 的创建代码如下。
 
 ```go
-import "trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
-
-candidateAgent, err := llmagent.New(
-	candidateAgentName,
-	llmagent.WithModel(candidateModel),
-	llmagent.WithInstruction("You are a helpful assistant."),
+import (
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
 )
-if err != nil {
-	return err
+
+// newCandidateAgent 创建待测 Agent。
+func newCandidateAgent(m model.Model) (agent.Agent, error) {
+	// generationConfig 固定待测 Agent 的生成参数。
+	generationConfig := model.GenerationConfig{
+		// MaxTokens 给体育战报保留足够输出空间。
+		MaxTokens:   intPtr(32768),
+		// Temperature 降低同一评估用例上的随机波动。
+		Temperature: floatPtr(0.0),
+		// Stream 关闭流式输出，便于 Evaluation 收集完整回答。
+		Stream:      false,
+	}
+	return llmagent.New(
+		"candidate",
+		llmagent.WithModel(m),
+		// PromptIter 本次运行会迭代这段 instruction。
+		llmagent.WithInstruction("生成一篇中文体育战报"),
+		llmagent.WithGenerationConfig(generationConfig),
+	), nil
 }
+
+candidateAgent, err := newCandidateAgent(candidateModel)
+if err != nil {
+	return nil, fmt.Errorf("create candidate agent: %w", err)
+}
+// Runner 是 Evaluation 执行待测 Agent 的入口。
+candidateRunner := runner.NewRunner("promptiter-nba-commentary-candidate", candidateAgent)
 ```
 
-示例中的 `judgeAgent` 也是普通 Agent。下面的代码展示如何为 `candidateAgent` 和 `judgeAgent` 创建 Runner，并基于 Evaluation 体系组装 `AgentEvaluator`。
+### 构造 AgentEvaluator
+
+评估阶段需要运行待测 Agent，并用训练集、验证集和指标文件计算分数。示例用 `candidateRunner` 表示待测 Agent 的运行入口，并通过 `evaluation.New` 创建 `AgentEvaluator`。使用 LLM Judge 类指标时，还需要提供作为裁判的 Judge Runner。随后示例创建本地 `EvalSetManager`、`MetricManager` 和 `EvalResultManager`，分别负责读取评估集、读取指标和保存评估结果。
 
 ```go
 import (
@@ -71,30 +114,26 @@ import (
 	evalresultlocal "trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult/local"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
 	evalsetlocal "trpc.group/trpc-go/trpc-agent-go/evaluation/evalset/local"
-	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/registry"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
 	metriclocal "trpc.group/trpc-go/trpc-agent-go/evaluation/metric/local"
 	"trpc.group/trpc-go/trpc-agent-go/runner"
 )
 
-candidateRunner := runner.NewRunner(candidateAppName, candidateAgent)
+// 使用 LLM Judge 类指标时，需要提供裁判 Runner。
 judgeRunner := runner.NewRunner(judgeAppName, judgeAgent)
 
-evalSetManager := evalsetlocal.New(evalset.WithBaseDir(cfg.DataDir))
-metricManager := metriclocal.New(
-	metric.WithBaseDir(cfg.DataDir),
-	metric.WithLocator(&sharedMetricLocator{metricFileID: sharedMetricFileID}),
-)
-evalResultManager := evalresultlocal.New(evalresult.WithBaseDir(cfg.OutputDir))
-registry := registry.New()
+// 评估集、指标和评估结果分别由对应 Manager 管理。
+evalSetManager := evalsetlocal.New(evalset.WithBaseDir("./data"))
+metricManager := metriclocal.New(metric.WithBaseDir("./data"))
+evalResultManager := evalresultlocal.New(evalresult.WithBaseDir("./output"))
 
+// AgentEvaluator 负责执行训练集和验证集评估。
 agentEvaluator, err := evaluation.New(
 	appName,
 	candidateRunner,
 	evaluation.WithEvalSetManager(evalSetManager),
 	evaluation.WithMetricManager(metricManager),
 	evaluation.WithEvalResultManager(evalResultManager),
-	evaluation.WithRegistry(registry),
 	evaluation.WithJudgeRunner(judgeRunner),
 )
 if err != nil {
@@ -102,9 +141,92 @@ if err != nil {
 }
 ```
 
-#### Engine 构造
+### 评估文件
 
-这段代码为反向传播器、梯度聚合器和优化器三个工作流组件分别创建 Runner 与实例，再将这些实例与 `candidateAgent` 和 `AgentEvaluator` 一起组装为 `Engine`。
+本地 `EvalSetManager` 和 `MetricManager` 会从示例的数据目录读取评估集和指标文件。PromptIter 沿用 Evaluation 的本地文件组织方式。一次 PromptIter 运行通过评估集 ID 指定要使用的训练集和验证集。完整示例复用同一个指标文件，这属于 Evaluation 文件组织细节，本文不展开。
+
+```text
+# data 是示例评估文件目录。
+data/
+  promptiter-nba-commentary-app/
+    nba-commentary-train.evalset.json
+    nba-commentary-validation.evalset.json
+    sports-commentary.metrics.json
+```
+
+这三类文件职责不同。
+
+- `nba-commentary-train.evalset.json` 是训练集，用于产生失败信号和优化信号。
+- `nba-commentary-validation.evalset.json` 是验证集，用于提供接受判定所需的评估结果。
+- `sports-commentary.metrics.json` 是指标文件，用于定义训练集和验证集共用的评分规则。
+
+本示例的训练集和验证集都使用同一种评估用例结构。`userContent.content` 是待测 Agent 的输入，内容是一段结构化比赛 JSON。`finalResponse.content` 是评估阶段使用的参考输出，内容是一篇预先写好的中文体育战报。
+
+```json
+{
+  "evalId": "train_01_nba_nuggets_blowout",
+  "conversation": [
+    {
+      "userContent": {
+        "role": "user",
+        "content": "{\"sport\":\"basketball\",\"league\":\"NBA\",\"teams\":{\"home\":{\"name\":\"丹佛掘金\",\"score\":128},\"away\":{\"name\":\"波特兰开拓者\",\"score\":104}},\"recapAngle\":\"丹佛外线和替补深度早早拉开比赛，主力末节无需久留\"}"
+      },
+      "finalResponse": {
+        "role": "assistant",
+        "content": "掘金128比104大胜开拓者 18记三分+替补52分让主力末节早收\n\n2026年1月12日，丹佛掘金在Ball Arena以128比104击败波特兰开拓者……"
+      }
+    }
+  ]
+}
+```
+
+运行评估时，Evaluation 会把 `userContent.content` 发送给待测 Agent，并用待测 Agent 的实际输出与 `finalResponse.content` 进行指标计算。固定参考输出使每次运行都对齐同一批评估基准，避免在线生成参考答案带来的额外波动。
+
+指标文件包含两个指标，关键字段如下。
+
+```json
+[
+  {
+    "metricName": "final_response_avg_score",
+    "threshold": 1.0,
+    "criterion": {
+      "finalResponse": {
+        "text": {
+          "length": {
+            "min": 350,
+            "max": 850
+          },
+          "matchStrategy": "skip"
+        }
+      }
+    }
+  },
+  {
+    "metricName": "llm_rubric_critic",
+    "threshold": 0.98,
+    "criterion": {
+      "llmJudge": {
+        "rubrics": [
+          {
+            "id": "source_grounding",
+            "description": "战报必须完全基于用户输入。",
+            "type": "FINAL_RESPONSE_QUALITY",
+            "content": {
+              "text": "实际战报只能使用用户输入和参考战报支持的事实。"
+            }
+          }
+        ]
+      }
+    }
+  }
+]
+```
+
+`final_response_avg_score` 是 Evaluation 提供的最终回答评估器，示例用它约束战报长度。`llm_rubric_critic` 是 LLM Judge 类指标，示例用它结合参考战报和 rubric 检查事实依据、主线、决定性过程、数字、标题、数据解释和中文体育文案质量。
+
+### 构造 Engine
+
+构造 PromptIter 的 `Engine` 时，需要先提供待测 Agent 和 `AgentEvaluator`。待测 Agent 用于导出结构快照，`AgentEvaluator` 用于执行训练集和验证集评估。候选补丁还依赖 `Backwarder`、`Aggregator` 和 `Optimizer`。`Backwarder` 负责反向传播归因，把训练集失败信号转成文本梯度，即指向相关步骤和提示词的修改方向。`Aggregator` 负责文本梯度聚合，把同一段待修改提示词上的多条文本梯度合成聚合结果。`Optimizer` 负责优化补丁生成，根据聚合结果生成这段提示词的候选补丁。
 
 ```go
 import (
@@ -115,23 +237,30 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/runner"
 )
 
+// backwarderRunner 调用模型完成反向传播归因。
 backwarderRunner := runner.NewRunner(backwarderAppName, backwarderAgent)
+// aggregatorRunner 调用模型完成文本梯度聚合。
 aggregatorRunner := runner.NewRunner(aggregatorAppName, aggregatorAgent)
+// optimizerRunner 调用模型完成优化补丁生成。
 optimizerRunner := runner.NewRunner(optimizerAppName, optimizerAgent)
 
+// Backwarder 负责反向传播归因。
 backwarderInstance, err := backwarder.New(ctx, backwarderRunner)
 if err != nil {
 	return err
 }
+// Aggregator 负责文本梯度聚合。
 aggregatorInstance, err := aggregator.New(ctx, aggregatorRunner)
 if err != nil {
 	return err
 }
+// Optimizer 负责优化补丁生成。
 optimizerInstance, err := optimizer.New(ctx, optimizerRunner)
 if err != nil {
 	return err
 }
 
+// Engine 绑定待测 Agent、评估器和三个 PromptIter 工作组件。
 engineInstance, err := engine.New(
 	ctx,
 	candidateAgent,
@@ -145,9 +274,9 @@ if err != nil {
 }
 ```
 
-#### 构造请求并执行
+### 构造 RunRequest
 
-这段代码构造 `RunRequest`，用于指定训练集、验证集、评估执行参数、接受策略、停止策略以及待优化的目标可编辑位置，然后调用 `engine.Run(...)` 发起一次多轮优化运行。
+`RunRequest` 指定一次 PromptIter 运行的训练集、验证集、迭代目标、最大轮数、接受策略和停止策略。
 
 ```go
 import (
@@ -155,292 +284,866 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
 )
 
+// targetScore 是本次运行的目标验证集分数。
 targetScore := 1.0
-targetSurfaceID := astructure.SurfaceID(candidateAgentName, astructure.SurfaceTypeInstruction)
+// targetInstructionID 指向 candidate Agent 的 instruction，值为 candidate#instruction。
+targetInstructionID := astructure.SurfaceID("candidate", astructure.SurfaceTypeInstruction)
 
 result, err := engineInstance.Run(ctx, &engine.RunRequest{
+	// Train 指定产生优化信号的训练集。
 	Train: []engine.EvalSetInput{
 		{
-			EvalSetID: "nba-commentary-train",
+			// EvalSetID 指向用于产生优化信号的训练集。
+			EvalSetID: trainEvalSetID,
 		},
 	},
+	// Validation 指定接受判定使用的验证集。
 	Validation: []engine.EvalSetInput{
 		{
-			EvalSetID: "nba-commentary-validation",
+			// EvalSetID 指向用于接受判定的验证集。
+			EvalSetID: validationEvalSetID,
 		},
 	},
+	// 训练集和验证集评估阶段按评估用例并发。
 	EvaluationOptions: engine.EvaluationOptions{
-		EvalCaseParallelism:               8,
+		// EvalCaseParallelism 限制评估用例并发数。
+		EvalCaseParallelism:               16,
+		// EvalCaseParallelInferenceEnabled 开启待测 Agent 并发推理。
 		EvalCaseParallelInferenceEnabled:  true,
+		// EvalCaseParallelEvaluationEnabled 开启指标并发计算。
 		EvalCaseParallelEvaluationEnabled: true,
 	},
-	AcceptancePolicy: engine.AcceptancePolicy{
-		MinScoreGain: 0.005,
+	// 反向传播归因阶段默认按评估用例串行处理。
+	BackwardOptions: engine.BackwardOptions{
+		// CaseParallelismEnabled 控制是否并发处理训练集评估用例。
+		CaseParallelismEnabled: false,
+		// CaseParallelism 是开启并发后的评估用例并发上限。
+		CaseParallelism:        16,
 	},
+	// 文本梯度聚合阶段按迭代目标并发。
+	AggregationOptions: engine.AggregationOptions{
+		// SurfaceParallelismEnabled 控制是否并发处理多个迭代目标。
+		SurfaceParallelismEnabled: true,
+		// SurfaceParallelism 是迭代目标并发上限。
+		SurfaceParallelism:        16,
+	},
+	// 优化补丁生成阶段按迭代目标并发。
+	OptimizerOptions: engine.OptimizerOptions{
+		// SurfaceParallelismEnabled 控制是否并发为多个迭代目标生成补丁。
+		SurfaceParallelismEnabled: true,
+		// SurfaceParallelism 是迭代目标并发上限。
+		SurfaceParallelism:        16,
+	},
+	// 候选提示词需要相对当前基准提示词提升至少 0.01 分。
+	AcceptancePolicy: engine.AcceptancePolicy{
+		// MinScoreGain 是接受候选提示词所需的最小验证分数增量。
+		MinScoreGain: 0.01,
+	},
+	// 达到最大轮数、连续未接受轮数或目标分数时停止。
+	MaxRounds: 4,
 	StopPolicy: engine.StopPolicy{
-		MaxRoundsWithoutAcceptance: 5,
+		// MaxRoundsWithoutAcceptance 限制连续未接受候选提示词的轮数。
+		MaxRoundsWithoutAcceptance: 3,
+		// TargetScore 是达到后即可停止的目标验证分数。
 		TargetScore:                &targetScore,
 	},
-	MaxRounds:        4,
-	TargetSurfaceIDs: []string{targetSurfaceID},
+	// 本次迭代目标是 candidate Agent 的 instruction。
+	TargetSurfaceIDs: []string{targetInstructionID},
 })
 if err != nil {
 	return err
 }
 ```
 
-#### 评估文件
+示例中 `TargetSurfaceIDs` 设置为 `candidate#instruction`，因此本次运行的迭代目标是待测 Agent 的 instruction。接入多 Agent 或图编排场景时，应先通过 `engine.Describe(ctx)` 或 HTTP `/structure` 接口获取结构快照，再从返回结果中选择要迭代的目标，避免在业务代码中写死目标 ID。
 
-PromptIter 的评估数据沿用 Evaluation 的文件组织方式，只是在一次运行中会同时使用训练集和验证集。示例目录结构如下所示。
-
-```bash
-data/
-  promptiter-nba-commentary-app/
-    nba-commentary-train.evalset.json
-    nba-commentary-validation.evalset.json
-    sports-commentary.metrics.json
-```
-
-这三类文件的职责如下：
-
-- `nba-commentary-train.evalset.json` 作为训练集，用于生成优化信号和修改建议。PromptIter 会在每一轮先基于训练集完成前向推理和指标评估，再从失败样本中提取 loss、做反向传播和梯度聚合。
-- `nba-commentary-validation.evalset.json` 作为验证集，用于判断当前改动是否应该被接受。训练集负责提供优化信号，验证集负责判断当前改动是否真的更好。这两类评估集分工不同，不应混用。
-- `sports-commentary.metrics.json` 作为评估指标文件，用于定义评估指标。PromptIter 直接复用 Evaluation 的评估指标。示例默认使用 `llm_rubric_reference_critic` 和 `final_response_length_compliance` 两条指标，前者负责与参考答案的内容对齐，后者负责长度约束。示例直接使用 EvalSet 中的静态参考答案完成参考答案对齐评估。
-
-#### 执行运行
+### 执行同步迭代
 
 ```bash
-cd examples/evaluation/promptiter/syncrun
+# 设置模型服务密钥
 export OPENAI_API_KEY="sk-xxx"
+# 可选，不设置时示例使用 OpenAI 兼容默认地址
 export OPENAI_BASE_URL="https://api.openai.com/v1"
-go run .
+
+# 运行提示词同步迭代示例
+go -C examples/evaluation run ./promptiter/syncrun \
+  -data-dir ./promptiter/syncrun/data \
+  -output-dir ./promptiter/syncrun/output \
+  -model "deepseek-v3.2" \
+  -judge-model "gpt-5.2" \
+  -worker-model "gpt-5.2"
 ```
 
-#### 查看结果
+示例默认开启训练集和验证集的评估用例级并发推理与并发评估，也默认开启文本梯度聚合和优化补丁生成阶段的迭代目标级并发。反向传播归因阶段默认按评估用例串行处理。如果模型服务限制并发，可调低 `-eval-case-parallelism`、`-aggregation-parallelism` 或 `-optimizer-parallelism`，也可关闭对应的并发开关。
 
-运行完成后，结果主要通过以下两处查看：
+### 查看结果
 
-- 终端输出，用于查看初始提示词、最终接受的提示词、每轮分数和停止原因。
-- 输出目录，用于查看每轮训练集和验证集评估结果及中间文件。
+提示词同步迭代完成后，`engine.Run(...)` 返回 `RunResult`。示例会在终端打印结构 ID、迭代目标、起始提示词、最终采纳的基准提示词、验证分数和每轮判定结果。
 
-同步运行时，`engine.Run(...)` 会直接返回 `RunResult`。异步运行以及返回运行结果的 HTTP 接口也都使用 `RunResult` 作为结果数据结构。
+示例输出如下表所示。
+
+| 输出项 | 示例值 |
+| --- | --- |
+| Initial validation score | `0.49` |
+| Final accepted validation score | `0.90` |
+| Rounds executed | `4` |
+| Round 1 | train `0.35`，validation `0.85`，accepted `true`，delta `0.36` |
+| Round 2 | train `0.83`，validation `0.90`，accepted `true`，delta `0.05` |
+| Round 3 | train `0.87`，validation `0.81`，accepted `false`，delta `-0.09` |
+| Round 4 | train `0.89`，validation `0.80`，accepted `false`，delta `-0.10` |
+
+该输出体现 PromptIter 的接受语义。第 1 轮和第 2 轮候选提示词通过接受判定，当前基准逐步更新到第 2 轮候选提示词。第 3 轮和第 4 轮虽然训练集分数较高，但候选提示词的验证分数没有超过当前基准提示词的验证分数，因此未被接受，最终基准停留在第 2 轮候选提示词。
 
 ## 核心概念
 
-PromptIter 在 Evaluation 之上增加了一条多轮优化流程。它的核心输入包括训练集、验证集、目标可编辑位置和运行策略，核心输出是一次运行的结果 `RunResult`。
+如下图所示，PromptIter 从起始提示词开始迭代。运行开始时，起始提示词形成起始基线，并作为第一轮的当前基准。每轮都会根据训练集失败信号生成候选提示词，再通过验证集评估和接受策略判断候选提示词是否优于当前基准。候选提示词通过接受判定后，才会更新当前基准并进入下一轮；未通过时，当前基准保持不变。迭代输入由 `RunRequest` 描述，迭代输出为 `RunResult`。
 
-`Engine` 负责执行整条优化流程。这里的训练集评估和验证集评估都包含前向推理与指标评估两个子步骤。下图用于说明各个运行阶段之间的先后关系以及回到下一轮的循环路径。
+![overview.svg](../assets/img/promptiter/overview.svg)
 
-```mermaid
-flowchart TB
-    A[RunRequest] --> B[基线验证]
-    B --> C[训练集评估]
-    C --> D[反向传播]
-    D --> E[梯度聚合]
-    E --> F[优化器生成修改建议]
-    F --> G[新的候选版本]
-    G --> H[验证集评估]
-    H --> I[接受判定]
-    I --> J[停止判定]
-    J --> K[RunResult]
-    J -->|继续下一轮| C
-```
+- **运行请求 RunRequest** 用于描述一次迭代运行的输入，包含训练集、验证集、迭代目标、最大轮数、接受策略和停止策略。
+- **起始基线验证 Baseline Validation** 基于起始提示词执行验证集评估，记录起始基线的验证分数。
+- **训练集评估 Train Evaluation** 基于当前基准提示词执行训练集评估，产出后续优化所需的失败信号。训练集不承担候选提示词验收职责。
+- **反向传播 Backward** 结合训练集失败原因和动态执行轨迹执行反向传播归因，将失败信号关联到目标提示词，并生成文本梯度。
+- **文本梯度聚合 Aggregate** 按目标提示词聚合文本梯度，形成面向该目标的聚合梯度。
+- **优化补丁生成 Optimize** 基于聚合梯度生成候选补丁。
+- **候选提示词快照 Candidate Profile** 表示将候选补丁应用到当前基准提示词后得到的提示词快照，是验证集评估的输入。
+- **验证集评估 Validation Evaluation** 基于候选提示词快照执行验证集评估，输出验证分数和指标明细。
+- **接受策略 Accept Policy** 对照候选提示词快照与当前基准的验证结果，判断是否更新当前基准。
+- **停止策略 Stop Policy** 根据运行状态判断是否结束本次运行。未满足停止条件时，流程回到训练集评估并进入下一轮。
+- **运行结果 RunResult** 汇总本次运行的结构快照、起始基线验证、训练评估、失败信号、反向传播归因、文本梯度聚合、候选补丁、候选提示词快照、验证评估和判定结果。
 
-一次 PromptIter 运行通常按以下顺序展开：
+一次 PromptIter 运行通常包含以下步骤。
 
-1. 读取 `RunRequest`，确定训练集、验证集、目标可编辑位置和运行策略。
-2. 对当前候选版本执行一次基线验证。
-3. 使用训练集完成前向推理与指标评估，并从失败样本中提取 loss。
-4. 将 loss 交给反向传播器和梯度聚合器，得到聚合后的优化信号。
-5. 由优化器根据聚合后的优化信号生成修改建议，形成新的候选版本。
-6. 使用验证集对新的候选版本完成前向推理与指标评估。
-7. 根据接受策略决定是否接受当前改动，并根据停止策略判断是否结束本次运行。
-8. 未触发停止条件时，下一轮会从训练集评估重新开始。
+1. PromptIter 根据 `RunRequest` 确认训练集、验证集和本次允许迭代的提示词
+2. Train Evaluation 在当前基准提示词上执行训练集评估，提取失败信号
+3. Backward 根据失败原因和动态执行轨迹生成目标提示词上的文本梯度
+4. Aggregate 聚合同一目标提示词上的文本梯度
+5. Optimize 根据聚合梯度生成候选补丁，并形成候选 Profile
+6. Validation Evaluation 在候选 Profile 上执行验证集评估
+7. Accept Policy 判断是否将候选 Profile 接受为新的当前基准
+8. Stop Policy 判断本次运行是否结束，未结束时进入下一轮
+9. PromptIter 将过程和结果写入 `RunResult`
 
-PromptIter 由评估、归因、聚合、优化器生成修改建议、接受判定和停止判定组成一条多轮流程。下面从评估数据、目标可编辑位置、候选版本、修改建议、运行输入输出以及接入方式几个方面展开说明。
+## 使用方法
 
 ### 评估体系
 
-PromptIter 直接建立在 Evaluation 之上，复用其中的评估数据与评估执行流程。
+PromptIter 复用 Evaluation 的评估资产和执行能力。
 
-- `EvalSet` 用于定义训练集和验证集中的评估用例。
-- `EvalMetric` 用于定义每条评估指标的打分规则。
-- `Evaluator` 用于执行单条指标的评分逻辑。
-- `EvalResult` 用于承载每次评估运行的结果明细。
-- `AgentEvaluator` 用于组织一次完整评估，读取评估集、指标和评估器，并返回评估结果。
+- `EvalSet` 描述训练集和验证集中的评估用例。
+- `EvalMetric` 描述每条评估指标，以及判断该指标是否通过的得分阈值。
+- `Evaluator` 执行单条指标的评分逻辑。
+- `AgentEvaluator` 组织一次评估，读取评估集和指标，通过注册中心调用评估器，并返回聚合结果。
+- `EvalResultManager` 保存每次评估结果，local 模式会写入本地文件。
 
-在 PromptIter 中，训练集评估和验证集评估都会通过 `AgentEvaluator` 执行。区别在于训练集评估的结果会继续进入 loss 提取、反向传播和梯度聚合流程，而验证集评估的结果主要用于接受判定与停止判定。
+在 PromptIter 中，训练集评估结果用于提取优化信号，提取出的信号会进入反向传播归因、文本梯度聚合和优化补丁生成。验证集评估结果用于判断候选提示词是否满足接受策略，并为停止策略提供当前基准的验证分数。
 
-如需进一步了解评估集、评估指标、评估器和评估结果的定义，可参考 [评估集 EvalSet](evaluation.md#评估集-evalset)、[评估指标 EvalMetric](evaluation.md#评估指标-evalmetric)、[Evaluator](evaluation.md#evaluator)、[评估结果 EvalResult](evaluation.md#评估结果-evalresult) 与 [AgentEvaluator](evaluation.md#agentevaluator)。
+### 训练验证分离
 
-### 训练集与验证集
-
-PromptIter 一次运行中会同时使用两类评估集：
-
-- 训练集用于产生优化信号。
-- 验证集用于判断当前改动是否应该被接受。
-
-训练集分数可以很高，但验证集仍然可能拒绝当前改动。因此，训练集提升只说明当前改动提供了更强的优化信号，是否接受该改动仍以验证集结果为准。
-
-### 结构快照与 Surface
-
-结构快照是对 Agent 静态结构的导出结果，其中包含节点、边以及可编辑的 `surface`。`Surface` 表示某个节点上的稳定可编辑基线面，例如 `instruction`、`model`、`tool`、`skill`。每个 `surface` 都有稳定的 `SurfaceID`，PromptIter 通过 `TargetSurfaceIDs` 指定本次运行允许优化的目标可编辑位置。
-
-PromptIter 会先读取结构快照，再定位其中允许被优化的 `surface`。推荐做法是先通过结构快照获取可编辑位置，再将目标写入 `TargetSurfaceIDs`。不要假设所有 Agent 都只有一个 instruction surface，也不要直接在业务代码中硬编码结构之外的字段。
-
-如需进一步了解结构导出和运行时 surface 覆盖方式，可参考 [静态结构导出](agent.md#静态结构导出) 与 [按 `nodeID` 覆盖运行时 surface](agent.md#按-nodeid-覆盖运行时-surface) 两节。
-
-### 执行 Trace
-
-执行 Trace 记录的是某次评估实际发生的执行步骤，以及这些步骤之间的真实依赖关系。这里的步骤表示某个静态节点在一次具体运行中的一次执行记录。同一个节点在不同分支、不同轮次或循环路径中可能被执行多次，因此一次 Trace 中可能出现多个对应同一 `NodeID` 的步骤。它用于描述一次具体运行的事实记录。
-
-每个步骤通常关心这些信息：
-
-- `NodeID`，表示该步骤对应的静态节点。
-- `PredecessorStepIDs`，表示该步骤在本次运行中的直接前驱步骤。
-- `Input` 和 `Output`，表示该步骤看到的输入输出快照。
-- `Error`，表示该步骤执行失败时的错误信息。
-
-PromptIter 使用执行 Trace 来定位问题出现在哪些步骤上，并决定 loss 和梯度应该沿哪条路径传播。
-
-### 反向传播
-
-训练集评估得到失败样本和执行 Trace 之后，PromptIter 会先进入反向传播环节。反向传播用于将失败样本转换为可传播的归因信号。它会结合步骤的输入输出快照、前驱步骤和可编辑位置，判断问题首先出现在哪里，以及这些问题是否需要继续向上游传播。
-
-### 梯度聚合
-
-梯度聚合用于将多个样本、多个步骤上的局部归因信号按 `SurfaceID` 合并，得到面向单个可编辑位置的统一优化信号。这个阶段负责把局部、分散的失败信号收敛成下一步可以消费的稳定输入。
-
-### 优化
-
-优化用于根据当前可编辑位置的基线值和聚合后的优化信号生成修改建议，最终形成新的候选版本。评估负责发现问题，反向传播负责归因与传播，梯度聚合负责收敛信号，优化负责生成新的修改建议。
-
-### 工作原理示例
-
-可以用一个更接近真实业务编排的例子，把静态结构图、执行 Trace、评估、反向传播、梯度聚合和优化器串起来理解。这个例子对应一类常见的多阶段工作流：先由 `planner` 规划处理方式，再由 `retrieve` 检索外部信息、`compose` 生成回答草稿，最后由 `reviewer` 统一审核；如果审核认为当前结果仍需修订，就进入 `rewrite` 并重新回到 `planner`，否则直接 `finalize`。
-
-静态结构图可能如下：
-
-```mermaid
-flowchart LR
-    planner[planner]
-    retrieve[retrieve]
-    compose[compose]
-    reviewer[reviewer]
-    rewrite[rewrite]
-    finalize[finalize]
-
-    planner --> retrieve
-    planner --> compose
-    retrieve --> reviewer
-    compose --> reviewer
-    reviewer -->|need_revision| rewrite
-    reviewer --> finalize
-    rewrite --> planner
-```
-
-这张图表达的是这个工作流的稳定结构：
-
-- `planner` 负责拆解任务，因此它之后会 fan-out 到 `retrieve` 和 `compose` 两个分支。
-- `reviewer` 是一个 fan-in 节点，表示它可能同时依赖前面的多个分支。
-- `reviewer -> rewrite` 是条件边，表示满足修订条件时会回到上游节点继续处理。
-- `rewrite -> planner` 表示图上允许再次回到上游节点，形成循环。
-- 可编辑位置固定挂在静态节点上，例如 `planner#instruction` 和 `reviewer#instruction`。
-
-某次评估实际跑出来的执行 Trace 可能如下：
-
-```mermaid
-flowchart LR
-    step1["step_1 planner"]
-    step2["step_2 retrieve"]
-    step3["step_3 compose"]
-    step4["step_4 reviewer"]
-    step5["step_5 rewrite"]
-    step6["step_6 planner"]
-    step7["step_7 retrieve"]
-    step8["step_8 compose"]
-    step9["step_9 reviewer"]
-    step10["step_10 finalize"]
-
-    step1 --> step2
-    step1 --> step3
-    step2 --> step4
-    step3 --> step4
-    step4 --> step5
-    step5 --> step6
-    step6 --> step7
-    step6 --> step8
-    step7 --> step9
-    step8 --> step9
-    step9 --> step10
-```
-
-这条 Trace 表达的是本次运行真实发生的步骤：
-
-- `planner` 两次都触发了 `retrieve` 和 `compose` 两个下游分支，这是 fan-out。
-- `reviewer` 两次都同时依赖 `retrieve` 和 `compose` 两个前驱步骤，这是 fan-in。
-- 第一次经过 `reviewer` 时走向了 `rewrite`，随后又回到 `planner`，这是一次循环。
-- 第二次经过 `reviewer` 时走向了 `finalize`，表示这次没有再进入修订分支。
-
-基于这个例子，可以按以下顺序理解 PromptIter 的一轮运行：
-
-1. 训练集评估先得到这次运行的实际输出、分数和执行 Trace。此时静态结构图不变，但系统已经知道这次真实走到了哪些步骤，以及哪些节点没有执行到。
-2. 如果训练集评估发现 `step_9 reviewer` 的输出质量不够，loss 会落在这个步骤上。`Backwarder` 会基于 `step_9` 的输入输出快照、前驱步骤和可编辑位置，把问题转换为步骤级梯度。
-3. 如果问题主要出在 `reviewer` 自身的表达方式，`Backwarder` 可能直接把梯度归因到 `reviewer#instruction`；如果问题来自上游信息不足，也可能继续向 `step_7 retrieve` 和 `step_8 compose` 传播，再进一步回到共享前驱 `step_6 planner`。
-4. 不同样本、不同步骤、不同分支产生的梯度，最终会通过 `Aggregator` 按 `SurfaceID` 合并。例如，多个步骤都可能把问题归因到 `planner#instruction`，这些梯度会被合并成一个统一信号。
-5. `Optimizer` 会面向单个 `surface` 的当前基线值和聚合后的梯度，生成对应的 `SurfacePatch`。
-6. `Engine` 将 `SurfacePatch` 应用到当前候选版本，得到新的 `Profile`，再交给验证集评估。
-7. 验证集负责判断这一轮修改是否真的更好。如果分数提升满足接受策略，则新的候选版本成为已接受版本；否则回退到上一版，并决定是否继续下一轮。
-
-这个例子说明三层信息各自承担的职责：
-
-- 静态结构图用于确定哪些位置可以修改。
-- 执行 Trace 用于确定这次运行里问题出现在哪些步骤上，以及梯度应该沿哪条路径传播。
-- `Backwarder`、`Aggregator` 和 `Optimizer` 负责把步骤级问题逐步转换成 `surface` 级修改建议。
-
-关于执行图的导出方式，可参考 [执行图导出](agent.md#执行图导出) 一节；如需进一步了解 graph 中的 fan-out、join 和循环语义，可参考 [Graph 使用文档](graph.md) 中关于并行边、Join 和 BSP 超步屏障的说明。
-
-### Profile
-
-`Profile` 用于表示一组应用在结构快照之上的覆盖值。每接受一轮修改，PromptIter 就会生成新的候选配置版本，并将其作为下一轮输入。
+训练集用于产生优化信号，验证集用于提供候选提示词接受判定所需的评估结果。二者都通过 `EvalSetInput` 指定，既可指向整个评估集，也可通过 `EvalCaseIDs` 将指定粒度细化到评估用例。
 
 ```go
-import astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter"
+)
 
-type Profile struct {
-	StructureID string            // StructureID 表示当前候选版本所属的结构版本。
-	Overrides   []SurfaceOverride // Overrides 表示各个可编辑位置上的覆盖值。
+// EvalSetInput 指定一次训练集或验证集输入。
+type EvalSetInput struct {
+	// EvalSetID 是要运行的评估集 ID。
+	EvalSetID   string
+	// EvalCaseIDs 将运行范围细化到指定评估用例，空列表表示运行全部评估用例。
+	EvalCaseIDs []string
+	// LossHints 为训练集失败指标补充业务侧已知的问题原因。
+	LossHints   []LossHint
 }
 
-type SurfaceOverride struct {
-	SurfaceID string                  // SurfaceID 表示目标可编辑位置。
-	Value     astructure.SurfaceValue // Value 表示该可编辑位置上的候选值。
+// LossHint 为单个评估用例上的单个失败指标补充问题原因。
+type LossHint struct {
+	// EvalCaseID 指定问题原因对应的评估用例。
+	EvalCaseID string
+	// MetricName 指定问题原因对应的评估指标。
+	MetricName string
+	// Severity 表示问题原因的优先级。
+	Severity   promptiter.LossSeverity
+	// Reason 是用于反向传播归因的问题原因文本。
+	Reason     string
 }
 ```
 
-### PatchSet
+不指定 `EvalCaseIDs` 时，PromptIter 会运行对应评估集下的全部评估用例。指定非空列表时，只运行列出的评估用例。
 
-`PatchSet` 表示一轮优化器生成的候选修改建议集合。
+当业务侧已经知道某个训练集评估用例的具体问题时，可以用 `LossHint` 补充问题原因。PromptIter 会把 `Reason` 并入对应失败指标的优化信号，使反向传播归因同时参考评估器给出的原因和业务侧补充原因。使用 `LossHint` 时，`EvalCaseID` 和 `MetricName` 必须能匹配本次训练评估结果中的失败指标，`Severity` 取值为 `P0`、`P1`、`P2` 或 `P3`。`LossHint` 不改变评估分数，也不参与验证集接受判定。
+
+训练集和验证集需要分离使用。训练集分数提升只能说明候选补丁在参与优化的样本上更接近指标要求，不能证明未参与优化的样本也满足指标。验证集用于暴露过拟合风险，并参与接受判定。
+
+### 静态结构快照
+
+静态结构快照是待测 Agent 的结构导出结果，包含节点、边和可迭代槽位。结构快照中可作为迭代目标的内容在代码中称为 surface，每个 surface 都有稳定的 `SurfaceID`。本文只讨论 `instruction` 提示词迭代，PromptIter 通过结构快照确认本次指定的 `instruction` surface 是否存在。
+
+本文只讨论 `instruction` 类型 surface，即节点上的 instruction 提示词。提示词迭代需要明确目标范围，接入代码需要把选中的 `SurfaceID` 写入迭代请求的 `TargetSurfaceIDs`。
+
+`Describe` 可用于查看结构快照。确定需要迭代的 `instruction` surface 后，将对应 ID 写入迭代请求的 `TargetSurfaceIDs`。
 
 ```go
-import astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
+// Describe 返回待测 Agent 的静态结构快照。
+snapshot, err := engineInstance.Describe(ctx)
+if err != nil {
+	return err
+}
+// Surfaces 列出当前结构中可作为迭代目标的 surface。
+for _, surface := range snapshot.Surfaces {
+	fmt.Println(surface.SurfaceID, surface.Type)
+}
+```
 
+#### LLMAgent 示例
+
+在 LLMAgent 场景中，待测 Agent 由 `llmagent.New` 创建。
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+)
+
+// llmagent.New 创建待测 Agent。
+llmagent.New(
+	"candidate",
+	llmagent.WithModel(candidateModel),
+	// WithInstruction 写入 candidate#instruction 对应的起始提示词。
+	llmagent.WithInstruction("生成一篇中文体育战报"),
+)
+```
+
+该 Agent 的静态结构只有一个节点。`instruction` surface 是该节点上的可迭代提示词，ID 是 `candidate#instruction`。对应静态结构如下。
+
+![llmagent-structure.svg](../assets/img/promptiter/llmagent-structure.svg)
+
+#### Graph Agent 示例
+
+在 Graph Agent 场景中，静态结构包含根 Agent、图节点和边。代码通过 `AddAgentNode` 挂载子 Agent，这些节点导出各自的 `instruction` surface。流程从 `prepare` 分发到 `title`、`introduction` 和 `highlight`，再汇聚到 `merge`，最后由 `review` 根据结果选择发布或退回润色，同时覆盖 fan-out、fan-in 和条件边。
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/graphagent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/graph"
+)
+
+// newGraphAgent 创建包含 fan-out、fan-in 和条件边的 Graph Agent。
+func newGraphAgent() (agent.Agent, error) {
+	// subAgents 列出 Graph Agent 使用的子 Agent。
+	subAgents := []agent.Agent{
+		// title 对应 candidate/title#instruction。
+		llmagent.New(
+			"title",
+			llmagent.WithModel(modelInstance),
+			llmagent.WithInstruction("生成中文战报标题"),
+		),
+		// introduction 对应 candidate/introduction#instruction。
+		llmagent.New(
+			"introduction",
+			llmagent.WithModel(modelInstance),
+			llmagent.WithInstruction("写出比赛背景和开场导语"),
+		),
+		// highlight 对应 candidate/highlight#instruction。
+		llmagent.New(
+			"highlight",
+			llmagent.WithModel(modelInstance),
+			llmagent.WithInstruction("提取关键回合和转折点"),
+		),
+		// polish 对应 candidate/polish#instruction。
+		llmagent.New(
+			"polish",
+			llmagent.WithModel(modelInstance),
+			llmagent.WithInstruction("润色战报结构和表达"),
+		),
+		// review 对应 candidate/review#instruction。
+		llmagent.New(
+			"review",
+			llmagent.WithModel(modelInstance),
+			llmagent.WithInstruction("审核事实一致性和发布标准"),
+		),
+	}
+
+	// StateGraph 连接普通函数节点和 AgentNode。
+	sg := graph.NewStateGraph(graph.NewStateSchema())
+	sg.AddNode("prepare", prepare)
+	sg.AddAgentNode("title")
+	sg.AddAgentNode("introduction")
+	sg.AddAgentNode("highlight")
+	sg.AddNode("merge", mergeDraft)
+	sg.AddAgentNode("polish")
+	sg.AddAgentNode("review")
+	sg.AddNode("publish", publish)
+	sg.SetEntryPoint("prepare")
+
+	// fan-out 表示一个节点分发到三个 AgentNode。
+	sg.AddEdge("prepare", "title")
+	sg.AddEdge("prepare", "introduction")
+	sg.AddEdge("prepare", "highlight")
+	// fan-in 表示等待 title、introduction 和 highlight 都完成后再进入 merge。
+	sg.AddJoinEdge([]string{"title", "introduction", "highlight"}, "merge")
+	sg.AddEdge("merge", "polish")
+	sg.AddEdge("polish", "review")
+	// 条件边通过 routeAfterReview 根据状态选择发布或退回润色。
+	sg.AddConditionalEdges("review", routeAfterReview, map[string]string{
+		"pass":   "publish",
+		"revise": "polish",
+	})
+	sg.SetFinishPoint("publish")
+
+	// Compile 生成 graphagent.New 需要的图结构。
+	g, err := sg.Compile()
+	if err != nil {
+		return nil, err
+	}
+	// graphagent.New 绑定图结构和子 Agent。
+	return graphagent.New("candidate", g, graphagent.WithSubAgents(subAgents))
+}
+```
+
+本例代码中的 `prepare`、`merge` 和 `publish` 是普通函数节点，不暴露 `instruction` surface。通过 `AddAgentNode` 挂载的节点导出子 Agent 的 `instruction` surface。
+
+Graph Agent 导出的 `NodeID` 带有根 Agent 名称前缀，例如代码中的 `merge` 在结构快照中对应 `candidate/merge`。AgentNode 上 `instruction` surface 的 `SurfaceID` 形如 `<根 Agent>/<节点名>#instruction`。
+
+本例包含五个 `instruction` surface，`SurfaceID` 分别如下。
+
+- `candidate/title#instruction`
+- `candidate/introduction#instruction`
+- `candidate/highlight#instruction`
+- `candidate/polish#instruction`
+- `candidate/review#instruction`
+
+对应静态结构如下。
+
+![graphagent-structure.svg](../assets/img/promptiter/graphagent-structure.svg)
+
+### 动态执行轨迹
+
+动态执行轨迹记录一次评估运行实际经过的步骤及其依赖关系。静态结构快照描述 Agent 可能包含的节点、边和 surface，动态执行轨迹记录本次运行实际经过的步骤。
+
+每个执行步骤都有 `StepID`，并通过 `NodeID` 关联静态结构中的节点。`PredecessorStepIDs` 记录直接前驱，`AppliedSurfaceIDs` 记录当前步骤实际应用的 surface。轨迹还包含输入输出快照和错误信息。静态节点和执行步骤不是一一对应关系。一个静态节点在某次运行中可能不执行，也可能因为循环或条件回退执行多次。
+
+#### LLMAgent 示例
+
+在 LLMAgent 场景中，只有一个静态节点。一次评估运行对应一个执行步骤。实际轨迹中的 `StepID` 由运行时分配，`NodeID` 为 `candidate`，`PredecessorStepIDs` 为空。该步骤的 `AppliedSurfaceIDs` 记录实际应用过的 surface。如果该样本产生失败指标，反向传播归因会从这个步骤开始。
+
+对应动态执行轨迹图如下。
+
+![llmagent-trace.svg](../assets/img/promptiter/llmagent-trace.svg)
+
+#### Graph Agent 示例
+
+在 Graph Agent 场景中，静态结构中的分支和条件边会体现在本次运行的步骤路径里。动态轨迹由 `StepID` 和 `NodeID` 共同描述一个执行步骤。`StepID` 是运行时分配的步骤标识，`NodeID` 指向静态结构中的节点。同一个 `NodeID` 可以对应多个不同的 `StepID`。
+
+图中的 `s1`、`s2` 等表示 `StepID`，`candidate/prepare`、`candidate/title` 等表示 `NodeID`。本次运行中，`candidate/review` 第一次命中 `revise`，流程回到 `candidate/polish`。第二次命中 `pass` 后进入 `candidate/publish`。
+
+![graphagent-trace.svg](../assets/img/promptiter/graphagent-trace.svg)
+
+`candidate/title`、`candidate/introduction`、`candidate/highlight`、`candidate/polish` 和 `candidate/review` 是带 `instruction` 的 AgentNode。对应步骤的 `AppliedSurfaceIDs` 会包含各自的 `instruction` surface，例如 `candidate/title#instruction`。`candidate/prepare`、`candidate/merge` 和 `candidate/publish` 是普通函数节点，不暴露 `instruction` surface。
+
+如果条件路由命中 `revise`，轨迹会回到 `candidate/polish`。再次执行同一静态节点时，会产生新的执行步骤和新的 `StepID`。如果再次命中 `revise`，轨迹会继续追加新的步骤，新增步骤的 `NodeID` 仍然指向 `candidate/polish` 和 `candidate/review`。
+
+反向传播归因需要同时参考静态结构和动态执行轨迹。训练集评估完成后，失败信号先关联到终端步骤。终端步骤是没有被其他步骤引用的步骤，通常对应本次运行的最后一个或最后一组输出步骤。随后，反向传播归因沿 `PredecessorStepIDs` 反向处理步骤。它会结合当前步骤的输入、输出、错误、实际应用的 surface 和后继步骤传回的问题信号，判断问题应归因到当前步骤的目标 `instruction` surface，还是继续传给前驱步骤。
+
+### Loss 提取
+
+训练集评估完成后，PromptIter 会从失败指标中提取 loss。只有状态为 `failed` 的指标会进入 loss 提取。通过的指标不会产生优化信号。
+
+Evaluation 的指标结果包含 `Details.Reason` 字段，用于记录该指标的判定原因。对失败指标而言，该字段说明评估用例未通过的原因。自定义评估器接入 PromptIter 时，需要写入可用于构造 loss 的具体原因，例如缺少事实、长度过长、输出过于泛化或与参考答案偏离。
+
+业务侧需要补充问题原因时，可在训练集 `EvalSetInput` 中设置 `LossHints`。
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+)
+
+// train 指定产生优化信号的训练集，并补充业务侧已知的问题原因。
+train := []engine.EvalSetInput{
+	{
+		// EvalSetID 指向用于产生优化信号的训练集。
+		EvalSetID: trainEvalSetID,
+		// LossHints 只补充已失败指标的问题原因，不改变评估分数。
+		LossHints: []engine.LossHint{
+			{
+				// EvalCaseID 指定问题原因对应的评估用例。
+				EvalCaseID: "case_1",
+				// MetricName 指定问题原因对应的评估指标。
+				MetricName: "llm_rubric_critic",
+				// Severity 表示该问题原因的优先级。
+				Severity: promptiter.LossSeverityP1,
+				// Reason 写入可供反向传播归因使用的具体问题原因。
+				Reason: "回答遗漏了当前回合的决定性球员和比分状态。",
+			},
+		},
+	},
+}
+```
+
+`LossHints` 只补充训练阶段的优化信号，不改变评估分数，也不会影响验证集接受判定。只有对应 EvalCase 的对应 Metric 在本次训练评估中处于 `failed` 状态时，PromptIter 才会使用 `LossHint`。如果该指标本轮通过，`LossHint` 不会把该评估用例改判为失败。
+
+### 反向传播器 Backwarder
+
+`Backwarder` 的职责是根据失败样本、当前步骤上下文和传入梯度包生成两类输出。一类是归因到当前步骤 surface 的文本梯度，另一类是需要继续传给前驱步骤的梯度包。
+
+```go
+import (
+	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
+	atrace "trpc.group/trpc-go/trpc-agent-go/agent/trace"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter"
+)
+
+// Backwarder 执行单个步骤上的反向传播归因。
+type Backwarder interface {
+	// Backward 根据步骤上下文生成文本梯度和上游梯度包。
+	Backward(ctx context.Context, request *Request) (*Result, error)
+}
+
+// Request 描述单个执行步骤的反向传播归因输入。
+type Request struct {
+	// EvalSetID 标识当前评估集。
+	EvalSetID string
+	// EvalCaseID 标识当前评估用例。
+	EvalCaseID string
+	// Node 是当前步骤对应的静态节点。
+	Node *astructure.Node
+	// StepID 标识当前执行步骤。
+	StepID string
+	// Input 是当前步骤的输入快照。
+	Input *atrace.Snapshot
+	// Output 是当前步骤的输出快照。
+	Output *atrace.Snapshot
+	// Error 记录当前步骤的运行错误。
+	Error string
+	// Surfaces 是影响当前步骤的 surface。
+	Surfaces []astructure.Surface
+	// AllowedGradientSurfaceIDs 限定允许归因的 surface。
+	AllowedGradientSurfaceIDs []string
+	// Predecessors 是当前步骤的直接前驱步骤。
+	Predecessors []Predecessor
+	// Incoming 是后继步骤传入的梯度包。
+	Incoming []GradientPacket
+}
+
+// Predecessor 描述当前步骤的一个直接前驱步骤。
+type Predecessor struct {
+	// StepID 标识前驱步骤。
+	StepID string
+	// NodeID 标识前驱步骤对应的静态节点。
+	NodeID string
+	// Output 是前驱步骤的输出快照。
+	Output *atrace.Snapshot
+	// Error 记录前驱步骤的运行错误。
+	Error string
+}
+
+// GradientPacket 描述从后继步骤传回的一条问题信号。
+type GradientPacket struct {
+	// FromStepID 标识问题信号来自哪个后继步骤。
+	FromStepID string
+	// Severity 表示问题信号的优先级。
+	Severity promptiter.LossSeverity
+	// Gradient 保存问题信号的文本内容。
+	Gradient string
+}
+
+// Result 描述当前步骤的反向传播归因结果。
+type Result struct {
+	// Gradients 是归因到当前步骤 surface 的文本梯度。
+	Gradients []promptiter.SurfaceGradient
+	// Upstream 是需要继续传给前驱步骤的问题信号。
+	Upstream []Propagation
+}
+
+// Propagation 描述需要传给一个前驱步骤的问题信号集合。
+type Propagation struct {
+	// PredecessorStepID 标识接收问题信号的前驱步骤。
+	PredecessorStepID string
+	// Gradients 是传给该前驱步骤的问题信号。
+	Gradients []GradientPacket
+}
+```
+
+`Backwarder.Request` 描述当前评估集、评估用例、静态节点和步骤 ID。请求还携带归因上下文，包括输入输出快照与错误、当前步骤应用过的 surfaces、允许归因的 `SurfaceID`、前驱步骤和传入梯度包。默认实现会把上述归因上下文组织成一条用户消息，并通过结构化输出约束模型返回 `Gradients` 和 `Upstream`。
+
+`Gradients` 表示归因到当前步骤 surface 的文本梯度。`Upstream` 表示需要继续传给前驱步骤的问题信号，由对应前驱步骤继续处理。
+
+下图以 `s1`、`s2`、`s3` 三个执行步骤节点为例。反向传播时，`s3` 把 `Incoming` 梯度包传给 `s2`，`Backwarder` 读取 `s2` 的上下文后，输出归因到 `s2` surface 的 `Gradients`，并把 `Upstream` 梯度包继续传给 `s1`。
+
+![backwarder.svg](../assets/img/promptiter/backwarder.svg)
+
+默认 `Backwarder` 实现通过 `backwarder.New` 创建，把当前步骤上下文、失败原因和后继步骤传回的问题信号组织为模型输入，并要求模型返回归因到当前 surface 的文本梯度和传给前驱步骤的 `Upstream`。
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+)
+
+
+// New 创建默认 Backwarder 实现。
+func New(ctx context.Context, runner runner.Runner, opt ...Option) (Backwarder, error)
+```
+
+使用示例如下。
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/backwarder"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+)
+
+// backwarderRunner 调用模型完成反向传播归因。
+backwarderRunner := runner.NewRunner("promptiter-backwarder", backwarderAgent)
+
+// backwarder.New 创建默认 Backwarder 实现。
+backwarderInstance, err := backwarder.New(ctx, backwarderRunner)
+```
+
+构造期 option 可以调整消息构造方法、Runner 参数和会话标识，定义如下。
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+// Option 配置默认 Backwarder 实现。
+type Option func(*options)
+
+// MessageBuilder 把 Backwarder 请求编码成传给 Runner 的消息。
+type MessageBuilder func(ctx context.Context, request *Request) (*model.Message, error)
+
+// UserIDSupplier 为一次 Backwarder 内部 Runner 调用提供 user ID。
+type UserIDSupplier func(ctx context.Context) string
+
+// SessionIDSupplier 为一次 Backwarder 内部 Runner 调用提供 session ID。
+type SessionIDSupplier func(ctx context.Context) string
+
+// WithRunOptions 追加 Backwarder 内部 Runner 调用使用的 RunOption。
+func WithRunOptions(runOptions ...agent.RunOption) Option
+
+// WithMessageBuilder 替换默认消息构造逻辑。
+func WithMessageBuilder(builder MessageBuilder) Option
+
+// WithUserIDSupplier 替换默认 user ID 生成逻辑。
+func WithUserIDSupplier(supplier UserIDSupplier) Option
+
+// WithSessionIDSupplier 替换默认 session ID 生成逻辑。
+func WithSessionIDSupplier(supplier SessionIDSupplier) Option
+```
+
+`WithRunOptions` 会透传给组件内部的 Runner 调用。`WithMessageBuilder` 可替换默认消息构造逻辑。`WithUserIDSupplier` 和 `WithSessionIDSupplier` 可指定内部调用使用的会话标识。
+
+### 梯度聚合器 Aggregator
+
+训练集中不同样本、不同步骤可能把问题归因到同一个 surface。`Aggregator` 的职责是按 `SurfaceID` 聚合局部文本梯度，输出面向单个 surface 的聚合结果。
+
+```go
+import (
+	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter"
+)
+
+// Aggregator 聚合同一 surface 上的多条文本梯度。
+type Aggregator interface {
+	// Aggregate 将局部文本梯度合成为单个 surface 的聚合结果。
+	Aggregate(ctx context.Context, request *Request) (*Result, error)
+}
+
+// Request 描述单个 surface 的文本梯度聚合输入。
+type Request struct {
+	// SurfaceID 标识本次聚合对应的 surface。
+	SurfaceID string
+	// NodeID 标识该 surface 所属的静态节点。
+	NodeID string
+	// Type 标识该 surface 的类型。
+	Type astructure.SurfaceType
+	// Gradients 是归因到该 surface 的全部局部文本梯度。
+	Gradients []promptiter.SurfaceGradient
+}
+
+// Result 描述单个 surface 的文本梯度聚合结果。
+type Result struct {
+	// Gradient 是聚合后的 surface 级文本梯度。
+	Gradient *promptiter.AggregatedSurfaceGradient
+}
+
+// SurfaceGradient 保存归因到单个 surface 的局部文本梯度。
+type SurfaceGradient struct {
+	// EvalSetID 标识产生该文本梯度的评估集。
+	EvalSetID string
+	// EvalCaseID 标识产生该文本梯度的评估用例。
+	EvalCaseID string
+	// StepID 标识产生该文本梯度的执行步骤。
+	StepID string
+	// SurfaceID 标识该文本梯度归因到的 surface。
+	SurfaceID string
+	// Severity 表示该文本梯度对应问题的优先级。
+	Severity LossSeverity
+	// Gradient 保存文本梯度内容。
+	Gradient string
+}
+
+// AggregatedSurfaceGradient 保存单个 surface 的聚合文本梯度。
+type AggregatedSurfaceGradient struct {
+	// SurfaceID 标识聚合结果对应的 surface。
+	SurfaceID string
+	// NodeID 标识该 surface 所属的静态节点。
+	NodeID string
+	// Type 标识该 surface 的类型。
+	Type astructure.SurfaceType
+	// Gradients 保存聚合后的文本梯度。
+	Gradients []SurfaceGradient
+}
+```
+
+`Aggregator.Request` 包含目标 `SurfaceID`、所属 `NodeID`、surface 类型和该 surface 下的全部文本梯度。默认实现会把重复或相近的文本梯度交给模型聚合。模型返回合并后的文本梯度列表，默认实现再绑定目标 `SurfaceID`、`NodeID` 和 surface 类型，形成 `AggregatedSurfaceGradient`。
+
+文本梯度聚合阶段不直接修改提示词。输出仍是面向单个 surface 的聚合文本梯度，供下一步 Optimizer 生成补丁。
+
+默认 `Aggregator` 实现通过 `aggregator.New` 创建，把同一 surface 上来自不同样本或步骤的文本梯度组织为模型输入，并把模型返回的聚合文本梯度转换为 `AggregatedSurfaceGradient`。
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+)
+
+
+// New 创建默认 Aggregator 实现。
+func New(ctx context.Context, runner runner.Runner, opt ...Option) (Aggregator, error)
+```
+
+使用示例如下。
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/aggregator"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+)
+
+// aggregatorRunner 调用模型完成文本梯度聚合。
+aggregatorRunner := runner.NewRunner("promptiter-aggregator", aggregatorAgent)
+
+// aggregator.New 创建默认 Aggregator 实现。
+aggregatorInstance, err := aggregator.New(ctx, aggregatorRunner)
+```
+
+构造期 option 可以调整消息构造方法、Runner 参数和会话标识，定义如下。
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+// Option 配置默认 Aggregator 实现。
+type Option func(*options)
+
+// MessageBuilder 把 Aggregator 请求编码成传给 Runner 的消息。
+type MessageBuilder func(ctx context.Context, request *Request) (*model.Message, error)
+
+// UserIDSupplier 为一次 Aggregator 内部 Runner 调用提供 user ID。
+type UserIDSupplier func(ctx context.Context) string
+
+// SessionIDSupplier 为一次 Aggregator 内部 Runner 调用提供 session ID。
+type SessionIDSupplier func(ctx context.Context) string
+
+// WithRunOptions 追加 Aggregator 内部 Runner 调用使用的 RunOption。
+func WithRunOptions(runOptions ...agent.RunOption) Option
+
+// WithMessageBuilder 替换默认消息构造逻辑。
+func WithMessageBuilder(builder MessageBuilder) Option
+
+// WithUserIDSupplier 替换默认 user ID 生成逻辑。
+func WithUserIDSupplier(supplier UserIDSupplier) Option
+
+// WithSessionIDSupplier 替换默认 session ID 生成逻辑。
+func WithSessionIDSupplier(supplier SessionIDSupplier) Option
+```
+
+`WithRunOptions` 会透传给组件内部的 Runner 调用。`WithMessageBuilder` 可替换默认消息构造逻辑。`WithUserIDSupplier` 和 `WithSessionIDSupplier` 可指定内部调用使用的会话标识。
+
+### 补丁优化器 Optimizer
+
+`Optimizer` 的职责是根据当前 surface 值和聚合后的文本梯度生成 `SurfacePatch`。
+
+```go
+import (
+	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter"
+)
+
+// Optimizer 根据聚合文本梯度生成候选补丁。
+type Optimizer interface {
+	// Optimize 为目标 surface 生成一个候选 SurfacePatch。
+	Optimize(ctx context.Context, request *Request) (*Result, error)
+}
+
+// Request 描述单个 surface 的优化输入。
+type Request struct {
+	// Surface 保存当前基准 Profile 中的 surface 值。
+	Surface *astructure.Surface
+	// Gradient 保存该 surface 的聚合文本梯度。
+	Gradient *promptiter.AggregatedSurfaceGradient
+}
+
+// Result 描述单个 surface 的优化结果。
+type Result struct {
+	// Patch 是为该 surface 生成的候选补丁。
+	Patch *promptiter.SurfacePatch
+}
+
+// PatchSet 保存一轮优化得到的候选补丁集合。
 type PatchSet struct {
-	Patches []SurfacePatch // Patches 表示当前轮生成的修改建议列表。
+	// Patches 是本轮所有候选 surface 补丁。
+	Patches []SurfacePatch
 }
 
+// SurfacePatch 描述单个 surface 的候选修改。
 type SurfacePatch struct {
-	SurfaceID string                  // SurfaceID 表示该修改作用于哪个可编辑位置。
-	Value     astructure.SurfaceValue // Value 表示新的候选值。
-	Reason    string                  // Reason 表示生成该修改建议的原因说明。
+	// SurfaceID 标识被修改的 surface。
+	SurfaceID string
+	// Value 保存候选 surface 值。
+	Value     astructure.SurfaceValue
+	// Reason 说明生成该补丁的原因。
+	Reason    string
 }
 ```
 
-优化器输出的是 `PatchSet`，engine 会将其中的修改应用到当前候选版本，形成新的候选版本，再交给验证集决定是否接受。
+`Request.Surface` 提供当前基准 Profile 中的 surface 值，`Request.Gradient` 提供聚合后的修改方向。单次 `Optimize` 调用返回一个 `SurfacePatch`，一轮运行可能包含多个目标 surface，Engine 会把这些补丁汇总为 `PatchSet`。
+
+默认 `Optimizer` 实现通过 `optimizer.New` 创建，把当前 surface 值和聚合文本梯度组织为模型输入，并要求模型返回候选 `SurfacePatch`。
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+)
+
+
+// New 创建默认 Optimizer 实现。
+func New(ctx context.Context, runner runner.Runner, opt ...Option) (Optimizer, error)
+```
+
+使用示例如下。
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/optimizer"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+)
+
+// optimizerRunner 调用模型完成优化补丁生成。
+optimizerRunner := runner.NewRunner("promptiter-optimizer", optimizerAgent)
+
+// optimizer.New 创建默认 Optimizer 实现。
+optimizerInstance, err := optimizer.New(ctx, optimizerRunner)
+```
+
+构造期 option 可以调整消息构造方法、Runner 参数和会话标识，定义如下。
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+// Option 配置默认 Optimizer 实现。
+type Option func(*options)
+
+// MessageBuilder 把 Optimizer 请求编码成传给 Runner 的消息。
+type MessageBuilder func(ctx context.Context, request *Request) (*model.Message, error)
+
+// UserIDSupplier 为一次 Optimizer 内部 Runner 调用提供 user ID。
+type UserIDSupplier func(ctx context.Context) string
+
+// SessionIDSupplier 为一次 Optimizer 内部 Runner 调用提供 session ID。
+type SessionIDSupplier func(ctx context.Context) string
+
+// WithRunOptions 追加 Optimizer 内部 Runner 调用使用的 RunOption。
+func WithRunOptions(runOptions ...agent.RunOption) Option
+
+// WithMessageBuilder 替换默认消息构造逻辑。
+func WithMessageBuilder(builder MessageBuilder) Option
+
+// WithUserIDSupplier 替换默认 user ID 生成逻辑。
+func WithUserIDSupplier(supplier UserIDSupplier) Option
+
+// WithSessionIDSupplier 替换默认 session ID 生成逻辑。
+func WithSessionIDSupplier(supplier SessionIDSupplier) Option
+```
+
+`WithRunOptions` 会透传给组件内部的 Runner 调用。`WithMessageBuilder` 可替换默认补丁生成消息，适合接入业务自己的补丁约束或输出风格要求。`WithUserIDSupplier` 和 `WithSessionIDSupplier` 可指定内部调用使用的会话标识。
+
+### 覆盖配置 Profile
+
+`Profile` 表示一组绑定到结构快照的 surface 覆盖值。
+
+```go
+import (
+	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
+)
+
+
+// Profile 保存绑定到某个结构快照的 surface 覆盖值。
+type Profile struct {
+	// StructureID 标识该 Profile 适用的结构快照。
+	StructureID string
+	// Overrides 保存相对结构快照原始值的覆盖项。
+	Overrides   []SurfaceOverride
+}
+
+// SurfaceOverride 描述单个 surface 的覆盖值。
+type SurfaceOverride struct {
+	// SurfaceID 标识被覆盖的 surface。
+	SurfaceID string
+	// Value 保存该 surface 的新值。
+	Value     astructure.SurfaceValue
+}
+```
+
+Engine 会把 `PatchSet` 应用到当前基准 `Profile` 上，得到候选 `Profile`。接受判定通过后，候选 `Profile` 才会成为新的当前基准。
+
+### 运行判定策略
+
+`AcceptancePolicy` 控制是否接受当前候选 `Profile`。
+
+```go
+// AcceptancePolicy 控制候选 Profile 是否被接受。
+type AcceptancePolicy struct {
+	// MinScoreGain 是候选 Profile 相对当前基准 Profile 的最小验证分数增量。
+	MinScoreGain float64
+}
+```
+
+实现会计算 `candidateScore - baselineScore`，其中 `baselineScore` 表示当前基准 Profile 的验证分数，`candidateScore` 是本轮候选 Profile 的验证分数。只有分数增量不小于 `MinScoreGain`，本轮候选 Profile 才会被接受。
+
+`StopPolicy` 控制何时结束本次运行。
+
+```go
+// StopPolicy 控制一次 PromptIter 运行何时停止。
+type StopPolicy struct {
+	// MaxRoundsWithoutAcceptance 限制连续未接受候选 Profile 的轮数。
+	MaxRoundsWithoutAcceptance int
+	// TargetScore 是达到后即可停止的目标验证分数，nil 表示不启用。
+	TargetScore                *float64
+}
+```
+
+停止判定按以下顺序执行。
+
+1. 当前轮数达到 `MaxRounds`，停止
+2. 连续未接受轮数达到 `MaxRoundsWithoutAcceptance`，停止
+3. 当前基准的验证分数达到 `TargetScore`，停止
+4. 否则继续下一轮
+
+`MaxRounds` 本身是 `RunRequest` 的必填约束，必须大于 0。`TargetScore` 为 `nil` 时不会触发目标分数停止条件。
 
 ### RunRequest
 
-`RunRequest` 描述一次 PromptIter 运行的输入。
+`RunRequest` 描述一次 PromptIter 运行的全部输入，用于指定训练集、验证集、初始版本、迭代目标、阶段配置和停止条件。
 
 ```go
 import (
@@ -448,209 +1151,112 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/runner"
 )
 
+// RunRequest 描述一次 PromptIter 运行的全部输入。
 type RunRequest struct {
-	Train                []EvalSetInput      // Train 表示用于生成梯度的评估数据。
-	Validation           []EvalSetInput      // Validation 表示用于补丁接受检查的评估数据。
-	InitialProfile       *promptiter.Profile // InitialProfile 表示第一轮开始前的初始候选版本。
-	Teacher              runner.Runner       // Teacher 表示按需动态生成参考答案时使用的 Runner。
-	Judge                runner.Runner       // Judge 表示 Judge 类指标按需使用的 Runner。
-	EvaluationOptions    EvaluationOptions   // EvaluationOptions 表示评估执行参数。
-	BackwardOptions      BackwardOptions     // BackwardOptions 表示反向传播阶段执行参数。
-	AggregationOptions   AggregationOptions  // AggregationOptions 表示梯度聚合阶段执行参数。
-	OptimizerOptions     OptimizerOptions    // OptimizerOptions 表示优化器阶段执行参数。
-	AcceptancePolicy     AcceptancePolicy    // AcceptancePolicy 表示接受策略。
-	StopPolicy           StopPolicy          // StopPolicy 表示停止策略。
-	MaxRounds            int                 // MaxRounds 表示最大优化轮数。
-	TargetSurfaceIDs     []string            // TargetSurfaceIDs 表示本次运行允许修改的可编辑位置列表。
+	// Train 指定用于产生优化信号的训练集。
+	Train              []EvalSetInput
+	// Validation 指定用于接受判定的验证集。
+	Validation         []EvalSetInput
+	// InitialProfile 指定初始版本，nil 时使用结构快照原始值。
+	InitialProfile     *promptiter.Profile
+	// Teacher 是传给 Evaluation 的可选预期 Runner。
+	Teacher            runner.Runner
+	// Judge 是传给 LLM Judge 类指标的可选裁判 Runner。
+	Judge              runner.Runner
+	// EvaluationOptions 配置训练集和验证集评估阶段。
+	EvaluationOptions  EvaluationOptions
+	// BackwardOptions 配置反向传播归因阶段。
+	BackwardOptions    BackwardOptions
+	// AggregationOptions 配置文本梯度聚合阶段。
+	AggregationOptions AggregationOptions
+	// OptimizerOptions 配置优化补丁生成阶段。
+	OptimizerOptions   OptimizerOptions
+	// AcceptancePolicy 控制候选 Profile 接受条件。
+	AcceptancePolicy   AcceptancePolicy
+	// StopPolicy 控制运行停止条件。
+	StopPolicy         StopPolicy
+	// MaxRounds 限制最大迭代轮数。
+	MaxRounds          int
+	// TargetSurfaceIDs 限制本次允许迭代的 surface。
+	TargetSurfaceIDs   []string
 }
-```
 
-#### Train 和 Validation
-
-`Train` 用于训练阶段，PromptIter 会基于训练集评估结果提取 loss 并生成梯度。`Validation` 用于验证阶段，PromptIter 会基于验证集评估结果计算 baseline、判断补丁是否接受，并参与停止条件判断。
-
-二者都使用 `[]EvalSetInput` 描述评估数据选择：
-
-```go
+// EvalSetInput 指定一次训练集或验证集输入。
 type EvalSetInput struct {
-	EvalSetID   string     // EvalSetID 表示要执行的评估集。
-	EvalCaseIDs []string   // EvalCaseIDs 表示按需限制执行的评估用例列表。
-	LossHints   []LossHint // LossHints 表示人工补充的失败原因提示。
+	// EvalSetID 是要运行的评估集 ID。
+	EvalSetID   string
+	// EvalCaseIDs 将运行范围细化到指定评估用例，空列表表示运行全部评估用例。
+	EvalCaseIDs []string
+	// LossHints 为训练集失败指标补充业务侧已知的问题原因。
+	LossHints   []LossHint
 }
 
+// LossHint 为单个评估用例上的单个失败指标补充问题原因。
 type LossHint struct {
-	EvalCaseID string                  // EvalCaseID 表示要附加提示的评估用例。
-	MetricName string                  // MetricName 表示要附加提示的失败指标名称。
-	Severity   promptiter.LossSeverity // Severity 表示该提示的优先级。
-	Reason     string                  // Reason 表示人工补充的失败原因。
+	// EvalCaseID 指定问题原因对应的评估用例。
+	EvalCaseID string
+	// MetricName 指定问题原因对应的评估指标。
+	MetricName string
+	// Severity 表示问题原因的优先级。
+	Severity   promptiter.LossSeverity
+	// Reason 是用于反向传播归因的问题原因文本。
+	Reason     string
 }
-```
 
-不指定 `EvalCaseIDs` 时，会执行对应评估集下的全部样本：
-
-```go
-request := &engine.RunRequest{
-	Train: []engine.EvalSetInput{
-		{
-			EvalSetID: "nba-commentary-train",
-		},
-	},
-	Validation: []engine.EvalSetInput{
-		{
-			EvalSetID: "nba-commentary-validation",
-		},
-	},
-}
-```
-
-如果只希望训练集或验证集执行指定样本，可以在对应的 `EvalSetInput` 中设置 `EvalCaseIDs`：
-
-```go
-request := &engine.RunRequest{
-	Train: []engine.EvalSetInput{
-		{
-			EvalSetID:   "nba-commentary-train",
-			EvalCaseIDs: []string{"case_1", "case_2"},
-		},
-	},
-	Validation: []engine.EvalSetInput{
-		{
-			EvalSetID:   "nba-commentary-validation",
-			EvalCaseIDs: []string{"case_3"},
-		},
-	},
-}
-```
-
-`EvalCaseIDs` 省略或传空数组时，表示执行该评估集下的全部样本；传非空数组时，只执行指定样本。
-
-如果业务已经知道某些 badcase 的失败原因，可以在对应的 `EvalSetInput` 中设置 `LossHints`。调用方只需要填写 case、metric 和原因，不需要关心 trace 或 step 细节。
-
-```go
-request := &engine.RunRequest{
-	Train: []engine.EvalSetInput{
-		{
-			EvalSetID: "nba-commentary-train",
-			LossHints: []engine.LossHint{
-				{
-					EvalCaseID: "case_1",
-					MetricName: "answer_quality",
-					Severity:   promptiter.LossSeverityP1,
-					Reason:     "回答遗漏了球队关键防守策略的约束。",
-				},
-			},
-		},
-	},
-	Validation: []engine.EvalSetInput{
-		{
-			EvalSetID: "nba-commentary-validation",
-		},
-	},
-}
-```
-
-`LossHints` 只补充训练阶段的优化信号，不改变评测分数，也不影响 validation 接受判定。框架只会在对应 case 的对应 metric 本轮确实失败时使用 hint；如果本轮通过，则不会强行把它当作失败处理。case 或 metric 写错时会返回参数错误。
-
-#### EvaluationOptions
-
-`EvaluationOptions` 用于控制评估阶段的并发方式。
-
-```go
+// EvaluationOptions 配置训练集和验证集评估阶段。
 type EvaluationOptions struct {
-	EvalCaseParallelism               int  // EvalCaseParallelism 表示评估样本并发数上限。
-	EvalCaseParallelInferenceEnabled  bool // EvalCaseParallelInferenceEnabled 表示是否并行执行推理。
-	EvalCaseParallelEvaluationEnabled bool // EvalCaseParallelEvaluationEnabled 表示是否并行执行评估。
+	// EvalCaseParallelism 限制评估用例级并发数。
+	EvalCaseParallelism               int
+	// EvalCaseParallelInferenceEnabled 开启评估用例级并发推理。
+	EvalCaseParallelInferenceEnabled  bool
+	// EvalCaseParallelEvaluationEnabled 开启评估用例级并发指标计算。
+	EvalCaseParallelEvaluationEnabled bool
 }
-```
 
-它与 Evaluation 中的评估选项保持一致。PromptIter 直接复用 Evaluation 的并发执行方式，并在内部固定使用单次评估结果。
-
-#### BackwardOptions
-
-`BackwardOptions` 用于控制反向传播阶段的并发方式。默认情况下，训练集样本会按串行方式依次执行 backward。
-
-```go
+// BackwardOptions 配置反向传播归因阶段。
 type BackwardOptions struct {
-	CaseParallelismEnabled bool // CaseParallelismEnabled 表示是否并行处理训练集样本的反向传播。
-	CaseParallelism        int  // CaseParallelism 表示反向传播样本并发数上限。
+	// CaseParallelismEnabled 开启训练集评估用例级并发反向传播归因。
+	CaseParallelismEnabled bool
+	// CaseParallelism 限制反向传播归因阶段的评估用例并发数。
+	CaseParallelism        int
 }
-```
 
-启用 `CaseParallelismEnabled` 后，PromptIter 会按训练集样本并发执行 backward。`CaseParallelism` 为 `0` 时使用 `GOMAXPROCS` 作为默认并发数；为负数时，`Engine` 会返回参数错误。
-
-#### AggregationOptions
-
-`AggregationOptions` 用于控制梯度聚合阶段的并发方式。默认情况下，多个目标 surface 会按串行方式依次聚合。
-
-```go
+// AggregationOptions 配置文本梯度聚合阶段。
 type AggregationOptions struct {
-	SurfaceParallelismEnabled bool // SurfaceParallelismEnabled 表示是否并行聚合多个目标 surface。
-	SurfaceParallelism        int  // SurfaceParallelism 表示聚合阶段 surface 并发数上限。
+	// SurfaceParallelismEnabled 开启多个 surface 的并发聚合。
+	SurfaceParallelismEnabled bool
+	// SurfaceParallelism 限制文本梯度聚合阶段的 surface 并发数。
+	SurfaceParallelism        int
 }
-```
 
-启用 `SurfaceParallelismEnabled` 后，PromptIter 会按目标 surface 并发执行梯度聚合。`SurfaceParallelism` 为 `0` 时使用 `GOMAXPROCS` 作为默认并发数；为负数时，`Engine` 会返回参数错误。
-
-#### OptimizerOptions
-
-`OptimizerOptions` 用于控制优化器生成修改建议阶段的并发方式。默认情况下，多个目标 surface 会按串行方式依次优化。
-
-```go
+// OptimizerOptions 配置优化补丁生成阶段。
 type OptimizerOptions struct {
-	SurfaceParallelismEnabled bool // SurfaceParallelismEnabled 表示是否并行优化多个目标 surface。
-	SurfaceParallelism        int  // SurfaceParallelism 表示优化阶段 surface 并发数上限。
+	// SurfaceParallelismEnabled 开启多个 surface 的并发补丁生成。
+	SurfaceParallelismEnabled bool
+	// SurfaceParallelism 限制优化补丁生成阶段的 surface 并发数。
+	SurfaceParallelism        int
 }
 ```
 
-启用 `SurfaceParallelismEnabled` 后，PromptIter 会按目标 surface 并发生成修改建议。`SurfaceParallelism` 为 `0` 时使用 `GOMAXPROCS` 作为默认并发数；为负数时，`Engine` 会返回参数错误。
+`RunRequest` 首先指定训练集和验证集。`Train` 用于产生优化信号，`Validation` 用于接受判定，二者均不能为空。每个 `EvalSetInput` 可以指向完整评估集，也可以通过 `EvalCaseIDs` 只运行其中部分评估用例。`LossHints` 只服务于训练集，用于补充业务侧已知的问题原因。
 
-#### AcceptancePolicy 与 StopPolicy
+`InitialProfile` 用于指定本次迭代的起始 Profile。未传入时，PromptIter 使用结构快照中的原始 surface 值作为起始基线。传入 `InitialProfile` 时，如果 `StructureID` 非空，需要与当前结构快照 ID 一致。
 
-`AcceptancePolicy` 与 `StopPolicy` 分别控制是否接受当前改动以及何时停止本次运行。
+`Teacher` 和 `Judge` 会传给 Evaluation。`Teacher` 用于在评估需要时生成预期轨迹或参考答案。如果 EvalSet 已包含这些预期信息，`Teacher` 可以不传入。`Judge` 用于支撑 LLM Judge 类指标打分。未使用这类指标时，`Judge` 可以不传入。
 
-```go
-type AcceptancePolicy struct {
-	MinScoreGain float64 // MinScoreGain 表示接受当前改动所需的最小验证集分数增量。
-}
+`TargetSurfaceIDs` 用于设置本次允许迭代的 surface。单 Agent 场景通常指向 `candidate#instruction`，多节点 Agent 场景可指向多个节点的 `instruction` surface。
 
-type StopPolicy struct {
-	MaxRoundsWithoutAcceptance int      // MaxRoundsWithoutAcceptance 表示连续未接受轮数的上限。
-	TargetScore                *float64 // TargetScore 表示已接受分数达到该阈值后停止运行。
-}
-```
+`EvaluationOptions` 配置训练集和验证集评估阶段。`Train` 和 `Validation` 都可以包含多个 EvalSet，每个 EvalSet 又包含多个 EvalCase，因此一次评估可能需要运行多个评估用例。`EvalCaseParallelism` 设置并发评估用例数，`EvalCaseParallelInferenceEnabled` 控制是否并发运行多个评估用例中的 Agent，`EvalCaseParallelEvaluationEnabled` 控制是否并发对多个评估用例打分。
 
-对应的判定结果会出现在每轮 `RoundResult` 中：
+`BackwardOptions` 配置反向传播归因阶段。`Train` 可以包含多个 EvalSet，每个 EvalSet 又包含多个 EvalCase。训练集评估完成后，PromptIter 会按失败信号所在的评估用例执行归因。`CaseParallelismEnabled` 控制是否并发处理多个训练集评估用例，`CaseParallelism` 限制并发评估用例数。
 
-```go
-type AcceptanceDecision struct {
-	Accepted   bool    // Accepted 表示当前轮是否被接受。
-	ScoreDelta float64 // ScoreDelta 表示相对已接受基线的验证集分数增量。
-	Reason     string  // Reason 表示接受判定的原因说明。
-}
+`AggregationOptions` 配置文本梯度聚合阶段。一次运行可以通过 `TargetSurfaceIDs` 指定多个迭代目标，训练集失败信号也可能归因到多个 surface。`SurfaceParallelismEnabled` 控制是否并发聚合多个 surface，`SurfaceParallelism` 限制并发 surface 数。
 
-type StopDecision struct {
-	ShouldStop bool   // ShouldStop 表示当前轮结束后是否停止运行。
-	Reason     string // Reason 表示停止判定的原因说明。
-}
-```
-
-下面这些参数通常作为示例推荐值使用，并非框架强制默认值：
-
-- `MinScoreGain = 0.005`
-- `MaxRounds = 4`
-- `MaxRoundsWithoutAcceptance = 5`
-- `TargetScore = 1.0`
-
-这些示例推荐值通常对应以下运行语义：
-
-- 当验证集分数提升达到 `MinScoreGain` 时，当前轮改动才会被接受。
-- 当达到 `MaxRounds`、连续多轮未接受，或已达到 `TargetScore` 时，本次运行停止。
-
-如果希望减少抖动带来的误接受，可以适当提高 `MinScoreGain`。如果希望更早结束长时间无效迭代，可以降低 `MaxRoundsWithoutAcceptance`。如果希望在达到既定质量线后立即退出，可以设置 `TargetScore`。
+`OptimizerOptions` 配置优化补丁生成阶段。文本梯度聚合后可能得到多个 surface 的聚合结果，每个 surface 都需要生成对应候选补丁。`SurfaceParallelismEnabled` 控制是否并发为多个 surface 生成候选补丁，`SurfaceParallelism` 限制并发 surface 数。
 
 ### RunResult
 
-`RunResult` 表示一次 PromptIter 运行的结果与状态快照。它既是同步运行的最终结果，也是异步运行查询时返回的状态快照。
+`RunResult` 保存一次 PromptIter 运行的状态和历史结果。同步迭代直接返回该结构。异步启动返回初始 `RunResult`，后续查询返回最新 `RunResult`。
 
 ```go
 import (
@@ -658,263 +1264,290 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter"
 )
 
+// RunResult 保存一次 PromptIter 运行的状态和历史结果。
 type RunResult struct {
-	AppName            string               // AppName 表示本次运行所属的应用名。
-	ID                 string               // ID 表示运行标识。
-	Status             RunStatus            // Status 表示当前运行状态。
-	CurrentRound       int                  // CurrentRound 表示当前执行到第几轮。
-	Structure          *astructure.Snapshot // Structure 表示本次运行使用的结构快照。
-	BaselineValidation *EvaluationResult    // BaselineValidation 表示优化开始前的基线验证结果。
-	AcceptedProfile    *promptiter.Profile  // AcceptedProfile 表示当前已接受的最佳候选版本。
-	Rounds             []RoundResult        // Rounds 表示每一轮的详细结果。
-	ErrorMessage       string               // ErrorMessage 表示失败或取消时的错误信息。
+	// AppName 标识所属应用。
+	AppName            string
+	// ID 标识本次 PromptIter 运行。
+	ID                 string
+	// Status 保存当前运行状态。
+	Status             RunStatus
+	// CurrentRound 记录当前或最后执行到的轮次。
+	CurrentRound       int
+	// Structure 保存待测 Agent 的结构快照。
+	Structure          *astructure.Snapshot
+	// BaselineValidation 保存起始基线的验证结果。
+	BaselineValidation *EvaluationResult
+	// AcceptedProfile 保存当前基准 Profile。
+	AcceptedProfile    *promptiter.Profile
+	// Rounds 保存每轮训练、补丁和验证结果。
+	Rounds             []RoundResult
+	// ErrorMessage 保存失败或取消时的错误信息。
+	ErrorMessage       string
 }
 
+// RoundResult 保存单轮迭代的完整结果。
 type RoundResult struct {
-	Round         int                   // Round 表示当前轮次。
-	InputProfile  *promptiter.Profile   // InputProfile 表示当前轮输入的候选版本。
-	Train         *EvaluationResult     // Train 表示训练集评估结果。
-	Losses        []promptiter.CaseLoss // Losses 表示从失败样本中提取的 loss。
-	Backward      *BackwardResult       // Backward 表示反向传播结果。
-	Aggregation   *AggregationResult    // Aggregation 表示梯度聚合结果。
-	Patches       *promptiter.PatchSet  // Patches 表示优化器生成的修改建议。
-	OutputProfile *promptiter.Profile   // OutputProfile 表示应用修改建议后的候选版本。
-	Validation    *EvaluationResult     // Validation 表示验证集评估结果。
-	Acceptance    *AcceptanceDecision   // Acceptance 表示当前轮的接受判定。
-	Stop          *StopDecision         // Stop 表示当前轮的停止判定。
+	// Round 是当前轮次编号。
+	Round         int
+	// InputProfile 是本轮开始时的当前基准 Profile。
+	InputProfile  *promptiter.Profile
+	// Train 保存本轮训练集评估结果。
+	Train         *EvaluationResult
+	// Losses 保存从训练集失败指标提取的 loss。
+	Losses        []promptiter.CaseLoss
+	// Backward 保存反向传播归因结果。
+	Backward      *BackwardResult
+	// Aggregation 保存文本梯度聚合结果。
+	Aggregation   *AggregationResult
+	// Patches 保存 Optimizer 生成的候选补丁集合。
+	Patches       *promptiter.PatchSet
+	// OutputProfile 是应用候选补丁后的候选 Profile。
+	OutputProfile *promptiter.Profile
+	// Validation 保存候选 Profile 的验证集评估结果。
+	Validation    *EvaluationResult
+	// Acceptance 保存本轮接受判定。
+	Acceptance    *AcceptanceDecision
+	// Stop 保存本轮停止判定。
+	Stop          *StopDecision
 }
 ```
 
-#### 结果查看
+定位一次运行时，可按以下顺序查看结果。
 
-结果通常从以下位置查看：
+1. 查看 `BaselineValidation.OverallScore`，确认起始基线的验证分数
+2. 查看 `Rounds[n].Train`，确认训练集是否暴露预期问题
+3. 查看 `Rounds[n].Losses`，确认失败指标是否给出可用原因
+4. 查看 `Rounds[n].Patches`，确认 Optimizer 修改了哪些 surface 以及修改原因
+5. 查看 `Rounds[n].Validation`，确认候选 Profile 的验证分数和未通过指标
+6. 查看 `Rounds[n].Acceptance`，确认本轮是否被接受以及分数增量
+7. 查看 `AcceptedProfile`，确认最终基准 Profile
 
-- `RunResult.BaselineValidation`，用于查看优化开始前的基线分数。
-- `RunResult.AcceptedProfile`，用于查看当前已接受的最佳版本。
-- `RunResult.Rounds`，用于查看每一轮的训练集评估结果、验证集评估结果、修改建议和判定结果。
-- `RoundResult.Acceptance`，用于查看当前轮是否被接受以及分数增量。
-- `RoundResult.Stop`，用于查看当前轮是否触发停止条件。
+`RunStatus` 包括 `queued`、`running`、`succeeded`、`failed` 和 `canceled`。同步 `engine.Run` 成功返回时状态为 `succeeded`。异步运行会先创建 `queued` 状态，再由 `Manager` 更新为 `running` 和终态。
 
-下面是一段典型的结果摘要：
+### Engine
 
-```text
-Initial validation score: 0.35
-Final accepted validation score: 0.92
-Round 1 -> train 0.25, validation 0.81, accepted true, delta 0.46
-Round 2 -> train 0.88, validation 0.92, accepted true, delta 0.12
-Round 3 -> train 1.00, validation 0.90, accepted false, delta -0.02
-```
-
-上述结果的含义如下：
-
-- `Initial validation score` 表示基线分数。
-- `Final accepted validation score` 表示本次运行最终接受版本的分数。
-- `accepted true` 表示该轮修改被接受。
-- `accepted false` 表示该轮修改被拒绝，已有最佳版本保持不变。
-- `delta` 表示该轮相对当前已接受版本的验证集分数增量。
-
-如需查看完整评估明细，可以继续查看每轮 `EvaluationResult` 中的 `EvalSets`、`Cases` 和各项 metric 分数。
-
-### 反向传播 Backwarder
-
-`Backwarder` 负责将失败样本、trace 和 loss 转换为逐样本梯度，用于确定问题主要出现在何处，以及这些问题应归因到哪些可编辑位置。
-
-### 梯度聚合 Aggregator
-
-`Aggregator` 负责将同一个可编辑位置上来自多个样本的梯度聚合为统一信号，用于提取跨样本重复出现的问题。
-
-### 优化器 Optimizer
-
-`Optimizer` 负责根据聚合后的梯度生成修改建议，用于确定当前可编辑位置应如何调整。
-
-## 使用方法
-
-PromptIter 的用户接入通常围绕四类对象展开：
-
-- `RunRequest`，用于描述一次运行的输入。
-- `RunResult`，用于查看一次运行的状态与结果。
-- `Engine` 与工作流组件，用于执行同步优化并按需替换多轮优化链路中的关键组件。
-- `Manager / Store`，用于选择异步和持久化接入方式。
-- PromptIter HTTP 服务模块，用于通过 HTTP 暴露接口。
-
-常见的接入顺序如下：
-
-- 仅需本地同步运行时，优先使用 `engine`。对应示例见 [syncrun](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/promptiter/syncrun)。
-- 需要异步运行生命周期管理时，引入 `manager`。对应示例见 [asyncrun](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/promptiter/asyncrun)。
-- 需要远程触发和平台化接入时，再使用 PromptIter HTTP 服务模块。对应示例见 [server](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/promptiter/server)。
-
-### 反向传播器 Backwarder
-
-`Backwarder` 负责将失败样本、trace 和 loss 转换为逐样本梯度。
-
-```go
-type Backwarder interface {
-	Backward(ctx context.Context, request *Request) (*Result, error)
-}
-```
-
-默认实现通过 `backwarder.New(ctx, runner, opts...)` 创建。构造时支持以下选项：
-
-- `WithRunOptions(...)`，用于向内部 Runner 调用继续附加 `agent.RunOption`。
-- `WithMessageBuilder(...)`，用于自定义如何将 `Backwarder.Request` 编码成发送给 Runner 的消息。
-- `WithUserIDSupplier(...)`，用于自定义每次反向传播调用使用的 `userID`。
-- `WithSessionIDSupplier(...)`，用于自定义每次反向传播调用使用的 `sessionID`。
-
-大多数场景直接使用默认构造即可。只有在需要复用统一的 Runner 选项、替换默认上下文组织方式，或与既有会话标识体系对齐时，才需要显式配置这些选项。
-
-`Request` 中包含当前步骤的输入输出快照、关联的可编辑位置、前驱步骤和传入梯度，`Result` 中则包含两类输出：
-
-- `Gradients`，表示当前步骤上归因到各个可编辑位置的梯度。
-- `Upstream`，表示仍然需要继续传播到前驱步骤的梯度。
-
-默认实现会将一条 `Backwarder.Request` 直接组织成单步上下文，再交给 Runner 执行。这个上下文主要包括：
-
-- 当前评估样本标识，例如 `EvalSetID` 与 `EvalCaseID`。
-- 当前步骤本身的信息，例如 `Node`、`StepID`、`Input`、`Output` 与 `Error`。
-- 当前步骤可归因的可编辑位置，即 `Surfaces` 和 `AllowedGradientSurfaceIDs`。
-- 当前步骤的直接前驱步骤，即 `Predecessors`。
-- 从下游传回当前步骤的梯度包，即 `Incoming`。
-
-默认 `Backwarder` 会将这些内容序列化为一条用户消息，并通过结构化输出约束结果只能返回两类内容：
-
-- 当前步骤上归因到各个可编辑位置的 `Gradients`。
-- 仍需继续传播到前驱步骤的 `Upstream`。
-
-Backwarder 负责将失败样本转换为可传播的归因信号，用于确定失败主要应归因到哪些可编辑位置，以及这些问题如何继续向上游步骤传播。
-
-### 梯度聚合器 Aggregator
-
-`Aggregator` 负责将同一个可编辑位置上来自多个样本的梯度合并为统一信号。
-
-```go
-type Aggregator interface {
-	Aggregate(ctx context.Context, request *Request) (*Result, error)
-}
-```
-
-默认实现通过 `aggregator.New(ctx, runner, opts...)` 创建。构造时支持以下选项：
-
-- `WithRunOptions(...)`，用于向内部 Runner 调用继续附加 `agent.RunOption`。
-- `WithMessageBuilder(...)`，用于自定义如何将 `aggregator.Request` 编码成发送给 Runner 的消息。
-- `WithUserIDSupplier(...)`，用于自定义每次梯度聚合调用使用的 `userID`。
-- `WithSessionIDSupplier(...)`，用于自定义每次梯度聚合调用使用的 `sessionID`。
-
-大多数场景直接使用默认构造即可。只有在需要复用统一的 Runner 选项、替换默认上下文组织方式，或与既有会话标识体系对齐时，才需要显式配置这些选项。
-
-其中：
-
-- `Request.SurfaceID` 表示当前要聚合的目标可编辑位置。
-- `Request.Gradients` 表示该可编辑位置上所有样本产生的梯度。
-- `Result.Gradient` 表示聚合后的单个可编辑位置级信号。
-
-默认实现会将一条 `aggregator.Request` 直接组织成单个可编辑位置的聚合上下文，再交给 Runner 执行。这个上下文主要包括：
-
-- 当前要聚合的目标可编辑位置，即 `SurfaceID`。
-- 该可编辑位置所属的静态节点，即 `NodeID`。
-- 该可编辑位置的类型，即 `Type`。
-- 来自多个样本的原始梯度列表，即 `Gradients`。
-
-默认 `Aggregator` 会将这些内容序列化为一条用户消息，并要求 Runner 返回一条聚合后的 `AggregatedSurfaceGradient`，供下一阶段优化器直接使用。
-
-Aggregator 负责将多个样本上的局部梯度收敛为统一信号，用于提取跨样本重复出现的问题。
-
-### 优化器 Optimizer
-
-`Optimizer` 负责根据聚合后的梯度生成修改建议。
-
-```go
-type Optimizer interface {
-	Optimize(ctx context.Context, request *Request) (*Result, error)
-}
-```
-
-默认实现通过 `optimizer.New(ctx, runner, opts...)` 创建。构造时支持以下选项：
-
-- `WithRunOptions(...)`，用于向内部 Runner 调用继续附加 `agent.RunOption`。
-- `WithMessageBuilder(...)`，用于自定义如何将 `optimizer.Request` 编码成发送给 Runner 的消息。
-- `WithUserIDSupplier(...)`，用于自定义每次优化调用使用的 `userID`。
-- `WithSessionIDSupplier(...)`，用于自定义每次优化调用使用的 `sessionID`。
-
-大多数场景直接使用默认构造即可。只有在需要复用统一的 Runner 选项、替换默认上下文组织方式，或与既有会话标识体系对齐时，才需要显式配置这些选项。
-
-其中：
-
-- `Request.Surface` 表示当前可编辑位置的基线值。
-- `Request.Gradient` 表示该可编辑位置上的聚合梯度。
-- `Result.Patch` 表示生成的修改建议。
-
-默认实现会将一条 `optimizer.Request` 直接组织成单个可编辑位置的优化上下文，再交给 Runner 执行。这个上下文主要包括：
-
-- 当前可编辑位置本身，即 `Surface`。
-- 该可编辑位置的当前基线值。
-- 针对该可编辑位置的聚合梯度，即 `Gradient`。
-
-默认 `Optimizer` 会将这些内容序列化为一条用户消息，并要求 Runner 返回一条 `SurfacePatch`，其中包含新的候选值和对应的原因说明。
-
-Optimizer 负责将聚合后的梯度转换为具体修改建议，用于确定当前可编辑位置应如何调整。
-
-### 运行引擎 Engine
-
-如果只需要直接执行一次 PromptIter 运行，推荐使用 `engine` 包。`Engine` 负责将反向传播器、梯度聚合器和优化器三个组件串成一次完整的多轮优化流程。
-
-对应示例见 [syncrun](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/promptiter/syncrun)。
+`Engine` 是提示词同步迭代入口，负责在当前调用中执行完整 PromptIter 流程，并在运行结束后返回 `RunResult`。本地调试、脚本化任务和需要阻塞等待结果的接入方式通常直接使用 `Engine`。
 
 ```go
 import (
 	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
 )
 
+// Engine 提供提示词同步迭代能力。
 type Engine interface {
+	// Describe 返回待测 Agent 的结构快照。
 	Describe(ctx context.Context) (*astructure.Snapshot, error)
+	// Run 执行一次多轮提示词迭代。
 	Run(ctx context.Context, request *RunRequest, opts ...Option) (*RunResult, error)
 }
 ```
 
-其中：
-
-- `Describe` 用于返回当前结构快照。
-- `Run` 用于执行多轮提示词优化。
-
-默认实现通过 `engine.New(ctx, targetAgent, agentEvaluator, backwarder, aggregator, optimizer)` 创建。创建时需要显式注入五类依赖：被优化的目标 Agent、训练集和验证集评估使用的 `agentEvaluator`，以及反向传播器、梯度聚合器和优化器三个工作流组件。
-
-其中，`targetAgent` 用于提供结构快照。`Engine` 会通过它导出静态结构图，用于确定可编辑位置、校验 `TargetSurfaceIDs`、规范化 `Profile`，并实现 `Describe()`。`agentEvaluator` 则负责执行训练集和验证集评估，两者分别对应结构描述与评估执行两类能力，职责并不重叠。
-
-`Engine` 的 option 出现在 `Run(...)` 调用阶段。当前运行期只提供 `WithObserver(...)`，用于在单次运行期间接收阶段事件；除观察能力之外，`Engine` 不额外暴露其他运行期 option。
-
-#### 运行观察 Observer
-
-`engine.Run` 支持通过 `WithObserver(...)` 注入运行观察器，用于在单次运行中接收阶段事件。
+默认实现通过 `engine.New` 创建，需要注入待测 Agent、`AgentEvaluator`、`Backwarder`、`Aggregator` 和 `Optimizer`，定义如下。
 
 ```go
-type Observer func(ctx context.Context, event *Event) error
+import (
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/aggregator"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/backwarder"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/optimizer"
+)
 
-type Event struct {
-	Kind    EventKind
-	Round   int
-	Payload any
+// New 创建默认 Engine 实现。
+func New(
+	ctx context.Context,
+	targetAgent agent.Agent,
+	agentEvaluator evaluation.AgentEvaluator,
+	backwarder backwarder.Backwarder,
+	aggregator aggregator.Aggregator,
+	optimizer optimizer.Optimizer,
+) (Engine, error)
+```
+
+使用示例如下。
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+)
+
+
+// engine.New 组装 PromptIter 同步迭代入口。
+engineInstance, err := engine.New(
+	ctx,
+	candidateAgent,
+	agentEvaluator,
+	backwarderInstance,
+	aggregatorInstance,
+	optimizerInstance,
+)
+if err != nil {
+	return err
 }
 ```
 
-典型事件包括：
+创建后可通过 `Describe` 查看结构快照，并通过 `Run` 执行同步迭代。
 
-- `structure_snapshot`
-- `baseline_validation`
-- `round_train_evaluation`
-- `round_losses`
-- `round_backward`
-- `round_aggregation`
-- `round_patch_set`
-- `round_output_profile`
-- `round_validation`
-- `round_completed`
+```go
+// Describe 返回待测 Agent 的结构快照。
+snapshot, err := engineInstance.Describe(ctx)
+if err != nil {
+	return err
+}
 
-如果仅需本地同步调试，通常直接查看 `RunResult` 即可；如果需要在运行过程中感知阶段变化，再引入 `Observer`。
+// Run 执行一次同步提示词迭代，并在完成后返回 RunResult。
+result, err := engineInstance.Run(ctx, request)
+if err != nil {
+	return err
+}
+```
 
-### 运行管理器 Manager
+`WithObserver(...)` 用于接收运行事件，观察迭代进度。
 
-如果需要异步运行的生命周期管理，可以使用 `manager` 包。
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+)
 
-对应示例见 [asyncrun](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/promptiter/asyncrun)。
+
+// WithObserver 注册运行事件回调。
+result, err := engineInstance.Run(ctx, request, engine.WithObserver(
+	func(ctx context.Context, event *engine.Event) error {
+		// event.Kind 是事件类型，event.Round 是所属轮次。
+		fmt.Println(event.Kind, event.Round)
+		return nil
+	},
+))
+```
+
+可观察事件如下。
+
+| 事件类型 | 含义 |
+| --- | --- |
+| `structure_snapshot` | 本次运行使用的结构快照。 |
+| `baseline_validation` | 起始基线 Profile 的验证结果。 |
+| `round_started` | 单轮迭代开始。 |
+| `round_train_evaluation` | 本轮训练集评估结果。 |
+| `round_losses` | 从训练集失败指标提取出的 loss。 |
+| `round_backward` | 本轮反向传播归因结果。 |
+| `round_aggregation` | 本轮文本梯度聚合结果。 |
+| `round_patch_set` | 本轮候选补丁集合。 |
+| `round_output_profile` | 应用候选补丁后得到的候选 Profile。 |
+| `round_validation` | 候选 Profile 的验证集评估结果。 |
+| `round_completed` | 本轮接受判定和停止判定摘要。 |
+
+### Manager
+
+`Manager` 在 `Engine` 之上提供提示词异步迭代能力，负责提交后台运行、查询 `RunResult`、取消运行和释放资源。
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+)
+
+// Manager 管理异步 PromptIter 运行。
+type Manager interface {
+	// Start 创建异步运行并返回初始 RunResult。
+	Start(ctx context.Context, request *engine.RunRequest) (*engine.RunResult, error)
+	// Get 按 runID 查询当前 RunResult。
+	Get(ctx context.Context, runID string) (*engine.RunResult, error)
+	// Cancel 请求取消指定运行。
+	Cancel(ctx context.Context, runID string) error
+	// Close 释放 Manager 持有的资源。
+	Close() error
+}
+```
+
+默认实现通过 `manager.New` 创建，需要注入应用名和同步 `Engine`。`New` 方法定义如下。
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+)
+
+
+// New 创建默认 Manager 实现。
+func New(appName string, engine engine.Engine, opts ...Option) (Manager, error)
+```
+
+使用示例如下。
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/manager"
+)
+
+
+// manager.New 创建使用默认存储的异步运行管理器。
+managerInstance, err := manager.New(appName, engineInstance)
+if err != nil {
+	return err
+}
+defer managerInstance.Close()
+```
+
+创建后可通过 `Start` 提交异步迭代，并通过 `Get` 查询最新的 `RunResult`。
+
+```go
+// Start 提交一次异步提示词迭代。
+run, err := managerInstance.Start(ctx, request)
+if err != nil {
+	return err
+}
+
+// Get 查询当前 RunResult。
+current, err := managerInstance.Get(ctx, run.ID)
+if err != nil {
+	return err
+}
+```
+
+`Start` 提交异步迭代任务并立即返回 `RunResult`，任务随后在后台执行。调用 `Get` 可查询最新的 `RunResult`。
+
+构造期 option 可替换存储实现，也可配置写入存储前的结果精简策略，定义如下。
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/store"
+)
+
+// Option 配置默认 Manager 实现。
+type Option func(*options)
+
+// WithStore 指定异步运行状态使用的存储。
+func WithStore(store store.Store) Option
+
+// WithStoredResultSlimming 指定写入存储前的 RunResult 精简策略。
+func WithStoredResultSlimming(slimming engine.RunResultSlimming) Option
+```
+
+`WithStore` 用于替换异步运行状态的存储实现。`WithStoredResultSlimming` 接收 `engine.RunResultSlimming`，用于在写入存储前精简 `RunResult`。`RunResultSlimming` 描述 `RunResult` 的字段省略策略。未配置任何省略项时，结果会完整保留。
+
+```go
+// RunResultSlimming 控制 RunResult 中哪些字段会在保存或返回前被省略。
+type RunResultSlimming struct {
+	// OmitStructure 省略导出的 Agent 结构快照。
+	OmitStructure bool
+	// OmitEvaluationCases 省略各阶段评估结果中的评估用例明细。
+	OmitEvaluationCases bool
+	// OmitBackward 省略每轮反向传播归因结果。
+	OmitBackward bool
+	// OmitAggregation 省略每轮文本梯度聚合结果。
+	OmitAggregation bool
+	// OmitPatches 省略每轮优化补丁结果。
+	OmitPatches bool
+	// OmitProfiles 省略输入 Profile、候选 Profile 和当前基准 Profile。
+	OmitProfiles bool
+	// OmitLosses 省略每轮 loss 明细。
+	OmitLosses bool
+}
+```
+
+### Store
+
+`Store` 负责持久化异步迭代的 `RunResult`。`Manager.Start` 创建运行记录时调用 `Create`，后台运行过程中通过 `Update` 写入最新结果，`Manager.Get` 通过 `Get` 查询当前结果。
 
 #### 接口定义
 
@@ -923,137 +1556,960 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
 )
 
-type Manager interface {
-	Start(ctx context.Context, request *engine.RunRequest) (*engine.RunResult, error)
-	Get(ctx context.Context, runID string) (*engine.RunResult, error)
-	Cancel(ctx context.Context, runID string) error
+// Store 持久化异步 PromptIter 运行的 RunResult。
+type Store interface {
+	// Create 保存新创建的运行记录。
+	Create(ctx context.Context, appName string, run *engine.RunResult) error
+	// Get 读取指定运行记录。
+	Get(ctx context.Context, appName, runID string) (*engine.RunResult, error)
+	// Update 覆盖指定运行记录的最新 RunResult。
+	Update(ctx context.Context, appName string, run *engine.RunResult) error
+	// Close 释放存储资源。
 	Close() error
 }
 ```
 
-#### 使用方式
+#### inmemory 实现
 
-最小调用方式如下。
+`Manager` 默认使用内存实现。内存实现通过 `inmemory.New` 创建，适合本地调试和测试，进程退出后记录会丢失。`New` 方法定义如下。
 
 ```go
-import "trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/manager"
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/store"
+)
 
+
+// New 创建内存 Store 实现。
+func New() store.Store
+```
+
+使用示例如下。
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/store/inmemory"
+)
+
+
+// inmemory.New 创建内存 Store。
+store := inmemory.New()
+```
+
+#### mysql 实现
+
+需要跨进程查询或长期保存时，可使用 MySQL 实现。MySQL 实现通过 `mysql.New` 创建，将 `RunResult` 序列化后写入单表。核心字段包括 `app_name`、`run_id`、`status`、`run_result`、`created_at` 和 `updated_at`。`app_name` 与 `run_id` 组成唯一键，用于隔离不同应用下的运行记录。`New` 方法定义如下。
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/store"
+)
+
+
+// New 创建 MySQL Store 实现。
+func New(opts ...Option) (store.Store, error)
+```
+
+使用示例如下。
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/store/mysql"
+)
+
+
+// mysql.New 创建 MySQL Store。
+store, err := mysql.New(
+	// WithMySQLClientDSN 使用 DSN 初始化 MySQL 连接。
+	mysql.WithMySQLClientDSN(dsn),
+)
+```
+
+如果关闭自动初始化，或需要由外部系统提前建表，可使用下面的 SQL。表名默认是 `promptiter_runs`。配置 `WithTablePrefix` 后，实际表名会加上对应前缀。
+
+```sql
+CREATE TABLE IF NOT EXISTS promptiter_runs (
+	id BIGINT NOT NULL AUTO_INCREMENT,
+	app_name VARCHAR(255) NOT NULL,
+	run_id VARCHAR(255) NOT NULL,
+	status VARCHAR(32) NOT NULL DEFAULT '',
+	run_result JSON NOT NULL,
+	created_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+	updated_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+	PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE UNIQUE INDEX uniq_promptiter_runs_app_run ON promptiter_runs(app_name, run_id);
+```
+
+创建 Store 后，在构造 Manager 时通过 `WithStore` 传入。
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/manager"
+)
+
+
+// WithStore 让 Manager 使用指定 Store 保存异步运行状态。
+managerInstance, err := manager.New(
+	appName,
+	engineInstance,
+	manager.WithStore(store),
+)
+```
+
+MySQL 实现在构造期可以通过 Option 指定连接来源、初始化行为和表名前缀，定义如下。
+
+```go
+// Option 配置 MySQL Store 实现。
+type Option func(*options)
+
+// WithMySQLClientDSN 使用 DSN 初始化 MySQL 连接。
+func WithMySQLClientDSN(dsn string) Option
+
+// WithMySQLInstance 使用已注册的 MySQL 实例。
+func WithMySQLInstance(instanceName string) Option
+
+// WithExtraOptions 追加传给 MySQL 客户端构造逻辑的选项。
+func WithExtraOptions(extraOptions ...any) Option
+
+// WithSkipDBInit 指定是否跳过表结构和索引初始化。
+func WithSkipDBInit(skip bool) Option
+
+// WithTablePrefix 指定 PromptIter 表名前缀。
+func WithTablePrefix(prefix string) Option
+
+// WithInitTimeout 指定表结构初始化超时时间。
+func WithInitTimeout(timeout time.Duration) Option
+```
+
+`WithMySQLClientDSN` 直接使用 DSN 创建连接。`WithMySQLInstance` 在未传入 DSN 时使用已注册的 MySQL 实例。`WithExtraOptions` 透传额外的客户端构造选项。`WithSkipDBInit` 可跳过表结构初始化，适合由外部系统提前建表的环境。`WithTablePrefix` 用于隔离不同部署的表名。`WithInitTimeout` 控制表结构初始化的超时时间。
+
+### HTTP 服务
+
+`server/promptiter` 将 PromptIter 的结构查询、同步迭代和异步迭代管理暴露为 HTTP API。
+
+```go
+import "net/http"
+
+// New 构建 PromptIter HTTP 服务。
+func New(opts ...Option) (*Server, error)
+
+// Handler 返回 HTTP 处理器，供 net/http 挂载。
+func (s *Server) Handler() http.Handler
+```
+
+如果调用方只读取结构快照并发起阻塞式同步迭代，服务端配置 `WithAppName` 和 `WithEngine` 即可。此配置会注册结构查询和同步迭代路由，不注册异步运行管理路由。
+
+```go
+import (
+	"net/http"
+
+	spromptiter "trpc.group/trpc-go/trpc-agent-go/server/promptiter"
+)
+
+const addr = ":8080"
+
+// New 创建只暴露结构查询和同步迭代的 PromptIter 服务。
+serverInstance, err := spromptiter.New(
+	// WithAppName 指定服务处理的应用名。
+	spromptiter.WithAppName(appName),
+	// WithEngine 提供同步迭代和结构查询能力。
+	spromptiter.WithEngine(engineInstance),
+)
+if err != nil {
+	return err
+}
+
+// ListenAndServe 使用 net/http 启动 PromptIter HTTP 服务。
+if err := http.ListenAndServe(addr, serverInstance.Handler()); err != nil {
+	return err
+}
+```
+
+如果调用方需要提交后台迭代任务，并在执行过程中查询状态或请求取消，服务端需要额外配置 `WithManager`。配置后会在结构查询和同步迭代路由之外，注册异步运行、异步查询和取消运行路由。
+
+```go
+import (
+	"net/http"
+
+	spromptiter "trpc.group/trpc-go/trpc-agent-go/server/promptiter"
+)
+
+const addr = ":8080"
+
+// New 创建同时暴露同步迭代接口和异步迭代接口的 PromptIter 服务。
+serverInstance, err := spromptiter.New(
+	// WithAppName 指定服务处理的应用名。
+	spromptiter.WithAppName(appName),
+	// WithEngine 提供同步迭代和结构查询能力。
+	spromptiter.WithEngine(engineInstance),
+	// WithManager 提供异步运行、查询和取消能力。
+	spromptiter.WithManager(managerInstance),
+)
+if err != nil {
+	return err
+}
+
+// ListenAndServe 使用 net/http 启动 PromptIter HTTP 服务。
+if err := http.ListenAndServe(addr, serverInstance.Handler()); err != nil {
+	return err
+}
+```
+
+除上面示例中的 `WithAppName`、`WithEngine` 和 `WithManager` 外，HTTP 服务还允许调整默认路由、单次请求超时和响应体精简策略。
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/manager"
+)
+
+// Option 配置 PromptIter HTTP 服务。
+type Option func(*options)
+
+// WithAppName 指定服务处理的应用名，必填。
+func WithAppName(name string) Option
+
+// WithBasePath 指定应用集合的基础路径，默认是 /promptiter/v1/apps。
+func WithBasePath(path string) Option
+
+// WithStructurePath 指定结构查询路径，默认是 /structure。
+func WithStructurePath(path string) Option
+
+// WithRunsPath 指定同步迭代路径，默认是 /runs。
+func WithRunsPath(path string) Option
+
+// WithAsyncRunsPath 指定异步迭代路径，默认是 /async-runs。
+func WithAsyncRunsPath(path string) Option
+
+// WithTimeout 指定单次 HTTP 请求的最大执行时间。
+func WithTimeout(timeout time.Duration) Option
+
+// WithEngine 指定结构查询和同步迭代使用的 Engine，必填。
+func WithEngine(promptIterEngine engine.Engine) Option
+
+// WithManager 指定异步运行管理使用的 Manager，配置后才会注册异步路由。
+func WithManager(promptIterManager manager.Manager) Option
+
+// WithResponseResultSlimming 指定 HTTP 返回前的 RunResult 精简策略。
+func WithResponseResultSlimming(slimming engine.RunResultSlimming) Option
+```
+
+HTTP 服务默认注册下列路由，`{appName}` 对应 `WithAppName` 指定的应用名，异步路由仅在配置 `WithManager` 后注册。
+
+| 方法 | 路径 | 行为 |
+| --- | --- | --- |
+| `GET` | `/promptiter/v1/apps/{appName}/structure` | 返回待测 Agent 的结构快照。 |
+| `POST` | `/promptiter/v1/apps/{appName}/runs` | 执行同步提示词迭代，并在完成后返回 `RunResult`。 |
+| `POST` | `/promptiter/v1/apps/{appName}/async-runs` | 提交异步提示词迭代，成功时返回 `201 Created` 和初始 `RunResult`，并在 `Location` 响应头写入运行查询路径。 |
+| `GET` | `/promptiter/v1/apps/{appName}/async-runs/{runID}` | 查询异步运行当前的 `RunResult`。 |
+| `POST` | `/promptiter/v1/apps/{appName}/async-runs/{runID}/cancel` | 请求取消指定异步运行，成功时返回 `202 Accepted`。 |
+
+同步和异步运行接口使用相同的请求和响应结构，结构查询接口返回待测 Agent 的结构快照。
+
+```go
+import (
+	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+)
+
+// RunRequest 表示一次 PromptIter 运行请求。
+type RunRequest struct {
+	// Run 保存传给 Engine 或 Manager 的运行配置。
+	Run *engine.RunRequest `json:"run"`
+}
+
+// RunResponse 表示一次 PromptIter 运行结果。
+type RunResponse struct {
+	// Result 保存 Engine 或 Manager 返回的运行结果。
+	Result *engine.RunResult `json:"result"`
+}
+
+// GetStructureResponse 表示结构查询结果。
+type GetStructureResponse struct {
+	// Structure 保存待测 Agent 的结构快照。
+	Structure *astructure.Snapshot `json:"structure"`
+}
+```
+
+业务侧接入 PromptIter 时通常先调用 `/structure` 读取结构快照，从中选择需要迭代的 surface，并把对应 ID 写入请求体的 `run.TargetSurfaceIDs`。需要同步结果时调用 `/runs`。需要后台运行时调用 `/async-runs`，再使用返回的运行 ID 查询当前 `RunResult`。
+
+### 同步迭代
+
+同步迭代通过 `Engine.Run` 在当前进程内完成，适合本地调试、脚本任务和阻塞等待结果的接入方式。关键步骤是创建待测 Runner、裁判 Runner、`AgentEvaluator`、三个 PromptIter 工作组件和 `Engine`，再提交 `RunRequest`。完整代码见 [examples/evaluation/promptiter/syncrun](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/promptiter/syncrun)。
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation"
+	evalresultlocal "trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult/local"
+	evalsetlocal "trpc.group/trpc-go/trpc-agent-go/evaluation/evalset/local"
+	metriclocal "trpc.group/trpc-go/trpc-agent-go/evaluation/metric/local"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/aggregator"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/backwarder"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/optimizer"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+)
+
+// candidateAgent 是本次迭代的待测 Agent。
+candidateAgent := llmagent.New(
+	candidateAgentName,
+	llmagent.WithModel(candidateModel),
+	// WithInstruction 写入 candidate#instruction 对应的起始提示词。
+	llmagent.WithInstruction("生成一篇中文体育战报"),
+)
+// candidateRunner 是 Evaluation 执行待测 Agent 的入口。
+candidateRunner := runner.NewRunner(candidateAppName, candidateAgent)
+
+// judgeRunner 供 LLM Judge 类指标调用裁判模型。
+judgeAgent := llmagent.New(judgeAppName, llmagent.WithModel(judgeModel))
+judgeRunner := runner.NewRunner(judgeAppName, judgeAgent)
+
+// 评估集、指标和评估结果分别由对应 Manager 管理。
+evalSetManager := evalsetlocal.New()
+metricManager := metriclocal.New()
+evalResultManager := evalresultlocal.New()
+
+// AgentEvaluator 负责执行训练集和验证集评估。
+agentEvaluator, err := evaluation.New(
+	appName,
+	candidateRunner,
+	evaluation.WithEvalSetManager(evalSetManager),
+	evaluation.WithMetricManager(metricManager),
+	evaluation.WithEvalResultManager(evalResultManager),
+	evaluation.WithJudgeRunner(judgeRunner),
+)
+if err != nil {
+	return err
+}
+
+// Backwarder 负责反向传播归因。
+backwarderRunner := runner.NewRunner(
+	backwarderAppName,
+	llmagent.New(backwarderAppName, llmagent.WithModel(workerModel)),
+)
+backwarderInstance, err := backwarder.New(ctx, backwarderRunner)
+if err != nil {
+	return err
+}
+
+// Aggregator 负责文本梯度聚合。
+aggregatorRunner := runner.NewRunner(
+	aggregatorAppName,
+	llmagent.New(aggregatorAppName, llmagent.WithModel(workerModel)),
+)
+aggregatorInstance, err := aggregator.New(ctx, aggregatorRunner)
+if err != nil {
+	return err
+}
+
+// Optimizer 负责优化补丁生成。
+optimizerRunner := runner.NewRunner(
+	optimizerAppName,
+	llmagent.New(optimizerAppName, llmagent.WithModel(workerModel)),
+)
+optimizerInstance, err := optimizer.New(ctx, optimizerRunner)
+if err != nil {
+	return err
+}
+
+// Engine 绑定待测 Agent、评估器和三个 PromptIter 工作组件。
+engineInstance, err := engine.New(
+	ctx,
+	candidateAgent,
+	agentEvaluator,
+	backwarderInstance,
+	aggregatorInstance,
+	optimizerInstance,
+)
+if err != nil {
+	return err
+}
+
+// targetInstructionID 指向 candidate Agent 的 instruction，值为 candidate#instruction。
+targetInstructionID := astructure.SurfaceID(candidateAgentName, astructure.SurfaceTypeInstruction)
+// targetScore 是本次运行的目标验证集分数。
+targetScore := 1.0
+
+// RunRequest 指定训练集、验证集、迭代目标、并发选项、最大轮数、接受策略和停止策略。
+// result 保存本次同步迭代的完整 RunResult。
+result, err := engineInstance.Run(ctx, &engine.RunRequest{
+	// Train 指定产生优化信号的训练集。
+	Train: []engine.EvalSetInput{
+		{
+			// EvalSetID 指向用于产生优化信号的训练集。
+			EvalSetID: trainEvalSetID,
+		},
+	},
+	// Validation 指定接受判定使用的验证集。
+	Validation: []engine.EvalSetInput{
+		{
+			// EvalSetID 指向用于接受判定的验证集。
+			EvalSetID: validationEvalSetID,
+		},
+	},
+	// 训练集和验证集评估阶段按评估用例并发。
+	EvaluationOptions: engine.EvaluationOptions{
+		// EvalCaseParallelism 限制评估用例并发数。
+		EvalCaseParallelism:               16,
+		// EvalCaseParallelInferenceEnabled 开启待测 Agent 并发推理。
+		EvalCaseParallelInferenceEnabled:  true,
+		// EvalCaseParallelEvaluationEnabled 开启指标并发计算。
+		EvalCaseParallelEvaluationEnabled: true,
+	},
+	// 反向传播归因阶段默认按评估用例串行处理。
+	BackwardOptions: engine.BackwardOptions{
+		// CaseParallelismEnabled 控制是否并发处理训练集评估用例。
+		CaseParallelismEnabled: false,
+		// CaseParallelism 是开启并发后的评估用例并发上限。
+		CaseParallelism:        16,
+	},
+	// 文本梯度聚合阶段按迭代目标并发。
+	AggregationOptions: engine.AggregationOptions{
+		// SurfaceParallelismEnabled 控制是否并发处理多个迭代目标。
+		SurfaceParallelismEnabled: true,
+		// SurfaceParallelism 是迭代目标并发上限。
+		SurfaceParallelism:        16,
+	},
+	// 优化补丁生成阶段按迭代目标并发。
+	OptimizerOptions: engine.OptimizerOptions{
+		// SurfaceParallelismEnabled 控制是否并发为多个迭代目标生成补丁。
+		SurfaceParallelismEnabled: true,
+		// SurfaceParallelism 是迭代目标并发上限。
+		SurfaceParallelism:        16,
+	},
+	// 候选提示词需要相对当前基准提示词提升至少 0.01 分。
+	AcceptancePolicy: engine.AcceptancePolicy{
+		// MinScoreGain 是接受候选提示词所需的最小验证分数增量。
+		MinScoreGain: 0.01,
+	},
+	// 达到最大轮数、连续未接受轮数或目标分数时停止。
+	StopPolicy: engine.StopPolicy{
+		// MaxRoundsWithoutAcceptance 限制连续未接受候选提示词的轮数。
+		MaxRoundsWithoutAcceptance: 3,
+		// TargetScore 是达到后即可停止的目标验证分数。
+		TargetScore:                &targetScore,
+	},
+	// MaxRounds 是本次运行的最大迭代轮数。
+	MaxRounds: 4,
+	// TargetSurfaceIDs 指定本次允许迭代的提示词。
+	TargetSurfaceIDs: []string{targetInstructionID},
+})
+if err != nil {
+	return err
+}
+```
+
+`Engine.Run` 返回的 `RunResult` 会记录结构 ID、迭代目标、起始提示词、最终基准提示词、验证分数和每轮判定结果。
+
+| 输出项 | 示例值 |
+| --- | --- |
+| Initial validation score | `0.49` |
+| Final accepted validation score | `0.90` |
+| Rounds executed | `4` |
+| Round 1 | train `0.35`，validation `0.85`，accepted `true`，delta `0.36` |
+| Round 2 | train `0.83`，validation `0.90`，accepted `true`，delta `0.05` |
+| Round 3 | train `0.87`，validation `0.81`，accepted `false`，delta `-0.09` |
+| Round 4 | train `0.89`，validation `0.80`，accepted `false`，delta `-0.10` |
+
+该输出体现 PromptIter 的接受语义。第 1 轮和第 2 轮候选提示词通过接受判定，当前基准逐步更新到第 2 轮候选提示词。第 3 轮和第 4 轮虽然训练集分数较高，但候选提示词的验证分数没有超过当前基准提示词的验证分数，因此未被接受，最终基准停留在第 2 轮候选提示词。
+
+### 异步迭代
+
+异步迭代通过 `Manager` 管理 `Engine.Run` 的后台执行，适合调用方提交运行请求后再查询结果的接入方式。接入时仍需先完成待测 Agent、`AgentEvaluator` 和三个 PromptIter 工作组件的组装，再用这些依赖创建 `Engine` 和 `Manager`。完整代码见 [examples/evaluation/promptiter/asyncrun](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/promptiter/asyncrun)。
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation"
+	evalresultlocal "trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult/local"
+	evalsetlocal "trpc.group/trpc-go/trpc-agent-go/evaluation/evalset/local"
+	metriclocal "trpc.group/trpc-go/trpc-agent-go/evaluation/metric/local"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/aggregator"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/backwarder"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/manager"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/optimizer"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+)
+
+// candidateAgent 是本次迭代的待测 Agent。
+candidateAgent := llmagent.New(
+	candidateAgentName,
+	llmagent.WithModel(candidateModel),
+	// WithInstruction 写入 candidate#instruction 对应的起始提示词。
+	llmagent.WithInstruction("生成一篇中文体育战报"),
+)
+
+// candidateRunner 是 Evaluation 执行待测 Agent 的入口。
+candidateRunner := runner.NewRunner(candidateAppName, candidateAgent)
+
+// judgeRunner 供 LLM Judge 类指标调用裁判模型。
+judgeAgent := llmagent.New(judgeAppName, llmagent.WithModel(judgeModel))
+judgeRunner := runner.NewRunner(judgeAppName, judgeAgent)
+
+// 评估集、指标和评估结果分别由对应 Manager 管理。
+evalSetManager := evalsetlocal.New()
+metricManager := metriclocal.New()
+evalResultManager := evalresultlocal.New()
+
+// AgentEvaluator 负责执行训练集和验证集评估。
+agentEvaluator, err := evaluation.New(
+	appName,
+	candidateRunner,
+	evaluation.WithEvalSetManager(evalSetManager),
+	evaluation.WithMetricManager(metricManager),
+	evaluation.WithEvalResultManager(evalResultManager),
+	evaluation.WithJudgeRunner(judgeRunner),
+)
+if err != nil {
+	return err
+}
+
+// Backwarder 负责反向传播归因。
+backwarderRunner := runner.NewRunner(
+	backwarderAppName,
+	llmagent.New(backwarderAppName, llmagent.WithModel(workerModel)),
+)
+backwarderInstance, err := backwarder.New(ctx, backwarderRunner)
+if err != nil {
+	return err
+}
+
+// Aggregator 负责文本梯度聚合。
+aggregatorRunner := runner.NewRunner(
+	aggregatorAppName,
+	llmagent.New(aggregatorAppName, llmagent.WithModel(workerModel)),
+)
+aggregatorInstance, err := aggregator.New(ctx, aggregatorRunner)
+if err != nil {
+	return err
+}
+
+// Optimizer 负责优化补丁生成。
+optimizerRunner := runner.NewRunner(
+	optimizerAppName,
+	llmagent.New(optimizerAppName, llmagent.WithModel(workerModel)),
+)
+optimizerInstance, err := optimizer.New(ctx, optimizerRunner)
+if err != nil {
+	return err
+}
+
+// Engine 绑定待测 Agent、评估器和三个 PromptIter 工作组件。
+engineInstance, err := engine.New(
+	ctx,
+	candidateAgent,
+	agentEvaluator,
+	backwarderInstance,
+	aggregatorInstance,
+	optimizerInstance,
+)
+if err != nil {
+	return err
+}
+
+// Manager 在 Engine 之上管理异步 PromptIter 运行。
 managerInstance, err := manager.New(appName, engineInstance)
 if err != nil {
 	return err
 }
 defer managerInstance.Close()
 
-run, err := managerInstance.Start(ctx, request)
-if err != nil {
-	return err
+// targetInstructionID 指向 candidate Agent 的 instruction，值为 candidate#instruction。
+targetInstructionID := astructure.SurfaceID(candidateAgentName, astructure.SurfaceTypeInstruction)
+// targetScore 是本次运行的目标验证集分数。
+targetScore := 1.0
+
+// RunRequest 指定训练集、验证集、迭代目标、并发选项、最大轮数、接受策略和停止策略。
+runRequest := &engine.RunRequest{
+	// Train 指定产生优化信号的训练集。
+	Train: []engine.EvalSetInput{
+		{
+			// EvalSetID 指向用于产生优化信号的训练集。
+			EvalSetID: trainEvalSetID,
+		},
+	},
+	// Validation 指定接受判定使用的验证集。
+	Validation: []engine.EvalSetInput{
+		{
+			// EvalSetID 指向用于接受判定的验证集。
+			EvalSetID: validationEvalSetID,
+		},
+	},
+	// 训练集和验证集评估阶段按评估用例并发。
+	EvaluationOptions: engine.EvaluationOptions{
+		// EvalCaseParallelism 限制评估用例并发数。
+		EvalCaseParallelism:               16,
+		// EvalCaseParallelInferenceEnabled 开启待测 Agent 并发推理。
+		EvalCaseParallelInferenceEnabled:  true,
+		// EvalCaseParallelEvaluationEnabled 开启指标并发计算。
+		EvalCaseParallelEvaluationEnabled: true,
+	},
+	// 反向传播归因阶段默认按评估用例串行处理。
+	BackwardOptions: engine.BackwardOptions{
+		// CaseParallelismEnabled 控制是否并发处理训练集评估用例。
+		CaseParallelismEnabled: false,
+		// CaseParallelism 是开启并发后的评估用例并发上限。
+		CaseParallelism:        16,
+	},
+	// 文本梯度聚合阶段按迭代目标并发。
+	AggregationOptions: engine.AggregationOptions{
+		// SurfaceParallelismEnabled 控制是否并发处理多个迭代目标。
+		SurfaceParallelismEnabled: true,
+		// SurfaceParallelism 是迭代目标并发上限。
+		SurfaceParallelism:        16,
+	},
+	// 优化补丁生成阶段按迭代目标并发。
+	OptimizerOptions: engine.OptimizerOptions{
+		// SurfaceParallelismEnabled 控制是否并发为多个迭代目标生成补丁。
+		SurfaceParallelismEnabled: true,
+		// SurfaceParallelism 是迭代目标并发上限。
+		SurfaceParallelism:        16,
+	},
+	// 候选提示词需要相对当前基准提示词提升至少 0.01 分。
+	AcceptancePolicy: engine.AcceptancePolicy{
+		// MinScoreGain 是接受候选提示词所需的最小验证分数增量。
+		MinScoreGain: 0.01,
+	},
+	// 达到最大轮数、连续未接受轮数或目标分数时停止。
+	StopPolicy: engine.StopPolicy{
+		// MaxRoundsWithoutAcceptance 限制连续未接受候选提示词的轮数。
+		MaxRoundsWithoutAcceptance: 3,
+		// TargetScore 是达到后即可停止的目标验证分数。
+		TargetScore:                &targetScore,
+	},
+	// MaxRounds 是本次运行的最大迭代轮数。
+	MaxRounds: 4,
+	// TargetSurfaceIDs 指定本次允许迭代的提示词。
+	TargetSurfaceIDs: []string{targetInstructionID},
 }
 
-current, err := managerInstance.Get(ctx, run.ID)
+// Start 提交异步提示词迭代，并返回带运行 ID 的初始 RunResult。
+run, err := managerInstance.Start(ctx, runRequest)
 if err != nil {
 	return err
 }
-_ = current
+runID := run.ID
+
+// Get 按运行 ID 查询当前 RunResult。
+current, err := managerInstance.Get(ctx, runID)
+if err != nil {
+	return err
+}
 ```
 
-Manager 适合以下场景：
+`Start` 返回初始 `RunResult`，`Get` 返回后台执行过程中持续更新的 `RunResult`。运行过程中，`RunResult` 会随着后台执行逐步写入起始基线验证、当前轮次、训练集评估、反向传播归因、文本梯度聚合、候选补丁、验证集评估、接受判定和停止判定。运行进入 `succeeded`、`failed` 或 `canceled` 后，调用方可根据终态结果读取 `AcceptedProfile`、每轮分数和补丁原因。
 
-- 后台任务
-- 前端轮询进度
-- 需要取消的长时间运行
-- 需要跨请求查询运行状态
+### HTTP 迭代服务
 
-### 运行存储 Store
+HTTP 服务把结构查询、同步迭代和异步迭代暴露为远程接口，适合控制台页面、任务系统或其他后端服务调用。HTTP 层接收 `Engine` 和可选 `Manager`，并将请求转为本地 `Describe`、`Run`、`Start`、`Get` 和 `Cancel` 调用。完整代码见 [examples/evaluation/promptiter/server](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/promptiter/server)。
 
-异步运行的结果持久化通过 `store` 包完成。
-
-#### 接口定义
+需要结构查询和同步迭代时，先按同步迭代接入方式创建 `Engine`，再配置 `WithAppName` 和 `WithEngine`。
 
 ```go
 import (
+	"net/http"
+
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+	spromptiter "trpc.group/trpc-go/trpc-agent-go/server/promptiter"
 )
 
-type Store interface {
-	Create(ctx context.Context, appName string, run *engine.RunResult) error
-	Get(ctx context.Context, appName, runID string) (*engine.RunResult, error)
-	Update(ctx context.Context, appName string, run *engine.RunResult) error
-	Close() error
+// engineInstance 绑定待测 Agent、评估器和三个 PromptIter 工作组件。
+engineInstance, err := engine.New(
+	ctx,
+	candidateAgent,
+	agentEvaluator,
+	backwarderInstance,
+	aggregatorInstance,
+	optimizerInstance,
+)
+if err != nil {
+	return err
+}
+
+// serverInstance 暴露结构查询和同步迭代接口。
+serverInstance, err := spromptiter.New(
+	// WithAppName 指定服务处理的应用名。
+	spromptiter.WithAppName(appName),
+	// WithEngine 提供结构查询和同步迭代能力。
+	spromptiter.WithEngine(engineInstance),
+)
+if err != nil {
+	return err
+}
+
+// ListenAndServe 使用 net/http 启动 PromptIter HTTP 服务。
+if err := http.ListenAndServe(":8080", serverInstance.Handler()); err != nil {
+	return err
 }
 ```
 
-#### InMemory 实现
+需要异步提交、查询和取消能力时，先基于同一个 `Engine` 创建 `Manager`，再额外配置 `WithManager`。`WithManager` 不改变同步接口，仅新增异步运行相关路由。
 
-`store/inmemory` 适合本地调试与测试。该实现不依赖外部存储，进程退出后数据会丢失。
+```go
+import (
+	"net/http"
 
-#### MySQL 实现
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/manager"
+	spromptiter "trpc.group/trpc-go/trpc-agent-go/server/promptiter"
+)
 
-`store/mysql` 适合跨进程持久化与平台查询。该实现会将 `RunResult` 序列化后存入 MySQL，并支持手工初始化 schema 或自动建表。
+// engineInstance 绑定待测 Agent、评估器和三个 PromptIter 工作组件。
+engineInstance, err := engine.New(
+	ctx,
+	candidateAgent,
+	agentEvaluator,
+	backwarderInstance,
+	aggregatorInstance,
+	optimizerInstance,
+)
+if err != nil {
+	return err
+}
 
-当前实现使用单表保存运行记录，核心字段包括 `app_name`、`run_id`、`status`、序列化后的 `run_result`，以及 `created_at`、`updated_at` 等时间字段。`app_name` 和 `run_id` 组成唯一键，用于隔离不同应用下的运行记录。完整表结构可参考 [schema.sql](https://github.com/trpc-group/trpc-agent-go/tree/main/evaluation/workflow/promptiter/store/mysql/schema.sql)。
+// managerInstance 管理异步 PromptIter 运行。
+managerInstance, err := manager.New(appName, engineInstance)
+if err != nil {
+	return err
+}
+defer managerInstance.Close()
 
-### HTTP 接口
+// serverInstance 同时暴露同步迭代接口和异步迭代接口。
+serverInstance, err := spromptiter.New(
+	// WithAppName 指定服务处理的应用名。
+	spromptiter.WithAppName(appName),
+	// WithEngine 提供结构查询和同步迭代能力。
+	spromptiter.WithEngine(engineInstance),
+	// WithManager 提供异步提交、查询和取消能力。
+	spromptiter.WithManager(managerInstance),
+)
+if err != nil {
+	return err
+}
 
-如果需要通过 HTTP 触发 PromptIter，可以使用 PromptIter HTTP 服务模块。
+// ListenAndServe 使用 net/http 启动 PromptIter HTTP 服务。
+if err := http.ListenAndServe(":8080", serverInstance.Handler()); err != nil {
+	return err
+}
+```
 
-对应示例见 [server](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/promptiter/server)。
+默认路径由基础路径、应用名和操作路径组成。`{appName}` 来自 `WithAppName`，异步路由只有配置 `WithManager` 后才会注册。
 
-#### 请求与响应
+| 方法 | 路径 | 行为 |
+| --- | --- | --- |
+| `GET` | `/promptiter/v1/apps/{appName}/structure` | 返回待测 Agent 的结构快照。 |
+| `POST` | `/promptiter/v1/apps/{appName}/runs` | 执行同步提示词迭代，并在完成后返回 `RunResult`。 |
+| `POST` | `/promptiter/v1/apps/{appName}/async-runs` | 提交异步提示词迭代，并返回带运行 ID 的初始 `RunResult`。 |
+| `GET` | `/promptiter/v1/apps/{appName}/async-runs/{runID}` | 查询异步运行当前的 `RunResult`。 |
+| `POST` | `/promptiter/v1/apps/{appName}/async-runs/{runID}/cancel` | 请求取消指定异步运行。 |
 
-PromptIter HTTP 服务模块公开的核心 payload 如下：
+外部系统发起提示词迭代时，通常先调用 `/structure` 读取结构快照，从中确认本次允许迭代的 `SurfaceID`，再把这些 ID 写入请求体的 `run.TargetSurfaceIDs`。需要阻塞等待结果时调用 `/runs`。需要后台执行时调用 `/async-runs`，保存返回的运行 ID，并通过异步查询接口读取最新 `RunResult`。
+
+### 多节点迭代
+
+多节点迭代适用于待测对象是 Graph Agent，且多个子 Agent 提示词共同影响最终输出的场景。普通函数节点参与执行流程，但不导出可迭代提示词。通过 `AddAgentNode` 挂载的子 Agent 会导出各自的 `instruction surface`，这些 ID 可作为迭代目标写入 `RunRequest.TargetSurfaceIDs`。`multinode` 的完整代码见 [examples/evaluation/promptiter/multinode](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/promptiter/multinode)。
+
+`multinode` 构造了一个体育战报 Graph Agent。流程先由 `prepare_game_input` 分发输入，分别生成标题、亮点和数据角度，三路结果在 `join_recap_parts` 汇聚后进入正文生成，再交给编辑润色节点生成最终结果。下面代码展示 Graph Agent 的节点关系和待测 Runner 创建过程。分支输入输出映射属于 Graph Agent 的业务逻辑，完整源码中已处理。
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/graphagent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/graph"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+)
+
+// subAgents 是 Graph Agent 中可被 PromptIter 迭代的子 Agent。
+subAgents := []agent.Agent{
+	llmagent.New(
+		headlineAgentName,
+		llmagent.WithModel(candidateModel),
+		// headlineInstruction 写入标题节点的 instruction surface。
+		llmagent.WithInstruction(headlineInstruction),
+	),
+	llmagent.New(
+		highlightsAgentName,
+		llmagent.WithModel(candidateModel),
+		// highlightsInstruction 写入亮点节点的 instruction surface。
+		llmagent.WithInstruction(highlightsInstruction),
+	),
+	llmagent.New(
+		statsAngleAgentName,
+		llmagent.WithModel(candidateModel),
+		// statsAngleInstruction 写入数据角度节点的 instruction surface。
+		llmagent.WithInstruction(statsAngleInstruction),
+	),
+	llmagent.New(
+		recapWriterAgentName,
+		llmagent.WithModel(candidateModel),
+		// recapWriterInstruction 写入正文生成节点的 instruction surface。
+		llmagent.WithInstruction(recapWriterInstruction),
+	),
+	llmagent.New(
+		sportsEditorAgentName,
+		llmagent.WithModel(candidateModel),
+		// sportsEditorInstruction 写入编辑润色节点的 instruction surface。
+		llmagent.WithInstruction(sportsEditorInstruction),
+	),
+}
+
+// sg 描述待测 Graph Agent 的静态节点和边。
+sg := graph.NewStateGraph(graph.NewStateSchema())
+// prepareGameInput 是普通函数节点，负责分发原始输入。
+sg.AddNode(nodePrepareGameInput, prepareGameInput)
+// 三个 AgentNode 并行生成标题、亮点和数据角度。
+sg.AddAgentNode(headlineAgentName)
+sg.AddAgentNode(highlightsAgentName)
+sg.AddAgentNode(statsAngleAgentName)
+// joinRecapParts 是普通函数节点，负责汇聚三个分支的中间结果。
+sg.AddNode(nodeJoinRecapParts, joinRecapParts)
+// recapWriterAgentName 和 sportsEditorAgentName 对应串行的正文生成与编辑润色节点。
+sg.AddAgentNode(recapWriterAgentName)
+sg.AddAgentNode(sportsEditorAgentName)
+// SetEntryPoint 指定图执行入口。
+sg.SetEntryPoint(nodePrepareGameInput)
+// AddEdge 建立从输入准备节点到三个并行分支的 fan-out。
+sg.AddEdge(nodePrepareGameInput, headlineAgentName)
+sg.AddEdge(nodePrepareGameInput, highlightsAgentName)
+sg.AddEdge(nodePrepareGameInput, statsAngleAgentName)
+// AddJoinEdge 建立三个并行分支到汇聚节点的 fan-in。
+sg.AddJoinEdge([]string{headlineAgentName, highlightsAgentName, statsAngleAgentName}, nodeJoinRecapParts)
+// 后续边把汇聚结果交给正文生成和编辑润色节点。
+sg.AddEdge(nodeJoinRecapParts, recapWriterAgentName)
+sg.AddEdge(recapWriterAgentName, sportsEditorAgentName)
+// SetFinishPoint 指定图执行终点。
+sg.SetFinishPoint(sportsEditorAgentName)
+
+// sportsGraph 是待测 Graph Agent 使用的编译后图结构。
+sportsGraph, err := sg.Compile()
+if err != nil {
+	return err
+}
+
+// candidateAgent 是本次迭代的待测 Graph Agent。
+candidateAgent, err := graphagent.New(
+	rootAgentName,
+	sportsGraph,
+	graphagent.WithSubAgents(subAgents),
+)
+if err != nil {
+	return err
+}
+// candidateRunner 是 Evaluation 执行待测 Graph Agent 的入口。
+candidateRunner := runner.NewRunner(candidateAppName, candidateAgent)
+```
+
+下例省略 `Engine`、`AgentEvaluator`、`Manager` 和三个 PromptIter 工作组件的重复组装代码，重点展示多节点场景的 `TargetSurfaceIDs`。单 Agent 场景通常写入一个 `candidate#instruction`，Graph Agent 场景可以把多个 AgentNode 的 `instruction surface` 同时作为迭代目标。
 
 ```go
 import (
 	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/manager"
 )
 
-type RunRequest struct {
-	Run *engine.RunRequest `json:"run"`
+// targetSurfaceIDs 指定本次允许迭代的多个 AgentNode 的 instruction。
+targetSurfaceIDs := []string{
+	astructure.SurfaceID(rootAgentName+"/"+headlineAgentName, astructure.SurfaceTypeInstruction),
+	astructure.SurfaceID(rootAgentName+"/"+highlightsAgentName, astructure.SurfaceTypeInstruction),
+	astructure.SurfaceID(rootAgentName+"/"+statsAngleAgentName, astructure.SurfaceTypeInstruction),
+	astructure.SurfaceID(rootAgentName+"/"+recapWriterAgentName, astructure.SurfaceTypeInstruction),
+	astructure.SurfaceID(rootAgentName+"/"+sportsEditorAgentName, astructure.SurfaceTypeInstruction),
 }
 
-type RunResponse struct {
-	Result *engine.RunResult `json:"result"`
+// runRequest 仍指定训练集、验证集、最大轮数和迭代目标。
+runRequest := &engine.RunRequest{
+	// Train 指定产生优化信号的训练集。
+	Train: []engine.EvalSetInput{
+		{
+			// EvalSetID 指向用于产生优化信号的训练集。
+			EvalSetID: trainEvalSetID,
+		},
+	},
+	// Validation 指定接受判定使用的验证集。
+	Validation: []engine.EvalSetInput{
+		{
+			// EvalSetID 指向用于接受判定的验证集。
+			EvalSetID: validationEvalSetID,
+		},
+	},
+	// MaxRounds 是本次运行的最大迭代轮数。
+	MaxRounds: maxRounds,
+	// TargetSurfaceIDs 指定本次允许迭代的多个提示词。
+	TargetSurfaceIDs: targetSurfaceIDs,
 }
 
-type GetStructureResponse struct {
-	Structure *astructure.Snapshot `json:"structure"`
-}
-```
-
-#### 服务构建
-
-最小构建方式如下。
-
-```go
-import promptiterserver "trpc.group/trpc-go/trpc-agent-go/server/promptiter"
-
-server, err := promptiterserver.New(
-	promptiterserver.WithAppName(appName),
-	promptiterserver.WithBasePath("/promptiter/v1/apps"),
-	promptiterserver.WithEngine(engineInstance),
-	promptiterserver.WithManager(managerInstance),
+// engineInstance 绑定待测 Graph Agent、评估器和三个 PromptIter 工作组件。
+engineInstance, err := engine.New(
+	ctx,
+	candidateAgent,
+	agentEvaluator,
+	backwarderInstance,
+	aggregatorInstance,
+	optimizerInstance,
 )
 if err != nil {
 	return err
 }
 
-return http.ListenAndServe(":8080", server.Handler())
+// managerInstance 在 Engine 之上管理异步多节点迭代。
+managerInstance, err := manager.New(appName, engineInstance)
+if err != nil {
+	return err
+}
+defer managerInstance.Close()
+
+// Start 提交多节点提示词迭代，并返回带运行 ID 的初始 RunResult。
+run, err := managerInstance.Start(ctx, runRequest)
+if err != nil {
+	return err
+}
 ```
 
-#### 路由
+多节点迭代沿用 PromptIter 主流程，差异在于一次运行可以把多个 AgentNode 的 `instruction surface` 写入 `TargetSurfaceIDs`。训练集失败信号会结合实际执行轨迹做反向传播归因，后续文本梯度聚合和优化补丁生成都限定在这些目标提示词上。
 
-当 `WithBasePath("/promptiter/v1/apps")` 与 `WithAppName(appName)` 同时生效时，完整接口路径如下：
+## 实践经验
 
-- `GET /promptiter/v1/apps/{appName}/structure`
-- `POST /promptiter/v1/apps/{appName}/runs`
-- `POST /promptiter/v1/apps/{appName}/async-runs`
-- `GET /promptiter/v1/apps/{appName}/async-runs/{run_id}`
-- `POST /promptiter/v1/apps/{appName}/async-runs/{run_id}/cancel`
+实践经验按 PromptIter 的接入顺序展开。先稳定评估口径和预期输出，再补足裁判上下文与失败原因，最后收敛迭代目标。
 
-推荐的调用顺序如下：
+#### 评估指标对齐
 
-1. 通过 `/promptiter/v1/apps/{appName}/structure` 获取结构快照和目标可编辑位置。
-2. 构造 `RunRequest` 并写入 `TargetSurfaceIDs`。
-3. 简单调用场景使用阻塞 `POST /promptiter/v1/apps/{appName}/runs`。
-4. 需要生命周期管理时使用异步 `POST /promptiter/v1/apps/{appName}/async-runs` 与 `GET /promptiter/v1/apps/{appName}/async-runs/{run_id}`。
+训练集用于暴露问题并产生优化信号，验证集用于判断候选提示词是否可接受。两者可以包含不同评估用例，但评估指标应面向训练集和验证集都需要满足的质量要求。专门围绕训练样本编写的指标，会把优化信号收窄到训练集，使训练分数可能提升，但候选提示词无法通过验证集接受判定。
+
+评估细则应拆成可观察、可独立验证的要求，例如事实有依据、关键过程不遗漏、标题准确。少数训练样本中的表达偏好，不应上升为训练集和验证集共用的评估指标要求。
+
+#### 预期输出来源
+
+使用需要预期输出的指标时，Evaluation 会将待测 Agent 的实际响应或轨迹与预期侧内容对照，并生成评分和判定结果。在这类指标中，训练集预期输出通过失败原因影响 loss、文本梯度和候选补丁；验证集预期输出通过验证分数和接受策略影响候选提示词是否被接受，不参与本轮补丁生成。预期输出的常见来源是人工金标和 Teacher 蒸馏。
+
+人工金标指经过标注或审核的预期输出，适合输入分布稳定、评估口径明确、需要长期回归的任务。金标用于训练集时，事实错误或口径不一致可能产生错误失败原因；用于验证集时，可能导致候选提示词被误接收或误拒绝。因此，金标进入训练集或验证集前，应完成事实、格式与口径复核。
+
+Teacher 蒸馏指在评估阶段用更强模型，或用包含更多规则、示例和上下文的提示词生成动态预期输出。Teacher 可以比待测 Agent 更重，因为它只用于生成评估对照，不直接进入待测 Agent 的生产调用路径。它适合样本规模较大、人工标注成本较高，或预期输出依赖实时上下文且可复现生成的场景。
+
+Teacher 输出仍需抽样复核。若 Teacher 存在事实错误、格式漂移或口径不一致，训练集评估会把偏差转成错误优化信号，验证集评估会把偏差转成失真的接受判定。复杂提示词可以用于 Teacher，但不应直接迁移到待测 Agent。Teacher 提示词中的规则、示例和上下文不一定对待测 Agent 有效。提示词过长还会增加上下文占用、约束冲突和维护成本。Teacher 蒸馏的目标不是复刻 Teacher 的完整提示词，而是把高质量预期输出转成评估信号，再由 PromptIter 生成待测 Agent 可长期维护的提示词补丁。
+
+#### 裁判上下文
+
+裁判上下文用于构造 LLM Judge 的裁判输入，应围绕评估细则组织。评估细则只检查表达质量、结构完整性或与参考答案的一致性时，用户输入、实际最终回答和参考答案通常足够。评估细则涉及事实依据、检索结果、工具结果或业务规则时，相关证据也需要进入裁判输入。证据可以来自业务数据、关键检索结果、工具结果或评估样本；没有进入裁判输入的内容，不会参与 LLM Judge 判定。
+
+补充裁判上下文时，只纳入与评估细则直接相关、可核验的材料，例如业务数据、关键检索结果、工具结果和规则说明。证据不足时，失败原因容易变得笼统。材料过多时，无关信息会稀释评估重点，增加判定波动。训练集和验证集应使用一致的上下文构造规则，避免训练阶段的失败原因和验证阶段的分数来自不同评估口径。
+
+#### LossHint 补充原因
+
+PromptIter 会从训练集失败指标中提取 loss。`LossHint` 用于在已有 loss 上补充业务侧已知的问题原因。它的作用位置是训练集优化信号，训练分数仍由评估指标产生，验证集接受判定仍由验证集评估结果和接受策略产生。`LossHint` 匹配本轮训练评估中已经失败的评估用例和指标后，会并入对应 loss，供 `Backward` 生成文本梯度。
+
+`LossHint` 的收益来自增量问题信息。评估结果中的失败原因已经覆盖业务侧问题时，同义 `LossHint` 主要起记录作用，优化收益有限。它更适合用于裁判生成的失败原因不准、不全的训练样本。此时，`LossHint` 把人工确认的问题补进训练集 loss，作为后续反向传播归因和提示词补丁生成的优化方向。
+
+#### 迭代目标选择
+
+选择迭代目标时，需要先将失败信号与节点职责对齐。结构快照用于确认待测 Agent 中可迭代的节点提示词，执行轨迹用于还原本次运行经过的节点和步骤。结合失败原因和节点输出后，可以判断问题主要归因于哪些节点提示词。
+
+失败原因集中于单个节点输出时，迭代目标可限定为该节点提示词。失败原因涉及多个协作节点时，可将职责相邻、共同影响同一类质量问题的节点提示词纳入同一轮。已有执行轨迹和评估结果显示质量稳定、优化空间有限的提示词，宜保持当前版本。目标数量过多会扩大补丁影响范围，降低验证结果的可解释性。
+
+目标范围较集中时，候选补丁与验证结果的对应关系更清晰。扩大目标范围时，新增目标应承载本轮失败信号，并与同轮目标共同指向同一类质量问题。候选提示词通过接受判定后，需要在测试环境审查各目标的补丁内容、修改原因和验证结果，再进入业务发布流程。


### PR DESCRIPTION
This updates the PromptIter guide in both Chinese and English with the current iteration workflow, adds the referenced diagrams, removes internal-only references, and documents HTTP service setup through net/http.