### PR TITLE
openclaw: add explicit user memory scope

### DIFF
--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -270,8 +270,8 @@ const (
 		"commands, prefer OPENCLAW_LAST_UPLOAD_PATH or " +
 		"OPENCLAW_SESSION_UPLOADS_DIR, OPENCLAW_LAST_UPLOAD_HOST_REF, " +
 		"OPENCLAW_LAST_UPLOAD_NAME, " +
-		"OPENCLAW_LAST_UPLOAD_MIME, and " +
-		"OPENCLAW_MEMORY_FILE, " +
+		"OPENCLAW_LAST_UPLOAD_MIME, OPENCLAW_MEMORY_FILE, " +
+		"OPENCLAW_USER_MEMORY_FILE, OPENCLAW_CHAT_MEMORY_FILE, and " +
 		"OPENCLAW_RECENT_UPLOADS_JSON instead of guessing " +
 		"attachment paths. For long-running work, independent " +
 		"verification, or background work that can continue after " +
@@ -347,17 +347,18 @@ const (
 		"files under " +
 		"OPENCLAW_SESSION_UPLOADS_DIR when you will send them " +
 		"back to the user. OPENCLAW_MEMORY_FILE is a visible " +
-		"MEMORY.md file for the current scope, not hidden " +
-		"internal state. If the user asks what you remember or " +
-		"asks to inspect that file, read it and quote or " +
-		"summarize the relevant " +
-		"lines. If the user explicitly says 'remember this' " +
-		"or asks you to remember a durable fact, preference, " +
-		"or workflow rule, update OPENCLAW_MEMORY_FILE with a " +
-		"short bullet in the same turn. Use " +
-		"OPENCLAW_MEMORY_FILE only for stable cross-session " +
-		"facts, preferences, or working style. Do not store " +
-		"secrets or large transcripts in that file. " +
+		"MEMORY.md file for the current scope, and remains a " +
+		"compatibility alias. OPENCLAW_USER_MEMORY_FILE is this " +
+		"user's personal memory file. OPENCLAW_CHAT_MEMORY_FILE " +
+		"is the current chat's shared memory file. These files are " +
+		"not hidden internal state. If the user asks what you " +
+		"remember or asks to inspect memory, read the relevant " +
+		"file and quote or summarize the relevant lines. If the " +
+		"user explicitly says 'remember this' or asks you to " +
+		"remember a durable fact, preference, workflow rule, task " +
+		"list, or reminder list, update the narrowest relevant " +
+		"memory file with a short bullet in the same turn. Do not " +
+		"store secrets or large transcripts in memory files. " +
 		"If a memory file does not exist yet, you may create it " +
 		"at that exact path. Prefer already installed local tools " +
 		"for OCR, PDF, audio, image, and video work before " +

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -626,6 +626,8 @@ func TestBuildOpenClawTools_ExposesMemoryFileEnvForFileBackend(t *testing.T) {
 	decl := findToolDeclaration(bundle.tools, "exec_command")
 	require.NotNil(t, decl)
 	require.Contains(t, decl.Description, "OPENCLAW_MEMORY_FILE")
+	require.Contains(t, decl.Description, "OPENCLAW_USER_MEMORY_FILE")
+	require.Contains(t, decl.Description, "OPENCLAW_CHAT_MEMORY_FILE")
 	require.Contains(
 		t,
 		decl.Description,

--- a/openclaw/app/conversation.go
+++ b/openclaw/app/conversation.go
@@ -48,6 +48,14 @@ func buildConversationRunOptionResolver(
 				storageUserID,
 			)
 		}
+		if personalUserID := strings.TrimSpace(
+			annotation.UserStorageID,
+		); personalUserID != "" {
+			ctx = conversationscope.WithUserStorageID(
+				ctx,
+				personalUserID,
+			)
+		}
 
 		runtimeState := conversation.RuntimeState(annotation)
 		runOpts := make([]agent.RunOption, 0, 2)

--- a/openclaw/app/conversation_test.go
+++ b/openclaw/app/conversation_test.go
@@ -38,6 +38,7 @@ func TestRunOptionResolversMergeRuntimeState(t *testing.T) {
 		conversation.Annotation{
 			HistoryMode:   conversation.HistoryModeShared,
 			StorageUserID: "chat-scope",
+			UserStorageID: "personal-scope",
 			ActorID:       "user1",
 			ActorLabel:    "Alice",
 			ActorLabels: map[string]string{
@@ -89,6 +90,11 @@ func TestRunOptionResolversMergeRuntimeState(t *testing.T) {
 		"chat-scope",
 		conversationscope.StorageUserIDFromContext(ctx, ""),
 	)
+	require.Equal(
+		t,
+		"personal-scope",
+		conversationscope.UserStorageIDFromContext(ctx, ""),
+	)
 
 	require.Equal(
 		t,
@@ -105,6 +111,7 @@ func TestRunOptionResolversMergeRuntimeState(t *testing.T) {
 		conversation.Annotation{
 			HistoryMode:   conversation.HistoryModeShared,
 			StorageUserID: "chat-scope",
+			UserStorageID: "personal-scope",
 			ActorID:       "user1",
 			ActorLabel:    "Alice",
 			ActorLabels: map[string]string{

--- a/openclaw/app/memory_file_tool_callback.go
+++ b/openclaw/app/memory_file_tool_callback.go
@@ -26,11 +26,21 @@ import (
 )
 
 const (
-	memoryToolFileName = "MEMORY.md"
+	memoryToolFileName     = "MEMORY.md"
+	memoryToolUserFileName = "USER_MEMORY.md"
+	memoryToolChatFileName = "CHAT_MEMORY.md"
 
 	memoryToolReadFileFS       = "fs_read_file"
 	memoryToolSaveFileFS       = "fs_save_file"
 	memoryToolReplaceContentFS = "fs_replace_content"
+)
+
+type memoryToolScope int
+
+const (
+	memoryToolScopeCurrent memoryToolScope = iota
+	memoryToolScopeUser
+	memoryToolScopeChat
 )
 
 var errMemorySaveFileExists = errors.New(
@@ -105,7 +115,15 @@ func newMemoryFileToolCallback(
 		if store == nil || args == nil {
 			return nil, nil
 		}
-		target, ok, err := memoryToolTargetFromContext(ctx, store)
+		fileName, ok := memoryToolFileNameFromArgs(args.Arguments)
+		if !ok {
+			return nil, nil
+		}
+		target, ok, err := memoryToolTargetFromContext(
+			ctx,
+			store,
+			fileName,
+		)
 		if err != nil || !ok {
 			return nil, err
 		}
@@ -155,14 +173,19 @@ func normalizeMemoryToolName(name string) string {
 func memoryToolTargetFromContext(
 	ctx context.Context,
 	store *memoryfile.Store,
+	fileName string,
 ) (memoryToolTarget, bool, error) {
 	inv, ok := agent.InvocationFromContext(ctx)
 	if !ok || inv == nil || inv.Session == nil || store == nil {
 		return memoryToolTarget{}, false, nil
 	}
+	scope, ok := memoryToolScopeForFileName(fileName)
+	if !ok {
+		return memoryToolTarget{}, false, nil
+	}
 	appName := strings.TrimSpace(inv.Session.AppName)
 	userID := strings.TrimSpace(inv.Session.UserID)
-	userID = conversationscope.StorageUserIDFromContext(ctx, userID)
+	userID = memoryToolScopeUserID(ctx, scope, userID)
 	if appName == "" || userID == "" {
 		return memoryToolTarget{}, false, nil
 	}
@@ -175,6 +198,37 @@ func memoryToolTargetFromContext(
 		UserID:  userID,
 		Path:    path,
 	}, true, nil
+}
+
+func memoryToolScopeUserID(
+	ctx context.Context,
+	scope memoryToolScope,
+	fallback string,
+) string {
+	switch scope {
+	case memoryToolScopeUser:
+		return conversationscope.UserStorageIDFromContext(
+			ctx,
+			fallback,
+		)
+	case memoryToolScopeCurrent, memoryToolScopeChat:
+		return conversationscope.StorageUserIDFromContext(ctx, fallback)
+	default:
+		return strings.TrimSpace(fallback)
+	}
+}
+
+func memoryToolFileNameFromArgs(args []byte) (string, bool) {
+	var req struct {
+		FileName string `json:"file_name"`
+	}
+	if err := json.Unmarshal(args, &req); err != nil {
+		return "", false
+	}
+	if !isMemoryFileAlias(req.FileName) {
+		return "", false
+	}
+	return req.FileName, true
 }
 
 func handleMemoryReadFileTool(
@@ -353,11 +407,27 @@ func memoryToolResult(result any) *tool.BeforeToolResult {
 }
 
 func isMemoryFileAlias(fileName string) bool {
+	_, ok := memoryToolScopeForFileName(fileName)
+	return ok
+}
+
+func memoryToolScopeForFileName(
+	fileName string,
+) (memoryToolScope, bool) {
 	normalized := filepath.ToSlash(strings.TrimSpace(fileName))
 	for strings.HasPrefix(normalized, "./") {
 		normalized = strings.TrimPrefix(normalized, "./")
 	}
-	return strings.EqualFold(normalized, memoryToolFileName)
+	switch {
+	case strings.EqualFold(normalized, memoryToolFileName):
+		return memoryToolScopeCurrent, true
+	case strings.EqualFold(normalized, memoryToolUserFileName):
+		return memoryToolScopeUser, true
+	case strings.EqualFold(normalized, memoryToolChatFileName):
+		return memoryToolScopeChat, true
+	default:
+		return memoryToolScopeCurrent, false
+	}
 }
 
 func nextMemorySaveContents(

--- a/openclaw/app/memory_file_tool_callback.go
+++ b/openclaw/app/memory_file_tool_callback.go
@@ -212,7 +212,11 @@ func memoryToolScopeUserID(
 			fallback,
 		)
 	case memoryToolScopeCurrent, memoryToolScopeChat:
-		return conversationscope.StorageUserIDFromContext(ctx, fallback)
+		userFallback := conversationscope.UserStorageIDFromContext(
+			ctx,
+			fallback,
+		)
+		return conversationscope.StorageUserIDFromContext(ctx, userFallback)
 	default:
 		return strings.TrimSpace(fallback)
 	}

--- a/openclaw/app/memory_file_tool_callback_test.go
+++ b/openclaw/app/memory_file_tool_callback_test.go
@@ -111,6 +111,68 @@ func TestMemoryFileToolCallback_SaveFileUsesStorageScopedMemory(
 	require.NotContains(t, string(userRaw), "- Shared rule")
 }
 
+func TestMemoryFileToolCallback_UsesExplicitMemoryScopes(t *testing.T) {
+	t.Parallel()
+
+	stateDir, store := newTestMemoryFileStore(t)
+	ctx := conversationscope.WithStorageUserID(
+		conversationscope.WithUserStorageID(
+			newTestMemoryToolContext(),
+			"wecom:dm:T123",
+		),
+		"wecom:chat:room-1",
+	)
+	callback := newMemoryFileToolCallback(store, stateDir)
+
+	result, err := callback(ctx, &tool.BeforeToolArgs{
+		ToolName: memoryToolSaveFileFS,
+		Arguments: []byte(
+			`{"file_name":"USER_MEMORY.md",` +
+				`"contents":"- Personal task\n",` +
+				`"overwrite":false}`,
+		),
+	})
+	require.NoError(t, err)
+	rsp, ok := result.CustomResult.(memorySaveFileResponse)
+	require.True(t, ok)
+	require.Equal(t, "Successfully saved: USER_MEMORY.md", rsp.Message)
+
+	result, err = callback(ctx, &tool.BeforeToolArgs{
+		ToolName: memoryToolSaveFileFS,
+		Arguments: []byte(
+			`{"file_name":"CHAT_MEMORY.md",` +
+				`"contents":"- Shared task\n",` +
+				`"overwrite":false}`,
+		),
+	})
+	require.NoError(t, err)
+	rsp, ok = result.CustomResult.(memorySaveFileResponse)
+	require.True(t, ok)
+	require.Equal(t, "Successfully saved: CHAT_MEMORY.md", rsp.Message)
+
+	userPath, err := store.EnsureMemory(
+		context.Background(),
+		testMemoryAppName,
+		"wecom:dm:T123",
+	)
+	require.NoError(t, err)
+	userRaw, err := os.ReadFile(userPath)
+	require.NoError(t, err)
+	require.Contains(t, string(userRaw), "- Personal task")
+	require.NotContains(t, string(userRaw), "- Shared task")
+
+	chatPath, err := store.EnsureMemory(
+		context.Background(),
+		testMemoryAppName,
+		"wecom:chat:room-1",
+	)
+	require.NoError(t, err)
+	chatRaw, err := os.ReadFile(chatPath)
+	require.NoError(t, err)
+	require.Contains(t, string(chatRaw), "- Shared task")
+	require.NotContains(t, string(chatRaw), "- Personal task")
+}
+
 func TestMemoryFileToolCallback_ReadFilePrefersScopedMemory(t *testing.T) {
 	t.Parallel()
 
@@ -622,6 +684,8 @@ func TestMemoryFileHelpers(t *testing.T) {
 
 	require.True(t, isMemoryFileAlias("./MEMORY.md"))
 	require.True(t, isMemoryFileAlias("././memory.md"))
+	require.True(t, isMemoryFileAlias("USER_MEMORY.md"))
+	require.True(t, isMemoryFileAlias("CHAT_MEMORY.md"))
 	require.False(t, isMemoryFileAlias("notes/MEMORY.md"))
 
 	next, err := nextMemorySaveContents("current", "replacement", true)

--- a/openclaw/app/memory_file_tool_callback_test.go
+++ b/openclaw/app/memory_file_tool_callback_test.go
@@ -25,11 +25,13 @@ import (
 )
 
 const (
-	testMemoryAppName = "openclaw"
-	testMemoryUserID  = "wecom:dm:test-user"
-	testMemoryName    = "Sample User"
-	testMemoryOldText = "Original Name"
-	testMemoryNewText = "Updated Name"
+	testMemoryAppName       = "openclaw"
+	testMemoryUserID        = "wecom:dm:test-user"
+	testMemoryUserStorageID = "wecom:dm:T123"
+	testMemoryChatStorageID = "wecom:chat:room-1"
+	testMemoryName          = "Sample User"
+	testMemoryOldText       = "Original Name"
+	testMemoryNewText       = "Updated Name"
 )
 
 func TestMemoryFileToolCallback_SaveFileWritesScopedMemory(t *testing.T) {
@@ -77,7 +79,7 @@ func TestMemoryFileToolCallback_SaveFileUsesStorageScopedMemory(
 	stateDir, store := newTestMemoryFileStore(t)
 	ctx := conversationscope.WithStorageUserID(
 		newTestMemoryToolContext(),
-		"wecom:chat:room-1",
+		testMemoryChatStorageID,
 	)
 	callback := newMemoryFileToolCallback(store, stateDir)
 
@@ -93,7 +95,7 @@ func TestMemoryFileToolCallback_SaveFileUsesStorageScopedMemory(
 	chatPath, err := store.EnsureMemory(
 		context.Background(),
 		testMemoryAppName,
-		"wecom:chat:room-1",
+		testMemoryChatStorageID,
 	)
 	require.NoError(t, err)
 	chatRaw, err := os.ReadFile(chatPath)
@@ -118,9 +120,9 @@ func TestMemoryFileToolCallback_UsesExplicitMemoryScopes(t *testing.T) {
 	ctx := conversationscope.WithStorageUserID(
 		conversationscope.WithUserStorageID(
 			newTestMemoryToolContext(),
-			"wecom:dm:T123",
+			testMemoryUserStorageID,
 		),
-		"wecom:chat:room-1",
+		testMemoryChatStorageID,
 	)
 	callback := newMemoryFileToolCallback(store, stateDir)
 
@@ -153,7 +155,7 @@ func TestMemoryFileToolCallback_UsesExplicitMemoryScopes(t *testing.T) {
 	userPath, err := store.EnsureMemory(
 		context.Background(),
 		testMemoryAppName,
-		"wecom:dm:T123",
+		testMemoryUserStorageID,
 	)
 	require.NoError(t, err)
 	userRaw, err := os.ReadFile(userPath)
@@ -164,13 +166,74 @@ func TestMemoryFileToolCallback_UsesExplicitMemoryScopes(t *testing.T) {
 	chatPath, err := store.EnsureMemory(
 		context.Background(),
 		testMemoryAppName,
-		"wecom:chat:room-1",
+		testMemoryChatStorageID,
 	)
 	require.NoError(t, err)
 	chatRaw, err := os.ReadFile(chatPath)
 	require.NoError(t, err)
 	require.Contains(t, string(chatRaw), "- Shared task")
 	require.NotContains(t, string(chatRaw), "- Personal task")
+}
+
+func TestMemoryFileToolCallback_CurrentAndChatScopesFallBackToUserStorageID(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	stateDir, store := newTestMemoryFileStore(t)
+	ctx := conversationscope.WithUserStorageID(
+		newTestMemoryToolContext(),
+		testMemoryUserStorageID,
+	)
+	callback := newMemoryFileToolCallback(store, stateDir)
+
+	result, err := callback(ctx, &tool.BeforeToolArgs{
+		ToolName: memoryToolSaveFileFS,
+		Arguments: []byte(
+			`{"file_name":"MEMORY.md",` +
+				`"contents":"- Personal fallback\n",` +
+				`"overwrite":false}`,
+		),
+	})
+	require.NoError(t, err)
+	rsp, ok := result.CustomResult.(memorySaveFileResponse)
+	require.True(t, ok)
+	require.Equal(t, "Successfully saved: MEMORY.md", rsp.Message)
+
+	result, err = callback(ctx, &tool.BeforeToolArgs{
+		ToolName: memoryToolSaveFileFS,
+		Arguments: []byte(
+			`{"file_name":"CHAT_MEMORY.md",` +
+				`"contents":"- Chat fallback\n",` +
+				`"overwrite":false}`,
+		),
+	})
+	require.NoError(t, err)
+	rsp, ok = result.CustomResult.(memorySaveFileResponse)
+	require.True(t, ok)
+	require.Equal(t, "Successfully saved: CHAT_MEMORY.md", rsp.Message)
+
+	userPath, err := store.EnsureMemory(
+		context.Background(),
+		testMemoryAppName,
+		testMemoryUserStorageID,
+	)
+	require.NoError(t, err)
+	userRaw, err := os.ReadFile(userPath)
+	require.NoError(t, err)
+	require.Contains(t, string(userRaw), "- Personal fallback")
+	require.Contains(t, string(userRaw), "- Chat fallback")
+
+	sessionPath, err := store.EnsureMemory(
+		context.Background(),
+		testMemoryAppName,
+		testMemoryUserID,
+	)
+	require.NoError(t, err)
+	sessionRaw, err := os.ReadFile(sessionPath)
+	require.NoError(t, err)
+	require.NotContains(t, string(sessionRaw), "- Personal fallback")
+	require.NotContains(t, string(sessionRaw), "- Chat fallback")
 }
 
 func TestMemoryFileToolCallback_ReadFilePrefersScopedMemory(t *testing.T) {

--- a/openclaw/conversation/annotation.go
+++ b/openclaw/conversation/annotation.go
@@ -20,6 +20,7 @@ import (
 type Annotation struct {
 	HistoryMode   string            `json:"history_mode,omitempty"`
 	StorageUserID string            `json:"storage_user_id,omitempty"`
+	UserStorageID string            `json:"user_storage_id,omitempty"`
 	ActorID       string            `json:"actor_id,omitempty"`
 	ActorLabel    string            `json:"actor_label,omitempty"`
 	ActorLabels   map[string]string `json:"actor_labels,omitempty"`
@@ -153,6 +154,7 @@ func decodeAnnotation(
 func isZeroRuntimeAnnotation(annotation Annotation) bool {
 	return strings.TrimSpace(annotation.HistoryMode) == "" &&
 		strings.TrimSpace(annotation.StorageUserID) == "" &&
+		strings.TrimSpace(annotation.UserStorageID) == "" &&
 		strings.TrimSpace(annotation.ActorID) == "" &&
 		strings.TrimSpace(annotation.ActorLabel) == "" &&
 		len(annotation.ActorLabels) == 0 &&
@@ -165,6 +167,9 @@ func normalizeAnnotation(annotation Annotation) Annotation {
 	)
 	annotation.StorageUserID = strings.TrimSpace(
 		annotation.StorageUserID,
+	)
+	annotation.UserStorageID = strings.TrimSpace(
+		annotation.UserStorageID,
 	)
 	annotation.ActorID = strings.TrimSpace(annotation.ActorID)
 	annotation.ActorLabel = strings.TrimSpace(

--- a/openclaw/internal/conversationscope/context.go
+++ b/openclaw/internal/conversationscope/context.go
@@ -19,6 +19,8 @@ import (
 
 type storageUserIDContextKey struct{}
 
+type userStorageIDContextKey struct{}
+
 // WithStorageUserID records the storage user scope for the current request.
 func WithStorageUserID(ctx context.Context, userID string) context.Context {
 	userID = strings.TrimSpace(userID)
@@ -44,8 +46,40 @@ func StorageUserIDFromContext(ctx context.Context, fallback string) string {
 	return strings.TrimSpace(fallback)
 }
 
-// ResolveStorageUserID extracts an explicit storage user override from request
-// extensions and falls back to the canonical request user when absent.
+// WithUserStorageID records the stable user-owned storage scope for
+// the current request.
+func WithUserStorageID(ctx context.Context, userID string) context.Context {
+	userID = strings.TrimSpace(userID)
+	if userID == "" {
+		return ctx
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, userStorageIDContextKey{}, userID)
+}
+
+// UserStorageIDFromContext resolves the stable user-owned storage
+// scope for the current request.
+func UserStorageIDFromContext(
+	ctx context.Context,
+	fallback string,
+) string {
+	if ctx != nil {
+		if userID, ok := ctx.Value(
+			userStorageIDContextKey{},
+		).(string); ok {
+			userID = strings.TrimSpace(userID)
+			if userID != "" {
+				return userID
+			}
+		}
+	}
+	return strings.TrimSpace(fallback)
+}
+
+// ResolveStorageUserID extracts an explicit storage user override from
+// request extensions and falls back to the canonical request user when absent.
 func ResolveStorageUserID(
 	extensions map[string]json.RawMessage,
 	fallback string,

--- a/openclaw/internal/conversationscope/session_service_test.go
+++ b/openclaw/internal/conversationscope/session_service_test.go
@@ -311,6 +311,28 @@ func TestWithStorageUserIDAndContextFallbacks(t *testing.T) {
 	require.Equal(t, "fallback", StorageUserIDFromContext(base, " fallback "))
 }
 
+func TestWithUserStorageIDAndContextFallbacks(t *testing.T) {
+	t.Parallel()
+
+	ctx := WithUserStorageID(
+		context.Background(),
+		" user-scope ",
+	)
+	require.Equal(
+		t,
+		"user-scope",
+		UserStorageIDFromContext(ctx, ""),
+	)
+
+	base := context.Background()
+	require.True(t, WithUserStorageID(base, "   ") == base)
+	require.Equal(
+		t,
+		"fallback",
+		UserStorageIDFromContext(base, " fallback "),
+	)
+}
+
 func TestWrapSessionService_UsesContextStorageScopeForStorage(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/internal/gateway/context_messages.go
+++ b/openclaw/internal/gateway/context_messages.go
@@ -110,9 +110,13 @@ func (s *Server) memoryFileContextMessages(
 		return nil
 	}
 
-	primaryUserID := conversationscope.StorageUserIDFromContext(
+	personalUserID := conversationscope.UserStorageIDFromContext(
 		ctx,
 		userID,
+	)
+	primaryUserID := conversationscope.StorageUserIDFromContext(
+		ctx,
+		personalUserID,
 	)
 	messages := make([]model.Message, 0, 2)
 	if msg := s.memoryFileContextMessage(
@@ -120,7 +124,7 @@ func (s *Server) memoryFileContextMessages(
 		appName,
 		primaryUserID,
 		func() string {
-			if primaryUserID != userID {
+			if primaryUserID != personalUserID {
 				return chatMemoryScopeLabel
 			}
 			return userMemoryScopeLabel
@@ -129,13 +133,13 @@ func (s *Server) memoryFileContextMessages(
 	); msg != nil {
 		messages = append(messages, *msg)
 	}
-	if primaryUserID == userID {
+	if primaryUserID == personalUserID {
 		return messages
 	}
 	if msg := s.memoryFileContextMessage(
 		ctx,
 		appName,
-		userID,
+		personalUserID,
 		userMemoryScopeLabel,
 		false,
 	); msg != nil {

--- a/openclaw/internal/gateway/context_messages_test.go
+++ b/openclaw/internal/gateway/context_messages_test.go
@@ -72,6 +72,69 @@ func TestMemoryFileContextMessages_UsesStorageScopeWithUserFallback(
 	require.Contains(t, msgs[1].Content, "personal preference")
 }
 
+func TestMemoryFileContextMessages_UsesPersonalStorageScope(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	root, err := memoryfile.DefaultRoot(t.TempDir())
+	require.NoError(t, err)
+	store, err := memoryfile.NewStore(root)
+	require.NoError(t, err)
+
+	chatPath, err := store.EnsureMemory(
+		context.Background(),
+		"demo-app",
+		"wecom:chat:room-1",
+	)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(
+		chatPath,
+		[]byte("# Memory\n\n- shared group note\n"),
+		0o600,
+	))
+
+	userPath, err := store.EnsureMemory(
+		context.Background(),
+		"demo-app",
+		"wecom:dm:T123",
+	)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(
+		userPath,
+		[]byte("# Memory\n\n- private todo\n"),
+		0o600,
+	))
+
+	aliasPath, err := store.EnsureMemory(
+		context.Background(),
+		"demo-app",
+		"wecom:dm:wineguo",
+	)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(
+		aliasPath,
+		[]byte("# Memory\n\n- alias-only note\n"),
+		0o600,
+	))
+
+	srv := &Server{
+		appName:         "demo-app",
+		memoryFileStore: store,
+	}
+	ctx := conversationscope.WithStorageUserID(
+		context.Background(),
+		"wecom:chat:room-1",
+	)
+	ctx = conversationscope.WithUserStorageID(ctx, "wecom:dm:T123")
+
+	msgs := srv.memoryFileContextMessages(ctx, "wecom:dm:wineguo")
+	require.Len(t, msgs, 2)
+	require.Contains(t, msgs[0].Content, "shared group note")
+	require.Contains(t, msgs[1].Content, "private todo")
+	require.NotContains(t, msgs[1].Content, "alias-only note")
+}
+
 func TestMemoryFileContextMessages_UsesRuntimeProfileAppName(
 	t *testing.T,
 ) {

--- a/openclaw/internal/octool/tools.go
+++ b/openclaw/internal/octool/tools.go
@@ -68,7 +68,9 @@ const (
 	envLastPDFName    = "OPENCLAW_LAST_PDF_NAME"
 	envLastPDFMIME    = "OPENCLAW_LAST_PDF_MIME"
 
-	envMemoryFile = "OPENCLAW_MEMORY_FILE"
+	envMemoryFile     = "OPENCLAW_MEMORY_FILE"
+	envUserMemoryFile = "OPENCLAW_USER_MEMORY_FILE"
+	envChatMemoryFile = "OPENCLAW_CHAT_MEMORY_FILE"
 
 	recentUploadsLimit = 6
 
@@ -215,9 +217,11 @@ func execToolDescription(hasMemoryFile bool) string {
 			"OPENCLAW_LAST_UPLOAD_PATH, OPENCLAW_LAST_UPLOAD_HOST_REF, " +
 			"OPENCLAW_LAST_UPLOAD_NAME, OPENCLAW_LAST_UPLOAD_MIME, " +
 			"kind-specific OPENCLAW_LAST_*_PATH vars, " +
-			"OPENCLAW_MEMORY_FILE, OPENCLAW_SESSION_UPLOADS_DIR, and " +
-			"OPENCLAW_RECENT_UPLOADS_JSON point to stable attachment " +
-			"metadata, memory-file paths, host refs, and host paths."
+			"OPENCLAW_MEMORY_FILE, OPENCLAW_USER_MEMORY_FILE, " +
+			"OPENCLAW_CHAT_MEMORY_FILE, OPENCLAW_SESSION_UPLOADS_DIR, " +
+			"and OPENCLAW_RECENT_UPLOADS_JSON point to stable " +
+			"attachment metadata, memory-file paths, host refs, " +
+			"and host paths."
 	}
 	parts = append(
 		parts,
@@ -227,14 +231,21 @@ func execToolDescription(hasMemoryFile bool) string {
 		parts = append(
 			parts,
 			"OPENCLAW_MEMORY_FILE is a visible MEMORY.md file for the "+
-				"current scope, not hidden internal state. If the user "+
-				"asks what you remember or asks to inspect that file, "+
-				"read it and quote or summarize the relevant lines.",
+				"current scope, and remains a compatibility alias. "+
+				"OPENCLAW_USER_MEMORY_FILE is this user's personal "+
+				"memory file. OPENCLAW_CHAT_MEMORY_FILE is the "+
+				"current chat's shared memory file. These are visible "+
+				"memory files, not hidden internal state. If the user "+
+				"asks what you remember or asks to inspect memory, read "+
+				"the relevant file and quote or summarize the relevant "+
+				"lines.",
 			"If the user explicitly says 'remember this' or asks you to "+
 				"remember a durable fact, preference, or workflow rule, "+
-				"update OPENCLAW_MEMORY_FILE with a short bullet.",
-			"Use OPENCLAW_MEMORY_FILE only for stable, cross-session "+
-				"facts, preferences, and working style.",
+				"update the narrowest relevant memory file with a short "+
+				"bullet.",
+			"Use memory files only for stable, cross-session facts, "+
+				"preferences, durable user tasks, reminder lists, and "+
+				"working style.",
 		)
 	}
 	parts = append(
@@ -753,22 +764,51 @@ func memoryFileEnvFromContext(
 
 	appName := strings.TrimSpace(inv.Session.AppName)
 	userID := strings.TrimSpace(inv.Session.UserID)
-	userID = conversationscope.StorageUserIDFromContext(ctx, userID)
 	if appName == "" || userID == "" {
 		return nil
 	}
 
+	storageUserID := conversationscope.StorageUserIDFromContext(
+		ctx,
+		userID,
+	)
+	personalUserID := conversationscope.UserStorageIDFromContext(
+		ctx,
+		userID,
+	)
+	currentPath := ensureMemoryEnvPath(store, appName, storageUserID)
+	personalPath := ensureMemoryEnvPath(store, appName, personalUserID)
+	if currentPath == "" {
+		return nil
+	}
+	env := map[string]string{
+		envMemoryFile:     currentPath,
+		envChatMemoryFile: currentPath,
+	}
+	if personalPath != "" {
+		env[envUserMemoryFile] = personalPath
+	}
+	return env
+}
+
+func ensureMemoryEnvPath(
+	store *memoryfile.Store,
+	appName string,
+	userID string,
+) string {
+	userID = strings.TrimSpace(userID)
+	if userID == "" {
+		return ""
+	}
 	path, err := store.EnsureMemory(
 		context.Background(),
 		appName,
 		userID,
 	)
-	if err != nil || strings.TrimSpace(path) == "" {
-		return nil
+	if err != nil {
+		return ""
 	}
-	return map[string]string{
-		envMemoryFile: path,
-	}
+	return strings.TrimSpace(path)
 }
 
 func addLatestKindUploadEnv(

--- a/openclaw/internal/octool/tools.go
+++ b/openclaw/internal/octool/tools.go
@@ -776,8 +776,8 @@ func memoryFileEnvFromContext(
 		ctx,
 		personalUserID,
 	)
-	currentPath := ensureMemoryEnvPath(store, appName, storageUserID)
-	personalPath := ensureMemoryEnvPath(store, appName, personalUserID)
+	currentPath := ensureMemoryEnvPath(ctx, store, appName, storageUserID)
+	personalPath := ensureMemoryEnvPath(ctx, store, appName, personalUserID)
 	if currentPath == "" {
 		return nil
 	}
@@ -792,6 +792,7 @@ func memoryFileEnvFromContext(
 }
 
 func ensureMemoryEnvPath(
+	ctx context.Context,
 	store *memoryfile.Store,
 	appName string,
 	userID string,
@@ -800,8 +801,11 @@ func ensureMemoryEnvPath(
 	if userID == "" {
 		return ""
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	path, err := store.EnsureMemory(
-		context.Background(),
+		ctx,
 		appName,
 		userID,
 	)

--- a/openclaw/internal/octool/tools.go
+++ b/openclaw/internal/octool/tools.go
@@ -768,13 +768,13 @@ func memoryFileEnvFromContext(
 		return nil
 	}
 
-	storageUserID := conversationscope.StorageUserIDFromContext(
-		ctx,
-		userID,
-	)
 	personalUserID := conversationscope.UserStorageIDFromContext(
 		ctx,
 		userID,
+	)
+	storageUserID := conversationscope.StorageUserIDFromContext(
+		ctx,
+		personalUserID,
 	)
 	currentPath := ensureMemoryEnvPath(store, appName, storageUserID)
 	personalPath := ensureMemoryEnvPath(store, appName, personalUserID)

--- a/openclaw/internal/octool/tools_test.go
+++ b/openclaw/internal/octool/tools_test.go
@@ -372,7 +372,10 @@ func TestExecTool_UsesMemoryFileEnvFromContext(t *testing.T) {
 	ctx := agent.NewInvocationContext(context.Background(), inv)
 
 	args := mustJSON(t, map[string]any{
-		"command": "printf %s \"$OPENCLAW_MEMORY_FILE\"",
+		"command": "printf '%s\\n%s\\n%s' " +
+			"\"$OPENCLAW_MEMORY_FILE\" " +
+			"\"$OPENCLAW_USER_MEMORY_FILE\" " +
+			"\"$OPENCLAW_CHAT_MEMORY_FILE\"",
 		"yieldMs": 0,
 	})
 	out, err := execTool.Call(ctx, args)
@@ -384,6 +387,7 @@ func TestExecTool_UsesMemoryFileEnvFromContext(t *testing.T) {
 	path, err := store.MemoryPath("app", "u1")
 	require.NoError(t, err)
 	require.Contains(t, res.Output, path)
+	require.Equal(t, strings.Count(res.Output, path), 3)
 	require.FileExists(t, path)
 }
 
@@ -407,19 +411,29 @@ func TestExecTool_UsesStorageScopedMemoryFileEnvFromContext(t *testing.T) {
 
 	inv := agent.NewInvocation(
 		agent.WithInvocationSession(
-			sessionpkg.NewSession("app", "u1", "wecom:chat:room-1"),
+			sessionpkg.NewSession(
+				"app",
+				"wecom:dm:wineguo",
+				"wecom:chat:room-1",
+			),
 		),
 	)
 	ctx := agent.NewInvocationContext(
 		conversationscope.WithStorageUserID(
-			context.Background(),
+			conversationscope.WithUserStorageID(
+				context.Background(),
+				"wecom:dm:T123",
+			),
 			"wecom:chat:room-1",
 		),
 		inv,
 	)
 
 	args := mustJSON(t, map[string]any{
-		"command": "printf %s \"$OPENCLAW_MEMORY_FILE\"",
+		"command": "printf '%s\\n%s\\n%s' " +
+			"\"$OPENCLAW_MEMORY_FILE\" " +
+			"\"$OPENCLAW_USER_MEMORY_FILE\" " +
+			"\"$OPENCLAW_CHAT_MEMORY_FILE\"",
 		"yieldMs": 0,
 	})
 	out, err := execTool.Call(ctx, args)
@@ -432,6 +446,11 @@ func TestExecTool_UsesStorageScopedMemoryFileEnvFromContext(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, res.Output, path)
 	require.FileExists(t, path)
+	userPath, err := store.MemoryPath("app", "wecom:dm:T123")
+	require.NoError(t, err)
+	require.Contains(t, res.Output, userPath)
+	require.NotContains(t, res.Output, "wecom:dm:wineguo")
+	require.FileExists(t, userPath)
 }
 
 func TestMemoryFileEnvFromContext_EmptyScopeReturnsNil(t *testing.T) {

--- a/openclaw/internal/octool/tools_test.go
+++ b/openclaw/internal/octool/tools_test.go
@@ -453,6 +453,67 @@ func TestExecTool_UsesStorageScopedMemoryFileEnvFromContext(t *testing.T) {
 	require.FileExists(t, userPath)
 }
 
+func TestExecTool_UsesUserStorageScopedMemoryFileEnvFallback(
+	t *testing.T,
+) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash is not available")
+	}
+
+	const (
+		appName       = "app"
+		sessionUserID = "wecom:dm:wineguo"
+		storageUserID = "wecom:dm:T123"
+		sessionID     = "wecom:dm:wineguo:s1"
+	)
+
+	stateDir := t.TempDir()
+	root, err := memoryfile.DefaultRoot(stateDir)
+	require.NoError(t, err)
+	store, err := memoryfile.NewStore(root)
+	require.NoError(t, err)
+
+	mgr := NewManager()
+	execTool := NewExecCommandToolWithMemoryFileStore(
+		mgr,
+		nil,
+		store,
+	).(tool.CallableTool)
+
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(
+			sessionpkg.NewSession(appName, sessionUserID, sessionID),
+		),
+	)
+	ctx := agent.NewInvocationContext(
+		conversationscope.WithUserStorageID(
+			context.Background(),
+			storageUserID,
+		),
+		inv,
+	)
+
+	args := mustJSON(t, map[string]any{
+		"command": "printf '%s\\n%s\\n%s' " +
+			"\"$OPENCLAW_MEMORY_FILE\" " +
+			"\"$OPENCLAW_USER_MEMORY_FILE\" " +
+			"\"$OPENCLAW_CHAT_MEMORY_FILE\"",
+		"yieldMs": 0,
+	})
+	out, err := execTool.Call(ctx, args)
+	require.NoError(t, err)
+
+	res := out.(execResult)
+	require.Equal(t, "exited", res.Status)
+
+	path, err := store.MemoryPath(appName, storageUserID)
+	require.NoError(t, err)
+	require.Contains(t, res.Output, path)
+	require.Equal(t, strings.Count(res.Output, path), 3)
+	require.NotContains(t, res.Output, sessionUserID)
+	require.FileExists(t, path)
+}
+
 func TestMemoryFileEnvFromContext_EmptyScopeReturnsNil(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/internal/octool/tools_test.go
+++ b/openclaw/internal/octool/tools_test.go
@@ -532,6 +532,26 @@ func TestMemoryFileEnvFromContext_EmptyScopeReturnsNil(t *testing.T) {
 	require.Nil(t, memoryFileEnvFromContext(ctx, store))
 }
 
+func TestMemoryFileEnvFromContext_CanceledContextReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	root, err := memoryfile.DefaultRoot(t.TempDir())
+	require.NoError(t, err)
+	store, err := memoryfile.NewStore(root)
+	require.NoError(t, err)
+
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(
+			sessionpkg.NewSession("app", "u1", "telegram:dm:u1:s1"),
+		),
+	)
+	baseCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	ctx := agent.NewInvocationContext(baseCtx, inv)
+
+	require.Nil(t, memoryFileEnvFromContext(ctx, store))
+}
+
 func TestMemoryFileEnvFromContext_EnsureMemoryErrorReturnsNil(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- add an explicit user storage scope to OpenClaw conversation annotations
- expose separate user/chat memory file aliases and environment variables
- use the stable personal storage scope when layering runtime memory context

## Root cause
WeCom can use a runtime/display user ID for model-facing context while the
personal memory file is stored under a canonical direct-message storage ID. In
cross-scope flows such as asking for personal tasks from a group chat, the
runtime memory fallback could therefore look up the wrong key and miss the
private personal memory.

## Validation
- `go test ./conversation ./internal/conversationscope ./internal/gateway ./internal/octool ./app`
