### PR TITLE
session: decouple summary threshold formatting

### DIFF
--- a/openclaw/app/backends_test.go
+++ b/openclaw/app/backends_test.go
@@ -30,6 +30,15 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/registry"
 )
 
+func summaryTestMessageEvent() event.Event {
+	return event.Event{
+		Timestamp: time.Now(),
+		Response: &model.Response{Choices: []model.Choice{{
+			Message: model.Message{Content: "message"},
+		}}},
+	}
+}
+
 func TestParseSummaryPolicy(t *testing.T) {
 	t.Parallel()
 
@@ -106,9 +115,7 @@ func TestNewSessionSummarizer_ManualMode(t *testing.T) {
 	// With event_threshold=1, 2 events should trigger.
 	sess := session.NewSession("app", "user", "sess")
 	for i := 0; i < 2; i++ {
-		sess.Events = append(sess.Events, event.Event{
-			Timestamp: time.Now(),
-		})
+		sess.Events = append(sess.Events, summaryTestMessageEvent())
 	}
 	require.True(t, summarizer.ShouldSummarize(sess))
 }

--- a/openclaw/internal/skills/status_test.go
+++ b/openclaw/internal/skills/status_test.go
@@ -27,13 +27,13 @@ description: "Probe weather prerequisites"
 metadata:
   openclaw:
     skillKey: "weather-api"
-    primaryEnv: "OPENAI_API_KEY"
+    primaryEnv: "OPENCLAW_STATUS_TEST_MISSING_ENV"
     emoji: "⛅"
     homepage: "https://example.com/weather"
     requires:
       bins: ["definitely-missing-bin"]
       anyBins: ["definitely-missing-a", "definitely-missing-b"]
-      env: ["OPENAI_API_KEY"]
+      env: ["OPENCLAW_STATUS_TEST_MISSING_ENV"]
       config: ["channels.telegram.token"]
 ---
 
@@ -55,9 +55,9 @@ metadata:
 		[]string{"definitely-missing-a", "definitely-missing-b"},
 		entry.Missing.AnyBins,
 	)
-	require.Equal(t, []string{"OPENAI_API_KEY"}, entry.Missing.Env)
+	require.Equal(t, []string{"OPENCLAW_STATUS_TEST_MISSING_ENV"}, entry.Missing.Env)
 	require.Equal(t, []string{"channels.telegram.token"}, entry.Missing.Config)
-	require.Equal(t, "OPENAI_API_KEY", entry.PrimaryEnv)
+	require.Equal(t, "OPENCLAW_STATUS_TEST_MISSING_ENV", entry.PrimaryEnv)
 	require.Equal(t, "https://example.com/weather", entry.Homepage)
 	require.Len(t, entry.Install, 2)
 	require.Equal(t, statusInstallIDRestartPath, entry.Install[0].ID)

--- a/session/summary/checker.go
+++ b/session/summary/checker.go
@@ -285,9 +285,7 @@ func checkTokenThreshold(
 	if len(thresholdEvents) == 0 {
 		return false
 	}
-	message := extractTokenThresholdMessage(
-		thresholdEvents, nil, nil,
-	)
+	message := extractTokenThresholdMessage(thresholdEvents)
 	return checkTokenThresholdFromMessage(
 		ctx,
 		tokenCount,

--- a/session/summary/context_test.go
+++ b/session/summary/context_test.go
@@ -16,10 +16,20 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 )
 
 type contextKey string
+
+func contextTestMessageEvent() event.Event {
+	return event.Event{
+		Timestamp: time.Now(),
+		Response: &model.Response{Choices: []model.Choice{{
+			Message: model.Message{Content: "message"},
+		}}},
+	}
+}
 
 func TestSessionSummarizer_WithChecksAnyContextReceivesContext(t *testing.T) {
 	s := NewSummarizer(&testModel{}, WithChecksAnyContext(func(
@@ -36,7 +46,7 @@ func TestSessionSummarizer_WithChecksAnyContextReceivesContext(t *testing.T) {
 	require.True(t, ok)
 
 	sess := &session.Session{
-		Events: []event.Event{{Timestamp: time.Now()}},
+		Events: []event.Event{contextTestMessageEvent()},
 	}
 	ctx := context.WithValue(context.Background(), contextKey("trace"), "trace-ctx")
 	assert.True(t, contextual.ShouldSummarizeWithContext(ctx, sess))
@@ -62,7 +72,7 @@ func TestSessionSummarizer_WithChecksAllContextAllMustPass(t *testing.T) {
 	require.True(t, ok)
 
 	sess := &session.Session{
-		Events: []event.Event{{Timestamp: time.Now()}},
+		Events: []event.Event{contextTestMessageEvent()},
 	}
 	ctx := context.WithValue(context.Background(), contextKey("trace"), "trace-ctx")
 	assert.True(t, contextual.ShouldSummarizeWithContext(ctx, sess))
@@ -92,7 +102,7 @@ func TestSessionSummarizer_WithChecksAllContextShortCircuits(t *testing.T) {
 	require.True(t, ok)
 
 	sess := &session.Session{
-		Events: []event.Event{{Timestamp: time.Now()}},
+		Events: []event.Event{contextTestMessageEvent()},
 	}
 	assert.False(t, contextual.ShouldSummarizeWithContext(context.Background(), sess))
 	assert.False(t, calledSecond)
@@ -119,7 +129,7 @@ func TestSessionSummarizer_WithChecksAnyContextShortCircuits(t *testing.T) {
 	require.True(t, ok)
 
 	sess := &session.Session{
-		Events: []event.Event{{Timestamp: time.Now()}},
+		Events: []event.Event{contextTestMessageEvent()},
 	}
 	assert.True(t, contextual.ShouldSummarizeWithContext(context.Background(), sess))
 	assert.False(t, calledSecond)

--- a/session/summary/options.go
+++ b/session/summary/options.go
@@ -200,6 +200,7 @@ func WithSummaryHookAbortOnError(abort bool) Option {
 // WithToolCallFormatter sets a custom formatter for tool calls in the summary input.
 // The formatter receives a ToolCall and returns a formatted string.
 // Return empty string to exclude the tool call from the summary.
+// This does not affect token threshold checks used by ShouldSummarize.
 //
 // Example:
 //
@@ -216,6 +217,7 @@ func WithToolCallFormatter(f ToolCallFormatter) Option {
 // WithToolResultFormatter sets a custom formatter for tool results in the summary input.
 // The formatter receives the Message containing the tool result and returns a formatted string.
 // Return empty string to exclude the tool result from the summary.
+// This does not affect token threshold checks used by ShouldSummarize.
 //
 // Example:
 //

--- a/session/summary/options.go
+++ b/session/summary/options.go
@@ -200,7 +200,9 @@ func WithSummaryHookAbortOnError(abort bool) Option {
 // WithToolCallFormatter sets a custom formatter for tool calls in the summary input.
 // The formatter receives a ToolCall and returns a formatted string.
 // Return empty string to exclude the tool call from the summary.
-// This does not affect token threshold checks used by ShouldSummarize.
+// For non-empty summary input, this does not affect token threshold counting
+// used by ShouldSummarize. Returning empty for all included content suppresses
+// summarization because there is no effective summary input.
 //
 // Example:
 //
@@ -217,7 +219,9 @@ func WithToolCallFormatter(f ToolCallFormatter) Option {
 // WithToolResultFormatter sets a custom formatter for tool results in the summary input.
 // The formatter receives the Message containing the tool result and returns a formatted string.
 // Return empty string to exclude the tool result from the summary.
-// This does not affect token threshold checks used by ShouldSummarize.
+// For non-empty summary input, this does not affect token threshold counting
+// used by ShouldSummarize. Returning empty for all included content suppresses
+// summarization because there is no effective summary input.
 //
 // Example:
 //

--- a/session/summary/options_test.go
+++ b/session/summary/options_test.go
@@ -20,6 +20,15 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/session"
 )
 
+func optionTestMessageEvent(content string, ts time.Time) event.Event {
+	return event.Event{
+		Timestamp: ts,
+		Response: &model.Response{Choices: []model.Choice{{
+			Message: model.Message{Content: content},
+		}}},
+	}
+}
+
 func TestOptions(t *testing.T) {
 	t.Run("WithPrompt", func(t *testing.T) {
 		s := NewSummarizer(&testModel{}, WithPrompt("test"))
@@ -313,13 +322,39 @@ func TestOptions(t *testing.T) {
 		assert.False(t, s.ShouldSummarize(sess))
 	})
 
+	t.Run("formatter-empty input suppresses event threshold", func(t *testing.T) {
+		s := NewSummarizer(
+			&testModel{},
+			WithToolResultFormatter(func(model.Message) string { return "" }),
+			WithEventThreshold(0),
+		)
+		sess := &session.Session{Events: []event.Event{
+			{
+				Author:    "tool",
+				Timestamp: time.Now(),
+				Response: &model.Response{Choices: []model.Choice{{
+					Message: model.Message{
+						ToolID:   "call-1",
+						ToolName: "read_file",
+						Content:  "excluded",
+					},
+				}}},
+			},
+		}}
+		assert.False(t, s.ShouldSummarize(sess))
+	})
+
 	t.Run("WithEventThreshold", func(t *testing.T) {
 		s := NewSummarizer(&testModel{}, WithEventThreshold(2))
 		md := s.Metadata()
 		assert.Equal(t, 1, md[metadataKeyCheckFunctions])
 
 		sIso := NewSummarizer(&testModel{}, WithEventThreshold(2))
-		sess := &session.Session{Events: []event.Event{{Timestamp: time.Now()}, {Timestamp: time.Now()}, {Timestamp: time.Now()}}}
+		sess := &session.Session{Events: []event.Event{
+			optionTestMessageEvent("one", time.Now()),
+			optionTestMessageEvent("two", time.Now()),
+			optionTestMessageEvent("three", time.Now()),
+		}}
 		assert.True(t, sIso.ShouldSummarize(sess))
 	})
 
@@ -330,7 +365,9 @@ func TestOptions(t *testing.T) {
 
 		sIso := NewSummarizer(&testModel{}, WithTimeThreshold(10*time.Millisecond))
 		older := time.Now().Add(-20 * time.Millisecond)
-		sess := &session.Session{Events: []event.Event{{Timestamp: older}}}
+		sess := &session.Session{Events: []event.Event{
+			optionTestMessageEvent("old", older),
+		}}
 		assert.True(t, sIso.ShouldSummarize(sess))
 	})
 
@@ -361,7 +398,7 @@ func TestOptions(t *testing.T) {
 		s := NewSummarizer(&testModel{}, WithChecksAny(checks...))
 		sess := &session.Session{Events: make([]event.Event, 4)}
 		for i := range sess.Events {
-			sess.Events[i] = event.Event{Timestamp: time.Now()}
+			sess.Events[i] = optionTestMessageEvent("event", time.Now())
 		}
 		assert.True(t, s.ShouldSummarize(sess))
 	})

--- a/session/summary/options_test.go
+++ b/session/summary/options_test.go
@@ -140,7 +140,7 @@ func TestOptions(t *testing.T) {
 		assert.False(t, s.ShouldSummarize(sess))
 	})
 
-	t.Run("WithTokenThreshold honors summarizer tool result formatter", func(t *testing.T) {
+	t.Run("WithTokenThreshold ignores summarizer tool result formatter", func(t *testing.T) {
 		s := NewSummarizer(
 			&testModel{},
 			WithToolResultFormatter(func(model.Message) string { return "" }),
@@ -159,7 +159,7 @@ func TestOptions(t *testing.T) {
 				}}},
 			},
 		}}
-		assert.False(t, s.ShouldSummarize(sess))
+		assert.True(t, s.ShouldSummarize(sess))
 	})
 
 	t.Run("WithChecksAny token checker honors skipRecent-filtered input", func(t *testing.T) {
@@ -201,7 +201,7 @@ func TestOptions(t *testing.T) {
 		assert.False(t, s.ShouldSummarize(sess))
 	})
 
-	t.Run("WithChecksAny token checker honors summarizer tool result formatter", func(t *testing.T) {
+	t.Run("WithChecksAny token checker ignores summarizer tool result formatter", func(t *testing.T) {
 		s := NewSummarizer(
 			&testModel{},
 			WithToolResultFormatter(func(model.Message) string { return "" }),
@@ -220,7 +220,7 @@ func TestOptions(t *testing.T) {
 				}}},
 			},
 		}}
-		assert.False(t, s.ShouldSummarize(sess))
+		assert.True(t, s.ShouldSummarize(sess))
 	})
 
 	t.Run("effective empty input suppresses summarize even when custom checks pass", func(t *testing.T) {

--- a/session/summary/options_test.go
+++ b/session/summary/options_test.go
@@ -162,6 +162,31 @@ func TestOptions(t *testing.T) {
 		assert.True(t, s.ShouldSummarize(sess))
 	})
 
+	t.Run("WithTokenThreshold ignores summarizer tool call formatter", func(t *testing.T) {
+		s := NewSummarizer(
+			&testModel{},
+			WithToolCallFormatter(func(model.ToolCall) string { return "[tool call]" }),
+			WithTokenThreshold(100),
+		)
+		sess := &session.Session{Events: []event.Event{
+			{
+				Author:    "assistant",
+				Timestamp: time.Now(),
+				Response: &model.Response{Choices: []model.Choice{{
+					Message: model.Message{
+						ToolCalls: []model.ToolCall{{
+							Function: model.FunctionDefinitionParam{
+								Name:      "read_file",
+								Arguments: []byte(`{"content":"` + strings.Repeat("x", 2000) + `"}`),
+							},
+						}},
+					},
+				}}},
+			},
+		}}
+		assert.True(t, s.ShouldSummarize(sess))
+	})
+
 	t.Run("WithTokenThreshold skips empty summary input", func(t *testing.T) {
 		s := NewSummarizer(
 			&testModel{},
@@ -238,6 +263,31 @@ func TestOptions(t *testing.T) {
 						ToolID:   "call-1",
 						ToolName: "read_file",
 						Content:  strings.Repeat("x", 2000),
+					},
+				}}},
+			},
+		}}
+		assert.True(t, s.ShouldSummarize(sess))
+	})
+
+	t.Run("WithChecksAny token checker ignores summarizer tool call formatter", func(t *testing.T) {
+		s := NewSummarizer(
+			&testModel{},
+			WithToolCallFormatter(func(model.ToolCall) string { return "[tool call]" }),
+			WithChecksAny(CheckTokenThreshold(100)),
+		)
+		sess := &session.Session{Events: []event.Event{
+			{
+				Author:    "assistant",
+				Timestamp: time.Now(),
+				Response: &model.Response{Choices: []model.Choice{{
+					Message: model.Message{
+						ToolCalls: []model.ToolCall{{
+							Function: model.FunctionDefinitionParam{
+								Name:      "read_file",
+								Arguments: []byte(`{"content":"` + strings.Repeat("x", 2000) + `"}`),
+							},
+						}},
 					},
 				}}},
 			},

--- a/session/summary/options_test.go
+++ b/session/summary/options_test.go
@@ -143,7 +143,7 @@ func TestOptions(t *testing.T) {
 	t.Run("WithTokenThreshold ignores summarizer tool result formatter", func(t *testing.T) {
 		s := NewSummarizer(
 			&testModel{},
-			WithToolResultFormatter(func(model.Message) string { return "" }),
+			WithToolResultFormatter(func(model.Message) string { return "[tool result]" }),
 			WithTokenThreshold(100),
 		)
 		sess := &session.Session{Events: []event.Event{
@@ -160,6 +160,28 @@ func TestOptions(t *testing.T) {
 			},
 		}}
 		assert.True(t, s.ShouldSummarize(sess))
+	})
+
+	t.Run("WithTokenThreshold skips empty summary input", func(t *testing.T) {
+		s := NewSummarizer(
+			&testModel{},
+			WithToolResultFormatter(func(model.Message) string { return "" }),
+			WithTokenThreshold(100),
+		)
+		sess := &session.Session{Events: []event.Event{
+			{
+				Author:    "tool",
+				Timestamp: time.Now(),
+				Response: &model.Response{Choices: []model.Choice{{
+					Message: model.Message{
+						ToolID:   "call-1",
+						ToolName: "read_file",
+						Content:  strings.Repeat("x", 2000),
+					},
+				}}},
+			},
+		}}
+		assert.False(t, s.ShouldSummarize(sess))
 	})
 
 	t.Run("WithChecksAny token checker honors skipRecent-filtered input", func(t *testing.T) {
@@ -204,7 +226,7 @@ func TestOptions(t *testing.T) {
 	t.Run("WithChecksAny token checker ignores summarizer tool result formatter", func(t *testing.T) {
 		s := NewSummarizer(
 			&testModel{},
-			WithToolResultFormatter(func(model.Message) string { return "" }),
+			WithToolResultFormatter(func(model.Message) string { return "[tool result]" }),
 			WithChecksAny(CheckTokenThreshold(100)),
 		)
 		sess := &session.Session{Events: []event.Event{

--- a/session/summary/summarizer.go
+++ b/session/summary/summarizer.go
@@ -370,11 +370,7 @@ func (s *sessionSummarizer) buildCheckSession(
 	delta := filterDeltaEvents(checkSess)
 	filtered := s.filterEventsForSummary(delta)
 	thresholdEvents := filterThresholdEventsForSession(filtered, checkSess)
-	thresholdMessage := extractTokenThresholdMessage(
-		thresholdEvents,
-		s.toolCallFormatter,
-		s.toolResultFormatter,
-	)
+	thresholdMessage := extractTokenThresholdMessage(thresholdEvents)
 	checkSess.SetState(
 		tokenThresholdConversationTextStateKey,
 		[]byte(thresholdMessage.Content),
@@ -621,17 +617,9 @@ func extractConversationText(
 	return strings.Join(parts, "\n")
 }
 
-func extractTokenThresholdMessage(
-	events []event.Event,
-	toolCallFmt ToolCallFormatter,
-	toolResultFmt ToolResultFormatter,
-) model.Message {
+func extractTokenThresholdMessage(events []event.Event) model.Message {
 	return model.Message{
-		Content: extractConversationText(
-			events,
-			toolCallFmt,
-			toolResultFmt,
-		),
+		Content:          extractConversationText(events, nil, nil),
 		ReasoningContent: extractReasoningContent(events),
 	}
 }

--- a/session/summary/summarizer.go
+++ b/session/summary/summarizer.go
@@ -370,7 +370,11 @@ func (s *sessionSummarizer) buildCheckSession(
 	delta := filterDeltaEvents(checkSess)
 	filtered := s.filterEventsForSummary(delta)
 	thresholdEvents := filterThresholdEventsForSession(filtered, checkSess)
-	thresholdMessage := extractTokenThresholdMessage(thresholdEvents)
+	var thresholdMessage model.Message
+	summaryInputEvents := filterSummaryInputEventsForSession(filtered, checkSess)
+	if s.hasSummarizableContent(summaryInputEvents) {
+		thresholdMessage = extractTokenThresholdMessage(thresholdEvents)
+	}
 	checkSess.SetState(
 		tokenThresholdConversationTextStateKey,
 		[]byte(thresholdMessage.Content),

--- a/session/summary/summarizer.go
+++ b/session/summary/summarizer.go
@@ -259,10 +259,11 @@ func (s *sessionSummarizer) ShouldSummarizeWithContext(
 	if sess == nil || len(sess.Events) == 0 {
 		return false
 	}
-	if len(filterSummaryInputEventsForSession(
+	summaryInputEvents := filterSummaryInputEventsForSession(
 		s.filterEventsForSummary(sess.Events),
 		sess,
-	)) == 0 {
+	)
+	if !s.hasSummarizableContent(summaryInputEvents) {
 		return false
 	}
 

--- a/session/summary/summarizer_test.go
+++ b/session/summary/summarizer_test.go
@@ -29,7 +29,12 @@ func TestSessionSummarizer_ShouldSummarize(t *testing.T) {
 		s := NewSummarizer(&fakeModel{}, WithChecksAny(checks...))
 		sess := &session.Session{Events: make([]event.Event, 4)}
 		for i := range sess.Events {
-			sess.Events[i] = event.Event{Timestamp: time.Now()}
+			sess.Events[i] = event.Event{
+				Timestamp: time.Now(),
+				Response: &model.Response{Choices: []model.Choice{{
+					Message: model.Message{Content: "message"},
+				}}},
+			}
 		}
 		assert.True(t, s.ShouldSummarize(sess))
 	})

--- a/session/summary/summarizer_test.go
+++ b/session/summary/summarizer_test.go
@@ -1683,7 +1683,7 @@ func TestSessionSummarizer_BuildCheckSession(t *testing.T) {
 
 	t.Run("injects token text without summary input formatter", func(t *testing.T) {
 		s := &sessionSummarizer{
-			toolResultFormatter: func(model.Message) string { return "" },
+			toolResultFormatter: func(model.Message) string { return "[tool result]" },
 		}
 		content := strings.Repeat("x", 2000)
 		sess := &session.Session{

--- a/session/summary/summarizer_test.go
+++ b/session/summary/summarizer_test.go
@@ -1681,10 +1681,11 @@ func TestSessionSummarizer_BuildCheckSession(t *testing.T) {
 		assert.Nil(t, s.buildCheckSession(nil))
 	})
 
-	t.Run("injects effective token text from formatter-aware delta", func(t *testing.T) {
+	t.Run("injects token text without summary input formatter", func(t *testing.T) {
 		s := &sessionSummarizer{
 			toolResultFormatter: func(model.Message) string { return "" },
 		}
+		content := strings.Repeat("x", 2000)
 		sess := &session.Session{
 			Events: []event.Event{
 				{
@@ -1694,7 +1695,7 @@ func TestSessionSummarizer_BuildCheckSession(t *testing.T) {
 						Message: model.Message{
 							ToolID:   "call-1",
 							ToolName: "read_file",
-							Content:  strings.Repeat("x", 2000),
+							Content:  content,
 						},
 					}}},
 				},
@@ -1706,7 +1707,7 @@ func TestSessionSummarizer_BuildCheckSession(t *testing.T) {
 
 		raw, ok := checkSess.GetState(tokenThresholdConversationTextStateKey)
 		require.True(t, ok)
-		assert.Empty(t, string(raw))
+		assert.Contains(t, string(raw), content)
 	})
 
 	t.Run("injects reasoning content only for token threshold checks", func(t *testing.T) {

--- a/tool/mcpbroker/broker_test.go
+++ b/tool/mcpbroker/broker_test.go
@@ -1059,6 +1059,7 @@ func TestOneShot_ReinitializesPerCall(t *testing.T) {
 	broker := New(WithServers(map[string]legacymcp.ConnectionConfig{
 		"http_named": {
 			ServerURL: server.URL,
+			Timeout:   5 * time.Second,
 		},
 	}))
 


### PR DESCRIPTION
## Summary
- Make summary token-threshold checks use default full tool call/result formatting instead of summary input formatters.
- Keep `WithToolCallFormatter` and `WithToolResultFormatter` scoped to summary prompt input.
- Update tests to cover the decoupled ShouldSummarize behavior.

## Test plan
- `go test ./session/summary`
- `go test ./...`