### PR TITLE
codeexecutor/e2b: honor RunProgramSpec.CleanEnv in RunProgram

### DIFF
--- a/codeexecutor/e2b/e2b.go
+++ b/codeexecutor/e2b/e2b.go
@@ -518,9 +518,31 @@ func (c *CodeExecutor) ExecuteInline(
 }
 
 // Engine exposes the sandbox-backed runtime as an Engine for skill tools.
+//
+// The engine advertises SupportsCleanEnv: RunProgram honors
+// RunProgramSpec.CleanEnv by launching the spawned program through
+// `env -i` with only the workspace base variables, the (already
+// scrubbed) spec.Env and a minimal PATH, so the program does not
+// inherit the sandbox process environment (issue #1845). This lets
+// tool/workspaceexec policy mode run on the e2b backend instead of
+// failing closed.
+//
+// Scope note: the e2b Jupyter `/execute` API exposes no hook to
+// launch the *framing* shell (the kernel-side bash that runs our
+// script and the output sentinels) in an empty environment, so that
+// shell still inherits the sandbox environment. This is not a
+// model-injection vector: the sandbox environment is fixed by the
+// template / WithEnvVars at sandbox creation (operator-controlled),
+// and model-supplied env (spec.Env) is confined to the `env -i`
+// invocation rather than the framing shell. The SupportsCleanEnv
+// contract is about the spawned program's environment, which `env -i`
+// satisfies.
 func (c *CodeExecutor) Engine() codeexecutor.Engine {
 	rt := c.ensureRuntime()
-	return codeexecutor.NewEngine(rt, rt, rt)
+	return codeexecutor.NewEngineWithCapabilities(
+		rt, rt, rt,
+		codeexecutor.Capabilities{SupportsCleanEnv: true},
+	)
 }
 
 // Close terminates the owned sandbox (if any).

--- a/codeexecutor/e2b/envtoken.go
+++ b/codeexecutor/e2b/envtoken.go
@@ -1,0 +1,98 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package e2b
+
+import (
+	"sort"
+	"strings"
+)
+
+// minimalCleanPATH is the default search path injected for a
+// CleanEnv spawn that does not carry its own PATH. It mirrors the
+// POSIX branch of codeexecutor/local's cleanEnvPath (and the
+// codeexecutor/container runtime) so all backends resolve bare
+// commands against the same minimal set of system directories. The
+// e2b sandbox always targets a Linux template, so no Windows branch
+// is needed.
+const minimalCleanPATH = "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+// envToken builds the leading `env ...` (or `env -i ...`) token that
+// RunProgram splices in front of the quoted command inside the bash
+// script handed to the sandbox.
+//
+//   - base holds the runtime-supplied workspace variables
+//     (WORKSPACE_DIR, SKILLS_DIR, ...); a base entry is dropped when
+//     spec overrides the same key, matching the "user env wins"
+//     behaviour.
+//   - spec holds the caller/tool-supplied env. When a command policy
+//     is active the tool layer has already scrubbed it before it
+//     reaches the runtime.
+//   - clean selects `env -i` (empty starting environment) and the
+//     minimalCleanPATH fallback, injected only when spec carries no
+//     PATH so `env -i` can still resolve the command name.
+//
+// The result is terminated with a trailing space, or empty when
+// clean is false and there is nothing to inject; a clean token
+// always contains at least PATH. This is the e2b copy of the
+// container runtime's helper: the two backends are separate modules,
+// so each keeps its own unexported version rather than sharing a
+// package across the module boundary.
+func envToken(base, spec map[string]string, clean bool) string {
+	parts := make([]string, 0, len(base)+len(spec))
+	for _, k := range sortedEnvKeys(base) {
+		if _, ok := spec[k]; ok {
+			continue
+		}
+		parts = append(parts, k+"="+shellQuote(base[k]))
+	}
+	for _, k := range sortedEnvKeys(spec) {
+		parts = append(parts, k+"="+shellQuote(spec[k]))
+	}
+	if clean {
+		if !hasPathKey(base, spec) {
+			parts = append(
+				[]string{"PATH=" + shellQuote(minimalCleanPATH)},
+				parts...,
+			)
+		}
+		return "env -i " + strings.Join(parts, " ") + " "
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return "env " + strings.Join(parts, " ") + " "
+}
+
+// hasPathKey reports whether the effective environment (base entries
+// not overridden by spec, plus spec) already defines PATH. The check
+// is case-sensitive because the sandbox targets Linux, where a
+// lowercase "Path" is a distinct variable and must not suppress the
+// minimalCleanPATH injection.
+func hasPathKey(base, spec map[string]string) bool {
+	if _, ok := spec["PATH"]; ok {
+		return true
+	}
+	_, ok := base["PATH"]
+	return ok
+}
+
+// sortedEnvKeys returns the map keys in sorted order so the generated
+// script is deterministic (Go map iteration order is randomised);
+// environment-variable order on an `env` invocation is semantically
+// irrelevant.
+func sortedEnvKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/codeexecutor/e2b/envtoken_test.go
+++ b/codeexecutor/e2b/envtoken_test.go
@@ -1,0 +1,111 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package e2b
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvToken_NoCleanKeepsLegacyEnv(t *testing.T) {
+	got := envToken(
+		map[string]string{"WORKSPACE_DIR": "/ws"},
+		map[string]string{"FOO": "bar"},
+		false,
+	)
+	require.True(t, strings.HasPrefix(got, "env "),
+		"non-clean token must use legacy `env `")
+	require.NotContains(t, got, "-i")
+	require.Contains(t, got, "WORKSPACE_DIR=")
+	require.Contains(t, got, "FOO=")
+	require.NotContains(t, got, minimalCleanPATH,
+		"non-clean token must not inject the minimal PATH")
+	require.True(t, strings.HasSuffix(got, " "),
+		"token must end with a separating space")
+}
+
+func TestEnvToken_NoCleanEmptyMapsYieldEmpty(t *testing.T) {
+	require.Equal(t, "", envToken(nil, nil, false))
+}
+
+func TestEnvToken_CleanUsesEnvIAndInjectsMinimalPATH(t *testing.T) {
+	got := envToken(
+		map[string]string{"WORKSPACE_DIR": "/ws"},
+		map[string]string{"FOO": "bar"},
+		true,
+	)
+	require.True(t, strings.HasPrefix(got, "env -i "),
+		"clean token must start the command from an empty env")
+	require.Contains(t, got, minimalCleanPATH)
+	require.Contains(t, got, "WORKSPACE_DIR=")
+	require.Contains(t, got, "FOO=")
+}
+
+func TestEnvToken_CleanKeepsCallerPATH(t *testing.T) {
+	got := envToken(nil, map[string]string{"PATH": "/caller/bin"}, true)
+	require.Contains(t, got, "/caller/bin")
+	require.NotContains(t, got, minimalCleanPATH,
+		"caller PATH must suppress the minimal PATH fallback")
+}
+
+// TestEnvToken_CleanWithEmptyPATH documents that an explicit empty
+// PATH in spec is honored as the caller's deliberate choice: like
+// codeexecutor/local's key-presence check, hasPathKey keys off the
+// presence of "PATH", not its value, so the minimalCleanPATH
+// fallback is suppressed and the token carries an empty PATH.
+func TestEnvToken_CleanWithEmptyPATH(t *testing.T) {
+	got := envToken(nil, map[string]string{"PATH": ""}, true)
+	require.Contains(t, got, "env -i ")
+	require.Contains(t, got, "PATH=''")
+	require.NotContains(t, got, minimalCleanPATH,
+		"explicit empty PATH should suppress the fallback")
+}
+
+// TestEnvToken_CleanCaseSensitivePATH guards the Linux-only target:
+// a lowercase "Path" is a distinct variable and must not suppress
+// the minimal PATH injection, otherwise `env -i` would leave the
+// command without a usable PATH.
+func TestEnvToken_CleanCaseSensitivePATH(t *testing.T) {
+	got := envToken(nil, map[string]string{"Path": "/caller/bin"}, true)
+	require.Contains(t, got, minimalCleanPATH)
+	require.Contains(t, got, "Path=")
+}
+
+func TestEnvToken_SpecOverridesBaseKey(t *testing.T) {
+	got := envToken(
+		map[string]string{"WORKSPACE_DIR": "/base"},
+		map[string]string{"WORKSPACE_DIR": "/override"},
+		true,
+	)
+	require.Contains(t, got, "/override")
+	require.NotContains(t, got, "/base")
+	require.Equal(t, 1, strings.Count(got, "WORKSPACE_DIR="),
+		"override must not duplicate the key")
+}
+
+func TestEnvToken_DeterministicOrdering(t *testing.T) {
+	base := map[string]string{"B": "2", "A": "1"}
+	spec := map[string]string{"D": "4", "C": "3"}
+	first := envToken(base, spec, true)
+	for i := 0; i < 16; i++ {
+		require.Equal(t, first, envToken(base, spec, true),
+			"token must be deterministic across calls")
+	}
+}
+
+func TestEnvToken_CleanEmptyMapsYieldPathOnly(t *testing.T) {
+	require.Equal(t,
+		"env -i PATH="+shellQuote(minimalCleanPATH)+" ",
+		envToken(nil, nil, true),
+	)
+}

--- a/codeexecutor/e2b/workspace_runtime.go
+++ b/codeexecutor/e2b/workspace_runtime.go
@@ -623,16 +623,13 @@ func (r *workspaceRuntime) RunProgram(
 		codeexecutor.EnvOutputDir:       outDir,
 		codeexecutor.EnvRunDir:          runDir,
 	}
-	var envParts []string
-	for k, v := range baseEnv {
-		if _, ok := spec.Env[k]; ok {
-			continue
-		}
-		envParts = append(envParts, k+"="+shellQuote(v))
-	}
-	for k, v := range spec.Env {
-		envParts = append(envParts, k+"="+shellQuote(v))
-	}
+	// envAssign is the leading `env ...` / `env -i ...` token spliced
+	// in front of the command. When spec.CleanEnv is set
+	// (workspace_exec / skill_run policy mode) it becomes `env -i ...`
+	// so the spawned program starts from an empty environment plus the
+	// workspace base vars and a minimal PATH, honoring
+	// RunProgramSpec.CleanEnv on the e2b backend (issue #1845).
+	envAssign := envToken(baseEnv, spec.Env, spec.CleanEnv)
 
 	quotedCmd := shellQuote(spec.Cmd)
 	var quotedArgs strings.Builder
@@ -645,11 +642,6 @@ func (r *workspaceRuntime) RunProgram(
 	if spec.Stdin != "" {
 		b64 := base64.StdEncoding.EncodeToString([]byte(spec.Stdin))
 		stdinRedir = " < <(printf %s " + shellQuote(b64) + " | base64 -d)"
-	}
-
-	envAssign := ""
-	if len(envParts) > 0 {
-		envAssign = "env " + strings.Join(envParts, " ") + " "
 	}
 
 	inner := fmt.Sprintf(

--- a/codeexecutor/e2b/workspace_runtime_test.go
+++ b/codeexecutor/e2b/workspace_runtime_test.go
@@ -449,6 +449,88 @@ func TestRunProgram_BashErrorSurfaced(t *testing.T) {
 	assert.Contains(t, err.Error(), "bash error")
 }
 
+// runProgramCaptureScript runs spec through a mock e2b sandbox and
+// returns the bash script handed to the sandbox `/execute` endpoint,
+// so CleanEnv tests can assert how RunProgram shapes the program
+// invocation without a real sandbox.
+func runProgramCaptureScript(
+	t *testing.T, spec codeexecutor.RunProgramSpec,
+) string {
+	t.Helper()
+	var gotScript string
+	srv := newMockE2BServer(t, func(code string) string {
+		gotScript = code
+		stdout := strings.Join([]string{
+			sentinelStdoutBegin, "", sentinelStdoutEnd,
+			sentinelExitPrefix + "0",
+		}, "\n") + "\n"
+		stderr := strings.Join([]string{
+			sentinelStderrBegin, sentinelStderrEnd,
+		}, "\n") + "\n"
+		return ndjsonLines(stdoutMsg(stdout), stderrMsg(stderr))
+	})
+	defer srv.close()
+	c := newMockedExecutor(t, srv)
+	ws := codeexecutor.Workspace{ID: "wCE", Path: "/tmp/ws"}
+	_, err := c.RunProgram(context.Background(), ws, spec)
+	require.NoError(t, err)
+	require.NotEmpty(t, gotScript)
+	return gotScript
+}
+
+// TestRunProgram_CleanEnvUsesEnvI guards the e2b half of issue
+// #1845: when spec.CleanEnv is set the spawned program must be
+// launched through `env -i` with a minimal PATH, so it starts from
+// an empty environment plus the workspace base vars instead of
+// inheriting the sandbox process environment.
+func TestRunProgram_CleanEnvUsesEnvI(t *testing.T) {
+	script := runProgramCaptureScript(t, codeexecutor.RunProgramSpec{
+		Cmd:      "echo",
+		Args:     []string{"hi"},
+		CleanEnv: true,
+		Timeout:  3 * time.Second,
+	})
+	require.Contains(t, script, "env -i ",
+		"clean mode must start the program from an empty env")
+	require.Contains(t, script, minimalCleanPATH,
+		"clean mode must inject a minimal PATH for env -i")
+	require.Contains(t, script, codeexecutor.WorkspaceEnvDirKey+"=",
+		"workspace base vars must still be injected in clean mode")
+}
+
+// TestRunProgram_CleanEnvKeepsSpecPATH verifies a caller-supplied
+// PATH is honored in clean mode and suppresses the minimalCleanPATH
+// fallback (so the tool/skill layer, which has already vetted that
+// PATH, stays authoritative).
+func TestRunProgram_CleanEnvKeepsSpecPATH(t *testing.T) {
+	script := runProgramCaptureScript(t, codeexecutor.RunProgramSpec{
+		Cmd:      "echo",
+		CleanEnv: true,
+		Env:      map[string]string{"PATH": "/opt/vetted/bin"},
+		Timeout:  3 * time.Second,
+	})
+	require.Contains(t, script, "env -i ")
+	require.Contains(t, script, "/opt/vetted/bin")
+	require.NotContains(t, script, minimalCleanPATH,
+		"caller PATH must suppress the minimal PATH fallback")
+}
+
+// TestRunProgram_NoCleanEnvUsesPlainEnv pins the non-policy
+// contract: without CleanEnv the runtime keeps a plain `env ...`
+// token and inherits the sandbox environment, so existing callers
+// are unaffected.
+func TestRunProgram_NoCleanEnvUsesPlainEnv(t *testing.T) {
+	script := runProgramCaptureScript(t, codeexecutor.RunProgramSpec{
+		Cmd:     "echo",
+		Env:     map[string]string{"FOO": "bar"},
+		Timeout: 3 * time.Second,
+	})
+	require.Contains(t, script, "env ")
+	require.NotContains(t, script, "env -i",
+		"non-clean mode must not isolate the environment")
+	require.NotContains(t, script, minimalCleanPATH)
+}
+
 func TestCollect_ReadsFiles(t *testing.T) {
 	calls := 0
 	srv := newMockE2BServer(t, func(code string) string {
@@ -703,6 +785,8 @@ func TestEngineExposure(t *testing.T) {
 	assert.NotNil(t, eng.Manager())
 	assert.NotNil(t, eng.FS())
 	assert.NotNil(t, eng.Runner())
+	assert.True(t, eng.Describe().SupportsCleanEnv,
+		"e2b engine must advertise CleanEnv support (issue #1845)")
 }
 
 func TestPickLanguageTrimsAndLowers(t *testing.T) {

--- a/codeexecutor/workspace.go
+++ b/codeexecutor/workspace.go
@@ -165,9 +165,9 @@ type Capabilities struct {
 	//
 	// Defaults to false so any backend that has not been audited
 	// for CleanEnv support is treated as "does not support" until
-	// it opts in. local opts in via NewEngineWithCapabilities;
-	// container / e2b currently do not (tracked in
-	// https://github.com/trpc-group/trpc-agent-go/issues/1845).
+	// it opts in. The local, container and e2b backends opt in via
+	// NewEngineWithCapabilities (issue #1845); other backends keep
+	// the zero value and fail closed.
 	SupportsCleanEnv bool
 }
 

--- a/codeexecutor/workspace.go
+++ b/codeexecutor/workspace.go
@@ -213,11 +213,12 @@ func NewEngine(
 
 // NewEngineWithCapabilities is the explicit-capabilities form of
 // NewEngine. Backends that have audited their runtime behaviour
-// against the Capabilities surface (today: codeexecutor/local
-// declares SupportsCleanEnv = true) use this constructor; backends
-// that have not yet been audited continue to use NewEngine and
-// inherit the zero value, which fails closed in any tool that
-// gates on a capability.
+// against the Capabilities surface (today: codeexecutor/local,
+// codeexecutor/container and codeexecutor/e2b declare
+// SupportsCleanEnv = true) use this constructor; backends that have
+// not yet been audited continue to use NewEngine and inherit the
+// zero value, which fails closed in any tool that gates on a
+// capability.
 func NewEngineWithCapabilities(
 	m WorkspaceManager,
 	f WorkspaceFS,

--- a/docs/mkdocs/en/codeexecutor.md
+++ b/docs/mkdocs/en/codeexecutor.md
@@ -928,16 +928,11 @@ caller-supplied env (including `PATH`) are preserved as before.
     `codeexecutor.Capabilities.SupportsCleanEnv` is `false`, and
     returns an error pointing the operator at a supported runtime.
 
-    Today only `codeexecutor/local` advertises
-    `SupportsCleanEnv: true`. `codeexecutor/container` and
-    `codeexecutor/e2b` keep the zero-valued capabilities, so policy
-    mode on those backends is currently refused at the gate.
-    Implementing `CleanEnv` for them (so the policy gate opens
-    automatically once they declare the capability) is tracked in
-    [#1845](https://github.com/trpc-group/trpc-agent-go/issues/1845).
-    Until then, run policy mode on the local backend, or drop the
-    policy lists and rely on the sandbox layer for env / network
-    isolation.
+    Today `codeexecutor/local`, `codeexecutor/container`, and
+    `codeexecutor/e2b` advertise `SupportsCleanEnv: true`, so policy
+    mode is supported on those backends. Other backends keep the
+    zero-valued capabilities and are refused at the gate until they
+    are audited and opt in via `NewEngineWithCapabilities`.
 
 ### Scope
 

--- a/docs/mkdocs/zh/codeexecutor.md
+++ b/docs/mkdocs/zh/codeexecutor.md
@@ -856,13 +856,10 @@ deny 里。
     是 `false`，工具会在 spawn 之前直接拒掉这次调用，错误信息指引
     operator 切到支持的 runtime。
 
-    目前只有 `codeexecutor/local` 声明了 `SupportsCleanEnv: true`。
-    `codeexecutor/container` 和 `codeexecutor/e2b` 保持 zero-valued
-    capabilities，所以这两个后端上的策略模式当前会在闸门处被拒掉。
-    给它们实现 `CleanEnv`（让它们声明 capability 后闸门自动放开）
-    跟在 [#1845](https://github.com/trpc-group/trpc-agent-go/issues/1845)
-    里。在那之前，请在 local 后端上开策略模式，或者去掉 allow/deny
-    列表，把 env / 网络隔离交给沙箱层。
+    目前 `codeexecutor/local`、`codeexecutor/container` 和
+    `codeexecutor/e2b` 都已声明 `SupportsCleanEnv: true`，因此这三个后端
+    都支持策略模式。其它后端会保持 zero-valued capabilities，并在闸门处被拒掉，
+    直到完成审计并通过 `NewEngineWithCapabilities` 显式声明能力。
 
 ### 边界
 


### PR DESCRIPTION
## Summary

Second step of #1845, following the container backend (#1890, merged).

- `RunProgram` builds its `env ...` token via a local `envToken` helper (mirroring the merged container runtime). When `spec.CleanEnv` is set it emits `env -i` with the workspace base vars, the already-scrubbed `spec.Env`, and a minimal `PATH` fallback, so the spawned program starts from an **empty** environment instead of inheriting the sandbox process environment.
- The e2b `Engine` now advertises `SupportsCleanEnv`, so `tool/workspaceexec` policy mode runs on this backend instead of **failing closed**.
- `envToken` is inlined into `package e2b` rather than shared, matching the container precedent (the backends are independent modules, so each keeps its own unexported copy).

## Scope note (documented on `Engine()`)

The e2b Jupyter `/execute` API exposes no hook to launch the **framing** kernel shell (the bash that runs our script + output sentinels) in an empty environment, so that shell still inherits the sandbox environment. This is **not a model-injection vector**:

- the sandbox environment is fixed by the template / `WithEnvVars` at sandbox creation (operator-controlled), and
- model-supplied env (`spec.Env`) is confined to the `env -i` invocation, never the framing shell.

The `SupportsCleanEnv` contract concerns the **spawned program's** environment, which `env -i` satisfies (consistent with the local/container backends).

## Test plan

- [x] `envtoken_test.go`: clean/non-clean tokens, minimal-PATH fallback, caller-PATH (incl. empty + case-sensitive) override, base/spec precedence, deterministic ordering.
- [x] `RunProgram` script assertions: clean mode emits `env -i` + minimal PATH + base vars; caller PATH suppresses the fallback; non-clean keeps a plain `env` token.
- [x] `TestEngineExposure` asserts `Describe().SupportsCleanEnv == true`.
- [x] `go build` / `go vet` / `gofmt` clean; full `codeexecutor/e2b/...` and `codeexecutor` suites pass.

Docs (the local-only caveat in `codeexecutor.md` and remaining `#1845` references) are updated in a separate follow-up PR.

Refs #1845.