### PR TITLE
knowledge : fix knowledge module versions

### DIFF
--- a/examples/knowledge/go.mod
+++ b/examples/knowledge/go.mod
@@ -23,17 +23,17 @@ replace (
 require (
 	github.com/getkin/kin-openapi v0.124.0
 	github.com/jackc/pgx/v5 v5.7.2
-	trpc.group/trpc-go/trpc-agent-go v1.8.2-0.20260429121222-b41f42aefbc5
-	trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader/golang v0.0.1-0.20260429130101-b1f1d9f169f0
+	trpc.group/trpc-go/trpc-agent-go v1.9.2-0.20260602121024-664ebd0ab56d
+	trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader/golang v0.0.0-20260602121024-664ebd0ab56d
 	trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader/pdf v0.5.0
-	trpc.group/trpc-go/trpc-agent-go/knowledge/graphstore/age v0.0.1-0.20260429130101-b1f1d9f169f0
+	trpc.group/trpc-go/trpc-agent-go/knowledge/graphstore/age v0.0.0-20260602121024-664ebd0ab56d
 	trpc.group/trpc-go/trpc-agent-go/knowledge/ocr/tesseract v0.0.0-20251203120347-0b4d62cb115d
 	trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/elasticsearch v0.2.1
 	trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/milvus v0.8.1-0.20251222024650-ea147adf3d21
 	trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/pgvector v0.2.0
-	trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/sqlitevec v0.0.0-20260327150826-d407bd208503
+	trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/sqlitevec v1.9.0
 	trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/tcvector v0.2.0
-	trpc.group/trpc-go/trpc-agent-go/storage/postgres v0.0.0-20251126064502-c8c2594d2519
+	trpc.group/trpc-go/trpc-agent-go/storage/postgres v1.9.0
 	trpc.group/trpc-go/trpc-mcp-go v0.0.10
 )
 

--- a/knowledge/document/reader/golang/go.mod
+++ b/knowledge/document/reader/golang/go.mod
@@ -6,7 +6,7 @@ replace trpc.group/trpc-go/trpc-agent-go => ../../../..
 
 require (
 	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d
-	trpc.group/trpc-go/trpc-agent-go v0.2.0
+	trpc.group/trpc-go/trpc-agent-go v1.9.2-0.20260602121024-664ebd0ab56d
 )
 
 require (

--- a/knowledge/graphstore/age/go.mod
+++ b/knowledge/graphstore/age/go.mod
@@ -9,8 +9,8 @@ replace (
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
-	trpc.group/trpc-go/trpc-agent-go v0.2.0
-	trpc.group/trpc-go/trpc-agent-go/storage/postgres v0.0.0-20251030021201-13c22db836ca
+	trpc.group/trpc-go/trpc-agent-go v1.9.2-0.20260602121024-664ebd0ab56d
+	trpc.group/trpc-go/trpc-agent-go/storage/postgres v1.9.0
 )
 
 require (


### PR DESCRIPTION
## Summary

- update newly split knowledge module versions to resolvable versions from current main
- align GraphRAG-related examples and AGE storage/postgres dependency versions
- replace an invalid sqlitevec pseudo-version in examples with the existing v1.9.0 tag

## Validation

- go test ./... in knowledge/document/reader/golang
- go test ./... in knowledge/graphstore/age
- go test ./... in examples/knowledge
- bash .github/scripts/check-go-mod-version.sh
- bash .github/scripts/check-go-mod-version.sh --module examples/knowledge/go.mod
- bash .github/scripts/check-go-mod-tidy.sh
- simulated external consumers by removing relevant replace directives in temporary copies
