### PR TITLE
model: raise unknown context window fallback

### DIFF
--- a/docs/mkdocs/en/model.md
+++ b/docs/mkdocs/en/model.md
@@ -1624,7 +1624,7 @@ for request-scoped output limits and tool definitions:
 
 > **Context Window Registration**
 >
-> Token Tailoring and session summary `WithContextThreshold` both need a model context window. Built-in model names are resolved automatically. For private deployments, tenant-provided models, or endpoint IDs, prefer model-instance configuration such as `openai.WithContextWindow(32768)` or the unified `provider.WithContextWindow(32768)`. For one-off runs, use `agent.WithModelContextWindow(32768)`. Use `model.RegisterModelContextWindow("my-model", 32768)` only when the name has a stable process-wide meaning. See the [Session Summary documentation](session/summary.md) for a full example.
+> Token Tailoring and session summary `WithContextThreshold` both need a model context window. Built-in model names are resolved automatically. Token Tailoring uses a 128000-token fallback for unknown model names. For private deployments, tenant-provided models, endpoint IDs, or smaller unknown models, prefer model-instance configuration such as `openai.WithContextWindow(32768)` or the unified `provider.WithContextWindow(32768)`. For one-off runs, use `agent.WithModelContextWindow(32768)`. Use `model.RegisterModelContextWindow("my-model", 32768)` only when the name has a stable process-wide meaning. See the [Session Summary documentation](session/summary.md) for a full example.
 
 ```text
 outputReserve = max(ReserveOutputTokens, request.MaxTokens, request.ThinkingTokens)

--- a/docs/mkdocs/zh/model.md
+++ b/docs/mkdocs/zh/model.md
@@ -1610,7 +1610,7 @@ model := openai.New("deepseek-v4-flash",
 
 > **Context Window 注册**
 >
-> Token 裁剪和会话摘要的 `WithContextThreshold` 都需要模型 context window。内置模型名会自动解析。对于私有部署、租户自定义模型或 endpoint ID，优先使用模型实例配置，例如 `openai.WithContextWindow(32768)` 或统一入口的 `provider.WithContextWindow(32768)`；对于单次运行覆盖，使用 `agent.WithModelContextWindow(32768)`。只有当模型名在当前进程中有稳定全局含义时，才使用 `model.RegisterModelContextWindow("my-model", 32768)`。完整示例参见[会话摘要文档](session/summary.md)。
+> Token 裁剪和会话摘要的 `WithContextThreshold` 都需要模型 context window。内置模型名会自动解析。Token 裁剪对未知模型名使用 128000 tokens 的 fallback。对于私有部署、租户自定义模型、endpoint ID 或更小的未知模型，优先使用模型实例配置，例如 `openai.WithContextWindow(32768)` 或统一入口的 `provider.WithContextWindow(32768)`；对于单次运行覆盖，使用 `agent.WithModelContextWindow(32768)`。只有当模型名在当前进程中有稳定全局含义时，才使用 `model.RegisterModelContextWindow("my-model", 32768)`。完整示例参见[会话摘要文档](session/summary.md)。
 
 ```text
 outputReserve = max(ReserveOutputTokens, request.MaxTokens, request.ThinkingTokens)

--- a/model/anthropic/anthropic_test.go
+++ b/model/anthropic/anthropic_test.go
@@ -2527,17 +2527,17 @@ func TestWithEnableTokenTailoring_Disabled(t *testing.T) {
 func TestWithEnableTokenTailoring_UnknownModel(t *testing.T) {
 	// Capture the built Anthropic request.
 	var captured *anthropic.MessageNewParams
-	m := New("unknown-model-xyz", // Unknown model should fallback to default context window
+	m := New("unknown-model-xyz", // Unknown model should fallback to the 128000-token default context window
 		WithEnableTokenTailoring(true),
 		WithChatRequestCallback(func(ctx context.Context, req *anthropic.MessageNewParams) {
 			captured = req
 		}),
 	)
 
-	// Create many messages to trigger tailoring.
+	// Create messages large enough to trigger tailoring with the unknown-model fallback window.
 	messages := []model.Message{model.NewSystemMessage("You are a helpful assistant.")}
 	for i := 0; i < 50; i++ {
-		messages = append(messages, model.NewUserMessage(fmt.Sprintf("Message %d: %s", i, strings.Repeat("lorem ipsum ", 50))))
+		messages = append(messages, model.NewUserMessage(fmt.Sprintf("Message %d: %s", i, strings.Repeat("lorem ipsum ", 1000))))
 	}
 
 	req := &model.Request{Messages: messages}

--- a/model/internal/model/model_info.go
+++ b/model/internal/model/model_info.go
@@ -16,7 +16,7 @@ import (
 )
 
 // defaultContextWindow is the fallback context window size (tokens) when model is unknown.
-const defaultContextWindow = 8192
+const defaultContextWindow = 128000
 
 // ModelMutex guards modelContextWindows.
 var ModelMutex sync.RWMutex

--- a/model/internal/model/model_info_test.go
+++ b/model/internal/model/model_info_test.go
@@ -24,7 +24,7 @@ func TestResolveContextWindow(t *testing.T) {
 		{
 			name:      "empty model name",
 			modelName: "",
-			expected:  defaultContextWindow,
+			expected:  128000,
 		},
 		{
 			name:      "exact match - GPT-4",
@@ -284,12 +284,12 @@ func TestResolveContextWindow(t *testing.T) {
 		{
 			name:      "no prefix match without separator boundary",
 			modelName: "gpt-5.4x",
-			expected:  defaultContextWindow,
+			expected:  128000,
 		},
 		{
 			name:      "unknown model fallback",
 			modelName: "unknown-model",
-			expected:  defaultContextWindow,
+			expected:  128000,
 		},
 	}
 

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -2618,17 +2618,17 @@ func TestWithEnableTokenTailoring_Disabled(t *testing.T) {
 func TestWithEnableTokenTailoring_UnknownModel(t *testing.T) {
 	// Capture the built OpenAI request to check messages count reflects tailoring.
 	var captured *openaigo.ChatCompletionNewParams
-	m := New("unknown-model-xyz", // Unknown model should fallback to default context window
+	m := New("unknown-model-xyz", // Unknown model should fallback to the 128000-token default context window
 		WithEnableTokenTailoring(true),
 		WithChatRequestCallback(func(ctx context.Context, req *openaigo.ChatCompletionNewParams) {
 			captured = req
 		}),
 	)
 
-	// Create many messages to trigger tailoring.
+	// Create messages large enough to trigger tailoring with the unknown-model fallback window.
 	messages := []model.Message{model.NewSystemMessage("You are a helpful assistant.")}
 	for i := 0; i < 50; i++ {
-		messages = append(messages, model.NewUserMessage(fmt.Sprintf("Message %d: %s", i, strings.Repeat("lorem ipsum ", 50))))
+		messages = append(messages, model.NewUserMessage(fmt.Sprintf("Message %d: %s", i, strings.Repeat("lorem ipsum ", 1000))))
 	}
 
 	req := &model.Request{Messages: messages}


### PR DESCRIPTION
## Summary

- Raise the unknown-model context window fallback used by token tailoring from 8192 to 128000 tokens.
- Update unknown-model token tailoring tests to still exercise trimming with the larger fallback.
- Document the 128000-token fallback and point smaller private or endpoint-based models to explicit context-window configuration.

## Validation

- go test ./model/internal/model ./model/openai
- (cd model/anthropic && go test ./...)
- go test ./...
