### PR TITLE
runner: avoid mutating streaming error events

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1087,6 +1087,7 @@ func (r *runner) processSingleAgentEvent(ctx context.Context, loop *eventLoopCon
 	if agentEvent == nil {
 		return nil
 	}
+	agentEvent = errorEventWithContent(agentEvent)
 	excludeRootCompletion := routedEvent && !sameSession(persistSession, loop.sess)
 	if excludeRootCompletion {
 		r.captureRoutedCompletionError(loop, agentEvent)
@@ -1996,7 +1997,7 @@ func (r *runner) handleEventPersistence(
 	agentEvent *event.Event,
 ) bool {
 	// Ensure error events have content so they are valid for persistence.
-	ensureErrorEventContent(agentEvent)
+	agentEvent = errorEventWithContent(agentEvent)
 
 	// Append event to session if it's complete (not partial).
 	if !r.shouldPersistEvent(agentEvent) {
@@ -3185,6 +3186,22 @@ func ensureErrorEventContent(e *event.Event) {
 		reason := "error"
 		e.Response.Choices[0].FinishReason = &reason
 	}
+}
+
+func errorEventWithContent(e *event.Event) *event.Event {
+	if e == nil || e.Response == nil || e.Response.Error == nil {
+		return e
+	}
+	if e.IsValidContent() {
+		return e
+	}
+
+	// Preserve event identity but repair content on an owned response copy.
+	eventCopy := *e
+	eventCopy.Response = e.Response.Clone()
+	ensureErrorEventContent(&eventCopy)
+
+	return &eventCopy
 }
 
 // RunWithMessages is a convenience helper that lets callers pass a full

--- a/runner/runner_error_test.go
+++ b/runner/runner_error_test.go
@@ -27,6 +27,7 @@ type streamingErrorAgent struct {
 	name      string
 	errorMsg  string
 	errorType string
+	emitted   *event.Event
 }
 
 func (m *streamingErrorAgent) Info() agent.Info                     { return agent.Info{Name: m.name} }
@@ -38,6 +39,7 @@ func (m *streamingErrorAgent) Run(ctx context.Context, inv *agent.Invocation) (<
 	// Create an error event. By default, NewErrorEvent does NOT populate Choices/Content.
 	// This simulates the behavior of llmflow/other components emitting raw error events.
 	ev := event.NewErrorEvent(inv.InvocationID, m.name, m.errorType, m.errorMsg)
+	m.emitted = ev
 	ch <- ev
 	close(ch)
 	return ch, nil
@@ -95,6 +97,48 @@ func TestRunner_FixesStreamingErrorEvent(t *testing.T) {
 	assert.Equal(t, "An error occurred during execution. Please contact the service provider.",
 		errorEvent.Response.Choices[0].Message.Content)
 	assert.Equal(t, "error", *errorEvent.Response.Choices[0].FinishReason)
+}
+
+func TestRunner_DoesNotMutateStreamingErrorEventWhenAddingContent(t *testing.T) {
+	svc := sessioninmemory.NewSessionService()
+	ag := &streamingErrorAgent{
+		name:      "stream-error-agent",
+		errorMsg:  "stream failed",
+		errorType: model.ErrorTypeStreamError,
+	}
+	r := NewRunner("test-app", ag, WithSessionService(svc))
+
+	ch, err := r.Run(context.Background(), "user-race", "session-race", model.NewUserMessage("start"))
+	require.NoError(t, err)
+
+	var eventsFromCh []*event.Event
+	for e := range ch {
+		eventsFromCh = append(eventsFromCh, e)
+	}
+
+	require.NotNil(t, ag.emitted)
+	require.Len(t, eventsFromCh, 2)
+	repairedEvent := eventsFromCh[0]
+
+	require.NotSame(t, ag.emitted, repairedEvent)
+	assert.Equal(t, ag.emitted.ID, repairedEvent.ID)
+	assert.Empty(t, ag.emitted.Response.Choices)
+	require.NotEmpty(t, repairedEvent.Response.Choices)
+	assert.Equal(
+		t,
+		"An error occurred during execution. Please contact the service provider.",
+		repairedEvent.Response.Choices[0].Message.Content,
+	)
+
+	sess, err := svc.GetSession(context.Background(), session.Key{
+		AppName:   "test-app",
+		UserID:    "user-race",
+		SessionID: "session-race",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Len(t, sess.Events, 2)
+	require.NotEmpty(t, sess.Events[1].Response.Choices)
 }
 
 // TestRunner_FixesDirectRunError verifies that the runner populates content for errors returned by agent.Run().


### PR DESCRIPTION
## Summary

Fixes #1907, a data race in runner streaming error handling by avoiding in-place mutation of agent-supplied error events.

When a streaming model emits an error event without message content, the runner currently repairs that event by writing fallback content into `Response.Choices`. That repair can happen on the same event/response object that other streaming-path code still holds, so readers such as `Response.IsToolCallResponse` can race with the runner's write.

This PR keeps the existing fallback-content behavior, but performs the repair on an owned response copy.

## What Changed

- Added `errorEventWithContent` in `runner/runner.go`.
- The helper returns the original event unchanged when no repair is needed.
- When an error event needs fallback content, it shallow-copies the event, clones `Response`, and repairs content on the cloned response.
- `processSingleAgentEvent` now normalizes error events after plugin handling, before completion capture, persistence, summarization checks, and emission.
- `handleEventPersistence` also uses the helper defensively for direct/internal callers.
- Added `TestRunner_DoesNotMutateStreamingErrorEventWhenAddingContent` to prove the original agent-emitted event is not mutated while the emitted and persisted event still has valid fallback content.

## Why This Shape

The bug is shared object ownership, not an isolated missing lock. Locking the runner would not protect all readers of `model.Response`, and adding locking to response classification would spread synchronization across unrelated code.

Clone-before-repair keeps the fix local to the runner boundary where ownership changes:

- event identity is preserved, including event ID and routing metadata
- persistence still receives valid content for otherwise-empty error events
- downstream consumers still see the repaired error event
- producer-owned or concurrently observed response state is no longer mutated