### PR TITLE
tool/agent: add dynamic AgentTool with scoped capabilities

### DIFF
--- a/agent/invocation_surface.go
+++ b/agent/invocation_surface.go
@@ -1,0 +1,63 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package agent
+
+import (
+	"context"
+
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
+	"trpc.group/trpc-go/trpc-agent-go/skill"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+// InvocationToolSurfaceProvider is an optional interface implemented by agents
+// that can expose the effective, invocation-scoped tool surface together with
+// the user-tool classification.
+//
+// The first return value is the full set of tools visible for the invocation
+// (user tools plus framework-managed tools). The second return value maps the
+// names that are classified as user tools (the tools registered via WithTools
+// and WithToolSets) so callers can distinguish them from framework tools.
+//
+// It is intentionally a structural interface so that helpers such as the
+// dynamic AgentTool can derive a child capability surface from a parent
+// invocation without importing any concrete agent implementation.
+type InvocationToolSurfaceProvider interface {
+	InvocationToolSurface(
+		ctx context.Context,
+		inv *Invocation,
+	) ([]tool.Tool, map[string]bool)
+}
+
+// InvocationSkillRepositoryProvider is an optional interface implemented by
+// agents that can expose the effective, invocation-scoped skill repository.
+//
+// The returned repository reflects any invocation-scoped surface overrides
+// (for example a surface patch) layered on top of the agent's configured
+// repository. It may return nil when the agent has no skills configured.
+type InvocationSkillRepositoryProvider interface {
+	InvocationSkillRepository(
+		ctx context.Context,
+		inv *Invocation,
+	) skill.Repository
+}
+
+// InvocationCodeExecutorProvider is an optional interface implemented by
+// agents that can expose the effective, invocation-scoped code executor.
+//
+// The returned executor reflects any per-run override (for example
+// WithCodeExecutor) layered on top of the agent's configured executor. It may
+// return nil when no executor is available for the invocation.
+type InvocationCodeExecutorProvider interface {
+	InvocationCodeExecutor(
+		ctx context.Context,
+		inv *Invocation,
+	) codeexecutor.CodeExecutor
+}

--- a/agent/llmagent/surface_runtime.go
+++ b/agent/llmagent/surface_runtime.go
@@ -96,6 +96,29 @@ func (a *LLMAgent) codeExecutorForInvocation(
 	return a.option.codeExecutor
 }
 
+// InvocationSkillRepository returns the effective skill repository for the
+// invocation, honoring an invocation-scoped surface patch when present. It
+// implements agent.InvocationSkillRepositoryProvider so helpers such as the
+// dynamic AgentTool can derive a child skill surface from a parent invocation
+// without importing the llmagent package.
+func (a *LLMAgent) InvocationSkillRepository(
+	_ context.Context,
+	inv *agent.Invocation,
+) skill.Repository {
+	return a.skillRepositoryForInvocation(inv)
+}
+
+// InvocationCodeExecutor returns the effective code executor for the
+// invocation, honoring a per-run override when present. It implements
+// agent.InvocationCodeExecutorProvider so callers can check executor
+// availability for a parent invocation without importing the llmagent package.
+func (a *LLMAgent) InvocationCodeExecutor(
+	_ context.Context,
+	inv *agent.Invocation,
+) codeexecutor.CodeExecutor {
+	return a.codeExecutorForInvocation(inv)
+}
+
 func (a *LLMAgent) supportsWorkspaceExecForInvocation(
 	inv *agent.Invocation,
 ) bool {
@@ -241,7 +264,10 @@ func (a *LLMAgent) InvocationToolSurface(
 	if options.EnableAwaitUserReplyTool {
 		allTools = append(allTools, toolawaitreply.New())
 	}
-	if len(subAgents) == 0 {
+	// A surface patch may suppress framework-managed sub-agent transfer for this
+	// node (the dynamic AgentTool does so for short-lived sub-agents that must
+	// not hand control to another agent). Treat it like having no sub-agents.
+	if len(subAgents) == 0 || patch.SuppressSubAgentTransfer() {
 		allTools = appendExtensionTools(allTools, &options)
 		return allTools, userToolNames
 	}

--- a/agent/surface_patch.go
+++ b/agent/surface_patch.go
@@ -55,6 +55,13 @@ func (p *SurfacePatch) SetSkillRepository(repo skill.Repository) {
 	p.patch.SetSkillRepository(repo)
 }
 
+// SetSuppressSubAgentTransfer omits framework-managed sub-agent transfer
+// (transfer_to_agent) from the node's tool surface even when the node's agent
+// has sub-agents.
+func (p *SurfacePatch) SetSuppressSubAgentTransfer() {
+	p.patch.SetSuppressSubAgentTransfer()
+}
+
 // WithSurfacePatchForNode applies one node's runtime surface overrides to this run.
 func WithSurfacePatchForNode(nodeID string, patch SurfacePatch) RunOption {
 	return func(opts *RunOptions) {

--- a/agent/surface_patch_test.go
+++ b/agent/surface_patch_test.go
@@ -112,6 +112,7 @@ func TestSurfacePatch_Setters_ApplyAllSupportedSurfaces(t *testing.T) {
 	patch.SetTools([]tool.Tool{surfacePatchTestTool{name: "tool_one"}})
 	patch.AppendTools([]tool.Tool{surfacePatchTestTool{name: "tool_two"}})
 	patch.SetSkillRepository(repoValue)
+	patch.SetSuppressSubAgentTransfer()
 	opts := NewRunOptions(WithSurfacePatchForNode("root", patch))
 	stored, ok := surfacepatch.PatchForNode(opts.CustomAgentConfigs, "root")
 	require.True(t, ok)
@@ -136,6 +137,7 @@ func TestSurfacePatch_Setters_ApplyAllSupportedSurfaces(t *testing.T) {
 	gotRepo, ok := stored.SkillRepository()
 	require.True(t, ok)
 	require.NotNil(t, gotRepo)
+	require.True(t, stored.SuppressSubAgentTransfer())
 }
 
 func TestWithSurfacePatchForNode_IgnoresEmptyInputs(t *testing.T) {

--- a/docs/mkdocs/en/tool.md
+++ b/docs/mkdocs/en/tool.md
@@ -1624,6 +1624,135 @@ child := agenttool.NewTool(
   `HistoryScopeIsolated` and pass the needed context through tool arguments.
 - `WithSkipSummarization(true)` only skips the extra outer summarization LLM call. It does not make `tool.response` a final assistant response; keep consuming until `runner.completion` if you need the real terminal signal
 
+### Dynamic AgentTool
+
+`agenttool.NewTool(agent)` is a good fit when the tool is backed by one clear
+specialist Agent. In that case, the application constructs the Agent first
+including its model, tools, skills, permissions, and runtime policy, then exposes
+that Agent as a tool to the parent.
+
+Use `agenttool.NewDynamicTool()` when the application cannot predefine every
+specialist role, and the parent Agent should choose a tool subset or per-call
+instruction for each task. It exposes a model-facing tool named `dynamic_agent`
+by default. Calling this tool does not create arbitrary Go objects and does not
+select one pre-registered Agent by name; it runs one short-lived child Agent
+invocation within a boundary defined by application code.
+
+Typical setup:
+
+```go
+dynamicAgent := agenttool.NewDynamicTool()
+
+parent := llmagent.New(
+    "assistant",
+    llmagent.WithModel(modelInstance),
+    llmagent.WithTools([]tool.Tool{
+        readFileTool,
+        searchCodeTool,
+        dynamicAgent,
+    }),
+)
+```
+
+By default, `dynamic_agent` derives its capability boundary from the parent
+Agent's currently available user tools. The model can pass `tools` to narrow the
+child Agent's tools for this call. If `tools` is omitted, the child may use all
+tools inside the boundary. `dynamic_agent` itself, `transfer_to_agent`, and
+caller-executed external tools are not selectable for the child.
+
+The default model-facing arguments are:
+
+```json
+{
+  "request": "Analyze this code for authorization bypass risks. Relevant context: ...",
+  "instruction": "Act as a security auditor. Return only risks and fixes.",
+  "tools": ["read_file", "search_code"]
+}
+```
+
+- `request`: Required task description. The default history scope is
+  `HistoryScopeIsolated`, so include the context the child needs in `request`.
+- `instruction`: Optional role, constraints, or execution guidance for this
+  child invocation.
+- `tools`: Optional exact tool names allowed for this invocation. An empty array
+  means the child receives no user tools.
+
+If the default parent-derived boundary is not the right business boundary, set a
+template Agent or explicit maximum capability surface in code:
+
+```go
+workerTemplate := llmagent.New(
+    "worker-template",
+    llmagent.WithModel(workerModel),
+    llmagent.WithInstruction("You are a focused worker Agent for one task."),
+)
+
+dynamicAgent := agenttool.NewDynamicTool(
+    // Optional: define the child Agent execution boundary: model, executor,
+    // callbacks, permission policy, and similar runtime settings.
+    agenttool.WithTemplateAgent(workerTemplate),
+    // Optional: restrict the maximum tool set the model can choose from.
+    agenttool.WithCapabilityTools([]tool.Tool{readFileTool, searchCodeTool}),
+)
+```
+
+`WithTemplateAgent` is a code-side boundary, not a model parameter. The model
+cannot use `dynamic_agent` to choose arbitrary Agents, models, or executors. It
+can only fill `request`, optionally set `instruction`, and optionally narrow the
+tools/skills subset inside the boundary configured by the developer.
+
+Common options:
+
+- `WithName(name)`: change the model-facing tool name. This only applies to
+  `NewDynamicTool`; regular `NewTool(agent)` always uses the wrapped Agent's
+  `Info().Name`.
+- `WithTemplateAgent(agent)`: set the dynamic child Agent template, commonly used
+  to fix the model, executor, callbacks, permission policy, and other runtime
+  boundaries.
+- `WithCapabilityTools(tools)`: set the maximum tool surface the model may choose
+  from. When omitted, it is derived from the parent Agent's effective user tools
+  for the current run. When set, the tool names are enumerated in the `tools`
+  schema so the model selects from a known set instead of guessing strings (the
+  parent-derived surface and `WithCapabilityProvider` are resolved per call and
+  are not enumerated).
+- `WithCapabilitySkills(repo)`: set the maximum skill repository the model may
+  choose from. When omitted, it is derived from the parent Agent's effective skill
+  repository for the current run.
+- `WithExposeToolSelection(false)`: hide the `tools` field from the model. The
+  child still receives the code-defined tool surface, but the model cannot narrow
+  it.
+- `WithExposeSkillSelection(true)`: expose the `skills` field to the model. This
+  is disabled by default because skill execution usually depends on deployment
+  environment and code executor availability.
+- `WithExposeInstruction(false)`: hide the `instruction` field from the model.
+- `WithRequestDescription` / `WithInstructionDescription` /
+  `WithToolsDescription` / `WithSkillsDescription`: customize field descriptions
+  using business-specific wording so the model fills arguments more reliably.
+
+Take extra care when exposing `skills`. Dynamic AgentTool checks whether selected
+skill names exist in the boundary repository. If the child has no available code
+executor and a selected skill may require running code, the tool result includes a
+warning. In production, prefer defining the executable range in code with
+`WithCapabilitySkills` and a template Agent before exposing the `skills` field to
+the model.
+
+Dynamic AgentTool has a different boundary from the other multi-Agent mechanisms:
+
+| Mechanism | What the model chooses | Lifetime | Control |
+| --- | --- | --- | --- |
+| `agenttool.NewTool(agent)` | one fixed tool entrypoint | per tool call | returns a tool result to the parent Agent |
+| `transfer_to_agent` | one registered sub-agent | target Agent continues the current turn | hands off control |
+| `agenttool.NewDynamicTool()` | `request`, `instruction`, and a tools/skills subset for this call | per tool call | returns a tool result to the parent Agent |
+
+If the same specialist Agent is exposed through both `WithSubAgents` and
+`agenttool.NewTool(agent)`, the parent model sees two different paths:
+`transfer_to_agent` and a regular AgentTool. The framework can run this, but the
+developer should explain when to use each path in the instruction or tool
+description, or expose only one path. A `dynamic_agent` child does not receive
+`transfer_to_agent`, but regular AgentTools are treated as user tools. If a
+dynamic child should not call other AgentTools, narrow the boundary with
+`WithCapabilityTools` or a runtime `ToolFilter`.
+
 ## Tool Integration and Usage
 
 ### Create an Agent and Integrate Tools

--- a/docs/mkdocs/zh/tool.md
+++ b/docs/mkdocs/zh/tool.md
@@ -1556,6 +1556,116 @@ child := agenttool.NewTool(
 - `HistoryScopeParentBranch` 是共享上下文链路，不是快照隔离。如果不希望子 Agent 的详细事件在父 Agent 后续上下文中出现，保持默认 `HistoryScopeIsolated`，并把必要上下文放进工具参数。
 - `WithSkipSummarization(true)` 只会跳过额外的外层总结型 LLM 调用，不会把 `tool.response` 变成 assistant final response；如果你需要真正的终止信号，仍应持续消费到 `runner.completion`
 
+### 动态 AgentTool
+
+`agenttool.NewTool(agent)` 适合工具背后已经有一个明确的专家 Agent：开发者先把
+Agent、模型、工具、skills、权限等配置好，再把它包装成父 Agent 的一个工具。
+
+当你的应用无法提前穷举所有专家角色，而是希望父 Agent 在每次调用时按任务临时选择
+工具子集或指定本次执行指令，可以使用 `agenttool.NewDynamicTool()`。它会向模型暴露
+一个默认名为 `dynamic_agent` 的工具；模型调用它时，不是在创建任意 Go 对象，也不是
+选择某个已注册 Agent，而是在代码定义的边界内运行一次短生命周期的子 Agent invocation。
+
+典型接入方式如下：
+
+```go
+dynamicAgent := agenttool.NewDynamicTool()
+
+parent := llmagent.New(
+    "assistant",
+    llmagent.WithModel(modelInstance),
+    llmagent.WithTools([]tool.Tool{
+        readFileTool,
+        searchCodeTool,
+        dynamicAgent,
+    }),
+)
+```
+
+默认情况下，`dynamic_agent` 的能力边界来自父 Agent 当前可用的业务工具。模型可以通过
+`tools` 字段把子 Agent 本次可用工具收窄到其中一部分；如果不传 `tools`，则允许使用
+边界内的全部工具。`dynamic_agent` 自身、`transfer_to_agent` 以及调用方执行的外部工具
+不会进入这个子 Agent 的可选工具面。
+
+模型侧默认可见的参数包括：
+
+```json
+{
+  "request": "分析这段代码是否存在权限绕过风险，必要上下文如下：...",
+  "instruction": "你是安全审计专家，只输出风险点和修复建议",
+  "tools": ["read_file", "search_code"]
+}
+```
+
+- `request`：必填，描述子 Agent 本次要完成的任务。默认历史作用域是
+  `HistoryScopeIsolated`，因此建议把完成任务需要的上下文写进 `request`。
+- `instruction`：可选，作为本次子 Agent invocation 的角色、约束或执行指令。
+- `tools`：可选，精确指定本次允许子 Agent 使用哪些工具名。传空数组表示本次不授予
+  任何业务工具。
+
+如果默认从父 Agent 派生能力面不符合业务边界，可以在代码侧显式设置模板 Agent 或最大
+能力面：
+
+```go
+workerTemplate := llmagent.New(
+    "worker-template",
+    llmagent.WithModel(workerModel),
+    llmagent.WithInstruction("你是一个只处理单个任务的执行型 Agent。"),
+)
+
+dynamicAgent := agenttool.NewDynamicTool(
+    // 可选：定义子 Agent 的模型、executor、callbacks、权限策略等执行边界。
+    agenttool.WithTemplateAgent(workerTemplate),
+    // 可选：限制模型最多只能从这些工具里选择。
+    agenttool.WithCapabilityTools([]tool.Tool{readFileTool, searchCodeTool}),
+)
+```
+
+`WithTemplateAgent` 是代码侧边界，不是模型参数。模型不能通过 `dynamic_agent` 选择任意
+Agent、模型或 executor；它只能在开发者配置好的边界内，为这一次调用填写 `request`、
+`instruction`，并按需选择 tools/skills 子集。
+
+常用选项：
+
+- `WithName(name)`：修改模型可见工具名。仅对 `NewDynamicTool` 生效；普通
+  `NewTool(agent)` 的工具名始终来自被包装 Agent 的 `Info().Name`。
+- `WithTemplateAgent(agent)`：设置动态子 Agent 的模板，常用于固定模型、executor、
+  callbacks、权限策略等执行边界。
+- `WithCapabilityTools(tools)`：设置模型可选择的最大工具集合。未设置时默认从父 Agent
+  本轮有效业务工具派生。显式设置后，这些工具名会被枚举进 `tools` 字段的 schema，模型从
+  已知集合中选择而非猜测字符串（父派生工具面与 `WithCapabilityProvider` 在每次调用时
+  解析，不会在此枚举）。
+- `WithCapabilitySkills(repo)`：设置模型可选择的最大 skill 仓库。未设置时默认从父
+  Agent 本轮有效 skill 仓库派生。
+- `WithExposeToolSelection(false)`：不向模型暴露 `tools` 字段。子 Agent 仍使用代码边界内
+  的工具面，但模型不能进一步收窄。
+- `WithExposeSkillSelection(true)`：向模型暴露 `skills` 字段。默认关闭，因为 skill 是否
+  可执行通常依赖部署环境和 code executor。
+- `WithExposeInstruction(false)`：不向模型暴露 `instruction` 字段。
+- `WithRequestDescription` / `WithInstructionDescription` /
+  `WithToolsDescription` / `WithSkillsDescription`：按业务语义调整字段描述，帮助模型更
+  稳定地填写参数。
+
+使用 `skills` 时需要额外注意 executor 环境。Dynamic AgentTool 会校验模型选择的 skill
+是否在边界仓库中；如果子 Agent 没有可用 code executor，而选中的 skill 可能需要执行代码，
+工具结果会带上提示。生产环境中更推荐在代码侧通过 `WithCapabilitySkills` 和模板 Agent
+先定义清楚可执行范围，再决定是否把 `skills` 字段暴露给模型。
+
+Dynamic AgentTool 与另外两种多 Agent 机制的边界不同：
+
+| 机制 | 模型选择什么 | 生命周期 | 控制权 |
+| --- | --- | --- | --- |
+| `agenttool.NewTool(agent)` | 一个固定的工具入口 | 每次工具调用 | 返回工具结果给父 Agent |
+| `transfer_to_agent` | 一个已注册 sub-agent | 当前轮继续由目标 Agent 处理 | 控制权移交 |
+| `agenttool.NewDynamicTool()` | 本次调用的 `request`、`instruction` 和 tools/skills 子集 | 每次工具调用 | 返回工具结果给父 Agent |
+
+如果同一个专家 Agent 同时通过 `WithSubAgents` 和 `agenttool.NewTool(agent)` 暴露给父
+Agent，模型会看到两条不同路径：`transfer_to_agent` 和普通 AgentTool。框架可以运行，
+但开发者应在 instruction 或工具 description 中明确何时使用哪一种，或者只保留一种入口。
+`dynamic_agent` 子调用内部不会获得 `transfer_to_agent`，但普通 AgentTool 会被视作业务工具；
+如果不希望动态子 Agent 再调用其他 AgentTool，可以用 `WithCapabilityTools` 或运行时
+`ToolFilter` 收窄边界。
+
 ## 工具集成与使用
 
 ### 创建 Agent 与工具集成

--- a/examples/dynamicagenttool/README.md
+++ b/examples/dynamicagenttool/README.md
@@ -1,0 +1,263 @@
+# Dynamic Sub-Agent Tool Example
+
+This example demonstrates the **dynamic AgentTool** (`agenttool.NewDynamicTool`):
+a single, code-defined `dynamic_agent` entrypoint that runs a short-lived
+sub-agent whose capability surface (tools and a per-call instruction)
+is selected by the model **per invocation**, within a safety boundary you
+define in code.
+
+The model-facing tool name is `dynamic_agent`; the *dynamic* part means
+per-invocation `instruction` and `tools`/`skills` selection within a
+code-defined boundary. The sub-agent is derived from the current agent or a
+code-defined template and cannot select arbitrary agents, models, or executors.
+
+Use it when you have a pool of tools but the right subset differs per task, so
+predefining one expert sub-agent per combination is impractical: the model
+picks the minimal tool set (and a role) for each task, runs it in a short-lived
+sub-agent, and the parent only gets the result back — no extra `AgentTool`
+boilerplate and no intermediate steps pushed into the parent context.
+
+## How it differs from the other sub-agent mechanisms
+
+| Mechanism | What the model picks | Lifetime | Control returns? |
+| --------- | -------------------- | -------- | ---------------- |
+| `agenttool.NewTool(agent)` | nothing — one fixed wrapped agent | per call | yes (result is the tool output) |
+| `transfer_to_agent` | one of N pre-registered agents | rest of the turn | no — control hands off |
+| **`agenttool.NewDynamicTool()`** | **a tool subset + instruction for a sub-agent** | **per call** | **yes (result is the tool output)** |
+
+With the dynamic tool, the model does not choose *which agent* to run — it runs
+inside the boundary you configure. It only chooses *which subset of the
+permitted tools* the sub-agent may use and *what role* it should take for that
+one task.
+
+## What the example builds
+
+The example ships two modes; choose one with `-mode` (default `minimal`).
+
+### `-mode=minimal` (default)
+
+The orchestrator registers the workspace tools **and** `dynamic_agent`:
+
+```
+orchestrator (main agent)
+├── calculator        (function tool)
+├── current_time      (function tool)
+├── word_count        (function tool)
+└── dynamic_agent     (dynamic AgentTool)
+        └── sub-agent: reuses the orchestrator as its base (no template);
+            tools are narrowed per call to a subset of the orchestrator's
+            surface, e.g. just ["calculator"]
+```
+
+The model can still call the direct tools for trivial one-step answers, but
+`dynamic_agent`'s default description tells it to delegate self-contained tool
+work and multiple independent subtasks when a separate working context keeps the
+parent conversation focused. The point is not that the sub-agent has unique
+tools; it isolates the work. With no template the sub-agent reuses the
+orchestrator's identity, so its streamed output is not visually separated —
+this mode is about the simplest possible onboarding.
+
+### `-mode=bounded`
+
+The orchestrator registers **only** `dynamic_agent`; the workspace tools live
+behind its capability surface:
+
+```
+orchestrator (main agent)
+└── dynamic_agent     (dynamic AgentTool)
+        ├── capability tools: calculator, current_time, word_count
+        │     (names appear in the `tools` enum; full schemas stay hidden
+        │      from the parent model)
+        └── subagent (template: identity + model + default role, no tools)
+            └── selected tools injected per call, e.g. just ["calculator"]
+```
+
+This is where the dynamic tool earns its keep (see [Bounded mode](#bounded-mode)):
+the parent model sees only one `dynamic_agent` entry plus the enumerated tool
+names, and the full tool schemas are disclosed only inside the short-lived
+sub-agent.
+
+In both modes:
+
+- **Max tool surface** — in `minimal` it is the orchestrator's *current
+  effective user tools* at call time (any run-scoped filter applied, run-added
+  tools included), minus the dynamic tool itself (no recursion) and
+  `transfer_to_agent`; in `bounded` it is exactly the `WithCapabilityTools` set.
+  Framework-managed tools (e.g. `knowledge_*`) are not hand-pickable.
+- The model **narrows tools** per call with the `tools` field and sets a role
+  with the `instruction` field.
+
+## Prerequisites
+
+- Go 1.24.4 or later (the `examples` module requires it)
+- A valid API key for an OpenAI-compatible endpoint
+
+## Environment Variables
+
+| Variable          | Description                              | Default                     |
+| ----------------- | ---------------------------------------- | --------------------------- |
+| `OPENAI_API_KEY`  | API key for the model service (required) | ``                          |
+| `OPENAI_BASE_URL` | Base URL for the model API endpoint      | `https://api.openai.com/v1` |
+
+```bash
+export OPENAI_BASE_URL="http://your-openai-compatible-endpoint/v1"
+export OPENAI_API_KEY="<your-key>"
+```
+
+The endpoint may serve Claude or OpenAI models (e.g. `gpt-5`,
+`claude-4-5-sonnet-20250929`, `deepseek-v4-flash`); select one with `-model`.
+
+## Command Line Arguments
+
+| Argument      | Description                                     | Default                      |
+| ------------- | ----------------------------------------------- | ---------------------------- |
+| `-model`      | Name of the model to use                        | `claude-4-5-sonnet-20250929` |
+| `-mode`       | Demo mode: `minimal` or `bounded`               | `minimal`                    |
+| `-show-inner` | Show the sub-agent transcript as it streams     | `true`                       |
+| `-inner-text` | Inner text mode: `include` or `exclude`         | `include`                    |
+| `-show-tool`  | Show the aggregated `tool.response`             | `false`                      |
+| `-debug`      | Prefix streamed lines with the event author     | `false`                      |
+
+## Usage
+
+```bash
+cd examples/dynamicagenttool
+export OPENAI_API_KEY="<your-key>"
+
+# Minimal mode (default): tools + dynamic_agent on the orchestrator.
+go run .
+
+# Bounded mode: only dynamic_agent on the orchestrator; tools behind its
+# capability surface (progressive disclosure + least privilege).
+go run . -mode=bounded
+```
+
+Then try prompts that delegate self-contained subtasks, for example:
+
+- `Use a sub-agent to compute (123 * 456) + 789. Grant it only the calculator.`
+- `Use a sub-agent to tell me the current time in UTC.`
+- `Use one sub-agent to compute 50 * 12, and a separate sub-agent to count the words in "the quick brown fox jumps". Grant each only the tool it needs.`
+
+## Bounded mode
+
+`minimal` mode is for learning the API. `bounded` mode (`-mode=bounded`) shows
+why the *dynamic* tool exists, and is the structure to copy for real apps:
+
+- **Progressive tool disclosure.** The parent model sees only the
+  `dynamic_agent` entry. Its `tools` field enumerates the selectable names
+  (`calculator`, `current_time`, `word_count`), but the full parameter schemas
+  of those tools are never shown to the parent — they are disclosed only inside
+  the sub-agent that gets spawned. The parent picks names; the child sees
+  schemas.
+- **Least-privilege delegation.** The orchestrator cannot call the workspace
+  tools directly. Every use goes through a short-lived sub-agent that receives
+  only the minimal subset selected for that one task.
+- **Code-defined boundary.** The selectable surface is fixed in code with
+  `WithCapabilityTools`, and `WithTemplateAgent` pins the sub-agent's model,
+  identity, and default role. The model can choose a tool subset and a per-call
+  `instruction`, but never an arbitrary agent, model, or executor.
+
+Wiring (see `main.go`'s `buildModeSetup`):
+
+```go
+dynamicTool := agenttool.NewDynamicTool(
+    agenttool.WithTemplateAgent(subTemplate),      // identity + model boundary
+    agenttool.WithCapabilityTools([]tool.Tool{     // the selectable surface
+        calculatorTool, timeTool, wordCountTool,
+    }),
+    // ... result-shaping options ...
+)
+
+orchestrator := llmagent.New(
+    "orchestrator",
+    llmagent.WithTools([]tool.Tool{dynamicTool}),  // ONLY the dynamic tool
+    // ...
+)
+```
+
+## Sample transcript
+
+```
+👤 You: Use one sub-agent to compute 50 * 12, and a separate sub-agent to count
+        the words in "the quick brown fox jumps". Grant each only the tool it needs.
+🤖 Assistant: I'll create two separate sub-agents, each with only the tool they need.
+🔧 Tool calls initiated:
+   • dynamic_agent  Args: {"request":"Calculate 50 * 12","tools":["calculator"],
+                          "instruction":"You are a calculation assistant..."}
+   • dynamic_agent  Args: {"request":"Count the words in \"the quick brown fox jumps\"",
+                          "tools":["word_count"],"instruction":"You are a text analysis assistant..."}
+
+🔄 Executing tools...
+   • calculator    Args: {"operation":"multiply","a":50,"b":12}
+   ✅ {"result":600}
+   • word_count    Args: {"text":"the quick brown fox jumps"}
+   ✅ {"words":5,"characters":25}
+```
+
+Each sub-agent only ever sees the single tool it was granted.
+
+## The `dynamic_agent` input schema
+
+By default the tool exposes:
+
+- `request` (string, required) — the task; the sub-agent is isolated by
+  default, so this should be self-contained unless `HistoryScopeParentBranch`
+  is configured.
+- `instruction` (string, optional) — the sub-agent's role / system prompt for
+  this run.
+- `tools` (string array, optional) — exact names of the orchestrator's user
+  tools to grant; omit to allow all currently-permitted user tools. When the
+  surface is fixed in code with `WithCapabilityTools`, those names are
+  enumerated in the schema (and appended to this field's description) so the
+  model picks from a known set instead of guessing strings; the default
+  parent-derived surface and `WithCapabilityProvider` are resolved per call and
+  are not enumerated here.
+
+A `skills` field can also be exposed (off by default). When it is, the
+sub-agent's skills are drawn from the orchestrator's effective skills (never the
+template's own), and selecting a skill that needs a code executor the sub-agent
+lacks adds a note to the result. Unknown or unavailable tool/skill names are
+ignored with a note appended to the tool result rather than failing the call.
+
+## Defining the safety boundary in code
+
+`minimal` mode uses the default parent-derived tool surface with no template;
+`bounded` mode uses `WithTemplateAgent` plus `WithCapabilityTools`. Other knobs
+let you tighten or reshape the boundary further:
+
+```go
+run := agenttool.NewDynamicTool(
+    // Identity + model + default instruction for the sub-agent.
+    agenttool.WithTemplateAgent(subTemplate),
+
+    // Optionally fix the exact tools the model may choose from, instead of
+    // deriving them from the parent agent. Their names are then enumerated in
+    // the `tools` schema, so the model selects from a known set:
+    // agenttool.WithCapabilityTools([]tool.Tool{calculatorTool}),
+    // or compute them dynamically from the parent invocation:
+    // agenttool.WithCapabilityProvider(func(ctx, parent) ([]tool.Tool, map[string]bool) { ... }),
+
+    // Toggle which fields the model may set:
+    // agenttool.WithExposeToolSelection(true),  // default
+    // agenttool.WithExposeInstruction(true),    // default
+    // agenttool.WithExposeSkillSelection(true), // default false
+
+    // Rename the entrypoint (default "dynamic_agent"):
+    // agenttool.WithName("explore"),
+
+    // Streaming / result shaping (shared with NewTool):
+    agenttool.WithStreamInner(true),
+    agenttool.WithInnerTextMode(agenttool.InnerTextModeInclude),
+    agenttool.WithSkipSummarization(true),
+    agenttool.WithResponseMode(agenttool.ResponseModeFinalOnly),
+)
+```
+
+### Safety guarantees
+
+- The model can never select an arbitrary agent, model, or executor — only a
+  subset of the permitted tools inside the configured boundary.
+- The dynamic tool and `transfer_to_agent` are always removed from the
+  sub-agent's surface, preventing runaway recursion.
+- The sub-agent is isolated by default (`HistoryScopeIsolated`): it cannot see
+  the parent conversation, so the `request` must be self-contained.

--- a/examples/dynamicagenttool/README.md
+++ b/examples/dynamicagenttool/README.md
@@ -38,7 +38,7 @@ The example ships two modes; choose one with `-mode` (default `minimal`).
 
 The orchestrator registers the workspace tools **and** `dynamic_agent`:
 
-```
+```text
 orchestrator (main agent)
 ├── calculator        (function tool)
 ├── current_time      (function tool)
@@ -62,7 +62,7 @@ this mode is about the simplest possible onboarding.
 The orchestrator registers **only** `dynamic_agent`; the workspace tools live
 behind its capability surface:
 
-```
+```text
 orchestrator (main agent)
 └── dynamic_agent     (dynamic AgentTool)
         ├── capability tools: calculator, current_time, word_count
@@ -177,7 +177,7 @@ orchestrator := llmagent.New(
 
 ## Sample transcript
 
-```
+```text
 👤 You: Use one sub-agent to compute 50 * 12, and a separate sub-agent to count
         the words in "the quick brown fox jumps". Grant each only the tool it needs.
 🤖 Assistant: I'll create two separate sub-agents, each with only the tool they need.

--- a/examples/dynamicagenttool/main.go
+++ b/examples/dynamicagenttool/main.go
@@ -1,0 +1,544 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+// Package main demonstrates the dynamic AgentTool (agenttool.NewDynamicTool):
+// a single, code-defined "dynamic_agent" entrypoint that spins up a
+// short-lived sub-agent whose capability surface (tools and per-call
+// instruction) is selected by the model within a safety boundary.
+//
+// Run with -mode=minimal (default) to register the workspace tools and
+// dynamic_agent on the orchestrator, or -mode=bounded to register only
+// dynamic_agent and keep the tools behind WithCapabilityTools + a template
+// (progressive tool disclosure + least-privilege delegation).
+package main
+
+import (
+	"bufio"
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/model/openai"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+	agenttool "trpc.group/trpc-go/trpc-agent-go/tool/agent"
+	"trpc.group/trpc-go/trpc-agent-go/tool/function"
+)
+
+const (
+	// defaultModelName works with the OpenAI-compatible proxy. The proxy also
+	// supports e.g. "gpt-5" and "deepseek-v4-flash"; override with -model.
+	defaultModelName     = "claude-4-5-sonnet-20250929"
+	defaultInnerTextMode = string(agenttool.InnerTextModeInclude)
+	orchestratorName     = "orchestrator"
+	subAgentName         = "subagent"
+
+	// modeMinimal registers the workspace tools and dynamic_agent on the
+	// orchestrator so the model narrows the tool subset per call (simplest
+	// onboarding; the sub-agent reuses the parent's identity).
+	modeMinimal = "minimal"
+	// modeBounded registers only dynamic_agent on the orchestrator and keeps the
+	// workspace tools behind WithCapabilityTools + a template, so the parent
+	// model sees just the tool-name enum while full tool schemas surface only
+	// inside the short-lived sub-agent (progressive disclosure + least
+	// privilege).
+	modeBounded = "bounded"
+)
+
+var (
+	modelName = flag.String(
+		"model",
+		defaultModelName,
+		"Name of the model to use",
+	)
+	debugAuthors = flag.Bool(
+		"debug",
+		false,
+		"Print event author names with streamed text",
+	)
+	showTool = flag.Bool(
+		"show-tool",
+		false,
+		"Show tool outputs (tool.response) in the transcript",
+	)
+	showInner = flag.Bool(
+		"show-inner",
+		true,
+		"Show the sub-agent transcript forwarded by the dynamic tool",
+	)
+	innerTextMode = flag.String(
+		"inner-text",
+		defaultInnerTextMode,
+		"Inner text mode: include or exclude",
+	)
+	demoModeFlag = flag.String(
+		"mode",
+		modeMinimal,
+		"Demo mode: 'minimal' (orchestrator registers the workspace tools + "+
+			"dynamic_agent) or 'bounded' (orchestrator registers only "+
+			"dynamic_agent; tools live behind WithCapabilityTools + a "+
+			"template, showing progressive tool disclosure)",
+	)
+)
+
+func main() {
+	flag.Parse()
+
+	mode, err := parseInnerTextMode(*innerTextMode)
+	if err != nil {
+		log.Fatalf("invalid -inner-text: %v", err)
+	}
+
+	demoMode := strings.ToLower(strings.TrimSpace(*demoModeFlag))
+	if demoMode == "" {
+		demoMode = modeMinimal
+	}
+	if demoMode != modeMinimal && demoMode != modeBounded {
+		log.Fatalf("invalid -mode %q (want %q or %q)",
+			*demoModeFlag, modeMinimal, modeBounded)
+	}
+
+	if os.Getenv("OPENAI_API_KEY") == "" {
+		fmt.Println("⚠️  OPENAI_API_KEY is not set. Export it (and optionally " +
+			"OPENAI_BASE_URL) before running, e.g.:")
+		fmt.Println(`    export OPENAI_BASE_URL="https://api.openai.com/v1"`)
+		fmt.Println(`    export OPENAI_API_KEY="<your-key>"`)
+		fmt.Println()
+	}
+
+	fmt.Printf("🚀 Dynamic Sub-Agent Tool Example\n")
+	fmt.Printf("Model: %s\n", *modelName)
+	fmt.Printf("Mode: %s\n", demoMode)
+	fmt.Printf("Show inner: %t\n", *showInner)
+	fmt.Printf("Inner text mode: %s\n", mode)
+	fmt.Printf("Show tool: %t\n", *showTool)
+	if demoMode == modeBounded {
+		fmt.Printf("Workspace tools: calculator, current_time, word_count " +
+			"(behind dynamic_agent's capability surface)\n")
+	} else {
+		fmt.Printf("Workspace tools: calculator, current_time, word_count " +
+			"(+ dynamic_agent, all registered on the orchestrator)\n")
+	}
+	fmt.Printf("Dynamic tool: %s (runs a focused sub-agent)\n",
+		agenttool.DefaultDynamicToolName)
+	fmt.Println(strings.Repeat("=", 50))
+
+	chat := &dynamicChat{
+		modelName:     *modelName,
+		mode:          demoMode,
+		debugAuthors:  *debugAuthors,
+		showTool:      *showTool,
+		showInner:     *showInner,
+		innerTextMode: mode,
+	}
+	if err := chat.run(); err != nil {
+		log.Fatalf("Chat failed: %v", err)
+	}
+}
+
+// dynamicChat manages the conversation with the dynamic sub-agent tool.
+type dynamicChat struct {
+	modelName     string
+	mode          string
+	runner        runner.Runner
+	userID        string
+	sessionID     string
+	agentName     string
+	debugAuthors  bool
+	showTool      bool
+	showInner     bool
+	innerTextMode agenttool.InnerTextMode
+}
+
+// run starts the interactive chat session.
+func (c *dynamicChat) run() error {
+	ctx := context.Background()
+	if err := c.setup(ctx); err != nil {
+		return fmt.Errorf("setup failed: %w", err)
+	}
+	defer c.runner.Close()
+	return c.startChat(ctx)
+}
+
+// setup wires the orchestrator agent, its workspace tools, and the dynamic
+// sub-agent tool, then builds the runner.
+func (c *dynamicChat) setup(_ context.Context) error {
+	modelInstance := openai.New(c.modelName)
+
+	// Workspace tools the sub-agent may use. In minimal mode they are also
+	// registered directly on the orchestrator; in bounded mode they live ONLY
+	// behind the dynamic tool's capability surface.
+	calculatorTool := function.NewFunctionTool(
+		c.calculate,
+		function.WithName("calculator"),
+		function.WithDescription(
+			"Perform one basic arithmetic operation (add, subtract, "+
+				"multiply, divide) on two numbers.",
+		),
+	)
+	timeTool := function.NewFunctionTool(
+		c.getCurrentTime,
+		function.WithName("current_time"),
+		function.WithDescription(
+			"Get the current time and date for a timezone "+
+				"(UTC, EST, PST, CST, or local).",
+		),
+	)
+	wordCountTool := function.NewFunctionTool(
+		c.wordCount,
+		function.WithName("word_count"),
+		function.WithDescription(
+			"Count the words and characters in a piece of text.",
+		),
+	)
+	workspaceTools := []tool.Tool{calculatorTool, timeTool, wordCountTool}
+
+	orchestratorTools, instruction := c.buildModeSetup(
+		modelInstance, workspaceTools,
+	)
+
+	c.agentName = orchestratorName
+	orchestrator := llmagent.New(
+		c.agentName,
+		llmagent.WithModel(modelInstance),
+		llmagent.WithDescription(
+			"An orchestrator that delegates focused subtasks to "+
+				"short-lived sub-agents.",
+		),
+		llmagent.WithInstruction(instruction),
+		llmagent.WithGenerationConfig(model.GenerationConfig{
+			MaxTokens:   intPtr(2000),
+			Temperature: floatPtr(0.7),
+			Stream:      true,
+		}),
+		llmagent.WithTools(orchestratorTools),
+	)
+
+	c.runner = runner.NewRunner("dynamic-agenttool-chat", orchestrator)
+	c.userID = "user"
+	c.sessionID = fmt.Sprintf("chat-session-%d", time.Now().UnixNano())
+
+	fmt.Printf("✅ Chat ready! Session: %s\n\n", c.sessionID)
+	return nil
+}
+
+// buildModeSetup wires the dynamic tool, the orchestrator's tool set, and the
+// orchestrator instruction for the selected demo mode.
+//
+//   - minimal: the orchestrator registers the workspace tools AND dynamic_agent.
+//     The dynamic tool derives its max surface from the parent at call time (no
+//     template, no capability tools) and the model narrows the subset per call.
+//   - bounded: the orchestrator registers ONLY dynamic_agent. The workspace
+//     tools live behind WithCapabilityTools + a template, so the parent model
+//     sees just the tool-name enum while full tool schemas surface only inside
+//     the short-lived sub-agent (progressive disclosure + least privilege).
+func (c *dynamicChat) buildModeSetup(
+	modelInstance model.Model,
+	workspaceTools []tool.Tool,
+) (orchestratorTools []tool.Tool, instruction string) {
+	// Result-shaping options shared by both modes.
+	common := []agenttool.Option{
+		agenttool.WithStreamInner(c.showInner),
+		agenttool.WithInnerTextMode(c.innerTextMode),
+		agenttool.WithSkipSummarization(true),
+		// The sub-agent does its own multi-step work; surface only its last
+		// complete message as the tool result (instead of concatenating every
+		// streamed chunk).
+		agenttool.WithResponseMode(agenttool.ResponseModeFinalOnly),
+	}
+
+	if c.mode == modeBounded {
+		// Template agent: a distinct, tool-less identity that fixes the
+		// sub-agent's execution boundary (model, identity, default role). The
+		// selected tools are injected per call via a runtime surface patch, so
+		// the sub-agent's streamed output is easy to tell apart from the
+		// orchestrator.
+		subTemplate := llmagent.New(
+			subAgentName,
+			llmagent.WithModel(modelInstance),
+			llmagent.WithDescription("A short-lived, focused worker sub-agent."),
+			llmagent.WithInstruction(
+				"You are a focused worker sub-agent. Complete the single task "+
+					"in the request using ONLY the tools you were granted, then "+
+					"report the result concisely. You cannot see the parent "+
+					"conversation, so rely solely on the request.",
+			),
+			llmagent.WithGenerationConfig(model.GenerationConfig{
+				MaxTokens:   intPtr(1000),
+				Temperature: floatPtr(0.3),
+				Stream:      true,
+			}),
+		)
+		opts := append([]agenttool.Option{
+			agenttool.WithTemplateAgent(subTemplate),
+			// The tools live ONLY here: the parent model sees their names in the
+			// dynamic_agent "tools" enum, but their full parameter schemas
+			// surface only inside the sub-agent once selected.
+			agenttool.WithCapabilityTools(workspaceTools),
+		}, common...)
+		dynamicTool := agenttool.NewDynamicTool(opts...)
+		return []tool.Tool{dynamicTool}, boundedOrchestratorInstruction
+	}
+
+	// minimal: no template and no capability tools; the surface is derived from
+	// the orchestrator (which also exposes the workspace tools directly).
+	dynamicTool := agenttool.NewDynamicTool(common...)
+	orchestratorTools = append(orchestratorTools, workspaceTools...)
+	orchestratorTools = append(orchestratorTools, dynamicTool)
+	return orchestratorTools, minimalOrchestratorInstruction
+}
+
+// minimalOrchestratorInstruction is used in minimal mode, where the
+// orchestrator also has the workspace tools registered directly.
+const minimalOrchestratorInstruction = "You are an orchestrator. You have " +
+	"three direct tools (calculator, current_time, word_count) and a special " +
+	"'dynamic_agent' tool that runs a short-lived sub-agent.\n\n" +
+	"Use direct tools for simple one-step answers. Use 'dynamic_agent' according " +
+	"to its tool description when a task should be delegated to a focused child " +
+	"run.\n\n" +
+	"When you call 'dynamic_agent':\n" +
+	"- Put EVERYTHING the sub-agent needs into 'request'; by default it cannot " +
+	"see this conversation.\n" +
+	"- Use 'tools' to grant only the minimal tools the subtask needs " +
+	"(by exact name).\n" +
+	"- Use 'instruction' to give the sub-agent a clear role for that task.\n\n" +
+	"If the user asks for two independent subtasks, you may run two separate " +
+	"sub-agents. After a sub-agent returns, summarize its result for the user."
+
+// boundedOrchestratorInstruction is used in bounded mode, where the
+// orchestrator's ONLY tool is dynamic_agent; the workspace tools live behind
+// its capability surface and can only be used by spawning a sub-agent.
+const boundedOrchestratorInstruction = "You are an orchestrator. Your ONLY " +
+	"tool is 'dynamic_agent', which runs a short-lived sub-agent. You cannot " +
+	"call calculator, current_time, or word_count directly; delegate every " +
+	"subtask by spawning a sub-agent.\n\n" +
+	"When you call 'dynamic_agent':\n" +
+	"- Put EVERYTHING the sub-agent needs into 'request'; by default it cannot " +
+	"see this conversation.\n" +
+	"- Use 'tools' to grant only the minimal tools the subtask needs, choosing " +
+	"from the names offered by the 'tools' field (by exact name).\n" +
+	"- Use 'instruction' to give the sub-agent a clear role for that task.\n\n" +
+	"If the user asks for two independent subtasks, you may run two separate " +
+	"sub-agents. After a sub-agent returns, summarize its result for the user."
+
+// startChat runs the interactive conversation loop.
+func (c *dynamicChat) startChat(ctx context.Context) error {
+	scanner := bufio.NewScanner(os.Stdin)
+	fmt.Println("💡 Try:")
+	fmt.Println("   • Use a sub-agent to compute (123 * 456) + 789.")
+	fmt.Println("   • Use a sub-agent to tell me the current time in UTC.")
+	fmt.Println("   • Count the words in: \"the quick brown fox\" using a sub-agent.")
+	fmt.Println("   Commands: /new (new session), /exit (quit)")
+	fmt.Println()
+
+	for {
+		fmt.Print("👤 You: ")
+		if !scanner.Scan() {
+			break
+		}
+		userInput := strings.TrimSpace(scanner.Text())
+		if userInput == "" {
+			continue
+		}
+		switch strings.ToLower(userInput) {
+		case "/exit":
+			fmt.Println("👋 Goodbye!")
+			return nil
+		case "/new":
+			c.startNewSession()
+			continue
+		}
+		if err := c.processMessage(ctx, userInput); err != nil {
+			fmt.Printf("❌ Error: %v\n", err)
+		}
+		fmt.Println()
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("input scanner error: %w", err)
+	}
+	return nil
+}
+
+// processMessage handles a single message exchange.
+func (c *dynamicChat) processMessage(
+	ctx context.Context,
+	userMessage string,
+) error {
+	message := model.NewUserMessage(userMessage)
+	eventChan, err := c.runner.Run(ctx, c.userID, c.sessionID, message)
+	if err != nil {
+		return fmt.Errorf("failed to run agent: %w", err)
+	}
+	return c.processStreamingResponse(eventChan)
+}
+
+// processStreamingResponse handles streaming with tool call visualization.
+func (c *dynamicChat) processStreamingResponse(
+	eventChan <-chan *event.Event,
+) error {
+	fmt.Print("🤖 Assistant: ")
+	var (
+		assistantStarted bool
+		fullContent      strings.Builder
+	)
+	for ev := range eventChan {
+		c.handleEvent(ev, &assistantStarted, &fullContent)
+	}
+	fmt.Println()
+	return nil
+}
+
+// handleEvent processes one event.
+func (c *dynamicChat) handleEvent(
+	ev *event.Event,
+	assistantStarted *bool,
+	fullContent *strings.Builder,
+) {
+	if ev.Error != nil {
+		fmt.Printf("\n❌ Error: %s\n", ev.Error.Message)
+		return
+	}
+	if c.handleToolCalls(ev, assistantStarted) {
+		return
+	}
+	if c.handleInnerAgentStreaming(ev) {
+		return
+	}
+	if c.handleAssistantStreaming(ev, assistantStarted, fullContent) {
+		return
+	}
+	c.handleToolResponses(ev)
+}
+
+// handleToolCalls prints tool call markers (including dynamic_agent args).
+func (c *dynamicChat) handleToolCalls(
+	ev *event.Event,
+	assistantStarted *bool,
+) bool {
+	if ev.Response == nil || len(ev.Response.Choices) == 0 {
+		return false
+	}
+	ch := ev.Response.Choices[0]
+	if len(ch.Message.ToolCalls) == 0 {
+		return false
+	}
+	if *assistantStarted {
+		fmt.Printf("\n")
+	}
+	fmt.Printf("🔧 Tool calls initiated:\n")
+	for _, tc := range ch.Message.ToolCalls {
+		fmt.Printf("   • %s (ID: %s)\n", tc.Function.Name, tc.ID)
+		if len(tc.Function.Arguments) > 0 {
+			fmt.Printf("     Args: %s\n", string(tc.Function.Arguments))
+		}
+	}
+	fmt.Printf("\n🔄 Executing tools...\n")
+	return true
+}
+
+// handleInnerAgentStreaming prints forwarded prose from a distinct child agent.
+// In minimal mode the dynamic child reuses the orchestrator identity, so its
+// text is handled like normal assistant streaming instead of being separated
+// here.
+func (c *dynamicChat) handleInnerAgentStreaming(ev *event.Event) bool {
+	if !c.showInner ||
+		ev.Author == c.agentName ||
+		ev.Response == nil ||
+		len(ev.Response.Choices) == 0 {
+		return false
+	}
+	ch := ev.Response.Choices[0]
+	if ch.Delta.Content == "" {
+		return false
+	}
+	if c.debugAuthors {
+		fmt.Printf("[%s] ", ev.Author)
+	}
+	fmt.Print(ch.Delta.Content)
+	return true
+}
+
+// handleAssistantStreaming prints the orchestrator's own streamed text.
+func (c *dynamicChat) handleAssistantStreaming(
+	ev *event.Event,
+	assistantStarted *bool,
+	fullContent *strings.Builder,
+) bool {
+	if ev.Author != c.agentName ||
+		ev.Response == nil ||
+		len(ev.Response.Choices) == 0 {
+		return false
+	}
+	ch := ev.Response.Choices[0]
+	if ch.Delta.Content == "" {
+		return false
+	}
+	if c.debugAuthors && !*assistantStarted {
+		fmt.Printf("[%s] ", ev.Author)
+	}
+	*assistantStarted = true
+	fmt.Print(ch.Delta.Content)
+	fullContent.WriteString(ch.Delta.Content)
+	return true
+}
+
+// handleToolResponses optionally prints the aggregated tool.response.
+func (c *dynamicChat) handleToolResponses(ev *event.Event) bool {
+	if ev.Response == nil ||
+		ev.Object != model.ObjectTypeToolResponse ||
+		len(ev.Response.Choices) == 0 {
+		return false
+	}
+	ch := ev.Response.Choices[0]
+	if ch.Delta.Content != "" {
+		if c.showTool && !c.showInner {
+			fmt.Printf("\n🛠️  tool> %s", ch.Delta.Content)
+		}
+		return true
+	}
+	if ch.Message.Content != "" {
+		if c.showTool {
+			fmt.Printf(
+				"\n✅ Tool response (ID: %s): %s\n",
+				ch.Message.ToolID,
+				strings.TrimSpace(ch.Message.Content),
+			)
+		} else {
+			fmt.Printf("\n✅ Tool execution completed.\n")
+		}
+		return true
+	}
+	fmt.Printf("\n✅ Tool execution completed.\n")
+	return true
+}
+
+// startNewSession creates a new session.
+func (c *dynamicChat) startNewSession() {
+	c.sessionID = fmt.Sprintf("chat-session-%d", time.Now().UnixNano())
+	fmt.Printf("🔄 New session started: %s\n\n", c.sessionID)
+}
+
+func parseInnerTextMode(mode string) (agenttool.InnerTextMode, error) {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "", string(agenttool.InnerTextModeInclude):
+		return agenttool.InnerTextModeInclude, nil
+	case string(agenttool.InnerTextModeExclude):
+		return agenttool.InnerTextModeExclude, nil
+	default:
+		return "", fmt.Errorf("unsupported mode %q", mode)
+	}
+}

--- a/examples/dynamicagenttool/tools.go
+++ b/examples/dynamicagenttool/tools.go
@@ -1,0 +1,153 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// calculate performs one basic arithmetic operation.
+func (c *dynamicChat) calculate(
+	_ context.Context,
+	args calculatorArgs,
+) (calculatorResult, error) {
+	var result float64
+	switch args.Operation {
+	case "add":
+		result = args.A + args.B
+	case "subtract":
+		result = args.A - args.B
+	case "multiply":
+		result = args.A * args.B
+	case "divide":
+		if args.B == 0 {
+			return calculatorResult{
+				Operation: args.Operation,
+				A:         args.A,
+				B:         args.B,
+				Error:     "Division by zero",
+			}, fmt.Errorf("division by zero")
+		}
+		result = args.A / args.B
+	default:
+		return calculatorResult{
+			Operation: args.Operation,
+			A:         args.A,
+			B:         args.B,
+			Error:     "Unknown operation",
+		}, fmt.Errorf("unknown operation %q", args.Operation)
+	}
+	return calculatorResult{
+		Operation: args.Operation,
+		A:         args.A,
+		B:         args.B,
+		Result:    result,
+	}, nil
+}
+
+// getCurrentTime returns the current time for a specific timezone.
+func (c *dynamicChat) getCurrentTime(
+	_ context.Context,
+	args timeArgs,
+) (timeResult, error) {
+	loc := time.Local
+	if args.Timezone != "" {
+		switch strings.ToUpper(args.Timezone) {
+		case "UTC":
+			loc = time.UTC
+		case "EST":
+			loc = time.FixedZone("EST", -5*3600)
+		case "PST":
+			loc = time.FixedZone("PST", -8*3600)
+		case "CST":
+			loc = time.FixedZone("CST", -6*3600)
+		default:
+			return timeResult{}, fmt.Errorf(
+				"unsupported timezone %q", args.Timezone,
+			)
+		}
+	}
+	now := time.Now().In(loc)
+	return timeResult{
+		Timezone: args.Timezone,
+		Time:     now.Format("15:04:05"),
+		Date:     now.Format("2006-01-02"),
+		Weekday:  now.Format("Monday"),
+	}, nil
+}
+
+// wordCount counts the words and characters in a piece of text.
+func (c *dynamicChat) wordCount(
+	_ context.Context,
+	args wordCountArgs,
+) (wordCountResult, error) {
+	trimmed := strings.TrimSpace(args.Text)
+	words := 0
+	if trimmed != "" {
+		words = len(strings.Fields(trimmed))
+	}
+	return wordCountResult{
+		Words:      words,
+		Characters: len([]rune(args.Text)),
+	}, nil
+}
+
+// calculatorArgs defines the input arguments for the calculator tool.
+type calculatorArgs struct {
+	Operation string  `json:"operation" jsonschema:"description=The operation to perform,enum=add,enum=subtract,enum=multiply,enum=divide"`
+	A         float64 `json:"a" jsonschema:"description=First number"`
+	B         float64 `json:"b" jsonschema:"description=Second number"`
+}
+
+// calculatorResult defines the output result for the calculator tool.
+type calculatorResult struct {
+	Operation string  `json:"operation"`
+	A         float64 `json:"a"`
+	B         float64 `json:"b"`
+	Result    float64 `json:"result"`
+	Error     string  `json:"error,omitempty"`
+}
+
+// timeArgs defines the input arguments for the time tool.
+type timeArgs struct {
+	Timezone string `json:"timezone" jsonschema:"description=Timezone (UTC/EST/PST/CST) or leave empty for local"`
+}
+
+// timeResult defines the output result for the time tool.
+type timeResult struct {
+	Timezone string `json:"timezone"`
+	Time     string `json:"time"`
+	Date     string `json:"date"`
+	Weekday  string `json:"weekday"`
+}
+
+// wordCountArgs defines the input arguments for the word_count tool.
+type wordCountArgs struct {
+	Text string `json:"text" jsonschema:"description=The text to analyze"`
+}
+
+// wordCountResult defines the output result for the word_count tool.
+type wordCountResult struct {
+	Words      int `json:"words"`
+	Characters int `json:"characters"`
+}
+
+// Helper functions for creating pointers.
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func floatPtr(f float64) *float64 {
+	return &f
+}

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -16,7 +16,6 @@ import (
 	"errors"
 	"fmt"
 	"runtime/debug"
-	"sort"
 	"time"
 
 	"github.com/google/uuid"
@@ -33,6 +32,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/steer"
 	itelemetry "trpc.group/trpc-go/trpc-agent-go/internal/telemetry"
 	"trpc.group/trpc-go/trpc-agent-go/internal/toolcall"
+	"trpc.group/trpc-go/trpc-agent-go/internal/toolsurface"
 	itrace "trpc.group/trpc-go/trpc-agent-go/internal/trace"
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/model"
@@ -1426,30 +1426,6 @@ func contextCompactionThreshold(inv *agent.Invocation, ratio float64) int {
 	return threshold
 }
 
-// UserToolsProvider is an optional interface that agents can implement to expose
-// which tools were explicitly registered by the user (WithTools, WithToolSets)
-// vs framework-added tools (Knowledge, SubAgents).
-//
-// User tools are subject to filtering via WithToolFilter.
-// Framework tools are never filtered and always available to the agent.
-type UserToolsProvider interface {
-	UserTools() []tool.Tool
-}
-
-// ToolFilterProvider is an optional interface that agents can implement to provide
-type ToolFilterProvider interface {
-	FilterTools(ctx context.Context) []tool.Tool
-}
-
-// InvocationToolSurfaceProvider is an optional interface that exposes
-// invocation-scoped tools and user-tool classification.
-type InvocationToolSurfaceProvider interface {
-	InvocationToolSurface(
-		ctx context.Context,
-		invocation *agent.Invocation,
-	) ([]tool.Tool, map[string]bool)
-}
-
 // getFilteredTools returns the list of tools for this invocation after applying the filter.
 //
 // User tools (can be filtered):
@@ -1473,36 +1449,12 @@ func (f *Flow) getFilteredTools(ctx context.Context, invocation *agent.Invocatio
 		return cached
 	}
 
-	var allTools []tool.Tool
-	var userToolNames map[string]bool
-	hasUserToolTracking := false
-	if provider, ok := invocation.Agent.(InvocationToolSurfaceProvider); ok {
-		allTools, userToolNames = provider.InvocationToolSurface(
-			ctx,
-			invocation,
-		)
-		hasUserToolTracking = userToolNames != nil
-	} else if provider, ok := invocation.Agent.(ToolFilterProvider); ok {
-		allTools = provider.FilterTools(ctx)
-	} else {
-		allTools = invocation.Agent.Tools()
-	}
-
-	// Get user tools (if the agent supports it).
-	// User tools are those explicitly registered via WithTools and
-	// WithToolSets. Framework tools (Knowledge, SubAgents) are never filtered.
-	if invocation.RunOptions.ToolFilter != nil && !hasUserToolTracking {
-		if provider, ok := invocation.Agent.(UserToolsProvider); ok {
-			userTools := provider.UserTools()
-			hasUserToolTracking = true
-			userToolNames = make(map[string]bool, len(userTools))
-			for _, t := range userTools {
-				userToolNames[t.Declaration().Name] = true
-			}
-		}
-	}
+	allTools, userToolNames, hasUserToolTracking := toolsurface.ResolveBase(
+		ctx,
+		invocation,
+	)
 	allTools, userToolNames, hasUserToolTracking, externalToolNames :=
-		appendRunOptionTools(
+		toolsurface.AppendRunOptionTools(
 			allTools,
 			userToolNames,
 			hasUserToolTracking,
@@ -1511,6 +1463,7 @@ func (f *Flow) getFilteredTools(ctx context.Context, invocation *agent.Invocatio
 
 	// If no filter is specified, return all tools for this invocation.
 	if invocation.RunOptions.ToolFilter == nil {
+		allTools = sanitizeTools(allTools)
 		setVisibleExternalToolNames(invocation, allTools, externalToolNames)
 		invocation.SetState(stateKeyToolsSnapshot, allTools)
 		invocation.SetState(
@@ -1520,33 +1473,16 @@ func (f *Flow) getFilteredTools(ctx context.Context, invocation *agent.Invocatio
 		return allTools
 	}
 
-	// Apply the filter function to each tool.
-	// Framework tools are never filtered.
-	filtered := make([]tool.Tool, 0, len(allTools))
-	for _, t := range allTools {
-		toolName := t.Declaration().Name
-
-		// Determine if this is a user tool or framework tool.
-		isUserTool := !hasUserToolTracking || userToolNames[toolName]
-
-		// Framework tools are always included (never filtered).
-		if !isUserTool {
-			filtered = append(filtered, t)
-			continue
-		}
-
-		// User tool: apply the filter function.
-		if invocation.RunOptions.ToolFilter(ctx, t) {
-			filtered = append(filtered, t)
-		}
-	}
-
-	// Sort tools by name to ensure stable order for better prompt cache hit rate.
-	// Map iteration order is random in Go, so sorting ensures consistent tool ordering
-	// across requests, which improves cache efficiency.
-	sort.Slice(filtered, func(i, j int) bool {
-		return filtered[i].Declaration().Name < filtered[j].Declaration().Name
-	})
+	// Framework tools are never filtered; user tools must pass the run-scoped
+	// filter. Shared via toolsurface so getFilteredTools and the dynamic tool's
+	// surface derivation stay in lockstep.
+	filtered := toolsurface.ApplyToolFilter(
+		ctx,
+		allTools,
+		userToolNames,
+		hasUserToolTracking,
+		invocation.RunOptions,
+	)
 
 	setVisibleExternalToolNames(invocation, filtered, externalToolNames)
 	invocation.SetState(stateKeyToolsSnapshot, filtered)
@@ -1558,90 +1494,17 @@ func (f *Flow) getFilteredTools(ctx context.Context, invocation *agent.Invocatio
 	return filtered
 }
 
-func appendRunOptionTools(
-	allTools []tool.Tool,
-	userToolNames map[string]bool,
-	hasUserToolTracking bool,
-	opts agent.RunOptions,
-) ([]tool.Tool, map[string]bool, bool, map[string]bool) {
-	if len(opts.AdditionalTools) == 0 && len(opts.ExternalTools) == 0 {
-		return allTools, userToolNames, hasUserToolTracking, nil
+func sanitizeTools(tools []tool.Tool) []tool.Tool {
+	if len(tools) == 0 {
+		return nil
 	}
-	allTools = append([]tool.Tool(nil), allTools...)
-	if hasUserToolTracking {
-		userToolNames = copyToolNames(userToolNames)
-	}
-	serverNames := collectToolNames(allTools)
-	seen := copyToolNames(serverNames)
-	allTools, userToolNames = appendRunOptionToolList(
-		allTools,
-		userToolNames,
-		hasUserToolTracking,
-		seen,
-		opts.AdditionalTools,
-	)
-	externalNames := make(map[string]bool, len(opts.ExternalTools))
-	for _, tl := range opts.ExternalTools {
-		name := toolName(tl)
-		if name == "" || serverNames[name] {
-			continue
-		}
-		if seen[name] {
-			continue
-		}
-		seen[name] = true
-		allTools = append(allTools, tl)
-		externalNames[name] = true
-		if hasUserToolTracking {
-			if userToolNames == nil {
-				userToolNames = make(map[string]bool)
-			}
-			userToolNames[name] = true
-		}
-	}
-	return allTools, userToolNames, hasUserToolTracking, externalNames
-}
-
-func appendRunOptionToolList(
-	allTools []tool.Tool,
-	userToolNames map[string]bool,
-	hasUserToolTracking bool,
-	seen map[string]bool,
-	tools []tool.Tool,
-) ([]tool.Tool, map[string]bool) {
+	out := make([]tool.Tool, 0, len(tools))
 	for _, tl := range tools {
-		name := toolName(tl)
-		if name == "" || seen[name] {
-			continue
-		}
-		seen[name] = true
-		allTools = append(allTools, tl)
-		if hasUserToolTracking {
-			if userToolNames == nil {
-				userToolNames = make(map[string]bool)
-			}
-			userToolNames[name] = true
+		if toolName(tl) != "" {
+			out = append(out, tl)
 		}
 	}
-	return allTools, userToolNames
-}
-
-func collectToolNames(tools []tool.Tool) map[string]bool {
-	names := make(map[string]bool, len(tools))
-	for _, tl := range tools {
-		if name := toolName(tl); name != "" {
-			names[name] = true
-		}
-	}
-	return names
-}
-
-func copyToolNames(src map[string]bool) map[string]bool {
-	dst := make(map[string]bool, len(src))
-	for name, ok := range src {
-		dst[name] = ok
-	}
-	return dst
+	return out
 }
 
 func setVisibleExternalToolNames(

--- a/internal/flow/llmflow/tool_filter_test.go
+++ b/internal/flow/llmflow/tool_filter_test.go
@@ -32,6 +32,16 @@ func (m *mockTool) Call(context.Context, []byte) (any, error) {
 	return nil, nil
 }
 
+type nilDeclarationTool struct{}
+
+func (nilDeclarationTool) Declaration() *tool.Declaration {
+	return nil
+}
+
+func (nilDeclarationTool) Call(context.Context, []byte) (any, error) {
+	return nil, nil
+}
+
 func hasToolName(tools []tool.Tool, name string) bool {
 	for _, tl := range tools {
 		if tl.Declaration().Name == name {
@@ -324,6 +334,31 @@ func TestGetFilteredTools_NoFilter(t *testing.T) {
 	if !hasUserTools {
 		t.Fatal("expected cached state to report user tools when the snapshot still includes them")
 	}
+}
+
+func TestGetFilteredTools_NoFilterSkipsInvalidTools(t *testing.T) {
+	f := New(nil, nil, Options{})
+
+	validTool := &mockTool{name: "valid_tool"}
+	mockAgent := &mockAgentWithUserTools{
+		name:      "test-agent",
+		allTools:  []tool.Tool{nil, nilDeclarationTool{}, validTool},
+		userTools: []tool.Tool{nil, nilDeclarationTool{}, validTool},
+	}
+
+	inv := agent.NewInvocation()
+	inv.Agent = mockAgent
+	inv.AgentName = "test-agent"
+
+	filtered := f.getFilteredTools(context.Background(), inv)
+
+	require.Len(t, filtered, 1)
+	require.Equal(t, "valid_tool", filtered[0].Declaration().Name)
+
+	snapshot, ok := agent.GetStateValue[[]tool.Tool](inv, stateKeyToolsSnapshot)
+	require.True(t, ok)
+	require.Len(t, snapshot, 1)
+	require.Equal(t, "valid_tool", snapshot[0].Declaration().Name)
 }
 
 func TestGetFilteredTools_CachesFilteredUserToolPresence(t *testing.T) {

--- a/internal/surfacepatch/patch.go
+++ b/internal/surfacepatch/patch.go
@@ -54,6 +54,13 @@ type Patch struct {
 	model             modelSlot
 	tools             toolsSlot
 	skillRepo         skillRepoSlot
+
+	// suppressSubAgentTransfer, when true, omits framework-managed sub-agent
+	// transfer (the transfer_to_agent tool, auto-added when the node's agent
+	// has sub-agents) from the node's tool surface. Unlike the tool slot it is
+	// not a value override: it only removes the framework tool, never a user
+	// tool, so it composes with SetTools.
+	suppressSubAgentTransfer bool
 }
 
 // SetInstruction sets the instruction surface override.
@@ -104,6 +111,14 @@ func (p *Patch) SetSkillRepository(repo skill.Repository) {
 	p.skillRepo.value = repo
 }
 
+// SetSuppressSubAgentTransfer requests that framework-managed sub-agent
+// transfer (transfer_to_agent) be omitted from the node's tool surface even
+// when the node's agent has sub-agents. The dynamic AgentTool uses this so a
+// short-lived sub-agent cannot hand control to another agent.
+func (p *Patch) SetSuppressSubAgentTransfer() {
+	p.suppressSubAgentTransfer = true
+}
+
 // Instruction returns the instruction surface override.
 func (p Patch) Instruction() (string, bool) {
 	return p.instruction.value, p.instruction.set
@@ -151,6 +166,12 @@ func (p Patch) SkillRepository() (skill.Repository, bool) {
 	return p.skillRepo.value, p.skillRepo.set
 }
 
+// SuppressSubAgentTransfer reports whether framework-managed sub-agent transfer
+// must be omitted from the node's tool surface.
+func (p Patch) SuppressSubAgentTransfer() bool {
+	return p.suppressSubAgentTransfer
+}
+
 // IsEmpty reports whether the patch carries any surface override.
 func (p Patch) IsEmpty() bool {
 	return !p.instruction.set &&
@@ -159,7 +180,8 @@ func (p Patch) IsEmpty() bool {
 		!p.model.set &&
 		!p.tools.set &&
 		len(p.tools.append) == 0 &&
-		!p.skillRepo.set
+		!p.skillRepo.set &&
+		!p.suppressSubAgentTransfer
 }
 
 // Merge returns a copy where values from other override the same surface type.
@@ -195,6 +217,9 @@ func (p Patch) Merge(other Patch) Patch {
 	if other.skillRepo.set {
 		out.skillRepo = other.skillRepo
 	}
+	if other.suppressSubAgentTransfer {
+		out.suppressSubAgentTransfer = true
+	}
 	return out
 }
 
@@ -213,7 +238,8 @@ func (p Patch) Clone() Patch {
 			value:  cloneTools(p.tools.value),
 			append: cloneTools(p.tools.append),
 		},
-		skillRepo: p.skillRepo,
+		skillRepo:                p.skillRepo,
+		suppressSubAgentTransfer: p.suppressSubAgentTransfer,
 	}
 }
 

--- a/internal/surfacepatch/patch_test.go
+++ b/internal/surfacepatch/patch_test.go
@@ -148,6 +148,28 @@ func TestPatch_TracksExplicitZeroValues(t *testing.T) {
 	require.Nil(t, repo)
 }
 
+func TestPatch_SuppressSubAgentTransferMergesAndClones(t *testing.T) {
+	var base Patch
+	require.True(t, base.IsEmpty())
+	require.False(t, base.SuppressSubAgentTransfer())
+
+	var suppress Patch
+	suppress.SetSuppressSubAgentTransfer()
+	require.False(t, suppress.IsEmpty())
+	require.True(t, suppress.SuppressSubAgentTransfer())
+
+	merged := base.Merge(suppress)
+	require.True(t, merged.SuppressSubAgentTransfer())
+
+	cloned := merged.Clone()
+	require.True(t, cloned.SuppressSubAgentTransfer())
+
+	cfgs := WithPatch(nil, "root", suppress)
+	stored, ok := PatchForNode(cfgs, "root")
+	require.True(t, ok)
+	require.True(t, stored.SuppressSubAgentTransfer())
+}
+
 func TestPatch_IgnoresNilModelOverride(t *testing.T) {
 	var patch Patch
 	patch.SetModel(nil)

--- a/internal/toolsurface/toolsurface.go
+++ b/internal/toolsurface/toolsurface.go
@@ -1,0 +1,278 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+// Package toolsurface resolves the effective tool surface for an invocation:
+// the base surface exposed by the agent plus the run-scoped tools, with the
+// run-scoped tool filter applied. It is the single source of truth shared by
+// the LLM flow (which uses it to build the model request) and by helpers such
+// as the dynamic AgentTool (which derives a child capability surface from a
+// parent invocation). Keeping the logic here avoids both behavioral drift and
+// an import cycle between the flow engine and the tool packages.
+package toolsurface
+
+import (
+	"context"
+	"sort"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+// UserToolsProvider is an optional interface that agents implement to expose
+// their user tools (those registered via WithTools/WithToolSets), so the filter
+// can distinguish them from framework-managed tools.
+type UserToolsProvider interface {
+	UserTools() []tool.Tool
+}
+
+// ToolFilterProvider is an optional interface that agents implement to provide
+// a pre-resolved tool list for an invocation.
+type ToolFilterProvider interface {
+	FilterTools(ctx context.Context) []tool.Tool
+}
+
+// ResolveBase resolves the pre-run-option tool surface for an invocation along
+// with user-tool tracking, before RunOptions tools/filter are applied.
+//
+// The returned map classifies user tools; a nil map means the agent does not
+// support user-tool tracking, in which case callers must treat all tools as
+// user tools.
+func ResolveBase(
+	ctx context.Context,
+	invocation *agent.Invocation,
+) ([]tool.Tool, map[string]bool, bool) {
+	var allTools []tool.Tool
+	var userToolNames map[string]bool
+	hasUserToolTracking := false
+	if provider, ok := invocation.Agent.(agent.InvocationToolSurfaceProvider); ok {
+		allTools, userToolNames = provider.InvocationToolSurface(ctx, invocation)
+		hasUserToolTracking = userToolNames != nil
+	} else if provider, ok := invocation.Agent.(ToolFilterProvider); ok {
+		allTools = provider.FilterTools(ctx)
+	} else {
+		allTools = invocation.Agent.Tools()
+	}
+
+	// User tools are those explicitly registered via WithTools and
+	// WithToolSets. Framework tools (Knowledge, SubAgents) are never filtered.
+	if !hasUserToolTracking {
+		if provider, ok := invocation.Agent.(UserToolsProvider); ok {
+			userTools := provider.UserTools()
+			hasUserToolTracking = true
+			userToolNames = make(map[string]bool, len(userTools))
+			for _, t := range userTools {
+				if name := toolName(t); name != "" {
+					userToolNames[name] = true
+				}
+			}
+		}
+	}
+	return allTools, userToolNames, hasUserToolTracking
+}
+
+// AppendRunOptionTools appends RunOptions.AdditionalTools and ExternalTools to
+// allTools (de-duplicated by name), tracking user-tool classification and the
+// names of any external tools that were added.
+func AppendRunOptionTools(
+	allTools []tool.Tool,
+	userToolNames map[string]bool,
+	hasUserToolTracking bool,
+	opts agent.RunOptions,
+) ([]tool.Tool, map[string]bool, bool, map[string]bool) {
+	if len(opts.AdditionalTools) == 0 && len(opts.ExternalTools) == 0 {
+		return allTools, userToolNames, hasUserToolTracking, nil
+	}
+	allTools = append([]tool.Tool(nil), allTools...)
+	if hasUserToolTracking {
+		userToolNames = copyToolNames(userToolNames)
+	}
+	serverNames := collectToolNames(allTools)
+	seen := copyToolNames(serverNames)
+	allTools, userToolNames = appendRunOptionToolList(
+		allTools,
+		userToolNames,
+		hasUserToolTracking,
+		seen,
+		opts.AdditionalTools,
+	)
+	externalNames := make(map[string]bool, len(opts.ExternalTools))
+	for _, tl := range opts.ExternalTools {
+		name := toolName(tl)
+		if name == "" || serverNames[name] {
+			continue
+		}
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		allTools = append(allTools, tl)
+		externalNames[name] = true
+		if hasUserToolTracking {
+			if userToolNames == nil {
+				userToolNames = make(map[string]bool)
+			}
+			userToolNames[name] = true
+		}
+	}
+	return allTools, userToolNames, hasUserToolTracking, externalNames
+}
+
+// ApplyToolFilter applies the run-scoped ToolFilter to allTools, always keeping
+// framework tools and keeping user tools only when the filter passes. The
+// result is sorted by name for stable prompt-cache behavior. It assumes
+// opts.ToolFilter != nil.
+func ApplyToolFilter(
+	ctx context.Context,
+	allTools []tool.Tool,
+	userToolNames map[string]bool,
+	hasUserToolTracking bool,
+	opts agent.RunOptions,
+) []tool.Tool {
+	filtered := make([]tool.Tool, 0, len(allTools))
+	for _, t := range allTools {
+		name := toolName(t)
+		if name == "" {
+			continue
+		}
+
+		// Determine if this is a user tool or framework tool.
+		isUserTool := !hasUserToolTracking || userToolNames[name]
+
+		// Framework tools are always included (never filtered).
+		if !isUserTool {
+			filtered = append(filtered, t)
+			continue
+		}
+
+		// User tool: apply the filter function.
+		if opts.ToolFilter(ctx, t) {
+			filtered = append(filtered, t)
+		}
+	}
+
+	// Sort tools by name to ensure stable order for better prompt cache hit
+	// rate. Map iteration order is random in Go, so sorting ensures consistent
+	// tool ordering across requests, which improves cache efficiency.
+	sort.Slice(filtered, func(i, j int) bool {
+		return toolName(filtered[i]) < toolName(filtered[j])
+	})
+	return filtered
+}
+
+// Effective returns the effective tool surface for the invocation: the base
+// surface (InvocationToolSurface / FilterTools / Tools) plus
+// RunOptions.AdditionalTools and ExternalTools, with the run-scoped
+// RunOptions.ToolFilter applied. It mirrors exactly what the LLM flow exposes
+// to the model, but it does not read or mutate invocation state (it
+// recomputes), so it is safe for callers that need to inspect a parent
+// invocation's current surface — for example a dynamic sub-agent tool deriving
+// a child capability surface — including when the invocation passed in is a
+// clone produced by parallel tool execution.
+//
+// The second return value classifies user tools (a nil map means the agent does
+// not support user-tool tracking; callers should treat all returned tools as
+// user tools).
+func Effective(
+	ctx context.Context,
+	invocation *agent.Invocation,
+) ([]tool.Tool, map[string]bool) {
+	tools, userToolNames, _ := EffectiveWithExternal(ctx, invocation)
+	return tools, userToolNames
+}
+
+// EffectiveWithExternal is like Effective but also returns the set of external
+// (caller-executed) tool names contributed by RunOptions.ExternalTools.
+//
+// External tools are visible-but-not-executed for the parent run; a synchronous
+// sub-agent has no channel to hand a caller-executed tool back to the original
+// caller, and folding them into a child's executed tool surface would silently
+// change their semantics. Callers deriving a child capability surface use this
+// set to exclude external tools from what the model may select.
+func EffectiveWithExternal(
+	ctx context.Context,
+	invocation *agent.Invocation,
+) ([]tool.Tool, map[string]bool, map[string]bool) {
+	if invocation == nil || invocation.Agent == nil {
+		return nil, nil, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	allTools, userToolNames, hasUserToolTracking := ResolveBase(ctx, invocation)
+	allTools, userToolNames, hasUserToolTracking, externalNames :=
+		AppendRunOptionTools(
+			allTools,
+			userToolNames,
+			hasUserToolTracking,
+			invocation.RunOptions,
+		)
+	if invocation.RunOptions.ToolFilter == nil {
+		return allTools, userToolNames, externalNames
+	}
+	return ApplyToolFilter(
+		ctx,
+		allTools,
+		userToolNames,
+		hasUserToolTracking,
+		invocation.RunOptions,
+	), userToolNames, externalNames
+}
+
+func appendRunOptionToolList(
+	allTools []tool.Tool,
+	userToolNames map[string]bool,
+	hasUserToolTracking bool,
+	seen map[string]bool,
+	tools []tool.Tool,
+) ([]tool.Tool, map[string]bool) {
+	for _, tl := range tools {
+		name := toolName(tl)
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		allTools = append(allTools, tl)
+		if hasUserToolTracking {
+			if userToolNames == nil {
+				userToolNames = make(map[string]bool)
+			}
+			userToolNames[name] = true
+		}
+	}
+	return allTools, userToolNames
+}
+
+func collectToolNames(tools []tool.Tool) map[string]bool {
+	names := make(map[string]bool, len(tools))
+	for _, tl := range tools {
+		if name := toolName(tl); name != "" {
+			names[name] = true
+		}
+	}
+	return names
+}
+
+func copyToolNames(src map[string]bool) map[string]bool {
+	dst := make(map[string]bool, len(src))
+	for name, ok := range src {
+		dst[name] = ok
+	}
+	return dst
+}
+
+func toolName(tl tool.Tool) string {
+	if tl == nil {
+		return ""
+	}
+	decl := tl.Declaration()
+	if decl == nil {
+		return ""
+	}
+	return decl.Name
+}

--- a/internal/toolsurface/toolsurface_test.go
+++ b/internal/toolsurface/toolsurface_test.go
@@ -1,0 +1,158 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package toolsurface
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+type stubSurfaceTool struct {
+	decl *tool.Declaration
+}
+
+func (s stubSurfaceTool) Declaration() *tool.Declaration {
+	return s.decl
+}
+
+type stubSurfaceAgent struct {
+	tools     []tool.Tool
+	userTools []tool.Tool
+}
+
+func (s *stubSurfaceAgent) Run(
+	context.Context,
+	*agent.Invocation,
+) (<-chan *event.Event, error) {
+	ch := make(chan *event.Event)
+	close(ch)
+	return ch, nil
+}
+
+func (s *stubSurfaceAgent) Tools() []tool.Tool {
+	return s.tools
+}
+
+func (s *stubSurfaceAgent) UserTools() []tool.Tool {
+	return s.userTools
+}
+
+func (s *stubSurfaceAgent) Info() agent.Info {
+	return agent.Info{Name: "surface-agent"}
+}
+
+func (s *stubSurfaceAgent) SubAgents() []agent.Agent {
+	return nil
+}
+
+func (s *stubSurfaceAgent) FindSubAgent(string) agent.Agent {
+	return nil
+}
+
+func TestResolveBase_UserToolTrackingSkipsInvalidTools(t *testing.T) {
+	agt := &stubSurfaceAgent{
+		tools: []tool.Tool{
+			nil,
+			surfaceTool("base"),
+		},
+		userTools: []tool.Tool{
+			nil,
+			stubSurfaceTool{},
+			surfaceTool("base"),
+		},
+	}
+	inv := agent.NewInvocation(
+		agent.WithInvocationAgent(agt),
+	)
+
+	tools, userToolNames, hasTracking := ResolveBase(context.Background(), inv)
+
+	require.Len(t, tools, 2)
+	require.True(t, hasTracking)
+	require.Equal(t, map[string]bool{"base": true}, userToolNames)
+}
+
+func TestApplyToolFilter_SkipsInvalidToolsAndSortsValidTools(t *testing.T) {
+	filteredNames := []string{}
+	opts := agent.NewRunOptions(agent.WithToolFilter(
+		func(_ context.Context, tl tool.Tool) bool {
+			filteredNames = append(filteredNames, tl.Declaration().Name)
+			return tl.Declaration().Name != "drop"
+		},
+	))
+
+	filtered := ApplyToolFilter(
+		context.Background(),
+		[]tool.Tool{
+			surfaceTool("zeta"),
+			nil,
+			stubSurfaceTool{},
+			surfaceTool("drop"),
+			surfaceTool("alpha"),
+		},
+		nil,
+		false,
+		opts,
+	)
+
+	require.Equal(t, []string{"zeta", "drop", "alpha"}, filteredNames)
+	requireToolNames(t, filtered, []string{"alpha", "zeta"})
+}
+
+func TestEffectiveWithExternal_AppendsAndClassifiesRunOptionTools(t *testing.T) {
+	agt := &stubSurfaceAgent{
+		tools:     []tool.Tool{surfaceTool("base")},
+		userTools: []tool.Tool{surfaceTool("base")},
+	}
+	inv := agent.NewInvocation(
+		agent.WithInvocationAgent(agt),
+		agent.WithInvocationRunOptions(agent.NewRunOptions(
+			agent.WithAdditionalTools([]tool.Tool{
+				nil,
+				stubSurfaceTool{},
+				surfaceTool("added"),
+			}),
+			agent.WithExternalTools([]tool.Tool{
+				surfaceTool("external"),
+				surfaceTool("base"),
+			}),
+		)),
+	)
+
+	tools, userToolNames, externalNames := EffectiveWithExternal(
+		context.Background(),
+		inv,
+	)
+
+	requireToolNames(t, tools, []string{"base", "added", "external"})
+	require.Equal(t, map[string]bool{
+		"base":     true,
+		"added":    true,
+		"external": true,
+	}, userToolNames)
+	require.Equal(t, map[string]bool{"external": true}, externalNames)
+}
+
+func surfaceTool(name string) tool.Tool {
+	return stubSurfaceTool{decl: &tool.Declaration{Name: name}}
+}
+
+func requireToolNames(t *testing.T, tools []tool.Tool, names []string) {
+	t.Helper()
+	got := make([]string, 0, len(tools))
+	for _, tl := range tools {
+		got = append(got, tl.Declaration().Name)
+	}
+	require.Equal(t, names, got)
+}

--- a/tool/agent/agent_tool.go
+++ b/tool/agent/agent_tool.go
@@ -45,6 +45,16 @@ type Tool struct {
 	description            string
 	inputSchema            *tool.Schema
 	outputSchema           *tool.Schema
+
+	// dynamic enables the dynamic AgentTool mode created by NewDynamicTool.
+	// In this mode the tool runs a short-lived sub-agent whose
+	// capability surface (tools / skills / instruction) is selected per call
+	// within a code-defined safety boundary, rather than wrapping one
+	// pre-defined agent.
+	dynamic bool
+	// dynamicCfg holds the dynamic-mode configuration. It is only consulted
+	// when dynamic is true.
+	dynamicCfg *dynamicOptions
 }
 
 // Option is a function that configures an AgentTool.
@@ -59,6 +69,42 @@ type agentToolOptions struct {
 	historyScope           HistoryScope
 	responseMode           ResponseMode
 	description            *string
+	name                   *string
+
+	// Dynamic AgentTool options. They are only meaningful for NewDynamicTool;
+	// NewTool ignores them.
+	dynamic *dynamicOptions
+}
+
+// dynamicOptions holds the configuration knobs for the dynamic AgentTool mode.
+type dynamicOptions struct {
+	templateAgent          agent.Agent
+	capabilityProvider     CapabilitySurfaceProvider
+	capabilityTools        []tool.Tool
+	capabilitySkills       skillRepository
+	capabilityToolsSet     bool
+	exposeToolSelection    bool
+	exposeSkillSelection   bool
+	exposeInstruction      bool
+	requestDescription     *string
+	instructionDescription *string
+	toolsDescription       *string
+	skillsDescription      *string
+}
+
+func defaultDynamicOptions() *dynamicOptions {
+	return &dynamicOptions{
+		exposeToolSelection:  true,
+		exposeSkillSelection: false,
+		exposeInstruction:    true,
+	}
+}
+
+func (opts *agentToolOptions) ensureDynamicOptions() *dynamicOptions {
+	if opts.dynamic == nil {
+		opts.dynamic = defaultDynamicOptions()
+	}
+	return opts.dynamic
 }
 
 // InnerTextMode controls whether forwarded inner assistant text is visible
@@ -141,6 +187,25 @@ func WithDescription(description string) Option {
 	}
 }
 
+// WithName overrides the model-facing tool name for NewDynamicTool.
+//
+// It applies ONLY to NewDynamicTool, whose name defaults to
+// DefaultDynamicToolName ("dynamic_agent"); use it to expose a different,
+// code-defined entrypoint name (for example "explore" or "implement").
+//
+// It is intentionally ignored by NewTool: a wrapped agent's tool name is its
+// identity (agent.Info().Name) and is also used for the child event-filter key,
+// team node id, and recursion guards, so renaming only the model-facing name
+// would split that identity. Rename the wrapped agent instead.
+//
+// The name must comply with LLM API requirements (^[a-zA-Z0-9_-]+$).
+func WithName(name string) Option {
+	return func(opts *agentToolOptions) {
+		copiedName := name
+		opts.name = &copiedName
+	}
+}
+
 // HistoryScope controls whether and how AgentTool inherits parent history.
 //   - HistoryScopeIsolated: keep child events isolated; do not inherit parent history.
 //   - HistoryScopeParentBranch: inherit parent branch history by using a hierarchical
@@ -185,6 +250,13 @@ func NewTool(agent agent.Agent, opts ...Option) *Tool {
 		opt(options)
 	}
 	info := agent.Info()
+	if options.name != nil {
+		log.Warnf(
+			"AgentTool: WithName(%q) is ignored by NewTool; "+
+				"rename the wrapped agent or use NewDynamicTool",
+			*options.name,
+		)
+	}
 
 	// Use the agent's input schema if available, otherwise fall back to default.
 	var inputSchema *tool.Schema
@@ -218,6 +290,10 @@ func NewTool(agent agent.Agent, opts ...Option) *Tool {
 	if options.description != nil {
 		description = *options.description
 	}
+	// NewTool's name is the wrapped agent's identity; WithName is intentionally
+	// dynamic-only (see WithName) so the model-facing name never diverges from
+	// the child filter key, team node id, and recursion guards.
+	name := info.Name
 	return &Tool{
 		agent:                  agent,
 		skipSummarization:      options.skipSummarization,
@@ -226,7 +302,7 @@ func NewTool(agent agent.Agent, opts ...Option) *Tool {
 		structuredStreamErrors: options.structuredStreamErrors,
 		historyScope:           options.historyScope,
 		responseMode:           normalizeResponseMode(options.responseMode),
-		name:                   info.Name,
+		name:                   name,
 		description:            description,
 		inputSchema:            inputSchema,
 		outputSchema:           outputSchema,
@@ -235,6 +311,12 @@ func NewTool(agent agent.Agent, opts ...Option) *Tool {
 
 // Call executes the agent tool with the provided JSON arguments.
 func (at *Tool) Call(ctx context.Context, jsonArgs []byte) (any, error) {
+	// Dynamic AgentTool mode runs a short-lived sub-agent whose capability
+	// surface is selected per call from the parent invocation.
+	if at.dynamic {
+		return at.callDynamic(ctx, jsonArgs)
+	}
+
 	message := model.NewUserMessage(string(jsonArgs))
 
 	// Prefer to reuse parent invocation + session so the child can see parent
@@ -896,6 +978,10 @@ type streamCompletionState struct {
 	lastAssistantContent       string
 	finalOnlyResult            string
 	overrideResult             string
+	// resultPrefix is prepended to the model-visible result. It carries
+	// dynamic sub-agent warnings so the parent model sees them in stream mode,
+	// matching the Call path. Empty for non-dynamic AgentTool streaming.
+	resultPrefix string
 }
 
 func (at *Tool) streamableCallContext(ctx context.Context) context.Context {
@@ -920,6 +1006,10 @@ func (at *Tool) runStreamableCall(
 	writer *tool.StreamWriter,
 ) {
 	defer writer.Close()
+	if at.dynamic {
+		at.streamDynamic(ctx, jsonArgs, writer)
+		return
+	}
 	parentInv, ok := agent.InvocationFromContext(ctx)
 	message := model.NewUserMessage(string(jsonArgs))
 	if ok && parentInv != nil && parentInv.Session != nil {
@@ -957,6 +1047,7 @@ func (at *Tool) streamFromParentInvocation(
 		subInv,
 		at.wrapWithStreamSemantics(subCtx, subInv, evCh),
 		writer,
+		"",
 	)
 }
 
@@ -965,58 +1056,25 @@ func (at *Tool) forwardSubInvocationStream(
 	subInv *agent.Invocation,
 	wrapped <-chan *event.Event,
 	writer *tool.StreamWriter,
+	resultPrefix string,
 ) {
 	managePendingVisibleCompletion := shouldDeferStreamCompletion(ctx, subInv)
 	emitFinalResultChunk := tool.FinalResultChunksFromContext(ctx)
-	state := streamCompletionState{}
+	state := streamCompletionState{resultPrefix: resultPrefix}
+	// When the model-visible result is built from merged inner content (no
+	// final-result chunk is emitted), inject the prefix as a leading content
+	// chunk so it is merged into the tool response. For final-result modes the
+	// prefix is folded into the emitted result instead (see the emit helpers).
+	if resultPrefix != "" && !emitFinalResultChunk {
+		if writer.Send(tool.StreamChunk{Content: resultPrefix}, nil) {
+			return
+		}
+	}
 	for ev := range wrapped {
-		if ev != nil {
-			ensureInvocationEventFields(subInv, ev)
-		}
-		if shouldSuppressGraphExecutorBarrierEvent(subInv, ev) {
-			at.completeSuppressedBarrierStreamEvent(ctx, subInv, ev, &state)
-			continue
-		}
-		at.updateFinalOnlyStreamResult(ev, &state)
-		if agent.IsGraphCompletionEventDisabled(subInv) &&
-			isGraphCompletionSnapshotEvent(ev) {
-			if emitFinalResultChunk {
-				at.capturePendingCompletionChunk(ev, &state)
-				if managePendingVisibleCompletion {
-					at.capturePendingVisibleCompletion(ctx, subInv, ev, &state)
-				}
-				continue
-			}
-			visibleEvent, ok := visibleCompletionStreamEvent(ev, subInv.AgentName)
-			if !ok {
-				continue
-			}
-			if managePendingVisibleCompletion {
-				at.capturePendingVisibleCompletion(ctx, subInv, visibleEvent, &state)
-			}
-			state.pendingStreamVisibleEvent = visibleEvent
-			state.sawGraphCompletionSnapshot = true
-			continue
-		}
-		if managePendingVisibleCompletion {
-			state.pendingVisibleCompletion = at.updatePendingVisibleCompletionForSession(
-				ctx,
-				subInv,
-				state.pendingVisibleCompletion,
-				ev,
-			)
-			if ev != nil &&
-				ev.RequiresCompletion &&
-				state.pendingVisibleCompletion != nil {
-				at.flushPendingVisibleCompletionForSession(
-					ctx,
-					subInv,
-					&state,
-				)
-			}
-		}
-		at.updateStreamCompletionState(ev, &state)
-		if writer.Send(tool.StreamChunk{Content: ev}, nil) {
+		if at.handleForwardedStreamEvent(
+			ctx, subInv, ev, writer, &state,
+			managePendingVisibleCompletion, emitFinalResultChunk,
+		) {
 			return
 		}
 	}
@@ -1032,6 +1090,81 @@ func (at *Tool) forwardSubInvocationStream(
 		return
 	}
 	at.emitPendingVisibleCompletionEvent(&state, writer)
+}
+
+// handleForwardedStreamEvent processes a single forwarded sub-invocation event
+// and reports whether forwarding should stop (the writer signalled completion,
+// so the caller must return). Graph-completion snapshots are captured for
+// deferred emission and never forwarded inline.
+func (at *Tool) handleForwardedStreamEvent(
+	ctx context.Context,
+	subInv *agent.Invocation,
+	ev *event.Event,
+	writer *tool.StreamWriter,
+	state *streamCompletionState,
+	managePendingVisibleCompletion bool,
+	emitFinalResultChunk bool,
+) (stop bool) {
+	if ev != nil {
+		ensureInvocationEventFields(subInv, ev)
+	}
+	if shouldSuppressGraphExecutorBarrierEvent(subInv, ev) {
+		at.completeSuppressedBarrierStreamEvent(ctx, subInv, ev, state)
+		return false
+	}
+	at.updateFinalOnlyStreamResult(ev, state)
+	if agent.IsGraphCompletionEventDisabled(subInv) &&
+		isGraphCompletionSnapshotEvent(ev) {
+		at.handleGraphCompletionSnapshot(
+			ctx, subInv, ev, state,
+			managePendingVisibleCompletion, emitFinalResultChunk,
+		)
+		return false
+	}
+	if managePendingVisibleCompletion {
+		state.pendingVisibleCompletion = at.updatePendingVisibleCompletionForSession(
+			ctx,
+			subInv,
+			state.pendingVisibleCompletion,
+			ev,
+		)
+		if ev != nil &&
+			ev.RequiresCompletion &&
+			state.pendingVisibleCompletion != nil {
+			at.flushPendingVisibleCompletionForSession(ctx, subInv, state)
+		}
+	}
+	at.updateStreamCompletionState(ev, state)
+	return writer.Send(tool.StreamChunk{Content: ev}, nil)
+}
+
+// handleGraphCompletionSnapshot captures a graph-completion snapshot for
+// deferred emission: final-result modes stash the completion chunk, otherwise a
+// model-visible completion event is captured/queued for end-of-stream flush.
+func (at *Tool) handleGraphCompletionSnapshot(
+	ctx context.Context,
+	subInv *agent.Invocation,
+	ev *event.Event,
+	state *streamCompletionState,
+	managePendingVisibleCompletion bool,
+	emitFinalResultChunk bool,
+) {
+	if emitFinalResultChunk {
+		at.capturePendingCompletionChunk(ev, state)
+		if managePendingVisibleCompletion {
+			at.capturePendingVisibleCompletion(ctx, subInv, ev, state)
+		}
+		return
+	}
+	visibleEvent, ok := visibleCompletionStreamEvent(ev, subInv.AgentName)
+	if !ok {
+		return
+	}
+	if managePendingVisibleCompletion {
+		at.capturePendingVisibleCompletion(ctx, subInv, visibleEvent, state)
+	}
+	state.pendingStreamVisibleEvent = visibleEvent
+	state.sawGraphCompletionSnapshot = true
 }
 
 func (at *Tool) updateFinalOnlyStreamResult(
@@ -1228,12 +1361,13 @@ func (at *Tool) emitPendingCompletionChunk(
 	if state.overrideResult != "" {
 		state.pendingCompletionChunk.Result = state.overrideResult
 	}
+	result := prefixStreamResult(state.resultPrefix, state.pendingCompletionChunk.Result)
 	var content any = tool.FinalResultChunk{
-		Result: state.pendingCompletionChunk.Result,
+		Result: result,
 	}
 	if len(state.pendingCompletionChunk.StateDelta) > 0 {
 		content = tool.FinalResultStateChunk{
-			Result:     state.pendingCompletionChunk.Result,
+			Result:     result,
 			StateDelta: cloneStateDelta(state.pendingCompletionChunk.StateDelta),
 		}
 	}
@@ -1248,20 +1382,44 @@ func (at *Tool) emitFinalOnlyResultChunk(
 ) {
 	result := ""
 	var stateDelta map[string][]byte
+	prefix := ""
 	if state != nil {
 		result = state.finalOnlyResult
+		prefix = state.resultPrefix
 		if state.pendingCompletionChunk != nil {
 			stateDelta = state.pendingCompletionChunk.StateDelta
 		}
 	}
-	var content any = tool.FinalResultChunk{Result: result}
+	finalResult := prefixStreamResult(prefix, result)
+	var content any = tool.FinalResultChunk{Result: finalResult}
 	if len(stateDelta) > 0 {
 		content = tool.FinalResultStateChunk{
-			Result:     result,
+			Result:     finalResult,
 			StateDelta: cloneStateDelta(stateDelta),
 		}
 	}
 	_ = writer.Send(tool.StreamChunk{Content: content}, nil)
+}
+
+// prefixStreamResult prepends prefix (e.g. dynamic sub-agent warnings) to a
+// streamed final result. It only prefixes string/nil results so non-text tool
+// results are never corrupted; non-dynamic streaming passes an empty prefix and
+// is therefore unaffected.
+func prefixStreamResult(prefix string, result any) any {
+	if prefix == "" {
+		return result
+	}
+	switch v := result.(type) {
+	case nil:
+		return prefix
+	case string:
+		if v == "" {
+			return prefix
+		}
+		return prefix + "\n" + v
+	default:
+		return result
+	}
 }
 
 func (at *Tool) streamFromFallbackRunner(

--- a/tool/agent/dynamic_tool.go
+++ b/tool/agent/dynamic_tool.go
@@ -1,0 +1,981 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/google/uuid"
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/flush"
+	"trpc.group/trpc-go/trpc-agent-go/internal/toolsurface"
+	"trpc.group/trpc-go/trpc-agent-go/log"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/skill"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+	"trpc.group/trpc-go/trpc-agent-go/tool/transfer"
+)
+
+// DefaultDynamicToolName is the default tool name exposed to the model by
+// NewDynamicTool. It is intentionally distinct from transfer_to_agent
+// (control handoff) and the *_task_run tools (background tasks): it runs a
+// short-lived sub-agent and returns its result synchronously.
+const DefaultDynamicToolName = "dynamic_agent"
+
+// defaultDynamicDescription is the default tool description exposed to the
+// model. It pins the semantic boundary so the model does not confuse this with
+// a transfer, a background task, or running a pre-registered sub-agent. It
+// deliberately does not name the optional "tools"/"skills" fields (those are
+// only present when exposed via the schema); it states the boundary as a fact
+// that holds whether or not the model can narrow the surface.
+const defaultDynamicDescription = "Run one short-lived sub-agent for a " +
+	"single focused task and return its result. The sub-agent is created on the " +
+	"fly for this call only and is destroyed afterward. It does NOT transfer " +
+	"control, does NOT run a pre-registered agent by name, and does NOT start a " +
+	"background task. To run several tasks, call this tool multiple times. Its " +
+	"tools and skills stay within a code-defined capability boundary, which by " +
+	"default is derived from what the current agent is already allowed to use " +
+	"(or set explicitly in code), and it cannot select arbitrary agents, models, " +
+	"or executors."
+
+const (
+	defaultRequestDescription = "The task for the sub-agent. Include all the " +
+		"context it needs to complete the task on its own."
+	defaultInstructionDescription = "Optional role, constraints, and " +
+		"execution guidance for this sub-agent invocation. It acts as the " +
+		"sub-agent's system prompt for this run."
+	defaultToolsDescription = "Optional exact tool names this sub-agent may " +
+		"use. Omit to allow all permitted tools."
+	defaultSkillsDescription = "Optional exact skill names this sub-agent may " +
+		"use. Omit to allow all permitted skills."
+)
+
+const (
+	fieldRequest     = "request"
+	fieldInstruction = "instruction"
+	fieldTools       = "tools"
+	fieldSkills      = "skills"
+)
+
+// skillRepository is a local alias so the dynamic option struct (declared in
+// agent_tool.go) can reference a skill repository without that file importing
+// the skill package directly.
+type skillRepository = skill.Repository
+
+// CapabilitySurfaceProvider returns the maximum capability surface (the set of
+// tools the model may select from for a dynamic sub-agent invocation) together
+// with the user-tool classification.
+//
+// It receives the parent invocation so a provider can derive the surface from
+// the live parent context. The second return value maps user-tool names; tools
+// not present in it are treated as framework-managed and are not selectable.
+// When the map is nil all returned tools are treated as user tools.
+type CapabilitySurfaceProvider func(
+	ctx context.Context,
+	parentInv *agent.Invocation,
+) ([]tool.Tool, map[string]bool)
+
+// WithTemplateAgent sets the base/template agent that defines the execution
+// boundary for the dynamic sub-agent (model, executor, callbacks, permission
+// policy, max calls, ...).
+//
+// When omitted, the dynamic tool lazily derives the base agent from the parent
+// invocation at call time. The model can never select an arbitrary agent; it
+// can only run within this boundary.
+func WithTemplateAgent(a agent.Agent) Option {
+	return func(opts *agentToolOptions) {
+		opts.ensureDynamicOptions().templateAgent = a
+	}
+}
+
+// WithCapabilityProvider overrides how the maximum capability surface is
+// resolved for a dynamic sub-agent. By default the surface is derived from the
+// parent invocation's effective tool surface.
+func WithCapabilityProvider(provider CapabilitySurfaceProvider) Option {
+	return func(opts *agentToolOptions) {
+		opts.ensureDynamicOptions().capabilityProvider = provider
+	}
+}
+
+// WithCapabilityTools sets a fixed maximum tool surface for a dynamic
+// sub-agent. The model may only select a subset of these tools. This takes
+// precedence over the default parent-derived surface (but not over
+// WithCapabilityProvider).
+func WithCapabilityTools(tools []tool.Tool) Option {
+	return func(opts *agentToolOptions) {
+		cfg := opts.ensureDynamicOptions()
+		cfg.capabilityTools = append([]tool.Tool(nil), tools...)
+		cfg.capabilityToolsSet = true
+	}
+}
+
+// WithCapabilitySkills sets a fixed maximum skill repository for a dynamic
+// sub-agent. The model may only select a subset of these skills. This takes
+// precedence over the default parent-derived skill repository.
+func WithCapabilitySkills(repo skill.Repository) Option {
+	return func(opts *agentToolOptions) {
+		opts.ensureDynamicOptions().capabilitySkills = repo
+	}
+}
+
+// WithExposeToolSelection controls whether the dynamic tool exposes the
+// "tools" field so the model can restrict the sub-agent's tools. Defaults to
+// true. When disabled the sub-agent still receives the permitted tool surface
+// (minus the dynamic tool itself), but the model cannot narrow it.
+func WithExposeToolSelection(expose bool) Option {
+	return func(opts *agentToolOptions) {
+		opts.ensureDynamicOptions().exposeToolSelection = expose
+	}
+}
+
+// WithExposeSkillSelection controls whether the dynamic tool exposes the
+// "skills" field so the model can restrict the sub-agent's skills. Defaults to
+// false because validating skill execution requirements is environment
+// dependent.
+func WithExposeSkillSelection(expose bool) Option {
+	return func(opts *agentToolOptions) {
+		opts.ensureDynamicOptions().exposeSkillSelection = expose
+	}
+}
+
+// WithExposeInstruction controls whether the dynamic tool exposes the
+// "instruction" field so the model can set a per-invocation role/system prompt
+// for the sub-agent. Defaults to true.
+func WithExposeInstruction(expose bool) Option {
+	return func(opts *agentToolOptions) {
+		opts.ensureDynamicOptions().exposeInstruction = expose
+	}
+}
+
+// WithRequestDescription customizes the schema description of the "request"
+// field for the dynamic tool.
+func WithRequestDescription(description string) Option {
+	return func(opts *agentToolOptions) {
+		copied := description
+		opts.ensureDynamicOptions().requestDescription = &copied
+	}
+}
+
+// WithInstructionDescription customizes the schema description of the
+// "instruction" field for the dynamic tool.
+func WithInstructionDescription(description string) Option {
+	return func(opts *agentToolOptions) {
+		copied := description
+		opts.ensureDynamicOptions().instructionDescription = &copied
+	}
+}
+
+// WithToolsDescription customizes the schema description of the "tools" field
+// for the dynamic tool.
+func WithToolsDescription(description string) Option {
+	return func(opts *agentToolOptions) {
+		copied := description
+		opts.ensureDynamicOptions().toolsDescription = &copied
+	}
+}
+
+// WithSkillsDescription customizes the schema description of the "skills" field
+// for the dynamic tool.
+func WithSkillsDescription(description string) Option {
+	return func(opts *agentToolOptions) {
+		copied := description
+		opts.ensureDynamicOptions().skillsDescription = &copied
+	}
+}
+
+// NewDynamicTool creates a dynamic AgentTool: a single, code-defined entrypoint
+// that runs a short-lived sub-agent whose capability surface (tools,
+// skills, instruction) is selected per invocation within a safety boundary.
+//
+// The default behavior is to lazily derive the sub-agent from the parent
+// invocation at call time:
+//   - base agent: the parent invocation's agent (or WithTemplateAgent),
+//   - tool surface: the parent invocation's effective user tools (minus this
+//     tool, transfer_to_agent and any caller-executed external tools),
+//     optionally narrowed by the model's "tools" field,
+//   - skills: the parent invocation's effective skills, optionally narrowed by
+//     the model's "skills" field,
+//   - instruction: the model's "instruction" field (when exposed),
+//   - context: isolated by default (HistoryScopeIsolated).
+//
+// The model cannot pick an arbitrary agent, model, or executor; it can only run
+// within the configured boundary.
+//
+// Minimal usage exposes a tool named "dynamic_agent":
+//
+//	main := llmagent.New("main",
+//	    llmagent.WithTools([]tool.Tool{agenttool.NewDynamicTool()}),
+//	)
+func NewDynamicTool(opts ...Option) *Tool {
+	options := &agentToolOptions{
+		historyScope: HistoryScopeIsolated,
+		dynamic:      defaultDynamicOptions(),
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(options)
+		}
+	}
+
+	name := DefaultDynamicToolName
+	if options.name != nil && *options.name != "" {
+		name = *options.name
+	}
+	dynamicCfg := options.ensureDynamicOptions()
+	description := buildDynamicDescription(dynamicCfg, options.historyScope)
+	if options.description != nil {
+		description = *options.description
+	}
+
+	return &Tool{
+		agent:                  dynamicCfg.templateAgent,
+		skipSummarization:      options.skipSummarization,
+		streamInner:            options.streamInner,
+		innerTextMode:          tool.NormalizeInnerTextMode(options.innerTextMode),
+		structuredStreamErrors: options.structuredStreamErrors,
+		historyScope:           options.historyScope,
+		responseMode:           normalizeResponseMode(options.responseMode),
+		name:                   name,
+		description:            description,
+		inputSchema:            buildDynamicInputSchema(name, dynamicCfg),
+		outputSchema: &tool.Schema{
+			Type:        "string",
+			Description: "The sub-agent's final response.",
+		},
+		dynamic:    true,
+		dynamicCfg: dynamicCfg,
+	}
+}
+
+// buildDynamicDescription assembles the model-facing tool description: the
+// fixed boundary statement, a context sentence matching the configured
+// history scope, plus one short hint per per-call field that is
+// actually exposed. The model learns it can configure instruction/tools/skills
+// from the schema and these hints — not from the tool name — so the hints stay
+// in lockstep with buildDynamicInputSchema and never advertise a field the
+// schema omits.
+func buildDynamicDescription(cfg *dynamicOptions, historyScope HistoryScope) string {
+	var b strings.Builder
+	b.WriteString(defaultDynamicDescription)
+	if historyScope == HistoryScopeParentBranch {
+		b.WriteString(" It can see the current conversation's history; still " +
+			"describe the task in 'request'. Use it when delegated tool work " +
+			"should run in a child invocation while continuing from the current " +
+			"conversation.")
+	} else {
+		b.WriteString(" Use it for self-contained tool work, multiple " +
+			"independent subtasks, or any task where delegating keeps the parent " +
+			"conversation focused instead of filling it with tool details and " +
+			"intermediate steps. It has no memory of this conversation, so put " +
+			"everything it needs in 'request'.")
+	}
+	if cfg.exposeInstruction {
+		b.WriteString(" Optionally set 'instruction' to give the sub-agent a " +
+			"role or constraints for this run.")
+	}
+	if cfg.exposeToolSelection {
+		b.WriteString(" Optionally set 'tools' to the exact subset of tool " +
+			"names it may use; omit to allow all permitted tools.")
+	}
+	if cfg.exposeSkillSelection {
+		b.WriteString(" Optionally set 'skills' to the exact subset of skill " +
+			"names it may use; omit to allow all permitted skills.")
+	}
+	return b.String()
+}
+
+// buildDynamicInputSchema builds the JSON schema exposed to the model based on
+// which fields are enabled.
+func buildDynamicInputSchema(name string, cfg *dynamicOptions) *tool.Schema {
+	properties := map[string]*tool.Schema{
+		fieldRequest: {
+			Type:        "string",
+			Description: optionalString(cfg.requestDescription, defaultRequestDescription),
+		},
+	}
+	if cfg.exposeInstruction {
+		properties[fieldInstruction] = &tool.Schema{
+			Type:        "string",
+			Description: optionalString(cfg.instructionDescription, defaultInstructionDescription),
+		}
+	}
+	if cfg.exposeToolSelection {
+		toolsSchema := &tool.Schema{
+			Type:        "array",
+			Description: optionalString(cfg.toolsDescription, defaultToolsDescription),
+			Items:       &tool.Schema{Type: "string"},
+		}
+		// When the capability surface is statically defined in code via
+		// WithCapabilityTools, enumerate the selectable tool names so the model
+		// picks from a known set instead of guessing. The default parent-derived
+		// surface and WithCapabilityProvider are resolved per call, so their
+		// names are not available at schema-build time.
+		if cfg.capabilityToolsSet {
+			if names, enum := capabilityToolNameEnum(cfg.capabilityTools); len(enum) > 0 {
+				toolsSchema.Items = &tool.Schema{Type: "string", Enum: enum}
+				if cfg.toolsDescription == nil {
+					toolsSchema.Description += " Available tool names: " +
+						strings.Join(names, ", ") + "."
+				}
+			}
+		}
+		properties[fieldTools] = toolsSchema
+	}
+	if cfg.exposeSkillSelection {
+		properties[fieldSkills] = &tool.Schema{
+			Type:        "array",
+			Description: optionalString(cfg.skillsDescription, defaultSkillsDescription),
+			Items:       &tool.Schema{Type: "string"},
+		}
+	}
+	return &tool.Schema{
+		Type:        "object",
+		Description: fmt.Sprintf("Input for the %s tool.", name),
+		Properties:  properties,
+		Required:    []string{fieldRequest},
+	}
+}
+
+func optionalString(value *string, fallback string) string {
+	if value != nil {
+		return *value
+	}
+	return fallback
+}
+
+// maxDynamicToolEnumValues bounds JSON schema size when enumerating statically
+// configured capability tool names.
+const maxDynamicToolEnumValues = 256
+
+// capabilityToolNameEnum returns the de-duplicated, sorted declaration names of
+// the statically configured capability tools (for the schema enum and a short
+// description hint), or nil when there are none, a name is missing, or the set
+// is too large. Only a code-defined surface (WithCapabilityTools) can be
+// enumerated at schema-build time; the parent-derived and provider surfaces are
+// resolved per call.
+func capabilityToolNameEnum(tools []tool.Tool) ([]string, []any) {
+	if len(tools) == 0 {
+		return nil, nil
+	}
+	seen := make(map[string]bool, len(tools))
+	names := make([]string, 0, len(tools))
+	for _, t := range tools {
+		n := declarationName(t)
+		if n == "" || seen[n] {
+			continue
+		}
+		seen[n] = true
+		names = append(names, n)
+	}
+	// Bound the schema size by the number of unique names actually enumerated,
+	// not the raw slice length (which may contain duplicates).
+	if len(names) == 0 || len(names) > maxDynamicToolEnumValues {
+		return nil, nil
+	}
+	sort.Strings(names)
+	enum := make([]any, 0, len(names))
+	for _, n := range names {
+		enum = append(enum, n)
+	}
+	return names, enum
+}
+
+// dynamicArgs is the wire format of the dynamic tool arguments. Tools and
+// Skills are pointers so the tool can distinguish an omitted field (allow all)
+// from an explicit empty array (allow none).
+type dynamicArgs struct {
+	Request     string    `json:"request"`
+	Instruction string    `json:"instruction"`
+	Tools       *[]string `json:"tools"`
+	Skills      *[]string `json:"skills"`
+}
+
+// dynamicSpec is the parsed, validated form of a single dynamic invocation.
+type dynamicSpec struct {
+	request        string
+	instruction    string
+	tools          []string
+	toolsProvided  bool
+	skills         []string
+	skillsProvided bool
+}
+
+func (at *Tool) parseDynamicArgs(jsonArgs []byte) dynamicSpec {
+	var raw dynamicArgs
+	if err := json.Unmarshal(jsonArgs, &raw); err != nil {
+		// Be permissive: treat the raw payload as the request so a minimal
+		// or non-conforming call still does something useful.
+		return dynamicSpec{request: strings.TrimSpace(string(jsonArgs))}
+	}
+	spec := dynamicSpec{request: strings.TrimSpace(raw.Request)}
+	if at.dynamicCfg.exposeInstruction {
+		spec.instruction = strings.TrimSpace(raw.Instruction)
+	}
+	if at.dynamicCfg.exposeToolSelection && raw.Tools != nil {
+		spec.toolsProvided = true
+		spec.tools = dedupeNonEmpty(*raw.Tools)
+	}
+	if at.dynamicCfg.exposeSkillSelection && raw.Skills != nil {
+		spec.skillsProvided = true
+		spec.skills = dedupeNonEmpty(*raw.Skills)
+	}
+	return spec
+}
+
+// callDynamic runs the dynamic sub-agent and returns its final response.
+func (at *Tool) callDynamic(ctx context.Context, jsonArgs []byte) (any, error) {
+	subCtx, subInv, warnings, err := at.buildDynamicSubInvocation(ctx, jsonArgs)
+	if err != nil {
+		return "", err
+	}
+	evCh, err := agent.RunWithPlugins(subCtx, subInv, subInv.Agent)
+	if err != nil {
+		return "", fmt.Errorf("failed to run sub-agent: %w", err)
+	}
+	response, err := at.collectResponse(
+		subInv,
+		at.wrapWithCallSemantics(subCtx, subInv, evCh),
+	)
+	if err != nil {
+		return "", err
+	}
+	return at.formatResponseWithWarnings(response, warnings), nil
+}
+
+// streamDynamic runs the dynamic sub-agent and forwards its streaming events.
+func (at *Tool) streamDynamic(
+	ctx context.Context,
+	jsonArgs []byte,
+	writer *tool.StreamWriter,
+) {
+	subCtx, subInv, warnings, err := at.buildDynamicSubInvocation(ctx, jsonArgs)
+	if err != nil {
+		sendStreamableCallError(ctx, writer, "dynamic sub-agent error: %w", err)
+		return
+	}
+	for _, w := range warnings {
+		log.Warnf("AgentTool[%s]: %s", at.name, w)
+	}
+	evCh, err := agent.RunWithPlugins(subCtx, subInv, subInv.Agent)
+	if err != nil {
+		sendStreamableCallError(ctx, writer, "dynamic sub-agent run error: %w", err)
+		return
+	}
+	// Surface warnings to the parent model in stream mode too (parity with the
+	// Call path), not just to the logs.
+	at.forwardSubInvocationStream(
+		subCtx,
+		subInv,
+		at.wrapWithStreamSemantics(subCtx, subInv, evCh),
+		writer,
+		at.warningsNote(warnings),
+	)
+}
+
+// buildDynamicSubInvocation resolves the base agent, capability surface and
+// instruction for one dynamic call and returns a ready-to-run child invocation
+// together with any non-fatal warnings to surface back to the parent model.
+func (at *Tool) buildDynamicSubInvocation(
+	ctx context.Context,
+	jsonArgs []byte,
+) (context.Context, *agent.Invocation, []string, error) {
+	parentInv, ok := agent.InvocationFromContext(ctx)
+	if !ok || parentInv == nil {
+		return nil, nil, nil, fmt.Errorf(
+			"agenttool: dynamic sub-agent requires a parent invocation; " +
+				"register the tool on a running agent",
+		)
+	}
+	if parentInv.Session == nil {
+		return nil, nil, nil, fmt.Errorf(
+			"agenttool: dynamic sub-agent requires a session on the parent invocation",
+		)
+	}
+
+	spec := at.parseDynamicArgs(jsonArgs)
+	if spec.request == "" {
+		return nil, nil, nil, fmt.Errorf("agenttool: 'request' is required")
+	}
+
+	baseAgent := at.dynamicCfg.templateAgent
+	if baseAgent == nil {
+		baseAgent = parentInv.Agent
+	}
+	if baseAgent == nil {
+		return nil, nil, nil, fmt.Errorf(
+			"agenttool: no base agent available; set WithTemplateAgent or " +
+				"call from an agent that exposes its invocation agent",
+		)
+	}
+
+	// Flush events emitted before this tool call so the child sees a complete
+	// snapshot of the parent history.
+	if err := flush.Invoke(ctx, parentInv); err != nil {
+		return nil, nil, nil, fmt.Errorf("flush parent invocation session: %w", err)
+	}
+
+	patch, warnings := at.buildDynamicPatch(ctx, parentInv, spec)
+
+	message := model.NewUserMessage(spec.request)
+	childKey := at.buildDynamicChildFilterKey(parentInv, baseAgent)
+	nodeID := dynamicSurfaceNodeID(at.name)
+	subInv := parentInv.Clone(
+		at.dynamicChildInvocationOptions(baseAgent, message, childKey, nodeID, patch)...,
+	)
+	subCtx := agent.NewInvocationContext(ctx, subInv)
+	return subCtx, subInv, warnings, nil
+}
+
+// buildDynamicPatch builds the surface patch that scopes the child invocation's
+// tools, skills and instruction.
+func (at *Tool) buildDynamicPatch(
+	ctx context.Context,
+	parentInv *agent.Invocation,
+	spec dynamicSpec,
+) (agent.SurfacePatch, []string) {
+	var patch agent.SurfacePatch
+	var warnings []string
+
+	if at.dynamicCfg.exposeInstruction && spec.instruction != "" {
+		patch.SetInstruction(spec.instruction)
+	}
+
+	// Tools: always set so the dynamic tool itself (and transfer_to_agent) are
+	// excluded from the child, preventing runaway recursion.
+	maxTools, userToolNames, externalNames := at.dynamicMaxToolSurface(ctx, parentInv)
+	selectedTools, toolWarnings := at.selectDynamicTools(maxTools, userToolNames, externalNames, spec)
+	patch.SetTools(selectedTools)
+	// SetTools only replaces the user tools. The framework re-derives
+	// transfer_to_agent from the base/template agent's own sub-agents, so
+	// suppress it explicitly: a short-lived sub-agent must never hand control
+	// to another agent (and the README guarantees the model cannot reach it).
+	patch.SetSuppressSubAgentTransfer()
+	warnings = append(warnings, toolWarnings...)
+
+	// Skills: selectDynamicSkills resolves both the repository and whether the
+	// patch must set it (e.g. to stop a template agent's own skills from leaking
+	// when the child should mirror the parent's — possibly empty — skills).
+	skillRepo, patchSkills, skillWarnings := at.selectDynamicSkills(ctx, parentInv, spec)
+	if patchSkills {
+		patch.SetSkillRepository(skillRepo)
+	}
+	warnings = append(warnings, skillWarnings...)
+
+	return patch, warnings
+}
+
+// dynamicMaxToolSurface resolves the maximum tool surface the model may select
+// from, honoring code-side overrides before deriving from the parent. It also
+// returns the set of external (caller-executed) tool names so the caller can
+// exclude them from selection.
+//
+// When deriving from the parent it uses the parent's effective surface: the
+// base surface plus the run-scoped RunOptions.AdditionalTools/ExternalTools,
+// with RunOptions.ToolFilter applied. This reuses the same resolution the LLM
+// flow uses (toolsurface, which getFilteredTools also delegates to) so the
+// child never sees tools the parent run filtered out and never misses business
+// tools the parent run temporarily appended.
+//
+// Known limitation: toolsurface recomputes the surface rather than reading the
+// flow's cached snapshot (the snapshot key is flow-internal and tool/agent
+// cannot import the flow without a cycle). This keeps it correct for clones
+// produced by parallel tool execution, but if a dynamic ToolSet / MCP ListTools
+// changes between the parent model call and this tool call, the child reflects
+// the current set rather than the exact snapshot the parent model just saw.
+func (at *Tool) dynamicMaxToolSurface(
+	ctx context.Context,
+	parentInv *agent.Invocation,
+) ([]tool.Tool, map[string]bool, map[string]bool) {
+	if at.dynamicCfg.capabilityProvider != nil {
+		tools, userToolNames := at.dynamicCfg.capabilityProvider(ctx, parentInv)
+		return tools, userToolNames, nil
+	}
+	if at.dynamicCfg.capabilityToolsSet {
+		return at.dynamicCfg.capabilityTools,
+			toolNameSet(at.dynamicCfg.capabilityTools), nil
+	}
+	if parentInv == nil || parentInv.Agent == nil {
+		return nil, nil, nil
+	}
+	return toolsurface.EffectiveWithExternal(ctx, parentInv)
+}
+
+// selectDynamicTools computes the child tool surface from the maximum surface
+// and the (optional) model selection.
+//
+// Semantics of the model-facing "tools" field: it selects from the parent's
+// currently-effective USER (business) tools only — those registered via
+// WithTools/WithToolSets (plus run-scoped AdditionalTools). Framework-managed
+// tools (transfer_to_agent, knowledge_*) are intentionally not hand-pickable;
+// the child agent receives its own framework tools based on the template/base
+// agent's configuration. The dynamic tool itself and transfer_to_agent are
+// always excluded to prevent runaway recursion, and external (caller-executed)
+// tools are excluded because a synchronous sub-agent has no channel to hand
+// them back to the original caller for execution.
+func (at *Tool) selectDynamicTools(
+	maxTools []tool.Tool,
+	userToolNames map[string]bool,
+	externalNames map[string]bool,
+	spec dynamicSpec,
+) ([]tool.Tool, []string) {
+	excluded := map[string]bool{at.name: true, transfer.TransferToolName: true}
+	for name := range externalNames {
+		excluded[name] = true
+	}
+	isUserTool := func(name string) bool {
+		if userToolNames == nil {
+			return true
+		}
+		return userToolNames[name]
+	}
+	candidates := make([]tool.Tool, 0, len(maxTools))
+	candidateByName := make(map[string]tool.Tool, len(maxTools))
+	for _, t := range maxTools {
+		if _, ok := t.(*Tool); ok {
+			continue
+		}
+		name := declarationName(t)
+		if name == "" || excluded[name] || !isUserTool(name) {
+			continue
+		}
+		if _, seen := candidateByName[name]; seen {
+			continue
+		}
+		candidates = append(candidates, t)
+		candidateByName[name] = t
+	}
+
+	if !at.dynamicCfg.exposeToolSelection || !spec.toolsProvided {
+		return candidates, nil
+	}
+	// An explicit empty array ("tools": []) is a valid "allow none" selection:
+	// the model deliberately ran a tool-free sub-agent. That is not an error,
+	// so return an empty surface without a warning.
+	if len(spec.tools) == 0 {
+		return nil, nil
+	}
+
+	selected := make([]tool.Tool, 0, len(spec.tools))
+	var warnings []string
+	for _, name := range spec.tools {
+		t, ok := candidateByName[name]
+		if !ok {
+			warnings = append(warnings, fmt.Sprintf(
+				"requested tool %q is not available and was ignored", name))
+			continue
+		}
+		selected = append(selected, t)
+	}
+	if len(selected) == 0 {
+		warnings = append(warnings,
+			"none of the requested tools were available; the sub-agent has no user tools")
+	}
+	return selected, warnings
+}
+
+// dynamicMaxSkillRepo resolves the maximum skill repository the model may
+// select from: the code-side WithCapabilitySkills repository when set, else the
+// parent invocation's effective repository. It never returns the template
+// agent's own repository — the boundary is always the parent's skills (or an
+// explicit capability override).
+func (at *Tool) dynamicMaxSkillRepo(
+	ctx context.Context,
+	parentInv *agent.Invocation,
+) skill.Repository {
+	if at.dynamicCfg.capabilitySkills != nil {
+		return at.dynamicCfg.capabilitySkills
+	}
+	if parentInv == nil || parentInv.Agent == nil {
+		return nil
+	}
+	if provider, ok := parentInv.Agent.(agent.InvocationSkillRepositoryProvider); ok {
+		return provider.InvocationSkillRepository(ctx, parentInv)
+	}
+	return nil
+}
+
+// childCodeExecutor resolves, best-effort, the code executor the dynamic child
+// will run with, so skill selection can warn when execution-dependent skills
+// are requested without one. It mirrors the child's executor AFTER RunOptions
+// sanitization:
+//   - with a template agent the template's own executor is authoritative (the
+//     parent's run-scoped executor is cleared on the child), so parentInv's
+//     RunOptions.CodeExecutor is intentionally ignored here;
+//   - without a template the child is the parent, so it inherits the parent's
+//     run-scoped executor, falling back to the parent agent's executor.
+func (at *Tool) childCodeExecutor(
+	ctx context.Context,
+	parentInv *agent.Invocation,
+) codeexecutor.CodeExecutor {
+	if at.dynamicCfg.templateAgent != nil {
+		if p, ok := at.dynamicCfg.templateAgent.(agent.InvocationCodeExecutorProvider); ok {
+			templateInv := agent.NewInvocation(
+				agent.WithInvocationAgent(at.dynamicCfg.templateAgent),
+			)
+			return p.InvocationCodeExecutor(ctx, templateInv)
+		}
+		return nil
+	}
+	if parentInv != nil && parentInv.RunOptions.CodeExecutor != nil {
+		return parentInv.RunOptions.CodeExecutor
+	}
+	if parentInv == nil || parentInv.Agent == nil {
+		return nil
+	}
+	if p, ok := parentInv.Agent.(agent.InvocationCodeExecutorProvider); ok {
+		return p.InvocationCodeExecutor(ctx, parentInv)
+	}
+	return nil
+}
+
+// selectDynamicSkills resolves the skill repository to mount on the child.
+//
+// It returns the repository, whether the surface patch must set it, and any
+// non-fatal warnings. The skill boundary is WithCapabilitySkills when set,
+// otherwise the parent invocation's effective repository (never the template
+// agent's own repository).
+//
+//   - With no model selection it defaults the child to the boundary repository
+//     and patches it whenever the boundary exists; when there is no boundary it
+//     still applies an empty override if a template agent is configured, so the
+//     template's own skills cannot leak into a child meant to mirror the parent.
+//   - With a model selection it narrows the boundary to the selected names,
+//     warning about unknown names and (best effort) about selected skills that
+//     may need a code executor the child does not have.
+func (at *Tool) selectDynamicSkills(
+	ctx context.Context,
+	parentInv *agent.Invocation,
+	spec dynamicSpec,
+) (skill.Repository, bool, []string) {
+	maxRepo := at.dynamicMaxSkillRepo(ctx, parentInv)
+
+	if !at.dynamicCfg.exposeSkillSelection || !spec.skillsProvided {
+		if maxRepo != nil {
+			return maxRepo, true, nil
+		}
+		// No boundary repository: override (with none) only when a template
+		// agent is configured, otherwise leave the base (== parent) untouched.
+		return nil, at.dynamicCfg.templateAgent != nil, nil
+	}
+
+	if maxRepo == nil {
+		// Selection is ignored (no boundary repository is available), but a
+		// template call must still override skills with none; otherwise the
+		// template agent's own skills would leak to the child, outside the
+		// code-defined dynamic boundary. This mirrors the skillsProvided==false
+		// branch above.
+		return nil, at.dynamicCfg.templateAgent != nil, []string{
+			"skills selection was ignored because no skill repository is available",
+		}
+	}
+
+	available := make(map[string]bool)
+	for _, s := range skill.SummariesForContext(ctx, maxRepo) {
+		available[s.Name] = true
+	}
+	selected := make(map[string]bool, len(spec.skills))
+	var warnings []string
+	for _, name := range spec.skills {
+		if available[name] {
+			selected[name] = true
+			continue
+		}
+		warnings = append(warnings, fmt.Sprintf(
+			"requested skill %q is not available and was ignored", name))
+	}
+	if len(selected) > 0 && at.childCodeExecutor(ctx, parentInv) == nil {
+		warnings = append(warnings,
+			"the sub-agent has no code executor, so any selected skill that "+
+				"requires running code may not work")
+	}
+	filtered := skill.NewFilteredRepository(
+		maxRepo,
+		func(_ context.Context, s skill.Summary) bool {
+			return selected[s.Name]
+		},
+	)
+	return filtered, true, warnings
+}
+
+// dynamicChildInvocationOptions builds the invocation options for a dynamic
+// child run, mounting the surface patch on a dedicated root node and sanitizing
+// the run-scoped options inherited from the parent clone so they cannot bypass
+// the code-defined boundary.
+func (at *Tool) dynamicChildInvocationOptions(
+	baseAgent agent.Agent,
+	message model.Message,
+	childKey string,
+	nodeID string,
+	patch agent.SurfacePatch,
+) []agent.InvocationOptions {
+	// With a template agent the template defines the execution boundary
+	// (model, executor, ...), so parent run-scoped overrides must not leak in.
+	// Without a template the child IS the parent agent, so it keeps them.
+	enforceTemplateBoundary := at.dynamicCfg.templateAgent != nil
+	return []agent.InvocationOptions{
+		agent.WithInvocationAgent(baseAgent),
+		agent.WithInvocationMessage(message),
+		agent.WithInvocationEventFilterKey(childKey),
+		func(inv *agent.Invocation) {
+			agent.SetInvocationSurfaceRootNodeID(inv, nodeID)
+			runOpts := inv.RunOptions
+			agent.WithSurfacePatchForNode(nodeID, patch)(&runOpts)
+			at.sanitizeChildRunOptions(&runOpts, enforceTemplateBoundary)
+			inv.RunOptions = runOpts
+		},
+	}
+}
+
+// sanitizeChildRunOptions strips run-scoped options inherited from the parent
+// clone that would otherwise undermine the dynamic boundary.
+//
+// Tool surface (cleared unconditionally): the surface patch is the single
+// source of truth for the child's tools, so every run-scoped tool input is
+// cleared. AdditionalTools/ExternalTools/ExternalToolNames would otherwise be
+// re-appended by the child flow on top of the selected tools, and ToolFilter
+// would re-run in the child flow — wrongly dropping code-defined
+// WithCapabilityTools/WithCapabilityProvider tools that never passed through it
+// (the parent filter was already applied when deriving the candidate surface).
+//
+// Template boundary (cleared only when a template agent is configured): the
+// template defines model, prompt and execution, so parent run-scoped overrides
+// must not leak in:
+//   - model: Model/ModelName/ModelSelector all outrank the template's own
+//     model resolution;
+//   - prompt: Instruction/GlobalInstruction outrank the template prompt — a
+//     model-provided instruction still applies because it travels via the
+//     surface patch, which is resolved before RunOptions;
+//   - execution: CodeExecutor, plus the execution-policy filters
+//     (ToolExecutionFilter defers tool calls, ToolPermissionPolicy gates them)
+//     which have no natural external-continuation channel for a synchronous
+//     sub-agent. Inheriting these requires an explicit future Option.
+func (at *Tool) sanitizeChildRunOptions(
+	runOpts *agent.RunOptions,
+	enforceTemplateBoundary bool,
+) {
+	runOpts.AdditionalTools = nil
+	runOpts.ExternalTools = nil
+	runOpts.ExternalToolNames = nil
+	runOpts.ToolFilter = nil
+	if !enforceTemplateBoundary {
+		return
+	}
+	runOpts.Model = nil
+	runOpts.ModelName = ""
+	runOpts.ModelSelector = nil
+	runOpts.Instruction = ""
+	runOpts.GlobalInstruction = ""
+	runOpts.CodeExecutor = nil
+	runOpts.ToolExecutionFilter = nil
+	runOpts.ToolPermissionPolicy = nil
+}
+
+// buildDynamicChildFilterKey constructs the child filter key honoring the
+// configured history scope (isolated by default).
+func (at *Tool) buildDynamicChildFilterKey(
+	parentInv *agent.Invocation,
+	baseAgent agent.Agent,
+) string {
+	base := at.name
+	if baseAgent != nil {
+		if info := baseAgent.Info(); info.Name != "" {
+			base = info.Name
+		}
+	}
+	childKey := base + "-" + uuid.NewString()
+	if at.historyScope == HistoryScopeParentBranch {
+		if pk := parentInv.GetEventFilterKey(); pk != "" {
+			childKey = pk + agent.EventFilterKeyDelimiter + childKey
+		}
+	}
+	return childKey
+}
+
+// dynamicSurfaceNodeID returns a unique surface root node id for one dynamic
+// invocation. Any unique string works because the surface patch is keyed by
+// this id and looked up by equality.
+func dynamicSurfaceNodeID(name string) string {
+	return name + "/dynamic-" + uuid.NewString()
+}
+
+// warningsNote renders non-fatal warnings as a short note block attributed to
+// the dynamic tool, or "" when there are none. It is shared by the Call and
+// stream paths so the parent model sees the same warnings either way.
+func (at *Tool) warningsNote(warnings []string) string {
+	if len(warnings) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("Note from ")
+	b.WriteString(at.name)
+	b.WriteString(":\n")
+	for _, w := range warnings {
+		b.WriteString("- ")
+		b.WriteString(w)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// formatResponseWithWarnings prepends any non-fatal warnings to the sub-agent
+// response so the parent model learns about ignored selections.
+func (at *Tool) formatResponseWithWarnings(response string, warnings []string) string {
+	note := at.warningsNote(warnings)
+	if note == "" {
+		return response
+	}
+	if response != "" {
+		return note + "\n" + response
+	}
+	return note
+}
+
+func toolNameSet(tools []tool.Tool) map[string]bool {
+	names := make(map[string]bool, len(tools))
+	for _, t := range tools {
+		if name := declarationName(t); name != "" {
+			names[name] = true
+		}
+	}
+	return names
+}
+
+func declarationName(t tool.Tool) string {
+	if t == nil {
+		return ""
+	}
+	decl := t.Declaration()
+	if decl == nil {
+		return ""
+	}
+	return decl.Name
+}
+
+func dedupeNonEmpty(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(values))
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		v = strings.TrimSpace(v)
+		if v == "" || seen[v] {
+			continue
+		}
+		seen[v] = true
+		out = append(out, v)
+	}
+	return out
+}

--- a/tool/agent/dynamic_tool_test.go
+++ b/tool/agent/dynamic_tool_test.go
@@ -1,0 +1,1335 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package agent
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	agentlog "trpc.group/trpc-go/trpc-agent-go/log"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/skill"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+	"trpc.group/trpc-go/trpc-agent-go/tool/function"
+	"trpc.group/trpc-go/trpc-agent-go/tool/transfer"
+)
+
+// dynStubTool is a minimal tool.Tool used to exercise the dynamic tool's
+// selection logic without a runtime.
+type dynStubTool struct {
+	name string
+}
+
+func (s dynStubTool) Declaration() *tool.Declaration {
+	return &tool.Declaration{Name: s.name}
+}
+
+func stubTools(names ...string) []tool.Tool {
+	tools := make([]tool.Tool, 0, len(names))
+	for _, n := range names {
+		tools = append(tools, dynStubTool{name: n})
+	}
+	return tools
+}
+
+func selectedNames(tools []tool.Tool) []string {
+	names := make([]string, 0, len(tools))
+	for _, t := range tools {
+		names = append(names, declarationName(t))
+	}
+	sort.Strings(names)
+	return names
+}
+
+func TestNewDynamicTool_Defaults(t *testing.T) {
+	at := NewDynamicTool()
+
+	decl := at.Declaration()
+	require.Equal(t, DefaultDynamicToolName, decl.Name)
+	require.Equal(t, "dynamic_agent", decl.Name)
+	require.NotEmpty(t, decl.Description)
+	require.True(t, at.dynamic)
+
+	require.NotNil(t, decl.InputSchema)
+	props := decl.InputSchema.Properties
+	require.Contains(t, props, fieldRequest)
+	require.Contains(t, props, fieldInstruction) // exposed by default
+	require.Contains(t, props, fieldTools)       // exposed by default
+	require.NotContains(t, props, fieldSkills)   // not exposed by default
+	require.Equal(t, []string{fieldRequest}, decl.InputSchema.Required)
+
+	require.NotNil(t, decl.OutputSchema)
+	require.Equal(t, "string", decl.OutputSchema.Type)
+}
+
+func TestNewDynamicTool_TypesRemainComparable(t *testing.T) {
+	_ = map[Tool]struct{}{}
+	_ = map[agentToolOptions]struct{}{}
+}
+
+func TestNewDynamicTool_WithNameAndDescription(t *testing.T) {
+	at := NewDynamicTool(
+		WithName("explore"),
+		WithDescription("custom desc"),
+	)
+	decl := at.Declaration()
+	require.Equal(t, "explore", decl.Name)
+	require.Equal(t, "custom desc", decl.Description)
+	// Schema description should reference the configured name.
+	require.Contains(t, decl.InputSchema.Description, "explore")
+}
+
+// TestNewDynamicTool_DescriptionReflectsExposedFields verifies the model-facing
+// description advertises exactly the per-call fields present in the schema, so
+// the model discovers configurability from the description+schema (not the
+// tool name) and is never told about a field the schema omits.
+func TestNewDynamicTool_DescriptionReflectsExposedFields(t *testing.T) {
+	// Defaults: instruction + tools exposed, skills not.
+	def := NewDynamicTool().Declaration().Description
+	require.Contains(t, def, "'instruction'")
+	require.Contains(t, def, "'tools'")
+	require.NotContains(t, def, "'skills'")
+
+	// All exposed.
+	all := NewDynamicTool(WithExposeSkillSelection(true)).Declaration().Description
+	require.Contains(t, all, "'instruction'")
+	require.Contains(t, all, "'tools'")
+	require.Contains(t, all, "'skills'")
+
+	// None exposed: only the fixed boundary statement, no field hints.
+	none := NewDynamicTool(
+		WithExposeInstruction(false),
+		WithExposeToolSelection(false),
+	).Declaration().Description
+	require.NotContains(t, none, "'instruction'")
+	require.NotContains(t, none, "'tools'")
+	require.NotContains(t, none, "'skills'")
+	require.Contains(t, none, "short-lived", "boundary statement must remain")
+}
+
+// TestNewDynamicTool_DescriptionReflectsHistoryScope verifies the model-facing
+// description matches the configured history scope (isolated by default,
+// parent-branch when opted in) so it never tells the model "no memory" when the
+// sub-agent actually inherits the parent conversation. It also checks the
+// capability-boundary wording covers code-defined surfaces, not only the parent
+// agent's currently-allowed tools.
+func TestNewDynamicTool_DescriptionReflectsHistoryScope(t *testing.T) {
+	def := NewDynamicTool().Declaration().Description
+	require.Contains(t, def, "no memory of this conversation")
+	require.NotContains(t, def, "see the current conversation's history")
+	require.Contains(t, def, "code-defined capability boundary")
+	require.Contains(t, def, "parent conversation focused")
+
+	pb := NewDynamicTool(
+		WithHistoryScope(HistoryScopeParentBranch),
+	).Declaration().Description
+	require.Contains(t, pb, "see the current conversation's history")
+	require.NotContains(t, pb, "no memory of this conversation")
+	require.NotContains(t, pb, "parent conversation focused")
+}
+
+// TestNewDynamicTool_CapabilityToolsEnumerated verifies a statically configured
+// capability surface (WithCapabilityTools) is enumerated in the schema so the
+// model selects from known names, while the parent-derived and provider
+// surfaces (resolved per call) are not enumerated at schema-build time.
+func TestNewDynamicTool_CapabilityToolsEnumerated(t *testing.T) {
+	// WithCapabilityTools: names appear as enum and in the default description.
+	at := NewDynamicTool(WithCapabilityTools(stubTools("search_code", "read_file")))
+	ts := at.Declaration().InputSchema.Properties[fieldTools]
+	require.NotNil(t, ts.Items)
+	require.ElementsMatch(t, []any{"read_file", "search_code"}, ts.Items.Enum)
+	require.Contains(t, ts.Description, "read_file")
+	require.Contains(t, ts.Description, "search_code")
+
+	// Duplicate names are de-duplicated; the enum holds unique names only and
+	// the size bound is applied after de-duplication.
+	atDup := NewDynamicTool(WithCapabilityTools(stubTools("dup", "dup", "other")))
+	tsDup := atDup.Declaration().InputSchema.Properties[fieldTools]
+	require.ElementsMatch(t, []any{"dup", "other"}, tsDup.Items.Enum)
+
+	// A custom tools description is respected (no auto-append) but enum stays.
+	at2 := NewDynamicTool(
+		WithCapabilityTools(stubTools("a")),
+		WithToolsDescription("pick wisely"),
+	)
+	ts2 := at2.Declaration().InputSchema.Properties[fieldTools]
+	require.Equal(t, "pick wisely", ts2.Description)
+	require.Equal(t, []any{"a"}, ts2.Items.Enum)
+
+	// Default parent-derived surface: not enumerable at schema-build time.
+	ts3 := NewDynamicTool().Declaration().InputSchema.Properties[fieldTools]
+	require.Nil(t, ts3.Items.Enum)
+
+	// Provider-based surface: resolved per call, not enumerated at build time.
+	at4 := NewDynamicTool(WithCapabilityProvider(
+		func(context.Context, *agent.Invocation) ([]tool.Tool, map[string]bool) {
+			return stubTools("x"), nil
+		}))
+	ts4 := at4.Declaration().InputSchema.Properties[fieldTools]
+	require.Nil(t, ts4.Items.Enum)
+}
+
+func TestNewDynamicTool_ExposeToggles(t *testing.T) {
+	at := NewDynamicTool(
+		WithExposeInstruction(false),
+		WithExposeToolSelection(false),
+		WithExposeSkillSelection(true),
+	)
+	props := at.Declaration().InputSchema.Properties
+	require.Contains(t, props, fieldRequest)
+	require.NotContains(t, props, fieldInstruction)
+	require.NotContains(t, props, fieldTools)
+	require.Contains(t, props, fieldSkills)
+}
+
+func TestNewDynamicTool_CustomFieldDescriptions(t *testing.T) {
+	at := NewDynamicTool(
+		WithRequestDescription("req-desc"),
+		WithInstructionDescription("inst-desc"),
+		WithToolsDescription("tools-desc"),
+		WithExposeSkillSelection(true),
+		WithSkillsDescription("skills-desc"),
+	)
+	props := at.Declaration().InputSchema.Properties
+	require.Equal(t, "req-desc", props[fieldRequest].Description)
+	require.Equal(t, "inst-desc", props[fieldInstruction].Description)
+	require.Equal(t, "tools-desc", props[fieldTools].Description)
+	require.Equal(t, "skills-desc", props[fieldSkills].Description)
+}
+
+func TestParseDynamicArgs(t *testing.T) {
+	t.Run("full args with everything exposed", func(t *testing.T) {
+		at := NewDynamicTool(WithExposeSkillSelection(true))
+		spec := at.parseDynamicArgs([]byte(
+			`{"request":" do it ","instruction":" be brief ","tools":["a","b"],"skills":["s1"]}`,
+		))
+		require.Equal(t, "do it", spec.request)
+		require.Equal(t, "be brief", spec.instruction)
+		require.True(t, spec.toolsProvided)
+		require.Equal(t, []string{"a", "b"}, spec.tools)
+		require.True(t, spec.skillsProvided)
+		require.Equal(t, []string{"s1"}, spec.skills)
+	})
+
+	t.Run("omitted tools means not provided", func(t *testing.T) {
+		at := NewDynamicTool()
+		spec := at.parseDynamicArgs([]byte(`{"request":"x"}`))
+		require.False(t, spec.toolsProvided)
+		require.Empty(t, spec.tools)
+	})
+
+	t.Run("empty tools array means provided-but-none", func(t *testing.T) {
+		at := NewDynamicTool()
+		spec := at.parseDynamicArgs([]byte(`{"request":"x","tools":[]}`))
+		require.True(t, spec.toolsProvided)
+		require.Empty(t, spec.tools)
+	})
+
+	t.Run("fields ignored when not exposed", func(t *testing.T) {
+		at := NewDynamicTool(
+			WithExposeInstruction(false),
+			WithExposeToolSelection(false),
+		)
+		spec := at.parseDynamicArgs([]byte(
+			`{"request":"x","instruction":"ignored","tools":["a"],"skills":["s"]}`,
+		))
+		require.Equal(t, "x", spec.request)
+		require.Empty(t, spec.instruction)
+		require.False(t, spec.toolsProvided)
+		require.False(t, spec.skillsProvided) // skills not exposed by default
+	})
+
+	t.Run("invalid json falls back to raw request", func(t *testing.T) {
+		at := NewDynamicTool()
+		spec := at.parseDynamicArgs([]byte(`just do the thing`))
+		require.Equal(t, "just do the thing", spec.request)
+	})
+
+	t.Run("tool names are trimmed and de-duplicated", func(t *testing.T) {
+		at := NewDynamicTool()
+		spec := at.parseDynamicArgs([]byte(`{"request":"x","tools":[" a ","a","","b"]}`))
+		require.Equal(t, []string{"a", "b"}, spec.tools)
+	})
+}
+
+func TestSelectDynamicTools_ExcludesSelfAndTransfer(t *testing.T) {
+	at := NewDynamicTool() // name == dynamic_agent
+	maxTools := stubTools(
+		"file_read",
+		"file_write",
+		at.name,                   // self must be excluded
+		transfer.TransferToolName, // transfer must be excluded
+	)
+	// No selection => all candidates minus excluded.
+	selected, warnings := at.selectDynamicTools(maxTools, toolNameSet(maxTools), nil, dynamicSpec{})
+	require.Empty(t, warnings)
+	require.Equal(t, []string{"file_read", "file_write"}, selectedNames(selected))
+}
+
+func TestSelectDynamicTools_OnlyUserTools(t *testing.T) {
+	at := NewDynamicTool()
+	maxTools := stubTools("file_read", "framework_tool")
+	userTools := map[string]bool{"file_read": true} // framework_tool not a user tool
+	selected, warnings := at.selectDynamicTools(maxTools, userTools, nil, dynamicSpec{})
+	require.Empty(t, warnings)
+	require.Equal(t, []string{"file_read"}, selectedNames(selected))
+}
+
+func TestSelectDynamicTools_SubsetSelection(t *testing.T) {
+	at := NewDynamicTool()
+	maxTools := stubTools("a", "b", "c")
+	spec := dynamicSpec{toolsProvided: true, tools: []string{"a", "c"}}
+	selected, warnings := at.selectDynamicTools(maxTools, toolNameSet(maxTools), nil, spec)
+	require.Empty(t, warnings)
+	require.Equal(t, []string{"a", "c"}, selectedNames(selected))
+}
+
+func TestSelectDynamicTools_UnknownRequestedToolWarns(t *testing.T) {
+	at := NewDynamicTool()
+	maxTools := stubTools("a", "b")
+	spec := dynamicSpec{toolsProvided: true, tools: []string{"a", "nope"}}
+	selected, warnings := at.selectDynamicTools(maxTools, toolNameSet(maxTools), nil, spec)
+	require.Equal(t, []string{"a"}, selectedNames(selected))
+	require.Len(t, warnings, 1)
+	require.Contains(t, warnings[0], "nope")
+}
+
+func TestSelectDynamicTools_AllUnknownWarnsNoUserTools(t *testing.T) {
+	at := NewDynamicTool()
+	maxTools := stubTools("a", "b")
+	spec := dynamicSpec{toolsProvided: true, tools: []string{"x", "y"}}
+	selected, warnings := at.selectDynamicTools(maxTools, toolNameSet(maxTools), nil, spec)
+	require.Empty(t, selected)
+	require.NotEmpty(t, warnings)
+	require.Contains(t, warnings[len(warnings)-1], "no user tools")
+}
+
+// TestSelectDynamicTools_ExcludesExternalTools verifies that caller-executed
+// external tools are never selectable for the child (fix 2): they are
+// visible-but-not-executed for the parent and have no execution channel in a
+// synchronous sub-agent.
+func TestSelectDynamicTools_ExcludesExternalTools(t *testing.T) {
+	at := NewDynamicTool()
+	maxTools := stubTools("tool_a", "ext_tool")
+	externalNames := map[string]bool{"ext_tool": true}
+
+	// No selection: external tool must not appear among the candidates.
+	selected, warnings := at.selectDynamicTools(
+		maxTools, toolNameSet(maxTools), externalNames, dynamicSpec{})
+	require.Empty(t, warnings)
+	require.Equal(t, []string{"tool_a"}, selectedNames(selected))
+
+	// Explicit selection of an external tool is rejected as unavailable.
+	spec := dynamicSpec{toolsProvided: true, tools: []string{"ext_tool"}}
+	selected, warnings = at.selectDynamicTools(
+		maxTools, toolNameSet(maxTools), externalNames, spec)
+	require.Empty(t, selected)
+	require.NotEmpty(t, warnings)
+}
+
+// TestSelectDynamicTools_EmptyArrayAllowsNoneWithoutWarning verifies that an
+// explicit empty "tools": [] is treated as a deliberate tool-free run, not an
+// error (fix 6).
+func TestSelectDynamicTools_EmptyArrayAllowsNoneWithoutWarning(t *testing.T) {
+	at := NewDynamicTool()
+	maxTools := stubTools("a", "b")
+	spec := dynamicSpec{toolsProvided: true, tools: nil} // provided, but empty
+	selected, warnings := at.selectDynamicTools(maxTools, toolNameSet(maxTools), nil, spec)
+	require.Empty(t, selected)
+	require.Empty(t, warnings, "an explicit empty selection must not warn")
+}
+
+func TestDedupeNonEmpty(t *testing.T) {
+	require.Nil(t, dedupeNonEmpty(nil))
+	require.Equal(t,
+		[]string{"a", "b"},
+		dedupeNonEmpty([]string{" a", "a ", "", "  ", "b"}),
+	)
+}
+
+func TestDeclarationNameAndToolNameSet(t *testing.T) {
+	require.Equal(t, "", declarationName(nil))
+	require.Equal(t, "foo", declarationName(dynStubTool{name: "foo"}))
+
+	set := toolNameSet(stubTools("a", "b", "a"))
+	require.True(t, set["a"])
+	require.True(t, set["b"])
+	require.Len(t, set, 2)
+}
+
+func TestFormatResponseWithWarnings(t *testing.T) {
+	at := NewDynamicTool()
+	require.Equal(t, "hello", at.formatResponseWithWarnings("hello", nil))
+
+	out := at.formatResponseWithWarnings("hello", []string{"w1", "w2"})
+	require.Contains(t, out, at.name)
+	require.Contains(t, out, "w1")
+	require.Contains(t, out, "w2")
+	require.Contains(t, out, "hello")
+}
+
+func TestDynamicSurfaceNodeID_UniqueWithPrefix(t *testing.T) {
+	a := dynamicSurfaceNodeID("dynamic_agent")
+	b := dynamicSurfaceNodeID("dynamic_agent")
+	require.NotEqual(t, a, b)
+	require.Contains(t, a, "dynamic_agent/dynamic-")
+}
+
+func TestCallDynamic_RequiresParentInvocation(t *testing.T) {
+	at := NewDynamicTool()
+	_, err := at.Call(context.Background(), []byte(`{"request":"x"}`))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "parent invocation")
+}
+
+func TestCallDynamic_RequiresRequest(t *testing.T) {
+	at := NewDynamicTool()
+	sess := session.NewSession("app", "user", "session")
+	parent := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationEventFilterKey("parent"),
+	)
+	ctx := agent.NewInvocationContext(context.Background(), parent)
+	_, err := at.Call(ctx, []byte(`{"request":"  "}`))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "request")
+}
+
+// dynRecordingModel records the set of tool names visible in each request.
+type dynRecordingModel struct {
+	name     string
+	response string
+	mu       sync.Mutex
+	seen     [][]string
+}
+
+func (m *dynRecordingModel) GenerateContent(
+	_ context.Context,
+	request *model.Request,
+) (<-chan *model.Response, error) {
+	names := make([]string, 0, len(request.Tools))
+	for n := range request.Tools {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	m.mu.Lock()
+	m.seen = append(m.seen, names)
+	m.mu.Unlock()
+
+	ch := make(chan *model.Response, 1)
+	ch <- &model.Response{
+		Done: true,
+		Choices: []model.Choice{{
+			Message: model.NewAssistantMessage(m.response),
+		}},
+	}
+	close(ch)
+	return ch, nil
+}
+
+func (m *dynRecordingModel) Info() model.Info { return model.Info{Name: m.name} }
+
+func (m *dynRecordingModel) snapshot() [][]string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([][]string, len(m.seen))
+	copy(out, m.seen)
+	return out
+}
+
+func newDynTestTool(name string) tool.Tool {
+	return function.NewFunctionTool(
+		func(_ context.Context, _ struct{}) (string, error) { return name, nil },
+		function.WithName(name),
+		function.WithDescription("test tool "+name),
+	)
+}
+
+// TestNewDynamicTool_Integration_RestrictsTools runs an actual dynamic
+// sub-agent (derived from the parent agent) and asserts the model selection
+// narrows the child's tool surface.
+func TestNewDynamicTool_Integration_RestrictsTools(t *testing.T) {
+	recModel := &dynRecordingModel{name: "rec", response: "child-done"}
+	main := llmagent.New(
+		"main",
+		llmagent.WithModel(recModel),
+		llmagent.WithTools([]tool.Tool{
+			newDynTestTool("tool_a"),
+			newDynTestTool("tool_b"),
+		}),
+	)
+
+	at := NewDynamicTool() // derive base agent + surface from the parent
+
+	sess := session.NewSession("app", "user", "session")
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(main),
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationEventFilterKey("main"),
+	)
+	ctx := agent.NewInvocationContext(context.Background(), parent)
+
+	got, err := at.Call(ctx, []byte(`{"request":"use tool a","tools":["tool_a"]}`))
+	require.NoError(t, err)
+	require.Equal(t, "child-done", got)
+
+	seen := recModel.snapshot()
+	require.Len(t, seen, 1, "child should have run exactly once")
+	require.Equal(t, []string{"tool_a"}, seen[0],
+		"child must see only the selected user tool")
+}
+
+// TestNewDynamicTool_Integration_DefaultAllTools verifies that omitting the
+// tools field lets the child use the full permitted (user) surface.
+func TestNewDynamicTool_Integration_DefaultAllTools(t *testing.T) {
+	recModel := &dynRecordingModel{name: "rec", response: "ok"}
+	main := llmagent.New(
+		"main",
+		llmagent.WithModel(recModel),
+		llmagent.WithTools([]tool.Tool{
+			newDynTestTool("tool_a"),
+			newDynTestTool("tool_b"),
+		}),
+	)
+
+	at := NewDynamicTool()
+
+	sess := session.NewSession("app", "user", "session")
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(main),
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationEventFilterKey("main"),
+	)
+	ctx := agent.NewInvocationContext(context.Background(), parent)
+
+	got, err := at.Call(ctx, []byte(`{"request":"do something"}`))
+	require.NoError(t, err)
+	require.Equal(t, "ok", got)
+
+	seen := recModel.snapshot()
+	require.Len(t, seen, 1)
+	require.Equal(t, []string{"tool_a", "tool_b"}, seen[0])
+}
+
+// TestNewDynamicTool_Integration_WithTemplateAgent verifies that a distinctly
+// named, tool-less template agent still receives the tools selected from the
+// parent surface (injected via the surface patch), and that the template agent
+// is the one that actually runs the child.
+func TestNewDynamicTool_Integration_WithTemplateAgent(t *testing.T) {
+	parentModel := &dynRecordingModel{name: "parent", response: "parent-should-not-run"}
+	templateModel := &dynRecordingModel{name: "template", response: "child-done"}
+
+	main := llmagent.New(
+		"main",
+		llmagent.WithModel(parentModel),
+		llmagent.WithTools([]tool.Tool{
+			newDynTestTool("tool_a"),
+			newDynTestTool("tool_b"),
+		}),
+	)
+	// Template defines the execution boundary (identity + model) but has no
+	// tools of its own; the selected tools are injected by the patch.
+	subTemplate := llmagent.New(
+		"subagent",
+		llmagent.WithModel(templateModel),
+		llmagent.WithInstruction("focused worker"),
+	)
+
+	at := NewDynamicTool(WithTemplateAgent(subTemplate))
+
+	sess := session.NewSession("app", "user", "session")
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(main),
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationEventFilterKey("main"),
+	)
+	ctx := agent.NewInvocationContext(context.Background(), parent)
+
+	got, err := at.Call(ctx, []byte(`{"request":"use tool a","tools":["tool_a"]}`))
+	require.NoError(t, err)
+	require.Equal(t, "child-done", got)
+
+	require.Empty(t, parentModel.snapshot(), "parent model must not run the child")
+	seen := templateModel.snapshot()
+	require.Len(t, seen, 1, "template agent should run exactly once")
+	require.Equal(t, []string{"tool_a"}, seen[0],
+		"tools selected from the parent surface must be injected into the template")
+}
+
+// TestNewDynamicTool_Integration_ExcludesSelf ensures the dynamic tool never
+// leaks itself into the child surface, preventing runaway recursion.
+func TestNewDynamicTool_Integration_ExcludesSelf(t *testing.T) {
+	recModel := &dynRecordingModel{name: "rec", response: "ok"}
+	at := NewDynamicTool()
+	main := llmagent.New(
+		"main",
+		llmagent.WithModel(recModel),
+		llmagent.WithTools([]tool.Tool{
+			newDynTestTool("tool_a"),
+			at, // the dynamic tool is also registered on the parent
+		}),
+	)
+
+	sess := session.NewSession("app", "user", "session")
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(main),
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationEventFilterKey("main"),
+	)
+	ctx := agent.NewInvocationContext(context.Background(), parent)
+
+	_, err := at.Call(ctx, []byte(`{"request":"go"}`))
+	require.NoError(t, err)
+
+	seen := recModel.snapshot()
+	require.Len(t, seen, 1)
+	require.Equal(t, []string{"tool_a"}, seen[0],
+		"the dynamic tool must not appear in its own child surface")
+}
+
+func TestNewDynamicTool_Integration_ExcludesSiblingAgentTools(t *testing.T) {
+	recModel := &dynRecordingModel{name: "rec", response: "ok"}
+	at := NewDynamicTool()
+	otherDynamic := NewDynamicTool(WithName("other_dynamic"))
+	wrappedAgent := llmagent.New(
+		"wrapped_agent",
+		llmagent.WithModel(&dynRecordingModel{name: "wrapped"}),
+	)
+	main := llmagent.New(
+		"main",
+		llmagent.WithModel(recModel),
+		llmagent.WithTools([]tool.Tool{
+			newDynTestTool("tool_a"),
+			at,
+			otherDynamic,
+			NewTool(wrappedAgent),
+		}),
+	)
+
+	sess := session.NewSession("app", "user", "session")
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(main),
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationEventFilterKey("main"),
+	)
+	ctx := agent.NewInvocationContext(context.Background(), parent)
+
+	_, err := at.Call(ctx, []byte(`{"request":"go"}`))
+	require.NoError(t, err)
+
+	seen := recModel.snapshot()
+	require.Len(t, seen, 1)
+	require.Equal(t, []string{"tool_a"}, seen[0],
+		"dynamic child surface must exclude all AgentTool entrypoints")
+}
+
+// --- Fix 5: WithName is dynamic-only ---------------------------------------
+
+// TestNewTool_IgnoresWithName ensures WithName does not rename a wrapped-agent
+// AgentTool, so its model-facing name never diverges from its identity (filter
+// key, team node id, recursion guards), and the misuse is surfaced.
+func TestNewTool_IgnoresWithName(t *testing.T) {
+	original := agentlog.Default
+	logger := &dynTestWarnLogger{}
+	agentlog.Default = logger
+	t.Cleanup(func() {
+		agentlog.Default = original
+	})
+
+	wrapped := llmagent.New("wrapped", llmagent.WithModel(&dynRecordingModel{name: "m"}))
+	at := NewTool(wrapped, WithName("renamed"))
+	require.Equal(t, "wrapped", at.Declaration().Name,
+		"NewTool keeps the wrapped agent's name; WithName is dynamic-only")
+	require.Equal(t, 1, logger.warnfCalls)
+}
+
+type dynTestWarnLogger struct {
+	warnfCalls int
+}
+
+func (l *dynTestWarnLogger) Debug(args ...any)                 {}
+func (l *dynTestWarnLogger) Debugf(format string, args ...any) {}
+func (l *dynTestWarnLogger) Info(args ...any)                  {}
+func (l *dynTestWarnLogger) Infof(format string, args ...any)  {}
+func (l *dynTestWarnLogger) Warn(args ...any)                  {}
+func (l *dynTestWarnLogger) Warnf(format string, args ...any)  { l.warnfCalls++ }
+func (l *dynTestWarnLogger) Error(args ...any)                 {}
+func (l *dynTestWarnLogger) Errorf(format string, args ...any) {}
+func (l *dynTestWarnLogger) Fatal(args ...any)                 {}
+func (l *dynTestWarnLogger) Fatalf(format string, args ...any) {}
+
+// --- Fix 4: stream-mode warnings reach the parent model --------------------
+
+func TestWarningsNoteAndPrefixStreamResult(t *testing.T) {
+	at := NewDynamicTool()
+	require.Equal(t, "", at.warningsNote(nil))
+	note := at.warningsNote([]string{"w1", "w2"})
+	require.Contains(t, note, at.name)
+	require.Contains(t, note, "w1")
+	require.Contains(t, note, "w2")
+
+	// Empty prefix leaves the result untouched (non-dynamic streaming path).
+	require.Equal(t, "x", prefixStreamResult("", "x"))
+	// String/nil results are prefixed; other types are left intact.
+	require.Equal(t, "p", prefixStreamResult("p", nil))
+	require.Equal(t, "p", prefixStreamResult("p", ""))
+	require.Equal(t, "p\nx", prefixStreamResult("p", "x"))
+	require.Equal(t, 42, prefixStreamResult("p", 42))
+}
+
+// --- Fixes 2/3/7: skills default to parent boundary, executor + context ----
+
+func newDynTestSkillRepo(t *testing.T, names ...string) skill.Repository {
+	t.Helper()
+	root := t.TempDir()
+	for _, n := range names {
+		dir := filepath.Join(root, n)
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, "SKILL.md"),
+			[]byte(fmt.Sprintf(
+				"---\nname: %s\ndescription: test skill\n---\nbody\n", n)),
+			0o644,
+		))
+	}
+	repo, err := skill.NewFSRepository(root)
+	require.NoError(t, err)
+	return repo
+}
+
+type fakeDynCodeExecutor struct{}
+
+func (fakeDynCodeExecutor) ExecuteCode(
+	context.Context, codeexecutor.CodeExecutionInput,
+) (codeexecutor.CodeExecutionResult, error) {
+	return codeexecutor.CodeExecutionResult{}, nil
+}
+
+func (fakeDynCodeExecutor) CodeBlockDelimiter() codeexecutor.CodeBlockDelimiter {
+	return codeexecutor.CodeBlockDelimiter{}
+}
+
+// taggedDynCodeExecutor is a code executor carrying an identity tag so tests can
+// assert which executor (template vs parent run-scoped) was resolved.
+type taggedDynCodeExecutor struct{ tag string }
+
+func (taggedDynCodeExecutor) ExecuteCode(
+	context.Context, codeexecutor.CodeExecutionInput,
+) (codeexecutor.CodeExecutionResult, error) {
+	return codeexecutor.CodeExecutionResult{}, nil
+}
+
+func (taggedDynCodeExecutor) CodeBlockDelimiter() codeexecutor.CodeBlockDelimiter {
+	return codeexecutor.CodeBlockDelimiter{}
+}
+
+type invocationCheckingExecutorAgent struct {
+	agent.Agent
+	exec      codeexecutor.CodeExecutor
+	sawInv    bool
+	sawAgent  bool
+	sawParent bool
+}
+
+func (a *invocationCheckingExecutorAgent) InvocationCodeExecutor(
+	_ context.Context,
+	inv *agent.Invocation,
+) codeexecutor.CodeExecutor {
+	if inv == nil {
+		panic("InvocationCodeExecutor received nil invocation")
+	}
+	a.sawInv = true
+	a.sawAgent = inv.Agent == a
+	a.sawParent = inv.GetParentInvocation() != nil
+	return a.exec
+}
+
+// TestSelectDynamicSkills_DefaultPatchesBoundary verifies that, with no model
+// selection, the child is patched to the resolved boundary repository so a
+// template agent's own skills cannot leak.
+func TestSelectDynamicSkills_DefaultPatchesBoundary(t *testing.T) {
+	repo := newDynTestSkillRepo(t, "alpha")
+	at := NewDynamicTool(WithCapabilitySkills(repo))
+	got, patch, warns := at.selectDynamicSkills(context.Background(), nil, dynamicSpec{})
+	require.True(t, patch)
+	require.Equal(t, repo, got)
+	require.Empty(t, warns)
+}
+
+// TestSelectDynamicSkills_TemplateOverridesEmpty verifies that when a template
+// agent is configured but there is no boundary repository, the patch still sets
+// an empty repository so the template's own skills do not leak into the child.
+func TestSelectDynamicSkills_TemplateOverridesEmpty(t *testing.T) {
+	tmpl := llmagent.New("subagent", llmagent.WithModel(&dynRecordingModel{name: "m"}))
+	at := NewDynamicTool(WithTemplateAgent(tmpl))
+	got, patch, warns := at.selectDynamicSkills(context.Background(), nil, dynamicSpec{})
+	require.True(t, patch, "template configured: must override with empty repo")
+	require.Nil(t, got)
+	require.Empty(t, warns)
+}
+
+// TestSelectDynamicSkills_NoTemplateNoRepoSkipsPatch verifies that with neither
+// a template nor a boundary repository the skill surface is left untouched.
+func TestSelectDynamicSkills_NoTemplateNoRepoSkipsPatch(t *testing.T) {
+	at := NewDynamicTool()
+	got, patch, warns := at.selectDynamicSkills(context.Background(), nil, dynamicSpec{})
+	require.False(t, patch)
+	require.Nil(t, got)
+	require.Empty(t, warns)
+}
+
+// TestSelectDynamicSkills_SelectionWarnsUnknownAndMissingExecutor covers the
+// model-selection path: unknown skills are dropped with a warning, and a
+// missing code executor is surfaced as a (best-effort) warning.
+func TestSelectDynamicSkills_SelectionWarnsUnknownAndMissingExecutor(t *testing.T) {
+	repo := newDynTestSkillRepo(t, "alpha")
+	at := NewDynamicTool(WithExposeSkillSelection(true), WithCapabilitySkills(repo))
+	spec := dynamicSpec{skillsProvided: true, skills: []string{"alpha", "ghost"}}
+	got, patch, warns := at.selectDynamicSkills(context.Background(), nil, spec)
+	require.True(t, patch)
+	require.NotNil(t, got)
+	require.Len(t, warns, 2)
+	require.Contains(t, warns[0], "ghost")
+	require.Contains(t, warns[1], "code executor")
+}
+
+// TestSelectDynamicSkills_SelectionWithExecutorNoExecWarning verifies that a
+// run-scoped executor on the parent invocation suppresses the executor warning.
+func TestSelectDynamicSkills_SelectionWithExecutorNoExecWarning(t *testing.T) {
+	repo := newDynTestSkillRepo(t, "alpha")
+	at := NewDynamicTool(WithExposeSkillSelection(true), WithCapabilitySkills(repo))
+	sess := session.NewSession("app", "user", "session")
+	parent := agent.NewInvocation(agent.WithInvocationSession(sess))
+	parent.RunOptions.CodeExecutor = fakeDynCodeExecutor{}
+	spec := dynamicSpec{skillsProvided: true, skills: []string{"alpha"}}
+	got, patch, warns := at.selectDynamicSkills(context.Background(), parent, spec)
+	require.True(t, patch)
+	require.NotNil(t, got)
+	require.Empty(t, warns)
+}
+
+// TestSelectDynamicSkills_SelectionIgnoredNoRepo covers the model-selection
+// path when no boundary repository is available: the selection is dropped with
+// a warning. A template call must still override skills with none (patch=true)
+// so the template agent's own skills cannot leak past the dynamic boundary,
+// while a non-template call leaves the parent's skill surface untouched.
+func TestSelectDynamicSkills_SelectionIgnoredNoRepo(t *testing.T) {
+	spec := dynamicSpec{skillsProvided: true, skills: []string{"alpha"}}
+
+	// With a template: override with an empty repo even though selection is
+	// ignored, otherwise the template's own skills would leak to the child.
+	tmpl := llmagent.New("subagent", llmagent.WithModel(&dynRecordingModel{name: "m"}))
+	atTmpl := NewDynamicTool(WithExposeSkillSelection(true), WithTemplateAgent(tmpl))
+	got, patch, warns := atTmpl.selectDynamicSkills(context.Background(), nil, spec)
+	require.True(t, patch, "template configured: must override with empty repo")
+	require.Nil(t, got)
+	require.Len(t, warns, 1)
+	require.Contains(t, warns[0], "no skill repository")
+
+	// Without a template: leave the base (== parent) skill surface untouched.
+	atNoTmpl := NewDynamicTool(WithExposeSkillSelection(true))
+	got, patch, warns = atNoTmpl.selectDynamicSkills(context.Background(), nil, spec)
+	require.False(t, patch, "no template: leave parent skill surface untouched")
+	require.Nil(t, got)
+	require.Len(t, warns, 1)
+	require.Contains(t, warns[0], "no skill repository")
+}
+
+// TestNewDynamicTool_StreamableCall_ForwardsChildResponse exercises the
+// streaming entry point (streamDynamic): the dynamic child runs and its
+// response is forwarded to the parent as stream chunks, mirroring the Call
+// path (same capability boundary, surfaced via the shared sub-invocation).
+func TestNewDynamicTool_StreamableCall_ForwardsChildResponse(t *testing.T) {
+	recModel := &dynRecordingModel{name: "main", response: "streamed-ok"}
+	main := llmagent.New(
+		"main",
+		llmagent.WithModel(recModel),
+		llmagent.WithTools([]tool.Tool{newDynTestTool("tool_a")}),
+	)
+	at := NewDynamicTool()
+
+	sess := session.NewSession("app", "user", "session")
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(main),
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationEventFilterKey("main"),
+	)
+	ctx := agent.NewInvocationContext(context.Background(), parent)
+
+	reader, err := at.StreamableCall(ctx, []byte(`{"request":"do something"}`))
+	require.NoError(t, err)
+	defer reader.Close()
+
+	var sb strings.Builder
+	for {
+		chunk, recvErr := reader.Recv()
+		if recvErr == io.EOF {
+			break
+		}
+		require.NoError(t, recvErr)
+		switch c := chunk.Content.(type) {
+		case *event.Event:
+			require.Nil(t, c.Error)
+			if c.Response != nil && len(c.Response.Choices) > 0 {
+				sb.WriteString(c.Response.Choices[0].Message.Content)
+			}
+		case string:
+			sb.WriteString(c)
+		}
+	}
+	require.Contains(t, sb.String(), "streamed-ok")
+	require.NotEmpty(t, recModel.snapshot(), "stream path must actually run the child")
+}
+
+// TestNewDynamicTool_StreamableCall_BuildErrorSurfaced verifies the streaming
+// error path: a request that fails to build a sub-invocation surfaces the error
+// on the stream (as a chunk) instead of panicking or silently dropping it.
+func TestNewDynamicTool_StreamableCall_BuildErrorSurfaced(t *testing.T) {
+	recModel := &dynRecordingModel{name: "main"}
+	main := llmagent.New("main", llmagent.WithModel(recModel))
+	at := NewDynamicTool()
+
+	sess := session.NewSession("app", "user", "session")
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(main),
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationEventFilterKey("main"),
+	)
+	ctx := agent.NewInvocationContext(context.Background(), parent)
+
+	// A blank request fails buildDynamicSubInvocation.
+	reader, err := at.StreamableCall(ctx, []byte(`{"request":"  "}`))
+	require.NoError(t, err)
+	defer reader.Close()
+
+	var sb strings.Builder
+	for {
+		chunk, recvErr := reader.Recv()
+		if recvErr == io.EOF {
+			break
+		}
+		require.NoError(t, recvErr)
+		switch c := chunk.Content.(type) {
+		case string:
+			sb.WriteString(c)
+		case *event.Event:
+			if c.Error != nil {
+				sb.WriteString(c.Error.Message)
+			}
+		}
+	}
+	require.Contains(t, sb.String(), "dynamic sub-agent error")
+	require.Empty(t, recModel.snapshot(), "no child should run for an invalid request")
+}
+
+// --- Fix 1: child surface = parent's CURRENT effective user surface --------
+
+// TestNewDynamicTool_Integration_AppliesParentToolFilter ensures the child
+// surface honors the parent run's ToolFilter (a tool hidden this turn must not
+// reappear in the child).
+func TestNewDynamicTool_Integration_AppliesParentToolFilter(t *testing.T) {
+	recModel := &dynRecordingModel{name: "rec", response: "ok"}
+	main := llmagent.New(
+		"main",
+		llmagent.WithModel(recModel),
+		llmagent.WithTools([]tool.Tool{
+			newDynTestTool("tool_a"),
+			newDynTestTool("tool_b"),
+		}),
+	)
+	at := NewDynamicTool()
+
+	sess := session.NewSession("app", "user", "session")
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(main),
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationEventFilterKey("main"),
+	)
+	parent.RunOptions.ToolFilter = func(_ context.Context, tl tool.Tool) bool {
+		return tl.Declaration().Name != "tool_b"
+	}
+	ctx := agent.NewInvocationContext(context.Background(), parent)
+
+	_, err := at.Call(ctx, []byte(`{"request":"go"}`))
+	require.NoError(t, err)
+
+	seen := recModel.snapshot()
+	require.Len(t, seen, 1)
+	require.Equal(t, []string{"tool_a"}, seen[0],
+		"child surface must reflect the parent's run-scoped ToolFilter")
+}
+
+// TestNewDynamicTool_Integration_IncludesRunOptionAdditionalTools ensures the
+// child surface includes tools the parent run temporarily appended via
+// RunOptions.AdditionalTools.
+func TestNewDynamicTool_Integration_IncludesRunOptionAdditionalTools(t *testing.T) {
+	recModel := &dynRecordingModel{name: "rec", response: "ok"}
+	main := llmagent.New(
+		"main",
+		llmagent.WithModel(recModel),
+		llmagent.WithTools([]tool.Tool{newDynTestTool("tool_a")}),
+	)
+	at := NewDynamicTool()
+
+	sess := session.NewSession("app", "user", "session")
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(main),
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationEventFilterKey("main"),
+	)
+	parent.RunOptions.AdditionalTools = []tool.Tool{newDynTestTool("extra_tool")}
+	ctx := agent.NewInvocationContext(context.Background(), parent)
+
+	_, err := at.Call(ctx, []byte(`{"request":"go"}`))
+	require.NoError(t, err)
+
+	seen := recModel.snapshot()
+	require.Len(t, seen, 1)
+	require.Equal(t, []string{"extra_tool", "tool_a"}, seen[0],
+		"child surface must include run-scoped AdditionalTools")
+}
+
+// TestNewDynamicTool_Integration_ModelSelectionDropsParentAdditionalTool is the
+// fix 1 regression: when the model narrows the selection, a parent
+// RunOptions.AdditionalTools tool the model did NOT pick must not be re-appended
+// to the child by the child flow. The surface patch is the only authority.
+func TestNewDynamicTool_Integration_ModelSelectionDropsParentAdditionalTool(t *testing.T) {
+	recModel := &dynRecordingModel{name: "rec", response: "ok"}
+	main := llmagent.New(
+		"main",
+		llmagent.WithModel(recModel),
+		llmagent.WithTools([]tool.Tool{newDynTestTool("tool_a")}),
+	)
+	at := NewDynamicTool()
+
+	sess := session.NewSession("app", "user", "session")
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(main),
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationEventFilterKey("main"),
+	)
+	parent.RunOptions.AdditionalTools = []tool.Tool{newDynTestTool("extra_tool")}
+	ctx := agent.NewInvocationContext(context.Background(), parent)
+
+	// Model selects only tool_a; extra_tool was offered but not chosen.
+	_, err := at.Call(ctx, []byte(`{"request":"go","tools":["tool_a"]}`))
+	require.NoError(t, err)
+
+	seen := recModel.snapshot()
+	require.Len(t, seen, 1)
+	require.Equal(t, []string{"tool_a"}, seen[0],
+		"a parent AdditionalTool the model did not select must not leak into the child")
+}
+
+// TestNewDynamicTool_Integration_ExcludesParentExternalTools is the fix 2
+// regression: caller-executed external tools declared on the parent run must
+// not be exposed to (or executable by) the child.
+func TestNewDynamicTool_Integration_ExcludesParentExternalTools(t *testing.T) {
+	recModel := &dynRecordingModel{name: "rec", response: "ok"}
+	main := llmagent.New(
+		"main",
+		llmagent.WithModel(recModel),
+		llmagent.WithTools([]tool.Tool{newDynTestTool("tool_a")}),
+	)
+	at := NewDynamicTool()
+
+	sess := session.NewSession("app", "user", "session")
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(main),
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationEventFilterKey("main"),
+	)
+	parent.RunOptions.ExternalTools = []tool.Tool{newDynTestTool("ext_tool")}
+	ctx := agent.NewInvocationContext(context.Background(), parent)
+
+	_, err := at.Call(ctx, []byte(`{"request":"go"}`))
+	require.NoError(t, err)
+
+	seen := recModel.snapshot()
+	require.Len(t, seen, 1)
+	require.Equal(t, []string{"tool_a"}, seen[0],
+		"external (caller-executed) tools must not be exposed to the child")
+}
+
+// TestNewDynamicTool_Integration_SuppressesFrameworkTransfer is the fix 3
+// regression: even when the base/template agent has sub-agents of its own, the
+// child must not be offered transfer_to_agent.
+func TestNewDynamicTool_Integration_SuppressesFrameworkTransfer(t *testing.T) {
+	templateModel := &dynRecordingModel{name: "template", response: "child-done"}
+	leaf := llmagent.New("leaf", llmagent.WithModel(&dynRecordingModel{name: "leaf"}))
+	// Template has a sub-agent, so the framework would normally auto-add
+	// transfer_to_agent to its tool surface.
+	subTemplate := llmagent.New(
+		"subagent",
+		llmagent.WithModel(templateModel),
+		llmagent.WithSubAgents([]agent.Agent{leaf}),
+	)
+	main := llmagent.New(
+		"main",
+		llmagent.WithModel(&dynRecordingModel{name: "parent"}),
+		llmagent.WithTools([]tool.Tool{newDynTestTool("tool_a")}),
+	)
+	at := NewDynamicTool(WithTemplateAgent(subTemplate))
+
+	sess := session.NewSession("app", "user", "session")
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(main),
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationEventFilterKey("main"),
+	)
+	ctx := agent.NewInvocationContext(context.Background(), parent)
+
+	got, err := at.Call(ctx, []byte(`{"request":"go"}`))
+	require.NoError(t, err)
+	require.Equal(t, "child-done", got)
+
+	seen := templateModel.snapshot()
+	require.Len(t, seen, 1)
+	require.NotContains(t, seen[0], transfer.TransferToolName,
+		"the child must not be offered framework transfer_to_agent")
+	require.Equal(t, []string{"tool_a"}, seen[0])
+}
+
+// TestNewDynamicTool_Integration_TemplateModelBoundary is the fix 4 regression:
+// when a template agent defines the boundary, a parent run-scoped model override
+// must not leak into the child; the template's own model runs it.
+func TestNewDynamicTool_Integration_TemplateModelBoundary(t *testing.T) {
+	overrideModel := &dynRecordingModel{name: "override", response: "override-ran"}
+	templateModel := &dynRecordingModel{name: "template", response: "child-done"}
+
+	main := llmagent.New(
+		"main",
+		llmagent.WithModel(&dynRecordingModel{name: "parent"}),
+		llmagent.WithTools([]tool.Tool{newDynTestTool("tool_a")}),
+	)
+	subTemplate := llmagent.New(
+		"subagent",
+		llmagent.WithModel(templateModel),
+	)
+	at := NewDynamicTool(WithTemplateAgent(subTemplate))
+
+	sess := session.NewSession("app", "user", "session")
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(main),
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationEventFilterKey("main"),
+	)
+	// Parent run pins a model override; it must not cross the template boundary.
+	parent.RunOptions.Model = overrideModel
+	ctx := agent.NewInvocationContext(context.Background(), parent)
+
+	got, err := at.Call(ctx, []byte(`{"request":"go"}`))
+	require.NoError(t, err)
+	require.Equal(t, "child-done", got)
+	require.Empty(t, overrideModel.snapshot(),
+		"parent RunOptions.Model must not override the template boundary")
+	require.Len(t, templateModel.snapshot(), 1,
+		"the template's own model must run the child")
+}
+
+// TestChildCodeExecutor_TemplateIgnoresParentRunOption verifies that, with a
+// template agent, the template's own executor is authoritative and a parent
+// run-scoped executor is ignored (it is cleared on the child clone).
+func TestChildCodeExecutor_TemplateIgnoresParentRunOption(t *testing.T) {
+	tmpl := llmagent.New(
+		"subagent",
+		llmagent.WithModel(&dynRecordingModel{name: "m"}),
+		llmagent.WithCodeExecutor(taggedDynCodeExecutor{tag: "template"}),
+	)
+	at := NewDynamicTool(WithTemplateAgent(tmpl))
+
+	sess := session.NewSession("app", "user", "session")
+	parent := agent.NewInvocation(agent.WithInvocationSession(sess))
+	parent.RunOptions.CodeExecutor = taggedDynCodeExecutor{tag: "parent"}
+
+	got := at.childCodeExecutor(context.Background(), parent)
+	tagged, ok := got.(taggedDynCodeExecutor)
+	require.True(t, ok)
+	require.Equal(t, "template", tagged.tag,
+		"with a template, the template's executor wins over a parent run-scoped one")
+}
+
+func TestChildCodeExecutor_TemplatePassesNonNilInvocation(t *testing.T) {
+	base := llmagent.New(
+		"subagent",
+		llmagent.WithModel(&dynRecordingModel{name: "m"}),
+	)
+	tmpl := &invocationCheckingExecutorAgent{
+		Agent: base,
+		exec:  taggedDynCodeExecutor{tag: "template"},
+	}
+	at := NewDynamicTool(WithTemplateAgent(tmpl))
+
+	got := at.childCodeExecutor(context.Background(), nil)
+
+	tagged, ok := got.(taggedDynCodeExecutor)
+	require.True(t, ok)
+	require.Equal(t, "template", tagged.tag)
+	require.True(t, tmpl.sawInv)
+	require.True(t, tmpl.sawAgent)
+	require.False(t, tmpl.sawParent)
+}
+
+// --- RunOptions sanitization (fixes 1/2/3 of this round) -------------------
+
+func fullyPopulatedChildRunOptions() agent.RunOptions {
+	return agent.RunOptions{
+		AdditionalTools:   stubTools("extra"),
+		ExternalTools:     stubTools("ext"),
+		ExternalToolNames: map[string]bool{"ext": true},
+		ToolFilter:        func(context.Context, tool.Tool) bool { return true },
+		Model:             &dynRecordingModel{name: "m"},
+		ModelName:         "mname",
+		ModelSelector: func(context.Context, *agent.Invocation) (model.Model, error) {
+			return nil, nil
+		},
+		Instruction:         "inst",
+		GlobalInstruction:   "ginst",
+		CodeExecutor:        fakeDynCodeExecutor{},
+		ToolExecutionFilter: func(context.Context, tool.Tool) bool { return true },
+		ToolPermissionPolicy: tool.PermissionPolicyFunc(
+			func(context.Context, *tool.PermissionRequest) (tool.PermissionDecision, error) {
+				return tool.AllowPermission(), nil
+			},
+		),
+	}
+}
+
+// TestSanitizeChildRunOptions_TemplateBoundaryClearsAll verifies that with a
+// template boundary every run-scoped tool input AND every model/prompt/
+// execution-policy override inherited from the parent clone is cleared, so the
+// template is a true strong boundary.
+func TestSanitizeChildRunOptions_TemplateBoundaryClearsAll(t *testing.T) {
+	at := NewDynamicTool()
+	runOpts := fullyPopulatedChildRunOptions()
+	at.sanitizeChildRunOptions(&runOpts, true)
+
+	// Tool surface: patch is the single source of truth.
+	require.Nil(t, runOpts.AdditionalTools)
+	require.Nil(t, runOpts.ExternalTools)
+	require.Nil(t, runOpts.ExternalToolNames)
+	require.Nil(t, runOpts.ToolFilter)
+	// Model / prompt boundary.
+	require.Nil(t, runOpts.Model)
+	require.Empty(t, runOpts.ModelName)
+	require.Nil(t, runOpts.ModelSelector)
+	require.Empty(t, runOpts.Instruction)
+	require.Empty(t, runOpts.GlobalInstruction)
+	// Execution boundary.
+	require.Nil(t, runOpts.CodeExecutor)
+	require.Nil(t, runOpts.ToolExecutionFilter)
+	require.Nil(t, runOpts.ToolPermissionPolicy)
+}
+
+// TestSanitizeChildRunOptions_NoTemplateKeepsBoundaryFields verifies that
+// without a template the child IS the parent agent, so only the tool-surface
+// inputs are cleared; model/prompt/execution overrides are inherited.
+func TestSanitizeChildRunOptions_NoTemplateKeepsBoundaryFields(t *testing.T) {
+	at := NewDynamicTool()
+	runOpts := fullyPopulatedChildRunOptions()
+	at.sanitizeChildRunOptions(&runOpts, false)
+
+	// Tool surface is always cleared (patch is authoritative; parent filter
+	// already applied while deriving the candidate surface).
+	require.Nil(t, runOpts.AdditionalTools)
+	require.Nil(t, runOpts.ExternalTools)
+	require.Nil(t, runOpts.ExternalToolNames)
+	require.Nil(t, runOpts.ToolFilter)
+	// Everything else is inherited unchanged.
+	require.NotNil(t, runOpts.Model)
+	require.Equal(t, "mname", runOpts.ModelName)
+	require.NotNil(t, runOpts.ModelSelector)
+	require.Equal(t, "inst", runOpts.Instruction)
+	require.Equal(t, "ginst", runOpts.GlobalInstruction)
+	require.NotNil(t, runOpts.CodeExecutor)
+	require.NotNil(t, runOpts.ToolExecutionFilter)
+	require.NotNil(t, runOpts.ToolPermissionPolicy)
+}
+
+// TestNewDynamicTool_Integration_CapabilityToolsBypassParentFilter is this
+// round's fix 1 regression: a fixed WithCapabilityTools surface must not be
+// re-filtered by the parent run's ToolFilter in the child flow.
+func TestNewDynamicTool_Integration_CapabilityToolsBypassParentFilter(t *testing.T) {
+	recModel := &dynRecordingModel{name: "rec", response: "ok"}
+	main := llmagent.New("main", llmagent.WithModel(recModel))
+	// cap_tool is a code-defined capability tool; it never passes through the
+	// parent ToolFilter when deriving the surface.
+	at := NewDynamicTool(WithCapabilityTools([]tool.Tool{newDynTestTool("cap_tool")}))
+
+	sess := session.NewSession("app", "user", "session")
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(main),
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationEventFilterKey("main"),
+	)
+	// A parent ToolFilter that would reject cap_tool must not reach the child.
+	parent.RunOptions.ToolFilter = func(_ context.Context, tl tool.Tool) bool {
+		return tl.Declaration().Name != "cap_tool"
+	}
+	ctx := agent.NewInvocationContext(context.Background(), parent)
+
+	_, err := at.Call(ctx, []byte(`{"request":"go"}`))
+	require.NoError(t, err)
+
+	seen := recModel.snapshot()
+	require.Len(t, seen, 1)
+	require.Equal(t, []string{"cap_tool"}, seen[0],
+		"a code-defined capability tool must survive in the child even when the "+
+			"parent ToolFilter would reject it")
+}
+
+// TestNewDynamicTool_Integration_TemplateIgnoresParentModelSelector is this
+// round's fix 2 regression: a parent run-scoped ModelSelector must not cross
+// the template boundary and re-pick the child's model.
+func TestNewDynamicTool_Integration_TemplateIgnoresParentModelSelector(t *testing.T) {
+	overrideModel := &dynRecordingModel{name: "override", response: "override-ran"}
+	templateModel := &dynRecordingModel{name: "template", response: "child-done"}
+
+	main := llmagent.New(
+		"main",
+		llmagent.WithModel(&dynRecordingModel{name: "parent"}),
+		llmagent.WithTools([]tool.Tool{newDynTestTool("tool_a")}),
+	)
+	subTemplate := llmagent.New("subagent", llmagent.WithModel(templateModel))
+	at := NewDynamicTool(WithTemplateAgent(subTemplate))
+
+	sess := session.NewSession("app", "user", "session")
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(main),
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationEventFilterKey("main"),
+	)
+	parent.RunOptions.ModelSelector = func(
+		context.Context, *agent.Invocation,
+	) (model.Model, error) {
+		return overrideModel, nil
+	}
+	ctx := agent.NewInvocationContext(context.Background(), parent)
+
+	got, err := at.Call(ctx, []byte(`{"request":"go"}`))
+	require.NoError(t, err)
+	require.Equal(t, "child-done", got)
+	require.Empty(t, overrideModel.snapshot(),
+		"parent RunOptions.ModelSelector must not override the template boundary")
+	require.Len(t, templateModel.snapshot(), 1)
+}


### PR DESCRIPTION
## Summary
- Add `dynamic_agent`, a dynamic AgentTool entrypoint that runs one short-lived child invocation and returns its result synchronously.
- Let the model narrow per-call `instruction`, `tools`, and `skills` within a code-defined capability boundary instead of creating arbitrary agents, models, or executors.
- Add invocation-scoped surface provider contracts, shared tool-surface resolution, transfer suppression for child surfaces, focused tests, and a runnable minimal/bounded example.

## Design Notes
- Default capability surface is derived from the parent invocation; callers can set a template agent and/or explicit capability tools/skills in code.
- The child surface excludes recursive AgentTool/transfer paths and caller-executed external tools.
- Template-agent mode is treated as a strong boundary, so parent run-time model/executor/policy overrides do not leak into the child.

## Validation
- `go test -count=1 ./tool/agent ./internal/toolsurface ./internal/surfacepatch ./agent ./agent/llmagent ./internal/flow/llmflow ./internal/flow/processor`
- `go vet ./tool/agent ./internal/toolsurface ./internal/surfacepatch ./agent ./agent/llmagent ./internal/flow/llmflow`
- `gocyclo -over 20 tool/agent/agent_tool.go tool/agent/dynamic_tool.go`
- `go-apidiff 664ebd0ab56d0ca9f257234d42e8c44a22ef4fe6 --compare-imports=false --print-compatible=true --repo-path=.`
- `go build .` in `examples/dynamicagenttool`