### PR TITLE
{agent/llmagent, internal/flow, docs, examples}: add tool activation

### DIFF
--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -142,12 +142,18 @@ func New(name string, opts ...Option) *LLMAgent {
 		if len(options.extensionContributedTools) > 0 {
 			panic("Invalid LLMAgent configuration: if output_schema is set, extension-contributed tools (WithExtensions → Registry.Tools) must be empty")
 		}
+		if len(options.toolActivationRules) > 0 {
+			panic("Invalid LLMAgent configuration: if output_schema is set, tool activation rules must be empty")
+		}
 		if options.Knowledge != nil {
 			panic("Invalid LLMAgent configuration: if output_schema is set, knowledge must be empty")
 		}
 		if len(options.SubAgents) > 0 {
 			panic("Invalid LLMAgent configuration: if output_schema is set, sub_agents must be empty to disable agent transfer")
 		}
+	}
+	if err := validateAndNormalizeToolActivationOptions(&options); err != nil {
+		panic(fmt.Sprintf("Invalid LLMAgent configuration: %v", err))
 	}
 
 	// Register tools from both tools and toolsets, including knowledge search tool if provided.
@@ -220,10 +226,21 @@ func New(name string, opts ...Option) *LLMAgent {
 		)
 	}
 
+	toolCallProcessorOptions := []processor.FunctionCallResponseProcessorOption{
+		processor.WithToolCallRetryPolicy(options.ToolCallRetryPolicy),
+	}
+	if len(options.toolActivationRules) > 0 {
+		toolCallProcessorOptions = append(
+			toolCallProcessorOptions,
+			processor.WithPostToolResultHook(
+				a.handleToolActivationPostToolResult,
+			),
+		)
+	}
 	toolcallProcessor := processor.NewFunctionCallResponseProcessor(
 		options.EnableParallelTools,
 		options.ToolCallbacks,
-		processor.WithToolCallRetryPolicy(options.ToolCallRetryPolicy),
+		toolCallProcessorOptions...,
 	)
 	// Configure default transfer message for direct sub-agent calls.
 	// Default behavior (when not configured): enabled with built-in default message.
@@ -249,6 +266,9 @@ func New(name string, opts ...Option) *LLMAgent {
 		SyncSummaryIntraRun:             options.SyncSummaryIntraRun,
 		EnableContextCompaction:         options.EnableContextCompaction,
 		ContextCompactionThresholdRatio: options.ContextCompactionThresholdRatio,
+	}
+	if len(options.toolActivationRules) > 0 {
+		flowOpts.ToolActivationApplier = a.applyToolActivation
 	}
 
 	a.flow = llmflow.New(

--- a/agent/llmagent/llm_agent_test.go
+++ b/agent/llmagent/llm_agent_test.go
@@ -1019,6 +1019,28 @@ func TestLLMAgent_New_WithOutputSchema_InvalidCombos(t *testing.T) {
 		)
 	})
 
+	t.Run("with activatable toolsets", func(t *testing.T) {
+		toolset := dummyToolSet{name: "activatable"}
+		require.NotPanics(t, func() {
+			_ = New("test",
+				WithOutputSchema(schema),
+				WithActivatableToolSets([]tool.ToolSet{toolset}),
+			)
+		})
+	})
+
+	t.Run("with tool activation rules", func(t *testing.T) {
+		require.PanicsWithValue(t,
+			"Invalid LLMAgent configuration: if output_schema is set, tool activation rules must be empty",
+			func() {
+				_ = New("test",
+					WithOutputSchema(schema),
+					WithToolActivationOnSkillLoad("research", []string{"activatable"}),
+				)
+			},
+		)
+	})
+
 	// A hook-only extension (Register that never calls r.Tools)
 	// leaves extensionContributedTools empty and must remain
 	// compatible with WithOutputSchema — the guard reaches the

--- a/agent/llmagent/option.go
+++ b/agent/llmagent/option.go
@@ -260,6 +260,10 @@ type Options struct {
 	Tools []tool.Tool
 	// ToolSets is the list of tool sets available to the agent.
 	ToolSets []tool.ToolSet
+	// activatableToolSets is the list of tool sets available for runtime activation.
+	activatableToolSets []tool.ToolSet
+	// toolActivationRules stores runtime tool activation rules.
+	toolActivationRules []toolActivationRule
 	// Planner is the planner to use for planning instructions.
 	Planner planner.Planner
 	// SubAgents is the list of sub-agents available to the agent.
@@ -807,6 +811,14 @@ func WithToolSets(toolSets []tool.ToolSet) Option {
 	}
 }
 
+// WithActivatableToolSets sets tool sets that may be activated at runtime.
+// These tool sets are not visible until an activation rule matches.
+func WithActivatableToolSets(toolSets []tool.ToolSet) Option {
+	return func(opts *Options) {
+		opts.activatableToolSets = append([]tool.ToolSet(nil), toolSets...)
+	}
+}
+
 // WithRefreshToolSetsOnRun controls whether tools from ToolSets are
 // refreshed from the underlying ToolSet on each run.
 // When enabled, the agent will call ToolSet.Tools again when building
@@ -849,6 +861,32 @@ func WithSkills(repo skill.Repository) Option {
 func WithSkillFilter(filter skill.VisibilityFilter) Option {
 	return func(opts *Options) {
 		opts.skillFilter = filter
+	}
+}
+
+// WithToolActivationOnSkillLoad activates tool sets after a skill is loaded.
+// The default mode is include and the default lifetime is invocation.
+// It is incompatible with WithOutputSchema.
+func WithToolActivationOnSkillLoad(
+	skill string,
+	toolSetNames []string,
+	opts ...ToolActivationOption,
+) Option {
+	return func(options *Options) {
+		ruleOptions := newToolActivationRuleOptions(opts...)
+		trigger := toolActivationTrigger{
+			kind:  toolActivationTriggerSkillLoad,
+			skill: skill,
+		}
+		options.toolActivationRules = append(
+			options.toolActivationRules,
+			toolActivationRule{
+				trigger:      trigger,
+				toolSetNames: append([]string(nil), toolSetNames...),
+				mode:         ruleOptions.mode,
+				lifetime:     ruleOptions.lifetime,
+			},
+		)
 	}
 }
 

--- a/agent/llmagent/tool_activation.go
+++ b/agent/llmagent/tool_activation.go
@@ -319,7 +319,7 @@ func (a *LLMAgent) applyToolActivation(
 	userToolNames map[string]bool,
 	externalToolNames map[string]bool,
 ) ([]tool.Tool, map[string]bool, map[string]bool) {
-	toolSets, filter := a.toolActivationInputs()
+	toolSets, rules, filter := a.toolActivationInputs()
 	return applyToolActivationRecords(
 		ctx,
 		inv,
@@ -327,17 +327,20 @@ func (a *LLMAgent) applyToolActivation(
 		userToolNames,
 		externalToolNames,
 		toolSets,
+		rules,
 		filter,
 	)
 }
 
 func (a *LLMAgent) toolActivationInputs() (
 	[]tool.ToolSet,
+	[]toolActivationRule,
 	func(context.Context, tool.Tool) bool,
 ) {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	return append([]tool.ToolSet(nil), a.option.activatableToolSets...),
+		append([]toolActivationRule(nil), a.option.toolActivationRules...),
 		a.option.toolFilter
 }
 
@@ -515,8 +518,9 @@ func marshalToolActivationRecord(record toolActivationRecord) []byte {
 func sessionToolActivationRecords(
 	ctx context.Context,
 	inv *agent.Invocation,
+	allowedRecordKeys map[string]bool,
 ) []toolActivationRecord {
-	if inv == nil || inv.Session == nil {
+	if inv == nil || inv.Session == nil || len(allowedRecordKeys) == 0 {
 		return nil
 	}
 	state := inv.Session.SnapshotState()
@@ -533,10 +537,24 @@ func sessionToolActivationRecords(
 	sort.Strings(keys)
 	records := make([]toolActivationRecord, 0, len(keys))
 	for _, key := range keys {
-		record, ok := parseSessionToolActivationRecord(ctx, key, state[key])
-		if ok {
-			records = append(records, record)
+		record, ok := parseSessionToolActivationRecord(
+			ctx,
+			inv.AgentName,
+			key,
+			state[key],
+		)
+		if !ok {
+			continue
 		}
+		if !allowedRecordKeys[toolActivationRecordKey(record)] {
+			log.WarnfContext(
+				ctx,
+				"Disallowed tool activation session record %s",
+				key,
+			)
+			continue
+		}
+		records = append(records, record)
 	}
 	return records
 }
@@ -595,6 +613,7 @@ func escapeToolActivationSegment(value string) string {
 
 func parseSessionToolActivationRecord(
 	ctx context.Context,
+	agentName string,
 	key string,
 	raw []byte,
 ) (toolActivationRecord, bool) {
@@ -624,6 +643,14 @@ func parseSessionToolActivationRecord(
 		)
 		return toolActivationRecord{}, false
 	}
+	if key != toolActivationSessionKey(agentName, normalized) {
+		log.WarnfContext(
+			ctx,
+			"Mismatched tool activation session record %s",
+			key,
+		)
+		return toolActivationRecord{}, false
+	}
 	return normalized, ok
 }
 
@@ -634,11 +661,16 @@ func applyToolActivationRecords(
 	userToolNames map[string]bool,
 	externalToolNames map[string]bool,
 	toolSets []tool.ToolSet,
+	rules []toolActivationRule,
 	filter func(context.Context, tool.Tool) bool,
 ) ([]tool.Tool, map[string]bool, map[string]bool) {
 	records := mergeToolActivationRecords(
 		invocationToolActivationRecords(inv),
-		sessionToolActivationRecords(ctx, inv),
+		sessionToolActivationRecords(
+			ctx,
+			inv,
+			allowedSessionToolActivationRecordKeys(rules),
+		),
 	)
 	if len(records) == 0 || len(toolSets) == 0 {
 		return tools, userToolNames, externalToolNames
@@ -669,6 +701,31 @@ func applyToolActivationRecords(
 		return out, userNames, externalNames
 	}
 	return applyOnly(out, userNames, externalNames, activatedToolsByName)
+}
+
+func allowedSessionToolActivationRecordKeys(
+	rules []toolActivationRule,
+) map[string]bool {
+	if len(rules) == 0 {
+		return nil
+	}
+	allowed := make(map[string]bool)
+	for _, rule := range rules {
+		if rule.lifetime != ToolActivationLifetimeSession {
+			continue
+		}
+		for _, toolSetName := range rule.toolSetNames {
+			record, ok := newToolActivationRecord(
+				rule.mode,
+				rule.lifetime,
+				toolSetName,
+			)
+			if ok {
+				allowed[toolActivationRecordKey(record)] = true
+			}
+		}
+	}
+	return allowed
 }
 
 func activeToolActivationSets(

--- a/agent/llmagent/tool_activation.go
+++ b/agent/llmagent/tool_activation.go
@@ -590,10 +590,7 @@ func sameToolActivationRecords(
 }
 
 func escapeToolActivationSegment(value string) string {
-	if strings.Contains(value, toolActivationSegmentDelimiter) {
-		return url.PathEscape(value)
-	}
-	return value
+	return url.PathEscape(value)
 }
 
 func parseSessionToolActivationRecord(

--- a/agent/llmagent/tool_activation.go
+++ b/agent/llmagent/tool_activation.go
@@ -1,0 +1,909 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package llmagent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/internal/flow/toolsnapshot"
+	itool "trpc.group/trpc-go/trpc-agent-go/internal/tool"
+	"trpc.group/trpc-go/trpc-agent-go/log"
+	"trpc.group/trpc-go/trpc-agent-go/skill"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+// ToolActivationMode controls how an activated tool set is composed.
+type ToolActivationMode string
+
+const (
+	// ToolActivationModeInclude keeps existing user tools and adds activated tools.
+	ToolActivationModeInclude ToolActivationMode = "include"
+	// ToolActivationModeOnly keeps only user tools from active only-mode tool sets.
+	// It fails closed when no active tool is available. Framework tools remain visible.
+	ToolActivationModeOnly ToolActivationMode = "only"
+)
+
+// ToolActivationLifetime controls how long a tool activation remains.
+type ToolActivationLifetime string
+
+const (
+	// ToolActivationLifetimeInvocation keeps activation in the current agent invocation.
+	ToolActivationLifetimeInvocation ToolActivationLifetime = "invocation"
+	// ToolActivationLifetimeSession keeps activation in session state.
+	ToolActivationLifetimeSession ToolActivationLifetime = "session"
+)
+
+// ToolActivationOption configures a tool activation rule.
+type ToolActivationOption func(*toolActivationRuleOptions)
+
+type toolActivationTriggerKind string
+
+const (
+	toolActivationTriggerSkillLoad toolActivationTriggerKind = "skill_load"
+)
+
+type toolActivationTrigger struct {
+	kind  toolActivationTriggerKind
+	skill string
+}
+
+type toolActivationRule struct {
+	trigger      toolActivationTrigger
+	toolSetNames []string
+	mode         ToolActivationMode
+	lifetime     ToolActivationLifetime
+}
+
+type toolActivationRuleOptions struct {
+	mode     ToolActivationMode
+	lifetime ToolActivationLifetime
+}
+
+func newToolActivationRuleOptions(
+	opts ...ToolActivationOption,
+) toolActivationRuleOptions {
+	options := toolActivationRuleOptions{
+		mode:     ToolActivationModeInclude,
+		lifetime: ToolActivationLifetimeInvocation,
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&options)
+		}
+	}
+	return options
+}
+
+// WithToolActivationMode sets how activated tool sets are composed.
+func WithToolActivationMode(mode ToolActivationMode) ToolActivationOption {
+	return func(opts *toolActivationRuleOptions) {
+		opts.mode = mode
+	}
+}
+
+// WithToolActivationLifetime sets how long activation records are retained.
+func WithToolActivationLifetime(
+	lifetime ToolActivationLifetime,
+) ToolActivationOption {
+	return func(opts *toolActivationRuleOptions) {
+		opts.lifetime = lifetime
+	}
+}
+
+type toolActivationRecord struct {
+	Mode        ToolActivationMode     `json:"mode"`
+	Lifetime    ToolActivationLifetime `json:"lifetime"`
+	ToolSetName string                 `json:"tool_set_name"`
+}
+
+const (
+	toolActivationInvocationStateKey = "tool_activation:records"
+	toolActivationSessionPrefix      = "temp:tool_activation:by_agent:"
+	toolActivationSegmentDelimiter   = "/"
+)
+
+func validateAndNormalizeToolActivationOptions(options *Options) error {
+	if options == nil {
+		return nil
+	}
+	toolSetNames, err := collectActivatableToolSetNames(options.activatableToolSets)
+	if err != nil {
+		return err
+	}
+	rules, err := normalizeToolActivationRules(
+		options.toolActivationRules,
+		toolSetNames,
+	)
+	if err != nil {
+		return err
+	}
+	options.toolActivationRules = rules
+	return nil
+}
+
+func collectActivatableToolSetNames(
+	toolSets []tool.ToolSet,
+) (map[string]bool, error) {
+	if len(toolSets) == 0 {
+		return nil, nil
+	}
+	names := make(map[string]bool, len(toolSets))
+	for _, toolSet := range toolSets {
+		if toolSet == nil {
+			return nil, fmt.Errorf("activatable tool set must not be nil")
+		}
+		name := strings.TrimSpace(toolSet.Name())
+		if name == "" {
+			return nil, fmt.Errorf("activatable tool set name must not be empty")
+		}
+		if names[name] {
+			return nil, fmt.Errorf("duplicate activatable tool set %q", name)
+		}
+		names[name] = true
+	}
+	return names, nil
+}
+
+func normalizeToolActivationRules(
+	rules []toolActivationRule,
+	toolSetNames map[string]bool,
+) ([]toolActivationRule, error) {
+	if len(rules) == 0 {
+		return nil, nil
+	}
+	out := make([]toolActivationRule, 0, len(rules))
+	for _, rule := range rules {
+		normalized, err := normalizeToolActivationRule(rule, toolSetNames)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, normalized)
+	}
+	return out, nil
+}
+
+func normalizeToolActivationRule(
+	rule toolActivationRule,
+	toolSetNames map[string]bool,
+) (toolActivationRule, error) {
+	trigger, err := normalizeToolActivationTrigger(rule.trigger)
+	if err != nil {
+		return toolActivationRule{}, err
+	}
+	names := normalizeToolSetNames(rule.toolSetNames)
+	if len(names) == 0 {
+		return toolActivationRule{}, fmt.Errorf(
+			"tool activation for trigger %s must reference at least one tool set",
+			trigger.describe(),
+		)
+	}
+	for _, name := range names {
+		if !toolSetNames[name] {
+			return toolActivationRule{}, fmt.Errorf("unknown activatable tool set %q", name)
+		}
+	}
+	mode, err := normalizeToolActivationMode(rule.mode)
+	if err != nil {
+		return toolActivationRule{}, err
+	}
+	lifetime, err := normalizeToolActivationLifetime(rule.lifetime)
+	if err != nil {
+		return toolActivationRule{}, err
+	}
+	return toolActivationRule{
+		trigger:      trigger,
+		toolSetNames: names,
+		mode:         mode,
+		lifetime:     lifetime,
+	}, nil
+}
+
+func normalizeToolActivationTrigger(
+	trigger toolActivationTrigger,
+) (toolActivationTrigger, error) {
+	switch trigger.kind {
+	case toolActivationTriggerSkillLoad:
+		skillName := strings.TrimSpace(trigger.skill)
+		if skillName == "" {
+			return toolActivationTrigger{}, fmt.Errorf("tool activation skill name must not be empty")
+		}
+		return toolActivationTrigger{
+			kind:  toolActivationTriggerSkillLoad,
+			skill: skillName,
+		}, nil
+	default:
+		return toolActivationTrigger{}, fmt.Errorf(
+			"unsupported tool activation trigger %q",
+			trigger.kind,
+		)
+	}
+}
+
+func (trigger toolActivationTrigger) describe() string {
+	switch trigger.kind {
+	case toolActivationTriggerSkillLoad:
+		return fmt.Sprintf("%s:%s", trigger.kind, trigger.skill)
+	default:
+		return string(trigger.kind)
+	}
+}
+
+func normalizeToolSetNames(names []string) []string {
+	if len(names) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(names))
+	seen := make(map[string]bool, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		out = append(out, name)
+	}
+	return out
+}
+
+func normalizeToolActivationMode(
+	mode ToolActivationMode,
+) (ToolActivationMode, error) {
+	normalized, ok := canonicalToolActivationMode(mode)
+	if !ok {
+		return "", fmt.Errorf(
+			"unsupported tool activation mode %q",
+			mode,
+		)
+	}
+	return normalized, nil
+}
+
+func normalizeToolActivationLifetime(
+	lifetime ToolActivationLifetime,
+) (ToolActivationLifetime, error) {
+	normalized, ok := canonicalToolActivationLifetime(lifetime)
+	if !ok {
+		return "", fmt.Errorf(
+			"unsupported tool activation lifetime %q",
+			lifetime,
+		)
+	}
+	return normalized, nil
+}
+
+func canonicalToolActivationMode(
+	mode ToolActivationMode,
+) (ToolActivationMode, bool) {
+	switch mode {
+	case ToolActivationModeInclude:
+		return ToolActivationModeInclude, true
+	case ToolActivationModeOnly:
+		return ToolActivationModeOnly, true
+	default:
+		return "", false
+	}
+}
+
+func canonicalToolActivationLifetime(
+	lifetime ToolActivationLifetime,
+) (ToolActivationLifetime, bool) {
+	switch lifetime {
+	case ToolActivationLifetimeInvocation:
+		return ToolActivationLifetimeInvocation, true
+	case ToolActivationLifetimeSession:
+		return ToolActivationLifetimeSession, true
+	default:
+		return "", false
+	}
+}
+
+func (a *LLMAgent) applyToolActivation(
+	ctx context.Context,
+	inv *agent.Invocation,
+	tools []tool.Tool,
+	userToolNames map[string]bool,
+	externalToolNames map[string]bool,
+) ([]tool.Tool, map[string]bool, map[string]bool) {
+	toolSets, filter := a.toolActivationInputs()
+	return applyToolActivationRecords(
+		ctx,
+		inv,
+		tools,
+		userToolNames,
+		externalToolNames,
+		toolSets,
+		filter,
+	)
+}
+
+func (a *LLMAgent) toolActivationInputs() (
+	[]tool.ToolSet,
+	func(context.Context, tool.Tool) bool,
+) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return append([]tool.ToolSet(nil), a.option.activatableToolSets...),
+		a.option.toolFilter
+}
+
+func (a *LLMAgent) handleToolActivationPostToolResult(
+	_ context.Context,
+	inv *agent.Invocation,
+	ev *event.Event,
+) {
+	if inv == nil || ev == nil || len(ev.StateDelta) == 0 {
+		return
+	}
+	loaded := loadedSkillsFromStateDelta(inv.AgentName, ev.StateDelta)
+	if len(loaded) == 0 {
+		return
+	}
+	records := a.activationRecordsForLoadedSkills(loaded)
+	if len(records) == 0 {
+		return
+	}
+	changed := addInvocationToolActivationRecords(inv, records)
+	// Session-lifetime records also need an invocation shadow so the next model request sees them immediately.
+	sessionChanged := appendSessionActivationStateDelta(inv, ev, records)
+	if changed || sessionChanged {
+		toolsnapshot.Invalidate(inv)
+	}
+}
+
+func loadedSkillsFromStateDelta(
+	agentName string,
+	delta map[string][]byte,
+) map[string]bool {
+	prefix := skill.LoadedPrefix(agentName)
+	loaded := map[string]bool{}
+	for key, value := range delta {
+		if !strings.HasPrefix(key, prefix) || len(value) == 0 {
+			continue
+		}
+		name := strings.TrimSpace(strings.TrimPrefix(key, prefix))
+		if name == "" {
+			continue
+		}
+		loaded[name] = true
+	}
+	return loaded
+}
+
+func (a *LLMAgent) activationRecordsForLoadedSkills(
+	loaded map[string]bool,
+) []toolActivationRecord {
+	a.mu.RLock()
+	rules := append([]toolActivationRule(nil), a.option.toolActivationRules...)
+	a.mu.RUnlock()
+	records := make([]toolActivationRecord, 0, len(rules))
+	for _, rule := range rules {
+		if !rule.matchesLoadedSkills(loaded) {
+			continue
+		}
+		for _, toolSetName := range rule.toolSetNames {
+			record, ok := newToolActivationRecord(rule.mode, rule.lifetime, toolSetName)
+			if ok {
+				records = append(records, record)
+			}
+		}
+	}
+	return records
+}
+
+func (rule toolActivationRule) matchesLoadedSkills(loaded map[string]bool) bool {
+	switch rule.trigger.kind {
+	case toolActivationTriggerSkillLoad:
+		return loaded[rule.trigger.skill]
+	default:
+		return false
+	}
+}
+
+func appendSessionActivationStateDelta(
+	inv *agent.Invocation,
+	ev *event.Event,
+	records []toolActivationRecord,
+) bool {
+	changed := false
+	for _, record := range records {
+		if !record.sessionScoped() {
+			continue
+		}
+		if ev.StateDelta == nil {
+			ev.StateDelta = map[string][]byte{}
+		}
+		key := toolActivationSessionKey(inv.AgentName, record)
+		ev.StateDelta[key] = marshalToolActivationRecord(record)
+		changed = true
+	}
+	return changed
+}
+
+func newToolActivationRecord(
+	mode ToolActivationMode,
+	lifetime ToolActivationLifetime,
+	toolSetName string,
+) (toolActivationRecord, bool) {
+	toolSetName = strings.TrimSpace(toolSetName)
+	if toolSetName == "" {
+		return toolActivationRecord{}, false
+	}
+	normalizedMode, ok := canonicalToolActivationMode(mode)
+	if !ok {
+		return toolActivationRecord{}, false
+	}
+	normalizedLifetime, ok := canonicalToolActivationLifetime(lifetime)
+	if !ok {
+		return toolActivationRecord{}, false
+	}
+	return toolActivationRecord{
+		Mode:        normalizedMode,
+		Lifetime:    normalizedLifetime,
+		ToolSetName: toolSetName,
+	}, true
+}
+
+func (r toolActivationRecord) sessionScoped() bool {
+	return r.Lifetime == ToolActivationLifetimeSession
+}
+
+func invocationToolActivationRecords(inv *agent.Invocation) []toolActivationRecord {
+	records, ok := agent.GetStateValue[[]toolActivationRecord](
+		inv,
+		toolActivationInvocationStateKey,
+	)
+	if !ok || len(records) == 0 {
+		return nil
+	}
+	return append([]toolActivationRecord(nil), records...)
+}
+
+func addInvocationToolActivationRecords(
+	inv *agent.Invocation,
+	records []toolActivationRecord,
+) bool {
+	if inv == nil || len(records) == 0 {
+		return false
+	}
+	base := invocationToolActivationRecords(inv)
+	merged := mergeToolActivationRecords(base, records)
+	if sameToolActivationRecords(base, merged) {
+		return false
+	}
+	inv.SetState(toolActivationInvocationStateKey, merged)
+	return true
+}
+
+func toolActivationSessionKey(
+	agentName string,
+	record toolActivationRecord,
+) string {
+	return toolActivationSessionPrefixForAgent(agentName) +
+		string(record.Mode) +
+		toolActivationSegmentDelimiter +
+		escapeToolActivationSegment(strings.TrimSpace(record.ToolSetName))
+}
+
+func toolActivationSessionPrefixForAgent(agentName string) string {
+	agentName = escapeToolActivationSegment(strings.TrimSpace(agentName))
+	return toolActivationSessionPrefix + agentName + toolActivationSegmentDelimiter
+}
+
+func marshalToolActivationRecord(record toolActivationRecord) []byte {
+	b, err := json.Marshal(record)
+	if err != nil {
+		return nil
+	}
+	return b
+}
+
+func sessionToolActivationRecords(
+	ctx context.Context,
+	inv *agent.Invocation,
+) []toolActivationRecord {
+	if inv == nil || inv.Session == nil {
+		return nil
+	}
+	state := inv.Session.SnapshotState()
+	if len(state) == 0 {
+		return nil
+	}
+	prefix := toolActivationSessionPrefixForAgent(inv.AgentName)
+	keys := make([]string, 0, len(state))
+	for key := range state {
+		if strings.HasPrefix(key, prefix) {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	records := make([]toolActivationRecord, 0, len(keys))
+	for _, key := range keys {
+		record, ok := parseSessionToolActivationRecord(ctx, key, state[key])
+		if ok {
+			records = append(records, record)
+		}
+	}
+	return records
+}
+
+func mergeToolActivationRecords(
+	base []toolActivationRecord,
+	added []toolActivationRecord,
+) []toolActivationRecord {
+	if len(base) == 0 && len(added) == 0 {
+		return nil
+	}
+	out := make([]toolActivationRecord, 0, len(base)+len(added))
+	seen := make(map[string]bool, len(base)+len(added))
+	for _, record := range append(append([]toolActivationRecord(nil), base...), added...) {
+		normalized, ok := newToolActivationRecord(
+			record.Mode,
+			record.Lifetime,
+			record.ToolSetName,
+		)
+		if !ok {
+			continue
+		}
+		key := toolActivationRecordKey(normalized)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, normalized)
+	}
+	return out
+}
+
+func toolActivationRecordKey(record toolActivationRecord) string {
+	return string(record.Mode) + "\x00" +
+		string(record.Lifetime) + "\x00" + record.ToolSetName
+}
+
+func sameToolActivationRecords(
+	a []toolActivationRecord,
+	b []toolActivationRecord,
+) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if toolActivationRecordKey(a[i]) != toolActivationRecordKey(b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func escapeToolActivationSegment(value string) string {
+	if strings.Contains(value, toolActivationSegmentDelimiter) {
+		return url.PathEscape(value)
+	}
+	return value
+}
+
+func parseSessionToolActivationRecord(
+	ctx context.Context,
+	key string,
+	raw []byte,
+) (toolActivationRecord, bool) {
+	if len(raw) == 0 {
+		return toolActivationRecord{}, false
+	}
+	var record toolActivationRecord
+	if err := json.Unmarshal(raw, &record); err != nil {
+		log.WarnfContext(
+			ctx,
+			"Parse tool activation session record %s failed: %v",
+			key,
+			err,
+		)
+		return toolActivationRecord{}, false
+	}
+	normalized, ok := newToolActivationRecord(
+		record.Mode,
+		record.Lifetime,
+		record.ToolSetName,
+	)
+	if !ok || !normalized.sessionScoped() {
+		log.WarnfContext(
+			ctx,
+			"Invalid tool activation session record %s",
+			key,
+		)
+		return toolActivationRecord{}, false
+	}
+	return normalized, ok
+}
+
+func applyToolActivationRecords(
+	ctx context.Context,
+	inv *agent.Invocation,
+	tools []tool.Tool,
+	userToolNames map[string]bool,
+	externalToolNames map[string]bool,
+	toolSets []tool.ToolSet,
+	filter func(context.Context, tool.Tool) bool,
+) ([]tool.Tool, map[string]bool, map[string]bool) {
+	records := mergeToolActivationRecords(
+		invocationToolActivationRecords(inv),
+		sessionToolActivationRecords(ctx, inv),
+	)
+	if len(records) == 0 || len(toolSets) == 0 {
+		return tools, userToolNames, externalToolNames
+	}
+	activeSets, onlyNames := activeToolActivationSets(ctx, records, toolSets)
+	if len(activeSets) == 0 {
+		return tools, userToolNames, externalToolNames
+	}
+	activatedTools := expandActivatedTools(
+		ctx,
+		activeSets,
+		onlyNames,
+		filter,
+	)
+	if len(activatedTools) == 0 && len(onlyNames) == 0 {
+		return tools, userToolNames, externalToolNames
+	}
+	activatedToolsByName := indexToolActivationTools(activatedTools)
+	out, userNames, externalNames := appendActivatedTools(
+		ctx,
+		tools,
+		userToolNames,
+		externalToolNames,
+		activatedTools,
+		activatedToolsByName,
+	)
+	if len(onlyNames) == 0 {
+		return out, userNames, externalNames
+	}
+	return applyOnly(out, userNames, externalNames, activatedToolsByName)
+}
+
+func activeToolActivationSets(
+	ctx context.Context,
+	records []toolActivationRecord,
+	toolSets []tool.ToolSet,
+) ([]tool.ToolSet, map[string]bool) {
+	available := make(map[string]bool, len(toolSets))
+	for _, toolSet := range toolSets {
+		if toolSet == nil {
+			continue
+		}
+		name := strings.TrimSpace(toolSet.Name())
+		if name != "" {
+			available[name] = true
+		}
+	}
+	activeNames := make(map[string]bool)
+	only := make(map[string]bool)
+	for _, record := range records {
+		name := strings.TrimSpace(record.ToolSetName)
+		if !available[name] {
+			log.WarnfContext(
+				ctx,
+				"Unknown activatable tool set: %s",
+				record.ToolSetName,
+			)
+			continue
+		}
+		activeNames[name] = true
+		if record.Mode == ToolActivationModeOnly {
+			only[name] = true
+		}
+	}
+	active := make([]tool.ToolSet, 0, len(activeNames))
+	seen := make(map[string]bool, len(activeNames))
+	for _, toolSet := range toolSets {
+		if toolSet == nil {
+			continue
+		}
+		name := strings.TrimSpace(toolSet.Name())
+		if !activeNames[name] || seen[name] {
+			continue
+		}
+		seen[name] = true
+		active = append(active, toolSet)
+	}
+	return active, only
+}
+
+func expandActivatedTools(
+	ctx context.Context,
+	active []tool.ToolSet,
+	only map[string]bool,
+	filter func(context.Context, tool.Tool) bool,
+) []tool.Tool {
+	out := make([]tool.Tool, 0)
+	acceptedToolNames := map[string]bool{}
+	for _, toolSet := range active {
+		name := strings.TrimSpace(toolSet.Name())
+		if len(only) > 0 && !only[name] {
+			continue
+		}
+		tools := expandOneToolActivationSet(
+			ctx,
+			toolSet,
+			acceptedToolNames,
+			filter,
+		)
+		if len(tools) == 0 {
+			log.DebugfContext(
+				ctx,
+				"Activatable tool set %s has no tools",
+				name,
+			)
+		}
+		out = append(out, tools...)
+	}
+	return out
+}
+
+func indexToolActivationTools(tools []tool.Tool) map[string]tool.Tool {
+	out := make(map[string]tool.Tool, len(tools))
+	for _, tl := range tools {
+		name := toolActivationToolName(tl)
+		if name == "" {
+			continue
+		}
+		if _, ok := out[name]; !ok {
+			out[name] = tl
+		}
+	}
+	return out
+}
+
+func expandOneToolActivationSet(
+	ctx context.Context,
+	toolSet tool.ToolSet,
+	acceptedToolNames map[string]bool,
+	filter func(context.Context, tool.Tool) bool,
+) []tool.Tool {
+	namedToolSet := itool.NewNamedToolSet(toolSet)
+	tools := namedToolSet.Tools(ctx)
+	if len(tools) == 0 {
+		return nil
+	}
+	out := make([]tool.Tool, 0, len(tools))
+	declaredToolNames := map[string]bool{}
+	for _, tl := range tools {
+		name := toolActivationToolName(tl)
+		if name == "" {
+			continue
+		}
+		if declaredToolNames[name] {
+			log.WarnfContext(
+				ctx,
+				"Duplicate tool name %s in activatable tool set %s",
+				name,
+				toolSet.Name(),
+			)
+			continue
+		}
+		declaredToolNames[name] = true
+		if acceptedToolNames[name] {
+			log.WarnfContext(
+				ctx,
+				"Duplicate activated tool name %s across tool sets",
+				name,
+			)
+			continue
+		}
+		if filter != nil && !filter(ctx, tl) {
+			continue
+		}
+		acceptedToolNames[name] = true
+		out = append(out, tl)
+	}
+	return out
+}
+
+func appendActivatedTools(
+	ctx context.Context,
+	tools []tool.Tool,
+	userToolNames map[string]bool,
+	externalToolNames map[string]bool,
+	activatedTools []tool.Tool,
+	activatedToolsByName map[string]tool.Tool,
+) ([]tool.Tool, map[string]bool, map[string]bool) {
+	out := make([]tool.Tool, 0, len(tools)+len(activatedTools))
+	userNames := copyToolActivationNames(userToolNames)
+	externalNames := copyToolActivationNames(externalToolNames)
+	seen := make(map[string]bool, len(tools)+len(activatedTools))
+	for _, tl := range tools {
+		name := toolActivationToolName(tl)
+		replacement, ok := activatedToolsByName[name]
+		if ok && isUserToolActivationName(name, userNames, externalNames) {
+			out = append(out, replacement)
+			seen[name] = true
+			userNames[name] = true
+			delete(externalNames, name)
+			continue
+		}
+		if ok && name != "" {
+			log.WarnfContext(
+				ctx,
+				"Activated tool %s conflicts with framework tool; keeping existing tool",
+				name,
+			)
+		}
+		if name != "" {
+			seen[name] = true
+		}
+		out = append(out, tl)
+	}
+	for _, tl := range activatedTools {
+		name := toolActivationToolName(tl)
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		out = append(out, tl)
+		userNames[name] = true
+	}
+	return out, userNames, externalNames
+}
+
+func applyOnly(
+	tools []tool.Tool,
+	userToolNames map[string]bool,
+	externalToolNames map[string]bool,
+	allowedToolsByName map[string]tool.Tool,
+) ([]tool.Tool, map[string]bool, map[string]bool) {
+	out := make([]tool.Tool, 0, len(tools))
+	for _, tl := range tools {
+		name := toolActivationToolName(tl)
+		if name == "" || !isUserToolActivationName(name, userToolNames, externalToolNames) {
+			out = append(out, tl)
+			continue
+		}
+		if _, ok := allowedToolsByName[name]; ok {
+			out = append(out, tl)
+			continue
+		}
+		delete(userToolNames, name)
+		delete(externalToolNames, name)
+	}
+	return out, userToolNames, externalToolNames
+}
+
+func isUserToolActivationName(
+	name string,
+	userNames map[string]bool,
+	externalNames map[string]bool,
+) bool {
+	return userNames[name] || externalNames[name]
+}
+
+func copyToolActivationNames(src map[string]bool) map[string]bool {
+	dst := make(map[string]bool, len(src))
+	for name, ok := range src {
+		dst[name] = ok
+	}
+	return dst
+}
+
+func toolActivationToolName(tl tool.Tool) string {
+	if tl == nil {
+		return ""
+	}
+	decl := tl.Declaration()
+	if decl == nil {
+		return ""
+	}
+	return strings.TrimSpace(decl.Name)
+}

--- a/agent/llmagent/tool_activation_test.go
+++ b/agent/llmagent/tool_activation_test.go
@@ -1,0 +1,691 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package llmagent
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/internal/flow/toolsnapshot"
+	itool "trpc.group/trpc-go/trpc-agent-go/internal/tool"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/skill"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+type activationTool struct {
+	name string
+}
+
+func (t activationTool) Declaration() *tool.Declaration {
+	return &tool.Declaration{Name: t.name}
+}
+
+type activationToolSet struct {
+	name  string
+	tools []tool.Tool
+}
+
+func (s activationToolSet) Tools(context.Context) []tool.Tool {
+	return s.tools
+}
+
+func (s activationToolSet) Close() error {
+	return nil
+}
+
+func (s activationToolSet) Name() string {
+	return s.name
+}
+
+func TestToolActivationOptionsValidateToolSets(t *testing.T) {
+	require.Panics(t, func() {
+		New(
+			"agent",
+			WithActivatableToolSets([]tool.ToolSet{
+				activationToolSet{name: "dup"},
+				activationToolSet{name: "dup"},
+			}),
+		)
+	})
+	require.Panics(t, func() {
+		New(
+			"agent",
+			WithActivatableToolSets([]tool.ToolSet{
+				activationToolSet{name: "github"},
+			}),
+			WithToolActivationOnSkillLoad("review", []string{"missing"}),
+		)
+	})
+	require.Panics(t, func() {
+		New(
+			"agent",
+			WithActivatableToolSets([]tool.ToolSet{
+				activationToolSet{name: "github"},
+			}),
+			WithToolActivationOnSkillLoad("", []string{"github"}),
+		)
+	})
+	require.Panics(t, func() {
+		New(
+			"agent",
+			WithActivatableToolSets([]tool.ToolSet{
+				activationToolSet{name: "github"},
+			}),
+			WithToolActivationOnSkillLoad("review", nil),
+		)
+	})
+	require.Panics(t, func() {
+		New(
+			"agent",
+			WithActivatableToolSets([]tool.ToolSet{
+				activationToolSet{name: "github"},
+			}),
+			WithToolActivationOnSkillLoad(
+				"review",
+				[]string{"github"},
+				WithToolActivationMode(ToolActivationMode("append")),
+			),
+		)
+	})
+	require.Panics(t, func() {
+		New(
+			"agent",
+			WithActivatableToolSets([]tool.ToolSet{
+				activationToolSet{name: "github"},
+			}),
+			WithToolActivationOnSkillLoad(
+				"review",
+				[]string{"github"},
+				WithToolActivationLifetime(ToolActivationLifetime("turn")),
+			),
+		)
+	})
+}
+
+func TestToolActivationPostToolResultWritesRecords(t *testing.T) {
+	agt := New(
+		"agent",
+		WithActivatableToolSets([]tool.ToolSet{
+			activationToolSet{
+				name:  "github",
+				tools: []tool.Tool{activationTool{name: "search"}},
+			},
+			activationToolSet{
+				name:  "browser",
+				tools: []tool.Tool{activationTool{name: "open"}},
+			},
+		}),
+		WithToolActivationOnSkillLoad(
+			"research",
+			[]string{"github"},
+			WithToolActivationMode(ToolActivationModeInclude),
+			WithToolActivationLifetime(ToolActivationLifetimeInvocation),
+		),
+		WithToolActivationOnSkillLoad(
+			"research",
+			[]string{"browser"},
+			WithToolActivationMode(ToolActivationModeOnly),
+			WithToolActivationLifetime(ToolActivationLifetimeSession),
+		),
+	)
+	inv := &agent.Invocation{
+		AgentName: "agent",
+		Session:   session.NewSession("app", "user", "session"),
+	}
+	toolsnapshot.Set(inv, []tool.Tool{activationTool{name: "old"}}, true)
+	ev := &event.Event{
+		StateDelta: map[string][]byte{
+			skill.LoadedKey("agent", "research"): []byte("1"),
+		},
+	}
+	agt.handleToolActivationPostToolResult(context.Background(), inv, ev)
+	require.Equal(t, []toolActivationRecord{
+		{
+			Mode:        ToolActivationModeInclude,
+			Lifetime:    ToolActivationLifetimeInvocation,
+			ToolSetName: "github",
+		},
+		{
+			Mode:        ToolActivationModeOnly,
+			Lifetime:    ToolActivationLifetimeSession,
+			ToolSetName: "browser",
+		},
+	}, invocationToolActivationRecords(inv))
+	sessionKey := toolActivationSessionKey("agent", toolActivationRecord{
+		Mode:        ToolActivationModeOnly,
+		Lifetime:    ToolActivationLifetimeSession,
+		ToolSetName: "browser",
+	})
+	require.NotEmpty(t, ev.StateDelta[sessionKey])
+	_, ok := toolsnapshot.Get(inv)
+	require.False(t, ok)
+}
+
+func TestToolActivationPostToolResultIgnoresUnmatchedSkill(t *testing.T) {
+	agt := New(
+		"agent",
+		WithActivatableToolSets([]tool.ToolSet{
+			activationToolSet{name: "github"},
+		}),
+		WithToolActivationOnSkillLoad("review", []string{"github"}),
+	)
+	inv := &agent.Invocation{
+		AgentName: "agent",
+		Session:   session.NewSession("app", "user", "session"),
+	}
+	ev := &event.Event{
+		StateDelta: map[string][]byte{
+			skill.LoadedKey("agent", "other"): []byte("1"),
+		},
+	}
+	agt.handleToolActivationPostToolResult(context.Background(), inv, ev)
+	require.Empty(t, invocationToolActivationRecords(inv))
+}
+
+func TestToolActivationSkillLoadUpdatesNextModelRequestTools(t *testing.T) {
+	repo, err := skill.NewFSRepository(
+		createNamedTestSkill(t, "research", "research skill"),
+	)
+	require.NoError(t, err)
+	mockModel := &activationSequenceModel{
+		responses: []*model.Response{
+			activationToolCallResponse(t, "call-1", "research"),
+			activationFinalResponse("done"),
+		},
+	}
+	agt := New(
+		"agent",
+		WithModel(mockModel),
+		WithSkills(repo),
+		WithActivatableToolSets([]tool.ToolSet{
+			activationToolSet{
+				name:  "browser",
+				tools: []tool.Tool{activationTool{name: "open"}},
+			},
+		}),
+		WithToolActivationOnSkillLoad("research", []string{"browser"}),
+	)
+	inv := &agent.Invocation{
+		InvocationID: "inv",
+		Session:      session.NewSession("app", "user", "session"),
+		Message:      model.NewUserMessage("load research"),
+	}
+	events, err := agt.Run(context.Background(), inv)
+	require.NoError(t, err)
+	for range events {
+	}
+	requests := mockModel.Requests()
+	require.Len(t, requests, 2)
+	require.Contains(t, requests[0].Tools, "skill_load")
+	require.NotContains(t, requests[0].Tools, "browser_open")
+	require.Contains(t, requests[1].Tools, "browser_open")
+}
+
+func TestToolActivationSessionLifetimeVisibleInNextInvocation(t *testing.T) {
+	repo, err := skill.NewFSRepository(
+		createNamedTestSkill(t, "research", "research skill"),
+	)
+	require.NoError(t, err)
+	mockModel := &activationSequenceModel{
+		responses: []*model.Response{
+			activationToolCallResponse(t, "call-1", "research"),
+			activationFinalResponse("first done"),
+			activationFinalResponse("second done"),
+		},
+	}
+	agt := New(
+		"agent",
+		WithModel(mockModel),
+		WithSkills(repo),
+		WithActivatableToolSets([]tool.ToolSet{
+			activationToolSet{
+				name:  "browser",
+				tools: []tool.Tool{activationTool{name: "open"}},
+			},
+		}),
+		WithToolActivationOnSkillLoad(
+			"research",
+			[]string{"browser"},
+			WithToolActivationLifetime(ToolActivationLifetimeSession),
+		),
+	)
+	sess := session.NewSession("app", "user", "session")
+	inv1 := &agent.Invocation{
+		InvocationID: "inv-1",
+		Session:      sess,
+		Message:      model.NewUserMessage("load research"),
+	}
+	events, err := agt.Run(context.Background(), inv1)
+	require.NoError(t, err)
+	drainEventsAndApplyStateDelta(t, sess, events)
+	inv2 := &agent.Invocation{
+		InvocationID: "inv-2",
+		Session:      sess,
+		Message:      model.NewUserMessage("use research"),
+	}
+	events, err = agt.Run(context.Background(), inv2)
+	require.NoError(t, err)
+	drainEventsAndApplyStateDelta(t, sess, events)
+	requests := mockModel.Requests()
+	require.Len(t, requests, 3)
+	require.Contains(t, requests[1].Tools, "browser_open")
+	require.Contains(t, requests[2].Tools, "browser_open")
+}
+
+func TestToolActivationInvocationLifetimeNotVisibleInNextInvocation(t *testing.T) {
+	repo, err := skill.NewFSRepository(
+		createNamedTestSkill(t, "research", "research skill"),
+	)
+	require.NoError(t, err)
+	mockModel := &activationSequenceModel{
+		responses: []*model.Response{
+			activationToolCallResponse(t, "call-1", "research"),
+			activationFinalResponse("first done"),
+			activationFinalResponse("second done"),
+		},
+	}
+	agt := New(
+		"agent",
+		WithModel(mockModel),
+		WithSkills(repo),
+		WithActivatableToolSets([]tool.ToolSet{
+			activationToolSet{
+				name:  "browser",
+				tools: []tool.Tool{activationTool{name: "open"}},
+			},
+		}),
+		WithToolActivationOnSkillLoad(
+			"research",
+			[]string{"browser"},
+			WithToolActivationLifetime(ToolActivationLifetimeInvocation),
+		),
+	)
+	sess := session.NewSession("app", "user", "session")
+	inv1 := &agent.Invocation{
+		InvocationID: "inv-1",
+		Session:      sess,
+		Message:      model.NewUserMessage("load research"),
+	}
+	events, err := agt.Run(context.Background(), inv1)
+	require.NoError(t, err)
+	drainEventsAndApplyStateDelta(t, sess, events)
+	inv2 := &agent.Invocation{
+		InvocationID: "inv-2",
+		Session:      sess,
+		Message:      model.NewUserMessage("use research"),
+	}
+	events, err = agt.Run(context.Background(), inv2)
+	require.NoError(t, err)
+	drainEventsAndApplyStateDelta(t, sess, events)
+	requests := mockModel.Requests()
+	require.Len(t, requests, 3)
+	require.Contains(t, requests[1].Tools, "browser_open")
+	require.NotContains(t, requests[2].Tools, "browser_open")
+}
+
+func TestToolActivationOnlyTrimsRunOptionTools(t *testing.T) {
+	mockModel := &activationSequenceModel{
+		responses: []*model.Response{activationFinalResponse("done")},
+	}
+	agt := New(
+		"agent",
+		WithModel(mockModel),
+		WithActivatableToolSets([]tool.ToolSet{
+			activationToolSet{
+				name:  "safe",
+				tools: []tool.Tool{activationTool{name: "browse"}},
+			},
+		}),
+		WithToolActivationOnSkillLoad(
+			"unused",
+			[]string{"safe"},
+			WithToolActivationMode(ToolActivationModeOnly),
+		),
+	)
+	record, ok := newToolActivationRecord(
+		ToolActivationModeOnly,
+		ToolActivationLifetimeInvocation,
+		"safe",
+	)
+	require.True(t, ok)
+	inv := &agent.Invocation{
+		InvocationID: "inv",
+		Session:      session.NewSession("app", "user", "session"),
+		Message:      model.NewUserMessage("use safe tools"),
+		RunOptions: agent.RunOptions{
+			AdditionalTools: []tool.Tool{activationTool{name: "extra"}},
+			ExternalTools:   []tool.Tool{activationTool{name: "external"}},
+		},
+	}
+	require.True(t, addInvocationToolActivationRecords(inv, []toolActivationRecord{record}))
+	events, err := agt.Run(context.Background(), inv)
+	require.NoError(t, err)
+	for range events {
+	}
+	requests := mockModel.Requests()
+	require.Len(t, requests, 1)
+	require.Contains(t, requests[0].Tools, "safe_browse")
+	require.NotContains(t, requests[0].Tools, "extra")
+	require.NotContains(t, requests[0].Tools, "external")
+	require.Empty(t, inv.RunOptions.ExternalToolNames)
+}
+
+func TestToolActivationOnlyExcludesIncludeActivatedTools(t *testing.T) {
+	mockModel := &activationSequenceModel{
+		responses: []*model.Response{activationFinalResponse("done")},
+	}
+	agt := New(
+		"agent",
+		WithModel(mockModel),
+		WithActivatableToolSets([]tool.ToolSet{
+			activationToolSet{
+				name:  "safe",
+				tools: []tool.Tool{activationTool{name: "browse"}},
+			},
+			activationToolSet{
+				name:  "extra",
+				tools: []tool.Tool{activationTool{name: "search"}},
+			},
+		}),
+		WithToolActivationOnSkillLoad(
+			"only",
+			[]string{"safe"},
+			WithToolActivationMode(ToolActivationModeOnly),
+		),
+		WithToolActivationOnSkillLoad("include", []string{"extra"}),
+	)
+	onlyRecord, ok := newToolActivationRecord(
+		ToolActivationModeOnly,
+		ToolActivationLifetimeInvocation,
+		"safe",
+	)
+	require.True(t, ok)
+	includeRecord, ok := newToolActivationRecord(
+		ToolActivationModeInclude,
+		ToolActivationLifetimeInvocation,
+		"extra",
+	)
+	require.True(t, ok)
+	inv := &agent.Invocation{
+		InvocationID: "inv",
+		Session:      session.NewSession("app", "user", "session"),
+		Message:      model.NewUserMessage("use safe tools"),
+	}
+	require.True(t, addInvocationToolActivationRecords(
+		inv,
+		[]toolActivationRecord{onlyRecord, includeRecord},
+	))
+	events, err := agt.Run(context.Background(), inv)
+	require.NoError(t, err)
+	for range events {
+	}
+	requests := mockModel.Requests()
+	require.Len(t, requests, 1)
+	require.Contains(t, requests[0].Tools, "safe_browse")
+	require.NotContains(t, requests[0].Tools, "extra_search")
+}
+
+func TestToolActivationIncludeReplacesExternalToolWithSameName(t *testing.T) {
+	record, ok := newToolActivationRecord(
+		ToolActivationModeInclude,
+		ToolActivationLifetimeInvocation,
+		"safe",
+	)
+	require.True(t, ok)
+	inv := &agent.Invocation{
+		AgentName: "agent",
+		Session:   session.NewSession("app", "user", "session"),
+	}
+	require.True(t, addInvocationToolActivationRecords(
+		inv,
+		[]toolActivationRecord{record},
+	))
+	external := activationTool{name: "safe_browse"}
+	userToolNames := map[string]bool{"safe_browse": true}
+	externalToolNames := map[string]bool{"safe_browse": true}
+	out, userNames, externalNames := applyToolActivationRecords(
+		context.Background(),
+		inv,
+		[]tool.Tool{external},
+		userToolNames,
+		externalToolNames,
+		[]tool.ToolSet{
+			activationToolSet{
+				name:  "safe",
+				tools: []tool.Tool{activationTool{name: "browse"}},
+			},
+		},
+		nil,
+	)
+	require.Len(t, out, 1)
+	activated, ok := out[0].(*itool.NamedTool)
+	require.True(t, ok)
+	require.Equal(t, "safe_browse", activated.Declaration().Name)
+	require.True(t, userNames["safe_browse"])
+	require.Empty(t, externalNames)
+	require.Equal(t, map[string]bool{"safe_browse": true}, externalToolNames)
+}
+
+func TestToolActivationRunFilterAppliesToActivatedTools(t *testing.T) {
+	mockModel := &activationSequenceModel{
+		responses: []*model.Response{activationFinalResponse("done")},
+	}
+	agt := New(
+		"agent",
+		WithModel(mockModel),
+		WithActivatableToolSets([]tool.ToolSet{
+			activationToolSet{
+				name:  "safe",
+				tools: []tool.Tool{activationTool{name: "browse"}},
+			},
+		}),
+		WithToolActivationOnSkillLoad("unused", []string{"safe"}),
+	)
+	record, ok := newToolActivationRecord(
+		ToolActivationModeInclude,
+		ToolActivationLifetimeInvocation,
+		"safe",
+	)
+	require.True(t, ok)
+	inv := &agent.Invocation{
+		InvocationID: "inv",
+		Session:      session.NewSession("app", "user", "session"),
+		Message:      model.NewUserMessage("use safe tools"),
+		RunOptions: agent.RunOptions{
+			ToolFilter: func(_ context.Context, tl tool.Tool) bool {
+				return tl.Declaration().Name != "safe_browse"
+			},
+		},
+	}
+	require.True(t, addInvocationToolActivationRecords(inv, []toolActivationRecord{record}))
+	events, err := agt.Run(context.Background(), inv)
+	require.NoError(t, err)
+	for range events {
+	}
+	requests := mockModel.Requests()
+	require.Len(t, requests, 1)
+	require.NotContains(t, requests[0].Tools, "safe_browse")
+}
+
+func TestToolActivationWithoutRulesIgnoresSessionRecords(t *testing.T) {
+	mockModel := &activationSequenceModel{
+		responses: []*model.Response{activationFinalResponse("done")},
+	}
+	agt := New(
+		"agent",
+		WithModel(mockModel),
+		WithActivatableToolSets([]tool.ToolSet{
+			activationToolSet{
+				name:  "browser",
+				tools: []tool.Tool{activationTool{name: "open"}},
+			},
+		}),
+	)
+	sess := session.NewSession("app", "user", "session")
+	record, ok := newToolActivationRecord(
+		ToolActivationModeInclude,
+		ToolActivationLifetimeSession,
+		"browser",
+	)
+	require.True(t, ok)
+	sess.SetState(
+		toolActivationSessionKey("agent", record),
+		marshalToolActivationRecord(record),
+	)
+	inv := &agent.Invocation{
+		InvocationID: "inv",
+		Session:      sess,
+		Message:      model.NewUserMessage("no activation rules"),
+	}
+	events, err := agt.Run(context.Background(), inv)
+	require.NoError(t, err)
+	for range events {
+	}
+	requests := mockModel.Requests()
+	require.Len(t, requests, 1)
+	require.NotContains(t, requests[0].Tools, "browser_open")
+}
+
+func TestToolActivationOutputSchemaIgnoresSessionRecords(t *testing.T) {
+	mockModel := &activationSequenceModel{
+		responses: []*model.Response{{
+			Done: true,
+			Choices: []model.Choice{{
+				Message: model.Message{
+					Role:    model.RoleAssistant,
+					Content: `{"ok":true}`,
+				},
+			}},
+		}},
+	}
+	agt := New(
+		"agent",
+		WithModel(mockModel),
+		WithOutputSchema(map[string]any{"type": "object"}),
+		WithActivatableToolSets([]tool.ToolSet{
+			activationToolSet{
+				name:  "browser",
+				tools: []tool.Tool{activationTool{name: "open"}},
+			},
+		}),
+	)
+	sess := session.NewSession("app", "user", "session")
+	record, ok := newToolActivationRecord(
+		ToolActivationModeInclude,
+		ToolActivationLifetimeSession,
+		"browser",
+	)
+	require.True(t, ok)
+	sess.SetState(
+		toolActivationSessionKey("agent", record),
+		marshalToolActivationRecord(record),
+	)
+	inv := &agent.Invocation{
+		InvocationID: "inv",
+		Session:      sess,
+		Message:      model.NewUserMessage("return json"),
+	}
+	events, err := agt.Run(context.Background(), inv)
+	require.NoError(t, err)
+	for range events {
+	}
+	requests := mockModel.Requests()
+	require.Len(t, requests, 1)
+	require.NotContains(t, requests[0].Tools, "browser_open")
+}
+
+type activationSequenceModel struct {
+	mu        sync.Mutex
+	responses []*model.Response
+	requests  []*model.Request
+}
+
+func (m *activationSequenceModel) GenerateContent(
+	_ context.Context,
+	request *model.Request,
+) (<-chan *model.Response, error) {
+	m.mu.Lock()
+	m.requests = append(m.requests, request)
+	idx := len(m.requests) - 1
+	m.mu.Unlock()
+	ch := make(chan *model.Response, 1)
+	if idx < len(m.responses) {
+		ch <- m.responses[idx]
+	}
+	close(ch)
+	return ch, nil
+}
+
+func (m *activationSequenceModel) Info() model.Info {
+	return model.Info{Name: "activation-sequence-model"}
+}
+
+func (m *activationSequenceModel) Requests() []*model.Request {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]*model.Request(nil), m.requests...)
+}
+
+func activationFinalResponse(content string) *model.Response {
+	return &model.Response{
+		Done: true,
+		Choices: []model.Choice{{
+			Message: model.Message{
+				Role:    model.RoleAssistant,
+				Content: content,
+			},
+		}},
+	}
+}
+
+func drainEventsAndApplyStateDelta(
+	t *testing.T,
+	sess *session.Session,
+	events <-chan *event.Event,
+) {
+	t.Helper()
+	for ev := range events {
+		sess.ApplyEventStateDelta(ev)
+	}
+}
+
+func activationToolCallResponse(
+	t *testing.T,
+	callID string,
+	skillName string,
+) *model.Response {
+	t.Helper()
+	args, err := json.Marshal(map[string]string{"skill": skillName})
+	require.NoError(t, err)
+	return &model.Response{
+		Model: "activation-sequence-model",
+		Done:  true,
+		Choices: []model.Choice{{
+			Message: model.Message{
+				Role: model.RoleAssistant,
+				ToolCalls: []model.ToolCall{{
+					ID: callID,
+					Function: model.FunctionDefinitionParam{
+						Name:      "skill_load",
+						Arguments: args,
+					},
+				}},
+			},
+		}},
+	}
+}

--- a/agent/llmagent/tool_activation_test.go
+++ b/agent/llmagent/tool_activation_test.go
@@ -634,6 +634,141 @@ func TestToolActivationSessionKeyEscapesSegmentsWithoutCollision(t *testing.T) {
 	)
 }
 
+func TestToolActivationValidationAndRecordEdgeCases(t *testing.T) {
+	require.NoError(t, validateAndNormalizeToolActivationOptions(nil))
+	_, err := collectActivatableToolSetNames([]tool.ToolSet{nil})
+	require.Error(t, err)
+	_, err = collectActivatableToolSetNames([]tool.ToolSet{
+		activationToolSet{name: " "},
+	})
+	require.Error(t, err)
+	trigger, err := normalizeToolActivationTrigger(toolActivationTrigger{
+		kind: toolActivationTriggerKind("unsupported"),
+	})
+	require.Error(t, err)
+	require.Empty(t, trigger)
+	require.Equal(
+		t,
+		"unsupported",
+		(toolActivationTrigger{kind: "unsupported"}).describe(),
+	)
+	require.Equal(t, []string{"a", "b"}, normalizeToolSetNames([]string{
+		" a ",
+		"",
+		"a",
+		"b",
+	}))
+	require.False(t, (toolActivationRule{
+		trigger: toolActivationTrigger{kind: "unsupported"},
+	}).matchesLoadedSkills(map[string]bool{"a": true}))
+	_, ok := newToolActivationRecord(
+		ToolActivationModeInclude,
+		ToolActivationLifetimeInvocation,
+		" ",
+	)
+	require.False(t, ok)
+	_, ok = newToolActivationRecord(
+		ToolActivationMode("append"),
+		ToolActivationLifetimeInvocation,
+		"x",
+	)
+	require.False(t, ok)
+	_, ok = newToolActivationRecord(
+		ToolActivationModeInclude,
+		ToolActivationLifetime("turn"),
+		"x",
+	)
+	require.False(t, ok)
+	record, ok := newToolActivationRecord(
+		ToolActivationModeInclude,
+		ToolActivationLifetimeInvocation,
+		"x",
+	)
+	require.True(t, ok)
+	require.False(t, addInvocationToolActivationRecords(nil, []toolActivationRecord{record}))
+	require.False(t, addInvocationToolActivationRecords(&agent.Invocation{}, nil))
+	inv := &agent.Invocation{}
+	require.True(t, addInvocationToolActivationRecords(inv, []toolActivationRecord{record}))
+	require.False(t, addInvocationToolActivationRecords(inv, []toolActivationRecord{record}))
+	require.False(t, sameToolActivationRecords(
+		[]toolActivationRecord{record},
+		[]toolActivationRecord{{
+			Mode:        ToolActivationModeInclude,
+			Lifetime:    ToolActivationLifetimeInvocation,
+			ToolSetName: "y",
+		}},
+	))
+	require.True(t, sameToolActivationRecords(
+		[]toolActivationRecord{record},
+		[]toolActivationRecord{record},
+	))
+}
+
+func TestSessionToolActivationRecordsSkipsInvalidState(t *testing.T) {
+	ctx := context.Background()
+	require.Empty(t, sessionToolActivationRecords(ctx, nil))
+	require.Empty(t, sessionToolActivationRecords(ctx, &agent.Invocation{}))
+	sess := session.NewSession("app", "user", "session")
+	inv := &agent.Invocation{AgentName: "agent", Session: sess}
+	require.Empty(t, sessionToolActivationRecords(ctx, inv))
+	prefix := toolActivationSessionPrefixForAgent("agent")
+	valid, ok := newToolActivationRecord(
+		ToolActivationModeInclude,
+		ToolActivationLifetimeSession,
+		"valid",
+	)
+	require.True(t, ok)
+	invalidLifetime := toolActivationRecord{
+		Mode:        ToolActivationModeInclude,
+		Lifetime:    ToolActivationLifetimeInvocation,
+		ToolSetName: "invalid",
+	}
+	sess.SetState(prefix+"empty", []byte{})
+	sess.SetState(prefix+"bad-json", []byte("{"))
+	sess.SetState(prefix+"invalid-lifetime", marshalToolActivationRecord(invalidLifetime))
+	sess.SetState(toolActivationSessionKey("agent", valid), marshalToolActivationRecord(valid))
+	require.Equal(t, []toolActivationRecord{valid}, sessionToolActivationRecords(ctx, inv))
+}
+
+func TestToolActivationExpansionSkipsDuplicatesAndFilteredTools(t *testing.T) {
+	ctx := context.Background()
+	toolSet := activationToolSet{
+		name: "safe",
+		tools: []tool.Tool{
+			activationTool{name: "browse"},
+			activationTool{name: "browse"},
+			activationTool{name: "skip"},
+		},
+	}
+	accepted := map[string]bool{}
+	tools := expandOneToolActivationSet(
+		ctx,
+		toolSet,
+		accepted,
+		func(_ context.Context, tl tool.Tool) bool {
+			return toolActivationToolName(tl) != "safe_skip"
+		},
+	)
+	require.Len(t, tools, 1)
+	require.Equal(t, "safe_browse", toolActivationToolName(tools[0]))
+	require.True(t, accepted["safe_browse"])
+	require.Empty(t, expandOneToolActivationSet(
+		ctx,
+		activationToolSet{
+			name:  "safe",
+			tools: []tool.Tool{activationTool{name: "browse"}},
+		},
+		accepted,
+		nil,
+	))
+	require.Empty(t, expandOneToolActivationSet(
+		ctx,
+		activationToolSet{name: "empty"},
+		map[string]bool{},
+		nil,
+	))
+}
+
 type activationSequenceModel struct {
 	mu        sync.Mutex
 	responses []*model.Response

--- a/agent/llmagent/tool_activation_test.go
+++ b/agent/llmagent/tool_activation_test.go
@@ -609,6 +609,31 @@ func TestToolActivationOutputSchemaIgnoresSessionRecords(t *testing.T) {
 	require.NotContains(t, requests[0].Tools, "browser_open")
 }
 
+func TestToolActivationSessionKeyEscapesSegmentsWithoutCollision(t *testing.T) {
+	slashRecord, ok := newToolActivationRecord(
+		ToolActivationModeInclude,
+		ToolActivationLifetimeSession,
+		"docs/a",
+	)
+	require.True(t, ok)
+	escapedRecord, ok := newToolActivationRecord(
+		ToolActivationModeInclude,
+		ToolActivationLifetimeSession,
+		"docs%2Fa",
+	)
+	require.True(t, ok)
+	require.NotEqual(
+		t,
+		toolActivationSessionKey("agent", slashRecord),
+		toolActivationSessionKey("agent", escapedRecord),
+	)
+	require.NotEqual(
+		t,
+		toolActivationSessionPrefixForAgent("agent/a"),
+		toolActivationSessionPrefixForAgent("agent%2Fa"),
+	)
+}
+
 type activationSequenceModel struct {
 	mu        sync.Mutex
 	responses []*model.Response

--- a/agent/llmagent/tool_activation_test.go
+++ b/agent/llmagent/tool_activation_test.go
@@ -471,6 +471,7 @@ func TestToolActivationIncludeReplacesExternalToolWithSameName(t *testing.T) {
 			},
 		},
 		nil,
+		nil,
 	)
 	require.Len(t, out, 1)
 	activated, ok := out[0].(*itool.NamedTool)
@@ -559,6 +560,65 @@ func TestToolActivationWithoutRulesIgnoresSessionRecords(t *testing.T) {
 	requests := mockModel.Requests()
 	require.Len(t, requests, 1)
 	require.NotContains(t, requests[0].Tools, "browser_open")
+}
+
+func TestToolActivationSessionRecordsRequireCurrentRules(t *testing.T) {
+	mockModel := &activationSequenceModel{
+		responses: []*model.Response{activationFinalResponse("done")},
+	}
+	agt := New(
+		"agent",
+		WithModel(mockModel),
+		WithActivatableToolSets([]tool.ToolSet{
+			activationToolSet{
+				name:  "allowed",
+				tools: []tool.Tool{activationTool{name: "open"}},
+			},
+			activationToolSet{
+				name:  "stale",
+				tools: []tool.Tool{activationTool{name: "open"}},
+			},
+		}),
+		WithToolActivationOnSkillLoad(
+			"research",
+			[]string{"allowed"},
+			WithToolActivationLifetime(ToolActivationLifetimeSession),
+		),
+	)
+	sess := session.NewSession("app", "user", "session")
+	allowed, ok := newToolActivationRecord(
+		ToolActivationModeInclude,
+		ToolActivationLifetimeSession,
+		"allowed",
+	)
+	require.True(t, ok)
+	stale, ok := newToolActivationRecord(
+		ToolActivationModeInclude,
+		ToolActivationLifetimeSession,
+		"stale",
+	)
+	require.True(t, ok)
+	sess.SetState(
+		toolActivationSessionKey("agent", allowed),
+		marshalToolActivationRecord(allowed),
+	)
+	sess.SetState(
+		toolActivationSessionKey("agent", stale),
+		marshalToolActivationRecord(stale),
+	)
+	inv := &agent.Invocation{
+		InvocationID: "inv",
+		Session:      sess,
+		Message:      model.NewUserMessage("use research"),
+	}
+	events, err := agt.Run(context.Background(), inv)
+	require.NoError(t, err)
+	for range events {
+	}
+	requests := mockModel.Requests()
+	require.Len(t, requests, 1)
+	require.Contains(t, requests[0].Tools, "allowed_open")
+	require.NotContains(t, requests[0].Tools, "stale_open")
 }
 
 func TestToolActivationOutputSchemaIgnoresSessionRecords(t *testing.T) {
@@ -706,11 +766,11 @@ func TestToolActivationValidationAndRecordEdgeCases(t *testing.T) {
 
 func TestSessionToolActivationRecordsSkipsInvalidState(t *testing.T) {
 	ctx := context.Background()
-	require.Empty(t, sessionToolActivationRecords(ctx, nil))
-	require.Empty(t, sessionToolActivationRecords(ctx, &agent.Invocation{}))
+	require.Empty(t, sessionToolActivationRecords(ctx, nil, nil))
+	require.Empty(t, sessionToolActivationRecords(ctx, &agent.Invocation{}, nil))
 	sess := session.NewSession("app", "user", "session")
 	inv := &agent.Invocation{AgentName: "agent", Session: sess}
-	require.Empty(t, sessionToolActivationRecords(ctx, inv))
+	require.Empty(t, sessionToolActivationRecords(ctx, inv, nil))
 	prefix := toolActivationSessionPrefixForAgent("agent")
 	valid, ok := newToolActivationRecord(
 		ToolActivationModeInclude,
@@ -727,7 +787,58 @@ func TestSessionToolActivationRecordsSkipsInvalidState(t *testing.T) {
 	sess.SetState(prefix+"bad-json", []byte("{"))
 	sess.SetState(prefix+"invalid-lifetime", marshalToolActivationRecord(invalidLifetime))
 	sess.SetState(toolActivationSessionKey("agent", valid), marshalToolActivationRecord(valid))
-	require.Equal(t, []toolActivationRecord{valid}, sessionToolActivationRecords(ctx, inv))
+	allowedKeys := allowedSessionToolActivationRecordKeys([]toolActivationRule{{
+		mode:         ToolActivationModeInclude,
+		lifetime:     ToolActivationLifetimeSession,
+		toolSetNames: []string{"valid"},
+	}})
+	require.Equal(t, []toolActivationRecord{valid}, sessionToolActivationRecords(ctx, inv, allowedKeys))
+}
+
+func TestSessionToolActivationRecordsFiltersCurrentRulesAndKeyPayload(t *testing.T) {
+	ctx := context.Background()
+	sess := session.NewSession("app", "user", "session")
+	inv := &agent.Invocation{AgentName: "agent", Session: sess}
+	allowed, ok := newToolActivationRecord(
+		ToolActivationModeInclude,
+		ToolActivationLifetimeSession,
+		"allowed",
+	)
+	require.True(t, ok)
+	stale, ok := newToolActivationRecord(
+		ToolActivationModeInclude,
+		ToolActivationLifetimeSession,
+		"stale",
+	)
+	require.True(t, ok)
+	modeMismatch, ok := newToolActivationRecord(
+		ToolActivationModeOnly,
+		ToolActivationLifetimeSession,
+		"allowed",
+	)
+	require.True(t, ok)
+	keyRecord, ok := newToolActivationRecord(
+		ToolActivationModeInclude,
+		ToolActivationLifetimeSession,
+		"key",
+	)
+	require.True(t, ok)
+	payloadRecord, ok := newToolActivationRecord(
+		ToolActivationModeInclude,
+		ToolActivationLifetimeSession,
+		"payload",
+	)
+	require.True(t, ok)
+	allowedKeys := allowedSessionToolActivationRecordKeys([]toolActivationRule{{
+		mode:         ToolActivationModeInclude,
+		lifetime:     ToolActivationLifetimeSession,
+		toolSetNames: []string{"allowed", "payload"},
+	}})
+	sess.SetState(toolActivationSessionKey("agent", allowed), marshalToolActivationRecord(allowed))
+	sess.SetState(toolActivationSessionKey("agent", stale), marshalToolActivationRecord(stale))
+	sess.SetState(toolActivationSessionKey("agent", modeMismatch), marshalToolActivationRecord(modeMismatch))
+	sess.SetState(toolActivationSessionKey("agent", keyRecord), marshalToolActivationRecord(payloadRecord))
+	require.Equal(t, []toolActivationRecord{allowed}, sessionToolActivationRecords(ctx, inv, allowedKeys))
 }
 
 func TestToolActivationExpansionSkipsDuplicatesAndFilteredTools(t *testing.T) {

--- a/docs/mkdocs/en/skill.md
+++ b/docs/mkdocs/en/skill.md
@@ -1168,6 +1168,8 @@ agent := llmagent.New(
 `WithToolActivationOnSkillLoad(...)` establishes the activation relationship between a skill and candidate ToolSets. After the model successfully calls `skill_load` to load the corresponding skill, the activation result takes effect starting from the next model request. If the same `Runner.Run` continues into a tool loop, later model requests in that run use the updated tool set. When multiple rules match at the same time, the framework first
 merges activation records and keeps only one copy of each identical `(mode, lifetime, toolSetName)` record. It then expands ToolSets, and the final tool set handles duplicates and name conflicts by tool name.
 
+`WithToolActivationOnSkillLoad(...)` cannot be configured together with `WithOutputSchema(...)`.
+
 User tools include tools added through `WithTools(...)`, `WithToolSets(...)`, runtime `agent.WithAdditionalTools(...)`, and `agent.WithExternalTools(...)`. Framework tools are registered automatically by `LLMAgent` based on enabled capabilities, such as `skill_load`, `workspace_exec`, and `transfer_to_agent`.
 
 ### Activation Mode

--- a/docs/mkdocs/en/skill.md
+++ b/docs/mkdocs/en/skill.md
@@ -1128,6 +1128,173 @@ disable `workspace_exec`. To hide execution capability from the model,
 disable the workspace execution surface when creating the Agent, for
 example with `llmagent.WithWorkspaceExecSurfaceEnabled(false)`.
 
+## Tool Activation Based on Skill Loading
+
+ToolSets registered with `WithToolSets(...)` enter model requests together with the Agent. Tool activation provides another way to attach tools: first register ToolSets as candidates, then decide whether they enter later model requests based on the result of `skill_load`.
+
+For a complete example, see [examples/skilltoolactivation/README.md](https://github.com/trpc-group/trpc-agent-go/blob/main/examples/skilltoolactivation/README.md).
+
+The following example registers `example_file` as a candidate ToolSet and declares that loading `example-skill` activates that ToolSet. After the model successfully calls `skill_load`, later model requests include the tools expanded from `example_file`.
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/skill"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+	"trpc.group/trpc-go/trpc-agent-go/tool/file"
+)
+
+repo, _ := skill.NewFSRepository("./skills")
+exampleFiles, _ := file.NewToolSet(
+	file.WithName("example_file"),
+	file.WithBaseDir("./files"),
+)
+
+agent := llmagent.New(
+	"skills-assistant",
+	llmagent.WithSkills(repo),
+	llmagent.WithActivatableToolSets([]tool.ToolSet{exampleFiles}),
+	llmagent.WithToolActivationOnSkillLoad(
+		"example-skill",
+		[]string{"example_file"},
+		llmagent.WithToolActivationMode(llmagent.ToolActivationModeInclude),
+		llmagent.WithToolActivationLifetime(llmagent.ToolActivationLifetimeInvocation),
+	),
+)
+```
+
+`WithActivatableToolSets(...)` registers candidate ToolSets. A candidate ToolSet uses `ToolSet.Name()` as its reference name and follows the normal ToolSet tool naming rules. Tools in the candidate set enter model requests only after an activation rule matches.
+
+`WithToolActivationOnSkillLoad(...)` establishes the activation relationship between a skill and candidate ToolSets. After the model successfully calls `skill_load` to load the corresponding skill, the activation result takes effect starting from the next model request. If the same `Runner.Run` continues into a tool loop, later model requests in that run use the updated tool set. When multiple rules match at the same time, the framework first
+merges activation records and keeps only one copy of each identical `(mode, lifetime, toolSetName)` record. It then expands ToolSets, and the final tool set handles duplicates and name conflicts by tool name.
+
+User tools include tools added through `WithTools(...)`, `WithToolSets(...)`, runtime `agent.WithAdditionalTools(...)`, and `agent.WithExternalTools(...)`. Framework tools are registered automatically by `LLMAgent` based on enabled capabilities, such as `skill_load`, `workspace_exec`, and `transfer_to_agent`.
+
+### Activation Mode
+
+`WithToolActivationMode(...)` sets how activated tools are composed with existing user tools.
+
+#### Include Mode
+
+`ToolActivationModeInclude` is the default mode. It adds activated tools on top of existing user tools.
+
+The following example configures two Include rules for the same skill.
+
+```go
+searchTool := function.NewFunctionTool(search, function.WithName("search"))
+calculatorTool := function.NewFunctionTool(calculator, function.WithName("calculator"))
+exampleSearch, _ := file.NewToolSet(
+	file.WithName("example_search"),
+	file.WithBaseDir("./search"),
+)
+
+agent := llmagent.New(
+	"skills-assistant",
+	llmagent.WithSkills(repo),
+	llmagent.WithTools([]tool.Tool{searchTool, calculatorTool}),
+	llmagent.WithActivatableToolSets([]tool.ToolSet{
+		exampleFiles,
+		exampleSearch,
+	}),
+	llmagent.WithToolActivationOnSkillLoad(
+		"example-skill",
+		[]string{"example_file"},
+		llmagent.WithToolActivationMode(llmagent.ToolActivationModeInclude),
+	),
+	llmagent.WithToolActivationOnSkillLoad(
+		"example-skill",
+		[]string{"example_search"},
+		llmagent.WithToolActivationMode(llmagent.ToolActivationModeInclude),
+	),
+)
+```
+
+After `example-skill` is loaded, later model requests include the existing `search` and `calculator` tools, and also include the tools expanded from `example_file` and `example_search`.
+
+#### Only Mode
+
+`ToolActivationModeOnly` makes the user tool set equal to the activated tool set, while framework tools remain available.
+
+The following example configures two Only rules for the same skill.
+
+```go
+searchTool := function.NewFunctionTool(search, function.WithName("search"))
+calculatorTool := function.NewFunctionTool(calculator, function.WithName("calculator"))
+exampleSearch, _ := file.NewToolSet(
+	file.WithName("example_search"),
+	file.WithBaseDir("./search"),
+)
+
+agent := llmagent.New(
+	"skills-assistant",
+	llmagent.WithSkills(repo),
+	llmagent.WithTools([]tool.Tool{searchTool, calculatorTool}),
+	llmagent.WithActivatableToolSets([]tool.ToolSet{
+		exampleFiles,
+		exampleSearch,
+	}),
+	llmagent.WithToolActivationOnSkillLoad(
+		"example-skill",
+		[]string{"example_file"},
+		llmagent.WithToolActivationMode(llmagent.ToolActivationModeOnly),
+	),
+	llmagent.WithToolActivationOnSkillLoad(
+		"example-skill",
+		[]string{"example_search"},
+		llmagent.WithToolActivationMode(llmagent.ToolActivationModeOnly),
+	),
+)
+```
+
+After `example-skill` is loaded, the user tools in later model requests come from the tools expanded from `example_file` and `example_search`; `search` and `calculator` are trimmed. Framework tools remain available.
+
+#### Include and Only Match Simultaneously
+
+When Include and Only activation results exist at the same time in one model request, the user tool set for that request is composed in Only mode. In other words, only user tools expanded from all Only rules are kept, while framework tools remain available.
+
+```go
+searchTool := function.NewFunctionTool(search, function.WithName("search"))
+calculatorTool := function.NewFunctionTool(calculator, function.WithName("calculator"))
+exampleSearch, _ := file.NewToolSet(
+	file.WithName("example_search"),
+	file.WithBaseDir("./search"),
+)
+
+agent := llmagent.New(
+	"skills-assistant",
+	llmagent.WithSkills(repo),
+	llmagent.WithTools([]tool.Tool{searchTool, calculatorTool}),
+	llmagent.WithActivatableToolSets([]tool.ToolSet{
+		exampleFiles,
+		exampleSearch,
+	}),
+	llmagent.WithToolActivationOnSkillLoad(
+		"example-skill",
+		[]string{"example_file"},
+		llmagent.WithToolActivationMode(llmagent.ToolActivationModeInclude),
+	),
+	llmagent.WithToolActivationOnSkillLoad(
+		"example-skill",
+		[]string{"example_search"},
+		llmagent.WithToolActivationMode(llmagent.ToolActivationModeOnly),
+	),
+)
+```
+
+After `example-skill` is loaded, the user tools in later model requests come from the tools expanded from `example_search`. `search`, `calculator`, and `example_file` from the Include rule do not enter the user tool set for that request.
+
+#### Same-name Tool Handling
+
+When an activated tool has the same name as an existing user tool, the activated tool is used in the final result. In Include mode, the same-name user tool is replaced. In Only mode, the final user tool set comes from the activated tools expanded by Only rules. When an activated tool has the same name as a framework tool, the framework tool remains visible and a warning
+is recorded.
+
+### Activation Lifetime
+
+`WithToolActivationLifetime(...)` sets the effective lifetime of activation results.
+
+- `ToolActivationLifetimeInvocation` is the default lifetime. The activation result is effective only within the current agent invocation. If this invocation continues to produce later model requests, those requests keep carrying the activated tools. The next invocation of the same agent needs to trigger activation again through `skill_load`.
+- `ToolActivationLifetimeSession` keeps the activation result effective within the same session. Later invocations of the same agent in that session keep carrying those activated tools.
+
 ## Troubleshooting
 
 - Unknown skill: verify name and repository path; ensure the overview

--- a/docs/mkdocs/zh/skill.md
+++ b/docs/mkdocs/zh/skill.md
@@ -1118,6 +1118,8 @@ agent := llmagent.New(
 
 `WithToolActivationOnSkillLoad(...)` 建立 skill 与候选 ToolSet 的激活关系。模型成功调用 `skill_load` 加载对应 skill 后，激活结果从下一次模型请求开始生效。一次 `Runner.Run` 内若继续进入工具循环，后续模型请求会使用更新后的工具集合。多条规则同时命中时，框架先合并激活记录，完全相同的 `(mode, lifetime, toolSetName)` 记录只保留一条；随后展开 ToolSet，最终工具集合按工具名处理重复和同名冲突。
 
+`WithToolActivationOnSkillLoad(...)` 不能与 `WithOutputSchema(...)` 同时配置。
+
 用户工具包括通过 `WithTools(...)`、`WithToolSets(...)`、运行时 `agent.WithAdditionalTools(...)` 和 `agent.WithExternalTools(...)` 加入的工具。框架工具由 `LLMAgent` 根据已启用能力自动注册，例如 `skill_load`、`workspace_exec` 和 `transfer_to_agent`。
 
 ### 激活模式

--- a/docs/mkdocs/zh/skill.md
+++ b/docs/mkdocs/zh/skill.md
@@ -1079,6 +1079,171 @@ events, err := r.Run(
 如果不希望暴露执行能力，请在创建 Agent 时关闭 workspace 执行
 surface，例如使用 `llmagent.WithWorkspaceExecSurfaceEnabled(false)`。
 
+## 基于 Skill 加载的工具激活
+
+`WithToolSets(...)` 注册的 ToolSet 会随 Agent 一起进入模型请求。工具激活提供另一种接入方式，先把 ToolSet 注册为候选集合，再由 `skill_load` 的结果决定是否进入后续模型请求。
+
+完整示例见 [examples/skilltoolactivation/README.md](https://github.com/trpc-group/trpc-agent-go/blob/main/examples/skilltoolactivation/README.md)。
+
+下面示例将 `example_file` 注册为候选 ToolSet，并声明加载 `example-skill` 后激活该 ToolSet。模型成功调用 `skill_load` 后，后续模型请求会包含 `example_file` 展开的工具。
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/skill"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+	"trpc.group/trpc-go/trpc-agent-go/tool/file"
+)
+
+repo, _ := skill.NewFSRepository("./skills")
+exampleFiles, _ := file.NewToolSet(
+	file.WithName("example_file"),
+	file.WithBaseDir("./files"),
+)
+
+agent := llmagent.New(
+	"skills-assistant",
+	llmagent.WithSkills(repo),
+	llmagent.WithActivatableToolSets([]tool.ToolSet{exampleFiles}),
+	llmagent.WithToolActivationOnSkillLoad(
+		"example-skill",
+		[]string{"example_file"},
+		llmagent.WithToolActivationMode(llmagent.ToolActivationModeInclude),
+		llmagent.WithToolActivationLifetime(llmagent.ToolActivationLifetimeInvocation),
+	),
+)
+```
+
+`WithActivatableToolSets(...)` 注册候选 ToolSet。候选 ToolSet 使用 `ToolSet.Name()` 作为引用名，并沿用普通 `ToolSet` 的工具命名规则。候选集合中的工具只会在激活规则命中后进入模型请求。
+
+`WithToolActivationOnSkillLoad(...)` 建立 skill 与候选 ToolSet 的激活关系。模型成功调用 `skill_load` 加载对应 skill 后，激活结果从下一次模型请求开始生效。一次 `Runner.Run` 内若继续进入工具循环，后续模型请求会使用更新后的工具集合。多条规则同时命中时，框架先合并激活记录，完全相同的 `(mode, lifetime, toolSetName)` 记录只保留一条；随后展开 ToolSet，最终工具集合按工具名处理重复和同名冲突。
+
+用户工具包括通过 `WithTools(...)`、`WithToolSets(...)`、运行时 `agent.WithAdditionalTools(...)` 和 `agent.WithExternalTools(...)` 加入的工具。框架工具由 `LLMAgent` 根据已启用能力自动注册，例如 `skill_load`、`workspace_exec` 和 `transfer_to_agent`。
+
+### 激活模式
+
+`WithToolActivationMode(...)` 设置激活工具与已有用户工具的合成方式。
+
+#### Include 模式
+
+`ToolActivationModeInclude` 为默认模式，在已有用户工具基础上追加激活工具。
+
+下面示例为同一个 skill 配置两条 Include 规则。
+
+```go
+searchTool := function.NewFunctionTool(search, function.WithName("search"))
+calculatorTool := function.NewFunctionTool(calculator, function.WithName("calculator"))
+exampleSearch, _ := file.NewToolSet(
+	file.WithName("example_search"),
+	file.WithBaseDir("./search"),
+)
+
+agent := llmagent.New(
+	"skills-assistant",
+	llmagent.WithSkills(repo),
+	llmagent.WithTools([]tool.Tool{searchTool, calculatorTool}),
+	llmagent.WithActivatableToolSets([]tool.ToolSet{
+		exampleFiles,
+		exampleSearch,
+	}),
+	llmagent.WithToolActivationOnSkillLoad(
+		"example-skill",
+		[]string{"example_file"},
+		llmagent.WithToolActivationMode(llmagent.ToolActivationModeInclude),
+	),
+	llmagent.WithToolActivationOnSkillLoad(
+		"example-skill",
+		[]string{"example_search"},
+		llmagent.WithToolActivationMode(llmagent.ToolActivationModeInclude),
+	),
+)
+```
+
+加载 `example-skill` 后，后续模型请求包含原有的 `search`、`calculator`，并包含 `example_file` 和 `example_search` 展开的工具。
+
+#### Only 模式
+
+`ToolActivationModeOnly` 使用户工具集合等于激活工具集合，框架工具继续保留。
+
+下面示例为同一个 skill 配置两条 Only 规则。
+
+```go
+searchTool := function.NewFunctionTool(search, function.WithName("search"))
+calculatorTool := function.NewFunctionTool(calculator, function.WithName("calculator"))
+exampleSearch, _ := file.NewToolSet(
+	file.WithName("example_search"),
+	file.WithBaseDir("./search"),
+)
+
+agent := llmagent.New(
+	"skills-assistant",
+	llmagent.WithSkills(repo),
+	llmagent.WithTools([]tool.Tool{searchTool, calculatorTool}),
+	llmagent.WithActivatableToolSets([]tool.ToolSet{
+		exampleFiles,
+		exampleSearch,
+	}),
+	llmagent.WithToolActivationOnSkillLoad(
+		"example-skill",
+		[]string{"example_file"},
+		llmagent.WithToolActivationMode(llmagent.ToolActivationModeOnly),
+	),
+	llmagent.WithToolActivationOnSkillLoad(
+		"example-skill",
+		[]string{"example_search"},
+		llmagent.WithToolActivationMode(llmagent.ToolActivationModeOnly),
+	),
+)
+```
+
+加载 `example-skill` 后，后续模型请求中的用户工具来自 `example_file` 和 `example_search` 展开的工具，`search` 和 `calculator` 会被裁剪。框架工具继续保留。
+
+#### Include 与 Only 同时命中
+
+一次模型请求同时存在 Include 与 Only 激活结果时，按 Only 模式合成本次用户工具集合，也就是只保留所有 Only 规则展开后的用户工具，框架工具继续保留。
+
+```go
+searchTool := function.NewFunctionTool(search, function.WithName("search"))
+calculatorTool := function.NewFunctionTool(calculator, function.WithName("calculator"))
+exampleSearch, _ := file.NewToolSet(
+	file.WithName("example_search"),
+	file.WithBaseDir("./search"),
+)
+
+agent := llmagent.New(
+	"skills-assistant",
+	llmagent.WithSkills(repo),
+	llmagent.WithTools([]tool.Tool{searchTool, calculatorTool}),
+	llmagent.WithActivatableToolSets([]tool.ToolSet{
+		exampleFiles,
+		exampleSearch,
+	}),
+	llmagent.WithToolActivationOnSkillLoad(
+		"example-skill",
+		[]string{"example_file"},
+		llmagent.WithToolActivationMode(llmagent.ToolActivationModeInclude),
+	),
+	llmagent.WithToolActivationOnSkillLoad(
+		"example-skill",
+		[]string{"example_search"},
+		llmagent.WithToolActivationMode(llmagent.ToolActivationModeOnly),
+	),
+)
+```
+
+加载 `example-skill` 后，后续模型请求中的用户工具来自 `example_search` 展开的工具。`search`、`calculator` 和 Include 规则中的 `example_file` 不进入本次用户工具集合。
+
+#### 同名工具处理
+
+激活工具与已有用户工具同名时，最终使用激活工具。在 Include 模式下，同名用户工具会被替换；在 Only 模式下，最终用户工具集合来自 Only 规则展开后的激活工具。激活工具与框架工具同名时，框架工具保持可见，并记录告警。
+
+### 激活生命周期
+
+`WithToolActivationLifetime(...)` 设置激活结果的生效周期。
+
+- `ToolActivationLifetimeInvocation` 为默认生命周期，激活结果仅在当前 agent 调用过程内生效。本次调用如果继续产生后续模型请求，这些请求会继续携带激活工具。下一次调用同一 agent 时，需要再次由 `skill_load` 触发。
+- `ToolActivationLifetimeSession` 使激活结果在同一 session 内持续生效。同一 session 后续调用该 agent 时，会继续携带这些激活工具。
+
 ## 故障排查
 
 - “unknown skill”：确认技能名与仓库路径；调用 `skill_load` 前

--- a/examples/skilltoolactivation/README.md
+++ b/examples/skilltoolactivation/README.md
@@ -23,7 +23,7 @@ From the `examples` module root:
 ```bash
 cd examples
 
-export OPENAI_BASE_URL="http://v2.open.venus.oa.com/llmproxy/"
+export OPENAI_BASE_URL="https://your-openai-compatible-endpoint/v1"
 export OPENAI_API_KEY="YOUR_API_KEY"
 
 go run ./skilltoolactivation

--- a/examples/skilltoolactivation/README.md
+++ b/examples/skilltoolactivation/README.md
@@ -1,0 +1,80 @@
+# Skill Tool Activation Example
+
+This example demonstrates activating a candidate `ToolSet` after a Skill is
+loaded with `skill_load`.
+
+It shows:
+
+- `WithActivatableToolSets(...)` registering a ToolSet that is not visible in
+  the first model request.
+- `WithToolActivationOnSkillLoad(...)` making that ToolSet visible after the
+  model loads `release-notes`.
+- `ToolActivationModeInclude` preserving existing user tools.
+- `ToolActivationModeOnly` trimming existing user tools and keeping only the
+  activated ToolSet tools, while framework tools remain visible.
+
+The example prints the model-visible tool names before each model request, so
+you can see the tool set change immediately after `skill_load`.
+
+## Run
+
+From the `examples` module root:
+
+```bash
+cd examples
+
+export OPENAI_BASE_URL="http://v2.open.venus.oa.com/llmproxy/"
+export OPENAI_API_KEY="YOUR_API_KEY"
+
+go run ./skilltoolactivation
+```
+
+Or from this example directory:
+
+```bash
+cd examples/skilltoolactivation
+go run .
+```
+
+The example defaults to `deepseek-v4-flash`. Use `-model` if your endpoint
+expects a different model name.
+
+## Include Mode
+
+```bash
+go run ./skilltoolactivation -mode include
+```
+
+Before `skill_load`, the model can see the base `calculator` user tool and
+framework skill tools. After `release-notes` is loaded, the model can also see
+tools expanded from the `release_docs` ToolSet, such as
+`release_docs_read_file`.
+
+## Only Mode
+
+```bash
+go run ./skilltoolactivation -mode only
+```
+
+Before `skill_load`, the model can see the base `calculator` user tool. After
+`release-notes` is loaded, the user tool set is replaced by the tools expanded
+from `release_docs`; framework tools such as `skill_load` remain visible.
+
+## Lifetime
+
+The default lifetime is `invocation`.
+
+```bash
+go run ./skilltoolactivation -lifetime invocation
+go run ./skilltoolactivation -lifetime session
+```
+
+Use `session` when the activation should remain effective for later runs in
+the same session.
+
+## Files
+
+- `skills/release-notes/SKILL.md` tells the model when and how to use the
+  release-notes skill.
+- `release_docs/release_notes.md` is exposed only through the activatable
+  `release_docs` ToolSet.

--- a/examples/skilltoolactivation/agent.go
+++ b/examples/skilltoolactivation/agent.go
@@ -1,0 +1,99 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/model/openai"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+	"trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+	"trpc.group/trpc-go/trpc-agent-go/skill"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+const instructionText = `
+You demonstrate skill-based tool activation.
+
+For every user request:
+1. First call skill_load for "release-notes".
+2. After the skill is loaded, use release_docs_read_file to read release_notes.md.
+3. Answer only from the file content.
+4. Do not call release_docs_read_file before skill_load.
+`
+
+func run(
+	ctx context.Context,
+	mode llmagent.ToolActivationMode,
+	lifetime llmagent.ToolActivationLifetime,
+) error {
+	repo, err := skill.NewFSRepository(*flagSkillsRoot)
+	if err != nil {
+		return fmt.Errorf("load skills repo: %w", err)
+	}
+	releaseDocs, err := releaseDocsToolSet(*flagDocsRoot)
+	if err != nil {
+		return err
+	}
+	modelInstance := openai.New(
+		*flagModel,
+		openai.WithVariant(openai.VariantOpenAI),
+	)
+	genConfig := model.GenerationConfig{
+		Temperature: floatPtr(0.2),
+		Stream:      *flagStreaming,
+	}
+	agt := llmagent.New(
+		agentName,
+		llmagent.WithModel(modelInstance),
+		llmagent.WithDescription("Demonstrates activating a ToolSet after skill_load."),
+		llmagent.WithInstruction(instructionText),
+		llmagent.WithGenerationConfig(genConfig),
+		llmagent.WithSkills(repo),
+		llmagent.WithTools([]tool.Tool{calculatorTool()}),
+		llmagent.WithActivatableToolSets([]tool.ToolSet{releaseDocs}),
+		llmagent.WithToolActivationOnSkillLoad(
+			skillName,
+			[]string{toolSetName},
+			llmagent.WithToolActivationMode(mode),
+			llmagent.WithToolActivationLifetime(lifetime),
+		),
+		llmagent.WithModelCallbacks(traceToolCallbacks(*flagTraceTools)),
+	)
+	r := runner.NewRunner(
+		appName,
+		agt,
+		runner.WithSessionService(inmemory.NewSessionService()),
+	)
+	defer r.Close()
+	sessionID := fmt.Sprintf("tool-activation-%d", time.Now().Unix())
+	printRunHeader(mode, lifetime, sessionID)
+	events, err := r.Run(
+		ctx,
+		userID,
+		sessionID,
+		model.NewUserMessage(*flagPrompt),
+	)
+	if err != nil {
+		return fmt.Errorf("run agent: %w", err)
+	}
+	for evt := range events {
+		printEvent(evt)
+	}
+	return nil
+}
+
+func floatPtr(v float64) *float64 {
+	return &v
+}

--- a/examples/skilltoolactivation/main.go
+++ b/examples/skilltoolactivation/main.go
@@ -1,0 +1,101 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package main demonstrates Skill-triggered tool activation.
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+)
+
+const (
+	appName          = "skill-tool-activation-example"
+	agentName        = "skill-tool-activation-agent"
+	userID           = "skill-tool-activation-user"
+	skillName        = "release-notes"
+	toolSetName      = "release_docs"
+	defaultModelName = "deepseek-v4-flash"
+)
+
+var (
+	flagModel = flag.String(
+		"model",
+		defaultModelName,
+		"OpenAI-compatible model name",
+	)
+	flagMode = flag.String(
+		"mode",
+		string(llmagent.ToolActivationModeInclude),
+		"tool activation mode: include|only",
+	)
+	flagLifetime = flag.String(
+		"lifetime",
+		string(llmagent.ToolActivationLifetimeInvocation),
+		"tool activation lifetime: invocation|session",
+	)
+	flagSkillsRoot = flag.String(
+		"skills-root",
+		defaultExamplePath("skills"),
+		"skills root directory",
+	)
+	flagDocsRoot = flag.String(
+		"docs-root",
+		defaultExamplePath("release_docs"),
+		"directory exposed by the activatable release_docs ToolSet",
+	)
+	flagStreaming = flag.Bool(
+		"streaming",
+		false,
+		"stream model responses",
+	)
+	flagTraceTools = flag.Bool(
+		"trace-tools",
+		true,
+		"print model-visible tool names before each model request",
+	)
+	flagPrompt = flag.String(
+		"prompt",
+		"Use the release-notes skill to summarize the release date, owners, and rollout checklist.",
+		"user prompt sent to the agent",
+	)
+)
+
+func main() {
+	flag.Parse()
+	if strings.TrimSpace(os.Getenv("OPENAI_API_KEY")) == "" {
+		log.Fatal("OPENAI_API_KEY is required")
+	}
+	mode, err := parseActivationMode(*flagMode)
+	if err != nil {
+		log.Fatal(err)
+	}
+	lifetime, err := parseActivationLifetime(*flagLifetime)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := run(context.Background(), mode, lifetime); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func defaultExamplePath(name string) string {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		return name
+	}
+	return filepath.Join(filepath.Dir(filename), name)
+}

--- a/examples/skilltoolactivation/print.go
+++ b/examples/skilltoolactivation/print.go
@@ -1,0 +1,112 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+func printRunHeader(
+	mode llmagent.ToolActivationMode,
+	lifetime llmagent.ToolActivationLifetime,
+	sessionID string,
+) {
+	fmt.Println("Skill Tool Activation")
+	fmt.Printf("Model: %s\n", *flagModel)
+	fmt.Printf("Mode: %s\n", mode)
+	fmt.Printf("Lifetime: %s\n", lifetime)
+	fmt.Printf("Skills root: %s\n", *flagSkillsRoot)
+	fmt.Printf("Docs root: %s\n", *flagDocsRoot)
+	fmt.Printf("Session: %s\n", sessionID)
+	fmt.Println()
+	fmt.Printf("User: %s\n\n", *flagPrompt)
+}
+
+func traceToolCallbacks(enabled bool) *model.Callbacks {
+	if !enabled {
+		return nil
+	}
+	var call int
+	return model.NewCallbacks().RegisterBeforeModel(func(
+		_ context.Context,
+		args *model.BeforeModelArgs,
+	) (*model.BeforeModelResult, error) {
+		call++
+		fmt.Printf("[before model #%d] visible tools:\n", call)
+		for _, name := range requestToolNames(args.Request) {
+			fmt.Printf("  - %s\n", name)
+		}
+		fmt.Println()
+		return nil, nil
+	})
+}
+
+func requestToolNames(req *model.Request) []string {
+	if req == nil || len(req.Tools) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(req.Tools))
+	for name := range req.Tools {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func printEvent(evt *event.Event) {
+	if evt == nil {
+		return
+	}
+	if evt.Error != nil {
+		fmt.Printf("error: %s\n", evt.Error.Message)
+		return
+	}
+	if evt.Response == nil || len(evt.Response.Choices) == 0 {
+		return
+	}
+	ch := evt.Response.Choices[0]
+	if len(ch.Message.ToolCalls) > 0 {
+		fmt.Println("tool calls:")
+		for _, tc := range ch.Message.ToolCalls {
+			fmt.Printf("  - %s args=%s\n",
+				tc.Function.Name,
+				string(tc.Function.Arguments),
+			)
+		}
+		return
+	}
+	if ch.Message.Role == model.RoleTool && ch.Message.Content != "" {
+		fmt.Printf("tool result: %s\n", compactText(ch.Message.Content))
+		return
+	}
+	if delta := strings.TrimSpace(ch.Delta.Content); delta != "" {
+		fmt.Print(delta)
+		return
+	}
+	if content := strings.TrimSpace(ch.Message.Content); content != "" {
+		fmt.Printf("assistant: %s\n", content)
+	}
+}
+
+func compactText(s string) string {
+	s = strings.TrimSpace(strings.ReplaceAll(s, "\n", " "))
+	const max = 220
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "..."
+}

--- a/examples/skilltoolactivation/release_docs/release_notes.md
+++ b/examples/skilltoolactivation/release_docs/release_notes.md
@@ -1,0 +1,22 @@
+# Orion Release Notes
+
+Release: Orion Search Refresh
+
+Date: 2026-06-18
+
+Owners:
+
+- Product: Mina Chen
+- Engineering: Rafael Ortiz
+- QA: Priya Shah
+
+Rollout checklist:
+
+- Confirm search relevance dashboards are green.
+- Validate canary traffic for the first two hours.
+- Keep rollback scripts ready until the next business day.
+
+Customer-facing summary:
+
+The release improves search ranking freshness and adds better handling for
+ambiguous product names.

--- a/examples/skilltoolactivation/skills/release-notes/SKILL.md
+++ b/examples/skilltoolactivation/skills/release-notes/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: release-notes
+description: Use this skill when the user asks about release dates, release owners, rollout status, or launch checklist details.
+---
+
+# Release Notes Lookup
+
+Use this skill to answer questions about the demo release notes.
+
+After loading this skill:
+
+1. Use `release_docs_read_file` to read `release_notes.md`.
+2. Answer from the file content only.
+3. If the requested detail is not in the file, say that the release notes do not contain it.

--- a/examples/skilltoolactivation/tool.go
+++ b/examples/skilltoolactivation/tool.go
@@ -1,0 +1,94 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+	"trpc.group/trpc-go/trpc-agent-go/tool/file"
+	"trpc.group/trpc-go/trpc-agent-go/tool/function"
+)
+
+func releaseDocsToolSet(root string) (tool.ToolSet, error) {
+	releaseDocs, err := file.NewToolSet(
+		file.WithName(toolSetName),
+		file.WithBaseDir(root),
+		file.WithSaveFileEnabled(false),
+		file.WithReplaceContentEnabled(false),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create release docs tool set: %w", err)
+	}
+	return releaseDocs, nil
+}
+
+func parseActivationMode(raw string) (llmagent.ToolActivationMode, error) {
+	switch llmagent.ToolActivationMode(strings.ToLower(strings.TrimSpace(raw))) {
+	case llmagent.ToolActivationModeInclude:
+		return llmagent.ToolActivationModeInclude, nil
+	case llmagent.ToolActivationModeOnly:
+		return llmagent.ToolActivationModeOnly, nil
+	default:
+		return "", fmt.Errorf("invalid -mode %q: want include|only", raw)
+	}
+}
+
+func parseActivationLifetime(raw string) (llmagent.ToolActivationLifetime, error) {
+	switch llmagent.ToolActivationLifetime(strings.ToLower(strings.TrimSpace(raw))) {
+	case llmagent.ToolActivationLifetimeInvocation:
+		return llmagent.ToolActivationLifetimeInvocation, nil
+	case llmagent.ToolActivationLifetimeSession:
+		return llmagent.ToolActivationLifetimeSession, nil
+	default:
+		return "", fmt.Errorf(
+			"invalid -lifetime %q: want invocation|session",
+			raw,
+		)
+	}
+}
+
+func calculatorTool() tool.Tool {
+	type calculatorInput struct {
+		Operation string  `json:"operation" description:"Operation to perform: add, subtract, multiply, or divide."`
+		A         float64 `json:"a" description:"First operand."`
+		B         float64 `json:"b" description:"Second operand."`
+	}
+	type calculatorOutput struct {
+		Result float64 `json:"result"`
+	}
+	return function.NewFunctionTool(
+		func(_ context.Context, in calculatorInput) (calculatorOutput, error) {
+			switch strings.ToLower(strings.TrimSpace(in.Operation)) {
+			case "add", "+":
+				return calculatorOutput{Result: in.A + in.B}, nil
+			case "subtract", "-":
+				return calculatorOutput{Result: in.A - in.B}, nil
+			case "multiply", "*":
+				return calculatorOutput{Result: in.A * in.B}, nil
+			case "divide", "/":
+				if in.B == 0 {
+					return calculatorOutput{}, fmt.Errorf("division by zero")
+				}
+				return calculatorOutput{Result: in.A / in.B}, nil
+			default:
+				return calculatorOutput{}, fmt.Errorf(
+					"unsupported operation %q",
+					in.Operation,
+				)
+			}
+		},
+		function.WithName("calculator"),
+		function.WithDescription("Perform basic arithmetic."),
+	)
+}

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -26,6 +26,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/internal/flow"
 	"trpc.group/trpc-go/trpc-agent-go/internal/flow/processor"
+	"trpc.group/trpc-go/trpc-agent-go/internal/flow/toolsnapshot"
 	"trpc.group/trpc-go/trpc-agent-go/internal/jsonmap"
 	"trpc.group/trpc-go/trpc-agent-go/internal/jsonrepair"
 	"trpc.group/trpc-go/trpc-agent-go/internal/modelcontext"
@@ -54,16 +55,6 @@ const (
 
 	flowRunPanicErrFmt = "flow panic: %v"
 
-	// stateKeyToolsSnapshot is the invocation state key used to cache the
-	// final tool list for a single Invocation. This ensures that the tool
-	// set (including ToolSet-based tools and filters) stays stable for the
-	// entire lifetime of an Invocation, even when underlying ToolSets are
-	// dynamic.
-	stateKeyToolsSnapshot = "llmflow:tools_snapshot"
-	// stateKeyHasFilteredUserTools caches whether the final filtered tool
-	// snapshot for this invocation still contains any user tool.
-	stateKeyHasFilteredUserTools = "llmflow:has_filtered_user_tools"
-
 	defaultContextCompactionThresholdRatio = 0.7
 	contextCompactionFallbackWindow        = 8192
 	contextCompactionMinTokens             = 2000
@@ -72,10 +63,7 @@ const (
 // InvocationHasFilteredUserTools reports whether the cached filtered tool
 // snapshot for this invocation still contains any user tool.
 func InvocationHasFilteredUserTools(invocation *agent.Invocation) (bool, bool) {
-	if invocation == nil {
-		return false, false
-	}
-	return agent.GetStateValue[bool](invocation, stateKeyHasFilteredUserTools)
+	return toolsnapshot.HasFilteredUserTools(invocation)
 }
 
 // Options contains configuration options for creating a Flow.
@@ -87,7 +75,17 @@ type Options struct {
 	SyncSummaryIntraRun             bool
 	EnableContextCompaction         bool
 	ContextCompactionThresholdRatio float64
+	ToolActivationApplier           ToolActivationApplier
 }
+
+// ToolActivationApplier applies invocation-specific tool activation.
+type ToolActivationApplier func(
+	ctx context.Context,
+	invocation *agent.Invocation,
+	tools []tool.Tool,
+	userToolNames map[string]bool,
+	externalToolNames map[string]bool,
+) ([]tool.Tool, map[string]bool, map[string]bool)
 
 // ModelBaseResolution describes the base model for one LLM call.
 type ModelBaseResolution struct {
@@ -109,6 +107,7 @@ type Flow struct {
 	syncSummaryIntraRun             bool
 	enableContextCompaction         bool
 	contextCompactionThresholdRatio float64
+	toolActivationApplier           ToolActivationApplier
 }
 
 type contextCompactionTailProcessor interface {
@@ -152,6 +151,7 @@ func New(
 		modelSelector:           opts.ModelSelector,
 		syncSummaryIntraRun:     opts.SyncSummaryIntraRun,
 		enableContextCompaction: opts.EnableContextCompaction,
+		toolActivationApplier:   opts.ToolActivationApplier,
 		contextCompactionThresholdRatio: normalizeContextCompactionThresholdRatio(
 			opts.ContextCompactionThresholdRatio,
 		),
@@ -1466,10 +1466,7 @@ func (f *Flow) getFilteredTools(ctx context.Context, invocation *agent.Invocatio
 		return nil
 	}
 
-	if cached, ok := agent.GetStateValue[[]tool.Tool](
-		invocation,
-		stateKeyToolsSnapshot,
-	); ok && cached != nil {
+	if cached, ok := toolsnapshot.Get(invocation); ok && cached != nil {
 		return cached
 	}
 
@@ -1508,13 +1505,24 @@ func (f *Flow) getFilteredTools(ctx context.Context, invocation *agent.Invocatio
 			hasUserToolTracking,
 			invocation.RunOptions,
 		)
+	if f.toolActivationApplier != nil {
+		allTools, userToolNames, externalToolNames =
+			f.toolActivationApplier(
+				ctx,
+				invocation,
+				allTools,
+				userToolNames,
+				externalToolNames,
+			)
+		hasUserToolTracking = userToolNames != nil
+	}
 
 	// If no filter is specified, return all tools for this invocation.
 	if invocation.RunOptions.ToolFilter == nil {
 		setVisibleExternalToolNames(invocation, allTools, externalToolNames)
-		invocation.SetState(stateKeyToolsSnapshot, allTools)
-		invocation.SetState(
-			stateKeyHasFilteredUserTools,
+		toolsnapshot.Set(
+			invocation,
+			allTools,
 			hasTrackedUserTool(allTools, hasUserToolTracking, userToolNames),
 		)
 		return allTools
@@ -1549,9 +1557,9 @@ func (f *Flow) getFilteredTools(ctx context.Context, invocation *agent.Invocatio
 	})
 
 	setVisibleExternalToolNames(invocation, filtered, externalToolNames)
-	invocation.SetState(stateKeyToolsSnapshot, filtered)
-	invocation.SetState(
-		stateKeyHasFilteredUserTools,
+	toolsnapshot.Set(
+		invocation,
+		filtered,
 		hasTrackedUserTool(filtered, hasUserToolTracking, userToolNames),
 	)
 

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -1506,6 +1506,13 @@ func (f *Flow) getFilteredTools(ctx context.Context, invocation *agent.Invocatio
 			invocation.RunOptions,
 		)
 	if f.toolActivationApplier != nil {
+		allTools = append([]tool.Tool(nil), allTools...)
+		if userToolNames != nil {
+			userToolNames = copyToolNames(userToolNames)
+		}
+		if externalToolNames != nil {
+			externalToolNames = copyToolNames(externalToolNames)
+		}
 		allTools, userToolNames, externalToolNames =
 			f.toolActivationApplier(
 				ctx,

--- a/internal/flow/llmflow/tool_filter_test.go
+++ b/internal/flow/llmflow/tool_filter_test.go
@@ -688,6 +688,54 @@ func TestGetFilteredTools_RunOptionToolsDoNotMutateToolSlice(
 	require.Nil(t, expandedBacking[2])
 }
 
+func TestGetFilteredTools_ToolActivationApplierReceivesCopies(
+	t *testing.T,
+) {
+	const (
+		registeredToolName = "registered_tool"
+		externalToolName   = "external_tool"
+		activatedToolName  = "activated_tool"
+	)
+	registeredTool := &mockTool{name: registeredToolName}
+	externalTool := &mockTool{name: externalToolName}
+	activatedTool := &mockTool{name: activatedToolName}
+	backing := make([]tool.Tool, 1, 2)
+	backing[0] = registeredTool
+	userToolNames := map[string]bool{registeredToolName: true}
+	f := New(nil, nil, Options{
+		ToolActivationApplier: func(
+			_ context.Context,
+			_ *agent.Invocation,
+			tools []tool.Tool,
+			userNames map[string]bool,
+			externalNames map[string]bool,
+		) ([]tool.Tool, map[string]bool, map[string]bool) {
+			tools = append(tools, activatedTool)
+			userNames[activatedToolName] = true
+			externalNames["unused_external"] = true
+			return tools, userNames, externalNames
+		},
+	})
+	mockAgent := &mockAgentWithInvocationToolSurface{
+		name:          "test-agent",
+		allTools:      backing[:1],
+		userToolNames: userToolNames,
+	}
+	inv := agent.NewInvocation()
+	inv.Agent = mockAgent
+	inv.AgentName = "test-agent"
+	inv.RunOptions = agent.NewRunOptions(
+		agent.WithExternalTools([]tool.Tool{externalTool}),
+	)
+	filtered := f.getFilteredTools(context.Background(), inv)
+	require.True(t, hasToolName(filtered, registeredToolName))
+	require.True(t, hasToolName(filtered, externalToolName))
+	require.True(t, hasToolName(filtered, activatedToolName))
+	require.Equal(t, map[string]bool{registeredToolName: true}, userToolNames)
+	require.Nil(t, backing[:cap(backing)][1])
+	require.Equal(t, map[string]bool{externalToolName: true}, inv.RunOptions.ExternalToolNames)
+}
+
 // TestGetFilteredTools_WithExcludeFilter tests tool filtering using exclude filter.
 func TestGetFilteredTools_WithExcludeFilter(t *testing.T) {
 	f := New(nil, nil, Options{})

--- a/internal/flow/processor/functioncall.go
+++ b/internal/flow/processor/functioncall.go
@@ -115,10 +115,18 @@ type FunctionCallResponseProcessor struct {
 	enableParallelTools bool
 	toolCallbacks       *tool.Callbacks
 	toolRetryPolicy     *tool.RetryPolicy
+	postToolResultHooks []PostToolResultHook
 }
 
 // FunctionCallResponseProcessorOption configures a function-call response processor.
 type FunctionCallResponseProcessorOption func(*FunctionCallResponseProcessor)
+
+// PostToolResultHook observes and may mutate a completed tool result event.
+type PostToolResultHook func(
+	ctx context.Context,
+	invocation *agent.Invocation,
+	ev *event.Event,
+)
 
 // WithToolCallRetryPolicy sets the retry policy used for single callable tool invocations.
 func WithToolCallRetryPolicy(policy *tool.RetryPolicy) FunctionCallResponseProcessorOption {
@@ -128,6 +136,18 @@ func WithToolCallRetryPolicy(policy *tool.RetryPolicy) FunctionCallResponseProce
 			return
 		}
 		p.toolRetryPolicy = policy
+	}
+}
+
+// WithPostToolResultHook appends an internal hook after tool state delta is attached.
+func WithPostToolResultHook(
+	hook PostToolResultHook,
+) FunctionCallResponseProcessorOption {
+	return func(p *FunctionCallResponseProcessor) {
+		if hook == nil {
+			return
+		}
+		p.postToolResultHooks = append(p.postToolResultHooks, hook)
 	}
 }
 
@@ -354,6 +374,7 @@ func (p *FunctionCallResponseProcessor) handleFunctionCalls(
 		toolResults = append(toolResults, result)
 	}
 	toolCallResponsesEvents := p.attachStateDeltaToToolResults(
+		ctx,
 		invocation,
 		toolResults,
 	)
@@ -397,6 +418,7 @@ func (p *FunctionCallResponseProcessor) executeSingleToolCallSequential(
 		return nil, err
 	}
 	toolEvents := p.attachStateDeltaToToolResults(
+		ctx,
 		invocation,
 		[]toolResult{result},
 	)
@@ -541,6 +563,7 @@ func (p *FunctionCallResponseProcessor) executeToolCallsInParallel(
 		ctx, resultChan, len(toolCalls),
 	)
 	toolCallResponsesEvents := p.attachStateDeltaToToolResults(
+		ctx,
 		invocation,
 		toolResults,
 	)
@@ -1107,6 +1130,7 @@ func shouldSkipToolSkipSummarization(ctx context.Context) bool {
 }
 
 func (p *FunctionCallResponseProcessor) attachStateDeltaToToolResults(
+	ctx context.Context,
 	invocation *agent.Invocation,
 	results []toolResult,
 ) []*event.Event {
@@ -1137,6 +1161,7 @@ func (p *FunctionCallResponseProcessor) attachStateDeltaToToolResults(
 				result.event,
 			)
 		}
+		p.runPostToolResultHooks(ctx, invocation, result.event)
 		if len(result.event.StateDelta) > 0 {
 			priorStateDelta = append(
 				priorStateDelta,
@@ -1146,6 +1171,16 @@ func (p *FunctionCallResponseProcessor) attachStateDeltaToToolResults(
 		events = append(events, result.event)
 	}
 	return events
+}
+
+func (p *FunctionCallResponseProcessor) runPostToolResultHooks(
+	ctx context.Context,
+	invocation *agent.Invocation,
+	ev *event.Event,
+) {
+	for _, hook := range p.postToolResultHooks {
+		hook(ctx, invocation, ev)
+	}
 }
 
 func applyPriorStateDeltas(

--- a/internal/flow/processor/functioncall_test.go
+++ b/internal/flow/processor/functioncall_test.go
@@ -1598,7 +1598,7 @@ func TestAttachStateDeltaToToolResults_ReplaysPendingStateDeltas(
 		},
 	}
 
-	events := p.attachStateDeltaToToolResults(inv, results)
+	events := p.attachStateDeltaToToolResults(context.Background(), inv, results)
 	require.Len(t, events, 2)
 	require.Equal(t, []byte("v1"), events[1].StateDelta[writeKey])
 }

--- a/internal/flow/processor/functioncall_test.go
+++ b/internal/flow/processor/functioncall_test.go
@@ -1603,6 +1603,37 @@ func TestAttachStateDeltaToToolResults_ReplaysPendingStateDeltas(
 	require.Equal(t, []byte("v1"), events[1].StateDelta[writeKey])
 }
 
+func TestPostToolResultHookRunsAfterToolResult(t *testing.T) {
+	const hookKey = "hook"
+	ctx := context.Background()
+	inv := &agent.Invocation{AgentName: "tester"}
+	called := 0
+	p := NewFunctionCallResponseProcessor(
+		false,
+		nil,
+		WithPostToolResultHook(nil),
+		WithPostToolResultHook(func(
+			gotCtx context.Context,
+			gotInv *agent.Invocation,
+			ev *event.Event,
+		) {
+			require.Equal(t, ctx, gotCtx)
+			require.Equal(t, inv, gotInv)
+			called++
+			if ev.StateDelta == nil {
+				ev.StateDelta = map[string][]byte{}
+			}
+			ev.StateDelta[hookKey] = []byte("ran")
+		}),
+	)
+	events := p.attachStateDeltaToToolResults(ctx, inv, []toolResult{
+		{event: &event.Event{}},
+	})
+	require.Len(t, events, 1)
+	require.Equal(t, 1, called)
+	require.Equal(t, []byte("ran"), events[0].StateDelta[hookKey])
+}
+
 func marshalSkillLoadArgs(
 	t *testing.T,
 	skillName string,

--- a/internal/flow/toolsnapshot/toolsnapshot.go
+++ b/internal/flow/toolsnapshot/toolsnapshot.go
@@ -1,0 +1,52 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+// Package toolsnapshot owns the invocation-scoped LLM tool snapshot keys.
+package toolsnapshot
+
+import (
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+const (
+	// ToolsSnapshotKey is the invocation state key used to cache the final tool list.
+	ToolsSnapshotKey = "llmflow:tools_snapshot"
+	// HasFilteredUserToolsKey caches whether the filtered snapshot has user tools.
+	HasFilteredUserToolsKey = "llmflow:has_filtered_user_tools"
+)
+
+// Get returns the cached tool snapshot for this invocation.
+func Get(inv *agent.Invocation) ([]tool.Tool, bool) {
+	return agent.GetStateValue[[]tool.Tool](inv, ToolsSnapshotKey)
+}
+
+// Set stores the cached tool snapshot for this invocation.
+func Set(inv *agent.Invocation, tools []tool.Tool, hasFilteredUserTools bool) {
+	if inv == nil {
+		return
+	}
+	inv.SetState(ToolsSnapshotKey, tools)
+	inv.SetState(HasFilteredUserToolsKey, hasFilteredUserTools)
+}
+
+// HasFilteredUserTools reports whether the cached snapshot has user tools.
+func HasFilteredUserTools(inv *agent.Invocation) (bool, bool) {
+	return agent.GetStateValue[bool](inv, HasFilteredUserToolsKey)
+}
+
+// Invalidate clears the cached tool snapshot for this invocation.
+func Invalidate(inv *agent.Invocation) {
+	if inv == nil {
+		return
+	}
+	inv.DeleteState(ToolsSnapshotKey)
+	inv.DeleteState(HasFilteredUserToolsKey)
+}

--- a/internal/flow/toolsnapshot/toolsnapshot.go
+++ b/internal/flow/toolsnapshot/toolsnapshot.go
@@ -25,7 +25,11 @@ const (
 
 // Get returns the cached tool snapshot for this invocation.
 func Get(inv *agent.Invocation) ([]tool.Tool, bool) {
-	return agent.GetStateValue[[]tool.Tool](inv, ToolsSnapshotKey)
+	tools, ok := agent.GetStateValue[[]tool.Tool](inv, ToolsSnapshotKey)
+	if !ok {
+		return nil, false
+	}
+	return copyTools(tools), true
 }
 
 // Set stores the cached tool snapshot for this invocation.
@@ -33,7 +37,7 @@ func Set(inv *agent.Invocation, tools []tool.Tool, hasFilteredUserTools bool) {
 	if inv == nil {
 		return
 	}
-	inv.SetState(ToolsSnapshotKey, tools)
+	inv.SetState(ToolsSnapshotKey, copyTools(tools))
 	inv.SetState(HasFilteredUserToolsKey, hasFilteredUserTools)
 }
 
@@ -49,4 +53,8 @@ func Invalidate(inv *agent.Invocation) {
 	}
 	inv.DeleteState(ToolsSnapshotKey)
 	inv.DeleteState(HasFilteredUserToolsKey)
+}
+
+func copyTools(tools []tool.Tool) []tool.Tool {
+	return append([]tool.Tool(nil), tools...)
 }

--- a/internal/flow/toolsnapshot/toolsnapshot_test.go
+++ b/internal/flow/toolsnapshot/toolsnapshot_test.go
@@ -33,6 +33,9 @@ func TestSetGetCopiesToolSlice(t *testing.T) {
 	second := testTool{name: "second"}
 	tools := []tool.Tool{first}
 	Set(inv, tools, true)
+	hasFiltered, ok := HasFilteredUserTools(inv)
+	require.True(t, ok)
+	require.True(t, hasFiltered)
 	tools[0] = second
 	cached, ok := Get(inv)
 	require.True(t, ok)
@@ -41,4 +44,20 @@ func TestSetGetCopiesToolSlice(t *testing.T) {
 	cachedAgain, ok := Get(inv)
 	require.True(t, ok)
 	require.Equal(t, "first", cachedAgain[0].Declaration().Name)
+}
+
+func TestSnapshotMissingAndInvalidate(t *testing.T) {
+	_, ok := Get(nil)
+	require.False(t, ok)
+	Set(nil, []tool.Tool{testTool{name: "ignored"}}, true)
+	Invalidate(nil)
+	inv := &agent.Invocation{}
+	_, ok = Get(inv)
+	require.False(t, ok)
+	Set(inv, []tool.Tool{testTool{name: "first"}}, true)
+	Invalidate(inv)
+	_, ok = Get(inv)
+	require.False(t, ok)
+	_, ok = HasFilteredUserTools(inv)
+	require.False(t, ok)
 }

--- a/internal/flow/toolsnapshot/toolsnapshot_test.go
+++ b/internal/flow/toolsnapshot/toolsnapshot_test.go
@@ -1,0 +1,44 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package toolsnapshot
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+type testTool struct {
+	name string
+}
+
+func (t testTool) Declaration() *tool.Declaration {
+	return &tool.Declaration{Name: t.name}
+}
+
+func TestSetGetCopiesToolSlice(t *testing.T) {
+	inv := &agent.Invocation{}
+	first := testTool{name: "first"}
+	second := testTool{name: "second"}
+	tools := []tool.Tool{first}
+	Set(inv, tools, true)
+	tools[0] = second
+	cached, ok := Get(inv)
+	require.True(t, ok)
+	require.Equal(t, "first", cached[0].Declaration().Name)
+	cached[0] = second
+	cachedAgain, ok := Get(inv)
+	require.True(t, ok)
+	require.Equal(t, "first", cachedAgain[0].Declaration().Name)
+}


### PR DESCRIPTION
Adds skill-triggered tool activation for candidate ToolSets, wires activation into LLM flow tool snapshots and run-option tool handling, documents Include and Only modes with activation lifetimes, and adds a runnable skilltoolactivation example.