### PR TITLE
openclaw: expose gateway run options

### DIFF
--- a/openclaw/EXTENDING.md
+++ b/openclaw/EXTENDING.md
@@ -624,6 +624,75 @@ If the application already owns the HTTP server, use
 `app.NewRuntimeWithOptions` and mount `rt.Gateway.Handler` instead of
 `app.MainWithOptions`.
 
+## Gateway run options (request-scoped controls)
+
+Use `app.WithGatewayRunOptions` for static `agent.RunOption` values that
+should apply to every HTTP gateway run from a custom binary.
+
+Use `app.WithGatewayRunOptionResolver` when the options depend on the inbound
+request. The resolver receives normalized gateway metadata, the user message,
+and request extensions. It can return a new context plus additional
+`agent.RunOption` values before OpenClaw calls `runner.Run`.
+
+This is useful for request-scoped controls such as:
+
+- caller-executed frontend tools via `agent.WithExternalTools`
+- temporary runtime state via `agent.MergeRuntimeState`
+- per-request instruction or model controls
+
+For frontend tools, keep the OpenClaw server as the orchestration layer and let
+the frontend execute only the tool calls it declared. Convert the frontend's
+tool declarations into `tool.Tool` values and pass them as external tools:
+
+```go
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/app"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+func main() {
+	os.Exit(app.MainWithOptions(
+		os.Args[1:],
+		app.WithGatewayRunOptionResolver(func(
+			ctx context.Context,
+			input app.GatewayRunOptionInput,
+		) (context.Context, []agent.RunOption, error) {
+			frontendTools, err := frontendToolsFromExtensions(
+				input.Extensions,
+			)
+			if err != nil {
+				return ctx, nil, err
+			}
+			if len(frontendTools) == 0 {
+				return ctx, nil, nil
+			}
+			return ctx, []agent.RunOption{
+				agent.WithExternalTools(frontendTools),
+			}, nil
+		}),
+	))
+}
+
+func frontendToolsFromExtensions(
+	extensions map[string]json.RawMessage,
+) ([]tool.Tool, error) {
+	// Parse your channel or frontend-specific extension schema here.
+	return nil, nil
+}
+```
+
+`agent.WithExternalTools` makes those tools visible to the model but leaves
+execution to the caller. When the model calls one, the run stops after the
+assistant tool-call response; the caller can execute the tool and continue by
+sending a tool result message.
+
 ## Memory backend plugin (centralized user memory storage)
 
 Memory backends implement `memory.Service` (from `trpc-agent-go`).

--- a/openclaw/EXTENDING.md
+++ b/openclaw/EXTENDING.md
@@ -636,13 +636,13 @@ and request extensions. It can return a new context plus additional
 
 This is useful for request-scoped controls such as:
 
-- caller-executed frontend tools via `agent.WithExternalTools`
+- request-scoped server tools via `agent.WithAdditionalTools`
 - temporary runtime state via `agent.MergeRuntimeState`
 - per-request instruction or model controls
 
-For frontend tools, keep the OpenClaw server as the orchestration layer and let
-the frontend execute only the tool calls it declared. Convert the frontend's
-tool declarations into `tool.Tool` values and pass them as external tools:
+For request-scoped tools, keep the OpenClaw server as the execution boundary.
+Convert channel-specific extension data into server-side `tool.Tool` values and
+pass them as additional tools:
 
 ```go
 package main
@@ -664,23 +664,23 @@ func main() {
 			ctx context.Context,
 			input app.GatewayRunOptionInput,
 		) (context.Context, []agent.RunOption, error) {
-			frontendTools, err := frontendToolsFromExtensions(
+			requestTools, err := requestToolsFromExtensions(
 				input.Extensions,
 			)
 			if err != nil {
 				return ctx, nil, err
 			}
-			if len(frontendTools) == 0 {
+			if len(requestTools) == 0 {
 				return ctx, nil, nil
 			}
 			return ctx, []agent.RunOption{
-				agent.WithExternalTools(frontendTools),
+				agent.WithAdditionalTools(requestTools),
 			}, nil
 		}),
 	))
 }
 
-func frontendToolsFromExtensions(
+func requestToolsFromExtensions(
 	extensions map[string]json.RawMessage,
 ) ([]tool.Tool, error) {
 	// Parse your channel or frontend-specific extension schema here.
@@ -688,10 +688,11 @@ func frontendToolsFromExtensions(
 }
 ```
 
-`agent.WithExternalTools` makes those tools visible to the model but leaves
-execution to the caller. When the model calls one, the run stops after the
-assistant tool-call response; the caller can execute the tool and continue by
-sending a tool result message.
+Do not use `agent.WithExternalTools` as a frontend tool-calling protocol with
+the stock OpenClaw gateway. External tools require the caller to receive full
+assistant tool-call data, execute it, and continue with a tool-result message;
+the gateway protocol currently exposes user-facing replies and progress events
+instead of that continuation surface.
 
 ## Memory backend plugin (centralized user memory storage)
 

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -1454,6 +1454,9 @@ OpenClaw supports these extension points:
   `registry.RegisterMemoryBackend(type, factory)`.
   Select via `memory.backend` (`-memory-backend`) and optional
   `memory.config`.
+- **Gateway run options**: pass `app.WithGatewayRunOptions(...)` or
+  `app.WithGatewayRunOptionResolver(...)` from a custom binary to inject
+  request-scoped `agent.RunOption` values.
 - **Skills**: no Go code needed; point `skills.extra_dirs` at a folder.
 
 For a step-by-step plugin authoring guide (with copy-paste templates),

--- a/openclaw/README.zh_CN.md
+++ b/openclaw/README.zh_CN.md
@@ -1208,6 +1208,10 @@ OpenClaw 支持以下扩展点：
   `registry.RegisterMemoryBackend(type, factory)` 注册。
   通过 `memory.backend`（`-memory-backend`）和可选的
   `memory.config` 选择。
+- **Gateway Run Options**：在自定义二进制文件中传入
+  `app.WithGatewayRunOptions(...)` 或
+  `app.WithGatewayRunOptionResolver(...)`，为每个请求注入
+  `agent.RunOption`。
 - **Skills**：无需 Go 代码；将 `skills.extra_dirs` 指向一个文件夹。
 
 有关插件编写的分步指南（含复制粘贴模板），参见 `openclaw/EXTENDING.md`。

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -1185,6 +1185,7 @@ func NewRuntimeWithOptions(
 			),
 		),
 	)
+	gwOpts = appendRuntimeGatewayRunOptions(gwOpts, runtimeOpts)
 	gwSrv, err := gateway.New(r, gwOpts...)
 	if err != nil {
 		return nil, &exitError{
@@ -1699,6 +1700,7 @@ func run(
 			),
 		),
 	)
+	gwOpts = appendRuntimeGatewayRunOptions(gwOpts, runtimeOpts)
 	gwSrv, err := gateway.New(r, gwOpts...)
 	if err != nil {
 		return &exitError{

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -1299,6 +1299,139 @@ func TestMainWithOptionsAppliesRuntimeOptions(t *testing.T) {
 	require.True(t, observed)
 }
 
+func TestRuntimeGatewayRunOptions(t *testing.T) {
+	t.Parallel()
+
+	type ctxKey string
+
+	const (
+		ctxValueKey        ctxKey = "runtime-run-option"
+		ctxValue                  = "observed"
+		channelName               = "telegram"
+		extensionKey              = "client_tools"
+		extensionValue            = `{"source":"frontend"}`
+		messageID                 = "msg-1"
+		messageText               = "hello"
+		requestID                 = "req-in"
+		replyText                 = "ok"
+		sessionID                 = "telegram:dm:u1"
+		toolName                  = "frontend_pick_date"
+		userID                    = "u1"
+		staticInstruction         = "static"
+		dynamicInstruction        = "dynamic"
+	)
+
+	runner := &capturingRuntimeRunOptionRunner{reply: replyText}
+	runtimeOpts := buildRuntimeOptions([]RuntimeOption{
+		WithGatewayRunOptions(agent.WithInstruction(staticInstruction)),
+		WithGatewayRunOptionResolver(func(
+			ctx context.Context,
+			input GatewayRunOptionInput,
+		) (context.Context, []agent.RunOption, error) {
+			require.Equal(t, channelName, input.Inbound.Channel)
+			require.Equal(t, userID, input.Inbound.From)
+			require.Equal(t, messageID, input.Inbound.MessageID)
+			require.Equal(t, userID, input.UserID)
+			require.Equal(t, sessionID, input.SessionID)
+			require.Equal(t, requestID, input.RequestID)
+			require.Equal(t, messageText, input.Message.Content)
+			require.Equal(
+				t,
+				json.RawMessage(extensionValue),
+				input.Extensions[extensionKey],
+			)
+			return context.WithValue(
+					ctx,
+					ctxValueKey,
+					ctxValue,
+				), []agent.RunOption{
+					agent.WithExternalTools(
+						[]tool.Tool{stubTool{name: toolName}},
+					),
+					agent.WithInstruction(dynamicInstruction),
+				}, nil
+		}),
+	})
+
+	srv, err := gateway.New(
+		runner,
+		appendRuntimeGatewayRunOptions(nil, runtimeOpts)...,
+	)
+	require.NoError(t, err)
+
+	rsp, status := srv.ProcessMessage(
+		context.Background(),
+		gwproto.MessageRequest{
+			Channel:   channelName,
+			From:      userID,
+			MessageID: messageID,
+			RequestID: requestID,
+			Text:      messageText,
+			Extensions: map[string]json.RawMessage{
+				extensionKey: json.RawMessage(extensionValue),
+			},
+		},
+	)
+	require.Equal(t, http.StatusOK, status)
+	require.Equal(t, replyText, rsp.Reply)
+	require.Equal(t, ctxValue, runner.ctx.Value(ctxValueKey))
+	require.Equal(t, dynamicInstruction, runner.opts.Instruction)
+	require.Len(t, runner.opts.ExternalTools, 1)
+	require.Equal(
+		t,
+		toolName,
+		runner.opts.ExternalTools[0].Declaration().Name,
+	)
+}
+
+func TestRuntimeGatewayRunOptionsEdgeCases(t *testing.T) {
+	t.Parallel()
+
+	const instruction = "static"
+
+	runtimeOpts := buildRuntimeOptions([]RuntimeOption{
+		WithGatewayRunOptions(),
+		WithGatewayRunOptions(nil),
+		WithGatewayRunOptionResolver(nil),
+	})
+	require.Empty(t, runtimeOpts.gatewayResolvers)
+
+	runOpt := agent.WithInstruction(instruction)
+	runtimeOpts = buildRuntimeOptions([]RuntimeOption{
+		WithGatewayRunOptions(runOpt),
+	})
+	require.Len(t, runtimeOpts.gatewayResolvers, 1)
+
+	firstCtx, firstOpts, err := runtimeOpts.gatewayResolvers[0](
+		context.Background(),
+		GatewayRunOptionInput{},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, firstCtx)
+	require.Len(t, firstOpts, 1)
+	firstOpts[0] = nil
+
+	_, secondOpts, err := runtimeOpts.gatewayResolvers[0](
+		context.Background(),
+		GatewayRunOptionInput{},
+	)
+	require.NoError(t, err)
+	require.Len(t, secondOpts, 1)
+	agentOpts := agent.NewRunOptions(secondOpts...)
+	require.Equal(t, instruction, agentOpts.Instruction)
+
+	gwOpts := appendRuntimeGatewayRunOptions(
+		nil,
+		runtimeOptions{
+			gatewayResolvers: []GatewayRunOptionResolver{nil},
+		},
+	)
+	require.Empty(t, gwOpts)
+
+	input := gatewayRunOptionInput(gateway.RunOptionInput{})
+	require.Nil(t, input.Extensions)
+}
+
 func TestMain_HelpSkipsErrorLog(t *testing.T) {
 	t.Parallel()
 
@@ -5664,6 +5797,38 @@ func (s *stubRunner) Close() error {
 	}
 	return s.closeErr
 }
+
+type capturingRuntimeRunOptionRunner struct {
+	ctx   context.Context
+	opts  agent.RunOptions
+	reply string
+}
+
+func (r *capturingRuntimeRunOptionRunner) Run(
+	ctx context.Context,
+	_ string,
+	_ string,
+	_ model.Message,
+	runOpts ...agent.RunOption,
+) (<-chan *event.Event, error) {
+	r.ctx = ctx
+	r.opts = agent.NewRunOptions(runOpts...)
+
+	ch := make(chan *event.Event, 1)
+	ch <- &event.Event{
+		Response: &model.Response{
+			Object: model.ObjectTypeChatCompletion,
+			Choices: []model.Choice{
+				{Message: model.NewAssistantMessage(r.reply)},
+			},
+			Done: true,
+		},
+	}
+	close(ch)
+	return ch, nil
+}
+
+func (r *capturingRuntimeRunOptionRunner) Close() error { return nil }
 
 type inProcGWTestRunner struct {
 	reply     string

--- a/openclaw/app/runtime_options.go
+++ b/openclaw/app/runtime_options.go
@@ -10,16 +10,50 @@
 package app
 
 import (
+	"context"
+	"encoding/json"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/gateway"
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/runtimeprofile"
 )
 
 // RuntimeOption customizes an embedded OpenClaw runtime.
 type RuntimeOption func(*runtimeOptions)
 
+// GatewayInboundMessage describes the inbound gateway message for one run.
+type GatewayInboundMessage struct {
+	Channel   string
+	From      string
+	To        string
+	Thread    string
+	MessageID string
+	Text      string
+}
+
+// GatewayRunOptionInput describes one OpenClaw gateway run before runner.Run.
+type GatewayRunOptionInput struct {
+	Inbound    GatewayInboundMessage
+	UserID     string
+	SessionID  string
+	RequestID  string
+	Message    model.Message
+	Extensions map[string]json.RawMessage
+}
+
+// GatewayRunOptionResolver decorates context and agent run options for one
+// OpenClaw gateway run.
+type GatewayRunOptionResolver func(
+	ctx context.Context,
+	input GatewayRunOptionInput,
+) (context.Context, []agent.RunOption, error)
+
 type runtimeOptions struct {
 	runtimeProfileResolver runtimeprofile.Resolver
 	runtimeProfileCatalog  runtimeprofile.Catalog
 	runtimeProfileRequired bool
+	gatewayResolvers       []GatewayRunOptionResolver
 }
 
 // WithRuntimeProfileResolver injects per-request runtime profile resolution.
@@ -67,6 +101,42 @@ func WithRuntimeProfileStore(
 	}
 }
 
+// WithGatewayRunOptions appends static agent run options to every OpenClaw
+// gateway run.
+func WithGatewayRunOptions(runOpts ...agent.RunOption) RuntimeOption {
+	return func(opts *runtimeOptions) {
+		if len(runOpts) == 0 {
+			return
+		}
+		staticRunOpts := make([]agent.RunOption, 0, len(runOpts))
+		for _, runOpt := range runOpts {
+			if runOpt != nil {
+				staticRunOpts = append(staticRunOpts, runOpt)
+			}
+		}
+		if len(staticRunOpts) == 0 {
+			return
+		}
+		opts.gatewayResolvers = append(
+			opts.gatewayResolvers,
+			staticGatewayRunOptionResolver(staticRunOpts),
+		)
+	}
+}
+
+// WithGatewayRunOptionResolver injects per-request agent run options for
+// OpenClaw gateway runs.
+func WithGatewayRunOptionResolver(
+	resolver GatewayRunOptionResolver,
+) RuntimeOption {
+	return func(opts *runtimeOptions) {
+		if resolver == nil {
+			return
+		}
+		opts.gatewayResolvers = append(opts.gatewayResolvers, resolver)
+	}
+}
+
 func buildRuntimeOptions(options []RuntimeOption) runtimeOptions {
 	var opts runtimeOptions
 	for _, option := range options {
@@ -76,4 +146,77 @@ func buildRuntimeOptions(options []RuntimeOption) runtimeOptions {
 		option(&opts)
 	}
 	return opts
+}
+
+func appendRuntimeGatewayRunOptions(
+	opts []gateway.Option,
+	runtimeOpts runtimeOptions,
+) []gateway.Option {
+	for _, resolver := range runtimeOpts.gatewayResolvers {
+		if resolver == nil {
+			continue
+		}
+		opts = append(
+			opts,
+			gateway.WithRunOptionResolver(
+				adaptGatewayRunOptionResolver(resolver),
+			),
+		)
+	}
+	return opts
+}
+
+func staticGatewayRunOptionResolver(
+	staticRunOpts []agent.RunOption,
+) GatewayRunOptionResolver {
+	return func(
+		ctx context.Context,
+		_ GatewayRunOptionInput,
+	) (context.Context, []agent.RunOption, error) {
+		return ctx, append([]agent.RunOption(nil), staticRunOpts...), nil
+	}
+}
+
+func adaptGatewayRunOptionResolver(
+	resolver GatewayRunOptionResolver,
+) gateway.RunOptionResolver {
+	return func(
+		ctx context.Context,
+		input gateway.RunOptionInput,
+	) (context.Context, []agent.RunOption, error) {
+		return resolver(ctx, gatewayRunOptionInput(input))
+	}
+}
+
+func gatewayRunOptionInput(
+	input gateway.RunOptionInput,
+) GatewayRunOptionInput {
+	return GatewayRunOptionInput{
+		Inbound: GatewayInboundMessage{
+			Channel:   input.Inbound.Channel,
+			From:      input.Inbound.From,
+			To:        input.Inbound.To,
+			Thread:    input.Inbound.Thread,
+			MessageID: input.Inbound.MessageID,
+			Text:      input.Inbound.Text,
+		},
+		UserID:     input.UserID,
+		SessionID:  input.SessionID,
+		RequestID:  input.RequestID,
+		Message:    input.Message,
+		Extensions: cloneGatewayRunOptionExtensions(input.Extensions),
+	}
+}
+
+func cloneGatewayRunOptionExtensions(
+	extensions map[string]json.RawMessage,
+) map[string]json.RawMessage {
+	if len(extensions) == 0 {
+		return nil
+	}
+	out := make(map[string]json.RawMessage, len(extensions))
+	for key, value := range extensions {
+		out[key] = append(json.RawMessage(nil), value...)
+	}
+	return out
 }


### PR DESCRIPTION
## Summary

- Expose `app.GatewayRunOptionResolver` and `app.GatewayRunOptionInput` for embedded OpenClaw gateway runs.
- Add `app.WithGatewayRunOptions` for static `agent.RunOption` injection.
- Wire both `NewRuntimeWithOptions` and `RunWithOptions` so downstream runtimes can pass options such as `agent.WithExternalTools(...)` without depending on OpenClaw internal packages.

## Why

OpenClaw already has an internal gateway run-option resolver, but downstream code that only imports `openclaw/app` could not inject `agent.RunOption` values before `runner.Run`. This keeps the API generic: clients can map request extensions or frontend-provided tool declarations to `agent.WithExternalTools(...)`, and the same extension point can carry other per-request run options later.

## Tests

- `go test ./app` from `openclaw/`
- `go test ./...` from `openclaw/`