### PR TITLE
{internal/flow/llmflow, agent/llmagent}: restore go build

### DIFF
--- a/agent/llmagent/builtin/explorer.go
+++ b/agent/llmagent/builtin/explorer.go
@@ -290,10 +290,10 @@ func (e *explorer) buildInner(
 		llmagent.WithInstruction(e.cfg.instruction),
 		llmagent.WithTools(e.resolveTools(ctx, parentInv)),
 	}
-	if repo := e.resolveSkills(parentInv); repo != nil {
+	if repo := e.resolveSkills(ctx, parentInv); repo != nil {
 		opts = append(opts, llmagent.WithSkills(repo))
 	}
-	if exec := e.resolveCodeExecutor(parentInv); exec != nil {
+	if exec := e.resolveCodeExecutor(ctx, parentInv); exec != nil {
 		opts = append(opts, llmagent.WithCodeExecutor(exec))
 	}
 	// Knowledge is inherited (capability replay) only on the inherit-tools
@@ -330,7 +330,10 @@ func (e *explorer) resolveTools(
 	return inheritParentUserTools(ctx, parentInv, e.cfg.toolFilter)
 }
 
-func (e *explorer) resolveSkills(parentInv *agent.Invocation) skill.Repository {
+func (e *explorer) resolveSkills(
+	ctx context.Context,
+	parentInv *agent.Invocation,
+) skill.Repository {
 	if e.cfg.skillsSet {
 		return e.cfg.skills
 	}
@@ -338,12 +341,13 @@ func (e *explorer) resolveSkills(parentInv *agent.Invocation) skill.Repository {
 		return nil
 	}
 	if p, ok := parentInv.Agent.(invocationSkillRepositoryProvider); ok {
-		return p.InvocationSkillRepository(parentInv)
+		return p.InvocationSkillRepository(ctx, parentInv)
 	}
 	return nil
 }
 
 func (e *explorer) resolveCodeExecutor(
+	ctx context.Context,
 	parentInv *agent.Invocation,
 ) codeexecutor.CodeExecutor {
 	if e.cfg.codeExecutor != nil {
@@ -353,7 +357,7 @@ func (e *explorer) resolveCodeExecutor(
 		return nil
 	}
 	if p, ok := parentInv.Agent.(invocationCodeExecutorProvider); ok {
-		return p.InvocationCodeExecutor(parentInv)
+		return p.InvocationCodeExecutor(ctx, parentInv)
 	}
 	return nil
 }
@@ -449,11 +453,17 @@ type invocationToolSurfaceProvider interface {
 }
 
 type invocationSkillRepositoryProvider interface {
-	InvocationSkillRepository(inv *agent.Invocation) skill.Repository
+	InvocationSkillRepository(
+		ctx context.Context,
+		inv *agent.Invocation,
+	) skill.Repository
 }
 
 type invocationCodeExecutorProvider interface {
-	InvocationCodeExecutor(inv *agent.Invocation) codeexecutor.CodeExecutor
+	InvocationCodeExecutor(
+		ctx context.Context,
+		inv *agent.Invocation,
+	) codeexecutor.CodeExecutor
 }
 
 type invocationKnowledgeOptionsProvider interface {

--- a/agent/llmagent/builtin/explorer_test.go
+++ b/agent/llmagent/builtin/explorer_test.go
@@ -74,12 +74,14 @@ func (f *fakeParentAgent) InvocationToolSurface(
 }
 
 func (f *fakeParentAgent) InvocationSkillRepository(
+	context.Context,
 	*agent.Invocation,
 ) skill.Repository {
 	return f.skills
 }
 
 func (f *fakeParentAgent) InvocationCodeExecutor(
+	context.Context,
 	*agent.Invocation,
 ) codeexecutor.CodeExecutor {
 	return f.exec
@@ -329,26 +331,30 @@ func TestResolveSkills(t *testing.T) {
 	inherited := fakeSkillRepo{id: "parent"}
 	explicit := fakeSkillRepo{id: "explicit"}
 	parentInv := &agent.Invocation{Agent: &fakeParentAgent{skills: inherited}}
+	noProviderInv := &agent.Invocation{Agent: &stubAgent{name: "plain"}}
 
 	e := NewExplorer().(*explorer)
-	require.Equal(t, inherited, e.resolveSkills(parentInv))
-	require.Nil(t, e.resolveSkills(nil))
+	require.Equal(t, inherited, e.resolveSkills(context.Background(), parentInv))
+	require.Nil(t, e.resolveSkills(context.Background(), nil))
+	require.Nil(t, e.resolveSkills(context.Background(), noProviderInv))
 
 	e2 := NewExplorer(WithSkills(explicit)).(*explorer)
-	require.Equal(t, explicit, e2.resolveSkills(parentInv))
+	require.Equal(t, explicit, e2.resolveSkills(context.Background(), parentInv))
 }
 
 func TestResolveCodeExecutor(t *testing.T) {
 	inherited := fakeExecutor{id: "parent"}
 	explicit := fakeExecutor{id: "explicit"}
 	parentInv := &agent.Invocation{Agent: &fakeParentAgent{exec: inherited}}
+	noProviderInv := &agent.Invocation{Agent: &stubAgent{name: "plain"}}
 
 	e := NewExplorer().(*explorer)
-	require.Equal(t, inherited, e.resolveCodeExecutor(parentInv))
-	require.Nil(t, e.resolveCodeExecutor(nil))
+	require.Equal(t, inherited, e.resolveCodeExecutor(context.Background(), parentInv))
+	require.Nil(t, e.resolveCodeExecutor(context.Background(), nil))
+	require.Nil(t, e.resolveCodeExecutor(context.Background(), noProviderInv))
 
 	e2 := NewExplorer(WithCodeExecutor(explicit)).(*explorer)
-	require.Equal(t, explicit, e2.resolveCodeExecutor(parentInv))
+	require.Equal(t, explicit, e2.resolveCodeExecutor(context.Background(), parentInv))
 }
 
 func TestBuildInner_NoParentNoModel_Errors(t *testing.T) {

--- a/agent/llmagent/surface_runtime.go
+++ b/agent/llmagent/surface_runtime.go
@@ -105,6 +105,9 @@ func (a *LLMAgent) InvocationSkillRepository(
 	_ context.Context,
 	inv *agent.Invocation,
 ) skill.Repository {
+	if a == nil {
+		return nil
+	}
 	return a.skillRepositoryForInvocation(inv)
 }
 
@@ -287,38 +290,6 @@ func (a *LLMAgent) InvocationToolSurface(
 	// from extension name collisions.
 	allTools = appendExtensionTools(allTools, &options)
 	return allTools, userToolNames
-}
-
-// InvocationSkillRepository returns the skill repository effective for the
-// given invocation, honoring a surface-patch override first and then the
-// agent's configured repository.
-//
-// It exposes skillRepositoryForInvocation so that external presets (for
-// example agent/llmagent/builtin) can inherit a parent agent's skill
-// capability at run time, in the same invocation-scoped style as
-// InvocationToolSurface.
-func (a *LLMAgent) InvocationSkillRepository(
-	inv *agent.Invocation,
-) skill.Repository {
-	if a == nil {
-		return nil
-	}
-	return a.skillRepositoryForInvocation(inv)
-}
-
-// InvocationCodeExecutor returns the code executor effective for the given
-// invocation, honoring a run-scoped RunOptions.CodeExecutor override first
-// and then the agent's configured executor.
-//
-// It mirrors the resolution InvocationToolSurface uses so external presets
-// can inherit a parent agent's execution capability at run time.
-func (a *LLMAgent) InvocationCodeExecutor(
-	inv *agent.Invocation,
-) codeexecutor.CodeExecutor {
-	if a == nil {
-		return nil
-	}
-	return a.codeExecutorForInvocation(inv)
 }
 
 // InvocationKnowledgeOptions returns the options required to reproduce this

--- a/agent/llmagent/surface_runtime_test.go
+++ b/agent/llmagent/surface_runtime_test.go
@@ -604,8 +604,8 @@ func TestLLMAgent_InvocationCapabilityAccessors(t *testing.T) {
 		)),
 	)
 
-	require.Same(t, repo, agt.InvocationSkillRepository(inv))
-	require.Same(t, runExec, agt.InvocationCodeExecutor(inv))
+	require.Same(t, repo, agt.InvocationSkillRepository(context.Background(), inv))
+	require.Same(t, runExec, agt.InvocationCodeExecutor(context.Background(), inv))
 
 	var opts Options
 	for _, opt := range agt.InvocationKnowledgeOptions(inv) {
@@ -620,13 +620,13 @@ func TestLLMAgent_InvocationCapabilityAccessors(t *testing.T) {
 
 func TestLLMAgent_InvocationCapabilityAccessors_NilAndEmpty(t *testing.T) {
 	var nilAgent *LLMAgent
-	require.Nil(t, nilAgent.InvocationSkillRepository(nil))
-	require.Nil(t, nilAgent.InvocationCodeExecutor(nil))
+	require.Nil(t, nilAgent.InvocationSkillRepository(context.Background(), nil))
+	require.Nil(t, nilAgent.InvocationCodeExecutor(context.Background(), nil))
 	require.Nil(t, nilAgent.InvocationKnowledgeOptions(nil))
 
 	agt := New("test-agent", WithModel(newDummyModel()))
-	require.Nil(t, agt.InvocationSkillRepository(nil))
-	require.Nil(t, agt.InvocationCodeExecutor(nil))
+	require.Nil(t, agt.InvocationSkillRepository(context.Background(), nil))
+	require.Nil(t, agt.InvocationCodeExecutor(context.Background(), nil))
 	require.Nil(t, agt.InvocationKnowledgeOptions(nil))
 }
 

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -1540,6 +1540,14 @@ func setVisibleExternalToolNames(
 	invocation.RunOptions.ExternalToolNames = visible
 }
 
+func copyToolNames(src map[string]bool) map[string]bool {
+	dst := make(map[string]bool, len(src))
+	for name, ok := range src {
+		dst[name] = ok
+	}
+	return dst
+}
+
 func toolName(tl tool.Tool) string {
 	if tl == nil {
 		return ""

--- a/internal/flow/llmflow/tool_filter_test.go
+++ b/internal/flow/llmflow/tool_filter_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/internal/flow/toolsnapshot"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
 
@@ -355,7 +356,7 @@ func TestGetFilteredTools_NoFilterSkipsInvalidTools(t *testing.T) {
 	require.Len(t, filtered, 1)
 	require.Equal(t, "valid_tool", filtered[0].Declaration().Name)
 
-	snapshot, ok := agent.GetStateValue[[]tool.Tool](inv, stateKeyToolsSnapshot)
+	snapshot, ok := agent.GetStateValue[[]tool.Tool](inv, toolsnapshot.ToolsSnapshotKey)
 	require.True(t, ok)
 	require.Len(t, snapshot, 1)
 	require.Equal(t, "valid_tool", snapshot[0].Declaration().Name)


### PR DESCRIPTION
Restores the root Go build by keeping llmflow's tool-name copy helper local after tool surface extraction and consolidating LLMAgent invocation capability accessors onto the context-aware provider signatures used by agent invocation capability providers.