### PR TITLE
.github: run PR checks for merge queue

### DIFF
--- a/.github/workflows/prc.yml
+++ b/.github/workflows/prc.yml
@@ -1,6 +1,7 @@
 name: Pull Request Check
 on:
   pull_request:
+  merge_group:
   push:
   workflow_dispatch:
 permissions:


### PR DESCRIPTION
## Summary
- Add the `merge_group` event to the Pull Request Check workflow.

## Motivation
GitHub merge queue validates queued pull requests on temporary merge-group branches. Required checks need to run on `merge_group` events so the queue can verify the combined result before merging.

## Validation
- Parsed `.github/workflows/prc.yml` with Ruby YAML parser.
