### PR TITLE
internal/toolcall: add sanitize downgrade warnings

### DIFF
--- a/graph/state_graph.go
+++ b/graph/state_graph.go
@@ -1560,7 +1560,7 @@ func (r *llmRunner) executeModel(
 		GenerationConfig: r.generationConfig,
 	}
 	// Sanitize invalid tool calls in history to avoid poisoning future requests.
-	request.Messages = toolcall.SanitizeMessagesWithTools(request.Messages, request.Tools)
+	request.Messages = toolcall.SanitizeMessagesWithTools(ctx, request.Messages, request.Tools)
 	applyInvocationRequestOverrides(request, callInvocation, nodeID)
 	invocationID, sessionID, appName, userID, eventChan := extractExecutionContext(state)
 	modelCallbacks, _ := state[StateKeyModelCallbacks].(*model.Callbacks)

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -1041,7 +1041,7 @@ func (f *Flow) preprocess(
 		}
 	}
 	// Sanitize invalid tool calls in history to avoid poisoning future requests.
-	llmRequest.Messages = toolcall.SanitizeMessagesWithTools(llmRequest.Messages, llmRequest.Tools)
+	llmRequest.Messages = toolcall.SanitizeMessagesWithTools(ctx, llmRequest.Messages, llmRequest.Tools)
 	return rebuildPlan
 }
 
@@ -1158,6 +1158,7 @@ func (f *Flow) rebuildRequestForContextCompaction(
 		}
 	}
 	rebuilt.Messages = toolcall.SanitizeMessagesWithTools(
+		ctx,
 		rebuilt.Messages,
 		rebuilt.Tools,
 	)

--- a/internal/toolcall/sanitize.go
+++ b/internal/toolcall/sanitize.go
@@ -12,6 +12,7 @@ package toolcall
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -46,7 +47,8 @@ var (
 // This function also downgrades orphan tool calls that are not associated with a kept
 // tool result message, and orphan tool result messages that are not associated with a
 // kept tool call message, to avoid invalid tool message sequences in strict chat APIs.
-func SanitizeMessagesWithTools(messages []model.Message, tools map[string]tool.Tool) []model.Message {
+// The context is used to attach request-scoped metadata to downgrade warnings.
+func SanitizeMessagesWithTools(ctx context.Context, messages []model.Message, tools map[string]tool.Tool) []model.Message {
 	if len(messages) == 0 {
 		return messages
 	}
@@ -58,12 +60,12 @@ func SanitizeMessagesWithTools(messages []model.Message, tools map[string]tool.T
 			for next < len(messages) && messages[next].Role == model.RoleTool {
 				next++
 			}
-			out = append(out, sanitizeToolRound(msg, messages[i+1:next], tools)...)
+			out = append(out, sanitizeToolRound(ctx, msg, messages[i+1:next], tools)...)
 			i = next
 			continue
 		}
 		if msg.Role == model.RoleTool {
-			out = append(out, downgradeOrphanToolResult(msg))
+			out = append(out, downgradeOrphanToolResult(ctx, msg))
 			i++
 			continue
 		}
@@ -97,7 +99,7 @@ type toolCallSplit struct {
 }
 
 // sanitizeToolRound sanitizes a single assistant tool-call round with its following tool results.
-func sanitizeToolRound(assistant model.Message, toolResults []model.Message, tools map[string]tool.Tool) []model.Message {
+func sanitizeToolRound(ctx context.Context, assistant model.Message, toolResults []model.Message, tools map[string]tool.Tool) []model.Message {
 	validation := validateToolCalls(assistant.ToolCalls, tools)
 	split := splitToolResults(toolResults, validation.validIDs, validation.invalidIDs)
 	toolCallSplit := splitToolCalls(validation.validToolCalls, split.kept)
@@ -116,16 +118,16 @@ func sanitizeToolRound(assistant model.Message, toolResults []model.Message, too
 		out = append(out, split.kept...)
 	}
 	for _, orphanCall := range toolCallSplit.orphan {
-		out = append(out, downgradeOrphanToolCall(orphanCall))
+		out = append(out, downgradeOrphanToolCall(ctx, orphanCall))
 	}
 	for _, invalid := range validation.invalidToolCalls {
-		out = append(out, downgradeInvalidToolCall(invalid.call, invalid.reason))
+		out = append(out, downgradeInvalidToolCall(ctx, invalid.call, invalid.reason))
 		for _, tr := range split.invalidByID[invalid.call.ID] {
-			out = append(out, downgradeInvalidToolResult(tr))
+			out = append(out, downgradeInvalidToolResult(ctx, tr))
 		}
 	}
 	for _, orphan := range split.orphan {
-		out = append(out, downgradeOrphanToolResult(orphan))
+		out = append(out, downgradeOrphanToolResult(ctx, orphan))
 	}
 	return out
 }
@@ -419,8 +421,8 @@ func splitToolResults(toolResults []model.Message, validIDs map[string]struct{},
 }
 
 // downgradeInvalidToolCall converts an invalid tool call into a user message that preserves its payload.
-func downgradeInvalidToolCall(call model.ToolCall, reason string) model.Message {
-	log.Warnf(
+func downgradeInvalidToolCall(ctx context.Context, call model.ToolCall, reason string) model.Message {
+	log.WarnfContext(ctx,
 		"toolcall: downgraded invalid tool call to user message: name=%q id=%q reason=%q",
 		call.Function.Name,
 		call.ID,
@@ -441,8 +443,8 @@ func downgradeInvalidToolCall(call model.ToolCall, reason string) model.Message 
 }
 
 // downgradeOrphanToolCall converts a tool call without a matching tool result into a user message.
-func downgradeOrphanToolCall(call model.ToolCall) model.Message {
-	log.Warnf(
+func downgradeOrphanToolCall(ctx context.Context, call model.ToolCall) model.Message {
+	log.WarnfContext(ctx,
 		"toolcall: downgraded orphan tool call to user message: name=%q id=%q",
 		call.Function.Name,
 		call.ID,
@@ -461,8 +463,8 @@ func downgradeOrphanToolCall(call model.ToolCall) model.Message {
 }
 
 // downgradeInvalidToolResult converts a tool result associated with an invalid tool call into a user message.
-func downgradeInvalidToolResult(msg model.Message) model.Message {
-	log.Warnf(
+func downgradeInvalidToolResult(ctx context.Context, msg model.Message) model.Message {
+	log.WarnfContext(ctx,
 		"toolcall: downgraded invalid tool result to user message: tool_name=%q tool_call_id=%q",
 		msg.ToolName,
 		msg.ToolID,
@@ -481,8 +483,8 @@ func downgradeInvalidToolResult(msg model.Message) model.Message {
 }
 
 // downgradeOrphanToolResult converts an orphaned tool result into a user message.
-func downgradeOrphanToolResult(msg model.Message) model.Message {
-	log.Warnf(
+func downgradeOrphanToolResult(ctx context.Context, msg model.Message) model.Message {
+	log.WarnfContext(ctx,
 		"toolcall: downgraded orphan tool result to user message: tool_name=%q tool_call_id=%q",
 		msg.ToolName,
 		msg.ToolID,

--- a/internal/toolcall/sanitize.go
+++ b/internal/toolcall/sanitize.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"trpc.group/trpc-go/trpc-agent-go/internal/util/message"
+	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
@@ -419,6 +420,12 @@ func splitToolResults(toolResults []model.Message, validIDs map[string]struct{},
 
 // downgradeInvalidToolCall converts an invalid tool call into a user message that preserves its payload.
 func downgradeInvalidToolCall(call model.ToolCall, reason string) model.Message {
+	log.Warnf(
+		"toolcall: downgraded invalid tool call to user message: name=%q id=%q reason=%q",
+		call.Function.Name,
+		call.ID,
+		reason,
+	)
 	content := fmt.Sprintf(
 		"%s Tool call arguments were downgraded to a user message (%s).\nname: %s\nid: %s\narguments:\n```text\n%s\n```",
 		invalidToolCallTag,
@@ -435,6 +442,11 @@ func downgradeInvalidToolCall(call model.ToolCall, reason string) model.Message 
 
 // downgradeOrphanToolCall converts a tool call without a matching tool result into a user message.
 func downgradeOrphanToolCall(call model.ToolCall) model.Message {
+	log.Warnf(
+		"toolcall: downgraded orphan tool call to user message: name=%q id=%q",
+		call.Function.Name,
+		call.ID,
+	)
 	content := fmt.Sprintf(
 		"%s Tool call was downgraded to a user message because no matching tool result exists.\nname: %s\nid: %s\narguments:\n```text\n%s\n```",
 		orphanToolCallTag,
@@ -450,6 +462,11 @@ func downgradeOrphanToolCall(call model.ToolCall) model.Message {
 
 // downgradeInvalidToolResult converts a tool result associated with an invalid tool call into a user message.
 func downgradeInvalidToolResult(msg model.Message) model.Message {
+	log.Warnf(
+		"toolcall: downgraded invalid tool result to user message: tool_name=%q tool_call_id=%q",
+		msg.ToolName,
+		msg.ToolID,
+	)
 	content := fmt.Sprintf(
 		"%s Tool result was downgraded to a user message.\ntool_call_id: %s\ntool_name: %s\ncontent:\n```text\n%s\n```",
 		invalidToolResultTag,
@@ -465,6 +482,11 @@ func downgradeInvalidToolResult(msg model.Message) model.Message {
 
 // downgradeOrphanToolResult converts an orphaned tool result into a user message.
 func downgradeOrphanToolResult(msg model.Message) model.Message {
+	log.Warnf(
+		"toolcall: downgraded orphan tool result to user message: tool_name=%q tool_call_id=%q",
+		msg.ToolName,
+		msg.ToolID,
+	)
 	content := fmt.Sprintf(
 		"%s Tool result was downgraded to a user message because it is orphaned.\ntool_call_id: %s\ntool_name: %s\ncontent:\n```text\n%s\n```",
 		orphanToolResultTag,

--- a/internal/toolcall/sanitize_test.go
+++ b/internal/toolcall/sanitize_test.go
@@ -12,10 +12,13 @@ package toolcall
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"trpc.group/trpc-go/trpc-agent-go/internal/util/message"
+	agentlog "trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 	"trpc.group/trpc-go/trpc-agent-go/tool/function"
@@ -26,6 +29,25 @@ type stubTool struct {
 }
 
 func (s stubTool) Declaration() *tool.Declaration { return s.decl }
+
+type sanitizeWarnLogger struct {
+	messages []string
+}
+
+func (l *sanitizeWarnLogger) Debug(args ...any)                 {}
+func (l *sanitizeWarnLogger) Debugf(format string, args ...any) {}
+func (l *sanitizeWarnLogger) Info(args ...any)                  {}
+func (l *sanitizeWarnLogger) Infof(format string, args ...any)  {}
+func (l *sanitizeWarnLogger) Warn(args ...any) {
+	l.messages = append(l.messages, fmt.Sprint(args...))
+}
+func (l *sanitizeWarnLogger) Warnf(format string, args ...any) {
+	l.messages = append(l.messages, fmt.Sprintf(format, args...))
+}
+func (l *sanitizeWarnLogger) Error(args ...any)                 {}
+func (l *sanitizeWarnLogger) Errorf(format string, args ...any) {}
+func (l *sanitizeWarnLogger) Fatal(args ...any)                 {}
+func (l *sanitizeWarnLogger) Fatalf(format string, args ...any) {}
 
 func TestSanitizeMessagesWithTools_DowngradesInvalidToolCallAndResult(t *testing.T) {
 	in := []model.Message{
@@ -61,6 +83,69 @@ func TestSanitizeMessagesWithTools_DowngradesInvalidToolCallAndResult(t *testing
 		assert.NotEqual(t, model.RoleTool, msg.Role)
 		assert.Empty(t, msg.ToolCalls)
 	}
+}
+
+func TestSanitizeMessagesWithTools_WarnsOnDowngradeWithoutPayload(t *testing.T) {
+	original := agentlog.Default
+	logger := &sanitizeWarnLogger{}
+	agentlog.Default = logger
+	defer func() {
+		agentlog.Default = original
+	}()
+	in := []model.Message{
+		{
+			Role: model.RoleAssistant,
+			ToolCalls: []model.ToolCall{
+				{
+					ID: "call_invalid",
+					Function: model.FunctionDefinitionParam{
+						Name:      "invalid_tool",
+						Arguments: []byte("{SECRET_ARGS"),
+					},
+				},
+			},
+		},
+		{
+			Role:     model.RoleTool,
+			ToolID:   "call_invalid",
+			ToolName: "invalid_tool",
+			Content:  "SECRET_RESULT",
+		},
+		{
+			Role: model.RoleAssistant,
+			ToolCalls: []model.ToolCall{
+				{
+					ID: "call_orphan",
+					Function: model.FunctionDefinitionParam{
+						Name:      "orphan_tool",
+						Arguments: []byte(`{"secret":"SECRET_ORPHAN_ARGS"}`),
+					},
+				},
+			},
+		},
+		{
+			Role:     model.RoleTool,
+			ToolID:   "call_orphan_result",
+			ToolName: "orphan_result_tool",
+			Content:  "SECRET_ORPHAN_RESULT",
+		},
+	}
+	out := SanitizeMessagesWithTools(in, nil)
+	assert.Len(t, out, 4)
+	assert.Len(t, logger.messages, 4)
+	allLogs := strings.Join(logger.messages, "\n")
+	assert.Contains(t, allLogs, "downgraded invalid tool call")
+	assert.Contains(t, allLogs, "downgraded invalid tool result")
+	assert.Contains(t, allLogs, "downgraded orphan tool call")
+	assert.Contains(t, allLogs, "downgraded orphan tool result")
+	assert.Contains(t, allLogs, "call_invalid")
+	assert.Contains(t, allLogs, "call_orphan")
+	assert.Contains(t, allLogs, "invalid_tool")
+	assert.Contains(t, allLogs, "orphan_tool")
+	assert.NotContains(t, allLogs, "SECRET_ARGS")
+	assert.NotContains(t, allLogs, "SECRET_RESULT")
+	assert.NotContains(t, allLogs, "SECRET_ORPHAN_ARGS")
+	assert.NotContains(t, allLogs, "SECRET_ORPHAN_RESULT")
 }
 
 func TestSanitizeMessagesWithTools_PreservesNilMessagesSlice(t *testing.T) {

--- a/internal/toolcall/sanitize_test.go
+++ b/internal/toolcall/sanitize_test.go
@@ -30,24 +30,7 @@ type stubTool struct {
 
 func (s stubTool) Declaration() *tool.Declaration { return s.decl }
 
-type sanitizeWarnLogger struct {
-	messages []string
-}
-
-func (l *sanitizeWarnLogger) Debug(args ...any)                 {}
-func (l *sanitizeWarnLogger) Debugf(format string, args ...any) {}
-func (l *sanitizeWarnLogger) Info(args ...any)                  {}
-func (l *sanitizeWarnLogger) Infof(format string, args ...any)  {}
-func (l *sanitizeWarnLogger) Warn(args ...any) {
-	l.messages = append(l.messages, fmt.Sprint(args...))
-}
-func (l *sanitizeWarnLogger) Warnf(format string, args ...any) {
-	l.messages = append(l.messages, fmt.Sprintf(format, args...))
-}
-func (l *sanitizeWarnLogger) Error(args ...any)                 {}
-func (l *sanitizeWarnLogger) Errorf(format string, args ...any) {}
-func (l *sanitizeWarnLogger) Fatal(args ...any)                 {}
-func (l *sanitizeWarnLogger) Fatalf(format string, args ...any) {}
+type sanitizeLogContextKey struct{}
 
 func TestSanitizeMessagesWithTools_DowngradesInvalidToolCallAndResult(t *testing.T) {
 	in := []model.Message{
@@ -71,7 +54,7 @@ func TestSanitizeMessagesWithTools_DowngradesInvalidToolCallAndResult(t *testing
 			Content:  "tool error",
 		},
 	}
-	out := SanitizeMessagesWithTools(in, nil)
+	out := SanitizeMessagesWithTools(context.Background(), in, nil)
 	if assert.Len(t, out, 3) {
 		assert.Equal(t, model.RoleUser, out[0].Role)
 		assert.Equal(t, model.RoleUser, out[1].Role)
@@ -86,12 +69,19 @@ func TestSanitizeMessagesWithTools_DowngradesInvalidToolCallAndResult(t *testing
 }
 
 func TestSanitizeMessagesWithTools_WarnsOnDowngradeWithoutPayload(t *testing.T) {
-	original := agentlog.Default
-	logger := &sanitizeWarnLogger{}
-	agentlog.Default = logger
+	original := agentlog.WarnfContext
+	var messages []string
+	contextMatches := 0
+	agentlog.WarnfContext = func(ctx context.Context, format string, args ...any) {
+		if ctx.Value(sanitizeLogContextKey{}) == "request" {
+			contextMatches++
+		}
+		messages = append(messages, fmt.Sprintf(format, args...))
+	}
 	defer func() {
-		agentlog.Default = original
+		agentlog.WarnfContext = original
 	}()
+	ctx := context.WithValue(context.Background(), sanitizeLogContextKey{}, "request")
 	in := []model.Message{
 		{
 			Role: model.RoleAssistant,
@@ -130,10 +120,11 @@ func TestSanitizeMessagesWithTools_WarnsOnDowngradeWithoutPayload(t *testing.T) 
 			Content:  "SECRET_ORPHAN_RESULT",
 		},
 	}
-	out := SanitizeMessagesWithTools(in, nil)
+	out := SanitizeMessagesWithTools(ctx, in, nil)
 	assert.Len(t, out, 4)
-	assert.Len(t, logger.messages, 4)
-	allLogs := strings.Join(logger.messages, "\n")
+	assert.Len(t, messages, 4)
+	assert.Equal(t, 4, contextMatches)
+	allLogs := strings.Join(messages, "\n")
 	assert.Contains(t, allLogs, "downgraded invalid tool call")
 	assert.Contains(t, allLogs, "downgraded invalid tool result")
 	assert.Contains(t, allLogs, "downgraded orphan tool call")
@@ -150,13 +141,13 @@ func TestSanitizeMessagesWithTools_WarnsOnDowngradeWithoutPayload(t *testing.T) 
 
 func TestSanitizeMessagesWithTools_PreservesNilMessagesSlice(t *testing.T) {
 	var in []model.Message
-	out := SanitizeMessagesWithTools(in, nil)
+	out := SanitizeMessagesWithTools(context.Background(), in, nil)
 	assert.Nil(t, out)
 }
 
 func TestSanitizeMessagesWithTools_PreservesEmptyMessagesSlice(t *testing.T) {
 	in := make([]model.Message, 0)
-	out := SanitizeMessagesWithTools(in, nil)
+	out := SanitizeMessagesWithTools(context.Background(), in, nil)
 	assert.NotNil(t, out)
 	assert.Len(t, out, 0)
 }
@@ -182,7 +173,7 @@ func TestSanitizeMessagesWithTools_PreservesValidToolRound(t *testing.T) {
 			Content: `{"ok":true}`,
 		},
 	}
-	out := SanitizeMessagesWithTools(in, nil)
+	out := SanitizeMessagesWithTools(context.Background(), in, nil)
 	if assert.Len(t, out, 3) {
 		assert.Equal(t, model.RoleAssistant, out[1].Role)
 		if assert.Len(t, out[1].ToolCalls, 1) {
@@ -219,7 +210,7 @@ func TestSanitizeMessagesWithTools_DowngradesDuplicateToolResult(t *testing.T) {
 		},
 	}
 
-	out := SanitizeMessagesWithTools(in, nil)
+	out := SanitizeMessagesWithTools(context.Background(), in, nil)
 	if assert.Len(t, out, 3) {
 		assert.Equal(t, model.RoleAssistant, out[0].Role)
 		assert.Equal(t, model.RoleTool, out[1].Role)
@@ -249,7 +240,7 @@ func TestSanitizeMessagesWithTools_NormalizesEmptyArgumentsToEmptyObject(t *test
 			ToolID: "call_1",
 		},
 	}
-	out := SanitizeMessagesWithTools(in, nil)
+	out := SanitizeMessagesWithTools(context.Background(), in, nil)
 	if assert.Len(t, out, 2) && assert.Len(t, out[0].ToolCalls, 1) {
 		assert.Equal(t, []byte("{}"), out[0].ToolCalls[0].Function.Arguments)
 	}
@@ -286,7 +277,7 @@ func TestSanitizeMessagesWithTools_SplitsMixedValidityToolRound(t *testing.T) {
 			Content: "bad tool error",
 		},
 	}
-	out := SanitizeMessagesWithTools(in, nil)
+	out := SanitizeMessagesWithTools(context.Background(), in, nil)
 	if assert.Len(t, out, 4) {
 		assert.Equal(t, model.RoleAssistant, out[0].Role)
 		if assert.Len(t, out[0].ToolCalls, 1) {
@@ -309,7 +300,7 @@ func TestSanitizeMessagesWithTools_DowngradesOrphanToolResult(t *testing.T) {
 			Content: "orphan",
 		},
 	}
-	out := SanitizeMessagesWithTools(in, nil)
+	out := SanitizeMessagesWithTools(context.Background(), in, nil)
 	if assert.Len(t, out, 1) {
 		assert.Equal(t, model.RoleUser, out[0].Role)
 		assert.Contains(t, out[0].Content, orphanToolResultTag)
@@ -331,7 +322,7 @@ func TestSanitizeMessagesWithTools_DowngradesOrphanToolCall(t *testing.T) {
 			},
 		},
 	}
-	out := SanitizeMessagesWithTools(in, nil)
+	out := SanitizeMessagesWithTools(context.Background(), in, nil)
 	if assert.Len(t, out, 1) {
 		assert.Equal(t, model.RoleUser, out[0].Role)
 		assert.Contains(t, out[0].Content, orphanToolCallTag)
@@ -356,7 +347,7 @@ func TestSanitizeMessagesWithTools_DropsReasoningOnlyAssistantAfterOrphanToolCal
 		},
 	}
 
-	out := SanitizeMessagesWithTools(in, nil)
+	out := SanitizeMessagesWithTools(context.Background(), in, nil)
 	if assert.Len(t, out, 1) {
 		assert.Equal(t, model.RoleUser, out[0].Role)
 		assert.Contains(t, out[0].Content, orphanToolCallTag)
@@ -392,7 +383,7 @@ func TestSanitizeMessagesWithTools_SplitsMatchedAndOrphanToolCalls(t *testing.T)
 			Content:  "ok",
 		},
 	}
-	out := SanitizeMessagesWithTools(in, nil)
+	out := SanitizeMessagesWithTools(context.Background(), in, nil)
 	if assert.Len(t, out, 3) {
 		assert.Equal(t, model.RoleAssistant, out[0].Role)
 		if assert.Len(t, out[0].ToolCalls, 1) {
@@ -427,7 +418,7 @@ func TestSanitizeMessagesWithTools_PreservesNonObjectJSONArgumentsWhenToolsUnkno
 			Content:  "ok",
 		},
 	}
-	out := SanitizeMessagesWithTools(in, nil)
+	out := SanitizeMessagesWithTools(context.Background(), in, nil)
 	if assert.Len(t, out, 2) {
 		assert.Equal(t, model.RoleAssistant, out[0].Role)
 		if assert.Len(t, out[0].ToolCalls, 1) {
@@ -464,7 +455,7 @@ func TestSanitizeMessagesWithTools_DowngradesSchemaTypeMismatch(t *testing.T) {
 			},
 		},
 	}
-	out := SanitizeMessagesWithTools(in, tools)
+	out := SanitizeMessagesWithTools(context.Background(), in, tools)
 	if assert.Len(t, out, 1) {
 		assert.Equal(t, model.RoleUser, out[0].Role)
 		assert.Contains(t, out[0].Content, invalidToolCallTag)
@@ -499,7 +490,7 @@ func TestSanitizeMessagesWithTools_DowngradesNonObjectJSONArgumentsWhenSchemaExp
 			},
 		},
 	}
-	out := SanitizeMessagesWithTools(in, tools)
+	out := SanitizeMessagesWithTools(context.Background(), in, tools)
 	if assert.Len(t, out, 1) {
 		assert.Equal(t, model.RoleUser, out[0].Role)
 		assert.Contains(t, out[0].Content, invalidToolCallTag)
@@ -536,7 +527,7 @@ func TestSanitizeMessagesWithTools_PreservesStringArgumentsWhenSchemaAllows(t *t
 			Content:  "ok",
 		},
 	}
-	out := SanitizeMessagesWithTools(in, tools)
+	out := SanitizeMessagesWithTools(context.Background(), in, tools)
 	if assert.Len(t, out, 2) {
 		assert.Equal(t, model.RoleAssistant, out[0].Role)
 		if assert.Len(t, out[0].ToolCalls, 1) {
@@ -576,7 +567,7 @@ func TestSanitizeMessagesWithTools_PreservesArrayArgumentsWhenSchemaAllows(t *te
 			Content:  "ok",
 		},
 	}
-	out := SanitizeMessagesWithTools(in, tools)
+	out := SanitizeMessagesWithTools(context.Background(), in, tools)
 	if assert.Len(t, out, 2) {
 		assert.Equal(t, model.RoleAssistant, out[0].Role)
 		if assert.Len(t, out[0].ToolCalls, 1) {
@@ -608,7 +599,7 @@ func TestSanitizeMessagesWithTools_PreservesNullArgumentsWhenToolsUnknown(t *tes
 			Content:  "ok",
 		},
 	}
-	out := SanitizeMessagesWithTools(in, nil)
+	out := SanitizeMessagesWithTools(context.Background(), in, nil)
 	if assert.Len(t, out, 2) {
 		assert.Equal(t, model.RoleAssistant, out[0].Role)
 		if assert.Len(t, out[0].ToolCalls, 1) {
@@ -645,7 +636,7 @@ func TestSanitizeMessagesWithTools_DowngradesNullArgumentsWhenSchemaExpectsObjec
 			},
 		},
 	}
-	out := SanitizeMessagesWithTools(in, tools)
+	out := SanitizeMessagesWithTools(context.Background(), in, tools)
 	if assert.Len(t, out, 1) {
 		assert.Equal(t, model.RoleUser, out[0].Role)
 		assert.Contains(t, out[0].Content, invalidToolCallTag)
@@ -684,7 +675,7 @@ func TestSanitizeMessagesWithTools_PreservesNullArgumentsWhenSchemaAllowsNull(t 
 			Content:  "ok",
 		},
 	}
-	out := SanitizeMessagesWithTools(in, tools)
+	out := SanitizeMessagesWithTools(context.Background(), in, tools)
 	if assert.Len(t, out, 2) {
 		assert.Equal(t, model.RoleAssistant, out[0].Role)
 		if assert.Len(t, out[0].ToolCalls, 1) {


### PR DESCRIPTION
Adds warning logs whenever tool-call sanitization downgrades invalid or orphaned tool calls or tool results into user messages, while limiting the emitted metadata to tool names, tool call IDs, and validation reasons so arguments and result contents are not written to logs.