### PR TITLE
tool/agent: add WithPinModel option for AgentTool

### DIFF
--- a/docs/mkdocs/en/multiagent.md
+++ b/docs/mkdocs/en/multiagent.md
@@ -634,6 +634,25 @@ and the parent Agent should only consume its final answer. Use
 `InnerTextModeExclude` separately when you also want to hide child assistant
 text from the streamed UI.
 
+#### Model Pinning
+
+By default, a sub-agent inherits the caller's `RunOptions.ModelName`,
+`RunOptions.Model` and `RunOptions.ModelSelector`. This only takes effect
+when the caller passes `agent.WithModelName(...)`, `agent.WithModel(...)`
+or `agent.WithModelSelector(...)` at `runner.Run` time (for example, an
+AGUI server forwarding the end-user's model choice). If no runtime model
+is set in RunOptions, the sub-agent naturally uses its own model
+configured via `llmagent.WithModel`.
+
+When the sub-agent should always use its own model regardless of the
+runtime model selection propagated through RunOptions:
+
+```go
+agenttool.NewTool(subAgent,
+    agenttool.WithPinModel(true),
+)
+```
+
 ### Agent Transfer
 
 Agent Transfer implements task delegation between Agents through the `transfer_to_agent` tool, allowing the main Agent to automatically select appropriate SubAgents based on task type.

--- a/docs/mkdocs/zh/multiagent.md
+++ b/docs/mkdocs/zh/multiagent.md
@@ -622,6 +622,23 @@ if ev.Response != nil && ev.Object == model.ObjectTypeToolResponse {
 使用 `ResponseModeFinalOnly`。如果还希望在流式 UI 中隐藏子 Agent 的正文，
 再单独组合 `InnerTextModeExclude`。
 
+#### 模型钉住 (Pin Model)
+
+默认情况下，子 Agent 会继承调用方的 `RunOptions.ModelName`、
+`RunOptions.Model` 和 `RunOptions.ModelSelector`。这仅在调用方通过
+`agent.WithModelName(...)`、`agent.WithModel(...)` 或
+`agent.WithModelSelector(...)` 在 `runner.Run` 时指定了模型才会生效（例如 AGUI
+服务端转发终端用户的模型选择）。如果 RunOptions 中未设置模型，子 Agent 自然使用
+自己通过 `llmagent.WithModel` 配置的模型。
+
+当子 Agent 需要始终使用自己的模型，不受 RunOptions 传入的运行时模型选择的影响：
+
+```go
+agenttool.NewTool(subAgent,
+    agenttool.WithPinModel(true),
+)
+```
+
 ### Agent 委托 (Agent Transfer)
 
 Agent 委托通过 `transfer_to_agent` 工具实现 Agent 间的任务委托，允许主 Agent 根据任务类型自动选择合适的 SubAgent。

--- a/tool/agent/agent_tool.go
+++ b/tool/agent/agent_tool.go
@@ -43,6 +43,7 @@ type Tool struct {
 	historyScope           HistoryScope
 	persistentHistory      *persistentHistoryOptions
 	responseMode           ResponseMode
+	pinModel               bool
 	name                   string
 	description            string
 	inputSchema            *tool.Schema
@@ -73,6 +74,7 @@ type agentToolOptions struct {
 	responseMode           ResponseMode
 	description            *string
 	name                   *string
+	pinModel               bool
 
 	// Dynamic AgentTool options. They are only meaningful for NewDynamicTool;
 	// NewTool ignores them.
@@ -308,6 +310,28 @@ func WithPersistentHistoryKeyFunc(fn PersistentHistoryKeyFunc) Option {
 	}
 }
 
+// WithPinModel pins the sub-agent's model so that it always uses its own
+// configured model (set via llmagent.WithModel) regardless of the caller's
+// runtime model selection propagated through RunOptions.
+//
+// Background: when the caller passes agent.WithModelName(...),
+// agent.WithModel(...) or agent.WithModelSelector(...) at runner.Run time
+// (e.g., AGUI server forwarding the user's model choice), RunOptions
+// propagate to child invocations via Clone(). This causes the sub-agent's
+// own model to be overridden.
+//
+// WithPinModel(true) clears RunOptions.ModelName, RunOptions.Model and
+// RunOptions.ModelSelector for the child invocation so the sub-agent's
+// own model takes effect.
+//
+// If no Model/ModelName/ModelSelector is set in RunOptions, the sub-agent
+// naturally uses its own model regardless of this option.
+func WithPinModel(enabled bool) Option {
+	return func(opts *agentToolOptions) {
+		opts.pinModel = enabled
+	}
+}
+
 // NewTool creates a new Tool that wraps the given agent.
 //
 // Note: The tool name is derived from the agent's info (agent.Info().Name).
@@ -393,6 +417,7 @@ func NewTool(agent agent.Agent, opts ...Option) *Tool {
 		historyScope:           options.historyScope,
 		persistentHistory:      persistent,
 		responseMode:           normalizeResponseMode(options.responseMode),
+		pinModel:               options.pinModel,
 		name:                   name,
 		description:            description,
 		inputSchema:            inputSchema,
@@ -503,6 +528,18 @@ func (at *Tool) childInvocationOptions(
 	}
 	if parentInv == nil {
 		return invocationOpts
+	}
+	// When pinModel is set, clear the inherited model selection so the
+	// sub-agent's own model (configured via llmagent.WithModel) takes effect
+	// instead of the parent's runtime model selection.
+	if at.pinModel && (parentInv.RunOptions.ModelName != "" ||
+		parentInv.RunOptions.Model != nil ||
+		parentInv.RunOptions.ModelSelector != nil) {
+		clearedOpts := parentInv.RunOptions
+		clearedOpts.ModelName = ""
+		clearedOpts.Model = nil
+		clearedOpts.ModelSelector = nil
+		invocationOpts = append(invocationOpts, agent.WithInvocationRunOptions(clearedOpts))
 	}
 	if surfaceRootNodeID := at.surfaceRootNodeIDForParentInvocation(parentInv); surfaceRootNodeID != "" {
 		invocationOpts = append(

--- a/tool/agent/agent_tool_test.go
+++ b/tool/agent/agent_tool_test.go
@@ -4012,3 +4012,128 @@ func TestTool_StreamableCall_NilEvent(t *testing.T) {
 		t.Fatalf("expected non-nil content")
 	}
 }
+
+func TestTool_WithPinModel_Default(t *testing.T) {
+	mockAgent := &mockAgent{
+		name:        "test-agent",
+		description: "A test agent",
+	}
+	agentTool := NewTool(mockAgent)
+	if agentTool.pinModel {
+		t.Error("Expected pinModel to be false by default")
+	}
+}
+
+func TestTool_WithPinModel_Enabled(t *testing.T) {
+	mockAgent := &mockAgent{
+		name:        "test-agent",
+		description: "A test agent",
+	}
+	agentTool := NewTool(mockAgent, WithPinModel(true))
+	if !agentTool.pinModel {
+		t.Error("Expected pinModel to be true")
+	}
+}
+
+func TestTool_WithPinModel_ClearsModelName(t *testing.T) {
+	mockAgent := &mockAgent{
+		name:        "test-agent",
+		description: "A test agent",
+	}
+	agentTool := NewTool(mockAgent, WithPinModel(true))
+
+	parentInv := agent.NewInvocation(
+		agent.WithInvocationRunOptions(agent.RunOptions{
+			ModelName: "parent-model",
+		}),
+	)
+
+	opts := agentTool.childInvocationOptions(parentInv, model.NewUserMessage("test"), "child-key")
+
+	// Apply options to a new invocation to verify ModelName is cleared
+	childInv := parentInv.Clone(opts...)
+	if childInv.RunOptions.ModelName != "" {
+		t.Errorf("Expected ModelName to be cleared, got %q", childInv.RunOptions.ModelName)
+	}
+	if childInv.RunOptions.Model != nil {
+		t.Error("Expected Model to be nil")
+	}
+}
+
+func TestTool_WithPinModel_ClearsModel(t *testing.T) {
+	mockAgent := &mockAgent{
+		name:        "test-agent",
+		description: "A test agent",
+	}
+	agentTool := NewTool(mockAgent, WithPinModel(true))
+
+	parentInv := agent.NewInvocation(
+		agent.WithInvocationRunOptions(agent.RunOptions{
+			Model: &fixedResponseModel{},
+		}),
+	)
+
+	opts := agentTool.childInvocationOptions(parentInv, model.NewUserMessage("test"), "child-key")
+
+	childInv := parentInv.Clone(opts...)
+	if childInv.RunOptions.Model != nil {
+		t.Error("Expected Model to be nil when WithPinModel is enabled")
+	}
+}
+
+func TestTool_WithPinModel_ClearsModelSelector(t *testing.T) {
+	mockAgent := &mockAgent{
+		name:        "test-agent",
+		description: "A test agent",
+	}
+	agentTool := NewTool(mockAgent, WithPinModel(true))
+
+	selector := func(ctx context.Context, inv *agent.Invocation) (model.Model, error) {
+		return &fixedResponseModel{}, nil
+	}
+	parentInv := agent.NewInvocation(
+		agent.WithInvocationRunOptions(agent.RunOptions{
+			ModelSelector: selector,
+		}),
+	)
+
+	opts := agentTool.childInvocationOptions(parentInv, model.NewUserMessage("test"), "child-key")
+
+	childInv := parentInv.Clone(opts...)
+	if childInv.RunOptions.ModelSelector != nil {
+		t.Error("Expected ModelSelector to be nil when WithPinModel is enabled")
+	}
+}
+
+func TestTool_WithPinModel_Disabled_PreservesModelName(t *testing.T) {
+	mockAgent := &mockAgent{
+		name:        "test-agent",
+		description: "A test agent",
+	}
+	agentTool := NewTool(mockAgent, WithPinModel(false))
+
+	parentModel := &fixedResponseModel{}
+	parentSelector := func(ctx context.Context, inv *agent.Invocation) (model.Model, error) {
+		return &fixedResponseModel{}, nil
+	}
+	parentInv := agent.NewInvocation(
+		agent.WithInvocationRunOptions(agent.RunOptions{
+			ModelName:     "parent-model",
+			Model:         parentModel,
+			ModelSelector: parentSelector,
+		}),
+	)
+
+	opts := agentTool.childInvocationOptions(parentInv, model.NewUserMessage("test"), "child-key")
+
+	childInv := parentInv.Clone(opts...)
+	if childInv.RunOptions.ModelName != "parent-model" {
+		t.Errorf("Expected ModelName to be preserved, got %q", childInv.RunOptions.ModelName)
+	}
+	if childInv.RunOptions.Model != parentModel {
+		t.Error("Expected Model to be preserved when WithPinModel is disabled")
+	}
+	if childInv.RunOptions.ModelSelector == nil {
+		t.Error("Expected ModelSelector to be preserved when WithPinModel is disabled")
+	}
+}


### PR DESCRIPTION
## Summary

When a caller's `RunOptions.ModelName` / `RunOptions.Model` propagates to child invocations via `Clone()`, the sub-agent's own model (set via `llmagent.WithModel`) gets overridden. `WithPinModel(true)` clears the inherited model selection so the sub-agent always uses its own configured model.

Renamed from the original `WithUseOwnModel` based on design review feedback:
- "UseOwnModel" was confusing — implied that without the option the sub-agent never uses its own model
- "PinModel" better conveys "pin this config, resist external override"
- Establishes an extensible `WithPin*` pattern for future options (e.g., `WithPinInstruction`, `WithPinGenerationConfig`)

## Changes

- `tool/agent/agent_tool.go`: Add `WithPinModel(bool)` option, clear `RunOptions.ModelName` and `RunOptions.Model` for child invocation when enabled
- `tool/agent/agent_tool_test.go`: 5 test cases covering default/enabled/disabled/clears-model-name/clears-model
- `docs/mkdocs/{en,zh}/multiagent.md`: Add "Model Pinning" section

## Test plan

- [x] `TestTool_WithPinModel_Default` — pinModel is false by default
- [x] `TestTool_WithPinModel_Enabled` — option sets the flag
- [x] `TestTool_WithPinModel_ClearsModelName` — RunOptions.ModelName cleared for child
- [x] `TestTool_WithPinModel_ClearsModel` — RunOptions.Model cleared for child
- [x] `TestTool_WithPinModel_Disabled_PreservesModelName` — no clearing when disabled