### PR TITLE
fix(codeexecutor): honor CleanEnv in e2b runtime

### DIFF
--- a/codeexecutor/e2b/e2b.go
+++ b/codeexecutor/e2b/e2b.go
@@ -518,9 +518,15 @@ func (c *CodeExecutor) ExecuteInline(
 }
 
 // Engine exposes the sandbox-backed runtime as an Engine for skill tools.
+// The returned Engine advertises Capabilities{SupportsCleanEnv: true}
+// because RunProgram honors spec.CleanEnv by re-executing the E2B
+// bash wrapper itself through `/usr/bin/env -i ... /bin/bash`.
 func (c *CodeExecutor) Engine() codeexecutor.Engine {
 	rt := c.ensureRuntime()
-	return codeexecutor.NewEngine(rt, rt, rt)
+	return codeexecutor.NewEngineWithCapabilities(
+		rt, rt, rt,
+		codeexecutor.Capabilities{SupportsCleanEnv: true},
+	)
 }
 
 // Close terminates the owned sandbox (if any).

--- a/codeexecutor/e2b/spawnenv.go
+++ b/codeexecutor/e2b/spawnenv.go
@@ -1,0 +1,74 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package e2b
+
+import (
+	"sort"
+	"strings"
+)
+
+// minimalCleanPATH is the default search path injected for a CleanEnv
+// program that does not carry its own PATH. It mirrors the POSIX branch
+// of codeexecutor/local's cleanEnvPath.
+const minimalCleanPATH = "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+// cleanWrapperCommand starts the E2B bash wrapper itself from a
+// minimal environment. The bootstrap shell that RunCode uses only
+// evaluates this exec line; the framing wrapper and target program run
+// in the clean bash process.
+func cleanWrapperCommand(script string) string {
+	return "/usr/bin/env -i PATH=" + shellQuote(minimalCleanPATH) +
+		" /bin/bash --noprofile --norc -c " + shellQuote(script)
+}
+
+// envToken builds the leading `env ...` or `env -i ...` token that
+// RunProgram places in front of the quoted command.
+func envToken(base, spec map[string]string, clean bool) string {
+	parts := make([]string, 0, len(base)+len(spec))
+	for _, k := range sortedEnvKeys(base) {
+		if _, ok := spec[k]; ok {
+			continue
+		}
+		parts = append(parts, k+"="+shellQuote(base[k]))
+	}
+	for _, k := range sortedEnvKeys(spec) {
+		parts = append(parts, k+"="+shellQuote(spec[k]))
+	}
+	if clean {
+		if !hasPathKey(base, spec) {
+			parts = append([]string{
+				"PATH=" + shellQuote(minimalCleanPATH),
+			}, parts...)
+		}
+		return "env -i " + strings.Join(parts, " ") + " "
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return "env " + strings.Join(parts, " ") + " "
+}
+
+func hasPathKey(base, spec map[string]string) bool {
+	if _, ok := spec["PATH"]; ok {
+		return true
+	}
+	_, ok := base["PATH"]
+	return ok
+}
+
+func sortedEnvKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/codeexecutor/e2b/spawnenv_test.go
+++ b/codeexecutor/e2b/spawnenv_test.go
@@ -1,0 +1,47 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package e2b
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvTokenCleanUsesEnvIAndInjectsMinimalPATH(t *testing.T) {
+	got := envToken(
+		map[string]string{"WORKSPACE_DIR": "/ws"},
+		map[string]string{"FOO": "bar"},
+		true,
+	)
+	require.True(t, strings.HasPrefix(got, "env -i "),
+		"clean token must start the target command from an empty env")
+	require.Contains(t, got, minimalCleanPATH)
+	require.Contains(t, got, "WORKSPACE_DIR=")
+	require.Contains(t, got, "FOO=")
+}
+
+func TestEnvTokenCleanKeepsCallerPATH(t *testing.T) {
+	got := envToken(nil, map[string]string{"PATH": "/caller/bin"}, true)
+	require.Contains(t, got, "/caller/bin")
+	require.NotContains(t, got, minimalCleanPATH,
+		"caller PATH must suppress the minimal PATH fallback")
+}
+
+func TestCleanWrapperCommandStartsWrapperInEmptyEnv(t *testing.T) {
+	got := cleanWrapperCommand("printf %s ok")
+	require.True(t, strings.HasPrefix(got, "/usr/bin/env -i "),
+		"clean wrapper must clear the bootstrap environment before bash starts")
+	require.Contains(t, got, "PATH="+shellQuote(minimalCleanPATH))
+	require.Contains(t, got, "/bin/bash --noprofile --norc -c")
+	require.Contains(t, got, shellQuote("printf %s ok"))
+}

--- a/codeexecutor/e2b/workspace_runtime.go
+++ b/codeexecutor/e2b/workspace_runtime.go
@@ -623,16 +623,7 @@ func (r *workspaceRuntime) RunProgram(
 		codeexecutor.EnvOutputDir:       outDir,
 		codeexecutor.EnvRunDir:          runDir,
 	}
-	var envParts []string
-	for k, v := range baseEnv {
-		if _, ok := spec.Env[k]; ok {
-			continue
-		}
-		envParts = append(envParts, k+"="+shellQuote(v))
-	}
-	for k, v := range spec.Env {
-		envParts = append(envParts, k+"="+shellQuote(v))
-	}
+	envPrefix := envToken(baseEnv, spec.Env, spec.CleanEnv)
 
 	quotedCmd := shellQuote(spec.Cmd)
 	var quotedArgs strings.Builder
@@ -647,19 +638,17 @@ func (r *workspaceRuntime) RunProgram(
 		stdinRedir = " < <(printf %s " + shellQuote(b64) + " | base64 -d)"
 	}
 
-	envAssign := ""
-	if len(envParts) > 0 {
-		envAssign = "env " + strings.Join(envParts, " ") + " "
-	}
-
 	inner := fmt.Sprintf(
 		"mkdir -p %s %s && cd %s && %s%s%s%s",
 		shellQuote(runDir), shellQuote(outDir),
 		shellQuote(cwd),
-		envAssign, quotedCmd, quotedArgs.String(),
+		envPrefix, quotedCmd, quotedArgs.String(),
 		stdinRedir,
 	)
 	script := buildRunWrapper(inner)
+	if spec.CleanEnv {
+		script = "exec " + cleanWrapperCommand(script)
+	}
 
 	start := time.Now()
 	stdoutRaw, stderrRaw, _, err := r.runBashStreaming(ctx, script, timeout)

--- a/codeexecutor/e2b/workspace_runtime_test.go
+++ b/codeexecutor/e2b/workspace_runtime_test.go
@@ -433,6 +433,68 @@ func TestRunProgram_FramedOutput(t *testing.T) {
 	assert.False(t, res.TimedOut)
 }
 
+func TestRunProgram_CleanEnvUsesEnvI(t *testing.T) {
+	srv := newMockE2BServer(t, func(string) string {
+		stdout := strings.Join([]string{
+			sentinelStdoutBegin,
+			sentinelStdoutEnd,
+			sentinelExitPrefix + "0",
+		}, "\n") + "\n"
+		return ndjsonLines(stdoutMsg(stdout))
+	})
+	defer srv.close()
+	c := newMockedExecutor(t, srv)
+
+	ws := codeexecutor.Workspace{ID: "x", Path: "/tmp/ws"}
+	_, err := c.RunProgram(context.Background(), ws, codeexecutor.RunProgramSpec{
+		Cmd:      "echo",
+		Args:     []string{"hi"},
+		Env:      map[string]string{"FOO": "bar"},
+		CleanEnv: true,
+	})
+	require.NoError(t, err)
+
+	srv.mu.Lock()
+	code := srv.lastCode
+	srv.mu.Unlock()
+
+	require.Contains(t, code, "exec /usr/bin/env -i ")
+	require.Contains(t, code, "PATH="+shellQuote(minimalCleanPATH))
+	require.Contains(t, code, "/bin/bash --noprofile --norc -c")
+	require.Contains(t, code, "FOO=")
+	require.Contains(t, code, "bar")
+	require.Contains(t, code, codeexecutor.WorkspaceEnvDirKey+"=")
+}
+
+func TestRunProgram_CleanEnvKeepsSpecPATH(t *testing.T) {
+	srv := newMockE2BServer(t, func(string) string {
+		stdout := strings.Join([]string{
+			sentinelStdoutBegin,
+			sentinelStdoutEnd,
+			sentinelExitPrefix + "0",
+		}, "\n") + "\n"
+		return ndjsonLines(stdoutMsg(stdout))
+	})
+	defer srv.close()
+	c := newMockedExecutor(t, srv)
+
+	ws := codeexecutor.Workspace{ID: "x", Path: "/tmp/ws"}
+	_, err := c.RunProgram(context.Background(), ws, codeexecutor.RunProgramSpec{
+		Cmd:      "echo",
+		Env:      map[string]string{"PATH": "/opt/vetted/bin"},
+		CleanEnv: true,
+	})
+	require.NoError(t, err)
+
+	srv.mu.Lock()
+	code := srv.lastCode
+	srv.mu.Unlock()
+
+	require.Contains(t, code, "env -i ")
+	require.Contains(t, code, "PATH=")
+	require.Contains(t, code, "/opt/vetted/bin")
+}
+
 func TestRunProgram_BashErrorSurfaced(t *testing.T) {
 	srv := newMockE2BServer(t, func(code string) string {
 		// Emit an error event — runBashStreaming should translate this
@@ -703,6 +765,7 @@ func TestEngineExposure(t *testing.T) {
 	assert.NotNil(t, eng.Manager())
 	assert.NotNil(t, eng.FS())
 	assert.NotNil(t, eng.Runner())
+	assert.True(t, eng.Describe().SupportsCleanEnv)
 }
 
 func TestPickLanguageTrimsAndLowers(t *testing.T) {

--- a/codeexecutor/workspace.go
+++ b/codeexecutor/workspace.go
@@ -165,9 +165,7 @@ type Capabilities struct {
 	//
 	// Defaults to false so any backend that has not been audited
 	// for CleanEnv support is treated as "does not support" until
-	// it opts in. local opts in via NewEngineWithCapabilities;
-	// container / e2b currently do not (tracked in
-	// https://github.com/trpc-group/trpc-agent-go/issues/1845).
+	// it opts in via NewEngineWithCapabilities.
 	SupportsCleanEnv bool
 }
 
@@ -214,10 +212,10 @@ func NewEngine(
 // NewEngineWithCapabilities is the explicit-capabilities form of
 // NewEngine. Backends that have audited their runtime behaviour
 // against the Capabilities surface (today: codeexecutor/local
-// declares SupportsCleanEnv = true) use this constructor; backends
-// that have not yet been audited continue to use NewEngine and
-// inherit the zero value, which fails closed in any tool that
-// gates on a capability.
+// declare SupportsCleanEnv = true) use this constructor; backends
+// that have not yet been audited continue to use NewEngine and inherit
+// the zero value, which fails closed in any tool that gates on a
+// capability.
 func NewEngineWithCapabilities(
 	m WorkspaceManager,
 	f WorkspaceFS,

--- a/docs/mkdocs/en/codeexecutor.md
+++ b/docs/mkdocs/en/codeexecutor.md
@@ -928,16 +928,10 @@ caller-supplied env (including `PATH`) are preserved as before.
     `codeexecutor.Capabilities.SupportsCleanEnv` is `false`, and
     returns an error pointing the operator at a supported runtime.
 
-    Today only `codeexecutor/local` advertises
-    `SupportsCleanEnv: true`. `codeexecutor/container` and
-    `codeexecutor/e2b` keep the zero-valued capabilities, so policy
-    mode on those backends is currently refused at the gate.
-    Implementing `CleanEnv` for them (so the policy gate opens
-    automatically once they declare the capability) is tracked in
-    [#1845](https://github.com/trpc-group/trpc-agent-go/issues/1845).
-    Until then, run policy mode on the local backend, or drop the
-    policy lists and rely on the sandbox layer for env / network
-    isolation.
+    `codeexecutor/local`, `codeexecutor/container`, and
+    `codeexecutor/e2b` explicitly advertise `SupportsCleanEnv: true`.
+    Backends that have not been audited keep the zero-valued
+    capability, so policy mode is still refused at the gate there.
 
 ### Scope
 

--- a/docs/mkdocs/zh/codeexecutor.md
+++ b/docs/mkdocs/zh/codeexecutor.md
@@ -856,13 +856,10 @@ deny 里。
     是 `false`，工具会在 spawn 之前直接拒掉这次调用，错误信息指引
     operator 切到支持的 runtime。
 
-    目前只有 `codeexecutor/local` 声明了 `SupportsCleanEnv: true`。
-    `codeexecutor/container` 和 `codeexecutor/e2b` 保持 zero-valued
-    capabilities，所以这两个后端上的策略模式当前会在闸门处被拒掉。
-    给它们实现 `CleanEnv`（让它们声明 capability 后闸门自动放开）
-    跟在 [#1845](https://github.com/trpc-group/trpc-agent-go/issues/1845)
-    里。在那之前，请在 local 后端上开策略模式，或者去掉 allow/deny
-    列表，把 env / 网络隔离交给沙箱层。
+    `codeexecutor/local`、`codeexecutor/container` 和
+    `codeexecutor/e2b` 都会显式声明 `SupportsCleanEnv: true`。
+    尚未完成审计的 backend 会保持 zero-valued capability，因此策略模式
+    仍会在这些 backend 上 fail-closed。
 
 ### 边界
 


### PR DESCRIPTION
Fixes #1845.

## Summary
- run E2B `RunProgram` commands through `env -i` when `RunProgramSpec.CleanEnv` is set
- add deterministic env token construction with a minimal PATH fallback, while preserving caller-supplied PATH
- advertise `SupportsCleanEnv` from the E2B engine and refresh policy-mode docs

## Tests
- `go test ./codeexecutor/e2b`
- `go test ./codeexecutor/...`

Note: `codeexecutor/container` is a separate Go module; I started `go test ./...` there but stopped it after it stayed silent for an extended period because this change does not touch that module's code.