### PR TITLE
{steer, llmflow, runner, server/agui}: add steer queue cancel signal

### DIFF
--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -356,6 +356,12 @@ func (f *Flow) maybeConsumeQueuedUserMessages(
 					Message: message,
 				}},
 			},
+			event.WithExtension(
+				steer.ExtensionKeyQueuedUserMessage,
+				steer.QueuedUserMessageMetadata{
+					Status: steer.QueuedUserMessageStatusConsumed,
+				},
+			),
 		)
 		evt.RequiresCompletion = true
 

--- a/internal/flow/llmflow/llmflow_test.go
+++ b/internal/flow/llmflow/llmflow_test.go
@@ -270,6 +270,13 @@ func TestMaybeConsumeQueuedUserMessages_DrainsInOrder(t *testing.T) {
 			require.NotNil(t, evt)
 			require.Equal(t, queuedUserAuthor, evt.Author)
 			require.True(t, evt.RequiresCompletion)
+			meta, ok, err := event.GetExtension[steer.QueuedUserMessageMetadata](
+				evt,
+				steer.ExtensionKeyQueuedUserMessage,
+			)
+			require.NoError(t, err)
+			require.True(t, ok)
+			require.Equal(t, steer.QueuedUserMessageStatusConsumed, meta.Status)
 			require.Equal(
 				t,
 				[]string{"first", "second"}[i],

--- a/internal/state/steer/steer.go
+++ b/internal/state/steer/steer.go
@@ -22,6 +22,21 @@ import (
 // StateKeyQueuedUserMessages is the invocation state key used by Attach.
 const StateKeyQueuedUserMessages = "__queued_user_messages__"
 
+const (
+	// ExtensionKeyQueuedUserMessage marks events emitted when queued user
+	// messages are consumed at a safe boundary.
+	ExtensionKeyQueuedUserMessage = "trpc_agent.steer.queued_user_message"
+
+	// QueuedUserMessageStatusConsumed is the status for consumed queued
+	// user-message events.
+	QueuedUserMessageStatusConsumed = "consumed"
+)
+
+// QueuedUserMessageMetadata describes the queued user-message event state.
+type QueuedUserMessageMetadata struct {
+	Status string `json:"status"`
+}
+
 // Queue stores queued user messages in FIFO order.
 type Queue struct {
 	mu       sync.Mutex
@@ -63,6 +78,22 @@ func (q *Queue) Drain() []model.Message {
 	drained := append([]model.Message(nil), q.messages...)
 	q.messages = nil
 	return drained
+}
+
+// Discard removes all queued messages without closing the queue.
+func (q *Queue) Discard() []model.Message {
+	if q == nil {
+		return nil
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if len(q.messages) == 0 {
+		return nil
+	}
+	discarded := append([]model.Message(nil), q.messages...)
+	q.messages = nil
+	return discarded
 }
 
 // Close rejects future enqueues.

--- a/internal/state/steer/steer_test.go
+++ b/internal/state/steer/steer_test.go
@@ -10,6 +10,7 @@
 package steer
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -17,6 +18,21 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 )
+
+func TestQueuedUserMessageWireValues(t *testing.T) {
+	require.Equal(
+		t,
+		"trpc_agent.steer.queued_user_message",
+		ExtensionKeyQueuedUserMessage,
+	)
+	require.Equal(t, "consumed", QueuedUserMessageStatusConsumed)
+
+	payload, err := json.Marshal(QueuedUserMessageMetadata{
+		Status: QueuedUserMessageStatusConsumed,
+	})
+	require.NoError(t, err)
+	require.JSONEq(t, `{"status":"consumed"}`, string(payload))
+}
 
 func TestQueue_FIFOAndClose(t *testing.T) {
 	queue := NewQueue()

--- a/internal/state/steer/steer_test.go
+++ b/internal/state/steer/steer_test.go
@@ -73,6 +73,25 @@ func TestClose_RejectsFutureEnqueueAndPreservesQueuedMessages(t *testing.T) {
 	require.Equal(t, "hello", drained[0].Content)
 }
 
+func TestQueue_DiscardClearsQueuedMessagesWithoutClosing(t *testing.T) {
+	queue := NewQueue()
+
+	require.Nil(t, queue.Discard())
+	require.True(t, queue.Enqueue(model.NewUserMessage("one")))
+	require.True(t, queue.Enqueue(model.NewUserMessage("two")))
+
+	discarded := queue.Discard()
+	require.Len(t, discarded, 2)
+	require.Equal(t, "one", discarded[0].Content)
+	require.Equal(t, "two", discarded[1].Content)
+	require.Nil(t, queue.Drain())
+
+	require.True(t, queue.Enqueue(model.NewUserMessage("three")))
+	drained := queue.Drain()
+	require.Len(t, drained, 1)
+	require.Equal(t, "three", drained[0].Content)
+}
+
 func TestNilSafety(t *testing.T) {
 	var (
 		invocation *agent.Invocation
@@ -83,6 +102,7 @@ func TestNilSafety(t *testing.T) {
 	require.False(t, IsAttached(invocation))
 	require.False(t, queue.Enqueue(model.NewUserMessage("x")))
 	require.Nil(t, queue.Drain())
+	require.Nil(t, queue.Discard())
 	queue.Close()
 	Clear(invocation)
 	require.Nil(t, Drain(invocation))

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -3192,7 +3192,44 @@ func normalizeQueuedUserMessage(
 	if message.Role != model.RoleUser || !model.HasPayload(message) {
 		return model.Message{}, ErrInvalidQueuedUserMessage
 	}
+	if !queuedUserMessageContentPartsSupported(message.ContentParts) {
+		return model.Message{}, ErrInvalidQueuedUserMessage
+	}
 	return message, nil
+}
+
+func queuedUserMessageContentPartsSupported(parts []model.ContentPart) bool {
+	for _, part := range parts {
+		switch part.Type {
+		case model.ContentTypeText:
+			if part.Text == nil {
+				return false
+			}
+		case model.ContentTypeImage:
+			if part.Image == nil {
+				return false
+			}
+			if strings.TrimSpace(part.Image.URL) == "" && len(part.Image.Data) == 0 {
+				return false
+			}
+		case model.ContentTypeAudio:
+			if part.Audio == nil || len(part.Audio.Data) == 0 {
+				return false
+			}
+		case model.ContentTypeFile:
+			if part.File == nil {
+				return false
+			}
+			if strings.TrimSpace(part.File.FileID) == "" &&
+				strings.TrimSpace(part.File.URL) == "" &&
+				len(part.File.Data) == 0 {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // ensureErrorEventContent ensures that error events have valid content.

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -211,6 +211,18 @@ type SteerableRunner interface {
 
 	// EnqueueUserMessage queues a user message for the active request.
 	EnqueueUserMessage(requestID string, message model.Message) error
+
+	// CancelQueuedUserMessages discards user messages that are queued but not
+	// yet consumed for the active request.
+	CancelQueuedUserMessages(requestID string) bool
+}
+
+type queuedUserMessageEnqueuer interface {
+	EnqueueUserMessage(requestID string, message model.Message) error
+}
+
+type queuedUserMessagesCanceler interface {
+	CancelQueuedUserMessages(requestID string) bool
 }
 
 // EnqueueUserMessage queues a user message on runners that support steering.
@@ -219,11 +231,21 @@ func EnqueueUserMessage(
 	requestID string,
 	message model.Message,
 ) error {
-	steerable, ok := r.(SteerableRunner)
+	steerable, ok := r.(queuedUserMessageEnqueuer)
 	if !ok {
 		return ErrQueuedUserMessageUnsupported
 	}
 	return steerable.EnqueueUserMessage(requestID, message)
+}
+
+// CancelQueuedUserMessages discards queued user messages on runners that
+// support steering.
+func CancelQueuedUserMessages(r Runner, requestID string) bool {
+	steerable, ok := r.(queuedUserMessagesCanceler)
+	if !ok {
+		return false
+	}
+	return steerable.CancelQueuedUserMessages(requestID)
 }
 
 // RunStatus is a snapshot of a running invocation.
@@ -783,6 +805,15 @@ func (r *runner) EnqueueUserMessage(
 		return ErrRunNotFound
 	}
 	return nil
+}
+
+func (r *runner) CancelQueuedUserMessages(requestID string) bool {
+	handle := r.lookupRun(requestID)
+	if handle == nil || handle.queue == nil {
+		return false
+	}
+	handle.queue.Discard()
+	return true
 }
 
 func (r *runner) newExecutionContext(

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -213,7 +213,10 @@ type SteerableRunner interface {
 	EnqueueUserMessage(requestID string, message model.Message) error
 }
 
-// QueuedUserMessagesCanceler supports discarding queued user messages.
+// QueuedUserMessagesCanceler is an optional capability detected by the
+// package-level CancelQueuedUserMessages helper. It is intentionally independent
+// from SteerableRunner so existing steerable runner implementations remain
+// compatible.
 type QueuedUserMessagesCanceler interface {
 	// CancelQueuedUserMessages discards user messages that are queued but not
 	// yet consumed for the active request.
@@ -225,6 +228,8 @@ type queuedUserMessageEnqueuer interface {
 }
 
 // EnqueueUserMessage queues a user message on runners that support steering.
+// The helper detects the EnqueueUserMessage method directly, so custom runners
+// do not need to satisfy SteerableRunner by name.
 func EnqueueUserMessage(
 	r Runner,
 	requestID string,

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -211,7 +211,10 @@ type SteerableRunner interface {
 
 	// EnqueueUserMessage queues a user message for the active request.
 	EnqueueUserMessage(requestID string, message model.Message) error
+}
 
+// QueuedUserMessagesCanceler supports discarding queued user messages.
+type QueuedUserMessagesCanceler interface {
 	// CancelQueuedUserMessages discards user messages that are queued but not
 	// yet consumed for the active request.
 	CancelQueuedUserMessages(requestID string) bool
@@ -219,10 +222,6 @@ type SteerableRunner interface {
 
 type queuedUserMessageEnqueuer interface {
 	EnqueueUserMessage(requestID string, message model.Message) error
-}
-
-type queuedUserMessagesCanceler interface {
-	CancelQueuedUserMessages(requestID string) bool
 }
 
 // EnqueueUserMessage queues a user message on runners that support steering.
@@ -241,11 +240,11 @@ func EnqueueUserMessage(
 // CancelQueuedUserMessages discards queued user messages on runners that
 // support steering.
 func CancelQueuedUserMessages(r Runner, requestID string) bool {
-	steerable, ok := r.(queuedUserMessagesCanceler)
+	cancelable, ok := r.(QueuedUserMessagesCanceler)
 	if !ok {
 		return false
 	}
-	return steerable.CancelQueuedUserMessages(requestID)
+	return cancelable.CancelQueuedUserMessages(requestID)
 }
 
 // RunStatus is a snapshot of a running invocation.

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -451,6 +451,33 @@ func TestEnqueueUserMessage_Errors(t *testing.T) {
 	err = EnqueueUserMessage(
 		r,
 		"req-1",
+		model.Message{
+			Role: model.RoleUser,
+			ContentParts: []model.ContentPart{{
+				Type:  model.ContentTypeImage,
+				Image: &model.Image{URL: " "},
+			}},
+		},
+	)
+	require.ErrorIs(t, err, ErrInvalidQueuedUserMessage)
+
+	textPart := "hello from part"
+	err = EnqueueUserMessage(
+		r,
+		"req-1",
+		model.Message{
+			Role: model.RoleUser,
+			ContentParts: []model.ContentPart{{
+				Type: model.ContentTypeText,
+				Text: &textPart,
+			}},
+		},
+	)
+	require.ErrorIs(t, err, ErrRunNotFound)
+
+	err = EnqueueUserMessage(
+		r,
+		"req-1",
 		model.NewUserMessage("hello"),
 	)
 	require.ErrorIs(t, err, ErrRunNotFound)

--- a/runner/steer_cancel_test.go
+++ b/runner/steer_cancel_test.go
@@ -175,7 +175,9 @@ func (r *enqueueOnlyRunner) Run(
 	model.Message,
 	...agent.RunOption,
 ) (<-chan *event.Event, error) {
-	return nil, nil
+	events := make(chan *event.Event)
+	close(events)
+	return events, nil
 }
 
 func (r *enqueueOnlyRunner) Close() error {

--- a/runner/steer_cancel_test.go
+++ b/runner/steer_cancel_test.go
@@ -1,0 +1,151 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package runner
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+	"trpc.group/trpc-go/trpc-agent-go/tool/function"
+)
+
+func TestRunner_CancelQueuedUserMessages_DiscardsPendingAndKeepsQueueOpen(t *testing.T) {
+	const (
+		appName        = "runner-steer-cancel"
+		userID         = "user-1"
+		sessionID      = "session-1"
+		requestID      = "req-steer-cancel"
+		toolName       = "lookup"
+		initialMessage = "Search alpha"
+		discardedSteer = "Ignore this queued steer"
+		keptSteer      = "Keep this queued steer"
+		finalAnswer    = "done"
+	)
+
+	type lookupInput struct {
+		Topic string `json:"topic"`
+	}
+	type lookupOutput struct {
+		Result string `json:"result"`
+	}
+
+	modelStub := &sequentialModel{
+		name: "sequential-steer-cancel-model",
+		responses: []*model.Response{
+			{
+				ID:   "resp-tool-call",
+				Done: true,
+				Choices: []model.Choice{{
+					Index: 0,
+					Message: model.Message{
+						Role: model.RoleAssistant,
+						ToolCalls: []model.ToolCall{{
+							ID:   "tool-call-1",
+							Type: "function",
+							Function: model.FunctionDefinitionParam{
+								Name:      toolName,
+								Arguments: []byte(`{"topic":"alpha"}`),
+							},
+						}},
+					},
+				}},
+			},
+			{
+				ID:   "resp-final",
+				Done: true,
+				Choices: []model.Choice{{
+					Index:   0,
+					Message: model.NewAssistantMessage(finalAnswer),
+				}},
+			},
+		},
+	}
+
+	var (
+		runnerInstance Runner
+		firstErr       error
+		secondErr      error
+		cancelMissing  bool
+		cancelOK       bool
+	)
+
+	toolImpl := function.NewFunctionTool(
+		func(_ context.Context, input lookupInput) (lookupOutput, error) {
+			firstErr = EnqueueUserMessage(
+				runnerInstance,
+				requestID,
+				model.NewUserMessage(discardedSteer),
+			)
+			cancelMissing = CancelQueuedUserMessages(
+				runnerInstance,
+				"missing-request",
+			)
+			cancelOK = CancelQueuedUserMessages(runnerInstance, requestID)
+			secondErr = EnqueueUserMessage(
+				runnerInstance,
+				requestID,
+				model.NewUserMessage(keptSteer),
+			)
+			return lookupOutput{Result: "tool result for " + input.Topic}, nil
+		},
+		function.WithName(toolName),
+		function.WithDescription("Looks up a topic"),
+	)
+
+	ag := llmagent.New(
+		"steer-cancel-agent",
+		llmagent.WithModel(modelStub),
+		llmagent.WithTools([]tool.Tool{toolImpl}),
+	)
+
+	runnerInstance = NewRunner(appName, ag)
+	events, err := runnerInstance.Run(
+		context.Background(),
+		userID,
+		sessionID,
+		model.NewUserMessage(initialMessage),
+		agent.WithRequestID(requestID),
+	)
+	require.NoError(t, err)
+
+	for range events {
+	}
+
+	require.NoError(t, firstErr)
+	require.False(t, cancelMissing)
+	require.True(t, cancelOK)
+	require.NoError(t, secondErr)
+
+	requests := modelStub.Requests()
+	require.Len(t, requests, 2)
+	secondRequest := requests[1]
+	require.NotNil(t, secondRequest)
+
+	discardedIdx := findMessageIndex(
+		secondRequest.messages,
+		func(message model.Message) bool {
+			return message.Role == model.RoleUser &&
+				message.Content == discardedSteer
+		},
+	)
+	keptIdx := findMessageIndex(
+		secondRequest.messages,
+		func(message model.Message) bool {
+			return message.Role == model.RoleUser &&
+				message.Content == keptSteer
+		},
+	)
+	require.Equal(t, -1, discardedIdx)
+	require.NotEqual(t, -1, keptIdx)
+}

--- a/runner/steer_cancel_test.go
+++ b/runner/steer_cancel_test.go
@@ -15,10 +15,24 @@ import (
 	"github.com/stretchr/testify/require"
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 	"trpc.group/trpc-go/trpc-agent-go/tool/function"
 )
+
+func TestCancelQueuedUserMessages_LeavesEnqueueOnlyRunnerCompatible(t *testing.T) {
+	r := &enqueueOnlyRunner{}
+
+	err := EnqueueUserMessage(
+		r,
+		"req-enqueue-only",
+		model.NewUserMessage("hello"),
+	)
+	require.NoError(t, err)
+	require.False(t, CancelQueuedUserMessages(r, "req-enqueue-only"))
+	require.Len(t, r.messages, 1)
+}
 
 func TestRunner_CancelQueuedUserMessages_DiscardsPendingAndKeepsQueueOpen(t *testing.T) {
 	const (
@@ -148,4 +162,30 @@ func TestRunner_CancelQueuedUserMessages_DiscardsPendingAndKeepsQueueOpen(t *tes
 	)
 	require.Equal(t, -1, discardedIdx)
 	require.NotEqual(t, -1, keptIdx)
+}
+
+type enqueueOnlyRunner struct {
+	messages []model.Message
+}
+
+func (r *enqueueOnlyRunner) Run(
+	context.Context,
+	string,
+	string,
+	model.Message,
+	...agent.RunOption,
+) (<-chan *event.Event, error) {
+	return nil, nil
+}
+
+func (r *enqueueOnlyRunner) Close() error {
+	return nil
+}
+
+func (r *enqueueOnlyRunner) EnqueueUserMessage(
+	_ string,
+	message model.Message,
+) error {
+	r.messages = append(r.messages, message)
+	return nil
 }

--- a/server/agui/internal/steerext/steerext.go
+++ b/server/agui/internal/steerext/steerext.go
@@ -1,0 +1,30 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+// Package steerext defines AG-UI-local queued steer extension metadata.
+//
+// Keep these wire-format values local to the standalone AG-UI module. Importing
+// root internal steer symbols would force published consumers to depend on a
+// root module version that already contains those newer symbols.
+package steerext
+
+const (
+	// QueuedUserMessageExtensionKey marks events emitted when queued user
+	// messages are consumed at a safe boundary.
+	QueuedUserMessageExtensionKey = "trpc_agent.steer.queued_user_message"
+
+	// QueuedUserMessageStatusConsumed is the status for consumed queued
+	// user-message events.
+	QueuedUserMessageStatusConsumed = "consumed"
+)
+
+// QueuedUserMessageMetadata describes the queued user-message event state.
+type QueuedUserMessageMetadata struct {
+	Status string `json:"status"`
+}

--- a/server/agui/internal/steerext/steerext_test.go
+++ b/server/agui/internal/steerext/steerext_test.go
@@ -1,0 +1,32 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package steerext
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueuedUserMessageWireValues(t *testing.T) {
+	require.Equal(
+		t,
+		"trpc_agent.steer.queued_user_message",
+		QueuedUserMessageExtensionKey,
+	)
+	require.Equal(t, "consumed", QueuedUserMessageStatusConsumed)
+
+	payload, err := json.Marshal(QueuedUserMessageMetadata{
+		Status: QueuedUserMessageStatusConsumed,
+	})
+	require.NoError(t, err)
+	require.JSONEq(t, `{"status":"consumed"}`, string(payload))
+}

--- a/server/agui/runner/steer_test.go
+++ b/server/agui/runner/steer_test.go
@@ -1,0 +1,97 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package runner
+
+import (
+	"context"
+	"testing"
+
+	aguievents "github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/events"
+	"github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	agentevent "trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/steer"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
+	"trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+)
+
+func TestRunQueuedUserMessageConsumedTrackedInMessagesSnapshot(t *testing.T) {
+	sessionService := inmemory.NewSessionService()
+	queued := agentevent.NewResponseEvent("inv-1", "user", &model.Response{
+		ID: "queued-user-1",
+		Choices: []model.Choice{{
+			Message: model.NewUserMessage("Only use the first three chapters"),
+		}},
+	})
+	queued.ID = "event-queued-user-1"
+	queued.RequestID = "request-1"
+	require.NoError(t, agentevent.SetExtension(
+		queued,
+		steer.ExtensionKeyQueuedUserMessage,
+		steer.QueuedUserMessageMetadata{
+			Status: steer.QueuedUserMessageStatusConsumed,
+		},
+	))
+	completion := agentevent.NewResponseEvent("inv-1", "agui.runner", &model.Response{
+		ID:     "runner-completion-1",
+		Object: model.ObjectTypeRunnerCompletion,
+		Done:   true,
+	})
+	agentEvents := make(chan *agentevent.Event, 2)
+	agentEvents <- queued
+	agentEvents <- completion
+	close(agentEvents)
+
+	underlying := &fakeRunner{
+		run: func(context.Context, string, string, model.Message, ...agent.RunOption) (<-chan *agentevent.Event, error) {
+			return agentEvents, nil
+		},
+	}
+	rr, ok := New(
+		underlying,
+		WithAppName("demo"),
+		WithSessionService(sessionService),
+	).(*runner)
+	require.True(t, ok)
+
+	eventsCh, err := rr.Run(context.Background(), &adapter.RunAgentInput{
+		ThreadID: "thread",
+		RunID:    "run",
+		Messages: []types.Message{{Role: types.RoleUser, Content: "Analyze the report"}},
+	})
+	require.NoError(t, err)
+	events := collectEvents(t, eventsCh)
+
+	var consumed *aguievents.ActivitySnapshotEvent
+	for _, evt := range events {
+		activity, ok := evt.(*aguievents.ActivitySnapshotEvent)
+		if ok && activity.ActivityType == "steer.consumed" {
+			consumed = activity
+			break
+		}
+	}
+	require.NotNil(t, consumed)
+	assert.Equal(t, "activity-steer-consumed-queued-user-1", consumed.MessageID)
+
+	snapshotMessages := loadSnapshotMessages(t, rr)
+	var foundQueuedUser bool
+	for _, msg := range snapshotMessages {
+		if msg.Role != types.RoleUser {
+			continue
+		}
+		if toolSnapshotContentString(t, msg) == "Only use the first three chapters" {
+			foundQueuedUser = true
+			break
+		}
+	}
+	require.True(t, foundQueuedUser)
+}

--- a/server/agui/runner/steer_test.go
+++ b/server/agui/runner/steer_test.go
@@ -10,6 +10,7 @@ package runner
 
 import (
 	"context"
+	"encoding/base64"
 	"testing"
 
 	aguievents "github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/events"
@@ -18,9 +19,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	agentevent "trpc.group/trpc-go/trpc-agent-go/event"
-	"trpc.group/trpc-go/trpc-agent-go/internal/state/steer"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
+	"trpc.group/trpc-go/trpc-agent-go/server/agui/internal/steerext"
 	"trpc.group/trpc-go/trpc-agent-go/session/inmemory"
 )
 
@@ -36,9 +37,9 @@ func TestRunQueuedUserMessageConsumedTrackedInMessagesSnapshot(t *testing.T) {
 	queued.RequestID = "request-1"
 	require.NoError(t, agentevent.SetExtension(
 		queued,
-		steer.ExtensionKeyQueuedUserMessage,
-		steer.QueuedUserMessageMetadata{
-			Status: steer.QueuedUserMessageStatusConsumed,
+		steerext.QueuedUserMessageExtensionKey,
+		steerext.QueuedUserMessageMetadata{
+			Status: steerext.QueuedUserMessageStatusConsumed,
 		},
 	))
 	completion := agentevent.NewResponseEvent("inv-1", "agui.runner", &model.Response{
@@ -92,6 +93,99 @@ func TestRunQueuedUserMessageConsumedTrackedInMessagesSnapshot(t *testing.T) {
 			foundQueuedUser = true
 			break
 		}
+	}
+	require.True(t, foundQueuedUser)
+}
+
+func TestRunQueuedUserMessageContentPartsTrackedInMessagesSnapshot(t *testing.T) {
+	sessionService := inmemory.NewSessionService()
+	text := "图中有哪些信息?"
+	queued := agentevent.NewResponseEvent("inv-1", "user", &model.Response{
+		ID: "queued-user-multimodal",
+		Choices: []model.Choice{{
+			Message: model.Message{
+				Role: model.RoleUser,
+				ContentParts: []model.ContentPart{
+					{
+						Type: model.ContentTypeImage,
+						Image: &model.Image{
+							URL:    "https://example.com/images/1.jpeg",
+							Format: "image/jpeg",
+						},
+					},
+					{
+						Type: model.ContentTypeFile,
+						File: &model.File{
+							Name:     "report.txt",
+							Data:     []byte("report"),
+							MimeType: "text/plain",
+						},
+					},
+					{
+						Type: model.ContentTypeText,
+						Text: &text,
+					},
+				},
+			},
+		}},
+	})
+	require.NoError(t, agentevent.SetExtension(
+		queued,
+		steerext.QueuedUserMessageExtensionKey,
+		steerext.QueuedUserMessageMetadata{
+			Status: steerext.QueuedUserMessageStatusConsumed,
+		},
+	))
+	completion := agentevent.NewResponseEvent("inv-1", "agui.runner", &model.Response{
+		ID:     "runner-completion-1",
+		Object: model.ObjectTypeRunnerCompletion,
+		Done:   true,
+	})
+	agentEvents := make(chan *agentevent.Event, 2)
+	agentEvents <- queued
+	agentEvents <- completion
+	close(agentEvents)
+
+	underlying := &fakeRunner{
+		run: func(context.Context, string, string, model.Message, ...agent.RunOption) (<-chan *agentevent.Event, error) {
+			return agentEvents, nil
+		},
+	}
+	rr, ok := New(
+		underlying,
+		WithAppName("demo"),
+		WithSessionService(sessionService),
+	).(*runner)
+	require.True(t, ok)
+
+	eventsCh, err := rr.Run(context.Background(), &adapter.RunAgentInput{
+		ThreadID: "thread",
+		RunID:    "run",
+		Messages: []types.Message{{Role: types.RoleUser, Content: "Analyze the image"}},
+	})
+	require.NoError(t, err)
+	collectEvents(t, eventsCh)
+
+	snapshotMessages := loadSnapshotMessages(t, rr)
+	var foundQueuedUser bool
+	for _, msg := range snapshotMessages {
+		if msg.ID != "queued-user-multimodal" || msg.Role != types.RoleUser {
+			continue
+		}
+		contents, ok := msg.ContentInputContents()
+		require.True(t, ok)
+		require.Len(t, contents, 3)
+		assert.Equal(t, types.InputContentTypeBinary, contents[0].Type)
+		assert.Equal(t, "image/jpeg", contents[0].MimeType)
+		assert.Equal(t, "https://example.com/images/1.jpeg", contents[0].URL)
+		assert.Equal(t, types.InputContentTypeBinary, contents[1].Type)
+		assert.Equal(t, "text/plain", contents[1].MimeType)
+		assert.Equal(t, "report.txt", contents[1].Filename)
+		assert.Equal(t, base64.StdEncoding.EncodeToString([]byte("report")), contents[1].Data)
+		assert.Equal(t, types.InputContentTypeText, contents[2].Type)
+		assert.Equal(t, text, contents[2].Text)
+		foundQueuedUser = true
+		break
 	}
 	require.True(t, foundQueuedUser)
 }

--- a/server/agui/translator/queued_user_message.go
+++ b/server/agui/translator/queued_user_message.go
@@ -1,0 +1,148 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package translator
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+
+	aguitypes "github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/types"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+func queuedUserMessageFromContentParts(
+	messageID string,
+	message model.Message,
+) (aguitypes.Message, error) {
+	contents, err := inputContentsFromMessage(message)
+	if err != nil {
+		return aguitypes.Message{}, err
+	}
+	return aguitypes.Message{
+		ID:      messageID,
+		Role:    aguitypes.RoleUser,
+		Content: contents,
+	}, nil
+}
+
+func inputContentsFromMessage(message model.Message) ([]aguitypes.InputContent, error) {
+	contents := make([]aguitypes.InputContent, 0, len(message.ContentParts)+1)
+	if message.Content != "" {
+		contents = append(contents, aguitypes.InputContent{
+			Type: aguitypes.InputContentTypeText,
+			Text: message.Content,
+		})
+	}
+	for _, part := range message.ContentParts {
+		content, err := inputContentFromPart(part)
+		if err != nil {
+			return nil, err
+		}
+		contents = append(contents, content)
+	}
+	if len(contents) == 0 {
+		return nil, errors.New("queued user message content parts are empty")
+	}
+	return contents, nil
+}
+
+func inputContentFromPart(part model.ContentPart) (aguitypes.InputContent, error) {
+	switch part.Type {
+	case model.ContentTypeText:
+		if part.Text == nil {
+			return aguitypes.InputContent{}, errors.New("queued user message text content part is nil")
+		}
+		return aguitypes.InputContent{
+			Type: aguitypes.InputContentTypeText,
+			Text: *part.Text,
+		}, nil
+	case model.ContentTypeImage:
+		return inputContentFromImage(part.Image)
+	case model.ContentTypeAudio:
+		return inputContentFromAudio(part.Audio)
+	case model.ContentTypeFile:
+		return inputContentFromFile(part.File)
+	default:
+		return aguitypes.InputContent{}, fmt.Errorf(
+			"queued user message content part type unsupported: %s",
+			part.Type,
+		)
+	}
+}
+
+func inputContentFromImage(image *model.Image) (aguitypes.InputContent, error) {
+	if image == nil {
+		return aguitypes.InputContent{}, errors.New("queued user message image content part is nil")
+	}
+	content := aguitypes.InputContent{
+		Type:     aguitypes.InputContentTypeBinary,
+		MimeType: binaryMimeType("image", image.Format),
+		URL:      strings.TrimSpace(image.URL),
+	}
+	if len(image.Data) > 0 {
+		content.Data = base64.StdEncoding.EncodeToString(image.Data)
+	}
+	if content.URL == "" && content.Data == "" {
+		return aguitypes.InputContent{}, errors.New("queued user message image content part is empty")
+	}
+	return content, nil
+}
+
+func inputContentFromAudio(audio *model.Audio) (aguitypes.InputContent, error) {
+	if audio == nil {
+		return aguitypes.InputContent{}, errors.New("queued user message audio content part is nil")
+	}
+	if len(audio.Data) == 0 {
+		return aguitypes.InputContent{}, errors.New("queued user message audio content part is empty")
+	}
+	return aguitypes.InputContent{
+		Type:     aguitypes.InputContentTypeBinary,
+		MimeType: binaryMimeType("audio", audio.Format),
+		Data:     base64.StdEncoding.EncodeToString(audio.Data),
+	}, nil
+}
+
+func inputContentFromFile(file *model.File) (aguitypes.InputContent, error) {
+	if file == nil {
+		return aguitypes.InputContent{}, errors.New("queued user message file content part is nil")
+	}
+	// File parts may carry any full MIME type; the application kind only
+	// supplies defaults for missing or short formats such as "pdf".
+	content := aguitypes.InputContent{
+		Type:     aguitypes.InputContentTypeBinary,
+		MimeType: binaryMimeType("application", file.MimeType),
+		ID:       strings.TrimSpace(file.FileID),
+		URL:      strings.TrimSpace(file.URL),
+		Filename: strings.TrimSpace(file.Name),
+	}
+	if len(file.Data) > 0 {
+		content.Data = base64.StdEncoding.EncodeToString(file.Data)
+	}
+	if content.ID == "" && content.URL == "" && content.Data == "" {
+		return aguitypes.InputContent{}, errors.New("queued user message file content part is empty")
+	}
+	return content, nil
+}
+
+func binaryMimeType(kind, format string) string {
+	format = strings.ToLower(strings.TrimSpace(format))
+	if format == "" {
+		if kind == "application" {
+			return "application/octet-stream"
+		}
+		return kind + "/*"
+	}
+	if strings.Contains(format, "/") {
+		return format
+	}
+	return kind + "/" + format
+}

--- a/server/agui/translator/translator.go
+++ b/server/agui/translator/translator.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/uuid"
 	agentevent "trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/graph"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/steer"
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
@@ -104,7 +105,10 @@ type translator struct {
 	streamingToolResultContent             map[string]string
 }
 
-const skillRunArtifactsStateKey = skill.StateKeyArtifacts
+const (
+	skillRunArtifactsStateKey = skill.StateKeyArtifacts
+	steerConsumedActivityType = "steer.consumed"
+)
 
 // Translate translates one trpc-agent-go event into zero or more AG-UI events.
 func (t *translator) Translate(ctx context.Context, event *agentevent.Event) ([]aguievents.Event, error) {
@@ -132,6 +136,14 @@ func (t *translator) Translate(ctx context.Context, event *agentevent.Event) ([]
 	// Handle node custom events (progress, text, custom).
 	events = append(events, t.graphNodeCustomEvents(event)...)
 	events = append(events, t.toolArtifactsEvents(event)...)
+	queuedUserEvents, handled, err := t.queuedUserMessageEvents(event)
+	if err != nil {
+		return nil, err
+	}
+	if handled {
+		events = append(events, queuedUserEvents...)
+		return t.finalizeEvents(event, events), nil
+	}
 
 	rsp := event.Response
 	if rsp == nil {
@@ -250,6 +262,71 @@ func (t *translator) finalizeEvents(
 		base.RawEvent = metadata
 	}
 	return events
+}
+
+func (t *translator) queuedUserMessageEvents(
+	evt *agentevent.Event,
+) ([]aguievents.Event, bool, error) {
+	meta, ok, err := agentevent.GetExtension[steer.QueuedUserMessageMetadata](
+		evt,
+		steer.ExtensionKeyQueuedUserMessage,
+	)
+	if err != nil {
+		return nil, true, fmt.Errorf("decode queued user message metadata: %w", err)
+	}
+	if !ok || meta.Status != steer.QueuedUserMessageStatusConsumed {
+		return nil, false, nil
+	}
+	if evt == nil || evt.Response == nil || len(evt.Response.Choices) == 0 {
+		return nil, true, errors.New("queued user message event missing message")
+	}
+	message := evt.Response.Choices[0].Message
+	if message.Role != model.RoleUser {
+		return nil, true, fmt.Errorf(
+			"queued user message event role must be user: %s",
+			message.Role,
+		)
+	}
+
+	messageID := evt.Response.ID
+	if messageID == "" {
+		messageID = evt.ID
+	}
+	if messageID == "" {
+		messageID = uuid.NewString()
+	}
+
+	events := make([]aguievents.Event, 0, 4)
+	if t.receivingMessage {
+		events = append(events, aguievents.NewTextMessageEndEvent(t.lastMessageID))
+		t.receivingMessage = false
+	}
+	if message.Content != "" {
+		events = append(
+			events,
+			aguievents.NewTextMessageStartEvent(
+				messageID,
+				aguievents.WithRole(string(aguitypes.RoleUser)),
+			),
+			aguievents.NewTextMessageContentEvent(messageID, message.Content),
+			aguievents.NewTextMessageEndEvent(messageID),
+		)
+		t.lastMessageID = messageID
+	}
+	events = append(events, aguievents.NewActivitySnapshotEvent(
+		steerConsumedActivityMessageID(messageID),
+		steerConsumedActivityType,
+		map[string]any{
+			"requestId": evt.RequestID,
+			"messageId": messageID,
+			"status":    meta.Status,
+		},
+	))
+	return events, true, nil
+}
+
+func steerConsumedActivityMessageID(messageID string) string {
+	return "activity-steer-consumed-" + messageID
 }
 
 type artifactRef struct {

--- a/server/agui/translator/translator.go
+++ b/server/agui/translator/translator.go
@@ -23,11 +23,12 @@ import (
 	"github.com/google/uuid"
 	agentevent "trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/graph"
-	"trpc.group/trpc-go/trpc-agent-go/internal/state/steer"
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
+	"trpc.group/trpc-go/trpc-agent-go/server/agui/internal/multimodal"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/internal/source"
+	"trpc.group/trpc-go/trpc-agent-go/server/agui/internal/steerext"
 	aguitool "trpc.group/trpc-go/trpc-agent-go/server/agui/internal/tool"
 	"trpc.group/trpc-go/trpc-agent-go/skill"
 )
@@ -267,14 +268,14 @@ func (t *translator) finalizeEvents(
 func (t *translator) queuedUserMessageEvents(
 	evt *agentevent.Event,
 ) ([]aguievents.Event, bool, error) {
-	meta, ok, err := agentevent.GetExtension[steer.QueuedUserMessageMetadata](
+	meta, ok, err := agentevent.GetExtension[steerext.QueuedUserMessageMetadata](
 		evt,
-		steer.ExtensionKeyQueuedUserMessage,
+		steerext.QueuedUserMessageExtensionKey,
 	)
 	if err != nil {
 		return nil, true, fmt.Errorf("decode queued user message metadata: %w", err)
 	}
-	if !ok || meta.Status != steer.QueuedUserMessageStatusConsumed {
+	if !ok || meta.Status != steerext.QueuedUserMessageStatusConsumed {
 		return nil, false, nil
 	}
 	if evt == nil || evt.Response == nil || len(evt.Response.Choices) == 0 {
@@ -301,7 +302,19 @@ func (t *translator) queuedUserMessageEvents(
 		events = append(events, aguievents.NewTextMessageEndEvent(t.lastMessageID))
 		t.receivingMessage = false
 	}
-	if message.Content != "" {
+	if len(message.ContentParts) > 0 {
+		userMessage, err := queuedUserMessageFromContentParts(messageID, message)
+		if err != nil {
+			return nil, true, err
+		}
+		events = append(
+			events,
+			aguievents.NewCustomEvent(
+				multimodal.CustomEventNameUserMessage,
+				aguievents.WithValue(userMessage),
+			),
+		)
+	} else if message.Content != "" {
 		events = append(
 			events,
 			aguievents.NewTextMessageStartEvent(

--- a/server/agui/translator/translator_test.go
+++ b/server/agui/translator/translator_test.go
@@ -183,6 +183,205 @@ func TestTranslateQueuedUserMessageConsumed(t *testing.T) {
 	assert.Equal(t, steer.QueuedUserMessageStatusConsumed, activityContent["status"])
 }
 
+func TestTranslateQueuedUserMessageConsumedClosesOpenMessage(t *testing.T) {
+	translator := newTranslatorImplForTest(t)
+	if translator == nil {
+		return
+	}
+
+	_, err := translator.Translate(context.Background(), &agentevent.Event{
+		Response: &model.Response{
+			ID:     "assistant-open",
+			Object: model.ObjectTypeChatCompletionChunk,
+			Choices: []model.Choice{{
+				Delta: model.Message{
+					Role:    model.RoleAssistant,
+					Content: "working",
+				},
+			}},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, translator.receivingMessage)
+
+	evt := agentevent.NewResponseEvent("inv-1", "user", &model.Response{
+		ID: "queued-message-2",
+		Choices: []model.Choice{{
+			Message: model.NewUserMessage("Use a shorter answer"),
+		}},
+	})
+	require.NoError(t, agentevent.SetExtension(
+		evt,
+		steer.ExtensionKeyQueuedUserMessage,
+		steer.QueuedUserMessageMetadata{
+			Status: steer.QueuedUserMessageStatusConsumed,
+		},
+	))
+
+	events, err := translator.Translate(context.Background(), evt)
+	require.NoError(t, err)
+	require.Len(t, events, 5)
+
+	endOpen, ok := events[0].(*aguievents.TextMessageEndEvent)
+	require.True(t, ok)
+	assert.Equal(t, "assistant-open", endOpen.MessageID)
+	assert.False(t, translator.receivingMessage)
+}
+
+func TestTranslateQueuedUserMessageConsumedWithEventIDFallback(t *testing.T) {
+	translator := newTranslatorForTest(t)
+	if translator == nil {
+		return
+	}
+
+	evt := agentevent.NewResponseEvent("inv-1", "user", &model.Response{
+		Choices: []model.Choice{{
+			Message: model.NewUserMessage("Use event ID"),
+		}},
+	})
+	evt.ID = "queued-event-id"
+	require.NoError(t, agentevent.SetExtension(
+		evt,
+		steer.ExtensionKeyQueuedUserMessage,
+		steer.QueuedUserMessageMetadata{
+			Status: steer.QueuedUserMessageStatusConsumed,
+		},
+	))
+
+	events, err := translator.Translate(context.Background(), evt)
+	require.NoError(t, err)
+	require.Len(t, events, 4)
+
+	start, ok := events[0].(*aguievents.TextMessageStartEvent)
+	require.True(t, ok)
+	assert.Equal(t, "queued-event-id", start.MessageID)
+	activity, ok := events[3].(*aguievents.ActivitySnapshotEvent)
+	require.True(t, ok)
+	assert.Equal(t, steerConsumedActivityMessageID("queued-event-id"), activity.MessageID)
+}
+
+func TestTranslateQueuedUserMessageConsumedWithEmptyContentUsesGeneratedID(t *testing.T) {
+	translator := newTranslatorForTest(t)
+	if translator == nil {
+		return
+	}
+
+	evt := agentevent.NewResponseEvent("inv-1", "user", &model.Response{
+		Choices: []model.Choice{{
+			Message: model.Message{Role: model.RoleUser},
+		}},
+	})
+	require.NoError(t, agentevent.SetExtension(
+		evt,
+		steer.ExtensionKeyQueuedUserMessage,
+		steer.QueuedUserMessageMetadata{
+			Status: steer.QueuedUserMessageStatusConsumed,
+		},
+	))
+
+	events, err := translator.Translate(context.Background(), evt)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+
+	activity, ok := events[0].(*aguievents.ActivitySnapshotEvent)
+	require.True(t, ok)
+	activityContent, ok := activity.Content.(map[string]any)
+	require.True(t, ok)
+	messageID, ok := activityContent["messageId"].(string)
+	require.True(t, ok)
+	assert.NotEmpty(t, messageID)
+	assert.Equal(t, steerConsumedActivityMessageID(messageID), activity.MessageID)
+}
+
+func TestTranslateQueuedUserMessageConsumedInvalidEvents(t *testing.T) {
+	tests := []struct {
+		name    string
+		event   *agentevent.Event
+		wantErr string
+	}{
+		{
+			name: "invalid metadata",
+			event: &agentevent.Event{
+				Extensions: map[string]json.RawMessage{
+					steer.ExtensionKeyQueuedUserMessage: json.RawMessage(`{bad`),
+				},
+			},
+			wantErr: "decode queued user message metadata",
+		},
+		{
+			name:    "missing response",
+			event:   queuedUserMessageEventForTest(t, nil),
+			wantErr: "queued user message event missing message",
+		},
+		{
+			name:    "missing choice",
+			event:   queuedUserMessageEventForTest(t, &model.Response{}),
+			wantErr: "queued user message event missing message",
+		},
+		{
+			name: "non user role",
+			event: queuedUserMessageEventForTest(t, &model.Response{
+				Choices: []model.Choice{{
+					Message: model.NewAssistantMessage("not user"),
+				}},
+			}),
+			wantErr: "queued user message event role must be user",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			translator := newTranslatorForTest(t)
+			if translator == nil {
+				return
+			}
+			events, err := translator.Translate(context.Background(), tt.event)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+			assert.Empty(t, events)
+		})
+	}
+}
+
+func TestTranslateQueuedUserMessageNonConsumedMetadataFallsThrough(t *testing.T) {
+	translator := newTranslatorForTest(t)
+	if translator == nil {
+		return
+	}
+
+	evt := agentevent.NewResponseEvent("inv-1", "user", &model.Response{
+		Choices: []model.Choice{{
+			Message: model.NewUserMessage("pending message"),
+		}},
+	})
+	require.NoError(t, agentevent.SetExtension(
+		evt,
+		steer.ExtensionKeyQueuedUserMessage,
+		steer.QueuedUserMessageMetadata{Status: "pending"},
+	))
+
+	events, err := translator.Translate(context.Background(), evt)
+	require.NoError(t, err)
+	assert.Empty(t, events)
+}
+
+func queuedUserMessageEventForTest(
+	t *testing.T,
+	response *model.Response,
+) *agentevent.Event {
+	t.Helper()
+
+	evt := agentevent.NewResponseEvent("inv-1", "user", response)
+	require.NoError(t, agentevent.SetExtension(
+		evt,
+		steer.ExtensionKeyQueuedUserMessage,
+		steer.QueuedUserMessageMetadata{
+			Status: steer.QueuedUserMessageStatusConsumed,
+		},
+	))
+	return evt
+}
+
 func TestTranslateUserLikeEventWithoutQueuedMetadataDoesNotEmitSteerConsumed(t *testing.T) {
 	translator := newTranslatorForTest(t)
 	if translator == nil {

--- a/server/agui/translator/translator_test.go
+++ b/server/agui/translator/translator_test.go
@@ -23,6 +23,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
 	agentevent "trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/graph"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/steer"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	trunner "trpc.group/trpc-go/trpc-agent-go/runner"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/internal/source"
@@ -128,6 +129,77 @@ func TestTranslateNilEvent(t *testing.T) {
 
 	_, err = translator.Translate(context.Background(), &agentevent.Event{})
 	assert.Error(t, err)
+}
+
+func TestTranslateQueuedUserMessageConsumed(t *testing.T) {
+	translator := newTranslatorForTest(t)
+	if translator == nil {
+		return
+	}
+
+	evt := agentevent.NewResponseEvent("inv-1", "user", &model.Response{
+		ID: "queued-message-1",
+		Choices: []model.Choice{{
+			Message: model.NewUserMessage("Please narrow the scope"),
+		}},
+	})
+	evt.ID = "event-1"
+	evt.RequestID = "request-1"
+	require.NoError(t, agentevent.SetExtension(
+		evt,
+		steer.ExtensionKeyQueuedUserMessage,
+		steer.QueuedUserMessageMetadata{
+			Status: steer.QueuedUserMessageStatusConsumed,
+		},
+	))
+
+	events, err := translator.Translate(context.Background(), evt)
+	require.NoError(t, err)
+	require.Len(t, events, 4)
+
+	start, ok := events[0].(*aguievents.TextMessageStartEvent)
+	require.True(t, ok)
+	assert.Equal(t, "queued-message-1", start.MessageID)
+	require.NotNil(t, start.Role)
+	assert.Equal(t, string(aguitypes.RoleUser), *start.Role)
+
+	content, ok := events[1].(*aguievents.TextMessageContentEvent)
+	require.True(t, ok)
+	assert.Equal(t, "queued-message-1", content.MessageID)
+	assert.Equal(t, "Please narrow the scope", content.Delta)
+
+	end, ok := events[2].(*aguievents.TextMessageEndEvent)
+	require.True(t, ok)
+	assert.Equal(t, "queued-message-1", end.MessageID)
+
+	activity, ok := events[3].(*aguievents.ActivitySnapshotEvent)
+	require.True(t, ok)
+	assert.Equal(t, steerConsumedActivityMessageID("queued-message-1"), activity.MessageID)
+	assert.Equal(t, steerConsumedActivityType, activity.ActivityType)
+	activityContent, ok := activity.Content.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "request-1", activityContent["requestId"])
+	assert.Equal(t, "queued-message-1", activityContent["messageId"])
+	assert.Equal(t, steer.QueuedUserMessageStatusConsumed, activityContent["status"])
+}
+
+func TestTranslateUserLikeEventWithoutQueuedMetadataDoesNotEmitSteerConsumed(t *testing.T) {
+	translator := newTranslatorForTest(t)
+	if translator == nil {
+		return
+	}
+
+	events, err := translator.Translate(context.Background(), agentevent.NewResponseEvent(
+		"inv-1",
+		"user",
+		&model.Response{
+			Choices: []model.Choice{{
+				Message: model.NewUserMessage("ordinary user event"),
+			}},
+		},
+	))
+	require.NoError(t, err)
+	assert.Empty(t, events)
 }
 
 func TestTranslateErrorResponse(t *testing.T) {

--- a/server/agui/translator/translator_test.go
+++ b/server/agui/translator/translator_test.go
@@ -11,6 +11,7 @@ package translator
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"sync"
 	"testing"
@@ -23,10 +24,11 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
 	agentevent "trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/graph"
-	"trpc.group/trpc-go/trpc-agent-go/internal/state/steer"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	trunner "trpc.group/trpc-go/trpc-agent-go/runner"
+	"trpc.group/trpc-go/trpc-agent-go/server/agui/internal/multimodal"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/internal/source"
+	"trpc.group/trpc-go/trpc-agent-go/server/agui/internal/steerext"
 	aguitool "trpc.group/trpc-go/trpc-agent-go/server/agui/internal/tool"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
@@ -147,9 +149,9 @@ func TestTranslateQueuedUserMessageConsumed(t *testing.T) {
 	evt.RequestID = "request-1"
 	require.NoError(t, agentevent.SetExtension(
 		evt,
-		steer.ExtensionKeyQueuedUserMessage,
-		steer.QueuedUserMessageMetadata{
-			Status: steer.QueuedUserMessageStatusConsumed,
+		steerext.QueuedUserMessageExtensionKey,
+		steerext.QueuedUserMessageMetadata{
+			Status: steerext.QueuedUserMessageStatusConsumed,
 		},
 	))
 
@@ -180,7 +182,7 @@ func TestTranslateQueuedUserMessageConsumed(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "request-1", activityContent["requestId"])
 	assert.Equal(t, "queued-message-1", activityContent["messageId"])
-	assert.Equal(t, steer.QueuedUserMessageStatusConsumed, activityContent["status"])
+	assert.Equal(t, steerext.QueuedUserMessageStatusConsumed, activityContent["status"])
 }
 
 func TestTranslateQueuedUserMessageConsumedClosesOpenMessage(t *testing.T) {
@@ -212,9 +214,9 @@ func TestTranslateQueuedUserMessageConsumedClosesOpenMessage(t *testing.T) {
 	})
 	require.NoError(t, agentevent.SetExtension(
 		evt,
-		steer.ExtensionKeyQueuedUserMessage,
-		steer.QueuedUserMessageMetadata{
-			Status: steer.QueuedUserMessageStatusConsumed,
+		steerext.QueuedUserMessageExtensionKey,
+		steerext.QueuedUserMessageMetadata{
+			Status: steerext.QueuedUserMessageStatusConsumed,
 		},
 	))
 
@@ -242,9 +244,9 @@ func TestTranslateQueuedUserMessageConsumedWithEventIDFallback(t *testing.T) {
 	evt.ID = "queued-event-id"
 	require.NoError(t, agentevent.SetExtension(
 		evt,
-		steer.ExtensionKeyQueuedUserMessage,
-		steer.QueuedUserMessageMetadata{
-			Status: steer.QueuedUserMessageStatusConsumed,
+		steerext.QueuedUserMessageExtensionKey,
+		steerext.QueuedUserMessageMetadata{
+			Status: steerext.QueuedUserMessageStatusConsumed,
 		},
 	))
 
@@ -260,6 +262,208 @@ func TestTranslateQueuedUserMessageConsumedWithEventIDFallback(t *testing.T) {
 	assert.Equal(t, steerConsumedActivityMessageID("queued-event-id"), activity.MessageID)
 }
 
+func TestTranslateQueuedUserMessageConsumedWithContentParts(t *testing.T) {
+	translator := newTranslatorForTest(t)
+	if translator == nil {
+		return
+	}
+
+	text := "describe this image"
+	message := model.Message{
+		Role:    model.RoleUser,
+		Content: "context",
+		ContentParts: []model.ContentPart{
+			{
+				Type: model.ContentTypeText,
+				Text: &text,
+			},
+			{
+				Type: model.ContentTypeImage,
+				Image: &model.Image{
+					URL:    " https://example.com/image.png ",
+					Format: "image/png",
+				},
+			},
+			{
+				Type: model.ContentTypeAudio,
+				Audio: &model.Audio{
+					Data:   []byte("audio"),
+					Format: "wav",
+				},
+			},
+			{
+				Type: model.ContentTypeFile,
+				File: &model.File{
+					Name:     "report.pdf",
+					Data:     []byte("file"),
+					MimeType: "application/pdf",
+				},
+			},
+			{
+				Type: model.ContentTypeFile,
+				File: &model.File{
+					Name:   "uploaded.pdf",
+					FileID: "file-123",
+				},
+			},
+		},
+	}
+	evt := queuedUserMessageEventForTest(t, &model.Response{
+		ID: "queued-multimodal",
+		Choices: []model.Choice{{
+			Message: message,
+		}},
+	})
+
+	events, err := translator.Translate(context.Background(), evt)
+	require.NoError(t, err)
+	require.Len(t, events, 2)
+
+	custom, ok := events[0].(*aguievents.CustomEvent)
+	require.True(t, ok)
+	assert.Equal(t, multimodal.CustomEventNameUserMessage, custom.Name)
+	userMessage, ok := custom.Value.(aguitypes.Message)
+	require.True(t, ok)
+	assert.Equal(t, "queued-multimodal", userMessage.ID)
+	assert.Equal(t, aguitypes.RoleUser, userMessage.Role)
+	contents, ok := userMessage.ContentInputContents()
+	require.True(t, ok)
+	require.Len(t, contents, 6)
+	assert.Equal(t, aguitypes.InputContentTypeText, contents[0].Type)
+	assert.Equal(t, "context", contents[0].Text)
+	assert.Equal(t, aguitypes.InputContentTypeText, contents[1].Type)
+	assert.Equal(t, text, contents[1].Text)
+	assert.Equal(t, aguitypes.InputContentTypeBinary, contents[2].Type)
+	assert.Equal(t, "image/png", contents[2].MimeType)
+	assert.Equal(t, "https://example.com/image.png", contents[2].URL)
+	assert.Equal(t, aguitypes.InputContentTypeBinary, contents[3].Type)
+	assert.Equal(t, "audio/wav", contents[3].MimeType)
+	assert.Equal(t, base64.StdEncoding.EncodeToString([]byte("audio")), contents[3].Data)
+	assert.Equal(t, aguitypes.InputContentTypeBinary, contents[4].Type)
+	assert.Equal(t, "application/pdf", contents[4].MimeType)
+	assert.Equal(t, "report.pdf", contents[4].Filename)
+	assert.Equal(t, base64.StdEncoding.EncodeToString([]byte("file")), contents[4].Data)
+	assert.Equal(t, aguitypes.InputContentTypeBinary, contents[5].Type)
+	assert.Equal(t, "application/octet-stream", contents[5].MimeType)
+	assert.Equal(t, "uploaded.pdf", contents[5].Filename)
+	assert.Equal(t, "file-123", contents[5].ID)
+
+	activity, ok := events[1].(*aguievents.ActivitySnapshotEvent)
+	require.True(t, ok)
+	assert.Equal(t, steerConsumedActivityMessageID("queued-multimodal"), activity.MessageID)
+}
+
+func TestQueuedUserMessageContentPartsConversionErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		message model.Message
+		want    string
+	}{
+		{
+			name:    "empty",
+			message: model.Message{Role: model.RoleUser},
+			want:    "queued user message content parts are empty",
+		},
+		{
+			name: "nil text",
+			message: model.Message{Role: model.RoleUser, ContentParts: []model.ContentPart{{
+				Type: model.ContentTypeText,
+			}}},
+			want: "queued user message text content part is nil",
+		},
+		{
+			name: "nil image",
+			message: model.Message{Role: model.RoleUser, ContentParts: []model.ContentPart{{
+				Type: model.ContentTypeImage,
+			}}},
+			want: "queued user message image content part is nil",
+		},
+		{
+			name: "empty image",
+			message: model.Message{Role: model.RoleUser, ContentParts: []model.ContentPart{{
+				Type:  model.ContentTypeImage,
+				Image: &model.Image{},
+			}}},
+			want: "queued user message image content part is empty",
+		},
+		{
+			name: "nil audio",
+			message: model.Message{Role: model.RoleUser, ContentParts: []model.ContentPart{{
+				Type: model.ContentTypeAudio,
+			}}},
+			want: "queued user message audio content part is nil",
+		},
+		{
+			name: "empty audio",
+			message: model.Message{Role: model.RoleUser, ContentParts: []model.ContentPart{{
+				Type:  model.ContentTypeAudio,
+				Audio: &model.Audio{},
+			}}},
+			want: "queued user message audio content part is empty",
+		},
+		{
+			name: "nil file",
+			message: model.Message{Role: model.RoleUser, ContentParts: []model.ContentPart{{
+				Type: model.ContentTypeFile,
+			}}},
+			want: "queued user message file content part is nil",
+		},
+		{
+			name: "empty file",
+			message: model.Message{Role: model.RoleUser, ContentParts: []model.ContentPart{{
+				Type: model.ContentTypeFile,
+				File: &model.File{},
+			}}},
+			want: "queued user message file content part is empty",
+		},
+		{
+			name: "unsupported",
+			message: model.Message{Role: model.RoleUser, ContentParts: []model.ContentPart{{
+				Type: "video",
+			}}},
+			want: "queued user message content part type unsupported",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := queuedUserMessageFromContentParts("message-id", tt.message)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.want)
+		})
+	}
+}
+
+func TestQueuedUserMessageContentPartsConversionDefaults(t *testing.T) {
+	message := model.Message{
+		Role: model.RoleUser,
+		ContentParts: []model.ContentPart{
+			{
+				Type: model.ContentTypeImage,
+				Image: &model.Image{
+					Data: []byte("image"),
+				},
+			},
+			{
+				Type: model.ContentTypeFile,
+				File: &model.File{
+					URL: " https://example.com/report.pdf ",
+				},
+			},
+		},
+	}
+
+	userMessage, err := queuedUserMessageFromContentParts("message-id", message)
+	require.NoError(t, err)
+	contents, ok := userMessage.ContentInputContents()
+	require.True(t, ok)
+	require.Len(t, contents, 2)
+	assert.Equal(t, "image/*", contents[0].MimeType)
+	assert.Equal(t, base64.StdEncoding.EncodeToString([]byte("image")), contents[0].Data)
+	assert.Equal(t, "application/octet-stream", contents[1].MimeType)
+	assert.Equal(t, "https://example.com/report.pdf", contents[1].URL)
+}
+
 func TestTranslateQueuedUserMessageConsumedWithEmptyContentUsesGeneratedID(t *testing.T) {
 	translator := newTranslatorForTest(t)
 	if translator == nil {
@@ -273,9 +477,9 @@ func TestTranslateQueuedUserMessageConsumedWithEmptyContentUsesGeneratedID(t *te
 	})
 	require.NoError(t, agentevent.SetExtension(
 		evt,
-		steer.ExtensionKeyQueuedUserMessage,
-		steer.QueuedUserMessageMetadata{
-			Status: steer.QueuedUserMessageStatusConsumed,
+		steerext.QueuedUserMessageExtensionKey,
+		steerext.QueuedUserMessageMetadata{
+			Status: steerext.QueuedUserMessageStatusConsumed,
 		},
 	))
 
@@ -303,7 +507,7 @@ func TestTranslateQueuedUserMessageConsumedInvalidEvents(t *testing.T) {
 			name: "invalid metadata",
 			event: &agentevent.Event{
 				Extensions: map[string]json.RawMessage{
-					steer.ExtensionKeyQueuedUserMessage: json.RawMessage(`{bad`),
+					steerext.QueuedUserMessageExtensionKey: json.RawMessage(`{bad`),
 				},
 			},
 			wantErr: "decode queued user message metadata",
@@ -356,8 +560,8 @@ func TestTranslateQueuedUserMessageNonConsumedMetadataFallsThrough(t *testing.T)
 	})
 	require.NoError(t, agentevent.SetExtension(
 		evt,
-		steer.ExtensionKeyQueuedUserMessage,
-		steer.QueuedUserMessageMetadata{Status: "pending"},
+		steerext.QueuedUserMessageExtensionKey,
+		steerext.QueuedUserMessageMetadata{Status: "pending"},
 	))
 
 	events, err := translator.Translate(context.Background(), evt)
@@ -374,9 +578,9 @@ func queuedUserMessageEventForTest(
 	evt := agentevent.NewResponseEvent("inv-1", "user", response)
 	require.NoError(t, agentevent.SetExtension(
 		evt,
-		steer.ExtensionKeyQueuedUserMessage,
-		steer.QueuedUserMessageMetadata{
-			Status: steer.QueuedUserMessageStatusConsumed,
+		steerext.QueuedUserMessageExtensionKey,
+		steerext.QueuedUserMessageMetadata{
+			Status: steerext.QueuedUserMessageStatusConsumed,
 		},
 	))
 	return evt


### PR DESCRIPTION
## Summary

- add queue-level `Discard` support for queued steer messages
- expose queued steer cancellation as an optional runner capability
- mark consumed queued user messages with steer metadata
- translate consumed steer messages in AG-UI as user text events plus `steer.consumed` activity snapshots
- ensure consumed steer messages enter AG-UI track/history snapshots

## Compatibility

- keeps the existing `SteerableRunner` interface source-compatible
- adds a separate optional capability interface, `QueuedUserMessagesCanceler`, for runners that support cancellation
- `QueuedUserMessagesCanceler` is intentionally not embedded in `SteerableRunner`
- `runner.EnqueueUserMessage` continues to work by detecting the `EnqueueUserMessage` method directly
- `runner.CancelQueuedUserMessages` returns `false` when the runner does not implement cancellation
- cancellation only discards messages not yet consumed by llmflow; already-drained messages are not rolled back

## Tests

- `env GOCACHE=/tmp/trpc-agent-go-gocache go test ./runner`
- `env GOCACHE=/tmp/trpc-agent-go-gocache go test ./internal/state/steer ./internal/flow/llmflow`
- `cd server/agui && env GOCACHE=/tmp/trpc-agent-go-gocache-agui go test ./runner ./translator ./internal/reduce`

Fixes #1925 