### PR TITLE
fix: set default HTTP client timeout to prevent goroutine leaks

### DIFF
--- a/model/http_client.go
+++ b/model/http_client.go
@@ -10,7 +10,18 @@
 // Package model provides interfaces for working with LLMs.
 package model
 
-import "net/http"
+import (
+	"net/http"
+	"time"
+)
+
+const (
+	// defaultHTTPClientTimeout is the default timeout for HTTP clients
+	// created by DefaultNewHTTPClient. This prevents goroutine leaks when
+	// a server becomes unresponsive and no caller-specified context deadline
+	// is set. Users can override this via WithHTTPClientTimeout.
+	defaultHTTPClientTimeout = 5 * time.Minute
+)
 
 // HTTPClient is the interface for the HTTP client.
 type HTTPClient interface {
@@ -26,7 +37,12 @@ var DefaultNewHTTPClient HTTPClientNewFunc = func(opts ...HTTPClientOption) HTTP
 	for _, opt := range opts {
 		opt(options)
 	}
+	timeout := options.Timeout
+	if timeout <= 0 {
+		timeout = defaultHTTPClientTimeout
+	}
 	return &http.Client{
+		Timeout:   timeout,
 		Transport: options.Transport,
 	}
 }
@@ -48,8 +64,17 @@ func WithHTTPClientTransport(transport http.RoundTripper) HTTPClientOption {
 	}
 }
 
+// WithHTTPClientTimeout sets the timeout for the HTTP client.
+// A zero or negative value disables the timeout (not recommended).
+func WithHTTPClientTimeout(timeout time.Duration) HTTPClientOption {
+	return func(options *HTTPClientOptions) {
+		options.Timeout = timeout
+	}
+}
+
 // HTTPClientOptions is the options for the HTTP client.
 type HTTPClientOptions struct {
 	Name      string
 	Transport http.RoundTripper
+	Timeout   time.Duration
 }

--- a/model/http_client.go
+++ b/model/http_client.go
@@ -76,8 +76,17 @@ func WithHTTPClientTimeout(timeout time.Duration) HTTPClientOption {
 
 // HTTPClientOptions is the options for the HTTP client.
 type HTTPClientOptions struct {
-	Name           string
-	Transport      http.RoundTripper
-	Timeout        time.Duration
+	// Name is the name of the HTTP client, used for identification and logging.
+	Name string
+
+	// Transport is the custom HTTP transport to use. If nil, the default transport is used.
+	Transport http.RoundTripper
+
+	// Timeout is the timeout for the HTTP client. A zero value with DisableTimeout
+	// set to false causes DefaultNewHTTPClient to apply the default 5-minute timeout.
+	Timeout time.Duration
+
+	// DisableTimeout indicates whether to explicitly disable the HTTP client timeout.
+	// When true, the client will have no timeout regardless of the Timeout field value.
 	DisableTimeout bool
 }

--- a/model/http_client.go
+++ b/model/http_client.go
@@ -38,7 +38,7 @@ var DefaultNewHTTPClient HTTPClientNewFunc = func(opts ...HTTPClientOption) HTTP
 		opt(options)
 	}
 	timeout := options.Timeout
-	if timeout <= 0 {
+	if timeout == 0 && !options.DisableTimeout {
 		timeout = defaultHTTPClientTimeout
 	}
 	return &http.Client{
@@ -65,16 +65,19 @@ func WithHTTPClientTransport(transport http.RoundTripper) HTTPClientOption {
 }
 
 // WithHTTPClientTimeout sets the timeout for the HTTP client.
-// A zero or negative value disables the timeout (not recommended).
+// Use 0 to explicitly disable the timeout (not recommended for production).
+// If not called, DefaultNewHTTPClient applies a 5-minute default timeout.
 func WithHTTPClientTimeout(timeout time.Duration) HTTPClientOption {
 	return func(options *HTTPClientOptions) {
 		options.Timeout = timeout
+		options.DisableTimeout = timeout == 0
 	}
 }
 
 // HTTPClientOptions is the options for the HTTP client.
 type HTTPClientOptions struct {
-	Name      string
-	Transport http.RoundTripper
-	Timeout   time.Duration
+	Name           string
+	Transport      http.RoundTripper
+	Timeout        time.Duration
+	DisableTimeout bool
 }

--- a/model/http_client_test.go
+++ b/model/http_client_test.go
@@ -13,6 +13,7 @@ package model
 import (
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -127,4 +128,45 @@ func TestMultipleOptionApplications(t *testing.T) {
 	WithHTTPClientName("third")(options)
 
 	assert.Equal(t, "third", options.Name)
+}
+
+func TestDefaultNewHTTPClient_DefaultTimeout(t *testing.T) {
+	client := DefaultNewHTTPClient()
+	require.NotNil(t, client)
+
+	httpClient, ok := client.(*http.Client)
+	require.True(t, ok)
+	assert.Equal(t, defaultHTTPClientTimeout, httpClient.Timeout)
+}
+
+func TestDefaultNewHTTPClient_CustomTimeout(t *testing.T) {
+	custom := 30 * time.Second
+	client := DefaultNewHTTPClient(WithHTTPClientTimeout(custom))
+	require.NotNil(t, client)
+
+	httpClient, ok := client.(*http.Client)
+	require.True(t, ok)
+	assert.Equal(t, custom, httpClient.Timeout)
+}
+
+func TestDefaultNewHTTPClient_DisableTimeout(t *testing.T) {
+	client := DefaultNewHTTPClient(WithHTTPClientTimeout(0))
+	require.NotNil(t, client)
+
+	httpClient, ok := client.(*http.Client)
+	require.True(t, ok)
+	assert.Equal(t, time.Duration(0), httpClient.Timeout)
+}
+
+func TestWithHTTPClientTimeout(t *testing.T) {
+	options := &HTTPClientOptions{}
+
+	WithHTTPClientTimeout(10 * time.Second)(options)
+	assert.Equal(t, 10*time.Second, options.Timeout)
+	assert.False(t, options.DisableTimeout)
+
+	options = &HTTPClientOptions{}
+	WithHTTPClientTimeout(0)(options)
+	assert.Equal(t, time.Duration(0), options.Timeout)
+	assert.True(t, options.DisableTimeout)
 }


### PR DESCRIPTION
## Problem

`DefaultNewHTTPClient` in `model/http_client.go` creates `http.Client` without setting `Timeout`. When a remote LLM server becomes unresponsive and no caller-specified context deadline is set, the HTTP connection blocks indefinitely, leaking the associated goroutine.

This affects all LLM model integrations (Anthropic, OpenAI, HuggingFace, etc.) that use the shared `DefaultNewHTTPClient` factory.

## Changes

- Add a `defaultHTTPClientTimeout` constant (5 minutes) as a sensible default for LLM API calls
- Apply the timeout in `DefaultNewHTTPClient` when no custom timeout is provided
- Add `WithHTTPClientTimeout` option to allow users to override or disable the timeout

## Testing

All existing tests pass (`go test ./model/...`).
