### PR TITLE
evaluation/service/internal/inference: skip partial tool results

### DIFF
--- a/evaluation/service/internal/inference/inference.go
+++ b/evaluation/service/internal/inference/inference.go
@@ -220,6 +220,9 @@ func inferenceInvocation(
 			eventErr = errors.Join(eventErr, fmt.Errorf("event: %w", event.Error))
 			continue
 		}
+		if event.Response != nil && event.Response.IsPartial {
+			continue
+		}
 		if event.IsFinalResponse() {
 			continue
 		}

--- a/evaluation/service/internal/inference/inference_test.go
+++ b/evaluation/service/internal/inference/inference_test.go
@@ -598,6 +598,85 @@ func TestInferenceInvocationRejectsUnexpectedToolResultResponse(t *testing.T) {
 	}
 }
 
+func TestInferenceInvocationSkipsPartialToolResultResponse(t *testing.T) {
+	ctx := context.Background()
+	session := &evalset.SessionInput{UserID: "user"}
+	toolCallEvent := &event.Event{
+		Response: &model.Response{
+			Choices: []model.Choice{
+				{
+					Message: model.Message{
+						ToolCalls: []model.ToolCall{
+							{
+								ID: "call-1",
+								Function: model.FunctionDefinitionParam{
+									Name:      "tool",
+									Arguments: []byte(`{"query":"hello"}`),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	partialToolResultEvent := &event.Event{
+		Response: &model.Response{
+			IsPartial: true,
+			Choices: []model.Choice{
+				{
+					Message: model.Message{
+						Role:   model.RoleTool,
+						ToolID: "missing-inner-call",
+					},
+					Delta: model.Message{
+						Role:    model.RoleTool,
+						ToolID:  "missing-inner-call",
+						Content: "partial",
+					},
+				},
+			},
+		},
+	}
+	finalToolResultEvent := &event.Event{
+		Response: &model.Response{
+			Choices: []model.Choice{
+				{
+					Message: model.Message{
+						Role:    model.RoleTool,
+						ToolID:  "call-1",
+						Content: `{"result":42}`,
+					},
+				},
+			},
+		},
+	}
+	r := &fakeRunner{
+		events: []*event.Event{
+			toolCallEvent,
+			partialToolResultEvent,
+			finalToolResultEvent,
+			makeFinalEvent("ok"),
+		},
+	}
+
+	result, executionTrace, err := inferenceInvocation(ctx, r, "session", session, &evalset.Invocation{
+		InvocationID: "inv",
+		UserContent:  &model.Message{Role: model.RoleUser, Content: "hi"},
+	}, nil)
+
+	require.NoError(t, err)
+	assert.Nil(t, executionTrace)
+	require.NotNil(t, result)
+	require.Len(t, result.Tools, 1)
+	assert.Equal(t, "call-1", result.Tools[0].ID)
+	assert.Equal(t, "tool", result.Tools[0].Name)
+	assert.Equal(t, map[string]any{"query": "hello"}, result.Tools[0].Arguments)
+	assert.Equal(t, map[string]any{"result": float64(42)}, result.Tools[0].Result)
+	require.NotNil(t, result.FinalResponse)
+	assert.Equal(t, "ok", result.FinalResponse.Content)
+}
+
 func TestInferenceInvocation_PreservesTraceOnToolResultMergeError(t *testing.T) {
 	ctx := context.Background()
 	session := &evalset.SessionInput{UserID: "user"}


### PR DESCRIPTION
Evaluation inference currently tries to merge partial streaming tool-result events into the tool-call index, but those delta events can use inner or incomplete tool IDs and trigger missing-ID errors before the final result arrives. This change ignores partial responses during inference collection so only finalized tool call and tool result events populate evaluation trajectories.