### PR TITLE
{openclaw, skill}: reduce summary reload overhead

### DIFF
--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -1179,6 +1179,12 @@ func NewRuntimeWithOptions(
 			),
 		)
 	}
+	gwOpts = appendLatencyDiagnosticsGatewayOption(
+		gwOpts,
+		opts.StateDir,
+		opts.LatencyDiagnosticsEnabled,
+		opts.LatencyDiagnosticsEvents,
+	)
 	gwOpts = appendSkillsOverviewGatewayOption(
 		gwOpts,
 		opts.SkillsOverviewLimit,
@@ -1702,6 +1708,12 @@ func run(
 			),
 		)
 	}
+	gwOpts = appendLatencyDiagnosticsGatewayOption(
+		gwOpts,
+		opts.StateDir,
+		opts.LatencyDiagnosticsEnabled,
+		opts.LatencyDiagnosticsEvents,
+	)
 	gwOpts = appendSkillsOverviewGatewayOption(
 		gwOpts,
 		opts.SkillsOverviewLimit,

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -227,6 +227,12 @@ const (
 		"input after reasonable local exploration, state " +
 		"the issue briefly and continue with the best " +
 		"fallback."
+	openClawSkillsPathGuidance = "Each entry includes a path to that " +
+		"skill's SKILL.md on disk."
+	openClawCompactSkillsGuidance = "The overview may show a compact " +
+		"subset. When no shown skill clearly matches, call " +
+		"`skill_list` to inspect the full catalog before " +
+		"choosing a skill."
 	openClawSkillLoadToolDescription = "Load a skill body and optional " +
 		"docs. This is a blocking requirement when the user " +
 		"names a listed skill, names a slash command, or the " +
@@ -1054,20 +1060,23 @@ func NewRuntimeWithOptions(
 			SkillsAllowBundled: splitCSV(
 				opts.SkillsAllowBundled,
 			),
-			SkillConfigs:        opts.SkillConfigs,
-			SkillConfigKeys:     resolveSkillConfigKeys(opts),
-			SkillsWatch:         opts.SkillsWatch,
-			SkillsWatchBundled:  opts.SkillsWatchBundled,
-			SkillsWatchDebounce: opts.SkillsWatchDebounce,
-			SkillsToolProfile:   opts.SkillsToolProfile,
-			SkillsLoadMode:      opts.SkillsLoadMode,
-			SkillsMaxLoaded:     opts.SkillsMaxLoaded,
-			SkillsToolResults:   opts.SkillsToolResults,
-			SkillsSkipFallback:  opts.SkillsSkipFallback,
-			SkillsToolingGuide:  opts.SkillsToolingGuide,
-			KnowledgesConfig:    opts.KnowledgesConfig,
-			StateDir:            resolvedStateDir,
-			MemoryFileStore:     fileMemoryStore,
+			SkillConfigs:          opts.SkillConfigs,
+			SkillConfigKeys:       resolveSkillConfigKeys(opts),
+			SkillsWatch:           opts.SkillsWatch,
+			SkillsWatchBundled:    opts.SkillsWatchBundled,
+			SkillsWatchDebounce:   opts.SkillsWatchDebounce,
+			SkillsSummaryCacheTTL: opts.SkillsSummaryCacheTTL,
+			SkillsOverviewLimit:   opts.SkillsOverviewLimit,
+			SkillsOverviewPinned:  splitCSV(opts.SkillsOverviewPinned),
+			SkillsToolProfile:     opts.SkillsToolProfile,
+			SkillsLoadMode:        opts.SkillsLoadMode,
+			SkillsMaxLoaded:       opts.SkillsMaxLoaded,
+			SkillsToolResults:     opts.SkillsToolResults,
+			SkillsSkipFallback:    opts.SkillsSkipFallback,
+			SkillsToolingGuide:    opts.SkillsToolingGuide,
+			KnowledgesConfig:      opts.KnowledgesConfig,
+			StateDir:              resolvedStateDir,
+			MemoryFileStore:       fileMemoryStore,
 
 			EnableLocalExec:      opts.EnableLocalExec,
 			EnableOpenClawTools:  opts.EnableOpenClawTools,
@@ -1170,6 +1179,11 @@ func NewRuntimeWithOptions(
 			),
 		)
 	}
+	gwOpts = appendSkillsOverviewGatewayOption(
+		gwOpts,
+		opts.SkillsOverviewLimit,
+		splitCSV(opts.SkillsOverviewPinned),
+	)
 	gwOpts = append(
 		gwOpts,
 		gateway.WithRunOptionResolver(
@@ -1576,20 +1590,23 @@ func run(
 			SkillsAllowBundled: splitCSV(
 				opts.SkillsAllowBundled,
 			),
-			SkillConfigs:        opts.SkillConfigs,
-			SkillConfigKeys:     resolveSkillConfigKeys(opts),
-			SkillsWatch:         opts.SkillsWatch,
-			SkillsWatchBundled:  opts.SkillsWatchBundled,
-			SkillsWatchDebounce: opts.SkillsWatchDebounce,
-			SkillsToolProfile:   opts.SkillsToolProfile,
-			SkillsLoadMode:      opts.SkillsLoadMode,
-			SkillsMaxLoaded:     opts.SkillsMaxLoaded,
-			SkillsToolResults:   opts.SkillsToolResults,
-			SkillsSkipFallback:  opts.SkillsSkipFallback,
-			SkillsToolingGuide:  opts.SkillsToolingGuide,
-			KnowledgesConfig:    opts.KnowledgesConfig,
-			StateDir:            resolvedStateDir,
-			MemoryFileStore:     fileMemoryStore,
+			SkillConfigs:          opts.SkillConfigs,
+			SkillConfigKeys:       resolveSkillConfigKeys(opts),
+			SkillsWatch:           opts.SkillsWatch,
+			SkillsWatchBundled:    opts.SkillsWatchBundled,
+			SkillsWatchDebounce:   opts.SkillsWatchDebounce,
+			SkillsSummaryCacheTTL: opts.SkillsSummaryCacheTTL,
+			SkillsOverviewLimit:   opts.SkillsOverviewLimit,
+			SkillsOverviewPinned:  splitCSV(opts.SkillsOverviewPinned),
+			SkillsToolProfile:     opts.SkillsToolProfile,
+			SkillsLoadMode:        opts.SkillsLoadMode,
+			SkillsMaxLoaded:       opts.SkillsMaxLoaded,
+			SkillsToolResults:     opts.SkillsToolResults,
+			SkillsSkipFallback:    opts.SkillsSkipFallback,
+			SkillsToolingGuide:    opts.SkillsToolingGuide,
+			KnowledgesConfig:      opts.KnowledgesConfig,
+			StateDir:              resolvedStateDir,
+			MemoryFileStore:       fileMemoryStore,
 
 			EnableLocalExec:     opts.EnableLocalExec,
 			EnableOpenClawTools: opts.EnableOpenClawTools,
@@ -1685,6 +1702,11 @@ func run(
 			),
 		)
 	}
+	gwOpts = appendSkillsOverviewGatewayOption(
+		gwOpts,
+		opts.SkillsOverviewLimit,
+		splitCSV(opts.SkillsOverviewPinned),
+	)
 	gwOpts = append(
 		gwOpts,
 		gateway.WithRunOptionResolver(
@@ -2432,14 +2454,22 @@ func newAgent(
 	cwd, _ := os.Getwd()
 	roots := resolveSkillRoots(cwd, cfg)
 	bundledRoot := resolveBundledSkillsRoot(cwd, cfg.StateDir)
-	repo, err := ocskills.NewRepository(
-		roots,
+	repoOptions := []ocskills.Option{
 		ocskills.WithDebug(cfg.SkillsDebug),
 		ocskills.WithConfigKeys(cfg.SkillConfigKeys),
 		ocskills.WithBundledSkillsRoot(bundledRoot),
 		ocskills.WithAllowBundled(cfg.SkillsAllowBundled),
 		ocskills.WithSkillConfigs(cfg.SkillConfigs),
-	)
+	}
+	if cfg.SkillsSummaryCacheTTL > 0 {
+		repoOptions = append(
+			repoOptions,
+			ocskills.WithSummaryCacheDirtyCheckTTL(
+				cfg.SkillsSummaryCacheTTL,
+			),
+		)
+	}
+	repo, err := ocskills.NewRepository(roots, repoOptions...)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -2559,7 +2589,16 @@ func buildOpenClawSkillsGuidance(cfg agentConfig) string {
 	if cfg.SkillsToolingGuide != nil {
 		return strings.TrimSpace(*cfg.SkillsToolingGuide)
 	}
-	return strings.TrimSpace(openClawSkillsGuidance)
+	guidance := strings.TrimSpace(openClawSkillsGuidance)
+	if cfg.SkillsOverviewLimit > 0 {
+		guidance = strings.Replace(
+			guidance,
+			openClawSkillsPathGuidance,
+			openClawCompactSkillsGuidance,
+			1,
+		)
+	}
+	return guidance
 }
 
 func hasToolNamed(tools []tool.Tool, name string) bool {
@@ -2739,22 +2778,25 @@ type agentConfig struct {
 	Instruction                                   string
 	SystemPrompt                                  string
 
-	SkillsRoot          string
-	SkillsExtraDirs     []string
-	SkillsDebug         bool
-	SkillsAllowBundled  []string
-	SkillConfigs        map[string]ocskills.SkillConfig
-	SkillConfigKeys     []string
-	SkillsWatch         bool
-	SkillsWatchBundled  bool
-	SkillsWatchDebounce time.Duration
-	SkillsToolProfile   string
-	SkillsLoadMode      string
-	SkillsMaxLoaded     int
-	SkillsToolResults   bool
-	SkillsSkipFallback  bool
-	SkillsToolingGuide  *string
-	KnowledgesConfig    []knowledgeEntry
+	SkillsRoot            string
+	SkillsExtraDirs       []string
+	SkillsDebug           bool
+	SkillsAllowBundled    []string
+	SkillConfigs          map[string]ocskills.SkillConfig
+	SkillConfigKeys       []string
+	SkillsWatch           bool
+	SkillsWatchBundled    bool
+	SkillsWatchDebounce   time.Duration
+	SkillsSummaryCacheTTL time.Duration
+	SkillsOverviewLimit   int
+	SkillsOverviewPinned  []string
+	SkillsToolProfile     string
+	SkillsLoadMode        string
+	SkillsMaxLoaded       int
+	SkillsToolResults     bool
+	SkillsSkipFallback    bool
+	SkillsToolingGuide    *string
+	KnowledgesConfig      []knowledgeEntry
 
 	StateDir string
 

--- a/openclaw/app/latency_diagnostics.go
+++ b/openclaw/app/latency_diagnostics.go
@@ -1,0 +1,64 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package app
+
+import (
+	"context"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/log"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/gateway"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/latencydiag"
+)
+
+func appendLatencyDiagnosticsGatewayOption(
+	opts []gateway.Option,
+	stateDir string,
+	enabled bool,
+	emitEvents bool,
+) []gateway.Option {
+	if !enabled {
+		return opts
+	}
+	return append(
+		opts,
+		gateway.WithRunOptionResolver(
+			buildLatencyDiagnosticsRunOptionResolver(
+				stateDir,
+				emitEvents,
+			),
+		),
+	)
+}
+
+func buildLatencyDiagnosticsRunOptionResolver(
+	stateDir string,
+	emitEvents bool,
+) gateway.RunOptionResolver {
+	return func(
+		ctx context.Context,
+		_ gateway.RunOptionInput,
+	) (context.Context, []agent.RunOption, error) {
+		enabled, err := latencydiag.Enabled(stateDir)
+		if err != nil {
+			log.Warnf(
+				"openclaw: read latency diagnostics state failed: %v",
+				err,
+			)
+		}
+		if !enabled {
+			return ctx, nil, nil
+		}
+		return ctx, []agent.RunOption{
+			agent.WithLatencyDiagnostics(true),
+			agent.WithLatencyDiagnosticsEvents(emitEvents),
+		}, nil
+	}
+}

--- a/openclaw/app/latency_diagnostics_test.go
+++ b/openclaw/app/latency_diagnostics_test.go
@@ -1,0 +1,74 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package app
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/gateway"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/latencydiag"
+)
+
+func TestAppendLatencyDiagnosticsGatewayOptionDisabled(t *testing.T) {
+	t.Parallel()
+
+	opts := appendLatencyDiagnosticsGatewayOption(nil, t.TempDir(), false, false)
+	require.Nil(t, opts)
+}
+
+func TestBuildLatencyDiagnosticsRunOptionResolver(t *testing.T) {
+	t.Parallel()
+
+	resolver := buildLatencyDiagnosticsRunOptionResolver(t.TempDir(), false)
+	_, runOpts, err := resolver(context.Background(), gateway.RunOptionInput{})
+	require.NoError(t, err)
+	require.Len(t, runOpts, 2)
+
+	cfg := agent.RunOptions{}
+	for _, opt := range runOpts {
+		opt(&cfg)
+	}
+	require.True(t, cfg.LatencyDiagnosticsEnabled)
+	require.False(t, cfg.LatencyDiagnosticsEmitEvents)
+}
+
+func TestBuildLatencyDiagnosticsRunOptionResolverEvents(t *testing.T) {
+	t.Parallel()
+
+	resolver := buildLatencyDiagnosticsRunOptionResolver(t.TempDir(), true)
+	_, runOpts, err := resolver(context.Background(), gateway.RunOptionInput{})
+	require.NoError(t, err)
+	require.Len(t, runOpts, 2)
+
+	cfg := agent.RunOptions{}
+	for _, opt := range runOpts {
+		opt(&cfg)
+	}
+	require.True(t, cfg.LatencyDiagnosticsEnabled)
+	require.True(t, cfg.LatencyDiagnosticsEmitEvents)
+}
+
+func TestBuildLatencyDiagnosticsRunOptionResolverStateOff(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	stateDir := t.TempDir()
+	require.NoError(t, latencydiag.SetEnabled(stateDir, false))
+
+	resolver := buildLatencyDiagnosticsRunOptionResolver(stateDir, true)
+	_, runOpts, err := resolver(context.Background(), gateway.RunOptionInput{})
+	require.NoError(t, err)
+	require.Nil(t, runOpts)
+}

--- a/openclaw/app/run_options.go
+++ b/openclaw/app/run_options.go
@@ -91,15 +91,18 @@ const (
 
 	flagEnableParallelTools = "enable-parallel-tools"
 
-	flagSkillsAllowBundled  = "skills-allow-bundled"
-	flagSkillsWatch         = "skills-watch"
-	flagSkillsWatchBundled  = "skills-watch-bundled"
-	flagSkillsWatchDebounce = "skills-watch-debounce"
-	flagSkillsToolProfile   = "skills-tool-profile"
-	flagSkillsLoadMode      = "skills-load-mode"
-	flagSkillsMaxLoaded     = "skills-max-loaded"
-	flagSkillsToolResults   = "skills-loaded-content-in-tool-results"
-	flagSkillsSkipFallback  = "skills-skip-fallback-on-session-summary"
+	flagSkillsAllowBundled    = "skills-allow-bundled"
+	flagSkillsWatch           = "skills-watch"
+	flagSkillsWatchBundled    = "skills-watch-bundled"
+	flagSkillsWatchDebounce   = "skills-watch-debounce"
+	flagSkillsSummaryCacheTTL = "skills-summary-cache-ttl"
+	flagSkillsOverviewLimit   = "skills-overview-limit"
+	flagSkillsOverviewPinned  = "skills-overview-pinned"
+	flagSkillsToolProfile     = "skills-tool-profile"
+	flagSkillsLoadMode        = "skills-load-mode"
+	flagSkillsMaxLoaded       = "skills-max-loaded"
+	flagSkillsToolResults     = "skills-loaded-content-in-tool-results"
+	flagSkillsSkipFallback    = "skills-skip-fallback-on-session-summary"
 
 	flagDebugRecorder     = "debug-recorder"
 	flagDebugRecorderDir  = "debug-recorder-dir"
@@ -173,28 +176,31 @@ type runOptions struct {
 	ClaudeEnv          string
 	ClaudeWorkDir      string
 
-	ModelMode           string
-	OpenAIModel         string
-	OpenAIVariant       string
-	OpenAIBaseURL       string
-	GenerationConfig    *model.GenerationConfig
-	ModelConfig         *yaml.Node
-	KnowledgesConfig    []knowledgeEntry
-	SkillsRoot          string
-	SkillsExtraDir      string
-	SkillsDebug         bool
-	SkillsAllowBundled  string
-	SkillConfigs        map[string]ocskills.SkillConfig
-	SkillsWatch         bool
-	SkillsWatchBundled  bool
-	SkillsWatchDebounce time.Duration
-	SkillsToolProfile   string
-	SkillsLoadMode      string
-	SkillsMaxLoaded     int
-	SkillsToolResults   bool
-	SkillsSkipFallback  bool
-	SkillsToolingGuide  *string
-	StateDir            string
+	ModelMode             string
+	OpenAIModel           string
+	OpenAIVariant         string
+	OpenAIBaseURL         string
+	GenerationConfig      *model.GenerationConfig
+	ModelConfig           *yaml.Node
+	KnowledgesConfig      []knowledgeEntry
+	SkillsRoot            string
+	SkillsExtraDir        string
+	SkillsDebug           bool
+	SkillsAllowBundled    string
+	SkillConfigs          map[string]ocskills.SkillConfig
+	SkillsWatch           bool
+	SkillsWatchBundled    bool
+	SkillsWatchDebounce   time.Duration
+	SkillsSummaryCacheTTL time.Duration
+	SkillsOverviewLimit   int
+	SkillsOverviewPinned  string
+	SkillsToolProfile     string
+	SkillsLoadMode        string
+	SkillsMaxLoaded       int
+	SkillsToolResults     bool
+	SkillsSkipFallback    bool
+	SkillsToolingGuide    *string
+	StateDir              string
 
 	DebugRecorderEnabled bool
 	DebugRecorderDir     string
@@ -599,6 +605,27 @@ func parseRunOptions(args []string) (runOptions, error) {
 		flagSkillsWatchBundled,
 		false,
 		"Also watch bundled skills roots for local changes",
+	)
+	fs.DurationVar(
+		&opts.SkillsSummaryCacheTTL,
+		flagSkillsSummaryCacheTTL,
+		0,
+		"How long to reuse the skills summary cache before "+
+			"checking for changes (0 uses the default)",
+	)
+	fs.IntVar(
+		&opts.SkillsOverviewLimit,
+		flagSkillsOverviewLimit,
+		0,
+		"Show at most N skills in the skills overview "+
+			"(0 shows all)",
+	)
+	fs.StringVar(
+		&opts.SkillsOverviewPinned,
+		flagSkillsOverviewPinned,
+		"",
+		"Comma-separated skill names to show first when "+
+			"skills-overview-limit is set",
 	)
 	fs.StringVar(
 		&opts.SkillsToolProfile,
@@ -1055,19 +1082,25 @@ type skillsConfig struct {
 	ExtraDirs []string `yaml:"extra_dirs,omitempty"`
 	Debug     *bool    `yaml:"debug,omitempty"`
 
-	AllowBundled       []string `yaml:"allow_bundled,omitempty"`
-	AllowBundledCamel  []string `yaml:"allowBundled,omitempty"`
-	Watch              *bool    `yaml:"watch,omitempty"`
-	WatchBundled       *bool    `yaml:"watch_bundled,omitempty"`
-	WatchBundledCamel  *bool    `yaml:"watchBundled,omitempty"`
-	WatchDebounceMS    *int     `yaml:"watch_debounce_ms,omitempty"`
-	WatchDebounceCamel *int     `yaml:"watchDebounceMs,omitempty"`
-	ToolProfile        *string  `yaml:"tool_profile,omitempty"`
-	ToolProfileCamel   *string  `yaml:"toolProfile,omitempty"`
-	LoadMode           *string  `yaml:"load_mode,omitempty"`
-	LoadModeCamel      *string  `yaml:"loadMode,omitempty"`
-	MaxLoadedSkills    *int     `yaml:"max_loaded_skills,omitempty"`
-	MaxLoadedCamel     *int     `yaml:"maxLoadedSkills,omitempty"`
+	AllowBundled        []string `yaml:"allow_bundled,omitempty"`
+	AllowBundledCamel   []string `yaml:"allowBundled,omitempty"`
+	Watch               *bool    `yaml:"watch,omitempty"`
+	WatchBundled        *bool    `yaml:"watch_bundled,omitempty"`
+	WatchBundledCamel   *bool    `yaml:"watchBundled,omitempty"`
+	WatchDebounceMS     *int     `yaml:"watch_debounce_ms,omitempty"`
+	WatchDebounceCamel  *int     `yaml:"watchDebounceMs,omitempty"`
+	SummaryCacheTTLMS   *int     `yaml:"summary_cache_ttl_ms,omitempty"`
+	SummaryCacheCamel   *int     `yaml:"summaryCacheTtlMs,omitempty"`
+	OverviewLimit       *int     `yaml:"overview_limit,omitempty"`
+	OverviewLimitCamel  *int     `yaml:"overviewLimit,omitempty"`
+	OverviewPinned      []string `yaml:"overview_pinned,omitempty"`
+	OverviewPinnedCamel []string `yaml:"overviewPinned,omitempty"`
+	ToolProfile         *string  `yaml:"tool_profile,omitempty"`
+	ToolProfileCamel    *string  `yaml:"toolProfile,omitempty"`
+	LoadMode            *string  `yaml:"load_mode,omitempty"`
+	LoadModeCamel       *string  `yaml:"loadMode,omitempty"`
+	MaxLoadedSkills     *int     `yaml:"max_loaded_skills,omitempty"`
+	MaxLoadedCamel      *int     `yaml:"maxLoadedSkills,omitempty"`
 
 	ToolResults          *bool   `yaml:"loaded_content_in_tool_results,omitempty"`
 	ToolResultsCamel     *bool   `yaml:"loadedContentInToolResults,omitempty"`
@@ -1576,6 +1609,35 @@ func (cfg *fileConfig) apply(
 				*watchDebounceMS,
 			) * time.Millisecond
 		}
+		summaryCacheTTLMS := firstIntPtr(
+			cfg.Skills.SummaryCacheTTLMS,
+			cfg.Skills.SummaryCacheCamel,
+		)
+		if summaryCacheTTLMS != nil &&
+			!flagWasSet(set, flagSkillsSummaryCacheTTL) {
+			opts.SkillsSummaryCacheTTL = time.Duration(
+				*summaryCacheTTLMS,
+			) * time.Millisecond
+		}
+		overviewLimit := firstIntPtr(
+			cfg.Skills.OverviewLimit,
+			cfg.Skills.OverviewLimitCamel,
+		)
+		if overviewLimit != nil &&
+			!flagWasSet(set, flagSkillsOverviewLimit) {
+			opts.SkillsOverviewLimit = *overviewLimit
+		}
+		overviewPinned := cfg.Skills.OverviewPinned
+		if len(overviewPinned) == 0 {
+			overviewPinned = cfg.Skills.OverviewPinnedCamel
+		}
+		if len(overviewPinned) > 0 &&
+			!flagWasSet(set, flagSkillsOverviewPinned) {
+			opts.SkillsOverviewPinned = strings.Join(
+				overviewPinned,
+				csvDelimiter,
+			)
+		}
 		if len(cfg.Skills.Entries) > 0 {
 			opts.SkillConfigs = convertSkillConfigs(
 				cfg.Skills.Entries,
@@ -2057,6 +2119,18 @@ func finalizeRunOptions(opts *runOptions) error {
 		return fmt.Errorf(
 			"invalid skills watch debounce: %v",
 			opts.SkillsWatchDebounce,
+		)
+	}
+	if opts.SkillsSummaryCacheTTL < 0 {
+		return fmt.Errorf(
+			"invalid skills summary cache ttl: %v",
+			opts.SkillsSummaryCacheTTL,
+		)
+	}
+	if opts.SkillsOverviewLimit < 0 {
+		return fmt.Errorf(
+			"invalid skills overview limit: %d",
+			opts.SkillsOverviewLimit,
 		)
 	}
 	opts.MemoryBackend = resolveMemoryBackendType(opts.MemoryBackend)

--- a/openclaw/app/run_options.go
+++ b/openclaw/app/run_options.go
@@ -108,6 +108,9 @@ const (
 	flagDebugRecorderDir  = "debug-recorder-dir"
 	flagDebugRecorderMode = "debug-recorder-mode"
 
+	flagLatencyDiagnostics       = "latency-diagnostics"
+	flagLatencyDiagnosticsEvents = "latency-diagnostics-events"
+
 	flagAdminEnabled  = "admin-enabled"
 	flagAdminAddr     = "admin-addr"
 	flagAdminAutoPort = "admin-auto-port"
@@ -136,6 +139,8 @@ type runOptions struct {
 	LangfuseUIBaseURL                    string
 	LangfuseTraceURLTemplate             string
 	LangfuseObservationLeafValueMaxBytes *int
+	LatencyDiagnosticsEnabled            bool
+	LatencyDiagnosticsEvents             bool
 
 	A2AEnabled        bool
 	A2AHost           string
@@ -682,6 +687,18 @@ func parseRunOptions(args []string) (runOptions, error) {
 		"",
 		"Debug recorder mode: full|safe (default: full)",
 	)
+	fs.BoolVar(
+		&opts.LatencyDiagnosticsEnabled,
+		flagLatencyDiagnostics,
+		false,
+		"Enable per-request latency diagnostic spans",
+	)
+	fs.BoolVar(
+		&opts.LatencyDiagnosticsEvents,
+		flagLatencyDiagnosticsEvents,
+		false,
+		"Emit latency diagnostic runner events",
+	)
 	fs.StringVar(
 		&opts.SessionBackend,
 		"session-backend",
@@ -979,7 +996,8 @@ type adminConfig struct {
 }
 
 type observabilityConfig struct {
-	Langfuse *langfuseConfig `yaml:"langfuse,omitempty"`
+	Langfuse    *langfuseConfig           `yaml:"langfuse,omitempty"`
+	LatencyDiag *latencyDiagnosticsConfig `yaml:"latency_diagnostics,omitempty"`
 }
 
 type langfuseConfig struct {
@@ -988,6 +1006,11 @@ type langfuseConfig struct {
 	UIBaseURL                    *string `yaml:"ui_base_url,omitempty"`
 	TraceURLTemplate             *string `yaml:"trace_url_template,omitempty"`
 	ObservationLeafValueMaxBytes *int    `yaml:"observation_leaf_value_max_bytes,omitempty"`
+}
+
+type latencyDiagnosticsConfig struct {
+	Enabled *bool `yaml:"enabled,omitempty"`
+	Events  *bool `yaml:"events,omitempty"`
 }
 
 type a2aConfig struct {
@@ -1347,12 +1370,20 @@ func (cfg *fileConfig) apply(
 			opts.AdminAutoPort = *cfg.Admin.AutoPort
 		}
 	}
-	if cfg.Observability != nil &&
-		cfg.Observability.Langfuse != nil {
-		applyLangfuseConfig(
-			cfg.Observability.Langfuse,
-			opts,
-		)
+	if cfg.Observability != nil {
+		if cfg.Observability.Langfuse != nil {
+			applyLangfuseConfig(
+				cfg.Observability.Langfuse,
+				opts,
+			)
+		}
+		if cfg.Observability.LatencyDiag != nil {
+			applyLatencyDiagnosticsConfig(
+				cfg.Observability.LatencyDiag,
+				opts,
+				set,
+			)
+		}
 	}
 	if cfg.A2A != nil {
 		if cfg.A2A.Enabled != nil &&
@@ -1829,6 +1860,22 @@ func applyLangfuseConfig(
 	if cfg.ObservationLeafValueMaxBytes != nil {
 		value := *cfg.ObservationLeafValueMaxBytes
 		opts.LangfuseObservationLeafValueMaxBytes = &value
+	}
+}
+
+func applyLatencyDiagnosticsConfig(
+	cfg *latencyDiagnosticsConfig,
+	opts *runOptions,
+	set map[string]struct{},
+) {
+	if cfg == nil || opts == nil {
+		return
+	}
+	if cfg.Enabled != nil && !flagWasSet(set, flagLatencyDiagnostics) {
+		opts.LatencyDiagnosticsEnabled = *cfg.Enabled
+	}
+	if cfg.Events != nil && !flagWasSet(set, flagLatencyDiagnosticsEvents) {
+		opts.LatencyDiagnosticsEvents = *cfg.Events
 	}
 }
 

--- a/openclaw/app/run_options_test.go
+++ b/openclaw/app/run_options_test.go
@@ -341,6 +341,9 @@ observability:
     ui_base_url: " http://127.0.0.1:3000/ "
     trace_url_template: " http://127.0.0.1:3000/project/local-dev/traces/{{trace_id}} "
     observation_leaf_value_max_bytes: 4096
+  latency_diagnostics:
+    enabled: true
+    events: true
 `)
 
 	opts, err := parseRunOptions([]string{"-config", cfgPath})
@@ -359,6 +362,30 @@ observability:
 		4096,
 		*opts.LangfuseObservationLeafValueMaxBytes,
 	)
+	require.True(t, opts.LatencyDiagnosticsEnabled)
+	require.True(t, opts.LatencyDiagnosticsEvents)
+}
+
+func TestParseRunOptions_LatencyDiagnosticsFlagsOverrideConfig(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	cfgPath := writeTempConfig(t, `
+observability:
+  latency_diagnostics:
+    enabled: true
+    events: true
+`)
+
+	opts, err := parseRunOptions([]string{
+		"-config", cfgPath,
+		"-latency-diagnostics=false",
+		"-latency-diagnostics-events=false",
+	})
+	require.NoError(t, err)
+	require.False(t, opts.LatencyDiagnosticsEnabled)
+	require.False(t, opts.LatencyDiagnosticsEvents)
 }
 
 func TestParseRunOptions_UsesDefaultConfigPath(t *testing.T) {
@@ -1322,6 +1349,8 @@ func TestParseRunOptions_SkillsDefaults(t *testing.T) {
 	require.True(t, opts.SkillsSkipFallback)
 	require.Zero(t, opts.SkillsMaxLoaded)
 	require.Nil(t, opts.SkillsToolingGuide)
+	require.False(t, opts.LatencyDiagnosticsEnabled)
+	require.False(t, opts.LatencyDiagnosticsEvents)
 }
 
 func TestParseRunOptions_SkillsLoadMode_InvalidFails(t *testing.T) {

--- a/openclaw/app/run_options_test.go
+++ b/openclaw/app/run_options_test.go
@@ -779,6 +779,9 @@ skills:
   watch: false
   watch_bundled: true
   watch_debounce_ms: 125
+  summary_cache_ttl_ms: 60000
+  overview_limit: 12
+  overview_pinned: ["coding-agent","skill-creator"]
   tool_profile: "knowledge_only"
   load_mode: "session"
   max_loaded_skills: 3
@@ -923,6 +926,13 @@ memory:
 	require.False(t, opts.SkillsWatch)
 	require.True(t, opts.SkillsWatchBundled)
 	require.Equal(t, 125*time.Millisecond, opts.SkillsWatchDebounce)
+	require.Equal(t, time.Minute, opts.SkillsSummaryCacheTTL)
+	require.Equal(t, 12, opts.SkillsOverviewLimit)
+	require.Equal(
+		t,
+		"coding-agent,skill-creator",
+		opts.SkillsOverviewPinned,
+	)
 	require.Equal(
 		t,
 		skillprofile.KnowledgeOnly,
@@ -1081,6 +1091,45 @@ skills:
 	})
 	require.NoError(t, err)
 	require.Equal(t, "b,c", opts.SkillsAllowBundled)
+}
+
+func TestParseRunOptions_SkillsSummaryCacheTTLFlagOverridesConfig(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	cfgPath := writeTempConfig(t, `
+skills:
+  summary_cache_ttl_ms: 1000
+`)
+
+	opts, err := parseRunOptions([]string{
+		"-config", cfgPath,
+		"-skills-summary-cache-ttl", "2m",
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2*time.Minute, opts.SkillsSummaryCacheTTL)
+}
+
+func TestParseRunOptions_SkillsOverviewFlagOverridesConfig(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	cfgPath := writeTempConfig(t, `
+skills:
+  overview_limit: 4
+  overview_pinned: ["alpha"]
+`)
+
+	opts, err := parseRunOptions([]string{
+		"-config", cfgPath,
+		"-skills-overview-limit", "2",
+		"-skills-overview-pinned", "beta,gamma",
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, opts.SkillsOverviewLimit)
+	require.Equal(t, "beta,gamma", opts.SkillsOverviewPinned)
 }
 
 func TestParseRunOptions_KnowledgesProvidersConfig(t *testing.T) {
@@ -1260,6 +1309,9 @@ func TestParseRunOptions_SkillsDefaults(t *testing.T) {
 		defaultSkillsWatchDebounce,
 		opts.SkillsWatchDebounce,
 	)
+	require.Zero(t, opts.SkillsSummaryCacheTTL)
+	require.Zero(t, opts.SkillsOverviewLimit)
+	require.Empty(t, opts.SkillsOverviewPinned)
 	require.Equal(
 		t,
 		defaultSkillsToolProfile,
@@ -1466,5 +1518,35 @@ func TestFinalizeRunOptions_SkillsWatchDebounce(t *testing.T) {
 		t,
 		err,
 		"invalid skills watch debounce: -1ms",
+	)
+}
+
+func TestFinalizeRunOptions_SkillsSummaryCacheTTL(t *testing.T) {
+	t.Parallel()
+
+	opts := &runOptions{
+		SkillsSummaryCacheTTL: -time.Millisecond,
+	}
+
+	err := finalizeRunOptions(opts)
+	require.EqualError(
+		t,
+		err,
+		"invalid skills summary cache ttl: -1ms",
+	)
+}
+
+func TestFinalizeRunOptions_SkillsOverviewLimit(t *testing.T) {
+	t.Parallel()
+
+	opts := &runOptions{
+		SkillsOverviewLimit: -1,
+	}
+
+	err := finalizeRunOptions(opts)
+	require.EqualError(
+		t,
+		err,
+		"invalid skills overview limit: -1",
 	)
 }

--- a/openclaw/app/run_options_test.go
+++ b/openclaw/app/run_options_test.go
@@ -1159,6 +1159,23 @@ skills:
 	require.Equal(t, "beta,gamma", opts.SkillsOverviewPinned)
 }
 
+func TestParseRunOptions_SkillsCamelCaseConfig(t *testing.T) {
+	t.Parallel()
+
+	cfgPath := writeTempConfig(t, `
+skills:
+  summaryCacheTtlMs: 1500
+  overviewLimit: 3
+  overviewPinned: ["alpha","beta"]
+`)
+
+	opts, err := parseRunOptions([]string{"-config", cfgPath})
+	require.NoError(t, err)
+	require.Equal(t, 1500*time.Millisecond, opts.SkillsSummaryCacheTTL)
+	require.Equal(t, 3, opts.SkillsOverviewLimit)
+	require.Equal(t, "alpha,beta", opts.SkillsOverviewPinned)
+}
+
 func TestParseRunOptions_KnowledgesProvidersConfig(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/app/skills_overview.go
+++ b/openclaw/app/skills_overview.go
@@ -126,8 +126,12 @@ func selectCompactSkillSummaries(
 		}
 		byName[name] = summary
 	}
+	total := len(byName)
+	if total == 0 {
+		return nil, 0
+	}
 
-	selected := make([]skill.Summary, 0, minInt(limit, len(summaries)))
+	selected := make([]skill.Summary, 0, minInt(limit, total))
 	seen := map[string]struct{}{}
 	appendByName := func(name string) bool {
 		summary, ok := byName[name]
@@ -144,15 +148,15 @@ func selectCompactSkillSummaries(
 
 	for _, name := range pinned {
 		if appendByName(name) {
-			return selected, len(summaries) - len(selected)
+			return selected, total - len(selected)
 		}
 	}
 	for _, summary := range summaries {
 		if appendByName(strings.TrimSpace(summary.Name)) {
-			return selected, len(summaries) - len(selected)
+			return selected, total - len(selected)
 		}
 	}
-	return selected, len(summaries) - len(selected)
+	return selected, total - len(selected)
 }
 
 func normalizePinnedSkillNames(pinned []string) []string {

--- a/openclaw/app/skills_overview.go
+++ b/openclaw/app/skills_overview.go
@@ -1,0 +1,183 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package app
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/gateway"
+	"trpc.group/trpc-go/trpc-agent-go/skill"
+)
+
+const (
+	compactSkillsOverviewHeader = "Available skills:"
+	compactSkillsMoreFmt        = "- %d more skills are available. " +
+		"Use `skill_list` to explore the full catalog before " +
+		"loading a skill not shown here.\n"
+)
+
+func appendSkillsOverviewGatewayOption(
+	opts []gateway.Option,
+	limit int,
+	pinned []string,
+) []gateway.Option {
+	resolver := buildSkillsOverviewRunOptionResolver(limit, pinned)
+	if resolver == nil {
+		return opts
+	}
+	return append(opts, gateway.WithRunOptionResolver(resolver))
+}
+
+func buildSkillsOverviewRunOptionResolver(
+	limit int,
+	pinned []string,
+) gateway.RunOptionResolver {
+	renderer := newSkillsOverviewRenderer(limit, pinned)
+	if renderer == nil {
+		return nil
+	}
+	return func(
+		ctx context.Context,
+		_ gateway.RunOptionInput,
+	) (context.Context, []agent.RunOption, error) {
+		return ctx, []agent.RunOption{
+			agent.WithAvailableSkillsRenderer(renderer),
+		}, nil
+	}
+}
+
+func newSkillsOverviewRenderer(
+	limit int,
+	pinned []string,
+) agent.AvailableSkillsRenderer {
+	if limit <= 0 {
+		return nil
+	}
+	pinned = normalizePinnedSkillNames(pinned)
+	return func(
+		ctx context.Context,
+		req agent.AvailableSkillsRenderRequest,
+	) string {
+		_ = ctx
+		return renderCompactSkillsOverview(
+			req.Summaries,
+			limit,
+			pinned,
+		)
+	}
+}
+
+func renderCompactSkillsOverview(
+	summaries []skill.Summary,
+	limit int,
+	pinned []string,
+) string {
+	selected, omitted := selectCompactSkillSummaries(
+		summaries,
+		limit,
+		pinned,
+	)
+	if len(selected) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString(compactSkillsOverviewHeader)
+	b.WriteByte('\n')
+	for _, summary := range selected {
+		fmt.Fprintf(
+			&b,
+			"- %s: %s\n",
+			strings.TrimSpace(summary.Name),
+			strings.TrimSpace(summary.Description),
+		)
+	}
+	if omitted > 0 {
+		fmt.Fprintf(&b, compactSkillsMoreFmt, omitted)
+	}
+	return b.String()
+}
+
+func selectCompactSkillSummaries(
+	summaries []skill.Summary,
+	limit int,
+	pinned []string,
+) ([]skill.Summary, int) {
+	if limit <= 0 || len(summaries) == 0 {
+		return nil, 0
+	}
+
+	byName := map[string]skill.Summary{}
+	for _, summary := range summaries {
+		name := strings.TrimSpace(summary.Name)
+		if name == "" {
+			continue
+		}
+		byName[name] = summary
+	}
+
+	selected := make([]skill.Summary, 0, minInt(limit, len(summaries)))
+	seen := map[string]struct{}{}
+	appendByName := func(name string) bool {
+		summary, ok := byName[name]
+		if !ok {
+			return false
+		}
+		if _, ok := seen[name]; ok {
+			return false
+		}
+		selected = append(selected, summary)
+		seen[name] = struct{}{}
+		return len(selected) >= limit
+	}
+
+	for _, name := range pinned {
+		if appendByName(name) {
+			return selected, len(summaries) - len(selected)
+		}
+	}
+	for _, summary := range summaries {
+		if appendByName(strings.TrimSpace(summary.Name)) {
+			return selected, len(summaries) - len(selected)
+		}
+	}
+	return selected, len(summaries) - len(selected)
+}
+
+func normalizePinnedSkillNames(pinned []string) []string {
+	if len(pinned) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(pinned))
+	seen := map[string]struct{}{}
+	for _, raw := range pinned {
+		name := strings.TrimSpace(raw)
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+	return out
+}
+
+func minInt(a int, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/openclaw/app/skills_overview_test.go
+++ b/openclaw/app/skills_overview_test.go
@@ -1,0 +1,81 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package app
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/gateway"
+	"trpc.group/trpc-go/trpc-agent-go/skill"
+)
+
+func TestRenderCompactSkillsOverviewPinnedAndOmitted(t *testing.T) {
+	t.Parallel()
+
+	summaries := []skill.Summary{
+		{Name: "alpha", Description: "Alpha skill"},
+		{Name: "beta", Description: "Beta skill"},
+		{Name: "gamma", Description: "Gamma skill"},
+	}
+
+	got := renderCompactSkillsOverview(
+		summaries,
+		2,
+		[]string{"gamma", "missing"},
+	)
+
+	require.True(t, strings.HasPrefix(
+		got,
+		"Available skills:\n- gamma: Gamma skill\n- alpha: Alpha skill\n",
+	))
+	require.Contains(t, got, "1 more skills are available")
+	require.Contains(t, got, "skill_list")
+	require.NotContains(t, got, "- beta: Beta skill")
+}
+
+func TestNewSkillsOverviewRendererDisabled(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, newSkillsOverviewRenderer(0, []string{"alpha"}))
+}
+
+func TestBuildSkillsOverviewRunOptionResolver(t *testing.T) {
+	t.Parallel()
+
+	resolver := buildSkillsOverviewRunOptionResolver(1, []string{"beta"})
+	require.NotNil(t, resolver)
+
+	_, runOpts, err := resolver(
+		context.Background(),
+		gateway.RunOptionInput{},
+	)
+	require.NoError(t, err)
+
+	opts := agent.NewRunOptions(runOpts...)
+	require.NotNil(t, opts.AvailableSkillsRenderer)
+
+	got := opts.AvailableSkillsRenderer(
+		context.Background(),
+		agent.AvailableSkillsRenderRequest{
+			Summaries: []skill.Summary{
+				{Name: "alpha", Description: "Alpha skill"},
+				{Name: "beta", Description: "Beta skill"},
+			},
+		},
+	)
+	require.Contains(t, got, "- beta: Beta skill")
+	require.NotContains(t, got, "- alpha: Alpha skill")
+}

--- a/openclaw/app/skills_overview_test.go
+++ b/openclaw/app/skills_overview_test.go
@@ -46,6 +46,25 @@ func TestRenderCompactSkillsOverviewPinnedAndOmitted(t *testing.T) {
 	require.NotContains(t, got, "- beta: Beta skill")
 }
 
+func TestRenderCompactSkillsOverviewOmittedUsesUniqueSkills(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	summaries := []skill.Summary{
+		{Name: "alpha", Description: "Alpha skill"},
+		{Name: " ", Description: "Blank skill"},
+		{Name: "beta", Description: "Beta skill"},
+		{Name: "alpha", Description: "Alpha updated"},
+		{Name: "gamma", Description: "Gamma skill"},
+	}
+
+	got := renderCompactSkillsOverview(summaries, 2, nil)
+
+	require.Contains(t, got, "1 more skills are available")
+	require.NotContains(t, got, "3 more skills are available")
+}
+
 func TestNewSkillsOverviewRendererDisabled(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/internal/skills/repository.go
+++ b/openclaw/internal/skills/repository.go
@@ -72,6 +72,7 @@ type Repository struct {
 	summaries             []skill.Summary
 	summaryFingerprints   map[string]summaryFileFingerprint
 	summaryCacheExpiresAt time.Time
+	summaryCacheTTL       time.Duration
 
 	baseDirs map[string]string
 
@@ -129,6 +130,16 @@ func WithSkillConfigs(cfg map[string]SkillConfig) Option {
 	}
 }
 
+// WithSummaryCacheDirtyCheckTTL sets how long Summaries can reuse cached
+// results before checking skill files for changes.
+func WithSummaryCacheDirtyCheckTTL(ttl time.Duration) Option {
+	return func(r *Repository) {
+		if ttl > 0 {
+			r.summaryCacheTTL = ttl
+		}
+	}
+}
+
 func NewRepository(roots []string, opts ...Option) (*Repository, error) {
 	base, err := skill.NewFSRepository(roots...)
 	if err != nil {
@@ -143,6 +154,8 @@ func NewRepository(roots []string, opts ...Option) (*Repository, error) {
 		baseDirs: map[string]string{},
 		metas:    map[string]*openClawMetadata{},
 		skillKey: map[string]string{},
+
+		summaryCacheTTL: summaryCacheDirtyCheckTTL,
 	}
 	for _, opt := range opts {
 		if opt != nil {
@@ -401,12 +414,13 @@ func (r *Repository) SetSkillEnabled(
 }
 
 func (r *Repository) indexLocked() {
+	now := time.Now()
 	if r.base == nil {
 		r.eligible = map[string]struct{}{}
 		r.reasons = map[string]string{}
 		r.summaries = nil
 		r.summaryFingerprints = map[string]summaryFileFingerprint{}
-		r.summaryCacheExpiresAt = time.Now().Add(summaryCacheDirtyCheckTTL)
+		r.summaryCacheExpiresAt = r.summaryCacheExpiry(now)
 		r.baseDirs = map[string]string{}
 		r.metas = map[string]*openClawMetadata{}
 		r.skillKey = map[string]string{}
@@ -502,7 +516,7 @@ func (r *Repository) indexLocked() {
 	r.summaryFingerprints = scanSummaryFingerprints(
 		r.summaryScanRootsLocked(),
 	)
-	r.summaryCacheExpiresAt = time.Now().Add(summaryCacheDirtyCheckTTL)
+	r.summaryCacheExpiresAt = r.summaryCacheExpiry(now)
 	r.baseDirs = baseDirs
 	r.metas = metas
 	r.skillKey = skillKeys
@@ -513,19 +527,27 @@ func (r *Repository) summaryCacheExpiredLocked(now time.Time) bool {
 		!now.Before(r.summaryCacheExpiresAt)
 }
 
+func (r *Repository) summaryCacheExpiry(now time.Time) time.Time {
+	ttl := r.summaryCacheTTL
+	if ttl <= 0 {
+		ttl = summaryCacheDirtyCheckTTL
+	}
+	return now.Add(ttl)
+}
+
 func (r *Repository) refreshSummaryCacheIfDirtyLocked(now time.Time) {
 	if !r.summaryCacheExpiredLocked(now) {
 		return
 	}
 	current := scanSummaryFingerprints(r.summaryScanRootsLocked())
 	if summaryFingerprintsEqual(current, r.summaryFingerprints) {
-		r.summaryCacheExpiresAt = now.Add(summaryCacheDirtyCheckTTL)
+		r.summaryCacheExpiresAt = r.summaryCacheExpiry(now)
 		return
 	}
 	if refreshable, ok := r.base.(skill.RefreshableRepository); ok {
 		if err := refreshable.Refresh(); err != nil {
 			log.Warnf("skills summary refresh failed: %v", err)
-			r.summaryCacheExpiresAt = now.Add(summaryCacheDirtyCheckTTL)
+			r.summaryCacheExpiresAt = r.summaryCacheExpiry(now)
 			return
 		}
 	}

--- a/openclaw/internal/skills/repository_test.go
+++ b/openclaw/internal/skills/repository_test.go
@@ -1456,6 +1456,33 @@ description: "Probe weather prerequisites"
 	require.False(t, hit)
 }
 
+func TestRepositorySummaryCacheDirtyCheckTTL(t *testing.T) {
+	t.Parallel()
+
+	const customSummaryCacheTTL = time.Hour
+
+	root := t.TempDir()
+	writeSkill(t, root, "weather-probe", `---
+name: weather-probe
+description: "Probe weather prerequisites"
+---
+
+# weather-probe
+`)
+
+	repo, err := NewRepository(
+		[]string{root},
+		WithSummaryCacheDirtyCheckTTL(customSummaryCacheTTL),
+	)
+	require.NoError(t, err)
+
+	repo.mu.RLock()
+	expiresAt := repo.summaryCacheExpiresAt
+	repo.mu.RUnlock()
+
+	require.Greater(t, time.Until(expiresAt), customSummaryCacheTTL/2)
+}
+
 func TestRepositorySummaryFingerprintHelpers(t *testing.T) {
 	t.Parallel()
 

--- a/skill/repository.go
+++ b/skill/repository.go
@@ -28,6 +28,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -91,8 +92,20 @@ type RefreshableRepository interface {
 type FSRepository struct {
 	roots []string
 	mu    sync.RWMutex
-	// name -> directory path that contains SKILL.md
-	index map[string]string
+	// name -> cached skill entry.
+	index map[string]fsSkillEntry
+}
+
+type fsSkillEntry struct {
+	dir       string
+	file      string
+	summary   Summary
+	signature fsFileSignature
+}
+
+type fsFileSignature struct {
+	size    int64
+	modTime time.Time
 }
 
 // NewFSRepository creates a FSRepository scanning the given roots.
@@ -133,12 +146,12 @@ func (r *FSRepository) Refresh() error {
 // It allows staging the whole skill folder for execution.
 func (r *FSRepository) Path(name string) (string, error) {
 	r.mu.RLock()
-	dir, ok := r.index[name]
+	entry, ok := r.index[name]
 	r.mu.RUnlock()
 	if !ok {
 		return "", fmt.Errorf("skill %q not found", name)
 	}
-	return dir, nil
+	return entry.dir, nil
 }
 
 // Roots returns the configured filesystem roots.
@@ -148,8 +161,8 @@ func (r *FSRepository) Roots() []string {
 	return append([]string(nil), r.roots...)
 }
 
-func scanRoots(roots []string) (map[string]string, error) {
-	index := map[string]string{}
+func scanRoots(roots []string) (map[string]fsSkillEntry, error) {
+	index := map[string]fsSkillEntry{}
 	seen := map[string]struct{}{}
 	for _, root := range roots {
 		if root == "" {
@@ -173,8 +186,8 @@ func scanRoots(roots []string) (map[string]string, error) {
 				return nil
 			}
 			sf := filepath.Join(p, skillFile)
-			st, err2 := os.Stat(sf)
-			if err2 != nil || st.IsDir() {
+			info, err2 := os.Stat(sf)
+			if err2 != nil || info.IsDir() {
 				return nil
 			}
 			sum, err3 := parseSummary(sf)
@@ -188,9 +201,17 @@ func scanRoots(roots []string) (map[string]string, error) {
 			if strings.TrimSpace(name) == "" {
 				return nil
 			}
+			if strings.TrimSpace(sum.Name) == "" {
+				sum.Name = name
+			}
 			// Record first occurrence; later ones ignored.
 			if _, ok := index[name]; !ok {
-				index[name] = p
+				index[name] = fsSkillEntry{
+					dir:       p,
+					file:      sf,
+					summary:   sum,
+					signature: newFSFileSignature(info),
+				}
 			}
 			return nil
 		})
@@ -200,22 +221,13 @@ func scanRoots(roots []string) (map[string]string, error) {
 
 // Summaries implements Repository.
 func (r *FSRepository) Summaries() []Summary {
-	r.mu.RLock()
-	index := make(map[string]string, len(r.index))
-	for name, dir := range r.index {
-		index[name] = dir
-	}
-	r.mu.RUnlock()
+	index := r.snapshotIndex()
 
 	out := make([]Summary, 0, len(index))
-	for name, dir := range index {
-		sf := filepath.Join(dir, skillFile)
-		s, err := parseSummary(sf)
-		if err != nil {
+	for name, entry := range index {
+		s, ok := r.summaryForEntry(name, entry)
+		if !ok {
 			continue
-		}
-		if s.Name == "" {
-			s.Name = name
 		}
 		out = append(out, s)
 	}
@@ -228,11 +240,12 @@ func (r *FSRepository) Summaries() []Summary {
 // Get implements Repository.
 func (r *FSRepository) Get(name string) (*Skill, error) {
 	r.mu.RLock()
-	dir, ok := r.index[name]
+	entry, ok := r.index[name]
 	r.mu.RUnlock()
 	if !ok {
 		return nil, fmt.Errorf("skill %q not found", name)
 	}
+	dir := entry.dir
 	sf := filepath.Join(dir, skillFile)
 	sum, body, err := parseFull(sf)
 	if err != nil {
@@ -243,6 +256,71 @@ func (r *FSRepository) Get(name string) (*Skill, error) {
 	}
 	docs := r.readDocs(dir)
 	return &Skill{Summary: sum, Body: body, Docs: docs}, nil
+}
+
+func (r *FSRepository) snapshotIndex() map[string]fsSkillEntry {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	index := make(map[string]fsSkillEntry, len(r.index))
+	for name, entry := range r.index {
+		index[name] = entry
+	}
+	return index
+}
+
+func (r *FSRepository) summaryForEntry(
+	name string,
+	entry fsSkillEntry,
+) (Summary, bool) {
+	info, err := os.Stat(entry.file)
+	if err != nil || info.IsDir() {
+		return Summary{}, false
+	}
+	signature := newFSFileSignature(info)
+	if signature == entry.signature {
+		return summaryWithFallbackName(entry.summary, name), true
+	}
+
+	summary, err := parseSummary(entry.file)
+	if err != nil {
+		return Summary{}, false
+	}
+	summary = summaryWithFallbackName(summary, name)
+	r.updateCachedSummary(name, entry, summary, signature)
+	return summary, true
+}
+
+func (r *FSRepository) updateCachedSummary(
+	name string,
+	oldEntry fsSkillEntry,
+	summary Summary,
+	signature fsFileSignature,
+) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	entry, ok := r.index[name]
+	if !ok || entry.dir != oldEntry.dir || entry.file != oldEntry.file {
+		return
+	}
+	entry.summary = summary
+	entry.signature = signature
+	r.index[name] = entry
+}
+
+func summaryWithFallbackName(summary Summary, name string) Summary {
+	if strings.TrimSpace(summary.Name) == "" {
+		summary.Name = name
+	}
+	return summary
+}
+
+func newFSFileSignature(info os.FileInfo) fsFileSignature {
+	return fsFileSignature{
+		size:    info.Size(),
+		modTime: info.ModTime(),
+	}
 }
 
 func (r *FSRepository) readDocs(dir string) []Doc {

--- a/skill/repository_test.go
+++ b/skill/repository_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -27,6 +28,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -41,6 +43,12 @@ func writeSkill(t *testing.T, dir, name string) string {
 		[]byte(data), 0o644)
 	require.NoError(t, err)
 	return sdir
+}
+
+func advanceFileModTime(t *testing.T, path string) {
+	t.Helper()
+	when := time.Now().Add(time.Second)
+	require.NoError(t, os.Chtimes(path, when, when))
 }
 
 func TestStateKeys_ScopedAndLegacy(t *testing.T) {
@@ -248,6 +256,53 @@ func TestFSRepository_Summaries_SortedByName(t *testing.T) {
 	require.Len(t, sums, 2)
 	require.Equal(t, "a", sums[0].Name)
 	require.Equal(t, "b", sums[1].Name)
+}
+
+func TestFSRepository_Summaries_ReflectsModifiedSkillFile(t *testing.T) {
+	const (
+		skillName       = "alpha"
+		updatedSummary  = "updated"
+		skillBody       = "body"
+		summaryTemplate = "---\nname: %s\n" +
+			"description: %s\n---\n%s\n"
+	)
+
+	root := t.TempDir()
+	sdir := writeSkill(t, root, skillName)
+
+	repo, err := NewFSRepository(root)
+	require.NoError(t, err)
+	require.Equal(t, "d", repo.Summaries()[0].Description)
+
+	skillPath := filepath.Join(sdir, skillFile)
+	data := fmt.Sprintf(
+		summaryTemplate,
+		skillName,
+		updatedSummary,
+		skillBody,
+	)
+	require.NoError(t, os.WriteFile(skillPath, []byte(data), 0o644))
+	advanceFileModTime(t, skillPath)
+
+	sums := repo.Summaries()
+	require.Len(t, sums, 1)
+	require.Equal(t, skillName, sums[0].Name)
+	require.Equal(t, updatedSummary, sums[0].Description)
+}
+
+func TestFSRepository_Summaries_SkipsMissingSkillFile(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	sdir := writeSkill(t, root, "alpha")
+
+	repo, err := NewFSRepository(root)
+	require.NoError(t, err)
+	require.Len(t, repo.Summaries(), 1)
+
+	require.NoError(t, os.Remove(filepath.Join(sdir, skillFile)))
+
+	require.Empty(t, repo.Summaries())
 }
 
 func TestFSRepository_Get_IncludesNestedDocs(t *testing.T) {


### PR DESCRIPTION
## Summary

- Cache parsed filesystem skill summaries and reuse them while `SKILL.md`
  file fingerprints are unchanged.
- Add an OpenClaw summary-cache dirty-check TTL option.
- Add an optional compact OpenClaw skills overview renderer with pinned skills,
  top-N summaries, and `skill_list` fallback discovery.
- Add opt-in OpenClaw latency diagnostics wiring so request-level traces can
  break down skill summary/cache/render, tool resolution, and LLM flow phases.

## Compatibility

- `skill.FSRepository` keeps existing refresh semantics for newly added or
  removed skill directories.
- Existing `SKILL.md` summary edits are still detected without `Refresh()` when
  file size or modification time changes.
- Compact skills overview is opt-in. Default OpenClaw behavior remains the
  full overview unless `skills.overview_limit` is configured.
- Latency diagnostics are default-off. They only run when
  `observability.latency_diagnostics.enabled` or `--latency-diagnostics` is
  set. Diagnostic runner events remain independently controlled by
  `observability.latency_diagnostics.events` /
  `--latency-diagnostics-events`.

## Validation

- `go test ./skill`
- `(cd openclaw && go test ./app ./internal/skills ./internal/octool)`
- `(cd openclaw && go test ./...)`
- `env -u LANGFUSE_PUBLIC_KEY -u LANGFUSE_SECRET_KEY -u LANGFUSE_HOST go test ./telemetry/langfuse/config`
- `git diff --check`

## Performance Notes

Local repository measurement on 78 bundled skills:

- repeated `FSRepository.Summaries()` average: `1.414ms -> 0.185ms` (`-86.9%`)
- rendered skills overview bytes: `18,348 -> 4,208` (`-77.1%`)

Downstream real-model OpenClaw validation, same text request, independent
sessions, three runs per version:

- debug trace duration average: `3865.877ms -> 2759.340ms` (`-28.62%`)
- full model call average: `3715.642ms -> 2727.778ms` (`-26.59%`)
- harness excluding model average: `150.224ms -> 31.552ms` (`-79.00%`)
- pre-model framework time average: `144.410ms -> 26.073ms` (`-81.94%`)
- post-model framework time average: `5.814ms -> 5.478ms` (`-5.77%`)
- model time to first token average: `3367.521ms -> 2563.547ms` (`-23.87%`)
- prompt tokens: `17,497 -> 13,757` (`-21.38%`)
- model request JSON payload bytes: `89,653 -> 75,846` (`-15.40%`)
- `Available skills` prompt section bytes:
  `20,374 -> 4,089` (`-79.93%`)

The total real-model trace includes model service latency, so the most stable
signals are harness excluding model time, pre-model framework time, prompt
tokens, and model request payload size. The old debug traces did not include
processor-level spans, so the exact historical `skills.summary.compute` share
cannot be read directly. The optimized diff removes `118.337ms` from the
pre-model path, equal to `78.77%` of the old harness. The new latency diagnostics
option makes the next run split that residual harness into `skills.*`,
`llmflow.tools.resolve`, and model spans.

In the optimized request, the largest remaining payload bucket is tool schemas:
35 tools, about `40,144` bytes. The top four tool definitions (`browser`,
`cron`, `exec_command`, `arxiv_search`) contribute about `15,759` bytes, or
`39.29%` of the tool JSON. That is outside this PR's skill-summary scope and is
a good candidate for a separate tool-surface optimization.
