### PR TITLE
model/openai: flatten text-only message content

### DIFF
--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -1118,12 +1118,16 @@ func (m *Model) omittedContentHint(parts []model.ContentPart) string {
 	return m.omittedContentHintForParts(parts, true)
 }
 
+// omittedContentHintCountingFileURLs includes URL-only files in the omitted
+// file count for roles that cannot preserve file URL fallback text.
 func (m *Model) omittedContentHintCountingFileURLs(
 	parts []model.ContentPart,
 ) string {
 	return m.omittedContentHintForParts(parts, false)
 }
 
+// omittedContentHintForParts summarizes non-text parts omitted by text-only
+// model variants.
 func (m *Model) omittedContentHintForParts(
 	parts []model.ContentPart,
 	skipFileURLFallback bool,
@@ -1234,6 +1238,8 @@ func singleUserContentString(
 	return "", false
 }
 
+// textOnlyUserContentString flattens user content parts when every outgoing
+// part is plain text and no variant-specific extra fields are required.
 func textOnlyUserContentString(
 	contentParts []openai.ChatCompletionContentPartUnionParam,
 	extraFields map[string]any,
@@ -1251,6 +1257,7 @@ func textOnlyUserContentString(
 	return joinedTextContent(texts)
 }
 
+// joinedTextContent joins non-empty text segments with a stable separator.
 func joinedTextContent(texts []string) (string, bool) {
 	if len(texts) == 0 {
 		return "", false
@@ -1316,11 +1323,6 @@ func (m *Model) convertAssistantMessageContent(
 	if m.variantConfig.textOnlyMessageContent {
 		texts := make([]string, 0, len(contentParts))
 		for _, part := range contentParts {
-			if part.OfText == nil {
-				return openai.ChatCompletionAssistantMessageParamContentUnion{
-					OfArrayOfContentParts: contentParts,
-				}
-			}
 			texts = append(texts, part.OfText.Text)
 		}
 		if omittedHint := m.omittedContentHintCountingFileURLs(

--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -923,6 +923,11 @@ func (m *Model) convertSystemMessageContent(msg model.Message) openai.ChatComple
 		for _, part := range contentParts {
 			texts = append(texts, part.Text)
 		}
+		if omittedHint := m.omittedContentHintCountingFileURLs(
+			msg.ContentParts,
+		); omittedHint != "" {
+			texts = append(texts, omittedHint)
+		}
 		if content, ok := joinedTextContent(texts); ok {
 			return openai.ChatCompletionSystemMessageParamContentUnion{
 				OfString: openai.String(content),
@@ -1110,6 +1115,19 @@ func (m *Model) appendUserContentParts(
 }
 
 func (m *Model) omittedContentHint(parts []model.ContentPart) string {
+	return m.omittedContentHintForParts(parts, true)
+}
+
+func (m *Model) omittedContentHintCountingFileURLs(
+	parts []model.ContentPart,
+) string {
+	return m.omittedContentHintForParts(parts, false)
+}
+
+func (m *Model) omittedContentHintForParts(
+	parts []model.ContentPart,
+	skipFileURLFallback bool,
+) string {
 	if !m.variantConfig.textOnlyMessageContent {
 		return ""
 	}
@@ -1122,7 +1140,8 @@ func (m *Model) omittedContentHint(parts []model.ContentPart) string {
 		case model.ContentTypeAudio:
 			audioCount++
 		case model.ContentTypeFile:
-			if fileURLFallbackText(part.File) != "" {
+			if skipFileURLFallback &&
+				fileURLFallbackText(part.File) != "" {
 				continue
 			}
 			fileCount++
@@ -1303,6 +1322,11 @@ func (m *Model) convertAssistantMessageContent(
 				}
 			}
 			texts = append(texts, part.OfText.Text)
+		}
+		if omittedHint := m.omittedContentHintCountingFileURLs(
+			msg.ContentParts,
+		); omittedHint != "" {
+			texts = append(texts, omittedHint)
 		}
 		if content, ok := joinedTextContent(texts); ok {
 			return openai.ChatCompletionAssistantMessageParamContentUnion{

--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -918,6 +918,17 @@ func (m *Model) convertSystemMessageContent(msg model.Message) openai.ChatComple
 			})
 		}
 	}
+	if m.variantConfig.textOnlyMessageContent {
+		texts := make([]string, 0, len(contentParts))
+		for _, part := range contentParts {
+			texts = append(texts, part.Text)
+		}
+		if content, ok := joinedTextContent(texts); ok {
+			return openai.ChatCompletionSystemMessageParamContentUnion{
+				OfString: openai.String(content),
+			}
+		}
+	}
 	return openai.ChatCompletionSystemMessageParamContentUnion{
 		OfArrayOfContentParts: contentParts,
 	}
@@ -951,6 +962,17 @@ func (m *Model) convertUserMessageContent(
 		contentParts = append(contentParts, userTextPart(omittedHint))
 	}
 	extraFields := m.appendUserContentParts(&contentParts, msg.ContentParts)
+
+	if m.variantConfig.textOnlyMessageContent {
+		if content, ok := textOnlyUserContentString(
+			contentParts,
+			extraFields,
+		); ok {
+			return openai.ChatCompletionUserMessageParamContentUnion{
+				OfString: openai.String(content),
+			}, nil
+		}
+	}
 
 	if strings.TrimSpace(msg.Content) == "" &&
 		fileHint != "" &&
@@ -1193,6 +1215,30 @@ func singleUserContentString(
 	return "", false
 }
 
+func textOnlyUserContentString(
+	contentParts []openai.ChatCompletionContentPartUnionParam,
+	extraFields map[string]any,
+) (string, bool) {
+	if extraFields != nil || len(contentParts) == 0 {
+		return "", false
+	}
+	texts := make([]string, 0, len(contentParts))
+	for _, part := range contentParts {
+		if part.OfText == nil {
+			return "", false
+		}
+		texts = append(texts, part.OfText.Text)
+	}
+	return joinedTextContent(texts)
+}
+
+func joinedTextContent(texts []string) (string, bool) {
+	if len(texts) == 0 {
+		return "", false
+	}
+	return strings.Join(texts, "\n"), true
+}
+
 func fileHintForContentParts(parts []model.ContentPart) string {
 	const (
 		fileHintDefaultName = "attachment"
@@ -1246,6 +1292,22 @@ func (m *Model) convertAssistantMessageContent(
 						Text: *part.Text,
 					},
 				})
+		}
+	}
+	if m.variantConfig.textOnlyMessageContent {
+		texts := make([]string, 0, len(contentParts))
+		for _, part := range contentParts {
+			if part.OfText == nil {
+				return openai.ChatCompletionAssistantMessageParamContentUnion{
+					OfArrayOfContentParts: contentParts,
+				}
+			}
+			texts = append(texts, part.OfText.Text)
+		}
+		if content, ok := joinedTextContent(texts); ok {
+			return openai.ChatCompletionAssistantMessageParamContentUnion{
+				OfString: openai.String(content),
+			}
 		}
 	}
 	return openai.ChatCompletionAssistantMessageParamContentUnion{

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -5485,6 +5485,30 @@ func TestConvertAssistantMessageContent_WithContentAndParts(t *testing.T) {
 		assert.Empty(t, content.OfArrayOfContentParts,
 			"expected no content parts")
 	})
+
+	t.Run("text-only variant reports omitted non-text parts", func(t *testing.T) {
+		m := New("deepseek-chat", WithVariant(VariantDeepSeek))
+		message := model.Message{
+			Role:    model.RoleAssistant,
+			Content: "Main content",
+			ContentParts: []model.ContentPart{
+				{
+					Type: model.ContentTypeImage,
+					Image: &model.Image{
+						URL: "https://example.com/image.png",
+					},
+				},
+			},
+		}
+
+		content := m.convertAssistantMessageContent(message)
+		require.True(t, content.OfString.Valid(),
+			"expected string content")
+		assert.Contains(t, content.OfString.Value, "Main content")
+		assert.Contains(t, content.OfString.Value, "1 image")
+		assert.Empty(t, content.OfArrayOfContentParts,
+			"expected no content parts")
+	})
 }
 
 // TestConvertTools_ErrorCases tests error handling in convertTools.
@@ -5582,6 +5606,28 @@ func TestConvertSystemMessageContent_WithParts(t *testing.T) {
 			"expected string content")
 		assert.Equal(t, "System instruction 1\nSystem instruction 2",
 			content.OfString.Value)
+		assert.Empty(t, content.OfArrayOfContentParts,
+			"expected no content parts")
+	})
+
+	t.Run("text-only variant reports omitted non-text parts", func(t *testing.T) {
+		m := New("deepseek-chat", WithVariant(VariantDeepSeek))
+		message := model.Message{
+			Role: model.RoleSystem,
+			ContentParts: []model.ContentPart{
+				{
+					Type: model.ContentTypeImage,
+					Image: &model.Image{
+						URL: "https://example.com/image.png",
+					},
+				},
+			},
+		}
+
+		content := m.convertSystemMessageContent(message)
+		require.True(t, content.OfString.Valid(),
+			"expected string content")
+		assert.Contains(t, content.OfString.Value, "1 image")
 		assert.Empty(t, content.OfArrayOfContentParts,
 			"expected no content parts")
 	})

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -5439,6 +5439,32 @@ func TestConvertUserMessageContent_DeepSeekVariant(t *testing.T) {
 	})
 }
 
+func TestTextOnlyUserContentString_EdgeCases(t *testing.T) {
+	content, ok := textOnlyUserContentString(
+		[]openai.ChatCompletionContentPartUnionParam{
+			userTextPart("Use this text."),
+		},
+		map[string]any{"file_ids": []string{"file-123"}},
+	)
+	require.False(t, ok)
+	assert.Empty(t, content)
+
+	content, ok = textOnlyUserContentString(nil, nil)
+	require.False(t, ok)
+	assert.Empty(t, content)
+
+	content, ok = textOnlyUserContentString(
+		[]openai.ChatCompletionContentPartUnionParam{{}},
+		nil,
+	)
+	require.False(t, ok)
+	assert.Empty(t, content)
+
+	content, ok = joinedTextContent(nil)
+	require.False(t, ok)
+	assert.Empty(t, content)
+}
+
 // TestConvertAssistantMessageContent_WithContentAndParts tests assistant message with both content and parts.
 func TestConvertAssistantMessageContent_WithContentAndParts(t *testing.T) {
 	m := &Model{}
@@ -8918,6 +8944,23 @@ func TestOmittedContentHint_FileURLFallbackNotCounted(t *testing.T) {
 		},
 	})
 	require.Empty(t, got)
+}
+
+func TestOmittedContentHintCountingFileURLs_FileURLCounted(t *testing.T) {
+	m := &Model{variantConfig: variantConfig{textOnlyMessageContent: true}}
+	got := m.omittedContentHintCountingFileURLs([]model.ContentPart{
+		{
+			Type: model.ContentTypeFile,
+			File: &model.File{
+				Name:     "report.pdf",
+				URL:      "https://example.com/report.pdf",
+				MimeType: "application/pdf",
+			},
+		},
+	})
+	require.Equal(t,
+		"Omitted non-text attachments for this provider: 1 file.",
+		got)
 }
 
 // TestChatRequestCallbackSynchronous verifies that

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -5358,6 +5358,29 @@ func TestConvertUserMessageContent_HunyuanVariant(t *testing.T) {
 func TestConvertUserMessageContent_DeepSeekVariant(t *testing.T) {
 	m := New("deepseek-chat", WithVariant(VariantDeepSeek))
 
+	t.Run("flattens multiple text parts into string", func(t *testing.T) {
+		message := model.Message{
+			Role:    model.RoleUser,
+			Content: "Please inspect this",
+			ContentParts: []model.ContentPart{
+				{
+					Type: model.ContentTypeText,
+					Text: stringPtr("Use the attached context."),
+				},
+			},
+		}
+
+		content, extraFields := m.convertUserMessageContent(message)
+		assert.Empty(t, extraFields, "expected no extra fields")
+		require.True(t, content.OfString.Valid(),
+			"expected string content")
+		assert.Equal(t,
+			"Please inspect this\nUse the attached context.",
+			content.OfString.Value)
+		assert.Empty(t, content.OfArrayOfContentParts,
+			"expected no content parts")
+	})
+
 	t.Run("omits non-text content parts", func(t *testing.T) {
 		message := model.Message{
 			Role:    model.RoleUser,
@@ -5380,16 +5403,14 @@ func TestConvertUserMessageContent_DeepSeekVariant(t *testing.T) {
 
 		content, extraFields := m.convertUserMessageContent(message)
 		assert.Empty(t, extraFields, "expected no extra fields")
-		require.Len(t, content.OfArrayOfContentParts, 2,
-			"expected main text and omission hint")
-		require.NotNil(t, content.OfArrayOfContentParts[0].OfText,
-			"expected first part to be text")
-		require.NotNil(t, content.OfArrayOfContentParts[1].OfText,
-			"expected omission hint to be text")
-		assert.Equal(t, "Please inspect this",
-			content.OfArrayOfContentParts[0].OfText.Text)
+		require.True(t, content.OfString.Valid(),
+			"expected string content")
+		assert.Empty(t, content.OfArrayOfContentParts,
+			"expected no content parts")
+		assert.Contains(t, content.OfString.Value,
+			"Please inspect this")
 		assert.Contains(t,
-			content.OfArrayOfContentParts[1].OfText.Text,
+			content.OfString.Value,
 			"1 image, 1 file")
 	})
 
@@ -5408,14 +5429,12 @@ func TestConvertUserMessageContent_DeepSeekVariant(t *testing.T) {
 
 		content, extraFields := m.convertUserMessageContent(message)
 		assert.Empty(t, extraFields, "expected no extra fields")
-		assert.False(t, content.OfString.Valid(),
-			"expected non-string content")
-		require.Len(t, content.OfArrayOfContentParts, 1,
-			"expected one omission hint")
-		require.NotNil(t, content.OfArrayOfContentParts[0].OfText,
-			"expected omission hint to be text")
+		require.True(t, content.OfString.Valid(),
+			"expected string content")
+		assert.Empty(t, content.OfArrayOfContentParts,
+			"expected no content parts")
 		assert.Contains(t,
-			content.OfArrayOfContentParts[0].OfText.Text,
+			content.OfString.Value,
 			"1 image")
 	})
 }
@@ -5446,6 +5465,25 @@ func TestConvertAssistantMessageContent_WithContentAndParts(t *testing.T) {
 
 		content := m.convertAssistantMessageContent(message)
 		assert.NotNil(t, content.OfString, "expected string content")
+	})
+
+	t.Run("text-only variant flattens text parts", func(t *testing.T) {
+		m := New("deepseek-chat", WithVariant(VariantDeepSeek))
+		message := model.Message{
+			Role:    model.RoleAssistant,
+			Content: "Main content",
+			ContentParts: []model.ContentPart{
+				{Type: "text", Text: stringPtr("Additional text")},
+			},
+		}
+
+		content := m.convertAssistantMessageContent(message)
+		require.True(t, content.OfString.Valid(),
+			"expected string content")
+		assert.Equal(t, "Main content\nAdditional text",
+			content.OfString.Value)
+		assert.Empty(t, content.OfArrayOfContentParts,
+			"expected no content parts")
 	})
 }
 
@@ -5527,6 +5565,25 @@ func TestConvertSystemMessageContent_WithParts(t *testing.T) {
 
 		content := m.convertSystemMessageContent(message)
 		assert.NotNil(t, content.OfString, "expected string content")
+	})
+
+	t.Run("text-only variant flattens text parts", func(t *testing.T) {
+		m := New("deepseek-chat", WithVariant(VariantDeepSeek))
+		message := model.Message{
+			Role:    model.RoleSystem,
+			Content: "System instruction 1",
+			ContentParts: []model.ContentPart{
+				{Type: "text", Text: stringPtr("System instruction 2")},
+			},
+		}
+
+		content := m.convertSystemMessageContent(message)
+		require.True(t, content.OfString.Valid(),
+			"expected string content")
+		assert.Equal(t, "System instruction 1\nSystem instruction 2",
+			content.OfString.Value)
+		assert.Empty(t, content.OfArrayOfContentParts,
+			"expected no content parts")
 	})
 }
 


### PR DESCRIPTION
## Summary

- Flatten text-only OpenAI-compatible message content into string payloads after supported text has been collected.
- Preserve omission hints and file URL fallback text by joining them into the same text payload.
- Cover user, system, and assistant message conversions for text-only variants.

## Validation

- go test ./model/openai -run 'TestConvertUserMessageContent_DeepSeekVariant' -count=1
- go test ./model/openai -count=1
- go test ./... -count=1 (fails locally in unrelated platform-sensitive packages: tool/hostexec and codeexecutor/local)
