### PR TITLE
runner: preserve await user reply lookup path on resume

### DIFF
--- a/runner/await_user_reply.go
+++ b/runner/await_user_reply.go
@@ -25,35 +25,36 @@ func (r *runner) applyAwaitUserReplyRoute(
 	sess *session.Session,
 	message model.Message,
 	ro agent.RunOptions,
-) (agent.RunOptions, string, error) {
+) (agent.RunOptions, string, string, error) {
 	if r == nil || !r.awaitUserReplyRouting {
-		return ro, "", nil
+		return ro, "", "", nil
 	}
 	if message.Role != model.RoleUser {
-		return ro, "", nil
+		return ro, "", "", nil
 	}
 	if ro.Agent != nil || ro.AgentByName != "" {
-		return r.clearOverriddenAwaitUserReplyRoute(
+		ro, rootName, err := r.clearOverriddenAwaitUserReplyRoute(
 			ctx,
 			key,
 			sess,
 			ro,
 		)
+		return ro, rootName, "", err
 	}
 
 	route, ok, err := agent.PendingAwaitUserReplyRoute(sess)
 	if err != nil {
 		if clearErr := r.clearAwaitUserReplyRoute(ctx, key, sess); clearErr != nil {
-			return ro, "", fmt.Errorf(
+			return ro, "", "", fmt.Errorf(
 				"runner: clear invalid await_user_reply route: %w",
 				clearErr,
 			)
 		}
 		log.Warnf("runner: ignore invalid await_user_reply route: %v", err)
-		return ro, "", nil
+		return ro, "", "", nil
 	}
 	if !ok {
-		return ro, "", nil
+		return ro, "", "", nil
 	}
 	selected, rootName, ok, err := r.resolveAwaitUserReplyRoute(
 		ctx,
@@ -61,11 +62,11 @@ func (r *runner) applyAwaitUserReplyRoute(
 		ro,
 	)
 	if err != nil {
-		return ro, "", err
+		return ro, "", "", err
 	}
 	if !ok {
 		if clearErr := r.clearAwaitUserReplyRoute(ctx, key, sess); clearErr != nil {
-			return ro, "", fmt.Errorf(
+			return ro, "", "", fmt.Errorf(
 				"runner: clear stale await_user_reply route: %w",
 				clearErr,
 			)
@@ -74,16 +75,16 @@ func (r *runner) applyAwaitUserReplyRoute(
 			"runner: ignore stale await_user_reply route for path %q",
 			route.LookupPath,
 		)
-		return ro, "", nil
+		return ro, "", "", nil
 	}
 	if err := r.clearAwaitUserReplyRoute(ctx, key, sess); err != nil {
-		return ro, "", fmt.Errorf(
+		return ro, "", "", fmt.Errorf(
 			"runner: consume await_user_reply route: %w",
 			err,
 		)
 	}
 	ro.Agent = selected
-	return ro, rootName, nil
+	return ro, rootName, route.LookupPath, nil
 }
 
 func (r *runner) clearOverriddenAwaitUserReplyRoute(

--- a/runner/await_user_reply_test.go
+++ b/runner/await_user_reply_test.go
@@ -337,6 +337,62 @@ func TestRunner_Run_AwaitUserReplyRoutingResolvesNestedPath(t *testing.T) {
 	require.Equal(t, 0, topLevelChild.calls)
 }
 
+func TestRunner_Run_AwaitUserReplyRoutingPreservesNestedPathOnRepeatedAwait(
+	t *testing.T,
+) {
+	ctx := context.Background()
+	svc := sessioninmemory.NewSessionService()
+	key := session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "sess-nested-repeat",
+	}
+	state, err := (agent.AwaitUserReplyRoute{
+		AgentName:  "child",
+		LookupPath: "parent/child",
+	}).State()
+	require.NoError(t, err)
+	_, err = svc.CreateSession(ctx, key, state)
+	require.NoError(t, err)
+
+	child := &awaitReplyTrackingAgent{
+		name:      "child",
+		markAwait: true,
+	}
+	parent := &awaitReplyTrackingAgent{
+		name:      "parent",
+		subAgents: []agent.Agent{child},
+	}
+	r := NewRunner(
+		"app",
+		parent,
+		WithSessionService(svc),
+		WithAwaitUserReplyRouting(true),
+	)
+
+	eventCh, err := r.Run(
+		ctx,
+		key.UserID,
+		key.SessionID,
+		model.NewUserMessage("follow up"),
+		agent.WithRequestID("req-await-nested-repeat"),
+	)
+	require.NoError(t, err)
+	for range eventCh {
+	}
+
+	require.Equal(t, 0, parent.calls)
+	require.Equal(t, 1, child.calls)
+
+	sess, err := svc.GetSession(ctx, key)
+	require.NoError(t, err)
+	route, ok, err := agent.PendingAwaitUserReplyRoute(sess)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "child", route.AgentName)
+	require.Equal(t, "parent/child", route.LookupPath)
+}
+
 func TestRunner_Run_AwaitUserReplyRoutingPersistsFactoryLookupPath(
 	t *testing.T,
 ) {
@@ -471,7 +527,7 @@ func TestRunner_ApplyAwaitUserReplyRoute_EdgeCases(t *testing.T) {
 	t.Run("disabled", func(t *testing.T) {
 		r := &runner{}
 
-		got, rootName, err := r.applyAwaitUserReplyRoute(
+		got, rootName, lookupPath, err := r.applyAwaitUserReplyRoute(
 			ctx,
 			key,
 			nil,
@@ -480,6 +536,7 @@ func TestRunner_ApplyAwaitUserReplyRoute_EdgeCases(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.Empty(t, rootName)
+		require.Empty(t, lookupPath)
 		require.Nil(t, got.Agent)
 		require.Empty(t, got.AgentByName)
 	})
@@ -487,7 +544,7 @@ func TestRunner_ApplyAwaitUserReplyRoute_EdgeCases(t *testing.T) {
 	t.Run("non user message", func(t *testing.T) {
 		r := &runner{awaitUserReplyRouting: true}
 
-		got, rootName, err := r.applyAwaitUserReplyRoute(
+		got, rootName, lookupPath, err := r.applyAwaitUserReplyRoute(
 			ctx,
 			key,
 			nil,
@@ -496,6 +553,7 @@ func TestRunner_ApplyAwaitUserReplyRoute_EdgeCases(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.Empty(t, rootName)
+		require.Empty(t, lookupPath)
 		require.Nil(t, got.Agent)
 	})
 
@@ -503,7 +561,7 @@ func TestRunner_ApplyAwaitUserReplyRoute_EdgeCases(t *testing.T) {
 		r := &runner{awaitUserReplyRouting: true}
 		sess := session.NewSession("app", "user", "sess")
 
-		got, rootName, err := r.applyAwaitUserReplyRoute(
+		got, rootName, lookupPath, err := r.applyAwaitUserReplyRoute(
 			ctx,
 			key,
 			sess,
@@ -512,6 +570,7 @@ func TestRunner_ApplyAwaitUserReplyRoute_EdgeCases(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.Empty(t, rootName)
+		require.Empty(t, lookupPath)
 		require.Nil(t, got.Agent)
 	})
 
@@ -533,7 +592,7 @@ func TestRunner_ApplyAwaitUserReplyRoute_EdgeCases(t *testing.T) {
 			}),
 		)
 
-		_, _, err := r.applyAwaitUserReplyRoute(
+		_, _, _, err := r.applyAwaitUserReplyRoute(
 			ctx,
 			key,
 			sess,
@@ -564,7 +623,7 @@ func TestRunner_ApplyAwaitUserReplyRoute_EdgeCases(t *testing.T) {
 			}),
 		)
 
-		got, rootName, err := r.applyAwaitUserReplyRoute(
+		got, rootName, lookupPath, err := r.applyAwaitUserReplyRoute(
 			ctx,
 			key,
 			sess,
@@ -573,6 +632,7 @@ func TestRunner_ApplyAwaitUserReplyRoute_EdgeCases(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.Empty(t, rootName)
+		require.Empty(t, lookupPath)
 		require.Nil(t, got.Agent)
 		require.Len(t, svc.updateCalls, 1)
 	})
@@ -598,7 +658,7 @@ func TestRunner_ApplyAwaitUserReplyRoute_EdgeCases(t *testing.T) {
 			session.WithSessionState(state),
 		)
 
-		_, _, err = r.applyAwaitUserReplyRoute(
+		_, _, _, err = r.applyAwaitUserReplyRoute(
 			ctx,
 			key,
 			sess,
@@ -609,6 +669,45 @@ func TestRunner_ApplyAwaitUserReplyRoute_EdgeCases(t *testing.T) {
 			t,
 			err,
 			"clear stale await_user_reply route",
+		)
+	})
+
+	t.Run("consume route clear error", func(t *testing.T) {
+		state, err := (agent.AwaitUserReplyRoute{
+			AgentName:  "root",
+			LookupPath: "root",
+		}).State()
+		require.NoError(t, err)
+
+		svc := &awaitReplySessionService{
+			mockSessionService: &mockSessionService{},
+			updateErr:          errors.New("clear failed"),
+		}
+		r := &runner{
+			awaitUserReplyRouting: true,
+			sessionService:        svc,
+			agents: map[string]agent.Agent{
+				"root": &awaitReplyTrackingAgent{name: "root"},
+			},
+		}
+		sess := session.NewSession(
+			"app",
+			"user",
+			"sess",
+			session.WithSessionState(state),
+		)
+
+		_, _, _, err = r.applyAwaitUserReplyRoute(
+			ctx,
+			key,
+			sess,
+			userMessage,
+			agent.RunOptions{},
+		)
+		require.ErrorContains(
+			t,
+			err,
+			"consume await_user_reply route",
 		)
 	})
 
@@ -636,7 +735,7 @@ func TestRunner_ApplyAwaitUserReplyRoute_EdgeCases(t *testing.T) {
 			session.WithSessionState(state),
 		)
 
-		_, _, err = r.applyAwaitUserReplyRoute(
+		_, _, _, err = r.applyAwaitUserReplyRoute(
 			ctx,
 			key,
 			sess,

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -562,7 +562,7 @@ func (r *runner) Run(
 		ro,
 		runnerLatencySpanAwaitRoute,
 	)
-	ro, awaitUserReplyRootName, err := r.applyAwaitUserReplyRoute(
+	ro, awaitUserReplyRootName, awaitUserReplyLookupPath, err := r.applyAwaitUserReplyRoute(
 		awaitCtx,
 		sessionKey,
 		sess,
@@ -623,6 +623,7 @@ func (r *runner) Run(
 		ro,
 		effectiveAppName,
 		awaitUserReplyRootName,
+		awaitUserReplyLookupPath,
 	)
 	currentTurnSession, err := sessionroute.ResolveCurrentTurnSession(
 		execCtx,
@@ -738,12 +739,13 @@ func (r *runner) newRunInvocation(
 	ro agent.RunOptions,
 	effectiveAppName string,
 	awaitUserReplyRootName string,
+	awaitUserReplyLookupPath string,
 ) *agent.Invocation {
 	eventFilterKey := effectiveAppName
 	if ro.EventFilterKey != "" {
 		eventFilterKey = ro.EventFilterKey
 	}
-	invocation := agent.NewInvocation(
+	invocationOpts := []agent.InvocationOptions{
 		agent.WithInvocationSession(sess),
 		agent.WithInvocationSessionService(r.sessionService),
 		agent.WithInvocationMessage(message),
@@ -755,7 +757,14 @@ func (r *runner) newRunInvocation(
 		agent.WithInvocationArtifactService(r.artifactService),
 		agent.WithInvocationEventFilterKey(eventFilterKey),
 		agent.WithInvocationPlugins(r.pluginManager),
-	)
+	}
+	if awaitUserReplyLookupPath != "" {
+		invocationOpts = append(
+			invocationOpts,
+			agent.WithInvocationBranch(awaitUserReplyLookupPath),
+		)
+	}
+	invocation := agent.NewInvocation(invocationOpts...)
 	if rootLookupName := r.selectedRootLookupName(
 		ro,
 		awaitUserReplyRootName,


### PR DESCRIPTION
## What changed

- Preserve the consumed `await_user_reply` route lookup path when Runner resumes directly into the routed agent.
- Use that lookup path as the new invocation branch so repeated `await_user_reply` calls from a sub-agent keep the full `root/sub-agent` path.
- Add a regression test for a nested sub-agent that awaits again after being resumed from a pending route.

## Root cause

When `WithAwaitUserReplyRouting(true)` resumed a user reply into a sub-agent, Runner selected the routed agent but created a fresh invocation without the route `LookupPath`. `NewInvocation` then defaulted `Branch` to the sub-agent name. If the sub-agent called `await_user_reply` again, lookup path rebuilding replaced the single branch segment with the root lookup name, dropping the sub-agent segment.

## Validation

- `go test ./runner -run AwaitUserReply`
- `go test ./runner`
- `go test ./agent -run AwaitUserReply`
