### PR TITLE
tool/agent: restore live session for dynamic AgentTool

### DIFF
--- a/tool/agent/dynamic_tool.go
+++ b/tool/agent/dynamic_tool.go
@@ -531,6 +531,7 @@ func (at *Tool) buildDynamicSubInvocation(
 	if err := flush.Invoke(ctx, parentInv); err != nil {
 		return nil, nil, nil, fmt.Errorf("flush parent invocation session: %w", err)
 	}
+	parentInv = parentInvocationWithLiveSession(parentInv)
 
 	patch, warnings := at.buildDynamicPatch(ctx, parentInv, spec)
 

--- a/tool/agent/dynamic_tool_test.go
+++ b/tool/agent/dynamic_tool_test.go
@@ -25,6 +25,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
 	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
 	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/livesession"
 	agentlog "trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
@@ -653,6 +654,30 @@ func TestNewDynamicTool_Integration_ExcludesSiblingAgentTools(t *testing.T) {
 	require.Len(t, seen, 1)
 	require.Equal(t, []string{"tool_a"}, seen[0],
 		"dynamic child surface must exclude all AgentTool entrypoints")
+}
+
+func TestNewDynamicTool_RestoresLiveSessionFromParallelClone(t *testing.T) {
+	const liveOnlyContent = "dynamic-live-only-history"
+	liveSess, frozenSess := liveAndFrozenSessionsForTest(t, liveOnlyContent)
+
+	child := &liveSessionHistoryAgent{
+		name:            "dynamic-live-session-child",
+		liveOnlyContent: liveOnlyContent,
+	}
+	at := NewDynamicTool()
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(child),
+		agent.WithInvocationSession(frozenSess),
+		agent.WithInvocationEventFilterKey("parent"),
+	)
+	livesession.Attach(parent, liveSess)
+	ctx := agent.NewInvocationContext(context.Background(), parent)
+
+	res, err := at.Call(ctx, []byte(`{"request":"hi"}`))
+	require.NoError(t, err)
+	require.Equal(t, "saw-live-session", res)
+	require.Same(t, liveSess, child.seenSession)
+	require.True(t, child.sawLiveOnly)
 }
 
 // --- Fix 5: WithName is dynamic-only ---------------------------------------


### PR DESCRIPTION
## What changed

- Restore the live session pointer before building the dynamic AgentTool child invocation.
- Add a regression test that simulates the parallel tool-call path where the parent invocation holds a frozen session clone while the runner writes to the live session.

## Why

Static AgentTool already restores the live session before spawning sub-agents. Dynamic AgentTool missed the same step in `buildDynamicSubInvocation`, so a dynamic child agent could inherit a frozen session in parallel execution. In that state, the child cannot see its own emitted `tool_call` / `tool_response` events on the next model turn and may repeat the same tool call until `maxLLMCalls` is exhausted.

This change keeps Dynamic AgentTool behavior aligned with static AgentTool and does not change public APIs.

## Testing

- `go test -count=1 ./tool/agent -run TestNewDynamicTool_RestoresLiveSessionFromParallelClone`
- `go test -count=1 ./tool/agent`
- `go vet ./tool/agent`

## Notes for reviewers

The key concurrency-sensitive point is in `buildDynamicSubInvocation`: after flushing the parent invocation, the code now calls `parentInvocationWithLiveSession(parentInv)` before building the dynamic child patch and cloning the child invocation. This mirrors the existing static AgentTool fix for frozen sessions in parallel tool execution.