### PR TITLE
openclaw: scope cron jobs to conversations

### DIFF
--- a/openclaw/conversation/constants.go
+++ b/openclaw/conversation/constants.go
@@ -40,6 +40,8 @@ const (
 		"prefer information from this conversation over the past " +
 		"summary.\n"
 
+	volatileHistoryToolCron = "cron"
+
 	attachmentWordSingular = "attachment"
 	attachmentWordPlural   = "attachments"
 )

--- a/openclaw/conversation/history.go
+++ b/openclaw/conversation/history.go
@@ -134,11 +134,13 @@ func buildVisibleHistory(
 	boundary *session.SummaryBoundary,
 	labelOverrides map[string]string,
 ) []model.Message {
+	volatileInvocations := volatileToolInvocationIDs(events)
 	if boundary != nil && strings.TrimSpace(boundary.LastEventID) != "" {
 		if history, ok := buildVisibleHistoryAfterEvent(
 			events,
 			boundary.LastEventID,
 			labelOverrides,
+			volatileInvocations,
 		); ok {
 			return history
 		}
@@ -151,7 +153,8 @@ func buildVisibleHistory(
 	}
 	for i := range events {
 		evt := events[i]
-		if !includeEvent(evt, since) {
+		if !includeEvent(evt, since) ||
+			skipVolatileToolHistoryEvent(evt, volatileInvocations) {
 			continue
 		}
 		msgs := visibleMessagesFromEvent(
@@ -167,6 +170,7 @@ func buildVisibleHistoryAfterEvent(
 	events []event.Event,
 	lastEventID string,
 	labelOverrides map[string]string,
+	volatileInvocations map[string]struct{},
 ) ([]model.Message, bool) {
 	out := make([]model.Message, 0, len(events))
 	var foundBoundary bool
@@ -178,7 +182,8 @@ func buildVisibleHistoryAfterEvent(
 			}
 			continue
 		}
-		if !includeEvent(evt, time.Time{}) {
+		if !includeEvent(evt, time.Time{}) ||
+			skipVolatileToolHistoryEvent(evt, volatileInvocations) {
 			continue
 		}
 		msgs := visibleMessagesFromEvent(
@@ -211,8 +216,12 @@ func buildTurns(
 func buildSummaryLines(events []event.Event) []string {
 	lines := make([]string, 0, len(events))
 	var hasAnnotatedUser bool
+	volatileInvocations := volatileToolInvocationIDs(events)
 	for i := range events {
 		evt := events[i]
+		if skipVolatileToolHistoryEvent(evt, volatileInvocations) {
+			continue
+		}
 		rendered, annotated := summaryLinesFromEvent(
 			evt,
 			nil,
@@ -237,6 +246,69 @@ func includeEvent(evt event.Event, since time.Time) bool {
 		return false
 	}
 	return true
+}
+
+func volatileToolInvocationIDs(events []event.Event) map[string]struct{} {
+	out := make(map[string]struct{})
+	for i := range events {
+		evt := events[i]
+		if strings.TrimSpace(evt.InvocationID) == "" ||
+			!eventHasVolatileTool(evt) {
+			continue
+		}
+		out[evt.InvocationID] = struct{}{}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func skipVolatileToolHistoryEvent(
+	evt event.Event,
+	volatileInvocations map[string]struct{},
+) bool {
+	if evt.Author == authorUser || evt.Author == authorSystem {
+		return false
+	}
+	if eventHasVolatileTool(evt) {
+		return true
+	}
+	if len(volatileInvocations) == 0 ||
+		strings.TrimSpace(evt.InvocationID) == "" {
+		return false
+	}
+	_, ok := volatileInvocations[evt.InvocationID]
+	return ok
+}
+
+func eventHasVolatileTool(evt event.Event) bool {
+	if evt.Response == nil {
+		return false
+	}
+	for _, choice := range evt.Response.Choices {
+		if messageHasVolatileTool(choice.Message) ||
+			messageHasVolatileTool(choice.Delta) {
+			return true
+		}
+	}
+	return false
+}
+
+func messageHasVolatileTool(msg model.Message) bool {
+	if isVolatileHistoryTool(msg.ToolName) {
+		return true
+	}
+	for _, toolCall := range msg.ToolCalls {
+		if isVolatileHistoryTool(toolCall.Function.Name) {
+			return true
+		}
+	}
+	return false
+}
+
+func isVolatileHistoryTool(name string) bool {
+	return strings.TrimSpace(name) == volatileHistoryToolCron
 }
 
 func turnsFromEvent(

--- a/openclaw/conversation/history_test.go
+++ b/openclaw/conversation/history_test.go
@@ -244,6 +244,70 @@ func TestBuildInjectedContextMessagesFallsBackToTimestampBoundary(
 	require.Equal(t, "later answer", got[1].Content)
 }
 
+func TestBuildInjectedContextMessagesSkipsVolatileCronInvocation(
+	t *testing.T,
+) {
+	base := time.Now().Add(-10 * time.Minute)
+	cronQuestion := userEvent(
+		"u1",
+		"Alice",
+		"list cron jobs",
+		base,
+	)
+	cronQuestion.InvocationID = "cron-inv"
+	nextQuestion := userEvent(
+		"u2",
+		"Bob",
+		"next question",
+		base.Add(4*time.Minute),
+	)
+	nextQuestion.InvocationID = "next-inv"
+	nextAnswer := assistantEvent(
+		"regular answer",
+		base.Add(5*time.Minute),
+	)
+	nextAnswer.InvocationID = "next-inv"
+
+	sess := &session.Session{
+		Events: []event.Event{
+			cronQuestion,
+			cronToolCallEvent(
+				"cron-inv",
+				"checking cron",
+				base.Add(time.Minute),
+			),
+			cronToolResultEvent(
+				"cron-inv",
+				`{"jobs":[{"name":"lunch reminder"}]}`,
+				base.Add(2*time.Minute),
+			),
+			assistantEventWithInvocation(
+				"cron-inv",
+				"lunch reminder runs at noon",
+				base.Add(3*time.Minute),
+			),
+			nextQuestion,
+			nextAnswer,
+		},
+	}
+
+	got := BuildInjectedContextMessages(sess, HistoryOptions{
+		MaxHistoryRuns: 10,
+	})
+	require.Len(t, got, 3)
+	require.Equal(t, model.RoleUser, got[0].Role)
+	require.Contains(t, got[0].Content, "list cron jobs")
+	require.Equal(t, model.RoleUser, got[1].Role)
+	require.Contains(t, got[1].Content, "next question")
+	require.Equal(t, model.RoleAssistant, got[2].Role)
+	require.Equal(t, "regular answer", got[2].Content)
+
+	rendered := got[0].Content + "\n" + got[1].Content + "\n" +
+		got[2].Content
+	require.NotContains(t, rendered, "checking cron")
+	require.NotContains(t, rendered, "lunch reminder")
+}
+
 func TestProjectEventMessage(t *testing.T) {
 	inv := agent.NewInvocation(
 		agent.WithInvocationMessage(model.Message{
@@ -656,6 +720,58 @@ func TestBuildSummaryText(t *testing.T) {
 	require.Contains(t, got, "Assistant: here is the update")
 }
 
+func TestBuildSummaryTextSkipsVolatileCronInvocationOutputs(
+	t *testing.T,
+) {
+	base := time.Now()
+	cronQuestion := userEvent(
+		"u1",
+		"Alice",
+		"list cron jobs",
+		base,
+	)
+	cronQuestion.InvocationID = "cron-inv"
+	nextQuestion := userEvent(
+		"u2",
+		"Bob",
+		"next question",
+		base.Add(4*time.Minute),
+	)
+	nextQuestion.InvocationID = "next-inv"
+	nextAnswer := assistantEvent(
+		"regular answer",
+		base.Add(5*time.Minute),
+	)
+	nextAnswer.InvocationID = "next-inv"
+
+	got := BuildSummaryText([]event.Event{
+		cronQuestion,
+		cronToolCallEvent(
+			"cron-inv",
+			"checking cron",
+			base.Add(time.Minute),
+		),
+		cronToolResultEvent(
+			"cron-inv",
+			`{"jobs":[{"name":"lunch reminder"}]}`,
+			base.Add(2*time.Minute),
+		),
+		assistantEventWithInvocation(
+			"cron-inv",
+			"lunch reminder runs at noon",
+			base.Add(3*time.Minute),
+		),
+		nextQuestion,
+		nextAnswer,
+	})
+
+	require.Contains(t, got, "Alice: list cron jobs")
+	require.Contains(t, got, "Bob: next question")
+	require.Contains(t, got, "Assistant: regular answer")
+	require.NotContains(t, got, "checking cron")
+	require.NotContains(t, got, "lunch reminder")
+}
+
 func TestBuildTurns(t *testing.T) {
 	base := time.Now()
 	sess := &session.Session{
@@ -913,6 +1029,66 @@ func assistantEvent(content string, ts time.Time) event.Event {
 		&model.Response{
 			Choices: []model.Choice{{
 				Message: model.NewAssistantMessage(content),
+			}},
+		},
+	)
+	evt.Timestamp = ts
+	return *evt
+}
+
+func assistantEventWithInvocation(
+	invocationID string,
+	content string,
+	ts time.Time,
+) event.Event {
+	evt := assistantEvent(content, ts)
+	evt.InvocationID = invocationID
+	return evt
+}
+
+func cronToolCallEvent(
+	invocationID string,
+	content string,
+	ts time.Time,
+) event.Event {
+	evt := event.NewResponseEvent(
+		invocationID,
+		authorAssistant,
+		&model.Response{
+			Choices: []model.Choice{{
+				Message: model.Message{
+					Role:    model.RoleAssistant,
+					Content: content,
+					ToolCalls: []model.ToolCall{{
+						ID:   "call-cron",
+						Type: "function",
+						Function: model.FunctionDefinitionParam{
+							Name: volatileHistoryToolCron,
+						},
+					}},
+				},
+			}},
+		},
+	)
+	evt.Timestamp = ts
+	return *evt
+}
+
+func cronToolResultEvent(
+	invocationID string,
+	content string,
+	ts time.Time,
+) event.Event {
+	evt := event.NewResponseEvent(
+		invocationID,
+		authorAssistant,
+		&model.Response{
+			Choices: []model.Choice{{
+				Message: model.NewToolMessage(
+					"call-cron",
+					volatileHistoryToolCron,
+					content,
+				),
 			}},
 		},
 	)

--- a/openclaw/internal/cron/service.go
+++ b/openclaw/internal/cron/service.go
@@ -69,6 +69,11 @@ const (
 	scheduledRunTemplateMarker = "{{"
 
 	debugTraceSourceCron = "cron"
+
+	wecomChannelID         = "wecom"
+	wecomDMUserPrefix      = "wecom:dm:"
+	wecomChatUserPrefix    = "wecom:chat:"
+	wecomGroupTargetPrefix = "group:"
 )
 
 // Service runs and persists scheduled jobs.
@@ -1306,18 +1311,63 @@ func matchesJobScope(
 	userID string,
 	delivery outbound.DeliveryTarget,
 ) bool {
-	if job == nil || strings.TrimSpace(job.UserID) != userID {
+	if job == nil {
+		return false
+	}
+	if strings.TrimSpace(job.UserID) == userID {
+		return matchesDeliveryFilter(job, delivery)
+	}
+	return matchesLegacyWeComGroupScope(job, userID, delivery)
+}
+
+func matchesDeliveryFilter(
+	job *Job,
+	delivery outbound.DeliveryTarget,
+) bool {
+	if job == nil {
 		return false
 	}
 	if delivery.Channel != "" &&
-		job.Delivery.Channel != delivery.Channel {
+		strings.TrimSpace(job.Delivery.Channel) != delivery.Channel {
 		return false
 	}
 	if delivery.Target != "" &&
-		job.Delivery.Target != delivery.Target {
+		strings.TrimSpace(job.Delivery.Target) != delivery.Target {
 		return false
 	}
 	return true
+}
+
+func matchesLegacyWeComGroupScope(
+	job *Job,
+	userID string,
+	delivery outbound.DeliveryTarget,
+) bool {
+	groupID, ok := strings.CutPrefix(
+		strings.TrimSpace(userID),
+		wecomChatUserPrefix,
+	)
+	if !ok {
+		return false
+	}
+	groupID = strings.TrimSpace(groupID)
+	if groupID == "" {
+		return false
+	}
+	if !strings.HasPrefix(
+		strings.TrimSpace(job.UserID),
+		wecomDMUserPrefix,
+	) {
+		return false
+	}
+	if strings.TrimSpace(job.Delivery.Channel) != wecomChannelID {
+		return false
+	}
+	if strings.TrimSpace(job.Delivery.Target) !=
+		wecomGroupTargetPrefix+groupID {
+		return false
+	}
+	return matchesDeliveryFilter(job, delivery)
 }
 
 func scheduledRunBase(job *Job, fallback time.Time) time.Time {

--- a/openclaw/internal/cron/service_test.go
+++ b/openclaw/internal/cron/service_test.go
@@ -1264,6 +1264,168 @@ func TestNewServicePreservesLoadedNextRunAt(t *testing.T) {
 	require.Equal(t, *job.NextRunAt, *jobs[0].NextRunAt)
 }
 
+func TestNewServiceListsLegacyWeComGroupJobOwner(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	now := time.Date(2026, 6, 11, 10, 0, 0, 0, time.UTC)
+	legacyUser := wecomDMUserPrefix + "shadowding"
+	groupUser := wecomChatUserPrefix + "room-1"
+	target := wecomGroupTargetPrefix + "room-1"
+	delivery := outbound.DeliveryTarget{
+		Channel: wecomChannelID,
+		Target:  target,
+	}
+
+	path := filepath.Join(dir, defaultCronDir, defaultJobsFile)
+	require.NoError(t, saveJobs(path, []*Job{{
+		ID:      "job-1",
+		Name:    "lunch",
+		Enabled: true,
+		Schedule: Schedule{
+			Kind:     ScheduleKindCron,
+			CronExpr: "30 11 * * *",
+			Timezone: "Asia/Shanghai",
+		},
+		Message:  "reply lunch",
+		UserID:   legacyUser,
+		Delivery: delivery,
+	}}))
+
+	svc, err := NewService(
+		dir,
+		&stubRunner{reply: "done"},
+		outbound.NewRouter(),
+		WithClock(func() time.Time { return now }),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, svc.Close())
+	})
+
+	jobs := svc.ListForUser(groupUser, delivery)
+	require.Len(t, jobs, 1)
+	require.Equal(t, "job-1", jobs[0].ID)
+	require.Equal(t, legacyUser, jobs[0].UserID)
+
+	jobs = svc.ListForUser(legacyUser, delivery)
+	require.Len(t, jobs, 1)
+	require.Equal(t, "job-1", jobs[0].ID)
+	require.Empty(t, svc.ListForUser(wecomChatUserPrefix+"room-2", delivery))
+}
+
+func TestMatchesLegacyWeComGroupScope(t *testing.T) {
+	t.Parallel()
+
+	legacyJob := &Job{
+		UserID: wecomDMUserPrefix + "user-1",
+		Delivery: outbound.DeliveryTarget{
+			Channel: wecomChannelID,
+			Target:  wecomGroupTargetPrefix + "room-1",
+		},
+	}
+	delivery := outbound.DeliveryTarget{
+		Channel: wecomChannelID,
+		Target:  wecomGroupTargetPrefix + "room-1",
+	}
+	require.False(
+		t,
+		matchesJobScope(nil, wecomChatUserPrefix+"room-1", delivery),
+	)
+	require.False(t, matchesDeliveryFilter(nil, delivery))
+
+	tests := []struct {
+		name     string
+		job      *Job
+		userID   string
+		delivery outbound.DeliveryTarget
+		want     bool
+	}{
+		{
+			name:     "legacy group owner",
+			job:      legacyJob,
+			userID:   wecomChatUserPrefix + "room-1",
+			delivery: delivery,
+			want:     true,
+		},
+		{
+			name: "direct owner",
+			job: &Job{
+				UserID:   wecomChatUserPrefix + "room-1",
+				Delivery: delivery,
+			},
+			userID:   wecomChatUserPrefix + "room-1",
+			delivery: delivery,
+			want:     true,
+		},
+		{
+			name:     "wrong group owner",
+			job:      legacyJob,
+			userID:   wecomChatUserPrefix + "room-2",
+			delivery: delivery,
+		},
+		{
+			name:   "delivery target mismatch",
+			job:    legacyJob,
+			userID: wecomChatUserPrefix + "room-1",
+			delivery: outbound.DeliveryTarget{
+				Channel: wecomChannelID,
+				Target:  wecomGroupTargetPrefix + "room-2",
+			},
+		},
+		{
+			name: "other channel",
+			job: &Job{
+				UserID: wecomDMUserPrefix + "user-1",
+				Delivery: outbound.DeliveryTarget{
+					Channel: "telegram",
+					Target:  wecomGroupTargetPrefix + "room-1",
+				},
+			},
+			userID:   wecomChatUserPrefix + "room-1",
+			delivery: delivery,
+		},
+		{
+			name: "direct message target",
+			job: &Job{
+				UserID: wecomDMUserPrefix + "user-1",
+				Delivery: outbound.DeliveryTarget{
+					Channel: wecomChannelID,
+					Target:  "dm:user-1",
+				},
+			},
+			userID:   wecomChatUserPrefix + "room-1",
+			delivery: delivery,
+		},
+		{
+			name:     "empty group owner",
+			job:      legacyJob,
+			userID:   wecomChatUserPrefix + " ",
+			delivery: delivery,
+		},
+		{
+			name:     "non chat owner",
+			job:      legacyJob,
+			userID:   wecomDMUserPrefix + "user-1",
+			delivery: delivery,
+			want:     true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(
+				t,
+				tc.want,
+				matchesJobScope(tc.job, tc.userID, tc.delivery),
+			)
+		})
+	}
+}
+
 func TestServiceRunNowDoesNotShiftSchedule(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/internal/cron/tool.go
+++ b/openclaw/internal/cron/tool.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/conversationscope"
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/outbound"
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/runtimeprofile"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
@@ -91,7 +92,7 @@ func (t *Tool) Declaration() *tool.Declaration {
 			"control what happens when one run is still busy. " +
 			cronTemplateHint + " " +
 			"Listing and mutating jobs is scoped to the " +
-			"current user.",
+			"current conversation.",
 		InputSchema: &tool.Schema{
 			Type:     "object",
 			Required: []string{"action"},
@@ -760,7 +761,7 @@ func currentUserID(ctx context.Context) (string, error) {
 	if userID == "" {
 		return "", fmt.Errorf("cron: current user id is unavailable")
 	}
-	return userID, nil
+	return conversationscope.StorageUserIDFromContext(ctx, userID), nil
 }
 
 func currentOwnedJob(
@@ -777,7 +778,7 @@ func currentOwnedJob(
 	if job == nil {
 		return nil, fmt.Errorf("cron: unknown job: %s", jobID)
 	}
-	if strings.TrimSpace(job.UserID) != userID {
+	if !matchesJobScope(job, userID, outbound.DeliveryTarget{}) {
 		return nil, fmt.Errorf("cron: unknown job: %s", jobID)
 	}
 	return job, nil

--- a/openclaw/internal/cron/tool_test.go
+++ b/openclaw/internal/cron/tool_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/conversationscope"
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/outbound"
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/runtimeprofile"
 	"trpc.group/trpc-go/trpc-agent-go/session"
@@ -1064,6 +1065,67 @@ func TestToolListScopesToCurrentUser(t *testing.T) {
 	require.True(t, ok)
 	require.Len(t, jobs, 1)
 	require.Equal(t, "mine", jobs[0].Name)
+}
+
+func TestToolUsesConversationStorageScope(t *testing.T) {
+	t.Parallel()
+
+	svc, err := NewService(
+		t.TempDir(),
+		&stubRunner{reply: "ok"},
+		outbound.NewRouter(),
+	)
+	require.NoError(t, err)
+
+	_, err = svc.Add(&Job{
+		Name:    "personal",
+		Enabled: true,
+		Schedule: Schedule{
+			Kind:  ScheduleKindEvery,
+			Every: "1m",
+		},
+		Message: "personal",
+		UserID:  "wecom:dm:user-1",
+	})
+	require.NoError(t, err)
+
+	tool := NewTool(svc)
+	var ctx context.Context = agent.NewInvocationContext(
+		context.Background(),
+		&agent.Invocation{
+			Session: &session.Session{
+				ID:     "wecom:chat:room-1",
+				UserID: "wecom:dm:user-1",
+			},
+		},
+	)
+	ctx = conversationscope.WithStorageUserID(ctx, "wecom:chat:room-1")
+
+	addArgs, err := json.Marshal(map[string]any{
+		"action":   "add",
+		"message":  "group reminder",
+		"interval": "1m",
+	})
+	require.NoError(t, err)
+
+	result, err := tool.Call(ctx, addArgs)
+	require.NoError(t, err)
+
+	job, ok := result.(*Job)
+	require.True(t, ok)
+	require.Equal(t, "wecom:chat:room-1", job.UserID)
+	require.Equal(t, "wecom", job.Delivery.Channel)
+	require.Equal(t, "group:room-1", job.Delivery.Target)
+
+	result, err = tool.Call(ctx, []byte(`{"action":"list"}`))
+	require.NoError(t, err)
+
+	payload, ok := result.(map[string]any)
+	require.True(t, ok)
+	jobs, ok := payload["jobs"].([]*Job)
+	require.True(t, ok)
+	require.Len(t, jobs, 1)
+	require.Equal(t, "group reminder", jobs[0].Message)
 }
 
 func TestToolRemoveRejectsOtherUsersJob(t *testing.T) {


### PR DESCRIPTION
## Summary

- Scope cron tool operations to the conversation storage owner when available.
- Migrate legacy WeCom group jobs that were stored under speaker DM owners to the group conversation owner on load.
- Add regression coverage for conversation-scoped cron creation/listing and legacy WeCom group job owner migration.

## Root Cause

WeCom group cron jobs can carry both a runtime-facing speaker user ID and a conversation storage scope. The cron tool previously used the runtime-facing session user as the job owner. That let natural-language cron listing find jobs created by the same speaker in a different group when the model omitted an explicit delivery target, while command/control-card paths queried the group conversation scope and could miss those legacy jobs.

## Validation

- `go test ./internal/cron -run 'Test(NewServiceMigratesLegacyWeComGroupJobOwner|ToolUsesConversationStorageScope|ToolListScopesToCurrentUser|ToolListFiltersByTarget)' -count=1`
- `go test ./internal/cron -count=1`
- `git diff --check`
