### PR TITLE
server/agui: wait on empty snapshot follow tracks

### DIFF
--- a/server/agui/runner/messagessnapshot.go
+++ b/server/agui/runner/messagessnapshot.go
@@ -234,6 +234,9 @@ func (r *runner) handleMessagesSnapshotFollowTick(
 ) bool {
 	trackEvents, err := r.tracker.GetEvents(ctx, input.key, session.WithEventTime(*cursorTime))
 	if err != nil {
+		if isEmptyTrackEventsError(err) {
+			return true
+		}
 		r.emitEvent(ctx, events, aguievents.NewRunErrorEvent(fmt.Sprintf("follow track events: %v", err),
 			aguievents.WithRunID(input.runID)), input)
 		return false
@@ -269,6 +272,10 @@ func (r *runner) handleMessagesSnapshotFollowTick(
 		}
 	}
 	return true
+}
+
+func isEmptyTrackEventsError(err error) bool {
+	return errors.Is(err, session.ErrTracksEmpty) || errors.Is(err, session.ErrTrackEventsNotFound)
 }
 
 func trackEndsWithTerminalRunEvent(events []session.TrackEvent) bool {

--- a/server/agui/runner/messagessnapshot_test.go
+++ b/server/agui/runner/messagessnapshot_test.go
@@ -12,6 +12,7 @@ package runner
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"sync"
 	"testing"
@@ -1157,6 +1158,50 @@ func TestMessagesSnapshotFollowEmitsRunErrorOnFollowGetEventsError(t *testing.T)
 	require.Contains(t, errEvt.Message, "follow track events: boom")
 }
 
+func TestMessagesSnapshotFollowTreatsEmptyTrackAsNoUpdate(t *testing.T) {
+	base := time.Now().Add(-time.Second)
+	initial := &session.TrackEvents{
+		Track: track.TrackAGUI,
+		Events: []session.TrackEvent{
+			newUserMessageTrackEventAt(t, "user-1", "hi", base.Add(-time.Millisecond)),
+			newTrackEventAt(t, aguievents.NewTextMessageStartEvent("msg-1", aguievents.WithRole("assistant")), base),
+			newTrackEventAt(t, aguievents.NewTextMessageContentEvent("msg-1", "hello"), base.Add(time.Millisecond)),
+			newTrackEventAt(t, aguievents.NewTextMessageEndEvent("msg-1"), base.Add(2*time.Millisecond)),
+		},
+	}
+	terminal := &session.TrackEvents{
+		Track: track.TrackAGUI,
+		Events: []session.TrackEvent{
+			newTrackEventAt(t, aguievents.NewRunFinishedEvent("thread", "real-run"), base.Add(3*time.Millisecond)),
+		},
+	}
+	tracker := &emptyTrackThenTerminalTracker{initial: initial, terminal: terminal}
+	r := &runner{
+		runner:                            noopBaseRunner{},
+		userIDResolver:                    NewOptions().UserIDResolver,
+		runAgentInputHook:                 NewOptions().RunAgentInputHook,
+		appName:                           "demo",
+		tracker:                           tracker,
+		flushInterval:                     time.Millisecond,
+		timeout:                           100 * time.Millisecond,
+		messagesSnapshotFollowEnabled:     true,
+		messagesSnapshotFollowMaxDuration: 100 * time.Millisecond,
+	}
+	stream, err := r.MessagesSnapshot(context.Background(), &adapter.RunAgentInput{ThreadID: "thread", RunID: "req-run"})
+	require.NoError(t, err)
+	collected := collectAGUIEvents(t, stream)
+	require.Len(t, collected, 3)
+	require.IsType(t, (*aguievents.RunStartedEvent)(nil), collected[0])
+	require.IsType(t, (*aguievents.MessagesSnapshotEvent)(nil), collected[1])
+	finished, ok := collected[2].(*aguievents.RunFinishedEvent)
+	require.True(t, ok)
+	require.Equal(t, "req-run", finished.RunID())
+	tracker.mu.Lock()
+	calls := tracker.calls
+	tracker.mu.Unlock()
+	require.GreaterOrEqual(t, calls, 3)
+}
+
 func TestMessagesSnapshotFollowEmitsTimeoutWhenNoTerminalEvent(t *testing.T) {
 	base := time.Now().Add(-time.Second)
 	initial := &session.TrackEvents{
@@ -1433,6 +1478,34 @@ func (t *errorAfterFirstTracker) GetEvents(ctx context.Context, key session.Key,
 }
 
 func (t *errorAfterFirstTracker) Flush(ctx context.Context, key session.Key) error {
+	return nil
+}
+
+type emptyTrackThenTerminalTracker struct {
+	mu       sync.Mutex
+	calls    int
+	initial  *session.TrackEvents
+	terminal *session.TrackEvents
+}
+
+func (t *emptyTrackThenTerminalTracker) AppendEvent(ctx context.Context, key session.Key, event aguievents.Event) error {
+	return nil
+}
+
+func (t *emptyTrackThenTerminalTracker) GetEvents(ctx context.Context, key session.Key, opts ...session.Option) (*session.TrackEvents, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.calls++
+	if t.calls == 1 {
+		return t.initial, nil
+	}
+	if t.calls == 2 {
+		return nil, fmt.Errorf("get track events: %w", session.ErrTracksEmpty)
+	}
+	return t.terminal, nil
+}
+
+func (t *emptyTrackThenTerminalTracker) Flush(ctx context.Context, key session.Key) error {
 	return nil
 }
 

--- a/session/session.go
+++ b/session/session.go
@@ -47,6 +47,10 @@ var (
 	ErrEventPageConflictsWithEventFilters = errors.New("event page cannot be combined with EventNum or EventTime")
 	// ErrInvalidListSessionPage indicates list-session paging arguments are invalid.
 	ErrInvalidListSessionPage = errors.New("list session page requires offset >= 0 and limit >= 0")
+	// ErrTracksEmpty indicates the session has no track data.
+	ErrTracksEmpty = errors.New("tracks is empty")
+	// ErrTrackEventsNotFound indicates the requested track has no events.
+	ErrTrackEventsNotFound = errors.New("track events not found")
 )
 
 // SummaryFilterKeyAllContents is the filter key representing
@@ -416,11 +420,11 @@ func (sess *Session) GetTrackEvents(track Track) (*TrackEvents, error) {
 	sess.TracksMu.RLock()
 	defer sess.TracksMu.RUnlock()
 	if sess.Tracks == nil {
-		return nil, fmt.Errorf("tracks is empty")
+		return nil, ErrTracksEmpty
 	}
 	trackEvents, ok := sess.Tracks[track]
 	if !ok || trackEvents == nil {
-		return nil, fmt.Errorf("track events not found: %s", track)
+		return nil, fmt.Errorf("%w: %s", ErrTrackEventsNotFound, track)
 	}
 	copied := &TrackEvents{Track: trackEvents.Track}
 	if len(trackEvents.Events) > 0 {


### PR DESCRIPTION
This change treats missing AG-UI track data during messages snapshot follow polling as no new updates, while preserving the initial history load behavior and real follow errors. It adds typed session track errors so the runner can distinguish empty follow windows from storage failures.