### PR TITLE
{server/agui, session/mysql}: fix empty AG-UI history replay

### DIFF
--- a/server/agui/internal/reduce/reduce.go
+++ b/server/agui/internal/reduce/reduce.go
@@ -141,11 +141,17 @@ func (r *reducer) reduce(trackEvent session.TrackEvent) error {
 func (r *reducer) reduceEvent(evt aguievents.Event) error {
 	switch e := evt.(type) {
 	case *aguievents.RunStartedEvent:
-		return r.handleRunStarted(e)
+		err := r.handleRunStarted(e)
+		r.finishRun()
+		return err
 	case *aguievents.RunFinishedEvent:
-		return r.handleRunFinished(e)
+		err := r.handleRunFinished(e)
+		r.finishRun()
+		return err
 	case *aguievents.RunErrorEvent:
-		return r.handleRunError(e)
+		err := r.handleRunError(e)
+		r.finishRun()
+		return err
 	case *aguievents.TextMessageStartEvent:
 		return r.handleTextStart(e)
 	case *aguievents.TextMessageContentEvent:
@@ -184,6 +190,20 @@ func (r *reducer) reduceEvent(evt aguievents.Event) error {
 	default:
 		return r.handleActivity(e)
 	}
+}
+
+func (r *reducer) finishRun() {
+	r.finalizePartial()
+	r.texts = make(map[string]*textState)
+	r.reasonings = make(map[string]*reasoningState)
+	r.lastReasoningChunkID = ""
+	pendingToolCalls := make(map[string]*toolCallState)
+	for id, state := range r.toolCalls {
+		if state.phase == toolAwaitingResult {
+			pendingToolCalls[id] = state
+		}
+	}
+	r.toolCalls = pendingToolCalls
 }
 
 func (r *reducer) handleUserMessageCustomEvent(e *aguievents.CustomEvent) error {

--- a/server/agui/internal/reduce/reduce_test.go
+++ b/server/agui/internal/reduce/reduce_test.go
@@ -138,6 +138,70 @@ func TestReduceUserMessageCustomEventWithStringContent(t *testing.T) {
 	assert.Equal(t, "hi", content)
 }
 
+func TestReduceAllowsRepeatedIDsAcrossRuns(t *testing.T) {
+	firstUser := types.Message{ID: "user-1", Role: types.RoleUser, Content: "hello"}
+	secondUser := types.Message{ID: "user-2", Role: types.RoleUser, Content: "again"}
+	events := trackEventsFrom(
+		aguievents.NewCustomEvent(multimodal.CustomEventNameUserMessage, aguievents.WithValue(firstUser)),
+		aguievents.NewRunStartedEvent("thread", "run-1"),
+		aguievents.NewTextMessageStartEvent("msg-1", aguievents.WithRole("assistant")),
+		aguievents.NewTextMessageContentEvent("msg-1", "first"),
+		aguievents.NewTextMessageEndEvent("msg-1"),
+		aguievents.NewRunFinishedEvent("thread", "run-1"),
+		aguievents.NewCustomEvent(multimodal.CustomEventNameUserMessage, aguievents.WithValue(secondUser)),
+		aguievents.NewRunStartedEvent("thread", "run-2"),
+		aguievents.NewTextMessageStartEvent("msg-1", aguievents.WithRole("assistant")),
+		aguievents.NewTextMessageContentEvent("msg-1", "second"),
+		aguievents.NewTextMessageEndEvent("msg-1"),
+		aguievents.NewRunFinishedEvent("thread", "run-2"),
+	)
+
+	msgs, err := Reduce(testAppName, testUserID, events)
+	require.NoError(t, err)
+	require.Len(t, msgs, 4)
+	assert.Equal(t, types.RoleUser, msgs[0].Role)
+	assert.Equal(t, types.RoleAssistant, msgs[1].Role)
+	assert.Equal(t, types.RoleUser, msgs[2].Role)
+	assert.Equal(t, types.RoleAssistant, msgs[3].Role)
+	firstContent, ok := msgs[1].ContentString()
+	require.True(t, ok)
+	assert.Equal(t, "first", firstContent)
+	secondContent, ok := msgs[3].ContentString()
+	require.True(t, ok)
+	assert.Equal(t, "second", secondContent)
+}
+
+func TestReduceAllowsToolResultAfterRunBoundary(t *testing.T) {
+	events := trackEventsFrom(
+		aguievents.NewRunStartedEvent("thread", "run-1"),
+		aguievents.NewTextMessageStartEvent("assistant-1", aguievents.WithRole("assistant")),
+		aguievents.NewToolCallStartEvent("call-1", "search", aguievents.WithParentMessageID("assistant-1")),
+		aguievents.NewToolCallArgsEvent("call-1", "{\"q\":\"hello\"}"),
+		aguievents.NewToolCallEndEvent("call-1"),
+		aguievents.NewTextMessageEndEvent("assistant-1"),
+		aguievents.NewRunFinishedEvent("thread", "run-1"),
+		aguievents.NewRunStartedEvent("thread", "run-2"),
+		aguievents.NewToolCallResultEvent("tool-msg-1", "call-1", "world"),
+		aguievents.NewRunFinishedEvent("thread", "run-2"),
+	)
+
+	msgs, err := Reduce(testAppName, testUserID, events)
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
+	assistant := msgs[0]
+	assert.Equal(t, types.RoleAssistant, assistant.Role)
+	require.Len(t, assistant.ToolCalls, 1)
+	assert.Equal(t, "call-1", assistant.ToolCalls[0].ID)
+	assert.Equal(t, "{\"q\":\"hello\"}", assistant.ToolCalls[0].Function.Arguments)
+	tool := msgs[1]
+	assert.Equal(t, types.RoleTool, tool.Role)
+	require.NotNil(t, tool.ToolCallID)
+	assert.Equal(t, "call-1", tool.ToolCallID)
+	content, ok := tool.ContentString()
+	require.True(t, ok)
+	assert.Equal(t, "world", content)
+}
+
 func TestHandleUserMessageCustomEventErrors(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/server/agui/runner/messagessnapshot.go
+++ b/server/agui/runner/messagessnapshot.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime/debug"
 	"time"
 
 	aguievents "github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/events"
@@ -37,8 +38,11 @@ func (r *runner) MessagesSnapshot(ctx context.Context,
 	runAgentInput *adapter.RunAgentInput) (eventCh <-chan aguievents.Event, err error) {
 	defer func() {
 		if rec := recover(); rec != nil {
+			// The error is written back to the HTTP client; keep the panic
+			// payload (hooks/resolvers may embed request internals) in logs only.
+			log.ErrorfContext(ctx, "agui messages snapshot: panic: %v\n%s", rec, debug.Stack())
 			eventCh = nil
-			err = fmt.Errorf("messages snapshot panic: %v", rec)
+			err = errors.New("messages snapshot internal error")
 		}
 	}()
 	if r.runner == nil {

--- a/server/agui/runner/messagessnapshot.go
+++ b/server/agui/runner/messagessnapshot.go
@@ -119,7 +119,8 @@ func (r *runner) messagesSnapshot(ctx context.Context, input *runInput, events c
 		return
 	}
 
-	if r.messagesSnapshotFollowEnabled && trackEvents != nil && !trackEndsWithTerminalRunEvent(trackEvents.Events) {
+	if r.messagesSnapshotFollowEnabled && trackEvents != nil && len(trackEvents.Events) > 0 &&
+		!trackEndsWithTerminalRunEvent(trackEvents.Events) {
 		r.messagesSnapshotFollow(ctx, input, events, trackEvents)
 		return
 	}

--- a/server/agui/runner/messagessnapshot.go
+++ b/server/agui/runner/messagessnapshot.go
@@ -34,7 +34,13 @@ type MessagesSnapshotter interface {
 
 // MessagesSnapshot sends a MessagesSnapshot event stream by replaying persisted AG-UI track events.
 func (r *runner) MessagesSnapshot(ctx context.Context,
-	runAgentInput *adapter.RunAgentInput) (<-chan aguievents.Event, error) {
+	runAgentInput *adapter.RunAgentInput) (eventCh <-chan aguievents.Event, err error) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			eventCh = nil
+			err = fmt.Errorf("messages snapshot panic: %v", rec)
+		}
+	}()
 	if r.runner == nil {
 		return nil, errors.New("runner is nil")
 	}
@@ -44,7 +50,7 @@ func (r *runner) MessagesSnapshot(ctx context.Context,
 	if r.tracker == nil {
 		return nil, errors.New("tracker is nil")
 	}
-	runAgentInput, err := r.applyRunAgentInputHook(ctx, runAgentInput)
+	runAgentInput, err = r.applyRunAgentInputHook(ctx, runAgentInput)
 	if err != nil {
 		return nil, fmt.Errorf("run input hook: %w", err)
 	}
@@ -132,6 +138,10 @@ func (r *runner) getMessagesSnapshotEvent(ctx context.Context,
 		return nil, nil, fmt.Errorf("get track events: %w", err)
 	}
 	eventsForReduce, safeForFollow := trimTrackEventsToHistoryStart(trackEvents.Events)
+	if !safeForFollow && len(trackEvents.Events) > 0 {
+		log.WarnfContext(ctx, "agui messages snapshot: no safe user message boundary, app=%s, user=%s, session=%s, trackEvents=%d",
+			sessionKey.AppName, sessionKey.UserID, sessionKey.SessionID, len(trackEvents.Events))
+	}
 	messages, err := reduce.Reduce(
 		sessionKey.AppName,
 		sessionKey.UserID,

--- a/server/agui/runner/messagessnapshot.go
+++ b/server/agui/runner/messagessnapshot.go
@@ -152,6 +152,8 @@ func (r *runner) getMessagesSnapshotEvent(ctx context.Context,
 	if err != nil {
 		err = fmt.Errorf("reduce track events: %w", err)
 	}
+	log.DebugfContext(ctx, "agui messages snapshot: app=%s, user=%s, session=%s, trackEvents=%d, eventsForReduce=%d, safeForFollow=%t, messages=%d, reduceErr=%v",
+		sessionKey.AppName, sessionKey.UserID, sessionKey.SessionID, len(trackEvents.Events), len(eventsForReduce), safeForFollow, len(messages), err)
 	event := aguievents.NewMessagesSnapshotEvent(messages)
 	if r.eventSourceMetadataEnabled {
 		metadata := source.BuildSnapshotMetadata(eventsForReduce)

--- a/server/agui/runner/messagessnapshot_test.go
+++ b/server/agui/runner/messagessnapshot_test.go
@@ -699,6 +699,30 @@ func TestMessagesSnapshotUserIDResolverError(t *testing.T) {
 	assert.Contains(t, err.Error(), "resolve user ID")
 }
 
+func TestMessagesSnapshotRecoversUserIDResolverPanic(t *testing.T) {
+	svc := &testSessionService{trackEvents: []session.TrackEvent{newUserMessageTrackEvent(t, "user-1", "hi")}}
+	tracker, err := track.New(svc)
+	require.NoError(t, err)
+	r := &runner{
+		runner: noopBaseRunner{},
+		userIDResolver: func(context.Context, *adapter.RunAgentInput) (string, error) {
+			panic("bad forwarded props")
+		},
+		runAgentInputHook: NewOptions().RunAgentInputHook,
+		appName:           "demo",
+		tracker:           tracker,
+	}
+
+	stream, err := r.MessagesSnapshot(
+		context.Background(),
+		&adapter.RunAgentInput{ThreadID: "thread", RunID: "run"},
+	)
+	require.Error(t, err)
+	assert.Nil(t, stream)
+	assert.Contains(t, err.Error(), "messages snapshot panic")
+	assert.Contains(t, err.Error(), "bad forwarded props")
+}
+
 func TestMessagesSnapshotAppNameResolverError(t *testing.T) {
 	svc := &testSessionService{}
 	tracker, err := track.New(svc)

--- a/server/agui/runner/messagessnapshot_test.go
+++ b/server/agui/runner/messagessnapshot_test.go
@@ -719,8 +719,10 @@ func TestMessagesSnapshotRecoversUserIDResolverPanic(t *testing.T) {
 	)
 	require.Error(t, err)
 	assert.Nil(t, stream)
-	assert.Contains(t, err.Error(), "messages snapshot panic")
-	assert.Contains(t, err.Error(), "bad forwarded props")
+	assert.Equal(t, "messages snapshot internal error", err.Error())
+	// The panic payload may carry request internals and must stay out of the
+	// error returned to HTTP clients.
+	assert.NotContains(t, err.Error(), "bad forwarded props")
 }
 
 func TestMessagesSnapshotAppNameResolverError(t *testing.T) {

--- a/server/agui/runner/messagessnapshot_test.go
+++ b/server/agui/runner/messagessnapshot_test.go
@@ -1100,6 +1100,45 @@ func TestMessagesSnapshotFollowSkipsWhenInitialAlreadyTerminal(t *testing.T) {
 	require.Equal(t, 1, calls)
 }
 
+func TestMessagesSnapshotFollowSkipsWhenInitialTrackEmpty(t *testing.T) {
+	base := time.Now().Add(-time.Second)
+	initial := &session.TrackEvents{Track: track.TrackAGUI}
+	follow := &session.TrackEvents{
+		Track: track.TrackAGUI,
+		Events: []session.TrackEvent{
+			newTrackEventAt(t, aguievents.NewRunFinishedEvent("thread", "real-run"), base),
+		},
+	}
+	tr := &sequenceTracker{first: initial, second: follow}
+	r := &runner{
+		runner:                            noopBaseRunner{},
+		userIDResolver:                    NewOptions().UserIDResolver,
+		runAgentInputHook:                 NewOptions().RunAgentInputHook,
+		appName:                           "demo",
+		tracker:                           tr,
+		flushInterval:                     time.Millisecond,
+		timeout:                           50 * time.Millisecond,
+		messagesSnapshotFollowEnabled:     true,
+		messagesSnapshotFollowMaxDuration: 50 * time.Millisecond,
+	}
+
+	stream, err := r.MessagesSnapshot(context.Background(), &adapter.RunAgentInput{ThreadID: "thread", RunID: "req-run"})
+	require.NoError(t, err)
+
+	collected := collectAGUIEvents(t, stream)
+	require.Len(t, collected, 3)
+	require.IsType(t, (*aguievents.RunStartedEvent)(nil), collected[0])
+	snapshot, ok := collected[1].(*aguievents.MessagesSnapshotEvent)
+	require.True(t, ok)
+	require.Empty(t, snapshot.Messages)
+	require.IsType(t, (*aguievents.RunFinishedEvent)(nil), collected[2])
+
+	tr.mu.Lock()
+	calls := tr.calls
+	tr.mu.Unlock()
+	require.Equal(t, 1, calls)
+}
+
 func TestMessagesSnapshotFollowEmitsRunErrorOnTerminalErrorEvent(t *testing.T) {
 	base := time.Now().Add(-time.Second)
 	initial := &session.TrackEvents{

--- a/session/mysql/service_helper.go
+++ b/session/mysql/service_helper.go
@@ -1025,25 +1025,25 @@ func (s *Service) getTrackEvents(
 			return nil, fmt.Errorf("get track list failed: %w", err)
 		}
 		for _, track := range tracks {
-			var query string
-			var args []any
+			query := fmt.Sprintf(`SELECT event FROM %s
+					WHERE app_name = ? AND user_id = ? AND session_id = ? AND track = ?
+					AND (expires_at IS NULL OR expires_at > ?)
+					AND deleted_at IS NULL`, s.tableSessionTracks)
+			args := []any{key.AppName, key.UserID, key.SessionID, track, now}
+			// A zero afterTime must not reach the driver: go-sql-driver encodes
+			// time.Time{} as '0000-00-00', which strict-mode MySQL rejects or
+			// matches nothing, silently dropping every track event.
+			if !afterTime.IsZero() {
+				query += `
+					AND created_at > ?`
+				args = append(args, afterTime)
+			}
+			query += `
+					ORDER BY created_at DESC`
 			if limit > 0 {
-				query = fmt.Sprintf(`SELECT event FROM %s
-					WHERE app_name = ? AND user_id = ? AND session_id = ? AND track = ?
-					AND (expires_at IS NULL OR expires_at > ?)
-					AND created_at > ?
-					AND deleted_at IS NULL
-					ORDER BY created_at DESC
-					LIMIT ?`, s.tableSessionTracks)
-				args = []any{key.AppName, key.UserID, key.SessionID, track, now, afterTime, limit}
-			} else {
-				query = fmt.Sprintf(`SELECT event FROM %s
-					WHERE app_name = ? AND user_id = ? AND session_id = ? AND track = ?
-					AND (expires_at IS NULL OR expires_at > ?)
-					AND created_at > ?
-					AND deleted_at IS NULL
-					ORDER BY created_at DESC`, s.tableSessionTracks)
-				args = []any{key.AppName, key.UserID, key.SessionID, track, now, afterTime}
+				query += `
+					LIMIT ?`
+				args = append(args, limit)
 			}
 			queries = append(queries, &trackQuery{
 				sessionIdx: i,

--- a/session/mysql/service_helper_test.go
+++ b/session/mysql/service_helper_test.go
@@ -451,7 +451,7 @@ func TestGetSession_WithTrackEvents(t *testing.T) {
 	}
 	trackBytes, _ := json.Marshal(trackEvent)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT event FROM session_track_events")).
-		WithArgs(key.AppName, key.UserID, key.SessionID, "alpha", sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WithArgs(key.AppName, key.UserID, key.SessionID, "alpha", sqlmock.AnyArg()).
 		WillReturnRows(sqlmock.NewRows([]string{"event"}).AddRow(trackBytes))
 
 	sess, err := s.GetSession(ctx, key)
@@ -649,7 +649,7 @@ func TestListSessions_WithTrackEvents(t *testing.T) {
 	}
 	trackBytes, _ := json.Marshal(trackEvent)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT event FROM session_track_events")).
-		WithArgs(userKey.AppName, userKey.UserID, "session-1", "alpha", sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WithArgs(userKey.AppName, userKey.UserID, "session-1", "alpha", sqlmock.AnyArg()).
 		WillReturnRows(sqlmock.NewRows([]string{"event"}).AddRow(trackBytes))
 
 	sessions, err := s.ListSessions(ctx, userKey)
@@ -1382,7 +1382,7 @@ func TestGetTrackEventsHelper_WithLimit(t *testing.T) {
 	eventBytes, _ := json.Marshal(event)
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT event FROM session_track_events")).
-		WithArgs("test-app", "test-user", "session-1", "alpha", sqlmock.AnyArg(), sqlmock.AnyArg(), 1).
+		WithArgs("test-app", "test-user", "session-1", "alpha", sqlmock.AnyArg(), 1).
 		WillReturnRows(sqlmock.NewRows([]string{"event"}).AddRow(eventBytes))
 
 	result, err := s.getTrackEvents(context.Background(), []session.Key{key}, []*SessionState{sessState}, 1, time.Time{})
@@ -1428,7 +1428,7 @@ func TestGetTrackEventsHelper_NoLimit_ReversedOrder(t *testing.T) {
 
 	// Rows come in reverse chronological order, but getTrackEvents should reverse them.
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT event FROM session_track_events")).
-		WithArgs("test-app", "test-user", "session-1", "alpha", sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WithArgs("test-app", "test-user", "session-1", "alpha", sqlmock.AnyArg()).
 		WillReturnRows(sqlmock.NewRows([]string{"event"}).
 			AddRow(event2Bytes).
 			AddRow(event1Bytes))
@@ -1463,7 +1463,7 @@ func TestGetTrackEventsHelper_QueryError(t *testing.T) {
 	}
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT event FROM session_track_events")).
-		WithArgs("test-app", "test-user", "session-1", "alpha", sqlmock.AnyArg(), sqlmock.AnyArg(), 1).
+		WithArgs("test-app", "test-user", "session-1", "alpha", sqlmock.AnyArg(), 1).
 		WillReturnError(fmt.Errorf("db error"))
 
 	result, err := s.getTrackEvents(context.Background(), []session.Key{key}, []*SessionState{sessState}, 1, time.Time{})
@@ -1493,7 +1493,7 @@ func TestGetTrackEventsHelper_UnmarshalError(t *testing.T) {
 
 	// Invalid JSON for track event.
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT event FROM session_track_events")).
-		WithArgs("test-app", "test-user", "session-1", "alpha", sqlmock.AnyArg(), sqlmock.AnyArg(), 1).
+		WithArgs("test-app", "test-user", "session-1", "alpha", sqlmock.AnyArg(), 1).
 		WillReturnRows(sqlmock.NewRows([]string{"event"}).
 			AddRow([]byte("{invalid")))
 

--- a/session/mysql/service_test.go
+++ b/session/mysql/service_test.go
@@ -2330,7 +2330,7 @@ func TestGetTrackEvents_WithLimit(t *testing.T) {
 	rows := sqlmock.NewRows([]string{"event"}).AddRow(eventBytes)
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT event FROM session_track_events")).
-		WithArgs("test-app", "test-user", "session-1", "alpha", sqlmock.AnyArg(), sqlmock.AnyArg(), 1).
+		WithArgs("test-app", "test-user", "session-1", "alpha", sqlmock.AnyArg(), 1).
 		WillReturnRows(rows)
 
 	result, err := s.getTrackEvents(ctx, []session.Key{key}, []*SessionState{sessState}, 1, time.Time{})
@@ -2339,6 +2339,96 @@ func TestGetTrackEvents_WithLimit(t *testing.T) {
 	alpha := result[0]["alpha"]
 	require.Len(t, alpha, 1)
 	assert.Equal(t, json.RawMessage(`"limited"`), alpha[0].Payload)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestGetTrackEvents_ZeroAfterTimeOmitsCreatedAtFilter guards against binding
+// a zero time.Time into the created_at predicate: go-sql-driver encodes
+// time.Time{} as '0000-00-00', which strict-mode MySQL rejects or matches
+// nothing, silently dropping every persisted track event.
+func TestGetTrackEvents_ZeroAfterTimeOmitsCreatedAtFilter(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db)
+	ctx := context.Background()
+
+	key := session.Key{
+		AppName:   "test-app",
+		UserID:    "test-user",
+		SessionID: "session-1",
+	}
+	sessState := &SessionState{
+		State: session.StateMap{
+			"tracks": []byte(`["alpha"]`),
+		},
+	}
+
+	event := &session.TrackEvent{
+		Track:     "alpha",
+		Payload:   json.RawMessage(`"kept"`),
+		Timestamp: time.Now(),
+	}
+	eventBytes, _ := json.Marshal(event)
+	rows := sqlmock.NewRows([]string{"event"}).AddRow(eventBytes)
+
+	// Without limit and with a zero afterTime, only the key, track, and
+	// expiry arguments may be bound; no created_at predicate may be added.
+	mock.ExpectQuery(`SELECT event FROM session_track_events\s+`+
+		`WHERE app_name = \? AND user_id = \? AND session_id = \? AND track = \?\s+`+
+		`AND \(expires_at IS NULL OR expires_at > \?\)\s+`+
+		`AND deleted_at IS NULL\s+`+
+		`ORDER BY created_at DESC$`).
+		WithArgs("test-app", "test-user", "session-1", "alpha", sqlmock.AnyArg()).
+		WillReturnRows(rows)
+
+	result, err := s.getTrackEvents(ctx, []session.Key{key}, []*SessionState{sessState}, 0, time.Time{})
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	alpha := result[0]["alpha"]
+	require.Len(t, alpha, 1)
+	assert.Equal(t, json.RawMessage(`"kept"`), alpha[0].Payload)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestGetTrackEvents_AfterTimeBindsCreatedAtFilter verifies a non-zero
+// afterTime still narrows the query through the created_at predicate.
+func TestGetTrackEvents_AfterTimeBindsCreatedAtFilter(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db)
+	ctx := context.Background()
+
+	key := session.Key{
+		AppName:   "test-app",
+		UserID:    "test-user",
+		SessionID: "session-1",
+	}
+	sessState := &SessionState{
+		State: session.StateMap{
+			"tracks": []byte(`["alpha"]`),
+		},
+	}
+
+	afterTime := time.Now().Add(-time.Hour)
+	mock.ExpectQuery(`SELECT event FROM session_track_events\s+`+
+		`WHERE app_name = \? AND user_id = \? AND session_id = \? AND track = \?\s+`+
+		`AND \(expires_at IS NULL OR expires_at > \?\)\s+`+
+		`AND deleted_at IS NULL\s+`+
+		`AND created_at > \?\s+`+
+		`ORDER BY created_at DESC$`).
+		WithArgs("test-app", "test-user", "session-1", "alpha", sqlmock.AnyArg(), afterTime).
+		WillReturnRows(sqlmock.NewRows([]string{"event"}))
+
+	result, err := s.getTrackEvents(ctx, []session.Key{key}, []*SessionState{sessState}, 0, afterTime)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	require.Empty(t, result[0]["alpha"])
 
 	require.NoError(t, mock.ExpectationsWereMet())
 }


### PR DESCRIPTION
## Summary

This PR fixes the reported "AG-UI `/history` cannot replay multi-turn conversations" issue. It contains one root-cause fix plus several hardening/diagnosability fixes found along the way:

1. **`session/mysql`: zero after-time filter silently dropped every track event** (root cause of the report). When `GetSession` runs without `WithEventTime`, the zero `time.Time{}` was bound directly into `AND created_at > ?`. go-sql-driver encodes a zero `time.Time` as `'0000-00-00'`; on MySQL 8.0.22 (including TXSQL 8.0.22 kernels) the prepared-statement path evaluates that predicate as matching nothing — no error, no warning — so `/history` always replayed an empty track. The query now omits the `created_at` predicate when the after-time is unset.
2. **Reducer state reset at run boundaries.** The snapshot reducer kept text/reasoning message state for the whole thread, so a later run reusing a model response ID (e.g. `msg-1`) was treated as a duplicate message start and reduction stopped early. Run-local state is now cleared at `RUN_STARTED` / `RUN_FINISHED` / `RUN_ERROR`, while tool calls awaiting results are preserved across runs because AG-UI tool results may be posted in a later run.
3. **Finish empty history snapshots.** With follow mode enabled, an empty track no longer enters the follow polling loop (which used to hang the request until timeout); the run finishes immediately after the empty snapshot.
4. **Recover panics during `/history` snapshot setup.** A panicking hook/resolver previously closed the HTTP connection before headers were written (`curl: (52) Empty reply from server`); the client now receives a stable `messages snapshot internal error` while the panic payload and stack are logged server-side only.
5. **Diagnosability.** `/history` now warns when persisted track events exist but no safe user-message boundary is found, and logs snapshot counts (`trackEvents` / `eventsForReduce` / `messages` / `reduceErr`), making this class of empty-snapshot issues visible from a single log line.

## Root Cause of the Reported Incident

Symptom: chat over `/api/agui/chat` streamed normally and track events were fully persisted (verified in the `session_track_events` table), yet `/history` stably returned `MESSAGES_SNAPSHOT` with `messages: []` and `RUN_FINISHED`, with zero error logs; a session-status check based on `GetTrackEvents` also saw zero events.

Verified chain: `getTrackEvents` binds the unset (zero) after-time → go-sql-driver sends `'0000-00-00'` (`packets.go`: `if v.IsZero() { b = append(b, "0000-00-00"...) }`) → server-version-dependent behavior of `TIMESTAMP > '0000-00-00'`:

| Server | Text protocol (literal) | Binary protocol (prepared, the real client path) |
|---|---|---|
| MySQL 5.7.44 | matches all rows | matches all rows |
| **MySQL 8.0.22** (= TXSQL 8.0.22 base) | **ERROR 1525** | **matches nothing, silently** ← incident |
| MySQL 8.0.44 | ERROR 1525 | matches all rows |

The incident environment ran `8.0.22-txsql`, which inherits the upstream 8.0.22 semantics. Because the same statement hard-errors over the text protocol, manual SQL reproduction kept failing while the service silently read zero rows. Other session/event queries were unaffected since they clamp the time filter to the session creation time; only the track query forwarded the raw option value.

## Validation

- `cd session/mysql && go test ./...` — includes new regression tests asserting the generated SQL and bind arguments for both the zero and non-zero after-time cases.
- `cd server/agui && go test ./...` — reducer run-boundary, empty-snapshot finish, and panic-recovery regression tests.
- Real-MySQL 8.0.22 end-to-end (docker): before the fix, `AppendTrackEvent` x3 then `GetSession` loaded 0 track events; after the fix it loads all 3.
- AG-UI HTTP end-to-end against MySQL 8.0.22 (mock model, `POST /agui` then `POST /history`): before — `MESSAGES_SNAPSHOT messages=0`; after — snapshot returns the full user/assistant turn.

