### PR TITLE
langfuse: add environment config option and pass to OTEL resource attributes

### DIFF
--- a/telemetry/langfuse/config.go
+++ b/telemetry/langfuse/config.go
@@ -69,6 +69,12 @@ func WithObservationLeafValueMaxBytes(maxBytes int) Option {
 	}
 }
 
+func WithEnvironment(environment string) Option {
+	return func(cfg *config) {
+		cfg.environment = environment
+	}
+}
+
 // config holds Langfuse configuration options.
 type config struct {
 	secretKey                    string
@@ -76,6 +82,7 @@ type config struct {
 	host                         string
 	insecure                     bool
 	maxObservationLeafValueBytes *int
+	environment                  string
 }
 
 // newConfigFromEnv creates a Langfuse config from environment variables.
@@ -94,6 +101,7 @@ func newConfigFromEnv() *config {
 		host:                         getEnv("LANGFUSE_HOST", ""),
 		insecure:                     getEnv("LANGFUSE_INSECURE", "") == "true",
 		maxObservationLeafValueBytes: leafBytes,
+		environment:                  getEnv("LANGFUSE_ENVIRONMENT", "default"),
 	}
 }
 

--- a/telemetry/langfuse/start_internal_test.go
+++ b/telemetry/langfuse/start_internal_test.go
@@ -27,7 +27,7 @@ func TestStart_Internal_WithNoopProvider(t *testing.T) {
 
 	atrace.TracerProvider = noop.NewTracerProvider()
 
-	clean, err := start(ctx, otlptracehttp.WithEndpoint("localhost:4318"), otlptracehttp.WithInsecure())
+	clean, err := start(ctx, &config{}, otlptracehttp.WithEndpoint("localhost:4318"), otlptracehttp.WithInsecure())
 	if err != nil {
 		t.Fatalf("start() error = %v", err)
 	}
@@ -42,7 +42,7 @@ func TestStart_Internal_WithExistingSDKProvider(t *testing.T) {
 	// Use a real sdk tracer provider to hit the branch that registers processor
 	atrace.TracerProvider = sdktrace.NewTracerProvider()
 
-	clean, err := start(ctx, otlptracehttp.WithEndpoint("localhost:4318"), otlptracehttp.WithInsecure())
+	clean, err := start(ctx, &config{}, otlptracehttp.WithEndpoint("localhost:4318"), otlptracehttp.WithInsecure())
 	if err != nil {
 		t.Fatalf("start() error = %v", err)
 	}

--- a/telemetry/langfuse/tracer.go
+++ b/telemetry/langfuse/tracer.go
@@ -14,6 +14,7 @@ import (
 	"encoding/base64"
 	"fmt"
 
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
@@ -57,10 +58,10 @@ func Start(ctx context.Context, opts ...Option) (clean func(context.Context) err
 		otelOpts = append(otelOpts, otlptracehttp.WithInsecure())
 	}
 
-	return start(ctx, otelOpts...)
+	return start(ctx, config, otelOpts...)
 }
 
-func start(ctx context.Context, opts ...otlptracehttp.Option) (clean func(context.Context) error, err error) {
+func start(ctx context.Context, conf *config, opts ...otlptracehttp.Option) (clean func(context.Context) error, err error) {
 	p := atrace.TracerProvider
 	_, ok := p.(noop.TracerProvider)
 	var provider *sdktrace.TracerProvider
@@ -83,6 +84,8 @@ func start(ctx context.Context, opts ...otlptracehttp.Option) (clean func(contex
 				semconv.ServiceNamespace(semconvtrace.ResourceServiceNamespace),
 				semconv.ServiceName(semconvtrace.ResourceServiceName),
 				semconv.ServiceVersion(semconvtrace.ResourceServiceVersion),
+				semconv.DeploymentEnvironment(conf.environment),
+				attribute.String("environment", conf.environment),
 			),
 		)
 		if err != nil {


### PR DESCRIPTION
**What changed**
Added an `environment` configuration option to Langfuse settings. This value is now automatically passed as an OpenTelemetry (OTEL) resource attribute.

**Why**
This enables better environment-based filtering and categorization within the Langfuse dashboard, distinguishing between production, staging, and development traces.

**Testing**

* Verified that the `environment` field is correctly parsed from the configuration.
* Manual check: Confirmed via OTEL exporter logs that `deployment.environment` is present in the resource attributes.

**Notes for reviewers**
Focus on the integration point where OTEL resource attributes are initialized. This change is additive and non-breaking.
