### PR TITLE
fix(session/postgres): cast JSON bytes to string for DB params

### DIFF
--- a/session/postgres/service.go
+++ b/session/postgres/service.go
@@ -30,8 +30,10 @@ import (
 	storage "trpc.group/trpc-go/trpc-agent-go/storage/postgres"
 )
 
-var _ session.Service = (*Service)(nil)
-var _ session.TrackService = (*Service)(nil)
+var (
+	_ session.Service      = (*Service)(nil)
+	_ session.TrackService = (*Service)(nil)
+)
 
 var errSessionNotFound = errors.New("session not found")
 
@@ -285,7 +287,7 @@ func (s *Service) CreateSession(
 	_, err = s.pgClient.ExecContext(ctx,
 		fmt.Sprintf(`INSERT INTO %s (app_name, user_id, session_id, state, created_at, updated_at, expires_at)
 		 VALUES ($1, $2, $3, $4, $5, $6, $7)`, s.tableSessionStates),
-		key.AppName, key.UserID, key.SessionID, sessBytes, sessState.CreatedAt, sessState.UpdatedAt, expiresAt,
+		key.AppName, key.UserID, key.SessionID, string(sessBytes), sessState.CreatedAt, sessState.UpdatedAt, expiresAt,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("create session failed: %w", err)
@@ -449,7 +451,6 @@ func (s *Service) ListAppStates(ctx context.Context, appName string) (session.St
 		AND (expires_at IS NULL OR expires_at > $2)
 		AND deleted_at IS NULL`, s.tableAppStates),
 		appName, time.Now())
-
 	if err != nil {
 		return nil, fmt.Errorf("postgres session service list app states failed: %w", err)
 	}
@@ -541,7 +542,6 @@ func (s *Service) ListUserStates(ctx context.Context, userKey session.UserKey) (
 		AND (expires_at IS NULL OR expires_at > $3)
 		AND deleted_at IS NULL`, s.tableUserStates),
 		userKey.AppName, userKey.UserID, time.Now())
-
 	if err != nil {
 		return nil, fmt.Errorf("postgres session service list user states failed: %w", err)
 	}
@@ -606,7 +606,7 @@ func (s *Service) UpdateSessionState(ctx context.Context, key session.Key, state
 		_, err = tx.ExecContext(ctx,
 			fmt.Sprintf(`UPDATE %s SET state = $1, updated_at = $2, expires_at = $3
 		 WHERE app_name = $4 AND user_id = $5 AND session_id = $6 AND deleted_at IS NULL`, s.tableSessionStates),
-			updatedStateBytes, now, expiresAt,
+			string(updatedStateBytes), now, expiresAt,
 			key.AppName, key.UserID, key.SessionID)
 		if err != nil {
 			return fmt.Errorf("postgres session service update session state failed: %w", err)

--- a/session/postgres/service_helper.go
+++ b/session/postgres/service_helper.go
@@ -53,7 +53,6 @@ func (s *Service) getSession(
 		}
 		return nil
 	}, stateQuery, stateArgs...)
-
 	if err != nil {
 		return nil, fmt.Errorf("get session state failed: %w", err)
 	}
@@ -177,7 +176,6 @@ func (s *Service) listSessions(
 		}
 		return nil
 	}, listQuery, listArgs...)
-
 	if err != nil {
 		return nil, fmt.Errorf("list session states failed: %w", err)
 	}
@@ -312,7 +310,7 @@ func (s *Service) addEvent(ctx context.Context, key session.Key, event *event.Ev
 		_, err = tx.ExecContext(ctx,
 			fmt.Sprintf(`UPDATE %s SET state = $1, updated_at = $2, expires_at = $3
 			 WHERE app_name = $4 AND user_id = $5 AND session_id = $6 AND deleted_at IS NULL`, s.tableSessionStates),
-			updatedStateBytes, updatedAt, expiresAt,
+			string(updatedStateBytes), updatedAt, expiresAt,
 			key.AppName, key.UserID, key.SessionID)
 		if err != nil {
 			return fmt.Errorf("update session state failed: %w", err)
@@ -323,14 +321,13 @@ func (s *Service) addEvent(ctx context.Context, key session.Key, event *event.Ev
 			_, err = tx.ExecContext(ctx,
 				fmt.Sprintf(`INSERT INTO %s (app_name, user_id, session_id, event, created_at, updated_at)
 				 VALUES ($1, $2, $3, $4, $5, $6)`, s.tableSessionEvents),
-				key.AppName, key.UserID, key.SessionID, eventBytes, now, now)
+				key.AppName, key.UserID, key.SessionID, string(eventBytes), now, now)
 			if err != nil {
 				return fmt.Errorf("insert event failed: %w", err)
 			}
 		}
 		return nil
 	})
-
 	if err != nil {
 		return fmt.Errorf("store event failed: %w", err)
 	}
@@ -395,7 +392,7 @@ func (s *Service) addTrackEvent(ctx context.Context, key session.Key, trackEvent
 		_, err = tx.ExecContext(ctx,
 			fmt.Sprintf(`UPDATE %s SET state = $1, updated_at = $2, expires_at = $3
 			 WHERE app_name = $4 AND user_id = $5 AND session_id = $6 AND deleted_at IS NULL`, s.tableSessionStates),
-			updatedStateBytes, updatedAt, expiresAt,
+			string(updatedStateBytes), updatedAt, expiresAt,
 			key.AppName, key.UserID, key.SessionID)
 		if err != nil {
 			return fmt.Errorf("update session state failed: %w", err)
@@ -405,7 +402,7 @@ func (s *Service) addTrackEvent(ctx context.Context, key session.Key, trackEvent
 		_, err = tx.ExecContext(ctx,
 			fmt.Sprintf(`INSERT INTO %s (app_name, user_id, session_id, track, event, created_at, updated_at, expires_at)
 			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`, s.tableSessionTracks),
-			key.AppName, key.UserID, key.SessionID, trackEvent.Track, eventBytes,
+			key.AppName, key.UserID, key.SessionID, trackEvent.Track, string(eventBytes),
 			trackEvent.Timestamp, trackEvent.Timestamp, expiresAt)
 		if err != nil {
 			return fmt.Errorf("insert track event failed: %w", err)
@@ -533,7 +530,6 @@ func (s *Service) deleteSessionState(ctx context.Context, key session.Key) error
 
 		return nil
 	})
-
 	if err != nil {
 		return fmt.Errorf("postgres session service delete session state failed: %w", err)
 	}
@@ -702,7 +698,6 @@ func (s *Service) getEventsList(
 		}
 		return nil
 	}, query, args...)
-
 	if err != nil {
 		return nil, fmt.Errorf("query events failed: %w", err)
 	}
@@ -944,7 +939,6 @@ func (s *Service) getSummariesList(
 		}
 		return nil
 	}, summaryQuery, sessionKeys[0].AppName, sessionKeys[0].UserID, sessionIDs, time.Now())
-
 	if err != nil {
 		return nil, fmt.Errorf("query summaries failed: %w", err)
 	}

--- a/session/postgres/summary.go
+++ b/session/postgres/summary.go
@@ -78,8 +78,7 @@ func (s *Service) CreateSessionSummary(
 		   summary = EXCLUDED.summary,
 		   updated_at = EXCLUDED.updated_at,
 		   expires_at = EXCLUDED.expires_at`, s.tableSessionSummaries),
-		sess.AppName, sess.UserID, sess.ID, filterKey, summaryBytes, sum.UpdatedAt, nil)
-
+		sess.AppName, sess.UserID, sess.ID, filterKey, string(summaryBytes), sum.UpdatedAt, nil)
 	if err != nil {
 		return fmt.Errorf("upsert summary failed: %w", err)
 	}


### PR DESCRIPTION
**What changed**
Explicitly cast JSON `[]byte` values to `string` when binding database parameters. Also removed redundant blank lines after transaction calls.

**Why**
When using the `database/sql` simple protocol, `pgx` sometimes treats `[]byte` as `bytea`. Casting to `string` forces the correct interpretation as JSON, aligning with `pgtype.JSON` behavior.
Ref: [https://github.com/jackc/pgtype/issues/45](https://github.com/jackc/pgtype/issues/45)

**Testing**

* Ran existing session storage unit tests against a PostgreSQL instance.
* Verified that JSON payloads are stored and retrieved without type mismatch errors.

**Notes for reviewers**
This ensures consistent behavior across different PostgreSQL driver protocols. Please verify if any downstream custom type encoders rely on the previous `[]byte` behavior (though unlikely).
