### PR TITLE
memory/tencentdb: add context offload

### DIFF
--- a/docs/mkdocs/en/memory.md
+++ b/docs/mkdocs/en/memory.md
@@ -1751,6 +1751,11 @@ The boundary is intentionally different from built-in backends:
 - Native tools expose read-oriented search through `tdai_conversation_search`
   (session-scoped, on by default) and `tdai_memory_search` (opt-in via
   `WithMemorySearchTool(true)`).
+- An optional short-term context offload plugin can externalize large tool
+  results into local `refs/*.md` files, maintain L1 JSONL summaries, judge
+  L1.5 task boundaries, generate L2 Mermaid task maps, and apply L3
+  token-pressure compression before model calls. It is separate from recall and
+  is off by default.
 
 > **Multi-tenant note:** automatic recall and `tdai_memory_search` read from the
 > gateway's shared long-term store, which does not currently enforce
@@ -1808,6 +1813,22 @@ memSvc, err := memorytencentdb.NewService(
     // Opt-in cross-session/user reads; enable only for a trusted/isolated gateway.
     memorytencentdb.WithRecallEnabled(true),
     memorytencentdb.WithMemorySearchTool(true),
+    // Optional short-term tool result offload; separate from long-term recall.
+    // memorytencentdb.WithContextOffload(memorytencentdb.ContextOffloadConfig{
+    //     Enabled: true,
+    //     DataDir: ".tdai-offload",
+    //     Mode:    memorytencentdb.ContextOffloadModeLocal,
+    //     Model:   openai.New("deepseek-v4-flash"),
+    // }),
+    // Or route L1/L1.5/L2 through a compatible offload backend:
+    // memorytencentdb.WithContextOffload(memorytencentdb.ContextOffloadConfig{
+    //     Enabled: true,
+    //     Mode:    memorytencentdb.ContextOffloadModeBackend,
+    //     Backend: memorytencentdb.ContextOffloadBackendConfig{
+    //         URL:    gatewayURL,
+    //         APIKey: os.Getenv("TDAI_GATEWAY_API_KEY"),
+    //     },
+    // }),
     // memorytencentdb.WithAPIKey(os.Getenv("TDAI_GATEWAY_API_KEY")),
 )
 if err != nil {
@@ -1827,7 +1848,10 @@ r := runner.NewRunner(
     agent,
     runner.WithSessionService(sessionSvc),
     runner.WithSessionIngestor(memSvc),
-    runner.WithPlugins(memSvc.Plugin()),
+    runner.WithPlugins(
+        memSvc.Plugin(),
+        // memSvc.ContextOffloadPlugin(),
+    ),
 )
 defer r.Close()
 ```
@@ -1839,6 +1863,12 @@ defer r.Close()
   transcripts to `/capture`
 - Use `runner.WithPlugins(memSvc.Plugin())` to enable automatic `/recall`
   before model calls
+- Use `runner.WithPlugins(memSvc.ContextOffloadPlugin())` only when
+  `WithContextOffload(memorytencentdb.ContextOffloadConfig{Enabled: true})` is
+  set and you want short-term tool result offload. Companion tools
+  `tdai_read_offload_ref`,
+  `tdai_read_offload_node`, and `tdai_search_offload_index` are exposed
+  through `memSvc.Tools()` when enabled.
 - Do **not** use `runner.WithMemoryService(...)` with this integration
 
 ### Interactive Example
@@ -1881,6 +1911,28 @@ tools even after conversation history is reset.
 | `WithConversationSearchTool(bool)` | Expose `tdai_conversation_search`. | `true` |
 | `WithStandardAliases(bool)` | Also expose standard `memory_search` alias (requires memory search enabled). | `false` |
 | `WithToolPrefix(prefix)` | Change native tool prefix. | `tdai` |
+| `WithContextOffload(ContextOffloadConfig)` | Configure explicit short-term context offload for large tool results. | disabled |
+
+`ContextOffloadConfig` groups the detailed settings by offload layer. Zero
+values are filled from defaults except `Enabled`, which must be set explicitly.
+
+| Field | Purpose | Default |
+| ----- | ------- | ------- |
+| `Enabled` | Enable context offload plugin and companion tools. | `false` |
+| `DataDir` | Directory for `refs/`, JSONL indexes, and Mermaid files. | `.tdai-offload` |
+| `Mode` | Select `local`, `backend`, or `collect` offload mode. | `local` |
+| `Model` | Model used for local L1/L1.5/L2 offload tasks. When unset, deterministic fallback summaries are used. | none |
+| `MaxEntries` | Maximum offload entries rendered into the current task Mermaid context. | `20` |
+| `Backend.URL`, `Backend.APIKey` | Backend endpoint and optional API key for backend-mode L1/L1.5/L2. | none |
+| `L0.MinToolResultBytes` | Minimum tool result size to externalize. | `8192` |
+| `L0.MaxRefBytes` | Maximum bytes returned by `tdai_read_offload_ref`. | `1048576` |
+| `L1.MaxPairsPerBatch` | Maximum tool pairs sent to one L1 summarization request. | `20` |
+| `L2.NullThreshold` | Number of unmapped L1 rows that trigger L2 Mermaid generation. | `4` |
+| `L2.Timeout` | Time-based L2 trigger interval. | `5m` |
+| `L3.ContextWindow` | Context window used for L3 token-pressure checks when the offload model does not report one. | `200000` |
+| `L3.MildRatio` | Token ratio that triggers L3 summary replacement. | `0.50` |
+| `L3.AggressiveRatio` | Token ratio that triggers deletion of old offloaded tool blocks. | `0.85` |
+| `L3.EmergencyRatio`, `L3.EmergencyTargetRatio` | Emergency compression trigger and target ratios. | `0.95`, `0.60` |
 
 ### Notes
 
@@ -1896,6 +1948,20 @@ tools even after conversation history is reset.
   searchable.
 - `tdai_conversation_search` searches conversation history and defaults to the
   current gateway `session_key`.
+- Context offload is local, opt-in, and runtime-scoped. It does not call
+  `/capture` or `/recall`, and enabling recall alone will not rewrite tool
+  result messages or create Mermaid task maps.
+- Context offload has three model modes. `local` calls the configured
+  `ContextOffloadConfig.Model` for L1/L1.5/L2 and falls back deterministically
+  when unset; `backend` calls compatible `/offload/v1/...` endpoints;
+  `collect` records refs and JSONL state without rewriting model-facing
+  messages.
+- The offload tools are scoped to the current invocation's agent/session data
+  directory. `read_offload_ref` validates `result_ref` reads against path
+  traversal; `read_offload_node` reads by `node_id` and does not accept
+  `result_ref`.
+- Live model coverage is behind the `integration` build tag, for example:
+  `TDAI_CONTEXT_OFFLOAD_INTEGRATION=1 OPENAI_API_KEY=... go test -tags=integration ./memory/tencentdb -run TestContextOffloadPlugin_IntegrationLocalModel`.
 - Call `Close()` on the service so background capture workers shut down cleanly.
 
 ## References

--- a/docs/mkdocs/zh/memory.md
+++ b/docs/mkdocs/zh/memory.md
@@ -1779,6 +1779,10 @@ tRPC-Agent-Go 侧继续负责 Runner、Session、Plugin 和 Tool 生命周期的
 - Go adapter 通过 `session.Ingestor` 把每轮完成后的会话内容发送给 gateway。
 - Runner plugin 在每次模型调用前请求 `/recall`，并把返回的上下文注入模型请求（需通过 `WithRecallEnabled(true)` 显式开启）。
 - 通过 `tdai_conversation_search`（按 session 作用域，默认开启）和 `tdai_memory_search`（需 `WithMemorySearchTool(true)` 显式开启）暴露只读检索工具。
+- 可选的短期上下文卸载 plugin 可以把较大的工具结果外置到本地
+  `refs/*.md`，维护 L1 JSONL 摘要、判断 L1.5 任务边界、生成 L2
+  Mermaid 任务图，并在模型调用前执行 L3 token 压力压缩。它与 recall
+  相互独立，默认关闭。
 
 > **多租户提示**：自动 recall 和 `tdai_memory_search` 会读取 gateway 的共享长期
 > 存储，而当前 gateway 并不会在这些路径上强制按 user/session 隔离，因此它们默认
@@ -1834,6 +1838,22 @@ memSvc, err := memorytencentdb.NewService(
     // 跨 session/user 的读取属于 opt-in，仅在 gateway 可信/隔离时开启。
     memorytencentdb.WithRecallEnabled(true),
     memorytencentdb.WithMemorySearchTool(true),
+    // 可选短期工具结果卸载；它与长期 recall 是独立能力。
+    // memorytencentdb.WithContextOffload(memorytencentdb.ContextOffloadConfig{
+    //     Enabled: true,
+    //     DataDir: ".tdai-offload",
+    //     Mode:    memorytencentdb.ContextOffloadModeLocal,
+    //     Model:   openai.New("deepseek-v4-flash"),
+    // }),
+    // 或将 L1/L1.5/L2 交给兼容的 offload backend：
+    // memorytencentdb.WithContextOffload(memorytencentdb.ContextOffloadConfig{
+    //     Enabled: true,
+    //     Mode:    memorytencentdb.ContextOffloadModeBackend,
+    //     Backend: memorytencentdb.ContextOffloadBackendConfig{
+    //         URL:    gatewayURL,
+    //         APIKey: os.Getenv("TDAI_GATEWAY_API_KEY"),
+    //     },
+    // }),
     // memorytencentdb.WithAPIKey(os.Getenv("TDAI_GATEWAY_API_KEY")),
 )
 if err != nil {
@@ -1853,7 +1873,10 @@ r := runner.NewRunner(
     agent,
     runner.WithSessionService(sessionSvc),
     runner.WithSessionIngestor(memSvc),
-    runner.WithPlugins(memSvc.Plugin()),
+    runner.WithPlugins(
+        memSvc.Plugin(),
+        // memSvc.ContextOffloadPlugin(),
+    ),
 )
 defer r.Close()
 ```
@@ -1863,6 +1886,11 @@ defer r.Close()
 - 通过 `llmagent.WithTools(memSvc.Tools())` 注册 TencentDB 原生检索工具。
 - 通过 `runner.WithSessionIngestor(memSvc)` 把带时间戳的 session transcript 发送给 `/capture`。
 - 通过 `runner.WithPlugins(memSvc.Plugin())` 在模型调用前启用自动 `/recall`。
+- 只有在设置 `WithContextOffload(memorytencentdb.ContextOffloadConfig{Enabled: true})`
+  且需要短期工具结果卸载时，才额外注册
+  `runner.WithPlugins(memSvc.ContextOffloadPlugin())`。启用后，配套
+  `tdai_read_offload_ref`、`tdai_read_offload_node` 和
+  `tdai_search_offload_index` 工具会通过 `memSvc.Tools()` 暴露。
 - 不要对该集成使用 `runner.WithMemoryService(...)`。
 
 ### 交互式示例
@@ -1902,6 +1930,28 @@ You: 我的项目代号、部署窗口和回答偏好是什么？
 | `WithConversationSearchTool(bool)` | 是否暴露 `tdai_conversation_search`。 | `true` |
 | `WithStandardAliases(bool)` | 是否额外暴露标准 `memory_search` 别名（需先启用 memory search）。 | `false` |
 | `WithToolPrefix(prefix)` | 修改原生工具名前缀。 | `tdai` |
+| `WithContextOffload(ContextOffloadConfig)` | 配置较大工具结果的显式短期上下文卸载。 | 关闭 |
+
+`ContextOffloadConfig` 按 offload 层级组织详细配置。除 `Enabled` 必须显式设置外，
+其余零值都会补全为保守默认值。
+
+| 字段 | 作用 | 默认值 |
+| ---- | ---- | ------ |
+| `Enabled` | 是否启用 context offload plugin 和配套工具。 | `false` |
+| `DataDir` | `refs/`、JSONL 索引和 Mermaid 文件目录。 | `.tdai-offload` |
+| `Mode` | 选择 `local`、`backend` 或 `collect` offload 模式。 | `local` |
+| `Model` | local 模式下执行 L1/L1.5/L2 offload 任务的模型。未设置时使用确定性 fallback 摘要。 | 无 |
+| `MaxEntries` | 注入当前任务 Mermaid 上下文的最大 offload 条目数。 | `20` |
+| `Backend.URL`、`Backend.APIKey` | backend 模式下的 L1/L1.5/L2 endpoint 和可选 API key。 | 无 |
+| `L0.MinToolResultBytes` | 触发外置化的最小工具结果大小。 | `8192` |
+| `L0.MaxRefBytes` | `tdai_read_offload_ref` 最多返回的字节数。 | `1048576` |
+| `L1.MaxPairsPerBatch` | 单次 L1 摘要请求最多处理的工具调用对数量。 | `20` |
+| `L2.NullThreshold` | 触发 L2 Mermaid 生成的未映射 L1 行数。 | `4` |
+| `L2.Timeout` | 基于时间的 L2 触发间隔。 | `5m` |
+| `L3.ContextWindow` | offload model 未报告窗口时，L3 token 压力检查使用的上下文窗口。 | `200000` |
+| `L3.MildRatio` | 触发 L3 摘要替换的 token 比例。 | `0.50` |
+| `L3.AggressiveRatio` | 触发删除旧 offloaded 工具块的 token 比例。 | `0.85` |
+| `L3.EmergencyRatio`、`L3.EmergencyTargetRatio` | emergency 压缩的触发比例和目标比例。 | `0.95`、`0.60` |
 
 ### 注意事项
 
@@ -1909,6 +1959,17 @@ You: 我的项目代号、部署窗口和回答偏好是什么？
 - 当 gateway 设置了 `TDAI_GATEWAY_API_KEY` 时，请用 `WithAPIKey(...)` 让请求携带 `Authorization: Bearer <key>`，否则除 `/health` 外的路由都会返回 401（health 仍可通过）。
 - `tdai_memory_search` 检索已提取的长期记忆；提取是异步的，新捕获的信息可能需要短暂等待后才可检索。
 - `tdai_conversation_search` 检索对话历史，默认使用当前 gateway `session_key`。
+- context offload 是本地、显式开启、运行时作用域的能力。它不调用 `/capture` 或
+  `/recall`；单独开启 recall 不会改写工具结果消息，也不会生成 Mermaid 任务图。
+- context offload 有三种模型模式：`local` 使用 `ContextOffloadConfig.Model`
+  配置的模型执行 L1/L1.5/L2，未配置时使用确定性 fallback；`backend`
+  调用兼容的 `/offload/v1/...` endpoint；`collect` 只记录 refs 和 JSONL
+  状态，不改写模型侧 messages。
+- offload 工具只读取当前 invocation 的 agent/session 数据目录。
+  `read_offload_ref` 会对 `result_ref` 读取做 path traversal 防护；
+  `read_offload_node` 按 `node_id` 读取，不接收 `result_ref`。
+- live model 覆盖放在 `integration` build tag 后，例如：
+  `TDAI_CONTEXT_OFFLOAD_INTEGRATION=1 OPENAI_API_KEY=... go test -tags=integration ./memory/tencentdb -run TestContextOffloadPlugin_IntegrationLocalModel`。
 - 使用完成后请调用 `Close()`，确保后台 capture worker 干净退出。
 
 ## 参考链接

--- a/internal/flow/processor/functioncall.go
+++ b/internal/flow/processor/functioncall.go
@@ -31,6 +31,7 @@ import (
 	itrace "trpc.group/trpc-go/trpc-agent-go/internal/trace"
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/plugin"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 	"trpc.group/trpc-go/trpc-agent-go/tool/function"
@@ -221,7 +222,7 @@ func (p *FunctionCallResponseProcessor) ProcessResponse(
 		return
 	}
 
-	functioncallResponseEvent, err := p.handleFunctionCallsAndSendEvent(ctx, invocation, rsp, req.Tools, ch)
+	functioncallResponseEvent, err := p.handleFunctionCallsAndSendEventWithRequest(ctx, invocation, req, rsp, ch)
 
 	// Option one: set invocation.EndInvocation is true, and stop next step.
 	// Option two: emit error event, maybe the LLM can correct this error and also need to wait for notice completion.
@@ -289,9 +290,30 @@ func (p *FunctionCallResponseProcessor) handleFunctionCallsAndSendEvent(
 	tools map[string]tool.Tool,
 	eventChan chan<- *event.Event,
 ) (*event.Event, error) {
-	functionResponseEvent, err := p.handleFunctionCalls(
+	return p.handleFunctionCallsAndSendEventWithRequest(
 		ctx,
 		invocation,
+		&model.Request{Tools: tools},
+		llmResponse,
+		eventChan,
+	)
+}
+
+func (p *FunctionCallResponseProcessor) handleFunctionCallsAndSendEventWithRequest(
+	ctx context.Context,
+	invocation *agent.Invocation,
+	req *model.Request,
+	llmResponse *model.Response,
+	eventChan chan<- *event.Event,
+) (*event.Event, error) {
+	var tools map[string]tool.Tool
+	if req != nil {
+		tools = req.Tools
+	}
+	functionResponseEvent, err := p.handleFunctionCallsWithRequest(
+		ctx,
+		invocation,
+		req,
 		llmResponse,
 		tools,
 		eventChan,
@@ -356,11 +378,49 @@ func (p *FunctionCallResponseProcessor) handleFunctionCalls(
 	tools map[string]tool.Tool,
 	eventChan chan<- *event.Event,
 ) (*event.Event, error) {
+	return p.handleFunctionCallsWithRequest(
+		ctx,
+		invocation,
+		&model.Request{Tools: tools},
+		llmResponse,
+		tools,
+		eventChan,
+	)
+}
+
+func (p *FunctionCallResponseProcessor) handleFunctionCallsWithRequest(
+	ctx context.Context,
+	invocation *agent.Invocation,
+	req *model.Request,
+	llmResponse *model.Response,
+	tools map[string]tool.Tool,
+	eventChan chan<- *event.Event,
+) (*event.Event, error) {
 	toolCalls := llmResponse.Choices[0].Message.ToolCalls
 
 	// If parallel tools are enabled AND multiple tool calls, execute concurrently
 	if p.enableParallelTools && len(toolCalls) > 1 {
-		return p.executeToolCallsInParallel(ctx, invocation, llmResponse, toolCalls, tools, eventChan)
+		mergedEvent, err := p.executeToolCallsInParallel(
+			ctx,
+			invocation,
+			llmResponse,
+			toolCalls,
+			tools,
+			eventChan,
+		)
+		if err != nil {
+			return mergedEvent, err
+		}
+		if err := p.applyAfterToolMessagesHooks(
+			ctx,
+			invocation,
+			req,
+			llmResponse,
+			mergedEvent,
+		); err != nil {
+			return nil, err
+		}
+		return mergedEvent, nil
 	}
 
 	toolResults := make([]toolResult, 0, len(toolCalls))
@@ -392,7 +452,237 @@ func (p *FunctionCallResponseProcessor) handleFunctionCalls(
 		ctx, invocation, llmResponse, tools, toolCalls, toolResults,
 		toolCallResponsesEvents,
 	)
+	if err := p.applyAfterToolMessagesHooks(
+		ctx,
+		invocation,
+		req,
+		llmResponse,
+		mergedEvent,
+	); err != nil {
+		return nil, err
+	}
 	return mergedEvent, nil
+}
+
+type afterToolMessagesManager interface {
+	AfterToolMessages(
+		context.Context,
+		*plugin.AfterToolMessagesArgs,
+	) (*plugin.AfterToolMessagesResult, error)
+}
+
+func (p *FunctionCallResponseProcessor) applyAfterToolMessagesHooks(
+	ctx context.Context,
+	invocation *agent.Invocation,
+	req *model.Request,
+	llmResponse *model.Response,
+	toolResultEvent *event.Event,
+) error {
+	if invocation == nil || invocation.Plugins == nil ||
+		toolResultEvent == nil || toolResultEvent.Response == nil {
+		return nil
+	}
+	hooks, ok := invocation.Plugins.(afterToolMessagesManager)
+	if !ok {
+		return nil
+	}
+	toolResultMessages := toolResultMessagesFromEvent(toolResultEvent)
+	if len(toolResultMessages) == 0 {
+		return nil
+	}
+	args := &plugin.AfterToolMessagesArgs{
+		Invocation:         invocation,
+		Request:            req,
+		ToolCallResponse:   llmResponse,
+		ToolResultEvent:    toolResultEvent,
+		Messages:           afterToolMessagesView(req, llmResponse, toolResultMessages),
+		ToolCalls:          toolCallsFromResponse(llmResponse),
+		ToolResultMessages: cloneModelMessages(toolResultMessages),
+	}
+	result, err := hooks.AfterToolMessages(ctx, args)
+	if err != nil {
+		return err
+	}
+	if result == nil || len(result.ToolResultMessages) == 0 {
+		return nil
+	}
+	choices, err := replacementToolChoices(
+		toolResultEvent.Response.Choices,
+		result.ToolResultMessages,
+	)
+	if err != nil {
+		return err
+	}
+	toolResultEvent.Response.Choices = choices
+	return nil
+}
+
+func toolResultMessagesFromEvent(ev *event.Event) []model.Message {
+	if ev == nil || ev.Response == nil {
+		return nil
+	}
+	messages := make([]model.Message, 0, len(ev.Response.Choices))
+	for _, choice := range ev.Response.Choices {
+		msg := choice.Message
+		if msg.ToolID == "" && choice.Delta.ToolID != "" {
+			msg = choice.Delta
+		}
+		if msg.ToolID == "" || !model.HasPayload(msg) {
+			continue
+		}
+		messages = append(messages, msg)
+	}
+	return messages
+}
+
+func afterToolMessagesView(
+	req *model.Request,
+	llmResponse *model.Response,
+	toolResultMessages []model.Message,
+) []model.Message {
+	var messages []model.Message
+	if req != nil && len(req.Messages) > 0 {
+		messages = append(messages, req.Messages...)
+	}
+	if msg, ok := assistantMessageFromToolCallResponse(llmResponse); ok {
+		messages = append(messages, msg)
+	}
+	messages = append(messages, toolResultMessages...)
+	return cloneModelMessages(messages)
+}
+
+func assistantMessageFromToolCallResponse(
+	rsp *model.Response,
+) (model.Message, bool) {
+	if rsp == nil || len(rsp.Choices) == 0 {
+		return model.Message{}, false
+	}
+	msg := rsp.Choices[0].Message
+	if len(msg.ToolCalls) > 0 || model.HasPayload(msg) {
+		return msg, true
+	}
+	delta := rsp.Choices[0].Delta
+	if len(delta.ToolCalls) > 0 || model.HasPayload(delta) {
+		return delta, true
+	}
+	return model.Message{}, false
+}
+
+func toolCallsFromResponse(rsp *model.Response) []model.ToolCall {
+	if rsp == nil || len(rsp.Choices) == 0 {
+		return nil
+	}
+	calls := rsp.Choices[0].Message.ToolCalls
+	if len(calls) == 0 {
+		calls = rsp.Choices[0].Delta.ToolCalls
+	}
+	if len(calls) == 0 {
+		return nil
+	}
+	out := make([]model.ToolCall, len(calls))
+	copy(out, calls)
+	return out
+}
+
+func replacementToolChoices(
+	originalChoices []model.Choice,
+	replacements []model.Message,
+) ([]model.Choice, error) {
+	original := toolChoiceIndexByID(originalChoices)
+	if len(original) == 0 {
+		return nil, errors.New("after tool messages: original tool result messages are empty")
+	}
+	if len(replacements) != len(original) {
+		return nil, fmt.Errorf(
+			"after tool messages: replacement count %d does not match original tool result count %d",
+			len(replacements),
+			len(original),
+		)
+	}
+	byID := make(map[string]model.Message, len(replacements))
+	for _, msg := range replacements {
+		if msg.ToolID == "" {
+			return nil, errors.New("after tool messages: replacement tool message missing tool id")
+		}
+		if msg.Role != model.RoleTool {
+			return nil, fmt.Errorf(
+				"after tool messages: replacement for tool id %q must use role %q",
+				msg.ToolID,
+				model.RoleTool,
+			)
+		}
+		if _, ok := byID[msg.ToolID]; ok {
+			return nil, fmt.Errorf(
+				"after tool messages: replacement contains duplicate tool id %q",
+				msg.ToolID,
+			)
+		}
+		byID[msg.ToolID] = msg
+	}
+	choices := make([]model.Choice, 0, len(original))
+	for _, choice := range originalChoices {
+		msg := choice.Message
+		if msg.ToolID == "" && choice.Delta.ToolID != "" {
+			msg = choice.Delta
+		}
+		if msg.ToolID == "" {
+			continue
+		}
+		replacement, ok := byID[msg.ToolID]
+		if !ok {
+			return nil, fmt.Errorf(
+				"after tool messages: replacement missing tool id %q",
+				msg.ToolID,
+			)
+		}
+		choices = append(choices, replaceChoiceToolMessage(choice, replacement))
+		delete(byID, msg.ToolID)
+	}
+	for toolID := range byID {
+		return nil, fmt.Errorf(
+			"after tool messages: replacement contains unknown tool id %q",
+			toolID,
+		)
+	}
+	return choices, nil
+}
+
+func replaceChoiceToolMessage(choice model.Choice, msg model.Message) model.Choice {
+	updated := choice
+	if updated.Message.ToolID != "" {
+		updated.Message = msg
+	}
+	if updated.Delta.ToolID != "" {
+		updated.Delta = msg
+	}
+	if updated.Message.ToolID == "" && updated.Delta.ToolID == "" {
+		updated.Message = msg
+	}
+	return updated
+}
+
+func toolChoiceIndexByID(choices []model.Choice) map[string]int {
+	out := make(map[string]int, len(choices))
+	for _, choice := range choices {
+		msg := choice.Message
+		if msg.ToolID == "" && choice.Delta.ToolID != "" {
+			msg = choice.Delta
+		}
+		if msg.ToolID == "" {
+			continue
+		}
+		out[msg.ToolID] = choice.Index
+	}
+	return out
+}
+
+func cloneModelMessages(messages []model.Message) []model.Message {
+	if len(messages) == 0 {
+		return nil
+	}
+	out := make([]model.Message, len(messages))
+	copy(out, messages)
+	return out
 }
 
 // executeSingleToolCallSequential runs one tool call and returns its event.

--- a/internal/flow/processor/functioncall_test.go
+++ b/internal/flow/processor/functioncall_test.go
@@ -2299,6 +2299,119 @@ func TestReplacementToolChoices_PreservesOriginalOrder(t *testing.T) {
 	assert.Equal(t, "summary 2", choices[1].Message.Content)
 }
 
+func TestAfterToolMessagesHelpers_EdgeCases(t *testing.T) {
+	assert.Nil(t, toolResultMessagesFromEvent(nil))
+	assert.Nil(t, toolResultMessagesFromEvent(&event.Event{}))
+
+	toolEvent := event.NewResponseEvent("inv", "agent", &model.Response{
+		Object: model.ObjectTypeToolResponse,
+		Choices: []model.Choice{
+			{Message: model.Message{Role: model.RoleTool, ToolID: "empty"}},
+			{Delta: model.NewToolMessage("call-delta", "lookup", "delta payload")},
+			{Message: model.NewToolMessage("call-message", "lookup", "message payload")},
+		},
+	})
+	messages := toolResultMessagesFromEvent(toolEvent)
+	require.Len(t, messages, 2)
+	assert.Equal(t, "call-delta", messages[0].ToolID)
+	assert.Equal(t, "call-message", messages[1].ToolID)
+
+	msg, ok := assistantMessageFromToolCallResponse(nil)
+	assert.False(t, ok)
+	assert.Empty(t, msg)
+	msg, ok = assistantMessageFromToolCallResponse(&model.Response{})
+	assert.False(t, ok)
+	assert.Empty(t, msg)
+	msg, ok = assistantMessageFromToolCallResponse(&model.Response{Choices: []model.Choice{{
+		Message: model.NewAssistantMessage("assistant payload"),
+	}}})
+	assert.True(t, ok)
+	assert.Equal(t, "assistant payload", msg.Content)
+	msg, ok = assistantMessageFromToolCallResponse(&model.Response{Choices: []model.Choice{{
+		Delta: model.Message{
+			Role: model.RoleAssistant,
+			ToolCalls: []model.ToolCall{{
+				ID:       "call-1",
+				Function: model.FunctionDefinitionParam{Name: "lookup"},
+			}},
+		},
+	}}})
+	assert.True(t, ok)
+	assert.Len(t, msg.ToolCalls, 1)
+	msg, ok = assistantMessageFromToolCallResponse(&model.Response{Choices: []model.Choice{{}}})
+	assert.False(t, ok)
+	assert.Empty(t, msg)
+
+	assert.Nil(t, toolCallsFromResponse(nil))
+	assert.Nil(t, toolCallsFromResponse(&model.Response{}))
+	assert.Nil(t, toolCallsFromResponse(&model.Response{Choices: []model.Choice{{}}}))
+	calls := toolCallsFromResponse(&model.Response{Choices: []model.Choice{{
+		Delta: model.Message{ToolCalls: []model.ToolCall{{
+			ID:       "call-delta",
+			Function: model.FunctionDefinitionParam{Name: "lookup"},
+		}}},
+	}}})
+	require.Len(t, calls, 1)
+	assert.Equal(t, "call-delta", calls[0].ID)
+
+	_, err := replacementToolChoices(nil, []model.Message{model.NewToolMessage("call-1", "lookup", "summary")})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "original tool result messages are empty")
+	_, err = replacementToolChoices(
+		[]model.Choice{{Message: model.NewToolMessage("call-1", "lookup", "raw")}},
+		[]model.Message{
+			model.NewToolMessage("call-1", "lookup", "summary"),
+			model.NewToolMessage("call-2", "lookup", "summary"),
+		},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "replacement count")
+	_, err = replacementToolChoices(
+		[]model.Choice{{Message: model.NewToolMessage("call-1", "lookup", "raw")}},
+		[]model.Message{{Role: model.RoleTool, Content: "missing id"}},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing tool id")
+	_, err = replacementToolChoices(
+		[]model.Choice{{Message: model.NewToolMessage("call-1", "lookup", "raw")}},
+		[]model.Message{{Role: model.RoleAssistant, ToolID: "call-1", Content: "summary"}},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must use role")
+	_, err = replacementToolChoices(
+		[]model.Choice{
+			{Message: model.NewToolMessage("call-1", "lookup", "raw")},
+			{Message: model.NewToolMessage("call-2", "lookup", "raw")},
+		},
+		[]model.Message{
+			model.NewToolMessage("call-1", "lookup", "summary"),
+			model.NewToolMessage("call-1", "lookup", "summary again"),
+		},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate tool id")
+	_, err = replacementToolChoices(
+		[]model.Choice{{Message: model.NewToolMessage("call-1", "lookup", "raw")}},
+		[]model.Message{model.NewToolMessage("call-2", "lookup", "summary")},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "replacement missing tool id")
+
+	updated := replaceChoiceToolMessage(model.Choice{}, model.NewToolMessage("call-new", "lookup", "summary"))
+	assert.Equal(t, "call-new", updated.Message.ToolID)
+	assert.Equal(t, "summary", updated.Message.Content)
+	index := toolChoiceIndexByID([]model.Choice{
+		{Index: 4, Delta: model.NewToolMessage("call-delta", "lookup", "raw")},
+		{Index: 5, Message: model.Message{Role: model.RoleAssistant}},
+	})
+	assert.Equal(t, 4, index["call-delta"])
+	assert.Len(t, index, 1)
+	assert.Nil(t, cloneModelMessages(nil))
+	cloned := cloneModelMessages([]model.Message{model.NewUserMessage("hello")})
+	require.Len(t, cloned, 1)
+	assert.Equal(t, "hello", cloned[0].Content)
+}
+
 func TestExecuteToolCallsInParallel(t *testing.T) {
 	tools := map[string]tool.Tool{
 		"func-1": &mockCallableTool{

--- a/internal/flow/processor/functioncall_test.go
+++ b/internal/flow/processor/functioncall_test.go
@@ -113,6 +113,18 @@ type permissionMockTool struct {
 	skipSummarize    bool
 }
 
+type afterToolMessagesTestPlugin struct {
+	hook plugin.AfterToolMessagesCallback
+}
+
+func (p afterToolMessagesTestPlugin) Name() string {
+	return "after_tool_messages_test"
+}
+
+func (p afterToolMessagesTestPlugin) Register(r *plugin.Registry) {
+	r.AfterToolMessages(p.hook)
+}
+
 func (m *permissionMockTool) ToolMetadata() tool.ToolMetadata {
 	return m.metadata
 }
@@ -2127,6 +2139,164 @@ func TestExecuteToolCall_ToolResultMessagesCallback_UnsupportedReturnType(t *tes
 	require.NoError(t, err)
 	assert.Equal(t, model.RoleTool, choices[0].Message.Role)
 	assert.Equal(t, string(wantBytes), choices[0].Message.Content)
+}
+
+func TestAfterToolMessagesHook_ReplacesToolResultMessages(t *testing.T) {
+	req := &model.Request{Messages: []model.Message{
+		model.NewUserMessage("look up data"),
+	}}
+	toolCalls := []model.ToolCall{{
+		ID: "call-1",
+		Function: model.FunctionDefinitionParam{
+			Name:      "lookup",
+			Arguments: []byte(`{"q":"data"}`),
+		},
+	}}
+	llmResponse := &model.Response{Choices: []model.Choice{{
+		Message: model.Message{
+			Role:      model.RoleAssistant,
+			ToolCalls: toolCalls,
+		},
+	}}}
+	toolEvent := event.NewResponseEvent("inv-1", "agent", &model.Response{
+		Object: model.ObjectTypeToolResponse,
+		Choices: []model.Choice{{
+			Index:   7,
+			Message: model.NewToolMessage("call-1", "lookup", "raw result"),
+		}},
+	})
+
+	var sawMessages []model.Message
+	mgr := plugin.MustNewManager(afterToolMessagesTestPlugin{
+		hook: func(ctx context.Context, args *plugin.AfterToolMessagesArgs) (*plugin.AfterToolMessagesResult, error) {
+			require.Len(t, args.Messages, 3)
+			require.Len(t, args.ToolCalls, 1)
+			require.Equal(t, "lookup", args.ToolCalls[0].Function.Name)
+			require.Equal(t, "raw result", args.ToolResultMessages[0].Content)
+			sawMessages = append([]model.Message(nil), args.Messages...)
+			msg := args.ToolResultMessages[0]
+			msg.Content = "summary result_ref=refs/node.md"
+			return &plugin.AfterToolMessagesResult{
+				ToolResultMessages: []model.Message{msg},
+			}, nil
+		},
+	})
+	inv := &agent.Invocation{InvocationID: "inv-1", AgentName: "agent", Plugins: mgr}
+	p := NewFunctionCallResponseProcessor(false, nil)
+
+	err := p.applyAfterToolMessagesHooks(
+		context.Background(),
+		inv,
+		req,
+		llmResponse,
+		toolEvent,
+	)
+	require.NoError(t, err)
+	require.Len(t, sawMessages, 3)
+	require.Len(t, toolEvent.Response.Choices, 1)
+	assert.Equal(t, 7, toolEvent.Response.Choices[0].Index)
+	assert.Equal(t, "call-1", toolEvent.Response.Choices[0].Message.ToolID)
+	assert.Equal(t, "summary result_ref=refs/node.md", toolEvent.Response.Choices[0].Message.Content)
+}
+
+func TestAfterToolMessagesHook_RejectsInvalidReplacement(t *testing.T) {
+	llmResponse := &model.Response{Choices: []model.Choice{{
+		Message: model.Message{
+			Role: model.RoleAssistant,
+			ToolCalls: []model.ToolCall{{
+				ID:       "call-1",
+				Function: model.FunctionDefinitionParam{Name: "lookup"},
+			}},
+		},
+	}}}
+	toolEvent := event.NewResponseEvent("inv-1", "agent", &model.Response{
+		Object: model.ObjectTypeToolResponse,
+		Choices: []model.Choice{{
+			Message: model.NewToolMessage("call-1", "lookup", "raw result"),
+		}},
+	})
+	mgr := plugin.MustNewManager(afterToolMessagesTestPlugin{
+		hook: func(ctx context.Context, args *plugin.AfterToolMessagesArgs) (*plugin.AfterToolMessagesResult, error) {
+			return &plugin.AfterToolMessagesResult{
+				ToolResultMessages: []model.Message{model.NewAssistantMessage("bad")},
+			}, nil
+		},
+	})
+	inv := &agent.Invocation{InvocationID: "inv-1", AgentName: "agent", Plugins: mgr}
+	p := NewFunctionCallResponseProcessor(false, nil)
+
+	err := p.applyAfterToolMessagesHooks(
+		context.Background(),
+		inv,
+		&model.Request{},
+		llmResponse,
+		toolEvent,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing tool id")
+	assert.Equal(t, "raw result", toolEvent.Response.Choices[0].Message.Content)
+}
+
+func TestAfterToolMessagesHook_SkipsMinimalToolPlaceholder(t *testing.T) {
+	toolCall := model.ToolCall{
+		ID: "call-empty",
+		Function: model.FunctionDefinitionParam{
+			Name: "noop",
+		},
+	}
+	llmResponse := &model.Response{Choices: []model.Choice{{
+		Message: model.Message{
+			Role:      model.RoleAssistant,
+			ToolCalls: []model.ToolCall{toolCall},
+		},
+	}}}
+	toolEvent := event.NewResponseEvent("inv-1", "agent", &model.Response{
+		Object:  model.ObjectTypeToolResponse,
+		Choices: []model.Choice{newMinimalToolChoice(toolCall, 0)},
+	})
+	called := false
+	mgr := plugin.MustNewManager(afterToolMessagesTestPlugin{
+		hook: func(context.Context, *plugin.AfterToolMessagesArgs) (*plugin.AfterToolMessagesResult, error) {
+			called = true
+			return nil, nil
+		},
+	})
+	inv := &agent.Invocation{InvocationID: "inv-1", AgentName: "agent", Plugins: mgr}
+	p := NewFunctionCallResponseProcessor(false, nil)
+
+	err := p.applyAfterToolMessagesHooks(
+		context.Background(),
+		inv,
+		&model.Request{},
+		llmResponse,
+		toolEvent,
+	)
+	require.NoError(t, err)
+	assert.False(t, called)
+}
+
+func TestReplacementToolChoices_PreservesOriginalOrder(t *testing.T) {
+	finishReason := "tool_calls"
+	choices, err := replacementToolChoices(
+		[]model.Choice{
+			{Index: 10, Message: model.NewToolMessage("call-1", "lookup", "raw 1"), FinishReason: &finishReason},
+			{Index: 11, Message: model.NewToolMessage("call-2", "lookup", "raw 2"), FinishReason: &finishReason},
+		},
+		[]model.Message{
+			model.NewToolMessage("call-2", "lookup", "summary 2"),
+			model.NewToolMessage("call-1", "lookup", "summary 1"),
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, choices, 2)
+	assert.Equal(t, 10, choices[0].Index)
+	assert.Same(t, &finishReason, choices[0].FinishReason)
+	assert.Equal(t, "call-1", choices[0].Message.ToolID)
+	assert.Equal(t, "summary 1", choices[0].Message.Content)
+	assert.Equal(t, 11, choices[1].Index)
+	assert.Same(t, &finishReason, choices[1].FinishReason)
+	assert.Equal(t, "call-2", choices[1].Message.ToolID)
+	assert.Equal(t, "summary 2", choices[1].Message.Content)
 }
 
 func TestExecuteToolCallsInParallel(t *testing.T) {

--- a/memory/tencentdb/context_offload.go
+++ b/memory/tencentdb/context_offload.go
@@ -1,0 +1,576 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package tencentdb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/log"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/plugin"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+var _ plugin.Plugin = (*contextOffloadPlugin)(nil)
+
+const contextOffloadPluginName = "tencentdb_context_offload"
+
+// ContextOffloadPlugin returns a runner plugin for short-term tool result
+// offload. It is separate from Plugin so long-term recall does not
+// unexpectedly rewrite tool result history.
+func (s *Service) ContextOffloadPlugin() plugin.Plugin {
+	if s == nil {
+		return &contextOffloadPlugin{opts: defaultOptions()}
+	}
+	return &contextOffloadPlugin{opts: s.opts}
+}
+
+// NewContextOffloadPlugin creates a standalone context offload plugin.
+func NewContextOffloadPlugin(opts ...Option) plugin.Plugin {
+	options := defaultOptions()
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&options)
+		}
+	}
+	return &contextOffloadPlugin{opts: options}
+}
+
+type contextOffloadPlugin struct {
+	opts Options
+}
+
+func (p *contextOffloadPlugin) Name() string {
+	return contextOffloadPluginName
+}
+
+func (p *contextOffloadPlugin) Register(r *plugin.Registry) {
+	if p == nil || !p.opts.ContextOffload.Enabled {
+		return
+	}
+	r.AfterToolMessages(p.afterToolMessages)
+	r.BeforeModel(p.beforeModel)
+}
+
+func (p *contextOffloadPlugin) afterToolMessages(
+	ctx context.Context,
+	args *plugin.AfterToolMessagesArgs,
+) (*plugin.AfterToolMessagesResult, error) {
+	if p == nil || args == nil || args.Invocation == nil ||
+		args.Invocation.Session == nil {
+		return nil, nil
+	}
+	sess := args.Invocation.Session
+	if err := validateSessionScope(sess); err != nil {
+		return nil, nil
+	}
+	store := newOffloadStorageContext(p.opts, sess, args.Invocation.AgentName)
+	if err := ensureOffloadDirs(store); err != nil {
+		log.WarnfContext(ctx, "tencentdb context offload: ensure dirs failed: %v", err)
+		return nil, nil
+	}
+	state, err := readOffloadState(store)
+	if err != nil {
+		log.WarnfContext(ctx, "tencentdb context offload: read state failed: %v", err)
+		state = newOffloadState()
+	}
+	state.LastSessionKey = store.SessionKey
+	registerOffloadSession(store)
+
+	pairs, err := p.collectToolPairs(store, args)
+	if err != nil {
+		log.WarnfContext(ctx, "tencentdb context offload: collect tool pairs failed: %v", err)
+		return nil, nil
+	}
+	if len(pairs) == 0 {
+		return nil, nil
+	}
+
+	entries := p.summarizeToolPairs(ctx, args.Messages, pairs)
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	if err := appendOffloadEntries(store, entries); err != nil {
+		log.WarnfContext(ctx, "tencentdb context offload: append entries failed: %v", err)
+		return nil, nil
+	}
+	for _, entry := range entries {
+		state.LastOffloadedToolCallID = entry.ToolCallID
+		state.addConfirmed(entry.ToolCallID)
+	}
+	if err := p.advanceOffloadState(ctx, store, state, args.Messages); err != nil {
+		log.WarnfContext(ctx, "tencentdb context offload: advance state failed: %v", err)
+	}
+	if err := writeOffloadState(store, state); err != nil {
+		log.WarnfContext(ctx, "tencentdb context offload: write state failed: %v", err)
+	}
+
+	if p.opts.ContextOffload.Mode == ContextOffloadModeCollect {
+		return nil, nil
+	}
+	return replaceCurrentToolResults(args.ToolResultMessages, entries), nil
+}
+
+func (p *contextOffloadPlugin) beforeModel(
+	ctx context.Context,
+	args *model.BeforeModelArgs,
+) (*model.BeforeModelResult, error) {
+	if p == nil || args == nil || args.Request == nil {
+		return nil, nil
+	}
+	inv, ok := agent.InvocationFromContext(ctx)
+	if !ok || inv == nil || inv.Session == nil {
+		return nil, nil
+	}
+	if err := validateSessionScope(inv.Session); err != nil {
+		return nil, nil
+	}
+	store := newOffloadStorageContext(p.opts, inv.Session, inv.AgentName)
+	if err := ensureOffloadDirs(store); err != nil {
+		log.WarnfContext(ctx, "tencentdb context offload: ensure dirs failed: %v", err)
+		return nil, nil
+	}
+	state, err := readOffloadState(store)
+	if err != nil {
+		log.WarnfContext(ctx, "tencentdb context offload: read state failed: %v", err)
+		state = newOffloadState()
+	}
+	state.LastSessionKey = store.SessionKey
+	registerOffloadSession(store)
+
+	entries, err := readAllOffloadEntries(store)
+	if err != nil {
+		log.WarnfContext(ctx, "tencentdb context offload: read index failed: %v", err)
+		return nil, nil
+	}
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	if err := p.advanceOffloadState(ctx, store, state, args.Request.Messages); err != nil {
+		log.WarnfContext(ctx, "tencentdb context offload: advance state failed: %v", err)
+	}
+	entries, err = readAllOffloadEntries(store)
+	if err != nil {
+		log.WarnfContext(ctx, "tencentdb context offload: reload index failed: %v", err)
+		return nil, nil
+	}
+	if p.opts.ContextOffload.Mode != ContextOffloadModeCollect {
+		history := p.applyL3(ctx, store, state, args.Request, entries)
+		if err := injectOffloadContext(args.Request, store, state, history, p.opts); err != nil {
+			log.WarnfContext(ctx, "tencentdb context offload: inject mmd failed: %v", err)
+		}
+	}
+	if err := writeOffloadState(store, state); err != nil {
+		log.WarnfContext(ctx, "tencentdb context offload: write state failed: %v", err)
+	}
+	return nil, nil
+}
+
+func (p *contextOffloadPlugin) collectToolPairs(
+	store offloadStorageContext,
+	args *plugin.AfterToolMessagesArgs,
+) ([]offloadToolPair, error) {
+	if args == nil {
+		return nil, nil
+	}
+	minBytes := p.opts.ContextOffload.L0.MinToolResultBytes
+	if minBytes <= 0 {
+		minBytes = defaultContextOffloadMinToolResultBytes
+	}
+	calls := toolCallsByID(args.ToolCalls)
+	pairs := make([]offloadToolPair, 0, len(args.ToolResultMessages))
+	for _, msg := range args.ToolResultMessages {
+		resultText := offloadToolResultText(msg)
+		if len([]byte(resultText)) < minBytes {
+			continue
+		}
+		call := calls[msg.ToolID]
+		if call.ID == "" {
+			call.ID = msg.ToolID
+		}
+		if call.Function.Name == "" {
+			call.Function.Name = msg.ToolName
+		}
+		ref, err := writeOffloadRef(store, call, msg)
+		if err != nil {
+			return nil, err
+		}
+		pairs = append(pairs, offloadToolPair{
+			ToolName:   toolCallName(call, msg),
+			ToolCallID: msg.ToolID,
+			Params:     string(call.Function.Arguments),
+			Result:     resultText,
+			ResultRef:  ref,
+			Timestamp:  time.Now().Format(time.RFC3339Nano),
+		})
+	}
+	return pairs, nil
+}
+
+func (p *contextOffloadPlugin) summarizeToolPairs(
+	ctx context.Context,
+	messages []model.Message,
+	pairs []offloadToolPair,
+) []offloadIndexEntry {
+	if len(pairs) == 0 {
+		return nil
+	}
+	maxPairs := p.opts.ContextOffload.L1.MaxPairsPerBatch
+	if maxPairs <= 0 {
+		maxPairs = defaultContextOffloadMaxPairsPerBatch
+	}
+	if maxPairs >= len(pairs) {
+		return p.summarizeToolPairBatch(ctx, messages, pairs)
+	}
+	entries := make([]offloadIndexEntry, 0, len(pairs))
+	for start := 0; start < len(pairs); start += maxPairs {
+		end := start + maxPairs
+		if end > len(pairs) {
+			end = len(pairs)
+		}
+		entries = append(entries, p.summarizeToolPairBatch(ctx, messages, pairs[start:end])...)
+	}
+	return entries
+}
+
+func (p *contextOffloadPlugin) summarizeToolPairBatch(
+	ctx context.Context,
+	messages []model.Message,
+	pairs []offloadToolPair,
+) []offloadIndexEntry {
+	client := p.newOffloadModelClient()
+	recent := recentMessagesText(messages, 6)
+	if client != nil {
+		entries, err := client.L1Summarize(ctx, offloadL1Request{
+			RecentMessages: recent,
+			ToolPairs:      pairs,
+		})
+		if err == nil && len(entries) > 0 {
+			return normalizeL1Entries(entries, pairs)
+		}
+		if err != nil && !errors.Is(err, errOffloadModelUnavailable) {
+			log.WarnfContext(ctx, "tencentdb context offload: L1 failed: %v", err)
+		}
+	}
+	entries := make([]offloadIndexEntry, 0, len(pairs))
+	for _, pair := range pairs {
+		entries = append(entries, fallbackL1Entry(pair))
+	}
+	return entries
+}
+
+func (p *contextOffloadPlugin) advanceOffloadState(
+	ctx context.Context,
+	store offloadStorageContext,
+	state *offloadState,
+	messages []model.Message,
+) error {
+	if state == nil {
+		return nil
+	}
+	entries, err := readAllOffloadEntries(store)
+	if err != nil {
+		return err
+	}
+	if len(entries) == 0 {
+		return nil
+	}
+	if err := p.ensureTaskBoundary(ctx, store, state, messages, entries); err != nil {
+		return err
+	}
+	return p.maybeRunL2(ctx, store, state, messages, entries)
+}
+
+func (p *contextOffloadPlugin) ensureTaskBoundary(
+	ctx context.Context,
+	store offloadStorageContext,
+	state *offloadState,
+	messages []model.Message,
+	entries []offloadIndexEntry,
+) error {
+	start := firstUnjudgedBoundaryStart(state, entries)
+	if start < 0 {
+		return nil
+	}
+	judgment := fallbackTaskJudgment(messages)
+	client := p.newOffloadModelClient()
+	if client != nil {
+		current, _ := readActiveMMD(store, state)
+		metas, _ := listMMDMetas(store)
+		got, err := client.L15Judge(ctx, offloadL15Request{
+			RecentMessages:    recentMessagesText(messages, 6),
+			CurrentMMD:        current,
+			AvailableMMDMetas: metas,
+		})
+		if err == nil {
+			judgment = normalizeTaskJudgment(got, judgment)
+		} else if !errors.Is(err, errOffloadModelUnavailable) {
+			log.WarnfContext(ctx, "tencentdb context offload: L1.5 failed: %v", err)
+		}
+	}
+	if !judgment.IsLongTask {
+		state.Boundaries = append(state.Boundaries, offloadBoundary{
+			StartIndex: start,
+			Result:     offloadBoundaryShort,
+		})
+		if judgment.TaskCompleted {
+			state.ActiveMMDFile = ""
+			state.ActiveMMDID = ""
+		}
+		state.L15Settled = true
+		state.LastL15JudgedToolCallID = entries[len(entries)-1].ToolCallID
+		return nil
+	}
+	target := judgment.ContinuationMMDFile
+	if strings.TrimSpace(target) == "" && judgment.IsContinuation {
+		target = state.ActiveMMDFile
+	}
+	if strings.TrimSpace(target) == "" {
+		state.MMDCounter++
+		if state.MMDCounter <= 0 {
+			state.MMDCounter = 1
+		}
+		target = fmt.Sprintf("%03d-%s.mmd", state.MMDCounter, safeTaskLabel(judgment.NewTaskLabel))
+	}
+	state.ActiveMMDFile = target
+	state.ActiveMMDID = strings.TrimSuffix(target, ".mmd")
+	state.Boundaries = append(state.Boundaries, offloadBoundary{
+		StartIndex: start,
+		Result:     offloadBoundaryLong,
+		TargetMMD:  target,
+	})
+	state.L15Settled = true
+	state.LastL15JudgedToolCallID = entries[len(entries)-1].ToolCallID
+	return nil
+}
+
+func firstUnjudgedBoundaryStart(state *offloadState, entries []offloadIndexEntry) int {
+	if state == nil || len(entries) == 0 {
+		return -1
+	}
+	if state.LastL15JudgedToolCallID == "" {
+		return nextBoundaryStart(state, entries)
+	}
+	for i, entry := range entries {
+		if entry.ToolCallID == state.LastL15JudgedToolCallID {
+			if i+1 >= len(entries) {
+				return -1
+			}
+			return i + 1
+		}
+	}
+	return nextBoundaryStart(state, entries)
+}
+
+func nextBoundaryStart(state *offloadState, entries []offloadIndexEntry) int {
+	start := 0
+	for _, boundary := range state.Boundaries {
+		if boundary.StartIndex >= start {
+			start = boundary.StartIndex + 1
+		}
+	}
+	if start >= len(entries) {
+		return -1
+	}
+	return start
+}
+
+func (p *contextOffloadPlugin) maybeRunL2(
+	ctx context.Context,
+	store offloadStorageContext,
+	state *offloadState,
+	messages []model.Message,
+	entries []offloadIndexEntry,
+) error {
+	target := state.ActiveMMDFile
+	if target == "" {
+		return nil
+	}
+	eligible := eligibleL2Entries(state, entries)
+	if len(eligible) == 0 {
+		return nil
+	}
+	runL2, err := p.shouldRunL2(store, state, eligible)
+	if err != nil {
+		return err
+	}
+	if !runL2 {
+		return nil
+	}
+	existing, err := readMMD(store, target)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	req := offloadL2Request{
+		ExistingMMD:   existing,
+		NewEntries:    eligible,
+		RecentHistory: recentMessagesText(messages, 6),
+		CurrentTurn:   latestUserMessageText(messages),
+		TaskLabel:     strings.TrimSuffix(target, ".mmd"),
+		MMDPrefix:     mmdPrefixFromFile(target),
+		MMDCharCount:  len(existing),
+	}
+	client := p.newOffloadModelClient()
+	var rsp offloadL2Response
+	if client != nil {
+		got, err := client.L2Generate(ctx, req)
+		if err == nil {
+			rsp = got
+		} else if !errors.Is(err, errOffloadModelUnavailable) {
+			log.WarnfContext(ctx, "tencentdb context offload: L2 failed: %v", err)
+		}
+	}
+	if rsp.FileAction == "" {
+		rsp = fallbackL2Response(req)
+	}
+	if err := applyL2Response(store, target, rsp); err != nil {
+		return err
+	}
+	if err := backfillOffloadNodeIDs(store, rsp.NodeMapping, eligible); err != nil {
+		return err
+	}
+	state.LastL2TriggerTime = time.Now().Format(time.RFC3339Nano)
+	return nil
+}
+
+func (p *contextOffloadPlugin) shouldRunL2(
+	store offloadStorageContext,
+	state *offloadState,
+	eligible []offloadIndexEntry,
+) (bool, error) {
+	if len(eligible) == 0 {
+		return false, nil
+	}
+	if state.ActiveMMDFile != "" {
+		if _, err := readMMD(store, state.ActiveMMDFile); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return true, nil
+			}
+			return false, err
+		}
+	}
+	threshold := p.opts.ContextOffload.L2.NullThreshold
+	if threshold <= 0 {
+		threshold = defaultContextOffloadL2NullThreshold
+	}
+	nullCount := 0
+	for _, entry := range eligible {
+		if entry.NodeID == nil {
+			nullCount++
+		}
+	}
+	if nullCount >= threshold {
+		return true, nil
+	}
+	timeout := p.opts.ContextOffload.L2.Timeout
+	if timeout <= 0 {
+		timeout = defaultContextOffloadL2Timeout
+	}
+	if state.LastL2TriggerTime == "" {
+		return false, nil
+	}
+	last, err := time.Parse(time.RFC3339Nano, state.LastL2TriggerTime)
+	if err != nil {
+		return true, nil
+	}
+	return time.Since(last) >= timeout, nil
+}
+
+func toolCallsByID(calls []model.ToolCall) map[string]model.ToolCall {
+	out := make(map[string]model.ToolCall, len(calls))
+	for _, call := range calls {
+		if call.ID != "" {
+			out[call.ID] = call
+		}
+	}
+	return out
+}
+
+func toolCallName(call model.ToolCall, msg model.Message) string {
+	if call.Function.Name != "" {
+		return call.Function.Name
+	}
+	if msg.ToolName != "" {
+		return msg.ToolName
+	}
+	return "tool"
+}
+
+func replaceCurrentToolResults(
+	original []model.Message,
+	entries []offloadIndexEntry,
+) *plugin.AfterToolMessagesResult {
+	byID := make(map[string]offloadIndexEntry, len(entries))
+	for _, entry := range entries {
+		byID[entry.ToolCallID] = entry
+	}
+	replacements := make([]model.Message, len(original))
+	copy(replacements, original)
+	var changed bool
+	for i := range replacements {
+		entry, ok := byID[replacements[i].ToolID]
+		if !ok {
+			continue
+		}
+		replacements[i].Content = offloadedToolMessageContent(entry)
+		replacements[i].ContentParts = nil
+		changed = true
+	}
+	if !changed {
+		return nil
+	}
+	return &plugin.AfterToolMessagesResult{ToolResultMessages: replacements}
+}
+
+func offloadedToolMessageContent(entry offloadIndexEntry) string {
+	var b strings.Builder
+	b.WriteString("Tool result has been externalized to TencentDB short-term context offload.\n\n")
+	b.WriteString("node_id: ")
+	b.WriteString(entry.displayNodeID())
+	b.WriteString("\nresult_ref: ")
+	b.WriteString(entry.ResultRef)
+	b.WriteString("\ntool_call_id: ")
+	b.WriteString(entry.ToolCallID)
+	b.WriteString("\nscore: ")
+	b.WriteString(fmt.Sprintf("%.1f", entry.Score))
+	b.WriteString("\n\nSummary:\n")
+	b.WriteString(entry.Summary)
+	b.WriteString("\n\nUse tdai_read_offload_ref with result_ref when exact details are needed.")
+	return b.String()
+}
+
+func currentInvocation(ctx context.Context) (*agent.Invocation, error) {
+	inv, ok := agent.InvocationFromContext(ctx)
+	if !ok || inv == nil || inv.Session == nil {
+		return nil, errors.New("tencentdb memory tool: invocation session is required")
+	}
+	if err := validateSessionScope(inv.Session); err != nil {
+		return nil, err
+	}
+	return inv, nil
+}
+
+func contextOffloadSessionDir(opts Options, sess *session.Session) string {
+	return newOffloadStorageContext(opts, sess, "").DataDir
+}
+
+func contextOffloadSessionDirForAgent(
+	opts Options,
+	sess *session.Session,
+	agentName string,
+) string {
+	return newOffloadStorageContext(opts, sess, agentName).DataDir
+}

--- a/memory/tencentdb/context_offload_integration_test.go
+++ b/memory/tencentdb/context_offload_integration_test.go
@@ -1,0 +1,115 @@
+//go:build integration
+
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package tencentdb
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/model/openai"
+	pluginpkg "trpc.group/trpc-go/trpc-agent-go/plugin"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+func TestContextOffloadPlugin_IntegrationLocalModel(t *testing.T) {
+	if os.Getenv("TDAI_CONTEXT_OFFLOAD_INTEGRATION") != "1" {
+		t.Skip("set TDAI_CONTEXT_OFFLOAD_INTEGRATION=1 to run the live model integration test")
+	}
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	if apiKey == "" {
+		t.Skip("OPENAI_API_KEY is not set")
+	}
+	modelName := os.Getenv("TDAI_CONTEXT_OFFLOAD_TEST_MODEL")
+	if modelName == "" {
+		modelName = "gpt-5.2"
+	}
+	opts := []openai.Option{openai.WithAPIKey(apiKey)}
+	if baseURL := os.Getenv("OPENAI_BASE_URL"); baseURL != "" {
+		opts = append(opts, openai.WithBaseURL(baseURL))
+	}
+	offloadModel := openai.New(modelName, opts...)
+	dataDir := t.TempDir()
+	svc, err := NewService(
+		WithGatewayURL("http://127.0.0.1:1"),
+		WithContextOffload(ContextOffloadConfig{
+			Enabled: true,
+			DataDir: dataDir,
+			Model:   offloadModel,
+			L0: ContextOffloadL0Config{
+				MinToolResultBytes: 10,
+			},
+			L2: ContextOffloadL2Config{
+				NullThreshold: 1,
+			},
+		}),
+		WithConversationSearchTool(false),
+	)
+	require.NoError(t, err)
+	defer svc.Close()
+
+	mgr := pluginpkg.MustNewManager(svc.ContextOffloadPlugin())
+	sess := &session.Session{AppName: "app", UserID: "user", ID: "live"}
+	inv := &agent.Invocation{InvocationID: "inv", AgentName: "agent", Session: sess, Plugins: mgr}
+	msg := model.NewToolMessage(
+		"call-live",
+		"read_file",
+		"File pkg/offload/demo.go defines a ContextOffloadPlugin. It writes refs, summarizes tool results, and injects Mermaid task context.",
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	result, err := mgr.AfterToolMessages(ctx, &pluginpkg.AfterToolMessagesArgs{
+		Invocation: inv,
+		Request: &model.Request{Messages: []model.Message{
+			model.NewUserMessage("实现 TencentDB context offload"),
+		}},
+		ToolCalls: []model.ToolCall{{
+			ID: "call-live",
+			Function: model.FunctionDefinitionParam{
+				Name:      "read_file",
+				Arguments: []byte(`{"path":"pkg/offload/demo.go"}`),
+			},
+		}},
+		ToolResultMessages: []model.Message{msg},
+		Messages: []model.Message{
+			model.NewUserMessage("实现 TencentDB context offload"),
+			msg,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.ToolResultMessages, 1)
+	assert.Contains(t, result.ToolResultMessages[0].Content, "result_ref:")
+
+	store := newOffloadStorageContext(svc.opts, sess, inv.AgentName)
+	entries, err := readAllOffloadEntries(store)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.NotEmpty(t, entries[0].Summary)
+	assert.NotEmpty(t, entries[0].ResultRef)
+	require.NotNil(t, entries[0].NodeID)
+
+	req := &model.Request{Messages: []model.Message{model.NewUserMessage("继续")}}
+	invCtx := agent.NewInvocationContext(ctx, inv).Context
+	callbacks := mgr.ModelCallbacks()
+	require.NotNil(t, callbacks)
+	_, err = callbacks.BeforeModel[0](invCtx, &model.BeforeModelArgs{Request: req})
+	require.NoError(t, err)
+	require.NotEmpty(t, req.Messages)
+	assert.Contains(t, req.Messages[0].Content, "<current_task_context>")
+}

--- a/memory/tencentdb/context_offload_l3.go
+++ b/memory/tencentdb/context_offload_l3.go
@@ -1,0 +1,374 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package tencentdb
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/log"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+var currentTaskContextRE = regexp.MustCompile(`(?s)\n*<current_task_context>.*?</current_task_context>\n*`)
+
+func (p *contextOffloadPlugin) applyL3(
+	ctx context.Context,
+	store offloadStorageContext,
+	state *offloadState,
+	req *model.Request,
+	entries []offloadIndexEntry,
+) string {
+	if req == nil || state == nil || len(entries) == 0 {
+		return ""
+	}
+	byToolID := offloadEntriesByToolID(entries)
+	replaceConfirmedToolResults(req.Messages, byToolID, state)
+	contextWindow := p.contextWindow()
+	mildThreshold := int(float64(contextWindow) * p.ratioOrDefault(
+		p.opts.ContextOffload.L3.MildRatio,
+		defaultContextOffloadMildRatio,
+	))
+	aggressiveThreshold := int(float64(contextWindow) * p.ratioOrDefault(
+		p.opts.ContextOffload.L3.AggressiveRatio,
+		defaultContextOffloadAggressiveRatio,
+	))
+	emergencyThreshold := int(float64(contextWindow) * p.ratioOrDefault(
+		p.opts.ContextOffload.L3.EmergencyRatio,
+		defaultContextOffloadEmergencyRatio,
+	))
+	emergencyTarget := int(float64(contextWindow) * p.ratioOrDefault(
+		p.opts.ContextOffload.L3.EmergencyTargetRatio,
+		defaultContextOffloadEmergencyTarget,
+	))
+	total := estimateMessagesTokens(req.Messages)
+	state.LastKnownTotalTokens = total
+	state.LastKnownMessageCount = len(req.Messages)
+	if total < mildThreshold {
+		return ""
+	}
+	mildReplaceByScore(req.Messages, byToolID, state, 5)
+	total = estimateMessagesTokens(req.Messages)
+	var deleted []offloadIndexEntry
+	if total >= aggressiveThreshold {
+		req.Messages, deleted = deleteOldOffloadedToolBlocks(
+			req.Messages,
+			byToolID,
+			state,
+			aggressiveThreshold,
+			6,
+		)
+		total = estimateMessagesTokens(req.Messages)
+	}
+	if total >= emergencyThreshold {
+		var emergencyDeleted []offloadIndexEntry
+		req.Messages, emergencyDeleted = deleteOldOffloadedToolBlocks(
+			req.Messages,
+			byToolID,
+			state,
+			emergencyTarget,
+			3,
+		)
+		deleted = append(deleted, emergencyDeleted...)
+	}
+	if len(deleted) > 0 {
+		if err := writeOffloadState(store, state); err != nil {
+			log.WarnfContext(ctx, "tencentdb context offload: write L3 state failed: %v", err)
+		}
+		return historyMMDFromEntries(deleted)
+	}
+	return ""
+}
+
+func (p *contextOffloadPlugin) contextWindow() int {
+	if p.opts.ContextOffload.Model != nil {
+		if info := p.opts.ContextOffload.Model.Info(); info.ContextWindow > 0 {
+			return info.ContextWindow
+		}
+	}
+	if p.opts.ContextOffload.L3.ContextWindow > 0 {
+		return p.opts.ContextOffload.L3.ContextWindow
+	}
+	return defaultContextOffloadContextWindow
+}
+
+func (p *contextOffloadPlugin) ratioOrDefault(got, def float64) float64 {
+	if got > 0 && got < 1 {
+		return got
+	}
+	return def
+}
+
+func offloadEntriesByToolID(entries []offloadIndexEntry) map[string]offloadIndexEntry {
+	out := make(map[string]offloadIndexEntry, len(entries))
+	for _, entry := range entries {
+		if entry.ToolCallID != "" {
+			out[entry.ToolCallID] = entry
+		}
+	}
+	return out
+}
+
+func replaceConfirmedToolResults(
+	messages []model.Message,
+	entries map[string]offloadIndexEntry,
+	state *offloadState,
+) {
+	confirmed := state.confirmedSet()
+	deleted := state.deletedSet()
+	for i := range messages {
+		if messages[i].Role != model.RoleTool || messages[i].ToolID == "" {
+			continue
+		}
+		if _, ok := deleted[messages[i].ToolID]; ok {
+			continue
+		}
+		if _, ok := confirmed[messages[i].ToolID]; !ok {
+			continue
+		}
+		entry, ok := entries[messages[i].ToolID]
+		if !ok {
+			continue
+		}
+		if strings.Contains(messages[i].Content, "result_ref: "+entry.ResultRef) {
+			continue
+		}
+		messages[i].Content = offloadedToolMessageContent(entry)
+	}
+}
+
+func mildReplaceByScore(
+	messages []model.Message,
+	entries map[string]offloadIndexEntry,
+	state *offloadState,
+	minScore float64,
+) {
+	for i := range messages {
+		if messages[i].Role != model.RoleTool || messages[i].ToolID == "" {
+			continue
+		}
+		entry, ok := entries[messages[i].ToolID]
+		if !ok || entry.Score < minScore {
+			continue
+		}
+		messages[i].Content = offloadedToolMessageContent(entry)
+		state.addConfirmed(messages[i].ToolID)
+	}
+}
+
+func deleteOldOffloadedToolBlocks(
+	messages []model.Message,
+	entries map[string]offloadIndexEntry,
+	state *offloadState,
+	targetTokens int,
+	keepTail int,
+) ([]model.Message, []offloadIndexEntry) {
+	if len(messages) <= keepTail+2 {
+		return messages, nil
+	}
+	var deleted []offloadIndexEntry
+	for i := 0; i < len(messages)-keepTail && estimateMessagesTokens(messages) > targetTokens; {
+		msg := messages[i]
+		if msg.Role != model.RoleAssistant || len(msg.ToolCalls) == 0 {
+			i++
+			continue
+		}
+		ids := make([]string, 0, len(msg.ToolCalls))
+		allKnown := true
+		for _, call := range msg.ToolCalls {
+			if call.ID == "" {
+				allKnown = false
+				break
+			}
+			if _, ok := entries[call.ID]; !ok {
+				allKnown = false
+				break
+			}
+			ids = append(ids, call.ID)
+		}
+		if !allKnown {
+			i++
+			continue
+		}
+		end := i + 1
+		seen := map[string]struct{}{}
+		for end < len(messages) {
+			next := messages[end]
+			if next.Role != model.RoleTool {
+				break
+			}
+			for _, id := range ids {
+				if next.ToolID == id {
+					seen[id] = struct{}{}
+					break
+				}
+			}
+			end++
+			if len(seen) == len(ids) {
+				break
+			}
+		}
+		if len(seen) != len(ids) {
+			i++
+			continue
+		}
+		for _, id := range ids {
+			entry := entries[id]
+			deleted = append(deleted, entry)
+			state.addConfirmed(id)
+			state.addDeleted(id)
+		}
+		nextMessages := append([]model.Message{}, messages[:i]...)
+		nextMessages = append(nextMessages, messages[end:]...)
+		messages = nextMessages
+	}
+	return messages, deleted
+}
+
+func historyMMDFromEntries(entries []offloadIndexEntry) string {
+	if len(entries) == 0 {
+		return ""
+	}
+	sort.SliceStable(entries, func(i, j int) bool {
+		return entries[i].Timestamp < entries[j].Timestamp
+	})
+	var b strings.Builder
+	b.WriteString("flowchart TD\n")
+	prevVertexID := ""
+	for i, entry := range entries {
+		displayNodeID := entry.displayNodeID()
+		vertexID := fmt.Sprintf("%s_%d", displayNodeID, i+1)
+		if displayNodeID == "pending" {
+			vertexID = fmt.Sprintf("deleted_%d", i+1)
+		}
+		b.WriteString(fmt.Sprintf(
+			"  %s[\"%s\\nnode_id: %s\\n%s\\nref: %s\"]\n",
+			mermaidNodeID(vertexID),
+			escapeMermaidLabel(truncateRunes(entry.ToolCall, 80)),
+			escapeMermaidLabel(displayNodeID),
+			escapeMermaidLabel(truncateRunes(entry.Summary, 120)),
+			escapeMermaidLabel(entry.ResultRef),
+		))
+		if prevVertexID != "" {
+			b.WriteString(fmt.Sprintf(
+				"  %s --> %s\n",
+				mermaidNodeID(prevVertexID),
+				mermaidNodeID(vertexID),
+			))
+		}
+		prevVertexID = vertexID
+	}
+	return b.String()
+}
+
+func injectOffloadContext(
+	req *model.Request,
+	store offloadStorageContext,
+	state *offloadState,
+	historyMMD string,
+	opts Options,
+) error {
+	if req == nil || state == nil || state.ActiveMMDFile == "" {
+		return nil
+	}
+	active, err := readMMD(store, state.ActiveMMDFile)
+	if err != nil {
+		return err
+	}
+	active = strings.TrimSpace(active)
+	if active == "" {
+		return nil
+	}
+	content := buildCurrentTaskContext(state.ActiveMMDFile, active, historyMMD, opts)
+	for i := range req.Messages {
+		req.Messages[i].Content = stripCurrentTaskContext(req.Messages[i].Content)
+	}
+	for i := range req.Messages {
+		if req.Messages[i].Role == model.RoleSystem {
+			if strings.TrimSpace(req.Messages[i].Content) == "" {
+				req.Messages[i].Content = content
+			} else {
+				req.Messages[i].Content = strings.TrimSpace(req.Messages[i].Content) + "\n\n" + content
+			}
+			return nil
+		}
+	}
+	req.Messages = append([]model.Message{model.NewSystemMessage(content)}, req.Messages...)
+	return nil
+}
+
+func buildCurrentTaskContext(activeFile, activeMMD, historyMMD string, opts Options) string {
+	readRefTool := nativeToolName(opts, "read_offload_ref")
+	readNodeTool := nativeToolName(opts, "read_offload_node")
+	searchIndexTool := nativeToolName(opts, "search_offload_index")
+	var b strings.Builder
+	b.WriteString("<current_task_context>\n")
+	if strings.TrimSpace(historyMMD) != "" {
+		b.WriteString("Historical task context replaced old offloaded tool blocks:\n")
+		b.WriteString("```mermaid\n")
+		b.WriteString(strings.TrimSpace(historyMMD))
+		b.WriteString("\n```\n\n")
+	}
+	b.WriteString("Active task Mermaid file: ")
+	b.WriteString(activeFile)
+	b.WriteString("\n")
+	b.WriteString("```mermaid\n")
+	b.WriteString(strings.TrimSpace(activeMMD))
+	b.WriteString("\n```\n\n")
+	b.WriteString("Use node_id to locate summarized tool calls. Use ")
+	b.WriteString(readRefTool)
+	b.WriteString(" with result_ref for exact tool output. Use ")
+	b.WriteString(readNodeTool)
+	b.WriteString(" or ")
+	b.WriteString(searchIndexTool)
+	b.WriteString(" when the relevant node/ref is unclear.\n")
+	b.WriteString("</current_task_context>")
+	return b.String()
+}
+
+func stripCurrentTaskContext(content string) string {
+	if !strings.Contains(content, "<current_task_context>") {
+		return content
+	}
+	return strings.TrimSpace(currentTaskContextRE.ReplaceAllString(content, "\n"))
+}
+
+func estimateMessagesTokens(messages []model.Message) int {
+	total := 0
+	for _, msg := range messages {
+		total += estimateTextTokens(offloadMessageText(msg))
+		if len(msg.ToolCalls) > 0 {
+			b, _ := json.Marshal(msg.ToolCalls)
+			total += estimateTextTokens(string(b))
+		}
+		total += 4
+	}
+	return total
+}
+
+func estimateTextTokens(text string) int {
+	if text == "" {
+		return 0
+	}
+	cjk := 0
+	for _, r := range text {
+		if (r >= 0x4e00 && r <= 0x9fff) ||
+			(r >= 0x3400 && r <= 0x4dbf) ||
+			(r >= 0xf900 && r <= 0xfaff) {
+			cjk++
+		}
+	}
+	rest := len([]rune(text)) - cjk
+	return int(float64(cjk)*1.5) + rest/4 + 1
+}

--- a/memory/tencentdb/context_offload_llm.go
+++ b/memory/tencentdb/context_offload_llm.go
@@ -1,0 +1,804 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package tencentdb
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+var errOffloadModelUnavailable = errors.New("context offload model unavailable")
+
+type offloadModelClient interface {
+	L1Summarize(context.Context, offloadL1Request) ([]offloadIndexEntry, error)
+	L15Judge(context.Context, offloadL15Request) (offloadTaskJudgment, error)
+	L2Generate(context.Context, offloadL2Request) (offloadL2Response, error)
+}
+
+type offloadL1Request struct {
+	RecentMessages string            `json:"recentMessages"`
+	ToolPairs      []offloadToolPair `json:"toolPairs"`
+}
+
+type offloadMMDContent struct {
+	Filename string `json:"filename"`
+	Content  string `json:"content"`
+	Path     string `json:"path"`
+}
+
+type offloadL15Request struct {
+	RecentMessages    string             `json:"recentMessages"`
+	CurrentMMD        *offloadMMDContent `json:"currentMmd,omitempty"`
+	AvailableMMDMetas []offloadMMDMeta   `json:"availableMmdMetas"`
+}
+
+type offloadTaskJudgment struct {
+	TaskCompleted       bool   `json:"taskCompleted"`
+	IsContinuation      bool   `json:"isContinuation"`
+	ContinuationMMDFile string `json:"continuationMmdFile"`
+	NewTaskLabel        string `json:"newTaskLabel"`
+	IsLongTask          bool   `json:"isLongTask"`
+}
+
+type offloadL2Request struct {
+	ExistingMMD   string              `json:"existingMmd"`
+	NewEntries    []offloadIndexEntry `json:"newEntries"`
+	RecentHistory string              `json:"recentHistory"`
+	CurrentTurn   string              `json:"currentTurn"`
+	TaskLabel     string              `json:"taskLabel"`
+	MMDPrefix     string              `json:"mmdPrefix"`
+	MMDCharCount  int                 `json:"mmdCharCount"`
+}
+
+type offloadL2Response struct {
+	FileAction    string                  `json:"file_action"`
+	MMDContent    string                  `json:"mmd_content"`
+	ReplaceBlocks []offloadL2ReplaceBlock `json:"replace_blocks"`
+	NodeMapping   map[string]string       `json:"node_mapping"`
+}
+
+func (r *offloadL2Response) UnmarshalJSON(data []byte) error {
+	type alias offloadL2Response
+	var raw struct {
+		alias
+		FileActionCamel    string                  `json:"fileAction"`
+		MMDContentCamel    string                  `json:"mmdContent"`
+		ReplaceBlocksCamel []offloadL2ReplaceBlock `json:"replaceBlocks"`
+		NodeMappingCamel   map[string]string       `json:"nodeMapping"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	*r = offloadL2Response(raw.alias)
+	if r.FileAction == "" {
+		r.FileAction = raw.FileActionCamel
+	}
+	if r.MMDContent == "" {
+		r.MMDContent = raw.MMDContentCamel
+	}
+	if len(r.ReplaceBlocks) == 0 {
+		r.ReplaceBlocks = raw.ReplaceBlocksCamel
+	}
+	if len(r.NodeMapping) == 0 {
+		r.NodeMapping = raw.NodeMappingCamel
+	}
+	return nil
+}
+
+type offloadL2ReplaceBlock struct {
+	StartLine int    `json:"start_line"`
+	EndLine   int    `json:"end_line"`
+	Content   string `json:"content"`
+}
+
+func (b *offloadL2ReplaceBlock) UnmarshalJSON(data []byte) error {
+	type alias offloadL2ReplaceBlock
+	var raw struct {
+		alias
+		StartLineCamel int `json:"startLine"`
+		EndLineCamel   int `json:"endLine"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	*b = offloadL2ReplaceBlock(raw.alias)
+	if b.StartLine == 0 {
+		b.StartLine = raw.StartLineCamel
+	}
+	if b.EndLine == 0 {
+		b.EndLine = raw.EndLineCamel
+	}
+	return nil
+}
+
+type localOffloadModelClient struct {
+	model model.Model
+	opts  Options
+}
+
+type backendOffloadModelClient struct {
+	baseURL    string
+	apiKey     string
+	httpClient *http.Client
+}
+
+func (p *contextOffloadPlugin) newOffloadModelClient() offloadModelClient {
+	cfg := p.opts.ContextOffload
+	switch strings.TrimSpace(cfg.Mode) {
+	case ContextOffloadModeBackend:
+		if strings.TrimSpace(cfg.Backend.URL) == "" {
+			return nil
+		}
+		return &backendOffloadModelClient{
+			baseURL: strings.TrimRight(strings.TrimSpace(cfg.Backend.URL), "/"),
+			apiKey:  cfg.Backend.APIKey,
+			httpClient: &http.Client{
+				Timeout: 2 * time.Minute,
+			},
+		}
+	case ContextOffloadModeCollect:
+		return nil
+	default:
+		return &localOffloadModelClient{model: cfg.Model, opts: p.opts}
+	}
+}
+
+func (c *localOffloadModelClient) L1Summarize(
+	ctx context.Context,
+	req offloadL1Request,
+) ([]offloadIndexEntry, error) {
+	if c == nil || c.model == nil {
+		return nil, errOffloadModelUnavailable
+	}
+	raw, err := c.generateJSON(ctx, l1SystemPrompt, buildL1UserPrompt(req))
+	if err != nil {
+		return nil, err
+	}
+	return parseL1Entries(raw)
+}
+
+func (c *localOffloadModelClient) L15Judge(
+	ctx context.Context,
+	req offloadL15Request,
+) (offloadTaskJudgment, error) {
+	if c == nil || c.model == nil {
+		return offloadTaskJudgment{}, errOffloadModelUnavailable
+	}
+	raw, err := c.generateJSON(ctx, l15SystemPrompt, buildL15UserPrompt(req))
+	if err != nil {
+		return offloadTaskJudgment{}, err
+	}
+	var parsed offloadTaskJudgment
+	if err := unmarshalExtractedJSON(raw, &parsed); err != nil {
+		return offloadTaskJudgment{}, err
+	}
+	return parsed, nil
+}
+
+func (c *localOffloadModelClient) L2Generate(
+	ctx context.Context,
+	req offloadL2Request,
+) (offloadL2Response, error) {
+	if c == nil || c.model == nil {
+		return offloadL2Response{}, errOffloadModelUnavailable
+	}
+	raw, err := c.generateJSON(ctx, l2SystemPrompt, buildL2UserPrompt(req))
+	if err != nil {
+		return offloadL2Response{}, err
+	}
+	var parsed offloadL2Response
+	if err := unmarshalExtractedJSON(raw, &parsed); err != nil {
+		return offloadL2Response{}, err
+	}
+	return normalizeL2Response(parsed), nil
+}
+
+func (c *localOffloadModelClient) generateJSON(
+	ctx context.Context,
+	systemPrompt string,
+	userPrompt string,
+) (string, error) {
+	temp := 0.2
+	maxTokens := 2048
+	req := &model.Request{
+		Messages: []model.Message{
+			model.NewSystemMessage(systemPrompt),
+			model.NewUserMessage(userPrompt),
+		},
+		GenerationConfig: model.GenerationConfig{
+			Temperature: &temp,
+			MaxTokens:   &maxTokens,
+		},
+	}
+	ch, err := c.model.GenerateContent(ctx, req)
+	if err != nil {
+		return "", err
+	}
+	var b strings.Builder
+	for rsp := range ch {
+		if rsp == nil {
+			continue
+		}
+		if rsp.Error != nil {
+			return "", fmt.Errorf("context offload model error: %s", rsp.Error.Message)
+		}
+		for _, choice := range rsp.Choices {
+			if choice.Delta.Content != "" {
+				b.WriteString(choice.Delta.Content)
+				continue
+			}
+			if choice.Message.Content != "" {
+				b.WriteString(choice.Message.Content)
+			}
+		}
+	}
+	if strings.TrimSpace(b.String()) == "" {
+		return "", errors.New("context offload model returned empty response")
+	}
+	return b.String(), nil
+}
+
+func (c *backendOffloadModelClient) L1Summarize(
+	ctx context.Context,
+	req offloadL1Request,
+) ([]offloadIndexEntry, error) {
+	var rsp struct {
+		Entries []offloadIndexEntry `json:"entries"`
+	}
+	if err := c.post(ctx, "/offload/v1/l1/summarize", req, &rsp); err != nil {
+		return nil, err
+	}
+	return rsp.Entries, nil
+}
+
+func (c *backendOffloadModelClient) L15Judge(
+	ctx context.Context,
+	req offloadL15Request,
+) (offloadTaskJudgment, error) {
+	var rsp offloadTaskJudgment
+	if err := c.post(ctx, "/offload/v1/l15/judge", req, &rsp); err != nil {
+		return offloadTaskJudgment{}, err
+	}
+	return rsp, nil
+}
+
+func (c *backendOffloadModelClient) L2Generate(
+	ctx context.Context,
+	req offloadL2Request,
+) (offloadL2Response, error) {
+	var rsp offloadL2Response
+	if err := c.post(ctx, "/offload/v1/l2/generate", req, &rsp); err != nil {
+		return offloadL2Response{}, err
+	}
+	return normalizeL2Response(rsp), nil
+}
+
+func (c *backendOffloadModelClient) post(
+	ctx context.Context,
+	path string,
+	req any,
+	rsp any,
+) error {
+	if c == nil || strings.TrimSpace(c.baseURL) == "" {
+		return errOffloadModelUnavailable
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		return err
+	}
+	httpReq, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		c.baseURL+path,
+		bytes.NewReader(body),
+	)
+	if err != nil {
+		return err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if c.apiKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
+	client := c.httpClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	httpRsp, err := client.Do(httpReq)
+	if err != nil {
+		return err
+	}
+	defer httpRsp.Body.Close()
+	limited := io.LimitReader(httpRsp.Body, defaultMaxBodyBytes)
+	b, err := io.ReadAll(limited)
+	if err != nil {
+		return err
+	}
+	if httpRsp.StatusCode < 200 || httpRsp.StatusCode >= 300 {
+		return fmt.Errorf("context offload backend %s: %s", httpRsp.Status, strings.TrimSpace(string(b)))
+	}
+	return json.Unmarshal(b, rsp)
+}
+
+const l1SystemPrompt = `你是工具结果摘要器。把 tool call/result pairs 压缩为高密度 JSON 数组。
+每个对象必须包含 tool_call、summary、tool_call_id、timestamp、score。
+summary 不超过 200 个中文字符，说明工具结果对当前任务的推进、结论或阻塞。score 为 0-10，表示摘要替代原文的可靠程度。
+只输出合法 JSON 数组，不要输出解释。`
+
+func buildL1UserPrompt(req offloadL1Request) string {
+	var b strings.Builder
+	b.WriteString("## 最近对话\n")
+	b.WriteString(req.RecentMessages)
+	b.WriteString("\n\n## 工具结果\n")
+	for i, pair := range req.ToolPairs {
+		b.WriteString(fmt.Sprintf("### Pair %d\n", i+1))
+		b.WriteString("tool_call_id: " + pair.ToolCallID + "\n")
+		b.WriteString("timestamp: " + pair.Timestamp + "\n")
+		b.WriteString("tool: " + pair.ToolName + "\n")
+		b.WriteString("params: " + truncateRunes(pair.Params, 500) + "\n")
+		b.WriteString("result_ref: " + pair.ResultRef + "\n")
+		b.WriteString("result: " + truncateRunes(pair.Result, 2000) + "\n\n")
+	}
+	return b.String()
+}
+
+const l15SystemPrompt = `你是任务生命周期判断器。根据最近对话、当前 Mermaid 和历史 Mermaid metadata，判断当前是否是长任务、是否延续旧任务、是否需要新任务画布。
+输出 JSON 对象：taskCompleted(boolean), isLongTask(boolean), isContinuation(boolean), continuationMmdFile(string|null), newTaskLabel(string|null)。
+普通问答或闲聊 isLongTask=false；多步工程、排查、实现、测试类任务 isLongTask=true。只输出 JSON。`
+
+func buildL15UserPrompt(req offloadL15Request) string {
+	var b strings.Builder
+	b.WriteString("## 最近对话\n")
+	b.WriteString(req.RecentMessages)
+	b.WriteString("\n\n## 当前 MMD\n")
+	if req.CurrentMMD == nil {
+		b.WriteString("(none)\n")
+	} else {
+		b.WriteString("file: " + req.CurrentMMD.Filename + "\n")
+		b.WriteString(req.CurrentMMD.Content)
+		b.WriteString("\n")
+	}
+	b.WriteString("\n## 历史 MMD metadata\n")
+	if len(req.AvailableMMDMetas) == 0 {
+		b.WriteString("(none)\n")
+	} else {
+		for _, meta := range req.AvailableMMDMetas {
+			b.WriteString(fmt.Sprintf("- %s goal=%s updated=%s done=%d doing=%d todo=%d\n",
+				meta.Filename, meta.TaskGoal, meta.UpdatedTime,
+				meta.DoneCount, meta.DoingCount, meta.TodoCount))
+		}
+	}
+	return b.String()
+}
+
+const l2SystemPrompt = `你是 AI 任务拓扑架构师。把工具摘要 entries 更新为紧凑 Mermaid flowchart TD。
+输出 JSON 对象：file_action("write"或"replace"), mmd_content, replace_blocks, node_mapping。
+每个新 tool_call_id 必须出现在 node_mapping。节点 ID 使用给定前缀，如 001-N1。MMD 需要包含 metadata 行和 flowchart TD。只输出 JSON。`
+
+func buildL2UserPrompt(req offloadL2Request) string {
+	var b strings.Builder
+	b.WriteString("## 近期历史\n")
+	b.WriteString(req.RecentHistory)
+	b.WriteString("\n\n## 当前轮\n")
+	b.WriteString(req.CurrentTurn)
+	b.WriteString("\n\n## MMD prefix\n")
+	b.WriteString(req.MMDPrefix)
+	b.WriteString("\n\n## task label\n")
+	b.WriteString(req.TaskLabel)
+	b.WriteString("\n\n## existing MMD\n")
+	if strings.TrimSpace(req.ExistingMMD) == "" {
+		b.WriteString("(empty)\n")
+	} else {
+		lines := strings.Split(req.ExistingMMD, "\n")
+		for i, line := range lines {
+			b.WriteString(fmt.Sprintf("L%d: %s\n", i+1, line))
+		}
+	}
+	b.WriteString("\n## new entries\n")
+	for i, entry := range req.NewEntries {
+		b.WriteString(fmt.Sprintf("%d. [%s] %s -> %s (%s)\n",
+			i+1, entry.ToolCallID, entry.ToolCall, entry.Summary, entry.Timestamp))
+	}
+	return b.String()
+}
+
+func normalizeL1Entries(
+	entries []offloadIndexEntry,
+	pairs []offloadToolPair,
+) []offloadIndexEntry {
+	byID := make(map[string]offloadToolPair, len(pairs))
+	seen := make(map[string]struct{}, len(pairs))
+	for _, pair := range pairs {
+		byID[pair.ToolCallID] = pair
+	}
+	out := make([]offloadIndexEntry, 0, len(pairs))
+	for _, entry := range entries {
+		pair, ok := byID[entry.ToolCallID]
+		if !ok {
+			continue
+		}
+		if strings.TrimSpace(entry.ToolCall) == "" {
+			entry.ToolCall = pair.ToolName
+		}
+		if strings.TrimSpace(entry.Summary) == "" {
+			entry.Summary = summarizeToolResult(pair.Result)
+		}
+		if strings.TrimSpace(entry.Timestamp) == "" {
+			entry.Timestamp = pair.Timestamp
+		}
+		entry.ResultRef = pair.ResultRef
+		entry.NodeID = nil
+		if entry.Score <= 0 {
+			entry.Score = 5
+		}
+		out = append(out, entry)
+		seen[entry.ToolCallID] = struct{}{}
+	}
+	for _, pair := range pairs {
+		if _, ok := seen[pair.ToolCallID]; ok {
+			continue
+		}
+		out = append(out, fallbackL1Entry(pair))
+	}
+	return out
+}
+
+func parseL1Entries(raw string) ([]offloadIndexEntry, error) {
+	raw = extractJSON(raw)
+	if raw == "" {
+		return nil, errors.New("no JSON array found")
+	}
+	var items []map[string]any
+	if err := json.Unmarshal([]byte(raw), &items); err != nil {
+		return nil, err
+	}
+	entries := make([]offloadIndexEntry, 0, len(items))
+	for _, item := range items {
+		toolCallID := stringField(item, "tool_call_id")
+		if toolCallID == "" {
+			toolCallID = stringField(item, "toolCallId")
+		}
+		if toolCallID == "" {
+			continue
+		}
+		entries = append(entries, offloadIndexEntry{
+			ToolCallID: toolCallID,
+			ToolCall:   flexibleStringField(item, "tool_call", "toolCall"),
+			Summary:    flexibleStringField(item, "summary"),
+			Timestamp:  stringField(item, "timestamp"),
+			Score:      numberField(item, "score"),
+		})
+	}
+	return entries, nil
+}
+
+func stringField(item map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if v, ok := item[key].(string); ok {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}
+
+func flexibleStringField(item map[string]any, keys ...string) string {
+	for _, key := range keys {
+		v, ok := item[key]
+		if !ok || v == nil {
+			continue
+		}
+		if s, ok := v.(string); ok {
+			return strings.TrimSpace(s)
+		}
+		b, err := json.Marshal(v)
+		if err == nil {
+			return string(b)
+		}
+		return fmt.Sprint(v)
+	}
+	return ""
+}
+
+func numberField(item map[string]any, key string) float64 {
+	switch v := item[key].(type) {
+	case float64:
+		return v
+	case int:
+		return float64(v)
+	case json.Number:
+		f, _ := v.Float64()
+		return f
+	default:
+		return 0
+	}
+}
+
+func fallbackL1Entry(pair offloadToolPair) offloadIndexEntry {
+	return offloadIndexEntry{
+		Timestamp:  pair.Timestamp,
+		NodeID:     nil,
+		ToolCall:   pair.ToolName + compactParams(pair.Params),
+		Summary:    summarizeToolResult(pair.Result),
+		ResultRef:  pair.ResultRef,
+		ToolCallID: pair.ToolCallID,
+		Score:      4,
+	}
+}
+
+func compactParams(params string) string {
+	params = strings.TrimSpace(params)
+	if params == "" {
+		return ""
+	}
+	return "(" + truncateRunes(strings.Join(strings.Fields(params), " "), 160) + ")"
+}
+
+func summarizeToolResult(content string) string {
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return "Tool returned an empty result."
+	}
+	normalized := strings.Join(strings.Fields(content), " ")
+	return truncateRunes(normalized, 600)
+}
+
+func fallbackTaskJudgment(messages []model.Message) offloadTaskJudgment {
+	latest := strings.ToLower(latestUserMessageText(messages))
+	if latest == "" {
+		return offloadTaskJudgment{TaskCompleted: true}
+	}
+	shortSignals := []string{"what is", "是什么", "解释", "why", "为什么"}
+	longSignals := []string{"实现", "修复", "排查", "测试", "改", "新增", "refactor", "implement", "fix", "debug", "test"}
+	for _, signal := range longSignals {
+		if strings.Contains(latest, signal) {
+			return offloadTaskJudgment{IsLongTask: true, NewTaskLabel: labelFromText(latest)}
+		}
+	}
+	for _, signal := range shortSignals {
+		if strings.Contains(latest, signal) {
+			return offloadTaskJudgment{TaskCompleted: true, IsLongTask: false}
+		}
+	}
+	return offloadTaskJudgment{IsLongTask: true, NewTaskLabel: labelFromText(latest)}
+}
+
+func normalizeTaskJudgment(got, fallback offloadTaskJudgment) offloadTaskJudgment {
+	if !got.IsLongTask && !got.TaskCompleted && !got.IsContinuation &&
+		strings.TrimSpace(got.NewTaskLabel) == "" &&
+		strings.TrimSpace(got.ContinuationMMDFile) == "" {
+		return fallback
+	}
+	if got.IsLongTask && strings.TrimSpace(got.NewTaskLabel) == "" &&
+		strings.TrimSpace(got.ContinuationMMDFile) == "" {
+		got.NewTaskLabel = fallback.NewTaskLabel
+	}
+	return got
+}
+
+func fallbackL2Response(req offloadL2Request) offloadL2Response {
+	now := time.Now().Format(time.RFC3339Nano)
+	existing := strings.TrimSpace(stripMermaidFence(req.ExistingMMD))
+	taskGoal := strings.TrimSpace(req.TaskLabel)
+	if taskGoal == "" {
+		taskGoal = "task"
+	}
+	mapping := make(map[string]string, len(req.NewEntries))
+	var b strings.Builder
+	if existing == "" {
+		b.WriteString(fmt.Sprintf(
+			"%%{ \"taskGoal\": %q, \"progress\": \"60\", \"createdTime\": %q, \"updatedTime\": %q }%%\n",
+			taskGoal,
+			now,
+			now,
+		))
+		b.WriteString("flowchart TD\n")
+	} else {
+		b.WriteString(existing)
+		if !strings.HasSuffix(existing, "\n") {
+			b.WriteString("\n")
+		}
+	}
+	startOrdinal := 1
+	if existing != "" {
+		startOrdinal = nextFallbackNodeOrdinal(existing, req.MMDPrefix)
+	}
+	for i, entry := range req.NewEntries {
+		ordinal := startOrdinal + i
+		nodeID := fmt.Sprintf("%s-N%d", req.MMDPrefix, ordinal)
+		mapping[entry.ToolCallID] = nodeID
+		b.WriteString(fmt.Sprintf(
+			"  %s[\"%s<br/>status: done<br/>summary: %s<br/>ref: %s<br/>Timestamp: %s\"]\n",
+			mermaidNodeID(nodeID),
+			escapeMermaidLabel(truncateRunes(entry.ToolCall, 80)),
+			escapeMermaidLabel(truncateRunes(entry.Summary, 120)),
+			escapeMermaidLabel(entry.ResultRef),
+			escapeMermaidLabel(entry.Timestamp),
+		))
+		if ordinal > 1 {
+			prev := fmt.Sprintf("%s-N%d", req.MMDPrefix, ordinal-1)
+			b.WriteString(fmt.Sprintf("  %s --> %s\n", mermaidNodeID(prev), mermaidNodeID(nodeID)))
+		}
+	}
+	return offloadL2Response{
+		FileAction:  "write",
+		MMDContent:  b.String(),
+		NodeMapping: mapping,
+	}
+}
+
+func nextFallbackNodeOrdinal(existing string, prefix string) int {
+	base := mermaidNodeID(fmt.Sprintf("%s-N", prefix))
+	re := regexp.MustCompile(regexp.QuoteMeta(base) + `(\d+)`)
+	maxOrdinal := 0
+	for _, match := range re.FindAllStringSubmatch(existing, -1) {
+		if len(match) < 2 {
+			continue
+		}
+		ordinal, err := strconv.Atoi(match[1])
+		if err == nil && ordinal > maxOrdinal {
+			maxOrdinal = ordinal
+		}
+	}
+	return maxOrdinal + 1
+}
+
+func normalizeL2Response(rsp offloadL2Response) offloadL2Response {
+	if rsp.FileAction == "" {
+		rsp.FileAction = "write"
+	}
+	if rsp.NodeMapping == nil {
+		rsp.NodeMapping = map[string]string{}
+	}
+	return rsp
+}
+
+func unmarshalExtractedJSON(raw string, target any) error {
+	raw = extractJSON(raw)
+	if raw == "" {
+		return errors.New("no JSON object found")
+	}
+	return json.Unmarshal([]byte(raw), target)
+}
+
+func extractJSON(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	if json.Valid([]byte(raw)) {
+		return raw
+	}
+	startObj := strings.Index(raw, "{")
+	startArr := strings.Index(raw, "[")
+	start := -1
+	endChar := byte('}')
+	if startObj >= 0 && (startArr < 0 || startObj < startArr) {
+		start = startObj
+		endChar = '}'
+	} else if startArr >= 0 {
+		start = startArr
+		endChar = ']'
+	}
+	if start < 0 {
+		return ""
+	}
+	end := strings.LastIndexByte(raw, endChar)
+	if end < start {
+		return ""
+	}
+	return raw[start : end+1]
+}
+
+func recentMessagesText(messages []model.Message, limit int) string {
+	if limit <= 0 {
+		limit = 6
+	}
+	start := len(messages) - limit
+	if start < 0 {
+		start = 0
+	}
+	var b strings.Builder
+	for _, msg := range messages[start:] {
+		text := offloadMessageText(msg)
+		if text == "" {
+			continue
+		}
+		b.WriteString("[")
+		b.WriteString(string(msg.Role))
+		b.WriteString("] ")
+		b.WriteString(truncateRunes(text, 500))
+		b.WriteByte('\n')
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func latestUserMessageText(messages []model.Message) string {
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Role == model.RoleUser {
+			return offloadMessageText(messages[i])
+		}
+	}
+	return ""
+}
+
+func offloadMessageText(msg model.Message) string {
+	if strings.TrimSpace(msg.Content) != "" {
+		return strings.TrimSpace(msg.Content)
+	}
+	var parts []string
+	for _, part := range msg.ContentParts {
+		if part.Text != nil {
+			parts = append(parts, *part.Text)
+		}
+	}
+	return strings.TrimSpace(strings.Join(parts, " "))
+}
+
+func offloadToolResultText(msg model.Message) string {
+	if msg.Content != "" {
+		return msg.Content
+	}
+	return offloadMessageText(msg)
+}
+
+func labelFromText(text string) string {
+	words := strings.Fields(strings.ToLower(text))
+	if len(words) == 0 {
+		return "task"
+	}
+	if len(words) > 5 {
+		words = words[:5]
+	}
+	return safeTaskLabel(strings.Join(words, "-"))
+}
+
+func truncateRunes(s string, max int) string {
+	if max <= 0 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	if max <= 3 {
+		return string(runes[:max])
+	}
+	return string(runes[:max-3]) + "..."
+}
+
+func mermaidNodeID(nodeID string) string {
+	nodeID = unsafeFilenameChars.ReplaceAllString(nodeID, "_")
+	nodeID = strings.Trim(nodeID, "_")
+	if nodeID == "" {
+		return "node"
+	}
+	if nodeID[0] >= '0' && nodeID[0] <= '9' {
+		return "n_" + nodeID
+	}
+	return nodeID
+}
+
+func escapeMermaidLabel(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	s = strings.ReplaceAll(s, "\r", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	return s
+}

--- a/memory/tencentdb/context_offload_storage.go
+++ b/memory/tencentdb/context_offload_storage.go
@@ -527,7 +527,7 @@ func parseMMDMeta(filename, content string) offloadMMDMeta {
 	}
 	if start := strings.Index(content, "%%{"); start >= 0 {
 		if end := strings.Index(content[start:], "}%%"); end >= 0 {
-			raw := strings.TrimSpace(content[start+3 : start+end+1])
+			raw := strings.TrimSpace(content[start+2 : start+end+1])
 			var parsed map[string]any
 			if json.Unmarshal([]byte(raw), &parsed) == nil {
 				if v, ok := parsed["taskGoal"].(string); ok {

--- a/memory/tencentdb/context_offload_storage.go
+++ b/memory/tencentdb/context_offload_storage.go
@@ -1,0 +1,746 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package tencentdb
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+const (
+	offloadBoundaryLong    = "long"
+	offloadBoundaryShort   = "short"
+	offloadBoundaryPending = "pending"
+	offloadWaitNodeID      = "wait"
+	offloadDirPerm         = 0o700
+	offloadFilePerm        = 0o600
+)
+
+type offloadStorageContext struct {
+	DataRoot     string
+	DataDir      string
+	RefsDir      string
+	MMDsDir      string
+	OffloadJSONL string
+	StateFile    string
+	Registry     string
+	AgentName    string
+	SessionID    string
+	SessionKey   string
+}
+
+type offloadIndexEntry struct {
+	Timestamp  string   `json:"timestamp"`
+	NodeID     *string  `json:"node_id"`
+	ToolCall   string   `json:"tool_call"`
+	Summary    string   `json:"summary"`
+	ResultRef  string   `json:"result_ref"`
+	ToolCallID string   `json:"tool_call_id"`
+	SessionKey string   `json:"session_key,omitempty"`
+	Score      float64  `json:"score,omitempty"`
+	Offloaded  any      `json:"offloaded,omitempty"`
+	Keywords   []string `json:"keywords,omitempty"`
+}
+
+type offloadToolPair struct {
+	ToolName   string
+	ToolCallID string
+	Params     string
+	Result     string
+	ResultRef  string
+	Timestamp  string
+}
+
+type offloadBoundary struct {
+	StartIndex int    `json:"start_index"`
+	Result     string `json:"result"`
+	TargetMMD  string `json:"target_mmd,omitempty"`
+}
+
+type offloadState struct {
+	ActiveMMDFile           string            `json:"active_mmd_file,omitempty"`
+	ActiveMMDID             string            `json:"active_mmd_id,omitempty"`
+	MMDCounter              int               `json:"mmd_counter,omitempty"`
+	LastSessionKey          string            `json:"last_session_key,omitempty"`
+	LastOffloadedToolCallID string            `json:"last_offloaded_tool_call_id,omitempty"`
+	LastL15JudgedToolCallID string            `json:"last_l15_judged_tool_call_id,omitempty"`
+	LastL2TriggerTime       string            `json:"last_l2_trigger_time,omitempty"`
+	L15Settled              bool              `json:"l15_settled,omitempty"`
+	Boundaries              []offloadBoundary `json:"boundaries,omitempty"`
+	ConfirmedOffloadIDs     []string          `json:"confirmed_offload_ids,omitempty"`
+	DeletedOffloadIDs       []string          `json:"deleted_offload_ids,omitempty"`
+	LastKnownTotalTokens    int               `json:"last_known_total_tokens,omitempty"`
+	LastKnownMessageCount   int               `json:"last_known_message_count,omitempty"`
+}
+
+type offloadMMDMeta struct {
+	Filename      string `json:"filename"`
+	Path          string `json:"path"`
+	TaskGoal      string `json:"taskGoal"`
+	DoneCount     int    `json:"doneCount"`
+	DoingCount    int    `json:"doingCount"`
+	TodoCount     int    `json:"todoCount"`
+	UpdatedTime   string `json:"updatedTime,omitempty"`
+	NodeSummaries []struct {
+		NodeID  string `json:"nodeId"`
+		Status  string `json:"status"`
+		Summary string `json:"summary"`
+	} `json:"nodeSummaries,omitempty"`
+}
+
+func newOffloadState() *offloadState {
+	return &offloadState{}
+}
+
+func (s *offloadState) addConfirmed(id string) {
+	s.ConfirmedOffloadIDs = addUniqueString(s.ConfirmedOffloadIDs, id)
+}
+
+func (s *offloadState) addDeleted(id string) {
+	s.DeletedOffloadIDs = addUniqueString(s.DeletedOffloadIDs, id)
+}
+
+func (s *offloadState) confirmedSet() map[string]struct{} {
+	return stringSet(s.ConfirmedOffloadIDs)
+}
+
+func (s *offloadState) deletedSet() map[string]struct{} {
+	return stringSet(s.DeletedOffloadIDs)
+}
+
+func addUniqueString(values []string, v string) []string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return values
+	}
+	for _, existing := range values {
+		if existing == v {
+			return values
+		}
+	}
+	return append(values, v)
+}
+
+func stringSet(values []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(values))
+	for _, v := range values {
+		if v != "" {
+			out[v] = struct{}{}
+		}
+	}
+	return out
+}
+
+func newOffloadStorageContext(
+	opts Options,
+	sess *session.Session,
+	agentName string,
+) offloadStorageContext {
+	root := strings.TrimSpace(opts.ContextOffload.DataDir)
+	if root == "" {
+		root = defaultContextOffloadDataDir
+	}
+	sessionKey := defaultSessionKeyWithFunc(opts, sess)
+	sessionID := "session"
+	if sess != nil && strings.TrimSpace(sess.ID) != "" {
+		sessionID = safeFilename(sess.ID)
+	} else if sessionKey != "" {
+		sessionID = safeFilename(base64.RawURLEncoding.EncodeToString([]byte(sessionKey)))
+	}
+	scope := safeScopeName(sess, agentName)
+	dataDir := filepath.Join(root, scope, sessionID)
+	return offloadStorageContext{
+		DataRoot:     root,
+		DataDir:      dataDir,
+		RefsDir:      filepath.Join(dataDir, "refs"),
+		MMDsDir:      filepath.Join(dataDir, "mmds"),
+		OffloadJSONL: filepath.Join(dataDir, "offload-"+sessionID+".jsonl"),
+		StateFile:    filepath.Join(dataDir, "state.json"),
+		Registry:     filepath.Join(dataDir, "sessions-registry.json"),
+		AgentName:    scope,
+		SessionID:    sessionID,
+		SessionKey:   sessionKey,
+	}
+}
+
+func defaultSessionKeyWithFunc(opts Options, sess *session.Session) string {
+	if opts.SessionKeyFunc != nil {
+		return opts.SessionKeyFunc(sess)
+	}
+	return defaultSessionKey(sess)
+}
+
+func safeScopeName(sess *session.Session, agentName string) string {
+	parts := []string{"agent"}
+	if sess != nil {
+		parts = append(parts, sess.AppName, sess.UserID)
+	}
+	parts = append(parts, agentName)
+	raw := strings.Join(parts, "_")
+	return safeFilename(raw)
+}
+
+var unsafeFilenameChars = regexp.MustCompile(`[^A-Za-z0-9_.-]+`)
+
+func safeFilename(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "session"
+	}
+	s = unsafeFilenameChars.ReplaceAllString(s, "_")
+	s = strings.Trim(s, "._-")
+	if s == "" {
+		return "session"
+	}
+	return s
+}
+
+func ensureOffloadDirs(ctx offloadStorageContext) error {
+	if err := os.MkdirAll(ctx.DataRoot, offloadDirPerm); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(ctx.DataDir, offloadDirPerm); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(ctx.RefsDir, offloadDirPerm); err != nil {
+		return err
+	}
+	return os.MkdirAll(ctx.MMDsDir, offloadDirPerm)
+}
+
+func registerOffloadSession(ctx offloadStorageContext) {
+	if ctx.SessionKey == "" || ctx.SessionID == "" {
+		return
+	}
+	registry := map[string]map[string]string{}
+	if b, err := os.ReadFile(ctx.Registry); err == nil {
+		_ = json.Unmarshal(b, &registry)
+	}
+	registry[ctx.SessionKey] = map[string]string{
+		"session_id":   ctx.SessionID,
+		"offload_file": filepath.Base(ctx.OffloadJSONL),
+		"updated_at":   time.Now().Format(time.RFC3339Nano),
+	}
+	b, err := json.MarshalIndent(registry, "", "  ")
+	if err == nil {
+		_ = os.WriteFile(ctx.Registry, b, offloadFilePerm)
+	}
+}
+
+func readOffloadState(ctx offloadStorageContext) (*offloadState, error) {
+	b, err := os.ReadFile(ctx.StateFile)
+	if errors.Is(err, os.ErrNotExist) {
+		return newOffloadState(), nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var state offloadState
+	if err := json.Unmarshal(b, &state); err != nil {
+		return nil, err
+	}
+	return &state, nil
+}
+
+func writeOffloadState(ctx offloadStorageContext, state *offloadState) error {
+	if state == nil {
+		return nil
+	}
+	if err := ensureOffloadDirs(ctx); err != nil {
+		return err
+	}
+	b, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(ctx.StateFile, b, offloadFilePerm)
+}
+
+func writeOffloadRef(
+	ctx offloadStorageContext,
+	call model.ToolCall,
+	msg model.Message,
+) (string, error) {
+	if msg.ToolID == "" {
+		return "", errors.New("tool id is required")
+	}
+	if err := ensureOffloadDirs(ctx); err != nil {
+		return "", err
+	}
+	now := time.Now()
+	resultText := offloadToolResultText(msg)
+	sum := sha256.Sum256([]byte(msg.ToolID + "\x00" + resultText))
+	refID := fmt.Sprintf(
+		"ref_%s_%s",
+		now.Format("20060102_150405_000000000"),
+		hex.EncodeToString(sum[:])[:12],
+	)
+	ref := filepath.ToSlash(filepath.Join("refs", refID+".md"))
+	path := filepath.Join(ctx.DataDir, filepath.FromSlash(ref))
+	entry := offloadIndexEntry{
+		Timestamp:  now.Format(time.RFC3339Nano),
+		ToolCall:   toolCallName(call, msg),
+		ResultRef:  ref,
+		ToolCallID: msg.ToolID,
+		SessionKey: ctx.SessionKey,
+	}
+	return ref, os.WriteFile(path, []byte(renderOffloadRef(entry, call, resultText)), offloadFilePerm)
+}
+
+func renderOffloadRef(
+	entry offloadIndexEntry,
+	call model.ToolCall,
+	content string,
+) string {
+	var b strings.Builder
+	b.WriteString("# Tool Result\n\n")
+	b.WriteString("- tool_call_id: " + entry.ToolCallID + "\n")
+	b.WriteString("- tool_name: " + entry.ToolCall + "\n")
+	b.WriteString("- timestamp: " + entry.Timestamp + "\n")
+	if entry.NodeID != nil {
+		b.WriteString("- node_id: " + *entry.NodeID + "\n")
+	}
+	b.WriteString("- result_ref: " + entry.ResultRef + "\n\n")
+	if len(call.Function.Arguments) > 0 {
+		b.WriteString("## Arguments\n\n```json\n")
+		b.Write(call.Function.Arguments)
+		b.WriteString("\n```\n\n")
+	}
+	b.WriteString("## Result\n\n")
+	b.WriteString(content)
+	if !strings.HasSuffix(content, "\n") {
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func appendOffloadEntries(ctx offloadStorageContext, entries []offloadIndexEntry) error {
+	if len(entries) == 0 {
+		return nil
+	}
+	if err := ensureOffloadDirs(ctx); err != nil {
+		return err
+	}
+	existing, err := readAllOffloadEntries(ctx)
+	if err != nil {
+		return err
+	}
+	seen := make(map[string]struct{}, len(existing))
+	for _, entry := range existing {
+		if entry.ToolCallID != "" {
+			seen[entry.ToolCallID] = struct{}{}
+		}
+	}
+	f, err := os.OpenFile(ctx.OffloadJSONL, os.O_CREATE|os.O_WRONLY|os.O_APPEND, offloadFilePerm)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	for _, entry := range entries {
+		if entry.ToolCallID == "" {
+			continue
+		}
+		if _, ok := seen[entry.ToolCallID]; ok {
+			continue
+		}
+		entry.SessionKey = ctx.SessionKey
+		b, err := json.Marshal(entry)
+		if err != nil {
+			return err
+		}
+		if _, err := f.Write(append(b, '\n')); err != nil {
+			return err
+		}
+		seen[entry.ToolCallID] = struct{}{}
+	}
+	return nil
+}
+
+func readAllOffloadEntries(ctx offloadStorageContext) ([]offloadIndexEntry, error) {
+	f, err := os.Open(ctx.OffloadJSONL)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	var entries []offloadIndexEntry
+	scanner := bufio.NewScanner(f)
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, 4*1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var entry offloadIndexEntry
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		if entry.ToolCallID == "" {
+			continue
+		}
+		entries = append(entries, entry)
+	}
+	return entries, scanner.Err()
+}
+
+func rewriteOffloadEntries(ctx offloadStorageContext, entries []offloadIndexEntry) error {
+	if err := ensureOffloadDirs(ctx); err != nil {
+		return err
+	}
+	var b strings.Builder
+	for _, entry := range entries {
+		line, err := json.Marshal(entry)
+		if err != nil {
+			return err
+		}
+		b.Write(line)
+		b.WriteByte('\n')
+	}
+	return os.WriteFile(ctx.OffloadJSONL, []byte(b.String()), offloadFilePerm)
+}
+
+func readRecentOffloadEntries(
+	ctx offloadStorageContext,
+	maxEntries int,
+) ([]offloadIndexEntry, error) {
+	entries, err := readAllOffloadEntries(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if maxEntries <= 0 {
+		maxEntries = defaultContextOffloadMaxEntries
+	}
+	if len(entries) > maxEntries {
+		entries = entries[len(entries)-maxEntries:]
+	}
+	return entries, nil
+}
+
+func readMMD(ctx offloadStorageContext, filename string) (string, error) {
+	path, err := safeMMDPath(ctx, filename)
+	if err != nil {
+		return "", err
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func writeMMD(ctx offloadStorageContext, filename, content string) error {
+	path, err := safeMMDPath(ctx, filename)
+	if err != nil {
+		return err
+	}
+	if err := ensureOffloadDirs(ctx); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(strings.TrimSpace(stripMermaidFence(content))+"\n"), offloadFilePerm)
+}
+
+func safeMMDPath(ctx offloadStorageContext, filename string) (string, error) {
+	cleaned := filepath.Base(safeFilename(filename))
+	if cleaned == "" || cleaned == "." {
+		return "", errors.New("invalid mmd filename")
+	}
+	if !strings.HasSuffix(cleaned, ".mmd") {
+		cleaned += ".mmd"
+	}
+	path := filepath.Join(ctx.MMDsDir, cleaned)
+	rel, err := filepath.Rel(filepath.Clean(ctx.MMDsDir), filepath.Clean(path))
+	if err != nil || rel == "." || strings.HasPrefix(rel, "..") {
+		return "", errors.New("invalid mmd filename")
+	}
+	return path, nil
+}
+
+func readActiveMMD(ctx offloadStorageContext, state *offloadState) (*offloadMMDContent, error) {
+	if state == nil || state.ActiveMMDFile == "" {
+		return nil, nil
+	}
+	content, err := readMMD(ctx, state.ActiveMMDFile)
+	if err != nil {
+		return nil, err
+	}
+	return &offloadMMDContent{
+		Filename: state.ActiveMMDFile,
+		Content:  content,
+		Path:     filepath.ToSlash(filepath.Join("mmds", state.ActiveMMDFile)),
+	}, nil
+}
+
+func listMMDMetas(ctx offloadStorageContext) ([]offloadMMDMeta, error) {
+	entries, err := os.ReadDir(ctx.MMDsDir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var metas []offloadMMDMeta
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".mmd") {
+			continue
+		}
+		content, err := readMMD(ctx, entry.Name())
+		if err != nil {
+			continue
+		}
+		metas = append(metas, parseMMDMeta(entry.Name(), content))
+	}
+	sort.Slice(metas, func(i, j int) bool {
+		return metas[i].UpdatedTime > metas[j].UpdatedTime
+	})
+	return metas, nil
+}
+
+func parseMMDMeta(filename, content string) offloadMMDMeta {
+	meta := offloadMMDMeta{
+		Filename: filename,
+		Path:     filepath.ToSlash(filepath.Join("mmds", filename)),
+		TaskGoal: strings.TrimSuffix(filename, ".mmd"),
+	}
+	if start := strings.Index(content, "%%{"); start >= 0 {
+		if end := strings.Index(content[start:], "}%%"); end >= 0 {
+			raw := strings.TrimSpace(content[start+3 : start+end+1])
+			var parsed map[string]any
+			if json.Unmarshal([]byte(raw), &parsed) == nil {
+				if v, ok := parsed["taskGoal"].(string); ok {
+					meta.TaskGoal = v
+				}
+				if v, ok := parsed["updatedTime"].(string); ok {
+					meta.UpdatedTime = v
+				}
+			}
+		}
+	}
+	meta.DoneCount = strings.Count(content, "status: done")
+	meta.DoingCount = strings.Count(content, "status: doing")
+	meta.TodoCount = strings.Count(content, "status: todo")
+	return meta
+}
+
+func applyL2Response(
+	ctx offloadStorageContext,
+	filename string,
+	rsp offloadL2Response,
+) error {
+	switch rsp.FileAction {
+	case "replace":
+		existing, err := readMMD(ctx, filename)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return writeMMD(ctx, filename, rsp.MMDContent)
+			}
+			return err
+		}
+		return writeMMD(ctx, filename, applyMMDReplaceBlocks(existing, rsp.ReplaceBlocks))
+	case "write", "":
+		return writeMMD(ctx, filename, rsp.MMDContent)
+	default:
+		return writeMMD(ctx, filename, rsp.MMDContent)
+	}
+}
+
+func applyMMDReplaceBlocks(existing string, blocks []offloadL2ReplaceBlock) string {
+	if len(blocks) == 0 {
+		return existing
+	}
+	ordered := append([]offloadL2ReplaceBlock(nil), blocks...)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		if ordered[i].StartLine == ordered[j].StartLine {
+			return ordered[i].EndLine > ordered[j].EndLine
+		}
+		return ordered[i].StartLine > ordered[j].StartLine
+	})
+	lines := strings.Split(existing, "\n")
+	for _, block := range ordered {
+		start := block.StartLine - 1
+		end := block.EndLine
+		if start < 0 {
+			start = 0
+		}
+		if end < start {
+			end = start
+		}
+		if start > len(lines) {
+			start = len(lines)
+		}
+		if end > len(lines) {
+			end = len(lines)
+		}
+		replacement := strings.Split(strings.TrimSpace(stripMermaidFence(block.Content)), "\n")
+		next := append([]string{}, lines[:start]...)
+		next = append(next, replacement...)
+		next = append(next, lines[end:]...)
+		lines = next
+	}
+	return strings.Join(lines, "\n")
+}
+
+func backfillOffloadNodeIDs(
+	ctx offloadStorageContext,
+	mapping map[string]string,
+	eligible []offloadIndexEntry,
+) error {
+	if len(mapping) == 0 && len(eligible) == 0 {
+		return nil
+	}
+	entries, err := readAllOffloadEntries(ctx)
+	if err != nil {
+		return err
+	}
+	fallback := ""
+	nodes := make([]string, 0, len(mapping))
+	for _, node := range mapping {
+		if node != "" {
+			nodes = append(nodes, node)
+		}
+	}
+	if len(nodes) > 0 {
+		sort.Strings(nodes)
+		fallback = nodes[0]
+	}
+	eligibleIDs := make(map[string]struct{}, len(eligible))
+	for _, entry := range eligible {
+		eligibleIDs[entry.ToolCallID] = struct{}{}
+	}
+	changed := false
+	for i := range entries {
+		if node, ok := mapping[entries[i].ToolCallID]; ok && node != "" {
+			entries[i].NodeID = stringPtr(node)
+			changed = true
+			continue
+		}
+		if _, ok := eligibleIDs[entries[i].ToolCallID]; ok && entries[i].NodeID == nil && fallback != "" {
+			entries[i].NodeID = stringPtr(fallback)
+			changed = true
+		}
+	}
+	if !changed {
+		return nil
+	}
+	return rewriteOffloadEntries(ctx, entries)
+}
+
+func (e offloadIndexEntry) displayNodeID() string {
+	if e.NodeID == nil || strings.TrimSpace(*e.NodeID) == "" {
+		return "pending"
+	}
+	return *e.NodeID
+}
+
+func stringPtr(s string) *string {
+	return &s
+}
+
+func stripMermaidFence(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "```mermaid")
+	s = strings.TrimPrefix(s, "```")
+	s = strings.TrimSuffix(s, "```")
+	return strings.TrimSpace(s)
+}
+
+func safeTaskLabel(label string) string {
+	label = strings.ToLower(strings.TrimSpace(label))
+	label = strings.ReplaceAll(label, "_", "-")
+	label = unsafeFilenameChars.ReplaceAllString(label, "-")
+	label = strings.Trim(label, "-.")
+	if label == "" {
+		return "task"
+	}
+	if len(label) > 40 {
+		label = label[:40]
+		label = strings.Trim(label, "-.")
+	}
+	return label
+}
+
+func mmdPrefixFromFile(filename string) string {
+	base := filepath.Base(filename)
+	if len(base) >= 3 {
+		prefix := base[:3]
+		if prefix[0] >= '0' && prefix[0] <= '9' &&
+			prefix[1] >= '0' && prefix[1] <= '9' &&
+			prefix[2] >= '0' && prefix[2] <= '9' {
+			return prefix
+		}
+	}
+	return "000"
+}
+
+func eligibleL2Entries(
+	state *offloadState,
+	entries []offloadIndexEntry,
+) []offloadIndexEntry {
+	if state == nil || state.ActiveMMDFile == "" {
+		return nil
+	}
+	var out []offloadIndexEntry
+	for _, entry := range entries {
+		if entry.NodeID != nil && *entry.NodeID != offloadWaitNodeID {
+			continue
+		}
+		if boundaryForEntry(state, entry, entries) != state.ActiveMMDFile {
+			continue
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+func boundaryForEntry(
+	state *offloadState,
+	entry offloadIndexEntry,
+	entries []offloadIndexEntry,
+) string {
+	if state == nil {
+		return ""
+	}
+	idx := -1
+	for i := range entries {
+		if entries[i].ToolCallID == entry.ToolCallID {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return ""
+	}
+	var chosen offloadBoundary
+	for _, boundary := range state.Boundaries {
+		if boundary.StartIndex <= idx && boundary.StartIndex >= chosen.StartIndex {
+			chosen = boundary
+		}
+	}
+	if chosen.Result != offloadBoundaryLong {
+		return ""
+	}
+	return chosen.TargetMMD
+}

--- a/memory/tencentdb/context_offload_test.go
+++ b/memory/tencentdb/context_offload_test.go
@@ -904,6 +904,202 @@ func TestContextOffloadStorage_ApplyL2MetadataAndIndexHelpers(t *testing.T) {
 	assert.Equal(t, "valid", stored[0].ToolCallID)
 }
 
+func TestContextOffloadStorage_ErrorAndBoundaryBranches(t *testing.T) {
+	opts := defaultOptions()
+	opts.ContextOffload.Enabled = true
+	opts.ContextOffload.DataDir = t.TempDir()
+	sess := &session.Session{AppName: "app", UserID: "user", ID: "sess"}
+	store := newOffloadStorageContext(opts, sess, "agent")
+	require.NoError(t, ensureOffloadDirs(store))
+
+	assert.Equal(t, []string{"x"}, addUniqueString([]string{"x"}, ""))
+	assert.Equal(t, []string{"x"}, addUniqueString([]string{"x"}, "x"))
+	assert.Equal(t, "session", safeFilename(""))
+	assert.Equal(t, "session", safeFilename("...---___"))
+	assert.Equal(t, "task", safeTaskLabel("..."))
+	assert.Equal(t, strings.Repeat("a", 39), safeTaskLabel(strings.Repeat("a", 39)+"."+strings.Repeat("b", 10)))
+	assert.Equal(t, "000", mmdPrefixFromFile("ab.mmd"))
+
+	defaultStore := newOffloadStorageContext(Options{}, nil, "")
+	assert.Equal(t, defaultContextOffloadDataDir, defaultStore.DataRoot)
+	assert.Equal(t, "session", defaultStore.SessionID)
+	assert.NotEmpty(t, defaultSessionKeyWithFunc(defaultOptions(), sess))
+	registerOffloadSession(offloadStorageContext{})
+
+	nodeID := "001-N1"
+	rendered := renderOffloadRef(
+		offloadIndexEntry{
+			ToolCallID: "call-node",
+			ToolCall:   "grep",
+			Timestamp:  "2026-06-12T00:00:00Z",
+			ResultRef:  "refs/node.md",
+			NodeID:     &nodeID,
+		},
+		model.ToolCall{
+			ID: "call-node",
+			Function: model.FunctionDefinitionParam{
+				Name:      "grep",
+				Arguments: []byte(`{"q":"context"}`),
+			},
+		},
+		"node payload",
+	)
+	assert.Contains(t, rendered, "- node_id: 001-N1")
+	assert.Contains(t, rendered, "## Arguments")
+
+	require.NoError(t, appendOffloadEntries(store, nil))
+	require.NoError(t, appendOffloadEntries(store, []offloadIndexEntry{
+		{},
+		{ToolCallID: "call-good", ToolCall: "grep", ResultRef: "refs/good.md"},
+	}))
+	entries, err := readRecentOffloadEntries(store, 0)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "call-good", entries[0].ToolCallID)
+	require.Error(t, appendOffloadEntries(store, []offloadIndexEntry{{
+		ToolCallID: "call-bad-json",
+		Offloaded:  make(chan int),
+	}}))
+	require.Error(t, rewriteOffloadEntries(store, []offloadIndexEntry{{
+		ToolCallID: "call-bad-json",
+		Offloaded:  make(chan int),
+	}}))
+
+	require.NoError(t, os.WriteFile(filepath.Join(store.MMDsDir, ".mmd"), []byte("broken"), offloadFilePerm))
+	metas, err := listMMDMetas(offloadStorageContext{MMDsDir: filepath.Join(t.TempDir(), "missing")})
+	require.NoError(t, err)
+	assert.Empty(t, metas)
+	metas, err = listMMDMetas(store)
+	require.NoError(t, err)
+	assert.Empty(t, metas)
+
+	mmdsFile := filepath.Join(t.TempDir(), "mmds-file")
+	require.NoError(t, os.WriteFile(mmdsFile, []byte("not a dir"), offloadFilePerm))
+	_, err = listMMDMetas(offloadStorageContext{MMDsDir: mmdsFile})
+	require.Error(t, err)
+	require.Error(t, applyL2Response(offloadStorageContext{MMDsDir: mmdsFile}, "001-task.mmd", offloadL2Response{
+		FileAction: "replace",
+	}))
+
+	assert.Equal(t, "same", applyMMDReplaceBlocks("same", nil))
+	assert.Equal(t, "ZERO\none\ntwo\nTAIL", applyMMDReplaceBlocks("one\ntwo", []offloadL2ReplaceBlock{
+		{StartLine: 99, EndLine: 200, Content: "TAIL"},
+		{StartLine: -2, EndLine: -5, Content: "ZERO"},
+	}))
+
+	require.NoError(t, appendOffloadEntries(store, []offloadIndexEntry{{
+		ToolCallID: "call-fallback",
+		ToolCall:   "grep",
+		ResultRef:  "refs/fallback.md",
+	}}))
+	require.NoError(t, backfillOffloadNodeIDs(store, map[string]string{"other": "001-N9"}, []offloadIndexEntry{{
+		ToolCallID: "call-fallback",
+	}}))
+	entries, err = readAllOffloadEntries(store)
+	require.NoError(t, err)
+	var fallbackNode *string
+	for _, entry := range entries {
+		if entry.ToolCallID == "call-fallback" {
+			fallbackNode = entry.NodeID
+			break
+		}
+	}
+	require.NotNil(t, fallbackNode)
+	assert.Equal(t, "001-N9", *fallbackNode)
+	require.NoError(t, backfillOffloadNodeIDs(store, nil, []offloadIndexEntry{{
+		ToolCallID: "call-fallback",
+	}}))
+	require.NoError(t, backfillOffloadNodeIDs(store, nil, nil))
+
+	blockedRoot := t.TempDir()
+	dataDirFile := filepath.Join(blockedRoot, "data-file")
+	require.NoError(t, os.WriteFile(dataDirFile, []byte("x"), offloadFilePerm))
+	blockedData := offloadStorageContext{
+		DataRoot:     blockedRoot,
+		DataDir:      dataDirFile,
+		RefsDir:      filepath.Join(dataDirFile, "refs"),
+		MMDsDir:      filepath.Join(dataDirFile, "mmds"),
+		OffloadJSONL: filepath.Join(dataDirFile, "offload.jsonl"),
+		StateFile:    filepath.Join(dataDirFile, "state.json"),
+	}
+	require.Error(t, ensureOffloadDirs(blockedData))
+	require.Error(t, writeOffloadState(blockedData, &offloadState{}))
+	_, err = writeOffloadRef(blockedData, model.ToolCall{ID: "call"}, model.NewToolMessage("call", "grep", "payload"))
+	require.Error(t, err)
+	require.Error(t, appendOffloadEntries(blockedData, []offloadIndexEntry{{ToolCallID: "call"}}))
+	require.Error(t, rewriteOffloadEntries(blockedData, []offloadIndexEntry{{ToolCallID: "call"}}))
+	require.Error(t, writeMMD(blockedData, "001-task.mmd", "flowchart TD"))
+
+	refsBlockedDir := filepath.Join(t.TempDir(), "data")
+	require.NoError(t, os.MkdirAll(refsBlockedDir, offloadDirPerm))
+	refsFile := filepath.Join(refsBlockedDir, "refs")
+	require.NoError(t, os.WriteFile(refsFile, []byte("x"), offloadFilePerm))
+	require.Error(t, ensureOffloadDirs(offloadStorageContext{
+		DataRoot: refsBlockedDir,
+		DataDir:  refsBlockedDir,
+		RefsDir:  refsFile,
+		MMDsDir:  filepath.Join(refsBlockedDir, "mmds"),
+	}))
+
+	notDir := filepath.Join(t.TempDir(), "not-dir")
+	require.NoError(t, os.WriteFile(notDir, []byte("x"), offloadFilePerm))
+	unreadableIndex := offloadStorageContext{OffloadJSONL: filepath.Join(notDir, "offload.jsonl")}
+	_, err = readAllOffloadEntries(unreadableIndex)
+	require.Error(t, err)
+	_, err = readRecentOffloadEntries(unreadableIndex, 1)
+	require.Error(t, err)
+	require.Error(t, backfillOffloadNodeIDs(unreadableIndex, map[string]string{"call": "001-N1"}, nil))
+
+	state := &offloadState{
+		ActiveMMDFile: "002-other.mmd",
+		Boundaries: []offloadBoundary{{
+			StartIndex: 0,
+			Result:     offloadBoundaryLong,
+			TargetMMD:  "001-task.mmd",
+		}},
+	}
+	assert.Empty(t, eligibleL2Entries(nil, []offloadIndexEntry{{ToolCallID: "call"}}))
+	assert.Empty(t, eligibleL2Entries(state, []offloadIndexEntry{{ToolCallID: "call"}}))
+	assert.Empty(t, boundaryForEntry(nil, offloadIndexEntry{ToolCallID: "call"}, nil))
+	assert.Empty(t, boundaryForEntry(&offloadState{Boundaries: []offloadBoundary{{StartIndex: 0, Result: offloadBoundaryShort}}},
+		offloadIndexEntry{ToolCallID: "call"}, []offloadIndexEntry{{ToolCallID: "call"}}))
+
+	p := &contextOffloadPlugin{opts: opts}
+	p.opts.ContextOffload.L0.MinToolResultBytes = 1
+	_, err = p.collectToolPairs(blockedData, &pluginpkg.AfterToolMessagesArgs{
+		ToolResultMessages: []model.Message{model.NewToolMessage("call", "grep", "payload")},
+	})
+	require.Error(t, err)
+	defaultPlugin := &contextOffloadPlugin{opts: opts}
+	defaultPlugin.opts.ContextOffload.L0.MinToolResultBytes = 0
+	pairs, err := defaultPlugin.collectToolPairs(store, nil)
+	require.NoError(t, err)
+	assert.Empty(t, pairs)
+	pairs, err = defaultPlugin.collectToolPairs(store, &pluginpkg.AfterToolMessagesArgs{
+		ToolResultMessages: []model.Message{model.NewToolMessage("call-small", "grep", "tiny")},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, pairs)
+	assert.Empty(t, defaultPlugin.summarizeToolPairs(context.Background(), nil, nil))
+	summaries := defaultPlugin.summarizeToolPairs(context.Background(), nil, []offloadToolPair{{
+		ToolName:   "grep",
+		ToolCallID: "call-summary",
+		Result:     "payload",
+		ResultRef:  "refs/summary.md",
+	}})
+	require.Len(t, summaries, 1)
+	assert.Equal(t, "call-summary", summaries[0].ToolCallID)
+	assert.Nil(t, replaceCurrentToolResults(
+		[]model.Message{model.NewToolMessage("call-original", "grep", "payload")},
+		[]offloadIndexEntry{{ToolCallID: "call-other"}},
+	))
+	_, err = currentInvocation(context.Background())
+	require.Error(t, err)
+	badInvocation := &agent.Invocation{Session: &session.Session{ID: "sess"}}
+	_, err = currentInvocation(agent.NewInvocationContext(context.Background(), badInvocation).Context)
+	require.Error(t, err)
+}
+
 func TestContextOffloadTools_ValidationTruncationAndSearch(t *testing.T) {
 	dataDir := t.TempDir()
 	svc, err := NewService(

--- a/memory/tencentdb/context_offload_test.go
+++ b/memory/tencentdb/context_offload_test.go
@@ -12,11 +12,14 @@ package tencentdb
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -600,6 +603,705 @@ func TestContextOffloadPlugin_L3DeletesOldOffloadedToolBlocks(t *testing.T) {
 	assert.Contains(t, req.Messages[0].Content, "<current_task_context>")
 }
 
+func TestBackendOffloadModelClient_RoundTripAndErrors(t *testing.T) {
+	var seenPaths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "Bearer secret", r.Header.Get("Authorization"))
+		seenPaths = append(seenPaths, r.URL.Path)
+
+		switch r.URL.Path {
+		case "/offload/v1/l1/summarize":
+			var req offloadL1Request
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+			assert.Equal(t, "recent", req.RecentMessages)
+			assert.Len(t, req.ToolPairs, 1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"entries":[{"tool_call":"grep","summary":"found","tool_call_id":"call-1","timestamp":"2026-06-12T00:00:00Z","score":8}]}`))
+		case "/offload/v1/l15/judge":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"taskCompleted":false,"isLongTask":true,"isContinuation":true,"continuationMmdFile":"001-task.mmd","newTaskLabel":"ignored"}`))
+		case "/offload/v1/l2/generate":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"fileAction":"replace","mmdContent":"flowchart TD","replaceBlocks":[{"startLine":1,"endLine":2,"content":"flowchart LR"}],"nodeMapping":{"call-1":"001-N1"}}`))
+		case "/bad-status":
+			http.Error(w, "backend unavailable", http.StatusServiceUnavailable)
+		case "/bad-json":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := &backendOffloadModelClient{
+		baseURL:    server.URL,
+		apiKey:     "secret",
+		httpClient: server.Client(),
+	}
+	entries, err := client.L1Summarize(context.Background(), offloadL1Request{
+		RecentMessages: "recent",
+		ToolPairs: []offloadToolPair{{
+			ToolName:   "grep",
+			ToolCallID: "call-1",
+		}},
+	})
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "found", entries[0].Summary)
+
+	judgment, err := client.L15Judge(context.Background(), offloadL15Request{})
+	require.NoError(t, err)
+	assert.True(t, judgment.IsContinuation)
+	assert.Equal(t, "001-task.mmd", judgment.ContinuationMMDFile)
+
+	l2, err := client.L2Generate(context.Background(), offloadL2Request{})
+	require.NoError(t, err)
+	assert.Equal(t, "replace", l2.FileAction)
+	assert.Equal(t, "flowchart TD", l2.MMDContent)
+	require.Len(t, l2.ReplaceBlocks, 1)
+	assert.Equal(t, 1, l2.ReplaceBlocks[0].StartLine)
+	assert.Equal(t, 2, l2.ReplaceBlocks[0].EndLine)
+	assert.Equal(t, "001-N1", l2.NodeMapping["call-1"])
+
+	err = client.post(context.Background(), "/bad-status", map[string]string{"x": "y"}, &struct{}{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "503")
+	assert.Contains(t, err.Error(), "backend unavailable")
+
+	err = client.post(context.Background(), "/bad-json", map[string]string{"x": "y"}, &struct{}{})
+	require.Error(t, err)
+
+	var nilClient *backendOffloadModelClient
+	require.ErrorIs(t, nilClient.post(context.Background(), "/x", nil, &struct{}{}), errOffloadModelUnavailable)
+	require.ErrorIs(t, (&backendOffloadModelClient{}).post(context.Background(), "/x", nil, &struct{}{}), errOffloadModelUnavailable)
+	require.Error(t, (&backendOffloadModelClient{baseURL: "://bad"}).post(context.Background(), "/x", nil, &struct{}{}))
+	assert.Contains(t, strings.Join(seenPaths, ","), "/offload/v1/l1/summarize")
+	assert.Contains(t, strings.Join(seenPaths, ","), "/offload/v1/l15/judge")
+	assert.Contains(t, strings.Join(seenPaths, ","), "/offload/v1/l2/generate")
+}
+
+func TestContextOffloadLLM_ParseNormalizeAndFormattingHelpers(t *testing.T) {
+	raw := `prefix
+[
+  {"toolCallId":"call-1","toolCall":{"name":"grep"},"summary":["found","matches"],"timestamp":"2026-06-12T00:00:00Z","score":7},
+  {"summary":"missing id"},
+  {"tool_call_id":"call-2","tool_call":"read_file","summary":"read summary","score":3}
+]
+suffix`
+	entries, err := parseL1Entries(raw)
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+	assert.Equal(t, "call-1", entries[0].ToolCallID)
+	assert.JSONEq(t, `{"name":"grep"}`, entries[0].ToolCall)
+	assert.JSONEq(t, `["found","matches"]`, entries[0].Summary)
+	assert.Equal(t, 7.0, entries[0].Score)
+	assert.Equal(t, "call-2", entries[1].ToolCallID)
+	assert.Equal(t, "read_file", entries[1].ToolCall)
+
+	_, err = parseL1Entries("no json here")
+	require.Error(t, err)
+	_, err = parseL1Entries("[")
+	require.Error(t, err)
+
+	item := map[string]any{
+		"string": " value ",
+		"object": map[string]any{
+			"k": "v",
+		},
+		"bad": make(chan int),
+		"int": 3,
+		"num": json.Number("4.5"),
+	}
+	assert.Equal(t, "value", stringField(item, "missing", "string"))
+	assert.Empty(t, stringField(item, "missing"))
+	assert.JSONEq(t, `{"k":"v"}`, flexibleStringField(item, "object"))
+	assert.NotEmpty(t, flexibleStringField(item, "bad"))
+	assert.Empty(t, flexibleStringField(item, "missing"))
+	assert.Equal(t, 3.0, numberField(item, "int"))
+	assert.Equal(t, 4.5, numberField(item, "num"))
+	assert.Zero(t, numberField(item, "missing"))
+
+	fallback := offloadTaskJudgment{IsLongTask: true, NewTaskLabel: "fallback-task"}
+	assert.Equal(t, fallback, normalizeTaskJudgment(offloadTaskJudgment{}, fallback))
+	got := normalizeTaskJudgment(offloadTaskJudgment{IsLongTask: true}, fallback)
+	assert.Equal(t, "fallback-task", got.NewTaskLabel)
+	assert.True(t, normalizeTaskJudgment(offloadTaskJudgment{TaskCompleted: true}, fallback).TaskCompleted)
+
+	assert.True(t, fallbackTaskJudgment(nil).TaskCompleted)
+	assert.True(t, fallbackTaskJudgment([]model.Message{model.NewUserMessage("what is context offload?")}).TaskCompleted)
+	long := fallbackTaskJudgment([]model.Message{model.NewUserMessage("please implement targeted tests")})
+	assert.True(t, long.IsLongTask)
+	assert.Contains(t, long.NewTaskLabel, "please-implement")
+
+	var l2 offloadL2Response
+	require.NoError(t, json.Unmarshal([]byte(`{"fileAction":"write","mmdContent":"flowchart TD","replaceBlocks":[{"startLine":2,"endLine":3,"content":"X"}],"nodeMapping":{"call":"node"}}`), &l2))
+	assert.Equal(t, "write", l2.FileAction)
+	assert.Equal(t, "flowchart TD", l2.MMDContent)
+	require.Len(t, l2.ReplaceBlocks, 1)
+	assert.Equal(t, 2, l2.ReplaceBlocks[0].StartLine)
+	assert.Equal(t, 3, l2.ReplaceBlocks[0].EndLine)
+	assert.Equal(t, "node", l2.NodeMapping["call"])
+
+	var target map[string]any
+	require.NoError(t, unmarshalExtractedJSON("before {\"ok\":true} after", &target))
+	assert.Equal(t, true, target["ok"])
+	require.Error(t, unmarshalExtractedJSON("nothing", &target))
+	require.Error(t, unmarshalExtractedJSON("{", &target))
+	assert.Equal(t, `{"a":1}`, extractJSON(`noise {"a":1} tail`))
+	assert.Equal(t, `[1,2]`, extractJSON(`noise [1,2] tail`))
+	assert.Empty(t, extractJSON("noise only"))
+	assert.Empty(t, extractJSON("noise [1,2"))
+
+	assert.Equal(t, "", truncateRunes("abcdef", 0))
+	assert.Equal(t, "ab", truncateRunes("abcdef", 2))
+	assert.Equal(t, "ab...", truncateRunes("abcdef", 5))
+	assert.Equal(t, "abc", truncateRunes("abc", 5))
+	assert.Equal(t, "node", mermaidNodeID("!!!"))
+	assert.Equal(t, "n_123_node", mermaidNodeID("123 node"))
+	assert.Equal(t, `a\\b\"c  d e`, escapeMermaidLabel("a\\b\"c\r\nd\ne"))
+}
+
+func TestContextOffloadStorage_ApplyL2MetadataAndIndexHelpers(t *testing.T) {
+	opts := defaultOptions()
+	opts.ContextOffload.Enabled = true
+	opts.ContextOffload.DataDir = t.TempDir()
+	opts.SessionKeyFunc = func(*session.Session) string { return "custom/session key" }
+	sess := &session.Session{AppName: "app*", UserID: "user", ID: ""}
+	store := newOffloadStorageContext(opts, sess, "agent:name")
+	assert.Contains(t, filepath.ToSlash(store.DataDir), "/agent_app__user_agent_name/")
+	assert.NotContains(t, filepath.ToSlash(store.DataDir), "custom/session key")
+	assert.Equal(t, "custom/session key", store.SessionKey)
+
+	registerOffloadSession(store)
+	require.NoFileExists(t, store.Registry)
+	require.NoError(t, ensureOffloadDirs(store))
+	registerOffloadSession(store)
+	assert.FileExists(t, store.Registry)
+
+	require.NoError(t, applyL2Response(store, "001-task.mmd", offloadL2Response{
+		FileAction: "write",
+		MMDContent: "```mermaid\n" +
+			"%%{ \"taskGoal\": \"task\", \"updatedTime\": \"2026-06-12T00:00:00Z\" }%%\n" +
+			"flowchart TD\n" +
+			"  A[\"old<br/>status: todo\"]\n" +
+			"```",
+	}))
+	mmd, err := readMMD(store, "001-task.mmd")
+	require.NoError(t, err)
+	assert.NotContains(t, mmd, "```")
+	assert.Contains(t, mmd, "status: todo")
+
+	require.NoError(t, applyL2Response(store, "001-task.mmd", offloadL2Response{
+		FileAction: "replace",
+		ReplaceBlocks: []offloadL2ReplaceBlock{{
+			StartLine: 3,
+			EndLine:   3,
+			Content:   `  A["new<br/>status: done"]`,
+		}},
+	}))
+	mmd, err = readMMD(store, "001-task.mmd")
+	require.NoError(t, err)
+	assert.Contains(t, mmd, "status: done")
+	assert.NotContains(t, mmd, "status: todo")
+
+	require.NoError(t, applyL2Response(store, "002-missing.mmd", offloadL2Response{
+		FileAction:  "replace",
+		MMDContent:  "flowchart TD\n  B[\"created<br/>status: doing\"]",
+		NodeMapping: map[string]string{"call-2": "002-N1"},
+	}))
+	mmd, err = readMMD(store, "002-missing.mmd")
+	require.NoError(t, err)
+	assert.Contains(t, mmd, "status: doing")
+
+	require.NoError(t, applyL2Response(store, "003-default", offloadL2Response{
+		FileAction:  "unexpected",
+		MMDContent:  "flowchart TD\n  C[\"created<br/>status: done\"]",
+		NodeMapping: map[string]string{"call-3": "003-N1"},
+	}))
+	assert.FileExists(t, filepath.Join(store.MMDsDir, "003-default.mmd"))
+
+	active, err := readActiveMMD(store, &offloadState{ActiveMMDFile: "001-task.mmd"})
+	require.NoError(t, err)
+	require.NotNil(t, active)
+	assert.Equal(t, "001-task.mmd", active.Filename)
+	assert.Equal(t, "mmds/001-task.mmd", active.Path)
+	emptyActive, err := readActiveMMD(store, nil)
+	require.NoError(t, err)
+	assert.Nil(t, emptyActive)
+
+	require.NoError(t, writeMMD(store, "004-meta.mmd",
+		"%%{ \"taskGoal\": \"meta task\", \"updatedTime\": \"2026-06-12T00:00:01Z\" }%%\n"+
+			"flowchart TD\n"+
+			"  D[\"done<br/>status: done\"]\n"+
+			"  E[\"doing<br/>status: doing\"]\n"+
+			"  F[\"todo<br/>status: todo\"]\n"))
+	require.NoError(t, os.WriteFile(filepath.Join(store.MMDsDir, "ignore.txt"), []byte("x"), offloadFilePerm))
+	metas, err := listMMDMetas(store)
+	require.NoError(t, err)
+	require.NotEmpty(t, metas)
+	var meta offloadMMDMeta
+	for _, got := range metas {
+		if got.Filename == "004-meta.mmd" {
+			meta = got
+			break
+		}
+	}
+	assert.Equal(t, "004-meta.mmd", meta.Filename)
+	assert.Equal(t, "meta task", meta.TaskGoal)
+	assert.Equal(t, 1, meta.DoneCount)
+	assert.Equal(t, 1, meta.DoingCount)
+	assert.Equal(t, 1, meta.TodoCount)
+
+	waitNode := offloadWaitNodeID
+	entries := []offloadIndexEntry{
+		{ToolCallID: "call-1", ToolCall: "grep", Summary: "summary one", ResultRef: "refs/1.md"},
+		{ToolCallID: "call-2", ToolCall: "read", Summary: "summary two", ResultRef: "refs/2.md", NodeID: &waitNode},
+	}
+	require.NoError(t, appendOffloadEntries(store, entries))
+	require.NoError(t, appendOffloadEntries(store, entries))
+	stored, err := readAllOffloadEntries(store)
+	require.NoError(t, err)
+	require.Len(t, stored, 2)
+	require.NoError(t, backfillOffloadNodeIDs(store, map[string]string{"call-1": "001-N1"}, entries))
+	stored, err = readAllOffloadEntries(store)
+	require.NoError(t, err)
+	require.NotNil(t, stored[0].NodeID)
+	assert.Equal(t, "001-N1", *stored[0].NodeID)
+	recent, err := readRecentOffloadEntries(store, 1)
+	require.NoError(t, err)
+	require.Len(t, recent, 1)
+	assert.Equal(t, "call-2", recent[0].ToolCallID)
+
+	state := &offloadState{
+		ActiveMMDFile: "001-task.mmd",
+		Boundaries: []offloadBoundary{{
+			StartIndex: 0,
+			Result:     offloadBoundaryLong,
+			TargetMMD:  "001-task.mmd",
+		}},
+	}
+	eligible := eligibleL2Entries(state, stored)
+	require.Len(t, eligible, 1)
+	assert.Equal(t, "call-2", eligible[0].ToolCallID)
+	assert.Empty(t, boundaryForEntry(state, offloadIndexEntry{ToolCallID: "missing"}, stored))
+
+	require.NoError(t, writeOffloadState(store, nil))
+	require.NoError(t, writeOffloadState(store, &offloadState{ActiveMMDFile: "001-task.mmd"}))
+	loaded, err := readOffloadState(store)
+	require.NoError(t, err)
+	assert.Equal(t, "001-task.mmd", loaded.ActiveMMDFile)
+	require.NoError(t, os.WriteFile(store.StateFile, []byte("{"), offloadFilePerm))
+	_, err = readOffloadState(store)
+	require.Error(t, err)
+
+	require.NoError(t, os.WriteFile(store.OffloadJSONL, []byte("\nnot-json\n{\"tool_call_id\":\"\"}\n{\"tool_call_id\":\"valid\"}\n"), offloadFilePerm))
+	stored, err = readAllOffloadEntries(store)
+	require.NoError(t, err)
+	require.Len(t, stored, 1)
+	assert.Equal(t, "valid", stored[0].ToolCallID)
+}
+
+func TestContextOffloadTools_ValidationTruncationAndSearch(t *testing.T) {
+	dataDir := t.TempDir()
+	svc, err := NewService(
+		WithGatewayURL("http://127.0.0.1:1"),
+		WithContextOffload(ContextOffloadConfig{
+			Enabled: true,
+			DataDir: dataDir,
+			L0: ContextOffloadL0Config{
+				MaxRefBytes: 4,
+			},
+		}),
+		WithConversationSearchTool(false),
+	)
+	require.NoError(t, err)
+	defer svc.Close()
+
+	sess := &session.Session{AppName: "app", UserID: "user", ID: "sess"}
+	inv := &agent.Invocation{InvocationID: "inv", AgentName: "agent", Session: sess}
+	ctx := agent.NewInvocationContext(context.Background(), inv).Context
+	store := newOffloadStorageContext(svc.opts, sess, inv.AgentName)
+	require.NoError(t, ensureOffloadDirs(store))
+	ref := "refs/large.md"
+	require.NoError(t, os.WriteFile(filepath.Join(store.DataDir, filepath.FromSlash(ref)), []byte("abcdef"), offloadFilePerm))
+
+	readTool := findCallableTool(t, svc.Tools(), "tdai_read_offload_ref")
+	_, err = readTool.Call(context.Background(), mustJSON(t, readOffloadRefToolRequest{ResultRef: ref}))
+	require.Error(t, err)
+	_, err = readTool.Call(ctx, mustJSON(t, readOffloadRefToolRequest{}))
+	require.Error(t, err)
+	_, err = readTool.Call(ctx, mustJSON(t, readOffloadRefToolRequest{ResultRef: "../secret"}))
+	require.Error(t, err)
+	raw, err := readTool.Call(ctx, mustJSON(t, readOffloadRefToolRequest{ResultRef: ref}))
+	require.NoError(t, err)
+	readRsp := raw.(*readOffloadRefToolResponse)
+	assert.Equal(t, "abcd", readRsp.Content)
+	assert.True(t, readRsp.Truncated)
+
+	nodeID := "001-N1"
+	require.NoError(t, appendOffloadEntries(store, []offloadIndexEntry{{
+		ToolCallID: "call-1",
+		ToolCall:   "grep",
+		Summary:    "summary",
+		ResultRef:  ref,
+		NodeID:     &nodeID,
+		Keywords:   []string{"needle"},
+		SessionKey: "session-only",
+	}}))
+	nodeTool := findCallableTool(t, svc.Tools(), "tdai_read_offload_node")
+	_, err = nodeTool.Call(ctx, mustJSON(t, readOffloadNodeToolRequest{}))
+	require.Error(t, err)
+	raw, err = nodeTool.Call(ctx, mustJSON(t, readOffloadNodeToolRequest{NodeID: nodeID}))
+	require.NoError(t, err)
+	nodeRsp := raw.(*readOffloadNodeToolResponse)
+	require.Len(t, nodeRsp.Entries, 1)
+	assert.Equal(t, "call-1", nodeRsp.Entries[0].ToolCallID)
+
+	searchTool := findCallableTool(t, svc.Tools(), "tdai_search_offload_index")
+	_, err = searchTool.Call(ctx, mustJSON(t, searchOffloadIndexToolRequest{}))
+	require.Error(t, err)
+	raw, err = searchTool.Call(ctx, mustJSON(t, searchOffloadIndexToolRequest{Query: "needle", Limit: 100}))
+	require.NoError(t, err)
+	searchRsp := raw.(*searchOffloadIndexToolResponse)
+	require.Len(t, searchRsp.Entries, 1)
+	assert.Equal(t, 1, searchRsp.Total)
+
+	assert.True(t, offloadEntryMatches(offloadIndexEntry{SessionKey: "session-only"}, "session-only"))
+	assert.False(t, offloadEntryMatches(offloadIndexEntry{ToolCall: "grep"}, "absent"))
+
+	path, err := svc.contextOffloadRefPath(sess, inv.AgentName, "refs/large.md")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(store.DataDir, "refs", "large.md"), path)
+	_, err = (*Service)(nil).contextOffloadRefPath(sess, inv.AgentName, "refs/large.md")
+	require.Error(t, err)
+}
+
+func TestInjectOffloadContextAndL3HelperBranches(t *testing.T) {
+	opts := defaultOptions()
+	opts.ContextOffload.Enabled = true
+	opts.ContextOffload.DataDir = t.TempDir()
+	opts.ContextOffload.L3.ContextWindow = 1234
+	store := newOffloadStorageContext(opts, &session.Session{AppName: "app", UserID: "user", ID: "sess"}, "agent")
+	require.NoError(t, writeMMD(store, "001-task.mmd", "flowchart TD\n  A[\"active<br/>status: doing\"]"))
+	req := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("base\n<current_task_context>old</current_task_context>"),
+		model.NewUserMessage("continue\n<current_task_context>old user</current_task_context>"),
+	}}
+	state := &offloadState{ActiveMMDFile: "001-task.mmd"}
+	require.NoError(t, injectOffloadContext(req, store, state, "flowchart TD\n  H[history]", opts))
+	require.Len(t, req.Messages, 2)
+	assert.Contains(t, req.Messages[0].Content, "base")
+	assert.Contains(t, req.Messages[0].Content, "Historical task context")
+	assert.Contains(t, req.Messages[0].Content, "Active task Mermaid file: 001-task.mmd")
+	assert.NotContains(t, req.Messages[0].Content, "old</current_task_context>")
+	assert.NotContains(t, req.Messages[1].Content, "<current_task_context>")
+
+	require.Error(t, injectOffloadContext(&model.Request{}, store, &offloadState{ActiveMMDFile: "missing.mmd"}, "", opts))
+	require.NoError(t, injectOffloadContext(nil, store, state, "", opts))
+	assert.Equal(t, "plain", stripCurrentTaskContext("plain"))
+	assert.Equal(t, "before\nafter", stripCurrentTaskContext("before\n<current_task_context>drop</current_task_context>\nafter"))
+
+	p := &contextOffloadPlugin{opts: opts}
+	assert.Equal(t, 1234, p.contextWindow())
+	assert.Equal(t, 0.25, p.ratioOrDefault(0.25, 0.5))
+	assert.Equal(t, 0.5, p.ratioOrDefault(0, 0.5))
+	assert.Equal(t, 0.5, p.ratioOrDefault(1, 0.5))
+
+	entry := offloadIndexEntry{
+		ToolCallID: "call-1",
+		ToolCall:   "grep",
+		Summary:    "summary",
+		ResultRef:  "refs/1.md",
+		Score:      9,
+	}
+	byID := map[string]offloadIndexEntry{"call-1": entry}
+	l3State := &offloadState{
+		ConfirmedOffloadIDs: []string{"call-1"},
+		DeletedOffloadIDs:   []string{"deleted"},
+	}
+	messages := []model.Message{
+		model.NewUserMessage("start"),
+		model.NewToolMessage("call-1", "grep", "raw payload"),
+		model.NewToolMessage("deleted", "grep", "deleted raw payload"),
+		model.NewToolMessage("missing", "grep", "missing raw payload"),
+	}
+	replaceConfirmedToolResults(messages, byID, l3State)
+	assert.Contains(t, messages[1].Content, "result_ref: refs/1.md")
+	assert.Equal(t, "deleted raw payload", messages[2].Content)
+	assert.Equal(t, "missing raw payload", messages[3].Content)
+	replaceConfirmedToolResults(messages, byID, l3State)
+	assert.Contains(t, messages[1].Content, "result_ref: refs/1.md")
+
+	l3State = newOffloadState()
+	messages = []model.Message{
+		model.NewToolMessage("call-1", "grep", "raw payload"),
+		model.NewToolMessage("low-score", "grep", "raw payload"),
+	}
+	mildReplaceByScore(messages, map[string]offloadIndexEntry{
+		"call-1":    entry,
+		"low-score": {ToolCallID: "low-score", Score: 1, ResultRef: "refs/low.md"},
+	}, l3State, 5)
+	assert.Contains(t, messages[0].Content, "refs/1.md")
+	assert.Equal(t, "raw payload", messages[1].Content)
+	assert.Contains(t, l3State.ConfirmedOffloadIDs, "call-1")
+
+	kept, deleted := deleteOldOffloadedToolBlocks(
+		[]model.Message{model.NewUserMessage("short")},
+		byID,
+		newOffloadState(),
+		1,
+		1,
+	)
+	require.Len(t, kept, 1)
+	assert.Empty(t, deleted)
+
+	assistantCall := model.Message{Role: model.RoleAssistant, ToolCalls: []model.ToolCall{{ID: "unknown"}}}
+	kept, deleted = deleteOldOffloadedToolBlocks(
+		[]model.Message{assistantCall, model.NewToolMessage("unknown", "grep", strings.Repeat("x", 200)), model.NewUserMessage("tail"), model.NewAssistantMessage("tail")},
+		byID,
+		newOffloadState(),
+		1,
+		1,
+	)
+	require.Len(t, kept, 4)
+	assert.Empty(t, deleted)
+}
+
+func TestContextOffloadPlugin_ControlFlowAndDecisionBranches(t *testing.T) {
+	var nilSvc *Service
+	nilSvcPlugin := nilSvc.ContextOffloadPlugin().(*contextOffloadPlugin)
+	assert.Equal(t, defaultContextOffloadDataDir, nilSvcPlugin.opts.ContextOffload.DataDir)
+
+	standalone := NewContextOffloadPlugin(nil, WithContextOffload(ContextOffloadConfig{
+		Enabled: true,
+		DataDir: "standalone",
+		Mode:    ContextOffloadModeCollect,
+	})).(*contextOffloadPlugin)
+	assert.True(t, standalone.opts.ContextOffload.Enabled)
+	assert.Equal(t, ContextOffloadModeCollect, standalone.opts.ContextOffload.Mode)
+
+	var nilPlugin *contextOffloadPlugin
+	nilPlugin.Register(nil)
+	res, err := nilPlugin.afterToolMessages(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Nil(t, res)
+	before, err := nilPlugin.beforeModel(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Nil(t, before)
+
+	opts := defaultOptions()
+	opts.ContextOffload.Enabled = true
+	opts.ContextOffload.DataDir = t.TempDir()
+	opts.ContextOffload.L0.MinToolResultBytes = 1
+	p := &contextOffloadPlugin{opts: opts}
+	sess := &session.Session{AppName: "app", UserID: "user", ID: "sess"}
+	inv := &agent.Invocation{InvocationID: "inv", AgentName: "agent", Session: sess}
+
+	res, err = p.afterToolMessages(context.Background(), &pluginpkg.AfterToolMessagesArgs{})
+	require.NoError(t, err)
+	assert.Nil(t, res)
+	res, err = p.afterToolMessages(context.Background(), &pluginpkg.AfterToolMessagesArgs{
+		Invocation: &agent.Invocation{Session: &session.Session{UserID: "user", ID: "sess"}},
+	})
+	require.NoError(t, err)
+	assert.Nil(t, res)
+	before, err = p.beforeModel(context.Background(), &model.BeforeModelArgs{Request: &model.Request{}})
+	require.NoError(t, err)
+	assert.Nil(t, before)
+	badCtx := agent.NewInvocationContext(context.Background(), &agent.Invocation{
+		Session: &session.Session{AppName: "app", UserID: "user"},
+	}).Context
+	before, err = p.beforeModel(badCtx, &model.BeforeModelArgs{Request: &model.Request{}})
+	require.NoError(t, err)
+	assert.Nil(t, before)
+
+	blockedRoot := filepath.Join(t.TempDir(), "not-dir")
+	require.NoError(t, os.WriteFile(blockedRoot, []byte("x"), offloadFilePerm))
+	blocked := &contextOffloadPlugin{opts: opts}
+	blocked.opts.ContextOffload.DataDir = blockedRoot
+	res, err = blocked.afterToolMessages(context.Background(), &pluginpkg.AfterToolMessagesArgs{Invocation: inv})
+	require.NoError(t, err)
+	assert.Nil(t, res)
+	before, err = blocked.beforeModel(
+		agent.NewInvocationContext(context.Background(), inv).Context,
+		&model.BeforeModelArgs{Request: &model.Request{}},
+	)
+	require.NoError(t, err)
+	assert.Nil(t, before)
+
+	store := newOffloadStorageContext(opts, sess, inv.AgentName)
+	require.NoError(t, ensureOffloadDirs(store))
+	require.NoError(t, os.WriteFile(store.StateFile, []byte("{"), offloadFilePerm))
+	res, err = p.afterToolMessages(context.Background(), &pluginpkg.AfterToolMessagesArgs{
+		Invocation: inv,
+	})
+	require.NoError(t, err)
+	assert.Nil(t, res)
+
+	_, err = p.collectToolPairs(store, &pluginpkg.AfterToolMessagesArgs{
+		ToolResultMessages: []model.Message{{
+			Role:    model.RoleTool,
+			Content: "large payload",
+		}},
+	})
+	require.Error(t, err)
+
+	require.NoError(t, os.Remove(store.StateFile))
+	pairs, err := p.collectToolPairs(store, &pluginpkg.AfterToolMessagesArgs{
+		ToolResultMessages: []model.Message{
+			model.NewToolMessage("call-missing", "fallback_tool", "large payload"),
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, pairs, 1)
+	assert.Equal(t, "fallback_tool", pairs[0].ToolName)
+	assert.Equal(t, "tool", toolCallName(model.ToolCall{}, model.Message{}))
+	assert.Contains(t, contextOffloadSessionDir(opts, sess), "sess")
+
+	appendSess := &session.Session{AppName: "app", UserID: "user", ID: "append"}
+	appendStore := newOffloadStorageContext(opts, appendSess, inv.AgentName)
+	require.NoError(t, ensureOffloadDirs(appendStore))
+	require.NoError(t, os.Mkdir(appendStore.OffloadJSONL, offloadDirPerm))
+	res, err = p.afterToolMessages(context.Background(), &pluginpkg.AfterToolMessagesArgs{
+		Invocation: &agent.Invocation{InvocationID: "inv", AgentName: inv.AgentName, Session: appendSess},
+		ToolCalls: []model.ToolCall{{
+			ID:       "call-append",
+			Function: model.FunctionDefinitionParam{Name: "grep"},
+		}},
+		ToolResultMessages: []model.Message{
+			model.NewToolMessage("call-append", "grep", "large payload"),
+		},
+		Messages: []model.Message{model.NewUserMessage("实现 append branch")},
+	})
+	require.NoError(t, err)
+	assert.Nil(t, res)
+
+	writeStateSess := &session.Session{AppName: "app", UserID: "user", ID: "state-dir"}
+	writeStateStore := newOffloadStorageContext(opts, writeStateSess, inv.AgentName)
+	require.NoError(t, ensureOffloadDirs(writeStateStore))
+	require.NoError(t, os.Mkdir(writeStateStore.StateFile, offloadDirPerm))
+	res, err = p.afterToolMessages(context.Background(), &pluginpkg.AfterToolMessagesArgs{
+		Invocation: &agent.Invocation{InvocationID: "inv", AgentName: inv.AgentName, Session: writeStateSess},
+		ToolCalls: []model.ToolCall{{
+			ID:       "call-state",
+			Function: model.FunctionDefinitionParam{Name: "grep"},
+		}},
+		ToolResultMessages: []model.Message{
+			model.NewToolMessage("call-state", "grep", "large payload"),
+		},
+		Messages: []model.Message{model.NewUserMessage("实现 state branch")},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	collectOpts := opts
+	collectOpts.ContextOffload.Mode = ContextOffloadModeCollect
+	collectPlugin := &contextOffloadPlugin{opts: collectOpts}
+	collectSess := &session.Session{AppName: "app", UserID: "user", ID: "collect"}
+	res, err = collectPlugin.afterToolMessages(context.Background(), &pluginpkg.AfterToolMessagesArgs{
+		Invocation: &agent.Invocation{InvocationID: "inv", AgentName: inv.AgentName, Session: collectSess},
+		ToolCalls: []model.ToolCall{{
+			ID:       "call-collect",
+			Function: model.FunctionDefinitionParam{Name: "grep"},
+		}},
+		ToolResultMessages: []model.Message{
+			model.NewToolMessage("call-collect", "grep", "large payload"),
+		},
+		Messages: []model.Message{model.NewUserMessage("实现 collect branch")},
+	})
+	require.NoError(t, err)
+	assert.Nil(t, res)
+
+	modelErrPlugin := &contextOffloadPlugin{opts: opts}
+	modelErrPlugin.opts.ContextOffload.Model = &errorOffloadModel{}
+	entries := modelErrPlugin.summarizeToolPairBatch(context.Background(), nil, []offloadToolPair{{
+		ToolName:   "grep",
+		ToolCallID: "call-error",
+		Result:     "fallback payload",
+		ResultRef:  "refs/error.md",
+	}})
+	require.Len(t, entries, 1)
+	assert.Equal(t, "call-error", entries[0].ToolCallID)
+
+	assert.IsType(t, &localOffloadModelClient{}, p.newOffloadModelClient())
+	backendPlugin := &contextOffloadPlugin{opts: opts}
+	backendPlugin.opts.ContextOffload.Mode = ContextOffloadModeBackend
+	assert.Nil(t, backendPlugin.newOffloadModelClient())
+	backendPlugin.opts.ContextOffload.Backend.URL = " http://127.0.0.1:9999/ "
+	assert.IsType(t, &backendOffloadModelClient{}, backendPlugin.newOffloadModelClient())
+	assert.Nil(t, collectPlugin.newOffloadModelClient())
+
+	require.NoError(t, p.advanceOffloadState(context.Background(), store, nil, nil))
+	emptyStore := newOffloadStorageContext(opts, &session.Session{AppName: "app", UserID: "user", ID: "empty"}, inv.AgentName)
+	require.NoError(t, ensureOffloadDirs(emptyStore))
+	require.NoError(t, p.advanceOffloadState(context.Background(), emptyStore, newOffloadState(), nil))
+	badIndexStore := newOffloadStorageContext(opts, &session.Session{AppName: "app", UserID: "user", ID: "bad-index"}, inv.AgentName)
+	require.NoError(t, ensureOffloadDirs(badIndexStore))
+	require.NoError(t, os.Mkdir(badIndexStore.OffloadJSONL, offloadDirPerm))
+	require.Error(t, p.advanceOffloadState(context.Background(), badIndexStore, newOffloadState(), nil))
+
+	shortState := &offloadState{ActiveMMDFile: "old.mmd", ActiveMMDID: "old"}
+	shortEntries := []offloadIndexEntry{{ToolCallID: "call-short"}}
+	require.NoError(t, p.ensureTaskBoundary(
+		context.Background(),
+		store,
+		shortState,
+		[]model.Message{model.NewUserMessage("what is context offload?")},
+		shortEntries,
+	))
+	require.Len(t, shortState.Boundaries, 1)
+	assert.Equal(t, offloadBoundaryShort, shortState.Boundaries[0].Result)
+	assert.Empty(t, shortState.ActiveMMDFile)
+	assert.Equal(t, -1, firstUnjudgedBoundaryStart(shortState, shortEntries))
+	assert.Equal(t, -1, nextBoundaryStart(&offloadState{
+		Boundaries: []offloadBoundary{{StartIndex: 1}},
+	}, shortEntries))
+
+	l2Store := newOffloadStorageContext(opts, &session.Session{AppName: "app", UserID: "user", ID: "l2"}, inv.AgentName)
+	require.NoError(t, ensureOffloadDirs(l2Store))
+	run, err := p.shouldRunL2(l2Store, &offloadState{}, nil)
+	require.NoError(t, err)
+	assert.False(t, run)
+	run, err = p.shouldRunL2(l2Store, &offloadState{ActiveMMDFile: "missing.mmd"}, []offloadIndexEntry{{ToolCallID: "call-l2"}})
+	require.NoError(t, err)
+	assert.True(t, run)
+	require.NoError(t, writeMMD(l2Store, "001-active.mmd", "flowchart TD"))
+	l2State := &offloadState{ActiveMMDFile: "001-active.mmd"}
+	l2Entry := offloadIndexEntry{ToolCallID: "call-l2", NodeID: stringPtr(offloadWaitNodeID)}
+	p.opts.ContextOffload.L2.NullThreshold = 10
+	run, err = p.shouldRunL2(l2Store, l2State, []offloadIndexEntry{l2Entry})
+	require.NoError(t, err)
+	assert.False(t, run)
+	l2State.LastL2TriggerTime = "not-a-time"
+	run, err = p.shouldRunL2(l2Store, l2State, []offloadIndexEntry{l2Entry})
+	require.NoError(t, err)
+	assert.True(t, run)
+	l2State.LastL2TriggerTime = time.Now().Add(-time.Hour).Format(time.RFC3339Nano)
+	p.opts.ContextOffload.L2.Timeout = time.Nanosecond
+	run, err = p.shouldRunL2(l2Store, l2State, []offloadIndexEntry{l2Entry})
+	require.NoError(t, err)
+	assert.True(t, run)
+
+	require.NoError(t, p.maybeRunL2(context.Background(), l2Store, &offloadState{}, nil, nil))
+	require.NoError(t, p.maybeRunL2(context.Background(), l2Store, &offloadState{ActiveMMDFile: "001-active.mmd"}, nil, []offloadIndexEntry{{
+		ToolCallID: "done",
+		NodeID:     stringPtr("001-N1"),
+	}}))
+	p.opts.ContextOffload.L2.Timeout = defaultContextOffloadL2Timeout
+	noRunState := &offloadState{
+		ActiveMMDFile: "001-active.mmd",
+		Boundaries: []offloadBoundary{{
+			StartIndex: 0,
+			Result:     offloadBoundaryLong,
+			TargetMMD:  "001-active.mmd",
+		}},
+	}
+	require.NoError(t, p.maybeRunL2(context.Background(), l2Store, noRunState, nil, []offloadIndexEntry{l2Entry}))
+}
+
 type scriptedOffloadModel struct{}
 
 func (m *scriptedOffloadModel) GenerateContent(
@@ -713,6 +1415,19 @@ func (m *boundarySwitchOffloadModel) GenerateContent(
 
 func (m *boundarySwitchOffloadModel) Info() model.Info {
 	return model.Info{Name: "boundary-switch-offload", ContextWindow: 200000}
+}
+
+type errorOffloadModel struct{}
+
+func (m *errorOffloadModel) GenerateContent(
+	context.Context,
+	*model.Request,
+) (<-chan *model.Response, error) {
+	return nil, assert.AnError
+}
+
+func (m *errorOffloadModel) Info() model.Info {
+	return model.Info{Name: "error-offload", ContextWindow: 200000}
 }
 
 func findCallableTool(t *testing.T, tools []tool.Tool, name string) tool.CallableTool {

--- a/memory/tencentdb/context_offload_test.go
+++ b/memory/tencentdb/context_offload_test.go
@@ -1,0 +1,741 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package tencentdb
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	pluginpkg "trpc.group/trpc-go/trpc-agent-go/plugin"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+func TestContextOffloadPlugin_ExternalizesToolResultAndInjectsMMD(t *testing.T) {
+	dataDir := t.TempDir()
+	svc, err := NewService(
+		WithGatewayURL("http://127.0.0.1:1"),
+		WithContextOffload(ContextOffloadConfig{
+			Enabled: true,
+			DataDir: dataDir,
+			L0: ContextOffloadL0Config{
+				MinToolResultBytes: 10,
+			},
+		}),
+		WithConversationSearchTool(false),
+	)
+	require.NoError(t, err)
+	defer svc.Close()
+
+	mgr := pluginpkg.MustNewManager(svc.ContextOffloadPlugin())
+	sess := &session.Session{AppName: "app", UserID: "user", ID: "sess"}
+	inv := &agent.Invocation{
+		InvocationID: "inv",
+		AgentName:    "agent",
+		Session:      sess,
+		Plugins:      mgr,
+	}
+	rawResult := strings.Repeat("payload ", 20)
+	msg := model.NewToolMessage("call-1", "search_docs", rawResult)
+	result, err := mgr.AfterToolMessages(context.Background(), &pluginpkg.AfterToolMessagesArgs{
+		Invocation: inv,
+		Request: &model.Request{Messages: []model.Message{
+			model.NewUserMessage("search docs"),
+		}},
+		ToolCallResponse: &model.Response{Choices: []model.Choice{{
+			Message: model.Message{
+				Role: model.RoleAssistant,
+				ToolCalls: []model.ToolCall{{
+					ID: "call-1",
+					Function: model.FunctionDefinitionParam{
+						Name:      "search_docs",
+						Arguments: []byte(`{"query":"context offload"}`),
+					},
+				}},
+			},
+		}}},
+		ToolCalls: []model.ToolCall{{
+			ID: "call-1",
+			Function: model.FunctionDefinitionParam{
+				Name:      "search_docs",
+				Arguments: []byte(`{"query":"context offload"}`),
+			},
+		}},
+		ToolResultMessages: []model.Message{msg},
+		Messages:           []model.Message{model.NewUserMessage("search docs"), msg},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.ToolResultMessages, 1)
+	assert.Contains(t, result.ToolResultMessages[0].Content, "result_ref: refs/")
+	assert.Contains(t, result.ToolResultMessages[0].Content, "node_id:")
+	assert.NotContains(t, result.ToolResultMessages[0].Content, rawResult)
+
+	store := newOffloadStorageContext(svc.opts, sess, inv.AgentName)
+	entries, err := readRecentOffloadEntries(store, svc.opts.ContextOffload.MaxEntries)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Contains(t, entries[0].ToolCall, "search_docs")
+	assert.Equal(t, "call-1", entries[0].ToolCallID)
+	assert.Contains(t, entries[0].Summary, "payload")
+
+	root := contextOffloadSessionDirForAgent(svc.opts, sess, inv.AgentName)
+	refBytes, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(entries[0].ResultRef)))
+	require.NoError(t, err)
+	assert.Contains(t, string(refBytes), rawResult)
+	state, err := readOffloadState(store)
+	require.NoError(t, err)
+	require.NotEmpty(t, state.ActiveMMDFile)
+	assert.FileExists(t, filepath.Join(root, "mmds", state.ActiveMMDFile))
+
+	callbacks := mgr.ModelCallbacks()
+	require.NotNil(t, callbacks)
+	req := &model.Request{Messages: []model.Message{model.NewUserMessage("continue")}}
+	ctx := agent.NewInvocationContext(context.Background(), inv).Context
+	_, err = callbacks.BeforeModel[0](ctx, &model.BeforeModelArgs{Request: req})
+	require.NoError(t, err)
+	require.NotEmpty(t, req.Messages)
+	assert.Contains(t, req.Messages[0].Content, "<current_task_context>")
+	assert.Contains(t, req.Messages[0].Content, "```mermaid")
+	assert.Contains(t, req.Messages[0].Content, entries[0].ResultRef)
+
+	readTool := findCallableTool(t, svc.Tools(), "tdai_read_offload_ref")
+	raw, err := readTool.Call(ctx, mustJSON(t, readOffloadRefToolRequest{ResultRef: entries[0].ResultRef}))
+	require.NoError(t, err)
+	readRsp := raw.(*readOffloadRefToolResponse)
+	assert.Equal(t, entries[0].ResultRef, readRsp.ResultRef)
+	assert.Contains(t, readRsp.Content, rawResult)
+	assert.False(t, readRsp.Truncated)
+}
+
+func TestContextOffloadPlugin_DisabledByDefault(t *testing.T) {
+	svc, err := NewService(
+		WithGatewayURL("http://127.0.0.1:1"),
+		WithConversationSearchTool(false),
+	)
+	require.NoError(t, err)
+	defer svc.Close()
+
+	mgr := pluginpkg.MustNewManager(svc.ContextOffloadPlugin())
+	assert.Nil(t, mgr.ModelCallbacks())
+	_, err = mgr.AfterToolMessages(context.Background(), &pluginpkg.AfterToolMessagesArgs{})
+	require.NoError(t, err)
+	assert.Nil(t, findTool(svc.Tools(), "tdai_read_offload_ref"))
+}
+
+func TestContextOffloadPlugin_UsesModelL1L15L2AndNodeTools(t *testing.T) {
+	dataDir := t.TempDir()
+	offloadModel := &scriptedOffloadModel{}
+	svc, err := NewService(
+		WithGatewayURL("http://127.0.0.1:1"),
+		WithContextOffload(ContextOffloadConfig{
+			Enabled: true,
+			DataDir: dataDir,
+			Model:   offloadModel,
+			L0: ContextOffloadL0Config{
+				MinToolResultBytes: 10,
+			},
+			L2: ContextOffloadL2Config{
+				NullThreshold: 1,
+			},
+		}),
+		WithConversationSearchTool(false),
+	)
+	require.NoError(t, err)
+	defer svc.Close()
+
+	mgr := pluginpkg.MustNewManager(svc.ContextOffloadPlugin())
+	sess := &session.Session{AppName: "app", UserID: "user", ID: "sess"}
+	inv := &agent.Invocation{
+		InvocationID: "inv",
+		AgentName:    "agent",
+		Session:      sess,
+		Plugins:      mgr,
+	}
+	rawResult := strings.Repeat("model payload ", 20)
+	msg := model.NewToolMessage("call-model", "grep", rawResult)
+	result, err := mgr.AfterToolMessages(context.Background(), &pluginpkg.AfterToolMessagesArgs{
+		Invocation: inv,
+		Request: &model.Request{Messages: []model.Message{
+			model.NewUserMessage("实现 context offload"),
+		}},
+		ToolCalls: []model.ToolCall{{
+			ID: "call-model",
+			Function: model.FunctionDefinitionParam{
+				Name:      "grep",
+				Arguments: []byte(`{"pattern":"offload"}`),
+			},
+		}},
+		ToolResultMessages: []model.Message{msg},
+		Messages: []model.Message{
+			model.NewUserMessage("实现 context offload"),
+			msg,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Contains(t, result.ToolResultMessages[0].Content, "模型摘要")
+
+	store := newOffloadStorageContext(svc.opts, sess, inv.AgentName)
+	entries, err := readAllOffloadEntries(store)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "模型摘要", entries[0].Summary)
+	assert.Equal(t, 9.0, entries[0].Score)
+	require.NotNil(t, entries[0].NodeID)
+	assert.Equal(t, "123-N1", *entries[0].NodeID)
+
+	state, err := readOffloadState(store)
+	require.NoError(t, err)
+	mmd, err := readMMD(store, state.ActiveMMDFile)
+	require.NoError(t, err)
+	assert.Contains(t, mmd, "模型节点")
+
+	ctx := agent.NewInvocationContext(context.Background(), inv).Context
+	nodeTool := findCallableTool(t, svc.Tools(), "tdai_read_offload_node")
+	raw, err := nodeTool.Call(ctx, mustJSON(t, readOffloadNodeToolRequest{NodeID: "123-N1"}))
+	require.NoError(t, err)
+	nodeRsp := raw.(*readOffloadNodeToolResponse)
+	require.Len(t, nodeRsp.Entries, 1)
+	assert.Equal(t, "call-model", nodeRsp.Entries[0].ToolCallID)
+
+	searchTool := findCallableTool(t, svc.Tools(), "tdai_search_offload_index")
+	raw, err = searchTool.Call(ctx, mustJSON(t, searchOffloadIndexToolRequest{Query: "模型摘要"}))
+	require.NoError(t, err)
+	searchRsp := raw.(*searchOffloadIndexToolResponse)
+	require.Len(t, searchRsp.Entries, 1)
+	assert.Equal(t, "call-model", searchRsp.Entries[0].ToolCallID)
+}
+
+func TestContextOffloadStorage_IsScopedBySession(t *testing.T) {
+	dataDir := t.TempDir()
+	svc, err := NewService(
+		WithGatewayURL("http://127.0.0.1:1"),
+		WithContextOffload(ContextOffloadConfig{
+			Enabled: true,
+			DataDir: dataDir,
+		}),
+		WithConversationSearchTool(false),
+	)
+	require.NoError(t, err)
+	defer svc.Close()
+
+	sessA := &session.Session{AppName: "app", UserID: "user", ID: "sess-a"}
+	sessB := &session.Session{AppName: "app", UserID: "user", ID: "sess-b"}
+	storeA := newOffloadStorageContext(svc.opts, sessA, "agent")
+	storeB := newOffloadStorageContext(svc.opts, sessB, "agent")
+
+	require.NotEqual(t, storeA.DataDir, storeB.DataDir)
+	assert.Contains(t, filepath.ToSlash(storeA.DataDir), "/sess-a")
+	assert.Contains(t, filepath.ToSlash(storeB.DataDir), "/sess-b")
+	assert.NotEqual(t, storeA.StateFile, storeB.StateFile)
+	assert.NotEqual(t, storeA.MMDsDir, storeB.MMDsDir)
+}
+
+func TestContextOffloadPlugin_L15JudgesLaterTaskBoundaries(t *testing.T) {
+	dataDir := t.TempDir()
+	offloadModel := &boundarySwitchOffloadModel{}
+	svc, err := NewService(
+		WithGatewayURL("http://127.0.0.1:1"),
+		WithContextOffload(ContextOffloadConfig{
+			Enabled: true,
+			DataDir: dataDir,
+			Model:   offloadModel,
+			L0: ContextOffloadL0Config{
+				MinToolResultBytes: 10,
+			},
+			L2: ContextOffloadL2Config{
+				NullThreshold: 1,
+			},
+		}),
+		WithConversationSearchTool(false),
+	)
+	require.NoError(t, err)
+	defer svc.Close()
+
+	mgr := pluginpkg.MustNewManager(svc.ContextOffloadPlugin())
+	sess := &session.Session{AppName: "app", UserID: "user", ID: "sess"}
+	inv := &agent.Invocation{InvocationID: "inv", AgentName: "agent", Session: sess, Plugins: mgr}
+
+	for _, tc := range []struct {
+		id      string
+		tool    string
+		content string
+		user    string
+	}{
+		{id: "call-a", tool: "grep", content: strings.Repeat("task a payload ", 20), user: "实现任务 A"},
+		{id: "call-b", tool: "grep", content: strings.Repeat("task b payload ", 20), user: "实现任务 B"},
+	} {
+		msg := model.NewToolMessage(tc.id, tc.tool, tc.content)
+		_, err := mgr.AfterToolMessages(context.Background(), &pluginpkg.AfterToolMessagesArgs{
+			Invocation: inv,
+			Request: &model.Request{Messages: []model.Message{
+				model.NewUserMessage(tc.user),
+			}},
+			ToolCalls: []model.ToolCall{{
+				ID: tc.id,
+				Function: model.FunctionDefinitionParam{
+					Name:      tc.tool,
+					Arguments: []byte(`{"pattern":"offload"}`),
+				},
+			}},
+			ToolResultMessages: []model.Message{msg},
+			Messages: []model.Message{
+				model.NewUserMessage(tc.user),
+				msg,
+			},
+		})
+		require.NoError(t, err)
+	}
+
+	store := newOffloadStorageContext(svc.opts, sess, inv.AgentName)
+	state, err := readOffloadState(store)
+	require.NoError(t, err)
+	require.Len(t, state.Boundaries, 2)
+	assert.Equal(t, 0, state.Boundaries[0].StartIndex)
+	assert.Contains(t, state.Boundaries[0].TargetMMD, "task-a")
+	assert.Equal(t, 1, state.Boundaries[1].StartIndex)
+	assert.Contains(t, state.Boundaries[1].TargetMMD, "task-b")
+	assert.Contains(t, state.ActiveMMDFile, "task-b")
+	assert.Equal(t, "call-b", state.LastL15JudgedToolCallID)
+}
+
+func TestContextOffloadPlugin_CollectsAllPairsBeyondBatchLimit(t *testing.T) {
+	dataDir := t.TempDir()
+	svc, err := NewService(
+		WithGatewayURL("http://127.0.0.1:1"),
+		WithContextOffload(ContextOffloadConfig{
+			Enabled: true,
+			DataDir: dataDir,
+			L0: ContextOffloadL0Config{
+				MinToolResultBytes: 1,
+			},
+			L1: ContextOffloadL1Config{
+				MaxPairsPerBatch: 1,
+			},
+		}),
+		WithConversationSearchTool(false),
+	)
+	require.NoError(t, err)
+	defer svc.Close()
+
+	p := svc.ContextOffloadPlugin().(*contextOffloadPlugin)
+	sess := &session.Session{AppName: "app", UserID: "user", ID: "sess"}
+	store := newOffloadStorageContext(svc.opts, sess, "agent")
+	require.NoError(t, ensureOffloadDirs(store))
+
+	pairs, err := p.collectToolPairs(store, &pluginpkg.AfterToolMessagesArgs{
+		ToolCalls: []model.ToolCall{
+			{ID: "call-1", Function: model.FunctionDefinitionParam{Name: "read_file"}},
+			{ID: "call-2", Function: model.FunctionDefinitionParam{Name: "grep"}},
+		},
+		ToolResultMessages: []model.Message{
+			model.NewToolMessage("call-1", "read_file", "payload 1"),
+			model.NewToolMessage("call-2", "grep", "payload 2"),
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, pairs, 2)
+
+	entries := p.summarizeToolPairs(context.Background(), nil, pairs)
+	require.Len(t, entries, 2)
+	assert.Equal(t, "call-1", entries[0].ToolCallID)
+	assert.Equal(t, "call-2", entries[1].ToolCallID)
+}
+
+func TestContextOffloadPlugin_CollectsToolResultContentParts(t *testing.T) {
+	dataDir := t.TempDir()
+	svc, err := NewService(
+		WithGatewayURL("http://127.0.0.1:1"),
+		WithContextOffload(ContextOffloadConfig{
+			Enabled: true,
+			DataDir: dataDir,
+			L0: ContextOffloadL0Config{
+				MinToolResultBytes: 1,
+			},
+		}),
+		WithConversationSearchTool(false),
+	)
+	require.NoError(t, err)
+	defer svc.Close()
+
+	p := svc.ContextOffloadPlugin().(*contextOffloadPlugin)
+	sess := &session.Session{AppName: "app", UserID: "user", ID: "sess"}
+	store := newOffloadStorageContext(svc.opts, sess, "agent")
+	require.NoError(t, ensureOffloadDirs(store))
+	text := "content part payload"
+	msg := model.Message{
+		Role:     model.RoleTool,
+		ToolID:   "call-parts",
+		ToolName: "search",
+		ContentParts: []model.ContentPart{{
+			Type: model.ContentTypeText,
+			Text: &text,
+		}},
+	}
+
+	pairs, err := p.collectToolPairs(store, &pluginpkg.AfterToolMessagesArgs{
+		ToolCalls: []model.ToolCall{{
+			ID:       "call-parts",
+			Function: model.FunctionDefinitionParam{Name: "search"},
+		}},
+		ToolResultMessages: []model.Message{msg},
+	})
+	require.NoError(t, err)
+	require.Len(t, pairs, 1)
+	assert.Equal(t, text, pairs[0].Result)
+
+	refContent, err := os.ReadFile(filepath.Join(store.DataDir, filepath.FromSlash(pairs[0].ResultRef)))
+	require.NoError(t, err)
+	assert.Contains(t, string(refContent), text)
+}
+
+func TestReplaceCurrentToolResults_ClearsContentParts(t *testing.T) {
+	text := "raw structured payload"
+	result := replaceCurrentToolResults(
+		[]model.Message{{
+			Role:     model.RoleTool,
+			ToolID:   "call-parts",
+			ToolName: "search",
+			ContentParts: []model.ContentPart{{
+				Type: model.ContentTypeText,
+				Text: &text,
+			}},
+		}},
+		[]offloadIndexEntry{{
+			ToolCallID: "call-parts",
+			ToolCall:   "search",
+			Summary:    "offloaded summary",
+			ResultRef:  "refs/parts.md",
+			Score:      9,
+		}},
+	)
+
+	require.NotNil(t, result)
+	require.Len(t, result.ToolResultMessages, 1)
+	replacement := result.ToolResultMessages[0]
+	assert.Empty(t, replacement.ContentParts)
+	assert.Contains(t, replacement.Content, "result_ref: refs/parts.md")
+	assert.Contains(t, replacement.Content, "offloaded summary")
+}
+
+func TestNormalizeL1Entries_BackfillsMissingPairs(t *testing.T) {
+	pairs := []offloadToolPair{
+		{ToolName: "read_file", ToolCallID: "call-1", Result: "payload 1", ResultRef: "refs/1.md", Timestamp: "t1"},
+		{ToolName: "grep", ToolCallID: "call-2", Result: "payload 2", ResultRef: "refs/2.md", Timestamp: "t2"},
+	}
+
+	entries := normalizeL1Entries([]offloadIndexEntry{{
+		ToolCallID: "call-1",
+		ToolCall:   "read_file",
+		Summary:    "model summary",
+		Score:      9,
+	}}, pairs)
+
+	require.Len(t, entries, 2)
+	assert.Equal(t, "call-1", entries[0].ToolCallID)
+	assert.Equal(t, "model summary", entries[0].Summary)
+	assert.Equal(t, "call-2", entries[1].ToolCallID)
+	assert.Equal(t, "refs/2.md", entries[1].ResultRef)
+	assert.NotEmpty(t, entries[1].Summary)
+}
+
+func TestApplyMMDReplaceBlocks_SortsOutOfOrderBlocks(t *testing.T) {
+	got := applyMMDReplaceBlocks("one\ntwo\nthree\nfour", []offloadL2ReplaceBlock{
+		{StartLine: 3, EndLine: 3, Content: "THREE"},
+		{StartLine: 1, EndLine: 1, Content: "ONE\nONE-B"},
+	})
+
+	assert.Equal(t, "ONE\nONE-B\ntwo\nTHREE\nfour", got)
+}
+
+func TestFallbackL2Response_MergesWithExistingMMD(t *testing.T) {
+	existing := "%%{ \"taskGoal\": \"demo\" }%%\n" +
+		"flowchart TD\n" +
+		"  n_001-N1[\"old<br/>status: done\"]\n"
+
+	rsp := fallbackL2Response(offloadL2Request{
+		ExistingMMD: existing,
+		NewEntries: []offloadIndexEntry{{
+			ToolCallID: "call-new",
+			ToolCall:   "grep",
+			Summary:    "new summary",
+			ResultRef:  "refs/new.md",
+			Timestamp:  "t2",
+		}},
+		TaskLabel: "demo",
+		MMDPrefix: "001",
+	})
+
+	assert.Equal(t, "write", rsp.FileAction)
+	assert.Equal(t, "001-N2", rsp.NodeMapping["call-new"])
+	assert.Contains(t, rsp.MMDContent, "n_001-N1[\"old<br/>status: done\"]")
+	assert.Contains(t, rsp.MMDContent, "n_001-N2[\"grep<br/>status: done<br/>summary: new summary")
+	assert.Contains(t, rsp.MMDContent, "n_001-N1 --> n_001-N2")
+}
+
+func TestShouldRunL2_ReturnsReadError(t *testing.T) {
+	dataDir := t.TempDir()
+	mmdsFile := filepath.Join(dataDir, "mmds-file")
+	require.NoError(t, os.WriteFile(mmdsFile, []byte("not a dir"), offloadFilePerm))
+
+	p := &contextOffloadPlugin{opts: defaultOptions()}
+	run, err := p.shouldRunL2(
+		offloadStorageContext{MMDsDir: mmdsFile},
+		&offloadState{ActiveMMDFile: "001-task.mmd"},
+		[]offloadIndexEntry{{ToolCallID: "call-1"}},
+	)
+
+	require.Error(t, err)
+	assert.False(t, run)
+}
+
+func TestHistoryMMDFromEntries_UsesUniqueVerticesForSharedNodeID(t *testing.T) {
+	nodeID := "123-N"
+	got := historyMMDFromEntries([]offloadIndexEntry{
+		{ToolCallID: "call-1", ToolCall: "grep a", Summary: "summary a", ResultRef: "refs/a.md", Timestamp: "t1", NodeID: &nodeID},
+		{ToolCallID: "call-2", ToolCall: "grep b", Summary: "summary b", ResultRef: "refs/b.md", Timestamp: "t2", NodeID: &nodeID},
+	})
+
+	assert.Contains(t, got, "n_123-N_1[")
+	assert.Contains(t, got, "n_123-N_2[")
+	assert.Contains(t, got, "node_id: 123-N")
+	assert.Contains(t, got, "n_123-N_1 --> n_123-N_2")
+}
+
+func TestBuildCurrentTaskContext_UsesConfiguredToolNames(t *testing.T) {
+	got := buildCurrentTaskContext("001-task.mmd", "flowchart TD", "", Options{ToolPrefix: "mem"})
+
+	assert.Contains(t, got, "mem_read_offload_ref")
+	assert.Contains(t, got, "mem_read_offload_node")
+	assert.Contains(t, got, "mem_search_offload_index")
+	assert.NotContains(t, got, "tdai_read_offload_ref")
+}
+
+func TestContextOffloadPlugin_L3DeletesOldOffloadedToolBlocks(t *testing.T) {
+	dataDir := t.TempDir()
+	svc, err := NewService(
+		WithGatewayURL("http://127.0.0.1:1"),
+		WithContextOffload(ContextOffloadConfig{
+			Enabled: true,
+			DataDir: dataDir,
+			L0: ContextOffloadL0Config{
+				MinToolResultBytes: 10,
+			},
+			L3: ContextOffloadL3Config{
+				ContextWindow:        120,
+				MildRatio:            0.1,
+				AggressiveRatio:      0.2,
+				EmergencyRatio:       0.3,
+				EmergencyTargetRatio: 0.15,
+			},
+		}),
+		WithConversationSearchTool(false),
+	)
+	require.NoError(t, err)
+	defer svc.Close()
+
+	mgr := pluginpkg.MustNewManager(svc.ContextOffloadPlugin())
+	sess := &session.Session{AppName: "app", UserID: "user", ID: "sess"}
+	inv := &agent.Invocation{InvocationID: "inv", AgentName: "agent", Session: sess, Plugins: mgr}
+	call := model.ToolCall{
+		ID: "call-old",
+		Function: model.FunctionDefinitionParam{
+			Name:      "search",
+			Arguments: []byte(`{"q":"old"}`),
+		},
+	}
+	toolMsg := model.NewToolMessage("call-old", "search", strings.Repeat("large old payload ", 80))
+	_, err = mgr.AfterToolMessages(context.Background(), &pluginpkg.AfterToolMessagesArgs{
+		Invocation:         inv,
+		ToolCalls:          []model.ToolCall{call},
+		ToolResultMessages: []model.Message{toolMsg},
+		Messages:           []model.Message{model.NewUserMessage("实现压缩"), toolMsg},
+		ToolCallResponse:   &model.Response{},
+		ToolResultEvent:    nil,
+		Request:            &model.Request{},
+	})
+	require.NoError(t, err)
+
+	req := &model.Request{Messages: []model.Message{
+		model.NewUserMessage("实现压缩"),
+		{Role: model.RoleAssistant, ToolCalls: []model.ToolCall{call}},
+		toolMsg,
+		model.NewAssistantMessage("old final"),
+		model.NewUserMessage("继续 1"),
+		model.NewAssistantMessage("reply 1"),
+		model.NewUserMessage("继续 2"),
+		model.NewAssistantMessage("reply 2"),
+		model.NewUserMessage("继续 3"),
+		model.NewAssistantMessage("reply 3"),
+	}}
+	ctx := agent.NewInvocationContext(context.Background(), inv).Context
+	callbacks := mgr.ModelCallbacks()
+	require.NotNil(t, callbacks)
+	_, err = callbacks.BeforeModel[0](ctx, &model.BeforeModelArgs{Request: req})
+	require.NoError(t, err)
+	for _, msg := range req.Messages {
+		assert.NotEqual(t, "call-old", msg.ToolID)
+		for _, gotCall := range msg.ToolCalls {
+			assert.NotEqual(t, "call-old", gotCall.ID)
+		}
+	}
+	assert.Contains(t, req.Messages[0].Content, "<current_task_context>")
+}
+
+type scriptedOffloadModel struct{}
+
+func (m *scriptedOffloadModel) GenerateContent(
+	_ context.Context,
+	req *model.Request,
+) (<-chan *model.Response, error) {
+	out := make(chan *model.Response, 1)
+	content := `{}`
+	system := ""
+	if req != nil && len(req.Messages) > 0 {
+		system = req.Messages[0].Content
+	}
+	switch {
+	case strings.Contains(system, "工具结果摘要器"):
+		content = `[{"tool_call":"grep: offload","summary":"模型摘要","tool_call_id":"call-model","timestamp":"2026-06-12T00:00:00Z","score":9}]`
+	case strings.Contains(system, "任务生命周期判断器"):
+		content = `{"taskCompleted":false,"isLongTask":true,"isContinuation":false,"continuationMmdFile":null,"newTaskLabel":"model-task"}`
+	case strings.Contains(system, "任务拓扑架构师"):
+		payload := map[string]any{
+			"file_action": "write",
+			"mmd_content": "```mermaid\n" +
+				"%%{ \"taskGoal\": \"model-task\", \"progress\": \"60\", \"createdTime\": \"2026-06-12T00:00:00Z\", \"updatedTime\": \"2026-06-12T00:00:00Z\" }%%\n" +
+				"flowchart TD\n" +
+				"  n_123_N1[\"模型节点<br/>status: done<br/>summary: 模型摘要<br/>ref: refs/model.md<br/>Timestamp: 2026-06-12T00:00:00Z\"]\n" +
+				"```",
+			"replace_blocks": []any{},
+			"node_mapping": map[string]string{
+				"call-model": "123-N1",
+			},
+		}
+		b, _ := json.Marshal(payload)
+		content = string(b)
+	}
+	out <- &model.Response{Choices: []model.Choice{{
+		Message: model.NewAssistantMessage(content),
+	}}}
+	close(out)
+	return out, nil
+}
+
+func (m *scriptedOffloadModel) Info() model.Info {
+	return model.Info{Name: "scripted-offload", ContextWindow: 200000}
+}
+
+type boundarySwitchOffloadModel struct {
+	mu       sync.Mutex
+	l15Calls int
+}
+
+func (m *boundarySwitchOffloadModel) GenerateContent(
+	_ context.Context,
+	req *model.Request,
+) (<-chan *model.Response, error) {
+	out := make(chan *model.Response, 1)
+	system := ""
+	user := ""
+	if req != nil && len(req.Messages) > 0 {
+		system = req.Messages[0].Content
+	}
+	if req != nil && len(req.Messages) > 1 {
+		user = req.Messages[1].Content
+	}
+	content := `{}`
+	switch {
+	case strings.Contains(system, "工具结果摘要器"):
+		if strings.Contains(user, "call-b") {
+			content = `[{"tool_call":"grep: task-b","summary":"任务 B 摘要","tool_call_id":"call-b","timestamp":"2026-06-12T00:00:01Z","score":9}]`
+		} else {
+			content = `[{"tool_call":"grep: task-a","summary":"任务 A 摘要","tool_call_id":"call-a","timestamp":"2026-06-12T00:00:00Z","score":9}]`
+		}
+	case strings.Contains(system, "任务生命周期判断器"):
+		m.mu.Lock()
+		m.l15Calls++
+		call := m.l15Calls
+		m.mu.Unlock()
+		if call == 1 {
+			content = `{"taskCompleted":false,"isLongTask":true,"isContinuation":false,"newTaskLabel":"task-a"}`
+		} else {
+			content = `{"taskCompleted":false,"isLongTask":true,"isContinuation":false,"newTaskLabel":"task-b"}`
+		}
+	case strings.Contains(system, "任务拓扑架构师"):
+		callID := "call-a"
+		nodeID := "123-A"
+		summary := "任务 A 摘要"
+		if strings.Contains(user, "call-b") {
+			callID = "call-b"
+			nodeID = "123-B"
+			summary = "任务 B 摘要"
+		}
+		payload := map[string]any{
+			"file_action": "write",
+			"mmd_content": "```mermaid\n" +
+				"%%{ \"taskGoal\": \"boundary-switch\", \"progress\": \"50\", \"createdTime\": \"2026-06-12T00:00:00Z\", \"updatedTime\": \"2026-06-12T00:00:00Z\" }%%\n" +
+				"flowchart TD\n" +
+				"  n_" + strings.ReplaceAll(nodeID, "-", "_") + "[\"" + summary + "<br/>status: done<br/>summary: " + summary + "<br/>ref: refs/model.md<br/>Timestamp: 2026-06-12T00:00:00Z\"]\n" +
+				"```",
+			"replace_blocks": []any{},
+			"node_mapping": map[string]string{
+				callID: nodeID,
+			},
+		}
+		b, _ := json.Marshal(payload)
+		content = string(b)
+	}
+	out <- &model.Response{Choices: []model.Choice{{
+		Message: model.NewAssistantMessage(content),
+	}}}
+	close(out)
+	return out, nil
+}
+
+func (m *boundarySwitchOffloadModel) Info() model.Info {
+	return model.Info{Name: "boundary-switch-offload", ContextWindow: 200000}
+}
+
+func findCallableTool(t *testing.T, tools []tool.Tool, name string) tool.CallableTool {
+	t.Helper()
+	tl := findTool(tools, name)
+	require.NotNil(t, tl)
+	callable, ok := tl.(tool.CallableTool)
+	require.True(t, ok)
+	return callable
+}
+
+func findTool(tools []tool.Tool, name string) tool.Tool {
+	for _, tl := range tools {
+		if tl != nil && tl.Declaration() != nil && tl.Declaration().Name == name {
+			return tl
+		}
+	}
+	return nil
+}
+
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return b
+}

--- a/memory/tencentdb/options.go
+++ b/memory/tencentdb/options.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 )
 
@@ -26,12 +27,94 @@ const (
 	defaultIngestWorkers    = 1
 	defaultIngestQueueSize  = 10
 	defaultIngestJobTimeout = 30 * time.Second
+
+	defaultContextOffloadDataDir            = ".tdai-offload"
+	defaultContextOffloadMinToolResultBytes = 8 << 10
+	defaultContextOffloadMaxRefBytes        = 1 << 20
+	defaultContextOffloadMaxEntries         = 20
+	defaultContextOffloadMaxPairsPerBatch   = 20
+	defaultContextOffloadL2NullThreshold    = 4
+	defaultContextOffloadL2Timeout          = 5 * time.Minute
+	defaultContextOffloadContextWindow      = 200000
+	defaultContextOffloadMildRatio          = 0.50
+	defaultContextOffloadAggressiveRatio    = 0.85
+	defaultContextOffloadEmergencyRatio     = 0.95
+	defaultContextOffloadEmergencyTarget    = 0.60
+)
+
+const (
+	// ContextOffloadModeLocal runs L1/L1.5/L2 through the configured local
+	// model, falling back to deterministic summaries when no model is set.
+	ContextOffloadModeLocal = "local"
+	// ContextOffloadModeBackend sends L1/L1.5/L2 to a TencentDB Agent Memory
+	// offload backend.
+	ContextOffloadModeBackend = "backend"
+	// ContextOffloadModeCollect records refs and JSONL state without rewriting
+	// model-facing messages.
+	ContextOffloadModeCollect = "collect"
 )
 
 // SessionKeyFunc maps a framework session to the TencentDB Agent Memory
 // session_key. The default avoids collisions across app/user/session IDs but
 // does not provide strong multi-tenant isolation in a shared sidecar.
 type SessionKeyFunc func(*session.Session) string
+
+// ContextOffloadConfig configures the optional short-term context offload
+// plugin. Zero values are filled from conservative defaults.
+type ContextOffloadConfig struct {
+	// Enabled controls whether ContextOffloadPlugin and its tools are active.
+	Enabled bool
+	// DataDir stores refs, JSONL indexes, Mermaid files, and state.
+	DataDir string
+	// Mode selects local, backend, or collect processing.
+	Mode string
+	// Model is used in local mode for L1/L1.5/L2 offload tasks.
+	Model model.Model
+	// MaxEntries limits recent entries rendered into injected task context.
+	MaxEntries int
+	// Backend configures backend-mode L1/L1.5/L2 calls.
+	Backend ContextOffloadBackendConfig
+	// L0 configures raw tool result externalization.
+	L0 ContextOffloadL0Config
+	// L1 configures tool pair summarization.
+	L1 ContextOffloadL1Config
+	// L2 configures Mermaid task map generation.
+	L2 ContextOffloadL2Config
+	// L3 configures token-pressure compression.
+	L3 ContextOffloadL3Config
+}
+
+// ContextOffloadBackendConfig configures backend-mode offload calls.
+type ContextOffloadBackendConfig struct {
+	URL    string
+	APIKey string
+}
+
+// ContextOffloadL0Config configures raw tool result externalization.
+type ContextOffloadL0Config struct {
+	MinToolResultBytes int
+	MaxRefBytes        int64
+}
+
+// ContextOffloadL1Config configures tool pair summarization.
+type ContextOffloadL1Config struct {
+	MaxPairsPerBatch int
+}
+
+// ContextOffloadL2Config configures Mermaid task map generation.
+type ContextOffloadL2Config struct {
+	NullThreshold int
+	Timeout       time.Duration
+}
+
+// ContextOffloadL3Config configures token-pressure compression.
+type ContextOffloadL3Config struct {
+	ContextWindow        int
+	MildRatio            float64
+	AggressiveRatio      float64
+	EmergencyRatio       float64
+	EmergencyTargetRatio float64
+}
 
 // Options configures Service.
 type Options struct {
@@ -55,6 +138,8 @@ type Options struct {
 	EnableConversationSearchTool bool
 	EnableStandardAliases        bool
 	ToolPrefix                   string
+
+	ContextOffload ContextOffloadConfig
 }
 
 // Option configures Service.
@@ -78,7 +163,84 @@ func defaultOptions() Options {
 		EnableMemorySearchTool:       false,
 		EnableConversationSearchTool: true,
 		ToolPrefix:                   "tdai",
+		ContextOffload:               defaultContextOffloadConfig(),
 	}
+}
+
+func defaultContextOffloadConfig() ContextOffloadConfig {
+	return ContextOffloadConfig{
+		Mode:       ContextOffloadModeLocal,
+		DataDir:    defaultContextOffloadDataDir,
+		MaxEntries: defaultContextOffloadMaxEntries,
+		L0: ContextOffloadL0Config{
+			MinToolResultBytes: defaultContextOffloadMinToolResultBytes,
+			MaxRefBytes:        defaultContextOffloadMaxRefBytes,
+		},
+		L1: ContextOffloadL1Config{
+			MaxPairsPerBatch: defaultContextOffloadMaxPairsPerBatch,
+		},
+		L2: ContextOffloadL2Config{
+			NullThreshold: defaultContextOffloadL2NullThreshold,
+			Timeout:       defaultContextOffloadL2Timeout,
+		},
+		L3: ContextOffloadL3Config{
+			ContextWindow:        defaultContextOffloadContextWindow,
+			MildRatio:            defaultContextOffloadMildRatio,
+			AggressiveRatio:      defaultContextOffloadAggressiveRatio,
+			EmergencyRatio:       defaultContextOffloadEmergencyRatio,
+			EmergencyTargetRatio: defaultContextOffloadEmergencyTarget,
+		},
+	}
+}
+
+func normalizeContextOffloadConfig(cfg ContextOffloadConfig) ContextOffloadConfig {
+	def := defaultContextOffloadConfig()
+	cfg.DataDir = strings.TrimSpace(cfg.DataDir)
+	if cfg.DataDir == "" {
+		cfg.DataDir = def.DataDir
+	}
+	switch strings.TrimSpace(cfg.Mode) {
+	case ContextOffloadModeLocal, ContextOffloadModeBackend, ContextOffloadModeCollect:
+		cfg.Mode = strings.TrimSpace(cfg.Mode)
+	default:
+		cfg.Mode = def.Mode
+	}
+	cfg.Backend.URL = strings.TrimRight(strings.TrimSpace(cfg.Backend.URL), "/")
+	cfg.Backend.APIKey = strings.TrimSpace(cfg.Backend.APIKey)
+	if cfg.MaxEntries <= 0 {
+		cfg.MaxEntries = def.MaxEntries
+	}
+	if cfg.L0.MinToolResultBytes <= 0 {
+		cfg.L0.MinToolResultBytes = def.L0.MinToolResultBytes
+	}
+	if cfg.L0.MaxRefBytes <= 0 {
+		cfg.L0.MaxRefBytes = def.L0.MaxRefBytes
+	}
+	if cfg.L1.MaxPairsPerBatch <= 0 {
+		cfg.L1.MaxPairsPerBatch = def.L1.MaxPairsPerBatch
+	}
+	if cfg.L2.NullThreshold <= 0 {
+		cfg.L2.NullThreshold = def.L2.NullThreshold
+	}
+	if cfg.L2.Timeout <= 0 {
+		cfg.L2.Timeout = def.L2.Timeout
+	}
+	if cfg.L3.ContextWindow <= 0 {
+		cfg.L3.ContextWindow = def.L3.ContextWindow
+	}
+	if cfg.L3.MildRatio <= 0 || cfg.L3.MildRatio >= 1 {
+		cfg.L3.MildRatio = def.L3.MildRatio
+	}
+	if cfg.L3.AggressiveRatio <= 0 || cfg.L3.AggressiveRatio >= 1 {
+		cfg.L3.AggressiveRatio = def.L3.AggressiveRatio
+	}
+	if cfg.L3.EmergencyRatio <= 0 || cfg.L3.EmergencyRatio >= 1 {
+		cfg.L3.EmergencyRatio = def.L3.EmergencyRatio
+	}
+	if cfg.L3.EmergencyTargetRatio <= 0 || cfg.L3.EmergencyTargetRatio >= 1 {
+		cfg.L3.EmergencyTargetRatio = def.L3.EmergencyTargetRatio
+	}
+	return cfg
 }
 
 // WithGatewayURL sets the TencentDB Agent Memory gateway URL.
@@ -215,5 +377,14 @@ func WithToolPrefix(prefix string) Option {
 		if prefix != "" {
 			o.ToolPrefix = prefix
 		}
+	}
+}
+
+// WithContextOffload configures the explicit context offload plugin and its
+// read-ref tool. It is disabled by default; set ContextOffloadConfig.Enabled
+// to true before registering ContextOffloadPlugin.
+func WithContextOffload(cfg ContextOffloadConfig) Option {
+	return func(o *Options) {
+		o.ContextOffload = normalizeContextOffloadConfig(cfg)
 	}
 }

--- a/memory/tencentdb/tools.go
+++ b/memory/tencentdb/tools.go
@@ -11,11 +11,14 @@ package tencentdb
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
 	"strings"
 
-	"trpc.group/trpc-go/trpc-agent-go/agent"
 	memorypkg "trpc.group/trpc-go/trpc-agent-go/memory"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
@@ -52,9 +55,39 @@ type searchConversationsToolResponse struct {
 	Total   int    `json:"total"`
 }
 
+type readOffloadRefToolRequest struct {
+	ResultRef string `json:"result_ref" description:"Relative result reference produced by TencentDB context offload, for example refs/node_20260612_000001.md."`
+}
+
+type readOffloadRefToolResponse struct {
+	ResultRef string `json:"result_ref"`
+	Content   string `json:"content"`
+	Truncated bool   `json:"truncated,omitempty"`
+}
+
+type readOffloadNodeToolRequest struct {
+	NodeID string `json:"node_id" description:"Mermaid node_id produced by TencentDB context offload."`
+}
+
+type readOffloadNodeToolResponse struct {
+	NodeID  string              `json:"node_id"`
+	Entries []offloadIndexEntry `json:"entries"`
+}
+
+type searchOffloadIndexToolRequest struct {
+	Query string `json:"query" description:"Keyword query over TencentDB context offload summaries, tool calls, node IDs, and result_refs."`
+	Limit int    `json:"limit,omitempty" description:"Maximum results. Defaults to 5, maximum 20."`
+}
+
+type searchOffloadIndexToolResponse struct {
+	Query   string              `json:"query"`
+	Entries []offloadIndexEntry `json:"entries"`
+	Total   int                 `json:"total"`
+}
+
 func (s *Service) buildTools() []tool.Tool {
-	out := make([]tool.Tool, 0, 3)
-	seen := make(map[string]struct{}, 3)
+	out := make([]tool.Tool, 0, 5)
+	seen := make(map[string]struct{}, 5)
 	add := func(t tool.Tool) {
 		if t == nil || t.Declaration() == nil {
 			return
@@ -76,11 +109,20 @@ func (s *Service) buildTools() []tool.Tool {
 	if s.opts.EnableConversationSearchTool {
 		add(s.newConversationSearchTool(s.nativeToolName("conversation_search")))
 	}
+	if s.opts.ContextOffload.Enabled {
+		add(s.newReadOffloadRefTool(s.nativeToolName("read_offload_ref")))
+		add(s.newReadOffloadNodeTool(s.nativeToolName("read_offload_node")))
+		add(s.newSearchOffloadIndexTool(s.nativeToolName("search_offload_index")))
+	}
 	return out
 }
 
 func (s *Service) nativeToolName(name string) string {
-	prefix := strings.Trim(strings.TrimSpace(s.opts.ToolPrefix), "_-")
+	return nativeToolName(s.opts, name)
+}
+
+func nativeToolName(opts Options, name string) string {
+	prefix := strings.Trim(strings.TrimSpace(opts.ToolPrefix), "_-")
 	if prefix == "" {
 		return name
 	}
@@ -156,12 +198,150 @@ func (s *Service) newConversationSearchTool(name string) tool.CallableTool {
 	)
 }
 
-func currentSession(ctx context.Context) (*session.Session, error) {
-	inv, ok := agent.InvocationFromContext(ctx)
-	if !ok || inv == nil || inv.Session == nil {
-		return nil, errors.New("tencentdb memory tool: invocation session is required")
+func (s *Service) newReadOffloadRefTool(name string) tool.CallableTool {
+	fn := func(ctx context.Context, req *readOffloadRefToolRequest) (*readOffloadRefToolResponse, error) {
+		if req == nil || strings.TrimSpace(req.ResultRef) == "" {
+			return nil, fmt.Errorf("%s: result_ref is required", name)
+		}
+		inv, err := currentInvocation(ctx)
+		if err != nil {
+			return nil, err
+		}
+		ref := strings.TrimSpace(req.ResultRef)
+		path, err := s.contextOffloadRefPath(inv.Session, inv.AgentName, ref)
+		if err != nil {
+			return nil, err
+		}
+		maxBytes := s.opts.ContextOffload.L0.MaxRefBytes
+		if maxBytes <= 0 {
+			maxBytes = defaultContextOffloadMaxRefBytes
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close()
+		limited := io.LimitReader(f, maxBytes+1)
+		b, err := io.ReadAll(limited)
+		if err != nil {
+			return nil, err
+		}
+		truncated := int64(len(b)) > maxBytes
+		if truncated {
+			b = b[:maxBytes]
+		}
+		return &readOffloadRefToolResponse{
+			ResultRef: ref,
+			Content:   string(b),
+			Truncated: truncated,
+		}, nil
 	}
-	if err := validateSessionScope(inv.Session); err != nil {
+	return function.NewFunctionTool(
+		fn,
+		function.WithName(name),
+		function.WithDescription("Read a tool result externalized by TencentDB context offload. "+
+			"Use this when the prompt contains a result_ref and exact details are needed."),
+	)
+}
+
+func (s *Service) newReadOffloadNodeTool(name string) tool.CallableTool {
+	fn := func(ctx context.Context, req *readOffloadNodeToolRequest) (*readOffloadNodeToolResponse, error) {
+		if req == nil || strings.TrimSpace(req.NodeID) == "" {
+			return nil, fmt.Errorf("%s: node_id is required", name)
+		}
+		inv, err := currentInvocation(ctx)
+		if err != nil {
+			return nil, err
+		}
+		store := newOffloadStorageContext(s.opts, inv.Session, inv.AgentName)
+		entries, err := readAllOffloadEntries(store)
+		if err != nil {
+			return nil, err
+		}
+		nodeID := strings.TrimSpace(req.NodeID)
+		var matches []offloadIndexEntry
+		for _, entry := range entries {
+			if entry.NodeID != nil && *entry.NodeID == nodeID {
+				matches = append(matches, entry)
+			}
+		}
+		return &readOffloadNodeToolResponse{NodeID: nodeID, Entries: matches}, nil
+	}
+	return function.NewFunctionTool(
+		fn,
+		function.WithName(name),
+		function.WithDescription("Read TencentDB context offload JSONL entries mapped to a Mermaid node_id. "+
+			"Use this to drill down from the active task Mermaid graph."),
+	)
+}
+
+func (s *Service) newSearchOffloadIndexTool(name string) tool.CallableTool {
+	fn := func(ctx context.Context, req *searchOffloadIndexToolRequest) (*searchOffloadIndexToolResponse, error) {
+		if req == nil || strings.TrimSpace(req.Query) == "" {
+			return nil, fmt.Errorf("%s: query is required", name)
+		}
+		inv, err := currentInvocation(ctx)
+		if err != nil {
+			return nil, err
+		}
+		store := newOffloadStorageContext(s.opts, inv.Session, inv.AgentName)
+		entries, err := readAllOffloadEntries(store)
+		if err != nil {
+			return nil, err
+		}
+		query := strings.ToLower(strings.TrimSpace(req.Query))
+		limit := normalizeLimit(req.Limit)
+		var matches []offloadIndexEntry
+		for _, entry := range entries {
+			if offloadEntryMatches(entry, query) {
+				matches = append(matches, entry)
+				if len(matches) >= limit {
+					break
+				}
+			}
+		}
+		return &searchOffloadIndexToolResponse{
+			Query:   strings.TrimSpace(req.Query),
+			Entries: matches,
+			Total:   len(matches),
+		}, nil
+	}
+	return function.NewFunctionTool(
+		fn,
+		function.WithName(name),
+		function.WithDescription("Search TencentDB context offload L1 summaries and refs for the current session. "+
+			"Use this when the active Mermaid graph does not show the exact result_ref needed."),
+	)
+}
+
+func (s *Service) contextOffloadRefPath(
+	sess *session.Session,
+	agentName string,
+	resultRef string,
+) (string, error) {
+	if s == nil {
+		return "", errors.New("tencentdb context offload: nil service")
+	}
+	root := contextOffloadSessionDirForAgent(s.opts, sess, agentName)
+	cleaned := filepath.ToSlash(filepath.Clean(resultRef))
+	if cleaned == "." || strings.HasPrefix(cleaned, "../") ||
+		strings.HasPrefix(cleaned, "/") ||
+		!strings.HasPrefix(cleaned, "refs/") {
+		return "", fmt.Errorf("tencentdb context offload: invalid result_ref %q", resultRef)
+	}
+	path := filepath.Join(root, filepath.FromSlash(cleaned))
+	rootClean := filepath.Clean(root)
+	pathClean := filepath.Clean(path)
+	rel, err := filepath.Rel(rootClean, pathClean)
+	if err != nil || rel == "." || strings.HasPrefix(rel, "..") {
+		return "", fmt.Errorf("tencentdb context offload: invalid result_ref %q", resultRef)
+	}
+	return pathClean, nil
+}
+
+func currentSession(ctx context.Context) (*session.Session, error) {
+	inv, err := currentInvocation(ctx)
+	if err != nil {
 		return nil, err
 	}
 	return inv.Session, nil
@@ -175,4 +355,24 @@ func normalizeLimit(limit int) int {
 		return maxSearchLimit
 	}
 	return limit
+}
+
+func offloadEntryMatches(entry offloadIndexEntry, query string) bool {
+	fields := []string{
+		entry.ToolCall,
+		entry.Summary,
+		entry.ResultRef,
+		entry.ToolCallID,
+		entry.displayNodeID(),
+	}
+	for _, keyword := range entry.Keywords {
+		fields = append(fields, keyword)
+	}
+	for _, field := range fields {
+		if strings.Contains(strings.ToLower(field), query) {
+			return true
+		}
+	}
+	b, err := json.Marshal(entry)
+	return err == nil && strings.Contains(strings.ToLower(string(b)), query)
 }

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -164,6 +164,18 @@ func (r *Registry) AfterTool(cb tool.AfterToolCallbackStructured) {
 	)
 }
 
+// AfterToolMessages registers a callback that can replace model-facing tool
+// result messages after tool execution and before the event is emitted.
+func (r *Registry) AfterToolMessages(cb AfterToolMessagesCallback) {
+	if r == nil || r.mgr == nil || cb == nil {
+		return
+	}
+	r.mgr.afterToolMessagesHooks = append(
+		r.mgr.afterToolMessagesHooks,
+		namedAfterToolMessagesHook{name: r.name, hook: cb},
+	)
+}
+
 // OnEvent registers an event hook.
 func (r *Registry) OnEvent(hook EventHook) {
 	if r == nil || r.mgr == nil || hook == nil {
@@ -179,16 +191,22 @@ func (r *Registry) OnEvent(hook EventHook) {
 //
 // Manager implements agent.PluginManager.
 type Manager struct {
-	plugins        []Plugin
-	agentCallbacks *agent.Callbacks
-	modelCallbacks *model.Callbacks
-	toolCallbacks  *tool.Callbacks
-	eventHooks     []namedEventHook
+	plugins                []Plugin
+	agentCallbacks         *agent.Callbacks
+	modelCallbacks         *model.Callbacks
+	toolCallbacks          *tool.Callbacks
+	eventHooks             []namedEventHook
+	afterToolMessagesHooks []namedAfterToolMessagesHook
 }
 
 type namedEventHook struct {
 	name string
 	hook EventHook
+}
+
+type namedAfterToolMessagesHook struct {
+	name string
+	hook AfterToolMessagesCallback
 }
 
 // NewManager builds a Manager and registers all plugin hooks.
@@ -294,6 +312,200 @@ func (m *Manager) OnEvent(
 	return curr, nil
 }
 
+// AfterToolMessages runs registered after-tool-messages hooks in plugin order.
+func (m *Manager) AfterToolMessages(
+	ctx context.Context,
+	args *AfterToolMessagesArgs,
+) (*AfterToolMessagesResult, error) {
+	if m == nil || args == nil {
+		return nil, nil
+	}
+	var last *AfterToolMessagesResult
+	for _, h := range m.afterToolMessagesHooks {
+		res, err := h.hook(ctx, args)
+		if err != nil {
+			return res, fmt.Errorf("plugin %q: %w", h.name, err)
+		}
+		if res == nil || len(res.ToolResultMessages) == 0 {
+			continue
+		}
+		current := cloneMessages(args.ToolResultMessages)
+		if len(current) == 0 {
+			current = toolResultMessagesFromEvent(args.ToolResultEvent)
+		}
+		replacements, err := normalizeToolResultReplacements(
+			current,
+			res.ToolResultMessages,
+		)
+		if err != nil {
+			return res, fmt.Errorf("plugin %q: %w", h.name, err)
+		}
+		if err := replaceToolResultEventChoices(
+			args.ToolResultEvent,
+			replacements,
+		); err != nil {
+			return res, fmt.Errorf("plugin %q: %w", h.name, err)
+		}
+		tailLen := len(args.ToolResultMessages)
+		if tailLen == 0 {
+			tailLen = len(current)
+		}
+		args.Messages = replaceTailMessages(
+			args.Messages,
+			tailLen,
+			replacements,
+		)
+		args.ToolResultMessages = cloneMessages(replacements)
+		last = &AfterToolMessagesResult{
+			ToolResultMessages: cloneMessages(replacements),
+		}
+	}
+	return last, nil
+}
+
+func normalizeToolResultReplacements(
+	original []model.Message,
+	replacements []model.Message,
+) ([]model.Message, error) {
+	if len(original) == 0 {
+		return nil, errors.New("after tool messages: original tool result messages are empty")
+	}
+	if len(replacements) != len(original) {
+		return nil, fmt.Errorf(
+			"after tool messages: replacement count %d does not match original tool result count %d",
+			len(replacements),
+			len(original),
+		)
+	}
+	byID := make(map[string]model.Message, len(replacements))
+	for _, msg := range replacements {
+		if msg.ToolID == "" {
+			return nil, errors.New("after tool messages: replacement tool message missing tool id")
+		}
+		if msg.Role != model.RoleTool {
+			return nil, fmt.Errorf(
+				"after tool messages: replacement for tool id %q must use role %q",
+				msg.ToolID,
+				model.RoleTool,
+			)
+		}
+		if _, ok := byID[msg.ToolID]; ok {
+			return nil, fmt.Errorf(
+				"after tool messages: replacement contains duplicate tool id %q",
+				msg.ToolID,
+			)
+		}
+		byID[msg.ToolID] = msg
+	}
+	out := make([]model.Message, 0, len(original))
+	for _, msg := range original {
+		if msg.ToolID == "" {
+			return nil, errors.New("after tool messages: original tool message missing tool id")
+		}
+		if msg.Role != model.RoleTool {
+			return nil, fmt.Errorf(
+				"after tool messages: original for tool id %q must use role %q",
+				msg.ToolID,
+				model.RoleTool,
+			)
+		}
+		replacement, ok := byID[msg.ToolID]
+		if !ok {
+			return nil, fmt.Errorf(
+				"after tool messages: replacement missing tool id %q",
+				msg.ToolID,
+			)
+		}
+		out = append(out, replacement)
+		delete(byID, msg.ToolID)
+	}
+	for toolID := range byID {
+		return nil, fmt.Errorf(
+			"after tool messages: replacement contains unknown tool id %q",
+			toolID,
+		)
+	}
+	return cloneMessages(out), nil
+}
+
+func replaceToolResultEventChoices(
+	ev *event.Event,
+	replacements []model.Message,
+) error {
+	if ev == nil || ev.Response == nil || len(replacements) == 0 {
+		return nil
+	}
+	byID := make(map[string]model.Message, len(replacements))
+	for _, msg := range replacements {
+		byID[msg.ToolID] = msg
+	}
+	choices := make([]model.Choice, 0, len(ev.Response.Choices))
+	seen := make(map[string]struct{}, len(replacements))
+	for _, choice := range ev.Response.Choices {
+		toolID := toolChoiceID(choice)
+		if toolID == "" {
+			return errors.New("after tool messages: original tool result choice missing tool id")
+		}
+		msg, ok := byID[toolID]
+		if !ok {
+			return fmt.Errorf(
+				"after tool messages: replacement missing tool id %q",
+				toolID,
+			)
+		}
+		choices = append(choices, replaceChoiceToolMessage(choice, msg))
+		seen[toolID] = struct{}{}
+	}
+	for _, msg := range replacements {
+		if _, ok := seen[msg.ToolID]; !ok {
+			return fmt.Errorf(
+				"after tool messages: replacement contains unknown tool id %q",
+				msg.ToolID,
+			)
+		}
+	}
+	ev.Response.Choices = choices
+	return nil
+}
+
+func replaceChoiceToolMessage(choice model.Choice, msg model.Message) model.Choice {
+	updated := choice
+	if updated.Message.ToolID != "" {
+		updated.Message = msg
+	}
+	if updated.Delta.ToolID != "" {
+		updated.Delta = msg
+	}
+	if updated.Message.ToolID == "" && updated.Delta.ToolID == "" {
+		updated.Message = msg
+	}
+	return updated
+}
+
+func toolResultMessagesFromEvent(ev *event.Event) []model.Message {
+	if ev == nil || ev.Response == nil {
+		return nil
+	}
+	out := make([]model.Message, 0, len(ev.Response.Choices))
+	for _, choice := range ev.Response.Choices {
+		msg := choice.Message
+		if msg.ToolID == "" && choice.Delta.ToolID != "" {
+			msg = choice.Delta
+		}
+		if msg.ToolID != "" {
+			out = append(out, msg)
+		}
+	}
+	return cloneMessages(out)
+}
+
+func toolChoiceID(choice model.Choice) string {
+	if choice.Message.ToolID != "" {
+		return choice.Message.ToolID
+	}
+	return choice.Delta.ToolID
+}
+
 // Close implements agent.PluginManager.
 func (m *Manager) Close(ctx context.Context) error {
 	if m == nil {
@@ -321,4 +533,27 @@ func (m *Manager) Close(ctx context.Context) error {
 		}
 	}
 	return errors.Join(errs...)
+}
+
+func replaceTailMessages(
+	messages []model.Message,
+	oldTailLen int,
+	replacement []model.Message,
+) []model.Message {
+	if oldTailLen < 0 || oldTailLen > len(messages) {
+		return cloneMessages(messages)
+	}
+	out := make([]model.Message, 0, len(messages)-oldTailLen+len(replacement))
+	out = append(out, messages[:len(messages)-oldTailLen]...)
+	out = append(out, replacement...)
+	return cloneMessages(out)
+}
+
+func cloneMessages(messages []model.Message) []model.Message {
+	if len(messages) == 0 {
+		return nil
+	}
+	out := make([]model.Message, len(messages))
+	copy(out, messages)
+	return out
 }

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -242,6 +242,101 @@ func TestManager_ModelCallbacks_EarlyExit(t *testing.T) {
 	require.Equal(t, []string{"p1"}, calls)
 }
 
+func TestManager_AfterToolMessagesCanonicalizesReplacements(t *testing.T) {
+	original := []model.Message{
+		model.NewToolMessage("call-1", "search", "raw 1"),
+		model.NewToolMessage("call-2", "search", "raw 2"),
+	}
+	finishReason := "tool_calls"
+	toolEvent := event.NewResponseEvent("inv", "agent", &model.Response{
+		Object: model.ObjectTypeToolResponse,
+		Choices: []model.Choice{
+			{Index: 10, Message: original[0], FinishReason: &finishReason},
+			{Index: 11, Message: original[1], FinishReason: &finishReason},
+		},
+	})
+	var secondHookMessages []model.Message
+	var secondHookChoices []model.Choice
+	m := plugin.MustNewManager(
+		&testPlugin{
+			name: "p1",
+			reg: func(r *plugin.Registry) {
+				r.AfterToolMessages(func(
+					context.Context,
+					*plugin.AfterToolMessagesArgs,
+				) (*plugin.AfterToolMessagesResult, error) {
+					return &plugin.AfterToolMessagesResult{
+						ToolResultMessages: []model.Message{
+							model.NewToolMessage("call-2", "search", "summary 2"),
+							model.NewToolMessage("call-1", "search", "summary 1"),
+						},
+					}, nil
+				})
+			},
+		},
+		&testPlugin{
+			name: "p2",
+			reg: func(r *plugin.Registry) {
+				r.AfterToolMessages(func(
+					_ context.Context,
+					args *plugin.AfterToolMessagesArgs,
+				) (*plugin.AfterToolMessagesResult, error) {
+					secondHookMessages = append([]model.Message(nil), args.ToolResultMessages...)
+					secondHookChoices = append([]model.Choice(nil), args.ToolResultEvent.Response.Choices...)
+					return nil, nil
+				})
+			},
+		},
+	)
+
+	args := &plugin.AfterToolMessagesArgs{
+		ToolResultEvent:    toolEvent,
+		Messages:           append([]model.Message{model.NewUserMessage("query")}, original...),
+		ToolResultMessages: original,
+	}
+	result, err := m.AfterToolMessages(context.Background(), args)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.ToolResultMessages, 2)
+	require.Equal(t, "call-1", result.ToolResultMessages[0].ToolID)
+	require.Equal(t, "summary 1", result.ToolResultMessages[0].Content)
+	require.Equal(t, "call-2", result.ToolResultMessages[1].ToolID)
+	require.Equal(t, "summary 2", result.ToolResultMessages[1].Content)
+	require.Equal(t, result.ToolResultMessages, args.ToolResultMessages)
+	require.Equal(t, result.ToolResultMessages, secondHookMessages)
+	require.Equal(t, "summary 1", secondHookChoices[0].Message.Content)
+	require.Equal(t, "summary 2", secondHookChoices[1].Message.Content)
+	require.Equal(t, 10, toolEvent.Response.Choices[0].Index)
+	require.Same(t, &finishReason, toolEvent.Response.Choices[0].FinishReason)
+	require.Equal(t, "summary 1", toolEvent.Response.Choices[0].Message.Content)
+	require.Equal(t, 11, toolEvent.Response.Choices[1].Index)
+	require.Same(t, &finishReason, toolEvent.Response.Choices[1].FinishReason)
+	require.Equal(t, "summary 2", toolEvent.Response.Choices[1].Message.Content)
+}
+
+func TestManager_AfterToolMessagesRejectsInvalidReplacement(t *testing.T) {
+	m := plugin.MustNewManager(&testPlugin{
+		name: "p1",
+		reg: func(r *plugin.Registry) {
+			r.AfterToolMessages(func(
+				context.Context,
+				*plugin.AfterToolMessagesArgs,
+			) (*plugin.AfterToolMessagesResult, error) {
+				return &plugin.AfterToolMessagesResult{
+					ToolResultMessages: []model.Message{model.NewAssistantMessage("bad")},
+				}, nil
+			})
+		},
+	})
+	_, err := m.AfterToolMessages(context.Background(), &plugin.AfterToolMessagesArgs{
+		ToolResultMessages: []model.Message{
+			model.NewToolMessage("call-1", "search", "raw"),
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing tool id")
+}
+
 func TestManager_OnEvent_Order(t *testing.T) {
 	var calls []string
 	p1 := &testPlugin{

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -337,6 +337,229 @@ func TestManager_AfterToolMessagesRejectsInvalidReplacement(t *testing.T) {
 	require.Contains(t, err.Error(), "missing tool id")
 }
 
+func TestManager_AfterToolMessagesEdgeCases(t *testing.T) {
+	var nilRegistry *plugin.Registry
+	nilRegistry.AfterToolMessages(nil)
+	(&plugin.Registry{}).AfterToolMessages(nil)
+
+	var nilManager *plugin.Manager
+	res, err := nilManager.AfterToolMessages(context.Background(), nil)
+	require.NoError(t, err)
+	require.Nil(t, res)
+
+	m := plugin.MustNewManager(&testPlugin{
+		name: "empty",
+		reg: func(r *plugin.Registry) {
+			r.AfterToolMessages(func(
+				context.Context,
+				*plugin.AfterToolMessagesArgs,
+			) (*plugin.AfterToolMessagesResult, error) {
+				return &plugin.AfterToolMessagesResult{}, nil
+			})
+		},
+	})
+	res, err = m.AfterToolMessages(context.Background(), &plugin.AfterToolMessagesArgs{})
+	require.NoError(t, err)
+	require.Nil(t, res)
+
+	hookErr := errors.New("hook failed")
+	m = plugin.MustNewManager(&testPlugin{
+		name: "hook-error",
+		reg: func(r *plugin.Registry) {
+			r.AfterToolMessages(func(
+				context.Context,
+				*plugin.AfterToolMessagesArgs,
+			) (*plugin.AfterToolMessagesResult, error) {
+				return &plugin.AfterToolMessagesResult{
+					ToolResultMessages: []model.Message{model.NewToolMessage("call-1", "lookup", "summary")},
+				}, hookErr
+			})
+		},
+	})
+	res, err = m.AfterToolMessages(context.Background(), &plugin.AfterToolMessagesArgs{
+		ToolResultMessages: []model.Message{model.NewToolMessage("call-1", "lookup", "raw")},
+	})
+	require.ErrorIs(t, err, hookErr)
+	require.NotNil(t, res)
+
+	t.Run("uses event messages when args messages are empty", func(t *testing.T) {
+		toolEvent := event.NewResponseEvent("inv", "agent", &model.Response{
+			Object: model.ObjectTypeToolResponse,
+			Choices: []model.Choice{
+				{Index: 2, Delta: model.NewToolMessage("call-1", "lookup", "raw delta")},
+			},
+		})
+		m := plugin.MustNewManager(&testPlugin{
+			name: "event-fallback",
+			reg: func(r *plugin.Registry) {
+				r.AfterToolMessages(func(
+					_ context.Context,
+					args *plugin.AfterToolMessagesArgs,
+				) (*plugin.AfterToolMessagesResult, error) {
+					require.Len(t, args.ToolResultMessages, 0)
+					return &plugin.AfterToolMessagesResult{
+						ToolResultMessages: []model.Message{
+							model.NewToolMessage("call-1", "lookup", "summary delta"),
+						},
+					}, nil
+				})
+			},
+		})
+		args := &plugin.AfterToolMessagesArgs{
+			ToolResultEvent: toolEvent,
+			Messages: []model.Message{
+				model.NewUserMessage("query"),
+				model.NewToolMessage("call-1", "lookup", "raw delta"),
+			},
+		}
+		res, err := m.AfterToolMessages(context.Background(), args)
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		require.Len(t, res.ToolResultMessages, 1)
+		require.Equal(t, "summary delta", res.ToolResultMessages[0].Content)
+		require.Equal(t, "summary delta", toolEvent.Response.Choices[0].Delta.Content)
+		require.Len(t, args.Messages, 2)
+		require.Equal(t, "summary delta", args.Messages[1].Content)
+	})
+
+	cases := []struct {
+		name         string
+		original     []model.Message
+		replacements []model.Message
+		want         string
+	}{
+		{
+			name:         "empty original",
+			original:     nil,
+			replacements: []model.Message{model.NewToolMessage("call-1", "lookup", "summary")},
+			want:         "original tool result messages are empty",
+		},
+		{
+			name:         "count mismatch",
+			original:     []model.Message{model.NewToolMessage("call-1", "lookup", "raw")},
+			replacements: []model.Message{model.NewToolMessage("call-1", "lookup", "summary"), model.NewToolMessage("call-2", "lookup", "summary")},
+			want:         "replacement count",
+		},
+		{
+			name:         "replacement role",
+			original:     []model.Message{model.NewToolMessage("call-1", "lookup", "raw")},
+			replacements: []model.Message{{Role: model.RoleAssistant, ToolID: "call-1", Content: "summary"}},
+			want:         "must use role",
+		},
+		{
+			name:         "duplicate replacement",
+			original:     []model.Message{model.NewToolMessage("call-1", "lookup", "raw"), model.NewToolMessage("call-2", "lookup", "raw")},
+			replacements: []model.Message{model.NewToolMessage("call-1", "lookup", "summary"), model.NewToolMessage("call-1", "lookup", "summary again")},
+			want:         "duplicate tool id",
+		},
+		{
+			name:         "original missing id",
+			original:     []model.Message{{Role: model.RoleTool, Content: "raw"}},
+			replacements: []model.Message{model.NewToolMessage("call-1", "lookup", "summary")},
+			want:         "original tool message missing tool id",
+		},
+		{
+			name:         "original role",
+			original:     []model.Message{{Role: model.RoleAssistant, ToolID: "call-1", Content: "raw"}},
+			replacements: []model.Message{model.NewToolMessage("call-1", "lookup", "summary")},
+			want:         "original for tool id",
+		},
+		{
+			name:         "missing replacement",
+			original:     []model.Message{model.NewToolMessage("call-1", "lookup", "raw")},
+			replacements: []model.Message{model.NewToolMessage("call-2", "lookup", "summary")},
+			want:         "replacement missing tool id",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := plugin.MustNewManager(&testPlugin{
+				name: "invalid",
+				reg: func(r *plugin.Registry) {
+					r.AfterToolMessages(func(
+						context.Context,
+						*plugin.AfterToolMessagesArgs,
+					) (*plugin.AfterToolMessagesResult, error) {
+						return &plugin.AfterToolMessagesResult{
+							ToolResultMessages: tc.replacements,
+						}, nil
+					})
+				},
+			})
+			_, err := m.AfterToolMessages(context.Background(), &plugin.AfterToolMessagesArgs{
+				ToolResultMessages: tc.original,
+			})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.want)
+		})
+	}
+
+	eventCases := []struct {
+		name         string
+		eventChoices []model.Choice
+		replacements []model.Message
+		want         string
+	}{
+		{
+			name: "choice missing id",
+			eventChoices: []model.Choice{{
+				Message: model.NewAssistantMessage("no tool id"),
+			}},
+			replacements: []model.Message{model.NewToolMessage("call-1", "lookup", "summary")},
+			want:         "original tool result choice missing tool id",
+		},
+		{
+			name: "event choice missing replacement",
+			eventChoices: []model.Choice{{
+				Message: model.NewToolMessage("call-2", "lookup", "raw"),
+			}},
+			replacements: []model.Message{model.NewToolMessage("call-1", "lookup", "summary")},
+			want:         "replacement missing tool id",
+		},
+		{
+			name: "event replacement unknown",
+			eventChoices: []model.Choice{{
+				Message: model.NewToolMessage("call-1", "lookup", "raw"),
+			}},
+			replacements: []model.Message{
+				model.NewToolMessage("call-1", "lookup", "summary"),
+				model.NewToolMessage("call-2", "lookup", "summary"),
+			},
+			want: "replacement contains unknown tool id",
+		},
+	}
+	for _, tc := range eventCases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := plugin.MustNewManager(&testPlugin{
+				name: "event-invalid",
+				reg: func(r *plugin.Registry) {
+					r.AfterToolMessages(func(
+						context.Context,
+						*plugin.AfterToolMessagesArgs,
+					) (*plugin.AfterToolMessagesResult, error) {
+						return &plugin.AfterToolMessagesResult{
+							ToolResultMessages: tc.replacements,
+						}, nil
+					})
+				},
+			})
+			original := make([]model.Message, 0, len(tc.replacements))
+			for _, msg := range tc.replacements {
+				original = append(original, model.NewToolMessage(msg.ToolID, msg.ToolName, "raw"))
+			}
+			_, err := m.AfterToolMessages(context.Background(), &plugin.AfterToolMessagesArgs{
+				ToolResultMessages: original,
+				ToolResultEvent: event.NewResponseEvent("inv", "agent", &model.Response{
+					Object:  model.ObjectTypeToolResponse,
+					Choices: tc.eventChoices,
+				}),
+			})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
+
 func TestManager_OnEvent_Order(t *testing.T) {
 	var calls []string
 	p1 := &testPlugin{

--- a/plugin/toolmessages.go
+++ b/plugin/toolmessages.go
@@ -1,0 +1,55 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package plugin
+
+import (
+	"context"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+// AfterToolMessagesArgs contains the model-facing context available after a
+// tool call has been executed and converted into tool result messages.
+//
+// The Messages slice is a point-in-time view of the next conversation state:
+// request messages, the assistant tool-call message, then current tool result
+// messages. Callbacks should treat it as read-only and return
+// AfterToolMessagesResult to replace the current tool result messages.
+type AfterToolMessagesArgs struct {
+	// Invocation is the active invocation.
+	Invocation *agent.Invocation
+	// Request is the model request that produced ToolCallResponse.
+	Request *model.Request
+	// ToolCallResponse is the assistant response containing tool calls.
+	ToolCallResponse *model.Response
+	// ToolResultEvent is the event carrying the current tool result messages.
+	ToolResultEvent *event.Event
+	// Messages is the current conversation view, including tool results.
+	Messages []model.Message
+	// ToolCalls contains the assistant tool calls being answered.
+	ToolCalls []model.ToolCall
+	// ToolResultMessages contains the current tool result messages.
+	ToolResultMessages []model.Message
+}
+
+// AfterToolMessagesResult contains replacements for tool result messages.
+type AfterToolMessagesResult struct {
+	// ToolResultMessages replaces the current tool result messages when non-empty.
+	// The framework validates that replacements preserve the same tool IDs.
+	ToolResultMessages []model.Message
+}
+
+// AfterToolMessagesCallback is called after tool results are converted into
+// model messages and before the tool result event is emitted.
+type AfterToolMessagesCallback func(
+	ctx context.Context,
+	args *AfterToolMessagesArgs,
+) (*AfterToolMessagesResult, error)


### PR DESCRIPTION
## Summary

- Add an `AfterToolMessages` plugin callback so plugins can rewrite current tool result messages after tool execution and before they are appended to model-facing history.
- Add TencentDB short-term context offload with L0 refs, L1 summaries, L1.5 task boundary handling, L2 Mermaid task maps, L3 token-pressure compression, and companion offload read/search tools.
- Configure context offload through a single `WithContextOffload(ContextOffloadConfig)` option and document the API in the English and Chinese memory docs.

## Validation

- `go test ./memory/tencentdb ./plugin ./internal/flow/processor ./agent`
- `go vet ./memory/tencentdb ./plugin ./internal/flow/processor ./agent`
- `git diff --check`
- Live model integration: `TestContextOffloadPlugin_IntegrationLocalModel`
- Local TencentDB Agent Memory gateway integration: health, capture, conversation search, and session end

## Notes

`go test ./...` was also run. It only failed in `codeexecutor/sandbox` because the local bubblewrap binary does not support `--clearenv`; all context-offload and plugin-related packages passed.