### PR TITLE
fix: carry steer queue across ralph loop

### DIFF
--- a/internal/state/steer/steer.go
+++ b/internal/state/steer/steer.go
@@ -118,6 +118,10 @@ func Attach(inv *agent.Invocation, queue *Queue) {
 		return
 	}
 	inv.SetState(StateKeyQueuedUserMessages, queue)
+	// Establish owning semantics unconditionally: clear any stale borrowed
+	// marker so Close/Clear close the queue regardless of a prior
+	// AttachBorrowed on this invocation.
+	inv.DeleteState(stateKeyBorrowed)
 }
 
 // AttachBorrowed binds a queue to the invocation without ownership: the

--- a/internal/state/steer/steer.go
+++ b/internal/state/steer/steer.go
@@ -22,6 +22,10 @@ import (
 // StateKeyQueuedUserMessages is the invocation state key used by Attach.
 const StateKeyQueuedUserMessages = "__queued_user_messages__"
 
+// stateKeyBorrowed marks an attachment as non-owning: the invocation may drain
+// the queue but must not close it (see AttachBorrowed and Close).
+const stateKeyBorrowed = "__queued_user_messages_borrowed__"
+
 const (
 	// ExtensionKeyQueuedUserMessage marks events emitted when queued user
 	// messages are consumed at a safe boundary.
@@ -107,12 +111,33 @@ func (q *Queue) Close() {
 	q.closed = true
 }
 
-// Attach binds a queue to the invocation.
+// Attach binds a queue to the invocation. The invocation owns the queue: a
+// subsequent Close (or Clear) closes it.
 func Attach(inv *agent.Invocation, queue *Queue) {
 	if inv == nil || queue == nil {
 		return
 	}
 	inv.SetState(StateKeyQueuedUserMessages, queue)
+}
+
+// AttachBorrowed binds a queue to the invocation without ownership: the
+// invocation may drain the queue, but Close (and Clear) leave it open so the
+// true owner can keep accepting enqueues. The ralph loop uses this to share the
+// run's live queue with each iteration's inner agent — the inner llmflow closes
+// its invocation queue when it finishes, but that must not close the run-level
+// queue the runner enqueues onto across iterations.
+func AttachBorrowed(inv *agent.Invocation, queue *Queue) {
+	if inv == nil || queue == nil {
+		return
+	}
+	inv.SetState(StateKeyQueuedUserMessages, queue)
+	inv.SetState(stateKeyBorrowed, true)
+}
+
+// isBorrowed reports whether the invocation holds a non-owning attachment.
+func isBorrowed(inv *agent.Invocation) bool {
+	borrowed, ok := agent.GetStateValue[bool](inv, stateKeyBorrowed)
+	return ok && borrowed
 }
 
 // IsAttached reports whether a queue is attached to the invocation.
@@ -136,9 +161,10 @@ func Drain(inv *agent.Invocation) []model.Message {
 	return queue.Drain()
 }
 
-// Close rejects future enqueues for the invocation queue.
+// Close rejects future enqueues for the invocation queue. A borrowed
+// attachment (see AttachBorrowed) is left open: only its owner may close it.
 func Close(inv *agent.Invocation) {
-	if inv == nil {
+	if inv == nil || isBorrowed(inv) {
 		return
 	}
 	queue, ok := agent.GetStateValue[*Queue](
@@ -150,11 +176,12 @@ func Close(inv *agent.Invocation) {
 	}
 }
 
-// Clear closes the queue and removes it from the invocation.
+// Clear closes the queue (unless borrowed) and removes it from the invocation.
 func Clear(inv *agent.Invocation) {
 	if inv == nil {
 		return
 	}
 	Close(inv)
 	inv.DeleteState(StateKeyQueuedUserMessages)
+	inv.DeleteState(stateKeyBorrowed)
 }

--- a/internal/state/steer/steer_test.go
+++ b/internal/state/steer/steer_test.go
@@ -129,6 +129,42 @@ func TestAttach_NotInheritedByPlainClone(t *testing.T) {
 	require.Nil(t, Drain(clone), "sub-agent clone must not drain the lead's steer")
 }
 
+// TestAttachBorrowed_DrainsButCloseIsNoOp pins the non-owning attachment: a
+// borrowed invocation may drain the queue, but Close (and Clear) must leave it
+// open so the owner keeps accepting enqueues. This is what lets the ralph loop
+// share the run's live queue with each iteration's inner agent without the
+// inner llmflow's Close closing the run-level queue.
+func TestAttachBorrowed_DrainsButCloseIsNoOp(t *testing.T) {
+	inv := agent.NewInvocation()
+	queue := NewQueue()
+	AttachBorrowed(inv, queue)
+	require.True(t, IsAttached(inv))
+
+	// Borrowing still drains.
+	require.True(t, queue.Enqueue(model.NewUserMessage("steer")))
+	drained := Drain(inv)
+	require.Len(t, drained, 1)
+	require.Equal(t, "steer", drained[0].Content)
+
+	// Close on a borrowed attachment is a no-op: the queue stays open.
+	Close(inv)
+	require.True(t, queue.Enqueue(model.NewUserMessage("after close")),
+		"Close on a borrowed attachment must not close the queue")
+
+	// Clear on a borrowed attachment detaches without closing.
+	Clear(inv)
+	require.False(t, IsAttached(inv))
+	require.True(t, queue.Enqueue(model.NewUserMessage("after clear")),
+		"Clear on a borrowed attachment must not close the queue")
+
+	// An owning attachment, by contrast, closes on Close.
+	owner := agent.NewInvocation()
+	Attach(owner, queue)
+	Close(owner)
+	require.False(t, queue.Enqueue(model.NewUserMessage("rejected")),
+		"Close on an owning attachment must close the queue")
+}
+
 func TestNilSafety(t *testing.T) {
 	var (
 		invocation *agent.Invocation

--- a/internal/state/steer/steer_test.go
+++ b/internal/state/steer/steer_test.go
@@ -165,6 +165,22 @@ func TestAttachBorrowed_DrainsButCloseIsNoOp(t *testing.T) {
 		"Close on an owning attachment must close the queue")
 }
 
+// TestAttach_AfterBorrowedReestablishesOwnership pins that Attach establishes
+// owning semantics unconditionally: re-attaching (owning) over a prior borrowed
+// attachment on the same invocation clears the stale borrowed marker, so Close
+// closes the queue rather than treating it as still borrowed.
+func TestAttach_AfterBorrowedReestablishesOwnership(t *testing.T) {
+	inv := agent.NewInvocation()
+	queue := NewQueue()
+
+	AttachBorrowed(inv, queue)
+	Attach(inv, queue) // re-attach as owner
+
+	Close(inv)
+	require.False(t, queue.Enqueue(model.NewUserMessage("rejected")),
+		"Attach must clear a stale borrowed marker so Close closes the queue")
+}
+
 func TestNilSafety(t *testing.T) {
 	var (
 		invocation *agent.Invocation

--- a/internal/state/steer/steer_test.go
+++ b/internal/state/steer/steer_test.go
@@ -108,6 +108,27 @@ func TestQueue_DiscardClearsQueuedMessagesWithoutClosing(t *testing.T) {
 	require.Equal(t, "three", drained[0].Content)
 }
 
+// TestAttach_NotInheritedByPlainClone pins the member-isolation invariant: the
+// steer queue is deliberately NOT in the invocation clone allowlist, so a plain
+// Clone (the path delegated sub-agents take — agent_tool clones the parent
+// invocation) does NOT inherit it. Otherwise a member sub-agent would drain a
+// steer the user meant for the lead. The ralph loop re-attaches the queue to its
+// inner (lead) invocation explicitly; see runner.newInnerInvocation.
+func TestAttach_NotInheritedByPlainClone(t *testing.T) {
+	root := agent.NewInvocation()
+	queue := NewQueue()
+	Attach(root, queue)
+	require.True(t, IsAttached(root))
+
+	clone := root.Clone()
+	require.False(t, IsAttached(clone),
+		"a plain clone (delegated sub-agent) must NOT inherit the steer queue")
+
+	// A steer enqueued on the root is invisible to the clone — it cannot drain it.
+	require.True(t, queue.Enqueue(model.NewUserMessage("steer")))
+	require.Nil(t, Drain(clone), "sub-agent clone must not drain the lead's steer")
+}
+
 func TestNilSafety(t *testing.T) {
 	var (
 		invocation *agent.Invocation

--- a/runner/ralph_loop.go
+++ b/runner/ralph_loop.go
@@ -300,15 +300,22 @@ func (a *ralphLoopAgent) newInnerInvocation(
 	}
 	inner := base.Clone(invocationOpts...)
 
-	// Carry the steer queue across the iteration boundary so user messages
-	// enqueued onto the run (Runner.EnqueueUserMessage) reach the inner agent and
-	// drain at its next safe boundary. The queue is intentionally NOT in the
-	// clone allowlist: that would also propagate it into delegated sub-agent
-	// invocations (which Clone the inner agent), and a member would then drain a
-	// steer meant for the lead. Re-attaching here scopes it to exactly the
-	// loop's inner agent — the lead the user is steering.
+	// Carry the run's steer queue across the iteration boundary so user
+	// messages enqueued onto the run (Runner.EnqueueUserMessage) reach the inner
+	// agent and drain at its next safe boundary.
+	//
+	// The attachment is borrowed, not owning: the inner llmflow closes its
+	// invocation queue when it finishes an iteration, but the run-level queue
+	// must stay open across iterations — otherwise EnqueueUserMessage returns
+	// ErrRunNotFound for every steer after the first iteration. The runner owns
+	// the queue and closes it once when the whole run ends.
+	//
+	// It is also intentionally NOT in the clone allowlist: that would propagate
+	// it into delegated sub-agent invocations (which Clone the inner agent), and
+	// a member would then drain a steer meant for the lead. Re-attaching here
+	// scopes it to exactly the loop's inner agent — the lead the user is steering.
 	if queue, ok := agent.GetStateValue[*steer.Queue](base, steer.StateKeyQueuedUserMessages); ok && queue != nil {
-		steer.Attach(inner, queue)
+		steer.AttachBorrowed(inner, queue)
 	}
 	return inner
 }

--- a/runner/ralph_loop.go
+++ b/runner/ralph_loop.go
@@ -23,6 +23,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/appender"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/steer"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
@@ -297,7 +298,19 @@ func (a *ralphLoopAgent) newInnerInvocation(
 	if len(entryPredecessors) > 0 {
 		invocationOpts = append(invocationOpts, agent.WithInvocationEntryPredecessorStepIDs(entryPredecessors))
 	}
-	return base.Clone(invocationOpts...)
+	inner := base.Clone(invocationOpts...)
+
+	// Carry the steer queue across the iteration boundary so user messages
+	// enqueued onto the run (Runner.EnqueueUserMessage) reach the inner agent and
+	// drain at its next safe boundary. The queue is intentionally NOT in the
+	// clone allowlist: that would also propagate it into delegated sub-agent
+	// invocations (which Clone the inner agent), and a member would then drain a
+	// steer meant for the lead. Re-attaching here scopes it to exactly the
+	// loop's inner agent — the lead the user is steering.
+	if queue, ok := agent.GetStateValue[*steer.Queue](base, steer.StateKeyQueuedUserMessages); ok && queue != nil {
+		steer.Attach(inner, queue)
+	}
+	return inner
 }
 
 func (a *ralphLoopAgent) forwardEvents(

--- a/runner/ralph_loop_test.go
+++ b/runner/ralph_loop_test.go
@@ -49,6 +49,13 @@ func TestNewInnerInvocation_ReattachesSteerQueue(t *testing.T) {
 	require.Len(t, drained, 1)
 	require.Equal(t, "steer", drained[0].Content)
 
+	// The inner llmflow closes its invocation queue when an iteration ends. That
+	// must NOT close the run-level queue: the runner keeps accepting steers
+	// across iterations. The attachment is borrowed, so Close is a no-op here.
+	steer.Close(inner)
+	require.True(t, queue.Enqueue(model.NewUserMessage("next iteration")),
+		"closing a borrowed inner invocation must leave the run-level queue open")
+
 	// A delegated sub-agent (agent_tool clones the inner invocation) must NOT
 	// inherit the queue — otherwise a member would drain the lead's steer.
 	member := inner.Clone()

--- a/runner/ralph_loop_test.go
+++ b/runner/ralph_loop_test.go
@@ -22,11 +22,39 @@ import (
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/steer"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	sessioninmemory "trpc.group/trpc-go/trpc-agent-go/session/inmemory"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
+
+// TestNewInnerInvocation_ReattachesSteerQueue verifies the ralph loop carries
+// the steer queue across the per-iteration clone to its inner (lead) agent, so
+// EnqueueUserMessage reaches the agent the user is steering — while a delegated
+// sub-agent (a plain clone of the inner invocation) does NOT inherit it.
+func TestNewInnerInvocation_ReattachesSteerQueue(t *testing.T) {
+	a := &ralphLoopAgent{inner: &scriptedAgent{name: "lead"}}
+	base := agent.NewInvocation()
+	queue := steer.NewQueue()
+	steer.Attach(base, queue)
+
+	inner := a.newInnerInvocation(base, nil)
+	require.True(t, steer.IsAttached(inner),
+		"ralph must re-attach the steer queue to its inner (lead) invocation")
+
+	// The re-attached queue is the SAME object the runner enqueues onto.
+	require.True(t, queue.Enqueue(model.NewUserMessage("steer")))
+	drained := steer.Drain(inner)
+	require.Len(t, drained, 1)
+	require.Equal(t, "steer", drained[0].Content)
+
+	// A delegated sub-agent (agent_tool clones the inner invocation) must NOT
+	// inherit the queue — otherwise a member would drain the lead's steer.
+	member := inner.Clone()
+	require.False(t, steer.IsAttached(member),
+		"a delegated sub-agent must not inherit the lead's steer queue")
+}
 
 type scriptedAgent struct {
 	name    string


### PR DESCRIPTION
runner, internal/state/steer iterations

Runner.EnqueueUserMessage attaches the steer queue to the run's root invocation, but ralphLoopAgent.newInnerInvocation builds each iteration's inner invocation via Invocation.Clone, which deliberately does not copy the steer queue. As a result, messages enqueued onto a ralph-loop run are never drained by the inner agent: queued steers sit unprocessed for the lifetime of the run.

Fix: re-attach the queue explicitly in newInnerInvocation. This is scoped re-attachment, not a clone-allowlist change: adding the queue to the Clone allowlist would also propagate it into delegated sub-agent invocations (agent_tool clones the parent invocation), letting a member agent drain a steer meant for the lead. Re-attaching only at the loop boundary keeps the queue on exactly the agent the user is steering.

Tests:
- runner: TestNewInnerInvocation_ReattachesSteerQueue pins both halves — the inner (lead) invocation drains the runner's queue, while a plain clone of it (a delegated sub-agent) does not inherit the queue.
- internal/state/steer: TestAttach_NotInheritedByPlainClone pins the member-isolation invariant that the queue stays out of plain clones.

## What changed

Describe the user-visible behavior, API, documentation, or example changes in
this pull request.

## Why

Explain the problem this solves and any compatibility considerations.

## Testing

List the commands or manual checks you ran. If a check is not applicable, say
why.

## Notes for reviewers

Call out areas that deserve extra attention, such as concurrency, persistence,
protocol compatibility, or public API changes.
