### PR TITLE
fix(sqlite): allow WithAsyncSummaryNum(0) to disable async workers

### DIFF
--- a/session/sqlite/options.go
+++ b/session/sqlite/options.go
@@ -152,6 +152,8 @@ func WithSummarizer(s summary.SessionSummarizer) ServiceOpt {
 }
 
 // WithAsyncSummaryNum sets the number of async summary workers.
+// A value of 0 disables async summary workers and falls back to synchronous
+// processing. Negative values fall back to the default (defaultAsyncSummaryNum).
 func WithAsyncSummaryNum(num int) ServiceOpt {
 	return func(opts *ServiceOpts) {
 		if num < 0 {

--- a/session/sqlite/options.go
+++ b/session/sqlite/options.go
@@ -154,7 +154,7 @@ func WithSummarizer(s summary.SessionSummarizer) ServiceOpt {
 // WithAsyncSummaryNum sets the number of async summary workers.
 func WithAsyncSummaryNum(num int) ServiceOpt {
 	return func(opts *ServiceOpts) {
-		if num < 1 {
+		if num < 0 {
 			num = defaultAsyncSummaryNum
 		}
 		opts.asyncSummaryNum = num

--- a/session/sqlite/summary_test.go
+++ b/session/sqlite/summary_test.go
@@ -31,9 +31,9 @@ func TestSessionSQLite_EnqueueSummaryJob_And_Fallback(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { require.NoError(t, svc.Close()) }()
 
-	// Force sync processing for deterministic testing.
-	require.NotNil(t, svc.asyncWorker)
-	svc.asyncWorker.Stop()
+	// When asyncSummaryNum is 0, asyncWorker should be nil and
+	// EnqueueSummaryJob will fall back to synchronous processing.
+	require.Nil(t, svc.asyncWorker)
 
 	ctx := context.Background()
 	key := session.Key{AppName: "app", UserID: "u1", SessionID: "s1"}


### PR DESCRIPTION
## Problem

WithAsyncSummaryNum(0) does not disable async summary workers because the validation logic rejects values < 1.

## Solution

Change validation from `num < 1` to `num < 0` in WithAsyncSummaryNum so that passing 0 is accepted as a valid value to disable async summary workers.

## Testing

- Verified that WithAsyncSummaryNum(0) now correctly sets asyncSummaryNum to 0
- Verified that negative values still fall back to defaultAsyncSummaryNum

Fixes #1966