### PR TITLE
{agent, plugin, runner, docs}: add per-run plugin injection

### DIFF
--- a/agent/invocation.go
+++ b/agent/invocation.go
@@ -1208,6 +1208,9 @@ type RunOptions struct {
 	// Key: agent type, Value: agent-specific config.
 	CustomAgentConfigs map[string]any
 
+	// Plugins contains plugin managers that apply only to this run.
+	Plugins []PluginManager
+
 	// Agent overrides the runner's default agent for this run.
 	Agent Agent
 

--- a/docs/mkdocs/en/plugin.md
+++ b/docs/mkdocs/en/plugin.md
@@ -152,6 +152,29 @@ runnerInstance := runner.NewRunner(
 defer runnerInstance.Close()
 ```
 
+## Per-run Plugins
+
+If a plugin should affect only the current request instead of the whole Runner,
+inject it into `Runner.Run(...)` through `plugin.WithPlugins(...)`:
+
+```go
+events, err := runnerInstance.Run(
+	ctx,
+	userID,
+	sessionID,
+	message,
+	plugin.WithPlugins(&RequestScopedPlugin{}),
+)
+```
+
+`plugin.WithPlugins(...)` is a RunOption and only affects this run. It reuses
+the same `plugin.Plugin` interface and hook points, which makes it suitable for
+request-scoped policies, test doubles, and temporary audit tagging. Plugin names
+within the same `plugin.WithPlugins(...)` call still must be unique; if the
+configuration is invalid, the framework logs the error and skips that set of
+run-level plugins. Runner does not call `Close()` on these plugins when the
+single run ends. If a plugin owns resources, the caller must manage them.
+
 ## Tool Identity Injection
 
 Plugins can add pre-processing or post-processing to every tool call through
@@ -263,7 +286,15 @@ if toolCallID, ok := tool.ToolCallIDFromContext(ctx); ok {
 
 ### Order and early-exit (short-circuit)
 
-Plugins run **in the order they are registered**.
+Plugins run by scope and registration order:
+
+1. Runner-level plugins registered through `runner.WithPlugins(...)` run first.
+2. Per-run plugins injected through `plugin.WithPlugins(...)` run next; multiple
+   RunOptions run in the order passed to `Runner.Run(...)`.
+3. Agent callbacks run last, if any.
+
+Multiple plugins in the same `WithPlugins(...)` call still run in argument
+order.
 
 Some “before” hooks can short-circuit default behavior:
 
@@ -314,9 +345,15 @@ stores shared state, make it safe for concurrent use (for example, by using
 
 ### Close (resource cleanup)
 
-If a plugin implements `plugin.Closer`, Runner calls `Close()` when you call
-`Runner.Close()`. Plugins are closed in **reverse registration order**, so
-later plugins can depend on earlier ones during shutdown.
+If a plugin registered through `runner.WithPlugins(...)` implements
+`plugin.Closer`, Runner calls `Close()` when you call `Runner.Close()`.
+Plugins are closed in **reverse registration order**, so later plugins can
+depend on earlier ones during shutdown.
+
+Per-run plugins injected through `plugin.WithPlugins(...)` are not closed by
+Runner when the run ends. They are usually objects temporarily provided by the
+caller for this run; if they own resources that must be released, close them at
+the appropriate time in the caller.
 
 ## Hook Points (What you can intercept)
 

--- a/docs/mkdocs/en/runner.md
+++ b/docs/mkdocs/en/runner.md
@@ -368,6 +368,24 @@ Notes:
 - Plugins run in the order they are registered.
 - If a plugin implements `plugin.Closer`, Runner will call it in `Close()`.
 
+If a plugin should affect only one run, pass it to `Run` as a RunOption:
+
+```go
+eventChan, err := r.Run(
+    ctx,
+    userID,
+    sessionID,
+    message,
+    plugin.WithPlugins(requestPlugin),
+)
+```
+
+Per-run plugins run after Runner-level plugins and only affect this `Run`.
+Runner does not call `Close()` on these plugins when the run ends; if a plugin
+owns external resources, the caller must manage them. See the
+[plugin documentation](plugin.md) for the full scope, execution order, and
+lifecycle details.
+
 ### 🔄 Ralph Loop Mode
 
 Ralph Loop is an "outer loop" mode. Instead of trusting a Large Language Model

--- a/docs/mkdocs/zh/plugin.md
+++ b/docs/mkdocs/zh/plugin.md
@@ -192,6 +192,27 @@ runnerInstance := runner.NewRunner(
 defer runnerInstance.Close()
 ```
 
+## 单次 Run 插件
+
+如果插件只应该影响当前请求，而不是挂到整个 Runner 上，可以在
+`Runner.Run(...)` 中通过 `plugin.WithPlugins(...)` 临时注入：
+
+```go
+events, err := runnerInstance.Run(
+	ctx,
+	userID,
+	sessionID,
+	message,
+	plugin.WithPlugins(&RequestScopedPlugin{}),
+)
+```
+
+`plugin.WithPlugins(...)` 是 RunOption，只对本次运行生效。它复用同一套
+`plugin.Plugin` 接口和 Hook 点，适合请求级策略、测试替身和临时审计打标。同一次
+`plugin.WithPlugins(...)` 里的插件名仍然需要唯一；配置无效时，框架会记录错误并跳过
+这组 Run 级插件。Runner 不会因为单次 Run 结束而调用这些插件的 `Close()`，如果插件
+持有资源，需要调用方自行管理。
+
 ## 工具身份注入
 
 插件可以通过 `BeforeTool` 和 `AfterTool` 对所有工具调用增加前置或后置处理。
@@ -299,7 +320,14 @@ if toolCallID, ok := tool.ToolCallIDFromContext(ctx); ok {
 
 ### 执行顺序与短路（short-circuit）
 
-插件会 **按注册顺序执行**。
+插件会按作用域和注册顺序执行：
+
+1. 先执行 `runner.WithPlugins(...)` 注册的 Runner 级插件。
+2. 再执行 `plugin.WithPlugins(...)` 注入的单次 Run 插件；多个 RunOption 按传入
+   `Runner.Run(...)` 的顺序执行。
+3. 最后执行 Agent 自己配置的回调（如果有）。
+
+同一个 `WithPlugins(...)` 调用里的多个插件仍按传入顺序执行。
 
 某些 Before* 回调支持“短路”默认行为：
 
@@ -342,8 +370,13 @@ if toolCallID, ok := tool.ToolCallIDFromContext(ctx); ok {
 
 ### Close（资源释放）
 
-如果插件实现了 `plugin.Closer`，当你调用 `Runner.Close()` 时，Runner 会调用插件的
-`Close()` 来释放资源。关闭顺序是 **按注册顺序的反向**（后注册的先关闭）。
+如果通过 `runner.WithPlugins(...)` 注册的插件实现了 `plugin.Closer`，当你调用
+`Runner.Close()` 时，Runner 会调用插件的 `Close()` 来释放资源。关闭顺序是
+**按注册顺序的反向**（后注册的先关闭）。
+
+通过 `plugin.WithPlugins(...)` 注入的单次 Run 插件不会在本次运行结束时被 Runner
+关闭。它们通常是调用方临时借给本次运行的对象；如果插件持有需要释放的资源，请由
+调用方在合适的时机关闭。
 
 ## Hook 点（Hook Points）
 

--- a/docs/mkdocs/zh/runner.md
+++ b/docs/mkdocs/zh/runner.md
@@ -354,6 +354,22 @@ defer r.Close()
 - 插件按注册顺序执行。
 - 如果插件实现了 `plugin.Closer`，Runner 会在 `Close()` 时调用它。
 
+如果插件只需要影响某一次运行，可以把它作为 RunOption 传给 `Run`：
+
+```go
+eventChan, err := r.Run(
+    ctx,
+    userID,
+    sessionID,
+    message,
+    plugin.WithPlugins(requestPlugin),
+)
+```
+
+单次 Run 插件会排在 Runner 级插件之后执行，只对本次 `Run` 生效。Runner 不会在
+本次运行结束时调用这些插件的 `Close()`；如果插件持有外部资源，调用方需要自行管理。
+更完整的作用域、执行顺序和生命周期说明见 [插件文档](plugin.md)。
+
 ### 🔄 Ralph Loop Mode
 
 Ralph Loop 是一种“外部循环（outer loop）”模式：不依赖 LLM 主观判断“我已经完成了”，

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -82,6 +82,35 @@ func TestMustNewManager_PanicsOnError(t *testing.T) {
 	})
 }
 
+func TestWithPlugins_AppendsRunPluginManager(t *testing.T) {
+	var opts agent.RunOptions
+	called := false
+	p := &testPlugin{
+		name: "p",
+		reg: func(r *plugin.Registry) {
+			r.BeforeAgent(func(ctx context.Context, args *agent.BeforeAgentArgs) (*agent.BeforeAgentResult, error) {
+				called = true
+				return nil, nil
+			})
+		},
+	}
+	plugin.WithPlugins(p)(&opts)
+	require.Len(t, opts.Plugins, 1)
+	callbacks := opts.Plugins[0].AgentCallbacks()
+	require.NotNil(t, callbacks)
+	_, err := callbacks.RunBeforeAgent(context.Background(), &agent.BeforeAgentArgs{})
+	require.NoError(t, err)
+	require.True(t, called)
+}
+
+func TestWithPlugins_InvalidPluginDoesNotAppendRunPluginManager(t *testing.T) {
+	var opts agent.RunOptions
+	require.NotPanics(t, func() {
+		plugin.WithPlugins(nil)(&opts)
+	})
+	require.Empty(t, opts.Plugins)
+}
+
 func TestManager_CallbackSetsNilWhenEmpty(t *testing.T) {
 	m, err := plugin.NewManager()
 	require.NoError(t, err)

--- a/plugin/options.go
+++ b/plugin/options.go
@@ -1,0 +1,28 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package plugin
+
+import (
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/log"
+)
+
+// WithPlugins registers plugins for one runner.Run call.
+func WithPlugins(plugins ...Plugin) agent.RunOption {
+	copied := append([]Plugin(nil), plugins...)
+	return func(opts *agent.RunOptions) {
+		manager, err := NewManager(copied...)
+		if err != nil {
+			log.Errorf("configure run plugins failed: %v", err)
+			return
+		}
+		opts.Plugins = append(opts.Plugins, manager)
+	}
+}

--- a/runner/plugin.go
+++ b/runner/plugin.go
@@ -1,0 +1,178 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package runner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/plugin"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+type pluginManagerChain []agent.PluginManager
+
+type afterToolMessagesManager interface {
+	AfterToolMessages(
+		context.Context,
+		*plugin.AfterToolMessagesArgs,
+	) (*plugin.AfterToolMessagesResult, error)
+}
+
+func newPluginManagerChain(managers ...agent.PluginManager) agent.PluginManager {
+	filtered := make([]agent.PluginManager, 0, len(managers))
+	for _, manager := range managers {
+		if manager != nil {
+			filtered = append(filtered, manager)
+		}
+	}
+	if len(filtered) == 0 {
+		return nil
+	}
+	if len(filtered) == 1 {
+		return filtered[0]
+	}
+	return pluginManagerChain(filtered)
+}
+
+func combineRunPlugins(runnerPlugins agent.PluginManager, runPlugins []agent.PluginManager) agent.PluginManager {
+	managers := make([]agent.PluginManager, 0, 1+len(runPlugins))
+	managers = append(managers, runnerPlugins)
+	managers = append(managers, runPlugins...)
+	return newPluginManagerChain(managers...)
+}
+
+func (c pluginManagerChain) AgentCallbacks() *agent.Callbacks {
+	out := agent.NewCallbacks()
+	hasCallbacks := false
+	for _, manager := range c {
+		callbacks := manager.AgentCallbacks()
+		if callbacks == nil {
+			continue
+		}
+		hasCallbacks = true
+		current := callbacks
+		out.RegisterBeforeAgent(func(ctx context.Context, args *agent.BeforeAgentArgs) (*agent.BeforeAgentResult, error) {
+			return current.RunBeforeAgent(ctx, args)
+		})
+		out.RegisterAfterAgent(func(ctx context.Context, args *agent.AfterAgentArgs) (*agent.AfterAgentResult, error) {
+			return current.RunAfterAgent(ctx, args)
+		})
+	}
+	if !hasCallbacks {
+		return nil
+	}
+	return out
+}
+
+func (c pluginManagerChain) ModelCallbacks() *model.Callbacks {
+	out := model.NewCallbacks()
+	hasCallbacks := false
+	for _, manager := range c {
+		callbacks := manager.ModelCallbacks()
+		if callbacks == nil {
+			continue
+		}
+		hasCallbacks = true
+		current := callbacks
+		out.RegisterBeforeModel(func(ctx context.Context, args *model.BeforeModelArgs) (*model.BeforeModelResult, error) {
+			return current.RunBeforeModel(ctx, args)
+		})
+		out.RegisterAfterModel(func(ctx context.Context, args *model.AfterModelArgs) (*model.AfterModelResult, error) {
+			return current.RunAfterModel(ctx, args)
+		})
+	}
+	if !hasCallbacks {
+		return nil
+	}
+	return out
+}
+
+func (c pluginManagerChain) ToolCallbacks() *tool.Callbacks {
+	out := tool.NewCallbacks()
+	hasCallbacks := false
+	for _, manager := range c {
+		callbacks := manager.ToolCallbacks()
+		if callbacks == nil {
+			continue
+		}
+		if len(callbacks.BeforeTool) > 0 {
+			hasCallbacks = true
+			current := callbacks
+			out.RegisterBeforeTool(func(ctx context.Context, args *tool.BeforeToolArgs) (*tool.BeforeToolResult, error) {
+				return current.RunBeforeTool(ctx, args)
+			})
+		}
+		if len(callbacks.AfterTool) > 0 {
+			hasCallbacks = true
+			current := callbacks
+			out.RegisterAfterTool(func(ctx context.Context, args *tool.AfterToolArgs) (*tool.AfterToolResult, error) {
+				return current.RunAfterTool(ctx, args)
+			})
+		}
+		if callbacks.ToolResultMessages != nil {
+			hasCallbacks = true
+			out.RegisterToolResultMessages(callbacks.ToolResultMessages)
+		}
+	}
+	if !hasCallbacks {
+		return nil
+	}
+	return out
+}
+
+func (c pluginManagerChain) OnEvent(ctx context.Context, invocation *agent.Invocation, e *event.Event) (*event.Event, error) {
+	current := e
+	for _, manager := range c {
+		updated, err := manager.OnEvent(ctx, invocation, current)
+		if err != nil {
+			return nil, err
+		}
+		if updated != nil {
+			current = updated
+		}
+	}
+	return current, nil
+}
+
+func (c pluginManagerChain) AfterToolMessages(
+	ctx context.Context,
+	args *plugin.AfterToolMessagesArgs,
+) (*plugin.AfterToolMessagesResult, error) {
+	var last *plugin.AfterToolMessagesResult
+	for _, manager := range c {
+		hooks, ok := manager.(afterToolMessagesManager)
+		if !ok {
+			continue
+		}
+		result, err := hooks.AfterToolMessages(ctx, args)
+		if err != nil {
+			return result, err
+		}
+		if result != nil && len(result.ToolResultMessages) > 0 {
+			last = result
+		}
+	}
+	return last, nil
+}
+
+func (c pluginManagerChain) Close(ctx context.Context) error {
+	var errs []error
+	for i := len(c) - 1; i >= 0; i-- {
+		if err := c[i].Close(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("plugin manager %d: %w", i, err))
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -758,7 +758,7 @@ func (r *runner) newRunInvocation(
 		agent.WithInvocationMemoryService(r.memoryService),
 		agent.WithInvocationArtifactService(r.artifactService),
 		agent.WithInvocationEventFilterKey(eventFilterKey),
-		agent.WithInvocationPlugins(r.pluginManager),
+		agent.WithInvocationPlugins(combineRunPlugins(r.pluginManager, ro.Plugins)),
 	}
 	if awaitUserReplyLookupPath != "" {
 		invocationOpts = append(

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -1449,6 +1449,347 @@ func TestRunner_WithPlugins_AppliesHooks(t *testing.T) {
 	}
 }
 
+type closeableTestPlugin struct {
+	testPlugin
+	closed bool
+}
+
+func (p *closeableTestPlugin) Close(ctx context.Context) error {
+	p.closed = true
+	return nil
+}
+
+type chainTestPluginManager struct {
+	agentCallbacks *agent.Callbacks
+	modelCallbacks *model.Callbacks
+	toolCallbacks  *tool.Callbacks
+	eventHook      func(context.Context, *agent.Invocation, *event.Event) (*event.Event, error)
+	closeHook      func(context.Context) error
+}
+
+func (m *chainTestPluginManager) AgentCallbacks() *agent.Callbacks {
+	return m.agentCallbacks
+}
+
+func (m *chainTestPluginManager) ModelCallbacks() *model.Callbacks {
+	return m.modelCallbacks
+}
+
+func (m *chainTestPluginManager) ToolCallbacks() *tool.Callbacks {
+	return m.toolCallbacks
+}
+
+func (m *chainTestPluginManager) OnEvent(
+	ctx context.Context,
+	invocation *agent.Invocation,
+	e *event.Event,
+) (*event.Event, error) {
+	if m.eventHook == nil {
+		return e, nil
+	}
+	return m.eventHook(ctx, invocation, e)
+}
+
+func (m *chainTestPluginManager) Close(ctx context.Context) error {
+	if m.closeHook == nil {
+		return nil
+	}
+	return m.closeHook(ctx)
+}
+
+func TestRunner_RunWithPlugins_AppliesAfterRunnerPluginsAndDoesNotClosePlugin(t *testing.T) {
+	var order []string
+	runnerPlugin := &testPlugin{
+		name: "runner",
+		reg: func(r *plugin.Registry) {
+			r.BeforeAgent(func(ctx context.Context, args *agent.BeforeAgentArgs) (*agent.BeforeAgentResult, error) {
+				order = append(order, "runner")
+				return nil, nil
+			})
+		},
+	}
+	runPlugin := &closeableTestPlugin{
+		testPlugin: testPlugin{
+			name: "run",
+			reg: func(r *plugin.Registry) {
+				r.BeforeAgent(func(ctx context.Context, args *agent.BeforeAgentArgs) (*agent.BeforeAgentResult, error) {
+					order = append(order, "run")
+					return nil, nil
+				})
+			},
+		},
+	}
+	sessionService := sessioninmemory.NewSessionService()
+	ag := &mockAgent{name: "test-agent"}
+	r := NewRunner(
+		"test-app",
+		ag,
+		WithSessionService(sessionService),
+		WithPlugins(runnerPlugin),
+	)
+	for _, sessionID := range []string{"s1", "s2"} {
+		ch, err := r.Run(
+			context.Background(),
+			"u",
+			sessionID,
+			model.NewUserMessage("hi"),
+			plugin.WithPlugins(runPlugin),
+		)
+		require.NoError(t, err)
+		for range ch {
+		}
+	}
+	require.Equal(t, []string{"runner", "run", "runner", "run"}, order)
+	require.False(t, runPlugin.closed)
+}
+
+func TestPluginManagerChain_FiltersManagers(t *testing.T) {
+	manager := &chainTestPluginManager{}
+	require.Nil(t, newPluginManagerChain(nil, nil))
+	require.Same(t, manager, newPluginManagerChain(nil, manager))
+	chain, ok := newPluginManagerChain(manager, nil, &chainTestPluginManager{}).(pluginManagerChain)
+	require.True(t, ok)
+	require.Len(t, chain, 2)
+}
+
+func TestPluginManagerChain_RunsCallbacksInManagerOrder(t *testing.T) {
+	var order []string
+	first := newChainTestPluginManager("first", &order)
+	second := newChainTestPluginManager("second", &order)
+	chain := newPluginManagerChain(first, second)
+	_, err := chain.AgentCallbacks().RunBeforeAgent(context.Background(), &agent.BeforeAgentArgs{})
+	require.NoError(t, err)
+	_, err = chain.AgentCallbacks().RunAfterAgent(context.Background(), &agent.AfterAgentArgs{})
+	require.NoError(t, err)
+	_, err = chain.ModelCallbacks().RunBeforeModel(context.Background(), &model.BeforeModelArgs{})
+	require.NoError(t, err)
+	_, err = chain.ModelCallbacks().RunAfterModel(context.Background(), &model.AfterModelArgs{})
+	require.NoError(t, err)
+	_, err = chain.ToolCallbacks().RunBeforeTool(context.Background(), &tool.BeforeToolArgs{})
+	require.NoError(t, err)
+	_, err = chain.ToolCallbacks().RunAfterTool(context.Background(), &tool.AfterToolArgs{})
+	require.NoError(t, err)
+	eventOut, err := chain.OnEvent(context.Background(), nil, &event.Event{Tag: "start"})
+	require.NoError(t, err)
+	require.Equal(t, "start-first-second", eventOut.Tag)
+	require.Equal(t, []string{
+		"first:before-agent",
+		"second:before-agent",
+		"first:after-agent",
+		"second:after-agent",
+		"first:before-model",
+		"second:before-model",
+		"first:after-model",
+		"second:after-model",
+		"first:before-tool",
+		"second:before-tool",
+		"first:after-tool",
+		"second:after-tool",
+		"first:event",
+		"second:event",
+	}, order)
+}
+
+func TestPluginManagerChain_ReturnsNilWhenManagersHaveNoCallbacks(t *testing.T) {
+	chain := pluginManagerChain{&chainTestPluginManager{}}
+	require.Nil(t, chain.AgentCallbacks())
+	require.Nil(t, chain.ModelCallbacks())
+	require.Nil(t, chain.ToolCallbacks())
+}
+
+func TestPluginManagerChain_ToolResultMessagesSurvivesMerge(t *testing.T) {
+	toolCallbacks := tool.NewCallbacks()
+	toolCallbacks.RegisterToolResultMessages(func(ctx context.Context, in *tool.ToolResultMessagesInput) (any, error) {
+		return model.NewToolMessage(in.ToolCallID, in.ToolName, "summary"), nil
+	})
+	chain := pluginManagerChain{
+		&chainTestPluginManager{},
+		&chainTestPluginManager{toolCallbacks: toolCallbacks},
+	}
+	callbacks := chain.ToolCallbacks()
+	require.NotNil(t, callbacks)
+	got, err := callbacks.RunToolResultMessages(context.Background(), &tool.ToolResultMessagesInput{
+		ToolName:   "lookup",
+		ToolCallID: "call-1",
+	})
+	require.NoError(t, err)
+	require.Equal(t, model.NewToolMessage("call-1", "lookup", "summary"), got)
+}
+
+func TestPluginManagerChain_OnEventKeepsEventWhenManagerReturnsNil(t *testing.T) {
+	called := false
+	chain := pluginManagerChain{
+		&chainTestPluginManager{eventHook: func(context.Context, *agent.Invocation, *event.Event) (*event.Event, error) {
+			called = true
+			return nil, nil
+		}},
+	}
+	original := &event.Event{Tag: "original"}
+	got, err := chain.OnEvent(context.Background(), nil, original)
+	require.NoError(t, err)
+	require.True(t, called)
+	require.Same(t, original, got)
+}
+
+func TestPluginManagerChain_OnEventStopsOnError(t *testing.T) {
+	expected := errors.New("event failed")
+	chain := pluginManagerChain{
+		&chainTestPluginManager{eventHook: func(context.Context, *agent.Invocation, *event.Event) (*event.Event, error) {
+			return nil, expected
+		}},
+	}
+	got, err := chain.OnEvent(context.Background(), nil, &event.Event{})
+	require.ErrorIs(t, err, expected)
+	require.Nil(t, got)
+}
+
+func newChainTestPluginManager(name string, order *[]string) *chainTestPluginManager {
+	agentCallbacks := agent.NewCallbacks()
+	agentCallbacks.RegisterBeforeAgent(func(context.Context, *agent.BeforeAgentArgs) (*agent.BeforeAgentResult, error) {
+		*order = append(*order, name+":before-agent")
+		return nil, nil
+	})
+	agentCallbacks.RegisterAfterAgent(func(context.Context, *agent.AfterAgentArgs) (*agent.AfterAgentResult, error) {
+		*order = append(*order, name+":after-agent")
+		return nil, nil
+	})
+	modelCallbacks := model.NewCallbacks()
+	modelCallbacks.RegisterBeforeModel(func(context.Context, *model.BeforeModelArgs) (*model.BeforeModelResult, error) {
+		*order = append(*order, name+":before-model")
+		return nil, nil
+	})
+	modelCallbacks.RegisterAfterModel(func(context.Context, *model.AfterModelArgs) (*model.AfterModelResult, error) {
+		*order = append(*order, name+":after-model")
+		return nil, nil
+	})
+	toolCallbacks := tool.NewCallbacks()
+	toolCallbacks.RegisterBeforeTool(func(context.Context, *tool.BeforeToolArgs) (*tool.BeforeToolResult, error) {
+		*order = append(*order, name+":before-tool")
+		return nil, nil
+	})
+	toolCallbacks.RegisterAfterTool(func(context.Context, *tool.AfterToolArgs) (*tool.AfterToolResult, error) {
+		*order = append(*order, name+":after-tool")
+		return nil, nil
+	})
+	return &chainTestPluginManager{
+		agentCallbacks: agentCallbacks,
+		modelCallbacks: modelCallbacks,
+		toolCallbacks:  toolCallbacks,
+		eventHook: func(_ context.Context, _ *agent.Invocation, e *event.Event) (*event.Event, error) {
+			*order = append(*order, name+":event")
+			e.Tag += "-" + name
+			return e, nil
+		},
+	}
+}
+
+func TestPluginManagerChain_AfterToolMessagesRunsManagersInOrder(t *testing.T) {
+	var order []string
+	runnerPlugin := &testPlugin{
+		name: "runner-messages",
+		reg: func(r *plugin.Registry) {
+			r.AfterToolMessages(func(ctx context.Context, args *plugin.AfterToolMessagesArgs) (*plugin.AfterToolMessagesResult, error) {
+				order = append(order, "runner:"+args.ToolResultMessages[0].Content)
+				msg := args.ToolResultMessages[0]
+				msg.Content = "runner summary"
+				return &plugin.AfterToolMessagesResult{ToolResultMessages: []model.Message{msg}}, nil
+			})
+		},
+	}
+	runPlugin := &testPlugin{
+		name: "run-messages",
+		reg: func(r *plugin.Registry) {
+			r.AfterToolMessages(func(ctx context.Context, args *plugin.AfterToolMessagesArgs) (*plugin.AfterToolMessagesResult, error) {
+				order = append(order, "run:"+args.ToolResultMessages[0].Content)
+				msg := args.ToolResultMessages[0]
+				msg.Content = "run summary"
+				return &plugin.AfterToolMessagesResult{ToolResultMessages: []model.Message{msg}}, nil
+			})
+		},
+	}
+	chain := newPluginManagerChain(
+		plugin.MustNewManager(runnerPlugin),
+		plugin.MustNewManager(runPlugin),
+	)
+	hooks, ok := chain.(afterToolMessagesManager)
+	require.True(t, ok)
+	toolMessage := model.NewToolMessage("call-1", "lookup", "raw")
+	args := &plugin.AfterToolMessagesArgs{
+		ToolResultEvent: event.NewResponseEvent("inv", "agent", &model.Response{
+			Object: model.ObjectTypeToolResponse,
+			Choices: []model.Choice{
+				{Message: toolMessage},
+			},
+		}),
+		Messages: []model.Message{
+			model.NewUserMessage("hi"),
+			toolMessage,
+		},
+		ToolResultMessages: []model.Message{toolMessage},
+	}
+	result, err := hooks.AfterToolMessages(context.Background(), args)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, []string{"runner:raw", "run:runner summary"}, order)
+	require.Equal(t, "run summary", result.ToolResultMessages[0].Content)
+	require.Equal(t, "run summary", args.ToolResultMessages[0].Content)
+	require.Equal(t, "run summary", args.Messages[len(args.Messages)-1].Content)
+	require.Equal(t, "run summary", args.ToolResultEvent.Response.Choices[0].Message.Content)
+}
+
+func TestPluginManagerChain_AfterToolMessagesSkipsManagersWithoutHook(t *testing.T) {
+	chain := pluginManagerChain{&chainTestPluginManager{}}
+	hooks, ok := agent.PluginManager(chain).(afterToolMessagesManager)
+	require.True(t, ok)
+	result, err := hooks.AfterToolMessages(context.Background(), &plugin.AfterToolMessagesArgs{})
+	require.NoError(t, err)
+	require.Nil(t, result)
+}
+
+func TestPluginManagerChain_AfterToolMessagesStopsOnError(t *testing.T) {
+	expected := errors.New("messages failed")
+	failingPlugin := &testPlugin{
+		name: "failing-messages",
+		reg: func(r *plugin.Registry) {
+			r.AfterToolMessages(func(context.Context, *plugin.AfterToolMessagesArgs) (*plugin.AfterToolMessagesResult, error) {
+				return &plugin.AfterToolMessagesResult{
+					ToolResultMessages: []model.Message{
+						model.NewToolMessage("call-1", "lookup", "summary"),
+					},
+				}, expected
+			})
+		},
+	}
+	chain := pluginManagerChain{
+		&chainTestPluginManager{},
+		plugin.MustNewManager(failingPlugin),
+	}
+	hooks, ok := agent.PluginManager(chain).(afterToolMessagesManager)
+	require.True(t, ok)
+	result, err := hooks.AfterToolMessages(context.Background(), &plugin.AfterToolMessagesArgs{})
+	require.ErrorIs(t, err, expected)
+	require.NotNil(t, result)
+}
+
+func TestPluginManagerChain_CloseRunsInReverseOrderAndJoinsErrors(t *testing.T) {
+	var order []string
+	firstErr := errors.New("first failed")
+	secondErr := errors.New("second failed")
+	first := &chainTestPluginManager{closeHook: func(context.Context) error {
+		order = append(order, "first")
+		return firstErr
+	}}
+	second := &chainTestPluginManager{closeHook: func(context.Context) error {
+		order = append(order, "second")
+		return secondErr
+	}}
+	err := newPluginManagerChain(first, second).Close(context.Background())
+	require.Error(t, err)
+	require.ErrorIs(t, err, firstErr)
+	require.ErrorIs(t, err, secondErr)
+	require.Equal(t, []string{"second", "first"}, order)
+}
+
 func TestRunner_applyEventPlugins_ReplacesEventAndCopiesFields(t *testing.T) {
 	const (
 		reqID    = "req"


### PR DESCRIPTION
This adds per-run plugin injection through plugin.WithPlugins as a RunOption, combines run-level plugins after runner-level plugins for invocation execution, preserves caller-managed lifecycle for run-scoped plugins, and documents the behavior in both English and Chinese docs.