### PR TITLE
WIP: server/agui: skip unpaired tool result in message snapshot reduce

### DIFF
--- a/server/agui/internal/reduce/reduce.go
+++ b/server/agui/internal/reduce/reduce.go
@@ -683,7 +683,15 @@ func (r *reducer) handleToolResult(e *aguievents.ToolCallResultEvent) error {
 	}
 	state, ok := r.toolCalls[e.ToolCallID]
 	if !ok || state.phase != toolAwaitingResult {
-		return fmt.Errorf("tool call result without completed call: %s", e.ToolCallID)
+		// The matching tool call start/end may be absent from the replayed
+		// track. Interrupt (human-in-the-loop) tools land their result in a
+		// later run, and resume/replay runs can emit only the interrupt
+		// activity without TOOL_CALL_START/END, so the result has no started
+		// call to attach to (!ok), an unfinished one (toolAwaitingArgs), or an
+		// already completed one (duplicate result, toolCompleted). Skip the
+		// unpaired result instead of failing the whole reduce, otherwise the
+		// history snapshot is truncated at this point.
+		return nil
 	}
 	role := string(model.RoleTool)
 	if e.Role != nil && *e.Role != "" {

--- a/server/agui/internal/reduce/reduce_test.go
+++ b/server/agui/internal/reduce/reduce_test.go
@@ -1055,10 +1055,6 @@ func TestReduceToolEndErrors(t *testing.T) {
 }
 
 func TestReduceToolResultErrors(t *testing.T) {
-	assistant := trackEventsFrom(
-		aguievents.NewTextMessageStartEvent("assistant-1", aguievents.WithRole("assistant")),
-		aguievents.NewTextMessageEndEvent("assistant-1"),
-	)
 	tests := []struct {
 		name   string
 		events []session.TrackEvent
@@ -1069,19 +1065,72 @@ func TestReduceToolResultErrors(t *testing.T) {
 			events: trackEventsFrom(aguievents.NewToolCallResultEvent("", "", "oops")),
 			want:   "tool call result missing identifiers",
 		},
-		{
-			name: "missing completion",
-			events: combineEvents(assistant, trackEventsFrom(
-				aguievents.NewToolCallStartEvent("tool-call-1", "calc", aguievents.WithParentMessageID("assistant-1")),
-				aguievents.NewToolCallArgsEvent("tool-call-1", "{}"),
-				aguievents.NewToolCallResultEvent("tool-msg-1", "tool-call-1", "oops"),
-			)),
-			want: "tool call result without completed call: tool-call-1",
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assertReduceError(t, tt.events, tt.want)
+		})
+	}
+}
+
+// TestReduceSkipsUnpairedToolResult ensures an unpaired TOOL_CALL_RESULT does
+// not fail the reduce or truncate the history. Interrupt (human-in-the-loop)
+// tools land their result in a later run, and resume/replay runs can persist
+// the result without the matching TOOL_CALL_START/END, so the reduced snapshot
+// must skip the orphan result and keep replaying the remaining events.
+func TestReduceSkipsUnpairedToolResult(t *testing.T) {
+	lead := trackEventsFrom(
+		aguievents.NewTextMessageStartEvent("user-1", aguievents.WithRole("user")),
+		aguievents.NewTextMessageContentEvent("user-1", "hi"),
+		aguievents.NewTextMessageEndEvent("user-1"),
+	)
+	// History that must survive after the unpaired result.
+	tail := trackEventsFrom(
+		aguievents.NewTextMessageStartEvent("assistant-1", aguievents.WithRole("assistant")),
+		aguievents.NewTextMessageContentEvent("assistant-1", "ok"),
+		aguievents.NewTextMessageEndEvent("assistant-1"),
+	)
+	tests := []struct {
+		name   string
+		middle []session.TrackEvent
+	}{
+		{
+			name: "orphan result without start",
+			middle: trackEventsFrom(
+				aguievents.NewToolCallResultEvent("tool-msg-1", "call-orphan", "r"),
+			),
+		},
+		{
+			name: "result without end",
+			middle: trackEventsFrom(
+				aguievents.NewToolCallStartEvent("call-1", "calc", aguievents.WithParentMessageID("assistant-mid")),
+				aguievents.NewToolCallArgsEvent("call-1", "{}"),
+				aguievents.NewToolCallResultEvent("tool-msg-1", "call-1", "r"),
+			),
+		},
+		{
+			name: "duplicate result",
+			middle: trackEventsFrom(
+				aguievents.NewToolCallStartEvent("call-1", "calc", aguievents.WithParentMessageID("assistant-mid")),
+				aguievents.NewToolCallEndEvent("call-1"),
+				aguievents.NewToolCallResultEvent("tool-msg-1", "call-1", "r"),
+				aguievents.NewToolCallResultEvent("tool-msg-2", "call-1", "r-dup"),
+			),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msgs, err := Reduce(testAppName, testUserID, combineEvents(lead, tt.middle, tail))
+			require.NoError(t, err)
+			ids := make([]string, 0, len(msgs))
+			for _, m := range msgs {
+				ids = append(ids, m.ID)
+			}
+			// History before and after the unpaired result is preserved.
+			assert.Contains(t, ids, "user-1")
+			assert.Contains(t, ids, "assistant-1")
+			// A duplicate result must not be emitted a second time.
+			assert.NotContains(t, ids, "tool-msg-2")
 		})
 	}
 }


### PR DESCRIPTION
## Problem

When the AG-UI message snapshot replays persisted track events, `reduce`
required every `TOOL_CALL_RESULT` to be preceded by a matching
`TOOL_CALL_START` / `TOOL_CALL_END`. If the replayed `agui` track contains an
orphan `TOOL_CALL_RESULT` (no started call), `reduce` returned an error and
**broke out of the replay loop**, so:

- the message snapshot was **truncated** at that event, and
- a spurious `RUN_ERROR` was emitted to the client even though the rest of the
  history was intact.

It surfaces as:

```
load history: reduce track events: reduce: tool call result without completed call: <toolCallId>
```

## How an orphan result happens

Interrupt (human-in-the-loop) tools land their result in a later run. On
resume/replay runs (e.g. after checkpoint retries) the persisted `agui` track
can end up with the `TOOL_CALL_RESULT` but without the matching
`TOOL_CALL_START` / `TOOL_CALL_END` for that call.

## This PR (stop-the-bleed)

`handleToolResult` now **skips** an unpaired result instead of failing the
whole reduce:

- no started call (`!ok`),
- unfinished call (`toolAwaitingArgs`, missing END),
- duplicate result (`toolCompleted`).

Effect: the remaining history is fully replayed — no truncation, and no
spurious `RUN_ERROR` for this recoverable case. Regression tests cover orphan /
missing-end / duplicate results.

## Not in this PR (WIP)

The upstream root cause — core graph not emitting `TOOL_CALL_START` / `END`
metadata for interrupt tools on resume/replay — is **not** addressed here. That
is a separate, broader change in `graph` (tool-execution / resume path) and is
tracked separately. This PR is the defensive guard on the replay side only.

## Test

```
cd server/agui && go test ./...   # all pass
go vet ./...                       # clean
```
