### PR TITLE
openclaw: allow disabling post-tool prompt

### DIFF
--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -1054,8 +1054,10 @@ func NewRuntimeWithOptions(
 			MaxHistoryRuns:   opts.MaxHistoryRuns,
 			PreloadMemory:    opts.PreloadMemory,
 			GenerationConfig: opts.GenerationConfig,
-			Instruction:      prompts.Instruction,
-			SystemPrompt:     prompts.SystemPrompt,
+			PostToolPromptEnabled: runtimeOpts.
+				postToolPromptEnabled,
+			Instruction:  prompts.Instruction,
+			SystemPrompt: prompts.SystemPrompt,
 
 			SkillsRoot:      opts.SkillsRoot,
 			SkillsExtraDirs: splitCSV(opts.SkillsExtraDir),
@@ -1605,8 +1607,10 @@ func run(
 			MaxHistoryRuns:   opts.MaxHistoryRuns,
 			PreloadMemory:    opts.PreloadMemory,
 			GenerationConfig: opts.GenerationConfig,
-			Instruction:      prompts.Instruction,
-			SystemPrompt:     prompts.SystemPrompt,
+			PostToolPromptEnabled: runtimeOpts.
+				postToolPromptEnabled,
+			Instruction:  prompts.Instruction,
+			SystemPrompt: prompts.SystemPrompt,
 
 			SkillsRoot:      opts.SkillsRoot,
 			SkillsExtraDirs: splitCSV(opts.SkillsExtraDir),
@@ -2560,6 +2564,14 @@ func newAgent(
 			runtimeprofile.SkillVisibilityFilterForRepository(repo),
 		),
 	}
+	if cfg.PostToolPromptEnabled != nil {
+		opts = append(
+			opts,
+			llmagent.WithEnablePostToolPrompt(
+				*cfg.PostToolPromptEnabled,
+			),
+		)
+	}
 	opts = append(opts, llmagent.WithSkills(repo))
 	opts = append(
 		opts,
@@ -2942,6 +2954,7 @@ type agentConfig struct {
 	MaxHistoryRuns                                int
 	PreloadMemory                                 int
 	GenerationConfig                              *model.GenerationConfig
+	PostToolPromptEnabled                         *bool
 	Instruction                                   string
 	SystemPrompt                                  string
 

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -1435,6 +1435,22 @@ func TestRuntimeGatewayRunOptionsEdgeCases(t *testing.T) {
 	require.Nil(t, input.Extensions)
 }
 
+func TestRuntimePostToolPromptOption(t *testing.T) {
+	t.Parallel()
+
+	runtimeOpts := buildRuntimeOptions([]RuntimeOption{
+		WithEnablePostToolPrompt(false),
+	})
+	require.NotNil(t, runtimeOpts.postToolPromptEnabled)
+	require.False(t, *runtimeOpts.postToolPromptEnabled)
+
+	runtimeOpts = buildRuntimeOptions([]RuntimeOption{
+		WithEnablePostToolPrompt(true),
+	})
+	require.NotNil(t, runtimeOpts.postToolPromptEnabled)
+	require.True(t, *runtimeOpts.postToolPromptEnabled)
+}
+
 func TestMain_HelpSkipsErrorLog(t *testing.T) {
 	t.Parallel()
 
@@ -2007,6 +2023,35 @@ func TestNewAgent_OpenClawPostToolPrompt_AppliedWithoutToolResult(
 	system := joinSystemMessages(req)
 	require.Contains(t, system, openClawPostToolPrompt)
 	require.Contains(
+		t,
+		system,
+		"Do not answer only with what you will do next.",
+	)
+}
+
+func TestNewAgent_OpenClawPostToolPrompt_Disabled(t *testing.T) {
+	t.Parallel()
+
+	enabled := false
+	root := createAppTestSkill(t)
+	mdl := &captureRequestModel{}
+	agt, _, err := newAgent(mdl, agentConfig{
+		AppName:               "demo",
+		SkillsRoot:            root,
+		StateDir:              t.TempDir(),
+		PostToolPromptEnabled: &enabled,
+	}, nil, nil)
+	require.NoError(t, err)
+
+	req := runAgentAndCapture(
+		t,
+		agt,
+		mdl,
+		session.NewSession("demo", "user", "sess"),
+	)
+	system := joinSystemMessages(req)
+	require.NotContains(t, system, openClawPostToolPrompt)
+	require.NotContains(
 		t,
 		system,
 		"Do not answer only with what you will do next.",

--- a/openclaw/app/runtime_options.go
+++ b/openclaw/app/runtime_options.go
@@ -54,6 +54,7 @@ type runtimeOptions struct {
 	runtimeProfileCatalog  runtimeprofile.Catalog
 	runtimeProfileRequired bool
 	gatewayResolvers       []GatewayRunOptionResolver
+	postToolPromptEnabled  *bool
 }
 
 // WithRuntimeProfileResolver injects per-request runtime profile resolution.
@@ -98,6 +99,14 @@ func WithRuntimeProfileStore(
 		opts.runtimeProfileResolver = resolver
 		opts.runtimeProfileCatalog = resolver
 		opts.runtimeProfileRequired = required
+	}
+}
+
+// WithEnablePostToolPrompt controls whether OpenClaw injects post-tool
+// guidance into agent requests.
+func WithEnablePostToolPrompt(enable bool) RuntimeOption {
+	return func(opts *runtimeOptions) {
+		opts.postToolPromptEnabled = &enable
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `app.WithEnablePostToolPrompt` to let embedded OpenClaw runtimes explicitly enable or disable post-tool prompt injection.
- Thread the option into OpenClaw agent construction while preserving the existing default behavior.
- Add tests for the runtime option and disabled injection path.

## Why

OpenClaw currently hardcodes `llmagent.WithPostToolPrompt(openClawPostToolPrompt)`, so downstream runtimes cannot opt out of the injected guidance without changing OpenClaw app code.

## Validation

- `go test ./openclaw/app`