### PR TITLE
log: prefix recovered panic logs

### DIFF
--- a/agent/callbacks.go
+++ b/agent/callbacks.go
@@ -25,7 +25,7 @@ const ErrorTypeAgentCallbackError = "agent_callback_error"
 
 const (
 	callbackPanicErrFmt = "%s: %v"
-	callbackPanicLogFmt = "%s (invocation: %s, agent: %s): " +
+	callbackPanicLogFmt = log.PanicPrefix + " %s (invocation: %s, agent: %s): " +
 		"%v\n%s"
 
 	beforeAgentCallbackPanic = "before agent callback panic"

--- a/agent/extension/todoenforcer/enforcer.go
+++ b/agent/extension/todoenforcer/enforcer.go
@@ -376,7 +376,7 @@ func (e *Enforcer) notify(evt EnforceEvent) {
 	}
 	defer func() {
 		if r := recover(); r != nil {
-			log.Errorf("todoenforcer: OnEnforce panic: %v", r)
+			log.Errorf(log.PanicPrefix+" todoenforcer: OnEnforce panic: %v", r)
 		}
 	}()
 	e.opts.OnEnforce(evt)

--- a/agent/parallelagent/parallel_agent.go
+++ b/agent/parallelagent/parallel_agent.go
@@ -164,7 +164,7 @@ func (a *ParallelAgent) startSubAgents(
 			defer func() {
 				if r := recover(); r != nil {
 					stack := debug.Stack()
-					log.Errorf("Sub-agent execution panic for %s (index: %d, parent: %s): %v\n%s",
+					log.Errorf(log.PanicPrefix+" Sub-agent execution panic for %s (index: %d, parent: %s): %v\n%s",
 						sa.Info().Name, idx, invocation.AgentName, r, string(stack))
 					// Send error event for the panic.
 					errorEvent := event.NewErrorEvent(
@@ -337,7 +337,7 @@ func (a *ParallelAgent) mergeEventStreams(
 				if r := recover(); r != nil {
 					// Log the panic but don't propagate error events here since
 					// we're already in the event merging phase.
-					log.Errorf("Event merging panic in parallel agent %s: %v", a.name, r)
+					log.Errorf(log.PanicPrefix+" Event merging panic in parallel agent %s: %v", a.name, r)
 				}
 			}()
 			for evt := range stream.ch {

--- a/agent/taskrun/inprocess/service.go
+++ b/agent/taskrun/inprocess/service.go
@@ -714,8 +714,8 @@ func runFinalizer(
 	defer cancel()
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			log.Warnf(
-				"taskrun: finalizer panic for run %s: %v",
+			log.Errorf(
+				log.PanicPrefix+" taskrun: finalizer panic for run %s: %v",
 				run.ID,
 				recovered,
 			)

--- a/evaluation/internal/callback/callbacks.go
+++ b/evaluation/internal/callback/callbacks.go
@@ -54,7 +54,15 @@ func callCallbackWithRecoveryInto[Args any, Result any, CallbackFn ~func(context
 			return
 		}
 		stack := debug.Stack()
-		log.ErrorfContext(ctx, "%s (callback: %s, idx: %d): %v\n%s", point, name, idx, recovered, string(stack))
+		log.ErrorfContext(
+			ctx,
+			log.PanicPrefix+" %s (callback: %s, idx: %d): %v\n%s",
+			point,
+			name,
+			idx,
+			recovered,
+			string(stack),
+		)
 		*errp = fmt.Errorf("callback panic: %v", recovered)
 	}()
 	result, err := callback(ctx, args)

--- a/graph/emitter.go
+++ b/graph/emitter.go
@@ -230,7 +230,7 @@ func (e *eventEmitter) Context() context.Context {
 func (e *eventEmitter) emitWithRecover(evt *event.Event) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Errorf("EventEmitter: recovered from panic while emitting event: %v", r)
+			log.Errorf(log.PanicPrefix+" EventEmitter: recovered from panic while emitting event: %v", r)
 			err = nil // Don't propagate panic as error
 		}
 	}()

--- a/graph/executor.go
+++ b/graph/executor.go
@@ -315,7 +315,7 @@ func (e *Executor) Execute(
 				stack := debug.Stack()
 				log.ErrorfContext(
 					ctx,
-					"panic in executor goroutine: %v\n%s",
+					log.PanicPrefix+" panic in executor goroutine: %v\n%s",
 					r,
 					string(stack),
 				)
@@ -2689,7 +2689,7 @@ func (e *Executor) executeStepTask(
 		if r := recover(); r != nil {
 			log.ErrorfContext(
 				runCtx,
-				"panic executing task %s: %v\n%s",
+				log.PanicPrefix+" panic executing task %s: %v\n%s",
 				t.NodeID,
 				r,
 				string(debug.Stack()),
@@ -4082,7 +4082,7 @@ func (e *Executor) executeNodeFunction(
 			stack := debug.Stack()
 			log.ErrorfContext(
 				ctx,
-				"panic in node %s: %v\n%s",
+				log.PanicPrefix+" panic in node %s: %v\n%s",
 				t.NodeID,
 				r,
 				string(stack),

--- a/graph/executor_test.go
+++ b/graph/executor_test.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -3735,6 +3736,8 @@ func TestDeepCopyAny_Branches(t *testing.T) {
 	require.Equal(t, []pair{{1}, {2}}, s) // original unchanged
 }
 
+var errorfContextHookMu sync.Mutex
+
 // TestExecuteNodeFunction_RecoversFromPanic ensures that panics in user node functions
 // are recovered and converted into errors, without crashing the executor.
 func TestExecuteNodeFunction_RecoversFromPanic(t *testing.T) {
@@ -3756,6 +3759,7 @@ func TestExecuteNodeFunction_RecoversFromPanic(t *testing.T) {
 	}
 	task := &Task{NodeID: "boom", TaskID: "boom-0"}
 
+	errorfContextHookMu.Lock()
 	oldErrorfContext := agentlog.ErrorfContext
 	var logFormat string
 	var logArgs []any
@@ -3763,9 +3767,10 @@ func TestExecuteNodeFunction_RecoversFromPanic(t *testing.T) {
 		logFormat = format
 		logArgs = append([]any(nil), args...)
 	}
-	defer func() {
+	t.Cleanup(func() {
 		agentlog.ErrorfContext = oldErrorfContext
-	}()
+		errorfContextHookMu.Unlock()
+	})
 
 	res, runErr := exec.executeNodeFunction(context.Background(), execCtx, task)
 	require.Error(t, runErr)

--- a/graph/executor_test.go
+++ b/graph/executor_test.go
@@ -29,6 +29,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/event"
 	ichannel "trpc.group/trpc-go/trpc-agent-go/graph/internal/channel"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/barrier"
+	agentlog "trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	teletrace "trpc.group/trpc-go/trpc-agent-go/telemetry/trace"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
@@ -3755,11 +3756,28 @@ func TestExecuteNodeFunction_RecoversFromPanic(t *testing.T) {
 	}
 	task := &Task{NodeID: "boom", TaskID: "boom-0"}
 
+	oldErrorfContext := agentlog.ErrorfContext
+	var logFormat string
+	var logArgs []any
+	agentlog.ErrorfContext = func(_ context.Context, format string, args ...any) {
+		logFormat = format
+		logArgs = append([]any(nil), args...)
+	}
+	defer func() {
+		agentlog.ErrorfContext = oldErrorfContext
+	}()
+
 	res, runErr := exec.executeNodeFunction(context.Background(), execCtx, task)
 	require.Error(t, runErr)
 	require.Nil(t, res)
 	require.Contains(t, runErr.Error(), "kaboom")
 	require.Contains(t, runErr.Error(), "node boom panic")
+	require.True(t, strings.HasPrefix(logFormat, agentlog.PanicPrefix+" "))
+	require.Contains(t, logFormat, "panic in node %s")
+	renderedLog := fmt.Sprintf(logFormat, logArgs...)
+	require.Contains(t, renderedLog, "panic in node boom")
+	require.Contains(t, renderedLog, "kaboom")
+	require.Contains(t, renderedLog, "goroutine")
 }
 
 func TestExecuteNodeFunction_AgentNodeFunctionOverrideHonored(t *testing.T) {

--- a/graph/state_graph.go
+++ b/graph/state_graph.go
@@ -1496,7 +1496,7 @@ func runGraphModelSelector(
 ) (selected model.Model, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Errorf("model selector panic: %v\n%s", r, debug.Stack())
+			log.Errorf(log.PanicPrefix+" model selector panic: %v\n%s", r, debug.Stack())
 			err = fmt.Errorf("panic: %v", r)
 		}
 	}()

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -53,7 +53,7 @@ const (
 
 	errMsgNoModelResponse = "no response received from model"
 
-	flowRunPanicLogFmt = "Flow execution panic (invocation: %s, " +
+	flowRunPanicLogFmt = log.PanicPrefix + " Flow execution panic (invocation: %s, " +
 		"agent: %s): %v\n%s"
 
 	flowRunPanicErrFmt = "flow panic: %v"
@@ -617,7 +617,7 @@ func runModelSelector(
 ) (selected model.Model, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Errorf("model selector panic: %v\n%s", r, debug.Stack())
+			log.Errorf(log.PanicPrefix+" model selector panic: %v\n%s", r, debug.Stack())
 			err = fmt.Errorf("panic: %v", r)
 		}
 	}()

--- a/internal/flow/processor/functioncall.go
+++ b/internal/flow/processor/functioncall.go
@@ -895,7 +895,7 @@ func (p *FunctionCallResponseProcessor) runParallelToolCall(
 		if r := recover(); r != nil {
 			log.ErrorfContext(
 				ctx,
-				"Tool execution panic for %s (index: %d, ID: %s, agent: %s): %v",
+				log.PanicPrefix+" Tool execution panic for %s (index: %d, ID: %s, agent: %s): %v",
 				tc.Function.Name,
 				index,
 				tc.ID,

--- a/knowledge/vectorstore/elasticsearch/condition_converter.go
+++ b/knowledge/vectorstore/elasticsearch/condition_converter.go
@@ -41,7 +41,7 @@ func (c *esConverter) Convert(cond *searchfilter.UniversalFilterCondition) (type
 	defer func() {
 		if r := recover(); r != nil {
 			stack := debug.Stack()
-			log.Errorf("panic in esConverter Convert: %v\n%s", r, string(stack))
+			log.Errorf(log.PanicPrefix+" panic in esConverter Convert: %v\n%s", r, string(stack))
 		}
 	}()
 

--- a/knowledge/vectorstore/inmemory/condition_converter.go
+++ b/knowledge/vectorstore/inmemory/condition_converter.go
@@ -57,7 +57,7 @@ func (c *inmemoryConverter) Convert(cond *searchfilter.UniversalFilterCondition)
 	defer func() {
 		if r := recover(); r != nil {
 			stack := debug.Stack()
-			log.Errorf("panic in inmemoryConverter Convert: %v\n%s", r, string(stack))
+			log.Errorf(log.PanicPrefix+" panic in inmemoryConverter Convert: %v\n%s", r, string(stack))
 		}
 	}()
 
@@ -70,7 +70,7 @@ func (c *inmemoryConverter) Convert(cond *searchfilter.UniversalFilterCondition)
 		defer func() {
 			if r := recover(); r != nil {
 				stack := debug.Stack()
-				log.Errorf("panic in condition function: %v\n%s", r, string(stack))
+				log.Errorf(log.PanicPrefix+" panic in condition function: %v\n%s", r, string(stack))
 			}
 		}()
 		return condFunc(doc)

--- a/knowledge/vectorstore/milvus/condition_converter.go
+++ b/knowledge/vectorstore/milvus/condition_converter.go
@@ -54,7 +54,7 @@ func (c *milvusFilterConverter) Convert(cond *searchfilter.UniversalFilterCondit
 	defer func() {
 		if r := recover(); r != nil {
 			stack := debug.Stack()
-			log.Errorf("panic in milvusFilterConverter Convert: %v\n%s", r, string(stack))
+			log.Errorf(log.PanicPrefix+" panic in milvusFilterConverter Convert: %v\n%s", r, string(stack))
 		}
 	}()
 

--- a/knowledge/vectorstore/pgvector/condition_converter.go
+++ b/knowledge/vectorstore/pgvector/condition_converter.go
@@ -44,7 +44,7 @@ func (c *pgVectorConverter) Convert(cond *searchfilter.UniversalFilterCondition)
 	defer func() {
 		if r := recover(); r != nil {
 			stack := debug.Stack()
-			log.Errorf("panic in pgVectorConverter Convert: %v\n%s", r, string(stack))
+			log.Errorf(log.PanicPrefix+" panic in pgVectorConverter Convert: %v\n%s", r, string(stack))
 		}
 	}()
 

--- a/knowledge/vectorstore/tcvector/condition_converter.go
+++ b/knowledge/vectorstore/tcvector/condition_converter.go
@@ -38,7 +38,7 @@ func (c *tcVectorConverter) Convert(cond *searchfilter.UniversalFilterCondition)
 	defer func() {
 		if r := recover(); r != nil {
 			stack := debug.Stack()
-			log.Errorf("panic in tcVectorConverter Convert: %v\n%s", r, string(stack))
+			log.Errorf(log.PanicPrefix+" panic in tcVectorConverter Convert: %v\n%s", r, string(stack))
 		}
 	}()
 

--- a/log/log.go
+++ b/log/log.go
@@ -28,6 +28,9 @@ const (
 	LevelFatal = "fatal"
 )
 
+// PanicPrefix marks recovered panic logs so log-based collectors can report them.
+const PanicPrefix = "[PANIC]"
+
 var (
 	zapLevel = zap.NewAtomicLevelAt(zapcore.InfoLevel)
 

--- a/memory/internal/memory/auto.go
+++ b/memory/internal/memory/auto.go
@@ -365,7 +365,7 @@ func (w *AutoMemoryWorker) tryEnqueueJob(
 func (w *AutoMemoryWorker) processJob(job *MemoryJob) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.ErrorfContext(context.Background(), "panic in memory worker: %v", r)
+			log.ErrorfContext(context.Background(), log.PanicPrefix+" panic in memory worker: %v", r)
 		}
 	}()
 	ctx := job.Ctx

--- a/model/callbacks.go
+++ b/model/callbacks.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	callbackPanicErrFmt = "%s: %v"
-	callbackPanicLogFmt = "%s: %v\n%s"
+	callbackPanicLogFmt = log.PanicPrefix + " %s: %v\n%s"
 
 	beforeModelCallbackPanic = "before model callback panic"
 	afterModelCallbackPanic  = "after model callback panic"

--- a/model/internal/model/callback_recovery.go
+++ b/model/internal/model/callback_recovery.go
@@ -21,7 +21,7 @@ func RecoverCallbackPanic(ctx context.Context, stage string) {
 	if recovered := recover(); recovered != nil {
 		log.ErrorfContext(
 			ctx,
-			"%s panic: %v\n%s",
+			log.PanicPrefix+" %s panic: %v\n%s",
 			stage,
 			recovered,
 			string(debug.Stack()),

--- a/model/internal/model/callback_recovery_test.go
+++ b/model/internal/model/callback_recovery_test.go
@@ -59,7 +59,7 @@ func TestRecoverCallbackPanic_RecoversAndLogs(t *testing.T) {
 	})
 
 	require.True(t, logged)
-	assert.Equal(t, "%s panic: %v\n%s", capturedFormat)
+	assert.Equal(t, log.PanicPrefix+" %s panic: %v\n%s", capturedFormat)
 	require.Len(t, capturedArgs, 3)
 	assert.Equal(t, "test callback", capturedArgs[0])
 	assert.Equal(t, "boom", capturedArgs[1])

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1305,7 +1305,7 @@ func (r *runner) runEventLoop(ctx context.Context, loop *eventLoopContext) {
 		}
 		finishRunnerLatencySpan(span, started, nil)
 		if rr := recover(); rr != nil {
-			log.Errorf("panic in runner event loop: %v\n%s", rr, string(debug.Stack()))
+			log.Errorf(log.PanicPrefix+" panic in runner event loop: %v\n%s", rr, string(debug.Stack()))
 		}
 		// Agent event stream completed.
 		steer.Close(loop.invocation)
@@ -2124,7 +2124,7 @@ func (r *runner) safePersistInterruptedAssistant(ctx context.Context, loop *even
 	defer func() {
 		finishRunnerLatencySpan(span, started, nil)
 		if rr := recover(); rr != nil {
-			log.Errorf("panic persisting interrupted assistant: %v\n%s", rr, string(debug.Stack()))
+			log.Errorf(log.PanicPrefix+" panic persisting interrupted assistant: %v\n%s", rr, string(debug.Stack()))
 		}
 	}()
 	r.persistInterruptedAssistant(ctx, loop)
@@ -2361,7 +2361,7 @@ func (r *runner) safeEmitRunnerCompletion(ctx context.Context, loop *eventLoopCo
 	defer func() {
 		finishRunnerLatencySpan(span, started, nil)
 		if rr := recover(); rr != nil {
-			log.Errorf("panic emitting runner completion: %v\n%s", rr, string(debug.Stack()))
+			log.Errorf(log.PanicPrefix+" panic emitting runner completion: %v\n%s", rr, string(debug.Stack()))
 		}
 	}()
 	r.emitRunnerCompletion(ctx, loop)

--- a/server/a2a/server.go
+++ b/server/a2a/server.go
@@ -681,7 +681,7 @@ func (m *messageProcessor) processStreamingMessage(
 			if r := recover(); r != nil {
 				log.ErrorfContext(
 					ctx,
-					"panic in streaming processing for task %s: %v",
+					log.PanicPrefix+" panic in streaming processing for task %s: %v",
 					taskID,
 					r,
 				)

--- a/server/agui/runner/messagessnapshot.go
+++ b/server/agui/runner/messagessnapshot.go
@@ -40,7 +40,7 @@ func (r *runner) MessagesSnapshot(ctx context.Context,
 		if rec := recover(); rec != nil {
 			// The error is written back to the HTTP client; keep the panic
 			// payload (hooks/resolvers may embed request internals) in logs only.
-			log.ErrorfContext(ctx, "agui messages snapshot: panic: %v\n%s", rec, debug.Stack())
+			log.ErrorfContext(ctx, log.PanicPrefix+" agui messages snapshot: panic: %v\n%s", rec, debug.Stack())
 			eventCh = nil
 			err = errors.New("messages snapshot internal error")
 		}

--- a/session/internal/summary/async.go
+++ b/session/internal/summary/async.go
@@ -192,7 +192,7 @@ func (w *AsyncSummaryWorker) tryEnqueueJob(ctx context.Context, job *summaryJob)
 func (w *AsyncSummaryWorker) processJob(job *summaryJob) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.ErrorfContext(context.Background(), "panic in summary worker: %v", r)
+			log.ErrorfContext(context.Background(), log.PanicPrefix+" panic in summary worker: %v", r)
 		}
 	}()
 

--- a/tool/callbacks.go
+++ b/tool/callbacks.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	callbackPanicErrFmt = "%s: %v"
-	callbackPanicLogFmt = "%s (tool_call_id: %s, tool: %s): " +
+	callbackPanicLogFmt = log.PanicPrefix + " %s (tool_call_id: %s, tool: %s): " +
 		"%v\n%s"
 
 	beforeToolCallbackPanic         = "before tool callback panic"


### PR DESCRIPTION
## Summary
- Add a shared panic log prefix constant for recovered panic messages.
- Prefix framework recover logs so Galileo log-based panic event collection can detect them.
- Cover representative panic logging behavior in tests.

## Test plan
- go test ./model/internal/model
- go test ./...
- git diff --check


Made with [Cursor](https://cursor.com)