### PR TITLE
{runner, session/mysql}: reduce event memory copies

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"runtime/debug"
 	"sort"
 	"strings"
@@ -3210,7 +3211,60 @@ func cloneAnyValue(value any) any {
 	case []any:
 		return cloneAnySlice(typed)
 	default:
+		if cloned, ok := cloneReflectContainer(reflect.ValueOf(value)); ok {
+			return cloned.Interface()
+		}
 		return typed
+	}
+}
+
+func cloneReflectContainer(value reflect.Value) (reflect.Value, bool) {
+	if !value.IsValid() {
+		return value, false
+	}
+	switch value.Kind() {
+	case reflect.Map:
+		if value.IsNil() {
+			return reflect.Zero(value.Type()), true
+		}
+		cloned := reflect.MakeMapWithSize(value.Type(), value.Len())
+		iter := value.MapRange()
+		for iter.Next() {
+			mapValue := iter.Value()
+			if clonedValue, ok := cloneReflectContainer(mapValue); ok &&
+				clonedValue.Type().AssignableTo(value.Type().Elem()) {
+				mapValue = clonedValue
+			}
+			cloned.SetMapIndex(iter.Key(), mapValue)
+		}
+		return cloned, true
+	case reflect.Slice:
+		if value.IsNil() {
+			return reflect.Zero(value.Type()), true
+		}
+		cloned := reflect.MakeSlice(value.Type(), value.Len(), value.Len())
+		for i := 0; i < value.Len(); i++ {
+			item := value.Index(i)
+			if clonedItem, ok := cloneReflectContainer(item); ok &&
+				clonedItem.Type().AssignableTo(value.Type().Elem()) {
+				item = clonedItem
+			}
+			cloned.Index(i).Set(item)
+		}
+		return cloned, true
+	case reflect.Array:
+		cloned := reflect.New(value.Type()).Elem()
+		for i := 0; i < value.Len(); i++ {
+			item := value.Index(i)
+			if clonedItem, ok := cloneReflectContainer(item); ok &&
+				clonedItem.Type().AssignableTo(value.Type().Elem()) {
+				item = clonedItem
+			}
+			cloned.Index(i).Set(item)
+		}
+		return cloned, true
+	default:
+		return value, false
 	}
 }
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -2912,10 +2912,7 @@ func (r *runner) propagateGraphCompletion(
 		runnerCompletionEvent.Response != nil &&
 		len(runnerCompletionEvent.Response.Choices) == 0 &&
 		len(finalChoices) > 0 {
-		// Keep only content to avoid carrying tool deltas etc.
-		// Use JSON marshal/unmarshal to deep-copy minimal fields safely.
-		b, _ := json.Marshal(finalChoices)
-		_ = json.Unmarshal(b, &runnerCompletionEvent.Response.Choices)
+		runnerCompletionEvent.Response.Choices = cloneChoices(finalChoices)
 	}
 }
 
@@ -3112,9 +3109,137 @@ func cloneChoices(choices []model.Choice) []model.Choice {
 	if len(choices) == 0 {
 		return nil
 	}
-	b, _ := json.Marshal(choices)
-	var cloned []model.Choice
-	_ = json.Unmarshal(b, &cloned)
+	cloned := make([]model.Choice, len(choices))
+	for i, choice := range choices {
+		cloned[i] = choice
+		cloned[i].Message = cloneMessage(choice.Message)
+		cloned[i].Delta = cloneMessage(choice.Delta)
+		if choice.FinishReason != nil {
+			reason := *choice.FinishReason
+			cloned[i].FinishReason = &reason
+		}
+		cloned[i].Logprobs = cloneChoiceLogprobs(choice.Logprobs)
+	}
+	return cloned
+}
+
+func cloneMessage(message model.Message) model.Message {
+	cloned := message
+	cloned.ContentParts = cloneContentParts(message.ContentParts)
+	cloned.ToolCalls = cloneToolCalls(message.ToolCalls)
+	return cloned
+}
+
+func cloneContentParts(parts []model.ContentPart) []model.ContentPart {
+	if parts == nil {
+		return nil
+	}
+	cloned := make([]model.ContentPart, len(parts))
+	for i, part := range parts {
+		cloned[i] = part
+		if part.Text != nil {
+			text := *part.Text
+			cloned[i].Text = &text
+		}
+		if part.Image != nil {
+			image := *part.Image
+			image.Data = append([]byte(nil), part.Image.Data...)
+			cloned[i].Image = &image
+		}
+		if part.Audio != nil {
+			audio := *part.Audio
+			audio.Data = append([]byte(nil), part.Audio.Data...)
+			cloned[i].Audio = &audio
+		}
+		if part.File != nil {
+			file := *part.File
+			file.Data = append([]byte(nil), part.File.Data...)
+			cloned[i].File = &file
+		}
+	}
+	return cloned
+}
+
+func cloneToolCalls(toolCalls []model.ToolCall) []model.ToolCall {
+	if toolCalls == nil {
+		return nil
+	}
+	cloned := make([]model.ToolCall, len(toolCalls))
+	for i, toolCall := range toolCalls {
+		cloned[i] = toolCall
+		cloned[i].Function.Arguments = append([]byte(nil), toolCall.Function.Arguments...)
+		if toolCall.Index != nil {
+			index := *toolCall.Index
+			cloned[i].Index = &index
+		}
+		cloned[i].ExtraFields = cloneAnyMap(toolCall.ExtraFields)
+	}
+	return cloned
+}
+
+func cloneAnyMap(values map[string]any) map[string]any {
+	if values == nil {
+		return nil
+	}
+	cloned := make(map[string]any, len(values))
+	for key, value := range values {
+		cloned[key] = cloneAnyValue(value)
+	}
+	return cloned
+}
+
+func cloneAnySlice(values []any) []any {
+	if values == nil {
+		return nil
+	}
+	cloned := make([]any, len(values))
+	for i, value := range values {
+		cloned[i] = cloneAnyValue(value)
+	}
+	return cloned
+}
+
+func cloneAnyValue(value any) any {
+	switch typed := value.(type) {
+	case json.RawMessage:
+		return append(json.RawMessage(nil), typed...)
+	case []byte:
+		return append([]byte(nil), typed...)
+	case map[string]any:
+		return cloneAnyMap(typed)
+	case []any:
+		return cloneAnySlice(typed)
+	default:
+		return typed
+	}
+}
+
+func cloneChoiceLogprobs(logprobs *model.Logprobs) *model.Logprobs {
+	if logprobs == nil {
+		return nil
+	}
+	cloned := &model.Logprobs{}
+	if logprobs.Content == nil {
+		return cloned
+	}
+	cloned.Content = make([]model.TokenLogprob, len(logprobs.Content))
+	for i, token := range logprobs.Content {
+		cloned.Content[i] = model.TokenLogprob{
+			Token:   token.Token,
+			Logprob: token.Logprob,
+			Bytes:   append([]int(nil), token.Bytes...),
+		}
+		if token.TopLogprobs != nil {
+			cloned.Content[i].TopLogprobs = make([]model.TopLogprob, len(token.TopLogprobs))
+			for j, top := range token.TopLogprobs {
+				cloned.Content[i].TopLogprobs[j] = model.TopLogprob{
+					Token:   top.Token,
+					Logprob: top.Logprob,
+					Bytes:   append([]int(nil), top.Bytes...),
+				}
+			}
+		}
+	}
 	return cloned
 }
 

--- a/runner/runner_clone_test.go
+++ b/runner/runner_clone_test.go
@@ -129,3 +129,51 @@ func TestCloneChoicesHandlesEmptyValues(t *testing.T) {
 	require.NoError(t, err)
 	require.JSONEq(t, string(originalJSON), string(clonedJSON))
 }
+
+func TestCloneAnyValueCopiesJSONContainers(t *testing.T) {
+	raw := json.RawMessage(`{"ok":true}`)
+	clonedRaw := cloneAnyValue(raw).(json.RawMessage)
+	raw[0] = '['
+	require.Equal(t, json.RawMessage(`{"ok":true}`), clonedRaw)
+
+	bytes := []byte("bytes")
+	clonedBytes := cloneAnyValue(bytes).([]byte)
+	bytes[0] = 'X'
+	require.Equal(t, []byte("bytes"), clonedBytes)
+
+	values := map[string]any{
+		"list": []any{json.RawMessage(`{"nested":true}`)},
+	}
+	clonedMap := cloneAnyValue(values).(map[string]any)
+	values["list"].([]any)[0].(json.RawMessage)[0] = '['
+	require.Equal(t, json.RawMessage(`{"nested":true}`), clonedMap["list"].([]any)[0])
+
+	require.Nil(t, cloneAnyValue(nil))
+	require.Nil(t, cloneAnyMap(nil))
+	require.Nil(t, cloneAnySlice(nil))
+}
+
+func TestCloneAnyValueCopiesTypedContainers(t *testing.T) {
+	typedMap := map[string][]string{"key": {"value"}}
+	clonedMap := cloneAnyValue(typedMap).(map[string][]string)
+	typedMap["key"][0] = "changed"
+	require.Equal(t, "value", clonedMap["key"][0])
+
+	typedSlice := [][]string{{"value"}}
+	clonedSlice := cloneAnyValue(typedSlice).([][]string)
+	typedSlice[0][0] = "changed"
+	require.Equal(t, "value", clonedSlice[0][0])
+
+	typedArray := [1][]string{{"value"}}
+	clonedArray := cloneAnyValue(typedArray).([1][]string)
+	typedArray[0][0] = "changed"
+	require.Equal(t, "value", clonedArray[0][0])
+
+	var nilMap map[string][]string
+	require.Nil(t, cloneAnyValue(nilMap).(map[string][]string))
+
+	var nilSlice [][]string
+	require.Nil(t, cloneAnyValue(nilSlice).([][]string))
+
+	require.Equal(t, "primitive", cloneAnyValue("primitive"))
+}

--- a/runner/runner_clone_test.go
+++ b/runner/runner_clone_test.go
@@ -107,7 +107,7 @@ func TestCloneChoicesDeepCopiesMutableFields(t *testing.T) {
 
 func TestCloneChoicesHandlesEmptyValues(t *testing.T) {
 	require.Nil(t, cloneChoices(nil))
-	require.Nil(t, cloneChoices([]model.Choice{}))
+	require.Empty(t, cloneChoices([]model.Choice{}))
 
 	choices := []model.Choice{
 		{

--- a/runner/runner_clone_test.go
+++ b/runner/runner_clone_test.go
@@ -104,3 +104,28 @@ func TestCloneChoicesDeepCopiesMutableFields(t *testing.T) {
 	require.Equal(t, []int{1, 2}, cloned[0].Logprobs.Content[0].Bytes)
 	require.Equal(t, []int{3, 4}, cloned[0].Logprobs.Content[0].TopLogprobs[0].Bytes)
 }
+
+func TestCloneChoicesHandlesEmptyValues(t *testing.T) {
+	require.Nil(t, cloneChoices(nil))
+	require.Nil(t, cloneChoices([]model.Choice{}))
+
+	choices := []model.Choice{
+		{
+			Index: 1,
+			Message: model.Message{
+				Role:         model.RoleAssistant,
+				ContentParts: []model.ContentPart{},
+			},
+		},
+	}
+	cloned := cloneChoices(choices)
+	require.Len(t, cloned, 1)
+	require.Nil(t, cloned[0].Logprobs)
+	require.Empty(t, cloned[0].Message.ContentParts)
+
+	originalJSON, err := json.Marshal(choices)
+	require.NoError(t, err)
+	clonedJSON, err := json.Marshal(cloned)
+	require.NoError(t, err)
+	require.JSONEq(t, string(originalJSON), string(clonedJSON))
+}

--- a/runner/runner_clone_test.go
+++ b/runner/runner_clone_test.go
@@ -43,8 +43,10 @@ func TestCloneChoicesDeepCopiesMutableFields(t *testing.T) {
 							Arguments: []byte(`{"value":"original"}`),
 						},
 						ExtraFields: map[string]any{
-							"nested": map[string]any{"key": "value"},
-							"list":   []any{"first"},
+							"nested":     map[string]any{"key": "value"},
+							"list":       []any{"first"},
+							"typed_map":  map[string][]string{"key": {"value"}},
+							"typed_list": []string{"first"},
 						},
 					},
 				},
@@ -83,6 +85,8 @@ func TestCloneChoicesDeepCopiesMutableFields(t *testing.T) {
 	choices[0].Message.ToolCalls[0].Function.Arguments[0] = '['
 	choices[0].Message.ToolCalls[0].ExtraFields["nested"].(map[string]any)["key"] = "changed"
 	choices[0].Message.ToolCalls[0].ExtraFields["list"].([]any)[0] = "changed"
+	choices[0].Message.ToolCalls[0].ExtraFields["typed_map"].(map[string][]string)["key"][0] = "changed"
+	choices[0].Message.ToolCalls[0].ExtraFields["typed_list"].([]string)[0] = "changed"
 	choices[0].Logprobs.Content[0].Bytes[0] = 9
 	choices[0].Logprobs.Content[0].TopLogprobs[0].Bytes[0] = 9
 
@@ -95,6 +99,8 @@ func TestCloneChoicesDeepCopiesMutableFields(t *testing.T) {
 	require.Equal(t, []byte(`{"value":"original"}`), cloned[0].Message.ToolCalls[0].Function.Arguments)
 	require.Equal(t, "value", cloned[0].Message.ToolCalls[0].ExtraFields["nested"].(map[string]any)["key"])
 	require.Equal(t, "first", cloned[0].Message.ToolCalls[0].ExtraFields["list"].([]any)[0])
+	require.Equal(t, "value", cloned[0].Message.ToolCalls[0].ExtraFields["typed_map"].(map[string][]string)["key"][0])
+	require.Equal(t, "first", cloned[0].Message.ToolCalls[0].ExtraFields["typed_list"].([]string)[0])
 	require.Equal(t, []int{1, 2}, cloned[0].Logprobs.Content[0].Bytes)
 	require.Equal(t, []int{3, 4}, cloned[0].Logprobs.Content[0].TopLogprobs[0].Bytes)
 }

--- a/runner/runner_clone_test.go
+++ b/runner/runner_clone_test.go
@@ -1,0 +1,100 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package runner
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+func TestCloneChoicesDeepCopiesMutableFields(t *testing.T) {
+	reason := "stop"
+	index := 1
+	text := "hello"
+	choices := []model.Choice{
+		{
+			Index: 0,
+			Message: model.Message{
+				Role:    model.RoleAssistant,
+				Content: "assistant content",
+				ContentParts: []model.ContentPart{
+					{Type: model.ContentTypeText, Text: &text},
+					{Type: model.ContentTypeImage, Image: &model.Image{Data: []byte("image"), Format: "png"}},
+					{Type: model.ContentTypeAudio, Audio: &model.Audio{Data: []byte("audio"), Format: "wav"}},
+					{Type: model.ContentTypeFile, File: &model.File{Name: "file.txt", Data: []byte("file")}},
+				},
+				ToolCalls: []model.ToolCall{
+					{
+						Type:  "function",
+						ID:    "call-1",
+						Index: &index,
+						Function: model.FunctionDefinitionParam{
+							Name:      "tool",
+							Arguments: []byte(`{"value":"original"}`),
+						},
+						ExtraFields: map[string]any{
+							"nested": map[string]any{"key": "value"},
+							"list":   []any{"first"},
+						},
+					},
+				},
+			},
+			FinishReason: &reason,
+			Logprobs: &model.Logprobs{
+				Content: []model.TokenLogprob{
+					{
+						Token:   "tok",
+						Logprob: -1,
+						Bytes:   []int{1, 2},
+						TopLogprobs: []model.TopLogprob{
+							{Token: "alt", Logprob: -2, Bytes: []int{3, 4}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cloned := cloneChoices(choices)
+	require.Len(t, cloned, 1)
+
+	originalJSON, err := json.Marshal(choices)
+	require.NoError(t, err)
+	clonedJSON, err := json.Marshal(cloned)
+	require.NoError(t, err)
+	require.JSONEq(t, string(originalJSON), string(clonedJSON))
+
+	*choices[0].FinishReason = "length"
+	*choices[0].Message.ContentParts[0].Text = "changed"
+	choices[0].Message.ContentParts[1].Image.Data[0] = 'X'
+	choices[0].Message.ContentParts[2].Audio.Data[0] = 'X'
+	choices[0].Message.ContentParts[3].File.Data[0] = 'X'
+	*choices[0].Message.ToolCalls[0].Index = 9
+	choices[0].Message.ToolCalls[0].Function.Arguments[0] = '['
+	choices[0].Message.ToolCalls[0].ExtraFields["nested"].(map[string]any)["key"] = "changed"
+	choices[0].Message.ToolCalls[0].ExtraFields["list"].([]any)[0] = "changed"
+	choices[0].Logprobs.Content[0].Bytes[0] = 9
+	choices[0].Logprobs.Content[0].TopLogprobs[0].Bytes[0] = 9
+
+	require.Equal(t, "stop", *cloned[0].FinishReason)
+	require.Equal(t, "hello", *cloned[0].Message.ContentParts[0].Text)
+	require.Equal(t, []byte("image"), cloned[0].Message.ContentParts[1].Image.Data)
+	require.Equal(t, []byte("audio"), cloned[0].Message.ContentParts[2].Audio.Data)
+	require.Equal(t, []byte("file"), cloned[0].Message.ContentParts[3].File.Data)
+	require.Equal(t, 1, *cloned[0].Message.ToolCalls[0].Index)
+	require.Equal(t, []byte(`{"value":"original"}`), cloned[0].Message.ToolCalls[0].Function.Arguments)
+	require.Equal(t, "value", cloned[0].Message.ToolCalls[0].ExtraFields["nested"].(map[string]any)["key"])
+	require.Equal(t, "first", cloned[0].Message.ToolCalls[0].ExtraFields["list"].([]any)[0])
+	require.Equal(t, []int{1, 2}, cloned[0].Logprobs.Content[0].Bytes)
+	require.Equal(t, []int{3, 4}, cloned[0].Logprobs.Content[0].TopLogprobs[0].Bytes)
+}

--- a/session/mysql/service_helper.go
+++ b/session/mysql/service_helper.go
@@ -329,9 +329,17 @@ func (s *Service) listSessions(
 
 // addEvent adds an event to a session (MySQL syntax).
 func (s *Service) addEvent(ctx context.Context, key session.Key, event *event.Event) error {
-	eventBytes, err := json.Marshal(event)
-	if err != nil {
-		return fmt.Errorf("marshal event failed: %w", err)
+	shouldPersistEvent := event != nil &&
+		event.Response != nil &&
+		!event.IsPartial &&
+		event.IsValidContent()
+	var eventBytes []byte
+	var err error
+	if shouldPersistEvent {
+		eventBytes, err = json.Marshal(event)
+		if err != nil {
+			return fmt.Errorf("marshal event failed: %w", err)
+		}
 	}
 	var updatedAt time.Time
 	var updatedStateBytes []byte
@@ -373,18 +381,18 @@ func (s *Service) addEvent(ctx context.Context, key session.Key, event *event.Ev
 		_, err = tx.ExecContext(ctx,
 			fmt.Sprintf(`UPDATE %s SET state = ?, updated_at = ?, expires_at = ?
 			 WHERE app_name = ? AND user_id = ? AND session_id = ? AND deleted_at IS NULL`, s.tableSessionStates),
-			string(updatedStateBytes), updatedAt, expiresAt,
+			updatedStateBytes, updatedAt, expiresAt,
 			key.AppName, key.UserID, key.SessionID)
 		if err != nil {
 			return fmt.Errorf("update session state failed: %w", err)
 		}
 
 		// Insert event if it has response and is not partial
-		if event.Response != nil && !event.IsPartial && event.IsValidContent() {
+		if shouldPersistEvent {
 			_, err = tx.ExecContext(ctx,
 				fmt.Sprintf(`INSERT INTO %s (app_name, user_id, session_id, event, created_at, updated_at)
 				 VALUES (?, ?, ?, ?, ?, ?)`, s.tableSessionEvents),
-				key.AppName, key.UserID, key.SessionID, string(eventBytes), now, now)
+				key.AppName, key.UserID, key.SessionID, eventBytes, now, now)
 			if err != nil {
 				return fmt.Errorf("insert event failed: %w", err)
 			}

--- a/session/mysql/service_helper.go
+++ b/session/mysql/service_helper.go
@@ -340,6 +340,8 @@ func (s *Service) addEvent(ctx context.Context, key session.Key, event *event.Ev
 		if err != nil {
 			return fmt.Errorf("marshal event failed: %w", err)
 		}
+	} else if err := validateEventRawMessages(event); err != nil {
+		return fmt.Errorf("marshal event failed: %w", err)
 	}
 	var updatedAt time.Time
 	var updatedStateBytes []byte
@@ -402,6 +404,18 @@ func (s *Service) addEvent(ctx context.Context, key session.Key, event *event.Ev
 
 	if err != nil {
 		return fmt.Errorf("store event failed: %w", err)
+	}
+	return nil
+}
+
+func validateEventRawMessages(event *event.Event) error {
+	if event == nil {
+		return nil
+	}
+	for key, raw := range event.Extensions {
+		if raw != nil && !json.Valid(raw) {
+			return fmt.Errorf("invalid extension %q JSON", key)
+		}
 	}
 	return nil
 }

--- a/session/mysql/service_helper.go
+++ b/session/mysql/service_helper.go
@@ -469,7 +469,7 @@ func (s *Service) addTrackEvent(ctx context.Context, key session.Key, trackEvent
 		_, err = tx.ExecContext(ctx,
 			fmt.Sprintf(`UPDATE %s SET state = ?, updated_at = ?, expires_at = ?
 			 WHERE app_name = ? AND user_id = ? AND session_id = ? AND deleted_at IS NULL`, s.tableSessionStates),
-			string(updatedStateBytes), updatedAt, expiresAt,
+			updatedStateBytes, updatedAt, expiresAt,
 			key.AppName, key.UserID, key.SessionID)
 		if err != nil {
 			return fmt.Errorf("update session state failed: %w", err)
@@ -479,7 +479,7 @@ func (s *Service) addTrackEvent(ctx context.Context, key session.Key, trackEvent
 		_, err = tx.ExecContext(ctx,
 			fmt.Sprintf(`INSERT INTO %s (app_name, user_id, session_id, track, event, created_at, updated_at, expires_at)
 			 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`, s.tableSessionTracks),
-			key.AppName, key.UserID, key.SessionID, trackEvent.Track, string(eventBytes),
+			key.AppName, key.UserID, key.SessionID, trackEvent.Track, eventBytes,
 			trackEvent.Timestamp, trackEvent.Timestamp, expiresAt)
 		if err != nil {
 			return fmt.Errorf("insert track event failed: %w", err)

--- a/session/mysql/service_helper_test.go
+++ b/session/mysql/service_helper_test.go
@@ -1518,6 +1518,7 @@ func TestAddEvent_UnpersistedInvalidExtension(t *testing.T) {
 	err = s.addEvent(ctx, key, evt)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "marshal event failed")
+	require.Contains(t, err.Error(), `invalid extension "bad" JSON`)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/session/mysql/service_helper_test.go
+++ b/session/mysql/service_helper_test.go
@@ -1495,6 +1495,32 @@ func TestAddEvent_PartialEvent(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestAddEvent_UnpersistedInvalidExtension(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db)
+	ctx := context.Background()
+
+	key := session.Key{
+		AppName:   "test-app",
+		UserID:    "user-123",
+		SessionID: "session-456",
+	}
+
+	evt := event.New("inv-1", "author")
+	evt.StateDelta = session.StateMap{"state-key": []byte(`"state-value"`)}
+	evt.Extensions = map[string]json.RawMessage{
+		"bad": json.RawMessage(`{`),
+	}
+
+	err = s.addEvent(ctx, key, evt)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "marshal event failed")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestAddTrackEvent_PreservesExistingSkillMarker(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)


### PR DESCRIPTION
## What changed

- Replace runner completion choice JSON round-tripping with typed cloning.
- Avoid marshaling session events in MySQL when the event will not be persisted.
- Pass marshaled session state and event payloads to SQL as `[]byte` instead of converting them to `string` first.
- Add coverage that the typed choice clone preserves JSON output and owns mutable nested fields.

## Why

OOM profiles showed large allocation pressure in `runner.cloneChoices` and `session/mysql.addEvent`. The previous implementation used JSON marshal/unmarshal for in-memory choice cloning and copied large JSON payloads again when converting `[]byte` to `string` for SQL arguments.

## Local benchmark notes

Temporary benchmarks were used locally and were not committed.

- `BenchmarkCloneChoicesLargeContent`: about 4.1 ms/op and 3.9-4.1 MB/op before; about 2.3 us/op and 29 KB/op after.
- `BenchmarkAddEventLargePayload`: about 4.7 MB/op before; about 3.2 MB/op after.
- `BenchmarkAddEventPartialLargePayload`: about 3.0 MB/op before; about 31 KB/op after.

## Validation

- `go test ./runner`
- `cd session/mysql && go test .`
- `go test ./...` was also attempted locally. It hit unrelated macOS failures: `tool/hostexec` references Linux-only `SysProcAttr.Pdeathsig`, and `codeexecutor/sandbox` has a symlink expectation failure.
