### PR TITLE
openclaw: defer broad tool surface

### DIFF
--- a/openclaw/INTEGRATIONS.md
+++ b/openclaw/INTEGRATIONS.md
@@ -854,6 +854,32 @@ Tool naming:
 If you set `tools.refresh_toolsets_on_run: true`, ToolSet tools are
 reloaded on each agent run (useful for MCP where tools can change).
 
+### Deferred tool surface (optional)
+
+Large tool and skill surfaces can dominate the parent model request even
+when a turn is answered directly. Set `tools.defer_to_dynamic_agent_mode:
+auto` to expose compact `tool_search` and `dynamic_agent` tools only when
+the configured tool declarations exceed the auto threshold. The parent can
+discover exact tool and skill names with `tool_search`, while the configured
+tools, toolsets, skills, memory, and code execution surface are loaded only
+inside the short-lived worker call. Existing `tools.defer_to_dynamic_agent:
+true` configs remain supported and force deferred mode on.
+
+YAML:
+
+```yaml
+tools:
+  defer_to_dynamic_agent_mode: auto # off|on|auto
+  defer_to_dynamic_agent_threshold_chars: 4000 # optional
+  defer_direct_tools: ["exec_command"] # optional keep-list
+```
+
+This is best for broad assistant runtimes where many turns do not need
+tools. The tradeoff is that the first cold tool-backed action may run through
+a worker agent call, so tasks that always require immediate tool execution may
+prefer `off`, a higher auto threshold, or a small `defer_direct_tools` list.
+This option is only supported by the `llm` agent.
+
 ### Parallel tool execution (optional)
 
 By default, OpenClaw executes tool calls **serially**.

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -283,6 +283,13 @@ tools:
   # Optional: override the built-in OpenClaw tooling guidance prompt.
   # Leave unset to use the built-in default, or set to "" to disable it.
   openclaw_tooling_guidance: ""
+  # Optional: reduce large parent model requests by exposing compact
+  # tool_search + dynamic_agent entrypoints when the direct tool surface
+  # exceeds the auto threshold. Set defer_to_dynamic_agent: true to force on.
+  defer_to_dynamic_agent_mode: auto # off|on|auto
+  defer_to_dynamic_agent_threshold_chars: 4000
+  # Optional: keep a small set of tools directly callable by the parent agent.
+  # defer_direct_tools: ["exec_command"]
   # Optional: configure fenced-code execution without exposing workspace_exec.
   code_executor:
     type: "sandbox" # none|local|sandbox

--- a/openclaw/README.zh_CN.md
+++ b/openclaw/README.zh_CN.md
@@ -272,6 +272,13 @@ tools:
   # 可选：覆盖内置的 OpenClaw tooling guidance 提示词。
   # 不设置时使用内置默认值，设为 "" 可禁用它。
   openclaw_tooling_guidance: ""
+  # 可选：当直接工具面超过 auto 阈值时，先只向父模型暴露轻量
+  # tool_search + dynamic_agent 入口。设置 defer_to_dynamic_agent: true
+  # 可以强制开启。
+  defer_to_dynamic_agent_mode: auto # off|on|auto
+  defer_to_dynamic_agent_threshold_chars: 4000
+  # 可选：保留少量父 agent 可直接调用的工具。
+  # defer_direct_tools: ["exec_command"]
   # 可选：配置 fenced-code 执行，但不暴露 workspace_exec。
   code_executor:
     type: "sandbox" # none|local|sandbox

--- a/openclaw/app/admin_runtime_config.go
+++ b/openclaw/app/admin_runtime_config.go
@@ -550,6 +550,72 @@ func adminRuntimeConfigSectionSpecs() []adminRuntimeConfigSectionSpec {
 						return strconv.FormatBool(opts.RefreshToolSetsOnRun)
 					},
 				),
+				adminRuntimeSelectField(
+					"tools.defer_to_dynamic_agent_mode",
+					"Deferred Tool Surface Mode",
+					"Control whether broad tool surfaces are loaded "+
+						"directly or through tool_search and "+
+						"dynamic_agent.",
+					[]adminRuntimeConfigKeyRef{
+						adminRuntimeKey("tools"),
+						adminRuntimeKey(
+							"defer_to_dynamic_agent_mode",
+							"deferToDynamicAgentMode",
+						),
+					},
+					func(opts runOptions) string {
+						mode, _ := normalizeDeferToolSurfaceMode(
+							opts.DeferToolSurfaceMode,
+						)
+						if opts.DeferToolSurface {
+							return deferToolSurfaceModeOn
+						}
+						return mode
+					},
+					deferToolSurfaceModeOff,
+					deferToolSurfaceModeOn,
+					deferToolSurfaceModeAuto,
+				),
+				adminRuntimeNumberField(
+					"tools.defer_to_dynamic_agent_threshold_chars",
+					"Deferred Tool Surface Threshold Chars",
+					"Auto mode defers when direct tool declarations "+
+						"exceed this approximate character count.",
+					[]adminRuntimeConfigKeyRef{
+						adminRuntimeKey("tools"),
+						adminRuntimeKey(
+							"defer_to_dynamic_agent_threshold_chars",
+							"deferToDynamicAgentThresholdChars",
+						),
+					},
+					func(opts runOptions) string {
+						return strconv.Itoa(
+							deferToolSurfaceThresholdChars(
+								opts.DeferToolSurfaceChars,
+							),
+						)
+					},
+				),
+				adminRuntimeTextField(
+					"tools.defer_direct_tools",
+					"Deferred Direct Tools",
+					"Comma-separated tool names to keep directly on "+
+						"the parent agent when deferred mode is "+
+						"active.",
+					"",
+					[]adminRuntimeConfigKeyRef{
+						adminRuntimeKey("tools"),
+						adminRuntimeKey(
+							"defer_direct_tools",
+							"deferDirectTools",
+						),
+					},
+					func(opts runOptions) string {
+						return strings.TrimSpace(
+							opts.DeferToolSurfaceDirect,
+						)
+					},
+				),
 			},
 		},
 		{

--- a/openclaw/app/admin_runtime_config.go
+++ b/openclaw/app/admin_runtime_config.go
@@ -599,9 +599,9 @@ func adminRuntimeConfigSectionSpecs() []adminRuntimeConfigSectionSpec {
 				adminRuntimeTextField(
 					"tools.defer_direct_tools",
 					"Deferred Direct Tools",
-					"Comma-separated tool names to keep directly on "+
-						"the parent agent when deferred mode is "+
-						"active.",
+					"Comma-separated additional tool names to keep "+
+						"directly on the parent agent when deferred "+
+						"mode is active.",
 					"",
 					[]adminRuntimeConfigKeyRef{
 						adminRuntimeKey("tools"),

--- a/openclaw/app/admin_runtime_config_test.go
+++ b/openclaw/app/admin_runtime_config_test.go
@@ -846,3 +846,49 @@ func TestBuildAdminOptions_ExposesOpenClawToolingGuidanceField(
 		field.InputType,
 	)
 }
+
+func TestBuildAdminOptions_ExposesDeferredToolSurfaceFields(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	cfgPath := writeAdminRuntimeConfigTestFile(
+		t,
+		"tools:\n"+
+			"  defer_to_dynamic_agent_mode: auto\n"+
+			"  defer_to_dynamic_agent_threshold_chars: 1234\n"+
+			"  defer_direct_tools: [exec_command]\n",
+	)
+	opts := adminRuntimeConfigTestOptions(cfgPath)
+	opts.DeferToolSurfaceMode = deferToolSurfaceModeAuto
+	opts.DeferToolSurfaceChars = 1234
+	opts.DeferToolSurfaceDirect = "exec_command"
+
+	provider, ok := buildAdminRuntimeConfigProvider(
+		opts,
+	).(*adminRuntimeConfigProvider)
+	require.True(t, ok)
+
+	status, err := provider.RuntimeConfigStatus()
+	require.NoError(t, err)
+	mode := findAdminRuntimeConfigField(
+		t,
+		status,
+		"tools.defer_to_dynamic_agent_mode",
+	)
+	require.Equal(t, deferToolSurfaceModeAuto, mode.RuntimeValue)
+	require.Equal(t, deferToolSurfaceModeAuto, mode.ConfiguredValue)
+	threshold := findAdminRuntimeConfigField(
+		t,
+		status,
+		"tools.defer_to_dynamic_agent_threshold_chars",
+	)
+	require.Equal(t, "1234", threshold.RuntimeValue)
+	require.Equal(t, "1234", threshold.ConfiguredValue)
+	direct := findAdminRuntimeConfigField(
+		t,
+		status,
+		"tools.defer_direct_tools",
+	)
+	require.Equal(t, "exec_command", direct.RuntimeValue)
+}

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -383,13 +383,16 @@ const (
 		"recurring work."
 
 	openClawDeferredToolingGuidance = "Tool-backed work is available " +
-		"through `tool_search` and `dynamic_agent`. Use `tool_search` " +
-		"when you need exact tool or skill names, then call " +
-		"`dynamic_agent` for files, uploads, browser automation, shell " +
-		"work, messaging, cron, memory, skills, knowledge, external " +
-		"tools, or verification. Give the sub-agent a self-contained " +
-		"request and ask it to complete the concrete action or return " +
-		"the exact blocker. Answer directly only when no tool work is " +
+		"through `tool_search` and `dynamic_agent`, with some " +
+		"latency-sensitive tools kept directly available when " +
+		"configured. Use direct tools for simple local actions when " +
+		"they are present. Use `tool_search` when you need exact " +
+		"tool or skill names, then call `dynamic_agent` for broader " +
+		"files, uploads, browser automation, shell work, messaging, " +
+		"cron, memory, skills, knowledge, external tools, or " +
+		"verification. Give the sub-agent a self-contained request " +
+		"and ask it to complete the concrete action or return the " +
+		"exact blocker. Answer directly only when no tool work is " +
 		"needed."
 
 	openClawDeferredToolDescription = "Run a focused OpenClaw tool " +

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -70,7 +70,6 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/subagentrun"
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/uploads"
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/registry"
-	"trpc.group/trpc-go/trpc-agent-go/openclaw/runtimeprofile"
 	openclawsubagent "trpc.group/trpc-go/trpc-agent-go/openclaw/subagent"
 )
 
@@ -382,6 +381,23 @@ const (
 		"tasks over brittle shell transcripts unless exact " +
 		"commands are truly required. Use cron for future or " +
 		"recurring work."
+
+	openClawDeferredToolingGuidance = "Tool-backed work is available " +
+		"through `tool_search` and `dynamic_agent`. Use `tool_search` " +
+		"when you need exact tool or skill names, then call " +
+		"`dynamic_agent` for files, uploads, browser automation, shell " +
+		"work, messaging, cron, memory, skills, knowledge, external " +
+		"tools, or verification. Give the sub-agent a self-contained " +
+		"request and ask it to complete the concrete action or return " +
+		"the exact blocker. Answer directly only when no tool work is " +
+		"needed."
+
+	openClawDeferredToolDescription = "Run a focused OpenClaw tool " +
+		"worker with access to configured local tools, toolsets, " +
+		"skills, memory, knowledge, and messaging capabilities. Use " +
+		"this for any task that needs tool work; include all relevant " +
+		"user context in the request and ask for the completed result " +
+		"or exact blocker."
 
 	browserToolingGuidance = "For real browser automation, use " +
 		"browser. Prefer browser snapshot plus act for page " +
@@ -1100,6 +1116,13 @@ func NewRuntimeWithOptions(
 			ToolSets:      opts.ToolSets,
 
 			RefreshToolSetsOnRun: opts.RefreshToolSetsOnRun,
+			DeferToolSurface:     opts.DeferToolSurface,
+			DeferToolSurfaceMode: opts.DeferToolSurfaceMode,
+			DeferToolSurfaceThresholdChars: opts.
+				DeferToolSurfaceChars,
+			DeferToolSurfaceDirectTools: splitCSV(
+				opts.DeferToolSurfaceDirect,
+			),
 		}
 		cwd, _ := os.Getwd()
 		skillsProv = newScopedSkillRepositoryProvider(cwd, agentCfg)
@@ -1672,6 +1695,13 @@ func run(
 			ToolSets:      opts.ToolSets,
 
 			RefreshToolSetsOnRun: opts.RefreshToolSetsOnRun,
+			DeferToolSurface:     opts.DeferToolSurface,
+			DeferToolSurfaceMode: opts.DeferToolSurfaceMode,
+			DeferToolSurfaceThresholdChars: opts.
+				DeferToolSurfaceChars,
+			DeferToolSurfaceDirectTools: splitCSV(
+				opts.DeferToolSurfaceDirect,
+			),
 		}
 		cwd, _ := os.Getwd()
 		skillsProv = newScopedSkillRepositoryProvider(cwd, agentCfg)
@@ -2382,6 +2412,15 @@ func validateAgentRunOptions(agentType string, opts runOptions) error {
 			"claude-code agent does not support refresh-toolsets-on-run",
 		)
 	}
+	deferMode, _ := normalizeDeferToolSurfaceMode(opts.DeferToolSurfaceMode)
+	if opts.DeferToolSurface {
+		deferMode = deferToolSurfaceModeOn
+	}
+	if deferMode != deferToolSurfaceModeOff {
+		return errors.New(
+			"claude-code agent does not support defer-tools-to-dynamic-agent",
+		)
+	}
 	return nil
 }
 
@@ -2517,17 +2556,9 @@ func newAgent(
 	extraTools []tool.Tool,
 	toolSets []tool.ToolSet,
 ) (agent.Agent, *ocskills.Repository, error) {
-	instruction := strings.TrimSpace(cfg.Instruction)
-	if instruction == "" {
-		instruction = defaultAgentInstruction
-	}
-	if cfg.EnableOpenClawTools {
-		guidance := buildOpenClawToolingGuidance(cfg)
-		if strings.TrimSpace(guidance) != "" {
-			instruction = strings.TrimSpace(
-				instruction + "\n\n" + guidance,
-			)
-		}
+	baseInstruction := strings.TrimSpace(cfg.Instruction)
+	if baseInstruction == "" {
+		baseInstruction = defaultAgentInstruction
 	}
 	knowledgeTools, err := buildKnowledgeTools(
 		cfg.KnowledgesConfig,
@@ -2586,106 +2617,50 @@ func newAgent(
 		}
 		tools = append(tools, extra...)
 	}
-	if hasToolNamed(tools, ocbrowser.ToolName) {
-		instruction = strings.TrimSpace(
-			instruction + "\n\n" + browserToolingGuidance,
-		)
-	}
-	genConfig := model.GenerationConfig{Stream: true}
-	if cfg.GenerationConfig != nil {
-		genConfig = *cfg.GenerationConfig
-	}
 
-	opts := []llmagent.Option{
-		llmagent.WithModel(mdl),
-		llmagent.WithInstruction(instruction),
-		llmagent.WithGlobalInstruction(strings.TrimSpace(cfg.SystemPrompt)),
-		llmagent.WithGenerationConfig(genConfig),
-		llmagent.WithAddSessionSummary(cfg.AddSessionSummary),
-		llmagent.WithEnableContextCompaction(cfg.EnableContextCompaction),
-		llmagent.WithContextCompactionOversizedToolResultMaxTokens(
-			cfg.ContextCompactionOversizedToolResultMaxTokens,
-		),
-		llmagent.WithMaxHistoryRuns(cfg.MaxHistoryRuns),
-		llmagent.WithPreloadMemory(cfg.PreloadMemory),
-		llmagent.WithEventMessageProjector(
-			conversation.ProjectEventMessage,
-		),
-		llmagent.WithEnableParallelTools(cfg.EnableParallelTools),
-		llmagent.WithPostToolPrompt(openClawPostToolPrompt),
-		llmagent.WithSkillFilter(
-			runtimeprofile.SkillVisibilityFilterForRepository(repo),
-		),
-	}
-	if cfg.PostToolPromptEnabled != nil {
-		opts = append(
-			opts,
-			llmagent.WithEnablePostToolPrompt(
-				*cfg.PostToolPromptEnabled,
-			),
-		)
-	}
-	opts = append(opts, llmagent.WithSkills(repo))
-	opts = append(
-		opts,
-		llmagent.WithSkillRepositoryProvider(repoProvider),
-		llmagent.WithSkillScopeMode(cfg.EvolutionSkillScopeMode),
-	)
-	opts = append(
-		opts,
-		llmagent.WithSkillToolProfile(
-			llmagent.SkillToolProfile(cfg.SkillsToolProfile),
-		),
-		llmagent.WithSkillsFilePathHints(true),
-		llmagent.WithSkillsDirectoryHints(true),
-		llmagent.WithSkillLoadMode(cfg.SkillsLoadMode),
-		llmagent.WithSkillsLoadedContentInToolResults(
-			cfg.SkillsToolResults,
-		),
-		llmagent.WithSkillLoadToolDescription(
-			openClawSkillLoadToolDescription,
-		),
-		llmagent.WithWorkspaceExecSurfaceEnabled(false),
-		llmagent.WithSkipSkillsFallbackOnSessionSummary(
-			cfg.SkillsSkipFallback,
-		),
-		llmagent.WithSkillsProtocolGuidance(
-			buildOpenClawSkillsGuidance(cfg),
-		),
-	)
-	if cfg.SkillsMaxLoaded > 0 {
-		opts = append(
-			opts,
-			llmagent.WithMaxLoadedSkills(cfg.SkillsMaxLoaded),
-		)
-	}
-	if len(tools) > 0 {
-		opts = append(opts, llmagent.WithTools(tools))
-	}
-	if len(toolSets) > 0 {
-		opts = append(opts, llmagent.WithToolSets(toolSets))
-	}
-	if cfg.RefreshToolSetsOnRun {
-		opts = append(opts, llmagent.WithRefreshToolSetsOnRun(true))
-	}
-	exec, err := codeExecutorFromConfig(
-		cfg.StateDir,
-		cfg.EnableLocalExec,
-		cfg.CodeExecutor,
+	deferToolSurface, directTools, err := resolveDeferredToolSurface(
+		cfg,
+		tools,
+		toolSets,
 	)
 	if err != nil {
 		return nil, nil, err
 	}
-	if exec != nil {
-		opts = append(opts, llmagent.WithCodeExecutor(exec))
-	}
-	if cfg.CodeExecutor.AutoExecuteCodeBlocks != nil {
-		opts = append(
-			opts,
-			llmagent.WithEnableCodeExecutionResponseProcessor(
-				*cfg.CodeExecutor.AutoExecuteCodeBlocks,
-			),
+	instruction := baseInstruction
+	childInstruction := baseInstruction
+	if deferToolSurface {
+		instruction = joinPromptParts(
+			instruction,
+			openClawDeferredToolingGuidance,
 		)
+	} else if cfg.EnableOpenClawTools {
+		instruction = joinPromptParts(
+			instruction,
+			buildOpenClawToolingGuidance(cfg),
+		)
+	}
+	if cfg.EnableOpenClawTools {
+		childInstruction = joinPromptParts(
+			childInstruction,
+			buildOpenClawToolingGuidance(cfg),
+		)
+	}
+	if hasToolNamed(tools, ocbrowser.ToolName) {
+		if deferToolSurface {
+			childInstruction = joinPromptParts(
+				childInstruction,
+				browserToolingGuidance,
+			)
+		} else {
+			instruction = joinPromptParts(
+				instruction,
+				browserToolingGuidance,
+			)
+		}
+	}
+	genConfig := model.GenerationConfig{Stream: true}
+	if cfg.GenerationConfig != nil {
+		genConfig = *cfg.GenerationConfig
 	}
 
 	callbacks := tool.NewCallbacks()
@@ -2695,6 +2670,76 @@ func newAgent(
 		cfg.StateDir,
 	)
 	callbacks.RegisterToolResultMessages(openClawToolResultMessages)
+
+	exec, err := codeExecutorFromConfig(
+		cfg.StateDir,
+		cfg.EnableLocalExec,
+		cfg.CodeExecutor,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	opts := baseLLMAgentOptions(
+		mdl,
+		cfg,
+		instruction,
+		strings.TrimSpace(cfg.SystemPrompt),
+		genConfig,
+		repo,
+	)
+	if cfg.PostToolPromptEnabled != nil {
+		opts = append(
+			opts,
+			llmagent.WithEnablePostToolPrompt(
+				*cfg.PostToolPromptEnabled,
+			),
+		)
+	}
+	if deferToolSurface {
+		searchTool := newDeferredCapabilitySearchTool(
+			deferredToolSurfaceConfig{
+				Model:         mdl,
+				Config:        cfg,
+				Instruction:   childInstruction,
+				SystemPrompt:  strings.TrimSpace(cfg.SystemPrompt),
+				Generation:    genConfig,
+				Repository:    repo,
+				RepoProvider:  repoProvider,
+				Tools:         tools,
+				ToolSets:      toolSets,
+				CodeExecutor:  exec,
+				ToolCallbacks: callbacks,
+			})
+		dynamicTool := newDeferredToolSurfaceTool(deferredToolSurfaceConfig{
+			Model:         mdl,
+			Config:        cfg,
+			Instruction:   childInstruction,
+			SystemPrompt:  strings.TrimSpace(cfg.SystemPrompt),
+			Generation:    genConfig,
+			Repository:    repo,
+			RepoProvider:  repoProvider,
+			Tools:         tools,
+			ToolSets:      toolSets,
+			CodeExecutor:  exec,
+			ToolCallbacks: callbacks,
+		})
+		parentTools := []tool.Tool{searchTool, dynamicTool}
+		parentTools = append(parentTools, directTools...)
+		opts = append(opts, llmagent.WithTools(parentTools))
+	} else {
+		opts = appendOpenClawSkillOptions(opts, cfg, repo, repoProvider)
+		if len(tools) > 0 {
+			opts = append(opts, llmagent.WithTools(tools))
+		}
+		if len(toolSets) > 0 {
+			opts = append(opts, llmagent.WithToolSets(toolSets))
+		}
+		if cfg.RefreshToolSetsOnRun {
+			opts = append(opts, llmagent.WithRefreshToolSetsOnRun(true))
+		}
+		opts = appendCodeExecutionOptions(opts, exec, cfg.CodeExecutor)
+	}
 	opts = append(opts, llmagent.WithToolCallbacks(callbacks))
 
 	return llmagent.New(defaultAgentName, opts...), repo, nil
@@ -3053,7 +3098,11 @@ type agentConfig struct {
 
 	ToolSets []pluginSpec
 
-	RefreshToolSetsOnRun bool
+	RefreshToolSetsOnRun           bool
+	DeferToolSurface               bool
+	DeferToolSurfaceMode           string
+	DeferToolSurfaceThresholdChars int
+	DeferToolSurfaceDirectTools    []string
 }
 
 type openClawToolsBundle struct {

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -47,6 +47,7 @@ import (
 	sessioninmemory "trpc.group/trpc-go/trpc-agent-go/session/inmemory"
 	"trpc.group/trpc-go/trpc-agent-go/skill"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
+	agenttool "trpc.group/trpc-go/trpc-agent-go/tool/agent"
 
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/admin"
 	occhannel "trpc.group/trpc-go/trpc-agent-go/openclaw/channel"
@@ -59,6 +60,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/memoryfile"
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/outbound"
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/persona"
+	ocskills "trpc.group/trpc-go/trpc-agent-go/openclaw/internal/skills"
 	tgapi "trpc.group/trpc-go/trpc-agent-go/openclaw/internal/telegram"
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/uploads"
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/registry"
@@ -553,6 +555,20 @@ func findToolDeclaration(
 			continue
 		}
 		return decl
+	}
+	return nil
+}
+
+func findTool(tools []tool.Tool, name string) tool.Tool {
+	for _, item := range tools {
+		if item == nil {
+			continue
+		}
+		decl := item.Declaration()
+		if decl == nil || decl.Name != name {
+			continue
+		}
+		return item
 	}
 	return nil
 }
@@ -2673,6 +2689,359 @@ func TestNewAgent_KnowledgeOnlyProfileUsesToolingGuidance(
 	)
 }
 
+func TestNewAgent_DeferToolSurfaceUsesDynamicAgent(t *testing.T) {
+	t.Parallel()
+
+	root := createAppTestSkill(t)
+	mdl := &captureRequestModel{}
+	agt, _, err := newAgent(mdl, agentConfig{
+		AppName:             "demo",
+		SkillsRoot:          root,
+		StateDir:            t.TempDir(),
+		EnableOpenClawTools: true,
+		DeferToolSurface:    true,
+	}, []tool.Tool{
+		stubTool{name: "exec_command"},
+	}, nil)
+	require.NoError(t, err)
+
+	parentTools := agt.Tools()
+	require.NotNil(
+		t,
+		findToolDeclaration(
+			parentTools,
+			agenttool.DefaultDynamicToolName,
+		),
+	)
+	require.NotNil(
+		t,
+		findToolDeclaration(
+			parentTools,
+			agenttool.DefaultCapabilitySearchToolName,
+		),
+	)
+	require.Nil(t, findToolDeclaration(parentTools, "exec_command"))
+	require.Nil(t, findToolDeclaration(parentTools, skillprofile.ToolLoad))
+
+	req := runAgentAndCapture(t, agt, mdl, &session.Session{})
+	require.NotNil(t, req.Tools[agenttool.DefaultDynamicToolName])
+	require.NotNil(t, req.Tools[agenttool.DefaultCapabilitySearchToolName])
+	require.Nil(t, req.Tools["exec_command"])
+	require.Nil(t, req.Tools[skillprofile.ToolLoad])
+	system := joinSystemMessages(req)
+	require.Contains(t, system, "dynamic_agent")
+	require.Contains(t, system, "tool_search")
+	require.Contains(t, system, "Tool-backed work is available")
+	require.NotContains(t, system, "OPENCLAW_LAST_UPLOAD_PATH")
+
+	searchTool := findTool(
+		parentTools,
+		agenttool.DefaultCapabilitySearchToolName,
+	)
+	searchCallable, ok := searchTool.(tool.CallableTool)
+	require.True(t, ok)
+	searchOut, err := searchCallable.Call(
+		agent.NewInvocationContext(context.Background(), agent.NewInvocation(
+			agent.WithInvocationAgent(agt),
+			agent.WithInvocationSession(
+				session.NewSession("demo", "user", "session"),
+			),
+		)),
+		[]byte(`{"query":"exec"}`),
+	)
+	require.NoError(t, err)
+	searchResult := searchOut.(agenttool.CapabilitySearchResult)
+	require.Equal(
+		t,
+		[]agenttool.CapabilityToolSummary{{
+			Name:        "exec_command",
+			Description: "stub tool",
+		}},
+		searchResult.Tools,
+	)
+
+	dynamicTool := findTool(parentTools, agenttool.DefaultDynamicToolName)
+	callable, ok := dynamicTool.(tool.CallableTool)
+	require.True(t, ok)
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(agt),
+		agent.WithInvocationMessage(model.NewUserMessage("hi")),
+		agent.WithInvocationSession(
+			session.NewSession("demo", "user", "session"),
+		),
+		agent.WithInvocationEventFilterKey("parent"),
+	)
+	_, err = callable.Call(
+		agent.NewInvocationContext(context.Background(), parent),
+		[]byte(`{"request":"inspect available tools"}`),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, mdl.got.Tools["exec_command"])
+	require.NotNil(t, mdl.got.Tools[skillprofile.ToolLoad])
+	require.Contains(
+		t,
+		joinSystemMessages(mdl.got),
+		"OPENCLAW_LAST_UPLOAD_PATH",
+	)
+}
+
+func TestNewAgent_DeferToolSurfaceAutoKeepsSmallToolSurface(t *testing.T) {
+	t.Parallel()
+
+	mdl := &captureRequestModel{}
+	agt, _, err := newAgent(mdl, agentConfig{
+		AppName:                        "demo",
+		StateDir:                       t.TempDir(),
+		DeferToolSurfaceMode:           deferToolSurfaceModeAuto,
+		DeferToolSurfaceThresholdChars: 10000,
+	}, []tool.Tool{
+		stubTool{name: "exec_command"},
+	}, nil)
+	require.NoError(t, err)
+
+	parentTools := agt.Tools()
+	require.NotNil(t, findToolDeclaration(parentTools, "exec_command"))
+	require.Nil(
+		t,
+		findToolDeclaration(parentTools, agenttool.DefaultDynamicToolName),
+	)
+	require.Nil(
+		t,
+		findToolDeclaration(
+			parentTools,
+			agenttool.DefaultCapabilitySearchToolName,
+		),
+	)
+
+	req := runAgentAndCapture(t, agt, mdl, &session.Session{})
+	require.NotNil(t, req.Tools["exec_command"])
+	require.Nil(t, req.Tools[agenttool.DefaultDynamicToolName])
+	require.Nil(t, req.Tools[agenttool.DefaultCapabilitySearchToolName])
+	require.NotContains(
+		t,
+		joinSystemMessages(req),
+		"Tool-backed work is available",
+	)
+}
+
+func TestNewAgent_DeferToolSurfaceAutoDefersLargeToolSurface(t *testing.T) {
+	t.Parallel()
+
+	mdl := &captureRequestModel{}
+	agt, _, err := newAgent(mdl, agentConfig{
+		AppName:                        "demo",
+		StateDir:                       t.TempDir(),
+		DeferToolSurfaceMode:           deferToolSurfaceModeAuto,
+		DeferToolSurfaceThresholdChars: 1,
+	}, []tool.Tool{
+		stubTool{
+			name:        "exec_command",
+			description: strings.Repeat("large ", 100),
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	parentTools := agt.Tools()
+	require.Nil(t, findToolDeclaration(parentTools, "exec_command"))
+	require.NotNil(
+		t,
+		findToolDeclaration(parentTools, agenttool.DefaultDynamicToolName),
+	)
+	require.NotNil(
+		t,
+		findToolDeclaration(
+			parentTools,
+			agenttool.DefaultCapabilitySearchToolName,
+		),
+	)
+}
+
+func TestNewAgent_DeferToolSurfaceKeepsConfiguredDirectTools(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	mdl := &captureRequestModel{}
+	agt, _, err := newAgent(mdl, agentConfig{
+		AppName:                     "demo",
+		StateDir:                    t.TempDir(),
+		DeferToolSurface:            true,
+		DeferToolSurfaceDirectTools: []string{"exec_command"},
+	}, []tool.Tool{
+		stubTool{name: "exec_command"},
+		stubTool{name: "message"},
+	}, nil)
+	require.NoError(t, err)
+
+	parentTools := agt.Tools()
+	require.NotNil(t, findToolDeclaration(parentTools, "exec_command"))
+	require.Nil(t, findToolDeclaration(parentTools, "message"))
+	require.NotNil(
+		t,
+		findToolDeclaration(parentTools, agenttool.DefaultDynamicToolName),
+	)
+	require.NotNil(
+		t,
+		findToolDeclaration(
+			parentTools,
+			agenttool.DefaultCapabilitySearchToolName,
+		),
+	)
+
+	req := runAgentAndCapture(t, agt, mdl, &session.Session{})
+	require.NotNil(t, req.Tools["exec_command"])
+	require.Nil(t, req.Tools["message"])
+	require.NotNil(t, req.Tools[agenttool.DefaultDynamicToolName])
+	require.NotNil(t, req.Tools[agenttool.DefaultCapabilitySearchToolName])
+}
+
+func TestNewDeferredToolSurfaceToolOptionalBranches(t *testing.T) {
+	t.Parallel()
+
+	root := createAppTestSkill(t)
+	repo, err := ocskills.NewRepository([]string{root})
+	require.NoError(t, err)
+	autoExecute := true
+	postToolPrompt := false
+
+	dynamicTool := newDeferredToolSurfaceTool(deferredToolSurfaceConfig{
+		Model: &captureRequestModel{},
+		Config: agentConfig{
+			AppName:               "demo",
+			StateDir:              t.TempDir(),
+			SkillsMaxLoaded:       1,
+			PostToolPromptEnabled: &postToolPrompt,
+			RefreshToolSetsOnRun:  true,
+			CodeExecutor: codeExecutorOptions{
+				AutoExecuteCodeBlocks: &autoExecute,
+			},
+		},
+		Instruction:  "worker",
+		SystemPrompt: "system",
+		Generation:   model.GenerationConfig{Stream: true},
+		Repository:   repo,
+		RepoProvider: skill.RepositoryProviderFunc(
+			func(context.Context, skill.SkillScope) (skill.Repository, error) {
+				return repo, nil
+			},
+		),
+		Tools: []tool.Tool{stubTool{name: "exec_command"}},
+		ToolSets: []tool.ToolSet{
+			&stubToolSet{
+				name:  "files",
+				tools: []tool.Tool{stubTool{name: "read"}},
+			},
+		},
+		ToolCallbacks: tool.NewCallbacks(),
+	})
+
+	decl := dynamicTool.Declaration()
+	require.Equal(t, agenttool.DefaultDynamicToolName, decl.Name)
+	require.Contains(t, decl.Description, "worker")
+}
+
+func TestDeferredCapabilitySkillsProviderUsesInvocationScope(t *testing.T) {
+	t.Parallel()
+
+	staticRepo := &testSkillRepository{
+		summary: skill.Summary{Name: "static", Description: "static"},
+		body:    "static body",
+	}
+	scopedRepo := &testSkillRepository{
+		summary: skill.Summary{Name: "scoped", Description: "scoped"},
+		body:    "scoped body",
+	}
+	var scopes []skill.SkillScope
+	provider := skill.RepositoryProviderFunc(
+		func(_ context.Context, scope skill.SkillScope) (skill.Repository, error) {
+			scopes = append(scopes, scope)
+			return scopedRepo, nil
+		},
+	)
+	resolve := deferredCapabilitySkillsProvider(
+		staticRepo,
+		provider,
+		skill.SkillScopeUser,
+	)
+
+	got := resolve(nil, agent.NewInvocation(agent.WithInvocationSession(
+		session.NewSession("demo", "user", "session"),
+	)))
+	require.Equal(t, scopedRepo.Summaries(), got.Summaries())
+	require.Equal(
+		t,
+		[]skill.SkillScope{{AppName: "demo", UserID: "user"}},
+		scopes,
+	)
+	require.Equal(t, staticRepo.Summaries(), resolve(nil, nil).Summaries())
+
+	missingUser := resolve(nil, agent.NewInvocation(agent.WithInvocationSession(
+		session.NewSession("demo", "", "session"),
+	)))
+	require.Nil(t, missingUser)
+
+	fallback := deferredCapabilitySkillsProvider(
+		staticRepo,
+		nil,
+		skill.SkillScopeApp,
+	)
+	require.Equal(t, staticRepo.Summaries(), fallback(nil, nil).Summaries())
+
+	errProvider := skill.RepositoryProviderFunc(
+		func(context.Context, skill.SkillScope) (skill.Repository, error) {
+			return nil, errors.New("repo unavailable")
+		},
+	)
+	errApp := deferredCapabilitySkillsProvider(
+		staticRepo,
+		errProvider,
+		skill.SkillScopeApp,
+	)
+	require.Equal(
+		t,
+		staticRepo.Summaries(),
+		errApp(nil, agent.NewInvocation(agent.WithInvocationSession(
+			session.NewSession("demo", "user", "session"),
+		))).Summaries(),
+	)
+	errUser := deferredCapabilitySkillsProvider(
+		staticRepo,
+		errProvider,
+		skill.SkillScopeUser,
+	)
+	require.Nil(t, errUser(nil, agent.NewInvocation(agent.WithInvocationSession(
+		session.NewSession("demo", "user", "session"),
+	))))
+}
+
+func TestDeferredCapabilityToolsDedupeAndSkipInvalid(t *testing.T) {
+	t.Parallel()
+
+	got := deferredCapabilityTools(nil, []tool.Tool{
+		nil,
+		nilDeclTool{},
+		stubTool{name: "exec_command"},
+		stubTool{name: "exec_command"},
+	}, []tool.ToolSet{
+		nil,
+		&stubToolSet{
+			tools: []tool.Tool{stubTool{name: "search"}},
+		},
+		&stubToolSet{
+			name:  "wiki",
+			tools: []tool.Tool{stubTool{name: "lookup"}},
+		},
+	})
+
+	names := toolNames(got)
+	require.Len(t, names, 3)
+	require.Contains(t, names, "exec_command")
+	require.Contains(t, names, "search")
+	require.Contains(t, names, "wiki_lookup")
+	require.Empty(t, toolDeclName(nil))
+	require.Empty(t, toolDeclName(nilDeclTool{}))
+}
+
 func TestNewAgent_FullProfileUsesToolingGuidance(t *testing.T) {
 	t.Parallel()
 
@@ -3938,13 +4307,20 @@ type toolProviderCfg struct {
 }
 
 type stubTool struct {
-	name string
+	name        string
+	description string
+	inputSchema *tool.Schema
 }
 
 func (t stubTool) Declaration() *tool.Declaration {
+	description := t.description
+	if description == "" {
+		description = "stub tool"
+	}
 	return &tool.Declaration{
 		Name:        t.name,
-		Description: "stub tool",
+		Description: description,
+		InputSchema: t.inputSchema,
 	}
 }
 
@@ -6066,11 +6442,14 @@ func (s stubCloser) Close() error { return s.closeErr }
 
 type stubToolSet struct {
 	name     string
+	tools    []tool.Tool
 	closeErr error
 	closed   *bool
 }
 
-func (s *stubToolSet) Tools(context.Context) []tool.Tool { return nil }
+func (s *stubToolSet) Tools(context.Context) []tool.Tool {
+	return append([]tool.Tool(nil), s.tools...)
+}
 
 func (s *stubToolSet) Close() error {
 	if s.closed != nil {

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -2720,13 +2720,13 @@ func TestNewAgent_DeferToolSurfaceUsesDynamicAgent(t *testing.T) {
 			agenttool.DefaultCapabilitySearchToolName,
 		),
 	)
-	require.Nil(t, findToolDeclaration(parentTools, "exec_command"))
+	require.NotNil(t, findToolDeclaration(parentTools, "exec_command"))
 	require.Nil(t, findToolDeclaration(parentTools, skillprofile.ToolLoad))
 
 	req := runAgentAndCapture(t, agt, mdl, &session.Session{})
 	require.NotNil(t, req.Tools[agenttool.DefaultDynamicToolName])
 	require.NotNil(t, req.Tools[agenttool.DefaultCapabilitySearchToolName])
-	require.Nil(t, req.Tools["exec_command"])
+	require.NotNil(t, req.Tools["exec_command"])
 	require.Nil(t, req.Tools[skillprofile.ToolLoad])
 	system := joinSystemMessages(req)
 	require.Contains(t, system, "dynamic_agent")
@@ -2842,7 +2842,7 @@ func TestNewAgent_DeferToolSurfaceAutoDefersLargeToolSurface(t *testing.T) {
 	require.NoError(t, err)
 
 	parentTools := agt.Tools()
-	require.Nil(t, findToolDeclaration(parentTools, "exec_command"))
+	require.NotNil(t, findToolDeclaration(parentTools, "exec_command"))
 	require.NotNil(
 		t,
 		findToolDeclaration(parentTools, agenttool.DefaultDynamicToolName),
@@ -2856,7 +2856,7 @@ func TestNewAgent_DeferToolSurfaceAutoDefersLargeToolSurface(t *testing.T) {
 	)
 }
 
-func TestNewAgent_DeferToolSurfaceKeepsConfiguredDirectTools(
+func TestNewAgent_DeferToolSurfaceKeepsDefaultAndConfiguredDirectTools(
 	t *testing.T,
 ) {
 	t.Parallel()
@@ -2866,7 +2866,7 @@ func TestNewAgent_DeferToolSurfaceKeepsConfiguredDirectTools(
 		AppName:                     "demo",
 		StateDir:                    t.TempDir(),
 		DeferToolSurface:            true,
-		DeferToolSurfaceDirectTools: []string{"exec_command"},
+		DeferToolSurfaceDirectTools: []string{"message"},
 	}, []tool.Tool{
 		stubTool{name: "exec_command"},
 		stubTool{name: "message"},
@@ -2875,7 +2875,7 @@ func TestNewAgent_DeferToolSurfaceKeepsConfiguredDirectTools(
 
 	parentTools := agt.Tools()
 	require.NotNil(t, findToolDeclaration(parentTools, "exec_command"))
-	require.Nil(t, findToolDeclaration(parentTools, "message"))
+	require.NotNil(t, findToolDeclaration(parentTools, "message"))
 	require.NotNil(
 		t,
 		findToolDeclaration(parentTools, agenttool.DefaultDynamicToolName),
@@ -2890,7 +2890,7 @@ func TestNewAgent_DeferToolSurfaceKeepsConfiguredDirectTools(
 
 	req := runAgentAndCapture(t, agt, mdl, &session.Session{})
 	require.NotNil(t, req.Tools["exec_command"])
-	require.Nil(t, req.Tools["message"])
+	require.NotNil(t, req.Tools["message"])
 	require.NotNil(t, req.Tools[agenttool.DefaultDynamicToolName])
 	require.NotNil(t, req.Tools[agenttool.DefaultCapabilitySearchToolName])
 }

--- a/openclaw/app/deferred_surface_policy.go
+++ b/openclaw/app/deferred_surface_policy.go
@@ -26,6 +26,12 @@ const (
 	defaultDeferToolSurfaceThresholdChars = 4000
 )
 
+var defaultDeferToolSurfaceDirectTools = []string{
+	configKeyExecCommand,
+	configKeyWriteStdin,
+	configKeyKillSession,
+}
+
 func normalizeDeferToolSurfaceMode(raw string) (string, error) {
 	mode := strings.ToLower(strings.TrimSpace(raw))
 	switch mode {
@@ -76,7 +82,9 @@ func resolveDeferredToolSurface(
 	}
 	return true, directToolSurfaceTools(
 		context.Background(),
-		cfg.DeferToolSurfaceDirectTools,
+		defaultedDirectToolSurfaceNames(
+			cfg.DeferToolSurfaceDirectTools,
+		),
 		baseTools,
 		toolSets,
 	), nil
@@ -87,6 +95,17 @@ func deferToolSurfaceThresholdChars(value int) int {
 		return value
 	}
 	return defaultDeferToolSurfaceThresholdChars
+}
+
+func defaultedDirectToolSurfaceNames(names []string) []string {
+	all := make(
+		[]string,
+		0,
+		len(defaultDeferToolSurfaceDirectTools)+len(names),
+	)
+	all = append(all, defaultDeferToolSurfaceDirectTools...)
+	all = append(all, names...)
+	return normalizeStringList(all)
 }
 
 func toolSurfaceDeclarationChars(

--- a/openclaw/app/deferred_surface_policy.go
+++ b/openclaw/app/deferred_surface_policy.go
@@ -1,0 +1,162 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+const (
+	deferToolSurfaceModeOff  = "off"
+	deferToolSurfaceModeOn   = "on"
+	deferToolSurfaceModeAuto = "auto"
+
+	defaultDeferToolSurfaceThresholdChars = 4000
+)
+
+func normalizeDeferToolSurfaceMode(raw string) (string, error) {
+	mode := strings.ToLower(strings.TrimSpace(raw))
+	switch mode {
+	case "", "off", "false", "never", "disabled":
+		return deferToolSurfaceModeOff, nil
+	case "on", "true", "always", "enabled":
+		return deferToolSurfaceModeOn, nil
+	case deferToolSurfaceModeAuto:
+		return deferToolSurfaceModeAuto, nil
+	default:
+		return "", fmt.Errorf(
+			"invalid defer tool surface mode %q: want off|on|auto",
+			raw,
+		)
+	}
+}
+
+func resolveDeferredToolSurface(
+	cfg agentConfig,
+	baseTools []tool.Tool,
+	toolSets []tool.ToolSet,
+) (bool, []tool.Tool, error) {
+	mode, err := normalizeDeferToolSurfaceMode(cfg.DeferToolSurfaceMode)
+	if err != nil {
+		return false, nil, err
+	}
+	if cfg.DeferToolSurface {
+		mode = deferToolSurfaceModeOn
+	}
+	enabled := false
+	switch mode {
+	case deferToolSurfaceModeOn:
+		enabled = true
+	case deferToolSurfaceModeAuto:
+		threshold := deferToolSurfaceThresholdChars(
+			cfg.DeferToolSurfaceThresholdChars,
+		)
+		enabled = toolSurfaceDeclarationChars(
+			context.Background(),
+			baseTools,
+			toolSets,
+		) >= threshold
+	case deferToolSurfaceModeOff:
+		enabled = false
+	}
+	if !enabled {
+		return false, nil, nil
+	}
+	return true, directToolSurfaceTools(
+		context.Background(),
+		cfg.DeferToolSurfaceDirectTools,
+		baseTools,
+		toolSets,
+	), nil
+}
+
+func deferToolSurfaceThresholdChars(value int) int {
+	if value > 0 {
+		return value
+	}
+	return defaultDeferToolSurfaceThresholdChars
+}
+
+func toolSurfaceDeclarationChars(
+	ctx context.Context,
+	baseTools []tool.Tool,
+	toolSets []tool.ToolSet,
+) int {
+	total := 0
+	for _, t := range deferredCapabilityTools(ctx, baseTools, toolSets) {
+		total += toolDeclarationChars(t)
+	}
+	return total
+}
+
+func toolDeclarationChars(t tool.Tool) int {
+	if t == nil {
+		return 0
+	}
+	decl := t.Declaration()
+	if decl == nil {
+		return 0
+	}
+	if data, err := json.Marshal(decl); err == nil {
+		return len(data)
+	}
+	return len(decl.Name) + len(decl.Description)
+}
+
+func directToolSurfaceTools(
+	ctx context.Context,
+	names []string,
+	baseTools []tool.Tool,
+	toolSets []tool.ToolSet,
+) []tool.Tool {
+	wanted := stringSet(normalizeStringList(names))
+	if len(wanted) == 0 {
+		return nil
+	}
+	allTools := deferredCapabilityTools(ctx, baseTools, toolSets)
+	out := make([]tool.Tool, 0, len(wanted))
+	seen := map[string]bool{}
+	for _, t := range allTools {
+		name := strings.TrimSpace(toolDeclName(t))
+		if name == "" || !wanted[name] || seen[name] {
+			continue
+		}
+		seen[name] = true
+		out = append(out, t)
+	}
+	return out
+}
+
+func normalizeStringList(values []string) []string {
+	out := make([]string, 0, len(values))
+	seen := map[string]bool{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		out = append(out, value)
+	}
+	return out
+}
+
+func stringSet(values []string) map[string]bool {
+	out := make(map[string]bool, len(values))
+	for _, value := range values {
+		out[value] = true
+	}
+	return out
+}

--- a/openclaw/app/deferred_surface_policy_test.go
+++ b/openclaw/app/deferred_surface_policy_test.go
@@ -1,0 +1,66 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+func TestDefaultedDirectToolSurfaceNames(t *testing.T) {
+	t.Parallel()
+
+	got := defaultedDirectToolSurfaceNames([]string{
+		configKeyExecCommand,
+		configKeyMessage,
+		" ",
+		configKeyMessage,
+	})
+	require.Equal(t, []string{
+		configKeyExecCommand,
+		configKeyWriteStdin,
+		configKeyKillSession,
+		configKeyMessage,
+	}, got)
+}
+
+func TestResolveDeferredToolSurfaceKeepsDefaultDirectTools(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	enabled, direct, err := resolveDeferredToolSurface(
+		agentConfig{DeferToolSurface: true},
+		[]tool.Tool{
+			stubTool{name: configKeyMessage},
+			stubTool{name: configKeyExecCommand},
+			stubTool{name: configKeyWriteStdin},
+			stubTool{name: configKeyKillSession},
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	require.True(t, enabled)
+	require.Equal(t, []string{
+		configKeyExecCommand,
+		configKeyWriteStdin,
+		configKeyKillSession,
+	}, testToolNames(direct))
+}
+
+func testToolNames(tools []tool.Tool) []string {
+	names := make([]string, 0, len(tools))
+	for _, t := range tools {
+		names = append(names, toolDeclName(t))
+	}
+	return names
+}

--- a/openclaw/app/deferred_tools.go
+++ b/openclaw/app/deferred_tools.go
@@ -1,0 +1,349 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package app
+
+import (
+	"context"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
+	itool "trpc.group/trpc-go/trpc-agent-go/internal/tool"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/conversation"
+	ocskills "trpc.group/trpc-go/trpc-agent-go/openclaw/internal/skills"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/runtimeprofile"
+	"trpc.group/trpc-go/trpc-agent-go/skill"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+	agenttool "trpc.group/trpc-go/trpc-agent-go/tool/agent"
+)
+
+type deferredToolSurfaceConfig struct {
+	Model         model.Model
+	Config        agentConfig
+	Instruction   string
+	SystemPrompt  string
+	Generation    model.GenerationConfig
+	Repository    *ocskills.Repository
+	RepoProvider  skill.RepositoryProvider
+	Tools         []tool.Tool
+	ToolSets      []tool.ToolSet
+	CodeExecutor  codeexecutor.CodeExecutor
+	ToolCallbacks *tool.Callbacks
+}
+
+func baseLLMAgentOptions(
+	mdl model.Model,
+	cfg agentConfig,
+	instruction string,
+	systemPrompt string,
+	genConfig model.GenerationConfig,
+	repo *ocskills.Repository,
+) []llmagent.Option {
+	return []llmagent.Option{
+		llmagent.WithModel(mdl),
+		llmagent.WithInstruction(instruction),
+		llmagent.WithGlobalInstruction(systemPrompt),
+		llmagent.WithGenerationConfig(genConfig),
+		llmagent.WithAddSessionSummary(cfg.AddSessionSummary),
+		llmagent.WithEnableContextCompaction(cfg.EnableContextCompaction),
+		llmagent.WithContextCompactionOversizedToolResultMaxTokens(
+			cfg.ContextCompactionOversizedToolResultMaxTokens,
+		),
+		llmagent.WithMaxHistoryRuns(cfg.MaxHistoryRuns),
+		llmagent.WithPreloadMemory(cfg.PreloadMemory),
+		llmagent.WithEventMessageProjector(
+			conversation.ProjectEventMessage,
+		),
+		llmagent.WithEnableParallelTools(cfg.EnableParallelTools),
+		llmagent.WithPostToolPrompt(openClawPostToolPrompt),
+		llmagent.WithSkillFilter(
+			runtimeprofile.SkillVisibilityFilterForRepository(repo),
+		),
+	}
+}
+
+func appendOpenClawSkillOptions(
+	opts []llmagent.Option,
+	cfg agentConfig,
+	repo *ocskills.Repository,
+	repoProvider skill.RepositoryProvider,
+) []llmagent.Option {
+	opts = append(opts, llmagent.WithSkills(repo))
+	opts = append(
+		opts,
+		llmagent.WithSkillRepositoryProvider(repoProvider),
+		llmagent.WithSkillScopeMode(cfg.EvolutionSkillScopeMode),
+	)
+	opts = append(
+		opts,
+		llmagent.WithSkillToolProfile(
+			llmagent.SkillToolProfile(cfg.SkillsToolProfile),
+		),
+		llmagent.WithSkillsFilePathHints(true),
+		llmagent.WithSkillsDirectoryHints(true),
+		llmagent.WithSkillLoadMode(cfg.SkillsLoadMode),
+		llmagent.WithSkillsLoadedContentInToolResults(
+			cfg.SkillsToolResults,
+		),
+		llmagent.WithSkillLoadToolDescription(
+			openClawSkillLoadToolDescription,
+		),
+		llmagent.WithWorkspaceExecSurfaceEnabled(false),
+		llmagent.WithSkipSkillsFallbackOnSessionSummary(
+			cfg.SkillsSkipFallback,
+		),
+		llmagent.WithSkillsProtocolGuidance(
+			buildOpenClawSkillsGuidance(cfg),
+		),
+	)
+	if cfg.SkillsMaxLoaded > 0 {
+		opts = append(
+			opts,
+			llmagent.WithMaxLoadedSkills(cfg.SkillsMaxLoaded),
+		)
+	}
+	return opts
+}
+
+func appendCodeExecutionOptions(
+	opts []llmagent.Option,
+	exec codeexecutor.CodeExecutor,
+	cfg codeExecutorOptions,
+) []llmagent.Option {
+	if exec != nil {
+		opts = append(opts, llmagent.WithCodeExecutor(exec))
+	}
+	if cfg.AutoExecuteCodeBlocks != nil {
+		opts = append(
+			opts,
+			llmagent.WithEnableCodeExecutionResponseProcessor(
+				*cfg.AutoExecuteCodeBlocks,
+			),
+		)
+	}
+	return opts
+}
+
+func newDeferredToolSurfaceTool(
+	cfg deferredToolSurfaceConfig,
+) tool.Tool {
+	templateOpts := baseLLMAgentOptions(
+		cfg.Model,
+		cfg.Config,
+		cfg.Instruction,
+		cfg.SystemPrompt,
+		cfg.Generation,
+		cfg.Repository,
+	)
+	if cfg.Config.PostToolPromptEnabled != nil {
+		templateOpts = append(
+			templateOpts,
+			llmagent.WithEnablePostToolPrompt(
+				*cfg.Config.PostToolPromptEnabled,
+			),
+		)
+	}
+	templateOpts = appendOpenClawSkillOptions(
+		templateOpts,
+		cfg.Config,
+		cfg.Repository,
+		cfg.RepoProvider,
+	)
+	if len(cfg.Tools) > 0 {
+		templateOpts = append(templateOpts, llmagent.WithTools(cfg.Tools))
+	}
+	if len(cfg.ToolSets) > 0 {
+		templateOpts = append(
+			templateOpts,
+			llmagent.WithToolSets(cfg.ToolSets),
+		)
+	}
+	if cfg.Config.RefreshToolSetsOnRun {
+		templateOpts = append(
+			templateOpts,
+			llmagent.WithRefreshToolSetsOnRun(true),
+		)
+	}
+	templateOpts = appendCodeExecutionOptions(
+		templateOpts,
+		cfg.CodeExecutor,
+		cfg.Config.CodeExecutor,
+	)
+	if cfg.ToolCallbacks != nil {
+		templateOpts = append(
+			templateOpts,
+			llmagent.WithToolCallbacks(cfg.ToolCallbacks),
+		)
+	}
+
+	template := llmagent.New(defaultAgentName+"-tool-worker", templateOpts...)
+	return agenttool.NewDynamicTool(
+		agenttool.WithDescription(openClawDeferredToolDescription),
+		agenttool.WithTemplateAgent(template),
+		agenttool.WithCapabilityProvider(
+			deferredCapabilityProvider(cfg.Tools, cfg.ToolSets),
+		),
+		agenttool.WithCapabilitySkillsProvider(
+			deferredCapabilitySkillsProvider(
+				cfg.Repository,
+				cfg.RepoProvider,
+				cfg.Config.EvolutionSkillScopeMode,
+			),
+		),
+		agenttool.WithExposeSkillSelection(true),
+		agenttool.WithRequestDescription(
+			"Self-contained tool-backed task for the OpenClaw worker.",
+		),
+		agenttool.WithInstructionDescription(
+			"Optional role or constraints for this worker call.",
+		),
+		agenttool.WithToolsDescription(
+			"Optional exact tool names if already known. Omit to let "+
+				"the worker choose from all permitted tools.",
+		),
+		agenttool.WithSkillsDescription(
+			"Optional exact skill names if already known. Omit to let "+
+				"the worker choose from all permitted skills.",
+		),
+	)
+}
+
+func newDeferredCapabilitySearchTool(
+	cfg deferredToolSurfaceConfig,
+) tool.Tool {
+	return agenttool.NewCapabilitySearchTool(
+		agenttool.WithCapabilitySearchProvider(
+			deferredCapabilityProvider(cfg.Tools, cfg.ToolSets),
+		),
+		agenttool.WithCapabilitySearchSkillsProvider(
+			deferredCapabilitySkillsProvider(
+				cfg.Repository,
+				cfg.RepoProvider,
+				cfg.Config.EvolutionSkillScopeMode,
+			),
+		),
+	)
+}
+
+func deferredCapabilitySkillsProvider(
+	staticRepo skill.Repository,
+	repoProvider skill.RepositoryProvider,
+	mode skill.SkillScopeMode,
+) agenttool.CapabilitySkillsProvider {
+	return func(ctx context.Context, parentInv *agent.Invocation) skill.Repository {
+		if repoProvider == nil {
+			return staticRepo
+		}
+		scope, err := deferredSkillScopeForInvocation(mode, parentInv)
+		if err != nil {
+			if skill.NormalizeSkillScopeMode(mode) == skill.SkillScopeUser {
+				return nil
+			}
+			return staticRepo
+		}
+		if scope.IsZero() {
+			return staticRepo
+		}
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		repo, err := repoProvider.Repository(ctx, scope)
+		if err != nil {
+			if skill.NormalizeSkillScopeMode(mode) == skill.SkillScopeUser {
+				return nil
+			}
+			return staticRepo
+		}
+		return repo
+	}
+}
+
+func deferredSkillScopeForInvocation(
+	mode skill.SkillScopeMode,
+	inv *agent.Invocation,
+) (skill.SkillScope, error) {
+	if inv == nil || inv.Session == nil {
+		return skill.SkillScope{}, nil
+	}
+	return skill.NewSkillScope(
+		skill.NormalizeSkillScopeMode(mode),
+		inv.Session.AppName,
+		inv.Session.UserID,
+	)
+}
+
+func deferredCapabilityProvider(
+	baseTools []tool.Tool,
+	toolSets []tool.ToolSet,
+) agenttool.CapabilitySurfaceProvider {
+	copiedBase := append([]tool.Tool(nil), baseTools...)
+	copiedSets := append([]tool.ToolSet(nil), toolSets...)
+	return func(
+		ctx context.Context,
+		_ *agent.Invocation,
+	) ([]tool.Tool, map[string]bool) {
+		tools := deferredCapabilityTools(ctx, copiedBase, copiedSets)
+		return tools, deferredToolNameSet(tools)
+	}
+}
+
+func deferredCapabilityTools(
+	ctx context.Context,
+	baseTools []tool.Tool,
+	toolSets []tool.ToolSet,
+) []tool.Tool {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	out := make([]tool.Tool, 0, len(baseTools))
+	seen := map[string]bool{}
+	appendTool := func(t tool.Tool) {
+		name := toolDeclName(t)
+		if name == "" || seen[name] {
+			return
+		}
+		seen[name] = true
+		out = append(out, t)
+	}
+	for _, t := range baseTools {
+		appendTool(t)
+	}
+	for _, toolSet := range toolSets {
+		if toolSet == nil {
+			continue
+		}
+		for _, t := range itool.NewNamedToolSet(toolSet).Tools(ctx) {
+			appendTool(t)
+		}
+	}
+	return out
+}
+
+func deferredToolNameSet(tools []tool.Tool) map[string]bool {
+	names := make(map[string]bool, len(tools))
+	for _, t := range tools {
+		if name := toolDeclName(t); name != "" {
+			names[name] = true
+		}
+	}
+	return names
+}
+
+func toolDeclName(t tool.Tool) string {
+	if t == nil {
+		return ""
+	}
+	decl := t.Declaration()
+	if decl == nil {
+		return ""
+	}
+	return decl.Name
+}

--- a/openclaw/app/run_options.go
+++ b/openclaw/app/run_options.go
@@ -132,6 +132,10 @@ const (
 
 	flagLatencyDiagnostics       = "latency-diagnostics"
 	flagLatencyDiagnosticsEvents = "latency-diagnostics-events"
+	flagDeferToolSurface         = "defer-tools-to-dynamic-agent"
+	flagDeferToolSurfaceMode     = "defer-tools-to-dynamic-agent-mode"
+	flagDeferToolSurfaceChars    = "defer-tools-to-dynamic-agent-threshold-chars"
+	flagDeferToolSurfaceDirect   = "defer-tools-to-dynamic-agent-direct-tools"
 
 	flagAdminEnabled  = "admin-enabled"
 	flagAdminAddr     = "admin-addr"
@@ -271,11 +275,15 @@ type runOptions struct {
 	SessionSummaryMaxWords            int
 	SessionSummaryApproxRunesPerToken float64
 
-	EnableLocalExec      bool
-	CodeExecutor         codeExecutorOptions
-	EnableOpenClawTools  bool
-	OpenClawToolingGuide *string
-	EnableParallelTools  bool
+	EnableLocalExec        bool
+	CodeExecutor           codeExecutorOptions
+	EnableOpenClawTools    bool
+	OpenClawToolingGuide   *string
+	EnableParallelTools    bool
+	DeferToolSurface       bool
+	DeferToolSurfaceMode   string
+	DeferToolSurfaceChars  int
+	DeferToolSurfaceDirect string
 
 	enableOpenClawToolsExplicit bool
 
@@ -882,6 +890,33 @@ func parseRunOptions(args []string) (runOptions, error) {
 		false,
 		"Refresh ToolSets tool list on each run (optional)",
 	)
+	fs.BoolVar(
+		&opts.DeferToolSurface,
+		flagDeferToolSurface,
+		false,
+		"Expose configured tools through dynamic_agent instead of "+
+			"the main agent tool surface",
+	)
+	fs.StringVar(
+		&opts.DeferToolSurfaceMode,
+		flagDeferToolSurfaceMode,
+		"",
+		"Deferred tool surface mode: off, on, auto",
+	)
+	fs.IntVar(
+		&opts.DeferToolSurfaceChars,
+		flagDeferToolSurfaceChars,
+		0,
+		"Auto-defer when direct tool declarations exceed this "+
+			"many characters (0 uses default)",
+	)
+	fs.StringVar(
+		&opts.DeferToolSurfaceDirect,
+		flagDeferToolSurfaceDirect,
+		"",
+		"Comma-separated tool names to keep directly on the "+
+			"parent agent when deferred mode is active",
+	)
 
 	if err := fs.Parse(args); err != nil {
 		return runOptions{}, &exitError{Code: 2, Err: err}
@@ -1174,13 +1209,21 @@ type skillEntryConfig struct {
 }
 
 type toolsConfig struct {
-	EnableLocalExec           *bool               `yaml:"enable_local_exec,omitempty"`
-	CodeExecutor              *codeExecutorConfig `yaml:"code_executor,omitempty"`
-	EnableOpenClawTools       *bool               `yaml:"enable_openclaw_tools,omitempty"`
-	OpenClawToolingGuide      *string             `yaml:"openclaw_tooling_guidance,omitempty"`
-	OpenClawToolingGuideCamel *string             `yaml:"openClawToolingGuidance,omitempty"`
-	EnableParallelTools       *bool               `yaml:"enable_parallel_tools,omitempty"`
-	RefreshToolSetsOnRun      *bool               `yaml:"refresh_toolsets_on_run,omitempty"`
+	EnableLocalExec               *bool               `yaml:"enable_local_exec,omitempty"`
+	CodeExecutor                  *codeExecutorConfig `yaml:"code_executor,omitempty"`
+	EnableOpenClawTools           *bool               `yaml:"enable_openclaw_tools,omitempty"`
+	OpenClawToolingGuide          *string             `yaml:"openclaw_tooling_guidance,omitempty"`
+	OpenClawToolingGuideCamel     *string             `yaml:"openClawToolingGuidance,omitempty"`
+	EnableParallelTools           *bool               `yaml:"enable_parallel_tools,omitempty"`
+	RefreshToolSetsOnRun          *bool               `yaml:"refresh_toolsets_on_run,omitempty"`
+	DeferToDynamicAgent           *bool               `yaml:"defer_to_dynamic_agent,omitempty"`
+	DeferToDynamicAgentCamel      *bool               `yaml:"deferToDynamicAgent,omitempty"`
+	DeferToDynamicAgentMode       *string             `yaml:"defer_to_dynamic_agent_mode,omitempty"`
+	DeferToDynamicAgentModeCamel  *string             `yaml:"deferToDynamicAgentMode,omitempty"`
+	DeferToDynamicAgentChars      *int                `yaml:"defer_to_dynamic_agent_threshold_chars,omitempty"`
+	DeferToDynamicAgentCharsCamel *int                `yaml:"deferToDynamicAgentThresholdChars,omitempty"`
+	DeferDirectTools              yamlStringList      `yaml:"defer_direct_tools,omitempty"`
+	DeferDirectToolsCamel         yamlStringList      `yaml:"deferDirectTools,omitempty"`
 
 	Providers []filePluginSpec `yaml:"providers,omitempty"`
 	ToolSets  []filePluginSpec `yaml:"toolsets,omitempty"`
@@ -1294,6 +1337,28 @@ type rawYAMLNode struct {
 func (r *rawYAMLNode) UnmarshalYAML(node *yaml.Node) error {
 	r.Node = node
 	return nil
+}
+
+type yamlStringList []string
+
+func (l *yamlStringList) UnmarshalYAML(node *yaml.Node) error {
+	if node == nil {
+		return nil
+	}
+	switch node.Kind {
+	case yaml.SequenceNode:
+		values := make([]string, 0, len(node.Content))
+		for _, item := range node.Content {
+			values = append(values, item.Value)
+		}
+		*l = yamlStringList(values)
+		return nil
+	case yaml.ScalarNode:
+		*l = yamlStringList(splitCSV(node.Value))
+		return nil
+	default:
+		return fmt.Errorf("expected string or list, got %v", node.Kind)
+	}
 }
 
 type filePluginSpec struct {
@@ -1843,6 +1908,47 @@ func (cfg *fileConfig) apply(
 		if cfg.Tools.RefreshToolSetsOnRun != nil &&
 			!flagWasSet(set, "refresh-toolsets-on-run") {
 			opts.RefreshToolSetsOnRun = *cfg.Tools.RefreshToolSetsOnRun
+		}
+		if !flagWasSet(set, flagDeferToolSurface) {
+			if cfg.Tools.DeferToDynamicAgent != nil {
+				opts.DeferToolSurface = *cfg.Tools.DeferToDynamicAgent
+			}
+			if cfg.Tools.DeferToDynamicAgentCamel != nil {
+				opts.DeferToolSurface =
+					*cfg.Tools.DeferToDynamicAgentCamel
+			}
+		}
+		deferMode := firstStringPtr(
+			cfg.Tools.DeferToDynamicAgentMode,
+			cfg.Tools.DeferToDynamicAgentModeCamel,
+		)
+		if deferMode != nil &&
+			!flagWasSet(set, flagDeferToolSurface) &&
+			!flagWasSet(set, flagDeferToolSurfaceMode) {
+			opts.DeferToolSurface = false
+			opts.DeferToolSurfaceMode = *deferMode
+		}
+		deferChars := firstIntPtr(
+			cfg.Tools.DeferToDynamicAgentChars,
+			cfg.Tools.DeferToDynamicAgentCharsCamel,
+		)
+		if deferChars != nil &&
+			!flagWasSet(set, flagDeferToolSurfaceChars) {
+			opts.DeferToolSurfaceChars = *deferChars
+		}
+		if !flagWasSet(set, flagDeferToolSurfaceDirect) {
+			if len(cfg.Tools.DeferDirectTools) > 0 {
+				opts.DeferToolSurfaceDirect = strings.Join(
+					[]string(cfg.Tools.DeferDirectTools),
+					",",
+				)
+			}
+			if len(cfg.Tools.DeferDirectToolsCamel) > 0 {
+				opts.DeferToolSurfaceDirect = strings.Join(
+					[]string(cfg.Tools.DeferDirectToolsCamel),
+					",",
+				)
+			}
 		}
 		if len(cfg.Tools.Providers) > 0 {
 			opts.ToolProviders = convertPluginSpecs(cfg.Tools.Providers)
@@ -2525,6 +2631,27 @@ func finalizeRunOptions(opts *runOptions) error {
 			"invalid session-summary-approx-runes-per-token: %v", v,
 		)
 	}
+	if opts.DeferToolSurface {
+		opts.DeferToolSurfaceMode = deferToolSurfaceModeOn
+	} else {
+		mode, err := normalizeDeferToolSurfaceMode(
+			opts.DeferToolSurfaceMode,
+		)
+		if err != nil {
+			return err
+		}
+		opts.DeferToolSurfaceMode = mode
+	}
+	if opts.DeferToolSurfaceChars < 0 {
+		return fmt.Errorf(
+			"invalid defer tool surface threshold chars: %d",
+			opts.DeferToolSurfaceChars,
+		)
+	}
+	opts.DeferToolSurfaceDirect = strings.Join(
+		normalizeStringList(splitCSV(opts.DeferToolSurfaceDirect)),
+		",",
+	)
 	normalizeA2AOptions(opts)
 	return nil
 }

--- a/openclaw/app/run_options.go
+++ b/openclaw/app/run_options.go
@@ -914,8 +914,8 @@ func parseRunOptions(args []string) (runOptions, error) {
 		&opts.DeferToolSurfaceDirect,
 		flagDeferToolSurfaceDirect,
 		"",
-		"Comma-separated tool names to keep directly on the "+
-			"parent agent when deferred mode is active",
+		"Comma-separated additional tool names to keep directly on "+
+			"the parent agent when deferred mode is active",
 	)
 
 	if err := fs.Parse(args); err != nil {

--- a/openclaw/app/run_options_test.go
+++ b/openclaw/app/run_options_test.go
@@ -851,6 +851,7 @@ tools:
   openclaw_tooling_guidance: ""
   enable_parallel_tools: true
   refresh_toolsets_on_run: true
+  defer_to_dynamic_agent: true
   providers:
     - type: "duckduckgo"
       name: "ddg"
@@ -1061,6 +1062,7 @@ memory:
 	require.Equal(t, "", *opts.OpenClawToolingGuide)
 	require.True(t, opts.EnableParallelTools)
 	require.True(t, opts.RefreshToolSetsOnRun)
+	require.True(t, opts.DeferToolSurface)
 
 	require.Len(t, opts.ToolProviders, 1)
 	require.Equal(t, "duckduckgo", opts.ToolProviders[0].Type)
@@ -1154,6 +1156,49 @@ tools:
 		opts.CodeExecutor.Sandbox.ShellEnv.Inherit,
 	)
 	require.True(t, opts.CodeExecutor.Sandbox.ShellEnv.ApplyDefaultExcludes)
+}
+
+func TestParseRunOptions_DeferToolSurfacePolicyConfig(t *testing.T) {
+	t.Parallel()
+
+	cfgPath := writeTempConfig(t, `
+tools:
+  defer_to_dynamic_agent_mode: auto
+  defer_to_dynamic_agent_threshold_chars: 1234
+  defer_direct_tools: ["exec_command", "message", "exec_command"]
+`)
+	opts, err := parseRunOptions([]string{"-config", cfgPath})
+	require.NoError(t, err)
+	require.False(t, opts.DeferToolSurface)
+	require.Equal(t, deferToolSurfaceModeAuto, opts.DeferToolSurfaceMode)
+	require.Equal(t, 1234, opts.DeferToolSurfaceChars)
+	require.Equal(t, "exec_command,message", opts.DeferToolSurfaceDirect)
+}
+
+func TestParseRunOptions_DeferDirectToolsStringConfig(t *testing.T) {
+	t.Parallel()
+
+	cfgPath := writeTempConfig(t, `
+tools:
+  defer_direct_tools: "exec_command, message, exec_command"
+`)
+	opts, err := parseRunOptions([]string{"-config", cfgPath})
+	require.NoError(t, err)
+	require.Equal(t, "exec_command,message", opts.DeferToolSurfaceDirect)
+}
+
+func TestParseRunOptions_DeferToolSurfaceInvalidModeFails(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	cfgPath := writeTempConfig(t, `
+tools:
+  defer_to_dynamic_agent_mode: sometimes
+`)
+	_, err := parseRunOptions([]string{"-config", cfgPath})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid defer tool surface mode")
 }
 
 func TestParseRunOptions_CodeExecutorInvalidEnumFails(t *testing.T) {

--- a/openclaw/openclaw.yaml
+++ b/openclaw/openclaw.yaml
@@ -38,6 +38,12 @@ model:
 
 tools:
   enable_parallel_tools: true
+  # Optional: expose compact tool_search + dynamic_agent entrypoints
+  # when direct tool declarations exceed the auto threshold.
+  # Set defer_to_dynamic_agent: true to force deferred mode on.
+  # defer_to_dynamic_agent_mode: auto # off|on|auto
+  # defer_to_dynamic_agent_threshold_chars: 4000
+  # defer_direct_tools: ["exec_command"]
   # code_executor:
   #   type: "sandbox" # none|local|sandbox
   #   auto_execute_code_blocks: true

--- a/tool/agent/agent_tool.go
+++ b/tool/agent/agent_tool.go
@@ -83,18 +83,19 @@ type agentToolOptions struct {
 
 // dynamicOptions holds the configuration knobs for the dynamic AgentTool mode.
 type dynamicOptions struct {
-	templateAgent          agent.Agent
-	capabilityProvider     CapabilitySurfaceProvider
-	capabilityTools        []tool.Tool
-	capabilitySkills       skillRepository
-	capabilityToolsSet     bool
-	exposeToolSelection    bool
-	exposeSkillSelection   bool
-	exposeInstruction      bool
-	requestDescription     *string
-	instructionDescription *string
-	toolsDescription       *string
-	skillsDescription      *string
+	templateAgent           agent.Agent
+	capabilityProvider      CapabilitySurfaceProvider
+	capabilitySkillProvider CapabilitySkillsProvider
+	capabilityTools         []tool.Tool
+	capabilitySkills        skillRepository
+	capabilityToolsSet      bool
+	exposeToolSelection     bool
+	exposeSkillSelection    bool
+	exposeInstruction       bool
+	requestDescription      *string
+	instructionDescription  *string
+	toolsDescription        *string
+	skillsDescription       *string
 }
 
 func defaultDynamicOptions() *dynamicOptions {

--- a/tool/agent/capability_search_index.go
+++ b/tool/agent/capability_search_index.go
@@ -1,0 +1,437 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package agent
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"unicode"
+
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+const (
+	capabilityKindTool  = "tool"
+	capabilityKindSkill = "skill"
+
+	capabilitySelectPrefix = "select:"
+
+	bm25K1 = 1.2
+	bm25B  = 0.75
+)
+
+type capabilitySearchItem struct {
+	kind        string
+	Name        string
+	Description string
+	SearchText  string
+}
+
+type capabilitySearchIndex struct {
+	items   []capabilitySearchItem
+	docs    []capabilitySearchDoc
+	docFreq map[string]int
+	avgLen  float64
+}
+
+type capabilitySearchDoc struct {
+	terms  map[string]int
+	length int
+}
+
+type scoredCapabilityItem struct {
+	item  capabilitySearchItem
+	score float64
+}
+
+func newCapabilitySearchIndex(
+	items []capabilitySearchItem,
+) *capabilitySearchIndex {
+	copied := append([]capabilitySearchItem(nil), items...)
+	index := &capabilitySearchIndex{
+		items:   copied,
+		docs:    make([]capabilitySearchDoc, 0, len(copied)),
+		docFreq: map[string]int{},
+	}
+	totalLen := 0
+	for _, item := range copied {
+		doc := newCapabilitySearchDoc(item.SearchText)
+		index.docs = append(index.docs, doc)
+		totalLen += doc.length
+		seen := map[string]bool{}
+		for term := range doc.terms {
+			if seen[term] {
+				continue
+			}
+			seen[term] = true
+			index.docFreq[term]++
+		}
+	}
+	if len(index.docs) > 0 {
+		index.avgLen = float64(totalLen) / float64(len(index.docs))
+	}
+	return index
+}
+
+func newCapabilitySearchDoc(text string) capabilitySearchDoc {
+	tokens := capabilitySearchTokens(text)
+	terms := make(map[string]int, len(tokens))
+	for _, token := range tokens {
+		terms[token]++
+	}
+	return capabilitySearchDoc{
+		terms:  terms,
+		length: len(tokens),
+	}
+}
+
+func (i *capabilitySearchIndex) search(query string) []capabilitySearchItem {
+	if i == nil || len(i.items) == 0 {
+		return nil
+	}
+	queryTerms := dedupeCapabilityTerms(capabilitySearchTokens(query))
+	if len(queryTerms) == 0 {
+		return append([]capabilitySearchItem(nil), i.items...)
+	}
+	scored := make([]scoredCapabilityItem, 0, len(i.items))
+	for idx, item := range i.items {
+		score := i.scoreDoc(i.docs[idx], queryTerms)
+		if score <= 0 {
+			continue
+		}
+		scored = append(scored, scoredCapabilityItem{
+			item:  item,
+			score: score,
+		})
+	}
+	sort.SliceStable(scored, func(a, b int) bool {
+		if scored[a].score == scored[b].score {
+			return compareCapabilityItems(
+				scored[a].item,
+				scored[b].item,
+			) < 0
+		}
+		return scored[a].score > scored[b].score
+	})
+	out := make([]capabilitySearchItem, 0, len(scored))
+	for _, item := range scored {
+		out = append(out, item.item)
+	}
+	return out
+}
+
+func (i *capabilitySearchIndex) scoreDoc(
+	doc capabilitySearchDoc,
+	queryTerms []string,
+) float64 {
+	if doc.length == 0 || len(i.docs) == 0 {
+		return 0
+	}
+	score := 0.0
+	for _, term := range queryTerms {
+		tf := doc.terms[term]
+		if tf == 0 {
+			continue
+		}
+		df := i.docFreq[term]
+		idf := math.Log(
+			1 + (float64(len(i.docs)-df)+0.5)/(float64(df)+0.5),
+		)
+		tfFloat := float64(tf)
+		denominator := tfFloat + bm25K1*(1-bm25B+
+			bm25B*float64(doc.length)/i.avgLen)
+		score += idf * (tfFloat * (bm25K1 + 1)) / denominator
+	}
+	return score
+}
+
+func capabilityToolSearchText(decl *tool.Declaration) string {
+	if decl == nil {
+		return ""
+	}
+	var parts []string
+	appendSearchPart(&parts, decl.Name)
+	appendSearchPart(&parts, splitIdentifier(decl.Name))
+	appendSearchPart(&parts, decl.Description)
+	appendSchemaSearchText(&parts, decl.InputSchema, map[*tool.Schema]bool{})
+	return strings.Join(parts, " ")
+}
+
+func capabilitySkillSearchText(name string, description string) string {
+	var parts []string
+	appendSearchPart(&parts, name)
+	appendSearchPart(&parts, splitIdentifier(name))
+	appendSearchPart(&parts, description)
+	return strings.Join(parts, " ")
+}
+
+func appendSchemaSearchText(
+	parts *[]string,
+	schema *tool.Schema,
+	seen map[*tool.Schema]bool,
+) {
+	if schema == nil || seen[schema] {
+		return
+	}
+	seen[schema] = true
+	appendSearchPart(parts, schema.Type)
+	appendSearchPart(parts, schema.Description)
+	appendSearchPart(parts, schema.Pattern)
+	appendSearchPart(parts, schema.Ref)
+	for _, value := range schema.Enum {
+		appendSearchPart(parts, fmt.Sprint(value))
+	}
+	propertyNames := sortedSchemaNames(schema.Properties)
+	for _, name := range propertyNames {
+		appendSearchPart(parts, name)
+		appendSearchPart(parts, splitIdentifier(name))
+		appendSchemaSearchText(parts, schema.Properties[name], seen)
+	}
+	appendSchemaSearchText(parts, schema.Items, seen)
+	defNames := sortedSchemaNames(schema.Defs)
+	for _, name := range defNames {
+		appendSearchPart(parts, name)
+		appendSearchPart(parts, splitIdentifier(name))
+		appendSchemaSearchText(parts, schema.Defs[name], seen)
+	}
+	if additional, ok := schema.AdditionalProperties.(*tool.Schema); ok {
+		appendSchemaSearchText(parts, additional, seen)
+	}
+}
+
+func sortedSchemaNames(values map[string]*tool.Schema) []string {
+	names := make([]string, 0, len(values))
+	for name := range values {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func appendSearchPart(parts *[]string, value string) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return
+	}
+	*parts = append(*parts, value)
+}
+
+func capabilitySearchTokens(text string) []string {
+	var tokens []string
+	var current strings.Builder
+	flush := func() {
+		if current.Len() == 0 {
+			return
+		}
+		tokens = append(tokens, strings.ToLower(current.String()))
+		current.Reset()
+	}
+	for _, r := range text {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			current.WriteRune(unicode.ToLower(r))
+			continue
+		}
+		flush()
+	}
+	flush()
+	return tokens
+}
+
+func dedupeCapabilityTerms(tokens []string) []string {
+	out := make([]string, 0, len(tokens))
+	seen := map[string]bool{}
+	for _, token := range tokens {
+		if token == "" || seen[token] {
+			continue
+		}
+		seen[token] = true
+		out = append(out, token)
+	}
+	return out
+}
+
+func splitIdentifier(value string) string {
+	var parts []string
+	var current strings.Builder
+	var previous rune
+	flush := func() {
+		if current.Len() == 0 {
+			return
+		}
+		parts = append(parts, current.String())
+		current.Reset()
+	}
+	for _, r := range value {
+		if r == '_' || r == '-' || r == '.' || r == '/' || unicode.IsSpace(r) {
+			flush()
+			previous = 0
+			continue
+		}
+		if previous != 0 && unicode.IsLower(previous) && unicode.IsUpper(r) {
+			flush()
+		}
+		current.WriteRune(r)
+		previous = r
+	}
+	flush()
+	return strings.Join(parts, " ")
+}
+
+func parseCapabilitySelectQuery(query string) ([]string, bool) {
+	trimmed := strings.TrimSpace(query)
+	if !strings.HasPrefix(strings.ToLower(trimmed), capabilitySelectPrefix) {
+		return nil, false
+	}
+	raw := strings.TrimSpace(trimmed[len(capabilitySelectPrefix):])
+	if raw == "" {
+		return nil, true
+	}
+	fields := strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ',' || unicode.IsSpace(r)
+	})
+	out := make([]string, 0, len(fields))
+	seen := map[string]bool{}
+	for _, field := range fields {
+		name := strings.TrimSpace(field)
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		out = append(out, name)
+	}
+	return out, true
+}
+
+func selectCapabilityItems(
+	items []capabilitySearchItem,
+	names []string,
+) ([]capabilitySearchItem, []string) {
+	byName := map[string]capabilitySearchItem{}
+	for _, item := range items {
+		if existing, ok := byName[item.Name]; ok &&
+			kindRank(existing.kind) <= kindRank(item.kind) {
+			continue
+		}
+		byName[item.Name] = item
+	}
+	selected := make([]capabilitySearchItem, 0, len(names))
+	missing := make([]string, 0)
+	for _, name := range names {
+		item, ok := byName[name]
+		if !ok {
+			missing = append(missing, name)
+			continue
+		}
+		selected = append(selected, item)
+	}
+	return selected, missing
+}
+
+func capabilitySummaries(
+	items []capabilitySearchItem,
+) ([]CapabilityToolSummary, []CapabilitySkillSummary) {
+	tools := make([]CapabilityToolSummary, 0)
+	skills := make([]CapabilitySkillSummary, 0)
+	for _, item := range items {
+		switch item.kind {
+		case capabilityKindSkill:
+			skills = append(skills, CapabilitySkillSummary{
+				Name:        item.Name,
+				Description: item.Description,
+			})
+		default:
+			tools = append(tools, CapabilityToolSummary{
+				Name:        item.Name,
+				Description: item.Description,
+			})
+		}
+	}
+	return tools, skills
+}
+
+func capabilityNameGroups(
+	items []capabilitySearchItem,
+) []CapabilityNameGroup {
+	var toolNames []string
+	var skillNames []string
+	for _, item := range items {
+		switch item.kind {
+		case capabilityKindSkill:
+			skillNames = append(skillNames, item.Name)
+		default:
+			toolNames = append(toolNames, item.Name)
+		}
+	}
+	groups := make([]CapabilityNameGroup, 0, 2)
+	if len(toolNames) > 0 {
+		groups = append(groups, CapabilityNameGroup{
+			Kind:  "tools",
+			Names: toolNames,
+		})
+	}
+	if len(skillNames) > 0 {
+		groups = append(groups, CapabilityNameGroup{
+			Kind:  "skills",
+			Names: skillNames,
+		})
+	}
+	return groups
+}
+
+func sortCapabilityItems(items []capabilitySearchItem) {
+	sort.SliceStable(items, func(i, j int) bool {
+		return compareCapabilityItems(items[i], items[j]) < 0
+	})
+}
+
+func compareCapabilityItems(
+	a capabilitySearchItem,
+	b capabilitySearchItem,
+) int {
+	if kindRank(a.kind) != kindRank(b.kind) {
+		return kindRank(a.kind) - kindRank(b.kind)
+	}
+	if a.Name < b.Name {
+		return -1
+	}
+	if a.Name > b.Name {
+		return 1
+	}
+	return 0
+}
+
+func kindRank(kind string) int {
+	switch kind {
+	case capabilityKindTool:
+		return 0
+	case capabilityKindSkill:
+		return 1
+	default:
+		return 2
+	}
+}
+
+func capabilityItemsFingerprint(items []capabilitySearchItem) string {
+	hash := sha256.New()
+	for _, item := range items {
+		fmt.Fprintf(
+			hash,
+			"%s\x00%s\x00%s\x00%s\x00",
+			item.kind,
+			item.Name,
+			item.Description,
+			item.SearchText,
+		)
+	}
+	return fmt.Sprintf("%x", hash.Sum(nil))
+}

--- a/tool/agent/capability_search_tool.go
+++ b/tool/agent/capability_search_tool.go
@@ -11,8 +11,8 @@ package agent
 
 import (
 	"context"
-	"sort"
 	"strings"
+	"sync"
 
 	coreagent "trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/skill"
@@ -24,10 +24,11 @@ import (
 // NewCapabilitySearchTool.
 const DefaultCapabilitySearchToolName = "tool_search"
 
-const defaultCapabilitySearchDescription = "Search the tools and skills " +
-	"available to a dynamic sub-agent. Use this to discover exact tool or skill " +
-	"names, then pass those names to dynamic_agent when running tool-backed " +
-	"work."
+const defaultCapabilitySearchDescription = "Search deferred tool and skill " +
+	"metadata for a dynamic sub-agent. Use natural-language queries to find " +
+	"relevant capabilities, `select:name1,name2` to fetch exact names, or an " +
+	"empty query for a compact name catalog. Pass selected names to " +
+	"dynamic_agent.tools or dynamic_agent.skills when running tool-backed work."
 
 const defaultCapabilitySearchLimit = 20
 const maxCapabilitySearchLimit = 50
@@ -38,6 +39,7 @@ type capabilitySearchOptions struct {
 	toolProvider   CapabilitySurfaceProvider
 	skillsProvider CapabilitySkillsProvider
 	defaultLimit   int
+	cache          *capabilitySearchCache
 }
 
 // CapabilitySearchOption configures NewCapabilitySearchTool.
@@ -51,7 +53,9 @@ func WithCapabilitySearchName(name string) CapabilitySearchOption {
 }
 
 // WithCapabilitySearchDescription overrides the search tool description.
-func WithCapabilitySearchDescription(description string) CapabilitySearchOption {
+func WithCapabilitySearchDescription(
+	description string,
+) CapabilitySearchOption {
 	return func(opts *capabilitySearchOptions) {
 		opts.description = strings.TrimSpace(description)
 	}
@@ -90,10 +94,14 @@ type CapabilitySearchInput struct {
 
 // CapabilitySearchResult is the output schema for tool_search.
 type CapabilitySearchResult struct {
-	Tools     []CapabilityToolSummary  `json:"tools,omitempty"`
-	Skills    []CapabilitySkillSummary `json:"skills,omitempty"`
-	Truncated bool                     `json:"truncated,omitempty"`
-	Note      string                   `json:"note,omitempty"`
+	Tools      []CapabilityToolSummary  `json:"tools,omitempty"`
+	Skills     []CapabilitySkillSummary `json:"skills,omitempty"`
+	Groups     []CapabilityNameGroup    `json:"groups,omitempty"`
+	Missing    []string                 `json:"missing,omitempty"`
+	Total      int                      `json:"total,omitempty"`
+	Truncated  bool                     `json:"truncated,omitempty"`
+	SearchMode string                   `json:"search_mode,omitempty"`
+	Note       string                   `json:"note,omitempty"`
 }
 
 // CapabilityToolSummary describes one available tool capability.
@@ -108,12 +116,19 @@ type CapabilitySkillSummary struct {
 	Description string `json:"description,omitempty"`
 }
 
+// CapabilityNameGroup is a compact name-only catalog section.
+type CapabilityNameGroup struct {
+	Kind  string   `json:"kind"`
+	Names []string `json:"names,omitempty"`
+}
+
 // NewCapabilitySearchTool returns a lightweight tool/skill discovery tool.
 func NewCapabilitySearchTool(opts ...CapabilitySearchOption) tool.Tool {
 	cfg := capabilitySearchOptions{
 		name:         DefaultCapabilitySearchToolName,
 		description:  defaultCapabilitySearchDescription,
 		defaultLimit: defaultCapabilitySearchLimit,
+		cache:        &capabilitySearchCache{},
 	}
 	for _, opt := range opts {
 		if opt != nil {
@@ -151,25 +166,84 @@ func searchCapabilities(
 	if limit == 0 {
 		limit = cfg.defaultLimit
 	}
-	query := strings.ToLower(strings.TrimSpace(in.Query))
-	tools := searchCapabilityTools(ctx, parentInv, cfg.toolProvider, query)
-	skills := searchCapabilitySkills(ctx, parentInv, cfg.skillsProvider, query)
-	total := len(tools) + len(skills)
-	truncated := total > limit
-	for total > limit && len(skills) > 0 {
-		skills = skills[:len(skills)-1]
-		total--
+	query := strings.TrimSpace(in.Query)
+	items := collectCapabilityItems(ctx, parentInv, cfg)
+	if selection, ok := parseCapabilitySelectQuery(query); ok {
+		selected, missing := selectCapabilityItems(items, selection)
+		return buildCapabilitySearchResult(
+			selected,
+			len(selected),
+			limit,
+			"select",
+			false,
+			missing,
+			nil,
+		)
 	}
-	for total > limit && len(tools) > 0 {
-		tools = tools[:len(tools)-1]
-		total--
+	if query == "" {
+		return buildCapabilitySearchResult(
+			items,
+			len(items),
+			limit,
+			"catalog",
+			true,
+			nil,
+			capabilityNameGroups(items),
+		)
+	}
+	index := cfg.cache.indexFor(items)
+	matches := index.search(query)
+	return buildCapabilitySearchResult(
+		matches,
+		len(matches),
+		limit,
+		"bm25",
+		false,
+		nil,
+		nil,
+	)
+}
+
+func collectCapabilityItems(
+	ctx context.Context,
+	parentInv *coreagent.Invocation,
+	cfg capabilitySearchOptions,
+) []capabilitySearchItem {
+	items := searchCapabilityTools(ctx, parentInv, cfg.toolProvider)
+	items = append(
+		items,
+		searchCapabilitySkills(ctx, parentInv, cfg.skillsProvider)...,
+	)
+	sortCapabilityItems(items)
+	return items
+}
+
+func buildCapabilitySearchResult(
+	items []capabilitySearchItem,
+	total int,
+	limit int,
+	mode string,
+	includeGroups bool,
+	missing []string,
+	groups []CapabilityNameGroup,
+) CapabilitySearchResult {
+	truncated := len(items) > limit
+	if truncated {
+		items = items[:limit]
+	}
+	tools, skills := capabilitySummaries(items)
+	if includeGroups && groups == nil {
+		groups = capabilityNameGroups(items)
 	}
 	return CapabilitySearchResult{
-		Tools:     tools,
-		Skills:    skills,
-		Truncated: truncated,
-		Note: "Pass selected names to dynamic_agent.tools or " +
-			"dynamic_agent.skills when running the tool-backed task.",
+		Tools:      tools,
+		Skills:     skills,
+		Groups:     groups,
+		Missing:    missing,
+		Total:      total,
+		Truncated:  truncated,
+		SearchMode: mode,
+		Note:       capabilitySearchResultNote,
 	}
 }
 
@@ -177,13 +251,12 @@ func searchCapabilityTools(
 	ctx context.Context,
 	parentInv *coreagent.Invocation,
 	provider CapabilitySurfaceProvider,
-	query string,
-) []CapabilityToolSummary {
+) []capabilitySearchItem {
 	if provider == nil {
 		return nil
 	}
 	tools, _ := provider(ctx, parentInv)
-	out := make([]CapabilityToolSummary, 0, len(tools))
+	out := make([]capabilitySearchItem, 0, len(tools))
 	seen := map[string]bool{}
 	for _, t := range tools {
 		if t == nil {
@@ -199,17 +272,13 @@ func searchCapabilityTools(
 		}
 		seen[name] = true
 		desc := strings.TrimSpace(decl.Description)
-		if !capabilitySearchMatches(query, name, desc) {
-			continue
-		}
-		out = append(out, CapabilityToolSummary{
+		out = append(out, capabilitySearchItem{
+			kind:        capabilityKindTool,
 			Name:        name,
 			Description: desc,
+			SearchText:  capabilityToolSearchText(decl),
 		})
 	}
-	sort.Slice(out, func(i, j int) bool {
-		return out[i].Name < out[j].Name
-	})
 	return out
 }
 
@@ -217,8 +286,7 @@ func searchCapabilitySkills(
 	ctx context.Context,
 	parentInv *coreagent.Invocation,
 	provider CapabilitySkillsProvider,
-	query string,
-) []CapabilitySkillSummary {
+) []capabilitySearchItem {
 	if provider == nil {
 		return nil
 	}
@@ -227,34 +295,21 @@ func searchCapabilitySkills(
 		return nil
 	}
 	summaries := skill.SummariesForContext(ctx, repo)
-	out := make([]CapabilitySkillSummary, 0, len(summaries))
+	out := make([]capabilitySearchItem, 0, len(summaries))
 	for _, summary := range summaries {
 		name := strings.TrimSpace(summary.Name)
 		desc := strings.TrimSpace(summary.Description)
-		if name == "" || !capabilitySearchMatches(query, name, desc) {
+		if name == "" {
 			continue
 		}
-		out = append(out, CapabilitySkillSummary{
+		out = append(out, capabilitySearchItem{
+			kind:        capabilityKindSkill,
 			Name:        name,
 			Description: desc,
+			SearchText:  capabilitySkillSearchText(name, desc),
 		})
 	}
-	sort.Slice(out, func(i, j int) bool {
-		return out[i].Name < out[j].Name
-	})
 	return out
-}
-
-func capabilitySearchMatches(query string, values ...string) bool {
-	if query == "" {
-		return true
-	}
-	for _, value := range values {
-		if strings.Contains(strings.ToLower(value), query) {
-			return true
-		}
-	}
-	return false
 }
 
 func normalizeCapabilitySearchLimit(limit int) int {
@@ -265,4 +320,31 @@ func normalizeCapabilitySearchLimit(limit int) int {
 		return maxCapabilitySearchLimit
 	}
 	return limit
+}
+
+const capabilitySearchResultNote = "Pass selected names to " +
+	"dynamic_agent.tools or dynamic_agent.skills when running the " +
+	"tool-backed task."
+
+type capabilitySearchCache struct {
+	mu          sync.Mutex
+	fingerprint string
+	index       *capabilitySearchIndex
+}
+
+func (c *capabilitySearchCache) indexFor(
+	items []capabilitySearchItem,
+) *capabilitySearchIndex {
+	if c == nil {
+		return newCapabilitySearchIndex(items)
+	}
+	fingerprint := capabilityItemsFingerprint(items)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.index != nil && c.fingerprint == fingerprint {
+		return c.index
+	}
+	c.index = newCapabilitySearchIndex(items)
+	c.fingerprint = fingerprint
+	return c.index
 }

--- a/tool/agent/capability_search_tool.go
+++ b/tool/agent/capability_search_tool.go
@@ -1,0 +1,268 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package agent
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	coreagent "trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/skill"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+	"trpc.group/trpc-go/trpc-agent-go/tool/function"
+)
+
+// DefaultCapabilitySearchToolName is the default tool name exposed by
+// NewCapabilitySearchTool.
+const DefaultCapabilitySearchToolName = "tool_search"
+
+const defaultCapabilitySearchDescription = "Search the tools and skills " +
+	"available to a dynamic sub-agent. Use this to discover exact tool or skill " +
+	"names, then pass those names to dynamic_agent when running tool-backed " +
+	"work."
+
+const defaultCapabilitySearchLimit = 20
+const maxCapabilitySearchLimit = 50
+
+type capabilitySearchOptions struct {
+	name           string
+	description    string
+	toolProvider   CapabilitySurfaceProvider
+	skillsProvider CapabilitySkillsProvider
+	defaultLimit   int
+}
+
+// CapabilitySearchOption configures NewCapabilitySearchTool.
+type CapabilitySearchOption func(*capabilitySearchOptions)
+
+// WithCapabilitySearchName overrides the model-facing search tool name.
+func WithCapabilitySearchName(name string) CapabilitySearchOption {
+	return func(opts *capabilitySearchOptions) {
+		opts.name = strings.TrimSpace(name)
+	}
+}
+
+// WithCapabilitySearchDescription overrides the search tool description.
+func WithCapabilitySearchDescription(description string) CapabilitySearchOption {
+	return func(opts *capabilitySearchOptions) {
+		opts.description = strings.TrimSpace(description)
+	}
+}
+
+// WithCapabilitySearchProvider sets the tool capability provider.
+func WithCapabilitySearchProvider(
+	provider CapabilitySurfaceProvider,
+) CapabilitySearchOption {
+	return func(opts *capabilitySearchOptions) {
+		opts.toolProvider = provider
+	}
+}
+
+// WithCapabilitySearchSkillsProvider sets the skill capability provider.
+func WithCapabilitySearchSkillsProvider(
+	provider CapabilitySkillsProvider,
+) CapabilitySearchOption {
+	return func(opts *capabilitySearchOptions) {
+		opts.skillsProvider = provider
+	}
+}
+
+// WithCapabilitySearchDefaultLimit sets the default result limit.
+func WithCapabilitySearchDefaultLimit(limit int) CapabilitySearchOption {
+	return func(opts *capabilitySearchOptions) {
+		opts.defaultLimit = normalizeCapabilitySearchLimit(limit)
+	}
+}
+
+// CapabilitySearchInput is the input schema for tool_search.
+type CapabilitySearchInput struct {
+	Query string `json:"query,omitempty"`
+	Limit int    `json:"limit,omitempty"`
+}
+
+// CapabilitySearchResult is the output schema for tool_search.
+type CapabilitySearchResult struct {
+	Tools     []CapabilityToolSummary  `json:"tools,omitempty"`
+	Skills    []CapabilitySkillSummary `json:"skills,omitempty"`
+	Truncated bool                     `json:"truncated,omitempty"`
+	Note      string                   `json:"note,omitempty"`
+}
+
+// CapabilityToolSummary describes one available tool capability.
+type CapabilityToolSummary struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+// CapabilitySkillSummary describes one available skill capability.
+type CapabilitySkillSummary struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+// NewCapabilitySearchTool returns a lightweight tool/skill discovery tool.
+func NewCapabilitySearchTool(opts ...CapabilitySearchOption) tool.Tool {
+	cfg := capabilitySearchOptions{
+		name:         DefaultCapabilitySearchToolName,
+		description:  defaultCapabilitySearchDescription,
+		defaultLimit: defaultCapabilitySearchLimit,
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+	if cfg.name == "" {
+		cfg.name = DefaultCapabilitySearchToolName
+	}
+	if cfg.description == "" {
+		cfg.description = defaultCapabilitySearchDescription
+	}
+	return function.NewFunctionTool(
+		func(ctx context.Context, in CapabilitySearchInput) (
+			CapabilitySearchResult,
+			error,
+		) {
+			return searchCapabilities(ctx, cfg, in), nil
+		},
+		function.WithName(cfg.name),
+		function.WithDescription(cfg.description),
+	)
+}
+
+func searchCapabilities(
+	ctx context.Context,
+	cfg capabilitySearchOptions,
+	in CapabilitySearchInput,
+) CapabilitySearchResult {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	parentInv, _ := coreagent.InvocationFromContext(ctx)
+	limit := normalizeCapabilitySearchLimit(in.Limit)
+	if limit == 0 {
+		limit = cfg.defaultLimit
+	}
+	query := strings.ToLower(strings.TrimSpace(in.Query))
+	tools := searchCapabilityTools(ctx, parentInv, cfg.toolProvider, query)
+	skills := searchCapabilitySkills(ctx, parentInv, cfg.skillsProvider, query)
+	total := len(tools) + len(skills)
+	truncated := total > limit
+	for total > limit && len(skills) > 0 {
+		skills = skills[:len(skills)-1]
+		total--
+	}
+	for total > limit && len(tools) > 0 {
+		tools = tools[:len(tools)-1]
+		total--
+	}
+	return CapabilitySearchResult{
+		Tools:     tools,
+		Skills:    skills,
+		Truncated: truncated,
+		Note: "Pass selected names to dynamic_agent.tools or " +
+			"dynamic_agent.skills when running the tool-backed task.",
+	}
+}
+
+func searchCapabilityTools(
+	ctx context.Context,
+	parentInv *coreagent.Invocation,
+	provider CapabilitySurfaceProvider,
+	query string,
+) []CapabilityToolSummary {
+	if provider == nil {
+		return nil
+	}
+	tools, _ := provider(ctx, parentInv)
+	out := make([]CapabilityToolSummary, 0, len(tools))
+	seen := map[string]bool{}
+	for _, t := range tools {
+		if t == nil {
+			continue
+		}
+		decl := t.Declaration()
+		if decl == nil || strings.TrimSpace(decl.Name) == "" {
+			continue
+		}
+		name := strings.TrimSpace(decl.Name)
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		desc := strings.TrimSpace(decl.Description)
+		if !capabilitySearchMatches(query, name, desc) {
+			continue
+		}
+		out = append(out, CapabilityToolSummary{
+			Name:        name,
+			Description: desc,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
+func searchCapabilitySkills(
+	ctx context.Context,
+	parentInv *coreagent.Invocation,
+	provider CapabilitySkillsProvider,
+	query string,
+) []CapabilitySkillSummary {
+	if provider == nil {
+		return nil
+	}
+	repo := provider(ctx, parentInv)
+	if repo == nil {
+		return nil
+	}
+	summaries := skill.SummariesForContext(ctx, repo)
+	out := make([]CapabilitySkillSummary, 0, len(summaries))
+	for _, summary := range summaries {
+		name := strings.TrimSpace(summary.Name)
+		desc := strings.TrimSpace(summary.Description)
+		if name == "" || !capabilitySearchMatches(query, name, desc) {
+			continue
+		}
+		out = append(out, CapabilitySkillSummary{
+			Name:        name,
+			Description: desc,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
+func capabilitySearchMatches(query string, values ...string) bool {
+	if query == "" {
+		return true
+	}
+	for _, value := range values {
+		if strings.Contains(strings.ToLower(value), query) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeCapabilitySearchLimit(limit int) int {
+	if limit < 0 {
+		return 0
+	}
+	if limit > maxCapabilitySearchLimit {
+		return maxCapabilitySearchLimit
+	}
+	return limit
+}

--- a/tool/agent/dynamic_tool.go
+++ b/tool/agent/dynamic_tool.go
@@ -87,6 +87,13 @@ type CapabilitySurfaceProvider func(
 	parentInv *agent.Invocation,
 ) ([]tool.Tool, map[string]bool)
 
+// CapabilitySkillsProvider returns the maximum skill repository the model may
+// select from for one dynamic sub-agent invocation.
+type CapabilitySkillsProvider func(
+	ctx context.Context,
+	parentInv *agent.Invocation,
+) skill.Repository
+
 // WithTemplateAgent sets the base/template agent that defines the execution
 // boundary for the dynamic sub-agent (model, executor, callbacks, permission
 // policy, max calls, ...).
@@ -127,6 +134,16 @@ func WithCapabilityTools(tools []tool.Tool) Option {
 func WithCapabilitySkills(repo skill.Repository) Option {
 	return func(opts *agentToolOptions) {
 		opts.ensureDynamicOptions().capabilitySkills = repo
+	}
+}
+
+// WithCapabilitySkillsProvider overrides how the maximum skill repository is
+// resolved for a dynamic sub-agent. By default the repository is derived from
+// the parent invocation's effective skills. This takes precedence over
+// WithCapabilitySkills.
+func WithCapabilitySkillsProvider(provider CapabilitySkillsProvider) Option {
+	return func(opts *agentToolOptions) {
+		opts.ensureDynamicOptions().capabilitySkillProvider = provider
 	}
 }
 
@@ -693,14 +710,18 @@ func (at *Tool) selectDynamicTools(
 }
 
 // dynamicMaxSkillRepo resolves the maximum skill repository the model may
-// select from: the code-side WithCapabilitySkills repository when set, else the
-// parent invocation's effective repository. It never returns the template
-// agent's own repository — the boundary is always the parent's skills (or an
-// explicit capability override).
+// select from: the code-side WithCapabilitySkillsProvider repository when set,
+// else the code-side WithCapabilitySkills repository when set, else the parent
+// invocation's effective repository. It never returns the template agent's own
+// repository — the boundary is always the parent's skills (or an explicit
+// capability override).
 func (at *Tool) dynamicMaxSkillRepo(
 	ctx context.Context,
 	parentInv *agent.Invocation,
 ) skill.Repository {
+	if at.dynamicCfg.capabilitySkillProvider != nil {
+		return at.dynamicCfg.capabilitySkillProvider(ctx, parentInv)
+	}
 	if at.dynamicCfg.capabilitySkills != nil {
 		return at.dynamicCfg.capabilitySkills
 	}

--- a/tool/agent/dynamic_tool_test.go
+++ b/tool/agent/dynamic_tool_test.go
@@ -215,6 +215,76 @@ func TestNewDynamicTool_ExposeToggles(t *testing.T) {
 	require.Contains(t, props, fieldSkills)
 }
 
+func TestDynamicTool_CapabilitySkillsProviderOverridesFixed(t *testing.T) {
+	fixed := newDynTestSkillRepo(t, "fixed")
+	dynamic := newDynTestSkillRepo(t, "dynamic")
+	calls := 0
+	at := NewDynamicTool(
+		WithCapabilitySkills(fixed),
+		WithCapabilitySkillsProvider(
+			func(context.Context, *agent.Invocation) skill.Repository {
+				calls++
+				return dynamic
+			},
+		),
+	)
+
+	got := at.dynamicMaxSkillRepo(
+		context.Background(),
+		agent.NewInvocation(),
+	)
+	require.Equal(t, dynamic.Summaries(), got.Summaries())
+	require.Equal(t, 1, calls)
+}
+
+func TestCapabilitySearchTool_SearchesToolsAndSkills(t *testing.T) {
+	repo := newDynTestSkillRepo(t, "coding", "weather")
+	parent := agent.NewInvocation()
+	search := NewCapabilitySearchTool(
+		WithCapabilitySearchProvider(
+			func(
+				_ context.Context,
+				got *agent.Invocation,
+			) ([]tool.Tool, map[string]bool) {
+				require.Same(t, parent, got)
+				return stubTools("read_file", "search_web"), nil
+			},
+		),
+		WithCapabilitySearchSkillsProvider(
+			func(
+				_ context.Context,
+				got *agent.Invocation,
+			) skill.Repository {
+				require.Same(t, parent, got)
+				return repo
+			},
+		),
+	)
+	callable, ok := search.(tool.CallableTool)
+	require.True(t, ok)
+
+	out, err := callable.Call(
+		agent.NewInvocationContext(context.Background(), parent),
+		[]byte(`{"query":"read","limit":10}`),
+	)
+	require.NoError(t, err)
+	got := out.(CapabilitySearchResult)
+	require.Equal(t, []CapabilityToolSummary{{Name: "read_file"}}, got.Tools)
+	require.Empty(t, got.Skills)
+	require.False(t, got.Truncated)
+	require.Contains(t, got.Note, "dynamic_agent")
+
+	out, err = callable.Call(
+		agent.NewInvocationContext(context.Background(), parent),
+		[]byte(`{"query":"","limit":2}`),
+	)
+	require.NoError(t, err)
+	got = out.(CapabilitySearchResult)
+	require.Len(t, got.Tools, 2)
+	require.Empty(t, got.Skills)
+	require.True(t, got.Truncated)
+}
+
 func TestNewDynamicTool_CustomFieldDescriptions(t *testing.T) {
 	at := NewDynamicTool(
 		WithRequestDescription("req-desc"),

--- a/tool/agent/dynamic_tool_test.go
+++ b/tool/agent/dynamic_tool_test.go
@@ -38,11 +38,17 @@ import (
 // dynStubTool is a minimal tool.Tool used to exercise the dynamic tool's
 // selection logic without a runtime.
 type dynStubTool struct {
-	name string
+	name        string
+	description string
+	inputSchema *tool.Schema
 }
 
 func (s dynStubTool) Declaration() *tool.Declaration {
-	return &tool.Declaration{Name: s.name}
+	return &tool.Declaration{
+		Name:        s.name,
+		Description: s.description,
+		InputSchema: s.inputSchema,
+	}
 }
 
 func stubTools(names ...string) []tool.Tool {
@@ -282,7 +288,142 @@ func TestCapabilitySearchTool_SearchesToolsAndSkills(t *testing.T) {
 	got = out.(CapabilitySearchResult)
 	require.Len(t, got.Tools, 2)
 	require.Empty(t, got.Skills)
+	require.Equal(t, "catalog", got.SearchMode)
+	require.Equal(t, 4, got.Total)
 	require.True(t, got.Truncated)
+	require.Equal(t, []CapabilityNameGroup{
+		{Kind: "tools", Names: []string{"read_file", "search_web"}},
+		{Kind: "skills", Names: []string{"coding", "weather"}},
+	}, got.Groups)
+}
+
+func TestCapabilitySearchTool_SelectsExactNames(t *testing.T) {
+	repo := newDynTestSkillRepo(t, "coding", "weather")
+	search := NewCapabilitySearchTool(
+		WithCapabilitySearchProvider(
+			func(
+				context.Context,
+				*agent.Invocation,
+			) ([]tool.Tool, map[string]bool) {
+				return stubTools("read_file", "search_web"), nil
+			},
+		),
+		WithCapabilitySearchSkillsProvider(
+			func(context.Context, *agent.Invocation) skill.Repository {
+				return repo
+			},
+		),
+	)
+	callable := search.(tool.CallableTool)
+
+	out, err := callable.Call(
+		context.Background(),
+		[]byte(`{"query":"select:search_web,coding,missing"}`),
+	)
+	require.NoError(t, err)
+	got := out.(CapabilitySearchResult)
+	require.Equal(t, "select", got.SearchMode)
+	require.Equal(t, []CapabilityToolSummary{{Name: "search_web"}}, got.Tools)
+	require.Equal(t, []CapabilitySkillSummary{{
+		Name:        "coding",
+		Description: "test skill",
+	}}, got.Skills)
+	require.Equal(t, []string{"missing"}, got.Missing)
+	require.False(t, got.Truncated)
+}
+
+func TestCapabilitySearchTool_SearchesSchemaMetadataWithBM25(
+	t *testing.T,
+) {
+	search := NewCapabilitySearchTool(
+		WithCapabilitySearchProvider(
+			func(
+				context.Context,
+				*agent.Invocation,
+			) ([]tool.Tool, map[string]bool) {
+				return []tool.Tool{
+					dynStubTool{
+						name:        "write_file",
+						description: "Modify file contents.",
+						inputSchema: &tool.Schema{
+							Type: "object",
+							Properties: map[string]*tool.Schema{
+								"path": {
+									Type:        "string",
+									Description: "Workspace path to update.",
+								},
+							},
+						},
+					},
+					dynStubTool{
+						name:        "search_web",
+						description: "Search public web pages.",
+					},
+				}, nil
+			},
+		),
+	)
+	callable := search.(tool.CallableTool)
+
+	out, err := callable.Call(
+		context.Background(),
+		[]byte(`{"query":"workspace path","limit":5}`),
+	)
+	require.NoError(t, err)
+	got := out.(CapabilitySearchResult)
+	require.Equal(t, "bm25", got.SearchMode)
+	require.Equal(t, []CapabilityToolSummary{{
+		Name:        "write_file",
+		Description: "Modify file contents.",
+	}}, got.Tools)
+	require.Empty(t, got.Skills)
+	require.Equal(t, 1, got.Total)
+}
+
+func TestCapabilitySearchTool_RebuildsCachedIndexOnCapabilityChange(
+	t *testing.T,
+) {
+	tools := []tool.Tool{dynStubTool{
+		name:        "alpha_tool",
+		description: "Alpha-only capability.",
+	}}
+	search := NewCapabilitySearchTool(
+		WithCapabilitySearchProvider(
+			func(
+				context.Context,
+				*agent.Invocation,
+			) ([]tool.Tool, map[string]bool) {
+				return tools, nil
+			},
+		),
+	)
+	callable := search.(tool.CallableTool)
+
+	out, err := callable.Call(
+		context.Background(),
+		[]byte(`{"query":"alpha"}`),
+	)
+	require.NoError(t, err)
+	got := out.(CapabilitySearchResult)
+	require.Equal(t, []CapabilityToolSummary{{
+		Name:        "alpha_tool",
+		Description: "Alpha-only capability.",
+	}}, got.Tools)
+
+	tools = []tool.Tool{dynStubTool{
+		name:        "beta_tool",
+		description: "Beta-only capability.",
+	}}
+	out, err = callable.Call(
+		context.Background(),
+		[]byte(`{"query":"beta"}`),
+	)
+	require.NoError(t, err)
+	got = out.(CapabilitySearchResult)
+	require.Equal(t, []CapabilityToolSummary{{
+		Name:        "beta_tool",
+		Description: "Beta-only capability.",
+	}}, got.Tools)
 }
 
 func TestNewDynamicTool_CustomFieldDescriptions(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR reduces OpenClaw's default parent-agent tool surface by deferring broad tool and skill capabilities behind `tool_search` and `dynamic_agent`, while keeping latency-sensitive local execution tools directly available.

The deferred tool surface now defaults to `auto` for LLM agents. Existing OpenClaw configs that do not set `tools.defer_to_dynamic_agent_mode` can get the prompt reduction automatically when the configured direct tool declarations exceed the threshold. Existing `tools.defer_to_dynamic_agent: true` still forces deferred mode on, and `tools.defer_to_dynamic_agent: false` or `tools.defer_to_dynamic_agent_mode: off` disables it. `claude-code` keeps its previous default behavior unless the unsupported defer mode is explicitly requested.

## Design

- Default LLM agents to `tools.defer_to_dynamic_agent_mode: auto`, gated by the declaration-size threshold.
- Keep direct parent-agent tools for common local execution control: `exec_command`, `write_stdin`, and `kill_session`.
- Add `tool_search` as the discovery layer for deferred tools and skills:
  - empty query returns a compact catalog grouped by name prefix
  - `select:<name>,...` returns exact tools/skills for deterministic handoff
  - natural-language queries use an in-memory BM25 index over name, description, and JSON schema metadata
- Use `dynamic_agent` for the selected long-tail capability set, so the parent prompt no longer carries every tool schema on every turn.
- Treat `defer_direct_tools` as additional direct tools instead of replacing the default execution-control tools.

## Tool Surface Metrics

Measured two ways:

- Code-level declaration metrics serialize actual `tool.Declaration()` values from the OpenClaw agent request. Token counts use a simple `chars / 4` estimate.
- Request-level metrics use real `model.chat.request` debug events plus provider usage metadata from the same configured model and prompt.

### Code-Level Declaration Surface

| Mode | Parent tools | Declaration chars | Est. tokens | Delta vs full |
| --- | ---: | ---: | ---: | ---: |
| Full direct surface | 21 | 17,509 | 4,377 | baseline |
| Deferred parent default | 5 | 5,275 | 1,319 | -69.9% chars / -3,058 est. tokens |
| Deferred parent + `message` direct | 6 | 6,662 | 1,666 | -62.0% chars / -2,711 est. tokens |

Largest full-surface declaration costs were `cron` (~1,041 est. tokens), `exec_command` (~504), `skill_load` (~373), and `message` (~346). In deferred mode, the parent keeps `dynamic_agent`, `tool_search`, `exec_command`, `write_stdin`, and `kill_session`.

### Real Model Prompt And Latency

Same configured real model, same one-turn request, 3 runs per mode.

| Mode | Request-side tools | Prompt tokens | Total tokens | Avg E2E latency |
| --- | ---: | ---: | ---: | ---: |
| Full direct surface | 35 provider-level tools | 13,764 | 13,775 | 2.43s |
| Deferred parent default | 5 parent tools | 6,389 | 6,400 | 1.98s |
| Delta | -30 provider-level tools | -7,375 (-53.6%) | -7,375 (-53.5%) | -0.45s (-18.5%) |

Baseline request-side prompt breakdown:

| Prompt area | Request chars | Approx. prompt tokens | Approx. share |
| --- | ---: | ---: | ---: |
| Provider-level tool schemas | 40,108 | 7.3K | 52.9% |
| OpenClaw tool/skills runtime guidance | 9,621 | 1.7K | 12.7% |
| Post-tool prompt | 1,586 | 0.3K | 2.1% |
| Combined tool-related prompt | 51,315 | 9.3K | 67.7% |

`browser` was the largest provider-level schema in the baseline request (6,376 chars, about 1.16K proportional tokens). It is not part of the deferred parent default surface; it remains available through `tool_search` and `dynamic_agent` worker delegation when needed.

## Validation

- `go test ./tool/agent`
- `cd openclaw && go test ./app`
- `cd openclaw && go test ./app -run 'DeferToolSurface|ValidateAgentRunOptions|ClaudeCode' -count=1`
- `git diff --check`
- `cd openclaw && go test ./...`
- Real-model A/B benchmark above: prompt tokens reduced from 13,764 to 6,389 and average E2E latency reduced from 2.43s to 1.98s.
- Real-model deferred-chain smoke: direct execution tools remain available on the parent agent, while deferred long-tail capabilities are reachable through `tool_search` and `dynamic_agent`.

CI status is tracked by the PR checks for the current head commit.