### PR TITLE
{plugin/debuglog, docs}: add debug payload logging

### DIFF
--- a/docs/design/debuglog-plugin.md
+++ b/docs/design/debuglog-plugin.md
@@ -1,0 +1,212 @@
+# DebugLog 插件设计
+
+## 目标
+
+新增 `plugin/debuglog`，提供一个临时诊断插件，用于在不修改 Agent、Model、Tool 代码的前提下，把框架层关键入参和出参打印成单行 JSON debug 日志。
+
+核心目标：
+
+- 通过 `runner.WithPlugins(...)` 或单次 `plugin.WithPlugins(...)` 启用。
+- 默认记录 agent/model/tool 的关键 callback 数据。
+- 默认不记录 Runner event 和 model partial response，避免流式场景日志过多。
+- 只观察，不修改 request、response、tool args、tool result 或 event。
+- 通过框架 logger 输出：`log.DebugfContext(ctx, "%s", rawJSON)`。
+- 能 JSON 序列化就按对象已有 JSON 契约输出；不能序列化就记录明确的错误和 Go 类型。
+
+非目标：
+
+- 不替代 `plugin.NewLogging()`。Logging 适合生命周期和耗时，DebugLog 适合排查 payload。
+- 不做 OpenTelemetry、采样、持久化、上传、轮转。
+- 不做 redact、truncate、字段白名单或 `%v` 兜底。DebugLog 可能包含 prompt、请求头、工具参数和工具结果，只应临时启用并配合受控日志落点。
+
+## API
+
+包路径：
+
+```text
+plugin/debuglog
+```
+
+文件：
+
+```text
+plugin/debuglog/plugin.go
+plugin/debuglog/options.go
+plugin/debuglog/entry.go
+plugin/debuglog/snapshot.go
+plugin/debuglog/plugin_test.go
+```
+
+公开接口：
+
+```go
+package debuglog
+
+func New(opts ...Option) plugin.Plugin
+
+type Option func(*options)
+
+func WithName(name string) Option
+func WithEventEnabled(enabled bool) Option
+func WithModelPartialResponseEnabled(enabled bool) Option
+```
+
+默认值：
+
+| 配置 | 默认值 | 说明 |
+| --- | --- | --- |
+| `name` | `"debug_log"` | 插件名。 |
+| `event_enabled` | `false` | 是否记录 Runner event。 |
+| `model_partial_response_enabled` | `false` | 是否记录 model partial response。 |
+
+不提供 `WithBeforeModelEnabled`、`WithToolEnabled` 这类细粒度开关。model request/response 和 tool arguments/result 是这个插件的核心诊断面；如果不能接受这些内容进入 debug log，就不应该启用 DebugLog。
+
+## 使用示例
+
+Runner 级启用：
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/plugin/debuglog"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+)
+
+runnerInstance := runner.NewRunner(
+	"my-app",
+	agentInstance,
+	runner.WithPlugins(debuglog.New()),
+)
+```
+
+单次 Run 临时启用，并打开 event 和 model partial response：
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/plugin"
+	"trpc.group/trpc-go/trpc-agent-go/plugin/debuglog"
+)
+
+events, err := runnerInstance.Run(
+	ctx,
+	userID,
+	sessionID,
+	message,
+	plugin.WithPlugins(
+		debuglog.New(
+			debuglog.WithEventEnabled(true),
+			debuglog.WithModelPartialResponseEnabled(true),
+		),
+	),
+)
+```
+
+输出示例：
+
+```json
+{"time":"2026-06-16T10:20:30.123456789+08:00","sequence":7,"plugin":"debug_log","phase":"before_tool","invocation_id":"inv-1","agent_name":"assistant","session_id":"sess-1","user_id":"user-1","tool_name":"calculator","tool_call_id":"call-1","payload":{"arguments":{"operation":"add","a":1,"b":2},"arguments_bytes":33}}
+```
+
+## 日志结构
+
+每条日志是一条单行 JSON message：
+
+不要在 JSON message 外额外拼 `debuglog:` 这类文本前缀，否则日志 message 本身就不再是合法 JSON。检索和过滤使用 JSON 内的 `plugin`、`phase`、`tool_name`、`invocation_id` 等字段。
+
+```go
+type entry struct {
+	Time               time.Time      `json:"time"`
+	Sequence           uint64         `json:"sequence"`
+	Plugin             string         `json:"plugin"`
+	Phase              string         `json:"phase"`
+	InvocationID       string         `json:"invocation_id,omitempty"`
+	ParentInvocationID string         `json:"parent_invocation_id,omitempty"`
+	AgentName          string         `json:"agent_name,omitempty"`
+	SessionID          string         `json:"session_id,omitempty"`
+	UserID             string         `json:"user_id,omitempty"`
+	ModelName          string         `json:"model_name,omitempty"`
+	ToolName           string         `json:"tool_name,omitempty"`
+	ToolCallID         string         `json:"tool_call_id,omitempty"`
+	Error              string         `json:"error,omitempty"`
+	Payload            map[string]any `json:"payload,omitempty"`
+}
+```
+
+`phase` 取值：
+
+```text
+before_agent
+after_agent
+before_model
+after_model
+before_tool
+after_tool
+event
+```
+
+## Hook 行为
+
+- `BeforeAgent` / `AfterAgent`：记录 invocation 元信息，不整体序列化 `agent.Invocation`。
+- `BeforeModel`：记录 `model.Request`，并补充 `Tools`、`ExtraFields`、`Headers`。
+- `AfterModel`：记录 `model.Request`、`model.Response` 和 error。`Response.IsPartial=true` 时默认跳过；打开 `WithModelPartialResponseEnabled(true)` 后记录。
+- `BeforeTool`：记录 tool declaration、JSON arguments、resume value、resume map。
+- `AfterTool`：记录 tool declaration、JSON arguments、result、meta 和 error。
+- `OnEvent`：默认关闭；打开 `WithEventEnabled(true)` 后记录 `event.Event`，并补充 `StructuredOutput` 和 `ExecutionTrace`。
+
+所有 hook 都应在常规路径返回 `nil, nil`。日志构造失败不应中断 Agent 执行，但失败原因必须体现在 payload 的错误字段里；如果整条 entry 无法 marshal，则通过 `log.WarnfContext` 记录一次。
+
+## 序列化规则
+
+DebugLog 只输出框架已经持有的对象，不猜 provider 原生 HTTP 请求体。
+
+处理原则：
+
+- `model.Request`、`model.Response`、`event.Event`、`tool.Declaration` 优先整体 `json.Marshal` 后再 `json.Unmarshal` 成 `any`，保持对象已有 JSON tag 和 `MarshalJSON` 行为。
+- 不整体序列化 callback args。它们是 hook 容器，不是日志契约。
+- 不整体序列化 `agent.Invocation`。它包含 agent、model、service、plugin manager、context、channel、mutex 等运行态对象，只提取稳定元信息。
+- `json:"-"` 字段不通过反射绕过。确有诊断价值的字段作为 supplement 明确输出。
+- tool arguments 是 JSON bytes，先按 JSON 解析；不能使用 Go 默认 `[]byte` JSON 编码，否则会变成 base64。
+- 不使用 `fmt.Sprintf("%v", value)` 兜底。不可序列化时记录 `*_encode_error` 和 `*_type`。
+
+关键 supplement：
+
+| 来源 | 输出位置 |
+| --- | --- |
+| `model.Request.Tools` | `payload.request_supplement.tools` |
+| `model.Request.ExtraFields` | `payload.request_supplement.extra_fields` |
+| `model.Request.Headers` | `payload.request_supplement.headers` |
+| `event.Event.StructuredOutput` | `payload.event_supplement.structured_output` |
+| `event.Event.ExecutionTrace` | `payload.event_supplement.execution_trace` |
+
+## 插件顺序
+
+DebugLog 记录它所在 hook 顺序下已经可见的数据。
+
+- 想看其他插件改写后的数据，把 mutating plugin 放在 `debuglog.New()` 前面。
+- 想看原始数据，把 `debuglog.New()` 放在 mutating plugin 前面。
+
+## 测试与验收
+
+单测重点：
+
+- 默认 name、nil option、`WithName`。
+- `BeforeModel` / `AfterModel` 输出 request、response 和 request supplement。
+- partial model response 默认跳过，`WithModelPartialResponseEnabled(true)` 后记录。
+- `BeforeTool` / `AfterTool` 将合法 JSON arguments 解码为 JSON value，不输出 base64。
+- 不可序列化的 result、meta、extra field 记录 Go 类型和 encode error。
+- event 默认不记录，`WithEventEnabled(true)` 后记录并不替换 event。
+- debug message 是合法单行 JSON。
+
+验证命令：
+
+```sh
+go test ./plugin/...
+```
+
+验收标准：
+
+- 不改 Agent 或 Tool 代码即可启用。
+- 默认包含 model request/response 和 tool arguments/result。
+- event 和 model partial response 默认关闭。
+- 可序列化值按原 JSON 契约输出。
+- 不可序列化值记录明确错误，不使用模糊兜底。
+- 插件不改变原有 Agent 执行结果。

--- a/docs/mkdocs/en/plugin.md
+++ b/docs/mkdocs/en/plugin.md
@@ -576,6 +576,59 @@ func (p *ToolArgsPlugin) Register(reg *plugin.Registry) {
 `plugin.NewLogging()` logs high-level start/end markers for agent/model/tool
 operations. It is useful for debugging and performance profiling.
 
+### DebugLog
+
+`debuglog.New(opts...)` writes single-line JSON through the framework debug
+logger for temporary diagnosis of model requests/responses and tool
+arguments/results.
+
+Runner event logging and model partial response logging are disabled by
+default. Enable them with `debuglog.WithEventEnabled(true)` and
+`debuglog.WithModelPartialResponseEnabled(true)`.
+
+A typical runner-level setup looks like this:
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/plugin/debuglog"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+)
+
+runnerInstance := runner.NewRunner(
+	"my-app",
+	agentInstance,
+	runner.WithPlugins(debuglog.New()),
+)
+```
+
+You can also enable DebugLog for a single run:
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/plugin"
+	"trpc.group/trpc-go/trpc-agent-go/plugin/debuglog"
+)
+
+events, err := runnerInstance.Run(
+	ctx,
+	userID,
+	sessionID,
+	message,
+	plugin.WithPlugins(
+		debuglog.New(
+			debuglog.WithEventEnabled(true),
+			debuglog.WithModelPartialResponseEnabled(true),
+		),
+	),
+)
+```
+
+The output is one JSON debug message per line, for example:
+
+```json
+{"time":"2026-06-16T10:20:30.123456789+08:00","sequence":7,"plugin":"debug_log","phase":"before_tool","tool_name":"calculator","tool_call_id":"call-1","payload":{"arguments":{"operation":"add","a":1,"b":2},"arguments_bytes":33}}
+```
+
 ### GlobalInstruction
 
 `plugin.NewGlobalInstruction(text)` prepends a system message to every model
@@ -997,10 +1050,11 @@ The example includes verified scenarios for:
 - A clearly unsafe request that is blocked
 - A defensive analysis request that is allowed
 
-The repository currently includes Logging, GlobalInstruction, ToolCallID,
-MessageMerger, ErrorMessage, and Guardrail as built-in plugins. Tool Approval,
-Prompt Injection, and Unsafe Intent are currently built-in capabilities under
-the Guardrail plugin. Additional plugins can be implemented as custom plugins.
+The repository currently includes Logging, DebugLog, GlobalInstruction,
+ToolCallID, MessageMerger, ErrorMessage, and Guardrail as built-in plugins.
+Tool Approval, Prompt Injection, and Unsafe Intent are currently built-in
+capabilities under the Guardrail plugin. Additional plugins can be implemented
+as custom plugins.
 
 ## Writing Your Own Plugin
 

--- a/docs/mkdocs/zh/plugin.md
+++ b/docs/mkdocs/zh/plugin.md
@@ -593,6 +593,57 @@ func (p *ToolArgsPlugin) Register(reg *plugin.Registry) {
 `plugin.NewLogging()` 会记录 agent/model/tool 的开始与结束信息，适合用于调试与
 性能分析。
 
+### DebugLog
+
+`debuglog.New(opts...)` 通过框架 debug logger 输出单行 JSON，用于临时排查 model
+request/response 和 tool arguments/result。
+
+默认跳过 Runner event 和 model partial response；需要时打开
+`debuglog.WithEventEnabled(true)`、`debuglog.WithModelPartialResponseEnabled(true)`。
+
+使用示例如下：
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/plugin/debuglog"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+)
+
+runnerInstance := runner.NewRunner(
+	"my-app",
+	agentInstance,
+	runner.WithPlugins(debuglog.New()),
+)
+```
+
+也可以只在单次 Run 临时启用：
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/plugin"
+	"trpc.group/trpc-go/trpc-agent-go/plugin/debuglog"
+)
+
+events, err := runnerInstance.Run(
+	ctx,
+	userID,
+	sessionID,
+	message,
+	plugin.WithPlugins(
+		debuglog.New(
+			debuglog.WithEventEnabled(true),
+			debuglog.WithModelPartialResponseEnabled(true),
+		),
+	),
+)
+```
+
+输出是一行 JSON debug message，例如：
+
+```json
+{"time":"2026-06-16T10:20:30.123456789+08:00","sequence":7,"plugin":"debug_log","phase":"before_tool","tool_name":"calculator","tool_call_id":"call-1","payload":{"arguments":{"operation":"add","a":1,"b":2},"arguments_bytes":33}}
+```
+
 ### GlobalInstruction
 
 `plugin.NewGlobalInstruction(text)` 会在每一次模型请求前，统一追加一条 system
@@ -973,7 +1024,7 @@ FinishReason：
 
 完整示例见 [examples/plugin/errormessage](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/plugin/errormessage)。
 
-说明：目前仓库内置了 Logging、GlobalInstruction、ToolCallID、MessageMerger、ErrorMessage、Guardrail 六类插件。其中 Guardrail 插件当前提供的内置 capability 包括工具审批、Prompt Injection 和 Unsafe Intent。更多插件可通过自定义插件实现。
+说明：目前仓库内置了 Logging、DebugLog、GlobalInstruction、ToolCallID、MessageMerger、ErrorMessage、Guardrail 七类插件。其中 Guardrail 插件当前提供的内置 capability 包括工具审批、Prompt Injection 和 Unsafe Intent。更多插件可通过自定义插件实现。
 
 ## 如何扩展：写一个自己的插件
 

--- a/plugin/debuglog/doc.go
+++ b/plugin/debuglog/doc.go
@@ -1,0 +1,11 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package debuglog provides a plugin that logs framework payloads for diagnosis.
+package debuglog

--- a/plugin/debuglog/entry.go
+++ b/plugin/debuglog/entry.go
@@ -1,0 +1,29 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package debuglog
+
+import "time"
+
+type entry struct {
+	Time               time.Time      `json:"time"`
+	Sequence           uint64         `json:"sequence"`
+	Plugin             string         `json:"plugin"`
+	Phase              string         `json:"phase"`
+	InvocationID       string         `json:"invocation_id,omitempty"`
+	ParentInvocationID string         `json:"parent_invocation_id,omitempty"`
+	AgentName          string         `json:"agent_name,omitempty"`
+	SessionID          string         `json:"session_id,omitempty"`
+	UserID             string         `json:"user_id,omitempty"`
+	ModelName          string         `json:"model_name,omitempty"`
+	ToolName           string         `json:"tool_name,omitempty"`
+	ToolCallID         string         `json:"tool_call_id,omitempty"`
+	Error              string         `json:"error,omitempty"`
+	Payload            map[string]any `json:"payload,omitempty"`
+}

--- a/plugin/debuglog/options.go
+++ b/plugin/debuglog/options.go
@@ -1,0 +1,56 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package debuglog
+
+const defaultPluginName = "debug_log"
+
+// Option configures the debug log plugin.
+type Option func(*options)
+
+type options struct {
+	name                        string
+	eventEnabled                bool
+	modelPartialResponseEnabled bool
+}
+
+func newOptions(opts ...Option) *options {
+	o := &options{
+		name: defaultPluginName,
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(o)
+		}
+	}
+	return o
+}
+
+// WithName sets the plugin name. The name must be unique within a Runner.
+func WithName(name string) Option {
+	return func(o *options) {
+		if name != "" {
+			o.name = name
+		}
+	}
+}
+
+// WithEventEnabled controls whether runner events are logged.
+func WithEventEnabled(enabled bool) Option {
+	return func(o *options) {
+		o.eventEnabled = enabled
+	}
+}
+
+// WithModelPartialResponseEnabled controls whether partial model responses are logged.
+func WithModelPartialResponseEnabled(enabled bool) Option {
+	return func(o *options) {
+		o.modelPartialResponseEnabled = enabled
+	}
+}

--- a/plugin/debuglog/plugin.go
+++ b/plugin/debuglog/plugin.go
@@ -1,0 +1,225 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package debuglog
+
+import (
+	"context"
+	"encoding/json"
+	"sync/atomic"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/log"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/plugin"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+type debugLogPlugin struct {
+	name                        string
+	eventEnabled                bool
+	modelPartialResponseEnabled bool
+	seq                         atomic.Uint64
+}
+
+// New creates a debug log plugin.
+func New(opts ...Option) plugin.Plugin {
+	o := newOptions(opts...)
+	return &debugLogPlugin{
+		name:                        o.name,
+		eventEnabled:                o.eventEnabled,
+		modelPartialResponseEnabled: o.modelPartialResponseEnabled,
+	}
+}
+
+// Name implements plugin.Plugin.
+func (p *debugLogPlugin) Name() string {
+	return p.name
+}
+
+// Register implements plugin.Plugin.
+func (p *debugLogPlugin) Register(r *plugin.Registry) {
+	if p == nil || r == nil {
+		return
+	}
+	r.BeforeAgent(p.beforeAgent)
+	r.AfterAgent(p.afterAgent)
+	r.BeforeModel(p.beforeModel)
+	r.AfterModel(p.afterModel)
+	r.BeforeTool(p.beforeTool)
+	r.AfterTool(p.afterTool)
+	r.OnEvent(p.onEvent)
+}
+
+func (p *debugLogPlugin) beforeAgent(
+	ctx context.Context,
+	args *agent.BeforeAgentArgs,
+) (*agent.BeforeAgentResult, error) {
+	if args == nil || args.Invocation == nil {
+		return nil, nil
+	}
+	payload := map[string]any{
+		"invocation": invocationSnapshot(args.Invocation),
+	}
+	ent := p.newEntry("before_agent", args.Invocation)
+	ent.Payload = payload
+	p.writeEntry(ctx, ent)
+	return nil, nil
+}
+
+func (p *debugLogPlugin) afterAgent(
+	ctx context.Context,
+	args *agent.AfterAgentArgs,
+) (*agent.AfterAgentResult, error) {
+	if args == nil || args.Invocation == nil {
+		return nil, nil
+	}
+	payload := map[string]any{
+		"invocation": invocationSnapshot(args.Invocation),
+	}
+	addFullResponseEventSnapshot(payload, args.FullResponseEvent)
+	ent := p.newEntry("after_agent", args.Invocation)
+	ent.Error = errorString(args.Error)
+	ent.Payload = payload
+	p.writeEntry(ctx, ent)
+	return nil, nil
+}
+
+func (p *debugLogPlugin) beforeModel(
+	ctx context.Context,
+	args *model.BeforeModelArgs,
+) (*model.BeforeModelResult, error) {
+	if args == nil {
+		return nil, nil
+	}
+	payload := map[string]any{}
+	addRequestSnapshot(payload, args.Request)
+	ent := p.newEntry("before_model", invocationFromContext(ctx))
+	ent.Payload = payload
+	p.writeEntry(ctx, ent)
+	return nil, nil
+}
+
+func (p *debugLogPlugin) afterModel(
+	ctx context.Context,
+	args *model.AfterModelArgs,
+) (*model.AfterModelResult, error) {
+	if args == nil {
+		return nil, nil
+	}
+	if args.Response != nil && args.Response.IsPartial && !p.modelPartialResponseEnabled {
+		return nil, nil
+	}
+	payload := map[string]any{}
+	addRequestSnapshot(payload, args.Request)
+	addJSONSnapshot(payload, "response", "response_encode_error", args.Response)
+	ent := p.newEntry("after_model", invocationFromContext(ctx))
+	ent.Error = errorString(args.Error)
+	ent.Payload = payload
+	p.writeEntry(ctx, ent)
+	return nil, nil
+}
+
+func (p *debugLogPlugin) beforeTool(
+	ctx context.Context,
+	args *tool.BeforeToolArgs,
+) (*tool.BeforeToolResult, error) {
+	if args == nil {
+		return nil, nil
+	}
+	payload := map[string]any{}
+	addToolDeclarationSnapshot(payload, args.Declaration)
+	addToolArgumentsSnapshot(payload, args.Arguments)
+	addJSONSnapshot(payload, "resume_value", "resume_value_encode_error", args.ResumeValue)
+	addJSONMapSnapshot(payload, "resume_map", "resume_map_errors", args.ResumeMap)
+	ent := p.newEntry("before_tool", invocationFromContext(ctx))
+	ent.ToolName = args.ToolName
+	ent.ToolCallID = toolCallID(ctx, args.ToolCallID)
+	ent.Payload = payload
+	p.writeEntry(ctx, ent)
+	return nil, nil
+}
+
+func (p *debugLogPlugin) afterTool(
+	ctx context.Context,
+	args *tool.AfterToolArgs,
+) (*tool.AfterToolResult, error) {
+	if args == nil {
+		return nil, nil
+	}
+	payload := map[string]any{}
+	addToolDeclarationSnapshot(payload, args.Declaration)
+	addToolArgumentsSnapshot(payload, args.Arguments)
+	addJSONSnapshot(payload, "result", "result_encode_error", args.Result)
+	addJSONMapSnapshot(payload, "meta", "meta_errors", args.Meta)
+	ent := p.newEntry("after_tool", invocationFromContext(ctx))
+	ent.ToolName = args.ToolName
+	ent.ToolCallID = toolCallID(ctx, args.ToolCallID)
+	ent.Error = errorString(args.Error)
+	ent.Payload = payload
+	p.writeEntry(ctx, ent)
+	return nil, nil
+}
+
+func (p *debugLogPlugin) onEvent(
+	ctx context.Context,
+	inv *agent.Invocation,
+	e *event.Event,
+) (*event.Event, error) {
+	if !p.eventEnabled || e == nil {
+		return nil, nil
+	}
+	if inv == nil {
+		inv = invocationFromContext(ctx)
+	}
+	payload := map[string]any{}
+	addEventSnapshot(payload, e)
+	ent := p.newEntry("event", inv)
+	ent.Payload = payload
+	p.writeEntry(ctx, ent)
+	return nil, nil
+}
+
+func (p *debugLogPlugin) newEntry(
+	phase string,
+	inv *agent.Invocation,
+) *entry {
+	ent := &entry{
+		Time:     time.Now(),
+		Sequence: p.seq.Add(1),
+		Plugin:   p.name,
+		Phase:    phase,
+	}
+	applyInvocationFields(ent, inv)
+	return ent
+}
+
+func (p *debugLogPlugin) writeEntry(ctx context.Context, ent *entry) {
+	raw, err := json.Marshal(ent)
+	if err != nil {
+		log.WarnfContext(ctx, "plugin=%s debuglog marshal entry failed: %v", p.name, err)
+		return
+	}
+	log.DebugfContext(ctx, "%s", raw)
+}
+
+func invocationFromContext(ctx context.Context) *agent.Invocation {
+	inv, _ := agent.InvocationFromContext(ctx)
+	return inv
+}
+
+func toolCallID(ctx context.Context, argID string) string {
+	if argID != "" {
+		return argID
+	}
+	callID, _ := tool.ToolCallIDFromContext(ctx)
+	return callID
+}

--- a/plugin/debuglog/plugin_test.go
+++ b/plugin/debuglog/plugin_test.go
@@ -1,0 +1,588 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package debuglog_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/trace"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	agentlog "trpc.group/trpc-go/trpc-agent-go/log"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	rootplugin "trpc.group/trpc-go/trpc-agent-go/plugin"
+	"trpc.group/trpc-go/trpc-agent-go/plugin/debuglog"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+type logEntry struct {
+	Sequence   uint64         `json:"sequence"`
+	Plugin     string         `json:"plugin"`
+	Phase      string         `json:"phase"`
+	ModelName  string         `json:"model_name"`
+	ToolName   string         `json:"tool_name"`
+	ToolCallID string         `json:"tool_call_id"`
+	Error      string         `json:"error"`
+	Payload    map[string]any `json:"payload"`
+}
+
+type testModel struct{}
+
+func (m testModel) GenerateContent(
+	_ context.Context,
+	_ *model.Request,
+) (<-chan *model.Response, error) {
+	return nil, nil
+}
+
+func (m testModel) Info() model.Info {
+	return model.Info{Name: "test-model"}
+}
+
+type testTool struct {
+	declaration *tool.Declaration
+}
+
+func (t testTool) Declaration() *tool.Declaration {
+	return t.declaration
+}
+
+type panickingTool struct{}
+
+func (panickingTool) Declaration() *tool.Declaration {
+	panic("boom")
+}
+
+func newManager(t *testing.T, p rootplugin.Plugin) *rootplugin.Manager {
+	t.Helper()
+	m, err := rootplugin.NewManager(p)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	return m
+}
+
+type captureLogger struct {
+	mu             sync.Mutex
+	debugfMessages []string
+}
+
+func captureDebugLogs(t *testing.T) *captureLogger {
+	t.Helper()
+	original := agentlog.ContextDefault
+	logger := &captureLogger{}
+	agentlog.ContextDefault = logger
+	t.Cleanup(func() {
+		agentlog.ContextDefault = original
+	})
+	return logger
+}
+
+func (l *captureLogger) reset() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.debugfMessages = nil
+}
+
+func (l *captureLogger) entries(t *testing.T) []logEntry {
+	t.Helper()
+	l.mu.Lock()
+	messages := append([]string(nil), l.debugfMessages...)
+	l.mu.Unlock()
+	if len(messages) == 0 {
+		return nil
+	}
+	entries := make([]logEntry, 0, len(messages))
+	for _, message := range messages {
+		var ent logEntry
+		require.NoError(t, json.Unmarshal([]byte(message), &ent))
+		entries = append(entries, ent)
+	}
+	return entries
+}
+
+func (l *captureLogger) Debug(args ...any) {}
+
+func (l *captureLogger) Debugf(format string, args ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.debugfMessages = append(l.debugfMessages, fmt.Sprintf(format, args...))
+}
+
+func (l *captureLogger) Info(args ...any) {}
+
+func (l *captureLogger) Infof(format string, args ...any) {}
+
+func (l *captureLogger) Warn(args ...any) {}
+
+func (l *captureLogger) Warnf(format string, args ...any) {}
+
+func (l *captureLogger) Error(args ...any) {}
+
+func (l *captureLogger) Errorf(format string, args ...any) {}
+
+func (l *captureLogger) Fatal(args ...any) {}
+
+func (l *captureLogger) Fatalf(format string, args ...any) {}
+
+func object(t *testing.T, value any) map[string]any {
+	t.Helper()
+	out, ok := value.(map[string]any)
+	require.True(t, ok)
+	return out
+}
+
+func array(t *testing.T, value any) []any {
+	t.Helper()
+	out, ok := value.([]any)
+	require.True(t, ok)
+	return out
+}
+
+func TestPlugin_DefaultNameAndOptions(t *testing.T) {
+	p := debuglog.New()
+	require.Equal(t, "debug_log", p.Name())
+	p = debuglog.New(
+		nil,
+		debuglog.WithName("local_debug"),
+	)
+	require.Equal(t, "local_debug", p.Name())
+}
+
+func TestPlugin_SkipsNilCallbackArgs(t *testing.T) {
+	logs := captureDebugLogs(t)
+	m := newManager(t, debuglog.New())
+	agentCallbacks := m.AgentCallbacks()
+	require.NotNil(t, agentCallbacks)
+	_, err := agentCallbacks.RunBeforeAgent(context.Background(), nil)
+	require.NoError(t, err)
+	_, err = agentCallbacks.RunAfterAgent(context.Background(), nil)
+	require.NoError(t, err)
+	modelCallbacks := m.ModelCallbacks()
+	require.NotNil(t, modelCallbacks)
+	_, err = modelCallbacks.RunBeforeModel(context.Background(), nil)
+	require.NoError(t, err)
+	_, err = modelCallbacks.RunAfterModel(context.Background(), nil)
+	require.NoError(t, err)
+	toolCallbacks := m.ToolCallbacks()
+	require.NotNil(t, toolCallbacks)
+	_, err = toolCallbacks.RunBeforeTool(context.Background(), nil)
+	require.NoError(t, err)
+	require.Empty(t, logs.entries(t))
+}
+
+func TestPlugin_LogsModelRequestJSONContractAndSupplement(t *testing.T) {
+	logs := captureDebugLogs(t)
+	m := newManager(t, debuglog.New())
+	inv := agent.NewInvocation(
+		agent.WithInvocationModel(testModel{}),
+		agent.WithInvocationSession(&session.Session{
+			ID:      "sess-1",
+			AppName: "app-1",
+			UserID:  "user-1",
+		}),
+		agent.WithInvocationRunOptions(agent.RunOptions{
+			RequestID: "req-1",
+		}),
+	)
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+	index := 0
+	req := &model.Request{
+		Messages: []model.Message{{
+			Role: model.RoleAssistant,
+			ToolCalls: []model.ToolCall{{
+				Type:  "function",
+				ID:    "call-1",
+				Index: &index,
+				Function: model.FunctionDefinitionParam{
+					Name:      "search",
+					Arguments: []byte(`{"q":"hi"}`),
+				},
+			}},
+		}},
+		ExtraFields: map[string]any{
+			"bad":   func() {},
+			"debug": map[string]any{"enabled": true},
+		},
+		Headers: map[string]string{
+			"Authorization": "Bearer secret",
+			"X-Trace":       "trace-1",
+		},
+		Tools: map[string]tool.Tool{
+			"search": testTool{declaration: &tool.Declaration{
+				Name:        "search",
+				Description: "Search documents.",
+				InputSchema: &tool.Schema{
+					Type: "object",
+				},
+			}},
+		},
+	}
+	_, err := m.ModelCallbacks().RunBeforeModel(ctx, &model.BeforeModelArgs{Request: req})
+	require.NoError(t, err)
+	entries := logs.entries(t)
+	require.Len(t, entries, 1)
+	require.Equal(t, "before_model", entries[0].Phase)
+	require.Equal(t, "test-model", entries[0].ModelName)
+	request := object(t, entries[0].Payload["request"])
+	messages := array(t, request["messages"])
+	message := object(t, messages[0])
+	toolCalls := array(t, message["tool_calls"])
+	toolCall := object(t, toolCalls[0])
+	function := object(t, toolCall["function"])
+	require.Equal(t, `{"q":"hi"}`, function["arguments"])
+	supplement := object(t, entries[0].Payload["request_supplement"])
+	headers := object(t, supplement["headers"])
+	require.Equal(t, "Bearer secret", headers["Authorization"])
+	require.Equal(t, "trace-1", headers["X-Trace"])
+	extraFields := object(t, supplement["extra_fields"])
+	debugField := object(t, extraFields["debug"])
+	require.Equal(t, true, debugField["enabled"])
+	extraErrors := object(t, supplement["extra_field_errors"])
+	badError := object(t, extraErrors["bad"])
+	require.Equal(t, "func()", badError["type"])
+	require.Contains(t, badError["error"], "unsupported type")
+	tools := object(t, supplement["tools"])
+	search := object(t, tools["search"])
+	require.Equal(t, "search", search["name"])
+}
+
+func TestPlugin_LogsRequestToolDeclarationErrors(t *testing.T) {
+	logs := captureDebugLogs(t)
+	m := newManager(t, debuglog.New())
+	req := model.NewRequest([]model.Message{model.NewUserMessage("hello")})
+	req.Tools = map[string]tool.Tool{
+		"bad_declaration": testTool{declaration: &tool.Declaration{
+			Name:        "bad",
+			Description: "Bad declaration.",
+			InputSchema: &tool.Schema{
+				Default: func() {},
+			},
+		}},
+		"nil_declaration": testTool{},
+		"nil_tool":        nil,
+		"panic_tool":      panickingTool{},
+	}
+	_, err := m.ModelCallbacks().RunBeforeModel(
+		context.Background(),
+		&model.BeforeModelArgs{Request: req},
+	)
+	require.NoError(t, err)
+	entries := logs.entries(t)
+	require.Len(t, entries, 1)
+	supplement := object(t, entries[0].Payload["request_supplement"])
+	toolErrors := object(t, supplement["tool_errors"])
+	badDeclaration := object(t, toolErrors["bad_declaration"])
+	require.Equal(t, "*tool.Declaration", badDeclaration["type"])
+	require.Contains(t, badDeclaration["error"], "unsupported type")
+	nilDeclaration := object(t, toolErrors["nil_declaration"])
+	require.Equal(t, "debuglog_test.testTool", nilDeclaration["type"])
+	require.Contains(t, nilDeclaration["error"], "tool declaration is nil")
+	nilTool := object(t, toolErrors["nil_tool"])
+	require.Equal(t, "nil", nilTool["type"])
+	require.Contains(t, nilTool["error"], "tool is nil")
+	panicTool := object(t, toolErrors["panic_tool"])
+	require.Equal(t, "debuglog_test.panickingTool", panicTool["type"])
+	require.Contains(t, panicTool["error"], "tool declaration panic: boom")
+	require.NotContains(t, supplement, "tools")
+}
+
+func TestPlugin_LogsModelResponseAndSkipsPartialByDefault(t *testing.T) {
+	logs := captureDebugLogs(t)
+	m := newManager(t, debuglog.New())
+	req := model.NewRequest([]model.Message{model.NewUserMessage("hello")})
+	partial := &model.Response{
+		Object:    model.ObjectTypeChatCompletionChunk,
+		IsPartial: true,
+		Choices: []model.Choice{{
+			Index: 0,
+			Delta: model.Message{
+				Role:    model.RoleAssistant,
+				Content: "partial",
+			},
+		}},
+	}
+	_, err := m.ModelCallbacks().RunAfterModel(
+		context.Background(),
+		&model.AfterModelArgs{Request: req, Response: partial},
+	)
+	require.NoError(t, err)
+	require.Empty(t, logs.entries(t))
+	logs.reset()
+	m = newManager(t, debuglog.New(
+		debuglog.WithModelPartialResponseEnabled(true),
+	))
+	_, err = m.ModelCallbacks().RunAfterModel(
+		context.Background(),
+		&model.AfterModelArgs{Request: req, Response: partial},
+	)
+	require.NoError(t, err)
+	entries := logs.entries(t)
+	require.Len(t, entries, 1)
+	response := object(t, entries[0].Payload["response"])
+	require.Equal(t, true, response["is_partial"])
+	require.Equal(t, model.ObjectTypeChatCompletionChunk, response["object"])
+}
+
+func TestPlugin_LogsUnserializableModelResponseType(t *testing.T) {
+	logs := captureDebugLogs(t)
+	m := newManager(t, debuglog.New())
+	req := model.NewRequest([]model.Message{model.NewUserMessage("hello")})
+	resp := &model.Response{
+		Object: model.ObjectTypeChatCompletion,
+		Done:   true,
+		Choices: []model.Choice{{
+			Index: 0,
+			Message: model.Message{
+				Role: model.RoleAssistant,
+				ToolCalls: []model.ToolCall{{
+					Type: "function",
+					ExtraFields: map[string]any{
+						"bad": func() {},
+					},
+				}},
+			},
+		}},
+	}
+	_, err := m.ModelCallbacks().RunAfterModel(
+		context.Background(),
+		&model.AfterModelArgs{Request: req, Response: resp},
+	)
+	require.NoError(t, err)
+	entries := logs.entries(t)
+	require.Len(t, entries, 1)
+	payload := entries[0].Payload
+	require.NotContains(t, payload, "response")
+	require.Equal(t, "*model.Response", payload["response_type"])
+	require.Contains(t, payload["response_encode_error"], "unsupported type")
+}
+
+func TestPlugin_LogsToolArgumentsAsJSONValues(t *testing.T) {
+	logs := captureDebugLogs(t)
+	m := newManager(t, debuglog.New())
+	callbacks := m.ToolCallbacks()
+	require.NotNil(t, callbacks)
+	_, err := callbacks.RunBeforeTool(
+		context.Background(),
+		&tool.BeforeToolArgs{
+			ToolCallID:  "call-1",
+			ToolName:    "calculator",
+			Declaration: sampleDeclaration(),
+			Arguments:   []byte(`{"a":1,"b":2}`),
+		},
+	)
+	require.NoError(t, err)
+	_, err = callbacks.RunBeforeTool(
+		context.Background(),
+		&tool.BeforeToolArgs{
+			ToolCallID: "call-2",
+			ToolName:   "calculator",
+			Arguments:  []byte(`{"a":`),
+		},
+	)
+	require.NoError(t, err)
+	entries := logs.entries(t)
+	require.Len(t, entries, 2)
+	require.Equal(t, "call-1", entries[0].ToolCallID)
+	args := object(t, entries[0].Payload["arguments"])
+	require.Equal(t, float64(1), args["a"])
+	require.Equal(t, float64(2), args["b"])
+	require.Equal(t, float64(len(`{"a":1,"b":2}`)), entries[0].Payload["arguments_bytes"])
+	require.Equal(t, "call-2", entries[1].ToolCallID)
+	require.Equal(t, `{"a":`, entries[1].Payload["arguments_text"])
+	require.Contains(t, entries[1].Payload["arguments_error"], "unexpected end")
+	require.Equal(t, float64(len(`{"a":`)), entries[1].Payload["arguments_bytes"])
+}
+
+func TestPlugin_UsesToolCallIDFromContext(t *testing.T) {
+	logs := captureDebugLogs(t)
+	m := newManager(t, debuglog.New())
+	ctx := context.WithValue(context.Background(), tool.ContextKeyToolCallID{}, "ctx-call-1")
+	_, err := m.ToolCallbacks().RunBeforeTool(
+		ctx,
+		&tool.BeforeToolArgs{
+			ToolName:  "calculator",
+			Arguments: []byte(`{}`),
+		},
+	)
+	require.NoError(t, err)
+	entries := logs.entries(t)
+	require.Len(t, entries, 1)
+	require.Equal(t, "ctx-call-1", entries[0].ToolCallID)
+}
+
+func TestPlugin_LogsUnserializableToolResultAsEncodeError(t *testing.T) {
+	logs := captureDebugLogs(t)
+	m := newManager(t, debuglog.New())
+	callbacks := m.ToolCallbacks()
+	require.NotNil(t, callbacks)
+	_, err := callbacks.RunAfterTool(
+		context.Background(),
+		&tool.AfterToolArgs{
+			ToolCallID:  "call-1",
+			ToolName:    "runner",
+			Declaration: sampleDeclaration(),
+			Arguments:   []byte(`{"ok":true}`),
+			Result:      make(chan int),
+			Error:       errors.New("tool failed"),
+			Meta: map[string]any{
+				"bad": func() {},
+				"ok":  "value",
+			},
+		},
+	)
+	require.NoError(t, err)
+	entries := logs.entries(t)
+	require.Len(t, entries, 1)
+	payload := entries[0].Payload
+	require.Equal(t, "tool failed", entries[0].Error)
+	require.NotContains(t, payload, "result")
+	require.Equal(t, "chan int", payload["result_type"])
+	require.Contains(t, payload["result_encode_error"], "unsupported type")
+	meta := object(t, payload["meta"])
+	require.Equal(t, "value", meta["ok"])
+	metaErrors := object(t, payload["meta_errors"])
+	badError := object(t, metaErrors["bad"])
+	require.Equal(t, "func()", badError["type"])
+	require.Contains(t, badError["error"], "unsupported type")
+}
+
+func TestPlugin_EventLoggingDefaultAndEnabled(t *testing.T) {
+	ev := event.NewResponseEvent("inv-1", "agent-1", &model.Response{
+		ID:     "rsp-1",
+		Object: model.ObjectTypeChatCompletion,
+		Done:   true,
+		Choices: []model.Choice{{
+			Index:   0,
+			Message: model.NewAssistantMessage("done"),
+		}},
+	})
+	ev.ID = "event-1"
+	ev.RequestID = "req-1"
+	ev.StructuredOutput = map[string]any{"answer": "done"}
+	ev.ExecutionTrace = &trace.Trace{RootAgentName: "agent-1", RootInvocationID: "inv-1"}
+	logs := captureDebugLogs(t)
+	m := newManager(t, debuglog.New())
+	out, err := m.OnEvent(context.Background(), nil, ev)
+	require.NoError(t, err)
+	require.Same(t, ev, out)
+	require.Empty(t, logs.entries(t))
+	logs.reset()
+	m = newManager(t, debuglog.New(
+		debuglog.WithEventEnabled(true),
+	))
+	out, err = m.OnEvent(context.Background(), nil, ev)
+	require.NoError(t, err)
+	require.Same(t, ev, out)
+	entries := logs.entries(t)
+	require.Len(t, entries, 1)
+	payloadEvent := object(t, entries[0].Payload["event"])
+	require.Equal(t, "event-1", payloadEvent["id"])
+	require.Equal(t, "req-1", payloadEvent["requestID"])
+	supplement := object(t, entries[0].Payload["event_supplement"])
+	structured := object(t, supplement["structured_output"])
+	require.Equal(t, "done", structured["answer"])
+	executionTrace := object(t, supplement["execution_trace"])
+	require.Equal(t, "agent-1", executionTrace["RootAgentName"])
+}
+
+func TestPlugin_KeepsSerializablePayloadValuesAsIs(t *testing.T) {
+	logs := captureDebugLogs(t)
+	m := newManager(t, debuglog.New())
+	longText := strings.Repeat("界", 3000)
+	_, err := m.ToolCallbacks().RunBeforeTool(
+		context.Background(),
+		&tool.BeforeToolArgs{
+			ToolCallID: "call-1",
+			ToolName:   "secure",
+			Arguments:  []byte(`{"password":"secret","long":"` + longText + `"}`),
+		},
+	)
+	require.NoError(t, err)
+	entries := logs.entries(t)
+	require.Len(t, entries, 1)
+	args := object(t, entries[0].Payload["arguments"])
+	require.Equal(t, "secret", args["password"])
+	require.Equal(t, longText, args["long"])
+}
+
+func TestPlugin_LogsAgentMetadataAndFullResponseEvent(t *testing.T) {
+	logs := captureDebugLogs(t)
+	m := newManager(t, debuglog.New())
+	parent := agent.NewInvocation(agent.WithInvocationID("parent-1"))
+	inv := parent.Clone(
+		agent.WithInvocationID("inv-1"),
+		agent.WithInvocationModel(testModel{}),
+		agent.WithInvocationSession(&session.Session{
+			ID:      "sess-1",
+			AppName: "app-1",
+			UserID:  "user-1",
+		}),
+		agent.WithInvocationRunOptions(agent.RunOptions{
+			RequestID:             "req-1",
+			StreamModeEnabled:     true,
+			StreamModes:           []agent.StreamMode{agent.StreamModeMessages},
+			ExecutionTraceEnabled: true,
+		}),
+	)
+	callbacks := m.AgentCallbacks()
+	require.NotNil(t, callbacks)
+	_, err := callbacks.RunBeforeAgent(context.Background(), &agent.BeforeAgentArgs{Invocation: inv})
+	require.NoError(t, err)
+	full := event.NewResponseEvent("inv-1", "agent-1", &model.Response{
+		ID:     "rsp-1",
+		Object: model.ObjectTypeChatCompletion,
+		Done:   true,
+		Choices: []model.Choice{{
+			Index:   0,
+			Message: model.NewAssistantMessage("done"),
+		}},
+	})
+	full.ID = "event-full"
+	_, err = callbacks.RunAfterAgent(
+		context.Background(),
+		&agent.AfterAgentArgs{
+			Invocation:        inv,
+			FullResponseEvent: full,
+		},
+	)
+	require.NoError(t, err)
+	entries := logs.entries(t)
+	require.Len(t, entries, 2)
+	invocation := object(t, entries[0].Payload["invocation"])
+	require.Equal(t, "inv-1", invocation["invocation_id"])
+	require.Equal(t, "parent-1", invocation["parent_invocation_id"])
+	require.Equal(t, "test-model", invocation["model_name"])
+	sessionValue := object(t, invocation["session"])
+	require.Equal(t, "sess-1", sessionValue["id"])
+	runOptions := object(t, invocation["run_options"])
+	require.Equal(t, true, runOptions["stream_mode_enabled"])
+	require.Equal(t, "req-1", runOptions["request_id"])
+	fullEvent := object(t, entries[1].Payload["full_response_event"])
+	require.Equal(t, "event-full", fullEvent["id"])
+}
+
+func sampleDeclaration() *tool.Declaration {
+	return &tool.Declaration{
+		Name:        "calculator",
+		Description: "Calculates expressions.",
+		InputSchema: &tool.Schema{
+			Type: "object",
+		},
+	}
+}

--- a/plugin/debuglog/snapshot.go
+++ b/plugin/debuglog/snapshot.go
@@ -1,0 +1,276 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package debuglog
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"sort"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+func jsonValue(v any) (any, error) {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	var out any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func addJSONSnapshot(payload map[string]any, key, errorKey string, v any) {
+	value, err := jsonValue(v)
+	if err != nil {
+		payload[errorKey] = err.Error()
+		payload[key+"_type"] = typeName(v)
+		return
+	}
+	payload[key] = value
+}
+
+func addRequestSnapshot(payload map[string]any, req *model.Request) {
+	addJSONSnapshot(payload, "request", "request_encode_error", req)
+	if req == nil {
+		return
+	}
+	supplement := requestSupplement(req)
+	if len(supplement) > 0 {
+		payload["request_supplement"] = supplement
+	}
+}
+
+func requestSupplement(req *model.Request) map[string]any {
+	supplement := map[string]any{}
+	addRequestToolsSupplement(supplement, req.Tools)
+	addJSONMapSnapshot(supplement, "extra_fields", "extra_field_errors", req.ExtraFields)
+	if len(req.Headers) > 0 {
+		supplement["headers"] = stringMapToAny(req.Headers)
+	}
+	return supplement
+}
+
+func addRequestToolsSupplement(supplement map[string]any, tools map[string]tool.Tool) {
+	if len(tools) == 0 {
+		return
+	}
+	values := map[string]any{}
+	errs := map[string]any{}
+	for _, name := range sortedKeys(tools) {
+		decl, err := safeToolDeclaration(tools[name])
+		if err != nil {
+			errs[name] = map[string]any{
+				"error": err.Error(),
+				"type":  typeName(tools[name]),
+			}
+			continue
+		}
+		value, err := jsonValue(decl)
+		if err != nil {
+			errs[name] = map[string]any{
+				"error": err.Error(),
+				"type":  typeName(decl),
+			}
+			continue
+		}
+		values[name] = value
+	}
+	if len(values) > 0 {
+		supplement["tools"] = values
+	}
+	if len(errs) > 0 {
+		supplement["tool_errors"] = errs
+	}
+}
+
+func addToolDeclarationSnapshot(payload map[string]any, decl *tool.Declaration) {
+	addJSONSnapshot(payload, "declaration", "declaration_encode_error", decl)
+}
+
+func addToolArgumentsSnapshot(payload map[string]any, args []byte) {
+	payload["arguments_bytes"] = len(args)
+	var value any
+	if err := json.Unmarshal(args, &value); err != nil {
+		payload["arguments_text"] = string(args)
+		payload["arguments_error"] = err.Error()
+		return
+	}
+	payload["arguments"] = value
+}
+
+func addJSONMapSnapshot(
+	payload map[string]any,
+	key string,
+	errorKey string,
+	values map[string]any,
+) {
+	if len(values) == 0 {
+		return
+	}
+	out := map[string]any{}
+	errs := map[string]any{}
+	for _, name := range sortedKeys(values) {
+		value, err := jsonValue(values[name])
+		if err != nil {
+			errs[name] = map[string]any{
+				"error": err.Error(),
+				"type":  typeName(values[name]),
+			}
+			continue
+		}
+		out[name] = value
+	}
+	if len(out) > 0 {
+		payload[key] = out
+	}
+	if len(errs) > 0 {
+		payload[errorKey] = errs
+	}
+}
+
+func addEventSnapshot(payload map[string]any, e *event.Event) {
+	addJSONSnapshot(payload, "event", "event_encode_error", e)
+	if e == nil {
+		return
+	}
+	supplement := map[string]any{}
+	if e.StructuredOutput != nil {
+		addJSONSnapshot(supplement, "structured_output", "structured_output_encode_error", e.StructuredOutput)
+	}
+	if e.ExecutionTrace != nil {
+		addJSONSnapshot(supplement, "execution_trace", "execution_trace_encode_error", e.ExecutionTrace)
+	}
+	if len(supplement) > 0 {
+		payload["event_supplement"] = supplement
+	}
+}
+
+func addFullResponseEventSnapshot(payload map[string]any, e *event.Event) {
+	if e == nil {
+		return
+	}
+	addJSONSnapshot(payload, "full_response_event", "full_response_event_encode_error", e)
+}
+
+func invocationSnapshot(inv *agent.Invocation) map[string]any {
+	out := map[string]any{
+		"agent_name":                inv.AgentName,
+		"branch":                    inv.Branch,
+		"end_invocation":            inv.EndInvocation,
+		"invocation_id":             inv.InvocationID,
+		"structured_output_present": inv.StructuredOutput != nil,
+	}
+	if parent := inv.GetParentInvocation(); parent != nil {
+		out["parent_invocation_id"] = parent.InvocationID
+	}
+	if inv.Session != nil {
+		out["session"] = map[string]any{
+			"app_name": inv.Session.AppName,
+			"id":       inv.Session.ID,
+			"user_id":  inv.Session.UserID,
+		}
+	}
+	if inv.Model != nil {
+		out["model_name"] = inv.Model.Info().Name
+	}
+	runOptions := map[string]any{
+		"app_name":                inv.RunOptions.AppName,
+		"disable_tracing":         inv.RunOptions.DisableTracing,
+		"event_filter_key":        inv.RunOptions.EventFilterKey,
+		"execution_trace_enabled": inv.RunOptions.ExecutionTraceEnabled,
+		"request_id":              inv.RunOptions.RequestID,
+		"resume":                  inv.RunOptions.Resume,
+		"stream_mode_enabled":     inv.RunOptions.StreamModeEnabled,
+		"stream_modes":            streamModes(inv.RunOptions.StreamModes),
+	}
+	out["run_options"] = runOptions
+	return out
+}
+
+func applyInvocationFields(ent *entry, inv *agent.Invocation) {
+	if inv == nil {
+		return
+	}
+	ent.InvocationID = inv.InvocationID
+	ent.AgentName = inv.AgentName
+	if parent := inv.GetParentInvocation(); parent != nil {
+		ent.ParentInvocationID = parent.InvocationID
+	}
+	if inv.Session != nil {
+		ent.SessionID = inv.Session.ID
+		ent.UserID = inv.Session.UserID
+	}
+	if inv.Model != nil {
+		ent.ModelName = inv.Model.Info().Name
+	}
+}
+
+func safeToolDeclaration(t tool.Tool) (decl *tool.Declaration, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("tool declaration panic: %v", recovered)
+		}
+	}()
+	if t == nil {
+		return nil, errors.New("tool is nil")
+	}
+	decl = t.Declaration()
+	if decl == nil {
+		return nil, errors.New("tool declaration is nil")
+	}
+	return decl, nil
+}
+
+func stringMapToAny(values map[string]string) map[string]any {
+	out := make(map[string]any, len(values))
+	for _, key := range sortedKeys(values) {
+		out[key] = values[key]
+	}
+	return out
+}
+
+func sortedKeys[V any](values map[string]V) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func streamModes(modes []agent.StreamMode) []string {
+	out := make([]string, 0, len(modes))
+	for _, mode := range modes {
+		out = append(out, string(mode))
+	}
+	return out
+}
+
+func errorString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+func typeName(v any) string {
+	if v == nil {
+		return "nil"
+	}
+	return reflect.TypeOf(v).String()
+}


### PR DESCRIPTION
Adds a debuglog plugin that emits framework-level agent, model, tool, and optional runner event payloads as single-line JSON debug logs, with documentation covering usage, defaults, output format, and serialization behavior.