### PR TITLE
tool/agent: add structured output pinning

### DIFF
--- a/docs/mkdocs/en/multiagent.md
+++ b/docs/mkdocs/en/multiagent.md
@@ -634,24 +634,34 @@ and the parent Agent should only consume its final answer. Use
 `InnerTextModeExclude` separately when you also want to hide child assistant
 text from the streamed UI.
 
-#### Model Pinning
+#### Model and Structured Output Pinning
 
-By default, a sub-agent inherits the caller's `RunOptions.ModelName`,
-`RunOptions.Model` and `RunOptions.ModelSelector`. This only takes effect
-when the caller passes `agent.WithModelName(...)`, `agent.WithModel(...)`
-or `agent.WithModelSelector(...)` at `runner.Run` time (for example, an
-AGUI server forwarding the end-user's model choice). If no runtime model
-is set in RunOptions, the sub-agent naturally uses its own model
-configured via `llmagent.WithModel`.
+By default, a sub-agent inherits the caller's run-scoped overrides from
+`RunOptions`. This only matters when the caller passes options at
+`runner.Run` time (for example, an AGUI server forwarding the end-user's model
+or output-format choice). If no runtime override is set in `RunOptions`, the
+sub-agent naturally uses its own static configuration.
 
-When the sub-agent should always use its own model regardless of the
-runtime model selection propagated through RunOptions:
+For fixed `AgentTool` sub-agents, you can pin selected child-side
+configuration so the inherited runtime overrides are cleared at the AgentTool
+boundary:
 
 ```go
 agenttool.NewTool(subAgent,
     agenttool.WithPinModel(true),
+    agenttool.WithPinStructuredOutput(true),
 )
 ```
+
+The options map to different inherited fields:
+
+- `WithPinModel(true)`: clears `RunOptions.ModelName`, `RunOptions.Model` and
+  `RunOptions.ModelSelector`, so the sub-agent's own `llmagent.WithModel(...)`
+  or model selector takes effect.
+- `WithPinStructuredOutput(true)`: clears `RunOptions.StructuredOutput` and
+  `RunOptions.StructuredOutputType`, so the sub-agent's own
+  `llmagent.WithStructuredOutputJSON(...)` or
+  `llmagent.WithStructuredOutputJSONSchema(...)` takes effect.
 
 #### Correlating Sub-Agent Events to the Parent Tool Call
 

--- a/docs/mkdocs/zh/multiagent.md
+++ b/docs/mkdocs/zh/multiagent.md
@@ -622,22 +622,32 @@ if ev.Response != nil && ev.Object == model.ObjectTypeToolResponse {
 使用 `ResponseModeFinalOnly`。如果还希望在流式 UI 中隐藏子 Agent 的正文，
 再单独组合 `InnerTextModeExclude`。
 
-#### 模型钉住 (Pin Model)
+#### 钉住模型与结构化输出
 
-默认情况下，子 Agent 会继承调用方的 `RunOptions.ModelName`、
-`RunOptions.Model` 和 `RunOptions.ModelSelector`。这仅在调用方通过
-`agent.WithModelName(...)`、`agent.WithModel(...)` 或
-`agent.WithModelSelector(...)` 在 `runner.Run` 时指定了模型才会生效（例如 AGUI
-服务端转发终端用户的模型选择）。如果 RunOptions 中未设置模型，子 Agent 自然使用
-自己通过 `llmagent.WithModel` 配置的模型。
+默认情况下，子 Agent 会继承调用方从 `RunOptions` 带下来的运行时覆盖项。
+这只在调用方于 `runner.Run` 时传入选项时才会产生影响（例如 AGUI 服务端转发
+终端用户选择的模型或输出格式）。如果 `RunOptions` 中没有设置运行时覆盖项，
+子 Agent 自然使用自己的静态配置。
 
-当子 Agent 需要始终使用自己的模型，不受 RunOptions 传入的运行时模型选择的影响：
+对固定的 `AgentTool` 子 Agent，可以在 AgentTool 边界清掉指定的继承覆盖项，
+让子 Agent 自己的配置重新生效：
 
 ```go
 agenttool.NewTool(subAgent,
     agenttool.WithPinModel(true),
+    agenttool.WithPinStructuredOutput(true),
 )
 ```
+
+这几个选项分别对应不同的继承字段：
+
+- `WithPinModel(true)`：清掉 `RunOptions.ModelName`、`RunOptions.Model` 和
+  `RunOptions.ModelSelector`，让子 Agent 自己的 `llmagent.WithModel(...)`
+  或模型选择器生效。
+- `WithPinStructuredOutput(true)`：清掉 `RunOptions.StructuredOutput` 和
+  `RunOptions.StructuredOutputType`，让子 Agent 自己的
+  `llmagent.WithStructuredOutputJSON(...)` 或
+  `llmagent.WithStructuredOutputJSONSchema(...)` 生效。
 
 #### 关联子 Agent 事件到父级工具调用
 

--- a/tool/agent/agent_tool.go
+++ b/tool/agent/agent_tool.go
@@ -44,6 +44,7 @@ type Tool struct {
 	persistentHistory      *persistentHistoryOptions
 	responseMode           ResponseMode
 	pinModel               bool
+	pinStructuredOutput    bool
 	name                   string
 	description            string
 	inputSchema            *tool.Schema
@@ -75,6 +76,7 @@ type agentToolOptions struct {
 	description            *string
 	name                   *string
 	pinModel               bool
+	pinStructuredOutput    bool
 
 	// Dynamic AgentTool options. They are only meaningful for NewDynamicTool;
 	// NewTool ignores them.
@@ -332,6 +334,26 @@ func WithPinModel(enabled bool) Option {
 	}
 }
 
+// WithPinStructuredOutput pins the sub-agent's structured-output contract so
+// it always uses its own configured structured output (for example,
+// llmagent.WithStructuredOutputJSON or llmagent.WithStructuredOutputJSONSchema)
+// regardless of the caller's runtime structured output propagated through
+// RunOptions.
+//
+// Background: when the caller passes agent.WithStructuredOutputJSON(...) or
+// agent.WithStructuredOutputJSONSchema(...) at runner.Run time, RunOptions
+// propagate to child invocations via Clone(). LLMAgent setup prefers those
+// run-scoped structured-output values over the sub-agent's own configuration.
+//
+// WithPinStructuredOutput(true) clears RunOptions.StructuredOutput and
+// RunOptions.StructuredOutputType for the child invocation so the sub-agent's
+// own structured output takes effect.
+func WithPinStructuredOutput(enabled bool) Option {
+	return func(opts *agentToolOptions) {
+		opts.pinStructuredOutput = enabled
+	}
+}
+
 // NewTool creates a new Tool that wraps the given agent.
 //
 // Note: The tool name is derived from the agent's info (agent.Info().Name).
@@ -418,6 +440,7 @@ func NewTool(agent agent.Agent, opts ...Option) *Tool {
 		persistentHistory:      persistent,
 		responseMode:           normalizeResponseMode(options.responseMode),
 		pinModel:               options.pinModel,
+		pinStructuredOutput:    options.pinStructuredOutput,
 		name:                   name,
 		description:            description,
 		inputSchema:            inputSchema,
@@ -597,17 +620,12 @@ func (at *Tool) childInvocationOptions(
 	if parentInv == nil {
 		return invocationOpts
 	}
-	// When pinModel is set, clear the inherited model selection so the
-	// sub-agent's own model (configured via llmagent.WithModel) takes effect
-	// instead of the parent's runtime model selection.
-	if at.pinModel && (parentInv.RunOptions.ModelName != "" ||
-		parentInv.RunOptions.Model != nil ||
-		parentInv.RunOptions.ModelSelector != nil) {
-		clearedOpts := parentInv.RunOptions
-		clearedOpts.ModelName = ""
-		clearedOpts.Model = nil
-		clearedOpts.ModelSelector = nil
-		invocationOpts = append(invocationOpts, agent.WithInvocationRunOptions(clearedOpts))
+	if at.hasPinnedRunOptions() {
+		invocationOpts = append(invocationOpts, func(inv *agent.Invocation) {
+			runOptions := inv.RunOptions
+			at.clearPinnedRunOptions(&runOptions)
+			inv.RunOptions = runOptions
+		})
 	}
 	if surfaceRootNodeID := at.surfaceRootNodeIDForParentInvocation(parentInv); surfaceRootNodeID != "" {
 		invocationOpts = append(
@@ -618,6 +636,25 @@ func (at *Tool) childInvocationOptions(
 		)
 	}
 	return invocationOpts
+}
+
+func (at *Tool) hasPinnedRunOptions() bool {
+	return at.pinModel || at.pinStructuredOutput
+}
+
+func (at *Tool) clearPinnedRunOptions(runOptions *agent.RunOptions) {
+	if runOptions == nil {
+		return
+	}
+	if at.pinModel {
+		runOptions.ModelName = ""
+		runOptions.Model = nil
+		runOptions.ModelSelector = nil
+	}
+	if at.pinStructuredOutput {
+		runOptions.StructuredOutput = nil
+		runOptions.StructuredOutputType = nil
+	}
 }
 
 // wrapWithCompletion consumes events, notifies completion when required, and forwards to a new channel.

--- a/tool/agent/agent_tool_test.go
+++ b/tool/agent/agent_tool_test.go
@@ -2984,6 +2984,14 @@ func (m *structuredOutputCaptureModel) Snapshot() (bool, string) {
 	return m.seen, m.schemaName
 }
 
+type agentToolParentStructuredOutput struct {
+	Summary string `json:"summary"`
+}
+
+type agentToolChildStructuredOutput struct {
+	Status string `json:"status"`
+}
+
 func TestTool_Call_MirrorsChildEventsToSession(t *testing.T) {
 	sa := &sessionMirrorAgent{name: "session-mirror"}
 	at := NewTool(sa)
@@ -5269,6 +5277,44 @@ func TestTool_callWithParentInvocation_PreservesRunStructuredOutput(t *testing.T
 	require.Equal(t, "tool_output", schemaName)
 }
 
+func TestTool_callWithParentInvocation_PinStructuredOutputUsesChildContract(t *testing.T) {
+	modelImpl := &structuredOutputCaptureModel{name: "capture-model"}
+	child := llmagent.New(
+		"structured-output-child",
+		llmagent.WithModel(modelImpl),
+		llmagent.WithStructuredOutputJSON(
+			new(agentToolChildStructuredOutput),
+			true,
+			"Child output.",
+		),
+	)
+	at := NewTool(child, WithPinStructuredOutput(true))
+	runOpts := agent.RunOptions{}
+	agent.WithStructuredOutputJSON(
+		new(agentToolParentStructuredOutput),
+		true,
+		"Parent output.",
+	)(&runOpts)
+	parent := agent.NewInvocation(
+		agent.WithInvocationSession(session.NewSession("app", "user", "session")),
+		agent.WithInvocationRunOptions(runOpts),
+		agent.WithInvocationStructuredOutput(runOpts.StructuredOutput),
+		agent.WithInvocationStructuredOutputType(runOpts.StructuredOutputType),
+		agent.WithInvocationEventFilterKey("parent-agent"),
+	)
+	res, err := at.callWithParentInvocation(
+		context.Background(),
+		parent,
+		model.NewUserMessage("hi"),
+		nil,
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, res)
+	seen, schemaName := modelImpl.Snapshot()
+	require.True(t, seen)
+	require.Equal(t, "agentToolChildStructuredOutput", schemaName)
+}
+
 func TestTool_callWithParentInvocation_RestoresLiveSessionFromParallelClone(
 	t *testing.T,
 ) {
@@ -5517,6 +5563,18 @@ func TestTool_WithPinModel_Enabled(t *testing.T) {
 	}
 }
 
+func TestTool_WithPinStructuredOutput_DefaultAndEnabled(t *testing.T) {
+	mockAgent := &mockAgent{
+		name:        "test-agent",
+		description: "A test agent",
+	}
+	defaultTool := NewTool(mockAgent)
+	require.False(t, defaultTool.pinStructuredOutput)
+
+	agentTool := NewTool(mockAgent, WithPinStructuredOutput(true))
+	require.True(t, agentTool.pinStructuredOutput)
+}
+
 func TestTool_WithPinModel_ClearsModelName(t *testing.T) {
 	mockAgent := &mockAgent{
 		name:        "test-agent",
@@ -5585,6 +5643,60 @@ func TestTool_WithPinModel_ClearsModelSelector(t *testing.T) {
 	if childInv.RunOptions.ModelSelector != nil {
 		t.Error("Expected ModelSelector to be nil when WithPinModel is enabled")
 	}
+}
+
+func TestTool_WithPinStructuredOutput_ClearsRunStructuredOutput(t *testing.T) {
+	mockAgent := &mockAgent{
+		name:        "test-agent",
+		description: "A test agent",
+	}
+	agentTool := NewTool(mockAgent, WithPinStructuredOutput(true))
+
+	runOpts := agent.RunOptions{}
+	agent.WithStructuredOutputJSON(
+		new(agentToolParentStructuredOutput),
+		true,
+		"Parent output.",
+	)(&runOpts)
+	parentInv := agent.NewInvocation(agent.WithInvocationRunOptions(runOpts))
+
+	opts := agentTool.childInvocationOptions(
+		context.Background(),
+		parentInv,
+		model.NewUserMessage("test"),
+		"child-key",
+		nil,
+	)
+
+	childInv := parentInv.Clone(opts...)
+	require.Nil(t, childInv.RunOptions.StructuredOutput)
+	require.Nil(t, childInv.RunOptions.StructuredOutputType)
+}
+
+func TestTool_WithPinRunOptions_PreservesRuntimeState(t *testing.T) {
+	mockAgent := &mockAgent{
+		name:        "test-agent",
+		description: "A test agent",
+	}
+	agentTool := NewTool(mockAgent, WithPinModel(true))
+	parentInv := agent.NewInvocation(
+		agent.WithInvocationRunOptions(agent.RunOptions{
+			ModelName: "parent-model",
+		}),
+	)
+	runtimeState := map[string]any{"room_id": "r1"}
+
+	opts := agentTool.childInvocationOptions(
+		context.Background(),
+		parentInv,
+		model.NewUserMessage("test"),
+		"child-key",
+		runtimeState,
+	)
+
+	childInv := parentInv.Clone(opts...)
+	require.Empty(t, childInv.RunOptions.ModelName)
+	require.Equal(t, runtimeState, childInv.RunOptions.RuntimeState)
 }
 
 func TestTool_WithPinModel_Disabled_PreservesModelName(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add `agenttool.WithPinStructuredOutput(true)` for fixed AgentTool child calls.
- Clear inherited run-scoped structured output so the child agent can use its own structured output contract.
- Update multi-agent docs and AgentTool tests.

## Testing

- `go test ./tool/agent`
