### PR TITLE
tool/agent: report unavailable dynamic capabilities

### DIFF
--- a/tool/agent/agent_tool.go
+++ b/tool/agent/agent_tool.go
@@ -83,19 +83,20 @@ type agentToolOptions struct {
 
 // dynamicOptions holds the configuration knobs for the dynamic AgentTool mode.
 type dynamicOptions struct {
-	templateAgent           agent.Agent
-	capabilityProvider      CapabilitySurfaceProvider
-	capabilitySkillProvider CapabilitySkillsProvider
-	capabilityTools         []tool.Tool
-	capabilitySkills        skillRepository
-	capabilityToolsSet      bool
-	exposeToolSelection     bool
-	exposeSkillSelection    bool
-	exposeInstruction       bool
-	requestDescription      *string
-	instructionDescription  *string
-	toolsDescription        *string
-	skillsDescription       *string
+	templateAgent             agent.Agent
+	capabilityProvider        CapabilitySurfaceProvider
+	capabilitySurfaceProvider DetailedCapabilitySurfaceProvider
+	capabilitySkillProvider   CapabilitySkillsProvider
+	capabilityTools           []tool.Tool
+	capabilitySkills          skillRepository
+	capabilityToolsSet        bool
+	exposeToolSelection       bool
+	exposeSkillSelection      bool
+	exposeInstruction         bool
+	requestDescription        *string
+	instructionDescription    *string
+	toolsDescription          *string
+	skillsDescription         *string
 }
 
 func defaultDynamicOptions() *dynamicOptions {

--- a/tool/agent/dynamic_tool.go
+++ b/tool/agent/dynamic_tool.go
@@ -94,6 +94,66 @@ type CapabilitySkillsProvider func(
 	parentInv *agent.Invocation,
 ) skill.Repository
 
+// CapabilityUnavailableReason describes why a named capability exists in the
+// system boundary but is not available for the current dynamic sub-agent call.
+type CapabilityUnavailableReason string
+
+const (
+	// CapabilityUnavailableReasonUnknown is used when the provider does not
+	// supply a more specific reason.
+	CapabilityUnavailableReasonUnknown CapabilityUnavailableReason = "unknown"
+	// CapabilityUnavailableReasonMissingCredential means a required credential
+	// or token is not configured for this user, tenant, or runtime.
+	CapabilityUnavailableReasonMissingCredential CapabilityUnavailableReason = "missing_credential"
+	// CapabilityUnavailableReasonPermissionDenied means policy denied this
+	// capability for the current user, tenant, or task.
+	CapabilityUnavailableReasonPermissionDenied CapabilityUnavailableReason = "permission_denied"
+	// CapabilityUnavailableReasonExecutorUnavailable means the required local,
+	// remote, sandbox, or workflow executor is not available.
+	CapabilityUnavailableReasonExecutorUnavailable CapabilityUnavailableReason = "executor_unavailable"
+	// CapabilityUnavailableReasonNetworkDisabled means network access required
+	// by the capability is disabled for this run.
+	CapabilityUnavailableReasonNetworkDisabled CapabilityUnavailableReason = "network_disabled"
+)
+
+// UnavailableCapability records a named capability that should not be mounted
+// into the child surface for this call, while still giving the parent model a
+// concrete reason when it requested that capability.
+type UnavailableCapability struct {
+	Name   string
+	Reason CapabilityUnavailableReason
+	// Detail is included in the dynamic tool's model-visible warning note.
+	// Keep it safe for prompt context: do not include secrets, credential
+	// values, internal policy internals, or tenant-specific sensitive data.
+	Detail string
+}
+
+// CapabilitySurface is the structured dynamic capability boundary returned by
+// DetailedCapabilitySurfaceProvider.
+type CapabilitySurface struct {
+	// Tools is the maximum available tool surface.
+	Tools []tool.Tool
+	// UserToolNames classifies selectable user tools. Nil means every returned
+	// tool is selectable unless excluded by framework rules.
+	UserToolNames map[string]bool
+	// ExternalToolNames marks caller-executed tools that must not be mounted
+	// into the synchronous child invocation.
+	ExternalToolNames map[string]bool
+	// UnavailableTools names capabilities that are known but unavailable for
+	// this call. They are not mounted. If requested, their reason is surfaced
+	// to the parent model in the dynamic tool warning note.
+	UnavailableTools []UnavailableCapability
+}
+
+// DetailedCapabilitySurfaceProvider returns a structured capability surface for
+// dynamic sub-agent calls. Use it when the provider needs to distinguish
+// "unknown tool" from "known but unavailable" and surface actionable reasons
+// such as missing_credential or executor_unavailable.
+type DetailedCapabilitySurfaceProvider func(
+	ctx context.Context,
+	parentInv *agent.Invocation,
+) CapabilitySurface
+
 // WithTemplateAgent sets the base/template agent that defines the execution
 // boundary for the dynamic sub-agent (model, executor, callbacks, permission
 // policy, max calls, ...).
@@ -108,18 +168,32 @@ func WithTemplateAgent(a agent.Agent) Option {
 }
 
 // WithCapabilityProvider overrides how the maximum capability surface is
-// resolved for a dynamic sub-agent. By default the surface is derived from the
-// parent invocation's effective tool surface.
+// resolved for a dynamic sub-agent. It is the legacy provider shape: it can
+// return available tools, but not known-unavailable tools with reasons. Use
+// WithCapabilitySurfaceProvider when the parent model needs actionable
+// unavailable reasons. By default the surface is derived from the parent
+// invocation's effective tool surface.
 func WithCapabilityProvider(provider CapabilitySurfaceProvider) Option {
 	return func(opts *agentToolOptions) {
 		opts.ensureDynamicOptions().capabilityProvider = provider
 	}
 }
 
+// WithCapabilitySurfaceProvider overrides how the maximum capability surface
+// is resolved for a dynamic sub-agent and can also report known-but-unavailable
+// capabilities with structured reasons. It takes precedence over
+// WithCapabilityProvider, WithCapabilityTools, and the default parent-derived
+// surface.
+func WithCapabilitySurfaceProvider(provider DetailedCapabilitySurfaceProvider) Option {
+	return func(opts *agentToolOptions) {
+		opts.ensureDynamicOptions().capabilitySurfaceProvider = provider
+	}
+}
+
 // WithCapabilityTools sets a fixed maximum tool surface for a dynamic
 // sub-agent. The model may only select a subset of these tools. This takes
 // precedence over the default parent-derived surface (but not over
-// WithCapabilityProvider).
+// WithCapabilityProvider or WithCapabilitySurfaceProvider).
 func WithCapabilityTools(tools []tool.Tool) Option {
 	return func(opts *agentToolOptions) {
 		cfg := opts.ensureDynamicOptions()
@@ -340,12 +414,14 @@ func buildDynamicInputSchema(name string, cfg *dynamicOptions) *tool.Schema {
 			Description: optionalString(cfg.toolsDescription, defaultToolsDescription),
 			Items:       &tool.Schema{Type: "string"},
 		}
-		// When the capability surface is statically defined in code via
-		// WithCapabilityTools, enumerate the selectable tool names so the model
-		// picks from a known set instead of guessing. The default parent-derived
-		// surface and WithCapabilityProvider are resolved per call, so their
-		// names are not available at schema-build time.
-		if cfg.capabilityToolsSet {
+		// When the effective capability surface is statically defined in code
+		// via WithCapabilityTools, enumerate the selectable tool names so the
+		// model picks from a known set instead of guessing. Provider-based and
+		// default parent-derived surfaces are resolved per call, so their names
+		// are not available at schema-build time.
+		if cfg.capabilityToolsSet &&
+			cfg.capabilityProvider == nil &&
+			cfg.capabilitySurfaceProvider == nil {
 			if names, enum := capabilityToolNameEnum(cfg.capabilityTools); len(enum) > 0 {
 				toolsSchema.Items = &tool.Schema{Type: "string", Enum: enum}
 				if cfg.toolsDescription == nil {
@@ -578,8 +654,9 @@ func (at *Tool) buildDynamicPatch(
 
 	// Tools: always set so the dynamic tool itself (and transfer_to_agent) are
 	// excluded from the child, preventing runaway recursion.
-	maxTools, userToolNames, externalNames := at.dynamicMaxToolSurface(ctx, parentInv)
-	selectedTools, toolWarnings := at.selectDynamicTools(maxTools, userToolNames, externalNames, spec)
+	maxTools, userToolNames, externalNames, unavailableTools := at.dynamicMaxToolSurface(ctx, parentInv)
+	selectedTools, toolWarnings := at.selectDynamicTools(
+		maxTools, userToolNames, externalNames, unavailableTools, spec)
 	patch.SetTools(selectedTools)
 	// SetTools only replaces the user tools. The framework re-derives
 	// transfer_to_agent from the base/template agent's own sub-agents, so
@@ -621,19 +698,27 @@ func (at *Tool) buildDynamicPatch(
 func (at *Tool) dynamicMaxToolSurface(
 	ctx context.Context,
 	parentInv *agent.Invocation,
-) ([]tool.Tool, map[string]bool, map[string]bool) {
+) ([]tool.Tool, map[string]bool, map[string]bool, map[string]UnavailableCapability) {
+	if at.dynamicCfg.capabilitySurfaceProvider != nil {
+		surface := at.dynamicCfg.capabilitySurfaceProvider(ctx, parentInv)
+		return surface.Tools,
+			surface.UserToolNames,
+			surface.ExternalToolNames,
+			unavailableCapabilityMap(surface.UnavailableTools)
+	}
 	if at.dynamicCfg.capabilityProvider != nil {
 		tools, userToolNames := at.dynamicCfg.capabilityProvider(ctx, parentInv)
-		return tools, userToolNames, nil
+		return tools, userToolNames, nil, nil
 	}
 	if at.dynamicCfg.capabilityToolsSet {
 		return at.dynamicCfg.capabilityTools,
-			toolNameSet(at.dynamicCfg.capabilityTools), nil
+			toolNameSet(at.dynamicCfg.capabilityTools), nil, nil
 	}
 	if parentInv == nil || parentInv.Agent == nil {
-		return nil, nil, nil
+		return nil, nil, nil, nil
 	}
-	return toolsurface.EffectiveWithExternal(ctx, parentInv)
+	tools, userToolNames, externalNames := toolsurface.EffectiveWithExternal(ctx, parentInv)
+	return tools, userToolNames, externalNames, nil
 }
 
 // selectDynamicTools computes the child tool surface from the maximum surface
@@ -652,6 +737,7 @@ func (at *Tool) selectDynamicTools(
 	maxTools []tool.Tool,
 	userToolNames map[string]bool,
 	externalNames map[string]bool,
+	unavailableTools map[string]UnavailableCapability,
 	spec dynamicSpec,
 ) ([]tool.Tool, []string) {
 	excluded := map[string]bool{at.name: true, transfer.TransferToolName: true}
@@ -672,6 +758,9 @@ func (at *Tool) selectDynamicTools(
 		}
 		name := declarationName(t)
 		if name == "" || excluded[name] || !isUserTool(name) {
+			continue
+		}
+		if _, unavailable := unavailableTools[name]; unavailable {
 			continue
 		}
 		if _, seen := candidateByName[name]; seen {
@@ -696,6 +785,10 @@ func (at *Tool) selectDynamicTools(
 	for _, name := range spec.tools {
 		t, ok := candidateByName[name]
 		if !ok {
+			if unavailable, exists := unavailableTools[name]; exists {
+				warnings = append(warnings, formatUnavailableToolWarning(name, unavailable))
+				continue
+			}
 			warnings = append(warnings, fmt.Sprintf(
 				"requested tool %q is not available and was ignored", name))
 			continue
@@ -968,6 +1061,57 @@ func (at *Tool) formatResponseWithWarnings(response string, warnings []string) s
 		return note + "\n" + response
 	}
 	return note
+}
+
+func unavailableCapabilityMap(values []UnavailableCapability) map[string]UnavailableCapability {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]UnavailableCapability, len(values))
+	for _, value := range values {
+		value.Name = strings.TrimSpace(value.Name)
+		if value.Name == "" {
+			continue
+		}
+		value.Detail = sanitizeUnavailableDetail(value.Detail)
+		if value.Reason == "" {
+			value.Reason = CapabilityUnavailableReasonUnknown
+		}
+		out[value.Name] = value
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+const maxUnavailableDetailRunes = 256
+
+func sanitizeUnavailableDetail(detail string) string {
+	cleaned := strings.Join(strings.Fields(strings.TrimSpace(detail)), " ")
+	runes := []rune(cleaned)
+	if len(runes) <= maxUnavailableDetailRunes {
+		return cleaned
+	}
+	return string(runes[:maxUnavailableDetailRunes]) + "..."
+}
+
+func formatUnavailableToolWarning(name string, unavailable UnavailableCapability) string {
+	reason := unavailable.Reason
+	if reason == "" {
+		reason = CapabilityUnavailableReasonUnknown
+	}
+	detail := sanitizeUnavailableDetail(unavailable.Detail)
+	if detail != "" {
+		return fmt.Sprintf(
+			"requested tool %q is unavailable (reason: %s; detail: %s) and was ignored",
+			name, reason, detail,
+		)
+	}
+	return fmt.Sprintf(
+		"requested tool %q is unavailable (reason: %s) and was ignored",
+		name, reason,
+	)
 }
 
 func toolNameSet(tools []tool.Tool) map[string]bool {

--- a/tool/agent/dynamic_tool_test.go
+++ b/tool/agent/dynamic_tool_test.go
@@ -206,6 +206,38 @@ func TestNewDynamicTool_CapabilityToolsEnumerated(t *testing.T) {
 		}))
 	ts4 := at4.Declaration().InputSchema.Properties[fieldTools]
 	require.Nil(t, ts4.Items.Enum)
+
+	// Provider takes runtime precedence over static tools, so the schema must
+	// not expose the static enum when both options are configured.
+	at4b := NewDynamicTool(
+		WithCapabilityTools(stubTools("static_only")),
+		WithCapabilityProvider(
+			func(context.Context, *agent.Invocation) ([]tool.Tool, map[string]bool) {
+				return stubTools("runtime_only"), nil
+			},
+		),
+	)
+	ts4b := at4b.Declaration().InputSchema.Properties[fieldTools]
+	require.Nil(t, ts4b.Items.Enum)
+
+	// Structured provider: also resolved per call, not enumerable at schema-build time.
+	at5 := NewDynamicTool(WithCapabilitySurfaceProvider(
+		func(context.Context, *agent.Invocation) CapabilitySurface {
+			return CapabilitySurface{Tools: stubTools("x")}
+		}))
+	ts5 := at5.Declaration().InputSchema.Properties[fieldTools]
+	require.Nil(t, ts5.Items.Enum)
+
+	at5b := NewDynamicTool(
+		WithCapabilityTools(stubTools("static_only")),
+		WithCapabilitySurfaceProvider(
+			func(context.Context, *agent.Invocation) CapabilitySurface {
+				return CapabilitySurface{Tools: stubTools("runtime_only")}
+			},
+		),
+	)
+	ts5b := at5b.Declaration().InputSchema.Properties[fieldTools]
+	require.Nil(t, ts5b.Items.Enum)
 }
 
 func TestNewDynamicTool_ExposeToggles(t *testing.T) {
@@ -505,7 +537,7 @@ func TestSelectDynamicTools_ExcludesSelfAndTransfer(t *testing.T) {
 		transfer.TransferToolName, // transfer must be excluded
 	)
 	// No selection => all candidates minus excluded.
-	selected, warnings := at.selectDynamicTools(maxTools, toolNameSet(maxTools), nil, dynamicSpec{})
+	selected, warnings := at.selectDynamicTools(maxTools, toolNameSet(maxTools), nil, nil, dynamicSpec{})
 	require.Empty(t, warnings)
 	require.Equal(t, []string{"file_read", "file_write"}, selectedNames(selected))
 }
@@ -514,7 +546,7 @@ func TestSelectDynamicTools_OnlyUserTools(t *testing.T) {
 	at := NewDynamicTool()
 	maxTools := stubTools("file_read", "framework_tool")
 	userTools := map[string]bool{"file_read": true} // framework_tool not a user tool
-	selected, warnings := at.selectDynamicTools(maxTools, userTools, nil, dynamicSpec{})
+	selected, warnings := at.selectDynamicTools(maxTools, userTools, nil, nil, dynamicSpec{})
 	require.Empty(t, warnings)
 	require.Equal(t, []string{"file_read"}, selectedNames(selected))
 }
@@ -523,7 +555,7 @@ func TestSelectDynamicTools_SubsetSelection(t *testing.T) {
 	at := NewDynamicTool()
 	maxTools := stubTools("a", "b", "c")
 	spec := dynamicSpec{toolsProvided: true, tools: []string{"a", "c"}}
-	selected, warnings := at.selectDynamicTools(maxTools, toolNameSet(maxTools), nil, spec)
+	selected, warnings := at.selectDynamicTools(maxTools, toolNameSet(maxTools), nil, nil, spec)
 	require.Empty(t, warnings)
 	require.Equal(t, []string{"a", "c"}, selectedNames(selected))
 }
@@ -532,17 +564,64 @@ func TestSelectDynamicTools_UnknownRequestedToolWarns(t *testing.T) {
 	at := NewDynamicTool()
 	maxTools := stubTools("a", "b")
 	spec := dynamicSpec{toolsProvided: true, tools: []string{"a", "nope"}}
-	selected, warnings := at.selectDynamicTools(maxTools, toolNameSet(maxTools), nil, spec)
+	selected, warnings := at.selectDynamicTools(maxTools, toolNameSet(maxTools), nil, nil, spec)
 	require.Equal(t, []string{"a"}, selectedNames(selected))
 	require.Len(t, warnings, 1)
 	require.Contains(t, warnings[0], "nope")
+}
+
+func TestSelectDynamicTools_UnavailableRequestedToolWarnsWithReason(t *testing.T) {
+	at := NewDynamicTool()
+	maxTools := stubTools("available", "secret")
+	unavailable := map[string]UnavailableCapability{
+		"secret": {
+			Name:   "secret",
+			Reason: CapabilityUnavailableReasonMissingCredential,
+			Detail: "configure SECRET_TOKEN",
+		},
+	}
+
+	// No selection: unavailable tools are simply not mounted and do not add noise.
+	selected, warnings := at.selectDynamicTools(
+		maxTools, toolNameSet(maxTools), nil, unavailable, dynamicSpec{})
+	require.Equal(t, []string{"available"}, selectedNames(selected))
+	require.Empty(t, warnings)
+
+	// Explicit selection: the parent gets an actionable reason instead of a
+	// generic "not available" warning.
+	spec := dynamicSpec{toolsProvided: true, tools: []string{"available", "secret"}}
+	selected, warnings = at.selectDynamicTools(
+		maxTools, toolNameSet(maxTools), nil, unavailable, spec)
+	require.Equal(t, []string{"available"}, selectedNames(selected))
+	require.Len(t, warnings, 1)
+	require.Contains(t, warnings[0], "secret")
+	require.Contains(t, warnings[0], string(CapabilityUnavailableReasonMissingCredential))
+	require.Contains(t, warnings[0], "SECRET_TOKEN")
+}
+
+func TestFormatUnavailableToolWarning_SanitizesDetail(t *testing.T) {
+	warning := formatUnavailableToolWarning("secret", UnavailableCapability{
+		Reason: CapabilityUnavailableReasonPermissionDenied,
+		Detail: "  policy\n\tdenied  ",
+	})
+	require.Contains(t, warning, "detail: policy denied")
+	require.NotContains(t, warning, "\n")
+	require.Contains(t, warning, string(CapabilityUnavailableReasonPermissionDenied))
+
+	longDetail := strings.Repeat("x", maxUnavailableDetailRunes+5)
+	warning = formatUnavailableToolWarning("secret", UnavailableCapability{
+		Detail: longDetail,
+	})
+	require.Contains(t, warning, string(CapabilityUnavailableReasonUnknown))
+	require.Contains(t, warning, strings.Repeat("x", maxUnavailableDetailRunes)+"...")
+	require.NotContains(t, warning, strings.Repeat("x", maxUnavailableDetailRunes+1))
 }
 
 func TestSelectDynamicTools_AllUnknownWarnsNoUserTools(t *testing.T) {
 	at := NewDynamicTool()
 	maxTools := stubTools("a", "b")
 	spec := dynamicSpec{toolsProvided: true, tools: []string{"x", "y"}}
-	selected, warnings := at.selectDynamicTools(maxTools, toolNameSet(maxTools), nil, spec)
+	selected, warnings := at.selectDynamicTools(maxTools, toolNameSet(maxTools), nil, nil, spec)
 	require.Empty(t, selected)
 	require.NotEmpty(t, warnings)
 	require.Contains(t, warnings[len(warnings)-1], "no user tools")
@@ -559,14 +638,14 @@ func TestSelectDynamicTools_ExcludesExternalTools(t *testing.T) {
 
 	// No selection: external tool must not appear among the candidates.
 	selected, warnings := at.selectDynamicTools(
-		maxTools, toolNameSet(maxTools), externalNames, dynamicSpec{})
+		maxTools, toolNameSet(maxTools), externalNames, nil, dynamicSpec{})
 	require.Empty(t, warnings)
 	require.Equal(t, []string{"tool_a"}, selectedNames(selected))
 
 	// Explicit selection of an external tool is rejected as unavailable.
 	spec := dynamicSpec{toolsProvided: true, tools: []string{"ext_tool"}}
 	selected, warnings = at.selectDynamicTools(
-		maxTools, toolNameSet(maxTools), externalNames, spec)
+		maxTools, toolNameSet(maxTools), externalNames, nil, spec)
 	require.Empty(t, selected)
 	require.NotEmpty(t, warnings)
 }
@@ -578,9 +657,82 @@ func TestSelectDynamicTools_EmptyArrayAllowsNoneWithoutWarning(t *testing.T) {
 	at := NewDynamicTool()
 	maxTools := stubTools("a", "b")
 	spec := dynamicSpec{toolsProvided: true, tools: nil} // provided, but empty
-	selected, warnings := at.selectDynamicTools(maxTools, toolNameSet(maxTools), nil, spec)
+	selected, warnings := at.selectDynamicTools(maxTools, toolNameSet(maxTools), nil, nil, spec)
 	require.Empty(t, selected)
 	require.Empty(t, warnings, "an explicit empty selection must not warn")
+}
+
+func TestDynamicMaxToolSurface_DetailedProviderWinsAndReportsUnavailable(t *testing.T) {
+	legacyCalled := false
+	at := NewDynamicTool(
+		WithCapabilityTools(stubTools("static")),
+		WithCapabilityProvider(func(context.Context, *agent.Invocation) ([]tool.Tool, map[string]bool) {
+			legacyCalled = true
+			return stubTools("legacy"), nil
+		}),
+		WithCapabilitySurfaceProvider(func(context.Context, *agent.Invocation) CapabilitySurface {
+			return CapabilitySurface{
+				Tools:             stubTools("available"),
+				UserToolNames:     map[string]bool{"available": true},
+				ExternalToolNames: map[string]bool{"external": true},
+				UnavailableTools: []UnavailableCapability{{
+					Name:   " unavailable ",
+					Reason: CapabilityUnavailableReasonExecutorUnavailable,
+					Detail: " no sandbox ",
+				}},
+			}
+		}),
+	)
+
+	tools, users, externals, unavailable := at.dynamicMaxToolSurface(context.Background(), nil)
+	require.False(t, legacyCalled, "structured provider should take precedence")
+	require.Equal(t, []string{"available"}, selectedNames(tools))
+	require.True(t, users["available"])
+	require.True(t, externals["external"])
+	got := unavailable["unavailable"]
+	require.Equal(t, CapabilityUnavailableReasonExecutorUnavailable, got.Reason)
+	require.Equal(t, "no sandbox", got.Detail)
+}
+
+func TestUnavailableCapabilityMap_NormalizesEntries(t *testing.T) {
+	values := unavailableCapabilityMap([]UnavailableCapability{
+		{Name: "  ", Reason: CapabilityUnavailableReasonPermissionDenied},
+		{Name: " tool_a ", Detail: "  access\n\tdenied  "},
+	})
+	require.Len(t, values, 1)
+	got := values["tool_a"]
+	require.Equal(t, CapabilityUnavailableReasonUnknown, got.Reason)
+	require.Equal(t, "access denied", got.Detail)
+	require.Nil(t, unavailableCapabilityMap(nil))
+	require.Nil(t, unavailableCapabilityMap([]UnavailableCapability{{Name: " "}}))
+}
+
+func TestFormatUnavailableToolWarning_WithoutDetail(t *testing.T) {
+	warning := formatUnavailableToolWarning("tool_a", UnavailableCapability{
+		Reason: CapabilityUnavailableReasonNetworkDisabled,
+	})
+	require.Contains(t, warning, "tool_a")
+	require.Contains(t, warning, string(CapabilityUnavailableReasonNetworkDisabled))
+	require.NotContains(t, warning, "detail:")
+}
+
+func TestDynamicMaxToolSurface_LegacyProviderAndNilParent(t *testing.T) {
+	at := NewDynamicTool(WithCapabilityProvider(
+		func(context.Context, *agent.Invocation) ([]tool.Tool, map[string]bool) {
+			return stubTools("legacy"), map[string]bool{"legacy": true}
+		},
+	))
+	tools, users, externals, unavailable := at.dynamicMaxToolSurface(context.Background(), nil)
+	require.Equal(t, []string{"legacy"}, selectedNames(tools))
+	require.True(t, users["legacy"])
+	require.Nil(t, externals)
+	require.Nil(t, unavailable)
+
+	tools, users, externals, unavailable = NewDynamicTool().dynamicMaxToolSurface(context.Background(), nil)
+	require.Nil(t, tools)
+	require.Nil(t, users)
+	require.Nil(t, externals)
+	require.Nil(t, unavailable)
 }
 
 func TestDedupeNonEmpty(t *testing.T) {
@@ -753,6 +905,48 @@ func TestNewDynamicTool_Integration_DefaultAllTools(t *testing.T) {
 	seen := recModel.snapshot()
 	require.Len(t, seen, 1)
 	require.Equal(t, []string{"tool_a", "tool_b"}, seen[0])
+}
+
+func TestNewDynamicTool_Integration_UnavailableReasonReturnedToParent(t *testing.T) {
+	recModel := &dynRecordingModel{name: "rec", response: "child-done"}
+	main := llmagent.New("main", llmagent.WithModel(recModel))
+	at := NewDynamicTool(WithCapabilitySurfaceProvider(
+		func(context.Context, *agent.Invocation) CapabilitySurface {
+			return CapabilitySurface{
+				Tools: stubTools("available"),
+				UnavailableTools: []UnavailableCapability{{
+					Name:   "secret",
+					Reason: CapabilityUnavailableReasonMissingCredential,
+					Detail: "configure SECRET_TOKEN",
+				}},
+			}
+		},
+	))
+
+	sess := session.NewSession("app", "user", "session")
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(main),
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationEventFilterKey("main"),
+	)
+	ctx := agent.NewInvocationContext(context.Background(), parent)
+
+	got, err := at.Call(ctx, []byte(
+		`{"request":"use both tools","tools":["available","secret"]}`,
+	))
+	require.NoError(t, err)
+	out, ok := got.(string)
+	require.True(t, ok)
+	require.Contains(t, out, "Note from "+at.name)
+	require.Contains(t, out, "secret")
+	require.Contains(t, out, string(CapabilityUnavailableReasonMissingCredential))
+	require.Contains(t, out, "configure SECRET_TOKEN")
+	require.Contains(t, out, "child-done")
+
+	seen := recModel.snapshot()
+	require.Len(t, seen, 1, "child should have run exactly once")
+	require.Equal(t, []string{"available"}, seen[0],
+		"child must not see known-but-unavailable tools")
 }
 
 // TestNewDynamicTool_Integration_WithTemplateAgent verifies that a distinctly


### PR DESCRIPTION
## Summary

- Add a detailed capability surface provider for Dynamic AgentTool.
- Let unavailable requested capabilities report a reason instead of only being ignored.
- Include unavailable tool/skill reasons in the warning text returned to the parent agent.

## Testing

- `go test ./tool/agent`
