### PR TITLE
storage/mongodb: generalize Client interface doc for session/memory backends

### DIFF
--- a/storage/mongodb/mongodb.go
+++ b/storage/mongodb/mongodb.go
@@ -85,9 +85,15 @@ func GetMongoDBInstance(name string) ([]ClientBuilderOpt, bool) {
 	return instance, ok
 }
 
-// Client defines the interface for MongoDB operations.
-// This is a subset of the internal mongodb.Client interface,
-// containing only the methods needed by the session layer.
+// Client defines the interface for MongoDB operations shared by the storage
+// backends (session, memory, etc.).
+//
+// It is intentionally a minimal, generic CRUD subset so it can be backed by the
+// default official-driver client below, or — when MongoDB is routed through a
+// custom client via SetClientBuilder — by a thin adapter over that client.
+// Keep any new method aligned with the official mongo-driver signature so such
+// adapters stay trivial; capabilities a backend may add later include Aggregate
+// (memory semantic search) and index management (TTL / unique constraints).
 type Client interface {
 	// InsertOne executes an insert command to insert a single document into the collection.
 	InsertOne(ctx context.Context, database string, coll string, document any,

--- a/storage/mongodb/option.go
+++ b/storage/mongodb/option.go
@@ -19,7 +19,7 @@ type ClientBuilderOpts struct {
 	// Format: "mongodb://username:password@host:port/database?options"
 	URI string
 
-	// ExtraOptions is the extra options for the redis client.
+	// ExtraOptions is the extra options for the mongodb client.
 	ExtraOptions []any
 }
 


### PR DESCRIPTION
## What

Documentation-only refinement of the `storage/mongodb` Client abstraction:

- Reword the `Client` interface doc: it is a generic, minimal CRUD subset shared by storage backends (session, memory, …), backable either by the default official-driver client or by a custom client via `SetClientBuilder` — not "session layer only".
- Note future extension points (Aggregate for memory semantic search; index management for TTL / unique constraints).
- Fix a copy-paste typo in the `ExtraOptions` field comment (redis → mongodb).

## Why

Prepares `storage/mongodb` to back upcoming MongoDB `session` and `memory` backends. No behavior or signature changes; `go build` and `go vet` pass.

## Status

WIP / draft — foundation only. The MongoDB `session` and `memory` service backends that consume this client will follow in separate PRs.