### PR TITLE
openclaw: default deferred tool surface to auto

### DIFF
--- a/openclaw/INTEGRATIONS.md
+++ b/openclaw/INTEGRATIONS.md
@@ -857,13 +857,15 @@ reloaded on each agent run (useful for MCP where tools can change).
 ### Deferred tool surface (optional)
 
 Large tool and skill surfaces can dominate the parent model request even
-when a turn is answered directly. Set `tools.defer_to_dynamic_agent_mode:
-auto` to expose compact `tool_search` and `dynamic_agent` tools only when
-the configured tool declarations exceed the auto threshold. The parent can
-discover exact tool and skill names with `tool_search`, while the configured
-tools, toolsets, skills, memory, and code execution surface are loaded only
-inside the short-lived worker call. Existing `tools.defer_to_dynamic_agent:
-true` configs remain supported and force deferred mode on.
+when a turn is answered directly. The default
+`tools.defer_to_dynamic_agent_mode: auto` exposes compact `tool_search` and
+`dynamic_agent` tools only when the configured tool declarations exceed the
+auto threshold. The parent can discover exact tool and skill names with
+`tool_search`, while the configured tools, toolsets, skills, memory, and code
+execution surface are loaded only inside the short-lived worker call. Existing
+`tools.defer_to_dynamic_agent: true` configs remain supported and force
+deferred mode on; use `tools.defer_to_dynamic_agent_mode: off` or
+`tools.defer_to_dynamic_agent: false` to disable it.
 
 YAML:
 

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -285,7 +285,8 @@ tools:
   openclaw_tooling_guidance: ""
   # Optional: reduce large parent model requests by exposing compact
   # tool_search + dynamic_agent entrypoints when the direct tool surface
-  # exceeds the auto threshold. Set defer_to_dynamic_agent: true to force on.
+  # exceeds the auto threshold. Default mode is auto; set
+  # defer_to_dynamic_agent_mode: on to force it on, or off to disable it.
   defer_to_dynamic_agent_mode: auto # off|on|auto
   defer_to_dynamic_agent_threshold_chars: 4000
   # Optional: keep a small set of tools directly callable by the parent agent.

--- a/openclaw/README.zh_CN.md
+++ b/openclaw/README.zh_CN.md
@@ -273,8 +273,8 @@ tools:
   # 不设置时使用内置默认值，设为 "" 可禁用它。
   openclaw_tooling_guidance: ""
   # 可选：当直接工具面超过 auto 阈值时，先只向父模型暴露轻量
-  # tool_search + dynamic_agent 入口。设置 defer_to_dynamic_agent: true
-  # 可以强制开启。
+  # tool_search + dynamic_agent 入口。默认模式为 auto；设置
+  # defer_to_dynamic_agent_mode: on 可强制开启，设置 off 可关闭。
   defer_to_dynamic_agent_mode: auto # off|on|auto
   defer_to_dynamic_agent_threshold_chars: 4000
   # 可选：保留少量父 agent 可直接调用的工具。

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -2419,6 +2419,11 @@ func validateAgentRunOptions(agentType string, opts runOptions) error {
 	if opts.DeferToolSurface {
 		deferMode = deferToolSurfaceModeOn
 	}
+	if deferMode == deferToolSurfaceModeAuto &&
+		!opts.deferToolSurfaceModeExplicit &&
+		!opts.DeferToolSurface {
+		deferMode = deferToolSurfaceModeOff
+	}
 	if deferMode != deferToolSurfaceModeOff {
 		return errors.New(
 			"claude-code agent does not support defer-tools-to-dynamic-agent",

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -3347,6 +3347,22 @@ func TestValidateAgentRunOptions(t *testing.T) {
 			agentType: agentTypeClaudeCode,
 		},
 		{
+			name:      "claude default defer auto ok",
+			agentType: agentTypeClaudeCode,
+			opts: runOptions{
+				DeferToolSurfaceMode: deferToolSurfaceModeAuto,
+			},
+		},
+		{
+			name:      "claude explicit defer auto",
+			agentType: agentTypeClaudeCode,
+			opts: runOptions{
+				DeferToolSurfaceMode:         deferToolSurfaceModeAuto,
+				deferToolSurfaceModeExplicit: true,
+			},
+			wantErr: true,
+		},
+		{
 			name:      "claude ralph loop",
 			agentType: agentTypeClaudeCode,
 			opts: runOptions{

--- a/openclaw/app/run_options.go
+++ b/openclaw/app/run_options.go
@@ -285,7 +285,8 @@ type runOptions struct {
 	DeferToolSurfaceChars  int
 	DeferToolSurfaceDirect string
 
-	enableOpenClawToolsExplicit bool
+	enableOpenClawToolsExplicit  bool
+	deferToolSurfaceModeExplicit bool
 
 	ToolProviders []pluginSpec
 	ToolSets      []pluginSpec
@@ -326,6 +327,8 @@ func parseRunOptions(args []string) (runOptions, error) {
 		SessionSummaryPolicy: summaryPolicyAny,
 
 		MemoryAutoPolicy: summaryPolicyAny,
+
+		DeferToolSurfaceMode: deferToolSurfaceModeAuto,
 	}
 
 	fs.StringVar(
@@ -900,7 +903,7 @@ func parseRunOptions(args []string) (runOptions, error) {
 	fs.StringVar(
 		&opts.DeferToolSurfaceMode,
 		flagDeferToolSurfaceMode,
-		"",
+		deferToolSurfaceModeAuto,
 		"Deferred tool surface mode: off, on, auto",
 	)
 	fs.IntVar(
@@ -936,6 +939,15 @@ func parseRunOptions(args []string) (runOptions, error) {
 		setFlags,
 		"enable-openclaw-tools",
 	)
+	opts.deferToolSurfaceModeExplicit = flagWasSet(
+		setFlags,
+		flagDeferToolSurfaceMode,
+	)
+	if flagWasSet(setFlags, flagDeferToolSurface) &&
+		!opts.DeferToolSurface &&
+		!flagWasSet(setFlags, flagDeferToolSurfaceMode) {
+		opts.DeferToolSurfaceMode = deferToolSurfaceModeOff
+	}
 
 	cfgPath := resolveConfigPath(opts.ConfigPath)
 	if cfgPath == "" {
@@ -1910,12 +1922,20 @@ func (cfg *fileConfig) apply(
 			opts.RefreshToolSetsOnRun = *cfg.Tools.RefreshToolSetsOnRun
 		}
 		if !flagWasSet(set, flagDeferToolSurface) {
+			deferConfigured := false
 			if cfg.Tools.DeferToDynamicAgent != nil {
+				deferConfigured = true
 				opts.DeferToolSurface = *cfg.Tools.DeferToDynamicAgent
 			}
 			if cfg.Tools.DeferToDynamicAgentCamel != nil {
+				deferConfigured = true
 				opts.DeferToolSurface =
 					*cfg.Tools.DeferToDynamicAgentCamel
+			}
+			if deferConfigured &&
+				!opts.DeferToolSurface &&
+				!flagWasSet(set, flagDeferToolSurfaceMode) {
+				opts.DeferToolSurfaceMode = deferToolSurfaceModeOff
 			}
 		}
 		deferMode := firstStringPtr(
@@ -1927,6 +1947,7 @@ func (cfg *fileConfig) apply(
 			!flagWasSet(set, flagDeferToolSurfaceMode) {
 			opts.DeferToolSurface = false
 			opts.DeferToolSurfaceMode = *deferMode
+			opts.deferToolSurfaceModeExplicit = true
 		}
 		deferChars := firstIntPtr(
 			cfg.Tools.DeferToDynamicAgentChars,

--- a/openclaw/app/run_options_test.go
+++ b/openclaw/app/run_options_test.go
@@ -1171,8 +1171,59 @@ tools:
 	require.NoError(t, err)
 	require.False(t, opts.DeferToolSurface)
 	require.Equal(t, deferToolSurfaceModeAuto, opts.DeferToolSurfaceMode)
+	require.True(t, opts.deferToolSurfaceModeExplicit)
 	require.Equal(t, 1234, opts.DeferToolSurfaceChars)
 	require.Equal(t, "exec_command,message", opts.DeferToolSurfaceDirect)
+}
+
+func TestParseRunOptions_DeferToolSurfaceDefaultsToAuto(t *testing.T) {
+	t.Parallel()
+
+	cfgPath := writeTempConfig(t, `
+tools:
+  enable_parallel_tools: true
+`)
+	opts, err := parseRunOptions([]string{"-config", cfgPath})
+	require.NoError(t, err)
+	require.False(t, opts.DeferToolSurface)
+	require.Equal(t, deferToolSurfaceModeAuto, opts.DeferToolSurfaceMode)
+	require.False(t, opts.deferToolSurfaceModeExplicit)
+}
+
+func TestParseRunOptions_DeferToolSurfaceFalseDisablesAuto(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	cfgPath := writeTempConfig(t, `
+tools:
+  defer_to_dynamic_agent: false
+`)
+	opts, err := parseRunOptions([]string{"-config", cfgPath})
+	require.NoError(t, err)
+	require.False(t, opts.DeferToolSurface)
+	require.Equal(t, deferToolSurfaceModeOff, opts.DeferToolSurfaceMode)
+	require.False(t, opts.deferToolSurfaceModeExplicit)
+}
+
+func TestParseRunOptions_DeferToolSurfaceFlagFalseDisablesAuto(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	cfgPath := writeTempConfig(t, `
+tools:
+  enable_parallel_tools: true
+`)
+	opts, err := parseRunOptions([]string{
+		"-config",
+		cfgPath,
+		"--defer-tools-to-dynamic-agent=false",
+	})
+	require.NoError(t, err)
+	require.False(t, opts.DeferToolSurface)
+	require.Equal(t, deferToolSurfaceModeOff, opts.DeferToolSurfaceMode)
+	require.False(t, opts.deferToolSurfaceModeExplicit)
 }
 
 func TestParseRunOptions_DeferDirectToolsStringConfig(t *testing.T) {

--- a/openclaw/openclaw.yaml
+++ b/openclaw/openclaw.yaml
@@ -40,7 +40,8 @@ tools:
   enable_parallel_tools: true
   # Optional: expose compact tool_search + dynamic_agent entrypoints
   # when direct tool declarations exceed the auto threshold.
-  # Set defer_to_dynamic_agent: true to force deferred mode on.
+  # Default mode is auto. Set defer_to_dynamic_agent_mode: on to force
+  # it on, or defer_to_dynamic_agent_mode: off to disable it.
   # defer_to_dynamic_agent_mode: auto # off|on|auto
   # defer_to_dynamic_agent_threshold_chars: 4000
   # defer_direct_tools: ["exec_command"]


### PR DESCRIPTION
## Summary

- Default OpenClaw LLM agents to `tools.defer_to_dynamic_agent_mode: auto`, so existing configs can automatically use the deferred tool-surface optimization when their direct tool declarations exceed the threshold.
- Preserve explicit opt-out through `tools.defer_to_dynamic_agent: false` or `tools.defer_to_dynamic_agent_mode: off`.
- Keep `claude-code` on its previous default behavior unless an unsupported defer mode is explicitly requested.
- Update OpenClaw docs and sample config to describe the default and opt-out behavior.

## Validation

- `git diff --check origin/main...HEAD`
- `cd openclaw && go test ./app -run 'DeferToolSurface|ValidateAgentRunOptions|ClaudeCode' -count=1`
- `cd openclaw && go test ./...`
- PR checks: 160/160 successful, including `test@PULL_REQUEST` and CodeRabbit with no new actionable comments.