### PR TITLE
llmagent: add tool transcript history mode

### DIFF
--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -428,6 +428,7 @@ func buildRequestProcessorsWithAgent(a *LLMAgent, options *Options) []flow.Reque
 		processor.WithAddSessionSummary(options.AddSessionSummary),
 		processor.WithSessionSummaryInjectionMode(options.SessionSummaryInjectionMode),
 		processor.WithMaxHistoryRuns(options.MaxHistoryRuns),
+		processor.WithToolTranscriptMode(options.ToolTranscriptMode),
 		processor.WithEnableContextCompaction(options.EnableContextCompaction),
 		processor.WithContextCompactionKeepRecentRequests(
 			options.ContextCompactionKeepRecentRequests,

--- a/agent/llmagent/llm_agent_test.go
+++ b/agent/llmagent/llm_agent_test.go
@@ -346,6 +346,21 @@ func TestBuildRequestProcessors_MaxHistoryRunsWiring(t *testing.T) {
 	require.Equal(t, 0, crp.MaxHistoryRuns)
 }
 
+func TestBuildRequestProcessors_ToolTranscriptModeWiring(t *testing.T) {
+	opts := &Options{}
+	WithToolTranscriptMode(ToolTranscriptModeOmitPreviousCompleted)(opts)
+
+	procs := buildRequestProcessors("test-agent", opts)
+	var crp *processor.ContentRequestProcessor
+	for _, p := range procs {
+		if v, ok := p.(*processor.ContentRequestProcessor); ok {
+			crp = v
+		}
+	}
+	require.NotNil(t, crp)
+	require.Equal(t, processor.ToolTranscriptModeOmitPreviousCompleted, crp.ToolTranscriptMode)
+}
+
 func TestBuildRequestProcessors_ContextCompactionWiring(t *testing.T) {
 	opts := &Options{}
 	WithEnableContextCompaction(true)(opts)

--- a/agent/llmagent/option.go
+++ b/agent/llmagent/option.go
@@ -69,6 +69,14 @@ const (
 	// Use this for maximum bandwidth savings when reasoning history is not needed.
 	ReasoningContentModeDiscardAll = processor.ReasoningContentModeDiscardAll
 
+	// ToolTranscriptModeKeepAll keeps all historical tool-call/tool-result
+	// transcripts in model requests.
+	ToolTranscriptModeKeepAll = processor.ToolTranscriptModeKeepAll
+	// ToolTranscriptModeOmitPreviousCompleted omits completed historical
+	// tool-call/tool-result pairs from previous requests when projecting session
+	// history into model requests.
+	ToolTranscriptModeOmitPreviousCompleted = processor.ToolTranscriptModeOmitPreviousCompleted
+
 	// SkillLoadModeOnce injects loaded skill content for the next model
 	// request, then offloads it from session state.
 	SkillLoadModeOnce = processor.SkillLoadModeOnce
@@ -112,6 +120,10 @@ type PreloadMemoryInjectionMode = processor.PreloadMemoryInjectionMode
 // PreloadSessionRecallInjectionMode controls where recalled session events are
 // injected.
 type PreloadSessionRecallInjectionMode = processor.PreloadSessionRecallInjectionMode
+
+// ToolTranscriptMode controls how historical tool-call/tool-result transcripts
+// are projected into model requests.
+type ToolTranscriptMode = processor.ToolTranscriptMode
 
 // MessageFilterMode is the mode for filtering messages.
 type MessageFilterMode int
@@ -191,6 +203,7 @@ var (
 
 		SkipSkillsFallbackOnSessionSummary: true,
 
+		ToolTranscriptMode:                   processor.ToolTranscriptModeKeepAll,
 		EnableContextCompaction:              false,
 		ContextCompactionThresholdRatio:      0.7,
 		ContextCompactionToolResultMaxTokens: processor.DefaultContextCompactionToolResultMaxTokens,
@@ -352,6 +365,9 @@ type Options struct {
 	// MaxHistoryRuns sets the maximum number of history messages when AddSessionSummary is false.
 	// When 0 (default), no limit is applied.
 	MaxHistoryRuns int
+	// ToolTranscriptMode controls how historical tool-call/tool-result
+	// transcripts are projected into model requests. Default is keep_all.
+	ToolTranscriptMode processor.ToolTranscriptMode
 	// EnableContextCompaction enables prompt-side context compaction.
 	// Historical oversized tool results can be compacted during request
 	// projection even when AddSessionSummary is false. When AddSessionSummary
@@ -1640,6 +1656,14 @@ func WithSyncSummaryIntraRun(enable bool) Option {
 func WithMaxHistoryRuns(maxRuns int) Option {
 	return func(opts *Options) {
 		opts.MaxHistoryRuns = maxRuns
+	}
+}
+
+// WithToolTranscriptMode sets how historical tool-call/tool-result transcripts
+// are projected into model requests.
+func WithToolTranscriptMode(mode ToolTranscriptMode) Option {
+	return func(opts *Options) {
+		opts.ToolTranscriptMode = processor.ToolTranscriptMode(mode)
 	}
 }
 

--- a/docs/mkdocs/en/agent.md
+++ b/docs/mkdocs/en/agent.md
@@ -371,6 +371,63 @@ agent := llmagent.New(
 
 **Note:** This option only affects how historical messages are processed before sending to the model. The current response's `reasoning_content` is always captured and stored in session events.
 
+### Tool Transcript History Mode
+
+By default, LLMAgent sends historical tool calls and their matching tool
+results back to the model on later requests. This is the most conservative
+behavior and preserves full compatibility, but long sessions with many completed
+tool rounds can spend unnecessary context on tool transcripts that the model no
+longer needs.
+
+LLMAgent provides `WithToolTranscriptMode` to control how completed historical
+tool-call/tool-result pairs are projected into model requests:
+
+| Mode | Constant | Description |
+|------|----------|-------------|
+| Keep All | `ToolTranscriptModeKeepAll` | Keep all historical tool-call/tool-result transcripts in model requests. **(Default)** |
+| Omit Previous Completed | `ToolTranscriptModeOmitPreviousCompleted` | Omit completed tool-call/tool-result pairs from previous requests while preserving active or incomplete tool rounds. |
+
+**Usage Example:**
+
+```go
+agent := llmagent.New(
+    "assistant",
+    llmagent.WithModel(modelInstance),
+    llmagent.WithInstruction("You are a helpful assistant."),
+    // Reduce prompt size by omitting completed tool transcripts from previous requests.
+    llmagent.WithToolTranscriptMode(llmagent.ToolTranscriptModeOmitPreviousCompleted),
+)
+```
+
+**How It Works:**
+
+- **`keep_all`**: All historical tool calls and tool results are preserved in
+  model requests.
+- **`omit_previous_completed`**: When building the message list for a new
+  request, completed tool-call/tool-result pairs from previous requests are
+  omitted from the projected history.
+
+The omit mode is intentionally conservative:
+
+- Current-request tool loops are preserved, so the model can still see the tool
+  calls it is actively resolving.
+- Incomplete historical tool calls are preserved because dropping them could
+  produce an invalid tool-call transcript.
+- Assistant text attached to an omitted tool-call event is retained; only the
+  tool calls and matching tool results are removed.
+- Session events are not deleted. The mode only changes what is sent to the
+  model request.
+
+Use `ToolTranscriptModeOmitPreviousCompleted` when completed historical tool
+transcripts are no longer needed by the model and prompt size matters. Keep the
+default `ToolTranscriptModeKeepAll` if later answers must inspect previous raw
+tool calls or tool results exactly.
+
+This option is different from context compaction: tool transcript mode can omit
+whole completed historical tool-call/tool-result pairs from request projection,
+while context compaction keeps the tool result message shape and only shrinks
+large tool-result content.
+
 ### Delegation Visibility Options
 
 When building multi‑Agent systems (task delegation between Agents), LLMAgent provides a unified fallback option for delegation events. Transfer events always include announcement text and are tagged `transfer` so UIs (User Interfaces) can filter them if desired.

--- a/docs/mkdocs/zh/agent.md
+++ b/docs/mkdocs/zh/agent.md
@@ -349,6 +349,45 @@ agent := llmagent.New(
 
 **注意：** 此选项仅影响发送给模型之前对历史消息的处理方式。当前响应的 `reasoning_content` 始终会被捕获并存储在会话事件中。
 
+### 工具调用记录历史模式
+
+默认情况下，LLMAgent 会在后续请求中继续把历史工具调用及其对应工具结果发送给模型。这是最保守、兼容性最强的行为；但在包含大量已完成工具调用轮次的长会话中，这些历史 tool transcript 可能会占用不必要的上下文。
+
+LLMAgent 提供 `WithToolTranscriptMode` 来控制已完成历史工具调用/工具结果对在模型请求中的投影方式：
+
+| 模式 | 常量 | 描述 |
+|------|------|------|
+| 保留全部 | `ToolTranscriptModeKeepAll` | 在模型请求中保留所有历史工具调用和工具结果记录。**（默认）** |
+| 省略之前已完成记录 | `ToolTranscriptModeOmitPreviousCompleted` | 省略之前请求中已完成的工具调用/工具结果对，同时保留当前请求或未完成的工具轮次。 |
+
+**使用示例：**
+
+```go
+agent := llmagent.New(
+    "assistant",
+    llmagent.WithModel(modelInstance),
+    llmagent.WithInstruction("You are a helpful assistant."),
+    // 省略之前请求中已完成的工具调用记录，降低 prompt 大小。
+    llmagent.WithToolTranscriptMode(llmagent.ToolTranscriptModeOmitPreviousCompleted),
+)
+```
+
+**工作原理：**
+
+- **`keep_all`**：所有历史工具调用和工具结果都会保留在模型请求中。
+- **`omit_previous_completed`**：构建新请求的消息列表时，之前请求中已经完整闭环的工具调用/工具结果对会从投影出的历史消息中省略。
+
+省略模式会保守处理以下情况：
+
+- 当前请求内的工具调用循环会保留，确保模型仍能看到正在处理的工具调用。
+- 未完成的历史工具调用会保留，避免生成无效的 tool-call transcript。
+- 如果被省略的工具调用事件里带有普通 assistant 文本，这部分文本会保留；只移除工具调用及其匹配的工具结果。
+- session event 不会被删除。该模式只影响发送给模型请求的消息投影。
+
+当历史中已完成的工具调用记录不再需要被模型逐字读取、且希望降低 prompt 大小时，可以启用 `ToolTranscriptModeOmitPreviousCompleted`。如果后续回答仍需要精确查看之前的原始工具调用或工具结果，请保留默认的 `ToolTranscriptModeKeepAll`。
+
+它和 context compaction 不同：tool transcript mode 可以在请求投影中省略完整的历史工具调用/工具结果对；context compaction 则保留 tool result 消息形态，只压缩较大的工具结果内容。
+
 ### 委托可见性选项
 
 在构建多 Agent（智能体）系统（Agent 之间的任务委托）时，LLMAgent 提供“默认占位消息”的统一配置。转移（transfer）事件始终包含提示文本，并统一打上 `transfer` 标签，前端（UI, User Interface）可按标签过滤。

--- a/internal/flow/processor/content.go
+++ b/internal/flow/processor/content.go
@@ -131,6 +131,22 @@ const (
 	ReasoningContentModeDiscardAll = "discard_all"
 )
 
+// ToolTranscriptMode controls how historical tool-call/tool-result transcripts
+// are projected into model requests.
+type ToolTranscriptMode string
+
+const (
+	// ToolTranscriptModeKeepAll keeps all historical tool-call/tool-result
+	// transcripts in model requests.
+	ToolTranscriptModeKeepAll ToolTranscriptMode = "keep_all"
+
+	// ToolTranscriptModeOmitPreviousCompleted omits completed historical
+	// tool-call/tool-result pairs from previous requests when projecting session
+	// history into model requests. Current-request and incomplete tool rounds are
+	// preserved to keep active tool loops valid.
+	ToolTranscriptModeOmitPreviousCompleted ToolTranscriptMode = "omit_previous_completed"
+)
+
 // ContentRequestProcessor implements content processing logic for agent requests.
 type ContentRequestProcessor struct {
 	// BranchFilterMode determines how to include content from session events.
@@ -165,6 +181,10 @@ type ContentRequestProcessor struct {
 	// keeps reasoning needed for tool-call replay while dropping ordinary older
 	// reasoning history.
 	ReasoningContentMode string
+	// ToolTranscriptMode controls how historical tool-call/tool-result
+	// transcripts are projected into model requests. Default is
+	// ToolTranscriptModeKeepAll.
+	ToolTranscriptMode ToolTranscriptMode
 	// PreloadMemory controls framework-side memory preload.
 	// When > 0, it acts as an adaptive preload budget:
 	//   - If total memories <= N, preload all memories.
@@ -320,6 +340,19 @@ func WithPreserveForeignMessages(preserve bool) ContentOption {
 func WithReasoningContentMode(mode string) ContentOption {
 	return func(p *ContentRequestProcessor) {
 		p.ReasoningContentMode = mode
+	}
+}
+
+// WithToolTranscriptMode sets how historical tool-call/tool-result transcripts
+// are projected into model requests.
+func WithToolTranscriptMode(mode ToolTranscriptMode) ContentOption {
+	return func(p *ContentRequestProcessor) {
+		switch mode {
+		case ToolTranscriptModeOmitPreviousCompleted:
+			p.ToolTranscriptMode = mode
+		default:
+			p.ToolTranscriptMode = ToolTranscriptModeKeepAll
+		}
 	}
 }
 
@@ -565,6 +598,8 @@ func NewContentRequestProcessor(opts ...ContentOption) *ContentRequestProcessor 
 		PreserveSameBranch: false,
 		// Default to append history message.
 		TimelineFilterMode: TimelineFilterAll,
+		// Default to preserving the full historical tool transcript.
+		ToolTranscriptMode: ToolTranscriptModeKeepAll,
 		// Default to disable memory preloading (use tools instead).
 		PreloadMemory:                     0,
 		PreloadMemoryInjectionMode:        PreloadMemoryInjectionSystem,
@@ -1235,6 +1270,7 @@ func (p *ContentRequestProcessor) getIncrementMessagesAfterCutoff(
 
 	resultEvents := p.rearrangeLatestFuncResp(events)
 	resultEvents = p.rearrangeAsyncFuncRespHist(resultEvents)
+	resultEvents = p.applyToolTranscriptMode(resultEvents, inv)
 	// Apply compaction to the already timeline-filtered projection. Tool-result
 	// policy (force-clean/keep) and historical passes must run for scoped modes
 	// such as request/invocation, not only when TimelineFilterAll is selected.
@@ -2479,6 +2515,182 @@ func (p *ContentRequestProcessor) convertForeignEvent(evt *event.Event) event.Ev
 		}
 	}
 	return *convertedEvent
+}
+
+func (p *ContentRequestProcessor) applyToolTranscriptMode(
+	events []event.Event,
+	inv *agent.Invocation,
+) []event.Event {
+	if p == nil || p.ToolTranscriptMode != ToolTranscriptModeOmitPreviousCompleted {
+		return events
+	}
+
+	responseMatchesByCallEvent := toolResponseMatchesByCallEvent(events)
+	if len(responseMatchesByCallEvent) == 0 {
+		return events
+	}
+
+	dropCallEvents := make(map[int]struct{})
+	dropResultChoices := make(map[int]map[int]struct{})
+	for callEventIndex, responseMatches := range responseMatchesByCallEvent {
+		if callEventIndex < 0 || callEventIndex >= len(events) {
+			continue
+		}
+		if !isPreviousToolTranscriptEvent(events[callEventIndex], inv) {
+			continue
+		}
+		if !allMatchedToolResultsArePrevious(events, responseMatches, inv) {
+			continue
+		}
+		if !allToolCallIDsMatched(
+			events[callEventIndex].GetToolCallIDs(),
+			events,
+			responseMatches,
+		) {
+			continue
+		}
+		dropCallEvents[callEventIndex] = struct{}{}
+		for _, match := range responseMatches {
+			if dropResultChoices[match.eventIndex] == nil {
+				dropResultChoices[match.eventIndex] = make(map[int]struct{})
+			}
+			for _, choiceIndex := range match.choiceIndices {
+				dropResultChoices[match.eventIndex][choiceIndex] = struct{}{}
+			}
+		}
+	}
+	if len(dropCallEvents) == 0 && len(dropResultChoices) == 0 {
+		return events
+	}
+
+	resultEvents := make([]event.Event, 0, len(events))
+	for i, evt := range events {
+		if _, drop := dropCallEvents[i]; drop {
+			if stripped, keep := stripToolCallsFromEvent(evt); keep {
+				resultEvents = append(resultEvents, stripped)
+			}
+			continue
+		}
+		if choices := dropResultChoices[i]; len(choices) > 0 {
+			if filtered, keep := omitToolResultChoices(evt, choices); keep {
+				resultEvents = append(resultEvents, filtered)
+			}
+			continue
+		}
+		resultEvents = append(resultEvents, evt)
+	}
+	return resultEvents
+}
+
+func isPreviousToolTranscriptEvent(evt event.Event, inv *agent.Invocation) bool {
+	if inv == nil {
+		return false
+	}
+	if inv.RunOptions.RequestID != "" && evt.RequestID == inv.RunOptions.RequestID {
+		return false
+	}
+	if inv.InvocationID != "" && evt.InvocationID == inv.InvocationID {
+		return false
+	}
+	return evt.RequestID != "" || evt.InvocationID != ""
+}
+
+func allMatchedToolResultsArePrevious(
+	events []event.Event,
+	matches []matchedToolResponseEvent,
+	inv *agent.Invocation,
+) bool {
+	if len(matches) == 0 {
+		return false
+	}
+	for _, match := range matches {
+		if match.eventIndex < 0 || match.eventIndex >= len(events) {
+			return false
+		}
+		if !isPreviousToolTranscriptEvent(events[match.eventIndex], inv) {
+			return false
+		}
+	}
+	return true
+}
+
+func allToolCallIDsMatched(
+	callIDs []string,
+	events []event.Event,
+	matches []matchedToolResponseEvent,
+) bool {
+	pendingCallIDs := make(map[string]struct{}, len(callIDs))
+	for _, callID := range callIDs {
+		if callID != "" {
+			pendingCallIDs[callID] = struct{}{}
+		}
+	}
+	if len(pendingCallIDs) == 0 {
+		return false
+	}
+	for _, match := range matches {
+		if match.eventIndex < 0 || match.eventIndex >= len(events) {
+			continue
+		}
+		evt := events[match.eventIndex]
+		if evt.Response == nil {
+			continue
+		}
+		for _, choiceIndex := range match.choiceIndices {
+			if choiceIndex < 0 || choiceIndex >= len(evt.Response.Choices) {
+				continue
+			}
+			responseID := toolResponseIDFromChoice(evt.Response.Choices[choiceIndex])
+			delete(pendingCallIDs, responseID)
+		}
+	}
+	return len(pendingCallIDs) == 0
+}
+
+func stripToolCallsFromEvent(evt event.Event) (event.Event, bool) {
+	if evt.Response == nil {
+		return evt, false
+	}
+	response := *evt.Response
+	response.Choices = make([]model.Choice, 0, len(evt.Response.Choices))
+	for _, choice := range evt.Response.Choices {
+		choice.Message.ToolCalls = nil
+		choice.Delta.ToolCalls = nil
+		if hasNonToolPayload(choice.Message) || hasNonToolPayload(choice.Delta) {
+			response.Choices = append(response.Choices, choice)
+		}
+	}
+	if len(response.Choices) == 0 {
+		return evt, false
+	}
+	evt.Response = &response
+	return evt, true
+}
+
+func omitToolResultChoices(
+	evt event.Event,
+	dropChoiceIndices map[int]struct{},
+) (event.Event, bool) {
+	if evt.Response == nil {
+		return evt, false
+	}
+	response := *evt.Response
+	response.Choices = make([]model.Choice, 0, len(evt.Response.Choices))
+	for choiceIndex, choice := range evt.Response.Choices {
+		if _, drop := dropChoiceIndices[choiceIndex]; drop {
+			continue
+		}
+		response.Choices = append(response.Choices, choice)
+	}
+	if len(response.Choices) == 0 {
+		return evt, false
+	}
+	evt.Response = &response
+	return evt, true
+}
+
+func hasNonToolPayload(msg model.Message) bool {
+	return msg.Content != "" || len(msg.ContentParts) > 0
 }
 
 // rearrangeEventsForLatestFunctionResponse rearranges the events for the latest function_response.

--- a/internal/flow/processor/content.go
+++ b/internal/flow/processor/content.go
@@ -1268,9 +1268,9 @@ func (p *ContentRequestProcessor) getIncrementMessagesAfterCutoff(
 		events = p.insertInvocationMessage(events, inv)
 	}
 
-	resultEvents := p.rearrangeLatestFuncResp(events)
+	resultEvents := p.applyToolTranscriptMode(events, inv)
+	resultEvents = p.rearrangeLatestFuncResp(resultEvents)
 	resultEvents = p.rearrangeAsyncFuncRespHist(resultEvents)
-	resultEvents = p.applyToolTranscriptMode(resultEvents, inv)
 	// Apply compaction to the already timeline-filtered projection. Tool-result
 	// policy (force-clean/keep) and historical passes must run for scoped modes
 	// such as request/invocation, not only when TimelineFilterAll is selected.
@@ -2586,8 +2586,13 @@ func isPreviousToolTranscriptEvent(evt event.Event, inv *agent.Invocation) bool 
 	if inv == nil {
 		return false
 	}
-	if inv.RunOptions.RequestID != "" && evt.RequestID == inv.RunOptions.RequestID {
-		return false
+	if inv.RunOptions.RequestID != "" {
+		if evt.RequestID == inv.RunOptions.RequestID {
+			return false
+		}
+		if evt.RequestID != "" {
+			return true
+		}
 	}
 	if inv.InvocationID != "" && evt.InvocationID == inv.InvocationID {
 		return false

--- a/internal/flow/processor/content_test.go
+++ b/internal/flow/processor/content_test.go
@@ -1670,6 +1670,7 @@ func TestNewContentRequestProcessor(t *testing.T) {
 		TimelineFilterMode:                "all",
 		AddSessionSummary:                 false,
 		MaxHistoryRuns:                    0,
+		ToolTranscriptMode:                ToolTranscriptModeKeepAll,
 		PreloadMemory:                     0, // Default to disable preloading.
 		PreloadMemoryInjectionMode:        PreloadMemoryInjectionSystem,
 		PreloadSessionRecallInjectionMode: PreloadSessionRecallInjectionSystem,
@@ -4319,6 +4320,276 @@ func TestContentRequestProcessor_getIncrementMessages_MixedToolContinuationPrese
 	require.Equal(t, "verified-by-caller", messages[3].Content)
 }
 
+func TestContentRequestProcessor_ToolTranscriptModeKeepAllByDefault(t *testing.T) {
+	sess := &session.Session{
+		EventMu: sync.RWMutex{},
+		Events: []event.Event{
+			toolTranscriptTestEvent("req1", "inv1", toolTranscriptTestCall("call_1", ""), ""),
+			toolTranscriptTestEvent(
+				"req1",
+				"inv1",
+				model.NewToolMessage("call_1", "lookup", "result"),
+				model.ObjectTypeToolResponse,
+			),
+		},
+	}
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationID("inv2"),
+		agent.WithInvocationRunOptions(agent.RunOptions{RequestID: "req2"}),
+	)
+	inv.AgentName = "test-agent"
+
+	messages := NewContentRequestProcessor().getIncrementMessages(inv, time.Time{})
+
+	require.Len(t, messages, 2)
+	require.Equal(t, model.RoleAssistant, messages[0].Role)
+	require.Len(t, messages[0].ToolCalls, 1)
+	require.Equal(t, model.RoleTool, messages[1].Role)
+	require.Equal(t, "call_1", messages[1].ToolID)
+}
+
+func TestContentRequestProcessor_ToolTranscriptModeOmitPreviousCompleted(t *testing.T) {
+	sess := &session.Session{
+		EventMu: sync.RWMutex{},
+		Events: []event.Event{
+			toolTranscriptTestEvent("req1", "inv1", toolTranscriptTestCall("call_1", ""), ""),
+			toolTranscriptTestEvent(
+				"req1",
+				"inv1",
+				model.NewToolMessage("call_1", "lookup", "result"),
+				model.ObjectTypeToolResponse,
+			),
+			toolTranscriptTestEvent(
+				"req1",
+				"inv1",
+				model.NewAssistantMessage("final answer"),
+				"",
+			),
+		},
+	}
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationID("inv2"),
+		agent.WithInvocationRunOptions(agent.RunOptions{RequestID: "req2"}),
+	)
+	inv.AgentName = "test-agent"
+
+	messages := NewContentRequestProcessor(
+		WithToolTranscriptMode(ToolTranscriptModeOmitPreviousCompleted),
+	).getIncrementMessages(inv, time.Time{})
+
+	require.Len(t, messages, 1)
+	require.Equal(t, model.RoleAssistant, messages[0].Role)
+	require.Equal(t, "final answer", messages[0].Content)
+	require.Empty(t, messages[0].ToolCalls)
+}
+
+func TestContentRequestProcessor_ToolTranscriptModeKeepsCurrentRequest(t *testing.T) {
+	sess := &session.Session{
+		EventMu: sync.RWMutex{},
+		Events: []event.Event{
+			toolTranscriptTestEvent("req2", "inv2", toolTranscriptTestCall("call_1", ""), ""),
+			toolTranscriptTestEvent(
+				"req2",
+				"inv2",
+				model.NewToolMessage("call_1", "lookup", "result"),
+				model.ObjectTypeToolResponse,
+			),
+		},
+	}
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationID("inv2"),
+		agent.WithInvocationRunOptions(agent.RunOptions{RequestID: "req2"}),
+	)
+	inv.AgentName = "test-agent"
+
+	messages := NewContentRequestProcessor(
+		WithToolTranscriptMode(ToolTranscriptModeOmitPreviousCompleted),
+	).getIncrementMessages(inv, time.Time{})
+
+	require.Len(t, messages, 2)
+	require.Equal(t, model.RoleAssistant, messages[0].Role)
+	require.Len(t, messages[0].ToolCalls, 1)
+	require.Equal(t, model.RoleTool, messages[1].Role)
+	require.Equal(t, "call_1", messages[1].ToolID)
+}
+
+func TestContentRequestProcessor_ToolTranscriptModeKeepsIncompletePreviousCall(t *testing.T) {
+	sess := &session.Session{
+		EventMu: sync.RWMutex{},
+		Events: []event.Event{
+			toolTranscriptTestEvent("req1", "inv1", toolTranscriptTestCall("call_1", ""), ""),
+		},
+	}
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationID("inv2"),
+		agent.WithInvocationRunOptions(agent.RunOptions{RequestID: "req2"}),
+	)
+	inv.AgentName = "test-agent"
+
+	messages := NewContentRequestProcessor(
+		WithToolTranscriptMode(ToolTranscriptModeOmitPreviousCompleted),
+	).getIncrementMessages(inv, time.Time{})
+
+	require.Len(t, messages, 1)
+	require.Equal(t, model.RoleAssistant, messages[0].Role)
+	require.Len(t, messages[0].ToolCalls, 1)
+	require.Equal(t, "call_1", messages[0].ToolCalls[0].ID)
+}
+
+func TestContentRequestProcessor_ToolTranscriptModeKeepsPartiallyCompletedPreviousCall(t *testing.T) {
+	toolCallMsg := model.Message{
+		Role: model.RoleAssistant,
+		ToolCalls: []model.ToolCall{
+			{
+				Type: "function",
+				ID:   "call_1",
+				Function: model.FunctionDefinitionParam{
+					Name:      "lookup",
+					Arguments: []byte(`{"q":"first"}`),
+				},
+			},
+			{
+				Type: "function",
+				ID:   "call_2",
+				Function: model.FunctionDefinitionParam{
+					Name:      "lookup",
+					Arguments: []byte(`{"q":"second"}`),
+				},
+			},
+		},
+	}
+	sess := &session.Session{
+		EventMu: sync.RWMutex{},
+		Events: []event.Event{
+			toolTranscriptTestEvent("req1", "inv1", toolCallMsg, ""),
+			toolTranscriptTestEvent(
+				"req1",
+				"inv1",
+				model.NewToolMessage("call_1", "lookup", "first result"),
+				model.ObjectTypeToolResponse,
+			),
+		},
+	}
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationID("inv2"),
+		agent.WithInvocationRunOptions(agent.RunOptions{RequestID: "req2"}),
+	)
+	inv.AgentName = "test-agent"
+
+	messages := NewContentRequestProcessor(
+		WithToolTranscriptMode(ToolTranscriptModeOmitPreviousCompleted),
+	).getIncrementMessages(inv, time.Time{})
+
+	require.Len(t, messages, 2)
+	require.Equal(t, model.RoleAssistant, messages[0].Role)
+	require.Len(t, messages[0].ToolCalls, 2)
+	require.Equal(t, model.RoleTool, messages[1].Role)
+	require.Equal(t, "call_1", messages[1].ToolID)
+}
+
+func TestContentRequestProcessor_ToolTranscriptModeKeepsPreviousCallWithCurrentResult(t *testing.T) {
+	sess := &session.Session{
+		EventMu: sync.RWMutex{},
+		Events: []event.Event{
+			toolTranscriptTestEvent("req1", "inv1", toolTranscriptTestCall("call_1", ""), ""),
+			toolTranscriptTestEvent(
+				"req2",
+				"inv2",
+				model.NewToolMessage("call_1", "lookup", "current result"),
+				model.ObjectTypeToolResponse,
+			),
+		},
+	}
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationID("inv2"),
+		agent.WithInvocationRunOptions(agent.RunOptions{RequestID: "req2"}),
+	)
+	inv.AgentName = "test-agent"
+
+	messages := NewContentRequestProcessor(
+		WithToolTranscriptMode(ToolTranscriptModeOmitPreviousCompleted),
+	).getIncrementMessages(inv, time.Time{})
+
+	require.Len(t, messages, 2)
+	require.Equal(t, model.RoleAssistant, messages[0].Role)
+	require.Len(t, messages[0].ToolCalls, 1)
+	require.Equal(t, model.RoleTool, messages[1].Role)
+	require.Equal(t, "call_1", messages[1].ToolID)
+	require.Equal(t, "current result", messages[1].Content)
+}
+
+func TestContentRequestProcessor_ToolTranscriptModeKeepsAssistantText(t *testing.T) {
+	sess := &session.Session{
+		EventMu: sync.RWMutex{},
+		Events: []event.Event{
+			toolTranscriptTestEvent("req1", "inv1", toolTranscriptTestCall("call_1", "I will check."), ""),
+			toolTranscriptTestEvent(
+				"req1",
+				"inv1",
+				model.NewToolMessage("call_1", "lookup", "result"),
+				model.ObjectTypeToolResponse,
+			),
+		},
+	}
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationID("inv2"),
+		agent.WithInvocationRunOptions(agent.RunOptions{RequestID: "req2"}),
+	)
+	inv.AgentName = "test-agent"
+
+	messages := NewContentRequestProcessor(
+		WithToolTranscriptMode(ToolTranscriptModeOmitPreviousCompleted),
+	).getIncrementMessages(inv, time.Time{})
+
+	require.Len(t, messages, 1)
+	require.Equal(t, model.RoleAssistant, messages[0].Role)
+	require.Equal(t, "I will check.", messages[0].Content)
+	require.Empty(t, messages[0].ToolCalls)
+}
+
+func toolTranscriptTestCall(id string, content string) model.Message {
+	return model.Message{
+		Role:    model.RoleAssistant,
+		Content: content,
+		ToolCalls: []model.ToolCall{
+			{
+				Type: "function",
+				ID:   id,
+				Function: model.FunctionDefinitionParam{
+					Name:      "lookup",
+					Arguments: []byte(`{"q":"status"}`),
+				},
+			},
+		},
+	}
+}
+
+func toolTranscriptTestEvent(
+	requestID string,
+	invocationID string,
+	msg model.Message,
+	object string,
+) event.Event {
+	return event.Event{
+		Author:       "test-agent",
+		RequestID:    requestID,
+		InvocationID: invocationID,
+		Version:      event.CurrentVersion,
+		Response: &model.Response{
+			Done:    true,
+			Object:  object,
+			Choices: []model.Choice{{Index: 0, Message: msg}},
+		},
+	}
+}
+
 func TestInsertInvocationMessage(t *testing.T) {
 	createInvocation := func(id, requestID, content string) *agent.Invocation {
 		return &agent.Invocation{
@@ -5269,6 +5540,41 @@ func TestContentRequestProcessor_WithReasoningContentMode(t *testing.T) {
 			assert.Equal(t, tt.expectedMode, p.ReasoningContentMode,
 				"WithReasoningContentMode() mode = %v, want %v",
 				p.ReasoningContentMode, tt.expectedMode)
+		})
+	}
+}
+
+func TestContentRequestProcessor_WithToolTranscriptMode(t *testing.T) {
+	tests := []struct {
+		name         string
+		mode         ToolTranscriptMode
+		expectedMode ToolTranscriptMode
+	}{
+		{
+			name:         "set keep_all mode",
+			mode:         ToolTranscriptModeKeepAll,
+			expectedMode: ToolTranscriptModeKeepAll,
+		},
+		{
+			name:         "set omit_previous_completed mode",
+			mode:         ToolTranscriptModeOmitPreviousCompleted,
+			expectedMode: ToolTranscriptModeOmitPreviousCompleted,
+		},
+		{
+			name:         "unknown mode falls back to keep_all",
+			mode:         ToolTranscriptMode("unknown"),
+			expectedMode: ToolTranscriptModeKeepAll,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewContentRequestProcessor(
+				WithToolTranscriptMode(tt.mode),
+			)
+			assert.Equal(t, tt.expectedMode, p.ToolTranscriptMode,
+				"WithToolTranscriptMode() mode = %v, want %v",
+				p.ToolTranscriptMode, tt.expectedMode)
 		})
 	}
 }

--- a/internal/flow/processor/content_test.go
+++ b/internal/flow/processor/content_test.go
@@ -4652,6 +4652,85 @@ func TestContentRequestProcessor_ToolTranscriptModeKeepsAssistantText(t *testing
 	require.Empty(t, messages[0].ToolCalls)
 }
 
+func TestContentRequestProcessor_ToolTranscriptModeKeepsUnmatchedResultChoices(t *testing.T) {
+	resultEvent := toolTranscriptTestEvent(
+		"req1",
+		"inv1",
+		model.Message{},
+		model.ObjectTypeToolResponse,
+	)
+	resultEvent.Response.Choices = []model.Choice{
+		{Message: model.NewToolMessage("call_1", "lookup", "old result")},
+		{Message: model.NewToolMessage("call_extra", "lookup", "kept result")},
+	}
+	inv := agent.NewInvocation(
+		agent.WithInvocationID("inv2"),
+		agent.WithInvocationRunOptions(agent.RunOptions{RequestID: "req2"}),
+	)
+
+	events := NewContentRequestProcessor(
+		WithToolTranscriptMode(ToolTranscriptModeOmitPreviousCompleted),
+	).applyToolTranscriptMode([]event.Event{
+		toolTranscriptTestEvent("req1", "inv1", toolTranscriptTestCall("call_1", ""), ""),
+		resultEvent,
+	}, inv)
+
+	require.Len(t, events, 1)
+	require.Len(t, events[0].Response.Choices, 1)
+	require.Equal(t, "call_extra", events[0].Response.Choices[0].Message.ToolID)
+	require.Equal(t, "kept result", events[0].Response.Choices[0].Message.Content)
+}
+
+func TestContentRequestProcessor_ToolTranscriptModeHelperBranches(t *testing.T) {
+	inv := agent.NewInvocation(
+		agent.WithInvocationID("inv2"),
+		agent.WithInvocationRunOptions(agent.RunOptions{RequestID: "req2"}),
+	)
+
+	require.False(t, isPreviousToolTranscriptEvent(event.Event{RequestID: "req1"}, nil))
+	require.False(t, isPreviousToolTranscriptEvent(
+		event.Event{InvocationID: "inv2"},
+		agent.NewInvocation(agent.WithInvocationID("inv2")),
+	))
+	require.False(t, isPreviousToolTranscriptEvent(event.Event{}, &agent.Invocation{}))
+	require.True(t, isPreviousToolTranscriptEvent(
+		event.Event{InvocationID: "inv1"},
+		agent.NewInvocation(agent.WithInvocationID("inv2")),
+	))
+
+	require.False(t, allMatchedToolResultsArePrevious(nil, nil, inv))
+	require.False(t, allMatchedToolResultsArePrevious(
+		[]event.Event{{}},
+		[]matchedToolResponseEvent{{eventIndex: 1}},
+		inv,
+	))
+
+	require.False(t, allToolCallIDsMatched(nil, nil, nil))
+	require.False(t, allToolCallIDsMatched(
+		[]string{"call_1"},
+		[]event.Event{{}},
+		[]matchedToolResponseEvent{{eventIndex: 0, choiceIndices: []int{0}}},
+	))
+	require.False(t, allToolCallIDsMatched(
+		[]string{"call_1"},
+		[]event.Event{toolTranscriptTestEvent(
+			"req1",
+			"inv1",
+			model.NewToolMessage("call_1", "lookup", "result"),
+			model.ObjectTypeToolResponse,
+		)},
+		[]matchedToolResponseEvent{
+			{eventIndex: -1, choiceIndices: []int{0}},
+			{eventIndex: 0, choiceIndices: []int{42}},
+		},
+	))
+
+	_, keep := stripToolCallsFromEvent(event.Event{})
+	require.False(t, keep)
+	_, keep = omitToolResultChoices(event.Event{}, map[int]struct{}{})
+	require.False(t, keep)
+}
+
 func toolTranscriptTestCall(id string, content string) model.Message {
 	return model.Message{
 		Role:    model.RoleAssistant,

--- a/internal/flow/processor/content_test.go
+++ b/internal/flow/processor/content_test.go
@@ -4385,6 +4385,42 @@ func TestContentRequestProcessor_ToolTranscriptModeOmitPreviousCompleted(t *test
 	require.Empty(t, messages[0].ToolCalls)
 }
 
+func TestContentRequestProcessor_ToolTranscriptModeOmitsPreviousRequestInSameInvocation(t *testing.T) {
+	sess := &session.Session{
+		EventMu: sync.RWMutex{},
+		Events: []event.Event{
+			toolTranscriptTestEvent("req1", "inv2", toolTranscriptTestCall("call_1", ""), ""),
+			toolTranscriptTestEvent(
+				"req1",
+				"inv2",
+				model.NewToolMessage("call_1", "lookup", "result"),
+				model.ObjectTypeToolResponse,
+			),
+			toolTranscriptTestEvent(
+				"req1",
+				"inv2",
+				model.NewAssistantMessage("final answer"),
+				"",
+			),
+		},
+	}
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationID("inv2"),
+		agent.WithInvocationRunOptions(agent.RunOptions{RequestID: "req2"}),
+	)
+	inv.AgentName = "test-agent"
+
+	messages := NewContentRequestProcessor(
+		WithToolTranscriptMode(ToolTranscriptModeOmitPreviousCompleted),
+	).getIncrementMessages(inv, time.Time{})
+
+	require.Len(t, messages, 1)
+	require.Equal(t, model.RoleAssistant, messages[0].Role)
+	require.Equal(t, "final answer", messages[0].Content)
+	require.Empty(t, messages[0].ToolCalls)
+}
+
 func TestContentRequestProcessor_ToolTranscriptModeKeepsCurrentRequest(t *testing.T) {
 	sess := &session.Session{
 		EventMu: sync.RWMutex{},
@@ -4522,6 +4558,68 @@ func TestContentRequestProcessor_ToolTranscriptModeKeepsPreviousCallWithCurrentR
 	require.Equal(t, model.RoleTool, messages[1].Role)
 	require.Equal(t, "call_1", messages[1].ToolID)
 	require.Equal(t, "current result", messages[1].Content)
+}
+
+func TestContentRequestProcessor_ToolTranscriptModeKeepsMultiToolCallWithCurrentResult(t *testing.T) {
+	toolCallMsg := model.Message{
+		Role: model.RoleAssistant,
+		ToolCalls: []model.ToolCall{
+			{
+				Type: "function",
+				ID:   "call_1",
+				Function: model.FunctionDefinitionParam{
+					Name:      "lookup",
+					Arguments: []byte(`{"q":"old"}`),
+				},
+			},
+			{
+				Type: "function",
+				ID:   "call_2",
+				Function: model.FunctionDefinitionParam{
+					Name:      "lookup",
+					Arguments: []byte(`{"q":"current"}`),
+				},
+			},
+		},
+	}
+	sess := &session.Session{
+		EventMu: sync.RWMutex{},
+		Events: []event.Event{
+			toolTranscriptTestEvent("req1", "inv1", toolCallMsg, ""),
+			toolTranscriptTestEvent(
+				"req1",
+				"inv1",
+				model.NewToolMessage("call_1", "lookup", "old result"),
+				model.ObjectTypeToolResponse,
+			),
+			toolTranscriptTestEvent(
+				"req2",
+				"inv2",
+				model.NewToolMessage("call_2", "lookup", "current result"),
+				model.ObjectTypeToolResponse,
+			),
+		},
+	}
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationID("inv2"),
+		agent.WithInvocationRunOptions(agent.RunOptions{RequestID: "req2"}),
+	)
+	inv.AgentName = "test-agent"
+
+	messages := NewContentRequestProcessor(
+		WithToolTranscriptMode(ToolTranscriptModeOmitPreviousCompleted),
+	).getIncrementMessages(inv, time.Time{})
+
+	require.Len(t, messages, 3)
+	require.Equal(t, model.RoleAssistant, messages[0].Role)
+	require.Len(t, messages[0].ToolCalls, 2)
+	require.Equal(t, model.RoleTool, messages[1].Role)
+	require.Equal(t, "call_1", messages[1].ToolID)
+	require.Equal(t, "old result", messages[1].Content)
+	require.Equal(t, model.RoleTool, messages[2].Role)
+	require.Equal(t, "call_2", messages[2].ToolID)
+	require.Equal(t, "current result", messages[2].Content)
 }
 
 func TestContentRequestProcessor_ToolTranscriptModeKeepsAssistantText(t *testing.T) {


### PR DESCRIPTION
## Summary

- add `ToolTranscriptModeKeepAll` and `ToolTranscriptModeOmitPreviousCompleted`
- omit completed previous-request tool call/result transcripts during history projection when explicitly enabled
- preserve current request tool loops, incomplete historical tool calls, and assistant text attached to omitted tool calls

## Validation

- `go test ./internal/flow/processor ./internal/flow/llmflow ./agent/llmagent ./model/openai`
- `go test ./...` was also run; it failed outside this change in `codeexecutor/sandbox` on a symlink path expectation and in `tool/hostexec` because Darwin does not provide `syscall.SysProcAttr.Pdeathsig`
- ran a `gpt-5.2` sanity review through the configured OpenAI-compatible endpoint and added coverage for the partial multi-tool and current-result edge cases it highlighted
