### PR TITLE
Add Requesty (OpenAI-compatible) support

### DIFF
--- a/docs/mkdocs/en/model.md
+++ b/docs/mkdocs/en/model.md
@@ -312,7 +312,15 @@ prefer the explicit DeepSeek v4 model names for new code.
 - Base URL: `https://api.hunyuan.cloud.tencent.com/v1`
 - Model Names: `hunyuan-2.0-thinking-20251109`, `hunyuan-2.0-instruct-20251111`, etc.
 
-**4. Other Providers**
+**4. Requesty**
+
+- Base URL: `https://router.requesty.ai/v1`
+- Auth: bearer key from `REQUESTY_API_KEY`
+- Model Names: `provider/model`, e.g. `openai/gpt-4o-mini` (browse models at <https://app.requesty.ai/router/list>)
+
+See the runnable example in `examples/model/requesty`.
+
+**5. Other Providers**
 
 - **Qwen**: Base URL `https://dashscope.aliyuncs.com/compatible-mode/v1`, Model Names: various qwen models
 

--- a/docs/mkdocs/zh/model.md
+++ b/docs/mkdocs/zh/model.md
@@ -309,7 +309,15 @@ type CompletionTokensDetails struct {
 - 基础 URL：`https://api.hunyuan.cloud.tencent.com/v1`
 - 模型名称：`hunyuan-2.0-thinking-20251109`、`hunyuan-2.0-instruct-20251111` 等
 
-**4. 其他提供商**
+**4. Requesty**
+
+- 基础 URL：`https://router.requesty.ai/v1`
+- 鉴权：通过 `REQUESTY_API_KEY` 传入 bearer key
+- 模型名称：`provider/model`，例如 `openai/gpt-4o-mini`（可在 <https://app.requesty.ai/router/list> 浏览可用模型）
+
+可运行示例见 `examples/model/requesty`。
+
+**5. 其他提供商**
 
 - **Qwen**：基础 URL `https://dashscope.aliyuncs.com/compatible-mode/v1`，模型名称：各种 Qwen 模型
 

--- a/examples/model/README.md
+++ b/examples/model/README.md
@@ -13,6 +13,7 @@ The example shows how to use the OpenAI-like model implementation with automatic
 See also the focused sub-examples in this directory:
 
 - `retry/` for SDK-level retry configuration.
+- `requesty/` for using the OpenAI-compatible Requesty router (`https://router.requesty.ai/v1`).
 - `switch/` for runtime model switching.
 - `selector/` for per-LLM-call model selection with `runner.Run`.
 - `failover/` for primary/backup model failover before the first non-error chunk.

--- a/examples/model/requesty/README.md
+++ b/examples/model/requesty/README.md
@@ -42,6 +42,8 @@ base URL and API key:
 
 ```go
 import (
+    "os"
+
     "trpc.group/trpc-go/trpc-agent-go/model"
     "trpc.group/trpc-go/trpc-agent-go/model/openai"
 )

--- a/examples/model/requesty/README.md
+++ b/examples/model/requesty/README.md
@@ -44,7 +44,6 @@ base URL and API key:
 import (
     "os"
 
-    "trpc.group/trpc-go/trpc-agent-go/model"
     "trpc.group/trpc-go/trpc-agent-go/model/openai"
 )
 

--- a/examples/model/requesty/README.md
+++ b/examples/model/requesty/README.md
@@ -1,0 +1,89 @@
+# Requesty Example
+
+This example demonstrates how to use the OpenAI-compatible model implementation
+with the [Requesty](https://requesty.ai) router. Requesty exposes an
+OpenAI-compatible Chat Completions API, so it works with the existing
+`model/openai` client by pointing the base URL at the Requesty router and
+supplying a Requesty API key.
+
+## Overview
+
+Requesty is an OpenAI-compatible LLM router. Because the framework already
+drives any OpenAI-compatible endpoint, no new provider code is required: you
+create an `openai.Model` and override the base URL and API key.
+
+- Base URL: `https://router.requesty.ai/v1`
+- Auth: bearer key from the `REQUESTY_API_KEY` environment variable
+- Model naming: `provider/model`, e.g. `openai/gpt-4o-mini`
+
+## Prerequisites
+
+- Go installed and the project dependencies available.
+- A Requesty API key. Create one at <https://app.requesty.ai/api-keys>.
+- Browse available models at <https://app.requesty.ai/router/list>.
+
+## Environment Variables
+
+| Variable           | Description                                      | Default |
+| ------------------ | ------------------------------------------------ | ------- |
+| `REQUESTY_API_KEY` | API key for the Requesty router (required)       | ``      |
+
+## Command Line Arguments
+
+| Argument     | Description                          | Default Value             |
+| ------------ | ------------------------------------ | ------------------------- |
+| `-model`     | Name of the model to use             | `openai/gpt-4o-mini`      |
+| `-base-url`  | Requesty router base URL             | `https://router.requesty.ai/v1` |
+
+## How It Works
+
+The example creates an OpenAI-compatible model instance and explicitly sets the
+base URL and API key:
+
+```go
+import (
+    "trpc.group/trpc-go/trpc-agent-go/model"
+    "trpc.group/trpc-go/trpc-agent-go/model/openai"
+)
+
+llm := openai.New("openai/gpt-4o-mini",
+    openai.WithBaseURL("https://router.requesty.ai/v1"),
+    openai.WithAPIKey(os.Getenv("REQUESTY_API_KEY")),
+)
+```
+
+Alternatively, you can rely on the OpenAI SDK environment variables instead of
+the explicit options:
+
+```bash
+export OPENAI_API_KEY="$REQUESTY_API_KEY"
+export OPENAI_BASE_URL="https://router.requesty.ai/v1"
+```
+
+## Running the Example
+
+```bash
+export REQUESTY_API_KEY="your-requesty-key"
+
+cd examples/model/requesty
+go run main.go
+```
+
+### Using a custom model:
+
+```bash
+cd examples/model/requesty
+go run main.go -model openai/gpt-4o
+```
+
+## Example Output
+
+The example runs two demonstrations:
+
+1. **🔄 Non-streaming Example**: basic request/response with token usage.
+2. **🌊 Streaming Example**: streaming response handling.
+
+## Security Notes
+
+- Never commit API keys to version control.
+- Use environment variables or secure configuration management.

--- a/examples/model/requesty/main.go
+++ b/examples/model/requesty/main.go
@@ -1,0 +1,172 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+// Package main demonstrates how to use the OpenAI-compatible model with the
+// Requesty router (https://router.requesty.ai/v1).
+//
+// Requesty exposes an OpenAI-compatible Chat Completions API, so it works with
+// the existing model/openai client by pointing the base URL at the Requesty
+// router and supplying a Requesty API key. Models are addressed with the
+// provider/model naming convention, e.g. "openai/gpt-4o-mini".
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/model/openai"
+)
+
+// defaultRequestyBaseURL is the OpenAI-compatible Requesty router endpoint.
+const defaultRequestyBaseURL = "https://router.requesty.ai/v1"
+
+func main() {
+	// Read configuration from command line flags.
+	modelName := flag.String("model", "openai/gpt-4o-mini", "Name of the model to use (provider/model)")
+	baseURL := flag.String("base-url", defaultRequestyBaseURL, "Requesty router base URL")
+	flag.Parse()
+
+	// Requesty authenticates with a bearer key passed via REQUESTY_API_KEY.
+	apiKey := os.Getenv("REQUESTY_API_KEY")
+	if apiKey == "" {
+		log.Fatal("REQUESTY_API_KEY is not set. Get a key at https://app.requesty.ai/api-keys")
+	}
+
+	fmt.Printf("🚀 Using configuration:\n")
+	fmt.Printf("   📝 Model Name: %s\n", *modelName)
+	fmt.Printf("   🌐 Base URL: %s\n", *baseURL)
+	fmt.Printf("   🔑 API key sourced from REQUESTY_API_KEY\n")
+	fmt.Println()
+
+	// Create an OpenAI-compatible model instance pointed at the Requesty router.
+	// WithBaseURL and WithAPIKey are passed explicitly so the example works
+	// without relying on OPENAI_BASE_URL / OPENAI_API_KEY.
+	llm := openai.New(*modelName,
+		openai.WithBaseURL(*baseURL),
+		openai.WithAPIKey(apiKey),
+	)
+
+	ctx := context.Background()
+
+	fmt.Println("🔄 === Non-streaming Example ===")
+	if err := nonStreamingExample(ctx, llm); err != nil {
+		log.Printf("❌ Non-streaming example failed: %v", err)
+	}
+
+	fmt.Println("\n🌊 === Streaming Example ===")
+	if err := streamingExample(ctx, llm); err != nil {
+		log.Printf("❌ Streaming example failed: %v", err)
+	}
+
+	fmt.Println("🎉 === Demo Complete ===")
+}
+
+// nonStreamingExample demonstrates non-streaming usage against Requesty.
+func nonStreamingExample(ctx context.Context, llm *openai.Model) error {
+	fmt.Println("💬 Sending non-streaming request...")
+
+	temperature := 0.7
+	maxTokens := 1000
+
+	request := &model.Request{
+		Messages: []model.Message{
+			model.NewSystemMessage("You are a helpful assistant."),
+			model.NewUserMessage("Tell me a short joke about programming."),
+		},
+		GenerationConfig: model.GenerationConfig{
+			Temperature: &temperature,
+			MaxTokens:   &maxTokens,
+			Stream:      false,
+		},
+	}
+
+	responseChan, err := llm.GenerateContent(ctx, request)
+	if err != nil {
+		return fmt.Errorf("failed to generate content: %w", err)
+	}
+
+	for response := range responseChan {
+		if response.Error != nil {
+			return fmt.Errorf("API error: %s", response.Error.Message)
+		}
+
+		if len(response.Choices) > 0 {
+			choice := response.Choices[0]
+			fmt.Printf("🤖 Response: %s\n", choice.Message.Content)
+
+			if choice.FinishReason != nil {
+				fmt.Printf("🏁 Finish reason: %s\n", *choice.FinishReason)
+			}
+		}
+
+		if response.Usage != nil {
+			fmt.Printf("💎 Token usage - Prompt: %d, Completion: %d, Total: %d\n",
+				response.Usage.PromptTokens,
+				response.Usage.CompletionTokens,
+				response.Usage.TotalTokens)
+		}
+
+		if response.Done {
+			break
+		}
+	}
+
+	return nil
+}
+
+// streamingExample demonstrates streaming usage against Requesty.
+func streamingExample(ctx context.Context, llm *openai.Model) error {
+	fmt.Println("🌊 Starting streaming request...")
+
+	request := &model.Request{
+		Messages: []model.Message{
+			model.NewUserMessage("Write a short poem about AI."),
+		},
+		GenerationConfig: model.GenerationConfig{
+			Stream: true,
+		},
+	}
+
+	responseChan, err := llm.GenerateContent(ctx, request)
+	if err != nil {
+		return fmt.Errorf("failed to generate content: %w", err)
+	}
+
+	fmt.Print("📝 Streaming response: ")
+	var fullContent string
+
+	for response := range responseChan {
+		if response.Error != nil {
+			return fmt.Errorf("API error: %s", response.Error.Message)
+		}
+
+		if len(response.Choices) > 0 {
+			choice := response.Choices[0]
+			if choice.Delta.Content != "" {
+				fmt.Print(choice.Delta.Content)
+				fullContent += choice.Delta.Content
+			}
+
+			if choice.FinishReason != nil {
+				fmt.Printf("\n🏁 Finish reason: %s\n", *choice.FinishReason)
+			}
+		}
+
+		if response.Done {
+			fmt.Printf("\n\n✅ Streaming completed. Full content length: %d characters\n", len(fullContent))
+			break
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
## What

Add first-class documentation and a runnable example for using
[Requesty](https://requesty.ai) — an OpenAI-compatible LLM router — with
trpc-agent-go.

Requesty exposes an OpenAI-compatible Chat Completions API
(`https://router.requesty.ai/v1`), so it works with the existing
`model/openai` client without any new provider code: you create an
`openai.Model` and override the base URL and API key. This mirrors how the
existing docs already document other OpenAI-compatible backends (DeepSeek,
Qwen) rather than introducing a redundant named-provider mechanism.

I deliberately did **not** add a new entry to `model/provider` because that
registry keys on protocol families (`openai`, `anthropic`, `gemini`, `ollama`,
`hunyuan`), not on individual OpenAI-compatible vendors. Requesty is reached
through the `openai` provider with a custom base URL, exactly like DeepSeek/Qwen
in the current `examples/provider` and `docs/.../model.md`. OpenRouter is
likewise only referenced as model-window metadata in
`model/internal/model/model_info.go`, not as a runnable provider, so there was
no named-provider precedent to mirror.

## Why

Requesty users currently have to infer the base URL / env var convention. This
adds a copy-pasteable example and lists Requesty alongside the other
OpenAI-compatible providers in the model docs.

## Files

- `examples/model/requesty/main.go` — runnable example. Creates an
  `openai.Model` with `openai.WithBaseURL("https://router.requesty.ai/v1")` and
  `openai.WithAPIKey(os.Getenv("REQUESTY_API_KEY"))`; runs a non-streaming and a
  streaming request. Uses only the public `model` and `model/openai` packages
  (no `internal` imports). Carries the required Tencent Apache 2.0 license
  header.
- `examples/model/requesty/README.md` — usage, env vars, flags, security notes.
- `examples/model/README.md` — adds the `requesty/` sub-example to the list.
- `docs/mkdocs/en/model.md` / `docs/mkdocs/zh/model.md` — add Requesty to the
  list of OpenAI-compatible providers (base URL, auth env var, `provider/model`
  naming), next to OpenAI / DeepSeek / Hunyuan / Qwen.

No production library code, dependencies, or `go.mod`/`go.sum` files were
changed. The example reuses the shared `examples` module.

## Verification

- `go build ./...` (root module) — passes.
- `cd examples && go build ./model/requesty/` — passes.
- `cd examples && go vet ./model/requesty/` — passes.
- `gofmt -r 'interface{} -> any' -l examples/model/requesty/main.go` and
  `gofmt -l examples/model/requesty/main.go` — both empty (clean).
- Live test: ran the example against `https://router.requesty.ai/v1` with
  model `openai/gpt-4o-mini` using a real `REQUESTY_API_KEY`. Both the
  non-streaming and streaming examples returned real completions and token
  usage.

I work at Requesty. This mirrors the existing OpenRouter integration /
OpenAI-compatible support as closely as possible. Happy to adjust or close it if
it is not a fit.
