### PR TITLE
server/agui: bound event history persistence

### DIFF
--- a/docs/mkdocs/en/agui/history.md
+++ b/docs/mkdocs/en/agui/history.md
@@ -98,6 +98,7 @@ Related configuration:
 
 - `aggregator.WithEnabled(true)` controls whether event aggregation is enabled. It is enabled by default.
 - `agui.WithFlushInterval(time.Second)` controls the periodic flush interval for aggregation results. The default is `1s`. Setting it to `0` disables periodic flushing.
+- `agui.WithTrackPersistenceTimeout(5*time.Second)` limits the maximum duration for event history persistence. The default is `5s`. Setting it to `0` means no timeout is applied.
 - `agui.WithPostRunFinalizationTimeout(5*time.Second)` limits the maximum duration of post-run finalization. The default is `5s`. Finalization needs to fill in protocol closing events and write the aggregation cache to `SessionService`; if session storage becomes slow or fails, the timeout prevents the request from blocking for too long. Setting it to `0` means no timeout is applied.
 
 ```go
@@ -116,6 +117,7 @@ server, err := agui.New(
     agui.WithSessionService(sessionService),
     agui.WithMessagesSnapshotEnabled(true),
     agui.WithFlushInterval(time.Second),
+    agui.WithTrackPersistenceTimeout(5*time.Second),
     agui.WithPostRunFinalizationTimeout(5*time.Second),
     agui.WithAGUIRunnerOptions(
         aguirunner.WithAggregationOption(aggregator.WithEnabled(true)),

--- a/docs/mkdocs/zh/agui/history.md
+++ b/docs/mkdocs/zh/agui/history.md
@@ -98,6 +98,7 @@ curl -N -X POST http://localhost:8080/history \
 
 - `aggregator.WithEnabled(true)` 用于控制是否开启事件聚合，默认开启。
 - `agui.WithFlushInterval(time.Second)` 用于控制聚合结果的定时刷新间隔，默认 `1s`。设置为 `0` 表示不开启定时刷新。
+- `agui.WithTrackPersistenceTimeout(5*time.Second)` 用于限制事件历史记录持久化的最长执行时间，默认 `5s`。设置为 `0` 表示不设置超时。
 - `agui.WithPostRunFinalizationTimeout(5*time.Second)` 用于限制运行结束后收尾流程的最长执行时间，默认 `5s`。收尾流程需要补齐协议结束事件，并将聚合缓存写入 `SessionService`；如果会话存储变慢或异常，超时可以避免请求长时间阻塞。设置为 `0` 表示不设置超时事件。
 
 ```go
@@ -116,6 +117,7 @@ server, err := agui.New(
     agui.WithSessionService(sessionService),
     agui.WithMessagesSnapshotEnabled(true),
     agui.WithFlushInterval(time.Second),
+    agui.WithTrackPersistenceTimeout(5*time.Second),
     agui.WithPostRunFinalizationTimeout(5*time.Second),
     agui.WithAGUIRunnerOptions(
         aguirunner.WithAggregationOption(aggregator.WithEnabled(true)),

--- a/server/agui/options.go
+++ b/server/agui/options.go
@@ -152,6 +152,13 @@ func WithPostRunFinalizationTimeout(d time.Duration) Option {
 	}
 }
 
+// WithTrackPersistenceTimeout sets the maximum duration allowed for AG-UI track persistence.
+func WithTrackPersistenceTimeout(d time.Duration) Option {
+	return func(o *options) {
+		o.aguiRunnerOptions = append(o.aguiRunnerOptions, aguirunner.WithTrackPersistenceTimeout(d))
+	}
+}
+
 // WithHeartbeatInterval sets how often the SSE transport sends heartbeat frames.
 func WithHeartbeatInterval(d time.Duration) Option {
 	return func(o *options) {

--- a/server/agui/options_test.go
+++ b/server/agui/options_test.go
@@ -94,6 +94,12 @@ func TestWithPostRunFinalizationTimeout(t *testing.T) {
 	assert.Equal(t, 2*time.Second, ro.PostRunFinalizationTimeout)
 }
 
+func TestWithTrackPersistenceTimeout(t *testing.T) {
+	opts := newOptions(WithTrackPersistenceTimeout(2 * time.Second))
+	ro := aguirunner.NewOptions(opts.aguiRunnerOptions...)
+	assert.Equal(t, 2*time.Second, ro.TrackPersistenceTimeout)
+}
+
 func TestWithHeartbeatInterval(t *testing.T) {
 	opts := newOptions(WithHeartbeatInterval(2 * time.Second))
 	assert.Equal(t, 2*time.Second, opts.heartbeatInterval)

--- a/server/agui/runner/options.go
+++ b/server/agui/runner/options.go
@@ -24,6 +24,7 @@ import (
 
 const (
 	defaultPostRunFinalizationTimeout             = 5 * time.Second
+	defaultTrackPersistenceTimeout                = 5 * time.Second
 	defaultTimeout                                = time.Hour
 	defaultGraphNodeLifecycleActivityEnabled      = false
 	defaultGraphNodeInterruptActivityEnabled      = false
@@ -57,6 +58,7 @@ type Options struct {
 	MessagesSnapshotRunLifecycleEventsEnabled bool                  // MessagesSnapshotRunLifecycleEventsEnabled includes persisted RUN_* events as activity messages in MESSAGES_SNAPSHOT.
 	StartSpan                                 StartSpan             // StartSpan starts a span for an AG-UI run.
 	PostRunFinalizationTimeout                time.Duration         // PostRunFinalizationTimeout bounds how long post-run finalization is allowed to take.
+	TrackPersistenceTimeout                   time.Duration         // TrackPersistenceTimeout bounds how long AG-UI track persistence is allowed to take.
 	Timeout                                   time.Duration         // Timeout controls how long a run is allowed to execute.
 	CancelOnContextDoneEnabled                bool                  // CancelOnContextDoneEnabled cancels the run when the parent context is done.
 	GraphNodeLifecycleActivityEnabled         bool                  // GraphNodeLifecycleActivityEnabled enables graph node lifecycle activity events.
@@ -85,6 +87,7 @@ func NewOptions(opt ...Option) *Options {
 		FlushInterval:                          track.DefaultFlushInterval,
 		StartSpan:                              defaultStartSpan,
 		PostRunFinalizationTimeout:             defaultPostRunFinalizationTimeout,
+		TrackPersistenceTimeout:                defaultTrackPersistenceTimeout,
 		Timeout:                                defaultTimeout,
 		GraphNodeLifecycleActivityEnabled:      defaultGraphNodeLifecycleActivityEnabled,
 		GraphNodeInterruptActivityEnabled:      defaultGraphNodeInterruptActivityEnabled,
@@ -251,6 +254,13 @@ func WithTimeout(d time.Duration) Option {
 func WithPostRunFinalizationTimeout(d time.Duration) Option {
 	return func(o *Options) {
 		o.PostRunFinalizationTimeout = d
+	}
+}
+
+// WithTrackPersistenceTimeout sets the maximum duration allowed for AG-UI track persistence.
+func WithTrackPersistenceTimeout(d time.Duration) Option {
+	return func(o *Options) {
+		o.TrackPersistenceTimeout = d
 	}
 }
 

--- a/server/agui/runner/options_test.go
+++ b/server/agui/runner/options_test.go
@@ -72,6 +72,7 @@ func TestNewOptionsDefaults(t *testing.T) {
 	assert.NotNil(t, span)
 
 	assert.Equal(t, 5*time.Second, opts.PostRunFinalizationTimeout)
+	assert.Equal(t, 5*time.Second, opts.TrackPersistenceTimeout)
 	assert.Equal(t, time.Hour, opts.Timeout)
 	assert.False(t, opts.CancelOnContextDoneEnabled)
 	assert.False(t, opts.GraphNodeLifecycleActivityEnabled)
@@ -293,6 +294,11 @@ func TestWithStartSpan(t *testing.T) {
 func TestWithTimeout(t *testing.T) {
 	opts := NewOptions(WithTimeout(2 * time.Second))
 	assert.Equal(t, 2*time.Second, opts.Timeout)
+}
+
+func TestWithTrackPersistenceTimeout(t *testing.T) {
+	opts := NewOptions(WithTrackPersistenceTimeout(2 * time.Second))
+	assert.Equal(t, 2*time.Second, opts.TrackPersistenceTimeout)
 }
 
 func TestWithCancelOnContextDoneEnabled(t *testing.T) {

--- a/server/agui/runner/runner.go
+++ b/server/agui/runner/runner.go
@@ -92,6 +92,7 @@ func New(r trunner.Runner, opt ...Option) Runner {
 		startSpan:                              opts.StartSpan,
 		flushInterval:                          opts.FlushInterval,
 		postRunFinalizationTimeout:             opts.PostRunFinalizationTimeout,
+		trackPersistenceTimeout:                opts.TrackPersistenceTimeout,
 		timeout:                                opts.Timeout,
 		cancelOnContextDoneEnabled:             opts.CancelOnContextDoneEnabled,
 		messagesSnapshotFollowEnabled:          opts.MessagesSnapshotFollowEnabled,
@@ -130,6 +131,7 @@ type runner struct {
 	startSpan                                 StartSpan
 	flushInterval                             time.Duration
 	postRunFinalizationTimeout                time.Duration
+	trackPersistenceTimeout                   time.Duration
 	timeout                                   time.Duration
 	cancelOnContextDoneEnabled                bool
 	messagesSnapshotFollowEnabled             bool
@@ -511,13 +513,8 @@ func (r *runner) run(ctx context.Context, cancel context.CancelCauseFunc, key se
 }
 
 func (r *runner) flushTrack(ctx context.Context, key session.Key) error {
-	flushCtx := agent.CloneContext(ctx)
-	flushCtx = context.WithoutCancel(flushCtx)
-	if r.postRunFinalizationTimeout > 0 {
-		timeoutCtx, cancel := context.WithTimeout(flushCtx, r.postRunFinalizationTimeout)
-		defer cancel()
-		flushCtx = timeoutCtx
-	}
+	flushCtx, cancel := r.newTrackPersistenceContext(ctx)
+	defer cancel()
 	return r.tracker.Flush(flushCtx, key)
 }
 
@@ -526,7 +523,7 @@ func (r *runner) emitPostRunTerminalEvent(ctx context.Context, events chan<- agu
 	if input.terminalEmitted {
 		return
 	}
-	emitCtx, cancel := r.newPostRunContext(ctx)
+	emitCtx, cancel := r.newPostRunFinalizationContext(ctx)
 	defer cancel()
 	var terminalEvent aguievents.Event
 	if finalizationErr != nil {
@@ -545,17 +542,24 @@ func (r *runner) emitPostRunTerminalEvent(ctx context.Context, events chan<- agu
 	r.emitEvent(emitCtx, events, terminalEvent, input)
 }
 
-func (r *runner) newPostRunContext(ctx context.Context) (context.Context, context.CancelFunc) {
-	emitCtx := agent.CloneContext(ctx)
-	emitCtx = context.WithoutCancel(emitCtx)
-	if r.postRunFinalizationTimeout > 0 {
-		return context.WithTimeout(emitCtx, r.postRunFinalizationTimeout)
+func (r *runner) newPostRunFinalizationContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return newDetachedBoundedContext(ctx, r.postRunFinalizationTimeout)
+}
+
+func (r *runner) newTrackPersistenceContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return newDetachedBoundedContext(ctx, r.trackPersistenceTimeout)
+}
+
+func newDetachedBoundedContext(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	emitCtx := context.WithoutCancel(agent.CloneContext(ctx))
+	if timeout > 0 {
+		return context.WithTimeout(emitCtx, timeout)
 	}
 	return context.WithCancel(emitCtx)
 }
 
 func (r *runner) emitPostRunFinalization(ctx context.Context, events chan<- aguievents.Event, input *runInput) error {
-	emitCtx, cancel := r.newPostRunContext(ctx)
+	emitCtx, cancel := r.newPostRunFinalizationContext(ctx)
 	defer cancel()
 	finalizationErr := r.emitPostRunFinalizationEvents(emitCtx, events, input)
 	if finalizationErr != nil {
@@ -998,7 +1002,9 @@ func (r *runner) unregister(key session.Key) {
 }
 
 func (r *runner) recordTrackEvent(ctx context.Context, key session.Key, event aguievents.Event) error {
-	return r.tracker.AppendEvent(ctx, key, event)
+	trackCtx, cancel := r.newTrackPersistenceContext(ctx)
+	defer cancel()
+	return r.tracker.AppendEvent(trackCtx, key, event)
 }
 
 func isExplicitRunCancel(ctx context.Context) bool {

--- a/server/agui/runner/runner_test.go
+++ b/server/agui/runner/runner_test.go
@@ -2199,6 +2199,43 @@ func TestRunFlushesTracker(t *testing.T) {
 	assert.Equal(t, 1, recorder.flushCount)
 }
 
+func TestRecordTrackEventUsesDetachedPersistenceContext(t *testing.T) {
+	recorder := &contextRecorderTracker{}
+	r := &runner{
+		tracker:                 recorder,
+		trackPersistenceTimeout: time.Second,
+	}
+	parentCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := r.recordTrackEvent(
+		parentCtx,
+		session.Key{AppName: "app", UserID: "user", SessionID: "thread"},
+		aguievents.NewRunStartedEvent("thread", "run"),
+	)
+	require.NoError(t, err)
+
+	assert.NoError(t, recorder.ctxErr)
+	assert.True(t, recorder.hasDeadline)
+	assert.False(t, recorder.deadline.IsZero())
+}
+
+func TestRecordTrackEventTimeoutBoundsDetachedPersistence(t *testing.T) {
+	r := &runner{
+		tracker:                 deadlineWaitingTracker{},
+		trackPersistenceTimeout: 10 * time.Millisecond,
+	}
+
+	start := time.Now()
+	err := r.recordTrackEvent(
+		context.Background(),
+		session.Key{AppName: "app", UserID: "user", SessionID: "thread"},
+		aguievents.NewRunStartedEvent("thread", "run"),
+	)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Less(t, time.Since(start), time.Second)
+}
+
 func TestNewWithSessionServiceEnablesTracker(t *testing.T) {
 	underlying := &fakeRunner{
 		run: func(context.Context, string, string, model.Message, ...agent.RunOption) (<-chan *agentevent.Event, error) {
@@ -2960,6 +2997,43 @@ func (f *flushRecorder) GetEvents(ctx context.Context, key session.Key, opts ...
 
 func (f *flushRecorder) Flush(ctx context.Context, key session.Key) error {
 	f.flushCount++
+	return nil
+}
+
+type contextRecorderTracker struct {
+	ctxErr      error
+	deadline    time.Time
+	hasDeadline bool
+}
+
+func (c *contextRecorderTracker) AppendEvent(ctx context.Context, _ session.Key, _ aguievents.Event) error {
+	c.ctxErr = ctx.Err()
+	c.deadline, c.hasDeadline = ctx.Deadline()
+	return nil
+}
+
+func (c *contextRecorderTracker) GetEvents(context.Context, session.Key,
+	...session.Option) (*session.TrackEvents, error) {
+	return nil, nil
+}
+
+func (c *contextRecorderTracker) Flush(context.Context, session.Key) error {
+	return nil
+}
+
+type deadlineWaitingTracker struct{}
+
+func (deadlineWaitingTracker) AppendEvent(ctx context.Context, _ session.Key, _ aguievents.Event) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (deadlineWaitingTracker) GetEvents(context.Context, session.Key,
+	...session.Option) (*session.TrackEvents, error) {
+	return nil, nil
+}
+
+func (deadlineWaitingTracker) Flush(context.Context, session.Key) error {
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated AG-UI event history persistence timeout and use a detached bounded context for track persistence
- keep post-run finalization timeout separate from event history persistence
- stabilize SQL-backed track event ordering for same-timestamp records
- document the new event history persistence timeout in English and Chinese AG-UI history docs

## Tests
- `go test -count=1 ./...` in `server/agui`
- `go test -count=1 ./...` in `session/mysql`
- `go test -count=1 ./...` in `session/postgres`
- `go test -count=1 ./...` in `session/sqlite`
- `go test -count=1 ./...` in `session/pgvector`