### PR TITLE
fix: DeepSeek cached_tokens always 0 due to missing read prompt_cache_hit_tokens

### DIFF
--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -1828,7 +1828,10 @@ func applyOpenAISDKTokenDetailsAccumulationFix(
 	acc.Usage.CompletionTokensDetails.ReasoningTokens += chunk.Usage.CompletionTokensDetails.ReasoningTokens
 	acc.Usage.CompletionTokensDetails.RejectedPredictionTokens += chunk.Usage.CompletionTokensDetails.RejectedPredictionTokens
 	acc.Usage.PromptTokensDetails.AudioTokens += chunk.Usage.PromptTokensDetails.AudioTokens
-	acc.Usage.PromptTokensDetails.CachedTokens += chunk.Usage.PromptTokensDetails.CachedTokens
+	acc.Usage.PromptTokensDetails.CachedTokens += int64(getCachedTokensWithDeepSeekFallback(
+		chunk.Usage.PromptTokensDetails.CachedTokens,
+		chunk.Usage.JSON.ExtraFields,
+	))
 }
 
 // accumulateChunk accumulates non-reasoning deltas into the SDK accumulator and

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -5039,53 +5039,6 @@ func TestModelUsageToCompletionUsage(t *testing.T) {
 	})
 }
 
-// TestCompletionUsageToModelUsage tests conversion from openai.CompletionUsage to model.Usage.
-func TestCompletionUsageToModelUsage(t *testing.T) {
-	t.Run("converts all fields correctly", func(t *testing.T) {
-		openaiUsage := openai.CompletionUsage{
-			PromptTokens:     int64(200),
-			CompletionTokens: int64(75),
-			TotalTokens:      int64(275),
-			PromptTokensDetails: openai.CompletionUsagePromptTokensDetails{
-				CachedTokens: int64(30),
-			},
-			CompletionTokensDetails: openai.CompletionUsageCompletionTokensDetails{
-				ReasoningTokens: int64(25),
-			},
-		}
-
-		result := completionUsageToModelUsage(openaiUsage)
-
-		assert.Equal(t, 200, result.PromptTokens, "expected prompt tokens to be 200")
-		assert.Equal(t, 75, result.CompletionTokens, "expected completion tokens to be 75")
-		assert.Equal(t, 275, result.TotalTokens, "expected total tokens to be 275")
-		assert.Equal(t, 30, result.PromptTokensDetails.CachedTokens, "expected cached tokens to be 30")
-		assert.Equal(t, 25, result.CompletionTokensDetails.ReasoningTokens, "expected reasoning tokens to be 25")
-	})
-
-	t.Run("converts zero values", func(t *testing.T) {
-		openaiUsage := openai.CompletionUsage{
-			PromptTokens:     int64(0),
-			CompletionTokens: int64(0),
-			TotalTokens:      int64(0),
-			PromptTokensDetails: openai.CompletionUsagePromptTokensDetails{
-				CachedTokens: int64(0),
-			},
-			CompletionTokensDetails: openai.CompletionUsageCompletionTokensDetails{
-				ReasoningTokens: int64(0),
-			},
-		}
-
-		result := completionUsageToModelUsage(openaiUsage)
-
-		assert.Equal(t, 0, result.PromptTokens, "expected prompt tokens to be 0")
-		assert.Equal(t, 0, result.CompletionTokens, "expected completion tokens to be 0")
-		assert.Equal(t, 0, result.TotalTokens, "expected total tokens to be 0")
-		assert.Equal(t, 0, result.PromptTokensDetails.CachedTokens, "expected cached tokens to be 0")
-		assert.Equal(t, 0, result.CompletionTokensDetails.ReasoningTokens, "expected reasoning tokens to be 0")
-	})
-}
-
 // TestWithChannelBufferSize_EdgeCases tests WithChannelBufferSize with edge cases.
 func TestWithChannelBufferSize_EdgeCases(t *testing.T) {
 	t.Run("zero size should use default", func(t *testing.T) {
@@ -8050,6 +8003,91 @@ func TestModel_accumulateChunk(t *testing.T) {
 		assert.Equal(t, int64(20), acc.Usage.PromptTokens)
 		assert.Equal(t, int64(10), acc.Usage.CompletionTokens)
 	})
+}
+
+func TestApplyOpenAISDKTokenDetailsAccumulationFix_DeepSeekFallback(t *testing.T) {
+	tests := []struct {
+		name             string
+		chunkJSON        string
+		accCachedTokens  int64
+		wantCachedTokens int64
+	}{
+		{
+			name: "standard cached_tokens accumulates normally",
+			chunkJSON: `{
+				"id":"c1","object":"chat.completion.chunk","created":0,"model":"m",
+				"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15,
+					"prompt_tokens_details":{"cached_tokens":8}}
+			}`,
+			accCachedTokens:  10,
+			wantCachedTokens: 18,
+		},
+		{
+			name: "DeepSeek fallback when standard cached_tokens is zero",
+			chunkJSON: `{
+				"id":"c1","object":"chat.completion.chunk","created":0,"model":"m",
+				"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15,
+					"prompt_tokens_details":{"cached_tokens":0},
+					"prompt_cache_hit_tokens":25}
+			}`,
+			accCachedTokens:  0,
+			wantCachedTokens: 25,
+		},
+		{
+			name: "DeepSeek fallback when standard cached_tokens is absent",
+			chunkJSON: `{
+				"id":"c1","object":"chat.completion.chunk","created":0,"model":"m",
+				"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15,
+					"prompt_cache_hit_tokens":30}
+			}`,
+			accCachedTokens:  0,
+			wantCachedTokens: 30,
+		},
+		{
+			name: "malformed DeepSeek field silently ignored",
+			chunkJSON: `{
+				"id":"c1","object":"chat.completion.chunk","created":0,"model":"m",
+				"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15,
+					"prompt_cache_hit_tokens":"invalid"}
+			}`,
+			accCachedTokens:  10,
+			wantCachedTokens: 10,
+		},
+		{
+			name: "standard cached_tokens takes precedence over DeepSeek field",
+			chunkJSON: `{
+				"id":"c1","object":"chat.completion.chunk","created":0,"model":"m",
+				"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15,
+					"prompt_tokens_details":{"cached_tokens":50},
+					"prompt_cache_hit_tokens":25}
+			}`,
+			accCachedTokens:  0,
+			wantCachedTokens: 50,
+		},
+		{
+			name: "multiple chunks accumulate DeepSeek fallback",
+			chunkJSON: `{
+				"id":"c1","object":"chat.completion.chunk","created":0,"model":"m",
+				"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15,
+					"prompt_cache_hit_tokens":15}
+			}`,
+			accCachedTokens:  20,
+			wantCachedTokens: 35,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chunk := parseChunkWithExtraFields(t, tt.chunkJSON)
+			acc := &openai.ChatCompletionAccumulator{}
+			acc.Usage.PromptTokensDetails.CachedTokens = tt.accCachedTokens
+
+			applyOpenAISDKTokenDetailsAccumulationFix(acc, chunk)
+
+			assert.Equal(t, tt.wantCachedTokens, acc.Usage.PromptTokensDetails.CachedTokens,
+				"CachedTokens mismatch after accumulation")
+		})
+	}
 }
 
 // TestModel_sendPartialResponse tests the sendPartialResponse method.

--- a/model/openai/options.go
+++ b/model/openai/options.go
@@ -12,9 +12,11 @@ package openai
 
 import (
 	"context"
+	"strconv"
 
 	openai "github.com/openai/openai-go"
 	openaiopt "github.com/openai/openai-go/option"
+	"github.com/openai/openai-go/packages/respjson"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	imodel "trpc.group/trpc-go/trpc-agent-go/model/internal/model"
 )
@@ -406,14 +408,32 @@ func inverseOpenAISDKAddChunkUsage(u model.Usage, delta model.Usage) model.Usage
 	}
 }
 
+// getCachedTokensWithDeepSeekFallback returns the cached token count, falling back to
+// DeepSeek's prompt_cache_hit_tokens field when the standard field is zero.
+func getCachedTokensWithDeepSeekFallback(standardCached int64, extraFields map[string]respjson.Field) int {
+	if standardCached > 0 {
+		return int(standardCached)
+	}
+	if f, ok := extraFields["prompt_cache_hit_tokens"]; ok {
+		if v, err := strconv.Atoi(f.Raw()); err == nil && v >= 0 {
+			return v
+		}
+	}
+	return 0
+}
+
 // completionUsageToModelUsage converts openai.CompletionUsage to model.Usage.
 func completionUsageToModelUsage(usage openai.CompletionUsage) model.Usage {
+	cached := getCachedTokensWithDeepSeekFallback(
+		usage.PromptTokensDetails.CachedTokens,
+		usage.JSON.ExtraFields,
+	)
 	return model.Usage{
 		PromptTokens:     int(usage.PromptTokens),
 		CompletionTokens: int(usage.CompletionTokens),
 		TotalTokens:      int(usage.TotalTokens),
 		PromptTokensDetails: model.PromptTokensDetails{
-			CachedTokens: int(usage.PromptTokensDetails.CachedTokens),
+			CachedTokens: cached,
 		},
 		CompletionTokensDetails: model.CompletionTokensDetails{
 			ReasoningTokens: int(usage.CompletionTokensDetails.ReasoningTokens),

--- a/model/openai/options_test.go
+++ b/model/openai/options_test.go
@@ -1,0 +1,214 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package openai
+
+import (
+	"encoding/json"
+	"testing"
+
+	openai "github.com/openai/openai-go"
+	"github.com/openai/openai-go/packages/respjson"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetCachedTokensWithDeepSeekFallback(t *testing.T) {
+	tests := []struct {
+		name           string
+		standardCached int64
+		extraFields    map[string]respjson.Field
+		expected       int
+	}{
+		{
+			name:           "standard field is non-zero, use it",
+			standardCached: 10,
+			extraFields:    map[string]respjson.Field{"prompt_cache_hit_tokens": respjson.NewField(`25`)},
+			expected:       10,
+		},
+		{
+			name:           "standard field is zero, fallback to DeepSeek field",
+			standardCached: 0,
+			extraFields:    map[string]respjson.Field{"prompt_cache_hit_tokens": respjson.NewField(`25`)},
+			expected:       25,
+		},
+		{
+			name:           "both fields zero",
+			standardCached: 0,
+			extraFields:    map[string]respjson.Field{},
+			expected:       0,
+		},
+		{
+			name:           "DeepSeek field missing",
+			standardCached: 0,
+			extraFields:    map[string]respjson.Field{},
+			expected:       0,
+		},
+		{
+			name:           "DeepSeek field malformed (string)",
+			standardCached: 0,
+			extraFields:    map[string]respjson.Field{"prompt_cache_hit_tokens": respjson.NewField(`"invalid"`)},
+			expected:       0,
+		},
+		{
+			name:           "DeepSeek field is negative",
+			standardCached: 0,
+			extraFields:    map[string]respjson.Field{"prompt_cache_hit_tokens": respjson.NewField(`-5`)},
+			expected:       0,
+		},
+		{
+			name:           "nil extra fields",
+			standardCached: 0,
+			extraFields:    nil,
+			expected:       0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getCachedTokensWithDeepSeekFallback(tt.standardCached, tt.extraFields)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCompletionUsageToModelUsage_DeepSeekFallback(t *testing.T) {
+	tests := []struct {
+		name           string
+		jsonData       string
+		expectedPrompt int
+		expectedTotal  int
+		expectedCached int
+		expectedReason int
+	}{
+		{
+			name: "DeepSeek response with valid prompt_cache_hit_tokens",
+			jsonData: `{
+				"prompt_tokens": 100,
+				"completion_tokens": 50,
+				"total_tokens": 150,
+				"prompt_tokens_details": {
+					"cached_tokens": 0
+				},
+				"prompt_cache_hit_tokens": 25
+			}`,
+			expectedPrompt: 100,
+			expectedTotal:  150,
+			expectedCached: 25,
+			expectedReason: 0,
+		},
+		{
+			name: "DeepSeek response with malformed prompt_cache_hit_tokens",
+			jsonData: `{
+				"prompt_tokens": 100,
+				"completion_tokens": 50,
+				"total_tokens": 150,
+				"prompt_tokens_details": {
+					"cached_tokens": 0
+				},
+				"prompt_cache_hit_tokens": "invalid"
+			}`,
+			expectedPrompt: 100,
+			expectedTotal:  150,
+			expectedCached: 0,
+			expectedReason: 0,
+		},
+		{
+			name: "standard cached tokens takes precedence over DeepSeek field",
+			jsonData: `{
+				"prompt_tokens": 100,
+				"completion_tokens": 50,
+				"total_tokens": 150,
+				"prompt_tokens_details": {
+					"cached_tokens": 10
+				},
+				"prompt_cache_hit_tokens": 25
+			}`,
+			expectedPrompt: 100,
+			expectedTotal:  150,
+			expectedCached: 10,
+			expectedReason: 0,
+		},
+		{
+			name: "no ExtraFields",
+			jsonData: `{
+				"prompt_tokens": 100,
+				"completion_tokens": 50,
+				"total_tokens": 150,
+				"prompt_tokens_details": {
+					"cached_tokens": 0
+				}
+			}`,
+			expectedPrompt: 100,
+			expectedTotal:  150,
+			expectedCached: 0,
+			expectedReason: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var usage openai.CompletionUsage
+			err := json.Unmarshal([]byte(tt.jsonData), &usage)
+			assert.NoError(t, err)
+
+			result := completionUsageToModelUsage(usage)
+
+			assert.Equal(t, tt.expectedPrompt, result.PromptTokens)
+			assert.Equal(t, tt.expectedTotal, result.TotalTokens)
+			assert.Equal(t, tt.expectedCached, result.PromptTokensDetails.CachedTokens)
+			assert.Equal(t, tt.expectedReason, result.CompletionTokensDetails.ReasoningTokens)
+		})
+	}
+}
+
+// TestCompletionUsageToModelUsage tests conversion from openai.CompletionUsage to model.Usage.
+func TestCompletionUsageToModelUsage(t *testing.T) {
+	t.Run("converts all fields correctly", func(t *testing.T) {
+		openaiUsage := openai.CompletionUsage{
+			PromptTokens:     int64(200),
+			CompletionTokens: int64(75),
+			TotalTokens:      int64(275),
+			PromptTokensDetails: openai.CompletionUsagePromptTokensDetails{
+				CachedTokens: int64(30),
+			},
+			CompletionTokensDetails: openai.CompletionUsageCompletionTokensDetails{
+				ReasoningTokens: int64(25),
+			},
+		}
+
+		result := completionUsageToModelUsage(openaiUsage)
+
+		assert.Equal(t, 200, result.PromptTokens, "expected prompt tokens to be 200")
+		assert.Equal(t, 75, result.CompletionTokens, "expected completion tokens to be 75")
+		assert.Equal(t, 275, result.TotalTokens, "expected total tokens to be 275")
+		assert.Equal(t, 30, result.PromptTokensDetails.CachedTokens, "expected cached tokens to be 30")
+		assert.Equal(t, 25, result.CompletionTokensDetails.ReasoningTokens, "expected reasoning tokens to be 25")
+	})
+
+	t.Run("converts zero values", func(t *testing.T) {
+		openaiUsage := openai.CompletionUsage{
+			PromptTokens:     int64(0),
+			CompletionTokens: int64(0),
+			TotalTokens:      int64(0),
+			PromptTokensDetails: openai.CompletionUsagePromptTokensDetails{
+				CachedTokens: int64(0),
+			},
+			CompletionTokensDetails: openai.CompletionUsageCompletionTokensDetails{
+				ReasoningTokens: int64(0),
+			},
+		}
+
+		result := completionUsageToModelUsage(openaiUsage)
+
+		assert.Equal(t, 0, result.PromptTokens, "expected prompt tokens to be 0")
+		assert.Equal(t, 0, result.CompletionTokens, "expected completion tokens to be 0")
+		assert.Equal(t, 0, result.TotalTokens, "expected total tokens to be 0")
+		assert.Equal(t, 0, result.PromptTokensDetails.CachedTokens, "expected cached tokens to be 0")
+		assert.Equal(t, 0, result.CompletionTokensDetails.ReasoningTokens, "expected reasoning tokens to be 0")
+	})
+}


### PR DESCRIPTION
…tokens mapping

Add fallback to read prompt_cache_hit_tokens from usage.JSON.ExtraFields when the standard prompt_tokens_details.cached_tokens is zero.

Fixes: #1995

## What changed

Describe the user-visible behavior, API, documentation, or example changes in
this pull request.

## Why

Explain the problem this solves and any compatibility considerations.

## Testing

List the commands or manual checks you ran. If a check is not applicable, say
why.

## Notes for reviewers

Call out areas that deserve extra attention, such as concurrency, persistence,
protocol compatibility, or public API changes.
