### PR TITLE
fix: Anthropic streaming JSON parse error on tool-use blocks with non…

### DIFF
--- a/model/anthropic/anthropic.go
+++ b/model/anthropic/anthropic.go
@@ -689,6 +689,12 @@ func (a *streamingMessageAccumulator) Accumulate(event anthropic.MessageStreamEv
 		if err := block.UnmarshalJSON([]byte(event.ContentBlock.RawJSON())); err != nil {
 			return err
 		}
+		// Some Anthropic-compatible proxies send "input": null instead of
+		// "input": {}. Normalize to empty JSON object so that the first
+		// input_json_delta replaces it correctly.
+		if string(block.Input) == "null" {
+			block.Input = json.RawMessage("{}")
+		}
 		a.message.Content = append(a.message.Content, block)
 		a.inputDeltaStartedAt = append(a.inputDeltaStartedAt, false)
 	case anthropic.ContentBlockDeltaEvent:
@@ -717,6 +723,11 @@ func (a *streamingMessageAccumulator) Accumulate(event anthropic.MessageStreamEv
 		if err != nil {
 			return fmt.Errorf("received event of type %s but %w", event.Type, err)
 		}
+		// Guard against invalid/partial JSON in tool-use Input fields.
+		// Certain Anthropic-compatible APIs send content_block_stop before
+		// all input_json_delta events, leaving accumulated Input as
+		// incomplete JSON.
+		ensureValidToolInput(block)
 		if err := refreshContentBlockRawJSON(block); err != nil {
 			return fmt.Errorf("error converting content block to JSON: %w", err)
 		}
@@ -789,6 +800,20 @@ func refreshContentBlockRawJSON(block *anthropic.ContentBlockUnion) error {
 		return err
 	}
 	return block.UnmarshalJSON(raw)
+}
+
+// ensureValidToolInput resets a ContentBlockUnion's Input to an empty JSON
+// object if it contains invalid or partial JSON. This prevents json.Marshal
+// from failing during accumulation when a stream ends before all
+// input_json_delta events are received (e.g. with Anthropic-compatible APIs
+// that don't strictly follow the streaming protocol).
+func ensureValidToolInput(cb *anthropic.ContentBlockUnion) {
+	if cb == nil {
+		return
+	}
+	if len(cb.Input) > 0 && !json.Valid(cb.Input) {
+		cb.Input = json.RawMessage("{}")
+	}
 }
 
 // buildStreamingPartialResponse builds a partial streaming response for a chunk.

--- a/model/anthropic/anthropic.go
+++ b/model/anthropic/anthropic.go
@@ -798,10 +798,12 @@ func refreshContentBlockRawJSON(block *anthropic.ContentBlockUnion) error {
 
 // ensureValidToolInput resets a ContentBlockUnion's Input to an empty JSON
 // object if it is empty, nil, or contains invalid/partial JSON. This handles
-// two cases with Anthropic-compatible proxies:
+// three cases with Anthropic-compatible proxies:
 //  1. "input": null decodes to nil bytes — normalize to {} so the tool call
 //     arguments stay valid JSON.
-//  2. The stream ends before all input_json_delta events are received, leaving
+//  2. "input":"null" (the literal JSON null) — json.Valid returns true but
+//     null is not a valid tool arguments object, so normalize to {}.
+//  3. The stream ends before all input_json_delta events are received, leaving
 //     accumulated Input as incomplete JSON.
 func ensureValidToolInput(cb *anthropic.ContentBlockUnion) {
 	if cb == nil {
@@ -811,7 +813,7 @@ func ensureValidToolInput(cb *anthropic.ContentBlockUnion) {
 		return
 	}
 	input := bytes.TrimSpace(cb.Input)
-	if len(input) == 0 || !json.Valid(input) {
+	if len(input) == 0 || string(input) == "null" || !json.Valid(input) {
 		cb.Input = json.RawMessage("{}")
 	}
 }

--- a/model/anthropic/anthropic.go
+++ b/model/anthropic/anthropic.go
@@ -689,12 +689,6 @@ func (a *streamingMessageAccumulator) Accumulate(event anthropic.MessageStreamEv
 		if err := block.UnmarshalJSON([]byte(event.ContentBlock.RawJSON())); err != nil {
 			return err
 		}
-		// Some Anthropic-compatible proxies send "input": null instead of
-		// "input": {}. Normalize to empty JSON object so that the first
-		// input_json_delta replaces it correctly.
-		if string(block.Input) == "null" {
-			block.Input = json.RawMessage("{}")
-		}
 		a.message.Content = append(a.message.Content, block)
 		a.inputDeltaStartedAt = append(a.inputDeltaStartedAt, false)
 	case anthropic.ContentBlockDeltaEvent:
@@ -803,15 +797,21 @@ func refreshContentBlockRawJSON(block *anthropic.ContentBlockUnion) error {
 }
 
 // ensureValidToolInput resets a ContentBlockUnion's Input to an empty JSON
-// object if it contains invalid or partial JSON. This prevents json.Marshal
-// from failing during accumulation when a stream ends before all
-// input_json_delta events are received (e.g. with Anthropic-compatible APIs
-// that don't strictly follow the streaming protocol).
+// object if it is empty, nil, or contains invalid/partial JSON. This handles
+// two cases with Anthropic-compatible proxies:
+//  1. "input": null decodes to nil bytes — normalize to {} so the tool call
+//     arguments stay valid JSON.
+//  2. The stream ends before all input_json_delta events are received, leaving
+//     accumulated Input as incomplete JSON.
 func ensureValidToolInput(cb *anthropic.ContentBlockUnion) {
 	if cb == nil {
 		return
 	}
-	if len(cb.Input) > 0 && !json.Valid(cb.Input) {
+	if cb.Type != "tool_use" {
+		return
+	}
+	input := bytes.TrimSpace(cb.Input)
+	if len(input) == 0 || !json.Valid(input) {
 		cb.Input = json.RawMessage("{}")
 	}
 }

--- a/model/anthropic/anthropic_test.go
+++ b/model/anthropic/anthropic_test.go
@@ -2118,6 +2118,15 @@ func Test_StreamingMessageAccumulator_ErrorPaths(t *testing.T) {
 		`{"type":"content_block_stop","index":0}`)))
 	// The invalid Input should have been reset to {}.
 	assert.Equal(t, json.RawMessage("{}"), acc.message.Content[0].Input)
+	// Proxy sends "input": null (literal JSON null) with no input_json_delta.
+	// ensureValidToolInput must treat this as empty and reset to {}.
+	acc3 := newStreamingMessageAccumulator()
+	acc3.message.Content = []anthropic.ContentBlockUnion{{Type: "tool_use", Input: json.RawMessage("null")}}
+	acc3.inputDeltaStartedAt = []bool{false}
+	require.NoError(t, acc3.Accumulate(mustMessageStreamEventUnion(t,
+		`{"type":"content_block_stop","index":0}`)))
+	assert.Equal(t, json.RawMessage("{}"), acc3.message.Content[0].Input)
+
 	// Non-tool_use blocks with malformed Input must NOT be auto-repaired.
 	acc2 := newStreamingMessageAccumulator()
 	acc2.message.Content = []anthropic.ContentBlockUnion{{Type: "text", Input: json.RawMessage("{")}}
@@ -2164,6 +2173,11 @@ func Test_ensureValidToolInput(t *testing.T) {
 	partialInput := &anthropic.ContentBlockUnion{Type: "tool_use", Input: json.RawMessage("{")}
 	ensureValidToolInput(partialInput)
 	assert.Equal(t, json.RawMessage("{}"), partialInput.Input)
+
+	// tool_use with literal "null" (json.Valid("null") is true) — reset to {}.
+	nullLiteral := &anthropic.ContentBlockUnion{Type: "tool_use", Input: json.RawMessage("null")}
+	ensureValidToolInput(nullLiteral)
+	assert.Equal(t, json.RawMessage("{}"), nullLiteral.Input)
 
 	// tool_use with valid JSON — unchanged.
 	validInput := &anthropic.ContentBlockUnion{Type: "tool_use", Input: json.RawMessage(`{"key":"val"}`)}

--- a/model/anthropic/anthropic_test.go
+++ b/model/anthropic/anthropic_test.go
@@ -2118,12 +2118,57 @@ func Test_StreamingMessageAccumulator_ErrorPaths(t *testing.T) {
 		`{"type":"content_block_stop","index":0}`)))
 	// The invalid Input should have been reset to {}.
 	assert.Equal(t, json.RawMessage("{}"), acc.message.Content[0].Input)
+	// Non-tool_use blocks with malformed Input must NOT be auto-repaired.
+	acc2 := newStreamingMessageAccumulator()
+	acc2.message.Content = []anthropic.ContentBlockUnion{{Type: "text", Input: json.RawMessage("{")}}
+	acc2.inputDeltaStartedAt = []bool{false}
+	require.Error(t, acc2.Accumulate(mustMessageStreamEventUnion(t,
+		`{"type":"content_block_stop","index":0}`)))
+	// Input remains unchanged — auto-repair is tool_use-specific.
+	assert.Equal(t, json.RawMessage("{"), acc2.message.Content[0].Input)
+
 	// refreshContentBlockRawJSON and finalizeStreamingMessage still fail on
 	// invalid Input when called directly (no ensureValidToolInput guard).
 	require.Error(t, refreshContentBlockRawJSON(&anthropic.ContentBlockUnion{Type: "tool_use", Input: json.RawMessage("{")}))
 	require.Error(t, finalizeStreamingMessage(&anthropic.Message{
 		Content: []anthropic.ContentBlockUnion{{Type: "tool_use", Input: json.RawMessage("{")}},
 	}))
+}
+
+func Test_ensureValidToolInput(t *testing.T) {
+	// nil input — no-op.
+	var nilBlock *anthropic.ContentBlockUnion
+	ensureValidToolInput(nilBlock) // should not panic
+
+	// non-tool_use block — no-op.
+	nonTool := &anthropic.ContentBlockUnion{Type: "text", Input: json.RawMessage("{bad")}
+	ensureValidToolInput(nonTool)
+	assert.Equal(t, json.RawMessage("{bad"), nonTool.Input, "non-tool_use Input must not be modified")
+
+	// tool_use with nil Input — reset to {}.
+	nilInput := &anthropic.ContentBlockUnion{Type: "tool_use"}
+	ensureValidToolInput(nilInput)
+	assert.Equal(t, json.RawMessage("{}"), nilInput.Input)
+
+	// tool_use with empty Input — reset to {}.
+	emptyInput := &anthropic.ContentBlockUnion{Type: "tool_use", Input: json.RawMessage("")}
+	ensureValidToolInput(emptyInput)
+	assert.Equal(t, json.RawMessage("{}"), emptyInput.Input)
+
+	// tool_use with whitespace-only Input — reset to {}.
+	wsInput := &anthropic.ContentBlockUnion{Type: "tool_use", Input: json.RawMessage("  ")}
+	ensureValidToolInput(wsInput)
+	assert.Equal(t, json.RawMessage("{}"), wsInput.Input)
+
+	// tool_use with partial JSON — reset to {}.
+	partialInput := &anthropic.ContentBlockUnion{Type: "tool_use", Input: json.RawMessage("{")}
+	ensureValidToolInput(partialInput)
+	assert.Equal(t, json.RawMessage("{}"), partialInput.Input)
+
+	// tool_use with valid JSON — unchanged.
+	validInput := &anthropic.ContentBlockUnion{Type: "tool_use", Input: json.RawMessage(`{"key":"val"}`)}
+	ensureValidToolInput(validInput)
+	assert.Equal(t, json.RawMessage(`{"key":"val"}`), validInput.Input)
 }
 
 func mustMessageStreamEventUnion(t *testing.T, raw string) anthropic.MessageStreamEventUnion {

--- a/model/anthropic/anthropic_test.go
+++ b/model/anthropic/anthropic_test.go
@@ -2110,10 +2110,16 @@ func Test_StreamingMessageAccumulator_ErrorPaths(t *testing.T) {
 		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"x"}}`)), "no content block")
 	require.ErrorContains(t, acc.Accumulate(mustMessageStreamEventUnion(t,
 		`{"type":"content_block_stop","index":0}`)), "no content block")
+	// Partial JSON in tool-use Input is now handled gracefully:
+	// ensureValidToolInput resets invalid Input to {} before refreshContentBlockRawJSON.
 	acc.message.Content = []anthropic.ContentBlockUnion{{Type: "tool_use", Input: json.RawMessage("{")}}
 	acc.inputDeltaStartedAt = []bool{false}
-	require.ErrorContains(t, acc.Accumulate(mustMessageStreamEventUnion(t,
-		`{"type":"content_block_stop","index":0}`)), "error converting content block to JSON")
+	require.NoError(t, acc.Accumulate(mustMessageStreamEventUnion(t,
+		`{"type":"content_block_stop","index":0}`)))
+	// The invalid Input should have been reset to {}.
+	assert.Equal(t, json.RawMessage("{}"), acc.message.Content[0].Input)
+	// refreshContentBlockRawJSON and finalizeStreamingMessage still fail on
+	// invalid Input when called directly (no ensureValidToolInput guard).
 	require.Error(t, refreshContentBlockRawJSON(&anthropic.ContentBlockUnion{Type: "tool_use", Input: json.RawMessage("{")}))
 	require.Error(t, finalizeStreamingMessage(&anthropic.Message{
 		Content: []anthropic.ContentBlockUnion{{Type: "tool_use", Input: json.RawMessage("{")}},


### PR DESCRIPTION
…-standard API proxies

Add ensureValidToolInput to reset invalid/partial JSON Input to {} before refreshContentBlockRawJSON during content_block_stop. Also normalize null initial Input on content_block_start.

Fixes: #1550

## What changed

Describe the user-visible behavior, API, documentation, or example changes in
this pull request.

## Why

Explain the problem this solves and any compatibility considerations.

## Testing

List the commands or manual checks you ran. If a check is not applicable, say
why.

## Notes for reviewers

Call out areas that deserve extra attention, such as concurrency, persistence,
protocol compatibility, or public API changes.
