### PR TITLE
docs: clarify summary sync behavior

### DIFF
--- a/docs/mkdocs/en/session/summary.md
+++ b/docs/mkdocs/en/session/summary.md
@@ -97,6 +97,8 @@ sessionService, err := clickhouse.NewService(
 )
 ```
 
+`WithAsyncSummaryNum` only controls the concurrency of background async summary workers. It is not a sync/async mode switch, and it does not disable summary generation. To disable summaries, do not configure `WithSummarizer`. To make a long ReAct loop refresh the summary before the next LLM call within the same `Run`, configure `llmagent.WithSyncSummaryIntraRun(true)` on the Agent.
+
 ### Step 3: Configure Agent and Runner
 
 Create an Agent and configure summary injection behavior:
@@ -111,6 +113,8 @@ llmAgent := llmagent.New(
     "my-agent",
     llmagent.WithModel(summaryModel),
     llmagent.WithAddSessionSummary(true),
+    // Optional: use for long ReAct loops that need same-run strong consistency.
+    llmagent.WithSyncSummaryIntraRun(true),
     llmagent.WithMaxHistoryRuns(10),
 )
 
@@ -776,6 +780,8 @@ summarizer := summary.NewSummarizer(
 ### Automatic Trigger (Recommended)
 
 The Runner automatically checks trigger conditions after each conversation completes, generating summaries asynchronously in the background when conditions are met.
+
+When `WithSyncSummaryIntraRun(true)` is enabled, the Flow synchronously calls `CreateSessionSummary(...)` between LLM iterations in the same `Run`, so the next LLM call can use the latest summary. Redundant async enqueueing for intermediate tool results is skipped; the final assistant response can still enqueue an async summary job to refresh the turn-ending state without blocking user output. The sync path and async workers share the same boundary/delta checks and session/filterKey serialization, so they normally do not issue duplicate expensive LLM summaries for the same events.
 
 **Trigger timing**:
 

--- a/docs/mkdocs/en/session/summary.md
+++ b/docs/mkdocs/en/session/summary.md
@@ -113,8 +113,6 @@ llmAgent := llmagent.New(
     "my-agent",
     llmagent.WithModel(summaryModel),
     llmagent.WithAddSessionSummary(true),
-    // Optional: use for long ReAct loops that need same-run strong consistency.
-    llmagent.WithSyncSummaryIntraRun(true),
     llmagent.WithMaxHistoryRuns(10),
 )
 
@@ -125,6 +123,18 @@ r := runner.NewRunner(
 )
 
 eventChan, err := r.Run(ctx, userID, sessionID, userMessage)
+```
+
+Keep the main setup on the default async summary path. For long ReAct loops that must refresh the summary before the next LLM call in the same `Run`, add the sync intra-run option explicitly:
+
+```go
+llmAgent := llmagent.New(
+    "my-agent",
+    llmagent.WithModel(summaryModel),
+    llmagent.WithAddSessionSummary(true),
+    llmagent.WithSyncSummaryIntraRun(true),
+    llmagent.WithMaxHistoryRuns(10),
+)
 ```
 
 After completing the above configuration, the summary feature runs automatically.

--- a/docs/mkdocs/en/session/summary.md
+++ b/docs/mkdocs/en/session/summary.md
@@ -791,7 +791,7 @@ summarizer := summary.NewSummarizer(
 
 The Runner automatically checks trigger conditions after each conversation completes, generating summaries asynchronously in the background when conditions are met.
 
-When `WithSyncSummaryIntraRun(true)` is enabled, the Flow synchronously calls `CreateSessionSummary(...)` between LLM iterations in the same `Run`, so the next LLM call can use the latest summary. Redundant async enqueueing for intermediate tool results is skipped; the final assistant response can still enqueue an async summary job to refresh the turn-ending state without blocking user output. The sync path and async workers share the same boundary/delta checks and session/filterKey serialization, so they normally do not issue duplicate expensive LLM summaries for the same events.
+When `WithSyncSummaryIntraRun(true)` is enabled, the Flow synchronously calls `CreateSessionSummary(...)` between LLM iterations in the same `Run`, so the next LLM call can use the latest summary. Redundant async enqueueing for intermediate tool results is skipped; the final assistant response can still enqueue a summary job to refresh the turn-ending state. With an available async worker and queue capacity, that job runs in the background. If no async worker is configured or the queue is full, `EnqueueSummaryJob` may fall back to synchronous summary creation, so this is not a hard non-blocking guarantee. The sync path and async workers share the same boundary/delta checks and process-local session/filterKey serialization, which normally avoids duplicate expensive LLM summaries for the same events in a single process, but it is not a cross-instance distributed lock.
 
 **Trigger timing**:
 

--- a/docs/mkdocs/zh/session/summary.md
+++ b/docs/mkdocs/zh/session/summary.md
@@ -116,8 +116,6 @@ llmAgent := llmagent.New(
     "my-agent",
     llmagent.WithModel(summaryModel),
     llmagent.WithAddSessionSummary(true),   // 启用摘要注入
-    // 可选：同一次 Run 内的长 ReAct loop 需要强一致摘要时启用
-    llmagent.WithSyncSummaryIntraRun(true),
     llmagent.WithMaxHistoryRuns(10),        // 当AddSessionSummary=false时限制历史轮次
 )
 
@@ -130,6 +128,18 @@ r := runner.NewRunner(
 
 // 运行对话 - 摘要将自动管理
 eventChan, err := r.Run(ctx, userID, sessionID, userMessage)
+```
+
+主示例保持默认异步摘要路径。只有在长 ReAct loop 需要同一次 `Run` 内下一次 LLM 调用前立刻看到最新摘要时，才显式添加同步 intra-run 选项：
+
+```go
+llmAgent := llmagent.New(
+    "my-agent",
+    llmagent.WithModel(summaryModel),
+    llmagent.WithAddSessionSummary(true),   // 启用摘要注入
+    llmagent.WithSyncSummaryIntraRun(true),
+    llmagent.WithMaxHistoryRuns(10),        // 当AddSessionSummary=false时限制历史轮次
+)
 ```
 
 完成以上配置后，摘要功能即可自动运行。

--- a/docs/mkdocs/zh/session/summary.md
+++ b/docs/mkdocs/zh/session/summary.md
@@ -777,7 +777,7 @@ summarizer := summary.NewSummarizer(
 
 Runner 在每次对话完成后自动检查触发条件，满足条件时在后台异步生成摘要。
 
-如果启用了 `WithSyncSummaryIntraRun(true)`，Flow 会在同一次 `Run` 的 LLM 迭代之间同步调用 `CreateSessionSummary(...)`，确保下一次 LLM 调用前可以使用最新摘要。中间 tool result 的冗余异步入队会被跳过；最终 assistant response 仍然可以异步入队，用于刷新本轮结束后的摘要而不阻塞用户输出。同步路径与异步 worker 共享同一套 boundary/delta 判断和 session/filterKey 级别的串行控制，因此通常不会对同一批事件重复发起昂贵的 LLM 摘要。
+如果启用了 `WithSyncSummaryIntraRun(true)`，Flow 会在同一次 `Run` 的 LLM 迭代之间同步调用 `CreateSessionSummary(...)`，确保下一次 LLM 调用前可以使用最新摘要。中间 tool result 的冗余异步入队会被跳过；最终 assistant response 仍然可以入队一个摘要任务，用于刷新本轮结束后的摘要。在 async worker 可用且队列有容量时，该任务会在后台执行；如果没有配置 async worker 或队列已满，`EnqueueSummaryJob` 可能 fallback 到同步摘要创建，因此这不是严格的非阻塞保证。同步路径与异步 worker 共享同一套 boundary/delta 判断和进程内 session/filterKey 级别的串行控制，在单进程内通常可以避免对同一批事件重复发起昂贵的 LLM 摘要，但它不是跨实例分布式锁。
 
 **触发时机**：
 

--- a/docs/mkdocs/zh/session/summary.md
+++ b/docs/mkdocs/zh/session/summary.md
@@ -99,6 +99,8 @@ sessionService, err := clickhouse.NewService(
 )
 ```
 
+`WithAsyncSummaryNum` 只控制后台异步摘要 worker 的并发数，不是同步/异步模式开关，也不是关闭摘要功能的开关。如果不需要生成摘要，不配置 `WithSummarizer` 即可；如果需要在同一次 `Run` 的长 ReAct loop 中让下一次 LLM 调用前立刻看到最新摘要，应在 Agent 侧使用 `llmagent.WithSyncSummaryIntraRun(true)`。
+
 ### 步骤 3：配置 Agent 和 Runner
 
 创建 Agent 并配置摘要注入行为：
@@ -114,6 +116,8 @@ llmAgent := llmagent.New(
     "my-agent",
     llmagent.WithModel(summaryModel),
     llmagent.WithAddSessionSummary(true),   // 启用摘要注入
+    // 可选：同一次 Run 内的长 ReAct loop 需要强一致摘要时启用
+    llmagent.WithSyncSummaryIntraRun(true),
     llmagent.WithMaxHistoryRuns(10),        // 当AddSessionSummary=false时限制历史轮次
 )
 
@@ -762,6 +766,8 @@ summarizer := summary.NewSummarizer(
 ### 自动触发（推荐）
 
 Runner 在每次对话完成后自动检查触发条件，满足条件时在后台异步生成摘要。
+
+如果启用了 `WithSyncSummaryIntraRun(true)`，Flow 会在同一次 `Run` 的 LLM 迭代之间同步调用 `CreateSessionSummary(...)`，确保下一次 LLM 调用前可以使用最新摘要。中间 tool result 的冗余异步入队会被跳过；最终 assistant response 仍然可以异步入队，用于刷新本轮结束后的摘要而不阻塞用户输出。同步路径与异步 worker 共享同一套 boundary/delta 判断和 session/filterKey 级别的串行控制，因此通常不会对同一批事件重复发起昂贵的 LLM 摘要。
 
 **触发时机**：
 


### PR DESCRIPTION
## Summary
- clarify that `WithAsyncSummaryNum` only controls async summary worker concurrency
- document `WithSyncSummaryIntraRun(true)` as the same-run strong-consistency option for long ReAct loops
- explain how sync intra-run summary coexists with async turn-end summary jobs without duplicate expensive summarization

## Testing
- `git diff --check`

Close #1966 #1967
