### PR TITLE
codeexecutor: add tool code orchestration

### DIFF
--- a/codeexecutor/codeact/doc.go
+++ b/codeexecutor/codeact/doc.go
@@ -1,0 +1,7 @@
+// Package codeact runs generated Python through a capability-limited tool gateway.
+//
+// CodeAct does not make Python safe by itself. The guest process must run in an
+// isolated container, microVM, or an equivalent sandbox. This package owns the
+// host-side security boundary: only explicitly registered tools can be called,
+// and their input and output schemas are validated on the Go side.
+package codeact

--- a/codeexecutor/codeact/doc.go
+++ b/codeexecutor/codeact/doc.go
@@ -1,3 +1,11 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
 // Package codeact runs generated Python through a capability-limited tool gateway.
 //
 // CodeAct does not make Python safe by itself. The guest process must run in an

--- a/codeexecutor/codeact/gateway.go
+++ b/codeexecutor/codeact/gateway.go
@@ -1,3 +1,11 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
 package codeact
 
 import (

--- a/codeexecutor/codeact/gateway.go
+++ b/codeexecutor/codeact/gateway.go
@@ -1,0 +1,149 @@
+package codeact
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+
+	jsonschema "github.com/santhosh-tekuri/jsonschema/v6"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+// Gateway is the host-side capability boundary exposed to generated code.
+// It deliberately accepts and returns JSON so a guest language never receives
+// Go object references or host credentials.
+type Gateway struct {
+	tools map[string]registeredTool
+}
+
+type registeredTool struct {
+	tool         tool.CallableTool
+	inputSchema  *jsonschema.Schema
+	outputSchema *jsonschema.Schema
+}
+
+// NewGateway creates an allowlist gateway. Duplicate and unnamed tools are
+// rejected because ambiguity is unsafe for generated code.
+func NewGateway(tools ...tool.CallableTool) (*Gateway, error) {
+	g := &Gateway{tools: make(map[string]registeredTool, len(tools))}
+	for _, candidate := range tools {
+		if candidate == nil || candidate.Declaration() == nil {
+			return nil, fmt.Errorf("codeact: tool declaration is required")
+		}
+		name := strings.TrimSpace(candidate.Declaration().Name)
+		if name == "" {
+			return nil, fmt.Errorf("codeact: tool name is required")
+		}
+		if _, ok := g.tools[name]; ok {
+			return nil, fmt.Errorf("codeact: duplicate tool %q", name)
+		}
+		decl := candidate.Declaration()
+		inputSchema, err := compileSchema(decl.InputSchema, name, "input")
+		if err != nil {
+			return nil, err
+		}
+		outputSchema, err := compileSchema(decl.OutputSchema, name, "output")
+		if err != nil {
+			return nil, err
+		}
+		g.tools[name] = registeredTool{
+			tool:         candidate,
+			inputSchema:  inputSchema,
+			outputSchema: outputSchema,
+		}
+	}
+	return g, nil
+}
+
+// Names returns the stable list of capabilities available to guest code.
+func (g *Gateway) Names() []string {
+	names := make([]string, 0, len(g.tools))
+	for name := range g.tools {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// Call validates a JSON argument object, invokes one allowlisted tool, then
+// validates and serializes its result before returning it to the guest.
+func (g *Gateway) Call(ctx context.Context, name string, args json.RawMessage) (json.RawMessage, error) {
+	if g == nil {
+		return nil, fmt.Errorf("codeact: nil gateway")
+	}
+	registered, ok := g.tools[name]
+	if !ok {
+		return nil, fmt.Errorf("codeact: tool %q is not allowlisted", name)
+	}
+	if err := validateJSON(args, registered.inputSchema, "input"); err != nil {
+		return nil, err
+	}
+	value, err := registered.tool.Call(ctx, args)
+	if err != nil {
+		return nil, fmt.Errorf("codeact: call %q: %w", name, err)
+	}
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("codeact: encode result from %q: %w", name, err)
+	}
+	if registered.outputSchema != nil {
+		if err := validateJSON(raw, registered.outputSchema, "output"); err != nil {
+			return nil, err
+		}
+	}
+	return raw, nil
+}
+
+// HandleToolCall implements ToolCallHandler.
+func (g *Gateway) HandleToolCall(ctx context.Context, call ToolCall) (json.RawMessage, error) {
+	return g.Call(ctx, call.Name, call.Args)
+}
+
+func compileSchema(schema *tool.Schema, toolName, direction string) (*jsonschema.Schema, error) {
+	if schema == nil {
+		return nil, nil
+	}
+	raw, err := json.Marshal(schema)
+	if err != nil {
+		return nil, fmt.Errorf("codeact: encode %s schema for %q: %w", direction, toolName, err)
+	}
+	document, err := jsonschema.UnmarshalJSON(bytes.NewReader(raw))
+	if err != nil {
+		return nil, fmt.Errorf("codeact: decode %s schema for %q: %w", direction, toolName, err)
+	}
+	location := fmt.Sprintf("https://codeact.invalid/tools/%s/%s.json", url.PathEscape(toolName), direction)
+	compiler := jsonschema.NewCompiler()
+	compiler.UseLoader(rejectExternalSchemaLoader{})
+	if err := compiler.AddResource(location, document); err != nil {
+		return nil, fmt.Errorf("codeact: register %s schema for %q: %w", direction, toolName, err)
+	}
+	compiled, err := compiler.Compile(location)
+	if err != nil {
+		return nil, fmt.Errorf("codeact: compile %s schema for %q: %w", direction, toolName, err)
+	}
+	return compiled, nil
+}
+
+type rejectExternalSchemaLoader struct{}
+
+func (rejectExternalSchemaLoader) Load(location string) (any, error) {
+	return nil, fmt.Errorf("codeact: external schema reference %q is not allowed", location)
+}
+
+func validateJSON(raw []byte, schema *jsonschema.Schema, direction string) error {
+	if schema == nil {
+		return nil
+	}
+	value, err := jsonschema.UnmarshalJSON(bytes.NewReader(raw))
+	if err != nil {
+		return fmt.Errorf("codeact: invalid %s JSON: %w", direction, err)
+	}
+	if err := schema.Validate(value); err != nil {
+		return fmt.Errorf("codeact: invalid %s: %w", direction, err)
+	}
+	return nil
+}

--- a/codeexecutor/codeact/gateway.go
+++ b/codeexecutor/codeact/gateway.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"reflect"
 	"sort"
 	"strings"
 
@@ -39,17 +40,20 @@ type registeredTool struct {
 func NewGateway(tools ...tool.CallableTool) (*Gateway, error) {
 	g := &Gateway{tools: make(map[string]registeredTool, len(tools))}
 	for _, candidate := range tools {
-		if candidate == nil || candidate.Declaration() == nil {
+		if isNilTool(candidate) {
 			return nil, fmt.Errorf("codeact: tool declaration is required")
 		}
-		name := strings.TrimSpace(candidate.Declaration().Name)
+		decl := candidate.Declaration()
+		if decl == nil {
+			return nil, fmt.Errorf("codeact: tool declaration is required")
+		}
+		name := strings.TrimSpace(decl.Name)
 		if name == "" {
 			return nil, fmt.Errorf("codeact: tool name is required")
 		}
 		if _, ok := g.tools[name]; ok {
 			return nil, fmt.Errorf("codeact: duplicate tool %q", name)
 		}
-		decl := candidate.Declaration()
 		inputSchema, err := compileSchema(decl.InputSchema, name, "input")
 		if err != nil {
 			return nil, err
@@ -65,6 +69,19 @@ func NewGateway(tools ...tool.CallableTool) (*Gateway, error) {
 		}
 	}
 	return g, nil
+}
+
+func isNilTool(candidate tool.CallableTool) bool {
+	if candidate == nil {
+		return true
+	}
+	value := reflect.ValueOf(candidate)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
 }
 
 // Names returns the stable list of capabilities available to guest code.

--- a/codeexecutor/codeact/gateway_test.go
+++ b/codeexecutor/codeact/gateway_test.go
@@ -1,8 +1,17 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
 package codeact
 
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -130,4 +139,49 @@ func TestGatewayValidatesOutputJSONSchema(t *testing.T) {
 	require.NoError(t, err)
 	_, err = g.Call(context.Background(), "bad-output", json.RawMessage(`{}`))
 	require.ErrorContains(t, err, "invalid output")
+}
+
+func TestNewGatewayRejectsInvalidTools(t *testing.T) {
+	valid := testTool{declaration: &tool.Declaration{Name: "valid"}}
+	tests := []struct {
+		name  string
+		tools []tool.CallableTool
+		want  string
+	}{
+		{name: "nil tool", tools: []tool.CallableTool{nil}, want: "declaration is required"},
+		{name: "nil declaration", tools: []tool.CallableTool{testTool{}}, want: "declaration is required"},
+		{name: "blank name", tools: []tool.CallableTool{testTool{declaration: &tool.Declaration{}}}, want: "tool name is required"},
+		{name: "duplicate name", tools: []tool.CallableTool{valid, valid}, want: "duplicate tool"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewGateway(tt.tools...)
+			require.ErrorContains(t, err, tt.want)
+		})
+	}
+}
+
+func TestGatewayNamesAndCallFailures(t *testing.T) {
+	toolError := errors.New("tool failed")
+	g, err := NewGateway(
+		testTool{declaration: &tool.Declaration{Name: "zeta", InputSchema: &tool.Schema{Type: "object"}}, call: func([]byte) (any, error) {
+			return nil, toolError
+		}},
+		testTool{declaration: &tool.Declaration{Name: "alpha"}, call: func([]byte) (any, error) {
+			return make(chan int), nil
+		}},
+	)
+	require.NoError(t, err)
+	require.Equal(t, []string{"alpha", "zeta"}, g.Names())
+
+	var nilGateway *Gateway
+	_, err = nilGateway.Call(context.Background(), "alpha", json.RawMessage(`{}`))
+	require.ErrorContains(t, err, "nil gateway")
+
+	_, err = g.Call(context.Background(), "zeta", json.RawMessage(`not-json`))
+	require.ErrorContains(t, err, "invalid input JSON")
+	_, err = g.Call(context.Background(), "zeta", json.RawMessage(`{}`))
+	require.ErrorIs(t, err, toolError)
+	_, err = g.Call(context.Background(), "alpha", json.RawMessage(`{}`))
+	require.ErrorContains(t, err, "encode result")
 }

--- a/codeexecutor/codeact/gateway_test.go
+++ b/codeexecutor/codeact/gateway_test.go
@@ -1,0 +1,133 @@
+package codeact
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+type testTool struct {
+	declaration *tool.Declaration
+	call        func([]byte) (any, error)
+}
+
+func (t testTool) Declaration() *tool.Declaration                   { return t.declaration }
+func (t testTool) Call(_ context.Context, args []byte) (any, error) { return t.call(args) }
+
+func TestGatewayValidatesAndOnlyCallsAllowlistedTools(t *testing.T) {
+	called := false
+	add := testTool{declaration: &tool.Declaration{Name: "add", InputSchema: &tool.Schema{Type: "object", Required: []string{"a", "b"}, Properties: map[string]*tool.Schema{"a": {Type: "integer"}, "b": {Type: "integer"}}, AdditionalProperties: false}, OutputSchema: &tool.Schema{Type: "object", Required: []string{"sum"}, Properties: map[string]*tool.Schema{"sum": {Type: "integer"}}}}, call: func(raw []byte) (any, error) {
+		called = true
+		var in struct{ A, B int }
+		require.NoError(t, json.Unmarshal(raw, &in))
+		return map[string]int{"sum": in.A + in.B}, nil
+	}}
+	g, err := NewGateway(add)
+	require.NoError(t, err)
+	_, err = g.Call(context.Background(), "missing", json.RawMessage(`{}`))
+	require.Error(t, err)
+	_, err = g.Call(context.Background(), "add", json.RawMessage(`{"a":1}`))
+	require.Error(t, err)
+	require.False(t, called)
+	raw, err := g.Call(context.Background(), "add", json.RawMessage(`{"a":2,"b":3}`))
+	require.NoError(t, err)
+	require.JSONEq(t, `{"sum":5}`, string(raw))
+	require.True(t, called)
+}
+
+func TestGatewayValidatesCompleteJSONSchema(t *testing.T) {
+	called := false
+	validate := testTool{
+		declaration: &tool.Declaration{
+			Name: "validate",
+			InputSchema: &tool.Schema{
+				Type:                 "object",
+				Required:             []string{"item", "labels", "mode"},
+				AdditionalProperties: false,
+				Properties: map[string]*tool.Schema{
+					"item":   {Ref: "#/$defs/item"},
+					"labels": {Type: "object", AdditionalProperties: &tool.Schema{Type: "string"}},
+					"mode":   {Enum: []any{1}},
+				},
+				Defs: map[string]*tool.Schema{
+					"item": {
+						Type:                 "object",
+						Required:             []string{"code"},
+						AdditionalProperties: false,
+						Properties: map[string]*tool.Schema{
+							"code": {Type: "string", Pattern: "^[A-Z]{2}-[0-9]{2}$"},
+						},
+					},
+				},
+			},
+		},
+		call: func([]byte) (any, error) {
+			called = true
+			return map[string]any{"ok": true}, nil
+		},
+	}
+	g, err := NewGateway(validate)
+	require.NoError(t, err)
+
+	for _, args := range []string{
+		`{"item":{"code":"bad"},"labels":{"env":"prod"},"mode":1}`,
+		`{"item":{"code":"AB-12","extra":true},"labels":{"env":"prod"},"mode":1}`,
+		`{"item":{"code":"AB-12"},"labels":{"env":1},"mode":1}`,
+		`{"item":{"code":"AB-12"},"labels":{"env":"prod"},"mode":"1"}`,
+		`{"item":{"code":"AB-12"},"labels":{"env":"prod"},"mode":1,"extra":true}`,
+	} {
+		_, err := g.Call(context.Background(), "validate", json.RawMessage(args))
+		require.Error(t, err, args)
+		require.False(t, called)
+	}
+
+	_, err = g.Call(context.Background(), "validate", json.RawMessage(`{"item":{"code":"AB-12"},"labels":{"env":"prod"},"mode":1}`))
+	require.NoError(t, err)
+	require.True(t, called)
+}
+
+func TestGatewayRejectsInvalidSchemaAtConstruction(t *testing.T) {
+	_, err := NewGateway(testTool{
+		declaration: &tool.Declaration{
+			Name:        "invalid",
+			InputSchema: &tool.Schema{Type: "string", Pattern: "("},
+		},
+		call: func([]byte) (any, error) { return nil, nil },
+	})
+	require.Error(t, err)
+}
+
+func TestGatewayRejectsExternalSchemaReferenceAtConstruction(t *testing.T) {
+	_, err := NewGateway(testTool{
+		declaration: &tool.Declaration{
+			Name:        "external-ref",
+			InputSchema: &tool.Schema{Ref: "https://example.invalid/schema.json"},
+		},
+		call: func([]byte) (any, error) { return nil, nil },
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "external schema reference")
+}
+
+func TestGatewayValidatesOutputJSONSchema(t *testing.T) {
+	g, err := NewGateway(testTool{
+		declaration: &tool.Declaration{
+			Name: "bad-output",
+			OutputSchema: &tool.Schema{
+				Type:                 "object",
+				Required:             []string{"code"},
+				AdditionalProperties: false,
+				Properties: map[string]*tool.Schema{
+					"code": {Type: "string", Pattern: "^[A-Z]{2}-[0-9]{2}$"},
+				},
+			},
+		},
+		call: func([]byte) (any, error) { return map[string]string{"code": "bad"}, nil },
+	})
+	require.NoError(t, err)
+	_, err = g.Call(context.Background(), "bad-output", json.RawMessage(`{}`))
+	require.ErrorContains(t, err, "invalid output")
+}

--- a/codeexecutor/codeact/gateway_test.go
+++ b/codeexecutor/codeact/gateway_test.go
@@ -26,6 +26,13 @@ type testTool struct {
 func (t testTool) Declaration() *tool.Declaration                   { return t.declaration }
 func (t testTool) Call(_ context.Context, args []byte) (any, error) { return t.call(args) }
 
+type pointerTestTool struct{}
+
+func (*pointerTestTool) Declaration() *tool.Declaration { return &tool.Declaration{Name: "pointer"} }
+func (*pointerTestTool) Call(context.Context, []byte) (any, error) {
+	return nil, nil
+}
+
 func TestGatewayValidatesAndOnlyCallsAllowlistedTools(t *testing.T) {
 	called := false
 	add := testTool{declaration: &tool.Declaration{Name: "add", InputSchema: &tool.Schema{Type: "object", Required: []string{"a", "b"}, Properties: map[string]*tool.Schema{"a": {Type: "integer"}, "b": {Type: "integer"}}, AdditionalProperties: false}, OutputSchema: &tool.Schema{Type: "object", Required: []string{"sum"}, Properties: map[string]*tool.Schema{"sum": {Type: "integer"}}}}, call: func(raw []byte) (any, error) {
@@ -143,12 +150,14 @@ func TestGatewayValidatesOutputJSONSchema(t *testing.T) {
 
 func TestNewGatewayRejectsInvalidTools(t *testing.T) {
 	valid := testTool{declaration: &tool.Declaration{Name: "valid"}}
+	var typedNil *pointerTestTool
 	tests := []struct {
 		name  string
 		tools []tool.CallableTool
 		want  string
 	}{
 		{name: "nil tool", tools: []tool.CallableTool{nil}, want: "declaration is required"},
+		{name: "typed nil tool", tools: []tool.CallableTool{typedNil}, want: "declaration is required"},
 		{name: "nil declaration", tools: []tool.CallableTool{testTool{}}, want: "declaration is required"},
 		{name: "blank name", tools: []tool.CallableTool{testTool{declaration: &tool.Declaration{}}}, want: "tool name is required"},
 		{name: "duplicate name", tools: []tool.CallableTool{valid, valid}, want: "duplicate tool"},

--- a/codeexecutor/codeact/guest.py
+++ b/codeexecutor/codeact/guest.py
@@ -1,0 +1,39 @@
+import asyncio
+import contextlib
+import io
+import json
+import sys
+import uuid
+
+def send(v):
+    sys.__stdout__.write(json.dumps(v, separators=(",", ":")) + "\n")
+    sys.__stdout__.flush()
+
+async def call_tool(name, **kwargs):
+    call_id = str(uuid.uuid4())
+    send({"type":"tool_call", "id":call_id, "name":name, "args":kwargs})
+    line = sys.stdin.readline()
+    if not line:
+        raise RuntimeError("host closed tool bridge")
+    reply = json.loads(line)
+    if reply.get("type") != "tool_result" or reply.get("id") != call_id:
+        raise RuntimeError("invalid tool bridge response")
+    if reply.get("error"):
+        raise RuntimeError(reply["error"])
+    return reply.get("result")
+
+async def main(code):
+    scope = {"call_tool": call_tool, "asyncio": asyncio}
+    wrapped = "async def __codeact_main__():\n" + "\n".join("    " + line for line in code.splitlines())
+    exec(compile(wrapped, "<codeact>", "exec"), scope, scope)
+    return await scope["__codeact_main__"]()
+
+line = sys.stdin.readline()
+try:
+    request = json.loads(line)
+    stdout = io.StringIO()
+    with contextlib.redirect_stdout(stdout):
+        result = asyncio.run(main(request["code"]))
+    send({"type":"complete", "args":result, "code":stdout.getvalue()})
+except BaseException as exc:
+    send({"type":"complete", "name":type(exc).__name__ + ": " + str(exc), "args":None, "code":""})

--- a/codeexecutor/codeact/runtime_test.go
+++ b/codeexecutor/codeact/runtime_test.go
@@ -1,0 +1,54 @@
+package codeact
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+func TestRuntimeAbstractionDoesNotRequireStdio(t *testing.T) {
+	add := testTool{
+		declaration: &tool.Declaration{
+			Name: "add",
+			InputSchema: &tool.Schema{
+				Type:                 "object",
+				Required:             []string{"a", "b"},
+				AdditionalProperties: false,
+				Properties: map[string]*tool.Schema{
+					"a": {Type: "integer"},
+					"b": {Type: "integer"},
+				},
+			},
+		},
+		call: func(raw []byte) (any, error) {
+			var in struct{ A, B int }
+			require.NoError(t, json.Unmarshal(raw, &in))
+			return map[string]int{"sum": in.A + in.B}, nil
+		},
+	}
+	gateway, err := NewGateway(add)
+	require.NoError(t, err)
+
+	result, err := Execute(context.Background(), fakeRemoteRuntime{}, gateway, "ignored by fake")
+	require.NoError(t, err)
+	require.JSONEq(t, `{"sum":3}`, string(result.Value))
+}
+
+type fakeRemoteRuntime struct{}
+
+func (fakeRemoteRuntime) ExecuteCodeAct(ctx context.Context, _ Request, handler ToolCallHandler) (Result, error) {
+	value, err := handler.HandleToolCall(ctx, ToolCall{
+		ID:   "remote-call-1",
+		Name: "add",
+		Args: json.RawMessage(`{"a":1,"b":2}`),
+	})
+	if err != nil {
+		return Result{}, err
+	}
+	return Result{Value: value}, nil
+}
+
+var _ Runtime = fakeRemoteRuntime{}

--- a/codeexecutor/codeact/runtime_test.go
+++ b/codeexecutor/codeact/runtime_test.go
@@ -1,3 +1,11 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
 package codeact
 
 import (
@@ -35,6 +43,26 @@ func TestRuntimeAbstractionDoesNotRequireStdio(t *testing.T) {
 	result, err := Execute(context.Background(), fakeRemoteRuntime{}, gateway, "ignored by fake")
 	require.NoError(t, err)
 	require.JSONEq(t, `{"sum":3}`, string(result.Value))
+}
+
+func TestExecuteValidatesRequiredInputs(t *testing.T) {
+	tests := []struct {
+		name    string
+		runtime Runtime
+		handler ToolCallHandler
+		code    string
+		want    string
+	}{
+		{name: "runtime", handler: fakeToolCallHandler{}, code: "return 1", want: "runtime is required"},
+		{name: "handler", runtime: fakeRemoteRuntime{}, code: "return 1", want: "tool call handler is required"},
+		{name: "code", runtime: fakeRemoteRuntime{}, handler: fakeToolCallHandler{}, want: "code is required"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Execute(context.Background(), tt.runtime, tt.handler, tt.code)
+			require.ErrorContains(t, err, tt.want)
+		})
+	}
 }
 
 type fakeRemoteRuntime struct{}

--- a/codeexecutor/codeact/stdio.go
+++ b/codeexecutor/codeact/stdio.go
@@ -1,3 +1,11 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
 package codeact
 
 import (

--- a/codeexecutor/codeact/stdio.go
+++ b/codeexecutor/codeact/stdio.go
@@ -1,0 +1,197 @@
+package codeact
+
+import (
+	"bufio"
+	"context"
+	_ "embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+//go:embed guest.py
+var guestPython string
+
+// stdioRunner starts a guest process that speaks the local stdio protocol.
+// It is an implementation detail of LocalRunner; non-stdio backends implement
+// Runtime directly.
+type stdioRunner interface {
+	start(context.Context, string) (stdioProcess, error)
+}
+
+type stdioProcess interface {
+	Stdin() io.WriteCloser
+	Stdout() io.ReadCloser
+	Wait() error
+	Kill() error
+}
+
+// LocalRunner runs the guest with a caller-supplied Python executable. Use it
+// only in an already isolated environment or for development/tests.
+type LocalRunner struct{ Python string }
+
+func (r LocalRunner) start(ctx context.Context, script string) (stdioProcess, error) {
+	python := r.Python
+	if python == "" {
+		python = "python3"
+	}
+	dir, err := os.MkdirTemp("", "trpc-codeact-")
+	if err != nil {
+		return nil, err
+	}
+	path := filepath.Join(dir, "guest.py")
+	if err := os.WriteFile(path, []byte(script), 0o600); err != nil {
+		_ = os.RemoveAll(dir)
+		return nil, err
+	}
+	cmd := exec.CommandContext(ctx, python, "-u", path)
+	in, err := cmd.StdinPipe()
+	if err != nil {
+		_ = os.RemoveAll(dir)
+		return nil, err
+	}
+	out, err := cmd.StdoutPipe()
+	if err != nil {
+		_ = os.RemoveAll(dir)
+		return nil, err
+	}
+	if err := cmd.Start(); err != nil {
+		_ = os.RemoveAll(dir)
+		return nil, err
+	}
+	return &localProcess{
+		cmd:     cmd,
+		in:      in,
+		out:     out,
+		cleanup: func() { _ = os.RemoveAll(dir) },
+	}, nil
+}
+
+// ExecuteCodeAct implements Runtime using a fresh local Python stdio guest.
+func (r LocalRunner) ExecuteCodeAct(ctx context.Context, req Request, handler ToolCallHandler) (Result, error) {
+	return executeStdio(ctx, r, req, handler)
+}
+
+type localProcess struct {
+	cmd     *exec.Cmd
+	in      io.WriteCloser
+	out     io.ReadCloser
+	cleanup func()
+}
+
+func (p *localProcess) Stdin() io.WriteCloser { return p.in }
+func (p *localProcess) Stdout() io.ReadCloser { return p.out }
+func (p *localProcess) Kill() error {
+	if p.cmd.Process == nil {
+		return nil
+	}
+	return p.cmd.Process.Kill()
+}
+func (p *localProcess) Wait() error {
+	err := p.cmd.Wait()
+	p.cleanup()
+	return err
+}
+
+type protocolMessage struct {
+	Type string          `json:"type"`
+	ID   string          `json:"id,omitempty"`
+	Name string          `json:"name,omitempty"`
+	Args json.RawMessage `json:"args,omitempty"`
+	Code string          `json:"code,omitempty"`
+}
+
+type protocolResponse struct {
+	Type   string          `json:"type"`
+	ID     string          `json:"id,omitempty"`
+	Result json.RawMessage `json:"result,omitempty"`
+	Error  string          `json:"error,omitempty"`
+}
+
+func executeStdio(ctx context.Context, runner stdioRunner, req Request, handler ToolCallHandler) (Result, error) {
+	if runner == nil {
+		return Result{}, errRequired("runner")
+	}
+	if handler == nil {
+		return Result{}, errRequired("tool call handler")
+	}
+	if req.Code == "" {
+		return Result{}, errRequired("code")
+	}
+	p, err := runner.start(ctx, guestPython)
+	if err != nil {
+		return Result{}, fmt.Errorf("codeact: start guest: %w", err)
+	}
+	waited := false
+	stdinClosed := false
+	closeStdin := func() {
+		if !stdinClosed {
+			_ = p.Stdin().Close()
+			stdinClosed = true
+		}
+	}
+	defer func() {
+		closeStdin()
+		if !waited {
+			_ = p.Kill()
+			_ = p.Wait()
+		}
+	}()
+
+	enc := json.NewEncoder(p.Stdin())
+	dec := bufio.NewScanner(p.Stdout())
+	dec.Buffer(make([]byte, 1024), 4<<20)
+	if err := enc.Encode(protocolMessage{Type: "run", Code: req.Code}); err != nil {
+		return Result{}, err
+	}
+	for dec.Scan() {
+		var msg protocolMessage
+		if err := json.Unmarshal(dec.Bytes(), &msg); err != nil {
+			return Result{}, fmt.Errorf("codeact: malformed guest message: %w", err)
+		}
+		switch msg.Type {
+		case "tool_call":
+			value, callErr := handler.HandleToolCall(ctx, ToolCall{
+				ID:   msg.ID,
+				Name: msg.Name,
+				Args: msg.Args,
+			})
+			out := protocolResponse{Type: "tool_result", ID: msg.ID, Result: value}
+			if callErr != nil {
+				out.Error = callErr.Error()
+			}
+			if err := enc.Encode(out); err != nil {
+				return Result{}, err
+			}
+		case "complete":
+			closeStdin()
+			waitErr := p.Wait()
+			waited = true
+			if waitErr != nil {
+				return Result{}, fmt.Errorf("codeact: wait for guest: %w", waitErr)
+			}
+			if msg.Name != "" {
+				return Result{}, errors.New(msg.Name)
+			}
+			return Result{Value: msg.Args, Stdout: msg.Code}, nil
+		default:
+			return Result{}, fmt.Errorf("codeact: unknown guest message %q", msg.Type)
+		}
+	}
+	if err := dec.Err(); err != nil {
+		return Result{}, err
+	}
+	select {
+	case <-ctx.Done():
+		return Result{}, ctx.Err()
+	case <-time.After(10 * time.Millisecond):
+	}
+	return Result{}, errors.New("codeact: guest exited without a completion message")
+}
+
+var _ Runtime = LocalRunner{}

--- a/codeexecutor/codeact/stdio.go
+++ b/codeexecutor/codeact/stdio.go
@@ -27,6 +27,7 @@ import (
 var guestPython string
 
 var completedGuestWaitTimeout = 2 * time.Second
+var completedGuestKillWaitTimeout = 100 * time.Millisecond
 
 // stdioRunner starts a guest process that speaks the local stdio protocol.
 // It is an implementation detail of LocalRunner; non-stdio backends implement
@@ -236,12 +237,16 @@ func waitForCompletedGuest(ctx context.Context, p stdioProcess, timeout time.Dur
 		}
 		return ctx.Err()
 	case <-timer.C:
-		_ = p.Kill()
+		killErr := p.Kill()
 		select {
-		case <-waitCh:
-		case <-time.After(100 * time.Millisecond):
+		case err := <-waitCh:
+			return err
+		case <-time.After(completedGuestKillWaitTimeout):
+			if killErr != nil {
+				return fmt.Errorf("kill timed-out guest: %w", killErr)
+			}
+			return errors.New("timed-out guest did not exit after kill")
 		}
-		return nil
 	}
 }
 

--- a/codeexecutor/codeact/stdio.go
+++ b/codeexecutor/codeact/stdio.go
@@ -19,11 +19,14 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
 //go:embed guest.py
 var guestPython string
+
+var completedGuestWaitTimeout = 2 * time.Second
 
 // stdioRunner starts a guest process that speaks the local stdio protocol.
 // It is an implementation detail of LocalRunner; non-stdio backends implement
@@ -131,6 +134,9 @@ func executeStdio(ctx context.Context, runner stdioRunner, req Request, handler 
 	if req.Code == "" {
 		return Result{}, errRequired("code")
 	}
+	if err := validateLocalLanguage(req.Language); err != nil {
+		return Result{}, err
+	}
 	p, err := runner.start(ctx, guestPython)
 	if err != nil {
 		return Result{}, fmt.Errorf("codeact: start guest: %w", err)
@@ -178,8 +184,8 @@ func executeStdio(ctx context.Context, runner stdioRunner, req Request, handler 
 			}
 		case "complete":
 			closeStdin()
-			waitErr := p.Wait()
 			waited = true
+			waitErr := waitForCompletedGuest(ctx, p, completedGuestWaitTimeout)
 			if waitErr != nil {
 				return Result{}, fmt.Errorf("codeact: wait for guest: %w", waitErr)
 			}
@@ -200,6 +206,43 @@ func executeStdio(ctx context.Context, runner stdioRunner, req Request, handler 
 	case <-time.After(10 * time.Millisecond):
 	}
 	return Result{}, errors.New("codeact: guest exited without a completion message")
+}
+
+func validateLocalLanguage(language string) error {
+	normalized := strings.TrimSpace(language)
+	if normalized == "" || strings.EqualFold(normalized, "python") {
+		return nil
+	}
+	return fmt.Errorf("codeact: unsupported language %q", language)
+}
+
+func waitForCompletedGuest(ctx context.Context, p stdioProcess, timeout time.Duration) error {
+	waitCh := make(chan error, 1)
+	go func() {
+		waitCh <- p.Wait()
+	}()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case err := <-waitCh:
+		return err
+	case <-ctx.Done():
+		_ = p.Kill()
+		select {
+		case <-waitCh:
+		case <-time.After(100 * time.Millisecond):
+		}
+		return ctx.Err()
+	case <-timer.C:
+		_ = p.Kill()
+		select {
+		case <-waitCh:
+		case <-time.After(100 * time.Millisecond):
+		}
+		return nil
+	}
 }
 
 var _ Runtime = LocalRunner{}

--- a/codeexecutor/codeact/stdio_test.go
+++ b/codeexecutor/codeact/stdio_test.go
@@ -17,6 +17,7 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
@@ -72,6 +73,16 @@ func TestExecuteStdioValidatesRequiredInputs(t *testing.T) {
 			require.ErrorContains(t, err, tt.want)
 		})
 	}
+}
+
+func TestExecuteStdioRejectsUnsupportedLanguage(t *testing.T) {
+	_, err := executeStdio(
+		context.Background(),
+		fakeStdioRunner{err: errors.New("runner should not start")},
+		Request{Code: "return 1", Language: "javascript"},
+		fakeToolCallHandler{},
+	)
+	require.ErrorContains(t, err, `unsupported language "javascript"`)
 }
 
 func TestExecuteStdioBridgesToolCalls(t *testing.T) {
@@ -148,6 +159,72 @@ func TestExecuteStdioReportsRunnerGuestAndContextErrors(t *testing.T) {
 		fakeToolCallHandler{},
 	)
 	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestExecuteStdioBoundsCompletedGuestWait(t *testing.T) {
+	originalTimeout := completedGuestWaitTimeout
+	completedGuestWaitTimeout = 10 * time.Millisecond
+	t.Cleanup(func() { completedGuestWaitTimeout = originalTimeout })
+
+	waitDone := make(chan struct{})
+	process := &fakeStdioProcess{
+		stdout: io.NopCloser(strings.NewReader(`{"type":"complete","args":{"answer":1},"code":"done\n"}
+`)),
+		waitFn: func() error {
+			<-waitDone
+			return nil
+		},
+		killFn: func() error {
+			close(waitDone)
+			return nil
+		},
+	}
+
+	start := time.Now()
+	result, err := executeStdio(
+		context.Background(),
+		fakeStdioRunner{process: process},
+		Request{Code: "return 1"},
+		fakeToolCallHandler{},
+	)
+	require.NoError(t, err)
+	require.Less(t, time.Since(start), 200*time.Millisecond)
+	require.JSONEq(t, `{"answer":1}`, string(result.Value))
+	require.Equal(t, "done\n", result.Stdout)
+	require.Equal(t, 1, process.kills)
+	require.Equal(t, 1, process.waits)
+}
+
+func TestExecuteStdioReturnsContextErrorWhileWaitingForCompletedGuest(t *testing.T) {
+	originalTimeout := completedGuestWaitTimeout
+	completedGuestWaitTimeout = time.Second
+	t.Cleanup(func() { completedGuestWaitTimeout = originalTimeout })
+
+	waitDone := make(chan struct{})
+	process := &fakeStdioProcess{
+		stdout: io.NopCloser(strings.NewReader(`{"type":"complete","args":{"answer":1}}
+`)),
+		waitFn: func() error {
+			<-waitDone
+			return nil
+		},
+		killFn: func() error {
+			close(waitDone)
+			return nil
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	_, err := executeStdio(
+		ctx,
+		fakeStdioRunner{process: process},
+		Request{Code: "return 1"},
+		fakeToolCallHandler{},
+	)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Equal(t, 1, process.kills)
+	require.Equal(t, 1, process.waits)
 }
 
 func TestExecuteStdioReportsProtocolEdgeCases(t *testing.T) {
@@ -249,7 +326,9 @@ type fakeStdioProcess struct {
 	kills       int
 	waits       int
 	stdinCloses int
+	waitFn      func() error
 	waitErr     error
+	killFn      func() error
 }
 
 func (p *fakeStdioProcess) Stdin() io.WriteCloser {
@@ -261,10 +340,16 @@ func (p *fakeStdioProcess) Stdin() io.WriteCloser {
 func (p *fakeStdioProcess) Stdout() io.ReadCloser { return p.stdout }
 func (p *fakeStdioProcess) Wait() error {
 	p.waits++
+	if p.waitFn != nil {
+		return p.waitFn()
+	}
 	return p.waitErr
 }
 func (p *fakeStdioProcess) Kill() error {
 	p.kills++
+	if p.killFn != nil {
+		return p.killFn()
+	}
 	return nil
 }
 

--- a/codeexecutor/codeact/stdio_test.go
+++ b/codeexecutor/codeact/stdio_test.go
@@ -1,9 +1,18 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
 package codeact
 
 import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"os/exec"
 	"strings"
@@ -44,9 +53,119 @@ func TestExecuteStdioReapsGuestAfterProtocolError(t *testing.T) {
 	require.Equal(t, 1, process.stdinCloses)
 }
 
-type fakeStdioRunner struct{ process *fakeStdioProcess }
+func TestExecuteStdioValidatesRequiredInputs(t *testing.T) {
+	process := &fakeStdioProcess{stdout: io.NopCloser(strings.NewReader(""))}
+	tests := []struct {
+		name    string
+		runner  stdioRunner
+		req     Request
+		handler ToolCallHandler
+		want    string
+	}{
+		{name: "runner", req: Request{Code: "return 1"}, handler: fakeToolCallHandler{}, want: "runner is required"},
+		{name: "handler", runner: fakeStdioRunner{process: process}, req: Request{Code: "return 1"}, want: "tool call handler is required"},
+		{name: "code", runner: fakeStdioRunner{process: process}, handler: fakeToolCallHandler{}, want: "code is required"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := executeStdio(context.Background(), tt.runner, tt.req, tt.handler)
+			require.ErrorContains(t, err, tt.want)
+		})
+	}
+}
 
-func (r fakeStdioRunner) start(context.Context, string) (stdioProcess, error) { return r.process, nil }
+func TestExecuteStdioBridgesToolCalls(t *testing.T) {
+	process := &fakeStdioProcess{stdout: io.NopCloser(strings.NewReader(`{"type":"tool_call","id":"call-1","name":"add","args":{"a":1,"b":2}}
+{"type":"complete","args":{"answer":3},"code":"done\n"}
+`))}
+	var got ToolCall
+	result, err := executeStdio(
+		context.Background(),
+		fakeStdioRunner{process: process},
+		Request{Code: "return 3"},
+		toolCallHandlerFunc(func(_ context.Context, call ToolCall) (json.RawMessage, error) {
+			got = call
+			return json.RawMessage(`3`), nil
+		}),
+	)
+	require.NoError(t, err)
+	require.Equal(t, "call-1", got.ID)
+	require.Equal(t, "add", got.Name)
+	require.JSONEq(t, `{"a":1,"b":2}`, string(got.Args))
+	require.JSONEq(t, `{"answer":3}`, string(result.Value))
+	require.Equal(t, "done\n", result.Stdout)
+	require.Equal(t, 0, process.kills)
+	require.Equal(t, 1, process.waits)
+	require.Equal(t, 1, process.stdinCloses)
+	require.Contains(t, process.stdin.String(), `"type":"run"`)
+	require.Contains(t, process.stdin.String(), `"type":"tool_result"`)
+	require.Contains(t, process.stdin.String(), `"result":3`)
+}
+
+func TestExecuteStdioReturnsHandlerErrorToGuest(t *testing.T) {
+	process := &fakeStdioProcess{stdout: io.NopCloser(strings.NewReader(`{"type":"tool_call","id":"call-1","name":"add","args":{}}
+{"type":"complete","args":null}
+`))}
+	result, err := executeStdio(
+		context.Background(),
+		fakeStdioRunner{process: process},
+		Request{Code: "return None"},
+		toolCallHandlerFunc(func(context.Context, ToolCall) (json.RawMessage, error) {
+			return nil, errors.New("denied")
+		}),
+	)
+	require.NoError(t, err)
+	require.JSONEq(t, "null", string(result.Value))
+	require.Contains(t, process.stdin.String(), `"error":"denied"`)
+}
+
+func TestExecuteStdioReportsRunnerGuestAndContextErrors(t *testing.T) {
+	tests := []struct {
+		name   string
+		ctx    context.Context
+		runner stdioRunner
+		want   string
+	}{
+		{name: "start", ctx: context.Background(), runner: fakeStdioRunner{err: errors.New("start failed")}, want: "start guest: start failed"},
+		{name: "guest", ctx: context.Background(), runner: fakeStdioRunner{process: &fakeStdioProcess{stdout: io.NopCloser(strings.NewReader(`{"type":"complete","name":"RuntimeError: boom"}
+`))}}, want: "RuntimeError: boom"},
+		{name: "wait", ctx: context.Background(), runner: fakeStdioRunner{process: &fakeStdioProcess{stdout: io.NopCloser(strings.NewReader(`{"type":"complete","args":1}
+`)), waitErr: errors.New("wait failed")}}, want: "wait for guest: wait failed"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := executeStdio(tt.ctx, tt.runner, Request{Code: "return 1"}, fakeToolCallHandler{})
+			require.ErrorContains(t, err, tt.want)
+		})
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := executeStdio(
+		ctx,
+		fakeStdioRunner{process: &fakeStdioProcess{stdout: io.NopCloser(strings.NewReader(""))}},
+		Request{Code: "return 1"},
+		fakeToolCallHandler{},
+	)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestLocalRunnerReturnsStartError(t *testing.T) {
+	_, err := LocalRunner{Python: "definitely-not-a-python-executable"}.start(context.Background(), "return 1")
+	require.Error(t, err)
+}
+
+type fakeStdioRunner struct {
+	process *fakeStdioProcess
+	err     error
+}
+
+func (r fakeStdioRunner) start(context.Context, string) (stdioProcess, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.process, nil
+}
 
 type fakeStdioProcess struct {
 	stdin       bytes.Buffer
@@ -54,6 +173,7 @@ type fakeStdioProcess struct {
 	kills       int
 	waits       int
 	stdinCloses int
+	waitErr     error
 }
 
 func (p *fakeStdioProcess) Stdin() io.WriteCloser {
@@ -62,7 +182,7 @@ func (p *fakeStdioProcess) Stdin() io.WriteCloser {
 func (p *fakeStdioProcess) Stdout() io.ReadCloser { return p.stdout }
 func (p *fakeStdioProcess) Wait() error {
 	p.waits++
-	return nil
+	return p.waitErr
 }
 func (p *fakeStdioProcess) Kill() error {
 	p.kills++
@@ -83,4 +203,10 @@ type fakeToolCallHandler struct{}
 
 func (fakeToolCallHandler) HandleToolCall(context.Context, ToolCall) (json.RawMessage, error) {
 	return nil, nil
+}
+
+type toolCallHandlerFunc func(context.Context, ToolCall) (json.RawMessage, error)
+
+func (f toolCallHandlerFunc) HandleToolCall(ctx context.Context, call ToolCall) (json.RawMessage, error) {
+	return f(ctx, call)
 }

--- a/codeexecutor/codeact/stdio_test.go
+++ b/codeexecutor/codeact/stdio_test.go
@@ -164,7 +164,12 @@ func TestExecuteStdioReportsRunnerGuestAndContextErrors(t *testing.T) {
 func TestExecuteStdioBoundsCompletedGuestWait(t *testing.T) {
 	originalTimeout := completedGuestWaitTimeout
 	completedGuestWaitTimeout = 10 * time.Millisecond
-	t.Cleanup(func() { completedGuestWaitTimeout = originalTimeout })
+	originalKillTimeout := completedGuestKillWaitTimeout
+	completedGuestKillWaitTimeout = 20 * time.Millisecond
+	t.Cleanup(func() {
+		completedGuestWaitTimeout = originalTimeout
+		completedGuestKillWaitTimeout = originalKillTimeout
+	})
 
 	waitDone := make(chan struct{})
 	process := &fakeStdioProcess{
@@ -195,10 +200,47 @@ func TestExecuteStdioBoundsCompletedGuestWait(t *testing.T) {
 	require.Equal(t, 1, process.waits)
 }
 
+func TestExecuteStdioFailsWhenTimedOutGuestDoesNotExitAfterKill(t *testing.T) {
+	originalTimeout := completedGuestWaitTimeout
+	completedGuestWaitTimeout = 10 * time.Millisecond
+	originalKillTimeout := completedGuestKillWaitTimeout
+	completedGuestKillWaitTimeout = 20 * time.Millisecond
+	waitDone := make(chan struct{})
+	t.Cleanup(func() {
+		completedGuestWaitTimeout = originalTimeout
+		completedGuestKillWaitTimeout = originalKillTimeout
+		close(waitDone)
+	})
+
+	process := &fakeStdioProcess{
+		stdout: io.NopCloser(strings.NewReader(`{"type":"complete","args":{"answer":1},"code":"done\n"}
+`)),
+		waitFn: func() error {
+			<-waitDone
+			return nil
+		},
+	}
+
+	_, err := executeStdio(
+		context.Background(),
+		fakeStdioRunner{process: process},
+		Request{Code: "return 1"},
+		fakeToolCallHandler{},
+	)
+	require.ErrorContains(t, err, "timed-out guest did not exit after kill")
+	require.Equal(t, 1, process.kills)
+	require.Equal(t, 1, process.waits)
+}
+
 func TestExecuteStdioReturnsContextErrorWhileWaitingForCompletedGuest(t *testing.T) {
 	originalTimeout := completedGuestWaitTimeout
 	completedGuestWaitTimeout = time.Second
-	t.Cleanup(func() { completedGuestWaitTimeout = originalTimeout })
+	originalKillTimeout := completedGuestKillWaitTimeout
+	completedGuestKillWaitTimeout = 20 * time.Millisecond
+	t.Cleanup(func() {
+		completedGuestWaitTimeout = originalTimeout
+		completedGuestKillWaitTimeout = originalKillTimeout
+	})
 
 	waitDone := make(chan struct{})
 	process := &fakeStdioProcess{

--- a/codeexecutor/codeact/stdio_test.go
+++ b/codeexecutor/codeact/stdio_test.go
@@ -150,9 +150,84 @@ func TestExecuteStdioReportsRunnerGuestAndContextErrors(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 }
 
+func TestExecuteStdioReportsProtocolEdgeCases(t *testing.T) {
+	tests := []struct {
+		name   string
+		stdout io.ReadCloser
+		want   string
+	}{
+		{name: "unknown message", stdout: io.NopCloser(strings.NewReader(`{"type":"surprise"}
+`)), want: `unknown guest message "surprise"`},
+		{name: "scanner error", stdout: errReadCloser{err: errors.New("read failed")}, want: "read failed"},
+		{name: "no completion", stdout: io.NopCloser(strings.NewReader("")), want: "guest exited without a completion message"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := executeStdio(
+				context.Background(),
+				fakeStdioRunner{process: &fakeStdioProcess{stdout: tt.stdout}},
+				Request{Code: "return 1"},
+				fakeToolCallHandler{},
+			)
+			require.ErrorContains(t, err, tt.want)
+		})
+	}
+}
+
+func TestExecuteStdioReportsWriteErrors(t *testing.T) {
+	t.Run("run request", func(t *testing.T) {
+		_, err := executeStdio(
+			context.Background(),
+			fakeStdioRunner{process: &fakeStdioProcess{
+				stdinWriter: errWriteCloser{err: errors.New("write failed")},
+				stdout:      io.NopCloser(strings.NewReader("")),
+			}},
+			Request{Code: "return 1"},
+			fakeToolCallHandler{},
+		)
+		require.ErrorContains(t, err, "write failed")
+	})
+
+	t.Run("tool result", func(t *testing.T) {
+		process := &fakeStdioProcess{
+			stdout: io.NopCloser(strings.NewReader(`{"type":"tool_call","id":"call-1","name":"add","args":{}}
+`)),
+		}
+		process.stdinWriter = &failAfterWritesWriteCloser{
+			Writer: &process.stdin,
+			After:  1,
+			Err:    errors.New("write failed"),
+			OnClose: func() {
+				process.stdinCloses++
+			},
+		}
+		_, err := executeStdio(
+			context.Background(),
+			fakeStdioRunner{process: process},
+			Request{Code: "return 1"},
+			fakeToolCallHandler{},
+		)
+		require.ErrorContains(t, err, "write failed")
+	})
+}
+
 func TestLocalRunnerReturnsStartError(t *testing.T) {
 	_, err := LocalRunner{Python: "definitely-not-a-python-executable"}.start(context.Background(), "return 1")
 	require.Error(t, err)
+}
+
+func TestLocalProcessKill(t *testing.T) {
+	notStarted := &localProcess{cmd: exec.Command("sleep", "60")}
+	require.NoError(t, notStarted.Kill())
+
+	if _, err := exec.LookPath("sleep"); err != nil {
+		t.Skip("sleep unavailable")
+	}
+	cmd := exec.Command("sleep", "60")
+	require.NoError(t, cmd.Start())
+	process := &localProcess{cmd: cmd}
+	require.NoError(t, process.Kill())
+	_ = cmd.Wait()
 }
 
 type fakeStdioRunner struct {
@@ -169,6 +244,7 @@ func (r fakeStdioRunner) start(context.Context, string) (stdioProcess, error) {
 
 type fakeStdioProcess struct {
 	stdin       bytes.Buffer
+	stdinWriter io.WriteCloser
 	stdout      io.ReadCloser
 	kills       int
 	waits       int
@@ -177,6 +253,9 @@ type fakeStdioProcess struct {
 }
 
 func (p *fakeStdioProcess) Stdin() io.WriteCloser {
+	if p.stdinWriter != nil {
+		return p.stdinWriter
+	}
 	return fakeWriteCloser{Writer: &p.stdin, onClose: func() { p.stdinCloses++ }}
 }
 func (p *fakeStdioProcess) Stdout() io.ReadCloser { return p.stdout }
@@ -196,6 +275,43 @@ type fakeWriteCloser struct {
 
 func (w fakeWriteCloser) Close() error {
 	w.onClose()
+	return nil
+}
+
+type errReadCloser struct {
+	err error
+}
+
+func (r errReadCloser) Read([]byte) (int, error) { return 0, r.err }
+func (r errReadCloser) Close() error             { return nil }
+
+type errWriteCloser struct {
+	err error
+}
+
+func (w errWriteCloser) Write([]byte) (int, error) { return 0, w.err }
+func (w errWriteCloser) Close() error              { return nil }
+
+type failAfterWritesWriteCloser struct {
+	io.Writer
+	After   int
+	Writes  int
+	Err     error
+	OnClose func()
+}
+
+func (w *failAfterWritesWriteCloser) Write(p []byte) (int, error) {
+	w.Writes++
+	if w.Writes > w.After {
+		return 0, w.Err
+	}
+	return w.Writer.Write(p)
+}
+
+func (w *failAfterWritesWriteCloser) Close() error {
+	if w.OnClose != nil {
+		w.OnClose()
+	}
 	return nil
 }
 

--- a/codeexecutor/codeact/stdio_test.go
+++ b/codeexecutor/codeact/stdio_test.go
@@ -1,0 +1,86 @@
+package codeact
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+func TestExecutePythonGuest(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 unavailable")
+	}
+	add := testTool{declaration: &tool.Declaration{Name: "add", InputSchema: &tool.Schema{Type: "object", Required: []string{"a", "b"}, Properties: map[string]*tool.Schema{"a": {Type: "integer"}, "b": {Type: "integer"}}}}, call: func(raw []byte) (any, error) {
+		var in struct{ A, B int }
+		require.NoError(t, json.Unmarshal(raw, &in))
+		return in.A + in.B, nil
+	}}
+	g, err := NewGateway(add)
+	require.NoError(t, err)
+	result, err := Execute(context.Background(), LocalRunner{}, g, "value = await call_tool('add', a=20, b=22)\nprint('computed', value)\nreturn {'answer': value}")
+	require.NoError(t, err)
+	require.JSONEq(t, `{"answer":42}`, string(result.Value))
+	require.Contains(t, result.Stdout, "computed 42")
+}
+
+func TestExecuteStdioReapsGuestAfterProtocolError(t *testing.T) {
+	process := &fakeStdioProcess{stdout: io.NopCloser(strings.NewReader("not-json\n"))}
+	_, err := executeStdio(
+		context.Background(),
+		fakeStdioRunner{process: process},
+		Request{Code: "return 1"},
+		fakeToolCallHandler{},
+	)
+	require.Error(t, err)
+	require.Equal(t, 1, process.kills)
+	require.Equal(t, 1, process.waits)
+	require.Equal(t, 1, process.stdinCloses)
+}
+
+type fakeStdioRunner struct{ process *fakeStdioProcess }
+
+func (r fakeStdioRunner) start(context.Context, string) (stdioProcess, error) { return r.process, nil }
+
+type fakeStdioProcess struct {
+	stdin       bytes.Buffer
+	stdout      io.ReadCloser
+	kills       int
+	waits       int
+	stdinCloses int
+}
+
+func (p *fakeStdioProcess) Stdin() io.WriteCloser {
+	return fakeWriteCloser{Writer: &p.stdin, onClose: func() { p.stdinCloses++ }}
+}
+func (p *fakeStdioProcess) Stdout() io.ReadCloser { return p.stdout }
+func (p *fakeStdioProcess) Wait() error {
+	p.waits++
+	return nil
+}
+func (p *fakeStdioProcess) Kill() error {
+	p.kills++
+	return nil
+}
+
+type fakeWriteCloser struct {
+	io.Writer
+	onClose func()
+}
+
+func (w fakeWriteCloser) Close() error {
+	w.onClose()
+	return nil
+}
+
+type fakeToolCallHandler struct{}
+
+func (fakeToolCallHandler) HandleToolCall(context.Context, ToolCall) (json.RawMessage, error) {
+	return nil, nil
+}

--- a/codeexecutor/codeact/types.go
+++ b/codeexecutor/codeact/types.go
@@ -1,3 +1,11 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
 package codeact
 
 import (

--- a/codeexecutor/codeact/types.go
+++ b/codeexecutor/codeact/types.go
@@ -1,0 +1,60 @@
+package codeact
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// Request describes one CodeAct execution request. CodeAct runtimes may use
+// any transport internally (stdio, container RPC, gRPC, WebSocket, sandbox FFI),
+// but they must preserve the ToolCall/ToolCallHandler semantics.
+type Request struct {
+	Code     string
+	Language string
+}
+
+// Result is the JSON-safe final value and captured stdout emitted by guest code.
+type Result struct {
+	Value  json.RawMessage `json:"value,omitempty"`
+	Stdout string          `json:"stdout,omitempty"`
+}
+
+// ToolCall is a single sandbox-to-host tool invocation.
+type ToolCall struct {
+	ID   string
+	Name string
+	Args json.RawMessage
+}
+
+// ToolCallHandler handles sandbox-originated tool calls. Implementations are
+// the host capability boundary; runtimes should not bypass them.
+type ToolCallHandler interface {
+	HandleToolCall(context.Context, ToolCall) (json.RawMessage, error)
+}
+
+// Runtime executes generated code and routes sandbox-originated tool calls to
+// the provided handler. Local stdio, Docker, remote, and sandbox-native
+// backends should all implement this interface.
+type Runtime interface {
+	ExecuteCodeAct(context.Context, Request, ToolCallHandler) (Result, error)
+}
+
+// Execute runs CodeAct code with the provided runtime and tool-call handler.
+func Execute(ctx context.Context, runtime Runtime, handler ToolCallHandler, code string) (Result, error) {
+	if runtime == nil {
+		return Result{}, errRequired("runtime")
+	}
+	if handler == nil {
+		return Result{}, errRequired("tool call handler")
+	}
+	if code == "" {
+		return Result{}, errRequired("code")
+	}
+	return runtime.ExecuteCodeAct(ctx, Request{Code: code, Language: "python"}, handler)
+}
+
+func errRequired(name string) error { return requiredError{name: name} }
+
+type requiredError struct{ name string }
+
+func (e requiredError) Error() string { return "codeact: " + e.name + " is required" }

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -20,6 +20,7 @@ nav:
           - Codex Agent: codex.md
       - Runner: runner.md
       - Code Executor: codeexecutor.md
+      - CodeAct: codeact.md
       - Error Handling: error-handling.md
       - Model: model.md
       - Prompt Template: prompt.md
@@ -116,6 +117,7 @@ plugins:
                     - Codex Agent: codex.md
                 - Runner: runner.md
                 - Code Executor: codeexecutor.md
+                - CodeAct: codeact.md
                 - 错误处理: error-handling.md
                 - Model: model.md
                 - Prompt Template: prompt.md

--- a/docs/mkdocs/en/codeact.md
+++ b/docs/mkdocs/en/codeact.md
@@ -1,0 +1,122 @@
+# Tool Code Orchestration
+
+`codeexecutor/codeact` implements the CodeAct-style pattern: generated code can orchestrate a narrow, explicitly allowlisted set of trpc tools. The public capability is better described as **tool code orchestration**. It is not a replacement for writing stable business workflows in Go.
+
+```text
+LLM -> execute_tool_code -> Runtime -> guest call_tool(name, JSON args)
+                                  -> Go Gateway -> trpc Tool
+```
+
+The Go gateway is the trust boundary: it rejects unknown tools, validates input JSON against the tool declaration, calls the tool, then validates/serializes its result before returning it to guest code. Guest code never gets Go references or host credentials.
+
+`Runtime` is the transport boundary. The built-in `LocalRunner` implements it with a Python stdio guest. Remote or sandbox-native backends should implement `Runtime` directly and route sandbox-originated `ToolCall` values to the provided `ToolCallHandler`.
+
+## Security
+
+`LocalRunner` starts a local Python process and is only for development or an already isolated container/VM. It is **not** a security sandbox. Applications should implement `codeact.Runtime` for their existing remote sandbox, microVM, or container service, with the isolation, resource, and dependency policies appropriate to their environment.
+
+## Why not call raw HTTP APIs from generated code?
+
+Tool code orchestration separates dynamic control flow from access to system
+capabilities. Generated code is useful for loops, branching, and transformation;
+business API access remains a host-owned tool. That keeps authentication,
+authorization, retry and idempotency policy, API-version adaptation, audit
+logging, and rate limits in application code instead of model-generated code.
+
+When an application genuinely needs HTTP access, expose a host adapter tool for
+the business operation. For a deliberately broad but bounded HTTP surface,
+expose a constrained `http_request`-style tool whose host controls allowed
+domains and methods, credentials, and response-size limits. Do not treat
+`LocalRunner`'s general Python environment as this security control: a
+production runtime must enforce its own network and process policy.
+
+| Need | Preferred implementation |
+| --- | --- |
+| Stable, deterministic business workflow | Go application code |
+| Dynamic branching or loops across approved tools | `execute_tool_code` |
+| Bounded external HTTP integration | Host adapter or constrained HTTP tool |
+| Untrusted code or unrestricted external access | Isolated runtime plus explicit application policy |
+
+## Example
+
+For an agent-facing example that orchestrates catalog search, inventory
+filtering, and quote creation, set `OPENAI_API_KEY` (and optionally
+`OPENAI_BASE_URL`) and run:
+
+```bash
+cd examples && go run ./codeact -model gpt-5
+```
+
+Only `execute_tool_code` is exposed to the model; `search_catalog`,
+`get_inventory`, and `create_quote` are callable only from guest Python through
+the allowlist. The example deliberately does not set a `GenerationConfig`:
+`openai.New` and environment variables provide the model configuration.
+
+For an agent-facing tool, create `tool/toolcode.NewTool(runtime, managedTools)`. Register that returned tool on the agent as `execute_tool_code`; only `managedTools` become callable by `await call_tool(...)` in guest code.
+
+Managed calls are direct, synchronous host-capability calls in this first version. They do not replay the agent's callback, retry, or inner tracing lifecycle, and they cannot pause an execution for interactive approval. Do not add tools that require an approval/resume flow to `managedTools`; enforce authorization in the business tool itself or use an application-defined adapter tool.
+
+## Model-facing tool guidance
+
+The default `execute_tool_code` declaration tells the model to prefer a single
+call when it can finish the workflow, use only `await call_tool(name,
+**json_arguments)`, and return JSON-compatible values. It also includes the
+name, description, input JSON Schema, and output JSON Schema for every managed
+tool. The instruction is guidance, not a replacement for the runtime security
+boundary described above.
+
+Write managed-tool descriptions as business contracts: explain the operation,
+preconditions, units, enum meanings, and result semantics. Avoid transport
+details such as headers or SDK mechanics unless the model needs them to choose
+the operation. Use a host adapter when two tools need a domain-specific mapping
+that cannot be described safely by a generic field transformation.
+
+`toolcode.WithDescription` replaces the default description. A custom
+description should preserve the `call_tool`-only capability boundary and the
+JSON argument/result constraints.
+
+## Boundaries with other execution tools
+
+`execute_tool_code` does not replace `workspace_exec`,
+`workspace_write_stdin`, or `workspace_kill_session`:
+
+- The `workspace_exec` family runs shell commands, scripts, CLIs, and long
+  tasks in the shared workspace. Its natural data model is terminal text,
+  files, artifacts, and exit codes.
+- `execute_tool_code` runs generated Python glue code that calls explicitly
+  allowlisted ordinary Go tools through `call_tool(...)`. It is for branching,
+  loops, JSON transformation, and multi-tool result aggregation.
+- `tool/codeexec`'s `execute_code` is ordinary code execution for computation,
+  data analysis, or logic verification. It does not bridge Python calls back
+  into Go tools.
+
+The default tool name is intentionally **not** `execute_code`: `tool/codeexec`
+already uses `execute_code` for ordinary code execution. If an application
+exposes only the tool-orchestration variant, it may override the name with
+`toolcode.WithName("execute_code")`, but do not register both tools with the
+same name on one agent.
+
+## Choosing managed tools
+
+`managedTools` is an application-owned, independent capability registry; it
+is not inferred from the tools already registered on the agent. Prefer ordinary
+business tools, data tools, and host-defined adapter tools. Normally exclude:
+
+- `workspace_exec` / `workspace_write_stdin` / `workspace_kill_session`
+- `workspace_save_artifact`
+- `execute_code` / `execute_tool_code`
+- `skill_run` / `skill_exec` / `skill_write_stdin` / `skill_poll_session` /
+  `skill_kill_session`
+- `transfer_to_agent` / `await_user_reply`
+
+These tools should normally stay out of the registry: execution tools create
+recursive or heterogeneous execution chains; `transfer_to_agent` and
+`await_user_reply` alter outer-invocation control flow; and `AgentTool` /
+`DynamicAgentTool` start a sub-agent run with separate history, streaming-event,
+and cost boundaries. The framework does not infer that policy from names or
+types; applications should pass only the ordinary capabilities they explicitly
+intend to orchestrate to `tool/toolcode.NewTool`.
+
+## Data flow
+
+Small tool values use JSON. For large datasets, tools should return an artifact/workspace reference and code should process the mounted artifact instead of serializing the full payload through the model context. Semantic conversions between tool A and B are explicit code or a host-defined adapter tool; tool code orchestration never guesses domain mappings.

--- a/docs/mkdocs/en/codeact.md
+++ b/docs/mkdocs/en/codeact.md
@@ -54,16 +54,19 @@ the allowlist. The example deliberately does not set a `GenerationConfig`:
 
 For an agent-facing tool, create `tool/toolcode.NewTool(runtime, managedTools)`. Register that returned tool on the agent as `execute_tool_code`; only `managedTools` become callable by `await call_tool(...)` in guest code.
 
-Managed calls are direct, synchronous host-capability calls in this first version. They do not replay the agent's callback, retry, or inner tracing lifecycle, and they cannot pause an execution for interactive approval. Do not add tools that require an approval/resume flow to `managedTools`; enforce authorization in the business tool itself or use an application-defined adapter tool.
+Managed calls are direct, synchronous host-capability calls in this first version. The built-in Python guest permits only one outstanding call: `await` is required by the guest API, but `asyncio.gather(...)` does not create parallel host calls. A failed host call becomes a Python `RuntimeError`, which generated code may handle with `try`/`except`. Managed calls do not replay the agent's callback, retry, or inner tracing lifecycle, and they cannot pause an execution for interactive approval. Do not add tools that require an approval/resume flow to `managedTools`; enforce authorization in the business tool itself or use an application-defined adapter tool.
 
 ## Model-facing tool guidance
 
 The default `execute_tool_code` declaration tells the model to prefer a single
 call when it can finish the workflow, use only `await call_tool(name,
-**json_arguments)`, and return JSON-compatible values. It also includes the
-name, description, input JSON Schema, and output JSON Schema for every managed
-tool. The instruction is guidance, not a replacement for the runtime security
-boundary described above.
+**json_arguments)`, make sequential calls, and return only a compact
+JSON-compatible value. It also includes the name, description, input JSON
+Schema, and output JSON Schema for every managed tool. Intermediate managed-tool
+values remain in guest code; only the final `value` and captured `stdout` of
+`execute_tool_code` become its outer tool result. Do not print or return raw
+large tool values unless they are needed by the model. The instruction is
+guidance, not a replacement for the runtime security boundary described above.
 
 Write managed-tool descriptions as business contracts: explain the operation,
 preconditions, units, enum meanings, and result semantics. Avoid transport
@@ -109,6 +112,13 @@ business tools, data tools, and host-defined adapter tools. Normally exclude:
   `skill_kill_session`
 - `transfer_to_agent` / `await_user_reply`
 
+For each business operation, normally choose one model-facing path: expose it
+as a direct agent tool, or make it callable only through `execute_tool_code`.
+An application can deliberately register the same operation in both places,
+but that gives the model two execution paths for the same action and weakens
+the guidance about when code orchestration is useful. The allowlist remains the
+actual capability boundary for guest code regardless of that choice.
+
 These tools should normally stay out of the registry: execution tools create
 recursive or heterogeneous execution chains; `transfer_to_agent` and
 `await_user_reply` alter outer-invocation control flow; and `AgentTool` /
@@ -119,4 +129,11 @@ intend to orchestrate to `tool/toolcode.NewTool`.
 
 ## Data flow
 
-Small tool values use JSON. For large datasets, tools should return an artifact/workspace reference and code should process the mounted artifact instead of serializing the full payload through the model context. Semantic conversions between tool A and B are explicit code or a host-defined adapter tool; tool code orchestration never guesses domain mappings.
+Small tool values use JSON. Intermediate values stay in guest code; only the
+returned `value` and captured `stdout` are sent back as the outer tool result.
+Return a compact aggregate, identifier, or artifact/workspace reference rather
+than a raw large payload. For large datasets, tools should return an
+artifact/workspace reference and code should process the mounted artifact
+instead of serializing the full payload through the model context. Semantic
+conversions between tool A and B are explicit code or a host-defined adapter
+tool; tool code orchestration never guesses domain mappings.

--- a/docs/mkdocs/en/codeexecutor.md
+++ b/docs/mkdocs/en/codeexecutor.md
@@ -60,6 +60,7 @@ More complete examples:
 - [examples/codeexecution/main.go](https://github.com/trpc-group/trpc-agent-go/blob/main/examples/codeexecution/main.go) (local backend)
 - [examples/codeexecution/container/README.md](https://github.com/trpc-group/trpc-agent-go/blob/main/examples/codeexecution/container/README.md) (Docker container backend)
 - [examples/codeexecution/jupyter/README.md](https://github.com/trpc-group/trpc-agent-go/blob/main/examples/codeexecution/jupyter/README.md) (Jupyter kernel backend)
+- [Tool Code Orchestration](codeact.md) (generated code orchestrating allowlisted tools through `call_tool`)
 
 ### `WithCodeExecutor` vs fenced-code auto-execution
 

--- a/docs/mkdocs/zh/codeact.md
+++ b/docs/mkdocs/zh/codeact.md
@@ -26,7 +26,7 @@ LLM -> execute_tool_code -> Runtime -> guest call_tool(name, JSON args)
 | 受限的外部 HTTP 集成 | 宿主 adapter 或受约束 HTTP tool |
 | 不可信代码或无边界外部访问 | 隔离 runtime 加明确的应用策略 |
 
-工具 A/B 的小型结构化数据经 JSON 传递。大数据应返回 artifact/workspace 引用，由 guest 在挂载 workspace 中处理。业务语义不匹配必须用显式转换代码或宿主 adapter tool 处理，CodeAct 不会猜测字段或单位含义。
+工具 A/B 的小型结构化数据经 JSON 传递；中间结果留在 guest 代码中，只有最终 `value` 和捕获的 `stdout` 会作为外层工具结果返回。应返回紧凑的聚合结果、标识符或 artifact/workspace 引用，而不是把大块原始数据交回模型。大数据应返回 artifact/workspace 引用，由 guest 在挂载 workspace 中处理。业务语义不匹配必须用显式转换代码或宿主 adapter tool 处理，CodeAct 不会猜测字段或单位含义。
 
 要运行 Agent 的多工具编排示例（产品搜索 → 库存筛选 → 创建报价），设置
 `OPENAI_API_KEY`（以及可选的 `OPENAI_BASE_URL`）后执行：
@@ -41,11 +41,11 @@ cd examples && go run ./codeact -model gpt-5
 
 需要给 Agent 暴露工具时，调用 `tool/toolcode.NewTool(runtime, managedTools)`，将返回的 `execute_tool_code` 注册给 Agent。只有 `managedTools` 能被 guest 中的 `await call_tool(...)` 调用。
 
-第一版中，managed tool 是同步的直接宿主能力调用：它不会重放 Agent 的 callback、retry 或内层 tracing 生命周期，也不能在执行中暂停以等待交互式审批。不要把需要“审批后恢复”流程的工具加入 `managedTools`；授权应在业务工具自身或应用定义的 adapter tool 中实现。
+第一版中，managed tool 是同步的直接宿主能力调用：内置 Python guest 任一时刻只有一个调用在执行，`await` 是 guest API 的调用形式，但 `asyncio.gather(...)` 不会产生并行的宿主工具调用。宿主工具失败会在 Python 中表现为 `RuntimeError`，生成代码可用 `try`/`except` 处理。它不会重放 Agent 的 callback、retry 或内层 tracing 生命周期，也不能在执行中暂停以等待交互式审批。不要把需要“审批后恢复”流程的工具加入 `managedTools`；授权应在业务工具自身或应用定义的 adapter tool 中实现。
 
 ## 面向模型的工具说明
 
-默认的 `execute_tool_code` 声明会告诉模型：能在一次调用完成流程时优先一次完成；只能使用 `await call_tool(name, **json_arguments)`；并返回 JSON 兼容的值。它还会动态列出每个 managed tool 的名称、描述、输入 JSON Schema 和输出 JSON Schema。这里的说明只是模型引导，不能替代前述 runtime 安全边界。
+默认的 `execute_tool_code` 声明会告诉模型：能在一次调用完成流程时优先一次完成；只能使用 `await call_tool(name, **json_arguments)`；按顺序调用工具；并只返回完成任务所需的紧凑 JSON 兼容值。它还会动态列出每个 managed tool 的名称、描述、输入 JSON Schema 和输出 JSON Schema。中间的 managed tool 结果留在 guest 代码中，只有 `execute_tool_code` 最终的 `value` 和捕获的 `stdout` 会作为外层工具结果返回；不要打印或返回模型不需要的大型原始结果。这里的说明只是模型引导，不能替代前述 runtime 安全边界。
 
 managed tool 的描述应写成业务契约：说明操作含义、前置条件、单位、枚举含义和结果语义。除非模型必须依此选择操作，否则不要塞入 header、SDK 等传输细节。两个工具之间若需要领域特定的语义映射，应使用宿主 adapter tool，而不要让通用字段转换去猜测含义。
 
@@ -80,6 +80,8 @@ tools 自动推导。应优先放业务工具、数据工具和宿主侧 adapter
 - `skill_run` / `skill_exec` / `skill_write_stdin` / `skill_poll_session` /
   `skill_kill_session`
 - `transfer_to_agent` / `await_user_reply`
+
+对于同一个业务操作，通常应只选择一种模型侧入口：要么作为 Agent 的直接工具暴露，要么仅加入 `execute_tool_code` 的 managed registry。应用当然可以有意同时注册两者，但这会让模型对同一个操作看到两条执行路径，弱化何时应该使用代码编排的引导。无论如何，managed registry 仍是 guest 代码的实际能力边界。
 
 这些工具通常不应加入 registry：执行类工具会形成递归或异质执行链；
 `transfer_to_agent` 和 `await_user_reply` 会修改外层 Invocation 的控制状态；

--- a/docs/mkdocs/zh/codeact.md
+++ b/docs/mkdocs/zh/codeact.md
@@ -1,0 +1,88 @@
+# 工具代码编排
+
+`codeexecutor/codeact` 实现的是 CodeAct-style pattern：模型生成的代码只能经由受限工具网关编排 trpc tools。作为框架能力，对外更建议叫 **工具代码编排**。未知工具会被拒绝，工具输入与输出都在 Go 侧按声明的 JSON Schema 校验。它不替代稳定业务流程中的 Go 代码。
+
+```text
+LLM -> execute_tool_code -> Runtime -> guest call_tool(name, JSON args)
+                                  -> Go Gateway -> trpc Tool
+```
+
+`Gateway` 是能力边界，负责 allowlist、schema 校验和真实 Go tool 调用。`Runtime` 是传输/执行边界：内置 `LocalRunner` 用 Python stdio guest 实现；远端 sandbox、microVM、容器服务或平台原生 callback 后端应直接实现 `codeact.Runtime`，并把 sandbox 产生的 `ToolCall` 路由给传入的 `ToolCallHandler`。
+
+## 安全边界
+
+`LocalRunner` 仅用于开发或已经隔离的容器/VM；它不是安全 sandbox。生产应用应基于已有远端 sandbox、microVM 或容器服务实现 `codeact.Runtime`，并由应用侧配置隔离、资源和依赖策略。
+
+## 为什么不让生成代码直接调用 HTTP API？
+
+工具代码编排把动态控制流和系统能力访问分开：生成代码适合循环、分支和数据转换，业务 API 访问仍应是宿主侧工具。这样认证、授权、重试与幂等策略、API 版本适配、审计和限流仍由应用代码掌控，而不是落在模型生成的代码中。
+
+确实需要 HTTP 能力时，应把具体业务操作做成宿主 adapter tool；如果需要一组较宽但明确受限的 HTTP 能力，可暴露受约束的 `http_request` 类工具，由宿主控制允许的域名和方法、凭证以及响应大小限制。不能把 `LocalRunner` 的通用 Python 环境当作安全控制；生产 runtime 必须自行落实网络和进程策略。
+
+| 需求 | 推荐实现 |
+| --- | --- |
+| 稳定、确定性的业务流程 | Go 应用代码 |
+| 在已批准工具间做动态分支或循环 | `execute_tool_code` |
+| 受限的外部 HTTP 集成 | 宿主 adapter 或受约束 HTTP tool |
+| 不可信代码或无边界外部访问 | 隔离 runtime 加明确的应用策略 |
+
+工具 A/B 的小型结构化数据经 JSON 传递。大数据应返回 artifact/workspace 引用，由 guest 在挂载 workspace 中处理。业务语义不匹配必须用显式转换代码或宿主 adapter tool 处理，CodeAct 不会猜测字段或单位含义。
+
+要运行 Agent 的多工具编排示例（产品搜索 → 库存筛选 → 创建报价），设置
+`OPENAI_API_KEY`（以及可选的 `OPENAI_BASE_URL`）后执行：
+
+```bash
+cd examples && go run ./codeact -model gpt-5
+```
+
+该示例只把 `execute_tool_code` 暴露给模型；`search_catalog`、`get_inventory` 和
+`create_quote` 仅能由 guest Python 经 allowlist 调用。它不设置 `GenerationConfig`，
+模型配置完全由 `openai.New` 和环境变量处理。
+
+需要给 Agent 暴露工具时，调用 `tool/toolcode.NewTool(runtime, managedTools)`，将返回的 `execute_tool_code` 注册给 Agent。只有 `managedTools` 能被 guest 中的 `await call_tool(...)` 调用。
+
+第一版中，managed tool 是同步的直接宿主能力调用：它不会重放 Agent 的 callback、retry 或内层 tracing 生命周期，也不能在执行中暂停以等待交互式审批。不要把需要“审批后恢复”流程的工具加入 `managedTools`；授权应在业务工具自身或应用定义的 adapter tool 中实现。
+
+## 面向模型的工具说明
+
+默认的 `execute_tool_code` 声明会告诉模型：能在一次调用完成流程时优先一次完成；只能使用 `await call_tool(name, **json_arguments)`；并返回 JSON 兼容的值。它还会动态列出每个 managed tool 的名称、描述、输入 JSON Schema 和输出 JSON Schema。这里的说明只是模型引导，不能替代前述 runtime 安全边界。
+
+managed tool 的描述应写成业务契约：说明操作含义、前置条件、单位、枚举含义和结果语义。除非模型必须依此选择操作，否则不要塞入 header、SDK 等传输细节。两个工具之间若需要领域特定的语义映射，应使用宿主 adapter tool，而不要让通用字段转换去猜测含义。
+
+`toolcode.WithDescription` 会替换默认描述。使用自定义描述时，应保留“只能经由 `call_tool` 访问能力”和 JSON 入参与结果约束。
+
+## 与其他执行工具的边界
+
+`execute_tool_code` 不是 `workspace_exec`、`workspace_write_stdin` 或
+`workspace_kill_session` 的替代品：
+
+- `workspace_exec` 系列用于在共享 workspace 里运行 shell command、脚本、
+  CLI 或长任务，输入输出主要是 terminal 文本、文件、artifact、exit code。
+- `execute_tool_code` 用于让生成的 Python 胶水代码通过 `call_tool(...)`
+  编排一组显式 allowlisted 的普通 Go tools，适合分支、循环、JSON 转换和
+  多工具结果聚合。
+- `tool/codeexec` 的 `execute_code` 用于普通代码执行、计算、数据分析或逻辑
+  验证；它不会把 Python 调用桥接回 Go tools。
+
+因此默认工具名刻意不叫 `execute_code`：`tool/codeexec` 已经把
+`execute_code` 用于普通代码执行。如果一个应用只暴露工具编排版本，可以用
+`toolcode.WithName("execute_code")` 覆盖；但不要在同一个 Agent 上注册两个
+同名工具。
+
+## managed tools 选择
+
+`managedTools` 是应用显式配置的独立 capability registry，不会从 Agent 已注册的
+tools 自动推导。应优先放业务工具、数据工具和宿主侧 adapter tool。通常应排除：
+
+- `workspace_exec` / `workspace_write_stdin` / `workspace_kill_session`
+- `workspace_save_artifact`
+- `execute_code` / `execute_tool_code`
+- `skill_run` / `skill_exec` / `skill_write_stdin` / `skill_poll_session` /
+  `skill_kill_session`
+- `transfer_to_agent` / `await_user_reply`
+
+这些工具通常不应加入 registry：执行类工具会形成递归或异质执行链；
+`transfer_to_agent` 和 `await_user_reply` 会修改外层 Invocation 的控制状态；
+`AgentTool` / `DynamicAgentTool` 会启动子 Agent 并带来独立的历史、流式事件和
+成本边界。框架不按名称或类型替应用判断；应用应只把明确需要编排的普通能力工具
+传给 `tool/toolcode.NewTool`。

--- a/docs/mkdocs/zh/codeexecutor.md
+++ b/docs/mkdocs/zh/codeexecutor.md
@@ -60,6 +60,7 @@ func main() {
 - [examples/codeexecution/main.go](https://github.com/trpc-group/trpc-agent-go/blob/main/examples/codeexecution/main.go)（本地 backend）
 - [examples/codeexecution/container/README.md](https://github.com/trpc-group/trpc-agent-go/blob/main/examples/codeexecution/container/README.md)（Docker container backend）
 - [examples/codeexecution/jupyter/README.md](https://github.com/trpc-group/trpc-agent-go/blob/main/examples/codeexecution/jupyter/README.md)（Jupyter kernel backend）
+- [工具代码编排](codeact.md)（生成代码通过 `call_tool` 编排受限工具）
 
 ### `WithCodeExecutor` 与围栏代码自动执行
 

--- a/examples/codeact/README.md
+++ b/examples/codeact/README.md
@@ -57,7 +57,7 @@ return {
 
 ## Prerequisites
 
-- Go 1.23.0 or later
+- Go 1.24.4 or later, matching the examples module toolchain
 - Python 3, used by the local development runtime
 - A model endpoint compatible with the configured OpenAI adapter
 

--- a/examples/codeact/README.md
+++ b/examples/codeact/README.md
@@ -1,0 +1,103 @@
+# Tool Code Orchestration Agent
+
+This example demonstrates an agent that creates a product quote by using
+`execute_tool_code` to orchestrate several dependent tools.
+
+The model sees only `execute_tool_code`. Generated Python can call the
+explicitly registered business tools through `await call_tool(...)`:
+
+```text
+LLM -> execute_tool_code -> generated Python -> allowlisted Go tools
+```
+
+For the quote request, the generated code searches the catalog, checks stock
+for every product, filters unavailable items, creates one quote, and returns a
+structured result.
+
+One successful run generated code equivalent to the following. The exact code
+is model-generated and can vary, but the only host calls available to it are
+the explicitly registered `call_tool(...)` calls:
+
+```python
+REQUESTED_QTY = 3
+QUERY = "ergonomic office chair"
+CUSTOMER_ID = "customer-42"
+
+catalog = await call_tool("search_catalog", query=QUERY)
+selected = []
+rejected = []
+
+for product in catalog.get("products", []):
+    inventory = await call_tool("get_inventory", sku=product["sku"])
+    item = {
+        "sku": product["sku"],
+        "name": product["name"],
+        "unit_price": product["unit_price"],
+        "available": inventory["available"],
+        "requested_quantity": REQUESTED_QTY,
+    }
+    if inventory["available"] >= REQUESTED_QTY:
+        selected.append(item)
+    else:
+        item["reason"] = "insufficient_stock"
+        rejected.append(item)
+
+quote = await call_tool(
+    "create_quote",
+    customer_id=CUSTOMER_ID,
+    items=[{"sku": item["sku"], "quantity": REQUESTED_QTY} for item in selected],
+)
+
+return {
+    "selected_products": selected,
+    "rejected_products": rejected,
+    "quote": quote,
+}
+```
+
+## Prerequisites
+
+- Go 1.23.0 or later
+- Python 3, used by the local development runtime
+- A model endpoint compatible with the configured OpenAI adapter
+
+## Run
+
+From the `examples` module, configure the model credentials and run:
+
+```bash
+cd examples
+export OPENAI_API_KEY="your-api-key"
+go run ./codeact -model gpt-5
+```
+
+Set `OPENAI_BASE_URL` when using a compatible endpoint with a non-default base
+URL. Pass `-prompt` to replace the default quote request.
+
+## Key Design Point
+
+The business tools are passed explicitly to `toolcode.NewTool`:
+
+```go
+orchestrator, err := toolcode.NewTool(
+	bridge.LocalRunner{},
+	[]tool.CallableTool{searchCatalog, getInventory, createQuote},
+)
+```
+
+They are not inferred from the agent's direct tool set. The model cannot invoke
+them as normal function calls; it can only invoke the outer
+`execute_tool_code` tool. The host-side gateway validates each generated tool
+call against this allowlist and the tool schemas.
+
+Managed calls are synchronous direct host-capability calls in this first
+version. They do not replay the agent callback, retry, or inner tracing
+lifecycle, and cannot pause for interactive approval. Keep tools that require
+an approval/resume flow out of this registry.
+
+## Security
+
+This example uses `LocalRunner` only to keep the example easy to run. It starts
+a local Python process and is not a security sandbox. Use an isolated runtime,
+such as a constrained container or an application-provided remote sandbox,
+when generated code is not trusted.

--- a/examples/codeact/README.md
+++ b/examples/codeact/README.md
@@ -91,9 +91,13 @@ them as normal function calls; it can only invoke the outer
 call against this allowlist and the tool schemas.
 
 Managed calls are synchronous direct host-capability calls in this first
-version. They do not replay the agent callback, retry, or inner tracing
-lifecycle, and cannot pause for interactive approval. Keep tools that require
-an approval/resume flow out of this registry.
+version. Calls execute sequentially; `asyncio.gather(...)` does not provide
+parallel host calls. A host-call failure becomes a Python `RuntimeError`, which
+the generated code can handle with `try`/`except`. Managed calls do not replay
+the agent callback, retry, or inner tracing lifecycle, and cannot pause for
+interactive approval. Keep tools that require an approval/resume flow out of
+this registry. Return only the compact result needed by the model rather than
+printing or returning raw large tool results.
 
 ## Security
 

--- a/examples/codeact/main.go
+++ b/examples/codeact/main.go
@@ -1,0 +1,197 @@
+// Command codeact demonstrates an LLMAgent using execute_tool_code for a
+// multi-step product-quote workflow. It does not use a GenerationConfig:
+// openai.New reads OPENAI_API_KEY and OPENAI_BASE_URL from the environment.
+//
+// Run from the examples module:
+//
+//	cd examples && go run ./codeact -model gpt-5
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	bridge "trpc.group/trpc-go/trpc-agent-go/codeexecutor/codeact"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/model/openai"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+	"trpc.group/trpc-go/trpc-agent-go/tool/function"
+	"trpc.group/trpc-go/trpc-agent-go/tool/toolcode"
+)
+
+var (
+	modelName = flag.String("model", "gpt-5", "Model name; OpenAI credentials and base URL come from the environment")
+	prompt    = flag.String("prompt", "Customer customer-42 needs 3 ergonomic office chairs. Find all options with enough stock, create a quote from those options, and report any unavailable options.", "Request to send to the quote agent")
+)
+
+type product struct {
+	SKU       string  `json:"sku" jsonschema:"description=Stable product SKU,required"`
+	Name      string  `json:"name" jsonschema:"description=Product name,required"`
+	UnitPrice float64 `json:"unit_price" jsonschema:"description=Unit price in USD,required"`
+}
+
+type searchCatalogInput struct {
+	Query string `json:"query" jsonschema:"description=Product search query,required"`
+}
+
+type searchCatalogOutput struct {
+	Products []product `json:"products" jsonschema:"description=Matching catalog products,required"`
+}
+
+type inventoryInput struct {
+	SKU string `json:"sku" jsonschema:"description=Product SKU,required"`
+}
+
+type inventoryOutput struct {
+	SKU       string `json:"sku" jsonschema:"description=Product SKU,required"`
+	Available int    `json:"available" jsonschema:"description=Units currently available to quote,required"`
+}
+
+type quoteItem struct {
+	SKU      string `json:"sku" jsonschema:"description=Product SKU,required"`
+	Quantity int    `json:"quantity" jsonschema:"description=Requested quantity,required"`
+}
+
+type createQuoteInput struct {
+	CustomerID string      `json:"customer_id" jsonschema:"description=Customer identifier,required"`
+	Items      []quoteItem `json:"items" jsonschema:"description=In-stock line items to quote,required"`
+}
+
+type createQuoteOutput struct {
+	QuoteID string      `json:"quote_id" jsonschema:"description=Created quote identifier,required"`
+	Total   float64     `json:"total" jsonschema:"description=Quote total in USD,required"`
+	Items   []quoteItem `json:"items" jsonschema:"description=Quoted line items,required"`
+}
+
+func main() {
+	flag.Parse()
+	if strings.TrimSpace(os.Getenv("OPENAI_API_KEY")) == "" {
+		log.Fatal("OPENAI_API_KEY is required")
+	}
+
+	quoteTool, err := newQuoteTool()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	agent := llmagent.New(
+		"product-quote-agent",
+		llmagent.WithModel(openai.New(*modelName)),
+		llmagent.WithDescription("Creates a product quote by orchestrating catalog, inventory, and quote tools"),
+		llmagent.WithInstruction(`You are a product-quote assistant.
+
+For requests that require finding products, checking stock, and creating a quote, use execute_tool_code. Generate Python that:
+1. calls search_catalog;
+2. loops through every returned product and calls get_inventory;
+3. includes a product in the quote only when available stock is at least the requested quantity;
+4. calls create_quote once, after the filtering is complete; and
+5. returns structured JSON containing selected products, rejected products, and the quote.
+
+Use only the tools documented in execute_tool_code. Do not use shell commands, filesystem APIs, transfer_to_agent, or nested agents. After the tool succeeds, explain the quote clearly to the user.`),
+		llmagent.WithTools([]tool.Tool{quoteTool}),
+	)
+
+	r := runner.NewRunner("codeact-product-quote", agent)
+	defer r.Close()
+
+	fmt.Printf("CodeAct product quote agent (model: %s)\n", *modelName)
+	fmt.Printf("Request: %s\n\n", *prompt)
+	events, err := r.Run(context.Background(), "demo-user", "codeact-quote-session", model.NewUserMessage(*prompt))
+	if err != nil {
+		log.Fatalf("run agent: %v", err)
+	}
+	printEvents(events)
+}
+
+func newQuoteTool() (tool.CallableTool, error) {
+	searchCatalog := function.NewFunctionTool(
+		func(_ context.Context, in searchCatalogInput) (searchCatalogOutput, error) {
+			return searchCatalogOutput{Products: []product{
+				{SKU: "chair-ergonomic-pro", Name: "Ergonomic Pro Chair", UnitPrice: 399},
+				{SKU: "chair-ergonomic-lite", Name: "Ergonomic Lite Chair", UnitPrice: 249},
+				{SKU: "chair-standing", Name: "Standing Chair", UnitPrice: 179},
+			}}, nil
+		},
+		function.WithName("search_catalog"),
+		function.WithDescription("Return catalog products that match a product query."),
+	)
+	getInventory := function.NewFunctionTool(
+		func(_ context.Context, in inventoryInput) (inventoryOutput, error) {
+			available := map[string]int{
+				"chair-ergonomic-pro":  8,
+				"chair-ergonomic-lite": 1,
+				"chair-standing":       5,
+			}[in.SKU]
+			return inventoryOutput{SKU: in.SKU, Available: available}, nil
+		},
+		function.WithName("get_inventory"),
+		function.WithDescription("Return currently available inventory for one SKU."),
+	)
+	createQuote := function.NewFunctionTool(
+		func(_ context.Context, in createQuoteInput) (createQuoteOutput, error) {
+			if len(in.Items) == 0 {
+				return createQuoteOutput{}, fmt.Errorf("cannot create a quote with no items")
+			}
+			priceBySKU := map[string]float64{
+				"chair-ergonomic-pro":  399,
+				"chair-ergonomic-lite": 249,
+				"chair-standing":       179,
+			}
+			var total float64
+			for _, item := range in.Items {
+				total += priceBySKU[item.SKU] * float64(item.Quantity)
+			}
+			return createQuoteOutput{
+				QuoteID: "quote-customer-42-demo",
+				Total:   total,
+				Items:   in.Items,
+			}, nil
+		},
+		function.WithName("create_quote"),
+		function.WithDescription("Create a quote from already validated in-stock line items."),
+	)
+
+	// Only this outer tool is visible to the model. The three business tools
+	// are visible only to the generated Python through the allowlisted gateway.
+	return toolcode.NewTool(
+		bridge.LocalRunner{},
+		[]tool.CallableTool{searchCatalog, getInventory, createQuote},
+	)
+}
+
+func printEvents(events <-chan *event.Event) {
+	for evt := range events {
+		if evt.Error != nil {
+			fmt.Printf("Agent error: %s\n", evt.Error.Message)
+			continue
+		}
+		if evt.Response == nil {
+			continue
+		}
+		if evt.Response.Error != nil {
+			fmt.Printf("Model error: %s\n", evt.Response.Error.Message)
+			continue
+		}
+		for _, choice := range evt.Response.Choices {
+			for _, call := range choice.Message.ToolCalls {
+				fmt.Printf("Tool call: %s\n%s\n\n", call.Function.Name, call.Function.Arguments)
+			}
+			if choice.Message.Role == model.RoleTool && choice.Message.Content != "" {
+				fmt.Printf("Tool result: %s\n\n", choice.Message.Content)
+			}
+			if choice.Delta.Content != "" {
+				fmt.Print(choice.Delta.Content)
+			} else if choice.Message.Role == model.RoleAssistant && choice.Message.Content != "" {
+				fmt.Print(choice.Message.Content)
+			}
+		}
+	}
+	fmt.Println()
+}

--- a/examples/codeact/main.go
+++ b/examples/codeact/main.go
@@ -1,3 +1,11 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
 // Command codeact demonstrates an LLMAgent using execute_tool_code for a
 // multi-step product-quote workflow. It does not use a GenerationConfig:
 // openai.New reads OPENAI_API_KEY and OPENAI_BASE_URL from the environment.

--- a/examples/codeact/main.go
+++ b/examples/codeact/main.go
@@ -154,7 +154,14 @@ func newQuoteTool() (tool.CallableTool, error) {
 			}
 			var total float64
 			for _, item := range in.Items {
-				total += priceBySKU[item.SKU] * float64(item.Quantity)
+				if item.Quantity <= 0 {
+					return createQuoteOutput{}, fmt.Errorf("invalid quantity for %q: %d", item.SKU, item.Quantity)
+				}
+				price, ok := priceBySKU[item.SKU]
+				if !ok {
+					return createQuoteOutput{}, fmt.Errorf("unknown sku: %q", item.SKU)
+				}
+				total += price * float64(item.Quantity)
 			}
 			return createQuoteOutput{
 				QuoteID: "quote-customer-42-demo",
@@ -176,10 +183,6 @@ func newQuoteTool() (tool.CallableTool, error) {
 
 func printEvents(events <-chan *event.Event) {
 	for evt := range events {
-		if evt.Error != nil {
-			fmt.Printf("Agent error: %s\n", evt.Error.Message)
-			continue
-		}
 		if evt.Response == nil {
 			continue
 		}

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -75,6 +75,7 @@ require (
 	github.com/ollama/ollama v0.16.3 // indirect
 	github.com/panjf2000/ants/v2 v2.11.3 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.2.0 // indirect

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -27,6 +27,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 h1:NMZiJj8QnKe1LgsbDayM4UoHwbvwDRwnI3hwNaAHRnc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0/go.mod h1:ZXNYxsqcloTdSy/rNShjYzMhyjf0LaoftYK0p+A3h40=
+github.com/dlclark/regexp2 v1.11.4 h1:rPYF9/LECdNymJufQKmri9gV604RvvABwgOA8un7yAo=
+github.com/dlclark/regexp2 v1.11.4/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
 github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
@@ -115,6 +117,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/sebdah/goldie/v2 v2.8.0 h1:dZb9wR8q5++oplmEiJT+U/5KyotVD+HNGCAc5gNr8rc=
 github.com/sebdah/goldie/v2 v2.8.0/go.mod h1:oZ9fp0+se1eapSRjfYbsV/0Hqhbuu3bJVvKI/NNtssI=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.32
 	github.com/openai/openai-go v1.12.0
 	github.com/panjf2000/ants/v2 v2.10.0
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/stretchr/testify v1.10.0
 	github.com/tencentyun/cos-go-sdk-v5 v0.7.69
 	github.com/yuin/goldmark v1.4.13

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 h1:NMZiJj8QnKe1LgsbDayM4UoHwbvwDRwnI3hwNaAHRnc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0/go.mod h1:ZXNYxsqcloTdSy/rNShjYzMhyjf0LaoftYK0p+A3h40=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/getkin/kin-openapi v0.124.0 h1:VSFNMB9C9rTKBnQ/fpyDU8ytMTr4dWI9QovSKj9kz/M=
 github.com/getkin/kin-openapi v0.124.0/go.mod h1:wb1aSZA/iWmorQP9KTAS/phLj/t17B5jT7+fS8ed9NM=
 github.com/go-ego/gse v1.0.0 h1:GNbtH1WP7Yd1VvCZ85fIK6eVEe7RctmgmnwliEPUMNA=
@@ -95,6 +97,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/rs/dnscache v0.0.0-20230804202142-fc85eb664529/go.mod h1:qe5TWALJ8/a1Lqznoc5BDHpYX/8HU60Hm2AwRmqzxqA=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/segmentio/asm v1.2.0 h1:9BQrFxC+YOHJlTlHGkTrFWf59nbL3XnCoFLTwDCI7ys=
 github.com/segmentio/asm v1.2.0/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/tool/toolcode/toolcode.go
+++ b/tool/toolcode/toolcode.go
@@ -1,3 +1,11 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
 // Package toolcode exposes capability-limited tool orchestration through generated code.
 package toolcode
 
@@ -19,7 +27,10 @@ type config struct {
 	description string
 }
 
+// WithName overrides the default execute_tool_code tool name.
 func WithName(name string) Option { return func(c *config) { c.name = name } }
+
+// WithDescription replaces the default execute_tool_code tool description.
 func WithDescription(description string) Option {
 	return func(c *config) { c.description = description }
 }
@@ -48,7 +59,7 @@ func NewTool(runtime bridge.Runtime, managedTools []tool.CallableTool, opts ...O
 	}, nil
 }
 
-const defaultDescription = "Run Python glue code to orchestrate explicitly allowlisted host tools. Use it for loops, branching, JSON transformation, and aggregation across dependent tool calls. Prefer one execute_tool_code call when it can complete the workflow. Inside the code, call only documented tools with await call_tool(\"tool_name\", **json_arguments); use keyword arguments and JSON-compatible values. Do not use direct HTTP clients, shell commands, filesystem APIs, environment variables, or imports to reach services or credentials: those are outside this tool's capability contract. The application chooses this independent tool registry; it is not inferred from the agent's direct tools."
+const defaultDescription = "Run Python glue code to orchestrate explicitly allowlisted host tools. Use it for loops, branching, JSON transformation, and aggregation across dependent tool calls. Prefer one execute_tool_code call when it can complete the workflow. Inside the code, call only documented tools with await call_tool(\"tool_name\", **json_arguments); use keyword arguments and JSON-compatible values. Calls execute sequentially in the current runtime; do not assume asyncio.gather provides parallel host calls. Return only the compact JSON-compatible value needed to complete the task; do not print or return raw large tool results. A failed host call raises Python RuntimeError, which code may handle with try/except. Do not use direct HTTP clients, shell commands, filesystem APIs, environment variables, or imports to reach services or credentials: those are outside this tool's capability contract. The application chooses this independent tool registry; it is not inferred from the agent's direct tools."
 
 type executeCodeTool struct {
 	runtime  bridge.Runtime

--- a/tool/toolcode/toolcode.go
+++ b/tool/toolcode/toolcode.go
@@ -1,0 +1,109 @@
+// Package toolcode exposes capability-limited tool orchestration through generated code.
+package toolcode
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	bridge "trpc.group/trpc-go/trpc-agent-go/codeexecutor/codeact"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+// Option configures the execute_tool_code tool.
+type Option func(*config)
+type config struct {
+	name        string
+	description string
+}
+
+func WithName(name string) Option { return func(c *config) { c.name = name } }
+func WithDescription(description string) Option {
+	return func(c *config) { c.description = description }
+}
+
+// NewTool creates an execute_tool_code tool. Only tools supplied here can be called
+// by guest code; the guest cannot access the agent's other tools or credentials.
+func NewTool(runtime bridge.Runtime, managedTools []tool.CallableTool, opts ...Option) (tool.CallableTool, error) {
+	cfg := config{name: "execute_tool_code", description: defaultDescription}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+	if strings.TrimSpace(cfg.name) == "" {
+		return nil, fmt.Errorf("codeact: tool name is required")
+	}
+	gateway, err := bridge.NewGateway(managedTools...)
+	if err != nil {
+		return nil, err
+	}
+	return &executeCodeTool{
+		runtime:  runtime,
+		gateway:  gateway,
+		toolHelp: buildToolHelp(managedTools),
+		cfg:      cfg,
+	}, nil
+}
+
+const defaultDescription = "Run Python glue code to orchestrate explicitly allowlisted host tools. Use it for loops, branching, JSON transformation, and aggregation across dependent tool calls. Prefer one execute_tool_code call when it can complete the workflow. Inside the code, call only documented tools with await call_tool(\"tool_name\", **json_arguments); use keyword arguments and JSON-compatible values. Do not use direct HTTP clients, shell commands, filesystem APIs, environment variables, or imports to reach services or credentials: those are outside this tool's capability contract. The application chooses this independent tool registry; it is not inferred from the agent's direct tools."
+
+type executeCodeTool struct {
+	runtime  bridge.Runtime
+	gateway  *bridge.Gateway
+	toolHelp string
+	cfg      config
+}
+
+func (t *executeCodeTool) Declaration() *tool.Declaration {
+	description := t.cfg.description
+	if t.toolHelp != "" {
+		description += "\n\nHost capabilities available inside Python (call only with await call_tool(name, **json_arguments)):\n" + t.toolHelp
+	}
+	return &tool.Declaration{Name: t.cfg.name, Description: description, InputSchema: &tool.Schema{Type: "object", Required: []string{"code"}, Properties: map[string]*tool.Schema{"code": {Type: "string", Description: "Top-level async Python source. Return a JSON-serializable value and use await call_tool(name, **json_arguments) only for documented host capabilities."}}}, OutputSchema: &tool.Schema{Type: "object", Properties: map[string]*tool.Schema{"value": {Description: "JSON-serializable value returned by the Python program"}, "stdout": {Type: "string", Description: "Captured Python stdout"}}}}
+}
+
+func (t *executeCodeTool) Call(ctx context.Context, raw []byte) (any, error) {
+	var in struct {
+		Code string `json:"code"`
+	}
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
+	}
+	return bridge.Execute(ctx, t.runtime, t.gateway, in.Code)
+}
+
+func buildToolHelp(tools []tool.CallableTool) string {
+	type entry struct {
+		name string
+		decl *tool.Declaration
+	}
+	entries := make([]entry, 0, len(tools))
+	for _, candidate := range tools {
+		if candidate == nil || candidate.Declaration() == nil {
+			continue
+		}
+		decl := candidate.Declaration()
+		entries = append(entries, entry{name: decl.Name, decl: decl})
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].name < entries[j].name })
+
+	var b strings.Builder
+	for _, entry := range entries {
+		inputSchema, err := json.Marshal(entry.decl.InputSchema)
+		if err != nil {
+			inputSchema = []byte("null")
+		}
+		fmt.Fprintf(&b, "- %s: %s\n  Input JSON Schema: %s\n", entry.name, entry.decl.Description, inputSchema)
+		if entry.decl.OutputSchema != nil {
+			outputSchema, err := json.Marshal(entry.decl.OutputSchema)
+			if err != nil {
+				outputSchema = []byte("null")
+			}
+			fmt.Fprintf(&b, "  Output JSON Schema: %s\n", outputSchema)
+		}
+	}
+	return strings.TrimSpace(b.String())
+}

--- a/tool/toolcode/toolcode_test.go
+++ b/tool/toolcode/toolcode_test.go
@@ -1,0 +1,47 @@
+package toolcode
+
+import (
+	"context"
+	"encoding/json"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	bridge "trpc.group/trpc-go/trpc-agent-go/codeexecutor/codeact"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+type addTool struct{}
+
+func (addTool) Declaration() *tool.Declaration {
+	return &tool.Declaration{Name: "add", InputSchema: &tool.Schema{Type: "object", Required: []string{"a", "b"}, Properties: map[string]*tool.Schema{"a": {Type: "integer"}, "b": {Type: "integer"}}}}
+}
+func (addTool) Call(_ context.Context, raw []byte) (any, error) {
+	var v struct {
+		A int `json:"a"`
+		B int `json:"b"`
+	}
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return nil, err
+	}
+	return v.A + v.B, nil
+}
+
+func TestToolRunsGuestThroughGateway(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 unavailable")
+	}
+	toolValue, err := NewTool(bridge.LocalRunner{}, []tool.CallableTool{addTool{}})
+	require.NoError(t, err)
+	require.Equal(t, "execute_tool_code", toolValue.Declaration().Name)
+	require.Contains(t, toolValue.Declaration().Description, "add")
+	require.Contains(t, toolValue.Declaration().Description, "Prefer one execute_tool_code call")
+	require.Contains(t, toolValue.Declaration().Description, "direct HTTP clients")
+	require.Contains(t, toolValue.Declaration().Description, "Host capabilities available inside Python")
+	require.Contains(t, toolValue.Declaration().Description, "Input JSON Schema")
+	require.Contains(t, toolValue.Declaration().Description, "\"a\"")
+	result, err := toolValue.Call(context.Background(), []byte(`{"code":"return await call_tool('add', a=1, b=41)"}`))
+	require.NoError(t, err)
+	got := result.(bridge.Result)
+	require.JSONEq(t, "42", string(got.Value))
+}

--- a/tool/toolcode/toolcode_test.go
+++ b/tool/toolcode/toolcode_test.go
@@ -1,9 +1,18 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
 package toolcode
 
 import (
 	"context"
 	"encoding/json"
 	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -36,6 +45,9 @@ func TestToolRunsGuestThroughGateway(t *testing.T) {
 	require.Equal(t, "execute_tool_code", toolValue.Declaration().Name)
 	require.Contains(t, toolValue.Declaration().Description, "add")
 	require.Contains(t, toolValue.Declaration().Description, "Prefer one execute_tool_code call")
+	require.Contains(t, toolValue.Declaration().Description, "Calls execute sequentially")
+	require.Contains(t, toolValue.Declaration().Description, "compact JSON-compatible value")
+	require.Contains(t, toolValue.Declaration().Description, "Python RuntimeError")
 	require.Contains(t, toolValue.Declaration().Description, "direct HTTP clients")
 	require.Contains(t, toolValue.Declaration().Description, "Host capabilities available inside Python")
 	require.Contains(t, toolValue.Declaration().Description, "Input JSON Schema")
@@ -44,4 +56,68 @@ func TestToolRunsGuestThroughGateway(t *testing.T) {
 	require.NoError(t, err)
 	got := result.(bridge.Result)
 	require.JSONEq(t, "42", string(got.Value))
+}
+
+func TestNewToolOptionsAndValidation(t *testing.T) {
+	toolValue, err := NewTool(nil, nil, WithName("orchestrate"), WithDescription("custom description"))
+	require.NoError(t, err)
+	decl := toolValue.Declaration()
+	require.Equal(t, "orchestrate", decl.Name)
+	require.Equal(t, "custom description", decl.Description)
+
+	_, err = NewTool(nil, nil, WithName(" \t"))
+	require.ErrorContains(t, err, "tool name is required")
+	_, err = NewTool(nil, []tool.CallableTool{nil})
+	require.ErrorContains(t, err, "tool declaration is required")
+}
+
+func TestToolCallValidationAndRuntime(t *testing.T) {
+	runtime := &recordingRuntime{result: bridge.Result{Value: json.RawMessage(`{"ok":true}`)}}
+	toolValue, err := NewTool(runtime, nil)
+	require.NoError(t, err)
+
+	_, err = toolValue.Call(context.Background(), []byte(`not-json`))
+	require.Error(t, err)
+	_, err = toolValue.Call(context.Background(), []byte(`{"code":""}`))
+	require.ErrorContains(t, err, "code is required")
+
+	result, err := toolValue.Call(context.Background(), []byte(`{"code":"return {'ok': True}"}`))
+	require.NoError(t, err)
+	require.Equal(t, "return {'ok': True}", runtime.request.Code)
+	require.Equal(t, "python", runtime.request.Language)
+	require.Equal(t, runtime.result, result)
+
+	nilRuntimeTool, err := NewTool(nil, nil)
+	require.NoError(t, err)
+	_, err = nilRuntimeTool.Call(context.Background(), []byte(`{"code":"return 1"}`))
+	require.ErrorContains(t, err, "runtime is required")
+}
+
+func TestBuildToolHelpSortsSchemasAndSkipsInvalidDeclarations(t *testing.T) {
+	help := buildToolHelp([]tool.CallableTool{
+		nil,
+		declaredTool{},
+		declaredTool{decl: &tool.Declaration{Name: "zeta", Description: "zeta description", InputSchema: &tool.Schema{Type: "object"}}},
+		declaredTool{decl: &tool.Declaration{Name: "alpha", Description: "alpha description", OutputSchema: &tool.Schema{Type: "string"}}},
+	})
+	require.Less(t, strings.Index(help, "alpha"), strings.Index(help, "zeta"))
+	require.Contains(t, help, "Input JSON Schema")
+	require.Contains(t, help, "Output JSON Schema")
+}
+
+type recordingRuntime struct {
+	request bridge.Request
+	result  bridge.Result
+}
+
+func (r *recordingRuntime) ExecuteCodeAct(_ context.Context, req bridge.Request, _ bridge.ToolCallHandler) (bridge.Result, error) {
+	r.request = req
+	return r.result, nil
+}
+
+type declaredTool struct{ decl *tool.Declaration }
+
+func (t declaredTool) Declaration() *tool.Declaration { return t.decl }
+func (declaredTool) Call(context.Context, []byte) (any, error) {
+	return nil, nil
 }


### PR DESCRIPTION
## Background

Workflows with loops, branching, and data transformation across dependent tools require repeated model turns when using one-tool-at-a-time function calling.

This PR adds tool code orchestration: `execute_tool_code` runs generated Python and bridges only an explicitly allowlisted set of Go tools. Stable business workflows should continue to be implemented in Go.