### PR TITLE
agent/extension/todoenforcer: preserve caller streaming mode

### DIFF
--- a/agent/extension/todoenforcer/doc.go
+++ b/agent/extension/todoenforcer/doc.go
@@ -27,7 +27,10 @@
 //     branch's todo list still contains pending or in-progress
 //     items, the response's `Done` flag is flipped to false so
 //     llmflow keeps looping; a "reminder pending" marker is
-//     stored on the invocation.
+//     stored on the invocation. Streaming remains enabled when
+//     requested by the caller: partial text may already be visible
+//     to clients, but the response is not accepted as terminal or
+//     persisted as assistant history.
 //  2. BeforeModel drains that marker on the next turn and
 //     appends a nudge user message to the request, listing the
 //     items that remain and the model's two valid next actions

--- a/agent/extension/todoenforcer/enforcer.go
+++ b/agent/extension/todoenforcer/enforcer.go
@@ -118,14 +118,16 @@ func (e *Enforcer) Register(r *extension.Registry) {
 
 // beforeModel prepares a model request while enforcement is active.
 //
-// It disables streaming whenever open todo items exist. The
-// enforcer can only make a hard allow/block decision after seeing
-// a complete model response; streaming deltas would otherwise
-// reach clients before AfterModel has a chance to reject the final
-// answer.
-//
-// It also injects a nudge user message when the previous
+// It injects a nudge user message when the previous
 // AfterModel turn flagged a pending reminder.
+//
+// Streaming is deliberately left to the caller. AfterModel sees
+// the complete response after any partial deltas have been emitted;
+// when open items remain it turns that final response into a
+// non-final control response, so llmflow starts another model turn.
+// A client can therefore observe an interim answer before the agent
+// continues, but that answer is never accepted as the terminal
+// response or persisted as assistant history.
 //
 // Notes worth pinning down:
 //
@@ -178,7 +180,6 @@ func (e *Enforcer) beforeModel(
 	if len(inProgress) == 0 && len(pending) == 0 {
 		return nil, nil
 	}
-	args.Request.GenerationConfig.Stream = false
 
 	if !pendingReminder {
 		return nil, nil

--- a/agent/extension/todoenforcer/enforcer_test.go
+++ b/agent/extension/todoenforcer/enforcer_test.go
@@ -429,12 +429,11 @@ func TestBeforeModel_NoPending_NoOp(t *testing.T) {
 	assert.Len(t, req.Messages, 1)
 }
 
-// TestBeforeModel_OpenItems_DisablesStreamingWithoutNudge covers
-// the streaming side of hard compliance. Even when no reminder is
-// pending yet, the enforcer must turn streaming off while open
-// todo items exist; otherwise partial deltas could reach clients
-// before AfterModel can reject the final answer.
-func TestBeforeModel_OpenItems_DisablesStreamingWithoutNudge(t *testing.T) {
+// TestBeforeModel_OpenItems_PreservesStreamingWithoutNudge ensures
+// enforcement does not override the caller's presentation choice.
+// AfterModel still converts an early final response into a non-final
+// control response after the streaming final arrives.
+func TestBeforeModel_OpenItems_PreservesStreamingWithoutNudge(t *testing.T) {
 	ctx, inv, sess := newTestInvocation(t, "a")
 	writeTodos(t, sess, "", []todo.Item{
 		{Content: "Run tests", ActiveForm: "Running tests", Status: todo.StatusInProgress},
@@ -449,8 +448,8 @@ func TestBeforeModel_OpenItems_DisablesStreamingWithoutNudge(t *testing.T) {
 	}
 	_, err := e.beforeModel(ctx, &model.BeforeModelArgs{Request: req})
 	require.NoError(t, err)
-	assert.False(t, req.GenerationConfig.Stream,
-		"hard enforcement must disable streaming while open todos exist")
+	assert.True(t, req.GenerationConfig.Stream,
+		"enforcement must preserve the caller's streaming choice")
 	assert.Len(t, req.Messages, 1,
 		"no pending reminder means no nudge message is injected yet")
 	assert.False(t, reminderPending(inv))

--- a/docs/mkdocs/en/tool.md
+++ b/docs/mkdocs/en/tool.md
@@ -742,7 +742,7 @@ agent := llmagent.New("todo-assistant",
 )
 ```
 
-The extension contributes both `todo_write` and `todo_declare_blocker`; do not also pass a separate `todo.New()` through `WithTools`. To reuse `tool/todo` options such as `WithStateKeyPrefix`, `WithClearOnAllDone`, or `WithNudgeHook`, construct the tool yourself and pass it with `todoenforcer.WithTodoTool(todo.New(...))`. `todo_declare_blocker` is the escape hatch for objective blockers such as missing permissions, credentials, infrastructure, or user decisions.
+The extension contributes both `todo_write` and `todo_declare_blocker`; do not also pass a separate `todo.New()` through `WithTools`. To reuse `tool/todo` options such as `WithStateKeyPrefix`, `WithClearOnAllDone`, or `WithNudgeHook`, construct the tool yourself and pass it with `todoenforcer.WithTodoTool(todo.New(...))`. `todo_declare_blocker` is the escape hatch for objective blockers such as missing permissions, credentials, infrastructure, or user decisions. The extension preserves the caller's streaming setting: text from an unfinished attempt may already reach the client, but its final response is converted into a continuation signal and is not persisted as the turn's terminal assistant history.
 
 #### Tool Result
 

--- a/docs/mkdocs/zh/tool.md
+++ b/docs/mkdocs/zh/tool.md
@@ -723,7 +723,7 @@ agent := llmagent.New("todo-assistant",
 )
 ```
 
-该 extension 会自动贡献 `todo_write` 和 `todo_declare_blocker`，不要再通过 `WithTools` 额外传入 `todo.New()`。如果需要复用 `tool/todo` 的选项（例如 `WithStateKeyPrefix`、`WithClearOnAllDone` 或 `WithNudgeHook`），先构造 `todo.New(...)`，再通过 `todoenforcer.WithTodoTool(...)` 传入。`todo_declare_blocker` 用于声明客观阻塞，例如缺少权限、凭据、基础设施或必须由用户决策的信息。
+该 extension 会自动贡献 `todo_write` 和 `todo_declare_blocker`，不要再通过 `WithTools` 额外传入 `todo.New()`。如果需要复用 `tool/todo` 的选项（例如 `WithStateKeyPrefix`、`WithClearOnAllDone` 或 `WithNudgeHook`），先构造 `todo.New(...)`，再通过 `todoenforcer.WithTodoTool(...)` 传入。`todo_declare_blocker` 用于声明客观阻塞，例如缺少权限、凭据、基础设施或必须由用户决策的信息。extension 不会改写调用方的流式设置：未完成时模型已经输出的文本仍可能到达客户端，但最终响应会被转为继续执行信号，不会作为本轮终态写入会话历史。
 
 #### 工具返回结构
 


### PR DESCRIPTION
## Summary
- preserve the caller's streaming setting while todo enforcement is active
- continue open todo work by converting only the completed model response into a non-terminal control response
- document that streamed interim text can reach clients but is not persisted as terminal assistant history

## Testing
- go test ./agent/extension/todoenforcer ./agent/llmagent ./internal/flow/llmflow