### PR TITLE
openclaw: trace prompt cache usage

### DIFF
--- a/openclaw/gwproto/types.go
+++ b/openclaw/gwproto/types.go
@@ -58,12 +58,24 @@ type Usage struct {
 	CompletionTokens int `json:"completion_tokens"`
 	TotalTokens      int `json:"total_tokens"`
 
+	PromptDetails *PromptDetails `json:"prompt_tokens_details,omitempty"`
+
 	// LastPromptTokens is the prompt_tokens from the most recent LLM call
 	// within the request. Unlike PromptTokens which aggregates across all
 	// LLM calls in a request (tool-call loops), this field reflects the
 	// actual context window occupancy of the final call and is used for
 	// accurate context usage display.
 	LastPromptTokens int `json:"last_prompt_tokens,omitempty"`
+
+	LastDetails *PromptDetails `json:"last_prompt_tokens_details,omitempty"`
+}
+
+// PromptDetails describes prompt-side cache usage when the provider
+// reports it.
+type PromptDetails struct {
+	CachedTokens        int `json:"cached_tokens,omitempty"`
+	CacheCreationTokens int `json:"cache_creation_tokens,omitempty"`
+	CacheReadTokens     int `json:"cache_read_tokens,omitempty"`
 }
 
 // MessageResponse matches the gateway /messages response JSON.

--- a/openclaw/gwproto/types_test.go
+++ b/openclaw/gwproto/types_test.go
@@ -43,11 +43,15 @@ func TestUsageJSONIncludesPromptTokenDetails(t *testing.T) {
 			CompletionTokens: 10,
 			TotalTokens:      110,
 			PromptDetails: &PromptDetails{
-				CachedTokens: 80,
+				CachedTokens:        80,
+				CacheCreationTokens: 12,
+				CacheReadTokens:     68,
 			},
 			LastPromptTokens: 100,
 			LastDetails: &PromptDetails{
-				CachedTokens: 80,
+				CachedTokens:        80,
+				CacheCreationTokens: 8,
+				CacheReadTokens:     72,
 			},
 		},
 	})
@@ -60,11 +64,15 @@ func TestUsageJSONIncludesPromptTokenDetails(t *testing.T) {
 				"completion_tokens": 10,
 				"total_tokens": 110,
 				"prompt_tokens_details": {
-					"cached_tokens": 80
+					"cached_tokens": 80,
+					"cache_creation_tokens": 12,
+					"cache_read_tokens": 68
 				},
 				"last_prompt_tokens": 100,
 				"last_prompt_tokens_details": {
-					"cached_tokens": 80
+					"cached_tokens": 80,
+					"cache_creation_tokens": 8,
+					"cache_read_tokens": 72
 				}
 			}
 		}`,

--- a/openclaw/gwproto/types_test.go
+++ b/openclaw/gwproto/types_test.go
@@ -31,3 +31,43 @@ func TestUsageJSONIncludesZeroCounters(t *testing.T) {
 		string(payload),
 	)
 }
+
+func TestUsageJSONIncludesPromptTokenDetails(t *testing.T) {
+	t.Parallel()
+
+	payload, err := json.Marshal(struct {
+		Usage *Usage `json:"usage,omitempty"`
+	}{
+		Usage: &Usage{
+			PromptTokens:     100,
+			CompletionTokens: 10,
+			TotalTokens:      110,
+			PromptDetails: &PromptDetails{
+				CachedTokens: 80,
+			},
+			LastPromptTokens: 100,
+			LastDetails: &PromptDetails{
+				CachedTokens: 80,
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.JSONEq(
+		t,
+		`{
+			"usage": {
+				"prompt_tokens": 100,
+				"completion_tokens": 10,
+				"total_tokens": 110,
+				"prompt_tokens_details": {
+					"cached_tokens": 80
+				},
+				"last_prompt_tokens": 100,
+				"last_prompt_tokens_details": {
+					"cached_tokens": 80
+				}
+			}
+		}`,
+		string(payload),
+	)
+}

--- a/openclaw/internal/debugrecorder/recorder.go
+++ b/openclaw/internal/debugrecorder/recorder.go
@@ -67,6 +67,7 @@ const (
 	KindRuntimeProfile = "runtime.profile"
 	KindModelReq       = "model.chat.request"
 	KindRunnerEvent    = "runner.event"
+	KindPromptCache    = "prompt_cache.usage"
 
 	ProviderOpenAIChatCompletions = "openai.chat.completions"
 

--- a/openclaw/internal/gateway/process.go
+++ b/openclaw/internal/gateway/process.go
@@ -122,6 +122,12 @@ func (s *Server) ProcessMessage(
 			}
 			status = http.StatusOK
 			if trace != nil {
+				recordPromptCacheUsage(
+					trace,
+					prepared.sessionID,
+					resolvedRequestID,
+					usage,
+				)
 				_ = trace.Record(
 					debugrecorder.KindGatewayRsp,
 					map[string]any{
@@ -163,6 +169,12 @@ func (s *Server) ProcessMessage(
 	status = http.StatusOK
 
 	if trace != nil {
+		recordPromptCacheUsage(
+			trace,
+			prepared.sessionID,
+			resolvedRequestID,
+			usage,
+		)
 		_ = trace.Record(
 			debugrecorder.KindGatewayRsp,
 			map[string]any{

--- a/openclaw/internal/gateway/prompt_cache_trace.go
+++ b/openclaw/internal/gateway/prompt_cache_trace.go
@@ -36,34 +36,38 @@ func promptCacheUsageRecord(
 ) map[string]any {
 	prompt := usage.PromptTokens
 	details := usage.PromptDetails
-	cached := promptCachedTokens(details)
 
 	record := map[string]any{
 		"session_id":        sessionID,
 		"request_id":        requestID,
 		"prompt_tokens":     prompt,
-		"cached_tokens":     cached,
-		"uncached_tokens":   nonNegativeDelta(prompt, cached),
 		"completion_tokens": usage.CompletionTokens,
 		"total_tokens":      usage.TotalTokens,
 	}
-	if prompt > 0 {
-		record["cache_hit_ratio"] = float64(cached) / float64(prompt)
+	if details != nil {
+		cached := promptCachedTokens(details)
+		record["cached_tokens"] = cached
+		record["uncached_tokens"] = nonNegativeDelta(prompt, cached)
+		if prompt > 0 {
+			record["cache_hit_ratio"] = float64(cached) / float64(prompt)
+		}
 	}
 	addPromptCacheDetails(record, "", details)
 
 	lastPrompt := usage.LastPromptTokens
 	if lastPrompt > 0 {
 		lastDetails := usage.LastDetails
-		lastCached := promptCachedTokens(lastDetails)
 		record["last_prompt_tokens"] = lastPrompt
-		record["last_cached_tokens"] = lastCached
-		record["last_uncached_tokens"] = nonNegativeDelta(
-			lastPrompt,
-			lastCached,
-		)
-		record["last_cache_hit_ratio"] = float64(lastCached) /
-			float64(lastPrompt)
+		if lastDetails != nil {
+			lastCached := promptCachedTokens(lastDetails)
+			record["last_cached_tokens"] = lastCached
+			record["last_uncached_tokens"] = nonNegativeDelta(
+				lastPrompt,
+				lastCached,
+			)
+			record["last_cache_hit_ratio"] = float64(lastCached) /
+				float64(lastPrompt)
+		}
 		addPromptCacheDetails(record, "last_", lastDetails)
 	}
 	return record

--- a/openclaw/internal/gateway/prompt_cache_trace.go
+++ b/openclaw/internal/gateway/prompt_cache_trace.go
@@ -1,0 +1,104 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package gateway
+
+import (
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/gwproto"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/debugrecorder"
+)
+
+func recordPromptCacheUsage(
+	trace *debugrecorder.Trace,
+	sessionID string,
+	requestID string,
+	usage *gwproto.Usage,
+) {
+	if trace == nil || usage == nil {
+		return
+	}
+	_ = trace.Record(
+		debugrecorder.KindPromptCache,
+		promptCacheUsageRecord(sessionID, requestID, usage),
+	)
+}
+
+func promptCacheUsageRecord(
+	sessionID string,
+	requestID string,
+	usage *gwproto.Usage,
+) map[string]any {
+	prompt := usage.PromptTokens
+	details := usage.PromptDetails
+	cached := promptCachedTokens(details)
+
+	record := map[string]any{
+		"session_id":        sessionID,
+		"request_id":        requestID,
+		"prompt_tokens":     prompt,
+		"cached_tokens":     cached,
+		"uncached_tokens":   nonNegativeDelta(prompt, cached),
+		"completion_tokens": usage.CompletionTokens,
+		"total_tokens":      usage.TotalTokens,
+	}
+	if prompt > 0 {
+		record["cache_hit_ratio"] = float64(cached) / float64(prompt)
+	}
+	addPromptCacheDetails(record, "", details)
+
+	lastPrompt := usage.LastPromptTokens
+	if lastPrompt > 0 {
+		lastDetails := usage.LastDetails
+		lastCached := promptCachedTokens(lastDetails)
+		record["last_prompt_tokens"] = lastPrompt
+		record["last_cached_tokens"] = lastCached
+		record["last_uncached_tokens"] = nonNegativeDelta(
+			lastPrompt,
+			lastCached,
+		)
+		record["last_cache_hit_ratio"] = float64(lastCached) /
+			float64(lastPrompt)
+		addPromptCacheDetails(record, "last_", lastDetails)
+	}
+	return record
+}
+
+func addPromptCacheDetails(
+	record map[string]any,
+	prefix string,
+	details *gwproto.PromptDetails,
+) {
+	if details == nil {
+		return
+	}
+	if details.CacheCreationTokens != 0 {
+		record[prefix+"cache_creation_tokens"] =
+			details.CacheCreationTokens
+	}
+	if details.CacheReadTokens != 0 {
+		record[prefix+"cache_read_tokens"] = details.CacheReadTokens
+	}
+}
+
+func promptCachedTokens(details *gwproto.PromptDetails) int {
+	if details == nil {
+		return 0
+	}
+	if details.CachedTokens > 0 {
+		return details.CachedTokens
+	}
+	return details.CacheReadTokens
+}
+
+func nonNegativeDelta(total int, part int) int {
+	if total <= part {
+		return 0
+	}
+	return total - part
+}

--- a/openclaw/internal/gateway/prompt_cache_trace.go
+++ b/openclaw/internal/gateway/prompt_cache_trace.go
@@ -90,10 +90,10 @@ func promptCachedTokens(details *gwproto.PromptDetails) int {
 	if details == nil {
 		return 0
 	}
-	if details.CachedTokens > 0 {
-		return details.CachedTokens
+	if details.CacheReadTokens > 0 {
+		return details.CacheReadTokens
 	}
-	return details.CacheReadTokens
+	return details.CachedTokens
 }
 
 func nonNegativeDelta(total int, part int) int {

--- a/openclaw/internal/gateway/prompt_cache_trace_test.go
+++ b/openclaw/internal/gateway/prompt_cache_trace_test.go
@@ -60,6 +60,7 @@ func TestPromptCacheUsageRecordPrefersCacheReadTokens(t *testing.T) {
 		&gwproto.Usage{
 			PromptTokens: 100,
 			PromptDetails: &gwproto.PromptDetails{
+				CachedTokens:    20,
 				CacheReadTokens: 60,
 			},
 		},
@@ -82,6 +83,7 @@ func TestPromptCacheUsageRecordPrefersLastCacheReadTokens(
 		&gwproto.Usage{
 			LastPromptTokens: 100,
 			LastDetails: &gwproto.PromptDetails{
+				CachedTokens:    20,
 				CacheReadTokens: 70,
 			},
 		},

--- a/openclaw/internal/gateway/prompt_cache_trace_test.go
+++ b/openclaw/internal/gateway/prompt_cache_trace_test.go
@@ -70,3 +70,25 @@ func TestPromptCacheUsageRecordPrefersCacheReadTokens(t *testing.T) {
 	require.Equal(t, 60, record["cache_read_tokens"])
 	require.InDelta(t, 0.6, record["cache_hit_ratio"], 0.0001)
 }
+
+func TestPromptCacheUsageRecordPrefersLastCacheReadTokens(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	record := promptCacheUsageRecord(
+		"session-1",
+		"request-1",
+		&gwproto.Usage{
+			LastPromptTokens: 100,
+			LastDetails: &gwproto.PromptDetails{
+				CacheReadTokens: 70,
+			},
+		},
+	)
+
+	require.Equal(t, 70, record["last_cached_tokens"])
+	require.Equal(t, 30, record["last_uncached_tokens"])
+	require.Equal(t, 70, record["last_cache_read_tokens"])
+	require.InDelta(t, 0.7, record["last_cache_hit_ratio"], 0.0001)
+}

--- a/openclaw/internal/gateway/prompt_cache_trace_test.go
+++ b/openclaw/internal/gateway/prompt_cache_trace_test.go
@@ -96,6 +96,30 @@ func TestPromptCacheUsageRecordPrefersLastCacheReadTokens(
 	require.InDelta(t, 0.7, record["last_cache_hit_ratio"], 0.0001)
 }
 
+func TestPromptCacheUsageRecordOmitsCacheFieldsWithoutDetails(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	record := promptCacheUsageRecord(
+		"session-1",
+		"request-1",
+		&gwproto.Usage{
+			PromptTokens:     100,
+			LastPromptTokens: 80,
+		},
+	)
+
+	require.Equal(t, 100, record["prompt_tokens"])
+	require.Equal(t, 80, record["last_prompt_tokens"])
+	require.NotContains(t, record, "cached_tokens")
+	require.NotContains(t, record, "uncached_tokens")
+	require.NotContains(t, record, "cache_hit_ratio")
+	require.NotContains(t, record, "last_cached_tokens")
+	require.NotContains(t, record, "last_uncached_tokens")
+	require.NotContains(t, record, "last_cache_hit_ratio")
+}
+
 func TestRecordPromptCacheUsageWritesTraceEvent(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/internal/gateway/prompt_cache_trace_test.go
+++ b/openclaw/internal/gateway/prompt_cache_trace_test.go
@@ -1,0 +1,72 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package gateway
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/gwproto"
+)
+
+func TestPromptCacheUsageRecord(t *testing.T) {
+	t.Parallel()
+
+	record := promptCacheUsageRecord(
+		"session-1",
+		"request-1",
+		&gwproto.Usage{
+			PromptTokens:     1000,
+			CompletionTokens: 50,
+			TotalTokens:      1050,
+			PromptDetails: &gwproto.PromptDetails{
+				CachedTokens: 800,
+			},
+			LastPromptTokens: 900,
+			LastDetails: &gwproto.PromptDetails{
+				CachedTokens: 700,
+			},
+		},
+	)
+
+	require.Equal(t, "session-1", record["session_id"])
+	require.Equal(t, "request-1", record["request_id"])
+	require.Equal(t, 1000, record["prompt_tokens"])
+	require.Equal(t, 800, record["cached_tokens"])
+	require.Equal(t, 200, record["uncached_tokens"])
+	require.Equal(t, 50, record["completion_tokens"])
+	require.Equal(t, 1050, record["total_tokens"])
+	require.InDelta(t, 0.8, record["cache_hit_ratio"], 0.0001)
+	require.Equal(t, 900, record["last_prompt_tokens"])
+	require.Equal(t, 700, record["last_cached_tokens"])
+	require.Equal(t, 200, record["last_uncached_tokens"])
+	require.InDelta(t, 0.7777, record["last_cache_hit_ratio"], 0.0001)
+}
+
+func TestPromptCacheUsageRecordPrefersCacheReadTokens(t *testing.T) {
+	t.Parallel()
+
+	record := promptCacheUsageRecord(
+		"session-1",
+		"request-1",
+		&gwproto.Usage{
+			PromptTokens: 100,
+			PromptDetails: &gwproto.PromptDetails{
+				CacheReadTokens: 60,
+			},
+		},
+	)
+
+	require.Equal(t, 60, record["cached_tokens"])
+	require.Equal(t, 40, record["uncached_tokens"])
+	require.Equal(t, 60, record["cache_read_tokens"])
+	require.InDelta(t, 0.6, record["cache_hit_ratio"], 0.0001)
+}

--- a/openclaw/internal/gateway/prompt_cache_trace_test.go
+++ b/openclaw/internal/gateway/prompt_cache_trace_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/gwproto"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/debugrecorder"
 )
 
 func TestPromptCacheUsageRecord(t *testing.T) {
@@ -93,4 +94,47 @@ func TestPromptCacheUsageRecordPrefersLastCacheReadTokens(
 	require.Equal(t, 30, record["last_uncached_tokens"])
 	require.Equal(t, 70, record["last_cache_read_tokens"])
 	require.InDelta(t, 0.7, record["last_cache_hit_ratio"], 0.0001)
+}
+
+func TestRecordPromptCacheUsageWritesTraceEvent(t *testing.T) {
+	t.Parallel()
+
+	rec, err := debugrecorder.New(t.TempDir(), "")
+	require.NoError(t, err)
+	trace, err := rec.Start(debugrecorder.TraceStart{
+		SessionID: "session-1",
+		RequestID: "request-1",
+	})
+	require.NoError(t, err)
+
+	recordPromptCacheUsage(nil, "session-1", "request-1", nil)
+	recordPromptCacheUsage(trace, "session-1", "request-1", nil)
+	recordPromptCacheUsage(
+		trace,
+		"session-1",
+		"request-1",
+		&gwproto.Usage{
+			PromptTokens: 100,
+			PromptDetails: &gwproto.PromptDetails{
+				CacheCreationTokens: 12,
+				CacheReadTokens:     64,
+			},
+			LastPromptTokens: 80,
+			LastDetails: &gwproto.PromptDetails{
+				CacheCreationTokens: 5,
+				CacheReadTokens:     32,
+			},
+		},
+	)
+	require.NoError(t, trace.Close(debugrecorder.TraceEnd{
+		Status: "ok",
+	}))
+
+	raw, err := debugrecorder.ReadEventsFile(trace.Dir())
+	require.NoError(t, err)
+	require.Contains(t, string(raw), debugrecorder.KindPromptCache)
+	require.Contains(t, string(raw), `"cache_creation_tokens":12`)
+	require.Contains(t, string(raw), `"cache_read_tokens":64`)
+	require.Contains(t, string(raw), `"last_cache_creation_tokens":5`)
+	require.Contains(t, string(raw), `"last_cache_read_tokens":32`)
 }

--- a/openclaw/internal/gateway/server.go
+++ b/openclaw/internal/gateway/server.go
@@ -719,7 +719,10 @@ func usageFromModelUsage(usage *model.Usage) *gwproto.Usage {
 		return nil
 	}
 	return &gwproto.Usage{
-		PromptTokens:     usage.PromptTokens,
+		PromptTokens: usage.PromptTokens,
+		PromptDetails: promptTokensDetailsFromModel(
+			usage.PromptTokensDetails,
+		),
 		CompletionTokens: usage.CompletionTokens,
 		TotalTokens:      usage.TotalTokens,
 	}
@@ -759,21 +762,35 @@ func mergeGatewayUsage(
 		cloned := cloneGatewayUsage(usage)
 		if cloned != nil {
 			cloned.LastPromptTokens = usage.PromptTokens
+			cloned.LastDetails = clonePromptTokensDetails(
+				usage.PromptDetails,
+			)
 		}
 		return cloned
 	}
 	lastPrompt := accumulated.LastPromptTokens
+	lastPromptDetails := clonePromptTokensDetails(
+		accumulated.LastDetails,
+	)
 	if usage.PromptTokens > 0 {
 		lastPrompt = usage.PromptTokens
+		lastPromptDetails = clonePromptTokensDetails(
+			usage.PromptDetails,
+		)
 	}
 	return &gwproto.Usage{
 		PromptTokens: accumulated.PromptTokens +
 			usage.PromptTokens,
+		PromptDetails: mergePromptTokensDetails(
+			accumulated.PromptDetails,
+			usage.PromptDetails,
+		),
 		CompletionTokens: accumulated.CompletionTokens +
 			usage.CompletionTokens,
 		TotalTokens: accumulated.TotalTokens +
 			usage.TotalTokens,
 		LastPromptTokens: lastPrompt,
+		LastDetails:      lastPromptDetails,
 	}
 }
 
@@ -782,7 +799,67 @@ func cloneGatewayUsage(usage *gwproto.Usage) *gwproto.Usage {
 		return nil
 	}
 	cloned := *usage
+	cloned.PromptDetails = clonePromptTokensDetails(
+		usage.PromptDetails,
+	)
+	cloned.LastDetails = clonePromptTokensDetails(
+		usage.LastDetails,
+	)
 	return &cloned
+}
+
+func promptTokensDetailsFromModel(
+	details model.PromptTokensDetails,
+) *gwproto.PromptDetails {
+	return nonZeroPromptTokensDetails(&gwproto.PromptDetails{
+		CachedTokens:        details.CachedTokens,
+		CacheCreationTokens: details.CacheCreationTokens,
+		CacheReadTokens:     details.CacheReadTokens,
+	})
+}
+
+func clonePromptTokensDetails(
+	details *gwproto.PromptDetails,
+) *gwproto.PromptDetails {
+	if details == nil {
+		return nil
+	}
+	cloned := *details
+	return nonZeroPromptTokensDetails(&cloned)
+}
+
+func mergePromptTokensDetails(
+	accumulated *gwproto.PromptDetails,
+	details *gwproto.PromptDetails,
+) *gwproto.PromptDetails {
+	if accumulated == nil {
+		return clonePromptTokensDetails(details)
+	}
+	if details == nil {
+		return clonePromptTokensDetails(accumulated)
+	}
+	return nonZeroPromptTokensDetails(&gwproto.PromptDetails{
+		CachedTokens: accumulated.CachedTokens +
+			details.CachedTokens,
+		CacheCreationTokens: accumulated.CacheCreationTokens +
+			details.CacheCreationTokens,
+		CacheReadTokens: accumulated.CacheReadTokens +
+			details.CacheReadTokens,
+	})
+}
+
+func nonZeroPromptTokensDetails(
+	details *gwproto.PromptDetails,
+) *gwproto.PromptDetails {
+	if details == nil {
+		return nil
+	}
+	if details.CachedTokens == 0 &&
+		details.CacheCreationTokens == 0 &&
+		details.CacheReadTokens == 0 {
+		return nil
+	}
+	return details
 }
 
 type laneLocker struct {

--- a/openclaw/internal/gateway/server_test.go
+++ b/openclaw/internal/gateway/server_test.go
@@ -2813,6 +2813,9 @@ func TestReplyAccumulator_CapturesUsage(t *testing.T) {
 				PromptTokens:     12000,
 				CompletionTokens: 345,
 				TotalTokens:      12345,
+				PromptTokensDetails: model.PromptTokensDetails{
+					CachedTokens: 8192,
+				},
 			},
 		},
 		RequestID: "req-1",
@@ -2822,6 +2825,11 @@ func TestReplyAccumulator_CapturesUsage(t *testing.T) {
 	require.Equal(t, 12000, acc.Usage.PromptTokens)
 	require.Equal(t, 345, acc.Usage.CompletionTokens)
 	require.Equal(t, 12345, acc.Usage.TotalTokens)
+	require.Equal(t, 12000, acc.Usage.LastPromptTokens)
+	require.NotNil(t, acc.Usage.PromptDetails)
+	require.Equal(t, 8192, acc.Usage.PromptDetails.CachedTokens)
+	require.NotNil(t, acc.Usage.LastDetails)
+	require.Equal(t, 8192, acc.Usage.LastDetails.CachedTokens)
 }
 
 func TestReplyAccumulator_AggregatesUsageAcrossResponses(
@@ -2844,6 +2852,9 @@ func TestReplyAccumulator_AggregatesUsageAcrossResponses(
 				PromptTokens:     100,
 				CompletionTokens: 50,
 				TotalTokens:      150,
+				PromptTokensDetails: model.PromptTokensDetails{
+					CachedTokens: 64,
+				},
 			},
 		},
 		RequestID: "req-1",
@@ -2858,6 +2869,9 @@ func TestReplyAccumulator_AggregatesUsageAcrossResponses(
 				PromptTokens:     200,
 				CompletionTokens: 30,
 				TotalTokens:      230,
+				PromptTokensDetails: model.PromptTokensDetails{
+					CachedTokens: 128,
+				},
 			},
 		},
 		RequestID: "req-1",
@@ -2868,6 +2882,11 @@ func TestReplyAccumulator_AggregatesUsageAcrossResponses(
 	require.Equal(t, 300, acc.Usage.PromptTokens)
 	require.Equal(t, 80, acc.Usage.CompletionTokens)
 	require.Equal(t, 380, acc.Usage.TotalTokens)
+	require.Equal(t, 200, acc.Usage.LastPromptTokens)
+	require.NotNil(t, acc.Usage.PromptDetails)
+	require.Equal(t, 192, acc.Usage.PromptDetails.CachedTokens)
+	require.NotNil(t, acc.Usage.LastDetails)
+	require.Equal(t, 128, acc.Usage.LastDetails.CachedTokens)
 }
 
 func TestReplyAccumulator_IgnoresUsageWithoutTokenCounts(

--- a/openclaw/internal/gateway/server_test.go
+++ b/openclaw/internal/gateway/server_test.go
@@ -2853,7 +2853,9 @@ func TestReplyAccumulator_AggregatesUsageAcrossResponses(
 				CompletionTokens: 50,
 				TotalTokens:      150,
 				PromptTokensDetails: model.PromptTokensDetails{
-					CachedTokens: 64,
+					CachedTokens:        64,
+					CacheCreationTokens: 10,
+					CacheReadTokens:     54,
 				},
 			},
 		},
@@ -2870,7 +2872,9 @@ func TestReplyAccumulator_AggregatesUsageAcrossResponses(
 				CompletionTokens: 30,
 				TotalTokens:      230,
 				PromptTokensDetails: model.PromptTokensDetails{
-					CachedTokens: 128,
+					CachedTokens:        128,
+					CacheCreationTokens: 20,
+					CacheReadTokens:     108,
 				},
 			},
 		},
@@ -2885,8 +2889,12 @@ func TestReplyAccumulator_AggregatesUsageAcrossResponses(
 	require.Equal(t, 200, acc.Usage.LastPromptTokens)
 	require.NotNil(t, acc.Usage.PromptDetails)
 	require.Equal(t, 192, acc.Usage.PromptDetails.CachedTokens)
+	require.Equal(t, 30, acc.Usage.PromptDetails.CacheCreationTokens)
+	require.Equal(t, 162, acc.Usage.PromptDetails.CacheReadTokens)
 	require.NotNil(t, acc.Usage.LastDetails)
 	require.Equal(t, 128, acc.Usage.LastDetails.CachedTokens)
+	require.Equal(t, 20, acc.Usage.LastDetails.CacheCreationTokens)
+	require.Equal(t, 108, acc.Usage.LastDetails.CacheReadTokens)
 }
 
 func TestReplyAccumulator_IgnoresUsageWithoutTokenCounts(

--- a/openclaw/internal/gateway/stream.go
+++ b/openclaw/internal/gateway/stream.go
@@ -686,6 +686,7 @@ func (s *Server) streamLocked(
 	if reply == "" {
 		reply = emptyReplyFallbackText
 	}
+	recordPromptCacheUsage(trace, run.sessionID, requestID, result.Usage)
 	if !sendStreamEvent(ctx, out, gwproto.StreamEvent{
 		Type:      gwproto.StreamEventTypeMessageCompleted,
 		SessionID: run.sessionID,


### PR DESCRIPTION
## Summary
- preserve prompt cache token details in OpenClaw gateway usage payloads
- aggregate prompt cache details across multi-call runs while keeping last-call details
- add opt-in debug trace events summarizing cached/uncached prompt tokens and hit ratio

## Tests
- go test ./gwproto ./internal/gateway -count=1
- go test ./... -count=1