### PR TITLE
session/mysql: remove id from all ORDER BY, cursor, and sort logic

### DIFF
--- a/session/mysql/init.go
+++ b/session/mysql/init.go
@@ -38,7 +38,7 @@ const (
 
 	sqlCreateSessionEventsTable = `
 		CREATE TABLE IF NOT EXISTS {{TABLE_NAME}} (
-			id BIGINT AUTO_INCREMENT PRIMARY KEY,
+			id BIGINT AUTO_INCREMENT PRIMARY KEY, -- row identity only; not used for ordering or cursor logic
 			app_name VARCHAR(255) NOT NULL,
 			user_id VARCHAR(255) NOT NULL,
 			session_id VARCHAR(255) NOT NULL,

--- a/session/mysql/service_edge_test.go
+++ b/session/mysql/service_edge_test.go
@@ -291,10 +291,10 @@ func TestGetEventsList(t *testing.T) {
 		}
 		createdAts := []time.Time{time.Now().Add(-time.Hour)}
 
-		rows := sqlmock.NewRows([]string{"id", "app_name", "user_id", "session_id", "event", "created_at"}).
-			AddRow(int64(1), "app1", "user1", "sess1", []byte("invalid-json"), time.Now())
+		rows := sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}).
+			AddRow("app1", "user1", "sess1", []byte("invalid-json"), time.Now())
 
-		mock.ExpectQuery("SELECT id, app_name, user_id, session_id, event, created_at FROM").
+		mock.ExpectQuery("SELECT app_name, user_id, session_id, event, created_at FROM").
 			WithArgs("app1", "user1", "sess1", "user1").
 			WillReturnRows(rows)
 
@@ -352,12 +352,12 @@ func TestGetEventsList(t *testing.T) {
 		evt3Bytes, _ := json.Marshal(evt3)
 		now := time.Now()
 
-		rows := sqlmock.NewRows([]string{"id", "app_name", "user_id", "session_id", "event", "created_at"}).
-			AddRow(int64(1), keys[0].AppName, keys[0].UserID, keys[0].SessionID, evt1Bytes, now).
-			AddRow(int64(2), keys[0].AppName, keys[0].UserID, keys[0].SessionID, evt2Bytes, now).
-			AddRow(int64(3), keys[0].AppName, keys[0].UserID, keys[0].SessionID, evt3Bytes, now)
+		rows := sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}).
+			AddRow(keys[0].AppName, keys[0].UserID, keys[0].SessionID, evt1Bytes, now).
+			AddRow(keys[0].AppName, keys[0].UserID, keys[0].SessionID, evt2Bytes, now).
+			AddRow(keys[0].AppName, keys[0].UserID, keys[0].SessionID, evt3Bytes, now)
 
-		mock.ExpectQuery("SELECT id, app_name, user_id, session_id, event, created_at FROM").
+		mock.ExpectQuery("SELECT app_name, user_id, session_id, event, created_at FROM").
 			WithArgs(keys[0].AppName, keys[0].UserID, keys[0].SessionID, keys[0].UserID).
 			WillReturnRows(rows)
 
@@ -396,12 +396,12 @@ func TestGetEventsList(t *testing.T) {
 		evt3Bytes, _ := json.Marshal(evt3)
 		now := time.Now()
 
-		rows := sqlmock.NewRows([]string{"id", "app_name", "user_id", "session_id", "event", "created_at"}).
-			AddRow(int64(1), "app1", "user1", "sess1", evt1Bytes, now).
-			AddRow(int64(2), "app1", "user1", "sess1", evt2Bytes, now).
-			AddRow(int64(3), "app1", "user1", "sess1", evt3Bytes, now)
+		rows := sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}).
+			AddRow("app1", "user1", "sess1", evt1Bytes, now).
+			AddRow("app1", "user1", "sess1", evt2Bytes, now).
+			AddRow("app1", "user1", "sess1", evt3Bytes, now)
 
-		mock.ExpectQuery("SELECT id, app_name, user_id, session_id, event, created_at FROM").
+		mock.ExpectQuery("SELECT app_name, user_id, session_id, event, created_at FROM").
 			WithArgs("app1", "user1", "sess1", "user1").
 			WillReturnRows(rows)
 
@@ -441,12 +441,12 @@ func TestGetEventsList(t *testing.T) {
 		evt3Bytes, _ := json.Marshal(evt3)
 		now := time.Now()
 		// DB returns newest-first; in-memory sort must produce oldest-first.
-		rows := sqlmock.NewRows([]string{"id", "app_name", "user_id", "session_id", "event", "created_at"}).
-			AddRow(int64(3), "app1", "user1", "sess1", evt3Bytes, now).
-			AddRow(int64(2), "app1", "user1", "sess1", evt2Bytes, now.Add(-time.Minute)).
-			AddRow(int64(1), "app1", "user1", "sess1", evt1Bytes, now.Add(-2*time.Minute))
+		rows := sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}).
+			AddRow("app1", "user1", "sess1", evt3Bytes, now).
+			AddRow("app1", "user1", "sess1", evt2Bytes, now.Add(-time.Minute)).
+			AddRow("app1", "user1", "sess1", evt1Bytes, now.Add(-2*time.Minute))
 
-		mock.ExpectQuery("SELECT id, app_name, user_id, session_id, event, created_at FROM").
+		mock.ExpectQuery("SELECT app_name, user_id, session_id, event, created_at FROM").
 			WithArgs("app1", "user1", "sess1", "user1").
 			WillReturnRows(rows)
 
@@ -700,12 +700,12 @@ func TestGetEventsList(t *testing.T) {
 		evt3Bytes, _ := json.Marshal(evt3)
 		now := time.Now()
 
-		rows := sqlmock.NewRows([]string{"id", "app_name", "user_id", "session_id", "event", "created_at"}).
-			AddRow(int64(1), "app1", "user1", "sess1", evt1Bytes, now).
-			AddRow(int64(2), "app1", "user1", "sess1", evt2Bytes, now).
-			AddRow(int64(3), "app1", "user1", "sess1", evt3Bytes, now)
+		rows := sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}).
+			AddRow("app1", "user1", "sess1", evt1Bytes, now).
+			AddRow("app1", "user1", "sess1", evt2Bytes, now).
+			AddRow("app1", "user1", "sess1", evt3Bytes, now)
 
-		mock.ExpectQuery("SELECT id, app_name, user_id, session_id, event, created_at FROM").
+		mock.ExpectQuery("SELECT app_name, user_id, session_id, event, created_at FROM").
 			WithArgs("app1", "user1", "sess1", "user1").
 			WillReturnRows(rows)
 
@@ -733,7 +733,7 @@ func TestGetEventsList(t *testing.T) {
 		rows := sqlmock.NewRows([]string{"app_name", "user_id"}).
 			AddRow("app1", "user1")
 
-		mock.ExpectQuery("SELECT id, app_name, user_id, session_id, event, created_at FROM").
+		mock.ExpectQuery("SELECT app_name, user_id, session_id, event, created_at FROM").
 			WithArgs("app1", "user1", "sess1", "user1").
 			WillReturnRows(rows)
 
@@ -808,10 +808,10 @@ func TestGetSessionEvents_DisabledLimitUsesLegacyList(t *testing.T) {
 	})
 	evtBytes, _ := json.Marshal(evt)
 
-	mock.ExpectQuery("SELECT id, app_name, user_id, session_id, event, created_at FROM").
+	mock.ExpectQuery("SELECT app_name, user_id, session_id, event, created_at FROM").
 		WithArgs(key.AppName, key.UserID, key.SessionID, key.UserID).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "app_name", "user_id", "session_id", "event", "created_at"}).
-			AddRow(int64(1), key.AppName, key.UserID, key.SessionID, evtBytes, createdAt.Add(time.Minute)))
+		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}).
+			AddRow(key.AppName, key.UserID, key.SessionID, evtBytes, createdAt.Add(time.Minute)))
 
 	result, err := s.getSessionEvents(context.Background(), key, createdAt, 0, time.Time{}, nil, time.Time{})
 	require.NoError(t, err)

--- a/session/mysql/service_edge_test.go
+++ b/session/mysql/service_edge_test.go
@@ -976,7 +976,7 @@ func TestLimitedEventHelpers_ErrorsAndBoundaries(t *testing.T) {
 			{id: 9, createdAt: now.Add(-time.Minute)},
 			{id: 11, createdAt: now.Add(time.Minute)},
 		})
-		assert.Equal(t, int64(9), oldest.id)
+		assert.Equal(t, now.Add(-time.Minute), oldest.createdAt)
 	})
 
 	t.Run("TimestampFilterAndLoadedAnchor", func(t *testing.T) {

--- a/session/mysql/service_edge_test.go
+++ b/session/mysql/service_edge_test.go
@@ -415,7 +415,7 @@ func TestGetEventsList(t *testing.T) {
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 
-	t.Run("SortsUnorderedRowsByIDWhenCreatedAtMatches", func(t *testing.T) {
+	t.Run("SortsUnorderedRowsByCreatedAt", func(t *testing.T) {
 		db, mock, err := sqlmock.New()
 		require.NoError(t, err)
 		defer db.Close()
@@ -440,11 +440,11 @@ func TestGetEventsList(t *testing.T) {
 		evt2Bytes, _ := json.Marshal(evt2)
 		evt3Bytes, _ := json.Marshal(evt3)
 		now := time.Now()
-
+		// DB returns newest-first; in-memory sort must produce oldest-first.
 		rows := sqlmock.NewRows([]string{"id", "app_name", "user_id", "session_id", "event", "created_at"}).
 			AddRow(int64(3), "app1", "user1", "sess1", evt3Bytes, now).
-			AddRow(int64(2), "app1", "user1", "sess1", evt2Bytes, now).
-			AddRow(int64(1), "app1", "user1", "sess1", evt1Bytes, now)
+			AddRow(int64(2), "app1", "user1", "sess1", evt2Bytes, now.Add(-time.Minute)).
+			AddRow(int64(1), "app1", "user1", "sess1", evt1Bytes, now.Add(-2*time.Minute))
 
 		mock.ExpectQuery("SELECT id, app_name, user_id, session_id, event, created_at FROM").
 			WithArgs("app1", "user1", "sess1", "user1").
@@ -512,7 +512,7 @@ func TestGetEventsList(t *testing.T) {
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 
-	t.Run("WithEventPageSortsSameCreatedAtByID", func(t *testing.T) {
+	t.Run("WithEventPageSortsByCreatedAt", func(t *testing.T) {
 		db, mock, err := sqlmock.New()
 		require.NoError(t, err)
 		defer db.Close()
@@ -537,11 +537,11 @@ func TestGetEventsList(t *testing.T) {
 		evt2Bytes, _ := json.Marshal(evt2)
 		evt3Bytes, _ := json.Marshal(evt3)
 		now := time.Now()
-
+		// Phase-1 returns newest-first (DESC). Phase-2 sort must produce oldest-first (ASC).
 		idRows := sqlmock.NewRows([]string{"id", "created_at"}).
 			AddRow(int64(3), now).
-			AddRow(int64(2), now).
-			AddRow(int64(1), now)
+			AddRow(int64(2), now.Add(-time.Minute)).
+			AddRow(int64(1), now.Add(-2*time.Minute))
 		mock.ExpectQuery("SELECT id, created_at FROM").
 			WithArgs("app1", "user1", "sess1", createdAt, 3, 0).
 			WillReturnRows(idRows)
@@ -969,11 +969,11 @@ func TestLimitedEventHelpers_ErrorsAndBoundaries(t *testing.T) {
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 
-	t.Run("OldestRefPrefersEarlierTimeThenID", func(t *testing.T) {
+	t.Run("OldestRefPrefersEarlierTime", func(t *testing.T) {
 		now := time.Now()
 		oldest := oldestEventRef([]eventRef{
 			{id: 10, createdAt: now},
-			{id: 9, createdAt: now},
+			{id: 9, createdAt: now.Add(-time.Minute)},
 			{id: 11, createdAt: now.Add(time.Minute)},
 		})
 		assert.Equal(t, int64(9), oldest.id)

--- a/session/mysql/service_helper.go
+++ b/session/mysql/service_helper.go
@@ -709,16 +709,7 @@ func (s *Service) getEventsList(
 		keyStr := fmt.Sprintf("%s:%s:%s", key.AppName, key.UserID, key.SessionID)
 		items := eventsMap[keyStr]
 		slices.SortFunc(items, func(a, b eventWithOrder) int {
-			if cmp := a.createdAt.Compare(b.createdAt); cmp != 0 {
-				return cmp
-			}
-			if a.id < b.id {
-				return -1
-			}
-			if a.id > b.id {
-				return 1
-			}
-			return 0
+			return a.createdAt.Compare(b.createdAt)
 		})
 		events := make([]event.Event, len(items))
 		for j, item := range items {
@@ -859,7 +850,7 @@ func (s *Service) getRecentEventRefs(
 		WHERE app_name = ? AND user_id = ? AND session_id = ?
 		AND created_at >= ?
 		AND deleted_at IS NULL
-		ORDER BY created_at DESC, id DESC
+		ORDER BY created_at DESC
 		LIMIT ?`,
 		s.tableSessionEvents)
 
@@ -957,16 +948,7 @@ func (s *Service) getEventsByRefs(
 	}
 
 	slices.SortFunc(refs, func(a, b eventRef) int {
-		if cmp := a.createdAt.Compare(b.createdAt); cmp != 0 {
-			return cmp
-		}
-		if a.id < b.id {
-			return -1
-		}
-		if a.id > b.id {
-			return 1
-		}
-		return 0
+		return a.createdAt.Compare(b.createdAt)
 	})
 	events := make([]event.Event, 0, len(refs))
 	for _, ref := range refs {
@@ -1044,10 +1026,10 @@ func (s *Service) getPreviousEventRefs(
 		s.tableSessionEvents)
 	args := []any{key.AppName, key.UserID, key.SessionID, sessionCreatedAt}
 	if before != nil {
-		query += ` AND (created_at < ? OR (created_at = ? AND id < ?))`
-		args = append(args, before.createdAt, before.createdAt, before.id)
+		query += ` AND created_at < ?`
+		args = append(args, before.createdAt)
 	}
-	query += ` ORDER BY created_at DESC, id DESC LIMIT ?`
+	query += ` ORDER BY created_at DESC LIMIT ?`
 	args = append(args, userAnchorSearchBatchSize)
 
 	refs := make([]eventRef, 0, userAnchorSearchBatchSize)
@@ -1081,10 +1063,10 @@ func (s *Service) getEventRefsWithTimestamp(
 	)
 	args := []any{key.AppName, key.UserID, key.SessionID, afterTime}
 	if before != nil {
-		query += ` AND (created_at < ? OR (created_at = ? AND id < ?))`
-		args = append(args, before.createdAt, before.createdAt, before.id)
+		query += ` AND created_at < ?`
+		args = append(args, before.createdAt)
 	}
-	query += ` ORDER BY created_at DESC, id DESC LIMIT ?`
+	query += ` ORDER BY created_at DESC LIMIT ?`
 	args = append(args, limit)
 
 	refs := make([]eventRef, 0, limit)
@@ -1129,8 +1111,7 @@ func filterRefsByEventTimestamp(refs []eventRef, afterTime time.Time) []eventRef
 func oldestEventRef(refs []eventRef) eventRef {
 	oldest := refs[0]
 	for _, ref := range refs[1:] {
-		if ref.createdAt.Before(oldest.createdAt) ||
-			(ref.createdAt.Equal(oldest.createdAt) && ref.id < oldest.id) {
+		if ref.createdAt.Before(oldest.createdAt) {
 			oldest = ref
 		}
 	}
@@ -1194,7 +1175,7 @@ func (s *Service) getPagedEvents(
 		WHERE app_name = ? AND user_id = ? AND session_id = ?
 		AND created_at >= ?
 		AND deleted_at IS NULL
-		ORDER BY created_at DESC, id DESC
+		ORDER BY created_at DESC
 		LIMIT ? OFFSET ?`,
 		s.tableSessionEvents)
 

--- a/session/mysql/service_helper.go
+++ b/session/mysql/service_helper.go
@@ -656,7 +656,7 @@ func (s *Service) getEventsList(
 
 	// TDSQL proxy cannot extract shardkey from tuple comparison;
 	// add explicit user_id for shard routing. Harmless on MySQL.
-	query := fmt.Sprintf(`SELECT id, app_name, user_id, session_id, event, created_at FROM %s
+	query := fmt.Sprintf(`SELECT app_name, user_id, session_id, event, created_at FROM %s
 		WHERE (app_name, user_id, session_id) IN (%s)
 		AND user_id = ?
 		AND deleted_at IS NULL`,
@@ -672,16 +672,14 @@ func (s *Service) getEventsList(
 	type eventWithOrder struct {
 		evt       event.Event
 		createdAt time.Time
-		id        int64
 	}
 	eventsMap := make(map[string][]eventWithOrder)
 
 	err := s.mysqlClient.Query(ctx, func(rows *sql.Rows) error {
-		var rowID int64
 		var appName, userID, sessionID string
 		var eventBytes []byte
 		var eventCreatedAt time.Time
-		if err := rows.Scan(&rowID, &appName, &userID, &sessionID, &eventBytes, &eventCreatedAt); err != nil {
+		if err := rows.Scan(&appName, &userID, &sessionID, &eventBytes, &eventCreatedAt); err != nil {
 			return err
 		}
 		keyStr := fmt.Sprintf("%s:%s:%s", appName, userID, sessionID)
@@ -696,7 +694,7 @@ func (s *Service) getEventsList(
 		if err := json.Unmarshal(eventBytes, &evt); err != nil {
 			return fmt.Errorf("unmarshal event failed: %w", err)
 		}
-		eventsMap[keyStr] = append(eventsMap[keyStr], eventWithOrder{evt: evt, createdAt: eventCreatedAt, id: rowID})
+		eventsMap[keyStr] = append(eventsMap[keyStr], eventWithOrder{evt: evt, createdAt: eventCreatedAt})
 		return nil
 	}, query, args...)
 

--- a/session/mysql/service_helper.go
+++ b/session/mysql/service_helper.go
@@ -1026,6 +1026,9 @@ func (s *Service) getPreviousEventRefs(
 		s.tableSessionEvents)
 	args := []any{key.AppName, key.UserID, key.SessionID, sessionCreatedAt}
 	if before != nil {
+		// Keyset cursor: rows sharing the exact same microsecond created_at as
+		// the cursor boundary may be skipped. TIMESTAMP(6) makes this rare in
+		// practice and we accept the tradeoff to avoid filesort on the index.
 		query += ` AND created_at < ?`
 		args = append(args, before.createdAt)
 	}
@@ -1063,6 +1066,9 @@ func (s *Service) getEventRefsWithTimestamp(
 	)
 	args := []any{key.AppName, key.UserID, key.SessionID, afterTime}
 	if before != nil {
+		// Keyset cursor: rows sharing the exact same microsecond created_at as
+		// the cursor boundary may be skipped. TIMESTAMP(6) makes this rare in
+		// practice and we accept the tradeoff to avoid filesort on the index.
 		query += ` AND created_at < ?`
 		args = append(args, before.createdAt)
 	}

--- a/session/mysql/service_helper_test.go
+++ b/session/mysql/service_helper_test.go
@@ -902,8 +902,8 @@ func TestListSessions_Success(t *testing.T) {
 			AddRow("session-1", stateBytes, time.Now(), time.Now()))
 
 	// Mock: Batch load events (empty)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, app_name, user_id, session_id, event, created_at FROM")).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "app_name", "user_id", "session_id", "event", "created_at"}))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, event, created_at FROM")).
+		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}))
 
 	// Mock: Batch load summaries (empty)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, filter_key, summary, updated_at FROM session_summaries")).
@@ -955,8 +955,8 @@ func TestListSessions_WithTrackEvents(t *testing.T) {
 			AddRow("session-1", stateBytes, time.Now(), time.Now()))
 
 	// Mock: Batch load events (empty).
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, app_name, user_id, session_id, event, created_at FROM")).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "app_name", "user_id", "session_id", "event", "created_at"}))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, event, created_at FROM")).
+		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}))
 
 	// Mock: Batch load summaries (empty).
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, filter_key, summary, updated_at FROM session_summaries")).
@@ -1070,8 +1070,8 @@ func TestListSessions_WithMultipleSessions(t *testing.T) {
 			AddRow("session-2", state2Bytes, time.Now(), time.Now()))
 
 	// Mock: Batch load events
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, app_name, user_id, session_id, event, created_at FROM")).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "app_name", "user_id", "session_id", "event", "created_at"}))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, event, created_at FROM")).
+		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}))
 
 	// Mock: Batch load summaries
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, filter_key, summary, updated_at FROM session_summaries")).
@@ -1114,7 +1114,7 @@ func TestListSessions_WithListSessionPage(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"session_id", "state", "created_at", "updated_at"}).
 			AddRow("session-2", stateBytes, time.Now(), time.Now()))
 
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, app_name, user_id, session_id, event, created_at FROM")).
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, event, created_at FROM")).
 		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, filter_key, summary, updated_at FROM session_summaries")).
 		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "filter_key", "summary", "updated_at"}))

--- a/session/mysql/service_helper_test.go
+++ b/session/mysql/service_helper_test.go
@@ -501,8 +501,6 @@ func TestGetSession_SummaryAwareRestoreBoundsAnchorSearch(t *testing.T) {
 		key,
 		sessState.CreatedAt,
 		assistantCreatedAt,
-		assistantCreatedAt,
-		int64(2),
 	)
 
 	sess, err := s.GetSession(ctx, key)

--- a/session/mysql/service_test.go
+++ b/session/mysql/service_test.go
@@ -221,7 +221,7 @@ func expectPreviousEventRefs(
 ) *sqlmock.ExpectedQuery {
 	args := []driver.Value{key.AppName, key.UserID, key.SessionID, sessionCreatedAt}
 	if before != nil {
-		args = append(args, before.createdAt, before.createdAt, before.id)
+		args = append(args, before.createdAt)
 	}
 	args = append(args, userAnchorSearchBatchSize)
 	rows := sqlmock.NewRows([]string{"id", "created_at"})

--- a/session/mysql/service_test.go
+++ b/session/mysql/service_test.go
@@ -175,11 +175,11 @@ func expectFullSessionEventsList(
 	key session.Key,
 	rows ...limitedEventRow,
 ) *sqlmock.ExpectedQuery {
-	sqlRows := sqlmock.NewRows([]string{"id", "app_name", "user_id", "session_id", "event", "created_at"})
+	sqlRows := sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"})
 	for _, row := range rows {
-		sqlRows.AddRow(row.id, key.AppName, key.UserID, key.SessionID, row.event, row.createdAt)
+		sqlRows.AddRow(key.AppName, key.UserID, key.SessionID, row.event, row.createdAt)
 	}
-	return mock.ExpectQuery(regexp.QuoteMeta("SELECT id, app_name, user_id, session_id, event, created_at FROM")).
+	return mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, event, created_at FROM")).
 		WithArgs(key.AppName, key.UserID, key.SessionID, key.UserID).
 		WillReturnRows(sqlRows)
 }
@@ -2219,9 +2219,9 @@ func TestListSessions_WithEvents(t *testing.T) {
 	eventBytes, _ := json.Marshal(evt)
 
 	// Mock: Batch load events with data
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, app_name, user_id, session_id, event, created_at FROM")).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "app_name", "user_id", "session_id", "event", "created_at"}).
-			AddRow(int64(1), userKey.AppName, userKey.UserID, "session-1", eventBytes, time.Now()))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, event, created_at FROM")).
+		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}).
+			AddRow(userKey.AppName, userKey.UserID, "session-1", eventBytes, time.Now()))
 
 	// Prepare mock summary
 	summary := session.Summary{Summary: "test summary", Topics: []string{}}

--- a/session/mysql/window.go
+++ b/session/mysql/window.go
@@ -28,7 +28,6 @@ var _ session.WindowService = (*Service)(nil)
 const eventWindowBatchSize = 64
 
 type persistedWindowEntry struct {
-	rowID int64
 	entry session.EventWindowEntry
 }
 
@@ -161,7 +160,7 @@ func (s *Service) loadWindowAnchor(
 			return nil
 		},
 		fmt.Sprintf(
-			`SELECT id, event, created_at FROM %s
+			`SELECT event, created_at FROM %s
 WHERE app_name = ? AND user_id = ? AND session_id = ?
 AND created_at >= ?
 AND JSON_UNQUOTE(JSON_EXTRACT(event, '$.id')) = ?
@@ -237,6 +236,9 @@ func (s *Service) queryWindowNeighborBatch(
 	cursorCreatedAt time.Time,
 	before bool,
 ) ([]*persistedWindowEntry, error) {
+	// Keyset cursor: rows sharing the exact same microsecond created_at as the
+	// batch boundary may be skipped. TIMESTAMP(6) makes this rare in practice
+	// and we accept the tradeoff to avoid filesort on the lookup index.
 	comparator := `(created_at > ?)`
 	orderBy := `ORDER BY created_at ASC`
 	if before {
@@ -256,7 +258,7 @@ func (s *Service) queryWindowNeighborBatch(
 			return nil
 		},
 		fmt.Sprintf(
-			`SELECT id, event, created_at FROM %s
+			`SELECT event, created_at FROM %s
 WHERE app_name = ? AND user_id = ? AND session_id = ?
 AND created_at >= ?
 AND deleted_at IS NULL
@@ -282,11 +284,10 @@ LIMIT ?`,
 
 func scanWindowRow(rows *sql.Rows) (*persistedWindowEntry, error) {
 	var (
-		rowID      int64
 		eventBytes []byte
 		createdAt  time.Time
 	)
-	if err := rows.Scan(&rowID, &eventBytes, &createdAt); err != nil {
+	if err := rows.Scan(&eventBytes, &createdAt); err != nil {
 		return nil, fmt.Errorf("scan event window entry: %w", err)
 	}
 	var evt event.Event
@@ -294,7 +295,6 @@ func scanWindowRow(rows *sql.Rows) (*persistedWindowEntry, error) {
 		return nil, fmt.Errorf("unmarshal event window entry: %w", err)
 	}
 	return &persistedWindowEntry{
-		rowID: rowID,
 		entry: session.EventWindowEntry{
 			Event:     evt,
 			CreatedAt: createdAt,

--- a/session/mysql/window.go
+++ b/session/mysql/window.go
@@ -166,7 +166,7 @@ WHERE app_name = ? AND user_id = ? AND session_id = ?
 AND created_at >= ?
 AND JSON_UNQUOTE(JSON_EXTRACT(event, '$.id')) = ?
 AND deleted_at IS NULL
-ORDER BY created_at ASC, id ASC
+ORDER BY created_at ASC
 LIMIT 1`,
 			s.tableSessionEvents,
 		),
@@ -195,7 +195,6 @@ func (s *Service) loadWindowNeighbors(
 		return nil, nil
 	}
 	cursorCreatedAt := anchor.entry.CreatedAt
-	cursorRowID := anchor.rowID
 	out := make([]session.EventWindowEntry, 0, limit)
 	for len(out) < limit {
 		rows, err := s.queryWindowNeighborBatch(
@@ -203,7 +202,6 @@ func (s *Service) loadWindowNeighbors(
 			key,
 			sessionCreatedAt,
 			cursorCreatedAt,
-			cursorRowID,
 			before,
 		)
 		if err != nil {
@@ -214,7 +212,6 @@ func (s *Service) loadWindowNeighbors(
 		}
 		for _, row := range rows {
 			cursorCreatedAt = row.entry.CreatedAt
-			cursorRowID = row.rowID
 			if !sessionwindow.EventAllowed(&row.entry.Event, roleFilter) {
 				continue
 			}
@@ -238,14 +235,13 @@ func (s *Service) queryWindowNeighborBatch(
 	key session.Key,
 	sessionCreatedAt time.Time,
 	cursorCreatedAt time.Time,
-	cursorRowID int64,
 	before bool,
 ) ([]*persistedWindowEntry, error) {
-	comparator := `((created_at > ?) OR (created_at = ? AND id > ?))`
-	orderBy := `ORDER BY created_at ASC, id ASC`
+	comparator := `(created_at > ?)`
+	orderBy := `ORDER BY created_at ASC`
 	if before {
-		comparator = `((created_at < ?) OR (created_at = ? AND id < ?))`
-		orderBy = `ORDER BY created_at DESC, id DESC`
+		comparator = `(created_at < ?)`
+		orderBy = `ORDER BY created_at DESC`
 	}
 
 	rows := make([]*persistedWindowEntry, 0, eventWindowBatchSize)
@@ -276,8 +272,6 @@ LIMIT ?`,
 		key.SessionID,
 		sessionCreatedAt,
 		cursorCreatedAt,
-		cursorCreatedAt,
-		cursorRowID,
 		eventWindowBatchSize,
 	)
 	if err != nil {

--- a/session/mysql/window_test.go
+++ b/session/mysql/window_test.go
@@ -41,12 +41,12 @@ func TestService_GetEventWindow(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"id", "event", "created_at"}).
 			AddRow(int64(3), mysqlWindowEventBytes(t, "u2", model.RoleUser, "three"), base.Add(2*time.Minute)))
 	mock.ExpectQuery("SELECT id, event, created_at FROM session_events").
-		WithArgs(key.AppName, key.UserID, key.SessionID, base, base.Add(2*time.Minute), base.Add(2*time.Minute), int64(3), eventWindowBatchSize).
+		WithArgs(key.AppName, key.UserID, key.SessionID, base, base.Add(2*time.Minute), eventWindowBatchSize).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "event", "created_at"}).
 			AddRow(int64(2), mysqlWindowEventBytes(t, "a1", model.RoleAssistant, "two"), base.Add(time.Minute)).
 			AddRow(int64(1), mysqlWindowEventBytes(t, "u1", model.RoleUser, "one"), base))
 	mock.ExpectQuery("SELECT id, event, created_at FROM session_events").
-		WithArgs(key.AppName, key.UserID, key.SessionID, base, base.Add(2*time.Minute), base.Add(2*time.Minute), int64(3), eventWindowBatchSize).
+		WithArgs(key.AppName, key.UserID, key.SessionID, base, base.Add(2*time.Minute), eventWindowBatchSize).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "event", "created_at"}).
 			AddRow(int64(4), mysqlWindowToolEventBytes(t, "t1", "calc", "four"), base.Add(3*time.Minute)).
 			AddRow(int64(5), mysqlWindowEventBytes(t, "u3", model.RoleUser, "five"), base.Add(4*time.Minute)))
@@ -225,7 +225,7 @@ func TestService_GetEventWindowNeighborQueryError(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"id", "event", "created_at"}).
 			AddRow(int64(1), mysqlWindowEventBytes(t, "anchor", model.RoleUser, "one"), base))
 	mock.ExpectQuery("SELECT id, event, created_at FROM session_events").
-		WithArgs(key.AppName, key.UserID, key.SessionID, base, base, base, int64(1), eventWindowBatchSize).
+		WithArgs(key.AppName, key.UserID, key.SessionID, base, base, eventWindowBatchSize).
 		WillReturnError(errors.New("neighbors failed"))
 
 	_, err = svc.GetEventWindow(context.Background(), session.EventWindowRequest{

--- a/session/mysql/window_test.go
+++ b/session/mysql/window_test.go
@@ -36,20 +36,20 @@ func TestService_GetEventWindow(t *testing.T) {
 	mock.ExpectQuery("SELECT created_at FROM session_states").
 		WithArgs(key.AppName, key.UserID, key.SessionID, sqlmock.AnyArg()).
 		WillReturnRows(sqlmock.NewRows([]string{"created_at"}).AddRow(base))
-	mock.ExpectQuery("SELECT id, event, created_at FROM session_events").
+	mock.ExpectQuery("SELECT event, created_at FROM session_events").
 		WithArgs(key.AppName, key.UserID, key.SessionID, base, "u2").
-		WillReturnRows(sqlmock.NewRows([]string{"id", "event", "created_at"}).
-			AddRow(int64(3), mysqlWindowEventBytes(t, "u2", model.RoleUser, "three"), base.Add(2*time.Minute)))
-	mock.ExpectQuery("SELECT id, event, created_at FROM session_events").
+		WillReturnRows(sqlmock.NewRows([]string{"event", "created_at"}).
+			AddRow(mysqlWindowEventBytes(t, "u2", model.RoleUser, "three"), base.Add(2*time.Minute)))
+	mock.ExpectQuery("SELECT event, created_at FROM session_events").
 		WithArgs(key.AppName, key.UserID, key.SessionID, base, base.Add(2*time.Minute), eventWindowBatchSize).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "event", "created_at"}).
-			AddRow(int64(2), mysqlWindowEventBytes(t, "a1", model.RoleAssistant, "two"), base.Add(time.Minute)).
-			AddRow(int64(1), mysqlWindowEventBytes(t, "u1", model.RoleUser, "one"), base))
-	mock.ExpectQuery("SELECT id, event, created_at FROM session_events").
+		WillReturnRows(sqlmock.NewRows([]string{"event", "created_at"}).
+			AddRow(mysqlWindowEventBytes(t, "a1", model.RoleAssistant, "two"), base.Add(time.Minute)).
+			AddRow(mysqlWindowEventBytes(t, "u1", model.RoleUser, "one"), base))
+	mock.ExpectQuery("SELECT event, created_at FROM session_events").
 		WithArgs(key.AppName, key.UserID, key.SessionID, base, base.Add(2*time.Minute), eventWindowBatchSize).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "event", "created_at"}).
-			AddRow(int64(4), mysqlWindowToolEventBytes(t, "t1", "calc", "four"), base.Add(3*time.Minute)).
-			AddRow(int64(5), mysqlWindowEventBytes(t, "u3", model.RoleUser, "five"), base.Add(4*time.Minute)))
+		WillReturnRows(sqlmock.NewRows([]string{"event", "created_at"}).
+			AddRow(mysqlWindowToolEventBytes(t, "t1", "calc", "four"), base.Add(3*time.Minute)).
+			AddRow(mysqlWindowEventBytes(t, "u3", model.RoleUser, "five"), base.Add(4*time.Minute)))
 
 	got, err := svc.GetEventWindow(ctx, session.EventWindowRequest{
 		Key:           key,
@@ -75,9 +75,9 @@ func TestService_GetEventWindowAnchorNotFound(t *testing.T) {
 	mock.ExpectQuery("SELECT created_at FROM session_states").
 		WithArgs(key.AppName, key.UserID, key.SessionID, sqlmock.AnyArg()).
 		WillReturnRows(sqlmock.NewRows([]string{"created_at"}).AddRow(base))
-	mock.ExpectQuery("SELECT id, event, created_at FROM session_events").
+	mock.ExpectQuery("SELECT event, created_at FROM session_events").
 		WithArgs(key.AppName, key.UserID, key.SessionID, base, "missing").
-		WillReturnRows(sqlmock.NewRows([]string{"id", "event", "created_at"}))
+		WillReturnRows(sqlmock.NewRows([]string{"event", "created_at"}))
 
 	_, err = svc.GetEventWindow(context.Background(), session.EventWindowRequest{
 		Key:           key,
@@ -125,10 +125,10 @@ func TestService_GetEventWindowAnchorOnly(t *testing.T) {
 	mock.ExpectQuery("SELECT created_at FROM session_states").
 		WithArgs(key.AppName, key.UserID, key.SessionID, sqlmock.AnyArg()).
 		WillReturnRows(sqlmock.NewRows([]string{"created_at"}).AddRow(base))
-	mock.ExpectQuery("SELECT id, event, created_at FROM session_events").
+	mock.ExpectQuery("SELECT event, created_at FROM session_events").
 		WithArgs(key.AppName, key.UserID, key.SessionID, base, "anchor").
-		WillReturnRows(sqlmock.NewRows([]string{"id", "event", "created_at"}).
-			AddRow(int64(1), mysqlWindowEventBytes(t, "anchor", model.RoleUser, "one"), base))
+		WillReturnRows(sqlmock.NewRows([]string{"event", "created_at"}).
+			AddRow(mysqlWindowEventBytes(t, "anchor", model.RoleUser, "one"), base))
 
 	got, err := svc.GetEventWindow(context.Background(), session.EventWindowRequest{
 		Key:           key,
@@ -193,10 +193,10 @@ func TestService_GetEventWindowAnchorFilteredByRole(t *testing.T) {
 	mock.ExpectQuery("SELECT created_at FROM session_states").
 		WithArgs(key.AppName, key.UserID, key.SessionID, sqlmock.AnyArg()).
 		WillReturnRows(sqlmock.NewRows([]string{"created_at"}).AddRow(base))
-	mock.ExpectQuery("SELECT id, event, created_at FROM session_events").
+	mock.ExpectQuery("SELECT event, created_at FROM session_events").
 		WithArgs(key.AppName, key.UserID, key.SessionID, base, "a1").
-		WillReturnRows(sqlmock.NewRows([]string{"id", "event", "created_at"}).
-			AddRow(int64(1), mysqlWindowEventBytes(t, "a1", model.RoleAssistant, "one"), base))
+		WillReturnRows(sqlmock.NewRows([]string{"event", "created_at"}).
+			AddRow(mysqlWindowEventBytes(t, "a1", model.RoleAssistant, "one"), base))
 
 	_, err = svc.GetEventWindow(context.Background(), session.EventWindowRequest{
 		Key:           key,
@@ -220,11 +220,11 @@ func TestService_GetEventWindowNeighborQueryError(t *testing.T) {
 	mock.ExpectQuery("SELECT created_at FROM session_states").
 		WithArgs(key.AppName, key.UserID, key.SessionID, sqlmock.AnyArg()).
 		WillReturnRows(sqlmock.NewRows([]string{"created_at"}).AddRow(base))
-	mock.ExpectQuery("SELECT id, event, created_at FROM session_events").
+	mock.ExpectQuery("SELECT event, created_at FROM session_events").
 		WithArgs(key.AppName, key.UserID, key.SessionID, base, "anchor").
-		WillReturnRows(sqlmock.NewRows([]string{"id", "event", "created_at"}).
-			AddRow(int64(1), mysqlWindowEventBytes(t, "anchor", model.RoleUser, "one"), base))
-	mock.ExpectQuery("SELECT id, event, created_at FROM session_events").
+		WillReturnRows(sqlmock.NewRows([]string{"event", "created_at"}).
+			AddRow(mysqlWindowEventBytes(t, "anchor", model.RoleUser, "one"), base))
+	mock.ExpectQuery("SELECT event, created_at FROM session_events").
 		WithArgs(key.AppName, key.UserID, key.SessionID, base, base, eventWindowBatchSize).
 		WillReturnError(errors.New("neighbors failed"))
 
@@ -250,10 +250,10 @@ func TestService_GetEventWindowUnmarshalError(t *testing.T) {
 	mock.ExpectQuery("SELECT created_at FROM session_states").
 		WithArgs(key.AppName, key.UserID, key.SessionID, sqlmock.AnyArg()).
 		WillReturnRows(sqlmock.NewRows([]string{"created_at"}).AddRow(base))
-	mock.ExpectQuery("SELECT id, event, created_at FROM session_events").
+	mock.ExpectQuery("SELECT event, created_at FROM session_events").
 		WithArgs(key.AppName, key.UserID, key.SessionID, base, "bad").
-		WillReturnRows(sqlmock.NewRows([]string{"id", "event", "created_at"}).
-			AddRow(int64(1), []byte("{bad-json"), base))
+		WillReturnRows(sqlmock.NewRows([]string{"event", "created_at"}).
+			AddRow([]byte("{bad-json"), base))
 
 	_, err = svc.GetEventWindow(context.Background(), session.EventWindowRequest{
 		Key:           key,


### PR DESCRIPTION
## Problem

Session event queries used `ORDER BY created_at DESC, id DESC`. MySQL cannot satisfy the `id` tiebreaker through the existing lookup index `(app_name, user_id, session_id, created_at)` because `id` is not an explicit index column. This forces filesort on every call, and on long sessions with many events the sort buffer is exhausted:

\`\`\`
Error 1038 (HY001): Out of sort memory, consider increasing server sort buffer size
\`\`\`

Adding `id` explicitly is not feasible — the compound index would exceed InnoDB's 3072-byte key length limit with utf8mb4 columns.

Beyond `ORDER BY`, the cursor pagination in `getPreviousEventRefs`, `getEventRefsWithTimestamp`, and `queryWindowNeighborBatch` also used `(created_at = ? AND id < ?)` tiebreaker conditions, for the same reason (and because TDSQL distributed auto_increment does not guarantee monotonic ordering across proxies, making the id tiebreaker unreliable regardless).

## Fix

Remove `id` from all ORDER BY clauses, cursor conditions, and in-memory sort comparators. The existing lookup index then satisfies every query via Backward index scan with no filesort.

EXPLAIN before (`ORDER BY created_at DESC, id DESC`):
\`\`\`
key: idx_..._lookup   Extra: Using index condition; Using where; Using filesort
\`\`\`

EXPLAIN after (`ORDER BY created_at DESC`):
\`\`\`
key: idx_..._lookup   Extra: Using index condition; Using where; Backward index scan
\`\`\`

`TIMESTAMP(6)` microsecond precision makes same-`created_at` collisions rare enough that removing the tiebreaker has no practical impact on ordering.

## Changes

- Drop `id` from `ORDER BY` in `getRecentEventRefs`, `getPreviousEventRefs`, `getPagedEvents`, `getEventRefsWithTimestamp`, `queryWindowEntry`, `queryWindowNeighborBatch`
- Simplify keyset cursor from `(created_at < ? OR (created_at = ? AND id < ?))` to `created_at < ?` in `getPreviousEventRefs`, `getEventRefsWithTimestamp`, `queryWindowNeighborBatch`
- Simplify in-memory sort tiebreakers in `getEventsList`, `getEventsByRefs`, `oldestEventRef` to compare only by `created_at`
- Remove unused `cursorRowID` parameter and dead `rowID` field from window queries; `id` is no longer fetched by `SELECT`
- Annotate schema: `id` is row identity only, not used for ordering or cursor logic

## Known limitations

**Keyset cursor boundary**: rows that share the exact same microsecond `created_at` value at a batch page boundary may be skipped. `TIMESTAMP(6)` precision makes this extremely rare under normal write rates. Documented in code comments on each affected function.

**`getPagedEvents` OFFSET**: this function uses `LIMIT ? OFFSET ?` for its first page; without a tiebreaker the order among rows with the same `created_at` is non-deterministic. In practice `created_at` values are distinct per session, and fixing this would require a significant refactor of the paging API, so it is left as-is.