### PR TITLE
openclaw: support late request context prompt

### DIFF
--- a/openclaw/gwproto/types.go
+++ b/openclaw/gwproto/types.go
@@ -31,6 +31,9 @@ type MessageRequest struct {
 	ContentParts []ContentPart `json:"content_parts,omitempty"`
 
 	RequestSystemPrompt string `json:"request_system_prompt,omitempty"`
+	// RequestLateContextPrompt is injected near the latest user turn and is
+	// not persisted into the session transcript.
+	RequestLateContextPrompt string `json:"request_late_context_prompt,omitempty"`
 
 	UserID    string `json:"user_id,omitempty"`
 	SessionID string `json:"session_id,omitempty"`

--- a/openclaw/internal/debugrecorder/recorder.go
+++ b/openclaw/internal/debugrecorder/recorder.go
@@ -453,7 +453,8 @@ type RequestSummary struct {
 	MessageID string `json:"message_id,omitempty"`
 	Text      string `json:"text,omitempty"`
 
-	RequestSystemPrompt string `json:"request_system_prompt,omitempty"`
+	RequestSystemPrompt      string `json:"request_system_prompt,omitempty"`
+	RequestLateContextPrompt string `json:"request_late_context_prompt,omitempty"`
 
 	UserID    string `json:"user_id,omitempty"`
 	SessionID string `json:"session_id,omitempty"`
@@ -507,6 +508,9 @@ func SummarizeRequest(
 		Text:      strings.TrimSpace(req.Text),
 		RequestSystemPrompt: strings.TrimSpace(
 			req.RequestSystemPrompt,
+		),
+		RequestLateContextPrompt: strings.TrimSpace(
+			req.RequestLateContextPrompt,
 		),
 		UserID:    strings.TrimSpace(req.UserID),
 		SessionID: strings.TrimSpace(req.SessionID),

--- a/openclaw/internal/debugrecorder/recorder_test.go
+++ b/openclaw/internal/debugrecorder/recorder_test.go
@@ -1113,7 +1113,7 @@ func TestSummarizeRequest_NilTraceDoesNotPanic(t *testing.T) {
 	require.Empty(t, summary.ContentParts[0].File.Data.Ref)
 }
 
-func TestSummarizeRequest_StoresRequestSystemPrompt(t *testing.T) {
+func TestSummarizeRequest_StoresRequestPrompts(t *testing.T) {
 	t.Parallel()
 
 	req := gwproto.MessageRequest{

--- a/openclaw/internal/debugrecorder/recorder_test.go
+++ b/openclaw/internal/debugrecorder/recorder_test.go
@@ -1117,9 +1117,10 @@ func TestSummarizeRequest_StoresRequestSystemPrompt(t *testing.T) {
 	t.Parallel()
 
 	req := gwproto.MessageRequest{
-		Channel:             "gateway",
-		Text:                "hello",
-		RequestSystemPrompt: "Use the active persona for tone.",
+		Channel:                  "gateway",
+		Text:                     "hello",
+		RequestSystemPrompt:      "Use the active persona for tone.",
+		RequestLateContextPrompt: "Current request environment.",
 	}
 
 	summary, err := SummarizeRequest(nil, req)
@@ -1129,6 +1130,11 @@ func TestSummarizeRequest_StoresRequestSystemPrompt(t *testing.T) {
 		t,
 		"Use the active persona for tone.",
 		summary.RequestSystemPrompt,
+	)
+	require.Equal(
+		t,
+		"Current request environment.",
+		summary.RequestLateContextPrompt,
 	)
 }
 

--- a/openclaw/internal/gateway/context_messages.go
+++ b/openclaw/internal/gateway/context_messages.go
@@ -57,6 +57,15 @@ func requestSystemPromptMessage(prompt string) *model.Message {
 	return &msg
 }
 
+func requestLateContextPromptMessage(prompt string) *model.Message {
+	prompt = strings.TrimSpace(prompt)
+	if prompt == "" {
+		return nil
+	}
+	msg := model.NewUserMessage(prompt)
+	return &msg
+}
+
 func (s *Server) personaContextMessage(
 	userID string,
 	sessionID string,

--- a/openclaw/internal/gateway/process.go
+++ b/openclaw/internal/gateway/process.go
@@ -25,14 +25,15 @@ import (
 )
 
 type preparedMessageRun struct {
-	userID              string
-	sessionID           string
-	requestID           string
-	requestSystemPrompt string
-	inbound             InboundMessage
-	userMsg             model.Message
-	streamOptions       *gwproto.MessageStreamOptions
-	extensions          map[string]json.RawMessage
+	userID                   string
+	sessionID                string
+	requestID                string
+	requestSystemPrompt      string
+	requestLateContextPrompt string
+	inbound                  InboundMessage
+	userMsg                  model.Message
+	streamOptions            *gwproto.MessageStreamOptions
+	extensions               map[string]json.RawMessage
 }
 
 // ProcessMessage processes a gateway message request without an HTTP hop.
@@ -271,14 +272,15 @@ func (s *Server) prepareMessageRun(
 	}
 
 	return preparedMessageRun{
-		userID:              userID,
-		sessionID:           sessionID,
-		requestID:           strings.TrimSpace(req.RequestID),
-		requestSystemPrompt: strings.TrimSpace(req.RequestSystemPrompt),
-		inbound:             msg,
-		userMsg:             userMsg,
-		streamOptions:       cloneStreamOptions(opts),
-		extensions:          cloneExtensions(req.Extensions),
+		userID:                   userID,
+		sessionID:                sessionID,
+		requestID:                strings.TrimSpace(req.RequestID),
+		requestSystemPrompt:      strings.TrimSpace(req.RequestSystemPrompt),
+		requestLateContextPrompt: strings.TrimSpace(req.RequestLateContextPrompt),
+		inbound:                  msg,
+		userMsg:                  userMsg,
+		streamOptions:            cloneStreamOptions(opts),
+		extensions:               cloneExtensions(req.Extensions),
 	}, nil, http.StatusOK
 }
 

--- a/openclaw/internal/gateway/server.go
+++ b/openclaw/internal/gateway/server.go
@@ -572,6 +572,7 @@ func (s *Server) resolveRunOptions(
 		run.sessionID,
 		run.requestID,
 		run.requestSystemPrompt,
+		run.requestLateContextPrompt,
 	)
 	if len(extra) == 0 {
 		return ctx, runOpts, nil
@@ -604,6 +605,7 @@ func (s *Server) runOptions(
 	sessionID string,
 	requestID string,
 	requestSystemPrompt string,
+	requestLateContextPrompt string,
 ) []agent.RunOption {
 	runOpts := make([]agent.RunOption, 0, 1)
 	if requestID != "" {
@@ -618,6 +620,14 @@ func (s *Server) runOptions(
 		runOpts = append(
 			runOpts,
 			agent.WithInjectedContextMessages(messages),
+		)
+	}
+	if msg := requestLateContextPromptMessage(
+		requestLateContextPrompt,
+	); msg != nil {
+		runOpts = append(
+			runOpts,
+			agent.WithLateContextMessages([]model.Message{*msg}),
 		)
 	}
 	return runOpts

--- a/openclaw/internal/gateway/server_test.go
+++ b/openclaw/internal/gateway/server_test.go
@@ -1550,6 +1550,46 @@ func TestServer_ProcessMessage_KeepsUserTextSeparateFromRequestSystemPrompt(
 	)
 }
 
+func TestServer_ProcessMessage_IncludesRequestLateContextPrompt(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	runner := &resolvingRunner{}
+	srv, err := New(runner)
+	require.NoError(t, err)
+
+	req := gwproto.MessageRequest{
+		Channel:                  "telegram",
+		From:                     "u1",
+		SessionID:                "telegram:dm:u1",
+		Text:                     "hello",
+		RequestSystemPrompt:      "Stable channel guidance.",
+		RequestLateContextPrompt: "Current request environment.",
+	}
+
+	rsp, status := srv.ProcessMessage(context.Background(), req)
+	require.Equal(t, http.StatusOK, status)
+	require.Equal(t, "ok", rsp.Reply)
+	require.Len(t, runner.opts.InjectedContextMessages, 1)
+	require.Equal(
+		t,
+		"Stable channel guidance.",
+		runner.opts.InjectedContextMessages[0].Content,
+	)
+	require.Len(t, runner.opts.LateContextMessages, 1)
+	require.Equal(
+		t,
+		model.RoleUser,
+		runner.opts.LateContextMessages[0].Role,
+	)
+	require.Equal(
+		t,
+		"Current request environment.",
+		runner.opts.LateContextMessages[0].Content,
+	)
+}
+
 func TestServer_ProcessMessage_RunOptionResolver(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- add `request_late_context_prompt` to openclaw gateway message requests
- map the field to `agent.WithLateContextMessages` so per-request context is injected near the latest user turn instead of the stable prompt prefix
- include the late prompt in debug request summaries for prompt-shape inspection

## Motivation

Channels sometimes need to attach request-scoped environment context such as current request metadata. Putting that changing content into the early injected prompt can reduce provider-side prompt cache reuse because the stable prefix changes every turn.

This keeps the existing `request_system_prompt` behavior unchanged while adding a separate path for temporary dynamic context that should stay close to the current user message and should not be persisted into the session transcript.

## Validation

- `go test ./internal/flow/processor`
- `go test ./...` from `openclaw/`
