### PR TITLE
fix: use UPDATE instead of DELETE for soft delete in rotateMemory

### DIFF
--- a/memory/mysqlvec/service.go
+++ b/memory/mysqlvec/service.go
@@ -393,6 +393,41 @@ func (s *Service) rotateMemory(
 	now time.Time,
 ) error {
 	return s.db.Transaction(ctx, func(tx *sql.Tx) error { // nolint:gosec // table name is validated
+
+		// Pre-check target ID before modifying the source row.
+		// An active (deleted_at IS NULL) target is always a conflict.
+		// A soft-deleted target is OK: revived by ON DUPLICATE KEY UPDATE in
+		// soft-delete mode, or physically removed before INSERT in hard-delete
+		// mode.
+		var targetActive bool
+		checkQ := fmt.Sprintf(
+			"SELECT deleted_at IS NULL FROM %s WHERE memory_id = ? AND app_name = ? AND user_id = ? FOR UPDATE",
+			s.tableName,
+		)
+		err := tx.QueryRowContext(ctx, checkQ, newID, memoryKey.AppName, memoryKey.UserID).Scan(&targetActive)
+		switch {
+		case err == sql.ErrNoRows:
+			// Target does not exist — safe to proceed.
+		case err != nil:
+			return fmt.Errorf("check rotated memory target: %w", err)
+		default:
+			if targetActive {
+				return fmt.Errorf("cannot rotate memory: target id %s already active", newID)
+			}
+			// Target is soft-deleted.  In hard-delete mode, physically remove
+			// it so the subsequent plain INSERT does not hit a duplicate key.
+			if !s.opts.softDelete {
+				sql := fmt.Sprintf(
+					"DELETE FROM %s WHERE memory_id = ? AND app_name = ? AND user_id = ?",
+					s.tableName,
+				)
+				_, err = tx.ExecContext(ctx, sql, newID, memoryKey.AppName, memoryKey.UserID)
+				if err != nil {
+					return fmt.Errorf("delete rotated memory: %w", err)
+				}
+			}
+		}
+
 		var (
 			query string
 			args  []any
@@ -466,20 +501,13 @@ func (s *Service) rotateMemory(
 				s.tableName,
 			)
 		}
-		insertRes, err := tx.ExecContext(ctx, insertQuery,
+		_, err = tx.ExecContext(ctx, insertQuery,
 			newID, memoryKey.AppName, memoryKey.UserID,
 			memoryStr, string(topicsJSON), embeddingArg,
 			ef.kind, ef.eventTime, ef.participants, ef.location,
 			createdAt, now)
 		if err != nil {
 			return fmt.Errorf("insert rotated memory: %w", err)
-		}
-		inserted, err := insertRes.RowsAffected()
-		if err != nil {
-			return fmt.Errorf("insert rotated memory rows affected: %w", err)
-		}
-		if inserted == 0 {
-			return fmt.Errorf("cannot rotate memory: target id %s is already active", newID)
 		}
 
 		return nil

--- a/memory/mysqlvec/service.go
+++ b/memory/mysqlvec/service.go
@@ -209,21 +209,36 @@ func (s *Service) AddMemory(
 		embeddingArg = embeddingBlob
 	}
 
+	// When soft-delete is enabled, only revive soft-deleted rows (deleted_at IS NOT NULL).
+	// For active rows (deleted_at IS NULL), the ON DUPLICATE KEY UPDATE becomes a no-op
+	// so the existing active row is preserved and not overwritten.
+	onDupCols := []string{
+		"memory_content = VALUES(memory_content)",
+		"topics = VALUES(topics)",
+		"embedding = VALUES(embedding)",
+		"memory_kind = VALUES(memory_kind)",
+		"event_time = VALUES(event_time)",
+		"participants = VALUES(participants)",
+		"location = VALUES(location)",
+		"deleted_at = NULL",
+		"updated_at = VALUES(updated_at)",
+	}
+	if s.opts.softDelete {
+		for i, col := range onDupCols {
+			colName := strings.SplitN(col, " = ", 2)[0]
+			valExpr := strings.SplitN(col, " = ", 2)[1]
+			onDupCols[i] = fmt.Sprintf(
+				"%s = IF(deleted_at IS NOT NULL, %s, %s)",
+				colName, valExpr, colName,
+			)
+		}
+	}
 	insertQuery := fmt.Sprintf(
 		"INSERT INTO %s (memory_id, app_name, user_id, memory_content, topics, "+
 			"embedding, memory_kind, event_time, participants, location, "+
 			"created_at, updated_at) "+
 			"VALUES (?, ?, ?, ?, ?, "+embeddingExpr+", ?, ?, ?, ?, ?, ?) "+
-			"ON DUPLICATE KEY UPDATE "+
-			"memory_content = VALUES(memory_content), "+
-			"topics = VALUES(topics), "+
-			"embedding = VALUES(embedding), "+
-			"memory_kind = VALUES(memory_kind), "+
-			"event_time = VALUES(event_time), "+
-			"participants = VALUES(participants), "+
-			"location = VALUES(location), "+
-			"deleted_at = NULL, "+
-			"updated_at = VALUES(updated_at)",
+			"ON DUPLICATE KEY UPDATE "+strings.Join(onDupCols, ", "),
 		s.tableName,
 	)
 
@@ -380,7 +395,7 @@ func (s *Service) updateInPlace(
 	return nil
 }
 
-// rotateMemory replaces a memory entry with a new ID via DELETE + INSERT in a transaction.
+// rotateMemory replaces a memory entry with a new ID via DELETE/UPDATE + INSERT in a transaction.
 func (s *Service) rotateMemory(
 	ctx context.Context,
 	memoryKey memory.Key,
@@ -393,14 +408,26 @@ func (s *Service) rotateMemory(
 	now time.Time,
 ) error {
 	return s.db.Transaction(ctx, func(tx *sql.Tx) error { // nolint:gosec // table name is validated
-		deleteQuery := fmt.Sprintf(
-			"DELETE FROM %s WHERE memory_id = ? AND app_name = ? AND user_id = ?",
-			s.tableName,
+		var (
+			query string
+			args  []any
 		)
 		if s.opts.softDelete {
-			deleteQuery += " AND deleted_at IS NULL"
+			query = fmt.Sprintf(
+				"UPDATE %s SET deleted_at = ? "+
+					"WHERE memory_id = ? AND app_name = ? AND user_id = ? "+
+					"AND deleted_at IS NULL",
+				s.tableName,
+			)
+			args = []any{now, memoryKey.MemoryID, memoryKey.AppName, memoryKey.UserID}
+		} else {
+			query = fmt.Sprintf(
+				"DELETE FROM %s WHERE memory_id = ? AND app_name = ? AND user_id = ?",
+				s.tableName,
+			)
+			args = []any{memoryKey.MemoryID, memoryKey.AppName, memoryKey.UserID}
 		}
-		res, err := tx.ExecContext(ctx, deleteQuery, memoryKey.MemoryID, memoryKey.AppName, memoryKey.UserID)
+		res, err := tx.ExecContext(ctx, query, args...)
 		if err != nil {
 			return fmt.Errorf("delete rotated memory: %w", err)
 		}
@@ -412,19 +439,44 @@ func (s *Service) rotateMemory(
 			return fmt.Errorf("memory with id %s not found", memoryKey.MemoryID)
 		}
 
+		// When soft-delete is enabled, only revive soft-deleted rows.
+		// For active rows, the ON DUPLICATE KEY UPDATE becomes a no-op.
+		onDupCols := []string{
+			"app_name = VALUES(app_name)",
+			"user_id = VALUES(user_id)",
+			"memory_content = VALUES(memory_content)",
+			"topics = VALUES(topics)",
+			"embedding = VALUES(embedding)",
+			"memory_kind = VALUES(memory_kind)",
+			"event_time = VALUES(event_time)",
+			"participants = VALUES(participants)",
+			"location = VALUES(location)",
+			"deleted_at = NULL",
+			"updated_at = VALUES(updated_at)",
+		}
+		if s.opts.softDelete {
+			for i, col := range onDupCols {
+				colName := strings.SplitN(col, " = ", 2)[0]
+				valExpr := strings.SplitN(col, " = ", 2)[1]
+				onDupCols[i] = fmt.Sprintf(
+					"%s = IF(deleted_at IS NOT NULL, %s, %s)",
+					colName, valExpr, colName,
+				)
+			}
+		}
 		insertQuery := fmt.Sprintf(
 			"INSERT INTO %s (memory_id, app_name, user_id, memory_content, topics, "+
 				"embedding, memory_kind, event_time, participants, location, "+
 				"created_at, updated_at) "+
-				"VALUES (?, ?, ?, ?, ?, "+embeddingExpr+", ?, ?, ?, ?, ?, ?)",
+				"VALUES (?, ?, ?, ?, ?, "+embeddingExpr+", ?, ?, ?, ?, ?, ?) "+
+				"ON DUPLICATE KEY UPDATE "+strings.Join(onDupCols, ", "),
 			s.tableName,
 		)
 		_, err = tx.ExecContext(ctx, insertQuery,
 			newID, memoryKey.AppName, memoryKey.UserID,
 			memoryStr, string(topicsJSON), embeddingArg,
 			ef.kind, ef.eventTime, ef.participants, ef.location,
-			createdAt, now,
-		)
+			createdAt, now)
 		if err != nil {
 			return fmt.Errorf("insert rotated memory: %w", err)
 		}

--- a/memory/mysqlvec/service.go
+++ b/memory/mysqlvec/service.go
@@ -209,36 +209,21 @@ func (s *Service) AddMemory(
 		embeddingArg = embeddingBlob
 	}
 
-	// When soft-delete is enabled, only revive soft-deleted rows (deleted_at IS NOT NULL).
-	// For active rows (deleted_at IS NULL), the ON DUPLICATE KEY UPDATE becomes a no-op
-	// so the existing active row is preserved and not overwritten.
-	onDupCols := []string{
-		"memory_content = VALUES(memory_content)",
-		"topics = VALUES(topics)",
-		"embedding = VALUES(embedding)",
-		"memory_kind = VALUES(memory_kind)",
-		"event_time = VALUES(event_time)",
-		"participants = VALUES(participants)",
-		"location = VALUES(location)",
-		"deleted_at = NULL",
-		"updated_at = VALUES(updated_at)",
-	}
-	if s.opts.softDelete {
-		for i, col := range onDupCols {
-			colName := strings.SplitN(col, " = ", 2)[0]
-			valExpr := strings.SplitN(col, " = ", 2)[1]
-			onDupCols[i] = fmt.Sprintf(
-				"%s = IF(deleted_at IS NOT NULL, %s, %s)",
-				colName, valExpr, colName,
-			)
-		}
-	}
 	insertQuery := fmt.Sprintf(
 		"INSERT INTO %s (memory_id, app_name, user_id, memory_content, topics, "+
 			"embedding, memory_kind, event_time, participants, location, "+
 			"created_at, updated_at) "+
 			"VALUES (?, ?, ?, ?, ?, "+embeddingExpr+", ?, ?, ?, ?, ?, ?) "+
-			"ON DUPLICATE KEY UPDATE "+strings.Join(onDupCols, ", "),
+			"ON DUPLICATE KEY UPDATE "+
+			"memory_content = VALUES(memory_content), "+
+			"topics = VALUES(topics), "+
+			"embedding = VALUES(embedding), "+
+			"memory_kind = VALUES(memory_kind), "+
+			"event_time = VALUES(event_time), "+
+			"participants = VALUES(participants), "+
+			"location = VALUES(location), "+
+			"deleted_at = NULL, "+
+			"updated_at = VALUES(updated_at)",
 		s.tableName,
 	)
 
@@ -454,6 +439,7 @@ func (s *Service) rotateMemory(
 			"deleted_at = NULL",
 			"updated_at = VALUES(updated_at)",
 		}
+		var insertQuery string
 		if s.opts.softDelete {
 			for i, col := range onDupCols {
 				colName := strings.SplitN(col, " = ", 2)[0]
@@ -463,16 +449,24 @@ func (s *Service) rotateMemory(
 					colName, valExpr, colName,
 				)
 			}
+			insertQuery = fmt.Sprintf(
+				"INSERT INTO %s (memory_id, app_name, user_id, memory_content, topics, "+
+					"embedding, memory_kind, event_time, participants, location, "+
+					"created_at, updated_at) "+
+					"VALUES (?, ?, ?, ?, ?, "+embeddingExpr+", ?, ?, ?, ?, ?, ?) "+
+					"ON DUPLICATE KEY UPDATE "+strings.Join(onDupCols, ", "),
+				s.tableName,
+			)
+		} else {
+			insertQuery = fmt.Sprintf(
+				"INSERT INTO %s (memory_id, app_name, user_id, memory_content, topics, "+
+					"embedding, memory_kind, event_time, participants, location, "+
+					"created_at, updated_at) "+
+					"VALUES (?, ?, ?, ?, ?, "+embeddingExpr+", ?, ?, ?, ?, ?, ?) ",
+				s.tableName,
+			)
 		}
-		insertQuery := fmt.Sprintf(
-			"INSERT INTO %s (memory_id, app_name, user_id, memory_content, topics, "+
-				"embedding, memory_kind, event_time, participants, location, "+
-				"created_at, updated_at) "+
-				"VALUES (?, ?, ?, ?, ?, "+embeddingExpr+", ?, ?, ?, ?, ?, ?) "+
-				"ON DUPLICATE KEY UPDATE "+strings.Join(onDupCols, ", "),
-			s.tableName,
-		)
-		_, err = tx.ExecContext(ctx, insertQuery,
+		insertRes, err := tx.ExecContext(ctx, insertQuery,
 			newID, memoryKey.AppName, memoryKey.UserID,
 			memoryStr, string(topicsJSON), embeddingArg,
 			ef.kind, ef.eventTime, ef.participants, ef.location,
@@ -480,6 +474,14 @@ func (s *Service) rotateMemory(
 		if err != nil {
 			return fmt.Errorf("insert rotated memory: %w", err)
 		}
+		inserted, err := insertRes.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("insert rotated memory rows affected: %w", err)
+		}
+		if inserted == 0 {
+			return fmt.Errorf("cannot rotate memory: target id %s is already active", newID)
+		}
+
 		return nil
 	})
 }

--- a/memory/mysqlvec/service_test.go
+++ b/memory/mysqlvec/service_test.go
@@ -778,8 +778,63 @@ func TestService_UpdateMemory_SoftDelete_RotateMemory_ReviveDeletedRow(t *testin
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 
-	err := svc.UpdateMemory(context.Background(), key, "content B", []string{"topic"})
+	var updateResult memory.UpdateResult
+	err := svc.UpdateMemory(context.Background(), key, "content B", []string{"topic"}, memory.WithUpdateResult(&updateResult))
+	require.NotEqual(t, updateResult.MemoryID, key.MemoryID)
 	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestService_UpdateMemory_SoftDelete_RotateMemory_ActiveRowNotOverwritten verifies
+// that when rotating A → B and B is already an active (non-soft-deleted) row,
+// the ON DUPLICATE KEY UPDATE is a no-op — B is NOT overwritten.
+// This is the complement to ReviveDeletedRow: the IF(deleted_at IS NOT NULL) guard
+// ensures only soft-deleted rows can be revived.
+func TestService_UpdateMemory_SoftDelete_RotateMemory_ActiveRowNotOverwritten(t *testing.T) {
+	db, mock := setupMockDB(t)
+	defer db.Close()
+	svc := setupMockService(t, db, mock, WithSkipDBInit(true), WithSoftDelete(true))
+	defer svc.Close()
+
+	key := memory.Key{AppName: "app", UserID: "u1", MemoryID: "mem-A"}
+	now := time.Now()
+	// Load returns original entry with ID "mem-A".
+	mock.ExpectQuery("SELECT memory_id").
+		WithArgs(key.MemoryID, key.AppName, key.UserID).
+		WillReturnRows(sqlmock.NewRows(memCols).AddRow(
+			key.MemoryID, key.AppName, key.UserID, "content A", `["topic"]`,
+			"fact", nil, nil, nil, now, now,
+		))
+	// Content changes → new ID "mem-B" → rotateMemory:
+	// BEGIN + soft-delete A + INSERT B + COMMIT.
+	// B is already an active row → ON DUPLICATE KEY UPDATE fires but IF guard
+	// makes it a no-op (0 rows affected). A is still soft-deleted.
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE").
+		WithArgs(sqlmock.AnyArg(), key.MemoryID, key.AppName, key.UserID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(`INSERT INTO.*ON DUPLICATE KEY UPDATE.*IF\(deleted_at IS NOT NULL`).
+		WillReturnResult(sqlmock.NewResult(0, 0)) // 0 rows = no-op, active row preserved
+	mock.ExpectCommit()
+
+	var updateResult memory.UpdateResult
+	err := svc.UpdateMemory(context.Background(), key, "content B", []string{"topic"}, memory.WithUpdateResult(&updateResult))
+	require.NotEqual(t, updateResult.MemoryID, key.MemoryID)
+	require.NoError(t, err)
+
+	// Verify B's content is unchanged by reading it back.
+	// The IF guard should have prevented the overwrite.
+	bKey := memory.UserKey{AppName: "app", UserID: "u1"}
+	mock.ExpectQuery("SELECT memory_id.*FROM").
+		WithArgs(bKey.AppName, bKey.UserID).
+		WillReturnRows(sqlmock.NewRows(memCols).AddRow(
+			"mem-B", "app", "u1", "content B_active", `["b_topic"]`,
+			"fact", nil, nil, nil, now, now,
+		))
+	entries, err := svc.ReadMemories(context.Background(), bKey, 10)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.Equal(t, "content B_active", entries[0].Memory.Memory, "active row should not be overwritten")
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/memory/mysqlvec/service_test.go
+++ b/memory/mysqlvec/service_test.go
@@ -550,26 +550,6 @@ func TestService_AddMemory_MemoryLimit_SoftDelete(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// TestService_AddMemory_SoftDelete_UpsertOnlyRevivesSoftDeleted verifies that
-// when soft-delete is enabled, the ON DUPLICATE KEY UPDATE clause uses
-// IF(deleted_at IS NOT NULL, ...) so that only soft-deleted rows are revived.
-// Active rows with the same key are not overwritten.
-func TestService_AddMemory_SoftDelete_UpsertOnlyRevivesSoftDeleted(t *testing.T) {
-	db, mock := setupMockDB(t)
-	defer db.Close()
-	svc := setupMockService(t, db, mock, WithSkipDBInit(true), WithMemoryLimit(0), WithSoftDelete(true))
-	defer svc.Close()
-
-	// When soft-delete is enabled, the INSERT should use IF(deleted_at IS NOT NULL, ...)
-	// to guard the ON DUPLICATE KEY UPDATE, so active rows are never overwritten.
-	mock.ExpectExec(`IF\(deleted_at IS NOT NULL`).
-		WillReturnResult(sqlmock.NewResult(0, 0)) // 0 rows affected = no-op on active row
-
-	err := svc.AddMemory(context.Background(), memory.UserKey{AppName: "a", UserID: "u"}, "m", nil)
-	require.NoError(t, err)
-	require.NoError(t, mock.ExpectationsWereMet())
-}
-
 func TestService_AddMemory_SQLError(t *testing.T) {
 	db, mock := setupMockDB(t)
 	defer db.Close()
@@ -785,12 +765,12 @@ func TestService_UpdateMemory_SoftDelete_RotateMemory_ReviveDeletedRow(t *testin
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
-// TestService_UpdateMemory_SoftDelete_RotateMemory_ActiveRowNotOverwritten verifies
+// TestService_UpdateMemory_SoftDelete_RotateMemory_ActiveRowConflict verifies
 // that when rotating A → B and B is already an active (non-soft-deleted) row,
-// the ON DUPLICATE KEY UPDATE is a no-op — B is NOT overwritten.
-// This is the complement to ReviveDeletedRow: the IF(deleted_at IS NOT NULL) guard
-// ensures only soft-deleted rows can be revived.
-func TestService_UpdateMemory_SoftDelete_RotateMemory_ActiveRowNotOverwritten(t *testing.T) {
+// the IF guard makes the INSERT a no-op, RowsAffected is 0, and the function
+// returns an error and rolls back — preventing data loss where A is soft-deleted
+// but B is left unchanged.
+func TestService_UpdateMemory_SoftDelete_RotateMemory_ActiveRowConflict(t *testing.T) {
 	db, mock := setupMockDB(t)
 	defer db.Close()
 	svc := setupMockService(t, db, mock, WithSkipDBInit(true), WithSoftDelete(true))
@@ -806,35 +786,18 @@ func TestService_UpdateMemory_SoftDelete_RotateMemory_ActiveRowNotOverwritten(t 
 			"fact", nil, nil, nil, now, now,
 		))
 	// Content changes → new ID "mem-B" → rotateMemory:
-	// BEGIN + soft-delete A + INSERT B + COMMIT.
-	// B is already an active row → ON DUPLICATE KEY UPDATE fires but IF guard
-	// makes it a no-op (0 rows affected). A is still soft-deleted.
+	// BEGIN + soft-delete A + INSERT B (guarded) → RowsAffected=0 → error → ROLLBACK.
 	mock.ExpectBegin()
 	mock.ExpectExec("UPDATE").
 		WithArgs(sqlmock.AnyArg(), key.MemoryID, key.AppName, key.UserID).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec(`INSERT INTO.*ON DUPLICATE KEY UPDATE.*IF\(deleted_at IS NOT NULL`).
-		WillReturnResult(sqlmock.NewResult(0, 0)) // 0 rows = no-op, active row preserved
-	mock.ExpectCommit()
+		WillReturnResult(sqlmock.NewResult(0, 0)) // 0 rows = active row conflict
+	mock.ExpectRollback()
 
-	var updateResult memory.UpdateResult
-	err := svc.UpdateMemory(context.Background(), key, "content B", []string{"topic"}, memory.WithUpdateResult(&updateResult))
-	require.NotEqual(t, updateResult.MemoryID, key.MemoryID)
-	require.NoError(t, err)
-
-	// Verify B's content is unchanged by reading it back.
-	// The IF guard should have prevented the overwrite.
-	bKey := memory.UserKey{AppName: "app", UserID: "u1"}
-	mock.ExpectQuery("SELECT memory_id.*FROM").
-		WithArgs(bKey.AppName, bKey.UserID).
-		WillReturnRows(sqlmock.NewRows(memCols).AddRow(
-			"mem-B", "app", "u1", "content B_active", `["b_topic"]`,
-			"fact", nil, nil, nil, now, now,
-		))
-	entries, err := svc.ReadMemories(context.Background(), bKey, 10)
-	require.NoError(t, err)
-	require.Len(t, entries, 1)
-	require.Equal(t, "content B_active", entries[0].Memory.Memory, "active row should not be overwritten")
+	err := svc.UpdateMemory(context.Background(), key, "content B", []string{"topic"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already active")
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/memory/mysqlvec/service_test.go
+++ b/memory/mysqlvec/service_test.go
@@ -597,6 +597,10 @@ func TestService_UpdateMemory(t *testing.T) {
 	expectUpdateLoad(mock, key, false)
 	// Content changes → ID changes → rotateMemory.
 	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT deleted_at IS NULL FROM memories").
+		WithArgs(sqlmock.AnyArg(), key.AppName, key.UserID).
+		WillReturnRows(sqlmock.NewRows([]string{"active"}).AddRow(false))
+	mock.ExpectExec("DELETE FROM").WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec("DELETE FROM").WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec("INSERT INTO").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
@@ -621,8 +625,13 @@ func TestService_UpdateMemory_IDChanged_RotateMemory(t *testing.T) {
 			key.MemoryID, key.AppName, key.UserID, "old content", `["old"]`,
 			"fact", nil, nil, nil, now, now,
 		))
-	// Content changed → new ID → rotateMemory: BEGIN + DELETE + INSERT + COMMIT.
+	// Content changed → new ID → rotateMemory: BEGIN + pre-check + DELETE + INSERT + COMMIT.
 	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT deleted_at IS NULL FROM memories").
+		WithArgs(sqlmock.AnyArg(), key.AppName, key.UserID).
+		WillReturnRows(sqlmock.NewRows([]string{"active"}).AddRow(false))
+
+	mock.ExpectExec("DELETE FROM").WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec("DELETE FROM").WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec("INSERT INTO").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
@@ -717,6 +726,9 @@ func TestService_UpdateMemory_SoftDelete(t *testing.T) {
 	key := memory.Key{AppName: "app", UserID: "u1", MemoryID: "mem-1"}
 	expectUpdateLoad(mock, key, true)
 	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT deleted_at IS NULL FROM memories").
+		WithArgs(sqlmock.AnyArg(), key.AppName, key.UserID).
+		WillReturnRows(sqlmock.NewRows([]string{"active"}).AddRow(false))
 	mock.ExpectExec("UPDATE").
 		WithArgs(sqlmock.AnyArg(), key.MemoryID, key.AppName, key.UserID).
 		WillReturnResult(sqlmock.NewResult(0, 1))
@@ -729,10 +741,11 @@ func TestService_UpdateMemory_SoftDelete(t *testing.T) {
 }
 
 // TestService_UpdateMemory_SoftDelete_RotateMemory_ReviveDeletedRow verifies
-// that when soft-delete is enabled, rotateMemory uses INSERT … ON DUPLICATE KEY
-// UPDATE … deleted_at = NULL so that a previously soft-deleted row with the same
-// primary key is revived instead of causing a duplicate-key error.
-// Regression test for the A → B → A memory_id rotation scenario.
+// that when soft-delete is enabled and the target row (B) already exists as a
+// soft-deleted row, rotateMemory revives it via INSERT … ON DUPLICATE KEY UPDATE
+// … deleted_at = NULL instead of causing a duplicate-key error.
+// Regression test for the A → B → A memory_id rotation scenario where B was
+// previously soft-deleted.
 func TestService_UpdateMemory_SoftDelete_RotateMemory_ReviveDeletedRow(t *testing.T) {
 	db, mock := setupMockDB(t)
 	defer db.Close()
@@ -749,8 +762,51 @@ func TestService_UpdateMemory_SoftDelete_RotateMemory_ReviveDeletedRow(t *testin
 			"fact", nil, nil, nil, now, now,
 		))
 	// Content changes → new ID "mem-B" → rotateMemory:
-	// BEGIN + soft-delete A + INSERT B (with ON DUPLICATE KEY) + COMMIT.
+	// BEGIN + pre-check finds B soft-deleted (not active) + soft-delete A +
+	// INSERT B with ON DUPLICATE KEY UPDATE to revive + COMMIT.
 	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT deleted_at IS NULL FROM memories").
+		WithArgs(sqlmock.AnyArg(), key.AppName, key.UserID).
+		WillReturnRows(sqlmock.NewRows([]string{"active"}).AddRow(false))
+	mock.ExpectExec("UPDATE").
+		WithArgs(sqlmock.AnyArg(), key.MemoryID, key.AppName, key.UserID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(`INSERT INTO.*ON DUPLICATE KEY UPDATE.*IF\(deleted_at IS NOT NULL`).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	var updateResult memory.UpdateResult
+	err := svc.UpdateMemory(context.Background(), key, "content B", []string{"topic"}, memory.WithUpdateResult(&updateResult))
+	require.NotEqual(t, updateResult.MemoryID, key.MemoryID)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestService_UpdateMemory_SoftDelete_RotateMemory_TargetNotExist verifies that
+// when soft-delete is enabled and the target row (B) does not exist at all,
+// rotateMemory performs a plain INSERT (no ON DUPLICATE KEY UPDATE needed).
+func TestService_UpdateMemory_SoftDelete_RotateMemory_TargetNotExist(t *testing.T) {
+	db, mock := setupMockDB(t)
+	defer db.Close()
+	svc := setupMockService(t, db, mock, WithSkipDBInit(true), WithSoftDelete(true))
+	defer svc.Close()
+
+	key := memory.Key{AppName: "app", UserID: "u1", MemoryID: "mem-A"}
+	now := time.Now()
+	// Load returns original entry with ID "mem-A".
+	mock.ExpectQuery("SELECT memory_id").
+		WithArgs(key.MemoryID, key.AppName, key.UserID).
+		WillReturnRows(sqlmock.NewRows(memCols).AddRow(
+			key.MemoryID, key.AppName, key.UserID, "content A", `["topic"]`,
+			"fact", nil, nil, nil, now, now,
+		))
+	// Content changes → new ID "mem-B" → rotateMemory:
+	// BEGIN + pre-check finds B does not exist (sql.ErrNoRows) + soft-delete A +
+	// INSERT B + COMMIT.
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT deleted_at IS NULL FROM memories").
+		WithArgs(sqlmock.AnyArg(), key.AppName, key.UserID).
+		WillReturnError(sql.ErrNoRows)
 	mock.ExpectExec("UPDATE").
 		WithArgs(sqlmock.AnyArg(), key.MemoryID, key.AppName, key.UserID).
 		WillReturnResult(sqlmock.NewResult(0, 1))
@@ -786,13 +842,11 @@ func TestService_UpdateMemory_SoftDelete_RotateMemory_ActiveRowConflict(t *testi
 			"fact", nil, nil, nil, now, now,
 		))
 	// Content changes → new ID "mem-B" → rotateMemory:
-	// BEGIN + soft-delete A + INSERT B (guarded) → RowsAffected=0 → error → ROLLBACK.
+	// BEGIN + pre-check finds target is active → error → ROLLBACK.
 	mock.ExpectBegin()
-	mock.ExpectExec("UPDATE").
-		WithArgs(sqlmock.AnyArg(), key.MemoryID, key.AppName, key.UserID).
-		WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec(`INSERT INTO.*ON DUPLICATE KEY UPDATE.*IF\(deleted_at IS NOT NULL`).
-		WillReturnResult(sqlmock.NewResult(0, 0)) // 0 rows = active row conflict
+	mock.ExpectQuery("SELECT deleted_at IS NULL FROM memories").
+		WithArgs(sqlmock.AnyArg(), key.AppName, key.UserID).
+		WillReturnRows(sqlmock.NewRows([]string{"active"}).AddRow(true))
 	mock.ExpectRollback()
 
 	err := svc.UpdateMemory(context.Background(), key, "content B", []string{"topic"})

--- a/memory/mysqlvec/service_test.go
+++ b/memory/mysqlvec/service_test.go
@@ -550,6 +550,26 @@ func TestService_AddMemory_MemoryLimit_SoftDelete(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestService_AddMemory_SoftDelete_UpsertOnlyRevivesSoftDeleted verifies that
+// when soft-delete is enabled, the ON DUPLICATE KEY UPDATE clause uses
+// IF(deleted_at IS NOT NULL, ...) so that only soft-deleted rows are revived.
+// Active rows with the same key are not overwritten.
+func TestService_AddMemory_SoftDelete_UpsertOnlyRevivesSoftDeleted(t *testing.T) {
+	db, mock := setupMockDB(t)
+	defer db.Close()
+	svc := setupMockService(t, db, mock, WithSkipDBInit(true), WithMemoryLimit(0), WithSoftDelete(true))
+	defer svc.Close()
+
+	// When soft-delete is enabled, the INSERT should use IF(deleted_at IS NOT NULL, ...)
+	// to guard the ON DUPLICATE KEY UPDATE, so active rows are never overwritten.
+	mock.ExpectExec(`IF\(deleted_at IS NOT NULL`).
+		WillReturnResult(sqlmock.NewResult(0, 0)) // 0 rows affected = no-op on active row
+
+	err := svc.AddMemory(context.Background(), memory.UserKey{AppName: "a", UserID: "u"}, "m", nil)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestService_AddMemory_SQLError(t *testing.T) {
 	db, mock := setupMockDB(t)
 	defer db.Close()
@@ -717,12 +737,50 @@ func TestService_UpdateMemory_SoftDelete(t *testing.T) {
 	key := memory.Key{AppName: "app", UserID: "u1", MemoryID: "mem-1"}
 	expectUpdateLoad(mock, key, true)
 	mock.ExpectBegin()
-	mock.ExpectExec("DELETE FROM").WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec("INSERT INTO").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("UPDATE").
+		WithArgs(sqlmock.AnyArg(), key.MemoryID, key.AppName, key.UserID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(`INSERT INTO.*ON DUPLICATE KEY UPDATE.*IF\(deleted_at IS NOT NULL`).
+		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 
 	err := svc.UpdateMemory(context.Background(), key, "updated", []string{"t"})
 	require.NoError(t, err)
+}
+
+// TestService_UpdateMemory_SoftDelete_RotateMemory_ReviveDeletedRow verifies
+// that when soft-delete is enabled, rotateMemory uses INSERT … ON DUPLICATE KEY
+// UPDATE … deleted_at = NULL so that a previously soft-deleted row with the same
+// primary key is revived instead of causing a duplicate-key error.
+// Regression test for the A → B → A memory_id rotation scenario.
+func TestService_UpdateMemory_SoftDelete_RotateMemory_ReviveDeletedRow(t *testing.T) {
+	db, mock := setupMockDB(t)
+	defer db.Close()
+	svc := setupMockService(t, db, mock, WithSkipDBInit(true), WithSoftDelete(true))
+	defer svc.Close()
+
+	key := memory.Key{AppName: "app", UserID: "u1", MemoryID: "mem-A"}
+	now := time.Now()
+	// Load returns original entry with ID "mem-A".
+	mock.ExpectQuery("SELECT memory_id").
+		WithArgs(key.MemoryID, key.AppName, key.UserID).
+		WillReturnRows(sqlmock.NewRows(memCols).AddRow(
+			key.MemoryID, key.AppName, key.UserID, "content A", `["topic"]`,
+			"fact", nil, nil, nil, now, now,
+		))
+	// Content changes → new ID "mem-B" → rotateMemory:
+	// BEGIN + soft-delete A + INSERT B (with ON DUPLICATE KEY) + COMMIT.
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE").
+		WithArgs(sqlmock.AnyArg(), key.MemoryID, key.AppName, key.UserID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(`INSERT INTO.*ON DUPLICATE KEY UPDATE.*IF\(deleted_at IS NOT NULL`).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	err := svc.UpdateMemory(context.Background(), key, "content B", []string{"topic"})
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestService_UpdateMemory_SQLError(t *testing.T) {


### PR DESCRIPTION
The rotateMemory function was incorrectly using DELETE statement when softDelete was enabled, which would permanently remove the record instead of setting deleted_at timestamp.

 This fix changes the behavior to use UPDATE with SET deleted_at = ? to properly implement soft delete, consistent with DeleteMemory and ClearMemories functions.

Also updated the corresponding test to expect UPDATE instead of DELETE.

## What changed

Describe the user-visible behavior, API, documentation, or example changes in
this pull request.

## Why

Explain the problem this solves and any compatibility considerations.

## Testing

List the commands or manual checks you ran. If a check is not applicable, say
why.

## Notes for reviewers

Call out areas that deserve extra attention, such as concurrency, persistence,
protocol compatibility, or public API changes.
