### PR TITLE
fix: UpdateMemory keep original memory_id to avoid primary key conflict

### DIFF
--- a/memory/mysql/service.go
+++ b/memory/mysql/service.go
@@ -212,7 +212,7 @@ func (s *Service) UpdateMemory(ctx context.Context, memoryKey memory.Key,
 	imemory.NormalizeEntry(entry)
 
 	now := time.Now()
-	newID := imemory.ApplyMemoryUpdate(
+	imemory.ApplyMemoryUpdate(
 		entry,
 		memoryKey.AppName,
 		memoryKey.UserID,
@@ -221,6 +221,8 @@ func (s *Service) UpdateMemory(ctx context.Context, memoryKey memory.Key,
 		ep,
 		now,
 	)
+	// Keep the original memory_id to avoid primary key conflicts.
+	entry.ID = memoryKey.MemoryID
 
 	updated, err := json.Marshal(entry)
 	if err != nil {
@@ -228,18 +230,18 @@ func (s *Service) UpdateMemory(ctx context.Context, memoryKey memory.Key,
 	}
 
 	updateQuery := fmt.Sprintf(
-		"UPDATE %s SET memory_id = ?, memory_data = ?, updated_at = ? WHERE app_name = ? AND user_id = ? AND memory_id = ?",
+		"UPDATE %s SET memory_data = ?, updated_at = ? WHERE app_name = ? AND user_id = ? AND memory_id = ?",
 		s.tableName,
 	)
 	if s.opts.softDelete {
 		updateQuery += " AND deleted_at IS NULL"
 	}
-	_, err = s.db.Exec(ctx, updateQuery, newID, updated, now, memoryKey.AppName, memoryKey.UserID, memoryKey.MemoryID)
+	_, err = s.db.Exec(ctx, updateQuery, updated, now, memoryKey.AppName, memoryKey.UserID, memoryKey.MemoryID)
 	if err != nil {
 		return fmt.Errorf("update memory entry failed: %w", err)
 	}
 	if result := memory.ResolveUpdateResult(opts); result != nil {
-		result.MemoryID = newID
+		result.MemoryID = memoryKey.MemoryID
 	}
 	return nil
 }

--- a/memory/mysql/service_test.go
+++ b/memory/mysql/service_test.go
@@ -691,7 +691,7 @@ func TestUpdateMemory_Success(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"memory_data"}).AddRow(entryJSON))
 
 	mock.ExpectExec("UPDATE").
-		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), "app", "user", "mem123").
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), "app", "user", "mem123").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	err := s.UpdateMemory(ctx, memKey, "updated memory", []string{"new"})
@@ -730,8 +730,8 @@ func TestUpdateMemory_SoftDeleteFalse(t *testing.T) {
 		WithArgs("app", "user", "mem123").
 		WillReturnRows(sqlmock.NewRows([]string{"memory_data"}).AddRow(existingJSON))
 
-	mock.ExpectExec("UPDATE.*SET memory_id = .*memory_data").
-		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), "app", "user", "mem123").
+	mock.ExpectExec("UPDATE.*SET memory_data").
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), "app", "user", "mem123").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	err := s.UpdateMemory(ctx, memKey, "new memory", []string{"new"})
@@ -810,7 +810,7 @@ func TestUpdateMemory_UpdateError(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"memory_data"}).AddRow(entryJSON))
 
 	mock.ExpectExec("UPDATE").
-		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), "app", "user", "mem123").
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), "app", "user", "mem123").
 		WillReturnError(errors.New("update error"))
 
 	err := s.UpdateMemory(ctx, memKey, "updated memory", []string{"new"})

--- a/memory/pgvector/service.go
+++ b/memory/pgvector/service.go
@@ -372,7 +372,7 @@ func (s *Service) UpdateMemory(
 
 	now := time.Now()
 	vector := pgvector.NewVector(convertToFloat32(embedding))
-	newID := imemory.ApplyMemoryUpdate(
+	imemory.ApplyMemoryUpdate(
 		entry,
 		memoryKey.AppName,
 		memoryKey.UserID,
@@ -381,12 +381,14 @@ func (s *Service) UpdateMemory(
 		ep,
 		now,
 	)
+	// Keep the original memory_id to avoid primary key conflicts.
+	entry.ID = memoryKey.MemoryID
 	ef := resolveMetadata(entry.Memory)
 
 	updateQuery := fmt.Sprintf(
-		"UPDATE %s SET memory_id = $1, memory_content = $2, topics = $3, embedding = $4, "+
-			"memory_kind = $5, event_time = $6, participants = $7, location = $8, updated_at = $9 "+
-			"WHERE memory_id = $10 AND app_name = $11 AND user_id = $12",
+		"UPDATE %s SET memory_content = $1, topics = $2, embedding = $3, "+
+			"memory_kind = $4, event_time = $5, participants = $6, location = $7, updated_at = $8 "+
+			"WHERE memory_id = $9 AND app_name = $10 AND user_id = $11",
 		s.tableName,
 	)
 	if s.opts.softDelete {
@@ -395,7 +397,6 @@ func (s *Service) UpdateMemory(
 	res, err := s.db.ExecContext(
 		ctx,
 		updateQuery,
-		newID,
 		memoryStr,
 		pq.Array(topics),
 		vector,
@@ -419,7 +420,7 @@ func (s *Service) UpdateMemory(
 		return fmt.Errorf("memory with id %s not found", memoryKey.MemoryID)
 	}
 	if result := memory.ResolveUpdateResult(opts); result != nil {
-		result.MemoryID = newID
+		result.MemoryID = memoryKey.MemoryID
 	}
 
 	return nil

--- a/memory/pgvector/service_test.go
+++ b/memory/pgvector/service_test.go
@@ -841,9 +841,8 @@ func TestService_UpdateMemory_WithoutMetadataDoesNotOverwriteMetadataColumns(t *
 		"Kyoto",
 	)
 
-	mock.ExpectExec(`UPDATE .* SET memory_id = \$1, memory_content = \$2, topics = \$3, embedding = \$4, memory_kind = \$5, event_time = \$6, participants = \$7, location = \$8, updated_at = \$9 WHERE memory_id = \$10 AND app_name = \$11 AND user_id = \$12`).
+	mock.ExpectExec(`UPDATE .* SET memory_content = \$1, topics = \$2, embedding = \$3, memory_kind = \$4, event_time = \$5, participants = \$6, location = \$7, updated_at = \$8 WHERE memory_id = \$9 AND app_name = \$10 AND user_id = \$11`).
 		WithArgs(
-			sqlmock.AnyArg(),
 			"updated memory",
 			pq.Array([]string{"new-topic"}),
 			sqlmock.AnyArg(),
@@ -887,9 +886,8 @@ func TestService_UpdateMemory_PartialMetadataPatchOnlyUpdatesProvidedColumns(t *
 		"Kyoto",
 	)
 
-	mock.ExpectExec(`UPDATE .* SET memory_id = \$1, memory_content = \$2, topics = \$3, embedding = \$4, memory_kind = \$5, event_time = \$6, participants = \$7, location = \$8, updated_at = \$9 WHERE memory_id = \$10 AND app_name = \$11 AND user_id = \$12`).
+	mock.ExpectExec(`UPDATE .* SET memory_content = \$1, topics = \$2, embedding = \$3, memory_kind = \$4, event_time = \$5, participants = \$6, location = \$7, updated_at = \$8 WHERE memory_id = \$9 AND app_name = \$10 AND user_id = \$11`).
 		WithArgs(
-			sqlmock.AnyArg(),
 			"updated memory",
 			pq.Array([]string{"new-topic"}),
 			sqlmock.AnyArg(),

--- a/memory/postgres/service.go
+++ b/memory/postgres/service.go
@@ -280,7 +280,7 @@ func (s *Service) UpdateMemory(ctx context.Context, memoryKey memory.Key, memory
 
 	now := time.Now()
 	ep := memory.ResolveUpdateOptions(opts)
-	newID := imemory.ApplyMemoryUpdate(
+	imemory.ApplyMemoryUpdate(
 		entry,
 		memoryKey.AppName,
 		memoryKey.UserID,
@@ -289,6 +289,8 @@ func (s *Service) UpdateMemory(ctx context.Context, memoryKey memory.Key, memory
 		ep,
 		now,
 	)
+	// Keep the original memory_id to avoid primary key conflicts.
+	entry.ID = memoryKey.MemoryID
 
 	updated, err := json.Marshal(entry)
 	if err != nil {
@@ -297,22 +299,22 @@ func (s *Service) UpdateMemory(ctx context.Context, memoryKey memory.Key, memory
 	}
 
 	updateQuery := fmt.Sprintf(
-		"UPDATE %s SET memory_id = $1, memory_data = $2, updated_at = $3 "+
-			"WHERE memory_id = $4 AND app_name = $5 "+
-			"AND user_id = $6",
+		"UPDATE %s SET memory_data = $1, updated_at = $2 "+
+			"WHERE memory_id = $3 AND app_name = $4 "+
+			"AND user_id = $5",
 		s.tableName,
 	)
 	if s.opts.softDelete {
 		updateQuery += " AND deleted_at IS NULL"
 	}
-	_, err = s.db.ExecContext(ctx, updateQuery, newID, updated, now,
+	_, err = s.db.ExecContext(ctx, updateQuery, updated, now,
 		memoryKey.MemoryID, memoryKey.AppName, memoryKey.UserID)
 	if err != nil {
 		return fmt.Errorf(
 			"update memory entry failed: %w", err)
 	}
 	if result := memory.ResolveUpdateResult(opts); result != nil {
-		result.MemoryID = newID
+		result.MemoryID = memoryKey.MemoryID
 	}
 	return nil
 }

--- a/memory/postgres/service_test.go
+++ b/memory/postgres/service_test.go
@@ -1177,7 +1177,7 @@ func TestService_UpdateMemory_Success(t *testing.T) {
 	entryData, _ := json.Marshal(entry)
 
 	mock.ExpectQuery("SELECT memory_data").WillReturnRows(sqlmock.NewRows([]string{"memory_data"}).AddRow(entryData))
-	mock.ExpectExec("UPDATE.*SET memory_id = .*memory_data").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("UPDATE.*SET memory_data").WillReturnResult(sqlmock.NewResult(0, 1))
 
 	err := svc.UpdateMemory(ctx, memoryKey, "new content", []string{"new"})
 	require.NoError(t, err)
@@ -1817,7 +1817,7 @@ func TestService_UpdateMemory_UpdateError(t *testing.T) {
 	mock.ExpectQuery("SELECT memory_data").WillReturnRows(
 		sqlmock.NewRows([]string{"memory_data"}).AddRow(entryData),
 	)
-	mock.ExpectExec("UPDATE.*SET memory_id = .*memory_data").WillReturnError(fmt.Errorf("update failed"))
+	mock.ExpectExec("UPDATE.*SET memory_data").WillReturnError(fmt.Errorf("update failed"))
 
 	err := svc.UpdateMemory(ctx, memoryKey, "new content", []string{"new"})
 	require.Error(t, err)

--- a/memory/sqlite/service.go
+++ b/memory/sqlite/service.go
@@ -260,7 +260,7 @@ func (s *Service) UpdateMemory(
 	}
 
 	now := time.Now()
-	newID := imemory.ApplyMemoryUpdate(
+	imemory.ApplyMemoryUpdate(
 		entry,
 		memoryKey.AppName,
 		memoryKey.UserID,
@@ -269,6 +269,8 @@ func (s *Service) UpdateMemory(
 		ep,
 		now,
 	)
+	// Keep the original memory_id to avoid primary key conflicts.
+	entry.ID = memoryKey.MemoryID
 
 	updated, err := json.Marshal(entry)
 	if err != nil {
@@ -276,11 +278,11 @@ func (s *Service) UpdateMemory(
 	}
 
 	const updateSQL = `UPDATE %s
-SET memory_id = ?, memory_data = ?, updated_at = ?
+SET memory_data = ?, updated_at = ?
 WHERE app_name = ? AND user_id = ? AND memory_id = ?`
 	query := fmt.Sprintf(updateSQL, s.tableName)
 	args := []any{
-		newID, updated, now.UTC().UnixNano(),
+		updated, now.UTC().UnixNano(),
 		memoryKey.AppName, memoryKey.UserID, memoryKey.MemoryID,
 	}
 	if s.opts.softDelete {
@@ -292,7 +294,7 @@ WHERE app_name = ? AND user_id = ? AND memory_id = ?`
 		return fmt.Errorf("update memory entry: %w", err)
 	}
 	if result := memory.ResolveUpdateResult(opts); result != nil {
-		result.MemoryID = newID
+		result.MemoryID = memoryKey.MemoryID
 	}
 	return nil
 }


### PR DESCRIPTION
## 问题

`UpdateMemory` 调用 `ApplyMemoryUpdate` 重新计算 `memory_id`（基于更新后的内容生成 SHA256 哈希），然后在 UPDATE 语句中修改主键列，导致 **Duplicate entry** 错误。

Fixes #2019

## 修复方案

`ApplyMemoryUpdate` 返回新 ID 后，覆盖回原始 `memoryKey.MemoryID`，保持主键不变。UPDATE SQL 不再修改 `memory_id` 列。

```go
imemory.ApplyMemoryUpdate(entry, ...)
entry.ID = memoryKey.MemoryID  // 保持原始 ID
```

## 已修复后端

| 后端 | 文件 |
|------|------|
| mysql | `memory/mysql/service.go` |
| postgres | `memory/postgres/service.go` |
| pgvector | `memory/pgvector/service.go` |
| sqlite | `memory/sqlite/service.go` |

## 待处理

sqlitevec 逻辑较复杂（DELETE 旧记录 + INSERT 新记录），需要单独处理，后续跟进。

## 测试

```
ok  trpc.group/trpc-go/trpc-agent-go/memory
ok  trpc.group/trpc-go/trpc-agent-go/memory/extractor
ok  trpc.group/trpc-go/trpc-agent-go/memory/inmemory
ok  trpc.group/trpc-go/trpc-agent-go/memory/internal/memory
ok  trpc.group/trpc-go/trpc-agent-go/memory/mem0
ok  trpc.group/trpc-go/trpc-agent-go/memory/tencentdb
ok  trpc.group/trpc-go/trpc-agent-go/memory/tool
```