### PR TITLE
session/mysql: skip schema DDL for pre-existing tables on init

### DIFF
--- a/session/mysql/init.go
+++ b/session/mysql/init.go
@@ -513,6 +513,22 @@ var tdsqlIndexDefs = []indexDefinition{
 }
 
 // initDB initializes the database schema.
+//
+// DDL is only executed for tables that do NOT already exist: a missing table is
+// created together with all of its indexes (a safe first-time bootstrap). For a
+// table that already exists, initDB never runs DDL against it — altering a live
+// table (e.g. adding an index, which can lock or rebuild it, and may require
+// privileges the runtime account intentionally lacks) is risky and is left to
+// the operator. Index drift on existing tables is surfaced by verifySchema: a
+// missing or incorrect UNIQUE index is fatal (the service refuses to start
+// without the uniqueness constraint), while other index drift is logged as a
+// warning.
+//
+// First-time creation still requires the account to hold CREATE and INDEX
+// privileges. If a freshly created table's index creation fails, the table is
+// left in place and treated as existing on the next start — but its missing
+// UNIQUE index is then caught by verifySchema and fails startup, so a partial
+// bootstrap cannot silently run without uniqueness enforcement.
 func (s *Service) initDB(ctx context.Context) error {
 	log.InfoContext(ctx, "initializing mysql session database schema...")
 
@@ -525,30 +541,69 @@ func (s *Service) initDB(ctx context.Context) error {
 		log.InfoContext(ctx, "TDSQL sharding mode enabled, using TDSQL schema")
 	}
 
-	// Create tables
-	for _, tableDef := range tables {
-		fullTableName := sqldb.BuildTableName(s.opts.tablePrefix, tableDef.name)
-		sql := strings.ReplaceAll(tableDef.template, "{{TABLE_NAME}}", fullTableName)
-
-		if _, err := s.mysqlClient.Exec(ctx, sql); err != nil {
-			return fmt.Errorf("create table %s failed: %w", fullTableName, err)
-		}
-		log.InfofContext(ctx, "created table: %s", fullTableName)
+	// Group index definitions by their table so a freshly created table can be
+	// populated with its indexes in the same bootstrap step.
+	indexesByTable := make(map[string][]indexDefinition, len(tables))
+	for _, indexDef := range indexes {
+		indexesByTable[indexDef.table] = append(indexesByTable[indexDef.table], indexDef)
 	}
 
-	// Create indexes
-	for _, indexDef := range indexes {
-		fullTableName := sqldb.BuildTableName(s.opts.tablePrefix, indexDef.table)
-		indexName := sqldb.BuildIndexName(s.opts.tablePrefix, indexDef.table, indexDef.suffix)
-		sql := indexDef.template
-		sql = strings.ReplaceAll(sql, "{{TABLE_NAME}}", fullTableName)
-		sql = strings.ReplaceAll(sql, "{{INDEX_NAME}}", indexName)
+	// Create each missing table together with its indexes. Pre-existing tables
+	// are left untouched; any schema drift is reported by verifySchema below.
+	for _, tableDef := range tables {
+		fullTableName := sqldb.BuildTableName(s.opts.tablePrefix, tableDef.name)
 
-		// MySQL doesn't have "IF NOT EXISTS" for indexes in older versions
-		// We'll use a different approach: try to create and ignore duplicate key errors
-		if _, err := s.mysqlClient.Exec(ctx, sql); err != nil {
-			// Check if it's a duplicate index name error (error code 1061).
-			// This means the index already exists, which is safe to skip.
+		exists, err := s.tableExists(ctx, fullTableName)
+		if err != nil {
+			return fmt.Errorf("check table %s existence failed: %w", fullTableName, err)
+		}
+		if exists {
+			log.InfofContext(ctx, "table %s already exists, skipping schema DDL; "+
+				"missing indexes (if any) are reported by schema verification and must "+
+				"be applied manually", fullTableName)
+			continue
+		}
+
+		if err := s.createTableWithIndexes(ctx, tableDef, indexesByTable[tableDef.name]); err != nil {
+			return err
+		}
+	}
+
+	// Verify schema (column drift is fatal; index drift is logged as warnings).
+	if err := s.verifySchema(ctx); err != nil {
+		return fmt.Errorf("schema verification failed: %w", err)
+	}
+
+	log.InfoContext(ctx, "mysql session database schema initialized successfully")
+	return nil
+}
+
+// createTableWithIndexes creates a single table and all of its indexes. It is
+// only called for tables that do not yet exist, so executing DDL here is safe.
+func (s *Service) createTableWithIndexes(
+	ctx context.Context,
+	tableDef tableDefinition,
+	indexes []indexDefinition,
+) error {
+	fullTableName := sqldb.BuildTableName(s.opts.tablePrefix, tableDef.name)
+
+	// Create the table. IF NOT EXISTS guards against a concurrent creator.
+	tableSQL := strings.ReplaceAll(tableDef.template, "{{TABLE_NAME}}", fullTableName)
+	if _, err := s.mysqlClient.Exec(ctx, tableSQL); err != nil {
+		return fmt.Errorf("create table %s failed: %w", fullTableName, err)
+	}
+	log.InfofContext(ctx, "created table: %s", fullTableName)
+
+	// Create the table's indexes as part of the same first-time bootstrap.
+	for _, indexDef := range indexes {
+		indexName := sqldb.BuildIndexName(s.opts.tablePrefix, indexDef.table, indexDef.suffix)
+		indexSQL := strings.ReplaceAll(indexDef.template, "{{TABLE_NAME}}", fullTableName)
+		indexSQL = strings.ReplaceAll(indexSQL, "{{INDEX_NAME}}", indexName)
+
+		// MySQL doesn't have "IF NOT EXISTS" for indexes in older versions, so we
+		// try to create and tolerate the "duplicate index name" error (1061) in
+		// case the index already exists (e.g. a concurrent creator won the race).
+		if _, err := s.mysqlClient.Exec(ctx, indexSQL); err != nil {
 			if !isDuplicateIndexNameError(err) {
 				return fmt.Errorf(
 					"create index %s on table %s failed: %w",
@@ -557,19 +612,11 @@ func (s *Service) initDB(ctx context.Context) error {
 					err,
 				)
 			}
-			// Index already exists, log and continue.
 			log.InfofContext(ctx, "index %s already exists on table %s, skipping", indexName, fullTableName)
-		} else {
-			log.InfofContext(ctx, "created index: %s on table %s", indexName, fullTableName)
+			continue
 		}
+		log.InfofContext(ctx, "created index: %s on table %s", indexName, fullTableName)
 	}
-
-	// Verify schema
-	if err := s.verifySchema(ctx); err != nil {
-		return fmt.Errorf("schema verification failed: %w", err)
-	}
-
-	log.InfoContext(ctx, "mysql session database schema initialized successfully")
 	return nil
 }
 
@@ -603,9 +650,11 @@ func (s *Service) verifySchema(ctx context.Context) error {
 			return fmt.Errorf("verify columns for table %s failed: %w", fullTableName, err)
 		}
 
-		// Verify indexes (non-fatal, just log warnings)
+		// Verify indexes. A missing/incorrect UNIQUE index is fatal (uniqueness is
+		// no longer enforced); non-unique index drift is logged as a warning
+		// inside verifyIndexes and does not return an error.
 		if err := s.verifyIndexes(ctx, fullTableName, schema.indexes); err != nil {
-			log.WarnfContext(ctx, "verify indexes for table %s failed (non-fatal): %v", fullTableName, err)
+			return fmt.Errorf("verify indexes for table %s failed: %w", fullTableName, err)
 		}
 	}
 
@@ -682,16 +731,20 @@ func (s *Service) verifyIndexes(ctx context.Context, fullTableName string, expec
 		expectedIndexNames[expectedIndexName] = true
 	}
 
-	// Get actual indexes from database
+	// Get actual indexes from database, including whether each is non-unique
+	// (NON_UNIQUE: 0 = unique, 1 = non-unique; same value on every column row).
 	actualIndexes := make(map[string][]string)
+	actualNonUnique := make(map[string]bool)
 	err := s.mysqlClient.Query(ctx, func(rows *sql.Rows) error {
 		var indexName, columnName string
-		if err := rows.Scan(&indexName, &columnName); err != nil {
+		var nonUnique int
+		if err := rows.Scan(&indexName, &columnName, &nonUnique); err != nil {
 			return err
 		}
 		actualIndexes[indexName] = append(actualIndexes[indexName], columnName)
+		actualNonUnique[indexName] = nonUnique != 0
 		return nil
-	}, `SELECT INDEX_NAME, COLUMN_NAME
+	}, `SELECT INDEX_NAME, COLUMN_NAME, NON_UNIQUE
 		FROM information_schema.statistics
 		WHERE table_schema = DATABASE()
 		AND table_name = ?
@@ -701,7 +754,10 @@ func (s *Service) verifyIndexes(ctx context.Context, fullTableName string, expec
 		return fmt.Errorf("query indexes failed: %w", err)
 	}
 
-	// Check each expected index
+	// Check each expected index. A missing/incorrect UNIQUE index is collected
+	// and returned as an error (fatal) because uniqueness is correctness-critical;
+	// non-unique index drift is only logged as a warning.
+	var invalidUnique []string
 	for _, expected := range expectedIndexes {
 		expectedIndexName := sqldb.BuildIndexName(s.opts.tablePrefix, expected.table, expected.suffix)
 		actualColumns, exists := actualIndexes[expectedIndexName]
@@ -709,8 +765,17 @@ func (s *Service) verifyIndexes(ctx context.Context, fullTableName string, expec
 			// Build CREATE INDEX statement for user reference.
 			columnsStr := buildIndexColumnsStr(expected.table, expected.suffix, expected.columns, s.opts.tdsqlSharding)
 			createSQL := buildCreateIndexSQL(expectedIndexName, fullTableName, columnsStr, expected.unique)
-			log.WarnfContext(ctx, "index %s on table %s is missing, please run: %s",
-				expectedIndexName, fullTableName, createSQL)
+			if expected.unique {
+				// A missing UNIQUE index is correctness-critical: uniqueness is no
+				// longer enforced. Log at ERROR and mark it fatal.
+				log.ErrorfContext(ctx, "UNIQUE index %s on table %s is missing; uniqueness is NOT "+
+					"enforced (duplicate active rows possible). Please run: %s",
+					expectedIndexName, fullTableName, createSQL)
+				invalidUnique = append(invalidUnique, expectedIndexName)
+			} else {
+				log.WarnfContext(ctx, "index %s on table %s is missing, please run: %s",
+					expectedIndexName, fullTableName, createSQL)
+			}
 			continue
 		}
 
@@ -719,9 +784,32 @@ func (s *Service) verifyIndexes(ctx context.Context, fullTableName string, expec
 			columnsStr := buildIndexColumnsStr(expected.table, expected.suffix, expected.columns, s.opts.tdsqlSharding)
 			dropSQL := fmt.Sprintf("DROP INDEX %s ON %s;", expectedIndexName, fullTableName)
 			createSQL := buildCreateIndexSQL(expectedIndexName, fullTableName, columnsStr, expected.unique)
-			log.WarnfContext(ctx, "index %s on table %s has wrong columns: got %v, want %v. "+
-				"Please drop and recreate: %s %s",
-				expectedIndexName, fullTableName, actualColumns, expected.columns, dropSQL, createSQL)
+			if expected.unique {
+				// A UNIQUE index on the wrong columns means uniqueness is not
+				// enforced as intended: log at ERROR and mark it fatal.
+				log.ErrorfContext(ctx, "UNIQUE index %s on table %s has wrong columns: got %v, want %v; "+
+					"uniqueness may not be enforced as expected. Please drop and recreate: %s %s",
+					expectedIndexName, fullTableName, actualColumns, expected.columns, dropSQL, createSQL)
+				invalidUnique = append(invalidUnique, expectedIndexName)
+			} else {
+				log.WarnfContext(ctx, "index %s on table %s has wrong columns: got %v, want %v. "+
+					"Please drop and recreate: %s %s",
+					expectedIndexName, fullTableName, actualColumns, expected.columns, dropSQL, createSQL)
+			}
+			continue
+		}
+
+		// Columns match. For a UNIQUE index, verify it is actually unique — a
+		// same-name index with the right columns could still be non-unique, which
+		// would leave the uniqueness constraint unenforced.
+		if expected.unique && actualNonUnique[expectedIndexName] {
+			columnsStr := buildIndexColumnsStr(expected.table, expected.suffix, expected.columns, s.opts.tdsqlSharding)
+			dropSQL := fmt.Sprintf("DROP INDEX %s ON %s;", expectedIndexName, fullTableName)
+			createSQL := buildCreateIndexSQL(expectedIndexName, fullTableName, columnsStr, expected.unique)
+			log.ErrorfContext(ctx, "index %s on table %s exists with the expected columns but is NOT unique; "+
+				"uniqueness is NOT enforced. Please drop and recreate: %s %s",
+				expectedIndexName, fullTableName, dropSQL, createSQL)
+			invalidUnique = append(invalidUnique, expectedIndexName)
 		}
 	}
 
@@ -737,6 +825,10 @@ func (s *Service) verifyIndexes(ctx context.Context, fullTableName string, expec
 		}
 	}
 
+	if len(invalidUnique) > 0 {
+		return fmt.Errorf("required unique index(es) missing or invalid on table %s: %v",
+			fullTableName, invalidUnique)
+	}
 	return nil
 }
 

--- a/session/mysql/init_test.go
+++ b/session/mysql/init_test.go
@@ -55,15 +55,19 @@ func mockVerifySchemaQueries(mock sqlmock.Sqlmock, tablePrefix string) {
 			WithArgs(fullTableName).
 			WillReturnRows(colRows)
 
-		// 3. verifyIndexes query
-		idxRows := sqlmock.NewRows([]string{"INDEX_NAME", "COLUMN_NAME"})
+		// 3. verifyIndexes query (INDEX_NAME, COLUMN_NAME, NON_UNIQUE)
+		idxRows := sqlmock.NewRows([]string{"INDEX_NAME", "COLUMN_NAME", "NON_UNIQUE"})
 		for _, idx := range schema.indexes {
 			idxName := sqldb.BuildIndexName(tablePrefix, idx.table, idx.suffix)
+			nonUnique := 1
+			if idx.unique {
+				nonUnique = 0
+			}
 			for _, col := range idx.columns {
-				idxRows.AddRow(idxName, col)
+				idxRows.AddRow(idxName, col, nonUnique)
 			}
 		}
-		idxRows.AddRow("PRIMARY", "id")
+		idxRows.AddRow("PRIMARY", "id", 0)
 		mock.ExpectQuery(regexp.QuoteMeta("SELECT INDEX_NAME")).
 			WithArgs(fullTableName).
 			WillReturnRows(idxRows)
@@ -78,31 +82,83 @@ func TestInitDB_Success(t *testing.T) {
 	s := createTestService(t, db)
 	ctx := context.Background()
 
-	// Mock: Create tables
-	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE IF NOT EXISTS session_states")).
-		WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE IF NOT EXISTS session_events")).
-		WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE IF NOT EXISTS session_track_events")).
-		WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE IF NOT EXISTS session_summaries")).
-		WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE IF NOT EXISTS app_states")).
-		WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE IF NOT EXISTS user_states")).
-		WillReturnResult(sqlmock.NewResult(0, 0))
-
-	// Mock: Create indexes (12 indexes total: 3 unique + 3 lookup + 6 TTL)
-	for i := 0; i < 12; i++ {
-		mock.ExpectExec(regexp.QuoteMeta("CREATE")).
-			WillReturnResult(sqlmock.NewResult(0, 0))
-	}
-
-	// Mock: verifySchema queries
+	// initDB creates each (missing) table together with its indexes, then
+	// verifies the schema.
+	mockCreateMissingTables(mock, s.opts.tablePrefix)
 	mockVerifySchemaQueries(mock, s.opts.tablePrefix)
 
 	err = s.initDB(ctx)
 	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestInitDB_ExistingTablesSkipDDL(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db)
+	ctx := context.Background()
+
+	// All tables already exist: initDB must NOT issue any CREATE TABLE or
+	// CREATE INDEX, only existence checks, then schema verification.
+	for _, tableDef := range tableDefs {
+		fullTableName := sqldb.BuildTableName(s.opts.tablePrefix, tableDef.name)
+		mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*)")).
+			WithArgs(fullTableName).
+			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	}
+	mockVerifySchemaQueries(mock, s.opts.tablePrefix)
+
+	err = s.initDB(ctx)
+	assert.NoError(t, err)
+	// No CREATE expectations were registered: if initDB had issued any DDL,
+	// sqlmock would have failed on an unexpected Exec.
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestInitDB_TableExistsCheckError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db)
+	ctx := context.Background()
+
+	// The first existence check itself fails (e.g. information_schema unreadable).
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*)")).
+		WithArgs(sqldb.BuildTableName(s.opts.tablePrefix, sqldb.TableNameSessionStates)).
+		WillReturnError(assert.AnError)
+
+	err = s.initDB(ctx)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "check table")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestInitDB_VerifySchemaError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db)
+	ctx := context.Background()
+
+	// All tables already exist → initDB skips DDL and proceeds to verifySchema.
+	for _, tableDef := range tableDefs {
+		mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*)")).
+			WithArgs(sqldb.BuildTableName(s.opts.tablePrefix, tableDef.name)).
+			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	}
+	// verifySchema re-checks existence; report the first table as missing so
+	// verification fails and initDB wraps the error.
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*)")).
+		WithArgs(sqldb.BuildTableName(s.opts.tablePrefix, sqldb.TableNameSessionStates)).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+	err = s.initDB(ctx)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "schema verification failed")
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -114,7 +170,10 @@ func TestInitDB_TableCreationError(t *testing.T) {
 	s := createTestService(t, db)
 	ctx := context.Background()
 
-	// Mock: First table creation fails
+	// session_states does not exist; its CREATE TABLE then fails.
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*)")).
+		WithArgs(sqldb.BuildTableName(s.opts.tablePrefix, sqldb.TableNameSessionStates)).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
 	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE IF NOT EXISTS session_states")).
 		WillReturnError(assert.AnError)
 
@@ -132,14 +191,14 @@ func TestInitDB_IndexCreationError(t *testing.T) {
 	s := createTestService(t, db)
 	ctx := context.Background()
 
-	// Mock: Create all tables successfully
-	for i := 0; i < 6; i++ {
-		mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE IF NOT EXISTS")).
-			WillReturnResult(sqlmock.NewResult(0, 0))
-	}
-
-	// Mock: First index creation fails with non-duplicate error
-	mock.ExpectExec(regexp.QuoteMeta("CREATE")).
+	// session_states does not exist: create it, then its first index fails with
+	// a non-duplicate error.
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*)")).
+		WithArgs(sqldb.BuildTableName(s.opts.tablePrefix, sqldb.TableNameSessionStates)).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE IF NOT EXISTS session_states")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("CREATE (UNIQUE )?INDEX").
 		WillReturnError(assert.AnError)
 
 	err = s.initDB(ctx)
@@ -181,27 +240,9 @@ func TestInitDB_WithTablePrefix(t *testing.T) {
 	assert.Equal(t, "trpc_app_states", s.tableAppStates)
 	assert.Equal(t, "trpc_user_states", s.tableUserStates)
 
-	// Mock: Create tables with prefix
-	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE IF NOT EXISTS trpc_session_states")).
-		WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE IF NOT EXISTS trpc_session_events")).
-		WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE IF NOT EXISTS trpc_session_track_events")).
-		WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE IF NOT EXISTS trpc_session_summaries")).
-		WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE IF NOT EXISTS trpc_app_states")).
-		WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE IF NOT EXISTS trpc_user_states")).
-		WillReturnResult(sqlmock.NewResult(0, 0))
-
-	// Mock: Create indexes with prefix
-	for i := 0; i < 12; i++ {
-		mock.ExpectExec(regexp.QuoteMeta("CREATE")).
-			WillReturnResult(sqlmock.NewResult(0, 0))
-	}
-
-	// Mock: verifySchema queries
+	// Mock: create each (missing) prefixed table together with its indexes,
+	// then verify the schema.
+	mockCreateMissingTables(mock, s.opts.tablePrefix)
 	mockVerifySchemaQueries(mock, s.opts.tablePrefix)
 
 	err = s.initDB(ctx)
@@ -217,29 +258,32 @@ func TestInitDB_DuplicateIndexIgnored(t *testing.T) {
 	s := createTestService(t, db)
 	ctx := context.Background()
 
-	// Mock: Create all tables successfully
-	for i := 0; i < 6; i++ {
-		mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE IF NOT EXISTS")).
-			WillReturnResult(sqlmock.NewResult(0, 0))
+	// Every table is new; each CREATE INDEX reports "duplicate index name"
+	// (1061), which initDB must tolerate so initialization still succeeds.
+	dupErr := &mysql.MySQLError{Number: sqldb.MySQLErrDuplicateKeyName, Message: "Duplicate key name"}
+	indexCount := make(map[string]int)
+	for _, idx := range indexDefs {
+		indexCount[idx.table]++
 	}
-
-	// Mock: Some indexes already exist (simulate duplicate key error)
-	for i := 0; i < 12; i++ {
-		if i%3 == 0 {
-			// Simulate duplicate index error
-			mock.ExpectExec(regexp.QuoteMeta("CREATE")).
-				WillReturnError(assert.AnError)
-		} else {
-			mock.ExpectExec(regexp.QuoteMeta("CREATE")).
-				WillReturnResult(sqlmock.NewResult(0, 0))
+	for _, tableDef := range tableDefs {
+		fullTableName := sqldb.BuildTableName(s.opts.tablePrefix, tableDef.name)
+		mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*)")).
+			WithArgs(fullTableName).
+			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+		mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE")).
+			WillReturnResult(sqlmock.NewResult(0, 0))
+		for i := 0; i < indexCount[tableDef.name]; i++ {
+			mock.ExpectExec("CREATE (UNIQUE )?INDEX").
+				WillReturnError(dupErr)
 		}
 	}
 
-	// Should succeed despite duplicate index errors
+	mockVerifySchemaQueries(mock, s.opts.tablePrefix)
+
+	// Duplicate index errors are ignored, so init succeeds.
 	err = s.initDB(ctx)
-	// This will fail because our mock doesn't actually return "Duplicate key name" error
-	// In real scenario, MySQL would return specific error for duplicate index
-	assert.Error(t, err) // Expected to fail with our simple mock
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestIsDuplicateIndexNameError(t *testing.T) {
@@ -333,15 +377,19 @@ func TestVerifySchema_Success(t *testing.T) {
 		WillReturnRows(rows)
 
 	// 3. verifyIndexes
-	idxRows := sqlmock.NewRows([]string{"INDEX_NAME", "COLUMN_NAME"})
+	idxRows := sqlmock.NewRows([]string{"INDEX_NAME", "COLUMN_NAME", "NON_UNIQUE"})
 	for _, idx := range expectedSchema[testTable].indexes {
 		idxName := sqldb.BuildIndexName(s.opts.tablePrefix, idx.table, idx.suffix)
+		nonUnique := 1
+		if idx.unique {
+			nonUnique = 0
+		}
 		for _, col := range idx.columns {
-			idxRows.AddRow(idxName, col)
+			idxRows.AddRow(idxName, col, nonUnique)
 		}
 	}
 	// Add PRIMARY key (should be ignored by unexpected check)
-	idxRows.AddRow("PRIMARY", "id")
+	idxRows.AddRow("PRIMARY", "id", 0)
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT INDEX_NAME")).
 		WithArgs(fullTableName).
@@ -352,11 +400,67 @@ func TestVerifySchema_Success(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestVerifySchema_MissingUniqueIndexFatal(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db)
+	ctx := context.Background()
+
+	originalExpectedSchema := expectedSchema
+	defer func() { expectedSchema = originalExpectedSchema }()
+
+	testTable := sqldb.TableNameSessionStates
+	expectedSchema = map[string]tableSchema{
+		testTable: originalExpectedSchema[testTable],
+	}
+	fullTableName := sqldb.BuildTableName(s.opts.tablePrefix, testTable)
+
+	// Table exists.
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*)")).
+		WithArgs(fullTableName).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	// Columns match.
+	colRows := sqlmock.NewRows([]string{"COLUMN_NAME", "DATA_TYPE", "IS_NULLABLE"})
+	for _, col := range expectedSchema[testTable].columns {
+		isNullable := "NO"
+		if col.nullable {
+			isNullable = "YES"
+		}
+		colRows.AddRow(col.name, col.dataType, isNullable)
+	}
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT COLUMN_NAME")).
+		WithArgs(fullTableName).
+		WillReturnRows(colRows)
+	// Indexes: omit the unique_active index so verification fails fatally.
+	idxRows := sqlmock.NewRows([]string{"INDEX_NAME", "COLUMN_NAME", "NON_UNIQUE"})
+	for _, idx := range expectedSchema[testTable].indexes {
+		if idx.suffix == sqldb.IndexSuffixUniqueActive {
+			continue
+		}
+		idxName := sqldb.BuildIndexName(s.opts.tablePrefix, idx.table, idx.suffix)
+		for _, col := range idx.columns {
+			idxRows.AddRow(idxName, col, 1)
+		}
+	}
+	idxRows.AddRow("PRIMARY", "id", 0)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT INDEX_NAME")).
+		WithArgs(fullTableName).
+		WillReturnRows(idxRows)
+
+	err = s.verifySchema(ctx)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "verify indexes")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestVerifyIndexes_Scenarios(t *testing.T) {
 	tests := []struct {
 		name            string
 		expectedIndexes []tableIndex
 		actualIndexes   map[string][]string // indexName -> columns
+		actualNonUnique map[string]bool     // indexName -> is non-unique (NON_UNIQUE=1)
 		wantError       bool
 	}{
 		{
@@ -423,14 +527,51 @@ func TestVerifyIndexes_Scenarios(t *testing.T) {
 			wantError: false,
 		},
 		{
-			name: "missing unique index - should warn with CREATE UNIQUE INDEX",
+			name: "missing unique index - fatal (uniqueness not enforced)",
 			expectedIndexes: []tableIndex{
 				{"session_states", "unique_active", []string{"app_name", "user_id"}, true},
 			},
 			actualIndexes: map[string][]string{
 				"PRIMARY": {"id"},
 			},
+			wantError: true,
+		},
+		{
+			name: "unique index with wrong columns - fatal",
+			expectedIndexes: []tableIndex{
+				{"session_states", "unique_active", []string{"app_name", "user_id", "session_id", "deleted_at"}, true},
+			},
+			actualIndexes: map[string][]string{
+				// Present but on the wrong columns: the unique-index check fails.
+				"idx_session_states_unique_active": {"app_name", "user_id"},
+				"PRIMARY":                          {"id"},
+			},
+			wantError: true,
+		},
+		{
+			name: "missing non-unique index - warns, non-fatal",
+			expectedIndexes: []tableIndex{
+				{"session_states", "expires", []string{"expires_at"}, false},
+			},
+			actualIndexes: map[string][]string{
+				"PRIMARY": {"id"},
+			},
 			wantError: false,
+		},
+		{
+			name: "unique index present with right columns but NOT unique - fatal",
+			expectedIndexes: []tableIndex{
+				{"session_states", "unique_active", []string{"app_name", "user_id", "session_id", "deleted_at"}, true},
+			},
+			actualIndexes: map[string][]string{
+				"idx_session_states_unique_active": {"app_name", "user_id", "session_id", "deleted_at"},
+				"PRIMARY":                          {"id"},
+			},
+			actualNonUnique: map[string]bool{
+				// Exists with the right columns, but is not a UNIQUE index.
+				"idx_session_states_unique_active": true,
+			},
+			wantError: true,
 		},
 	}
 
@@ -446,10 +587,14 @@ func TestVerifyIndexes_Scenarios(t *testing.T) {
 			fullTableName := "session_states"
 
 			// Build mock rows from actualIndexes
-			idxRows := sqlmock.NewRows([]string{"INDEX_NAME", "COLUMN_NAME"})
+			idxRows := sqlmock.NewRows([]string{"INDEX_NAME", "COLUMN_NAME", "NON_UNIQUE"})
 			for idxName, cols := range tt.actualIndexes {
+				nonUnique := 0
+				if tt.actualNonUnique[idxName] {
+					nonUnique = 1
+				}
 				for _, col := range cols {
-					idxRows.AddRow(idxName, col)
+					idxRows.AddRow(idxName, col, nonUnique)
 				}
 			}
 

--- a/session/mysql/service.go
+++ b/session/mysql/service.go
@@ -127,6 +127,7 @@ func NewService(options ...ServiceOpt) (*Service, error) {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 		if err := s.initDB(ctx); err != nil {
+			_ = mysqlClient.Close()
 			return nil, fmt.Errorf("init database failed: %w", err)
 		}
 	}

--- a/session/mysql/service_test.go
+++ b/session/mysql/service_test.go
@@ -3214,8 +3214,11 @@ func TestNewService_DBInitFailure(t *testing.T) {
 		return &mockMySQLClient{db: db}, nil
 	})
 
-	// Mock DB init failure
-	mock.ExpectExec("CREATE TABLE").WillReturnError(assert.AnError)
+	// Mock DB init failure: existence check passes (table absent), then the
+	// CREATE TABLE fails.
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*)")).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE IF NOT EXISTS")).WillReturnError(assert.AnError)
 
 	svc, err := NewService(
 		WithMySQLClientDSN("test:test@tcp(localhost:3306)/testdb"),
@@ -3485,17 +3488,30 @@ func mockDBInit(mock sqlmock.Sqlmock) {
 	mockDBInitWithPrefix(mock, "")
 }
 
+// mockCreateMissingTables mocks initDB's DDL path for the case where none of
+// the tables exist yet: per table, an existence check returning 0 followed by a
+// CREATE TABLE and one CREATE statement per index.
+func mockCreateMissingTables(mock sqlmock.Sqlmock, tablePrefix string) {
+	indexCount := make(map[string]int)
+	for _, idx := range indexDefs {
+		indexCount[idx.table]++
+	}
+	for _, tableDef := range tableDefs {
+		fullTableName := sqldb.BuildTableName(tablePrefix, tableDef.name)
+		mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*)")).
+			WithArgs(fullTableName).
+			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+		mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE IF NOT EXISTS")).WillReturnResult(sqlmock.NewResult(0, 0))
+		for i := 0; i < indexCount[tableDef.name]; i++ {
+			mock.ExpectExec("CREATE (UNIQUE )?INDEX").WillReturnResult(sqlmock.NewResult(0, 0))
+		}
+	}
+}
+
 // mockDBInitWithPrefix mocks the database initialization process with table prefix
 func mockDBInitWithPrefix(mock sqlmock.Sqlmock, tablePrefix string) {
-	// Mock: Create 6 tables
-	for i := 0; i < 6; i++ {
-		mock.ExpectExec("CREATE TABLE").WillReturnResult(sqlmock.NewResult(0, 0))
-	}
-
-	// Mock: Create 12 indexes
-	for i := 0; i < 12; i++ {
-		mock.ExpectExec("CREATE").WillReturnResult(sqlmock.NewResult(0, 0))
-	}
+	// Mock: create each (missing) table together with its indexes.
+	mockCreateMissingTables(mock, tablePrefix)
 
 	// Mock: verifySchema queries for each table
 	tableNames := []string{
@@ -3529,15 +3545,19 @@ func mockDBInitWithPrefix(mock sqlmock.Sqlmock, tablePrefix string) {
 			WithArgs(fullTableName).
 			WillReturnRows(colRows)
 
-		// 3. verifyIndexes query
-		idxRows := sqlmock.NewRows([]string{"INDEX_NAME", "COLUMN_NAME"})
+		// 3. verifyIndexes query (INDEX_NAME, COLUMN_NAME, NON_UNIQUE)
+		idxRows := sqlmock.NewRows([]string{"INDEX_NAME", "COLUMN_NAME", "NON_UNIQUE"})
 		for _, idx := range schema.indexes {
 			idxName := sqldb.BuildIndexName(tablePrefix, idx.table, idx.suffix)
+			nonUnique := 1
+			if idx.unique {
+				nonUnique = 0
+			}
 			for _, col := range idx.columns {
-				idxRows.AddRow(idxName, col)
+				idxRows.AddRow(idxName, col, nonUnique)
 			}
 		}
-		idxRows.AddRow("PRIMARY", "id")
+		idxRows.AddRow("PRIMARY", "id", 0)
 		mock.ExpectQuery("SELECT INDEX_NAME").
 			WithArgs(fullTableName).
 			WillReturnRows(idxRows)


### PR DESCRIPTION
## What changed

`initDB` now decides per table whether to run DDL:

- A table that does **not** exist is created together with all of its indexes
  (unchanged first-time bootstrap).
- A table that **already exists** is left untouched — `initDB` no longer issues
  `CREATE TABLE` / `CREATE INDEX` against it.

Schema drift on existing tables is surfaced by `verifySchema`:

- a **missing or incorrect UNIQUE index is fatal** — the service refuses to start
  rather than run without the uniqueness constraint that session/state writes
  rely on;
- other index drift (TTL / lookup) is logged as a warning;
- column drift remains fatal (unchanged).

Previously `initDB` unconditionally issued a standalone `CREATE [UNIQUE] INDEX`
for every index on every startup, tolerating only the "duplicate index name"
error (1061).

## Why

When the runtime account lacks the `INDEX` privilege but the schema is already
provisioned (table + indexes created by a migration or a privileged account),
startup failed with:

```
init database failed: create index idx_..._session_states_unique_active on
table ... failed: Error 1142 (42000): INDEX command denied to user 'writeuser'
```

MySQL evaluates the `INDEX` privilege **before** checking whether the index
already exists, so a standalone `CREATE INDEX` returns `1142` even when the
index is already present — the `1061` tolerance never gets a chance, and `1142`
was fatal.

Skipping DDL for existing tables fixes that and avoids running index DDL against
populated production tables (which can lock or rebuild them). To make sure this
does not hide a broken schema, a **missing or incorrect UNIQUE index is fatal**:
this also covers the case where a previous bootstrap created a table but failed
before creating its UNIQUE index — the table is treated as existing next start,
but `verifySchema` now fails fast, so a partial bootstrap cannot silently run
without uniqueness enforcement.

**Behavior change:** an existing table that is missing (or has a wrong-columns)
UNIQUE index now fails startup, instead of warning and continuing. Operators who
intentionally diverge can use `WithSkipDBInit(true)`. `WithSkipDBInit(true)` is
otherwise unchanged (it still skips initialization entirely).

## Testing

- `go test ./... -race` in `session/mysql` — all pass
- `go vet ./...` and `gofmt` clean; `codecov/patch` green
- `TestInitDB_ExistingTablesSkipDDL`: no `CREATE TABLE` / `CREATE INDEX` is
  issued when all tables already exist.
- `TestInitDB_TableExistsCheckError` / `TestInitDB_VerifySchemaError`: error
  paths in `initDB`.
- `TestVerifySchema_MissingUniqueIndexFatal` and `TestVerifyIndexes_Scenarios`
  (missing/incorrect unique index → fatal; non-unique drift → warning).
- Rewrote `TestInitDB_DuplicateIndexIgnored` to actually exercise the
  1061-tolerated path; tightened sqlmock matchers per review.

## Notes for reviewers

- Addresses the partial-bootstrap concern raised in review: a missing/incorrect
  UNIQUE index is fatal, so a table left incomplete by a failed init cannot
  silently run without its uniqueness constraint.
- "No DDL on existing tables" is preserved — the fatal check refuses startup, it
  does not run DDL against the live table.
- Column drift stays fatal; non-unique index drift stays a warning.
- New tables still get their indexes via standalone `CREATE INDEX` (grouped per
  table), so first-time bootstrap behavior is preserved.
- `NewService` now closes the client if `initDB` fails, to avoid leaking the
  connection pool on a failed startup.
