### PR TITLE
agent/structure: add tool surface id parts

### DIFF
--- a/agent/structure/id_test.go
+++ b/agent/structure/id_test.go
@@ -47,6 +47,11 @@ func TestExport_SurfaceID_IsStableAcrossRepeatedExports(t *testing.T) {
 	assert.Equal(t, first.Surfaces[0].SurfaceID, second.Surfaces[0].SurfaceID)
 }
 
+func TestSurfaceIDWithParts(t *testing.T) {
+	assert.Equal(t, "root#tool.lookup_record", SurfaceID("root", SurfaceTypeTool, "lookup_record"))
+	assert.Equal(t, "root#tool.lookup_record.input_schema", SurfaceID("root", SurfaceTypeTool, "lookup_record", "input_schema"))
+}
+
 func TestExport_StructureID_IsStableAcrossRepeatedExports(t *testing.T) {
 	ag := &testAgent{name: "root"}
 	first, err := Export(context.Background(), ag)

--- a/agent/structure/structure.go
+++ b/agent/structure/structure.go
@@ -86,9 +86,13 @@ type Surface struct {
 	Value     SurfaceValue
 }
 
-// SurfaceID returns the stable surface id for one node and surface type.
-func SurfaceID(nodeID string, surfaceType SurfaceType) string {
-	return nodeID + "#" + string(surfaceType)
+// SurfaceID returns the stable surface id for one node, surface type, and optional parts.
+func SurfaceID(nodeID string, surfaceType SurfaceType, parts ...string) string {
+	id := nodeID + "#" + string(surfaceType)
+	for _, part := range parts {
+		id += "." + part
+	}
+	return id
 }
 
 // SurfaceValue is a discriminated union keyed by SurfaceType.


### PR DESCRIPTION
This is the first PR in the PromptIter tool surface stack; it extends stable surface identifiers with optional parts so framework surfaces can address individual tool declarations without changing existing node-level surface IDs.