### PR TITLE
{agent, internal}: trace runtime tool surfaces

### DIFF
--- a/agent/invocation.go
+++ b/agent/invocation.go
@@ -27,6 +27,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
 	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/internal/structuredoutput"
+	itool "trpc.group/trpc-go/trpc-agent-go/internal/tool"
 	"trpc.group/trpc-go/trpc-agent-go/internal/tracecapture"
 	"trpc.group/trpc-go/trpc-agent-go/internal/util"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/searchfilter"
@@ -1413,7 +1414,7 @@ func (opts RunOptions) ShouldExecuteTool(
 	if opts.ToolExecutionFilter == nil {
 		return true
 	}
-	return opts.ToolExecutionFilter(ctx, tl)
+	return opts.ToolExecutionFilter(ctx, itool.ResolveDeclaration(tl))
 }
 
 func (opts RunOptions) isExternalTool(tl tool.Tool) bool {

--- a/agent/invocation_messages_test.go
+++ b/agent/invocation_messages_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
+	itool "trpc.group/trpc-go/trpc-agent-go/internal/tool"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/skill"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
@@ -285,6 +286,23 @@ func (s *stubTool) Declaration() *tool.Declaration {
 	return s.decl
 }
 
+type stubToolSet struct {
+	name  string
+	tools []tool.Tool
+}
+
+func (s stubToolSet) Tools(context.Context) []tool.Tool {
+	return s.tools
+}
+
+func (s stubToolSet) Close() error {
+	return nil
+}
+
+func (s stubToolSet) Name() string {
+	return s.name
+}
+
 func TestWithAdditionalTools(t *testing.T) {
 	const toolName = "runtime_tool"
 
@@ -397,6 +415,39 @@ func TestWithToolExecutionFilter(t *testing.T) {
 
 	require.True(t, ro.ToolExecutionFilter(ctx, allowed))
 	require.False(t, ro.ToolExecutionFilter(ctx, denied))
+}
+
+func TestRunOptionsShouldExecuteToolPreservesNamedToolIdentity(t *testing.T) {
+	ctx := context.Background()
+	base := &stubTool{
+		decl: &tool.Declaration{Name: "browse"},
+	}
+	namedTools := itool.NewNamedToolSet(stubToolSet{
+		name:  "safe",
+		tools: []tool.Tool{base},
+	}).Tools(ctx)
+	require.Len(t, namedTools, 1)
+	ro := NewRunOptions(
+		WithToolExecutionFilter(tool.NewIncludeToolNamesFilter("safe_browse")),
+	)
+	require.True(t, ro.ShouldExecuteTool(ctx, namedTools[0]))
+	require.False(t, ro.ShouldExecuteTool(ctx, base))
+}
+
+func TestRunOptionsShouldExecuteToolUnwrapsDeclarationWrapper(t *testing.T) {
+	ctx := context.Background()
+	base := &stubTool{
+		decl: &tool.Declaration{Name: "lookup"},
+	}
+	patchedTools := itool.ApplyDeclarations([]tool.Tool{base}, []tool.Declaration{{
+		Name:        "lookup",
+		Description: "patched",
+	}})
+	require.Len(t, patchedTools, 1)
+	ro := NewRunOptions(WithToolExecutionFilter(func(_ context.Context, tl tool.Tool) bool {
+		return tl == base
+	}))
+	require.True(t, ro.ShouldExecuteTool(ctx, patchedTools[0]))
 }
 
 // TestWithToolCallArgumentsJSONRepairEnabled_SetsRunOptions verifies the option toggles the RunOptions flag.

--- a/agent/llmagent/surface_runtime.go
+++ b/agent/llmagent/surface_runtime.go
@@ -226,8 +226,31 @@ func (a *LLMAgent) ExecutionTraceAppliedSurfaceIDs(inv *agent.Invocation) []stri
 	if inv != nil && inv.Model != nil {
 		appliedSurfaceIDs = append(appliedSurfaceIDs, astructure.SurfaceID(nodeID, astructure.SurfaceTypeModel))
 	}
-	if hasUserTools, ok := llmflow.InvocationHasFilteredUserTools(inv); ok && hasUserTools {
-		appliedSurfaceIDs = append(appliedSurfaceIDs, astructure.SurfaceID(nodeID, astructure.SurfaceTypeTool))
+	if hasUserTools, ok := llmflow.InvocationHasFilteredUserTools(inv); ok {
+		if inv != nil && surfacepatch.ToolSurfaceTracingEnabled(inv.RunOptions.CustomAgentConfigs) {
+			traceableToolNames, _ := llmflow.InvocationFilteredTraceableUserToolNames(inv)
+			if len(traceableToolNames) == 0 && hasUserTools {
+				appliedSurfaceIDs = append(
+					appliedSurfaceIDs,
+					astructure.SurfaceID(nodeID, astructure.SurfaceTypeTool),
+				)
+			}
+			for _, toolName := range traceableToolNames {
+				appliedSurfaceIDs = append(
+					appliedSurfaceIDs,
+					astructure.SurfaceID(
+						nodeID,
+						astructure.SurfaceTypeTool,
+						toolName,
+					),
+				)
+			}
+		} else if hasUserTools {
+			appliedSurfaceIDs = append(
+				appliedSurfaceIDs,
+				astructure.SurfaceID(nodeID, astructure.SurfaceTypeTool),
+			)
+		}
 	}
 	if a.skillRepositoryForInvocation(context.Background(), inv) != nil {
 		appliedSurfaceIDs = append(appliedSurfaceIDs, astructure.SurfaceID(nodeID, astructure.SurfaceTypeSkill))
@@ -249,6 +272,7 @@ func (a *LLMAgent) InvocationToolSurface(
 	options := a.option
 	subAgents := append([]agent.Agent(nil), a.subAgents...)
 	a.mu.RUnlock()
+	userTools = applyToolDeclarationPatch(userTools, patch)
 	userTools, userToolNames = filterInvocationUserTools(
 		ctx,
 		userTools,
@@ -425,6 +449,17 @@ func applyUserToolPatch(
 		return userTools, userToolNames
 	}
 	return patchedTools, collectUserToolNames(patchedTools)
+}
+
+func applyToolDeclarationPatch(
+	tools []tool.Tool,
+	patch surfacepatch.Patch,
+) []tool.Tool {
+	declarations, ok := patch.ToolDeclarations()
+	if !ok {
+		return tools
+	}
+	return itool.ApplyDeclarations(tools, declarations)
 }
 
 func filterInvocationUserTools(

--- a/agent/llmagent/surface_runtime_test.go
+++ b/agent/llmagent/surface_runtime_test.go
@@ -16,9 +16,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"trpc.group/trpc-go/trpc-agent-go/agent"
+	atrace "trpc.group/trpc-go/trpc-agent-go/agent/trace"
 	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/internal/flow/processor"
+	"trpc.group/trpc-go/trpc-agent-go/internal/flow/toolsnapshot"
 	"trpc.group/trpc-go/trpc-agent-go/internal/surfacepatch"
+	itool "trpc.group/trpc-go/trpc-agent-go/internal/tool"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/searchfilter"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
@@ -27,6 +30,30 @@ import (
 )
 
 var errAlwaysFails = errors.New("provider failure")
+
+func withSurfacePatchForNode(nodeID string, patch surfacepatch.Patch) agent.RunOption {
+	return func(opts *agent.RunOptions) {
+		if opts == nil || nodeID == "" || patch.IsEmpty() {
+			return
+		}
+		opts.CustomAgentConfigs = surfacepatch.WithPatch(
+			opts.CustomAgentConfigs,
+			nodeID,
+			patch,
+		)
+	}
+}
+
+func withToolSurfaceTracing() agent.RunOption {
+	return func(opts *agent.RunOptions) {
+		if opts == nil {
+			return
+		}
+		opts.CustomAgentConfigs = surfacepatch.WithToolSurfaceTracing(
+			opts.CustomAgentConfigs,
+		)
+	}
+}
 
 func TestLLMAgent_SurfacePatch_OverridesInstructionAndSystemPrompt(t *testing.T) {
 	agt := New(
@@ -124,7 +151,7 @@ func TestLLMAgent_ExecutionTraceAppliedSurfaceIDs(t *testing.T) {
 	)
 }
 
-func TestLLMAgent_ExecutionTraceAppliedSurfaceIDs_UsesFilteredToolSnapshot(t *testing.T) {
+func TestLLMAgent_ExecutionTraceAppliedSurfaceIDs_UsesFilteredToolNames(t *testing.T) {
 	agt := New(
 		"test-agent",
 		WithModel(newDummyModel()),
@@ -136,13 +163,70 @@ func TestLLMAgent_ExecutionTraceAppliedSurfaceIDs_UsesFilteredToolSnapshot(t *te
 		agent.WithInvocationTraceNodeID("test-agent"),
 		agent.WithInvocationRunOptions(agent.NewRunOptions(
 			agent.WithExecutionTraceEnabled(true),
+			withToolSurfaceTracing(),
+			agent.WithAdditionalTools([]tool.Tool{
+				itool.NewUnprefixedNamedTool(dummyTool{decl: &tool.Declaration{Name: "run_option_tool"}}),
+			}),
 		)),
 	)
 	agt.setupInvocation(inv)
-	inv.SetState("llmflow:has_filtered_user_tools", false)
-	require.NotContains(t, agt.ExecutionTraceAppliedSurfaceIDs(inv), "test-agent#tool")
-	inv.SetState("llmflow:has_filtered_user_tools", true)
-	require.Contains(t, agt.ExecutionTraceAppliedSurfaceIDs(inv), "test-agent#tool")
+	staticTool := dummyTool{decl: &tool.Declaration{Name: "user_tool"}}
+	toolsnapshot.Set(inv, []tool.Tool{staticTool}, false, []string{})
+	require.NotContains(t, agt.ExecutionTraceAppliedSurfaceIDs(inv), "test-agent#tool.user_tool")
+	toolsnapshot.Set(inv, []tool.Tool{
+		agt.UserTools()[0],
+		itool.NewUnprefixedNamedTool(dummyTool{decl: &tool.Declaration{Name: "run_option_tool"}}),
+	}, true, []string{"user_tool"})
+	surfaceIDs := agt.ExecutionTraceAppliedSurfaceIDs(inv)
+	require.Contains(t, surfaceIDs, "test-agent#tool.user_tool")
+	require.NotContains(t, surfaceIDs, "test-agent#tool.run_option_tool")
+	toolsnapshot.Set(inv, []tool.Tool{
+		dummyTool{decl: &tool.Declaration{Name: "user_tool"}},
+	}, true, []string{})
+	fallbackSurfaceIDs := agt.ExecutionTraceAppliedSurfaceIDs(inv)
+	require.Contains(t, fallbackSurfaceIDs, "test-agent#tool")
+	require.NotContains(t, fallbackSurfaceIDs, "test-agent#tool.user_tool")
+}
+
+type traceRefreshToolSet struct {
+	calls int
+}
+
+func (s *traceRefreshToolSet) Tools(context.Context) []tool.Tool {
+	s.calls++
+	name := "dynamic_first"
+	if s.calls > 1 {
+		name = "dynamic_second"
+	}
+	return []tool.Tool{dummyTool{decl: &tool.Declaration{Name: name}}}
+}
+
+func (s *traceRefreshToolSet) Close() error { return nil }
+
+func (s *traceRefreshToolSet) Name() string { return "dynamic" }
+
+func TestLLMAgent_ExecutionTraceAppliedSurfaceIDs_FiltersRuntimeOnlyToolSets(t *testing.T) {
+	toolSet := &traceRefreshToolSet{}
+	agt := New(
+		"dynamic-agent",
+		WithModel(newDummyModel()),
+		WithToolSets([]tool.ToolSet{toolSet}),
+		WithRefreshToolSetsOnRun(true),
+	)
+	inv := agent.NewInvocation(
+		agent.WithInvocationTraceNodeID("dynamic-agent"),
+		agent.WithInvocationRunOptions(agent.NewRunOptions(
+			agent.WithExecutionTraceEnabled(true),
+			withToolSurfaceTracing(),
+		)),
+	)
+	agt.setupInvocation(inv)
+	toolSet.calls = 0
+	toolsnapshot.Set(inv, []tool.Tool{
+		itool.NewUnprefixedNamedTool(dummyTool{decl: &tool.Declaration{Name: "dynamic_first"}}),
+	}, true, []string{"dynamic_first"})
+	require.Contains(t, agt.ExecutionTraceAppliedSurfaceIDs(inv), "dynamic-agent#tool.dynamic_first")
+	require.Zero(t, toolSet.calls)
 }
 
 func TestLLMAgent_SurfaceRuntimeHelpers_CoverPatchAndFallbackBranches(t *testing.T) {
@@ -194,7 +278,7 @@ func TestLLMAgent_SurfaceRuntimeHelpers_CoverPatchAndFallbackBranches(t *testing
 		)),
 	)
 	agt.setupInvocation(patchedInv)
-	patchedInv.SetState("llmflow:has_filtered_user_tools", false)
+	patchedInv.SetState(toolsnapshot.HasFilteredUserToolsKey, false)
 	require.Len(t, agt.fewShotForInvocation(patchedInv), 1)
 	require.NotNil(t, agt.skillRepositoryForInvocation(context.Background(), patchedInv))
 	m, ok := agt.modelSurfaceForInvocation(patchedInv)
@@ -584,6 +668,104 @@ func TestLLMAgent_Run_AgentToolFilterStillAppliesWithInvocationToolSurface(
 	require.Contains(t, m.got.Tools, "allowed_user_tool")
 	require.NotContains(t, m.got.Tools, "blocked_user_tool")
 	require.Contains(t, m.got.Tools, testTransferToolName)
+}
+
+func TestLLMAgent_Run_SurfacePatch_OverridesToolDeclarations(t *testing.T) {
+	m := &captureModel{}
+	agt := New(
+		"test-agent",
+		WithModel(m),
+		WithTools([]tool.Tool{
+			dummyTool{decl: &tool.Declaration{
+				Name:        "allowed_user_tool",
+				Description: "old description",
+				InputSchema: &tool.Schema{
+					Type: "object",
+					Properties: map[string]*tool.Schema{
+						"query": {Type: "string", Description: "old query"},
+					},
+				},
+			}},
+			dummyTool{decl: &tool.Declaration{Name: "blocked_user_tool"}},
+		}),
+		WithToolFilter(func(_ context.Context, tl tool.Tool) bool {
+			declaration := tl.Declaration()
+			return declaration != nil && declaration.Description == "patched description"
+		}),
+	)
+	var patch surfacepatch.Patch
+	patch.SetToolDeclarations([]tool.Declaration{{
+		Name:        "allowed_user_tool",
+		Description: "patched description",
+		InputSchema: &tool.Schema{
+			Type: "object",
+			Properties: map[string]*tool.Schema{
+				"query": {Type: "string", Description: "patched query"},
+			},
+		},
+	}})
+	inv := agent.NewInvocation(
+		agent.WithInvocationMessage(model.NewUserMessage("hello")),
+		agent.WithInvocationRunOptions(agent.NewRunOptions(
+			withSurfacePatchForNode("test-agent", patch),
+		)),
+	)
+	ch, err := agt.Run(context.Background(), inv)
+	require.NoError(t, err)
+	for range ch {
+	}
+	require.NotNil(t, m.got)
+	gotTool, ok := m.got.Tools["allowed_user_tool"]
+	require.True(t, ok)
+	require.Equal(t, "patched description", gotTool.Declaration().Description)
+	require.Equal(t, "patched query", gotTool.Declaration().InputSchema.Properties["query"].Description)
+	require.NotContains(t, m.got.Tools, "blocked_user_tool")
+}
+
+func TestLLMAgent_Run_SurfacePatchToolDeclarationTraceUsesStaticSurfaces(t *testing.T) {
+	m := &captureModel{}
+	agt := New(
+		"test-agent",
+		WithModel(m),
+		WithTools([]tool.Tool{
+			dummyTool{decl: &tool.Declaration{
+				Name:        "allowed_user_tool",
+				Description: "old description",
+				InputSchema: &tool.Schema{Type: "object"},
+			}},
+		}),
+	)
+	var patch surfacepatch.Patch
+	patch.SetToolDeclarations([]tool.Declaration{{
+		Name:        "allowed_user_tool",
+		Description: "patched description",
+		InputSchema: &tool.Schema{Type: "object"},
+	}})
+	inv := agent.NewInvocation(
+		agent.WithInvocationMessage(model.NewUserMessage("hello")),
+		agent.WithInvocationTraceNodeID("test-agent"),
+		agent.WithInvocationRunOptions(agent.NewRunOptions(
+			agent.WithExecutionTraceEnabled(true),
+			withToolSurfaceTracing(),
+			agent.WithAdditionalTools([]tool.Tool{
+				dummyTool{decl: &tool.Declaration{Name: "run_option_tool"}},
+			}),
+			withSurfacePatchForNode("test-agent", patch),
+		)),
+	)
+	ch, err := agt.Run(context.Background(), inv)
+	require.NoError(t, err)
+	for range ch {
+	}
+	require.NotNil(t, m.got)
+	require.Contains(t, m.got.Tools, "allowed_user_tool")
+	require.Contains(t, m.got.Tools, "run_option_tool")
+	require.Equal(t, "patched description", m.got.Tools["allowed_user_tool"].Declaration().Description)
+	trace := agent.BuildExecutionTrace(inv, atrace.TraceStatusCompleted)
+	require.NotNil(t, trace)
+	require.Len(t, trace.Steps, 1)
+	require.Contains(t, trace.Steps[0].AppliedSurfaceIDs, "test-agent#tool.allowed_user_tool")
+	require.NotContains(t, trace.Steps[0].AppliedSurfaceIDs, "test-agent#tool.run_option_tool")
 }
 
 func TestLLMAgent_Run_SurfacePatch_DisablesStaticSkills(t *testing.T) {

--- a/agent/llmagent/tool_activation_test.go
+++ b/agent/llmagent/tool_activation_test.go
@@ -147,7 +147,7 @@ func TestToolActivationPostToolResultWritesRecords(t *testing.T) {
 		AgentName: "agent",
 		Session:   session.NewSession("app", "user", "session"),
 	}
-	toolsnapshot.Set(inv, []tool.Tool{activationTool{name: "old"}}, true)
+	toolsnapshot.Set(inv, []tool.Tool{activationTool{name: "old"}}, true, []string{"old"})
 	ev := &event.Event{
 		StateDelta: map[string][]byte{
 			skill.LoadedKey("agent", "research"): []byte("1"),

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime/debug"
+	"sort"
 	"time"
 
 	"github.com/google/uuid"
@@ -34,6 +35,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/internal/responseusage"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/steer"
 	itelemetry "trpc.group/trpc-go/trpc-agent-go/internal/telemetry"
+	itool "trpc.group/trpc-go/trpc-agent-go/internal/tool"
 	"trpc.group/trpc-go/trpc-agent-go/internal/toolcall"
 	"trpc.group/trpc-go/trpc-agent-go/internal/toolsurface"
 	itrace "trpc.group/trpc-go/trpc-agent-go/internal/trace"
@@ -67,6 +69,11 @@ const (
 // snapshot for this invocation still contains any user tool.
 func InvocationHasFilteredUserTools(invocation *agent.Invocation) (bool, bool) {
 	return toolsnapshot.HasFilteredUserTools(invocation)
+}
+
+// InvocationFilteredTraceableUserToolNames reports filtered user tool names that have structure surfaces.
+func InvocationFilteredTraceableUserToolNames(invocation *agent.Invocation) ([]string, bool) {
+	return toolsnapshot.FilteredTraceableUserToolNames(invocation)
 }
 
 // Options contains configuration options for creating a Flow.
@@ -1259,7 +1266,7 @@ func collectLongRunningToolIDs(ToolCalls []model.ToolCall, tools map[string]tool
 		if !ok {
 			continue
 		}
-		caller, ok := t.(function.LongRunner)
+		caller, ok := itool.ResolveDeclaration(t).(function.LongRunner)
 		if !ok {
 			continue
 		}
@@ -1969,6 +1976,11 @@ func (f *Flow) getFilteredTools(
 		ctx,
 		invocation,
 	)
+	traceableUserToolNames := trackedUserToolNames(
+		allTools,
+		hasUserToolTracking,
+		userToolNames,
+	)
 	allTools, userToolNames, hasUserToolTracking, externalToolNames :=
 		toolsurface.AppendRunOptionTools(
 			allTools,
@@ -2002,7 +2014,8 @@ func (f *Flow) getFilteredTools(
 		toolsnapshot.Set(
 			invocation,
 			allTools,
-			hasTrackedUserTool(allTools, hasUserToolTracking, userToolNames),
+			len(trackedUserToolNames(allTools, hasUserToolTracking, userToolNames)) > 0,
+			filteredTraceableToolNames(allTools, traceableUserToolNames),
 		)
 		return allTools
 	}
@@ -2022,7 +2035,8 @@ func (f *Flow) getFilteredTools(
 	toolsnapshot.Set(
 		invocation,
 		filtered,
-		hasTrackedUserTool(filtered, hasUserToolTracking, userToolNames),
+		len(trackedUserToolNames(filtered, hasUserToolTracking, userToolNames)) > 0,
+		filteredTraceableToolNames(filtered, traceableUserToolNames),
 	)
 
 	return filtered
@@ -2078,26 +2092,66 @@ func toolName(tl tool.Tool) string {
 	return decl.Name
 }
 
-func hasTrackedUserTool(
+func trackedUserToolNames(
 	tools []tool.Tool,
 	hasUserToolTracking bool,
 	userToolNames map[string]bool,
-) bool {
+) []string {
 	if len(tools) == 0 {
-		return false
+		return nil
 	}
+	seen := make(map[string]struct{}, len(tools))
 	if !hasUserToolTracking {
-		return true
+		for _, tl := range tools {
+			if name := toolName(tl); name != "" {
+				seen[name] = struct{}{}
+			}
+		}
+		return sortedToolNames(seen)
 	}
 	for _, tl := range tools {
-		if tl == nil || tl.Declaration() == nil {
-			continue
-		}
-		if userToolNames[tl.Declaration().Name] {
-			return true
+		name := toolName(tl)
+		if name != "" && userToolNames[name] {
+			seen[name] = struct{}{}
 		}
 	}
-	return false
+	return sortedToolNames(seen)
+}
+
+func sortedToolNames(names map[string]struct{}) []string {
+	if len(names) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(names))
+	for name := range names {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func filteredTraceableToolNames(
+	tools []tool.Tool,
+	traceableToolNames []string,
+) []string {
+	if len(tools) == 0 || len(traceableToolNames) == 0 {
+		return nil
+	}
+	traceable := make(map[string]struct{}, len(traceableToolNames))
+	for _, name := range traceableToolNames {
+		traceable[name] = struct{}{}
+	}
+	seen := make(map[string]struct{}, len(tools))
+	for _, tl := range tools {
+		name := toolName(tl)
+		if name == "" {
+			continue
+		}
+		if _, ok := traceable[name]; ok {
+			seen[name] = struct{}{}
+		}
+	}
+	return sortedToolNames(seen)
 }
 
 // callLLM performs the actual LLM call using core/model.

--- a/internal/flow/llmflow/tool_filter_test.go
+++ b/internal/flow/llmflow/tool_filter_test.go
@@ -335,6 +335,9 @@ func TestGetFilteredTools_NoFilter(t *testing.T) {
 	if !hasUserTools {
 		t.Fatal("expected cached state to report user tools when the snapshot still includes them")
 	}
+	traceableNames, ok := InvocationFilteredTraceableUserToolNames(inv)
+	require.True(t, ok)
+	require.Equal(t, []string{"user_tool_1"}, traceableNames)
 }
 
 func TestGetFilteredTools_NoFilterSkipsInvalidTools(t *testing.T) {
@@ -389,6 +392,9 @@ func TestGetFilteredTools_CachesFilteredUserToolPresence(t *testing.T) {
 	if hasUserTools {
 		t.Fatal("expected no filtered user tools after invocation filter")
 	}
+	traceableNames, ok := InvocationFilteredTraceableUserToolNames(inv)
+	require.True(t, ok)
+	require.Empty(t, traceableNames)
 }
 
 func TestInvocationHasFilteredUserTools_NilInvocation(t *testing.T) {
@@ -399,26 +405,31 @@ func TestInvocationHasFilteredUserTools_NilInvocation(t *testing.T) {
 	if hasUserTools {
 		t.Fatal("expected nil invocation to report no cached user tools")
 	}
+	traceableNames, ok := InvocationFilteredTraceableUserToolNames(nil)
+	require.False(t, ok)
+	require.Empty(t, traceableNames)
 }
 
-func TestHasTrackedUserTool_CoversTrackingBranches(t *testing.T) {
-	require.False(t, hasTrackedUserTool(nil, false, nil))
-	require.True(
+func TestTrackedUserToolNames_CoversTrackingBranches(t *testing.T) {
+	require.Empty(t, trackedUserToolNames(nil, false, nil))
+	require.Equal(
 		t,
-		hasTrackedUserTool([]tool.Tool{&mockTool{name: "user_tool"}}, false, nil),
+		[]string{"user_tool"},
+		trackedUserToolNames([]tool.Tool{&mockTool{name: "user_tool"}}, false, nil),
 	)
-	require.False(
+	require.Empty(
 		t,
-		hasTrackedUserTool(
+		trackedUserToolNames(
 			[]tool.Tool{&mockTool{name: "framework_tool"}},
 			true,
 			map[string]bool{"user_tool": true},
 		),
 	)
-	require.True(
+	require.Equal(
 		t,
-		hasTrackedUserTool(
-			[]tool.Tool{&mockTool{name: "user_tool"}},
+		[]string{"user_tool"},
+		trackedUserToolNames(
+			[]tool.Tool{&mockTool{name: "user_tool"}, &mockTool{name: "user_tool"}},
 			true,
 			map[string]bool{"user_tool": true},
 		),
@@ -443,6 +454,9 @@ func TestGetFilteredTools_UsesInvocationToolSurfaceProvider(t *testing.T) {
 	hasUserTools, ok := InvocationHasFilteredUserTools(inv)
 	require.True(t, ok)
 	require.True(t, hasUserTools)
+	traceableNames, ok := InvocationFilteredTraceableUserToolNames(inv)
+	require.True(t, ok)
+	require.Equal(t, []string{"user_tool"}, traceableNames)
 }
 
 // TestGetFilteredTools_WithToolFilter tests tool filtering using FilterFunc.
@@ -528,6 +542,12 @@ func TestGetFilteredTools_AppendsRunOptionTools(t *testing.T) {
 	require.True(t, hasToolName(filtered, "framework_tool"))
 	require.True(t, hasToolName(filtered, "runtime_allowed"))
 	require.False(t, hasToolName(filtered, "runtime_denied"))
+	hasUserTools, ok := InvocationHasFilteredUserTools(inv)
+	require.True(t, ok)
+	require.True(t, hasUserTools)
+	traceableNames, ok := InvocationFilteredTraceableUserToolNames(inv)
+	require.True(t, ok)
+	require.Empty(t, traceableNames)
 }
 
 func TestGetFilteredTools_FiltersRunOptionToolsWithFilterProvider(
@@ -577,6 +597,12 @@ func TestGetFilteredTools_FiltersRunOptionToolsWithFilterProvider(
 	require.True(t, hasToolName(filtered, registeredToolName))
 	require.True(t, hasToolName(filtered, runtimeAllowedName))
 	require.False(t, hasToolName(filtered, runtimeDeniedName))
+	hasUserTools, ok := InvocationHasFilteredUserTools(inv)
+	require.True(t, ok)
+	require.True(t, hasUserTools)
+	traceableNames, ok := InvocationFilteredTraceableUserToolNames(inv)
+	require.True(t, ok)
+	require.Equal(t, []string{registeredToolName}, traceableNames)
 }
 
 func TestGetFilteredTools_ExternalToolCannotShadowExistingTool(t *testing.T) {

--- a/internal/flow/processor/functioncall.go
+++ b/internal/flow/processor/functioncall.go
@@ -1170,10 +1170,6 @@ func (p *FunctionCallResponseProcessor) attachStateDelta(
 	if tl == nil || choice == nil || ev == nil {
 		return
 	}
-	original := tl
-	if nameTool, ok := tl.(*itool.NamedTool); ok {
-		original = nameTool.Original()
-	}
 	b := []byte(choice.Message.Content)
 	toolCallID := choice.Message.ToolID
 
@@ -1190,10 +1186,13 @@ func (p *FunctionCallResponseProcessor) attachStateDelta(
 	}
 
 	var delta map[string][]byte
-	if isdp, ok := original.(invocationStateDeltaProvider); ok {
+	providerTool := itool.ResolveSemantic(tl)
+	if isdp, ok := providerTool.(invocationStateDeltaProvider); ok {
 		delta = isdp.StateDeltaForInvocation(inv, toolCallID, args, b)
-	} else if sdp, ok := original.(stateDeltaProvider); ok {
+	} else if sdp, ok := providerTool.(stateDeltaProvider); ok {
 		delta = sdp.StateDelta(toolCallID, args, b)
+	} else {
+		return
 	}
 	if len(delta) == 0 {
 		return
@@ -1660,7 +1659,7 @@ func (p *FunctionCallResponseProcessor) executeToolCall(
 		return ctx, nil, modifiedArgs, true, skipSummarization, err
 	}
 	//  allow to return nil not provide function response.
-	if r, ok := tl.(function.LongRunner); ok && r.LongRunning() {
+	if r, ok := itool.ResolveDeclaration(tl).(function.LongRunner); ok && r.LongRunning() {
 		if result == nil {
 			return ctx, nil, modifiedArgs, true, skipSummarization, nil
 		}
@@ -2281,15 +2280,16 @@ func (p *FunctionCallResponseProcessor) checkToolPermission(
 	tl tool.Tool,
 	decl *tool.Declaration,
 ) (*tool.PermissionResult, error) {
+	semanticTool := itool.ResolveSemantic(tl)
 	req := &tool.PermissionRequest{
 		Tool:        tl,
 		ToolName:    toolCall.Function.Name,
 		ToolCallID:  toolCall.ID,
 		Declaration: decl,
 		Arguments:   toolCall.Function.Arguments,
-		Metadata:    tool.MetadataOf(tl),
+		Metadata:    tool.MetadataOf(semanticTool),
 	}
-	if checker, ok := tl.(tool.PermissionChecker); ok {
+	if checker, ok := semanticTool.(tool.PermissionChecker); ok {
 		decision, err := checker.CheckPermission(ctx, req)
 		result, err := normalizeToolPermissionResult(req, decision, err)
 		if result != nil || err != nil {
@@ -2352,12 +2352,24 @@ func afterCallbackReplacedResult(toolErr error, toolResult any) bool {
 // isStreamable returns true if the tool supports streaming and its stream
 // preference is enabled.
 func isStreamable(t tool.Tool) bool {
-	// Check if the tool has a stream preference and if it is enabled.
-	if pref, ok := t.(streamInnerPreference); ok && !pref.StreamInner() {
-		return false
-	}
-	_, ok := t.(tool.StreamableTool)
+	_, ok := streamableTool(t)
 	return ok
+}
+
+func streamableTool(t tool.Tool) (tool.StreamableTool, bool) {
+	streamable, ok := t.(tool.StreamableTool)
+	if !ok {
+		return nil, false
+	}
+	probe := itool.ResolveSemantic(t)
+	if _, ok := probe.(tool.StreamableTool); !ok {
+		return nil, false
+	}
+	// Check if the tool has a stream preference and if it is enabled.
+	if pref, ok := probe.(streamInnerPreference); ok && !pref.StreamInner() {
+		return nil, false
+	}
+	return streamable, true
 }
 
 // executeTool executes the tool based on its capabilities.
@@ -2368,18 +2380,10 @@ func (f *FunctionCallResponseProcessor) executeTool(
 	tl tool.Tool,
 	eventChan chan<- *event.Event,
 ) (context.Context, any, bool, error) {
-	// originalTool refers to the actual underlying tool used to determine
-	// whether streaming is supported. If tl is a NamedTool, use its
-	// inner original tool instead of the wrapper itself.
-	originalTool := tl
-	if nameTool, ok := tl.(*itool.NamedTool); ok {
-		originalTool = nameTool.Original()
-	}
 	// Prefer streaming execution if the tool supports it.
-	if isStreamable(originalTool) {
-		// Safe to cast since isStreamable checks for StreamableTool.
+	if streamable, ok := streamableTool(tl); ok {
 		return f.executeStreamableTool(
-			ctx, invocation, toolCall, tl.(tool.StreamableTool), eventChan,
+			ctx, invocation, toolCall, streamable, eventChan,
 		)
 	}
 	// Fallback to callable tool execution if supported.
@@ -2506,11 +2510,7 @@ func shouldRequestStructuredStreamErrors(tl tool.StreamableTool) bool {
 	if tl == nil {
 		return false
 	}
-	candidate := any(tl)
-	if namedTool, ok := tl.(*itool.NamedTool); ok {
-		candidate = namedTool.Original()
-	}
-	pref, ok := candidate.(structuredStreamErrorOptIn)
+	pref, ok := itool.ResolveSemantic(tl).(structuredStreamErrorOptIn)
 	return ok && pref.TRPCAgentGoStructuredStreamErrorsOptIn()
 }
 
@@ -2518,11 +2518,7 @@ func innerTextModeForTool(tl tool.StreamableTool) tool.InnerTextMode {
 	if tl == nil {
 		return tool.InnerTextModeInclude
 	}
-	candidate := any(tl)
-	if namedTool, ok := tl.(*itool.NamedTool); ok {
-		candidate = namedTool.Original()
-	}
-	pref, ok := candidate.(innerTextModePreference)
+	pref, ok := itool.ResolveSemantic(tl).(innerTextModePreference)
 	if !ok {
 		return tool.InnerTextModeInclude
 	}
@@ -3004,14 +3000,7 @@ func markSkipSummarization(ev *event.Event) {
 }
 
 func toolPrefersSkipSummarization(tl tool.Tool) bool {
-	if tl == nil {
-		return false
-	}
-	original := tl
-	if nameTool, ok := tl.(*itool.NamedTool); ok {
-		original = nameTool.Original()
-	}
-	if skipper, ok := original.(summarizationSkipper); ok {
+	if skipper, ok := itool.ResolveSemantic(tl).(summarizationSkipper); ok {
 		return skipper.SkipSummarization()
 	}
 	return false

--- a/internal/flow/processor/functioncall_test.go
+++ b/internal/flow/processor/functioncall_test.go
@@ -6945,6 +6945,18 @@ func TestIsStreamable_RespectsPreferenceFalse(t *testing.T) {
 	require.False(t, isStreamable(&noStreamPrefTool{}))
 }
 
+type originalOnlyStreamWrapper struct {
+	original tool.Tool
+}
+
+func (w *originalOnlyStreamWrapper) Declaration() *tool.Declaration {
+	return w.original.Declaration()
+}
+
+func (w *originalOnlyStreamWrapper) Original() tool.Tool {
+	return w.original
+}
+
 // onlyTool implements Tool but neither Callable nor Streamable.
 type onlyTool struct{}
 
@@ -6958,6 +6970,18 @@ func TestExecuteTool_UnsupportedToolType(t *testing.T) {
 	inv := &agent.Invocation{}
 	tc := model.ToolCall{Function: model.FunctionDefinitionParam{Name: "only"}}
 	_, _, _, err := p.executeTool(ctx, inv, tc, &onlyTool{}, nil)
+	require.Error(t, err)
+}
+
+func TestExecuteTool_OriginalOnlyStreamWrapperDoesNotPanic(t *testing.T) {
+	p := NewFunctionCallResponseProcessor(false, nil)
+	ctx := context.Background()
+	inv := &agent.Invocation{}
+	tc := model.ToolCall{Function: model.FunctionDefinitionParam{Name: "stream"}}
+	wrapper := &originalOnlyStreamWrapper{
+		original: &mockStreamTool{name: "stream"},
+	}
+	_, _, _, err := p.executeTool(ctx, inv, tc, wrapper, nil)
 	require.Error(t, err)
 }
 
@@ -8672,6 +8696,14 @@ func TestShouldRequestStructuredStreamErrors_NilAndNamedTool(t *testing.T) {
 	namedStreamTool, ok := namedTools[0].(tool.StreamableTool)
 	require.True(t, ok)
 	require.True(t, shouldRequestStructuredStreamErrors(namedStreamTool))
+	patchedTools := itool.ApplyDeclarations([]tool.Tool{baseTool}, []tool.Declaration{{
+		Name:        "structured",
+		Description: "patched",
+	}})
+	require.Len(t, patchedTools, 1)
+	patchedStreamTool, ok := patchedTools[0].(tool.StreamableTool)
+	require.True(t, ok)
+	require.True(t, shouldRequestStructuredStreamErrors(patchedStreamTool))
 }
 
 func TestHasSyntheticStateOnlyToolChoice_NilContext(t *testing.T) {

--- a/internal/flow/toolsnapshot/toolsnapshot.go
+++ b/internal/flow/toolsnapshot/toolsnapshot.go
@@ -20,7 +20,8 @@ const (
 	// ToolsSnapshotKey is the invocation state key used to cache the final tool list.
 	ToolsSnapshotKey = "llmflow:tools_snapshot"
 	// HasFilteredUserToolsKey caches whether the filtered snapshot has user tools.
-	HasFilteredUserToolsKey = "llmflow:has_filtered_user_tools"
+	HasFilteredUserToolsKey           = "llmflow:has_filtered_user_tools"
+	filteredTraceableUserToolNamesKey = "llmflow:filtered_traceable_user_tool_names"
 )
 
 // Get returns the cached tool snapshot for this invocation.
@@ -33,17 +34,35 @@ func Get(inv *agent.Invocation) ([]tool.Tool, bool) {
 }
 
 // Set stores the cached tool snapshot for this invocation.
-func Set(inv *agent.Invocation, tools []tool.Tool, hasFilteredUserTools bool) {
+func Set(
+	inv *agent.Invocation,
+	tools []tool.Tool,
+	hasFilteredUserTools bool,
+	filteredTraceableUserToolNames []string,
+) {
 	if inv == nil {
 		return
 	}
 	inv.SetState(ToolsSnapshotKey, copyTools(tools))
 	inv.SetState(HasFilteredUserToolsKey, hasFilteredUserTools)
+	inv.SetState(
+		filteredTraceableUserToolNamesKey,
+		copyStrings(filteredTraceableUserToolNames),
+	)
 }
 
 // HasFilteredUserTools reports whether the cached snapshot has user tools.
 func HasFilteredUserTools(inv *agent.Invocation) (bool, bool) {
 	return agent.GetStateValue[bool](inv, HasFilteredUserToolsKey)
+}
+
+// FilteredTraceableUserToolNames reports filtered user tool names that have structure surfaces.
+func FilteredTraceableUserToolNames(inv *agent.Invocation) ([]string, bool) {
+	names, ok := agent.GetStateValue[[]string](inv, filteredTraceableUserToolNamesKey)
+	if !ok {
+		return nil, false
+	}
+	return copyStrings(names), true
 }
 
 // Invalidate clears the cached tool snapshot for this invocation.
@@ -53,8 +72,13 @@ func Invalidate(inv *agent.Invocation) {
 	}
 	inv.DeleteState(ToolsSnapshotKey)
 	inv.DeleteState(HasFilteredUserToolsKey)
+	inv.DeleteState(filteredTraceableUserToolNamesKey)
 }
 
 func copyTools(tools []tool.Tool) []tool.Tool {
 	return append([]tool.Tool(nil), tools...)
+}
+
+func copyStrings(values []string) []string {
+	return append([]string(nil), values...)
 }

--- a/internal/flow/toolsnapshot/toolsnapshot_test.go
+++ b/internal/flow/toolsnapshot/toolsnapshot_test.go
@@ -32,10 +32,22 @@ func TestSetGetCopiesToolSlice(t *testing.T) {
 	first := testTool{name: "first"}
 	second := testTool{name: "second"}
 	tools := []tool.Tool{first}
-	Set(inv, tools, true)
+	traceableUserToolNames := []string{"first"}
+	Set(inv, tools, true, traceableUserToolNames)
 	hasFiltered, ok := HasFilteredUserTools(inv)
 	require.True(t, ok)
 	require.True(t, hasFiltered)
+	traceableNames, ok := FilteredTraceableUserToolNames(inv)
+	require.True(t, ok)
+	require.Equal(t, []string{"first"}, traceableNames)
+	traceableUserToolNames[0] = "changed"
+	traceableAgain, ok := FilteredTraceableUserToolNames(inv)
+	require.True(t, ok)
+	require.Equal(t, []string{"first"}, traceableAgain)
+	traceableNames[0] = "returned"
+	traceableAfterReturnedMutation, ok := FilteredTraceableUserToolNames(inv)
+	require.True(t, ok)
+	require.Equal(t, []string{"first"}, traceableAfterReturnedMutation)
 	tools[0] = second
 	cached, ok := Get(inv)
 	require.True(t, ok)
@@ -49,15 +61,17 @@ func TestSetGetCopiesToolSlice(t *testing.T) {
 func TestSnapshotMissingAndInvalidate(t *testing.T) {
 	_, ok := Get(nil)
 	require.False(t, ok)
-	Set(nil, []tool.Tool{testTool{name: "ignored"}}, true)
+	Set(nil, []tool.Tool{testTool{name: "ignored"}}, true, []string{"ignored"})
 	Invalidate(nil)
 	inv := &agent.Invocation{}
 	_, ok = Get(inv)
 	require.False(t, ok)
-	Set(inv, []tool.Tool{testTool{name: "first"}}, true)
+	Set(inv, []tool.Tool{testTool{name: "first"}}, true, []string{"first"})
 	Invalidate(inv)
 	_, ok = Get(inv)
 	require.False(t, ok)
 	_, ok = HasFilteredUserTools(inv)
+	require.False(t, ok)
+	_, ok = FilteredTraceableUserToolNames(inv)
 	require.False(t, ok)
 }

--- a/internal/surfacepatch/patch.go
+++ b/internal/surfacepatch/patch.go
@@ -16,8 +16,9 @@ import (
 )
 
 const (
-	configsKey           = "__trpc_agent_internal_node_surface_patches__"
-	rootNodeIDConfigsKey = "__trpc_agent_internal_surface_root_node_id__"
+	configsKey                 = "__trpc_agent_internal_node_surface_patches__"
+	rootNodeIDConfigsKey       = "__trpc_agent_internal_surface_root_node_id__"
+	toolSurfaceTraceConfigsKey = "__trpc_agent_internal_promptiter_tool_surface_trace__"
 )
 
 type textSlot struct {
@@ -41,6 +42,11 @@ type toolsSlot struct {
 	append []tool.Tool
 }
 
+type toolDeclarationSlot struct {
+	set   bool
+	value []tool.Declaration
+}
+
 type skillRepoSlot struct {
 	set   bool
 	value skill.Repository
@@ -53,6 +59,7 @@ type Patch struct {
 	fewShot           fewShotSlot
 	model             modelSlot
 	tools             toolsSlot
+	toolDeclarations  toolDeclarationSlot
 	skillRepo         skillRepoSlot
 
 	// suppressSubAgentTransfer, when true, omits framework-managed sub-agent
@@ -103,6 +110,12 @@ func (p *Patch) AppendTools(tools []tool.Tool) {
 		return
 	}
 	p.tools.append = append(p.tools.append, cloneTools(tools)...)
+}
+
+// SetToolDeclarations sets model-facing tool declaration overrides.
+func (p *Patch) SetToolDeclarations(declarations []tool.Declaration) {
+	p.toolDeclarations.set = true
+	p.toolDeclarations.value = cloneToolDeclarations(declarations)
 }
 
 // SetSkillRepository sets the skill repository surface override.
@@ -161,6 +174,14 @@ func (p Patch) ApplyTools(base []tool.Tool) ([]tool.Tool, bool) {
 	return appendTools(base, p.tools.append), true
 }
 
+// ToolDeclarations returns model-facing tool declaration overrides.
+func (p Patch) ToolDeclarations() ([]tool.Declaration, bool) {
+	if !p.toolDeclarations.set {
+		return nil, false
+	}
+	return cloneToolDeclarations(p.toolDeclarations.value), true
+}
+
 // SkillRepository returns the skill repository surface override.
 func (p Patch) SkillRepository() (skill.Repository, bool) {
 	return p.skillRepo.value, p.skillRepo.set
@@ -180,6 +201,7 @@ func (p Patch) IsEmpty() bool {
 		!p.model.set &&
 		!p.tools.set &&
 		len(p.tools.append) == 0 &&
+		!p.toolDeclarations.set &&
 		!p.skillRepo.set &&
 		!p.suppressSubAgentTransfer
 }
@@ -214,6 +236,12 @@ func (p Patch) Merge(other Patch) Patch {
 			cloneTools(other.tools.append)...,
 		)
 	}
+	if other.toolDeclarations.set {
+		out.toolDeclarations = toolDeclarationSlot{
+			set:   true,
+			value: cloneToolDeclarations(other.toolDeclarations.value),
+		}
+	}
 	if other.skillRepo.set {
 		out.skillRepo = other.skillRepo
 	}
@@ -237,6 +265,10 @@ func (p Patch) Clone() Patch {
 			set:    p.tools.set,
 			value:  cloneTools(p.tools.value),
 			append: cloneTools(p.tools.append),
+		},
+		toolDeclarations: toolDeclarationSlot{
+			set:   p.toolDeclarations.set,
+			value: cloneToolDeclarations(p.toolDeclarations.value),
 		},
 		skillRepo:                p.skillRepo,
 		suppressSubAgentTransfer: p.suppressSubAgentTransfer,
@@ -304,6 +336,22 @@ func RootNodeID(cfgs map[string]any, fallback string) string {
 	return nodeID
 }
 
+// WithToolSurfaceTracing enables PromptIter per-tool surface tracing.
+func WithToolSurfaceTracing(cfgs map[string]any) map[string]any {
+	out := copyConfigs(cfgs)
+	out[toolSurfaceTraceConfigsKey] = true
+	return out
+}
+
+// ToolSurfaceTracingEnabled reports whether PromptIter per-tool surface tracing is enabled.
+func ToolSurfaceTracingEnabled(cfgs map[string]any) bool {
+	if cfgs == nil {
+		return false
+	}
+	enabled, ok := cfgs[toolSurfaceTraceConfigsKey].(bool)
+	return ok && enabled
+}
+
 type nodePatches map[string]Patch
 
 func nodePatchesFromConfigs(cfgs map[string]any) nodePatches {
@@ -362,6 +410,10 @@ func cloneTools(in []tool.Tool) []tool.Tool {
 		return nil
 	}
 	return append([]tool.Tool(nil), in...)
+}
+
+func cloneToolDeclarations(in []tool.Declaration) []tool.Declaration {
+	return append([]tool.Declaration(nil), in...)
 }
 
 func appendTools(base []tool.Tool, appended []tool.Tool) []tool.Tool {

--- a/internal/surfacepatch/patch_test.go
+++ b/internal/surfacepatch/patch_test.go
@@ -148,6 +148,35 @@ func TestPatch_TracksExplicitZeroValues(t *testing.T) {
 	require.Nil(t, repo)
 }
 
+func TestPatch_TracksExplicitToolDeclarations(t *testing.T) {
+	var patch Patch
+	declarations, ok := patch.ToolDeclarations()
+	require.False(t, ok)
+	require.Nil(t, declarations)
+	patch.SetToolDeclarations(nil)
+	declarations, ok = patch.ToolDeclarations()
+	require.True(t, ok)
+	require.Nil(t, declarations)
+	require.False(t, patch.IsEmpty())
+	var first Patch
+	first.SetToolDeclarations([]tool.Declaration{
+		{Name: "lookup", Description: "old"},
+	})
+	var second Patch
+	second.SetToolDeclarations([]tool.Declaration{
+		{Name: "lookup", Description: "new"},
+	})
+	cfgs := WithPatch(nil, "root", first)
+	cfgs = WithPatch(cfgs, "root", second)
+	stored, ok := PatchForNode(cfgs, "root")
+	require.True(t, ok)
+	declarations, ok = stored.ToolDeclarations()
+	require.True(t, ok)
+	require.Equal(t, []tool.Declaration{
+		{Name: "lookup", Description: "new"},
+	}, declarations)
+}
+
 func TestPatch_SuppressSubAgentTransferMergesAndClones(t *testing.T) {
 	var base Patch
 	require.True(t, base.IsEmpty())
@@ -226,15 +255,23 @@ func TestPatch_ClonesMutableValues(t *testing.T) {
 		model.NewUserMessage("u1"),
 		model.NewAssistantMessage("a1"),
 	}}
+	declarations := []tool.Declaration{
+		{
+			Name:        "search",
+			Description: "original",
+		},
+	}
 
 	var patch Patch
 	patch.SetFewShot(examples)
 	patch.SetModel(modelValue)
 	patch.SetTools(tools)
+	patch.SetToolDeclarations(declarations)
 	patch.SetSkillRepository(repo)
 
 	examples[0][0].Content = "changed"
 	tools[0] = dummyTool{name: "changed"}
+	declarations[0].Name = "changed"
 
 	gotExamples, ok := patch.FewShot()
 	require.True(t, ok)
@@ -245,6 +282,25 @@ func TestPatch_ClonesMutableValues(t *testing.T) {
 	require.True(t, ok)
 	require.Len(t, gotTools, 1)
 	require.Equal(t, "first", gotTools[0].Declaration().Name)
+
+	gotDeclarations, ok := patch.ToolDeclarations()
+	require.True(t, ok)
+	require.Len(t, gotDeclarations, 1)
+	require.Equal(t, "search", gotDeclarations[0].Name)
+	gotDeclarations[0].Name = "returned"
+	gotDeclarations, ok = patch.ToolDeclarations()
+	require.True(t, ok)
+	require.Len(t, gotDeclarations, 1)
+	require.Equal(t, "search", gotDeclarations[0].Name)
+	clonedDeclarations, ok := patch.Clone().ToolDeclarations()
+	require.True(t, ok)
+	require.Len(t, clonedDeclarations, 1)
+	require.Equal(t, "search", clonedDeclarations[0].Name)
+	var merged Patch
+	mergedDeclarations, ok := merged.Merge(patch).ToolDeclarations()
+	require.True(t, ok)
+	require.Len(t, mergedDeclarations, 1)
+	require.Equal(t, "search", mergedDeclarations[0].Name)
 
 	gotModel, ok := patch.Model()
 	require.True(t, ok)
@@ -294,6 +350,19 @@ func TestRootNodeID_UsesStoredValueAndFallsBack(t *testing.T) {
 		"fallback",
 		RootNodeID(map[string]any{rootNodeIDConfigsKey: 123}, "fallback"),
 	)
+}
+
+func TestToolSurfaceTracingEnabled(t *testing.T) {
+	cfgs := map[string]any{"keep": "value"}
+	require.False(t, ToolSurfaceTracingEnabled(nil))
+	require.False(t, ToolSurfaceTracingEnabled(cfgs))
+	require.False(t, ToolSurfaceTracingEnabled(map[string]any{
+		toolSurfaceTraceConfigsKey: "true",
+	}))
+	got := WithToolSurfaceTracing(cfgs)
+	require.Equal(t, "value", got["keep"])
+	require.True(t, ToolSurfaceTracingEnabled(got))
+	require.False(t, ToolSurfaceTracingEnabled(cfgs))
 }
 
 func TestPatchForNode_ReadsMapStringPatchConfigs(t *testing.T) {

--- a/internal/tool/tool_test.go
+++ b/internal/tool/tool_test.go
@@ -86,6 +86,61 @@ func (m *metadataPolicyTool) CheckPermission(
 	return m.decision, nil
 }
 
+type declarationWrapperTool struct {
+	base tool.Tool
+}
+
+func (d *declarationWrapperTool) Declaration() *tool.Declaration {
+	return &tool.Declaration{Name: "wrapped"}
+}
+
+func (d *declarationWrapperTool) originalTool() tool.Tool {
+	return d.base
+}
+
+type callableOnlyTool struct {
+	decl       *tool.Declaration
+	callResult any
+}
+
+func (c *callableOnlyTool) Declaration() *tool.Declaration {
+	return c.decl
+}
+
+func (c *callableOnlyTool) Call(context.Context, []byte) (any, error) {
+	return c.callResult, nil
+}
+
+type streamOnlyTool struct {
+	decl   *tool.Declaration
+	stream *tool.Stream
+}
+
+func (s *streamOnlyTool) Declaration() *tool.Declaration {
+	return s.decl
+}
+
+func (s *streamOnlyTool) StreamableCall(context.Context, []byte) (*tool.StreamReader, error) {
+	if s.stream == nil {
+		s.stream = tool.NewStream(1)
+	}
+	return s.stream.Reader, nil
+}
+
+type nonStreamInnerTool struct {
+	*fakeTool
+}
+
+func (n *nonStreamInnerTool) StreamInner() bool {
+	return false
+}
+
+type nilDeclarationTool struct{}
+
+func (nilDeclarationTool) Declaration() *tool.Declaration {
+	return nil
+}
+
 // fakeToolSet implements tool.ToolSet.
 type fakeToolSet struct {
 	name   string
@@ -227,6 +282,127 @@ func TestNamedTool_MetadataAndPermissionDelegation(t *testing.T) {
 	decision, err = plain.CheckPermission(ctx, &tool.PermissionRequest{})
 	require.NoError(t, err)
 	require.Equal(t, tool.PermissionActionAllow, decision.Action)
+}
+
+func TestNewUnprefixedNamedTool(t *testing.T) {
+	base := &simpleTool{name: "raw", desc: "raw tool"}
+	named := NewUnprefixedNamedTool(base)
+	require.Same(t, base, named.Original())
+	require.Equal(t, "raw", named.Declaration().Name)
+	require.Equal(t, "", named.ToolSetName())
+	require.Same(t, base, ResolveSemantic(named))
+}
+
+func TestResolveDeclarationAndSemantic(t *testing.T) {
+	base := &simpleTool{name: "raw"}
+	named := NewNamedToolSet(&fakeToolSet{
+		name:  "set",
+		tools: []tool.Tool{base},
+	}).Tools(context.Background())[0]
+	wrapped := &declarationWrapperTool{base: named}
+	require.Same(t, named, ResolveDeclaration(wrapped))
+	require.Same(t, base, ResolveSemantic(wrapped))
+	require.Nil(t, ResolveDeclaration(nil))
+	require.Nil(t, ResolveSemantic(nil))
+}
+
+func TestApplyDeclarationsOverlaysMatchingTools(t *testing.T) {
+	base := []tool.Tool{
+		&simpleTool{name: "plain", desc: "plain description"},
+		nilDeclarationTool{},
+		nil,
+	}
+	declarations := []tool.Declaration{
+		{Name: ""},
+		{Name: "plain", Description: "patched description"},
+		{Name: "missing", Description: "missing description"},
+	}
+	got := ApplyDeclarations(base, declarations)
+	require.Len(t, got, 3)
+	require.Equal(t, "patched description", got[0].Declaration().Description)
+	require.Same(t, base[0], ResolveDeclaration(got[0]))
+	require.Same(t, base[0], ResolveSemantic(got[0]))
+	require.Equal(t, base[1], got[1])
+	require.Nil(t, got[2])
+	require.Equal(t, base, ApplyDeclarations(base, nil))
+	require.Equal(t, base, ApplyDeclarations(base, []tool.Declaration{{Name: ""}}))
+	require.Nil(t, ApplyDeclarations(nil, declarations))
+}
+
+func TestApplyDeclarationsPreservesCallableAndStreamableCapabilities(t *testing.T) {
+	ctx := context.Background()
+	callableBase := &callableOnlyTool{
+		decl:       &tool.Declaration{Name: "callable", Description: "old"},
+		callResult: "called",
+	}
+	streamBase := &streamOnlyTool{
+		decl: &tool.Declaration{Name: "streamable", Description: "old"},
+	}
+	bothBase := &fakeTool{
+		decl:       &tool.Declaration{Name: "both", Description: "old"},
+		callResult: "both-called",
+	}
+	base := []tool.Tool{callableBase, streamBase, bothBase}
+	got := ApplyDeclarations(base, []tool.Declaration{
+		{Name: "callable", Description: "new callable"},
+		{Name: "streamable", Description: "new streamable"},
+		{Name: "both", Description: "new both"},
+	})
+	require.Equal(t, "new callable", got[0].Declaration().Description)
+	callable, ok := got[0].(tool.CallableTool)
+	require.True(t, ok)
+	callResult, err := callable.Call(ctx, nil)
+	require.NoError(t, err)
+	require.Equal(t, "called", callResult)
+	_, ok = got[0].(tool.StreamableTool)
+	require.False(t, ok)
+	streamable, ok := got[1].(tool.StreamableTool)
+	require.True(t, ok)
+	reader, err := streamable.StreamableCall(ctx, nil)
+	require.NoError(t, err)
+	streamBase.stream.Writer.Send(tool.StreamChunk{Content: "streamed"}, nil)
+	chunk, err := reader.Recv()
+	require.NoError(t, err)
+	require.Equal(t, "streamed", chunk.Content)
+	streamBase.stream.Writer.Close()
+	_, ok = got[1].(tool.CallableTool)
+	require.False(t, ok)
+	bothCallable, ok := got[2].(tool.CallableTool)
+	require.True(t, ok)
+	bothResult, err := bothCallable.Call(ctx, nil)
+	require.NoError(t, err)
+	require.Equal(t, "both-called", bothResult)
+	bothStreamable, ok := got[2].(tool.StreamableTool)
+	require.True(t, ok)
+	bothReader, err := bothStreamable.StreamableCall(ctx, nil)
+	require.NoError(t, err)
+	bothBase.stream.Writer.Send(tool.StreamChunk{Content: "both-streamed"}, nil)
+	bothChunk, err := bothReader.Recv()
+	require.NoError(t, err)
+	require.Equal(t, "both-streamed", bothChunk.Content)
+	bothBase.stream.Writer.Close()
+}
+
+func TestApplyDeclarationsHonorsStreamInnerPreference(t *testing.T) {
+	base := &nonStreamInnerTool{
+		fakeTool: &fakeTool{
+			decl:       &tool.Declaration{Name: "search", Description: "old"},
+			callResult: "called",
+		},
+	}
+	got := ApplyDeclarations([]tool.Tool{NewUnprefixedNamedTool(base)}, []tool.Declaration{
+		{Name: "search", Description: "new"},
+	})
+	require.Len(t, got, 1)
+	require.Equal(t, "new", got[0].Declaration().Description)
+	_, streamable := got[0].(tool.StreamableTool)
+	require.False(t, streamable)
+	callable, ok := got[0].(tool.CallableTool)
+	require.True(t, ok)
+	result, err := callable.Call(context.Background(), nil)
+	require.NoError(t, err)
+	require.Equal(t, "called", result)
+	require.Same(t, base, ResolveSemantic(got[0]))
 }
 
 func TestGenerateJSONSchema_Primitives(t *testing.T) {

--- a/internal/tool/toolset.go
+++ b/internal/tool/toolset.go
@@ -78,6 +78,171 @@ func NewUnprefixedNamedTool(t tool.Tool) *NamedTool {
 	return &NamedTool{original: t}
 }
 
+type declarationWrapper interface {
+	originalTool() tool.Tool
+}
+
+// ApplyDeclarations overlays model-facing declarations onto matching tools.
+func ApplyDeclarations(base []tool.Tool, declarations []tool.Declaration) []tool.Tool {
+	if len(base) == 0 || len(declarations) == 0 {
+		return base
+	}
+	declarationByName := make(map[string]tool.Declaration, len(declarations))
+	for _, declaration := range declarations {
+		if declaration.Name == "" {
+			continue
+		}
+		declarationByName[declaration.Name] = declaration
+	}
+	if len(declarationByName) == 0 {
+		return base
+	}
+	out := make([]tool.Tool, len(base))
+	for i, candidate := range base {
+		out[i] = candidate
+		name := toolName(candidate)
+		if name == "" {
+			continue
+		}
+		declaration, ok := declarationByName[name]
+		if !ok {
+			continue
+		}
+		out[i] = wrapDeclarationTool(candidate, declaration)
+	}
+	return out
+}
+
+// ResolveDeclaration unwraps framework declaration overlays.
+func ResolveDeclaration(t tool.Tool) tool.Tool {
+	switch current := t.(type) {
+	case nil:
+		return nil
+	case declarationWrapper:
+		return ResolveDeclaration(current.originalTool())
+	default:
+		return t
+	}
+}
+
+// ResolveSemantic unwraps framework wrappers for semantic capability checks.
+func ResolveSemantic(t tool.Tool) tool.Tool {
+	switch current := t.(type) {
+	case nil:
+		return nil
+	case declarationWrapper:
+		return ResolveSemantic(current.originalTool())
+	case *NamedTool:
+		return ResolveSemantic(current.Original())
+	default:
+		return t
+	}
+}
+
+type declarationTool struct {
+	decl tool.Declaration
+	base tool.Tool
+}
+
+func (t *declarationTool) Declaration() *tool.Declaration {
+	return &t.decl
+}
+
+func (t *declarationTool) originalTool() tool.Tool {
+	return t.base
+}
+
+type callableDeclarationTool struct {
+	*declarationTool
+	callable tool.CallableTool
+}
+
+func (t *callableDeclarationTool) Call(ctx context.Context, jsonArgs []byte) (any, error) {
+	return t.callable.Call(ctx, jsonArgs)
+}
+
+type streamableDeclarationTool struct {
+	*declarationTool
+	streamable tool.StreamableTool
+}
+
+func (t *streamableDeclarationTool) StreamableCall(
+	ctx context.Context,
+	jsonArgs []byte,
+) (*tool.StreamReader, error) {
+	return t.streamable.StreamableCall(ctx, jsonArgs)
+}
+
+type callableStreamableDeclarationTool struct {
+	*declarationTool
+	callable   tool.CallableTool
+	streamable tool.StreamableTool
+}
+
+func (t *callableStreamableDeclarationTool) Call(
+	ctx context.Context,
+	jsonArgs []byte,
+) (any, error) {
+	return t.callable.Call(ctx, jsonArgs)
+}
+
+func (t *callableStreamableDeclarationTool) StreamableCall(
+	ctx context.Context,
+	jsonArgs []byte,
+) (*tool.StreamReader, error) {
+	return t.streamable.StreamableCall(ctx, jsonArgs)
+}
+
+func wrapDeclarationTool(base tool.Tool, declaration tool.Declaration) tool.Tool {
+	wrapped := &declarationTool{
+		decl: declaration,
+		base: base,
+	}
+	callable, hasCallable := base.(tool.CallableTool)
+	streamable, hasStreamable := base.(tool.StreamableTool)
+	hasStreamable = hasStreamable && isReallyStreamable(base)
+	switch {
+	case hasCallable && hasStreamable:
+		return &callableStreamableDeclarationTool{
+			declarationTool: wrapped,
+			callable:        callable,
+			streamable:      streamable,
+		}
+	case hasCallable:
+		return &callableDeclarationTool{
+			declarationTool: wrapped,
+			callable:        callable,
+		}
+	case hasStreamable:
+		return &streamableDeclarationTool{
+			declarationTool: wrapped,
+			streamable:      streamable,
+		}
+	default:
+		return wrapped
+	}
+}
+
+func isReallyStreamable(t tool.Tool) bool {
+	candidate := ResolveSemantic(t)
+	if pref, ok := candidate.(interface{ StreamInner() bool }); ok && !pref.StreamInner() {
+		return false
+	}
+	_, ok := candidate.(tool.StreamableTool)
+	return ok
+}
+
+func toolName(tl tool.Tool) string {
+	if tl == nil {
+		return ""
+	}
+	decl := tl.Declaration()
+	if decl == nil {
+		return ""
+	}
+	return decl.Name
+}
+
 // Declaration returns the tool declaration with a prefixed name.
 func (t *NamedTool) Declaration() *tool.Declaration {
 	decl := t.original.Declaration()

--- a/internal/toolsurface/toolsurface.go
+++ b/internal/toolsurface/toolsurface.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
+	itool "trpc.group/trpc-go/trpc-agent-go/internal/tool"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
 
@@ -151,7 +152,7 @@ func ApplyToolFilter(
 		}
 
 		// User tool: apply the filter function.
-		if opts.ToolFilter(ctx, t) {
+		if opts.ToolFilter(ctx, itool.ResolveDeclaration(t)) {
 			filtered = append(filtered, t)
 		}
 	}

--- a/internal/toolsurface/toolsurface_test.go
+++ b/internal/toolsurface/toolsurface_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/event"
+	itool "trpc.group/trpc-go/trpc-agent-go/internal/tool"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
 
@@ -24,6 +25,97 @@ type stubSurfaceTool struct {
 
 func (s stubSurfaceTool) Declaration() *tool.Declaration {
 	return s.decl
+}
+
+type stubCallableSurfaceTool struct {
+	stubSurfaceTool
+	called bool
+}
+
+func (s *stubCallableSurfaceTool) Call(context.Context, []byte) (any, error) {
+	s.called = true
+	return "called", nil
+}
+
+type stubStreamableSurfaceTool struct {
+	stubSurfaceTool
+	called bool
+}
+
+func (s *stubStreamableSurfaceTool) StreamableCall(
+	context.Context,
+	[]byte,
+) (*tool.StreamReader, error) {
+	s.called = true
+	stream := tool.NewStream(1)
+	stream.Writer.Close()
+	return stream.Reader, nil
+}
+
+type semanticSurfaceTool struct {
+	stubCallableSurfaceTool
+}
+
+func (s *semanticSurfaceTool) CheckPermission(
+	context.Context,
+	*tool.PermissionRequest,
+) (tool.PermissionDecision, error) {
+	return tool.DenyPermission("blocked"), nil
+}
+
+func (s *semanticSurfaceTool) SkipSummarization() bool { return true }
+
+func (s *semanticSurfaceTool) LongRunning() bool { return true }
+
+func (s *semanticSurfaceTool) StreamInner() bool { return false }
+
+func (s *semanticSurfaceTool) InnerTextMode() tool.InnerTextMode {
+	return tool.InnerTextModeExclude
+}
+
+func (s *semanticSurfaceTool) ToolSetName() string { return "toolset" }
+
+func (s *semanticSurfaceTool) ToolMetadata() tool.ToolMetadata {
+	return tool.ToolMetadata{
+		ReadOnly:        true,
+		ConcurrencySafe: true,
+		MaxResultSize:   42,
+	}
+}
+
+func (s *semanticSurfaceTool) ShouldDefer(context.Context) bool { return true }
+
+func (s *semanticSurfaceTool) StateDeltaForInvocation(
+	*agent.Invocation,
+	string,
+	[]byte,
+	[]byte,
+) map[string][]byte {
+	return map[string][]byte{"invocation": []byte("delta")}
+}
+
+type namedLikeSurfaceTool struct {
+	original tool.Tool
+	decl     *tool.Declaration
+}
+
+func (n *namedLikeSurfaceTool) Declaration() *tool.Declaration {
+	return n.decl
+}
+
+func (n *namedLikeSurfaceTool) Original() tool.Tool {
+	return n.original
+}
+
+func (n *namedLikeSurfaceTool) Call(ctx context.Context, jsonArgs []byte) (any, error) {
+	return n.original.(tool.CallableTool).Call(ctx, jsonArgs)
+}
+
+func (n *namedLikeSurfaceTool) StreamableCall(
+	context.Context,
+	[]byte,
+) (*tool.StreamReader, error) {
+	return nil, nil
 }
 
 type stubSurfaceAgent struct {
@@ -142,6 +234,137 @@ func TestEffectiveWithExternal_AppendsAndClassifiesRunOptionTools(t *testing.T) 
 		"external": true,
 	}, userToolNames)
 	require.Equal(t, map[string]bool{"external": true}, externalNames)
+}
+
+func TestApplyDeclarations_OverridesDeclarationAndPreservesCall(t *testing.T) {
+	base := &stubCallableSurfaceTool{
+		stubSurfaceTool: stubSurfaceTool{decl: &tool.Declaration{
+			Name:        "search",
+			Description: "old",
+			InputSchema: &tool.Schema{
+				Type: "object",
+				Properties: map[string]*tool.Schema{
+					"query": {Type: "string", Description: "old query"},
+				},
+			},
+		}},
+	}
+	patched := itool.ApplyDeclarations([]tool.Tool{base}, []tool.Declaration{{
+		Name:        "search",
+		Description: "new",
+		InputSchema: &tool.Schema{
+			Type: "object",
+			Properties: map[string]*tool.Schema{
+				"query": {Type: "string", Description: "new query"},
+			},
+		},
+	}})
+	require.Len(t, patched, 1)
+	require.Equal(t, "new", patched[0].Declaration().Description)
+	require.Equal(t, "new query", patched[0].Declaration().InputSchema.Properties["query"].Description)
+	callable, ok := patched[0].(tool.CallableTool)
+	require.True(t, ok)
+	result, err := callable.Call(context.Background(), nil)
+	require.NoError(t, err)
+	require.Equal(t, "called", result)
+	require.True(t, base.called)
+}
+
+func TestApplyDeclarations_PreservesStreamableTool(t *testing.T) {
+	base := &stubStreamableSurfaceTool{
+		stubSurfaceTool: stubSurfaceTool{decl: &tool.Declaration{Name: "stream"}},
+	}
+	patched := itool.ApplyDeclarations([]tool.Tool{base}, []tool.Declaration{{
+		Name:        "stream",
+		Description: "patched",
+	}})
+	streamable, ok := patched[0].(tool.StreamableTool)
+	require.True(t, ok)
+	reader, err := streamable.StreamableCall(context.Background(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, reader)
+	require.True(t, base.called)
+}
+
+func TestApplyDeclarations_DoesNotUnwrapNamedLikeToolSemantics(t *testing.T) {
+	original := &semanticSurfaceTool{
+		stubCallableSurfaceTool: stubCallableSurfaceTool{
+			stubSurfaceTool: stubSurfaceTool{decl: &tool.Declaration{Name: "named"}},
+		},
+	}
+	base := &namedLikeSurfaceTool{
+		original: original,
+		decl:     &tool.Declaration{Name: "named"},
+	}
+	patched := itool.ApplyDeclarations([]tool.Tool{base}, []tool.Declaration{{
+		Name:        "named",
+		Description: "patched",
+	}})
+	_, ok := patched[0].(tool.StreamableTool)
+	require.True(t, ok)
+	callable, ok := patched[0].(tool.CallableTool)
+	require.True(t, ok)
+	result, err := callable.Call(context.Background(), nil)
+	require.NoError(t, err)
+	require.Equal(t, "called", result)
+	type skipper interface{ SkipSummarization() bool }
+	type longRunner interface{ LongRunning() bool }
+	type innerTextMode interface{ InnerTextMode() tool.InnerTextMode }
+	type toolSetNamer interface{ ToolSetName() string }
+	type stateDeltaForInvocation interface {
+		StateDeltaForInvocation(*agent.Invocation, string, []byte, []byte) map[string][]byte
+	}
+	_, ok = patched[0].(skipper)
+	require.False(t, ok)
+	_, ok = patched[0].(longRunner)
+	require.False(t, ok)
+	_, ok = patched[0].(innerTextMode)
+	require.False(t, ok)
+	_, ok = patched[0].(toolSetNamer)
+	require.False(t, ok)
+	require.Equal(t, tool.ToolMetadata{}, tool.MetadataOf(patched[0]))
+	require.False(t, tool.ShouldDefer(context.Background(), patched[0]))
+	_, ok = patched[0].(stateDeltaForInvocation)
+	require.False(t, ok)
+}
+
+func TestApplyDeclarations_DoesNotExposeOptionalRuntimeInterfaces(t *testing.T) {
+	base := &semanticSurfaceTool{
+		stubCallableSurfaceTool: stubCallableSurfaceTool{
+			stubSurfaceTool: stubSurfaceTool{
+				decl: &tool.Declaration{Name: "semantic"},
+			},
+		},
+	}
+	patched := itool.ApplyDeclarations([]tool.Tool{base}, []tool.Declaration{{
+		Name:        "semantic",
+		Description: "patched",
+	}})
+	type skipper interface{ SkipSummarization() bool }
+	type longRunner interface{ LongRunning() bool }
+	type streamInner interface{ StreamInner() bool }
+	type innerTextMode interface{ InnerTextMode() tool.InnerTextMode }
+	type toolSetNamer interface{ ToolSetName() string }
+	type stateDeltaForInvocation interface {
+		StateDeltaForInvocation(*agent.Invocation, string, []byte, []byte) map[string][]byte
+	}
+	_, ok := patched[0].(skipper)
+	require.False(t, ok)
+	_, ok = patched[0].(longRunner)
+	require.False(t, ok)
+	_, ok = patched[0].(streamInner)
+	require.False(t, ok)
+	_, ok = patched[0].(innerTextMode)
+	require.False(t, ok)
+	_, ok = patched[0].(toolSetNamer)
+	require.False(t, ok)
+	require.Equal(t, base, itool.ResolveDeclaration(patched[0]))
+	require.Equal(t, tool.ToolMetadata{}, tool.MetadataOf(patched[0]))
+	require.False(t, tool.ShouldDefer(context.Background(), patched[0]))
+	_, ok = patched[0].(tool.PermissionChecker)
+	require.False(t, ok)
+	_, ok = patched[0].(stateDeltaForInvocation)
+	require.False(t, ok)
 }
 
 func surfaceTool(name string) tool.Tool {


### PR DESCRIPTION
This follows #2023 and carries runtime plumbing for per-tool applied-surface tracing and model-facing tool declaration overlays without adding PromptIter optimization behavior.