### PR TITLE
session/postgres: surface init failures as errors and fail on missing unique index

### DIFF
--- a/session/postgres/init.go
+++ b/session/postgres/init.go
@@ -359,22 +359,25 @@ func parseTableName(fullTableName string) (schema, tableName string) {
 	return "public", fullTableName
 }
 
-// initDB initializes the database schema
-func (s *Service) initDB(ctx context.Context) {
+// initDB initializes the database schema. It returns an error instead of
+// panicking so NewService can surface a startup failure (e.g. the runtime
+// account lacks DDL privilege) rather than crashing the process.
+func (s *Service) initDB(ctx context.Context) error {
 	// Create tables
 	if err := createTables(ctx, s.pgClient, s.opts.schema, s.opts.tablePrefix); err != nil {
-		panic(fmt.Sprintf("create tables failed: %v", err))
+		return fmt.Errorf("create tables failed: %w", err)
 	}
 
 	// Create indexes
 	if err := createIndexes(ctx, s.pgClient, s.opts.schema, s.opts.tablePrefix); err != nil {
-		panic(fmt.Sprintf("create indexes failed: %v", err))
+		return fmt.Errorf("create indexes failed: %w", err)
 	}
 
 	// Verify schema
 	if err := s.verifySchema(ctx); err != nil {
-		panic(fmt.Sprintf("schema verification failed: %v", err))
+		return fmt.Errorf("schema verification failed: %w", err)
 	}
+	return nil
 }
 
 // createTables creates all required tables with the given prefix.
@@ -424,14 +427,10 @@ func (s *Service) verifySchema(ctx context.Context) error {
 			return fmt.Errorf("verify columns for table %s failed: %w", fullTableName, err)
 		}
 
-		// Verify indexes
+		// Verify indexes. A missing UNIQUE index is fatal (uniqueness is no longer
+		// enforced); other index drift is logged as a warning inside verifyIndexes.
 		if err := s.verifyIndexes(ctx, fullTableName, schema.indexes); err != nil {
-			log.WarnfContext(
-				ctx,
-				"verify indexes for table %s failed (non-fatal): %v",
-				fullTableName,
-				err,
-			)
+			return fmt.Errorf("verify indexes for table %s failed: %w", fullTableName, err)
 		}
 	}
 
@@ -511,27 +510,48 @@ func (s *Service) verifyColumns(ctx context.Context, fullTableName string, expec
 // verifyIndexes verifies that table indexes exist
 func (s *Service) verifyIndexes(ctx context.Context, fullTableName string, expectedIndexes []tableIndex) error {
 	schema, tableName := parseTableName(fullTableName)
-	// Get actual indexes from database
-	actualIndexes := make(map[string]bool)
+	// Get each index's uniqueness and full definition. Verifying the columns and
+	// partial predicate (via pg_get_indexdef), not just the name and uniqueness,
+	// catches a same-name index that is non-unique, on the wrong columns, or
+	// missing the `deleted_at IS NULL` predicate — any of which would leave the
+	// uniqueness contract unenforced.
+	type indexInfo struct {
+		unique bool
+		def    string
+	}
+	actual := make(map[string]indexInfo)
 	err := s.pgClient.Query(ctx, func(rows *sql.Rows) error {
 		for rows.Next() {
-			var indexName string
-			if err := rows.Scan(&indexName); err != nil {
+			var name, def string
+			var isUnique bool
+			if err := rows.Scan(&name, &isUnique, &def); err != nil {
 				return err
 			}
-			actualIndexes[indexName] = true
+			actual[name] = indexInfo{unique: isUnique, def: def}
 		}
 		return nil
-	}, `SELECT indexname
-		FROM pg_indexes
-		WHERE schemaname = $1
-		AND tablename = $2`, schema, tableName)
+	}, `SELECT i.relname, ix.indisunique, pg_get_indexdef(i.oid)
+		FROM pg_class t
+		JOIN pg_namespace n ON n.oid = t.relnamespace
+		JOIN pg_index ix ON t.oid = ix.indrelid
+		JOIN pg_class i ON i.oid = ix.indexrelid
+		WHERE n.nspname = $1 AND t.relname = $2`, schema, tableName)
 
 	if err != nil {
 		return fmt.Errorf("query indexes failed: %w", err)
 	}
 
-	// Check each expected index
+	// normalizeIndexDef lowercases, strips quotes and collapses whitespace so the
+	// expected column list / predicate can be matched against pg_get_indexdef's
+	// normalized output without being tripped up by quoting or spacing.
+	normalizeIndexDef := func(s string) string {
+		return strings.ToLower(strings.Join(strings.Fields(strings.ReplaceAll(s, `"`, "")), " "))
+	}
+
+	// Check each expected index. The required partial UNIQUE index must exist, be
+	// unique, cover the expected columns, and carry the `deleted_at IS NULL`
+	// predicate; any deviation is fatal. Other missing indexes are only warnings.
+	var invalidUnique []string
 	for _, expected := range expectedIndexes {
 		// Use sqldb.BuildIndexNameWithSchema to construct the expected index.
 		expectedIndexName := sqldb.BuildIndexNameWithSchema(
@@ -541,16 +561,39 @@ func (s *Service) verifyIndexes(ctx context.Context, fullTableName string, expec
 			expected.suffix,
 		)
 
-		if !actualIndexes[expectedIndexName] {
-			log.WarnfContext(
-				ctx,
-				"index %s on table %s is missing",
-				expectedIndexName,
-				fullTableName,
-			)
+		info, exists := actual[expectedIndexName]
+
+		if expected.suffix != sqldb.IndexSuffixUniqueActive {
+			if !exists {
+				log.WarnfContext(ctx, "index %s on table %s is missing", expectedIndexName, fullTableName)
+			}
+			continue
+		}
+
+		switch {
+		case !exists:
+			log.ErrorfContext(ctx, "UNIQUE index %s on table %s is missing; uniqueness is NOT enforced",
+				expectedIndexName, fullTableName)
+			invalidUnique = append(invalidUnique, expectedIndexName)
+		case !info.unique:
+			log.ErrorfContext(ctx, "index %s on table %s exists but is NOT unique; uniqueness is NOT enforced",
+				expectedIndexName, fullTableName)
+			invalidUnique = append(invalidUnique, expectedIndexName)
+		default:
+			def := normalizeIndexDef(info.def)
+			wantCols := normalizeIndexDef("(" + strings.Join(expected.columns, ", ") + ")")
+			if !strings.Contains(def, wantCols) || !strings.Contains(def, "deleted_at is null") {
+				log.ErrorfContext(ctx, "UNIQUE index %s on table %s does not match the expected definition "+
+					"(want columns %v with predicate deleted_at IS NULL); uniqueness may not be enforced as "+
+					"intended. Actual: %s", expectedIndexName, fullTableName, expected.columns, info.def)
+				invalidUnique = append(invalidUnique, expectedIndexName)
+			}
 		}
 	}
 
+	if len(invalidUnique) > 0 {
+		return fmt.Errorf("required unique index(es) invalid on table %s: %v", fullTableName, invalidUnique)
+	}
 	return nil
 }
 

--- a/session/postgres/init_schema_test.go
+++ b/session/postgres/init_schema_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/internal/session/sqldb"
 )
 
 // TestTableExists_TableFound tests tableExists when table exists
@@ -223,12 +224,14 @@ func TestVerifyIndexes_Success(t *testing.T) {
 
 	s := createTestService(t, db)
 
-	// Mock pg_indexes query
-	rows := sqlmock.NewRows([]string{"indexname"}).
-		AddRow("idx_session_states_unique_active").
-		AddRow("idx_session_states_expires")
+	// Mock index query (name + indisunique + definition)
+	rows := sqlmock.NewRows([]string{"relname", "indisunique", "indexdef"}).
+		AddRow("idx_session_states_unique_active", true,
+			"CREATE UNIQUE INDEX idx_session_states_unique_active ON public.session_states USING btree (app_name, user_id, session_id) WHERE (deleted_at IS NULL)").
+		AddRow("idx_session_states_expires", false,
+			"CREATE INDEX idx_session_states_expires ON public.session_states USING btree (expires_at) WHERE (expires_at IS NOT NULL)")
 
-	mock.ExpectQuery("SELECT indexname").
+	mock.ExpectQuery("indisunique, pg_get_indexdef").
 		WithArgs("public", "session_states").
 		WillReturnRows(rows)
 
@@ -250,12 +253,13 @@ func TestVerifyIndexes_MissingIndex(t *testing.T) {
 
 	s := createTestService(t, db)
 
-	// Mock pg_indexes query - missing one index
-	rows := sqlmock.NewRows([]string{"indexname"}).
-		AddRow("idx_session_states_unique_active")
+	// Mock index query - the unique index exists and is valid; the TTL one is missing.
+	rows := sqlmock.NewRows([]string{"relname", "indisunique", "indexdef"}).
+		AddRow("idx_session_states_unique_active", true,
+			"CREATE UNIQUE INDEX idx_session_states_unique_active ON public.session_states USING btree (app_name, user_id, session_id) WHERE (deleted_at IS NULL)")
 	// idx_session_states_expires is missing
 
-	mock.ExpectQuery("SELECT indexname").
+	mock.ExpectQuery("indisunique, pg_get_indexdef").
 		WithArgs("public", "session_states").
 		WillReturnRows(rows)
 
@@ -270,6 +274,258 @@ func TestVerifyIndexes_MissingIndex(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+// TestVerifyIndexes_MissingUniqueIndex tests that a missing UNIQUE index is fatal.
+func TestVerifyIndexes_MissingUniqueIndex(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db)
+
+	// Mock index query - the unique index is missing (only the TTL one exists).
+	rows := sqlmock.NewRows([]string{"relname", "indisunique", "indexdef"}).
+		AddRow("idx_session_states_expires", false,
+			"CREATE INDEX idx_session_states_expires ON public.session_states USING btree (expires_at) WHERE (expires_at IS NOT NULL)")
+
+	mock.ExpectQuery("indisunique, pg_get_indexdef").
+		WithArgs("public", "session_states").
+		WillReturnRows(rows)
+
+	expectedIndexes := []tableIndex{
+		{"session_states", "unique_active", []string{"app_name", "user_id", "session_id"}}, // missing -> fatal
+		{"session_states", "expires", []string{"expires_at"}},
+	}
+
+	err = s.verifyIndexes(context.Background(), "session_states", expectedIndexes)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unique index")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestVerifyIndexes_UniqueIndexNotUnique tests that an index with the expected
+// unique_active name which exists but is NOT unique is fatal.
+func TestVerifyIndexes_UniqueIndexNotUnique(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db)
+
+	// The unique_active name exists but the index is NOT unique.
+	rows := sqlmock.NewRows([]string{"relname", "indisunique", "indexdef"}).
+		AddRow("idx_session_states_unique_active", false,
+			"CREATE INDEX idx_session_states_unique_active ON public.session_states USING btree (app_name, user_id, session_id) WHERE (deleted_at IS NULL)").
+		AddRow("idx_session_states_expires", false,
+			"CREATE INDEX idx_session_states_expires ON public.session_states USING btree (expires_at) WHERE (expires_at IS NOT NULL)")
+
+	mock.ExpectQuery("indisunique, pg_get_indexdef").
+		WithArgs("public", "session_states").
+		WillReturnRows(rows)
+
+	expectedIndexes := []tableIndex{
+		{"session_states", "unique_active", []string{"app_name", "user_id", "session_id"}},
+		{"session_states", "expires", []string{"expires_at"}},
+	}
+
+	err = s.verifyIndexes(context.Background(), "session_states", expectedIndexes)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestVerifyIndexes_UniqueIndexWrongDefinition tests that a unique index with the
+// expected name but a definition missing the partial predicate is fatal.
+func TestVerifyIndexes_UniqueIndexWrongDefinition(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db)
+
+	// Unique, right columns, but missing the `deleted_at IS NULL` predicate
+	// (a full unique index instead of the required partial one).
+	rows := sqlmock.NewRows([]string{"relname", "indisunique", "indexdef"}).
+		AddRow("idx_session_states_unique_active", true,
+			"CREATE UNIQUE INDEX idx_session_states_unique_active ON public.session_states USING btree (app_name, user_id, session_id)")
+
+	mock.ExpectQuery("indisunique, pg_get_indexdef").
+		WithArgs("public", "session_states").
+		WillReturnRows(rows)
+
+	expectedIndexes := []tableIndex{
+		{"session_states", "unique_active", []string{"app_name", "user_id", "session_id"}},
+	}
+
+	err = s.verifyIndexes(context.Background(), "session_states", expectedIndexes)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestServiceInitDB_ReturnsErrorOnDDLFailure verifies the Service initDB returns
+// an error (instead of panicking) when a DDL step fails.
+func TestServiceInitDB_ReturnsErrorOnDDLFailure(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db)
+
+	// First CREATE TABLE fails.
+	mock.ExpectExec("CREATE TABLE").WillReturnError(assert.AnError)
+
+	assert.NotPanics(t, func() {
+		err = s.initDB(context.Background())
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create tables failed")
+	require.ErrorIs(t, err, assert.AnError) // %w wrapping preserved
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// restrictToSessionStates overrides the package-level schema definitions to
+// cover only session_states, so initDB/verifySchema tests run deterministically
+// on a single table (no Go map-iteration randomness). Restored via t.Cleanup.
+func restrictToSessionStates(t *testing.T) {
+	t.Helper()
+	origTables, origIndexes, origSchema := tableDefs, indexDefs, expectedSchema
+	t.Cleanup(func() {
+		tableDefs, indexDefs, expectedSchema = origTables, origIndexes, origSchema
+	})
+	for _, td := range origTables {
+		if td.name == sqldb.TableNameSessionStates {
+			tableDefs = []tableDefinition{td}
+			break
+		}
+	}
+	indexDefs = nil
+	for _, id := range origIndexes {
+		if id.table == sqldb.TableNameSessionStates {
+			indexDefs = append(indexDefs, id)
+		}
+	}
+	expectedSchema = map[string]struct {
+		columns []tableColumn
+		indexes []tableIndex
+	}{
+		sqldb.TableNameSessionStates: origSchema[sqldb.TableNameSessionStates],
+	}
+}
+
+// mockSessionStatesColumns queues a verifyColumns response with the expected columns.
+func mockSessionStatesColumns(mock sqlmock.Sqlmock) {
+	colRows := sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable"})
+	for _, c := range expectedSchema[sqldb.TableNameSessionStates].columns {
+		nullable := "NO"
+		if c.nullable {
+			nullable = "YES"
+		}
+		colRows.AddRow(c.name, c.dataType, nullable)
+	}
+	mock.ExpectQuery("SELECT column_name").
+		WithArgs("public", "session_states").
+		WillReturnRows(colRows)
+}
+
+// mockSessionStatesValidIndexes queues a verifyIndexes response with a valid
+// partial unique index plus the TTL index.
+func mockSessionStatesValidIndexes(mock sqlmock.Sqlmock) {
+	mock.ExpectQuery("indisunique, pg_get_indexdef").
+		WithArgs("public", "session_states").
+		WillReturnRows(sqlmock.NewRows([]string{"relname", "indisunique", "indexdef"}).
+			AddRow("idx_session_states_unique_active", true,
+				"CREATE UNIQUE INDEX idx_session_states_unique_active ON public.session_states USING btree (app_name, user_id, session_id) WHERE (deleted_at IS NULL)").
+			AddRow("idx_session_states_expires", false,
+				"CREATE INDEX idx_session_states_expires ON public.session_states USING btree (expires_at) WHERE (expires_at IS NOT NULL)"))
+}
+
+// TestServiceInitDB_Success drives initDB through create + verify to success.
+func TestServiceInitDB_Success(t *testing.T) {
+	restrictToSessionStates(t)
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+	s := createTestService(t, db)
+
+	// createTables (1) + createIndexes (unique + expires).
+	mock.ExpectExec("CREATE TABLE").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("CREATE").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("CREATE").WillReturnResult(sqlmock.NewResult(0, 0))
+	// verifySchema: exists, columns, indexes all valid.
+	mock.ExpectQuery("SELECT EXISTS").
+		WithArgs("public", "session_states").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+	mockSessionStatesColumns(mock)
+	mockSessionStatesValidIndexes(mock)
+
+	require.NoError(t, s.initDB(context.Background()))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestServiceInitDB_CreateIndexesError covers the createIndexes failure path.
+func TestServiceInitDB_CreateIndexesError(t *testing.T) {
+	restrictToSessionStates(t)
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+	s := createTestService(t, db)
+
+	mock.ExpectExec("CREATE TABLE").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("CREATE").WillReturnError(assert.AnError)
+
+	err = s.initDB(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create indexes failed")
+	require.ErrorIs(t, err, assert.AnError) // %w wrapping preserved
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestServiceInitDB_VerifySchemaError covers the verifySchema failure path.
+func TestServiceInitDB_VerifySchemaError(t *testing.T) {
+	restrictToSessionStates(t)
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+	s := createTestService(t, db)
+
+	mock.ExpectExec("CREATE TABLE").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("CREATE").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("CREATE").WillReturnResult(sqlmock.NewResult(0, 0))
+	// verifySchema reports the table as missing.
+	mock.ExpectQuery("SELECT EXISTS").
+		WithArgs("public", "session_states").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+
+	err = s.initDB(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "schema verification failed")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestVerifySchema_IndexVerificationFails covers verifySchema propagating a
+// fatal verifyIndexes error (missing unique index).
+func TestVerifySchema_IndexVerificationFails(t *testing.T) {
+	restrictToSessionStates(t)
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+	s := createTestService(t, db)
+
+	mock.ExpectQuery("SELECT EXISTS").
+		WithArgs("public", "session_states").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+	mockSessionStatesColumns(mock)
+	// verifyIndexes: unique index missing -> fatal, propagated by verifySchema.
+	mock.ExpectQuery("indisunique, pg_get_indexdef").
+		WithArgs("public", "session_states").
+		WillReturnRows(sqlmock.NewRows([]string{"relname", "indisunique", "indexdef"}))
+
+	err = s.verifySchema(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "verify indexes")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 // TestVerifyIndexes_QueryError tests verifyIndexes when query fails
 func TestVerifyIndexes_QueryError(t *testing.T) {
 	db, mock, err := sqlmock.New()
@@ -279,7 +535,7 @@ func TestVerifyIndexes_QueryError(t *testing.T) {
 	s := createTestService(t, db)
 
 	// Mock query error
-	mock.ExpectQuery("SELECT indexname").
+	mock.ExpectQuery("indisunique, pg_get_indexdef").
 		WithArgs("public", "session_states").
 		WillReturnError(assert.AnError)
 

--- a/session/postgres/service.go
+++ b/session/postgres/service.go
@@ -164,7 +164,10 @@ func NewService(options ...ServiceOpt) (*Service, error) {
 
 	// Initialize database schema unless skipped
 	if !opts.skipDBInit {
-		s.initDB(context.Background())
+		if err := s.initDB(context.Background()); err != nil {
+			_ = pgClient.Close()
+			return nil, fmt.Errorf("init database failed: %w", err)
+		}
 	}
 
 	if opts.enableAsyncPersist {

--- a/session/postgres/service_test.go
+++ b/session/postgres/service_test.go
@@ -2996,6 +2996,38 @@ func TestNewService_WithInstance_Success(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+// TestNewService_InitDBFailureClosesClient covers NewService closing the client
+// and returning an error when initDB fails (rather than leaking the pool).
+func TestNewService_InitDBFailureClosesClient(t *testing.T) {
+	restrictToSessionStates(t)
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+
+	originalBuilder := storage.GetClientBuilder()
+	defer storage.SetClientBuilder(originalBuilder)
+	storage.SetClientBuilder(func(ctx context.Context, builderOpts ...storage.ClientBuilderOpt) (storage.Client, error) {
+		return &mockPostgresClient{db: db}, nil
+	})
+
+	instanceName := "test-instance-initdb-fail"
+	storage.RegisterPostgresInstance(instanceName,
+		storage.WithClientConnString("test:test@tcp(localhost:5432)/testdb"),
+	)
+
+	// initDB runs (skipDBInit is false) and fails on the first CREATE TABLE;
+	// NewService must then close the client. ExpectClose (with no deferred
+	// db.Close) is only satisfied if NewService actually closed it.
+	mock.ExpectExec("CREATE TABLE").WillReturnError(assert.AnError)
+	mock.ExpectClose()
+
+	svc, err := NewService(WithPostgresInstance(instanceName))
+	require.Error(t, err)
+	require.Nil(t, svc)
+	assert.Contains(t, err.Error(), "init database failed")
+	require.ErrorIs(t, err, assert.AnError)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestNewService_WithDSN_Success(t *testing.T) {
 	db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
 	require.NoError(t, err)


### PR DESCRIPTION
## What changed

- `initDB` (the Service's startup schema initialization) now **returns an error
  instead of panicking**; `NewService` propagates it as `init database failed`.
- A **missing UNIQUE index is now fatal** during schema verification:
  `verifyIndexes` returns an error for a missing `unique_active` index (other
  missing indexes stay warnings) and `verifySchema` propagates it.

## Why

- The previous `initDB` panicked on any failure. A DDL/privilege error on startup
  (e.g. the runtime account is not the table owner, so `CREATE INDEX` is denied)
  would **crash the caller of `NewService`** instead of returning an error. This
  brings the postgres backend in line with the other SQL session backends, which
  return an `init database failed` error.
- The `unique_active` index enforces the "one active row" invariant that
  session/app/user state writes rely on. Logging its absence as a non-fatal
  warning let the service run **without the uniqueness constraint** (e.g. a
  partial bootstrap that created the table but not the index, or a pre-provisioned
  schema missing it). Failing fast prevents silently running without it.

## Testing

- `go test ./... -race`, `go vet ./...`, `gofmt` in `session/postgres` — all pass.
- Added `TestVerifyIndexes_MissingUniqueIndex` (missing unique index → error) and
  `TestServiceInitDB_ReturnsErrorOnDDLFailure` (initDB returns an error, does not
  panic). Existing `TestVerifyIndexes_MissingIndex` (a non-unique index) still
  passes as non-fatal.

## Notes for reviewers

- Non-unique (TTL / lookup) index drift stays a warning — unchanged.
- This mirrors the equivalent init/verification hardening for the mysql backend
  in #2022.
